### PR TITLE
AP_GPS: resolve compilation problem with timeval

### DIFF
--- a/libraries/AP_GPS/AP_GPS_SITL.cpp
+++ b/libraries/AP_GPS/AP_GPS_SITL.cpp
@@ -21,6 +21,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <sys/time.h>
 
 extern const AP_HAL::HAL& hal;
 


### PR DESCRIPTION
```
./../libraries/AP_GPS/AP_GPS_SITL.cpp:37:27: error: aggregate 'timeval first_tv' has incomplete type and cannot be defined
    37 |     static struct timeval first_tv;
       |                           ^~~~~~~~
 compilation terminated due to -Wfatal-errors.

 Waf: Leaving directory `/ardupilot/src/build/sitl'
 Build failed
  -> task in 'objs/AP_GPS' failed (exit status 1):
  {task 135805090486368: cxx AP_GPS_SITL.cpp -> AP_GPS_SITL.cpp.0.o}
```

Closes https://github.com/ArduPilot/ardupilot/issues/27227
