### PR TITLE
AP_Scripting: reduce Lua state memory usage

### DIFF
--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -2381,7 +2381,7 @@ void emit_methods(struct userdata *node) {
 }
 
 void emit_enum(struct userdata * data) {
-    fprintf(source, "struct userdata_enum %s_enums[] = {\n", data->sanatized_name);
+    fprintf(source, "const struct userdata_enum %s_enums[] = {\n", data->sanatized_name);
     struct userdata_enum *ud_enum = data->enums;
     while (ud_enum != NULL) {
       fprintf(source, "    {\"%s\", %s::%s},\n", ud_enum->name, data->name, ud_enum->name);

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -2527,16 +2527,11 @@ void emit_loaders(void) {
 
   fprintf(source, "    // singleton metatables\n");
   fprintf(source, "    for (uint32_t i = 0; i < ARRAY_SIZE(singleton_fun); i++) {\n");
+  fprintf(source, "        lua_newuserdata(L, 0);\n");
   fprintf(source, "        luaL_newmetatable(L, singleton_fun[i].name);\n");
   fprintf(source, "        lua_pushcfunction(L, singleton_fun[i].func);\n");
   fprintf(source, "        lua_setfield(L, -2, \"__index\");\n");
-  fprintf(source, "        lua_pushstring(L, \"__call\");\n");
-  fprintf(source, "        lua_pushvalue(L, -2);\n");
-  fprintf(source, "        lua_settable(L, -3);\n");
 
-  fprintf(source, "        lua_pop(L, 1);\n");
-  fprintf(source, "        lua_newuserdata(L, 0);\n");
-  fprintf(source, "        luaL_getmetatable(L, singleton_fun[i].name);\n");
   fprintf(source, "        lua_setmetatable(L, -2);\n");
   fprintf(source, "        lua_setglobal(L, singleton_fun[i].name);\n");
   fprintf(source, "    }\n");

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -2504,46 +2504,31 @@ void emit_loaders(void) {
   fprintf(source, "    // userdata metatables\n");
   fprintf(source, "    for (uint32_t i = 0; i < ARRAY_SIZE(userdata_fun); i++) {\n");
   fprintf(source, "        luaL_newmetatable(L, userdata_fun[i].name);\n");
-  fprintf(source, "        lua_pushcclosure(L, userdata_fun[i].func, 0);\n");
+  fprintf(source, "        lua_pushcfunction(L, userdata_fun[i].func);\n");
   fprintf(source, "        lua_setfield(L, -2, \"__index\");\n");
 
   fprintf(source, "        if (userdata_fun[i].operators != nullptr) {\n");
   fprintf(source, "            luaL_setfuncs(L, userdata_fun[i].operators, 0);\n");
   fprintf(source, "        }\n");
 
-  fprintf(source, "        lua_pushstring(L, \"__call\");\n");
-  fprintf(source, "        lua_pushvalue(L, -2);\n");
-  fprintf(source, "        lua_settable(L, -3);\n");
-
   fprintf(source, "        lua_pop(L, 1);\n");
-  fprintf(source, "        lua_newuserdata(L, 0);\n");
-  fprintf(source, "        luaL_getmetatable(L, userdata_fun[i].name);\n");
-  fprintf(source, "        lua_setmetatable(L, -2);\n");
-  fprintf(source, "        lua_setglobal(L, userdata_fun[i].name);\n");
   fprintf(source, "    }\n");
   fprintf(source, "\n");
 
   fprintf(source, "    // ap object metatables\n");
   fprintf(source, "    for (uint32_t i = 0; i < ARRAY_SIZE(ap_object_fun); i++) {\n");
   fprintf(source, "        luaL_newmetatable(L, ap_object_fun[i].name);\n");
-  fprintf(source, "        lua_pushcclosure(L, ap_object_fun[i].func, 0);\n");
+  fprintf(source, "        lua_pushcfunction(L, ap_object_fun[i].func);\n");
   fprintf(source, "        lua_setfield(L, -2, \"__index\");\n");
-  fprintf(source, "        lua_pushstring(L, \"__call\");\n");
-  fprintf(source, "        lua_pushvalue(L, -2);\n");
-  fprintf(source, "        lua_settable(L, -3);\n");
 
   fprintf(source, "        lua_pop(L, 1);\n");
-  fprintf(source, "        lua_newuserdata(L, 0);\n");
-  fprintf(source, "        luaL_getmetatable(L, ap_object_fun[i].name);\n");
-  fprintf(source, "        lua_setmetatable(L, -2);\n");
-  fprintf(source, "        lua_setglobal(L, ap_object_fun[i].name);\n");
   fprintf(source, "    }\n");
   fprintf(source, "\n");
 
   fprintf(source, "    // singleton metatables\n");
   fprintf(source, "    for (uint32_t i = 0; i < ARRAY_SIZE(singleton_fun); i++) {\n");
   fprintf(source, "        luaL_newmetatable(L, singleton_fun[i].name);\n");
-  fprintf(source, "        lua_pushcclosure(L, singleton_fun[i].func, 0);\n");
+  fprintf(source, "        lua_pushcfunction(L, singleton_fun[i].func);\n");
   fprintf(source, "        lua_setfield(L, -2, \"__index\");\n");
   fprintf(source, "        lua_pushstring(L, \"__call\");\n");
   fprintf(source, "        lua_pushvalue(L, -2);\n");


### PR DESCRIPTION
A few re-engineerings to make the state setup more efficient and on-demand. Please see the commits for details.

There are no visible changes to scripts except for ones that play games reading `_ENV`, which none in the repo do. There might be a slight downside of increased risk of fragmentation and out of memory problems at inopportune moments, but I think the savings are worth it.

Tested some scripts including my REPL in SITL and on Cube Orange.

Total savings on Cube Orange:
* 104 bytes of statically allocated RAM
* 14K of Lua heap memory (reduced by 2/3)
* ~800 bytes per running script
* 216 bytes of flash