### PR TITLE
AP_ESC_Telem: Add ifndef before defining ESC_TELEM_MAX_ESCS

### DIFF
--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.h
@@ -7,7 +7,9 @@
 
 #if HAL_WITH_ESC_TELEM
 
-#define ESC_TELEM_MAX_ESCS NUM_SERVO_CHANNELS
+#ifndef ESC_TELEM_MAX_ESCS
+    #define ESC_TELEM_MAX_ESCS NUM_SERVO_CHANNELS
+#endif
 static_assert(ESC_TELEM_MAX_ESCS > 0, "Cannot have 0 ESC telemetry instances");
 
 #define ESC_TELEM_DATA_TIMEOUT_MS 5000UL


### PR DESCRIPTION
This change was needed to get a AP_Periph board to sense analog voltage and current, and forward that as ESC telemetry. 
I had to define ESC_TELEM_MAX_ESCS in the hwdef which was being redefined again, and throwing an error. 