### PR TITLE
add send statustext to osd for sysid 10

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3476,7 +3476,14 @@ void GCS_MAVLINK::handle_statustext(const mavlink_message_t &msg) const
     char text[text_len] = { 'G','C','S',':'};
     uint8_t offset = strlen(text);
 
-    if (msg.sysid != sysid_my_gcs()) {
+    if (msg.sysid == 10) {
+	            offset = hal.util->snprintf(text,
+                                    max_prefix_len,
+                                    "CC:");
+        offset = MIN(offset, max_prefix_len);
+    }
+
+    if (msg.sysid != sysid_my_gcs() && msg.sysid != 10) {
         offset = hal.util->snprintf(text,
                                     max_prefix_len,
                                     "SRC=%u/%u:",
@@ -3486,7 +3493,7 @@ void GCS_MAVLINK::handle_statustext(const mavlink_message_t &msg) const
     }
 
     memcpy(&text[offset], packet.text, MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN);
-
+    send_text(MAV_SEVERITY_INFO, "%s", text); 
     logger->Write_Message(text);
 #endif
 }


### PR DESCRIPTION
https://github.com/ArduPilot/ardupilot/pull/10899

I propose implementing a feature that allows statustext messages to be sent to the OSD. This would be beneficial for those utilizing a Companion Computer.