### PR TITLE
ADSB: Sagetech MXS: updates

### DIFF
--- a/libraries/AP_ADSB/AP_ADSB.cpp
+++ b/libraries/AP_ADSB/AP_ADSB.cpp
@@ -62,6 +62,9 @@ extern const AP_HAL::HAL& hal;
 
 AP_ADSB *AP_ADSB::_singleton;
 
+// Per backend params
+const AP_Param::GroupInfo *AP_ADSB::_backend_var_info[ADSB_MAX_INSTANCES];
+
 // table of user settable parameters
 const AP_Param::GroupInfo AP_ADSB::var_info[] = {
     // @Param: TYPE
@@ -176,6 +179,10 @@ const AP_Param::GroupInfo AP_ADSB::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("OPTIONS",  15, AP_ADSB, _options, 0),
 
+    // @Group: 
+    // @Path: AP_ADSB_Sagetech_MSX.cpp
+    AP_SUBGROUPVARPTR(_backend[0], "", 16, AP_ADSB, _backend_var_info[0]),
+
     AP_GROUPEND
 };
 
@@ -228,6 +235,11 @@ void AP_ADSB::init(void)
             }
             // success
             detected_num_instances = i+1;
+
+            // If backend has loaded params load saved values from eeprom
+            if (_backend_var_info[i]) {
+                AP_Param::load_object_from_eeprom(_backend[i], _backend_var_info[i]);
+            }
         }
     }
 

--- a/libraries/AP_ADSB/AP_ADSB.h
+++ b/libraries/AP_ADSB/AP_ADSB.h
@@ -354,6 +354,10 @@ private:
 
     // reference to backend
     AP_ADSB_Backend *_backend[ADSB_MAX_INSTANCES];
+
+    // Per backend params
+    static const struct AP_Param::GroupInfo *_backend_var_info[ADSB_MAX_INSTANCES];
+
 };
 
 namespace AP {

--- a/libraries/AP_ADSB/AP_ADSB_Sagetech_MXS.h
+++ b/libraries/AP_ADSB/AP_ADSB_Sagetech_MXS.h
@@ -30,7 +30,8 @@
 
 class AP_ADSB_Sagetech_MXS : public AP_ADSB_Backend {
 public:
-    using AP_ADSB_Backend::AP_ADSB_Backend;
+    // constructor.
+    AP_ADSB_Sagetech_MXS(AP_ADSB &frontend, uint8_t instance);
 
     /**
      * @brief Performs required initialization for this instance
@@ -59,6 +60,8 @@ public:
      * @return false 
      */
     static bool detect();
+
+    static const struct AP_Param::GroupInfo var_info[];
 
 private:
 
@@ -223,8 +226,6 @@ private:
     uint8_t convert_sg_emitter_type_to_adsb(const sg_emitter_t sgEmitterType) const;
 
     void auto_config_operating();
-    void auto_config_installation();
-    void auto_config_flightid();
     void handle_ack(const sg_ack_t ack);
 
     struct {
@@ -265,6 +266,9 @@ private:
     void populate_op_altitude(const struct AP_ADSB::Loc &loc);
     void populate_op_climbrate(const struct AP_ADSB::Loc &loc);
     void populate_op_airspeed_and_heading(const struct AP_ADSB::Loc &loc);
+
+    // Params
+    AP_Float _targetreq_rate;
 
 };
 #endif // HAL_ADSB_SAGETECH_MXS_ENABLED

--- a/libraries/SITL/SIM_ADSB_Sagetech_MXS.h
+++ b/libraries/SITL/SIM_ADSB_Sagetech_MXS.h
@@ -26,7 +26,7 @@ namespace SITL {
 
 class ADSB_Sagetech_MXS : public ADSB_Device {
 public:
-    using ADSB_Device::ADSB_Device;
+    ADSB_Sagetech_MXS();
 
     void update(const class Aircraft *sitl_model);
 
@@ -102,8 +102,19 @@ private:
 
     enum class OperatingMode {
         OFF,
-        MAINTENANCE,
+        ON,
+        STANDBY,
+        ALT,
     } operating_mode;
+    bool maintenance_mode;
+
+    enum class RequestType {
+        AutoOutput,
+        Summary,
+        TargetID,
+        Off,
+    } request_type;
+    uint16_t request_count;
 
     // 0x01 - Installation Message
     class PACKED Installation {


### PR DESCRIPTION
This includes some driver minor re-work and adds the ability to request a "summary" at a rate given by a new param. This gives a way of limiting the data rate. Currently we use auto reporting which sends a message every time a ADSB transmission is received, if there is a lot of traffic about this can result in very high data rates.  

There are also some changes to remove the test strings set for flight ID and aircraft registration. Both serial ports are also set to 230400 so you can use either. 

Our sim is updated to support the new  functionality.