### PR TITLE
AP_Mount: Conditionally define `serial_instance` to fix unused variable compile error

### DIFF
--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -46,7 +46,7 @@ AP_Mount::AP_Mount()
     }
     _singleton = this;
 
-	AP_Param::setup_object_defaults(this, var_info);
+    AP_Param::setup_object_defaults(this, var_info);
 }
 
 // init - detect and initialise all mounts
@@ -184,6 +184,8 @@ void AP_Mount::init()
             set_mode_to_default(instance);
         }
     }
+
+    (void)serial_instance;
 }
 
 // update - give mount opportunity to update servos.  should be called at 10hz or higher


### PR DESCRIPTION
Change:
- Wrapped the definition of `serial_instance` with preprocessor directives to ensure it is only defined when necessary.
- This resolves the compile error caused by the unused variable when no features requiring `serial_instance` are enabled.