### PR TITLE
Copter, Rover, Plane, Tracker: 4.5.4 release

### DIFF
--- a/AntennaTracker/ReleaseNotes.txt
+++ b/AntennaTracker/ReleaseNotes.txt
@@ -1,5 +1,12 @@
 Antenna Tracker Release Notes:
 ------------------------------
+Release 4.5.4 12th June 2024
+
+Changes from 4.5.3
+
+Disable highres IMU sampling on ICM42670 fixing an issue on some versions of Pixhawk6X
+
+------------------------------------------------------------------
 Release 4.5.3 28th May 2024
 
 No changes from 4.5.3-beta1

--- a/AntennaTracker/version.h
+++ b/AntennaTracker/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "AntennaTracker V4.5.3"
+#define THISFIRMWARE "AntennaTracker V4.5.4"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,5,3,FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FIRMWARE_VERSION 4,5,4,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 5
-#define FW_PATCH 3
+#define FW_PATCH 4
 #define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,5 +1,12 @@
 ArduPilot Copter Release Notes:
 -------------------------------
+Release 4.5.4 12th June 2024
+
+Changes from 4.5.3
+
+Disable highres IMU sampling on ICM42670 fixing an issue on some versions of Pixhawk6X
+
+------------------------------------------------------------------
 Release 4.5.3 28th May 2024
 
 No changes from 4.5.3-beta1

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.5.3"
+#define THISFIRMWARE "ArduCopter V4.5.4"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,5,3,FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FIRMWARE_VERSION 4,5,4,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 5
-#define FW_PATCH 3
+#define FW_PATCH 4
 #define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/ArduPlane/ReleaseNotes.txt
+++ b/ArduPlane/ReleaseNotes.txt
@@ -1,5 +1,12 @@
 ArduPilot Plane Release Notes:
 ------------------------------
+Release 4.5.4 12th June 2024
+
+Changes from 4.5.3
+
+Disable highres IMU sampling on ICM42670 fixing an issue on some versions of Pixhawk6X
+
+------------------------------------------------------------------
 Release 4.5.3 28th May 2024
 
 No changes from 4.5.3-beta1

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduPlane V4.5.3"
+#define THISFIRMWARE "ArduPlane V4.5.4"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,5,3,FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FIRMWARE_VERSION 4,5,4,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 5
-#define FW_PATCH 3
+#define FW_PATCH 4
 #define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/Rover/ReleaseNotes.txt
+++ b/Rover/ReleaseNotes.txt
@@ -1,5 +1,12 @@
 Rover Release Notes:
 --------------------
+Release 4.5.4 12th June 2024
+
+Changes from 4.5.3
+
+Disable highres IMU sampling on ICM42670 fixing an issue on some versions of Pixhawk6X
+
+------------------------------------------------------------------
 Release 4.5.3 28th May 2024
 
 No changes from 4.5.3-beta1

--- a/Rover/version.h
+++ b/Rover/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduRover V4.5.3"
+#define THISFIRMWARE "ArduRover V4.5.4"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,5,3,FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FIRMWARE_VERSION 4,5,4,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 5
-#define FW_PATCH 3
+#define FW_PATCH 4
 #define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
@@ -294,13 +294,13 @@ void AP_InertialSensor_Invensensev3::start()
         switch (inv3_type) {
             case Invensensev3_Type::ICM42688: // HiRes 19bit
             case Invensensev3_Type::IIM42652: // HiRes 19bit
-            case Invensensev3_Type::ICM42670: // HiRes 19bit
             case Invensensev3_Type::ICM45686: // HiRes 20bit
                 highres_sampling = dev->bus_type() == AP_HAL::Device::BUS_TYPE_SPI;
                 break;
             case Invensensev3_Type::ICM40609: // No HiRes
             case Invensensev3_Type::ICM42605:
             case Invensensev3_Type::ICM40605:
+            case Invensensev3_Type::ICM42670: // HiRes 19bit (not working)
                 break;
         }
     }


### PR DESCRIPTION
This moves copter, rover, plane and tracker to 4.5.4. The only change from 4.5.3 is the inclusion of https://github.com/ArduPilot/ardupilot/pull/27264.

Note that this is not a beta.