### PR TITLE
add checking of instance number before update with incoming data

### DIFF
--- a/libraries/AP_GPS/AP_GPS_MAV.cpp
+++ b/libraries/AP_GPS/AP_GPS_MAV.cpp
@@ -47,6 +47,11 @@ void AP_GPS_MAV::handle_msg(const mavlink_message_t &msg)
             mavlink_gps_input_t packet;
             mavlink_msg_gps_input_decode(&msg, &packet);
 
+            // check if target instance belongs to incoming gps data.
+            if (state.instance != packet.gps_id) {
+                return;
+            }
+
             bool have_alt    = ((packet.ignore_flags & GPS_INPUT_IGNORE_FLAG_ALT) == 0);
             bool have_hdop   = ((packet.ignore_flags & GPS_INPUT_IGNORE_FLAG_HDOP) == 0);
             bool have_vdop   = ((packet.ignore_flags & GPS_INPUT_IGNORE_FLAG_VDOP) == 0);
@@ -144,6 +149,11 @@ void AP_GPS_MAV::handle_msg(const mavlink_message_t &msg)
         case MAVLINK_MSG_ID_HIL_GPS: {
             mavlink_hil_gps_t packet;
             mavlink_msg_hil_gps_decode(&msg, &packet);
+
+            // check if target instance belongs to incoming gps data.
+            if (state.instance != packet.id) {
+                return;
+            }
 
             state.time_week = 0;
             state.time_week_ms  = packet.time_usec/1000;


### PR DESCRIPTION
according to mavlink specification, GPS_MAV should check "gps_id" field before handle incoming GPS_INPUT or HIL_GPS message for correct multiply GPS support via mavlink.
![Screenshot from 2024-05-21 14-00-01](https://github.com/ArduPilot/ardupilot/assets/55427288/b6ca7315-259b-42e1-8c75-7a0d752b1502)
![image](https://github.com/ArduPilot/ardupilot/assets/55427288/d6e7c2a1-7a6e-40fb-b3a2-ffe25076085c)
