### PR TITLE
Simplify g2 object conversion

### DIFF
--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -588,17 +588,17 @@ void Tracker::load_parameters(void)
 
 #if AP_STATS_ENABLED
     // PARAMETER_CONVERSION - Added: Jan-2024
-    AP_Param::convert_class(g.k_param_stats_old, &stats, stats.var_info, 0, 0, true);
+    AP_Param::convert_class(g.k_param_stats_old, &stats, stats.var_info, 0, true);
 #endif
 
 #if AP_SCRIPTING_ENABLED
     // PARAMETER_CONVERSION - Added: Jan-2024
-    AP_Param::convert_class(g.k_param_scripting_old, &scripting, scripting.var_info, 0, 0, true);
+    AP_Param::convert_class(g.k_param_scripting_old, &scripting, scripting.var_info, 0, true);
 #endif
 
     // PARAMETER_CONVERSION - Added: Feb-2024 for Tracker-4.6
 #if HAL_LOGGING_ENABLED
-    AP_Param::convert_class(g.k_param_logger, &logger, logger.var_info, 0, 0, true);
+    AP_Param::convert_class(g.k_param_logger, &logger, logger.var_info, 0, true);
 #endif
 
 #if HAL_HAVE_SAFETY_SWITCH

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1354,21 +1354,21 @@ void Copter::load_parameters(void)
 
     // PARAMETER_CONVERSION - Added: Mar-2022
 #if AP_FENCE_ENABLED
-    AP_Param::convert_class(g.k_param_fence_old, &fence, fence.var_info, 0, 0, true);
+    AP_Param::convert_class(g.k_param_fence_old, &fence, fence.var_info, 0, true);
 #endif
 
     static const AP_Param::G2ObjectConversion g2_conversions[] {
 #if AP_STATS_ENABLED
     // PARAMETER_CONVERSION - Added: Jan-2024 for Copter-4.6
-        { &stats, stats.var_info, 12, 4044 },
+        { &stats, stats.var_info, 12 },
 #endif
 #if AP_SCRIPTING_ENABLED
     // PARAMETER_CONVERSION - Added: Jan-2024 for Copter-4.6
-        { &scripting, scripting.var_info, 30, 94 },
+        { &scripting, scripting.var_info, 30 },
 #endif
 #if AP_GRIPPER_ENABLED
     // PARAMETER_CONVERSION - Added: Feb-2024 for Copter-4.6
-        { &gripper, gripper.var_info, 13,  4045},
+        { &gripper, gripper.var_info, 13 },
 #endif
     };
 
@@ -1376,7 +1376,7 @@ void Copter::load_parameters(void)
 
     // PARAMETER_CONVERSION - Added: Feb-2024 for Copter-4.6
 #if HAL_LOGGING_ENABLED
-    AP_Param::convert_class(g.k_param_logger, &logger, logger.var_info, 0, 0, true);
+    AP_Param::convert_class(g.k_param_logger, &logger, logger.var_info, 0, true);
 #endif
 
     // setup AP_Param frame type flags

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1357,53 +1357,26 @@ void Copter::load_parameters(void)
     AP_Param::convert_class(g.k_param_fence_old, &fence, fence.var_info, 0, 0, true);
 #endif
 
