### PR TITLE
Handle esc extended status

### DIFF
--- a/Tools/AP_Periph/AP_Periph.h
+++ b/Tools/AP_Periph/AP_Periph.h
@@ -337,6 +337,7 @@ public:
     uint32_t last_esc_telem_update_ms;
     void esc_telem_update();
     uint32_t esc_telem_update_period_ms;
+    void esc_extended_telem_update();
 #endif
 
     SRV_Channels servo_channels;

--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -1720,6 +1720,26 @@ void AP_Periph_FW::esc_telem_update()
                          total_size);
     }
 }
+
+void AP_Periph_FW::esc_extended_telem_update()
+{
+    uavcan_equipment_esc_StatusExtended pkt {};
+    pkt.esc_index = 1;
+    pkt.input_pct = 10;
+    pkt.output_pct = 20;
+    pkt.motor_temperature_degC = 30;
+    pkt.motor_angle = 40;
+    pkt.status_flags = 1;
+
+    uint8_t buffer[UAVCAN_EQUIPMENT_ESC_STATUSEXTENDED_MAX_SIZE] {};
+    uint16_t total_size = uavcan_equipment_esc_StatusExtended_encode(&pkt, buffer, !canfdout());
+    canard_broadcast(UAVCAN_EQUIPMENT_ESC_STATUS_SIGNATURE,
+                    UAVCAN_EQUIPMENT_ESC_STATUSEXTENDED_ID,
+                    CANARD_TRANSFER_PRIORITY_LOW,
+                    &buffer[0],
+                    total_size);
+}
+
 #endif // HAL_WITH_ESC_TELEM
 
 #ifdef HAL_PERIPH_ENABLE_ESC_APD
@@ -1837,6 +1857,7 @@ void AP_Periph_FW::can_update()
 #ifdef HAL_PERIPH_ENABLE_ESC_APD
         apd_esc_telem_update();
 #endif
+    esc_extended_telem_update();
     #ifdef HAL_PERIPH_ENABLE_MSP
         msp_sensor_update();
     #endif

--- a/libraries/AP_DroneCAN/AP_DroneCAN.h
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.h
@@ -255,6 +255,7 @@ private:
 
     // last log time
     uint32_t last_log_ms;
+    uint32_t last_log_escx_ms;
 
 #if AP_DRONECAN_SEND_GPS
     // send GNSS Fix and yaw, same thing AP_GPS_DroneCAN would receive
@@ -326,6 +327,9 @@ private:
     Canard::ObjCallback<AP_DroneCAN, uavcan_equipment_esc_Status> esc_status_cb{this, &AP_DroneCAN::handle_ESC_status};
     Canard::Subscriber<uavcan_equipment_esc_Status> esc_status_listener{esc_status_cb, _driver_index};
 
+    Canard::ObjCallback<AP_DroneCAN, uavcan_equipment_esc_StatusExtended> esc_status_extended_cb{this, &AP_DroneCAN::handle_ESC_extended_status};
+    Canard::Subscriber<uavcan_equipment_esc_StatusExtended> esc_status_extended_listener{esc_status_extended_cb, _driver_index};
+
     Canard::ObjCallback<AP_DroneCAN, uavcan_protocol_debug_LogMessage> debug_cb{this, &AP_DroneCAN::handle_debug};
     Canard::Subscriber<uavcan_protocol_debug_LogMessage> debug_listener{debug_cb, _driver_index};
 
@@ -387,6 +391,7 @@ private:
     void handle_actuator_status(const CanardRxTransfer& transfer, const uavcan_equipment_actuator_Status& msg);
     void handle_actuator_status_Volz(const CanardRxTransfer& transfer, const com_volz_servo_ActuatorStatus& msg);
     void handle_ESC_status(const CanardRxTransfer& transfer, const uavcan_equipment_esc_Status& msg);
+    void handle_ESC_extended_status(const CanardRxTransfer& transfer, const uavcan_equipment_esc_StatusExtended& msg);
     static bool is_esc_data_index_valid(const uint8_t index);
     void handle_debug(const CanardRxTransfer& transfer, const uavcan_protocol_debug_LogMessage& msg);
     void handle_param_get_set_response(const CanardRxTransfer& transfer, const uavcan_protocol_param_GetSetResponse& rsp);

--- a/libraries/AP_HAL_ChibiOS/hwdef/CarbonixF405/hwdef-bl.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CarbonixF405/hwdef-bl.dat
@@ -16,7 +16,7 @@ APJ_BOARD_ID 1064
 env AP_PERIPH 1
 
 # crystal frequency set to 0 to use internal clock
-OSCILLATOR_HZ 0
+OSCILLATOR_HZ 12000000
 
 # assume 1024K flash part
 FLASH_SIZE_KB 1024

--- a/libraries/AP_HAL_ChibiOS/hwdef/CarbonixF405/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CarbonixF405/hwdef.dat
@@ -17,7 +17,7 @@ APJ_BOARD_ID 1064
 env AP_PERIPH 1
 
 # crystal frequency set to 0 to use internal clock
-OSCILLATOR_HZ 0
+OSCILLATOR_HZ 12000000
 
 #MCU F405 Flash 1024
 FLASH_SIZE_KB 1024


### PR DESCRIPTION
This is a PR to allow logging of ESC extended status. 
It is still not a finished changes and an rushed push will update the PR tomorrow.

Mainly I need an opinion on if the ESC extended packets need to be logged in DroneCAN or AP_ESC_Telem. Also, if this is needed to pushed on Mavlink? I don't have a requirement for it.