### PR TITLE
Remove class specifier prefixing Location in function declarations

### DIFF
--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -97,7 +97,7 @@ public:
     uint8_t check();
 
     // returns true if the destination is within fence (used to reject waypoints outside the fence)
-    bool check_destination_within_fence(const class Location& loc);
+    bool check_destination_within_fence(const Location& loc);
 
     /// get_breaches - returns bit mask of the fence types that have been breached
     uint8_t get_breaches() const { return _breached_fences; }

--- a/libraries/AP_DAL/AP_DAL.h
+++ b/libraries/AP_DAL/AP_DAL.h
@@ -192,7 +192,7 @@ public:
 
     // get the home location. This is const to prevent any changes to
     // home without telling AHRS about the change
-    const class Location &get_home(void) const {
+    const Location &get_home(void) const {
         return _home;
     }
 

--- a/libraries/AP_L1_Control/AP_L1_Control.h
+++ b/libraries/AP_L1_Control/AP_L1_Control.h
@@ -50,8 +50,8 @@ public:
     float turn_distance(float wp_radius) const override;
     float turn_distance(float wp_radius, float turn_angle) const override;
     float loiter_radius (const float loiter_radius) const override;
-    void update_waypoint(const class Location &prev_WP, const class Location &next_WP, float dist_min = 0.0f) override;
-    void update_loiter(const class Location &center_WP, float radius, int8_t loiter_direction) override;
+    void update_waypoint(const Location &prev_WP, const Location &next_WP, float dist_min = 0.0f) override;
+    void update_loiter(const Location &center_WP, float radius, int8_t loiter_direction) override;
     void update_heading_hold(int32_t navigation_heading_cd) override;
     void update_level_flight(void) override;
     bool reached_loiter_target(void) override;

--- a/libraries/AP_Navigation/AP_Navigation.h
+++ b/libraries/AP_Navigation/AP_Navigation.h
@@ -67,7 +67,7 @@ public:
     // main flight code will call an output function (such as
     // nav_roll_cd()) after this function to ask for the new required
     // navigation attitude/steering.
-    virtual void update_waypoint(const class Location &prev_WP, const class Location &next_WP, float dist_min = 0.0f) = 0;
+    virtual void update_waypoint(const Location &prev_WP, const Location &next_WP, float dist_min = 0.0f) = 0;
 
     // update the internal state of the navigation controller for when
     // the vehicle has been commanded to circle about a point.  This
@@ -76,7 +76,7 @@ public:
     // main flight code will call an output function (such as
     // nav_roll_cd()) after this function to ask for the new required
     // navigation attitude/steering.
-    virtual void update_loiter(const class Location &center_WP, float radius, int8_t loiter_direction) = 0;
+    virtual void update_loiter(const Location &center_WP, float radius, int8_t loiter_direction) = 0;
 
     // update the internal state of the navigation controller, given a
     // fixed heading. This is the step function for navigation control


### PR DESCRIPTION
Remove  occurrences of `class` prefixing `Location` in function declarations:

- See comment in: https://github.com/ArduPilot/ardupilot/pull/26328#discussion_r1522653270