### PR TITLE
Add support for RADIO_LINK_STATS

### DIFF
--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -253,6 +253,7 @@ public:
     void Write_NamedValueFloat(const char *name, float value);
     void Write_Power(void);
     void Write_Radio(const mavlink_radio_t &packet);
+    void Write_RadioLinkStats(const mavlink_radio_link_stats_t &packet);
     void Write_Message(const char *message);
     void Write_MessageF(const char *fmt, ...);
     void Write_ServoStatus(uint64_t time_us, uint8_t id, float position, float force, float speed, uint8_t power_pct,

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -397,6 +397,39 @@ void AP_Logger::Write_Radio(const mavlink_radio_t &packet)
     WriteBlock(&pkt, sizeof(pkt));
 }
 
+#if AP_RCPROTOCOL_MAVLINK_RADIO_ENABLED
+void AP_Logger::Write_RadioLinkStats(const mavlink_radio_link_stats_t &packet)
+{
+    const struct log_RadioLinkStatsRx pktrx{
+        LOG_PACKET_HEADER_INIT(LOG_RADIO_LINK_STATS_MSG_RX),
+        time_us             : AP_HAL::micros64(),
+        LQrc                : packet.rx_LQ_rc,
+        LQser               : packet.rx_LQ_ser,
+        rssi1               : packet.rx_rssi1,
+        snr1                : packet.rx_snr1,
+        rssi2               : packet.rx_rssi2,
+        snr2                : packet.rx_snr2,
+        receive_antenna     : packet.rx_receive_antenna,
+        transmit_antenna    : packet.rx_transmit_antenna
+    };
+    WriteBlock(&pktrx, sizeof(pktrx));
+
+    const struct log_RadioLinkStatsTx pkttx{
+        LOG_PACKET_HEADER_INIT(LOG_RADIO_LINK_STATS_MSG_TX),
+        time_us             : AP_HAL::micros64(),
+        LQser               : packet.tx_LQ_ser,
+        rssi1               : packet.tx_rssi1,
+        snr1                : packet.tx_snr1,
+        rssi2               : packet.tx_rssi2,
+        snr2                : packet.tx_snr2,
+        receive_antenna     : packet.tx_receive_antenna,
+        transmit_antenna    : packet.tx_transmit_antenna,
+        flags               : packet.flags
+    };
+    WriteBlock(&pkttx, sizeof(pkttx));
+}
+#endif // AP_RCPROTOCOL_MAVLINK_RADIO_ENABLED
+
 void AP_Logger::Write_Compass_instance(const uint64_t time_us, const uint8_t mag_instance)
 {
     const Compass &compass = AP::compass();

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -396,6 +396,32 @@ struct PACKED log_Radio {
     uint16_t fixed;
 };
 
+struct PACKED log_RadioLinkStatsRx {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t LQrc;
+    uint8_t LQser;
+    uint8_t rssi1;
+    int8_t snr1;
+    uint8_t rssi2;
+    int8_t snr2;
+    uint8_t receive_antenna;
+    uint8_t transmit_antenna;
+};
+
+struct PACKED log_RadioLinkStatsTx {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t LQser;
+    uint8_t rssi1;
+    int8_t snr1;
+    uint8_t rssi2;
+    int8_t snr2;
+    uint8_t receive_antenna;
+    uint8_t transmit_antenna;
+    uint8_t flags;
+};
+
 struct PACKED log_PID {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -1220,6 +1246,10 @@ LOG_STRUCTURE_FROM_PRECLAND \
       "MAVC", "QBBBBBHffffiifBB","TimeUS,TS,TC,SS,SC,Fr,Cmd,P1,P2,P3,P4,X,Y,Z,Res,WL", "s---------------", "F---------------" }, \
     { LOG_RADIO_MSG, sizeof(log_Radio), \
       "RAD", "QBBBBBHH", "TimeUS,RSSI,RemRSSI,TxBuf,Noise,RemNoise,RxErrors,Fixed", "s-------", "F-------", true }, \
+    { LOG_RADIO_LINK_STATS_MSG_RX, sizeof(log_RadioLinkStatsRx), \
+      "RDRX", "QBBBbBbBB", "TimeUS,rxLQrc,rxLQser,rxRssi1,rxSnr1,rxRssi2,rxSnr2,rxRAn,rxTAn", "s%%------", "F--------", true }, \
+    { LOG_RADIO_LINK_STATS_MSG_TX, sizeof(log_RadioLinkStatsTx), \
+      "RDTX", "QBBbBbBBB", "TimeUS,txLQser,txRssi1,txSnr1,txRssi2,txSnr2,txRAn,txTAn,flags", "s%-------", "F--------", true }, \
 LOG_STRUCTURE_FROM_CAMERA \
 LOG_STRUCTURE_FROM_MOUNT \
     { LOG_ARSP_MSG, sizeof(log_ARSP), "ARSP",  "QBffcffBBffB", "TimeUS,I,Airspeed,DiffPress,Temp,RawPress,Offset,U,H,Hp,TR,Pri", "s#nPOPP-----", "F-00B00-----", true }, \
@@ -1388,6 +1418,8 @@ enum LogMessages : uint8_t {
     LOG_RCOUT2_MSG,
     LOG_RCOUT3_MSG,
     LOG_IDS_FROM_FENCE,
+    LOG_RADIO_LINK_STATS_MSG_RX,
+    LOG_RADIO_LINK_STATS_MSG_TX,
 
     _LOG_LAST_MSG_
 };

--- a/libraries/AP_RCProtocol/AP_RCProtocol.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.cpp
@@ -617,6 +617,15 @@ void AP_RCProtocol::handle_radio_rc_channels(const mavlink_radio_rc_channels_t* 
 
     backend[AP_RCProtocol::MAVLINK_RADIO]->update_radio_rc_channels(packet);
 };
+
+void AP_RCProtocol::handle_radio_link_stats(const mavlink_radio_link_stats_t* packet)
+{
+    if (_detected_protocol != AP_RCProtocol::MAVLINK_RADIO) {
+        return;
+    }
+
+    backend[AP_RCProtocol::MAVLINK_RADIO]->update_radio_link_stats(packet);
+}
 #endif // AP_RCPROTOCOL_MAVLINK_RADIO_ENABLED
 
 namespace AP {

--- a/libraries/AP_RCProtocol/AP_RCProtocol.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.h
@@ -217,6 +217,7 @@ public:
     // handle mavlink radio
 #if AP_RCPROTOCOL_MAVLINK_RADIO_ENABLED
     void handle_radio_rc_channels(const mavlink_radio_rc_channels_t* packet);
+    void handle_radio_link_stats(const mavlink_radio_link_stats_t* packet);
 #endif
 
 private:

--- a/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
@@ -47,6 +47,7 @@ public:
     // update from mavlink messages
 #if AP_RCPROTOCOL_MAVLINK_RADIO_ENABLED
     virtual void update_radio_rc_channels(const mavlink_radio_rc_channels_t* packet) {}
+    virtual void update_radio_link_stats(const mavlink_radio_link_stats_t* packet) {}
 #endif
 
     // get number of frames, ignoring failsafe
@@ -133,6 +134,9 @@ protected:
     // decode channels from the standard 11bit format (used by CRSF and SBUS)
     static void decode_11bit_channels(const uint8_t* data, uint8_t nchannels, uint16_t *values, uint16_t mult, uint16_t div, uint16_t offset);
 
+    int16_t rssi = -1;
+    int16_t rx_link_quality = -1;
+
 private:
     uint32_t rc_input_count;
     uint32_t last_rc_input_count;
@@ -140,8 +144,6 @@ private:
 
     uint16_t _pwm_values[MAX_RCIN_CHANNELS];
     uint8_t  _num_channels;
-    int16_t rssi = -1;
-    int16_t rx_link_quality = -1;
 };
 
 #endif  // AP_RCPROTOCOL_ENABLED

--- a/libraries/AP_RCProtocol/AP_RCProtocol_MAVLinkRadio.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_MAVLinkRadio.cpp
@@ -21,5 +21,59 @@ void AP_RCProtocol_MAVLinkRadio::update_radio_rc_channels(const mavlink_radio_rc
     add_input(count, rc_chan, failsafe);
 }
 
+void AP_RCProtocol_MAVLinkRadio::update_radio_link_stats(const mavlink_radio_link_stats_t* packet)
+{
+    // update the backend's fields
+
+    if (packet->rx_LQ_rc != UINT8_MAX) {
+        rx_link_quality = packet->rx_LQ_rc;
+    } else
+    if (packet->rx_LQ_ser != UINT8_MAX) {
+        rx_link_quality = packet->rx_LQ_ser;
+    } else {
+        rx_link_quality = -1;
+    }
+
+    int32_t _rssi = -1;
+
+    if (packet->rx_receive_antenna > 0) { // should be 1, but just always assume antenna1 is meant
+        // receiving on antenna 1
+        if (packet->rx_rssi2 != UINT8_MAX) {
+            _rssi = packet->rx_rssi2;
+        } else
+        if (packet->rx_rssi1 != UINT8_MAX) { // value is stored in rx_rssi1
+            _rssi = packet->rx_rssi1;
+        }
+    } else {
+        // receiving on antenna 0
+        if (packet->rx_rssi1 != UINT8_MAX) {
+            _rssi = packet->rx_rssi1;
+        }
+    }
+
+    if (_rssi == -1) { // no rssi value set
+        rssi = -1;
+        return;
+    }
+
+    if (packet->flags & RADIO_LINK_STATS_FLAGS_RSSI_DBM_DEV) {
+        // rssi is in negative dBm, 255 = unknown, 254 = no link connection, 0...253 = 0...-253 dBm
+        // convert to AP rssi using the same logic as in CRSF driver
+        // AP rssi: -1 for unknown, 0 for no link connection, 255 for maximum link
+        if (_rssi == 254) {
+            rssi = 0; // no connection
+        } else if (_rssi < 50) {
+            rssi = 255;
+        } else if (_rssi > 120) {
+            rssi = 1; // connection, but very low rssi
+        } else {
+            rssi = int16_t(roundf((1.0f - ((float)_rssi - 50.0f) / 70.0f) * 255.0f));
+        }
+    } else {
+        // _rssi is in mavlink scale 0..254, scale it to 0..255 with rounding
+        rssi = (_rssi * 255 + 127) / 254;
+    }
+}
+
 #endif // AP_RCPROTOCOL_MAVLINK_RADIO_ENABLED
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_MAVLinkRadio.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_MAVLinkRadio.h
@@ -15,6 +15,7 @@ public:
 
     // update from mavlink messages
     void update_radio_rc_channels(const mavlink_radio_rc_channels_t* packet) override;
+    void update_radio_link_stats(const mavlink_radio_link_stats_t* packet) override;
 };
 
 #endif // AP_RCPROTOCOL_MAVLINK_RADIO_ENABLED

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -691,6 +691,7 @@ protected:
 
     void handle_manual_control(const mavlink_message_t &msg);
     void handle_radio_rc_channels(const mavlink_message_t &msg);
