### PR TITLE
AP_MSP: Use scaled RC inputs instead of direct RC in

### DIFF
--- a/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
@@ -1056,8 +1056,12 @@ MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_rc(sbuf_t *dst)
     if (rcmap == nullptr) {
         return MSP_RESULT_ERROR;
     }
-    uint16_t values[16] = {};
-    rc().get_radio_in(values, ARRAY_SIZE(values));
+
+    // note: rcmap channels start at 1
+    float roll = rc().rc_channel(rcmap->roll()-1)->norm_input_dz();
+    float pitch = -rc().rc_channel(rcmap->pitch()-1)->norm_input_dz();
+    float yaw = rc().rc_channel(rcmap->yaw()-1)->norm_input_dz();
+    float throttle = rc().rc_channel(rcmap->throttle()-1)->norm_input_dz();
 
     const struct PACKED {
         uint16_t a;
@@ -1066,11 +1070,10 @@ MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_rc(sbuf_t *dst)
         uint16_t t;
     } rc {
         // send only 4 channels, MSP order is AERT
-        // note: rcmap channels start at 1
-        a : values[rcmap->roll()-1],       // A
-        e : values[rcmap->pitch()-1],      // E
-        r : values[rcmap->yaw()-1],        // R
-        t : values[rcmap->throttle()-1]    // T
+        a : uint16_t(roll*500+1500),       // A
+        e : uint16_t(pitch*500+1500),      // E
+        r : uint16_t(yaw*500+1500),        // R
+        t : uint16_t(throttle*1000+1000)    // T
     };
 
     sbuf_write_data(dst, &rc, sizeof(rc));


### PR DESCRIPTION
This makes the MSP RC output scaled RC inputs instead of just passing through the received RC input. 
This is especially useful if you have RC reversals, so that ArduPilot's _REVERSED parameters still apply.

Tested with a copter with an HDZero VTX which uses stick commands.
I've also reversed pitch because ArduPilot's pitch is inverted relative to other flight controllers (eg Betaflight) and OpenTX and thus how devices like the HDZero VTX expect it to be.

@yaapu Re our previous discussion - not sure if this would affect other (non-VTX/OSD) MSP devices that wouldn't expect pitch to be reversed? At the moment, if people using MSP devices used ArduPilot's _REVERSED parameter to reverse pitch instead of reversing it on their transmitter, then how I've currently done it should result in no change of behaviour, whereas if they've done it on their transmitter then this should result in pitch being the opposite way around...
Not sure if we need a parameter to decide which of the two doesn't get a change in behaviour?