### PR TITLE
AP_HAL_ESP32: Bugfix added missing printf statement

### DIFF
--- a/libraries/AP_HAL_ESP32/SPIDevice.cpp
+++ b/libraries/AP_HAL_ESP32/SPIDevice.cpp
@@ -169,7 +169,7 @@ void SPIDevice::acquire_bus(bool accuire)
 AP_HAL::Semaphore *SPIDevice::get_semaphore()
 {
 #ifdef SPIDEBUG
-    rintf("%s:%d \n", __PRETTY_FUNCTION__, __LINE__);
+    printf("%s:%d \n", __PRETTY_FUNCTION__, __LINE__);
 #endif
     return &bus.semaphore;
 }


### PR DESCRIPTION
I accidentally found a typo in printf statement so this small PR fixes that.

Hi @rmackay9, I had to create this new PR because the previous one got closed automatically after I reset the head. Sorry for the confusion.