### PR TITLE
SITL: add UART tx/rx tracking and `@SYS/uarts.txt`

### DIFF
--- a/libraries/AP_HAL/UARTDriver.cpp
+++ b/libraries/AP_HAL/UARTDriver.cpp
@@ -163,3 +163,13 @@ uint64_t AP_HAL::UARTDriver::receive_time_constraint_us(uint16_t nbytes)
 {
     return AP_HAL::micros64();
 }
+
+#if HAL_UART_STATS_ENABLED
+// Take cumulative bytes and return the change since last call
+uint32_t AP_HAL::UARTDriver::StatsTracker::ByteTracker::update(uint32_t bytes)
+{
+    const uint32_t change = bytes - last_bytes;
+    last_bytes = bytes;
+    return change;
+}
+#endif

--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -152,8 +152,21 @@ public:
     virtual bool is_dma_enabled() const { return false; }
 
 #if HAL_UART_STATS_ENABLED
+    // Helper to keep track of data usage since last call
+    struct StatsTracker {
+        class ByteTracker {
+        public:
+            // Take cumulative bytes and return the change since last call
+            uint32_t update(uint32_t bytes);
+        private:
+            uint32_t last_bytes;
+        };
+        ByteTracker tx;
+        ByteTracker rx;
+    };
+
     // request information on uart I/O for this uart, for @SYS/uarts.txt
