### PR TITLE
Plane: Takeoff improvements

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -493,10 +493,14 @@ void Plane::update_GPS_10Hz(void)
  */
 void Plane::update_control_mode(void)
 {
-    if (control_mode != &mode_auto) {
+    if ((control_mode != &mode_auto) && (control_mode != &mode_takeoff)) {
         // hold_course is only used in takeoff and landing
         steer_state.hold_course_cd = -1;
     }
+    // refresh the throttle limits, to avoid using stale values
+    // they will be updated once takeoff_calc_throttle is called
+    takeoff_state.throttle_lim_max = 100.0f;
+    takeoff_state.throttle_lim_min = -100.0f;
 
     update_fly_forward();
 

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -446,6 +446,10 @@ private:
         uint32_t accel_event_ms;
         uint32_t start_time_ms;
         bool waiting_for_rudder_neutral;
+        float throttle_lim_max;
+        float throttle_lim_min;
+        uint32_t throttle_max_timer_ms;
+        // Good candidate for keeping the initial time for TKOFF_THR_MAX_T.
     } takeoff_state;
 
     // ground steering controller state
@@ -1131,7 +1135,7 @@ private:
     bool auto_takeoff_check(void);
     void takeoff_calc_roll(void);
     void takeoff_calc_pitch(void);
-    void takeoff_calc_throttle(const bool use_max_throttle=false);
+    void takeoff_calc_throttle();
     int8_t takeoff_tail_hold(void);
     int16_t get_takeoff_pitch_min_cd(void);
     void landing_gear_update(void);

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -393,7 +393,7 @@ void Plane::do_land(const AP_Mission::Mission_Command& cmd)
     set_next_WP(cmd.content.location);
 
     // configure abort altitude and pitch
-    // if NAV_LAND has an abort altitude then use it, else use last takeoff, else use 50m
+    // if NAV_LAND has an abort altitude then use it, else use last takeoff, else use 30m
     if (cmd.p1 > 0) {
         auto_state.takeoff_altitude_rel_cm = (int16_t)cmd.p1 * 100;
     } else if (auto_state.takeoff_altitude_rel_cm <= 0) {

--- a/ArduPlane/mode_auto.cpp
+++ b/ArduPlane/mode_auto.cpp
@@ -89,7 +89,7 @@ void ModeAuto::update()
         (nav_cmd_id == MAV_CMD_NAV_LAND && plane.flight_stage == AP_FixedWing::FlightStage::ABORT_LANDING)) {
         plane.takeoff_calc_roll();
         plane.takeoff_calc_pitch();
-        plane.calc_throttle();
+        plane.takeoff_calc_throttle();
     } else if (nav_cmd_id == MAV_CMD_NAV_LAND) {
         plane.calc_nav_roll();
         plane.calc_nav_pitch();

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3401,7 +3401,8 @@ bool QuadPlane::verify_vtol_takeoff(const AP_Mission::Mission_Command &cmd)
         return false;
     }
     transition->restart();
-    plane.TECS_controller.set_pitch_max_limit(transition_pitch_max);
+    plane.TECS_controller.set_pitch_max(transition_pitch_max);
+    plane.TECS_controller.set_pitch_min(-transition_pitch_max);
 
     // todo: why are you doing this, I want to delete it.
     set_alt_target_current();
@@ -4551,7 +4552,8 @@ void SLT_Transition::set_FW_roll_pitch(int32_t& nav_pitch_cd, int32_t& nav_roll_
     }
 
     // set a single loop pitch limit in TECS
-    plane.TECS_controller.set_pitch_max_limit(max_pitch);
+    plane.TECS_controller.set_pitch_max(max_pitch);
+    plane.TECS_controller.set_pitch_min(-max_pitch);
 
     // ensure pitch is constrained to limit
     nav_pitch_cd = constrain_int32(nav_pitch_cd, -max_pitch*100.0, max_pitch*100.0);

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -519,6 +519,7 @@ float Plane::apply_throttle_limits(float throttle_in)
         min_throttle = 0;
     }
 
+    // Handle throttle limits for takeoff conditions.
     // Query the conditions where TKOFF_THR_MAX applies.
     const bool use_takeoff_throttle =
         (flight_stage == AP_FixedWing::FlightStage::TAKEOFF) ||
