### PR TITLE
Tools: Expose map/console mavproxy args

### DIFF
--- a/Tools/ros2/README.md
+++ b/Tools/ros2/README.md
@@ -13,6 +13,14 @@ For example `ardurover` SITL may be launched with:
 ros2 launch ardupilot_sitl sitl.launch.py command:=ardurover model:=rover
 ```
 
+Other launch files are included with many arguments.
+Some common arguments are exposed and forwarded to the underlying process.
+
+For example, MAVProxy can be launched, and you can enable the `console` and `map`.
+```bash
+ros2 launch ardupilot_sitl sitl_mavproxy.launch.py map:=True console:=True 
+```
+
 #### `ardupilot_dds_test`
 
 A `colcon` package for testing communication between `micro_ros_agent` and the

--- a/Tools/ros2/ardupilot_sitl/src/ardupilot_sitl/launch.py
+++ b/Tools/ros2/ardupilot_sitl/src/ardupilot_sitl/launch.py
@@ -286,26 +286,36 @@ class MAVProxyLaunch:
         master = LaunchConfiguration("master").perform(context)
         out = LaunchConfiguration("out").perform(context)
         sitl = LaunchConfiguration("sitl").perform(context)
+        console = LaunchConfiguration("console").perform(context)
+        map = LaunchConfiguration("map").perform(context)
 
         # Display launch arguments.
         print(f"command:          {command}")
         print(f"master:           {master}")
         print(f"sitl:             {sitl}")
         print(f"out:              {out}")
+        print(f"console:          {console}")
+        print(f"map:              {map}")
+
+        cmd = [
+            f"{command} ",
+            f"--out {out} ",
+            "--out ",
+            "127.0.0.1:14551 ",
+            f"--master {master} ",
+            f"--sitl {sitl} ",
+            "--non-interactive ",
+        ]
+
+        if console:
+            cmd.append("--console ")
+
+        if map:
+            cmd.append("--map ")
 
         # Create action.
         mavproxy_process = ExecuteProcess(
-            cmd=[
-                [
-                    f"{command} ",
-                    f"--out {out} ",
-                    "--out ",
-                    "127.0.0.1:14551 ",
-                    f"--master {master} ",
-                    f"--sitl {sitl} ",
-                    "--non-interactive ",
-                ]
-            ],
+            cmd=cmd,
             shell=True,
             output="both",
             respawn=False,
@@ -354,6 +364,16 @@ class MAVProxyLaunch:
                 "sitl",
                 default_value="127.0.0.1:5501",
                 description="SITL output port.",
+            ),
+            DeclareLaunchArgument(
+                "map",
+                default_value="False",
+                description="Enable MAVProxy Map.",
+            ),
+            DeclareLaunchArgument(
+                "console",
+                default_value="False",
+                description="Enable MAVProxy Console.",
             ),
         ]
 


### PR DESCRIPTION
# Purpose

Expose mavproxy map and console into the ROS 2 launch CLI

# Testing

Try the README changes, expect MAVProxy to start with map and console when supplied. Default is false which maintains existing behavior (which will work in CI).