### PR TITLE
AP_Arming: do not wait 10 seconds with single gyro/accel

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -365,8 +365,9 @@ bool AP_Arming::ins_accels_consistent(const AP_InertialSensor &ins)
         last_accel_pass_ms = now;
     }
 
+    // if accels can in theory be inconsistent,
     // must pass for at least 10 seconds before we're considered consistent:
-    if (now - last_accel_pass_ms < 10000) {
+    if (ins.get_accel_count() > 1 && now - last_accel_pass_ms < 10000) {
         return false;
     }
 
@@ -389,8 +390,9 @@ bool AP_Arming::ins_gyros_consistent(const AP_InertialSensor &ins)
         last_gyro_pass_ms = now;
     }
 
+    // if gyros can in theory be inconsistent,
     // must pass for at least 10 seconds before we're considered consistent:
-    if (now - last_gyro_pass_ms < 10000) {
+    if (ins.get_gyro_count() > 1 && now - last_gyro_pass_ms < 10000) {
         return false;
     }
 


### PR DESCRIPTION
Commit d80449ac1323d5b26d356a2d4295bc62f1667158 fixed the comparison direction in the safety delay of 10 seconds to ensure multiple gyros or accelerometers are consistent and stable at that.

However, on flight controllers where there is only one gyro or accel, or only one is used, this delay, which is unconditional, does not make much sense. It certainly feels like a regression at the moment. What is more, pre-arm messages like "Gyros inconsistent" or "Accels inconsistent" only add to confusion in the presence of a single gyro or accel.

This PR turns the 10 second delay to be conditional on having more than one sensor.

I understand that this is a slight encapsulation breach, and one should probably have `bool AP_InertialSensor::gyros_can_be_inconsistent`, which, if `false`, bypasses the delay. But I am not sure whether this is currently worth it.