### PR TITLE
AP_Networking: enable Socket SO_REUSEADDR on LwIP

### DIFF
--- a/libraries/AP_Networking/config/lwipopts.h
+++ b/libraries/AP_Networking/config/lwipopts.h
@@ -69,6 +69,12 @@ extern "C"
 #define MEMP_MEM_MALLOC 1
 #define LWIP_NETCONN_SEM_PER_THREAD 0
 
+/**
+ * SO_REUSE==1: Enable SO_REUSEADDR option.
+ */
+#ifndef SO_REUSE
+#define SO_REUSE                   1
+#endif
 
 #define NO_SYS                     0
 #define LWIP_SOCKET                (NO_SYS==0)


### PR DESCRIPTION
Broadcast support has been broken in LwIP because we never enabled Socket Reuse. Enabling SO_REUSE will enable SO_REUSEADDR.

This change allows us to use UDP Client/Server broadcast IP of 255.255.255.255 on ChibiOS/LwIP systems. It's already enabled on Linux/SITL systems. I don't know about Cygwin.

4.5.3 and on master:
- Correctly defined in the bootloader [here](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/scripts/defaults_bootloader.h#L47)
- Not defined in the app's AP_Networking/config/lwipopts.h so the lwip default in opts.h sets it to zero [here](https://github.com/ArduPilot/lwip/blob/143a6a5cb8023921b5dced55c30551ffb752b640/src/include/lwip/opt.h#L2112-L2117)

I would consider this a candidate for a 4.5.x backport but not important enough to cause a hotfix release by itself. v4.5 has been our big network release and this seems pretty core to that.