### PR TITLE
Rover: call stats set_flying from 1Hz loop

### DIFF
--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -293,17 +293,6 @@ void Rover::nav_script_time_done(uint16_t id)
 }
 #endif // AP_SCRIPTING_ENABLED
 
-#if AP_STATS_ENABLED
-/*
-  update AP_Stats
-*/
-void Rover::stats_update(void)
-{
-    AP::stats()->set_flying(g2.motors.active());
-}
-#endif
-
-
 // update AHRS system
 void Rover::ahrs_update()
 {
@@ -468,6 +457,11 @@ void Rover::one_second_loop(void)
     g2.wp_nav.set_turn_params(g2.turn_radius, g2.motors.have_skid_steering());
     g2.pos_control.set_turn_params(g2.turn_radius, g2.motors.have_skid_steering());
     g2.wheel_rate_control.set_notch_sample_rate(AP::scheduler().get_filtered_loop_rate_hz());
+
+#if AP_STATS_ENABLED
+    // Update stats "flying" time
+    AP::stats()->set_flying(g2.motors.active());
+#endif
 }
 
 void Rover::update_current_mode(void)

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -285,7 +285,6 @@ private:
     bool nav_script_time(uint16_t &id, uint8_t &cmd, float &arg1, float &arg2, int16_t &arg3, int16_t &arg4) override;
     void nav_script_time_done(uint16_t id) override;
 #endif // AP_SCRIPTING_ENABLED
-    void stats_update();
     void ahrs_update();
     void gcs_failsafe_check(void);
     void update_logging1(void);


### PR DESCRIPTION
Rover had a `stats_update` function, but its not called from anywhere. Rather than keeping the function this moves the one line that was in it to the 1Hz loop.