### PR TITLE
autotest: use speedup parameter default for speedup, not command-line option

### DIFF
--- a/Tools/autotest/fakepos.py
+++ b/Tools/autotest/fakepos.py
@@ -36,22 +36,6 @@ class udp_out(object):
             pass
 
 
-def ft2m(x):
-    return x * 0.3048
-
-
-def m2ft(x):
-    return x / 0.3048
-
-
-def kt2mps(x):
-    return x * 0.514444444
-
-
-def mps2kt(x):
-    return x / 0.514444444
-
-
 udp = udp_out("127.0.0.1:5501")
 
 latitude = -35

--- a/Tools/autotest/pysim/fg_display.py
+++ b/Tools/autotest/pysim/fg_display.py
@@ -44,21 +44,6 @@ class udp_socket(object):
             pass
 
 
-def ft2m(x):
-    return x * 0.3048
-
-
-def m2ft(x):
-    return x / 0.3048
-
-
-def kt2mps(x):
-    return x * 0.514444444
-
-
-def mps2kt(x):
-    return x / 0.514444444
-
 udp = udp_socket("127.0.0.1:5123")
 fgout = udp_socket("127.0.0.1:5124", is_input=False)
 

--- a/Tools/autotest/pysim/util.py
+++ b/Tools/autotest/pysim/util.py
@@ -29,24 +29,6 @@ RADIUS_OF_EARTH = 6378100.0  # in meters
 windowID = []
 
 
-def m2ft(x):
-    """Meters to feet."""
-    return float(x) / 0.3048
-
-
-def ft2m(x):
-    """Feet to meters."""
-    return float(x) * 0.3048
-
-
-def kt2mps(x):
-    return x * 0.514444444
-
-
-def mps2kt(x):
-    return x / 0.514444444
-
-
 def topdir():
     """Return top of git tree where autotest is running from."""
     d = os.path.dirname(os.path.realpath(__file__))

--- a/Tools/autotest/pysim/util.py
+++ b/Tools/autotest/pysim/util.py
@@ -421,7 +421,7 @@ def start_SITL(binary,
                model=None,
                speedup=1,
                sim_rate_hz=None,
-               defaults_filepath=None,
+               defaults_filepath=[],
                unhide_parameters=False,
                gdbserver=False,
                breakpoints=[],
@@ -506,6 +506,13 @@ def start_SITL(binary,
             raise RuntimeError("DISPLAY was not set")
 
     cmd.append(binary)
+
+    if defaults_filepath is None:
+        defaults_filepath = []
+    if not isinstance(defaults_filepath, list):
+        defaults_filepath = [defaults_filepath]
+    defaults = [reltopdir(path) for path in defaults_filepath]
+
     if not supplementary:
         if wipe:
             cmd.append('-w')
@@ -515,7 +522,12 @@ def start_SITL(binary,
             cmd.extend(['--home', home])
         cmd.extend(['--model', model])
         if speedup is not None and speedup != 1:
-            cmd.extend(['--speedup', str(speedup)])
+            ntf = tempfile.NamedTemporaryFile(mode="w", delete=False)
+            print(f"SIM_SPEEDUP {speedup}", file=ntf)
+            ntf.close()
+            # prepend it so that a caller can override the speedup in
+            # passed-in defaults:
+            defaults = [ntf.name] + defaults
         if sim_rate_hz is not None:
             cmd.extend(['--rate', str(sim_rate_hz)])
         if unhide_parameters:
@@ -525,13 +537,8 @@ def start_SITL(binary,
         if enable_fgview_output:
             cmd.append("--enable-fgview")
 
-    if defaults_filepath is not None:
-        if isinstance(defaults_filepath, list):
-            defaults = [reltopdir(path) for path in defaults_filepath]
-            if len(defaults):
-                cmd.extend(['--defaults', ",".join(defaults)])
-        else:
-            cmd.extend(['--defaults', reltopdir(defaults_filepath)])
+    if len(defaults):
+        cmd.extend(['--defaults', ",".join(defaults)])
 
     cmd.extend(customisations)
 


### PR DESCRIPTION
A replacement for (the merged) https://github.com/ArduPilot/ardupilot/pull/26471

thee ArduPilot SITL binary *must* honour the `--speedup` parameter above the initial value of the `SIM_SPEEDUP` parameter, so any time we `reboot_sitl()` the speedup goes back to the command-line option value.  tridge worked around that in his PR by setting the speedup after reboot in several tests where it really matters that we get the right speedup.

This PR, instead, stops the autotest suite from setting the `--speedup` command-line option, instead relying on setting the `SIM_SPEEDUP` parameter to accomplish speedup.

I have not reverted the changes made in that other PR, but it should be reasonable to do so after this.
