### PR TITLE
AP_NavEKF: option to align extnav to optflow pos estimate

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
@@ -135,7 +135,7 @@ const AP_Param::GroupInfo AP_NavEKF_Source::var_info[] = {
     // @Param: _OPTIONS
     // @DisplayName: EKF Source Options
     // @Description: EKF Source Options
-    // @Bitmask: 0:FuseAllVelocities
+    // @Bitmask: 0:FuseAllVelocities, 1:AlignExtNavPosWhenUsingOptFlow
     // @User: Advanced
     AP_GROUPINFO("_OPTIONS", 16, AP_NavEKF_Source, _options, (int16_t)SourceOptions::FUSE_ALL_VELOCITIES),
 
@@ -257,11 +257,12 @@ void AP_NavEKF_Source::align_inactive_sources()
         return;
     }
 
-    // consider aligning XY position:
+    // consider aligning ExtNav XY position:
     bool align_posxy = false;
     if ((getPosXYSource() == SourceXY::GPS) ||
-        (getPosXYSource() == SourceXY::BEACON)) {
-        // only align position if active source is GPS or Beacon
+        (getPosXYSource() == SourceXY::BEACON) ||
+        ((getVelXYSource() == SourceXY::OPTFLOW) && option_is_set(SourceOptions::ALIGN_EXTNAV_POS_WHEN_USING_OPTFLOW))) {
+        // align ExtNav position if active source is GPS, Beacon or (optionally) Optflow
         for (uint8_t i=0; i<AP_NAKEKF_SOURCE_SET_MAX; i++) {
             if (_source_set[i].posxy == SourceXY::EXTNAV) {
                 // ExtNav could potentially be used, so align it

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.h
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.h
@@ -47,7 +47,8 @@ public:
 
     // enum for OPTIONS parameter
     enum class SourceOptions {
-        FUSE_ALL_VELOCITIES = (1 << 0)  // fuse all velocities configured in source sets
+        FUSE_ALL_VELOCITIES = (1 << 0),                 // fuse all velocities configured in source sets
+        ALIGN_EXTNAV_POS_WHEN_USING_OPTFLOW = (1 << 1)  // align position of inactive sources to ahrs when using optical flow
     };
 
     // initialisation
@@ -117,6 +118,9 @@ private:
         AP_Enum<SourceZ>   velz;   // velocity z source
         AP_Enum<SourceYaw> yaw;    // yaw source
     } _source_set[AP_NAKEKF_SOURCE_SET_MAX];
+
+    // helper to check if an option parameter bit has been set
+    bool option_is_set(SourceOptions option) const { return (_options.get() & int16_t(option)) != 0; }
 
     AP_Int16 _options;      // source options bitmask
 


### PR DESCRIPTION
This is a cut-down version of PR https://github.com/ArduPilot/ardupilot/pull/26632

This adds a new EK3_SRC_OPTION bit that allows "re-aligning" the External Nav position to the AHRS when optical flow is used (e.g. when External Nav is not used).  Previously this re-alignment would only occur when using GPS or Beacons that provide an absolute position.

Re-aligning to the optical flow is useful when the ModalAI VOXL cameras (and perhaps other external nav systems) are paired with an optical flow sensor for backup.  It means the pilot should not notice any position jumps when switching between the two sources.

This has been tested on real hardware and below are the before and after screenshots.  During this testing the vehicle was first switched to use Optical Flow, the vehicle was then moved and switched to ExtNav.  The "Before" image shows the position jump which is cause by optical flow drifting a bit compared to the VOXL camera.  In the "After" we see there is no position jump because, while the optical flow was active, the VOXL's position was constantly being shifted to the optical flow based position.

![before-pos-jump](https://github.com/ArduPilot/ardupilot/assets/1498098/db150f1e-86d9-4880-b2c1-a6cdaa9124c1)
![after-no-pos-jump](https://github.com/ArduPilot/ardupilot/assets/1498098/22041916-7f2a-4ba8-9c7d-146bd2408d08)
