### PR TITLE
Make GCS_MAVLink base class handle DO_SET_HOME

### DIFF
--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -451,13 +451,6 @@ MAV_RESULT GCS_MAVLINK_Tracker::handle_command_int_packet(const mavlink_command_
     }
 }
 
-bool GCS_MAVLINK_Tracker::set_home_to_current_location(bool _lock) {
-    return tracker.set_home(AP::gps().location());
-}
-bool GCS_MAVLINK_Tracker::set_home(const Location& loc, bool _lock) {
-    return tracker.set_home(loc);
-}
-
 void GCS_MAVLINK_Tracker::handle_message(const mavlink_message_t &msg)
 {
     switch (msg.msgid) {
@@ -584,7 +577,7 @@ void GCS_MAVLINK_Tracker::handle_message_mission_item(const mavlink_message_t &m
 
         // check if this is the HOME wp
         if (packet.seq == 0) {
-            if (!tracker.set_home(tell_command)) {
+            if (!tracker.set_home(tell_command, false)) {
                 result = MAV_MISSION_ERROR;
                 goto mission_failed;
             }

--- a/AntennaTracker/GCS_Mavlink.h
+++ b/AntennaTracker/GCS_Mavlink.h
@@ -27,9 +27,6 @@ protected:
         return 0; // what if we have been picked up and carried somewhere?
     }
 
-    bool set_home_to_current_location(bool lock) override WARN_IF_UNUSED;
-    bool set_home(const Location& loc, bool lock) override WARN_IF_UNUSED;
-
     void send_nav_controller_output() const override;
     void send_pid_tuning() override;
 

--- a/AntennaTracker/Tracker.cpp
+++ b/AntennaTracker/Tracker.cpp
@@ -92,7 +92,7 @@ void Tracker::one_second_loop()
         // set home to current location
         Location temp_loc;
         if (ahrs.get_location(temp_loc)) {
-            if (!set_home(temp_loc)){
+            if (!set_home(temp_loc, false)) {
                 // fail silently
             }
         }

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -197,7 +197,8 @@ private:
     void init_ardupilot() override;
     bool get_home_eeprom(Location &loc) const;
     bool set_home_eeprom(const Location &temp) WARN_IF_UNUSED;
-    bool set_home(const Location &temp) WARN_IF_UNUSED;
+    bool set_home_to_current_location(bool lock) override WARN_IF_UNUSED;
+    bool set_home(const Location &temp, bool lock) override WARN_IF_UNUSED;
     void prepare_servos();
     void set_mode(Mode &newmode, ModeReason reason);
     bool set_mode(uint8_t new_mode, ModeReason reason) override;

--- a/AntennaTracker/sensors.cpp
+++ b/AntennaTracker/sensors.cpp
@@ -51,7 +51,7 @@ void Tracker::update_GPS(void)
                 // Now have an initial GPS position
                 // use it as the HOME position in future startups
                 current_loc = gps.location();
-                IGNORE_RETURN(set_home(current_loc));
+                IGNORE_RETURN(set_home(current_loc, false));
                 ground_start_count = 0;
             }
         }

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -116,7 +116,12 @@ bool Tracker::set_home_eeprom(const Location &temp)
     return true;
 }
 
-bool Tracker::set_home(const Location &temp)
+bool Tracker::set_home_to_current_location(bool lock)
+{
+    return set_home(AP::gps().location(), lock);
+}
+
+bool Tracker::set_home(const Location &temp, bool lock)
 {
     // check EKF origin has been set
     Location ekf_origin;

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -739,8 +739,8 @@ private:
     // commands.cpp
     void update_home_from_EKF();
     void set_home_to_current_location_inflight();
-    bool set_home_to_current_location(bool lock) WARN_IF_UNUSED;
-    bool set_home(const Location& loc, bool lock) WARN_IF_UNUSED;
+    bool set_home_to_current_location(bool lock) override WARN_IF_UNUSED;
+    bool set_home(const Location& loc, bool lock) override WARN_IF_UNUSED;
     bool far_from_EKF_origin(const Location& loc);
 
     // compassmot.cpp

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -711,13 +711,6 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_preflight_reboot(const mavlink_command_int
     return GCS_MAVLINK::handle_preflight_reboot(packet, msg);
 }
 
-bool GCS_MAVLINK_Copter::set_home_to_current_location(bool _lock) {
-    return copter.set_home_to_current_location(_lock);
-}
-bool GCS_MAVLINK_Copter::set_home(const Location& loc, bool _lock) {
-    return copter.set_home(loc, _lock);
-}
-
 MAV_RESULT GCS_MAVLINK_Copter::handle_command_int_do_reposition(const mavlink_command_int_t &packet)
 {
 #if MODE_GUIDED_ENABLED == ENABLED

--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -48,8 +48,6 @@ protected:
 
     void handle_landing_target(const mavlink_landing_target_t &packet, uint32_t timestamp_ms) override;
 
-    bool set_home_to_current_location(bool lock) override WARN_IF_UNUSED;
-    bool set_home(const Location& loc, bool lock) override WARN_IF_UNUSED;
     void send_nav_controller_output() const override;
     uint64_t capabilities() const override;
 

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -781,25 +781,25 @@ void GCS_MAVLINK_Plane::packetReceived(const mavlink_status_t &status,
 }
 
 
-bool GCS_MAVLINK_Plane::set_home_to_current_location(bool _lock)
+bool Plane::set_home_to_current_location(bool _lock)
 {
-    if (!plane.set_home_persistently(AP::gps().location())) {
+    if (!set_home_persistently(AP::gps().location())) {
         return false;
     }
     if (_lock) {
         AP::ahrs().lock_home();
     }
-    if ((plane.control_mode == &plane.mode_rtl)
+    if ((control_mode == &mode_rtl)
 #if HAL_QUADPLANE_ENABLED
-            || (plane.control_mode == &plane.mode_qrtl)
+            || (control_mode == &mode_qrtl)
 #endif
                                                         ) {
         // if in RTL head to the updated home location
-        plane.control_mode->enter();
+        control_mode->enter();
     }
     return true;
 }
-bool GCS_MAVLINK_Plane::set_home(const Location& loc, bool _lock)
+bool Plane::set_home(const Location& loc, bool _lock)
 {
     if (!AP::ahrs().set_home(loc)) {
         return false;
@@ -807,13 +807,13 @@ bool GCS_MAVLINK_Plane::set_home(const Location& loc, bool _lock)
     if (_lock) {
         AP::ahrs().lock_home();
     }
-    if ((plane.control_mode == &plane.mode_rtl)
+    if ((control_mode == &mode_rtl)
 #if HAL_QUADPLANE_ENABLED
-            || (plane.control_mode == &plane.mode_qrtl)
+            || (control_mode == &mode_qrtl)
 #endif
                                                         ) {
         // if in RTL head to the updated home location
-        plane.control_mode->enter();
+        control_mode->enter();
     }
     return true;
 }

--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -42,8 +42,6 @@ protected:
 
     bool persist_streamrates() const override { return true; }
 
-    bool set_home_to_current_location(bool lock) override WARN_IF_UNUSED;
-    bool set_home(const Location& loc, bool lock) override WARN_IF_UNUSED;
     uint64_t capabilities() const override;
 
     void send_nav_controller_output() const override;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -986,6 +986,8 @@ private:
 
     // set home location and store it persistently:
     bool set_home_persistently(const Location &loc) WARN_IF_UNUSED;
+    bool set_home_to_current_location(bool lock) override WARN_IF_UNUSED;
+    bool set_home(const Location& loc, bool lock) override WARN_IF_UNUSED;
 
     // control_modes.cpp
     void read_control_switch();

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -475,13 +475,6 @@ MAV_RESULT GCS_MAVLINK_Sub::handle_command_do_set_roi(const Location &roi_loc)
     return MAV_RESULT_ACCEPTED;
 }
 
-bool GCS_MAVLINK_Sub::set_home_to_current_location(bool _lock) {
-    return sub.set_home_to_current_location(_lock);
-}
-bool GCS_MAVLINK_Sub::set_home(const Location& loc, bool _lock) {
-    return sub.set_home(loc, _lock);
-}
-
 MAV_RESULT GCS_MAVLINK_Sub::handle_command_int_packet(const mavlink_command_int_t &packet, const mavlink_message_t &msg)
 {
     switch(packet.command) {

--- a/ArduSub/GCS_Mavlink.h
+++ b/ArduSub/GCS_Mavlink.h
@@ -29,9 +29,6 @@ protected:
     int32_t global_position_int_alt() const override;
     int32_t global_position_int_relative_alt() const override;
 
-    bool set_home_to_current_location(bool lock) override WARN_IF_UNUSED;
-    bool set_home(const Location& loc, bool lock) override WARN_IF_UNUSED;
-
     void send_banner() override;
 
     void send_nav_controller_output() const override;

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -423,8 +423,8 @@ private:
     void userhook_SuperSlowLoop();
     void update_home_from_EKF();
     void set_home_to_current_location_inflight();
-    bool set_home_to_current_location(bool lock) WARN_IF_UNUSED;
-    bool set_home(const Location& loc, bool lock) WARN_IF_UNUSED;
+    bool set_home_to_current_location(bool lock) override WARN_IF_UNUSED;
+    bool set_home(const Location& loc, bool lock) override WARN_IF_UNUSED;
     bool far_from_EKF_origin(const Location& loc);
     void exit_mission();
     bool verify_loiter_unlimited();

--- a/Blimp/Blimp.h
+++ b/Blimp/Blimp.h
@@ -310,8 +310,8 @@ private:
     // commands.cpp
     void update_home_from_EKF();
     void set_home_to_current_location_inflight();
-    bool set_home_to_current_location(bool lock) WARN_IF_UNUSED;
-    bool set_home(const Location& loc, bool lock) WARN_IF_UNUSED;
+    bool set_home_to_current_location(bool lock) override WARN_IF_UNUSED;
+    bool set_home(const Location& loc, bool lock) override WARN_IF_UNUSED;
     bool far_from_EKF_origin(const Location& loc);
 
     // ekf_check.cpp

--- a/Blimp/GCS_Mavlink.cpp
+++ b/Blimp/GCS_Mavlink.cpp
@@ -448,15 +448,6 @@ MAV_RESULT GCS_MAVLINK_Blimp::handle_command_do_set_roi(const Location &roi_loc)
     return MAV_RESULT_ACCEPTED;
 }
 
-bool GCS_MAVLINK_Blimp::set_home_to_current_location(bool _lock)
-{
-    return blimp.set_home_to_current_location(_lock);
-}
-bool GCS_MAVLINK_Blimp::set_home(const Location& loc, bool _lock)
-{
-    return blimp.set_home(loc, _lock);
-}
-
 MAV_RESULT GCS_MAVLINK_Blimp::handle_command_int_do_reposition(const mavlink_command_int_t &packet)
 {
     const bool change_modes = ((int32_t)packet.param2 & MAV_DO_REPOSITION_FLAGS_CHANGE_MODE) == MAV_DO_REPOSITION_FLAGS_CHANGE_MODE;

--- a/Blimp/GCS_Mavlink.h
+++ b/Blimp/GCS_Mavlink.h
@@ -35,8 +35,6 @@ protected:
     bool mav_frame_for_command_long(MAV_FRAME &frame, MAV_CMD packet_command) const override;
 #endif
 
-    bool set_home_to_current_location(bool lock) override WARN_IF_UNUSED;
-    bool set_home(const Location& loc, bool lock) override WARN_IF_UNUSED;
     void send_nav_controller_output() const override; //TODO Apparently can't remove this or the build fails.
     uint64_t capabilities() const override;
 

--- a/Rover/GCS_Mavlink.cpp
+++ b/Rover/GCS_Mavlink.cpp
@@ -656,14 +656,6 @@ MAV_RESULT GCS_MAVLINK_Rover::_handle_command_preflight_calibration(const mavlin
     return GCS_MAVLINK::_handle_command_preflight_calibration(packet, msg);
 }
 
-bool GCS_MAVLINK_Rover::set_home_to_current_location(bool _lock) {
-    return rover.set_home_to_current_location(_lock);
-}
-
-bool GCS_MAVLINK_Rover::set_home(const Location& loc, bool _lock) {
-    return rover.set_home(loc, _lock);
-}
-
 MAV_RESULT GCS_MAVLINK_Rover::handle_command_int_packet(const mavlink_command_int_t &packet, const mavlink_message_t &msg)
 {
     switch (packet.command) {

--- a/Rover/GCS_Mavlink.h
+++ b/Rover/GCS_Mavlink.h
@@ -31,8 +31,6 @@ protected:
 
     bool persist_streamrates() const override { return true; }
 
-    bool set_home_to_current_location(bool lock) override;
-    bool set_home(const Location& loc, bool lock) override;
     uint64_t capabilities() const override;
 
     void send_nav_controller_output() const override;

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -295,8 +295,8 @@ private:
     bool is_balancebot() const;
 
     // commands.cpp
-    bool set_home_to_current_location(bool lock) WARN_IF_UNUSED;
-    bool set_home(const Location& loc, bool lock) WARN_IF_UNUSED;
+    bool set_home_to_current_location(bool lock) override WARN_IF_UNUSED;
+    bool set_home(const Location& loc, bool lock) override WARN_IF_UNUSED;
     void update_home();
 
     // crash_check.cpp

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -290,8 +290,8 @@ public:
     virtual bool get_rate_ef_targets(Vector3f& rate_ef_targets) const { return false; }
 
 #if AP_AHRS_ENABLED
-    virtual bool set_home_to_current_location(bool lock) WARN_IF_UNUSED = 0;
-    virtual bool set_home(const Location& loc, bool lock) WARN_IF_UNUSED = 0;
+    virtual bool set_home_to_current_location(bool lock) WARN_IF_UNUSED { return false; }
+    virtual bool set_home(const Location& loc, bool lock) WARN_IF_UNUSED { return false; }
 #endif
 
 protected:

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -289,6 +289,11 @@ public:
      */
     virtual bool get_rate_ef_targets(Vector3f& rate_ef_targets) const { return false; }
 
+#if AP_AHRS_ENABLED
+    virtual bool set_home_to_current_location(bool lock) WARN_IF_UNUSED = 0;
+    virtual bool set_home(const Location& loc, bool lock) WARN_IF_UNUSED = 0;
+#endif
+
 protected:
 
     virtual void init_ardupilot() = 0;

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -526,8 +526,8 @@ protected:
     virtual MAV_RESULT handle_command_int_packet(const mavlink_command_int_t &packet, const mavlink_message_t &msg);
     MAV_RESULT handle_command_int_external_position_estimate(const mavlink_command_int_t &packet);
 
-    virtual bool set_home_to_current_location(bool lock) = 0;
-    virtual bool set_home(const Location& loc, bool lock) = 0;
+    bool set_home_to_current_location(bool lock);
+    bool set_home(const Location& loc, bool lock);
 
 #if AP_ARMING_ENABLED
     virtual MAV_RESULT handle_command_component_arm_disarm(const mavlink_command_int_t &packet);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -5057,6 +5057,23 @@ void GCS_MAVLINK::handle_landing_target(const mavlink_message_t &msg)
 }
 
 
+bool GCS_MAVLINK::set_home_to_current_location(bool _lock)
+{
+#if AP_VEHICLE_ENABLED
+    return AP::vehicle()->set_home_to_current_location(_lock);
+#else
+    return false;
+#endif
+}
+
+bool GCS_MAVLINK::set_home(const Location& loc, bool _lock) {
+#if AP_VEHICLE_ENABLED
+    return AP::vehicle()->set_home(loc, _lock);
+#else
+    return false;
+#endif
+}
+
 MAV_RESULT GCS_MAVLINK::handle_command_do_set_home(const mavlink_command_int_t &packet)
 {
     if (is_equal(packet.param1, 1.0f) || (packet.x == 0 && packet.y == 0)) {

--- a/libraries/GCS_MAVLink/GCS_Dummy.h
+++ b/libraries/GCS_MAVLink/GCS_Dummy.h
@@ -33,9 +33,6 @@ protected:
     MAV_MODE base_mode() const override { return (MAV_MODE)MAV_MODE_FLAG_CUSTOM_MODE_ENABLED; }
     MAV_STATE vehicle_system_status() const override { return MAV_STATE_CALIBRATING; }
 
-    bool set_home_to_current_location(bool _lock) override { return false; }
-    bool set_home(const Location& loc, bool _lock) override { return false; }
-
     void send_nav_controller_output() const override {};
     void send_pid_tuning() override {};
 };


### PR DESCRIPTION
This takes advantage of all our vehicles inheriting from AP_Vehicle, which they didn't when the pure-virtual methods on GCS_MAVLink were first created.

I'm not sure this is the correct shape for handling home generally, but given all but one of our vehicles had the relevant methods already on the vehicle class it seems a reasonable improvement.

There's the basic question of whether home is an AHRS thing or an AP_Vehicle thing.  While AHRS has been a good place for home, notionally you don't need AHRS to have a home (Tracker kinda-sorta shows that....)

A first step in further unifying home-position behaviour across vehicle types, anyway.