-    // PARAMETER_CONVERSION - Added: Jan-2024 for Copter-4.6
+    static const AP_Param::G2ObjectConversion g2_conversions[] {
 #if AP_STATS_ENABLED
-    {
-        // Find G2's Top Level Key
-        AP_Param::ConversionInfo info;
-        if (!AP_Param::find_top_level_key_by_pointer(&g2, info.old_key)) {
-            return;
-        }
-
-        const uint16_t old_index = 12;       // Old parameter index in g2
-        const uint16_t old_top_element = 4044; // Old group element in the tree for the first subgroup element (see AP_PARAM_KEY_DUMP)
-        AP_Param::convert_class(info.old_key, &stats, stats.var_info, old_index, old_top_element, false);
-    }
-#endif
     // PARAMETER_CONVERSION - Added: Jan-2024 for Copter-4.6
-#if AP_SCRIPTING_ENABLED
-    {
-        // Find G2's Top Level Key
-        AP_Param::ConversionInfo info;
-        if (!AP_Param::find_top_level_key_by_pointer(&g2, info.old_key)) {
-            return;
-        }
-
-        const uint16_t old_index = 30;       // Old parameter index in g2
-        const uint16_t old_top_element = 94; // Old group element in the tree for the first subgroup element (see AP_PARAM_KEY_DUMP)
-        AP_Param::convert_class(info.old_key, &scripting, scripting.var_info, old_index, old_top_element, false);
-    }
+        { &stats, stats.var_info, 12, 4044 },
 #endif
+#if AP_SCRIPTING_ENABLED
+    // PARAMETER_CONVERSION - Added: Jan-2024 for Copter-4.6
+        { &scripting, scripting.var_info, 30, 94 },
+#endif
+#if AP_GRIPPER_ENABLED
+    // PARAMETER_CONVERSION - Added: Feb-2024 for Copter-4.6
+        { &gripper, gripper.var_info, 13,  4045},
+#endif
+    };
+
+    AP_Param::convert_g2_objects(&g2, g2_conversions, ARRAY_SIZE(g2_conversions));
 
     // PARAMETER_CONVERSION - Added: Feb-2024 for Copter-4.6
 #if HAL_LOGGING_ENABLED
     AP_Param::convert_class(g.k_param_logger, &logger, logger.var_info, 0, 0, true);
-#endif
-
-    // PARAMETER_CONVERSION - Added: Feb-2024 for Copter-4.6
-#if AP_GRIPPER_ENABLED
-    {
-        // Find G2's Top Level Key
-        AP_Param::ConversionInfo info;
-        if (!AP_Param::find_top_level_key_by_pointer(&g2, info.old_key)) {
-            return;
-        }
-
-        const uint16_t old_index = 13;       // Old parameter index in g2
-        const uint16_t old_top_element = 4045; // Old group element in the tree for the first subgroup element (see AP_PARAM_KEY_DUMP)
-        AP_Param::convert_class(info.old_key, &gripper, gripper.var_info, old_index, old_top_element, false);
-    }
 #endif
 
     // setup AP_Param frame type flags

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1527,49 +1527,22 @@ void Plane::load_parameters(void)
 
     landing.convert_parameters();
 
-    // PARAMETER_CONVERSION - Added: Jan-2024 for Plane-4.6
+    static const AP_Param::G2ObjectConversion g2_conversions[] {
 #if AP_STATS_ENABLED
-    {
-        // Find G2's Top Level Key
-        AP_Param::ConversionInfo info;
-        if (!AP_Param::find_top_level_key_by_pointer(&g2, info.old_key)) {
-            return;
-        }
-
-        const uint16_t old_index = 5;       // Old parameter index in g2
-        const uint16_t old_top_element = 4037; // Old group element in the tree for the first subgroup element (see AP_PARAM_KEY_DUMP)
-        AP_Param::convert_class(info.old_key, &stats, stats.var_info, old_index, old_top_element, false);
-    }
-#endif
     // PARAMETER_CONVERSION - Added: Jan-2024 for Plane-4.6
+        { &stats, stats.var_info, 5, 4037 },
+#endif
 #if AP_SCRIPTING_ENABLED
-    {
-        // Find G2's Top Level Key
-        AP_Param::ConversionInfo info;
-        if (!AP_Param::find_top_level_key_by_pointer(&g2, info.old_key)) {
-            return;
-        }
-
-        const uint16_t old_index = 14;       // Old parameter index in g2
-        const uint16_t old_top_element = 78; // Old group element in the tree for the first subgroup element (see AP_PARAM_KEY_DUMP)
-        AP_Param::convert_class(info.old_key, &scripting, scripting.var_info, old_index, old_top_element, false);
-    }
+    // PARAMETER_CONVERSION - Added: Jan-2024 for Plane-4.6
+        { &scripting, scripting.var_info, 14, 78 },
 #endif
-
-    // PARAMETER_CONVERSION - Added: Feb-2024 for Plane-4.6
 #if AP_GRIPPER_ENABLED
-    {
-        // Find G2's Top Level Key
-        AP_Param::ConversionInfo info;
-        if (!AP_Param::find_top_level_key_by_pointer(&g2, info.old_key)) {
-            return;
-        }
-
-        const uint16_t old_index = 12;       // Old parameter index in g2
-        const uint16_t old_top_element = 4044; // Old group element in the tree for the first subgroup element (see AP_PARAM_KEY_DUMP)
-        AP_Param::convert_class(info.old_key, &gripper, gripper.var_info, old_index, old_top_element, false);
-    }
+    // PARAMETER_CONVERSION - Added: Feb-2024 for Plane-4.6
+        { &gripper, gripper.var_info, 12, 4044 },
 #endif
+    };
+
+    AP_Param::convert_g2_objects(&g2, g2_conversions, ARRAY_SIZE(g2_conversions));
 
     // PARAMETER_CONVERSION - Added: Feb-2024 for Copter-4.6
 #if HAL_LOGGING_ENABLED

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1473,8 +1473,7 @@ void Plane::load_parameters(void)
     {
         const uint16_t old_key = g.k_param_airspeed;
         const uint16_t old_index = 0;       // Old parameter index in the tree
-        const uint16_t old_top_element = 0; // Old group element in the tree for the first subgroup element (see AP_PARAM_KEY_DUMP)
-        AP_Param::convert_class(old_key, &airspeed, airspeed.var_info, old_index, old_top_element, true);
+        AP_Param::convert_class(old_key, &airspeed, airspeed.var_info, old_index, true);
     }
 #endif
 
