### PR TITLE
AP_Scripting: add `uint64_t` userdata and auto generate `uint32_t` operators.

### DIFF
--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -44,6 +44,44 @@ function uint32_t_ud:tofloat() end
 ---@return integer
 function uint32_t_ud:toint() end
 
+---@class (exact) uint64_t_ud
+---@operator add(uint64_t_ud|uint32_t_ud|integer|number): uint64_t_ud
+---@operator sub(uint64_t_ud|uint32_t_ud|integer|number): uint64_t_ud
+---@operator mul(uint64_t_ud|uint32_t_ud|integer|number): uint64_t_ud
+---@operator div(uint64_t_ud|uint32_t_ud|integer|number): uint64_t_ud
+---@operator mod(uint64_t_ud|uint32_t_ud|integer|number): uint64_t_ud
+---@operator band(uint64_t_ud|uint32_t_ud|integer|number): uint64_t_ud
+---@operator bor(uint64_t_ud|uint32_t_ud|integer|number): uint64_t_ud
+---@operator shl(uint64_t_ud|uint32_t_ud|integer|number): uint64_t_ud
+---@operator shr(uint64_t_ud|uint32_t_ud|integer|number): uint64_t_ud
+local uint64_t_ud = {}
+
+-- create uint64_t_ud with optional value
+-- Note that lua ints are 32 bits and lua floats will loose resolution at large values
+---@param value? uint64_t_ud|uint32_t_ud|integer|number
+---@return uint64_t_ud
+function uint64_t(value) end
+
+-- create uint64_t_ud from a low and high half
+-- value = (high << 32) | low
+---@param high uint32_t_ud|integer|number
+---@param low uint32_t_ud|integer|number
+---@return uint64_t_ud
+function uint64_t(high, low) end
+
+-- Convert to number, will loose resolution at large values
+---@return number
+function uint64_t_ud:tofloat() end
+
+-- Convert to integer, nil if too large to be represented by native int32
+---@return integer|nil
+function uint64_t_ud:toint() end
+
+-- Split into high and low half's, returning each as a uint32_t_ud
+---@return uint32_t_ud -- high (value >> 32)
+---@return uint32_t_ud -- low (value & 0xFFFFFFFF)
+function uint64_t_ud:split() end
+
 -- system time in milliseconds
 ---@return uint32_t_ud -- milliseconds
 function millis() end

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -2897,6 +2897,11 @@ gps.GPS_OK_FIX_2D = enum_integer
 gps.NO_FIX = enum_integer
 gps.NO_GPS = enum_integer
 
+-- get unix time
+---@param instance integer -- instance number
+---@return uint64_t_ud -- unix time microseconds
+function gps:time_epoch_usec(instance) end
+
 -- get yaw from GPS in degrees
 ---@param instance integer -- instance number
 ---@return number|nil -- yaw in degrees

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -854,21 +854,23 @@ global manual micros lua_micros 0 1
 global manual mission_receive lua_mission_receive 0 5 depends AP_MISSION_ENABLED
 
 userdata uint32_t creation lua_new_uint32_t 1
-userdata uint32_t manual_operator __add uint32_t___add
-userdata uint32_t manual_operator __sub uint32_t___sub
-userdata uint32_t manual_operator __mul uint32_t___mul
-userdata uint32_t manual_operator __div uint32_t___div
-userdata uint32_t manual_operator __mod uint32_t___mod
+userdata uint32_t operator_getter coerce_to_uint32_t
+userdata uint32_t operator +
+userdata uint32_t operator -
+userdata uint32_t operator *
+userdata uint32_t operator /
+-- We know name of the generated function so we can point at it again with a manual operator so idiv is the same as div
 userdata uint32_t manual_operator __idiv uint32_t___div
