### PR TITLE
Gps ground course in NMEA and GSOF was incorrect

### DIFF
--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -197,7 +197,7 @@ public:
         uint16_t time_week;                 ///< GPS week number
         Location location;                  ///< last fix location
         float ground_speed;                 ///< ground speed in m/s
-        float ground_course;                ///< ground course in degrees
+        float ground_course;                ///< ground course in degrees, wrapped 0-360
         float gps_yaw;                      ///< GPS derived yaw information, if available (degrees)
         uint32_t gps_yaw_time_ms;           ///< timestamp of last GPS yaw reading
         bool  gps_yaw_configured;           ///< GPS is configured to provide yaw

--- a/libraries/AP_GPS/AP_GPS_GSOF.cpp
+++ b/libraries/AP_GPS/AP_GPS_GSOF.cpp
@@ -326,7 +326,7 @@ AP_GPS_GSOF::process_message(void)
                 if ((vflag & 1) == 1)
                 {
                     state.ground_speed = SwapFloat(msg.data, a + 1);
-                    state.ground_course = degrees(SwapFloat(msg.data, a + 5));
+                    state.ground_course = wrap_360(degrees(SwapFloat(msg.data, a + 5)));
                     fill_3d_velocity();
                     state.velocity.z = -SwapFloat(msg.data, a + 9);
                     state.have_vertical_velocity = true;

--- a/libraries/SITL/SIM_GPS.cpp
+++ b/libraries/SITL/SIM_GPS.cpp
@@ -462,10 +462,9 @@ GPS_Data GPS::interpolate_data(const GPS_Data &d, uint32_t delay_ms)
     return _gps_history[N-1];
 }
 
-float GPS_Data::heading() const
+float GPS_Data::ground_track_rad() const
 {
-    const auto velocity = Vector2d{speedE, speedN};
-    return velocity.angle();
+    return atan2f(speedE, speedN);
 }
 
 float GPS_Data::speed_2d() const

--- a/libraries/SITL/SIM_GPS.h
+++ b/libraries/SITL/SIM_GPS.h
@@ -49,8 +49,9 @@ struct GPS_Data {
     float speed_acc;
     uint8_t num_sats;
 
-    // Get heading [rad], where 0 = North in WGS-84 coordinate system
-    float heading() const WARN_IF_UNUSED;
+    // Get course over ground [rad], where 0 = North in WGS-84 coordinate system.
+    // Calculated from 2D velocity.
+    float ground_track_rad() const WARN_IF_UNUSED;
 
     // Get 2D speed [m/s] in WGS-84 coordinate system
     float speed_2d() const WARN_IF_UNUSED;

--- a/libraries/SITL/SIM_GPS_NMEA.cpp
+++ b/libraries/SITL/SIM_GPS_NMEA.cpp
@@ -79,13 +79,13 @@ void GPS_NMEA::publish(const GPS_Data *d)
 
     const float speed_mps = d->speed_2d();
     const float speed_knots = speed_mps * M_PER_SEC_TO_KNOTS;
-    const auto heading_rad = d->heading();
+    const auto ground_track_deg = degrees(d->ground_track_rad());
 
     //$GPVTG,133.18,T,120.79,M,0.11,N,0.20,K,A*24
     nmea_printf("$GPVTG,%.2f,T,%.2f,M,%.2f,N,%.2f,K,A",
                      tstring,
-                     heading_rad,
-                     heading_rad,
+                     ground_track_deg,
+                     ground_track_deg,
                      speed_knots,
                      speed_knots * KNOTS_TO_METERS_PER_SECOND * 3.6);
 
@@ -95,7 +95,7 @@ void GPS_NMEA::publish(const GPS_Data *d)
                      lat_string,
                      lng_string,
                      speed_knots,
-                     heading_rad,
+                     ground_track_deg,
                      dstring);
 
     if (_sitl->gps_hdg_enabled[instance] == SITL::SIM::GPS_HEADING_HDT) {
@@ -112,7 +112,7 @@ void GPS_NMEA::publish(const GPS_Data *d)
                     d->altitude,
                     wrap_360(d->yaw_deg),
                     d->pitch_deg,
-                    heading_rad,
+                    ground_track_deg,
                     speed_mps,
                     d->roll_deg,
                     d->have_lock?1:0, // 2=rtkfloat 3=rtkfixed,

--- a/libraries/SITL/SIM_GPS_Trimble.cpp
+++ b/libraries/SITL/SIM_GPS_Trimble.cpp
@@ -175,7 +175,7 @@ void GPS_Trimble::publish(const GPS_Data *d)
                 GSOF_VEL_LEN,
                 vel_flags,
                 gsof_pack_float(d->speed_2d()),
-                gsof_pack_float(d->heading()),
+                gsof_pack_float(d->ground_track_rad()),
                 // Trimble API has ambiguous direction here.
                 // Intentionally narrow from double.
                 gsof_pack_float(static_cast<float>(d->speedD))


### PR DESCRIPTION
# Purpose

Both the NMEA and GSOF simulators have broken ground course in SITL. 

## Steps to reproduce

Set these params for GSOF against UBX:
```
GPS2_TYPE  11
SIM_GPS2_TYPE    11
```

Or these for NMEA
```
GPS2_TYPE  5
SIM_GPS2_TYPE  5
```

Then, start SITL with plane, arm, and takeoff.

## Before this PR

Here's the GPS course over ground for Ublox (GPS 1) and GSOF (GPS 2).

![image](https://github.com/ArduPilot/ardupilot/assets/25047695/3a8c5f83-d826-436a-a9a0-b0f7971819c2)

## With the fixed math on ground course, but no pi-wrapping (intermediate):
![image](https://github.com/ArduPilot/ardupilot/assets/25047695/15f4c156-5c19-417a-8217-5ad14da9f32c)


## After this PR

GSOF:
![image](https://github.com/ArduPilot/ardupilot/assets/25047695/75b8ff14-3ffd-4fe3-ace3-f2440657999f)

NMEA:
![image](https://github.com/ArduPilot/ardupilot/assets/25047695/16984413-f3f5-4e3b-a393-271f14e14d91)


## Question

Is it bad you can have a flyaway if you don't wrap the GPS ground course from 0-360? 