@@ -1495,7 +1494,7 @@ void Plane::load_parameters(void)
     
     // PARAMETER_CONVERSION - Added: Mar-2022
 #if AP_FENCE_ENABLED
-    AP_Param::convert_class(g.k_param_fence, &fence, fence.var_info, 0, 0, true);
+    AP_Param::convert_class(g.k_param_fence, &fence, fence.var_info, 0, true);
 #endif
   
     // PARAMETER_CONVERSION - Added: Dec 2023
@@ -1514,19 +1513,19 @@ void Plane::load_parameters(void)
     static const AP_Param::G2ObjectConversion g2_conversions[] {
     // PARAMETER_CONVERSION - Added: Oct-2021
 #if HAL_EFI_ENABLED
-        { &efi, efi.var_info, 22, 86 },
+        { &efi, efi.var_info, 22 },
 #endif
 #if AP_STATS_ENABLED
     // PARAMETER_CONVERSION - Added: Jan-2024 for Plane-4.6
-        { &stats, stats.var_info, 5, 4037 },
+        { &stats, stats.var_info, 5 },
 #endif
 #if AP_SCRIPTING_ENABLED
     // PARAMETER_CONVERSION - Added: Jan-2024 for Plane-4.6
-        { &scripting, scripting.var_info, 14, 78 },
+        { &scripting, scripting.var_info, 14 },
 #endif
 #if AP_GRIPPER_ENABLED
     // PARAMETER_CONVERSION - Added: Feb-2024 for Plane-4.6
-        { &gripper, gripper.var_info, 12, 4044 },
+        { &gripper, gripper.var_info, 12 },
 #endif
     };
 
@@ -1534,6 +1533,6 @@ void Plane::load_parameters(void)
 
     // PARAMETER_CONVERSION - Added: Feb-2024 for Copter-4.6
 #if HAL_LOGGING_ENABLED
-    AP_Param::convert_class(g.k_param_logger, &logger, logger.var_info, 0, 0, true);
+    AP_Param::convert_class(g.k_param_logger, &logger, logger.var_info, 0, true);
 #endif
 }

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1468,22 +1468,6 @@ void Plane::load_parameters(void)
 
     g.use_reverse_thrust.convert_parameter_width(AP_PARAM_INT16);
 
