### PR TITLE
AP_Logger_MAVLink: Remove code that changes behavior when in SITL

### DIFF
--- a/libraries/AP_Logger/AP_Logger_MAVLink.cpp
+++ b/libraries/AP_Logger/AP_Logger_MAVLink.cpp
@@ -577,13 +577,6 @@ bool AP_Logger_MAVLink::send_log_block(struct dm_block &block)
         return false;
     }
 
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    // deliberately fail 10% of the time in SITL:
-    if ((rand() % 100 + 1) < 10) {
-        return false;
-    }
-#endif
-    
 #if DF_MAVLINK_DISABLE_INTERRUPTS
     void *istate = hal.scheduler->disable_interrupts_save();
 #endif


### PR DESCRIPTION
The removed code changed behavior of the send_log_block function when simulating with SITL. While I can understand the intention I do not think that it is the right way to do it and has the potential to confuse people debugging stuff with SITL and comparing to the real world.