### PR TITLE
GCS_MAVLink: ftp receiving messages where size takes into account terminating null

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -1042,6 +1042,7 @@ private:
     static struct ftp_state ftp;
 
     static void ftp_error(struct pending_ftp &response, FTP_ERROR error); // FTP helper method for packing a NAK
+    static bool ftp_check_name_len(const struct pending_ftp &request);
     static int gen_dir_entry(char *dest, size_t space, const char * path, const struct dirent * entry); // FTP helper for emitting a dir response
     static void ftp_list_dir(struct pending_ftp &request, struct pending_ftp &response);
 

--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -262,7 +262,9 @@ void GCS_MAVLINK::ftp_worker(void) {
 
                         // sanity check that our the request looks well formed
                         const size_t file_name_len = strnlen((char *)request.data, sizeof(request.data));
-                        if ((file_name_len != request.size) || (request.size == 0)) {
+                        const bool is_req_size_consider_tnull = ((request.size - file_name_len == 1) &&
+                                                                 request.data[sizeof(request.data) - 1] == 0);
+                        if (((file_name_len != request.size) && !is_req_size_consider_tnull) || (request.size == 0)) {
                             ftp_error(reply, FTP_ERROR::InvalidDataSize);
                             break;
                         }
@@ -348,7 +350,9 @@ void GCS_MAVLINK::ftp_worker(void) {
 
                         // sanity check that our the request looks well formed
                         const size_t file_name_len = strnlen((char *)request.data, sizeof(request.data));
-                        if ((file_name_len != request.size) || (request.size == 0)) {
+                        const bool is_req_size_consider_tnull = ((request.size - file_name_len == 1) &&
+                                                                 request.data[sizeof(request.data) - 1] == 0);
+                        if (((file_name_len != request.size) && !is_req_size_consider_tnull) || (request.size == 0)) {
                             ftp_error(reply, FTP_ERROR::InvalidDataSize);
                             break;
                         }
@@ -403,7 +407,9 @@ void GCS_MAVLINK::ftp_worker(void) {
                     {
                         // sanity check that our the request looks well formed
                         const size_t file_name_len = strnlen((char *)request.data, sizeof(request.data));
-                        if ((file_name_len != request.size) || (request.size == 0)) {
+                        const bool is_req_size_consider_tnull = ((request.size - file_name_len == 1) &&
+                                                                 request.data[sizeof(request.data) - 1] == 0);
+                        if (((file_name_len != request.size) && !is_req_size_consider_tnull) || (request.size == 0)) {
                             ftp_error(reply, FTP_ERROR::InvalidDataSize);
                             break;
                         }
@@ -424,7 +430,9 @@ void GCS_MAVLINK::ftp_worker(void) {
                     {
                         // sanity check that our the request looks well formed
                         const size_t file_name_len = strnlen((char *)request.data, sizeof(request.data));
-                        if ((file_name_len != request.size) || (request.size == 0)) {
+                        const bool is_req_size_consider_tnull = ((request.size - file_name_len == 1) &&
+                                                                 request.data[sizeof(request.data) - 1] == 0);
+                        if (((file_name_len != request.size) && !is_req_size_consider_tnull) || (request.size == 0)) {
                             ftp_error(reply, FTP_ERROR::InvalidDataSize);
                             break;
                         }
@@ -444,7 +452,9 @@ void GCS_MAVLINK::ftp_worker(void) {
                     {
                         // sanity check that our the request looks well formed
                         const size_t file_name_len = strnlen((char *)request.data, sizeof(request.data));
-                        if ((file_name_len != request.size) || (request.size == 0)) {
+                        const bool is_req_size_consider_tnull = ((request.size - file_name_len == 1) &&
+                                                                 request.data[sizeof(request.data) - 1] == 0);
+                        if (((file_name_len != request.size) && !is_req_size_consider_tnull) || (request.size == 0)) {
                             ftp_error(reply, FTP_ERROR::InvalidDataSize);
                             break;
                         }
@@ -555,7 +565,9 @@ void GCS_MAVLINK::ftp_worker(void) {
                     const size_t len1 = strnlen(filename1, sizeof(request.data)-2);
                     const char *filename2 = (char*)&request.data[len1+1];
                     const size_t len2 = strnlen(filename2, sizeof(request.data)-(len1+1));
-                    if (filename1[len1] != 0 || (len1+len2+1 != request.size) || (request.size == 0)) {
+                    const bool is_req_size_consider_tnull = (request.size - (len1+len2) == 2 &&
+                                                             request.data[sizeof(request.data) - 1] == 0);
+                    if (filename1[len1] != 0 || ((len1+len2+1 != request.size) && !is_req_size_consider_tnull) || (request.size == 0)) {
                         ftp_error(reply, FTP_ERROR::InvalidDataSize);
                         break;
                     }
@@ -636,8 +648,10 @@ void GCS_MAVLINK::ftp_list_dir(struct pending_ftp &request, struct pending_ftp &
     response.offset = request.offset; // this should be set for any failure condition for debugging
 
     const size_t directory_name_size = strnlen((char *)request.data, sizeof(request.data));
+    const bool is_req_size_consider_tnull = ((request.size - directory_name_size == 1) &&
+                                             request.data[sizeof(request.data) - 1] == 0);
     // sanity check that our the request looks well formed
-    if ((directory_name_size != request.size) || (request.size == 0)) {
+    if (((directory_name_size != request.size) && !is_req_size_consider_tnull) || (request.size == 0)) {
         ftp_error(response, FTP_ERROR::InvalidDataSize);
         return;
     }

--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -120,6 +120,17 @@ bool GCS_MAVLINK::send_ftp_reply(const pending_ftp &reply)
     return true;
 }
 
+bool GCS_MAVLINK::ftp_check_name_len(const struct pending_ftp &request) {
+    const size_t file_name_len = strnlen((char *)request.data, sizeof(request.data));
+    if (request.size == 0) {
+        return false;
+    }
+    if (file_name_len == request.size) {
+        return true;
+    }
+    return (request.size - file_name_len == 1) && (request.data[sizeof(request.data) - 1] == 0);
+}
+
 void GCS_MAVLINK::ftp_error(struct pending_ftp &response, FTP_ERROR error) {
     response.opcode = FTP_OP::Nack;
     response.data[0] = static_cast<uint8_t>(error);
@@ -261,10 +272,7 @@ void GCS_MAVLINK::ftp_worker(void) {
                         }
 
                         // sanity check that our the request looks well formed
-                        const size_t file_name_len = strnlen((char *)request.data, sizeof(request.data));
-                        const bool is_req_size_consider_tnull = ((request.size - file_name_len == 1) &&
-                                                                 request.data[sizeof(request.data) - 1] == 0);
-                        if (((file_name_len != request.size) && !is_req_size_consider_tnull) || (request.size == 0)) {
+                        if (!ftp_check_name_len(request)) {
                             ftp_error(reply, FTP_ERROR::InvalidDataSize);
                             break;
                         }
@@ -349,10 +357,7 @@ void GCS_MAVLINK::ftp_worker(void) {
                         }
 
                         // sanity check that our the request looks well formed
-                        const size_t file_name_len = strnlen((char *)request.data, sizeof(request.data));
-                        const bool is_req_size_consider_tnull = ((request.size - file_name_len == 1) &&
-                                                                 request.data[sizeof(request.data) - 1] == 0);
-                        if (((file_name_len != request.size) && !is_req_size_consider_tnull) || (request.size == 0)) {
+                        if (!ftp_check_name_len(request)) {
                             ftp_error(reply, FTP_ERROR::InvalidDataSize);
                             break;
                         }
@@ -406,10 +411,7 @@ void GCS_MAVLINK::ftp_worker(void) {
                 case FTP_OP::CreateDirectory:
                     {
                         // sanity check that our the request looks well formed
-                        const size_t file_name_len = strnlen((char *)request.data, sizeof(request.data));
-                        const bool is_req_size_consider_tnull = ((request.size - file_name_len == 1) &&
-                                                                 request.data[sizeof(request.data) - 1] == 0);
-                        if (((file_name_len != request.size) && !is_req_size_consider_tnull) || (request.size == 0)) {
+                        if (!ftp_check_name_len(request)) {
                             ftp_error(reply, FTP_ERROR::InvalidDataSize);
                             break;
                         }
@@ -429,10 +431,7 @@ void GCS_MAVLINK::ftp_worker(void) {
                 case FTP_OP::RemoveFile:
                     {
                         // sanity check that our the request looks well formed
-                        const size_t file_name_len = strnlen((char *)request.data, sizeof(request.data));
-                        const bool is_req_size_consider_tnull = ((request.size - file_name_len == 1) &&
-                                                                 request.data[sizeof(request.data) - 1] == 0);
-                        if (((file_name_len != request.size) && !is_req_size_consider_tnull) || (request.size == 0)) {
+                        if (!ftp_check_name_len(request)) {
                             ftp_error(reply, FTP_ERROR::InvalidDataSize);
                             break;
                         }
@@ -451,10 +450,7 @@ void GCS_MAVLINK::ftp_worker(void) {
                 case FTP_OP::CalcFileCRC32:
                     {
                         // sanity check that our the request looks well formed
-                        const size_t file_name_len = strnlen((char *)request.data, sizeof(request.data));
-                        const bool is_req_size_consider_tnull = ((request.size - file_name_len == 1) &&
-                                                                 request.data[sizeof(request.data) - 1] == 0);
-                        if (((file_name_len != request.size) && !is_req_size_consider_tnull) || (request.size == 0)) {
+                        if (!ftp_check_name_len(request)) {
                             ftp_error(reply, FTP_ERROR::InvalidDataSize);
                             break;
                         }
@@ -647,11 +643,8 @@ int GCS_MAVLINK::gen_dir_entry(char *dest, size_t space, const char *path, const
 void GCS_MAVLINK::ftp_list_dir(struct pending_ftp &request, struct pending_ftp &response) {
     response.offset = request.offset; // this should be set for any failure condition for debugging
 
-    const size_t directory_name_size = strnlen((char *)request.data, sizeof(request.data));
-    const bool is_req_size_consider_tnull = ((request.size - directory_name_size == 1) &&
-                                             request.data[sizeof(request.data) - 1] == 0);
     // sanity check that our the request looks well formed
-    if (((directory_name_size != request.size) && !is_req_size_consider_tnull) || (request.size == 0)) {
+    if (!ftp_check_name_len(request)) {
         ftp_error(response, FTP_ERROR::InvalidDataSize);
         return;
     }


### PR DESCRIPTION
The pr solves the following problem:

In [mavsdk](https://github.com/mavlink/MAVSDK) ftp client message size is presented taking into account terminating null, but ardupilot compare file name len with message size not considering terminating null and return error.

Tested in sitl with [ftp client](https://github.com/mavlink/MAVSDK/tree/main/examples/ftp_client)