### PR TITLE
Tools: autotest: copter: add test for unhealthy pre-arm and failsafe

### DIFF
--- a/libraries/AP_HAL_SITL/AnalogIn.cpp
+++ b/libraries/AP_HAL_SITL/AnalogIn.cpp
@@ -62,7 +62,7 @@ float ADCSource::read_latest() {
 
 bool ADCSource::set_pin(uint8_t pin) {
     _pin = pin;
-    return true;
+    return pin != ANALOG_INPUT_NONE;
 }
 
 void AnalogIn::init() {


### PR DESCRIPTION
This adds a test for the battery unhealthy fail safe added in https://github.com/ArduPilot/ardupilot/pull/27358.

So we can easily make a monitor unhealthy this changes SITL `ADCSource::set_pin` to return false for a pin of value `ANALOG_INPUT_NONE` (-1).