### PR TITLE
autotest: correct command-line for sitl in FlyEachFrame

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -8886,7 +8886,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             if not isinstance(defaults, list):
                 defaults = [defaults]
             self.customise_SITL_commandline(
-                ["--defaults", ','.join(defaults), ],
+                [],
+                defaults_filepath=defaults,
                 model=model,
                 wipe=True,
             )


### PR DESCRIPTION
.... end up passing `--defaults` twice on SITL command-line, which is last-one-in-wins
