### PR TITLE
AP_InertialSensor: Improve bitmask indicating persistent parameters on bootloader flash

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -656,8 +656,8 @@ const AP_Param::GroupInfo AP_InertialSensor::var_info[] = {
 
     // @Param: _TCAL_OPTIONS
     // @DisplayName: Options for temperature calibration
-    // @Description: This enables optional temperature calibration features. Setting PersistParams will save the accelerometer and temperature calibration parameters in the bootloader sector on the next update of the bootloader.
-    // @Bitmask: 0:PersistParams
+    // @Description: This enables optional temperature calibration features. Setting of the Persist bits will save the temperature and/or accelerometer calibration parameters in the bootloader sector on the next update of the bootloader.
+    // @Bitmask: 0:PersistTemps, 1:PersistAccels
     // @User: Advanced
     AP_GROUPINFO("_TCAL_OPTIONS", 52, AP_InertialSensor, tcal_options, 0),
     


### PR DESCRIPTION
The current param description indicates that bit 0 will do _both_ accels and tempcals. However, `INS_TCAL_OPTIONS` is a bitmask that is used to persist 0:tempcals and 1:accels (or both).

See: [TCalOptions Definition](https://github.com/ArduPilot/ardupilot/blob/77c7052865517975d04fe4cf747ad2c40cb024c8/libraries/AP_InertialSensor/AP_InertialSensor.h#L777)

I don't have access to add labels to wiki, but there is an associated wiki PR to better describe how to use the persistence here: [ardupilot_wiki PR#5841](https://github.com/ArduPilot/ardupilot_wiki/pull/5841)
