### PR TITLE
AP_Logger: Add support to W25N02KV nand flash

### DIFF
--- a/libraries/AP_Logger/AP_Logger_W25N01GV.h
+++ b/libraries/AP_Logger/AP_Logger_W25N01GV.h
@@ -39,6 +39,8 @@ private:
     AP_HAL::OwnPtr<AP_HAL::SPIDevice> dev;
     AP_HAL::Semaphore *dev_sem;
 
+    uint32_t flash_blockNum;
+
     bool flash_died;
     uint32_t erase_start_ms;
     uint16_t erase_block;


### PR DESCRIPTION
Add support to W25N02KV flash
Tested on custom hardware, now the driver W25NXX will detect the flash automatically, so I will rename the related hwdef and class in another pr