### PR TITLE
AP_Bootloader: treat substitute_vars input as string

### DIFF
--- a/Tools/AP_Bootloader/network.h
+++ b/Tools/AP_Bootloader/network.h
@@ -39,7 +39,7 @@ private:
     static bool low_level_input(struct netif *netif, struct pbuf **pbuf);
     static int8_t ethernetif_init(struct netif *netif);
 
-    static char *substitute_vars(const char *msg, uint32_t size);
+    static char *substitute_vars(const char *msg);
     static struct web_var {
         const char *name;
         const char *value;


### PR DESCRIPTION
Guaranteed by the way ROMFS works and saves some flash. Also fixes issue where the length could be overrun anyway.

Needs testing on real hardware; I don't own any suitable. Also not sure if updated bootloader files should be committed.