### PR TITLE
AP_Scripting: added pullup or pulldown to pinMode()

### DIFF
--- a/libraries/AP_HAL_ChibiOS/GPIO.cpp
+++ b/libraries/AP_HAL_ChibiOS/GPIO.cpp
@@ -209,17 +209,30 @@ ioline_t GPIO::resolve_alt_config(ioline_t base, PERIPH_TYPE ptype, uint8_t inst
 }
 
 
-void GPIO::pinMode(uint8_t pin, uint8_t output)
+void GPIO::pinMode(uint8_t pin, uint8_t pin_type)
 {
     struct gpio_entry *g = gpio_by_pin_num(pin);
     if (g) {
-        if (!output && g->is_input &&
+        if (pin_type != 1 && g->is_input &&
             (g->mode == PAL_MODE_INPUT_PULLUP ||
              g->mode == PAL_MODE_INPUT_PULLDOWN)) {
             // already set
             return;
         }
-        g->mode = output?PAL_MODE_OUTPUT_PUSHPULL:PAL_MODE_INPUT;
+        switch(pin_type) {
+        case 0:
+            g->mode = PAL_MODE_INPUT;
+            break;
+        case 1:
+            g->mode = PAL_MODE_OUTPUT_PUSHPULL;
+            break;
+        case 2:
+            g->mode = PAL_MODE_INPUT_PULLUP;
+            break;
+        case 3:
+            g->mode = PAL_MODE_INPUT_PULLDOWN;
+            break;
+        }
 #if defined(STM32F7) || defined(STM32H7) || defined(STM32F4) || defined(STM32G4) || defined(STM32L4) || defined(STM32L4PLUS)
         if (g->mode == PAL_MODE_OUTPUT_PUSHPULL) {
             // retain OPENDRAIN if already set
@@ -230,7 +243,7 @@ void GPIO::pinMode(uint8_t pin, uint8_t output)
         }
 #endif
         palSetLineMode(g->pal_line, g->mode);
-        g->is_input = !output;
+        g->is_input = 0;
     }
 }
 

--- a/libraries/AP_HAL_ChibiOS/GPIO.h
+++ b/libraries/AP_HAL_ChibiOS/GPIO.h
@@ -34,7 +34,7 @@ class ChibiOS::GPIO : public AP_HAL::GPIO {
 public:
     GPIO();
     void    init() override;
-    void    pinMode(uint8_t pin, uint8_t output) override;
+    void    pinMode(uint8_t pin, uint8_t pin_type) override;
     uint8_t read(uint8_t pin) override;
     void    write(uint8_t pin, uint8_t value) override;
     void    toggle(uint8_t pin) override;

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -614,7 +614,7 @@ singleton hal.gpio literal
 singleton hal.gpio method read boolean uint8_t'skip_check
 singleton hal.gpio method write void uint8_t'skip_check uint8_t 0 1
 singleton hal.gpio method toggle void uint8_t'skip_check
-singleton hal.gpio method pinMode void uint8_t'skip_check uint8_t 0 1
+singleton hal.gpio method pinMode void uint8_t'skip_check uint8_t 0 3
 
 singleton hal.analogin depends !defined(HAL_DISABLE_ADC_DRIVER)
 singleton hal.analogin rename analog


### PR DESCRIPTION
This is a non-breaking change for existing scripts. 
The pin_types are: 
0 - input (floating)
1 - output
2 - input (pullup enabled)
3 - input (pulldown enabled)