### PR TITLE
Use NET_ENABLE instead of NET_ENABLED for consistency with other _ENABLE parameters

### DIFF
--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6654,7 +6654,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             "SCR_ENABLE": 1,
             "SCR_VM_I_COUNT": 1000000,
             "SIM_SPEEDUP": 20,
-            "NET_ENABLED": 1,
+            "NET_ENABLE": 1,
         })
 
         self.reboot_sitl()
@@ -6688,7 +6688,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             "SCR_ENABLE": 1,
             "SCR_VM_I_COUNT": 1000000,
             "SIM_SPEEDUP": 20,
-            "NET_ENABLED": 1,
+            "NET_ENABLE": 1,
             "SERIAL5_PROTOCOL": 48,
         })
 

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -4371,7 +4371,7 @@ class TestSuite(ABC):
         """Download latest log over network port"""
         self.context_push()
         self.set_parameters({
-            "NET_ENABLED": 1,
+            "NET_ENABLE": 1,
             "LOG_DISARMED": 0,
             "LOG_DARM_RATEMAX": 1, # make small logs
             # UDP client

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubePilot-PPPGW/defaults.parm
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubePilot-PPPGW/defaults.parm
@@ -1,4 +1,4 @@
-NET_ENABLED 1
+NET_ENABLE 1
 NET_OPTIONS 1
 
 # enable hw flow control

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeRedPrimary-PPPGW/defaults.parm
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeRedPrimary-PPPGW/defaults.parm
@@ -1,4 +1,4 @@
-NET_ENABLED 1
+NET_ENABLE 1
 NET_OPTIONS 1
 
 # enable hw flow control

--- a/libraries/AP_Networking/AP_Networking.cpp
+++ b/libraries/AP_Networking/AP_Networking.cpp
@@ -38,7 +38,7 @@ const AP_Param::GroupInfo AP_Networking::var_info[] = {
     // @Values: 0:Disable,1:Enable
     // @RebootRequired: True
     // @User: Advanced
-    AP_GROUPINFO_FLAGS("ENABLED",  1, AP_Networking, param.enabled, 0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("ENABLE",  1, AP_Networking, param.enabled, 0, AP_PARAM_FLAG_ENABLE),
 
 #if AP_NETWORKING_CONTROLS_HOST_IP_SETTINGS_ENABLED
     // @Group: IPADDR

--- a/libraries/AP_Networking/AP_Networking.cpp
+++ b/libraries/AP_Networking/AP_Networking.cpp
@@ -32,7 +32,7 @@ extern const AP_HAL::HAL& hal;
 #endif
 
 const AP_Param::GroupInfo AP_Networking::var_info[] = {
-    // @Param: ENABLED
+    // @Param: ENABLE
     // @DisplayName: Networking Enable
     // @Description: Networking Enable
     // @Values: 0:Disable,1:Enable


### PR DESCRIPTION
The new networking capability in 4.5.0 has used NET_ENABLED. With rare exceptions, NET_ENABLE seems to be the standard. This fixes that.

There is no parameter conversion since this code has never been officially released.