### PR TITLE
Plane: added TKOFF_THR_MIN

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3973,6 +3973,21 @@ bool QuadPlane::in_transition(void) const
 }
 
 /*
+  return true if we are in a fwd transition for a SLT quadplane
+  and in an auto-throttle mode
+ */
+bool QuadPlane::in_slt_fwd_transition(void) const
+{
+    if (!in_transition() || tiltrotor.enabled() || tailsitter.enabled()) {
+        return false;
+    }
+    if (!plane.control_mode->does_auto_throttle()) {
+        return false;
+    }
+    return transition->in_fwd_transition();
+}
+
+/*
   calculate current stopping distance for a quadplane in fixed wing flight
  */
 float QuadPlane::stopping_distance(float ground_speed_squared) const
@@ -4460,6 +4475,15 @@ void SLT_Transition::set_last_fw_pitch()
 {
     last_fw_mode_ms = AP_HAL::millis();
     last_fw_nav_pitch_cd = plane.nav_pitch_cd;
+}
+
+/*
+  return true if in a forward transition
+ */
+bool SLT_Transition::in_fwd_transition() const
+{
+    return transition_state == TRANSITION_AIRSPEED_WAIT ||
+        transition_state == TRANSITION_TIMER;
 }
 
 void SLT_Transition::force_transition_complete() {

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -108,6 +108,12 @@ public:
     */
     bool in_transition(void) const;
 
+    /*
+      return true if we are in a fwd transition for a SLT quadplane
+      and in an auto-throttle mode
+     */
+    bool in_slt_fwd_transition(void) const;
+
     bool handle_do_vtol_transition(enum MAV_VTOL_STATE state) const;
 
     bool do_vtol_takeoff(const AP_Mission::Mission_Command& cmd);

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -521,6 +521,9 @@ float Plane::apply_throttle_limits(float throttle_in)
 
     // Query the conditions where TKOFF_THR_MAX applies.
     const bool use_takeoff_throttle =
+#if HAL_QUADPLANE_ENABLED
+        quadplane.in_slt_fwd_transition() ||
+#endif
         (flight_stage == AP_FixedWing::FlightStage::TAKEOFF) ||
         (flight_stage == AP_FixedWing::FlightStage::ABORT_LANDING);
 

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -1039,4 +1039,12 @@ bool Tailsitter_Transition::allow_weathervane()
     return !tailsitter.in_vtol_transition() && (vtol_limit_start_ms == 0);
 }
 
+/*
+  return true if in a forward transition
+ */
+bool Tailsitter_Transition::in_fwd_transition() const
+{
+    return transition_state == TRANSITION_ANGLE_WAIT_FW;
+}
+
 #endif  // HAL_QUADPLANE_ENABLED

--- a/ArduPlane/tailsitter.h
+++ b/ArduPlane/tailsitter.h
@@ -189,6 +189,8 @@ public:
 
     bool allow_weathervane() override;
 
+    bool in_fwd_transition() const override;
+
 private:
 
     enum {

--- a/ArduPlane/transition.h
+++ b/ArduPlane/transition.h
@@ -58,6 +58,8 @@ public:
 
     virtual bool allow_stick_mixing() const { return true; }
 
+    virtual bool in_fwd_transition() const = 0;
+
 protected:
 
     // refences for convenience
@@ -100,6 +102,8 @@ public:
     bool set_VTOL_roll_pitch_limit(int32_t& nav_roll_cd, int32_t& nav_pitch_cd) override;
 
     void set_last_fw_pitch(void) override;
+
+    bool in_fwd_transition() const override;
 
 protected:
 


### PR DESCRIPTION
this allows for a minimum throttle to be applied during a takeoff or quadplane forward transition in auto throttle modes. This is useful on high drag aircraft where normal TECS throttle control results in a slow transition