### PR TITLE
Rename PID setter methods to include set_

### DIFF
--- a/ArduCopter/tuning.cpp
+++ b/ArduCopter/tuning.cpp
@@ -37,70 +37,70 @@ void Copter::tuning()
 
     // Roll, Pitch tuning
     case TUNING_STABILIZE_ROLL_PITCH_KP:
-        attitude_control->get_angle_roll_p().kP(tuning_value);
-        attitude_control->get_angle_pitch_p().kP(tuning_value);
+        attitude_control->get_angle_roll_p().set_kP(tuning_value);
+        attitude_control->get_angle_pitch_p().set_kP(tuning_value);
         break;
 
     case TUNING_RATE_ROLL_PITCH_KP:
-        attitude_control->get_rate_roll_pid().kP(tuning_value);
-        attitude_control->get_rate_pitch_pid().kP(tuning_value);
+        attitude_control->get_rate_roll_pid().set_kP(tuning_value);
+        attitude_control->get_rate_pitch_pid().set_kP(tuning_value);
         break;
 
     case TUNING_RATE_ROLL_PITCH_KI:
-        attitude_control->get_rate_roll_pid().kI(tuning_value);
-        attitude_control->get_rate_pitch_pid().kI(tuning_value);
+        attitude_control->get_rate_roll_pid().set_kI(tuning_value);
+        attitude_control->get_rate_pitch_pid().set_kI(tuning_value);
         break;
 
     case TUNING_RATE_ROLL_PITCH_KD:
-        attitude_control->get_rate_roll_pid().kD(tuning_value);
-        attitude_control->get_rate_pitch_pid().kD(tuning_value);
+        attitude_control->get_rate_roll_pid().set_kD(tuning_value);
+        attitude_control->get_rate_pitch_pid().set_kD(tuning_value);
         break;
 
     // Yaw tuning
     case TUNING_STABILIZE_YAW_KP:
-        attitude_control->get_angle_yaw_p().kP(tuning_value);
+        attitude_control->get_angle_yaw_p().set_kP(tuning_value);
         break;
 
     case TUNING_YAW_RATE_KP:
-        attitude_control->get_rate_yaw_pid().kP(tuning_value);
+        attitude_control->get_rate_yaw_pid().set_kP(tuning_value);
         break;
 
     case TUNING_YAW_RATE_KD:
-        attitude_control->get_rate_yaw_pid().kD(tuning_value);
+        attitude_control->get_rate_yaw_pid().set_kD(tuning_value);
         break;
 
     // Altitude and throttle tuning
     case TUNING_ALTITUDE_HOLD_KP:
-        pos_control->get_pos_z_p().kP(tuning_value);
+        pos_control->get_pos_z_p().set_kP(tuning_value);
         break;
 
     case TUNING_THROTTLE_RATE_KP:
-        pos_control->get_vel_z_pid().kP(tuning_value);
+        pos_control->get_vel_z_pid().set_kP(tuning_value);
         break;
 
     case TUNING_ACCEL_Z_KP:
-        pos_control->get_accel_z_pid().kP(tuning_value);
+        pos_control->get_accel_z_pid().set_kP(tuning_value);
         break;
 
     case TUNING_ACCEL_Z_KI:
-        pos_control->get_accel_z_pid().kI(tuning_value);
+        pos_control->get_accel_z_pid().set_kI(tuning_value);
         break;
 
     case TUNING_ACCEL_Z_KD:
-        pos_control->get_accel_z_pid().kD(tuning_value);
+        pos_control->get_accel_z_pid().set_kD(tuning_value);
         break;
 
     // Loiter and navigation tuning
     case TUNING_LOITER_POSITION_KP:
-        pos_control->get_pos_xy_p().kP(tuning_value);
+        pos_control->get_pos_xy_p().set_kP(tuning_value);
         break;
 
     case TUNING_VEL_XY_KP:
-        pos_control->get_vel_xy_pid().kP(tuning_value);
+        pos_control->get_vel_xy_pid().set_kP(tuning_value);
         break;
 
     case TUNING_VEL_XY_KI:
-        pos_control->get_vel_xy_pid().kI(tuning_value);
+        pos_control->get_vel_xy_pid().set_kI(tuning_value);
         break;
 
     case TUNING_WP_SPEED:
@@ -127,15 +127,15 @@ void Copter::tuning()
         break;
 
     case TUNING_RATE_PITCH_FF:
-        attitude_control->get_rate_pitch_pid().ff(tuning_value);
+        attitude_control->get_rate_pitch_pid().set_ff(tuning_value);
         break;
 
     case TUNING_RATE_ROLL_FF:
-        attitude_control->get_rate_roll_pid().ff(tuning_value);
+        attitude_control->get_rate_roll_pid().set_ff(tuning_value);
         break;
 
     case TUNING_RATE_YAW_FF:
-        attitude_control->get_rate_yaw_pid().ff(tuning_value);
+        attitude_control->get_rate_yaw_pid().set_ff(tuning_value);
         break;
 #endif
 
@@ -154,27 +154,27 @@ void Copter::tuning()
         break;
 
     case TUNING_RATE_PITCH_KP:
-        attitude_control->get_rate_pitch_pid().kP(tuning_value);
+        attitude_control->get_rate_pitch_pid().set_kP(tuning_value);
         break;
 
     case TUNING_RATE_PITCH_KI:
-        attitude_control->get_rate_pitch_pid().kI(tuning_value);
+        attitude_control->get_rate_pitch_pid().set_kI(tuning_value);
         break;
 
     case TUNING_RATE_PITCH_KD:
