### PR TITLE
AP_DAL: visual odom get_delay_ms return fix

### DIFF
--- a/libraries/AP_DAL/AP_DAL_VisualOdom.h
+++ b/libraries/AP_DAL/AP_DAL_VisualOdom.h
@@ -18,7 +18,7 @@ public:
         return RVOH.enabled;
     }
 
-    bool get_delay_ms() const {
+    uint16_t get_delay_ms() const {
         return RVOH.delay_ms;
     }
 


### PR DESCRIPTION
This resolves issue https://github.com/ArduPilot/ardupilot/issues/26800

This has been lightly tested using the ModalAI VOXL camera to confirm that it still works.  I also tried setting the delay to a large value (>100ms) and the EKF variances become large so we know the parameter is being used.

Thanks very much to @luweiagi for finding this!

