### PR TITLE
Tools: ardupilotwaf: use classic clang linker when compiling on macOS

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -433,9 +433,14 @@ class Board:
             ]
 
         if cfg.env.DEST_OS == 'darwin':
-            env.LINKFLAGS += [
-                '-Wl,-dead_strip',
-            ]
+            if self.cc_version_gte(cfg, 15, 0):
+                env.LINKFLAGS += [
+                    '-Wl,-dead_strip,-ld_classic',
+                ]
+            else:
+                env.LINKFLAGS += [
+                    '-Wl,-dead_strip',
+                ]
         else:
             env.LINKFLAGS += [
                 '-fno-exceptions',


### PR DESCRIPTION
Fix issue where linker fails with Xcode 15.3.

Reported here:
- https://discuss.ardupilot.org/t/compile-ardupilot-4-4-4-copter-sitl-on-mac-m1-sonoma-14-4/115210
- https://discord.com/channels/674039678562861068/674039678982422579/1225621147278770316

Some discussion about Xcode linker changes here:
- https://developer.apple.com/forums/thread/731089?page=2

Fix verified using:
- MacBookPro M1 Max
- macOS Sonoma 14.3.1
- Xcode_15.3
- Command_Line_Tools_for_Xcode_15.3

## Tasks

- [x] Needs to be backwards compatible for versions of Apple clang < 15.0.0 (clang-1500.3.9.4)