### PR TITLE
Baro: improved atmospheric model for high altitude flight

### DIFF
--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -707,7 +707,7 @@ void Tailsitter::speed_scaling(void)
             // (mass / A) is disk loading DL so:
             // Ue^2 = (((t / t_h) * DL * 9.81)/(0.5 * rho)) + U0^2
 
-            const float rho = SSL_AIR_DENSITY * plane.barometer.get_air_density_ratio();
+            const float rho = SSL_AIR_DENSITY * quadplane.ahrs.get_air_density_ratio();
             float hover_rho = rho;
             if ((gain_scaling_mask & TAILSITTER_GSCL_ALTITUDE) != 0) {
                 // if applying altitude correction use sea level density for hover case
@@ -752,7 +752,7 @@ void Tailsitter::speed_scaling(void)
 
     if ((gain_scaling_mask & TAILSITTER_GSCL_ALTITUDE) != 0) {
         // air density correction
-        spd_scaler /= plane.barometer.get_air_density_ratio();
+        spd_scaler /= quadplane.ahrs.get_air_density_ratio();
     }
 
     const SRV_Channel::Aux_servo_function_t functions[] = {

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -3780,7 +3780,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         minimum_duration = 5
 
-        self.takeoff(500, timeout=60)
+        self.takeoff(500, timeout=70)
         self.change_mode('AUTO')
 
         start_speed_ms = self.get_parameter('WPNAV_SPEED_DN') / 100.0

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -3570,6 +3570,13 @@ float AP_AHRS::get_EAS2TAS(void) const
     return 1.0;
 }
 
+// get air density / sea level density - decreases as altitude climbs
+float AP_AHRS::get_air_density_ratio(void) const
+{
+    const float eas2tas = get_EAS2TAS();
+    return 1.0 / sq(eas2tas);
+}
+
 // singleton instance
 AP_AHRS *AP_AHRS::_singleton;
 

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -143,6 +143,9 @@ public:
     // get apparent to true airspeed ratio
     float get_EAS2TAS(void) const;
 
+    // get air density / sea level density - decreases as altitude climbs
+    float get_air_density_ratio(void) const;
+    
     // return an airspeed estimate if available. return true
     // if we have an estimate
     bool airspeed_estimate(float &airspeed_ret) const;

--- a/libraries/AP_AHRS/AP_AHRS_Backend.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.cpp
@@ -265,7 +265,7 @@ void AP_AHRS::Log_Write_Home_And_Origin()
 
 // get apparent to true airspeed ratio
 float AP_AHRS_Backend::get_EAS2TAS(void) {
-    return AP::baro().get_EAS2TAS();
+    return AP::baro()._get_EAS2TAS();
 }
 
 // return current vibration vector for primary IMU

--- a/libraries/AP_Airspeed/AP_Airspeed_SITL.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_SITL.cpp
@@ -33,11 +33,8 @@ bool AP_Airspeed_SITL::get_temperature(float &temperature)
     // this was mostly swiped from SIM_Airspeed_DLVR:
     const float sim_alt = sitl->state.altitude;
 
-    float sigma, delta, theta;
-    AP_Baro::SimpleAtmosphere(sim_alt * 0.001f, sigma, delta, theta);
-
     // To Do: Add a sensor board temperature offset parameter
-    temperature = (KELVIN_TO_C(SSL_AIR_TEMPERATURE * theta)) + 25.0;
+    temperature = AP_Baro::get_temperatureC_for_alt_amsl(sim_alt);
 
     return true;
 }

--- a/libraries/AP_Airspeed/Airspeed_Calibration.cpp
+++ b/libraries/AP_Airspeed/Airspeed_Calibration.cpp
@@ -12,7 +12,7 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Math/AP_Math.h>
 #include <GCS_MAVLink/GCS.h>
-#include <AP_Baro/AP_Baro.h>
+#include <AP_AHRS/AP_AHRS.h>
 
 #include "AP_Airspeed.h"
 
