### PR TITLE
AP_Arming: OPTIONS parameter is a bitmask

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -142,7 +142,7 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: Arming options
     // @Description: Options that can be applied to change arming behaviour
-    // @Values: 0:None,1:Disable prearm display,2:Do not send status text on state change
+    // @Bitmask: 0:Disable prearm display,1:Do not send status text on state change
     // @User: Advanced
     AP_GROUPINFO("OPTIONS", 9,   AP_Arming, _arming_options, 0),
 


### PR DESCRIPTION
Parameter is used as a bitmask but not marked as one, this makes it hard to setup in the GCS as you get a values drop down rather than bitmask check boxes. 

https://github.com/ArduPilot/ardupilot/blob/dc97899ce8a95aa8c328a2e380b0c5e693b3eea0/libraries/AP_Arming/AP_Arming.h#L141-L148