### PR TITLE
LUA: Add a function to retrieve the landed state

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -460,6 +460,28 @@ bool Copter::is_taking_off() const
     return flightmode->is_taking_off();
 }
 
+/**
+ * Get landed detector states.
+ * 
+ * @retval 1 landed (on ground) 
+ * @retval 2 in air
+ * @retval 3 currently taking off
+ * @retval 4 currently landing
+*/
+uint8_t Copter::get_landed_state() const
+{
+    if (ap.land_complete) {
+        return uint8_t(MAV_LANDED_STATE_ON_GROUND);
+    }
+    if (flightmode->is_landing()) {
+        return uint8_t(MAV_LANDED_STATE_LANDING);
+    }
+    if (flightmode->is_taking_off()) {
+        return uint8_t(MAV_LANDED_STATE_TAKEOFF);
+    }
+    return uint8_t(MAV_LANDED_STATE_IN_AIR);
+}
+
 bool Copter::current_mode_requires_mission() const
 {
 #if MODE_AUTO_ENABLED == ENABLED

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -689,6 +689,7 @@ private:
 #endif // AP_SCRIPTING_ENABLED
     bool is_landing() const override;
     bool is_taking_off() const override;
+    uint8_t get_landed_state() const override;
     void rc_loop();
     void throttle_loop();
     void update_batt_compass(void);

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1549,16 +1549,7 @@ uint64_t GCS_MAVLINK_Copter::capabilities() const
 
 MAV_LANDED_STATE GCS_MAVLINK_Copter::landed_state() const
 {
-    if (copter.ap.land_complete) {
-        return MAV_LANDED_STATE_ON_GROUND;
-    }
-    if (copter.flightmode->is_landing()) {
-        return MAV_LANDED_STATE_LANDING;
-    }
-    if (copter.flightmode->is_taking_off()) {
-        return MAV_LANDED_STATE_TAKEOFF;
-    }
-    return MAV_LANDED_STATE_IN_AIR;
+    return MAV_LANDED_STATE(copter.get_landed_state());
 }
 
 void GCS_MAVLINK_Copter::send_wind() const

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -2388,6 +2388,15 @@ function vehicle:is_taking_off() end
 function vehicle:is_landing() end
 
 -- desc
+---@return integer
+---| '0' # unknown
+---| '1' # landed (on ground) 
+---| '2' # in air
+---| '3' # currently taking off
+---| '4' # currently landing 
+function vehicle:get_landed_state() end
+
+-- desc
 onvif = {}
 
 -- desc

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -345,6 +345,7 @@ singleton AP_Vehicle method has_ekf_failsafed boolean
 singleton AP_Vehicle method reboot void boolean
 singleton AP_Vehicle method is_landing boolean
 singleton AP_Vehicle method is_taking_off boolean
+singleton AP_Vehicle method get_landed_state uint8_t
 
 include AP_SerialLED/AP_SerialLED.h
 singleton AP_SerialLED rename serialLED

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -247,6 +247,8 @@ public:
     // returns true if vehicle is in the process of taking off
     virtual bool is_taking_off() const { return false; }
 
+    virtual uint8_t get_landed_state() const { return uint8_t(MAV_LANDED_STATE_UNDEFINED); }
+
     // zeroing the RC outputs can prevent unwanted motor movement:
     virtual bool should_zero_rc_outputs_on_reboot() const { return false; }
 


### PR DESCRIPTION
I want to get the value of LANDED_STATE to determine the landing status in LUA. I will add a method to retrieve the LANDED_STATE. This ticket is related to #27221 .

RESULT
![Screenshot from 2024-06-02 15-32-46](https://github.com/ArduPilot/ardupilot/assets/646194/6bf31132-69ce-4223-b799-d9d3aec5704e)

LUA SCRIPT
![Screenshot from 2024-06-02 17-21-16](https://github.com/ArduPilot/ardupilot/assets/646194/ea20d4d6-15a4-4e55-b9b5-8f39066b79d7)
