### PR TITLE
AP_Logger: handle LOG_DISARMED=0 in mavlink-logging backend

### DIFF
--- a/libraries/AP_Logger/AP_Logger_MAVLink.cpp
+++ b/libraries/AP_Logger/AP_Logger_MAVLink.cpp
@@ -57,6 +57,10 @@ void AP_Logger_MAVLink::Init()
 
 bool AP_Logger_MAVLink::logging_failed() const
 {
+    // Ensure check doesnt fail for special case: Plane disarmed & logging while disarmed disabled
+    if (_front._params.log_disarmed == AP_Logger::LogDisarmed::NONE && !hal.util->get_soft_armed()) { 
+        return false;
+    }
     return !_sending_to_client;
 }
 


### PR DESCRIPTION
# Description

In the current implementation the mavlink backend cant be used without warning messages from the GCS if the GCS doesnt want to / can permanently receive the whole logging stream (e.g. LOG_DISARMED=0 which is the default value). To explain the erroneous behaviour i want to show 3 possible situations which are possible with the [two possible operation modes of the mavlink-router](https://github.com/mavlink-router/mavlink-router/blob/master/examples/config.sample#L66) which implementats the GCS side of mavlink-logging:

### 1.

- mavlink-router: logging mode "always"
- APM: DISARMED||ARMED + LOG_BACKEND_TYPE=MAVLINK-BIT-SET
- Mavlink-logging backend detects mavlink-router which saves data to disc. Mavlink-logging backend logging_failed == false


### 2.

- mavlink-router: logging mode "while-armed"
- APM: DISARMED + LOG_DISARMED=0 + LOG_BACKEND_TYPE=MAVLINK-BIT-SET
- Mavlink-logging backend doesnt detect mavlink-router as no data is saved. Mavlink-logging backend logging_failed == true
 

### 3.

- mavlink-router: logging mode "while-armed"
- APM: ARMED + LOG_DISARMED=0 + LOG_BACKEND_TYPE=MAVLINK-BIT-SET
- Mavlink-logging backend detects mavlink-router which saves data to disc. Mavlink-logging backend logging_failed == false
 

Case 1 is a inconvient for the user as a lot of non interesting data is saved. 

Case 2 prevents usage of the arming checks for logging and creates warnings in AP_RCTelemetry.cpp, as the mavlink-logger always fails.

# Implementation details

This PR tries to create a exception behaviour for Case 2 to not fail automatically when no logging stream is supposed to be sent via mavlink(LOG_DISARMED=0 + DISARMED).

# Tests performed

Tested Usecases 1,2,3 with SITL on my local machine successfully without further warnings by safetychecks and also checked the [`logging_healthy` variable](https://github.com/ArduPilot/ardupilot/blob/master/libraries/GCS_MAVLink/GCS.cpp#L244) manually in the debugger.

mavlink-router config file used:

```
[General]
# Valid values: <auto>, <common> or <ardupilotmega>
# Default: <auto>
MavlinkDialect = ardupilotmega

# folder to put logs to
Log = /tmp/logs

# Define when to store flight stack or telemetry logs. From the start of
# mavlink-router until it's stopped or just while the vehicle is armed.
# Valid values: <always>, <while-armed>
# Default: <always>
LogMode = while-armed
#LogMode = always

[UdpEndpoint in_binlogrecorder]
Mode = Server
Address = 127.0.0.1
Port = 14550

```