### PR TITLE
AP_Camera: proper string formatting

### DIFF
--- a/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.cpp
+++ b/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.cpp
@@ -141,7 +141,7 @@ void AP_Camera_MAVLinkCamV2::handle_message(mavlink_channel_t chan, const mavlin
         const uint8_t fw_ver_build = (_cam_info.firmware_version & 0xFF000000) >> 24;
 
         // display camera info to user
-        gcs().send_text(MAV_SEVERITY_INFO, "Camera: %s.32 %s.32 fw:%u.%u.%u.%u",
+        gcs().send_text(MAV_SEVERITY_INFO, "Camera: %.32s %.32s fw:%u.%u.%u.%u",
                 _cam_info.vendor_name,
                 _cam_info.model_name,
                 (unsigned)fw_ver_major,


### PR DESCRIPTION
I believe the original code was a typo, because `.32` as a string doesn't make sense (and it did confuse me for a long time). It was probably meant as a safeguard against a full 32 byte string situation where the mavlink library would not add a terminator. Without this fix a camera advertising such a name would cause a buffer overflow.