### PR TITLE
Plane: handle guided path requests in GUIDED mode

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1361,10 +1361,13 @@ void GCS_MAVLINK_Plane::handle_set_position_target_global_int(const mavlink_mess
         // be IGNORNED rather than INCLUDED.  See mavlink documentation of the
         // SET_POSITION_TARGET_GLOBAL_INT message, type_mask field.
         const uint16_t alt_mask = 0b1111111111111011; // (z mask at bit 3)
-            
+
+        // bit mask for path following: ignore force_set, yaw, yaw_rate
+        const uint16_t path_mask = 0b1111111000000000;
+
         bool msg_valid = true;
         AP_Mission::Mission_Command cmd = {0};
-        
+
         if (pos_target.type_mask & alt_mask)
         {
             cmd.content.location.alt = pos_target.alt * 100;
@@ -1391,7 +1394,66 @@ void GCS_MAVLINK_Plane::handle_set_position_target_global_int(const mavlink_mess
             if (msg_valid) {
                 handle_change_alt_request(cmd);
             }
-        } // end if alt_mask       
+        } // end if alt_mask
+
+        // guided path following
+        if (pos_target.type_mask & path_mask) {
+            cmd.content.location.lat = pos_target.lat_int;
+            cmd.content.location.lng = pos_target.lon_int;
+
+            cmd.content.location.alt = pos_target.alt * 100;
+            cmd.content.location.relative_alt = false;
+            cmd.content.location.terrain_alt = false;
+            switch (pos_target.coordinate_frame) 
+            {
+                case MAV_FRAME_GLOBAL_RELATIVE_ALT_INT:
+                    cmd.content.location.relative_alt = true;
+                    break;
+                default:
+                    gcs().send_text(MAV_SEVERITY_WARNING, "Invalid coord frame in SET_POSTION_TARGET_GLOBAL_INT");
+                    msg_valid = false;
+                    break;
+            }
+
+            if (msg_valid) {
+                Vector2f vel(pos_target.vx, pos_target.vy);
+                Vector2f accel(pos_target.afx, pos_target.afy);
+                Vector2f unit_vel;
+
+                float path_curvature{0.0};
+                bool dir_is_ccw{false};
+
+                if (!vel.is_zero()) {
+                    unit_vel = vel.normalized();
+
+                    if (!accel.is_zero()) {
+                        // curvature is determined from the acceleration normal
+                        // to the planar velocity and the equation for uniform
+                        // circular motion: a = v^2 / r.
+                        float accel_proj = accel.dot(unit_vel);
+                        Vector2f accel_lat = accel - unit_vel * accel_proj;
+                        Vector2f accel_lat_unit = accel_lat.normalized();
+
+                        path_curvature = accel_lat.length() / vel.length_squared();
+
+                        // % is cross product, direction: cw:= 1, ccw:= -1
+                        float dir = accel_lat_unit % unit_vel;
+                        dir_is_ccw = dir < 0.0;
+                    }
+                }
+            
+                // only accept position updates when in GUIDED mode
+                if (!plane.control_mode->is_guided_mode()) {
+                    return;
+                }
+                plane.mode_guided.handle_guided_path_request(
+                    cmd.content.location, unit_vel, path_curvature, dir_is_ccw);
+
+                // update adjust_altitude_target immediately rather than wait
+                // for the scheduler.
+                plane.adjust_altitude_target();
+            }
+        }
     }
 
 MAV_RESULT GCS_MAVLINK_Plane::handle_command_do_set_mission_current(const mavlink_command_int_t &packet)

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -296,17 +296,32 @@ public:
     // handle a guided target request from GCS
     bool handle_guided_request(Location target_loc) override;
 
+    // handle a guided path following request
+    bool handle_guided_path_request(Location position_on_path, Vector2f unit_path_tangent, const float path_curvature, const bool direction_is_ccw);
+
     void set_radius_and_direction(const float radius, const bool direction_is_ccw);
 
     void update_target_altitude() override;
 
 protected:
 
+    enum class SubMode: uint8_t {
+        WP,
+        Path
+    };
+
     bool _enter() override;
     bool _pre_arm_checks(size_t buflen, char *buffer) const override { return true; }
 
 private:
+
+    SubMode _guided_mode;
+
     float active_radius_m;
+
+    // used in path mode
+    float _path_curvature;
+    Vector2f _unit_path_tangent;
 };
 
 class ModeCircle: public Mode

--- a/ArduPlane/mode_guided.cpp
+++ b/ArduPlane/mode_guided.cpp
@@ -103,7 +103,18 @@ void ModeGuided::update()
 
 void ModeGuided::navigate()
 {
-    plane.update_loiter(active_radius_m);
+    switch (_guided_mode) {
+    case SubMode::WP:
+        plane.update_loiter(active_radius_m);
+        break;
+    case SubMode::Path:
+        plane.nav_controller->update_path(plane.next_WP_loc,
+            _unit_path_tangent, _path_curvature, plane.loiter.direction);
+        break;
+    default:
+        gcs().send_text(MAV_SEVERITY_WARNING, "Unknown GUIDED mode");
+        break;
+    }
 }
 
 bool ModeGuided::handle_guided_request(Location target_loc)
@@ -115,6 +126,33 @@ bool ModeGuided::handle_guided_request(Location target_loc)
     }
 
     plane.set_guided_WP(target_loc);
