### PR TITLE
Mount: fix serial port used for 2nd serial driver

### DIFF
--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -62,6 +62,9 @@ void AP_Mount::init()
     // primary is reset to the first instantiated mount
     bool primary_set = false;
 
+    // keep track of number of serial instances for initialisation
+    uint8_t serial_instance = 0;
+
     // create each instance
     for (uint8_t instance=0; instance<AP_MOUNT_MAX_INSTANCES; instance++) {
         switch (get_mount_type(instance)) {
@@ -98,8 +101,9 @@ void AP_Mount::init()
 #if HAL_MOUNT_STORM32SERIAL_ENABLED
         // check for SToRM32 mounts using serial protocol
         case Type::SToRM32_serial:
-            _backends[instance] = new AP_Mount_SToRM32_serial(*this, _params[instance], instance);
+            _backends[instance] = new AP_Mount_SToRM32_serial(*this, _params[instance], instance, serial_instance);
             _num_instances++;
+            serial_instance++;
             break;
 #endif
 
@@ -122,8 +126,9 @@ void AP_Mount::init()
 #if HAL_MOUNT_SIYI_ENABLED
         // check for Siyi gimbal
         case Type::Siyi:
-            _backends[instance] = new AP_Mount_Siyi(*this, _params[instance], instance);
+            _backends[instance] = new AP_Mount_Siyi(*this, _params[instance], instance, serial_instance);
             _num_instances++;
+            serial_instance++;
             break;
 #endif // HAL_MOUNT_SIYI_ENABLED
 
@@ -146,8 +151,9 @@ void AP_Mount::init()
 #if HAL_MOUNT_VIEWPRO_ENABLED
         // check for Xacti gimbal
         case Type::Viewpro:
-            _backends[instance] = new AP_Mount_Viewpro(*this, _params[instance], instance);
+            _backends[instance] = new AP_Mount_Viewpro(*this, _params[instance], instance, serial_instance);
             _num_instances++;
+            serial_instance++;
             break;
 #endif // HAL_MOUNT_VIEWPRO_ENABLED
         }

--- a/libraries/AP_Mount/AP_Mount_Backend_Serial.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend_Serial.cpp
@@ -1,0 +1,24 @@
+#include "AP_Mount_Backend_Serial.h"
+
+#if HAL_MOUNT_ENABLED
+#include <AP_SerialManager/AP_SerialManager.h>
+
+// Default init function for every mount
+void AP_Mount_Backend_Serial::init()
+{
+    const AP_SerialManager& serial_manager = AP::serialmanager();
+
+    // search for serial port.  hild classes should check that uart is not nullptr
+    _uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Gimbal, _serial_instance);
+    if (_uart == nullptr) {
+        return;
+    }
+
+    // initialised successfully if uart is found
+    _initialised = true;
+
+    // call the parent class init
+    AP_Mount_Backend::init();
+}
+
+#endif // HAL_MOUNT_ENABLED

--- a/libraries/AP_Mount/AP_Mount_Backend_Serial.h
+++ b/libraries/AP_Mount/AP_Mount_Backend_Serial.h
@@ -1,0 +1,48 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+  Mount driver backend class for serial drivers
+  Mounts using custom serial protocols should be derived from this class
+ */
+#pragma once
+
+#include "AP_Mount_config.h"
+
+#if HAL_MOUNT_ENABLED
+
+#include "AP_Mount_Backend.h"
+
+class AP_Mount_Backend_Serial : public AP_Mount_Backend
+{
+public:
+    // Constructor
+    AP_Mount_Backend_Serial(class AP_Mount &frontend, class AP_Mount_Params &params, uint8_t instance, uint8_t serial_instance) :
+        AP_Mount_Backend(frontend, params, instance),
+        _serial_instance(serial_instance)
+    {}
+
+    // perform any required initialisation for this instance
+    void init() override;
+
+protected:
+
+    // internal variables
+    AP_HAL::UARTDriver *_uart;      // uart connected to gimbal
+    uint8_t _serial_instance;       // this instance's serial instance number
+    bool _initialised;              // true if uart has been initialised
+};
+
+#endif // HAL_MOUNT_ENABLED

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
@@ -3,7 +3,7 @@
  */
 #pragma once
 
