### PR TITLE
AP_BattMonitor: ESC: add mask parameter

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -66,6 +66,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_Synthetic_Current.cpp
     // @Group: _
     // @Path: AP_BattMonitor_INA2xx.cpp
+    // @Group: _
+    // @Path: AP_BattMonitor_ESC.cpp
     AP_SUBGROUPVARPTR(drivers[0], "_", 41, AP_BattMonitor, backend_var_info[0]),
 
 #if AP_BATT_MONITOR_MAX_INSTANCES > 1
@@ -87,6 +89,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_Synthetic_Current.cpp
     // @Group: 2_
     // @Path: AP_BattMonitor_INA2xx.cpp
+    // @Group: 2_
+    // @Path: AP_BattMonitor_ESC.cpp
     AP_SUBGROUPVARPTR(drivers[1], "2_", 42, AP_BattMonitor, backend_var_info[1]),
 #endif
 
@@ -109,6 +113,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_Synthetic_Current.cpp
     // @Group: 3_
     // @Path: AP_BattMonitor_INA2xx.cpp
+    // @Group: 3_
+    // @Path: AP_BattMonitor_ESC.cpp
     AP_SUBGROUPVARPTR(drivers[2], "3_", 43, AP_BattMonitor, backend_var_info[2]),
 #endif
 
@@ -131,6 +137,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_Synthetic_Current.cpp
     // @Group: 4_
     // @Path: AP_BattMonitor_INA2xx.cpp
+    // @Group: 4_
+    // @Path: AP_BattMonitor_ESC.cpp
     AP_SUBGROUPVARPTR(drivers[3], "4_", 44, AP_BattMonitor, backend_var_info[3]),
 #endif
 
@@ -153,6 +161,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_Synthetic_Current.cpp
     // @Group: 5_
     // @Path: AP_BattMonitor_INA2xx.cpp
+    // @Group: 5_
+    // @Path: AP_BattMonitor_ESC.cpp
     AP_SUBGROUPVARPTR(drivers[4], "5_", 45, AP_BattMonitor, backend_var_info[4]),
 #endif
 
@@ -175,6 +185,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_Synthetic_Current.cpp
     // @Group: 6_
     // @Path: AP_BattMonitor_INA2xx.cpp
+    // @Group: 6_
+    // @Path: AP_BattMonitor_ESC.cpp
     AP_SUBGROUPVARPTR(drivers[5], "6_", 46, AP_BattMonitor, backend_var_info[5]),
 #endif
 
@@ -197,6 +209,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_Synthetic_Current.cpp
     // @Group: 7_
     // @Path: AP_BattMonitor_INA2xx.cpp
+    // @Group: 7_
+    // @Path: AP_BattMonitor_ESC.cpp
     AP_SUBGROUPVARPTR(drivers[6], "7_", 47, AP_BattMonitor, backend_var_info[6]),
 #endif
 
@@ -219,6 +233,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_Synthetic_Current.cpp
     // @Group: 8_
     // @Path: AP_BattMonitor_INA2xx.cpp
+    // @Group: 8_
+    // @Path: AP_BattMonitor_ESC.cpp
     AP_SUBGROUPVARPTR(drivers[7], "8_", 48, AP_BattMonitor, backend_var_info[7]),
 #endif
 
@@ -241,6 +257,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_Synthetic_Current.cpp
     // @Group: 9_
     // @Path: AP_BattMonitor_INA2xx.cpp
+    // @Group: 9_
+    // @Path: AP_BattMonitor_ESC.cpp
     AP_SUBGROUPVARPTR(drivers[8], "9_", 49, AP_BattMonitor, backend_var_info[8]),
 #endif
 
@@ -263,6 +281,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_Synthetic_Current.cpp
     // @Group: A_
     // @Path: AP_BattMonitor_INA2xx.cpp
+    // @Group: A_
+    // @Path: AP_BattMonitor_ESC.cpp
     AP_SUBGROUPVARPTR(drivers[9], "A_", 50, AP_BattMonitor, backend_var_info[9]),
 #endif
 
