### PR TITLE
Initialize sample buffer pointer with nullptr

### DIFF
--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -79,7 +79,8 @@ extern const AP_HAL::HAL& hal;
 ///////////////////// PUBLIC INTERFACE /////////////////////
 ////////////////////////////////////////////////////////////
 
-CompassCalibrator::CompassCalibrator()
+CompassCalibrator::CompassCalibrator() :
+    _sample_buffer(nullptr)
 {
     set_status(Status::NOT_STARTED);
 }


### PR DESCRIPTION
to avoid memory corruption on deallocating uninitialized value in `CompassCalibrator.cpp`:384:

```c
if (_sample_buffer != nullptr) {
    free(_sample_buffer);
```