-
-    // PARAMETER_CONVERSION - Added: Oct-2021
-#if HAL_EFI_ENABLED
-    {
-        // Find G2's Top Level Key
-        AP_Param::ConversionInfo info;
-        if (!AP_Param::find_top_level_key_by_pointer(&g2, info.old_key)) {
-            return;
-        }
-
-        const uint16_t old_index = 22;       // Old parameter index in g2
-        const uint16_t old_top_element = 86; // Old group element in the tree for the first subgroup element (see AP_PARAM_KEY_DUMP)
-        AP_Param::convert_class(info.old_key, &efi, efi.var_info, old_index, old_top_element, false);
-    }
-#endif
-
 #if AP_AIRSPEED_ENABLED
     // PARAMETER_CONVERSION - Added: Jan-2022
     {
@@ -1528,6 +1512,10 @@ void Plane::load_parameters(void)
     landing.convert_parameters();
 
     static const AP_Param::G2ObjectConversion g2_conversions[] {
+    // PARAMETER_CONVERSION - Added: Oct-2021
+#if HAL_EFI_ENABLED
+        { &efi, efi.var_info, 22, 86 },
+#endif
 #if AP_STATS_ENABLED
     // PARAMETER_CONVERSION - Added: Jan-2024 for Plane-4.6
         { &stats, stats.var_info, 5, 4037 },

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -743,25 +743,25 @@ void Sub::load_parameters()
 
     // PARAMETER_CONVERSION - Added: Mar-2022
 #if AP_FENCE_ENABLED
-    AP_Param::convert_class(g.k_param_fence_old, &fence, fence.var_info, 0, 0, true);
+    AP_Param::convert_class(g.k_param_fence_old, &fence, fence.var_info, 0, true);
 #endif
 
     static const AP_Param::G2ObjectConversion g2_conversions[] {
 #if AP_AIRSPEED_ENABLED
     // PARAMETER_CONVERSION - Added: JAN-2022
-        { &airspeed, airspeed.var_info, 19, 4051 },
+        { &airspeed, airspeed.var_info, 19 },
 #endif
 #if AP_STATS_ENABLED
     // PARAMETER_CONVERSION - Added: Jan-2024
-        { &stats, stats.var_info, 1, 4033 },
+        { &stats, stats.var_info, 1 },
 #endif
 #if AP_SCRIPTING_ENABLED
     // PARAMETER_CONVERSION - Added: Jan-2024
-        { &scripting, scripting.var_info, 18, 82 },
+        { &scripting, scripting.var_info, 18 },
 #endif
 #if AP_GRIPPER_ENABLED
     // PARAMETER_CONVERSION - Added: Feb-2024
-        { &gripper, gripper.var_info, 3, 4035 },
+        { &gripper, gripper.var_info, 3 },
 #endif
     };
 
@@ -769,7 +769,7 @@ void Sub::load_parameters()
 
     // PARAMETER_CONVERSION - Added: Feb-2024
 #if HAL_LOGGING_ENABLED
-    AP_Param::convert_class(g.k_param_logger, &logger, logger.var_info, 0, 0, true);
+    AP_Param::convert_class(g.k_param_logger, &logger, logger.var_info, 0, true);
 #endif
 }
 

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -741,68 +741,31 @@ void Sub::load_parameters()
     // We should ignore this parameter since ROVs are neutral buoyancy
     AP_Param::set_by_name("MOT_THST_HOVER", 0.5);
 
-// PARAMETER_CONVERSION - Added: JAN-2022
-#if AP_AIRSPEED_ENABLED
-    // Find G2's Top Level Key
-    AP_Param::ConversionInfo info;
-    if (!AP_Param::find_top_level_key_by_pointer(&g2, info.old_key)) {
-        return;
-    }
-
-    const uint16_t old_index = 19;          // Old parameter index in the tree
-    const uint16_t old_top_element = 4051;  // Old group element in the tree for the first subgroup element
-    AP_Param::convert_class(info.old_key, &airspeed, airspeed.var_info, old_index, old_top_element, false);
-#endif
-
-
     // PARAMETER_CONVERSION - Added: Mar-2022
 #if AP_FENCE_ENABLED
     AP_Param::convert_class(g.k_param_fence_old, &fence, fence.var_info, 0, 0, true);
 #endif
 
-    // PARAMETER_CONVERSION - Added: Jan-2024
+    static const AP_Param::G2ObjectConversion g2_conversions[] {
+#if AP_AIRSPEED_ENABLED
+    // PARAMETER_CONVERSION - Added: JAN-2022
+        { &airspeed, airspeed.var_info, 19, 4051 },
+#endif
 #if AP_STATS_ENABLED
-    {
-        // Find G2's Top Level Key
-        AP_Param::ConversionInfo stats_info;
-        if (!AP_Param::find_top_level_key_by_pointer(&g2, stats_info.old_key)) {
-            return;
-        }
-
-        const uint16_t stats_old_index = 1;       // Old parameter index in g2
-        const uint16_t stats_old_top_element = 4033; // Old group element in the tree for the first subgroup element (see AP_PARAM_KEY_DUMP)
-        AP_Param::convert_class(stats_info.old_key, &stats, stats.var_info, stats_old_index, stats_old_top_element, false);
-    }
-#endif
     // PARAMETER_CONVERSION - Added: Jan-2024
+        { &stats, stats.var_info, 1, 4033 },
+#endif
 #if AP_SCRIPTING_ENABLED
-    {
-        // Find G2's Top Level Key
-        AP_Param::ConversionInfo scripting_info;
-        if (!AP_Param::find_top_level_key_by_pointer(&g2, scripting_info.old_key)) {
-            return;
-        }
-
-        const uint16_t scripting_old_index = 18;       // Old parameter index in g2
-        const uint16_t scripting_old_top_element = 82; // Old group element in the tree for the first subgroup element (see AP_PARAM_KEY_DUMP)
-        AP_Param::convert_class(scripting_info.old_key, &scripting, scripting.var_info, scripting_old_index, scripting_old_top_element, false);
-    }
+    // PARAMETER_CONVERSION - Added: Jan-2024
+        { &scripting, scripting.var_info, 18, 82 },
 #endif
-
-    // PARAMETER_CONVERSION - Added: Feb-2024
 #if AP_GRIPPER_ENABLED
-    {
-        // Find G2's Top Level Key
-        AP_Param::ConversionInfo gripper_info;
-        if (!AP_Param::find_top_level_key_by_pointer(&g2, gripper_info.old_key)) {
-            return;
-        }
-
-        const uint16_t old_gripper_index = 3;       // Old parameter index in g2
-        const uint16_t old_gripper_top_element = 4035; // Old group element in the tree for the first subgroup element (see AP_PARAM_KEY_DUMP)
-        AP_Param::convert_class(gripper_info.old_key, &gripper, gripper.var_info, old_gripper_index, old_gripper_top_element, false);
-    }
+    // PARAMETER_CONVERSION - Added: Feb-2024
+        { &gripper, gripper.var_info, 3, 4035 },
 #endif
+    };
+
+    AP_Param::convert_g2_objects(&g2, g2_conversions, ARRAY_SIZE(g2_conversions));
 
     // PARAMETER_CONVERSION - Added: Feb-2024
 #if HAL_LOGGING_ENABLED

--- a/Blimp/Parameters.cpp
+++ b/Blimp/Parameters.cpp
@@ -845,18 +845,18 @@ void Blimp::load_parameters(void)
     static const AP_Param::G2ObjectConversion g2_conversions[] {
 #if AP_STATS_ENABLED
     // PARAMETER_CONVERSION - Added: Jan-2024 for Copter-4.6
-        { &stats, stats.var_info, 12, 4044 },
+        { &stats, stats.var_info, 12 },
 #endif
 #if AP_SCRIPTING_ENABLED
     // PARAMETER_CONVERSION - Added: Jan-2024 for Copter-4.6
-        { &scripting, scripting.var_info, 30, 94 },
+        { &scripting, scripting.var_info, 30 },
 #endif
     };
     AP_Param::convert_g2_objects(&g2, g2_conversions, ARRAY_SIZE(g2_conversions));
 
     // PARAMETER_CONVERSION - Added: Feb-2024
 #if HAL_LOGGING_ENABLED
-    AP_Param::convert_class(g.k_param_logger, &logger, logger.var_info, 0, 0, true);
+    AP_Param::convert_class(g.k_param_logger, &logger, logger.var_info, 0, true);
 #endif
 
     // setup AP_Param frame type flags

--- a/Blimp/Parameters.cpp
+++ b/Blimp/Parameters.cpp
@@ -842,34 +842,17 @@ void Blimp::load_parameters(void)
 {
     AP_Vehicle::load_parameters(g.format_version, Parameters::k_format_version);
 
-    // PARAMETER_CONVERSION - Added: Jan-2024 for Copter-4.6
+    static const AP_Param::G2ObjectConversion g2_conversions[] {
 #if AP_STATS_ENABLED
-    {
-        // Find G2's Top Level Key
-        AP_Param::ConversionInfo info;
-        if (!AP_Param::find_top_level_key_by_pointer(&g2, info.old_key)) {
-            return;
-        }
-
-        const uint16_t old_index = 12;       // Old parameter index in g2
-        const uint16_t old_top_element = 4044; // Old group element in the tree for the first subgroup element (see AP_PARAM_KEY_DUMP)
-        AP_Param::convert_class(info.old_key, &stats, stats.var_info, old_index, old_top_element, false);
-    }
-#endif
     // PARAMETER_CONVERSION - Added: Jan-2024 for Copter-4.6
-#if AP_SCRIPTING_ENABLED
-    {
-        // Find G2's Top Level Key
-        AP_Param::ConversionInfo info;
-        if (!AP_Param::find_top_level_key_by_pointer(&g2, info.old_key)) {
-            return;
-        }
-
-        const uint16_t old_index = 30;       // Old parameter index in g2
-        const uint16_t old_top_element = 94; // Old group element in the tree for the first subgroup element (see AP_PARAM_KEY_DUMP)
-        AP_Param::convert_class(info.old_key, &scripting, scripting.var_info, old_index, old_top_element, false);
-    }
+        { &stats, stats.var_info, 12, 4044 },
 #endif
+#if AP_SCRIPTING_ENABLED
+    // PARAMETER_CONVERSION - Added: Jan-2024 for Copter-4.6
+        { &scripting, scripting.var_info, 30, 94 },
+#endif
+    };
+    AP_Param::convert_g2_objects(&g2, g2_conversions, ARRAY_SIZE(g2_conversions));
 
     // PARAMETER_CONVERSION - Added: Feb-2024
 #if HAL_LOGGING_ENABLED

--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -878,27 +878,27 @@ void Rover::load_parameters(void)
     static const AP_Param::G2ObjectConversion g2_conversions[] {
 #if AP_AIRSPEED_ENABLED
 // PARAMETER_CONVERSION - Added: JAN-2022
-        { &airspeed, airspeed.var_info, 37, 4069 },
+        { &airspeed, airspeed.var_info, 37 },
 #endif
 #if AP_AIS_ENABLED
 // PARAMETER_CONVERSION - Added: MAR-2022
-        { &ais, ais.var_info, 50, 114 },
+        { &ais, ais.var_info, 50 },
 #endif
 #if AP_FENCE_ENABLED
 // PARAMETER_CONVERSION - Added: Mar-2022
-        { &fence, fence.var_info, 17, 4049 },
+        { &fence, fence.var_info, 17 },
 #endif
 #if AP_STATS_ENABLED
     // PARAMETER_CONVERSION - Added: Jan-2024 for Rover-4.6
-        { &stats, stats.var_info, 1, 4033 },
+        { &stats, stats.var_info, 1 },
 #endif
 #if AP_SCRIPTING_ENABLED
     // PARAMETER_CONVERSION - Added: Jan-2024 for Rover-4.6
-        { &scripting, scripting.var_info, 41, 105 },
+        { &scripting, scripting.var_info, 41 },
 #endif
 #if AP_GRIPPER_ENABLED
     // PARAMETER_CONVERSION - Added: Feb-2024 for Copter-4.6
-        { &gripper, gripper.var_info, 39, 4071 },
+        { &gripper, gripper.var_info, 39 },
 #endif
     };
 
@@ -906,7 +906,7 @@ void Rover::load_parameters(void)
 
     // PARAMETER_CONVERSION - Added: Feb-2024 for Rover-4.6
 #if HAL_LOGGING_ENABLED
-    AP_Param::convert_class(g.k_param_logger, &logger, logger.var_info, 0, 0, true);
+    AP_Param::convert_class(g.k_param_logger, &logger, logger.var_info, 0, true);
 #endif
 
 }

--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -875,66 +875,34 @@ void Rover::load_parameters(void)
     }
 #endif
 
