### PR TITLE
AP_InertialSensor: Check the gyro/accel id has not been previously registered

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -736,6 +736,14 @@ bool AP_InertialSensor::register_gyro(uint8_t &instance, uint16_t raw_sample_rat
         return false;
     }
 
+    // Loop over the existing instances and check if the instance already exists
+    for (uint8_t instance_to_check = 0; instance_to_check < _gyro_count; instance_to_check++) {
+        if ((uint32_t)_gyro_id(instance_to_check) == id) {
+            // if it does, then bail
+            return false;
+        }
+    }
+
     _gyro_raw_sample_rates[_gyro_count] = raw_sample_rate_hz;
     _gyro_over_sampling[_gyro_count] = 1;
     _gyro_raw_sampling_multiplier[_gyro_count] = INT16_MAX/radians(2000);
@@ -794,6 +802,14 @@ bool AP_InertialSensor::register_accel(uint8_t &instance, uint16_t raw_sample_ra
     if (_accel_count == INS_MAX_INSTANCES) {
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Failed to register accel id %u", unsigned(id));
         return false;
+    }
+
+    // Loop over the existing instances and check if the instance already exists
+    for (uint8_t instance_to_check = 0; instance_to_check < _accel_count; instance_to_check++) {
+        if ((uint32_t)_accel_id(instance_to_check) == id) {
+            // if it does, then bail
+            return false;
+        }
     }
 
     _accel_raw_sample_rates[_accel_count] = raw_sample_rate_hz;


### PR DESCRIPTION
Discovered on CubeOrangePlus BG3 in a production environment.

On the very first boot of the CubeOrangePlus-BG3 after a parameter wipe, 4 IMU instances are registered. These register under the Parameters with the IDs:
* INS_ACC_ID       3867682
* INS_ACC2_ID      3867938
* INS_ACC3_ID      3867658 **<< This appears to be a legitimate ICM45686 discovered with CHECK_ICM45686_EXT in CHECK_IMU2_PRESENT**
* INS4_ACC_ID      3867658 **<< NOTICE DUPLICATE OF INS_ACC3_ID - This is added when AUX:3867658 is processed**

On subsequent boots, it appears the macro `ADD_BACKEND_AUX` filters the AUX IMU so it is never probed or registered in the first place.

The problem arises if you take the BG3 out of the box, flash AP and go straight into an accelcal on the first boot. Since IMU4 is registered, it calibrates for IMU4 as well. The next reboot then fails pre-arm check requiring 3D Accel Calibration (even though it's already been performed, because now IMU4 is not present).

I've tested this on CubeOrangePlus BG _**and**_ BG3 - and all the IMUs I expect to be present are present with this change in place.

Disclosure: I do not fully understand how AUX IMUs are intended to work, I couldn't find a relevant wiki page - as such this may not be the appropriate fix, but it seems to address the experienced issue.