### PR TITLE
Plane: support precision QLOITER in quadplanes

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -869,8 +869,8 @@ bool Plane::update_target_location(const Location &old_loc, const Location &new_
     next_WP_loc = new_loc;
 
 #if HAL_QUADPLANE_ENABLED
-    if (control_mode == &mode_qland) {
-        mode_qland.last_target_loc_set_ms = AP_HAL::millis();
+    if (control_mode == &mode_qland || control_mode == &mode_qloiter) {
+        mode_qloiter.last_target_loc_set_ms = AP_HAL::millis();
     }
 #endif
 
@@ -966,8 +966,7 @@ bool Plane::flight_option_enabled(FlightOptions flight_option) const
 void Plane::precland_update(void)
 {
     // alt will be unused if we pass false through as the second parameter:
-    return g2.precland.update(rangefinder_state.height_estimate*100,
-                              rangefinder_state.in_range && rangefinder_state.in_use);
+    return g2.precland.update(rangefinder_state.height_estimate*100, rangefinder_state.in_range);
 }
 #endif
 

--- a/ArduPlane/RC_Channel.cpp
+++ b/ArduPlane/RC_Channel.cpp
@@ -177,6 +177,7 @@ void RC_Channel_Plane::init_aux_function(const RC_Channel::AUX_FUNC ch_option,
     case AUX_FUNC::EMERGENCY_LANDING_EN:
     case AUX_FUNC::FW_AUTOTUNE:
     case AUX_FUNC::VFWD_THR_OVERRIDE:
+    case AUX_FUNC::PRECISION_LOITER:
         break;
 
     case AUX_FUNC::SOARING:
@@ -441,6 +442,10 @@ bool RC_Channel_Plane::do_aux_function(const AUX_FUNC ch_option, const AuxSwitch
         } else {
            plane.autotune_enable(false); 
         }
+        break;
+
+    case AUX_FUNC::PRECISION_LOITER:
+        // handled by lua scripting, just ignore here
         break;
 
     default:

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -647,6 +647,8 @@ class ModeQLoiter : public Mode
 {
 friend class QuadPlane;
 friend class ModeQLand;
+friend class Plane;
+
 public:
 
     Number mode_number() const override { return Number::QLOITER; }
@@ -664,13 +666,12 @@ public:
 protected:
 
     bool _enter() override;
+    uint32_t last_target_loc_set_ms;
 };
 
 class ModeQLand : public Mode
 {
 public:
-    friend class Plane;
-
     Number mode_number() const override { return Number::QLAND; }
     const char *name() const override { return "QLAND"; }
     const char *name4() const override { return "QLND"; }
@@ -686,8 +687,6 @@ protected:
 
     bool _enter() override;
     bool _pre_arm_checks(size_t buflen, char *buffer) const override { return false; }
-
-    uint32_t last_target_loc_set_ms;
 };
 
 class ModeQRTL : public Mode

--- a/ArduPlane/mode_qland.cpp
+++ b/ArduPlane/mode_qland.cpp
@@ -20,9 +20,6 @@ bool ModeQLand::_enter()
     plane.fence.auto_disable_fence_for_landing();
 #endif
 
-    // clear precland timestamp
-    last_target_loc_set_ms = 0;
-
     return true;
 }
 
@@ -33,30 +30,6 @@ void ModeQLand::update()
 
 void ModeQLand::run()
 {
-    /*
-      see if precision landing is active with an override of the
-      target location
-     */
-    const uint32_t last_pos_set_ms = last_target_loc_set_ms;
-    const uint32_t last_vel_set_ms = quadplane.poscontrol.last_velocity_match_ms;
-    const uint32_t now_ms = AP_HAL::millis();
-
-    if (last_pos_set_ms != 0 && now_ms - last_pos_set_ms < 500) {
-        // we have an active landing target override
-        Vector2f rel_origin;
-        if (plane.next_WP_loc.get_vector_xy_from_origin_NE(rel_origin)) {
-            quadplane.pos_control->set_pos_target_xy_cm(rel_origin.x, rel_origin.y);
-        }
-    }
-
-    // allow for velocity override as well
-    if (last_vel_set_ms != 0 && now_ms - last_vel_set_ms < 500) {
-        // we have an active landing velocity override
-        Vector2f target_accel;
-        Vector2f target_speed_xy_cms{quadplane.poscontrol.velocity_match.x*100, quadplane.poscontrol.velocity_match.y*100};
-        quadplane.pos_control->input_vel_accel_xy(target_speed_xy_cms, target_accel);
-    }
-
     /*
       use QLOITER to do the main control
      */

--- a/libraries/AP_Scripting/applets/plane_precland.md
+++ b/libraries/AP_Scripting/applets/plane_precland.md
@@ -1,8 +1,10 @@
 # Plane Precision Landing
 
 This script implements a precision landing system for VTOL fixed wing
-aircraft (quadplanes). It is a simple script which is intended to be
-modified by vendors for their specific aircraft.
+aircraft (quadplanes).
+
+Precision positioning over a landing sensor is supported in QLOITER,
+QLAND, QRTL and AUTO landing.
 
 # Parameters
 
@@ -47,3 +49,11 @@ may malfunction.
 If the PLND_OPTIONS bit for a moving target is enabled then the
 vehicle will be set to track the estimated target velocity during
 descent
+
+## Precision QLoiter
+
+To enable precision position hold in QLOITER you will need to use
+auxiliary function 39 (PRECISION_LOITER) on an R/C switch or via GCS
+auxiliary switch buttons. When enabled the vehicle will position
+itself above the landing target. Height control is under user control.
+

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -1001,7 +1001,7 @@ void Aircraft::update_external_payload(const struct sitl_input &input)
     }
 
     if (precland && precland->is_enabled()) {
-        precland->update(get_location(), get_position_relhome());
+        precland->update(get_location());
         if (precland->_over_precland_base) {
             local_ground_level += precland->_device_height;
         }

--- a/libraries/SITL/SIM_Precland.h
+++ b/libraries/SITL/SIM_Precland.h
@@ -28,7 +28,7 @@ public:
     };
 
     // update precland state
-    void update(const Location &loc, const Vector3d &position);
+    void update(const Location &loc);
 
     // true if precland sensor is online and healthy
     bool healthy() const { return _healthy; }
@@ -56,7 +56,9 @@ public:
     AP_Float _alt_limit;
     AP_Float _dist_limit;
     AP_Int8 _orient;
+    AP_Int8 _ship;
     AP_Enum<Option> _options;
+
     bool _over_precland_base;
 
     enum PreclandType {

--- a/libraries/SITL/SIM_Ship.cpp
+++ b/libraries/SITL/SIM_Ship.cpp
@@ -76,16 +76,28 @@ ShipSim::ShipSim()
 }
 
 /*
+  get the location of the ship
+ */
+bool ShipSim::get_location(Location &loc) const
+{
+    if (!enable) {
+        return false;
+    }
+    loc = home;
+    loc.offset(ship.position.x, ship.position.y);
+    return true;
+}
+
+/*
   get ground speed adjustment if we are landed on the ship
  */
 Vector2f ShipSim::get_ground_speed_adjustment(const Location &loc, float &yaw_rate)
 {
-    if (!enable) {
+    Location shiploc;
+    if (!get_location(shiploc)) {
         yaw_rate = 0;
         return Vector2f(0,0);
     }
-    Location shiploc = home;
-    shiploc.offset(ship.position.x, ship.position.y);
     if (loc.get_distance(shiploc) > deck_size) {
         yaw_rate = 0;
         return Vector2f(0,0);
@@ -192,8 +204,10 @@ void ShipSim::send_report(void)
     /*
       send a GLOBAL_POSITION_INT messages
      */
-    Location loc = home;
-    loc.offset(ship.position.x, ship.position.y);
+    Location loc;
+    if (!get_location(loc)) {
+        return;
+    }
 
     int32_t alt_mm = home.alt * 10;  // assume home altitude
 

--- a/libraries/SITL/SIM_Ship.h
+++ b/libraries/SITL/SIM_Ship.h
@@ -61,6 +61,8 @@ public:
      */
     Vector2f get_ground_speed_adjustment(const Location &loc, float &yaw_rate);
 
+    bool get_location(Location &loc) const;
+
 private:
 
     AP_Int8 enable;


### PR DESCRIPTION
This extends the plane_precland.lua script to support precision loiter, enabled with the same AUX function as for copter (value 39)
