### PR TITLE
autotest: clarify AutoTuneSwitch test

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -6026,11 +6026,11 @@ class TestSuite(ABC):
                 pass
         raise NotAchievedException("Failed to retrieve parameter (%s)" % name)
 
-    def get_parameters(self, some_list):
+    def get_parameters(self, some_list, **kwargs):
         ret = {}
 
         for n in some_list:
-            ret[n] = self.get_parameter(n)
+            ret[n] = self.get_parameter(n, **kwargs)
 
         return ret
 


### PR DESCRIPTION
Just cleans things up a little to have less parameter fetching.

Also clears up a mis-understanding in the test about the way reported parameter gains work in autotune once tuning is complete.
