### PR TITLE
AP_Bootloader: fix build for STM32H7 without heap

### DIFF
--- a/Tools/AP_Bootloader/AP_Bootloader.cpp
+++ b/Tools/AP_Bootloader/AP_Bootloader.cpp
@@ -74,7 +74,7 @@ int main(void)
 
     flash_init();
 
-#ifdef STM32H7
+#if defined(STM32H7) && CH_CFG_USE_HEAP
     check_ecc_errors();
 #endif
     

--- a/Tools/AP_Bootloader/support.cpp
+++ b/Tools/AP_Bootloader/support.cpp
@@ -533,7 +533,7 @@ void port_setbaud(uint32_t baudrate)
 }
 #endif // BOOTLOADER_DEV_LIST
 
-#ifdef STM32H7
+#if defined(STM32H7) && CH_CFG_USE_HEAP
 /*
   check if flash has any ECC errors and if it does then erase all of
   flash
@@ -580,5 +580,5 @@ void check_ecc_errors(void)
     }
     __enable_fault_irq();
 }
-#endif // STM32H7
+#endif // defined(STM32H7) && CH_CFG_USE_HEAP
 

--- a/Tools/AP_Bootloader/support.h
+++ b/Tools/AP_Bootloader/support.h
@@ -51,7 +51,9 @@ void thread_sleep_ms(uint32_t ms);
 
 void custom_startup(void);
 
+#if defined(STM32H7) && CH_CFG_USE_HEAP
 void check_ecc_errors(void);
+#endif
 
 // printf to debug uart (or USB)
 extern "C" {


### PR DESCRIPTION
* Disables ecc check for boards without Heap as well