### PR TITLE
Tools: install-prereqs-ubuntu.sh: fix script after setuptools>=71.0.0 release

### DIFF
--- a/Tools/environment_install/install-prereqs-arch.sh
+++ b/Tools/environment_install/install-prereqs-arch.sh
@@ -26,7 +26,7 @@ BASE_PKGS="base-devel ccache git gsfonts tk wget gcc"
 SITL_PKGS="python-pip python-setuptools python-wheel python-wxpython opencv python-numpy python-scipy"
 PX4_PKGS="lib32-glibc zip zlib ncurses"
 
-PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect argparse matplotlib pyparsing geocoder pyserial empy==3.3.4 dronecan setuptools wheel"
+PYTHON_PKGS="future lxml pymavlink MAVProxy pexpect argparse matplotlib pyparsing geocoder pyserial empy==3.3.4 dronecan packaging setuptools wheel"
 
 # GNU Tools for ARM Embedded Processors
 # (see https://launchpad.net/gcc-arm-embedded/)

--- a/Tools/environment_install/install-prereqs-openSUSE-Tumbleweed.sh
+++ b/Tools/environment_install/install-prereqs-openSUSE-Tumbleweed.sh
@@ -105,7 +105,7 @@ if ! grep -Fxq "$SOURCE_LINE" ~/.bashrc; then
     fi
 fi
 
-$PIP3 install -U pip setuptools wheel
+$PIP3 install -U pip packaging setuptools wheel
 $PIP3 install -U attrdict3
 $PIP3 install -U $PYTHON_PKGS
 

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -399,8 +399,8 @@ if [ -n "$PYTHON_VENV_PACKAGE" ]; then
     fi
 fi
 
-# try update setuptools and wheel before installing pip package that may need compilation
-$PIP install $PIP_USER_ARGUMENT -U pip setuptools wheel
+# try update packaging, setuptools and wheel before installing pip package that may need compilation
+$PIP install $PIP_USER_ARGUMENT -U pip packaging setuptools wheel
 
 if [ "$GITHUB_ACTIONS" == "true" ]; then
     PIP_USER_ARGUMENT+=" --progress-bar off"


### PR DESCRIPTION
Explicitly upgrade to use newest `packaging` to avoid `packaging` incompatibility with `setuptools>=71.0`

As https://github.com/pypa/setuptools/issues/4496#issuecomment-2240322375 mentions:
> setuptools>=71.0 does not work with packaging<24.0, but will not upgrade it if packaging is already installed

Also relevant: https://github.com/pypa/setuptools/issues/4496