### PR TITLE
autotest: ensure latest log is timestamped, small and not growing

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -4372,7 +4372,7 @@ class TestSuite(ABC):
         self.context_push()
         self.set_parameters({
             "NET_ENABLED": 1,
-            "LOG_DISARMED": 1,
+            "LOG_DISARMED": 0,
             "LOG_DARM_RATEMAX": 1, # make small logs
             # UDP client
             "NET_P1_TYPE": 1,
@@ -4408,6 +4408,17 @@ class TestSuite(ABC):
             "NET_P4_IP3": 0,
             })
         self.reboot_sitl()
+
+        # ensure the latest log file is very small:
+        self.context_push()
+        self.set_parameter('LOG_DISARMED', 1)
+        self.delay_sim_time(15)
+        self.progress(f"Current onboard log filepath {self.current_onboard_log_filepath()}")
+        self.context_pop()
+
+        # ensure that the autopilot has a timestamp on that file by
+        # now, or MAVProxy does not see it as the latest log:
+        self.wait_gps_fix_type_gte(3)
 
         self.set_parameter('SIM_SPEEDUP', 1)
 


### PR DESCRIPTION
A fixed time this log is open for ensures we know what we are downloading.

We will not be keeping dataflash logs of the rest of this test after this PR as we leave LOG_DISARMED as it is.

Waiting for GPS ensures the file gets a timestamp, so MAVProxy's "log download latest" will return that log file.

This is an excerpt from a test which failed in CI.  Note that the log being downloaded is *massive*, despite the test's attempts to make a small log (it is not downloading the latest log, but the previous).  This is because that really small log does not have a timestamp associated with it before the simulation gets GPS, and MAVProxy's `log download latest` treats zero as oldest-log.  Key line is "Downloading log 23 as..."

```
2024-03-11T10:41:51.5074012Z Log 11  numLogs 24 lastLog 24 size 139264 Mon Mar 11 10:36:05 2024
2024-03-11T10:41:51.5074667Z Log 12  numLogs 24 lastLog 24 size 95744 Mon Mar 11 10:36:06 2024
2024-03-11T10:41:51.5075284Z Log 13  numLogs 24 lastLog 24 size 507904 Mon Mar 11 10:36:09 2024
2024-03-11T10:41:51.5075900Z Log 14  numLogs 24 lastLog 24 size 454656 Mon Mar 11 10:36:11 2024
2024-03-11T10:41:51.5076410Z Log 15  numLogs 24 lastLog 24 size 95232 Mon Mar 11 10:36:11 2024
2024-03-11T10:41:51.5076918Z Log 16  numLogs 24 lastLog 24 size 724992 Mon Mar 11 10:36:17 2024
2024-03-11T10:41:51.5077428Z Log 17  numLogs 24 lastLog 24 size 569344 Mon Mar 11 10:36:22 2024
2024-03-11T10:41:51.5077934Z Log 18  numLogs 24 lastLog 24 size 303104 Mon Mar 11 10:36:24 2024
2024-03-11T10:41:51.5078524Z Log 19  numLogs 24 lastLog 24 size 536576 Mon Mar 11 10:36:27 2024
2024-03-11T10:41:51.5079142Z Log 20  numLogs 24 lastLog 24 size 466944 Mon Mar 11 10:36:33 2024
2024-03-11T10:41:51.5080109Z Log 21  numLogs 24 lastLog 24 size 737280 Mon Mar 11 10:36:34 2024
2024-03-11T10:41:51.5081155Z Log 22  numLogs 24 lastLog 24 size 14958592 Mon Mar 11 10:36:54 2024
2024-03-11T10:41:51.5082171Z Log 23  numLogs 24 lastLog 24 size 55513088 Mon Mar 11 10:38:15 2024
2024-03-11T10:41:51.5083024Z Log 24  numLogs 24 lastLog 24 size 81920 
2024-03-11T10:41:51.5083748Z AP: ArduSub V4.6.0-dev (abcdef)
2024-03-11T10:41:51.5084309Z AP: 260748ee710842fc996f4d815438f1cc
2024-03-11T10:41:51.5084882Z AP: Frame: VECTORED
2024-03-11T10:41:51.5085553Z AT-0256.4: Drained 0 messages from mav (0.000000/s)
2024-03-11T10:41:51.5086415Z AT-0256.7: AP: EKF3 IMU0 tilt alignment complete
2024-03-11T10:41:51.5087237Z AT-0256.7: AP: EKF3 IMU1 tilt alignment complete
2024-03-11T10:41:51.5087750Z AP: EKF3 IMU0 tilt alignment complete
2024-03-11T10:41:51.5088192Z AP: EKF3 IMU1 tilt alignment complete
2024-03-11T10:41:51.5088863Z AT-0256.8: AP: EKF3 IMU0 MAG0 initial yaw alignment complete
2024-03-11T10:41:51.5089583Z AT-0256.8: AP: EKF3 IMU1 MAG0 initial yaw alignment complete
2024-03-11T10:41:51.5090033Z AP: EKF3 IMU0 MAG0 initial yaw alignment complete
2024-03-11T10:41:51.5090549Z AP: EKF3 IMU1 MAG0 initial yaw alignment complete
2024-03-11T10:41:51.5091631Z AT-0257.4: Drained 0 messages from mav (0.000000/s)
2024-03-11T10:41:51.5092205Z AT-0258.4: Drained 0 messages from mav (0.000000/s)
2024-03-11T10:41:51.5092835Z AT-0259.4: Drained 0 messages from mav (0.000000/s)
2024-03-11T10:41:51.5093377Z log download latest MAVProxy-downloaded-net-log-UDPClient.BIN
2024-03-11T10:41:51.5094286Z log download latest MAVProxy-downloaded-net-log-UDPClient.BIN
2024-03-11T10:41:51.5095084Z MANUAL> Downloading log 23 as MAVProxy-downloaded-net-log-UDPClient.BIN
2024-03-11T10:41:51.5096131Z AP: GPS 1: probing for u-blox at 230400 baud
```
