### PR TITLE
AP_TemperatureSensor: add logging option to only log sensors with no source

### DIFF
--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor.cpp
@@ -40,12 +40,14 @@ const AP_Param::GroupInfo AP_TemperatureSensor::var_info[] = {
 
     // SKIP INDEX 0
 
+#if HAL_LOGGING_ENABLED
     // @Param: _LOG
     // @DisplayName: Logging
     // @Description: Enables temperature sensor logging
-    // @Values: 0:Disabled, 1:Enabled
+    // @Values: 0:Disabled, 1:Log all instances, 2: Log only instances with sensor source set to None
     // @User: Standard
-    AP_GROUPINFO("_LOG", 1, AP_TemperatureSensor, _log_flag, 0),
+    AP_GROUPINFO("_LOG", 1, AP_TemperatureSensor, _logging_type, 0),
+#endif
 
     // SKIP Index 2-9 to be for parameters that apply to every sensor
 
@@ -239,7 +241,9 @@ void AP_TemperatureSensor::update()
 
 #if HAL_LOGGING_ENABLED
             const AP_Logger *logger = AP_Logger::get_singleton();
-            if (logger != nullptr && _log_flag) {
+            const bool should_log = (_logging_type == LoggingType::All) ||
+                                    ((_logging_type == LoggingType::SourceNone) && (_params[i].source == AP_TemperatureSensor_Params::Source::None));
+            if (logger != nullptr && should_log) {
                 drivers[i]->Log_Write_TEMP();
             }
 #endif

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor.h
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor.h
@@ -88,8 +88,14 @@ private:
 
     uint8_t     _num_instances;         // number of temperature sensors
 
-    // Parameters
-    AP_Int8 _log_flag;                  // log_flag: true if we should log all sensors data
+#if HAL_LOGGING_ENABLED
+    enum class LoggingType : uint8_t {
+        All = 1,
+        SourceNone = 2,
+    };
+    AP_Enum<LoggingType> _logging_type;
+#endif
+
 };
 
 namespace AP {


### PR DESCRIPTION
If temperature sensors have a source set then there values are logged elsewhere. ESC and motor temp are logged in the ESC message, battery temperature is logged by the battery monitor. This allows those sensors to not be logged individually while keeping logging of any additional sensors, this reduces log size and makes log review less confusing. 

