### PR TITLE
AP_Camera: TYPE param description get Topotek, Viewpro, Xacti

### DIFF
--- a/libraries/AP_Camera/AP_Camera_Params.cpp
+++ b/libraries/AP_Camera/AP_Camera_Params.cpp
@@ -8,7 +8,7 @@ const AP_Param::GroupInfo AP_Camera_Params::var_info[] = {
     // @Param: _TYPE
     // @DisplayName: Camera shutter (trigger) type
     // @Description: how to trigger the camera to take a picture
-    // @Values: 0:None, 1:Servo, 2:Relay, 3:GoPro in Solo Gimbal, 4:Mount (Siyi), 5:MAVLink, 6:MAVLinkCamV2, 7:Scripting
+    // @Values: 0:None, 1:Servo, 2:Relay, 3:GoPro in Solo Gimbal, 4:Mount (Siyi/Viewpro/Xacti), 5:MAVLink, 6:MAVLinkCamV2, 7:Scripting
     // @User: Standard
     AP_GROUPINFO_FLAGS("_TYPE",  1, AP_Camera_Params, type, 0, AP_PARAM_FLAG_ENABLE),
 

--- a/libraries/AP_Camera/AP_Camera_Params.cpp
+++ b/libraries/AP_Camera/AP_Camera_Params.cpp
@@ -8,7 +8,7 @@ const AP_Param::GroupInfo AP_Camera_Params::var_info[] = {
     // @Param: _TYPE
     // @DisplayName: Camera shutter (trigger) type
     // @Description: how to trigger the camera to take a picture
-    // @Values: 0:None, 1:Servo, 2:Relay, 3:GoPro in Solo Gimbal, 4:Mount (Siyi/Viewpro/Xacti), 5:MAVLink, 6:MAVLinkCamV2, 7:Scripting
+    // @Values: 0:None, 1:Servo, 2:Relay, 3:GoPro in Solo Gimbal, 4:Mount (Siyi/Topotek/Viewpro/Xacti), 5:MAVLink, 6:MAVLinkCamV2, 7:Scripting
     // @User: Standard
     AP_GROUPINFO_FLAGS("_TYPE",  1, AP_Camera_Params, type, 0, AP_PARAM_FLAG_ENABLE),
 


### PR DESCRIPTION
When users setup a combined camera+gimbal they normally need to set the CAMx_TYPE to 4 (Mount).  This updates the parameter description to name all the possible camera gimbal types it might refer to which now includes Topotek, Viewpro and Xacti.

I've created two commits so we can backport the 1st one (which doesn't include Topotek) into 4.5 if we choose

FYI @laozhou-fujian 