### PR TITLE
SITL: added plane-steering model for ground steering

### DIFF
--- a/libraries/SITL/SIM_Plane.h
+++ b/libraries/SITL/SIM_Plane.h
@@ -102,6 +102,7 @@ protected:
     bool aerobatic;
     bool copter_tailsitter;
     bool have_launcher;
+    bool have_steering;
     float launch_accel;
     float launch_time;
     uint64_t launch_start_ms;


### PR DESCRIPTION
needs to be updated with improved yaw rate calculation

need to set SERVO5_FUNCTION = 26
and launch with sim_vehicle.py -f plane-steering
