### PR TITLE
 AC_Fence: warn on use of old fence point / rally point protocols 

### DIFF
--- a/libraries/AC_Fence/AC_Fence_config.h
+++ b/libraries/AC_Fence/AC_Fence_config.h
@@ -12,6 +12,10 @@
 #define AP_FENCE_ENABLED 2
 #endif
 
+// CODE_REMOVAL
+// ArduPilot 4.6 sends deprecation warnings for FENCE_POINT/FENCE_FETCH_POINT
+// ArduPilot 4.7 stops compiling them in
+// ArduPilot 4.8 removes the code entirely
 #ifndef AC_POLYFENCE_FENCE_POINT_PROTOCOL_SUPPORT
 #define AC_POLYFENCE_FENCE_POINT_PROTOCOL_SUPPORT HAL_GCS_ENABLED && AP_FENCE_ENABLED
 #endif

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4079,6 +4079,7 @@ void GCS_MAVLINK::handle_message(const mavlink_message_t &msg)
 #if AC_POLYFENCE_FENCE_POINT_PROTOCOL_SUPPORT
     case MAVLINK_MSG_ID_FENCE_POINT:
     case MAVLINK_MSG_ID_FENCE_FETCH_POINT:
+        send_received_message_deprecation_warning("FENCE_FETCH_POINT");
         handle_fence_message(msg);
         break;
 #endif
@@ -4160,6 +4161,7 @@ void GCS_MAVLINK::handle_message(const mavlink_message_t &msg)
 #if AP_MAVLINK_RALLY_POINT_PROTOCOL_ENABLED
     case MAVLINK_MSG_ID_RALLY_POINT:
     case MAVLINK_MSG_ID_RALLY_FETCH_POINT:
+        send_received_message_deprecation_warning("RALLY_FETCH_POINT");
         handle_common_rally_message(msg);
         break;
 #endif

--- a/libraries/GCS_MAVLink/GCS_config.h
+++ b/libraries/GCS_MAVLink/GCS_config.h
@@ -55,6 +55,10 @@
 #define AP_MAVLINK_FAILURE_CREATION_ENABLED 1
 #endif
 
+// CODE_REMOVAL
+// ArduPilot 4.6 sends deprecation warnings for RALLY_POINT/RALLY_FETCH_POINT
+// ArduPilot 4.7 stops compiling them in by default
+// ArduPilot 4.8 removes the code entirely
 #ifndef AP_MAVLINK_RALLY_POINT_PROTOCOL_ENABLED
 #define AP_MAVLINK_RALLY_POINT_PROTOCOL_ENABLED HAL_GCS_ENABLED && HAL_RALLY_ENABLED
 #endif


### PR DESCRIPTION
Send mavlink warning if old FENCE_POINT / RALLY_POINT protocols are used.

MAVProxy stopped using these protocols roughly a year ago, MissionPlanner and QGC years before that.

```
STABILIZE> message fence_fetch_point AP: EKF3 IMU1 origin set
AP: Field Elevation Set: 584m
1 AP: EKF3 IMU0 origin set
1 6
STABILIZE> AP: Received message (FENCE_FETCH_POINT) is deprecated
```
