### PR TITLE
Plane: option to allow plane to crosstrack on all mission items

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -908,6 +908,55 @@ bool Plane::set_land_descent_rate(float descent_rate)
 #endif
     return false;
 }
+
+// allow scripte to find access prev_WP_loc
+bool Plane::get_previous_location(Location &previous_location)
+{
+    switch (control_mode->mode_number()) {
+    case Mode::Number::RTL:
+    case Mode::Number::AVOID_ADSB:
+    case Mode::Number::GUIDED:
+    case Mode::Number::AUTO:
+    case Mode::Number::LOITER:
+    case Mode::Number::TAKEOFF:
+#if HAL_QUADPLANE_ENABLED
+    case Mode::Number::QLOITER:
+    case Mode::Number::QLAND:
+    case Mode::Number::QRTL:
+#endif
+        previous_location = prev_WP_loc;
+        return true;
+        break;
+    default:
+        break;
+    }
+    return false;
+}
+
+bool Plane::set_crosstrack_start(const Location &new_start_location)
+{
+    switch (control_mode->mode_number()) {
+    case Mode::Number::RTL:
+    case Mode::Number::AVOID_ADSB:
+    case Mode::Number::GUIDED:
+    case Mode::Number::AUTO:
+    case Mode::Number::LOITER:
+    case Mode::Number::TAKEOFF:
+#if HAL_QUADPLANE_ENABLED
+    case Mode::Number::QLOITER:
+    case Mode::Number::QLAND:
+    case Mode::Number::QRTL:
+#endif
+        prev_WP_loc   = new_start_location;
+        auto_state.crosstrack = true;
+        return true;
+        break;
+    default:
+        break;
+    }
+    return false;
+}
+
 #endif // AP_SCRIPTING_ENABLED
 
 // returns true if vehicle is landing.

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1430,7 +1430,7 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_command_do_set_mission_current(const mavlin
     }
 
     // if you change this you must change handle_mission_set_current
-    plane.auto_state.next_wp_crosstrack = false;
+    plane.auto_state.next_wp_crosstrack = plane.mission.always_crosstrack();
     if (plane.control_mode == &plane.mode_auto && plane.mission.state() == AP_Mission::MISSION_STOPPED) {
         plane.mission.resume();
     }
@@ -1442,7 +1442,7 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_command_do_set_mission_current(const mavlin
 void GCS_MAVLINK_Plane::handle_mission_set_current(AP_Mission &mission, const mavlink_message_t &msg)
 {
     // if you change this you must change handle_command_do_set_mission_current
-    plane.auto_state.next_wp_crosstrack = false;
+    plane.auto_state.next_wp_crosstrack = plane.mission.always_crosstrack();
     GCS_MAVLINK::handle_mission_set_current(mission, msg);
     if (plane.control_mode == &plane.mode_auto && plane.mission.state() == AP_Mission::MISSION_STOPPED) {
         plane.mission.resume();

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1288,6 +1288,11 @@ public:
 
     // allow for landing descent rate to be overridden by a script, may be -ve to climb
     bool set_land_descent_rate(float descent_rate) override;
+
+    // allow scripts to override mission crosstrack behaviour
+    bool get_previous_location(Location &previous_location) override;
+    bool set_crosstrack_start(const Location &new_start_location) override;
+
 #endif // AP_SCRIPTING_ENABLED
 
 };

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -388,6 +388,7 @@ void Plane::do_takeoff(const AP_Mission::Mission_Command& cmd)
 
 void Plane::do_nav_wp(const AP_Mission::Mission_Command& cmd)
 {
+    auto_state.next_wp_crosstrack = plane.mission.always_crosstrack();
     set_next_WP(cmd.content.location);
 }
 
@@ -940,6 +941,7 @@ bool Plane::do_change_speed(uint8_t speedtype, float speed_target_ms, float thro
             gcs().send_text(MAV_SEVERITY_INFO, "Set airspeed %u m/s", (unsigned)speed_target_ms);
             return true;
         }
+        gcs().send_text(MAV_SEVERITY_INFO, "Set airspeed %u m/s FAILED", (unsigned)speed_target_ms);
         break;
     case 1:             // Ground speed
         gcs().send_text(MAV_SEVERITY_INFO, "Set groundspeed %u", (unsigned)speed_target_ms);

--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -37,7 +37,7 @@ bool Mode::enter()
     plane.takeoff_state.waiting_for_rudder_neutral = false;
 
     // don't cross-track when starting a mission
-    plane.auto_state.next_wp_crosstrack = false;
+    plane.auto_state.next_wp_crosstrack = plane.mission.always_crosstrack();
 
     // reset landing check
     plane.auto_state.checked_for_autoland = false;

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3425,7 +3425,7 @@ bool QuadPlane::verify_vtol_takeoff(const AP_Mission::Mission_Command &cmd)
     }
 
     // don't crosstrack on next WP
-    plane.auto_state.next_wp_crosstrack = false;
+    plane.auto_state.next_wp_crosstrack = plane.mission.always_crosstrack();
 
     return true;
 }

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -39,7 +39,7 @@ const AP_Param::GroupInfo AP_Mission::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: Mission options bitmask
     // @Description: Bitmask of what options to use in missions.
