### PR TITLE
EKF: Match handling of MAV_CMD_EXTERNAL_POSITION_ESTIMATE to common MAVLink dialect

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -145,8 +145,8 @@ void NavEKF3_core::ResetPosition(resetDataSource posResetSource)
 }
 
 #if EK3_FEATURE_POSITION_RESET
-// Sets the EKF's NE horizontal position states and their corresponding variances from a supplied WGS-84 location and uncertainty
-// The altitude element of the location is not used.
+// Sets the EKF's NE horizontal position states and their corresponding variances from a supplied WGS-84 location and optionally uncertainty
+// The altitude element of the location is not used. If accuracy is not known should be passed as NaN.
 // Returns true if the set was successful
 bool NavEKF3_core::setLatLng(const Location &loc, float posAccuracy, uint32_t timestamp_ms)
 {
@@ -163,6 +163,11 @@ bool NavEKF3_core::setLatLng(const Location &loc, float posAccuracy, uint32_t ti
     // reset the corresponding covariances
     zeroRows(P,7,8);
     zeroCols(P,7,8);
+
+    // handle unknown accuracy
+    if (isnan(posAccuracy)) {
+        posAccuracy = 0.0f; // will be ignored due to MAX below
+    }
 
     // set the variances using the position measurement noise parameter
     P[7][7] = P[8][8] = sq(MAX(posAccuracy,frontend->_gpsHorizPosNoise));

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -5069,7 +5069,7 @@ MAV_RESULT GCS_MAVLINK::handle_command_do_set_home(const mavlink_command_int_t &
 #if AP_AHRS_POSITION_RESET_ENABLED
 MAV_RESULT GCS_MAVLINK::handle_command_int_external_position_estimate(const mavlink_command_int_t &packet)
 {
-    if (packet.frame != MAV_FRAME_GLOBAL ||
+    if ((packet.frame != MAV_FRAME_GLOBAL && packet.frame != MAV_FRAME_GLOBAL_INT) ||
         !isnan(packet.z)) {
         // we only support global frame without altitude
         return MAV_RESULT_DENIED;


### PR DESCRIPTION
This is a minor follow up to #23903. The feature works great, thanks a lot! I ran into some minor surprises when implementing support for it in our GCS. I initially wrote the code based on the [MAVLink docs for MAV_CMD_EXTERNAL_POSITION_ESTIMATE](https://mavlink.io/en/messages/common.html#MAV_CMD_EXTERNAL_POSITION_ESTIMATE), and found that frame and accuracy weren't handled as I expected.

Accuracy is explicitly advised to be set to NaN if unknown:
> estimated one standard deviation accuracy of the measurement. Set to NaN if not known. [source](https://github.com/mavlink/mavlink/blob/bcdbeb7f07906490fbc945fb5e2db29bad1196d7/message_definitions/v1.0/common.xml#L2489)

But I found that it was stopping the whole autopilot when I tried that in SITL (`Connection reset or closed by peer on TCP socket`)

---

I assume that [MAV_FRAME](https://mavlink.io/en/messages/common.html#MAV_FRAME) sent in COMMAND_INT should behave the same way for [MAV_FRAME_GLOBAL](https://mavlink.io/en/messages/common.html#MAV_FRAME_GLOBAL) and [MAV_FRAME_GLOBAL_INT](https://mavlink.io/en/messages/common.html#MAV_FRAME_GLOBAL_INT) ([a search of the repo](https://github.com/search?q=repo%3AArduPilot%2Fardupilot%20MAV_FRAME_GLOBAL_INT&type=code) shows them together), but only the first one was accepted in the check.

*(Contribution on behalf of @FlyfocusUAV)*