### PR TITLE
AC_AutoTune: make safe shutdown for tradheli when landing in Autotune

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -184,6 +184,8 @@ public:
     // pause and resume a mode
     virtual bool pause() { return false; };
     virtual bool resume() { return false; };
+
+    // handle situations where the vehicle is on the ground waiting for takeoff
     void make_safe_ground_handling(bool force_throttle_unlimited = false);
 
     // true if weathervaning is allowed in the current mode

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -184,6 +184,7 @@ public:
     // pause and resume a mode
     virtual bool pause() { return false; };
     virtual bool resume() { return false; };
+    void make_safe_ground_handling(bool force_throttle_unlimited = false);
 
     // true if weathervaning is allowed in the current mode
 #if WEATHERVANE_ENABLED == ENABLED
@@ -196,7 +197,6 @@ protected:
     bool is_disarmed_or_landed() const;
     void zero_throttle_and_relax_ac(bool spool_up = false);
     void zero_throttle_and_hold_attitude();
-    void make_safe_ground_handling(bool force_throttle_unlimited = false);
 
     // Return stopping point as a location with above origin alt frame
     Location get_stopping_point() const;


### PR DESCRIPTION
This PR fixes a bug in autotune that was documented in issue #27418.  A tradheli user discovered this bug after landing in autotune and as the aircraft rotor system was spooling down, accidentally raised the collective, commanding positive climb rate.  This caused the motor interlock to engage unintentionally and caused the main gear to be stripped.  This would not usually happen in this case but did because of a bad setting for H_RSC_IDLE.  Regardless, this illustrates the possibility for the rotor to spool up once landed.

The fix to this bug is to change the logic so the interlock can never be enabled after landing in autotune.  In fact this PR causes the aircraft to disarm once ground idle is reached.  So this will affect the behavior for multirotors too.  @lthall I wasn't sure what the original intention of keeping the aircraft from disarming after the user lands in autotune as well as allowing the spool state to go throttle unlimited if the user commands a climb rate.