### PR TITLE
APM_Control: add AP_FW_Controller as common base class to roll and pitch controlers

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -4339,6 +4339,65 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
     def AUTOTUNE(self):
         '''Test AutoTune mode'''
+        self.run_autotune()
+
+        # Values that are set to constants
+        # If these are changed then the expected tune paramters should also change
+        self.check_parameter_value("RLL2SRV_TCONST", 0.5, 0)
+        self.check_parameter_value("RLL2SRV_RMAX", 75, 0)
+        self.check_parameter_value("RLL_RATE_IMAX", 0.666, 0.01) # allow some small error to acount for floating point stuff
+        self.check_parameter_value("RLL_RATE_FLTT", 3.183, 0.01)
+        self.check_parameter_value("RLL_RATE_FLTE", 0, 0)
+        self.check_parameter_value("RLL_RATE_FLTD", 10.0, 0)
+        self.check_parameter_value("RLL_RATE_SMAX", 150.0, 0)
+
+        self.check_parameter_value("PTCH2SRV_TCONST", 0.75, 0)
+        self.check_parameter_value("PTCH2SRV_RMAX_UP", 75, 0)
+        self.check_parameter_value("PTCH2SRV_RMAX_DN", 75, 0)
+        self.check_parameter_value("PTCH_RATE_IMAX", 0.666, 0.01)
+        self.check_parameter_value("PTCH_RATE_FLTT", 2.122, 0.01)
+        self.check_parameter_value("PTCH_RATE_FLTE", 0, 0)
+        self.check_parameter_value("PTCH_RATE_FLTD", 10, 0)
+        self.check_parameter_value("PTCH_RATE_SMAX", 150, 0)
+
+        # Check tunned values, targets derived from running tests multiple times and taking average
+        # Expect within 2%
+        # Note that I is not checked directly, its value is derived from P, FF, and TCONST which are all checked.
+        self.check_parameter_value("RLL_RATE_P", 1.222702146, 2)
+        self.check_parameter_value("RLL_RATE_D", 0.070284024, 2)
+        self.check_parameter_value("RLL_RATE_FF", 0.229291457, 2)
+
+        self.check_parameter_value("PTCH_RATE_FF", 0.503520715, 5)
+
+        # There seem to be multiple solutions for pitch. I'm not sure why this is.
+        # Each value is quite consistent becasue of the fixed steps that autotune takes
+        try:
+            # Expect this about 84% of the time
+            self.check_parameter_value("PTCH_RATE_P", 1.746079683, 2)
+        except ValueError:
+            try:
+                # 12%
+                self.check_parameter_value("PTCH_RATE_P", 1.343138218, 2)
+            except ValueError:
+                # 4%
+                self.check_parameter_value("PTCH_RATE_P", 2.26990366, 2)
+
+        try:
+            # 64%
+            self.check_parameter_value("PTCH_RATE_D", 0.108, 2)
+        except ValueError:
+            try:
+                # 28%
+                self.check_parameter_value("PTCH_RATE_D", 0.141, 2)
+            except ValueError:
+                try:
+                    # 4%
+                    self.check_parameter_value("PTCH_RATE_D", 0.049, 2)
+                except ValueError:
+                    # 4%
+                    self.check_parameter_value("PTCH_RATE_D", 0.0836, 2)
+
+    def run_autotune(self):
         self.takeoff(100)
         self.change_mode('AUTOTUNE')
         self.context_collect('STATUSTEXT')
@@ -4354,6 +4413,14 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
                 self.progress("Got %s" % str(m))
                 if axis == "Roll":
                     axis = "Pitch"
+                    # Center sticks to allow roll to return to nuetral before starting pitch
+                    self.set_rc(1, 1500)
+                    self.set_rc(2, 1500)
+                    self.delay_sim_time(15)
+
+                    # Reset toggle value so the initial input is in a consistent directon
+                    rc_value = 1000
+
                 elif axis == "Pitch":
                     break
                 else:
@@ -4399,7 +4466,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             "RLL_RATE_FLTT": 20,
             "PTCH_RATE_FLTT": 20,
         })
-        self.AUTOTUNE()
+        self.run_autotune()
 
     def LandingDrift(self):
         '''Circuit with baro drift'''

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -6271,6 +6271,35 @@ class TestSuite(ABC):
             return
         raise ValueError("Failed to set parameters (%s)" % want)
 
+    def check_parameter_value(self, name, expected_value, max_error_percent):
+        value = self.get_parameter_direct(name, verbose=False)
+
+        # Convert to ratio and find limits
+        error_ratio = max_error_percent / 100
+        limits = [expected_value * (1 + error_ratio), expected_value * (1 - error_ratio)]
+
+        # Ensure that min and max are always the corret way round
+        upper_limit = max(limits)
+        lower_limit = min(limits)
+
+        # Work out the true error percentage
+        error_percent = math.nan
+        if expected_value != 0:
+            error_percent = abs(1.0 - (value / expected_value)) * 100
+
+        # Check value is within limits
+        if (value > upper_limit) or (value < lower_limit):
+            raise ValueError("%s expected %f ± %f%% (%f to %f) got %s with %f%% error" % (
+                name,
+                expected_value,
+                max_error_percent,
+                lower_limit,
+                upper_limit,
+                value,
+                error_percent))
+
+        self.progress("%s: (%f) check passed %f%% error less than %f%%" % (name, value, error_percent, max_error_percent))
+
     def get_parameter(self, *args, **kwargs):
         return self.get_parameter_direct(*args, **kwargs)
 

