### PR TITLE
Tradheli Autotune Improvements

### DIFF
--- a/Tools/autotest/helicopter.py
+++ b/Tools/autotest/helicopter.py
@@ -876,7 +876,7 @@ class AutoTestHelicopter(AutoTestCopter):
         self.wait_statustext('AutoTune: Success', timeout=1000)
         now = self.get_sim_time()
         self.progress("AUTOTUNE OK (%u seconds)" % (now - tstart))
-        self.land_and_disarm()
+        self.autotune_land_and_save_gains()
 
         # test pitch rate P and Rate D tuning
         self.set_parameters({
@@ -895,7 +895,7 @@ class AutoTestHelicopter(AutoTestCopter):
         self.wait_statustext('AutoTune: Success', timeout=1000)
         now = self.get_sim_time()
         self.progress("AUTOTUNE OK (%u seconds)" % (now - tstart))
-        self.land_and_disarm()
+        self.autotune_land_and_save_gains()
 
         # test Roll rate P and Rate D tuning
         self.set_parameters({
@@ -914,7 +914,7 @@ class AutoTestHelicopter(AutoTestCopter):
         self.wait_statustext('AutoTune: Success', timeout=1000)
         now = self.get_sim_time()
         self.progress("AUTOTUNE OK (%u seconds)" % (now - tstart))
-        self.land_and_disarm()
+        self.autotune_land_and_save_gains()
 
         # test Roll and pitch angle P tuning
         self.set_parameters({
@@ -935,7 +935,7 @@ class AutoTestHelicopter(AutoTestCopter):
         self.wait_statustext('AutoTune: Success', timeout=1000)
         now = self.get_sim_time()
         self.progress("AUTOTUNE OK (%u seconds)" % (now - tstart))
-        self.land_and_disarm()
+        self.autotune_land_and_save_gains()
 
         # test yaw FF and rate P and Rate D
         self.set_parameters({
@@ -956,8 +956,7 @@ class AutoTestHelicopter(AutoTestCopter):
         self.wait_statustext('AutoTune: Success', timeout=1000)
         now = self.get_sim_time()
         self.progress("AUTOTUNE OK (%u seconds)" % (now - tstart))
-        self.land_and_disarm()
-        self.set_rc(8, 1000)
+        self.autotune_land_and_save_gains()
 
         # test yaw angle P tuning
         self.set_parameters({
@@ -978,7 +977,36 @@ class AutoTestHelicopter(AutoTestCopter):
         self.wait_statustext('AutoTune: Success', timeout=1000)
         now = self.get_sim_time()
         self.progress("AUTOTUNE OK (%u seconds)" % (now - tstart))
+        self.autotune_land_and_save_gains()
+
+        # tune check
+        self.set_parameters({
+            "AUTOTUNE_AXES": 7,
+            "AUTOTUNE_SEQ": 16,
+            "AUTOTUNE_FRQ_MIN": 10,
+            "AUTOTUNE_FRQ_MAX": 80,
+            })
+
+        # Conduct testing from althold
+        self.takeoff(10, mode="ALT_HOLD")
+
+        # hold position in loiter
+        self.change_mode('AUTOTUNE')
+
+        tstart = self.get_sim_time()
+        self.wait_statustext('AutoTune: Success', timeout=1000)
+        now = self.get_sim_time()
+        self.progress("AUTOTUNE OK (%u seconds)" % (now - tstart))
         self.land_and_disarm()
+
+    def autotune_land_and_save_gains(self):
+        self.set_rc(3, 1000)
+        self.context_collect('STATUSTEXT')
+        self.wait_statustext(r"SIM Hit ground at ([0-9.]+) m/s",
+                             check_context=True,
+                             regex=True)
+        self.set_rc(8, 1000)
+        self.wait_disarmed()
 
     def land_and_disarm(self, **kwargs):
         super(AutoTestHelicopter, self).land_and_disarm(**kwargs)

--- a/Tools/autotest/helicopter.py
+++ b/Tools/autotest/helicopter.py
@@ -882,7 +882,7 @@ class AutoTestHelicopter(AutoTestCopter):
         self.set_parameters({
             "AUTOTUNE_AXES": 2,
             "AUTOTUNE_SEQ": 2,
-            "AUTOTUNE_GN_MAX": 2.0,
+            "AUTOTUNE_GN_MAX": 1.8,
             })
 
         # Conduct testing from althold
@@ -901,7 +901,7 @@ class AutoTestHelicopter(AutoTestCopter):
         self.set_parameters({
             "AUTOTUNE_AXES": 1,
             "AUTOTUNE_SEQ": 2,
-            "AUTOTUNE_GN_MAX": 1.8,
+            "AUTOTUNE_GN_MAX": 1.6,
             })
 
         # Conduct testing from althold
@@ -920,7 +920,9 @@ class AutoTestHelicopter(AutoTestCopter):
         self.set_parameters({
             "AUTOTUNE_AXES": 3,
             "AUTOTUNE_SEQ": 4,
-            "AUTOTUNE_GN_MAX": 2.0,
+            "AUTOTUNE_FRQ_MIN": 5,
+            "AUTOTUNE_FRQ_MAX": 50,
+            "AUTOTUNE_GN_MAX": 1.6,
             })
 
         # Conduct testing from althold
@@ -935,11 +937,35 @@ class AutoTestHelicopter(AutoTestCopter):
         self.progress("AUTOTUNE OK (%u seconds)" % (now - tstart))
         self.land_and_disarm()
 
-        # test yaw FF, rate P and Rate D, and angle P tuning
+        # test yaw FF and rate P and Rate D
         self.set_parameters({
             "AUTOTUNE_AXES": 4,
-            "AUTOTUNE_SEQ": 7,
-            "AUTOTUNE_GN_MAX": 2.0,
+            "AUTOTUNE_SEQ": 3,
+            "AUTOTUNE_FRQ_MIN": 10,
+            "AUTOTUNE_FRQ_MAX": 70,
+            "AUTOTUNE_GN_MAX": 1.4,
+            })
+
+        # Conduct testing from althold
+        self.takeoff(10, mode="ALT_HOLD")
+
+        # hold position in loiter
+        self.change_mode('AUTOTUNE')
+
+        tstart = self.get_sim_time()
+        self.wait_statustext('AutoTune: Success', timeout=1000)
+        now = self.get_sim_time()
+        self.progress("AUTOTUNE OK (%u seconds)" % (now - tstart))
+        self.land_and_disarm()
+        self.set_rc(8, 1000)
+
+        # test yaw angle P tuning
+        self.set_parameters({
+            "AUTOTUNE_AXES": 4,
+            "AUTOTUNE_SEQ": 4,
+            "AUTOTUNE_FRQ_MIN": 5,
+            "AUTOTUNE_FRQ_MAX": 50,
+            "AUTOTUNE_GN_MAX": 1.5,
             })
 
         # Conduct testing from althold

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -120,12 +120,27 @@ public:
 
     // get the roll angular velocity limit in radians/s
     float get_ang_vel_roll_max_rads() const { return radians(_ang_vel_roll_max); }
+    // get the roll angular velocity limit in degrees/s
+    float get_ang_vel_roll_max_degs() const { return _ang_vel_roll_max; }
+
+    // set the roll angular velocity limit in degrees/s
+    void set_ang_vel_roll_max_degs(float vel_roll_max) { _ang_vel_roll_max.set(vel_roll_max); }
 
     // get the pitch angular velocity limit in radians/s
     float get_ang_vel_pitch_max_rads() const { return radians(_ang_vel_pitch_max); }
+    // get the pitch angular velocity limit in degrees/s
+    float get_ang_vel_pitch_max_degs() const { return _ang_vel_pitch_max; }
+
+    // set the pitch angular velocity limit in degrees/s
+    void set_ang_vel_pitch_max_degs(float vel_pitch_max) { _ang_vel_pitch_max.set(vel_pitch_max); }
 
     // get the yaw angular velocity limit in radians/s
     float get_ang_vel_yaw_max_rads() const { return radians(_ang_vel_yaw_max); }
+    // get the yaw angular velocity limit in degrees/s
+    float get_ang_vel_yaw_max_degs() const { return _ang_vel_yaw_max; }
+
+    // set the yaw angular velocity limit in degrees/s
+    void set_ang_vel_yaw_max_degs(float vel_yaw_max) { _ang_vel_yaw_max.set(vel_yaw_max); }
 
     // get the slew yaw rate limit in deg/s
     float get_slew_yaw_max_degs() const;

--- a/libraries/AC_AutoTune/AC_AutoTune.h
+++ b/libraries/AC_AutoTune/AC_AutoTune.h
@@ -300,10 +300,8 @@ protected:
     float roll_cd, pitch_cd;
 
     // heli specific variables
-    uint8_t  freq_cnt;                              // dwell test iteration counter
-    float    start_freq;                            // start freq for dwell test
-    float    stop_freq;                             // ending freq for dwell test
-    bool     ff_up_first_iter;                      // true on first iteration of ff up testing
+    float    start_freq;                            //start freq for dwell test
+    float    stop_freq;                             //ending freq for dwell test
 
 private:
     // return true if we have a good position estimate

--- a/libraries/AC_AutoTune/AC_AutoTune.h
+++ b/libraries/AC_AutoTune/AC_AutoTune.h
@@ -283,9 +283,9 @@ protected:
     LowPassFilterFloat  rotation_rate_filt;         // filtered rotation rate in radians/second
 
     // backup of currently being tuned parameter values
-    float    orig_roll_rp, orig_roll_ri, orig_roll_rd, orig_roll_rff, orig_roll_dff, orig_roll_fltt, orig_roll_smax, orig_roll_sp, orig_roll_accel;
-    float    orig_pitch_rp, orig_pitch_ri, orig_pitch_rd, orig_pitch_rff, orig_pitch_dff, orig_pitch_fltt, orig_pitch_smax, orig_pitch_sp, orig_pitch_accel;
-    float    orig_yaw_rp, orig_yaw_ri, orig_yaw_rd, orig_yaw_rff, orig_yaw_dff, orig_yaw_fltt, orig_yaw_smax, orig_yaw_rLPF, orig_yaw_sp, orig_yaw_accel;
+    float    orig_roll_rp, orig_roll_ri, orig_roll_rd, orig_roll_rff, orig_roll_dff, orig_roll_fltt, orig_roll_smax, orig_roll_sp, orig_roll_accel, orig_roll_rate;
+    float    orig_pitch_rp, orig_pitch_ri, orig_pitch_rd, orig_pitch_rff, orig_pitch_dff, orig_pitch_fltt, orig_pitch_smax, orig_pitch_sp, orig_pitch_accel, orig_pitch_rate;
+    float    orig_yaw_rp, orig_yaw_ri, orig_yaw_rd, orig_yaw_rff, orig_yaw_dff, orig_yaw_fltt, orig_yaw_smax, orig_yaw_rLPF, orig_yaw_sp, orig_yaw_accel, orig_yaw_rate;
     bool     orig_bf_feedforward;
 
     // currently being tuned parameter values

--- a/libraries/AC_AutoTune/AC_AutoTune_FreqResp.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_FreqResp.cpp
@@ -71,7 +71,7 @@ void AC_AutoTune_FreqResp::update(float command, float tgt_resp, float meas_resp
     }
 
     // cycles are complete! determine gain and phase and exit
-    if (max_meas_cnt > AUTOTUNE_DWELL_CYCLES + 1 && max_target_cnt > AUTOTUNE_DWELL_CYCLES + 1 && excitation == DWELL) {
+    if (max_meas_cnt > dwell_cycles + 1 && max_target_cnt > dwell_cycles + 1 && excitation == DWELL) {
         float delta_time = 0.0f;
         float sum_gain = 0.0f;
         uint8_t cnt = 0;
@@ -81,7 +81,7 @@ void AC_AutoTune_FreqResp::update(float command, float tgt_resp, float meas_resp
         float tgt_ampl = 0.0f;
         uint32_t meas_time = 0;
         uint32_t tgt_time = 0;
-        for (uint8_t i = 0;  i < AUTOTUNE_DWELL_CYCLES; i++) {
+        for (uint8_t i = 0;  i < dwell_cycles; i++) {
             meas_cnt=0;
             tgt_cnt=0;
             pull_from_meas_buffer(meas_cnt, meas_ampl, meas_time);

--- a/libraries/AC_AutoTune/AC_AutoTune_FreqResp.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_FreqResp.cpp
@@ -25,8 +25,12 @@ void AC_AutoTune_FreqResp::init(InputType input_type, ResponseType response_type
     max_accel = 0.0f;
     max_meas_rate = 0.0f;
     max_command = 0.0f;
-    meas_peak_info_buffer.clear();
-    tgt_peak_info_buffer.clear();
+    if (meas_peak_info_buffer != nullptr) {
+        meas_peak_info_buffer->clear();
+    }
+    if (tgt_peak_info_buffer != nullptr) {
+        tgt_peak_info_buffer->clear();
+    }
     cycle_complete = false;
 }
 
@@ -258,14 +262,14 @@ void AC_AutoTune_FreqResp::push_to_meas_buffer(uint16_t count, float amplitude, 
     sample.curr_count = count;
     sample.amplitude = amplitude;
     sample.time_ms = time_ms;
-    meas_peak_info_buffer.push(sample);
+    meas_peak_info_buffer->push(sample);
 }
 
 // pull measured peak info from buffer
 void AC_AutoTune_FreqResp::pull_from_meas_buffer(uint16_t &count, float &amplitude, uint32_t &time_ms)
 {
     peak_info sample;
-    if (!meas_peak_info_buffer.pop(sample)) {
+    if (!meas_peak_info_buffer->pop(sample)) {
         // no sample
         return;
     }
@@ -281,7 +285,7 @@ void AC_AutoTune_FreqResp::push_to_tgt_buffer(uint16_t count, float amplitude, u
     sample.curr_count = count;
     sample.amplitude = amplitude;
     sample.time_ms = time_ms;
-    tgt_peak_info_buffer.push(sample);
+    tgt_peak_info_buffer->push(sample);
 
 }
 
@@ -289,11 +293,21 @@ void AC_AutoTune_FreqResp::push_to_tgt_buffer(uint16_t count, float amplitude, u
 void AC_AutoTune_FreqResp::pull_from_tgt_buffer(uint16_t &count, float &amplitude, uint32_t &time_ms)
 {
     peak_info sample;
-    if (!tgt_peak_info_buffer.pop(sample)) {
+    if (!tgt_peak_info_buffer->pop(sample)) {
         // no sample
         return;
     }
     count = sample.curr_count;
     amplitude = sample.amplitude;
     time_ms = sample.time_ms;
+}
+
+void AC_AutoTune_FreqResp::set_dwell_cycles(uint8_t cycles)
+{
+    dwell_cycles = cycles;
+    if (meas_peak_info_buffer != nullptr) { delete meas_peak_info_buffer;}
+    meas_peak_info_buffer = new ObjectBuffer<peak_info>(cycles);
+    if (tgt_peak_info_buffer != nullptr) { delete tgt_peak_info_buffer;}
+    tgt_peak_info_buffer = new ObjectBuffer<peak_info>(cycles);
+
 }

--- a/libraries/AC_AutoTune/AC_AutoTune_FreqResp.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_FreqResp.cpp
@@ -262,14 +262,16 @@ void AC_AutoTune_FreqResp::push_to_meas_buffer(uint16_t count, float amplitude, 
     sample.curr_count = count;
     sample.amplitude = amplitude;
     sample.time_ms = time_ms;
-    meas_peak_info_buffer->push(sample);
+    if (meas_peak_info_buffer != nullptr) {
+        meas_peak_info_buffer->push(sample);
+    }
 }
 
 // pull measured peak info from buffer
 void AC_AutoTune_FreqResp::pull_from_meas_buffer(uint16_t &count, float &amplitude, uint32_t &time_ms)
 {
     peak_info sample;
-    if (!meas_peak_info_buffer->pop(sample)) {
+    if ((meas_peak_info_buffer == nullptr) || !meas_peak_info_buffer->pop(sample)) {
         // no sample
         return;
     }
@@ -285,15 +287,16 @@ void AC_AutoTune_FreqResp::push_to_tgt_buffer(uint16_t count, float amplitude, u
     sample.curr_count = count;
     sample.amplitude = amplitude;
     sample.time_ms = time_ms;
-    tgt_peak_info_buffer->push(sample);
-
+    if (tgt_peak_info_buffer != nullptr) {
+        tgt_peak_info_buffer->push(sample);
+    }
 }
 
 // pull target peak info from buffer
 void AC_AutoTune_FreqResp::pull_from_tgt_buffer(uint16_t &count, float &amplitude, uint32_t &time_ms)
 {
     peak_info sample;
-    if (!tgt_peak_info_buffer->pop(sample)) {
+    if ((tgt_peak_info_buffer == nullptr) || !tgt_peak_info_buffer->pop(sample)) {
         // no sample
         return;
     }

--- a/libraries/AC_AutoTune/AC_AutoTune_FreqResp.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_FreqResp.cpp
@@ -305,9 +305,9 @@ void AC_AutoTune_FreqResp::pull_from_tgt_buffer(uint16_t &count, float &amplitud
 void AC_AutoTune_FreqResp::set_dwell_cycles(uint8_t cycles)
 {
     dwell_cycles = cycles;
-    if (meas_peak_info_buffer != nullptr) { delete meas_peak_info_buffer;}
+    delete meas_peak_info_buffer;
     meas_peak_info_buffer = NEW_NOTHROW ObjectBuffer<peak_info>(cycles);
-    if (tgt_peak_info_buffer != nullptr) { delete tgt_peak_info_buffer;}
+    delete tgt_peak_info_buffer;
     tgt_peak_info_buffer = NEW_NOTHROW ObjectBuffer<peak_info>(cycles);
 
 }

--- a/libraries/AC_AutoTune/AC_AutoTune_FreqResp.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_FreqResp.cpp
@@ -6,7 +6,7 @@ This library receives time history data (angular rate or angle) during a dwell t
 #include "AC_AutoTune_FreqResp.h"
 
 // Initialize the Frequency Response Object. Must be called before running dwell or frequency sweep tests
-void AC_AutoTune_FreqResp::init(InputType input_type, ResponseType response_type)
+void AC_AutoTune_FreqResp::init(InputType input_type, ResponseType response_type, uint8_t cycles)
 {
     excitation = input_type;
     response = response_type;
@@ -25,6 +25,7 @@ void AC_AutoTune_FreqResp::init(InputType input_type, ResponseType response_type
     max_accel = 0.0f;
     max_meas_rate = 0.0f;
     max_command = 0.0f;
+    dwell_cycles = cycles;
     if (meas_peak_info_buffer != nullptr) {
         meas_peak_info_buffer->clear();
     }
@@ -305,12 +306,3 @@ void AC_AutoTune_FreqResp::pull_from_tgt_buffer(uint16_t &count, float &amplitud
     time_ms = sample.time_ms;
 }
 
-void AC_AutoTune_FreqResp::set_dwell_cycles(uint8_t cycles)
-{
-    dwell_cycles = cycles;
-    delete meas_peak_info_buffer;
-    meas_peak_info_buffer = NEW_NOTHROW ObjectBuffer<peak_info>(cycles);
-    delete tgt_peak_info_buffer;
-    tgt_peak_info_buffer = NEW_NOTHROW ObjectBuffer<peak_info>(cycles);
-
-}

--- a/libraries/AC_AutoTune/AC_AutoTune_FreqResp.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_FreqResp.cpp
@@ -306,8 +306,8 @@ void AC_AutoTune_FreqResp::set_dwell_cycles(uint8_t cycles)
 {
     dwell_cycles = cycles;
     if (meas_peak_info_buffer != nullptr) { delete meas_peak_info_buffer;}
-    meas_peak_info_buffer = new ObjectBuffer<peak_info>(cycles);
+    meas_peak_info_buffer = NEW_NOTHROW ObjectBuffer<peak_info>(cycles);
     if (tgt_peak_info_buffer != nullptr) { delete tgt_peak_info_buffer;}
-    tgt_peak_info_buffer = new ObjectBuffer<peak_info>(cycles);
+    tgt_peak_info_buffer = NEW_NOTHROW ObjectBuffer<peak_info>(cycles);
 
 }

--- a/libraries/AC_AutoTune/AC_AutoTune_FreqResp.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_FreqResp.cpp
@@ -93,7 +93,6 @@ void AC_AutoTune_FreqResp::update(float command, float tgt_resp, float meas_resp
             pull_from_tgt_buffer(tgt_cnt, tgt_ampl, tgt_time);
             push_to_meas_buffer(0, 0.0f, 0);
             push_to_tgt_buffer(0, 0.0f, 0);
-            // gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: tgt_cnt=%f meas_cnt=%f", (double)(tgt_cnt), (double)(meas_cnt));
 
             if (meas_cnt == tgt_cnt && meas_cnt != 0) {
                 if (tgt_ampl > 0.0f) {
@@ -111,8 +110,7 @@ void AC_AutoTune_FreqResp::update(float command, float tgt_resp, float meas_resp
             } else if (meas_cnt < tgt_cnt) {
                 pull_from_meas_buffer(meas_cnt, meas_ampl, meas_time);
                 push_to_meas_buffer(0, 0.0f, 0);
-            }                
-
+            }        
         }
         if (gcnt > 0) {
             curr_test_gain = sum_gain / gcnt;
@@ -140,7 +138,6 @@ void AC_AutoTune_FreqResp::update(float command, float tgt_resp, float meas_resp
 
         curr_test_freq = tgt_freq;
         cycle_complete = true;
-        // gcs().send_text(MAV_SEVERITY_INFO, "AutoTune: cycles completed");
         return;
     }
 
@@ -160,7 +157,9 @@ void AC_AutoTune_FreqResp::update(float command, float tgt_resp, float meas_resp
             sweep_tgt.count_m1 = min_target_cnt - 1;
             sweep_tgt.amplitude_m1 = temp_tgt_ampl;
             temp_tgt_ampl = temp_max_target - temp_min_target;
-            push_to_tgt_buffer(min_target_cnt,temp_tgt_ampl,temp_max_tgt_time);
+            if (excitation == DWELL) {
+                push_to_tgt_buffer(min_target_cnt,temp_tgt_ampl,temp_max_tgt_time);
+            }
         }
 
     } else if (((response == ANGLE && !is_positive(prev_target) && is_positive(target_rate))
@@ -189,8 +188,9 @@ void AC_AutoTune_FreqResp::update(float command, float tgt_resp, float meas_resp
             sweep_meas.count_m1 = min_meas_cnt - 1;
             sweep_meas.amplitude_m1 = temp_meas_ampl;
             temp_meas_ampl = temp_max_meas - temp_min_meas;
-            push_to_meas_buffer(min_meas_cnt,temp_meas_ampl,temp_max_meas_time);
-
+            if (excitation == DWELL) {
+                push_to_meas_buffer(min_meas_cnt,temp_meas_ampl,temp_max_meas_time);
+            }
             if (excitation == SWEEP) {
                 float tgt_period = 0.001f * (temp_max_tgt_time - sweep_tgt.max_time_m1);
                 if (!is_zero(tgt_period)) {

--- a/libraries/AC_AutoTune/AC_AutoTune_FreqResp.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_FreqResp.cpp
@@ -26,12 +26,8 @@ void AC_AutoTune_FreqResp::init(InputType input_type, ResponseType response_type
     max_meas_rate = 0.0f;
     max_command = 0.0f;
     dwell_cycles = cycles;
-    if (meas_peak_info_buffer != nullptr) {
-        meas_peak_info_buffer->clear();
-    }
-    if (tgt_peak_info_buffer != nullptr) {
-        tgt_peak_info_buffer->clear();
-    }
+    meas_peak_info_buffer.clear();
+    tgt_peak_info_buffer.clear();
     cycle_complete = false;
 }
 
@@ -263,16 +259,14 @@ void AC_AutoTune_FreqResp::push_to_meas_buffer(uint16_t count, float amplitude, 
     sample.curr_count = count;
     sample.amplitude = amplitude;
     sample.time_ms = time_ms;
-    if (meas_peak_info_buffer != nullptr) {
-        meas_peak_info_buffer->push(sample);
-    }
+    meas_peak_info_buffer.push(sample);
 }
 
 // pull measured peak info from buffer
 void AC_AutoTune_FreqResp::pull_from_meas_buffer(uint16_t &count, float &amplitude, uint32_t &time_ms)
 {
     peak_info sample;
-    if ((meas_peak_info_buffer == nullptr) || !meas_peak_info_buffer->pop(sample)) {
+    if (!meas_peak_info_buffer.pop(sample)) {
         // no sample
         return;
     }
@@ -288,16 +282,14 @@ void AC_AutoTune_FreqResp::push_to_tgt_buffer(uint16_t count, float amplitude, u
     sample.curr_count = count;
     sample.amplitude = amplitude;
     sample.time_ms = time_ms;
-    if (tgt_peak_info_buffer != nullptr) {
-        tgt_peak_info_buffer->push(sample);
-    }
+    tgt_peak_info_buffer.push(sample);
 }
 
 // pull target peak info from buffer
 void AC_AutoTune_FreqResp::pull_from_tgt_buffer(uint16_t &count, float &amplitude, uint32_t &time_ms)
 {
     peak_info sample;
-    if ((tgt_peak_info_buffer == nullptr) || !tgt_peak_info_buffer->pop(sample)) {
+    if (!tgt_peak_info_buffer.pop(sample)) {
         // no sample
         return;
     }

--- a/libraries/AC_AutoTune/AC_AutoTune_FreqResp.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_FreqResp.h
@@ -11,6 +11,9 @@ public:
     // Constructor
     AC_AutoTune_FreqResp()
 {
+    dwell_cycles = 6;
+    meas_peak_info_buffer = new ObjectBuffer<peak_info>(dwell_cycles);
+    tgt_peak_info_buffer = new ObjectBuffer<peak_info>(dwell_cycles);
 }
 
     // Enumeration of input type
@@ -38,7 +41,7 @@ public:
     // Reset cycle_complete flag
     void reset_cycle_complete() { cycle_complete = false; }
 
-    void set_dwell_cycles(uint8_t cycles) { dwell_cycles = cycles; }
+    void set_dwell_cycles(uint8_t cycles);
 
     uint8_t get_dwell_cycles() { return dwell_cycles;}
 
@@ -184,10 +187,10 @@ private:
     };
 
     // Buffer object for measured peak data
-    ObjectBuffer<peak_info> meas_peak_info_buffer{6};
+    ObjectBuffer<peak_info> *meas_peak_info_buffer;
 
     // Buffer object for target peak data
-    ObjectBuffer<peak_info> tgt_peak_info_buffer{6};
+    ObjectBuffer<peak_info> *tgt_peak_info_buffer;
 
     // Push data into measured peak data buffer object
     void push_to_meas_buffer(uint16_t count, float amplitude, uint32_t time_ms);

--- a/libraries/AC_AutoTune/AC_AutoTune_FreqResp.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_FreqResp.h
@@ -6,8 +6,6 @@
 
 #include <AP_Math/AP_Math.h>
 
-#define AUTOTUNE_DWELL_CYCLES                6
-
 class AC_AutoTune_FreqResp {
 public:
     // Constructor
@@ -39,6 +37,10 @@ public:
 
     // Reset cycle_complete flag
     void reset_cycle_complete() { cycle_complete = false; }
+
+    void set_dwell_cycles(uint8_t cycles) { dwell_cycles = cycles; }
+
+    uint8_t get_dwell_cycles() { return dwell_cycles;}
 
     // Frequency response data accessors
     float get_freq() { return curr_test_freq; }
@@ -137,6 +139,9 @@ private:
     // flag indicating when one oscillation cycle is complete
     bool cycle_complete = false;
 
+    // number of dwell cycles to complete for dwell excitation
+    uint8_t dwell_cycles;
+
     // current test frequency, gain, and phase
     float curr_test_freq; 
     float curr_test_gain;
@@ -179,10 +184,10 @@ private:
     };
 
     // Buffer object for measured peak data
-    ObjectBuffer<peak_info> meas_peak_info_buffer{AUTOTUNE_DWELL_CYCLES};
+    ObjectBuffer<peak_info> meas_peak_info_buffer{6};
 
     // Buffer object for target peak data
-    ObjectBuffer<peak_info> tgt_peak_info_buffer{AUTOTUNE_DWELL_CYCLES};
+    ObjectBuffer<peak_info> tgt_peak_info_buffer{6};
 
     // Push data into measured peak data buffer object
     void push_to_meas_buffer(uint16_t count, float amplitude, uint32_t time_ms);

--- a/libraries/AC_AutoTune/AC_AutoTune_FreqResp.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_FreqResp.h
@@ -12,8 +12,8 @@ public:
     AC_AutoTune_FreqResp()
 {
     dwell_cycles = 6;
-    meas_peak_info_buffer = new ObjectBuffer<peak_info>(dwell_cycles);
-    tgt_peak_info_buffer = new ObjectBuffer<peak_info>(dwell_cycles);
+    meas_peak_info_buffer = NEW_NOTHROW ObjectBuffer<peak_info>(dwell_cycles);
+    tgt_peak_info_buffer = NEW_NOTHROW ObjectBuffer<peak_info>(dwell_cycles);
 }
 
     // Enumeration of input type

--- a/libraries/AC_AutoTune/AC_AutoTune_FreqResp.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_FreqResp.h
@@ -11,9 +11,9 @@ public:
     // Constructor
     AC_AutoTune_FreqResp()
 {
-    dwell_cycles = 6;
-    meas_peak_info_buffer = NEW_NOTHROW ObjectBuffer<peak_info>(dwell_cycles);
-    tgt_peak_info_buffer = NEW_NOTHROW ObjectBuffer<peak_info>(dwell_cycles);
+    // ring buffers sized to for more cycles than are needed.  Most cycles needed are 6.
+    meas_peak_info_buffer = NEW_NOTHROW ObjectBuffer<peak_info>(12);
+    tgt_peak_info_buffer = NEW_NOTHROW ObjectBuffer<peak_info>(12);
 }
 
     // Enumeration of input type
@@ -30,7 +30,7 @@ public:
 
     // Initialize the Frequency Response Object. 
     // Must be called before running dwell or frequency sweep tests
-    void init(InputType input_type, ResponseType response_type);
+    void init(InputType input_type, ResponseType response_type, uint8_t cycles);
 
     // Determines the gain and phase based on angle response for a dwell or sweep
     void update(float command, float tgt_resp, float meas_resp, float tgt_freq);
@@ -40,10 +40,6 @@ public:
 
     // Reset cycle_complete flag
     void reset_cycle_complete() { cycle_complete = false; }
-
-    void set_dwell_cycles(uint8_t cycles);
-
-    uint8_t get_dwell_cycles() { return dwell_cycles;}
 
     // Frequency response data accessors
     float get_freq() { return curr_test_freq; }

--- a/libraries/AC_AutoTune/AC_AutoTune_FreqResp.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_FreqResp.h
@@ -11,9 +11,6 @@ public:
     // Constructor
     AC_AutoTune_FreqResp()
 {
-    // ring buffers sized to for more cycles than are needed.  Most cycles needed are 6.
-    meas_peak_info_buffer = NEW_NOTHROW ObjectBuffer<peak_info>(12);
-    tgt_peak_info_buffer = NEW_NOTHROW ObjectBuffer<peak_info>(12);
 }
 
     // Enumeration of input type
@@ -183,10 +180,10 @@ private:
     };
 
     // Buffer object for measured peak data
-    ObjectBuffer<peak_info> *meas_peak_info_buffer;
+    ObjectBuffer<peak_info> meas_peak_info_buffer{12};
 
     // Buffer object for target peak data
-    ObjectBuffer<peak_info> *tgt_peak_info_buffer;
+    ObjectBuffer<peak_info> tgt_peak_info_buffer{12};
 
     // Push data into measured peak data buffer object
     void push_to_meas_buffer(uint16_t count, float amplitude, uint32_t time_ms);

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
@@ -753,17 +753,15 @@ void AC_AutoTune_Heli::dwell_test_init(float start_frq, float stop_frq, float am
         curr_test.phase = 0.0f;
         chirp_input.init(0.001f * sweep_time_ms, start_frq / M_2PI, stop_frq / M_2PI, 0.0f, 0.0001f * sweep_time_ms, 0.0f);
     } else {
-        freqresp_tgt.set_dwell_cycles(num_dwell_cycles);
-        freqresp_mtr.set_dwell_cycles(num_dwell_cycles);
         if (!is_zero(start_frq)) {
             // time limit set by adding the pre calc cycles with the dwell cycles.  500 ms added to account for settling with buffer.
-            step_time_limit_ms = (uint32_t) (2000 + ((float) freqresp_tgt.get_dwell_cycles() + pre_calc_cycles + 2.0f) * 1000.0f * M_2PI / start_frq);
+            step_time_limit_ms = (uint32_t) (2000 + ((float)num_dwell_cycles + pre_calc_cycles + 2.0f) * 1000.0f * M_2PI / start_frq);
         }
         chirp_input.init(0.001f * step_time_limit_ms, start_frq / M_2PI, stop_frq / M_2PI, 0.0f, 0.0001f * step_time_limit_ms, 0.0f);
     }
 
-    freqresp_tgt.init(test_input_type, resp_type);
-    freqresp_mtr.init(test_input_type, resp_type);
+    freqresp_tgt.init(test_input_type, resp_type, num_dwell_cycles);
+    freqresp_mtr.init(test_input_type, resp_type, num_dwell_cycles);
     
     dwell_start_time_ms = 0.0f;
     settle_time = 200;

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
@@ -743,7 +743,7 @@ void AC_AutoTune_Heli::dwell_test_init(float start_frq, float stop_frq, float am
     test_calc_type = calc_type;
     test_start_freq = start_frq;
     //target attitude magnitude
-    tgt_attitude = amplitude * 0.01745f;
+    tgt_attitude = radians(amplitude);
 
     // initialize frequency response object
     if (test_input_type == AC_AutoTune_FreqResp::InputType::SWEEP) {
@@ -815,7 +815,7 @@ void AC_AutoTune_Heli::dwell_test_run(sweep_info &test_data)
     }
 
     if (settle_time == 0) {
-        target_angle_cd = -chirp_input.update((now - dwell_start_time_ms) * 0.001, tgt_attitude * 5730.0f);
+        target_angle_cd = -chirp_input.update((now - dwell_start_time_ms) * 0.001, degrees(tgt_attitude) * 100.0f);
         dwell_freq = chirp_input.get_frequency_rads();
         const Vector2f att_fdbk {
             -5730.0f * vel_hold_gain * velocity_bf.y,
@@ -841,28 +841,28 @@ void AC_AutoTune_Heli::dwell_test_run(sweep_info &test_data)
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_angle_cd + trim_angle_cd.x, trim_angle_cd.y, 0.0f);
         command_reading = motors->get_roll();
         if (test_calc_type == DRB) {
-            tgt_rate_reading = (target_angle_cd) / 5730.0f;
-            gyro_reading = ((float)ahrs_view->roll_sensor + trim_angle_cd.x - target_angle_cd) / 5730.0f;
+            tgt_rate_reading = radians(target_angle_cd * 0.01f);
+            gyro_reading = radians(((float)ahrs_view->roll_sensor + trim_angle_cd.x - target_angle_cd) * 0.01f);
         } else if (test_calc_type == RATE) {
             tgt_rate_reading = attitude_control->rate_bf_targets().x;
             gyro_reading = ahrs_view->get_gyro().x;
         } else {
-            tgt_rate_reading = ((float)attitude_control->get_att_target_euler_cd().x) / 5730.0f;
-            gyro_reading = ((float)ahrs_view->roll_sensor) / 5730.0f;
+            tgt_rate_reading = radians((float)attitude_control->get_att_target_euler_cd().x * 0.01f);
+            gyro_reading = radians((float)ahrs_view->roll_sensor * 0.01f);
         }
         break;
     case PITCH:
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(trim_angle_cd.x, target_angle_cd + trim_angle_cd.y, 0.0f);
         command_reading = motors->get_pitch();
         if (test_calc_type == DRB) {
-            tgt_rate_reading = (target_angle_cd) / 5730.0f;
-            gyro_reading = ((float)ahrs_view->pitch_sensor + trim_angle_cd.y - target_angle_cd) / 5730.0f;
+            tgt_rate_reading = radians(target_angle_cd * 0.01f);
+            gyro_reading = radians(((float)ahrs_view->pitch_sensor + trim_angle_cd.y - target_angle_cd) * 0.01f);
         } else if (test_calc_type == RATE) {
             tgt_rate_reading = attitude_control->rate_bf_targets().y;
             gyro_reading = ahrs_view->get_gyro().y;
         } else {
-            tgt_rate_reading = ((float)attitude_control->get_att_target_euler_cd().y) / 5730.0f;
-            gyro_reading = ((float)ahrs_view->pitch_sensor) / 5730.0f;
+            tgt_rate_reading = radians((float)attitude_control->get_att_target_euler_cd().y * 0.01f);
+            gyro_reading = radians((float)ahrs_view->pitch_sensor * 0.01f);
         }
         break;
     case YAW:
@@ -870,14 +870,14 @@ void AC_AutoTune_Heli::dwell_test_run(sweep_info &test_data)
         attitude_control->input_euler_angle_roll_pitch_yaw(trim_angle_cd.x, trim_angle_cd.y, wrap_180_cd(trim_yaw_tgt_reading + target_angle_cd), false);
         command_reading = motors->get_yaw();
         if (test_calc_type == DRB) {
-            tgt_rate_reading = (target_angle_cd) / 5730.0f;
-            gyro_reading = (wrap_180_cd((float)ahrs_view->yaw_sensor - trim_yaw_heading_reading - target_angle_cd)) / 5730.0f;
+            tgt_rate_reading = radians(target_angle_cd * 0.01f);
+            gyro_reading = radians((wrap_180_cd((float)ahrs_view->yaw_sensor - trim_yaw_heading_reading - target_angle_cd)) * 0.01f);
         } else if (test_calc_type == RATE) {
             tgt_rate_reading = attitude_control->rate_bf_targets().z;
             gyro_reading = ahrs_view->get_gyro().z;
         } else {
-            tgt_rate_reading = (wrap_180_cd((float)attitude_control->get_att_target_euler_cd().z - trim_yaw_tgt_reading)) / 5730.0f;
-            gyro_reading = (wrap_180_cd((float)ahrs_view->yaw_sensor - trim_yaw_heading_reading)) / 5730.0f;
+            tgt_rate_reading = radians((wrap_180_cd((float)attitude_control->get_att_target_euler_cd().z - trim_yaw_tgt_reading)) * 0.01f);
+            gyro_reading = radians((wrap_180_cd((float)ahrs_view->yaw_sensor - trim_yaw_heading_reading)) * 0.01f);
         }
         break;
     }

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
@@ -192,8 +192,8 @@ void AC_AutoTune_Heli::test_init()
     case RD_UP:
         // initialize start frequency
         if (is_zero(start_freq)) {
-            // continue using frequency where testing left off or RD_UP completed
-            if (test_phase[12] > 0.0f && test_phase[12] < 180.0f) {
+            // continue using frequency where testing left off with RD_UP completed
+            if (test_phase[12] > 0.0f && test_phase[12] < 180.0f && tune_type == RP_UP) {
                 freq_cnt = 12;
             // start with freq found for sweep where phase was 180 deg
             } else if (!is_zero(sweep_tgt.ph180.freq)) {
@@ -268,7 +268,7 @@ void AC_AutoTune_Heli::test_init()
         freqresp_mtr.set_dwell_cycles(num_dwell_cycles);
         if (!is_zero(start_freq)) {
             // time limit set by adding the pre calc cycles with the dwell cycles.  500 ms added to account for settling with buffer.
-            step_time_limit_ms = (uint32_t) (500 + ((float) freqresp_tgt.get_dwell_cycles() + pre_calc_cycles + 2.0f) * 1000.0f * M_2PI / start_freq);
+            step_time_limit_ms = (uint32_t) (2000 + ((float) freqresp_tgt.get_dwell_cycles() + pre_calc_cycles + 2.0f) * 1000.0f * M_2PI / start_freq);
         }
     }
     freqresp_tgt.init(input_type, resp_type);
@@ -1168,7 +1168,7 @@ void AC_AutoTune_Heli::updating_rate_ff_up(float &tune_ff, float *freq, float *g
     } else {
         if ((gain[frq_cnt] > 0.1 && gain[frq_cnt] < 0.93) || gain[frq_cnt] > 0.98) {
             if (tune_ff > 0.0f) {
-                tune_ff =  tune_ff / gain[frq_cnt];    
+                tune_ff =  0.95f * tune_ff / gain[frq_cnt];
             } else {
                 tune_ff = 0.03f;
             }

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
@@ -142,6 +142,8 @@ void AC_AutoTune_Heli::test_init()
     AC_AutoTune_FreqResp::ResponseType resp_type = AC_AutoTune_FreqResp::ResponseType::RATE;
     FreqRespCalcType calc_type = RATE;
     FreqRespInput freq_resp_input = TARGET;
+    float freq_resp_amplitude = 5.0f;  // amplitude in deg
+    float filter_freq = 10.0f;
     switch (tune_type) {
     case RFF_UP:
         if (!is_positive(next_test_freq)) {
@@ -150,10 +152,12 @@ void AC_AutoTune_Heli::test_init()
             start_freq = next_test_freq;
         }
         stop_freq = start_freq;
-
+        filter_freq = start_freq;
+        
         attitude_control->bf_feedforward(false);
         attitude_control->use_sqrt_controller(false);
-
+//        attitude_control->use_sqrt_controller(true); // invoke rate and acceleration limits to provide square wave rate response.
+//        freq_resp_amplitude = 10.0f;  // increase amplitude with limited rate to get desired square wave rate response
         // variables needed to initialize frequency response object and test method
         resp_type = AC_AutoTune_FreqResp::ResponseType::RATE;
         calc_type = RATE;
@@ -172,6 +176,7 @@ void AC_AutoTune_Heli::test_init()
             stop_freq = start_freq;
             test_accel_max = 0.0f;
         }
+        filter_freq = start_freq;
 
         attitude_control->bf_feedforward(false);
         attitude_control->use_sqrt_controller(false);
@@ -201,6 +206,7 @@ void AC_AutoTune_Heli::test_init()
             start_freq = next_test_freq;
         }
         stop_freq = start_freq;
+        filter_freq = start_freq;
 
         attitude_control->bf_feedforward(false);
         attitude_control->use_sqrt_controller(false);
@@ -223,6 +229,7 @@ void AC_AutoTune_Heli::test_init()
             stop_freq = start_freq;
             test_accel_max = 0.0f;
         }
+        filter_freq = start_freq;
         attitude_control->bf_feedforward(false);
         attitude_control->use_sqrt_controller(false);
 
@@ -238,6 +245,7 @@ void AC_AutoTune_Heli::test_init()
         start_freq = min_sweep_freq;
         stop_freq = max_sweep_freq;
         test_accel_max = 0.0f;
+        filter_freq = start_freq;
 
         // variables needed to initialize frequency response object and test method
         resp_type = AC_AutoTune_FreqResp::ResponseType::ANGLE;
@@ -256,7 +264,7 @@ void AC_AutoTune_Heli::test_init()
 
 
     // initialize dwell test method
-    dwell_test_init(start_freq, stop_freq, start_freq, freq_resp_input, calc_type, resp_type, input_type);
+    dwell_test_init(start_freq, stop_freq, freq_resp_amplitude, filter_freq, freq_resp_input, calc_type, resp_type, input_type);
 
     start_angles = Vector3f(roll_cd, pitch_cd, desired_yaw_cd);  // heli specific
 }
@@ -418,6 +426,7 @@ void AC_AutoTune_Heli::backup_gains_and_initialise()
     orig_roll_smax = attitude_control->get_rate_roll_pid().slew_limit();
     orig_roll_sp = attitude_control->get_angle_roll_p().kP();
     orig_roll_accel = attitude_control->get_accel_roll_max_cdss();
+    orig_roll_rate = attitude_control->get_ang_vel_roll_max_degs();
     tune_roll_rp = attitude_control->get_rate_roll_pid().kP();
     tune_roll_rd = attitude_control->get_rate_roll_pid().kD();
     tune_roll_rff = attitude_control->get_rate_roll_pid().ff();
@@ -432,6 +441,7 @@ void AC_AutoTune_Heli::backup_gains_and_initialise()
     orig_pitch_smax = attitude_control->get_rate_pitch_pid().slew_limit();
     orig_pitch_sp = attitude_control->get_angle_pitch_p().kP();
     orig_pitch_accel = attitude_control->get_accel_pitch_max_cdss();
+    orig_pitch_rate = attitude_control->get_ang_vel_pitch_max_degs();
     tune_pitch_rp = attitude_control->get_rate_pitch_pid().kP();
     tune_pitch_rd = attitude_control->get_rate_pitch_pid().kD();
     tune_pitch_rff = attitude_control->get_rate_pitch_pid().ff();
@@ -447,6 +457,7 @@ void AC_AutoTune_Heli::backup_gains_and_initialise()
     orig_yaw_rLPF = attitude_control->get_rate_yaw_pid().filt_E_hz();
     orig_yaw_accel = attitude_control->get_accel_yaw_max_cdss();
     orig_yaw_sp = attitude_control->get_angle_yaw_p().kP();
+    orig_yaw_rate = attitude_control->get_ang_vel_yaw_max_degs();
     tune_yaw_rp = attitude_control->get_rate_yaw_pid().kP();
     tune_yaw_rd = attitude_control->get_rate_yaw_pid().kD();
     tune_yaw_rff = attitude_control->get_rate_yaw_pid().ff();
@@ -463,13 +474,13 @@ void AC_AutoTune_Heli::load_orig_gains()
 {
     attitude_control->bf_feedforward(orig_bf_feedforward);
     if (roll_enabled()) {
-        load_gain_set(ROLL, orig_roll_rp, orig_roll_ri, orig_roll_rd, orig_roll_rff, orig_roll_sp, orig_roll_accel, orig_roll_fltt, 0.0f, orig_roll_smax);
+        load_gain_set(ROLL, orig_roll_rp, orig_roll_ri, orig_roll_rd, orig_roll_rff, orig_roll_sp, orig_roll_accel, orig_roll_fltt, 0.0f, orig_roll_smax, orig_roll_rate);
     }
     if (pitch_enabled()) {
-        load_gain_set(PITCH, orig_pitch_rp, orig_pitch_ri, orig_pitch_rd, orig_pitch_rff, orig_pitch_sp, orig_pitch_accel, orig_pitch_fltt, 0.0f, orig_pitch_smax);
+        load_gain_set(PITCH, orig_pitch_rp, orig_pitch_ri, orig_pitch_rd, orig_pitch_rff, orig_pitch_sp, orig_pitch_accel, orig_pitch_fltt, 0.0f, orig_pitch_smax, orig_pitch_rate);
     }
     if (yaw_enabled()) {
-        load_gain_set(YAW, orig_yaw_rp, orig_yaw_ri, orig_yaw_rd, orig_yaw_rff, orig_yaw_sp, orig_yaw_accel, orig_yaw_fltt, orig_yaw_rLPF, orig_yaw_smax);
+        load_gain_set(YAW, orig_yaw_rp, orig_yaw_ri, orig_yaw_rd, orig_yaw_rff, orig_yaw_sp, orig_yaw_accel, orig_yaw_fltt, orig_yaw_rLPF, orig_yaw_smax, orig_yaw_rate);
     }
 }
 
@@ -482,14 +493,14 @@ void AC_AutoTune_Heli::load_tuned_gains()
         attitude_control->set_accel_pitch_max_cdss(0.0f);
     }
     if (roll_enabled()) {
-        load_gain_set(ROLL, tune_roll_rp, tune_roll_rff*AUTOTUNE_FFI_RATIO_FINAL, tune_roll_rd, tune_roll_rff, tune_roll_sp, tune_roll_accel, orig_roll_fltt, 0.0f, orig_roll_smax);
+        load_gain_set(ROLL, tune_roll_rp, tune_roll_rff*AUTOTUNE_FFI_RATIO_FINAL, tune_roll_rd, tune_roll_rff, tune_roll_sp, tune_roll_accel, orig_roll_fltt, 0.0f, orig_roll_smax, orig_roll_rate);
     }
     if (pitch_enabled()) {
-        load_gain_set(PITCH, tune_pitch_rp, tune_pitch_rff*AUTOTUNE_FFI_RATIO_FINAL, tune_pitch_rd, tune_pitch_rff, tune_pitch_sp, tune_pitch_accel, orig_pitch_fltt, 0.0f, orig_pitch_smax);
+        load_gain_set(PITCH, tune_pitch_rp, tune_pitch_rff*AUTOTUNE_FFI_RATIO_FINAL, tune_pitch_rd, tune_pitch_rff, tune_pitch_sp, tune_pitch_accel, orig_pitch_fltt, 0.0f, orig_pitch_smax, orig_pitch_rate);
     }
     if (yaw_enabled()) {
         if (!is_zero(tune_yaw_rp)) {
-            load_gain_set(YAW, tune_yaw_rp, tune_yaw_rp*AUTOTUNE_YAW_PI_RATIO_FINAL, tune_yaw_rd, tune_yaw_rff, tune_yaw_sp, tune_yaw_accel, orig_yaw_fltt, tune_yaw_rLPF, orig_yaw_smax);
+            load_gain_set(YAW, tune_yaw_rp, tune_yaw_rp*AUTOTUNE_YAW_PI_RATIO_FINAL, tune_yaw_rd, tune_yaw_rff, tune_yaw_sp, tune_yaw_accel, orig_yaw_fltt, tune_yaw_rLPF, orig_yaw_smax, orig_yaw_rate);
         }
     }
 }
@@ -502,13 +513,13 @@ void AC_AutoTune_Heli::load_intra_test_gains()
     // sanity check the gains
     attitude_control->bf_feedforward(true);
     if (roll_enabled()) {
-        load_gain_set(ROLL, orig_roll_rp, orig_roll_rff * AUTOTUNE_FFI_RATIO_FOR_TESTING, orig_roll_rd, orig_roll_rff, orig_roll_sp, orig_roll_accel, orig_roll_fltt, 0.0f, orig_roll_smax);
+        load_gain_set(ROLL, orig_roll_rp, orig_roll_rff * AUTOTUNE_FFI_RATIO_FOR_TESTING, orig_roll_rd, orig_roll_rff, orig_roll_sp, orig_roll_accel, orig_roll_fltt, 0.0f, orig_roll_smax, orig_roll_rate);
     }
     if (pitch_enabled()) {
-        load_gain_set(PITCH, orig_pitch_rp, orig_pitch_rff * AUTOTUNE_FFI_RATIO_FOR_TESTING, orig_pitch_rd, orig_pitch_rff, orig_pitch_sp, orig_pitch_accel, orig_pitch_fltt, 0.0f, orig_pitch_smax);
+        load_gain_set(PITCH, orig_pitch_rp, orig_pitch_rff * AUTOTUNE_FFI_RATIO_FOR_TESTING, orig_pitch_rd, orig_pitch_rff, orig_pitch_sp, orig_pitch_accel, orig_pitch_fltt, 0.0f, orig_pitch_smax, orig_pitch_rate);
     }
     if (yaw_enabled()) {
-        load_gain_set(YAW, orig_yaw_rp, orig_yaw_rp*AUTOTUNE_PI_RATIO_FOR_TESTING, orig_yaw_rd, orig_yaw_rff, orig_yaw_sp, orig_yaw_accel, orig_yaw_fltt, orig_yaw_rLPF, orig_yaw_smax);
+        load_gain_set(YAW, orig_yaw_rp, orig_yaw_rp*AUTOTUNE_PI_RATIO_FOR_TESTING, orig_yaw_rd, orig_yaw_rff, orig_yaw_sp, orig_yaw_accel, orig_yaw_fltt, orig_yaw_rLPF, orig_yaw_smax, orig_yaw_rate);
     }
 }
 
@@ -516,7 +527,7 @@ void AC_AutoTune_Heli::load_intra_test_gains()
 // called by control_attitude() just before it beings testing a gain (i.e. just before it twitches)
 void AC_AutoTune_Heli::load_test_gains()
 {
-    float rate_p, rate_i, rate_d;
+    float rate_p, rate_i, rate_d, rate_test_max;
     switch (axis) {
     case ROLL:
         if (tune_type == SP_UP || tune_type == TUNE_CHECK) {
@@ -532,7 +543,14 @@ void AC_AutoTune_Heli::load_test_gains()
             rate_p = tune_roll_rp;
             rate_d = tune_roll_rd;
         }
-        load_gain_set(ROLL, rate_p, rate_i, rate_d, tune_roll_rff, tune_roll_sp, tune_roll_accel, orig_roll_fltt, 0.0f, 0.0f);
+/*        if (tune_type == RFF_UP) {
+            rate_test_max = 5.0f;
+        } else {
+            rate_test_max = orig_roll_rate;
+        }
+*/
+        rate_test_max = orig_roll_rate;
+        load_gain_set(ROLL, rate_p, rate_i, rate_d, tune_roll_rff, tune_roll_sp, tune_roll_accel, orig_roll_fltt, 0.0f, 0.0f, rate_test_max);
         break;
     case PITCH:
         if (tune_type == SP_UP || tune_type == TUNE_CHECK) {
@@ -548,7 +566,14 @@ void AC_AutoTune_Heli::load_test_gains()
             rate_p = tune_pitch_rp;
             rate_d = tune_pitch_rd;
         }
-        load_gain_set(PITCH, rate_p, rate_i, rate_d, tune_pitch_rff, tune_pitch_sp, tune_pitch_accel, orig_pitch_fltt, 0.0f, 0.0f);
+/*        if (tune_type == RFF_UP) {
+            rate_test_max = 5.0f;
+        } else {
+            rate_test_max = orig_pitch_rate;
+        }
+*/
+        rate_test_max = orig_pitch_rate;
+        load_gain_set(PITCH, rate_p, rate_i, rate_d, tune_pitch_rff, tune_pitch_sp, tune_pitch_accel, orig_pitch_fltt, 0.0f, 0.0f, rate_test_max);
         break;
     case YAW:
     case YAW_D:
@@ -558,13 +583,20 @@ void AC_AutoTune_Heli::load_test_gains()
             // freeze integrator to hold trim by making i term small during rate controller tuning
             rate_i = 0.01f * orig_yaw_ri;
         }
-        load_gain_set(YAW, tune_yaw_rp, rate_i, tune_yaw_rd, tune_yaw_rff, tune_yaw_sp, tune_yaw_accel, orig_yaw_fltt, tune_yaw_rLPF, 0.0f);
+/*        if (tune_type == RFF_UP) {
+            rate_test_max = 5.0f;
+        } else {
+            rate_test_max = orig_yaw_rate;
+        }
+*/
+        rate_test_max = orig_yaw_rate;
+        load_gain_set(YAW, tune_yaw_rp, rate_i, tune_yaw_rd, tune_yaw_rff, tune_yaw_sp, tune_yaw_accel, orig_yaw_fltt, tune_yaw_rLPF, 0.0f, rate_test_max);
         break;
     }
 }
 
 // load gains
-void AC_AutoTune_Heli::load_gain_set(AxisType s_axis, float rate_p, float rate_i, float rate_d, float rate_ff, float angle_p, float max_accel, float rate_fltt, float rate_flte, float smax)
+void AC_AutoTune_Heli::load_gain_set(AxisType s_axis, float rate_p, float rate_i, float rate_d, float rate_ff, float angle_p, float max_accel, float rate_fltt, float rate_flte, float smax, float max_rate)
 {
     switch (s_axis) {
     case ROLL:
@@ -576,6 +608,7 @@ void AC_AutoTune_Heli::load_gain_set(AxisType s_axis, float rate_p, float rate_i
         attitude_control->get_rate_roll_pid().slew_limit(smax);
         attitude_control->get_angle_roll_p().kP(angle_p);
         attitude_control->set_accel_roll_max_cdss(max_accel);
+        attitude_control->set_ang_vel_roll_max_degs(max_rate);
         break;
     case PITCH:
         attitude_control->get_rate_pitch_pid().kP(rate_p);
@@ -586,6 +619,7 @@ void AC_AutoTune_Heli::load_gain_set(AxisType s_axis, float rate_p, float rate_i
         attitude_control->get_rate_pitch_pid().slew_limit(smax);
         attitude_control->get_angle_pitch_p().kP(angle_p);
         attitude_control->set_accel_pitch_max_cdss(max_accel);
+        attitude_control->set_ang_vel_pitch_max_degs(max_rate);
         break;
     case YAW:
     case YAW_D:
@@ -598,6 +632,7 @@ void AC_AutoTune_Heli::load_gain_set(AxisType s_axis, float rate_p, float rate_i
         attitude_control->get_rate_yaw_pid().filt_E_hz(rate_flte);
         attitude_control->get_angle_yaw_p().kP(angle_p);
         attitude_control->set_accel_yaw_max_cdss(max_accel);
+        attitude_control->set_ang_vel_yaw_max_degs(max_rate);
         break;
     }
 }
@@ -619,7 +654,7 @@ void AC_AutoTune_Heli::save_tuning_gains()
 
     // sanity check the rate P values
     if ((axes_completed & AUTOTUNE_AXIS_BITMASK_ROLL) && roll_enabled()) {
-        load_gain_set(ROLL, tune_roll_rp, tune_roll_rff*AUTOTUNE_FFI_RATIO_FINAL, tune_roll_rd, tune_roll_rff, tune_roll_sp, tune_roll_accel, orig_roll_fltt, 0.0f, orig_roll_smax);
+        load_gain_set(ROLL, tune_roll_rp, tune_roll_rff*AUTOTUNE_FFI_RATIO_FINAL, tune_roll_rd, tune_roll_rff, tune_roll_sp, tune_roll_accel, orig_roll_fltt, 0.0f, orig_roll_smax, orig_roll_rate);
         // save rate roll gains
         attitude_control->get_rate_roll_pid().save_gains();
 
@@ -636,7 +671,7 @@ void AC_AutoTune_Heli::save_tuning_gains()
     }
 
     if ((axes_completed & AUTOTUNE_AXIS_BITMASK_PITCH) && pitch_enabled()) {
-        load_gain_set(PITCH, tune_pitch_rp, tune_pitch_rff*AUTOTUNE_FFI_RATIO_FINAL, tune_pitch_rd, tune_pitch_rff, tune_pitch_sp, tune_pitch_accel, orig_pitch_fltt, 0.0f, orig_pitch_smax);
+        load_gain_set(PITCH, tune_pitch_rp, tune_pitch_rff*AUTOTUNE_FFI_RATIO_FINAL, tune_pitch_rd, tune_pitch_rff, tune_pitch_sp, tune_pitch_accel, orig_pitch_fltt, 0.0f, orig_pitch_smax, orig_pitch_rate);
         // save rate pitch gains
         attitude_control->get_rate_pitch_pid().save_gains();
 
@@ -653,7 +688,7 @@ void AC_AutoTune_Heli::save_tuning_gains()
     }
 
     if ((axes_completed & AUTOTUNE_AXIS_BITMASK_YAW) && yaw_enabled() && !is_zero(tune_yaw_rp)) {
-        load_gain_set(YAW, tune_yaw_rp, tune_yaw_rp*AUTOTUNE_YAW_PI_RATIO_FINAL, tune_yaw_rd, tune_yaw_rff, tune_yaw_sp, tune_yaw_accel, orig_yaw_fltt, orig_yaw_rLPF, orig_yaw_smax);
+        load_gain_set(YAW, tune_yaw_rp, tune_yaw_rp*AUTOTUNE_YAW_PI_RATIO_FINAL, tune_yaw_rd, tune_yaw_rff, tune_yaw_sp, tune_yaw_accel, orig_yaw_fltt, orig_yaw_rLPF, orig_yaw_smax, orig_yaw_rate);
         // save rate yaw gains
         attitude_control->get_rate_yaw_pid().save_gains();
 
@@ -702,12 +737,14 @@ void AC_AutoTune_Heli::report_axis_gains(const char* axis_string, float rate_P, 
     gcs().send_text(MAV_SEVERITY_NOTICE,"AutoTune: %s Angle P:%0.2f, Max Accel:%0.0f",axis_string,angle_P,max_accel);
 }
 
-void AC_AutoTune_Heli::dwell_test_init(float start_frq, float stop_frq, float filt_freq, FreqRespInput freq_resp_input, FreqRespCalcType calc_type, AC_AutoTune_FreqResp::ResponseType resp_type, AC_AutoTune_FreqResp::InputType waveform_input_type)
+void AC_AutoTune_Heli::dwell_test_init(float start_frq, float stop_frq, float amplitude, float filt_freq, FreqRespInput freq_resp_input, FreqRespCalcType calc_type, AC_AutoTune_FreqResp::ResponseType resp_type, AC_AutoTune_FreqResp::InputType waveform_input_type)
 {
     test_input_type = waveform_input_type;
     test_freq_resp_input = freq_resp_input;
     test_calc_type = calc_type;
     test_start_freq = start_frq;
+    //target attitude magnitude
+    tgt_attitude = amplitude * 0.01745f;
 
     // initialize frequency response object
     if (test_input_type == AC_AutoTune_FreqResp::InputType::SWEEP) {
@@ -744,10 +781,10 @@ void AC_AutoTune_Heli::dwell_test_init(float start_frq, float stop_frq, float fi
     filt_target_rate = 0.0f;
 
     // filter at lower frequency to remove steady state
-    filt_command_reading.set_cutoff_frequency(0.2f * start_frq);
-    filt_gyro_reading.set_cutoff_frequency(0.2f * start_frq);
-    filt_tgt_rate_reading.set_cutoff_frequency(0.2f * start_frq);
-    filt_att_fdbk_from_velxy_cd.set_cutoff_frequency(0.2f * start_frq);
+    filt_command_reading.set_cutoff_frequency(0.2f * filt_freq);
+    filt_gyro_reading.set_cutoff_frequency(0.05f * filt_freq);
+    filt_tgt_rate_reading.set_cutoff_frequency(0.05f * filt_freq);
+    filt_att_fdbk_from_velxy_cd.set_cutoff_frequency(0.2f * filt_freq);
 
     curr_test_mtr = {};
     curr_test_tgt = {};
@@ -762,7 +799,6 @@ void AC_AutoTune_Heli::dwell_test_run(sweep_info &test_data)
     float gyro_reading = 0.0f;
     float command_reading = 0.0f;
     float tgt_rate_reading = 0.0f;
-    float tgt_attitude;
     const uint32_t now = AP_HAL::millis();
     float target_angle_cd = 0.0f;
     float dwell_freq = test_start_freq;
@@ -771,9 +807,6 @@ void AC_AutoTune_Heli::dwell_test_run(sweep_info &test_data)
     if (!is_zero(dwell_freq)) {
         cycle_time_ms = 1000.0f * M_2PI / dwell_freq;
     }
-
-    //Determine target attitude magnitude limiting acceleration and rate
-    tgt_attitude = 5.0f * 0.01745f;
 
     // body frame calculation of velocity
     Vector3f velocity_ned, velocity_bf;
@@ -1059,6 +1092,10 @@ void AC_AutoTune_Heli::updating_angle_p_up_all(AxisType test_axis)
         // if a max gain frequency was found then set the start of the dwells to that freq otherwise start at min frequency
         if (!is_zero(sweep_tgt.maxgain.freq)) {
             next_test_freq = constrain_float(sweep_tgt.maxgain.freq, min_sweep_freq, max_sweep_freq);
+            freq_max = next_test_freq;
+            sp_prev_gain = sweep_tgt.maxgain.gain;
+            phase_max = sweep_tgt.maxgain.phase;
+            found_max_gain_freq = true;            
         } else {
             next_test_freq = min_sweep_freq;            
         }
@@ -1173,25 +1210,35 @@ void AC_AutoTune_Heli::set_gains_post_tune(AxisType test_axis)
 // FF is adjusted until rate requested is achieved
 void AC_AutoTune_Heli::updating_rate_ff_up(float &tune_ff, sweep_info &test_data, float &next_freq)
 {
-    float test_freq_incr = 0.05f * M_2PI;
+    float tune_tgt = 0.95;
+    float tune_tol = 0.025;
     next_freq = test_data.freq;
-    if (test_data.phase > 15.0f) {
-        next_freq = constrain_float(next_freq - test_freq_incr, 0.1 * M_2PI, max_sweep_freq);
-    } else if (test_data.phase < 0.0f) {
-        next_freq = constrain_float(next_freq + test_freq_incr, 0.1 * M_2PI, max_sweep_freq);
-    } else {
-        if ((test_data.gain > 0.1 && test_data.gain < 0.93) || test_data.gain > 0.98) {
-            if (tune_ff > 0.0f) {
-                tune_ff =  0.95f * tune_ff / test_data.gain;
-            } else {
-                tune_ff = 0.03f;
-            }
-        } else if (test_data.gain >= 0.93 && test_data.gain <= 0.98) {
-            counter = AUTOTUNE_SUCCESS_COUNT;
-            // reset next_freq for next test
-            next_freq = 0.0f;
-            tune_ff = constrain_float(tune_ff,0.0f,1.0f);
+
+    // handle axes where FF gain is initially zero
+    if (test_data.gain < tune_tgt - tune_tol && !is_positive(tune_ff)) {
+        tune_ff = 0.03f;
+        return;
+    }
+
+    if (test_data.gain < tune_tgt - 0.2 || test_data.gain > tune_tgt + 0.2) {
+        tune_ff =  tune_ff * constrain_float(tune_tgt / test_data.gain, 0.75, 1.25);  //keep changes less than 25%
+    } else if (test_data.gain < tune_tgt - 0.1 || test_data.gain > tune_tgt + 0.1) {
+        if (test_data.gain < tune_tgt - 0.1) {
+            tune_ff *= 1.05;
+        } else {
+            tune_ff *= 0.95;
         }
+    } else if (test_data.gain < tune_tgt - tune_tol || test_data.gain > tune_tgt + tune_tol) {
+        if (test_data.gain < tune_tgt - tune_tol) {
+            tune_ff *= 1.02;
+        } else {
+            tune_ff *= 0.98;
+        }
+    } else if (test_data.gain >= tune_tgt - tune_tol && test_data.gain <= tune_tgt + tune_tol) {
+        counter = AUTOTUNE_SUCCESS_COUNT;
+        // reset next_freq for next test
+        next_freq = 0.0f;
+        tune_ff = constrain_float(tune_ff,0.0f,1.0f);
     }
 }
 
@@ -1276,7 +1323,7 @@ void AC_AutoTune_Heli::updating_angle_p_up(float &tune_p, sweep_info &test_data,
             next_freq = test_data.freq + test_freq_incr;
             return;
         // Gain is expected to continue decreasing past gain peak. declare max gain freq found and refine search.
-        } else if (test_data.gain < 0.9f * sp_prev_gain) {
+        } else if (test_data.gain < 0.95f * sp_prev_gain) {
             found_max_gain_freq = true;
             next_freq = freq_max + 0.5 * test_freq_incr;
             return;

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
@@ -1241,7 +1241,9 @@ void AC_AutoTune_Heli::updating_rate_ff_up(float &tune_ff, sweep_info &test_data
     }
 }
 
-// updating_rate_p_up - uses maximum allowable gain determined from max_gain test to determine rate p gain that does not exceed exceed max response gain
+// updating_rate_p_up - uses maximum allowable gain determined from max_gain test to determine rate p gain that does not
+// exceed max response gain.  A phase of 161 deg is used to conduct the tuning as this phase is where analytically
+// max gain to 6db gain margin is determined for a unity feedback controller.
 void AC_AutoTune_Heli::updating_rate_p_up(float &tune_p, sweep_info &test_data, float &next_freq, max_gain_data &max_gain_p)
 {
     float test_freq_incr = 0.25f * M_2PI;
@@ -1265,7 +1267,9 @@ void AC_AutoTune_Heli::updating_rate_p_up(float &tune_p, sweep_info &test_data, 
     }
 }
 
-// updating_rate_d_up - uses maximum allowable gain determined from max_gain test to determine rate d gain where the response gain is at a minimum
+// updating_rate_d_up - uses maximum allowable gain determined from max_gain test to determine rate d gain where the response
+// gain is at a minimum.  A phase of 161 deg is used to conduct the tuning as this phase is where analytically
+// max gain to 6db gain margin is determined for a unity feedback controller.
 void AC_AutoTune_Heli::updating_rate_d_up(float &tune_d, sweep_info &test_data, float &next_freq, max_gain_data &max_gain_d)
 {
     float test_freq_incr = 0.25f * M_2PI;  // set for 1/4 hz increments
@@ -1291,7 +1295,8 @@ void AC_AutoTune_Heli::updating_rate_d_up(float &tune_d, sweep_info &test_data, 
     }
 }
 
-// updating_angle_p_up - determines maximum angle p gain for pitch and roll
+// updating_angle_p_up - determines maximum angle p gain for pitch and roll.  This is accomplished by determining the frequency
+// for the maximum response gain that is the disturbance rejection peak.
 void AC_AutoTune_Heli::updating_angle_p_up(float &tune_p, sweep_info &test_data, float &next_freq)
 {
     float test_freq_incr = 0.5f * M_2PI;
@@ -1382,7 +1387,11 @@ void AC_AutoTune_Heli::updating_angle_p_up(float &tune_p, sweep_info &test_data,
     }
 }
 
-// updating_max_gains: use dwells at increasing frequency to determine gain at which instability will occur
+// updating_max_gains: use dwells at increasing frequency to determine gain at which instability will occur.  This uses the frequency
+// response of motor class input to rate response to determine the max allowable gain for rate P gain.  A phase of 161 deg is used to
+// determine analytically the max gain to 6db gain margin for a unity feedback controller. Since acceleration can be more noisy, the
+// response of the motor class input to rate response to determine the max allowable gain for rate D gain.  A phase of 251 deg is used
+// to determine analytically the max gain to 6db gain margin for a unity feedback controller.
 void AC_AutoTune_Heli::updating_max_gains(sweep_info &test_data, float &next_freq, max_gain_data &max_gain_p, max_gain_data &max_gain_d, float &tune_p, float &tune_d)
 {
     float test_freq_incr = 0.5f * M_2PI;

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.h
@@ -45,13 +45,6 @@ protected:
     //
     // methods to load and save gains
     //
-    // sweep_info contains information about a specific test's sweep results
-    struct sweep_info {
-        float freq;
-        float gain;
-        float phase;
-    };
-
 
     // backup original gains and prepare for start of tuning
     void backup_gains_and_initialise() override;
@@ -143,6 +136,13 @@ protected:
     uint32_t get_testing_step_timeout_ms() const override;
 
 private:
+    // sweep_info contains information about a specific test's sweep results
+    struct sweep_info {
+        float freq;
+        float gain;
+        float phase;
+    };
+
     // max_gain_data type stores information from the max gain test
     struct max_gain_data {
         float freq;

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.h
@@ -149,11 +149,16 @@ private:
     // max gain data for rate d tuning
     max_gain_data max_rate_d;
 
-    // dwell type identifies whether the dwell is ran on rate or angle
-    enum DwellType {
+    // FreqRespCalcType is the type of calculation done for the frequency response 
+    enum FreqRespCalcType {
         RATE    = 0,
         ANGLE   = 1,
         DRB     = 2,
+    };
+
+    enum FreqRespInput {
+        MOTOR    = 0,
+        TARGET   = 1,
     };
 
     float target_angle_max_rp_cd() const override;
@@ -169,10 +174,10 @@ private:
     float angle_lim_neg_rpy_cd() const override;
 
     // initialize dwell test or angle dwell test variables
-    void dwell_test_init(float start_frq, float stop_frq, float filt_freq, DwellType dwell_type);
+    void dwell_test_init(float start_frq, float stop_frq, float filt_freq, FreqRespInput freq_resp_input, FreqRespCalcType calc_type, AC_AutoTune_FreqResp::ResponseType resp_type, AC_AutoTune_FreqResp::InputType waveform_input_type);
 
     // dwell test used to perform frequency dwells for rate gains
-    void dwell_test_run(uint8_t freq_resp_input, float start_frq, float stop_frq, float &dwell_gain, float &dwell_phase, DwellType dwell_type);
+    void dwell_test_run(float &dwell_gain, float &dwell_phase);
 
     // updating_rate_ff_up - adjust FF to ensure the target is reached
     // FF is adjusted until rate requested is achieved
@@ -202,6 +207,9 @@ private:
     // report gain formatting helper
     void report_axis_gains(const char* axis_string, float rate_P, float rate_I, float rate_D, float rate_ff, float angle_P, float max_accel) const;
 
+    // define input type as Dwell or Sweep.  Used through entire class
+    AC_AutoTune_FreqResp::InputType input_type;
+    
     // updating rate FF variables
     // flag for completion of the initial direction for the feedforward test
     bool first_dir_complete;
@@ -233,6 +241,16 @@ private:
     uint8_t rd_prev_good_frq_cnt;
     // previous gain
     float rd_prev_gain;
+
+    // Dwell Test variables
+    AC_AutoTune_FreqResp::InputType test_input_type;
+    FreqRespCalcType test_calc_type;
+    FreqRespInput test_freq_resp_input;
+    uint8_t num_dwell_cycles;
+    float test_start_freq;
+    
+    // number of cycles to complete before running frequency response calculations
+    float pre_calc_cycles;
 
     float    command_out;                           // test axis command output
     float    filt_target_rate;                      // filtered target rate
@@ -289,9 +307,6 @@ private:
 
     // fix the frequency sweep time to 23 seconds
     const float sweep_time_ms = 23000;
-
-    // number of cycles to complete before running frequency response calculations
-    float pre_calc_cycles;
 
     // parameters
     AP_Int8  axis_bitmask;        // axes to be tuned

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.h
@@ -186,10 +186,10 @@ private:
     void updating_rate_ff_up(float &tune_ff, sweep_info &test_data, float &next_freq);
 
     // updating_rate_p_up - uses maximum allowable gain determined from max_gain test to determine rate p gain that does not exceed exceed max response gain
-    void updating_rate_p_up(float &tune_p, float *freq, float *gain, float *phase, uint8_t &frq_cnt, max_gain_data &max_gain_p);
+    void updating_rate_p_up(float &tune_p, sweep_info &test_data, float &next_freq, max_gain_data &max_gain_p);
 
     // updating_rate_d_up - uses maximum allowable gain determined from max_gain test to determine rate d gain where the response gain is at a minimum
-    void updating_rate_d_up(float &tune_d, float *freq, float *gain, float *phase, uint8_t &frq_cnt, max_gain_data &max_gain_d);
+    void updating_rate_d_up(float &tune_d, sweep_info &test_data, float &next_freq, max_gain_data &max_gain_d);
 
     // updating_angle_p_up - determines maximum angle p gain for pitch and roll
     void updating_angle_p_up(float &tune_p, float *freq, float *gain, float *phase, uint8_t &frq_cnt);

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.h
@@ -192,7 +192,7 @@ private:
     void updating_rate_d_up(float &tune_d, sweep_info &test_data, float &next_freq, max_gain_data &max_gain_d);
 
     // updating_angle_p_up - determines maximum angle p gain for pitch and roll
-    void updating_angle_p_up(float &tune_p, float *freq, float *gain, float *phase, uint8_t &frq_cnt);
+    void updating_angle_p_up(float &tune_p, sweep_info &test_data, float &next_freq);
 
    // updating_max_gains: use dwells at increasing frequency to determine gain at which instability will occur
     void updating_max_gains(float *freq, float *gain, float *phase, uint8_t &frq_cnt, max_gain_data &max_gain_p, max_gain_data &max_gain_d, float &tune_p, float &tune_d);
@@ -234,12 +234,15 @@ private:
     bool find_middle;
 
     // updating angle P up variables
-    // track the maximum phase
+    // track the maximum phase and freq
     float phase_max;
+    float freq_max;
     // previous gain
     float sp_prev_gain;
+    // flag for finding max gain frequency
+    bool found_max_gain_freq;
     // flag for finding the peak of the gain response
-    bool find_peak;
+    bool found_peak;
 
     // updating rate P up
     // counter value of previous good frequency
@@ -299,6 +302,7 @@ private:
     };
     sweep_data sweep_mtr;
     sweep_data sweep_tgt;
+    bool sweep_complete;
 
     // fix the frequency sweep time to 23 seconds
     const float sweep_time_ms = 23000;

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.h
@@ -45,6 +45,13 @@ protected:
     //
     // methods to load and save gains
     //
+    // sweep_info contains information about a specific test's sweep results
+    struct sweep_info {
+        float freq;
+        float gain;
+        float phase;
+    };
+
 
     // backup original gains and prepare for start of tuning
     void backup_gains_and_initialise() override;
@@ -144,13 +151,6 @@ private:
         float max_allowed;
     };
 
-    // sweep_info contains information about a specific test's sweep results
-    struct sweep_info {
-        float freq;
-        float gain;
-        float phase;
-    };
-
     // FreqRespCalcType is the type of calculation done for the frequency response 
     enum FreqRespCalcType {
         RATE    = 0,
@@ -179,7 +179,7 @@ private:
     void dwell_test_init(float start_frq, float stop_frq, float filt_freq, FreqRespInput freq_resp_input, FreqRespCalcType calc_type, AC_AutoTune_FreqResp::ResponseType resp_type, AC_AutoTune_FreqResp::InputType waveform_input_type);
 
     // dwell test used to perform frequency dwells for rate gains
-    void dwell_test_run(float &dwell_gain, float &dwell_phase, sweep_info &test_data);
+    void dwell_test_run(sweep_info &test_data);
 
     // updating_rate_ff_up - adjust FF to ensure the target is reached
     // FF is adjusted until rate requested is achieved
@@ -195,7 +195,7 @@ private:
     void updating_angle_p_up(float &tune_p, sweep_info &test_data, float &next_freq);
 
    // updating_max_gains: use dwells at increasing frequency to determine gain at which instability will occur
-    void updating_max_gains(float *freq, float *gain, float *phase, uint8_t &frq_cnt, max_gain_data &max_gain_p, max_gain_data &max_gain_d, float &tune_p, float &tune_d);
+    void updating_max_gains(sweep_info &test_data, float &next_freq, max_gain_data &max_gain_p, max_gain_data &max_gain_d, float &tune_p, float &tune_d);
 
     // reset the max_gains update gain variables
     void reset_maxgains_update_gain_variables();
@@ -215,11 +215,6 @@ private:
     sweep_info curr_data;                           // frequency response test results
     float    next_test_freq;                        // next test frequency for next test cycle setup
 
-    float    test_gain[20];                         // frequency response gain for each dwell test iteration
-    float    test_freq[20];                         // frequency of each dwell test iteration
-    float    test_phase[20];                        // frequency response phase for each dwell test iteration
-    uint8_t  freq_cnt_max;                          // counter number for frequency that produced max gain response
-
     // max gain data for rate p tuning
     max_gain_data max_rate_p;
     // max gain data for rate d tuning
@@ -232,6 +227,10 @@ private:
     bool found_max_d;
     // flag for interpolating to find max response gain
     bool find_middle;
+    // data holding variables for calculations
+    sweep_info data_m_one;
+    sweep_info data_m_two;
+
 
     // updating angle P up variables
     // track the maximum phase and freq

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.h
@@ -180,7 +180,7 @@ private:
 
     // updating_rate_ff_up - adjust FF to ensure the target is reached
     // FF is adjusted until rate requested is achieved
-    void updating_rate_ff_up(float &tune_ff, float rate_target, float meas_rate, float meas_command);
+    void updating_rate_ff_up(float &tune_ff, float *freq, float *gain, float *phase, uint8_t &frq_cnt);
 
     // updating_rate_p_up - uses maximum allowable gain determined from max_gain test to determine rate p gain that does not exceed exceed max response gain
     void updating_rate_p_up(float &tune_p, float *freq, float *gain, float *phase, uint8_t &frq_cnt, max_gain_data &max_gain_p);
@@ -238,11 +238,7 @@ private:
     // previous gain
     float rd_prev_gain;
 
-    uint8_t  ff_test_phase;                         // phase of feedforward test
-    float    test_command_filt;                     // filtered commanded output for FF test analysis
-    float    test_rate_filt;                        // filtered rate output for FF test analysis
     float    command_out;                           // test axis command output
-    float    test_tgt_rate_filt;                    // filtered target rate for FF test analysis
     float    filt_target_rate;                      // filtered target rate
     float    test_gain[20];                         // frequency response gain for each dwell test iteration
     float    test_freq[20];                         // frequency of each dwell test iteration
@@ -260,14 +256,11 @@ private:
 
     Vector3f start_angles;                          // aircraft attitude at the start of test
     uint32_t settle_time;                           // time in ms for allowing aircraft to stabilize before initiating test
-    uint32_t phase_out_time;                        // time in ms to phase out response
     float    trim_meas_rate;                        // trim measured gyro rate
 
     //variables from rate FF test
     float trim_command_reading;
     float trim_heading;
-    LowPassFilterFloat rate_request_cds;
-    LowPassFilterFloat angle_request_cd;
 
     // variables from dwell test
     LowPassFilterVector2f filt_att_fdbk_from_velxy_cd;

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.h
@@ -50,7 +50,7 @@ protected:
     void backup_gains_and_initialise() override;
 
     // load gains
-    void load_gain_set(AxisType s_axis, float rate_p, float rate_i, float rate_d, float rate_ff, float angle_p, float max_accel, float rate_fltt, float rate_flte, float smax);
+    void load_gain_set(AxisType s_axis, float rate_p, float rate_i, float rate_d, float rate_ff, float angle_p, float max_accel, float rate_fltt, float rate_flte, float smax, float max_rate);
 
     // switch to use original gains
     void load_orig_gains() override;
@@ -176,7 +176,7 @@ private:
     float angle_lim_neg_rpy_cd() const override;
 
     // initialize dwell test or angle dwell test variables
-    void dwell_test_init(float start_frq, float stop_frq, float filt_freq, FreqRespInput freq_resp_input, FreqRespCalcType calc_type, AC_AutoTune_FreqResp::ResponseType resp_type, AC_AutoTune_FreqResp::InputType waveform_input_type);
+    void dwell_test_init(float start_frq, float stop_frq, float amplitude, float filt_freq, FreqRespInput freq_resp_input, FreqRespCalcType calc_type, AC_AutoTune_FreqResp::ResponseType resp_type, AC_AutoTune_FreqResp::InputType waveform_input_type);
 
     // dwell test used to perform frequency dwells for rate gains
     void dwell_test_run(sweep_info &test_data);
@@ -248,6 +248,7 @@ private:
     FreqRespInput test_freq_resp_input;
     uint8_t num_dwell_cycles;
     float test_start_freq;
+    float tgt_attitude;
     
     float    pre_calc_cycles;                       // number of cycles to complete before running frequency response calculations
     float    command_out;                           // test axis command output

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.h
@@ -261,7 +261,6 @@ private:
     Vector3f start_angles;                          // aircraft attitude at the start of test
     uint32_t settle_time;                           // time in ms for allowing aircraft to stabilize before initiating test
     uint32_t phase_out_time;                        // time in ms to phase out response
-    float    trim_pff_out;                          // trim output of the PID rate controller for P, I and FF terms
     float    trim_meas_rate;                        // trim measured gyro rate
 
     //variables from rate FF test
@@ -271,8 +270,6 @@ private:
     LowPassFilterFloat angle_request_cd;
 
     // variables from dwell test
-    LowPassFilterVector2f filt_pit_roll_cd;         // filtered pitch and roll attitude for dwell rate method
-    LowPassFilterFloat filt_heading_error_cd;       // filtered heading error for dwell rate method
     LowPassFilterVector2f filt_att_fdbk_from_velxy_cd;
     LowPassFilterFloat filt_command_reading;        // filtered command reading to keep oscillation centered
     LowPassFilterFloat filt_gyro_reading;           // filtered gyro reading to keep oscillation centered
@@ -308,6 +305,8 @@ private:
     AP_Float max_sweep_freq;    // maximum sweep frequency
     AP_Float max_resp_gain;     // maximum response gain
     AP_Float vel_hold_gain;     // gain for velocity hold
+    AP_Float accel_max;         // maximum autotune angular acceleration
+    AP_Float rate_max;          // maximum autotune angular rate
 
     // freqresp object for the frequency response tests
     AC_AutoTune_FreqResp freqresp;

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.h
@@ -114,7 +114,7 @@ protected:
 
     // methods to log autotune frequency response results
     void Log_AutoTuneSweep() override;
-    void Log_Write_AutoTuneSweep(float freq, float gain, float phase);
+    void Log_Write_AutoTuneSweep(float freq_mtr, float gain_mtr, float phase_mtr, float freq_tgt, float gain_tgt, float phase_tgt);
 #endif
 
     // send intermittent updates to user on status of tune
@@ -253,6 +253,8 @@ private:
         float phase;
     };
     sweep_info curr_test;
+    sweep_info curr_test_mtr;
+    sweep_info curr_test_tgt;
 
     Vector3f start_angles;                          // aircraft attitude at the start of test
     uint32_t settle_time;                           // time in ms for allowing aircraft to stabilize before initiating test
@@ -285,7 +287,8 @@ private:
 
         uint8_t  progress;  // set based on phase of frequency response.  0 - start; 1 - reached 180 deg; 2 - reached 270 deg;
     };
-    sweep_data sweep;
+    sweep_data sweep_mtr;
+    sweep_data sweep_tgt;
 
     // fix the frequency sweep time to 23 seconds
     const float sweep_time_ms = 23000;
@@ -302,7 +305,8 @@ private:
     AP_Float rate_max;          // maximum autotune angular rate
 
     // freqresp object for the frequency response tests
-    AC_AutoTune_FreqResp freqresp;
+    AC_AutoTune_FreqResp freqresp_mtr; // frequency response of output to motor mixer input
+    AC_AutoTune_FreqResp freqresp_tgt; // frequency response of output to target input
 
     Chirp chirp_input;
 };

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.h
@@ -197,6 +197,9 @@ private:
    // updating_max_gains: use dwells at increasing frequency to determine gain at which instability will occur
     void updating_max_gains(sweep_info &test_data, float &next_freq, max_gain_data &max_gain_p, max_gain_data &max_gain_d, float &tune_p, float &tune_d);
 
+    // freq_search_for_phase: general search strategy for specified phase.  interpolation done once specified phase has been bounded.
+    bool freq_search_for_phase(sweep_info test, float desired_phase, float freq_incr, sweep_info &est_data, float &new_freq);
+
     // reset the max_gains update gain variables
     void reset_maxgains_update_gain_variables();
 
@@ -225,33 +228,19 @@ private:
     bool found_max_p;
     // flag for finding maximum d gain
     bool found_max_d;
-    // flag for interpolating to find max response gain
-    bool find_middle;
-    // data holding variables for calculations
-    sweep_info data_m_one;
-    sweep_info data_m_two;
-
 
     // updating angle P up variables
-    // track the maximum phase and freq
-    float phase_max;
+    float phase_max;             // track the maximum phase and freq
     float freq_max;
-    // previous gain
-    float sp_prev_gain;
-    // flag for finding max gain frequency
-    bool found_max_gain_freq;
-    // flag for finding the peak of the gain response
-    bool found_peak;
-
-    // updating rate P up
-    // counter value of previous good frequency
-    uint8_t rp_prev_good_frq_cnt;
+    float sp_prev_gain;          // previous gain
+    bool found_max_gain_freq;    // flag for finding max gain frequency
+    bool found_peak;             // flag for finding the peak of the gain response
 
     // updating rate D up
-    // counter value of previous good frequency
-    uint8_t rd_prev_good_frq_cnt;
-    // previous gain
-    float rd_prev_gain;
+    float rd_prev_gain;               // previous gain
+
+    // freq search for phase
+    sweep_info prev_test;              // data from previous dwell
 
     // Dwell Test variables
     AC_AutoTune_FreqResp::InputType test_input_type;

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.h
@@ -168,10 +168,6 @@ private:
 
     float angle_lim_neg_rpy_cd() const override;
 
-    // Feedforward test used to determine Rate FF gain
-    void rate_ff_test_init();
-    void rate_ff_test_run(float max_angle_cds, float target_rate_cds, float dir_sign);
-
     // initialize dwell test or angle dwell test variables
     void dwell_test_init(float start_frq, float stop_frq, float filt_freq, DwellType dwell_type);
 
@@ -255,6 +251,7 @@ private:
     sweep_info curr_test;
     sweep_info curr_test_mtr;
     sweep_info curr_test_tgt;
+    sweep_info test[20];
 
     Vector3f start_angles;                          // aircraft attitude at the start of test
     uint32_t settle_time;                           // time in ms for allowing aircraft to stabilize before initiating test
@@ -293,6 +290,8 @@ private:
     // fix the frequency sweep time to 23 seconds
     const float sweep_time_ms = 23000;
 
+    // number of cycles to complete before running frequency response calculations
+    float pre_calc_cycles;
 
     // parameters
     AP_Int8  axis_bitmask;        // axes to be tuned
@@ -307,6 +306,10 @@ private:
     // freqresp object for the frequency response tests
     AC_AutoTune_FreqResp freqresp_mtr; // frequency response of output to motor mixer input
     AC_AutoTune_FreqResp freqresp_tgt; // frequency response of output to target input
+
+    // allow tracking of cycles complete for frequency response object
+    bool cycle_complete_tgt;
+    bool cycle_complete_mtr;
 
     Chirp chirp_input;
 };


### PR DESCRIPTION
This PR was primarily focused on enabling the safe tuning of larger helicopters.  I have made other changes along the way that help clean up the code and make it more efficient.  Here is a list of changes

- feedforward tuning was switched to a 5 deg attitude frequency dwell test for safety
- all tuning of the rate PIDs is accomplished with a sweep in attitude rather than rate to provide more safety when going to low frequencies for larger vehicles. 
- Rate and acceleration limits are used and included as separate parameters
- removed the sweep conducted before Rate D tuning and modified code so that data could be gathered during Max Gain sweep
- Significantly cleaned up the dwell_run method
- significantly cleaned up the test_init method
- Significantly cleaned up the update gain methods
- Align frequency search algorithms for the rate P, rate D, and max gained tests

