### PR TITLE
Blimp:  get MAV_STATE_BOOT on reboot

### DIFF
--- a/Blimp/GCS_Mavlink.cpp
+++ b/Blimp/GCS_Mavlink.cpp
@@ -40,6 +40,9 @@ MAV_STATE GCS_MAVLINK_Blimp::vehicle_system_status() const
     if (blimp.ap.land_complete) {
         return MAV_STATE_STANDBY;
     }
+    if (!blimp.ap.initialised) {
+    	return MAV_STATE_BOOT;
+    }
 
     return MAV_STATE_ACTIVE;
 }


### PR DESCRIPTION
PR to get MAV_STATE_BOOT on reboot on Blimp in a different PR as asked in PR #27289