### PR TITLE
VectorNav: Reorganize message packets

### DIFF
--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.cpp
@@ -16,6 +16,7 @@
   support for serial connected AHRS systems
  */
 
+#include <cstdint>
 #define ALLOW_DOUBLE_MATH_FUNCTIONS
 
 #include "AP_ExternalAHRS_config.h"
@@ -38,136 +39,138 @@
 
 extern const AP_HAL::HAL &hal;
 
+
 /*
-  header for 50Hz INS data
-  assumes the following config for VN-300:
-    $VNWRG,75,3,8,34,072E,0106,0612*0C
-
-    0x34: Groups 3,5,6
-    Group 3 (IMU):
-        0x072E:
-            UncompMag
-            UncompAccel
-            UncompGyro
-            Pres
-            Mag
-            Accel
-            AngularRate
-    Group 5 (Attitude):
-        0x0106:
-            YawPitchRoll
-            Quaternion
-            YprU
-    Group 6 (INS):
-        0x0612:
-            PosLLa
-            VelNed
-            PosU
-            VelU
-
+TYPE::VN_AHRS configures 2 packets: high-rate IMU and mid-rate EKF
+Header for IMU packet
+    $VNWRG,75,3,16,01,0721*D415
+    Common group (Group 1)
+        TimeStartup
+        AngularRate
+        Accel
+        Imu
+        MagPres
+Header for EKF packet
+    $VNWRG,76,3,16,11,0001,0106*B36B
+    Common group (Group 1)
+        TimeStartup
+    Attitude group (Group 4)
+        Ypr
+        Quaternion
+        YprU
 */
-static const uint8_t vn_ins_pkt1_header[] { 0x34, 0x2E, 0x07, 0x06, 0x01, 0x12, 0x06 };
-#define VN_INS_PKT1_LENGTH 170 // includes header and CRC
 
