### PR TITLE
AP_Scripting: add lua-language-server checks and docs generation.

### DIFF
--- a/.github/workflows/test_scripting.yml
+++ b/.github/workflows/test_scripting.yml
@@ -36,6 +36,27 @@ jobs:
           sudo apt-get -y install lua-check
           ./Tools/scripts/run_luacheck.sh
 
+      - name: Setup language server
+        shell: bash
+        run: |
+          sudo apt install -y curl
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          (echo; echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"') >> /github/home/.bashrc
+          source ~/.bashrc
+          brew install lua-language-server
+
+      - name: Generate docs md
+        shell: bash
+        run: |
+          source ~/.bashrc
+          ./Tools/scripts/generate_lua_docs.sh
+
+      - name: Language server check
+        shell: bash
+        run: |
+          source ~/.bashrc
+          python ./Tools/scripts/run_lua_language_check.py
+
       - name: copy docs
         run: |
           PATH="/github/home/.local/bin:$PATH"
@@ -53,3 +74,10 @@ jobs:
         run: |
           PATH="/github/home/.local/bin:$PATH"
           python ./libraries/AP_Scripting/tests/docs_check.py "./libraries/AP_Scripting/docs/docs.lua" "./libraries/AP_Scripting/docs/current_docs.lua"
+
+      - name: Upload docs
+        uses: actions/upload-artifact@v3
+        with:
+          name: Docs
+          path: ScriptingDocs.md
+          retention-days: 7

--- a/.github/workflows/test_scripting.yml
+++ b/.github/workflows/test_scripting.yml
@@ -36,26 +36,16 @@ jobs:
           sudo apt-get -y install lua-check
           ./Tools/scripts/run_luacheck.sh
 
-      - name: Setup language server
+      - name: Language server check
         shell: bash
         run: |
-          sudo apt install -y curl
-          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          (echo; echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"') >> /github/home/.bashrc
-          source ~/.bashrc
-          brew install lua-language-server
+          python -m pip install github-release-downloader
+          python ./Tools/scripts/run_lua_language_check.py
 
       - name: Generate docs md
         shell: bash
         run: |
-          source ~/.bashrc
           ./Tools/scripts/generate_lua_docs.sh
-
-      - name: Language server check
-        shell: bash
-        run: |
-          source ~/.bashrc
-          python ./Tools/scripts/run_lua_language_check.py
 
       - name: copy docs
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -155,6 +155,7 @@ dumpstack_*out
 build.tmp.binaries/
 tasklist.json
 modules/esp_idf
+ScriptingDocs.md
 
 # Ignore Python virtual environments
 #   from: https://github.com/github/gitignore/blob/4488915eec0b3a45b5c63ead28f286819c0917de/Python.gitignore#L125

--- a/.gitignore
+++ b/.gitignore
@@ -155,7 +155,11 @@ dumpstack_*out
 build.tmp.binaries/
 tasklist.json
 modules/esp_idf
+
+# lua-language-server linter
 ScriptingDocs.md
+/lua-language-server/
+repo-LuaLS-lua-language-server.cache
 
 # Ignore Python virtual environments
 #   from: https://github.com/github/gitignore/blob/4488915eec0b3a45b5c63ead28f286819c0917de/Python.gitignore#L125

--- a/Tools/AP_Periph/Web/scripts/pppgw_webui.lua
+++ b/Tools/AP_Periph/Web/scripts/pppgw_webui.lua
@@ -2,6 +2,11 @@
    example script to test lua socket API
 --]]
 
+---@diagnostic disable: param-type-mismatch
+---@diagnostic disable: need-check-nil
+---@diagnostic disable: redundant-parameter
+---@diagnostic disable: undefined-field
+
 PARAM_TABLE_KEY = 47
 PARAM_TABLE_PREFIX = "WEB_"
 

--- a/Tools/scripts/generate_lua_docs.sh
+++ b/Tools/scripts/generate_lua_docs.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Generate md file from lua docs with lua-language-sever
+
+cd "$(dirname "$0")"
+cd ../..
+
+if [ -n "$(ls -A lualogs)" ]; then
+    echo "lualogs Not Empty"
+    exit 1
+fi
+
+# Need to use abs paths due to lua-language-sever bug
+CONFIG_PATH=$(realpath libraries/AP_Scripting/tests/docs.json)
+DOC_PATH=$(realpath libraries/AP_Scripting/docs/)
+
+lua-language-server --configpath ${CONFIG_PATH}  --logpath lualogs --doc ${DOC_PATH}
+
+mv lualogs/doc.md ScriptingDocs.md
+rm -r lualogs

--- a/Tools/scripts/generate_lua_docs.sh
+++ b/Tools/scripts/generate_lua_docs.sh
@@ -9,11 +9,17 @@ if [ -n "$(ls -A lualogs)" ]; then
     exit 1
 fi
 
+if [ -e "lua-language-server/bin/lua-language-server" ]; then
+    LLS_PATH=$(realpath lua-language-server/bin/lua-language-server)
+else
+    LLS_PATH=lua-language-server
+fi
+
 # Need to use abs paths due to lua-language-sever bug
 CONFIG_PATH=$(realpath libraries/AP_Scripting/tests/docs.json)
 DOC_PATH=$(realpath libraries/AP_Scripting/docs/)
 
-lua-language-server --configpath ${CONFIG_PATH}  --logpath lualogs --doc ${DOC_PATH}
+${LLS_PATH} --configpath ${CONFIG_PATH}  --logpath lualogs --doc ${DOC_PATH}
 
 mv lualogs/doc.md ScriptingDocs.md
 rm -r lualogs

--- a/Tools/scripts/run_lua_language_check.py
+++ b/Tools/scripts/run_lua_language_check.py
@@ -1,0 +1,105 @@
+'''
+Reads lua-language-sever check
+
+It generates a json report that this then parses to make it look nicer
+
+AP_FLAKE8_CLEAN
+'''
+
+import optparse
+import sys
+import os
+import pathlib
+import json
+import shutil
+from urllib.parse import unquote
+
+
+def print_failures(file_name, fails):
+    file_name = unquote(file_name)
+    file_path = pathlib.Path(file_name[5:])
+
+    for fail in fails:
+        start = fail['range']['start']
+
+        # These seem to be off by one, not sure why
+        line = start['line'] + 1
+        character = start['character'] + 1
+
+        print("%s:%i:%i" % (file_path, line, character))
+
+        print("\tCode: %s" % fail['code'])
+        message = fail['message'].split("\n")
+        for line in message:
+            print("\t%s" % line)
+
+    print()
+    return len(fails)
+
+
+if __name__ == '__main__':
+
+    parser = optparse.OptionParser(__file__)
+
+    opts, args = parser.parse_args()
+
+    if len(args) > 1:
+        print('Usage: %s "check path"' % parser.usage)
+        sys.exit(0)
+
+    check_path = "./"
+    if len(args) > 0:
+        check_path = args[0]
+
+    if not os.path.exists(check_path):
+        raise Exception("Path invalid: %s" % check_path)
+
+    # Work out full path to config file
+    ap_root = (pathlib.Path(__file__) / "../../../").resolve()
+    setup = (ap_root / "libraries/AP_Scripting/tests/check.json").resolve()
+    logs = (ap_root / "lualogs").resolve()
+    docs = (ap_root / "libraries/AP_Scripting/docs/docs.lua").resolve()
+
+    # Make sure the log directory is empty
+    if os.path.exists(logs) and len(os.listdir(logs)) != 0:
+        raise Exception("lualogs not empty")
+
+    # Can't get the lua-language-server to find docs outside of workspace, so just copy in and then delete
+    docs_check_path = (pathlib.Path(os.getcwd()) / check_path).resolve()
+    if os.path.isfile(docs_check_path):
+        docs_check_path = (docs_check_path / "../").resolve()
+
+    docs_copy = None
+    if not docs.is_relative_to(docs_check_path):
+        docs_copy = (docs_check_path / "docs.lua").resolve()
+
+    if docs_copy is not None:
+        # make copy of docs
+        shutil.copyfile(docs, docs_copy)
+
+    # Run check
+    os.system("lua-language-server --configpath %s --logpath %s --check %s" % (setup, logs, check_path))
+
+    if docs_copy is not None:
+        # remove copy of docs
+        os.remove(docs_copy)
+
+    # Read output
+    errors = 0
+    result = (logs / "check.json").resolve()
+    if os.path.exists(result):
+        # File only created if there are errors
+        f = open((logs / "check.json").resolve())
+        data = json.load(f)
+        f.close()
+
+        # Print output
+        for key, value in data.items():
+            errors += print_failures(key, value)
+
+    # Remove output
+    shutil.rmtree(logs)
+
+    # Rase error if detected
+    if errors != 0:
+        raise Exception("Detected %i errors" % errors)

--- a/libraries/AP_Scripting/applets/Aerobatics/FixedWing/RateBased/sport_aerobatics.lua
+++ b/libraries/AP_Scripting/applets/Aerobatics/FixedWing/RateBased/sport_aerobatics.lua
@@ -6,6 +6,10 @@ cmd = 4: knife edge at any angle, arg1 = roll angle to hold, arg2 = duration
 cmd = 5: pause, holding heading and alt to allow stabilization after a move, arg1 = duration in seconds
 ]]--
 -- luacheck: only 0
+---@diagnostic disable: param-type-mismatch
+---@diagnostic disable: need-check-nil
+---@diagnostic disable: cast-local-type
+---@diagnostic disable: undefined-global
 
 DO_JUMP = 177
 k_throttle = 70

--- a/libraries/AP_Scripting/applets/Aerobatics/FixedWing/plane_aerobatics.lua
+++ b/libraries/AP_Scripting/applets/Aerobatics/FixedWing/plane_aerobatics.lua
@@ -5,6 +5,13 @@
    assistance from Paul Riseborough, testing by Henry Wurzburg
 ]]--
 -- luacheck: ignore 212 (Unused argument)
+---@diagnostic disable: param-type-mismatch
+---@diagnostic disable: undefined-field
+---@diagnostic disable: missing-parameter
+---@diagnostic disable: cast-local-type
+---@diagnostic disable: need-check-nil
+---@diagnostic disable: undefined-global
+---@diagnostic disable: inject-field
 
 -- setup param block for aerobatics, reserving 35 params beginning with AERO_
 local PARAM_TABLE_KEY = 70

--- a/libraries/AP_Scripting/applets/BattEstimate.lua
+++ b/libraries/AP_Scripting/applets/BattEstimate.lua
@@ -4,6 +4,9 @@
    See Tools/scripts/battery_fit.py for a tool to calculate the coefficients from a log
 --]]
 
