### PR TITLE
AP_Motors: Heli: Fix SWSH logging for reversed collectives

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
@@ -211,15 +211,16 @@ void AP_MotorsHeli_Swash::add_servo_raw(uint8_t num, float roll, float pitch, fl
 // calculates servo output
 void AP_MotorsHeli_Swash::calculate(float roll, float pitch, float collective)
 {
+
+    // Store inputs for logging, store col before col reversal to ensure logging comes out with the correct sign (+/-)
+    _roll_input = roll;
+    _pitch_input = pitch;
+    _collective_input_scaled = collective;
+
     // Collective control direction. Swash moves up for negative collective pitch, down for positive collective pitch
     if (_collective_direction == COLLECTIVE_DIRECTION_REVERSED){
         collective = 1 - collective;
     }
-
-    // Store inputs for logging
-    _roll_input = roll;
-    _pitch_input = pitch;
-    _collective_input_scaled = collective;
 
     for (uint8_t i = 0; i < _max_num_servos; i++) {
         if (!_enabled[i]) {

--- a/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
@@ -218,7 +218,7 @@ void AP_MotorsHeli_Swash::calculate(float roll, float pitch, float collective)
     _collective_input_scaled = collective;
 
     // Collective control direction. Swash moves up for negative collective pitch, down for positive collective pitch
-    if (_collective_direction == COLLECTIVE_DIRECTION_REVERSED){
+    if (_collective_direction == COLLECTIVE_DIRECTION_REVERSED) {
         collective = 1 - collective;
     }
 


### PR DESCRIPTION
I didn't account for reversed collective directions correctly in my original PR that added swash plate angle logging: https://github.com/ArduPilot/ardupilot/pull/26606

Plot below shows the issue.  This aircraft has two reversed collectives and the collective angle range has come out reversed:
![image](https://github.com/ArduPilot/ardupilot/assets/34512430/4e16a2b1-8a35-42bd-8265-3463a7170d18)

This fix up resolves the issue by storing the collective value before we apply the collective reversal for the control outputs.