### PR TITLE
AP_Proximity: prevent buffer overflow in LD06 driver

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity_LD06.h
+++ b/libraries/AP_Proximity/AP_Proximity_LD06.h
@@ -57,7 +57,6 @@ private:
 
     // Store and keep track of the bytes being read from the sensor
     uint8_t _response[MESSAGE_LENGTH_LD06];
-    bool _response_data;
     uint16_t _byte_count;
 
     // Store for error-tracking purposes


### PR DESCRIPTION
We're using a value off the wire before it has been validated.  That value is used to limit indexing into a buffer, and that buffer isn't big enough to handle all possible "bad" values that index could take on.  Note that "read" here returns int16_t....

I've tried to simply make minimal changes in this driver to avoid the buffer overrun.
