### PR TITLE
Copter: Add latching timeout on out of range rangefinder

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -264,6 +264,12 @@ private:
         float terrain_offset_cm;    // filtered terrain offset (e.g. terrain's height above EKF origin)
     } rangefinder_state, rangefinder_up_state;
 
+    uint32_t rangefinder_timeout_ms;
+
+    void set_rangefinder_timeout(uint32_t timeout) { rangefinder_timeout_ms = timeout; }
+
+    void reset_rangefinder_timeout(void) { set_rangefinder_timeout(0); }
+
     // return rangefinder height interpolated using inertial altitude
     bool get_rangefinder_height_interpolated_cm(int32_t& ret) const;
 
@@ -815,6 +821,8 @@ private:
     void heli_update_rotor_speed_targets();
     void heli_update_autorotation();
     void update_collective_low_flag(int16_t throttle_control);
+
+    bool arot_rng_finder_set_on;   // Switch to prevent spamming the rangefinder setting required for autorotaion
 
     // inertia.cpp
     void read_inertia();

--- a/ArduCopter/heli.cpp
+++ b/ArduCopter/heli.cpp
@@ -209,6 +209,19 @@ void Copter::heli_update_autorotation()
         motors->set_enable_bailout(false);
     }
 
+    // See if we need to use autorotation config for preliminary tests
+    if (g2.arot.is_enable()) {
+        if (g2.arot.use_autorotation_config() && !arot_rng_finder_set_on) {
+            gcs().send_text(MAV_SEVERITY_INFO, "arot rngfnd test on");
+            set_rangefinder_timeout(10000);
+            arot_rng_finder_set_on = true;
+        } else if (!g2.arot.use_autorotation_config() && arot_rng_finder_set_on) {
+            gcs().send_text(MAV_SEVERITY_INFO, "arot rngfnd test off");
+            reset_rangefinder_timeout();
+            arot_rng_finder_set_on = false;
+        }
+    }
+
 }
 
 // update collective low flag.  Use a debounce time of 400 milliseconds.

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1918,7 +1918,8 @@ public:
     Number mode_number() const override { return Number::AUTOROTATE; }
 
     bool init(bool ignore_checks) override;
-    void run() override;
+    void run(void) override;
+    void exit(void) override;
 
     bool is_autopilot() const override { return true; }
     bool requires_GPS() const override { return false; }

--- a/ArduCopter/mode_autorotate.cpp
+++ b/ArduCopter/mode_autorotate.cpp
@@ -58,6 +58,9 @@ bool ModeAutorotate::init(bool ignore_checks)
     _flags.bail_out_initial = true;
     _msg_flags.bad_rpm = true;
 
+    // Extend rangefinder time out for use in the autorotation
+    copter.set_rangefinder_timeout(10000);
+
     // Setting default starting switches
     phase_switch = Autorotation_Phase::ENTRY;
 
@@ -318,6 +321,10 @@ void ModeAutorotate::warning_message(uint8_t message_n)
             break;
         }
     }
+}
+
+void ModeAutorotate::exit(void) {
+    copter.reset_rangefinder_timeout();
 }
 
 #endif

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -52,8 +52,10 @@ void Copter::read_rangefinder(void)
         // tilt corrected but unfiltered, not glitch protected alt
         rf_state.alt_cm = tilt_correction * rangefinder.distance_cm_orient(rf_orient);
 
-        // remember inertial alt to allow us to interpolate rangefinder
-        rf_state.inertial_alt_cm = inertial_nav.get_position_z_up_cm();
+        // remember inertial alt to allow us to interpolate rangefinder from last healthy measurement
+        if (rf_state.alt_healthy) {
+            rf_state.inertial_alt_cm = inertial_nav.get_position_z_up_cm();
+        }
 
         // glitch handling.  rangefinder readings more than RANGEFINDER_GLITCH_ALT_CM from the last good reading
         // are considered a glitch and glitch_count becomes non-zero
