### PR TITLE
MAVLink: log Tx and Rx data rates, SITL: add `@SYS/uarts.txt` and improve rate limiting

### DIFF
--- a/libraries/AP_HAL/UARTDriver.cpp
+++ b/libraries/AP_HAL/UARTDriver.cpp
@@ -163,3 +163,13 @@ uint64_t AP_HAL::UARTDriver::receive_time_constraint_us(uint16_t nbytes)
 {
     return AP_HAL::micros64();
 }
+
+#if HAL_UART_STATS_ENABLED
+// Take cumulative bytes and return the change since last call
+uint32_t AP_HAL::UARTDriver::StatsTracker::ByteTracker::update(uint32_t bytes)
+{
+    const uint32_t change = bytes - last_bytes;
+    last_bytes = bytes;
+    return change;
+}
+#endif

--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -152,8 +152,21 @@ public:
     virtual bool is_dma_enabled() const { return false; }
 
 #if HAL_UART_STATS_ENABLED
+    // Helper to keep track of data usage since last call
+    struct StatsTracker {
+        class ByteTracker {
+        public:
+            // Take cumulative bytes and return the change since last call
+            uint32_t update(uint32_t bytes);
+        private:
+            uint32_t last_bytes;
+        };
+        ByteTracker tx;
+        ByteTracker rx;
+    };
+
     // request information on uart I/O for this uart, for @SYS/uarts.txt
