### PR TITLE
AP_Common: Location: allow retrieval of Vector3p from vector-from-origin

### DIFF
--- a/libraries/AP_Common/Location.cpp
+++ b/libraries/AP_Common/Location.cpp
@@ -224,7 +224,8 @@ bool Location::get_alt_m(AltFrame desired_frame, float &ret_alt) const
 #if AP_AHRS_ENABLED
 // converts location to a vector from origin; if this method returns
 // false then vec_ne is unmodified
-bool Location::get_vector_xy_from_origin_NE(Vector2f &vec_ne) const
+template<typename T>
+bool Location::get_vector_xy_from_origin_NE(T &vec_ne) const
 {
     Location ekf_origin;
     if (!AP::ahrs().get_origin(ekf_origin)) {
@@ -235,9 +236,16 @@ bool Location::get_vector_xy_from_origin_NE(Vector2f &vec_ne) const
     return true;
 }
 
+// define for float and position vectors
+template bool Location::get_vector_xy_from_origin_NE<Vector2f>(Vector2f &vec_ne) const;
+#if HAL_WITH_POSTYPE_DOUBLE
+template bool Location::get_vector_xy_from_origin_NE<Vector2p>(Vector2p &vec_ne) const;
+#endif
+
 // converts location to a vector from origin; if this method returns
 // false then vec_neu is unmodified
-bool Location::get_vector_from_origin_NEU(Vector3f &vec_neu) const
+template<typename T>
+bool Location::get_vector_from_origin_NEU(T &vec_neu) const
 {
     // convert altitude
     int32_t alt_above_origin_cm = 0;
@@ -254,6 +262,13 @@ bool Location::get_vector_from_origin_NEU(Vector3f &vec_neu) const
 
     return true;
 }
+
+// define for float and position vectors
+template bool Location::get_vector_from_origin_NEU<Vector3f>(Vector3f &vec_neu) const;
+#if HAL_WITH_POSTYPE_DOUBLE
+template bool Location::get_vector_from_origin_NEU<Vector3p>(Vector3p &vec_neu) const;
+#endif
+
 #endif  // AP_AHRS_ENABLED
 
 // return horizontal distance in meters between two locations

--- a/libraries/AP_Common/Location.h
+++ b/libraries/AP_Common/Location.h
@@ -60,10 +60,12 @@ public:
     // happen if the EKF origin has not been set yet x, y and z are in
     // centimetres.  If this method returns false then vec_ne is
     // unmodified.
-    bool get_vector_xy_from_origin_NE(Vector2f &vec_ne) const WARN_IF_UNUSED;
+    template<typename T>
+    bool get_vector_xy_from_origin_NE(T &vec_ne) const WARN_IF_UNUSED;
     // converts location to a vector from origin; if this method returns
     // false then vec_neu is unmodified
-    bool get_vector_from_origin_NEU(Vector3f &vec_neu) const WARN_IF_UNUSED;
+    template<typename T>
+    bool get_vector_from_origin_NEU(T &vec_neu) const WARN_IF_UNUSED;
 
     // return horizontal distance in meters between two locations
     ftype get_distance(const Location &loc2) const;

--- a/libraries/AP_HAL/AP_HAL_Boards.h
+++ b/libraries/AP_HAL/AP_HAL_Boards.h
@@ -381,4 +381,8 @@
 #error "HAL_GPIO_LED_OFF must not be defined, it is implicitly !HAL_GPIO_LED_ON"
 #endif
 
+#ifndef HAL_WITH_POSTYPE_DOUBLE
+#define HAL_WITH_POSTYPE_DOUBLE BOARD_FLASH_SIZE > 1024
+#endif
+
 #define HAL_GPIO_LED_OFF (!HAL_GPIO_LED_ON)

--- a/libraries/AP_Math/control.h
+++ b/libraries/AP_Math/control.h
@@ -4,10 +4,6 @@
 #include "vector2.h"
 #include "vector3.h"
 
-#ifndef HAL_WITH_POSTYPE_DOUBLE
-#define HAL_WITH_POSTYPE_DOUBLE BOARD_FLASH_SIZE > 1024
-#endif
-
 #if HAL_WITH_POSTYPE_DOUBLE
 typedef double postype_t;
 typedef Vector2d Vector2p;


### PR DESCRIPTION
Extracted from https://github.com/ArduPilot/ardupilot/pull/27250

This allows a vehicle using double-precision position offsets to get that increased precision object from a Location.

I've used a template here as the maths is identical, just the types different.  Since we don't instantiate the second type at the moment there's no flash cost.

This is also built on top of https://github.com/ArduPilot/ardupilot/pull/27253 which fixes the methods up a bit.

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                                                     
Durandal                            0      *           0       0                 0      0      0
Hitec-Airspeed           *                                                                     
KakuteH7-bdshot                     0      *           0       0                 0      0      0
MatekF405                           0      *           0       0                 0      0      0
Pixhawk1-1M-bdshot                  0                  0       0                 0      0      0
f103-QiotekPeriph        *                                                                     
f303-Universal           *                                                                     
iomcu                                                                *                         
revo-mini                           0      *           0       0                 0      0      0
skyviper-v2450                                         0                                       
```

This work sponsored by Freespace Operations
