### PR TITLE
AP_Scripting: correct use-after-free in script statistics

### DIFF
--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -550,8 +550,11 @@ void lua_scripts::run(void) {
             if ((_debug_options.get() & uint8_t(DebugLevel::RUNTIME_MSG)) != 0) {
                 GCS_SEND_TEXT(MAV_SEVERITY_DEBUG, "Lua: Running %s", scripts->name);
             }
-            // copy name for logging, cant do it after as script reschedule moves the pointers
-            const char * script_name = scripts->name;
+            // take a copy of the script name for the purposes of
+            // logging statistics.  "scripts" may become invalid
+            // during the "run_next_script" call, below.
+            char script_name[128+1] {};
+            strncpy_noterm(script_name, scripts->name, 128);
 
 #if DISABLE_INTERRUPTS_FOR_SCRIPT_RUN
             void *istate = hal.scheduler->disable_interrupts_save();
@@ -560,6 +563,10 @@ void lua_scripts::run(void) {
             const int startMem = lua_gc(L, LUA_GCCOUNT, 0) * 1024 + lua_gc(L, LUA_GCCOUNTB, 0);
             const uint32_t loadEnd = AP_HAL::micros();
 
+            // NOTE!  the base pointer of our scripts linked list,
+            // *and all its contents* may become invalid as part of
+            // "run_next_script"!  So do *NOT* attempt to access
+            // anything that was in *scripts after this call.
             run_next_script(L);
 
             const uint32_t runEnd = AP_HAL::micros();


### PR DESCRIPTION
... I think a restructure may not be a bad option here....

Before the patch is applied the autotest reproduces the valgrind problem if you run it like this:
`./Tools/autotest/autotest.py build.Plane --valgrind test.Plane.ScriptStats`

No Valgrind problem after the patch.

OTOH, `math.lua` doesn't seem to work any more - before *or* after this patch.
```
AT-0031.7: AP: Lua: ./scripts/math.lua exceeded time limit
```
... in fact, that's why we're getting the Valgrind problem, the removal of that script due to it running overtime.  So if we fix `math.lua` we might need a `run_overtime.lua` to make sure we cross the relevant path in our lua script handling.

Implications here.... well, you're limited to reading memory with random contents, but AFAICS that memory pointer will always be valid.  A crash may still still possible, but extraordinarily unlikely:
 - scripts->name points to an address just before the end of a valid memory region
 - the "random contents" at that location doesn't contain a null
 - strncpy from the stale scripts->name over-reads into invalid memory as it doesn't find a nullptr
 - you buy a lottery ticket, as karma dictates any ticket bought must be a winner
