### PR TITLE
AP_InertialSensor: Clearly state the maximum G-force

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_ADIS1647x.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_ADIS1647x.cpp
@@ -137,7 +137,7 @@ bool AP_InertialSensor_ADIS1647x::check_product_id(uint16_t &prod_id)
         // can do up to 40G
         opmode = OpMode::Basic;
         accel_scale = 1.25 * GRAVITY_MSS * 0.001;
-        _clip_limit = 39.5f * GRAVITY_MSS;
+        _clip_limit = (40.0f - 0.5f) * GRAVITY_MSS;
         gyro_scale = radians(0.1);
         expected_sample_rate_hz = 2000;
         return true;
@@ -146,7 +146,7 @@ bool AP_InertialSensor_ADIS1647x::check_product_id(uint16_t &prod_id)
         // can do up to 40G
         opmode = OpMode::Basic;
         accel_scale = 1.25 * GRAVITY_MSS * 0.001;
-        _clip_limit = 39.5f * GRAVITY_MSS;
+        _clip_limit = (40.0f - 0.5f) * GRAVITY_MSS;
         expected_sample_rate_hz = 2000;
         // RANG_MDL register used for gyro range
         uint16_t rang_mdl = read_reg16(REG_RANG_MDL);
@@ -167,11 +167,12 @@ bool AP_InertialSensor_ADIS1647x::check_product_id(uint16_t &prod_id)
     }
         
     case PROD_ID_16507: {
+        // can do up to 40G
         opmode = OpMode::Delta32;
         expected_sample_rate_hz = 1200;
         accel_scale = 392.0 / 2097152000.0;
         dvel_scale = 400.0 / 0x7FFFFFFF;
-        _clip_limit = 39.5f * GRAVITY_MSS;
+        _clip_limit = (40.0f - 0.5f) * GRAVITY_MSS;
         // RANG_MDL register used for gyro range
         uint16_t rang_mdl = read_reg16(REG_RANG_MDL);
         switch ((rang_mdl >> 2) & 3) {

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -139,7 +139,7 @@ protected:
     HAL_Semaphore _sem;
 
     //Default Clip Limit
-    float _clip_limit = 15.5f * GRAVITY_MSS;
+    float _clip_limit = (16.0f - 0.5f) * GRAVITY_MSS;
 
     // instance numbers of accel and gyro data
     uint8_t gyro_instance;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
@@ -1037,7 +1037,7 @@ bool AP_InertialSensor_Invensensev3::hardware_init(void)
     case Invensensev3_Type::ICM42605:
     case Invensensev3_Type::ICM40605:
     case Invensensev3_Type::ICM42670:
-        _clip_limit = 15.5f * GRAVITY_MSS;
+        _clip_limit = (16.0f - 0.5f) * GRAVITY_MSS;
         break;
     }
 


### PR DESCRIPTION
The basis for the clip count thresholds of 39.5G and 15.5G is unclear. 
By explicitly stating it, we can be aware that 0.5G is being subtracted.
