### PR TITLE
AP_OSD: use `set_and_default` when ensuring first screen is enabled

### DIFF
--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -256,8 +256,8 @@ AP_OSD::AP_OSD()
     }
     AP_Param::setup_object_defaults(this, var_info);
 #if OSD_ENABLED
-    // default first screen enabled
-    screen[0].enabled.set(1);
+    // force first screen enabled
+    screen[0].enabled.set_and_default(1);
     previous_pwm_screen = -1;
 #endif
 #ifdef WITH_SITL_OSD


### PR DESCRIPTION
The set here makes it look like a user change. I have also updated the comment to reflect what the code does, forcing to enabled. Alternatively we could just call `set_default` to only change the default but not set the value if the user has configured which is what the comment seems to suggest it should do.