### PR TITLE
remove defaulting of OSD_ENABLED

### DIFF
--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -600,10 +600,6 @@
   #error Toy mode is not available on Helicopters
 #endif
 
-#ifndef OSD_ENABLED
- #define OSD_ENABLED DISABLED
-#endif
-
 #ifndef HAL_FRAME_TYPE_DEFAULT
 #define HAL_FRAME_TYPE_DEFAULT AP_Motors::MOTOR_FRAME_TYPE_X
 #endif

--- a/ArduPlane/config.h
+++ b/ArduPlane/config.h
@@ -219,10 +219,6 @@
 #define PARACHUTE HAL_PARACHUTE_ENABLED
 #endif
 
-#ifndef OSD_ENABLED
- #define OSD_ENABLED DISABLED
-#endif
-
 #ifndef OFFBOARD_GUIDED
  #define OFFBOARD_GUIDED 1
 #endif

--- a/Rover/config.h
+++ b/Rover/config.h
@@ -75,8 +75,3 @@
 #ifndef ADVANCED_FAILSAFE
   #define ADVANCED_FAILSAFE DISABLED
 #endif
-
-#ifndef OSD_ENABLED
- #define OSD_ENABLED DISABLED
-#endif
-


### PR DESCRIPTION
we do this in AP_OSD_config.h too so include ordering can break things badly