### PR TITLE
AP_Math: split CRCs from checksums

### DIFF
--- a/Tools/AP_Periph/esc_apd_telem.cpp
+++ b/Tools/AP_Periph/esc_apd_telem.cpp
@@ -43,8 +43,8 @@ bool ESC_APD_Telem::update() {
         if ((size_t)len >= sizeof(received.packet)) {
             // we have a full packet, check the stop byte
             if (received.packet.stop == 65535) {
-                // valid stop byte, check the CRC
-                if (crc_fletcher16(received.bytes, 18) == received.packet.checksum) {
+                // valid stop byte, check the checksum
+                if (cksum_fletcher16(received.bytes, 18) == received.packet.checksum) {
                     // valid packet, copy the data we need and reset length
                     decoded.voltage = le16toh(received.packet.voltage) * 1e-2f;
                     decoded.temperature = convert_temperature(le16toh(received.packet.temperature));

--- a/Tools/AP_Periph/esc_apd_telem.cpp
+++ b/Tools/AP_Periph/esc_apd_telem.cpp
@@ -5,7 +5,7 @@
  */
 #include "esc_apd_telem.h"
 #include <AP_HAL/utility/sparse-endian.h>
-#include <AP_Math/crc.h>
+#include <AP_Math/checksum.h>
 #include <AP_Math/definitions.h>
 #include <string.h>
 

--- a/libraries/AP_ADSB/AP_ADSB_uAvionix_UCP.cpp
+++ b/libraries/AP_ADSB/AP_ADSB_uAvionix_UCP.cpp
@@ -413,7 +413,7 @@ uint16_t AP_ADSB_uAvionix_UCP::gdl90Transmit(GDL90_TX_MESSAGE &message, const ui
 {
     uint8_t gdl90FrameBuffer[GDL90_TX_MAX_FRAME_LENGTH] {};
 
-    const uint16_t frameCrc = crc16_ccitt_GDL90((uint8_t*)&message.raw, length, 0);
+    const uint16_t frameCrc = cksum_GDL90((uint8_t*)&message.raw, length);
 
     // Set flag byte in frame buffer
     gdl90FrameBuffer[0] = GDL90_FLAG_BYTE;
@@ -491,7 +491,7 @@ bool AP_ADSB_uAvionix_UCP::parseByte(const uint8_t data, GDL90_RX_MESSAGE &msg, 
 
             // NOTE: status.length contains messageId, payload and CRC16. So status.length-3 is effective payload length
             msg.crc = (uint16_t)crc_LSB | ((uint16_t)crc_MSB << 8);
-            const uint16_t crc = crc16_ccitt_GDL90((uint8_t*)&msg.raw, status.length-2, 0);
+            const uint16_t crc = cksum_GDL90((uint8_t*)&msg.raw, status.length-2);
             if (crc == msg.crc) {
                 status.prev_data = data;
                 // NOTE: this is the only path that returns true

--- a/libraries/AP_Beacon/AP_Beacon_Marvelmind.cpp
+++ b/libraries/AP_Beacon/AP_Beacon_Marvelmind.cpp
@@ -266,7 +266,7 @@ void AP_Beacon_Marvelmind::update(void)
             num_bytes_in_block_received++;
             if (num_bytes_in_block_received >= 7 + input_buffer[4]) {
                 // parse dgram
-                uint16_t block_crc = calc_crc_modbus(input_buffer, num_bytes_in_block_received);
+                uint16_t block_crc = crc_modbus(input_buffer, num_bytes_in_block_received);
                 if (block_crc == 0) {
                     switch (data_id) {
                         case AP_BEACON_MARVELMIND_POSITION_DATAGRAM_ID:

--- a/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.cpp
@@ -50,7 +50,7 @@ We return it packed inside the referenced NodeData structure */
 void AP_DroneCAN_DNA_Server::getHash(NodeData &node_data, const uint8_t unique_id[], uint8_t size) const
 {
     uint64_t hash = FNV_1_OFFSET_BASIS_64;
-    hash_fnv_1a(size, unique_id, &hash);
+    cksum_fnv_1a(size, unique_id, &hash);
 
     // xor-folding per http://www.isthe.com/chongo/tech/comp/fnv/
     hash = (hash>>56) ^ (hash&(((uint64_t)1<<56)-1));

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_InertialLabs.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_InertialLabs.cpp
@@ -215,7 +215,7 @@ bool AP_ExternalAHRS_InertialLabs::check_uart()
     }
 
     // check checksum
-    const uint16_t crc1 = crc_sum_of_bytes_16(&buffer[2], buffer_ofs-4);
+    const uint16_t crc1 = cksum_sum16(&buffer[2], buffer_ofs-4);
     const uint16_t crc2 = le16toh_ptr(&buffer[buffer_ofs-2]);
     if (crc1 != crc2) {
         re_sync();

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_InertialLabs.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_InertialLabs.cpp
@@ -22,7 +22,7 @@
 
 #include "AP_ExternalAHRS_InertialLabs.h"
 #include <AP_Math/AP_Math.h>
-#include <AP_Math/crc.h>
+#include <AP_Math/checksum.h>
 #include <AP_Baro/AP_Baro.h>
 #include <AP_Compass/AP_Compass.h>
 #include <AP_GPS/AP_GPS.h>

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -9,6 +9,7 @@
 #include <AP_Param/AP_Param.h>
 
 #include "definitions.h"
+#include "checksum.h"
 #include "crc.h"
 #include "matrix3.h"
 #include "polygon.h"

--- a/libraries/AP_Math/checksum.cpp
+++ b/libraries/AP_Math/checksum.cpp
@@ -22,7 +22,7 @@
 #include <AP_HAL/AP_HAL_Boards.h>
 
 // fletcher 16 implementation
-uint16_t crc_fletcher16(const uint8_t *buffer, uint32_t len) {
+uint16_t cksum_fletcher16(const uint8_t *buffer, uint32_t len) {
     uint16_t c0 = 0;
     uint16_t c1 = 0;
     for (uint32_t i = 0; i < len; i++) {
@@ -35,7 +35,7 @@ uint16_t crc_fletcher16(const uint8_t *buffer, uint32_t len) {
 
 // FNV-1a implementation
 #define FNV_1_PRIME_64 1099511628211UL
-void hash_fnv_1a(uint32_t len, const uint8_t* buf, uint64_t* hash)
+void cksum_fnv_1a(uint32_t len, const uint8_t* buf, uint64_t* hash)
 {
     uint32_t i;
     for (i=0; i<len; i++) {
@@ -45,7 +45,7 @@ void hash_fnv_1a(uint32_t len, const uint8_t* buf, uint64_t* hash)
 }
 
 // simple 8 bit checksum used by FPort
-uint8_t crc_sum8_with_carry(const uint8_t *p, uint8_t len)
+uint8_t cksum_fport(const uint8_t *p, uint8_t len)
 {
     uint16_t sum = 0;
     for (uint8_t i=0; i<len; i++) {
@@ -61,7 +61,7 @@ uint8_t crc_sum8_with_carry(const uint8_t *p, uint8_t len)
 // set, "0" if there is an even number of bits set note that
 // __builtin_parity causes hardfaults on Pixracer-periph - and is
 // slower on 1 byte than this:
-uint8_t parity(uint8_t byte)
+uint8_t cksum_byte_parity(uint8_t byte)
 {
     uint8_t p = 0;
 
@@ -85,7 +85,7 @@ uint8_t parity(uint8_t byte)
 }
 
 // sums the bytes in the supplied buffer, returns that sum mod 0xFFFF
-uint16_t crc_sum_of_bytes_16(const uint8_t *data, uint16_t count)
+uint16_t cksum_sum16(const uint8_t *data, uint16_t count)
 {
     uint16_t ret = 0;
     for (uint32_t i=0; i<count; i++) {
@@ -96,7 +96,7 @@ uint16_t crc_sum_of_bytes_16(const uint8_t *data, uint16_t count)
 
 // sums the bytes in the supplied buffer, returns that sum mod 256
 // (i.e. shoved into a uint8_t)
-uint8_t crc_sum_of_bytes(const uint8_t *data, uint16_t count)
+uint8_t cksum_sum8(const uint8_t *data, uint16_t count)
 {
-    return crc_sum_of_bytes_16(data, count) & 0xFF;
+    return cksum_sum16(data, count) & 0xFF;
 }

--- a/libraries/AP_Math/checksum.cpp
+++ b/libraries/AP_Math/checksum.cpp
@@ -1,0 +1,102 @@
+/*
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*
+  collection of non-CRC checksum calculation functions
+ */
+
+#include <stdint.h>
+#include "checksum.h"
+
+#include <AP_HAL/AP_HAL_Boards.h>
+
+// fletcher 16 implementation
+uint16_t crc_fletcher16(const uint8_t *buffer, uint32_t len) {
+    uint16_t c0 = 0;
+    uint16_t c1 = 0;
+    for (uint32_t i = 0; i < len; i++) {
+        c0 = (c0 + buffer[i]) % 255;
+        c1 = (c1 + c0) % 255;
+    }
+
+    return (c1 << 8) | c0;
+}
+
+// FNV-1a implementation
+#define FNV_1_PRIME_64 1099511628211UL
+void hash_fnv_1a(uint32_t len, const uint8_t* buf, uint64_t* hash)
+{
+    uint32_t i;
+    for (i=0; i<len; i++) {
+        *hash ^= (uint64_t)buf[i];
+        *hash *= FNV_1_PRIME_64;
+    }
+}
+
+// simple 8 bit checksum used by FPort
+uint8_t crc_sum8_with_carry(const uint8_t *p, uint8_t len)
+{
+    uint16_t sum = 0;
+    for (uint8_t i=0; i<len; i++) {
+        sum += p[i];
+        sum += sum >> 8;
+        sum &= 0xFF;              
+    }
+    sum = 0xff - ((sum & 0xff) + (sum >> 8));
+    return sum;
+}
+
+// return the parity of byte - "1" if there is an odd number of bits
+// set, "0" if there is an even number of bits set note that
+// __builtin_parity causes hardfaults on Pixracer-periph - and is
+// slower on 1 byte than this:
+uint8_t parity(uint8_t byte)
+{
+    uint8_t p = 0;
+
+    p ^= byte & 0x1;
+    byte >>= 1;
+    p ^= byte & 0x1;
+    byte >>= 1;
+    p ^= byte & 0x1;
+    byte >>= 1;
+    p ^= byte & 0x1;
+    byte >>= 1;
+    p ^= byte & 0x1;
+    byte >>= 1;
+    p ^= byte & 0x1;
+    byte >>= 1;
+    p ^= byte & 0x1;
+    byte >>= 1;
+    p ^= byte & 0x1;
+
+    return p;
+}
+
+// sums the bytes in the supplied buffer, returns that sum mod 0xFFFF
+uint16_t crc_sum_of_bytes_16(const uint8_t *data, uint16_t count)
+{
+    uint16_t ret = 0;
+    for (uint32_t i=0; i<count; i++) {
+        ret += data[i];
+    }
+    return ret;
+}
+
+// sums the bytes in the supplied buffer, returns that sum mod 256
+// (i.e. shoved into a uint8_t)
+uint8_t crc_sum_of_bytes(const uint8_t *data, uint16_t count)
+{
+    return crc_sum_of_bytes_16(data, count) & 0xFF;
+}

--- a/libraries/AP_Math/checksum.cpp
+++ b/libraries/AP_Math/checksum.cpp
@@ -18,6 +18,7 @@
 
 #include <stdint.h>
 #include "checksum.h"
+#include "crc.h"
 
 #include <AP_HAL/AP_HAL_Boards.h>
 
@@ -42,6 +43,16 @@ void cksum_fnv_1a(uint32_t len, const uint8_t* buf, uint64_t* hash)
         *hash ^= (uint64_t)buf[i];
         *hash *= FNV_1_PRIME_64;
     }
+}
+
+uint16_t cksum_GDL90(const uint8_t *buf, uint32_t len)
+{
+    uint8_t zero = 0;
+    uint16_t result = 0;
+    for (uint32_t i = 0; i < len; i++) {
+        result = crc16_ccitt(&zero, 1, result) ^ *buf++;
+    }
+    return result;
 }
 
 // simple 8 bit checksum used by FPort

--- a/libraries/AP_Math/checksum.h
+++ b/libraries/AP_Math/checksum.h
@@ -25,6 +25,10 @@ uint16_t cksum_fletcher16(const uint8_t * buffer, uint32_t len);
 #define FNV_1_OFFSET_BASIS_64 14695981039346656037UL
 void cksum_fnv_1a(uint32_t len, const uint8_t* buf, uint64_t* hash);
 
+// used by GDL90 ADSB protocol. claims to be a CRC, and uses one, but is not.
+// https://www.faa.gov/nextgen/programs/adsb/archival/media/gdl90_public_icd_reva.pdf
+uint16_t cksum_GDL90(const uint8_t *buf, uint32_t len);
+
 // checksum used by SPORT/FPort.  For each byte, adds it to a 16-bit
 // sum, then adds those two bytes together.  Returns the complement of
 // the final sum.

--- a/libraries/AP_Math/checksum.h
+++ b/libraries/AP_Math/checksum.h
@@ -1,0 +1,42 @@
+/*
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*
+  collection of non-CRC checksum calculation functions
+ */
+#pragma once
+
+#include <stdint.h>
+
+// checksum used by SPORT/FPort.  For each byte, adds it to a 16-bit
+// sum, then adds those two bytes together.  Returns the complement of
+// the final sum.
+uint8_t crc_sum8_with_carry(const uint8_t *p, uint8_t len);
+
+uint16_t crc_fletcher16(const uint8_t * buffer, uint32_t len);
+
+// generate 64bit FNV1a hash from buffer
+#define FNV_1_OFFSET_BASIS_64 14695981039346656037UL
+void hash_fnv_1a(uint32_t len, const uint8_t* buf, uint64_t* hash);
+
+// return the parity of byte - "1" if there is an odd number of bits
+// set, "0" if there is an even number of bits set
+uint8_t parity(uint8_t byte);
+
+// sums the bytes in the supplied buffer, returns that sum mod 256
+// (i.e. shoved into a uint8_t)
+uint8_t crc_sum_of_bytes(const uint8_t *data, uint16_t count);
+
+// sums the bytes in the supplied buffer, returns that sum mod 0xFFFF
+uint16_t crc_sum_of_bytes_16(const uint8_t *data, uint16_t count);

--- a/libraries/AP_Math/checksum.h
+++ b/libraries/AP_Math/checksum.h
@@ -19,24 +19,24 @@
 
 #include <stdint.h>
 
-// checksum used by SPORT/FPort.  For each byte, adds it to a 16-bit
-// sum, then adds those two bytes together.  Returns the complement of
-// the final sum.
-uint8_t crc_sum8_with_carry(const uint8_t *p, uint8_t len);
-
-uint16_t crc_fletcher16(const uint8_t * buffer, uint32_t len);
+uint16_t cksum_fletcher16(const uint8_t * buffer, uint32_t len);
 
 // generate 64bit FNV1a hash from buffer
 #define FNV_1_OFFSET_BASIS_64 14695981039346656037UL
-void hash_fnv_1a(uint32_t len, const uint8_t* buf, uint64_t* hash);
+void cksum_fnv_1a(uint32_t len, const uint8_t* buf, uint64_t* hash);
+
+// checksum used by SPORT/FPort.  For each byte, adds it to a 16-bit
+// sum, then adds those two bytes together.  Returns the complement of
+// the final sum.
+uint8_t cksum_fport(const uint8_t *p, uint8_t len);
 
 // return the parity of byte - "1" if there is an odd number of bits
 // set, "0" if there is an even number of bits set
-uint8_t parity(uint8_t byte);
+uint8_t cksum_byte_parity(uint8_t byte);
+
+// sums the bytes in the supplied buffer, returns that sum mod 0xFFFF
+uint16_t cksum_sum16(const uint8_t *data, uint16_t count);
 
 // sums the bytes in the supplied buffer, returns that sum mod 256
 // (i.e. shoved into a uint8_t)
-uint8_t crc_sum_of_bytes(const uint8_t *data, uint16_t count);
-
-// sums the bytes in the supplied buffer, returns that sum mod 0xFFFF
-uint16_t crc_sum_of_bytes_16(const uint8_t *data, uint16_t count);
+uint8_t cksum_sum8(const uint8_t *data, uint16_t count);

--- a/libraries/AP_Math/crc.cpp
+++ b/libraries/AP_Math/crc.cpp
@@ -464,7 +464,7 @@ uint16_t crc16_ccitt_GDL90(const uint8_t *buf, uint32_t len, uint16_t crc)
  * @param [in] len size of buffer
  * @return CRC value
  */
-uint16_t calc_crc_modbus(const uint8_t *buf, uint16_t len)
+uint16_t crc_modbus(const uint8_t *buf, uint16_t len)
 {
     uint16_t crc = 0xFFFF;
     for (uint16_t pos = 0; pos < len; pos++) {

--- a/libraries/AP_Math/crc.cpp
+++ b/libraries/AP_Math/crc.cpp
@@ -13,7 +13,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 /*
-  collection of CRCs. 
+  collection of CRC calculation functions
  */
 
 #include <stdint.h>
@@ -482,29 +482,6 @@ uint16_t calc_crc_modbus(const uint8_t *buf, uint16_t len)
     return crc;
 }
 
-// fletcher 16 implementation
-uint16_t crc_fletcher16(const uint8_t *buffer, uint32_t len) {
-    uint16_t c0 = 0;
-    uint16_t c1 = 0;
-    for (uint32_t i = 0; i < len; i++) {
-        c0 = (c0 + buffer[i]) % 255;
-        c1 = (c1 + c0) % 255;
-    }
-
-    return (c1 << 8) | c0;
-}
-
-// FNV-1a implementation
-#define FNV_1_PRIME_64 1099511628211UL
-void hash_fnv_1a(uint32_t len, const uint8_t* buf, uint64_t* hash)
-{
-    uint32_t i;
-    for (i=0; i<len; i++) {
-        *hash ^= (uint64_t)buf[i];
-        *hash *= FNV_1_PRIME_64;
-    }
-}
-
 // calculate 24 bit crc. We take an approach that saves memory and flash at the cost of higher CPU load.
 uint32_t crc_crc24(const uint8_t *bytes, uint16_t len)
 {
@@ -523,19 +500,6 @@ uint32_t crc_crc24(const uint8_t *bytes, uint16_t len)
         crc = ((crc<<8)&0xFFFFFF) ^ crct;
     }
     return crc;
-}
-
-// simple 8 bit checksum used by FPort
-uint8_t crc_sum8_with_carry(const uint8_t *p, uint8_t len)
-{
-    uint16_t sum = 0;
-    for (uint8_t i=0; i<len; i++) {
-        sum += p[i];
-        sum += sum >> 8;
-        sum &= 0xFF;              
-    }
-    sum = 0xff - ((sum & 0xff) + (sum >> 8));
-    return sum;
 }
 
 // CRC-16 (IBM/ANSI)
@@ -615,48 +579,4 @@ uint64_t crc_crc64(const uint32_t *data, uint16_t num_words)
     crc ^= ~(0ULL);
 
     return crc;
-}
-
-// return the parity of byte - "1" if there is an odd number of bits
-// set, "0" if there is an even number of bits set note that
-// __builtin_parity causes hardfaults on Pixracer-periph - and is
-// slower on 1 byte than this:
-uint8_t parity(uint8_t byte)
-{
-    uint8_t p = 0;
-
-    p ^= byte & 0x1;
-    byte >>= 1;
-    p ^= byte & 0x1;
-    byte >>= 1;
-    p ^= byte & 0x1;
-    byte >>= 1;
-    p ^= byte & 0x1;
-    byte >>= 1;
-    p ^= byte & 0x1;
-    byte >>= 1;
-    p ^= byte & 0x1;
-    byte >>= 1;
-    p ^= byte & 0x1;
-    byte >>= 1;
-    p ^= byte & 0x1;
-
-    return p;
-}
-
-// sums the bytes in the supplied buffer, returns that sum mod 0xFFFF
-uint16_t crc_sum_of_bytes_16(const uint8_t *data, uint16_t count)
-{
-    uint16_t ret = 0;
-    for (uint32_t i=0; i<count; i++) {
-        ret += data[i];
-    }
-    return ret;
-}
-
-// sums the bytes in the supplied buffer, returns that sum mod 256
-// (i.e. shoved into a uint8_t)
-uint8_t crc_sum_of_bytes(const uint8_t *data, uint16_t count)
-{
-    return crc_sum_of_bytes_16(data, count) & 0xFF;
 }

--- a/libraries/AP_Math/crc.cpp
+++ b/libraries/AP_Math/crc.cpp
@@ -449,14 +449,6 @@ uint16_t crc16_ccitt_r(const uint8_t *buf, uint32_t len, uint16_t crc, uint16_t 
 	return crc;
 }
 
-uint16_t crc16_ccitt_GDL90(const uint8_t *buf, uint32_t len, uint16_t crc)
-{
-    for (uint32_t i = 0; i < len; i++) {
-        crc = crc16tab[crc >> 8] ^ (crc << 8) ^ (uint16_t) *buf++;
-    }
-    return crc;
-}
-
 /**
  * Calculate Modbus CRC16 for array of bytes
  * 

--- a/libraries/AP_Math/crc.h
+++ b/libraries/AP_Math/crc.h
@@ -45,7 +45,7 @@ uint16_t crc16_ccitt_r(const uint8_t *buf, uint32_t len, uint16_t crc, uint16_t 
 // https://www.faa.gov/nextgen/programs/adsb/archival/media/gdl90_public_icd_reva.pdf
 uint16_t crc16_ccitt_GDL90(const uint8_t *buf, uint32_t len, uint16_t crc);
 
-uint16_t calc_crc_modbus(const uint8_t *buf, uint16_t len);
+uint16_t crc_modbus(const uint8_t *buf, uint16_t len);
 
 // CRC-64-WE using the polynomial of 0x42F0E1EBA9EA3693
 uint64_t crc_crc64(const uint32_t *data, uint16_t num_words);

--- a/libraries/AP_Math/crc.h
+++ b/libraries/AP_Math/crc.h
@@ -41,10 +41,6 @@ uint16_t crc_crc16_ibm(uint16_t crc_accum, uint8_t *data_blk_ptr, uint16_t data_
 uint16_t crc16_ccitt(const uint8_t *buf, uint32_t len, uint16_t crc);
 uint16_t crc16_ccitt_r(const uint8_t *buf, uint32_t len, uint16_t crc, uint16_t out);
 
-// CRC16_CCITT algorithm using the GDL90 parser method which is non-standard
-// https://www.faa.gov/nextgen/programs/adsb/archival/media/gdl90_public_icd_reva.pdf
-uint16_t crc16_ccitt_GDL90(const uint8_t *buf, uint32_t len, uint16_t crc);
-
 uint16_t crc_modbus(const uint8_t *buf, uint16_t len);
 
 // CRC-64-WE using the polynomial of 0x42F0E1EBA9EA3693

--- a/libraries/AP_Math/crc.h
+++ b/libraries/AP_Math/crc.h
@@ -13,7 +13,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 /*
-  interfaces to ArduPilot collection of CRCs.
+  collection of CRC calculation functions
  */
 #pragma once
 
@@ -36,11 +36,6 @@ uint32_t crc32_small(uint32_t crc, const uint8_t *buf, uint32_t size);
 uint32_t crc_crc24(const uint8_t *bytes, uint16_t len);
 uint16_t crc_crc16_ibm(uint16_t crc_accum, uint8_t *data_blk_ptr, uint16_t data_blk_size);
 
-// checksum used by SPORT/FPort.  For each byte, adds it to a 16-bit
-// sum, then adds those two bytes together.  Returns the complement of
-// the final sum.
-uint8_t crc_sum8_with_carry(const uint8_t *p, uint8_t len);
-
 // Copyright (C) 2010 Swift Navigation Inc.
 // Contact: Fergus Noble <fergus@swift-nav.com>
 uint16_t crc16_ccitt(const uint8_t *buf, uint32_t len, uint16_t crc);
@@ -52,22 +47,5 @@ uint16_t crc16_ccitt_GDL90(const uint8_t *buf, uint32_t len, uint16_t crc);
 
 uint16_t calc_crc_modbus(const uint8_t *buf, uint16_t len);
 
-uint16_t crc_fletcher16(const uint8_t * buffer, uint32_t len);
-
-// generate 64bit FNV1a hash from buffer
-#define FNV_1_OFFSET_BASIS_64 14695981039346656037UL
-void hash_fnv_1a(uint32_t len, const uint8_t* buf, uint64_t* hash);
-
 // CRC-64-WE using the polynomial of 0x42F0E1EBA9EA3693
 uint64_t crc_crc64(const uint32_t *data, uint16_t num_words);
-
-// return the parity of byte - "1" if there is an odd number of bits
-// set, "0" if there is an even number of bits set
-uint8_t parity(uint8_t byte);
-
-// sums the bytes in the supplied buffer, returns that sum mod 256
-// (i.e. shoved into a uint8_t)
-uint8_t crc_sum_of_bytes(const uint8_t *data, uint16_t count);
-
-// sums the bytes in the supplied buffer, returns that sum mod 0xFFFF
-uint16_t crc_sum_of_bytes_16(const uint8_t *data, uint16_t count);

--- a/libraries/AP_Math/tests/test_math.cpp
+++ b/libraries/AP_Math/tests/test_math.cpp
@@ -683,14 +683,14 @@ TEST(MathTest, FIXEDWINGTURNRATE)
 
 TEST(CRCTest, parity)
 {
-    EXPECT_EQ(parity(0b1), 1);
-    EXPECT_EQ(parity(0b10), 1);
-    EXPECT_EQ(parity(0b100), 1);
+    EXPECT_EQ(cksum_byte_parity(0b1), 1);
+    EXPECT_EQ(cksum_byte_parity(0b10), 1);
+    EXPECT_EQ(cksum_byte_parity(0b100), 1);
 
-    EXPECT_EQ(parity(0b11), 0);
-    EXPECT_EQ(parity(0b110), 0);
-    EXPECT_EQ(parity(0b111), 1);
-    EXPECT_EQ(parity(0b11111111), 0);
+    EXPECT_EQ(cksum_byte_parity(0b11), 0);
+    EXPECT_EQ(cksum_byte_parity(0b110), 0);
+    EXPECT_EQ(cksum_byte_parity(0b111), 1);
+    EXPECT_EQ(cksum_byte_parity(0b11111111), 0);
 }
 
 TEST(MathTest, div1000)

--- a/libraries/AP_RCProtocol/AP_RCProtocol_FPort.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_FPort.cpp
@@ -179,7 +179,7 @@ void AP_RCProtocol_FPort::decode_downlink(const FPort_Frame &frame)
     buf[3] = telem_data.packet.appid & 0xFF;
     buf[4] = telem_data.packet.appid >> 8;
     memcpy(&buf[5], &telem_data.packet.data, 4);
-    buf[9] = crc_sum8_with_carry(&buf[0], 9);
+    buf[9] = cksum_fport(&buf[0], 9);
 
     // perform byte stuffing per FPort spec
     uint8_t len = 0;
@@ -307,7 +307,7 @@ reset:
 bool AP_RCProtocol_FPort::check_checksum(void)
 {
     const uint8_t len = byte_input.buf[1]+2;
-    return crc_sum8_with_carry(&byte_input.buf[1], len) == 0x00;
+    return cksum_fport(&byte_input.buf[1], len) == 0x00;
 }
 
 // support byte input

--- a/libraries/AP_RCProtocol/AP_RCProtocol_FPort2.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_FPort2.cpp
@@ -179,7 +179,7 @@ void AP_RCProtocol_FPort2::decode_downlink(const FPort2_Frame &frame)
         // get fresh telem_data in the next call
         telem_data.available = false;
     }
-    buf[9] = crc_sum8_with_carry(&buf[1], 8);
+    buf[9] = cksum_fport(&buf[1], 8);
     
     uart->write(buf, sizeof(buf));
 #endif
@@ -286,7 +286,7 @@ reset:
 // check checksum byte
 bool AP_RCProtocol_FPort2::check_checksum(void)
 {
-    return crc_sum8_with_carry(&byte_input.buf[1], byte_input.control_len-1) == 0;
+    return cksum_fport(&byte_input.buf[1], byte_input.control_len-1) == 0;
 }
 
 // support byte input

--- a/libraries/AP_RCProtocol/SoftSerial.cpp
+++ b/libraries/AP_RCProtocol/SoftSerial.cpp
@@ -86,7 +86,7 @@ bool SoftSerial::process_pulse(uint32_t width_high, uint32_t width_low, uint8_t 
         }
         if (config == SERIAL_CONFIG_8E2I) {
             // check parity
-            if (parity((state.byte>>1)&0xFF) != (state.byte&0x200)>>9) {
+            if (cksum_byte_parity((state.byte>>1)&0xFF) != (state.byte&0x200)>>9) {
                 goto reset;
             }
         }

--- a/libraries/AP_RCProtocol/SoftSerial.cpp
+++ b/libraries/AP_RCProtocol/SoftSerial.cpp
@@ -17,7 +17,7 @@
  */
 
 #include "SoftSerial.h"
-#include <AP_Math/crc.h>
+#include <AP_Math/checksum.h>
 #include <stdio.h>
 
 SoftSerial::SoftSerial(uint32_t _baudrate, serial_config _config) :

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.cpp
@@ -62,7 +62,7 @@ bool AP_RangeFinder_Ainstein_LR_D1::get_reading(float &reading_m)
         available -= uart->read(buffer, ARRAY_SIZE(buffer));
 
         const uint8_t checksum = buffer[ARRAY_SIZE(buffer)-1]; // last byte is a checksum
-        if (crc_sum_of_bytes(buffer, ARRAY_SIZE(buffer)-1) != checksum) {
+        if (cksum_sum8(buffer, ARRAY_SIZE(buffer)-1) != checksum) {
             // bad Checksum
             continue;
         }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Lanbao.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Lanbao.cpp
@@ -68,7 +68,7 @@ bool AP_RangeFinder_Lanbao::get_reading(float &reading_m)
         if (buf_len == sizeof(buf)) {
             buf_len = 0;
             uint16_t crc = (buf[5]<<8) | buf[4];
-            if (crc != calc_crc_modbus(buf, 4)) {
+            if (crc != crc_modbus(buf, 4)) {
                 // bad CRC, discard
                 continue;
             }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarOne.cpp
@@ -96,7 +96,7 @@ bool AP_RangeFinder_LeddarOne::get_reading(float &reading_m)
 */
 bool AP_RangeFinder_LeddarOne::CRC16(uint8_t *aBuffer, uint8_t aLength, bool aCheck)
 {
-    uint16_t crc = calc_crc_modbus(aBuffer, aLength);
+    uint16_t crc = crc_modbus(aBuffer, aLength);
 
     uint8_t lCRCLo = LOWBYTE(crc);
     uint8_t lCRCHi = HIGHBYTE(crc);

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LeddarVu8.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LeddarVu8.cpp
@@ -112,7 +112,7 @@ void AP_RangeFinder_LeddarVu8::request_distances()
     const uint8_t req_buf_len = sizeof(req_buf);
 
     // fill in crc bytes
-    uint16_t crc = calc_crc_modbus(req_buf, req_buf_len - 2);
+    uint16_t crc = crc_modbus(req_buf, req_buf_len - 2);
     req_buf[req_buf_len - 2] = LOWBYTE(crc);
     req_buf[req_buf_len - 1] = HIGHBYTE(crc);
 
@@ -181,7 +181,7 @@ bool AP_RangeFinder_LeddarVu8::parse_byte(uint8_t b, bool &valid_reading, uint16
         parsed_msg.state = ParseState::WAITING_FOR_ADDRESS;
 
         // check crc
-        uint16_t expected_crc = calc_crc_modbus(&parsed_msg.address, 3+parsed_msg.payload_recv);
+        uint16_t expected_crc = crc_modbus(&parsed_msg.address, 3+parsed_msg.payload_recv);
         if (expected_crc == parsed_msg.crc) {
             // calculate and return shortest distance
             reading_cm = 0;

--- a/libraries/SITL/SIM_EFI_Hirth.cpp
+++ b/libraries/SITL/SIM_EFI_Hirth.cpp
@@ -54,7 +54,7 @@ void EFI_Hirth::update_receive()
     }
 
     // checksum is sum of all bytes except the received checksum:
-    const uint8_t expected_checksum = 256U - crc_sum_of_bytes(receive_buf, expected_bytes_in_message-1);
+    const uint8_t expected_checksum = 256U - cksum_sum8(receive_buf, expected_bytes_in_message-1);
     const uint8_t received_checksum = receive_buf[expected_bytes_in_message-1];
     if (expected_checksum == received_checksum) {
         PacketCode received_packet_code = PacketCode(receive_buf[1]);

--- a/libraries/SITL/SIM_EFI_Hirth.h
+++ b/libraries/SITL/SIM_EFI_Hirth.h
@@ -76,7 +76,7 @@ private:
         }
 
         void update_checksum() {
-            checksum = 256U - crc_sum_of_bytes((uint8_t*)this, length-1);
+            checksum = 256U - cksum_sum8((uint8_t*)this, length-1);
         }
     };
 

--- a/libraries/SITL/SIM_GPS_Trimble.cpp
+++ b/libraries/SITL/SIM_GPS_Trimble.cpp
@@ -337,7 +337,7 @@ bool DCOL_Parser::valid_csum() {
     uint8_t sum = (uint8_t)status;
     sum += (uint8_t)packet_type;
     sum += expected_payload_length;
-    sum += crc_sum_of_bytes(payload, expected_payload_length);
+    sum += cksum_sum8(payload, expected_payload_length);
     return sum == expected_csum;
 }
 

--- a/libraries/SITL/SIM_InertialLabs.cpp
+++ b/libraries/SITL/SIM_InertialLabs.cpp
@@ -99,7 +99,7 @@ void InertialLabs::send_packet(void)
     pkt.temperature = 23.4*10;
 
     const uint8_t *buffer = (const uint8_t *)&pkt;
-    pkt.crc = crc_sum_of_bytes_16(&buffer[2], sizeof(pkt)-4);
+    pkt.crc = cksum_sum16(&buffer[2], sizeof(pkt)-4);
 
     write_to_autopilot((char *)&pkt, sizeof(pkt));
 

--- a/libraries/SITL/SIM_RF_Ainstein_LR_D1.cpp
+++ b/libraries/SITL/SIM_RF_Ainstein_LR_D1.cpp
@@ -44,7 +44,7 @@ uint32_t RF_Ainstein_LR_D1::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uin
     buffer[9] = 0;  // speed high
     buffer[10] = 0;  // speed low
     memset(&buffer[11], 0xff, 20); // unused
-    buffer[31] = crc_sum_of_bytes(&buffer[3], PACKET_LEN-4); // minus headerMSB, headerLSB, device_id and checksum
+    buffer[31] = cksum_sum8(&buffer[3], PACKET_LEN-4); // minus headerMSB, headerLSB, device_id and checksum
 
     return PACKET_LEN;
 }

--- a/libraries/SITL/SIM_RF_Lanbao.cpp
+++ b/libraries/SITL/SIM_RF_Lanbao.cpp
@@ -31,7 +31,7 @@ uint32_t RF_Lanbao::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buf
     buffer[2] = (alt_cm * 10) >> 8;
     buffer[3] = (alt_cm * 10) & 0xff;
 
-    const uint16_t crc = calc_crc_modbus(buffer, 4);
+    const uint16_t crc = crc_modbus(buffer, 4);
     buffer[4] = crc & 0xff;
     buffer[5] = crc >> 8;
 

--- a/libraries/SITL/SIM_RF_LeddarOne.cpp
+++ b/libraries/SITL/SIM_RF_LeddarOne.cpp
@@ -60,7 +60,7 @@ uint32_t RF_LeddarOne::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t 
     buffer[21] = third_amplitude >> 8;
     buffer[22] = third_amplitude & 0xff;
 
-    const uint16_t crc = calc_crc_modbus(buffer, 23);
+    const uint16_t crc = crc_modbus(buffer, 23);
     buffer[23] = crc & 0xff;
     buffer[24] = crc >> 8;
 


### PR DESCRIPTION
All CRCs are checksums but not all checksums are CRCs.

Paves the way for deduplication and unification of CRC implementations, including interface and standard of implementation.

No functional change yet. Hopefully this cleanup is appreciated.