### PR TITLE
Tools: Do not emit __field_text in JSON parameter documentation

### DIFF
--- a/Tools/autotest/param_metadata/jsonemit.py
+++ b/Tools/autotest/param_metadata/jsonemit.py
@@ -62,6 +62,10 @@ class JSONEmit(Emit):
                 except KeyError:
                     pass
 
+            # Remove __field_text key
+            if '__field_text' in param.__dict__:
+                param.__dict__.pop('__field_text')
+
             # Get range section if available
             range_json = {}
             if 'Range' in param.__dict__:


### PR DESCRIPTION
`__field_text` is basically the raw parsed text, and is used internally but as far as I can tell it was never meant for external usage, the JSON emitter already removes other fields that were not intended to be there. By including the `__field_text` entry we were doubling the size of the emitted documentation.

As a sample this is the old output:
``` json
    "ADSB_EMIT_TYPE": {    
      "Description": "ADSB classification for the type of vehicle emitting the transponder signal. Default value is 14 (UAV).",    
      "DisplayName": "Emitter type",    
      "User": "Advanced",    
      "Values": {    
        "0": "NoInfo",    
        "1": "Light",    
        "10": "LightAir",    
        "11": "Parachute",    
        "12": "UltraLight",    
        "13": "RESERVED",    
        "14": "UAV",    
        "15": "Space",    
        "16": "RESERVED",    
        "17": "EmergencySurface",    
        "18": "ServiceSurface",    
        "19": "PointObstacle",    
        "2": "Small",    
        "3": "Large",    
        "4": "HighVortexlarge",    
        "5": "Heavy",    
        "6": "HighlyManuv",    
        "7": "Rotocraft",    
        "8": "RESERVED",    
        "9": "Glider"                                                                                                                 
      },
      "__field_text": "\n    // @DisplayName: Emitter type\n    // @Description: ADSB classification for the type of vehicle emitting the transponder signal. Default value is 14 (UAV).\n    // @Values: 0:NoInfo,1:Light,2:Small,3:Large,4:HighVortexlarge,5:Heavy,6:HighlyManuv,7:Rotocraft,8:RESERVED,9:Glider,10:LightAir,11:Parachute,12:UltraLight,13:RESERVED,14:UAV,15:Space,16:RESERVED,17:EmergencySurface,18:ServiceSurface,19:PointObstacle\n    // @User: Advanced"
    },
```

And with this change:
``` json
    "ADSB_EMIT_TYPE": {    
      "Description": "ADSB classification for the type of vehicle emitting the transponder signal. Default value is 14 (UAV).",
      "DisplayName": "Emitter type",    
      "User": "Advanced",    
      "Values": {    
        "0": "NoInfo",    
        "1": "Light",    
        "10": "LightAir",    
        "11": "Parachute",    
        "12": "UltraLight",    
        "13": "RESERVED",    
        "14": "UAV",    
        "15": "Space",    
        "16": "RESERVED",    
        "17": "EmergencySurface",    
        "18": "ServiceSurface",    
        "19": "PointObstacle",    
        "2": "Small",    
        "3": "Large",    
        "4": "HighVortexlarge",    
        "5": "Heavy",      
        "6": "HighlyManuv",    
        "7": "Rotocraft",    
        "8": "RESERVED",    
        "9": "Glider"        
      }    
    },  
```