--- a/libraries/APM_Control/AP_AutoTune.cpp
+++ b/libraries/APM_Control/AP_AutoTune.cpp
@@ -153,7 +153,12 @@ void AP_AutoTune::stop(void)
 
 const char *AP_AutoTune::axis_string(void) const
 {
-    switch (type) {
+    return axis_string(type);
+}
+
+const char *AP_AutoTune::axis_string(ATType _type)
+{
+    switch (_type) {
     case AUTOTUNE_ROLL:
         return "Roll";
     case AUTOTUNE_PITCH:

--- a/libraries/APM_Control/AP_AutoTune.h
+++ b/libraries/APM_Control/AP_AutoTune.h
@@ -64,6 +64,8 @@ public:
     // are we running?
     bool running;
 
+    static const char *axis_string(ATType _type);
+
 private:
     // the current gains
     ATGains &current;

--- a/libraries/APM_Control/AP_FW_Controller.cpp
+++ b/libraries/APM_Control/AP_FW_Controller.cpp
@@ -1,0 +1,135 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+//	Code by Jon Challinger
+//  Modified by Paul Riseborough
+//
+
+
+#include "AP_FW_Controller.h"
+#include <AP_AHRS/AP_AHRS.h>
+#include <AP_Scheduler/AP_Scheduler.h>
+
+AP_FW_Controller::AP_FW_Controller(const AP_FixedWing &parms, const AC_PID::Defaults &defaults)
+    : aparm(parms),
+      rate_pid(defaults)
+{
+    rate_pid.set_slew_limit_scale(45);
+}
+
+/*
+  AC_PID based rate controller
+*/
+float AP_FW_Controller::_get_rate_out(float desired_rate, float scaler, bool disable_integrator, float aspeed, bool ground_mode)
+{
+    const float dt = AP::scheduler().get_loop_period_s();
+
+    const float eas2tas = AP::ahrs().get_EAS2TAS();
+    bool limit_I = fabsf(_last_out) >= 45;
+    const float rate = get_measured_rate();
+    const float old_I = rate_pid.get_i();
+
+    const bool underspeed = is_underspeed(aspeed);
+    if (underspeed) {
+        limit_I = true;
+    }
+
+    // the P and I elements are scaled by sq(scaler). To use an
+    // unmodified AC_PID object we scale the inputs and calculate FF separately
+    //
+    // note that we run AC_PID in radians so that the normal scaling
+    // range for IMAX in AC_PID applies (usually an IMAX value less than 1.0)
+    rate_pid.update_all(radians(desired_rate) * scaler * scaler, rate * scaler * scaler, dt, limit_I);
+
+    if (underspeed) {
+        // when underspeed we lock the integrator
+        rate_pid.set_integrator(old_I);
+    }
+
+    // FF should be scaled by scaler/eas2tas, but since we have scaled
+    // the AC_PID target above by scaler*scaler we need to instead
+    // divide by scaler*eas2tas to get the right scaling
+    const float ff = degrees(ff_scale * rate_pid.get_ff() / (scaler * eas2tas));
+    ff_scale = 1.0;
+
+    if (disable_integrator) {
+        rate_pid.reset_I();
+    }
+
+    // convert AC_PID info object to same scale as old controller
+    _pid_info = rate_pid.get_pid_info();
+    auto &pinfo = _pid_info;
+
+    const float deg_scale = degrees(1);
+    pinfo.FF = ff;
+    pinfo.P *= deg_scale;
+    pinfo.I *= deg_scale;
+    pinfo.D *= deg_scale;
+    pinfo.DFF *= deg_scale;
+
+    // fix the logged target and actual values to not have the scalers applied
+    pinfo.target = desired_rate;
+    pinfo.actual = degrees(rate);
+
+    // sum components
+    float out = pinfo.FF + pinfo.P + pinfo.I + pinfo.D + pinfo.DFF;
+    if (ground_mode) {
+        // when on ground suppress D and half P term to prevent oscillations
+        out -= pinfo.D + 0.5*pinfo.P;
+    }
+
+    // remember the last output to trigger the I limit
+    _last_out = out;
+
+    if (autotune != nullptr && autotune->running && aspeed > aparm.airspeed_min) {
+        // let autotune have a go at the values
+        autotune->update(pinfo, scaler, angle_err_deg);
+    }
+
+    // output is scaled to notional centidegrees of deflection
+    return constrain_float(out * 100, -4500, 4500);
+}
+
+/*
+ Function returns an equivalent control surface deflection in centi-degrees in the range from -4500 to 4500
+*/
+float AP_FW_Controller::get_rate_out(float desired_rate, float scaler)
+{
+    return _get_rate_out(desired_rate, scaler, false, get_airspeed(), false);
+}
+
+void AP_FW_Controller::reset_I()
+{
+    rate_pid.reset_I();
+}
+
+/*
+    reduce the integrator, used when we have a low scale factor in a quadplane hover
+*/
+void AP_FW_Controller::decay_I()
+{
+    // this reduces integrator by 95% over 2s
+    _pid_info.I *= 0.995f;
+    rate_pid.set_integrator(rate_pid.get_i() * 0.995);
+}
+
+/*
+  restore autotune gains
+ */
+void AP_FW_Controller::autotune_restore(void)
+{
+    if (autotune != nullptr) {
+        autotune->stop();
+    }
+}

--- a/libraries/APM_Control/AP_FW_Controller.h
+++ b/libraries/APM_Control/AP_FW_Controller.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <AP_Common/AP_Common.h>
+#include "AP_AutoTune.h"
+#include <AC_PID/AC_PID.h>
+
+class AP_FW_Controller
+{
+public:
+    AP_FW_Controller(const AP_FixedWing &parms, const AC_PID::Defaults &defaults);
+
+    /* Do not allow copies */
+    CLASS_NO_COPY(AP_FW_Controller);
+
+    float get_rate_out(float desired_rate, float scaler);
+    virtual float get_servo_out(int32_t angle_err, float scaler, bool disable_integrator, bool ground_mode) = 0;
+
+    // setup a one loop FF scale multiplier. This replaces any previous scale applied
+    // so should only be used when only one source of scaling is needed
+    void set_ff_scale(float _ff_scale) { ff_scale = _ff_scale; }
+
+    void reset_I();
+
+    /*
+      reduce the integrator, used when we have a low scale factor in a quadplane hover
+    */
+    void decay_I();
+
+    virtual void autotune_start(void) = 0;
+    void autotune_restore(void);
+
+    const AP_PIDInfo& get_pid_info(void) const
+    {
+        return _pid_info;
+    }
+
+    // set the PID notch sample rates
+    void set_notch_sample_rate(float sample_rate) { rate_pid.set_notch_sample_rate(sample_rate); }
+
+    AP_Float &kP(void) { return rate_pid.kP(); }
+    AP_Float &kI(void) { return rate_pid.kI(); }
+    AP_Float &kD(void) { return rate_pid.kD(); }
+    AP_Float &kFF(void) { return rate_pid.ff(); }
+    AP_Float &tau(void) { return gains.tau; }
+
+protected:
+    const AP_FixedWing &aparm;
+    AP_AutoTune::ATGains gains;
+    AP_AutoTune *autotune;
+    bool failed_autotune_alloc;
+    float _last_out;
+    AC_PID rate_pid;
+    float angle_err_deg;
+    float ff_scale = 1.0;
+
+    AP_PIDInfo _pid_info;
+
+    float _get_rate_out(float desired_rate, float scaler, bool disable_integrator, float aspeed, bool ground_mode);
+
+    virtual bool is_underspeed(const float aspeed) const = 0;
+
+    virtual float get_airspeed() const = 0;
+
+    virtual float get_measured_rate() const = 0;
+};

--- a/libraries/APM_Control/AP_FW_Controller.h
+++ b/libraries/APM_Control/AP_FW_Controller.h
@@ -7,7 +7,7 @@
 class AP_FW_Controller
 {
 public:
-    AP_FW_Controller(const AP_FixedWing &parms, const AC_PID::Defaults &defaults);
+    AP_FW_Controller(const AP_FixedWing &parms, const AC_PID::Defaults &defaults, AP_AutoTune::ATType _autotune_type);
 
     /* Do not allow copies */
     CLASS_NO_COPY(AP_FW_Controller);
@@ -26,7 +26,7 @@ public:
     */
     void decay_I();
 
-    virtual void autotune_start(void) = 0;
+    void autotune_start(void);
     void autotune_restore(void);
 
     const AP_PIDInfo& get_pid_info(void) const
@@ -62,4 +62,6 @@ protected:
     virtual float get_airspeed() const = 0;
 
     virtual float get_measured_rate() const = 0;
+
+    const AP_AutoTune::ATType autotune_type;
 };

--- a/libraries/APM_Control/AP_PitchController.cpp
+++ b/libraries/APM_Control/AP_PitchController.cpp
@@ -20,7 +20,6 @@
 #include "AP_PitchController.h"
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Scheduler/AP_Scheduler.h>
-#include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -174,7 +173,8 @@ AP_PitchController::AP_PitchController(const AP_FixedWing &parms)
         .filt_D_hz = 12.0,
         .srmax     = 150.0,
         .srtau     = 1.0
-    })
+    },
+    AP_AutoTune::ATType::AUTOTUNE_PITCH)
 {
     AP_Param::setup_object_defaults(this, var_info);
 }
@@ -332,23 +332,4 @@ void AP_PitchController::convert_pid()
     rate_pid.kP().set_and_save_ifchanged(old_d);
     rate_pid.kD().set_and_save_ifchanged(0);
     rate_pid.kIMAX().set_and_save_ifchanged(old_imax/4500.0);
