### PR TITLE
Plane: Limit possible climb/sink rate in FBWB/CRUISE to TECS limits

### DIFF
--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -401,7 +401,10 @@ void Plane::update_fbwb_speed_height(void)
             set_target_altitude_current();
         }
 
-        int32_t alt_change_cm = g.flybywire_climb_rate * elevator_input * dt * 100;
+        float climb_rate = g.flybywire_climb_rate * elevator_input;
+        climb_rate = constrain_float(climb_rate, -TECS_controller.get_max_sinkrate(), TECS_controller.get_max_climbrate());
+
+        int32_t alt_change_cm = climb_rate * dt * 100;
         change_target_altitude(alt_change_cm);
 
 #if HAL_SOARING_ENABLED


### PR DESCRIPTION
A simple constrain to never change target altitude more than configured TECS limits, even if `FBWB_CLIMB_RATE` is more than `TECS_SINK_MAX` or `TECS_CLMB_MAX`. Should not change anything for properly configured `FBWB_CLIMB_RATE`. This constrain is asymetrical, meaning climb or sink constrain may happen at different stick deflections if `TECS_SINK_MAX` is different than `TECS_CLMB_MAX`.

Tested with SITL with:
```
TECS_SINK_MAX 4
TECS_CLMB_MAX 6
FBWB_CLIMB_RATE 8
```
Before:
![image](https://github.com/ArduPilot/ardupilot/assets/7950377/2a9fe6b4-76e4-4af1-bfb6-33bcd6d18fa8)

After:
![image](https://github.com/ArduPilot/ardupilot/assets/7950377/8f721230-8a74-4a9e-9f33-ad7cc0c3afb7)
