### PR TITLE
Enabled sending waypoints to ardupilot for copter and rover

### DIFF
--- a/ArduCopter/AP_ExternalControl_Copter.cpp
+++ b/ArduCopter/AP_ExternalControl_Copter.cpp
@@ -29,6 +29,15 @@ bool AP_ExternalControl_Copter::set_linear_velocity_and_yaw_rate(const Vector3f 
     return true;
 }
 
+bool AP_ExternalControl_Copter::set_global_position(const Location& loc)
+{
+    // Check if copter is ready for external control and returns false if it is not.
+    if (!ready_for_external_control()) {
+        return false;
+    }
+    return copter.set_target_location(loc);
+}
+
 bool AP_ExternalControl_Copter::ready_for_external_control()
 {
     return copter.flightmode->in_guided_mode() && copter.motors->armed();

--- a/ArduCopter/AP_ExternalControl_Copter.h
+++ b/ArduCopter/AP_ExternalControl_Copter.h
@@ -7,7 +7,8 @@
 
 #if AP_EXTERNAL_CONTROL_ENABLED
 
-class AP_ExternalControl_Copter : public AP_ExternalControl {
+class AP_ExternalControl_Copter : public AP_ExternalControl
+{
 public:
     /*
       Set linear velocity and yaw rate. Pass NaN for yaw_rate_rads to not control yaw.
@@ -15,6 +16,11 @@ public:
       Yaw is in earth frame, NED [rad/s].
      */
     bool set_linear_velocity_and_yaw_rate(const Vector3f &linear_velocity, float yaw_rate_rads) override WARN_IF_UNUSED;
+
+    /*
+      Sets the target global position for a loiter point.
+    */
+    bool set_global_position(const Location& loc) override WARN_IF_UNUSED;
 private:
     /*
       Return true if Copter is ready to handle external control data.

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -272,6 +272,22 @@ void Copter::get_scheduler_tasks(const AP_Scheduler::Task *&tasks,
 
 constexpr int8_t Copter::_failsafe_priorities[7];
 
+
+#if AP_SCRIPTING_ENABLED || AP_EXTERNAL_CONTROL_ENABLED
+#if MODE_GUIDED_ENABLED == ENABLED
+// set target location (for use by external control and scripting)
+bool Copter::set_target_location(const Location& target_loc)
+{
+    // exit if vehicle is not in Guided mode or Auto-Guided mode
+    if (!flightmode->in_guided_mode()) {
+        return false;
+    }
+
+    return mode_guided.set_destination(target_loc);
+}
+#endif //MODE_GUIDED_ENABLED == ENABLED
+#endif //AP_SCRIPTING_ENABLED || AP_EXTERNAL_CONTROL_ENABLED
+
 #if AP_SCRIPTING_ENABLED
 #if MODE_GUIDED_ENABLED == ENABLED
 // start takeoff to given altitude (for use by scripting)
@@ -287,17 +303,6 @@ bool Copter::start_takeoff(float alt)
         return true;
     }
     return false;
-}
-
-// set target location (for use by scripting)
-bool Copter::set_target_location(const Location& target_loc)
-{
-    // exit if vehicle is not in Guided mode or Auto-Guided mode
-    if (!flightmode->in_guided_mode()) {
-        return false;
-    }
-
-    return mode_guided.set_destination(target_loc);
 }
 
 // set target position (for use by scripting)

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -666,10 +666,15 @@ private:
     void get_scheduler_tasks(const AP_Scheduler::Task *&tasks,
                              uint8_t &task_count,
                              uint32_t &log_bit) override;
+#if AP_SCRIPTING_ENABLED || AP_EXTERNAL_CONTROL_ENABLED
+#if MODE_GUIDED_ENABLED == ENABLED
+    bool set_target_location(const Location& target_loc) override;
+#endif // MODE_GUIDED_ENABLED == ENABLED
+#endif // AP_SCRIPTING_ENABLED || AP_EXTERNAL_CONTROL_ENABLED
+
 #if AP_SCRIPTING_ENABLED
 #if MODE_GUIDED_ENABLED == ENABLED
     bool start_takeoff(float alt) override;
-    bool set_target_location(const Location& target_loc) override;
     bool set_target_pos_NED(const Vector3f& target_pos, bool use_yaw, float yaw_deg, bool use_yaw_rate, float yaw_rate_degs, bool yaw_relative, bool terrain_alt) override;
     bool set_target_posvel_NED(const Vector3f& target_pos, const Vector3f& target_vel) override;
     bool set_target_posvelaccel_NED(const Vector3f& target_pos, const Vector3f& target_vel, const Vector3f& target_accel, bool use_yaw, float yaw_deg, bool use_yaw_rate, float yaw_rate_degs, bool yaw_relative) override;

--- a/Rover/AP_ExternalControl_Rover.cpp
+++ b/Rover/AP_ExternalControl_Rover.cpp
@@ -29,6 +29,12 @@ bool AP_ExternalControl_Rover::set_linear_velocity_and_yaw_rate(const Vector3f &
     return true;
 }
 
+bool AP_ExternalControl_Rover::set_global_position(const Location& loc)
+{
+    // set_target_location only checks if the rover is in guided mode or not
+    return rover.set_target_location(loc);
+}
+
 bool AP_ExternalControl_Rover::ready_for_external_control()
 {
     return rover.control_mode->in_guided_mode() && rover.arming.is_armed();

--- a/Rover/AP_ExternalControl_Rover.h
+++ b/Rover/AP_ExternalControl_Rover.h
@@ -7,7 +7,8 @@
 
 #if AP_EXTERNAL_CONTROL_ENABLED
 
-class AP_ExternalControl_Rover : public AP_ExternalControl {
+class AP_ExternalControl_Rover : public AP_ExternalControl
+{
 public:
     /*
       Set linear velocity and yaw rate. Pass NaN for yaw_rate_rads to not control yaw.
@@ -15,6 +16,12 @@ public:
       Yaw is in earth frame, NED [rad/s].
      */
     bool set_linear_velocity_and_yaw_rate(const Vector3f &linear_velocity, float yaw_rate_rads)override WARN_IF_UNUSED;
+
+    /*
+      Sets the global position for loiter point
+    */
+    bool set_global_position(const Location& loc) override WARN_IF_UNUSED;
+
 private:
     /*
       Return true if Rover is ready to handle external control data.

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -157,8 +157,8 @@ Rover::Rover(void) :
 {
 }
 
-#if AP_SCRIPTING_ENABLED
-// set target location (for use by scripting)
+#if AP_SCRIPTING_ENABLED || AP_EXTERNAL_CONTROL_ENABLED
+// set target location (for use by external control and scripting)
 bool Rover::set_target_location(const Location& target_loc)
 {
     // exit if vehicle is not in Guided mode or Auto-Guided mode
@@ -168,7 +168,9 @@ bool Rover::set_target_location(const Location& target_loc)
 
     return mode_guided.set_desired_location(target_loc);
 }
+#endif //AP_SCRIPTING_ENABLED || AP_EXTERNAL_CONTROL_ENABLED
 
+#if AP_SCRIPTING_ENABLED
 // set target velocity (for use by scripting)
 bool Rover::set_target_velocity_NED(const Vector3f& vel_ned)
 {

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -269,8 +269,11 @@ private:
     cruise_learn_t cruise_learn;
 
     // Rover.cpp
-#if AP_SCRIPTING_ENABLED
+#if AP_SCRIPTING_ENABLED || AP_EXTERNAL_CONTROL_ENABLED
     bool set_target_location(const Location& target_loc) override;
+#endif
+
+#if AP_SCRIPTING_ENABLED
     bool set_target_velocity_NED(const Vector3f& vel_ned) override;
     bool set_steering_and_throttle(float steering, float throttle) override;
     bool get_steering_and_throttle(float& steering, float& throttle) override;

--- a/Tools/scripts/run_astyle.py
+++ b/Tools/scripts/run_astyle.py
@@ -26,8 +26,12 @@ class AStyleChecker(object):
         ]
         self.files_to_check = [
             pathlib.Path(s) for s in [
+                'ArduCopter/AP_ExternalControl_Copter.cpp',
+                'ArduCopter/AP_ExternalControl_Copter.h',
                 'libraries/AP_ExternalAHRS/AP_ExternalAHRS_MicroStrain7.cpp',
                 'libraries/AP_ExternalAHRS/AP_ExternalAHRS_MicroStrain7.h',
+                'Rover/AP_ExternalControl_Rover.cpp',
+                'Rover/AP_ExternalControl_Rover.h',
             ]
         ]
         self.dry_run = dry_run


### PR DESCRIPTION
### Way point support for Copter
This is to fix the issue #25381 

Implemented `set_global_location` for Rover and Copter ( taking inspiration from  ArduPlane)

### Demo

Taking everything from [this](https://github.com/ArduPilot/ardupilot/pull/25722#issue-2030071065) pull request

In ArduPilot repo:
```shell
./sim_vehicle.py -v ArduCopter --map --console --enable-dds
```

Running MicroROS agent:

```shell
cd ~/ros2_ws
. /opt/ros/humble/setup.bash
colcon build --packages-up-to ardupilot_sitl
. install/setup.bash
cd src/ardupilot/libraries/AP_DDS
ros2 run micro_ros_agent micro_ros_agent udp4 -p 2019 -r dds_xrce_profile.xml
``` 

Taking off the copter
```shell
mode guided
arm throttle
takeoff 50
```

Now publish a message for drone to go to greyhound track.
```shell
cd ~/ros2_ws
. /opt/ros/humble/setup.bash
colcon build --packages-up-to ardupilot_msgs
. install/setup.bash
ros2 topic pub /ap/cmd_gps_pose  ardupilot_msgs/msg/GlobalPosition "{header: {frame_id: map}, latitude: -35.345996, longitude: 149.159017, altitude: 40, coordinate_frame: 6}" --once
```
<img width="1440" alt="Screenshot 2024-03-03 at 7 32 13 PM" src="https://github.com/ArduPilot/ardupilot/assets/59084710/a5d5761f-a042-41a0-82a9-4595c40e3a99">

<img width="1440" alt="Screenshot 2024-03-03 at 7 35 34 PM" src="https://github.com/ArduPilot/ardupilot/assets/59084710/522e7fc5-3d04-4d76-99a8-d9c8b0dcacf9">

### Way point support for copter Rover
Follow all the steps as for copter above

### Demo Rover
Same as copter (plus altitude is ignored in ros message)
Result Screenshot (Rover going to the same location as copter)
<img width="1440" alt="Screenshot 2024-03-03 at 8 05 29 PM" src="https://github.com/ArduPilot/ardupilot/assets/59084710/8d804d04-2161-4322-8dd6-252d5761ac71">


