### PR TITLE
AP_Rangefinder: fix (very) out-of-range lidar causing float inf

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_SITL.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_SITL.cpp
@@ -35,7 +35,7 @@ void AP_RangeFinder_SITL::update(void)
     const float dist = AP::sitl()->get_rangefinder(_instance);
 
     // nan distance means nothing is connected
-    if (isnan(dist)) {
+    if (isnan(dist) || isinf(dist)) {
         state.status = RangeFinder::Status::NoData;
         return;
     }


### PR DESCRIPTION
AP_Rangefinder: fix (very) out-of-range lidar causing float inf which caused a sitl crash. This was triggered when a wrongly configured VTOL was flipping over and the simulated lidar was pointing at the sky