### PR TITLE
Constellation choice for septentrio gnss

### DIFF
--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -138,6 +138,19 @@ AP_GPS_SBF::read(void)
                                     config_string = nullptr;
                                 }
                                 break;
+                            case Config_State::Constellation:
+                                if ((params.gnss_mode&0x6F)!=0) {
+                                    //IMES not taken into account by Septentrio receivers
+                                    if (asprintf(&config_string, "sst, %s%s%s%s%s%s\n", (params.gnss_mode&(1U<<0))!=0 ? "GPS" : "",
+                                                            (params.gnss_mode&(1U<<1))!=0 ? ((params.gnss_mode&0x01)==0 ? "SBAS" : "+SBAS") : "",
+                                                            (params.gnss_mode&(1U<<2))!=0 ? ((params.gnss_mode&0x03)==0  ? "GALILEO" : "+GALILEO") : "",
+                                                            (params.gnss_mode&(1U<<3))!=0 ? ((params.gnss_mode&0x07)==0 ? "BEIDOU" : "+BEIDOU") : "",
+                                                            (params.gnss_mode&(1U<<5))!=0 ? ((params.gnss_mode&0x0F)==0 ? "QZSS" : "+QZSS") : "",
+                                                            (params.gnss_mode&(1U<<6))!=0 ? ((params.gnss_mode&0x2F)==0  ? "GLONASS" : "+GLONASS") : "") == -1) {
+                                        config_string=nullptr;
+                                    }
+                                }
+                                break;
                             case Config_State::Blob:
                                 if (asprintf(&config_string, "%s\n", _initialisation_blob[_init_blob_index]) == -1) {
                                     config_string = nullptr;
@@ -364,6 +377,9 @@ AP_GPS_SBF::parse(uint8_t temp)
                                     config_step = Config_State::SSO;
                                     break;
                                 case Config_State::SSO:
+                                    config_step = Config_State::Constellation;
+                                    break;
+                                case Config_State::Constellation:
                                     config_step = Config_State::Blob;
                                     break;
                                 case Config_State::Blob:
@@ -699,4 +715,5 @@ bool AP_GPS_SBF::prepare_for_arming(void) {
 
     return is_logging;
 }
+
 #endif

--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -76,6 +76,7 @@ private:
         Blob,
         SBAS,
         SGA,
+        Constellation,
         Complete
     };
     Config_State config_step;


### PR DESCRIPTION
# Changes
## General overview
This pull request adds the feature to chose the system used for Septentrio receivers through the GPS_GNSS_MODE parameter. 
Any configuration is possible outside of IMES only (see below) and will take effect on start-up.

## Special case : IMES
The IMES system is not implemented as there is no feature for it on the Septentrio receivers. The same way, NavIc and L-Band that can be configured on the receiver but are not present in the current parameters are not implemented.
If the user choses to use only IMES, it is treated as an absence of choice and the system is left as is.

## SBAS parameter 
The Septentrio driver also uses the GPS_SBAS_MODE parameter, this parameter takes precedence over this new feature. To take only this new feature into account, the parameter can be left as NoChange. Redundant choices should not cause any issue.

## Tests
This new feature has been tested with the CubeOrangePlus connected to one mosaic-go through its com2 port, and the copter build. It has been tested with all possible configurations. It has also been tested to work as intended with the SBAS parameter.
RxControl has been used to monitor the receiver and confirm the drop in satellites used corresponded to the right systems.

  Example of corresponding parameter and receiver configuration:
![image](https://github.com/ArduPilot/ardupilot/assets/165775238/406570ce-dfd0-4c90-9a1a-799fa4ae3fb0)
*Parameter on mission planner*

![image](https://github.com/ArduPilot/ardupilot/assets/165775238/961d1af0-7a2f-44a9-8394-083fc4fcb3b4)
*Configuration on RxControl*