@@ -526,27 +527,9 @@ float Plane::apply_throttle_limits(float throttle_in)
 
     // Handle throttle limits for takeoff conditions.
     if (use_takeoff_throttle) {
-        if (aparm.takeoff_throttle_max != 0) {
-            // Replace max throttle with the takeoff max throttle setting.
-            // This is typically done to protect against long intervals of large power draw.
-            // Or (in contrast) to give some extra throttle during the initial climb.
-            max_throttle = aparm.takeoff_throttle_max.get();
-        }
-        // Do not allow min throttle to go below a lower threshold.
-        // This is typically done to protect against premature stalls close to the ground.
-        const bool use_throttle_range = (aparm.takeoff_options & (uint32_t)AP_FixedWing::TakeoffOption::THROTTLE_RANGE);
-        if (!use_throttle_range || !ahrs.using_airspeed_sensor()) {
-            // Use a constant max throttle throughout the takeoff or when airspeed readings are not available.
-            if (aparm.takeoff_throttle_max.get() == 0) {
-                min_throttle = MAX(min_throttle, aparm.throttle_max.get());
-            } else {
-                min_throttle = MAX(min_throttle, aparm.takeoff_throttle_max.get());
-            }
-        } else if (use_throttle_range) { // Use a throttle range through the takeoff.
-            if (aparm.takeoff_throttle_min.get() != 0) { // This is enabled by TKOFF_MODE==1.
-                min_throttle = MAX(min_throttle, aparm.takeoff_throttle_min.get());
-            }
-        }
+        // Read from takeoff_state
+        max_throttle = takeoff_state.throttle_lim_max;
+        min_throttle = takeoff_state.throttle_lim_min;
     } else if (landing.is_flaring()) {
         // Allow throttle cutoff when flaring.
         // This is to allow the aircraft to bleed speed faster and land with a shut off thruster.
@@ -587,6 +570,7 @@ float Plane::apply_throttle_limits(float throttle_in)
     min_throttle = MIN(min_throttle, max_throttle);
 
     // Let TECS know about the updated throttle limits.
+    // These will be taken into account on the next iteration.
     TECS_controller.set_throttle_min(0.01f*min_throttle);
     TECS_controller.set_throttle_max(0.01f*max_throttle);
     return constrain_float(throttle_in, min_throttle, max_throttle);

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -4396,10 +4396,12 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         })
 
         # Load and start mission. It contains a MAV_CMD_NAV_TAKEOFF item at 100m.
+        self.wait_ready_to_arm()
+
+        # Load and start mission. It contains a MAV_CMD_NAV_TAKEOFF item at 100m.
         self.load_mission("catapult.txt", strict=True)
         self.change_mode('AUTO')
 
-        self.wait_ready_to_arm()
         self.arm_vehicle()
 
         # Throw the catapult.
@@ -4410,7 +4412,8 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.wait_altitude(test_alt, test_alt+2, relative=True)
 
         # Ensure that by then the aircraft still goes at max allowed throttle.
-        self.assert_servo_channel_value(3, 1000+10*self.get_parameter("TKOFF_THR_MAX"))
+        target_throttle = 1000+10*(self.get_parameter("TKOFF_THR_MAX"))
+        self.assert_servo_channel_range(3, target_throttle-10, target_throttle+10)
 
         # Wait for landing waypoint.
         self.wait_current_waypoint(11, timeout=1200)
@@ -4420,7 +4423,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         '''Test the behaviour of an AUTO takeoff, pt2.'''
         '''
         Conditions:
-        - ARSPD_USE=1
+        - ARSPD_USE=0
         - TKOFF_OPTIONS[0]=0
         - TKOFF_THR_MAX > THR_MAX
         '''
@@ -4441,10 +4444,12 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         })
 
         # Load and start mission. It contains a MAV_CMD_NAV_TAKEOFF item at 100m.
+        self.wait_ready_to_arm()
+
+        # Load and start mission. It contains a MAV_CMD_NAV_TAKEOFF item at 100m.
         self.load_mission("catapult.txt", strict=True)
         self.change_mode('AUTO')
 
-        self.wait_ready_to_arm()
         self.arm_vehicle()
 
         # Throw the catapult.