-#include "AP_Mount_Backend.h"
+#include "AP_Mount_Backend_Serial.h"
 
 #if HAL_MOUNT_STORM32SERIAL_ENABLED
 
@@ -13,15 +13,12 @@
 
 #define AP_MOUNT_STORM32_SERIAL_RESEND_MS   1000    // resend angle targets to gimbal once per second
 
-class AP_Mount_SToRM32_serial : public AP_Mount_Backend
+class AP_Mount_SToRM32_serial : public AP_Mount_Backend_Serial
 {
 
 public:
     // Constructor
-    using AP_Mount_Backend::AP_Mount_Backend;
-
-    // init - performs any required initialisation for this instance
-    void init() override;
+    using AP_Mount_Backend_Serial::AP_Mount_Backend_Serial;
 
     // update mount position - should be called periodically
     void update() override;
@@ -127,11 +124,7 @@ private:
 
 
     // internal variables
-    AP_HAL::UARTDriver *_port;
-
-    bool _initialised;              // true once the driver has been initialised
     uint32_t _last_send;            // system time of last do_mount_control sent to gimbal
-
     uint8_t _reply_length;
     uint8_t _reply_counter;
     ReplyType _reply_type = ReplyType_UNKNOWN;

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -5,7 +5,6 @@
 #include <AP_AHRS/AP_AHRS.h>
 #include <GCS_MAVLink/GCS.h>
 #include <GCS_MAVLink/include/mavlink/v2.0/checksum.h>
-#include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_RTC/AP_RTC.h>
 
 extern const AP_HAL::HAL& hal;
@@ -31,20 +30,6 @@ const AP_Mount_Siyi::HWInfo AP_Mount_Siyi::hardware_lookup_table[] {
         {{'7','8'}, "ZR30"},
         {{'7','A'}, "ZT30"},
 };
-
-// init - performs any required initialisation for this instance
-void AP_Mount_Siyi::init()
-{
-    const AP_SerialManager& serial_manager = AP::serialmanager();
-
-    _uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Gimbal, 0);
-    if (_uart == nullptr) {
-        return;
-    }
-
-    _initialised = true;
-    AP_Mount_Backend::init();
-}
 
 // update mount position - should be called periodically
 void AP_Mount_Siyi::update()

--- a/libraries/AP_Mount/AP_Mount_Siyi.h
+++ b/libraries/AP_Mount/AP_Mount_Siyi.h
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "AP_Mount_Backend.h"
+#include "AP_Mount_Backend_Serial.h"
 
 #if HAL_MOUNT_SIYI_ENABLED
 
@@ -29,18 +29,15 @@
 
 #define AP_MOUNT_SIYI_PACKETLEN_MAX     38  // maximum number of bytes in a packet sent to or received from the gimbal
 
