### PR TITLE
AP_Compass: magcal keeps soft iron matrix + scale bugfix

### DIFF
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -2188,6 +2188,18 @@ bool Compass::have_scale_factor(uint8_t i) const
     return true;
 }
 
+/*
+  return scale factor for compass instance or 1 if unavailable
+ */
+float Compass::get_scale_factor(uint8_t i) const
+{
+    if (!have_scale_factor(i)) {
+        return 1;
+    }
+    StateIndex id = _get_state_id(Priority(i));
+    return _state[id].scale_factor;
+}
+
 #if AP_COMPASS_MSP_ENABLED
 void Compass::handle_msp(const MSP::msp_compass_data_message_t &pkt)
 {

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -161,6 +161,9 @@ public:
 
     /// Return true if we have set a scale factor for a compass
     bool have_scale_factor(uint8_t i) const;
+    
+    // Return scale factor for this compass or 1.0 if not set
+    float get_scale_factor(uint8_t i) const;
 
     // compass calibrator interface
     void cal_update();
@@ -412,9 +415,8 @@ private:
       get mag field with the effects of offsets, diagonals and
       off-diagonals removed
     */
-    bool get_uncorrected_field(uint8_t instance, Vector3f &field) const;
+    bool compute_offsets(uint8_t instance, const Vector3f& truth_field, Vector3f &new_offsets) const;
 #endif
-
 #if COMPASS_CAL_ENABLED
     //keep track of which calibrators have been saved
     RestrictIDTypeArray<bool, COMPASS_MAX_INSTANCES, Priority> _cal_saved;


### PR DESCRIPTION
This patch changes the large vehicle compass calibration so that it keeps the soft-iron calibration matrix and the scale. This way, the user can perform a full compass calibration on a subsystem of the vehicle, without losing it when a large vehicle cal is performed.

It also fixes a bug: large vehicle compass calibration currently does not respect the scale parameter. It needs to either incorporate it into the math or reset it to 1.

Why was the scale param added when the diagonals already exist? Seems like something that can be removed.