### PR TITLE
README: add Navigator maintainer attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ for reviewing patches on their specific area.
   - ***Vehicle***: Rover
 - [Willian Galvani](https://github.com/williangalvani):
   - ***Vehicle***: Sub
+  - ***Board***: Navigator
 - [Michael du Breuil](https://github.com/WickedShell):
   - ***Subsystem***: Batteries
   - ***Subsystem***: GPS


### PR DESCRIPTION
@Williangalvani [fits the description](https://github.com/ArduPilot/ardupilot/pulls?q=is%3Apr+is%3Aclosed+Navigator):
> ... people that regularly contribute to the project and are responsible for reviewing patches on their specific area

so nice to give some attribution :-)