### PR TITLE
Rover: Determine the prearm check results

### DIFF
--- a/Rover/AP_Arming.cpp
+++ b/Rover/AP_Arming.cpp
@@ -212,12 +212,14 @@ bool AP_Arming_Rover::motor_checks(bool report)
     bool ret = rover.g2.motors.pre_arm_check(report);
 
 #if HAL_TORQEEDO_ENABLED
-    char failure_msg[50] = {};
-    AP_Torqeedo *torqeedo = AP_Torqeedo::get_singleton();
-    if (torqeedo != nullptr) {
-        if (!torqeedo->pre_arm_checks(failure_msg, ARRAY_SIZE(failure_msg))) {
-            check_failed(report, "Torqeedo: %s", failure_msg);
-            ret = false;
+    if (ret) {
+        char failure_msg[50] = {};
+        AP_Torqeedo *torqeedo = AP_Torqeedo::get_singleton();
+        if (torqeedo != nullptr) {
+            if (!torqeedo->pre_arm_checks(failure_msg, ARRAY_SIZE(failure_msg))) {
+                check_failed(report, "Torqeedo: %s", failure_msg);
+                ret = false;
+            }
         }
     }
 #endif


### PR DESCRIPTION
The results of the first pre-arm check have not been verified.
It is better to judge the pre-arm check result and check the next pre-arm check.