### PR TITLE
GCS_MAVLink: support HIGHRES_IMU

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -354,6 +354,7 @@ public:
     void send_rc_channels() const;
     void send_rc_channels_raw() const;
     void send_raw_imu();
+    void send_highres_imu();
 
     void send_scaled_pressure_instance(uint8_t instance, void (*send_fn)(mavlink_channel_t chan, uint32_t time_boot_ms, float press_abs, float press_diff, int16_t temperature, int16_t temperature_press_diff));
     void send_scaled_pressure();
@@ -1401,4 +1402,3 @@ enum MAV_SEVERITY
 #define AP_HAVE_GCS_SEND_TEXT 0
 
 #endif // HAL_GCS_ENABLED
-

--- a/libraries/GCS_MAVLink/GCS_config.h
+++ b/libraries/GCS_MAVLink/GCS_config.h
@@ -3,6 +3,7 @@
 #include <AP_HAL/AP_HAL_Boards.h>
 #include <AP_Relay/AP_Relay_config.h>
 #include <AP_Mission/AP_Mission_config.h>
+#include <AP_InertialSensor/AP_InertialSensor_config.h>
 
 #ifndef HAL_GCS_ENABLED
 #define HAL_GCS_ENABLED 1
@@ -121,4 +122,8 @@
 // left in place.
 #ifndef AP_MAVLINK_COMMAND_LONG_ENABLED
 #define AP_MAVLINK_COMMAND_LONG_ENABLED 1
+#endif
+
+#ifndef AP_MAVLINK_MSG_HIGHRES_IMU_ENABLED
+#define AP_MAVLINK_MSG_HIGHRES_IMU_ENABLED (BOARD_FLASH_SIZE > 1024) && AP_INERTIALSENSOR_ENABLED
 #endif

--- a/libraries/GCS_MAVLink/ap_message.h
+++ b/libraries/GCS_MAVLink/ap_message.h
@@ -94,5 +94,8 @@ enum ap_message : uint8_t {
     MSG_HYGROMETER,
     MSG_AUTOPILOT_STATE_FOR_GIMBAL_DEVICE,
     MSG_RELAY_STATUS,
+#if AP_MAVLINK_MSG_HIGHRES_IMU_ENABLED
+    MSG_HIGHRES_IMU,
+#endif
     MSG_LAST // MSG_LAST must be the last entry in this enum
 };


### PR DESCRIPTION
Duplicates #24258 
It allows a companion computer to query the flightcontrollers IMU for navigation and control.
This PR implements all fields for the [HIGHRES_IMU](https://mavlink.io/en/messages/common.html#HIGHRES_IMU) Mavlink message.