### PR TITLE
Tools: size_compare_branches.py: write out some.csv less racily

### DIFF
--- a/Tools/scripts/size_compare_branches.py
+++ b/Tools/scripts/size_compare_branches.py
@@ -483,8 +483,9 @@ class SizeCompareBranches(object):
             for task in tasks:
                 task_results.append(self.gather_results_for_task(task))
             # progress CSV:
-            with open("/tmp/some.csv", "w") as f:
-                f.write(self.csv_for_results(self.compare_task_results(task_results, no_elf_diff=True)))
+            csv_for_results = self.csv_for_results(self.compare_task_results(task_results, no_elf_diff=True))
+            path = pathlib.Path("/tmp/some.csv")
+            path.write_text(csv_for_results)
 
             time.sleep(1)
         self.progress("All threads returned")


### PR DESCRIPTION
The current construct wipes the old file before reading and collating the data and writing to the file.  This meant the file was empty a lot of the time...

Formulate the output then write to file....