### PR TITLE
AP_Proximity: Include database push in MR72 driver

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity_MR72_CAN.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_MR72_CAN.cpp
@@ -117,6 +117,7 @@ bool AP_Proximity_MR72_CAN::parse_distance_message(AP_HAL::CANFrame &frame)
 
     const AP_Proximity_Boundary_3D::Face face = frontend.boundary.get_face(yaw);
     _temp_boundary.add_distance(face, yaw, objects_dist);
+    database_push(yaw, objects_dist);
     return true;
 }
 


### PR DESCRIPTION
This is a fix for #27216.
I have tested this on bench by connecting an MR72 to my Cube Orange and checking if the Obstacles are being populated in the OA DB. 