### PR TITLE
Autotune: Add switch to test gains after tune is complete

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -809,12 +809,8 @@ bool AP_Arming_Copter::disarm(const AP_Arming::Method method, bool do_disarm_che
     }
 
 #if AUTOTUNE_ENABLED == ENABLED
-    // save auto tuned parameters
-    if (copter.flightmode == &copter.mode_autotune) {
-        copter.mode_autotune.save_tuning_gains();
-    } else {
-        copter.mode_autotune.reset();
-    }
+    // Possibly save auto tuned parameters
+    copter.mode_autotune.autotune.disarmed(copter.flightmode == &copter.mode_autotune);
 #endif
 
     // we are not in the air

--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -76,7 +76,8 @@ void RC_Channel_Copter::init_aux_function(const AUX_FUNC ch_option, const AuxSwi
     // the following functions do not need to be initialised:
     case AUX_FUNC::ALTHOLD:
     case AUX_FUNC::AUTO:
-    case AUX_FUNC::AUTOTUNE:
+    case AUX_FUNC::AUTOTUNE_MODE:
+    case AUX_FUNC::AUTOTUNE_TEST_GAINS:
     case AUX_FUNC::BRAKE:
     case AUX_FUNC::CIRCLE:
     case AUX_FUNC::DRIFT:
@@ -291,8 +292,11 @@ bool RC_Channel_Copter::do_aux_function(const AUX_FUNC ch_option, const AuxSwitc
 #endif
 
 #if AUTOTUNE_ENABLED == ENABLED
-        case AUX_FUNC::AUTOTUNE:
+        case AUX_FUNC::AUTOTUNE_MODE:
             do_aux_function_change_mode(Mode::Number::AUTOTUNE, ch_flag);
+            break;
+        case AUX_FUNC::AUTOTUNE_TEST_GAINS:
+            copter.mode_autotune.autotune.do_aux_function(ch_flag);
             break;
 #endif
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -796,18 +796,12 @@ public:
     bool allows_arming(AP_Arming::Method method) const override { return false; }
     bool is_autopilot() const override { return false; }
 
-    void save_tuning_gains();
-    void reset();
+    AutoTune autotune;
 
 protected:
 
     const char *name() const override { return "AUTOTUNE"; }
     const char *name4() const override { return "ATUN"; }
-
-private:
-
-    AutoTune autotune;
-
 };
 #endif
 

--- a/ArduCopter/mode_autotune.cpp
+++ b/ArduCopter/mode_autotune.cpp
@@ -118,19 +118,9 @@ void ModeAutoTune::run()
     autotune.run();
 }
 
-void ModeAutoTune::save_tuning_gains()
-{
-    autotune.save_tuning_gains();
-}
-
 void ModeAutoTune::exit()
 {
     autotune.stop();
-}
-
-void ModeAutoTune::reset()
-{
-    autotune.reset();
 }
 
 #endif  // AUTOTUNE_ENABLED == ENABLED

