### PR TITLE
Tools: ROS2: Add missing dependencies with docs

### DIFF
--- a/Tools/ros2/README.md
+++ b/Tools/ros2/README.md
@@ -1,12 +1,12 @@
 # ArduPilot ROS 2 packages
 
- This directory contains ROS 2 packages and configuration files for running
- ROS 2 processes and nodes that communicate with the ArduPilot DDS client
- library using the microROS agent. It contains the following packages:
+This directory contains ROS 2 packages and configuration files for running
+ROS 2 processes and nodes that communicate with the ArduPilot DDS client
+library using the microROS agent. It contains the following packages:
  
 #### `ardupilot_sitl`
 
-A `colcon` package for building and running ArduPilot SITL using the ROS 2 CLI.
+This is a `colcon` package for building and running ArduPilot SITL using the ROS 2 CLI.
 For example `ardurover` SITL may be launched with:
 
 ```bash
@@ -19,6 +19,14 @@ Some common arguments are exposed and forwarded to the underlying process.
 For example, MAVProxy can be launched, and you can enable the `console` and `map`.
 ```bash
 ros2 launch ardupilot_sitl sitl_mavproxy.launch.py map:=True console:=True 
+```
+
+ArduPilot SITL does not yet expose all arguments from the underlying binary.
+See [#27714](https://github.com/ArduPilot/ardupilot/issues/27714) for context.
+
+To see all current options, use the `-s` argument:
+```bash
+ros2 launch ardupilot_sitl sitl.launch.py -s
 ```
 
 #### `ardupilot_dds_test`

--- a/Tools/ros2/ardupilot_dds_tests/package.xml
+++ b/Tools/ros2/ardupilot_dds_tests/package.xml
@@ -27,12 +27,15 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ardupilot_msgs</test_depend>
   <test_depend>ardupilot_sitl</test_depend>
+  <test_depend>builtin_interfaces</test_depend>
   <test_depend>launch</test_depend>
   <test_depend>launch_pytest</test_depend>
   <test_depend>launch_ros</test_depend>
   <exec_depend>micro_ros_msgs</exec_depend>
   <test_depend>python3-pytest</test_depend>
   <test_depend>rclpy</test_depend>
+  <test_depend>sensor_msgs</test_depend>
+
 
   <export>
     <build_type>ament_python</build_type>

--- a/Tools/ros2/ardupilot_sitl/package.xml
+++ b/Tools/ros2/ardupilot_sitl/package.xml
@@ -11,7 +11,15 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
+  <exec_depend>ardupilot_msgs</exec_depend>
+  <exec_depend>builtin_interfaces</exec_depend>
+  <exec_depend>geographic_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>micro_ros_agent</exec_depend>
+  <exec_depend>rosgraph_msgs</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>tf2_msgs</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_black</test_depend>


### PR DESCRIPTION
# Purpose

Tridge tried out DDS and couldn't echo the topic in the wiki. This was because the message package was not installed.
```ap/geopose/filtered [geographic_msgs/msg/GeoPoseStamped]```

# Details

* Depend on all messages used in ardupilot_sitl
* Clarify limitations of wrapping with colcon
* Link github issue to support argument passthrough

# How to test

Use two terminals.

**Terminal 1:**

```
cd /path/to/your/workspace
source install/setup.bash
rosdep install --from-paths src --ignore-src
```

Expect to get geographic_msgs installed through `apt`: `ros-humble-geographic-msgs`. 
Now, run ArduPilot SITL:
```
ros2 launch ardupilot_sitl sitl_dds_udp.launch.py transport:=udp4  synthetic_clock:=True wipe:=False model:=quad speedup:=1 slave:=0 instance:=0 defaults:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/copter.parm,$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/dds_udp.parm sim_address:=127.0.0.1 master:=tcp:127.0.0.1:5760 sitl:=127.0.0.1:5501
```

**Terminal 2:**

```bash
cd /path/to/your/workspace
source install/setup.bash
ros2 topic echo /ap/geopose/filtered  --once
```

Expect some data, and not an error that `geographic_msgs/msg/GeoPoseStamped` is not found.
```
header:
  stamp:
    sec: 1722388542
    nanosec: 530041000
  frame_id: base_link
pose:
  position:
    latitude: -35.36326217651367
    longitude: 149.1652374267578
    altitude: 584.0800170898438
  orientation:
    x: 0.0007886550156399608
    y: 0.00011114936205558479
    z: 0.7403627038002014
    w: 0.6722070574760437
---
```

