### PR TITLE
SIH glider improvements

### DIFF
--- a/Tools/scripts/sitl-on-hardware/sitl-on-hw.py
+++ b/Tools/scripts/sitl-on-hardware/sitl-on-hw.py
@@ -66,6 +66,8 @@ if args.defaults:
     defaults_write(open(args.defaults,"r").read() + "\n")
 
 if args.simclass:
+    if args.simclass == 'Glider':
+        hwdef_write("define AP_SIM_GLIDER_ENABLED 1\n")
     hwdef_write("define AP_SIM_FRAME_CLASS %s\n" % args.simclass)
 if args.frame:
     hwdef_write('define AP_SIM_FRAME_STRING "%s"\n' % args.frame)

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -181,7 +181,7 @@ void Aircraft::update_position(void)
         uint32_t now = AP_HAL::millis();
         if (now - last_one_hz_ms >= 1000) {
             // shift origin of position at 1Hz to current location
-            // this prevents sperical errors building up in the GPS data
+            // this prevents spherical errors building up in the GPS data
             last_one_hz_ms = now;
             Vector2d diffNE = origin.get_distance_NE_double(location);
             position.xy() -= diffNE;


### PR DESCRIPTION
This is a continuation of https://github.com/ArduPilot/ardupilot/pull/27559.

Up to now, in a typical Simulation in Hardware (SIH) you could not enable glider and balloon simulation on SIH, because `SIM_config.h` would have at its end:
```c++
#ifndef AP_SIM_GLIDER_ENABLED
#define AP_SIM_GLIDER_ENABLED (CONFIG_HAL_BOARD == HAL_BOARD_SITL)
#endif
```
which evaluates to false for SIH.

This PR allows the use of `./Tools/scripts/sitl-on-hardware/sitl-on-hw.py --vehicle plane --simclass Glider --frame Plane` to capture the `simclass` and enable the `AP_SIM_GLIDER_ENABLED` flag.

Additionally, it fixes a bug where the balloon channel would initialize in a negative value, resulting in the balloon getting downwards velocity and going underground, dragging the glider with it.

To test it:
1. Run `./Tools/scripts/sitl-on-hardware/sitl-on-hw.py --board CubeOrangePlus-SimOnHardWare --vehicle plane --simclass Glider --frame Plane --upload` and upload to your flight controller (here assuming Cube Orange+).
2. `rc 3 1000`, `arm throttle`.
3. `servo set 6 1200` to launch the balloon and the plane altitude rise after a few seconds.
4. `servo set 6 2000` to have the balloon climb at the full `SIM_GLD_BLN_RATE`.
5. `servo set 10 2000` to cut the glider off the balloon. It will start falling to the ground shortly afterwards.

Unfortunately, its aerodynamic parameters will have it fall flat. RTLing cannot take over control. This is a known, existing issue.