### PR TITLE
AP_DroneCAN: DNA_Server: lock all high level database operations

### DIFF
--- a/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.cpp
@@ -74,7 +74,6 @@ void AP_DroneCAN_DNA_Server::Database::readNodeData(NodeData &data, uint8_t node
         return;
     }
 
-    WITH_SEMAPHORE(sem);
     storage->read_block(&data, NODEDATA_LOC(node_id), sizeof(struct NodeData));
 }
 
@@ -85,7 +84,6 @@ void AP_DroneCAN_DNA_Server::Database::writeNodeData(const NodeData &data, uint8
         return;
     }
 
-    WITH_SEMAPHORE(sem);
     storage->write_block(NODEDATA_LOC(node_id), &data, sizeof(struct NodeData));
 }
 

--- a/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.h
+++ b/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.h
@@ -23,6 +23,35 @@ class AP_DroneCAN_DNA_Server
         uint8_t crc;
     };
 
+    class Database {
+    public:
+        Database() {};
+
+        // initialize database (storage accessor is always replaced with the one supplied)
+        void init(StorageAccess *storage_);
+
+        //Reset the Server Record
+        void reset();
+
+        //Look in the storage and check if there's a valid Server Record there
+        bool isValidNodeDataAvailable(uint8_t node_id);
+
+        //Reads the Server Record from storage for specified node id
+        void readNodeData(NodeData &data, uint8_t node_id);
+
+        //Writes the Server Record from storage for specified node id
+        void writeNodeData(const NodeData &data, uint8_t node_id);
+
+        // bitmasks containing a status for each possible node ID (except 0 and > MAX_NODE_ID)
+        Bitmask<128> node_storage_occupied; // storage has a valid entry
+
+    private:
+        StorageAccess *storage;
+        HAL_Semaphore sem;
+    };
+
+    static Database db;
+
     enum ServerState {
         NODE_STATUS_UNHEALTHY = -5,
         DUPLICATE_NODES = -2,
@@ -35,7 +64,6 @@ class AP_DroneCAN_DNA_Server
     bool nodeInfo_resp_rcvd;
 
     // bitmasks containing a status for each possible node ID (except 0 and > MAX_NODE_ID)
-    Bitmask<128> node_storage_occupied; // storage has a valid entry
     Bitmask<128> node_verified; // node seen and unique ID matches stored
     Bitmask<128> node_seen; // received NodeStatus
     Bitmask<128> node_logged; // written to log fle
@@ -57,15 +85,6 @@ class AP_DroneCAN_DNA_Server
     //Generates 6Byte long hash from the specified unique_id
     void getHash(NodeData &node_data, const uint8_t unique_id[], uint8_t size) const;
 
-    //Reset the Server Record
-    void reset();
-
-    //Reads the Server Record from storage for specified node id
-    void readNodeData(NodeData &data, uint8_t node_id);
-
-    //Writes the Server Record from storage for specified node id
-    void writeNodeData(const NodeData &data, uint8_t node_id);
-
     //Methods to set, clear and report NodeIDs allocated/registered so far
     void freeNodeID(uint8_t node_id);
 
@@ -78,10 +97,6 @@ class AP_DroneCAN_DNA_Server
     //Finds next available free Node, starting from preferred NodeID
     uint8_t findFreeNodeID(uint8_t preferred);
 
-    //Look in the storage and check if there's a valid Server Record there
-    bool isValidNodeDataAvailable(uint8_t node_id);
-
-    HAL_Semaphore storage_sem;
     AP_DroneCAN &_ap_dronecan;
     CanardInterface &_canard_iface;
 

--- a/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.h
+++ b/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.h
@@ -44,6 +44,9 @@ class AP_DroneCAN_DNA_Server
         // handle processing the node info message. returns true if duplicate.
         bool handleNodeInfo(uint8_t source_node_id, const uint8_t unique_id[]);
 
+        // handle the allocation message. returns the new node ID.
+        uint8_t handleAllocation(uint8_t node_id, const uint8_t unique_id[]);
+
         //Generates 6Byte long hash from the specified unique_id
         void getHash(NodeData &node_data, const uint8_t unique_id[], uint8_t size) const;
 

--- a/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.h
+++ b/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.h
@@ -33,6 +33,27 @@ class AP_DroneCAN_DNA_Server
         //Reset the Server Record
         void reset();
 
+        // returns true if the given node ID is occupied (has valid stored data)
+        bool isOccupied(uint8_t node_id) {
+            return node_storage_occupied.get(node_id);
+        }
+
+        //Generates 6Byte long hash from the specified unique_id
+        void getHash(NodeData &node_data, const uint8_t unique_id[], uint8_t size) const;
+
+        //Methods to set, clear and report NodeIDs allocated/registered so far
+        void freeNodeID(uint8_t node_id);
+
+        //Go through List to find node id for specified unique id
+        uint8_t getNodeIDForUniqueID(const uint8_t unique_id[], uint8_t size);
+
+        //Add Node ID info to the record and setup necessary mask fields
+        void addNodeIDForUniqueID(uint8_t node_id, const uint8_t unique_id[], uint8_t size);
+
+        //Finds next available free Node, starting from preferred NodeID
+        uint8_t findFreeNodeID(uint8_t preferred);
+
+    private:
         //Look in the storage and check if there's a valid Server Record there
         bool isValidNodeDataAvailable(uint8_t node_id);
 
@@ -45,7 +66,6 @@ class AP_DroneCAN_DNA_Server
         // bitmasks containing a status for each possible node ID (except 0 and > MAX_NODE_ID)
         Bitmask<128> node_storage_occupied; // storage has a valid entry
 
-    private:
         StorageAccess *storage;
         HAL_Semaphore sem;
     };
