### PR TITLE
fix logging feature extract

### DIFF
--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -243,7 +243,7 @@ class ExtractFeatures(object):
             ('AP_NETWORKING_BACKEND_PPP', 'AP_Networking_PPP::init'),
             ('FORCE_APJ_DEFAULT_PARAMETERS', 'AP_Param::param_defaults_data'),
             ('HAL_BUTTON_ENABLED', 'AP_Button::update'),
-            ('HAL_LOGGING_ENABLED', 'AP_Logger::Init'),
+            ('HAL_LOGGING_ENABLED', 'AP_Logger::init'),
             ('AP_COMPASS_CALIBRATION_FIXED_YAW_ENABLED', 'AP_Compass::mag_cal_fixed_yaw'),
             ('COMPASS_LEARN_ENABLED', 'CompassLearn::update'),
             ('AP_CUSTOMROTATIONS_ENABLED', 'AP_CustomRotation::init'),


### PR DESCRIPTION
currently custom builds have no logging enabled by default....this should correct that, as well as correcting the feature lists for ALLthe boards which currently show no logging is included .....tested on omnibusf4pro build...logging now in included features list