### PR TITLE
Fix arming check for duplicate scripting RC channels and extra RC checks for rover-quiktune

### DIFF
--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -1798,7 +1798,7 @@ RC_Channel *RC_Channels::find_channel_for_option(const RC_Channel::AUX_FUNC opti
 // duplicate_options_exist - returns true if any options are duplicated
 bool RC_Channels::duplicate_options_exist()
 {
-    uint8_t auxsw_option_counts[256] = {};
+    uint8_t auxsw_option_counts[512] = {};
     for (uint8_t i=0; i<NUM_RC_CHANNELS; i++) {
         const RC_Channel *c = channel(i);
         if (c == nullptr) {


### PR DESCRIPTION
Fixing two (related) issues in here, from a user support session:
1. The arming check for duplicate RC Aux functions didn't check for Scripting functions, as it only checked for Aux function with an ID <256 (Scripting was 300+)
~~2. Added an extra check in the rover-quiktune script to warn the user if they had a mis-configured (or no) RC channel mapped to scripting~~