### PR TITLE
Allow full compass calibration with location sources other than GPS

### DIFF
--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -1067,6 +1067,7 @@ bool CompassCalibrator::fix_radius(void)
 {
     Location loc;
     if (!AP::ahrs().get_location(loc) && !AP::ahrs().get_origin(loc)) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "MagCal: No location, fix_radius skipped");
         // we don't have a position, leave scale factor as 0. This
         // will disable use of WMM in the EKF. Users can manually set
         // scale factor after calibration if it is known

--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -1065,14 +1065,14 @@ bool CompassCalibrator::calculate_orientation(void)
  */
 bool CompassCalibrator::fix_radius(void)
 {
-    if (AP::gps().status() < AP_GPS::GPS_OK_FIX_2D) {
+    Location loc;
+    if (!AP::ahrs().get_location(loc) && !AP::ahrs().get_origin(loc)) {
         // we don't have a position, leave scale factor as 0. This
         // will disable use of WMM in the EKF. Users can manually set
         // scale factor after calibration if it is known
         _params.scale_factor = 0;
         return true;
     }
-    const Location &loc = AP::gps().location();
     float intensity;
     float declination;
     float inclination;


### PR DESCRIPTION
Not having a GPS connected currently causes compass calibration to skip the fix_radius step, which prevents using the WMM in the ekf.

I also added a warning so users can know something is wrong.

this is a step towards fix #18229, and is extracted from #26506 