### PR TITLE
AP_NavEKF3: filter velocity corrections for IMU position

### DIFF
--- a/libraries/AP_DAL/AP_DAL_InertialSensor.cpp
+++ b/libraries/AP_DAL/AP_DAL_InertialSensor.cpp
@@ -54,9 +54,9 @@ void AP_DAL_InertialSensor::start_frame()
 void AP_DAL_InertialSensor::update_filtered(uint8_t i)
 {
     if (!is_positive(alpha)) {
-        // we use a constant 20Hz for EKF filtered accel/gyro, making the EKF
+        // we use a constant 10Hz for EKF filtered accel/gyro, making the EKF
         // independent of the INS filter settings
-        const float cutoff_hz = 20.0;
+        const float cutoff_hz = 10.0;
         alpha = calc_lowpass_alpha_dt(get_loop_delta_t(), cutoff_hz);
     }
     if (is_positive(_RISI[i].delta_angle_dt)) {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -863,7 +863,7 @@ void NavEKF3_core::calcOutputStates()
     if (!accelPosOffset.is_zero()) {
         // calculate the average angular rate across the last IMU update
         // note delAngDT is prevented from being zero in readIMUData()
-        Vector3F angRate = imuDataNew.delAng * (1.0f/imuDataNew.delAngDT);
+        Vector3F angRate = dal.ins().get_gyro(gyro_index_active).toftype();
 
         // Calculate the velocity of the body frame origin relative to the IMU in body frame
         // and rotate into earth frame. Note % operator has been overloaded to perform a cross product


### PR DESCRIPTION
this is a possible fix for #20710 

the velocity corrections introduce a lot of noise in the reported velocity to external controllers. With the velocity correction enabled a VTOL aircraft may oscillate badly if the IMU position is significant.
This PR uses the filtered gyro, and lowers the filter frequency in the DAL to 10Hz
This is an example on a large quadplane:
![image](https://github.com/ArduPilot/ardupilot/assets/831867/a11ac3b3-add9-4d05-8200-8e146ef7ac8d)
the yellow line shows the much better velocity east output with this change versus the original in blue
this aircraft has:
 - INS_POSn_X = 0.5
 - GPS_POS1_X = -0.1
 - GPS_POS1_Y = -1.2

the issue was noticed as the aircraft oscillated in QLOITER mode with the correct INS and GPS position parameters. Setting INS_POSn_X==0 stopped the oscillation