-}
-
-/*
-  start an autotune
- */
-void AP_PitchController::autotune_start(void)
-{
-    if (autotune == nullptr) {
-        autotune = NEW_NOTHROW AP_AutoTune(gains, AP_AutoTune::AUTOTUNE_PITCH, aparm, rate_pid);
-        if (autotune == nullptr) {
-            if (!failed_autotune_alloc) {
-                GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "AutoTune: failed pitch allocation");
-            }
-            failed_autotune_alloc = true;
-        }
-    }
-    if (autotune != nullptr) {
-        autotune->start();
-    }
 }

--- a/libraries/APM_Control/AP_PitchController.cpp
+++ b/libraries/APM_Control/AP_PitchController.cpp
@@ -162,105 +162,41 @@ const AP_Param::GroupInfo AP_PitchController::var_info[] = {
 };
 
 AP_PitchController::AP_PitchController(const AP_FixedWing &parms)
-    : aparm(parms)
+    : AP_FW_Controller(parms,
+      AC_PID::Defaults{
+        .p         = 0.04,
+        .i         = 0.15,
+        .d         = 0.0,
+        .ff        = 0.345,
+        .imax      = 0.666,
+        .filt_T_hz = 3.0,
+        .filt_E_hz = 0.0,
+        .filt_D_hz = 12.0,
+        .srmax     = 150.0,
+        .srtau     = 1.0
+    })
 {
     AP_Param::setup_object_defaults(this, var_info);
-    rate_pid.set_slew_limit_scale(45);
 }
 
-/*
-  AC_PID based rate controller
-*/
-float AP_PitchController::_get_rate_out(float desired_rate, float scaler, bool disable_integrator, float aspeed, bool ground_mode)
+float AP_PitchController::get_measured_rate() const
 {
-    const float dt = AP::scheduler().get_loop_period_s();
-
-    const AP_AHRS &_ahrs = AP::ahrs();
-
-    const float eas2tas = _ahrs.get_EAS2TAS();
-    bool limit_I = fabsf(_last_out) >= 45;
-    float rate_y = _ahrs.get_gyro().y;
-    float old_I = rate_pid.get_i();
-
-    bool underspeed = aspeed <= 0.5*float(aparm.airspeed_min);
-    if (underspeed) {
-        limit_I = true;
-    }
-
-    // the P and I elements are scaled by sq(scaler). To use an
-    // unmodified AC_PID object we scale the inputs and calculate FF separately
-    //
-    // note that we run AC_PID in radians so that the normal scaling
-    // range for IMAX in AC_PID applies (usually an IMAX value less than 1.0)
-    rate_pid.update_all(radians(desired_rate) * scaler * scaler, rate_y * scaler * scaler, dt, limit_I);
-
-    if (underspeed) {
-        // when underspeed we lock the integrator
-        rate_pid.set_integrator(old_I);
-    }
-
-    // FF should be scaled by scaler/eas2tas, but since we have scaled
-    // the AC_PID target above by scaler*scaler we need to instead
-    // divide by scaler*eas2tas to get the right scaling
-    const float ff = degrees(ff_scale * rate_pid.get_ff() / (scaler * eas2tas));
-    ff_scale = 1.0;
-
-    if (disable_integrator) {
-        rate_pid.reset_I();
-    }
-
-    // convert AC_PID info object to same scale as old controller
-    _pid_info = rate_pid.get_pid_info();
-    auto &pinfo = _pid_info;
-
-    const float deg_scale = degrees(1);
-    pinfo.FF = ff;
-    pinfo.P *= deg_scale;
-    pinfo.I *= deg_scale;
-    pinfo.D *= deg_scale;
-    pinfo.DFF *= deg_scale;
-
-    // fix the logged target and actual values to not have the scalers applied
-    pinfo.target = desired_rate;
-    pinfo.actual = degrees(rate_y);
-
-    // sum components
-    float out = pinfo.FF + pinfo.P + pinfo.I + pinfo.D + pinfo.DFF;
-    if (ground_mode) {
-        // when on ground suppress D and half P term to prevent oscillations
-        out -= pinfo.D + 0.5*pinfo.P;
-    }
-
-    // remember the last output to trigger the I limit
-    _last_out = out;
-
-    if (autotune != nullptr && autotune->running && aspeed > aparm.airspeed_min) {
-        // let autotune have a go at the values
-        autotune->update(pinfo, scaler, angle_err_deg);
-    }
-
-    // output is scaled to notional centidegrees of deflection
-    return constrain_float(out * 100, -4500, 4500);
+    return AP::ahrs().get_gyro().y;
 }
 
-/*
- Function returns an equivalent elevator deflection in centi-degrees in the range from -4500 to 4500
- A positive demand is up
- Inputs are:
- 1) demanded pitch rate in degrees/second
- 2) control gain scaler = scaling_speed / aspeed
- 3) boolean which is true when stabilise mode is active
- 4) minimum FBW airspeed (metres/sec)
- 5) maximum FBW airspeed (metres/sec)
-*/
-float AP_PitchController::get_rate_out(float desired_rate, float scaler)
+float AP_PitchController::get_airspeed() const
 {
     float aspeed;
     if (!AP::ahrs().airspeed_estimate(aspeed)) {
         // If no airspeed available use average of min and max
         aspeed = 0.5f*(float(aparm.airspeed_min) + float(aparm.airspeed_max));
     }
-    return _get_rate_out(desired_rate, scaler, false, aspeed, false);
+    return aspeed;
+}
+
+bool AP_PitchController::is_underspeed(const float aspeed) const
+{
+    return aspeed <= 0.5*float(aparm.airspeed_min);
 }
 
 /*
@@ -270,7 +206,7 @@ float AP_PitchController::get_rate_out(float desired_rate, float scaler)
   Also returns the inverted flag and the estimated airspeed in m/s for
   use by the rest of the pitch controller
  */
-float AP_PitchController::_get_coordination_rate_offset(float &aspeed, bool &inverted) const
+float AP_PitchController::_get_coordination_rate_offset(const float &aspeed, bool &inverted) const
 {
     float rate_offset;
     float bank_angle = AP::ahrs().get_roll();
@@ -288,10 +224,6 @@ float AP_PitchController::_get_coordination_rate_offset(float &aspeed, bool &inv
         }
     }
     const AP_AHRS &_ahrs = AP::ahrs();
