### PR TITLE
Plane: 4.5.2 release

### DIFF
--- a/AntennaTracker/ReleaseNotes.txt
+++ b/AntennaTracker/ReleaseNotes.txt
@@ -1,5 +1,9 @@
 Antenna Tracker Release Notes:
 ------------------------------
+Release 4.5.2 14th May 2024
+
+No changes from 4.5.2-beta1
+------------------------------------------------------------------
 Release 4.5.2-beta1 29th April 2024
 
 Changes from 4.5.1

--- a/AntennaTracker/version.h
+++ b/AntennaTracker/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "AntennaTracker V4.5.2-beta1"
+#define THISFIRMWARE "AntennaTracker V4.5.2"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,5,2,FIRMWARE_VERSION_TYPE_BETA
+#define FIRMWARE_VERSION 4,5,2,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 5
 #define FW_PATCH 2
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,5 +1,9 @@
 ArduPilot Copter Release Notes:
 -------------------------------
+Release 4.5.2 14th May 2024
+
+No changes from 4.5.2-beta1
+------------------------------------------------------------------
 Release 4.5.2-beta1 29th April 2024
 
 Changes from 4.5.1

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.5.2-beta1"
+#define THISFIRMWARE "ArduCopter V4.5.2"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,5,2,FIRMWARE_VERSION_TYPE_BETA
+#define FIRMWARE_VERSION 4,5,2,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 5
 #define FW_PATCH 2
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/ArduPlane/ReleaseNotes.txt
+++ b/ArduPlane/ReleaseNotes.txt
@@ -1,5 +1,9 @@
 ArduPilot Plane Release Notes:
 ------------------------------
+Release 4.5.2 14th May 2024
+
+No changes from 4.5.2-beta1
+------------------------------------------------------------------
 Release 4.5.2-beta1 29th April 2024
 
 Changes from 4.5.1

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduPlane V4.5.2-beta1"
+#define THISFIRMWARE "ArduPlane V4.5.2"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,5,2,FIRMWARE_VERSION_TYPE_BETA
+#define FIRMWARE_VERSION 4,5,2,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 5
 #define FW_PATCH 2
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/Rover/ReleaseNotes.txt
+++ b/Rover/ReleaseNotes.txt
@@ -1,5 +1,9 @@
 Rover Release Notes:
 --------------------
+Release 4.5.2 14th May 2024
+
+No changes from 4.5.2-beta1
+------------------------------------------------------------------
 Release 4.5.2-beta1 29th April 2024
 
 Changes from 4.5.1

--- a/Rover/version.h
+++ b/Rover/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduRover V4.5.2-beta1"
+#define THISFIRMWARE "ArduRover V4.5.2"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,5,2,FIRMWARE_VERSION_TYPE_BETA
+#define FIRMWARE_VERSION 4,5,2,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 5
 #define FW_PATCH 2
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -428,7 +428,7 @@ for t in $CI_BUILD_TARGET; do
         echo "Building signed firmwares"
         sudo apt-get update
         sudo apt-get install -y python3-dev
-        python3 -m pip install pymonocypher
+        python3 -m pip install pymonocypher==3.1.3.2
         ./Tools/scripts/signing/generate_keys.py testkey
         $waf configure --board CubeOrange-ODID --signed-fw --private-key testkey_private_key.dat
         $waf copter


### PR DESCRIPTION
This is the Plane-4.5.2 release which is the same as the 4.5.2-beta1 release

This is the corresponding Copter release: https://github.com/ArduPilot/ardupilot/pull/27054