### PR TITLE
Tools: build_parameters: stop using --sitl option

### DIFF
--- a/Tools/scripts/build_parameters.sh
+++ b/Tools/scripts/build_parameters.sh
@@ -40,26 +40,6 @@ generate_parameters() {
     fi
 }
 
-generate_sitl_parameters() {
-    VEHICLE="ArduCopter"
-
-    # generate Parameters.html, Parameters.rst etc etc:
-    ./Tools/autotest/param_metadata/param_parse.py --sitl --vehicle $VEHICLE
-
-    # stash some of the results away:
-    VEHICLE_PARAMS_DIR="$PARAMS_DIR/SITL"
-    mkdir -p "$VEHICLE_PARAMS_DIR"
-    /bin/cp Parameters.html *.pdef.xml "$VEHICLE_PARAMS_DIR/"
-    gzip -9 <"$VEHICLE_PARAMS_DIR"/apm.pdef.xml >"$VEHICLE_PARAMS_DIR"/apm.pdef.xml.gz.new && mv "$VEHICLE_PARAMS_DIR"/apm.pdef.xml.gz.new "$VEHICLE_PARAMS_DIR"/apm.pdef.xml.gz
-    xz -e <"$VEHICLE_PARAMS_DIR"/apm.pdef.xml >"$VEHICLE_PARAMS_DIR"/apm.pdef.xml.xz.new && mv "$VEHICLE_PARAMS_DIR"/apm.pdef.xml.xz.new "$VEHICLE_PARAMS_DIR"/apm.pdef.xml.xz
-    if [ -e "Parameters.rst" ]; then
-	/bin/cp Parameters.rst "$VEHICLE_PARAMS_DIR/"
-    fi
-    if [ -e "ParametersLatex.rst" ]; then
-    /bin/cp ParametersLatex.rst "$VEHICLE_PARAMS_DIR/"
-    fi
-}
-
 generate_parameters ArduPlane
 
 generate_parameters ArduCopter
@@ -73,5 +53,3 @@ generate_parameters AntennaTracker
 generate_parameters AP_Periph
 
 generate_parameters Blimp
-
-generate_sitl_parameters


### PR DESCRIPTION
this option was removed because we now mix the SIM parameters in with everything else.


alternative to https://github.com/ArduPilot/ardupilot/pull/26522
