### PR TITLE
Fix Skyviper-Journey build

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/include/skyviper.inc
+++ b/libraries/AP_HAL_ChibiOS/hwdef/include/skyviper.inc
@@ -1,0 +1,4 @@
+# include file for SkyViper boards.  Move things in from
+#  skyviper-v2450/hwdef.dat as required.
+
+define AP_AIRSPEED_ENABLED 0

--- a/libraries/AP_HAL_ChibiOS/hwdef/skyviper-journey/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/skyviper-journey/hwdef.dat
@@ -134,6 +134,7 @@ env BUILD_ABIN True
 define AP_PARAM_MAX_EMBEDDED_PARAM 8192
 
 # Disable un-needed hardware drivers
+include ../include/skyviper.inc
 define HAL_WITH_ESC_TELEM 0
 define AP_FETTEC_ONEWIRE_ENABLED 0
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/skyviper-v2450/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/skyviper-v2450/hwdef.dat
@@ -68,6 +68,7 @@ STORAGE_FLASH_PAGE 22
 env BUILD_ABIN True
 
 # Disable un-needed hardware drivers
+include ../include/skyviper.inc
 define AP_AIRSPEED_ENABLED 0
 define AP_BEACON_ENABLED 0
 define AP_OPTICALFLOW_ENABLED 0

--- a/libraries/AP_Radio/AP_Radio_cc2500.cpp
+++ b/libraries/AP_Radio/AP_Radio_cc2500.cpp
@@ -3,12 +3,13 @@
 
   Many thanks to the cleanflight and betaflight projects
  */
+#include "AP_Radio_config.h"
+
+#if AP_RADIO_CC2500_ENABLED
+
 #include <AP_HAL/AP_HAL.h>
 
 // #pragma GCC optimize("O0")
-
-#if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
-#if HAL_RCINPUT_WITH_AP_RADIO
 
 #include <AP_Math/AP_Math.h>
 #include "AP_Radio_cc2500.h"
@@ -1563,5 +1564,4 @@ void AP_Radio_cc2500::check_double_bind(void)
     radio_singleton->nextChannel(1);
 }
 
-#endif // HAL_RCINPUT_WITH_AP_RADIO
-#endif // CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
+#endif  // AP_RADIO_CC2500_ENABLED


### PR DESCRIPTION
Start to share excludes from Skyviper-v2450

Also fixes the defines in one of the radio .cpp files which got missed in earlier work
