### PR TITLE
AP_RCProtocol: fixed crc memory range error in CRSF

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
@@ -276,7 +276,7 @@ bool AP_RCProtocol_CRSF::check_frame(uint32_t timestamp_us)
         return false;
     }
 
-    if (_frame.length + CRSF_HEADER_LEN < _frame_ofs) {
+    if (_frame.length < CRSF_FRAME_LENGTH_MIN) {
         // invalid short frame
         return false;
     }

--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
@@ -276,6 +276,11 @@ bool AP_RCProtocol_CRSF::check_frame(uint32_t timestamp_us)
         return false;
     }
 
+    if (_frame.length + CRSF_HEADER_LEN < _frame_ofs) {
+        // invalid short frame
+        return false;
+    }
+
     // decode whatever we got and expect
     if (_frame_ofs >= _frame.length + CRSF_HEADER_LEN) {
         const uint8_t crc = crc8_dvb_s2_update(0, &_frame_bytes[CRSF_HEADER_LEN], _frame.length - 1);

--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.h
@@ -33,6 +33,7 @@
 #define CRSF_FRAMELEN_MAX   64U      // maximum possible framelength
 #define CRSF_HEADER_LEN     2U       // header length
 #define CRSF_FRAME_PAYLOAD_MAX (CRSF_FRAMELEN_MAX - CRSF_HEADER_LEN)     // maximum size of the frame length field in a packet
+#define CRSF_FRAME_LENGTH_MIN 2 // min value for _frame.length
 #define CRSF_BAUDRATE      416666U
 #define ELRS_BAUDRATE      420000U
 #define CRSF_TX_TIMEOUT    500000U   // the period after which the transmitter is considered disconnected (matches copters failsafe)

--- a/libraries/AP_RCProtocol/AP_RCProtocol_GHST.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_GHST.cpp
@@ -177,6 +177,12 @@ void AP_RCProtocol_GHST::_process_byte(uint32_t timestamp_us, uint8_t byte)
         return;
     }
 
+    if (_frame.length < 2) {
+        // invalid length, we subtract 2 below
+        _frame_ofs = 0;
+        return;
+    }
+    
     // decode whatever we got and expect
     if (_frame_ofs == _frame.length + GHST_HEADER_LEN) {
         log_data(AP_RCProtocol::GHST, timestamp_us, (const uint8_t*)&_frame, _frame_ofs - GHST_HEADER_LEN);

--- a/libraries/AP_RCProtocol/examples/RCProtocolTest/RCProtocolTest.cpp
+++ b/libraries/AP_RCProtocol/examples/RCProtocolTest/RCProtocolTest.cpp
@@ -23,6 +23,12 @@
 #include <AP_VideoTX/AP_VideoTX.h>
 #include <stdio.h>
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#endif
+
 void setup();
 void loop();
 
@@ -280,6 +286,39 @@ static bool test_protocol_bytesonly(const char *name, uint32_t baudrate,
     return ret;
 }
 
+/*
+  test with random data
+ */
+static void test_random(void)
+{
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    const uint32_t baudrates[] = { 115200, 100000, 416666, 420000 };
+    const uint32_t test_bytes = 1000000;
+    int fd = open("/dev/urandom", O_RDONLY);
+    if (fd == -1) {
+        printf("Can't open /dev/urandom\n");
+        return;
+    }
+    uint8_t *buf = (uint8_t *)malloc(test_bytes);
+    for (const auto b : baudrates) {
+        printf("Testing random with baud %u\n", unsigned(b));
+        rcprot = new AP_RCProtocol();
+        rcprot->init();
+        if (::read(fd, buf, test_bytes) != test_bytes) {
+            printf("Failed to read from /dev/urandom\n");
+            break;
+        }
+        for (uint32_t i=0; i<test_bytes; i++) {
+            rcprot->process_byte(buf[i], b);
+        }
+        delete rcprot;
+        rcprot = nullptr;
+    }
+    free(buf);
+    close(fd);
+#endif
+}
+
 //Main loop where the action takes place
 #pragma GCC diagnostic error "-Wframe-larger-than=2000"
 void loop()
@@ -478,6 +517,11 @@ void loop()
     test_protocol("FPORT", 115200, fport_bytes, sizeof(fport_bytes), fport_output, ARRAY_SIZE(fport_output), 3, 0, true);
     test_protocol("FPORT2_16CH", 115200, fport2_16ch_bytes, sizeof(fport2_16ch_bytes), fport2_16ch_output, ARRAY_SIZE(fport2_16ch_output), 3, 0, true);
     test_protocol("FPORT2_24CH", 115200, fport2_24ch_bytes, sizeof(fport2_24ch_bytes), fport2_24ch_output, ARRAY_SIZE(fport2_24ch_output), 3, 0, true);
+
+    /*
+      now test with random data to ensure we don't have any logic bugs that can cause a crash of the parser
+     */
+    test_random();
 
     if (test_count++ == 10) {
         if (test_failures == 0) {


### PR DESCRIPTION
this fixes a crash bug that caused a watchdog for Henry on a F765-Wing. The bug happens with corrupt serial data causing an underflow in the length argument to the crc call
![image](https://github.com/ArduPilot/ardupilot/assets/831867/fddc2502-8813-426e-91ed-3c24d00705ce)
![image](https://github.com/ArduPilot/ardupilot/assets/831867/2729ce61-716a-471b-b83b-75ca9fe4a032)
this also adds a random data test that triggers the bug, which demonstrates the fix
