### PR TITLE
AP_Scripting: fixed hard fault on handling of lua exception

### DIFF
--- a/libraries/AP_Scripting/examples/fault_handling.lua
+++ b/libraries/AP_Scripting/examples/fault_handling.lua
@@ -1,0 +1,56 @@
+--[[
+   example script to test fault handling with pcall
+--]]
+
+local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
+
+gcs:send_text(MAV_SEVERITY.INFO, "Loading fault test")
+
+local test_count = 0
+local fault_count = 0
+
+--[[
+   evaluate a lua function and return nil on fault or the functions return value
+--]]
+local function evaluate(f)
+   local ok, s = pcall(f)
+   eval_func = nil
+   if ok then
+      return s
+   end
+   fault_count = fault_count + 1
+   return nil
+end
+
+local function nil_deref()
+   local loc = nil
+   return loc:lat()
+end
+
+local function bad_random()
+   return math.random(1,0)
+end
+
+local function run_test()
+   local script_variant = test_count % 2
+   if script_variant == 0 then
+      evaluate(nil_deref)
+   elseif script_variant == 1 then
+      evaluate(bad_random)
+   end
+end
+
+local function update()
+   if test_count % 100 == 0 then
+      gcs:send_text(MAV_SEVERITY.INFO,string.format("Test %u fault_count %u", test_count, fault_count))
+   end
+   test_count = test_count + 1
+   run_test()
+   assert(fault_count == test_count, "fault and test counts should match")
+   return update,1
+end
+
+gcs:send_text(MAV_SEVERITY.INFO, "Starting fault test in 2 seconds")
+
+-- wait a while for GCS to connect
+return update,2000

--- a/libraries/AP_Scripting/lua/src/ldo.c
+++ b/libraries/AP_Scripting/lua/src/ldo.c
@@ -142,10 +142,10 @@ int luaD_rawrunprotected (lua_State *L, Pfunc f, void *ud) {
   lj.status = LUA_OK;
   lj.previous = L->errorJmp;  /* chain new error handler */
   L->errorJmp = &lj;
-  LUAI_TRY(L, &lj,
 #ifdef ARM_MATH_CM7
     __asm__("vpush {s16-s31}");
 #endif
+  LUAI_TRY(L, &lj,
     (*f)(L, ud);
   );
 #ifdef ARM_MATH_CM7


### PR DESCRIPTION
this PR adds a test that exercises rapid fault handling and fixes it by shifting the save of the extra registers before the setjmp call and adding save/restore of the first 16 fp registers
The test was derived from the networking web server. The reason the web server triggered this issue is it continues running after a fault, and continually calls async functions (server side lua calls) that may fault. Most lua scripts when they fault will stop, so only have one chance to trigger the bug. The web server gets lots of chances per second to trigger the bug.
without the fix this lua script hard faults in a few seconds
This bug has been confirmed to happen with 4.3.x and 4.4.x as well as current stable 4.5.x

