### PR TITLE
SITL: make simulated SBP2 vastly more accurate

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -13696,8 +13696,8 @@ switch value'''
             (1, "UBLOX", None, "u-blox", 5, 'probing'),
             (5, "NMEA", 5, "NMEA", 5, 'probing'),
             (6, "SBP", None, "SBP", 5, 'probing'),
-            # (7, "SBP2", 9, "SBP2", 5),  # broken, "waiting for config data"
             (8, "NOVA", 15, "NOVA", 5, 'probing'),  # no attempt to auto-detect this in AP_GPS
+            (9, "SBP2", None, "SBP2", 5, 'probing'),
             (11, "GSOF", 11, "GSOF", 5, 'specified'), # no attempt to auto-detect this in AP_GPS
             (19, "MSP", 19, "MSP", 32, 'specified'),  # no attempt to auto-detect this in AP_GPS
             # (9, "FILE"),

--- a/libraries/SITL/SIM_GPS_SBP2.cpp
+++ b/libraries/SITL/SIM_GPS_SBP2.cpp
@@ -92,8 +92,8 @@ void GPS_SBP2::publish(const GPS_Data *d)
     velned.n = 1e3 * d->speedN;
     velned.e = 1e3 * d->speedE;
     velned.d = 1e3 * d->speedD;
-    velned.h_accuracy = 5e3;
-    velned.v_accuracy = 5e3;
+    velned.h_accuracy = 1e3 * 0.5;
+    velned.v_accuracy = 1e3 * 0.5;
     velned.n_sats = d->have_lock ? _sitl->gps_numsats[instance] : 3;
     velned.flags = 1;
     sbp_send_message(SBP_VEL_NED_MSGTYPE, 0x2222, sizeof(velned), (uint8_t*)&velned);


### PR DESCRIPTION
I have no idea if this is actually the sort of number which these devices will return.

However, for the EKF to be happy with the GPS the reported speed accuracy must be much lower than the SBP2 driver reports when we give it these numbers.

It might be that we are interpretting these fields incorrectly in the driver and that the simulator is, in fact, correct.
