### PR TITLE
Automatically scale OSD placement for HD MSP DisplayPort

### DIFF
--- a/libraries/AP_MSP/msp.h
+++ b/libraries/AP_MSP/msp.h
@@ -31,7 +31,7 @@
 #define DISPLAYPORT_MSP_ATTR_BLINK   1U<<6 // Device local blink
 #define DISPLAYPORT_MSP_ATTR_MASK    (~(DISPLAYPORT_MSP_ATTR_VERSION|DISPLAYPORT_MSP_ATTR_BLINK))
 // betaflight/src/main/io/displayport_msp.c
-#define OSD_MSP_DISPLAYPORT_MAX_STRING_LENGTH 30
+#define OSD_MSP_DISPLAYPORT_MAX_STRING_LENGTH 50
 
 class AP_MSP_Telem_Backend;
 

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -100,11 +100,21 @@ public:
 
 protected:
     bool check_option(uint32_t option);
+    virtual uint8_t get_msg_visible_width() const { return 26; }
 #if HAL_WITH_MSP_DISPLAYPORT
+
+    enum TextResolution {
+        SCALE_30x16=0,
+        SCALE_50x18=1,
+    };
+
     virtual uint8_t get_txt_resolution() const {
         return 0;
     }
     virtual uint8_t get_font_index() const {
+        return 0;
+    }
+    virtual uint8_t get_txt_scale() const {
         return 0;
     }
 #endif
@@ -120,6 +130,9 @@ protected:
 
     char u_icon(enum unit_type unit);
     float u_scale(enum unit_type unit, float value);
+
+    uint8_t scale_x(uint8_t x) const;
+    uint8_t scale_y(uint8_t x) const;
 
     AP_OSD_Backend *backend;
     AP_OSD *osd;
@@ -154,13 +167,18 @@ public:
     uint8_t get_font_index() const override {
         return font_index;
     }
+    uint8_t get_txt_scale() const override {
+        return txt_scale;
+    }
+    uint8_t get_msg_visible_width() const override {
+        return (txt_scale.get() && txt_resolution == SCALE_50x18) ? MIN(50-scale_x(message.xpos), 46) : 26;
+    }
 #endif
 private:
     friend class AP_MSP;
     friend class AP_MSP_Telem_Backend;
     friend class AP_MSP_Telem_DJI;
 
-    static const uint8_t message_visible_width = 26;
     static const uint8_t message_scroll_time_ms = 200;
     static const uint8_t message_scroll_delay = 5;
 
@@ -259,6 +277,7 @@ private:
     // Per screen HD resolution options (currently supported only by DisplayPort)
     AP_Int8 txt_resolution;
     AP_Int8 font_index;
+    AP_Int8 txt_scale;
 #endif
 #if HAL_WITH_ESC_TELEM
     AP_Int8 esc_index;

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -71,7 +71,8 @@ public:
     AP_Int8 xpos;
     AP_Int8 ypos;
 
-    AP_OSD_Setting(bool enabled = 0, uint8_t x = 0, uint8_t y = 0);
+    AP_OSD_Setting(bool enabled = 0, uint8_t x = 0, uint8_t y = 0,
+                   uint8_t x_hd = 0, uint8_t y_hd = 0);
 
     // User settable parameters
     static const struct AP_Param::GroupInfo var_info[];
@@ -80,6 +81,10 @@ private:
     const float default_enabled;
     const float default_xpos;
     const float default_ypos;
+#if HAL_WITH_MSP_DISPLAYPORT
+    const float default_xpos_hd;
+    const float default_ypos_hd;
+#endif
 };
 
 class AP_OSD;
@@ -193,29 +198,29 @@ private:
         RESTING_CELL,
     };
 
-    AP_OSD_Setting altitude{true, 23, 8};
-    AP_OSD_Setting bat_volt{true, 24, 1};
-    AP_OSD_Setting rssi{true, 1, 1};
+    AP_OSD_Setting altitude{true, 23, 8, 38, 9};
+    AP_OSD_Setting bat_volt{true, 24, 1, 40, 1};
+    AP_OSD_Setting rssi{true, 1, 1, 1, 1};
     AP_OSD_Setting link_quality{false,1,1};
     AP_OSD_Setting restvolt{false, 24, 2};
     AP_OSD_Setting avgcellvolt{false, 24, 3};
     AP_OSD_Setting avgcellrestvolt{false, 24, 4};
