### PR TITLE
AP_GPS: SBF report correct satellite count on NrSV DNU value

### DIFF
--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -455,8 +455,10 @@ AP_GPS_SBF::process_message(void)
             set_alt_amsl_cm(state, ((float)temp.Height - temp.Undulation) * 1e2f);
         }
 
-        if (temp.NrSV != 255) {
-            state.num_sats = temp.NrSV;
+        state.num_sats = temp.NrSV;
+        if (temp.NrSV == 255) {
+            // Do-Not-Use value for NrSV field in PVTGeodetic message
+            state.num_sats = 0;
         }
 
         Debug("temp.Mode=0x%02x\n", (unsigned)temp.Mode);


### PR DESCRIPTION
When the NrSV field of the SBF PVTGeodetic message contains the Do-Not-Use value of 255, set the satellite count to 0 instead of ignoring the change.