-        attitude_control->get_rate_pitch_pid().kD(tuning_value);
+        attitude_control->get_rate_pitch_pid().set_kD(tuning_value);
         break;
 
     case TUNING_RATE_ROLL_KP:
-        attitude_control->get_rate_roll_pid().kP(tuning_value);
+        attitude_control->get_rate_roll_pid().set_kP(tuning_value);
         break;
 
     case TUNING_RATE_ROLL_KI:
-        attitude_control->get_rate_roll_pid().kI(tuning_value);
+        attitude_control->get_rate_roll_pid().set_kI(tuning_value);
         break;
 
     case TUNING_RATE_ROLL_KD:
-        attitude_control->get_rate_roll_pid().kD(tuning_value);
+        attitude_control->get_rate_roll_pid().set_kD(tuning_value);
         break;
 
 #if FRAME_CONFIG != HELI_FRAME
@@ -184,7 +184,7 @@ void Copter::tuning()
 #endif
 
     case TUNING_RATE_YAW_FILT:
-        attitude_control->get_rate_yaw_pid().filt_E_hz(tuning_value);
+        attitude_control->get_rate_yaw_pid().set_filt_E_hz(tuning_value);
         break;
 
     case TUNING_SYSTEM_ID_MAGNITUDE:

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -995,7 +995,7 @@ void AC_PosControl::update_z_controller()
 
     // ensure imax is always large enough to overpower hover throttle
     if (_motors.get_throttle_hover() * 1000.0f > _pid_accel_z.imax()) {
-        _pid_accel_z.imax(_motors.get_throttle_hover() * 1000.0f);
+        _pid_accel_z.set_imax(_motors.get_throttle_hover() * 1000.0f);
     }
     float thr_out;
     if (_vibe_comp_enabled) {

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
@@ -599,37 +599,37 @@ void AC_AutoTune_Heli::load_gain_set(AxisType s_axis, float rate_p, float rate_i
 {
     switch (s_axis) {
     case AxisType::ROLL:
-        attitude_control->get_rate_roll_pid().kP(rate_p);
-        attitude_control->get_rate_roll_pid().kI(rate_i);
-        attitude_control->get_rate_roll_pid().kD(rate_d);
-        attitude_control->get_rate_roll_pid().ff(rate_ff);
-        attitude_control->get_rate_roll_pid().filt_T_hz(rate_fltt);
-        attitude_control->get_rate_roll_pid().slew_limit(smax);
-        attitude_control->get_angle_roll_p().kP(angle_p);
+        attitude_control->get_rate_roll_pid().set_kP(rate_p);
+        attitude_control->get_rate_roll_pid().set_kI(rate_i);
+        attitude_control->get_rate_roll_pid().set_kD(rate_d);
+        attitude_control->get_rate_roll_pid().set_ff(rate_ff);
+        attitude_control->get_rate_roll_pid().set_filt_T_hz(rate_fltt);
+        attitude_control->get_rate_roll_pid().set_slew_limit(smax);
+        attitude_control->get_angle_roll_p().set_kP(angle_p);
         attitude_control->set_accel_roll_max_cdss(max_accel);
         attitude_control->set_ang_vel_roll_max_degs(max_rate);
         break;
     case AxisType::PITCH:
-        attitude_control->get_rate_pitch_pid().kP(rate_p);
-        attitude_control->get_rate_pitch_pid().kI(rate_i);
-        attitude_control->get_rate_pitch_pid().kD(rate_d);
-        attitude_control->get_rate_pitch_pid().ff(rate_ff);
-        attitude_control->get_rate_pitch_pid().filt_T_hz(rate_fltt);
-        attitude_control->get_rate_pitch_pid().slew_limit(smax);
-        attitude_control->get_angle_pitch_p().kP(angle_p);
+        attitude_control->get_rate_pitch_pid().set_kP(rate_p);
+        attitude_control->get_rate_pitch_pid().set_kI(rate_i);
+        attitude_control->get_rate_pitch_pid().set_kD(rate_d);
+        attitude_control->get_rate_pitch_pid().set_ff(rate_ff);
+        attitude_control->get_rate_pitch_pid().set_filt_T_hz(rate_fltt);
+        attitude_control->get_rate_pitch_pid().set_slew_limit(smax);
+        attitude_control->get_angle_pitch_p().set_kP(angle_p);
         attitude_control->set_accel_pitch_max_cdss(max_accel);
         attitude_control->set_ang_vel_pitch_max_degs(max_rate);
         break;
     case AxisType::YAW:
     case AxisType::YAW_D:
-        attitude_control->get_rate_yaw_pid().kP(rate_p);
-        attitude_control->get_rate_yaw_pid().kI(rate_i);
-        attitude_control->get_rate_yaw_pid().kD(rate_d);
-        attitude_control->get_rate_yaw_pid().ff(rate_ff);
-        attitude_control->get_rate_yaw_pid().filt_T_hz(rate_fltt);
-        attitude_control->get_rate_yaw_pid().slew_limit(smax);
-        attitude_control->get_rate_yaw_pid().filt_E_hz(rate_flte);
-        attitude_control->get_angle_yaw_p().kP(angle_p);
+        attitude_control->get_rate_yaw_pid().set_kP(rate_p);
+        attitude_control->get_rate_yaw_pid().set_kI(rate_i);
+        attitude_control->get_rate_yaw_pid().set_kD(rate_d);
+        attitude_control->get_rate_yaw_pid().set_ff(rate_ff);
+        attitude_control->get_rate_yaw_pid().set_filt_T_hz(rate_fltt);
+        attitude_control->get_rate_yaw_pid().set_slew_limit(smax);
+        attitude_control->get_rate_yaw_pid().set_filt_E_hz(rate_flte);
+        attitude_control->get_angle_yaw_p().set_kP(angle_p);
         attitude_control->set_accel_yaw_max_cdss(max_accel);
         attitude_control->set_ang_vel_yaw_max_degs(max_rate);
         break;

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -212,41 +212,41 @@ void AC_AutoTune_Multi::load_orig_gains()
     attitude_control->bf_feedforward(orig_bf_feedforward);
     if (roll_enabled()) {
         if (!is_zero(orig_roll_rp)) {
-            attitude_control->get_rate_roll_pid().kP(orig_roll_rp);
-            attitude_control->get_rate_roll_pid().kI(orig_roll_ri);
-            attitude_control->get_rate_roll_pid().kD(orig_roll_rd);
-            attitude_control->get_rate_roll_pid().ff(orig_roll_rff);
-            attitude_control->get_rate_roll_pid().kDff(orig_roll_dff);
-            attitude_control->get_rate_roll_pid().filt_T_hz(orig_roll_fltt);
-            attitude_control->get_rate_roll_pid().slew_limit(orig_roll_smax);
-            attitude_control->get_angle_roll_p().kP(orig_roll_sp);
+            attitude_control->get_rate_roll_pid().set_kP(orig_roll_rp);
+            attitude_control->get_rate_roll_pid().set_kI(orig_roll_ri);
+            attitude_control->get_rate_roll_pid().set_kD(orig_roll_rd);
+            attitude_control->get_rate_roll_pid().set_ff(orig_roll_rff);
+            attitude_control->get_rate_roll_pid().set_kDff(orig_roll_dff);
+            attitude_control->get_rate_roll_pid().set_filt_T_hz(orig_roll_fltt);
+            attitude_control->get_rate_roll_pid().set_slew_limit(orig_roll_smax);
+            attitude_control->get_angle_roll_p().set_kP(orig_roll_sp);
             attitude_control->set_accel_roll_max_cdss(orig_roll_accel);
         }
     }
     if (pitch_enabled()) {
         if (!is_zero(orig_pitch_rp)) {
-            attitude_control->get_rate_pitch_pid().kP(orig_pitch_rp);
-            attitude_control->get_rate_pitch_pid().kI(orig_pitch_ri);
-            attitude_control->get_rate_pitch_pid().kD(orig_pitch_rd);
-            attitude_control->get_rate_pitch_pid().ff(orig_pitch_rff);
-            attitude_control->get_rate_pitch_pid().kDff(orig_pitch_dff);
-            attitude_control->get_rate_pitch_pid().filt_T_hz(orig_pitch_fltt);
-            attitude_control->get_rate_pitch_pid().slew_limit(orig_pitch_smax);
-            attitude_control->get_angle_pitch_p().kP(orig_pitch_sp);
+            attitude_control->get_rate_pitch_pid().set_kP(orig_pitch_rp);
+            attitude_control->get_rate_pitch_pid().set_kI(orig_pitch_ri);
+            attitude_control->get_rate_pitch_pid().set_kD(orig_pitch_rd);
+            attitude_control->get_rate_pitch_pid().set_ff(orig_pitch_rff);
+            attitude_control->get_rate_pitch_pid().set_kDff(orig_pitch_dff);
+            attitude_control->get_rate_pitch_pid().set_filt_T_hz(orig_pitch_fltt);
+            attitude_control->get_rate_pitch_pid().set_slew_limit(orig_pitch_smax);
+            attitude_control->get_angle_pitch_p().set_kP(orig_pitch_sp);
             attitude_control->set_accel_pitch_max_cdss(orig_pitch_accel);
         }
     }
     if (yaw_enabled() || yaw_d_enabled()) {
         if (!is_zero(orig_yaw_rp)) {
-            attitude_control->get_rate_yaw_pid().kP(orig_yaw_rp);
-            attitude_control->get_rate_yaw_pid().kI(orig_yaw_ri);
-            attitude_control->get_rate_yaw_pid().kD(orig_yaw_rd);
-            attitude_control->get_rate_yaw_pid().ff(orig_yaw_rff);
-            attitude_control->get_rate_yaw_pid().kDff(orig_yaw_dff);
-            attitude_control->get_rate_yaw_pid().filt_E_hz(orig_yaw_rLPF);
-            attitude_control->get_rate_yaw_pid().filt_T_hz(orig_yaw_fltt);
-            attitude_control->get_rate_yaw_pid().slew_limit(orig_yaw_smax);
-            attitude_control->get_angle_yaw_p().kP(orig_yaw_sp);
+            attitude_control->get_rate_yaw_pid().set_kP(orig_yaw_rp);
+            attitude_control->get_rate_yaw_pid().set_kI(orig_yaw_ri);
+            attitude_control->get_rate_yaw_pid().set_kD(orig_yaw_rd);
+            attitude_control->get_rate_yaw_pid().set_ff(orig_yaw_rff);
+            attitude_control->get_rate_yaw_pid().set_kDff(orig_yaw_dff);
+            attitude_control->get_rate_yaw_pid().set_filt_E_hz(orig_yaw_rLPF);
+            attitude_control->get_rate_yaw_pid().set_filt_T_hz(orig_yaw_fltt);
+            attitude_control->get_rate_yaw_pid().set_slew_limit(orig_yaw_smax);
+            attitude_control->get_angle_yaw_p().set_kP(orig_yaw_sp);
             attitude_control->set_accel_yaw_max_cdss(orig_yaw_accel);
         }
     }
@@ -262,39 +262,39 @@ void AC_AutoTune_Multi::load_tuned_gains()
     }
     if (roll_enabled()) {
         if (!is_zero(tune_roll_rp)) {
-            attitude_control->get_rate_roll_pid().kP(tune_roll_rp);
-            attitude_control->get_rate_roll_pid().kI(tune_roll_rp*AUTOTUNE_PI_RATIO_FINAL);
-            attitude_control->get_rate_roll_pid().kD(tune_roll_rd);
-            attitude_control->get_rate_roll_pid().ff(orig_roll_rff);
-            attitude_control->get_rate_roll_pid().kDff(orig_roll_dff);
-            attitude_control->get_angle_roll_p().kP(tune_roll_sp);
+            attitude_control->get_rate_roll_pid().set_kP(tune_roll_rp);
+            attitude_control->get_rate_roll_pid().set_kI(tune_roll_rp*AUTOTUNE_PI_RATIO_FINAL);
+            attitude_control->get_rate_roll_pid().set_kD(tune_roll_rd);
+            attitude_control->get_rate_roll_pid().set_ff(orig_roll_rff);
+            attitude_control->get_rate_roll_pid().set_kDff(orig_roll_dff);
+            attitude_control->get_angle_roll_p().set_kP(tune_roll_sp);
             attitude_control->set_accel_roll_max_cdss(tune_roll_accel);
         }
     }
     if (pitch_enabled()) {
         if (!is_zero(tune_pitch_rp)) {
-            attitude_control->get_rate_pitch_pid().kP(tune_pitch_rp);
-            attitude_control->get_rate_pitch_pid().kI(tune_pitch_rp*AUTOTUNE_PI_RATIO_FINAL);
-            attitude_control->get_rate_pitch_pid().kD(tune_pitch_rd);
-            attitude_control->get_rate_pitch_pid().ff(orig_pitch_rff);
-            attitude_control->get_rate_pitch_pid().kDff(orig_pitch_dff);
-            attitude_control->get_angle_pitch_p().kP(tune_pitch_sp);
+            attitude_control->get_rate_pitch_pid().set_kP(tune_pitch_rp);
+            attitude_control->get_rate_pitch_pid().set_kI(tune_pitch_rp*AUTOTUNE_PI_RATIO_FINAL);
+            attitude_control->get_rate_pitch_pid().set_kD(tune_pitch_rd);
+            attitude_control->get_rate_pitch_pid().set_ff(orig_pitch_rff);
+            attitude_control->get_rate_pitch_pid().set_kDff(orig_pitch_dff);
+            attitude_control->get_angle_pitch_p().set_kP(tune_pitch_sp);
             attitude_control->set_accel_pitch_max_cdss(tune_pitch_accel);
         }
     }
     if (yaw_enabled() || yaw_d_enabled()) {
         if (!is_zero(tune_yaw_rp)) {
-            attitude_control->get_rate_yaw_pid().kP(tune_yaw_rp);
-            attitude_control->get_rate_yaw_pid().kI(tune_yaw_rp*AUTOTUNE_YAW_PI_RATIO_FINAL);
+            attitude_control->get_rate_yaw_pid().set_kP(tune_yaw_rp);
+            attitude_control->get_rate_yaw_pid().set_kI(tune_yaw_rp*AUTOTUNE_YAW_PI_RATIO_FINAL);
             if (yaw_d_enabled()) {
-                attitude_control->get_rate_yaw_pid().kD(tune_yaw_rd);
+                attitude_control->get_rate_yaw_pid().set_kD(tune_yaw_rd);
             }
             if (yaw_enabled()) {
-                attitude_control->get_rate_yaw_pid().filt_E_hz(tune_yaw_rLPF);
+                attitude_control->get_rate_yaw_pid().set_filt_E_hz(tune_yaw_rLPF);
             }
-            attitude_control->get_rate_yaw_pid().ff(orig_yaw_rff);
-            attitude_control->get_rate_yaw_pid().kDff(orig_yaw_dff);
-            attitude_control->get_angle_yaw_p().kP(tune_yaw_sp);
+            attitude_control->get_rate_yaw_pid().set_ff(orig_yaw_rff);
+            attitude_control->get_rate_yaw_pid().set_kDff(orig_yaw_dff);
+            attitude_control->get_angle_yaw_p().set_kP(tune_yaw_sp);
             attitude_control->set_accel_yaw_max_cdss(tune_yaw_accel);
         }
     }
@@ -308,35 +308,35 @@ void AC_AutoTune_Multi::load_intra_test_gains()
     // sanity check the gains
     attitude_control->bf_feedforward(true);
     if (roll_enabled()) {
-        attitude_control->get_rate_roll_pid().kP(orig_roll_rp);
-        attitude_control->get_rate_roll_pid().kI(orig_roll_rp*AUTOTUNE_PI_RATIO_FOR_TESTING);
-        attitude_control->get_rate_roll_pid().kD(orig_roll_rd);
-        attitude_control->get_rate_roll_pid().ff(orig_roll_rff);
-        attitude_control->get_rate_roll_pid().kDff(orig_roll_dff);
-        attitude_control->get_rate_roll_pid().filt_T_hz(orig_roll_fltt);
-        attitude_control->get_rate_roll_pid().slew_limit(orig_roll_smax);
-        attitude_control->get_angle_roll_p().kP(orig_roll_sp);
+        attitude_control->get_rate_roll_pid().set_kP(orig_roll_rp);
+        attitude_control->get_rate_roll_pid().set_kI(orig_roll_rp*AUTOTUNE_PI_RATIO_FOR_TESTING);
+        attitude_control->get_rate_roll_pid().set_kD(orig_roll_rd);
+        attitude_control->get_rate_roll_pid().set_ff(orig_roll_rff);
+        attitude_control->get_rate_roll_pid().set_kDff(orig_roll_dff);
+        attitude_control->get_rate_roll_pid().set_filt_T_hz(orig_roll_fltt);
+        attitude_control->get_rate_roll_pid().set_slew_limit(orig_roll_smax);
+        attitude_control->get_angle_roll_p().set_kP(orig_roll_sp);
     }
     if (pitch_enabled()) {
-        attitude_control->get_rate_pitch_pid().kP(orig_pitch_rp);
-        attitude_control->get_rate_pitch_pid().kI(orig_pitch_rp*AUTOTUNE_PI_RATIO_FOR_TESTING);
-        attitude_control->get_rate_pitch_pid().kD(orig_pitch_rd);
-        attitude_control->get_rate_pitch_pid().ff(orig_pitch_rff);
-        attitude_control->get_rate_pitch_pid().kDff(orig_pitch_dff);
-        attitude_control->get_rate_pitch_pid().filt_T_hz(orig_pitch_fltt);
-        attitude_control->get_rate_pitch_pid().slew_limit(orig_pitch_smax);
-        attitude_control->get_angle_pitch_p().kP(orig_pitch_sp);
+        attitude_control->get_rate_pitch_pid().set_kP(orig_pitch_rp);
+        attitude_control->get_rate_pitch_pid().set_kI(orig_pitch_rp*AUTOTUNE_PI_RATIO_FOR_TESTING);
+        attitude_control->get_rate_pitch_pid().set_kD(orig_pitch_rd);
+        attitude_control->get_rate_pitch_pid().set_ff(orig_pitch_rff);
+        attitude_control->get_rate_pitch_pid().set_kDff(orig_pitch_dff);
+        attitude_control->get_rate_pitch_pid().set_filt_T_hz(orig_pitch_fltt);
+        attitude_control->get_rate_pitch_pid().set_slew_limit(orig_pitch_smax);
+        attitude_control->get_angle_pitch_p().set_kP(orig_pitch_sp);
     }
     if (yaw_enabled() || yaw_d_enabled()) {
-        attitude_control->get_rate_yaw_pid().kP(orig_yaw_rp);
-        attitude_control->get_rate_yaw_pid().kI(orig_yaw_rp*AUTOTUNE_PI_RATIO_FOR_TESTING);
-        attitude_control->get_rate_yaw_pid().kD(orig_yaw_rd);
-        attitude_control->get_rate_yaw_pid().ff(orig_yaw_rff);
-        attitude_control->get_rate_yaw_pid().kDff(orig_yaw_dff);
-        attitude_control->get_rate_yaw_pid().filt_T_hz(orig_yaw_fltt);
-        attitude_control->get_rate_yaw_pid().slew_limit(orig_yaw_smax);
-        attitude_control->get_rate_yaw_pid().filt_E_hz(orig_yaw_rLPF);
-        attitude_control->get_angle_yaw_p().kP(orig_yaw_sp);
+        attitude_control->get_rate_yaw_pid().set_kP(orig_yaw_rp);
+        attitude_control->get_rate_yaw_pid().set_kI(orig_yaw_rp*AUTOTUNE_PI_RATIO_FOR_TESTING);
+        attitude_control->get_rate_yaw_pid().set_kD(orig_yaw_rd);
+        attitude_control->get_rate_yaw_pid().set_ff(orig_yaw_rff);
+        attitude_control->get_rate_yaw_pid().set_kDff(orig_yaw_dff);
+        attitude_control->get_rate_yaw_pid().set_filt_T_hz(orig_yaw_fltt);
+        attitude_control->get_rate_yaw_pid().set_slew_limit(orig_yaw_smax);
+        attitude_control->get_rate_yaw_pid().set_filt_E_hz(orig_yaw_rLPF);
+        attitude_control->get_angle_yaw_p().set_kP(orig_yaw_sp);
     }
 }
 
@@ -346,40 +346,40 @@ void AC_AutoTune_Multi::load_test_gains()
 {
     switch (axis) {
     case AxisType::ROLL:
-        attitude_control->get_rate_roll_pid().kP(tune_roll_rp);
-        attitude_control->get_rate_roll_pid().kI(tune_roll_rp * 0.01);
-        attitude_control->get_rate_roll_pid().kD(tune_roll_rd);
-        attitude_control->get_rate_roll_pid().ff(0.0);
-        attitude_control->get_rate_roll_pid().kDff(0.0);
-        attitude_control->get_rate_roll_pid().filt_T_hz(0.0);
-        attitude_control->get_rate_roll_pid().slew_limit(0.0);
-        attitude_control->get_angle_roll_p().kP(tune_roll_sp);
+        attitude_control->get_rate_roll_pid().set_kP(tune_roll_rp);
+        attitude_control->get_rate_roll_pid().set_kI(tune_roll_rp * 0.01);
+        attitude_control->get_rate_roll_pid().set_kD(tune_roll_rd);
+        attitude_control->get_rate_roll_pid().set_ff(0.0);
+        attitude_control->get_rate_roll_pid().set_kDff(0.0);
+        attitude_control->get_rate_roll_pid().set_filt_T_hz(0.0);
+        attitude_control->get_rate_roll_pid().set_slew_limit(0.0);
+        attitude_control->get_angle_roll_p().set_kP(tune_roll_sp);
         break;
     case AxisType::PITCH:
-        attitude_control->get_rate_pitch_pid().kP(tune_pitch_rp);
-        attitude_control->get_rate_pitch_pid().kI(tune_pitch_rp * 0.01);
-        attitude_control->get_rate_pitch_pid().kD(tune_pitch_rd);
-        attitude_control->get_rate_pitch_pid().ff(0.0);
-        attitude_control->get_rate_pitch_pid().kDff(0.0);
-        attitude_control->get_rate_pitch_pid().filt_T_hz(0.0);
-        attitude_control->get_rate_pitch_pid().slew_limit(0.0);
-        attitude_control->get_angle_pitch_p().kP(tune_pitch_sp);
+        attitude_control->get_rate_pitch_pid().set_kP(tune_pitch_rp);
+        attitude_control->get_rate_pitch_pid().set_kI(tune_pitch_rp * 0.01);
+        attitude_control->get_rate_pitch_pid().set_kD(tune_pitch_rd);
+        attitude_control->get_rate_pitch_pid().set_ff(0.0);
+        attitude_control->get_rate_pitch_pid().set_kDff(0.0);
+        attitude_control->get_rate_pitch_pid().set_filt_T_hz(0.0);
+        attitude_control->get_rate_pitch_pid().set_slew_limit(0.0);
+        attitude_control->get_angle_pitch_p().set_kP(tune_pitch_sp);
         break;
     case AxisType::YAW:
     case AxisType::YAW_D:
-        attitude_control->get_rate_yaw_pid().kP(tune_yaw_rp);
-        attitude_control->get_rate_yaw_pid().kI(tune_yaw_rp * 0.01);
-        attitude_control->get_rate_yaw_pid().ff(0.0);
-        attitude_control->get_rate_yaw_pid().kDff(0.0);
+        attitude_control->get_rate_yaw_pid().set_kP(tune_yaw_rp);
+        attitude_control->get_rate_yaw_pid().set_kI(tune_yaw_rp * 0.01);
+        attitude_control->get_rate_yaw_pid().set_ff(0.0);
+        attitude_control->get_rate_yaw_pid().set_kDff(0.0);
         if (axis == AxisType::YAW_D) {
-            attitude_control->get_rate_yaw_pid().kD(tune_yaw_rd);
+            attitude_control->get_rate_yaw_pid().set_kD(tune_yaw_rd);
         } else {
-            attitude_control->get_rate_yaw_pid().kD(0.0);
-            attitude_control->get_rate_yaw_pid().filt_E_hz(tune_yaw_rLPF);
+            attitude_control->get_rate_yaw_pid().set_kD(0.0);
+            attitude_control->get_rate_yaw_pid().set_filt_E_hz(tune_yaw_rLPF);
         }
-        attitude_control->get_rate_yaw_pid().filt_T_hz(0.0);
-        attitude_control->get_rate_yaw_pid().slew_limit(0.0);
-        attitude_control->get_angle_yaw_p().kP(tune_yaw_sp);
+        attitude_control->get_rate_yaw_pid().set_filt_T_hz(0.0);
+        attitude_control->get_rate_yaw_pid().set_slew_limit(0.0);
+        attitude_control->get_angle_yaw_p().set_kP(tune_yaw_sp);
         break;
     }
 }
@@ -402,17 +402,17 @@ void AC_AutoTune_Multi::save_tuning_gains()
     // sanity check the rate P values
     if ((axes_completed & AUTOTUNE_AXIS_BITMASK_ROLL) && roll_enabled() && !is_zero(tune_roll_rp)) {
         // rate roll gains
-        attitude_control->get_rate_roll_pid().kP(tune_roll_rp);
-        attitude_control->get_rate_roll_pid().kI(tune_roll_rp*AUTOTUNE_PI_RATIO_FINAL);
-        attitude_control->get_rate_roll_pid().kD(tune_roll_rd);
-        attitude_control->get_rate_roll_pid().ff(orig_roll_rff);
-        attitude_control->get_rate_roll_pid().kDff(orig_roll_dff);
-        attitude_control->get_rate_roll_pid().filt_T_hz(orig_roll_fltt);
-        attitude_control->get_rate_roll_pid().slew_limit(orig_roll_smax);
+        attitude_control->get_rate_roll_pid().set_kP(tune_roll_rp);
+        attitude_control->get_rate_roll_pid().set_kI(tune_roll_rp*AUTOTUNE_PI_RATIO_FINAL);
+        attitude_control->get_rate_roll_pid().set_kD(tune_roll_rd);
+        attitude_control->get_rate_roll_pid().set_ff(orig_roll_rff);
+        attitude_control->get_rate_roll_pid().set_kDff(orig_roll_dff);
+        attitude_control->get_rate_roll_pid().set_filt_T_hz(orig_roll_fltt);
+        attitude_control->get_rate_roll_pid().set_slew_limit(orig_roll_smax);
         attitude_control->get_rate_roll_pid().save_gains();
 
         // stabilize roll
-        attitude_control->get_angle_roll_p().kP(tune_roll_sp);
+        attitude_control->get_angle_roll_p().set_kP(tune_roll_sp);
         attitude_control->get_angle_roll_p().save_gains();
 
         // acceleration roll
@@ -430,17 +430,17 @@ void AC_AutoTune_Multi::save_tuning_gains()
 
     if ((axes_completed & AUTOTUNE_AXIS_BITMASK_PITCH) && pitch_enabled() && !is_zero(tune_pitch_rp)) {
         // rate pitch gains
-        attitude_control->get_rate_pitch_pid().kP(tune_pitch_rp);
-        attitude_control->get_rate_pitch_pid().kI(tune_pitch_rp*AUTOTUNE_PI_RATIO_FINAL);
-        attitude_control->get_rate_pitch_pid().kD(tune_pitch_rd);
-        attitude_control->get_rate_pitch_pid().ff(orig_pitch_rff);
-        attitude_control->get_rate_pitch_pid().kDff(orig_pitch_dff);
-        attitude_control->get_rate_pitch_pid().filt_T_hz(orig_pitch_fltt);
-        attitude_control->get_rate_pitch_pid().slew_limit(orig_pitch_smax);
+        attitude_control->get_rate_pitch_pid().set_kP(tune_pitch_rp);
+        attitude_control->get_rate_pitch_pid().set_kI(tune_pitch_rp*AUTOTUNE_PI_RATIO_FINAL);
+        attitude_control->get_rate_pitch_pid().set_kD(tune_pitch_rd);
+        attitude_control->get_rate_pitch_pid().set_ff(orig_pitch_rff);
+        attitude_control->get_rate_pitch_pid().set_kDff(orig_pitch_dff);
+        attitude_control->get_rate_pitch_pid().set_filt_T_hz(orig_pitch_fltt);
+        attitude_control->get_rate_pitch_pid().set_slew_limit(orig_pitch_smax);
         attitude_control->get_rate_pitch_pid().save_gains();
 
         // stabilize pitch
-        attitude_control->get_angle_pitch_p().kP(tune_pitch_sp);
+        attitude_control->get_angle_pitch_p().set_kP(tune_pitch_sp);
         attitude_control->get_angle_pitch_p().save_gains();
 
         // acceleration pitch
@@ -459,22 +459,22 @@ void AC_AutoTune_Multi::save_tuning_gains()
     if ((((axes_completed & AUTOTUNE_AXIS_BITMASK_YAW) && yaw_enabled())
             || ((axes_completed & AUTOTUNE_AXIS_BITMASK_YAW_D) && yaw_d_enabled())) && !is_zero(tune_yaw_rp)) {
         // rate yaw gains
-        attitude_control->get_rate_yaw_pid().kP(tune_yaw_rp);
-        attitude_control->get_rate_yaw_pid().kI(tune_yaw_rp*AUTOTUNE_YAW_PI_RATIO_FINAL);
-        attitude_control->get_rate_yaw_pid().ff(orig_yaw_rff);
-        attitude_control->get_rate_yaw_pid().kDff(orig_yaw_dff);
-        attitude_control->get_rate_yaw_pid().filt_T_hz(orig_yaw_fltt);
-        attitude_control->get_rate_yaw_pid().slew_limit(orig_yaw_smax);
+        attitude_control->get_rate_yaw_pid().set_kP(tune_yaw_rp);
+        attitude_control->get_rate_yaw_pid().set_kI(tune_yaw_rp*AUTOTUNE_YAW_PI_RATIO_FINAL);
+        attitude_control->get_rate_yaw_pid().set_ff(orig_yaw_rff);
+        attitude_control->get_rate_yaw_pid().set_kDff(orig_yaw_dff);
+        attitude_control->get_rate_yaw_pid().set_filt_T_hz(orig_yaw_fltt);
+        attitude_control->get_rate_yaw_pid().set_slew_limit(orig_yaw_smax);
         if (yaw_d_enabled()) {
-            attitude_control->get_rate_yaw_pid().kD(tune_yaw_rd);
+            attitude_control->get_rate_yaw_pid().set_kD(tune_yaw_rd);
         }
         if (yaw_enabled()) {
-            attitude_control->get_rate_yaw_pid().filt_E_hz(tune_yaw_rLPF);
+            attitude_control->get_rate_yaw_pid().set_filt_E_hz(tune_yaw_rLPF);
         }
         attitude_control->get_rate_yaw_pid().save_gains();
 
         // stabilize yaw
-        attitude_control->get_angle_yaw_p().kP(tune_yaw_sp);
+        attitude_control->get_angle_yaw_p().set_kP(tune_yaw_sp);
         attitude_control->get_angle_yaw_p().save_gains();
 
         // acceleration yaw

--- a/libraries/AC_PID/AC_P.h
+++ b/libraries/AC_PID/AC_P.h
@@ -59,7 +59,7 @@ public:
     // accessors
     AP_Float    &kP() { return _kp; }
     const AP_Float &kP() const { return _kp; }
-    void        kP(const float v) { _kp.set(v); }
+    void        set_kP(const float v) { _kp.set(v); }
 
     static const struct AP_Param::GroupInfo        var_info[];
 

--- a/libraries/AC_PID/AC_PID.cpp
+++ b/libraries/AC_PID/AC_PID.cpp
@@ -130,25 +130,25 @@ AC_PID::AC_PID(float initial_p, float initial_i, float initial_d, float initial_
 }
 
 // filt_T_hz - set target filter hz
-void AC_PID::filt_T_hz(float hz)
+void AC_PID::set_filt_T_hz(float hz)
 {
     _filt_T_hz.set(fabsf(hz));
 }
 
 // filt_E_hz - set error filter hz
-void AC_PID::filt_E_hz(float hz)
+void AC_PID::set_filt_E_hz(float hz)
 {
     _filt_E_hz.set(fabsf(hz));
 }
 
 // filt_D_hz - set derivative filter hz
-void AC_PID::filt_D_hz(float hz)
+void AC_PID::set_filt_D_hz(float hz)
 {
     _filt_D_hz.set(fabsf(hz));
 }
 
 // slew_limit - set slew limit
-void AC_PID::slew_limit(float smax)
+void AC_PID::set_slew_limit(float smax)
 {
     _slew_rate_max.set(fabsf(smax));
 }

--- a/libraries/AC_PID/AC_PID.h
+++ b/libraries/AC_PID/AC_PID.h
@@ -117,17 +117,17 @@ public:
     float get_filt_D_alpha(float dt) const;
 
     // set accessors
-    void kP(const float v) { _kp.set(v); }
-    void kI(const float v) { _ki.set(v); }
-    void kD(const float v) { _kd.set(v); }
-    void ff(const float v) { _kff.set(v); }
-    void imax(const float v) { _kimax.set(fabsf(v)); }
-    void pdmax(const float v) { _kpdmax.set(fabsf(v)); }
-    void filt_T_hz(const float v);
-    void filt_E_hz(const float v);
-    void filt_D_hz(const float v);
-    void slew_limit(const float v);
-    void kDff(const float v) { _kdff.set(v); }
+    void set_kP(const float v) { _kp.set(v); }
+    void set_kI(const float v) { _ki.set(v); }
+    void set_kD(const float v) { _kd.set(v); }
+    void set_ff(const float v) { _kff.set(v); }
+    void set_imax(const float v) { _kimax.set(fabsf(v)); }
+    void set_pdmax(const float v) { _kpdmax.set(fabsf(v)); }
+    void set_filt_T_hz(const float v);
+    void set_filt_E_hz(const float v);
+    void set_filt_D_hz(const float v);
+    void set_slew_limit(const float v);
+    void set_kDff(const float v) { _kdff.set(v); }
 
     // set the desired and actual rates (for logging purposes)
     void set_target_rate(float target) { _pid_info.target = target; }

--- a/libraries/AC_PID/AC_PID_2D.h
+++ b/libraries/AC_PID/AC_PID_2D.h
@@ -59,13 +59,13 @@ public:
     float get_filt_D_alpha(float dt) const;
 
     // set accessors
-    void kP(float v) { _kp.set(v); }
-    void kI(float v) { _ki.set(v); }
-    void kD(float v) { _kd.set(v); }
-    void ff(float v) { _kff.set(v); }
-    void imax(float v) { _kimax.set(fabsf(v)); }
-    void filt_E_hz(float hz) { _filt_E_hz.set(fabsf(hz)); }
-    void filt_D_hz(float hz) { _filt_D_hz.set(fabsf(hz)); }
+    void set_kP(float v) { _kp.set(v); }
+    void set_kI(float v) { _ki.set(v); }
+    void set_kD(float v) { _kd.set(v); }
+    void set_ff(float v) { _kff.set(v); }
+    void set_imax(float v) { _kimax.set(fabsf(v)); }
+    void set_filt_E_hz(float hz) { _filt_E_hz.set(fabsf(hz)); }
+    void set_filt_D_hz(float hz) { _filt_D_hz.set(fabsf(hz)); }
 
     // integrator setting functions
     void set_integrator(const Vector2f& target, const Vector2f& measurement, const Vector2f& i);

--- a/libraries/AC_PID/AC_PID_Basic.h
+++ b/libraries/AC_PID/AC_PID_Basic.h
@@ -54,13 +54,13 @@ public:
     float get_filt_D_alpha(float dt) const WARN_IF_UNUSED;
 
     // set accessors
-    void kP(float v) { _kp.set(v); }
-    void kI(float v) { _ki.set(v); }
-    void kD(float v) { _kd.set(v); }
-    void ff(float v) { _kff.set(v); }
-    void imax(float v) { _kimax.set(fabsf(v)); }
-    void filt_E_hz(float hz) { _filt_E_hz.set(fabsf(hz)); }
-    void filt_D_hz(float hz) { _filt_D_hz.set(fabsf(hz)); }
+    void set_kP(float v) { _kp.set(v); }
+    void set_kI(float v) { _ki.set(v); }
+    void set_kD(float v) { _kd.set(v); }
+    void set_ff(float v) { _kff.set(v); }
+    void set_imax(float v) { _kimax.set(fabsf(v)); }
+    void set_filt_E_hz(float hz) { _filt_E_hz.set(fabsf(hz)); }
+    void set_filt_D_hz(float hz) { _filt_D_hz.set(fabsf(hz)); }
 
     // integrator setting functions
     void set_integrator(float target, float measurement, float i);

--- a/libraries/AC_PID/AC_P_1D.h
+++ b/libraries/AC_PID/AC_P_1D.h
@@ -42,7 +42,7 @@ public:
     float get_error() const { return _error; }
 
     // set accessors
-    void kP(float v) { _kp.set(v); }
+    void set_kP(float v) { _kp.set(v); }
 
     // parameter var table
     static const struct AP_Param::GroupInfo var_info[];

--- a/libraries/AC_PID/AC_P_2D.h
+++ b/libraries/AC_PID/AC_P_2D.h
@@ -44,7 +44,7 @@ public:
     const Vector2f& get_error() const { return _error; }
 
     // set accessors
-    void kP(float v) { _kp.set(v); }
+    void set_kP(float v) { _kp.set(v); }
 
     // parameter var table
     static const struct AP_Param::GroupInfo var_info[];


### PR DESCRIPTION
There are very few places in ArduPilot where we don't have "set_" for setters.

PIDs are one of them - make them uniform.

This is a no-compiler-output change on the smaller set of builds I run.  I will be running the full set of builds.
