### PR TITLE
AP_HAL_SITL: correct define around use of RC singleton

### DIFF
--- a/libraries/AP_HAL_SITL/Scheduler.cpp
+++ b/libraries/AP_HAL_SITL/Scheduler.cpp
@@ -290,7 +290,7 @@ void Scheduler::_run_io_procs()
     check_thread_stacks();
 #endif
 
-#ifndef HAL_BUILD_AP_PERIPH
+#if AP_RCPROTOCOL_ENABLED
     AP::RC().update();
 #endif
 }


### PR DESCRIPTION
... you may not be a periphs and *still* not have RC...


... 'though I'm actually not sure what this call is really doing here in the first place.  Needed a comment....
