### PR TITLE
Plane: do not set desired vel/accel on takeoff for quadplanes

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3099,8 +3099,6 @@ void QuadPlane::takeoff_controller(void)
     if (no_navigation) {
         pos_control->relax_velocity_controller_xy();
     } else {
-        pos_control->set_accel_desired_xy_cmss(zero);
-        pos_control->set_vel_desired_xy_cms(vel);
         pos_control->input_vel_accel_xy(vel, zero);
 
         // nav roll and pitch are controller by position controller


### PR DESCRIPTION
This effectively bypasses the input shaping.

Currently this creates a step change in the position controller.

![image](https://github.com/ArduPilot/ardupilot/assets/69254089/e2413187-5ae2-4fb1-94aa-30ef9072ab44)
![image](https://github.com/ArduPilot/ardupilot/assets/69254089/5d7075ce-985a-4ec5-b884-5ee53f4098ac)

Removing this allows for the smooth setting.
![image](https://github.com/ArduPilot/ardupilot/assets/69254089/cf596d5d-c9ac-4141-9675-a5d31f22ea12)
![image](https://github.com/ArduPilot/ardupilot/assets/69254089/c72575e5-33f3-403a-ba73-2489dd337db2)

