### PR TITLE
Remove "startup_ground" functions from Rover and Plane

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1085,13 +1085,12 @@ private:
 
     // system.cpp
     void init_ardupilot() override;
-    void startup_ground(void);
     bool set_mode(Mode& new_mode, const ModeReason reason);
     bool set_mode(const uint8_t mode, const ModeReason reason) override;
     bool set_mode_by_number(const Mode::Number new_mode_number, const ModeReason reason);
     void check_long_failsafe();
     void check_short_failsafe();
-    void startup_INS_ground(void);
+    void startup_INS(void);
     bool should_log(uint32_t mask);
     int8_t throttle_percentage(void);
     void notify_mode(const Mode& mode);

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -393,7 +393,7 @@ private:
         return control_mode == &mode_auto;
     }
 
-    void startup_INS_ground(void);
+    void startup_INS(void);
     void notify_mode(const Mode *new_mode);
     uint8_t check_digital_pin(uint8_t pin);
     bool should_log(uint32_t mask);

--- a/Rover/system.cpp
+++ b/Rover/system.cpp
@@ -1,10 +1,3 @@
-/*****************************************************************************
-The init_ardupilot function processes everything we need for an in - air restart
-    We will determine later if we are actually on the ground and process a
-    ground start in that case.
-
-*****************************************************************************/
-
 #include "Rover.h"
 
 static void failsafe_check_static()
@@ -121,7 +114,21 @@ void Rover::init_ardupilot()
     g2.oa.init();
 #endif
 
-    startup_ground();
+    set_mode(mode_initializing, ModeReason::INITIALISED);
+
+    startup_INS();
+
+#if AP_MISSION_ENABLED
+    // initialise mission library
+    mode_auto.mission.init();
+#endif
+
+    // initialise AP_Logger library
+#if HAL_LOGGING_ENABLED
+    logger.setVehicle_Startup_Writer(
+        FUNCTOR_BIND(&rover, &Rover::Log_Write_Vehicle_Startup_Messages, void)
+        );
+#endif
 
     Mode *initial_mode = mode_from_mode_num((enum Mode::Number)g.initial_mode.get());
     if (initial_mode == nullptr) {
@@ -143,30 +150,6 @@ void Rover::init_ardupilot()
 
     // flag that initialisation has completed
     initialised = true;
-}
-
-//*********************************************************************************
-// This function does all the calibrations, etc. that we need during a ground start
-//*********************************************************************************
-void Rover::startup_ground(void)
-{
-    set_mode(mode_initializing, ModeReason::INITIALISED);
-
-    // IMU ground start
-    //------------------------
-    //
-
-    startup_INS_ground();
-
-    // initialise mission library
-    mode_auto.mission.init();
-
-    // initialise AP_Logger library
-#if HAL_LOGGING_ENABLED
-    logger.setVehicle_Startup_Writer(
-        FUNCTOR_BIND(&rover, &Rover::Log_Write_Vehicle_Startup_Messages, void)
-        );
-#endif
 }
 
 // update the ahrs flyforward setting which can allow
@@ -285,7 +268,7 @@ bool Rover::set_mode(Mode::Number new_mode, ModeReason reason)
     return rover.set_mode(*mode, reason);
 }
 
-void Rover::startup_INS_ground(void)
+void Rover::startup_INS(void)
 {
     gcs().send_text(MAV_SEVERITY_INFO, "Beginning INS calibration. Do not move vehicle");
     hal.scheduler->delay(100);


### PR DESCRIPTION
these make it harder to think about moving things into common code

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *
Durandal                            *      *           *       *                 -24    0      *
Hitec-Airspeed           *
KakuteH7-bdshot                     *      *           *       *                 -24    -16    *
MatekF405                           *      *           *       *                 -8     -8     *
Pixhawk1-1M-bdshot                  *                  *       *                 -8     -16    *
f103-QiotekPeriph        *
f303-Universal           *
iomcu                                                                *
revo-mini                           *      *           *       *                 -8     -16    *
skyviper-v2450                                         *
```
