### PR TITLE
AP_Mount: Topotek image tracking fix

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Topotek.h
+++ b/libraries/AP_Mount/AP_Mount_Topotek.h
@@ -27,7 +27,7 @@
 #include <AP_Common/AP_Common.h>
 
 #define AP_MOUNT_TOPOTEK_PACKETLEN_MAX              36          // maximum number of bytes in a packet sent to or received from the gimbal
-#define AP_MOUNT_RECV_GIMBAL_CMD_CATEGORIES_NUM     6           // parse the number of gimbal command types
+#define AP_MOUNT_RECV_GIMBAL_CMD_CATEGORIES_NUM     7           // parse the number of gimbal command types
 
 class AP_Mount_Topotek : public AP_Mount_Backend_Serial
 {
@@ -168,6 +168,9 @@ private:
     // request gimbal version
     void request_gimbal_version();
 
+    // request gimbal model name
+    void request_gimbal_model_name();
+
     // send angle target in radians to gimbal
     void send_angle_target(const MountTarget& angle_rad);
 
@@ -194,6 +197,9 @@ private:
 
     // gimbal basic information analysis
     void gimbal_version_analyse();
+
+    // gimbal model name message analysis
+    void gimbal_model_name_analyse();
 
     // gimbal distance information analysis
     void gimbal_dist_info_analyse();
@@ -229,8 +235,10 @@ private:
     bool _sdcard_status;                                        // memory card status (received from gimbal)
     bool _last_lock;                                            // last lock mode sent to gimbal
     bool _got_gimbal_version;                                   // true if gimbal's version has been received
+    bool _got_gimbal_model_name;                                // true if gimbal's model name has been received
     bool _last_zoom_stop;                                       // true if zoom has been stopped (used to re-send in order to handle lost packets)
     bool _last_focus_stop;                                      // true if focus has been stopped (used to re-sent in order to handle lost packets)
+    uint8_t _model_name[16];                                    // gimbal model name
     uint8_t _sent_time_count;                                   // count of current time messages sent to gimbal
     uint32_t _firmware_ver;                                     // firmware version
     Vector3f _current_angle_rad;                                // current angles in radians received from gimbal (x=roll, y=pitch, z=yaw)
@@ -260,6 +268,7 @@ private:
         {{"LRF"}, &AP_Mount_Topotek::gimbal_dist_info_analyse},
         {{"TRC"}, &AP_Mount_Topotek::gimbal_track_analyse},
         {{"VSN"}, &AP_Mount_Topotek::gimbal_version_analyse},
+        {{"PA2"}, &AP_Mount_Topotek::gimbal_model_name_analyse}
     };
 };
 

--- a/libraries/AP_Mount/AP_Mount_Topotek.h
+++ b/libraries/AP_Mount/AP_Mount_Topotek.h
@@ -147,6 +147,13 @@ private:
         WAITING_FOR_CRC_HIGH,
     };
 
+    // tracking status
+    enum class TrackingStatus : uint8_t {
+        STOPPED_TRACKING = 0x30,                // not tracking
+        WAITING_FOR_TRACKING = 0x31,            // wait to track command status
+        TRACKING_IN_PROGRESS = 0x32             // the status is being tracked.
+    };
+
     // identifier bytes
     typedef char Identifier[3];
 
@@ -230,7 +237,7 @@ private:
     // members
     bool _recording;                                            // recording status (received from gimbal)
     bool _is_tracking;                                          // whether to enable the tracking state
-    uint8_t _last_tracking_state;                               // last tracking state received from gimbal
+    TrackingStatus _last_tracking_state = TrackingStatus::STOPPED_TRACKING; // last tracking state received from gimbal
     uint8_t _last_mode;                                         // mode during latest update, used to detect mode changes and cancel tracking
     bool _sdcard_status;                                        // memory card status (received from gimbal)
     bool _last_lock;                                            // last lock mode sent to gimbal


### PR DESCRIPTION
This replaces PR https://github.com/ArduPilot/ardupilot/pull/26666

This PR adds 3 enhancements to the Topotek driver:

1. versions can be returned by the gimbal in "1.2.3" format (previously it was only "123"
2. gimbal's model name is retrieve
3. image tracking status is improved to handle gimbals that do not have this feature

This has been lightly tested on a real gimbal but we need to clear up these issues:

1. the model name appears as "000000000"
2. I don't really understand the new tracking state "waiting" and how the driver should decide what state to put the gimbal into