@@ -81,21 +101,6 @@ class AP_DroneCAN_DNA_Server
     uint8_t rcvd_unique_id[16];
     uint8_t rcvd_unique_id_offset;
     uint32_t last_alloc_msg_ms;
-
-    //Generates 6Byte long hash from the specified unique_id
-    void getHash(NodeData &node_data, const uint8_t unique_id[], uint8_t size) const;
-
-    //Methods to set, clear and report NodeIDs allocated/registered so far
-    void freeNodeID(uint8_t node_id);
-
-    //Go through List to find node id for specified unique id
-    uint8_t getNodeIDForUniqueID(const uint8_t unique_id[], uint8_t size);
-
-    //Add Node ID info to the record and setup necessary mask fields
-    void addNodeIDForUniqueID(uint8_t node_id, const uint8_t unique_id[], uint8_t size);
-
-    //Finds next available free Node, starting from preferred NodeID
-    uint8_t findFreeNodeID(uint8_t preferred);
 
     AP_DroneCAN &_ap_dronecan;
     CanardInterface &_canard_iface;

--- a/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.h
+++ b/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.h
@@ -41,6 +41,9 @@ class AP_DroneCAN_DNA_Server
         // handle initializing the server with the given expected node ID and unique ID
         void initServer(uint8_t node_id, const uint8_t own_unique_id[], uint8_t own_unique_id_len);
 
+        // handle processing the node info message. returns true if duplicate.
+        bool handleNodeInfo(uint8_t source_node_id, const uint8_t unique_id[]);
+
         //Generates 6Byte long hash from the specified unique_id
         void getHash(NodeData &node_data, const uint8_t unique_id[], uint8_t size) const;
 

--- a/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.h
+++ b/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.h
@@ -38,6 +38,9 @@ class AP_DroneCAN_DNA_Server
             return node_storage_occupied.get(node_id);
         }
 
+        // handle initializing the server with the given expected node ID and unique ID
+        void initServer(uint8_t node_id, const uint8_t own_unique_id[], uint8_t own_unique_id_len);
+
         //Generates 6Byte long hash from the specified unique_id
         void getHash(NodeData &node_data, const uint8_t unique_id[], uint8_t size) const;
 

--- a/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.h
+++ b/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.h
@@ -47,6 +47,7 @@ class AP_DroneCAN_DNA_Server
         // handle the allocation message. returns the new node ID.
         uint8_t handleAllocation(uint8_t node_id, const uint8_t unique_id[]);
 
+    private:
         //Generates 6Byte long hash from the specified unique_id
         void getHash(NodeData &node_data, const uint8_t unique_id[], uint8_t size) const;
 
@@ -62,7 +63,6 @@ class AP_DroneCAN_DNA_Server
         //Finds next available free Node, starting from preferred NodeID
         uint8_t findFreeNodeID(uint8_t preferred);
 
-    private:
         //Look in the storage and check if there's a valid Server Record there
         bool isValidNodeDataAvailable(uint8_t node_id);
 


### PR DESCRIPTION
This adds a database class which contains the lock over all high level database operations (as most are read-modify-write) and does the database operations on the storage, and a static instance of it which is shared among all server instances. Please see commits for details.

There should be no behavior or logic changes at all to users using only one driver, for better or worse. Users using multiple won't have duplicate IDs assigned when attaching new nodes to different drivers without rebooting in between. They also won't risk corrupting the database due to race conditions, however unlikely that probably was in practice.

It doesn't look immediately feasible in Ardupilot right now to have the same ID on two different drivers anyway as the parameters which store the GPS node IDs can't handle that. That work will have to be done too (not sure if there are other places which don't store the driver index), in addition to expanding the storage. I do not plan to do this work; hoping that 120 IDs should be enough for anybody. Fortunately, once that is done, the DNA server will not need any modification except for the instantiation of one database per server.

Tested in SITL using a node on each bus. Testing on hardware to come soon.