### PR TITLE
Tools: Added option to set environment variable to not add the compile_commands.json to VSCode's c_cpp_properties.json

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -187,7 +187,7 @@ class Board:
         cfg.env.prepend_value('INCLUDES', [
             cfg.srcnode.find_dir('libraries/AP_Common/missing').abspath()
         ])
-        if os.path.exists(os.path.join(env.SRCROOT, '.vscode/c_cpp_properties.json')):
+        if os.path.exists(os.path.join(env.SRCROOT, '.vscode/c_cpp_properties.json')) and 'AP_NO_COMPILE_COMMANDS' not in os.environ:
             # change c_cpp_properties.json configure the VSCode Intellisense env
             c_cpp_properties = json.load(open(os.path.join(env.SRCROOT, '.vscode/c_cpp_properties.json')))
             for config in c_cpp_properties['configurations']:


### PR DESCRIPTION
This allows users to set an environment variable (AP_NO_COMPILE_COMMANDS) to stop the build system from adding the compile commands to their c_cpp_properties.json file.

This is useful for testing - say if I'm switching between sitl and a real board and I don't want VS code's Intellisense to keep being switched around between the two, or if one wants the Intellisense to be for a specific board even when one is compiling other boards (i.e. you could set it for a specific board's compile_commands.json and have it not be changed when you compile other boards). Also, because the build system sets the file when it starts compiling but when the file was being generated, it would only be generated at the end, it means that if you do a ./waf clean then the Intellisense would be broken until the build finishes. 

And finally, because this part of the build system is currently broken, this allows us to use a workaround (by setting up the include path, defines and compiler args parts) until @bugobliterator's PR https://github.com/ArduPilot/ardupilot/pull/27243 to fix it is merged, because unfortunately, just having the line in the file (even when the compile_commands.json file doesn't even exist) _overrides_ all the other settings, thus completely breaking Intellisense.