### PR TITLE
ChibiOS, SITL: add 1Hz logging of UART data rates

### DIFF
--- a/libraries/AP_HAL/LogStructure.h
+++ b/libraries/AP_HAL/LogStructure.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <AP_Logger/LogStructure.h>
+#include "UARTDriver.h"
+
+#define LOG_IDS_FROM_HAL \
+    LOG_UART_MSG
+
+// @LoggerMessage: UART
+// @Description: UART stats
+// @Field: TimeUS: Time since system startup
+// @Field: I: instance
+// @Field: Tx: transmitted data rate bytes per second
+// @Field: Rx: received data rate bytes per second
+struct PACKED log_UART {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t instance;
+    float tx_rate;
+    float rx_rate;
+};
+
+#if !HAL_UART_STATS_ENABLED
+#define LOG_STRUCTURE_FROM_HAL
+#else
+#define LOG_STRUCTURE_FROM_HAL                          \
+    { LOG_UART_MSG, sizeof(log_UART),                   \
+      "UART","QBff","TimeUS,I,Tx,Rx", "s#BB", "F---" },
+#endif

--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -4,6 +4,7 @@
 
 #include "AP_HAL_Namespace.h"
 #include "utility/BetterStream.h"
+#include <AP_Logger/AP_Logger_config.h>
 
 #ifndef HAL_UART_STATS_ENABLED
 #define HAL_UART_STATS_ENABLED !defined(HAL_NO_UARTDRIVER)
@@ -167,7 +168,12 @@ public:
 
     // request information on uart I/O for this uart, for @SYS/uarts.txt
     virtual void uart_info(ExpandingString &str, StatsTracker &stats, const uint32_t dt_ms) {}
+
+#if HAL_LOGGING_ENABLED
+    // Log stats for this instance
+    void log_stats(const uint8_t inst, StatsTracker &stats, const uint32_t dt_ms);
 #endif
