### PR TITLE
AP_GPS: improve reporting of backend inaccurancy

### DIFF
--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -369,8 +369,8 @@ bool AP_GPS_Backend::calculate_moving_base_yaw(AP_GPS::GPS_State &interim_state,
 
         if ((offset_dist - reported_distance) > (min_dist * permitted_error_length_pct)) {
             // the magnitude of the vector is much further then we were expecting
-            Debug("Exceeded the permitted error margin %f > %f",
-                  (double)(offset_dist - reported_distance), (double)(min_dist * permitted_error_length_pct));
+            Debug("Offset=%.2f vs reported-distance=%.2f (max-delta=%.2f)",
+                  offset_dist, reported_distance, (double)(min_dist * permitted_error_length_pct));
             goto bad_yaw;
         }
 


### PR DESCRIPTION
I didn't find this debug message particularly informative; add more info.

Old:
```
calculate_moving_base_yaw:372: Exceeded the permitted error margin 29.73999 > 0.052001
calculate_moving_base_yaw:372: Exceeded the permitted error margin 29.73999 > 0.052001
calculate_moving_base_yaw:372: Exceeded the permitted error margin 29.73999 > 0.052001
calculate_moving_base_yaw:372: Exceeded the permitted error margin 29.73999 > 0.052001
```

New:
```
calculate_moving_base_yaw:372: Offset=0.300000 vs reported-distance=0.250000 (max-delta=0.050000)
calculate_moving_base_yaw:372: Offset=0.300000 vs reported-distance=0.250000 (max-delta=0.050000)
calculate_moving_base_yaw:372: Offset=0.300000 vs reported-distance=0.250000 (max-delta=0.050000)
calculate_moving_base_yaw:372: Offset=0.300000 vs reported-distance=0.239990 (max-delta=0.047998)
```

Only affects things when you've got the compile-time debug option enabled
