### PR TITLE
SITL: correct diagnostic message obout what AirSim-in addr we bound

### DIFF
--- a/libraries/SITL/SIM_AirSim.cpp
+++ b/libraries/SITL/SIM_AirSim.cpp
@@ -55,12 +55,14 @@ AirSim::AirSim(const char *frame_str) :
 */
 void AirSim::set_interface_ports(const char* address, const int port_in, const int port_out)
 {
-	if (!sock.bind("0.0.0.0", port_in)) {
+    static const char *port_in_addr = "0.0.0.0";
+
+    if (!sock.bind(port_in_addr, port_in)) {
 		printf("Unable to bind Airsim sensor_in socket at port %u - Error: %s\n",
 				 port_in, strerror(errno));
 		return;
 	}
-	printf("Bind SITL sensor input at %s:%u\n", "127.0.0.1", port_in);
+	printf("Bind SITL sensor input at %s:%u\n", port_in_addr, port_in);
 	sock.set_blocking(false);
 	sock.reuseaddress();
 


### PR DESCRIPTION
Co-authored-by: Oleksiy Protas <elfy.ua@gmail.com>

Replaces https://github.com/ArduPilot/ardupilot/pull/24158/files

![image](https://github.com/ArduPilot/ardupilot/assets/7077857/abd1fe94-b16f-4225-8a8f-48bcfbe8b03a)
