### PR TITLE
Plane: fix DO_SET_MISSION_CURRENT

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1410,13 +1410,13 @@ void GCS_MAVLINK_Plane::handle_set_position_target_global_int(const mavlink_mess
 
 MAV_RESULT GCS_MAVLINK_Plane::handle_command_do_set_mission_current(const mavlink_command_int_t &packet)
 {
+    plane.auto_state.next_wp_crosstrack = false;
     const MAV_RESULT result = GCS_MAVLINK::handle_command_do_set_mission_current(packet);
     if (result != MAV_RESULT_ACCEPTED) {
         return result;
     }
 
     // if you change this you must change handle_mission_set_current
-    plane.auto_state.next_wp_crosstrack = false;
     if (plane.control_mode == &plane.mode_auto && plane.mission.state() == AP_Mission::MISSION_STOPPED) {
         plane.mission.resume();
     }


### PR DESCRIPTION
This PR adress #26640 issue, where not having `plane.auto_state.next_wp_crosstrack = false;` prior to actual command handling leads to accend or descend trajectory computed based on not a current altitude, but a previously active WP altitude.