### PR TITLE
AP_SCripting: update VTOL QuickTune to allow YAW FLTE = 0

### DIFF
--- a/libraries/AP_Scripting/applets/VTOL-quicktune.lua
+++ b/libraries/AP_Scripting/applets/VTOL-quicktune.lua
@@ -298,7 +298,7 @@ function setup_filters(axis)
    adjust_gain(fltd, INS_GYRO_FILTER:get() * FLTD_MUL)
    if axis == "YAW" then
       local FLTE = params[flte]
-      if FLTE:get() <= 0.0 or FLTE:get() > YAW_FLTE_MAX then
+      if FLTE:get() < 0.0 or FLTE:get() > YAW_FLTE_MAX then
          adjust_gain(flte, YAW_FLTE_MAX)
       end
    end

--- a/libraries/AP_Scripting/applets/VTOL-quicktune.md
+++ b/libraries/AP_Scripting/applets/VTOL-quicktune.md
@@ -121,6 +121,8 @@ Install the lua script in the APM/SCRIPTS directory on the flight
 controllers microSD card, then set SCR_ENABLE to 1. Reboot, and
 refresh parameters. Then set QUIK_ENABLE to 1.
 
+IF vectored yaw ((tilt rotors) or TVBS tailsitter(motors on tilting servos), set Q_A_RAT_YAW_FLTE = 0 before running yaw tuning.
+
 You will then need to setup a 3 position switch on an available RC
 input channel for controlling the tune (or 2 position if you set
 QUIK_AUTO_SAVE). If for example channel 6 is available with a 3


### PR DESCRIPTION
although the change merged yesterday was an improvement, it does not allow Leonards recommended yaw flte to be used (0) for vectored yaw quadplanes...this allows that and recommends it in the script setup instructions...matching wiki recommendations already updated.

currently, the default of 2.5 would be unchanged by the script which can result in yaw wobble in the outer angle loop
 if the user changes to 0, it would reset to 8hz by the script which may or may not wobble...this allows it to be set to 0 and remain at that value when the script is run