### PR TITLE
GCS_MAVLink: remove MOUNT_CONFIGURE/MOUNT_CONTROL handling by default 

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -5437,32 +5437,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 )
                 self.test_mount_pitch(angle, 1, mavutil.mavlink.MAV_MOUNT_MODE_MAVLINK_TARGETING)
 
-            # point gimbal at specified location
-            self.progress("Point gimbal at Location using MOUNT_CONTROL (GPS)")
-            self.do_pitch(despitch)
-            self.set_mount_mode(mavutil.mavlink.MAV_MOUNT_MODE_GPS_POINT)
-
-            # Delay here to allow the attitude to command to timeout and level out the copter a bit
-            self.delay_sim_time(3)
-
-            start = self.mav.location()
-            self.progress("start=%s" % str(start))
-            (t_lat, t_lon) = mavextra.gps_offset(start.lat, start.lng, 10, 20)
-            t_alt = 0
-
-            self.progress("loc %f %f %f" % (start.lat, start.lng, start.alt))
-            self.progress("targetting %f %f %f" % (t_lat, t_lon, t_alt))
-            self.do_pitch(despitch)
-            self.mav.mav.mount_control_send(
-                1, # target system
-                1, # target component
-                int(t_lat * 1e7), # lat
-                int(t_lon * 1e7), # lon
-                t_alt * 100, # alt
-                0  # save position
-            )
-            self.test_mount_pitch(-52, 5, mavutil.mavlink.MAV_MOUNT_MODE_GPS_POINT)
-
             # this is a one-off; ArduCopter *will* time out this directive!
             self.progress("Levelling aircraft")
             self.mav.mav.set_attitude_target_send(

--- a/libraries/GCS_MAVLink/GCS_config.h
+++ b/libraries/GCS_MAVLink/GCS_config.h
@@ -12,7 +12,10 @@
 #define HAL_MAVLINK_BINDINGS_ENABLED HAL_GCS_ENABLED
 #endif
 
+// CODE_REMOVAL
 // BATTERY2 is slated to be removed:
+// ArduPilot 4.6 stops compiling support in
+// ArduPilot 4.7 removes the code entirely
 #ifndef AP_MAVLINK_BATTERY2_ENABLED
 #define AP_MAVLINK_BATTERY2_ENABLED 0
 #endif
@@ -59,8 +62,11 @@
 #define AP_MAVLINK_RALLY_POINT_PROTOCOL_ENABLED HAL_GCS_ENABLED && HAL_RALLY_ENABLED
 #endif
 
+// CODE_REMOVAL
 // handling of HIL_GPS is slated to be removed in 4.7; GPS_INPUT can be used
 // in its place
+// ArduPilot 4.6 stops compiling support in
+// ArduPilot 4.7 removes the code entirely
 #ifndef AP_MAVLINK_MSG_HIL_GPS_ENABLED
 #define AP_MAVLINK_MSG_HIL_GPS_ENABLED 0
 #endif

--- a/libraries/GCS_MAVLink/GCS_config.h
+++ b/libraries/GCS_MAVLink/GCS_config.h
@@ -65,12 +65,16 @@
 #define AP_MAVLINK_MSG_HIL_GPS_ENABLED 0
 #endif
 
+// CODE_REMOVAL
+// ArduPilot 4.5 sends deprecation warnings for MOUNT_CONTROL/MOUNT_CONFIGURE
+// ArduPilot 4.6 stops compiling them in
+// ArduPilot 4.7 removes the code entirely
 #ifndef AP_MAVLINK_MSG_MOUNT_CONFIGURE_ENABLED
-#define AP_MAVLINK_MSG_MOUNT_CONFIGURE_ENABLED HAL_GCS_ENABLED
+#define AP_MAVLINK_MSG_MOUNT_CONFIGURE_ENABLED 0
 #endif
 
 #ifndef AP_MAVLINK_MSG_MOUNT_CONTROL_ENABLED
-#define AP_MAVLINK_MSG_MOUNT_CONTROL_ENABLED HAL_GCS_ENABLED
+#define AP_MAVLINK_MSG_MOUNT_CONTROL_ENABLED 0
 #endif
 
 // this is for both read and write messages:


### PR DESCRIPTION
Also add lifetime hint comments so we remove these in 4.7
