### PR TITLE
Copter/Plane/Rover/Tracker: 4.5.5-beta2 release

### DIFF
--- a/AntennaTracker/ReleaseNotes.txt
+++ b/AntennaTracker/ReleaseNotes.txt
@@ -1,5 +1,14 @@
 Antenna Tracker Release Notes:
-------------------------------
+------------------------------------------------------------------
+Release 4.5.5-beta2 27 July 2024
+
+Changes from 4.5.5-beta1
+
+1) Board specific enhancements and bug fixes
+
+- CubeRed's second core disabled at boot to avoid spurious writes to RAM
+- CubeRed bootloader's dual endpoint update method fixed
+------------------------------------------------------------------
 Release 4.5.5-beta1 1st July 2024
 
 Changes from 4.5.4

--- a/AntennaTracker/version.h
+++ b/AntennaTracker/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "AntennaTracker V4.5.5-beta1"
+#define THISFIRMWARE "AntennaTracker V4.5.5-beta2"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,5,5,FIRMWARE_VERSION_TYPE_BETA
+#define FIRMWARE_VERSION 4,5,5,FIRMWARE_VERSION_TYPE_BETA+1
 
 #define FW_MAJOR 4
 #define FW_MINOR 5
 #define FW_PATCH 5
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA+1
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,5 +1,14 @@
 ArduPilot Copter Release Notes:
--------------------------------
+------------------------------------------------------------------
+Release 4.5.5-beta2 27 July 2024
+
+Changes from 4.5.5-beta1
+
+1) Board specific enhancements and bug fixes
+
+- CubeRed's second core disabled at boot to avoid spurious writes to RAM
+- CubeRed bootloader's dual endpoint update method fixed
+------------------------------------------------------------------
 Release 4.5.5-beta1 1st July 2024
 
 Changes from 4.5.4

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.5.5-beta1"
+#define THISFIRMWARE "ArduCopter V4.5.5-beta2"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,5,5,FIRMWARE_VERSION_TYPE_BETA
+#define FIRMWARE_VERSION 4,5,5,FIRMWARE_VERSION_TYPE_BETA+1
 
 #define FW_MAJOR 4
 #define FW_MINOR 5
 #define FW_PATCH 5
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA+1
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/ArduPlane/ReleaseNotes.txt
+++ b/ArduPlane/ReleaseNotes.txt
@@ -1,5 +1,14 @@
 ArduPilot Plane Release Notes:
-------------------------------
+------------------------------------------------------------------
+Release 4.5.5-beta2 27 July 2024
+
+Changes from 4.5.5-beta1
+
+1) Board specific enhancements and bug fixes
+
+- CubeRed's second core disabled at boot to avoid spurious writes to RAM
+- CubeRed bootloader's dual endpoint update method fixed
+------------------------------------------------------------------
 Release 4.5.5-beta1 1st July 2024
 
 Changes from 4.5.4

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduPlane V4.5.5-beta1"
+#define THISFIRMWARE "ArduPlane V4.5.5-beta2"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,5,5,FIRMWARE_VERSION_TYPE_BETA
+#define FIRMWARE_VERSION 4,5,5,FIRMWARE_VERSION_TYPE_BETA+1
 
 #define FW_MAJOR 4
 #define FW_MINOR 5
 #define FW_PATCH 5
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA+1
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/Rover/ReleaseNotes.txt
+++ b/Rover/ReleaseNotes.txt
@@ -1,5 +1,14 @@
 Rover Release Notes:
---------------------
+------------------------------------------------------------------
+Release 4.5.5-beta2 27 July 2024
+
+Changes from 4.5.5-beta1
+
+1) Board specific enhancements and bug fixes
+
+- CubeRed's second core disabled at boot to avoid spurious writes to RAM
+- CubeRed bootloader's dual endpoint update method fixed
+------------------------------------------------------------------
 Release 4.5.5-beta1 1st July 2024
 
 Changes from 4.5.4

--- a/Rover/version.h
+++ b/Rover/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduRover V4.5.5-beta1"
+#define THISFIRMWARE "ArduRover V4.5.5-beta2"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,5,5,FIRMWARE_VERSION_TYPE_BETA
+#define FIRMWARE_VERSION 4,5,5,FIRMWARE_VERSION_TYPE_BETA+1
 
 #define FW_MAJOR 4
 #define FW_MINOR 5
 #define FW_PATCH 5
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA+1
 
 #include <AP_Common/AP_FWVersionDefine.h>


### PR DESCRIPTION
This the Copter, Rover, Tracker, Plane 4.5.5-beta2 release and includes just a single PR

- https://github.com/ArduPilot/ardupilot/pull/27458

Everything included in 4.5.5 can be seen in [this project](https://github.com/orgs/ArduPilot/projects/8/views/6)