### PR TITLE
Plane: tiltrotor: fix canceling out of `Q_FWD_THR_GAIN`

### DIFF
--- a/ArduPlane/tiltrotor.cpp
+++ b/ArduPlane/tiltrotor.cpp
@@ -295,7 +295,7 @@ void Tiltrotor::continuous_update(void)
         // operate in all VTOL modes except Q_AUTOTUNE. Forward rotor tilt is used to produce
         // forward thrust equivalent to what would have been produced by a forward thrust motor
         // set to quadplane.forward_throttle_pct()
-        const float fwd_g_demand = 0.01f * quadplane.forward_throttle_pct() / plane.quadplane.q_fwd_thr_gain;
+        const float fwd_g_demand = 0.01 * quadplane.forward_throttle_pct();
         const float fwd_tilt_deg = MIN(degrees(atanf(fwd_g_demand)), (float)max_angle_deg);
         slew(MIN(fwd_tilt_deg * (1/90.0), get_forward_flight_tilt()));
         return;


### PR DESCRIPTION
Currently `Q_FWD_THR_GAIN` is not functional on tilt rotors.  It is applied here:
https://github.com/ArduPilot/ardupilot/blob/71a4885c87cef276b376f82cf3712a85f6eb0878/ArduPlane/quadplane.cpp#L2911-L2914

The reverse calculation is then done in tiltrotor to get back to a angle here:
https://github.com/ArduPilot/ardupilot/blob/71a4885c87cef276b376f82cf3712a85f6eb0878/ArduPlane/tiltrotor.cpp#L298-L299

Because `Q_FWD_THR_GAIN` is used again the result is that is cancels out. This is from a test using the Griffin in realflight using https://github.com/ArduPilot/ardupilot/pull/26978 for tilt angle logging. Tested in Qhover with constant pilot pitch demand of 25 deg nose down:
![newplot (51)](https://github.com/ArduPilot/ardupilot/assets/33176108/6bd6284d-6a26-4b55-9808-a936e7b1d28c)

Changing gain from 0.1 to 2.0 has no effect. 

This fix remove the division by the gain in tiltrotor so it does not cancel out. This results in a tilt angle of `atan(gain * tan(requested pitch))`. That is what I would have expected the calculation to be. This results in higher tilt angles with larger gains:
![newplot (52)](https://github.com/ArduPilot/ardupilot/assets/33176108/d91696f2-a74e-436d-92c8-721c52793d49)

Unfortunately this bug exists in 4.5 and the default gain is 2, effectively until this fix is was using a gain of 1. So when we fix everyone using tiltrotors will get double the gain (if they have not tried changeling the parameter manually and have some random value)

We could:

- Set the default to 1 on tilt rotors. This will result in no change in behavior for anyone who has not manually changed the parameter.

- The above and moving the param to a new index and not doing the conversion on tiltrotors would also fix it for anyone who has manually changed the parameter, but not anyone who copies in a old value manually. 

- The above and changing the param name would make it harder for anyone to copy a old value manually. However its already confusing with `Q_FWD_THR_GAIN` and `Q_VFWD_GAIN` another new name will make it even worse.