### PR TITLE
AP_RangeFinder: populate last_reading_ms in the backend for some sensors

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_HC_SR04.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_HC_SR04.cpp
@@ -99,7 +99,7 @@ void AP_RangeFinder_HC_SR04::update(void)
     const uint32_t now = AP_HAL::millis();
     if (value_us == 0) {
         // no reading; check for timeout:
-        if (now - last_reading_ms > 1000) {
+        if (now - state.last_reading_ms > 1000) {
             // no reading for a second - something is broken
             state.distance_m = 0.0f;
         }
@@ -125,7 +125,7 @@ void AP_RangeFinder_HC_SR04::update(void)
             glitch_count = 0;
         }
 
-        last_reading_ms = now;
+        state.last_reading_ms = now;
     }
 
     // update range_valid state based on distance measured

--- a/libraries/AP_RangeFinder/AP_RangeFinder_HC_SR04.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_HC_SR04.h
@@ -34,7 +34,6 @@ private:
     void check_trigger_pin();
 
     int8_t trigger_pin;
-    uint32_t last_reading_ms;      // system time of last read (used for health reporting)
     float last_distance_m;         // last distance reported (used to prevent glitches in measurement)
     uint8_t glitch_count;          // glitch counter
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
@@ -469,6 +469,7 @@ void AP_RangeFinder_LightWareI2C::legacy_timer(void)
     if (legacy_get_reading(state.distance_m)) {
         // update range_valid state based on distance measured
         update_status();
+        state.last_reading_ms = AP_HAL::millis();
     } else {
         set_status(RangeFinder::Status::NoData);
     }
@@ -479,6 +480,7 @@ void AP_RangeFinder_LightWareI2C::sf20_timer(void)
     if (sf20_get_reading(state.distance_m)) {
         // update range_valid state based on distance measured
         update_status();
+        state.last_reading_ms = AP_HAL::millis();
     } else {
         set_status(RangeFinder::Status::NoData);
     }


### PR DESCRIPTION
This was noticed when trying to use Lightware LW20 I2C with AP_Periph. The Rangefinder support inside AP_Periph checks for the backends last update time so that we don't send duplicates: 

https://github.com/ArduPilot/ardupilot/blob/master/Tools/AP_Periph/rangefinder.cpp#L67

I did a drive-through of all the other backend and it looks like only one other backend suffers from the issue. 

This problem has been reported a few times in the past: https://discuss.ardupilot.org/t/ap-periph-not-working-with-lightwarei2c/95913