### PR TITLE
Leverage yaw lock/follow support on gimbal manager v2 protocol

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -799,6 +799,8 @@ uint16_t AP_Mount_Backend::get_gimbal_device_flags() const
 {
     const uint16_t flags = (get_mode() == MAV_MOUNT_MODE_RETRACT ? GIMBAL_DEVICE_FLAGS_RETRACT : 0) |
                            (get_mode() == MAV_MOUNT_MODE_NEUTRAL ? GIMBAL_DEVICE_FLAGS_NEUTRAL : 0) |
+                           (_yaw_lock ? GIMBAL_DEVICE_FLAGS_YAW_LOCK : 0) |
+                           GIMBAL_DEVICE_FLAGS_YAW_IN_VEHICLE_FRAME | // Yaw angle is always in vehicle-frame
                            GIMBAL_DEVICE_FLAGS_ROLL_LOCK | // roll angle is always earth-frame
                            GIMBAL_DEVICE_FLAGS_PITCH_LOCK; // pitch angle is always earth-frame, yaw_angle is always body-frame
     return flags;

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -83,6 +83,9 @@ public:
     // If false (aka "follow") the gimbal's yaw is maintained in body-frame meaning it will rotate with the vehicle
     void set_yaw_lock(bool yaw_lock) { _yaw_lock = yaw_lock; }
 
+    // get yaw lock state
+    bool get_yaw_lock() { return _yaw_lock; }
+
     // set angle target in degrees
     // yaw_is_earth_frame (aka yaw_lock) should be true if yaw angle is earth-frame, false if body-frame
     void set_angle_target(float roll_deg, float pitch_deg, float yaw_deg, bool yaw_is_earth_frame);


### PR DESCRIPTION
currently the only way to command yaw lock/follow is by rc channels MOUNT_LOCK (163) action. As we are moving to gimbal manager v2 protocol we need some way to command this from gimbal manager protocol.

I didn't place a return MAV_CMD right after the yaw lock flags check because we could have the situation where only gimbal yaw lock is commanded, but we could also receive a gimbal lock/unlock command together with rate or angle targets. This way both situations are handled.

I need clarification in one particular situation. As it is now, if it receives a yaw lock, but yaw was already locked, it will return MAV_RESULT_FAILED. It will only return MAV_RESULT_ACCEPTED if the state changed. Is this preferable or should we return accepted even if the command didn't change it?

@rmackay9 if you could double check this one is fine it would be great. Thanks!