### PR TITLE
Scripting: added command_int API for accessing MAV_CMD_xxx

### DIFF
--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -2605,6 +2605,12 @@ function gcs:send_text(severity, text) end
 ---@return uint32_t_ud -- system time in milliseconds
 function gcs:last_seen() end
 
+-- call a MAVLink MAV_CMD_xxx command via command_int interface
+---@param command integer -- MAV_CMD_xxx
+---@param params table -- parameters of p1, p2, p3, p4, x, y and z and frame. Any not specified taken as zero
+---@return boolean
+function gcs:run_command_int(command, params) end
+
 -- The relay library provides access to controlling relay outputs.
 relay = {}
 

--- a/libraries/AP_Scripting/examples/command_int.lua
+++ b/libraries/AP_Scripting/examples/command_int.lua
@@ -1,0 +1,56 @@
+--[[
+   demonstrate using the gcs:command_int() interface to send commands from MAVLink MAV_CMD_xxx set
+--]]
+
+local MAV_FRAME_GLOBAL_RELATIVE_ALT = 3
+
+local MAV_CMD_DO_SET_MODE = 176
+local MAV_CMD_DO_REPOSITION = 192
+
+-- some plane flight modes for testing
+local MODE_LOITER = 12
+local MODE_GUIDED = 15
+
+local MAV_MODE_FLAG_CUSTOM_MODE_ENABLED = 1
+
+--[[
+create a NaN value
+--]]
+local function NaN()
+   return 0/0
+end
+
+--[[
+   test API calls. When in LOITER mode change to GUIDED and force flying to a location NE of home
+--]]
+local function test_command_int()
+   if vehicle:get_mode() ~= MODE_LOITER then
+      return
+   end
+   local home = ahrs:get_home()
+   if not home then
+      return
+   end
+
+   -- force mode GUIDED
+   gcs:run_command_int(MAV_CMD_DO_SET_MODE, { p1 = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED, p2 = MODE_GUIDED })
+
+   -- and fly to 200m NE of home and 100m above home
+   local dest = home:copy()
+   dest:offset_bearing(45, 200)
+
+   gcs:run_command_int(MAV_CMD_DO_REPOSITION, { frame = MAV_FRAME_GLOBAL_RELATIVE_ALT,
+                                                p1 = -1,
+                                                p4 = NaN(),
+                                                x = dest:lat(),
+                                                y = dest:lng(),
+                                                z = 100 })
+end
+
+local function update()
+   test_command_int()
+   return update, 1000
+end
+
+return update, 1000
+

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -296,6 +296,7 @@ singleton GCS method get_high_latency_status depends HAL_HIGH_LATENCY2_ENABLED =
 
 singleton GCS method enable_high_latency_connections void boolean
 singleton GCS method enable_high_latency_connections depends HAL_HIGH_LATENCY2_ENABLED == 1
+singleton GCS manual run_command_int lua_GCS_command_int 2 1
 
 include AP_ONVIF/AP_ONVIF.h depends ENABLE_ONVIF == 1
 singleton AP_ONVIF depends ENABLE_ONVIF == 1

--- a/libraries/AP_Scripting/lua_bindings.h
+++ b/libraries/AP_Scripting/lua_bindings.h
@@ -30,3 +30,4 @@ int lua_mavlink_send_chan(lua_State *L);
 int lua_mavlink_block_command(lua_State *L);
 int lua_print(lua_State *L);
 int lua_range_finder_handle_script_msg(lua_State *L);
+int lua_GCS_command_int(lua_State *L);

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -406,4 +406,25 @@ bool GCS_MAVLINK::check_payload_size(uint16_t max_payload_len)
     return true;
 }
 
+#if AP_SCRIPTING_ENABLED
+/*
+  lua access to command_int
+
+  Note that this is called with the AP_Scheduler lock, ensuring the
+  main thread does not race with a lua command_int
+*/
+MAV_RESULT GCS::lua_command_int_packet(const mavlink_command_int_t &packet)
+{
+    // for now we assume channel 0. In the future we may create a dedicated channel
+    auto *ch = chan(0);
+    if (ch == nullptr) {
+        return MAV_RESULT_UNSUPPORTED;
+    }
+    // we need a dummy message for some calls
+    mavlink_message_t msg {};
+
+    return ch->handle_command_int_packet(packet, msg);
+}
+#endif // AP_SCRIPTING_ENABLED
+
 #endif  // HAL_GCS_ENABLED

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -1271,6 +1271,11 @@ public:
 
     virtual uint8_t sysid_this_mav() const = 0;
 
+#if AP_SCRIPTING_ENABLED
+    // lua access to command_int
+    MAV_RESULT lua_command_int_packet(const mavlink_command_int_t &packet);
+#endif
+
 protected:
 
     virtual GCS_MAVLINK *new_gcs_mavlink_backend(GCS_MAVLINK_Parameters &params,


### PR DESCRIPTION
This makes it possible to call most MAV_CMD_xxx calls from lua scripts, gaining us a lot of functionality with a small amount of flash
This was prompted by #27223 and the MAV_CMD_GUIDED_xxx commands, but is really very broadly useful

some questions:
 - should we return the full MAV_RESULT enum? Is it useful?
 - should we create a dedicated GCS_MAVLink channel for lua?

this also adds an example that tests DO_SET_MODE and DO_REPOSITION
