### PR TITLE
Actions: fix tests that don't like repos not called "ardupilot"

### DIFF
--- a/.github/workflows/cygwin_build.yml
+++ b/.github/workflows/cygwin_build.yml
@@ -202,6 +202,7 @@ jobs:
           PATH: /usr/bin:$(cygpath ${SYSTEMROOT})/system32
         shell: C:\cygwin\bin\bash.exe -eo pipefail '{0}'
         run: >-
+          git config --global --add safe.directory /cygdrive/d/a/${GITHUB_REPOSITORY#$GITHUB_REPOSITORY_OWNER/}/${GITHUB_REPOSITORY#$GITHUB_REPOSITORY_OWNER/} &&
           export PATH=/usr/local/bin:/usr/bin:$(cygpath ${SYSTEMROOT})/system32 &&
           source ~/ccache.conf &&
           Tools/scripts/cygwin_build.sh &&

--- a/.github/workflows/test_environment.yml
+++ b/.github/workflows/test_environment.yml
@@ -79,7 +79,7 @@ jobs:
         with:
             submodules: 'recursive'
       - name: test install environment ${{matrix.os}}.${{matrix.name}}
-        timeout-minutes: 45
+        timeout-minutes: 60
         env:
           DISABLE_MAVNATIVE: True
           DEBIAN_FRONTEND: noninteractive

--- a/.github/workflows/test_environment.yml
+++ b/.github/workflows/test_environment.yml
@@ -103,7 +103,7 @@ jobs:
             *"archlinux"*)
             cp /etc/skel/.bashrc /root
             cp /etc/skel/.bashrc /github/home
-            git config --global --add safe.directory /__w/ardupilot/ardupilot
+            git config --global --add safe.directory ${GITHUB_WORKSPACE}
             Tools/environment_install/install-prereqs-arch.sh -qy
             ;;
           esac

--- a/.github/workflows/test_scripts.yml
+++ b/.github/workflows/test_scripts.yml
@@ -30,4 +30,5 @@ jobs:
           CI_BUILD_TARGET: ${{matrix.config}}
         shell: bash
         run: |
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
           Tools/scripts/build_ci.sh

--- a/Tools/scripts/cygwin_build.sh
+++ b/Tools/scripts/cygwin_build.sh
@@ -18,8 +18,6 @@ $GPP_COMPILER -print-sysroot
 SYS_ROOT=$($GPP_COMPILER -print-sysroot)
 echo "SYS_ROOT=$SYS_ROOT"
 
-git config --global --add safe.directory /cygdrive/d/a/ardupilot/ardupilot
-
 rm -rf artifacts
 mkdir artifacts
 


### PR DESCRIPTION
A few of the git safe directory calls assume the repo is called `ardupilot`, if your fork happens not to be called that then CI fails. GitHub provides us with a environmental variable to get the correct directory which we already use in most places. The tricky one is cygwin which uses the repo name, but on a different path, so in that case I have to some messing about to extract the repo name from `GITHUB_REPOSITORY` and `GITHUB_REPOSITORY_OWNER` (see https://tom-gallacher.co.uk/articles/how-to-github-actions-repo-name/)

This also ups the timeout for the environment install scripts from 45 mins to 60 mins. These seem to run a bit slower outside of the main repo, I'm not sure why. 