### PR TITLE
AP_InertialSensor: fixed ICM42670

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
@@ -294,13 +294,13 @@ void AP_InertialSensor_Invensensev3::start()
         switch (inv3_type) {
             case Invensensev3_Type::ICM42688: // HiRes 19bit
             case Invensensev3_Type::IIM42652: // HiRes 19bit
-            case Invensensev3_Type::ICM42670: // HiRes 19bit
             case Invensensev3_Type::ICM45686: // HiRes 20bit
                 highres_sampling = dev->bus_type() == AP_HAL::Device::BUS_TYPE_SPI;
                 break;
             case Invensensev3_Type::ICM40609: // No HiRes
             case Invensensev3_Type::ICM42605:
             case Invensensev3_Type::ICM40605:
+            case Invensensev3_Type::ICM42670: // HiRes 19bit (not working)
                 break;
         }
     }


### PR DESCRIPTION
highres sampling is not working on the ICM42670 on some versions of the Pixhawk6X. Disable for now.
without this change the 3rd IMU gets no data