### PR TITLE
waf: remove SKETCH and SKETCHNAME from build sysmte

### DIFF
--- a/Tools/ardupilotwaf/ap_library.py
+++ b/Tools/ardupilotwaf/ap_library.py
@@ -52,7 +52,7 @@ def _vehicle_index(vehicle):
     return _vehicle_indexes[vehicle]
 
 # note that AP_NavEKF3_core.h is needed for AP_NavEKF3_feature.h
-_vehicle_macros = ['SKETCHNAME', 'SKETCH', 'APM_BUILD_DIRECTORY',
+_vehicle_macros = ['APM_BUILD_DIRECTORY', 'AP_BUILD_TARGET_NAME',
                    'APM_BUILD_TYPE', 'APM_BUILD_COPTER_OR_HELI',
                    'AP_NavEKF3_core.h', 'lua_generated_bindings.h']
 _macros_re = re.compile(r'\b(%s)\b' % '|'.join(_vehicle_macros))

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -125,14 +125,12 @@ def get_legacy_defines(sketch_name, bld):
     if bld.cmd == 'heli' or 'heli' in bld.targets:
         return [
         'APM_BUILD_DIRECTORY=APM_BUILD_Heli',
-        'SKETCH="' + sketch_name + '"',
-        'SKETCHNAME="' + sketch_name + '"',
+        'AP_BUILD_TARGET_NAME="' + sketch_name + '"',
         ]
 
     return [
         'APM_BUILD_DIRECTORY=APM_BUILD_' + sketch_name,
-        'SKETCH="' + sketch_name + '"',
-        'SKETCHNAME="' + sketch_name + '"',
+        'AP_BUILD_TARGET_NAME="' + sketch_name + '"',
     ]
 
 IGNORED_AP_LIBRARIES = [

--- a/libraries/AP_HAL_ChibiOS/HAL_ChibiOS_Class.cpp
+++ b/libraries/AP_HAL_ChibiOS/HAL_ChibiOS_Class.cpp
@@ -286,7 +286,7 @@ static void main_loop()
     hal.scheduler->set_system_initialized();
 
     thread_running = true;
-    chRegSetThreadName(SKETCHNAME);
+    chRegSetThreadName(AP_BUILD_TARGET_NAME);
 
     /*
       switch to high priority for main loop

--- a/libraries/AP_HAL_ChibiOS/Storage.cpp
+++ b/libraries/AP_HAL_ChibiOS/Storage.cpp
@@ -31,9 +31,9 @@ using namespace ChibiOS;
 extern const AP_HAL::HAL& hal;
 
 #ifndef HAL_STORAGE_FILE
-// using SKETCHNAME allows the one microSD to be used
+// using AP_BUILD_TARGET_NAME allows the one microSD to be used
 // for multiple vehicle types
-#define HAL_STORAGE_FILE "/APM/" SKETCHNAME ".stg"
+#define HAL_STORAGE_FILE "/APM/" AP_BUILD_TARGET_NAME ".stg"
 #endif
 
 #ifndef HAL_STORAGE_BACKUP_FOLDER

--- a/libraries/AP_HAL_Linux/Storage.cpp
+++ b/libraries/AP_HAL_Linux/Storage.cpp
@@ -20,7 +20,7 @@ using namespace Linux;
 
 // name the storage file after the sketch so you can use the same board
 // card for ArduCopter and ArduPlane
-#define STORAGE_FILE SKETCHNAME ".stg"
+#define STORAGE_FILE AP_BUILD_TARGET_NAME ".stg"
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -212,7 +212,7 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
     // default to CMAC
     const char *home_str = nullptr;
     const char *model_str = nullptr;
-    const char *vehicle_str = SKETCH;
+    const char *vehicle_str = AP_BUILD_TARGET_NAME;
     _use_fg_view = false;
     char *autotest_dir = nullptr;
     _fg_address = "127.0.0.1";


### PR DESCRIPTION
... renaming one of them to AP_BUILD_TARGET

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                                                     
Durandal                            *      *           *       *                 *      *      *
Hitec-Airspeed           *                                                                     
KakuteH7-bdshot                     *      *           *       *                 *      *      *
MatekF405                           *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *                  *       *                 *      *      *
f103-QiotekPeriph        *                                                                     
f303-Universal           *                                                                     
iomcu                                                                *                         
revo-mini                           *      *           *       *                 *      *      *
skyviper-v2450                                         *                                       
```

... relying on CI for other build targets like Replay, examples, unit tests.
