### PR TITLE
Add more AUX_FUNC options to RC_Channel transition-required list

### DIFF
--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -865,6 +865,9 @@ bool RC_Channel::init_position_on_first_radio_read(AUX_FUNC func) const
     switch (func) {
     case AUX_FUNC::ARMDISARM_AIRMODE:
     case AUX_FUNC::ARMDISARM:
+    case AUX_FUNC::ARM_EMERGENCY_STOP:
+    case AUX_FUNC::PARACHUTE_RELEASE:
+
         // we do not want to process 
         return true;
     default:
@@ -1151,7 +1154,6 @@ void RC_Channel::do_aux_function_sprayer(const AuxSwitchPos ch_flag)
     if (sprayer == nullptr) {
         return;
     }
-
     sprayer->run(ch_flag == AuxSwitchPos::HIGH);
     // if we are disarmed the pilot must want to test the pump
     sprayer->test_pump((ch_flag == AuxSwitchPos::HIGH) && !hal.util->get_soft_armed());


### PR DESCRIPTION
We need to make sure the behaviour changes between master and this PR - so bad on master, good after this patch.

@timtuxworth if you're up for testing I'll create a similar PR for the functions you suggested also needed to be in this list.  Henry volunteered to test the ones in this PR.

@Hwurzburg I'm a bit concerned about that 3-pos switch change.  Past this change we will not enable auto-release if your switch is in the middle position at first-rc-received time.  If you're working off muscle memory to ensure your switches are in expected positions, it could currently actually be a middle-position-by-default sort of thing... and this would mean people flying without their safety system engaged.... IOW I'm not convinced we can use this exact option for the parachute 3-pos.

