### PR TITLE
AP_Mount: Topotek safely parses version packet

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Topotek.cpp
+++ b/libraries/AP_Mount/AP_Mount_Topotek.cpp
@@ -1060,15 +1060,15 @@ void AP_Mount_Topotek::gimbal_version_analyse()
     const uint8_t data_buf_len = char_to_hex(_msg_buff[5]);
 
     // check for "."
-    bool constains_period = false;
+    bool contains_period = false;
     for (uint8_t i = 0; i < data_buf_len; i++) {
-        constains_period |= _msg_buff[10 + i] == '.';
+        contains_period |= _msg_buff[10 + i] == '.';
     }
 
     // if contains period, extract version number
     uint32_t ver_num = 0;
     uint8_t ver_count = 0;
-    if (constains_period) {
+    if (contains_period) {
         for (uint8_t i = 0; i < data_buf_len; i++) {
             if (_msg_buff[10 + i] != '.') {
                 ver_num = ver_num * 10 + char_to_hex(_msg_buff[10 + i]);

--- a/libraries/AP_Mount/AP_Mount_Topotek.cpp
+++ b/libraries/AP_Mount/AP_Mount_Topotek.cpp
@@ -1076,6 +1076,9 @@ void AP_Mount_Topotek::gimbal_version_analyse()
                 version[ver_count++] = ver_num;
                 ver_num = 0;
             }
+            if (ver_count >= ARRAY_SIZE(version)) {
+                break;
+            }
         }
     } else {
         if (data_buf_len >= 1) {


### PR DESCRIPTION
This corrects a potential issue in the Topotek driver (introduced this morning by PR https://github.com/ArduPilot/ardupilot/pull/27568) that could lead to writing past the end of the "version" variable while parsing the version packet received from the gimbal.

This has been lightly tested on real hardware but the exact code path affected is not run due to the hardware I'm using sending the old style version string
![image](https://github.com/user-attachments/assets/9660446e-61b4-4f19-acea-31fb489a5dbe)


Thanks @peterbarker for finding this issue