### PR TITLE
AP_Scripting: plane doublet example modification

### DIFF
--- a/libraries/AP_Scripting/examples/plane-doublets.lua
+++ b/libraries/AP_Scripting/examples/plane-doublets.lua
@@ -6,17 +6,19 @@
 -- Magnitude and duration of the doublet can also be controlled.
 -- It is suggested to allow the aircraft to trim for straight, level, unaccelerated flight (SLUF) in FBWB mode before
 -- starting a doublet
--- Charlie Johnson, Oklahoma State University 2020
+-- Charlie Johnson, Oklahoma State University 2020, modification by Astik Srivastava, Delhi Technological University 2024
 
 local DOUBLET_ACTION_CHANNEL = 6 -- RCIN channel to start a doublet when high (>1700)
 local DOUBLET_CHOICE_CHANNEL = 7 -- RCIN channel to choose elevator (low) or rudder (high)
-local DOUBLET_FUCNTION = 19 -- which control surface (SERVOx_FUNCTION) number will have a doublet happen
+local DOUBLET_FUCNTION = 1 -- which control surface (SERVOx_FUNCTION) number will have a doublet happen
 -- A (Servo 1, Function 4), E (Servo 2, Function 19), and R (Servo 4, Function 21)
 local DOUBLET_MAGNITUDE = 6 -- defined out of 45 deg used for set_output_scaled
-local DOUBLET_TIME = 500 -- period of doublet signal in ms
-
+local DOUBLET_TIME = 2000 -- period of doublet signal in ms
+local start_time = -1
+local end_time = -1
 -- flight mode numbers for plane https://mavlink.io/en/messages/ardupilotmega.html
 local MODE_MANUAL = 0
+local MODE_STABILIZE = 2
 local MODE_FBWA = 5
 local K_AILERON = 4
 local K_ELEVATOR = 19
@@ -29,10 +31,6 @@ local end_time = -1
 local now = -1
 
 -- store information about the doublet channel
-local doublet_srv_chan = SRV_Channels:find_channel(DOUBLET_FUCNTION)
-local doublet_srv_min = param:get("SERVO" .. doublet_srv_chan + 1 .. "_MIN")
-local doublet_srv_max = param:get("SERVO" .. doublet_srv_chan + 1 .. "_MAX")
-local doublet_srv_trim = param:get("SERVO" .. doublet_srv_chan + 1 .. "_TRIM")
 local pre_doublet_mode = vehicle:get_mode()
 
 function retry_set_mode(mode)
@@ -48,106 +46,75 @@ function retry_set_mode(mode)
 end
 
 function doublet()
+    local now = millis()
+    local pre_doublet_mode = vehicle:get_mode()
+    local pre_doublet_elevator = SRV_Channels:get_output_pwm(K_ELEVATOR)
+    local pre_doublet_aileron = SRV_Channels:get_output_pwm(K_AILERON)
+    local pre_doublet_rudder = SRV_Channels:get_output_pwm(K_RUDDER)
+    local pre_doublet_throttle = 1200
+    local doublet_choice_pwm = rc:get_pwm(DOUBLET_CHOICE_CHANNEL)
     local callback_time = 100
