### PR TITLE
AP_Scripting: Change serial depends HAL_GCS to AP_SERIALMANAGER

### DIFF
--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -406,7 +406,7 @@ userdata AP_Scripting_SerialAccess method available uint32_t
 userdata AP_Scripting_SerialAccess method set_flow_control void AP_HAL::UARTDriver::flow_control'enum AP_HAL::UARTDriver::FLOW_CONTROL_DISABLE AP_HAL::UARTDriver::FLOW_CONTROL_RTS_DE
 
 -- serial is not a real C++ type here, but its name never gets used in C++ as we only have manual methods
-singleton serial depends HAL_GCS_ENABLED
+singleton serial depends AP_SERIALMANAGER_ENABLED
 singleton serial manual find_serial lua_serial_find_serial 1 1
 singleton serial manual find_simulated_device lua_serial_find_simulated_device 2 1 depends AP_SCRIPTING_SERIALDEVICE_ENABLED
 

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -740,7 +740,7 @@ int lua_get_CAN_device2(lua_State *L) {
 }
 #endif // AP_SCRIPTING_CAN_SENSOR_ENABLED
 
-#if HAL_GCS_ENABLED
+#if AP_SERIALMANAGER_ENABLED
 int lua_serial_find_serial(lua_State *L) {
     // Allow : and . access
     const int arg_offset = (luaL_testudata(L, 1, "serial") != NULL) ? 1 : 0;
@@ -765,7 +765,7 @@ int lua_serial_find_serial(lua_State *L) {
 
     return 1;
 }
-#endif // HAL_GCS_ENABLED
+#endif // AP_SERIALMANAGER_ENABLED
 
 #if AP_SCRIPTING_SERIALDEVICE_ENABLED
 int lua_serial_find_simulated_device(lua_State *L) {


### PR DESCRIPTION
Serial bindings were dependant on HAL_GCS_ENABLED but this is not ideal, it should be dependant on AP_SERIALMANAGER_ENABLED so that serial can function without GCS.

Tested on: CubePilot-PPPGW running AP_Periph, CubeOrangePlus running Plane