### PR TITLE
Stop creating firmware version objects in GCS_Dummy

### DIFF
--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -27,6 +27,8 @@
 #include <AP_Filesystem/posix_compat.h>
 #include <AP_AdvancedFailsafe/AP_AdvancedFailsafe.h>
 
+#include <AP_Common/ExampleFirmwareVersion.h>
+
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
 #include <AP_HAL_Linux/Scheduler.h>
 #endif

--- a/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.cpp
+++ b/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.cpp
@@ -13,6 +13,8 @@
 #include <AP_ExternalAHRS/AP_ExternalAHRS.h>
 #include <AP_Vehicle/AP_Vehicle.h>
 
+#include <AP_Common/ExampleFirmwareVersion.h>
+
 void setup();
 void loop();
 

--- a/libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp
+++ b/libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp
@@ -24,6 +24,8 @@
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <GCS_MAVLink/GCS_Dummy.h>
 
+#include <AP_Common/ExampleFirmwareVersion.h>
+
 void setup();
 void loop();
 

--- a/libraries/AP_Baro/examples/BARO_generic/BARO_generic.cpp
+++ b/libraries/AP_Baro/examples/BARO_generic/BARO_generic.cpp
@@ -23,6 +23,7 @@
 #include <GCS_MAVLink/GCS_Dummy.h>
 #include <AP_ExternalAHRS/AP_ExternalAHRS.h>
 
+#include <AP_Common/ExampleFirmwareVersion.h>
 
 const AP_HAL::HAL &hal = AP_HAL::get_HAL();
 

--- a/libraries/AP_Common/ExampleFirmwareVersion.h
+++ b/libraries/AP_Common/ExampleFirmwareVersion.h
@@ -1,0 +1,26 @@
+#pragma once
+
+/*
+ this is a file intended to be included by examples and other tools
+ which need to make the firmware version defines but really don't
+ care how that is done.
+
+ it is intended to be included in a .cpp file, never transitively, as
+ it does create objects.
+*/
+
+#define THISFIRMWARE "GCSDummy V3.1.4-dev"
+
+#define FW_MAJOR 3
+#define FW_MINOR 1
+#define FW_PATCH 4
+#define FW_TYPE FIRMWARE_VERSION_TYPE_DEV
+
+#ifndef APM_BUILD_DIRECTORY
+#define APM_BUILD_DIRECTORY APM_BUILD_UNKNOWN
+#endif
+
+#define FORCE_VERSION_H_INCLUDE
+#include <AP_Common/AP_FWVersionDefine.h>
+#include <AP_CheckFirmware/AP_CheckFirmwareDefine.h>
+#undef FORCE_VERSION_H_INCLUDE

--- a/libraries/AP_Common/tests/test_fwversion.cpp
+++ b/libraries/AP_Common/tests/test_fwversion.cpp
@@ -6,6 +6,8 @@
 #include <GCS_MAVLink/GCS_Dummy.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 
+#include <AP_Common/ExampleFirmwareVersion.h>
+
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
 

--- a/libraries/AP_Common/tests/test_location.cpp
+++ b/libraries/AP_Common/tests/test_location.cpp
@@ -5,6 +5,8 @@
 #include <AP_Terrain/AP_Terrain.h>
 #include <GCS_MAVLink/GCS_Dummy.h>
 
