### PR TITLE
AP_TECS: modify max climb estimate to prevent throttle bouncing on limit

### DIFF
--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -579,9 +579,13 @@ void AP_TECS::_update_height_demand(void)
             }
             const float hgt_dem_alpha = _DT / MAX(_DT + _hgt_dem_tconst, _DT);
             if (max_climb_condition && _hgt_dem > _hgt_dem_prev) {
-                    _max_climb_scaler *= (1.0f - hgt_dem_alpha);
+                float est_max_climb_scaler = constrain_float((_climb_rate * 1.1f) / _maxClimbRate,0.0f,1.0f);
+                
+                _max_climb_scaler += (est_max_climb_scaler-_max_climb_scaler) * hgt_dem_alpha;
             } else if (max_descent_condition && _hgt_dem < _hgt_dem_prev) {
-                _max_sink_scaler *= (1.0f - hgt_dem_alpha);
+                float est_max_sink_scaler = constrain_float((-_climb_rate * 1.1f) / _maxSinkRate,0.0f,1.0f);
+                
+                _max_sink_scaler += (est_max_sink_scaler-_max_sink_scaler) * hgt_dem_alpha;
             } else {
                 _max_climb_scaler = _max_climb_scaler * (1.0f - hgt_dem_alpha) + hgt_dem_alpha;
                 _max_sink_scaler  =  _max_sink_scaler * (1.0f - hgt_dem_alpha) + hgt_dem_alpha;


### PR DESCRIPTION
During a steady climb where throttle is saturated, throttle will not consistently hold at 100%, but will instead periodically bounce because of the behavior of ```_max_climb_scaler```. The same applies to descents.

Example from log:
![bouncing-throttle](https://github.com/ArduPilot/ardupilot/assets/1015761/8f12dedd-5853-4d5b-b26d-f59e2145f77d)

This pull request contains a **currently un-tested** proposal for fixing this. ```_max_(climb|sink)_scaler``` will now asymptotically approach the current climb/sink rate (plus a 10% margin, to be discussed) over time, rather than rocketing down toward zero. @magicrub @tridge @samuelctabor @priseborough thoughts?