### PR TITLE
Remove AP_Baro accumulate API

### DIFF
--- a/AntennaTracker/Tracker.cpp
+++ b/AntennaTracker/Tracker.cpp
@@ -58,7 +58,6 @@ const AP_Scheduler::Task Tracker::scheduler_tasks[] = {
     SCHED_TASK_CLASS(AP_Baro,          &tracker.barometer,  update,         10, 1500, 40),
     SCHED_TASK_CLASS(GCS,              (GCS*)&tracker._gcs, update_receive, 50, 1700, 45),
     SCHED_TASK_CLASS(GCS,              (GCS*)&tracker._gcs, update_send,    50, 3000, 50),
-    SCHED_TASK_CLASS(AP_Baro,           &tracker.barometer, accumulate,     50,  900, 55),
 #if HAL_LOGGING_ENABLED
     SCHED_TASK(ten_hz_logging_loop,    10,    300, 60),
     SCHED_TASK_CLASS(AP_Logger,   &tracker.logger, periodic_tasks, 50,  300, 65),

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -186,7 +186,6 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
 #if AP_SERVORELAYEVENTS_ENABLED
     SCHED_TASK_CLASS(AP_ServoRelayEvents,  &copter.ServoRelayEvents,      update_events, 50,  75,  60),
 #endif
-    SCHED_TASK_CLASS(AP_Baro,              &copter.barometer,             accumulate,    50,  90,  63),
 #if AC_PRECLAND_ENABLED
     SCHED_TASK(update_precland,      400,     50,  69),
 #endif

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -81,7 +81,6 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
     SCHED_TASK_CLASS(AP_ServoRelayEvents, &plane.ServoRelayEvents, update_events, 50, 150,  63),
 #endif
     SCHED_TASK_CLASS(AP_BattMonitor, &plane.battery, read,   10, 300,  66),
-    SCHED_TASK_CLASS(AP_Baro, &plane.barometer, accumulate,  50, 150,  69),
     SCHED_TASK(read_rangefinder,       50,    100, 78),
 #if AP_ICENGINE_ENABLED
     SCHED_TASK_CLASS(AP_ICEngine,      &plane.g2.ice_control, update,     10, 100,  81),

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -79,7 +79,6 @@ const AP_Scheduler::Task Sub::scheduler_tasks[] = {
     SCHED_TASK(update_altitude,       10,    100,  18),
     SCHED_TASK(three_hz_loop,          3,     75,  21),
     SCHED_TASK(update_turn_counter,   10,     50,  24),
-    SCHED_TASK_CLASS(AP_Baro,             &sub.barometer,    accumulate,          50,  90,  27),
     SCHED_TASK(one_hz_loop,            1,    100,  33),
     SCHED_TASK_CLASS(GCS,                 (GCS*)&sub._gcs,   update_receive,     400, 180,  36),
     SCHED_TASK_CLASS(GCS,                 (GCS*)&sub._gcs,   update_send,        400, 550,  39),

--- a/Blimp/Blimp.cpp
+++ b/Blimp/Blimp.cpp
@@ -75,7 +75,6 @@ const AP_Scheduler::Task Blimp::scheduler_tasks[] = {
 #if AP_SERVORELAYEVENTS_ENABLED
     SCHED_TASK_CLASS(AP_ServoRelayEvents,  &blimp.ServoRelayEvents,      update_events, 50,     75,  27),
 #endif
-    SCHED_TASK_CLASS(AP_Baro,              &blimp.barometer,             accumulate,    50,     90,  30),
 #if HAL_LOGGING_ENABLED
     SCHED_TASK(full_rate_logging,     50,    50,  33),
 #endif

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -1043,16 +1043,6 @@ void AP_Baro::update_field_elevation(void)
 #endif
 }
 
-/*
-  call accumulate on all drivers
- */
-void AP_Baro::accumulate(void)
-{
-    for (uint8_t i=0; i<_num_drivers; i++) {
-        drivers[i]->accumulate();
-    }
-}
-
 
 /* register a new sensor, claiming a sensor slot. If we are out of
    slots it will panic

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -87,10 +87,6 @@ public:
     // get pressure correction in Pascal. Divide by 100 for millibars or hectopascals
     float get_pressure_correction(void) const { return get_pressure_correction(_primary); }
     float get_pressure_correction(uint8_t instance) const { return sensors[instance].p_correction; }
-    
-    // accumulate a reading on sensors. Some backends without their
-    // own thread or a timer may need this.
-    void accumulate(void);
 
     // calibrate the barometer. This must be called on startup if the
     // altitude/climb_rate/acceleration interfaces are ever used

--- a/libraries/AP_Baro/AP_Baro_Backend.h
+++ b/libraries/AP_Baro/AP_Baro_Backend.h
@@ -12,11 +12,6 @@ public:
     // data to the frontend
     virtual void update() = 0;
 
-    // accumulate function. This is used for backends that don't use a
-    // timer, and need to be called regularly by the main code to
-    // trigger them to read the sensor
-    virtual void accumulate(void) {}
-
     void backend_update(uint8_t instance);
 
     //  Check that the baro valid by using a mean filter.

--- a/libraries/AP_Baro/examples/BARO_generic/BARO_generic.cpp
+++ b/libraries/AP_Baro/examples/BARO_generic/BARO_generic.cpp
@@ -33,7 +33,6 @@ static AP_Baro barometer;
 #endif // HAL_EXTERNAL_AHRS_ENABLED
 
 static uint32_t timer;
-static uint8_t counter;
 static AP_BoardConfig board_config;
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
@@ -69,14 +68,9 @@ void loop()
         return;
     }
 
-    // run accumulate() at 50Hz and update() at 10Hz
-    if ((AP_HAL::micros() - timer) > 20 * 1000UL) {
+    // run update() at 10Hz
+    if ((AP_HAL::micros() - timer) > 100 * 1000UL) {
         timer = AP_HAL::micros();
-        barometer.accumulate();
-        if (counter++ < 5) {
-            return;
-        }
-        counter = 0;
         barometer.update();
 
         //calculate time taken for barometer readings to update


### PR DESCRIPTION
no backend actually needs to be prodded, everything is done on timers


... note that the virtual function is being removed; if any backend was overriding it they would now fail as they must have said they were overriding and now don't.