-userdata uint32_t manual_operator __band uint32_t___band
-userdata uint32_t manual_operator __bor uint32_t___bor
-userdata uint32_t manual_operator __bxor uint32_t___bxor
-userdata uint32_t manual_operator __shl uint32_t___shl
-userdata uint32_t manual_operator __shr uint32_t___shr
-userdata uint32_t manual_operator __eq uint32_t___eq
-userdata uint32_t manual_operator __lt uint32_t___lt
-userdata uint32_t manual_operator __le uint32_t___le
-userdata uint32_t manual_operator __bnot uint32_t___bnot
+userdata uint32_t operator %
+userdata uint32_t operator &
+userdata uint32_t operator |
+userdata uint32_t operator ^
+userdata uint32_t operator <<
+userdata uint32_t operator >>
+userdata uint32_t operator ==
+userdata uint32_t operator <
+userdata uint32_t operator <=
+userdata uint32_t operator ~
 userdata uint32_t manual_operator __tostring uint32_t___tostring
 userdata uint32_t manual toint uint32_t_toint 0 1
 userdata uint32_t manual tofloat uint32_t_tofloat 0 1

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -875,6 +875,27 @@ userdata uint32_t manual_operator __tostring uint32_t___tostring
 userdata uint32_t manual toint uint32_t_toint 0 1
 userdata uint32_t manual tofloat uint32_t_tofloat 0 1
 
+userdata uint64_t creation lua_new_uint64_t 2
+userdata uint64_t operator_getter coerce_to_uint64_t
+userdata uint64_t operator +
+userdata uint64_t operator -
+userdata uint64_t operator *
+userdata uint64_t operator /
+userdata uint64_t operator %
+userdata uint64_t operator &
+userdata uint64_t operator |
+userdata uint64_t operator ^
+userdata uint64_t operator <<
+userdata uint64_t operator >>
+userdata uint64_t operator ==
+userdata uint64_t operator <
+userdata uint64_t operator <=
+userdata uint64_t operator ~
+userdata uint64_t manual_operator __tostring uint64_t___tostring
+userdata uint64_t manual toint uint64_t_toint 0 1
+userdata uint64_t manual tofloat uint64_t_tofloat 0 1
+userdata uint64_t manual split uint64_t_split 0 2
+
 global manual dirlist lua_dirlist 1 2
 global manual remove lua_removefile 1 3
 global manual print lua_print 1 0

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -135,6 +135,7 @@ singleton AP_GPS method have_vertical_velocity boolean uint8_t 0 ud->num_sensors
 singleton AP_GPS method get_antenna_offset Vector3f uint8_t 0 ud->num_sensors()
 singleton AP_GPS method first_unconfigured_gps boolean uint8_t'Null
 singleton AP_GPS method gps_yaw_deg boolean uint8_t 0 ud->num_sensors() float'Null float'Null uint32_t'Null
