### PR TITLE
Scripting: only try loading from ROMFS if scripts exist

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -770,6 +770,11 @@ class sitl(Board):
                     env.ROMFS_FILES += [('scripts/'+f,'ROMFS/scripts/'+f)]
 
         if len(env.ROMFS_FILES) > 0:
+            # Allow lua to load from ROMFS if any lua files are added
+            for file in env.ROMFS_FILES:
+                if file[0].startswith("scripts") and file[0].endswith(".lua"):
+                    env.CXXFLAGS += ['-DHAL_HAVE_AP_ROMFS_EMBEDDED_LUA']
+                    break
             env.CXXFLAGS += ['-DHAL_HAVE_AP_ROMFS_EMBEDDED_H']
 
         if cfg.options.sitl_rgbled:
@@ -1343,6 +1348,11 @@ class linux(Board):
                 HAL_PARAM_DEFAULTS_PATH='"@ROMFS/defaults.parm"',
             )
         if len(env.ROMFS_FILES) > 0:
+            # Allow lua to load from ROMFS if any lua files are added
+            for file in env.ROMFS_FILES:
+                if file[0].startswith("scripts") and file[0].endswith(".lua"):
+                    env.CXXFLAGS += ['-DHAL_HAVE_AP_ROMFS_EMBEDDED_LUA']
+                    break
             env.CXXFLAGS += ['-DHAL_HAVE_AP_ROMFS_EMBEDDED_H']
 
     def build(self, bld):

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -2625,6 +2625,11 @@ Please run: Tools/scripts/build_bootloaders.py %s
         self.embed_bootloader(f)
 
         if len(self.romfs) > 0:
+            # Allow lua to load from ROMFS if any lua files are added
+            for file in self.romfs.keys():
+                if file.startswith("scripts") and file.endswith(".lua"):
+                    f.write('#define HAL_HAVE_AP_ROMFS_EMBEDDED_LUA 1\n')
+                    break
             f.write('#define HAL_HAVE_AP_ROMFS_EMBEDDED_H 1\n')
 
         if self.mcu_series.startswith('STM32F1'):
@@ -3204,14 +3209,15 @@ Please run: Tools/scripts/build_bootloaders.py %s
         # write out hw.dat for ROMFS
         self.write_all_lines(os.path.join(self.outdir, "hw.dat"))
 
+        # Add ROMFS directories
+        self.romfs_add_dir(['scripts'])
+        self.romfs_add_dir(['param'])
+
         # write out hwdef.h
         self.write_hwdef_header(os.path.join(self.outdir, "hwdef.h"))
 
         # write out ldscript.ld
         self.write_ldscript(os.path.join(self.outdir, "ldscript.ld"))
-
-        self.romfs_add_dir(['scripts'])
-        self.romfs_add_dir(['param'])
 
         self.write_ROMFS(self.outdir)
 

--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -524,10 +524,12 @@ void lua_scripts::run(void) {
         load_all_scripts_in_dir(L, SCRIPTING_DIRECTORY);
         loaded = true;
     }
+#ifdef HAL_HAVE_AP_ROMFS_EMBEDDED_LUA
     if ((dir_disable & uint16_t(AP_Scripting::SCR_DIR::ROMFS)) == 0) {
         load_all_scripts_in_dir(L, "@ROMFS/scripts");
         loaded = true;
     }
+#endif
     if (!loaded) {
         GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Lua: All directory's disabled see SCR_DIR_DISABLE");
     }


### PR DESCRIPTION
https://github.com/ArduPilot/ardupilot/pull/26225 means that ROMFS will fail to open directories that don't exist. This results in a failed to open directory warning in ROMFS:

![image](https://github.com/ArduPilot/ardupilot/assets/33176108/03755b3f-9db3-445d-abc3-2a3ef71b6d54)

We can tell at compile time if there are any scripts we could try to load,  so we can compile out trying to load from ROMFS.