-    AP_OSD_Setting current{true, 25, 2};
-    AP_OSD_Setting batused{true, 23, 3};
-    AP_OSD_Setting sats{true, 1, 3};
-    AP_OSD_Setting fltmode{true, 2, 8};
-    AP_OSD_Setting message{true, 2, 6};
-    AP_OSD_Setting gspeed{true, 2, 14};
-    AP_OSD_Setting horizon{true, 14, 8};
-    AP_OSD_Setting home{true, 14, 1};
-    AP_OSD_Setting throttle{true, 24, 11};
-    AP_OSD_Setting heading{true, 13, 2};
-    AP_OSD_Setting compass{true, 15, 3};
+    AP_OSD_Setting current{true, 25, 2, 42, 2};
+    AP_OSD_Setting batused{true, 23, 3, 38, 3};
+    AP_OSD_Setting sats{true, 1, 3, 2, 3};
+    AP_OSD_Setting fltmode{true, 2, 8, 3, 9};
+    AP_OSD_Setting message{true, 2, 6, 3, 7};
+    AP_OSD_Setting gspeed{true, 2, 14, 3, 16};
+    AP_OSD_Setting horizon{true, 14, 8, 23, 9};
+    AP_OSD_Setting home{true, 14, 1, 23, 1};
+    AP_OSD_Setting throttle{true, 24, 11, 40, 12};
+    AP_OSD_Setting heading{true, 13, 2, 22, 1};
+    AP_OSD_Setting compass{true, 15, 3, 25, 3};
     AP_OSD_Setting wind{false, 2, 12};
     AP_OSD_Setting aspeed{false, 2, 13};
     AP_OSD_Setting aspd1;
     AP_OSD_Setting aspd2;
-    AP_OSD_Setting vspeed{true, 24, 9};
+    AP_OSD_Setting vspeed{true, 24, 9, 40, 10};
 #if AP_RPM_ENABLED
     AP_OSD_Setting rrpm{false, 2, 2};
 #endif
@@ -224,8 +229,8 @@ private:
     AP_OSD_Setting esc_rpm{false, 22, 12};
     AP_OSD_Setting esc_amps{false, 24, 14};
 #endif
-    AP_OSD_Setting gps_latitude{true, 9, 13};
-    AP_OSD_Setting gps_longitude{true, 9, 14};
+    AP_OSD_Setting gps_latitude{true, 9, 13, 15, 14};
+    AP_OSD_Setting gps_longitude{true, 9, 14, 15, 16};
     AP_OSD_Setting roll_angle;
     AP_OSD_Setting pitch_angle;
     AP_OSD_Setting temp;
@@ -277,7 +282,6 @@ private:
     // Per screen HD resolution options (currently supported only by DisplayPort)
     AP_Int8 txt_resolution;
     AP_Int8 font_index;
-    AP_Int8 txt_scale;
 #endif
 #if HAL_WITH_ESC_TELEM
     AP_Int8 esc_index;

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -1172,13 +1172,6 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info2[] = {
     // @Description: Index of the ESC to use for displaying ESC information. 0 means use the ESC with the highest value.
     // @Range: 0 32
     AP_GROUPINFO("ESC_IDX", 10, AP_OSD_Screen, esc_index, 0),
-#if HAL_WITH_MSP_DISPLAYPORT
-    // @Param: TXT_SCALE
-    // @DisplayName: Scales OSD element positions based on the the overlay text resolution (MSP DisplayPort only)
-    // @Description: Scales OSD element positions based on the the overlay text resolution (MSP DisplayPort only)
-    // @Values: 0:Disable,1:Enabled
-    // @User: Standard
-    AP_GROUPINFO("TXT_SCALE", 11, AP_OSD_Screen, txt_scale, 0),
 #endif
 
     AP_GROUPEND
@@ -1190,8 +1183,8 @@ uint8_t AP_OSD_AbstractScreen::symbols_lookup_table[AP_OSD_NUM_SYMBOLS];
 // Symbol indexes to acces _symbols[index][set]
 #define SYM_M 0
 #define SYM_KM 1
-#define SYM_FT 2
 #define SYM_MI 3
+#define SYM_FT 2
 #define SYM_ALT_M 4
 #define SYM_ALT_FT 5
 #define SYM_BATT_FULL 6
@@ -1433,26 +1426,6 @@ float AP_OSD_AbstractScreen::u_scale(enum unit_type unit, float value)
     };
     uint8_t units = constrain_int16(osd->units, 0, AP_OSD::UNITS_LAST-1);
     return value * scale[units][unit] + (offsets[units]?offsets[units][unit]:0);
-}
-
-uint8_t  AP_OSD_AbstractScreen::scale_x(uint8_t x) const
-{
-#if HAL_WITH_MSP_DISPLAYPORT
-    if (get_txt_scale() && get_txt_resolution() == SCALE_50x18) {
-        return x*50/30;
-    }
-#endif
-    return x;
-}
-
-uint8_t  AP_OSD_AbstractScreen::scale_y(uint8_t x) const
-{
-#if HAL_WITH_MSP_DISPLAYPORT
-    if (get_txt_scale() && get_txt_resolution() == SCALE_50x18) {
-        return x*18/16;
-    }
-#endif
-    return x;
 }
 
 char AP_OSD_Screen::get_arrow_font_index(int32_t angle_cd)
