### PR TITLE
AP_GPS: prevent announcing DroneCAN at 5Hz

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1000,8 +1000,7 @@ void AP_GPS::update_instance(uint8_t instance)
             state[instance].corrected_timestamp_updated = false;
         }
 
-        // we set delta_time_ms to the timeout value when clearing
-        // state; use it being zero to mark first message
+        // announce the GPS type once
         if (!state[instance].announced_detection) {
             state[instance].announced_detection = true;
             GCS_SEND_TEXT(MAV_SEVERITY_INFO, "GPS %d: detected %s", instance + 1, drivers[instance]->name());

--- a/libraries/AP_GPS/AP_GPS_DroneCAN.cpp
+++ b/libraries/AP_GPS/AP_GPS_DroneCAN.cpp
@@ -717,6 +717,9 @@ bool AP_GPS_DroneCAN::read(void)
         interim_state.vertical_accuracy = MIN(interim_state.vertical_accuracy, 1000.0);
         interim_state.speed_accuracy = MIN(interim_state.speed_accuracy, 1000.0);
 
+        // prevent announcing multiple times
+        interim_state.announced_detection = state.announced_detection;
+
         state = interim_state;
         if (interim_state.last_corrected_gps_time_us) {
             // If we were able to get a valid last_corrected_gps_time_us


### PR DESCRIPTION
fixes this:
![image](https://github.com/ArduPilot/ardupilot/assets/831867/b0cd1066-f771-4e88-8b3a-a3ed755b8df9)
