### PR TITLE
SITL: correct valgrind failure in SIM_GPS_SBP2

### DIFF
--- a/libraries/SITL/SIM_GPS_SBP2.cpp
+++ b/libraries/SITL/SIM_GPS_SBP2.cpp
@@ -111,6 +111,7 @@ void GPS_SBP2::publish(const GPS_Data *d)
         sbp_send_message(SBP_DOPS_MSGTYPE, 0x2222, sizeof(dops),
                           (uint8_t*)&dops);
 
+        hb = {}; 
         hb.protocol_major = 2; //Sends protocol version 2.0
         sbp_send_message(SBP_HEARTBEAT_MSGTYPE, 0x2222, sizeof(hb),
                           (uint8_t*)&hb);


### PR DESCRIPTION
Make it the same process as commit hash b2b8eb93 .
