### PR TITLE
Heli Swashplate: Make motor numbers const

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
@@ -88,13 +88,9 @@ const AP_Param::GroupInfo AP_MotorsHeli_Swash::var_info[] = {
 };
 
 AP_MotorsHeli_Swash::AP_MotorsHeli_Swash(uint8_t mot_0, uint8_t mot_1, uint8_t mot_2, uint8_t mot_3, uint8_t instance) :
-    _instance(instance)
+    _instance(instance),
+    _motor_num{mot_0, mot_1, mot_2, mot_3}
 {
-    _motor_num[0] = mot_0;
-    _motor_num[1] = mot_1;
-    _motor_num[2] = mot_2;
-    _motor_num[3] = mot_3;
-
     AP_Param::setup_object_defaults(this, var_info);
 }
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Swash.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Swash.h
@@ -81,7 +81,7 @@ private:
     float                _pitchFactor[_max_num_servos];             // Pitch axis scaling of servo output based on servo position
     float                _collectiveFactor[_max_num_servos];        // Collective axis scaling of servo output based on servo position
     float                _output[_max_num_servos];                  // Servo output value
-    uint8_t              _motor_num[_max_num_servos];               // Motor function to use for output
+    const uint8_t        _motor_num[_max_num_servos];               // Motor function to use for output
     const uint8_t        _instance;                                 // Swashplate instance. Used for logging.
 
     // Variables stored for logging


### PR DESCRIPTION
A minor PR to make the motor numbers in heli swashplate const.  This provides additional protection so that we cannot accidently change the motor numbers.