### PR TITLE
ChibiOS: UART: Add support for RS-485 Driver Enable RTS flow control

### DIFF
--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -115,7 +115,7 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
     // @Param: SER1_RTSCTS
     // @DisplayName: Serial 1 flow control
     // @Description: Enable flow control on serial 1 (telemetry 1). You must have the RTS and CTS pins connected to your radio. The standard DF13 6 pin connector for a 3DR radio does have those pins connected. If this is set to 2 then flow control will be auto-detected by checking for the output buffer filling on startup. Note that the PX4v1 does not have hardware flow control pins on this port, so you should leave this disabled.
-    // @Values: 0:Disabled,1:Enabled,2:Auto
+    // @Values: 0:Disabled,1:Enabled,2:Auto,3:RS-485 Driver enable RTS pin
     // @RebootRequired: True
     // @User: Advanced
     AP_GROUPINFO("SER1_RTSCTS",    1, AP_BoardConfig, state.ser_rtscts[1], BOARD_SER1_RTSCTS_DEFAULT),
@@ -123,41 +123,33 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
 
 #ifdef HAL_HAVE_RTSCTS_SERIAL2
     // @Param: SER2_RTSCTS
+    // @CopyFieldsFrom: BRD_SER1_RTSCTS
     // @DisplayName: Serial 2 flow control
     // @Description: Enable flow control on serial 2 (telemetry 2). You must have the RTS and CTS pins connected to your radio. The standard DF13 6 pin connector for a 3DR radio does have those pins connected. If this is set to 2 then flow control will be auto-detected by checking for the output buffer filling on startup.
-    // @Values: 0:Disabled,1:Enabled,2:Auto
-    // @RebootRequired: True
-    // @User: Advanced
     AP_GROUPINFO("SER2_RTSCTS",    2, AP_BoardConfig, state.ser_rtscts[2], 2),
 #endif
 
 #ifdef HAL_HAVE_RTSCTS_SERIAL3
     // @Param: SER3_RTSCTS
+    // @CopyFieldsFrom: BRD_SER1_RTSCTS
     // @DisplayName: Serial 3 flow control
     // @Description: Enable flow control on serial 3. You must have the RTS and CTS pins connected to your radio. The standard DF13 6 pin connector for a 3DR radio does have those pins connected. If this is set to 2 then flow control will be auto-detected by checking for the output buffer filling on startup.
-    // @Values: 0:Disabled,1:Enabled,2:Auto
-    // @RebootRequired: True
-    // @User: Advanced
     AP_GROUPINFO("SER3_RTSCTS",    26, AP_BoardConfig, state.ser_rtscts[3], 2),
 #endif
 
 #ifdef HAL_HAVE_RTSCTS_SERIAL4
     // @Param: SER4_RTSCTS
+    // @CopyFieldsFrom: BRD_SER1_RTSCTS
     // @DisplayName: Serial 4 flow control
     // @Description: Enable flow control on serial 4. You must have the RTS and CTS pins connected to your radio. The standard DF13 6 pin connector for a 3DR radio does have those pins connected. If this is set to 2 then flow control will be auto-detected by checking for the output buffer filling on startup.
-    // @Values: 0:Disabled,1:Enabled,2:Auto
-    // @RebootRequired: True
-    // @User: Advanced
     AP_GROUPINFO("SER4_RTSCTS",    27, AP_BoardConfig, state.ser_rtscts[4], 2),
 #endif
 
 #ifdef HAL_HAVE_RTSCTS_SERIAL5
     // @Param: SER5_RTSCTS
+    // @CopyFieldsFrom: BRD_SER1_RTSCTS
     // @DisplayName: Serial 5 flow control
     // @Description: Enable flow control on serial 5. You must have the RTS and CTS pins connected to your radio. The standard DF13 6 pin connector for a 3DR radio does have those pins connected. If this is set to 2 then flow control will be auto-detected by checking for the output buffer filling on startup.