-    if (!_ahrs.airspeed_estimate(aspeed)) {
-        // If no airspeed available use average of min and max
-        aspeed = 0.5f*(float(aparm.airspeed_min) + float(aparm.airspeed_max));
-    }
     if (abs(_ahrs.pitch_sensor) > 7000) {
         // don't do turn coordination handling when at very high pitch angles
         rate_offset = 0;
@@ -318,13 +250,14 @@ float AP_PitchController::get_servo_out(int32_t angle_err, float scaler, bool di
     // Calculate offset to pitch rate demand required to maintain pitch angle whilst banking
     // Calculate ideal turn rate from bank angle and airspeed assuming a level coordinated turn
     // Pitch rate offset is the component of turn rate about the pitch axis
-    float aspeed;
     float rate_offset;
     bool inverted;
 
     if (gains.tau < 0.05f) {
         gains.tau.set(0.05f);
     }
+
+    const float aspeed = get_airspeed();
 
     rate_offset = _get_coordination_rate_offset(aspeed, inverted);
 
@@ -368,11 +301,6 @@ float AP_PitchController::get_servo_out(int32_t angle_err, float scaler, bool di
     }
 
     return _get_rate_out(desired_rate, scaler, disable_integrator, aspeed, ground_mode);
-}
-
-void AP_PitchController::reset_I()
-{
-    rate_pid.reset_I();
 }
 
 /*
@@ -422,15 +350,5 @@ void AP_PitchController::autotune_start(void)
     }
     if (autotune != nullptr) {
         autotune->start();
-    }
-}
-
-/*
-  restore autotune gains
- */
-void AP_PitchController::autotune_restore(void)
-{
-    if (autotune != nullptr) {
-        autotune->stop();
     }
 }

--- a/libraries/APM_Control/AP_PitchController.h
+++ b/libraries/APM_Control/AP_PitchController.h
@@ -11,7 +11,6 @@ public:
     CLASS_NO_COPY(AP_PitchController);
 
     float get_servo_out(int32_t angle_err, float scaler, bool disable_integrator, bool ground_mode) override;
-    void autotune_start(void) override;
 
     static const struct AP_Param::GroupInfo var_info[];
 

--- a/libraries/APM_Control/AP_PitchController.h
+++ b/libraries/APM_Control/AP_PitchController.h
@@ -1,11 +1,8 @@
 #pragma once
 
-#include <AP_Common/AP_Common.h>
-#include "AP_AutoTune.h"
-#include <AP_Math/AP_Math.h>
-#include <AC_PID/AC_PID.h>
+#include "AP_FW_Controller.h"
 
-class AP_PitchController
+class AP_PitchController : public AP_FW_Controller
 {
 public:
     AP_PitchController(const AP_FixedWing &parms);
@@ -13,60 +10,20 @@ public:
     /* Do not allow copies */
     CLASS_NO_COPY(AP_PitchController);
 
-    float get_rate_out(float desired_rate, float scaler);
-    float get_servo_out(int32_t angle_err, float scaler, bool disable_integrator, bool ground_mode);
-
-    // setup a one loop FF scale multiplier. This replaces any previous scale applied
-    // so should only be used when only one source of scaling is needed
-    void set_ff_scale(float _ff_scale) { ff_scale = _ff_scale; }
-
-    void reset_I();
-
-    /*
-      reduce the integrator, used when we have a low scale factor in a quadplane hover
-    */
-    void decay_I()
-    {
-        // this reduces integrator by 95% over 2s
-        _pid_info.I *= 0.995f;
-        rate_pid.set_integrator(rate_pid.get_i() * 0.995);
-    }
-
-    void autotune_start(void);
-    void autotune_restore(void);
-
-    const AP_PIDInfo& get_pid_info(void) const
-    {
-        return _pid_info;
-    }
-
-    // set the PID notch sample rates
-    void set_notch_sample_rate(float sample_rate) { rate_pid.set_notch_sample_rate(sample_rate); }
+    float get_servo_out(int32_t angle_err, float scaler, bool disable_integrator, bool ground_mode) override;
+    void autotune_start(void) override;
 
     static const struct AP_Param::GroupInfo var_info[];
-
-    AP_Float &kP(void) { return rate_pid.kP(); }
-    AP_Float &kI(void) { return rate_pid.kI(); }
-    AP_Float &kD(void) { return rate_pid.kD(); }
-    AP_Float &kFF(void) { return rate_pid.ff(); }
-    AP_Float &tau(void) { return gains.tau; }
 
     void convert_pid();
 
 private:
-    const AP_FixedWing &aparm;
-    AP_AutoTune::ATGains gains;
-    AP_AutoTune *autotune;
-    bool failed_autotune_alloc;
-    AP_Int16 _max_rate_neg;
     AP_Float _roll_ff;
-    float _last_out;
-    AC_PID rate_pid{0.04, 0.15, 0, 0.345, 0.666, 3, 0, 12, 150, 1};
-    float angle_err_deg;
-    float ff_scale = 1.0;
 
-    AP_PIDInfo _pid_info;
+    float _get_coordination_rate_offset(const float &aspeed, bool &inverted) const;
 
-    float _get_rate_out(float desired_rate, float scaler, bool disable_integrator, float aspeed, bool ground_mode);
-    float _get_coordination_rate_offset(float &aspeed, bool &inverted) const;
+    float get_airspeed() const override;
+    bool is_underspeed(const float aspeed) const override;
+    float get_measured_rate() const override;
+
 };

--- a/libraries/APM_Control/AP_RollController.cpp
+++ b/libraries/APM_Control/AP_RollController.cpp
@@ -146,101 +146,41 @@ const AP_Param::GroupInfo AP_RollController::var_info[] = {
 
 // constructor
 AP_RollController::AP_RollController(const AP_FixedWing &parms)
-    : aparm(parms)
+    : AP_FW_Controller(parms,
+      AC_PID::Defaults{
+        .p         = 0.08,
+        .i         = 0.15,
+        .d         = 0.0,
+        .ff        = 0.345,
+        .imax      = 0.666,
+        .filt_T_hz = 3.0,
+        .filt_E_hz = 0.0,
+        .filt_D_hz = 12.0,
+        .srmax     = 150.0,
+        .srtau     = 1.0
+    })
 {
     AP_Param::setup_object_defaults(this, var_info);
-    rate_pid.set_slew_limit_scale(45);
 }
 
-
-/*
-  AC_PID based rate controller
-*/
-float AP_RollController::_get_rate_out(float desired_rate, float scaler, bool disable_integrator, bool ground_mode)
+float AP_RollController::get_measured_rate() const
 {
-    const AP_AHRS &_ahrs = AP::ahrs();
+    return AP::ahrs().get_gyro().x;
+}
 
-    const float dt = AP::scheduler().get_loop_period_s();
-    const float eas2tas = _ahrs.get_EAS2TAS();
-    bool limit_I = fabsf(_last_out) >= 45;
-    float rate_x = _ahrs.get_gyro().x;
+float AP_RollController::get_airspeed() const
+{
     float aspeed;
-    float old_I = rate_pid.get_i();
-
-    if (!_ahrs.airspeed_estimate(aspeed)) {
-        aspeed = 0;
+    if (!AP::ahrs().airspeed_estimate(aspeed)) {
+        // If no airspeed available use 0
+        aspeed = 0.0;
     }
-    bool underspeed = aspeed <= float(aparm.airspeed_min);
-    if (underspeed) {
-        limit_I = true;
-    }
-
-    // the P and I elements are scaled by sq(scaler). To use an
-    // unmodified AC_PID object we scale the inputs and calculate FF separately
-    //
-    // note that we run AC_PID in radians so that the normal scaling
-    // range for IMAX in AC_PID applies (usually an IMAX value less than 1.0)
-    rate_pid.update_all(radians(desired_rate) * scaler * scaler, rate_x * scaler * scaler, dt, limit_I);
-
-    if (underspeed) {
-        // when underspeed we lock the integrator
-        rate_pid.set_integrator(old_I);
-    }
-
-    // FF should be scaled by scaler/eas2tas, but since we have scaled
-    // the AC_PID target above by scaler*scaler we need to instead
-    // divide by scaler*eas2tas to get the right scaling
-    const float ff = degrees(ff_scale * rate_pid.get_ff() / (scaler * eas2tas));
-    ff_scale = 1.0;
-
-    if (disable_integrator) {
-        rate_pid.reset_I();
-    }
-
-    // convert AC_PID info object to same scale as old controller
-    _pid_info = rate_pid.get_pid_info();
-    auto &pinfo = _pid_info;
-
-    const float deg_scale = degrees(1);
-    pinfo.FF = ff;
-    pinfo.P *= deg_scale;
-    pinfo.I *= deg_scale;
-    pinfo.D *= deg_scale;
-    pinfo.DFF *= deg_scale;
-
-    // fix the logged target and actual values to not have the scalers applied
-    pinfo.target = desired_rate;
-    pinfo.actual = degrees(rate_x);
-
-    // sum components
-    float out = pinfo.FF + pinfo.P + pinfo.I + pinfo.D + pinfo.DFF;
-    if (ground_mode) {
-        // when on ground suppress D term to prevent oscillations
-        out -= pinfo.D + 0.5*pinfo.P;
-    }
-
-    // remember the last output to trigger the I limit
-    _last_out = out;
-
-    if (autotune != nullptr && autotune->running && aspeed > aparm.airspeed_min) {
-        // let autotune have a go at the values
-        autotune->update(pinfo, scaler, angle_err_deg);
-    }
-
-    // output is scaled to notional centidegrees of deflection
-    return constrain_float(out * 100, -4500, 4500);
+    return aspeed;
 }
 
-/*
- Function returns an equivalent elevator deflection in centi-degrees in the range from -4500 to 4500
- A positive demand is up
- Inputs are:
- 1) desired roll rate in degrees/sec
- 2) control gain scaler = scaling_speed / aspeed
-*/
-float AP_RollController::get_rate_out(float desired_rate, float scaler)
+bool AP_RollController::is_underspeed(const float aspeed) const
 {
-    return _get_rate_out(desired_rate, scaler, false, false);
+    return aspeed <= float(aparm.airspeed_min);
 }
 
 /*
@@ -269,12 +209,7 @@ float AP_RollController::get_servo_out(int32_t angle_err, float scaler, bool dis
         desired_rate = gains.rmax_pos;
     }
 
-    return _get_rate_out(desired_rate, scaler, disable_integrator, ground_mode);
-}
-
-void AP_RollController::reset_I()
-{
-    rate_pid.reset_I();
+    return _get_rate_out(desired_rate, scaler, disable_integrator, get_airspeed(), ground_mode);
 }
 
 /*
@@ -323,15 +258,5 @@ void AP_RollController::autotune_start(void)
     }
     if (autotune != nullptr) {
         autotune->start();
-    }
-}
-
-/*
-  restore autotune gains
- */
-void AP_RollController::autotune_restore(void)
-{
-    if (autotune != nullptr) {
-        autotune->stop();
     }
 }

--- a/libraries/APM_Control/AP_RollController.cpp
+++ b/libraries/APM_Control/AP_RollController.cpp
@@ -21,7 +21,6 @@
 #include "AP_RollController.h"
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Scheduler/AP_Scheduler.h>
-#include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -158,7 +157,8 @@ AP_RollController::AP_RollController(const AP_FixedWing &parms)
         .filt_D_hz = 12.0,
         .srmax     = 150.0,
         .srtau     = 1.0
-    })
+    },
+    AP_AutoTune::ATType::AUTOTUNE_ROLL)
 {
     AP_Param::setup_object_defaults(this, var_info);
 }
