### PR TITLE
AP_BattMonitor: FuelLevel_Analog: set has_current true so capacity is reported

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_FuelLevel_Analog.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_FuelLevel_Analog.h
@@ -40,8 +40,8 @@ public:
     // returns true if battery monitor provides consumed energy info
     bool has_consumed_energy() const override { return true; }
 
-    // returns true if battery monitor provides current info
-    bool has_current() const override { return false; }
+    // returns true if battery monitor provides current info (or capacity)
+    bool has_current() const override { return true; }
 
     void init(void) override {}
 


### PR DESCRIPTION
This was changed in https://github.com/ArduPilot/ardupilot/pull/25219, I'm not sure why. Fixes https://github.com/ArduPilot/ardupilot/issues/27017