### PR TITLE
AP_Scripting: ignore hidden Lua files

### DIFF
--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -268,8 +268,8 @@ void lua_scripts::load_all_scripts_in_dir(lua_State *L, const char *dirname) {
             continue;
         }
 
-        if (strncmp(&de->d_name[length-4], ".lua", 4)) {
-            // doesn't end in .lua
+        if ((de->d_name[0] == '.') || strncmp(&de->d_name[length-4], ".lua", 4)) {
+            // starts with . (hidden file) or doesn't end in .lua
             continue;
         }
 


### PR DESCRIPTION
On macOS, sometimes ._script.lua is created to store metadata when the user copies script.lua over to their SD card. Previously, the scripting engine would barf since the file is not Lua. Now, these files are ignored.

Also avoids a case where a hidden and valid script might be loaded without the user's knowledge.

Tested on SITL that a hidden file is rejected and non hidden files are still loaded.