-// PARAMETER_CONVERSION - Added: JAN-2022
+    static const AP_Param::G2ObjectConversion g2_conversions[] {
 #if AP_AIRSPEED_ENABLED
-    const uint16_t old_index = 37;          // Old parameter index in the tree
-    const uint16_t old_top_element = 4069;  // Old group element in the tree for the first subgroup element
-    AP_Param::convert_class(info.old_key, &airspeed, airspeed.var_info, old_index, old_top_element, false);
+// PARAMETER_CONVERSION - Added: JAN-2022
+        { &airspeed, airspeed.var_info, 37, 4069 },
 #endif
-
-// PARAMETER_CONVERSION - Added: MAR-2022
 #if AP_AIS_ENABLED
-    AP_Param::convert_class(info.old_key, &ais, ais.var_info, 50, 114, false);
+// PARAMETER_CONVERSION - Added: MAR-2022
+        { &ais, ais.var_info, 50, 114 },
 #endif
-
-// PARAMETER_CONVERSION - Added: Mar-2022
 #if AP_FENCE_ENABLED
-    AP_Param::convert_class(info.old_key, &fence, fence.var_info, 17, 4049, false);
+// PARAMETER_CONVERSION - Added: Mar-2022
+        { &fence, fence.var_info, 17, 4049 },
 #endif
-
-    // PARAMETER_CONVERSION - Added: Jan-2024 for Rover-4.6
 #if AP_STATS_ENABLED
-    {
-        // Find G2's Top Level Key
-        AP_Param::ConversionInfo stats_info;
-        if (!AP_Param::find_top_level_key_by_pointer(&g2, stats_info.old_key)) {
-            return;
-        }
-
-        const uint16_t stats_old_index = 1;       // Old parameter index in g2
-        const uint16_t stats_old_top_element = 4033; // Old group element in the tree for the first subgroup element (see AP_PARAM_KEY_DUMP)
-        AP_Param::convert_class(stats_info.old_key, &stats, stats.var_info, stats_old_index, stats_old_top_element, false);
-    }
-#endif
     // PARAMETER_CONVERSION - Added: Jan-2024 for Rover-4.6
+        { &stats, stats.var_info, 1, 4033 },
+#endif
 #if AP_SCRIPTING_ENABLED
-    {
-        // Find G2's Top Level Key
-        AP_Param::ConversionInfo scripting_info;
-        if (!AP_Param::find_top_level_key_by_pointer(&g2, scripting_info.old_key)) {
-            return;
-        }
-
-        const uint16_t scripting_old_index = 41;       // Old parameter index in g2
-        const uint16_t scripting_old_top_element = 105; // Old group element in the tree for the first subgroup element (see AP_PARAM_KEY_DUMP)
-        AP_Param::convert_class(scripting_info.old_key, &scripting, scripting.var_info, scripting_old_index, scripting_old_top_element, false);
-    }
+    // PARAMETER_CONVERSION - Added: Jan-2024 for Rover-4.6
+        { &scripting, scripting.var_info, 41, 105 },
 #endif
-
-    // PARAMETER_CONVERSION - Added: Feb-2024 for Copter-4.6
 #if AP_GRIPPER_ENABLED
-    {
-        // Find G2's Top Level Key
-        AP_Param::ConversionInfo gripper_info;
-        if (!AP_Param::find_top_level_key_by_pointer(&g2, gripper_info.old_key)) {
-            return;
-        }
-
-        const uint16_t gripper_old_index = 39;       // Old parameter index in g2
-        const uint16_t gripper_old_top_element = 4071; // Old group element in the tree for the first subgroup element (see AP_PARAM_KEY_DUMP)
-        AP_Param::convert_class(gripper_info.old_key, &gripper, gripper.var_info, gripper_old_index, gripper_old_top_element, false);
-    }
+    // PARAMETER_CONVERSION - Added: Feb-2024 for Copter-4.6
+        { &gripper, gripper.var_info, 39, 4071 },
 #endif
+    };
+
+    AP_Param::convert_g2_objects(&g2, g2_conversions, ARRAY_SIZE(g2_conversions));
 
     // PARAMETER_CONVERSION - Added: Feb-2024 for Rover-4.6
 #if HAL_LOGGING_ENABLED

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -2033,7 +2033,7 @@ void AP_Param::convert_old_parameters_scaled(const struct ConversionInfo *conver
 // is_top_level: Is true if the class had its own top level key, param_key. It is false if the class was a subgroup
 void AP_Param::convert_class(uint16_t param_key, void *object_pointer,
                                     const struct AP_Param::GroupInfo *group_info,
-                                    uint16_t old_index, uint16_t old_top_element, bool is_top_level)
+                                    uint16_t old_index, bool is_top_level)
 {
     const uint8_t group_shift = is_top_level ? 0 : 6;
 
@@ -2083,7 +2083,7 @@ void AP_Param::convert_g2_objects(const void *g2, const G2ObjectConversion g2_co
     }
     for (uint8_t i=0; i<num_conversions; i++) {
         const auto &c { g2_conversions[i] };
-        convert_class(info.old_key, c.object_pointer, c.var_info, c.old_index, c.old_top_element, false);
+        convert_class(info.old_key, c.object_pointer, c.var_info, c.old_index, false);
     }
 }
 

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -2074,6 +2074,20 @@ void AP_Param::convert_class(uint16_t param_key, void *object_pointer,
     flush();
 }
 
