### PR TITLE
Rename get_primary_*() to get_first_healthy_*() and record primary instance in inertial sensors

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -591,8 +591,8 @@ void AP_AHRS::update_EKF2(void)
             // Use the primary EKF to select the primary gyro
             const AP_InertialSensor &_ins = AP::ins();
             const int8_t primary_imu = EKF2.getPrimaryCoreIMUIndex();
-            const uint8_t primary_gyro = primary_imu>=0?primary_imu:_ins.get_primary_gyro();
-            const uint8_t primary_accel = primary_imu>=0?primary_imu:_ins.get_primary_accel();
+            const uint8_t primary_gyro = primary_imu>=0?primary_imu:_ins.get_first_healthy_gyro();
+            const uint8_t primary_accel = primary_imu>=0?primary_imu:_ins.get_first_healthy_accel();
 
             // get gyro bias for primary EKF and change sign to give gyro drift
             // Note sign convention used by EKF is bias = measurement - truth
@@ -660,8 +660,8 @@ void AP_AHRS::update_EKF3(void)
 
             // Use the primary EKF to select the primary gyro
             const int8_t primary_imu = EKF3.getPrimaryCoreIMUIndex();
-            const uint8_t primary_gyro = primary_imu>=0?primary_imu:_ins.get_primary_gyro();
-            const uint8_t primary_accel = primary_imu>=0?primary_imu:_ins.get_primary_accel();
+            const uint8_t primary_gyro = primary_imu>=0?primary_imu:_ins.get_first_healthy_gyro();
+            const uint8_t primary_accel = primary_imu>=0?primary_imu:_ins.get_first_healthy_accel();
 
             // get gyro bias for primary EKF and change sign to give gyro drift
             // Note sign convention used by EKF is bias = measurement - truth
@@ -3215,7 +3215,7 @@ uint8_t AP_AHRS::_get_primary_IMU_index() const
 #endif
     }
     if (imu == -1) {
-        imu = AP::ins().get_primary_gyro();
+        imu = AP::ins().get_first_healthy_gyro();
     }
     return imu;
 }

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -614,7 +614,7 @@ public:
 
     // return primary accels, for lua
     const Vector3f &get_accel(void) const {
-        return AP::ins().get_accel();
+        return AP::ins().get_accel(_get_primary_accel_index());
     }
 
     // return primary accel bias. This should be subtracted from

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -77,7 +77,7 @@ public:
     // get the index of the current primary accelerometer sensor
     virtual uint8_t get_primary_accel_index(void) const {
 #if AP_INERTIALSENSOR_ENABLED
-        return AP::ins().get_primary_accel();
+        return AP::ins().get_first_healthy_accel();
 #else
         return 0;
 #endif
@@ -86,7 +86,7 @@ public:
     // get the index of the current primary gyro sensor
     virtual uint8_t get_primary_gyro_index(void) const {
 #if AP_INERTIALSENSOR_ENABLED
-        return AP::ins().get_primary_gyro();
+        return AP::ins().get_first_healthy_gyro();
 #else
         return 0;
 #endif

--- a/libraries/AP_DAL/AP_DAL_InertialSensor.cpp
+++ b/libraries/AP_DAL/AP_DAL_InertialSensor.cpp
@@ -18,9 +18,9 @@ void AP_DAL_InertialSensor::start_frame()
     const log_RISH old_RISH = _RISH;
 
     _RISH.loop_rate_hz = ins.get_loop_rate_hz();
-    _RISH.primary_gyro = ins.get_primary_gyro();
+    _RISH.primary_gyro = ins.get_first_healthy_gyro();
     _RISH.loop_delta_t = ins.get_loop_delta_t();
-    _RISH.primary_accel = ins.get_primary_accel();
+    _RISH.primary_accel = ins.get_first_healthy_accel();
     _RISH.accel_count = ins.get_accel_count();
     _RISH.gyro_count = ins.get_gyro_count();
     WRITE_REPLAY_BLOCK_IFCHANGED(RISH, _RISH, old_RISH);

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1933,13 +1933,25 @@ void AP_InertialSensor::update(void)
         // set primary to first healthy accel and gyro
         for (uint8_t i=0; i<INS_MAX_INSTANCES; i++) {
             if (_gyro_healthy[i] && _use(i)) {
-                _primary_gyro = i;
+                _first_healthy_gyro = i;
+#if AP_AHRS_ENABLED
+                // ask AHRS for the true primary, might just be us though
+                _primary_gyro = AP::ahrs().get_primary_gyro_index();
+#else
+                _primary_gyro = _first_healthy_gyro;
+#endif
                 break;
             }
         }
         for (uint8_t i=0; i<INS_MAX_INSTANCES; i++) {
             if (_accel_healthy[i] && _use(i)) {
-                _primary_accel = i;
+                _first_healthy_accel = i;
+#if AP_AHRS_ENABLED
+                // ask AHRS for the true primary, might just be us though
+                _primary_accel = AP::ahrs().get_primary_accel_index();
+#else
+                _primary_accel = _first_healthy_accel;
+#endif
                 break;
             }
         }
@@ -2749,8 +2761,8 @@ void AP_InertialSensor::send_uart_data(void)
     data.length = sizeof(data);
     data.timestamp_us = AP_HAL::micros();
 
-    get_delta_angle(get_primary_gyro(), data.delta_angle, data.delta_angle_dt);
-    get_delta_velocity(get_primary_accel(), data.delta_velocity, data.delta_velocity_dt);
+    get_delta_angle(get_first_healthy_gyro(), data.delta_angle, data.delta_angle_dt);
+    get_delta_velocity(get_first_healthy_accel(), data.delta_velocity, data.delta_velocity_dt);
 
     data.counter = uart.counter++;
     data.crc = crc_xmodem((const uint8_t *)&data, sizeof(data)-sizeof(uint16_t));

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -222,8 +222,8 @@ public:
 
     bool healthy(void) const { return get_gyro_health() && get_accel_health(); }
 
-    uint8_t get_primary_accel(void) const { return _primary_accel; }
-    uint8_t get_primary_gyro(void) const { return _primary_gyro; }
+    uint8_t get_first_healthy_accel(void) const { return _primary_accel; }
+    uint8_t get_first_healthy_gyro(void) const { return _primary_gyro; }
 
     // get the gyro filter rate in Hz
     uint16_t get_gyro_filter_hz(void) const { return _gyro_filter_cutoff; }
@@ -659,6 +659,10 @@ private:
     // primary accel and gyro
     uint8_t _primary_gyro;
     uint8_t _primary_accel;
+
+    // first_healthy accel and gyro
+    uint8_t _first_healthy_gyro;
+    uint8_t _first_healthy_accel;
 
     // mask of accels and gyros which we will be actively using
     // and this should wait for in wait_for_sample()

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -212,7 +212,6 @@ void AP_InertialSensor_Backend::apply_gyro_filters(const uint8_t instance, const
     save_gyro_window(instance, gyro, filter_phase++);
 
     Vector3f gyro_filtered = gyro;
-
 #if AP_INERTIALSENSOR_HARMONICNOTCH_ENABLED
     // apply the harmonic notch filters
     for (auto &notch : _imu.harmonic_notches) {
@@ -220,15 +219,13 @@ void AP_InertialSensor_Backend::apply_gyro_filters(const uint8_t instance, const
             continue;
         }
         bool inactive = notch.is_inactive();
-#if AP_AHRS_ENABLED
         // by default we only run the expensive notch filters on the
         // currently active IMU we reset the inactive notch filters so
         // that if we switch IMUs we're not left with old data
         if (!notch.params.hasOption(HarmonicNotchFilterParams::Options::EnableOnAllIMUs) &&
-            instance != AP::ahrs().get_primary_gyro_index()) {
+            instance != _imu._primary_gyro) {
             inactive = true;
         }
-#endif
         if (inactive) {
             // while inactive we reset the filter so when it activates the first output
             // will be the first input sample
@@ -799,6 +796,8 @@ void AP_InertialSensor_Backend::update_gyro(uint8_t instance) /* front end */
         }
     }
 #endif
+
+    set_primary_gyro(_imu._primary_gyro);
 }
 
 /*
@@ -821,6 +820,8 @@ void AP_InertialSensor_Backend::update_accel(uint8_t instance) /* front end */
         _imu._accel_filter[instance].set_cutoff_frequency(_accel_raw_sample_rate(instance), _accel_filter_cutoff());
         _last_accel_filter_hz = _accel_filter_cutoff();
     }
+
+    set_primary_accel(_imu._primary_accel);
 }
 
 #if HAL_LOGGING_ENABLED

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -269,6 +269,10 @@ protected:
     // common accel update function for all backends
     void update_accel(uint8_t instance) __RAMFUNC__; /* front end */
 
