### PR TITLE
AP_RPM: Demystifying RPM sensors 

### DIFF
--- a/libraries/AP_RPM/LogStructure.h
+++ b/libraries/AP_RPM/LogStructure.h
@@ -8,15 +8,19 @@
 // @LoggerMessage: RPM
 // @Description: Data from RPM sensors
 // @Field: TimeUS: Time since system startup
-// @Field: rpm1: First sensor's data
-// @Field: rpm2: Second sensor's data
+// @Field: I: Instance
+// @Field: RPM: Sensor's rpm measurement
+// @Field: Qual: Signal quality
+// @Field: H: Sensor Health (Bool)
 struct PACKED log_RPM {
     LOG_PACKET_HEADER;
     uint64_t time_us;
-    float rpm1;
-    float rpm2;
+    uint8_t inst;
+    float rpm;
+    float quality;
+    uint8_t health;
 };
 
 #define LOG_STRUCTURE_FROM_RPM        \
     { LOG_RPM_MSG, sizeof(log_RPM), \
-      "RPM",  "Qff", "TimeUS,rpm1,rpm2", "sqq", "F00" , true },
+      "RPM",  "QBffB", "TimeUS,I,RPM,Qual,H", "s#q--", "F-000" , true },


### PR DESCRIPTION
Lots of users struggle with setting up interrupt-based RPM sensors.  (see here for a number of users asking for help: https://discuss.ardupilot.org/t/rpm-sensor-wiki-knowledge-share/45091/83).

In an attempt to demystify RPM sensors, this PR improves the logging:
- Move to instance based logging.
- Always log the rpm reading regardless of quality.
- Log the calculated quality value.
- Log the bool so that we can clearly see when AP reports the sensor as healthy.

It is my hope that adding this information will help users to figure out what is going wrong.

**Example from Testing:**  

Tested IRL on Heli.
Thankfully I had a dodgy RPM sensor for testing 😬
So now, by always logging raw RPM I can see that something is not right in the measurement and I can see that the corresponding quality is measure is on the floor.
![image](https://github.com/ArduPilot/ardupilot/assets/34512430/58f487ad-4fed-4ff0-bca1-8c68efe21282)

Here is an example of the 2nd instance working as well:
![image](https://github.com/ArduPilot/ardupilot/assets/34512430/b033a4c8-be93-4a82-8512-9bd136d02f85)