-    virtual void uart_info(ExpandingString &str) {}
+    virtual void uart_info(ExpandingString &str, StatsTracker &stats, const uint32_t dt_ms) {}
 #endif
 
     /*

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -1696,9 +1696,11 @@ uint16_t UARTDriver::get_options(void) const
 
 #if HAL_UART_STATS_ENABLED
 // request information on uart I/O for @SYS/uarts.txt for this uart
-void UARTDriver::uart_info(ExpandingString &str)
+void UARTDriver::uart_info(ExpandingString &str, StatsTracker &stats, const uint32_t dt_ms)
 {
-    uint32_t now_ms = AP_HAL::millis();
+    const uint32_t tx_bytes = stats.tx.update(_tx_stats_bytes);
+    const uint32_t rx_bytes = stats.rx.update(_rx_stats_bytes);
+
     if (sdef.is_usb) {
         str.printf("OTG%u  ", unsigned(sdef.instance));
     } else {
@@ -1706,14 +1708,11 @@ void UARTDriver::uart_info(ExpandingString &str)
     }
     str.printf("TX%c=%8u RX%c=%8u TXBD=%6u RXBD=%6u\n",
                tx_dma_enabled ? '*' : ' ',
-               unsigned(_tx_stats_bytes),
+               unsigned(tx_bytes),
                rx_dma_enabled ? '*' : ' ',
-               unsigned(_rx_stats_bytes),
-               unsigned(_tx_stats_bytes * 10000 / (now_ms - _last_stats_ms)),
-               unsigned(_rx_stats_bytes * 10000 / (now_ms - _last_stats_ms)));
-    _tx_stats_bytes = 0;
-    _rx_stats_bytes = 0;
-    _last_stats_ms = now_ms;
+               unsigned(rx_bytes),
+               unsigned((tx_bytes * 10000) / dt_ms),
+               unsigned((rx_bytes * 10000) / dt_ms));
 }
 #endif
 

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -123,7 +123,7 @@ public:
 
 #if HAL_UART_STATS_ENABLED
     // request information on uart I/O for one uart
-    void uart_info(ExpandingString &str) override;
+    void uart_info(ExpandingString &str, StatsTracker &stats, const uint32_t dt_ms) override;
 #endif
 
     /*
@@ -209,7 +209,6 @@ private:
     // statistics
     uint32_t _tx_stats_bytes;
     uint32_t _rx_stats_bytes;
-    uint32_t _last_stats_ms;
 
     // we remember config options from set_options to apply on sdStart()
     uint32_t _cr1_options;

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -682,18 +682,23 @@ extern ChibiOS::UARTDriver uart_io;
 // request information on uart I/O
 void Util::uart_info(ExpandingString &str)
 {
+    // Calculate time since last call
+    const uint32_t now_ms = AP_HAL::millis();
+    const uint32_t dt_ms = now_ms - uart_stats.last_ms;
+    uart_stats.last_ms = now_ms;
+
     // a header to allow for machine parsers to determine format
     str.printf("UARTV1\n");
     for (uint8_t i = 0; i < HAL_UART_NUM_SERIAL_PORTS; i++) {
         auto *uart = hal.serial(i);
         if (uart) {
             str.printf("SERIAL%u ", i);
-            uart->uart_info(str);
+            uart->uart_info(str, uart_stats.serial[i], dt_ms);
         }
     }
 #if HAL_WITH_IO_MCU
     str.printf("IOMCU   ");
-    uart_io.uart_info(str);
+    uart_io.uart_info(str, uart_stats.io, dt_ms);
 #endif
 }
 #endif

--- a/libraries/AP_HAL_ChibiOS/Util.h
+++ b/libraries/AP_HAL_ChibiOS/Util.h
@@ -98,7 +98,7 @@ public:
 #endif
 #if HAL_UART_STATS_ENABLED
     // request information on uart I/O
-    virtual void uart_info(ExpandingString &str) override;
+    void uart_info(ExpandingString &str) override;
 #endif
 #if HAL_USE_PWM == TRUE
     void timer_info(ExpandingString &str) override;
@@ -160,5 +160,15 @@ private:
 
 #if HAL_ENABLE_DFU_BOOT
     void boot_to_dfu() override;
+#endif
+
+#if HAL_UART_STATS_ENABLED
+    struct {
+        AP_HAL::UARTDriver::StatsTracker serial[HAL_UART_NUM_SERIAL_PORTS];
+#if HAL_WITH_IO_MCU
+        AP_HAL::UARTDriver::StatsTracker io;
+#endif
+        uint32_t last_ms;
+    } uart_stats;
 #endif
 };

--- a/libraries/AP_HAL_Empty/UARTDriver.cpp
+++ b/libraries/AP_HAL_Empty/UARTDriver.cpp
@@ -24,7 +24,7 @@ ssize_t Empty::UARTDriver::_read(uint8_t *buffer, uint16_t size)
 }
 
 #if HAL_UART_STATS_ENABLED
-void Empty::UARTDriver::uart_info(ExpandingString &str)
+void Empty::UARTDriver::uart_info(ExpandingString &str, StatsTracker &stats, const uint32_t dt_ms)
 {
     str.printf("EMPTY\n");
 }

--- a/libraries/AP_HAL_Empty/UARTDriver.h
+++ b/libraries/AP_HAL_Empty/UARTDriver.h
@@ -15,7 +15,7 @@ public:
 
 #if HAL_UART_STATS_ENABLED
     // request information on uart I/O for one uart
-    void uart_info(ExpandingString &str) override;
+    void uart_info(ExpandingString &str, StatsTracker &stats, const uint32_t dt_ms) override;
 #endif
 
 protected:

--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -46,6 +46,7 @@
 
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 #include <AP_Filesystem/AP_Filesystem.h>
+#include <AP_Common/ExpandingString.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -227,7 +228,9 @@ uint32_t UARTDriver::txspace(void)
 
 ssize_t UARTDriver::_read(uint8_t *buffer, uint16_t count)
 {
-    return _readbuffer.read(buffer, count);
+    const ssize_t ret = _readbuffer.read(buffer, count);
+    _rx_stats_bytes += ret;
+    return ret;
 }
 
 bool UARTDriver::_discard_input(void)
@@ -284,6 +287,8 @@ size_t UARTDriver::_write(const uint8_t *buffer, size_t size)
         }
 #endif // HAL_BUILD_AP_PERIPH
 
+    // Include lost byte in tx count, we think we sent it even though it was never added to the write buffer
+    _tx_stats_bytes += lost_byte;
 
     const size_t ret = _writebuffer.write(buffer, size - lost_byte) + lost_byte;
     if (_unbuffered_writes) {
@@ -834,6 +839,7 @@ void UARTDriver::handle_writing_from_writebuffer_to_device()
             ssize_t ret = send(_fd, tmpbuf, n, MSG_DONTWAIT);
             if (ret > 0) {
                 _writebuffer.advance(ret);
+                _tx_stats_bytes += ret;
             }
         }
     } else {
@@ -855,6 +861,7 @@ void UARTDriver::handle_writing_from_writebuffer_to_device()
             }
             if (nwritten > 0) {
                 _writebuffer.advance(nwritten);
+                _tx_stats_bytes += nwritten;
             }
         }
     }
@@ -1012,5 +1019,23 @@ uint32_t UARTDriver::bw_in_bytes_per_second() const
     const uint32_t bitrate = _connected ? 10E6 : _uart_baudrate;
     return bitrate/10; // convert bits to bytes minus overhead
 };
+
+#if HAL_UART_STATS_ENABLED
+// request information on uart I/O for @SYS/uarts.txt for this uart
+void UARTDriver::uart_info(ExpandingString &str, StatsTracker &stats, const uint32_t dt_ms)
+{
+    const uint32_t tx_bytes = stats.tx.update(_tx_stats_bytes);
+    const uint32_t rx_bytes = stats.rx.update(_rx_stats_bytes);
+
+    str.printf("TX=%8u RX=%8u TXBD=%6u RXBD=%6u %s (%s)\n",
+                unsigned(tx_bytes),
+                unsigned(rx_bytes),
+                unsigned((tx_bytes * 10000) / dt_ms),
+                unsigned((rx_bytes * 10000) / dt_ms),
+                _connected ? "connected    " : "not connected",
+                _sitlState->_serial_path[_portNumber]);
+}
+#endif
+
 #endif // CONFIG_HAL_BOARD
 

--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -1015,8 +1015,13 @@ ssize_t UARTDriver::get_system_outqueue_length() const
 
 uint32_t UARTDriver::bw_in_bytes_per_second() const
 {
-    // if connected, assume at least a 10/100Mbps connection
-    const uint32_t bitrate = _connected ? 10E6 : _uart_baudrate;
+    // if connected, assume at least a 10/100Mbps connection if not limited
+    bool baud_limit = false;
+#if !defined(HAL_BUILD_AP_PERIPH)
+    SITL::SIM *_sitl = AP::sitl();
+    baud_limit = (_sitl != nullptr) && _sitl->telem_baudlimit_enable;
+#endif
+    const uint32_t bitrate = (_connected && !baud_limit) ? 10E6 : _uart_baudrate;
     return bitrate/10; // convert bits to bytes minus overhead
 };
 

--- a/libraries/AP_HAL_SITL/UARTDriver.h
+++ b/libraries/AP_HAL_SITL/UARTDriver.h
@@ -67,6 +67,11 @@ public:
 
     uint32_t get_baud_rate() const override { return _uart_baudrate; }
 
+#if HAL_UART_STATS_ENABLED
+    // request information on uart I/O
+    void uart_info(ExpandingString &str, StatsTracker &stats, const uint32_t dt_ms) override;
+#endif
+
 private:
 
     int _fd;
@@ -143,6 +148,10 @@ protected:
 private:
     void handle_writing_from_writebuffer_to_device();
     void handle_reading_from_device_to_readbuffer();
+
+    // statistics
+    uint32_t _tx_stats_bytes;
+    uint32_t _rx_stats_bytes;
 };
 
 #endif

--- a/libraries/AP_HAL_SITL/Util.h
+++ b/libraries/AP_HAL_SITL/Util.h
@@ -106,4 +106,18 @@ private:
 
     int saved_argc;
     char *const *saved_argv;
+
+#if HAL_UART_STATS_ENABLED
+    // request information on uart I/O
+    void uart_info(ExpandingString &str) override;
+#endif
+
+private:
+#if HAL_UART_STATS_ENABLED
+    // UART stats tracking helper
+    struct {
+        AP_HAL::UARTDriver::StatsTracker serial[AP_HAL::HAL::num_serial];
+        uint32_t last_ms;
+    } uart_stats;
+#endif
 };


### PR DESCRIPTION
Extract from https://github.com/ArduPilot/ardupilot/pull/26532. This adds a byte tracking helper `StatsTracker` which allows the UART driver to keep a cumulative count rather than zeroing. ChibiOS is moved to use that and SITL gets by tracking and fills in  `@SYS/uarts.txt`.

SITL:
```
UARTV1
SERIAL0 TX=   60956 RX=     354 TXBD= 36742 RXBD=   213 connected     (tcp:0:wait)
SERIAL1 TX=       0 RX=       0 TXBD=     0 RXBD=     0 not connected (tcp:2)
SERIAL2 TX=   19259 RX=     812 TXBD= 11608 RXBD=   489 connected     (tcp:3)
SERIAL3 TX=    1089 RX=   35358 TXBD=   656 RXBD= 21312 connected     (GPS1)
SERIAL4 TX=       0 RX=       0 TXBD=     0 RXBD=     0 connected     (GPS2)
SERIAL5 TX=       0 RX=       0 TXBD=     0 RXBD=     0 not connected (tcp:5)
SERIAL6 TX=       0 RX=       0 TXBD=     0 RXBD=     0 not connected (tcp:6)
SERIAL7 TX=       0 RX=       0 TXBD=     0 RXBD=     0 not connected (tcp:7)
SERIAL8 TX=       0 RX=       0 TXBD=     0 RXBD=     0 not connected (tcp:8)
```
ChibiOS (CubeOrange):
```
UARTV1
SERIAL0 OTG1  TX =    7809 RX =     620 TXBD=  8632 RXBD=   685
SERIAL1 UART2 TX =     214 RX*=       0 TXBD=   236 RXBD=     0
SERIAL2 UART3 TX =     214 RX*=       0 TXBD=   236 RXBD=     0
SERIAL3 UART4 TX =    1296 RX =       0 TXBD=  1432 RXBD=     0
SERIAL4 UART8 TX =       0 RX*=       0 TXBD=     0 RXBD=     0
SERIAL5 UART7 TX =     611 RX*=     234 TXBD=   675 RXBD=   258
SERIAL6 OTG2  TX =       0 RX =       0 TXBD=     0 RXBD=     0
IOMCU   UART6 TX*=   72638 RX*=   42920 TXBD= 80298 RXBD= 47446
```

The last commit updates the SITL `bw_in_bytes_per_second` function to report the true baudrate if baud rate limiting is enabled.
