### PR TITLE
AP_Scripting: reduce flash usage

### DIFF
--- a/libraries/AP_Scripting/AP_Scripting_helpers.cpp
+++ b/libraries/AP_Scripting/AP_Scripting_helpers.cpp
@@ -21,7 +21,6 @@ int lua_new_Parameter(lua_State *L) {
 
     // This chunk is the same as the auto generated constructor
     void *ud = lua_newuserdata(L, sizeof(Parameter));
-    memset(ud, 0, sizeof(Parameter));
     new (ud) Parameter();
     luaL_getmetatable(L, "Parameter");
     lua_setmetatable(L, -2);

--- a/libraries/AP_Scripting/AP_Scripting_helpers.cpp
+++ b/libraries/AP_Scripting/AP_Scripting_helpers.cpp
@@ -20,7 +20,6 @@ int lua_new_Parameter(lua_State *L) {
     }
 
     // This chunk is the same as the auto generated constructor
-    luaL_checkstack(L, 2, "Out of stack");
     void *ud = lua_newuserdata(L, sizeof(Parameter));
     memset(ud, 0, sizeof(Parameter));
     new (ud) Parameter();

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -1902,11 +1902,6 @@ void emit_userdata_method(const struct userdata *data, const struct method *meth
   // emit comments on expected arg/type
   struct argument *arg = method->arguments;
 
-  if ((data->ud_type == UD_SINGLETON) && !(data->flags & UD_FLAG_LITERAL)) {
-      // fetch and check the singleton pointer
-      fprintf(source, "    %s * ud = check_%s(L);\n", data->name, data->sanatized_name);
-  }
-
   // emit warning if configured
   if (method->deprecate != NULL) {
     fprintf(source, "    static bool warned = false;\n");
@@ -1915,7 +1910,6 @@ void emit_userdata_method(const struct userdata *data, const struct method *meth
     fprintf(source, "        warned = true;\n");
     fprintf(source, "    }\n\n");
   }
-
 
   // sanity check number of args called with
   arg_count = 1;
@@ -1933,8 +1927,12 @@ void emit_userdata_method(const struct userdata *data, const struct method *meth
       fprintf(source, "    %s * ud = check_%s(L, 1);\n", data->name, data->sanatized_name);
       break;
     case UD_SINGLETON:
+      if (!(data->flags & UD_FLAG_LITERAL)) {
+        // fetch and check the singleton pointer
+        fprintf(source, "    %s * ud = check_%s(L);\n", data->name, data->sanatized_name);
+      }
+      break;
     case UD_GLOBAL:
-      // this was bound early
       break;
     case UD_AP_OBJECT:
       // extract the userdata, it was a pointer, so we need to grab it

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -2459,15 +2459,11 @@ void emit_index(struct userdata *head) {
     }
 
     fprintf(source, "static int %s_index(lua_State *L) {\n", node->sanatized_name);
-    fprintf(source, "    const char * name = luaL_checkstring(L, 2);\n");
-    fprintf(source, "    if (load_function(L,%s_meta,ARRAY_SIZE(%s_meta),name)",node->sanatized_name,node->sanatized_name);
+    fprintf(source, "    return load_function(L,%s_meta,ARRAY_SIZE(%s_meta))",node->sanatized_name,node->sanatized_name);
     if (node->enums != NULL) {
-      fprintf(source, " || load_enum(L,%s_enums,ARRAY_SIZE(%s_enums),name)",node->sanatized_name,node->sanatized_name);
+      fprintf(source, " || load_enum(L,%s_enums,ARRAY_SIZE(%s_enums))",node->sanatized_name,node->sanatized_name);
     }
-    fprintf(source, ") {\n");
-    fprintf(source, "        return 1;\n");
-    fprintf(source, "    }\n");
-    fprintf(source, "    return 0;\n");
+    fprintf(source, ";\n");
     fprintf(source, "}\n");
     end_dependency(source, node->dependency);
     fprintf(source, "\n");
@@ -2992,14 +2988,15 @@ void emit_docs(struct userdata *node, int is_userdata, int emit_creation) {
 
 
 void emit_index_helpers(void) {
-  fprintf(source, "static bool load_function(lua_State *L, const luaL_Reg *list, const uint8_t length, const char* name) {\n");
+  fprintf(source, "static int load_function(lua_State *L, const luaL_Reg *list, const uint8_t length) {\n");
+  fprintf(source, "    const char * name = luaL_checkstring(L, 2);\n");
   fprintf(source, "    for (uint8_t i = 0; i < length; i++) {\n");
   fprintf(source, "        if (strcmp(name,list[i].name) == 0) {\n");
   fprintf(source, "            lua_pushcfunction(L, list[i].func);\n");
-  fprintf(source, "            return true;\n");
+  fprintf(source, "            return 1;\n");
   fprintf(source, "        }\n");
   fprintf(source, "    }\n");
-  fprintf(source, "    return false;\n");
+  fprintf(source, "    return 0;\n");
   fprintf(source, "}\n\n");
 
   // If enough stuff is defined out we can end up with no enums.
@@ -3007,14 +3004,15 @@ void emit_index_helpers(void) {
   fprintf(source, "#pragma GCC diagnostic push\n");
   fprintf(source, "#pragma GCC diagnostic ignored \"-Wunused-function\"\n");
 
-  fprintf(source, "static bool load_enum(lua_State *L, const userdata_enum *list, const uint8_t length, const char* name) {\n");
+  fprintf(source, "static int load_enum(lua_State *L, const userdata_enum *list, const uint8_t length) {\n");
+  fprintf(source, "    const char * name = luaL_checkstring(L, 2);\n");
   fprintf(source, "    for (uint8_t i = 0; i < length; i++) {\n");
   fprintf(source, "        if (strcmp(name,list[i].name) == 0) {\n");
   fprintf(source, "            lua_pushinteger(L, list[i].value);\n");
-  fprintf(source, "            return true;\n");
+  fprintf(source, "            return 1;\n");
   fprintf(source, "        }\n");
   fprintf(source, "    }\n");
-  fprintf(source, "    return false;\n");
+  fprintf(source, "    return 0;\n");
   fprintf(source, "}\n");
 
   fprintf(source, "#pragma GCC diagnostic pop\n\n");

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -1363,13 +1363,7 @@ void emit_ap_object_checkers(void) {
   while (node) {
     start_dependency(source, node->dependency);
     fprintf(source, "%s ** check_%s(lua_State *L, int arg) {\n", node->name, node->sanatized_name);
-    fprintf(source, "    %s ** data = (%s**)luaL_checkudata(L, arg, \"%s\");\n", node->name, node->name, node->name);
-    fprintf(source, "    %s * ud = *data;\n", node->name);
-    fprintf(source, "    if (ud == NULL) {\n");
-    fprintf(source, "        // This error will never return, so there is no danger of returning a NULL\n");
-    fprintf(source, "        luaL_error(L, \"Internal error, null pointer\");\n");
-    fprintf(source, "    }\n");
-    fprintf(source, "    return data;\n");
+    fprintf(source, "    return (%s **)check_ap_object(L, arg, \"%s\");\n", node->name, node->name);
     fprintf(source, "}\n");
     end_dependency(source, node->dependency);
     fprintf(source, "\n");
@@ -2712,6 +2706,14 @@ void emit_argcheck_helper(void) {
   fprintf(source, "    return ud;\n");
   fprintf(source, "}\n\n");
 
+  fprintf(source, "void ** check_ap_object(lua_State *L, int arg_num, const char * name) {\n");
+  fprintf(source, "    void ** data = (void **)luaL_checkudata(L, arg_num, name);\n");
+  fprintf(source, "    if (*data == NULL) {\n");
+  fprintf(source, "        luaL_error(L, \"internal error: %%s is null\", name); // does not return\n");
+  fprintf(source, "    }\n");
+  fprintf(source, "    return data;\n");
+  fprintf(source, "}\n\n");
+
 }
 
 void emit_not_supported_helper(void) {
@@ -3205,6 +3207,7 @@ int main(int argc, char **argv) {
   fprintf(header, "float get_number(lua_State *L, int arg_num, float min_val, float max_val);\n");
   fprintf(header, "uint32_t get_uint32(lua_State *L, int arg_num, uint32_t min_val, uint32_t max_val);\n");
   fprintf(header, "void * new_ap_object(lua_State *L, size_t size, const char * name);\n");
+  fprintf(header, "void ** check_ap_object(lua_State *L, int arg_num, const char * name);\n");
 
   struct userdata * node = parsed_singletons;
   while (node) {

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -1779,7 +1779,7 @@ void emit_field(const struct userdata_field *field, const char* object_name, con
 
   if (use_switch) {
     fprintf(source, "        default:\n");
-    fprintf(source, "            return luaL_argerror(L, lua_gettop(L), \"too many arguments\");\n");
+    fprintf(source, "            return field_argerror(L); // too many arguments\n");
     fprintf(source, "    }\n");
   }
 
@@ -2644,6 +2644,10 @@ void emit_argcheck_helper(void) {
   fprintf(source, "    return 0;\n");
   fprintf(source, "}\n\n");
 
+  fprintf(source, "int field_argerror(lua_State *L) {\n");
+  fprintf(source, "    return binding_argcheck(L, -1); // force too many args error\n");
+  fprintf(source, "}\n\n");
+
   // emit warning if augments are parsed
   fprintf(source, "bool userdata_zero_arg_check(lua_State *L) {\n");
   fprintf(source, "    if (lua_gettop(L) == 0) {\n");
@@ -3203,6 +3207,7 @@ int main(int argc, char **argv) {
   fprintf(header, "void load_generated_bindings(lua_State *L);\n");
   fprintf(header, "void load_generated_sandbox(lua_State *L);\n");
   fprintf(header, "int binding_argcheck(lua_State *L, int expected_arg_count);\n");
+  fprintf(header, "int field_argerror(lua_State *L);\n");
   fprintf(header, "bool userdata_zero_arg_check(lua_State *L);\n");
   fprintf(header, "lua_Integer get_integer(lua_State *L, int arg_num, lua_Integer min_val, lua_Integer max_val);\n");
   fprintf(header, "int8_t get_int8_t(lua_State *L, int arg_num);\n");

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -34,8 +34,7 @@ extern const AP_HAL::HAL& hal;
 int lua_millis(lua_State *L) {
     binding_argcheck(L, 0);
 
-    new_uint32_t(L);
-    *check_uint32_t(L, -1) = AP_HAL::millis();
+    *new_uint32_t(L) = AP_HAL::millis();
 
     return 1;
 }
@@ -44,8 +43,7 @@ int lua_millis(lua_State *L) {
 int lua_micros(lua_State *L) {
     binding_argcheck(L, 0);
 
-    new_uint32_t(L);
-    *check_uint32_t(L, -1) = AP_HAL::micros();
+    *new_uint32_t(L) = AP_HAL::micros();
 
     return 1;
 }
@@ -101,8 +99,7 @@ int lua_mavlink_receive_chan(lua_State *L) {
         luaL_addlstring(&b, (char *)&msg.msg, sizeof(msg.msg));
         luaL_pushresult(&b);
         lua_pushinteger(L, msg.chan);
-        new_uint32_t(L);
-        *check_uint32_t(L, -1) = msg.timestamp_ms;
+        *new_uint32_t(L) = msg.timestamp_ms;
         return 3;
     } else {
         // no MAVLink to handle, just return no results
@@ -240,8 +237,7 @@ int lua_mission_receive(lua_State *L) {
         return 0;
     }
 
-    new_uint32_t(L);
-    *check_uint32_t(L, -1) = cmd.time_ms;
+    *new_uint32_t(L) = cmd.time_ms;
 
     lua_pushinteger(L, cmd.p1);
     lua_pushnumber(L, cmd.content_p1);
@@ -606,8 +602,7 @@ int lua_get_i2c_device(lua_State *L) {
         return luaL_argerror(L, 1, "i2c device nullptr");
     }
 
-    new_AP_HAL__I2CDevice(L);
-    *((AP_HAL::I2CDevice**)luaL_checkudata(L, -1, "AP_HAL::I2CDevice")) = scripting->_i2c_dev[scripting->num_i2c_devices]->get();
+    *new_AP_HAL__I2CDevice(L) = scripting->_i2c_dev[scripting->num_i2c_devices]->get();
 
     scripting->num_i2c_devices++;
 
@@ -682,8 +677,7 @@ int lua_get_CAN_device(lua_State *L) {
         return 0;
     }
 
-    new_ScriptingCANBuffer(L);
-    *((ScriptingCANBuffer**)luaL_checkudata(L, -1, "ScriptingCANBuffer")) = scripting->_CAN_dev->add_buffer(buffer_len);
+    *new_ScriptingCANBuffer(L) = scripting->_CAN_dev->add_buffer(buffer_len);
 
     return 1;
 }
@@ -713,8 +707,7 @@ int lua_get_CAN_device2(lua_State *L) {
         return 0;
     }
 
-    new_ScriptingCANBuffer(L);
-    *((ScriptingCANBuffer**)luaL_checkudata(L, -1, "ScriptingCANBuffer")) = scripting->_CAN_dev2->add_buffer(buffer_len);
+    *new_ScriptingCANBuffer(L) = scripting->_CAN_dev2->add_buffer(buffer_len);
 
     return 1;
 }
@@ -737,8 +730,7 @@ int lua_serial_find_serial(lua_State *L) {
         return 0;
     }
 
-    new_AP_Scripting_SerialAccess(L);
-    AP_Scripting_SerialAccess *port = check_AP_Scripting_SerialAccess(L, -1);
+    AP_Scripting_SerialAccess *port = new_AP_Scripting_SerialAccess(L);
     port->stream = driver_stream;
 #if AP_SCRIPTING_SERIALDEVICE_ENABLED
     port->is_device_port = false;
@@ -775,8 +767,7 @@ int lua_serial_find_simulated_device(lua_State *L) {
         return 0;
     }
 
-    new_AP_Scripting_SerialAccess(L);
-    AP_Scripting_SerialAccess *port = check_AP_Scripting_SerialAccess(L, -1);
+    AP_Scripting_SerialAccess *port = new_AP_Scripting_SerialAccess(L);
     port->stream = device_stream;
     port->is_device_port = true;
 
@@ -888,8 +879,7 @@ int lua_get_PWMSource(lua_State *L) {
         return luaL_argerror(L, 1, "PWMSources device nullptr");
     }
 
-    new_AP_HAL__PWMSource(L);
-    *((AP_HAL::PWMSource**)luaL_checkudata(L, -1, "AP_HAL::PWMSource")) = scripting->_pwm_source[scripting->num_pwm_source];
+    *new_AP_HAL__PWMSource(L) = scripting->_pwm_source[scripting->num_pwm_source];
 
     scripting->num_pwm_source++;
 
@@ -912,8 +902,7 @@ int lua_get_SocketAPM(lua_State *L) {
     for (uint8_t i=0; i<SCRIPTING_MAX_NUM_NET_SOCKET; i++) {
         if (scripting->_net_sockets[i] == nullptr) {
             scripting->_net_sockets[i] = sock;
-            new_SocketAPM(L);
-            *((SocketAPM**)luaL_checkudata(L, -1, "SocketAPM")) = scripting->_net_sockets[i];
+            *new_SocketAPM(L) = scripting->_net_sockets[i];
             return 1;
         }
     }
@@ -1012,8 +1001,7 @@ int SocketAPM_accept(lua_State *L) {
             if (scripting->_net_sockets[i] == nullptr) {
                 return 0;
             }
-            new_SocketAPM(L);
-            *((SocketAPM**)luaL_checkudata(L, -1, "SocketAPM")) = scripting->_net_sockets[i];
+            *new_SocketAPM(L) = scripting->_net_sockets[i];
             return 1;
         }
     }

--- a/libraries/AP_Scripting/lua_boxed_numerics.cpp
+++ b/libraries/AP_Scripting/lua_boxed_numerics.cpp
@@ -79,8 +79,7 @@ int lua_new_uint32_t(lua_State *L) {
         return luaL_argerror(L, args, "too many arguments");
     }
 
-    new_uint32_t(L);
-    *check_uint32_t(L, -1) = (args == 1) ? coerce_to_uint32_t(L, 1) : 0;
+    *new_uint32_t(L) = (args == 1) ? coerce_to_uint32_t(L, 1) : 0;
     return 1;
 }
 
@@ -110,8 +109,7 @@ int lua_new_uint64_t(lua_State *L) {
             break;
     }
 
-    new_uint64_t(L);
-    *check_uint64_t(L, -1) = value;
+    *new_uint64_t(L) = value;
     return 1;
 }
 
@@ -193,12 +191,10 @@ int uint64_t_split(lua_State *L) {
     const uint64_t v = *check_uint64_t(L, 1);
 
     // high
-    new_uint32_t(L);
-    *check_uint32_t(L, -1) = v >> 32;
+    *new_uint32_t(L) = v >> 32;
 
     // low
-    new_uint32_t(L);
-    *check_uint32_t(L, -1) = v & 0xFFFFFFFF;
+    *new_uint32_t(L) = v & 0xFFFFFFFF;
 
     return 2;
 }


### PR DESCRIPTION
A pile of optimizations to the way bindings are generated and used in order to improve the code and reduce flash usage. Please see the commit messages individually for details.

Saves ~4.3K flash on Cube Orange. There are no user visible script changes except for error message text. Tested in SITL and on the bench through my REPL and some example scripts.