### PR TITLE
AP_Periph: allow airspeed without I2C

### DIFF
--- a/Tools/AP_Periph/AP_Periph.cpp
+++ b/Tools/AP_Periph/AP_Periph.cpp
@@ -208,7 +208,7 @@ void AP_Periph_FW::init()
 #endif
 
 #ifdef HAL_PERIPH_ENABLE_AIRSPEED
-#if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
+#if (CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS) && (HAL_USE_I2C == TRUE)
     const bool pins_enabled = ChibiOS::I2CBus::check_select_pins(0x01);
     if (pins_enabled) {
         ChibiOS::I2CBus::set_bus_to_floating(0);


### PR DESCRIPTION
Currently you cannot build periph including airspeed but without i2c. There only realistic reason you would want to do this would be to use MSP airspeed, but even that would be quite unusual. This gets it building again. The other option would be to put in a `#error` that airspeed requires i2c.