### PR TITLE
TECS: fixed tuning of speed without airspeed sensor

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -597,7 +597,8 @@ void Plane::update_alt()
                                                  get_takeoff_pitch_min_cd(),
                                                  throttle_nudge,
                                                  tecs_hgt_afe(),
-                                                 aerodynamic_load_factor);
+                                                 aerodynamic_load_factor,
+                                                 g.pitch_trim.get());
     }
 }
 

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -52,7 +52,8 @@ public:
                                int32_t ptchMinCO_cd,
                                int16_t throttle_nudge,
                                float hgt_afe,
-                               float load_factor);
+                               float load_factor,
+                               float pitch_trim_deg);
 
     // demanded throttle in percentage
     // should return -100 to 100, usually positive unless reverse thrust is enabled via _THRminf < 0
@@ -455,7 +456,7 @@ private:
     void _update_throttle_with_airspeed(void);
 
     // Update Demanded Throttle Non-Airspeed
-    void _update_throttle_without_airspeed(int16_t throttle_nudge);
+    void _update_throttle_without_airspeed(int16_t throttle_nudge, float pitch_trim_deg);
 
     // get integral gain which is flight_stage dependent
     float _get_i_gain(void);


### PR DESCRIPTION
the pitch trim variable that was not connected in aparm is needed to allow tuning of the flight speed using PTCH_TRIM_DEG and TRIM_THROTTLE.
    
This was broken in 4.4.x by this PR:
    
https://github.com/ArduPilot/ardupilot/pull/22191

Fixes https://github.com/ArduPilot/ardupilot/issues/26340

many thanks to @fredowski for reporting and @Hwurzburg for reproducing

