### PR TITLE
AP_Scripting: fix failures with require()

### DIFF
--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -5308,6 +5308,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
         self.install_test_scripts_context([
             "scripting_test.lua",
+            "scripting_require_test_2.lua",
             "math.lua",
             "strings.lua",
             "mavlink_test.lua",
@@ -5320,6 +5321,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
         for success_text in [
                 "Internal tests passed",
+                "Require test 2 passed",
                 "Math tests passed",
                 "String tests passed",
                 "Received heartbeat from"

--- a/libraries/AP_Scripting/AP_Scripting.h
+++ b/libraries/AP_Scripting/AP_Scripting.h
@@ -122,8 +122,8 @@ public:
     // PWMSource storage
     uint8_t num_pwm_source;
     AP_HAL::PWMSource *_pwm_source[SCRIPTING_MAX_NUM_PWM_SOURCE];
-    int get_current_ref() { return current_ref; }
-    void set_current_ref(int ref) { current_ref = ref; }
+    int get_current_env_ref() { return current_env_ref; }
+    void set_current_env_ref(int ref) { current_env_ref = ref; }
 
 #if AP_NETWORKING_ENABLED
     // SocketAPM storage
@@ -193,7 +193,7 @@ private:
     bool _stop; // true if scripts should be stopped
 
     static AP_Scripting *_singleton;
-    int current_ref;
+    int current_env_ref;
 };
 
 namespace AP {

--- a/libraries/AP_Scripting/lua/src/loadlib.c
+++ b/libraries/AP_Scripting/lua/src/loadlib.c
@@ -622,26 +622,25 @@ static void findloader (lua_State *L, const char *name) {
 static int ll_require (lua_State *L) {
   const char *name = luaL_checkstring(L, 1);
   lua_settop(L, 1);
-  lua_rawgeti(L, LUA_REGISTRYINDEX, lua_get_current_ref()); /* get the current script */
-  lua_getupvalue(L, 2, 1); /* get the environment of the script */
-  lua_getfield(L, 3, LUA_LOADED_TABLE); /* get _LOADED */
-  lua_getfield(L, 4, name);  /* LOADED[name] */
+  lua_rawgeti(L, LUA_REGISTRYINDEX, lua_get_current_env_ref()); /* get the environment of the current script */
+  lua_getfield(L, 2, LUA_LOADED_TABLE); /* get _LOADED */
+  lua_getfield(L, 3, name);  /* LOADED[name] */
   if (lua_toboolean(L, -1))  /* is it there? */
     return 1;  /* package is already loaded */
   /* else must load package */
   lua_pop(L, 1);  /* remove 'getfield' result */
   findloader(L, name);
-  lua_pushvalue(L, 3); /* push current script's environment */
+  lua_pushvalue(L, 2); /* push current script's environment */
   lua_setupvalue(L, -3, 1); /* set the environment of the module */
   lua_pushstring(L, name);  /* pass name as argument to module loader */
   lua_insert(L, -2);  /* name is 1st argument (before search data) */
   lua_call(L, 2, 1);  /* run loader to load module */
   if (!lua_isnil(L, -1))  /* non-nil return? */
-    lua_setfield(L, 4, name);  /* LOADED[name] = returned value */
-  if (lua_getfield(L, 4, name) == LUA_TNIL) {   /* module set no value? */
+    lua_setfield(L, 3, name);  /* LOADED[name] = returned value */
+  if (lua_getfield(L, 3, name) == LUA_TNIL) {   /* module set no value? */
     lua_pushboolean(L, 1);  /* use true as result */
     lua_pushvalue(L, -1);  /* extra copy to be returned */
-    lua_setfield(L, 4, name);  /* LOADED[name] = true */
+    lua_setfield(L, 3, name);  /* LOADED[name] = true */
   }
   return 1;
 }

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -1025,10 +1025,10 @@ int SocketAPM_accept(lua_State *L) {
 #endif // AP_NETWORKING_ENABLED
 
 
-int lua_get_current_ref()
+int lua_get_current_env_ref()
 {
     auto *scripting = AP::scripting();
-    return scripting->get_current_ref();
+    return scripting->get_current_env_ref();
 }
 
 // This is used when loading modules with require, lua must only look in enabled directory's

--- a/libraries/AP_Scripting/lua_common_defs.h
+++ b/libraries/AP_Scripting/lua_common_defs.h
@@ -10,7 +10,7 @@
   #endif //HAL_OS_FATFS_IO
 #endif // SCRIPTING_DIRECTORY
 
-int lua_get_current_ref();
+int lua_get_current_env_ref();
 const char* lua_get_modules_path();
 void lua_abort(void) __attribute__((noreturn));
 

--- a/libraries/AP_Scripting/lua_scripts.h
+++ b/libraries/AP_Scripting/lua_scripts.h
@@ -62,7 +62,7 @@ private:
     void create_sandbox(lua_State *L);
 
     typedef struct script_info {
-       int lua_ref;          // reference to the loaded script object
+       int env_ref;          // reference to the script's environment table
        int run_ref;          // reference to the function to run
        uint64_t next_run_ms; // time (in milliseconds) the script should next be run at
        uint32_t crc;         // crc32 checksum
@@ -111,7 +111,6 @@ private:
     static HAL_Semaphore error_msg_buf_sem;
     static uint8_t print_error_count;
     static uint32_t last_print_ms;
-    int current_ref;
 
     // XOR of crc32 of running scripts
     static uint32_t loaded_checksum;

--- a/libraries/AP_Scripting/lua_scripts.h
+++ b/libraries/AP_Scripting/lua_scripts.h
@@ -63,6 +63,7 @@ private:
 
     typedef struct script_info {
        int lua_ref;          // reference to the loaded script object
+       int run_ref;          // reference to the function to run
        uint64_t next_run_ms; // time (in milliseconds) the script should next be run at
        uint32_t crc;         // crc32 checksum
        char *name;           // filename for the script // FIXME: This information should be available from Lua

--- a/libraries/AP_Scripting/tests/scripting_require_test_2.lua
+++ b/libraries/AP_Scripting/tests/scripting_require_test_2.lua
@@ -1,0 +1,35 @@
+-- main require tests are in scripting_test.lua
+
+-- DO NOT EDIT!!!! it's very easy to make this accidentally pass even when the
+-- original problem is still present!! we do some very careful work to check
+-- that require works even when the function's first upvalue is not the script
+-- environment.
+
+local loop_time = 500 -- number of ms between runs
+
+-- need to shadow gcs to make the upvalues right
+local gcs = gcs -- luacheck: ignore
+
+local passes = 0 -- run both before and after scheduling
+
+local require_global = require("test/nested")
+
+local function update()
+   -- need to send before requiring to make the upvalues right
+  gcs:send_text(6, "testing")
+  local require_local = require("test/nested") -- should not crash
+
+  -- validate we got the same object (object contents validated in main test)
+  if require_local == require_global then
+    passes = passes + 1
+  else
+    gcs:send_text(0, "Failed: require returned different objects")
+  end
+  if passes >= 3 then
+    gcs:send_text(3, "Require test 2 passed")
+  end
+
+  return update, loop_time
+end
+
+return update() -- run immediately before starting to reschedule


### PR DESCRIPTION
The `require()` function needs the environment of the currently executing script to get the table of loaded modules. It currently does this by getting the first upvalue of the function currently used to run the script and hoping that is the environment table it needs. However, that function (and hence the upvalues) can change every time the script reschedules, so there is no guarantee that the environment table will be where `require()` needs it, and indeed it is possible to accidentally create a script where `require()` fails with a mysterious Lua error.

Correct the issue by splitting the script reference originally used by `require()` into a reference to the function used to run the script, and a separate reference specifically for the environment table, which `require()` now uses. Also add a (n admittedly fragile) test that the issue is resolved. Tested in SITL and on Cube Orange with my REPL that `require()` works properly and the issue is fixed.

Bonus: saves 184 bytes of flash on Cube Orange because `lua_getupvalue` is no longer used anywhere