+#include <AP_Common/ExampleFirmwareVersion.h>
+
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
 class DummyVehicle {

--- a/libraries/AP_FlashIface/examples/jedec_test/jedec_test.cpp
+++ b/libraries/AP_FlashIface/examples/jedec_test/jedec_test.cpp
@@ -21,6 +21,8 @@ void loop()
 #include <AP_FlashIface/AP_FlashIface.h>
 #include <stdio.h>
 
+#include <AP_Common/ExampleFirmwareVersion.h>
+
 AP_FlashIface_JEDEC jedec_dev;
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 

--- a/libraries/AP_GPS/examples/GPS_AUTO_test/GPS_AUTO_test.cpp
+++ b/libraries/AP_GPS/examples/GPS_AUTO_test/GPS_AUTO_test.cpp
@@ -26,6 +26,8 @@
 #include <SITL/SITL.h>
 #include <AP_Scheduler/AP_Scheduler.h>
 
+#include <AP_Common/ExampleFirmwareVersion.h>
+
 void setup();                                                   //This function is defined in most of the libraries. This function is called only once at boot up time. This function is called by main() function in HAL.
 void loop();                                                    //This function is defined in most of the libraries. This function is called by main function in HAL. The main work of the sketch is typically in this function only.
 

--- a/libraries/AP_GyroFFT/examples/ReplayGyroFFT/ReplayGyroFFT.cpp
+++ b/libraries/AP_GyroFFT/examples/ReplayGyroFFT/ReplayGyroFFT.cpp
@@ -13,6 +13,8 @@
 #include <AP_Arming/AP_Arming.h>
 #include <SITL/SITL.h>
 
+#include <AP_Common/ExampleFirmwareVersion.h>
+
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 const AP_HAL::HAL &hal = AP_HAL::get_HAL();
 

--- a/libraries/AP_HAL/examples/DSP_test/DSP_test.cpp
+++ b/libraries/AP_HAL/examples/DSP_test/DSP_test.cpp
@@ -6,6 +6,8 @@
 #include <AP_Logger/AP_Logger.h>
 #include "GyroFrame.h"
 
+#include <AP_Common/ExampleFirmwareVersion.h>
+
 #if HAL_WITH_DSP
 const AP_HAL::HAL &hal = AP_HAL::get_HAL();
 

--- a/libraries/AP_InertialSensor/examples/INS_generic/INS_generic.cpp
+++ b/libraries/AP_InertialSensor/examples/INS_generic/INS_generic.cpp
@@ -9,6 +9,8 @@
 #include <AP_Logger/AP_Logger.h>
 #include <GCS_MAVLink/GCS_Dummy.h>
 
+#include <AP_Common/ExampleFirmwareVersion.h>
+
 const AP_HAL::HAL &hal = AP_HAL::get_HAL();
 
 static AP_InertialSensor ins;

--- a/libraries/AP_Logger/examples/AP_Logger_AllTypes/AP_Logger_AllTypes.cpp
+++ b/libraries/AP_Logger/examples/AP_Logger_AllTypes/AP_Logger_AllTypes.cpp
@@ -8,6 +8,8 @@
 #include <GCS_MAVLink/GCS_Dummy.h>
 #include <stdio.h>
 
+#include <AP_Common/ExampleFirmwareVersion.h>
+
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
 // Format characters in the format string for binary log messages

--- a/libraries/AP_Logger/examples/AP_Logger_test/AP_Logger_test.cpp
+++ b/libraries/AP_Logger/examples/AP_Logger_test/AP_Logger_test.cpp
@@ -9,6 +9,8 @@
 #include <GCS_MAVLink/GCS_Dummy.h>
 #include <stdio.h>
 
+#include <AP_Common/ExampleFirmwareVersion.h>
+
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
 #define LOG_TEST_MSG 1

--- a/libraries/AP_Mission/examples/AP_Mission_test/AP_Mission_test.cpp
+++ b/libraries/AP_Mission/examples/AP_Mission_test/AP_Mission_test.cpp
@@ -13,6 +13,8 @@
 #include <AP_AHRS/AP_AHRS_DCM.h>
 #include <GCS_MAVLink/GCS_Dummy.h>
 
+#include <AP_Common/ExampleFirmwareVersion.h>
+
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
 const struct AP_Param::GroupInfo        GCS_MAVLINK_Parameters::var_info[] = {

--- a/libraries/AP_Module/examples/ModuleTest/ModuleTest.cpp
+++ b/libraries/AP_Module/examples/ModuleTest/ModuleTest.cpp
@@ -10,6 +10,8 @@
 #include <AP_ExternalAHRS/AP_ExternalAHRS.h>
 #include <GCS_MAVLink/GCS_Dummy.h>
 
+#include <AP_Common/ExampleFirmwareVersion.h>
+
 const struct AP_Param::GroupInfo        GCS_MAVLINK_Parameters::var_info[] = {
     AP_GROUPEND
 };

--- a/libraries/AP_NMEA_Output/examples/NMEA_Output/nmea_output.cpp
+++ b/libraries/AP_NMEA_Output/examples/NMEA_Output/nmea_output.cpp
@@ -14,6 +14,8 @@
 #include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_Vehicle/AP_Vehicle.h>
 
+#include <AP_Common/ExampleFirmwareVersion.h>
+
 void setup();
 void loop();
 

--- a/libraries/AP_RTC/examples/RTC_test/RTC_Test.cpp
+++ b/libraries/AP_RTC/examples/RTC_test/RTC_Test.cpp
@@ -7,6 +7,8 @@
 #include <GCS_MAVLink/GCS_Dummy.h>
 #include <AP_Logger/AP_Logger.h>
 
+#include <AP_Common/ExampleFirmwareVersion.h>
+
 #include <stdio.h>
 
 void setup();

--- a/libraries/AP_RangeFinder/examples/RFIND_test/RFIND_test.cpp
+++ b/libraries/AP_RangeFinder/examples/RFIND_test/RFIND_test.cpp
@@ -6,6 +6,8 @@
 #include <AP_RangeFinder/AP_RangeFinder_Backend.h>
 #include <GCS_MAVLink/GCS_Dummy.h>
 
+#include <AP_Common/ExampleFirmwareVersion.h>
+
 const struct AP_Param::GroupInfo        GCS_MAVLINK_Parameters::var_info[] = {
     AP_GROUPEND
 };

--- a/libraries/AP_Scheduler/examples/Scheduler_test/Scheduler_test.cpp
+++ b/libraries/AP_Scheduler/examples/Scheduler_test/Scheduler_test.cpp
@@ -11,6 +11,8 @@
 #include <GCS_MAVLink/GCS_Dummy.h>
 #include <stdio.h>
 
+#include <AP_Common/ExampleFirmwareVersion.h>
+
 const struct AP_Param::GroupInfo        GCS_MAVLINK_Parameters::var_info[] = {
     AP_GROUPEND
 };

--- a/libraries/GCS_MAVLink/GCS_Dummy.cpp
+++ b/libraries/GCS_MAVLink/GCS_Dummy.cpp
@@ -3,13 +3,9 @@
 #if HAL_GCS_ENABLED
 
 #include "GCS_Dummy.h"
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 
 #include <stdio.h>
-
-#define FORCE_VERSION_H_INCLUDE
-#include <AP_Common/AP_FWVersionDefine.h>
-#include <AP_CheckFirmware/AP_CheckFirmwareDefine.h>
-#undef FORCE_VERSION_H_INCLUDE
 
 const struct GCS_MAVLINK::stream_entries GCS_MAVLINK::all_stream_entries[] {};
 

--- a/libraries/GCS_MAVLink/GCS_Dummy.h
+++ b/libraries/GCS_MAVLink/GCS_Dummy.h
@@ -3,14 +3,6 @@
 #if HAL_GCS_ENABLED
 
 #include "GCS.h"
-#include <AP_Common/AP_FWVersion.h>
-
-#define THISFIRMWARE "GCSDummy V3.1.4-dev"
-
-#define FW_MAJOR 3
-#define FW_MINOR 1
-#define FW_PATCH 4
-#define FW_TYPE FIRMWARE_VERSION_TYPE_DEV
 
 /*
  *  GCS backend used for many examples and tools

--- a/libraries/GCS_MAVLink/examples/routing/routing.cpp
+++ b/libraries/GCS_MAVLink/examples/routing/routing.cpp
@@ -9,6 +9,8 @@
 #include <AP_Common/AP_FWVersion.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 
+#include <AP_Common/ExampleFirmwareVersion.h>
+
 void setup();
 void loop();
 


### PR DESCRIPTION
This was always a bit of a nasty kludge, and gets in the way when you're trying to *sometimes* have a GCS in your firmware and sometimes not.

So instead of having the dummy do it, include a file into the cpp which accomplishes the same thing.

Only affects examples, unit tests and Replay.

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                                                     
Durandal                            *      *           *       *                 *      *      *
Hitec-Airspeed           *                                                                     
KakuteH7-bdshot                     *      *           *       *                 *      *      *
MatekF405                           *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *                  *       *                 *      *      *
f103-QiotekPeriph        *                                                                     
f303-Universal           *                                                                     
iomcu                                                                *                         
revo-mini                           *      *           *       *                 *      *      *
skyviper-v2450                                         *                                       
```