-class AP_Mount_Siyi : public AP_Mount_Backend
+class AP_Mount_Siyi : public AP_Mount_Backend_Serial
 {
 
 public:
     // Constructor
-    using AP_Mount_Backend::AP_Mount_Backend;
+    using AP_Mount_Backend_Serial::AP_Mount_Backend_Serial;
 
     /* Do not allow copies */
     CLASS_NO_COPY(AP_Mount_Siyi);
-
-    // init - performs any required initialisation for this instance
-    void init() override;
 
     // update mount position - should be called periodically
     void update() override;
@@ -293,8 +290,6 @@ private:
     void check_firmware_version() const;
 
     // internal variables
-    AP_HAL::UARTDriver *_uart;                      // uart connected to gimbal
-    bool _initialised;                              // true once the driver has been initialised
     bool _got_hardware_id;                          // true once hardware id ha been received
 
     FirmwareVersion _fw_version;                    // firmware version (for reporting for GCS)

--- a/libraries/AP_Mount/AP_Mount_Viewpro.cpp
+++ b/libraries/AP_Mount/AP_Mount_Viewpro.cpp
@@ -7,7 +7,6 @@
 #include <AP_RTC/AP_RTC.h>
 #include <GCS_MAVLink/GCS.h>
 #include <GCS_MAVLink/include/mavlink/v2.0/checksum.h>
-#include <AP_SerialManager/AP_SerialManager.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -27,20 +26,6 @@ extern const AP_HAL::HAL& hal;
 #define debug(fmt, args ...) do { if (AP_MOUNT_VIEWPRO_DEBUG) { GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Viewpro: " fmt, ## args); } } while (0)
 
 const char* AP_Mount_Viewpro::send_text_prefix = "Viewpro:";
-
-// init - performs any required initialisation for this instance
-void AP_Mount_Viewpro::init()
-{
-    const AP_SerialManager& serial_manager = AP::serialmanager();
-
-    _uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Gimbal, 0);
-    if (_uart == nullptr) {
-        return;
-    }
-
-    _initialised = true;
-    AP_Mount_Backend::init();
-}
 
 // update mount position - should be called periodically
 void AP_Mount_Viewpro::update()

--- a/libraries/AP_Mount/AP_Mount_Viewpro.h
+++ b/libraries/AP_Mount/AP_Mount_Viewpro.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include "AP_Mount_Backend.h"
+#include "AP_Mount_Backend_Serial.h"
 
 #if HAL_MOUNT_VIEWPRO_ENABLED
 
@@ -27,18 +27,15 @@
 
 #define AP_MOUNT_VIEWPRO_PACKETLEN_MAX  63  // maximum number of bytes in a packet sent to or received from the gimbal
 
-class AP_Mount_Viewpro : public AP_Mount_Backend
+class AP_Mount_Viewpro : public AP_Mount_Backend_Serial
 {
 
 public:
     // Constructor
-    using AP_Mount_Backend::AP_Mount_Backend;
+    using AP_Mount_Backend_Serial::AP_Mount_Backend_Serial;
 
     /* Do not allow copies */
     CLASS_NO_COPY(AP_Mount_Viewpro);
-
-    // init - performs any required initialisation for this instance
-    void init() override;
 
     // update mount position - should be called periodically
     void update() override;
@@ -378,8 +375,6 @@ private:
     bool send_m_ahrs();
 
     // internal variables
-    AP_HAL::UARTDriver *_uart;                      // uart connected to gimbal
-    bool _initialised;                              // true once the driver has been initialised
     uint8_t _msg_buff[AP_MOUNT_VIEWPRO_PACKETLEN_MAX];  // buffer holding latest bytes from gimbal
     uint8_t _msg_buff_len;                          // number of bytes held in msg buff
     const uint8_t _msg_buff_data_start = 2;         // data starts at this byte of _msg_buff


### PR DESCRIPTION
This PR fixes a bug in our three serial mount drivers which currently always try to use the first serial port defined for use with gimbals (e.g. SERIALx_PROTOCOL = 8/Gimbal).  The bug appears when the user tries to set up two serial mounts.

The fix uses a similar pattern to our rangefinder drivers in that we track the serial driver instance and pass that into the constructor.  This serial instance (instead of the regular instance) is used when searching for the serial port.

This has been lightly tested on CubeRed connectded to a Siyi A8 (over ethernet) and ViewPro A10 (over serial).  Below is a picture of the new QGC 4.4 that includes support for controlling multiple gimbals.  Using the changes in this PR I was able to control both gimbals independently.
![image](https://github.com/ArduPilot/ardupilot/assets/1498098/8f36a5d1-26b6-4981-b0ab-9c2371d0c3e5)

It will likely be difficult to get testing done for the SToRM32.

This resolves issue https://github.com/ArduPilot/ardupilot/issues/27090

FYI @timtuxworth, I'm happy to build you a binary if you'd also like to test.  Alternatively it may be merged to master/latest soon.
