### PR TITLE
Fix for unhandled TKOFF_THR_MAX

### DIFF
--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -534,12 +534,17 @@ float Plane::apply_throttle_limits(float throttle_in)
             // Or (in contrast) to give some extra throttle during the initial climb.
             max_throttle = aparm.takeoff_throttle_max.get();
         }
+
         // Do not allow min throttle to go below a lower threshold.
         // This is typically done to protect against premature stalls close to the ground.
         const bool use_throttle_range = (aparm.takeoff_options & (uint32_t)AP_FixedWing::TakeoffOption::THROTTLE_RANGE);
         if (!use_throttle_range || !ahrs.using_airspeed_sensor()) {
             // Use a constant max throttle throughout the takeoff or when airspeed readings are not available.
-            min_throttle = MAX(min_throttle, aparm.takeoff_throttle_max.get());
+            if (aparm.takeoff_throttle_max.get() == 0) {
+                min_throttle = MAX(min_throttle, aparm.throttle_max.get());
+            } else {
+                min_throttle = MAX(min_throttle, aparm.takeoff_throttle_max.get());
+            }
         } else if (use_throttle_range) { // Use a throttle range through the takeoff.
             if (aparm.takeoff_throttle_min.get() != 0) { // This is enabled by TKOFF_MODE==1.
                 min_throttle = MAX(min_throttle, aparm.takeoff_throttle_min.get());

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -521,12 +521,10 @@ float Plane::apply_throttle_limits(float throttle_in)
 
     // Query the conditions where TKOFF_THR_MAX applies.
     const bool use_takeoff_throttle =
-#if HAL_QUADPLANE_ENABLED
-        quadplane.in_transition() ||
-#endif
         (flight_stage == AP_FixedWing::FlightStage::TAKEOFF) ||
         (flight_stage == AP_FixedWing::FlightStage::ABORT_LANDING);
 
+    // Handle throttle limits for takeoff conditions.
     if (use_takeoff_throttle) {
         if (aparm.takeoff_throttle_max != 0) {
             // Replace max throttle with the takeoff max throttle setting.
@@ -534,7 +532,6 @@ float Plane::apply_throttle_limits(float throttle_in)
             // Or (in contrast) to give some extra throttle during the initial climb.
             max_throttle = aparm.takeoff_throttle_max.get();
         }
-
         // Do not allow min throttle to go below a lower threshold.
         // This is typically done to protect against premature stalls close to the ground.
         const bool use_throttle_range = (aparm.takeoff_options & (uint32_t)AP_FixedWing::TakeoffOption::THROTTLE_RANGE);
@@ -555,6 +552,15 @@ float Plane::apply_throttle_limits(float throttle_in)
         // This is to allow the aircraft to bleed speed faster and land with a shut off thruster.
         min_throttle = 0;
     }
+
+    // Handle throttle limits for transition conditions.
+#if HAL_QUADPLANE_ENABLED
+    if (quadplane.in_transition()) {
+        if (aparm.takeoff_throttle_max != 0) {
+            max_throttle = aparm.takeoff_throttle_max.get();
+        }
+    }
+#endif
 
     // Compensate the limits for battery voltage drop.
     // This relaxes the limits when the battery is getting depleted.

--- a/ArduPlane/takeoff.cpp
+++ b/ArduPlane/takeoff.cpp
@@ -232,7 +232,8 @@ void Plane::takeoff_calc_throttle(const bool use_max_throttle) {
     // Set the minimum throttle limit.
     const bool use_throttle_range = (aparm.takeoff_options & (uint32_t)AP_FixedWing::TakeoffOption::THROTTLE_RANGE);
     if (!use_throttle_range || !ahrs.using_airspeed_sensor() || use_max_throttle) { // Traditional takeoff throttle limit.
-        TECS_controller.set_throttle_min(0.01f*aparm.takeoff_throttle_max);
+        float min_throttle = (aparm.takeoff_throttle_max != 0) ? 0.01f*aparm.takeoff_throttle_max : 0.01f*aparm.throttle_max;
+        TECS_controller.set_throttle_min(min_throttle);
     } else { // TKOFF_MODE == 1, allow for a throttle range.
         if (aparm.takeoff_throttle_min != 0) { // Override THR_MIN.
             TECS_controller.set_throttle_min(0.01f*aparm.takeoff_throttle_min);


### PR DESCRIPTION
This patches a bug that was introduced via https://github.com/ArduPilot/ardupilot/pull/27174.

It fixes an unhandled case of `TKOFF_THR_MAX=0`, where `THR_MAX` would not be sourced as a value for the minimum throttle limit during takeoff.
The relevant conditions are:
- TKOFF_OPTIONS=0 (default)
- TKOFF_THR_MAX=0 (default)

This would result in incorrect backing-off of the minimum throttle during the climb, which @Hwurzburg spotted:
![image](https://github.com/user-attachments/assets/319b1dac-8ad4-44a1-a04e-6627f033749e)

Now it behaves as it should:
![image](https://github.com/user-attachments/assets/56cefdfe-c75b-4590-89ec-b0efff4d6e1a)
Log: https://www.dropbox.com/scl/fi/akdqr9o5niv3qleexh3yd/122221_TakeoffTakeoff4.bin?rlkey=o9uykk6cm7785oxctkj17txxq&dl=0

---
Side-note:

I notice that there was significant pitch and throttle oscillation in Henry's log.
I don't think this is related to #27174, as the oscillation persists even after TAKEOFF mode has finished climbing, where TECS operates in a regime which I haven't edited.
I believe that a sudden pitch-down and throttle-cut was triggered (because of this bug) during the climb and the default tuning and model physics would yield bad control behaviour.