### PR TITLE
Tools: fix checking of hwdef includes for Periph

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -609,15 +609,13 @@ def get_ap_periph_boards():
                     list_ap.append(d)
                     continue
                 # process any include lines:
-                m = re.match(r"include\s+([^\s]*)", content)
-                if m is None:
-                    continue
-                include_path = os.path.join(os.path.dirname(hwdef), m.group(1))
-                with open(include_path, "r") as g:
-                    content = g.read()
-                    if 'AP_PERIPH' in content:
-                        list_ap.append(d)
-                        continue
+                for m in re.finditer(r"^include\s+([^\s]*)", content, re.MULTILINE):
+                    include_path = os.path.join(os.path.dirname(hwdef), m.group(1))
+                    with open(include_path, "r") as g:
+                        content = g.read()
+                        if 'AP_PERIPH' in content:
+                            list_ap.append(d)
+                            break
 
     list_ap = list(set(list_ap))
     return list_ap


### PR DESCRIPTION
I was having an issue where an AP_Periph hwdef I was working on started failing when I added a comment to the top of the file. In fact, it was failing if the include was anywhere except at the very top. To reproduce the bug on master, place a line-break at the top of `libraries/AP_HAL_ChibiOS/hwdef/AeroFox-Airspeed/hwdef.dat` and try to compile.

When waf was trying to determine which boards AP_Periph could compile for, it did not correctly follow includes. It only considered one include at the very beginning of the file. This fixes that so it correctly scans through all includes, wherever they are in the hwdef.
