### PR TITLE
Mount: Viewpro support for enable/disable rangefinder

### DIFF
--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -873,6 +873,16 @@ bool AP_Mount::get_rangefinder_distance(uint8_t instance, float& distance_m) con
     return backend->get_rangefinder_distance(distance_m);
 }
 
+// enable/disable rangefinder.  Returns true on success
+bool AP_Mount::set_rangefinder_enable(uint8_t instance, bool enable)
+{
+    auto *backend = get_instance(instance);
+    if (backend == nullptr) {
+        return false;
+    }
+    return backend->set_rangefinder_enable(enable);
+}
+
 AP_Mount_Backend *AP_Mount::get_primary() const
 {
     return get_instance(_primary);

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -266,6 +266,9 @@ public:
     // get rangefinder distance.  Returns true on success
     bool get_rangefinder_distance(uint8_t instance, float& distance_m) const;
 
+    // enable/disable rangefinder.  Returns true on success
+    bool set_rangefinder_enable(uint8_t instance, bool enable);
+
     // parameter var table
     static const struct AP_Param::GroupInfo        var_info[];
 

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -203,6 +203,9 @@ public:
     // get rangefinder distance.  Returns true on success
     virtual bool get_rangefinder_distance(float& distance_m) const { return false; }
 
+    // enable/disable rangefinder.  Returns true on success
+    virtual bool set_rangefinder_enable(bool enable) { return false; }
+
 protected:
 
     enum class MountTargetType {

--- a/libraries/AP_Mount/AP_Mount_Viewpro.cpp
+++ b/libraries/AP_Mount/AP_Mount_Viewpro.cpp
@@ -573,22 +573,23 @@ bool AP_Mount_Viewpro::send_target_angles(float pitch_rad, float yaw_rad, bool y
 }
 
 // send camera command, affected image sensor and value (e.g. zoom speed)
-bool AP_Mount_Viewpro::send_camera_command(ImageSensor img_sensor, CameraCommand cmd, uint8_t value)
+bool AP_Mount_Viewpro::send_camera_command(ImageSensor img_sensor, CameraCommand cmd, uint8_t value, LRFCommand lrf_cmd)
 {
     // fill in 2 bytes containing sensor, zoom speed, operation command and LRF
     // bit0~2: sensor
     // bit3~5: zoom speed
     // bit6~12: operation command no
-    // bit13~15: LRF command (unused)
+    // bit13~15: LRF command
     const uint16_t sensor_id = (uint16_t)img_sensor;
     const uint16_t zoom_speed = ((uint16_t)value & 0x07) << 3;
     const uint16_t operation_cmd = ((uint16_t)cmd & 0x7F) << 6;
+    const uint16_t rangefinder_cmd = ((uint16_t)lrf_cmd & 0x07) << 13;
 
     // fill in packet
     const C1Packet c1_packet {
         .content = {
             frame_id: FrameId::C1,
-            sensor_zoom_cmd_be:  htobe16(sensor_id | zoom_speed | operation_cmd)
+            sensor_zoom_cmd_be:  htobe16(sensor_id | zoom_speed | operation_cmd | rangefinder_cmd)
         }
     };
 
@@ -937,6 +938,12 @@ bool AP_Mount_Viewpro::get_rangefinder_distance(float& distance_m) const
 
     distance_m = _rangefinder_dist_m;
     return true;
+}
+
+// enable/disable rangefinder.  Returns true on success
+bool AP_Mount_Viewpro::set_rangefinder_enable(bool enable)
+{
+    return send_camera_command(ImageSensor::NO_ACTION, CameraCommand::NO_ACTION, 0, enable ? LRFCommand::CONTINUOUS_RANGING_START : LRFCommand::STOP_RANGING);
 }
 
 #endif // HAL_MOUNT_VIEWPRO_ENABLED

--- a/libraries/AP_Mount/AP_Mount_Viewpro.h
+++ b/libraries/AP_Mount/AP_Mount_Viewpro.h
@@ -91,6 +91,9 @@ public:
     // get rangefinder distance.  Returns true on success
     bool get_rangefinder_distance(float& distance_m) const override;
 
+    // enable/disable rangefinder.  Returns true on success
+    bool set_rangefinder_enable(bool enable) override;
+
 protected:
 
     // get attitude as a quaternion.  returns true on success
@@ -155,6 +158,15 @@ private:
         STOP_RECORD = 0x15,
         AUTO_FOCUS = 0x19,
         MANUAL_FOCUS = 0x1A
+    };
+
+    // C1 rangefinder commands
+    enum class LRFCommand : uint8_t {
+        NO_ACTION = 0x00,
+        SINGLE_RANGING = 0x01,
+        CONTINUOUS_RANGING_START = 0x02,
+        LPCL_CONTINUOUS_RANGING_START = 0x03,
+        STOP_RANGING = 0x05
     };
 
     // C2 camera commands
@@ -347,7 +359,7 @@ private:
     bool send_target_angles(float pitch_rad, float yaw_rad, bool yaw_is_ef);
 
     // send camera command, affected image sensor and value (e.g. zoom speed)
-    bool send_camera_command(ImageSensor img_sensor, CameraCommand cmd, uint8_t value);
+    bool send_camera_command(ImageSensor img_sensor, CameraCommand cmd, uint8_t value, LRFCommand lrf_cmd = LRFCommand::NO_ACTION);
 
     // send camera command2 and corresponding value (e.g. zoom as absolute value)
     bool send_camera_command2(CameraCommand2 cmd, uint16_t value);

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -236,6 +236,7 @@ const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Values{Copter, Rover, Plane, Blimp}: 174:Camera Image Tracking
     // @Values{Copter, Rover, Plane, Blimp}: 175:Camera Lens
     // @Values{Plane}: 176:Quadplane Fwd Throttle Override enable
+    // @Values{Copter, Rover, Plane, Blimp}: 177:Mount LRF enable
     // @Values{Rover}: 201:Roll
     // @Values{Rover}: 202:Pitch
     // @Values{Rover}: 207:MainSail
@@ -665,6 +666,7 @@ void RC_Channel::init_aux_function(const AUX_FUNC ch_option, const AuxSwitchPos 
     case AUX_FUNC::LOWEHEISER_STARTER:
     case AUX_FUNC::MAG_CAL:
     case AUX_FUNC::CAMERA_IMAGE_TRACKING:
+    case AUX_FUNC::MOUNT_LRF_ENABLE:
         break;
 
     // not really aux functions:
@@ -770,6 +772,7 @@ const RC_Channel::LookupTable RC_Channel::lookuptable[] = {
     { AUX_FUNC::CAMERA_AUTO_FOCUS, "Camera Auto Focus"},
     { AUX_FUNC::CAMERA_IMAGE_TRACKING, "Camera Image Tracking"},
     { AUX_FUNC::CAMERA_LENS, "Camera Lens"},
+    { AUX_FUNC::MOUNT_LRF_ENABLE, "Mount LRF Enable"},
 };
 
 /* lookup the announcement for switch change */
@@ -1553,6 +1556,15 @@ bool RC_Channel::do_aux_function(const AUX_FUNC ch_option, const AuxSwitchPos ch
             break;
         }
         mount->set_yaw_lock(ch_flag == AuxSwitchPos::HIGH);
+        break;
+    }
+
+    case AUX_FUNC::MOUNT_LRF_ENABLE: {
+        AP_Mount *mount = AP::mount();
+        if (mount == nullptr) {
+            break;
+        }
+        mount->set_rangefinder_enable(0, ch_flag == AuxSwitchPos::HIGH);
         break;
     }
 #endif

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -249,6 +249,7 @@ public:
         CAMERA_IMAGE_TRACKING = 174, // camera image tracking
         CAMERA_LENS =        175, // camera lens selection
         VFWD_THR_OVERRIDE =  176, // force enabled VTOL forward throttle method
+        MOUNT_LRF_ENABLE =   177,  // mount LRF enable/disable
 
 
         // inputs from 200 will eventually used to replace RCMAP


### PR DESCRIPTION
This adds support for enabling/disabling the ViewPro rangefinder using an auxiliary function switch.

This has been lightly tested on real-hardware and appears to work although testing in my office is difficult because the LRF doesn't reliably read distances below about 5m.

I would like to add support for enabling/disabling using a MAVLink message but that requires more thought and coordination and this change gets one of our Partners what they most urgently need.

How to Test:

- Install firmware from this PR
- Set RC8_OPTION = 177 (Mount LRF enable)
- Reboot the autopilot
- Raise and lower the RC8 auxiliary switch and confirm that messages like, "RC8: Mount LRF Enable LOW" (or HIGH) appear
- Connect to the ViewPro camera's video output and check the OSD for the LRF distance.
- Pull the aux switch high and confirm the LRF distance changes
- Pull the aux switch low and confirm the LRF distance does not change (when the LRF is disable, the distances appear to freeze at their last good value)