### PR TITLE
hwdef: remove EKF opinion from FlywooF745

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/FlywooF745/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/FlywooF745/hwdef.dat
@@ -162,10 +162,6 @@ ROMFS_WILDCARD libraries/AP_OSD/fonts/font0.bin
 # define HAL_GYROFFT_ENABLED 1
 # define AP_OAPATHPLANNER_ENABLED 0
 
-# EK2 options (disabled by default)
-# define HAL_NAVEKF2_AVAILABLE 1
-# define HAL_NAVEKF3_AVAILABLE 0
-
 # save some flash
 include ../include/minimize_fpv_osd.inc
 include ../include/no_bootloader_DFU.inc


### PR DESCRIPTION
No effect as lines have always been commented out, but not useful and EKF2 is not something to encourage.

Verified no compiler output change.