### PR TITLE
Use 64 bit time for PPS interrupt in Ublox driver

### DIFF
--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -1835,7 +1835,7 @@ AP_GPS_UBLOX::_parse_gps(void)
 void
 AP_GPS_UBLOX::pps_interrupt(uint8_t pin, bool high, uint32_t timestamp_us)
 {
-    _last_pps_time_us = timestamp_us;
+    _last_pps_time_us = AP_HAL::micros64();
 }
 
 void


### PR DESCRIPTION
If using 32 bit time for PPS interrupt the corrected time can be set incorrectly after 2^32 microsecond, and cause ublox redetection code to run again and result in Ublox module to drop out after around 1hour and 12 minutes. 