@@ -4455,7 +4460,8 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.wait_altitude(test_alt, test_alt+2, relative=True)
 
         # Ensure that by then the aircraft still goes at max allowed throttle.
-        self.assert_servo_channel_value(3, 1000+10*self.get_parameter("TKOFF_THR_MAX"))
+        target_throttle = 1000+10*(self.get_parameter("TKOFF_THR_MAX"))
+        self.assert_servo_channel_range(3, target_throttle-10, target_throttle+10)
 
         # Wait for landing waypoint.
         self.wait_current_waypoint(11, timeout=1200)
@@ -4488,10 +4494,12 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         })
 
         # Load and start mission. It contains a MAV_CMD_NAV_TAKEOFF item at 100m.
+        self.wait_ready_to_arm()
+
+        # Load and start mission. It contains a MAV_CMD_NAV_TAKEOFF item at 100m.
         self.load_mission("catapult.txt", strict=True)
         self.change_mode('AUTO')
 
-        self.wait_ready_to_arm()
         self.arm_vehicle()
 
         # Throw the catapult.
@@ -4499,7 +4507,8 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         # Ensure that TKOFF_THR_MAX_T is respected.
         self.delay_sim_time(self.get_parameter("TKOFF_THR_MAX_T")-1)
-        self.assert_servo_channel_value(3, 1000+10*(self.get_parameter("TKOFF_THR_MAX")-1))
+        target_throttle = 1000+10*(self.get_parameter("TKOFF_THR_MAX"))
+        self.assert_servo_channel_range(3, target_throttle-10, target_throttle+10)
 
         # Ensure that after that the aircraft does not go full throttle anymore.
         test_alt = 50
@@ -4543,11 +4552,12 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             "RTL_AUTOLAND": 2, # The mission contains a DO_LAND_START item.
         })
 
+        self.wait_ready_to_arm()
+
         # Load and start mission. It contains a MAV_CMD_NAV_TAKEOFF item at 100m.
         self.load_mission("catapult.txt", strict=True)
         self.change_mode('AUTO')
 
-        self.wait_ready_to_arm()
         self.arm_vehicle()
 
         # Throw the catapult.
@@ -4555,14 +4565,14 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         # Ensure that TKOFF_THR_MAX_T is respected.
         self.delay_sim_time(self.get_parameter("TKOFF_THR_MAX_T")-1)
-        self.assert_servo_channel_value(3, 1000+10*(self.get_parameter("TKOFF_THR_MAX")), operator.le)
-        self.assert_servo_channel_value(3, 1000+10*(self.get_parameter("TKOFF_THR_MAX"))-10, operator.ge)
+        target_throttle = 1000+10*(self.get_parameter("TKOFF_THR_MAX"))
+        self.assert_servo_channel_range(3, target_throttle-10, target_throttle+10)
 
         # Ensure that after that the aircraft still goes to maximum throttle.
         test_alt = 50
         self.wait_altitude(test_alt, test_alt+2, relative=True)
-        self.assert_servo_channel_value(3, 1000+10*(self.get_parameter("TKOFF_THR_MAX")), operator.le)
-        self.assert_servo_channel_value(3, 1000+10*(self.get_parameter("TKOFF_THR_MAX"))-10, operator.ge)
+        target_throttle = 1000+10*(self.get_parameter("TKOFF_THR_MAX"))
+        self.assert_servo_channel_range(3, target_throttle-10, target_throttle+10)
 
         # Wait for landing waypoint.
         self.wait_current_waypoint(11, timeout=1200)
@@ -4586,7 +4596,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             "ARSPD_USE": 1.0,
             "THR_MAX": 100.0,
             "TKOFF_LVL_ALT": 30.0,
-            "TKOFF_ALT": 100.0,
+            "TKOFF_ALT": 80.0,
             "TKOFF_OPTIONS": 0.0,
             "TKOFF_THR_MINACC": 3.0,
             "TKOFF_THR_MAX": 80.0,
@@ -4604,17 +4614,21 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         # Check whether we're at max throttle below TKOFF_LVL_ALT.
         test_alt = self.get_parameter("TKOFF_LVL_ALT")-10
         self.wait_altitude(test_alt, test_alt+2, relative=True)
