### PR TITLE
board_types.txt: Reserving board id for Stellar F4

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -312,6 +312,8 @@ AP_HW_LongbowF405                    1422
 
 AP_HW_MountainEagleH743              1444
 
+AP_HW_StellarF4                      1500
+
 AP_HW_SakuraRC-H743                  2714
 
 # IDs 4200-4220 reserved for HAKRC


### PR DESCRIPTION
Reserve Board-ID for StingBee Stellar F4

board info on:
https://stingbee.com.ua/flight_controllers/stellarf4