-    // @Bitmask: 0:Clear Mission on reboot, 1:Use distance to land calc on battery failsafe,2:ContinueAfterLand
+    // @Bitmask: 0:Clear Mission on reboot, 1:Use distance to land calc on battery failsafe,2:ContinueAfterLand,3:Always Crosstrack
     // @Bitmask{Copter}: 0:Clear Mission on reboot, 2:ContinueAfterLand
     // @Bitmask{Rover, Sub}: 0:Clear Mission on reboot
     // @User: Advanced

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -45,6 +45,10 @@
 #define AP_MISSION_RESTART_DEFAULT          0       // resume the mission from the last command run by default
 
 #define AP_MISSION_OPTIONS_DEFAULT          0       // Do not clear the mission when rebooting
+#define AP_MISSION_MASK_MISSION_CLEAR       (1<<0)  // If set then Clear the mission on boot
+#define AP_MISSION_MASK_DIST_TO_LAND_CALC   (1<<1)  // Allow distance to best landing calculation to be run on failsafe
+#define AP_MISSION_MASK_CONTINUE_AFTER_LAND (1<<2)  // Allow mission to continue after land
+#define AP_MISSION_MASK_ALWAYS_CROSSTRACK   (1<<3)  // ALways use crosstrack on every waypoint
 
 #define AP_MISSION_MAX_WP_HISTORY           7       // The maximum number of previous wp commands that will be stored from the active missions history
 #define LAST_WP_PASSED (AP_MISSION_MAX_WP_HISTORY-2)
@@ -746,6 +750,11 @@ public:
     bool continue_after_land_check_for_takeoff(void);
     bool continue_after_land(void) const {
         return option_is_set(Option::CONTINUE_AFTER_LAND);
+    }
+
+    // Return true of the MIS_OPTIONS always crosstrack bit is set
+    bool always_crosstrack(void) const {
+        return (_options.get() & AP_MISSION_MASK_ALWAYS_CROSSTRACK) != 0;
     }
 
     // user settable parameters

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -2485,6 +2485,15 @@ function vehicle:is_taking_off() end
 ---@return boolean
 function vehicle:is_landing() end
 
+-- Get the previous target location if available in current mode
+---@return Location_ud|nil -- previous target ocation
+function vehicle:get_previous_location() end
+
+-- Set the previous target location for crosstrack and enable crosstrack if available in the current mode
+---@param new_start_location Location_ud -- target location
+---@return boolean -- true on success
+function vehicle:set_crosstrack_start(new_start_location) end
+
 -- desc
 onvif = {}
 

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -348,6 +348,8 @@ singleton AP_Vehicle method has_ekf_failsafed boolean
 singleton AP_Vehicle method reboot void boolean
 singleton AP_Vehicle method is_landing boolean
 singleton AP_Vehicle method is_taking_off boolean
+singleton AP_Vehicle method get_previous_location boolean Location'Null
+singleton AP_Vehicle method set_crosstrack_start boolean Location
 
 include AP_SerialLED/AP_SerialLED.h
 singleton AP_SerialLED rename serialLED

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -221,7 +221,11 @@ public:
 
     // allow for landing descent rate to be overridden by a script, may be -ve to climb
     virtual bool set_land_descent_rate(float descent_rate) { return false; }
-    
+
+    // Allow for scripting to have control over the crosstracking when exiting and resuming missions
+    virtual bool get_previous_location(Location &previous_location) { return false; }
+    virtual bool set_crosstrack_start(const Location &new_start_location) { return false; }
+
     // control outputs enumeration
     enum class ControlOutput {
         Roll = 1,


### PR DESCRIPTION
When a mission is interrupted, by default in Plane it will never crosstrack (i.e. get right back on the defined mission path) when the mission is resumed.

I am working on object avoidance script that diverts the plane from the mission based on rangefinder readings of real obstacles, while running long missions on fixed wing planes with magnetic sensors attached. For those sensors, being "on track" is essential to getting correct data for the client, so getting back on track after the obstacle is mission critical.

The code to do this is already in ArduPilot, there is an existing plane.auto_state.next_wp_crosstrack boolean value, but it is only ever set to true when first starting the mission and not set on resume. This PR adds MIS_OPTION bit that sets the next_wp_crosstrack value to true for every new waypoint, which does a much better job of following the required path.

Tested in SITL.