### PR TITLE
Add SITL support for skid-steering boat

### DIFF
--- a/Tools/autotest/pysim/vehicleinfo.py
+++ b/Tools/autotest/pysim/vehicleinfo.py
@@ -407,6 +407,12 @@ class VehicleInfo(object):
                 "default_params_filename": ["default_params/rover.parm",
                                             "default_params/motorboat.parm"],
             },
+            "motorboat-skid": {
+                "waf_target": "bin/ardurover",
+                "default_params_filename": ["default_params/rover.parm",
+                                            "default_params/motorboat.parm",
+                                            "default_params/rover-skid.parm"],
+            },
             "sailboat": {
                 "waf_target": "bin/ardurover",
                 "default_params_filename": ["default_params/rover.parm",

--- a/libraries/SITL/SIM_Sailboat.h
+++ b/libraries/SITL/SIM_Sailboat.h
@@ -41,6 +41,7 @@ public:
 
 protected:
     bool motor_connected;       // true if this frame has a motor
+    bool skid_steering;         // true if this vehicle is a skid-steering vehicle
     float sail_area; // 1.0 for normal area
 
 private:


### PR DESCRIPTION
Adding a SITL model for a skid-steering motorboat, as we don't currently have one in the built-in simulator.

Makes it easier to debug pivot turns, etc for boats.

Use ``sim_vehicle.py --vehicle=Rover --frame=motorboat-skid`` to use it

