### PR TITLE
Phase lag pre-arm check

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -6119,8 +6119,11 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         esc_hz = self.get_average_esc_frequency()
         esc_peakdb1 = psd["X"][int(esc_hz)]
 
-        # now add notch-per motor and check that the peak is squashed
-        self.set_parameter("INS_HNTCH_OPTS", 2)
+        # now add notch-per motor at f/4 and check that the peak is squashed
+        self.set_parameters({
+            "INS_HNTCH_OPTS": 2,
+            "INS_HNTCH_BW": 20,
+        })
         self.reboot_sitl()
 
         freq, hover_throttle, peakdb2, psd = \
@@ -6147,6 +6150,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         try:
             self.progress("Flying Octacopter with ESC telemetry driven dynamic notches")
             self.set_parameter("INS_HNTCH_OPTS", 0)
+            self.set_parameter("INS_HNTCH_BW", 40)
+
             self.customise_SITL_commandline(
                 [],
                 defaults_filepath=','.join(self.model_defaults_filepath("octa")),
@@ -6159,8 +6164,11 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             esc_peakdb1 = psd["X"][int(esc_hz)]
 
             # now add notch-per motor and check that the peak is squashed
-            self.set_parameter("INS_HNTCH_HMNCS", 1)
-            self.set_parameter("INS_HNTCH_OPTS", 2)
+            self.set_parameters({
+                "INS_HNTCH_OPTS": 2,
+                "INS_HNTCH_BW": 20,
+                "INS_HNTCH_HMNCS": 1
+            })
             self.reboot_sitl()
 
             freq, hover_throttle, peakdb2, psd = \

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1635,7 +1635,10 @@ bool AP_Arming::pre_arm_checks(bool report)
         &  opendroneid_checks(report)
 #endif
 #if AP_ARMING_CRASHDUMP_ACK_ENABLED
-        & crashdump_checks(report)
+        &  crashdump_checks(report)
+#endif
+#if AP_INERTIALSENSOR_HARMONICNOTCH_ENABLED
+        &  notch_checks(report)
 #endif
         &  serial_protocol_checks(report)
         &  estop_checks(report);
@@ -1724,6 +1727,17 @@ bool AP_Arming::crashdump_checks(bool report)
     return false;
 }
 #endif  // AP_ARMING_CRASHDUMP_ACK_ENABLED
+
+bool AP_Arming::notch_checks(bool report)
+{
+#if APM_BUILD_COPTER_OR_HELI || APM_BUILD_TYPE(APM_BUILD_ArduPlane) || APM_BUILD_TYPE(APM_BUILD_Rover)
+    if (!AP::vehicle()->pre_arm_check_notches()) {
+        check_failed(ARMING_CHECK_NOTCHES, report, "Notch bandwidth too high");
+        return false;
+    }
+#endif
+    return true;
+}
 
 bool AP_Arming::mandatory_checks(bool report)
 {

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -43,6 +43,7 @@ public:
         ARMING_CHECK_VISION      = (1U << 18),
         ARMING_CHECK_FFT         = (1U << 19),
         ARMING_CHECK_OSD         = (1U << 20),
+        ARMING_CHECK_NOTCHES     = (1U << 21),
     };
 
     enum class Method {
@@ -235,6 +236,7 @@ protected:
 #if AP_ARMING_CRASHDUMP_ACK_ENABLED
     bool crashdump_checks(bool report);
 #endif
+    bool notch_checks(bool report);
 
     virtual bool system_checks(bool report);
 

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -293,7 +293,8 @@ public:
     virtual bool set_home_to_current_location(bool lock) WARN_IF_UNUSED { return false; }
     virtual bool set_home(const Location& loc, bool lock) WARN_IF_UNUSED { return false; }
 #endif
-
+    // notch pre-arm check
+    bool pre_arm_check_notches() const;
 protected:
 
     virtual void init_ardupilot() = 0;

--- a/libraries/Filter/HarmonicNotchFilter.h
+++ b/libraries/Filter/HarmonicNotchFilter.h
@@ -114,6 +114,7 @@ public:
         EnableOnAllIMUs = 1<<3,
         TripleNotch = 1<<4,
         TreatLowAsMin = 1<<5,
+        DisableNotchPreArm = 1<<6,
     };
 
     HarmonicNotchFilterParams(void);


### PR DESCRIPTION
Made a separate PR for discussion so as to not hold up https://github.com/ArduPilot/ardupilot/pull/26674

@tridge your original suggestion was ```bw > 0.75*freq/nsources```, I assume that was a typo because that will break the configuration of all 14 of my copters that are using this feature very successfully (and for which this feature was originally written) 😄 I have changed that to  ```bw * 0.75 > freq/nsources``` which at least does not break many existing configurations but it does not work on octacopters. It is impossible to get the octacopter test to pass with this setting which was my original concern with having any check like this - it simply does not filter enough noise. My suggestion therefore is either to make this a warning or simply clamp the check at f/4. Either way much discussion and testing required!