### PR TITLE
Plane: Manual: use `apply_throttle_limits` function in manual mode if `IDLE_GOV_MANUAL` is enabled.

### DIFF
--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -400,7 +400,7 @@ public:
     void run() override;
 
     // true if throttle min/max limits should be applied
-    bool use_throttle_limits() const override { return false; }
+    bool use_throttle_limits() const override;
 
     // true if voltage correction should be applied to throttle
     bool use_battery_compensation() const override { return false; }


### PR DESCRIPTION
This moves the application of throttle limits to the main `apply_throttle_limits` function that all other modes used here:

https://github.com/ArduPilot/ardupilot/blob/e01e697343cf3eb9b0991d7153f135b60b96f965/ArduPlane/servos.cpp#L507

This makes manual mode behave the same as any other mode. This does result in a couple of changes in behavior:

-  `THR_MAX` is also applied along with `THR_MIN`. 
- Battery compensation is done if enabled.
- Watt limiting is done if enabled.
