### PR TITLE
AP_GPS: copy GPS metadata in for pre-per-instance-parameters

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1987,6 +1987,155 @@ bool AP_GPS::gps_yaw_deg(uint8_t instance, float &yaw_deg, float &accuracy_deg, 
     return true;
 }
 
+/*
+ * Old parameter metadata.  Until we have versioned parameters, keeping
+ * old parameters around for a while can help with an adjustment
+ * period.
+ */
+
+    // @Param: _TYPE
+    // @DisplayName: 1st GPS type
+    // @Description: GPS type of 1st GPS
+    // @Values: 0:None,1:AUTO,2:uBlox,5:NMEA,6:SiRF,7:HIL,8:SwiftNav,9:DroneCAN,10:SBF,11:GSOF,13:ERB,14:MAV,15:NOVA,16:HemisphereNMEA,17:uBlox-MovingBaseline-Base,18:uBlox-MovingBaseline-Rover,19:MSP,20:AllyStar,21:ExternalAHRS,22:DroneCAN-MovingBaseline-Base,23:DroneCAN-MovingBaseline-Rover,24:UnicoreNMEA,25:UnicoreMovingBaselineNMEA,26:SBF-DualAntenna
+    // @RebootRequired: True
+    // @User: Advanced
+
+    // @Param: _TYPE2
+    // @CopyFieldsFrom: GPS_TYPE
+    // @DisplayName: 2nd GPS type
+    // @Description: GPS type of 2nd GPS
+
+    // @Param: _GNSS_MODE
+    // @DisplayName: GNSS system configuration
+    // @Description: Bitmask for what GNSS system to use on the first GPS (all unchecked or zero to leave GPS as configured)
+    // @Bitmask: 0:GPS,1:SBAS,2:Galileo,3:Beidou,4:IMES,5:QZSS,6:GLONASS
+    // @User: Advanced
+
+    // @Param: _GNSS_MODE2
+    // @DisplayName: GNSS system configuration
+    // @Description: Bitmask for what GNSS system to use on the second GPS (all unchecked or zero to leave GPS as configured)
+    // @Bitmask: 0:GPS,1:SBAS,2:Galileo,3:Beidou,4:IMES,5:QZSS,6:GLONASS
+    // @User: Advanced
+
+    // @Param: _RATE_MS
+    // @DisplayName: GPS update rate in milliseconds
+    // @Description: Controls how often the GPS should provide a position update. Lowering below 5Hz(default) is not allowed. Raising the rate above 5Hz usually provides little benefit and for some GPS (eg Ublox M9N) can severely impact performance.
+    // @Units: ms
+    // @Values: 100:10Hz,125:8Hz,200:5Hz
+    // @Range: 50 200
+    // @User: Advanced
+
+    // @Param: _RATE_MS2
+    // @DisplayName: GPS 2 update rate in milliseconds
+    // @Description: Controls how often the GPS should provide a position update. Lowering below 5Hz(default) is not allowed. Raising the rate above 5Hz usually provides little benefit and for some GPS (eg Ublox M9N) can severely impact performance.
+    // @Units: ms
+    // @Values: 100:10Hz,125:8Hz,200:5Hz
+    // @Range: 50 200
+    // @User: Advanced
+
+    // @Param: _POS1_X
+    // @DisplayName: Antenna X position offset
+    // @Description: X position of the first GPS antenna in body frame. Positive X is forward of the origin. Use antenna phase centroid location if provided by the manufacturer.
+    // @Units: m
+    // @Range: -5 5
+    // @Increment: 0.01
+    // @User: Advanced
+
+    // @Param: _POS1_Y
+    // @DisplayName: Antenna Y position offset
+    // @Description: Y position of the first GPS antenna in body frame. Positive Y is to the right of the origin. Use antenna phase centroid location if provided by the manufacturer.
+    // @Units: m
+    // @Range: -5 5
+    // @Increment: 0.01
+    // @User: Advanced
+
+    // @Param: _POS1_Z
+    // @DisplayName: Antenna Z position offset
+    // @Description: Z position of the first GPS antenna in body frame. Positive Z is down from the origin. Use antenna phase centroid location if provided by the manufacturer.
+    // @Units: m
+    // @Range: -5 5
+    // @Increment: 0.01
+    // @User: Advanced
+
+    // @Param: _POS2_X
+    // @DisplayName: Antenna X position offset
+    // @Description: X position of the second GPS antenna in body frame. Positive X is forward of the origin. Use antenna phase centroid location if provided by the manufacturer.
+    // @Units: m
+    // @Range: -5 5
+    // @Increment: 0.01
+    // @User: Advanced
+
+    // @Param: _POS2_Y
+    // @DisplayName: Antenna Y position offset
+    // @Description: Y position of the second GPS antenna in body frame. Positive Y is to the right of the origin. Use antenna phase centroid location if provided by the manufacturer.
+    // @Units: m
+    // @Range: -5 5
+    // @Increment: 0.01
+    // @User: Advanced
+
+    // @Param: _POS2_Z
+    // @DisplayName: Antenna Z position offset
+    // @Description: Z position of the second GPS antenna in body frame. Positive Z is down from the origin. Use antenna phase centroid location if provided by the manufacturer.
+    // @Units: m
+    // @Range: -5 5
+    // @Increment: 0.01
+    // @User: Advanced
+
+    // @Param: _DELAY_MS
+    // @DisplayName: GPS delay in milliseconds
+    // @Description: Controls the amount of GPS  measurement delay that the autopilot compensates for. Set to zero to use the default delay for the detected GPS type.
+    // @Units: ms
+    // @Range: 0 250
+    // @User: Advanced
+    // @RebootRequired: True
+
+    // @Param: _DELAY_MS2
+    // @DisplayName: GPS 2 delay in milliseconds
+    // @Description: Controls the amount of GPS  measurement delay that the autopilot compensates for. Set to zero to use the default delay for the detected GPS type.
+    // @Units: ms
+    // @Range: 0 250
+    // @User: Advanced
+    // @RebootRequired: True
+
+    // @Param: _COM_PORT
+    // @DisplayName: GPS physical COM port
+    // @Description: The physical COM port on the connected device, currently only applies to SBF and GSOF GPS
+    // @Range: 0 10
+    // @Increment: 1
+    // @User: Advanced
+    // @Values: 0:COM1(RS232) on GSOF, 1:COM2(TTL) on GSOF
+    // @RebootRequired: True
+
+    // @Param: _COM_PORT2
+    // @DisplayName: GPS physical COM port
+    // @Description: The physical COM port on the connected device, currently only applies to SBF and GSOF GPS
+    // @Range: 0 10
+    // @Increment: 1
+    // @User: Advanced
+    // @RebootRequired: True
+
+    // @Group: _MB1_
+    // @Path: MovingBase.cpp
+
+    // @Group: _MB2_
+    // @Path: MovingBase.cpp
+
+    // @Param: _CAN_NODEID1
+    // @DisplayName: GPS Node ID 1
+    // @Description: GPS Node id for first-discovered GPS.
+    // @ReadOnly: True
+    // @User: Advanced
+
+    // @Param: _CAN_NODEID2
+    // @DisplayName: GPS Node ID 2
+    // @Description: GPS Node id for second-discovered GPS.
+    // @ReadOnly: True
+    // @User: Advanced
+
+/*
+ * end old parameter metadata
+ */
+
 namespace AP {
 
 AP_GPS &gps()


### PR DESCRIPTION
allows to not break older firmware in terms of available metadata