### PR TITLE
AP_HAL_SITL: allow disabling CAN interfaces

### DIFF
--- a/libraries/AP_HAL_SITL/CANSocketIface.cpp
+++ b/libraries/AP_HAL_SITL/CANSocketIface.cpp
@@ -224,6 +224,10 @@ bool CANIface::init(const uint32_t bitrate, const OperatingMode mode)
         transport = NEW_NOTHROW CAN_SocketCAN();
 #endif
         break;
+    case SITL::SIM::CANTransport::None:
+    default: // if user supplies an invalid value for the parameter
+        transport = nullptr;
+        break;
     }
     if (transport == nullptr) {
         return false;

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -133,7 +133,7 @@ const AP_Param::GroupInfo SIM::var_info[] = {
     // @Param: CAN_TYPE1
     // @DisplayName: transport type for first CAN interface
     // @Description: transport type for first CAN interface
-    // @Values: 0:MulticastUDP,1:SocketCAN
+    // @Values: 0:None,1:MulticastUDP,2:SocketCAN
     // @User: Advanced
     AP_GROUPINFO("CAN_TYPE1", 30, SIM,  can_transport[0], uint8_t(CANTransport::MulticastUDP)),
 #endif
@@ -142,7 +142,7 @@ const AP_Param::GroupInfo SIM::var_info[] = {
     // @Param: CAN_TYPE2
     // @DisplayName: transport type for second CAN interface
     // @Description: transport type for second CAN interface
-    // @Values: 0:MulticastUDP,1:SocketCAN
+    // @Values: 0:None,1:MulticastUDP,2:SocketCAN
     // @User: Advanced
     AP_GROUPINFO("CAN_TYPE2", 31, SIM,  can_transport[1], uint8_t(CANTransport::MulticastUDP)),
 #endif

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -229,8 +229,9 @@ public:
 
 #if HAL_NUM_CAN_IFACES
     enum class CANTransport : uint8_t {
-      MulticastUDP = 0,
-      SocketCAN = 1
+      None = 0,
+      MulticastUDP = 1,
+      SocketCAN = 2,
     };
     AP_Enum<CANTransport> can_transport[HAL_NUM_CAN_IFACES];
 #endif


### PR DESCRIPTION
Also corrects an issue where setting an invalid type could result in undefined behavior.

Tested by running two peripherals on two different buses.