-    // @Values: 0:Disabled,1:Enabled,2:Auto
-    // @RebootRequired: True
-    // @User: Advanced
     AP_GROUPINFO("SER5_RTSCTS",    25, AP_BoardConfig, state.ser_rtscts[5], 2),
 #endif
 #endif

--- a/libraries/AP_HAL/UARTDriver.cpp
+++ b/libraries/AP_HAL/UARTDriver.cpp
@@ -165,6 +165,20 @@ uint64_t AP_HAL::UARTDriver::receive_time_constraint_us(uint16_t nbytes)
     return AP_HAL::micros64();
 }
 
+// Helper to check if flow control is enabled given the passed setting
+bool AP_HAL::UARTDriver::flow_control_enabled(enum flow_control flow_control_setting) const
+{
+    switch(flow_control_setting) {
+        case FLOW_CONTROL_ENABLE:
+        case FLOW_CONTROL_AUTO:
+            return true;
+        case FLOW_CONTROL_DISABLE:
+        case FLOW_CONTROL_RTS_DE:
+            break;
+    }
+    return false;
+}
+
 #if HAL_UART_STATS_ENABLED
 // Take cumulative bytes and return the change since last call
 uint32_t AP_HAL::UARTDriver::StatsTracker::ByteTracker::update(uint32_t bytes)

--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -103,9 +103,13 @@ public:
         FLOW_CONTROL_DISABLE=0,
         FLOW_CONTROL_ENABLE=1,
         FLOW_CONTROL_AUTO=2,
+        FLOW_CONTROL_RTS_DE=3, // RTS pin is used as a driver enable (used in RS-485)
     };
     virtual void set_flow_control(enum flow_control flow_control_setting) {};
     virtual enum flow_control get_flow_control(void) { return FLOW_CONTROL_DISABLE; }
+
+    // Return true if flow control is currently enabled
+    bool flow_control_enabled() { return flow_control_enabled(get_flow_control()); }
 
     virtual void configure_parity(uint8_t v){};
     virtual void set_stop_bits(int n){};
@@ -239,6 +243,9 @@ protected:
 
     // discard incoming data on the port
     virtual bool _discard_input(void) = 0;
+
+    // Helper to check if flow control is enabled given the passed setting
+    bool flow_control_enabled(enum flow_control flow_control_setting) const;
 
 #if HAL_UART_STATS_ENABLED
     // Getters for cumulative tx and rx counts

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -74,6 +74,7 @@ public:
         int8_t txinv_gpio;
         uint8_t txinv_polarity;
         uint8_t endpoint_id;
+        uint8_t rts_alternative_function;
         uint8_t get_index(void) const {
             return uint8_t(this - &_serial_tab[0]);
         }

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -1885,7 +1885,8 @@ INCLUDE common.ld
             devlist.append('HAL_%s_CONFIG' % dev)
             tx_line = self.make_line(dev + '_TX')
             rx_line = self.make_line(dev + '_RX')
-            rts_line = self.make_line(dev + '_RTS')
+            rts_line_name = dev + '_RTS'
+            rts_line = self.make_line(rts_line_name)
             cts_line = self.make_line(dev + '_CTS')
             if rts_line != "0":
                 have_rts_cts = True
