### PR TITLE
GCS_MAVLink: Avoid serial passthrough buffer exhausted/lost data

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -6767,14 +6767,14 @@ void GCS::passthru_timer(void)
     uint8_t buf[64];
 
     // read from port1, and write to port2
-    int16_t nbytes = _passthru.port1->read_locked(buf, sizeof(buf), lock_key);
+    int16_t nbytes = _passthru.port1->read_locked(buf, MIN(sizeof(buf),_passthru.port2->txspace()), lock_key);
     if (nbytes > 0) {
         _passthru.last_port1_data_ms = AP_HAL::millis();
         _passthru.port2->write_locked(buf, nbytes, lock_key);
     }
 
     // read from port2, and write to port1
-    nbytes = _passthru.port2->read_locked(buf, sizeof(buf), lock_key);
+    nbytes = _passthru.port2->read_locked(buf, MIN(sizeof(buf),_passthru.port1->txspace()), lock_key);
     if (nbytes > 0) {
         _passthru.port1->write_locked(buf, nbytes, lock_key);
     }


### PR DESCRIPTION
Rework the serial port write logic in passthru_timer() to use the return value to detect partial writes due to the serial buffer filling up.  Unwritten data is saved in buf1 or buf2 and the write is retried on the next iteration.  This avoids lost data when the speed of the two serial ports differs and large blocks of data are sent.

For example, flash programming of ESP MCUs via USB to serial passthrough results in writes of more than 6000 bytes at a time which quickly fills the serial port buffer.

The existing code fails when flashing ELRS receivers via serial passthrough of ELRS which has become a more common need with the mavlink-rc branch of ELRS and the recent support of ESP based receivers in mLRS.  This is especially troublesome with AIO flight controllers which may not provide easy access to the serial port connecting the FC to an integrated ELRS receiver.