### PR TITLE
hwdef: H757_EVAL: make it not-AP_Periph

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/H757I_EVAL/hwdef-bl.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/H757I_EVAL/hwdef-bl.dat
@@ -21,9 +21,6 @@ APJ_BOARD_ID 146
 
 FLASH_SIZE_KB 2048
 
-# setup build for a peripheral firmware
-env AP_PERIPH 1
-
 EXT_FLASH_SIZE_MB 32
 
 # bootloader is installed at zero offset

--- a/libraries/AP_HAL_ChibiOS/hwdef/H757I_EVAL/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/H757I_EVAL/hwdef.dat
@@ -23,9 +23,6 @@ APJ_BOARD_ID 146
 
 FLASH_SIZE_KB 2048
 
-# setup build for a peripheral firmware
-env AP_PERIPH 1
-
 # bootloader is installed at zero offset
 FLASH_RESERVE_START_KB 128
 


### PR DESCRIPTION
avoids this compilation error:

../../Tools/AP_Periph/can.cpp:152:33: error: static assertion failed: DroneCAN bootloader cannot support external flash
  152 | static_assert(EXT_FLASH_SIZE_MB == 0, "DroneCAN bootloader cannot support external flash");
compilation terminated due to -Wfatal-errors.