### PR TITLE
Tools: waf help output shows --define under build

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -591,15 +591,15 @@ arducopter and upload it to my board".
         help='''Override board type check and continue loading. Same as using uploader.py --force.
 ''')
 
+    g.add_option('--define',
+        action='append',
+        help='Add C++ define to build.')
+
     g = opt.ap_groups['check']
 
     g.add_option('--check-verbose',
         action='store_true',
         help='Output all test programs.')
-
-    g.add_option('--define',
-        action='append',
-        help='Add C++ define to build.')
 
     g = opt.ap_groups['clean']
 


### PR DESCRIPTION
A tiny non-functional change to ./waf so that in "./waf --help" we show "--define" under "build" instead of "check options".

Before:
![image](https://github.com/ArduPilot/ardupilot/assets/1498098/f81cc9fb-7227-4592-80be-ad9296de619b)

After:
![image](https://github.com/ArduPilot/ardupilot/assets/1498098/99e33ee0-5295-4e0f-9d7e-0201927a6aa7)
