### PR TITLE
AP_Generator: IE 2400: MAV_SEVERITY level depends on error code

### DIFF
--- a/libraries/AP_Generator/AP_Generator_IE_2400.cpp
+++ b/libraries/AP_Generator/AP_Generator_IE_2400.cpp
@@ -562,4 +562,18 @@ void AP_Generator_IE_2400::update_state_msg()
     }
 }
 
+#if HAL_GCS_ENABLED
+// Get the MAV_SEVERITY level of a given error code
+MAV_SEVERITY AP_Generator_IE_2400::get_mav_severity(uint32_t err_code) const
+{
+    if (err_code <= 9) {
+        return MAV_SEVERITY_INFO;
+    }
+    if (err_code <= 20) {
+        return MAV_SEVERITY_WARNING;
+    }
+    return MAV_SEVERITY_CRITICAL;
+}
+#endif // HAL_GCS_ENABLED
+
 #endif  // AP_GENERATOR_IE_2400_ENABLED

--- a/libraries/AP_Generator/AP_Generator_IE_2400.h
+++ b/libraries/AP_Generator/AP_Generator_IE_2400.h
@@ -39,6 +39,11 @@ private:
     // Check if we have received an warning code and populate message with warning code
     bool check_for_warning_code(char* msg_txt, uint8_t msg_len) const override;
 
+#if HAL_GCS_ENABLED
+    // Get the MAV_SEVERITY level of a given error code
+    MAV_SEVERITY get_mav_severity(uint32_t err_code) const override;
+#endif
+
     // Check for error codes that are deemed critical
     bool is_critical_error(const uint32_t err_in) const;
 

--- a/libraries/AP_Generator/AP_Generator_IE_FuelCell.cpp
+++ b/libraries/AP_Generator/AP_Generator_IE_FuelCell.cpp
@@ -179,14 +179,16 @@ void AP_Generator_IE_FuelCell::check_for_err_code_if_changed()
         return;
     }
 
+#if HAL_GCS_ENABLED
     char msg_txt[64];
     if (check_for_err_code(msg_txt, sizeof(msg_txt)) || check_for_warning_code(msg_txt, sizeof(msg_txt))) {
-        GCS_SEND_TEXT(MAV_SEVERITY_ALERT, "%s", msg_txt);
+        GCS_SEND_TEXT(get_mav_severity(_err_code), "%s", msg_txt);
 
     } else if ((_err_code == 0) && (_sub_err_code == 0)) {
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Fuel cell error cleared");
 
     }
+#endif
 
     _last_err_code = _err_code;
     _last_sub_err_code = _sub_err_code;

--- a/libraries/AP_Generator/AP_Generator_IE_FuelCell.h
+++ b/libraries/AP_Generator/AP_Generator_IE_FuelCell.h
@@ -5,6 +5,7 @@
 #if AP_GENERATOR_IE_ENABLED
 
 #include <AP_Logger/AP_Logger_config.h>
+#include <GCS_MAVLink/GCS.h>
 
 class AP_Generator_IE_FuelCell : public AP_Generator_Backend
 {
@@ -116,6 +117,11 @@ protected:
 
     // Print msg to user updating on state change
     virtual void update_state_msg();
+
+#if HAL_GCS_ENABLED
+    // Get the MAV_SEVERITY level of a given error code
+    virtual MAV_SEVERITY get_mav_severity(uint32_t err_code) const { return MAV_SEVERITY_ALERT; }
+#endif
 
 };
 #endif  // AP_GENERATOR_IE_ENABLED


### PR DESCRIPTION
This adds variable severity levels to the IE 2400 fuel cell generator driver based on the error code. 