### PR TITLE
build: fixed cygwin build with malloc wrap

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -1021,8 +1021,7 @@ class esp32(Board):
                          '-fno-inline-functions',
                          '-mlongcalls',
                          '-fsingle-precision-constant', # force const vals to be float , not double. so 100.0 means 100.0f 
-                         '-fno-threadsafe-statics',
-                         '-DCYGWIN_BUILD']
+                         '-fno-threadsafe-statics']
         env.CXXFLAGS.remove('-Werror=undef')
         env.CXXFLAGS.remove('-Werror=shadow')
 

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -753,8 +753,10 @@ class sitl(Board):
         ]
 
         # wrap malloc to ensure memory is zeroed
-        # don't do this on MacOS as ld doesn't support --wrap
-        if platform.system() != 'Darwin':
+        if cfg.env.DEST_OS == 'cygwin':
+            # on cygwin we need to wrap _malloc_r instead
+            env.LINKFLAGS += ['-Wl,--wrap,_malloc_r']
+        elif platform.system() != 'Darwin':
             env.LINKFLAGS += ['-Wl,--wrap,malloc']
         
         if cfg.options.enable_sfml:

--- a/libraries/AP_Common/c++.cpp
+++ b/libraries/AP_Common/c++.cpp
@@ -84,8 +84,35 @@ void operator delete[](void * ptr)
     if (ptr) free(ptr);
 }
 
+#ifdef CYGWIN_BUILD
+/*
+  wrapper around malloc to ensure all memory is initialised as zero
+  cygwin needs to wrap _malloc_r
+ */
+#undef _malloc_r
+extern "C" {
+    void *__wrap__malloc_r(_reent *r, size_t size);
+    void *__real__malloc_r(_reent *r, size_t size);
+    void *_malloc_r(_reent *r, size_t size);
+}
+void *__wrap__malloc_r(_reent *r, size_t size)
+{
+    void *ret = __real__malloc_r(r, size);
+    if (ret != nullptr) {
+        memset(ret, 0, size);
+    }
+    return ret;
+}
+void *_malloc_r(_reent *x, size_t size)
+{
+    void *ret = __real__malloc_r(x, size);
+    if (ret != nullptr) {
+        memset(ret, 0, size);
+    }
+    return ret;
+}
 
-#if CONFIG_HAL_BOARD != HAL_BOARD_CHIBIOS
+#elif CONFIG_HAL_BOARD != HAL_BOARD_CHIBIOS
 /*
   wrapper around malloc to ensure all memory is initialised as zero
   ChibiOS has its own wrapper


### PR DESCRIPTION
on Cygwin we need to wrap _malloc_r not malloc
See https://cygwin.com/pipermail/cygwin/2000-July/038916.html
fixes #27197 
