### PR TITLE
Tools: build_options.py: add AP_BARO_PROBE_EXTERNAL_COMPASSES

### DIFF
--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -292,6 +292,7 @@ BUILD_OPTIONS = [
     Feature('Baro', 'ICP101XX', 'AP_BARO_ICP101XX_ENABLED', 'Enable ICP101XX Barometric Sensor', 0, None),
     Feature('Baro', 'ICP201XX', 'AP_BARO_ICP201XX_ENABLED', 'Enable ICP201XX Barometric Sensor', 0, None),
     Feature('Baro', 'BARO_TEMPCAL', 'AP_TEMPCALIBRATION_ENABLED', 'Enable Baro Temperature Calibration', 0, None),
+    Feature('Baro', 'BARO_PROBEXT', 'AP_BARO_PROBE_EXTERNAL_I2C_BUSES', 'Enable Probing of External i2c buses', 0, None),
 
     Feature('Sensors', 'RPM', 'AP_RPM_ENABLED', 'Enable RPM sensors', 0, None),
     Feature('Sensors', 'RPM_EFI', 'AP_RPM_EFI_ENABLED', 'Enable RPM EFI sensors', 0, 'RPM,EFI'),

--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -255,6 +255,7 @@ class ExtractFeatures(object):
             ('AP_OSD_LINK_STATS_EXTENSIONS_ENABLED', r'AP_OSD_Screen::draw_rc_tx_power'),
             ('HAL_ENABLE_DRONECAN_DRIVERS', r'AP_DroneCAN::init'),
             ('AP_MAVLINK_MSG_HIL_GPS_ENABLED', r'mavlink_msg_hil_gps_decode'),
+            ('AP_BARO_PROBE_EXTERNAL_I2C_BUSES', r'AP_Compass::_probe_external_i2c_compasses'),
         ]
 
     def progress(self, msg):


### PR DESCRIPTION
```
###### Enabling BARO_PROBEXT(AP_BARO_PROBE_EXTERNAL_I2C_BUSES) on copter costs -10304 bytes
###### Enabling BARO_PROBEXT(AP_BARO_PROBE_EXTERNAL_I2C_BUSES) on plane costs -10280 bytes
###### Enabling BARO_PROBEXT(AP_BARO_PROBE_EXTERNAL_I2C_BUSES) on rover costs -10280 bytes
###### Enabling BARO_PROBEXT(AP_BARO_PROBE_EXTERNAL_I2C_BUSES) on antennatracker costs -10528 bytes
###### Enabling BARO_PROBEXT(AP_BARO_PROBE_EXTERNAL_I2C_BUSES) on sub costs -10352 bytes
###### Enabling BARO_PROBEXT(AP_BARO_PROBE_EXTERNAL_I2C_BUSES) on blimp costs -10528 bytes
```