+---@diagnostic disable: param-type-mismatch
+---@diagnostic disable: cast-local-type
+
 local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
 
 local PARAM_TABLE_KEY = 14

--- a/libraries/AP_Scripting/applets/Heli_IM_COL_Tune.lua
+++ b/libraries/AP_Scripting/applets/Heli_IM_COL_Tune.lua
@@ -5,6 +5,7 @@
 -- the value of the 50% point on the curve.  This can be used to set the collective position to aid with hovering 
 -- at the midstick.
 -- luacheck: only 0
+---@diagnostic disable: cast-local-type
 
 -- Tested and working as of 25th Aug 2020 (Copter Dev)
 

--- a/libraries/AP_Scripting/applets/Heli_idle_control.lua
+++ b/libraries/AP_Scripting/applets/Heli_idle_control.lua
@@ -1,4 +1,6 @@
 -- idle_control.lua: a closed loop control throttle control while on ground idle (trad-heli)
+---@diagnostic disable: param-type-mismatch
+---@diagnostic disable: need-check-nil
 
 local PARAM_TABLE_KEY = 73
 local PARAM_TABLE_PREFIX = 'IDLE_'

--- a/libraries/AP_Scripting/applets/MissionSelector.lua
+++ b/libraries/AP_Scripting/applets/MissionSelector.lua
@@ -3,6 +3,8 @@
 -- but also on the disarm to arm transition, it will load (if file exists) a file in the root named
 -- missionH.txt, missionM.txt, or missionH.txt corresponding to the the Mission Reset switch position of High/Mid/Low
 -- luacheck: only 0
+---@diagnostic disable: need-check-nil
+
 
 local mission_loaded = false
 local rc_switch = rc:find_channel_for_option(24)  --AUX FUNC sw for mission restart

--- a/libraries/AP_Scripting/applets/RockBlock.lua
+++ b/libraries/AP_Scripting/applets/RockBlock.lua
@@ -24,12 +24,14 @@ The param SCR_VM_I_COUNT may need to be increased in some circumstances
 Written by Stephen Dade (stephen_dade@hotmail.com)
 ]]--
 
+---@diagnostic disable: cast-local-type
+
 local PARAM_TABLE_KEY = 10
 local PARAM_TABLE_PREFIX = "RCK_"
 
 local port = serial:find_serial(0)
 
-if not port or baud == 0 then
+if not port then
     gcs:send_text(0, "Rockblock: No Scripting Serial Port")
     return
 end

--- a/libraries/AP_Scripting/applets/Script_Controller.lua
+++ b/libraries/AP_Scripting/applets/Script_Controller.lua
@@ -3,6 +3,8 @@
     /1 /2 or /3 subdirectories of the scripts directory
 --]]
 -- luacheck: only 0
+---@diagnostic disable: param-type-mismatch
+
 
 local THIS_SCRIPT = "Script_Controller.lua"
 local sel_ch = Parameter("SCR_USER6")

--- a/libraries/AP_Scripting/applets/SmartAudio.lua
+++ b/libraries/AP_Scripting/applets/SmartAudio.lua
@@ -20,6 +20,9 @@
 ---------and set to -1 for unchanged, 0 (PitMode),1,2,3, or 4 for power level (1 lowest,4 maximum)
 -- 3. Attach the UART's TX for the Serial port chosen above to the VTX's SmartAudio input
 
+---@diagnostic disable: need-check-nil
+
+
 -- init local variables
 local startup_pwr = param:get('SCR_USER1') 
 local scripting_rc = rc:find_channel_for_option(300)

--- a/libraries/AP_Scripting/applets/VTOL-quicktune.lua
+++ b/libraries/AP_Scripting/applets/VTOL-quicktune.lua
@@ -6,6 +6,9 @@
 
 --]]
 
+---@diagnostic disable: param-type-mismatch
+---@diagnostic disable: need-check-nil
+---@diagnostic disable: missing-parameter
 
 --[[
  - TODO:

--- a/libraries/AP_Scripting/applets/copter-deadreckon-home.lua
+++ b/libraries/AP_Scripting/applets/copter-deadreckon-home.lua
@@ -56,6 +56,9 @@
 --   b. SIM_WIND_SPD <-- sets wind speed in m/s
 --
 
+---@diagnostic disable: param-type-mismatch
+---@diagnostic disable: cast-local-type
+
 -- create and initialise parameters
 local PARAM_TABLE_KEY = 86  -- parameter table key must be used by only one script on a particular flight controller
 assert(param:add_table(PARAM_TABLE_KEY, "DR_", 9), 'could not add param table')

--- a/libraries/AP_Scripting/applets/forward_flight_motor_shutdown.lua
+++ b/libraries/AP_Scripting/applets/forward_flight_motor_shutdown.lua
@@ -5,6 +5,8 @@
 -- slew up and down times allow to configure how fast the motors are disabled and re-enabled
 
 -- luacheck: only 0
+---@diagnostic disable: cast-local-type
+
 
 -- Config
 

--- a/libraries/AP_Scripting/applets/leds_on_a_switch.lua
+++ b/libraries/AP_Scripting/applets/leds_on_a_switch.lua
@@ -1,6 +1,8 @@
 -- leds_on_a_switch.lua: control led brightness with a radio switch
 --
 
+---@diagnostic disable: cast-local-type
+
 -- constants
 local AuxSwitchPos = {LOW=0, MIDDLE=1, HIGH=2}
 local NTF_LED_BRIGHT = Parameter("NTF_LED_BRIGHT")

--- a/libraries/AP_Scripting/applets/mount-poi.lua
+++ b/libraries/AP_Scripting/applets/mount-poi.lua
@@ -19,6 +19,10 @@
 --  10. interpolate between test_loc and prev_test_loc to find the lat, lon, alt (above sea-level) where alt-above-terrain is zero
 --  11. display the POI to the user
 
+---@diagnostic disable: param-type-mismatch
+---@diagnostic disable: cast-local-type
+---@diagnostic disable: missing-parameter
+
 -- global definitions
 local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
 local ALT_FRAME_ABSOLUTE = 0

--- a/libraries/AP_Scripting/applets/net_webserver.lua
+++ b/libraries/AP_Scripting/applets/net_webserver.lua
@@ -1,6 +1,10 @@
 --[[
    example script to test lua socket API
 --]]
+---@diagnostic disable: param-type-mismatch
+---@diagnostic disable: undefined-field
+---@diagnostic disable: need-check-nil
+---@diagnostic disable: redundant-parameter
 
 local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
 

--- a/libraries/AP_Scripting/applets/plane_package_place.lua
+++ b/libraries/AP_Scripting/applets/plane_package_place.lua
@@ -2,6 +2,7 @@
  support package place for quadplanes
 --]]
 -- luacheck: only 0
+---@diagnostic disable: param-type-mismatch
 
 
 local PARAM_TABLE_KEY = 9

--- a/libraries/AP_Scripting/applets/plane_precland.lua
+++ b/libraries/AP_Scripting/applets/plane_precland.lua
@@ -5,6 +5,8 @@
  for development of a custom solution
 --]]
 
+---@diagnostic disable: param-type-mismatch
+
 local PARAM_TABLE_KEY = 12
 local PARAM_TABLE_PREFIX = "PLND_"
 

--- a/libraries/AP_Scripting/applets/plane_ship_landing.lua
+++ b/libraries/AP_Scripting/applets/plane_ship_landing.lua
@@ -4,6 +4,10 @@
  See this post for details: https://discuss.ardupilot.org/t/ship-landing-support
 --]]
 
+---@diagnostic disable: param-type-mismatch
+---@diagnostic disable: cast-local-type
+---@diagnostic disable: need-check-nil
+
 local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
 
 local PARAM_TABLE_KEY = 7

--- a/libraries/AP_Scripting/applets/revert_param.lua
+++ b/libraries/AP_Scripting/applets/revert_param.lua
@@ -2,6 +2,10 @@
    parameter reversion utility. This helps with manual tuning
    in-flight by giving a way to instantly revert parameters to the startup parameters
 --]]
+
+---@diagnostic disable: param-type-mismatch
+
+
 local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
 
 local PARAM_TABLE_KEY = 31

--- a/libraries/AP_Scripting/applets/rover-quicktune.lua
+++ b/libraries/AP_Scripting/applets/rover-quicktune.lua
@@ -18,6 +18,9 @@ See the accompanying rover-quiktune.md file for instructions on how to use
 
 --]]
 
+---@diagnostic disable: param-type-mismatch
+---@diagnostic disable: need-check-nil
+
 -- global definitions
 local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
 

--- a/libraries/AP_Scripting/applets/winch-control.lua
+++ b/libraries/AP_Scripting/applets/winch-control.lua
@@ -10,6 +10,9 @@
 -- Alternatively Mission Planner's Aux Function screen can be used in place of an actual RC switch
 --
 
+---@diagnostic disable: param-type-mismatch
+
+
 -- global definitions
 local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
 local PARAM_TABLE_KEY = 80

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1,3 +1,4 @@
+---@meta
 -- ArduPilot lua scripting documentation in EmmyLua Annotations
 -- This file should be auto generated and then manual edited
 -- generate with --scripting-docs, eg  ./waf copter --scripting-docs
@@ -6,18 +7,32 @@
 -- luacheck: ignore 122 (Setting a read-only field of a global variable)
 -- luacheck: ignore 212 (Unused argument)
 -- luacheck: ignore 241 (Local variable is mutated but never accessed)
+-- luacheck: ignore 221 (Local variable is accessed but never set.)
 
 -- set and get for field types share function names
 ---@diagnostic disable: duplicate-set-field
 ---@diagnostic disable: missing-return
 
+-- integer enum value unknown by docs generator
+---@type integer
+local enum_integer
+
 -- manual bindings
 
----@class uint32_t_ud
+---@class (exact) uint32_t_ud
+---@operator add(uint32_t_ud|integer|number): uint32_t_ud
+---@operator sub(uint32_t_ud|integer|number): uint32_t_ud
+---@operator mul(uint32_t_ud|integer|number): uint32_t_ud
+---@operator div(uint32_t_ud|integer|number): uint32_t_ud
+---@operator mod(uint32_t_ud|integer|number): uint32_t_ud
+---@operator band(uint32_t_ud|integer|number): uint32_t_ud
+---@operator bor(uint32_t_ud|integer|number): uint32_t_ud
+---@operator shl(uint32_t_ud|integer|number): uint32_t_ud
+---@operator shr(uint32_t_ud|integer|number): uint32_t_ud
 local uint32_t_ud = {}
 
 -- create uint32_t_ud with optional value