@@ -240,23 +240,4 @@ void AP_RollController::convert_pid()
     rate_pid.kP().set_and_save_ifchanged(old_d);
     rate_pid.kD().set_and_save_ifchanged(0);
     rate_pid.kIMAX().set_and_save_ifchanged(old_imax/4500.0);
-}
-
-/*
-  start an autotune
- */
-void AP_RollController::autotune_start(void)
-{
-    if (autotune == nullptr) {
-        autotune = NEW_NOTHROW AP_AutoTune(gains, AP_AutoTune::AUTOTUNE_ROLL, aparm, rate_pid);
-        if (autotune == nullptr) {
-            if (!failed_autotune_alloc) {
-                GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "AutoTune: failed roll allocation");
-            }
-            failed_autotune_alloc = true;
-        }
-    }
-    if (autotune != nullptr) {
-        autotune->start();
-    }
 }

--- a/libraries/APM_Control/AP_RollController.h
+++ b/libraries/APM_Control/AP_RollController.h
@@ -1,11 +1,8 @@
 #pragma once
 
-#include <AP_Common/AP_Common.h>
-#include "AP_AutoTune.h"
-#include <AP_Math/AP_Math.h>
-#include <AC_PID/AC_PID.h>
+#include "AP_FW_Controller.h"
 
-class AP_RollController
+class AP_RollController : public AP_FW_Controller
 {
 public:
     AP_RollController(const AP_FixedWing &parms);
@@ -13,59 +10,16 @@ public:
     /* Do not allow copies */
     CLASS_NO_COPY(AP_RollController);
 
-    float get_rate_out(float desired_rate, float scaler);
-    float get_servo_out(int32_t angle_err, float scaler, bool disable_integrator, bool ground_mode);
+    float get_servo_out(int32_t angle_err, float scaler, bool disable_integrator, bool ground_mode) override;
 
-    // setup a one loop FF scale multiplier. This replaces any previous scale applied
-    // so should only be used when only one source of scaling is needed
-    void set_ff_scale(float _ff_scale) { ff_scale = _ff_scale; }
-
-    void reset_I();
-
-    /*
-      reduce the integrator, used when we have a low scale factor in a quadplane hover
-    */
-    void decay_I()
-    {
-        // this reduces integrator by 95% over 2s
-        _pid_info.I *= 0.995f;
-        rate_pid.set_integrator(rate_pid.get_i() * 0.995);
-    }
-
-    void autotune_start(void);
-    void autotune_restore(void);
-
-    const AP_PIDInfo& get_pid_info(void) const
-    {
-        return _pid_info;
-    }
-
-    // set the PID notch sample rates
-    void set_notch_sample_rate(float sample_rate) { rate_pid.set_notch_sample_rate(sample_rate); }
+    void autotune_start(void) override;
 
     static const struct AP_Param::GroupInfo var_info[];
-
-
-    // tuning accessors
-    AP_Float &kP(void) { return rate_pid.kP(); }
-    AP_Float &kI(void) { return rate_pid.kI(); }
-    AP_Float &kD(void) { return rate_pid.kD(); }
-    AP_Float &kFF(void) { return rate_pid.ff(); }
-    AP_Float &tau(void) { return gains.tau; }
 
     void convert_pid();
 
 private:
-    const AP_FixedWing &aparm;
-    AP_AutoTune::ATGains gains;
-    AP_AutoTune *autotune;
-    bool failed_autotune_alloc;
-    float _last_out;
-    AC_PID rate_pid{0.08, 0.15, 0, 0.345, 0.666, 3, 0, 12, 150, 1};
-    float angle_err_deg;
-    float ff_scale = 1.0;
-
-    AP_PIDInfo _pid_info;
-
-    float _get_rate_out(float desired_rate, float scaler, bool disable_integrator, bool ground_mode);
+    float get_airspeed() const override;
+    bool is_underspeed(const float aspeed) const override;
+    float get_measured_rate() const override;
 };

--- a/libraries/APM_Control/AP_RollController.h
+++ b/libraries/APM_Control/AP_RollController.h
@@ -12,8 +12,6 @@ public:
 
     float get_servo_out(int32_t angle_err, float scaler, bool disable_integrator, bool ground_mode) override;
 
-    void autotune_start(void) override;
-
     static const struct AP_Param::GroupInfo var_info[];
 
     void convert_pid();