-struct PACKED VN_INS_packet1 {
-    float uncompMag[3];
+struct PACKED VN_IMU_packet {
+    static constexpr uint8_t header[]{0x01, 0x21, 0x07};
+    uint64_t timeStartup;
+    float gyro[3];
+    float accel[3];
     float uncompAccel[3];
     float uncompAngRate[3];
-    float pressure;
     float mag[3];
-    float accel[3];
-    float gyro[3];
+    float temp;
+    float pressure;
+};
+constexpr uint8_t VN_IMU_packet::header[];
+constexpr uint8_t VN_IMU_LENGTH = sizeof(VN_IMU_packet) + sizeof(VN_IMU_packet::header) + 1 + 2; // Includes sync byte and CRC
+
+struct PACKED VN_AHRS_ekf_packet {
+    static constexpr uint8_t header[]{0x11, 0x01, 0x00, 0x06, 0x01};
+    uint64_t timeStartup;
     float ypr[3];
     float quaternion[4];
     float yprU[3];
-    double positionLLA[3];
-    float velNED[3];
+};
+constexpr uint8_t VN_AHRS_ekf_packet::header[];
+constexpr uint8_t VN_AHRS_EKF_LENGTH = sizeof(VN_AHRS_ekf_packet) + sizeof(VN_AHRS_ekf_packet::header) + 1 + 2; // Includes sync byte and CRC
+
+/*
+TYPE::VN_INS configures 3 packets: high-rate IMU, mid-rate EKF, and 5Hz GNSS
+Header for IMU packet
+    $VNWRG,75,3,16,01,0721*D415
+    Common group (Group 1)
+        TimeStartup
+        AngularRate
+        Accel
+        Imu
+        MagPres
+Header for EKF packet
+    $VNWRG,76,3,16,31,0001,0106,0613*097A
+    Common group (Group 1)
+        TimeStartup
+    Attitude group (Group 4)
+        Ypr
+        Quaternion
+        YprU
+    Ins group (Group 5)
+        InsStatus
+        PosLla
+        VelNed
+        PosU
+        VelU
+Header for GNSS packet
+    $VNWRG,77,1,160,49,0003,26B8,0018*4FD9
+    Common group (Group 1)
+        TimeStartup
+        TimeGps
+    Gnss1 group (Group 3)
+        NumSats
+        GnssFix
+        GnssPosLla
+        GnssVelNed
+        PosU1
+        VelU1
+        GnssDop
+    Gnss2 group (Group 6)
+        NumSats
+        GnssFix
+*/
+
+union Ins_Status {
+    uint16_t _value;
+    struct {
+        uint16_t mode : 2;
+        uint16_t gnssFix : 1;
+        uint16_t resv1 : 2;
+        uint16_t imuErr : 1;
+        uint16_t magPresErr : 1;
+        uint16_t gnssErr : 1;
+        uint16_t resv2 : 1;
+        uint16_t gnssHeadingIns : 2;
+    };
+};
+
+struct PACKED VN_INS_ekf_packet {
+    static constexpr uint8_t header[]{0x31, 0x01, 0x00, 0x06, 0x01, 0x13, 0x06};
+    uint64_t timeStartup;
+    float ypr[3];
+    float quaternion[4];
+    float yprU[3];
+    uint16_t insStatus;
+    double posLla[3];
+    float velNed[3];
     float posU;
     float velU;
 };
+constexpr uint8_t VN_INS_ekf_packet::header[];
+constexpr uint8_t VN_INS_EKF_LENGTH = sizeof(VN_INS_ekf_packet) + sizeof(VN_INS_ekf_packet::header) + 1 + 2; // Includes sync byte and CRC
 
-// check packet size for 4 groups
-static_assert(sizeof(VN_INS_packet1)+2+3*2+2 == VN_INS_PKT1_LENGTH, "incorrect VN_INS_packet1 length");
-
-/*
-  header for 5Hz GNSS data
-  assumes the following VN-300 config:
-    $VNWRG,76,3,80,4E,0002,0010,20B8,0018*63
-
-    0x4E: Groups 2,3,4,7
-    Group 2 (Time):
-        0x0002:
-            TimeGps
-    Group 3 (IMU):
-        0x0010:
-            Temp
-    Group 4 (GPS1):
-        0x20B8:
-            NumSats
-            Fix
-            PosLLa
-            VelNed
-            DOP
-    Group 7 (GPS2):
-        0x0018:
-            NumSats
-            Fix
-*/
-static const uint8_t vn_ins_pkt2_header[] { 0x4e, 0x02, 0x00, 0x10, 0x00, 0xb8, 0x20, 0x18, 0x00 };
-#define VN_INS_PKT2_LENGTH 92 // includes header and CRC
-
-struct PACKED VN_INS_packet2 {
-    uint64_t timeGPS;
-    float temp;
-    uint8_t numGPS1Sats;
-    uint8_t GPS1Fix;
-    double GPS1posLLA[3];
-    float GPS1velNED[3];
-    float GPS1DOP[7];
-    uint8_t numGPS2Sats;
-    uint8_t GPS2Fix;
+struct PACKED VN_INS_gnss_packet {
+    static constexpr uint8_t header[]{0x49, 0x03, 0x00, 0xB8, 0x26, 0x18, 0x00};
+    uint64_t timeStartup;
+    uint64_t timeGps;
+    uint8_t numSats1;
+    uint8_t fix1;
+    double posLla1[3];
+    float velNed1[3];
+    float posU1[3];
+    float velU1;
+    float dop1[7];
+    uint8_t numSats2;
+    uint8_t fix2;
 };
-
-// check packet size for 4 groups
-static_assert(sizeof(VN_INS_packet2)+2+4*2+2 == VN_INS_PKT2_LENGTH, "incorrect VN_INS_packet2 length");
-
-/*
-header for 50Hz IMU data, used in TYPE::VN_AHRS only 
-  assumes the following VN-100 config:
-    $VNWRG,75,3,80,14,073E,0004*66
-
-  Alternate first packet for VN-100
-    0x14: Groups 3, 5
-        Group 3 (IMU):
-            0x073E:
-                UncompMag
-                UncompAccel
-                UncompGyro
-                Temp
-                Pres
-                Mag
-                Accel
-                Gyro
-        Group 5 (Attitude):
-            0x0004:
-                Quaternion
-*/
-static const uint8_t vn_ahrs_pkt1_header[] { 0x14, 0x3E, 0x07, 0x04, 0x00 };
-#define VN_AHRS_PKT1_LENGTH 104 // includes header and CRC
-
-struct PACKED VN_AHRS_packet1 {
-    float uncompMag[3];
-    float uncompAccel[3];
-    float uncompAngRate[3];
-    float temp;
-    float pressure;
-    float mag[3];
-    float accel[3];
-    float gyro[3];
-    float quaternion[4];
-};
-
-static_assert(sizeof(VN_AHRS_packet1)+2+2*2+2 == VN_AHRS_PKT1_LENGTH, "incorrect VN_AHRS_packet1 length");
+constexpr uint8_t VN_INS_gnss_packet::header[];
+constexpr uint8_t VN_INS_GNSS_LENGTH = sizeof(VN_INS_gnss_packet) + sizeof(VN_INS_gnss_packet::header) + 1 + 2; // Includes sync byte and CRC
 
 // constructor
 AP_ExternalAHRS_VectorNav::AP_ExternalAHRS_VectorNav(AP_ExternalAHRS *_frontend,
@@ -183,12 +186,13 @@ AP_ExternalAHRS_VectorNav::AP_ExternalAHRS_VectorNav(AP_ExternalAHRS *_frontend,
     baudrate = sm.find_baudrate(AP_SerialManager::SerialProtocol_AHRS, 0);
     port_num = sm.find_portnum(AP_SerialManager::SerialProtocol_AHRS, 0);
 
-    bufsize = MAX(MAX(VN_INS_PKT1_LENGTH, VN_INS_PKT2_LENGTH), VN_AHRS_PKT1_LENGTH);
-    pktbuf = NEW_NOTHROW uint8_t[bufsize];
-    last_ins_pkt1 = NEW_NOTHROW VN_INS_packet1;
-    last_ins_pkt2 = NEW_NOTHROW VN_INS_packet2;
+    bufsize = MAX(MAX(MAX(VN_IMU_LENGTH, VN_INS_EKF_LENGTH), VN_INS_GNSS_LENGTH), VN_AHRS_EKF_LENGTH);
 
-    if (!pktbuf || !last_ins_pkt1 || !last_ins_pkt2) {
+    pktbuf = NEW_NOTHROW uint8_t[bufsize];
+    latest_ins_ekf_packet = NEW_NOTHROW VN_INS_ekf_packet;
+    latest_ins_gnss_packet = NEW_NOTHROW VN_INS_gnss_packet;
+
+    if (!pktbuf || !latest_ins_ekf_packet) {
         AP_BoardConfig::allocation_error("VectorNav ExternalAHRS");
     }
 
@@ -226,48 +230,57 @@ bool AP_ExternalAHRS_VectorNav::check_uart()
     bool match_header1 = false;
     bool match_header2 = false;
     bool match_header3 = false;
+    bool match_header4 = false;
 
     if (pktbuf[0] != SYNC_BYTE) {
         goto reset;
     }
 
-    if (type == TYPE::VN_INS) {
-        match_header1 = (0 == memcmp(&pktbuf[1], vn_ins_pkt1_header, MIN(sizeof(vn_ins_pkt1_header), unsigned(pktoffset-1))));
-        match_header2 = (0 == memcmp(&pktbuf[1], vn_ins_pkt2_header, MIN(sizeof(vn_ins_pkt2_header), unsigned(pktoffset-1))));
+
+    match_header1 = (0 == memcmp(&pktbuf[1], VN_IMU_packet::header,  MIN(sizeof(VN_IMU_packet::header), unsigned(pktoffset - 1))));
+    if (type == TYPE::VN_AHRS) {
+        match_header2 = (0 == memcmp(&pktbuf[1], VN_AHRS_ekf_packet::header, MIN(sizeof(VN_AHRS_ekf_packet::header), unsigned(pktoffset - 1))));
     } else {
-        match_header3 = (0 == memcmp(&pktbuf[1], vn_ahrs_pkt1_header, MIN(sizeof(vn_ahrs_pkt1_header), unsigned(pktoffset-1))));
+        match_header3 = (0 == memcmp(&pktbuf[1], VN_INS_ekf_packet::header,  MIN(sizeof(VN_INS_ekf_packet::header), unsigned(pktoffset - 1))));
+        match_header4 = (0 == memcmp(&pktbuf[1], VN_INS_gnss_packet::header, MIN(sizeof(VN_INS_gnss_packet::header), unsigned(pktoffset - 1))));
     }
-    if (!match_header1 && !match_header2 && !match_header3) {
+    if (!match_header1 && !match_header2 && !match_header3 && !match_header4) {
         goto reset;
     }
 
-    if (match_header1 && pktoffset >= VN_INS_PKT1_LENGTH) {
-        uint16_t crc = crc16_ccitt(&pktbuf[1], VN_INS_PKT1_LENGTH-1, 0);
+    if (match_header1 && pktoffset >= VN_IMU_LENGTH) {
+        uint16_t crc = crc16_ccitt(&pktbuf[1], VN_IMU_LENGTH - 1, 0);
         if (crc == 0) {
-            // got pkt1
-            process_ins_packet1(&pktbuf[sizeof(vn_ins_pkt1_header)+1]);
-            memmove(&pktbuf[0], &pktbuf[VN_INS_PKT1_LENGTH], pktoffset-VN_INS_PKT1_LENGTH);
-            pktoffset -= VN_INS_PKT1_LENGTH;
+            process_imu_packet(&pktbuf[sizeof(VN_IMU_packet::header) + 1]);
+            memmove(&pktbuf[0], &pktbuf[VN_IMU_LENGTH], pktoffset - VN_IMU_LENGTH);
+            pktoffset -= VN_IMU_LENGTH;
         } else {
             goto reset;
         }
-    } else if (match_header2 && pktoffset >= VN_INS_PKT2_LENGTH) {
-        uint16_t crc = crc16_ccitt(&pktbuf[1], VN_INS_PKT2_LENGTH-1, 0);
+    } else if (match_header2 && pktoffset >= VN_AHRS_EKF_LENGTH) {
+        uint16_t crc = crc16_ccitt(&pktbuf[1], VN_AHRS_EKF_LENGTH - 1, 0);
         if (crc == 0) {
-            // got pkt2
-            process_ins_packet2(&pktbuf[sizeof(vn_ins_pkt2_header)+1]);
-            memmove(&pktbuf[0], &pktbuf[VN_INS_PKT2_LENGTH], pktoffset-VN_INS_PKT2_LENGTH);
-            pktoffset -= VN_INS_PKT2_LENGTH;
+            process_ahrs_ekf_packet(&pktbuf[sizeof(VN_AHRS_ekf_packet::header) + 1]);
+            memmove(&pktbuf[0], &pktbuf[VN_AHRS_EKF_LENGTH], pktoffset - VN_AHRS_EKF_LENGTH);
+            pktoffset -= VN_AHRS_EKF_LENGTH;
         } else {
             goto reset;
         }
-    } else if (match_header3 && pktoffset >= VN_AHRS_PKT1_LENGTH) {
-        uint16_t crc = crc16_ccitt(&pktbuf[1], VN_AHRS_PKT1_LENGTH-1, 0);
+    } else if (match_header3 && pktoffset >= VN_INS_EKF_LENGTH) {
+        uint16_t crc = crc16_ccitt(&pktbuf[1], VN_INS_EKF_LENGTH - 1, 0);
         if (crc == 0) {
-            // got AHRS pkt
-            process_ahrs_packet(&pktbuf[sizeof(vn_ahrs_pkt1_header)+1]);
-            memmove(&pktbuf[0], &pktbuf[VN_AHRS_PKT1_LENGTH], pktoffset-VN_AHRS_PKT1_LENGTH);
-            pktoffset -= VN_AHRS_PKT1_LENGTH;
+            process_ins_ekf_packet(&pktbuf[sizeof(VN_INS_ekf_packet::header) + 1]);
+            memmove(&pktbuf[0], &pktbuf[VN_INS_EKF_LENGTH], pktoffset - VN_INS_EKF_LENGTH);
+            pktoffset -= VN_INS_EKF_LENGTH;
+        } else {
+            goto reset;
+        }
+    } else if (match_header4 && pktoffset >= VN_INS_GNSS_LENGTH) {
+        uint16_t crc = crc16_ccitt(&pktbuf[1], VN_INS_GNSS_LENGTH - 1, 0);
+        if (crc == 0) {
+            process_ins_gnss_packet(&pktbuf[sizeof(VN_INS_gnss_packet::header) + 1]);
+            memmove(&pktbuf[0], &pktbuf[VN_INS_GNSS_LENGTH], pktoffset - VN_INS_GNSS_LENGTH);
+            pktoffset -= VN_INS_GNSS_LENGTH;
         } else {
             goto reset;
         }
@@ -431,8 +444,9 @@ void AP_ExternalAHRS_VectorNav::initialize() {
         // VN-1X0
         type = TYPE::VN_AHRS;
 
-        // This assumes unit is still configured at its default rate of 800hz
-        run_command("VNWRG,75,3,%u,14,073E,0004", unsigned(800 / get_rate()));
+        // These assumes unit is still configured at its default rate of 800hz
+        run_command("VNWRG,75,3,%u,01,0721", unsigned(800 / get_rate()));
+        run_command("VNWRG,76,3,16,11,0001,0106");
     } else {
         // Default to setup for sensors other than VN-100 or VN-110
         // This assumes unit is still configured at its default IMU rate of 400hz for VN-300, 800hz for others
@@ -443,8 +457,9 @@ void AP_ExternalAHRS_VectorNav::initialize() {
         if (strncmp(model_name, "VN-3", 4) == 0) {
             has_dual_gnss = true;
         }
-        run_command("VNWRG,75,3,%u,34,072E,0106,0612", unsigned(imu_rate / get_rate()));
-        run_command("VNWRG,76,3,%u,4E,0002,0010,20B8,0018", unsigned(imu_rate / 5));
+        run_command("VNWRG,75,3,%u,01,0721", unsigned(imu_rate / get_rate()));
+        run_command("VNWRG,76,3,%u,31,0001,0106,0613", unsigned(imu_rate / 50));
+        run_command("VNWRG,77,3,%u,49,0003,26B8,0018", unsigned(imu_rate / 5));
     }
 
     // Resume asynchronous communications
@@ -469,129 +484,10 @@ const char* AP_ExternalAHRS_VectorNav::get_name() const
     return nullptr;
 }
 
-/*
-  process INS mode INS packet
- */
-void AP_ExternalAHRS_VectorNav::process_ins_packet1(const uint8_t *b)
+// process INS mode INS packet
+void AP_ExternalAHRS_VectorNav::process_imu_packet(const uint8_t *b)
 {
-    const struct VN_INS_packet1 &pkt1 = *(struct VN_INS_packet1 *)b;
-    const struct VN_INS_packet2 &pkt2 = *last_ins_pkt2;
-
-    last_pkt1_ms = AP_HAL::millis();
-    *last_ins_pkt1 = pkt1;
-
-    const bool use_uncomp = option_is_set(AP_ExternalAHRS::OPTIONS::VN_UNCOMP_IMU);
-
-    {
-        WITH_SEMAPHORE(state.sem);
-        if (use_uncomp) {
-            state.accel = Vector3f{pkt1.uncompAccel[0], pkt1.uncompAccel[1], pkt1.uncompAccel[2]};
-            state.gyro = Vector3f{pkt1.uncompAngRate[0], pkt1.uncompAngRate[1], pkt1.uncompAngRate[2]};
-        } else {
-            state.accel = Vector3f{pkt1.accel[0], pkt1.accel[1], pkt1.accel[2]};
-            state.gyro = Vector3f{pkt1.gyro[0], pkt1.gyro[1], pkt1.gyro[2]};
-        }
-
-        state.quat = Quaternion{pkt1.quaternion[3], pkt1.quaternion[0], pkt1.quaternion[1], pkt1.quaternion[2]};
-        state.have_quaternion = true;
-
-        state.velocity = Vector3f{pkt1.velNED[0], pkt1.velNED[1], pkt1.velNED[2]};
-        state.have_velocity = true;
-
-        state.location = Location{int32_t(pkt1.positionLLA[0] * 1.0e7),
-                                  int32_t(pkt1.positionLLA[1] * 1.0e7),
-                                  int32_t(pkt1.positionLLA[2] * 1.0e2),
-                                  Location::AltFrame::ABSOLUTE};
-        state.last_location_update_us = AP_HAL::micros();
-        state.have_location = true;
-    }
-
-#if AP_BARO_EXTERNALAHRS_ENABLED
-    {
-        AP_ExternalAHRS::baro_data_message_t baro;
-        baro.instance = 0;
-        baro.pressure_pa = pkt1.pressure*1e3;
-        baro.temperature = pkt2.temp;
-
-        AP::baro().handle_external(baro);
-    }
-#endif
-
-#if AP_COMPASS_EXTERNALAHRS_ENABLED
-    {
-        AP_ExternalAHRS::mag_data_message_t mag;
-        mag.field = Vector3f{pkt1.mag[0], pkt1.mag[1], pkt1.mag[2]};
-        mag.field *= 1000; // to mGauss
-
-        AP::compass().handle_external(mag);
-    }
-#endif
-
-    {
-        AP_ExternalAHRS::ins_data_message_t ins;
-
-        ins.accel = state.accel;
-        ins.gyro = state.gyro;
-        ins.temperature = pkt2.temp;
-
-        AP::ins().handle_external(ins);
-    }
-}
-
-/*
-  process INS mode GNSS packet
- */
-void AP_ExternalAHRS_VectorNav::process_ins_packet2(const uint8_t *b)
-{
-    const struct VN_INS_packet2 &pkt2 = *(struct VN_INS_packet2 *)b;
-    const struct VN_INS_packet1 &pkt1 = *last_ins_pkt1;
-
-    last_pkt2_ms = AP_HAL::millis();
-    *last_ins_pkt2 = pkt2;
-
-    AP_ExternalAHRS::gps_data_message_t gps;
-
-    // get ToW in milliseconds
-    gps.gps_week = pkt2.timeGPS / (AP_MSEC_PER_WEEK * 1000000ULL);
-    gps.ms_tow = (pkt2.timeGPS / 1000000ULL) % (60*60*24*7*1000ULL);
-    gps.fix_type = pkt2.GPS1Fix;
-    gps.satellites_in_view = pkt2.numGPS1Sats;
-
-    gps.horizontal_pos_accuracy = pkt1.posU;
-    gps.vertical_pos_accuracy = pkt1.posU;
-    gps.horizontal_vel_accuracy = pkt1.velU;
-
-    gps.hdop = pkt2.GPS1DOP[4];
-    gps.vdop = pkt2.GPS1DOP[3];
-
-    gps.latitude = pkt2.GPS1posLLA[0] * 1.0e7;
-    gps.longitude = pkt2.GPS1posLLA[1] * 1.0e7;
-    gps.msl_altitude = pkt2.GPS1posLLA[2] * 1.0e2;
-
-    gps.ned_vel_north = pkt2.GPS1velNED[0];
-    gps.ned_vel_east = pkt2.GPS1velNED[1];
-    gps.ned_vel_down = pkt2.GPS1velNED[2];
-
-    if (gps.fix_type >= 3 && !state.have_origin) {
-        WITH_SEMAPHORE(state.sem);
-        state.origin = Location{int32_t(pkt2.GPS1posLLA[0] * 1.0e7),
-                                int32_t(pkt2.GPS1posLLA[1] * 1.0e7),
-                                int32_t(pkt2.GPS1posLLA[2] * 1.0e2),
-                                Location::AltFrame::ABSOLUTE};
-        state.have_origin = true;
-    }
-    uint8_t instance;
-    if (AP::gps().get_first_external_instance(instance)) {
-        AP::gps().handle_external(gps, instance);
-    }
-}
-
-/*
-  process AHRS mode AHRS packet
- */
-void AP_ExternalAHRS_VectorNav::process_ahrs_packet(const uint8_t *b)
-{
-    const struct VN_AHRS_packet1 &pkt = *(struct VN_AHRS_packet1 *)b;
+    const struct VN_IMU_packet &pkt = *(struct VN_IMU_packet *)b;
 
     last_pkt1_ms = AP_HAL::millis();
 
@@ -606,16 +502,13 @@ void AP_ExternalAHRS_VectorNav::process_ahrs_packet(const uint8_t *b)
             state.accel = Vector3f{pkt.accel[0], pkt.accel[1], pkt.accel[2]};
             state.gyro = Vector3f{pkt.gyro[0], pkt.gyro[1], pkt.gyro[2]};
         }
-
-        state.quat = Quaternion{pkt.quaternion[3], pkt.quaternion[0], pkt.quaternion[1], pkt.quaternion[2]};
-        state.have_quaternion = true;
     }
 
 #if AP_BARO_EXTERNALAHRS_ENABLED
     {
         AP_ExternalAHRS::baro_data_message_t baro;
         baro.instance = 0;
-        baro.pressure_pa = pkt.pressure*1e3;
+        baro.pressure_pa = pkt.pressure * 1e3;
         baro.temperature = pkt.temp;
 
         AP::baro().handle_external(baro);
@@ -625,11 +518,7 @@ void AP_ExternalAHRS_VectorNav::process_ahrs_packet(const uint8_t *b)
 #if AP_COMPASS_EXTERNALAHRS_ENABLED
     {
         AP_ExternalAHRS::mag_data_message_t mag;
-        if (use_uncomp) {
-            mag.field = Vector3f{pkt.uncompMag[0], pkt.uncompMag[1], pkt.uncompMag[2]};
-        } else {
-            mag.field = Vector3f{pkt.mag[0], pkt.mag[1], pkt.mag[2]};
-        }
+        mag.field = Vector3f{pkt.mag[0], pkt.mag[1], pkt.mag[2]};
         mag.field *= 1000; // to mGauss
 
         AP::compass().handle_external(mag);
@@ -647,8 +536,8 @@ void AP_ExternalAHRS_VectorNav::process_ahrs_packet(const uint8_t *b)
     }
 
 #if HAL_LOGGING_ENABLED
-    // @LoggerMessage: EAH3
-    // @Description: External AHRS data
+    // @LoggerMessage: EAHI
+    // @Description: External AHRS IMU data
     // @Field: TimeUS: Time since system startup
     // @Field: Temp: Temprature
     // @Field: Pres: Pressure
@@ -661,25 +550,160 @@ void AP_ExternalAHRS_VectorNav::process_ahrs_packet(const uint8_t *b)
     // @Field: GX: Rotation rate X-axis
     // @Field: GY: Rotation rate Y-axis
     // @Field: GZ: Rotation rate Z-axis
-    // @Field: Q1: Attitude quaternion 1
-    // @Field: Q2: Attitude quaternion 2
-    // @Field: Q3: Attitude quaternion 3
-    // @Field: Q4: Attitude quaternion 4
 
-    AP::logger().WriteStreaming("EAH3", "TimeUS,Temp,Pres,MX,MY,MZ,AX,AY,AZ,GX,GY,GZ,Q1,Q2,Q3,Q4",
-                       "sdPGGGoooEEE----", "F000000000000000",
-                       "Qfffffffffffffff",
+    AP::logger().WriteStreaming("EAHIM", "TimeUS,Temp,Pres,MX,MY,MZ,AX,AY,AZ,GX,GY,GZ",
+                       "sdPGGGoooEEE", "F00000000000",
+                       "Qfffffffffff",
                        AP_HAL::micros64(),
                        pkt.temp, pkt.pressure*1e3,
-                       use_uncomp ? pkt.uncompMag[0] : pkt.mag[0],
-                       use_uncomp ? pkt.uncompMag[1] : pkt.mag[1], 
-                       use_uncomp ? pkt.uncompMag[2] : pkt.mag[2],
+                       pkt.mag[0], pkt.mag[1], pkt.mag[2],
                        state.accel[0], state.accel[1], state.accel[2],
                        state.gyro[0], state.gyro[1], state.gyro[2],
                        state.quat[0], state.quat[1], state.quat[2], state.quat[3]);
 #endif  // HAL_LOGGING_ENABLED
 }
 
+// process AHRS mode AHRS packet
+void AP_ExternalAHRS_VectorNav::process_ahrs_ekf_packet(const uint8_t *b) {
+    const struct VN_AHRS_ekf_packet &pkt = *(struct VN_AHRS_ekf_packet *)b;
+
+    last_pkt2_ms = AP_HAL::millis();
+
+    state.quat = Quaternion{pkt.quaternion[3], pkt.quaternion[0], pkt.quaternion[1], pkt.quaternion[2]};
+    state.have_quaternion = true;
+
+#if HAL_LOGGING_ENABLED
+    // @LoggerMessage: EAHA
+    // @Description: External AHRS Attitude data
+    // @Field: TimeUS: Time since system startup
+    // @Field: Q1: Attitude quaternion 1
+    // @Field: Q2: Attitude quaternion 2
+    // @Field: Q3: Attitude quaternion 3
+    // @Field: Q4: Attitude quaternion 4
+    // @Field: Yaw: Yaw
+    // @Field: Pitch: Pitch
+    // @Field: Roll: Roll
+    // @Field: YU: Yaw unceratainty
+    // @Field: PU: Pitch uncertainty
+    // @Field: RU: Roll uncertainty
+
+    AP::logger().WriteStreaming("EAHAT", "TimeUS,Q1,Q2,Q3,Q4,Yaw,Pitch,Roll,YU,PU,RU",
+                       "s----dddddd", "F0000000000",
+                       "Qffffffffff",
+                       AP_HAL::micros64(),
+                       state.quat[0], state.quat[1], state.quat[2], state.quat[3],
+                       pkt.ypr[0], pkt.ypr[1], pkt.ypr[2], 
+                       pkt.yprU[0], pkt.yprU[1], pkt.yprU[2]);
+#endif  // HAL_LOGGING_ENABLED
+}
+
+// process INS mode EKF packet
+void AP_ExternalAHRS_VectorNav::process_ins_ekf_packet(const uint8_t *b) {
+    const struct VN_INS_ekf_packet &pkt = *(struct VN_INS_ekf_packet *)b;
+
+    last_pkt2_ms          = AP_HAL::millis();
+    latest_ins_ekf_packet = &pkt;
+
+    state.quat = Quaternion{pkt.quaternion[3], pkt.quaternion[0], pkt.quaternion[1], pkt.quaternion[2]};
+    state.have_quaternion = true;
+
+    state.velocity      = Vector3f{pkt.velNed[0], pkt.velNed[1], pkt.velNed[2]};
+    state.have_velocity = true;
+
+    state.location = Location{int32_t(pkt.posLla[0] * 1.0e7), int32_t(pkt.posLla[1] * 1.0e7), int32_t(pkt.posLla[2] * 1.0e2), Location::AltFrame::ABSOLUTE};
+    state.last_location_update_us = AP_HAL::micros();
+    state.have_location           = true;
+
+#if HAL_LOGGING_ENABLED
+    auto now = AP_HAL::micros64();
+
+    // @LoggerMessage: EAHA
+    // @Description: External AHRS Attitude data
+    // @Field: TimeUS: Time since system startup
+    // @Field: Q1: Attitude quaternion 1
+    // @Field: Q2: Attitude quaternion 2
+    // @Field: Q3: Attitude quaternion 3
+    // @Field: Q4: Attitude quaternion 4
+    // @Field: Yaw: Yaw
+    // @Field: Pitch: Pitch
+    // @Field: Roll: Roll
+    // @Field: YU: Yaw unceratainty
+    // @Field: PU: Pitch uncertainty
+    // @Field: RU: Roll uncertainty
+
+    AP::logger().WriteStreaming("EAHAT", "TimeUS,Q1,Q2,Q3,Q4,Yaw,Pitch,Roll,YU,PU,RU",
+                       "s----dddddd", "F0000000000",
+                       "Qffffffffff",
+                       now,
+                       state.quat[0], state.quat[1], state.quat[2], state.quat[3],
+                       pkt.ypr[0], pkt.ypr[1], pkt.ypr[2], 
+                       pkt.yprU[0], pkt.yprU[1], pkt.yprU[2]);
+
+    // @LoggerMessage: EAHK
+    // @Description: External AHRS INS Kalman Filter data
+    // @Field: TimeUS: Time since system startup
+    // @Field: InsStatus: VectorNav INS health status
+    // @Field: Lat: Latitude
+    // @Field: Lon: Longitude
+    // @Field: Alt: Altitude
+    // @Field: VelN: Velocity Northing
+    // @Field: VelE: Velocity Easting
+    // @Field: VelD: Velocity Downing
+    // @Field: PosU: Filter estimated position uncertainty
+    // @Field: VelU: Filter estimated Velocity uncertainty
+
+    AP::logger().WriteStreaming("EAHKF", "TimeUS,InsStatus,Lat,Lon,Alt,VelN,VelE,VelD,PosU,VelU",
+                       "s-ddmnnndn", "F00000000",
+                       "QHdddfffff",
+                       now,
+                       pkt.insStatus,
+                       pkt.posLla[0], pkt.posLla[1], pkt.posLla[2],
+                       pkt.velNed[0], pkt.velNed[1], pkt.velNed[2],
+                       pkt.posU, pkt.velU);
+#endif  // HAL_LOGGING_ENABLED
+}
+
+// process INS mode GNSS packet
+void AP_ExternalAHRS_VectorNav::process_ins_gnss_packet(const uint8_t *b) {
+    const struct VN_INS_gnss_packet &pkt = *(struct VN_INS_gnss_packet *)b;
+    AP_ExternalAHRS::gps_data_message_t gps;
+
+
+    last_pkt3_ms          = AP_HAL::millis();
+    latest_ins_gnss_packet = &pkt;
+    
+    // get ToW in milliseconds
+    gps.gps_week           = pkt.timeGps / (AP_MSEC_PER_WEEK * 1000000ULL);
+    gps.ms_tow             = (pkt.timeGps / 1000000ULL) % (60 * 60 * 24 * 7 * 1000ULL);
+    gps.fix_type           = pkt.fix1;
+    gps.satellites_in_view = pkt.numSats1;
+
+    gps.horizontal_pos_accuracy = pkt.posU1[0];
+    gps.vertical_pos_accuracy   = pkt.posU1[2];
+    gps.horizontal_vel_accuracy = pkt.velU1;
+
+    gps.hdop = pkt.dop1[4];
+    gps.vdop = pkt.dop1[3];
+
+    gps.latitude     = pkt.posLla1[0] * 1.0e7;
+    gps.longitude    = pkt.posLla1[1] * 1.0e7;
+    gps.msl_altitude = pkt.posLla1[2] * 1.0e2;
+
+    gps.ned_vel_north = pkt.velNed1[0];
+    gps.ned_vel_east  = pkt.velNed1[1];
+    gps.ned_vel_down  = pkt.velNed1[2];
+
+    if (!state.have_origin && gps.fix_type >= 3) {
+        WITH_SEMAPHORE(state.sem);
+        state.origin = Location{int32_t(pkt.posLla1[0] * 1.0e7), int32_t(pkt.posLla1[1] * 1.0e7),
+                                int32_t(pkt.posLla1[2] * 1.0e2), Location::AltFrame::ABSOLUTE};
+        state.have_origin = true;
+    }
+    uint8_t instance;
+    if (AP::gps().get_first_external_instance(instance)) {
+        AP::gps().handle_external(gps, instance);
+    }
+}
 
 // get serial port number for the uart
 int8_t AP_ExternalAHRS_VectorNav::get_port(void) const
@@ -694,10 +718,7 @@ int8_t AP_ExternalAHRS_VectorNav::get_port(void) const
 bool AP_ExternalAHRS_VectorNav::healthy(void) const
 {
     const uint32_t now = AP_HAL::millis();
-    if (type == TYPE::VN_AHRS) {
-        return (now - last_pkt1_ms < 40);
-    }
-    return (now - last_pkt1_ms < 40 && now - last_pkt2_ms < 500);
+    return (now - last_pkt1_ms < 40) && (now - last_pkt2_ms < 500) && (type == TYPE::VN_AHRS ? true: now - last_pkt3_ms < 1000);
 }
 
 bool AP_ExternalAHRS_VectorNav::initialised(void) const
@@ -705,10 +726,7 @@ bool AP_ExternalAHRS_VectorNav::initialised(void) const
     if (!setup_complete) {
         return false;
     }
-    if (type == TYPE::VN_AHRS) {
-        return last_pkt1_ms != 0;
-    }
-    return last_pkt1_ms != 0 && last_pkt2_ms != 0;
+    return last_pkt1_ms != UINT32_MAX && last_pkt2_ms != UINT32_MAX && (type == TYPE::VN_AHRS ? true : last_pkt3_ms != UINT32_MAX);
 }
 
 bool AP_ExternalAHRS_VectorNav::pre_arm_check(char *failure_msg, uint8_t failure_msg_len) const
@@ -722,11 +740,11 @@ bool AP_ExternalAHRS_VectorNav::pre_arm_check(char *failure_msg, uint8_t failure
         return false;
     }
     if (type == TYPE::VN_INS) {
-        if (last_ins_pkt2->GPS1Fix < 3) {
+        if (latest_ins_gnss_packet->fix1 < 3) {
             hal.util->snprintf(failure_msg, failure_msg_len, "VectorNav no GPS1 lock");
             return false;
         }
-        if (has_dual_gnss && (last_ins_pkt2->GPS2Fix < 3)) {
+        if (has_dual_gnss && (latest_ins_gnss_packet->fix2 < 3)) {
             hal.util->snprintf(failure_msg, failure_msg_len, "VectorNav no GPS2 lock");
             return false;
         }
@@ -741,29 +759,23 @@ bool AP_ExternalAHRS_VectorNav::pre_arm_check(char *failure_msg, uint8_t failure
 void AP_ExternalAHRS_VectorNav::get_filter_status(nav_filter_status &status) const
 {
     memset(&status, 0, sizeof(status));
-    if (type == TYPE::VN_INS) {
-        if (last_ins_pkt1 && last_ins_pkt2) {
-            status.flags.initalized = true;
-        }
-        if (healthy() && last_ins_pkt2) {
+    status.flags.initalized = initialised();
+    if (healthy()) {
+        if (type == TYPE::VN_AHRS) {
             status.flags.attitude = true;
-            status.flags.vert_vel = true;
-            status.flags.vert_pos = true;
+        } else {
+            status.flags.attitude = true;
+            if (latest_ins_ekf_packet) {
+                status.flags.vert_vel = true;
+                status.flags.vert_pos = true;
 
-            const struct VN_INS_packet2 &pkt2 = *last_ins_pkt2;
-            if (pkt2.GPS1Fix >= 3) {
-                status.flags.horiz_vel = true;
-                status.flags.horiz_pos_rel = true;
-                status.flags.horiz_pos_abs = true;
+                status.flags.horiz_vel          = true;
+                status.flags.horiz_pos_rel      = true;
+                status.flags.horiz_pos_abs      = true;
                 status.flags.pred_horiz_pos_rel = true;
                 status.flags.pred_horiz_pos_abs = true;
-                status.flags.using_gps = true;
+                status.flags.using_gps          = true;
             }
-        }
-    } else {
-        status.flags.initalized = initialised();
-        if (healthy()) {
-            status.flags.attitude = true;
         }
     }
 }
@@ -771,7 +783,7 @@ void AP_ExternalAHRS_VectorNav::get_filter_status(nav_filter_status &status) con
 // send an EKF_STATUS message to GCS
 void AP_ExternalAHRS_VectorNav::send_status_report(GCS_MAVLINK &link) const
 {
-    if (!last_ins_pkt1) {
+    if (!latest_ins_ekf_packet) {
         return;
     }
     // prepare flags
@@ -813,13 +825,13 @@ void AP_ExternalAHRS_VectorNav::send_status_report(GCS_MAVLINK &link) const
     }
 
     // send message
-    const struct VN_INS_packet1 &pkt1 = *(struct VN_INS_packet1 *)last_ins_pkt1;
+    const struct VN_INS_ekf_packet &pkt = *(struct VN_INS_ekf_packet *)latest_ins_ekf_packet;
     const float vel_gate = 5;
     const float pos_gate = 5;
     const float hgt_gate = 5;
     const float mag_var = 0;
     mavlink_msg_ekf_status_report_send(link.get_chan(), flags,
-                                       pkt1.velU/vel_gate, pkt1.posU/pos_gate, pkt1.posU/hgt_gate,
+                                       pkt.velU / vel_gate, pkt.posU / pos_gate, pkt.posU / hgt_gate,
                                        mag_var, 0, 0);
 }
 

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.cpp
@@ -551,7 +551,7 @@ void AP_ExternalAHRS_VectorNav::process_imu_packet(const uint8_t *b)
     // @Field: GY: Rotation rate Y-axis
     // @Field: GZ: Rotation rate Z-axis
 
-    AP::logger().WriteStreaming("EAHIM", "TimeUS,Temp,Pres,MX,MY,MZ,AX,AY,AZ,GX,GY,GZ",
+    AP::logger().WriteStreaming("EAHI", "TimeUS,Temp,Pres,MX,MY,MZ,AX,AY,AZ,GX,GY,GZ",
                        "sdPGGGoooEEE", "F00000000000",
                        "Qfffffffffff",
                        AP_HAL::micros64(),
@@ -587,7 +587,7 @@ void AP_ExternalAHRS_VectorNav::process_ahrs_ekf_packet(const uint8_t *b) {
     // @Field: PU: Pitch uncertainty
     // @Field: RU: Roll uncertainty
 
-    AP::logger().WriteStreaming("EAHAT", "TimeUS,Q1,Q2,Q3,Q4,Yaw,Pitch,Roll,YU,PU,RU",
+    AP::logger().WriteStreaming("EAHA", "TimeUS,Q1,Q2,Q3,Q4,Yaw,Pitch,Roll,YU,PU,RU",
                        "s----dddddd", "F0000000000",
                        "Qffffffffff",
                        AP_HAL::micros64(),
@@ -602,7 +602,7 @@ void AP_ExternalAHRS_VectorNav::process_ins_ekf_packet(const uint8_t *b) {
     const struct VN_INS_ekf_packet &pkt = *(struct VN_INS_ekf_packet *)b;
 
     last_pkt2_ms          = AP_HAL::millis();
-    latest_ins_ekf_packet = &pkt;
+    *latest_ins_ekf_packet = pkt;
 
     state.quat = Quaternion{pkt.quaternion[3], pkt.quaternion[0], pkt.quaternion[1], pkt.quaternion[2]};
     state.have_quaternion = true;
@@ -631,7 +631,7 @@ void AP_ExternalAHRS_VectorNav::process_ins_ekf_packet(const uint8_t *b) {
     // @Field: PU: Pitch uncertainty
     // @Field: RU: Roll uncertainty
 
-    AP::logger().WriteStreaming("EAHAT", "TimeUS,Q1,Q2,Q3,Q4,Yaw,Pitch,Roll,YU,PU,RU",
+    AP::logger().WriteStreaming("EAHA", "TimeUS,Q1,Q2,Q3,Q4,Yaw,Pitch,Roll,YU,PU,RU",
                        "s----dddddd", "F0000000000",
                        "Qffffffffff",
                        now,
@@ -652,8 +652,8 @@ void AP_ExternalAHRS_VectorNav::process_ins_ekf_packet(const uint8_t *b) {
     // @Field: PosU: Filter estimated position uncertainty
     // @Field: VelU: Filter estimated Velocity uncertainty
 
-    AP::logger().WriteStreaming("EAHKF", "TimeUS,InsStatus,Lat,Lon,Alt,VelN,VelE,VelD,PosU,VelU",
-                       "s-ddmnnndn", "F00000000",
+    AP::logger().WriteStreaming("EAHK", "TimeUS,InsStatus,Lat,Lon,Alt,VelN,VelE,VelD,PosU,VelU",
+                       "s-ddmnnndn", "F000000000",
                        "QHdddfffff",
                        now,
                        pkt.insStatus,
@@ -670,7 +670,7 @@ void AP_ExternalAHRS_VectorNav::process_ins_gnss_packet(const uint8_t *b) {
 
 
     last_pkt3_ms          = AP_HAL::millis();
-    latest_ins_gnss_packet = &pkt;
+    *latest_ins_gnss_packet = pkt;
     
     // get ToW in milliseconds
     gps.gps_week           = pkt.timeGps / (AP_MSEC_PER_WEEK * 1000000ULL);

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.cpp
@@ -16,7 +16,6 @@
   support for serial connected AHRS systems
  */
 
-#include <cstdint>
 #define ALLOW_DOUBLE_MATH_FUNCTIONS
 
 #include "AP_ExternalAHRS_config.h"

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.h
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.h
@@ -73,13 +73,13 @@ private:
     uint16_t pktoffset;
     uint16_t bufsize;
 
-    struct VN_imu_packet *latest_imu_packet = nullptr;
-    struct VN_INS_ekf_packet *latest_ins_ekf_packet = nullptr;
-    struct VN_INS_gnss_packet *latest_ins_gnss_packet = nullptr;
+    struct VN_imu_packet *latest_imu_packet;
+    struct VN_INS_ekf_packet *latest_ins_ekf_packet;
+    struct VN_INS_gnss_packet *latest_ins_gnss_packet;
 
-    uint32_t last_pkt1_ms = UINT32_MAX;
-    uint32_t last_pkt2_ms = UINT32_MAX;
-    uint32_t last_pkt3_ms = UINT32_MAX;
+    uint32_t last_pkt1_ms;
+    uint32_t last_pkt2_ms;
+    uint32_t last_pkt3_ms;
 
     enum class TYPE {
         VN_INS,  // Full INS mode, requiring GNSS. Used by VN-2X0 and VN-3X0

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.h
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.h
@@ -63,20 +63,23 @@ private:
 
     void initialize();
 
-    void process_ins_packet1(const uint8_t *b);
-    void process_ins_packet2(const uint8_t *b);
-    void process_ahrs_packet(const uint8_t *b);
     void run_command(const char *fmt, ...);
+    void process_imu_packet(const uint8_t *b);
+    void process_ahrs_ekf_packet(const uint8_t *b);
+    void process_ins_ekf_packet(const uint8_t *b);
+    void process_ins_gnss_packet(const uint8_t *b);
 
     uint8_t *pktbuf;
     uint16_t pktoffset;
     uint16_t bufsize;
 
-    struct VN_INS_packet1 *last_ins_pkt1;
-    struct VN_INS_packet2 *last_ins_pkt2;
+    struct VN_imu_packet const *latest_imu_packet = nullptr;
+    struct VN_INS_ekf_packet const *latest_ins_ekf_packet = nullptr;
+    struct VN_INS_gnss_packet const *latest_ins_gnss_packet = nullptr;
 
-    uint32_t last_pkt1_ms;
-    uint32_t last_pkt2_ms;
+    uint32_t last_pkt1_ms = UINT32_MAX;
+    uint32_t last_pkt2_ms = UINT32_MAX;
+    uint32_t last_pkt3_ms = UINT32_MAX;
 
     enum class TYPE {
         VN_INS,  // Full INS mode, requiring GNSS. Used by VN-2X0 and VN-3X0

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.h
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.h
@@ -64,10 +64,14 @@ private:
     void initialize();
 
     void run_command(const char *fmt, ...);
+
+    struct EAHA;
+    void write_eaha(const EAHA& data_to_log) const;
     void process_imu_packet(const uint8_t *b);
     void process_ahrs_ekf_packet(const uint8_t *b);
     void process_ins_ekf_packet(const uint8_t *b);
     void process_ins_gnss_packet(const uint8_t *b);
+
 
     uint8_t *pktbuf;
     uint16_t pktoffset;

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.h
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.h
@@ -73,9 +73,9 @@ private:
     uint16_t pktoffset;
     uint16_t bufsize;
 
-    struct VN_imu_packet const *latest_imu_packet = nullptr;
-    struct VN_INS_ekf_packet const *latest_ins_ekf_packet = nullptr;
-    struct VN_INS_gnss_packet const *latest_ins_gnss_packet = nullptr;
+    struct VN_imu_packet *latest_imu_packet = nullptr;
+    struct VN_INS_ekf_packet *latest_ins_ekf_packet = nullptr;
+    struct VN_INS_gnss_packet *latest_ins_gnss_packet = nullptr;
 
     uint32_t last_pkt1_ms = UINT32_MAX;
     uint32_t last_pkt2_ms = UINT32_MAX;

--- a/libraries/SITL/SIM_VectorNav.cpp
+++ b/libraries/SITL/SIM_VectorNav.cpp
@@ -129,16 +129,16 @@ void VectorNav::send_imu_packet(void)
     pkt.pressure = pressure_Pa*0.001 + rand_float() * 0.01;
 
     const uint8_t sync_byte = 0xFA;
-    write_to_autopilot((char *)&sync_byte, 1);
-    write_to_autopilot((char *)&VN_IMU_packet_sim::header, sizeof(VN_IMU_packet_sim::header));
-    write_to_autopilot((char *)&pkt, sizeof(pkt));
+    write_to_autopilot((const char *)&sync_byte, 1);
+    write_to_autopilot((const char *)&VN_IMU_packet_sim::header, sizeof(VN_IMU_packet_sim::header));
+    write_to_autopilot((const char *)&pkt, sizeof(pkt));
 
     uint16_t crc = crc16_ccitt(&VN_IMU_packet_sim::header[0], sizeof(VN_IMU_packet_sim::header), 0);
     crc = crc16_ccitt((const uint8_t *)&pkt, sizeof(pkt), crc);
     uint16_t crc2;
     swab(&crc, &crc2, 2);
 
-    write_to_autopilot((char *)&crc2, sizeof(crc2));
+    write_to_autopilot((const char *)&crc2, sizeof(crc2));
 }
 
 void VectorNav::send_ins_ekf_packet(void)
@@ -174,9 +174,9 @@ void VectorNav::send_ins_ekf_packet(void)
     pkt.velU = 0.25;
 
     const uint8_t sync_byte = 0xFA;
-    write_to_autopilot((char *)&sync_byte, 1);
-    write_to_autopilot((char *)&VN_INS_ekf_packet_sim::header, sizeof(VN_INS_ekf_packet_sim::header));
-    write_to_autopilot((char *)&pkt, sizeof(pkt));
+    write_to_autopilot((const char *)&sync_byte, 1);
+    write_to_autopilot((const char *)&VN_INS_ekf_packet_sim::header, sizeof(VN_INS_ekf_packet_sim::header));
+    write_to_autopilot((const char *)&pkt, sizeof(pkt));
 
     uint16_t crc = crc16_ccitt(&VN_INS_ekf_packet_sim::header[0], sizeof(VN_INS_ekf_packet_sim::header), 0);
     crc = crc16_ccitt((const uint8_t *)&pkt, sizeof(pkt), crc);
@@ -184,7 +184,7 @@ void VectorNav::send_ins_ekf_packet(void)
     uint16_t crc2;
     swab(&crc, &crc2, 2);
 
-    write_to_autopilot((char *)&crc2, sizeof(crc2));
+    write_to_autopilot((const char *)&crc2, sizeof(crc2));
 }
 
 void VectorNav::send_ins_gnss_packet(void)
@@ -221,9 +221,9 @@ void VectorNav::send_ins_gnss_packet(void)
     pkt.fix2 = 3;
 
     const uint8_t sync_byte = 0xFA;
-    write_to_autopilot((char *)&sync_byte, 1);
-    write_to_autopilot((char *)&VN_INS_gnss_packet_sim::header, sizeof(VN_INS_gnss_packet_sim::header));
-    write_to_autopilot((char *)&pkt, sizeof(pkt));
+    write_to_autopilot((const char *)&sync_byte, 1);
+    write_to_autopilot((const char *)&VN_INS_gnss_packet_sim::header, sizeof(VN_INS_gnss_packet_sim::header));
+    write_to_autopilot((const char *)&pkt, sizeof(pkt));
 
     uint16_t crc = crc16_ccitt(&VN_INS_gnss_packet_sim::header[0], sizeof(VN_INS_gnss_packet_sim::header), 0);
     crc = crc16_ccitt((const uint8_t *)&pkt, sizeof(pkt), crc);
@@ -231,7 +231,7 @@ void VectorNav::send_ins_gnss_packet(void)
     uint16_t crc2;
     swab(&crc, &crc2, 2);
 
-    write_to_autopilot((char *)&crc2, sizeof(crc2));
+    write_to_autopilot((const char *)&crc2, sizeof(crc2));
 }
 
 void VectorNav::nmea_printf(const char *fmt, ...)

--- a/libraries/SITL/SIM_VectorNav.cpp
+++ b/libraries/SITL/SIM_VectorNav.cpp
@@ -29,37 +29,49 @@ VectorNav::VectorNav() :
 {
 }
 
-struct PACKED VN_INS_packet1 {
-    float uncompMag[3];
+
+struct PACKED VN_IMU_packet_sim {
+    static constexpr uint8_t header[]{0x01, 0x21, 0x07};
+    uint64_t timeStartup;
+    float gyro[3];
+    float accel[3];
     float uncompAccel[3];
     float uncompAngRate[3];
-    float pressure;
     float mag[3];
-    float accel[3];
-    float gyro[3];
+    float temp;
+    float pressure;
+};
+constexpr uint8_t VN_IMU_packet_sim::header[];
+
+struct PACKED VN_INS_ekf_packet_sim {
+    static constexpr uint8_t header[]{0x31, 0x01, 0x00, 0x06, 0x01, 0x13, 0x06};
+    uint64_t timeStartup;
     float ypr[3];
     float quaternion[4];
     float yprU[3];
-    double positionLLA[3];
-    float velNED[3];
+    uint16_t insStatus;
+    double posLla[3];
+    float velNed[3];
     float posU;
     float velU;
 };
+constexpr uint8_t VN_INS_ekf_packet_sim::header[];
 
-struct PACKED VN_INS_packet2 {
-    uint64_t timeGPS;
-    float temp;
-    uint8_t numGPS1Sats;
-    uint8_t GPS1Fix;
-    double GPS1posLLA[3];
-    float GPS1velNED[3];
-    float GPS1DOP[7];
-    uint8_t numGPS2Sats;
-    uint8_t GPS2Fix;
+struct PACKED VN_INS_gnss_packet_sim {
+    static constexpr uint8_t header[]{0x49, 0x03, 0x00, 0xB8, 0x26, 0x18, 0x00};
+    uint64_t timeStartup;
+    uint64_t timeGps;
+    uint8_t numSats1;
+    uint8_t fix1;
+    double posLla1[3];
+    float velNed1[3];
+    float posU1[3];
+    float velU1;
+    float dop1[7];
+    uint8_t numSats2;
+    uint8_t fix2;
 };
-
-#define VN_PKT1_HEADER { 0xFA, 0x34, 0x2E, 0x07, 0x06, 0x01, 0x12, 0x06 }
-#define VN_PKT2_HEADER { 0xFA, 0x4E, 0x02, 0x00, 0x10, 0x00, 0xB8, 0x20, 0x18, 0x00 }
+constexpr uint8_t VN_INS_gnss_packet_sim::header[];
 
 /*
   get timeval using simulation time
@@ -80,36 +92,62 @@ static void simulation_timeval(struct timeval *tv)
     tv->tv_usec = new_usec % 1000000ULL;
 }
 
-void VectorNav::send_packet1(void)
+void VectorNav::send_imu_packet(void)
 {
     const auto &fdm = _sitl->state;
 
-    struct VN_INS_packet1 pkt {};
+    struct VN_IMU_packet_sim pkt {};
+
+    pkt.timeStartup = AP_HAL::micros() * 1e3;
+    
+    
+    const float gyro_noise = 0.05;
+
+    pkt.gyro[0] = radians(fdm.rollRate + rand_float() * gyro_noise);
+    pkt.gyro[1] = radians(fdm.pitchRate + rand_float() * gyro_noise);
+    pkt.gyro[2] = radians(fdm.yawRate + rand_float() * gyro_noise);
+    
+    pkt.accel[0] = fdm.xAccel;
+    pkt.accel[1] = fdm.yAccel;
+    pkt.accel[2] = fdm.zAccel;
 
     pkt.uncompAccel[0] = fdm.xAccel;
     pkt.uncompAccel[1] = fdm.yAccel;
     pkt.uncompAccel[2] = fdm.zAccel;
-    const float gyro_noise = 0.05;
+    
     pkt.uncompAngRate[0] = radians(fdm.rollRate + gyro_noise * rand_float());
     pkt.uncompAngRate[1] = radians(fdm.pitchRate + gyro_noise * rand_float());
     pkt.uncompAngRate[2] = radians(fdm.yawRate + gyro_noise * rand_float());
 
-    const float pressure_Pa = AP_Baro::get_pressure_for_alt_amsl(fdm.altitude);
-    pkt.pressure = pressure_Pa*0.001 + rand_float() * 0.01;
-
     pkt.mag[0] = fdm.bodyMagField.x*0.001;
     pkt.mag[1] = fdm.bodyMagField.y*0.001;
     pkt.mag[2] = fdm.bodyMagField.z*0.001;
-    pkt.uncompMag[0] = pkt.mag[0];
-    pkt.uncompMag[1] = pkt.mag[1];
-    pkt.uncompMag[2] = pkt.mag[2];
 
-    pkt.accel[0] = fdm.xAccel;
-    pkt.accel[1] = fdm.yAccel;
-    pkt.accel[2] = fdm.zAccel;
-    pkt.gyro[0] = radians(fdm.rollRate + rand_float() * gyro_noise);
-    pkt.gyro[1] = radians(fdm.pitchRate + rand_float() * gyro_noise);
-    pkt.gyro[2] = radians(fdm.yawRate + rand_float() * gyro_noise);
+    pkt.temp = AP_Baro::get_temperatureC_for_alt_amsl(fdm.altitude);
+
+    const float pressure_Pa = AP_Baro::get_pressure_for_alt_amsl(fdm.altitude);
+    pkt.pressure = pressure_Pa*0.001 + rand_float() * 0.01;
+
+    const uint8_t sync_byte = 0xFA;
+    write_to_autopilot((char *)&sync_byte, 1);
+    write_to_autopilot((char *)&VN_IMU_packet_sim::header, sizeof(VN_IMU_packet_sim::header));
+    write_to_autopilot((char *)&pkt, sizeof(pkt));
+
+    uint16_t crc = crc16_ccitt(&VN_IMU_packet_sim::header[0], sizeof(VN_IMU_packet_sim::header), 0);
+    crc = crc16_ccitt((const uint8_t *)&pkt, sizeof(pkt), crc);
+    uint16_t crc2;
+    swab(&crc, &crc2, 2);
+
+    write_to_autopilot((char *)&crc2, sizeof(crc2));
+}
+
+void VectorNav::send_ins_ekf_packet(void)
+{
+    const auto &fdm = _sitl->state;
+
+    struct VN_INS_ekf_packet_sim pkt {};
+
+    pkt.timeStartup = AP_HAL::micros() * 1e3;
 
     pkt.ypr[0] = fdm.yawDeg;
     pkt.ypr[1] = fdm.pitchDeg;
@@ -120,58 +158,74 @@ void VectorNav::send_packet1(void)
     pkt.quaternion[2] = fdm.quaternion.q4;
     pkt.quaternion[3] = fdm.quaternion.q1;
 
-    pkt.positionLLA[0] = fdm.latitude;
-    pkt.positionLLA[1] = fdm.longitude;
-    pkt.positionLLA[2] = fdm.altitude;
-    pkt.velNED[0] = fdm.speedN;
-    pkt.velNED[1] = fdm.speedE;
-    pkt.velNED[2] = fdm.speedD;
+    pkt.yprU[0] = 0.03;
+    pkt.yprU[1] = 0.03;
+    pkt.yprU[2] = 0.15;
+
+    pkt.insStatus = 0x0306;
+
+    pkt.posLla[0] = fdm.latitude;
+    pkt.posLla[1] = fdm.longitude;
+    pkt.posLla[2] = fdm.altitude;
+    pkt.velNed[0] = fdm.speedN;
+    pkt.velNed[1] = fdm.speedE;
+    pkt.velNed[2] = fdm.speedD;
     pkt.posU = 0.5;
     pkt.velU = 0.25;
 
-    const uint8_t header[] VN_PKT1_HEADER;
-
-    write_to_autopilot((char *)&header, sizeof(header));
+    const uint8_t sync_byte = 0xFA;
+    write_to_autopilot((char *)&sync_byte, 1);
+    write_to_autopilot((char *)&VN_INS_ekf_packet_sim::header, sizeof(VN_INS_ekf_packet_sim::header));
     write_to_autopilot((char *)&pkt, sizeof(pkt));
 
-    uint16_t crc = crc16_ccitt(&header[1], sizeof(header)-1, 0);
+    uint16_t crc = crc16_ccitt(&VN_INS_ekf_packet_sim::header[0], sizeof(VN_INS_ekf_packet_sim::header), 0);
     crc = crc16_ccitt((const uint8_t *)&pkt, sizeof(pkt), crc);
+
     uint16_t crc2;
     swab(&crc, &crc2, 2);
 
     write_to_autopilot((char *)&crc2, sizeof(crc2));
 }
 
-void VectorNav::send_packet2(void)
+void VectorNav::send_ins_gnss_packet(void)
 {
     const auto &fdm = _sitl->state;
 
-    struct VN_INS_packet2 pkt {};
+    struct VN_INS_gnss_packet_sim pkt {};
+
+    pkt.timeStartup = AP_HAL::micros() * 1e3;
 
     struct timeval tv;
     simulation_timeval(&tv);
 
-    pkt.timeGPS = tv.tv_usec * 1000ULL;
+    pkt.timeGps = tv.tv_usec * 1000ULL;
 
-    pkt.temp = AP_Baro::get_temperatureC_for_alt_amsl(fdm.altitude);
-    pkt.numGPS1Sats = 19;
-    pkt.GPS1Fix = 3;
-    pkt.GPS1posLLA[0] = fdm.latitude;
-    pkt.GPS1posLLA[1] = fdm.longitude;
-    pkt.GPS1posLLA[2] = fdm.altitude;
-    pkt.GPS1velNED[0] = fdm.speedN;
-    pkt.GPS1velNED[1] = fdm.speedE;
-    pkt.GPS1velNED[2] = fdm.speedD;
-    // pkt.GPS1DOP =
-    pkt.numGPS2Sats = 18;
-    pkt.GPS2Fix = 3;
+    pkt.numSats1 = 19;
+    pkt.fix1 = 3;
+    pkt.posLla1[0] = fdm.latitude;
+    pkt.posLla1[1] = fdm.longitude;
+    pkt.posLla1[2] = fdm.altitude;
+    pkt.velNed1[0] = fdm.speedN;
+    pkt.velNed1[1] = fdm.speedE;
+    pkt.velNed1[2] = fdm.speedD;
 
-    const uint8_t header[] VN_PKT2_HEADER;
+    pkt.posU1[0] = 1;
+    pkt.posU1[0] = 1;
+    pkt.posU1[0] = 1.5;
 
-    write_to_autopilot((char *)&header, sizeof(header));
+    pkt.velNed1[0] = 0.05;
+    pkt.velNed1[0] = 0.05;
+    pkt.velNed1[0] = 0.05;
+    // pkt.dop1 =
+    pkt.numSats2 = 18;
+    pkt.fix2 = 3;
+
+    const uint8_t sync_byte = 0xFA;
+    write_to_autopilot((char *)&sync_byte, 1);
+    write_to_autopilot((char *)&VN_INS_gnss_packet_sim::header, sizeof(VN_INS_gnss_packet_sim::header));
     write_to_autopilot((char *)&pkt, sizeof(pkt));
 
-    uint16_t crc = crc16_ccitt(&header[1], sizeof(header)-1, 0);
+    uint16_t crc = crc16_ccitt(&VN_INS_gnss_packet_sim::header[0], sizeof(VN_INS_gnss_packet_sim::header), 0);
     crc = crc16_ccitt((const uint8_t *)&pkt, sizeof(pkt), crc);
 
     uint16_t crc2;
@@ -203,14 +257,19 @@ void VectorNav::update(void)
     }
 
     uint32_t now = AP_HAL::micros();
-    if (now - last_pkt1_us >= 20000) {
-        last_pkt1_us = now;
-        send_packet1();
+    if (now - last_imu_pkt_us >= 20000) {
+        last_imu_pkt_us = now;
+        send_imu_packet();
     }
-
-    if (now - last_pkt2_us >= 200000) {
-        last_pkt2_us = now;
-        send_packet2();
+    
+    if (now - last_ekf_pkt_us >= 20000) {
+        last_ekf_pkt_us = now;
+        send_ins_ekf_packet();
+    }
+    
+    if (now - last_gnss_pkt_us >= 200000) {
+        last_gnss_pkt_us = now;
+        send_ins_gnss_packet();
     }
 
     char receive_buf[50];

--- a/libraries/SITL/SIM_VectorNav.h
+++ b/libraries/SITL/SIM_VectorNav.h
@@ -41,12 +41,13 @@ public:
     void update(void);
 
 private:
-    uint32_t last_pkt1_us;
-    uint32_t last_pkt2_us;
-    uint32_t last_type_us;
+    uint32_t last_imu_pkt_us;
+    uint32_t last_ekf_pkt_us;
+    uint32_t last_gnss_pkt_us;
 
-    void send_packet1();
-    void send_packet2();
+    void send_imu_packet();
+    void send_ins_ekf_packet();
+    void send_ins_gnss_packet();
     void nmea_printf(const char *fmt, ...);
 };
 


### PR DESCRIPTION
A few key outputs for logging are missing, and the current structure prevents 800Hz IMU data using TYPE::INS. I would split the messages into:

IMU packet, EKF packet, GNSS packet

There should also be additional logging messages for the new packets coming through

This both aids in debugging, and allows use of VectorNav uncertainty and status information for internal publishing and use