### PR TITLE
AP_HAL_ChibiOS: always normalize ESC channel when using iomcu

### DIFF
--- a/libraries/AP_HAL_ChibiOS/RCOutput_bdshot.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput_bdshot.cpp
@@ -757,7 +757,7 @@ bool RCOutput::bdshot_decode_telemetry_from_erpm(uint16_t encodederpm, uint8_t c
     uint8_t normalized_chan = chan;
 #endif
 #if HAL_WITH_IO_MCU
-    if (iomcu_dshot) {
+    if (iomcu_enabled) {
         normalized_chan = chan + chan_offset;
     }
 #endif


### PR DESCRIPTION
This prevented TKOFF_MIN_RPM from working on boards with iomcu