### PR TITLE
AP_Mount: add Siyi ZT6 support

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -29,6 +29,7 @@ const AP_Mount_Siyi::HWInfo AP_Mount_Siyi::hardware_lookup_table[] {
         {{'7','3'}, "A8"},
         {{'6','B'}, "ZR10"},
         {{'7','8'}, "ZR30"},
+        {{'8','2'}, "ZT6"},
         {{'7','A'}, "ZT30"},
 };
 
@@ -827,7 +828,8 @@ float AP_Mount_Siyi::get_zoom_mult_max() const
         return 0;
     case HardwareModel::A2:
     case HardwareModel::A8:
-        // a8 has 6x digital zoom
+    case HardwareModel::ZT6:
+        // a8, zt6 have 6x digital zoom
         return 6;
     case HardwareModel::ZR10:
     case HardwareModel::ZR30:
@@ -1045,6 +1047,7 @@ void AP_Mount_Siyi::send_camera_information(mavlink_channel_t chan) const
     case HardwareModel::UNKNOWN:
     case HardwareModel::A2:
     case HardwareModel::A8:
+    case HardwareModel::ZT6:
         focal_length_mm = 21;
         break;
     case HardwareModel::ZR10:
@@ -1152,6 +1155,7 @@ void AP_Mount_Siyi::check_firmware_version() const
         case HardwareModel::A2:
         case HardwareModel::ZR10:
         case HardwareModel::ZR30:
+        case HardwareModel::ZT6:
         case HardwareModel::ZT30:
             // TBD
             break;

--- a/libraries/AP_Mount/AP_Mount_Siyi.h
+++ b/libraries/AP_Mount/AP_Mount_Siyi.h
@@ -166,6 +166,7 @@ private:
         A8,
         ZR10,
         ZR30,
+        ZT6,
         ZT30
     } _hardware_model;
 


### PR DESCRIPTION
This adds support for the new [Siyi ZT6 RGB+Thermal camera](https://en.siyi.biz/products/siyi-zt6).

This resolves issue https://github.com/ArduPilot/ardupilot/issues/27060

This is in response to this discussion https://discuss.ardupilot.org/t/gimbal-zoom-type-issue/117708