+#endif // HAL_UART_STATS_ENABLED
 
     /*
       software control of the CTS/RTS pins if available. Return false if

--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -233,7 +233,13 @@ protected:
 
     // discard incoming data on the port
     virtual bool _discard_input(void) = 0;
-    
+
+#if HAL_UART_STATS_ENABLED
+    // Getters for cumulative tx and rx counts
+    virtual uint32_t get_total_tx_bytes() const { return 0; }
+    virtual uint32_t get_total_rx_bytes() const { return 0; }
+#endif
+
 private:
     // option bits for port
     uint16_t _last_options;

--- a/libraries/AP_HAL/Util.h
+++ b/libraries/AP_HAL/Util.h
@@ -3,6 +3,7 @@
 #include <stdarg.h>
 #include <AP_Common/AP_Common.h> // for FMT_PRINTF
 #include "AP_HAL_Namespace.h"
+#include <AP_Logger/AP_Logger_config.h>
 
 class ExpandingString;
 
@@ -192,7 +193,13 @@ public:
 #if HAL_UART_STATS_ENABLED
     // request information on uart I/O
     virtual void uart_info(ExpandingString &str) {}
+
+#if HAL_LOGGING_ENABLED
+    // Log UART message for each serial port
+    virtual void uart_log() {};
 #endif
+#endif // HAL_UART_STATS_ENABLED
+
     // request information on timer frequencies
     virtual void timer_info(ExpandingString &str) {}
 

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -274,6 +274,12 @@ protected:
     ssize_t _read(uint8_t *buffer, uint16_t count) override;
     uint32_t _available() override;
     bool _discard_input() override;
+
+#if HAL_UART_STATS_ENABLED
+    // Getters for cumulative tx and rx counts
+    uint32_t get_total_tx_bytes() const override { return _tx_stats_bytes; }
+    uint32_t get_total_rx_bytes() const override { return _rx_stats_bytes; }
+#endif
 };
 
 // access to usb init for stdio.cpp

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -684,8 +684,8 @@ void Util::uart_info(ExpandingString &str)
 {
     // Calculate time since last call
     const uint32_t now_ms = AP_HAL::millis();
-    const uint32_t dt_ms = now_ms - uart_stats.last_ms;
-    uart_stats.last_ms = now_ms;
+    const uint32_t dt_ms = now_ms - sys_uart_stats.last_ms;
+    sys_uart_stats.last_ms = now_ms;
 
     // a header to allow for machine parsers to determine format
     str.printf("UARTV1\n");
@@ -693,15 +693,38 @@ void Util::uart_info(ExpandingString &str)
         auto *uart = hal.serial(i);
         if (uart) {
             str.printf("SERIAL%u ", i);
-            uart->uart_info(str, uart_stats.serial[i], dt_ms);
+            uart->uart_info(str, sys_uart_stats.serial[i], dt_ms);
         }
     }
 #if HAL_WITH_IO_MCU
     str.printf("IOMCU   ");
-    uart_io.uart_info(str, uart_stats.io, dt_ms);
+    uart_io.uart_info(str, sys_uart_stats.io, dt_ms);
 #endif
 }
+
+// Log UART message for each serial port
+#if HAL_LOGGING_ENABLED
+void Util::uart_log()
+{
+    // Calculate time since last call
+    const uint32_t now_ms = AP_HAL::millis();
+    const uint32_t dt_ms = now_ms - log_uart_stats.last_ms;
+    log_uart_stats.last_ms = now_ms;
+
+    // Loop over all numbered ports
+    for (uint8_t i = 0; i < HAL_UART_NUM_SERIAL_PORTS; i++) {
+        auto *uart = hal.serial(i);
+        if (uart) {
+            uart->log_stats(i, log_uart_stats.serial[i], dt_ms);
+        }
+    }
+#if HAL_WITH_IO_MCU
+    // Use magic instance 100 for IOMCU
+    uart_io.log_stats(100, log_uart_stats.io, dt_ms);
 #endif
+}
+#endif // HAL_LOGGING_ENABLED
+#endif // HAL_UART_STATS_ENABLED
 
 // request information on uart I/O
 #if HAL_USE_PWM == TRUE

--- a/libraries/AP_HAL_ChibiOS/Util.h
+++ b/libraries/AP_HAL_ChibiOS/Util.h
@@ -20,6 +20,7 @@
 #include "AP_HAL_ChibiOS_Namespace.h"
 #include "AP_HAL_ChibiOS.h"
 #include <ch.h>
+#include <AP_Logger/AP_Logger_config.h>
 
 class ExpandingString;
 
@@ -99,7 +100,13 @@ public:
 #if HAL_UART_STATS_ENABLED
     // request information on uart I/O
     void uart_info(ExpandingString &str) override;
+
+#if HAL_LOGGING_ENABLED
+    // Log UART message for each serial port
+    void uart_log() override;
 #endif
+#endif // HAL_UART_STATS_ENABLED
+
 #if HAL_USE_PWM == TRUE
     void timer_info(ExpandingString &str) override;
 #endif
@@ -163,12 +170,16 @@ private:
 #endif
 
 #if HAL_UART_STATS_ENABLED
-    struct {
+    struct uart_stats {
         AP_HAL::UARTDriver::StatsTracker serial[HAL_UART_NUM_SERIAL_PORTS];
 #if HAL_WITH_IO_MCU
         AP_HAL::UARTDriver::StatsTracker io;
 #endif
         uint32_t last_ms;
-    } uart_stats;
+    };
+    uart_stats sys_uart_stats;
+#if HAL_LOGGING_ENABLED
+    uart_stats log_uart_stats;
+#endif
 #endif
 };

--- a/libraries/AP_HAL_SITL/UARTDriver.h
+++ b/libraries/AP_HAL_SITL/UARTDriver.h
@@ -145,6 +145,12 @@ protected:
     void _flush() override;
     bool _discard_input() override;
 
+#if HAL_UART_STATS_ENABLED
+    // Getters for cumulative tx and rx counts
+    uint32_t get_total_tx_bytes() const override { return _tx_stats_bytes; }
+    uint32_t get_total_rx_bytes() const override { return _rx_stats_bytes; }
+#endif
+
 private:
     void handle_writing_from_writebuffer_to_device();
     void handle_reading_from_device_to_readbuffer();

--- a/libraries/AP_HAL_SITL/Util.cpp
+++ b/libraries/AP_HAL_SITL/Util.cpp
@@ -199,8 +199,8 @@ void HALSITL::Util::uart_info(ExpandingString &str)
 {
     // Calculate time since last call
     const uint32_t now_ms = AP_HAL::millis();
-    const uint32_t dt_ms = now_ms - uart_stats.last_ms;
-    uart_stats.last_ms = now_ms;
+    const uint32_t dt_ms = now_ms - sys_uart_stats.last_ms;
+    sys_uart_stats.last_ms = now_ms;
 
     // a header to allow for machine parsers to determine format
     str.printf("UARTV1\n");
@@ -211,8 +211,27 @@ void HALSITL::Util::uart_info(ExpandingString &str)
         auto *uart = hal.serial(i);
         if (uart) {
             str.printf("SERIAL%u ", i);
-            uart->uart_info(str, uart_stats.serial[i], dt_ms);
+            uart->uart_info(str, sys_uart_stats.serial[i], dt_ms);
         }
     }
 }
-#endif
+
+#if HAL_LOGGING_ENABLED
+// Log UART message for each serial port
+void HALSITL::Util::uart_log()
+{
+    // Calculate time since last call
+    const uint32_t now_ms = AP_HAL::millis();
+    const uint32_t dt_ms = now_ms - log_uart_stats.last_ms;
+    log_uart_stats.last_ms = now_ms;
+
+    // Loop over all ports
+    for (uint8_t i = 0; i < hal.num_serial; i++) {
+        auto *uart = hal.serial(i);
+        if (uart) {
+            uart->log_stats(i, log_uart_stats.serial[i], dt_ms);
+        }
+    }
+}
+#endif // HAL_LOGGING_ENABLED
+#endif // HAL_UART_STATS_ENABLED

--- a/libraries/AP_HAL_SITL/Util.h
+++ b/libraries/AP_HAL_SITL/Util.h
@@ -5,6 +5,7 @@
 #include "AP_HAL_SITL.h"
 #include "Semaphores.h"
 #include "ToneAlarm_SF.h"
+#include <AP_Logger/AP_Logger_config.h>
 
 #if !defined(__CYGWIN__) && !defined(__CYGWIN64__)
 #include <sys/types.h>
@@ -110,14 +111,23 @@ private:
 #if HAL_UART_STATS_ENABLED
     // request information on uart I/O
     void uart_info(ExpandingString &str) override;
+
+#if HAL_LOGGING_ENABLED
+    // Log UART message for each serial port
+    void uart_log() override;
 #endif
+#endif // HAL_UART_STATS_ENABLED
 
 private:
 #if HAL_UART_STATS_ENABLED
     // UART stats tracking helper
-    struct {
+    struct uart_stats {
         AP_HAL::UARTDriver::StatsTracker serial[AP_HAL::HAL::num_serial];
         uint32_t last_ms;
-    } uart_stats;
+    };
+    uart_stats sys_uart_stats;
+#if HAL_LOGGING_ENABLED
+    uart_stats log_uart_stats;
 #endif
+#endif // HAL_UART_STATS_ENABLED
 };

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -48,6 +48,7 @@ const struct UnitStructure log_Units[] = {
     { 'a', "Ah" },            // Ampere hours
     { 'd', "deg" },           // of the angular variety, -180 to 180
     { 'b', "B" },             // bytes
+    { 'B', "B/s" },           // bytes per second
     { 'k', "deg/s" },         // degrees per second. Degrees are NOT SI, but is some situations more user-friendly than radians
     { 'D', "deglatitude" },   // degrees of latitude
     { 'e', "deg/s/s" },       // degrees per second per second. Degrees are NOT SI, but is some situations more user-friendly than radians

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -145,6 +145,7 @@ const struct MultiplierStructure log_Multipliers[] = {
 #include <AC_Fence/LogStructure.h>
 #include <AP_Landing/LogStructure.h>
 #include <AC_AttitudeControl/LogStructure.h>
+#include <AP_HAL/LogStructure.h>
 
 // structure used to define logging format
 // It is packed on ChibiOS to save flash space; however, this causes problems
@@ -1271,6 +1272,7 @@ LOG_STRUCTURE_FROM_NAVEKF3 \
 LOG_STRUCTURE_FROM_NAVEKF \
 LOG_STRUCTURE_FROM_AHRS \
 LOG_STRUCTURE_FROM_HAL_CHIBIOS \
+LOG_STRUCTURE_FROM_HAL \
 LOG_STRUCTURE_FROM_RPM \
 LOG_STRUCTURE_FROM_FENCE \
     { LOG_DF_FILE_STATS, sizeof(log_DSF), \
@@ -1391,6 +1393,7 @@ enum LogMessages : uint8_t {
     LOG_RCOUT2_MSG,
     LOG_RCOUT3_MSG,
     LOG_IDS_FROM_FENCE,
+    LOG_IDS_FROM_HAL,
 
     _LOG_LAST_MSG_
 };

--- a/libraries/AP_Logger/README.md
+++ b/libraries/AP_Logger/README.md
@@ -46,6 +46,7 @@ Please keep the names consistent with Tools/autotest/param_metadata/param.py:33
 | 'A' | "A" | Ampere|
 | 'd' | "deg" | of the angular variety | -180 to 180|
 | 'b' | "B" | bytes|
+| 'B' | "B/s" | bytes per second |
 | 'k' | "deg/s" | degrees per second | Not an SI unit, but in some situations more user-friendly than radians per second|
 | 'D' | "deglatitude" | degrees of latitude|
 | 'e' | "deg/s/s" | degrees per second per second | Not an SI unit, but in some situations more user-friendly than radians per second^2|

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -1027,6 +1027,10 @@ void AP_Vehicle::one_Hz_update(void)
     scripting.update();
 #endif
 
+#if HAL_LOGGING_ENABLED
+    hal.util->uart_log();
+#endif
+
 }
 
 void AP_Vehicle::check_motor_noise()


### PR DESCRIPTION
This is a generalized version of https://github.com/ArduPilot/ardupilot/pull/26532 for all serial ports rather than only MAVLink. It does not have all the extra logging fields that https://github.com/ArduPilot/ardupilot/pull/17360 does, but they could be added in the future.

From SITL:
![image](https://github.com/ArduPilot/ardupilot/assets/33176108/d339edab-10ee-4ca1-a8d4-ca7e8e743f46)

CubeOrangePlus:
![image](https://github.com/ArduPilot/ardupilot/assets/33176108/b8534bce-1abf-4c8f-a777-f6b774c5ebc7)

Which matches more or less mission planners stats:
![image](https://github.com/ArduPilot/ardupilot/assets/33176108/a464ac41-1b04-44d8-a205-ff93dbcb735f)

Note that we do get log for every port except 4. 
![image](https://github.com/ArduPilot/ardupilot/assets/33176108/2aefe460-a25f-49de-9d8f-44185924f612)

0 I was connected to on USB.
1 and 2 are set to MAVlink, there is no rx, but we see tx data going out (both ports are the same).
![image](https://github.com/ArduPilot/ardupilot/assets/33176108/bfb53168-7c02-4d91-8cbe-3e02afbb7864)

3 is set to GPS, so it was trying to do something.
![image](https://github.com/ArduPilot/ardupilot/assets/33176108/73b122ed-f5e7-4636-8b5b-4739642e7de3)

4 is the second GPS which is disabled, so not in the log.

5 is the internal ADSB over MAVLink:
![image](https://github.com/ArduPilot/ardupilot/assets/33176108/d17aa665-fd67-4399-9060-0392222887fc)

6 is the second USB end point which is set to SLCAN. Interestingly this is in the log, so there must have been some data at some-point. But we see only 0 rate for both tx and rx.

![image](https://github.com/ArduPilot/ardupilot/assets/33176108/7d976ecc-8929-4246-865b-e3dbc83c60c1)

100 is the magic value for the IOMCU UART:
 
![image](https://github.com/ArduPilot/ardupilot/assets/33176108/29263f9d-2158-4ac8-89a1-00630ef50b87)

That we get so many in the log for a flight controller with nothing plugged in makes me wonder if we should only log if we get RX data back rather than if RX or TX. On the other hand it probably is best practice to disable the protocol for a serial port if it has nothing plugged in. 
