### PR TITLE
Vehicles: Unmark FORMAT_VERSION as read-only

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -34,7 +34,6 @@ const AP_Param::Info Copter::var_info[] = {
     // @DisplayName: Eeprom format version number
     // @Description: This value is incremented when changes are made to the eeprom format
     // @User: Advanced
-    // @ReadOnly: True
     GSCALAR(format_version, "FORMAT_VERSION",   0),
 
     // @Param: SYSID_THISMAV

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -36,7 +36,6 @@ const AP_Param::Info Sub::var_info[] = {
     // @DisplayName: Eeprom format version number
     // @Description: This value is incremented when changes are made to the eeprom format
     // @User: Advanced
-    // @ReadOnly: True
     GSCALAR(format_version, "FORMAT_VERSION",   0),
 
     // @Param: SYSID_THISMAV

--- a/Blimp/Parameters.cpp
+++ b/Blimp/Parameters.cpp
@@ -27,7 +27,6 @@ const AP_Param::Info Blimp::var_info[] = {
     // @DisplayName: Eeprom format version number
     // @Description: This value is incremented when changes are made to the eeprom format
     // @User: Advanced
-    // @ReadOnly: True
     GSCALAR(format_version, "FORMAT_VERSION",   0),
 
     // @Param: SYSID_THISMAV


### PR DESCRIPTION
Match behavior of all vehicles. Allows GCSes to use documented behavior of a zero write to FORMAT_VERSION to reset EEPROM contents.

Verified that this does not change the built firmware contents. Presumably GCSes will need to update their parameter metadata.