### PR TITLE
AP_Follow: clarify what we're doing when rotating a vector

### DIFF
--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -492,9 +492,10 @@ bool AP_Follow::get_offsets_ned(Vector3f &offset) const
 Vector3f AP_Follow::rotate_vector(const Vector3f &vec, float angle_deg) const
 {
     // rotate roll, pitch input from north facing to vehicle's perspective
-    const float cos_yaw = cosf(radians(angle_deg));
-    const float sin_yaw = sinf(radians(angle_deg));
-    return Vector3f((vec.x * cos_yaw) - (vec.y * sin_yaw), (vec.y * cos_yaw) + (vec.x * sin_yaw), vec.z);
+    Vector3f ret = vec;
+    ret.xy().rotate(radians(angle_deg));
+
+    return ret;
 }
 
 // set recorded distance and bearing to target to zero


### PR DESCRIPTION
odd sort of a transform, make it clear what's happening

Tested in SITL using this:
```
--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -495,6 +495,15 @@ Vector3f AP_Follow::rotate_vector(const Vector3f &vec, float angle_deg) const
     Vector3f ret = vec;
     ret.xy().rotate(radians(angle_deg));
 
+    const float cos_yaw = cosf(radians(angle_deg));
+    const float sin_yaw = sinf(radians(angle_deg));
+    Vector3f old_ret = Vector3f((vec.x * cos_yaw) - (vec.y * sin_yaw), (vec.y * cos_yaw) + (vec.x * sin_yaw), vec.z);
+    const float delta = (ret - old_ret).length();
+    gcs().send_text(MAV_SEVERITY_INFO, "ang=%f %f/%f/%f delta: %f", angle_deg, ret.x, ret.y, ret.z, delta);
+    if (delta > 0.0001) {
+        abort();
+    }
+
     return ret;
 }
```
