### PR TITLE
Copter: Remove Payload release on thrust loss detection

### DIFF
--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -169,12 +169,6 @@ void Copter::thrust_loss_check()
         // enable thrust loss handling
         motors->set_thrust_boost(true);
         // the motors library disables this when it is no longer needed to achieve the commanded output
-
-#if AP_GRIPPER_ENABLED
-        if (copter.option_is_enabled(FlightOption::RELEASE_GRIPPER_ON_THRUST_LOSS)) {
-            gripper.release();
-        }
-#endif
     }
 }
 

--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -96,7 +96,12 @@ void Copter::crash_check()
     }
 }
 
-// check for loss of thrust and trigger thrust boost in motors library
+// thrust_loss_check - returns true when the aircraft detects for 1 second that it is:
+//                      above 90% thrust,
+//                      less than 15 degrees lean angle target,
+//                      less than 30 degrees of attitude error,
+//                      is descending.
+// This check provides a warning that the aircraft is near it's maximum thrust limits and is used trigger thrust boost algorithm in the motors library
 void Copter::thrust_loss_check()
 {
     static uint16_t thrust_loss_counter;  // number of iterations vehicle may have been crashed


### PR DESCRIPTION
This PR removes a potentially very dangerous "feature" added in this PR #19890.

The previous PR will release the payload any time the aircraft uses more than 90% thrust for a second while descending under control and less than 15 degrees lean angle.

The thrust loss detection is designed to be a sub check of further dependent checks like the motor out test. It is a check that is expected to happen in normal flight.

This feature above looks like a sensible check to enable but is expected to result in random releases of the payload during landings on low battery for example. The aircraft is heavily loaded because it has a payload, the aircraft is descending and it is normal for the industry to specify their aircraft maximum take-off at 80% thrust on a full battery.

Releasing payloads in an unplanned and automated way, over landing zones or on approach is literally a risk of serious or fatal injury to ground crew.


-----------------------------

I have tried to improve the comments on thrust_loss_check() to make it clearer what this check is doing.
We may also be able to improve the output message to the user to be clearer or more appropriate. It is currently "Potential Thrust Loss (%d)" and a motor. However, it does not require a motor lost so it will say motor 1 when no motor is lost I think.

The name is also misleading. Perhaps the name "Thrust Limited Detection" would be better.

We could also reduce the likelihood of this going off by changing the check for decent to make it "less than commanded decent" in alt_hold based modes.
