### PR TITLE
AP_DDS: add param DDS_DOMAIN_ID

### DIFF
--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -74,6 +74,14 @@ const AP_Param::GroupInfo AP_DDS_Client::var_info[] {
 
 #endif
 
+    // @Param: _DOMAIN_ID
+    // @DisplayName: DDS DOMAIN ID
+    // @Description: Set the ROS_DOMAIN_ID
+    // @Range: 0 232
+    // @RebootRequired: True
+    // @User: Standard
+    AP_GROUPINFO("_DOMAIN_ID", 4, AP_DDS_Client, domain_id, 0),
+
     AP_GROUPEND
 };
 
@@ -816,9 +824,8 @@ bool AP_DDS_Client::create()
         .type = UXR_PARTICIPANT_ID
     };
     const char* participant_name = "ardupilot_dds";
-    const uint16_t domain_id = 0;
     const auto participant_req_id = uxr_buffer_create_participant_bin(&session, reliable_out, participant_id,
-                                    domain_id, participant_name, UXR_REPLACE);
+                                    static_cast<uint16_t>(domain_id), participant_name, UXR_REPLACE);
 
     //Participant requests
     constexpr uint8_t nRequestsParticipant = 1;

--- a/libraries/AP_DDS/AP_DDS_Client.h
+++ b/libraries/AP_DDS/AP_DDS_Client.h
@@ -213,6 +213,9 @@ public:
     //! @brief Parameter storage
     static const struct AP_Param::GroupInfo var_info[];
 
+    //! @brief ROS_DOMAIN_ID
+    AP_Int32 domain_id;
+
     //! @brief Enum used to mark a topic as a data reader or writer
     enum class Topic_rw : uint8_t {
         DataReader = 0,


### PR DESCRIPTION
Add a param `DDS_DOMAIN_ID`.

This allows the `ROS_DOMAIN_ID` to be set to values other than the current default of 0, useful for managing multiple vehicles or keeping various ROS 2 running instances separated. The behaviour is backward compatible with a default of 0.

The range of valid domain ids is 0 to 232 (see: https://docs.ros.org/en/rolling/Concepts/About-Domain-ID.html)

Comment: the param should really be `ROS_DOMAIN_ID` to be consistent with usage with the ros2 cli, but as it's in the `DDS_` param tree the name `DDS_ROS_DOMAIN_ID` would just be confusing.

### Testing

Run the default UDP instance:

```bash
ros2 launch ardupilot_sitl sitl_dds_udp.launch.py transport:=udp4 synthetic_clock:=True wipe:=False model:=quad speedup:=1 slave:=0 instance:=0 defaults:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/copter.parm,$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/dds_udp.parm sim_address:=127.0.0.1 master:=tcp:127.0.0.1:5760 sitl:=127.0.0.1:5501
```

In a separate terminal start mavproxy and set the DDS_DOMAIN_ID to a different value:

```bash
$ mavproxy.py --master 127.0.0.1:14550 --console

> param set DDS_DOMAIN_ID 1
> param show DDS*
DDS_DOMAIN_ID    1.0
DDS_ENABLE       1.0         # Enabled
DDS_IP0          127.0
DDS_IP1          0.0
DDS_IP2          0.0
DDS_IP3          1.0
DDS_UDP_PORT     2019.0
```

Now restart the SITL instance prefixing with the `ROS_DOMAIN_ID` env variable set

```bash
ROS_DOMAIN_ID=1 ros2 launch ardupilot_sitl sitl_dds_udp.launch.py transport:=udp4 synthetic_clock:=True wipe:=False model:=quad speedup:=1 slave:=0 instance:=0 defaults:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/copter.parm,$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/dds_udp.parm sim_address:=127.0.0.1 master:=tcp:127.0.0.1:5760 sitl:=127.0.0.1:5501
```

Use the ros2 cli to inspect nodes:

```bash
# expect no nodes, as the default domain is 0
$ ros2 node list
```

```bash
# expect the ardupilot node in domain 1
$ ROS_DOMAIN_ID=1 ros2 node list
/ardupilot_dds
```
