### PR TITLE
AP_Periph: Fix compiling issues with AP_PERIPH_PROBE_CONTIONUS enabled

### DIFF
--- a/Tools/AP_Periph/compass.cpp
+++ b/Tools/AP_Periph/compass.cpp
@@ -20,6 +20,8 @@
 #define AP_PERIPH_MAG_HIRES 0
 #endif
 
+extern const AP_HAL::HAL &hal;
+
 /*
   update CAN magnetometer
  */


### PR DESCRIPTION
I coudn't compile a periph board with a compass and AP_PERIPH_PROBE_CONTIONUS enabled without this change. 