### PR TITLE
Copter: guided mode fix for landing detector internal error

### DIFF
--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -960,8 +960,8 @@ void ModeGuided::angle_control_run()
     }
 
     // TODO: use get_alt_hold_state
-    // landed with positive desired climb rate, takeoff
-    if (copter.ap.land_complete && (guided_angle_state.climb_rate_cms > 0.0f)) {
+    // landed with positive desired climb rate or thrust, takeoff
+    if (copter.ap.land_complete && positive_thrust_or_climbrate) {
         zero_throttle_and_relax_ac();
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
         if (motors->get_spool_state() == AP_Motors::SpoolState::THROTTLE_UNLIMITED) {

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -11020,7 +11020,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "GroundEffectCompensation_touchDownExpected": "Flapping",
             "FlyMissionTwice": "See https://github.com/ArduPilot/ardupilot/pull/18561",
             "GPSForYawCompassLearn": "Vehicle currently crashed in spectacular fashion",
-            "GuidedModeThrust": "land detector raises internal error as we're not saying we're about to take off but just did",
             "CompassMot": "Cuases an arithmetic exception in the EKF",
         }
 


### PR DESCRIPTION
This resolves an Internal Error (see issue https://github.com/ArduPilot/ardupilot/issues/26865) which is caused by **Guided** mode neglecting its responsibility to call set_land_complete(false) when it believes the vehicle has taken off.

This only occurs when the caller is providing [SET_ATTITUDE_CONTROL messages](https://ardupilot.org/dev/docs/copter-commands-in-guided-mode.html#set-attitude-target) where the "thrust" field is really interpreted as a thrust (as opposed to being interpreted as a climb rate).

This has been tested in SITL to confirm that before this fix the issue occurs and afterwards it does not.

The GuideMostThrust autotest (see PR https://github.com/ArduPilot/ardupilot/pull/26782) has also been enabled
