### PR TITLE
Heli: Create Copter Level Param Group for General Heli Params 

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -676,6 +676,11 @@ void Copter::one_hz_loop()
 #if AC_CUSTOMCONTROL_MULTI_ENABLED == ENABLED
     custom_control.set_notch_sample_rate(AP::scheduler().get_filtered_loop_rate_hz());
 #endif
+
+#if FRAME_CONFIG == HELI_FRAME
+    // set the leaky integrator flag in the motors library. This is based on the H_G_OPTIONS param.
+    motors->set_leaky_integrator(g2.heli_params.using_leaky_integrator());
+#endif
 }
 
 void Copter::init_simple_bearing()

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -78,6 +78,7 @@
 
 #if FRAME_CONFIG == HELI_FRAME
  #define MOTOR_CLASS AP_MotorsHeli
+ #include "heli_params.h" // Collection of general heli specific parameters and helpers
 #else
  #define MOTOR_CLASS AP_MotorsMulticopter
 #endif
@@ -548,9 +549,9 @@ private:
     AC_PrecLand_StateMachine precland_statemachine;
 #endif
 
+#if FRAME_CONFIG == HELI_FRAME
     // Pilot Input Management Library
     // Only used for Helicopter for now
-#if FRAME_CONFIG == HELI_FRAME
     AC_InputManager_Heli input_manager;
 #endif
 

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1234,6 +1234,12 @@ const AP_Param::GroupInfo ParametersG2::var_info2[] = {
     // @User: Advanced
     AP_GROUPINFO("FS_EKF_FILT", 8, ParametersG2, fs_ekf_filt_hz, FS_EKF_FILT_DEFAULT),
 
+#if FRAME_CONFIG == HELI_FRAME
+    // @Group: H_G_
+    // @Path: heli_params.cpp
+    AP_SUBGROUPINFO(heli_params, "H_G_", 9, ParametersG2, Heli_Params),
+#endif
+
     // ID 62 is reserved for the AP_SUBGROUPEXTENSION
 
     AP_GROUPEND
@@ -1851,5 +1857,11 @@ void Copter::convert_tradheli_parameters(void) const
         AP_Param::convert_old_parameter(&collhelipct_conversion_info[i], 0.1f);
     }
 
+    // PARAMETER_CONVERSION - Added: Feb-2024
+    // Move the H_OPTIONS param from the motors lib upto the heli_params object
+    const AP_Param::ConversionInfo h_options_info[] = {
+        { Parameters::k_param_motors, 1792, AP_PARAM_INT8, "H_G_OPTIONS" }
+    };
+    AP_Param::convert_old_parameter(&h_options_info[0], 1.0);
 }
 #endif

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -685,6 +685,12 @@ public:
     AP_Float pldp_range_finder_minimum_m;
     AP_Float pldp_delay_s;
     AP_Float pldp_descent_speed_ms;
