### PR TITLE
AP_ExternalAHRS: missing check for HAL_LOGGING_ENABLED in common logging

### DIFF
--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS.cpp
@@ -301,6 +301,7 @@ void AP_ExternalAHRS::update(void)
             state.have_origin = true;
         }
     }
+#if HAL_LOGGING_ENABLED
     const uint32_t now_ms = AP_HAL::millis();
     if (log_rate.get() > 0 && now_ms - last_log_ms >= uint32_t(1000U/log_rate.get())) {
         last_log_ms = now_ms;
@@ -334,6 +335,7 @@ void AP_ExternalAHRS::update(void)
                                     state.location.lat, state.location.lng, state.location.alt*0.01,
                                     filterStatus.value);
     }
+#endif  // HAL_LOGGING_ENABLED
 }
 
 // Get model/type name


### PR DESCRIPTION
 Building copter for Pixhawk6C with ``#define HAL_LOGGING_ENABLED 0`` gives error:
``` [ 264/1240] Compiling libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
../../libraries/AP_ExternalAHRS/AP_ExternalAHRS.cpp: In member function 'void AP_ExternalAHRS::update()':
../../libraries/AP_ExternalAHRS/AP_ExternalAHRS.cpp:327:13: error: 'logger' is not a member of 'AP'

327 |         AP::logger().WriteStreaming("EAHR", "TimeUS,Roll,Pitch,Yaw,VN,VE,VD,Lat,Lon,Alt,Flg",
      |             ^~~~~~
compilation terminated due to -Wfatal-errors.
```
Builds fine with ``HAL_LOGGING_ENABLED 1``.
 
This is arises due to missing ``#if HAL_LOGGING_ENABLED``  in recent pushed changes (#26329)