### PR TITLE
Rover: add frame type Omni3Mecanum

### DIFF
--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -523,7 +523,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: FRAME_TYPE
     // @DisplayName: Frame Type
     // @Description: Frame Type
-    // @Values: 0:Undefined,1:Omni3,2:OmniX,3:OmniPlus
+    // @Values: 0:Undefined,1:Omni3,2:OmniX,3:OmniPlus,4:Omni3Mecanum
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("FRAME_TYPE", 24, ParametersG2, frame_type, 0),

--- a/libraries/AR_Motors/AP_MotorsUGV.cpp
+++ b/libraries/AR_Motors/AP_MotorsUGV.cpp
@@ -647,6 +647,13 @@ void AP_MotorsUGV::setup_omni()
         add_omni_motor(2, 0.0f, -1.0f, 1.0f);
         add_omni_motor(3, 1.0f, 0.0f, 0.0f);
         break;
+
+    case FRAME_TYPE_OMNI3MECANUM:
+        _motors_num = 3;
+        add_omni_motor(0,  -1.0f,    1.0f,  -0.26795f);
+        add_omni_motor(1,  0.73205f, 1.0f,  -0.73205f);
+        add_omni_motor(2,  0.26795f, 1.0f,   1.0f);
+        break;
     }
 }
 

--- a/libraries/AR_Motors/AP_MotorsUGV.h
+++ b/libraries/AR_Motors/AP_MotorsUGV.h
@@ -27,6 +27,7 @@ public:
         FRAME_TYPE_OMNI3 = 1,
         FRAME_TYPE_OMNIX = 2,
         FRAME_TYPE_OMNIPLUS = 3,
+        FRAME_TYPE_OMNI3MECANUM = 4,
     };
 
     // initialise motors


### PR DESCRIPTION
Add a frame type to support 3 wheel rovers that use Mecanum wheels. The frame requires different mixing weights to Omni3 to ensure the linear (v_x, v_y) and angular (omega_z) velocities align with the vehicle axes. 

### Testing

Mecanum wheeled rover examples have been added to the Gazebo models in https://github.com/ArduPilot/SITL_Models/pull/139.

_Figure: `rc 3` controls forward and back movement._
![omni3rover_fwd](https://github.com/user-attachments/assets/eff8d482-c979-44eb-b2f7-d1848f4cd282)

_Figure: `rc 4` controls lateral movement._
![omni3rover_lat](https://github.com/user-attachments/assets/c3a40b82-bc6d-43ed-bb69-6b36d4899985)

_Figure: `rc 1` controls yaw._
![omni3rover_yaw](https://github.com/user-attachments/assets/45f1389e-847a-4f24-ab5d-1d7e643c4ad1)

### References

The weights are determined using the approach to derive the inverse kinematics described in A. Gfrerrer. _"Geometry and kinematics of the Mecanum wheel"_, Computer Aided Geometric Design 25 (2008) 784–791. Retrieved from https://www.geometrie.tugraz.at/gfrerrer/publications/MecanumWheel.pdf.
