### PR TITLE
Rover: Change division to multiplication

### DIFF
--- a/Rover/GCS_Mavlink.cpp
+++ b/Rover/GCS_Mavlink.cpp
@@ -124,11 +124,11 @@ void GCS_MAVLINK_Rover::send_servo_out()
 {
     float motor1, motor3;
     if (rover.g2.motors.have_skid_steering()) {
-        motor1 = 10000 * (SRV_Channels::get_output_scaled(SRV_Channel::k_throttleLeft) / 1000.0f);
-        motor3 = 10000 * (SRV_Channels::get_output_scaled(SRV_Channel::k_throttleRight) / 1000.0f);
+        motor1 = 10000 * (SRV_Channels::get_output_scaled(SRV_Channel::k_throttleLeft) * 0.001f);
+        motor3 = 10000 * (SRV_Channels::get_output_scaled(SRV_Channel::k_throttleRight) * 0.001f);
     } else {
         motor1 = 10000 * (SRV_Channels::get_output_scaled(SRV_Channel::k_steering) / 4500.0f);
-        motor3 = 10000 * (SRV_Channels::get_output_scaled(SRV_Channel::k_throttle) / 100.0f);
+        motor3 = 10000 * (SRV_Channels::get_output_scaled(SRV_Channel::k_throttle) * 0.01f);
     }
     mavlink_msg_rc_channels_scaled_send(
         chan,

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -246,19 +246,19 @@ bool Rover::get_control_output(AP_Vehicle::ControlOutput control_output, float &
         control_value = constrain_float(g2.motors.get_walking_height(), -1.0f, 1.0f);
         return true;
     case AP_Vehicle::ControlOutput::Throttle:
-        control_value = constrain_float(g2.motors.get_throttle() / 100.0f, -1.0f, 1.0f);
+        control_value = constrain_float(g2.motors.get_throttle() * 0.01f, -1.0f, 1.0f);
         return true;
     case AP_Vehicle::ControlOutput::Yaw:
         control_value = constrain_float(g2.motors.get_steering() / 4500.0f, -1.0f, 1.0f);
         return true;
     case AP_Vehicle::ControlOutput::Lateral:
-        control_value = constrain_float(g2.motors.get_lateral() / 100.0f, -1.0f, 1.0f);
+        control_value = constrain_float(g2.motors.get_lateral() * 0.01f, -1.0f, 1.0f);
         return true;
     case AP_Vehicle::ControlOutput::MainSail:
-        control_value = constrain_float(g2.motors.get_mainsail() / 100.0f, -1.0f, 1.0f);
+        control_value = constrain_float(g2.motors.get_mainsail() * 0.01f, -1.0f, 1.0f);
         return true;
     case AP_Vehicle::ControlOutput::WingSail:
-        control_value = constrain_float(g2.motors.get_wingsail() / 100.0f, -1.0f, 1.0f);
+        control_value = constrain_float(g2.motors.get_wingsail() * 0.01f, -1.0f, 1.0f);
         return true;
     default:
         return false;

--- a/Rover/mode.cpp
+++ b/Rover/mode.cpp
@@ -111,7 +111,7 @@ void Mode::get_pilot_desired_steering_and_throttle(float &steering_out, float &t
     // we proportionally reduce steering and throttle
     if (g2.motors.have_skid_steering()) {
         const float steer_normalised = constrain_float(steering_out / 4500.0f, -1.0f, 1.0f);
-        const float throttle_normalised = constrain_float(throttle_out / 100.0f, -1.0f, 1.0f);
+        const float throttle_normalised = constrain_float(throttle_out * 0.01f, -1.0f, 1.0f);
         const float saturation_value = fabsf(steer_normalised) + fabsf(throttle_normalised);
         if (saturation_value > 1.0f) {
             steering_out /= saturation_value;

--- a/Rover/mode_guided.cpp
+++ b/Rover/mode_guided.cpp
@@ -82,7 +82,7 @@ void ModeGuided::update()
             }
             if (have_attitude_target) {
                 // run steering and throttle controllers
-                float steering_out = attitude_control.get_steering_out_rate(radians(_desired_yaw_rate_cds / 100.0f),
+                float steering_out = attitude_control.get_steering_out_rate(radians(_desired_yaw_rate_cds * 0.01f),
                                                                             g2.motors.limit.steer_left,
                                                                             g2.motors.limit.steer_right,
                                                                             rover.G_Dt);


### PR DESCRIPTION
ArduPilot is based on the STM32.
The STM32 is better at multiplication than division.
Strong at multiplication means shorter time to use.