### PR TITLE
AP_Compass: removed IST8310 overrun message

### DIFF
--- a/libraries/AP_Compass/AP_Compass_IST8308.cpp
+++ b/libraries/AP_Compass/AP_Compass_IST8308.cpp
@@ -200,10 +200,6 @@ void AP_Compass_IST8308::timer()
         return;
     }
 
-    if (stat & STAT1_VAL_DOR) {
-        printf("IST8308: data overrun\n");
-    }
-
     if (!_dev->read_registers(DATAX_L_REG, (uint8_t *) &buffer,
                               sizeof(buffer))) {
         return;


### PR DESCRIPTION
this is not useful and just causes concern to users. Any small bus delay can trigger this. We have health monitoring at a higher level