### PR TITLE
HAL_ChibiOS: fixed a cache corruption issue on H7

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/malloc.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/malloc.c
@@ -635,7 +635,7 @@ bool mem_is_dma_safe(const void *addr, uint32_t size, bool filesystem_op)
         // use bouncebuffer for all non FS ops on H7
         return false;
     }
-    if (((uint32_t)addr) & 0x1F) {
+    if ((((uint32_t)addr) & 0x1F) != 0 || (size & 0x1F) != 0) {
         return false;
     }
     if (filesystem_op) {


### PR DESCRIPTION
This fixes a bug introduced in this PR:

https://github.com/ArduPilot/ardupilot/pull/25900

the bug is that when we don't go via the bouncebuffer on H7 we were also skipping the cache invalidate/flush ops. This caused data corruption for filesystem operations, particularly noticible as lua scripts failing to load with parse errors or log corruption