### PR TITLE
hwdef: compilation fix for CSKY405-fix

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CSKY405/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CSKY405/hwdef.dat
@@ -28,7 +28,6 @@ PA14 LED0 OUTPUT LOW GPIO(90) # blue marked as ACT
 PA13 LED1 OUTPUT LOW GPIO(91) # green marked as B/E
 define HAL_GPIO_A_LED_PIN 91
 define HAL_GPIO_B_LED_PIN 90
-define HAL_GPIO_LED_OFF 1
 
 # --------------------- PWM -----------------------
 PA8  TIM1_CH1   TIM1  PWM(1)  GPIO(50)          // S1


### PR DESCRIPTION
```
SCB-WAF: ../../libraries/AP_HAL/AP_HAL_Boards.h:372:2: error: #error "HAL_GPIO_LED_OFF must not be defined, it is implicitly !HAL_GPIO_LED_ON"  372 | #error "HAL_GPIO_LED_OFF must not be defined, it is implicitly !HAL_GPIO_LED_ON"
```