### PR TITLE
Filter: NotchFilter: return NaN for `logging_frequency` if not initialised

### DIFF
--- a/libraries/Filter/NotchFilter.cpp
+++ b/libraries/Filter/NotchFilter.cpp
@@ -19,6 +19,7 @@
 #endif
 
 #include "NotchFilter.h"
+#include <AP_Logger/AP_Logger.h>
 
 const static float NOTCH_MAX_SLEW       = 0.05f;
 const static float NOTCH_MAX_SLEW_LOWER = 1.0f - NOTCH_MAX_SLEW;
@@ -134,6 +135,15 @@ void NotchFilter<T>::reset()
 {
     need_reset = true;
 }
+
+#if HAL_LOGGING_ENABLED
+// return the frequency to log for the notch
+template <class T>
+float NotchFilter<T>::logging_frequency() const
+{
+    return initialised ? _center_freq_hz : AP::logger().quiet_nanf();
+}
+#endif
 
 /*
    instantiate template classes

--- a/libraries/Filter/NotchFilter.h
+++ b/libraries/Filter/NotchFilter.h
@@ -49,9 +49,7 @@ public:
     }
 
     // return the frequency to log for the notch
-    float logging_frequency(void) const {
-        return initialised?_center_freq_hz:0;
-    }
+    float logging_frequency(void) const;
 
 protected:
 


### PR DESCRIPTION
This means we get NaN rather than zero in the log if not initialised. Could also change to log -1 rather than NaN.


I hope it will help with debugging https://discuss.ardupilot.org/t/notch-filters-turn-on-with-a-delay/116276/12

