### PR TITLE
Copter/Blimp: Do not set the same value

### DIFF
--- a/ArduCopter/radio.cpp
+++ b/ArduCopter/radio.cpp
@@ -148,7 +148,7 @@ void Copter::set_throttle_and_failsafe(uint16_t throttle_pwm)
     }else{
         // we have a good throttle so reduce failsafe counter
         failsafe.radio_counter--;
-        if( failsafe.radio_counter <= 0 ) {
+        if( failsafe.radio_counter < 0 ) {
             failsafe.radio_counter = 0;   // check to ensure we don't underflow the counter
 
             // disengage failsafe after three (nearly) consecutive valid throttle values

--- a/Blimp/radio.cpp
+++ b/Blimp/radio.cpp
@@ -120,7 +120,7 @@ void Blimp::set_throttle_and_failsafe(uint16_t throttle_pwm)
     } else {
         // we have a good throttle so reduce failsafe counter
         failsafe.radio_counter--;
-        if ( failsafe.radio_counter <= 0 ) {
+        if ( failsafe.radio_counter < 0 ) {
             failsafe.radio_counter = 0;   // check to ensure we don't underflow the counter
 
             // disengage failsafe after three (nearly) consecutive valid throttle values


### PR DESCRIPTION
If 0, there is no need to set 0.
If it is less than 0, it would be set to 0.