### PR TITLE
autotest: revert SIM_SPEEDUP for RTL in follow test

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -7596,6 +7596,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "FOLL_OFS_TYPE": 1, # relative to other vehicle heading
         })
         self.takeoff(10, mode="LOITER")
+        self.context_push()
         self.set_parameter("SIM_SPEEDUP", 1)
         self.change_mode("FOLLOW")
         new_loc = self.mav.location()
@@ -7634,6 +7635,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             self.progress("position delta=%f (want <%f)" % (delta, max_delta))
             if delta < max_delta:
                 break
+        self.context_pop()
         self.do_RTL()
 
     def get_global_position_int(self, timeout=30):


### PR DESCRIPTION
Just makes the test take a shorter amount of time

Extracted from https://github.com/ArduPilot/ardupilot/pull/27250

This work sponsored by Freespace Operations
