### PR TITLE
Make chibios_hwdef.py include error clearer

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -618,8 +618,12 @@ def get_ap_periph_boards():
         hwdef = os.path.join(dirname, d, 'hwdef.dat')
         if os.path.exists(hwdef):
             ch = chibios_hwdef.ChibiOSHWDef(hwdef=[hwdef], quiet=True)
-            if ch.is_periph_fw_unprocessed():
-                list_ap.append(d)
+            try:
+                if ch.is_periph_fw_unprocessed():
+                    list_ap.append(d)
+            except chibios_hwdef.ChibiOSHWDefIncludeNotFoundException as e:
+                print(f"{e.includer} includes {e.hwdef} which does not exist")
+                sys.exit(1)
 
     list_ap = list(set(list_ap))
     return list_ap


### PR DESCRIPTION
Replaces https://github.com/ArduPilot/ardupilot/pull/18479

```
pbarker@fx:~/rc/ardupilot(master)$ ./waf configure --board=CubeOrange
libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/hwdef.dat includes libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/nope which does not exist
pbarker@fx:~/rc/ardupilot(master)$ git checkout -b pr/include-file-error-better
```