----@param value? number|integer
+---@param value? uint32_t_ud|integer|number
 ---@return uint32_t_ud
 function uint32_t(value) end
 
@@ -52,7 +67,6 @@ function mission_receive() end
 function print(text) end
 
 -- data flash logging to SD card
----@class logger
 logger = {}
 
 -- write value to data flash log with given types and names, optional units and multipliers, timestamp will be automatically added
@@ -69,19 +83,18 @@ function logger:write(name, labels, format, units, multipliers, data1, ...) end
 function logger:log_file_content(filename) end
 
 -- i2c bus interaction
----@class i2c
 i2c = {}
 
 -- get a i2c device handler
 ---@param bus integer -- bus number
 ---@param address integer -- device address 0 to 128
----@param clock? uint32_t_ud -- optional bus clock, default 400000
+---@param clock? uint32_t_ud|integer|number -- optional bus clock, default 400000
 ---@param smbus? boolean -- optional sumbus flag, default false
 ---@return AP_HAL__I2CDevice_ud|nil
 function i2c:get_device(bus, address, clock, smbus) end
 
 -- EFI state structure
----@class EFI_State_ud
+---@class (exact) EFI_State_ud
 local EFI_State_ud = {}
 
 ---@return EFI_State_ud
@@ -236,7 +249,7 @@ function EFI_State_ud:spark_dwell_time_ms(value) end
 function EFI_State_ud:engine_speed_rpm() end
 
 -- set field
----@param value uint32_t_ud
+---@param value uint32_t_ud|integer|number
 function EFI_State_ud:engine_speed_rpm(value) end
 
 -- get field
@@ -260,12 +273,12 @@ function EFI_State_ud:general_error(value) end
 function EFI_State_ud:last_updated_ms() end
 
 -- set field
----@param value uint32_t_ud
+---@param value uint32_t_ud|integer|number
 function EFI_State_ud:last_updated_ms(value) end
 
 
 -- EFI Cylinder_Status structure
----@class Cylinder_Status_ud
+---@class (exact) Cylinder_Status_ud
 local Cylinder_Status_ud = {}
 
 ---@return Cylinder_Status_ud
@@ -328,7 +341,6 @@ function Cylinder_Status_ud:ignition_timing_deg() end
 function Cylinder_Status_ud:ignition_timing_deg(value) end
 
 -- desc
----@class efi
 efi = {}
 
 -- desc
@@ -341,23 +353,22 @@ function efi:get_state() end
 function efi:get_backend(instance) end
 
 -- CAN bus interaction
----@class CAN
 CAN = {}
 
 -- get a CAN bus device handler first scripting driver, will return nil if no driver with protocol Scripting is configured
----@param buffer_len uint32_t_ud -- buffer length 1 to 25
+---@param buffer_len uint32_t_ud|integer|number -- buffer length 1 to 25
 ---@return ScriptingCANBuffer_ud|nil
 function CAN:get_device(buffer_len) end
 
 -- get a CAN bus device handler second scripting driver, will return nil if no driver with protocol Scripting2 is configured
----@param buffer_len uint32_t_ud -- buffer length 1 to 25
+---@param buffer_len uint32_t_ud|integer|number -- buffer length 1 to 25
 ---@return ScriptingCANBuffer_ud|nil
 function CAN:get_device2(buffer_len) end
 
 -- Auto generated binding
 
 -- desc
----@class CANFrame_ud
+---@class (exact) CANFrame_ud
 local CANFrame_ud = {}
 
 ---@return CANFrame_ud
@@ -386,7 +397,7 @@ function CANFrame_ud:data(index, value) end
 function CANFrame_ud:id() end
 
 -- set field
----@param value uint32_t_ud
+---@param value uint32_t_ud|integer|number
 function CANFrame_ud:id(value) end
 
 -- desc
@@ -406,7 +417,7 @@ function CANFrame_ud:isExtended() end
 function CANFrame_ud:id_signed() end
 
 -- desc
----@class motor_factor_table_ud
+---@class (exact) motor_factor_table_ud
 local motor_factor_table_ud = {}
 
 ---@return motor_factor_table_ud
@@ -453,7 +464,7 @@ function motor_factor_table_ud:roll(index) end
 function motor_factor_table_ud:roll(index, value) end
 
 -- network socket class
----@class SocketAPM_ud
+---@class (exact) SocketAPM_ud
 local SocketAPM_ud = {}
 
 -- Get a new socket
@@ -477,7 +488,7 @@ function SocketAPM_ud:listen(backlog) end
 
 -- send a lua string. May contain binary data
 ---@param str string
----@param len uint32_t_ud
+---@param len uint32_t_ud|integer|number
 ---@return integer
 function SocketAPM_ud:send(str, len) end
 
@@ -505,12 +516,12 @@ function SocketAPM_ud:accept() end
 function SocketAPM_ud:recv(length) end
 
 -- check for available input
----@param timeout_ms uint32_t_ud
+---@param timeout_ms uint32_t_ud|integer|number
 ---@return boolean
 function SocketAPM_ud:pollin(timeout_ms) end
 
 -- check for availability of space to write to socket
----@param timeout_ms uint32_t_ud
+---@param timeout_ms uint32_t_ud|integer|number
 ---@return boolean
 function SocketAPM_ud:pollout(timeout_ms) end
 
@@ -535,7 +546,7 @@ function SocketAPM_ud:sendfile(filehandle) end
 function SocketAPM_ud:reuseaddress() end
 
 -- desc
----@class AP_HAL__PWMSource_ud
+---@class (exact) AP_HAL__PWMSource_ud
 local AP_HAL__PWMSource_ud = {}
 
 ---@return AP_HAL__PWMSource_ud
@@ -556,7 +567,7 @@ function AP_HAL__PWMSource_ud:set_pin(pin_number) end
 
 
 -- desc
----@class mavlink_mission_item_int_t_ud
+---@class (exact) mavlink_mission_item_int_t_ud
 local mavlink_mission_item_int_t_ud = {}
 
 ---@return mavlink_mission_item_int_t_ud
@@ -652,7 +663,7 @@ function mavlink_mission_item_int_t_ud:param1(value) end
 
 
 -- desc
----@class Parameter_ud
+---@class (exact) Parameter_ud
 local Parameter_ud = {}
 
 ---@return Parameter_ud
@@ -684,7 +695,7 @@ function Parameter_ud:get() end
 
 -- desc
 ---@param key integer
----@param group_element uint32_t_ud
+---@param group_element uint32_t_ud|integer|number
 ---@param type integer
 ---| '1' # AP_PARAM_INT8
 ---| '2' # AP_PARAM_INT16
@@ -700,7 +711,9 @@ function Parameter_ud:init(name) end
 
 
 -- desc
----@class Vector2f_ud
+---@class (exact) Vector2f_ud
+---@operator add(Vector2f_ud): Vector2f_ud
+---@operator sub(Vector2f_ud): Vector2f_ud
 local Vector2f_ud = {}
 
 ---@return Vector2f_ud
@@ -754,7 +767,9 @@ function Vector2f_ud:length() end
 function Vector2f_ud:angle() end
 
 -- desc
----@class Vector3f_ud
+---@class (exact) Vector3f_ud
+---@operator add(Vector3f_ud): Vector3f_ud
+---@operator sub(Vector3f_ud): Vector3f_ud
 local Vector3f_ud = {}
 
 ---@return Vector3f_ud
@@ -836,7 +851,8 @@ function Vector3f_ud:rotate_xy(param1) end
 function Vector3f_ud:xy() end
 
 -- desc
----@class Quaternion_ud
+---@class (exact) Quaternion_ud
+---@operator mul(Quaternion_ud): Quaternion_ud
 local Quaternion_ud = {}
 
 ---@return Quaternion_ud
@@ -922,7 +938,7 @@ function Quaternion_ud:normalize() end
 function Quaternion_ud:length() end
 
 -- desc
----@class Location_ud
+---@class (exact) Location_ud
 local Location_ud = {}
 
 ---@return Location_ud
@@ -1046,7 +1062,7 @@ function Location_ud:offset(ofs_north, ofs_east) end
 function Location_ud:get_distance(loc) end
 
 -- desc
----@class AP_EFI_Backend_ud
+---@class (exact) AP_EFI_Backend_ud
 local AP_EFI_Backend_ud = {}
 
 -- desc
@@ -1055,7 +1071,7 @@ local AP_EFI_Backend_ud = {}
 function AP_EFI_Backend_ud:handle_scripting(state) end
 
 -- desc
----@class ScriptingCANBuffer_ud
+---@class (exact) ScriptingCANBuffer_ud
 local ScriptingCANBuffer_ud = {}
 
 -- desc
@@ -1065,20 +1081,20 @@ function ScriptingCANBuffer_ud:read_frame() end
 -- Add a filter to the CAN buffer, mask is bitwise ANDed with the frame id and compared to value if not match frame is not buffered
 -- By default no filters are added and all frames are buffered, write is not affected by filters
 -- Maximum number of filters is 8
----@param mask uint32_t_ud
----@param value uint32_t_ud
+---@param mask uint32_t_ud|integer|number
+---@param value uint32_t_ud|integer|number
 ---@return boolean -- returns true if the filler was added successfully
 function ScriptingCANBuffer_ud:add_filter(mask, value) end
 
 -- desc
 ---@param frame CANFrame_ud
----@param timeout_us uint32_t_ud
+---@param timeout_us uint32_t_ud|integer|number
 ---@return boolean
 function ScriptingCANBuffer_ud:write_frame(frame, timeout_us) end
 
 
 -- desc
----@class AP_HAL__AnalogSource_ud
+---@class (exact) AP_HAL__AnalogSource_ud
 local AP_HAL__AnalogSource_ud = {}
 
 -- desc
@@ -1100,7 +1116,7 @@ function AP_HAL__AnalogSource_ud:set_pin(pin_number) end
 
 
 -- desc
----@class AP_HAL__I2CDevice_ud
+---@class (exact) AP_HAL__I2CDevice_ud
 local AP_HAL__I2CDevice_ud = {}
 
 -- desc
@@ -1126,7 +1142,7 @@ function AP_HAL__I2CDevice_ud:set_retries(retries) end
 
 
 -- desc
----@class AP_HAL__UARTDriver_ud
+---@class (exact) AP_HAL__UARTDriver_ud
 local AP_HAL__UARTDriver_ud = {}
 
 -- desc
@@ -1150,7 +1166,7 @@ function AP_HAL__UARTDriver_ud:write(value) end
 function AP_HAL__UARTDriver_ud:read() end
 
 -- desc
