### PR TITLE
Tools: only produce _with_bl.hex not *.hex for vehicle firmware

### DIFF
--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -435,7 +435,10 @@ def chibios_firmware(self):
     bootloader_bin = self.bld.srcnode.make_node("Tools/bootloaders/%s_bl.bin" % self.env.BOARD)
     if self.bld.env.HAVE_INTEL_HEX:
         if os.path.exists(bootloader_bin.abspath()):
-            hex_target = self.bld.bldnode.find_or_declare('bin/' + link_output.change_ext('.hex').name)
+            if int(self.bld.env.FLASH_RESERVE_START_KB) > 0:
+                hex_target = self.bld.bldnode.find_or_declare('bin/' + link_output.change_ext('_with_bl.hex').name)
+            else:
+                hex_target = self.bld.bldnode.find_or_declare('bin/' + link_output.change_ext('.hex').name)
             hex_task = self.create_task('build_intel_hex', src=[bin_target[0], bootloader_bin], tgt=hex_target)
             hex_task.set_run_after(cleanup_task)
         else:

--- a/Tools/scripts/make_intel_hex.py
+++ b/Tools/scripts/make_intel_hex.py
@@ -39,13 +39,14 @@ with_bl = blimage + appimage
 
 tmpfile = hexfile + ".tmp"
 
-open(tmpfile, "wb").write(appimage)
-
-intelhex.bin2hex(tmpfile, hexfile, offset=(0x08000000 + reserve_kb*1024))
-
+# we either write a _with_bl.hex or a .hex. We don't write both as users get
+# confused if offered a arducopter.hex and try to flash it with INAV DFU
+# flashing tool, not realising it has to be flashed at the correct flash offset
 if reserve_kb > 0:
-   open(tmpfile, "wb").write(with_bl)
-   intelhex.bin2hex(tmpfile, hex_with_bl, offset=0x08000000)
-   
-os.unlink(tmpfile)
+    open(tmpfile, "wb").write(with_bl)
+    intelhex.bin2hex(tmpfile, hex_with_bl, offset=0x08000000)
+else:
+    open(tmpfile, "wb").write(appimage)
+    intelhex.bin2hex(tmpfile, hexfile, offset=(0x08000000 + reserve_kb*1024))
 
+os.unlink(tmpfile)


### PR DESCRIPTION
if we are producing _with_bl.hex then don't also build *.hex as it can confuse users who think they should flash *.hex with a DFU flashing tool