--- a/libraries/APM_Control/examples/AP_FW_Controller_test/AP_FW_Controller_test.cpp
+++ b/libraries/APM_Control/examples/AP_FW_Controller_test/AP_FW_Controller_test.cpp
@@ -1,0 +1,299 @@
+#include <AP_HAL/AP_HAL.h>
+
+#include <AP_Math/chirp.h>
+#include <APM_Control/AP_RollController.h>
+#include <APM_Control/AP_PitchController.h>
+#include <AP_Vehicle/AP_FixedWing.h>
+#include <AP_AHRS/AP_AHRS.h>
+#include <stdio.h>
+#include <errno.h>
+#include <AP_Scheduler/AP_Scheduler.h>
+
+/* run with:
+    ./waf configure --board linux
+    ./waf build --targets examples/AP_FW_Controller_test
+    ./build/linux/examples/AP_FW_Controller_test
+*/
+
+void setup();
+void loop();
+
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+// Need a scheduler so the controllers can get DT
+AP_Scheduler scheduler;
+
+// When using stop clock the normal hal scheduler sleeps don't work.
+// We need to sleep to clear print buffer, so microsleep implementation is copied here
+void microsleep(uint32_t usec)
+{
+    struct timespec ts;
+    ts.tv_sec = 0;
+    ts.tv_nsec = usec*1000UL;
+    while (nanosleep(&ts, &ts) == -1 && errno == EINTR);
+}
+
+
+// Chirp object to generate test signal
+Chirp chirp;
+
+// Chirp setup params
+const float magnitude = 60.0; // deg - large magnitude means slew limit should kick in (very high values needed because of low default gains)
+const float duration = 60.0; // seconds
+const float frequency_start = 1.0; // hz
+const float frequency_stop = 20; // hz, stay under the 25Hz nyquist limit on a 50Hz loop rate
+const float time_fade_in = 15; // seconds
+const float time_fade_out = 10; // seconds
+const float time_const_freq = 2.0 / frequency_start; // seconds
+
+// Param object used by controllers
+AP_FixedWing params;
+
+// Controller objects to test
+AP_RollController roll_control { params };
+AP_PitchController pitch_control { params };
+
+// 50 hz loop, start at time 0
+// Loop rate must match SCHEDULER_DEFAULT_LOOP_RATE
+const uint16_t dt_us = 20000;
+uint64_t waveform_time_us = 0;
+
+// Scaling speed parameter value
+float scaling_speed = 15;
+
+// Default values for user provided configuration
+enum class Axis {
+    Roll = 0,
+    Pitch = 1,
+} test_axis = Axis::Roll;
+bool override_have_airspeed = true;
+float override_airspeed = 10;
+float override_roll = 0;
+float override_pitch = 0;
+bool ground_mode = false;
+bool disable_integrator = false;
+
+// Define the AHRS functions we need
+AP_AHRS::AP_AHRS(uint8_t flags) :
+    _ekf_flags(flags)
+{
+    _singleton = this;
+}
+
+// This is a dirty hack so we can set private values inside the ahrs
+void AP_AHRS::update(bool skip_ins_update)
+{
+    roll = override_roll;
+    pitch = override_pitch;
+    update_cd_values();
+
+    state.airspeed = override_airspeed;
+    state.airspeed_ok = override_have_airspeed;
+}
+
+// Copys of the functions we need out of AP_AHRS.cpp
+bool AP_AHRS::airspeed_estimate(float &airspeed_ret) const
+{
+    airspeed_ret = state.airspeed;
+    return state.airspeed_ok;
+}
+float AP_AHRS::get_EAS2TAS(void) const
+{
+    if (is_positive(state.EAS2TAS)) {
+        return state.EAS2TAS;
+    }
+    return 1.0;
+}
+
+// singleton instance
+AP_AHRS *AP_AHRS::_singleton;
+
+namespace AP {
+AP_AHRS &ahrs() {
+    return *AP_AHRS::get_singleton();
+}
+}
+
+AP_AHRS ahrs;
+
+// Calculate the airspeed scaler based on airspeed and the configured param
+// Method from `Plane::calc_speed_scaler`
+float calc_speed_scaler()
+{
+    float aspeed;
+    if (!ahrs.airspeed_estimate(aspeed)) {
+        return 1.0;
+    }
+
+    // ensure we have scaling over the full configured airspeed
+    const float airspeed_min = MAX(params.airspeed_min, 5);
+    const float scale_min = MIN(0.5, scaling_speed / (2.0 * params.airspeed_max));
+    const float scale_max = MAX(2.0, scaling_speed / (0.7 * airspeed_min));
+    float speed_scaler = scale_max;
+    if (aspeed > 0.0001) {
+        speed_scaler = scaling_speed / aspeed;
+    }
+    return constrain_float(speed_scaler, scale_min, scale_max);
+}
+
+
+// setup function
+void setup()
+{
+    // Read in user provided configuration
+    uint8_t argc;
+    char * const *argv;
+    hal.util->commandline_arguments(argc, argv);
+    if (argc > 1) {
+        for (uint8_t i = 1; i < argc; i++) {
+            const char *arg = argv[i];
+            const char *eq = strchr(arg, '=');
+
+            if (eq == NULL) {
+                ::printf("Expected argument with \"=\"\n");
+                exit(1);
+            }
+
+            char cmd[20] {};
+            strncpy(cmd, arg, eq-arg);
+            const float value = atof(eq+1);
+            if (strcmp(cmd, "axis") == 0) {
+                if (strcmp(eq+1, "roll") == 0) {
+                    test_axis = Axis::Roll;
+                } else if (strcmp(eq+1, "pitch") == 0) {
+                    test_axis = Axis::Pitch;
+
+                } else {
+                    ::printf("Unknown axis: %s\n", eq+1);
+                    exit(1);
+                }
+
+            } else if (strcmp(cmd, "roll") == 0) {
+                override_roll = radians(value);
+
+            } else if (strcmp(cmd, "pitch") == 0) {
+                override_pitch = radians(value);
+
+            } else if (strcmp(cmd, "airspeed") == 0) {
+                override_airspeed = value;
+
+            } else if (strcmp(cmd,"airspeed_fail") == 0) {
+                override_have_airspeed = value <= 0.0;
+
+            } else if (strcmp(cmd,"ground_mode") == 0) {
+                ground_mode = value > 0.0;
+
+            } else if (strcmp(cmd,"disable_integrator") == 0) {
+                disable_integrator = value > 0.0;
+
+            } else {
+                ::printf("Expected \"axis\", \"roll\", \"pitch\", \"airspeed\", \"airspeed_fail\",  \"ground_mode\",  \"disable_integrator\"\n");
+                exit(1);
+            }
+        }
+    }
+
+    ::printf("FixedWing controller test - ");
+    switch (test_axis) {
+        case Axis::Roll:
+            ::printf("Roll");
+            break;
+
+        case Axis::Pitch:
+            ::printf("Pitch");
+            break;
+    }
+    ::printf(" - ground_mode: %i, disable_integrator: %i\n", ground_mode, disable_integrator);
+
+    // Set the configured values into the AHRS
+    ahrs.update();
+
+    // Set default values for the params used by the controllers
+    params.airspeed_min.set(9);
+    params.airspeed_max.set(22);
+    params.roll_limit.set(45);
+    params.pitch_limit_max.set(20);
+    params.pitch_limit_min.set(-25);
+    params.autotune_level.set(6);
+    params.autotune_options.set(0);
+
+    // Setup chirp object
+    chirp.init(duration, frequency_start, frequency_stop, time_fade_in, time_fade_out, time_const_freq);
+
+    // Force clock to start at 0
+    hal.scheduler->stop_clock(waveform_time_us);
+
+    // Print constant inputs
+    ::printf("Chirp - duration: %fs, magnitude: %f, start: %fHz, stop: %fHz, fade in: %fs, fade out:%fs, hold: %fs\n", duration, magnitude, frequency_start, frequency_stop, time_fade_in, time_fade_out, time_const_freq);
+
+    // Print AHRS state
+    float airspeed = -1;
+    bool airspeed_ok = ahrs.airspeed_estimate(airspeed);
+    ::printf("AHRS - roll: %f, pitch: %f, airspeed: %f, airspeed OK: %i, EAS2TAS %f, gyro: { %f, %f, %f }\n", ahrs.roll_sensor * 0.01, ahrs.pitch_sensor * 0.01, airspeed, airspeed_ok, ahrs.get_EAS2TAS(), ahrs.get_gyro().x, ahrs.get_gyro().y, ahrs.get_gyro().z);
+
+    // Header for results
+    ::printf("Time (s), angle error, output, PID target, PID actual, error, P, I, D, FF, DFF, Dmod, Slew rate, limit, PD limit, reset, I term set\n");
+
+}
+
+void loop(void)
+{
+    // Update the chirp to generate input for controller
+    const float waveform_time_s = waveform_time_us * 1.0e-6;
+    const float nav_angle_cd = chirp.update(waveform_time_s, magnitude) * 100.0;
+
+    // Calculate speed scaler
+    const float speed_scaler = calc_speed_scaler();
+
+    // Run the controller
+    float angle_error_cd;
+    float output;
+    const AP_PIDInfo* info = nullptr;
+
+    switch (test_axis) {
+        case Axis::Roll:
+            angle_error_cd = nav_angle_cd - ahrs.roll_sensor;
+            output = roll_control.get_servo_out(angle_error_cd, speed_scaler, disable_integrator, ground_mode);
+            info = &roll_control.get_pid_info();
+            break;
+
+        case Axis::Pitch:
+            angle_error_cd = nav_angle_cd - ahrs.pitch_sensor;
+            output = pitch_control.get_servo_out(angle_error_cd, speed_scaler, disable_integrator, ground_mode);
+            info = &pitch_control.get_pid_info();
+            break;
+    }
+
+    // Print results
+    ::printf("%0.4f,%0.4f,%0.4f,%0.4f,%0.4f,%0.4f,%0.4f,%0.4f,%0.4f,%0.4f,%0.4f,%0.4f,%0.4f,%u,%u,%u,%u\n",
+        waveform_time_s,
+        angle_error_cd * 0.01,
+        output,
+        info->target,
+        info->actual,
+        info->error,
+        info->P,
+        info->I,
+        info->D,
+        info->FF,
+        info->DFF,
+        info->Dmod,
+        info->slew_rate,
+        info->limit,
+        info->PD_limit,
+        info->reset,
+        info->I_term_set);
+
+    if (chirp.completed()) {
+        // Sleep gives the print buffer a chance to keep up
+        microsleep(10000);
+        exit(1);
+    }
+
+    // Force clock times so we can run faster than real time
+    waveform_time_us += dt_us;
+    hal.scheduler->stop_clock(waveform_time_us);
+
+}
+
+AP_HAL_MAIN();

