### PR TITLE
GCS_MAVLink: dont send timesync or on active channels for high latency links

### DIFF
--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -99,6 +99,11 @@ void GCS::send_to_active_channels(uint32_t msgid, const char *pkt)
         if (!c.is_active()) {
             continue;
         }
+#if HAL_HIGH_LATENCY2_ENABLED
+        if (c.is_high_latency_link) {
+            continue;
+        }
+#endif
         // size checks done by this method:
         c.send_message(pkt, entry);
     }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1851,7 +1851,11 @@ GCS_MAVLINK::update_receive(uint32_t max_time_us)
 
     // send a timesync message every 10 seconds; this is for data
     // collection purposes
+#if HAL_HIGH_LATENCY2_ENABLED
+    if (tnow - _timesync_request.last_sent_ms > _timesync_request.interval_ms && !is_private() && !is_high_latency_link) {
+#else
     if (tnow - _timesync_request.last_sent_ms > _timesync_request.interval_ms && !is_private()) {
+#endif
         if (HAVE_PAYLOAD_SPACE(chan, TIMESYNC)) {
             send_timesync();
             _timesync_request.last_sent_ms = tnow;


### PR DESCRIPTION
Currently, the ``TIMESYNC`` and ``NAMED_VALUE_FLOAT`` MAVLink messages are sent over High Latency MAVLink ports. They should not be sent.

This PR prevents them from being sent.

Note I'm using the ``send_to_active_channels()`` function in ``libraries/GCS_MAVLink/GCS.cpp`` to filter out the ``NAMED_VALUE_FLOAT`` messages, as ``send_named_float()`` doesn't allow me to select which channels to send/not send.