### PR TITLE
hwdef: add named Pixhack-v3 board

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CUAV-Pixhack-v3/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CUAV-Pixhack-v3/hwdef.dat
@@ -1,0 +1,3 @@
+include ../fmuv3/hwdef.dat
+
+USE_BOOTLOADER_FROM_BOARD fmuv3


### PR DESCRIPTION
allows for building this on the custom build server


custom build server doesn't give fmuv3 as an option.  Pixhawk limits the number of sensors

Closes https://github.com/ArduPilot/ardupilot/issues/26697
