### PR TITLE
Copter: Handle DO_MOUNT_CONTROL yaw angle as body frame 

### DIFF
--- a/ArduCopter/autoyaw.cpp
+++ b/ArduCopter/autoyaw.cpp
@@ -149,6 +149,18 @@ void Mode::AutoYaw::set_yaw_angle_rate(float yaw_angle_d, float yaw_rate_ds)
     set_mode(Mode::ANGLE_RATE);
 }
 
+// set_yaw_angle_offset - sets the yaw look at heading for auto mode, as an offset from the current yaw angle
+void Mode::AutoYaw::set_yaw_angle_offset(const float yaw_angle_offset_d)
+{
+    _last_update_ms = millis();
+
+    _yaw_angle_cd = wrap_360_cd(_yaw_angle_cd + (yaw_angle_offset_d * 100.0));
+    _yaw_rate_cds = 0.0f;
+
+    // set yaw mode
+    set_mode(Mode::ANGLE_RATE);
+}
+
 // set_roi - sets the yaw to look at roi for auto mode
 void Mode::AutoYaw::set_roi(const Location &roi_location)
 {

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -335,6 +335,8 @@ public:
 
         void set_yaw_angle_rate(float yaw_angle_d, float yaw_rate_ds);
 
+        void set_yaw_angle_offset(const float yaw_angle_offset_d);
+
         bool reached_fixed_yaw_target();
 
 #if WEATHERVANE_ENABLED

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1983,7 +1983,9 @@ void ModeAuto::do_mount_control(const AP_Mission::Mission_Command& cmd)
     // if vehicle has a camera mount but it doesn't do pan control then yaw the entire vehicle instead
     if ((copter.camera_mount.get_mount_type() != AP_Mount::Type::None) &&
         !copter.camera_mount.has_pan_control()) {
-        auto_yaw.set_yaw_angle_rate(cmd.content.mount_control.yaw,0.0f);
+        // Per the handler in AP_Mount, DO_MOUNT_CONTROL yaw angle is in body frame, which is
+        // equivalent to an offset to the current yaw demand.
+        auto_yaw.set_yaw_angle_offset(cmd.content.mount_control.yaw);
     }
     // pass the target angles to the camera mount
     copter.camera_mount.set_angle_target(cmd.content.mount_control.roll, cmd.content.mount_control.pitch, cmd.content.mount_control.yaw, false);

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -1251,6 +1251,7 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
         break;
 
     case MAV_CMD_DO_MOUNT_CONTROL:                      // MAV ID: 205
+        // TODO: this is only valid if packet.z == MAV_MOUNT_MODE_MAVLINK_TARGETING
         cmd.content.mount_control.pitch = packet.param1;
         cmd.content.mount_control.roll = packet.param2;
         cmd.content.mount_control.yaw = packet.param3;
@@ -1767,6 +1768,7 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
         packet.param1 = cmd.content.mount_control.pitch;
         packet.param2 = cmd.content.mount_control.roll;
         packet.param3 = cmd.content.mount_control.yaw;
+        packet.z = MAV_MOUNT_MODE_MAVLINK_TARGETING;
         break;
 
     case MAV_CMD_DO_SET_CAM_TRIGG_DIST:                 // MAV ID: 206


### PR DESCRIPTION
The demanded yaw angles in the `MOUNT_CONTROL` and `DO_MOUNT_CONTROL` commands are in body frame (and are handled this way in `AP_Mount`). This fixes the Copter handlers where they were being treated as earth frame.

It also rejects these messages if an invalid mode is provided, as the yaw control is only applicable when the mode is `MAV_MOUNT_MODE_MAVLINK_TARGETING`.

FYI: @rmackay9