### PR TITLE
AP_Motors6DOF: use its own rc_write, which allows trimming motor outputs

### DIFF
--- a/libraries/AP_Motors/AP_Motors6DOF.h
+++ b/libraries/AP_Motors/AP_Motors6DOF.h
@@ -49,6 +49,8 @@ public:
 
     bool set_reversed(int motor_number, bool reversed);
 
+    void rc_write(uint8_t chan, uint16_t pwm) override;
+
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo        var_info[];
 


### PR DESCRIPTION
I was told some people out there sell ESCs with bad crystals or something that fail to detect 1500us properly.
I was also told "they calibrate it in the factory", but that doesn't seem to be quite true. These (bi-directional) ESCs end up centered at 1520 or sometimes more.

This allows the users to cope with these and other ESCs.

Tested and working.

should fix #23002 