### PR TITLE
waf: add --redefine to command-line

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -601,6 +601,10 @@ arducopter and upload it to my board".
         action='append',
         help='Add C++ define to build.')
 
+    g.add_option('--redefine',
+        action='append',
+        help='Undefine, then add C++ define to build.')
+
     g = opt.ap_groups['clean']
 
     g.add_option('--clean-all-sigs',

--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -601,12 +601,8 @@ def configure(cfg):
         cfg.msg('Default parameters', cfg.options.default_parameters, color='YELLOW')
         env.DEFAULT_PARAMETERS = cfg.options.default_parameters
 
-    try:
-        ret = generate_hwdef_h(env)
-    except Exception:
+    if not generate_hwdef_h(env):
         cfg.fatal("Failed to process hwdef.dat")
-    if ret != 0:
-        cfg.fatal("Failed to process hwdef.dat ret=%d" % ret)
     load_env_vars(cfg.env)
     if env.HAL_NUM_CAN_IFACES and not env.AP_PERIPH:
         setup_canmgr_build(cfg)
@@ -645,7 +641,12 @@ def generate_hwdef_h(env):
         cmd += " '{0}'".format(env.HWDEF_EXTRA)
     if env.BOOTLOADER_OPTION:
         cmd += " " + env.BOOTLOADER_OPTION
-    return subprocess.call(cmd, shell=True)
+    try:
+        ret = subprocess.call(cmd, shell=True)
+    except Exception as e:
+        return False
+
+    return ret == 0
 
 def pre_build(bld):
     '''pre-build hook to change dynamic sources'''
@@ -655,12 +656,8 @@ def pre_build(bld):
     hwdef_h = os.path.join(bld.env.BUILDROOT, 'hwdef.h')
     if not os.path.exists(hwdef_h):
         print("Generating hwdef.h")
-        try:
-            ret = generate_hwdef_h(bld.env)
-        except Exception:
+        if not generate_hwdef_h(bld.env):
             bld.fatal("Failed to process hwdef.dat")
-        if ret != 0:
-            bld.fatal("Failed to process hwdef.dat ret=%d" % ret)
     setup_optimization(bld.env)
 
 def build(bld):

--- a/wscript
+++ b/wscript
@@ -502,6 +502,8 @@ def configure(cfg):
 
     cfg.env.OPTIONS = cfg.options.__dict__
 
+    cfg.env.REDEFINE = cfg.options.redefine
+
     # Allow to differentiate our build from the make build
     cfg.define('WAF_BUILD', 1)
 


### PR DESCRIPTION
Allows turning features back on from command-line which are turned off in hwdef.

e.g.
```
reset; ./waf configure --board=MatekF405 --redefine "MODE_GUIDED_NOGPS_ENABLED=1"
```

Also narrow the scope of try/except block

This is really just a shortcut/alternative to creating an `--extra-hwdef` file.
