### PR TITLE
autotest: correct Valgrind error detection 

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -3191,26 +3191,6 @@ class TestSuite(ABC):
         util.pexpect_close(self.sitl)
         self.sitl = None
 
-    def close(self):
-        """Tidy up after running all tests."""
-
-        if self.mav is not None:
-            self.mav.close()
-            self.mav = None
-        self.stop_SITL()
-
-        valgrind_log = util.valgrind_log_filepath(binary=self.binary,
-                                                  model=self.frame)
-        files = glob.glob("*" + valgrind_log)
-        for valgrind_log in files:
-            os.chmod(valgrind_log, 0o644)
-            if os.path.getsize(valgrind_log) > 0:
-                target = self.buildlogs_path("%s-%s" % (
-                    self.log_name(),
-                    os.path.basename(valgrind_log)))
-                self.progress("Valgrind log: moving %s to %s" % (valgrind_log, target))
-                shutil.move(valgrind_log, target)
-
     def start_test(self, description):
         self.progress("##################################################################################")
         self.progress("########## %s  ##########" % description)
@@ -11833,7 +11813,24 @@ switch value'''
             self.rc_thread_should_quit = True
             self.rc_thread.join()
             self.rc_thread = None
-        self.close()
+
+        if self.mav is not None:
+            self.mav.close()
+            self.mav = None
+
+        self.stop_SITL()
+
+        valgrind_log = util.valgrind_log_filepath(binary=self.binary,
+                                                  model=self.frame)
+        files = glob.glob("*" + valgrind_log)
+        for valgrind_log in files:
+            os.chmod(valgrind_log, 0o644)
+            if os.path.getsize(valgrind_log) > 0:
+                target = self.buildlogs_path("%s-%s" % (
+                    self.log_name(),
+                    os.path.basename(valgrind_log)))
+                self.progress("Valgrind log: moving %s to %s" % (valgrind_log, target))
+                shutil.move(valgrind_log, target)
 
         return result_list
 

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -1666,6 +1666,16 @@ class Result(object):
         return ret
 
 
+class ValgrindFailedResult(Result):
+    '''a custom Result to allow passing of Vaglrind failures around'''
+    def __init__(self):
+        super(ValgrindFailedResult, self).__init__(None)
+        self.passed = False
+
+    def __str__(self):
+        return "Valgrind error detected"
+
+
 class TestSuite(ABC):
     """Base abstract class.
     It implements the common function for all vehicle types.
@@ -11823,6 +11833,7 @@ switch value'''
         valgrind_log = util.valgrind_log_filepath(binary=self.binary,
                                                   model=self.frame)
         files = glob.glob("*" + valgrind_log)
+        valgrind_failed = False
         for valgrind_log in files:
             os.chmod(valgrind_log, 0o644)
             if os.path.getsize(valgrind_log) > 0:
@@ -11831,6 +11842,9 @@ switch value'''
                     os.path.basename(valgrind_log)))
                 self.progress("Valgrind log: moving %s to %s" % (valgrind_log, target))
                 shutil.move(valgrind_log, target)
+                valgrind_failed = True
+        if valgrind_failed:
+            result_list.append(ValgrindFailedResult())
 
         return result_list
 

--- a/libraries/SITL/SIM_GPS_SBP.cpp
+++ b/libraries/SITL/SIM_GPS_SBP.cpp
@@ -111,6 +111,7 @@ void GPS_SBP::publish(const GPS_Data *d)
         sbp_send_message(SBP_DOPS_MSGTYPE, 0x2222, sizeof(dops),
                           (uint8_t*)&dops);
 
+        hb = {};
         hb.protocol_major = 0; //Sends protocol version 0
         sbp_send_message(SBP_HEARTBEAT_MSGTYPE, 0x2222, sizeof(hb),
                           (uint8_t*)&hb);


### PR DESCRIPTION
Somehow we lost this aspect of autotest where a non-zero valgrind log means failiure.

Fix that.

I've tested the failure case here and CI hsould cover the no-failure case.
