### PR TITLE
Replace PWM_TYPE* with PWMType::

### DIFF
--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -400,13 +400,17 @@ void AP_BLHeli::msp_process_command(void)
         msp_send_reply(msp.cmdMSP, (const uint8_t *)UDID_START, 12);
         break;
 
+        // a literal "4" is used for the PWMType here to allow Rover
+        // to use the same number for the same protocol.  At time of
+        // writing the AP_MotorsUGV::PWMType has not been unified with
+        // AP_Motors::PWMType.
     case MSP_ADVANCED_CONFIG: {
         debug("MSP_ADVANCED_CONFIG");
         uint8_t buf[10];
         buf[0] = 1; // gyro sync denom
         buf[1] = 4; // pid process denom
         buf[2] = 0; // use unsynced pwm
-        buf[3] = (uint8_t)PWM_TYPE_DSHOT150; // motor PWM protocol
+        buf[3] = 4; // (uint8_t)AP_Motors::PWMType::DSHOT150;
         putU16(&buf[4], 480); // motor PWM Rate
         putU16(&buf[6], 450); // idle offset value
         buf[8] = 0; // use 32kHz

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -90,7 +90,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @Values: 0:Normal,1:OneShot,2:OneShot125,3:Brushed,4:DShot150,5:DShot300,6:DShot600,7:DShot1200,8:PWMRange,9:PWMAngle
     // @User: Advanced
     // @RebootRequired: True
-    AP_GROUPINFO("PWM_TYPE", 15, AP_MotorsMulticopter, _pwm_type, PWM_TYPE_NORMAL),
+    AP_GROUPINFO("PWM_TYPE", 15, AP_MotorsMulticopter, _pwm_type, float(PWMType::NORMAL)),
 
     // @Param: PWM_MIN
     // @DisplayName: PWM output minimum
@@ -474,7 +474,7 @@ void AP_MotorsMulticopter::update_throttle_range()
 {
     // if all outputs are digital adjust the range. We also do this for type PWM_RANGE, as those use the
     // scaled output, which is then mapped to PWM via the SRV_Channel library
-    if (SRV_Channels::have_digital_outputs(get_motor_mask()) || (_pwm_type == PWM_TYPE_PWM_RANGE) || (_pwm_type == PWM_TYPE_PWM_ANGLE)) {
+    if (SRV_Channels::have_digital_outputs(get_motor_mask()) || (_pwm_type == PWMType::PWM_RANGE) || (_pwm_type == PWMType::PWM_ANGLE)) {
         _pwm_min.set_and_default(1000);
         _pwm_max.set_and_default(2000);
     }

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -135,35 +135,35 @@ void AP_Motors::rc_set_freq(uint32_t motor_mask, uint16_t freq_hz)
     hal.rcout->set_freq(mask, freq_hz);
     hal.rcout->set_dshot_esc_type(SRV_Channels::get_dshot_esc_type());
 
-    const pwm_type type = (pwm_type)_pwm_type.get();
+    const PWMType type = _pwm_type;
     switch (type) {
-    case PWM_TYPE_ONESHOT:
+    case PWMType::ONESHOT:
         if (freq_hz > 50 && mask != 0) {
             hal.rcout->set_output_mode(mask, AP_HAL::RCOutput::MODE_PWM_ONESHOT);
         }
         break;
-    case PWM_TYPE_ONESHOT125:
+    case PWMType::ONESHOT125:
         if (freq_hz > 50 && mask != 0) {
             hal.rcout->set_output_mode(mask, AP_HAL::RCOutput::MODE_PWM_ONESHOT125);
         }
         break;
-    case PWM_TYPE_BRUSHED:
+    case PWMType::BRUSHED:
         hal.rcout->set_output_mode(mask, AP_HAL::RCOutput::MODE_PWM_BRUSHED);
         break;
-    case PWM_TYPE_DSHOT150:
+    case PWMType::DSHOT150:
         hal.rcout->set_output_mode(mask, AP_HAL::RCOutput::MODE_PWM_DSHOT150);
         break;
-    case PWM_TYPE_DSHOT300:
+    case PWMType::DSHOT300:
         hal.rcout->set_output_mode(mask, AP_HAL::RCOutput::MODE_PWM_DSHOT300);
         break;
-    case PWM_TYPE_DSHOT600:
+    case PWMType::DSHOT600:
         hal.rcout->set_output_mode(mask, AP_HAL::RCOutput::MODE_PWM_DSHOT600);
         break;
-    case PWM_TYPE_DSHOT1200:
+    case PWMType::DSHOT1200:
         hal.rcout->set_output_mode(mask, AP_HAL::RCOutput::MODE_PWM_DSHOT1200);
         break;
-    case PWM_TYPE_PWM_RANGE:
-    case PWM_TYPE_PWM_ANGLE:
+    case PWMType::PWM_RANGE:
+    case PWMType::PWM_ANGLE:
         /*
           this is a motor output type for multirotors which honours
           the SERVOn_MIN/MAX (and TRIM for angle) values per channel
@@ -173,20 +173,20 @@ void AP_Motors::rc_set_freq(uint32_t motor_mask, uint16_t freq_hz)
           Angle type offsets by 1500 to get -500 to 500.
          */
 
-        if (type == PWM_TYPE_PWM_RANGE) {
+        if (type == PWMType::PWM_RANGE) {
             _motor_pwm_scaled.offset = 1000.0;
         } else {
-            // PWM_TYPE_PWM_ANGLE
+            // PWMType::PWM_ANGLE
             _motor_pwm_scaled.offset = 1500.0;
         }
 
         _motor_pwm_scaled.mask |= motor_mask;
         for (uint8_t i=0; i<16; i++) {
             if ((1U<<i) & motor_mask) {
-                if (type == PWM_TYPE_PWM_RANGE) {
+                if (type == PWMType::PWM_RANGE) {
                     SRV_Channels::set_range(SRV_Channels::get_motor_function(i), 1000);
                 } else {
-                    // PWM_TYPE_PWM_ANGLE
+                    // PWMType::PWM_ANGLE
                     SRV_Channels::set_angle(SRV_Channels::get_motor_function(i), 500);
                 }
             }
@@ -251,19 +251,19 @@ void AP_Motors::set_external_limits(bool roll, bool pitch, bool yaw, bool thrott
 // returns true if the configured PWM type is digital and should have fixed endpoints
 bool AP_Motors::is_digital_pwm_type() const
 {
-    switch (_pwm_type) {
-        case PWM_TYPE_DSHOT150:
-        case PWM_TYPE_DSHOT300:
-        case PWM_TYPE_DSHOT600:
-        case PWM_TYPE_DSHOT1200:
-            return true;
-        case PWM_TYPE_NORMAL:
-        case PWM_TYPE_ONESHOT:
-        case PWM_TYPE_ONESHOT125:
-        case PWM_TYPE_BRUSHED:
-        case PWM_TYPE_PWM_RANGE:
-        case PWM_TYPE_PWM_ANGLE:
-            break;
+    switch ((PWMType)_pwm_type) {
+    case PWMType::DSHOT150:
+    case PWMType::DSHOT300:
+    case PWMType::DSHOT600:
+    case PWMType::DSHOT1200:
+        return true;
+    case PWMType::NORMAL:
+    case PWMType::ONESHOT:
+    case PWMType::ONESHOT125:
+    case PWMType::BRUSHED:
+    case PWMType::PWM_RANGE:
+    case PWMType::PWM_ANGLE:
+        break;
     }
     return false;
 }

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -262,10 +262,10 @@ public:
     bool is_digital_pwm_type() const;
 
     // returns true is pwm type is brushed
-    bool is_brushed_pwm_type() const { return _pwm_type == PWM_TYPE_BRUSHED; }
+    bool is_brushed_pwm_type() const { return _pwm_type == PWMType::BRUSHED; }
 
     // returns true is pwm type is normal
-    bool is_normal_pwm_type() const { return (_pwm_type == PWM_TYPE_NORMAL) || (_pwm_type == PWM_TYPE_PWM_RANGE) || (_pwm_type == PWM_TYPE_PWM_ANGLE); }
+    bool is_normal_pwm_type() const { return (_pwm_type == PWMType::NORMAL) || (_pwm_type == PWMType::PWM_RANGE) || (_pwm_type == PWMType::PWM_ANGLE); }
 
     MAV_TYPE get_frame_mav_type() const { return _mav_type; }
 
@@ -333,7 +333,7 @@ protected:
     // mask of what channels need fast output
     uint32_t            _motor_fast_mask;
 
-    // Used with PWM_TYPE_PWM_RANGE and PWM_TYPE_PWM_ANGLE
+    // Used with PWMType::PWM_RANGE and PWMType::PWM_ANGLE
     struct {
         // Mask of motors using scaled output
         uint32_t mask;
@@ -349,7 +349,20 @@ protected:
     float _throttle_radio_passthrough; // throttle/collective input from pilot in 0 ~ 1 range.  used for setup and providing servo feedback while landed
     float _yaw_radio_passthrough;      // yaw input from pilot in -1 ~ +1 range.  used for setup and providing servo feedback while landed
 
-    AP_Int8             _pwm_type;            // PWM output type
+    enum class PWMType : uint8_t {
+        NORMAL     = 0,
+        ONESHOT    = 1,
+        ONESHOT125 = 2,
+        BRUSHED    = 3,
+        DSHOT150   = 4,
+        DSHOT300   = 5,
+        DSHOT600   = 6,
+        DSHOT1200  = 7,
+        PWM_RANGE  = 8,
+        PWM_ANGLE  = 9,
+    };
+
+    AP_Enum<PWMType>             _pwm_type;            // PWM output type
 
     // motor failure handling
     bool                _thrust_boost;          // true if thrust boost is enabled to handle motor failure
@@ -360,19 +373,6 @@ protected:
     AP_Int16            _options;
 
     MAV_TYPE _mav_type; // MAV_TYPE_GENERIC = 0;
-
-    enum pwm_type {
-        PWM_TYPE_NORMAL     = 0,
-        PWM_TYPE_ONESHOT    = 1,
-        PWM_TYPE_ONESHOT125 = 2,
-        PWM_TYPE_BRUSHED    = 3,
-        PWM_TYPE_DSHOT150   = 4,
-        PWM_TYPE_DSHOT300   = 5,
-        PWM_TYPE_DSHOT600   = 6,
-        PWM_TYPE_DSHOT1200  = 7,
-        PWM_TYPE_PWM_RANGE  = 8,
-        PWM_TYPE_PWM_ANGLE  = 9
-    };
 
     // return string corresponding to frame_class
     virtual const char* _get_frame_string() const = 0;

--- a/libraries/AR_Motors/AP_MotorsUGV.cpp
+++ b/libraries/AR_Motors/AP_MotorsUGV.cpp
@@ -33,7 +33,7 @@ const AP_Param::GroupInfo AP_MotorsUGV::var_info[] = {
     // @Values: 0:Normal,1:OneShot,2:OneShot125,3:BrushedWithRelay,4:BrushedBiPolar,5:DShot150,6:DShot300,7:DShot600,8:DShot1200
     // @User: Advanced
     // @RebootRequired: True
-    AP_GROUPINFO("PWM_TYPE", 1, AP_MotorsUGV, _pwm_type, PWM_TYPE_NORMAL),
+    AP_GROUPINFO("PWM_TYPE", 1, AP_MotorsUGV, _pwm_type, PWMType::NORMAL),
 
     // @Param: PWM_FREQ
     // @DisplayName: Motor Output PWM freq for brushed motors
@@ -149,7 +149,7 @@ void AP_MotorsUGV::init(uint8_t frtype)
 
 bool AP_MotorsUGV::get_legacy_relay_index(int8_t &index1, int8_t &index2, int8_t &index3, int8_t &index4) const
 {
-    if (_pwm_type != PWM_TYPE_BRUSHED_WITH_RELAY) {
+    if (_pwm_type != PWMType::BRUSHED_WITH_RELAY) {
         // Relays only used if PWM type is set to brushed with relay
         return false;
     }
@@ -177,7 +177,7 @@ bool AP_MotorsUGV::get_legacy_relay_index(int8_t &index1, int8_t &index2, int8_t
 // setup output in case of main CPU failure
 void AP_MotorsUGV::setup_safety_output()
 {
-    if (_pwm_type == PWM_TYPE_BRUSHED_WITH_RELAY) {
+    if (_pwm_type == PWMType::BRUSHED_WITH_RELAY) {
         // set trim to min to set duty cycle range (0 - 100%) to servo range
         // ignore servo revese flag, it is used by the relay
         SRV_Channels::set_trim_to_min_for(SRV_Channel::k_throttle, true);
@@ -529,7 +529,7 @@ bool AP_MotorsUGV::pre_arm_check(bool report) const
     // Check relays are configured for brushed with relay outputs
 #if AP_RELAY_ENABLED
     AP_Relay*relay = AP::relay();
-    if ((_pwm_type == PWM_TYPE_BRUSHED_WITH_RELAY) && (relay != nullptr)) {
+    if ((_pwm_type == PWMType::BRUSHED_WITH_RELAY) && (relay != nullptr)) {
         // If a output is configured its relay must be enabled
         struct RelayTable {
             bool output_assigned;
@@ -581,27 +581,27 @@ void AP_MotorsUGV::setup_pwm_type()
     }
 
     switch (_pwm_type) {
-    case PWM_TYPE_ONESHOT:
+    case PWMType::ONESHOT:
         hal.rcout->set_output_mode(_motor_mask, AP_HAL::RCOutput::MODE_PWM_ONESHOT);
         break;
-    case PWM_TYPE_ONESHOT125:
+    case PWMType::ONESHOT125:
         hal.rcout->set_output_mode(_motor_mask, AP_HAL::RCOutput::MODE_PWM_ONESHOT125);
         break;
-    case PWM_TYPE_BRUSHED_WITH_RELAY:
-    case PWM_TYPE_BRUSHED_BIPOLAR:
+    case PWMType::BRUSHED_WITH_RELAY:
+    case PWMType::BRUSHED_BIPOLAR:
         hal.rcout->set_output_mode(_motor_mask, AP_HAL::RCOutput::MODE_PWM_BRUSHED);
         hal.rcout->set_freq(_motor_mask, uint16_t(_pwm_freq * 1000));
         break;
-    case PWM_TYPE_DSHOT150:
+    case PWMType::DSHOT150:
         hal.rcout->set_output_mode(_motor_mask, AP_HAL::RCOutput::MODE_PWM_DSHOT150);
         break;
-    case PWM_TYPE_DSHOT300:
+    case PWMType::DSHOT300:
         hal.rcout->set_output_mode(_motor_mask, AP_HAL::RCOutput::MODE_PWM_DSHOT300);
         break;
-    case PWM_TYPE_DSHOT600:
+    case PWMType::DSHOT600:
         hal.rcout->set_output_mode(_motor_mask, AP_HAL::RCOutput::MODE_PWM_DSHOT600);
         break;
-    case PWM_TYPE_DSHOT1200:
+    case PWMType::DSHOT1200:
         hal.rcout->set_output_mode(_motor_mask, AP_HAL::RCOutput::MODE_PWM_DSHOT1200);
         break;
     default:
@@ -988,7 +988,7 @@ void AP_MotorsUGV::output_throttle(SRV_Channel::Aux_servo_function_t function, f
     // set relay if necessary
 #if AP_RELAY_ENABLED
     AP_Relay*relay = AP::relay();
-    if ((_pwm_type == PWM_TYPE_BRUSHED_WITH_RELAY) && (relay != nullptr)) {
+    if ((_pwm_type == PWMType::BRUSHED_WITH_RELAY) && (relay != nullptr)) {
 
         // find the output channel, if not found return
         const SRV_Channel *out_chan = SRV_Channels::get_channel_for(function);
@@ -1153,17 +1153,17 @@ bool AP_MotorsUGV::active() const
 bool AP_MotorsUGV::is_digital_pwm_type() const
 {
     switch (_pwm_type) {
-        case PWM_TYPE_DSHOT150:
-        case PWM_TYPE_DSHOT300:
-        case PWM_TYPE_DSHOT600:
-        case PWM_TYPE_DSHOT1200:
-            return true;
-        case PWM_TYPE_NORMAL:
-        case PWM_TYPE_ONESHOT:
-        case PWM_TYPE_ONESHOT125:
-        case PWM_TYPE_BRUSHED_WITH_RELAY:
-        case PWM_TYPE_BRUSHED_BIPOLAR:
-            break;
+    case PWMType::DSHOT150:
+    case PWMType::DSHOT300:
+    case PWMType::DSHOT600:
+    case PWMType::DSHOT1200:
+        return true;
+    case PWMType::NORMAL:
+    case PWMType::ONESHOT:
+    case PWMType::ONESHOT125:
+    case PWMType::BRUSHED_WITH_RELAY:
+    case PWMType::BRUSHED_BIPOLAR:
+        break;
     }
     return false;
 }

--- a/libraries/AR_Motors/AP_MotorsUGV.h
+++ b/libraries/AR_Motors/AP_MotorsUGV.h
@@ -131,16 +131,16 @@ public:
 
 private:
 
-    enum pwm_type {
-        PWM_TYPE_NORMAL = 0,
-        PWM_TYPE_ONESHOT = 1,
-        PWM_TYPE_ONESHOT125 = 2,
-        PWM_TYPE_BRUSHED_WITH_RELAY = 3,
-        PWM_TYPE_BRUSHED_BIPOLAR = 4,
-        PWM_TYPE_DSHOT150 = 5,
-        PWM_TYPE_DSHOT300 = 6,
-        PWM_TYPE_DSHOT600 = 7,
-        PWM_TYPE_DSHOT1200 = 8
+    enum PWMType {
+        NORMAL = 0,
+        ONESHOT = 1,
+        ONESHOT125 = 2,
+        BRUSHED_WITH_RELAY = 3,
+        BRUSHED_BIPOLAR = 4,
+        DSHOT150 = 5,
+        DSHOT300 = 6,
+        DSHOT600 = 7,
+        DSHOT1200 = 8
     };
 
     // sanity check parameters


### PR DESCRIPTION
Unfortunately we have two enumerations which convey similar information but are different between Copter and Rover.

It would be nice to unify them, but that would require parameter conversion (and change-in-name of the most  critical parameter on Rover, meaning much documenation change!)

In the meantime, add proper namespacing to the enumerations.

Also changed blheli to always return "4" in one of the MSP packets.  We should really not be bearing internal ArduPilot values like this in one of these packets.  Right now in master Copter will put one number in this field and Rover will put a different one - but they're both "DShot150".... if the number is not used we should probably use a flag value rather than a real number so we don't give the wrong impression to any client.

Replaces https://github.com/ArduPilot/ardupilot/pull/20009
