### PR TITLE
AP_VisualOdom: correct unused variable in visualodom

### DIFF
--- a/libraries/AP_VisualOdom/AP_VisualOdom_Backend.cpp
+++ b/libraries/AP_VisualOdom/AP_VisualOdom_Backend.cpp
@@ -55,7 +55,9 @@ void AP_VisualOdom_Backend::handle_vision_position_delta_msg(const mavlink_messa
     _last_update_ms = now_ms;
 
     // send to EKF
+#if AP_AHRS_ENABLED || HAL_LOGGING_ENABLED
     const float time_delta_sec = packet.time_delta_usec * 1.0E-6;
+#endif
 #if AP_AHRS_ENABLED
     AP::ahrs().writeBodyFrameOdom(packet.confidence,
                                   position_delta,


### PR DESCRIPTION
when both logging and gcs are compiled out