### PR TITLE
AP_Logger: write formats out as required rather than at start of log

### DIFF
--- a/libraries/AP_Logger/AP_Logger_Backend.h
+++ b/libraries/AP_Logger/AP_Logger_Backend.h
@@ -9,6 +9,7 @@
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <AP_Mission/AP_Mission.h>
 #include <AP_Vehicle/ModeReason.h>
+#include "LogStructure.h"
 
 class LoggerMessageWriter_DFLogStart;
 
@@ -132,6 +133,9 @@ public:
     bool Write_Fence();
 #endif
     bool Write_Format(const struct LogStructure *structure);
+    bool have_emitted_format_for_type(LogMessages a_type) const {
+        return _formats_written.get(uint8_t(a_type));
+    }
     bool Write_Message(const char *message);
     bool Write_MessageF(const char *fmt, ...);
     bool Write_Mission_Cmd(const AP_Mission &mission,
@@ -195,7 +199,6 @@ protected:
     /*
       read a block
     */
-    virtual bool WriteBlockCheckStartupMessages();
     virtual void WriteMoreStartupMessages();
     virtual void push_log_blocks();
 
@@ -262,6 +265,12 @@ private:
 
     void Write_AP_Logger_Stats_File(const struct df_stats &_stats);
     void validate_WritePrioritisedBlock(const void *pBuffer, uint16_t size);
+
+    bool message_type_from_block(const void *pBuffer, uint16_t size, LogMessages &type) const;
+    bool ensure_format_emitted(const void *pBuffer, uint16_t size);
+    bool emit_format_for_type(LogMessages a_type);
+    Bitmask<256> _formats_written;
+
 };
 
 #endif  // HAL_LOGGING_ENABLED

--- a/libraries/AP_Logger/AP_Logger_Block.cpp
+++ b/libraries/AP_Logger/AP_Logger_Block.cpp
@@ -132,11 +132,6 @@ bool AP_Logger_Block::_WritePrioritisedBlock(const void *pBuffer, uint16_t size,
         return false;
     }
 
-    if (!WriteBlockCheckStartupMessages()) {
-        _dropped++;
-        return false;
-    }
-
     WITH_SEMAPHORE(write_sem);
 
     const uint32_t space = writebuf.space();