@@ -131,7 +131,7 @@ void AP_Airspeed::update_calibration(uint8_t i, const Vector3f &vground, int16_t
 
     // calculate true airspeed, assuming a airspeed ratio of 1.0
     float dpress = MAX(get_differential_pressure(i), 0);
-    float true_airspeed = sqrtf(dpress) * AP::baro().get_EAS2TAS();
+    float true_airspeed = sqrtf(dpress) * AP::ahrs().get_EAS2TAS();
 
     float zratio = state[i].calibration.update(true_airspeed, vground, max_airspeed_allowed_during_cal);
 
@@ -177,7 +177,7 @@ void AP_Airspeed::send_airspeed_calibration(const Vector3f &vground)
         vy: vground.y,
         vz: vground.z,
         diff_pressure: get_differential_pressure(primary),
-        EAS2TAS: AP::baro().get_EAS2TAS(),
+        EAS2TAS: AP::ahrs().get_EAS2TAS(),
         ratio: param[primary].ratio.get(),
         state_x: state[primary].calibration.state.x,
         state_y: state[primary].calibration.state.y,

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -102,7 +102,8 @@ public:
     float get_altitude(uint8_t instance) const { return sensors[instance].altitude; }
 
     // get altitude above mean sea level
-    float get_altitude_AMSL(void) const { return get_altitude() + _field_elevation_active; }
+    float get_altitude_AMSL(uint8_t instance) const { return get_altitude(instance) + _field_elevation_active; }
+    float get_altitude_AMSL(void) const { return get_altitude_AMSL(_primary); }
 
     // returns which i2c bus is considered "the" external bus
     uint8_t external_bus() const { return _ext_bus; }

--- a/libraries/AP_Baro/AP_Baro_HIL.cpp
+++ b/libraries/AP_Baro/AP_Baro_HIL.cpp
@@ -8,33 +8,6 @@ extern const AP_HAL::HAL& hal;
 // ==========================================================================
 // based on tables.cpp from http://www.pdas.com/atmosdownload.html
 
-/* 
-   Compute the temperature, density, and pressure in the standard atmosphere
-   Correct to 20 km.  Only approximate thereafter.
-*/
-void AP_Baro::SimpleAtmosphere(
-	const float alt,                           // geometric altitude, km.
-	float& sigma,                   // density/sea-level standard density
-	float& delta,                 // pressure/sea-level standard pressure
-	float& theta)           // temperature/sea-level standard temperature
-{
-    const float REARTH = 6369.0f;        // radius of the Earth (km)
-    const float GMR    = 34.163195f;     // gas constant
-    float h=alt*REARTH/(alt+REARTH);     // geometric to geopotential altitude
-
-    if (h < 11.0f) {
-        // Troposphere
-        theta = (SSL_AIR_TEMPERATURE - 6.5f * h) / SSL_AIR_TEMPERATURE;
-        delta = powf(theta, GMR / 6.5f);
-    } else {
-        // Stratosphere
-        theta = 216.65f / SSL_AIR_TEMPERATURE;
-        delta = 0.2233611f * expf(-GMR * (h - 11.0f) / 216.65f);
-    }
-
-    sigma = delta/theta;
-}
-
 void AP_Baro::SimpleUnderWaterAtmosphere(
 	float alt,            // depth, km.
 	float& rho,           // density/sea-level

--- a/libraries/AP_Baro/AP_Baro_Logging.cpp
+++ b/libraries/AP_Baro/AP_Baro_Logging.cpp
@@ -13,6 +13,7 @@ void AP_Baro::Write_Baro_instance(uint64_t time_us, uint8_t baro_instance)
         time_us       : time_us,
         instance      : baro_instance,
         altitude      : get_altitude(baro_instance),
+        altitude_AMSL : get_altitude_AMSL(baro_instance),
         pressure      : get_pressure(baro_instance),
         temperature   : (int16_t)(get_temperature(baro_instance) * 100 + 0.5f),
         climbrate     : get_climb_rate(),

--- a/libraries/AP_Baro/AP_Baro_Wind.cpp
+++ b/libraries/AP_Baro/AP_Baro_Wind.cpp
@@ -76,15 +76,17 @@ float AP_Baro::wind_pressure_correction(uint8_t instance)
         return 0;
     }
 
+    auto &ahrs = AP::ahrs();
+
     // correct for static pressure position errors
     Vector3f airspeed_vec_bf;
-    if (!AP::ahrs().airspeed_vector_true(airspeed_vec_bf)) {
+    if (!ahrs.airspeed_vector_true(airspeed_vec_bf)) {
         return 0;
     }
 
     float error = 0.0;
 
-    const float kp = 0.5 * SSL_AIR_DENSITY * get_air_density_ratio();
+    const float kp = 0.5 * SSL_AIR_DENSITY * ahrs.get_air_density_ratio();
     const float sqxp = sq(airspeed_vec_bf.x) * kp;
     const float sqyp = sq(airspeed_vec_bf.y) * kp;
     const float sqzp = sq(airspeed_vec_bf.z) * kp;

--- a/libraries/AP_Baro/AP_Baro_atmosphere.cpp
+++ b/libraries/AP_Baro/AP_Baro_atmosphere.cpp
@@ -1,0 +1,362 @@
+#include "AP_Baro.h"
+#include <AP_InternalError/AP_InternalError.h>
+
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* 1976 U.S. Standard Atmosphere: https://ntrs.nasa.gov/api/citations/19770009539/downloads/19770009539.pdf?attachment=true
+
+The US Standard Atmosphere defines the atmopshere in terms of whether the temperature is an iso-thermal or gradient layer.
+Ideal gas laws apply thus P = rho * R_specific * T : P = pressure, rho = density, R_specific = air gas constant, T = temperature
+
+Note: the 1976 model is the same as the 1962 US Standard Atomsphere up to 51km.
+R_universal: the universal gas constant is slightly off in the 1976 model and thus R_specific is different than today's value
+
+*/
+
+/* Model Constants
+R_universal = 8.31432e-3;   // Universal gas constant (J/(kmol-K)) incorrect to the redefined 2019 value of 8.31446261815324 J⋅K−1⋅mol−1
+M_air  = (0.78084 * 28.0134 + 0.209476 * 31.9988 + 9.34e-3 * 39.948 + 3.14e-4 * 44.00995 + 1.818e-5 * 20.183 + 5.24E-6 * 4.0026 + 1.14E-6 * 83.8 + 8.7E-7 * 131.30 + 2E-6 * 16.04303 + 5E-7 * 2.01594) * 1E-3; (kg/mol)
+M_air = 28.9644             // Molecular weight of air (kg/kmol) see page 3
+R_specific  = 287.053072    // air specifc gas constant (J⋅kg−1⋅K−1), R_universal / M_air;
+gama = 1.4;                 // specific heat ratio of air used to determine the speed of sound
+
+R0 = 6356.766E3;            // Earth's radius (in m)
+g0 = 9.80665;               // gravity (m/s^2)
+
+Sea-Level Constants
+H_asml = 0 meters
+T0     = 288.150 K
+P0     = 101325 Pa
+rho0   = 1.2250 kg/m^3 
+T0_slope = -6.5E-3 (K/m')
+
+The tables list altitudes -5 km to 0 km using the same equations as 0 km to 11 km.
+*/
+
+#ifndef AP_BARO_1976_STANDARD_ATMOSPHERE_ENABLED
+// default to using the extended functions when doing double precision EKF (which implies more flash space and faster MCU)
+// this allows for using the simple model with the --ekf-single configure option
+#define AP_BARO_1976_STANDARD_ATMOSPHERE_ENABLED HAL_WITH_EKF_DOUBLE
+#endif
+
+/*
+  return altitude difference in meters between current pressure and a
+  given base_pressure in Pascal. This is a simple atmospheric model
+  good to about 11km AMSL.
+*/
+float AP_Baro::get_altitude_difference_simple(float base_pressure, float pressure) const
+{
+    float ret;
+    float temp_K = C_TO_KELVIN(get_ground_temperature());
+    float scaling = pressure / base_pressure;
+
+    // This is an exact calculation that is within +-2.5m of the standard
+    // atmosphere tables in the troposphere (up to 11,000 m amsl).
+    ret = 153.8462f * temp_K * (1.0f - expf(0.190259f * logf(scaling)));
+
+    return ret;
+}
+
+#if AP_BARO_1976_STANDARD_ATMOSPHERE_ENABLED || AP_SIM_ENABLED
+
+/*
+  Note parameters are as defined in the 1976 model.
+  These are slightly different from the ones in definitions.h
+*/
+static const float radius_earth = 6356.766E3;      // Earth's radius (in m)
+static const float R_specific = 287.053072;        // air specifc gas constant (J⋅kg−1⋅K−1) in 1976 model, R_universal / M_air;
+
+static const struct {
+    float amsl_m;       // geopotential height above mean sea-level (km')
+    float temp_K;       // Temperature (K)
+    float pressure_Pa;  // Pressure (Pa)
+    float density;      // Density (Pa/kg)
+    float temp_lapse;   // Temperature gradients rates (K/m'), see page 3
+} atmospheric_1976_consts[] = {
+    { -5000,    320.650,     177687,      1.930467,    -6.5E-3 },
+    { 11000,    216.650,    22632.1,      0.363918,          0 },
+    { 20000,    216.650,    5474.89,    8.80349E-2,       1E-3 },
+    { 32000,    228.650,    868.019,    1.32250E-2,     2.8E-3 },
+    { 47000,    270.650,    110.906,    1.42753E-3,          0 },
+    { 51000,    270.650,    66.9389,    8.61606E-4,    -2.8E-3 },
+    { 71000,    214.650,    3.95642,    6.42110E-5,    -2.0E-3 },
+    { 84852,    186.946,    0.37338,    6.95788E-6,          0 },
+};
+
+/*
+  find table entry given geopotential altitude in meters. This returns at least 1
+ */
+static uint8_t find_atmosphere_layer_by_altitude(float alt_m)
+{
+    for (uint8_t idx = 1; idx < ARRAY_SIZE(atmospheric_1976_consts); idx++) {
+        if(alt_m < atmospheric_1976_consts[idx].amsl_m) {
+            return idx - 1;
+        }
+    }
+
+    // Over the largest altitude return the last index
+    return ARRAY_SIZE(atmospheric_1976_consts) - 1;
+}
+
+/*
+  find table entry given pressure (Pa). This returns at least 1
+ */
+static uint8_t find_atmosphere_layer_by_pressure(float pressure)
+{
+    for (uint8_t idx = 1; idx < ARRAY_SIZE(atmospheric_1976_consts); idx++) {
+        if (atmospheric_1976_consts[idx].pressure_Pa < pressure) {
+            return idx - 1;
+        }
+    }
+
+    // pressure is less than the smallest pressure return the last index
+    return ARRAY_SIZE(atmospheric_1976_consts) - 1;
+
+}
+
+// Convert geopotential altitude to geometric altitude
+// 
+float AP_Baro::geopotential_alt_to_geometric(float alt)
+{
+    return (radius_earth * alt) / (radius_earth - alt);
+}
+
+float AP_Baro::geometric_alt_to_geopotential(float alt)
+{
+    return (radius_earth * alt) / (radius_earth + alt);
+}
+
+/*
+  Compute expected temperature for a given geometric altitude and altitude layer.
+*/
+float AP_Baro::get_temperature_from_altitude(float alt) const
+{
+    alt = geometric_alt_to_geopotential(alt);
+    const uint8_t idx = find_atmosphere_layer_by_altitude(alt);
+    return get_temperature_by_altitude_layer(alt, idx);
+}
+
+/*
+  Compute expected temperature for a given geopotential altitude and altitude layer.
+*/
+float AP_Baro::get_temperature_by_altitude_layer(float alt, int8_t idx)
+{
+    if (is_zero(atmospheric_1976_consts[idx].temp_lapse)) {
+        return atmospheric_1976_consts[idx].temp_K;
+    }
+    return atmospheric_1976_consts[idx].temp_K + atmospheric_1976_consts[idx].temp_lapse * (alt - atmospheric_1976_consts[idx].amsl_m);
+}
+
+/*
+  return geometric altitude (m) given a pressure (Pa)
+*/
+float AP_Baro::get_altitude_from_pressure(float pressure) const
+{
+    const uint8_t idx = find_atmosphere_layer_by_pressure(pressure);
+    const float pressure_ratio = pressure / atmospheric_1976_consts[idx].pressure_Pa;
+
+    // Pressure ratio is nonsensical return an error??
+    if (!is_positive(pressure_ratio)) {
+        INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
+        return get_altitude_AMSL();
+    }
+
+    float alt;
+    const float temp_slope = atmospheric_1976_consts[idx].temp_lapse;
+    if (is_zero(temp_slope)) {  // Iso-thermal layer
+        const float fac = -(atmospheric_1976_consts[idx].temp_K * R_specific) / GRAVITY_MSS;
+        alt = atmospheric_1976_consts[idx].amsl_m + fac * logf(pressure_ratio);
+    } else {                    // Gradient temperature layer
+        const float fac = -(temp_slope * R_specific) / GRAVITY_MSS;
+        alt = atmospheric_1976_consts[idx].amsl_m + (atmospheric_1976_consts[idx].temp_K / atmospheric_1976_consts[idx].temp_lapse) * (powf(pressure_ratio, fac) - 1);
+    }
+
+    return geopotential_alt_to_geometric(alt);
+}
+
+/*
+  Compute expected pressure and temperature for a given geometric altitude. Used for SITL
+*/
+void AP_Baro::get_pressure_temperature_for_alt_amsl(float alt_amsl, float &pressure, float &temperature_K)
+{
+    alt_amsl = geometric_alt_to_geopotential(alt_amsl);
+
+    const uint8_t idx = find_atmosphere_layer_by_altitude(alt_amsl);
+    const float temp_slope = atmospheric_1976_consts[idx].temp_lapse;
+    temperature_K =  get_temperature_by_altitude_layer(alt_amsl, idx);
+
+    // Previous versions used the current baro temperature instead of an estimate we could try to incorporate this??? non-standard atmosphere
+    // const float temp =  get_temperature();
+
+    if (is_zero(temp_slope)) {    // Iso-thermal layer
+        const float fac = expf(-GRAVITY_MSS / (temperature_K * R_specific) * (alt_amsl - atmospheric_1976_consts[idx].amsl_m));
+        pressure = atmospheric_1976_consts[idx].pressure_Pa * fac;
+    } else {            // Gradient temperature layer
+        const float fac =  GRAVITY_MSS / (temp_slope * R_specific);
+        const float temp_ratio = temperature_K / atmospheric_1976_consts[idx].temp_K; // temperature ratio [unitless]
+        pressure = atmospheric_1976_consts[idx].pressure_Pa * powf(temp_ratio, -fac);
+    }
+}
+
+/*
+  return air density (kg/m^3), given geometric altitude (m)
+*/
+float AP_Baro::get_air_density_for_alt_amsl(float alt_amsl)
+{
+    alt_amsl = geometric_alt_to_geopotential(alt_amsl);
+
+    const uint8_t idx = find_atmosphere_layer_by_altitude(alt_amsl);
+    const float temp_slope = atmospheric_1976_consts[idx].temp_lapse;
+    const float temp =  get_temperature_by_altitude_layer(alt_amsl, idx);
+    // const float temp =  get_temperature();
+
+    float rho;
+    if (is_zero(temp_slope)) {    // Iso-thermal layer
+        const float fac = expf(-GRAVITY_MSS / (temp * R_specific) * (alt_amsl - atmospheric_1976_consts[idx].amsl_m));
+        rho      = atmospheric_1976_consts[idx].density     * fac;
+    } else {            // Gradient temperature layer
+        const float fac =  GRAVITY_MSS / (temp_slope * R_specific);
+        const float temp_ratio = temp / atmospheric_1976_consts[idx].temp_K; // temperature ratio [unitless]
+        rho      = atmospheric_1976_consts[idx].density     * powf(temp_ratio, -(fac + 1));
+    }
+    return rho;
+}
+
+/*
+  return current scale factor that converts from equivalent to true airspeed
+*/
+float AP_Baro::get_EAS2TAS_extended(float altitude) const
+{
+    float density = get_air_density_for_alt_amsl(altitude);
+    if (!is_positive(density)) {
+        // above this height we are getting closer to spacecraft territory...
+        const uint8_t table_size = ARRAY_SIZE(atmospheric_1976_consts);
+        density = atmospheric_1976_consts[table_size-1].density;
+    }
+    return sqrtf(SSL_AIR_DENSITY / density);
+}
+
+/*
+  Given the geometric altitude (m)
+  return scale factor that converts from equivalent to true airspeed
+  used by SITL only
+*/
+float AP_Baro::get_EAS2TAS_for_alt_amsl(float alt_amsl)
+{
+    const float density = get_air_density_for_alt_amsl(alt_amsl);
+    return sqrtf(SSL_AIR_DENSITY / MAX(0.00001,density));
+}
+
+#endif // AP_BARO_1976_STANDARD_ATMOSPHERE_ENABLED || AP_SIM_ENABLED
+
+/*
+  return geometric altitude difference in meters between current pressure and a
+  given base_pressure in Pascal.
+*/
+float AP_Baro::get_altitude_difference(float base_pressure, float pressure) const
+{
+#if AP_BARO_1976_STANDARD_ATMOSPHERE_ENABLED
+    const float alt1 = get_altitude_from_pressure(base_pressure);
+    const float alt2 = get_altitude_from_pressure(pressure);
+    return alt2 - alt1;
+#else
+    return get_altitude_difference_simple(base_pressure, pressure);
+#endif
+}
+
+/*
+  return current scale factor that converts from equivalent to true airspeed
+  valid for altitudes up to 11km AMSL
+  assumes USA 1976 standard atmosphere lapse rate
+*/
+float AP_Baro::get_EAS2TAS_simple(float altitude, float pressure) const
+{
+    if (is_zero(pressure)) {
+        return 1.0f;
+    }
+
+    // only estimate lapse rate for the difference from the ground location
+    // provides a more consistent reading then trying to estimate a complete
+    // ISA model atmosphere
+    float tempK = C_TO_KELVIN(get_ground_temperature()) - ISA_LAPSE_RATE * altitude;
+    const float eas2tas_squared = SSL_AIR_DENSITY / (pressure / (ISA_GAS_CONSTANT * tempK));
+    if (!is_positive(eas2tas_squared)) {
+        return 1.0f;
+    }
+    return sqrtf(eas2tas_squared);
+}
+
+/*
+  return current scale factor that converts from equivalent to true airspeed
+*/
+float AP_Baro::_get_EAS2TAS(void) const
+{
+    const float altitude = get_altitude_AMSL();
+
+#if AP_BARO_1976_STANDARD_ATMOSPHERE_ENABLED
+    return get_EAS2TAS_extended(altitude);
+#else
+    // otherwise use function
+    return get_EAS2TAS_simple(altitude, get_pressure());
+#endif
+}
+
+// lookup expected temperature in degrees C for a given altitude. Used for SITL backend
+float AP_Baro::get_temperatureC_for_alt_amsl(const float alt_amsl)
+{
+    float pressure, temp_K;
+    get_pressure_temperature_for_alt_amsl(alt_amsl, pressure, temp_K);
+    return KELVIN_TO_C(temp_K);
+}
+
+// lookup expected pressure in Pa for a given altitude. Used for SITL backend
+float AP_Baro::get_pressure_for_alt_amsl(const float alt_amsl)
+{
+    float pressure, temp_K;
+    get_pressure_temperature_for_alt_amsl(alt_amsl, pressure, temp_K);
+    return pressure;
+}
+
+/*
+  return sea level pressure given a current altitude and pressure reading
+  this is the pressure p0 such that
+    get_altitude_difference(p0, pressure) == altitude
+  this function is used during calibration
+*/
+float AP_Baro::get_sealevel_pressure(float pressure, float altitude) const
+{
+    const float min_pressure = 0.01;
+    const float max_pressure = 1e6;
+    float p0 = pressure;
+    /*
+      use a simple numerical gradient descent method so we don't need
+      the inverse function. This typically converges in about 5 steps,
+      we limit it to 20 steps to prevent possible high CPU usage
+     */
+    uint16_t count = 20;
+    while (count--) {
+        const float delta = 0.1;
+        const float err1 = get_altitude_difference(p0, pressure) - altitude;
+        const float err2 = get_altitude_difference(p0+delta, pressure) - altitude;
+        const float dalt = err2 - err1;
+        if (fabsf(err1) < 0.01) {
+            break;
+        }
+        p0 -= err1 * delta / dalt;
+        p0 = constrain_float(p0, min_pressure, max_pressure);
+    }
+    return p0;
+}

--- a/libraries/AP_Baro/LogStructure.h
+++ b/libraries/AP_Baro/LogStructure.h
@@ -11,6 +11,7 @@
 // @Field: TimeUS: Time since system startup
 // @Field: I: barometer sensor instance number
 // @Field: Alt: calculated altitude
+// @Field: AltAMSL: altitude AMSL
 // @Field: Press: measured atmospheric pressure
 // @Field: Temp: measured atmospheric temperature
 // @Field: CRt: derived climb rate from primary barometer
@@ -23,6 +24,7 @@ struct PACKED log_BARO {
     uint64_t time_us;
     uint8_t instance;
     float   altitude;
+    float   altitude_AMSL;
     float   pressure;
     int16_t temperature;
     float   climbrate;
@@ -51,10 +53,10 @@ struct PACKED log_BARD {
 #define LOG_STRUCTURE_FROM_BARO                                         \
     { LOG_BARO_MSG, sizeof(log_BARO),                                   \
             "BARO",                                                     \
-            "Q"       "B"  "f"    "f"      "c"     "f"    "I"    "f"       "f"        "B", \
-            "TimeUS," "I," "Alt," "Press," "Temp," "CRt," "SMS," "Offset," "GndTemp," "Health", \
-            "s"       "#"  "m"    "P"      "O"     "n"    "s"    "m"       "O"        "-", \
-            "F"       "-"  "0"    "0"      "B"     "0"    "C"    "?"       "0"        "-", \
+            "Q"       "B"  "f"    "f"        "f"      "c"     "f"    "I"    "f"       "f"        "B", \
+            "TimeUS," "I," "Alt," "AltAMSL," "Press," "Temp," "CRt," "SMS," "Offset," "GndTemp," "Health", \
+            "s"       "#"  "m"    "m"        "P"      "O"     "n"    "s"    "m"       "O"        "-", \
+            "F"       "-"  "0"    "0"        "0"      "B"     "0"    "C"    "?"       "0"        "-", \
             true                                                        \
             },                                                          \
     { LOG_BARD_MSG, sizeof(log_BARD),                                   \

--- a/libraries/AP_Baro/tests/test_baro_atmosphere.cpp
+++ b/libraries/AP_Baro/tests/test_baro_atmosphere.cpp
@@ -1,0 +1,130 @@
+/*
+  test atmospheric model
+  to build, use:
+    ./waf configure --board sitl --debug
+    ./waf --target tests/test_baro_atmosphere
+ */
+#include <AP_gtest.h>
+
+#include <AP_Baro/AP_Baro.h>
+
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+TEST(AP_Baro, get_air_density_for_alt_amsl)
+{
+    float accuracy = 1E-6;
+
+    EXPECT_NEAR(AP_Baro::get_air_density_for_alt_amsl(-4000), 1.7697266, accuracy);
+    EXPECT_NEAR(AP_Baro::get_air_density_for_alt_amsl(6000), 0.66011156, accuracy);
+    EXPECT_NEAR(AP_Baro::get_air_density_for_alt_amsl(17500), 131.5688E-3, accuracy);
+    EXPECT_NEAR(AP_Baro::get_air_density_for_alt_amsl(25000), 40.08393E-3, accuracy);
+    EXPECT_NEAR(AP_Baro::get_air_density_for_alt_amsl(40000), 3.99567824728293E-3, accuracy);
+    EXPECT_NEAR(AP_Baro::get_air_density_for_alt_amsl(49000), 1.16276961471707E-3, accuracy);
+    EXPECT_NEAR(AP_Baro::get_air_density_for_alt_amsl(65000), 163.210100967015E-6, accuracy);
+    EXPECT_NEAR(AP_Baro::get_air_density_for_alt_amsl(78000), 25.2385188936996E-6, accuracy);
+}
+
+TEST(AP_Baro, get_altitude_from_pressure)
+{
+    AP_Baro baro;
+    float accuracy = 1.5E-1;
+
+    EXPECT_NEAR(baro.get_altitude_from_pressure(159598.2), -4000, accuracy);
+    EXPECT_NEAR(baro.get_altitude_from_pressure(47217.6), 6000, accuracy);
+    EXPECT_NEAR(baro.get_altitude_from_pressure(8182.3), 17500, accuracy);
+    EXPECT_NEAR(baro.get_altitude_from_pressure(2549.2), 25000, accuracy);
+    EXPECT_NEAR(baro.get_altitude_from_pressure(287.1441), 40000, accuracy);
+    EXPECT_NEAR(baro.get_altitude_from_pressure(90.3365), 49000, accuracy);
+    EXPECT_NEAR(baro.get_altitude_from_pressure(10.9297), 65000, accuracy);
+    EXPECT_NEAR(baro.get_altitude_from_pressure(1.4674), 78000, accuracy);
+}
+
+TEST(AP_Baro, get_temperature_from_altitude)
+{
+    AP_Baro baro;
+
+    EXPECT_FLOAT_EQ(baro.get_temperature_from_altitude(-4000), 314.166370821781);
+    EXPECT_FLOAT_EQ(baro.get_temperature_from_altitude(6000), 249.186776458540);
+    EXPECT_FLOAT_EQ(baro.get_temperature_from_altitude(17500), 216.650000000000);
+    EXPECT_FLOAT_EQ(baro.get_temperature_from_altitude(25000), 221.552064726284);
+    EXPECT_FLOAT_EQ(baro.get_temperature_from_altitude(40000), 250.349646102421);
+    EXPECT_FLOAT_EQ(baro.get_temperature_from_altitude(49000), 270.650000000000);
+    EXPECT_FLOAT_EQ(baro.get_temperature_from_altitude(65000), 233.292172386848);
+    EXPECT_FLOAT_EQ(baro.get_temperature_from_altitude(78000), 202.540977853740);
+}
+
+TEST(AP_Baro, geopotential_alt_to_geometric)
+{
+    EXPECT_FLOAT_EQ(AP_Baro::geopotential_alt_to_geometric(-4002.51858796625), -4000);
+    EXPECT_FLOAT_EQ(AP_Baro::geopotential_alt_to_geometric(5994.34208330151), 6000.0);
+    EXPECT_FLOAT_EQ(AP_Baro::geopotential_alt_to_geometric(17451.9552525734), 17500);
+    EXPECT_FLOAT_EQ(AP_Baro::geopotential_alt_to_geometric(24902.0647262842), 25000);
+    EXPECT_FLOAT_EQ(AP_Baro::geopotential_alt_to_geometric(39749.8736080075), 40000);
+    EXPECT_FLOAT_EQ(AP_Baro::geopotential_alt_to_geometric(48625.1814380981), 49000);
+    EXPECT_FLOAT_EQ(AP_Baro::geopotential_alt_to_geometric(64342.0812904114), 65000);
+    EXPECT_FLOAT_EQ(AP_Baro::geopotential_alt_to_geometric(77054.5110731299), 78000);
+}
+
+TEST(AP_Baro, geometric_alt_to_geopotential)
+{
+    EXPECT_FLOAT_EQ(AP_Baro::geometric_alt_to_geopotential(-4000), -4002.51858796625);
+    EXPECT_FLOAT_EQ(AP_Baro::geometric_alt_to_geopotential(6000), 5994.34208330151);
+    EXPECT_FLOAT_EQ(AP_Baro::geometric_alt_to_geopotential(17500), 17451.9552525734);
+    EXPECT_FLOAT_EQ(AP_Baro::geometric_alt_to_geopotential(25000), 24902.0647262842);
+    EXPECT_FLOAT_EQ(AP_Baro::geometric_alt_to_geopotential(40000), 39749.8736080075);
+    EXPECT_FLOAT_EQ(AP_Baro::geometric_alt_to_geopotential(49000), 48625.1814380981);
+    EXPECT_FLOAT_EQ(AP_Baro::geometric_alt_to_geopotential(65000), 64342.0812904114);
+    EXPECT_FLOAT_EQ(AP_Baro::geometric_alt_to_geopotential(78000), 77054.5110731299);
+}
+
+TEST(AP_Baro, get_pressure_temperature_for_alt_amsl)
+{
+    float accuracy = 1E-6;
+
+    // layer 0 -4000 m
+    float pressure, temperature_K;
+    AP_Baro::get_pressure_temperature_for_alt_amsl(-4000, pressure, temperature_K);
+    // EXPECT_FLOAT_EQ(pressure, 159598.164433755);    // Matlab
+    EXPECT_FLOAT_EQ(pressure, 159598.09375);
+    EXPECT_FLOAT_EQ(temperature_K, 314.166370821781);
+
+    // layer 0: 6000 m
+    AP_Baro::get_pressure_temperature_for_alt_amsl(6000, pressure, temperature_K);
+    EXPECT_FLOAT_EQ(pressure, 47217.6489854302);
+    EXPECT_FLOAT_EQ(temperature_K, 249.186776458540);
+
+    // layer 1: 17500 m
+    AP_Baro::get_pressure_temperature_for_alt_amsl(17500, pressure, temperature_K);
+    EXPECT_FLOAT_EQ(pressure, 8182.27857345022);
+    EXPECT_FLOAT_EQ(temperature_K, 216.650000000000);
+
+    // layer 2: 25000m
+    AP_Baro::get_pressure_temperature_for_alt_amsl(25000, pressure, temperature_K);
+    // EXPECT_FLOAT_EQ(pressure, 2549.22361148236);    // Matlab
+    EXPECT_FLOAT_EQ(pressure, 2549.2251);
+    EXPECT_FLOAT_EQ(temperature_K, 221.552064726284);
+
+    // layer 3: 40000m
+    AP_Baro::get_pressure_temperature_for_alt_amsl(40000, pressure, temperature_K);
+    EXPECT_FLOAT_EQ(pressure, 287.144059695555);
+    EXPECT_FLOAT_EQ(temperature_K, 250.349646102421);
+
+    // layer 4: 49000m
+    AP_Baro::get_pressure_temperature_for_alt_amsl(49000, pressure, temperature_K);
+    EXPECT_FLOAT_EQ(pressure, 90.3365441635632);
+    EXPECT_FLOAT_EQ(temperature_K, 270.650000000000);
+
+    // layer 5: 65000m
+    AP_Baro::get_pressure_temperature_for_alt_amsl(65000, pressure, temperature_K);
+    // EXPECT_FLOAT_EQ(pressure, 10.9297197424037);    // Matlab
+    EXPECT_FLOAT_EQ(pressure, 10.929715);
+    EXPECT_FLOAT_EQ(temperature_K, 233.292172386848);
+
+    // layer 6: 78000m
+    AP_Baro::get_pressure_temperature_for_alt_amsl(78000, pressure, temperature_K);
+    // EXPECT_FLOAT_EQ(pressure, 1.46736727632119);    // matlab
+    EXPECT_NEAR(pressure, 1.4673687, accuracy);
+    EXPECT_FLOAT_EQ(temperature_K, 202.540977853740);
+}
+
+AP_GTEST_MAIN()

--- a/libraries/AP_Baro/tests/wscript
+++ b/libraries/AP_Baro/tests/wscript
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+def build(bld):
+    bld.ap_find_tests(
+        use='ap',
+    )

--- a/libraries/AP_DAL/AP_DAL.cpp
+++ b/libraries/AP_DAL/AP_DAL.cpp
@@ -65,7 +65,7 @@ void AP_DAL::start_frame(AP_DAL::FrameType frametype)
     _RFRN.lat = _home.lat;
     _RFRN.lng = _home.lng;
     _RFRN.alt = _home.alt;
-    _RFRN.EAS2TAS = AP::baro().get_EAS2TAS();
+    _RFRN.EAS2TAS = ahrs.get_EAS2TAS();
     _RFRN.vehicle_class = (uint8_t)ahrs.get_vehicle_class();
     _RFRN.fly_forward = ahrs.get_fly_forward();
     _RFRN.takeoff_expected = ahrs.get_takeoff_expected();

--- a/libraries/AP_Motors/AP_Motors_Thrust_Linearization.cpp
+++ b/libraries/AP_Motors/AP_Motors_Thrust_Linearization.cpp
@@ -3,6 +3,7 @@
 #include "AP_Motors_Class.h"
 #include <AP_BattMonitor/AP_BattMonitor.h>
 #include <AP_Baro/AP_Baro.h>
+#include <AP_AHRS/AP_AHRS.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 
 #define AP_MOTORS_BATT_VOLT_FILT_HZ 0.5 // battery voltage filtered at 0.5hz
@@ -193,7 +194,7 @@ float Thrust_Linearization::get_compensation_gain() const
 
 #if AP_MOTORS_DENSITY_COMP == 1
     // air density ratio is increasing in density / decreasing in altitude
-    const float air_density_ratio = AP::baro().get_air_density_ratio();
+    const float air_density_ratio = AP::ahrs().get_air_density_ratio();
     if (air_density_ratio > 0.3 && air_density_ratio < 1.5) {
         ret *= 1.0 / constrain_float(air_density_ratio, 0.5, 1.25);
     }

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -103,6 +103,7 @@ public:
         return velocity_ef;
     }
 
+    // return TAS airspeed in earth frame
     const Vector3f &get_velocity_air_ef(void) const {
         return velocity_air_ef;
     }
@@ -180,15 +181,15 @@ protected:
     Vector3f gyro;                       // rad/s
     Vector3f velocity_ef;                // m/s, earth frame
     Vector3f wind_ef;                    // m/s, earth frame
-    Vector3f velocity_air_ef;            // velocity relative to airmass, earth frame
+    Vector3f velocity_air_ef;            // velocity relative to airmass, earth frame (true airspeed)
     Vector3f velocity_air_bf;            // velocity relative to airmass, body frame
     Vector3d position;                   // meters, NED from origin
     float mass;                          // kg
     float external_payload_mass;         // kg
     Vector3f accel_body{0.0f, 0.0f, -GRAVITY_MSS}; // m/s/s NED, body frame
-    float airspeed;                      // m/s, apparent airspeed
-    float airspeed_pitot;                // m/s, apparent airspeed, as seen by fwd pitot tube
-    float battery_voltage = 0.0f;
+    float airspeed;                      // m/s, EAS airspeed
+    float airspeed_pitot;                // m/s, EAS airspeed, as seen by fwd pitot tube
+    float battery_voltage;
     float battery_current;
     float local_ground_level;            // ground level at local position
     bool lock_step_scheduled;
@@ -319,6 +320,9 @@ protected:
 
     // get local thermal updraft
     float get_local_updraft(const Vector3d &currentPos);
+
+    // update EAS speeds
+    void update_eas_airspeed();
 
 private:
     uint64_t last_time_us;

--- a/libraries/SITL/SIM_Airspeed_DLVR.cpp
+++ b/libraries/SITL/SIM_Airspeed_DLVR.cpp
@@ -65,9 +65,6 @@ void SITL::Airspeed_DLVR::update(const class Aircraft &aircraft)
     float sim_alt = AP::sitl()->state.altitude;
     sim_alt += 2 * rand_float();
 
-    float sigma, delta, theta;
-    AP_Baro::SimpleAtmosphere(sim_alt * 0.001f, sigma, delta, theta);
-
     // To Do: Add a sensor board temperature offset parameter
-    temperature = (KELVIN_TO_C(SSL_AIR_TEMPERATURE * theta)) + 25.0;
+    temperature = AP_Baro::get_temperatureC_for_alt_amsl(sim_alt);
 }

--- a/libraries/SITL/SIM_Balloon.cpp
+++ b/libraries/SITL/SIM_Balloon.cpp
@@ -50,7 +50,7 @@ void Balloon::update(const struct sitl_input &input)
     Vector3f rot_accel = -gyro * radians(400) / terminal_rotation_rate;
 
     // air resistance
-    Vector3f air_resistance = -velocity_air_ef * (GRAVITY_MSS/terminal_velocity);
+    Vector3f air_resistance = -velocity_air_ef * (GRAVITY_MSS/terminal_velocity) / eas2tas;
 
     float lift_accel = 0;
     if (!burst && released) {

--- a/libraries/SITL/SIM_DroneCANDevice.cpp
+++ b/libraries/SITL/SIM_DroneCANDevice.cpp
@@ -92,11 +92,10 @@ void DroneCANDevice::update_baro() {
     }
 
 #if !APM_BUILD_TYPE(APM_BUILD_ArduSub)
-    float sigma, delta, theta;
 
-    AP_Baro::SimpleAtmosphere(sim_alt * 0.001f, sigma, delta, theta);
-    float p = SSL_AIR_PRESSURE * delta;
-    float T = KELVIN_TO_C(SSL_AIR_TEMPERATURE * theta);
+    float p, t_K;
+    AP_Baro::get_pressure_temperature_for_alt_amsl(sim_alt, p, t_K);
+    float T = KELVIN_TO_C(t_K);
 
     AP_Baro_SITL::temperature_adjustment(p, T);
     T = C_TO_KELVIN(T);
@@ -131,11 +130,8 @@ void DroneCANDevice::update_airspeed() {
     // this was mostly swiped from SIM_Airspeed_DLVR:
     const float sim_alt = AP::sitl()->state.altitude;
 
-    float sigma, delta, theta;
-    AP_Baro::SimpleAtmosphere(sim_alt * 0.001f, sigma, delta, theta);
-
     // To Do: Add a sensor board temperature offset parameter
-    msg.static_air_temperature = SSL_AIR_TEMPERATURE * theta + 25.0;
+    msg.static_air_temperature = C_TO_KELVIN(AP_Baro::get_temperatureC_for_alt_amsl(sim_alt));
 
     static Canard::Publisher<uavcan_equipment_air_data_RawAirData> raw_air_pub{CanardInterface::get_test_iface()};
     raw_air_pub.broadcast(msg);

--- a/libraries/SITL/SIM_Frame.cpp
+++ b/libraries/SITL/SIM_Frame.cpp
@@ -323,12 +323,7 @@ static Frame supported_frames[] =
 // get air density in kg/m^3
 float Frame::get_air_density(float alt_amsl) const
 {
-    float sigma, delta, theta;
-
-    AP_Baro::SimpleAtmosphere(alt_amsl * 0.001f, sigma, delta, theta);
-
-    const float air_pressure = SSL_AIR_PRESSURE * delta;
-    return air_pressure / (ISA_GAS_CONSTANT * (C_TO_KELVIN(model.refTempC)));
+    return AP_Baro::get_air_density_for_alt_amsl(alt_amsl);
 }
 
 /*

--- a/libraries/SITL/SIM_InertialLabs.cpp
+++ b/libraries/SITL/SIM_InertialLabs.cpp
@@ -39,11 +39,12 @@ void InertialLabs::send_packet(void)
     pkt.gyro_data_hr.x = fdm.pitchRate*1.0e5;
     pkt.gyro_data_hr.z = -fdm.yawRate*1.0e5;
 
-    float sigma, delta, theta;
-    AP_Baro::SimpleAtmosphere((fdm.altitude+rand_float()*0.25) * 0.001, sigma, delta, theta);
-    pkt.baro_data.pressure_pa2 = SSL_AIR_PRESSURE * delta * 0.5;
+    float p, t_K;
+    AP_Baro::get_pressure_temperature_for_alt_amsl(fdm.altitude+rand_float()*0.25, p, t_K);
+
+    pkt.baro_data.pressure_pa2 = p;
     pkt.baro_data.baro_alt = fdm.altitude;
-    pkt.temperature = KELVIN_TO_C(SSL_AIR_TEMPERATURE * theta);
+    pkt.temperature = KELVIN_TO_C(t_K);
 
     pkt.mag_data.x = (fdm.bodyMagField.y / NTESLA_TO_MGAUSS)*0.1;
     pkt.mag_data.y = (fdm.bodyMagField.x / NTESLA_TO_MGAUSS)*0.1;

--- a/libraries/SITL/SIM_JSON.cpp
+++ b/libraries/SITL/SIM_JSON.cpp
@@ -331,6 +331,9 @@ void JSON::recv_fdm(const struct sitl_input &input)
 
         // airspeed as seen by a fwd pitot tube (limited to 120m/s)
         airspeed_pitot = constrain_float(velocity_air_bf * Vector3f(1.0f, 0.0f, 0.0f), 0.0f, 120.0f);
+
+        // airspeed fix for eas2tas
+        update_eas_airspeed();
     }
 
     // Convert from a meters from origin physics to a lat long alt

--- a/libraries/SITL/SIM_MS5525.cpp
+++ b/libraries/SITL/SIM_MS5525.cpp
@@ -68,11 +68,7 @@ void MS5525::get_pressure_temperature_readings(float &P_Pa, float &Temp_C)
     float sim_alt = AP::sitl()->state.altitude;
     sim_alt += 2 * rand_float();
 
-    float sigma, delta, theta;
-    AP_Baro::SimpleAtmosphere(sim_alt * 0.001f, sigma, delta, theta);
-
-    // To Do: Add a sensor board temperature offset parameter
-    Temp_C = (KELVIN_TO_C(SSL_AIR_TEMPERATURE * theta)) + 25.0;
+    Temp_C = AP_Baro::get_temperatureC_for_alt_amsl(sim_alt);
     const uint8_t instance = 0;  // TODO: work out which sensor this is
     P_Pa = AP::sitl()->state.airspeed_raw_pressure[instance] + AP::sitl()->airspeed[instance].offset;
 }

--- a/libraries/SITL/SIM_MS5611.cpp
+++ b/libraries/SITL/SIM_MS5611.cpp
@@ -106,15 +106,14 @@ void MS5611::check_conversion_accuracy(float P_Pa, float Temp_C, uint32_t D1, ui
 
 void MS5611::get_pressure_temperature_readings(float &P_Pa, float &Temp_C)
 {
-    float sigma, delta, theta;
-
     float sim_alt = AP::sitl()->state.altitude;
     sim_alt += 2 * rand_float();
 
-    AP_Baro::SimpleAtmosphere(sim_alt * 0.001f, sigma, delta, theta);
-    P_Pa = SSL_AIR_PRESSURE * delta;
+    float p, T_K;
+    AP_Baro::get_pressure_temperature_for_alt_amsl(sim_alt, p, T_K);
 
-    Temp_C = KELVIN_TO_C(SSL_AIR_TEMPERATURE * theta) + AP::sitl()->temp_board_offset;
+    P_Pa = p;
+    Temp_C = KELVIN_TO_C(T_K) + AP::sitl()->temp_board_offset;
 
     // TO DO add in temperature adjustment by inheritting from AP_Baro_SITL_Generic?
     // AP_Baro_SITL::temperature_adjustment(P_Pa, Temp_C);

--- a/libraries/SITL/SIM_MS5XXX.cpp
+++ b/libraries/SITL/SIM_MS5XXX.cpp
@@ -58,6 +58,8 @@ void MS5XXX::convert_D2()
         // bug in the conversion code.  The simulation can pass in
         // very, very low numbers.  Clamp it.
         P_Pa = 0.1;
+
+        // This should be a simulation error??? Pressure at 86km is 0.374Pa
     }
 
     uint32_t D1;

--- a/libraries/SITL/SIM_MicroStrain.cpp
+++ b/libraries/SITL/SIM_MicroStrain.cpp
@@ -101,9 +101,9 @@ void MicroStrain::send_imu_packet(void)
     // Add ambient pressure field
     packet.payload[packet.payload_size++] = 0x06; // Ambient Pressure Field Size
     packet.payload[packet.payload_size++] = 0x17; // Descriptor
-    float sigma, delta, theta;
-    AP_Baro::SimpleAtmosphere(fdm.altitude * 0.001f, sigma, delta, theta);
-    put_float(packet, SSL_AIR_PRESSURE * delta * 0.001 + rand_float() * 0.1);
+
+    float pressure_Pa = AP_Baro::get_pressure_for_alt_amsl(fdm.altitude);
+    put_float(packet, pressure_Pa*0.001 + rand_float() * 0.1);
 
     // Add scaled magnetometer field
     packet.payload[packet.payload_size++] = 0x0E; // Scaled Magnetometer Field Size

--- a/libraries/SITL/SIM_Plane.h
+++ b/libraries/SITL/SIM_Plane.h
@@ -41,7 +41,6 @@ public:
 
 protected:
     const float hover_throttle = 0.7f;
-    const float air_density = 1.225; // kg/m^3 at sea level, ISA conditions
     float angle_of_attack;
     float beta;
 

--- a/libraries/SITL/SIM_Scrimmage.cpp
+++ b/libraries/SITL/SIM_Scrimmage.cpp
@@ -106,7 +106,7 @@ void Scrimmage::recv_fdm(const struct sitl_input &input)
 
 
     // velocity relative to air mass, in earth frame TODO
-    velocity_air_ef = velocity_ef;
+    velocity_air_ef = velocity_ef - wind_ef;
 
     // velocity relative to airmass in body frame TODO
     velocity_air_bf = dcm.transposed() * velocity_air_ef;

--- a/libraries/SITL/SIM_SingleCopter.cpp
+++ b/libraries/SITL/SIM_SingleCopter.cpp
@@ -90,7 +90,7 @@ void SingleCopter::update(const struct sitl_input &input)
     rot_accel.z -= gyro.z * radians(400.0)  / terminal_rotation_rate;
 
     // air resistance
-    Vector3f air_resistance = -velocity_air_ef * (GRAVITY_MSS/terminal_velocity);
+    Vector3f air_resistance = -velocity_air_ef * (GRAVITY_MSS/terminal_velocity) / eas2tas;
 
     // scale thrust to newtons
     thrust *= thrust_scale;

--- a/libraries/SITL/SIM_Temperature_TSYS01.cpp
+++ b/libraries/SITL/SIM_Temperature_TSYS01.cpp
@@ -193,9 +193,6 @@ float SITL::TSYS01::get_sim_temperature() const
     float sim_alt = AP::sitl()->state.altitude;
     sim_alt += 2 * rand_float();
 
-    float sigma, delta, theta;
-    AP_Baro::SimpleAtmosphere(sim_alt * 0.001f, sigma, delta, theta);
-
     // To Do: Add a sensor board temperature offset parameter
-    return (KELVIN_TO_C(SSL_AIR_TEMPERATURE * theta)) + 25.0;
+    return AP_Baro::get_temperatureC_for_alt_amsl(sim_alt) + 25;
 }

--- a/libraries/SITL/SIM_VectorNav.cpp
+++ b/libraries/SITL/SIM_VectorNav.cpp
@@ -94,9 +94,8 @@ void VectorNav::send_packet1(void)
     pkt.uncompAngRate[1] = radians(fdm.pitchRate + gyro_noise * rand_float());
     pkt.uncompAngRate[2] = radians(fdm.yawRate + gyro_noise * rand_float());
 
-    float sigma, delta, theta;
-    AP_Baro::SimpleAtmosphere(fdm.altitude * 0.001f, sigma, delta, theta);
-    pkt.pressure = SSL_AIR_PRESSURE * delta * 0.001 + rand_float() * 0.01;
+    const float pressure_Pa = AP_Baro::get_pressure_for_alt_amsl(fdm.altitude);
+    pkt.pressure = pressure_Pa*0.001 + rand_float() * 0.01;
 
     pkt.mag[0] = fdm.bodyMagField.x*0.001;
     pkt.mag[1] = fdm.bodyMagField.y*0.001;
@@ -153,7 +152,8 @@ void VectorNav::send_packet2(void)
     simulation_timeval(&tv);
 
     pkt.timeGPS = tv.tv_usec * 1000ULL;
-    pkt.temp = 23.5;
+
+    pkt.temp = AP_Baro::get_temperatureC_for_alt_amsl(fdm.altitude);
     pkt.numGPS1Sats = 19;
     pkt.GPS1Fix = 3;
     pkt.GPS1posLLA[0] = fdm.latitude;

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -63,8 +63,8 @@ struct sitl_fdm {
     double rollRate, pitchRate, yawRate; // degrees/s in body frame
     double rollDeg, pitchDeg, yawDeg;    // euler angles, degrees
     Quaternion quaternion;
-    double airspeed; // m/s
-    Vector3f velocity_air_bf; // velocity relative to airmass, body frame
+    double airspeed; // m/s, EAS
+    Vector3f velocity_air_bf; // velocity relative to airmass, body frame, TAS
     double battery_voltage; // Volts
     double battery_current; // Amps
     double battery_remaining; // Ah, if non-zero capacity


### PR DESCRIPTION
this replaces PR #17984 
the formula in this PR are from @hendjoshsr71 who re-worked my original PR to use a parametric system instead of a full table
the use of the new formula is only enabled if EKF double precision is enabled or building for SITL
