### PR TITLE
Tools: add comment at end of file restricting range to be allocated from

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -331,3 +331,6 @@ AP_HW_Holybro-PERIPH-H7              5404
 # OpenDroneID enabled boards. Use 10000 + the base board ID
 AP_HW_CubeOrange_ODID               10140
 AP_HW_Pixhawk6_ODID                 10053
+
+# do not allocate board IDs above 10,000 for non-ODID boards.
+# do not allocate board IDs above 19,999 in this file.


### PR DESCRIPTION
we allocated outside the comment mentioned at the top of the file, so add a comment at the end too