### PR TITLE
AP_NavEKF3: Fix yaw alignment bug preventing copter  wind estimation

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -294,6 +294,7 @@ void NavEKF3_core::SelectMagFusion()
                 have_fused_gps_yaw = true;
                 lastSynthYawTime_ms = imuSampleTime_ms;
                 last_gps_yaw_fuse_ms = imuSampleTime_ms;
+                recordYawResetsCompleted();
             } else if (tiltAlignComplete && yawAlignComplete) {
                 have_fused_gps_yaw = fuseEulerYaw(yawFusionMethod::GPS);
                 if (have_fused_gps_yaw) {


### PR DESCRIPTION
This patch fixes the bug that was preventing copters using GPS yaw from using drag fusion to estimate wind. See https://github.com/ArduPilot/ardupilot/issues/26650 for details

Testing in SITL using the https://github.com/ArduPilot/ardupilot/blob/master/Tools/autotest/default_params/copter-gps-for-yaw.parm parameters results in a wind speed being reported at the ground station with varying readings when EK3_DRAG_MCOEF is also set to a positive value.

<img width="719" alt="Screenshot 2024-07-25 at 6 06 49 AM" src="https://github.com/user-attachments/assets/5f09e275-86a4-4ec4-bfc2-3bd06d010a3a">

The values reported are  large and varying because the default SITL physics model does not model X and Y axis specific forces, however this test does show that that after the patch, wind estimation is active with a GPS yaw source.
