### PR TITLE
Tools: fix flaky RngfndQuality test

### DIFF
--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -172,7 +172,6 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
     def RngfndQuality(self):
         """Check lua Range Finder quality information flow"""
         self.context_push()
-        self.context_collect('STATUSTEXT')
 
         ex = None
         try:
@@ -192,6 +191,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
 
             self.reboot_sitl()
 
+            self.context_collect('STATUSTEXT')
             self.wait_statustext(complete_str, timeout=20, check_context=True)
             found_failure = self.statustext_in_collections(failure_str)
 


### PR DESCRIPTION
The RngfndQuality test does an initial check that the reported status of the rangefinder Lua backend is NotConnected. This should be the case after a reboot as the Lua backend has never sent any data. There is a normally harmless race condition between enabling scripting and installing the test script which might cause it to start before the SITL reboot.

Unfortunately, the previous test uses the Lua rangefinder backend, so once it finishes, the status of the backend will be NoData (after the data times out) instead of NotConnected. If the test script does start before the reboot, it will see the leftover NoData and raise a failure.

Don't collect STATUSTEXTs until after the reboot so that a spurious failure is ignored.