### PR TITLE
Param: added arming check for eeprom full

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1046,6 +1046,11 @@ bool AP_Arming::system_checks(bool report)
             return false;
         }
 
+        if (AP_Param::get_eeprom_full()) {
+            check_failed(ARMING_CHECK_PARAMETERS, report, "parameter storage full");
+            return false;
+        }
+        
         // check main loop rate is at least 90% of expected value
         const float actual_loop_rate = AP::scheduler().get_filtered_loop_rate_hz();
         const uint16_t expected_loop_rate = AP::scheduler().get_loop_rate_hz();

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -112,6 +112,9 @@ uint16_t AP_Param::param_overrides_len;
 uint16_t AP_Param::num_param_overrides;
 uint16_t AP_Param::num_read_only;
 
+// goes true if we run out of param space
+bool AP_Param::eeprom_full;
+
 ObjectBuffer_TS<AP_Param::param_save> AP_Param::save_queue{30};
 bool AP_Param::registered_save_handler;
 
@@ -1192,6 +1195,8 @@ void AP_Param::save_sync(bool force_save, bool send_to_gcs)
         return;
     }
     if (ofs == (uint16_t) ~0) {
+        eeprom_full = true;
+        DEV_PRINTF("EEPROM full\n");
         return;
     }
 
@@ -1224,6 +1229,7 @@ void AP_Param::save_sync(bool force_save, bool send_to_gcs)
 
     if (ofs+type_size((enum ap_var_type)phdr.type)+2*sizeof(phdr) >= _storage.size()) {
         // we are out of room for saving variables
+        eeprom_full = true;
         DEV_PRINTF("EEPROM full\n");
         return;
     }

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -430,6 +430,11 @@ public:
     ///
     static bool load_all();
 
+    // return true if eeprom is full, used for arming check
+    static bool get_eeprom_full(void) {
+        return eeprom_full;
+    }
+
     // returns storage space used:
     static uint16_t storage_used() { return sentinal_offset; }
 
@@ -865,6 +870,8 @@ private:
     };
     static defaults_list *default_list;
     static void check_default(AP_Param *ap, float *default_value);
+
+    static bool eeprom_full;
 };
 
 namespace AP {


### PR DESCRIPTION
this allows users to know if their params won't persist, which is dangerous for a common
preflight reboot