### PR TITLE
MissionItemProtocol_Rally: Use *_INT frames for Rally mission items

### DIFF
--- a/libraries/GCS_MAVLink/MissionItemProtocol_Rally.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol_Rally.cpp
@@ -117,16 +117,16 @@ bool MissionItemProtocol_Rally::get_item_as_mission_item(uint16_t seq,
     }
 
     // Default to relative to home
-    ret_packet.frame = MAV_FRAME_GLOBAL_RELATIVE_ALT;
+    ret_packet.frame = MAV_FRAME_GLOBAL_RELATIVE_ALT_INT;
 
     if (rallypoint.alt_frame_valid == 1) {
         switch (Location::AltFrame(rallypoint.alt_frame)) {
             case Location::AltFrame::ABSOLUTE:
-                ret_packet.frame = MAV_FRAME_GLOBAL;
+                ret_packet.frame = MAV_FRAME_GLOBAL_INT;
                 break;
 
             case Location::AltFrame::ABOVE_HOME:
-                ret_packet.frame = MAV_FRAME_GLOBAL_RELATIVE_ALT;
+                ret_packet.frame = MAV_FRAME_GLOBAL_RELATIVE_ALT_INT;
                 break;
 
             case Location::AltFrame::ABOVE_ORIGIN:
@@ -134,7 +134,7 @@ bool MissionItemProtocol_Rally::get_item_as_mission_item(uint16_t seq,
                 return false;
 
             case Location::AltFrame::ABOVE_TERRAIN:
-                ret_packet.frame = MAV_FRAME_GLOBAL_TERRAIN_ALT;
+                ret_packet.frame = MAV_FRAME_GLOBAL_TERRAIN_ALT_INT;
                 break;
         }
     }


### PR DESCRIPTION
`get_item_as_mission_item()` returns a `mavlink_mission_item_int_t` and as such should be using the `*_INT` versions of the [`MAV_FRAME`](https://mavlink.io/en/messages/common.html#MAV_FRAME)s.

Follows from changes in #25380.

FYI: @IamPete1 