### PR TITLE
hwdef: enable can port on Blitz743Pro

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/BlitzH743Pro/defaults.parm
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BlitzH743Pro/defaults.parm
@@ -1,3 +1,6 @@
 # setup for LEDs on chan9
 SERVO13_FUNCTION 120
 NTF_LED_TYPES 257
+
+#enable CAN port
+CAN_P1_DRIVER 1


### PR DESCRIPTION
we usually do this on any bd with CAN to ease setup.....adding DroneCAN GPS only requires setting GPS_TYPE to work