### PR TITLE
waf: move setting of ROMFS flags to embed step

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -542,6 +542,14 @@ class Board:
         if not embed.create_embedded_h(header, ctx.env.ROMFS_FILES, ctx.env.ROMFS_UNCOMPRESSED):
             ctx.fatal("Failed to created ap_romfs_embedded.h")
 
+        ctx.env.CXXFLAGS += ['-DHAL_HAVE_AP_ROMFS_EMBEDDED_H']
+
+        # Allow lua to load from ROMFS if any lua files are added
+        for file in ctx.env.ROMFS_FILES:
+            if file[0].startswith("scripts") and file[0].endswith(".lua"):
+                ctx.env.CXXFLAGS += ['-DHAL_HAVE_AP_ROMFS_EMBEDDED_LUA']
+                break
+
 Board = BoardMeta('Board', Board.__bases__, dict(Board.__dict__))
 
 def add_dynamic_boards_chibios():
@@ -776,14 +784,6 @@ class sitl(Board):
             for f in os.listdir('ROMFS/scripts'):
                 if fnmatch.fnmatch(f, "*.lua"):
                     env.ROMFS_FILES += [('scripts/'+f,'ROMFS/scripts/'+f)]
-
-        if len(env.ROMFS_FILES) > 0:
-            # Allow lua to load from ROMFS if any lua files are added
-            for file in env.ROMFS_FILES:
-                if file[0].startswith("scripts") and file[0].endswith(".lua"):
-                    env.CXXFLAGS += ['-DHAL_HAVE_AP_ROMFS_EMBEDDED_LUA']
-                    break
-            env.CXXFLAGS += ['-DHAL_HAVE_AP_ROMFS_EMBEDDED_H']
 
         if cfg.options.sitl_rgbled:
             env.CXXFLAGS += ['-DWITH_SITL_RGBLED']
@@ -1357,13 +1357,6 @@ class linux(Board):
             env.DEFINES.update(
                 HAL_PARAM_DEFAULTS_PATH='"@ROMFS/defaults.parm"',
             )
-        if len(env.ROMFS_FILES) > 0:
-            # Allow lua to load from ROMFS if any lua files are added
-            for file in env.ROMFS_FILES:
-                if file[0].startswith("scripts") and file[0].endswith(".lua"):
-                    env.CXXFLAGS += ['-DHAL_HAVE_AP_ROMFS_EMBEDDED_LUA']
-                    break
-            env.CXXFLAGS += ['-DHAL_HAVE_AP_ROMFS_EMBEDDED_H']
 
     def build(self, bld):
         super(linux, self).build(bld)

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -2613,14 +2613,6 @@ Please run: Tools/scripts/build_bootloaders.py %s
 
         self.embed_bootloader(f)
 
-        if len(self.romfs) > 0:
-            # Allow lua to load from ROMFS if any lua files are added
-            for file in self.romfs.keys():
-                if file.startswith("scripts") and file.endswith(".lua"):
-                    f.write('#define HAL_HAVE_AP_ROMFS_EMBEDDED_LUA 1\n')
-                    break
-            f.write('#define HAL_HAVE_AP_ROMFS_EMBEDDED_H 1\n')
-
         if self.mcu_series.startswith('STM32F1'):
             f.write('''
 /*


### PR DESCRIPTION
Currently on ChibiOS these flags are set before files are added from `ROMFS_custom` so the flags may be incorrect. This moves the setting of the flags to the same step as where the files are imbedded so nothing is missed. This also has the advantage of unifying the approach across all boards. 

I have tested imbedding a script in SITL, I have built a ChibiOS board and grepped the bin to see that the script is embedded correctly, but I have not had a chance to flash to a board to double check.