### PR TITLE
Copter/Rover: allow target position on track to stop advancing

### DIFF
--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -482,7 +482,7 @@ bool AC_WPNav::advance_wp_target_along_track(float dt)
         const float track_error = _pos_control.get_pos_error_cm().dot(track_direction);
         const float track_velocity = _inav.get_velocity_neu_cms().dot(track_direction);
         // set time scaler to be consistent with the achievable aircraft speed with a 5% buffer for short term variation.
-        track_scaler_dt = constrain_float(0.05f + (track_velocity - _pos_control.get_pos_xy_p().kP() * track_error) / curr_target_vel.length(), 0.1f, 1.0f);
+        track_scaler_dt = constrain_float(0.05f + (track_velocity - _pos_control.get_pos_xy_p().kP() * track_error) / curr_target_vel.length(), 0.0f, 1.0f);
     }
 
     // Use vel_scaler_dt to slow down the trajectory time

--- a/libraries/AR_WPNav/AR_WPNav.cpp
+++ b/libraries/AR_WPNav/AR_WPNav.cpp
@@ -426,7 +426,7 @@ void AR_WPNav::advance_wp_target_along_track(const Location &current_loc, float 
         float track_velocity = curr_vel_NED.xy().dot(track_direction);
         // set time scaler to be consistent with the achievable vehicle speed with a 5% buffer for short term variation.
         const float time_scaler_dt_max = _overspeed_enabled ? AR_WPNAV_OVERSPEED_RATIO_MAX : 1.0f;
-        track_scaler_dt = constrain_float(0.05f + (track_velocity - _pos_control.get_pos_p().kP() * track_error) / curr_target_vel.length(), 0.1f, time_scaler_dt_max);
+        track_scaler_dt = constrain_float(0.05f + (track_velocity - _pos_control.get_pos_p().kP() * track_error) / curr_target_vel.length(), 0.0f, time_scaler_dt_max);
     }
     // change s-curve time speed with a time constant of maximum acceleration / maximum jerk
     float track_scaler_tc = 1.0f;


### PR DESCRIPTION
This PR resolves issue https://github.com/ArduPilot/ardupilot/issues/26519 in which, given enough time, a waypoint is "completed" even though the vehicle never got close to it.

The fix is to remove the constraint on the minimum size of the "track_scaler_dt".  This variables controls how quickly the target point may advance along the track and is used to be sure that the target never gets too far ahead of the vehicle.

This has been tested in SITL for both Copter and Rover and no ill effects were observed.  The testing included:

1. creating a square mission
2. increasing the SIM_WIND_SPD or SIM_TIDE_SPEED so that the vehicle could make almost no progress
3. ran the above mission with and without these changes to confirm that **without these changes** some waypoints would be completed with the vehicle far from them and **with these changes** the waypoints were only completed once the vehicle got close.

For Copter both regular waypoints and spline waypoints were tested.

Just for fun, below is a picture from SITL of a boat fighting its way towards a waypoint in a very strong current.
![image](https://github.com/ArduPilot/ardupilot/assets/1498098/664636c0-a034-4e13-8d20-0a92dd7ea7aa)
