### PR TITLE
Rover: Make the definition name a class type

### DIFF
--- a/Rover/Parameters.h
+++ b/Rover/Parameters.h
@@ -257,7 +257,7 @@ public:
     // Throttle
     //
     AP_Int8     throttle_cruise;
-    AP_Int8     pilot_steer_type;
+    AP_Enum<PilotSteerType>     pilot_steer_type;
 
     // failsafe control
     AP_Int8     fs_action;

--- a/Rover/defines.h
+++ b/Rover/defines.h
@@ -80,11 +80,11 @@ enum fs_ekf_action {
 
 #define DISTANCE_HOME_MINCHANGE 0.5f  // minimum distance to adjust home location
 
-enum pilot_steer_type_t {
-    PILOT_STEER_TYPE_DEFAULT = 0,
-    PILOT_STEER_TYPE_TWO_PADDLES = 1,
-    PILOT_STEER_TYPE_DIR_REVERSED_WHEN_REVERSING = 2,
-    PILOT_STEER_TYPE_DIR_UNCHANGED_WHEN_REVERSING = 3,
+enum class PilotSteerType : uint8_t {
+    DEFAULT = 0,
+    TWO_PADDLES = 1,
+    DIR_REVERSED_WHEN_REVERSING = 2,
+    DIR_UNCHANGED_WHEN_REVERSING = 3,
 };
 
 // frame class enum used for FRAME_CLASS parameter

--- a/Rover/mode.cpp
+++ b/Rover/mode.cpp
@@ -123,8 +123,8 @@ void Mode::get_pilot_desired_steering_and_throttle(float &steering_out, float &t
     // check for special case of input and output throttle being in opposite directions
     float throttle_out_limited = g2.motors.get_slew_limited_throttle(throttle_out, rover.G_Dt);
     if ((is_negative(throttle_out) != is_negative(throttle_out_limited)) &&
-        ((PilotSteerType(g.pilot_steer_type.get()) == PilotSteerType::DEFAULT) ||
-         (PilotSteerType(g.pilot_steer_type.get()) == PilotSteerType::DIR_REVERSED_WHEN_REVERSING))) {
+        (g.pilot_steer_type == PilotSteerType::DEFAULT ||
+         g.pilot_steer_type == PilotSteerType::DIR_REVERSED_WHEN_REVERSING)) {
         steering_out *= -1;
     }
     throttle_out = throttle_out_limited;
@@ -139,8 +139,8 @@ void Mode::get_pilot_desired_steering_and_speed(float &steering_out, float &spee
     // check for special case of input and output throttle being in opposite directions
     float speed_out_limited = g2.attitude_control.get_desired_speed_accel_limited(speed_out, rover.G_Dt);
     if ((is_negative(speed_out) != is_negative(speed_out_limited)) &&
-        ((PilotSteerType(g.pilot_steer_type.get()) == PilotSteerType::DEFAULT) ||
-         (PilotSteerType(g.pilot_steer_type.get()) == PilotSteerType::DIR_REVERSED_WHEN_REVERSING))) {
+        (g.pilot_steer_type == PilotSteerType::DEFAULT ||
+         g.pilot_steer_type == PilotSteerType::DIR_REVERSED_WHEN_REVERSING)) {
         steering_out *= -1;
     }
     speed_out = speed_out_limited;
@@ -167,7 +167,7 @@ void Mode::get_pilot_desired_heading_and_speed(float &heading_out, float &speed_
     float desired_throttle = constrain_float(rover.channel_throttle->norm_input_dz(), -1.0f, 1.0f);
 
     // handle two paddle input
-    if ((PilotSteerType)g.pilot_steer_type.get() == PilotSteerType::TWO_PADDLES) {
+    if (g.pilot_steer_type == PilotSteerType::TWO_PADDLES) {
         const float left_paddle = desired_steering;
         const float right_paddle = desired_throttle;
         desired_steering = (left_paddle - right_paddle) * 0.5f;

--- a/Rover/mode.cpp
+++ b/Rover/mode.cpp
@@ -67,10 +67,10 @@ void Mode::get_pilot_input(float &steering_out, float &throttle_out) const
     }
 
     // apply RC skid steer mixing
-    switch ((enum pilot_steer_type_t)g.pilot_steer_type.get())
+    switch ((PilotSteerType)g.pilot_steer_type.get())
     {
-        case PILOT_STEER_TYPE_DEFAULT:
-        case PILOT_STEER_TYPE_DIR_REVERSED_WHEN_REVERSING:
+        case PilotSteerType::DEFAULT:
+        case PilotSteerType::DIR_REVERSED_WHEN_REVERSING:
         default: {
             // by default regular and skid-steering vehicles reverse their rotation direction when backing up
             throttle_out = rover.channel_throttle->get_control_in();
@@ -79,7 +79,7 @@ void Mode::get_pilot_input(float &steering_out, float &throttle_out) const
             break;
         }
 
-        case PILOT_STEER_TYPE_TWO_PADDLES: {
+        case PilotSteerType::TWO_PADDLES: {
             // convert the two radio_in values from skid steering values
             // left paddle from steering input channel, right paddle from throttle input channel
             // steering = left-paddle - right-paddle
@@ -92,7 +92,7 @@ void Mode::get_pilot_input(float &steering_out, float &throttle_out) const
             break;
         }
 
-        case PILOT_STEER_TYPE_DIR_UNCHANGED_WHEN_REVERSING: {
+        case PilotSteerType::DIR_UNCHANGED_WHEN_REVERSING: {
             throttle_out = rover.channel_throttle->get_control_in();
             steering_out = rover.channel_steer->get_control_in();
             break;
@@ -123,8 +123,8 @@ void Mode::get_pilot_desired_steering_and_throttle(float &steering_out, float &t
     // check for special case of input and output throttle being in opposite directions
     float throttle_out_limited = g2.motors.get_slew_limited_throttle(throttle_out, rover.G_Dt);
     if ((is_negative(throttle_out) != is_negative(throttle_out_limited)) &&
-        ((g.pilot_steer_type == PILOT_STEER_TYPE_DEFAULT) ||
-         (g.pilot_steer_type == PILOT_STEER_TYPE_DIR_REVERSED_WHEN_REVERSING))) {
+        ((PilotSteerType(g.pilot_steer_type.get()) == PilotSteerType::DEFAULT) ||
+         (PilotSteerType(g.pilot_steer_type.get()) == PilotSteerType::DIR_REVERSED_WHEN_REVERSING))) {
         steering_out *= -1;
     }
     throttle_out = throttle_out_limited;
@@ -139,8 +139,8 @@ void Mode::get_pilot_desired_steering_and_speed(float &steering_out, float &spee
     // check for special case of input and output throttle being in opposite directions
     float speed_out_limited = g2.attitude_control.get_desired_speed_accel_limited(speed_out, rover.G_Dt);
     if ((is_negative(speed_out) != is_negative(speed_out_limited)) &&
-        ((g.pilot_steer_type == PILOT_STEER_TYPE_DEFAULT) ||
-         (g.pilot_steer_type == PILOT_STEER_TYPE_DIR_REVERSED_WHEN_REVERSING))) {
+        ((PilotSteerType(g.pilot_steer_type.get()) == PilotSteerType::DEFAULT) ||
+         (PilotSteerType(g.pilot_steer_type.get()) == PilotSteerType::DIR_REVERSED_WHEN_REVERSING))) {
         steering_out *= -1;
     }
     speed_out = speed_out_limited;
@@ -167,7 +167,7 @@ void Mode::get_pilot_desired_heading_and_speed(float &heading_out, float &speed_
     float desired_throttle = constrain_float(rover.channel_throttle->norm_input_dz(), -1.0f, 1.0f);
 
     // handle two paddle input
-    if ((enum pilot_steer_type_t)g.pilot_steer_type.get() == PILOT_STEER_TYPE_TWO_PADDLES) {
+    if ((PilotSteerType)g.pilot_steer_type.get() == PilotSteerType::TWO_PADDLES) {
         const float left_paddle = desired_steering;
         const float right_paddle = desired_throttle;
         desired_steering = (left_paddle - right_paddle) * 0.5f;


### PR DESCRIPTION
Definition names were prefixed with group names. I can make definition names clearer by making the group name the class name.
