### PR TITLE
AP_Scripting: checks fixes and improvements 

### DIFF
--- a/Tools/scripts/run_lua_language_check.py
+++ b/Tools/scripts/run_lua_language_check.py
@@ -129,9 +129,9 @@ if __name__ == '__main__':
     p = subprocess.Popen(command, shell=True, text=True, stdout=subprocess.PIPE)
     result = []
     while p.poll() is None:
-        l = p.stdout.readline()
-        result.append(l)
-        print(l, end="")
+        line = p.stdout.readline()
+        result.append(line)
+        print(line, end="")
 
     # Make sure we checked at least one file
     file_count_re = re.compile(r"^>*=* \d+/(\d+)")

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -69,14 +69,21 @@ function print(text) end
 -- data flash logging to SD card
 logger = {}
 
--- write value to data flash log with given types and names, optional units and multipliers, timestamp will be automatically added
+-- write value to data flash log with given types and names with units and multipliers, timestamp will be automatically added
 ---@param name string -- up to 4 characters
 ---@param labels string -- comma separated value labels, up to 58 characters
 ---@param format string -- type format string, see https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Logger/README.md
----@param units? string -- optional units string
----@param multipliers? string -- optional multipliers string
----@param data1 integer|number|uint32_t_ud|string -- data to be logged, type to match format string
-function logger:write(name, labels, format, units, multipliers, data1, ...) end
+---@param units string -- units string
+---@param multipliers string -- multipliers string
+---@param ... integer|number|uint32_t_ud|string -- data to be logged, type to match format string
+function logger:write(name, labels, format, units, multipliers, ...) end
+
+-- write value to data flash log with given types and names, timestamp will be automatically added
+---@param name string -- up to 4 characters
+---@param labels string -- comma separated value labels, up to 58 characters
+---@param format string -- type format string, see https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Logger/README.md
+---@param ... integer|number|uint32_t_ud|string -- data to be logged, type to match format string
+function logger:write(name, labels, format, ...) end
 
 -- log a files content to onboard log
 ---@param filename string -- file name

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -843,7 +843,7 @@ singleton AP_EFI method get_state void EFI_State'Ref
 include AP_Logger/AP_Logger.h
 singleton AP_Logger depends HAL_LOGGING_ENABLED
 singleton AP_Logger rename logger
-singleton AP_Logger manual write AP_Logger_Write 7 0
+singleton AP_Logger manual write AP_Logger_Write 6 0
 singleton AP_Logger method log_file_content void string
 singleton AP_Logger method log_file_content depends HAL_LOGGER_FILE_CONTENTS_ENABLED
 

--- a/libraries/AP_Scripting/tests/check.json
+++ b/libraries/AP_Scripting/tests/check.json
@@ -1,4 +1,5 @@
 { // lua-language-server config for checking
+    "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
     "runtime.version": "Lua 5.3",
     "runtime.builtin": {
         // Not all of the standard functionality is available
@@ -10,6 +11,10 @@
         "table.clear": "disable",
         "table.new": "disable"
       },
-    // These lua scripts are not for running on AP
-    "workspace.ignoreDir": ["Tools/CHDK-Scripts/*", "modules/*", "libraries/AP_Scripting/tests/luacheck.lua" ],
+    "workspace": {
+      // These lua scripts are not for running on AP
+      "ignoreDir": ["Tools/CHDK-Scripts/*", "modules/*", "libraries/AP_Scripting/tests/luacheck.lua", "lua-language-server/*"],
+      // Dont use gitignore, it results in skipping checks for in progress scripts running in SITL
+      "useGitIgnore": false
+    }
 }

--- a/libraries/AP_Scripting/tests/luacheck.lua
+++ b/libraries/AP_Scripting/tests/luacheck.lua
@@ -8,7 +8,7 @@ ignore = {"111", -- Setting an undefined global variable.
           "614"} -- Trailing whitespace in a comment.
 
 -- These lua scripts are not for running on AP
-exclude_files = {"Tools/CHDK-Scripts/*", "modules/*", "libraries/AP_Scripting/tests/luacheck.lua"}
+exclude_files = {"Tools/CHDK-Scripts/*", "modules/*", "libraries/AP_Scripting/tests/luacheck.lua", "lua-language-server/*"}
 
 -- Grab AP globals from docs file
 stds.ArduPilot = {}


### PR DESCRIPTION
A number of fixes:

- luacheck ignores the new lua-language-sever lua code that is downloaded when you first run the new checks (the code does not pass the checks configured for the AP environment)
- lua-language checks can now be run on a single file. The file is copied to a new temporary directory the checks run and the directory is then deleted. 
- lua-language checks stop using gitignore so they will check scripts your working on in the SITL `scripts` dir.
- lua-language checks report the number of files it has tested and errors out if the number is 0 or not known.
- the docs document the logger write function both with and without units and multipliers so the checks will now pass in both cases. 