### PR TITLE
Copter: SmartRTL restores last waypoint if users switches to another mode

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1541,6 +1541,10 @@ private:
     // point while following our path home.  If we take too long we
     // may choose to land the vehicle.
     uint32_t path_follow_last_pop_fail_ms;
+
+    // backup last popped point so that it can be restored to the path
+    // if vehicle exits SmartRTL mode before reaching home. invalid if zero
+    Vector3f dest_NED_backup;
 };
 
 

--- a/libraries/AP_SmartRTL/AP_SmartRTL.h
+++ b/libraries/AP_SmartRTL/AP_SmartRTL.h
@@ -41,6 +41,9 @@ public:
     // get a point on the path
     const Vector3f& get_point(uint16_t index) const { return _path[index]; }
 
+    // add point to end of path. returns true on success, false on failure (due to failure to take the semaphore)
+    bool add_point(const Vector3f& point);
+
     // get next point on the path to home, returns true on success
     bool pop_point(Vector3f& point);
 
@@ -108,9 +111,6 @@ private:
         // bits 1 and 2 are still available, pilot yaw was mapped to bit 2 for symmetry with auto
         IgnorePilotYaw    = (1U << 2),
     };
-
-    // add point to end of path
-    bool add_point(const Vector3f& point);
 
     // routine cleanup attempts to remove 10 points (see SMARTRTL_CLEANUP_POINT_MIN definition) by simplification or loop pruning
     void routine_cleanup(uint16_t path_points_count, uint16_t path_points_complete_limit);


### PR DESCRIPTION
This resolves issue https://github.com/ArduPilot/ardupilot/issues/27517 by backing up the current destination and then adding it back to the path if the user exits SmartRTL mode while returning.

This has been tested in SITL and resolves the problem.  During testing I created a zig zag mission as shown below and after the vehicle reached the final waypoint on the top-left I repeatedly switched the vehicle back and forth between SmartRTL and Brake mode about 20 times.

In master when finally switched to SmartRTL for the last time, the vehicle simply landed in place.
![image](https://github.com/user-attachments/assets/7cb13af7-a0ad-4ced-a454-de6072347430)

With this PR applied the vehicle correctly flew the zig-zag pattern home (apologies for mixing MP and MAVProxy views).
![image](https://github.com/user-attachments/assets/f1e3c1f8-43d0-49d4-9c0e-143c5fed4592)
