### PR TITLE
AP_Periph: always limit rangefinder update rate to given max rate

### DIFF
--- a/Tools/AP_Periph/rangefinder.cpp
+++ b/Tools/AP_Periph/rangefinder.cpp
@@ -39,6 +39,7 @@ void AP_Periph_FW::can_rangefinder_update(void)
         // limit to max rate
         return;
     }
+    last_rangefinder_update_ms = now;
 
     // update all rangefinder instances
     rangefinder.update();
@@ -114,7 +115,6 @@ void AP_Periph_FW::can_rangefinder_update(void)
                         &buffer[0],
                         total_size);
 
-        last_rangefinder_update_ms = now;
     }
 }
 


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/ArduPilot/ardupilot/pull/26607. The `last_rangefinder_update_ms` was only set if when a reading was sent. That resulted in calling rangefinder update at the periph loop rate if the sensor is unhealthy or had no new reading. In my case I was testing a serial "request and response" rangefinder and this bug meant we just flooded the uart with requests.