### PR TITLE
Plane: Change a return statement that is not executed

### DIFF
--- a/ArduPlane/mode_auto.cpp
+++ b/ArduPlane/mode_auto.cpp
@@ -14,7 +14,7 @@ bool ModeAuto::_enter()
             return false;
         }
     }
-    
+
     if (plane.quadplane.available() && plane.quadplane.enable == 2) {
         plane.auto_state.vtol_mode = true;
     } else {
@@ -147,7 +147,7 @@ bool ModeAuto::_pre_arm_checks(size_t buflen, char *buffer) const
 #if HAL_QUADPLANE_ENABLED
     if (plane.quadplane.enabled()) {
         if (plane.quadplane.option_is_set(QuadPlane::OPTION::ONLY_ARM_IN_QMODE_OR_AUTO) &&
-                !plane.quadplane.is_vtol_takeoff(plane.mission.get_current_nav_cmd().id)) {
+            !plane.quadplane.is_vtol_takeoff(plane.mission.get_current_nav_cmd().id)) {
             hal.util->snprintf(buffer, buflen, "not in VTOL takeoff");
             return false;
         }

--- a/ArduPlane/mode_auto.cpp
+++ b/ArduPlane/mode_auto.cpp
@@ -126,17 +126,19 @@ void ModeAuto::navigate()
 bool ModeAuto::does_auto_navigation() const
 {
 #if AP_SCRIPTING_ENABLED
-   return (!plane.nav_scripting_active());
+    return (!plane.nav_scripting_active());
+#else
+    return true;
 #endif
-   return true;
 }
 
 bool ModeAuto::does_auto_throttle() const
 {
 #if AP_SCRIPTING_ENABLED
-   return (!plane.nav_scripting_active());
+    return (!plane.nav_scripting_active());
+#else
+    return true;
 #endif
-   return true;
 }
 
 // returns true if the vehicle can be armed in this mode


### PR DESCRIPTION
When AP_SCRIPTING_ENABLED is enabled, there are RETURN statements that are not executed.
I would make sure to select the RETURN statement