### PR TITLE
AP_Logger: `Write_VER` keep g++ 7.5 happy by removeing non-trivial designated initializers

### DIFF
--- a/libraries/AP_Logger/AP_Logger_Backend.cpp
+++ b/libraries/AP_Logger/AP_Logger_Backend.cpp
@@ -575,7 +575,6 @@ bool AP_Logger_Backend::Write_VER()
         patch: fwver.patch,
         fw_type: fwver.fw_type,
         git_hash: fwver.fw_hash,
-        filter_version: AP_FILTER_VERSION,
     };
     strncpy(pkt.fw_string, fwver.fw_string, ARRAY_SIZE(pkt.fw_string)-1);
 
@@ -583,6 +582,8 @@ bool AP_Logger_Backend::Write_VER()
     pkt._APJ_BOARD_ID = APJ_BOARD_ID;
 #endif
     pkt.build_type = fwver.vehicle_type;
+    pkt.filter_version = AP_FILTER_VERSION;
+
     return WriteCriticalBlock(&pkt, sizeof(pkt));
 }
 


### PR DESCRIPTION
Same problem as https://github.com/ArduPilot/ardupilot/pull/25362:

```
../../libraries/AP_Logger/AP_Logger_Backend.cpp: In member function ‘bool AP_Logger_Backend::Write_VER()’:
../../libraries/AP_Logger/AP_Logger_Backend.cpp:579:5: sorry, unimplemented: non-trivial designated initializers not supported
     };
     ^
```

This keeps g++ 7.5 working for now, at some point I guess we might want say we don't support it anymore. 