### PR TITLE
SITL: log number of times sim paused on serial0 buffer

### DIFF
--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
@@ -206,6 +206,11 @@ bool HAL_SITL::run_in_maintenance_mode() const
 }
 #endif
 
+uint32_t HAL_SITL::get_uart_output_full_queue_count() const
+{
+    return _sitl_state->_serial_0_outqueue_full_count;
+}
+
 void HAL_SITL::run(int argc, char * const argv[], Callbacks* callbacks) const
 {
     assert(callbacks);

--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.h
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.h
@@ -41,6 +41,8 @@ public:
     bool run_in_maintenance_mode() const;
 #endif
 
+    uint32_t get_uart_output_full_queue_count() const;
+
 private:
     HALSITL::SITL_State *_sitl_state;
 

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -188,6 +188,7 @@ void SITL_State::wait_clock(uint64_t wait_time_usec)
             if (queue_length < 1024) {
                 break;
             }
+            _serial_0_outqueue_full_count++;
             usleep(1000);
         }
     }

--- a/libraries/AP_HAL_SITL/SITL_State_common.h
+++ b/libraries/AP_HAL_SITL/SITL_State_common.h
@@ -247,6 +247,10 @@ public:
     void multicast_state_open(void);
     void multicast_state_send(void);
 
+    // number of times we have paused the simulation for 1ms because
+    // the TCP queue is full:
+    uint32_t _serial_0_outqueue_full_count;
+
 protected:
     enum vehicle_type _vehicle;
 

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -32,10 +32,16 @@
 #include <AP_JSON/AP_JSON.h>
 #include <AP_Filesystem/AP_Filesystem.h>
 #include <AP_AHRS/AP_AHRS.h>
+#include <AP_HAL_SITL/HAL_SITL_Class.h>
 
 using namespace SITL;
 
 extern const AP_HAL::HAL& hal;
+
+// the SITL HAL can add information about pausing the simulation and its effect on the UART.  Not present when we're compiling for simulation-on-hardware
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+extern const HAL_SITL& hal_sitl;
+#endif
 
 /*
   parent class for all simulator types
@@ -452,6 +458,14 @@ void Aircraft::fill_fdm(struct sitl_fdm &fdm)
     }
 
 #if HAL_LOGGING_ENABLED
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    // the SITL HAL can add information about pausing the simulation
+    // and its effect on the UART.  Not present when we're compiling
+    // for simulation-on-hardware
+    const uint32_t full_count = hal_sitl.get_uart_output_full_queue_count();
+#else
+    const uint32_t full_count = 0;
+#endif
     // for EKF comparison log relhome pos and velocity at loop rate
     static uint16_t last_ticks;
     uint16_t ticks = AP::scheduler().ticks();
@@ -468,15 +482,20 @@ void Aircraft::fill_fdm(struct sitl_fdm &fdm)
 // @Field: VD: Velocity down
 // @Field: As: Airspeed
 // @Field: ASpdU: Achieved simulation speedup value
+// @Field: UFC: Number of times simulation paused for serial0 output
         Vector3d pos = get_position_relhome();
         Vector3f vel = get_velocity_ef();
-        AP::logger().WriteStreaming("SIM2", "TimeUS,PN,PE,PD,VN,VE,VD,As,ASpdU",
-                                    "Qdddfffff",
-                                    AP_HAL::micros64(),
-                                    pos.x, pos.y, pos.z,
-                                    vel.x, vel.y, vel.z,
-                                    airspeed_pitot,
-                                    achieved_rate_hz/rate_hz);
+        AP::logger().WriteStreaming(
+            "SIM2",
+            "TimeUS,PN,PE,PD,VN,VE,VD,As,ASpdU,UFC",
+            "QdddfffffI",
+            AP_HAL::micros64(),
+            pos.x, pos.y, pos.z,
+            vel.x, vel.y, vel.z,
+            airspeed_pitot,
+            achieved_rate_hz/rate_hz,
+            full_count
+        );
     }
 #endif
 }


### PR DESCRIPTION
SITL pauses the simulation if we do not have a minimum amount of space in its out queue.

Log the number of times we do this.

Fora run of the AutoTuneSwitch test:

![image](https://github.com/ArduPilot/ardupilot/assets/7077857/b2eb9279-5f4e-4ffb-8bda-4c4b9e8989dc)

...shows we drop a packet at the start before we bring up the mavlink connection from autotest.  I think.  `SIM_SPEEDUP` was the default 100.


I've also tested ctrl-z on the terminal running autotest, and the sim starts complaining a lot:

![image](https://github.com/ArduPilot/ardupilot/assets/7077857/1e7b7895-29a9-4e36-bede-64a7148db1bf)
