### PR TITLE
Plane: NAV_ALTITUDE_WAIT apply wiggle to all control surfaces

### DIFF
--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -378,9 +378,16 @@ void ModeAuto::wiggle_servos()
         wiggle.stage = 0;
         servo_value = 0;
     }
-    SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, servo_value);
-    SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, servo_value);
-    SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, servo_value);
+    for (uint8_t i = 0; i < NUM_SERVO_CHANNELS ; i++) {
+        const SRV_Channel *chan = SRV_Channels::srv_channel(i);
+        if (chan == nullptr) {
+            continue;
+        }
+        const SRV_Channel::Aux_servo_function_t func = chan->get_function();
+        if (SRV_Channel::is_control_surface(func)) {
+            SRV_Channels::set_output_scaled(func, servo_value);
+        }
+    }
 
 }
 


### PR DESCRIPTION
This is two commits. First is an NFC refactor to bring `NAV_ALTITUDE_WAIT` mission and logic code paths to line up with `NAV_DELAY`. It is now owned by `ModeAuto` instead of global access via `plane.auto_state`. Second is to wiggle all control surfaces instead of just the 3 main ones. I wrote this in the Holybro booth at AUVSI Exponential 2024 /w inspiration from @ohitstarik to improve his balloon drop servo wiggles.

This code hasn't been changed in many years so I thought it deserved a refactor before anyone added new functionality to it.