### PR TITLE
AP_HAL: default SITL and Linux to have 4MB of "flash"

### DIFF
--- a/libraries/AP_HAL/AP_HAL_Boards.h
+++ b/libraries/AP_HAL/AP_HAL_Boards.h
@@ -191,13 +191,6 @@
 #define AP_EXTENDED_DSHOT_TELEM_V2_ENABLED HAL_REQUIRES_BDSHOT_SUPPORT
 #endif
 
-// this is used as a general mechanism to make a 'small' build by
-// dropping little used features. We use this to allow us to keep
-// FMUv2 going for as long as possible
-#ifndef HAL_MINIMIZE_FEATURES
-#define HAL_MINIMIZE_FEATURES       0
-#endif
-
 #ifndef BOARD_FLASH_SIZE
 #define BOARD_FLASH_SIZE 2048
 #endif

--- a/libraries/AP_HAL/board/linux.h
+++ b/libraries/AP_HAL/board/linux.h
@@ -341,6 +341,10 @@
     #error "no Linux board subtype set"
 #endif
 
+#ifndef BOARD_FLASH_SIZE
+#define BOARD_FLASH_SIZE 4096
+#endif
+
 #ifndef HAL_OPTFLOW_PX4FLOW_I2C_ADDRESS
     #define HAL_OPTFLOW_PX4FLOW_I2C_ADDRESS 0x42
 #endif

--- a/libraries/AP_HAL/board/sitl.h
+++ b/libraries/AP_HAL/board/sitl.h
@@ -29,6 +29,10 @@
 #define HAL_FLASH_ALLOW_UPDATE 0
 #endif
 
+#ifndef BOARD_FLASH_SIZE
+#define BOARD_FLASH_SIZE 4096
+#endif
+
 #ifndef HAL_STORAGE_SIZE
 #define HAL_STORAGE_SIZE            32768
 #endif


### PR DESCRIPTION
I've run this through size-compare-branches and there's no compiler output change.
