### PR TITLE
AP_Scripting: do not send fragmented messages

### DIFF
--- a/libraries/AP_Scripting/AP_Scripting.cpp
+++ b/libraries/AP_Scripting/AP_Scripting.cpp
@@ -380,6 +380,7 @@ bool AP_Scripting::arming_checks(size_t buflen, char *buffer) const
     lua_scripts::get_last_error_semaphore()->take_blocking();
     const char *error_buf = lua_scripts::get_last_error_message();
     if (error_buf != nullptr) {
+        buflen = buflen < 44 ? buflen : 43;
         hal.util->snprintf(buffer, buflen, "Scripting: %s", error_buf);
         lua_scripts::get_last_error_semaphore()->give();
         return false;

--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -68,6 +68,9 @@ void lua_scripts::print_error(MAV_SEVERITY severity) {
         return;
     }
     last_print_ms = AP_HAL::millis();
+    if (strlen(error_msg_buf) > 44) {
+        error_msg_buf[45] = 0;
+    }
     GCS_SEND_TEXT(severity, "Lua: %s", error_msg_buf);
     error_msg_buf_sem.give();
 }


### PR DESCRIPTION
The text status is limited to 50 bytes. 
If it exceeds 50 bytes, it is fragmented and sent. 
The fragmented strings become garbage. 
When I send, I truncate the text at this 50-byte limit. 
With this process, I will no longer send text that has become garbage.


MISSION PLANNER
AFETR
![Screenshot from 2024-05-30 22-24-14](https://github.com/ArduPilot/ardupilot/assets/646194/01b89de6-aecb-4322-8882-eb824ba222ee)

BEFORE
![Screenshot from 2024-05-30 22-30-59](https://github.com/ArduPilot/ardupilot/assets/646194/7f9e3d1a-0f8a-4879-ba17-aa4e83146ff0)