### PR TITLE
OSD: allow size of simulated OSD to be set

### DIFF
--- a/libraries/AP_OSD/AP_OSD_SITL.cpp
+++ b/libraries/AP_OSD/AP_OSD_SITL.cpp
@@ -27,6 +27,7 @@
 #include <AP_HAL/Semaphores.h>
 #include <AP_HAL/Scheduler.h>
 #include <AP_ROMFS/AP_ROMFS.h>
+#include <SITL/SITL.h>
 #include <utility>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -100,7 +101,7 @@ void AP_OSD_SITL::write(uint8_t x, uint8_t y, const char* text)
     WITH_SEMAPHORE(mutex);
 
     while ((x < video_cols) && (*text != 0)) {
-        buffer[y][x] = *text;
+        getbuffer(buffer, y, x) = *text;
         ++text;
         ++x;
     }
@@ -110,7 +111,7 @@ void AP_OSD_SITL::clear(void)
 {
     AP_OSD_Backend::clear();
     WITH_SEMAPHORE(mutex);
-    memset(buffer, 0, sizeof(buffer));
+    memset(buffer, 0, video_cols*video_lines);
 }
 
 void AP_OSD_SITL::flush(void)
@@ -207,6 +208,10 @@ AP_OSD_Backend *AP_OSD_SITL::probe(AP_OSD &osd)
 AP_OSD_SITL::AP_OSD_SITL(AP_OSD &osd):
     AP_OSD_Backend(osd)
 {
+    const auto *_sitl = AP::sitl();
+    video_lines = _sitl->osd_rows;
+    video_cols = _sitl->osd_columns;
+    buffer = (uint8_t *)malloc(video_lines*video_cols);
 }
 
 #endif // WITH_SITL_OSD

--- a/libraries/AP_OSD/AP_OSD_SITL.h
+++ b/libraries/AP_OSD/AP_OSD_SITL.h
@@ -72,14 +72,19 @@ private:
     // setup to match MAX7456 layout
     static const uint8_t char_width = 12;
     static const uint8_t char_height = 18;
-    static const uint8_t video_lines = 16; // PAL
-    static const uint8_t video_cols = 30;
+    uint8_t video_lines;
+    uint8_t video_cols;
     static const uint8_t char_spacing = 0;
 
     // scaling factor to make it easier to read
     static const uint8_t char_scale = 2;
 
-    uint8_t buffer[video_lines][video_cols];
+    // get a byte from a buffer
+    uint8_t &getbuffer(uint8_t *buf, uint8_t y, uint8_t x) const {
+        return buf[y*uint32_t(video_cols) + x];
+    }
+
+    uint8_t *buffer;
 
     void update_thread();
     static void *update_thread_start(void *obj);

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -524,6 +524,20 @@ const AP_Param::GroupInfo SIM::var_info3[] = {
     // @Bitmask: 0:MAVLink,3:SageTechMXS
     AP_GROUPINFO("ADSB_TYPES",    52, SIM,  adsb_types, 1),
 
+#ifdef WITH_SITL_OSD
+    // @Param: OSD_COLUMNS
+    // @DisplayName: Simulated OSD number of text columns
+    // @Description: Simulated OSD number of text columns
+    // @Range: 10 100
+    AP_GROUPINFO("OSD_COLUMNS",   53, SIM,  osd_columns, 30),
+
+    // @Param: OSD_ROWS
+    // @DisplayName: Simulated OSD number of text rows
+    // @Description: Simulated OSD number of text rows
+    // @Range: 10 100
+    AP_GROUPINFO("OSD_ROWS",     54, SIM,  osd_rows, 16),
+#endif
+    
 #ifdef SFML_JOYSTICK
     AP_SUBGROUPEXTENSION("",      63, SIM,  var_sfml_joystick),
 #endif // SFML_JOYSTICK

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -537,6 +537,11 @@ public:
     AP_Int8 gyro_file_rw;
     AP_Int8 accel_file_rw;
 #endif
+
+#ifdef WITH_SITL_OSD
+    AP_Int16 osd_rows;
+    AP_Int16 osd_columns;
+#endif
 };
 
 } // namespace SITL


### PR DESCRIPTION
this adds SIM_OSD_ROWS and SIM_OSD_COLUMNS
this aims to make it easier to test PRs like this one:
https://github.com/ArduPilot/ardupilot/pull/26605
