### PR TITLE
Tidy AP_Follow library

### DIFF
--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -411,6 +411,15 @@ void AP_Follow::handle_msg(const mavlink_message_t &msg)
 
     if (updated) {
 #if HAL_LOGGING_ENABLED
+        Log_Write_FOLL();
+#endif
+    }
+}
+
+// write out an onboard-log message to help diagnose follow problems:
+#if HAL_LOGGING_ENABLED
+void AP_Follow::Log_Write_FOLL()
+{
         // get estimated location and velocity
         Location loc_estimate{};
         Vector3f vel_estimate;
@@ -445,9 +454,8 @@ void AP_Follow::handle_msg(const mavlink_message_t &msg)
                                                loc_estimate.lng,
                                                loc_estimate.alt
                                                );
-#endif
-    }
 }
+#endif  // HAL_LOGGING_ENABLED
 
 // get velocity estimate in m/s in NED frame using dt since last update
 bool AP_Follow::get_velocity_ned(Vector3f &vel_ned, float dt) const

--- a/libraries/AP_Follow/AP_Follow.h
+++ b/libraries/AP_Follow/AP_Follow.h
@@ -136,6 +136,10 @@ private:
     // set recorded distance and bearing to target to zero
     void clear_dist_and_bearing_to_target();
 
+    // handle various mavlink messages supplying position:
+    bool handle_global_position_int_message(const mavlink_message_t &msg);
+    bool handle_follow_target_message(const mavlink_message_t &msg);
+
     // write out an onboard-log message to help diagnose follow problems:
     void Log_Write_FOLL();
 

--- a/libraries/AP_Follow/AP_Follow.h
+++ b/libraries/AP_Follow/AP_Follow.h
@@ -118,6 +118,9 @@ public:
 private:
     static AP_Follow *_singleton;
 
+    // returns true if we should extract information from msg
+    bool should_handle_message(const mavlink_message_t &msg) const;
+
     // get velocity estimate in m/s in NED frame using dt since last update
     bool get_velocity_ned(Vector3f &vel_ned, float dt) const;
 

--- a/libraries/AP_Follow/AP_Follow.h
+++ b/libraries/AP_Follow/AP_Follow.h
@@ -136,6 +136,9 @@ private:
     // set recorded distance and bearing to target to zero
     void clear_dist_and_bearing_to_target();
 
+    // write out an onboard-log message to help diagnose follow problems:
+    void Log_Write_FOLL();
+
     // parameters
     AP_Int8     _enabled;           // 1 if this subsystem is enabled
     AP_Int16    _sysid;             // target's mavlink system id (0 to use first sysid seen)


### PR DESCRIPTION
This PR simply splits up the monolithic `handle_message` function into 4 separate functions:
 - `should_handle_message to clarify the logic, remove the modification of state during this stage and make the total file delta in this PR smaller
 - two methods for handling the two different messages we might consume
 - a method that takes care of the logging

Extracted from https://github.com/ArduPilot/ardupilot/pull/27250

This work sponsored by Freespace Operations
