### PR TITLE
AP_Logger: Add enum information to VER log message metadata

### DIFF
--- a/libraries/AP_HAL/AP_HAL_Boards.h
+++ b/libraries/AP_HAL/AP_HAL_Boards.h
@@ -6,6 +6,7 @@
  */
 #pragma once
 
+// @LoggerEnum: HAL_BOARD
 #define HAL_BOARD_SITL     3
 // #define HAL_BOARD_SMACCM   4  // unused
 // #define HAL_BOARD_PX4      5  // unused
@@ -16,7 +17,9 @@
 #define HAL_BOARD_ESP32	   12
 #define HAL_BOARD_QURT     13
 #define HAL_BOARD_EMPTY    99
+// @LoggerEnumEnd
 
+// @LoggerEnum: HAL_BOARD_SUBTYPE
 /* Default board subtype is -1 */
 #define HAL_BOARD_SUBTYPE_NONE -1
 
@@ -70,6 +73,7 @@
 #define HAL_BOARD_SUBTYPE_ESP32_NICK            6006
 #define HAL_BOARD_SUBTYPE_ESP32_S3DEVKIT        6007
 #define HAL_BOARD_SUBTYPE_ESP32_S3EMPTY         6008
+// @LoggerEnumEnd
 
 /* InertialSensor driver types */
 #define HAL_INS_NONE         0

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1134,7 +1134,9 @@ struct PACKED log_VER {
 // @Description: Ardupilot version
 // @Field: TimeUS: Time since system startup
 // @Field: BT: Board type
+// @FieldValueEnum: BT: HAL_BOARD
 // @Field: BST: Board subtype
+// @FieldValueEnum: BST: HAL_BOARD_SUBTYPE
 // @Field: Maj: Major version number
 // @Field: Min: Minor version number
 // @Field: Pat: Patch number
@@ -1143,6 +1145,7 @@ struct PACKED log_VER {
 // @Field: FWS: Firmware version string
 // @Field: APJ: Board ID
 // @Field: BU: Build vehicle type
+// @FieldValueEnum: BU: APM_BUILD
 // @Field: FV: Filter version
 
 // @LoggerMessage: MOTB

--- a/libraries/AP_Vehicle/AP_Vehicle_Type.h
+++ b/libraries/AP_Vehicle/AP_Vehicle_Type.h
@@ -19,6 +19,7 @@
   Also note that code needs to support other APM_BUILD_DIRECTORY
   values for example sketches
  */
+// @LoggerEnum: APM_BUILD
 #define APM_BUILD_Rover      1
 #define APM_BUILD_ArduCopter     2
 #define APM_BUILD_ArduPlane      3
@@ -32,6 +33,7 @@
 #define APM_BUILD_AP_Bootloader  11
 #define APM_BUILD_Blimp      12
 #define APM_BUILD_Heli       13
+// @LoggerEnumEnd
 
 #ifdef APM_BUILD_DIRECTORY
 /*


### PR DESCRIPTION
The aim of this PR is to add help text for the VER and FILE log messages (linked to issue #26088).

Implemented by adding the relevant comment tags into AP_Logger.cpp

As well as just adding the field descriptions, I wanted to include the enumeration information for the BT, BST and BU fields of the VER message. As there are sets of #defines and not actual enums, I made the following updates:
* Add support to enum_parse.py to extract #define sets enclosed between @LoggerEnum and @LoggerEnumEnd comment tags.
* Add @LoggerEnum and @LoggerEnumEnd comment tags around HAL_BOARD and HAL_BOARD_SUBTYPE defines in AP_HAL_Boards.h.
* Add @LoggerEnum and @LoggerEnumEnd comment tags around APM_BUILD defines in AP_Vehicle_Type.h.

Tested by running parse.py for each vehicle type, and checking the output.
As example, this is the output for the VER message in the .rst output file used to create the wiki page (truncated here to save space):
```
+--------+----------+-------------------------------------------------------+
| TimeUS | μs       | Time since system startup                             |
+--------+----------+-------------------------------------------------------+
| BT     | enum     | Board type                                            |
|        |          | Values:                                               |
|        |          |                                                       |
|        |          | +-------------------+----+----------+                 |
|        |          | | HAL_BOARD_SITL    | 3  |          |                 |
|        |          | +-------------------+----+----------+                 |
|        |          | | HAL_BOARD_SMACCM  | 4  | unused   |                 |
|        |          | +-------------------+----+----------+                 |
|        |          | (etc)                                                 |
+--------+----------+-------------------------------------------------------+
| BST    | enum     | Board subtype                                         |
|        |          | Values:                                               |
|        |          |                                                       |
|        |          | +-----------------------------------------+------+--+ |
|        |          | | HAL_BOARD_SUBTYPE_NONE                  | -1   |  | |
|        |          | +-----------------------------------------+------+--+ |
|        |          | | HAL_BOARD_SUBTYPE_LINUX_NONE            | 1000 |  | |
|        |          | +-----------------------------------------+------+--+ |
|        |          | (etc)                                                 |
```