### PR TITLE
Plane: Allow a Lua script to return to a previous mission track

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -908,6 +908,16 @@ bool Plane::set_land_descent_rate(float descent_rate)
 #endif
     return false;
 }
+
+// Allow for scripting to have control over the crosstracking when exiting and resuming missions or guided flight
+// It's up to the Lua script to ensure the provided location makes sense
+bool Plane::set_crosstrack_start(const Location &new_start_location)
+{        
+    prev_WP_loc = new_start_location;
+    auto_state.crosstrack = true;
+    return true;
+}
+
 #endif // AP_SCRIPTING_ENABLED
 
 // returns true if vehicle is landing.

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1286,6 +1286,11 @@ public:
 
     // allow for landing descent rate to be overridden by a script, may be -ve to climb
     bool set_land_descent_rate(float descent_rate) override;
+
+    // allow scripts to override mission/guided crosstrack behaviour
+    // It's up to the Lua script to ensure the provided location makes sense
+    bool set_crosstrack_start(const Location &new_start_location) override;
+
 #endif // AP_SCRIPTING_ENABLED
 
 };

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -2506,6 +2506,12 @@ function vehicle:is_taking_off() end
 ---@return boolean
 function vehicle:is_landing() end
 
+-- Set the previous target location for crosstrack and crosstrack if available in the current mode
+-- It's up to the Lua code to ensure the new_start_location makes sense
+---@param new_start_location Location_ud
+---@return boolean -- true on success
+function vehicle:set_crosstrack_start(new_start_location) end
+
 -- desc
 onvif = {}
 

--- a/libraries/AP_Scripting/examples/crosstrack_restore.lua
+++ b/libraries/AP_Scripting/examples/crosstrack_restore.lua
@@ -1,0 +1,99 @@
+--[[
+
+   example script to show interrupting a mission and then 
+   reseting the crosstracking to the correct line when
+   returning to the mission after the interruption
+
+   this functionality is only available in Plane
+--]]
+
+SCRIPT_NAME = "Crosstrack Restore"
+SCRIPT_NAME_SHORT = "XTrack"
+SCRIPT_VERSION = "4.6.0-001"
+
+
+MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
+FLIGHT_MODE = {AUTO=10, RTL=11, LOITER=12, GUIDED=15, QHOVER=18, QLOITER=19, QRTL=21}
+
+local last_sw = -1
+local AUX_FN = 300
+
+-- Attempts to duplicate the code that updates the prev_WP_loc variable in the c++ code
+local function LocationTracker()
+
+   local self = {}
+
+   -- to get this to work, need to keep 2 prior generations of "target_location"
+   local previous_target_location            -- the target prior to the current one
+   local previous_previous_target_location   -- the target prior to that - this is the one we want
+
+   function self.same_loc_as(A, B)
+      if A == nil or B == nil then
+         return false
+      end
+      if (A:lat() ~= B:lat()) or (A:lng() ~= B:lng()) then
+         return false
+      end
+      return (A:alt() == B:alt()) and (A:get_alt_frame() == B:get_alt_frame())
+   end
+
+   function self.save_previous_target_location()
+      local target_location = vehicle:get_target_location()
+      if target_location ~= nil then
+         if not self.same_loc_as(previous_target_location, target_location) then
+            -- maintain three generations of location
+            previous_previous_target_location = previous_target_location
+            previous_target_location = target_location
+         end
+      else
+         previous_target_location = ahrs:get_location()
+         previous_previous_target_location = previous_target_location
+      end
+   end
+
+   function self.get_saved_location()
+      return previous_previous_target_location
+   end
+
+   return self
+end
+
+local location_tracker = LocationTracker()
+
+local function update()
+
+   -- save the previous target location only if in auto mode, if restoring it in AUTO mode
+   if vehicle:get_mode() == FLIGHT_MODE.AUTO and location_tracker ~= nil then
+      location_tracker.save_previous_target_location()
+   end
+
+   local sw_current = rc:get_aux_cached(AUX_FN)
+   if not sw_current then
+      sw_current = 0
+   end
+   if sw_current ~= last_sw then
+      last_sw = sw_current
+      if sw_current == 0 then
+        vehicle:set_mode(FLIGHT_MODE.AUTO)
+        if location_tracker ~= nil then
+            local previous_location = location_tracker.get_saved_location()
+            if previous_location ~= nil then
+               vehicle:set_crosstrack_start(previous_location)
+            end
+         end
+         gcs:send_text(MAV_SEVERITY.INFO, string.format("%s: Switched to AUTO", SCRIPT_NAME_SHORT))
+      else
+         vehicle:set_mode(FLIGHT_MODE.LOITER)
+         gcs:send_text(MAV_SEVERITY.INFO, string.format("%s: Switched to LOITER", SCRIPT_NAME_SHORT))
+      end
+   end
+
+   return update,100
+end
+
+if FWVersion:type() == 3 then
+   gcs:send_text(MAV_SEVERITY.NOTICE, string.format("%s %s script loaded", SCRIPT_NAME, SCRIPT_VERSION) )
+   return update()
+else
+   gcs:send_text(MAV_SEVERITY.NOTICE,string.format("%s: Must run on Plane", SCRIPT_NAME_SHORT))
+end

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -349,6 +349,7 @@ singleton AP_Vehicle method has_ekf_failsafed boolean
 singleton AP_Vehicle method reboot void boolean
 singleton AP_Vehicle method is_landing boolean
 singleton AP_Vehicle method is_taking_off boolean
+singleton AP_Vehicle method set_crosstrack_start boolean Location
 
 include AP_SerialLED/AP_SerialLED.h
 singleton AP_SerialLED rename serialLED

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -223,7 +223,11 @@ public:
 
     // allow for landing descent rate to be overridden by a script, may be -ve to climb
     virtual bool set_land_descent_rate(float descent_rate) { return false; }
-    
+
+    // Allow for scripting to have control over the crosstracking when exiting and resuming missions or guided flight
+    // It's up to the Lua script to ensure the provided location makes sense
+    virtual bool set_crosstrack_start(const Location &new_start_location) { return false; }
+
     // control outputs enumeration
     enum class ControlOutput {
         Roll = 1,


### PR DESCRIPTION
As discussed in #27639 on the dev call on 29 Aug 2024, added a way to get the previous WP location prior to switching out of AUTO mode and then restore it again after (in my case) doing some terrain object avoidance. This allows a plane to resume cross tracking mid mission which is required for magnetic field measurements in wilderness areas.

I changed the names proposed by @tridge in the call because:
1. getting the previous WP could conceivably be used for other purposes not just cross tracking, so I'm proposing vehicle:get_previous_location() - REMOVED based on the dev call on 12 Aug 2024
2. Restoring the previous location for crosstracking also requires setting the internal crosstrack boolean to true, so proposing to call this vehicle:set_crosstrack_start() which both sets the prev_WP_loc and also sets auto_state.crosstrack = true to resume cross tracking for the current mission item.

The sample script includes a LocationTracker() class which can be used to save previous target locations that can be passed to set_crosstrack_start()

Includes a sample lua script which requires you to be running a mission. A switch will save the previous location (high) and switch to loiter, then resume the mission and restore crosstracking (low). This screen shot shows a loiter being triggered, then switching back to crosstracking and resuming the path by crosstracking to the mission track rather than just heading direct for the next WP (WP 10).

![Screenshot 2024-08-05 100641](https://github.com/user-attachments/assets/11aeedaf-3999-4744-97fb-5fbcc8974181)
