### PR TITLE
AP_Notify: Set the value that matches the type of the variable

### DIFF
--- a/libraries/AP_Notify/AP_BoardLED.cpp
+++ b/libraries/AP_Notify/AP_BoardLED.cpp
@@ -85,7 +85,7 @@ void AP_BoardLED::update(void)
                 break;
 
             default:
-                save_trim_counter = -1;
+                save_trim_counter = 255u;
                 break;
         }
         return;
@@ -115,7 +115,7 @@ void AP_BoardLED::update(void)
                     break;
                 default:
                     // reset counter to restart the sequence
-                    arm_counter = -1;
+                    arm_counter = 255u;
                     break;
             }
         }else{
@@ -135,7 +135,7 @@ void AP_BoardLED::update(void)
                     break;
 
                 default:
-                    arm_counter = -1;
+                    arm_counter = 255u;
                     break;
             }
         }


### PR DESCRIPTION
The variable type is UINT8_T.
This variable is being set to -1.
This is a type mismatch.
I will set a value that matches the type.