### PR TITLE
board_types.txt:  PMU And GNSS ID Reserve for ZeroOne.

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -356,9 +356,10 @@ AP_HW_Holybro-PERIPH-H7              5404
 #IDs 5501-5599 reserved for MATEKSYS
 AP_HW_MATEKH743SE                    5501
 
-
 #IDs 5600-5699 reserved for ZeroOne
 AP_HW_ZeroOne_X6                     5600
+AP_HW_ZeroOne_PMU                    5601
+AP_HW_ZeroOne_GNSS                   5602
 
 # IDs 6000-6099 reserved for SpektreWorks
 


### PR DESCRIPTION
PMU And GNSS ID Reserve for ZeroOne.