### PR TITLE
Filter: LowPass: use `calc_lowpass_alpha_dt` in `apply` and prefix all class varables with `_`

### DIFF
--- a/libraries/Filter/LowPassFilter.h
+++ b/libraries/Filter/LowPassFilter.h
@@ -59,18 +59,18 @@ public:
     CLASS_NO_COPY(DigitalLPF);
 
     void compute_alpha(float sample_freq, float cutoff_freq);
-    
+
     // get latest filtered value from filter (equal to the value returned by latest call to apply method)
     const T &get() const;
     void reset(T value);
     void reset() {
-        initialised = false;
+        _initialised = false;
     }
 
 private:
     T _output;
-    float alpha = 1.0f;
-    bool initialised;
+    float _alpha = 1.0f;
+    bool _initialised;
 };
 
 // LPF base class


### PR DESCRIPTION
A small simplification to our base low pass filter. It now uses `calc_lowpass_alpha_dt` and `apply` so the existing code is reused rather than being re-implemented. 

There are some changes in behavior in the invalid dt/cutoff_freq cases. Previously the local copy of alpha was not updated where as it now is. This should not matter because the two apply methods should not be used together. 


**Future work**
I would like to split the filter in to two classes one for each of the methods outlined here:

https://github.com/ArduPilot/ardupilot/blob/5a54d9a2ecbff9a32d26aa7feee72f0056a01027/libraries/Filter/LowPassFilter.h#L25-L39

The two methods should not be mixed, so separate classes will ensure that. 

Then I would like to add a filter class which includes the cutoff frequency parameter since that is a very common usecase. 
