### PR TITLE
autotest: reboot after reverting rangefinder settings

### DIFF
--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -382,6 +382,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
 
         self.disarm_vehicle()
         self.context_pop()
+        self.reboot_sitl()  # e.g. revert rangefinder configuration
 
     def SimTerrainMission(self):
         """Mission at a constant height above synthetic sea floor"""
@@ -421,6 +422,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
 
         self.disarm_vehicle()
         self.context_pop()
+        self.reboot_sitl()  # e.g. revert rangefinder configuration
 
     def ModeChanges(self, delta=0.2):
         """Check if alternating between ALTHOLD, STABILIZE, POSHOLD and SURFTRAK (mode 21) affects altitude"""


### PR DESCRIPTION
Co-authored-by: Thomas Watson <twatson52@icloud.com>

Thomas noted that tests prior to RngFndQuality were leaving a LUA rangefinder hanging around in https://github.com/ArduPilot/ardupilot/pull/27484

Thomas' patch fixes RngFndQuality to only collect context messages after a reboot, which will fix the problem.

But tests should *not* leave the vehicle in this state, so this patch fixes that.