### PR TITLE
Sub: use cork() when writing motors,  move servo updates to motors_output()

### DIFF
--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -158,10 +158,7 @@ void Sub::fifty_hz_loop()
 
     failsafe_sensors_check();
 
-    // Update rc input/output
     rc().read_input();
-    SRV_Channels::calc_pwm();
-    SRV_Channels::output_ch_all();
 }
 
 // update_batt_compass - read battery and compass

--- a/ArduSub/motors.cpp
+++ b/ArduSub/motors.cpp
@@ -18,7 +18,11 @@ void Sub::motors_output()
         verify_motor_test();
     } else {
         motors.set_interlock(true);
+        SRV_Channels::cork();
+        SRV_Channels::calc_pwm();
+        SRV_Channels::output_ch_all();
         motors.output();
+        SRV_Channels::push();
     }
 }
 


### PR DESCRIPTION
it turns out that sub was missing this, which meant that there were two code paths able to change pwm, which harmed cpu usage and made the fifty_hz_loop() take longer than it should. 

I also moved calc_pwm from the fifty_hz loop down to motors_output, which despite causing us to calculate the servos more often, improves things as we no longer write to rcout on that task