@@ -164,9 +166,14 @@ void Copter::update_rangefinder_terrain_offset()
  */
 bool Copter::get_rangefinder_height_interpolated_cm(int32_t& ret) const
 {
-    if (!rangefinder_alt_ok()) {
+    // rangefinder_timeout_ms gives us the chance to use the inertially interpolated
+    // range finder height for a short time after it goes out of range. This
+    // is needed to prevent jumps in hagl when the rangefinder comes close to
+    // the ground in a heli autorotation landing
+    if (!rangefinder_alt_ok() && ((rangefinder_timeout_ms == 0) || (AP_HAL::millis() - rangefinder_state.last_healthy_ms > rangefinder_timeout_ms))) {
         return false;
     }
+
     ret = rangefinder_state.alt_cm_filt.get();
     float inertial_alt_cm = inertial_nav.get_position_z_up_cm();
     ret += inertial_alt_cm - rangefinder_state.inertial_alt_cm;

--- a/libraries/AC_Autorotation/AC_Autorotation.cpp
+++ b/libraries/AC_Autorotation/AC_Autorotation.cpp
@@ -115,6 +115,12 @@ const AP_Param::GroupInfo AC_Autorotation::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("FW_V_FF", 11, AC_Autorotation, _param_fwd_k_ff, AP_FW_VEL_FF),
 
+    // @Param: OPTIONS
+    // @DisplayName: Autorotation options
+    // @Description: Bitmask for autorotation options.
+    // @Bitmask: 0: Test rangefinder config
+    AP_GROUPINFO("OPTIONS", 12, AC_Autorotation, _options, 0),
+
     AP_GROUPEND
 };
 

--- a/libraries/AC_Autorotation/AC_Autorotation.h
+++ b/libraries/AC_Autorotation/AC_Autorotation.h
@@ -38,6 +38,7 @@ public:
     int32_t get_pitch(void) const { return _pitch_target; }  // Get pitch target
     float calc_speed_forward(void);  // Calculates the forward speed in the horizontal plane
     void set_dt(float delta_sec);
+    bool use_autorotation_config(void) const { return int32_t(_options.get()) & int32_t(OPTION::TEST_RANGEFINDER_TIMEOUT); }
 
     // User Settable Parameters
     static const struct AP_Param::GroupInfo var_info[];
@@ -84,12 +85,17 @@ private:
     AP_Float _param_bail_time;
     AP_Int8  _param_rpm_instance;
     AP_Float _param_fwd_k_ff;
+    AP_Int32 _options;
 
     //--------Internal Flags--------
     struct controller_flags {
             bool bad_rpm             : 1;
             bool bad_rpm_warning     : 1;
     } _flags;
+
+    enum class OPTION {
+        TEST_RANGEFINDER_TIMEOUT = (1<<0)
+    };
 
     //--------Internal Functions--------
     void set_collective(float _collective_filter_cutoff) const;


### PR DESCRIPTION
We want to use the copter function get_rangefinder_height_interpolated_cm() for the height above ground measurement in the heli autorotation mode.  This is important for initiating both the flare and touchdown phases.

The aforementioned function does the inertially interpolated lidar measurement which is one of the key bits we want from that function.  However, as the plot below illustrates, the return from that function jumps between terrain and rangefinder measurements when the rangefinder goes out of range.  The rangefinder will inevitably go out of range low autorotation landing, but I do not want the height measurement to jump in this case.

In this plot AROT.h is the return value from get_rangefinder_height_interpolated_cm().  It can be seen to jump between the terrain height and rangefinder readings.
![image](https://github.com/ArduPilot/ardupilot/assets/34512430/f3b050d9-c597-42a3-8c03-3562a7ae5d21)

This PR proposes a work around so that we trust the last lidar measurement and interpolate from it based on inertial nav for a short period of time, but long enough to allow us to complete the landing without the height source jumping.

I wanted to get some thoughts on whether this is an acceptable approach to resolving this problem.