--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -474,11 +474,6 @@ bool AP_Logger_File::_WritePrioritisedBlock(const void *pBuffer, uint16_t size, 
 {
     WITH_SEMAPHORE(semaphore);
 
-    if (! WriteBlockCheckStartupMessages()) {
-        _dropped++;
-        return false;
-    }
-
 #if APM_BUILD_TYPE(APM_BUILD_Replay)
     if (AP::FS().write(_write_fd, pBuffer, size) != size) {
         AP_HAL::panic("Short write");

--- a/libraries/AP_Logger/AP_Logger_MAVLink.cpp
+++ b/libraries/AP_Logger/AP_Logger_MAVLink.cpp
@@ -136,11 +136,6 @@ bool AP_Logger_MAVLink::_WritePrioritisedBlock(const void *pBuffer, uint16_t siz
         return false;
     }
 
-    if (! WriteBlockCheckStartupMessages()) {
-        semaphore.give();
-        return false;
-    }
-
     if (bufferspace_available() < size) {
         if (_startup_messagewriter->finished()) {
             // do not count the startup packets as being dropped...

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -60,7 +60,11 @@ bool AP_Logger_Backend::Write_Format(const struct LogStructure *s)
 {
     struct log_Format pkt;
     Fill_Format(s, pkt);
-    return WriteCriticalBlock(&pkt, sizeof(pkt));
+    if (!WriteCriticalBlock(&pkt, sizeof(pkt))) {
+        return false;
+    }
+    _formats_written.set(s->msg_type);
+    return true;
 }
 
 /*

--- a/libraries/AP_Logger/LoggerMessageWriter.cpp
+++ b/libraries/AP_Logger/LoggerMessageWriter.cpp
@@ -109,7 +109,12 @@ void LoggerMessageWriter_DFLogStart::process()
     case Stage::FORMATS:
         // write log formats so the log is self-describing
         while (next_format_to_send < _logger_backend->num_types()) {
-            if (!_logger_backend->Write_Format(_logger_backend->structure(next_format_to_send))) {
+            const auto &s { _logger_backend->structure(next_format_to_send) };
+            if (_logger_backend->have_emitted_format_for_type((LogMessages)s->msg_type)) {
+                next_format_to_send++;
+                continue;
+            }
+            if (!_logger_backend->Write_Format(s)) {
                 return; // call me again!
             }
             next_format_to_send++;


### PR DESCRIPTION
We may need to resurrect the `push_log_blocks` stuff here to try to make more room?

```
pbarker@fx:~/rc/ardupilot(pr/logger-formats-when-required)$ mavlogdump.py logs/00000001.BIN  | head
2024-06-14 22:52:00.55: FMT {Type : 128, Length : 89, Name : FMT, Format : BBnNZ, Columns : Type,Length,Name,Format,Columns}
2024-06-14 22:52:00.55: FMT {Type : 59, Length : 75, Name : MSG, Format : QZ, Columns : TimeUS,Message}
2024-06-14 22:51:51.96: MSG {TimeUS : 37148468, Message : Arming motors}
2024-06-14 22:51:51.96: FMT {Type : 3, Length : 16, Name : D32, Format : QBi, Columns : TimeUS,Id,Value}
2024-06-14 22:51:51.96: D32 {TimeUS : 37148468, Id : 9, Value : 35570}
2024-06-14 22:51:51.96: FMT {Type : 71, Length : 24, Name : ORGN, Format : QBLLe, Columns : TimeUS,Type,Lat,Lng,Alt}
2024-06-14 22:51:51.96: ORGN {TimeUS : 37148468, Type : 0, Lat : -35.3632621, Lng : 149.1652374, Alt : 584.09}
2024-06-14 22:51:51.96: ORGN {TimeUS : 37148468, Type : 1, Lat : -35.3632621, Lng : 149.1652374, Alt : 584.09}
2024-06-14 22:51:51.96: FMT {Type : 119, Length : 14, Name : MODE, Format : QMBB, Columns : TimeUS,Mode,ModeNum,Rsn}
2024-06-14 22:51:51.96: MODE {TimeUS : 37148468, Mode : 0, ModeNum : 0, Rsn : 1}
2024-06-14 22:51:51.96: FMT {Type : 77, Length : 48, Name : MAVC, Format : QBBBBBHffffiifBB, Columns : TimeUS,TS,TC,SS,SC,Fr,Cmd,P1,P2,P3,P4,X,Y,Z,Res,WL}
2024-06-14 22:51:51.96: MAVC {TimeUS : 37148468, TS : 1, TC : 1, SS : 255, SC : 230, Fr : 3, Cmd : 400, P1 : 1.0, P2 : 0.0, P3 : 0.0, P4 : 0.0, X : 0, Y : 0, Z : 0.0, Res : 0, WL : 1}
2024-06-14 22:51:51.96: FMT {Type : 116, Length : 76, Name : UNIT, Format : QbZ, Columns : TimeUS,Id,Label}
2024-06-14 22:51:51.96: FMT {Type : 115, Length : 44, Name : FMTU, Format : QBNN, Columns : TimeUS,FmtType,UnitIds,MultIds}
2024-06-14 22:51:51.96: FMT {Type : 117, Length : 20, Name : MULT, Format : Qbd, Columns : TimeUS,Id,Mult}
2024-06-14 22:51:51.96: FMT {Type : 32, Length : 35, Name : PARM, Format : QNff, Columns : TimeUS,Name,Value,Default}
2024-06-14 22:51:51.96: FMT {Type : 91, Length : 51, Name : GPS, Format : QBBIHBcLLeffffB, Columns : TimeUS,I,Status,GMS,GWk,NSats,HDop,Lat,Lng,Alt,Spd,GCrs,VZ,Yaw,U}
2024-06-14 22:51:51.96: FMT {Type : 92, Length : 39, Name : GPA, Format : QBCCCCfBIHfHH, Columns : TimeUS,I,VDop,HAcc,VAcc,SAcc,YAcc,VV,SMS,Delta,Und,RTCMFU,RTCMFD}
2024-06-14 22:51:51.96: FMT {Type : 96, Length : 22, Name : UBX1, Format : QBHBBHI, Columns : TimeUS,Instance,noisePerMS,jamInd,aPower,agcCnt,config}
2024-06-14 22:51:51.96: FMT {Type : 97, Length : 16, Name : UBX2, Format : QBbBbB, Columns : TimeUS,Instance,ofsI,magI,ofsQ,magQ}
2024-06-14 22:51:51.96: FMT {Type : 93, Length : 42, Name : GRAW, Format : QIHBBddfBbB, Columns : TimeUS,WkMS,Week,numSV,sv,cpMes,prMes,doMes,mesQI,cno,lli}
2024-06-14 22:51:51.96: FMT {Type : 94, Length : 24, Name : GRXH, Format : QdHbBB, Columns : TimeUS,rcvTime,week,leapS,numMeas,recStat}
2024-06-14 22:51:51.96: FMT {Type : 95, Length : 41, Name : GRXS, Format : QddfBBBHBBBBB, Columns : TimeUS,prMes,cpMes,doMes,gnss,sv,freq,lock,cno,prD,cpD,doD,trk}
2024-06-14 22:51:51.96: FMT {Type : 98, Length : 23, Name : SBPH, Format : QIII, Columns : TimeUS,CrcError,LastInject,IARhyp}
2024-06-14 22:51:51.96: FMT {Type : 99, Length : 67, Name : SBRH, Format : QQQQQQQQ, Columns : TimeUS,msg_flag,1,2,3,4,5,6}
2024-06-14 22:51:51.96: FMT {Type : 100, Length : 123, Name : SBRM, Format : QQQQQQQQQQQQQQQ, Columns : TimeUS,msg_flag,1,2,3,4,5,6,7,8,9,10,11,12,13}
2024-06-14 22:51:51.96: FMT {Type : 101, Length : 23, Name : SBRE, Format : QHIiBB, Columns : TimeUS,GWk,GMS,ns_residual,level,quality}
2024-06-14 22:51:51.96: FMT {Type : 60, Length : 39, Name : RCIN, Format : QHHHHHHHHHHHHHH, Columns : TimeUS,C1,C2,C3,C4,C5,C6,C7,C8,C9,C10,C11,C12,C13,C14}
2024-06-14 22:51:51.96: FMT {Type : 61, Length : 18, Name : RCI2, Format : QHHHB, Columns : TimeUS,C15,C16,OMask,Flags}
2024-06-14 22:51:51.96: FMT {Type : 62, Length : 39, Name : RCOU, Format : QHHHHHHHHHHHHHH, Columns : TimeUS,C1,C2,C3,C4,C5,C6,C7,C8,C9,C10,C11,C12,C13,C14}
2024-06-14 22:51:51.96: FMT {Type : 202, Length : 19, Name : RCO2, Format : QHHHH, Columns : TimeUS,C15,C16,C17,C18}
```

This might stop us dropping any messages at the start of a log...
