### PR TITLE
Correct Periph compilation if Check Firmware is not enabled

### DIFF
--- a/Tools/AP_Periph/AP_Periph.cpp
+++ b/Tools/AP_Periph/AP_Periph.cpp
@@ -127,7 +127,9 @@ void AP_Periph_FW::init()
     logger.init(g.log_bitmask, log_structure, ARRAY_SIZE(log_structure));
 #endif
 
+#if AP_CHECK_FIRMWARE_ENABLED
     check_firmware_print();
+#endif
 
     if (hal.util->was_watchdog_reset()) {
         printf("Reboot after watchdog reset\n");

--- a/Tools/AP_Periph/AP_Periph.h
+++ b/Tools/AP_Periph/AP_Periph.h
@@ -113,10 +113,13 @@
 void stm32_watchdog_init();
 void stm32_watchdog_pat();
 #endif
+
+#if AP_CHECK_FIRMWARE_ENABLED
 /*
   app descriptor for firmware checking
  */
 extern const app_descriptor_t app_descriptor;
+#endif
 
 extern "C" {
     void can_vprintf(uint8_t severity, const char *fmt, va_list arg);

--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -194,10 +194,12 @@ void AP_Periph_FW::handle_get_node_info(CanardInstance* canard_instance,
     pkt.software_version.major = AP::fwversion().major;
     pkt.software_version.minor = AP::fwversion().minor;
     pkt.software_version.optional_field_flags = UAVCAN_PROTOCOL_SOFTWAREVERSION_OPTIONAL_FIELD_FLAG_VCS_COMMIT | UAVCAN_PROTOCOL_SOFTWAREVERSION_OPTIONAL_FIELD_FLAG_IMAGE_CRC;
+#if AP_CHECK_FIRMWARE_ENABLED
     pkt.software_version.vcs_commit = app_descriptor.git_hash;
     uint32_t *crc = (uint32_t *)&pkt.software_version.image_crc;
     crc[0] = app_descriptor.image_crc1;
     crc[1] = app_descriptor.image_crc2;
+#endif
 
     readUniqueID(pkt.hardware_version.unique_id);
 

--- a/libraries/AP_HAL_ChibiOS/Scheduler.cpp
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.cpp
@@ -42,6 +42,7 @@
 #if CH_CFG_USE_DYNAMIC == TRUE
 
 #include <AP_Logger/AP_Logger.h>
+#include <AP_Math/AP_Math.h>
 #include <AP_Scheduler/AP_Scheduler.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include "hwdef/common/stm32_util.h"

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/defaults_periph.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/defaults_periph.h
@@ -449,3 +449,9 @@
 #ifndef AP_CUSTOMROTATIONS_ENABLED
 #define AP_CUSTOMROTATIONS_ENABLED 0
 #endif
+
+// it is important to enable this on peripherals, or it is too easy to
+// brick AP_Periphs with a bad flash.
+#ifndef AP_CHECK_FIRMWARE_ENABLED
+#define AP_CHECK_FIRMWARE_ENABLED 1
+#endif


### PR DESCRIPTION
```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                                                     
Durandal                            *      *           *       *                 *      *      *
Hitec-Airspeed           *                                                                     
KakuteH7-bdshot                     *      *           *       *                 *      *      *
MatekF405                           *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *                  *       *                 *      *      *
f103-QiotekPeriph        *                                                                     
f303-Universal           *                                                                     
iomcu                                                                *                         
revo-mini                           *      *           *       *                 *      *      *
skyviper-v2450                                         *                                       
```

app_descriptor is guarded behing AP_CHECK_FIRMWARE_ENABLED, and that's only enabled by default when AP_OPENDRONEID_ENABLED is true.

Given the app descriptor seems to contain useful information useful in places where  AP_OPENDRONEID_ENABLED is false, this is maybe a bit unfortunate.
