### PR TITLE
Copter: Heli: move runup event log down to AP_Motors

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -580,8 +580,7 @@ private:
     // Tradheli flags
     typedef struct {
         uint8_t dynamic_flight          : 1;    // 0   // true if we are moving at a significant speed (used to turn on/off leaky I terms)
-        uint8_t in_autorotation         : 1;    // 1   // true when heli is in autorotation
-        bool coll_stk_low                  ;    // 2   // true when collective stick is on lower limit
+        bool coll_stk_low                  ;    // 1   // true when collective stick is on lower limit
     } heli_flags_t;
     heli_flags_t heli_flags;
 

--- a/ArduCopter/heli.cpp
+++ b/ArduCopter/heli.cpp
@@ -154,9 +154,6 @@ float Copter::get_pilot_desired_rotor_speed() const
 // heli_update_rotor_speed_targets - reads pilot input and passes new rotor speed targets to heli motors object
 void Copter::heli_update_rotor_speed_targets()
 {
-
-    static bool rotor_runup_complete_last = false;
-
     // get rotor control method
     uint8_t rsc_control_mode = motors->get_rsc_mode();
 
@@ -182,13 +179,6 @@ void Copter::heli_update_rotor_speed_targets()
         break;
     }
 
-    // when rotor_runup_complete changes to true, log event
-    if (!rotor_runup_complete_last && motors->rotor_runup_complete()) {
-        LOGGER_WRITE_EVENT(LogEvent::ROTOR_RUNUP_COMPLETE);
-    } else if (rotor_runup_complete_last && !motors->rotor_runup_complete() && !heli_flags.in_autorotation) {
-        LOGGER_WRITE_EVENT(LogEvent::ROTOR_SPEED_BELOW_CRITICAL);
-    }
-    rotor_runup_complete_last = motors->rotor_runup_complete();
 }
 
 
@@ -205,20 +195,17 @@ void Copter::heli_update_autorotation()
                 set_mode(Mode::Number::AUTOROTATE, ModeReason::AUTOROTATION_START);
             }
             // set flag to facilitate both auto and manual autorotations
-            heli_flags.in_autorotation = true;
-            motors->set_in_autorotation(heli_flags.in_autorotation);
+            motors->set_in_autorotation(true);
             motors->set_enable_bailout(true);
         }
 #endif
         if (flightmode->has_manual_throttle() && motors->arot_man_enabled()) {
             // set flag to facilitate both auto and manual autorotations
-            heli_flags.in_autorotation = true;
-            motors->set_in_autorotation(heli_flags.in_autorotation);
+            motors->set_in_autorotation(true);
             motors->set_enable_bailout(true);
         }
     } else {
-        heli_flags.in_autorotation = false;
-        motors->set_in_autorotation(heli_flags.in_autorotation);
+        motors->set_in_autorotation(false);
         motors->set_enable_bailout(false);
     }
 

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -17,6 +17,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include "AP_MotorsHeli.h"
 #include <GCS_MAVLink/GCS.h>
+#include <AP_Logger/AP_Logger.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -597,4 +598,17 @@ AP_MotorsHeli_RSC::RotorControlState AP_MotorsHeli::get_rotor_control_state() co
 
     // Should be unreachable, but needed to keep the compiler happy
     return AP_MotorsHeli_RSC::RotorControlState::STOP;
+}
+
+// Update _heliflags.rotor_runup_complete value writing log event on state change
+void AP_MotorsHeli::set_rotor_runup_complete(bool new_value)
+{
+#if HAL_LOGGING_ENABLED
+    if (!_heliflags.rotor_runup_complete && new_value) {
+        LOGGER_WRITE_EVENT(LogEvent::ROTOR_RUNUP_COMPLETE);
+    } else if (_heliflags.rotor_runup_complete && !new_value && !_heliflags.in_autorotation) {
+        LOGGER_WRITE_EVENT(LogEvent::ROTOR_SPEED_BELOW_CRITICAL);
+    }
+#endif
+    _heliflags.rotor_runup_complete = new_value;
 }

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -233,6 +233,9 @@ protected:
     // update turbine start flag
     void update_turbine_start();
 
+    // Update _heliflags.rotor_runup_complete value writing log event on state change
+    void set_rotor_runup_complete(bool new_value);
+
     // enum values for HOVER_LEARN parameter
     enum HoverLearn {
         HOVER_LEARN_DISABLED = 0,

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -374,7 +374,8 @@ void AP_MotorsHeli_Dual::update_motor_control(AP_MotorsHeli_RSC::RotorControlSta
     }
 
     // Check if rotors are run-up
-    _heliflags.rotor_runup_complete = _main_rotor.is_runup_complete();
+    set_rotor_runup_complete(_main_rotor.is_runup_complete());
+
     // Check if rotors are spooled down
     _heliflags.rotor_spooldown_complete = _main_rotor.is_spooldown_complete();
 }

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -159,7 +159,8 @@ void AP_MotorsHeli_Quad::update_motor_control(AP_MotorsHeli_RSC::RotorControlSta
     }
 
     // Check if rotors are run-up
-    _heliflags.rotor_runup_complete = _main_rotor.is_runup_complete();
+    set_rotor_runup_complete(_main_rotor.is_runup_complete());
+
     // Check if rotors are spooled down
     _heliflags.rotor_spooldown_complete = _main_rotor.is_spooldown_complete();
 }

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -362,7 +362,7 @@ void AP_MotorsHeli_Single::update_motor_control(AP_MotorsHeli_RSC::RotorControlS
     }
 
     // Check if both rotors are run-up, tail rotor controller always returns true if not enabled
-    _heliflags.rotor_runup_complete = ( _main_rotor.is_runup_complete() && _tail_rotor.is_runup_complete() );
+    set_rotor_runup_complete(_main_rotor.is_runup_complete() && _tail_rotor.is_runup_complete());
 
     // Check if both rotors are spooled down, tail rotor controller always returns true if not enabled
     _heliflags.rotor_spooldown_complete = ( _main_rotor.is_spooldown_complete() );


### PR DESCRIPTION
This moves event logging of "runup complete" and "rotor speed below critical" events down to motors. This means we can remove some extra state from the copter level. 

Tested by running the auto test and checking we still get the events:

![image](https://github.com/ArduPilot/ardupilot/assets/33176108/91ffe552-c719-480d-84e0-4969dfbcef6d)


![image](https://github.com/ArduPilot/ardupilot/assets/33176108/84e02b2d-3f22-417a-aa34-52fd3432227f)
