### PR TITLE
AP_NavEKF: add option to align ExtNav position when using OptFlow

### DIFF
--- a/libraries/AP_DAL/AP_DAL_VisualOdom.cpp
+++ b/libraries/AP_DAL/AP_DAL_VisualOdom.cpp
@@ -8,6 +8,15 @@
 #include "AP_DAL.h"
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 
+// request sensor's yaw be aligned with vehicle's AHRS/EKF attitude
+void AP_DAL_VisualOdom::request_align_yaw_to_ahrs()
+{
+#if !APM_BUILD_TYPE(APM_BUILD_AP_DAL_Standalone)
+    auto *vo = AP::visualodom();
+    vo->request_align_yaw_to_ahrs();
+#endif
+}
+
 /*
    update position offsets to align to AHRS position
    should only be called when this library is not being used as the position source

--- a/libraries/AP_DAL/AP_DAL_VisualOdom.h
+++ b/libraries/AP_DAL/AP_DAL_VisualOdom.h
@@ -27,6 +27,9 @@ public:
         return RVOH.pos_offset;
     }
 
+    // request sensor's yaw be aligned with vehicle's AHRS/EKF attitude
+    void request_align_yaw_to_ahrs();
+
     // update position offsets to align to AHRS position
     // should only be called when this library is not being used as the position source
     void align_position_to_ahrs(bool align_xy, bool align_z);

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
@@ -288,6 +288,20 @@ void AP_NavEKF_Source::align_inactive_sources()
         }
     }
     visual_odom->align_position_to_ahrs(align_posxy, align_posz);
+
+    // consider aligning yaw:
+    if ((getYawSource() == SourceYaw::COMPASS) ||
+        (getYawSource() == SourceYaw::GPS) ||
+        (getYawSource() == SourceYaw::GPS_COMPASS_FALLBACK) ||
+        (getYawSource() == SourceYaw::GSF)) {
+        for (uint8_t i=0; i<AP_NAKEKF_SOURCE_SET_MAX; i++) {
+            if (_source_set[i].yaw == SourceYaw::EXTNAV) {
+                // ExtNav could potentially be used, so align it
+                visual_odom->request_align_yaw_to_ahrs();
+                break;
+            }
+        }
+    }
 #endif
 }
 

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
@@ -135,7 +135,7 @@ const AP_Param::GroupInfo AP_NavEKF_Source::var_info[] = {
     // @Param: _OPTIONS
     // @DisplayName: EKF Source Options
     // @Description: EKF Source Options
-    // @Bitmask: 0:FuseAllVelocities
+    // @Bitmask: 0:FuseAllVelocities, 1:AlignPosWhenUsingOptFlow
     // @User: Advanced
     AP_GROUPINFO("_OPTIONS", 16, AP_NavEKF_Source, _options, (int16_t)SourceOptions::FUSE_ALL_VELOCITIES),
 
@@ -260,7 +260,8 @@ void AP_NavEKF_Source::align_inactive_sources()
     // consider aligning XY position:
     bool align_posxy = false;
     if ((getPosXYSource() == SourceXY::GPS) ||
-        (getPosXYSource() == SourceXY::BEACON)) {
+        (getPosXYSource() == SourceXY::BEACON) ||
+        ((getVelXYSource() == SourceXY::OPTFLOW) && option_is_set(SourceOptions::ALIGN_WHEN_USING_OPTFLOW))) {
         // only align position if active source is GPS or Beacon
         for (uint8_t i=0; i<AP_NAKEKF_SOURCE_SET_MAX; i++) {
             if (_source_set[i].posxy == SourceXY::EXTNAV) {

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.h
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.h
@@ -47,7 +47,8 @@ public:
 
     // enum for OPTIONS parameter
     enum class SourceOptions {
-        FUSE_ALL_VELOCITIES = (1 << 0)  // fuse all velocities configured in source sets
+        FUSE_ALL_VELOCITIES = (1 << 0),     // fuse all velocities configured in source sets
+        ALIGN_WHEN_USING_OPTFLOW = (1 << 1) // align position of inactive sources to ahrs when using optical flow
     };
 
     // initialisation
@@ -117,6 +118,9 @@ private:
         AP_Enum<SourceZ>   velz;   // velocity z source
         AP_Enum<SourceYaw> yaw;    // yaw source
     } _source_set[AP_NAKEKF_SOURCE_SET_MAX];
+
+    // helper to check if an option parameter bit has been set
+    bool option_is_set(SourceOptions option) const { return (_options.get() & int16_t(option)) != 0; }
 
     AP_Int16 _options;      // source options bitmask
 


### PR DESCRIPTION
This increases "alignment" of External Nav (aka VisualOdometry) in a couple of situations.

- EK3_SRC_OPTIONS gets a new bit which enables aligning the External Nav position to the Optical Flow based position estimate.  This is useful for situations where only optical flow is being used as a backup for the external nav system and we want to avoid jumps when switching from optical flow to external nav.  The downside is that any drift that has occurred while using optical flow will essentially be "locked-in".
- External Nav's yaw is aligned at the same time as its position and velocity are aligned.  This means most users will not need to use the VisoAlign auxiliary switch any more.  It is hard to imagine why users would *not* want to align the yaw which is why I have not hidden this new feature behind an option bit.

This has not yet been tested.