### PR TITLE
chibios_hwdef.py: correct extraction of intdefines from hwdef files

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -3072,7 +3072,7 @@ Please run: Tools/scripts/build_bootloaders.py %s
             self.env_vars[name] = value
         elif a[0] == 'define':
             # extract numerical defines for processing by other parts of the script
-            result = re.match(r'define\s*([A-Z_]+)\s*([0-9]+)', line)
+            result = re.match(r'define\s*([A-Z_0-9]+)\s*([0-9]+)', line)
             if result:
                 self.intdefines[result.group(1)] = int(result.group(2))
 


### PR DESCRIPTION
many of our hwdef files contain lines which look like this:

define STM32_PWM_USE_ADVANCED TRUE

The current regex does not allow for numbers in those define, so the regex ends up matching "STM" as a name....

the "intdefines" hash which is populated from these is only used internally to chibios_hwdey.py for logic purposes, not directly in hwdef output purposes, and none of the strings which it looks at contain numbers at the moment, so this is a non-functional change.

I have done a `configure_all.py` on master and this and compared the results to ensure there are no changes to any hwdefs.