-    virtual void uart_info(ExpandingString &str) {}
+    virtual void uart_info(ExpandingString &str, StatsTracker &stats, const uint32_t dt_ms) {}
 #endif
 
     /*

--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -167,6 +167,10 @@ public:
 
     // request information on uart I/O for this uart, for @SYS/uarts.txt
     virtual void uart_info(ExpandingString &str, StatsTracker &stats, const uint32_t dt_ms) {}
+
+    // Getters for cumulative tx and rx counts
+    virtual uint32_t get_tx_bytes() const { return 0; }
+    virtual uint32_t get_rx_bytes() const { return 0; }
 #endif
 
     /*

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -1696,9 +1696,11 @@ uint16_t UARTDriver::get_options(void) const
 
 #if HAL_UART_STATS_ENABLED
 // request information on uart I/O for @SYS/uarts.txt for this uart
-void UARTDriver::uart_info(ExpandingString &str)
+void UARTDriver::uart_info(ExpandingString &str, StatsTracker &stats, const uint32_t dt_ms)
 {
-    uint32_t now_ms = AP_HAL::millis();
+    const uint32_t tx_bytes = stats.tx.update(_tx_stats_bytes);
+    const uint32_t rx_bytes = stats.rx.update(_rx_stats_bytes);
+
     if (sdef.is_usb) {
         str.printf("OTG%u  ", unsigned(sdef.instance));
     } else {
@@ -1706,14 +1708,11 @@ void UARTDriver::uart_info(ExpandingString &str)
     }
     str.printf("TX%c=%8u RX%c=%8u TXBD=%6u RXBD=%6u\n",
                tx_dma_enabled ? '*' : ' ',
-               unsigned(_tx_stats_bytes),
+               unsigned(tx_bytes),
                rx_dma_enabled ? '*' : ' ',
-               unsigned(_rx_stats_bytes),
-               unsigned(_tx_stats_bytes * 10000 / (now_ms - _last_stats_ms)),
-               unsigned(_rx_stats_bytes * 10000 / (now_ms - _last_stats_ms)));
-    _tx_stats_bytes = 0;
-    _rx_stats_bytes = 0;
-    _last_stats_ms = now_ms;
+               unsigned(rx_bytes),
+               unsigned((tx_bytes * 1000) / dt_ms),
+               unsigned((rx_bytes * 1000) / dt_ms));
 }
 #endif
 

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -1714,6 +1714,17 @@ void UARTDriver::uart_info(ExpandingString &str, StatsTracker &stats, const uint
                unsigned((tx_bytes * 1000) / dt_ms),
                unsigned((rx_bytes * 1000) / dt_ms));
 }
+
+// Getters for cumulative tx and rx counts
+uint32_t UARTDriver::get_tx_bytes() const
+{
+    return _tx_stats_bytes;
+}
+
+uint32_t UARTDriver::get_rx_bytes() const
+{
+    return _rx_stats_bytes;
+}
 #endif
 
 /*

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -123,7 +123,7 @@ public:
 
 #if HAL_UART_STATS_ENABLED
     // request information on uart I/O for one uart
-    void uart_info(ExpandingString &str) override;
+    void uart_info(ExpandingString &str, StatsTracker &stats, const uint32_t dt_ms) override;
 #endif
 
     /*
@@ -209,7 +209,6 @@ private:
     // statistics
     uint32_t _tx_stats_bytes;
     uint32_t _rx_stats_bytes;
-    uint32_t _last_stats_ms;
 
     // we remember config options from set_options to apply on sdStart()
     uint32_t _cr1_options;

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -124,6 +124,10 @@ public:
 #if HAL_UART_STATS_ENABLED
     // request information on uart I/O for one uart
     void uart_info(ExpandingString &str, StatsTracker &stats, const uint32_t dt_ms) override;
+
+    // Getters for cumulative tx and rx counts
+    uint32_t get_tx_bytes() const override;
+    uint32_t get_rx_bytes() const override;
 #endif
 
     /*

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -682,18 +682,23 @@ extern ChibiOS::UARTDriver uart_io;
 // request information on uart I/O
 void Util::uart_info(ExpandingString &str)
 {
+    // Calculate time since last call
+    const uint32_t now_ms = AP_HAL::millis();
+    const uint32_t dt_ms = now_ms - uart_stats.last_ms;
+    uart_stats.last_ms = now_ms;
+
     // a header to allow for machine parsers to determine format
     str.printf("UARTV1\n");
     for (uint8_t i = 0; i < HAL_UART_NUM_SERIAL_PORTS; i++) {
         auto *uart = hal.serial(i);
         if (uart) {
             str.printf("SERIAL%u ", i);
-            uart->uart_info(str);
+            uart->uart_info(str, uart_stats.serial[i], dt_ms);
         }
     }
 #if HAL_WITH_IO_MCU
     str.printf("IOMCU   ");
-    uart_io.uart_info(str);
+    uart_io.uart_info(str, uart_stats.io, dt_ms);
 #endif
 }
 #endif

--- a/libraries/AP_HAL_ChibiOS/Util.h
+++ b/libraries/AP_HAL_ChibiOS/Util.h
@@ -98,7 +98,7 @@ public:
 #endif
 #if HAL_UART_STATS_ENABLED
     // request information on uart I/O
-    virtual void uart_info(ExpandingString &str) override;
+    void uart_info(ExpandingString &str) override;
 #endif
 #if HAL_USE_PWM == TRUE
     void timer_info(ExpandingString &str) override;
@@ -160,5 +160,15 @@ private:
 
 #if HAL_ENABLE_DFU_BOOT
     void boot_to_dfu() override;
+#endif
+
+#if HAL_UART_STATS_ENABLED
+    struct {
+        AP_HAL::UARTDriver::StatsTracker serial[HAL_UART_NUM_SERIAL_PORTS];
+#if HAL_WITH_IO_MCU
+        AP_HAL::UARTDriver::StatsTracker io;
+#endif
+        uint32_t last_ms;
+    } uart_stats;
 #endif
 };

--- a/libraries/AP_HAL_Empty/UARTDriver.cpp
+++ b/libraries/AP_HAL_Empty/UARTDriver.cpp
@@ -24,7 +24,7 @@ ssize_t Empty::UARTDriver::_read(uint8_t *buffer, uint16_t size)
 }
 
 #if HAL_UART_STATS_ENABLED
-void Empty::UARTDriver::uart_info(ExpandingString &str)
+void Empty::UARTDriver::uart_info(ExpandingString &str, StatsTracker &stats, const uint32_t dt_ms)
 {
     str.printf("EMPTY\n");
 }

--- a/libraries/AP_HAL_Empty/UARTDriver.h
+++ b/libraries/AP_HAL_Empty/UARTDriver.h
@@ -15,7 +15,7 @@ public:
 
 #if HAL_UART_STATS_ENABLED
     // request information on uart I/O for one uart
-    void uart_info(ExpandingString &str) override;
+    void uart_info(ExpandingString &str, StatsTracker &stats, const uint32_t dt_ms) override;
 #endif
 
 protected:

--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -1015,8 +1015,13 @@ ssize_t UARTDriver::get_system_outqueue_length() const
 
 uint32_t UARTDriver::bw_in_bytes_per_second() const
 {
-    // if connected, assume at least a 10/100Mbps connection
-    const uint32_t bitrate = _connected ? 10E6 : _uart_baudrate;
+    // if connected, assume at least a 10/100Mbps connection if not limited
+    bool baud_limit = false;
+#if !defined(HAL_BUILD_AP_PERIPH)
+    SITL::SIM *_sitl = AP::sitl();
+    baud_limit = (_sitl != nullptr) && _sitl->telem_baudlimit_enable;
+#endif
+    const uint32_t bitrate = (_connected && !baud_limit) ? 10E6 : _uart_baudrate;
     return bitrate/10; // convert bits to bytes minus overhead
 };
 

--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -46,6 +46,7 @@
 
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 #include <AP_Filesystem/AP_Filesystem.h>
+#include <AP_Common/ExpandingString.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -227,7 +228,9 @@ uint32_t UARTDriver::txspace(void)
 
 ssize_t UARTDriver::_read(uint8_t *buffer, uint16_t count)
 {
-    return _readbuffer.read(buffer, count);
+    const ssize_t ret = _readbuffer.read(buffer, count);
+    _rx_stats_bytes += ret;
+    return ret;
 }
 
 bool UARTDriver::_discard_input(void)
@@ -284,6 +287,8 @@ size_t UARTDriver::_write(const uint8_t *buffer, size_t size)
         }
 #endif // HAL_BUILD_AP_PERIPH
 
+    // Include lost byte in tx count, we think we sent it even though it was never added to the write buffer
+    _tx_stats_bytes += lost_byte;
 
     const size_t ret = _writebuffer.write(buffer, size - lost_byte) + lost_byte;
     if (_unbuffered_writes) {
@@ -834,6 +839,7 @@ void UARTDriver::handle_writing_from_writebuffer_to_device()
             ssize_t ret = send(_fd, tmpbuf, n, MSG_DONTWAIT);
             if (ret > 0) {
                 _writebuffer.advance(ret);
+                _tx_stats_bytes += ret;
             }
         }
     } else {
@@ -855,6 +861,7 @@ void UARTDriver::handle_writing_from_writebuffer_to_device()
             }
             if (nwritten > 0) {
                 _writebuffer.advance(nwritten);
+                _tx_stats_bytes += nwritten;
             }
         }
     }
@@ -1012,5 +1019,23 @@ uint32_t UARTDriver::bw_in_bytes_per_second() const
     const uint32_t bitrate = _connected ? 10E6 : _uart_baudrate;
     return bitrate/10; // convert bits to bytes minus overhead
 };
+
+#if HAL_UART_STATS_ENABLED
+// request information on uart I/O for @SYS/uarts.txt for this uart
+void UARTDriver::uart_info(ExpandingString &str, StatsTracker &stats, const uint32_t dt_ms)
+{
+    const uint32_t tx_bytes = stats.tx.update(_tx_stats_bytes);
+    const uint32_t rx_bytes = stats.rx.update(_rx_stats_bytes);
+
+    str.printf("TX=%8u RX=%8u TXBD=%6u RXBD=%6u %s (%s)\n",
+                unsigned(tx_bytes),
+                unsigned(rx_bytes),
+                unsigned((tx_bytes * 1000) / dt_ms),
+                unsigned((rx_bytes * 1000) / dt_ms),
+                _connected ? "connected    " : "not connected",
+                _sitlState->_serial_path[_portNumber]);
+}
+#endif
+
 #endif // CONFIG_HAL_BOARD
 

--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -1040,6 +1040,17 @@ void UARTDriver::uart_info(ExpandingString &str, StatsTracker &stats, const uint
                 _connected ? "connected    " : "not connected",
                 _sitlState->_serial_path[_portNumber]);
 }
+
+// Getters for cumulative tx and rx counts
+uint32_t UARTDriver::get_tx_bytes() const
+{
+    return _tx_stats_bytes;
+}
+
+uint32_t UARTDriver::get_rx_bytes() const
+{
+    return _rx_stats_bytes;
+}
 #endif
 
 #endif // CONFIG_HAL_BOARD

--- a/libraries/AP_HAL_SITL/UARTDriver.h
+++ b/libraries/AP_HAL_SITL/UARTDriver.h
@@ -67,6 +67,11 @@ public:
 
     uint32_t get_baud_rate() const override { return _uart_baudrate; }
 
+#if HAL_UART_STATS_ENABLED
+    // request information on uart I/O
+    void uart_info(ExpandingString &str, StatsTracker &stats, const uint32_t dt_ms) override;
+#endif
+
 private:
 
     int _fd;
@@ -143,6 +148,10 @@ protected:
 private:
     void handle_writing_from_writebuffer_to_device();
     void handle_reading_from_device_to_readbuffer();
+
+    // statistics
+    uint32_t _tx_stats_bytes;
+    uint32_t _rx_stats_bytes;
 };
 
 #endif

--- a/libraries/AP_HAL_SITL/UARTDriver.h
+++ b/libraries/AP_HAL_SITL/UARTDriver.h
@@ -70,6 +70,10 @@ public:
 #if HAL_UART_STATS_ENABLED
     // request information on uart I/O
     void uart_info(ExpandingString &str, StatsTracker &stats, const uint32_t dt_ms) override;
+
+    // Getters for cumulative tx and rx counts
+    uint32_t get_tx_bytes() const override;
+    uint32_t get_rx_bytes() const override;
 #endif
 
 private:

--- a/libraries/AP_HAL_SITL/UARTDriver.h
+++ b/libraries/AP_HAL_SITL/UARTDriver.h
@@ -117,8 +117,17 @@ private:
     uint16_t _mc_myport;
 
     // for baud-rate limiting:
-    uint32_t last_read_tick_us;
-    uint32_t last_write_tick_us;
+    class ApplyBaudLimit {
+    public:
+        uint32_t max_bytes(const uint32_t baudrate);
+    private:
+        uint32_t last_us;
+        float remainder;
+    };
+    struct {
+        ApplyBaudLimit write;
+        ApplyBaudLimit read;
+    } baud_limits;
 
     HAL_Semaphore write_mtx;
 

--- a/libraries/AP_HAL_SITL/Util.h
+++ b/libraries/AP_HAL_SITL/Util.h
@@ -106,4 +106,18 @@ private:
 
     int saved_argc;
     char *const *saved_argv;
+
+#if HAL_UART_STATS_ENABLED
+    // request information on uart I/O
+    void uart_info(ExpandingString &str) override;
+#endif
+
+private:
+#if HAL_UART_STATS_ENABLED
+    // UART stats tracking helper
+    struct {
+        AP_HAL::UARTDriver::StatsTracker serial[AP_HAL::HAL::num_serial];
+        uint32_t last_ms;
+    } uart_stats;
+#endif
 };

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -48,6 +48,7 @@ const struct UnitStructure log_Units[] = {
     { 'a', "Ah" },            // Ampere hours
     { 'd', "deg" },           // of the angular variety, -180 to 180
     { 'b', "B" },             // bytes
+    { 'B', "B/s" },           // bytes per second
     { 'k', "deg/s" },         // degrees per second. Degrees are NOT SI, but is some situations more user-friendly than radians
     { 'D', "deglatitude" },   // degrees of latitude
     { 'e', "deg/s/s" },       // degrees per second per second. Degrees are NOT SI, but is some situations more user-friendly than radians

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -311,6 +311,8 @@ struct PACKED log_MAV {
     uint8_t flags;
     uint16_t stream_slowdown_ms;
     uint16_t times_full;
+    float tx_rate;
+    float rx_rate;
 };
 
 struct PACKED log_RSSI {
@@ -832,6 +834,8 @@ struct PACKED log_VER {
 // @FieldBitmaskEnum: flags: GCS_MAVLINK::Flags
 // @Field: ss: stream slowdown is the number of ms being added to each message to fit within bandwidth
 // @Field: tf: times buffer was full when a message was going to be sent
+// @Field: tx: transmitted data rate bytes per second
+// @Field: rx: received data rate bytes per second
 
 // @LoggerMessage: MAVC
 // @Description: MAVLink command we have just executed
@@ -1278,7 +1282,7 @@ LOG_STRUCTURE_FROM_FENCE \
     { LOG_RALLY_MSG, sizeof(log_Rally), \
       "RALY", "QBBLLhB", "TimeUS,Tot,Seq,Lat,Lng,Alt,Flags", "s--DUm-", "F--GGB-" },  \
     { LOG_MAV_MSG, sizeof(log_MAV),   \
-      "MAV", "QBHHHBHH",   "TimeUS,chan,txp,rxp,rxdp,flags,ss,tf", "s#----s-", "F-000-C-" },   \
+      "MAV", "QBHHHBHHff",   "TimeUS,chan,txp,rxp,rxdp,flags,ss,tf,tx,rx", "s#----s-BB", "F-000-C---" },   \
 LOG_STRUCTURE_FROM_VISUALODOM \
     { LOG_OPTFLOW_MSG, sizeof(log_Optflow), \
       "OF",   "QBffff",   "TimeUS,Qual,flowX,flowY,bodyX,bodyY", "s-EEnn", "F-0000" , true }, \

--- a/libraries/AP_Logger/README.md
+++ b/libraries/AP_Logger/README.md
@@ -46,6 +46,7 @@ Please keep the names consistent with Tools/autotest/param_metadata/param.py:33
 | 'A' | "A" | Ampere|
 | 'd' | "deg" | of the angular variety | -180 to 180|
 | 'b' | "B" | bytes|
+| 'B' | "B/s" | bytes per second |
 | 'k' | "deg/s" | degrees per second | Not an SI unit, but in some situations more user-friendly than radians per second|
 | 'D' | "deglatitude" | degrees of latitude|
 | 'e' | "deg/s/s" | degrees per second per second | Not an SI unit, but in some situations more user-friendly than radians per second^2|

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -775,6 +775,9 @@ private:
         LOCKED = (1<<4),
     };
     void log_mavlink_stats();
+#if HAL_UART_STATS_ENABLED
+    AP_HAL::UARTDriver::StatsTracker serial_stats;
+#endif
 
     MAV_RESULT _set_mode_common(const MAV_MODE base_mode, const uint32_t custom_mode);
 


### PR DESCRIPTION
This includes a number of improvements around monitoring and testing of uart data rates. 

- New `StatsTracker` class is added to make calculating the bytes since last call easy. This means that the uart driver can just keep a cumulative total which means we can use that total in different places over different time periods.
- HAL getters added for the cumulative bytes. 
- byte tracking added to SITL along with `uart_info` resulting in `@SYS/uarts.txt`:
```
UARTV1
SERIAL0 TX=  142379 RX=    2155 TXBD=  4856 RXBD=    73 connected     (tcp:0:wait)
SERIAL1 TX=       0 RX=       0 TXBD=     0 RXBD=     0 not connected (tcp:2)
SERIAL2 TX=       0 RX=       0 TXBD=     0 RXBD=     0 not connected (tcp:3)
SERIAL3 TX=    1929 RX=   62622 TXBD=    65 RXBD=  2135 connected     (GPS1)
SERIAL4 TX=       0 RX=       0 TXBD=     0 RXBD=     0 connected     (GPS2)
SERIAL5 TX=       0 RX=       0 TXBD=     0 RXBD=     0 not connected (tcp:5)
SERIAL6 TX=       0 RX=       0 TXBD=     0 RXBD=     0 not connected (tcp:6)
SERIAL7 TX=       0 RX=       0 TXBD=     0 RXBD=     0 not connected (tcp:7)
SERIAL8 TX=       0 RX=       0 TXBD=     0 RXBD=     0 not connected (tcp:8)
```

- New logging unit added for bytes per second using `B`
- MAVLink connections report transmit and received data rate in the `MAV` log message.
- SITL baud rate limits made more accurate.

MAV example log from SITL with improved baud limits set to 57600 baud. This results in the expected rate of 5760 bytes per second.
![image](https://github.com/ArduPilot/ardupilot/assets/33176108/7df1a43f-7b1b-48df-9959-02570855e5cb)
