### PR TITLE
AP_HAL: make NeoPixel high-low proportions match for 0 and 1

### DIFF
--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -406,7 +406,7 @@ public:
 
     // See WS2812B spec for expected pulse widths
     static constexpr uint32_t NEOP_BIT_WIDTH_TICKS = 8;
-    static constexpr uint32_t NEOP_BIT_0_TICKS = 3;
+    static constexpr uint32_t NEOP_BIT_0_TICKS = 2;
     static constexpr uint32_t NEOP_BIT_1_TICKS = 6;
     // neopixel does not use pulse widths at all
     static constexpr uint32_t PROFI_BIT_0_TICKS = 7;


### PR DESCRIPTION
Fixes https://github.com/ArduPilot/ardupilot/issues/26295

@rmackay9 's LED is not compliant with the LED spec. The original 4.4 timing gives an output of 833Khz which is incorrect - it should be 800Khz which has been corrected in 4.5. With this output rate Randy's LED is unable to parse the pulse widths even though they too are in-spec (widths should be 850ns +- 150ns and 400us +- 150ns. The current 4.5 widths are: 464/776 and 930/310. Randy's LED will work with the following timings: 308/932 and 930/310. So it is the T0 timing that is the problem *even though* the current timing is closer to spec. That said, the timing that Randy's LED wants is still in spec and means that T0 and T1 are symmetrical - so I think this is an ok change, even though its a hardware problem. 

A final note - Randy's LED also has incorrect signal leveling on a CubeOrange - even with a pull-up the high level is 3.0v which is not the 0.7VDD (3.5v) that these devices actually require. A Matek LED in contrast can be pulled up to 3.6v which is in spec.

