### PR TITLE
Update MAVLink parsing for wiki inclusion

### DIFF
--- a/Tools/scripts/mavlink_parse.py
+++ b/Tools/scripts/mavlink_parse.py
@@ -152,7 +152,8 @@ class MAVLinkDetector:
     ARDUPILOT_URL = 'https://github.com/ArduPilot/ardupilot/tree/{branch}/{source}'
     EXPORT_FILETYPES = {
         'csv': 'csv',
-        'markdown': 'md'
+        'markdown': 'md',
+        'rst': 'rst',
     }
 
     MARKDOWN_INTRO = (
@@ -169,6 +170,9 @@ class MAVLinkDetector:
         ' least shows that the autopilot is aware it exists, and will try'
         ' to do something meaningful with it.{unsupported}{stream_groups}'
     )
+
+    # Convert markdown hyperlinks into rst syntax
+    RST_INTRO = MARKDOWN_INTRO.replace('[', '`').replace('](', ' <').replace(')', '>`_')
 
     VEHICLES = ('AntennaTracker', 'ArduCopter', 'ArduPlane', 'ArduSub', 'Rover')
 
@@ -422,6 +426,74 @@ class MAVLinkDetector:
 
                     print(name, source, dialect, sep=' | ', file=file)
 
+    def export_rst(self, file, iterable, branch='master', header=None, 
+                        use_intro=True, **extra_kwargs):
+        if header == 'ardupilot_wiki':
+            header = '\n'.join((
+                '.. _mavlink_support:',
+                '',
+                '===============',
+                'MAVLink Support',
+                '===============',
+                '\n',
+            ))
+
+        if header:
+            print(header, file=file)
+
+        if use_intro:
+            commands = stream_groups = unsupported = ''
+            if extra_kwargs['include_commands']:
+                commands = ' (and commands)'
+            if extra_kwargs['include_unsupported']:
+                unsupported = (
+                    '\n\nKnown :ref:`unsupported messages <mavlink_missing_messages>`'
+                    f'{commands} are shown at the end.'
+                )
+            if extra_kwargs['include_stream_groups']:
+                stream_groups = (
+                    '\n\nThe autopilot includes a set of :ref:`mavlink_stream_groups`'
+                    ' for convenience, which allow configuring the stream rates of'
+                    ' groups of requestable messages by setting parameter values. '
+                    'It is also possible to manually request messages, and request'
+                    ' individual messages be streamed at a specified rate.'
+                )
+            vehicle = self.vehicle.replace('ALL', 'ArduPilot')
+             
+            print(self.RST_INTRO.format(
+                vehicle=vehicle, commands=commands, 
+                stream_groups=stream_groups, unsupported=unsupported
+            ), '\n', file=file)
+            
+        for data in iterable:
+            match data:
+                case str() as type_:
+                    reference = f'mavlink_{type_}'
+                    heading = type_.title().replace('_', ' ')
+                    source_header = (
+                        'Code Source' if type_ != 'stream_groups' else
+                        'Stream Group Parameter'
+                    )
+                    print(f'\n.. _{reference}:\n\n{heading}\n{"="*len(heading)}\n',
+                          self.get_description(type_).replace('`','``'),
+                          '\n.. csv-table::',
+                          f'  :header: MAVLink Message, {source_header}, MAVLink Dialect\n\n',
+                          sep='\n', file=file)
+                case MAVLinkMessage() as message:
+                    name, source, dialect = message.as_tuple()
+                    if dialect != MAVLinkDialect.UNKNOWN:
+                        msg_url = self.MAVLINK_URL.format(dialect=dialect,
+                                                          message_name=name.split(':')[0])
+                        name = f'`{name} <{msg_url}>`_'
+                    if source != 'UNSUPPORTED' and not source.startswith('SRn'):
+                        folder = source.split('/')[0]
+                        base = 'libraries/' if folder not in self.VEHICLES else '' 
+                        code_url = self.ARDUPILOT_URL.format(branch=branch,
+                                                             source=base+source)
+                        source = f'`{source} <{code_url}>`_'
+
+                    print(f'  {name}', source, dialect, sep=', ', file=file)
+
 
 if __name__ == '__main__':
     from inspect import signature
@@ -431,6 +503,7 @@ if __name__ == '__main__':
     default_vehicle = detector_init_params['vehicle'].default
     vehicle_options = [default_vehicle, *MAVLinkDetector.VEHICLES]
     default_exclusions = detector_init_params['exclude_libraries'].default
+    format_options = [*MAVLinkDetector.EXPORT_FILETYPES, 'none']
 
     parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
     parse_opts = parser.add_argument_group('parsing options')
@@ -449,7 +522,7 @@ if __name__ == '__main__':
     export_opts.add_argument('-q', '--quiet', action='store_true',
                              help='Disable printout, only export a file.')
     export_opts.add_argument('-f', '--format', default='markdown',
-                             choices=['csv', 'markdown', 'none'],
+                             choices=format_options,
                              help='Desired format for the exported file.')
     export_opts.add_argument('-b', '--branch',
                              help=('The branch to link to in markdown mode.'


### PR DESCRIPTION
ArduPilot Wiki uses reStructuredText (rst) source files, so supporting rst output is essential for this script to generate wiki files. Ideally this can be run automatically for every vehicle type and version, like the existing parameter lists.

- [x] Add rst support
- [ ] Add per-vehicle dropdown version selection support, like the parameter lists
    - Not yet sure how this is done
- [ ] Set up automatic generation per vehicle, per version
    - May be done via autotest, [like for parameters](https://github.com/ArduPilot/ardupilot/blob/master/Tools/autotest/autotest.py#L194)
        - Moving this to autotest could be useful for notifying of changes in MAVLink support on PRs, but is probably too much effort for this PR
    - Will likely get done externally, in what is currently [the parameters repository](https://github.com/ArduPilot/ParameterRepository/blob/main/scripts/run_param_parse.py#L132)
        - Extra attractive because the script requires Python &geq; 3.11, which will be easier to specify there than forcing autotest to update

Example file for ArduSub 4.1, with all options included:
[ArduSub_Sub-4.1_MAVLink_Messages.rst.zip](https://github.com/user-attachments/files/15531781/ArduSub_Sub-4.1_MAVLink_Messages.rst.zip)