### PR TITLE
AC_WPNav: correct calculation of predict-accel when zeroing pilot desired accel

### DIFF
--- a/libraries/AC_WPNav/AC_Loiter.h
+++ b/libraries/AC_WPNav/AC_Loiter.h
@@ -33,7 +33,9 @@ public:
     Vector2f get_pilot_desired_acceleration() const { return Vector2f{_desired_accel.x, _desired_accel.y}; }
 
     /// clear pilot desired acceleration
-    void clear_pilot_desired_acceleration() { _desired_accel.zero(); }
+    void clear_pilot_desired_acceleration() {
+        set_pilot_desired_acceleration(0, 0);
+    }
 
     /// get vector to stopping point based on a horizontal position and velocity
     void get_stopping_point_xy(Vector2f& stopping_point) const;


### PR DESCRIPTION
This is a (currently failing) test which checks what happens if we re-enter LOITER from AUTO while we are in RC failsafe.

This picture shows that we maintain 1.3m/s in LOITER when in RC failsafe following an auto mission.

![image](https://github.com/ArduPilot/ardupilot/assets/7077857/8a722482-1b3f-4fb1-aec6-2c55bb69229b)

If the set-parameter of `SIM_RC_FAIL` is removed, and the re-setting of the roll input to 1500 is commented back in the test passes (i.e. the vehicle comes to a stop)
