### PR TITLE
Tidy use of backend type in AP_GPS

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -2418,7 +2418,7 @@ bool AP_GPS::gps_yaw_deg(uint8_t instance, float &yaw_deg, float &accuracy_deg, 
 {
 #if GPS_MAX_RECEIVERS > 1
     const auto type = get_type(instance);
-    if (instance < GPS_MAX_RECEIVERS &&
+    if (
         ((type == GPS_TYPE_UBLOX_RTK_BASE) || (type == GPS_TYPE_UAVCAN_RTK_BASE)) &&
         ((get_type(instance^1) == GPS_TYPE_UBLOX_RTK_ROVER) || (get_type(instance^1) == GPS_TYPE_UAVCAN_RTK_ROVER))) {
         // return the yaw from the rover

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -138,6 +138,10 @@ public:
 #endif
     };
 
+    // convenience methods for working out what general type an instance is:
+    bool is_rtk_base(uint8_t instance) const;
+    bool is_rtk_rover(uint8_t instance) const;
+
     /// GPS status codes.  These are kept aligned with MAVLink by
     /// static_assert in AP_GPS.cpp
     enum GPS_Status {


### PR DESCRIPTION
Also uses get_type in a few spots to avoid external callers doing something nasty.

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  -32                                                     
Durandal                            48     *           56      48                56     56     48
Hitec-Airspeed           *                                                       
KakuteH7-bdshot                     80     *           80      80                80     80     80
MatekF405                           64     *           64      72                64     64     72
Pixhawk1-1M-bdshot                  64                 56      64                56     64     64
f103-QiotekPeriph        *                                                       
f303-Universal           64                                                      
iomcu                                                                *           
revo-mini                           64     *           72      72                64     72     72
skyviper-v2450                                         64                        
```

In preparation for making `AP_GPS_Params`
