### PR TITLE
AP_Math: Remove template parameter from constructor

### DIFF
--- a/libraries/AP_Math/matrix3.h
+++ b/libraries/AP_Math/matrix3.h
@@ -55,18 +55,18 @@ public:
 
     // trivial ctor
     // note that the Vector3 ctor will zero the vector elements
-    constexpr Matrix3<T>() {}
+    constexpr Matrix3() {}
 
     // setting ctor
-    constexpr Matrix3<T>(const Vector3<T> &a0, const Vector3<T> &b0, const Vector3<T> &c0)
+    constexpr Matrix3(const Vector3<T> &a0, const Vector3<T> &b0, const Vector3<T> &c0)
         : a(a0)
         , b(b0)
         , c(c0) {}
 
     // setting ctor
-    constexpr Matrix3<T>(const T ax, const T ay, const T az,
-                         const T bx, const T by, const T bz,
-                         const T cx, const T cy, const T cz)
+    constexpr Matrix3(const T ax, const T ay, const T az,
+                      const T bx, const T by, const T bz,
+                      const T cx, const T cy, const T cz)
         : a(ax,ay,az)
         , b(bx,by,bz)
         , c(cx,cy,cz) {}

--- a/libraries/AP_Math/vector2.h
+++ b/libraries/AP_Math/vector2.h
@@ -47,12 +47,12 @@ struct Vector2
     T x, y;
 
     // trivial ctor
-    constexpr Vector2<T>()
+    constexpr Vector2()
         : x(0)
         , y(0) {}
 
     // setting ctor
-    constexpr Vector2<T>(const T x0, const T y0)
+    constexpr Vector2(const T x0, const T y0)
         : x(x0)
         , y(y0) {}
 

--- a/libraries/AP_Math/vector3.h
+++ b/libraries/AP_Math/vector3.h
@@ -76,19 +76,19 @@ public:
     T        x, y, z;
 
     // trivial ctor
-    constexpr Vector3<T>()
+    constexpr Vector3()
         : x(0)
         , y(0)
         , z(0) {}
 
     // setting ctor
-    constexpr Vector3<T>(const T x0, const T y0, const T z0)
+    constexpr Vector3(const T x0, const T y0, const T z0)
         : x(x0)
         , y(y0)
         , z(z0) {}
 
     //Create a Vector3 from a Vector2 with z
-    constexpr Vector3<T>(const Vector2<T> &v0, const T z0)
+    constexpr Vector3(const Vector2<T> &v0, const T z0)
         : x(v0.x)
         , y(v0.y)
         , z(z0) {}

--- a/libraries/AP_Math/vectorN.h
+++ b/libraries/AP_Math/vectorN.h
@@ -35,14 +35,14 @@ class VectorN
 {
 public:
     // trivial ctor
-    inline VectorN<T,N>() {
+    inline VectorN() {
         for (auto i = 0; i < N; i++) {
             _v[i] = T{};
         }
     }
 
     // vector ctor
-    inline VectorN<T,N>(const T *v) {
+    inline VectorN(const T *v) {
         memcpy(_v, v, sizeof(T)*N);
     }
     


### PR DESCRIPTION
Not valid in C++20, and makes GCC 14.1.1 very unhappy.

Without these changes you get the following spammed at you when building, for basically every compilation unit, makes it very very hard to find actual build errors.

```
[  68/1324] Compiling libraries/APM_Control/AP_AutoTune.cpp
In file included from ../../libraries/AP_Math/matrix3.h:42,
                 from ../../libraries/AP_Math/AP_Math.h:13,
                 from ../../libraries/AC_AutoTune/AC_AutoTune_FreqResp.h:7,
                 from ../../libraries/AC_AutoTune/AC_AutoTune_FreqResp.cpp:6:
../../libraries/AP_Math/vector3.h:79:25: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
   79 |     constexpr Vector3<T>()
      |                         ^
../../libraries/AP_Math/vector3.h:79:25: note: remove the ‘< >’
../../libraries/AP_Math/vector3.h:85:25: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
   85 |     constexpr Vector3<T>(const T x0, const T y0, const T z0)
      |                         ^
../../libraries/AP_Math/vector3.h:85:25: note: remove the ‘< >’
../../libraries/AP_Math/vector3.h:91:25: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
   91 |     constexpr Vector3<T>(const Vector2<T> &v0, const T z0)
      |                         ^
../../libraries/AP_Math/vector3.h:91:25: note: remove the ‘< >’
In file included from ../../libraries/AP_Math/matrix3.h:43:
../../libraries/AP_Math/vector2.h:50:25: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
   50 |     constexpr Vector2<T>()
      |                         ^
../../libraries/AP_Math/vector2.h:50:25: note: remove the ‘< >’
../../libraries/AP_Math/vector2.h:55:25: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
   55 |     constexpr Vector2<T>(const T x0, const T y0)
      |                         ^
../../libraries/AP_Math/vector2.h:55:25: note: remove the ‘< >’
../../libraries/AP_Math/matrix3.h:58:25: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
   58 |     constexpr Matrix3<T>() {}
      |                         ^
../../libraries/AP_Math/matrix3.h:58:25: note: remove the ‘< >’
../../libraries/AP_Math/matrix3.h:61:25: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
   61 |     constexpr Matrix3<T>(const Vector3<T> &a0, const Vector3<T> &b0, const Vector3<T> &c0)
      |                         ^
../../libraries/AP_Math/matrix3.h:61:25: note: remove the ‘< >’
../../libraries/AP_Math/matrix3.h:67:25: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
   67 |     constexpr Matrix3<T>(const T ax, const T ay, const T az,
      |                         ^
../../libraries/AP_Math/matrix3.h:67:25: note: remove the ‘< >’
```