### PR TITLE
Tools: --sitl is not valid to param_parse.py

### DIFF
--- a/Tools/scripts/build_parameters.sh
+++ b/Tools/scripts/build_parameters.sh
@@ -44,7 +44,7 @@ generate_sitl_parameters() {
     VEHICLE="ArduCopter"
 
     # generate Parameters.html, Parameters.rst etc etc:
-    ./Tools/autotest/param_metadata/param_parse.py --sitl --vehicle $VEHICLE
+    ./Tools/autotest/param_metadata/param_parse.py --vehicle $VEHICLE
 
     # stash some of the results away:
     VEHICLE_PARAMS_DIR="$PARAMS_DIR/SITL"


### PR DESCRIPTION
noticed on build server

![image](https://github.com/ArduPilot/ardupilot/assets/831867/8705de09-2ce2-4d69-96ef-ad91fc8756d4)