-    if arming:is_armed() == true and rc:get_pwm(DOUBLET_ACTION_CHANNEL) > 1700 and end_time ==-1 then
-        -- try for the best timing possible while performing a doublet
-        callback_time = DOUBLET_TIME / 10
-        -- start a quick doublet based on some math/logic
-        now = millis()
+    if arming:is_armed() == true and rc:get_pwm(DOUBLET_ACTION_CHANNEL) > 1700 then
+        gcs:send_text(6, "in Doublet function")
+        local trim_funcs
+        local doublet_srv_trim = 1500
+        -- choosing control actuator, 900 for elevator, 1100 for aileron, 1300 for rudder, 1500 for throttle 
+        if doublet_choice_pwm < 1000 then
+            DOUBLET_FUCNTION = K_ELEVATOR
+            doublet_srv_trim = pre_doublet_elevator
+            trim_funcs = {K_AILERON, K_RUDDER, K_THROTTLE}
+            DOUBLET_MAGNITUDE = 12
+        elseif doublet_choice_pwm > 1000 and doublet_choice_pwm < 1200 then
+            DOUBLET_FUCNTION = K_AILERON
+            doublet_srv_trim = pre_doublet_aileron
+            trim_funcs = {K_ELEVATOR, K_RUDDER, K_THROTTLE}
+            DOUBLET_MAGNITUDE = 15
+        elseif doublet_choice_pwm > 1200 and doublet_choice_pwm < 1400 then
+            DOUBLET_FUCNTION = K_RUDDER
+            doublet_srv_trim = pre_doublet_rudder
+            trim_funcs = {K_ELEVATOR, K_AILERON, K_THROTTLE}
+            DOUBLET_MAGNITUDE = 15
+        elseif doublet_choice_pwm > 1400 and doublet_choice_pwm < 1600 then
+            DOUBLET_FUCNTION = K_THROTTLE
+            doublet_srv_trim = pre_doublet_throttle
+            trim_funcs = {K_ELEVATOR, K_AILERON, K_RUDDER}
+            DOUBLET_MAGNITUDE = 12
+        else
+            DOUBLET_FUCNTION = K_ELEVATOR
+            doublet_srv_trim = pre_doublet_elevator
+            trim_funcs = {K_THROTTLE, K_AILERON, K_RUDDER}
+            DOUBLET_MAGNITUDE = 12
+        end
+        local doublet_srv_chan = SRV_Channels:find_channel(DOUBLET_FUCNTION)
+        local doublet_srv_min = param:get("SERVO" .. doublet_srv_chan + 1 .. "_MIN")
+        local doublet_srv_max = param:get("SERVO" .. doublet_srv_chan + 1 .. "_MAX")
+        doublet_srv_trim = param:get("SERVO" .. doublet_srv_chan + 1 .. "_TRIM")
         if start_time == -1 then
-            -- this is the time that we started
-            -- stop time will be start_time + DOUBLET_TIME
             start_time = now
-            pre_doublet_mode = vehicle:get_mode()
-            -- are we doing a doublet on elevator or rudder? set the other controls to trim
-            local doublet_choice_pwm = rc:get_pwm(DOUBLET_CHOICE_CHANNEL)
-            local trim_funcs
-            local pre_doublet_elevator = SRV_Channels:get_output_pwm(K_ELEVATOR)
-            if doublet_choice_pwm < 1500 then
-                -- doublet on elevator
-                DOUBLET_FUCNTION = K_ELEVATOR
-                trim_funcs = {K_AILERON, K_RUDDER}
-                DOUBLET_MAGNITUDE = 12
-                doublet_srv_trim = pre_doublet_elevator
-            else
-                -- doublet on rudder
-                DOUBLET_FUCNTION = K_RUDDER
-                trim_funcs = {K_AILERON}
-                DOUBLET_MAGNITUDE = 15
-                -- pin elevator to current position. This is most likely different than the _TRIM value
-                SRV_Channels:set_output_pwm_chan_timeout(SRV_Channels:find_channel(K_ELEVATOR), pre_doublet_elevator, DOUBLET_TIME * 4)
-            end
-            -- notify the gcs that we are starting a doublet
-            gcs:send_text(6, "STARTING DOUBLET " .. DOUBLET_FUCNTION)
-            -- get info about the doublet channel
-            doublet_srv_chan = SRV_Channels:find_channel(DOUBLET_FUCNTION)
-            doublet_srv_min = param:get("SERVO" .. doublet_srv_chan + 1 .. "_MIN")
-            doublet_srv_max = param:get("SERVO" .. doublet_srv_chan + 1 .. "_MAX")
-            -- set the channels that need to be pinned to trim until the doublet is done
-            for i = 1, #trim_funcs do
-                local trim_chan = SRV_Channels:find_channel(trim_funcs[i])
-                local trim_pwm = param:get("SERVO" .. trim_chan + 1 .. "_TRIM")
-                SRV_Channels:set_output_pwm_chan_timeout(trim_chan, trim_pwm, DOUBLET_TIME * 2)
-            end
-            -- get the current throttle PWM and pin it there until the doublet is done
-            local pre_doublet_throttle = SRV_Channels:get_output_pwm(K_THROTTLE)
-            SRV_Channels:set_output_pwm_chan_timeout(
-                SRV_Channels:find_channel(K_THROTTLE),
-                pre_doublet_throttle,
-                DOUBLET_TIME * 3
-            )
-            -- enter manual mode
+            gcs:send_text(6, "STARTING DOUBLET " .. doublet_srv_chan)
             retry_set_mode(MODE_MANUAL)
         end
