### PR TITLE
AP_Logger: tidy running of LoggerMessageWriter sub-writers

### DIFF
--- a/libraries/AP_Logger/LoggerMessageWriter.cpp
+++ b/libraries/AP_Logger/LoggerMessageWriter.cpp
@@ -177,40 +177,30 @@ void LoggerMessageWriter_DFLogStart::process()
         stage = Stage::RUNNING_SUBWRITERS;
         FALLTHROUGH;
 
-    case Stage::RUNNING_SUBWRITERS:
-        if (!_writesysinfo.finished()) {
-            _writesysinfo.process();
-            if (!_writesysinfo.finished()) {
-                return;
-            }
-        }
+    case Stage::RUNNING_SUBWRITERS: {
+        LoggerMessageWriter *subwriters[] {
+            &_writesysinfo,
 #if AP_MISSION_ENABLED
-        if (!_writeentiremission.finished()) {
-            _writeentiremission.process();
-            if (!_writeentiremission.finished()) {
-                return;
-            }
-        }
+            &_writeentiremission,
 #endif
 #if HAL_LOGGER_RALLY_ENABLED
-        if (!_writeallrallypoints.finished()) {
-            _writeallrallypoints.process();
-            if (!_writeallrallypoints.finished()) {
-                return;
-            }
-        }
+            &_writeallrallypoints,
 #endif
 #if HAL_LOGGER_FENCE_ENABLED
-        if (!_writeallpolyfence.finished()) {
-            _writeallpolyfence.process();
-            if (!_writeallpolyfence.finished()) {
-                return;
+            &_writeallpolyfence,
+#endif
+        };
+        for (auto *sw : subwriters) {
+            if (!sw->finished()) {
+                sw->process();
+                if (!sw->finished()) {
+                    return;
+                }
             }
         }
-#endif
         stage = Stage::VEHICLE_MESSAGES;
         FALLTHROUGH;
-
+    }
     case Stage::VEHICLE_MESSAGES:
         // we guarantee 200 bytes of space for the vehicle startup
         // messages.  This allows them to be simple functions rather

--- a/libraries/AP_Logger/LoggerMessageWriter.h
+++ b/libraries/AP_Logger/LoggerMessageWriter.h
@@ -8,7 +8,7 @@ public:
 
     virtual void reset() = 0;
     virtual void process() = 0;
-    virtual bool finished() { return _finished; }
+    bool finished() const { return _finished; }
 
     virtual void set_logger_backend(class AP_Logger_Backend *backend) {
         _logger_backend = backend;


### PR DESCRIPTION
... use the fact these all have a common base class to reduce effectively duplicate code.

Also un-virtualise and const a function which wasn't overridden and can be const

Tested in SITL by creating fence, mission and rally and ensuring they still get to the log.

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  16                                                                    
Durandal                            -64    *           -64     -64               -64    -64    -64
Hitec-Airspeed           *                                                                     
KakuteH7-bdshot                     -88    *           -88     -88               -96    -88    -96
MatekF405                           -96    *           -96     -88               -96    -96    -88
Pixhawk1-1M-bdshot                  -88                -96     -96               -88    -88    -96
f103-QiotekPeriph        *                                                                     
f303-Universal           *                                                                     
iomcu                                                                *                         
revo-mini                           -88    *           -96     -88               -88    -96    -88
skyviper-v2450                                         -88                                     
```

Some more saving to be made by making `PARM`, `UNIT`, `MULTI` and `FMTU` all subwriters.
