### PR TITLE
AP_ExternalAHRS: Remove incorrect 0xFFFF default comment

### DIFF
--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS.h
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS.h
@@ -136,7 +136,7 @@ public:
     } mag_data_message_t;
 
     typedef struct {
-        uint16_t gps_week;                   // GPS week, 0xFFFF if not available
+        uint16_t gps_week;
         uint32_t ms_tow;
         uint8_t  fix_type;
         uint8_t  satellites_in_view;


### PR DESCRIPTION
The GPS week value of 0xFFFF is a hold-over from MSP. None of the EAHRS systems set that value now, and it's not handled in any special way in AP_GPS. 