### PR TITLE
Copter: Land Detector: Include angle checks

### DIFF
--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -382,6 +382,9 @@
 #ifndef LAND_DETECTOR_ACCEL_MAX
 # define LAND_DETECTOR_ACCEL_MAX            1.0f    // vehicle acceleration must be under 1m/s/s
 #endif
+#ifndef LAND_DETECTOR_VEL_Z_MAX
+# define LAND_DETECTOR_VEL_Z_MAX              1.0f    // vehicle vertical velocity must be under 1m/s
+#endif
 
 //////////////////////////////////////////////////////////////////////////////
 // Flight mode definitions

--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -112,7 +112,7 @@ void Copter::update_land_detector()
         bool accel_stationary = (land_accel_ef_filter.get().length() <= LAND_DETECTOR_ACCEL_MAX * land_detector_scalar);
 
         // check that vertical speed is within 1m/s of zero
-        bool descent_rate_low = fabsf(inertial_nav.get_velocity_z_up_cms()) < 100 * land_detector_scalar;
+        bool descent_rate_low = fabsf(inertial_nav.get_velocity_z_up_cms()) < 100.0 * LAND_DETECTOR_VEL_Z_MAX * land_detector_scalar;
 
         // if we have a healthy rangefinder only allow landing detection below 2 meters
         bool rangefinder_check = (!rangefinder_alt_ok() || rangefinder_state.alt_cm_filt.get() < LAND_RANGEFINDER_MIN_ALT_CM);

--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -100,6 +100,14 @@ void Copter::update_land_detector()
         }
 #endif
 
+        // check for aggressive flight requests - requested roll or pitch angle below 15 degrees
+        const Vector3f angle_target = attitude_control->get_att_target_euler_cd();
+        bool large_angle_request = angle_target.xy().length() > LAND_CHECK_LARGE_ANGLE_CD;
+
+        // check for large external disturbance - angle error over 30 degrees
+        const float angle_error = attitude_control->get_att_error_angle_deg();
+        bool large_angle_error = (angle_error > LAND_CHECK_ANGLE_ERROR_DEG);
+
         // check that the airframe is not accelerating (not falling or braking after fast forward flight)
         bool accel_stationary = (land_accel_ef_filter.get().length() <= LAND_DETECTOR_ACCEL_MAX * land_detector_scalar);
 
@@ -116,7 +124,7 @@ void Copter::update_land_detector()
         const bool WoW_check = true;
 #endif
 
-        if (motor_at_lower_limit && throttle_mix_at_min && accel_stationary && descent_rate_low && rangefinder_check && WoW_check) {
+        if (motor_at_lower_limit && throttle_mix_at_min && !large_angle_request && !large_angle_error && accel_stationary && descent_rate_low && rangefinder_check && WoW_check) {
             // landed criteria met - increment the counter and check if we've triggered
             if( land_detector_count < land_trigger_sec*scheduler.get_loop_rate_hz()) {
                 land_detector_count++;

--- a/Tools/autotest/helicopter.py
+++ b/Tools/autotest/helicopter.py
@@ -966,8 +966,6 @@ class AutoTestHelicopter(AutoTestCopter):
 
     def tests(self):
         '''return list of all tests'''
-        ret = ([self.AutoRotation, self.ManAutoRotation,])
-        return ret
         ret = vehicle_test_suite.TestSuite.tests(self)
         ret.extend([
             self.AVCMission,

--- a/Tools/autotest/helicopter.py
+++ b/Tools/autotest/helicopter.py
@@ -362,8 +362,12 @@ class AutoTestHelicopter(AutoTestCopter):
                            timeout=timeout)
         self.context_collect('STATUSTEXT')
         self.progress("Triggering autorotate by raising interlock")
+        self.set_rc(3, 1000)
         self.set_rc(8, 1000)
+
         self.wait_statustext("SS Glide Phase", check_context=True)
+
+        self.change_mode('STABILIZE')
         self.wait_statustext(r"SIM Hit ground at ([0-9.]+) m/s",
                              check_context=True,
                              regex=True)
@@ -962,6 +966,8 @@ class AutoTestHelicopter(AutoTestCopter):
 
     def tests(self):
         '''return list of all tests'''
+        ret = ([self.AutoRotation, self.ManAutoRotation,])
+        return ret
         ret = vehicle_test_suite.TestSuite.tests(self)
         ret.extend([
             self.AVCMission,


### PR DESCRIPTION
This PR fixes #26864 where the aircraft can detect a landing when at full throttle in stabilize and upside down. Now the aircraft will correct detect a crash.

Sorry I didn't explain what is happening here and why this fix works. 

The land detector checks that the throttle mix value has dropped to near throttle_mix_at_min as part of the landing checks. To set the throttle mix value to throttle_mix_at_min we have two key checks:

1. Angle requested < 15 degrees
2. Angle error < 30 degrees

It then sets throttle_mix to throttle_mix_at_min.

The land detector checks to see if throttle_mix is close to throttle_mix_at_min before proceeding but this is not the same as checking that it has been set to throttle_mix_at_min. This check passes all the time with the default settings as throttle_mix_at_min = throttle_mix_at_man.

We are then left in a state where we are able to detect a landing without passing the two checks above.

Why does this fix the problem above?
The problem above goes through a number of steps:

1. throttle goes high in stabilize
2. stabilise correctly detects a take off
3. aircraft is inverted and left stationary
4. the angle boost takes the throttle to zero
5. the land detector checks throttle_mix and finds that it is equal to throttle_mix_at_min and throttle_mix_at_man so it passes
6. a landing is detected with a high throttle request
7. the takeoff flow of control error is triggered because the aircraft should not have detected a landing

Crash detection:

The crash detection now works correctly because we are not detecting the landing. As Pete says below this is a race and we simply need to not detect a landing to allow the crash detection to work correctly. In this case the aircraft will repeatedly detect a landing and a takeoff meaning the aircraft would never disarm.

Tricky little bugger.