### PR TITLE
Support all Tramp Power Levels

### DIFF
--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
@@ -66,6 +66,11 @@ bool AP_CRSF_Telem::init(void)
         return false;
     }
 
+    // Someone explicitly configure CRSF control for VTX
+    if (AP::serialmanager().have_serial(AP_SerialManager::SerialProtocol_CRSF, 0)) {
+        AP::vtx().set_provider_enabled(AP_VideoTX::VTXType::CRSF);
+    }
+
     return AP_RCTelemetry::init();
 }
 
@@ -554,6 +559,8 @@ void AP_CRSF_Telem::process_vtx_frame(VTXFrame* vtx) {
         return;
     }
 
+    apvtx.set_provider_enabled(AP_VideoTX::VTXType::CRSF);
+
     apvtx.set_band(vtx->band);
     apvtx.set_channel(vtx->channel);
     if (vtx->is_in_user_frequency_mode) {
@@ -599,6 +606,8 @@ void AP_CRSF_Telem::process_vtx_telem_frame(VTXTelemetryFrame* vtx)
     if (!apvtx.get_enabled()) {
         return;
     }
+
+    apvtx.set_provider_enabled(AP_VideoTX::VTXType::CRSF);
 
     apvtx.set_frequency_mhz(vtx->frequency);
 
@@ -731,11 +740,6 @@ void AP_CRSF_Telem::process_param_read_frame(ParameterSettingsReadFrame* read_fr
     _pending_request.frame_type = AP_RCProtocol_CRSF::CRSF_FRAMETYPE_PARAMETER_READ;
 }
 
-// process any changed settings and schedule for transmission
-void AP_CRSF_Telem::update()
-{
-}
-
 void AP_CRSF_Telem::process_pending_requests()
 {
     // handle general parameter requests
@@ -766,7 +770,8 @@ void AP_CRSF_Telem::update_vtx_params()
 {
     AP_VideoTX& vtx = AP::vtx();
 
-    if (!vtx.get_enabled()) {
+    // This function does ugly things with the vtx parameters which will upset other providers
+    if (!vtx.get_enabled() || !vtx.is_provider_enabled(AP_VideoTX::VTXType::CRSF)) {
         return;
     }
 

--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.h
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.h
@@ -232,8 +232,6 @@ public:
 
     // Process a frame from the CRSF protocol decoder
     static bool process_frame(AP_RCProtocol_CRSF::FrameType frame_type, void* data);
-    // process any changed settings and schedule for transmission
-    void update();
     // get next telemetry data for external consumers of SPort data
     static bool get_telem_data(AP_RCProtocol_CRSF::Frame* frame, bool is_tx_active);
     // start bind request

--- a/libraries/AP_VideoTX/AP_SmartAudio.cpp
+++ b/libraries/AP_VideoTX/AP_SmartAudio.cpp
@@ -62,6 +62,8 @@ bool AP_SmartAudio::init()
             return false;
         }
 
+        AP::vtx().set_provider_enabled(AP_VideoTX::VTXType::SmartAudio);
+
         return true;
     }
     return false;

--- a/libraries/AP_VideoTX/AP_Tramp.h
+++ b/libraries/AP_VideoTX/AP_Tramp.h
@@ -38,6 +38,11 @@
 // Race lock - settings can't be changed
 #define TRAMP_CONTROL_RACE_LOCK (0x01)
 
+#define VTX_TRAMP_UART_BAUD            9600
+#define VTX_TRAMP_SMARTBAUD_MIN        9120     // -5%
+#define VTX_TRAMP_SMARTBAUD_MAX        10080    // +5%
+#define VTX_TRAMP_SMARTBAUD_STEP       120
+
 class AP_Tramp
 {
 public:
@@ -73,6 +78,8 @@ private:
     void set_frequency(uint16_t freq);
     void set_power(uint16_t power);
     void set_pit_mode(uint8_t onoff);
+    // change baud automatically when request-response fails many times
+    void update_baud_rate();
 
     // serial interface
     AP_HAL::UARTDriver *port;                  // UART used to send data to Tramp VTX
@@ -114,6 +121,17 @@ private:
     uint16_t cur_act_power; // Actual power
     int16_t cur_temp;
     uint8_t cur_control_mode;
+
+    // statistics
+    uint16_t _packets_sent;
+    uint16_t _packets_rcvd;
+
+    // value for current baud adjust
+    int32_t _smartbaud = VTX_TRAMP_UART_BAUD;
+    enum class AutobaudDirection {
+        UP = 1,
+        DOWN = -1
+    } _smartbaud_direction = AutobaudDirection::DOWN;
 
     // Retry count
     uint8_t retry_count = VTX_TRAMP_MAX_RETRIES;

--- a/libraries/AP_VideoTX/AP_VideoTX.cpp
+++ b/libraries/AP_VideoTX/AP_VideoTX.cpp
@@ -113,7 +113,7 @@ AP_VideoTX::PowerLevel AP_VideoTX::_power_levels[VTX_MAX_POWER_LEVELS] = {
     { 1,    200,  23, 16   },
     { 0x12, 400,  26, 0xFF }, // only in SA 2.1
     { 2,    500,  27, 25   },
-    //{ 0x13, 600,  28, 0xFF },
+    { 0x12, 600,  28, 0xFF }, // Tramp lies above power levels and always returns 25/100/200/400/600
     { 3,    800,  29, 40   },
     { 0x13, 1000, 30, 0xFF }, // only in SA 2.1
     { 0xFF, 0,    0,  0XFF, PowerActive::Inactive }  // slot reserved for a custom power level
@@ -342,13 +342,6 @@ void AP_VideoTX::update(void)
         return;
     }
 
-#if HAL_CRSF_TELEM_ENABLED
-    AP_CRSF_Telem* crsf = AP::crsf_telem();
-
-    if (crsf != nullptr) {
-        crsf->update();
-    }
-#endif
     // manipulate pitmode if pitmode-on-disarm or power-on-arm is set
     if (has_option(VideoOptions::VTX_PITMODE_ON_DISARM) || has_option(VideoOptions::VTX_PITMODE_UNTIL_ARM)) {
         if (hal.util->get_soft_armed() && has_option(VideoOptions::VTX_PITMODE)) {

--- a/libraries/AP_VideoTX/AP_VideoTX.h
+++ b/libraries/AP_VideoTX/AP_VideoTX.h
@@ -21,7 +21,7 @@
 #include <AP_Param/AP_Param.h>
 
 #define VTX_MAX_CHANNELS 8
-#define VTX_MAX_POWER_LEVELS 9
+#define VTX_MAX_POWER_LEVELS 10
 
 class AP_VideoTX {
 public:
@@ -72,6 +72,12 @@ public:
         Unknown,
         Active,
         Inactive
+    };
+
+    enum VTXType {
+        CRSF = 1U<<0,
+        SmartAudio = 1U<<1,
+        Tramp = 1U<<2
     };
 
     struct PowerLevel {
@@ -164,6 +170,10 @@ public:
     void set_configuration_finished(bool configuration_finished) { _configuration_finished = configuration_finished; }
     bool is_configuration_finished() { return _configuration_finished; }
 
+    // manage VTX backends
+    bool is_provider_enabled(VTXType type) const { return (_types & type) != 0; }
+    void set_provider_enabled(VTXType type) { _types |= type; }
+
     static AP_VideoTX *singleton;
 
 private:
@@ -197,6 +207,9 @@ private:
     bool _defaults_set;
     // true when configuration have been applied successfully to the VTX
     bool _configuration_finished;
+
+    // types of VTX providers
+    uint8_t _types;
 };
 
 namespace AP {


### PR DESCRIPTION
This fixes a bug whereby it was impossible to select the highest power level when using Tramp because the CRSF provider would immediately reset it.

It also fixes a bug where Tramp was unreliable due to temperature fluctuations and implements the same autobauding scheme that SmartAudio uses.

Tramp lies about power levels and always takes fixed input of 25/100/200/400/600 even though the output may be very different.