### PR TITLE
SITL: SIM_Morse: correct compilation with HAL_GCS_ENABLED false

### DIFF
--- a/libraries/SITL/SIM_Morse.cpp
+++ b/libraries/SITL/SIM_Morse.cpp
@@ -566,7 +566,9 @@ void Morse::update(const struct sitl_input &input)
 
     report_FPS();
 
+#if HAL_GCS_ENABLED
     send_report();
+#endif
 }
 
 
@@ -591,6 +593,7 @@ void Morse::report_FPS(void)
 
 
 
+#if HAL_GCS_ENABLED
 /*
   send a report to the vehicle control code over MAVLink
 */
@@ -669,5 +672,6 @@ void Morse::send_report(void)
     }
 
 }
+#endif  // HAL_GCS_ENABLED
 
 #endif  // HAL_SIM_MORSE_ENABLED


### PR DESCRIPTION
arising from AP_GenericVehicle
