### PR TITLE
GCS_MAVLink: send set_position_target_global_int with non _INT frame

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -5678,7 +5678,7 @@ void GCS_MAVLINK::send_set_position_target_global_int(uint8_t target_system, uin
             AP_HAL::millis(),
             target_system,
             target_component,
-            MAV_FRAME_GLOBAL_RELATIVE_ALT_INT,
+            MAV_FRAME_GLOBAL_RELATIVE_ALT,
             type_mask,
             loc.lat,
             loc.lng,


### PR DESCRIPTION
deprecating and hopefully removing the _INT frames.

This method is only called by Rover, so thankfully the altitude is not that important...