### PR TITLE
AP_NavEKF3: remove storedRange member variable if rangefinder measure…

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -394,7 +394,9 @@ void NavEKF3_core::InitialiseVariables()
     storedGPS.reset();
     storedBaro.reset();
     storedTAS.reset();
+#if EK3_FEATURE_RANGEFINDER_MEASUREMENTS
     storedRange.reset();
+#endif
     storedOutput.reset();
 #if EK3_FEATURE_BEACON_FUSION
     rngBcn.storedRange.reset();

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1056,7 +1056,9 @@ private:
     EKF_obs_buffer_t<mag_elements> storedMag;      // Magnetometer data buffer
     EKF_obs_buffer_t<baro_elements> storedBaro;    // Baro data buffer
     EKF_obs_buffer_t<tas_elements> storedTAS;      // TAS data buffer
+#if EK3_FEATURE_RANGEFINDER_MEASUREMENTS
     EKF_obs_buffer_t<range_elements> storedRange;  // Range finder data buffer
+#endif
     EKF_IMU_buffer_t<output_elements> storedOutput;// output state buffer
     Matrix3F prevTnb;               // previous nav to body transformation used for INS earth rotation compensation
     ftype accNavMag;                // magnitude of navigation accel - used to adjust GPS obs variance (m/s^2)


### PR DESCRIPTION
…ments disabled

```
Board               blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal            -32    *           -16     -16               -24    -24    -16
KakuteH7-bdshot     -104   *           -112    -104              -104   -112   -112
MatekF405           -72    *           -72     -72               -64    -16    -64
Pixhawk1-1M-bdshot  -96                -96     -88               -88    -24    -88
iomcu                                                *                         
revo-mini           -72    *           -72     -64               -64    -24    -64
```

We do need to come back and clean up these defines.  We should have one define for "do we store rangefinder measurements?" (which we have), but we should also have a "can we directly fuse rangefinder measurements?" and "can we provide rangefinder measurements for optical flow fusion?"

At the moment we essentially only have one define controlling all of these things (`AP_RANGEFINDER_ENABLED`)