+
+#if FRAME_CONFIG == HELI_FRAME
+    // General heli-specific parameters
+    Heli_Params heli_params;
+#endif
+
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduCopter/heli.cpp
+++ b/ArduCopter/heli.cpp
@@ -74,7 +74,7 @@ void Copter::check_dynamic_flight(void)
 void Copter::update_heli_control_dynamics(void)
 {
 
-    if (!motors->using_leaky_integrator()) {
+    if (!g2.heli_params.using_leaky_integrator()) {
         //turn off leaky_I
         attitude_control->use_leaky_i(false);
         if (ap.land_complete || ap.land_complete_maybe) {

--- a/ArduCopter/heli_params.cpp
+++ b/ArduCopter/heli_params.cpp
@@ -1,0 +1,19 @@
+#include "heli_params.h"
+
+const AP_Param::GroupInfo Heli_Params::var_info[] = {
+
+    // @Param: OPTIONS
+    // @DisplayName: Heli Options
+    // @Description: Bitmask of heli options. Bit 0 changes how the pitch, roll, and yaw axis integrator term is managed for low speed and takeoff/landing. In AC 4.0 and earlier, scheme uses a leaky integrator for ground speeds less than 5 m/s and won't let the steady state integrator build above ILMI. The integrator is allowed to build to the ILMI value when it is landed. The other integrator management scheme bases integrator limiting on takeoff and landing. Whenever the aircraft is landed the integrator is set to zero. When the aicraft is airborne, the integrator is only limited by IMAX.
+    // @Bitmask: 0:Use Leaky I
+    // @User: Standard
+    AP_GROUPINFO("OPTIONS", 1, Heli_Params, _heli_options, (uint8_t)HeliOption::USE_LEAKY_I),
+
+    AP_GROUPEND
+};
+
+// Determines if _heli_options bit is set
+bool Heli_Params::heli_option(HeliOption opt) const
+{
+    return (_heli_options.get() & (uint8_t)opt);
+}

--- a/ArduCopter/heli_params.h
+++ b/ArduCopter/heli_params.h
@@ -1,0 +1,26 @@
+#include <AP_Param/AP_Param.h>
+
+class Heli_Params
+{
+public:
+
+    // Enum for heli optional features
+    enum class HeliOption {
+        USE_LEAKY_I = (1<<0), // 1
+    };
+
+    // Determines if _heli_options bit is set
+    bool heli_option(HeliOption opt) const;
+
+    // Use leaking integrator management scheme
+    bool using_leaky_integrator() const { return heli_option(HeliOption::USE_LEAKY_I); }
+
+    // User Settable Parameters
+    static const struct AP_Param::GroupInfo var_info[];
+
+private:
+
+    // Parameters
+    AP_Int8 _heli_options; // Bitmask for optional features
+
+};

--- a/ArduCopter/mode_acro_heli.cpp
+++ b/ArduCopter/mode_acro_heli.cpp
@@ -51,13 +51,13 @@ void ModeAcro_Heli::run()
     case AP_Motors::SpoolState::GROUND_IDLE:
         // If aircraft is landed, set target heading to current and reset the integrator
         // Otherwise motors could be at ground idle for practice autorotation
-        if ((motors->init_targets_on_arming() && motors->using_leaky_integrator()) || (copter.ap.land_complete && !motors->using_leaky_integrator())) {
+        if ((motors->init_targets_on_arming() && copter.g2.heli_params.using_leaky_integrator()) || (copter.ap.land_complete && !copter.g2.heli_params.using_leaky_integrator())) {
             attitude_control->reset_target_and_rate(false);
             attitude_control->reset_rate_controller_I_terms_smoothly();
         }
         break;
     case AP_Motors::SpoolState::THROTTLE_UNLIMITED:
-        if (copter.ap.land_complete && !motors->using_leaky_integrator()) {
+        if (copter.ap.land_complete && !copter.g2.heli_params.using_leaky_integrator()) {
             attitude_control->reset_rate_controller_I_terms_smoothly();
         }
         break;

--- a/ArduCopter/mode_stabilize_heli.cpp
+++ b/ArduCopter/mode_stabilize_heli.cpp
@@ -58,13 +58,13 @@ void ModeStabilize_Heli::run()
     case AP_Motors::SpoolState::GROUND_IDLE:
         // If aircraft is landed, set target heading to current and reset the integrator
         // Otherwise motors could be at ground idle for practice autorotation
-        if ((motors->init_targets_on_arming() && motors->using_leaky_integrator()) || (copter.ap.land_complete && !motors->using_leaky_integrator())) {
+        if ((motors->init_targets_on_arming() && copter.g2.heli_params.using_leaky_integrator()) || (copter.ap.land_complete && !copter.g2.heli_params.using_leaky_integrator())) {
             attitude_control->reset_yaw_target_and_rate(false);
             attitude_control->reset_rate_controller_I_terms_smoothly();
         }
         break;
     case AP_Motors::SpoolState::THROTTLE_UNLIMITED:
-        if (copter.ap.land_complete && !motors->using_leaky_integrator()) {
+        if (copter.ap.land_complete && !copter.g2.heli_params.using_leaky_integrator()) {
             attitude_control->reset_rate_controller_I_terms_smoothly();
         }
         break;

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -103,12 +103,7 @@ const AP_Param::GroupInfo AP_MotorsHeli::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("HOVER_LEARN", 27, AP_MotorsHeli, _collective_hover_learn, HOVER_LEARN_AND_SAVE),
 
-    // @Param: OPTIONS
-    // @DisplayName: Heli_Options
-    // @Description: Bitmask of heli options.  Bit 0 changes how the pitch, roll, and yaw axis integrator term is managed for low speed and takeoff/landing. In AC 4.0 and earlier, scheme uses a leaky integrator for ground speeds less than 5 m/s and won't let the steady state integrator build above ILMI. The integrator is allowed to build to the ILMI value when it is landed.  The other integrator management scheme bases integrator limiting on takeoff and landing.  Whenever the aircraft is landed the integrator is set to zero.  When the aicraft is airborne, the integrator is only limited by IMAX. 
-    // @Bitmask: 0:Use Leaky I
-    // @User: Standard
-    AP_GROUPINFO("OPTIONS", 28, AP_MotorsHeli, _heli_options, (uint8_t)HeliOption::USE_LEAKY_I),
+    // index 28 was OPTIONS and was moved up to copter/heli_params. Do not use this index in the future.
 
     // @Param: COL_ANG_MIN
     // @DisplayName: Collective Blade Pitch Angle Minimum
@@ -341,7 +336,7 @@ void AP_MotorsHeli::output_logic()
             // Servos set to their trim values or in a test condition.
 
             // set limits flags
-            if (!using_leaky_integrator()) {
+            if (!_heliflags._using_leaky_integrator) {
                 set_limit_flag_pitch_roll_yaw(true);
             } else {
                 set_limit_flag_pitch_roll_yaw(false);
@@ -358,7 +353,7 @@ void AP_MotorsHeli::output_logic()
         case SpoolState::GROUND_IDLE: {
             // Motors should be stationary or at ground idle.
             // set limits flags
-            if (_heliflags.land_complete && !using_leaky_integrator()) {
+            if (_heliflags.land_complete && !_heliflags._using_leaky_integrator) {
                 set_limit_flag_pitch_roll_yaw(true);
             } else {
                 set_limit_flag_pitch_roll_yaw(false);
@@ -380,7 +375,7 @@ void AP_MotorsHeli::output_logic()
             // Servos should exhibit normal flight behavior.
 
             // set limits flags
-            if (_heliflags.land_complete && !using_leaky_integrator()) {
+            if (_heliflags.land_complete && !_heliflags._using_leaky_integrator) {
                 set_limit_flag_pitch_roll_yaw(true);
             } else {
                 set_limit_flag_pitch_roll_yaw(false);
@@ -402,7 +397,7 @@ void AP_MotorsHeli::output_logic()
             // Servos should exhibit normal flight behavior.
 
             // set limits flags
-            if (_heliflags.land_complete && !using_leaky_integrator()) {
+            if (_heliflags.land_complete && !_heliflags._using_leaky_integrator) {
                 set_limit_flag_pitch_roll_yaw(true);
             } else {
                 set_limit_flag_pitch_roll_yaw(false);
@@ -422,7 +417,7 @@ void AP_MotorsHeli::output_logic()
             // Servos should exhibit normal flight behavior.
 
             // set limits flags
-            if (_heliflags.land_complete && !using_leaky_integrator()) {
+            if (_heliflags.land_complete && !_heliflags._using_leaky_integrator) {
                 set_limit_flag_pitch_roll_yaw(true);
             } else {
                 set_limit_flag_pitch_roll_yaw(false);
@@ -495,12 +490,6 @@ void AP_MotorsHeli::update_takeoff_collective_flag(float coll_out)
     } else {
         _heliflags.takeoff_collective = false;
     }
-}
-
-// Determines if _heli_options bit is set
-bool AP_MotorsHeli::heli_option(HeliOption opt) const
-{
-    return (_heli_options & (uint8_t)opt);
 }
 
 // updates the turbine start flag

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -145,14 +145,6 @@ public:
 	//return zero lift collective position
     float get_coll_mid() const { return _collective_zero_thrust_pct; }
 
-    // enum for heli optional features
-    enum class HeliOption {
-        USE_LEAKY_I                     = (1<<0),   // 1
-    };
-
-    // use leaking integrator management scheme
-    bool using_leaky_integrator() const { return heli_option(HeliOption::USE_LEAKY_I); }
-
     // Run arming checks
     bool arming_checks(size_t buflen, char *buffer) const override;
 
@@ -164,6 +156,9 @@ public:
 
     // Helper function for param conversions to be done in motors class
     virtual void heli_motors_param_conversions(void) { return; }
+
+    // Helper function to set the _using_leaky_integrator flag
+    void set_leaky_integrator(bool use) { _heliflags._using_leaky_integrator = use; }
 
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo var_info[];
@@ -226,9 +221,6 @@ protected:
     // save parameters as part of disarming
     void save_params_on_disarm() override;
 
-    // Determines if _heli_options bit is set
-    bool heli_option(HeliOption opt) const;
-
     // updates the takeoff collective flag indicating that current collective is greater than collective required to indicate takeoff.
     void update_takeoff_collective_flag(float coll_out);
 
@@ -257,8 +249,9 @@ protected:
         uint8_t land_complete           : 1;    // true if aircraft is landed
         uint8_t takeoff_collective      : 1;    // true if collective is above 30% between H_COL_MID and H_COL_MAX
         uint8_t below_land_min_coll     : 1;    // true if collective is below H_COL_LAND_MIN
-        uint8_t rotor_spooldown_complete : 1;    // true if the rotors have spooled down completely
+        uint8_t rotor_spooldown_complete : 1;   // true if the rotors have spooled down completely
         uint8_t start_engine            : 1;    // true if turbine start RC option is initiated
+        bool _using_leaky_integrator    : 1;    // true if h_options is set to use leaky I term
     } _heliflags;
 
     // parameters
@@ -269,7 +262,6 @@ protected:
     AP_Int8         _servo_test;                // sets number of cycles to test servo movement on bootup
     AP_Float        _collective_hover;          // estimated collective required to hover throttle in the range 0 ~ 1
     AP_Int8         _collective_hover_learn;    // enable/disabled hover collective learning
-    AP_Int8         _heli_options;              // bitmask for optional features
     AP_Float        _collective_zero_thrust_deg;// Zero thrust blade collective pitch in degrees
     AP_Float        _collective_land_min_deg;   // Minimum Landed collective blade pitch in degrees for non-manual collective modes (i.e. modes that use altitude hold)
     AP_Float        _collective_max_deg;        // Maximum collective blade pitch angle in deg that corresponds to the PWM set for maximum collective pitch (H_COL_MAX)


### PR DESCRIPTION
With the autorotation PR (#22871) pending I would like to create a general set of heli params at the copter level in preparation for more generic vehicle params to go into (e.g. Rotor size, disc solidity).

To make a start I have moved H_OPTIONS out of motors and into copter so that it can be suitably used in the future for more than just motor's options.

I have given the param prefix H_G_.  The key thing I am hoping to achieve is to keep the it under the H params for heli in the GCS to make it easier on users, without the risk of string search conflicts in the future.  The "G" was meant as "General" but I am open to better naming conventions.

Param conversion tested in SITL. 