### PR TITLE
Copter: Change the definitions of the direct values 0 and 1 to the definition names DISABLED and ENABLED

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -399,7 +399,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Description: This enables automatic crash checking. When enabled the motors will disarm if a crash is detected.
     // @Values: 0:Disabled, 1:Enabled
     // @User: Advanced
-    GSCALAR(fs_crash_check, "FS_CRASH_CHECK",    1),
+    GSCALAR(fs_crash_check, "FS_CRASH_CHECK",    ENABLED),
 
     // @Param: RC_SPEED
     // @DisplayName: ESC Update Speed
@@ -769,7 +769,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Description: Ground Effect Compensation Enable/Disable
     // @Values: 0:Disabled,1:Enabled
     // @User: Advanced
-    AP_GROUPINFO("GND_EFFECT_COMP", 5, ParametersG2, gndeffect_comp_enabled, 1),
+    AP_GROUPINFO("GND_EFFECT_COMP", 5, ParametersG2, gndeffect_comp_enabled, ENABLED),
 
 #if ADVANCED_FAILSAFE == ENABLED
     // @Group: AFS_
@@ -933,7 +933,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Description: This enables the vibration failsafe which will use modified altitude estimation and control during high vibrations
     // @Values: 0:Disabled, 1:Enabled
     // @User: Standard
-    AP_GROUPINFO("FS_VIBE_ENABLE", 35, ParametersG2, fs_vibe_enabled, 1),
+    AP_GROUPINFO("FS_VIBE_ENABLE", 35, ParametersG2, fs_vibe_enabled, ENABLED),
 
     // @Param: FS_OPTIONS
     // @DisplayName: Failsafe options bitmask

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -15,7 +15,7 @@ const AP_Param::GroupInfo ModeZigZag::var_info[] = {
     // @Description: Allows you to enable (1) or disable (0) ZigZag auto feature
     // @Values: 0:Disabled,1:Enabled
     // @User: Advanced
-    AP_GROUPINFO_FLAGS("AUTO_ENABLE", 1, ModeZigZag, _auto_enabled, 0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("AUTO_ENABLE", 1, ModeZigZag, _auto_enabled, DISABLED, AP_PARAM_FLAG_ENABLE),
 
 #if HAL_SPRAYER_ENABLED
     // @Param: SPRAYER
@@ -23,7 +23,7 @@ const AP_Param::GroupInfo ModeZigZag::var_info[] = {
     // @Description: Enable the auto sprayer in ZigZag mode. SPRAY_ENABLE = 1 and SERVOx_FUNCTION = 22(SprayerPump) / 23(SprayerSpinner) also must be set. This makes the sprayer on while moving to destination A or B. The sprayer will stop if the vehicle reaches destination or the flight mode is changed from ZigZag to other.
     // @Values: 0:Disabled,1:Enabled
     // @User: Advanced
-    AP_GROUPINFO("SPRAYER", 2, ModeZigZag, _spray_enabled, 0),
+    AP_GROUPINFO("SPRAYER", 2, ModeZigZag, _spray_enabled, DISABLED),
 #endif // HAL_SPRAYER_ENABLED
 
     // @Param: WP_DELAY

--- a/ArduCopter/toy_mode.cpp
+++ b/ArduCopter/toy_mode.cpp
@@ -24,7 +24,7 @@ const AP_Param::GroupInfo ToyMode::var_info[] = {
     // @Description: tmode (or "toy" mode) gives a simplified user interface designed for mass market drones. Version1 is for the SkyViper V2450GPS. Version2 is for the F412 based boards
     // @Values: 0:Disabled,1:EnableVersion1,2:EnableVersion2
     // @User: Advanced
-    AP_GROUPINFO_FLAGS("_ENABLE", 1, ToyMode, enable, 0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("_ENABLE", 1, ToyMode, enable, DISABLED, AP_PARAM_FLAG_ENABLE),
 
     // @Param: _MODE1
     // @DisplayName: Tmode first mode


### PR DESCRIPTION
Copter defines DISABLED as 0 and ENABLED as 1. Using these defined names makes the settings clearer.