### PR TITLE
hwdef: FPV/OSD boards only get one GPS

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/include/minimize_fpv_osd.inc
+++ b/libraries/AP_HAL_ChibiOS/hwdef/include/minimize_fpv_osd.inc
@@ -9,6 +9,8 @@ define AP_OPTICALFLOW_ENABLED 0
 # minimize_common.py removes backends except for a select few.  Add
 # some back in:
 define AP_GPS_NMEA_ENABLED 1
+define GPS_MAX_INSTANCES 1
+define GPS_MAX_RECEIVERS 1
 
 define AP_MOTORS_FRAME_DEFAULT_ENABLED 0
 define AP_MOTORS_FRAME_QUAD_ENABLED 1


### PR DESCRIPTION
notably cuts out blended GPS support

```
Board                    AP_Periph  blimp  bootloader  copter  heli   iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                                                      
Durandal                            *      *           *       *                  *      *      *
Hitec-Airspeed           *                                                                      
KakuteH7-bdshot                     *      *           *       *                  *      *      *
MatekF405                           -1488  *           -1800   -1720              -1640  -1872  -1608
Pixhawk1-1M-bdshot                  *                  *       *                  *      *      *
f103-QiotekPeriph        *                                                                      
f303-Universal           *                                                                      
iomcu                                                                 *                         
revo-mini                           -1616  *           -1504   -1536              -1688  -1824  -1696
skyviper-v2450                                         *                                        
```