### PR TITLE
Sub: allow setting backup origin parameters for a happier gps-less operation

### DIFF
--- a/ArduSub/AP_Arming_Sub.cpp
+++ b/ArduSub/AP_Arming_Sub.cpp
@@ -149,6 +149,11 @@ bool AP_Arming_Sub::arm(AP_Arming::Method method, bool do_arming_checks)
     // flag exiting this function
     in_arm_motors = false;
 
+    // if we do not have an ekf origin then we can't use the WMM tables
+    if (!sub.ensure_ekf_origin()) {
+        gcs().send_text(MAV_SEVERITY_WARNING, "Compass performance degraded");
+    }
+
     // return success
     return true;
 }

--- a/ArduSub/AP_Arming_Sub.cpp
+++ b/ArduSub/AP_Arming_Sub.cpp
@@ -152,8 +152,11 @@ bool AP_Arming_Sub::arm(AP_Arming::Method method, bool do_arming_checks)
     // if we do not have an ekf origin then we can't use the WMM tables
     if (!sub.ensure_ekf_origin()) {
         gcs().send_text(MAV_SEVERITY_WARNING, "Compass performance degraded");
+        if (check_enabled(ARMING_CHECK_PARAMETERS)) {
+            check_failed(ARMING_CHECK_PARAMETERS, true, "No world position, check ORIGIN_* parameters");
+            return false;
+        }
     }
-
     // return success
     return true;
 }

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -709,14 +709,14 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: ORIGIN_LAT
     // @DisplayName: Backup latitude for EKF origin
     // @Description:  Backup EKF origin latitude used when not using a positioning system.
-    // @Units: degrees
+    // @Units: deg
     // @User: Standard
     AP_GROUPINFO("ORIGIN_LAT", 19, ParametersG2, backup_origin_lat, 0),
 
     // @Param: ORIGIN_LON
     // @DisplayName: Backup longitude for EKF origin
     // @Description:  Backup EKF origin longitude used when not using a positioning system.
-    // @Units: degrees
+    // @Units: deg
     // @User: Standard
     AP_GROUPINFO("ORIGIN_LON", 20, ParametersG2, backup_origin_lon, 0),
 

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -706,7 +706,26 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
 
     // 18 was scripting
 
-    // 19 was airspeed
+    // @Param: ORIGIN_LAT
+    // @DisplayName: Backup latitude for EKF origin
+    // @Description:  Backup EKF origin latitude used when not using a positioning system.
+    // @Units: degrees
+    // @User: Standard
+    AP_GROUPINFO("ORIGIN_LAT", 19, ParametersG2, backup_origin_lat, 0),
+
+    // @Param: ORIGIN_LON
+    // @DisplayName: Backup longitude for EKF origin
+    // @Description:  Backup EKF origin longitude used when not using a positioning system.
+    // @Units: degrees
+    // @User: Standard
+    AP_GROUPINFO("ORIGIN_LON", 20, ParametersG2, backup_origin_lon, 0),
+
+    // @Param: ORIGIN_ALT
+    // @DisplayName: Backup altitude (MSL) for EKF origin
+    // @Description:  Backup EKF origin altitude (MSL) used when not using a positioning system.
+    // @Units: m
+    // @User: Standard
+    AP_GROUPINFO("ORIGIN_ALT", 21, ParametersG2, backup_origin_alt, 0),
 
     AP_GROUPEND
 };

--- a/ArduSub/Parameters.h
+++ b/ArduSub/Parameters.h
@@ -366,6 +366,9 @@ public:
     // control over servo output ranges
     SRV_Channels servo_channels;
 
+    AP_Float backup_origin_lat;
+    AP_Float backup_origin_lon;
+    AP_Float backup_origin_alt;
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -439,6 +439,8 @@ private:
     float get_alt_rel() const WARN_IF_UNUSED;
     float get_alt_msl() const WARN_IF_UNUSED;
     void exit_mission();
+    void set_origin(const Location& loc);
+    bool ensure_ekf_origin();
     bool verify_loiter_unlimited();
     bool verify_loiter_time();
     bool verify_wait_delay();


### PR DESCRIPTION
This change makes it so that, when arming, if no GPS is present and the origin wasn't set some other way (dvl or ugps), we use set a backup origin so we are able to use the WMM table even without position data