+    void handle_radio_link_stats(const mavlink_message_t &msg);
 
     // default empty handling of LANDING_TARGET
     virtual void handle_landing_target(const mavlink_landing_target_t &packet, uint32_t timestamp_ms) { }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4197,6 +4197,9 @@ void GCS_MAVLINK::handle_message(const mavlink_message_t &msg)
     case MAVLINK_MSG_ID_RADIO_RC_CHANNELS:
         handle_radio_rc_channels(msg);
         break;
+    case MAVLINK_MSG_ID_RADIO_LINK_STATS:
+        handle_radio_link_stats(msg);
+        break;
 #endif
 #endif
 
@@ -6988,6 +6991,20 @@ void GCS_MAVLINK::handle_radio_rc_channels(const mavlink_message_t &msg)
     mavlink_msg_radio_rc_channels_decode(&msg, &packet);
 
     AP::RC().handle_radio_rc_channels(&packet);
+}
+
+void GCS_MAVLINK::handle_radio_link_stats(const mavlink_message_t &msg)
+{
+    mavlink_radio_link_stats_t packet;
+    mavlink_msg_radio_link_stats_decode(&msg, &packet);
+
+    AP::RC().handle_radio_link_stats(&packet);
+
+#if HAL_LOGGING_ENABLED
+    if (AP::logger().should_log(log_radio_bit())) {
+        AP::logger().Write_RadioLinkStats(packet);
+    }
+#endif
 }
 #endif // AP_RCPROTOCOL_MAVLINK_RADIO_ENABLED
 


### PR DESCRIPTION
This is the second step in adding MAVLink receiver support, which is about radio link statistics. The first step was adding the MAVLinkRadio receiver class, which was about handling the RADIO_RC_CHANNELS mavlink message, and which was recently merged (https://github.com/ArduPilot/ardupilot/pull/26356).   

The PR is dependent on https://github.com/ArduPilot/mavlink/pull/354, which brings in the definition of the RADIO_LINK_STATS message. 

The PR will thus not work at this time, but is intended to show where things may go, and to spur the discussion on the code.

The PR does these things:
- adds handling of RADIO_LINK_STATS to the AP_RCProtocol library. In this library the LQ and rssi fields are digested and made available via the usual ways.
- adds logging. Since these are more than ca 7 data items to log, two new log items are created for the logging, RDRX and RDTX.
- adds handling of RADIO_LINK_STATS to the GCS library. It reads the message and forwards it to the AP_RCProtocol library and does the logging.
