### PR TITLE
SITL: correct compilation on g++-7.5.0

### DIFF
--- a/libraries/SITL/SIM_Ship.cpp
+++ b/libraries/SITL/SIM_Ship.cpp
@@ -185,8 +185,13 @@ void ShipSim::send_report(void)
         last_heartbeat_ms = now;
 
         const mavlink_heartbeat_t heartbeat{
+        custom_mode: 0,
         type : MAV_TYPE_SURFACE_BOAT,
-        autopilot : MAV_AUTOPILOT_INVALID};
+        autopilot : MAV_AUTOPILOT_INVALID,
+        base_mode: 0,
+        system_status: 0,
+        mavlink_version: 0,
+        };
 
         mavlink_message_t msg;
         mavlink_msg_heartbeat_encode_status(

--- a/libraries/SITL/SIM_Vicon.cpp
+++ b/libraries/SITL/SIM_Vicon.cpp
@@ -50,8 +50,12 @@ void Vicon::maybe_send_heartbeat()
     last_heartbeat_ms = now;
 
     const mavlink_heartbeat_t heartbeat{
-    type : MAV_TYPE_GCS,
-    autopilot : MAV_AUTOPILOT_INVALID,
+        custom_mode: 0,
+        type : MAV_TYPE_GCS,
+        autopilot : MAV_AUTOPILOT_INVALID,
+        base_mode: 0,
+        system_status: 0,
+        mavlink_version: 0,
     };
 
     mavlink_msg_heartbeat_encode_status(


### PR DESCRIPTION
autotest still uses 7.5.0 for x86-64 builds

```.cpp: In member function void SITL::ShipSim::send_report(): BB-WAF: /mnt/volume_nyc3_01/autotest/APM/APM/libraries/SITL/SIM_Ship.cpp:189:42: sorry, unimplemented: non-trivial designated initializers not supported
BB-WAF:          autopilot : MAV_AUTOPILOT_INVALID};
BB-WAF:                                           ^
BB-WAF: compilation terminated due to -Wfatal-errors.
BB-WAF:
BB-WAF: Waf: Leaving directory `/home/autotest/build/tmp/binaries.build/SITL_x86_64_linux_gnu
```

Tested on a bionic64 VM.
