### PR TITLE
AC_Fence: A circular fence with a radius of 0 meters is ignored

### DIFF
--- a/libraries/AC_Fence/AC_PolyFence_loader.cpp
+++ b/libraries/AC_Fence/AC_PolyFence_loader.cpp
@@ -968,7 +968,7 @@ bool AC_PolyFence_loader::validate_fence(const AC_PolyFenceItem *new_items, uint
                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Received incorrect type (want=%u got=%u)", (unsigned)expecting_type, (unsigned)new_items[i].type);
                return false;
             }
-            if (!is_positive(new_items[i].radius)) {
+            if (is_negative(new_items[i].radius)) {
                 GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Non-positive circle radius");
                 return false;
             }
@@ -1093,6 +1093,10 @@ bool AC_PolyFence_loader::write_fence(const AC_PolyFenceItem *new_items, uint16_
             return false;
         case AC_PolyFenceType::CIRCLE_INCLUSION:
         case AC_PolyFenceType::CIRCLE_EXCLUSION: {
+            if (!is_positive(new_item.radius)) {  // radius must be positive
+                break;
+            }
+
             total_vertex_count++; // useful to make number of lines in QGC file match FENCE_TOTAL
             const bool store_as_int = (new_item.radius - int(new_item.radius) < 0.001);
             AC_PolyFenceType store_type = new_item.type;


### PR DESCRIPTION
I am developing an application for vehicles that support MAVLINK messages. I have discovered different behaviors in the setting of circular fences. I want to ignore circles with a radius of 0 meters. By ignoring circles with a radius of 0 meters, I can standardize the processing with vehicles other than ArduPilot.

AFTER
![Screenshot from 2024-05-18 23-13-29](https://github.com/ArduPilot/ardupilot/assets/646194/f8e44da2-e523-405b-b8cb-9366482063e5)

![Screenshot from 2024-05-18 23-13-36](https://github.com/ArduPilot/ardupilot/assets/646194/d76dfbde-d99b-4221-8aed-2cf7be9faead)

BEFORE
![Screenshot from 2024-05-18 22-11-23](https://github.com/ArduPilot/ardupilot/assets/646194/ffd40aa9-82bf-411d-9d8b-9d6985d0f8d8)