-        self.assert_servo_channel_value(3, 1000+10*self.get_parameter("TKOFF_THR_MAX"))
+        target_throttle = 1000+10*(self.get_parameter("TKOFF_THR_MAX"))
+        self.assert_servo_channel_range(3, target_throttle-10, target_throttle+10)
 
         # Check whether we're still at max throttle past TKOFF_LVL_ALT.
         test_alt = self.get_parameter("TKOFF_LVL_ALT")+10
         self.wait_altitude(test_alt, test_alt+2, relative=True)
-        self.assert_servo_channel_value(3, 1000+10*(self.get_parameter("TKOFF_THR_MAX")), operator.le)
-        self.assert_servo_channel_value(3, 1000+10*(self.get_parameter("TKOFF_THR_MAX"))-1, operator.ge)
+        target_throttle = 1000+10*(self.get_parameter("TKOFF_THR_MAX"))
+        self.assert_servo_channel_range(3, target_throttle-10, target_throttle+10)
 
         # Wait for the takeoff to complete.
         target_alt = self.get_parameter("TKOFF_ALT")
         self.wait_altitude(target_alt-5, target_alt, relative=True)
+
+        # Wait a bit for the Takeoff altitude to settle.
+        self.delay_sim_time(5)
 
         self.fly_home_land_and_disarm()
 