--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -370,12 +370,8 @@ bool AP_Arming_Plane::disarm(const AP_Arming::Method method, bool do_disarm_chec
     change_arm_state();
 
 #if QAUTOTUNE_ENABLED
-    //save qautotune gains if enabled and success
-    if (plane.control_mode == &plane.mode_qautotune) {
-        plane.quadplane.qautotune.save_tuning_gains();
-    } else {
-        plane.quadplane.qautotune.reset();
-    }
+    // Possibly save auto tuned parameters
+    plane.quadplane.qautotune.disarmed(plane.control_mode == &plane.mode_qautotune);
 #endif
 
     // re-initialize speed variable used in AUTO and GUIDED for

--- a/ArduPlane/RC_Channel.cpp
+++ b/ArduPlane/RC_Channel.cpp
@@ -169,6 +169,9 @@ void RC_Channel_Plane::init_aux_function(const RC_Channel::AUX_FUNC ch_option,
     case AUX_FUNC::FW_AUTOTUNE:
     case AUX_FUNC::VFWD_THR_OVERRIDE:
     case AUX_FUNC::PRECISION_LOITER:
+#if QAUTOTUNE_ENABLED
+    case AUX_FUNC::AUTOTUNE_TEST_GAINS:
+#endif
         break;
 
     case AUX_FUNC::SOARING:
@@ -440,6 +443,12 @@ bool RC_Channel_Plane::do_aux_function(const AUX_FUNC ch_option, const AuxSwitch
     case AUX_FUNC::PRECISION_LOITER:
         // handled by lua scripting, just ignore here
         break;
+
+#if QAUTOTUNE_ENABLED
+    case AUX_FUNC::AUTOTUNE_TEST_GAINS:
+        plane.quadplane.qautotune.do_aux_function(ch_flag);
+        break;
+#endif
 
     default:
         return RC_Channel::do_aux_function(ch_option, ch_flag);

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
@@ -487,16 +487,14 @@ void AC_AutoTune_Heli::load_tuned_gains()
         attitude_control->set_accel_roll_max_cdss(0.0f);
         attitude_control->set_accel_pitch_max_cdss(0.0f);
     }
-    if (roll_enabled()) {
+    if ((axes_completed & AUTOTUNE_AXIS_BITMASK_ROLL) && roll_enabled()) {
         load_gain_set(AxisType::ROLL, tune_roll_rp, tune_roll_rff*AUTOTUNE_FFI_RATIO_FINAL, tune_roll_rd, tune_roll_rff, tune_roll_sp, tune_roll_accel, orig_roll_fltt, 0.0f, orig_roll_smax, orig_roll_rate);
     }
-    if (pitch_enabled()) {
+    if ((axes_completed & AUTOTUNE_AXIS_BITMASK_PITCH) && pitch_enabled()) {
         load_gain_set(AxisType::PITCH, tune_pitch_rp, tune_pitch_rff*AUTOTUNE_FFI_RATIO_FINAL, tune_pitch_rd, tune_pitch_rff, tune_pitch_sp, tune_pitch_accel, orig_pitch_fltt, 0.0f, orig_pitch_smax, orig_pitch_rate);
     }
-    if (yaw_enabled()) {
-        if (!is_zero(tune_yaw_rp)) {
-            load_gain_set(AxisType::YAW, tune_yaw_rp, tune_yaw_rp*AUTOTUNE_YAW_PI_RATIO_FINAL, tune_yaw_rd, tune_yaw_rff, tune_yaw_sp, tune_yaw_accel, orig_yaw_fltt, tune_yaw_rLPF, orig_yaw_smax, orig_yaw_rate);
-        }
+    if ((axes_completed & AUTOTUNE_AXIS_BITMASK_YAW) && yaw_enabled() && !is_zero(tune_yaw_rp)) {
+        load_gain_set(AxisType::YAW, tune_yaw_rp, tune_yaw_rp*AUTOTUNE_YAW_PI_RATIO_FINAL, tune_yaw_rd, tune_yaw_rff, tune_yaw_sp, tune_yaw_accel, orig_yaw_fltt, tune_yaw_rLPF, orig_yaw_smax, orig_yaw_rate);
     }
 }
 

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -260,43 +260,38 @@ void AC_AutoTune_Multi::load_tuned_gains()
         attitude_control->set_accel_roll_max_cdss(0.0);
         attitude_control->set_accel_pitch_max_cdss(0.0);
     }
-    if (roll_enabled()) {
-        if (!is_zero(tune_roll_rp)) {
-            attitude_control->get_rate_roll_pid().set_kP(tune_roll_rp);
-            attitude_control->get_rate_roll_pid().set_kI(tune_roll_rp*AUTOTUNE_PI_RATIO_FINAL);
-            attitude_control->get_rate_roll_pid().set_kD(tune_roll_rd);
-            attitude_control->get_rate_roll_pid().set_ff(orig_roll_rff);
-            attitude_control->get_rate_roll_pid().set_kDff(orig_roll_dff);
-            attitude_control->get_angle_roll_p().set_kP(tune_roll_sp);
-            attitude_control->set_accel_roll_max_cdss(tune_roll_accel);
-        }
+    if ((axes_completed & AUTOTUNE_AXIS_BITMASK_ROLL) && roll_enabled() && !is_zero(tune_roll_rp)) {
+        attitude_control->get_rate_roll_pid().set_kP(tune_roll_rp);
+        attitude_control->get_rate_roll_pid().set_kI(tune_roll_rp*AUTOTUNE_PI_RATIO_FINAL);
+        attitude_control->get_rate_roll_pid().set_kD(tune_roll_rd);
+        attitude_control->get_rate_roll_pid().set_ff(orig_roll_rff);
+        attitude_control->get_rate_roll_pid().set_kDff(orig_roll_dff);
+        attitude_control->get_angle_roll_p().set_kP(tune_roll_sp);
+        attitude_control->set_accel_roll_max_cdss(tune_roll_accel);
     }
-    if (pitch_enabled()) {
-        if (!is_zero(tune_pitch_rp)) {
-            attitude_control->get_rate_pitch_pid().set_kP(tune_pitch_rp);
-            attitude_control->get_rate_pitch_pid().set_kI(tune_pitch_rp*AUTOTUNE_PI_RATIO_FINAL);
-            attitude_control->get_rate_pitch_pid().set_kD(tune_pitch_rd);
-            attitude_control->get_rate_pitch_pid().set_ff(orig_pitch_rff);
-            attitude_control->get_rate_pitch_pid().set_kDff(orig_pitch_dff);
-            attitude_control->get_angle_pitch_p().set_kP(tune_pitch_sp);
-            attitude_control->set_accel_pitch_max_cdss(tune_pitch_accel);
-        }
+    if ((axes_completed & AUTOTUNE_AXIS_BITMASK_PITCH) && pitch_enabled() && !is_zero(tune_pitch_rp)) {
+        attitude_control->get_rate_pitch_pid().set_kP(tune_pitch_rp);
+        attitude_control->get_rate_pitch_pid().set_kI(tune_pitch_rp*AUTOTUNE_PI_RATIO_FINAL);
+        attitude_control->get_rate_pitch_pid().set_kD(tune_pitch_rd);
+        attitude_control->get_rate_pitch_pid().set_ff(orig_pitch_rff);
+        attitude_control->get_rate_pitch_pid().set_kDff(orig_pitch_dff);
+        attitude_control->get_angle_pitch_p().set_kP(tune_pitch_sp);
+        attitude_control->set_accel_pitch_max_cdss(tune_pitch_accel);
     }
-    if (yaw_enabled() || yaw_d_enabled()) {
-        if (!is_zero(tune_yaw_rp)) {
-            attitude_control->get_rate_yaw_pid().set_kP(tune_yaw_rp);
-            attitude_control->get_rate_yaw_pid().set_kI(tune_yaw_rp*AUTOTUNE_YAW_PI_RATIO_FINAL);
-            if (yaw_d_enabled()) {
-                attitude_control->get_rate_yaw_pid().set_kD(tune_yaw_rd);
-            }
-            if (yaw_enabled()) {
-                attitude_control->get_rate_yaw_pid().set_filt_E_hz(tune_yaw_rLPF);
-            }
-            attitude_control->get_rate_yaw_pid().set_ff(orig_yaw_rff);
-            attitude_control->get_rate_yaw_pid().set_kDff(orig_yaw_dff);
-            attitude_control->get_angle_yaw_p().set_kP(tune_yaw_sp);
-            attitude_control->set_accel_yaw_max_cdss(tune_yaw_accel);
+    if ((((axes_completed & AUTOTUNE_AXIS_BITMASK_YAW) && yaw_enabled())
+            || ((axes_completed & AUTOTUNE_AXIS_BITMASK_YAW_D) && yaw_d_enabled())) && !is_zero(tune_yaw_rp)) {
+        attitude_control->get_rate_yaw_pid().set_kP(tune_yaw_rp);
+        attitude_control->get_rate_yaw_pid().set_kI(tune_yaw_rp*AUTOTUNE_YAW_PI_RATIO_FINAL);
+        if (yaw_d_enabled()) {
+            attitude_control->get_rate_yaw_pid().set_kD(tune_yaw_rd);
         }
+        if (yaw_enabled()) {
+            attitude_control->get_rate_yaw_pid().set_filt_E_hz(tune_yaw_rLPF);
+        }
+        attitude_control->get_rate_yaw_pid().set_ff(orig_yaw_rff);
+        attitude_control->get_rate_yaw_pid().set_kDff(orig_yaw_dff);
+        attitude_control->get_angle_yaw_p().set_kP(tune_yaw_sp);
+        attitude_control->set_accel_yaw_max_cdss(tune_yaw_accel);
     }
 }
 

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -239,6 +239,7 @@ const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Values{Plane}: 176:Quadplane Fwd Throttle Override enable
     // @Values{Copter, Rover, Plane, Blimp}: 177:Mount LRF enable
     // @Values{Copter}: 178:FlightMode Pause/Resume
+    // @Values{Copter, Plane}: 180:Test autotuned gains after tune is complete
     // @Values{Rover}: 201:Roll
     // @Values{Rover}: 202:Pitch
     // @Values{Rover}: 207:MainSail

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -119,7 +119,7 @@ public:
         ACRO_TRAINER =        14, // low = disabled, middle = leveled, high = leveled and limited
         SPRAYER =             15, // enable/disable the crop sprayer
         AUTO =                16, // change to auto flight mode
-        AUTOTUNE =            17, // auto tune
+        AUTOTUNE_MODE =       17, // auto tune
         LAND =                18, // change to LAND flight mode
         GRIPPER =             19, // Operate cargo grippers low=off, middle=neutral, high=on
         PARACHUTE_ENABLE  =   21, // Parachute enable/disable
@@ -252,6 +252,7 @@ public:
         VFWD_THR_OVERRIDE =  176, // force enabled VTOL forward throttle method
         MOUNT_LRF_ENABLE =   177,  // mount LRF enable/disable
         FLIGHTMODE_PAUSE =   178,  // e.g. pause movement towards waypoint
+        AUTOTUNE_TEST_GAINS = 180, // auto tune tuning switch to test or revert gains
 
 
         // inputs from 200 will eventually used to replace RCMAP


### PR DESCRIPTION
This adds a switch allowing the user to test gains in any mode once the autotune has been completed. If the user has used the switch they can then disarm in any mode and the gains will be saved if they are active. If the user does not use the switch then they must disarm in autotune to save gains per the current behavior. 

This allows easy testing of the tune in any mode and makes the procedure to save a little simpler. 

The load test gains functions have been updated to ensure they use the same criteria as the saving of gains for the load. Currently they were not checking if a axis had completed, only that the axis was enabled. 

