### PR TITLE
AP_Notify: Fix building BUG, otherwise u will build fail on the real FC!

### DIFF
--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -305,7 +305,7 @@ void AP_Notify::add_backends(void)
                 ADD_BACKEND(NEW_NOTHROW ExternalLED()); // despite the name this is a built in set of onboard LED's
 #endif
 
-#if AP_NOTIFY_GPIO_LED_RGB_ENABLED
+#ifdef AP_NOTIFY_GPIO_LED_RGB_ENABLED
                 ADD_BACKEND(NEW_NOTHROW PixRacerLED());
 #elif AP_NOTIFY_VRBOARD_LED_ENABLED
                 ADD_BACKEND(NEW_NOTHROW VRBoard_LED());

--- a/libraries/AP_Notify/PixRacerLED.cpp
+++ b/libraries/AP_Notify/PixRacerLED.cpp
@@ -15,7 +15,7 @@
 
 #include "AP_Notify_config.h"
 
-#if AP_NOTIFY_GPIO_LED_RGB_ENABLED
+#ifdef AP_NOTIFY_GPIO_LED_RGB_ENABLED
 
 #include "PixRacerLED.h"
 

--- a/libraries/AP_Notify/PixRacerLED.h
+++ b/libraries/AP_Notify/PixRacerLED.h
@@ -16,7 +16,7 @@
 
 #include "AP_Notify_config.h"
 
-#if AP_NOTIFY_GPIO_LED_RGB_ENABLED
+#ifdef AP_NOTIFY_GPIO_LED_RGB_ENABLED
 
 #include "RGBLed.h"
 


### PR DESCRIPTION
If anyone's hwdef files have these content, will build error.

"
define AP_NOTIFY_GPIO_LED_RGB_ENABLED
define HAL_GPIO_LED_ON 0
define AP_NOTIFY_GPIO_LED_RGB_RED_PIN 90
define AP_NOTIFY_GPIO_LED_RGB_GREEN_PIN 91
define AP_NOTIFY_GPIO_LED_RGB_BLUE_PIN 92
"

So I fixed the problem and can be build  on the real FC successful!