### PR TITLE
Tools: stop emitting debug as part of test_build_options.py

### DIFF
--- a/Tools/autotest/test_build_options.py
+++ b/Tools/autotest/test_build_options.py
@@ -147,7 +147,7 @@ class TestBuildOptions(object):
                     if f.define not in ret:
                         continue
 
-                    print("%s requires %s" % (option.define, f.define), file=sys.stderr)
+                    # print("%s requires %s" % (option.define, f.define), file=sys.stderr)
                     added_one = True
                     ret[option.define] = 0
                     break


### PR DESCRIPTION
This allows simple redirection from `./Tools/autotest/test_build_options.py --board=FSO_Beacon --emit-disable-all-defines` to a file which can then be inserted into an editor buffer easily.

Sponsored by FreeSpace Operations