### PR TITLE
Tools: use previous release of pymonocypher

### DIFF
--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -428,7 +428,7 @@ for t in $CI_BUILD_TARGET; do
         echo "Building signed firmwares"
         sudo apt-get update
         sudo apt-get install -y python3-dev
-        python3 -m pip install pymonocypher
+        python3 -m pip install pymonocypher==3.1.3.2
         ./Tools/scripts/signing/generate_keys.py testkey
         $waf configure --board CubeOrange-ODID --signed-fw --private-key testkey_private_key.dat
         $waf copter


### PR DESCRIPTION
the new release of pymonocypher breaks generation of public keys
see this issue:
https://github.com/jetperch/pymonocypher/issues/9