----@param baud_rate uint32_t_ud
+---@param baud_rate uint32_t_ud|integer|number
 function AP_HAL__UARTDriver_ud:begin(baud_rate) end
 
 --[[
@@ -1163,7 +1179,7 @@ function AP_HAL__UARTDriver_ud:readstring(count) end
 
 
 -- desc
----@class RC_Channel_ud
+---@class (exact) RC_Channel_ud
 local RC_Channel_ud = {}
 
 -- desc
@@ -1187,7 +1203,6 @@ function RC_Channel_ud:norm_input() end
 function RC_Channel_ud:norm_input_dz() end
 
 -- desc
----@class winch
 winch = {}
 
 -- desc
@@ -1210,7 +1225,6 @@ function winch:relax() end
 function winch:healthy() end
 
 -- desc
----@class iomcu
 iomcu = {}
 
 -- Check if the IO is healthy
@@ -1218,7 +1232,6 @@ iomcu = {}
 function iomcu:healthy() end
 
 -- desc
----@class compass
 compass = {}
 
 -- Check if the compass is healthy
@@ -1227,7 +1240,6 @@ compass = {}
 function compass:healthy(instance) end
 
 -- desc
----@class camera
 camera = {}
 
 -- desc
@@ -1246,7 +1258,7 @@ function camera:record_video(instance, start_recording) end
 function camera:take_picture(instance) end
 
 -- desc
----@class AP_Camera__camera_state_t_ud
+---@class (exact) AP_Camera__camera_state_t_ud
 local AP_Camera__camera_state_t_ud = {}
 
 ---@return AP_Camera__camera_state_t_ud
@@ -1294,7 +1306,6 @@ function AP_Camera__camera_state_t_ud:take_pic_incr() end
 function camera:get_state(instance) end
 
 -- desc
----@class mount
 mount = {}
 
 -- desc
@@ -1364,7 +1375,6 @@ function mount:get_mode(instance) end
 function mount:get_attitude_euler(instance) end
 
 -- desc
----@class motors
 motors = {}
 
 -- Get motors interlock state, the state of motors controlled by AP_Motors, Copter and Quadplane VTOL motors. Not plane forward flight motors.
@@ -1435,7 +1445,6 @@ function motors:get_roll_ff() end
 function motors:get_roll() end
 
 -- desc
----@class FWVersion
 FWVersion = {}
 
 -- get field
@@ -1472,7 +1481,6 @@ function FWVersion:string() end
 
 
 -- desc
----@class periph
 periph = {}
 
 -- desc
@@ -1492,7 +1500,6 @@ function periph:can_printf(text) end
 function periph:reboot(hold_in_bootloader) end
 
 -- desc
----@class ins
 ins = {}
 
 -- desc
@@ -1535,7 +1542,6 @@ function ins:get_gyro(instance) end
 function ins:get_accel(instance) end
 
 -- desc
----@class Motors_dynamic
 Motors_dynamic = {}
 
 -- desc
@@ -1554,7 +1560,6 @@ function Motors_dynamic:init(expected_num_motors) end
 
 
 -- desc
----@class analog
 analog = {}
 
 -- desc
@@ -1563,7 +1568,6 @@ function analog:channel() end
 
 
 -- Control of general purpose input/output pins
----@class gpio
 gpio = {}
 
 -- set GPIO pin mode
@@ -1591,7 +1595,6 @@ function gpio:read(pin_number) end
 
 
 -- desc
----@class Motors_6DoF
 Motors_6DoF = {}
 
 -- desc
@@ -1613,7 +1616,6 @@ function Motors_6DoF:init(expected_num_motors) end
 
 
 -- desc
----@class attitude_control
 attitude_control = {}
 
 -- desc
@@ -1631,7 +1633,6 @@ function attitude_control:set_lateral_enable(bool) end
 
 
 -- desc
----@class frsky_sport
 frsky_sport = {}
 
 -- desc
@@ -1651,7 +1652,6 @@ function frsky_sport:sport_telemetry_push(sensor, frame, appid, data) end
 
 
 -- desc
----@class MotorsMatrix
 MotorsMatrix = {}
 
 -- desc
@@ -1683,7 +1683,6 @@ function MotorsMatrix:get_thrust_boost() end
 
 
 -- Sub singleton
----@class sub
 sub = {}
 
 -- Return true if joystick button is currently pressed
@@ -1711,7 +1710,6 @@ function sub:set_rangefinder_target_cm(new_target_cm) end
 
 
 -- desc
----@class quadplane
 quadplane = {}
 
 -- desc
@@ -1732,7 +1730,6 @@ function quadplane:abort_landing() end
 
 
 -- desc
----@class LED
 LED = {}
 
 -- desc
@@ -1743,7 +1740,6 @@ function LED:get_rgb() end
 
 
 -- desc
----@class button
 button = {}
 
 -- desc
@@ -1753,7 +1749,6 @@ function button:get_button_state(button_number) end
 
 
 -- desc
----@class RPM
 RPM = {}
 
 -- desc
@@ -1763,11 +1758,10 @@ function RPM:get_rpm(instance) end
 
 
 -- desc
----@class mission
----@field MISSION_COMPLETE number
----@field MISSION_RUNNING number
----@field MISSION_STOPPED number
 mission = {}
+mission.MISSION_COMPLETE = enum_integer
+mission.MISSION_RUNNING = enum_integer
+mission.MISSION_STOPPED = enum_integer
 
 -- clear - clears out mission
 ---@return boolean
@@ -1853,7 +1847,6 @@ function mission:jump_to_landing_sequence() end
 function mission:jump_to_abort_landing_sequence() end
 
 -- desc
----@class param
 param = {}
 
 -- desc
@@ -1895,7 +1888,7 @@ function param:add_table(table_key, prefix, num_params) end
 function param:add_param(table_key, param_num, name, default_value) end
 
 -- desc
----@class ESCTelemetryData_ud
+---@class (exact) ESCTelemetryData_ud
 local ESCTelemetryData_ud = {}
 
 ---@return ESCTelemetryData_ud
@@ -1922,7 +1915,6 @@ function ESCTelemetryData_ud:voltage(value) end
 function ESCTelemetryData_ud:temperature_cdeg(value) end
 
 -- desc
----@class esc_telem
 esc_telem = {}
 
 -- update telemetry data for an ESC instance
@@ -1978,7 +1970,6 @@ function esc_telem:update_rpm(esc_index, rpm, error_rate) end
 function esc_telem:set_rpm_scale(esc_index, scale_factor) end
 
 -- desc
----@class optical_flow
 optical_flow = {}
 
 -- desc
@@ -1995,7 +1986,6 @@ function optical_flow:enabled() end
 
 
 -- desc
----@class baro
 baro = {}
 
 -- desc
@@ -2022,7 +2012,6 @@ function baro:healthy(instance) end
 
 
 -- desc
----@class serial
 serial = {}
 
 -- Returns the UART instance that allows connections from scripts (those with SERIALx_PROTOCOL = 28`).
@@ -2034,7 +2023,6 @@ function serial:find_serial(instance) end
 
 
 -- desc
----@class rc
 rc = {}
 
 -- desc
@@ -2072,7 +2060,6 @@ function rc:get_pwm(chan_num) end
 
 
 -- desc
----@class SRV_Channels
 SRV_Channels = {}
 
 -- Get emergency stop state if active no motors of any kind will be active
@@ -2140,7 +2127,6 @@ function SRV_Channels:find_channel(function_num) end
 
 
 -- desc
----@class serialLED
 serialLED = {}
 
 -- desc
@@ -2176,7 +2162,6 @@ function serialLED:set_num_neopixel(chan, num_leds) end
 function serialLED:set_num_neopixel_rgb(chan, num_leds) end
 
 -- desc
----@class vehicle
 vehicle = {}
 
 -- override landing descent rate, times out in 1s
@@ -2393,7 +2378,6 @@ function vehicle:is_taking_off() end
 function vehicle:is_landing() end
 
 -- desc
----@class onvif
 onvif = {}
 
 -- desc
@@ -2420,7 +2404,6 @@ function onvif:start(username, password, httphostname) end
 
 
 -- MAVLink interaction with ground control station
----@class gcs
 gcs = {}
 
 -- send named float value using NAMED_VALUE_FLOAT message
@@ -2430,7 +2413,7 @@ function gcs:send_named_float(name, value) end
 
 -- set message interval for a given serial port and message id
 ---@param port_num integer -- serial port number
----@param msg_id uint32_t_ud -- MAVLink message id
+---@param msg_id uint32_t_ud|integer|number -- MAVLink message id
 ---@param interval_us integer -- interval in micro seconds
 ---@return integer
 ---| '0' # Accepted
@@ -2515,7 +2498,6 @@ function gcs:send_text(severity, text) end
 function gcs:last_seen() end
 
 -- desc
----@class relay
 relay = {}
 
 -- desc
@@ -2542,11 +2524,10 @@ function relay:on(instance) end
 
 
 -- desc
----@class terrain
----@field TerrainStatusOK number
----@field TerrainStatusUnhealthy number
----@field TerrainStatusDisabled number
 terrain = {}
+terrain.TerrainStatusOK = enum_integer
+terrain.TerrainStatusUnhealthy = enum_integer
+terrain.TerrainStatusDisabled = enum_integer
 
 -- desc
 ---@param extrapolate boolean
@@ -2574,7 +2555,7 @@ function terrain:enabled() end
 
 
 -- RangeFinder state structure
----@class RangeFinder_State_ud
+---@class (exact) RangeFinder_State_ud
 local RangeFinder_State_ud = {}
 
 ---@return RangeFinder_State_ud
@@ -2585,7 +2566,7 @@ function RangeFinder_State() end
 function RangeFinder_State_ud:last_reading() end
 
 -- set system time (ms) of last successful update from sensor
----@param value uint32_t_ud
+---@param value uint32_t_ud|integer|number
 function RangeFinder_State_ud:last_reading(value) end
 
 -- get sensor status
@@ -2630,7 +2611,7 @@ function RangeFinder_State_ud:voltage(value) end
 
 
 -- RangeFinder backend
----@class AP_RangeFinder_Backend_ud
+---@class (exact) AP_RangeFinder_Backend_ud
 local AP_RangeFinder_Backend_ud = {}
 
 -- Send range finder measurement to lua rangefinder backend. Returns false if failed
@@ -2664,7 +2645,6 @@ function AP_RangeFinder_Backend_ud:get_state() end
 
 
 -- desc
----@class rangefinder
 rangefinder = {}
 
 -- get backend based on rangefinder instance provided
@@ -2722,7 +2702,7 @@ function rangefinder:has_orientation(orientation) end
 function rangefinder:num_sensors() end
 
 -- Proximity backend methods
----@class AP_Proximity_Backend_ud
+---@class (exact) AP_Proximity_Backend_ud
 local AP_Proximity_Backend_ud = {}
 
 -- Push virtual proximity boundary into actual boundary
@@ -2754,7 +2734,6 @@ function AP_Proximity_Backend_ud:handle_script_3d_msg(vector_3d, update_boundary
 function AP_Proximity_Backend_ud:handle_script_distance_msg(dist_m, yaw_deg, pitch_deg, update_boundary) end
 
 -- desc
----@class proximity
 proximity = {}
 
 -- get backend based on proximity instance provided
@@ -2787,7 +2766,6 @@ function proximity:get_status() end
 
 
 -- desc
----@class notify
 notify = {}
 
 -- desc
@@ -2818,15 +2796,14 @@ function notify:send_text(text, row) end
 function notify:release_text(row) end
 
 -- desc
----@class gps
----@field GPS_OK_FIX_3D_RTK_FIXED number
----@field GPS_OK_FIX_3D_RTK_FLOAT number
----@field GPS_OK_FIX_3D_DGPS number
----@field GPS_OK_FIX_3D number
----@field GPS_OK_FIX_2D number
----@field NO_FIX number
----@field NO_GPS number
 gps = {}
+--gps.GPS_OK_FIX_3D_RTK_FIXED = enum_integer
+--gps.GPS_OK_FIX_3D_RTK_FLOAT = enum_integer
+--gps.GPS_OK_FIX_3D_DGPS = enum_integer
+--gps.GPS_OK_FIX_3D = enum_integer
+--gps.GPS_OK_FIX_2D = enum_integer
+--gps.NO_FIX = enum_integer
+--gps.NO_GPS = enum_integer
 
 -- desc
 ---@return integer|nil
@@ -2926,7 +2903,7 @@ function gps:primary_sensor() end
 function gps:num_sensors() end
 
 -- desc
----@class BattMonitorScript_State_ud
+---@class (exact) BattMonitorScript_State_ud
 local BattMonitorScript_State_ud = {}
 
 ---@return BattMonitorScript_State_ud
@@ -2974,7 +2951,6 @@ function BattMonitorScript_State_ud:voltage(value) end
 function BattMonitorScript_State_ud:healthy(value) end
 
 -- desc
----@class battery
 battery = {}
 
 -- desc
@@ -3060,7 +3036,6 @@ function battery:get_cell_voltage(instance, cell) end
 
 
 -- desc
----@class arming
 arming = {}
 
 -- desc
@@ -3094,7 +3069,6 @@ function arming:disarm() end
 
 
 -- desc
----@class ahrs
 ahrs = {}
 
 -- desc
@@ -3244,7 +3218,6 @@ function ahrs:get_pitch() end
 function ahrs:get_roll() end
 
 -- desc
----@class AC_AttitudeControl
 AC_AttitudeControl = {}
 
 -- return slew rates for VTOL controller
@@ -3254,7 +3227,6 @@ AC_AttitudeControl = {}
 function AC_AttitudeControl:get_rpy_srate() end
 
 -- desc
----@class AR_AttitudeControl
 AR_AttitudeControl = {}
 
 -- return attitude controller slew rates for rovers
@@ -3263,7 +3235,6 @@ AR_AttitudeControl = {}
 function AR_AttitudeControl:get_srate() end
 
 -- desc
----@class AR_PosControl
 AR_PosControl = {}
 
 -- return position controller slew rates for rovers
@@ -3271,7 +3242,6 @@ AR_PosControl = {}
 function AR_PosControl:get_srate() end
 
 -- precision landing access
----@class precland
 precland = {}
 
 -- get Location of target or nil if target not acquired
@@ -3295,7 +3265,6 @@ function precland:target_acquired() end
 function precland:healthy() end
 
 -- desc
----@class follow
 follow = {}
 
 -- desc
@@ -3321,7 +3290,6 @@ function follow:get_last_update_ms() end
 function follow:have_target() end
 
 -- desc
----@class scripting
 scripting = {}
 
 -- desc
@@ -3341,12 +3309,11 @@ function dirlist(directoryname) end
 function remove(filename) end
 
 -- desc
----@class mavlink
 mavlink = {}
 
 -- initializes mavlink
----@param num_rx_msgid uint32_t_ud|integer
----@param msg_queue_length uint32_t_ud|integer
+---@param num_rx_msgid uint32_t_ud|integer|number
+---@param msg_queue_length uint32_t_ud|integer|number
 function mavlink:init(num_rx_msgid, msg_queue_length) end
 
 -- marks mavlink message for receive, message id can be get using mavlink_msgs.get_msgid("MSG_NAME")
@@ -3374,7 +3341,6 @@ function mavlink:send_chan(chan, msgid, message) end
 function mavlink:block_command(comand_id) end
 
 -- Geofence library
----@class fence
 fence = {}
 
 -- Returns the time at which the current breach started
@@ -3390,7 +3356,7 @@ function fence:get_breach_time() end
 function fence:get_breaches() end
 
 -- desc
----@class stat_t_ud
+---@class (exact) stat_t_ud
 local stat_t_ud = {}
 
 ---@return stat_t_ud
@@ -3421,7 +3387,6 @@ function stat_t_ud:size() end
 function stat_t_ud:is_directory() end
 
 -- desc
----@class rtc
 rtc = {}
 
 -- return a time since 1970 in seconds from GMT date elements
@@ -3435,7 +3400,7 @@ rtc = {}
 function rtc:date_fields_to_clock_s(year, month, day, hour, min, sec) end
 
 -- break a time in seconds since 1970 to GMT date elements
----@param param1 uint32_t_ud
+---@param param1 uint32_t_ud|integer|number
 ---@return integer|nil -- year 20xx
 ---@return integer|nil -- month 0-11
 ---@return integer|nil -- day 1-31
@@ -3446,7 +3411,6 @@ function rtc:date_fields_to_clock_s(year, month, day, hour, min, sec) end
 function rtc:clock_s_to_date_fields(param1) end
 
 -- desc
----@class fs
 fs = {}
 
 -- desc
@@ -3468,11 +3432,10 @@ function fs:get_format_status() end
 function fs:crc32(file_name) end
 
 -- desc
----@class networking
 networking = {}
 
 -- conver uint32_t address to string
----@param ip4addr uint32_t_ud
+---@param ip4addr uint32_t_ud|integer|number
 ---@return string
 function networking:address_to_str(ip4addr) end
 

--- a/libraries/AP_Scripting/drivers/BattMon_ANX.lua
+++ b/libraries/AP_Scripting/drivers/BattMon_ANX.lua
@@ -2,6 +2,9 @@
  device driver for ANX CAN battery monitor
 --]]
 
+---@diagnostic disable: param-type-mismatch
+---@diagnostic disable: missing-parameter
+
 local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
 
 local PARAM_TABLE_KEY = 45

--- a/libraries/AP_Scripting/drivers/EFI_HFE.lua
+++ b/libraries/AP_Scripting/drivers/EFI_HFE.lua
@@ -2,6 +2,11 @@
   EFI Scripting backend driver for HFE based on HFEDCN0191 Rev E
 --]]
 -- luacheck: only 0
+---@diagnostic disable: param-type-mismatch
+---@diagnostic disable: redundant-parameter
+---@diagnostic disable: undefined-field
+---@diagnostic disable: missing-parameter
+---@diagnostic disable: need-check-nil
 
 
 -- Check Script uses a miniumum firmware version

--- a/libraries/AP_Scripting/drivers/EFI_Halo6000.lua
+++ b/libraries/AP_Scripting/drivers/EFI_Halo6000.lua
@@ -2,6 +2,11 @@
   EFI Scripting backend driver for Halo6000 generator
 --]]
 
+---@diagnostic disable: param-type-mismatch
+---@diagnostic disable: undefined-field
+---@diagnostic disable: missing-parameter
+---@diagnostic disable: need-check-nil
+
 -- Check Script uses a miniumum firmware version
 local SCRIPT_AP_VERSION = 4.3
 local SCRIPT_NAME       = "EFI: Halo6000 CAN"

--- a/libraries/AP_Scripting/drivers/EFI_SkyPower.lua
+++ b/libraries/AP_Scripting/drivers/EFI_SkyPower.lua
@@ -12,6 +12,12 @@ CAN_D1_BITRATE 500000 (500 kbit/s)
 
 --]]
 
+---@diagnostic disable: param-type-mismatch
+---@diagnostic disable: need-check-nil
+---@diagnostic disable: undefined-field
+---@diagnostic disable: missing-parameter
+
+
 -- Check Script uses a miniumum firmware version
 local SCRIPT_AP_VERSION = 4.3
 local SCRIPT_NAME       = "EFI: Skypower CAN"

--- a/libraries/AP_Scripting/drivers/Generator_SVFFI.lua
+++ b/libraries/AP_Scripting/drivers/Generator_SVFFI.lua
@@ -3,6 +3,9 @@
    See http://www.svffi.com/en/
 --]]
 
+---@diagnostic disable: param-type-mismatch
+---@diagnostic disable: missing-parameter
+
 local PARAM_TABLE_KEY = 42
 local PARAM_TABLE_PREFIX = "EFI_SVF_"
 

--- a/libraries/AP_Scripting/drivers/Hobbywing_DataLink.lua
+++ b/libraries/AP_Scripting/drivers/Hobbywing_DataLink.lua
@@ -2,6 +2,8 @@
    driver for HobbyWing DataLink ESC telemetry
 --]]
 
+---@diagnostic disable: param-type-mismatch
+
 local PARAM_TABLE_KEY = 44
 local PARAM_TABLE_PREFIX = "ESC_HW_"
 

--- a/libraries/AP_Scripting/drivers/TOFSense-M/TOFSense-M_CAN.lua
+++ b/libraries/AP_Scripting/drivers/TOFSense-M/TOFSense-M_CAN.lua
@@ -2,6 +2,9 @@
    Driver for NoopLoop TOFSense-M CAN Version. Can be used as a 1-D RangeFidner or 3-D proximity sensor. Upto 3 CAN devices supported in this script although its easy to extend.
 --]]
 
+---@diagnostic disable: undefined-field
+---@diagnostic disable: undefined-global
+
 local update_rate_ms    = 10  -- update rate (in ms) of the driver. 10ms was found to be appropriate
 
 -- Global variables (DO NOT CHANGE)

--- a/libraries/AP_Scripting/drivers/TOFSense-M/TOFSense-M_Serial.lua
+++ b/libraries/AP_Scripting/drivers/TOFSense-M/TOFSense-M_Serial.lua
@@ -2,6 +2,10 @@
   Upto 3 CAN devices supported in this script although its easy to extend.
 --]]
 
+---@diagnostic disable: param-type-mismatch
+---@diagnostic disable: cast-local-type
+---@diagnostic disable: undefined-global
+
 local sensor_no         = 1     -- Sensor ID. Upload a copy of this script to the flight controller with this variable changed if you would like to use multiple of these sensors as serial. Switching to CAN highly recommended in that case
 local update_rate_ms    = 10    -- update rate (in ms) of the driver. 10ms was found to be appropriate
 local bytes_to_parse    = 100   -- serial bytes to parse in one interation of lua script. Reduce this if script is not able to complete in time

--- a/libraries/AP_Scripting/drivers/mount-djirs2-driver.lua
+++ b/libraries/AP_Scripting/drivers/mount-djirs2-driver.lua
@@ -71,6 +71,9 @@
 
 --]]
 
+---@diagnostic disable: cast-local-type
+
+
 -- global definitions
 local INIT_INTERVAL_MS = 3000           -- attempt to initialise the gimbal at this interval
 local UPDATE_INTERVAL_MS = 1            -- update interval in millis

--- a/libraries/AP_Scripting/drivers/mount-viewpro-driver.lua
+++ b/libraries/AP_Scripting/drivers/mount-viewpro-driver.lua
@@ -31,6 +31,9 @@
      n+2       checksum        XOR of byte3 to n+1 (inclusive)
 --]]
 
+---@diagnostic disable: cast-local-type
+---@diagnostic disable: undefined-global
+
 -- parameters
 local PARAM_TABLE_KEY = 39
 assert(param:add_table(PARAM_TABLE_KEY, "VIEP_", 6), "could not add param table")

--- a/libraries/AP_Scripting/examples/AHRS_switch.lua
+++ b/libraries/AP_Scripting/examples/AHRS_switch.lua
@@ -1,5 +1,7 @@
 -- switch between DCM and EKF3 on a switch
 
+---@diagnostic disable: need-check-nil
+
 local scripting_rc1 = rc:find_channel_for_option(300)
 local EKF_TYPE = Parameter('AHRS_EKF_TYPE')
 

--- a/libraries/AP_Scripting/examples/CAN_MiniCheetah_drive.lua
+++ b/libraries/AP_Scripting/examples/CAN_MiniCheetah_drive.lua
@@ -2,6 +2,7 @@
 -- https://os.mbed.com/users/benkatz/code/HKC_MiniCheetah/docs/tip/CAN__com_8cpp_source.html
 
 ---@diagnostic disable: param-type-mismatch
+---@diagnostic disable: need-check-nil
 
 -- Load CAN driver with a buffer size of 20
 local driver = CAN:get_device(20)

--- a/libraries/AP_Scripting/examples/CAN_MiniCheetah_drive.lua
+++ b/libraries/AP_Scripting/examples/CAN_MiniCheetah_drive.lua
@@ -1,6 +1,8 @@
 -- Control MiniCheetah motor driver over CAN
 -- https://os.mbed.com/users/benkatz/code/HKC_MiniCheetah/docs/tip/CAN__com_8cpp_source.html
 
+---@diagnostic disable: param-type-mismatch
+
 -- Load CAN driver with a buffer size of 20
 local driver = CAN:get_device(20)
 

--- a/libraries/AP_Scripting/examples/CAN_logger.lua
+++ b/libraries/AP_Scripting/examples/CAN_logger.lua
@@ -4,6 +4,8 @@
    Also need LOG_DISARMED set to 1 if running this while disarmed.
 --]]
 
+---@diagnostic disable: param-type-mismatch
+
 local can_driver = CAN:get_device(25)
 
 if not can_driver then

--- a/libraries/AP_Scripting/examples/CAN_read.lua
+++ b/libraries/AP_Scripting/examples/CAN_read.lua
@@ -1,4 +1,5 @@
 -- This script is an example of reading from the CAN bus
+---@diagnostic disable: need-check-nil
 
 -- Load CAN driver1. The first will attach to a protocol of 10, the 2nd to a protocol of 12
 -- this allows the script to distinguish packets on two CAN interfaces

--- a/libraries/AP_Scripting/examples/CAN_write.lua
+++ b/libraries/AP_Scripting/examples/CAN_write.lua
@@ -1,4 +1,5 @@
 -- This script is an example of writing to CAN bus
+---@diagnostic disable: need-check-nil
 
 -- Load CAN driver, using the scripting protocol and with a buffer size of 5
 local driver = CAN:get_device(5)

--- a/libraries/AP_Scripting/examples/EFI_tester.lua
+++ b/libraries/AP_Scripting/examples/EFI_tester.lua
@@ -3,6 +3,10 @@
    this can be used with a loopback cable between CAN1 and CAN2 to test CAN EFI Drivers
 --]]
 
+---@diagnostic disable: param-type-mismatch
+---@diagnostic disable: missing-parameter
+
+
 local driver2 = CAN.get_device2(25)
 if not driver2 then
    gcs:send_text(0,string.format("EFISIM: Failed to load CAN driver"))

--- a/libraries/AP_Scripting/examples/MAVLinkHL.lua
+++ b/libraries/AP_Scripting/examples/MAVLinkHL.lua
@@ -17,9 +17,14 @@ Caveats:
 
 Written by Stephen Dade (stephen_dade@hotmail.com)
 --]]
+
+---@diagnostic disable: need-check-nil
+---@diagnostic disable: cast-local-type
+
+
 local port = serial:find_serial(0)
 
-if not port or baud == 0 then
+if not port then
     gcs:send_text(0, "No Scripting Serial Port")
     return
 end

--- a/libraries/AP_Scripting/examples/RC_override.lua
+++ b/libraries/AP_Scripting/examples/RC_override.lua
@@ -1,5 +1,8 @@
 -- example of overriding RC inputs
 
+---@diagnostic disable: need-check-nil
+---@diagnostic disable: param-type-mismatch
+
 local RC4 = rc:get_channel(4)
 
 function update()

--- a/libraries/AP_Scripting/examples/SN-GCJA5-particle-sensor.lua
+++ b/libraries/AP_Scripting/examples/SN-GCJA5-particle-sensor.lua
@@ -8,6 +8,9 @@
     https://github.com/sparkfun/SparkFun_Particle_Sensor_SN-GCJA5_Arduino_Library
 ]]--
 
+---@diagnostic disable: need-check-nil
+---@diagnostic disable: undefined-global
+
 -- search for a index without a file, this stops us overwriting from a previous run
 local index = 0
 local file_name

--- a/libraries/AP_Scripting/examples/Serial_Dump.lua
+++ b/libraries/AP_Scripting/examples/Serial_Dump.lua
@@ -1,5 +1,9 @@
 -- this script reads data from a serial port and dumps it to a file
 
+---@diagnostic disable: param-type-mismatch
+---@diagnostic disable: need-check-nil
+---@diagnostic disable: cast-local-type
+
 local file_name = 'raw serial dump.txt'
 local file_name_plain = 'serial dump.txt'
 local baud_rate = 9600

--- a/libraries/AP_Scripting/examples/UART_log.lua
+++ b/libraries/AP_Scripting/examples/UART_log.lua
@@ -3,7 +3,7 @@
 -- find the serial first (0) scripting serial port instance
 local port = serial:find_serial(0)
 
-if not port or baud == 0 then
+if not port then
     gcs:send_text(0, "No Scripting Serial Port")
     return
 end

--- a/libraries/AP_Scripting/examples/ahrs-set-home-to-vehicle-location.lua
+++ b/libraries/AP_Scripting/examples/ahrs-set-home-to-vehicle-location.lua
@@ -1,6 +1,8 @@
 -- example script for using "set_home()"
 -- sets the home location to the current vehicle location every 5 seconds
 
+---@diagnostic disable: param-type-mismatch
+
 function update ()
 
     if ahrs:home_is_set() then

--- a/libraries/AP_Scripting/examples/ahrs-source-gps-optflow.lua
+++ b/libraries/AP_Scripting/examples/ahrs-source-gps-optflow.lua
@@ -27,6 +27,8 @@
 --
 -- When the 2nd auxiliary switch (300/Scripting1) is pulled high automatic source selection uses these thresholds:
 -- luacheck: only 0
+---@diagnostic disable: cast-local-type
+---@diagnostic disable: need-check-nil
 
 local rangefinder_rotation = 25     -- check downward (25) facing lidar
 local source_prev = 0               -- previous source, defaults to primary source

--- a/libraries/AP_Scripting/examples/ahrs-source-gps-wheelencoders.lua
+++ b/libraries/AP_Scripting/examples/ahrs-source-gps-wheelencoders.lua
@@ -10,6 +10,8 @@
 --     if GPS speed accuracy <= SCR_USER2 and GPS innovations <= SRC_USER3 then the GPS (primary source set) will be used
 --     otherwise wheel encoders (secondary source set) will be used
 -- luacheck: only 0
+---@diagnostic disable: cast-local-type
+---@diagnostic disable: need-check-nil
 
 local source_prev = 0               -- previous source, defaults to primary source
 local sw_source_prev = -1           -- previous source switch position

--- a/libraries/AP_Scripting/examples/ahrs-source.lua
+++ b/libraries/AP_Scripting/examples/ahrs-source.lua
@@ -16,6 +16,9 @@
 --     otherwise source2 (T265) or source3 (optical flow) will be used based on rangefinder distance
 -- luacheck: only 0
 
+---@diagnostic disable: need-check-nil
+---@diagnostic disable: cast-local-type
+
 local rangefinder_rotation = 25     -- check downward (25) facing lidar
 local source_prev = 0               -- previous source, defaults to primary source
 local sw_source_prev = -1           -- previous source switch position

--- a/libraries/AP_Scripting/examples/analog_input_and_GPIO.lua
+++ b/libraries/AP_Scripting/examples/analog_input_and_GPIO.lua
@@ -2,6 +2,8 @@
 
 -- for these examples BRD_PWM_COUNT must be 0
 
+---@diagnostic disable: need-check-nil
+
 -- load the analog pin, there are only 16 of these available
 -- some are used by the main AP code, ie battery monitors
 -- assign them like this in the init, not in the main loop

--- a/libraries/AP_Scripting/examples/benewakeH30_can_rangefinder.lua
+++ b/libraries/AP_Scripting/examples/benewakeH30_can_rangefinder.lua
@@ -1,5 +1,7 @@
 -- Lua Can Driver for Benewake CAN Rangefinder
 
+---@diagnostic disable: undefined-global
+
 -- User settable parameters
 local update_rate_ms    = 10    -- update rate (in ms) of the driver
 local debug_enable = false    -- true to enable debug messages

--- a/libraries/AP_Scripting/examples/benewakeH30_can_rangefinder.lua
+++ b/libraries/AP_Scripting/examples/benewakeH30_can_rangefinder.lua
@@ -1,6 +1,7 @@
 -- Lua Can Driver for Benewake CAN Rangefinder
 
 ---@diagnostic disable: undefined-global
+---@diagnostic disable: need-check-nil
 
 -- User settable parameters
 local update_rate_ms    = 10    -- update rate (in ms) of the driver

--- a/libraries/AP_Scripting/examples/camera-test.lua
+++ b/libraries/AP_Scripting/examples/camera-test.lua
@@ -1,5 +1,7 @@
 -- camera-test.lua.  Tests triggering taking pictures at regular intervals
 
+---@diagnostic disable: cast-local-type
+
 -- global definitions
 local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
 local TAKE_PIC_INTERVAL_MS = 5000   -- take pictures at this interval

--- a/libraries/AP_Scripting/examples/cell_balance_check.lua
+++ b/libraries/AP_Scripting/examples/cell_balance_check.lua
@@ -2,6 +2,8 @@
  script implementing pre-arm check that batteries are well balanced
 --]]
 
+---@diagnostic disable: param-type-mismatch
+
 local MAX_CELL_DEVIATION = 0.2
 
 local auth_id = arming:get_aux_auth_id()

--- a/libraries/AP_Scripting/examples/copter-fast-descent.lua
+++ b/libraries/AP_Scripting/examples/copter-fast-descent.lua
@@ -6,6 +6,10 @@
 --    b) slows the spiral and stops at the preset altitude
 --    c) switches to RTL
 
+---@diagnostic disable: param-type-mismatch
+---@diagnostic disable: cast-local-type
+---@diagnostic disable: need-check-nil
+
 -- constants
 local copter_guided_mode_num = 4    -- Guided mode is 4 on copter
 local copter_rtl_mode_num = 6       -- RTL is 6 on copter

--- a/libraries/AP_Scripting/examples/copter-nav-script-time.lua
+++ b/libraries/AP_Scripting/examples/copter-nav-script-time.lua
@@ -12,6 +12,9 @@
 -- "arg2" specifies the height (e.g. North-South) in meters
 -- Once the vehicle completes the square or the timeout expires the mission will continue and the vehicle should RTL home
 
+---@diagnostic disable: param-type-mismatch
+---@diagnostic disable: need-check-nil
+
 local running = false
 local last_id = -1          -- unique id used to detect if a new NAV_SCRIPT_TIME command has started
 local start_loc             -- vehicle's location when command starts (South-West corner of square)

--- a/libraries/AP_Scripting/examples/fault_handling.lua
+++ b/libraries/AP_Scripting/examples/fault_handling.lua
@@ -2,6 +2,9 @@
    example script to test fault handling with pcall
 --]]
 
+---@diagnostic disable: need-check-nil
+---@diagnostic disable: undefined-field
+
 local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
 
 gcs:send_text(MAV_SEVERITY.INFO, "Loading fault test")

--- a/libraries/AP_Scripting/examples/frsky_wp.lua
+++ b/libraries/AP_Scripting/examples/frsky_wp.lua
@@ -18,6 +18,7 @@
   Note: 17 is the index, 0x71 is the actual ID
 --]]
 -- luacheck: only 0
+---@diagnostic disable: param-type-mismatch
 
 local loop_time = 1000 -- number of ms between runs
 

--- a/libraries/AP_Scripting/examples/fw_vtol_failsafe.lua
+++ b/libraries/AP_Scripting/examples/fw_vtol_failsafe.lua
@@ -8,6 +8,8 @@
 -- If the aircraft drops below a predetermined minimum altitude, QLAND mode is engaged and the aircraft lands at its current position.
 -- If the aircraft arrives within Q_FW_LND_APR_RAD of the return point before dropping below the minimum altitude, it should loiter down to the minimum altitude before switching to QRTL and landing.
 
+---@diagnostic disable: cast-local-type
+
 -- setup param block for VTOL failsafe params
 local PARAM_TABLE_KEY = 77
 local PARAM_TABLE_PREFIX = "VTFS_"

--- a/libraries/AP_Scripting/examples/gen_control.lua
+++ b/libraries/AP_Scripting/examples/gen_control.lua
@@ -7,6 +7,8 @@
 --]]
 -- luacheck: only 0
 
+---@diagnostic disable: need-check-nil
+---@diagnostic disable: param-type-mismatch
 
 UPDATE_RATE_HZ = 10
 

--- a/libraries/AP_Scripting/examples/i2c_scan.lua
+++ b/libraries/AP_Scripting/examples/i2c_scan.lua
@@ -1,4 +1,7 @@
 -- This script scans for devices on the i2c bus
+
+---@diagnostic disable: need-check-nil
+
 local address = 0
 local found = 0
 

--- a/libraries/AP_Scripting/examples/mission-edit-demo.lua
+++ b/libraries/AP_Scripting/examples/mission-edit-demo.lua
@@ -2,6 +2,9 @@
 -- by Buzz 2020
 -- luacheck: only 0
 
+---@diagnostic disable: param-type-mismatch
+---@diagnostic disable: undefined-field
+
 current_pos = nil
 home = 0
 a = {}

--- a/libraries/AP_Scripting/examples/mission-load.lua
+++ b/libraries/AP_Scripting/examples/mission-load.lua
@@ -5,7 +5,7 @@
 --The "mission1.txt" file containing the mission items should be placed in the directory above the "scripts" directory. 
 --In case of placing it on SD Card, mission1.txt file should be placed in the APM directory root.
 
-
+---@diagnostic disable: param-type-mismatch
 
 local function read_mission(file_name)
 

--- a/libraries/AP_Scripting/examples/mission-save.lua
+++ b/libraries/AP_Scripting/examples/mission-save.lua
@@ -1,5 +1,7 @@
 -- Example of saving the current mission to a file on the SD card on arming
 
+---@diagnostic disable: need-check-nil
+
 local function save_to_SD()
 
   -- check if there is a mission to save

--- a/libraries/AP_Scripting/examples/mount-test.lua
+++ b/libraries/AP_Scripting/examples/mount-test.lua
@@ -12,6 +12,8 @@
 -- stage 9: point North and Down
 -- stage 10: move angle to neutral position
 
+---@diagnostic disable: cast-local-type
+
 local stage = 0
 local stage_time_ms = 5000
 local stage_start_time_ms = 0

--- a/libraries/AP_Scripting/examples/net_test.lua
+++ b/libraries/AP_Scripting/examples/net_test.lua
@@ -2,6 +2,8 @@
    example script to test lua socket API
 --]]
 
+---@diagnostic disable: param-type-mismatch
+
 local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
 
 PARAM_TABLE_KEY = 46

--- a/libraries/AP_Scripting/examples/plane-doublets.lua
+++ b/libraries/AP_Scripting/examples/plane-doublets.lua
@@ -8,6 +8,9 @@
 -- starting a doublet
 -- Charlie Johnson, Oklahoma State University 2020
 
+---@diagnostic disable: param-type-mismatch
+---@diagnostic disable: cast-local-type
+
 local DOUBLET_ACTION_CHANNEL = 6 -- RCIN channel to start a doublet when high (>1700)
 local DOUBLET_CHOICE_CHANNEL = 7 -- RCIN channel to choose elevator (low) or rudder (high)
 local DOUBLET_FUCNTION = 19 -- which control surface (SERVOx_FUNCTION) number will have a doublet happen

--- a/libraries/AP_Scripting/examples/plane-wind-fs.lua
+++ b/libraries/AP_Scripting/examples/plane-wind-fs.lua
@@ -3,6 +3,9 @@
 --
 -- CAUTION: This script only works for Plane
 
+---@diagnostic disable: cast-local-type
+---@diagnostic disable: undefined-global
+
 -- store the batt info as { instance, filtered, capacity, margin_mah }
 -- instance: the battery monitor instance (zero indexed)
 -- filtered: internal variable for current draw

--- a/libraries/AP_Scripting/examples/plane_guided_follow.lua
+++ b/libraries/AP_Scripting/examples/plane_guided_follow.lua
@@ -1,5 +1,7 @@
 -- support follow in GUIDED mode in plane
 -- luacheck: only 0
+---@diagnostic disable: cast-local-type
+
 
 local PARAM_TABLE_KEY = 11
 local PARAM_TABLE_PREFIX = "GFOLL_"

--- a/libraries/AP_Scripting/examples/quadruped.lua
+++ b/libraries/AP_Scripting/examples/quadruped.lua
@@ -19,6 +19,8 @@
 --
 -- CAUTION: This script should only be used with ArduPilot Rover's firmware
 
+---@diagnostic disable: cast-local-type
+
 
 local FRAME_LEN = 80    -- frame length in mm
 local FRAME_WIDTH = 150 -- frame width in mm

--- a/libraries/AP_Scripting/examples/rangefinder_quality_test.lua
+++ b/libraries/AP_Scripting/examples/rangefinder_quality_test.lua
@@ -10,6 +10,9 @@
 -- "RNGFND1_MIN_CM": 10,
 -- "RNGFND1_MAX_CM": 5000,
 
+---@diagnostic disable: cast-local-type
+
+
 -- UPDATE_PERIOD_MS is the time between when a distance is set and
 -- when it is read. There is a periodic task that copies the set distance to
 -- the state structure that it is read from. If UPDATE_PERIOD_MS is too short this periodic

--- a/libraries/AP_Scripting/examples/rover-MinFixType.lua
+++ b/libraries/AP_Scripting/examples/rover-MinFixType.lua
@@ -13,6 +13,8 @@ of a vehicle.  Use this script AT YOUR OWN RISK.
 LICENSE - GNU GPLv3 https://www.gnu.org/licenses/gpl-3.0.en.html
 ------------------------------------------------------------------------------]]
 
+---@diagnostic disable: param-type-mismatch
+
 local SCRIPT_NAME = 'MinFixType'
 
 --------  MAVLINK/AUTOPILOT 'CONSTANTS'  --------

--- a/libraries/AP_Scripting/examples/rover-SaveTurns.lua
+++ b/libraries/AP_Scripting/examples/rover-SaveTurns.lua
@@ -12,6 +12,9 @@ of a vehicle.  Use this script AT YOUR OWN RISK.
 LICENSE - GNU GPLv3 https://www.gnu.org/licenses/gpl-3.0.en.html
 ------------------------------------------------------------------------------]]
 
+---@diagnostic disable: cast-local-type
+---@diagnostic disable: need-check-nil
+
 local SCRIPT_NAME = 'SaveTurns'
 
 --------  USER EDITABLE GLOBALS  --------

--- a/libraries/AP_Scripting/examples/rover-TerrainDetector.lua
+++ b/libraries/AP_Scripting/examples/rover-TerrainDetector.lua
@@ -28,6 +28,8 @@ https://www.youtube.com/watch?v=UdXGXjigxAo&t=7155s
 Credit to @ktrussell for the idea and discussion!
 ------------------------------------------------------------------------------]]
 
+---@diagnostic disable: param-type-mismatch
+
 local SCRIPT_NAME     = 'TerrainDetector'
 local RUN_INTERVAL_MS =  25  -- needs to be pretty fast for good detection
 local SBY_INTERVAL_MS = 500  -- slower interval when detection is disabled

--- a/libraries/AP_Scripting/examples/serial_test.lua
+++ b/libraries/AP_Scripting/examples/serial_test.lua
@@ -1,5 +1,7 @@
 -- Lua script to write and read from a serial
 
+---@diagnostic disable: need-check-nil
+
 local port = serial:find_serial(0)
 
 port:begin(115200)

--- a/libraries/AP_Scripting/examples/servo_set_get.lua
+++ b/libraries/AP_Scripting/examples/servo_set_get.lua
@@ -5,7 +5,7 @@
 
 local flipflop = true
 local K_AILERON = 4
-local aileron_channel = SRV_Channels:find_channel(K_AILERON)
+local aileron_channel = assert(SRV_Channels:find_channel(K_AILERON))
 
 function update()
     if flipflop then

--- a/libraries/AP_Scripting/examples/set_target_posvel_circle.lua
+++ b/libraries/AP_Scripting/examples/set_target_posvel_circle.lua
@@ -8,6 +8,9 @@
 --      3) the vehilce will follow a circle in clockwise direction with increasing speed until ramp_up_time_s time has passed.
 --      4) switch out of and into the GUIDED mode any time to restart the trajectory from the start.
 
+---@diagnostic disable: cast-local-type
+---@diagnostic disable: redundant-parameter
+
 -- Edit these variables
 local rad_xy_m = 10.0   -- circle radius in xy plane in m
 local target_speed_xy_mps = 5.0     -- maximum target speed in m/s

--- a/libraries/AP_Scripting/examples/ship_vel_match.lua
+++ b/libraries/AP_Scripting/examples/ship_vel_match.lua
@@ -1,5 +1,7 @@
 -- support takeoff with velocity matching for quadplanes
 
+---@diagnostic disable: need-check-nil
+
 local PARAM_TABLE_KEY = 35
 local PARAM_TABLE_PREFIX = "SHIPV_"
 

--- a/libraries/AP_Scripting/examples/sub_test_synthetic_seafloor.lua
+++ b/libraries/AP_Scripting/examples/sub_test_synthetic_seafloor.lua
@@ -13,6 +13,8 @@
 --  SCR_USER3 is a bit field that controls driver logging.
 --
 
+---@diagnostic disable: param-type-mismatch
+---@diagnostic disable: cast-local-type
 
 local UPDATE_PERIOD_MS = 50
 

--- a/libraries/AP_Scripting/examples/test_load.lua
+++ b/libraries/AP_Scripting/examples/test_load.lua
@@ -1,6 +1,7 @@
 --[[
  test the load function for loading new code from strings
 --]]
+---@diagnostic disable: undefined-global
 
 gcs:send_text(0,"Testing load() method")
 

--- a/libraries/AP_Scripting/examples/wrap32_test.lua
+++ b/libraries/AP_Scripting/examples/wrap32_test.lua
@@ -8,6 +8,8 @@ a script to test handling of 32 bit micros timer wrap with BDShot
 - BRD_SAFETY_DFLT must be 0
 - BDShot must be enabled on outputs 9-12
 --]]
+---@diagnostic disable: param-type-mismatch
+---@diagnostic disable: cast-local-type
 
 local PARAM_TABLE_KEY = 138
 local PARAM_TABLE_PREFIX = "WRAP32_"

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -2615,6 +2615,16 @@ void emit_docs_type(struct type type, const char *prefix, const char *suffix) {
   }
 }
 
+void emit_docs_param_type(struct type type, const char *prefix, const char *suffix) {
+  if (type.type == TYPE_UINT32_T) {
+    // we will try and convert int and numbers to uint32
+    fprintf(docs, "%s uint32_t_ud|integer|number%s", prefix, suffix);
+    return;
+  }
+
+  emit_docs_type(type, prefix, suffix);
+}
+
 void emit_docs_return_type(struct type type, int nullable) {
   // AP_Objects can be nil
   nullable |= (type.type == TYPE_AP_OBJECT);
@@ -2636,7 +2646,7 @@ void emit_docs_method(const char *name, const char *method_name, struct method *
     if ((arg->type.type != TYPE_LITERAL) && (arg->type.flags & (TYPE_FLAGS_NULLABLE | TYPE_FLAGS_REFERNCE)) == 0) {
       char *param_name = (char *)allocate(20);
       sprintf(param_name, "---@param param%i", count);
-      emit_docs_type(arg->type, param_name, "\n");
+      emit_docs_param_type(arg->type, param_name, "\n");
       free(param_name);
       count++;
     }
@@ -2679,7 +2689,9 @@ void emit_docs(struct userdata *node, int is_userdata, int emit_creation) {
 
 
     fprintf(docs, "-- desc\n");
-    fprintf(docs, "---@class %s\n", name);
+    if (is_userdata) {
+      fprintf(docs, "---@class %s\n", name);
+    }
 
     // enums
     if (node->enums != NULL) {
@@ -2736,7 +2748,7 @@ void emit_docs(struct userdata *node, int is_userdata, int emit_creation) {
             }
             if (field->access_flags & ACCESS_FLAG_WRITE) {
               fprintf(docs, "-- set field\n");
-              emit_docs_type(field->type, "---@param value", "\n");
+              emit_docs_param_type(field->type, "---@param value", "\n");
               fprintf(docs, "function %s:%s(value) end\n\n", name, field->rename ? field->rename : field->name);
             }
           } else {
@@ -2750,7 +2762,7 @@ void emit_docs(struct userdata *node, int is_userdata, int emit_creation) {
             if (field->access_flags & ACCESS_FLAG_WRITE) {
               fprintf(docs, "-- set array field\n");
               fprintf(docs, "---@param index integer\n");
-              emit_docs_type(field->type, "---@param value", "\n");
+              emit_docs_param_type(field->type, "---@param value", "\n");
               fprintf(docs, "function %s:%s(index, value) end\n\n", name, field->rename ? field->rename : field->name);
             }
           }

--- a/libraries/AP_Scripting/tests/check.json
+++ b/libraries/AP_Scripting/tests/check.json
@@ -1,0 +1,15 @@
+{ // lua-language-server config for checking
+    "runtime.version": "Lua 5.3",
+    "runtime.builtin": {
+        // Not all of the standard functionality is available
+        "coroutine": "disable",
+        "os": "disable",
+        "debug": "disable",
+        "ffi": "disable",
+        "jit": "disable",
+        "table.clear": "disable",
+        "table.new": "disable"
+      },
+    // These lua scripts are not for running on AP
+    "workspace.ignoreDir": ["Tools/CHDK-Scripts/*", "modules/*", "libraries/AP_Scripting/tests/luacheck.lua" ],
+}

--- a/libraries/AP_Scripting/tests/docs.json
+++ b/libraries/AP_Scripting/tests/docs.json
@@ -1,0 +1,22 @@
+{ // lua-language-server config for docs generation
+    "runtime.version": "Lua 5.3",
+    "runtime.builtin": {
+        "basic": "disable",
+        "bit": "disable",
+        "bit32": "disable",
+        "builtin": "disable",
+        "coroutine": "disable",
+        "debug": "disable",
+        "ffi": "disable",
+        "io": "disable",
+        "jit": "disable",
+        "math": "disable",
+        "os": "disable",
+        "package": "disable",
+        "string": "disable",
+        "table": "disable",
+        "table.clear": "disable",
+        "table.new": "disable",
+        "utf8": "disable"
+      }
+}

--- a/libraries/AP_Scripting/tests/math.lua
+++ b/libraries/AP_Scripting/tests/math.lua
@@ -33,6 +33,9 @@
 -- luacheck: ignore 421 (Shadowing a local variable)
 -- luacheck: ignore 581 (Negation of a relational operator - operator can be flipped)
 
+---@diagnostic disable: cast-local-type
+---@diagnostic disable: undefined-global
+
 gcs:send_text(6, "testing numbers and math lib")
 
 local minint = math.mininteger

--- a/libraries/AP_Scripting/tests/mavlink_test.lua
+++ b/libraries/AP_Scripting/tests/mavlink_test.lua
@@ -1,3 +1,6 @@
+---@diagnostic disable: param-type-mismatch
+---@diagnostic disable: missing-parameter
+
 local mavlink_msgs = require("mavlink/mavlink_msgs")
 
 local msg_map = {}

--- a/libraries/AP_Scripting/tests/strings.lua
+++ b/libraries/AP_Scripting/tests/strings.lua
@@ -29,6 +29,11 @@
 
 -- luacheck: ignore 581 (Negation of a relational operator - operator can be flipped)
 
+---@diagnostic disable: param-type-mismatch
+---@diagnostic disable: missing-parameter
+---@diagnostic disable: undefined-global
+
+
 gcs:send_text(6, 'testing strings and string library')
 
 local maxi, mini = math.maxinteger, math.mininteger


### PR DESCRIPTION
This updates the docs and adds configuration and helpers to run lua-language-server. It is smarter than the current luacheck checks we run allowing type checking. https://luals.github.io/ This is the same checker that is used in by the recommended VSCode extension.

The new check is added as part of CI. Lots of stuff currently fails, rather than trying to fix (for the most part) this just adds overrides to ignore warnings in those files. The eventual goal would be to gradually resolve those warnings over time. Most of these failures are relatively harmless, but there are some quite nasty ones in there. 

The tool checks the scripts against the lua documentation file, there are lots of updates to it to ensure that it is correct.

The check can be run locally (after installation) with `python ./Tools/scripts/run_lua_language_check.py` but the recommended way would be to use the VSCode extension which reports the same issues in any case (although we should add the VSCode config to point the extension at the new setup file).

This also enables automatic generation of the docs in a easier to read `.md` format. This can be generated with `./Tools/scripts/generate_lua_docs.sh`. This is added to CI and the docs are uploaded as a artefact.

For example: [ScriptingDocs.md](https://github.com/ArduPilot/ardupilot/files/15228951/ScriptingDocs.md)

The eventual goal would be to convert this to a rst format for direct inclusion into the wiki.
