### PR TITLE
Plane: PitchController: add rate and actuator output Sys ID inject

### DIFF
--- a/libraries/APM_Control/AP_PitchController.cpp
+++ b/libraries/APM_Control/AP_PitchController.cpp
@@ -24,6 +24,8 @@
 
 extern const AP_HAL::HAL& hal;
 
+AP_PitchController *AP_PitchController::singleton;
+
 const AP_Param::GroupInfo AP_PitchController::var_info[] = {
 
     // @Param: 2SRV_TCONST
@@ -164,6 +166,11 @@ const AP_Param::GroupInfo AP_PitchController::var_info[] = {
 AP_PitchController::AP_PitchController(const AP_FixedWing &parms)
     : aparm(parms)
 {
+    if (singleton != nullptr) {
+        AP_HAL::panic("AP_PitchController must be singleton");
+    }
+    singleton = this;
+
     AP_Param::setup_object_defaults(this, var_info);
     rate_pid.set_slew_limit_scale(45);
 }
@@ -173,6 +180,10 @@ AP_PitchController::AP_PitchController(const AP_FixedWing &parms)
 */
 float AP_PitchController::_get_rate_out(float desired_rate, float scaler, bool disable_integrator, float aspeed, bool ground_mode)
 {
+    // Apply sys ID rate offset and clear
+    desired_rate += sysid.rate;
+    sysid.rate = 0;
+
     const float dt = AP::scheduler().get_loop_period_s();
 
     const AP_AHRS &_ahrs = AP::ahrs();
@@ -230,6 +241,10 @@ float AP_PitchController::_get_rate_out(float desired_rate, float scaler, bool d
         // when on ground suppress D and half P term to prevent oscillations
         out -= pinfo.D + 0.5*pinfo.P;
     }
+
+    // Apply sys ID actuator offset and clear
+    out += sysid.actuator;
+    sysid.actuator = 0;
 
     // remember the last output to trigger the I limit
     _last_out = out;

--- a/libraries/APM_Control/AP_PitchController.h
+++ b/libraries/APM_Control/AP_PitchController.h
@@ -53,6 +53,16 @@ public:
 
     void convert_pid();
 
+    // Set system identification angular velocity in degrees/s
+    void set_rate_sysid(float rate) { sysid.rate = rate; }
+
+    // Set system identification actuator in range +-1.0
+    // Scale by 4500 so input range is +-1.0
+    void set_actuator_sysid(float command) { sysid.actuator = command * 4500.0; }
+
+    // Get singleton
+    static AP_PitchController *get_singleton() { return singleton; }
+
 private:
     const AP_FixedWing &aparm;
     AP_AutoTune::ATGains gains;
@@ -69,4 +79,11 @@ private:
 
     float _get_rate_out(float desired_rate, float scaler, bool disable_integrator, float aspeed, bool ground_mode);
     float _get_coordination_rate_offset(float &aspeed, bool &inverted) const;
+
+    struct {
+        float rate;
+        float actuator;
+    } sysid;
+
+    static AP_PitchController *singleton;
 };

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -3592,7 +3592,6 @@ function networking:get_netmask_active() end
 function networking:get_ip_active() end
 
 -- visual odometry object
---@class visual_odom
 visual_odom = {}
 
 -- visual odometry health
@@ -3602,3 +3601,14 @@ function visual_odom:healthy() end
 -- visual odometry quality as a percentage from 1 to 100 or 0 if unknown
 ---@return integer
 function visual_odom:quality() end
+
+-- Plane Pitch Controller
+PitchController = {}
+
+-- Inject rate demand offset into pitch controller
+---@param rate number -- rate in deg / s
+function PitchController:set_rate_sysid(rate) end
+
+-- Inject actuator offset into pitch controller
+---@param actuator number -- range of -1.0 to +1.0
+function PitchController:set_actuator_sysid(actuator) end

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -965,3 +965,9 @@ singleton AP_VisualOdom depends HAL_VISUALODOM_ENABLED
 singleton AP_VisualOdom rename visual_odom
 singleton AP_VisualOdom method healthy boolean
 singleton AP_VisualOdom method quality int8_t
+
+include APM_Control/AP_PitchController.h depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)
+singleton AP_PitchController rename PitchController
+singleton AP_PitchController depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)
+singleton AP_PitchController method set_rate_sysid void float'skip_check
+singleton AP_PitchController method set_actuator_sysid void float'skip_check


### PR DESCRIPTION
This adds a path for injecting outputs for the purposes of system identification of fixed wing vehicles. This follows the pattern of how its done for copter in AC_AttitudeControl.

Just a draft for now, needs testing and a similar patch for roll. 