### PR TITLE
Scripting: backport of pcall fault fix for 4.3.x

### DIFF
--- a/libraries/AP_Scripting/lua/src/ldo.c
+++ b/libraries/AP_Scripting/lua/src/ldo.c
@@ -142,10 +142,10 @@ int luaD_rawrunprotected (lua_State *L, Pfunc f, void *ud) {
   lj.status = LUA_OK;
   lj.previous = L->errorJmp;  /* chain new error handler */
   L->errorJmp = &lj;
-  LUAI_TRY(L, &lj,
 #ifdef ARM_MATH_CM7
     __asm__("vpush {s16-s31}");
 #endif
+  LUAI_TRY(L, &lj,
     (*f)(L, ud);
   );
 #ifdef ARM_MATH_CM7


### PR DESCRIPTION
backport of this critical PR:
https://github.com/ArduPilot/ardupilot/pull/27056
