### PR TITLE
README: Remove myself from maintainers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,6 @@ for reviewing patches on their specific area.
   - ***Vehicle***: Rover
 - [Willian Galvani](https://github.com/williangalvani):
   - ***Vehicle***: Sub
-- [Lucas De Marchi](https://github.com/lucasdemarchi):
-  - ***Subsystem***: Linux
 - [Michael du Breuil](https://github.com/WickedShell):
   - ***Subsystem***: Batteries
   - ***Subsystem***: GPS


### PR DESCRIPTION
I've been pretty busy in the last years with the Linux kernel and couldn't dedicate the time needed to really maintain the Linux HAL in Ardupilot. I will still be around and receive notification when people mention my username, but I may not have time to review/reply as it's already happening.  Hopefully I can return in future and be more active.