### PR TITLE
AP_BattMonitor: prevent memory corruption when manipulating DroneCAN backends

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -944,6 +944,19 @@ class sitl_periph_gps(sitl_periph):
             HAL_PERIPH_ENABLE_GPS = 1,
         )
 
+class sitl_periph_battmon(sitl_periph):
+    def configure_env(self, cfg, env):
+        cfg.env.AP_PERIPH = 1
+        super(sitl_periph_battmon, self).configure_env(cfg, env)
+        env.DEFINES.update(
+            HAL_BUILD_AP_PERIPH = 1,
+            PERIPH_FW = 1,
+            CAN_APP_NODE_NAME = '"org.ardupilot.ap_periph_battmon"',
+            APJ_BOARD_ID = 101,
+
+            HAL_PERIPH_ENABLE_BATTERY = 1,
+        )
+
 class esp32(Board):
     abstract = True
     toolchain = 'xtensa-esp32-elf'

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -11527,6 +11527,57 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         ])
         return ret
 
+    def BattCANSplitAuxInfo(self):
+        '''test CAN battery periphs'''
+        self.start_subtest("Swap UAVCAN backend at runtime")
+        self.set_parameters({
+            "CAN_P1_DRIVER": 1,
+            "BATT_MONITOR": 4,  # 4 is ananlog volt+curr
+            "BATT2_MONITOR": 8,  # 8 is UAVCAN_BatteryInfo
+            "BATT_SERIAL_NUM": 0,
+            "BATT2_SERIAL_NUM": 0,
+            "BATT_OPTIONS": 128,  # allow split auxinfo
+            "BATT2_OPTIONS": 128,  # allow split auxinfo
+        })
+        self.reboot_sitl()
+        self.delay_sim_time(2)
+        self.set_parameters({
+            "BATT_MONITOR": 8,  # 8 is UAVCAN_BatteryInfo
+            "BATT2_MONITOR": 4,  # 8 is UAVCAN_BatteryInfo
+        })
+        self.delay_sim_time(2)
+        self.set_parameters({
+            "BATT_MONITOR": 4,  # 8 is UAVCAN_BatteryInfo
+            "BATT2_MONITOR": 8,  # 8 is UAVCAN_BatteryInfo
+        })
+        self.delay_sim_time(2)
+        self.set_parameters({
+            "BATT_MONITOR": 8,  # 8 is UAVCAN_BatteryInfo
+            "BATT2_MONITOR": 4,  # 8 is UAVCAN_BatteryInfo
+        })
+        self.delay_sim_time(2)
+
+    def BattCANReplaceRuntime(self):
+        '''test CAN battery periphs'''
+        self.start_subtest("Replace UAVCAN backend at runtime")
+        self.set_parameters({
+            "CAN_P1_DRIVER": 1,
+            "BATT_MONITOR": 11,  # 4 is ananlog volt+curr
+        })
+        self.reboot_sitl()
+        self.delay_sim_time(2)
+        self.set_parameters({
+            "BATT_MONITOR": 8,  # 4 is UAVCAN batterinfo
+        })
+        self.delay_sim_time(2)
+
+    def testcanbatt(self):
+        ret = ([
+            self.BattCANReplaceRuntime,
+            self.BattCANSplitAuxInfo,
+        ])
+        return ret
+
     def tests(self):
         ret = []
         ret.extend(self.tests1a())
@@ -11590,3 +11641,9 @@ class AutoTestCAN(AutoTestCopter):
 
     def tests(self):
         return self.testcan()
+
+
+class AutoTestBattCAN(AutoTestCopter):
+
+    def tests(self):
+        return self.testcanbatt()

--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -287,7 +287,9 @@ __bin_names = {
     "BalanceBot": "ardurover",
     "Sailboat": "ardurover",
     "SITLPeriphUniversal": ("sitl_periph_universal", "AP_Periph"),
+    "SITLPeriphBattMon": ("sitl_periph_battmon", "AP_Periph"),
     "CAN": "arducopter",
+    "BattCAN": "arducopter",
 }
 
 
@@ -358,11 +360,15 @@ tester_class_map = {
     "test.Sub": ardusub.AutoTestSub,
     "test.Tracker": antennatracker.AutoTestTracker,
     "test.CAN": arducopter.AutoTestCAN,
+    "test.BattCAN": arducopter.AutoTestBattCAN,
 }
 
 supplementary_test_binary_map = {
     "test.CAN": ["sitl_periph_universal:AP_Periph:0:Tools/autotest/default_params/periph.parm,Tools/autotest/default_params/quad-periph.parm", # noqa: E501
                  "sitl_periph_universal:AP_Periph:1:Tools/autotest/default_params/periph.parm"],
+    "test.BattCAN": [
+        "sitl_periph_battmon:AP_Periph:0:Tools/autotest/default_params/periph-battmon.parm,Tools/autotest/default_params/quad-periph.parm", # noqa: E501
+    ],
 }
 
 
@@ -444,6 +450,10 @@ def run_step(step):
     if step == 'build.SITLPeriphUniversal':
         vehicle_binary = 'bin/AP_Periph'
         board = 'sitl_periph_universal'
