### PR TITLE
Added board IDs for Eagle Eye Drones

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -302,6 +302,8 @@ AP_HW_Sierra-F1-Pro                  5309
 
 # IDs 6000-6099 reserved for SpektreWorks
 
+# IDs 6600-6699 reserved for Eagle Eye Drones
+
 # OpenDroneID enabled boards. Use 10000 + the base board ID
 AP_HW_CubeOrange_ODID               10140
 AP_HW_Pixhawk6_ODID                 10053


### PR DESCRIPTION
Added board ID reservations between 6600 and 6699 for EagleEye Drones.