### PR TITLE
Sub: update status to include all failsafes

### DIFF
--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -232,7 +232,18 @@ private:
     } failsafe;
 
     bool any_failsafe_triggered() const {
-        return (failsafe.pilot_input || battery.has_failsafed() || failsafe.gcs || failsafe.ekf || failsafe.terrain);
+        return (
+            failsafe.pilot_input
+            || battery.has_failsafed()
+            || failsafe.gcs
+            || failsafe.ekf
+            || failsafe.terrain
+            || failsafe.leak
+            || failsafe.internal_pressure
+            || failsafe.internal_temperature
+            || failsafe.crash
+            || failsafe.sensor_health
+        );
     }
 
     // sensor health for logging


### PR DESCRIPTION
Found this while looking through the code [for this](https://github.com/ArduPilot/ardupilot/issues/19103#issuecomment-2195818938) - seems like the failsafes list didn't get updated in this function definition.

Rover uses a bitmask for the failsafes (instead of separate variables), which seems like a better approach, but this is at least an improvement for now.

@Williangalvani 