### PR TITLE
AP_DroneCAN: Serial: map baudrates so param works as expected

### DIFF
--- a/libraries/AP_DroneCAN/AP_DroneCAN_serial.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN_serial.cpp
@@ -132,7 +132,7 @@ void AP_DroneCAN_Serial::handle_tunnel_targetted(AP_DroneCAN *dronecan,
  */
 void AP_DroneCAN_Serial::Port::init(void)
 {
-    baudrate = state.baud;
+    baudrate = AP_SerialManager::map_baudrate(state.baud);
     begin(baudrate, 0, 0);
 }
 


### PR DESCRIPTION
This allows the short hand baud rates to work. EG "57" for 57600. The param descriptions suggest they should work already because they just copy from the main serial port descriptions. 