### PR TITLE
AP_Logger: remove short-filename compatability code

### DIFF
--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -367,50 +367,17 @@ void AP_Logger_File::Prep_MinSpace()
 }
 
 /*
-  construct a log file name given a log number. 
-  The number in the log filename will *not* be zero-padded.
-  Note: Caller must free.
- */
-char *AP_Logger_File::_log_file_name_short(const uint16_t log_num) const
-{
-    char *buf = nullptr;
-    if (asprintf(&buf, "%s/%u.BIN", _log_directory, (unsigned)log_num) == -1) {
-        return nullptr;
-    }
-    return buf;
-}
-
-/*
   construct a log file name given a log number.
   The number in the log filename will be zero-padded.
   Note: Caller must free.
  */
-char *AP_Logger_File::_log_file_name_long(const uint16_t log_num) const
+char *AP_Logger_File::_log_file_name(const uint16_t log_num) const
 {
     char *buf = nullptr;
     if (asprintf(&buf, "%s/%08u.BIN", _log_directory, (unsigned)log_num) == -1) {
         return nullptr;
     }
     return buf;
-}
-
-/*
-  return a log filename appropriate for the supplied log_num if a
-  filename exists with the short (not-zero-padded name) then it is the
-  appropirate name, otherwise the long (zero-padded) version is.
-  Note: Caller must free.
- */
-char *AP_Logger_File::_log_file_name(const uint16_t log_num) const
-{
-    char *filename = _log_file_name_short(log_num);
-    if (filename == nullptr) {
-        return nullptr;
-    }
-    if (file_exists(filename)) {
-        return filename;
-    }
-    free(filename);
-    return _log_file_name_long(log_num);
 }
 
 /*

--- a/libraries/AP_Logger/AP_Logger_File.h
+++ b/libraries/AP_Logger/AP_Logger_File.h
@@ -111,8 +111,6 @@ private:
 
     /* construct a file name given a log number. Caller must free. */
     char *_log_file_name(const uint16_t log_num) const;
-    char *_log_file_name_long(const uint16_t log_num) const;
-    char *_log_file_name_short(const uint16_t log_num) const;
     char *_lastlog_file_name() const;
     uint32_t _get_log_size(const uint16_t log_num);
     uint32_t _get_log_time(const uint16_t log_num);


### PR DESCRIPTION
We used to produce files hwih looked like log1.BIN.  We moved to 00000001.BIN instead so things collate.

This code allowed the autopilot to return data from SD cards which had old logs on them.