--- a/libraries/APM_Control/examples/AP_FW_Controller_test/TestMatrix.sh
+++ b/libraries/APM_Control/examples/AP_FW_Controller_test/TestMatrix.sh
@@ -7,39 +7,40 @@ cd ../../../..
 
 mkdir -p FW_Controller_matrix
 
-./waf configure --board linux
+./waf configure --board sitl
 ./waf build --target examples/AP_FW_Controller_test
 echo
 
 Axis="roll pitch"
-Angle="-20 10 5 0 5 10 20"
+RollAngle="-170 -160 -150 -140 -130 -120 -110 -100 -90 -80 -70 -60 -50 -40 -30 -20 10 0 10 20 30 40 50 60 70 80 90 100 110 120 130 140 150 160 170 180"
+PitchAngle="-80 -70 -60 -50 -40 -30 -20 10 0 10 20 30 40 50 60 70 80"
 Airspeed="5 10 15 20 25"
 
 COUNTER=0
 # Range of roll angles
-for roll in $Angle; do
+for roll in $RollAngle; do
     # Range of pitch angles
-    for pitch in $Angle; do
+    for pitch in $PitchAngle; do
         # Both roll and piith
         for ax in $Axis; do
             # Range of airspeeds
             for speed in $Airspeed; do
-                ./build/linux/examples/AP_FW_Controller_test axis=$ax roll=$roll pitch=$pitch airspeed=$speed > FW_Controller_matrix/$COUNTER.csv
+                ./build/sitl/examples/AP_FW_Controller_test axis=$ax roll=$roll pitch=$pitch airspeed=$speed > FW_Controller_matrix/$COUNTER.csv
                 let COUNTER++
             done
 
             # Airspeed failure
-            ./build/linux/examples/AP_FW_Controller_test axis=$ax roll=$roll pitch=$pitch airspeed_fail=1 > FW_Controller_matrix/$COUNTER.csv
+            ./build/sitl/examples/AP_FW_Controller_test axis=$ax roll=$roll pitch=$pitch airspeed_fail=1 > FW_Controller_matrix/$COUNTER.csv
             let COUNTER++
 
             # Ground mode and intergrator diable flags, only test at defualt airspeed
-            ./build/linux/examples/AP_FW_Controller_test axis=$ax roll=$roll pitch=$pitch ground_mode=1 > FW_Controller_matrix/$COUNTER.csv
+            ./build/sitl/examples/AP_FW_Controller_test axis=$ax roll=$roll pitch=$pitch ground_mode=1 > FW_Controller_matrix/$COUNTER.csv
             let COUNTER++
 
-            ./build/linux/examples/AP_FW_Controller_test axis=$ax roll=$roll pitch=$pitch disable_integrator=1 > FW_Controller_matrix/$COUNTER.csv
+            ./build/sitl/examples/AP_FW_Controller_test axis=$ax roll=$roll pitch=$pitch disable_integrator=1 > FW_Controller_matrix/$COUNTER.csv
             let COUNTER++
 
-            ./build/linux/examples/AP_FW_Controller_test axis=$ax roll=$roll pitch=$pitch ground_mode=1 disable_integrator=1 > FW_Controller_matrix/$COUNTER.csv
+            ./build/sitl/examples/AP_FW_Controller_test axis=$ax roll=$roll pitch=$pitch ground_mode=1 disable_integrator=1 > FW_Controller_matrix/$COUNTER.csv
             let COUNTER++
         done
     done

