### PR TITLE
AP_DroneCAN: DNA_Server: fix handling of empty entry

### DIFF
--- a/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.cpp
@@ -202,8 +202,10 @@ bool AP_DroneCAN_DNA_Server::isValidNodeDataAvailable(uint8_t node_id)
 {
     NodeData node_data;
     readNodeData(node_data, node_id);
+
+    uint8_t empty_hwid[sizeof(NodeData::hwid_hash)] {};
     uint8_t crc = crc_crc8(node_data.hwid_hash, sizeof(node_data.hwid_hash));
-    if (crc == node_data.crc && node_data.crc != 0) {
+    if (crc == node_data.crc && memcmp(&node_data.hwid_hash[0], &empty_hwid[0], sizeof(empty_hwid)) != 0) {
         return true;
     }
     return false;


### PR DESCRIPTION
Replaces the check for a CRC of 0 with a check that the hwid is 0. Substantially reduces 1/256 chance that a particular node ID couldn't be stored.

The core locking fix will not be back-port-able so I have decided to get this done now. The storage area is already protected by semaphores in the StorageManager and HAL, the mis-use of the lock in the DNA server is not a few-line fix, and nobody has complained so far.

Tested on plane on CubeOrange using a selection of nodes and GPSes that the DNA server is preserved on upgrade and correctly registers and remembers nodes after the upgrade.