### PR TITLE
AP_HAL_Linux: fix SPIUARTDriver to work with GPS autodetection

### DIFF
--- a/libraries/AP_HAL_Linux/SPIUARTDriver.cpp
+++ b/libraries/AP_HAL_Linux/SPIUARTDriver.cpp
@@ -69,14 +69,17 @@ void SPIUARTDriver::_begin(uint32_t b, uint16_t rxS, uint16_t txS)
                 * it's sage to update speed
                 */
             _dev->set_speed(AP_HAL::Device::SPEED_HIGH);
+            high_speed_set = true;
             debug("Set higher SPI-frequency");
         } else {
             _dev->set_speed(AP_HAL::Device::SPEED_LOW);
+            high_speed_set = false;
             debug("Set lower SPI-frequency");
         }
         break;
     default:
         _dev->set_speed(AP_HAL::Device::SPEED_LOW);
+        high_speed_set = false;
         debug("Set lower SPI-frequency");
         debug("%s: wrong baudrate (%u) for SPI-driven device. setting default speed", __func__, b);
         break;

--- a/libraries/AP_HAL_Linux/SPIUARTDriver.h
+++ b/libraries/AP_HAL_Linux/SPIUARTDriver.h
@@ -11,6 +11,9 @@ public:
     SPIUARTDriver();
     void _begin(uint32_t b, uint16_t rxS, uint16_t txS) override;
     void _timer_tick(void) override;
+    uint32_t get_baud_rate() const override {
+        return high_speed_set ? 4000000U : 1000000U;
+    }
 
 protected:
     int _write_fd(const uint8_t *buf, uint16_t n) override;
@@ -23,6 +26,8 @@ protected:
     uint32_t _last_update_timestamp;
 
     bool _external;
+
+    bool high_speed_set;
 };
 
 }

--- a/libraries/AP_HAL_Linux/UARTDriver.h
+++ b/libraries/AP_HAL_Linux/UARTDriver.h
@@ -56,7 +56,7 @@ public:
 
     uint32_t bw_in_bytes_per_second() const override;
 
-    uint32_t get_baud_rate() const override { return _baudrate; }
+    virtual uint32_t get_baud_rate() const override { return _baudrate; }
 
 private:
     AP_HAL::OwnPtr<SerialDevice> _device;


### PR DESCRIPTION
GPS auto-detection requires get_baud_rate to return non-zero.  The SPIUARTDriver was returning 0.

Tested on NavIO2.

Still something strange going on:
![image](https://github.com/ArduPilot/ardupilot/assets/7077857/62c6b6b1-ae7a-4aea-a319-3f4a12c5c992)

... but it's now working.

Note that the return value doesn't actually matter here, it's just got to be non-zero.
