### PR TITLE
Copter: add a Mode method to disable crash check

### DIFF
--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -42,7 +42,7 @@ void Copter::crash_check()
     }
 
     // return immediately if we are not in an angle stabilize flight mode or we are flipping
-    if (flightmode->mode_number() == Mode::Number::ACRO || flightmode->mode_number() == Mode::Number::FLIP) {
+    if (flightmode->disable_crash_check()) {
         crash_counter = 0;
         return;
     }
@@ -273,7 +273,7 @@ void Copter::parachute_check()
     }
 
     // return immediately if we are not in an angle stabilize flight mode or we are flipping
-    if (flightmode->mode_number() == Mode::Number::ACRO || flightmode->mode_number() == Mode::Number::FLIP) {
+    if (flightmode->disable_crash_check()) {
         control_loss_count = 0;
         return;
     }

--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -42,7 +42,7 @@ void Copter::crash_check()
     }
 
     // return immediately if we are not in an angle stabilize flight mode or we are flipping
-    if (flightmode->disable_crash_check()) {
+    if (!flightmode->crash_check_enabled()) {
         crash_counter = 0;
         return;
     }
@@ -273,7 +273,7 @@ void Copter::parachute_check()
     }
 
     // return immediately if we are not in an angle stabilize flight mode or we are flipping
-    if (flightmode->disable_crash_check()) {
+    if (!flightmode->crash_check_enabled()) {
         control_loss_count = 0;
         return;
     }

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -128,7 +128,7 @@ public:
     virtual bool allows_save_trim() const { return false; }
     virtual bool allows_autotune() const { return false; }
     virtual bool allows_flip() const { return false; }
-    virtual bool disable_crash_check() const { return false; }
+    virtual bool crash_check_enabled() const { return true; }
 
 #if FRAME_CONFIG == HELI_FRAME
     virtual bool allows_inverted() const { return false; };
@@ -421,7 +421,7 @@ public:
     void air_mode_aux_changed();
     bool allows_save_trim() const override { return true; }
     bool allows_flip() const override { return true; }
-    bool disable_crash_check() const override { return true; }
+    bool crash_check_enabled() const override { return false; }
 
 protected:
 
@@ -913,7 +913,7 @@ public:
     bool has_manual_throttle() const override { return false; }
     bool allows_arming(AP_Arming::Method method) const override { return false; };
     bool is_autopilot() const override { return false; }
-    bool disable_crash_check() const override { return true; }
+    bool crash_check_enabled() const override { return false; }
 
 protected:
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -128,6 +128,7 @@ public:
     virtual bool allows_save_trim() const { return false; }
     virtual bool allows_autotune() const { return false; }
     virtual bool allows_flip() const { return false; }
+    virtual bool disable_crash_check() const { return false; }
 
 #if FRAME_CONFIG == HELI_FRAME
     virtual bool allows_inverted() const { return false; };
@@ -420,6 +421,7 @@ public:
     void air_mode_aux_changed();
     bool allows_save_trim() const override { return true; }
     bool allows_flip() const override { return true; }
+    bool disable_crash_check() const override { return true; }
 
 protected:
 
@@ -911,6 +913,7 @@ public:
     bool has_manual_throttle() const override { return false; }
     bool allows_arming(AP_Arming::Method method) const override { return false; };
     bool is_autopilot() const override { return false; }
+    bool disable_crash_check() const override { return true; }
 
 protected:
 

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -2433,8 +2433,6 @@ class TestSuite(ABC):
             "SIM_DRIFT_SPEED",
             "SIM_DRIFT_TIME",
             "SIM_EFI_TYPE",
-            "SIM_ENGINE_FAIL",
-            "SIM_ENGINE_MUL",
             "SIM_ESC_ARM_RPM",
             "SIM_FTOWESC_ENA",
             "SIM_FTOWESC_POW",

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -68,6 +68,10 @@ const AP_Param::GroupInfo SIM::var_info[] = {
     
     AP_GROUPINFO("DRIFT_SPEED",    5, SIM,  drift_speed, 0.05f),
     AP_GROUPINFO("DRIFT_TIME",     6, SIM,  drift_time,  5),
+    // @Param: ENGINE_MUL
+    // @DisplayName: Engine failure thrust scaler
+    // @Description: Thrust from Motors in SIM_ENGINE_FAIL will be multiplied by this factor
+    // @Units: ms
     AP_GROUPINFO("ENGINE_MUL",     8, SIM,  engine_mul,  1),
     // @Param: WIND_SPD
     // @DisplayName: Simulated Wind speed
@@ -189,6 +193,10 @@ const AP_Param::GroupInfo SIM::var_info[] = {
     // @Units: m
     // @Vector3Parameter: 1
     AP_GROUPINFO("FLOW_POS",      56, SIM,  optflow_pos_offset, 0),
+    // @Param: ENGINE_FAIL
+    // @DisplayName: Engine Fail Mask
+    // @Description: mask of motors which SIM_ENGINE_MUL will be applied to
+    // @Bitmask: 0: Servo 1, 1: Servo 2, 2: Servo 3, 3: Servo 4, 4: Servo 5, 5: Servo 6, 6: Servo 7, 7: Servo 8
     AP_GROUPINFO("ENGINE_FAIL",   58, SIM,  engine_fail,  0),
     AP_SUBGROUPINFO(models, "",   59, SIM, SIM::ModelParm),
     AP_SUBGROUPEXTENSION("",      60, SIM,  var_mag),


### PR DESCRIPTION
prevents looking for specific modes in the crash checker

Replaces https://github.com/ArduPilot/ardupilot/pull/20000/files

Tested the crash checker works on the bench in Loiter with a CubeOrange.

Can't easily test in SITL because of attitude reset on ground interaction
