### PR TITLE
Add validation to initialization configuration commands

### DIFF
--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.cpp
@@ -404,7 +404,15 @@ void AP_ExternalAHRS_VectorNav::initialize() {
     // Open port in the thread
     uart->begin(baudrate, 1024, 512);
 
-    hal.util->snprintf(message_to_send, sizeof(message_to_send), "VNWRG,06,0");
+    // Pause asynchronous communications to simplify packet finding
+    hal.util->snprintf(message_to_send, sizeof(message_to_send), "VNASY,0");
+    send_command_blocking();
+
+    // Stop ASCII async outputs for both UARTs. If only active UART is disabled, we get a baudrate
+    // overflow on the other UART when configuring binary outputs (reg 75 and 76) to both UARTs
+    hal.util->snprintf(message_to_send, sizeof(message_to_send), "VNWRG,06,1");
+    send_command_blocking();
+    hal.util->snprintf(message_to_send, sizeof(message_to_send), "VNWRG,06,2");
     send_command_blocking();
 
     // Read Model Number Register, ID 1
@@ -438,6 +446,9 @@ void AP_ExternalAHRS_VectorNav::initialize() {
         send_command_blocking();
     }
 
+    // Resume asynchronous communications
+    hal.util->snprintf(message_to_send, sizeof(message_to_send), "VNASY,1");
+    send_command_blocking();
     setup_complete = true;
 }
 

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.h
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.h
@@ -99,6 +99,7 @@ private:
         bool term_is_checksum;    // current term is the checksum
         bool sentence_valid;      // is current sentence valid so far
         bool sentence_done;       // true if this sentence has already been decoded
+        bool error_response;      // true if received a VNERR response
     } nmea;
 };
 

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.h
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.h
@@ -61,10 +61,12 @@ private:
     void update_thread();
     bool check_uart();
 
+    void initialize();
+
     void process_ins_packet1(const uint8_t *b);
     void process_ins_packet2(const uint8_t *b);
     void process_ahrs_packet(const uint8_t *b);
-    void wait_register_responce(const uint8_t register_num);
+    void send_command_blocking();
 
     uint8_t *pktbuf;
     uint16_t pktoffset;
@@ -83,22 +85,21 @@ private:
 
     bool has_dual_gnss = false;
 
-    char model_name[25];
+    char model_name[20];
 
+    char message_to_send[50];
     // NMEA parsing for setup
     bool decode(char c);
     bool decode_latest_term();
     struct NMEA_parser {
-        char term[25];            // buffer for the current term within the current sentence
+        char term[20];            // buffer for the current term within the current sentence
         uint8_t term_offset;      // offset within the _term buffer where the next character should be placed
         uint8_t term_number;      // term index within the current sentence
         uint8_t checksum;         // checksum accumulator
         bool term_is_checksum;    // current term is the checksum
         bool sentence_valid;      // is current sentence valid so far
         bool sentence_done;       // true if this sentence has already been decoded
-        uint8_t register_number;  // VectorNAV register number were reading
     } nmea;
-
 };
 
 #endif  // AP_EXTERNAL_AHRS_VECTORNAV_ENABLED

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.h
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.h
@@ -66,7 +66,7 @@ private:
     void process_ins_packet1(const uint8_t *b);
     void process_ins_packet2(const uint8_t *b);
     void process_ahrs_packet(const uint8_t *b);
-    void send_command_blocking();
+    void run_command(const char *fmt, ...);
 
     uint8_t *pktbuf;
     uint16_t pktoffset;

--- a/libraries/SITL/SIM_VectorNav.cpp
+++ b/libraries/SITL/SIM_VectorNav.cpp
@@ -213,11 +213,13 @@ void VectorNav::update(void)
         send_packet2();
     }
 
-    // Strictly we should send this in responce to the request
-    // but sending it occasionally acheaves the same thing
-    if (now - last_type_us >= 1000000) {
-        last_type_us = now;
-        nmea_printf("$VNRRG,01,VN-300-SITL");
+    const ssize_t n = read_from_autopilot(&receive_buf[0], ARRAY_SIZE(receive_buf));
+    if (n > 0) {
+        if (strncmp(receive_buf, "$VNRRG,01", 9) == 0) {
+            nmea_printf("$VNRRG,01,VN-300-SITL");
+        } else {
+            nmea_printf("$%s", receive_buf);
+        }
     }
 
 }

--- a/libraries/SITL/SIM_VectorNav.cpp
+++ b/libraries/SITL/SIM_VectorNav.cpp
@@ -213,6 +213,7 @@ void VectorNav::update(void)
         send_packet2();
     }
 
+    char receive_buf[50];
     const ssize_t n = read_from_autopilot(&receive_buf[0], ARRAY_SIZE(receive_buf));
     if (n > 0) {
         if (strncmp(receive_buf, "$VNRRG,01", 9) == 0) {

--- a/libraries/SITL/SIM_VectorNav.h
+++ b/libraries/SITL/SIM_VectorNav.h
@@ -45,8 +45,6 @@ private:
     uint32_t last_pkt2_us;
     uint32_t last_type_us;
 
-    char receive_buf[50];
-
     void send_packet1();
     void send_packet2();
     void nmea_printf(const char *fmt, ...);

--- a/libraries/SITL/SIM_VectorNav.h
+++ b/libraries/SITL/SIM_VectorNav.h
@@ -45,6 +45,8 @@ private:
     uint32_t last_pkt2_us;
     uint32_t last_type_us;
 
+    char receive_buf[50];
+
     void send_packet1();
     void send_packet2();
     void nmea_printf(const char *fmt, ...);


### PR DESCRIPTION
Currently, all configuration commands sent to the VN unit are not validated for a response, leading to difficult-to-diagnose errors when a command doesn't go through or is rejected by the VN. All commands send to the unit (particularly setup commands) should have their acceptance confirmation checked before the driver begins to use the data.