--- a/libraries/APM_Control/examples/AP_FW_Controller_test/TestMatrix.sh
+++ b/libraries/APM_Control/examples/AP_FW_Controller_test/TestMatrix.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Fixedwing controller test and run over a range of inputs
+# Output results to files for comparison
+
+cd "$(dirname "$0")"
+cd ../../../..
+
+mkdir -p FW_Controller_matrix
+
+./waf configure --board linux
+./waf build --target examples/AP_FW_Controller_test
+echo
+
+Axis="roll pitch"
+Angle="-20 10 5 0 5 10 20"
+Airspeed="5 10 15 20 25"
+
+COUNTER=0
+# Range of roll angles
+for roll in $Angle; do
+    # Range of pitch angles
+    for pitch in $Angle; do
+        # Both roll and piith
+        for ax in $Axis; do
+            # Range of airspeeds
+            for speed in $Airspeed; do
+                ./build/linux/examples/AP_FW_Controller_test axis=$ax roll=$roll pitch=$pitch airspeed=$speed > FW_Controller_matrix/$COUNTER.csv
+                let COUNTER++
+            done
+
+            # Airspeed failure
+            ./build/linux/examples/AP_FW_Controller_test axis=$ax roll=$roll pitch=$pitch airspeed_fail=1 > FW_Controller_matrix/$COUNTER.csv
+            let COUNTER++
+
+            # Ground mode and intergrator diable flags, only test at defualt airspeed
+            ./build/linux/examples/AP_FW_Controller_test axis=$ax roll=$roll pitch=$pitch ground_mode=1 > FW_Controller_matrix/$COUNTER.csv
+            let COUNTER++
+
+            ./build/linux/examples/AP_FW_Controller_test axis=$ax roll=$roll pitch=$pitch disable_integrator=1 > FW_Controller_matrix/$COUNTER.csv
+            let COUNTER++
+
+            ./build/linux/examples/AP_FW_Controller_test axis=$ax roll=$roll pitch=$pitch ground_mode=1 disable_integrator=1 > FW_Controller_matrix/$COUNTER.csv
+            let COUNTER++
+        done
+    done
+done
+

--- a/libraries/APM_Control/examples/AP_FW_Controller_test/plot_results.py
+++ b/libraries/APM_Control/examples/AP_FW_Controller_test/plot_results.py
@@ -1,0 +1,82 @@
+
+# Plot the results of a controller test run
+# For example run test with:
+# ./build/linux/examples/AP_FW_Controller_test > results.csv
+# The plot with:
+# python3 libraries/APM_Control/examples/AP_FW_Controller_test/plot_results.py results.csv
+
+import csv
+from argparse import ArgumentParser
+from collections import defaultdict
+from matplotlib import pyplot as plt
+
+if __name__ == '__main__':
+
+    parser = ArgumentParser(description='Plot results of controller test run')
+    parser.add_argument('filename', help='csv file to read')
+    args = parser.parse_args()
+
+    with open(args.filename) as csv_file:
+        csv_reader = csv.DictReader(csv_file)
+
+        # Skip First few lines
+        next(csv_file, None)
+        next(csv_file, None)
+        next(csv_file, None)
+
+        csv_data = [row for row in csv_reader]
+
+    # Reshape data from list of dicts to dict of lists
+    data = defaultdict(list)
+    for i in csv_data:
+        for key, value in i.items():
+            data[key.strip()].append(float(value))
+
+    # Make some plots!
+
+    fig, ax = plt.subplots(2)
+    fig.suptitle('Input => output')
+    ax[0].plot(data['Time (s)'], data['angle error'])
+    ax[0].set_ylabel('input angle error (deg)')
+    ax[1].plot(data['Time (s)'], data['output'])
+    ax[1].set_ylabel('output servo position')
+    ax[1].set_xlabel('Time (s)')
+
+    fig, ax = plt.subplots(2)
+    fig.suptitle('Rate controller')
+    ax[0].plot(data['Time (s)'], data['PID target'], label = "target")
+    ax[0].plot(data['Time (s)'], data['PID actual'], label = "actual")
+    ax[0].legend()
+    ax[0].set_ylabel('rate target and actual')
+    ax[1].plot(data['Time (s)'], data['error'])
+    ax[1].set_ylabel('rate error')
+    ax[1].set_xlabel('Time (s)')
+
+    fig = plt.figure()
+    plt.title('Rate controller PID components')
+    plt.plot(data['Time (s)'], data['P'], label = "P")
+    plt.plot(data['Time (s)'], data['I'], label = "I")
+    plt.plot(data['Time (s)'], data['D'], label = "D")
+    plt.plot(data['Time (s)'], data['FF'], label = "FF")
+    plt.plot(data['Time (s)'], data['DFF'], label = "DFF")
+    plt.legend()
+    plt.xlabel('Time (s)')
+
+    fig, ax = plt.subplots(2)
+    fig.suptitle('Rate controller')
+    ax[0].plot(data['Time (s)'], data['Slew rate'])
+    ax[0].set_ylabel('Slew rate')
+    ax[1].plot(data['Time (s)'], data['Dmod'])
+    ax[1].set_ylabel('Dmod')
+    ax[1].set_xlabel('Time (s)')
+
+    fig = plt.figure()
+    plt.title('Rate controller PID flags')
+    plt.plot(data['Time (s)'], data['limit'], label = "limit")
+    plt.plot(data['Time (s)'], data['PD limit'], label = "PD limit")
+    plt.plot(data['Time (s)'], data['reset'], label = "reset")
+    plt.plot(data['Time (s)'], data['I term set'], label = "I term set")
+    plt.legend()
+    plt.xlabel('Time (s)')
+
+    plt.show()

--- a/libraries/APM_Control/examples/AP_FW_Controller_test/plot_results.py
+++ b/libraries/APM_Control/examples/AP_FW_Controller_test/plot_results.py
@@ -23,6 +23,11 @@ if __name__ == '__main__':
         next(csv_file, None)
         next(csv_file, None)
         next(csv_file, None)
+        next(csv_file, None)
+        next(csv_file, None)
+        next(csv_file, None)
+        next(csv_file, None)
+        next(csv_file, None)
 
         csv_data = [row for row in csv_reader]
 

--- a/libraries/APM_Control/examples/AP_FW_Controller_test/wscript
+++ b/libraries/APM_Control/examples/AP_FW_Controller_test/wscript
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+def build(bld):
+
+    if bld.env.BOARD != 'linux':
+        return
+
+    # Turn off the normal AHRS so we can define a custom one
+    bld.env.DEFINES += ['AP_AHRS_ENABLED=0']
+
+    # Turn off other things that are expecting a complete AHRS
+    bld.env.DEFINES += ['AP_FRSKY_SPORT_PASSTHROUGH_ENABLED=0', 'AP_AIRSPEED_ENABLED=0']
+
+    bld.ap_program(
+        use='ap',
+        program_groups=['examples'],
+    )
+

--- a/libraries/APM_Control/examples/AP_FW_Controller_test/wscript
+++ b/libraries/APM_Control/examples/AP_FW_Controller_test/wscript
@@ -3,17 +3,19 @@
 
 def build(bld):
 
-    if bld.env.BOARD != 'linux':
+    if bld.env.BOARD != 'sitl':
         return
 
-    # Turn off the normal AHRS so we can define a custom one
-    bld.env.DEFINES += ['AP_AHRS_ENABLED=0']
-
-    # Turn off other things that are expecting a complete AHRS
-    bld.env.DEFINES += ['AP_FRSKY_SPORT_PASSTHROUGH_ENABLED=0', 'AP_AIRSPEED_ENABLED=0']
+    bld.ap_stlib(
+        name='AP_FW_Controller_test_libs',
+        ap_vehicle='UNKNOWN',
+        ap_libraries=bld.ap_common_vehicle_libraries() + [
+            'SITL', 'APM_Control', 'AP_AdvancedFailsafe',
+        ],
+    )
 
     bld.ap_program(
-        use='ap',
+        use='AP_FW_Controller_test_libs',
         program_groups=['examples'],
     )
 

--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.h
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.h
@@ -43,6 +43,8 @@ public:
 
     uint32_t get_uart_output_full_queue_count() const;
 
+    HALSITL::SITL_State * get_sitl_state() { return _sitl_state; }
+
 private:
     HALSITL::SITL_State *_sitl_state;
 


### PR DESCRIPTION
This moves to a shared base class between the plane roll and pitch controllers, there is lots of shared code which was duplicated. This helps with future tidyups as they now only need to happen in one place.