### PR TITLE
hwdef: enable relay support in MatekL431-DShot fw

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekL431-DShot/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekL431-DShot/hwdef.dat
@@ -32,3 +32,7 @@ define HAL_PERIPH_ENABLE_NOTIFY
 define HAL_SERIAL_ESC_COMM_ENABLED 1
 define HAL_SUPPORT_RCOUT_SERIAL 1
 define HAL_WITH_ESC_TELEM 1
+
+# also enable relay output via hardpoint msgs
+define HAL_PERIPH_ENABLE_RELAY
+define AP_RELAY_ENABLED 1


### PR DESCRIPTION
the PWM expansion boards can also be used for relay control, often combined with PWM output