### PR TITLE
 AP_Scripting: CAN: `get_device` and `get_device2` return nil if no driver is configure with the correct protocol

### DIFF
--- a/libraries/AP_CANManager/AP_CANSensor.h
+++ b/libraries/AP_CANManager/AP_CANSensor.h
@@ -36,6 +36,9 @@ public:
     void init(uint8_t driver_index, bool enable_filters) override;
     bool add_interface(AP_HAL::CANIface* can_iface) override;
 
+    // Return true if this sensor has been successfully registered to a driver and initialized.
+    bool initialized() const { return _initialized; }
+
     // handler for incoming frames
     virtual void handle_frame(AP_HAL::CANFrame &frame) = 0;
 

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -344,14 +344,14 @@ function efi:get_backend(instance) end
 ---@class CAN
 CAN = {}
 
--- get a CAN bus device handler first scripting driver
+-- get a CAN bus device handler first scripting driver, will return nil if no driver with protocol Scripting is configured
 ---@param buffer_len uint32_t_ud -- buffer length 1 to 25
----@return ScriptingCANBuffer_ud
+---@return ScriptingCANBuffer_ud|nil
 function CAN:get_device(buffer_len) end
 
--- get a CAN bus device handler second scripting driver
+-- get a CAN bus device handler second scripting driver, will return nil if no driver with protocol Scripting2 is configured
 ---@param buffer_len uint32_t_ud -- buffer length 1 to 25
----@return ScriptingCANBuffer_ud
+---@return ScriptingCANBuffer_ud|nil
 function CAN:get_device2(buffer_len) end
 
 -- Auto generated binding

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -682,6 +682,12 @@ int lua_get_CAN_device(lua_State *L) {
         }
     }
 
+    if (!scripting->_CAN_dev->initialized()) {
+        // Driver not initialized, probably because there is no can driver set to scripting
+        // Return nil
+        return 0;
+    }
+
     new_ScriptingCANBuffer(L);
     *((ScriptingCANBuffer**)luaL_checkudata(L, -1, "ScriptingCANBuffer")) = scripting->_CAN_dev->add_buffer(buffer_len);
 
@@ -705,6 +711,12 @@ int lua_get_CAN_device2(lua_State *L) {
         if (scripting->_CAN_dev2 == nullptr) {
             return luaL_argerror(L, 1, "CAN device nullptr");
         }
+    }
+
+    if (!scripting->_CAN_dev2->initialized()) {
+        // Driver not initialized, probably because there is no can driver set to scripting 2
+        // Return nil
+        return 0;
     }
 
     new_ScriptingCANBuffer(L);


### PR DESCRIPTION
Currently you will get a valid can device in your script even-though it will never actually work because the is no protocol configured for it. This allows that case to be caught by the script and an appropriate message given if required. 