### PR TITLE
Copter: remove unused #if around rangefinder

### DIFF
--- a/ArduCopter/surface_tracking.cpp
+++ b/ArduCopter/surface_tracking.cpp
@@ -6,7 +6,6 @@
 //   level measured using the range finder.
 void Copter::SurfaceTracking::update_surface_offset()
 {
-#if AP_RANGEFINDER_ENABLED
     // check for timeout
     const uint32_t now_ms = millis();
     const bool timeout = (now_ms - last_update_ms) > SURFACE_TRACKING_TIMEOUT_MS;
@@ -43,10 +42,6 @@ void Copter::SurfaceTracking::update_surface_offset()
             reset_target = true;
         }
     }
-#else
-    copter.pos_control->set_pos_offset_z_cm(0);
-    copter.pos_control->set_pos_offset_target_z_cm(0);
-#endif
 }
 
 


### PR DESCRIPTION
the contents of this entire file are removed when AP_RANGEFINDER_ENABLED is false

```
Board               AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                       *      *           *       *                 *      *      *
Hitec-Airspeed      *                                                                     
KakuteH7-bdshot                *      *           *       *                 *      *      *
MatekF405                      *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot             *                  *       *                 *      *      *
f103-QiotekPeriph   *                                                                     
f303-Universal      *                                                                     
iomcu                                                           *                         
revo-mini                      *      *           *       *                 *      *      *
skyviper-v2450                                    *                                       
```
