### PR TITLE
waf: Revert "waf: use debug option 3 which records defines as well"

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -286,7 +286,7 @@ class Board:
 
         if cfg.env.DEBUG:
             env.CFLAGS += [
-                '-g3',
+                '-g',
                 '-O0',
             ]
             env.DEFINES.update(
@@ -294,7 +294,7 @@ class Board:
             )
         elif cfg.options.debug_symbols:
             env.CFLAGS += [
-                '-g3',
+                '-g',
             ]
         if cfg.env.COVERAGE:
             env.CFLAGS += [


### PR DESCRIPTION
this change made use of gdb so slow it is completely unusable for ArduPilot. Far too many macros, loading gdb takes forever
I don't know exactly how long it does take as I gave up before it finished parsing all the macros