### PR TITLE
TradHeli: fix yaw behavior in autorotation

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -129,7 +129,7 @@ public:
     uint32_t    get_output_mask() const;
 
     // rotor_speed_above_critical - return true if rotor speed is above that critical for flight
-    bool        rotor_speed_above_critical(void) const { return get_rotor_speed() > get_critical_speed(); }
+    bool        rotor_speed_above_critical(void) const { return get_rotor_speed() >= get_critical_speed(); }
 
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo var_info[];


### PR DESCRIPTION
Currently, when performing autorotations, bool variable "rotor_speed_above_critical" is allowed to switch to false.
This cause the rotor_runup_complete bool to change to false and consequently limits the I-term of the yaw axis controller (AC_AttitudeControl_Heli.cpp line line 515) , in flight, see following log screenshot:
![image](https://github.com/ArduPilot/ardupilot/assets/8063851/fa033bf8-b920-4909-b084-8cc3907f5fd7)
This has potentially dangerous consequences on vehicle controllability.
Suggested mod keeps the "rotor_runup_complete" variable true, thus preventing decay of yaw axis I-term during glide descent.