+
+    if step == 'build.SITLPeriphBattMon':
+        vehicle_binary = 'bin/AP_Periph'
+        board = 'sitl_periph_battmon'
 
     if step == 'build.Replay':
         return util.build_replay(board='SITL')
@@ -1080,6 +1090,9 @@ if __name__ == "__main__":
 
         'build.SITLPeriphUniversal',
         'test.CAN',
+
+        'build.SITLPeriphBattMon',
+        'test.BattCAN',
 
         # convertgps disabled as it takes 5 hours
         # 'convertgpx',

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -160,6 +160,7 @@ public:
         uint8_t     state_of_health_pct;       // state of health (SOH) in percent
         bool        has_state_of_health_pct;   // state_of_health_pct is only valid if this is true
         uint8_t     instance;                  // instance number of this backend
+        Type        type;                      // allocated instance type
         const struct AP_Param::GroupInfo *var_info;
     };
 
@@ -219,10 +220,13 @@ public:
     /// returns the highest failsafe action that has been triggered
     int8_t get_highest_failsafe_priority(void) const { return _highest_failsafe_priority; };
 
-    /// get_type - returns battery monitor type
-    enum Type get_type() const { return get_type(AP_BATT_PRIMARY_INSTANCE); }
-    enum Type get_type(uint8_t instance) const {
+    /// configured_type - returns battery monitor type as configured in parameters
+    enum Type configured_type(uint8_t instance) const {
         return (Type)_params[instance]._type.get();
+    }
+    /// allocated_type - returns battery monitor type as allocated
+    enum Type allocated_type(uint8_t instance) const {
+        return state[instance].type;
     }
 
     /// get_serial_number - returns battery serial number

--- a/libraries/AP_BattMonitor/AP_BattMonitor_DroneCAN.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_DroneCAN.cpp
@@ -79,7 +79,7 @@ AP_BattMonitor_DroneCAN* AP_BattMonitor_DroneCAN::get_dronecan_backend(AP_DroneC
     const auto &batt = AP::battery();
     for (uint8_t i = 0; i < batt._num_instances; i++) {
         if (batt.drivers[i] == nullptr ||
-            batt.get_type(i) != AP_BattMonitor::Type::UAVCAN_BatteryInfo) {
+            batt.allocated_type(i) != AP_BattMonitor::Type::UAVCAN_BatteryInfo) {
             continue;
         }
         AP_BattMonitor_DroneCAN* driver = (AP_BattMonitor_DroneCAN*)batt.drivers[i];
@@ -90,7 +90,7 @@ AP_BattMonitor_DroneCAN* AP_BattMonitor_DroneCAN::get_dronecan_backend(AP_DroneC
     // find empty uavcan driver
     for (uint8_t i = 0; i < batt._num_instances; i++) {
         if (batt.drivers[i] != nullptr &&
-            batt.get_type(i) == AP_BattMonitor::Type::UAVCAN_BatteryInfo &&
+            batt.allocated_type(i) == AP_BattMonitor::Type::UAVCAN_BatteryInfo &&
             match_battery_id(i, battery_id)) {
 
             AP_BattMonitor_DroneCAN* batmon = (AP_BattMonitor_DroneCAN*)batt.drivers[i];
@@ -241,7 +241,7 @@ void AP_BattMonitor_DroneCAN::handle_battery_info_aux_trampoline(AP_DroneCAN *ap
     for (uint8_t i = 0; i < batt._num_instances; i++) {
         const auto *drv = batt.drivers[i];
         if (drv != nullptr &&
-            batt.get_type(i) == AP_BattMonitor::Type::UAVCAN_BatteryInfo &&
+            batt.allocated_type(i) == AP_BattMonitor::Type::UAVCAN_BatteryInfo &&
             drv->option_is_set(AP_BattMonitor_Params::Options::AllowSplitAuxInfo) &&
             batt.get_serial_number(i) == int32_t(msg.battery_id)) {
             driver = (AP_BattMonitor_DroneCAN *)batt.drivers[i];

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -377,7 +377,9 @@ bool GCS_MAVLINK::send_battery_status()
 
     for(uint8_t i = 0; i < AP_BATT_MONITOR_MAX_INSTANCES; i++) {
         const uint8_t battery_id = (last_battery_status_idx + 1) % AP_BATT_MONITOR_MAX_INSTANCES;
-        if (battery.get_type(battery_id) != AP_BattMonitor::Type::NONE) {
+        const auto configured_type = battery.configured_type(battery_id);
+        if (configured_type != AP_BattMonitor::Type::NONE &&
+            configured_type == battery.allocated_type(battery_id)) {
             CHECK_PAYLOAD_SIZE(BATTERY_STATUS);
             send_battery_status(battery_id);
             last_battery_status_idx = battery_id;


### PR DESCRIPTION
```
./Tools/autotest/autotest.py --gdb --debug build.SITLPeriphBattMon build.Copter test.BattCAN
```

Casting a backend to the wrong pointer type and then dereferencing  it is unlikely to end well.  We were doing that in at least two places.

No reason this can't be bad in flight, but the operator is probably insane manipulating these parameters in-flight.
