### PR TITLE
Add and use new ModeReason::AUX_FUNCTION

### DIFF
--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -144,7 +144,7 @@ void RC_Channel_Copter::do_aux_function_change_mode(const Mode::Number mode,
     switch(ch_flag) {
     case AuxSwitchPos::HIGH: {
         // engage mode (if not possible we remain in current flight mode)
-        copter.set_mode(mode, ModeReason::RC_COMMAND);
+        copter.set_mode(mode, ModeReason::AUX_FUNCTION);
         break;
     }
     default:
@@ -163,7 +163,7 @@ bool RC_Channel_Copter::do_aux_function(const AUX_FUNC ch_option, const AuxSwitc
         case AUX_FUNC::FLIP:
             // flip if switch is on, positive throttle and we're actually flying
             if (ch_flag == AuxSwitchPos::HIGH) {
-                copter.set_mode(Mode::Number::FLIP, ModeReason::RC_COMMAND);
+                copter.set_mode(Mode::Number::FLIP, ModeReason::AUX_FUNCTION);
             }
             break;
 

--- a/ArduPlane/RC_Channel.cpp
+++ b/ArduPlane/RC_Channel.cpp
@@ -43,7 +43,7 @@ void RC_Channel_Plane::do_aux_function_change_mode(const Mode::Number number,
     switch(ch_flag) {
     case AuxSwitchPos::HIGH: {
         // engage mode (if not possible we remain in current flight mode)
-        plane.set_mode_by_number(number, ModeReason::RC_COMMAND);
+        plane.set_mode_by_number(number, ModeReason::AUX_FUNCTION);
         break;
     }
     default:

--- a/Blimp/RC_Channel.cpp
+++ b/Blimp/RC_Channel.cpp
@@ -79,7 +79,7 @@ void RC_Channel_Blimp::do_aux_function_change_mode(const Mode::Number mode,
     switch (ch_flag) {
     case AuxSwitchPos::HIGH: {
         // engage mode (if not possible we remain in current flight mode)
-        const bool success = blimp.set_mode(mode, ModeReason::RC_COMMAND);
+        const bool success = blimp.set_mode(mode, ModeReason::AUX_FUNCTION);
         if (blimp.ap.initialised) {
             if (success) {
                 AP_Notify::events.user_mode_change = 1;

--- a/Rover/RC_Channel.cpp
+++ b/Rover/RC_Channel.cpp
@@ -86,7 +86,7 @@ void RC_Channel_Rover::do_aux_function_change_mode(Mode &mode,
 {
     switch (ch_flag) {
     case AuxSwitchPos::HIGH:
-        rover.set_mode(mode, ModeReason::RC_COMMAND);
+        rover.set_mode(mode, ModeReason::AUX_FUNCTION);
         break;
     case AuxSwitchPos::MIDDLE:
         // do nothing

--- a/libraries/AP_Vehicle/ModeReason.h
+++ b/libraries/AP_Vehicle/ModeReason.h
@@ -70,4 +70,5 @@ enum class ModeReason : uint8_t {
   DEADRECKON_FAILSAFE = 50,
   MODE_TAKEOFF_FAILSAFE = 51,
   DDS_COMMAND = 52,
+  AUX_FUNCTION = 53,
 };


### PR DESCRIPTION
Aux function are no longer only from RC. This changes to use a dedicated mode reason.

We don't check for the old `ModeReason::RC_COMMAND` anywhere in the main code. Nor is it exposed over MAVLink. There is a scripting binding, and it is used in logging.

The scripting binding is `vehicle:get_control_mode_reason()`, it is not used by any of our examples.