### PR TITLE
board_types.txt: Reserve board IDs for CUAV

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -359,6 +359,9 @@ AP_HW_ZeroOne_X6                     5600
 
 # IDs 6600-6699 reserved for Eagle Eye Drones
 
+# IDs 7000-7099 reserved for CUAV
+AP_HW_CUAV-7-NANO                    7000
+
 # OpenDroneID enabled boards. Use 10000 + the base board ID
 AP_HW_CubeOrange_ODID               10140
 AP_HW_Pixhawk6_ODID                 10053


### PR DESCRIPTION
Add reserve board IDs from 7000 to 7099 for CUAV.