### PR TITLE
AP_Scripting: add an example which denies arming if home not set

### DIFF
--- a/libraries/AP_Scripting/examples/require-home-set-to-arm.lua
+++ b/libraries/AP_Scripting/examples/require-home-set-to-arm.lua
@@ -1,0 +1,20 @@
+-- example script for ensuring home is set before allowing arming
+-- useful so users don't take off in stabilize before RTL will work.
+
+---@dxiagnostic disable: param-type-mismatch
+
+auth_id = arming:get_aux_auth_id()
+
+function update ()
+
+    if not ahrs:home_is_set() then
+      arming:set_aux_auth_failed(auth_id, "Home is not set")
+    else
+      arming:set_aux_auth_passed(auth_id)
+    end
+
+    return update, 5000
+
+end
+
+return update()


### PR DESCRIPTION
Note sure if this shouldn't do additional checks that the AHRS does when gps is required.  But it's a little tricky given the structure of those prearms...
