### PR TITLE
AP_Arming: Change the initialization of the string buffer

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -44,7 +44,8 @@ bool AP_Arming_Copter::run_pre_arm_checks(bool display_failure)
     }
 
     // always check motors
-    char failure_msg[50] {};
+    char failure_msg[50];
+    failure_msg[0] = 0;
     if (!copter.motors->arming_checks(ARRAY_SIZE(failure_msg), failure_msg)) {
         check_failed(display_failure, "Motors: %s", failure_msg);
         passed = false;
@@ -291,7 +292,8 @@ bool AP_Arming_Copter::parameter_checks(bool display_failure)
 #endif
 
         // ensure controllers are OK with us arming:
-        char failure_msg[50] = {};
+        char failure_msg[50];
+        failure_msg[0] = 0;
         if (!copter.pos_control->pre_arm_checks("PSC", failure_msg, ARRAY_SIZE(failure_msg))) {
             check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Bad parameter: %s", failure_msg);
             return false;
@@ -308,7 +310,8 @@ bool AP_Arming_Copter::parameter_checks(bool display_failure)
 bool AP_Arming_Copter::oa_checks(bool display_failure)
 {
 #if AP_OAPATHPLANNER_ENABLED
-    char failure_msg[50] = {};
+    char failure_msg[50];
+    failure_msg[0] = 0;
     if (copter.g2.oa.pre_arm_check(failure_msg, ARRAY_SIZE(failure_msg))) {
         return true;
     }
@@ -439,7 +442,8 @@ bool AP_Arming_Copter::mandatory_gps_checks(bool display_failure)
 
     // always check if inertial nav has started and is ready
     const auto &ahrs = AP::ahrs();
-    char failure_msg[50] = {};
+    char failure_msg[50];
+    failure_msg[0] = 0;
     if (!ahrs.pre_arm_check(mode_requires_gps, failure_msg, sizeof(failure_msg))) {
         check_failed(display_failure, "AHRS: %s", failure_msg);
         return false;
@@ -528,7 +532,8 @@ bool AP_Arming_Copter::winch_checks(bool display_failure) const
     if (winch == nullptr) {
         return true;
     }
-    char failure_msg[50] = {};
+    char failure_msg[50];
+    failure_msg[0] = 0;
     if (!winch->pre_arm_check(failure_msg, sizeof(failure_msg))) {
         check_failed(display_failure, "%s", failure_msg);
         return false;

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -543,7 +543,8 @@ bool AP_Arming::compass_checks(bool report)
         if (!_compass.learn_offsets_enabled())
 #endif
         {
-            char failure_msg[50] = {};
+            char failure_msg[50];
+            failure_msg[0] = 0;
             if (!_compass.configured(failure_msg, ARRAY_SIZE(failure_msg))) {
                 check_failed(ARMING_CHECK_COMPASS, report, "%s", failure_msg);
                 return false;
@@ -602,7 +603,8 @@ bool AP_Arming::gps_checks(bool report)
     if (check_enabled(ARMING_CHECK_GPS)) {
 
         // Any failure messages from GPS backends
-        char failure_msg[50] = {};
+        char failure_msg[50];
+        failure_msg[0] = 0;
         if (!AP::gps().pre_arm_checks(failure_msg, ARRAY_SIZE(failure_msg))) {
             if (failure_msg[0] != '\0') {
                 check_failed(ARMING_CHECK_GPS, report, "%s", failure_msg);
@@ -1205,7 +1207,8 @@ bool AP_Arming::proximity_checks(bool report) const
 bool AP_Arming::can_checks(bool report)
 {
     if (check_enabled(ARMING_CHECK_SYSTEM)) {
-        char fail_msg[50] = {};
+        char fail_msg[50];
+        fail_msg[0] = 0;
         (void)fail_msg; // might be left unused
         uint8_t num_drivers = AP::can().get_num_drivers();
 
@@ -1494,7 +1497,8 @@ bool AP_Arming::generator_checks(bool display_failure) const
     if (generator == nullptr) {
         return true;
     }
-    char failure_msg[50] = {};
+    char failure_msg[50];
+    failure_msg[0] = 0;
     if (!generator->pre_arm_check(failure_msg, sizeof(failure_msg))) {
         check_failed(display_failure, "Generator: %s", failure_msg);
         return false;
@@ -1509,7 +1513,8 @@ bool AP_Arming::opendroneid_checks(bool display_failure)
 {
     auto &opendroneid = AP::opendroneid();
 
-    char failure_msg[50] {};
+    char failure_msg[50];
+    failure_msg[0] = 0;
     if (!opendroneid.pre_arm_check(failure_msg, sizeof(failure_msg))) {
         check_failed(display_failure, "OpenDroneID: %s", failure_msg);
         return false;


### PR DESCRIPTION
It's not necessary to clear the entire string buffer with zeros.
It's sufficient to set the first byte of the string buffer to NULL.
This method can free up 8 bytes of FLUSH memory.

STM32 has limited FLUSH memory.
I want to prioritize practical benefits over appearance.


AFTER
UILD SUMMARY
Build directory: /home/muramura/work2/ardupilot/build/fmuv3
Target          Text (B)  Data (B)  BSS (B)  Total Flash Used (B)  Free Flash (B)  External Flash Used (B)
bin/arducopter   1550208      3988   192768               1554196          526560  Not Applicable   

BEFORE
BUILD SUMMARY
Build directory: /home/muramura/work2/ardupilot/build/fmuv3
Target          Text (B)  Data (B)  BSS (B)  Total Flash Used (B)  Free Flash (B)  External Flash Used (B)
bin/arducopter   1550284      3988   192772               1554272          526480  Not Applicable  