### PR TITLE
Tools: ros2: Improve ability to launch plane in headless mode

### DIFF
--- a/Tools/ros2/ardupilot_sitl/CMakeLists.txt
+++ b/Tools/ros2/ardupilot_sitl/CMakeLists.txt
@@ -99,6 +99,12 @@ install(DIRECTORY
   DESTINATION share/${PROJECT_NAME}/config/
 )
 
+# Install additional autotest model params.
+install(DIRECTORY
+  ${ARDUPILOT_ROOT}/Tools/autotest/models
+  DESTINATION share/${PROJECT_NAME}/config/
+)
+
 # Install Python package.
 ament_python_install_package(${PROJECT_NAME}
   PACKAGE_DIR src/${PROJECT_NAME}

--- a/Tools/ros2/ardupilot_sitl/src/ardupilot_sitl/launch.py
+++ b/Tools/ros2/ardupilot_sitl/src/ardupilot_sitl/launch.py
@@ -31,6 +31,9 @@ from launch_ros.substitutions import FindPackageShare
 
 from .actions import ExecuteFunction
 
+TRUE_STRING = "True"
+FALSE_STRING = "False"
+BOOL_STRING_CHOICES = set([TRUE_STRING, FALSE_STRING])
 
 class VirtualPortsLaunch:
     """Launch functions for creating virtual ports using `socat`."""
@@ -307,10 +310,10 @@ class MAVProxyLaunch:
             "--non-interactive ",
         ]
 
-        if console:
+        if console == TRUE_STRING:
             cmd.append("--console ")
 
-        if map:
+        if map == TRUE_STRING:
             cmd.append("--map ")
 
         # Create action.
@@ -369,11 +372,13 @@ class MAVProxyLaunch:
                 "map",
                 default_value="False",
                 description="Enable MAVProxy Map.",
+                choices=BOOL_STRING_CHOICES
             ),
             DeclareLaunchArgument(
                 "console",
                 default_value="False",
                 description="Enable MAVProxy Console.",
+                choices=BOOL_STRING_CHOICES
             ),
         ]
 
@@ -419,12 +424,12 @@ class SITLLaunch:
 
         # Optional arguments.
         wipe = LaunchConfiguration("wipe").perform(context)
-        if wipe == "True":
+        if wipe == TRUE_STRING:
             cmd_args.append("--wipe ")
             print(f"wipe:             {wipe}")
 
         synthetic_clock = LaunchConfiguration("synthetic_clock").perform(context)
-        if synthetic_clock == "True":
+        if synthetic_clock == TRUE_STRING:
             cmd_args.append("--synthetic-clock ")
             print(f"synthetic_clock:  {synthetic_clock}")
 
@@ -586,13 +591,13 @@ class SITLLaunch:
                 "wipe",
                 default_value="False",
                 description="Wipe eeprom.",
-                choices=["True", "False"],
+                choices=BOOL_STRING_CHOICES,
             ),
             DeclareLaunchArgument(
                 "synthetic_clock",
                 default_value="False",
                 description="Set synthetic clock mode.",
-                choices=["True", "False"],
+                choices=BOOL_STRING_CHOICES,
             ),
             DeclareLaunchArgument(
                 "home",


### PR DESCRIPTION
# Purpose

* Install models for other users such as the `plane.parm` that SITL launches with for plane
* Fix bool parsing in some launch args such as mavproxy and console

# Testing


Create a launch file with the contents;
```xml
<?xml version="1.0"?>
<launch>
  <include file="$(find-pkg-share ardupilot_sitl)/launch/sitl_dds_udp.launch.py">
    <arg name="defaults" value="$(find-pkg-share ardupilot_sitl)/config/models/plane.parm"/>
    <arg name="model" value="plane"/>
    <arg name="command" value="arduplane"/>
  </include>
</launch>
```

```bash
ros2 launch your_package your_launch_file.launch.xml \
   refs:=$(pwd)/src/ardupilot/libraries/AP_DDS/dds_xrce_profile.xml \
   map:=True \
   console:=True
```

Then, change map and console to false and observe them not appear.
The plane should boot up just like sim_vehicle, and be able to use mavproxy.
Mavproxy should show a plane icon.

# Issue

Solves https://github.com/ArduPilot/ardupilot/issues/27130

I found this running `colcon test` and saw a ton of windows popping up.

![image](https://github.com/ArduPilot/ardupilot/assets/25047695/2ab65e55-1a20-4b8a-8dda-134ddedaad40)


# Follow up

I'd like CMake to install the refs file and default that location so you don't need to specify the refs path when you launch in a directory other than ardupilot.