### PR TITLE
DroneCAN: fix dangerous bug for twin-motor Planes

### DIFF
--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -58,6 +58,8 @@ void Plane::set_control_channels(void)
         // setup correct scaling for ESCs like the UAVCAN ESCs which
         // take a proportion of speed. For quadplanes we use AP_Motors
         // scaling
+        g2.servo_channels.set_esc_scaling_for(SRV_Channel::k_throttleLeft);
+        g2.servo_channels.set_esc_scaling_for(SRV_Channel::k_throttleRight);
         g2.servo_channels.set_esc_scaling_for(SRV_Channel::k_throttle);
     }
 }

--- a/libraries/AP_DroneCAN/AP_DroneCAN.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.cpp
@@ -709,14 +709,17 @@ void AP_DroneCAN::handle_node_info_request(const CanardRxTransfer& transfer, con
 
 int16_t AP_DroneCAN::scale_esc_output(uint8_t idx){
     static const int16_t cmd_max = ((1<<13)-1);
-    float scaled = 0;
-
+    float scaled = hal.rcout->scale_esc_to_unity(_SRV_conf[idx].pulse);
+    // Prevent invalid values (from misconfigured scaling parameters) from sending non-zero commands
+    if (!isfinite(scaled)) {
+        return 0;
+    }
+    scaled = constrain_float(scaled, -1, 1);
     //Check if this channel has a reversible ESC. If it does, we can send negative commands.
     if ((((uint32_t) 1) << idx) & _esc_rv) {
-        scaled = cmd_max * (hal.rcout->scale_esc_to_unity(_SRV_conf[idx].pulse));
+        scaled *= cmd_max;
     } else {
-        scaled = cmd_max * (hal.rcout->scale_esc_to_unity(_SRV_conf[idx].pulse) + 1.0) / 2.0;
-        scaled = constrain_float(scaled, 0, cmd_max);
+        scaled = cmd_max * (scaled + 1.0) / 2.0;
     }
 
     return static_cast<int16_t>(scaled);

--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -422,6 +422,6 @@ protected:
     void append_to_banner(char banner_msg[], uint8_t banner_msg_len, output_mode out_mode, uint8_t low_ch, uint8_t high_ch) const;
     const char* get_output_mode_string(enum output_mode out_mode) const;
 
-    uint16_t _esc_pwm_min;
-    uint16_t _esc_pwm_max;
+    uint16_t _esc_pwm_min = 1000;
+    uint16_t _esc_pwm_max = 2000;
 };


### PR DESCRIPTION
Without this, twin motor planes with DroneCAN ESCs need to set a
dummy throttle channel for the `scale_esc_to_unity` to work correctly.

Worse yet, if you don't do this, your ESCs will receive a max throttle command while disarmed as soon as the safety switch is disengaged.

The first commit prevents the max-throttle symptom when esc scaling is unconfigured or misconfigured (costs 16 bytes). The second commit allows the left/right throttle servos to be used to configure esc scaling (costs 24 bytes).

Params to reproduce this bug on CubeOrange, disengage the safety switch and look at RawCommand coming out of the autopilot in DroneCAN GUI
```
CAN_D1_UC_ESC_BM 3
CAN_P1_DRIVER 1
CAN_P2_DRIVER 1
SERIAL6_PROTOCOL 2
SERVO1_FUNCTION 74
SERVO1_MAX 2000
SERVO1_MIN 1000
SERVO2_FUNCTION 73
SERVO2_MAX 2000
SERVO2_MIN 1000
SERVO3_FUNCTION 0
SERVO4_FUNCTION 0
```