### PR TITLE
AP_Proximity: add RPLidarC1 support

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
@@ -108,6 +108,8 @@ float AP_Proximity_RPLidarA2::distance_max() const
         return 8.0f;
     case Model::A2:
         return 16.0f;
+    case Model::C1:
+        return 12.0f;
     case Model::S1:
         return 40.0f;
     }
@@ -121,8 +123,8 @@ float AP_Proximity_RPLidarA2::distance_min() const
     case Model::UNKNOWN:
         return 0.0f;
     case Model::A1:
-        return 0.2f;
     case Model::A2:
+    case Model::C1:
     case Model::S1:
         return 0.2f;
     }
@@ -333,6 +335,10 @@ void AP_Proximity_RPLidarA2::parse_response_device_info()
     case 0x28:
         model = Model::A2;
         device_type = "A2";
+        break;
+    case 0x41:
+        model=Model::C1;
+        device_type="C1";
         break;
     case 0x61:
         model = Model::S1;

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
@@ -151,6 +151,7 @@ private:
         UNKNOWN,
         A1,
         A2,
+        C1,
         S1,
     } model = Model::UNKNOWN;
 


### PR DESCRIPTION
This adds support for the [RPLidar C1](https://www.slamtec.ai/product/slamtec-rplidar-c1/) based on [development and discussion here](https://discuss.ardupilot.org/t/rplidar-c1-has-different-results-in-firmware-copter-4-5-and-copter-4-4/114466/4).

The datasheet says the lidar has a "low blind range of 0.05m" so the 0.2m minimum is slightly conservative but consistent with other RPLidar.