### PR TITLE
CI: only run qurt build on ArduPilot main repo

### DIFF
--- a/.github/workflows/qurt_build.yml
+++ b/.github/workflows/qurt_build.yml
@@ -141,8 +141,8 @@ concurrency:
 
 jobs:
   build:
+    if: github.repository == 'ArduPilot/ardupilot'
     runs-on: 'ardupilot-qurt'
-
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
this prevents user repos getting failures

thanks to Pete for the suggestion