@@ -4635,8 +4649,8 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.set_parameters({
             "ARSPD_USE": 1.0,
             "THR_MAX": 100.0,
-            "TKOFF_LVL_ALT": 80.0,
-            "TKOFF_ALT": 150.0,
+            "TKOFF_LVL_ALT": 30.0,
+            "TKOFF_ALT": 80.0,
             "TKOFF_OPTIONS": 1.0,
             "TKOFF_THR_MINACC": 3.0,
             "TKOFF_THR_MAX": 80.0,
@@ -4654,18 +4668,22 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         # Check whether we're at max throttle below TKOFF_LVL_ALT.
         test_alt = self.get_parameter("TKOFF_LVL_ALT")-10
         self.wait_altitude(test_alt, test_alt+2, relative=True)
-        self.assert_servo_channel_value(3, 1000+10*(self.get_parameter("TKOFF_THR_MAX")), operator.le)
-        self.assert_servo_channel_value(3, 1000+10*(self.get_parameter("TKOFF_THR_MAX"))-1, operator.ge)
+        target_throttle = 1000+10*(self.get_parameter("TKOFF_THR_MAX"))
+        self.assert_servo_channel_range(3, target_throttle-10, target_throttle+10)
 
         # Check whether we've receded from max throttle past TKOFF_LVL_ALT.
         test_alt = self.get_parameter("TKOFF_LVL_ALT")+10
         self.wait_altitude(test_alt, test_alt+2, relative=True)
-        self.assert_servo_channel_value(3, 1000+10*(self.get_parameter("TKOFF_THR_MAX")), operator.le)
-        self.assert_servo_channel_value(3, 1000+10*(self.get_parameter("TKOFF_THR_MIN"))-1, operator.ge)
+        thr_min = 1000+10*(self.get_parameter("TKOFF_THR_MIN"))-1
+        thr_max = 1000+10*(self.get_parameter("TKOFF_THR_MAX"))-10
+        self.assert_servo_channel_range(3, thr_min, thr_max)
 
         # Wait for the takeoff to complete.
         target_alt = self.get_parameter("TKOFF_ALT")
         self.wait_altitude(target_alt-5, target_alt, relative=True)
+
+        # Wait a bit for the Takeoff altitude to settle.
+        self.delay_sim_time(5)
 
         self.fly_home_land_and_disarm()
 
@@ -4688,6 +4706,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.set_parameters({
             "ARSPD_USE": 0.0,
             "THR_MAX": 100.0,
+            "TKOFF_DIST": 400.0,
             "TKOFF_LVL_ALT": 30.0,
             "TKOFF_ALT": 100.0,
             "TKOFF_OPTIONS": 0.0,
@@ -4715,7 +4734,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self,
             3,  # throttle
             expected_takeoff_throttle,
-            epsilon=1,
+            epsilon=10,
             minimum_duration=1,
         )
         w.run()
@@ -4728,7 +4747,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self,
             3,  # throttle
             expected_takeoff_throttle,
-            epsilon=1,
+            epsilon=10,
             minimum_duration=1,
         )
         w.run()
@@ -4764,18 +4783,48 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         # Check whether we're at max throttle below TKOFF_LVL_ALT.
         test_alt = self.get_parameter("TKOFF_LVL_ALT")-10
         self.wait_altitude(test_alt, test_alt+2, relative=True)
-        self.assert_servo_channel_value(3, 1000+10*(self.get_parameter("THR_MAX")), operator.le)
-        self.assert_servo_channel_value(3, 1000+10*(self.get_parameter("THR_MAX"))-10, operator.ge)
+        target_throttle = 1000+10*(self.get_parameter("THR_MAX"))
+        self.assert_servo_channel_range(3, target_throttle-10, target_throttle+10)
 
         # Check whether we're still at max throttle past TKOFF_LVL_ALT.
         test_alt = self.get_parameter("TKOFF_LVL_ALT")+10
         self.wait_altitude(test_alt, test_alt+2, relative=True)
-        self.assert_servo_channel_value(3, 1000+10*(self.get_parameter("THR_MAX")), operator.le)
-        self.assert_servo_channel_value(3, 1000+10*(self.get_parameter("THR_MAX"))-10, operator.ge)
+        target_throttle = 1000+10*(self.get_parameter("THR_MAX"))
+        self.assert_servo_channel_range(3, target_throttle-10, target_throttle+10)
 
         # Wait for the takeoff to complete.
         target_alt = self.get_parameter("TKOFF_ALT")
         self.wait_altitude(target_alt-5, target_alt, relative=True)
+
+        # Wait a bit for the Takeoff altitude to settle.
+        self.delay_sim_time(5)
+
+        self.fly_home_land_and_disarm()
+
+    def TakeoffGround(self):
+        '''Test a rolling TAKEOFF.'''
+
+        self.set_parameters({
+            "TKOFF_ROTATE_SPD": 15.0,
+        })
+        self.change_mode("TAKEOFF")
+
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+
+        # Check that we demand minimum pitch below rotation speed.
+        self.wait_groundspeed(8, 10)
+        m = self.assert_receive_message('NAV_CONTROLLER_OUTPUT', timeout=5)
+        nav_pitch = m.nav_pitch
+        if nav_pitch > 5.1 or nav_pitch < 4.9:
+            raise NotAchievedException(f"Did not achieve correct takeoff pitch ({nav_pitch}).")
+
+        # Check whether we've achieved correct target pitch after rotation.
+        self.wait_groundspeed(23, 24)
+        m = self.assert_receive_message('NAV_CONTROLLER_OUTPUT', timeout=5)
+        nav_pitch = m.nav_pitch
+        if nav_pitch > 15.1 or nav_pitch < 14.9:
+            raise NotAchievedException(f"Did not achieve correct takeoff pitch ({nav_pitch}).")
 
         self.fly_home_land_and_disarm()
 
@@ -6315,6 +6364,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.TakeoffTakeoff2,
             self.TakeoffTakeoff3,
             self.TakeoffTakeoff4,
+            self.TakeoffGround,
             self.ForcedDCM,
             self.DCMFallback,
             self.MAVFTP,

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -7977,6 +7977,20 @@ class TestSuite(ABC):
             return m_value
         raise NotAchievedException("Wrong value")
 
+    def assert_servo_channel_range(self, channel, value_min, value_max):
+        """assert channel value is within the range [value_min, value_max]"""
+        channel_field = "servo%u_raw" % channel
+        m = self.assert_receive_message('SERVO_OUTPUT_RAW', timeout=1)
+        m_value = getattr(m, channel_field, None)
+        if m_value is None:
+            raise ValueError("message (%s) has no field %s" %
+                             (str(m), channel_field))
+        self.progress("assert SERVO_OUTPUT_RAW.%s=%u in [%u, %u]" %
+                      (channel_field, m_value, value_min, value_max))
+        if m_value >= value_min and m_value <= value_max:
+            return m_value
+        raise NotAchievedException("Wrong value")
+
     def get_rc_channel_value(self, channel, timeout=2):
         """wait for channel to hit value"""
         channel_field = "chan%u_raw" % channel

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -1053,6 +1053,9 @@ void AP_TECS::_update_pitch(void)
         _pitch_dem_unc += (_TAS_dem_adj - _pitch_ff_v0) * _pitch_ff_k;
     }
 
+    // Constrain pitch demand
+    _pitch_dem = constrain_float(_pitch_dem_unc, _PITCHminf, _PITCHmaxf);
+
     // Rate limit the pitch demand to comply with specified vertical
     // acceleration limit
     float ptchRateIncr = _DT * _vertAccLim / _TAS_state;
@@ -1062,9 +1065,6 @@ void AP_TECS::_update_pitch(void)
     } else if ((_pitch_dem - _last_pitch_dem) < -ptchRateIncr) {
         _pitch_dem = _last_pitch_dem - ptchRateIncr;
     }
