### PR TITLE
AP_DDS: add missing config include in client and type_conversions

### DIFF
--- a/libraries/AP_DDS/AP_DDS_Client.h
+++ b/libraries/AP_DDS/AP_DDS_Client.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "AP_DDS_config.h"
+
 #if AP_DDS_ENABLED
 
 #include "uxr/client/client.h"
@@ -26,7 +28,6 @@
 #include "fcntl.h"
 
 #include <AP_Param/AP_Param.h>
-#include "AP_DDS_config.h"
 
 #define DDS_MTU             512
 #define DDS_STREAM_HISTORY  8

--- a/libraries/AP_DDS/AP_DDS_Type_Conversions.h
+++ b/libraries/AP_DDS/AP_DDS_Type_Conversions.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include "AP_DDS_config.h"
+
 #if AP_DDS_ENABLED
 
 #include "builtin_interfaces/msg/Time.h"


### PR DESCRIPTION
Follow up to https://github.com/ArduPilot/ardupilot/pull/26342