+
+    // use waypoint navigation sub-mode
+    _guided_mode = SubMode::WP;
+
+    return true;
+}
+
+bool ModeGuided::handle_guided_path_request(Location position_on_path, Vector2f unit_path_tangent, const float path_curvature, const bool direction_is_ccw)
+{
+    // add home alt if needed
+    if (position_on_path.relative_alt) {
+        position_on_path.alt += plane.home.alt;
+        position_on_path.relative_alt = 0;
+    }
+
+    // copy the current location into the OldWP slot
+    plane.prev_WP_loc = plane.current_loc;
+
+    // load the next_WP slot
+    plane.next_WP_loc = position_on_path;
+
+    _unit_path_tangent = unit_path_tangent;
+    _path_curvature = path_curvature;
+    plane.loiter.direction = direction_is_ccw ? -1 : 1;
+
+    // use path navigation sub-mode
+    _guided_mode = SubMode::Path;
 
     return true;
 }

--- a/libraries/AP_L1_Control/AP_L1_Control.cpp
+++ b/libraries/AP_L1_Control/AP_L1_Control.cpp
@@ -515,3 +515,31 @@ void AP_L1_Control::update_level_flight(void)
 
     _data_is_stale = false; // status are correctly updated with current waypoint data
 }
+
+// update L1 control for path following
+void AP_L1_Control::update_path(const class Location &position_on_path, Vector2f unit_path_tangent, float path_curvature, int8_t direction) {
+    //! @note initial implementation uses existing functions
+    if (!is_zero(path_curvature)) {
+        // moving along arc of circle - loiter about wp located at
+        // centre of curvature.
+        float radius_m = 1.0 / path_curvature;
+        auto center_wp = position_on_path;
+        Vector3p tangent_ned(unit_path_tangent.x, unit_path_tangent.y, 0.0);
+        Vector3p dn_ned(0.0, 0.0, 1.0); 
+        auto ofs_ned = dn_ned.cross(tangent_ned) * radius_m * direction;
+        center_wp.offset(ofs_ned);
+
+        update_loiter(center_wp, radius_m, direction);
+    } else {
+        // moving along a line segment - navigate to wp ahead of closest point
+        // in direction of path tangent 
+        float ofs_m = 1000.0;
+        Vector3p ofs_ned(ofs_m * unit_path_tangent.x,
+            ofs_m * unit_path_tangent.y, 0.0);
+        auto prev_wp = position_on_path;
+        auto next_wp = position_on_path;
+        next_wp.offset(ofs_ned);
+
+        update_waypoint(prev_wp, next_wp);
+    }
+}

--- a/libraries/AP_L1_Control/AP_L1_Control.h
+++ b/libraries/AP_L1_Control/AP_L1_Control.h
@@ -54,6 +54,7 @@ public:
     void update_loiter(const class Location &center_WP, float radius, int8_t loiter_direction) override;
     void update_heading_hold(int32_t navigation_heading_cd) override;
     void update_level_flight(void) override;
+    void update_path(const class Location &position_on_path, Vector2f unit_path_tangent, float path_curvature, int8_t direction) override;
     bool reached_loiter_target(void) override;
 
     // set the default NAVL1_PERIOD

--- a/libraries/AP_Navigation/AP_Navigation.h
+++ b/libraries/AP_Navigation/AP_Navigation.h
@@ -95,6 +95,16 @@ public:
     // attitude/steering.
     virtual void update_level_flight(void) = 0;
 
+    // update the internal state of the navigation controller when
+    // the vehicle has been commanded with a path following setpoint, which
+    // includes the closest point on the path, the unit tangent to the path,
+    // and the curvature. This is the step function for navigation control when
+    // path following. This function is called at regular intervals
+    // (typically 10Hz). The main flight code will call an output function
+    // (such as nav_roll_cd()) after this function to ask for the new required
+    // navigation attitude/steering.
+    virtual void update_path(const class Location &position_on_path, Vector2f unit_path_tangent, float path_curvature, int8_t direction) {}
+
     // return true if we have reached the target loiter location. This
     // may be a fuzzy decision, depending on internal navigation
     // parameters. For example the controller may return true only


### PR DESCRIPTION
Add a new method `handle_guided_path_request` to the plane GUIDED mode and extra update function `update_path ` in `AP_Navigation`. A preliminary implementation is provided for `AP_L1_Control`. The guided path mode is used to handle `SET_POSITION_TARGET_GLOBAL_INT` mavlink commands.

This is a simplified version of:

- https://github.com/ArduPilot/ardupilot/pull/26262

It excludes the NPFG controller and modifies the existing `ModeGuided` rather than introduce a new mode.

### Details

- The implementation follows the approach used in Rover's `ModeGuided` which supports sub-modes.
- Two modes are provided: `WP` for the existing `handle_guided_request`, and `Path` for the new `handled_guided_path_request`.
- A new virtual update method `update_path` is added to `AP_Navigation`.
- An implementation in `AP_L1_Control` uses the existing `update_waypoint` and `update_loiter` functions.

### Testing

See the tests using the [`terrain_navigation`](https://github.com/ethz-asl/terrain-navigation/tree/ros2) package in:

- https://github.com/ArduPilot/ardupilot/pull/26262