### PR TITLE
Periph: Add probe continuous checks to airspeed and compass

### DIFF
--- a/Tools/AP_Periph/airspeed.cpp
+++ b/Tools/AP_Periph/airspeed.cpp
@@ -21,7 +21,7 @@ void AP_Periph_FW::can_airspeed_update(void)
         return;
     }
 #if AP_PERIPH_PROBE_CONTINUOUS
-    if (!airspeed.healthy()) {
+    if (option_is_set(PeriphOptions::PROBE_CONTINUOUS) && !hal.util->get_soft_armed() && !airspeed.healthy()) {
         uint32_t now = AP_HAL::millis();
         static uint32_t last_probe_ms;
         if (now - last_probe_ms >= 1000) {

--- a/Tools/AP_Periph/compass.cpp
+++ b/Tools/AP_Periph/compass.cpp
@@ -40,7 +40,7 @@ void AP_Periph_FW::can_mag_update(void)
     compass.read();
 
 #if AP_PERIPH_PROBE_CONTINUOUS
-    if (compass.get_count() == 0) {
+    if (option_is_set(PeriphOptions::PROBE_CONTINUOUS) && !hal.util->get_soft_armed() && (compass.get_count() == 0)) {
         static uint32_t last_probe_ms;
         uint32_t now = AP_HAL::millis();
         if (now - last_probe_ms >= 1000) {


### PR DESCRIPTION
This propagates the new periph option and not armed check to the continuous probe used by airspeed and compass, brining them in line with rangefinder.