### PR TITLE
AP_BatteryMonitor: add missing failsafe with no action

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -81,6 +81,7 @@ public:
     // battery failsafes must be defined in levels of severity so that vehicles wont fall backwards
     enum class Failsafe : uint8_t {
         None = 0,
+        Unhealthy,
         Low,
         Critical
     };
@@ -153,6 +154,7 @@ public:
         float       resistance;                // resistance, in Ohms, calculated by comparing resting voltage vs in flight voltage
         Failsafe failsafe;                     // stage failsafe the battery is in
         bool        healthy;                   // battery monitor is communicating correctly
+        uint32_t    last_healthy_ms;           // Time when monitor was last healthy
         bool        is_powering_off;           // true when power button commands power off
         bool        powerOffNotified;          // only send powering off notification once
         uint32_t    time_remaining;            // remaining battery time

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
@@ -168,6 +168,11 @@ AP_BattMonitor::Failsafe AP_BattMonitor_Backend::update_failsafes(void)
         return AP_BattMonitor::Failsafe::Low;
     }
 
+    // 5 second health timeout
+    if ((now - _state.last_healthy_ms) > 5000) {
+        return AP_BattMonitor::Failsafe::Unhealthy;
+    }
+
     // if we've gotten this far then battery is ok
     return AP_BattMonitor::Failsafe::None;
 }


### PR DESCRIPTION
Currently if your battery monitor goes away the only way to tell is a bit in sys status. This is quite easy to miss. This now results in a full battery failsafe with no action. We might want to consider adding a parameter in the future. This uses a 5 second timeout.

This becomes more likely with CAN battery monitors which are often powered from the battery itself, so if the battery fails the node also disappears rather than telling us that the battery is gone. 

Example:
![image](https://github.com/ArduPilot/ardupilot/assets/33176108/48df93f5-d4ce-48e9-92fb-4ed9a76c588c)