-        -- split time evenly between high and low signal
-        if now < start_time + (DOUBLET_TIME / 2) then
-            down = doublet_srv_trim - math.floor((doublet_srv_trim - doublet_srv_min) * (DOUBLET_MAGNITUDE / 45))
-            SRV_Channels:set_output_pwm_chan_timeout(doublet_srv_chan, down, DOUBLET_TIME / 2 + 100)
-        elseif now < start_time + DOUBLET_TIME then
+        if now < (start_time + (DOUBLET_TIME / 2)) then
+            gcs:send_text(6, "DOUBLET up" .. doublet_srv_chan)
             up = doublet_srv_trim + math.floor((doublet_srv_max - doublet_srv_trim) * (DOUBLET_MAGNITUDE / 45))
             SRV_Channels:set_output_pwm_chan_timeout(doublet_srv_chan, up, DOUBLET_TIME / 2 + 100)
-        elseif now < start_time + (DOUBLET_TIME * 2) then
+            gcs:send_text(6, "pwm" .. tostring(SRV_Channels:get_output_pwm(DOUBLET_FUCNTION)))
+        elseif now < (start_time + DOUBLET_TIME) and now > (start_time + (DOUBLET_TIME / 2))then
+            gcs:send_text(6, "DOUBLET down" .. doublet_srv_chan)
+            down = doublet_srv_trim - math.floor((doublet_srv_trim - doublet_srv_min) * (DOUBLET_MAGNITUDE / 45))
+            SRV_Channels:set_output_pwm_chan_timeout(doublet_srv_chan, down, DOUBLET_TIME / 2 + 100)
+            gcs:send_text(6, "pwm" .. tostring(SRV_Channels:get_output_pwm(DOUBLET_FUCNTION)))
+        elseif now > start_time + (DOUBLET_TIME * 2) then
             -- stick fixed response
             -- hold at pre doublet trim position for any damping effects
-            SRV_Channels:set_output_pwm_chan_timeout(doublet_srv_chan, doublet_srv_trim, DOUBLET_TIME * 2)
-        elseif now > start_time + (DOUBLET_TIME * 2) then
-            -- notify GCS
-            end_time = now
-            gcs:send_text(6, "DOUBLET FINISHED")
-        else
-            gcs:send_text(6, "this should not be reached")
+            gcs:send_text(6, "DOUBLET finished")
+
+            if vehicle:get_mode() == MODE_MANUAL then
+                retry_set_mode(MODE_FBWA)
+                gcs:send_text(6, "DOUBLET FINISHED, in mode" ..vehicle:get_mode())
+                SRV_Channels:set_output_pwm_chan_timeout(DOUBLET_ACTION_CHANNEL, 1000, DOUBLET_TIME)
+            end
         end
-    elseif end_time ~= -1 and rc:get_pwm(DOUBLET_ACTION_CHANNEL) > 1700 then
-        -- wait for RC input channel to go low
-        gcs:send_text(6, "RC" .. DOUBLET_ACTION_CHANNEL .. " still high")
-        callback_time = 100 -- prevent spamming messages to the GCS
-    elseif now ~= -1 and end_time ~= -1 then
-        gcs:send_text(6, "RETURN TO PREVIOUS FLIGHT MODE")
-        now = -1
-        end_time = -1
-        start_time = -1
-        -- clear all of the timeouts
-        control_functions = {K_AILERON, K_ELEVATOR, K_THROTTLE, K_RUDDER}
-        for i = 1, 4 do
-            local control_chan = SRV_Channels:find_channel(control_functions[i])
-            SRV_Channels:set_output_pwm_chan_timeout(control_chan, param:get("SERVO" .. control_chan + 1 .. "_TRIM"), 0)
-        end
-        retry_set_mode(pre_doublet_mode)
-        callback_time = 100 -- don't need to rerun for a little while
-    elseif now ~= -1 then
-        -- stopped before finishing. recover to level attitude
-        gcs:send_text(6, "FBWA RECOVER")
-        now = -1
-        end_time = -1
-        start_time = -1
-        -- clear all of the timeouts
-        control_functions = {K_AILERON, K_ELEVATOR, K_THROTTLE, K_RUDDER}
-        for i = 1, 4 do
-            local control_chan = SRV_Channels:find_channel(control_functions[i])
-            SRV_Channels:set_output_pwm_chan_timeout(control_chan, param:get("SERVO" .. control_chan + 1 .. "_TRIM"), 0)
-        end
-        retry_set_mode(MODE_FBWA)
-        callback_time = 100
     end
     return doublet, callback_time
 end


### PR DESCRIPTION
This pr modifies the plane_doublet.lua example. Added features are
A) All four actuators are excited now (aileron, elevator, rudder, throttle) instead of just elevator and rudder
B) Aircraft returns to fbwa mode when doublet finishes after the doublet finishes, even if trigger channel is high. This will ensure safety. 