### PR TITLE
AP_Periph: fixed check of return of get_RelPosNed

### DIFF
--- a/Tools/AP_Periph/gps.cpp
+++ b/Tools/AP_Periph/gps.cpp
@@ -295,8 +295,8 @@ void AP_Periph_FW::send_relposheading_msg() {
     float relative_down_pos;
     float reported_heading_acc;
     uint32_t curr_timestamp = 0;
-    gps.get_RelPosHeading(curr_timestamp, reported_heading, relative_distance, relative_down_pos, reported_heading_acc);
-    if (last_relposheading_ms == curr_timestamp) {
+    if (!gps.get_RelPosHeading(curr_timestamp, reported_heading, relative_distance, relative_down_pos, reported_heading_acc) ||
+        last_relposheading_ms == curr_timestamp) {
         return;
     }
     last_relposheading_ms = curr_timestamp;

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -980,7 +980,7 @@ void AP_GPS::update_instance(uint8_t instance)
 
 
 #if GPS_MOVING_BASELINE
-void AP_GPS::get_RelPosHeading(uint32_t &timestamp, float &relPosHeading, float &relPosLength, float &relPosD, float &accHeading)
+bool AP_GPS::get_RelPosHeading(uint32_t &timestamp, float &relPosHeading, float &relPosLength, float &relPosD, float &accHeading)
 {
     for (uint8_t i=0; i< GPS_MAX_RECEIVERS; i++) {
         if (drivers[i] &&
@@ -991,8 +991,10 @@ void AP_GPS::get_RelPosHeading(uint32_t &timestamp, float &relPosHeading, float 
            relPosD = state[i].relPosD;
            accHeading = state[i].accHeading;
            timestamp = state[i].relposheading_ts;
+           return true;
         }
     }
+    return false;
 }
 
 bool AP_GPS::get_RTCMV3(const uint8_t *&bytes, uint16_t &len)

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -594,7 +594,7 @@ public:
 #if GPS_MOVING_BASELINE
     // methods used by UAVCAN GPS driver and AP_Periph for moving baseline
     void inject_MBL_data(uint8_t* data, uint16_t length);
-    void get_RelPosHeading(uint32_t &timestamp, float &relPosHeading, float &relPosLength, float &relPosD, float &accHeading);
+    bool get_RelPosHeading(uint32_t &timestamp, float &relPosHeading, float &relPosLength, float &relPosD, float &accHeading) WARN_IF_UNUSED;
     bool get_RTCMV3(const uint8_t *&bytes, uint16_t &len);
     void clear_RTCMV3();
 #endif // GPS_MOVING_BASELINE


### PR DESCRIPTION
If the rover GPS does not get a RelPosNed sample for 500ms then it would send invalid values on the CAN bus, causing the flight controller to show GPS yaw as unhealthy
![image](https://github.com/ArduPilot/ardupilot/assets/831867/3f45cd4a-ae15-4812-b74d-2d6dae6d32c0)