+    // catch updates to the primary gyro and accel
+    virtual void set_primary_gyro(uint8_t instance) {}
+    virtual void set_primary_accel(uint8_t instance) {}
+
     // support for updating filter at runtime
     uint16_t _last_accel_filter_hz;
     uint16_t _last_gyro_filter_hz;

--- a/libraries/AP_Mount/SoloGimbal.cpp
+++ b/libraries/AP_Mount/SoloGimbal.cpp
@@ -245,7 +245,7 @@ void SoloGimbal::update_fast() {
         // single gyro mode - one of the first two gyros are unhealthy or don't exist
         // just read primary gyro
         Vector3f dAng;
-        readVehicleDeltaAngle(ins.get_primary_gyro(), dAng);
+        readVehicleDeltaAngle(ins.get_first_healthy_gyro(), dAng);
         _vehicle_delta_angles += dAng;
     }
 }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2172,7 +2172,7 @@ void GCS_MAVLINK::send_highres_imu()
         .temperature = 0.0,  
         .fields_updated = (HIGHRES_IMU_UPDATED_XACC | HIGHRES_IMU_UPDATED_YACC | HIGHRES_IMU_UPDATED_ZACC |
             HIGHRES_IMU_UPDATED_XGYRO | HIGHRES_IMU_UPDATED_YGYRO | HIGHRES_IMU_UPDATED_ZGYRO), 
-        .id = ins.get_primary_accel(),
+        .id = ins.get_first_healthy_accel(),
     };
     
     


### PR DESCRIPTION
Split out from https://github.com/ArduPilot/ardupilot/pull/27029

This PR makes explicit the difference between the "primary gyro" as selected by the EKF and the "first healthy gyro" as selected by the IMU. Both are used in different ways in different places, and sometimes they are the same. The existing naming was far too error prone.