### PR TITLE
AP_TemperatureSensor: Extend analog sensor backend to 5th order polynomial

### DIFF
--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Analog.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Analog.cpp
@@ -33,28 +33,33 @@ const AP_Param::GroupInfo AP_TemperatureSensor_Analog::var_info[] = {
 
     // @Param: A0
     // @DisplayName: Temperature sensor analog 0th polynomial coefficient
-    // @Description: a0 in polynomial of form temperature in deg = a0 + a1*voltage + a2*voltage^2 + a3*voltage^3 + a4*voltage^4
+    // @Description: a0 in polynomial of form temperature in deg = a0 + a1*voltage + a2*voltage^2 + a3*voltage^3 + a4*voltage^4 + a5*voltage^5
     AP_GROUPINFO("A0", 2, AP_TemperatureSensor_Analog, _a[0], 0),
 
     // @Param: A1
     // @DisplayName: Temperature sensor analog 1st polynomial coefficient
-    // @Description: a1 in polynomial of form temperature in deg = a0 + a1*voltage + a2*voltage^2 + a3*voltage^3 + a4*voltage^4
+    // @Description: a1 in polynomial of form temperature in deg = a0 + a1*voltage + a2*voltage^2 + a3*voltage^3 + a4*voltage^4 + a5*voltage^5
     AP_GROUPINFO("A1", 3, AP_TemperatureSensor_Analog, _a[1], 0),
 
     // @Param: A2
     // @DisplayName: Temperature sensor analog 2nd polynomial coefficient
-    // @Description: a2 in polynomial of form temperature in deg = a0 + a1*voltage + a2*voltage^2 + a3*voltage^3 + a4*voltage^4
+    // @Description: a2 in polynomial of form temperature in deg = a0 + a1*voltage + a2*voltage^2 + a3*voltage^3 + a4*voltage^4 + a5*voltage^5
     AP_GROUPINFO("A2", 4, AP_TemperatureSensor_Analog, _a[2], 0),
 
     // @Param: A3
     // @DisplayName: Temperature sensor analog 3rd polynomial coefficient
-    // @Description: a3 in polynomial of form temperature in deg = a0 + a1*voltage + a2*voltage^2 + a3*voltage^3 + a4*voltage^4
+    // @Description: a3 in polynomial of form temperature in deg = a0 + a1*voltage + a2*voltage^2 + a3*voltage^3 + a4*voltage^4 + a5*voltage^5
     AP_GROUPINFO("A3", 5, AP_TemperatureSensor_Analog, _a[3], 0),
 
     // @Param: A4
     // @DisplayName: Temperature sensor analog 4th polynomial coefficient
-    // @Description: a4 in polynomial of form temperature in deg = a0 + a1*voltage + a2*voltage^2 + a3*voltage^3 + a4*voltage^4
+    // @Description: a4 in polynomial of form temperature in deg = a0 + a1*voltage + a2*voltage^2 + a3*voltage^3 + a4*voltage^4 + a5*voltage^5
     AP_GROUPINFO("A4", 6, AP_TemperatureSensor_Analog, _a[4], 0),
+
+    // @Param: A5
+    // @DisplayName: Temperature sensor analog 5th polynomial coefficient
+    // @Description: a5 in polynomial of form temperature in deg = a0 + a1*voltage + a2*voltage^2 + a3*voltage^3 + a4*voltage^4 + a5*voltage^5
+    AP_GROUPINFO("A5", 7, AP_TemperatureSensor_Analog, _a[5], 0),
 
     AP_GROUPEND
 };
@@ -81,7 +86,7 @@ void AP_TemperatureSensor_Analog::update()
     const float voltage = _analog_source->voltage_average_ratiometric();
 
     // Evaluate polynomial
-    // temperature (deg) = a0 + a1*voltage + a2*voltage^2 + a3*voltage^3 + a4*voltage^4
+    // temperature (deg) = a0 + a1*voltage + a2*voltage^2 + a3*voltage^3 + a4*voltage^4 + a5*voltage^5
     float temp = 0.0;
     float poly = 1.0;
     for (uint8_t i = 0; i < ARRAY_SIZE(_a); i++) {

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Analog.h
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Analog.h
@@ -35,10 +35,10 @@ private:
     AP_HAL::AnalogSource *_analog_source;
 
     // Pin used to measure voltage
-    AP_Int8  _pin; 
+    AP_Int8  _pin;
 
     // Polynomial coefficients to calculate temperature from voltage
-    AP_Float _a[5];
+    AP_Float _a[6];
 
 };
 


### PR DESCRIPTION
After collecting some data from a analog temperature sensor, a 5th order polynomial tracked the temperature better. 


![image](https://github.com/user-attachments/assets/19a83df6-e63d-4470-b5ec-5fc069e86d53)

![image](https://github.com/user-attachments/assets/17254d43-ed9d-4707-87b3-78ee5a0c7f2c)
