### PR TITLE
ArduSub:  get MAV_STATE_BOOT on reboot

### DIFF
--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -63,6 +63,9 @@ MAV_STATE GCS_MAVLINK_Sub::vehicle_system_status() const
     if (sub.motors.armed()) {
         return MAV_STATE_ACTIVE;
     }
+    if (!sub.ap.initialised) {
+    	return MAV_STATE_BOOT;
+    }
 
     return MAV_STATE_STANDBY;
 }


### PR DESCRIPTION
PR to get MAV_STATE_BOOT on reboot on Sub in a different PR as asked in PR #27289