### PR TITLE
AP_HAL_SITL: If HAL_CAN_WITH_SOCKETCAN is undefined, treat it as NONE

### DIFF
--- a/libraries/AP_HAL_SITL/CANSocketIface.cpp
+++ b/libraries/AP_HAL_SITL/CANSocketIface.cpp
@@ -219,11 +219,11 @@ bool CANIface::init(const uint32_t bitrate, const OperatingMode mode)
     case SITL::SIM::CANTransport::MulticastUDP:
         transport = NEW_NOTHROW CAN_Multicast();
         break;
-    case SITL::SIM::CANTransport::SocketCAN:
 #if HAL_CAN_WITH_SOCKETCAN
+    case SITL::SIM::CANTransport::SocketCAN:
         transport = NEW_NOTHROW CAN_SocketCAN();
-#endif
         break;
+#endif
     case SITL::SIM::CANTransport::None:
     default: // if user supplies an invalid value for the parameter
         transport = nullptr;


### PR DESCRIPTION
If HAL_CAN_WITH_SOCKETCAN is undefined, set transport to NULLPTR instead of leaving it undefined.
When undefined, treat it the same as NONE, and set it to NULLPTR.