### PR TITLE
AP_Logger: avoid logging dma.txt for normal builds

### DIFF
--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -1567,7 +1567,10 @@ void AP_Logger::prepare_at_arming_sys_file_logging()
      */
     static const char *log_content_filenames[] = {
         "@SYS/uarts.txt",
+#ifdef HAL_DEBUG_BUILD
+        // logging dma.txt has a performance impact
         "@SYS/dma.txt",
+#endif
         "@SYS/memory.txt",
         "@SYS/threads.txt",
         "@SYS/timers.txt",


### PR DESCRIPTION
logging of dma.txt currently does no good as the first time you read it you get no content. It then enables statistics in the shared_dma code which makes all DMA operations slower, so all we are doing is making DMA slower