@@ -2578,7 +2551,7 @@ void AP_OSD_Screen::draw_rngf(uint8_t x, uint8_t y)
 }
 #endif
 
-#define DRAW_SETTING(n) if (n.enabled) draw_ ## n(scale_x(n.xpos), scale_y(n.ypos))
+#define DRAW_SETTING(n) if (n.enabled) draw_ ## n(n.xpos, n.ypos)
 
 #if HAL_WITH_OSD_BITMAP || HAL_WITH_MSP_DISPLAYPORT
 void AP_OSD_Screen::draw(void)

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -1172,6 +1172,13 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info2[] = {
     // @Description: Index of the ESC to use for displaying ESC information. 0 means use the ESC with the highest value.
     // @Range: 0 32
     AP_GROUPINFO("ESC_IDX", 10, AP_OSD_Screen, esc_index, 0),
+#if HAL_WITH_MSP_DISPLAYPORT
+    // @Param: TXT_SCALE
+    // @DisplayName: Scales OSD element positions based on the the overlay text resolution (MSP DisplayPort only)
+    // @Description: Scales OSD element positions based on the the overlay text resolution (MSP DisplayPort only)
+    // @Values: 0:Disable,1:Enabled
+    // @User: Standard
+    AP_GROUPINFO("TXT_SCALE", 11, AP_OSD_Screen, txt_scale, 0),
 #endif
 
     AP_GROUPEND
@@ -1428,6 +1435,26 @@ float AP_OSD_AbstractScreen::u_scale(enum unit_type unit, float value)
     return value * scale[units][unit] + (offsets[units]?offsets[units][unit]:0);
 }
 
+uint8_t  AP_OSD_AbstractScreen::scale_x(uint8_t x) const
+{
+#if HAL_WITH_MSP_DISPLAYPORT
+    if (get_txt_scale() && get_txt_resolution() == SCALE_50x18) {
+        return x*50/30;
+    }
+#endif
+    return x;
+}
+
+uint8_t  AP_OSD_AbstractScreen::scale_y(uint8_t x) const
+{
+#if HAL_WITH_MSP_DISPLAYPORT
+    if (get_txt_scale() && get_txt_resolution() == SCALE_50x18) {
+        return x*18/16;
+    }
+#endif
+    return x;
+}
+
 char AP_OSD_Screen::get_arrow_font_index(int32_t angle_cd)
 {
     uint32_t interval = 36000 / SYMBOL(SYM_ARROW_COUNT);
@@ -1640,6 +1667,7 @@ void AP_OSD_Screen::draw_message(uint8_t x, uint8_t y)
             }
 
             int16_t start_position = 0;
+            const uint8_t message_visible_width = MIN(get_msg_visible_width(), int(sizeof(buffer)-1));
             //scroll if required
             //scroll pattern: wait, scroll to the left, wait, scroll to the right
             if (len > message_visible_width) {
@@ -2550,7 +2578,7 @@ void AP_OSD_Screen::draw_rngf(uint8_t x, uint8_t y)
 }
 #endif
 
-#define DRAW_SETTING(n) if (n.enabled) draw_ ## n(n.xpos, n.ypos)
+#define DRAW_SETTING(n) if (n.enabled) draw_ ## n(scale_x(n.xpos), scale_y(n.ypos))
 
 #if HAL_WITH_OSD_BITMAP || HAL_WITH_MSP_DISPLAYPORT
 void AP_OSD_Screen::draw(void)

--- a/libraries/AP_OSD/AP_OSD_Setting.cpp
+++ b/libraries/AP_OSD/AP_OSD_Setting.cpp
@@ -49,10 +49,15 @@ const AP_Param::GroupInfo AP_OSD_Setting::var_info[] = {
 };
 
 // constructor
-AP_OSD_Setting::AP_OSD_Setting(bool _enabled, uint8_t x, uint8_t y) :
+AP_OSD_Setting::AP_OSD_Setting(bool _enabled, uint8_t x, uint8_t y,
+                               uint8_t x_hd, uint8_t y_hd) :
     default_enabled(_enabled),
     default_xpos(x),
     default_ypos(y)
+#if HAL_WITH_MSP_DISPLAYPORT
+    ,default_xpos_hd(x_hd),
+    default_ypos_hd(y_hd)
+#endif
 {
     AP_Param::setup_object_defaults(this, var_info);
 }


### PR DESCRIPTION
This PR adds a new screen parameter ```OSDx_TXT_SCALE``` that if set to 1 will scale the positions of OSD elements on DisplayPort to fit an HD screen