### PR TITLE
Rover: Commonly use standardized wording

### DIFF
--- a/Rover/mode.h
+++ b/Rover/mode.h
@@ -545,6 +545,8 @@ public:
     void limit_init_time_and_location();
     bool limit_breached() const;
 
+    static constexpr const char *timeout_msg = "target not received last 3secs, stopping";
+
 protected:
 
     enum class SubMode: uint8_t {

--- a/Rover/mode_guided.cpp
+++ b/Rover/mode_guided.cpp
@@ -53,7 +53,7 @@ void ModeGuided::update()
         {
             // stop vehicle if target not updated within 3 seconds
             if (have_attitude_target && (millis() - _des_att_time_ms) > 3000) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "target not received last 3secs, stopping");
+                gcs().send_text(MAV_SEVERITY_WARNING, timeout_msg);
                 have_attitude_target = false;
             }
             if (have_attitude_target) {
@@ -77,7 +77,7 @@ void ModeGuided::update()
         {
             // stop vehicle if target not updated within 3 seconds
             if (have_attitude_target && (millis() - _des_att_time_ms) > 3000) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "target not received last 3secs, stopping");
+                gcs().send_text(MAV_SEVERITY_WARNING, timeout_msg);
                 have_attitude_target = false;
             }
             if (have_attitude_target) {
@@ -112,7 +112,7 @@ void ModeGuided::update()
             // handle timeout
             if (_have_strthr && (AP_HAL::millis() - _strthr_time_ms) > 3000) {
                 _have_strthr = false;
-                gcs().send_text(MAV_SEVERITY_WARNING, "target not received last 3secs, stopping");
+                gcs().send_text(MAV_SEVERITY_WARNING, timeout_msg);
             }
             if (_have_strthr) {
                 // pass latest steering and throttle directly to motors library


### PR DESCRIPTION
The same message is present in three places.
I make the message variable.

AFTER
![Screenshot from 2024-05-06 19-12-45](https://github.com/ArduPilot/ardupilot/assets/646194/0a55c154-6267-4a13-bbd0-712f8382c759)
