### PR TITLE
AP_MSP:add option for backward compatibility

### DIFF
--- a/libraries/AP_MSP/AP_MSP.cpp
+++ b/libraries/AP_MSP/AP_MSP.cpp
@@ -44,8 +44,8 @@ const AP_Param::GroupInfo AP_MSP::var_info[] = {
 
     // @Param: _OPTIONS
     // @DisplayName: MSP OSD Options
-    // @Description: A bitmask to set some MSP specific options: EnableTelemetryMode-allows "push" mode telemetry when only rx line of OSD ic connected to autopilot,  EnableBTFLFonts-uses indexes corresponding to Betaflight fonts if OSD uses those instead of ArduPilot fonts.
-    // @Bitmask: 0:EnableTelemetryMode, 1: unused, 2:EnableBTFLFonts
+    // @Description: A bitmask to set some MSP specific options: EnableTelemetryMode-allows "push" mode telemetry when only rx line of OSD ic connected to autopilot,  EnableBTFLFonts-uses indexes corresponding to Betaflight fonts if OSD uses those instead of ArduPilot fonts. Raw MSP RC- uses directly received RC input for MSP telem as did prior versions to 4.6 reported instead of scaled/reversed 
+    // @Bitmask: 0:EnableTelemetryMode, 1: unused, 2:EnableBTFLFonts, 3: Raw MSP RC
     // @User: Standard
     AP_GROUPINFO("_OPTIONS", 2, AP_MSP, _options, 0),
 

--- a/libraries/AP_MSP/AP_MSP.h
+++ b/libraries/AP_MSP/AP_MSP.h
@@ -57,6 +57,7 @@ public:
         TELEMETRY_MODE = 1U<<0,
         TELEMETRY_DISABLE_DJI_WORKAROUNDS = 1U<<1,
         DISPLAYPORT_BTFL_SYMBOLS = 1U<<2,
+        RAW_RC_TELEM = 1U<<3,
     };
 
     bool is_option_enabled(const Option option) const;


### PR DESCRIPTION
#26304 will **break** any existing configuration relying on raw rc over MSP that use the AP RC input reversing parameter currently....this is primarily VTX and OSD stick commands and the user would have gotten used to the reversed sick patterns

while it is possible to reconfigure by changing both the TX reverse (assuming it has that ability...many old simple TXs do not but we may elect to consider them obsolete now) and the AP RCx_ reverse param...it is still a breaking setup change for some.
Our wiki recommends both ways of adjusting RC reverse...in one section it say avoid the RC reverse param if possible using TX reverse, in another it says don't mess with the TX reverse use the RC reverse...this wiki contradiction will be changed to the former recommendation but the previous PR still breaks some existing setups...with this option we offer those cases an easy reversion which can be mentioned in the wiki in the multiple RC setup mentions.

I am asking @timtuxworth to test this PR both with and without the option bit set in one of his setups for both VTX and HDzero if possible

note:I welcome coding efficiency suggestions since I am not skilled in that for sure
