### PR TITLE
ArduPlane: Minor log message help text updates

### DIFF
--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -314,9 +314,9 @@ const struct LogStructure Plane::log_structure[] = {
 // @Field: RdO: scaled output rudder
 // @Field: ThD: demanded speed-height-controller throttle
 // @Field: As: airspeed estimate (or measurement if airspeed sensor healthy and ARSPD_USE>0)
-// @Field: SAs: DCM's airspeed estimate, NaN if not available
 // @Field: AsT: airspeed type ( old estimate or source of new estimate)
 // @FieldValueEnum: AsT: AP_AHRS::AirspeedEstimateType
+// @Field: SAs: DCM's airspeed estimate, NaN if not available
 // @Field: E2T: equivalent to true airspeed ratio
 // @Field: GU: groundspeed undershoot when flying with minimum groundspeed
 

--- a/libraries/AP_Compass/AP_Compass_DroneCAN.cpp
+++ b/libraries/AP_Compass/AP_Compass_DroneCAN.cpp
@@ -223,7 +223,7 @@ void AP_Compass_DroneCAN::handle_magnetic_field_hires(AP_DroneCAN *ap_dronecan, 
 // @Field: Mz: z axis field
 
     // just log it for now
-    AP::logger().WriteStreaming("MAGH", "TimeUS,Node,Sensor,Bus,Mx,My,Mz", "s#-----", "F-----", "QBBBfff",
+    AP::logger().WriteStreaming("MAGH", "TimeUS,Node,Sensor,Bus,Mx,My,Mz", "s#-----", "F------", "QBBBfff",
                                 transfer.timestamp_usec,
                                 transfer.source_node_id,
                                 ap_dronecan->get_driver_index(),

--- a/libraries/AP_GPS/LogStructure.h
+++ b/libraries/AP_GPS/LogStructure.h
@@ -23,7 +23,7 @@
 // @Field: GMS: milliseconds since start of GPS Week
 // @Field: GWk: weeks since 5 Jan 1980
 // @Field: NSats: number of satellites visible
-// @Field: HDop: horizontal precision
+// @Field: HDop: horizontal dilution of precision
 // @Field: Lat: latitude
 // @Field: Lng: longitude
 // @Field: Alt: altitude
@@ -55,7 +55,7 @@ struct PACKED log_GPS {
 // @Description: GPS accuracy information
 // @Field: I: GPS instance number
 // @Field: TimeUS: Time since system startup
-// @Field: VDop: vertical degree of procession
+// @Field: VDop: vertical dilution of precision
 // @Field: HAcc: horizontal position accuracy
 // @Field: VAcc: vertical position accuracy
 // @Field: SAcc: speed accuracy


### PR DESCRIPTION
This PR contains 3 minor updates to log message help.
(Note I did a seperate commit per library, but have not done 3 seperate PRs, as I was thinking it was all one topic and small enough, but happy to do differently if I should).

1. I noticed that the ordering of the fields on the CTUN message help differs from the actual order of the fields.
This ends up causing the units to be mis-attributed, so that the wiki says that AsT (airspeed type) is in m/s, but this should instead be shown against SAs (DCM’s airspeed estimate).

Probably the parser could be smarter to cope with this, or an autotest check could check that fields match the real order, but I thought this may not be worth the time/effort.

2. When testing this change with logger_metadata/parse.py, I checked that CTUN was corrected, but I had the error:
```
Number of units/mults/fields don't match: msg=MAGH units=s#----- mults=F----- num_fields=7
```
This is corrected by adding of one '-' to the LogStreaming call AP_Compass_DroneCAN.cpp.

3. I noticed that the text for HDop and VDop were inconsistent, so have changed both to use the term 'dilution of precision'.

I have checked all 3 changes, by checking the output of running logger_metadata/parse.py for all vehicle types.
