### PR TITLE
GCS_MAVLink: deny attempt to do partial upload while mission transfer in progress

### DIFF
--- a/libraries/GCS_MAVLink/MissionItemProtocol.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol.cpp
@@ -220,6 +220,19 @@ void MissionItemProtocol::handle_mission_write_partial_list(GCS_MAVLINK &_link,
                                                             const mavlink_message_t &msg,
                                                             const mavlink_mission_write_partial_list_t &packet)
 {
+    if (!mavlink2_requirement_met(_link, msg)) {
+        return;
+    }
+
+    if (receiving) {
+        // someone is already uploading a mission.  Deny ability to
+        // write a partial list here as they might be trying to
+        // overwrite a subset of the waypoints which the current
+        // transfer is uploading, and that may lead to storing a whole
+        // bunch of empty items.
+        send_mission_ack(_link, msg, MAV_MISSION_DENIED);
+        return;
+    }
 
     // start waypoint receiving
     if ((unsigned)packet.start_index > item_count() ||


### PR DESCRIPTION
Fixes this internal error:
```
ardurover: #4  0x0000604a12ed5b75 in AP_HAL::dump_stack_trace () at ../../libraries/AP_HAL_SITL/system.cpp:147
ardurover: No locals.
ardurover: #5  0x0000604a12ed5757 in AP_HAL::panic (errormsg=0x604a1302b4cd "AP_InternalError::error_t::%s") at ../../libraries/AP_HAL_SITL/system.cpp:51
ardurover:         ap = {{gp_offset = 16, fp_offset = 48, overflow_arg_area = 0x7ffd7b9dec00, reg_save_area = 0x7ffd7b9deb40}}
ardurover: #6  0x0000604a12dc0d9f in AP_InternalError::error (this=0x604a13139258 <instance>, e=AP_InternalError::error_t::flow_of_control, line=217) at ../../libraries/AP_InternalError/AP_InternalError.cpp:28
ardurover:         buffer = "flow_of_ctrl", '\000' <repeats 36 times>, <incomplete sequence \354>
ardurover: #7  0x0000604a12fd4eee in MissionItemProtocol_Fence::allocate_receive_resources (this=0x604a14c4a930, count=0) at ../../libraries/GCS_MAVLink/MissionItemProtocol_Fence.cpp:217
ardurover:         allocation_size = 0
ardurover: #8  0x0000604a12fd4ff4 in MissionItemProtocol_Fence::allocate_update_resources (this=0x604a14c4a930) at ../../libraries/GCS_MAVLink/MissionItemProtocol_Fence.cpp:240
ardurover:         _item_count = 0
ardurover:         ret = 24650
ardurover: #9  0x0000604a12fd3f9c in MissionItemProtocol::handle_mission_write_partial_list (this=0x604a14c4a930, _link=..., msg=..., packet=...) at ../../libraries/GCS_MAVLink/MissionItemProtocol.cpp:231
ardurover:         ret_alloc = 32765
ardurover: #10 0x0000604a12ddd41c in GCS_MAVLINK::handle_mission_write_partial_list (this=0x604a14c44360, msg=...) at ../../libraries/GCS_MAVLink/GCS_Common.cpp:783
ardurover:         packet = {start_index = 3, end_index = 3, target_system = 1 '\001', target_component = 1 '\001', mission_type = 1 '\001'}
ardurover:         use_prot = 0x604a14c4a930
ardurover: #11 0x0000604a12de5238 in GCS_MAVLINK::handle_common_mission_message (this=0x604a14c44360, msg=...) at ../../libraries/GCS_MAVLink/GCS_Common.cpp:4316
ardurover: No locals.
ardurover: #12 0x0000604a12de4d75 in GCS_MAVLINK::handle_message (this=0x604a14c44360, msg=...) at ../../libraries/GCS_MAVLink/GCS_Common.cpp:4068
```

The included autotest recreates the problem before the patch is applied.
