### PR TITLE
EKF: use `set_and_default` when changing IMU mask

### DIFF
--- a/libraries/AP_DAL/examples/AP_DAL_Standalone/main.cpp
+++ b/libraries/AP_DAL/examples/AP_DAL_Standalone/main.cpp
@@ -9,6 +9,11 @@
 
 void AP_Param::setup_object_defaults(void const*, AP_Param::GroupInfo const*) {}
 
+template<typename T, ap_var_type PT>
+void AP_ParamT<T, PT>::set_and_default(const T &v) {}
+template class AP_ParamT<int8_t, AP_PARAM_INT8>;
+
+
 int AP_HAL::Util::vsnprintf(char*, size_t, char const*, va_list) { return -1; }
 
 void *nologger = nullptr;

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -643,7 +643,7 @@ bool NavEKF2::InitialiseFilter(void)
 
         // don't allow more filters than IMUs
         uint8_t mask = (1U<<ins.get_accel_count())-1;
-        _imuMask.set(_imuMask.get() & mask);
+        _imuMask.set_and_default(_imuMask.get() & mask);
         
         // count IMUs from mask
         num_cores = __builtin_popcount(_imuMask);

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -781,7 +781,7 @@ bool NavEKF3::InitialiseFilter(void)
 
         // don't run multiple filters for 1 IMU
         uint8_t mask = (1U<<ins.get_accel_count())-1;
-        _imuMask.set(_imuMask.get() & mask);
+        _imuMask.set_and_default(_imuMask.get() & mask);
         
         // initialise the setup variables
         for (uint8_t i=0; i<MAX_EKF_CORES; i++) {


### PR DESCRIPTION
Just calling set here makes it look like a user change. Alternately we could just not change the param at all and mask a local copy. 