### PR TITLE
ArduCopter: get MAV_STATE_BOOT on reboot

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -89,6 +89,10 @@ MAV_STATE GCS_MAVLINK_Copter::vehicle_system_status() const
         return MAV_STATE_STANDBY;
     }
 
+    if (!copter.ap.initialised) {
+    	return MAV_STATE_BOOT;
+    }
+
     return MAV_STATE_ACTIVE;
 }
 


### PR DESCRIPTION
this change add a step in the booting process to let know a companion computer if the autopilot has rebooted