### PR TITLE
AP_Param: add Convert bitmask parameter width, Harmonic notch use new param width conversion.

### DIFF
--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -2099,7 +2099,7 @@ void AP_Param::convert_toplevel_objects(const TopLevelObjectConversion conversio
  convert width of a parameter, allowing update to wider scalar values
  without changing the parameter indexes
 */
-bool AP_Param::convert_parameter_width(ap_var_type old_ptype, float scale_factor)
+bool AP_Param::_convert_parameter_width(ap_var_type old_ptype, float scale_factor, bool bitmask)
 {
     if (configured_in_storage()) {
         // already converted or set by the user
@@ -2143,10 +2143,46 @@ bool AP_Param::convert_parameter_width(ap_var_type old_ptype, float scale_factor
     
     AP_Param *old_ap = (AP_Param *)&old_value[0];
 
-    // going via float is safe as the only time we would be converting
-    // from AP_Int32 is when converting to float
-    float old_float_value = old_ap->cast_to_float(old_ptype);
-    set_value(new_ptype, this, old_float_value*scale_factor);
+    if (!bitmask) {
+        // Numeric conversion
+        // going via float is safe as the only time we would be converting
+        // from AP_Int32 is when converting to float
+        float old_float_value = old_ap->cast_to_float(old_ptype);
+        set_value(new_ptype, this, old_float_value*scale_factor);
+
+    } else {
+        // Bitmask conversion, go via uint32
+        // int8 -1 should convert to int16 255
+        uint32_t mask;
+        switch (old_ptype) {
+        case AP_PARAM_INT8:
+            mask = (uint8_t)(*(AP_Int8*)old_ap);
+            break;
+        case AP_PARAM_INT16:
+            mask = (uint16_t)(*(AP_Int16*)old_ap);
+            break;
+        case AP_PARAM_INT32:
+            mask = (uint32_t)(*(AP_Int32*)old_ap);
+            break;
+        default:
+            return false;
+        }
+
+        switch (new_ptype) {
+        case AP_PARAM_INT8:
+            ((AP_Int8 *)this)->set(mask);
+            break;
+        case AP_PARAM_INT16:
+            ((AP_Int16 *)this)->set(mask);
+            break;
+        case AP_PARAM_INT32:
+            ((AP_Int32 *)this)->set(mask);
+            break;
+        default:
+            return false;
+        }
+    }
+
 
     // force save as the new type
     save(true);

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -495,11 +495,17 @@ public:
       values without changing the parameter indexes. This will return
       true if the parameter was converted from an old parameter value
     */
-    bool convert_parameter_width(ap_var_type old_ptype, float scale_factor=1.0);
+    bool convert_parameter_width(ap_var_type old_ptype, float scale_factor=1.0) {
+        return _convert_parameter_width(old_ptype, scale_factor, false);
+    }
     bool convert_centi_parameter(ap_var_type old_ptype) {
         return convert_parameter_width(old_ptype, 0.01f);
     }
-    
+    // Converting bitmasks should be done bitwise rather than numerically
+    bool convert_bitmask_parameter_width(ap_var_type old_ptype) {
+        return _convert_parameter_width(old_ptype, 1.0, true);
+    }
+
     // convert a single parameter with scaling
     enum {
         CONVERT_FLAG_REVERSE=1, // handle _REV -> _REVERSED conversion
@@ -784,6 +790,13 @@ private:
 
     // return true if the parameter is configured in EEPROM/FRAM
     bool configured_in_storage(void) const;
+
+    /*
+      convert width of a parameter, allowing update to wider scalar
+      values without changing the parameter indexes. This will return
+      true if the parameter was converted from an old parameter value
+    */
+    bool _convert_parameter_width(ap_var_type old_ptype, float scale_factor, bool bitmask);
 
     // send a parameter to all GCS instances
     void send_parameter(const char *name, enum ap_var_type param_header_type, uint8_t idx) const;

--- a/libraries/Filter/HarmonicNotchFilter.cpp
+++ b/libraries/Filter/HarmonicNotchFilter.cpp
@@ -515,7 +515,7 @@ HarmonicNotchFilterParams::HarmonicNotchFilterParams(void)
 
 void HarmonicNotchFilterParams::init()
 {
-    _harmonics.convert_parameter_width(AP_PARAM_INT8);
+    _harmonics.convert_bitmask_parameter_width(AP_PARAM_INT8);
 }
 
 /*


### PR DESCRIPTION
This fixes parameter conversion for the harmonics bitmask in the harmonic notch. If the 7th bit was set the conversion comes out incorrectly because it does a numerical conversion rather than a bitmask one. The original conversion was added in https://github.com/ArduPilot/ardupilot/pull/24309. This conversion is included in 4.5 so we should include this fix since we only get one attempt at conversion. 

The current conversion results in all harmonics above 8 being enabled if the 8th harmonic is enabled. For example:

int8 -1 is 0b1111,1111 the current conversion converts this to int32 -1 which is 0b1111,1111,1111,1111,1111,1111,1111,1111 this is all harmonics on (although we only support 16).

The new conversion converts to int32 255 which is 0b0000,0000,0000,0000,0000,0000,1111,1111.

I don 't think this is critical bug. The 9th to 16th harmonics are only enabled if the user has enabled the 8th harmonic. Either the user does not notice as they will be a such a high frequency (although there will be extra CPU load).  Or the 8 extra notches with the triple notch or with multi source puts the total number of notches over the limit of 54/27/24 (depending on board) and the user gets a board config error prompting them to reduce the number of notches (hitting this config error is how I found the bug).

I did have a look for the same bug with other conversions. There are a few other int8 bitmasks that have been converted, but none that had a user of the 8th bit prior to the conversion. 