### PR TITLE
AP_MSP: correct compilation when GPS disabled

### DIFF
--- a/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
@@ -201,6 +201,7 @@ void AP_MSP_Telem_Backend::update_home_pos(home_state_t &home_state)
     home_state.home_is_set = _ahrs.home_is_set();
 }
 
+#if AP_GPS_ENABLED
 void AP_MSP_Telem_Backend::update_gps_state(gps_state_t &gps_state)
 {
     AP_GPS& gps = AP::gps();
@@ -220,6 +221,7 @@ void AP_MSP_Telem_Backend::update_gps_state(gps_state_t &gps_state)
         gps_state.ground_course_cd = gps.ground_course_cd();
     }
 }
+#endif
 
 #if AP_BATTERY_ENABLED
 void AP_MSP_Telem_Backend::update_battery_state(battery_state_t &battery_state)
@@ -645,8 +647,10 @@ MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_raw_gps(sbuf_t *dst)
         return MSP_RESULT_ERROR;
     }
 #endif
-    gps_state_t gps_state;
+    gps_state_t gps_state {};
+#if AP_GPS_ENABLED
     update_gps_state(gps_state);
+#endif
 
     // handle airspeed override
     bool airspeed_en = false;


### PR DESCRIPTION
... which is all the time on some AP_Periph devices

```
../../libraries/AP_MSP/AP_MSP_Telem_Backend.cpp: In member function 'virtual void AP_MSP_Telem_Backend::update_gps_state(AP_MSP_Telem_Backend::gps_state_t&)': ../../libraries/AP_MSP/AP_MSP_Telem_Backend.cpp:206:5: error: 'AP_GPS' was not declared in this scope; did you mean 'RAW_GPS'?
  206 |     AP_GPS& gps = AP::gps();
      |     ^~~~~~
      |     RAW_GPS
compilation terminated due to -Wfatal-errors.
```

We still send the packet but just with the airspeed in it.  I think that does sound  Quite Right.
