### PR TITLE
HAL_ChibiOS: fixed AP_FILESYSTEM_ROMFS_ENABLED for peripherals with d…

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -32,6 +32,7 @@ class ChibiOSHWDef(object):
         self.signed_fw = signed_fw
         self.default_params_filepath = default_params_filepath
         self.quiet = quiet
+        self.have_defaults_file = False
 
         # if true then parameters will be appended in special apj-tool
         # section at end of binary:
@@ -2613,6 +2614,13 @@ Please run: Tools/scripts/build_bootloaders.py %s
         self.write_board_validate_macro(f)
         self.write_check_firmware(f)
 
+        if self.have_defaults_file:
+            f.write('''
+#ifndef AP_FILESYSTEM_ROMFS_ENABLED
+#define AP_FILESYSTEM_ROMFS_ENABLED 1
+#endif
+''')
+
         self.write_peripheral_enable(f)
 
         if os.path.exists(self.processed_defaults_filepath()):
@@ -3241,6 +3249,7 @@ Please run: Tools/scripts/build_bootloaders.py %s
             return
 
         self.romfs_add('defaults.parm', filepath)
+        self.have_defaults_file = True
 
     def process_hwdefs(self):
         for fname in self.hwdef:


### PR DESCRIPTION
now that defaults are in ROMFS we must enable AP_FILESYSTEM_ROMFS_ENABLED