+void AP_Param::convert_g2_objects(const void *g2, const G2ObjectConversion g2_conversions[], uint8_t num_conversions)
+{
+    // Find G2's Top Level Key
+    ConversionInfo info;
+    if (!find_top_level_key_by_pointer(g2, info.old_key)) {
+        return;
+    }
+    for (uint8_t i=0; i<num_conversions; i++) {
+        const auto &c { g2_conversions[i] };
+        convert_class(info.old_key, c.object_pointer, c.var_info, c.old_index, c.old_top_element, false);
+    }
+}
+
+
 /*
  convert width of a parameter, allowing update to wider scalar values
  without changing the parameter indexes

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -472,6 +472,14 @@ public:
     // convert old vehicle parameters to new object parameters with scaling - assumes we use the same scaling factor for all values in the table
     static void         convert_old_parameters_scaled(const ConversionInfo *conversion_table, uint8_t table_size, float scaler, uint8_t flags);
 
+    struct G2ObjectConversion {
+        void *object_pointer;
+        const struct AP_Param::GroupInfo *var_info;
+        uint16_t old_index;  // Old parameter index in g
+        uint16_t old_top_element;  // Old group element in the tree for the first subgroup element (see AP_PARAM_KEY_DUMP)
+    };
+    static void         convert_g2_objects(const void *g2, const G2ObjectConversion g2_conversions[], uint8_t num_conversions);
+
     /*
       convert width of a parameter, allowing update to wider scalar
       values without changing the parameter indexes. This will return

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -476,7 +476,6 @@ public:
         void *object_pointer;
         const struct AP_Param::GroupInfo *var_info;
         uint16_t old_index;  // Old parameter index in g
-        uint16_t old_top_element;  // Old group element in the tree for the first subgroup element (see AP_PARAM_KEY_DUMP)
     };
     static void         convert_g2_objects(const void *g2, const G2ObjectConversion g2_conversions[], uint8_t num_conversions);
 
@@ -501,7 +500,7 @@ public:
     // is_top_level: Is true if the class had its own top level key, param_key. It is false if the class was a subgroup
     static void         convert_class(uint16_t param_key, void *object_pointer,
                                         const struct AP_Param::GroupInfo *group_info,
-                                        uint16_t old_index, uint16_t old_top_element, bool is_top_level);
+                                        uint16_t old_index, bool is_top_level);
 
     /*
       fetch a parameter value based on the index within a group. This


### PR DESCRIPTION
```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                                                     
Durandal                            -48    *           -68     -68               -112   -96    -88
Hitec-Airspeed           *                                                                     
KakuteH7-bdshot                     48     *           20      20                -16    -8     -8
MatekF405                           60     *           68      60                60     44     32
Pixhawk1-1M-bdshot                  60                 60      60                60     44     40
f103-QiotekPeriph        *                                                                     
f303-Universal           *                                                                     
iomcu                                                                *                         
revo-mini                           60     *           68      60                60     44     32
skyviper-v2450                                         60                                      
```