### PR TITLE
ROMFS: avoid decompressing in stat()

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_ROMFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_ROMFS.cpp
@@ -119,12 +119,10 @@ int32_t AP_Filesystem_ROMFS::lseek(int fd, int32_t offset, int seek_from)
 int AP_Filesystem_ROMFS::stat(const char *name, struct stat *stbuf)
 {
     uint32_t size;
-    const uint8_t *data = AP_ROMFS::find_decompress(name, size);
-    if (data == nullptr) {
+    if (!AP_ROMFS::find_size(name, size)) {
         errno = ENOENT;
         return -1;
     }
-    AP_ROMFS::free(data);
     memset(stbuf, 0, sizeof(*stbuf));
     stbuf->st_size = size;
     return 0;

--- a/libraries/AP_ROMFS/AP_ROMFS.cpp
+++ b/libraries/AP_ROMFS/AP_ROMFS.cpp
@@ -53,7 +53,7 @@ const AP_ROMFS::embedded_file *AP_ROMFS::find_file(const char *name)
 const uint8_t *AP_ROMFS::find_decompress(const char *name, uint32_t &size)
 {
     const struct embedded_file *f = find_file(name);
-    if (!f) {
+    if (f == nullptr) {
         return nullptr;
     }
 
@@ -146,3 +146,17 @@ const char *AP_ROMFS::dir_list(const char *dirname, uint16_t &ofs)
     }
     return nullptr;
 }
+
+/*
+  find a compressed file and return its size
+*/
+bool AP_ROMFS::find_size(const char *name, uint32_t &size)
+{
+    const struct embedded_file *f = find_file(name);
+    if (f == nullptr) {
+        return false;
+    }
+    size = f->decompressed_size;
+    return true;
+}
+

--- a/libraries/AP_ROMFS/AP_ROMFS.h
+++ b/libraries/AP_ROMFS/AP_ROMFS.h
@@ -16,6 +16,9 @@ public:
     // free returned data
     static void free(const uint8_t *data);
 
+    // get the size of a file without decompressing
+    static bool find_size(const char *name, uint32_t &size);
+
     /*
       directory listing interface. Start with ofs=0. Returns pathnames
       that match dirname prefix. Ends with nullptr return when no more


### PR DESCRIPTION
This makes ROMFS much more efficient. It is particularly important when serving up javascript and html for the web server as we use if-modified-since to avoid re-sending files to the client. Without this changes we decompress every time.