@@ -1893,12 +1894,12 @@ INCLUDE common.ld
 
             if dev.startswith('OTG2'):
                 f.write(
-                    '#define HAL_%s_CONFIG {(BaseSequentialStream*) &SDU2, 2, true, false, 0, 0, false, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}\n' % dev)  # noqa
+                    '#define HAL_%s_CONFIG {(BaseSequentialStream*) &SDU2, 2, true, false, 0, 0, false, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, UINT8_MAX}\n' % dev)  # noqa
                 OTG2_index = serial_list.index(dev)
                 self.dual_USB_enabled = True
             elif dev.startswith('OTG'):
                 f.write(
-                    '#define HAL_%s_CONFIG {(BaseSequentialStream*) &SDU1, 1, true, false, 0, 0, false, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}\n' % dev)  # noqa
+                    '#define HAL_%s_CONFIG {(BaseSequentialStream*) &SDU1, 1, true, false, 0, 0, false, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, UINT8_MAX}\n' % dev)  # noqa
             else:
                 need_uart_driver = True
                 f.write(
@@ -1914,7 +1915,30 @@ INCLUDE common.ld
                 f.write("%d, " % self.get_gpio_bylabel(dev + "_RXINV"))
                 f.write("%s, " % self.get_extra_bylabel(dev + "_RXINV", "POL", "0"))
                 f.write("%d, " % self.get_gpio_bylabel(dev + "_TXINV"))
-                f.write("%s, 0}\n" % self.get_extra_bylabel(dev + "_TXINV", "POL", "0"))
+                f.write("%s, " % self.get_extra_bylabel(dev + "_TXINV", "POL", "0"))
+
+                # USB endpoint ID, not used
+                f.write("0, ") 
+
+                # Find and add RTS alt fuction number if avalable
+                def get_RTS_alt_function():
+                    # Typicaly we do software RTS control, so there is no requirement for the pin to have valid UART RTS alternative function
+                    # If it does this enables hardware flow control for RS-485
+                    lib = self.get_mcu_lib(self.mcu_type)
+                    if (rts_line == "0") or (rts_line_name not in self.bylabel) or not hasattr(lib, "AltFunction_map"):
+                        # No pin, 0 is a valid alt function, use UINT8_MAX for invalid
+                        return "UINT8_MAX"
+
+                    pin = self.bylabel[rts_line_name]
+                    for label in self.af_labels:
+                        if rts_line_name.startswith(label):
+                            s = pin.portpin + ":" + rts_line_name
+                            if s not in lib.AltFunction_map:
+                                return "UINT8_MAX"
+                            return lib.AltFunction_map[s]
+
+                f.write("%s}\n" % get_RTS_alt_function())
+
         if have_rts_cts:
             f.write('#define AP_FEATURE_RTSCTS 1\n')
         if OTG2_index is not None:

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -397,7 +397,7 @@ ap_object AP_HAL::UARTDriver method read int16_t
 ap_object AP_HAL::UARTDriver manual readstring AP_HAL__UARTDriver_readstring 1
 ap_object AP_HAL::UARTDriver method write uint32_t uint8_t'skip_check
 ap_object AP_HAL::UARTDriver method available uint32_t
-ap_object AP_HAL::UARTDriver method set_flow_control void AP_HAL::UARTDriver::flow_control'enum AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE AP_HAL::UARTDriver::FLOW_CONTROL_AUTO
+ap_object AP_HAL::UARTDriver method set_flow_control void AP_HAL::UARTDriver::flow_control'enum AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE AP_HAL::UARTDriver::FLOW_CONTROL_RTS_DE
 
 singleton AP_SerialManager rename serial
 singleton AP_SerialManager depends HAL_GCS_ENABLED

--- a/libraries/GCS_MAVLink/GCS_Param.cpp
+++ b/libraries/GCS_MAVLink/GCS_Param.cpp
@@ -108,7 +108,7 @@ bool GCS_MAVLINK::have_flow_control(void)
         return false;
     }
 
-    if (_port->get_flow_control() != AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE) {
+    if (_port->flow_control_enabled()) {
         return true;
     }
 


### PR DESCRIPTION
This adds support for outputting a driver enable signal from the UART. That is a line that is held high for the duration of a transmit. This is used with RS-485 transceivers. The STM32 has hardware support for this, so we just need to set the pin to the correct alternative function and set the bit in the UART config.  

The new flow control type can be set with the `BRD_SERx_RTSCTS` param. 

This is MAVLink with it enabled:
![image](https://github.com/ArduPilot/ardupilot/assets/33176108/f93aa829-95ac-4496-a747-9798b7776994)

![image](https://github.com/ArduPilot/ardupilot/assets/33176108/d12c1c75-d518-4dd0-a886-b7657b54d968)

Currently this just uses the default timings for the time the pin goes high before the transmit is started and the time it takes to go low after the transmit has finished. There are config registers we could use to change this if we needed to.

In order to know which alternate function to use the information must be passed in from the hwdef.   