### PR TITLE
Use active ESC when only one can be displayed

### DIFF
--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -120,6 +120,30 @@ uint32_t AP_ESC_Telem::get_active_esc_mask() const {
     return ret;
 }
 
+// return an active ESC for the purposes of reporting (e.g. in the OSD)
+uint8_t AP_ESC_Telem::get_max_rpm_esc() const
+{
+    uint32_t ret = 0;
+    float max_rpm = 0;
+    const uint32_t now = AP_HAL::millis();
+    const uint32_t now_us = AP_HAL::micros();
+    for (uint8_t i = 0; i < ESC_TELEM_MAX_ESCS; i++) {
+        if (_telem_data[i].last_update_ms == 0 && !was_rpm_data_ever_reported(_rpm_data[i])) {
+            // have never seen telem from this ESC
+            continue;
+        }
+        if (_telem_data[i].stale(now)
+            && !rpm_data_within_timeout(_rpm_data[i], now_us, ESC_RPM_DATA_TIMEOUT_US)) {
+            continue;
+        }
+        if (_rpm_data[i].rpm > max_rpm) {
+            max_rpm = _rpm_data[i].rpm;
+            ret = i;
+        }
+    }
+    return ret;
+}
+
 // return number of active ESCs present
 uint8_t AP_ESC_Telem::get_num_active_escs() const {
     uint32_t active = get_active_esc_mask();

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.h
@@ -83,6 +83,9 @@ public:
     // ESC_TELEM_DATA_TIMEOUT_MS
     uint32_t get_active_esc_mask() const;
 
+    // return an active ESC with the highest RPM for the purposes of reporting (e.g. in the OSD)
+    uint8_t get_max_rpm_esc() const;
+
     // return the last time telemetry data was received in ms for the given ESC or 0 if never
     uint32_t get_last_telem_data_ms(uint8_t esc_index) const {
         if (esc_index >= ESC_TELEM_MAX_ESCS) {return 0;}

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -259,6 +259,9 @@ private:
     AP_Int8 txt_resolution;
     AP_Int8 font_index;
 #endif
+#if HAL_WITH_ESC_TELEM
+    AP_Int8 esc_index;
+#endif
 
     void draw_altitude(uint8_t x, uint8_t y);
     void draw_bat_volt(uint8_t instance,VoltageType  type,uint8_t x, uint8_t y);

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -358,7 +358,7 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info[] = {
 #if HAL_WITH_ESC_TELEM
     // @Param: ESCTEMP_EN
     // @DisplayName: ESCTEMP_EN
-    // @Description: Displays first esc's temp
+    // @Description: Displays highest temp of all active ESCs, or of a specific ECS if OSDx_ESC_IDX is set
     // @Values: 0:Disabled,1:Enabled
 
     // @Param: ESCTEMP_X
@@ -374,7 +374,7 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info[] = {
 
     // @Param: ESCRPM_EN
     // @DisplayName: ESCRPM_EN
-    // @Description: Displays first esc's rpm
+    // @Description: Displays highest rpm of all active ESCs, or of a specific ESC if OSDx_ESC_IDX is set
     // @Values: 0:Disabled,1:Enabled
 
     // @Param: ESCRPM_X
@@ -390,7 +390,7 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info[] = {
 
     // @Param: ESCAMPS_EN
     // @DisplayName: ESCAMPS_EN
-    // @Description: Displays first esc's current
+    // @Description: Displays the current of the ESC with the highest rpm of all active ESCs, or of a specific ESC if OSDx_ESC_IDX is set
     // @Values: 0:Disabled,1:Enabled
 
     // @Param: ESCAMPS_X
@@ -1164,6 +1164,14 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info2[] = {
     // @Description: Vertical position on screen
     // @Range: 0 21
     AP_SUBGROUPINFO(rc_lq, "RC_LQ", 9, AP_OSD_Screen, AP_OSD_Setting),
+#endif
+
+#if HAL_WITH_ESC_TELEM
+    // @Param: ESC_IDX
+    // @DisplayName: ESC_IDX
+    // @Description: Index of the ESC to use for displaying ESC information. 0 means use the ESC with the highest value.
+    // @Range: 0 32
+    AP_GROUPINFO("ESC_IDX", 10, AP_OSD_Screen, esc_index, 0),
 #endif
 
     AP_GROUPEND
@@ -2003,8 +2011,13 @@ void AP_OSD_Screen::draw_vspeed(uint8_t x, uint8_t y)
 void AP_OSD_Screen::draw_esc_temp(uint8_t x, uint8_t y)
 {
     int16_t etemp;
-    // first parameter is index into array of ESC's.  Hardwire to zero (first) for now.
-    if (!AP::esc_telem().get_temperature(0, etemp)) {
+
+    if (esc_index > 0) {
+        if (!AP::esc_telem().get_motor_temperature(esc_index-1, etemp)) {
+            return;
+        }
+    }
+    else if (!AP::esc_telem().get_highest_motor_temperature(etemp)) {
         return;
     }
 
@@ -2014,8 +2027,12 @@ void AP_OSD_Screen::draw_esc_temp(uint8_t x, uint8_t y)
 void AP_OSD_Screen::draw_esc_rpm(uint8_t x, uint8_t y)
 {
     float rpm;
-    // first parameter is index into array of ESC's.  Hardwire to zero (first) for now.
-    if (!AP::esc_telem().get_rpm(0, rpm)) {
+    uint8_t esc = AP::esc_telem().get_max_rpm_esc();
+    if (esc_index > 0) {
+        if (!AP::esc_telem().get_rpm(esc_index-1, rpm)) {
+            return;
+        }
+    } else if (!AP::esc_telem().get_rpm(esc, rpm)) {
         return;
     }
     float krpm = rpm * 0.001f;
@@ -2026,8 +2043,12 @@ void AP_OSD_Screen::draw_esc_rpm(uint8_t x, uint8_t y)
 void AP_OSD_Screen::draw_esc_amps(uint8_t x, uint8_t y)
 {
     float amps;
-    // first parameter is index into array of ESC's.  Hardwire to zero (first) for now.
-    if (!AP::esc_telem().get_current(0, amps)) {
+    uint8_t esc = AP::esc_telem().get_max_rpm_esc();
+    if (esc_index > 0) {
+        if (!AP::esc_telem().get_current(esc_index-1, amps)) {
+            return;
+        }
+    } else if (!AP::esc_telem().get_current(esc, amps)) {
         return;
     }
     backend->write(x, y, false, "%4.1f%c", amps, SYMBOL(SYM_AMP));


### PR DESCRIPTION
Currently the OSD displays ESC 0 only. This attempts to show the most relevant information