### PR TITLE
AP_Beacon: use enum class for type

### DIFF
--- a/libraries/AP_Beacon/AP_Beacon.cpp
+++ b/libraries/AP_Beacon/AP_Beacon.cpp
@@ -97,24 +97,30 @@ void AP_Beacon::init(void)
     }
 
     // create backend
-    if (_type == AP_BeaconType_Pozyx) {
+    switch ((Type)_type) {
+    case Type::Pozyx:
         _driver = NEW_NOTHROW AP_Beacon_Pozyx(*this);
-    } else if (_type == AP_BeaconType_Marvelmind) {
+        break;
+    case Type::Marvelmind:
         _driver = NEW_NOTHROW AP_Beacon_Marvelmind(*this);
-    } else if (_type == AP_BeaconType_Nooploop) {
+        break;
+    case Type::Nooploop:
         _driver = NEW_NOTHROW AP_Beacon_Nooploop(*this);
-    }
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    if (_type == AP_BeaconType_SITL) {
+        break;
+#if AP_BEACON_SITL_ENABLED
+    case Type::SITL:
         _driver = NEW_NOTHROW AP_Beacon_SITL(*this);
-    }
+        break;
 #endif
+    case Type::None:
+        break;
+    }
 }
 
 // return true if beacon feature is enabled
 bool AP_Beacon::enabled(void) const
 {
-    return (_type != AP_BeaconType_None);
+    return (_type != Type::None);
 }
 
 // return true if sensor is basically healthy (we are receiving data)
@@ -236,7 +242,7 @@ Vector3f AP_Beacon::beacon_position(uint8_t beacon_instance) const
 // return last update time from beacon in milliseconds
 uint32_t AP_Beacon::beacon_last_update_ms(uint8_t beacon_instance) const
 {
-    if (_type == AP_BeaconType_None || beacon_instance >= num_beacons) {
+    if (_type == Type::None || beacon_instance >= num_beacons) {
         return 0;
     }
     return beacon_state[beacon_instance].distance_update_ms;
@@ -388,7 +394,7 @@ const Vector2f* AP_Beacon::get_boundary_points(uint16_t& num_points) const
 // check if the device is ready
 bool AP_Beacon::device_ready(void) const
 {
-    return ((_driver != nullptr) && (_type != AP_BeaconType_None));
+    return ((_driver != nullptr) && (_type != Type::None));
 }
 
 #if HAL_LOGGING_ENABLED

--- a/libraries/AP_Beacon/AP_Beacon.h
+++ b/libraries/AP_Beacon/AP_Beacon.h
@@ -40,12 +40,14 @@ public:
     static AP_Beacon *get_singleton() { return _singleton; }
 
     // external position backend types (used by _TYPE parameter)
-    enum AP_BeaconType {
-        AP_BeaconType_None   = 0,
-        AP_BeaconType_Pozyx  = 1,
-        AP_BeaconType_Marvelmind = 2,
-        AP_BeaconType_Nooploop  = 3,
-        AP_BeaconType_SITL   = 10
+    enum class Type : uint8_t {
+        None   = 0,
+        Pozyx  = 1,
+        Marvelmind = 2,
+        Nooploop  = 3,
+#if AP_BEACON_SITL_ENABLED
+        SITL   = 10
+#endif
     };
 
     // The AP_BeaconState structure is filled in by the backend driver
@@ -125,7 +127,7 @@ private:
     static bool get_next_boundary_point(const Vector2f* boundary, uint8_t num_points, uint8_t current_index, float start_angle, uint8_t& next_index, float& next_angle);
 
     // parameters
-    AP_Int8 _type;
+    AP_Enum<Type> _type;
     AP_Float origin_lat;
     AP_Float origin_lon;
     AP_Float origin_alt;


### PR DESCRIPTION
Relying on autotests to make sure this works.

zero-byte-change on CubeOrange/ArduCopter.
