### PR TITLE
AP_Mount: Do not override default mode when first connecting to RC

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -618,6 +618,13 @@ void AP_Mount_Backend::set_rctargeting_on_rcinput_change()
     const int16_t pitch_in = (pitch_ch == nullptr) ? 0 : pitch_ch->get_radio_in();
     const int16_t yaw_in = (yaw_ch == nullptr) ? 0 : yaw_ch->get_radio_in();
 
+    if (!last_rc_input.initialised) {
+            // The first time through, initial RC inputs should be set, but not used
+            last_rc_input.initialised = true;
+            last_rc_input.roll_in = roll_in;
+            last_rc_input.pitch_in = pitch_in;
+            last_rc_input.yaw_in = yaw_in;
+    }
     // if not in RC_TARGETING or RETRACT modes then check for RC change
     if (get_mode() != MAV_MOUNT_MODE_RC_TARGETING && get_mode() != MAV_MOUNT_MODE_RETRACT) {
         // get dead zones
@@ -629,11 +636,11 @@ void AP_Mount_Backend::set_rctargeting_on_rcinput_change()
         if ((abs(last_rc_input.roll_in - roll_in) > roll_dz) ||
             (abs(last_rc_input.pitch_in - pitch_in) > pitch_dz) ||
             (abs(last_rc_input.yaw_in - yaw_in) > yaw_dz)) {
-            set_mode(MAV_MOUNT_MODE_RC_TARGETING);
+                set_mode(MAV_MOUNT_MODE_RC_TARGETING);
         }
     }
 
-    // if in RC_TARGETING or RETRACT mode then store last RC input
+    // if NOW in RC_TARGETING or RETRACT mode then store last RC input (mode might have changed)
     if (get_mode() == MAV_MOUNT_MODE_RC_TARGETING || get_mode() == MAV_MOUNT_MODE_RETRACT) {
         last_rc_input.roll_in = roll_in;
         last_rc_input.pitch_in = pitch_in;

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -329,6 +329,7 @@ protected:
 
     // structure holding the last RC inputs
     struct {
+        bool    initialised;
         int16_t roll_in;
         int16_t pitch_in;
         int16_t yaw_in;


### PR DESCRIPTION
When the AP boots it sets the gimbal mount mode from MNTx_DEFLT_MODE, but if there are also RC channels for roll, pitch, yaw on the mount, when the RC connects it will immediately override the default because the RC values "changed" (from nothing to whatever is coming from RC). I noticed this with SysID tracking mode, but it would also have affected other modes using _DEFLT_MODE.

This fix ignores the initial RC values until it has received valid values one time, so it will only override the gimbal targeting mode if the pilot actually changes the relevant RC channels. "relevant" is any one of the channels set for pan/tilt/roll for the specific camera mount (MNTx).