### PR TITLE
set the last_updated_ms field of efi_state

### DIFF
--- a/libraries/AP_EFI/AP_EFI_DroneCAN.cpp
+++ b/libraries/AP_EFI/AP_EFI_DroneCAN.cpp
@@ -151,6 +151,9 @@ void AP_EFI_DroneCAN::handle_status(const uavcan_equipment_ice_reciprocating_Sta
         c.lambda_coefficient = cs.lambda_coefficient;
     }
 
+    // Required for healthy message
+    istate.last_updated_ms = AP_HAL::millis();
+
     copy_to_frontend();
 }
 


### PR DESCRIPTION
The last_update_ms variable was never set in the DroneCAN implementation of the Electronic Fuel Injector sensor. This causes the function `bool AP_EFI::is_healthy` to always return false. Solved by adding one line of code to set the variable to the correct value.