### PR TITLE
Tools: specify pymonocypher version in more places

### DIFF
--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -261,8 +261,13 @@ def sign_firmware(image, private_keyfile):
     try:
         import monocypher
     except ImportError:
-        Logs.error("Please install monocypher with: python3 -m pip install pymonocypher")
+        Logs.error("Please install monocypher with: python3 -m pip install pymonocypher==3.1.3.2")
         return None
+
+    if monocypher.__version__ != "3.1.3.2":
+        Logs.error("must use monocypher 3.1.3.2, please run: python3 -m pip install pymonocypher==3.1.3.2")
+        return None
+
     try:
         key = open(private_keyfile, 'r').read()
     except Exception as ex:

--- a/Tools/scripts/signing/README.md
+++ b/Tools/scripts/signing/README.md
@@ -12,7 +12,7 @@ firmware doesn't match any of the public keys in the bootloader.
 To generate a public/private key pair, run the following command:
 
 ```
-  python3 -m pip install pymonocypher
+  python3 -m pip install pymonocypher==3.1.3.2
   Tools/scripts/signing/generate_keys.py NAME
 ```
 
@@ -131,7 +131,13 @@ This opens a secure command session using your private_key.dat file to allow the
   securecommand getpublickeys        will return the number of public keys...you will need this next
   securecommand removepublickeys 0 X   where X is the number of public keys...this removes them
 ```
-Re-run the 'getpublickeys' command again to verify that all keys have been removed.
+
+For example, if you have a standard firmware with the 3 ArduPilot
+public keys and one of your own public keys then X will be 4 in the
+above command.
+
+Re-run the 'getpublickeys' command again to verify that all keys have
+been removed.
 
 Now exit MAVProxy and build a firmware using the normal bootloader but still using the --signed-fw option:
 

--- a/Tools/scripts/signing/generate_keys.py
+++ b/Tools/scripts/signing/generate_keys.py
@@ -9,9 +9,12 @@ import base64
 try:
     import monocypher
 except ImportError:
-    print("Please install monocypher with: python3 -m pip install pymonocypher")
+    print("Please install monocypher with: python3 -m pip install pymonocypher==3.1.3.2")
     sys.exit(1)
 
+if monocypher.__version__ != "3.1.3.2":
+    Logs.error("must use monocypher 3.1.3.2, please run: python3 -m pip install pymonocypher==3.1.3.2")
+    sys.exit(1)
 
 if len(sys.argv) != 2:
     print("Usage: generate_keys.py BASENAME")

--- a/Tools/scripts/signing/make_secure_bl.py
+++ b/Tools/scripts/signing/make_secure_bl.py
@@ -7,12 +7,6 @@ import sys
 import os
 import base64
 
-try:
-    import monocypher
-except ImportError:
-    print("Please install monocypher with: python3 -m pip install pymonocypher")
-    sys.exit(1)
-
 # get command line arguments
 from argparse import ArgumentParser
 parser = ArgumentParser(description='make_secure_bl')

--- a/Tools/scripts/signing/make_secure_fw.py
+++ b/Tools/scripts/signing/make_secure_fw.py
@@ -10,9 +10,13 @@ import json, base64, zlib
 try:
     import monocypher
 except ImportError:
-    print("Please install monocypher with: python3 -m pip install pymonocypher")
+    print("Please install monocypher with: python3 -m pip install pymonocypher==3.1.3.2")
     sys.exit(1)
 
+if monocypher.__version__ != "3.1.3.2":
+    Logs.error("must use monocypher 3.1.3.2, please run: python3 -m pip install pymonocypher==3.1.3.2")
+    return None
+    
 key_len = 32
 sig_len = 64
 sig_version = 30437


### PR DESCRIPTION
ensure users don't end up with the wrong version, and throw an error if they do
