### PR TITLE
AC_AttitudeControl: fix ATC_SLEW_YAW description (NFC)

### DIFF
--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -24,7 +24,7 @@ const AP_Param::GroupInfo AC_AttitudeControl::var_info[] = {
 
     // @Param: SLEW_YAW
     // @DisplayName: Yaw target slew rate
-    // @Description: Maximum rate the yaw target can be updated in Loiter, RTL, Auto flight modes
+    // @Description: Maximum rate the yaw target can be updated in RTL and Auto flight modes
     // @Units: cdeg/s
     // @Range: 500 18000
     // @Increment: 100


### PR DESCRIPTION
ATC_SLEW_YAW parameter does not affect the Loiter mode. (#20758)

https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/ReleaseNotes.txt#L1153
> Loiter mode ignores ATC_SLEW_YAW parameter

This parameter seems to work in the following flight modes:
- Auto
- Circle
- Guided
- RTL
- SmartRTL
- Land