### PR TITLE
AP_Baro: Do not cache EAS2TAS conversions

### DIFF
--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -395,9 +395,6 @@ void AP_Baro::update_calibration()
 
     // always update the guessed ground temp
     _guessed_ground_temperature = get_external_temperature();
-
-    // force EAS2TAS to recalculate
-    _EAS2TAS = 0;
 }
 
 // return altitude difference in meters between current pressure and a
@@ -433,10 +430,6 @@ float AP_Baro::get_sealevel_pressure(float pressure) const
 float AP_Baro::get_EAS2TAS(void)
 {
     float altitude = get_altitude();
-    if ((fabsf(altitude - _last_altitude_EAS2TAS) < 25.0f) && !is_zero(_EAS2TAS)) {
-        // not enough change to require re-calculating
-        return _EAS2TAS;
-    }
 
     float pressure = get_pressure();
     if (is_zero(pressure)) {
@@ -451,9 +444,7 @@ float AP_Baro::get_EAS2TAS(void)
     if (!is_positive(eas2tas_squared)) {
         return 1.0f;
     }
-    _EAS2TAS = sqrtf(eas2tas_squared);
-    _last_altitude_EAS2TAS = altitude;
-    return _EAS2TAS;
+    return sqrtf(eas2tas_squared);
 }
 
 // return air density / sea level density - decreases as altitude climbs

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -287,8 +287,6 @@ private:
     uint32_t                            _field_elevation_last_ms;
     AP_Int8                             _primary_baro; // primary chosen by user
     AP_Int8                             _ext_bus; // bus number for external barometer
-    float                               _last_altitude_EAS2TAS;
-    float                               _EAS2TAS;
     float                               _external_temperature;
     uint32_t                            _last_external_temperature_ms;
     DerivativeFilterFloat_Size7         _climb_rate_filter;


### PR DESCRIPTION
Caching this introduces discontinuities in TECS, as the step change modifies the target speed demand.

The graph of speed demand steps are from EAS2TAS recalculating every 25 meters in the climb, these changes then ripple into the throttle feed forward for throttle as a throttle spike, that makes it all the way out to the motor.

![2024-04-11T18:21:15,050500232-07:00](https://github.com/ArduPilot/ardupilot/assets/567688/b9a4a205-e57c-4a72-8ece-b3601a63e304)

My understanding of the reason for this cache is this was very expensive for us back in the APM2 days, but the world has moved on since then and has a lot more processing power available then we used to. We could try to limit this to faster boards, but I think we can probably afford this on all our currently supported boards. (Side benefit, saves memory :) )

Will be test flying this on a backport to 4.4 tomorrow.