### PR TITLE
AP_AHRS: avoid use of AP_Motors include in header

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_View.h
+++ b/libraries/AP_AHRS/AP_AHRS_View.h
@@ -21,7 +21,6 @@
  */
 
 #include "AP_AHRS.h"
-#include <AP_Motors/AP_Motors.h>
 
 // fwd declarations to avoid include errors
 class AC_AttitudeControl;
@@ -175,8 +174,9 @@ public:
 
     // Logging Functions
     void Write_AttitudeView(const Vector3f &targets) const;    
-    void Write_Rate( const AP_Motors &motors, const AC_AttitudeControl &attitude_control,
-                        const AC_PosControl &pos_control) const;
+    void Write_Rate(const class AP_Motors &motors,
+                    const class AC_AttitudeControl &attitude_control,
+                    const AC_PosControl &pos_control) const;
 
     float roll;
     float pitch;


### PR DESCRIPTION
... don't need to know the shape of the library here
