### PR TITLE
Detune to stop ground oscillation

### DIFF
--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -423,6 +423,7 @@ void Copter::update_flight_mode()
 #if AP_RANGEFINDER_ENABLED
     surface_tracking.invalidate_for_logging();  // invalidate surface tracking alt, flight mode will set to true if used
 #endif
+    attitude_control->landed_gain_reduction(copter.ap.land_complete); // Adjust gains when landed to attenuate ground oscillation
 
     flightmode->run();
 }

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -163,6 +163,9 @@ public:
     // reset rate controller I terms smoothly to zero in 0.5 seconds
     void reset_rate_controller_I_terms_smoothly();
 
+    // Reduce attitude control gains while landed to stop ground resonance
+    void landed_gain_reduction(bool landed);
+
     // Sets attitude target to vehicle attitude and sets all rates to zero
     // If reset_rate is false rates are not reset to allow the rate controllers to run
     void reset_target_and_rate(bool reset_rate = true);
@@ -479,6 +482,11 @@ protected:
     // rate controller input smoothing time constant
     AP_Float            _input_tc;
 
+    // Controller gain multiplyer to be used when landed
+    AP_Float            _land_roll_mult;
+    AP_Float            _land_pitch_mult;
+    AP_Float            _land_yaw_mult;
+
     // Intersampling period in seconds
     float               _dt;
 
@@ -560,6 +568,9 @@ protected:
 
     // PD scale used for last loop, used for logging
     Vector3f            _pd_scale_used;
+
+    // ratio of normal gain to landed gain
+    float               _landed_gain_ratio;
 
     // References to external libraries
     const AP_AHRS_View&  _ahrs;


### PR DESCRIPTION
This pr provides the ability to reduce the gains of roll, pitch, and yaw to remove ground oscillation while landed. Each axis has a gain reduction variable that is set when the aircraft is landed. The gain returns to normal in 2 x ATC_INPUT_TC.

This is a common problem on aircraft with flexible landing gear. It is often seen as a yaw oscillation during spool up on more solidly built aircraft also.