### PR TITLE
SITL: delete unnecessary settings

### DIFF
--- a/libraries/SITL/SIM_GPS_SBP.cpp
+++ b/libraries/SITL/SIM_GPS_SBP.cpp
@@ -111,8 +111,7 @@ void GPS_SBP::publish(const GPS_Data *d)
         sbp_send_message(SBP_DOPS_MSGTYPE, 0x2222, sizeof(dops),
                           (uint8_t*)&dops);
 
-        hb = {};
-        hb.protocol_major = 0; //Sends protocol version 0
+        hb = {}; //Sends protocol version 0
         sbp_send_message(SBP_HEARTBEAT_MSGTYPE, 0x2222, sizeof(hb),
                           (uint8_t*)&hb);
 


### PR DESCRIPTION
Since the elements are being cleared, the subsequent zero settings are unnecessary.