### PR TITLE
Tidy GPS pre-arm checks

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -5443,6 +5443,19 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.context_pop()
         self.reboot_sitl()
 
+    def GPSPreArms(self):
+        '''ensure GPS prearm checks work'''
+        self.wait_ready_to_arm()
+        self.start_subtest('DroneCAN sanity checks')
+        self.set_parameter('GPS1_TYPE', 9)
+        self.set_parameter('GPS2_TYPE', 9)
+        self.set_parameter('GPS1_CAN_OVRIDE', 130)
+        self.set_parameter('GPS2_CAN_OVRIDE', 130)
+        self.assert_prearm_failure(
+            "set for multiple GPS",
+            other_prearm_failures_fatal=False,
+        )
+
     def tests(self):
         '''return list of all tests'''
         ret = super(AutoTestPlane, self).tests()
@@ -5555,6 +5568,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.ClimbThrottleSaturation,
             self.GuidedAttitudeNoGPS,
             self.ScriptStats,
+            self.GPSPreArms,
         ])
         return ret
 

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -603,7 +603,7 @@ bool AP_Arming::gps_checks(bool report)
 
         // Any failure messages from GPS backends
         char failure_msg[50] = {};
-        if (!AP::gps().backends_healthy(failure_msg, ARRAY_SIZE(failure_msg))) {
+        if (!AP::gps().pre_arm_checks(failure_msg, ARRAY_SIZE(failure_msg))) {
             if (failure_msg[0] != '\0') {
                 check_failed(ARMING_CHECK_GPS, report, "%s", failure_msg);
             }

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -551,9 +551,10 @@ public:
     // returns true if all GPS instances have passed all final arming checks/state changes
     bool prepare_for_arming(void);
 
-    // returns true if all GPS backend drivers haven't seen any failure
-    // this is for backends to be able to spout pre arm error messages
-    bool backends_healthy(char failure_msg[], uint16_t failure_msg_len);
+    // returns true if all GPS backend drivers are OK with the concept
+    // of the vehicle arming.  this is for backends to be able to
+    // spout pre arm error messages
+    bool pre_arm_checks(char failure_msg[], uint16_t failure_msg_len);
 
     // returns false if any GPS drivers are not performing their logging appropriately
     bool logging_failed(void) const;

--- a/libraries/AP_GPS/AP_GPS_DroneCAN.cpp
+++ b/libraries/AP_GPS/AP_GPS_DroneCAN.cpp
@@ -225,8 +225,24 @@ AP_GPS_Backend* AP_GPS_DroneCAN::probe(AP_GPS &_gps, AP_GPS::GPS_State &_state)
     return backend;
 }
 
-bool AP_GPS_DroneCAN::backends_healthy(char failure_msg[], uint16_t failure_msg_len)
+bool AP_GPS_DroneCAN::inter_instance_pre_arm_checks(char failure_msg[], uint16_t failure_msg_len)
 {
+    // only do these checks if there is at least one DroneCAN GPS:
+    bool found_uavan_type = false;
+    for (uint8_t i = 0; i < GPS_MAX_RECEIVERS; i++) {
+        const auto type = AP::gps().params[i].type;
+        if (type != AP_GPS::GPS_TYPE_UAVCAN &&
+            type != AP_GPS::GPS_TYPE_UAVCAN_RTK_BASE &&
+            type != AP_GPS::GPS_TYPE_UAVCAN_RTK_ROVER) {
+            continue;
+        }
+        found_uavan_type = true;
+   }
+    if (!found_uavan_type) {
+        return true;
+    }
+
+    // lint parameters and detected node IDs:
     for (uint8_t i = 0; i < GPS_MAX_RECEIVERS; i++) {
         const auto &params_i = AP::gps().params[i];
         bool overriden_node_found = false;

--- a/libraries/AP_GPS/AP_GPS_DroneCAN.h
+++ b/libraries/AP_GPS/AP_GPS_DroneCAN.h
@@ -149,6 +149,15 @@ private:
         uint32_t last_send_ms;
         ByteBuffer *buf;
     } _rtcm_stream;
+
+    // returns true if the supplied GPS_Type is a DroneCAN GPS type
+    static bool is_dronecan_gps_type(AP_GPS::GPS_Type type) {
+        return (
+            type == AP_GPS::GPS_TYPE_UAVCAN ||
+            type == AP_GPS::GPS_TYPE_UAVCAN_RTK_BASE ||
+            type == AP_GPS::GPS_TYPE_UAVCAN_RTK_ROVER
+       );
+    }
 };
 
 #endif  // AP_GPS_DRONECAN_ENABLED

--- a/libraries/AP_GPS/AP_GPS_DroneCAN.h
+++ b/libraries/AP_GPS/AP_GPS_DroneCAN.h
@@ -56,7 +56,7 @@ public:
     static void handle_moving_baseline_msg_trampoline(AP_DroneCAN *ap_dronecan, const CanardRxTransfer& transfer, const ardupilot_gnss_MovingBaselineData& msg);
     static void handle_relposheading_msg_trampoline(AP_DroneCAN *ap_dronecan, const CanardRxTransfer& transfer, const ardupilot_gnss_RelPosHeading& msg);
 #endif
-    static bool backends_healthy(char failure_msg[], uint16_t failure_msg_len);
+    static bool inter_instance_pre_arm_checks(char failure_msg[], uint16_t failure_msg_len);
     void inject_data(const uint8_t *data, uint16_t len) override;
 
     bool get_error_codes(uint32_t &error_codes) const override { error_codes = error_code; return seen_status; };


### PR DESCRIPTION
Will allow backends to have their own pre-arm checks.

Rename pre-arm checks to be consistent with our libraries.  Note that the pre-arm check doesn't actually check the backends are healthy, despite the previous name...