-
-    // Constrain pitch demand
-    _pitch_dem = constrain_float(_pitch_dem_unc, _PITCHminf, _PITCHmaxf);
 
     _last_pitch_dem = _pitch_dem;
 

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -328,7 +328,6 @@ void AP_TECS::update_50hz(void)
         _height_filter.dd_height = 0.0f;
         DT = 0.02f; // when first starting TECS, use most likely time constant
         _vdot_filter.reset();
-        _takeoff_start_ms = 0;
     }
     _update_50hz_last_usec = now;
 
@@ -1115,8 +1114,6 @@ void AP_TECS::_initialise_states(float hgt_afe)
     // Initialise states and variables if DT > 0.2 second or TECS is getting overriden or in climbout.
     _flags.reset = false;
 
-    _need_reset = _need_reset || (_flag_pitch_forced && _flag_throttle_forced);
-
     if (_DT > 0.2f || _need_reset) {
         _SKE_weighting        = 1.0f;
         _integTHR_state       = 0.0f;
@@ -1134,7 +1131,6 @@ void AP_TECS::_initialise_states(float hgt_afe)
         _DT                   = 0.02f; // when first starting TECS, use the most likely time constant
         _lag_comp_hgt_offset  = 0.0f;
         _post_TO_hgt_offset   = 0.0f;
-        _takeoff_start_ms = 0;
         _use_synthetic_airspeed_once = false;
 
         _flags.underspeed            = false;
@@ -1379,49 +1375,10 @@ void AP_TECS::set_throttle_max(const float thr_max) {
 
 void AP_TECS::_update_throttle_limits() {
 
-    // Configure max throttle.
-
-    // Read the maximum throttle limit.
-    _THRmaxf  = aparm.throttle_max * 0.01f;
-    // If more max throttle is allowed during takeoff, use it.
-    if (aparm.takeoff_throttle_max*0.01f > _THRmaxf
-        && (_flight_stage == AP_FixedWing::FlightStage::TAKEOFF || _flight_stage == AP_FixedWing::FlightStage::ABORT_LANDING)
-        ) {
-        _THRmaxf  = aparm.takeoff_throttle_max * 0.01f;
-    }
-    // In any case, constrain to the external safety limits.
-    _THRmaxf = MIN(_THRmaxf, _THRmaxf_ext);
-
-    // Configure min throttle.
-
-    // Use takeoff min throttle, if applicable.
-    bool use_takeoff_throttle = _flight_stage == AP_FixedWing::FlightStage::TAKEOFF || _flight_stage == AP_FixedWing::FlightStage::ABORT_LANDING;
-    use_takeoff_throttle = use_takeoff_throttle && (aparm.takeoff_throttle_min != 0);
-    if ( use_takeoff_throttle ) { 
-        _THRminf = MIN(_THRminf, aparm.takeoff_throttle_min * 0.01f);
-    }
-    else { // Otherwise, during normal situations let regular limit.
-        _THRminf = aparm.throttle_min * 0.01f;
-    }
-    // Raise min to force max throttle for TKOFF_THR_MAX_T after a takeoff.
-    if (_flight_stage == AP_FixedWing::FlightStage::TAKEOFF) {
-        const uint32_t now = AP_HAL::millis();
-        if (_takeoff_start_ms == 0) {
-            _takeoff_start_ms = now;
-        }
-        const uint32_t dt = now - _takeoff_start_ms;
-        if (dt*0.001 < aparm.takeoff_throttle_max_t) {
-            _THRminf = _THRmaxf;
-        }
-    } else {
-        _takeoff_start_ms = 0;
-    }
-    // If we are flaring, allow the throttle to go to 0.
-    if (_landing.is_flaring()) {
-        _THRminf = 0;
-    }
-    // In any case, constrain to the external safety limits.
-    _THRminf = MAX(_THRminf, _THRminf_ext);
+    // Configure max throttle; constrain to the external safety limits.
+    _THRmaxf = MIN(1.0f, _THRmaxf_ext);
+    // Configure min throttle; constrain to the external safety limits.
+    _THRminf = MAX(-1.0f, _THRminf_ext);
 
     // Allow a minimum of 1% throttle range, primarily to prevent TECS numerical errors.
     const float thr_eps = 0.01;
@@ -1437,6 +1394,7 @@ void AP_TECS::_update_throttle_limits() {
     }
     
     // Reset the external throttle limits.
+    // Caller will have to reset them in the next iteration.
     _THRminf_ext = -1.0f;
     _THRmaxf_ext = 1.0f;
 }
@@ -1540,12 +1498,4 @@ void AP_TECS::_update_pitch_limits(const int32_t ptchMinCO_cd) {
 
     // don't allow max pitch to go below min pitch
     _PITCHmaxf = MAX(_PITCHmaxf, _PITCHminf);
-
-    // Test if someone is forcing pitch to a specific value.
-    const float pitch_eps = DEG_TO_RAD*1;
-    if (fabsf(_PITCHmaxf-_PITCHminf)<pitch_eps) {
-        _flag_pitch_forced = true;
-    } else {
-        _flag_pitch_forced = false;
-    }
 }

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -316,9 +316,6 @@ private:
     // Total energy rate filter state
     float _STEdotErrLast;
 
-    // time we started a takeoff
-    uint32_t _takeoff_start_ms;
-
     struct flags {
         // Underspeed condition
         bool underspeed:1;
@@ -434,8 +431,6 @@ private:
 
     // need to reset on next loop
     bool _need_reset;
-    // Flag if someone else drives pitch externally.
-    bool _flag_pitch_forced;
     // Flag if someone else drives throttle externally.
     bool _flag_throttle_forced;
 

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -128,19 +128,21 @@ public:
         _flags.propulsion_failed = propulsion_failed;
     }
 
-
-    // set pitch max limit in degrees
-    void set_pitch_max_limit(int8_t pitch_limit) {
-        _pitch_max_limit = pitch_limit;
-    }
-
     // set minimum throttle override, [-1, -1] range
     // it is applicable for one control cycle only
     void set_throttle_min(const float thr_min);
 
-    // set minimum throttle override, [0, -1] range
+    // set maximum throttle override, [0, -1] range
     // it is applicable for one control cycle only
     void set_throttle_max(const float thr_max);
+
+    // set minimum pitch override, in degrees.
+    // it is applicable for one control cycle only
+    void set_pitch_min(const float pitch_min);
+
+    // set maximum pitch override, in degrees.
+    // it is applicable for one control cycle only
+    void set_pitch_max(const float pitch_max);
 
     // force use of synthetic airspeed for one loop
     void use_synthetic_airspeed(void) {
@@ -371,6 +373,9 @@ private:
     // Maximum and minimum throttle safety limits, set externally, typically by servos.cpp:apply_throttle_limits()
     float _THRmaxf_ext = 1.0f;
     float _THRminf_ext = -1.0f;
+    // Maximum and minimum pitch limits, set externally, typically by the takeoff logic.
+    float _PITCHmaxf_ext = 90.0f;
+    float _PITCHminf_ext = -90.0f;
 
     // Maximum and minimum floating point pitch limits
     float _PITCHmaxf;
@@ -429,6 +434,10 @@ private:
 
     // need to reset on next loop
     bool _need_reset;
+    // Flag if someone else drives pitch externally.
+    bool _flag_pitch_forced;
+    // Flag if someone else drives throttle externally.
+    bool _flag_throttle_forced;
 
     // Checks if we reset at the beginning of takeoff.
     bool _flag_have_reset_after_takeoff;
@@ -485,7 +494,7 @@ private:
     void _update_pitch(void);
 
     // Initialise states and variables
-    void _initialise_states(int32_t ptchMinCO_cd, float hgt_afe);
+    void _initialise_states(float hgt_afe);
 
     // Calculate specific total energy rate limits
     void _update_STE_rate_lim(void);
@@ -498,4 +507,7 @@ private:
 
     // Update the allowable throttle range.
     void _update_throttle_limits();
+
+    // Update the allowable pitch range.
+    void _update_pitch_limits(const int32_t ptchMinCO_cd);
 };


### PR DESCRIPTION
This PR fixes TECS oscillations that would occur once mode TAKEOFF would reach `TKOFF_ALT`.
Additionally, it harmonizes the takeoff behaviour between modes AUTO and TAKEOFF.
Finally, it fixes a few bugs.

Many thanks to @Hwurzburg for sharing code for fixing the pitch setpoint.

## Notable behaviour changes

1. Mode TAKEOFF and AUTO now behave identically during a takeoff.
2. `TKOFF_LVL_ALT` now also affects AUTO mode.
3. TAKEOFF mode now respects the level-off angles, as it approaches altitude. There should now be significantly less overshoot.
4. The behaviour of TKOFF_ROTATION_SPD now works as advertized. It was inactive before.

## Notable code changes

1. Mode TAKEOFF now spends all of the climb in FlightStage::TAKEOFF, just like AUTO mode did.
2. `TECS::set_pitch_max_limit()` is now split into `TECS::set_pitch_max()` and `TECS::set_pitch_min()`. Its usage in `quadplane.cpp` has been modified accordingly.
3. TECS pitch limits are now applied at the end of the calculation. Before, vertical acceleration limitations were applied last.
5. TECS: `_post_TO_hgt_offset` will now never pull height demand above the target altitude.
6. `mode_takeoff.cpp` is now prevented from switching behaviours from past `TKOFF_ALT`-2m back to climb behaviour. This would cause behaviour switching if the plane would drop slightly lower than 2m from `TKOFF_ALT`.
7. There are many occasions were TECS is overridden both in pitch and throttle. When that happens, TECS is now effectively inactive and will reset itself.
8. Changed behaviour of `TECS_PITCH_MIN` to match description.
9. `servos.cpp` now doesn't try to enforce all of the takeoff throttle logic combinations. Only `TKOFF_THR_MAX` and `TKOFF_THR_MIN`.

## Tests

The following were tested in autotests:

1. Altitude and pitch no longer oscillation upon reaching the takeoff altitude. ✅
2. TAKEOFF and AUTO takeoffs now behave exactly the same in all combinations of `ARSPD_USE` and `TKOFF_OPTIONS`. ✅
3. The level-off of minimum pitch demand now works in TAKEOFF. ✅
4. When `TKOFF_ROTATE_SPD` is nonzero, pitch demand will be 5deg before the rotation speed and will climb up to the minimum takeoff pitch for groundspeed equal to cruise airspeed. ✅

The following were tested in manual SITL:

1. Altitude and pitch no longer oscillation upon reaching the takeoff altitude. ✅
2. The level-off of minimum pitch demand now works in TAKEOFF. ✅
3. When `TKOFF_ROTATE_SPD` is nonzero, pitch demand will be 5deg before the rotation speed and will climb up to the minimum takeoff pitch for groundspeed equal to cruise airspeed. ✅

## Known issues

1. Ground speed is used in some airspeed comparisons.
5. If AUTO is engaged while in flight and has a NAV_TAKEOFF point, it will force the pitch to positive while it gets processed. This lasts for a few cycles.
6. The SITL plane doesn't regulate pitch well when it's flying at full throttle and fast. Nothing to do with this PR, just an observation.

## Future work

1. I noticed that if you load a mission before you get a GNSS fix, the NAV_TAKEOFF waypoint (i.e. next_WP_loc) will be set at coordinates at the home coordinates and altitude. This can break some takeoff logic in AUTO mode.
2. Render `TKOFF_LVL_ALT` a higher-level parameter, as it is now used also by AUTO mode, not just TAKEOFF.