### PR TITLE
Plane: manual: fix not overriding functions

### DIFF
--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -136,10 +136,10 @@ public:
     virtual bool is_taking_off() const;
 
     // true if throttle min/max limits should be applied
-    bool use_throttle_limits() const;
+    virtual bool use_throttle_limits() const;
 
     // true if voltage correction should be applied to throttle
-    bool use_battery_compensation() const;
+    virtual bool use_battery_compensation() const;
 
 protected:
 
@@ -400,10 +400,10 @@ public:
     void run() override;
 
     // true if throttle min/max limits should be applied
-    bool use_throttle_limits() const { return false; }
+    bool use_throttle_limits() const override { return false; }
 
     // true if voltage correction should be applied to throttle
-    bool use_battery_compensation() const { return false; }
+    bool use_battery_compensation() const override { return false; }
 
 };
 


### PR DESCRIPTION
This fixes a bug I added in https://github.com/ArduPilot/ardupilot/pull/26223 where the two new manual methods were not overriding because the base class was not virtual.

I'm actually a bit surprised that the compiler allowed this..