+singleton AP_GPS method time_epoch_usec uint64_t uint8_t 0 ud->num_sensors()
 
 include AP_Math/AP_Math.h
 

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -381,9 +381,8 @@ int AP_Logger_Write(lua_State *L) {
         switch(fmt_cat[index]) {
             // logger variable types not available to scripting
             // 'd': double
-            // 'Q': uint64_t
             // 'q': int64_t
-            // 'a': arrays
+            // 'a': int16_t[32]
             case 'b': { // int8_t
                 int isnum;
                 const lua_Integer tmp1 = lua_tointegerx(L, arg_index, &isnum);
@@ -494,6 +493,18 @@ int AP_Logger_Write(lua_State *L) {
                 }
                 memcpy(&buffer[offset], &tmp, sizeof(uint32_t));
                 offset += sizeof(uint32_t);
+                break;
+            }
+            case 'Q': { // uint64_t
+                void * ud = luaL_testudata(L, arg_index, "uint64_t");
+                if (ud == nullptr) {
+                    luaM_free(L, buffer);
+                    luaL_argerror(L, arg_index, "argument out of range");
+                    // no return
+                }
+                uint64_t tmp = *static_cast<uint64_t *>(ud);
+                memcpy(&buffer[offset], &tmp, sizeof(uint64_t));
+                offset += sizeof(uint64_t);
                 break;
             }
             case 'N': { // char[16]

--- a/libraries/AP_Scripting/lua_boxed_numerics.cpp
+++ b/libraries/AP_Scripting/lua_boxed_numerics.cpp
@@ -39,6 +39,39 @@ uint32_t coerce_to_uint32_t(lua_State *L, int arg) {
     return luaL_argerror(L, arg, "Unable to coerce to uint32_t");
 }
 
+uint64_t coerce_to_uint64_t(lua_State *L, int arg) {
+    { // uint64_t userdata
+        const uint64_t * ud = static_cast<uint64_t *>(luaL_testudata(L, arg, "uint64_t"));
+        if (ud != nullptr) {
+            return *ud;
+        }
+    }
+    { // integer
+        int success;
+        const lua_Integer v = lua_tointegerx(L, arg, &success);
+
+        // Lua int maps to int32. However, because of the size difference negatives numbers wont come out correctly as they do for uint32
+        if (success && v >= 0) {
+            return static_cast<uint64_t>(v);
+        }
+    }
+    { // uint32_t userdata
+        const uint32_t * ud = static_cast<uint32_t *>(luaL_testudata(L, arg, "uint32_t"));
+        if (ud != nullptr) {
+            return static_cast<uint64_t>(*ud);
+        }
+    }
+    { // float
+        int success;
+        const lua_Number v = lua_tonumberx(L, arg, &success);
+        if (success && (v >= 0) && (v <= float(UINT64_MAX))) {
+            return static_cast<uint64_t>(v);
+        }
+    }
+    // failure
+    return luaL_argerror(L, arg, "Unable to coerce to uint64_t");
+}
+
 // the exposed constructor to lua calls to create a uint32_t
 int lua_new_uint32_t(lua_State *L) {
     const int args = lua_gettop(L);
@@ -51,11 +84,56 @@ int lua_new_uint32_t(lua_State *L) {
     return 1;
 }
 
+// the exposed constructor to lua calls to create a uint64_t
+int lua_new_uint64_t(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    }
+
+    uint64_t value = 0;
+    switch (args) {
+        case 0:
+        default:
+            // No arguments, init to 0
+            break;
+        case 1:
+            // Single argument
+            value = coerce_to_uint64_t(L, 1);
+            break;
+
+        case 2:
+            // Two uint32 giving high and low half
+            const uint64_t high = coerce_to_uint32_t(L, 1);
+            const uint64_t low = coerce_to_uint32_t(L, 2);
+            value = (high << 32) | low;
+            break;
+    }
+
+    new_uint64_t(L);
+    *check_uint64_t(L, -1) = value;
+    return 1;
+}
+
 int uint32_t_toint(lua_State *L) {
     binding_argcheck(L, 1);
 
     const uint32_t v = *check_uint32_t(L, 1);
 
+    lua_pushinteger(L, static_cast<lua_Integer>(v));
+
+    return 1;
+}
+
+int uint64_t_toint(lua_State *L) {
+    binding_argcheck(L, 1);
+
+    const uint64_t v = *check_uint64_t(L, 1);
+
+    if (v > INT32_MAX) {
+        // uint64_t too large to convert to int return nill rather than giving error
+        return 0;
+    }
 
     lua_pushinteger(L, static_cast<lua_Integer>(v));
 
@@ -67,6 +145,15 @@ int uint32_t_tofloat(lua_State *L) {
 
     const uint32_t v = *check_uint32_t(L, 1);
 
+    lua_pushnumber(L, static_cast<lua_Number>(v));
+
+    return 1;
+}
+
+int uint64_t_tofloat(lua_State *L) {
+    binding_argcheck(L, 1);
+
+    const uint64_t v = *check_uint64_t(L, 1);
 
     lua_pushnumber(L, static_cast<lua_Number>(v));
 
@@ -79,11 +166,41 @@ int uint32_t___tostring(lua_State *L) {
     const uint32_t v = *check_uint32_t(L, 1);
 
     char buf[32];
-    hal.util->snprintf(buf, ARRAY_SIZE(buf), "%u", (unsigned)v);
+    hal.util->snprintf(buf, ARRAY_SIZE(buf), "%lu", (unsigned long)v);
 
     lua_pushstring(L, buf);
 
     return 1;
+}
+
+int uint64_t___tostring(lua_State *L) {
+    binding_argcheck(L, 1);
+
+    const uint64_t v = *check_uint64_t(L, 1);
+
+    char buf[32];
+    hal.util->snprintf(buf, ARRAY_SIZE(buf), "%llu", (unsigned long long)v);
+
+    lua_pushstring(L, buf);
+
+    return 1;
+}
+
+// Split uint64 into a high and low uint32
+int uint64_t_split(lua_State *L) {
+    binding_argcheck(L, 1);
+
+    const uint64_t v = *check_uint64_t(L, 1);
+
+    // high
+    new_uint32_t(L);
+    *check_uint32_t(L, -1) = v >> 32;
+
+    // low
+    new_uint32_t(L);
+    *check_uint32_t(L, -1) = v & 0xFFFFFFFF;
+
+    return 2;
 }
 
 #endif  // AP_SCRIPTING_ENABLED

--- a/libraries/AP_Scripting/lua_boxed_numerics.cpp
+++ b/libraries/AP_Scripting/lua_boxed_numerics.cpp
@@ -46,68 +46,16 @@ int lua_new_uint32_t(lua_State *L) {
         return luaL_argerror(L, args, "too many arguments");
     }
 
-    *static_cast<uint32_t *>(lua_newuserdata(L, sizeof(uint32_t))) = (args == 1) ? coerce_to_uint32_t(L, 1) : 0;
-    luaL_getmetatable(L, "uint32_t");
-    lua_setmetatable(L, -2);
+    new_uint32_t(L);
+    *check_uint32_t(L, -1) = (args == 1) ? coerce_to_uint32_t(L, 1) : 0;
     return 1;
 }
-
-#define UINT32_T_BOX_OP(name, sym) \
-    int uint32_t___##name(lua_State *L) { \
-        binding_argcheck(L, 2); \
-          \
-        uint32_t v1 = coerce_to_uint32_t(L, 1); \
-        uint32_t v2 = coerce_to_uint32_t(L, 2); \
-          \
-        new_uint32_t(L); \
-        *static_cast<uint32_t *>(luaL_checkudata(L, -1, "uint32_t")) = v1 sym v2; \
-        return 1; \
-    }
-
-UINT32_T_BOX_OP(add, +)
-UINT32_T_BOX_OP(sub, -)
-UINT32_T_BOX_OP(mul, *)
-UINT32_T_BOX_OP(div, /)
-UINT32_T_BOX_OP(mod, %)
-UINT32_T_BOX_OP(band, &)
-UINT32_T_BOX_OP(bor, |)
-UINT32_T_BOX_OP(bxor, ^)
-UINT32_T_BOX_OP(shl, <<)
-UINT32_T_BOX_OP(shr, >>)
-
-#define UINT32_T_BOX_OP_BOOL(name, sym) \
-    int uint32_t___##name(lua_State *L) { \
-        binding_argcheck(L, 2); \
-          \
-        uint32_t v1 = coerce_to_uint32_t(L, 1); \
-        uint32_t v2 = coerce_to_uint32_t(L, 2); \
-          \
-        lua_pushboolean(L, v1 sym v2); \
-        return 1; \
-    }
-
-UINT32_T_BOX_OP_BOOL(eq, ==)
-UINT32_T_BOX_OP_BOOL(lt, <)
-UINT32_T_BOX_OP_BOOL(le, <=)
-
-#define UINT32_T_BOX_OP_UNARY(name, sym) \
-    int uint32_t___##name(lua_State *L) { \
-        binding_argcheck(L, 2); \
-          \
-        uint32_t v1 = coerce_to_uint32_t(L, 1); \
-          \
-        new_uint32_t(L); \
-        *static_cast<uint32_t *>(luaL_checkudata(L, -1, "uint32_t")) = sym v1; \
-        return 1; \
-    }
-
-// DO NOT SUPPORT UNARY NEGATION
-UINT32_T_BOX_OP_UNARY(bnot, ~)
 
 int uint32_t_toint(lua_State *L) {
     binding_argcheck(L, 1);
 
-    uint32_t v = *static_cast<uint32_t *>(luaL_checkudata(L, 1, "uint32_t"));
+    const uint32_t v = *check_uint32_t(L, 1);
+
 
     lua_pushinteger(L, static_cast<lua_Integer>(v));
 
@@ -117,7 +65,8 @@ int uint32_t_toint(lua_State *L) {
 int uint32_t_tofloat(lua_State *L) {
     binding_argcheck(L, 1);
 
-    uint32_t v = *static_cast<uint32_t *>(luaL_checkudata(L, 1, "uint32_t"));
+    const uint32_t v = *check_uint32_t(L, 1);
+
 
     lua_pushnumber(L, static_cast<lua_Number>(v));
 
@@ -127,7 +76,7 @@ int uint32_t_tofloat(lua_State *L) {
 int uint32_t___tostring(lua_State *L) {
     binding_argcheck(L, 1);
 
-    uint32_t v = *static_cast<uint32_t *>(luaL_checkudata(L, 1, "uint32_t"));
+    const uint32_t v = *check_uint32_t(L, 1);
 
     char buf[32];
     hal.util->snprintf(buf, ARRAY_SIZE(buf), "%u", (unsigned)v);

--- a/libraries/AP_Scripting/lua_boxed_numerics.h
+++ b/libraries/AP_Scripting/lua_boxed_numerics.h
@@ -5,20 +5,6 @@
 uint32_t coerce_to_uint32_t(lua_State *L, int arg);
 int lua_new_uint32_t(lua_State *L);
 
-int uint32_t___add(lua_State *L);
-int uint32_t___sub(lua_State *L);
-int uint32_t___mul(lua_State *L);
-int uint32_t___div(lua_State *L);
-int uint32_t___mod(lua_State *L);
-int uint32_t___band(lua_State *L);
-int uint32_t___bor(lua_State *L);
-int uint32_t___bxor(lua_State *L);
-int uint32_t___shl(lua_State *L);
-int uint32_t___shr(lua_State *L);
-int uint32_t___eq(lua_State *L);
-int uint32_t___lt(lua_State *L);
-int uint32_t___le(lua_State *L);
-int uint32_t___bnot(lua_State *L);
 int uint32_t___tostring(lua_State *L);
 int uint32_t_toint(lua_State *L);
 int uint32_t_tofloat(lua_State *L);

--- a/libraries/AP_Scripting/lua_boxed_numerics.h
+++ b/libraries/AP_Scripting/lua_boxed_numerics.h
@@ -8,3 +8,12 @@ int lua_new_uint32_t(lua_State *L);
 int uint32_t___tostring(lua_State *L);
 int uint32_t_toint(lua_State *L);
 int uint32_t_tofloat(lua_State *L);
+
+int lua_new_uint64_t(lua_State *L);
+uint64_t coerce_to_uint64_t(lua_State *L, int arg);
+
+int uint64_t___tostring(lua_State *L);
+int uint64_t_toint(lua_State *L);
+int uint64_t_tofloat(lua_State *L);
+int uint64_t_split(lua_State *L);
+

--- a/libraries/AP_Scripting/tests/scripting_test.lua
+++ b/libraries/AP_Scripting/tests/scripting_test.lua
@@ -35,6 +35,34 @@ function test_offset(ofs_e, ofs_n)
   return true
 end
 
+function test_uint64()
+  local pass = true
+
+  local zero = uint64_t()
+  local max = uint64_t(-1, -1)
+
+  pass = pass and (zero - 1) == max
+  pass = pass and ~max == zero
+  pass = pass and max > zero
+  pass = pass and (((zero + 1) + 1.1) + uint32_t(1)) == uint64_t(0, 3)
+  pass = pass and tostring(zero) == "0"
+  pass = pass and (uint64_t(15) & uint64_t(130)) == uint32_t(2)
+  pass = pass and (uint64_t(1) | uint64_t(2)) == uint64_t(3)
+  pass = pass and (uint64_t(1) << 1) == uint64_t(2)
+  pass = pass and (uint64_t(16) >> 1) == uint64_t(8)
+  pass = pass and type(zero:tofloat()) == "number"
+  pass = pass and zero:tofloat() == 0
+
+  local high, low
+  high, low = zero:split()
+  pass = pass and high == uint32_t(0) and low == uint32_t(0)
+
+  high, low = max:split()
+  pass = pass and high == uint32_t(-1) and low == uint32_t(-1)
+
+  return pass
+end
+
 function update()
   local all_tests_passed = true
   local require_test_local = require('test/nested')
@@ -53,6 +81,7 @@ function update()
   end
   -- each test should run then and it's result with the previous ones
   all_tests_passed = test_offset(500, 200) and all_tests_passed
+  all_tests_passed = test_uint64() and all_tests_passed
 
   if all_tests_passed then
     gcs:send_text(3, "Internal tests passed")


### PR DESCRIPTION
This adds a new userdata for uint64 much like the existing one for uint32. This makes big numbers much easier. A small section is added to the test script to make sure there doing the correct thing. There is also support for logging the new type.

Currently you could use it is a argument for a binding, but it would be better to do some more work so that it can be "coerced" so you could pass a normal lua number if you wanted to. We don't have many functions that take a uint64 argument, so I have not added that (it will still work, you just have to be sure to pass the correct type).

This adds a binding to get unix epoc from gps which needs the uint64 type. In the future we might want to add support for `micros64` too.

I have also moved the uint32 operators to automatically generated bindings and increased the possible auto generated operator types. 