### PR TITLE
Plane: support inverted rangefinder for landing

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1084,6 +1084,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Bitmask: 11: Disable suppression of fixed wing rate gains in ground mode
     // @Bitmask: 12: Enable FBWB style loiter altitude control
     // @Bitmask: 13: Indicate takeoff waiting for neutral rudder with flight control surfaces
+    // @Bitmask: 14: Support inverted landings
     // @User: Advanced
     AP_GROUPINFO("FLIGHT_OPTIONS", 13, ParametersG2, flight_options, 0),
 

--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -667,6 +667,14 @@ void Plane::rangefinder_height_update(void)
         // correct the range for attitude (multiply by DCM.c.z, which
         // is cos(roll)*cos(pitch))
         rangefinder_state.height_estimate = distance * ahrs.get_rotation_body_to_ned().c.z;
+        if (flight_option_enabled(FlightOptions::INVERTED_LANDING) && fly_inverted()) {
+            /*
+              allow for rangefinders which point upwards for an
+              inverted landing. Some aircraft are setup for inverted
+              landing to protect camera payloads
+             */
+            rangefinder_state.height_estimate *= -1;
+        }
 
         rangefinder_terrain_correction(rangefinder_state.height_estimate);
 

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -168,6 +168,7 @@ enum FlightOptions {
     DISABLE_GROUND_PID_SUPPRESSION = (1<<11),
     ENABLE_LOITER_ALT_CONTROL = (1<<12),
     INDICATE_WAITING_FOR_RUDDER_NEUTRAL = (1<<13),
+    INVERTED_LANDING = (1<<14),
 };
 
 enum CrowFlapOptions {


### PR DESCRIPTION
this allows for planes where the rangefinder is setup so it sees the ground when landing inverted.

Inverted landing can be useful for some types of payload