### PR TITLE
AP_TECS: Add a separate stall speed parameter used for minimum speed scaling

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -296,6 +296,14 @@ const AP_Param::Info Plane::var_info[] = {
     // @User: Standard
     ASCALAR(airspeed_max, "AIRSPEED_MAX",  AIRSPEED_FBW_MAX),
 
+    // @Param: AIRSPEED_STALL
+    // @DisplayName: Stall airspeed
+    // @Description: If stall prevention is enabled this speed is used to calculate the minimum airspeed while banking. If this is set to 0 then the stall speed is assumed to be the minimum airspeed speed. Typically set slightly higher then true stall speed. Value is as an indicated (calibrated/apparent) airspeed.
+    // @Units: m/s
+    // @Range: 5 75
+    // @User: Standard
+    ASCALAR(airspeed_stall, "AIRSPEED_STALL", 0),
+
     // @Param: FBWB_ELEV_REV
     // @DisplayName: Fly By Wire elevator reverse
     // @Description: Reverse sense of elevator in FBWB and CRUISE modes. When set to 0 up elevator (pulling back on the stick) means to lower altitude. When set to 1, up elevator means to raise altitude.

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -343,6 +343,7 @@ public:
 
         k_param_mixing_offset,
         k_param_dspoiler_rud_rate,
+        k_param_airspeed_stall,
 
         k_param_logger = 253, // Logging Group
 

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -415,7 +415,11 @@ void AP_TECS::_update_speed(float DT)
     if (aparm.stall_prevention) {
         // when stall prevention is active we raise the minimum
         // airspeed based on aerodynamic load factor
-        _TASmin *= _load_factor;
+        if (is_positive(aparm.airspeed_stall)) {
+            _TASmin = MAX(_TASmin, aparm.airspeed_stall*EAS2TAS*_load_factor);
+        } else {
+            _TASmin *= _load_factor;
+        }
     }
 
     if (_TASmax < _TASmin) {

--- a/libraries/AP_Vehicle/AP_FixedWing.h
+++ b/libraries/AP_Vehicle/AP_FixedWing.h
@@ -14,6 +14,7 @@ struct AP_FixedWing {
     AP_Int16 airspeed_min;
     AP_Int16 airspeed_max;
     AP_Float airspeed_cruise;
+    AP_Float airspeed_stall;
     AP_Float min_groundspeed;
     AP_Int8  crash_detection_enable;
     AP_Float roll_limit;


### PR DESCRIPTION
When stall prevention is enabled we were scaling from the aircraft's minimum flight speed. However this is normally already picked as being above the stall speed, and for a variety of reasons we may want to pin the aircraft at a higher minimum speed. But if the aircraft was commanded to fly to close to that minimum speed as soon as it banked for a pattern it would command a increase in speed to keep it away from stalling. However if your minimum speed is far from stalling this increase was incorrect. To make it worse what this actually results in happening is an aircraft diving for more speed (over 10 m/s on some aircraft) as well as descending to gain that speed resulting in over 200 foot deviations in altitude control.

This was found on a real vehicle (in a rather alarming flight), I've recreated the behavior in the sim easily, and tested the patch in the sim. The one question I have is do we want to keep this parameter within TECS which is the only user currently, or should it be moved into the vehicle side just incase we want to do more with it in the future?

If the stall speed isn't configured this will result in no change in behavior.