### PR TITLE
AP_HAL_ChibiOS:correct pin to be pulled high during boot

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/FlywooF405HD-AIOv2/hwdef-bl.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/FlywooF405HD-AIOv2/hwdef-bl.dat
@@ -12,4 +12,4 @@ undef APJ_BOARD_ID
 APJ_BOARD_ID 1180
 
 #required to prevent ELRS from changing modes at boot
-PD6 USART2_RX USART2 OUTPUT HIGH
+PA10 USART1_RX USART1 OUTPUT HIGH


### PR DESCRIPTION
my mistake....the internal module's RX pin needs to be high during boot to prevent the ELRS module from going into a special mode....I suggested the wrong pin during the review as we moved things around...