### PR TITLE
Tools, CI: use same-bdshotness boards for ccache test

### DIFF
--- a/.github/workflows/test_ccache.yml
+++ b/.github/workflows/test_ccache.yml
@@ -143,6 +143,6 @@ jobs:
         shell: bash
         run: |
           PATH="/usr/lib/ccache:/opt/gcc-arm-none-eabi-${{matrix.gcc}}/bin:$PATH"
-          Tools/scripts/build_tests/test_ccache.py --boards MatekF405,MatekF405-bdshot --min-cache-pct=75
-          Tools/scripts/build_tests/test_ccache.py --boards Durandal,Pixhawk6X --min-cache-pct=70
+          Tools/scripts/build_tests/test_ccache.py --boards MatekF405-bdshot,MatekF405-TE-bdshot --min-cache-pct=75
+          Tools/scripts/build_tests/test_ccache.py --boards Durandal-bdshot,Pixhawk6X --min-cache-pct=70
 

--- a/Tools/scripts/build_tests/test_ccache.py
+++ b/Tools/scripts/build_tests/test_ccache.py
@@ -9,7 +9,7 @@ import sys
 import os
 
 parser = argparse.ArgumentParser(description='test ccache performance')
-parser.add_argument('--boards', default='MatekF405,MatekF405-bdshot', help='boards to test')
+parser.add_argument('--boards', default='MatekF405-bdshot,MatekF405-TE-bdshot', help='boards to test')
 parser.add_argument('--min-cache-pct', type=int, default=75, help='minimum acceptable ccache hit rate')
 parser.add_argument('--display', action='store_true', help='parse and show ccache stats')
 


### PR DESCRIPTION
Currently, the ccache test uses two pairs of boards: `Matek-F405` vs `Matek-F405-bdshot`, and `Pixhawk6X` vs `Durandal`.

With more code coming that depends on bidirectional DShot, these boards will increasingly diverge, causing the test to fail. My work-in-progress PR #26321 is one of such changes. In light of this, the choice of boards different by being or not being bdshot-enabled seems imperfect.

This PR updates the configuration of the ccache test, so that both pairs of boards have bdshot code enabled. I tried to change as little as possible, so the first pair becomes `Matek-F405-bdshot` vs `Matek-F405-TE-bdshot`, and the second pair becomes `Pixhawk6X` vs `Durandal-bdshot`. Note that `Pixhawk6X`, just like `Pixhawk6X-bdshot`, is bdshot-enabled in terms of code compilation, because it has to support possible bidirectional DShot coming from IOMCUs.

I updated the default arguments in the Python script as well to reduce possible confusion (if left unchanged, the default arguments will eventually stop producing a positive result).