### PR TITLE
Add test for EK3_ORGN_HGT_MASK

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -6045,13 +6045,14 @@ class TestSuite(ABC):
         del context.collections[msg_type]
         return ret
 
-    def context_pop(self, process_interaction_allowed=True):
+    def context_pop(self, process_interaction_allowed=True, hooks_already_removed=False):
         """Set parameters to origin values in reverse order."""
         dead = self.contexts.pop()
         # remove hooks first; these hooks can raise exceptions which
         # we really don't want...
-        for hook in dead.message_hooks:
-            self.remove_message_hook(hook)
+        if not hooks_already_removed:
+            for hook in dead.message_hooks:
+                self.remove_message_hook(hook)
         for script in dead.installed_scripts:
             self.remove_installed_script(script)
         for (message_id, interval_us) in dead.overridden_message_rates.items():
@@ -8409,7 +8410,7 @@ Also, ignores heartbeats not from our target system'''
 
         tee = TeeBoth(test_output_filename, 'w', self.mavproxy_logfile, suppress_stdout=suppress_stdout)
 
-        start_message_hooks = self.mav.message_hooks
+        start_message_hooks = copy.copy(self.mav.message_hooks)
 
         prettyname = "%s (%s)" % (name, desc)
         self.start_test(prettyname)
@@ -8420,6 +8421,8 @@ Also, ignores heartbeats not from our target system'''
         start_time = time.time()
 
         orig_speedup = None
+
+        hooks_removed = False
 
         ex = None
         try:
@@ -8444,6 +8447,7 @@ Also, ignores heartbeats not from our target system'''
             for h in self.mav.message_hooks:
                 if h not in start_message_hooks:
                     self.mav.message_hooks.remove(h)
+            hooks_removed = True
         self.test_timings[desc] = time.time() - start_time
         reset_needed = self.contexts[-1].sitl_commandline_customised
 
@@ -8470,7 +8474,7 @@ Also, ignores heartbeats not from our target system'''
             reset_needed = True
 
         try:
-            self.context_pop(process_interaction_allowed=ardupilot_alive)
+            self.context_pop(process_interaction_allowed=ardupilot_alive, hooks_already_removed=hooks_removed)
         except Exception as e:
             self.print_exception_caught(e, send_statustext=False)
             passed = False
@@ -8522,7 +8526,7 @@ Also, ignores heartbeats not from our target system'''
             # pop off old contexts to clean up message hooks etc
             while len(self.contexts) > old_contexts_length:
                 try:
-                    self.context_pop(process_interaction_allowed=ardupilot_alive)
+                    self.context_pop(process_interaction_allowed=ardupilot_alive, hooks_already_removed=hooks_removed)
                 except Exception as e:
                     self.print_exception_caught(e, send_statustext=False)
             self.progress("Done popping extra contexts")

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -2331,7 +2331,6 @@ class TestSuite(ABC):
             "SIM_BARO_COUNT",
             "SIM_BARO_DELAY",
             "SIM_BARO_DISABLE",
-            "SIM_BARO_DRIFT",
             "SIM_BARO_FREEZE",
             "SIM_BARO_WCF_BAK",
             "SIM_BARO_WCF_DN",

--- a/libraries/AP_Baro/AP_Baro_SITL.cpp
+++ b/libraries/AP_Baro/AP_Baro_SITL.cpp
@@ -66,7 +66,11 @@ void AP_Baro_SITL::_timer()
         return;
     }
 
-    sim_alt += _sitl->baro[_instance].drift * now * 0.001f;
+    const auto drift_delta_t_ms = now - last_drift_delta_t_ms;
+    last_drift_delta_t_ms = now;
+    total_alt_drift += _sitl->baro[_instance].drift * drift_delta_t_ms * 0.001f;
+
+    sim_alt += total_alt_drift;
     sim_alt += _sitl->baro[_instance].noise * rand_float();
 
     // add baro glitch

--- a/libraries/AP_Baro/AP_Baro_SITL.h
+++ b/libraries/AP_Baro/AP_Baro_SITL.h
@@ -48,5 +48,7 @@ private:
     float _recent_press;
     float _last_altitude;
 
+    uint32_t last_drift_delta_t_ms;  // allows for integration of drift over time
+    float total_alt_drift;  // integrated altitude drift in metres
 };
 #endif  // AP_SIM_BARO_ENABLED

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -548,6 +548,11 @@ const AP_Param::GroupInfo SIM::var_info3[] = {
 // user settable parameters for the barometers
 const AP_Param::GroupInfo SIM::BaroParm::var_info[] = {
     AP_GROUPINFO("RND",      1, SIM::BaroParm,  noise, 0.2f),
+    // @Param: BARO_DRIFT
+    // @DisplayName: Baro altitude drift
+    // @Description: Barometer altitude drifts at this rate
+    // @Units: m/s
+    // @User: Advanced
     AP_GROUPINFO("DRIFT",    2, SIM::BaroParm,  drift, 0),
     AP_GROUPINFO("DISABLE",  3, SIM::BaroParm,  disable, 0),
     AP_GROUPINFO("GLITCH",   4, SIM::BaroParm,  glitch, 0),


### PR DESCRIPTION
 - accumulate simulated barometer drift rather than setting based on vehicle uptime
 - add description for SIM_BARO_DRIFT
 - bugfixes for hook removal in exception handling

... and, of course, add a test that we adjust the barometer altitude over time.If the EKF parameter is not set then the test doesn't pass.  In fact, it fails with a flow-of-control error in the landing detector....

This work sponsored by Harris Aerial
