### PR TITLE
GCS_MAVLink: Routing: forward ADSB if local ADSB parsing if disabled

### DIFF
--- a/libraries/GCS_MAVLink/MAVLink_routing.cpp
+++ b/libraries/GCS_MAVLink/MAVLink_routing.cpp
@@ -26,6 +26,8 @@
 #include "GCS.h"
 #include "MAVLink_routing.h"
 
+#include <AP_ADSB/AP_ADSB.h>
+
 extern const AP_HAL::HAL& hal;
 
 #define ROUTING_DEBUG 0
@@ -130,10 +132,15 @@ bool MAVLink_routing::check_and_forward(GCS_MAVLINK &in_link, const mavlink_mess
         return true;
     }
 
+#if HAL_ADSB_ENABLED
     if (msg.msgid == MAVLINK_MSG_ID_ADSB_VEHICLE) {
-        // ADSB packets are not forwarded, they have their own stream rate
-        return true;
+        // if enabled ADSB packets are not forwarded, they have their own stream rate
+        const AP_ADSB *adsb = AP::ADSB();
+        if ((adsb != nullptr) && (adsb->enabled())) {
+            return true;
+        }
     }
+#endif
 
     // extract the targets for this packet
     int16_t target_system = -1;


### PR DESCRIPTION
This should mean that tracker will forward on ADSB packets from the vehicle to the GCS. 