### PR TITLE
AP_GPS: remove blended GPS from small boards

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1054,6 +1054,11 @@ bool AP_Arming::system_checks(bool report)
     }
 
     if (check_enabled(ARMING_CHECK_PARAMETERS)) {
+#if !AP_GPS_BLENDED_ENABLED
+        if (!blending_auto_switch_checks(report)) {
+            return false;
+        }
+#endif
 #if AP_RPM_ENABLED
         auto *rpm = AP::rpm();
         if (rpm && !rpm->arming_checks(sizeof(buffer), buffer)) {
@@ -1644,6 +1649,19 @@ bool AP_Arming::arm_checks(AP_Arming::Method method)
 
     return true;
 }
+
+#if !AP_GPS_BLENDED_ENABLED
+bool AP_Arming::blending_auto_switch_checks(bool report)
+{
+    if (AP::gps().get_auto_switch_type() == 2) {
+        if (report) {
+            check_failed(ARMING_CHECK_GPS, true, "GPS_AUTO_SWITCH==2 but no blending");
+        }
+        return false;
+    }
+    return true;
+}
+#endif
 
 bool AP_Arming::mandatory_checks(bool report)
 {

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -576,7 +576,7 @@ bool AP_Arming::gps_checks(bool report)
         }
 
         for (uint8_t i = 0; i < gps.num_sensors(); i++) {
-#if defined(GPS_BLENDED_INSTANCE)
+#if AP_GPS_BLENDED_ENABLED
             if ((i != GPS_BLENDED_INSTANCE) &&
 #else
             if (
@@ -614,7 +614,7 @@ bool AP_Arming::gps_checks(bool report)
                          (double)distance_m);
             return false;
         }
-#if defined(GPS_BLENDED_INSTANCE)
+#if AP_GPS_BLENDED_ENABLED
         if (!gps.blend_health_check()) {
             check_failed(ARMING_CHECK_GPS, report, "GPS blending unhealthy");
             return false;

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -3,6 +3,7 @@
 #include <AP_HAL/AP_HAL_Boards.h>
 #include <AP_HAL/Semaphores.h>
 #include <AP_Param/AP_Param.h>
+#include <AP_GPS/AP_GPS_config.h>
 
 #include "AP_Arming_config.h"
 #include "AP_InertialSensor/AP_InertialSensor_config.h"
@@ -309,6 +310,10 @@ private:
     bool report_immediately; // set to true when check goes from true to false, to trigger immediate report
 
     void update_arm_gpio();
+
+#if !AP_GPS_BLENDED_ENABLED
+    bool blending_auto_switch_checks(bool report);
+#endif
 };
 
 namespace AP {

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -214,7 +214,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
 
     // 19 was GPS_DELAY_MS2
 
-#if defined(GPS_BLENDED_INSTANCE)
+#if AP_GPS_BLENDED_ENABLED
     // @Param: _BLEND_MASK
     // @DisplayName: Multi GPS Blending Mask
     // @Description: Determines which of the accuracy measures Horizontal position, Vertical Position and Speed are used to calculate the weighting on each GPS receiver when soft switching has been selected by setting GPS_AUTO_SWITCH to 2(Blend)
@@ -400,7 +400,7 @@ void AP_GPS::convert_parameters()
 // GPS solution is treated as an additional sensor.
 uint8_t AP_GPS::num_sensors(void) const
 {
-#if defined(GPS_BLENDED_INSTANCE)
+#if AP_GPS_BLENDED_ENABLED
     if (_output_is_blended) {
         return num_instances+1;
     }
@@ -1072,7 +1072,7 @@ void AP_GPS::update(void)
 #if GPS_MAX_RECEIVERS > 1
 void AP_GPS::update_primary(void)
 {
-#if defined(GPS_BLENDED_INSTANCE)
+#if AP_GPS_BLENDED_ENABLED
     /*
       if blending is requested, attempt to calculate weighting for
       each GPS
@@ -1105,7 +1105,7 @@ void AP_GPS::update_primary(void)
         primary_instance = GPS_BLENDED_INSTANCE;
         return;
     }
-#endif // defined (GPS_BLENDED_INSTANCE)
+#endif //   AP_GPS_BLENDED_ENABLED
 
     // check the primary param is set to possible GPS
     int8_t primary_param = _primary.get();
@@ -1145,7 +1145,7 @@ void AP_GPS::update_primary(void)
         }
     }
 
-#if defined(GPS_BLENDED_INSTANCE)
+#if AP_GPS_BLENDED_ENABLED
     // handling switching away from blended GPS
     if (primary_instance == GPS_BLENDED_INSTANCE) {
         primary_instance = 0;
@@ -1180,7 +1180,7 @@ void AP_GPS::update_primary(void)
         _last_instance_swap_ms = now;
         return;
     }
-#endif  // defined(GPS_BLENDED_INSTANCE)
+#endif  // AP_GPS_BLENDED_ENABLED
 
     // Use primary if 3D fix or better
     if (((GPSAutoSwitch)_auto_switch.get() == GPSAutoSwitch::USE_PRIMARY_IF_3D_FIX) && (state[primary_param].status >= GPS_OK_FIX_3D)) {
@@ -1690,7 +1690,7 @@ bool AP_GPS::get_lag(uint8_t instance, float &lag_sec) const
         return false;
     }
 
-#if defined(GPS_BLENDED_INSTANCE)
+#if AP_GPS_BLENDED_ENABLED
     // return lag of blended GPS
     if (instance == GPS_BLENDED_INSTANCE) {
         lag_sec = _blended_lag_sec;
@@ -1727,7 +1727,7 @@ const Vector3f &AP_GPS::get_antenna_offset(uint8_t instance) const
         return params[0].antenna_offset;
     }
 
-#if defined(GPS_BLENDED_INSTANCE)
+#if AP_GPS_BLENDED_ENABLED
     if (instance == GPS_BLENDED_INSTANCE) {
         // return an offset for the blended GPS solution
         return _blended_antenna_offset;
@@ -1786,7 +1786,7 @@ bool AP_GPS::is_healthy(uint8_t instance) const
     }
 #endif // HAL_BUILD_AP_PERIPH
 
-#if defined(GPS_BLENDED_INSTANCE)
+#if AP_GPS_BLENDED_ENABLED
     if (instance == GPS_BLENDED_INSTANCE) {
         return blend_health_check();
     }

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -30,28 +30,6 @@
 #include <SITL/SIM_GPS.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 
-/**
-   maximum number of GPS instances available on this platform. If more
-   than 1 then redundant sensors may be available
- */
-#ifndef GPS_MAX_RECEIVERS
-#define GPS_MAX_RECEIVERS 2 // maximum number of physical GPS sensors allowed - does not include virtual GPS created by blending receiver data
-#endif
-#if !defined(GPS_MAX_INSTANCES)
-#if GPS_MAX_RECEIVERS > 1
-#define GPS_MAX_INSTANCES  (GPS_MAX_RECEIVERS + 1) // maximum number of GPS instances including the 'virtual' GPS created by blending receiver data
-#else
-#define GPS_MAX_INSTANCES 1
-#endif // GPS_MAX_RECEIVERS > 1
-#endif // GPS_MAX_INSTANCES
-
-#if GPS_MAX_RECEIVERS <= 1 && GPS_MAX_INSTANCES > 1
-#error "GPS_MAX_INSTANCES should be 1 for GPS_MAX_RECEIVERS <= 1"
-#endif
-
-#if GPS_MAX_INSTANCES > GPS_MAX_RECEIVERS
-#define GPS_BLENDED_INSTANCE GPS_MAX_RECEIVERS  // the virtual blended GPS is always the highest instance (2)
-#endif
 #define GPS_UNKNOWN_DOP UINT16_MAX // set unknown DOP's to maximum value, which is also correct for MAVLink
 
 // the number of GPS leap seconds - copied into SIM_GPS.cpp
@@ -761,7 +739,7 @@ private:
     void inject_data(const uint8_t *data, uint16_t len);
     void inject_data(uint8_t instance, const uint8_t *data, uint16_t len);
 
-#if defined(GPS_BLENDED_INSTANCE)
+#if AP_GPS_BLENDED_ENABLED
     // GPS blending and switching
     Vector3f _blended_antenna_offset; // blended antenna offset
     float _blended_lag_sec; // blended receiver lag in seconds

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -599,6 +599,10 @@ public:
     void clear_RTCMV3();
 #endif // GPS_MOVING_BASELINE
 
+#if !AP_GPS_BLENDED_ENABLED
+    uint8_t get_auto_switch_type() const { return _auto_switch; }
+#endif
+
 protected:
 
     // configuration parameters

--- a/libraries/AP_GPS/AP_GPS_Blended.cpp
+++ b/libraries/AP_GPS/AP_GPS_Blended.cpp
@@ -1,6 +1,6 @@
 #include "AP_GPS.h"
 
-#if defined(GPS_BLENDED_INSTANCE)
+#if AP_GPS_BLENDED_ENABLED
 
 // defines used to specify the mask position for use of different accuracy metrics in the blending algorithm
 #define BLEND_MASK_USE_HPOS_ACC     1
@@ -377,4 +377,4 @@ void AP_GPS::calc_blended_state(void)
     }
 #endif
 }
-#endif // GPS_BLENDED_INSTANCE
+#endif  // AP_GPS_BLENDED_ENABLED

--- a/libraries/AP_GPS/AP_GPS_config.h
+++ b/libraries/AP_GPS/AP_GPS_config.h
@@ -7,8 +7,37 @@
 #define AP_GPS_ENABLED 1
 #endif
 
+#if AP_GPS_ENABLED
+/**
+   maximum number of GPS instances available on this platform. If more
+   than 1 then redundant sensors may be available
+ */
+#ifndef GPS_MAX_RECEIVERS
+#define GPS_MAX_RECEIVERS 2 // maximum number of physical GPS sensors allowed - does not include virtual GPS created by blending receiver data
+#endif
+#if !defined(GPS_MAX_INSTANCES)
+#if GPS_MAX_RECEIVERS > 1
+#define GPS_MAX_INSTANCES  (GPS_MAX_RECEIVERS + 1) // maximum number of GPS instances including the 'virtual' GPS created by blending receiver data
+#else
+#define GPS_MAX_INSTANCES 1
+#endif // GPS_MAX_RECEIVERS > 1
+#endif // GPS_MAX_INSTANCES
+
+#if GPS_MAX_RECEIVERS <= 1 && GPS_MAX_INSTANCES > 1
+#error "GPS_MAX_INSTANCES should be 1 for GPS_MAX_RECEIVERS <= 1"
+#endif
+
+#if GPS_MAX_INSTANCES > GPS_MAX_RECEIVERS
+#define GPS_BLENDED_INSTANCE GPS_MAX_RECEIVERS  // the virtual blended GPS is always the highest instance (2)
+#endif
+#endif
+
 #ifndef AP_GPS_BACKEND_DEFAULT_ENABLED
 #define AP_GPS_BACKEND_DEFAULT_ENABLED AP_GPS_ENABLED
+#endif
+
+#ifndef AP_GPS_BLENDED_ENABLED
+#define AP_GPS_BLENDED_ENABLED AP_GPS_BACKEND_DEFAULT_ENABLED && defined(GPS_BLENDED_INSTANCE)
 #endif
 
 #ifndef AP_GPS_DRONECAN_ENABLED


### PR DESCRIPTION
those boards which are not including all backends will lose blended after this
```
Board                    AP_Periph  blimp  bootloader  copter  heli   iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *
Durandal                            *      *           *       *                  *      *      *
Hitec-Airspeed           *
KakuteH7-bdshot                     *      *           *       *                  *      *      *
MatekF405                           -2688  *           -2656   -2680              -2792  -2680  -2688
Pixhawk1-1M-bdshot                  -2624              -2664   -2656              -2624  -2672  -2624
f103-QiotekPeriph        *
f303-Universal           *
iomcu                                                                 *
revo-mini                           -2648  *           -2752   -2680              -2552  -2680  -2664
skyviper-v2450                                         *
```