@@ -285,6 +305,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_Synthetic_Current.cpp
     // @Group: B_
     // @Path: AP_BattMonitor_INA2xx.cpp
+    // @Group: B_
+    // @Path: AP_BattMonitor_ESC.cpp
     AP_SUBGROUPVARPTR(drivers[10], "B_", 51, AP_BattMonitor, backend_var_info[10]),
 #endif
 
@@ -307,6 +329,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_Synthetic_Current.cpp
     // @Group: C_
     // @Path: AP_BattMonitor_INA2xx.cpp
+    // @Group: C_
+    // @Path: AP_BattMonitor_ESC.cpp
     AP_SUBGROUPVARPTR(drivers[11], "C_", 52, AP_BattMonitor, backend_var_info[11]),
 #endif
 
@@ -329,6 +353,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_Synthetic_Current.cpp
     // @Group: D_
     // @Path: AP_BattMonitor_INA2xx.cpp
+    // @Group: D_
+    // @Path: AP_BattMonitor_ESC.cpp
     AP_SUBGROUPVARPTR(drivers[12], "D_", 53, AP_BattMonitor, backend_var_info[12]),
 #endif
 
@@ -351,6 +377,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_Synthetic_Current.cpp
     // @Group: E_
     // @Path: AP_BattMonitor_INA2xx.cpp
+    // @Group: E_
+    // @Path: AP_BattMonitor_ESC.cpp
     AP_SUBGROUPVARPTR(drivers[13], "E_", 54, AP_BattMonitor, backend_var_info[13]),
 #endif
 
@@ -373,6 +401,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_Synthetic_Current.cpp
     // @Group: F_
     // @Path: AP_BattMonitor_INA2xx.cpp
+    // @Group: F_
+    // @Path: AP_BattMonitor_ESC.cpp
     AP_SUBGROUPVARPTR(drivers[14], "F_", 55, AP_BattMonitor, backend_var_info[14]),
 #endif
 
@@ -395,6 +425,8 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_Synthetic_Current.cpp
     // @Group: G_
     // @Path: AP_BattMonitor_INA2xx.cpp
+    // @Group: G_
+    // @Path: AP_BattMonitor_ESC.cpp
     AP_SUBGROUPVARPTR(drivers[15], "G_", 56, AP_BattMonitor, backend_var_info[15]),
 #endif
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_DroneCAN.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_DroneCAN.cpp
@@ -26,7 +26,7 @@ const AP_Param::GroupInfo AP_BattMonitor_DroneCAN::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("CURR_MULT", 30, AP_BattMonitor_DroneCAN, _curr_mult, 1.0),
 
-    // Param indexes must be between 30 and 39 to avoid conflict with other battery monitor param tables loaded by pointer
+    // Param indexes must be between 30 and 35 to avoid conflict with other battery monitor param tables loaded by pointer
 
     AP_GROUPEND
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_ESC.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_ESC.h
@@ -25,9 +25,7 @@ class AP_BattMonitor_ESC :public AP_BattMonitor_Backend
 {
 public:
     // constructor. This incorporates initialisation as well.
-    AP_BattMonitor_ESC(AP_BattMonitor &mon, AP_BattMonitor::BattMonitor_State &mon_state, AP_BattMonitor_Params &params):
-        AP_BattMonitor_Backend(mon, mon_state, params)
-    {};
+    AP_BattMonitor_ESC(AP_BattMonitor &mon, AP_BattMonitor::BattMonitor_State &mon_state, AP_BattMonitor_Params &params);
 
     virtual ~AP_BattMonitor_ESC(void) {};
 
@@ -46,7 +44,12 @@ public:
     // reset remaining percentage to given value
     virtual bool reset_remaining(float percentage) override;
 
+    static const struct AP_Param::GroupInfo var_info[];
+
 private:
+
+    AP_Int32  _mask;
+
     bool have_current;
     bool have_temperature;
     float delta_mah;


### PR DESCRIPTION
This adds a `ESC_MASK` parameter to allow assigning particular ESCs to particular batteries. Default is 0 for use all which is the current behaviour. 