### PR TITLE
AP_Bootloader: ID reserve for FlywooF405HD_AIOv2

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -280,6 +280,8 @@ AP_HW_SDMODELH7V2                    1167
 AP_HW_JHEMCUF405WING                 1169
 AP_HW_MatekG474                      1170
 
+AP_HW_FlywooF405HD_AIOv2             1180
+
 AP_HW_ESP32_PERIPH                   1205
 AP_HW_ESP32S3_PERIPH                 1206
 


### PR DESCRIPTION
Complements PR #27036 with a new Board ID proposal.