### PR TITLE
AP_DroneCAN: fix and clean up DNA server

### DIFF
--- a/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.cpp
@@ -188,8 +188,10 @@ bool AP_DroneCAN_DNA_Server::isValidNodeDataAvailable(uint8_t node_id)
 {
     NodeData node_data;
     readNodeData(node_data, node_id);
+
+    uint8_t empty_hwid[sizeof(NodeData::hwid_hash)] = {0};
     uint8_t crc = crc_crc8(node_data.hwid_hash, sizeof(node_data.hwid_hash));
-    if (crc == node_data.crc && node_data.crc != 0) {
+    if (crc == node_data.crc && memcmp(&node_data.hwid_hash[0], &empty_hwid[0], sizeof(empty_hwid)) != 0) {
         return true;
     }
     return false;

--- a/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.cpp
@@ -217,13 +217,6 @@ bool AP_DroneCAN_DNA_Server::init(uint8_t own_unique_id[], uint8_t own_unique_id
 {
     //Read the details from AP_DroneCAN
     server_state = HEALTHY;
-    /* Go through our records and look for valid NodeData, to initialise
-    occupation mask */
-    for (uint8_t i = 0; i <= MAX_NODE_ID; i++) {
-        if (isValidNodeDataAvailable(i)) {
-            occupation_mask.set(i);
-        }
-    }
 
     // Check if the magic is present
     uint16_t magic;
@@ -239,6 +232,15 @@ bool AP_DroneCAN_DNA_Server::init(uint8_t own_unique_id[], uint8_t own_unique_id
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "UC DNA database reset");
         reset();
     }
+
+    /* Go through our records and look for valid NodeData, to initialise
+    occupation mask */
+    for (uint8_t i = 0; i <= MAX_NODE_ID; i++) {
+        if (isValidNodeDataAvailable(i)) {
+            occupation_mask.set(i);
+        }
+    }
+
     // Making sure that the server is started with the same node ID
     const uint8_t stored_own_node_id = getNodeIDForUniqueID(own_unique_id, own_unique_id_len);
     static bool reset_done;

--- a/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.cpp
@@ -148,10 +148,10 @@ bool AP_DroneCAN_DNA_Server::isNodeIDVerified(uint8_t node_id) const
 
 /* Go through Server Records, and fetch node id that matches the provided
 Unique IDs hash.
-Returns 255 if no Node ID was detected */
+Returns 0 if no Node ID was detected */
 uint8_t AP_DroneCAN_DNA_Server::getNodeIDForUniqueID(const uint8_t unique_id[], uint8_t size)
 {
-    uint8_t node_id = 255;
+    uint8_t node_id = 0;
     NodeData node_data, cmp_node_data;
     getHash(cmp_node_data, unique_id, size);
 
@@ -230,7 +230,7 @@ bool AP_DroneCAN_DNA_Server::init(uint8_t own_unique_id[], uint8_t own_unique_id
     // Making sure that the server is started with the same node ID
     const uint8_t stored_own_node_id = getNodeIDForUniqueID(own_unique_id, own_unique_id_len);
     static bool reset_done;
-    if (stored_own_node_id != 255) {
+    if (stored_own_node_id != 0) {
         if (stored_own_node_id != node_id) {
             /* We have a different node id recorded against our own unique id
             This calls for a reset */
@@ -304,7 +304,7 @@ uint8_t AP_DroneCAN_DNA_Server::findFreeNodeID(uint8_t preferred)
         candidate--;
     }
     // Not found
-    return 255;
+    return 0;
 }
 
 //Check if we have received Node Status from this node_id
@@ -472,7 +472,7 @@ void AP_DroneCAN_DNA_Server::handleNodeInfo(const CanardRxTransfer& transfer, co
         /* Node Id was not allocated by us, or during this boot, let's register this in our records
         Check if we allocated this Node before */
         uint8_t prev_node_id = getNodeIDForUniqueID(rsp.hardware_version.unique_id, 16);
-        if (prev_node_id != 255) {
+        if (prev_node_id != 0) {
             //yes we did, remove this registration
             freeNodeID(prev_node_id);
         }
@@ -545,9 +545,9 @@ void AP_DroneCAN_DNA_Server::handleAllocation(const CanardRxTransfer& transfer, 
     if (rcvd_unique_id_offset == 16) {
         //We have received the full Unique ID, time to do allocation
         uint8_t resp_node_id = getNodeIDForUniqueID((const uint8_t*)rcvd_unique_id, 16);
-        if (resp_node_id == 255) {
+        if (resp_node_id == 0) {
             resp_node_id = findFreeNodeID(msg.node_id > MAX_NODE_ID ? 0 : msg.node_id);
-            if (resp_node_id != 255) {
+            if (resp_node_id != 0) {
                 addNodeIDForUniqueID(resp_node_id, (const uint8_t*)rcvd_unique_id, 16);
                 rsp.node_id = resp_node_id;
             } else {

--- a/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.h
+++ b/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.h
@@ -25,9 +25,7 @@ class AP_DroneCAN_DNA_Server
 
     enum ServerState {
         NODE_STATUS_UNHEALTHY = -5,
-        STORAGE_FAILURE = -3,
         DUPLICATE_NODES = -2,
-        FAILED_TO_ADD_NODE = -1,
         HEALTHY = 0
     };
 
@@ -66,15 +64,15 @@ class AP_DroneCAN_DNA_Server
     void reset();
 
     //Reads the Server Record from storage for specified node id
-    bool readNodeData(NodeData &data, uint8_t node_id);
+    void readNodeData(NodeData &data, uint8_t node_id);
 
     //Writes the Server Record from storage for specified node id
-    bool writeNodeData(const NodeData &data, uint8_t node_id);
+    void writeNodeData(const NodeData &data, uint8_t node_id);
 
     //Methods to set, clear and report NodeIDs allocated/registered so far
-    bool setOccupationMask(uint8_t node_id);
+    void setOccupationMask(uint8_t node_id);
     bool isNodeIDOccupied(uint8_t node_id) const;
-    bool freeNodeID(uint8_t node_id);
+    void freeNodeID(uint8_t node_id);
 
     //Set the mask to report that the unique id matches the record
     void setVerificationMask(uint8_t node_id);
@@ -83,7 +81,7 @@ class AP_DroneCAN_DNA_Server
     uint8_t getNodeIDForUniqueID(const uint8_t unique_id[], uint8_t size);
 
     //Add Node ID info to the record and setup necessary mask fields
-    bool addNodeIDForUniqueID(uint8_t node_id, const uint8_t unique_id[], uint8_t size);
+    void addNodeIDForUniqueID(uint8_t node_id, const uint8_t unique_id[], uint8_t size);
 
     //Finds next available free Node, starting from preferred NodeID
     uint8_t findFreeNodeID(uint8_t preferred);

--- a/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.h
+++ b/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.h
@@ -62,6 +62,9 @@ class AP_DroneCAN_DNA_Server
     //Generates 6Byte long hash from the specified unique_id
     void getHash(NodeData &node_data, const uint8_t unique_id[], uint8_t size) const;
 
+    //Reset the Server Record
+    void reset();
+
     //Reads the Server Record from storage for specified node id
     bool readNodeData(NodeData &data, uint8_t node_id);
 
@@ -112,9 +115,6 @@ public:
 
     //Initialises publisher and Server Record for specified uavcan driver
     bool init(uint8_t own_unique_id[], uint8_t own_unique_id_len, uint8_t node_id);
-
-    //Reset the Server Record
-    void reset();
 
     /* Checks if the node id has been verified against the record
     Specific CAN drivers are expected to check use this method to 

--- a/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.h
+++ b/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.h
@@ -34,11 +34,12 @@ class AP_DroneCAN_DNA_Server
     uint8_t self_node_id;
     bool nodeInfo_resp_rcvd;
 
-    Bitmask<128> occupation_mask;
-    Bitmask<128> verified_mask;
-    Bitmask<128> node_seen_mask;
-    Bitmask<128> logged;
-    Bitmask<128> node_healthy_mask;
+    // bitmasks containing a status for each possible node ID (except 0 and > MAX_NODE_ID)
+    Bitmask<128> node_storage_occupied; // storage has a valid entry
+    Bitmask<128> node_verified; // node seen and unique ID matches stored
+    Bitmask<128> node_seen; // received NodeStatus
+    Bitmask<128> node_logged; // written to log fle
+    Bitmask<128> node_healthy; // reports healthy
 
     uint8_t last_logging_count;
 
@@ -53,10 +54,6 @@ class AP_DroneCAN_DNA_Server
     uint8_t rcvd_unique_id_offset;
     uint32_t last_alloc_msg_ms;
 
-    //Methods to handle and report Node IDs seen on the bus
-    void addToSeenNodeMask(uint8_t node_id);
-    bool isNodeSeen(uint8_t node_id);
-
     //Generates 6Byte long hash from the specified unique_id
     void getHash(NodeData &node_data, const uint8_t unique_id[], uint8_t size) const;
 
@@ -70,12 +67,7 @@ class AP_DroneCAN_DNA_Server
     void writeNodeData(const NodeData &data, uint8_t node_id);
 
     //Methods to set, clear and report NodeIDs allocated/registered so far
-    void setOccupationMask(uint8_t node_id);
-    bool isNodeIDOccupied(uint8_t node_id) const;
     void freeNodeID(uint8_t node_id);
-
-    //Set the mask to report that the unique id matches the record
-    void setVerificationMask(uint8_t node_id);
 
     //Go through List to find node id for specified unique id
     uint8_t getNodeIDForUniqueID(const uint8_t unique_id[], uint8_t size);
@@ -113,12 +105,6 @@ public:
 
     //Initialises publisher and Server Record for specified uavcan driver
     bool init(uint8_t own_unique_id[], uint8_t own_unique_id_len, uint8_t node_id);
-
-    /* Checks if the node id has been verified against the record
-    Specific CAN drivers are expected to check use this method to 
-    verify if the node is healthy and has static node_id against 
-    hwid in the records */
-    bool isNodeIDVerified(uint8_t node_id) const;
 
     /* Subscribe to the messages to be handled for maintaining and allocating
     Node ID list */


### PR DESCRIPTION
Please see commit messages for details.

Fixes the following issues:
* Correctly annotates and validates the node ID parameter set by the user
* Fix various cases where invalid node IDs could be used or stored
* Fixes 1/256 chance where a node's unique ID could not be registered
* Cleans up the code

Does not yet address the elephant in the room of multiple servers using the same storage. That will come next; this all makes that easier.

Tested on SITL and a Cube Orange on the bench using various configurations of AP_Periph nodes. Tested that the DNA database is preserved and that the DroneCAN GUI tool still works properly as well.