### PR TITLE
AP_BattMonitor: Sum, ESC: all selected items must be found for health.

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_ESC.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_ESC.cpp
@@ -99,12 +99,27 @@ void AP_BattMonitor_ESC::read(void)
         }
     }
 
+    // Max number of ESCs ever seen
+    esc_count = MAX(esc_count, voltage_escs);
+
+    if (voltage_escs == 0) {
+        // Need at least one to be healthy
+        _state.healthy = false;
+
+    } else if (all_enabled) {
+        // All ESCs must be found
+        _state.healthy = voltage_escs == esc_count;
+
+    } else {
+        // All selected ESCs must be found
+        _state.healthy = voltage_escs == __builtin_popcount(_mask);
+
+    }
+
     if (voltage_escs > 0) {
         _state.voltage = voltage_sum / voltage_escs;
-        _state.healthy = true;
     } else {
         _state.voltage = 0;
-        _state.healthy = false;
     }
     if (temperature_escs > 0) {
         _state.temperature = temperature_sum / temperature_escs;

--- a/libraries/AP_BattMonitor/AP_BattMonitor_ESC.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_ESC.h
@@ -53,6 +53,8 @@ private:
     bool have_current;
     bool have_temperature;
     float delta_mah;
+
+    uint8_t esc_count;
 };
 
 #endif  // AP_BATTERY_ESC_ENABLED

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Sum.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Sum.cpp
@@ -54,6 +54,7 @@ AP_BattMonitor_Sum::read()
     float current_sum = 0;
     uint8_t current_count = 0;
 
+    bool all_healthy = true;
     for (uint8_t i=0; i<_mon.num_instances(); i++) {
         if (i == _instance) {
             // never include self
@@ -68,6 +69,7 @@ AP_BattMonitor_Sum::read()
             continue;
         }
         if (!_mon.healthy(i)) {
+            all_healthy = false;
             continue;
         }
         voltage_sum += _mon.voltage(i);
@@ -91,7 +93,7 @@ AP_BattMonitor_Sum::read()
     update_consumed(_state, dt_us);
 
     _has_current = (current_count > 0);
-    _state.healthy = (voltage_count > 0);
+    _state.healthy = (voltage_count > 0) && all_healthy;
 
     if (_state.healthy) {
         _state.last_time_micros = tnow_us;


### PR DESCRIPTION
Currently both the sum and ESC backends will hide a failure because they take a average. So if one item is lost the voltage stays the same and no fail-safe is tripped. This will now mark the monitor unhealthy if any item is missing. With https://github.com/ArduPilot/ardupilot/pull/27358 this gives a clear warning to the pilot.