### PR TITLE
AP_Logger: Add metadata for VER and FILE messages

### DIFF
--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1195,6 +1195,13 @@ struct PACKED log_VER {
 // @Field: Free: free stack
 // @Field: Name: thread name
 
+// @LoggerMessage: FILE
+// @Description: File data
+// @Field: FileName: File name
+// @Field: Offset: Offset into the file of this block
+// @Field: Length: Length of this data block
+// @Field: Data: File data of this block
+
 // @LoggerMessage: SCR
 // @Description: Scripting runtime stats
 // @Field: TimeUS: Time since system startup
@@ -1202,6 +1209,20 @@ struct PACKED log_VER {
 // @Field: Runtime: run time
 // @Field: Total_mem: total memory usage of all scripts
 // @Field: Run_mem: run memory usage
+
+// @LoggerMessage: VER
+// @Description: Ardupilot version
+// @Field: TimeUS: Time since system startup
+// @Field: BT: Board type
+// @Field: BST: Board subtype
+// @Field: Maj: Major version number
+// @Field: Min: Minor version number
+// @Field: Pat: Patch number
+// @Field: FWT: Firmware type
+// @Field: GH: Github commit
+// @Field: FWS: Firmware version string
+// @Field: APJ: Board ID
+// @Field: BU: Build vehicle type
 
 // @LoggerMessage: MOTB
 // @Description: Motor mixer information


### PR DESCRIPTION
The aim of this PR is to add help text for the VER and FILE log messages (linked to issue #26088).
Implemented by adding the relevant comment tags into AP_Logger.cpp.

(Note that it does _not_ link the VER fields to enumerations, as they are #defines and not pure enums, and so not currently extracted. Ref comments on https://github.com/ArduPilot/ardupilot/pull/26308#issuecomment-1962065366).