### PR TITLE
AP_Scripting: Only try to make scripts directory if file write and directory is enabled

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_config.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_config.h
@@ -34,7 +34,7 @@
 #define AP_FILESYSTEM_SYS_ENABLED 1
 #endif
 
-// AP_FILESYSTEM_FILE_READING_ENABLED is true if you could expect to
+// AP_FILESYSTEM_FILE_WRITING_ENABLED is true if you could expect to
 // be able to open and write a non-virtual file.  Notably this
 // excludes virtual files like SYSFS, and the magic param/mission
 // upload targets, and also excludes ROMFS (where you can read but not

--- a/libraries/AP_Scripting/AP_Scripting.cpp
+++ b/libraries/AP_Scripting/AP_Scripting.cpp
@@ -180,12 +180,17 @@ void AP_Scripting::init(void) {
         return;
     }
 
-    const char *dir_name = SCRIPTING_DIRECTORY;
-    if (AP::FS().mkdir(dir_name)) {
-        if (errno != EEXIST) {
-            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Scripting: failed to create (%s)", dir_name);
+#if AP_FILESYSTEM_FILE_WRITING_ENABLED
+    if ((_dir_disable & uint16_t(AP_Scripting::SCR_DIR::SCRIPTS)) == 0) {
+        // Only try creating scripts directory if loading from it is enabled
+        const char *dir_name = SCRIPTING_DIRECTORY;
+        if (AP::FS().mkdir(dir_name)) {
+            if (errno != EEXIST) {
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Scripting: failed to create (%s)", dir_name);
+            }
         }
     }
+#endif
 
     AP_HAL::Scheduler::priority_base priority = AP_HAL::Scheduler::PRIORITY_SCRIPTING;
     static const struct {


### PR DESCRIPTION
This gates the attempted creation of the directory on `AP_FILESYSTEM_FILE_WRITING_ENABLED`. If that is disabled the creation will always fail. Secondly it only attempts to create the directory if it is not disabled with `SCR_DIR_DISABLE`.

Finally it fixes up a comment in AP_Filesystem.