### PR TITLE
Copter: Give better error in opendroneid build when DID_ENABLE=0.

### DIFF
--- a/libraries/AP_OpenDroneID/AP_OpenDroneID.cpp
+++ b/libraries/AP_OpenDroneID/AP_OpenDroneID.cpp
@@ -166,6 +166,11 @@ bool AP_OpenDroneID::pre_arm_check(char* failmsg, uint8_t failmsg_len)
         return true;
     }
 
+    if(_enable == 0) {
+        strncpy(failmsg, "DID_ENABLE must be 1", failmsg_len);
+        return false;
+    }
+
     if (pkt_basic_id.id_type == MAV_ODID_ID_TYPE_NONE) {
         strncpy(failmsg, "UA_TYPE required in BasicID", failmsg_len);
         return false;


### PR DESCRIPTION
Based on my report on discord:

Problem arises when:

- ArduPilot compiled with ``--enable-opendroneid``
- ``DID_ENABLE`` set to 0
- init and update functions do not do anything but pre_arm_checks still fail.

Should pre_arm_checks also be skipped or there should be a different error message like DID_ENABLE is not allowed to be 0 when compiled with --enable-opendroneid.

Currently one of the pre_arm_checks will fail but there's no indiciation of what exactly the problem is. A better error message or disabling pre arm checks might save time for users.


This PR adds a better error message to report that ``DID_ENABLE`` is not allowed to be 0 when compiled with ``--enable-opendroneid``.

