### PR TITLE
AC_AttitudeControl_Heli: passthrough_bf_roll_pitch_rate_yaw use quaterion to update attitude target

### DIFF
--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
@@ -364,21 +364,16 @@ void AC_AttitudeControl_Heli::passthrough_bf_roll_pitch_rate_yaw(float roll_pass
     Quaternion att;
     _ahrs.get_quat_body_to_ned(att);
     if (ang_vel_to_euler_rate(att, _att_error_rot_vec_rad, att_error_euler_rad)) {
-        _euler_angle_target.x = wrap_PI(att_error_euler_rad.x + _ahrs.roll);
-        _euler_angle_target.y = wrap_PI(att_error_euler_rad.y + _ahrs.pitch);
-        _euler_angle_target.z = wrap_2PI(att_error_euler_rad.z + _ahrs.yaw);
-    }
 
-    // handle flipping over pitch axis
-    if (_euler_angle_target.y > M_PI / 2.0f) {
-        _euler_angle_target.x = wrap_PI(_euler_angle_target.x + M_PI);
-        _euler_angle_target.y = wrap_PI(M_PI - _euler_angle_target.x);
-        _euler_angle_target.z = wrap_2PI(_euler_angle_target.z + M_PI);
-    }
-    if (_euler_angle_target.y < -M_PI / 2.0f) {
-        _euler_angle_target.x = wrap_PI(_euler_angle_target.x + M_PI);
-        _euler_angle_target.y = wrap_PI(-M_PI - _euler_angle_target.x);
-        _euler_angle_target.z = wrap_2PI(_euler_angle_target.z + M_PI);
+        // Convert euler attitude error to Quaternion
+        Quaternion attitude_target_update;
+        attitude_target_update.from_euler(att_error_euler_rad);
+
+        // Set target based on current attitude and error
+        _attitude_target = att * attitude_target_update;
+
+        // Keep euler target upto date
+        _attitude_target.to_euler(_euler_angle_target);
     }
 
     // convert body-frame angle errors to body-frame rate targets


### PR DESCRIPTION
This is a update to remove lots of uses of `_euler_angle_target` this does two things:

- Switching to use quaternions means we don't need to worry about euler wrap handling
- This keeps the quaternion attitude target `_attitude_target` up to date rather than just the euler one `_euler_angle_target`.

As far as I can tell this should make no difference because neither attitude targets are actually used for anything other than logging while in roll/pitch flybar passthrough.