### PR TITLE
hwdef: remove redundant defines from hwdefs

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/Sierra-F412/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Sierra-F412/hwdef.dat
@@ -87,7 +87,6 @@ define HAL_NO_GPIO_IRQ
 # avoid RCIN thread to save memory
 define HAL_USE_RTC FALSE
 define DMA_RESERVE_SIZE 0
-define PERIPH_FW TRUE
 
 # enable CAN support
 PA11 CAN1_RX CAN1

--- a/libraries/AP_HAL_ChibiOS/hwdef/Sierra-F9P/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Sierra-F9P/hwdef.dat
@@ -98,7 +98,6 @@ define HAL_NO_GPIO_IRQ
 # avoid RCIN thread to save memory
 define HAL_USE_RTC TRUE
 define DMA_RESERVE_SIZE 0
-define PERIPH_FW TRUE
 
 # enable CAN support
 PB8 CAN1_RX CAN1

--- a/libraries/AP_HAL_ChibiOS/hwdef/kha_eth/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/kha_eth/hwdef.dat
@@ -132,10 +132,6 @@ define HAL_DISABLE_ADC_DRIVER TRUE
 #define HAL_NO_GPIO_IRQ
 define HAL_PERIPH_SHOW_SERIAL_MANAGER_PARAMS
 
-
-define PERIPH_FW TRUE
-#define NO_DATAFLASH TRUE
-
 #################################
 # AP_Periph - configurations specific to this App
 #################################


### PR DESCRIPTION
this is set in the periph defaults file