### PR TITLE
AP_Temperature:expand metadata for analog sensors

### DIFF
--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Analog.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Analog.cpp
@@ -26,7 +26,7 @@ const AP_Param::GroupInfo AP_TemperatureSensor_Analog::var_info[] = {
 
     // @Param: PIN
     // @DisplayName: Temperature sensor analog voltage sensing pin
-    // @Description: Sets the analog input pin that should be used for temprature monitoring.
+    // @Description: Sets the analog input pin that should be used for temprature monitoring. Values for some autopilots are given as examples. Search wiki for "Analog pins".
     // @Values: -1:Disabled, 2:Pixhawk/Pixracer/Navio2/Pixhawk2_PM1, 5:Navigator, 13:Pixhawk2_PM2/CubeOrange_PM2, 14:CubeOrange, 16:Durandal, 100:PX4-v1
     // @User: Standard
     AP_GROUPINFO("PIN", 1, AP_TemperatureSensor_Analog, _pin, -1),


### PR DESCRIPTION
NFC....expands metadata which tends to imply only the values listed work