### PR TITLE
AP_Periph: correct compilation when HAL_GCS_ENABLED

### DIFF
--- a/Tools/AP_Periph/GCS_MAVLink.h
+++ b/Tools/AP_Periph/GCS_MAVLink.h
@@ -39,9 +39,6 @@ protected:
     MAV_MODE base_mode() const override { return (MAV_MODE)MAV_MODE_FLAG_CUSTOM_MODE_ENABLED; }
     MAV_STATE vehicle_system_status() const override { return MAV_STATE_CALIBRATING; }
 
-    bool set_home_to_current_location(bool _lock) override { return false; }
-    bool set_home(const Location& loc, bool _lock) override { return false; }
-
     void send_nav_controller_output() const override {};
     void send_pid_tuning() override {};
 };


### PR DESCRIPTION
I missed this GCS_MAVLINK subclass in my recent restructure.

This overrides are no longer required.
