### PR TITLE
Use enumerations in CompassCalibrator

### DIFF
--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -473,10 +473,10 @@ bool CompassCalibrator::set_status(CompassCalibrator::Status status)
 
             _status = status;
             return true;
-
-        default:
-            return false;
     };
+
+    // compiler guarantees we don't get here
+    return false;
 }
 
 bool CompassCalibrator::fit_acceptable() const

--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -138,9 +138,21 @@ void CompassCalibrator::new_sample(const Vector3f& sample)
 
 bool CompassCalibrator::failed() {
     WITH_SEMAPHORE(state_sem);
-    return (cal_state.status == Status::FAILED ||
-            cal_state.status == Status::BAD_ORIENTATION || 
-            cal_state.status == Status::BAD_RADIUS);
+    switch (cal_state.status) {
+    case Status::FAILED:
+    case Status::BAD_ORIENTATION:
+    case Status::BAD_RADIUS:
+        return true;
+    case Status::SUCCESS:
+    case Status::NOT_STARTED:
+    case Status::WAITING_TO_START:
+    case Status::RUNNING_STEP_ONE:
+    case Status::RUNNING_STEP_TWO:
+        return false;
+    }
+
+    // compiler guarantees we don't get here
+    return true;
 }
 
 

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -34,7 +34,8 @@ public:
     // update the state machine and calculate offsets, diagonals and offdiagonals
     void update();
 
-    // compass calibration states
+    // compass calibration states - these correspond to the mavlink
+    // MAG_CAL_STATUS enumeration
     enum class Status {
         NOT_STARTED = 0,
         WAITING_TO_START = 1,


### PR DESCRIPTION
forces user to make decisions in these cases.

No size difference on CubeOrange or MatekF405 Plane
