### PR TITLE
Correct off-by-one problem in EKF IMU ringbuffer

### DIFF
--- a/libraries/AP_NavEKF/EKF_Buffer.cpp
+++ b/libraries/AP_NavEKF/EKF_Buffer.cpp
@@ -137,6 +137,7 @@ bool ekf_imu_buffer::init(uint32_t size)
     _size = size;
     _youngest = 0;
     _oldest = 0;
+    _filled = 0;
     return true;
 }
 

--- a/libraries/AP_NavEKF/EKF_Buffer.cpp
+++ b/libraries/AP_NavEKF/EKF_Buffer.cpp
@@ -137,7 +137,7 @@ bool ekf_imu_buffer::init(uint32_t size)
     _size = size;
     _youngest = 0;
     _oldest = 0;
-    _filled = 0;
+    _filled = false;
     return true;
 }
 
@@ -152,13 +152,14 @@ void ekf_imu_buffer::push_youngest_element(const void *element)
         return;
     }
     // push youngest to the buffer
-    _youngest = (_youngest+1) % _size;
+    _youngest++;
+    if (_youngest == _size) {
+        _youngest = 0;
+        _filled = true;
+    }
     memcpy(get_offset(_youngest), element, elsize);
     // set oldest data index
     _oldest = (_youngest+1) % _size;
-    if (_oldest == 0) {
-        _filled = true;
-    }
 }
 
 // retrieve the oldest data from the ring buffer tail


### PR DESCRIPTION
This is an alternate solution to a bug @luweiagi found in the EKF buffer code.

His PR is here: https://github.com/ArduPilot/ardupilot/issues/25316

My formulation here switches the determination of whether the buffer has ever been full to looking for us wrapping the new offset, rather than looking at the old offset.

I think all of these approaches are bogus; if we advance the oldest pointer then we may never actually be "full".  I think the current behaviour only works because the EKF doesn't consume until the buffers have been full at least once.

The supplied tests fail before this PR, pass after (the buffer says it is full on the third element, not the fourth, as @luweiagi pointed out in the issue).

Closes #25316 
