### PR TITLE
AP_TECS: fix PTCH_TRIM_DEG

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -924,7 +924,7 @@ void Plane::get_osd_roll_pitch_rad(float &roll, float &pitch) const
     pitch = ahrs.get_pitch();
     roll = ahrs.get_roll();
     if (!(flight_option_enabled(FlightOptions::OSD_REMOVE_TRIM_PITCH))) {  // correct for PTCH_TRIM_DEG
-        pitch -= g.pitch_trim * DEG_TO_RAD;
+        pitch -= aparm.pitch_trim * DEG_TO_RAD;
     }
 }
 

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -209,7 +209,7 @@ float Plane::stabilize_pitch_get_pitch_out()
     const bool quadplane_in_transition = false;
 #endif
 
-    int32_t demanded_pitch = nav_pitch_cd + int32_t(g.pitch_trim * 100.0) + SRV_Channels::get_output_scaled(SRV_Channel::k_throttle) * g.kff_throttle_to_pitch;
+    int32_t demanded_pitch = nav_pitch_cd + int32_t(aparm.pitch_trim * 100.0) + SRV_Channels::get_output_scaled(SRV_Channel::k_throttle) * g.kff_throttle_to_pitch;
     bool disable_integrator = false;
     if (control_mode == &mode_stabilize && channel_pitch->get_control_in() != 0) {
         disable_integrator = true;

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -134,7 +134,7 @@ void GCS_MAVLINK_Plane::send_attitude() const
     float y = ahrs.get_yaw();
 
     if (!(plane.flight_option_enabled(FlightOptions::GCS_REMOVE_TRIM_PITCH))) {
-        p -= radians(plane.g.pitch_trim);
+        p -= radians(plane.aparm.pitch_trim);
     }
 
 #if HAL_QUADPLANE_ENABLED

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -650,7 +650,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Units: deg
     // @Range: -45 45
     // @User: Standard
-    GSCALAR(pitch_trim,             "PTCH_TRIM_DEG",  0.0f),
+    ASCALAR(pitch_trim,             "PTCH_TRIM_DEG",  0.0f),
 
     // @Param: RTL_ALTITUDE
     // @DisplayName: RTL altitude
@@ -1497,7 +1497,7 @@ void Plane::load_parameters(void)
   
     // PARAMETER_CONVERSION - Added: Dec 2023
     // Convert _CM (centimeter) parameters to meters and _CD (centidegrees) parameters to meters
-    g.pitch_trim.convert_centi_parameter(AP_PARAM_INT16);
+    aparm.pitch_trim.convert_centi_parameter(AP_PARAM_INT16);
     aparm.airspeed_cruise.convert_centi_parameter(AP_PARAM_INT32);
     aparm.min_groundspeed.convert_centi_parameter(AP_PARAM_INT32);
     g.RTL_altitude.convert_centi_parameter(AP_PARAM_INT32);

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -436,7 +436,6 @@ public:
     AP_Int16 dspoiler_rud_rate;
     AP_Int32 log_bitmask;
     AP_Float RTL_altitude;
-    AP_Float pitch_trim;
     AP_Float cruise_alt_floor;
 
     AP_Int8 flap_1_percent;

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -873,7 +873,7 @@ void AP_TECS::_update_throttle_without_airspeed(int16_t throttle_nudge)
     _pitch_demand_lpf.apply(_pitch_dem, _DT);
     const float pitch_demand_hpf = _pitch_dem - _pitch_demand_lpf.get();
     _pitch_measured_lpf.apply(_ahrs.get_pitch(), _DT);
-    const float pitch_corrected_lpf = _pitch_measured_lpf.get();
+    const float pitch_corrected_lpf = _pitch_measured_lpf.get() - radians(aparm.pitch_trim);;
     const float pitch_blended = pitch_demand_hpf + pitch_corrected_lpf;
 
     if (pitch_blended > 0.0f && _PITCHmaxf > 0.0f)

--- a/libraries/AP_Vehicle/AP_FixedWing.h
+++ b/libraries/AP_Vehicle/AP_FixedWing.h
@@ -24,6 +24,7 @@ struct AP_FixedWing {
     AP_Int8  stall_prevention;
     AP_Int16 loiter_radius;
     AP_Float takeoff_throttle_max_t;
+    AP_Float pitch_trim;
 
     struct Rangefinder_State {
         bool in_range:1;


### PR DESCRIPTION
The commits

AP_Vehicle: Add pitch_trim_cd to fixed wing shared parameters
AP_TECS: Implement improved control loops

introduced a new control scheme for TECS in 2022. The pitch trim parameter is located in the global parameter block and not in the fw parameter block and so the implementation results in pitch_trim always 0. The previous control scheme handled TRIM_PITCH_CD indirectly as the throttle output used _pitch_dem which is affected by pitch_trim as pitch_trim is added after TECS in the pitch stabilizer. The integrators in TECS will adapt to this permanent offset and adapt the TECS pitch demand output. With new control scheme from the  above commit only a highpassed _pitch_dem is used for throttle which will "forget" the pitch_trim for the throttle. With this commit the pitch_trim is added directly.