### PR TITLE
AP_Motors: Heli: remove `output_armed_zero_throttle` and use identical `output_armed_stabilizing`

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -211,11 +211,7 @@ void AP_MotorsHeli::output()
         // block servo_test from happening at disarm
         _servo_test_cycle_counter = 0;
         calculate_armed_scalars();
-        if (!get_interlock()) {
-            output_armed_zero_throttle();
-        } else {
-            output_armed_stabilizing();
-        }
+        output_armed_stabilizing();
     } else {
         output_disarmed();
     }
@@ -228,17 +224,6 @@ void AP_MotorsHeli::output()
 
 // sends commands to the motors
 void AP_MotorsHeli::output_armed_stabilizing()
-{
-    // if manual override active after arming, deactivate it and reinitialize servos
-    if (_servo_mode != SERVO_CONTROL_MODE_AUTOMATED) {
-        reset_flight_controls();
-    }
-
-    move_actuators(_roll_in, _pitch_in, get_throttle(), _yaw_in);
-}
-
-// output_armed_zero_throttle - sends commands to the motors
-void AP_MotorsHeli::output_armed_zero_throttle()
 {
     // if manual override active after arming, deactivate it and reinitialize servos
     if (_servo_mode != SERVO_CONTROL_MODE_AUTOMATED) {

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -182,7 +182,6 @@ protected:
 
     // output - sends commands to the motors
     void output_armed_stabilizing() override;
-    void output_armed_zero_throttle();
     void output_disarmed();
 
     // external objects we depend upon


### PR DESCRIPTION
We don't need two copies of the same function, this removes `output_armed_zero_throttle`.

`output_armed_zero_throttle`:
https://github.com/ArduPilot/ardupilot/blob/079ffb4a400714689792e54babca6d45938bde1d/libraries/AP_Motors/AP_MotorsHeli.cpp#L241-L249

`output_armed_stabilizing`:
https://github.com/ArduPilot/ardupilot/blob/079ffb4a400714689792e54babca6d45938bde1d/libraries/AP_Motors/AP_MotorsHeli.cpp#L230-L238

