### PR TITLE
AP_DDS: ensure zero rotation quaternions are normalised

### DIFF
--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -226,6 +226,12 @@ void AP_DDS_Client::populate_static_transforms(tf2_msgs_msg_TFMessage& msg)
         msg.transforms[i].transform.translation.y = -1 * offset[1];
         msg.transforms[i].transform.translation.z = -1 * offset[2];
 
+        // Ensure rotation is normalised
+        msg.transforms[i].transform.rotation.x = 0.0;
+        msg.transforms[i].transform.rotation.y = 0.0;
+        msg.transforms[i].transform.rotation.z = 0.0;
+        msg.transforms[i].transform.rotation.w = 1.0;
+
         msg.transforms_size++;
     }
 
@@ -337,6 +343,11 @@ void AP_DDS_Client::update_topic(geometry_msgs_msg_PoseStamped& msg)
         msg.pose.orientation.x = orientation[1];
         msg.pose.orientation.y = orientation[2];
         msg.pose.orientation.z = orientation[3];
+    } else {
+        msg.pose.orientation.x = 0.0;
+        msg.pose.orientation.y = 0.0;
+        msg.pose.orientation.z = 0.0;
+        msg.pose.orientation.w = 1.0;
     }
 }
 
@@ -416,6 +427,11 @@ void AP_DDS_Client::update_topic(geographic_msgs_msg_GeoPoseStamped& msg)
         msg.pose.orientation.x = orientation[1];
         msg.pose.orientation.y = orientation[2];
         msg.pose.orientation.z = orientation[3];
+    } else {
+        msg.pose.orientation.x = 0.0;
+        msg.pose.orientation.y = 0.0;
+        msg.pose.orientation.z = 0.0;
+        msg.pose.orientation.w = 1.0;
     }
 }
 
@@ -435,6 +451,11 @@ void AP_DDS_Client::update_topic(sensor_msgs_msg_Imu& msg)
         msg.orientation.y = orientation[1];
         msg.orientation.z = orientation[2];
         msg.orientation.w = orientation[3];
+    } else {
+        msg.orientation.x = 0.0;
+        msg.orientation.y = 0.0;
+        msg.orientation.z = 0.0;
+        msg.orientation.w = 1.0;
     }
     msg.orientation_covariance[0] = -1;
 


### PR DESCRIPTION
ROS expects quaternions to be normalised and the default message constructor does not enforce this.

## Testing

Quick check is to run the copter launch example:

```bash
ros2 launch ardupilot_sitl sitl_dds_udp.launch.py transport:=udp4 refs:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/dds_xrce_profile.xml synthetic_clock:=True wipe:=False model:=quad speedup:=1 slave:=0 instance:=0 defaults:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/copter.parm,$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/dds_udp.parm sim_address:=127.0.0.1 master:=tcp:127.0.0.1:5760 sitl:=127.0.0.1:5501
```

Then run rviz with the ArduPilot TF topics remapped:

```bash
ros2 run rviz2 rviz2 --ros-args -r tf:=/ap/tf -r tf_static:=/ap/tf_static
```

Without this change there is a warning about Quaternion normalisation

```bash
$ ros2 run rviz2 rviz2 --ros-args -r tf:=/ap/tf -r tf_static:=/ap/tf_static
[INFO] [1716465954.524460000] [rviz2]: Stereo is NOT SUPPORTED
[INFO] [1716465954.524511000] [rviz2]: OpenGl version: 2.1 (GLSL 1.2)
[INFO] [1716465954.618444000] [rviz2]: Stereo is NOT SUPPORTED
[ERROR] [1716465956.356920000] []: TF_NAN_INPUT: Ignoring transform for child_frame_id "GPS_0" from authority "Authority undetectable" because of a nan value in the transform (0.000000 -0.000000 -0.000000) (nan nan nan nan)
[ERROR] [1716465956.357087000] []: TF_DENORMALIZED_QUATERNION: Ignoring transform for child_frame_id "GPS_0" from authority "Authority undetectable" because of an invalid quaternion in the transform (nan nan nan nan)
[ERROR] [1716465959.054706000] []: TF_NAN_INPUT: Ignoring transform for child_frame_id "GPS_0" from authority "Authority undetectable" because of a nan value in the transform (0.000000 -0.000000 -0.000000) (nan nan nan nan)
[ERROR] [1716465959.054789000] []: TF_DENORMALIZED_QUATERNION: Ignoring transform for child_frame_id "GPS_0" from authority "Authority undetectable" because of an invalid quaternion in the transform (nan nan nan nan)
```

and there is no tf data for the Fixed Frame.

With the change the tf data is good, and the TF tree can be viewed.

