### PR TITLE
Reserving board id for sakurarc h743

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -286,6 +286,8 @@ AP_HW_PIXHAWK6X_PERIPH               1408
 AP_HW_CUBERED_PERIPH                 1409
 AP_HW_RadiolinkPIX6                  1410
 
+AP_HW_SakuraRC-H743                  2714
+
 # IDs 5000-5099 reserved for Carbonix
 # IDs 5100-5199 reserved for SYPAQ Systems
 # IDs 5200-5209 reserved for Airvolute


### PR DESCRIPTION
Will be released for purchase in mainland china, may be available globally but not sure.