### PR TITLE
Sub: support ABOVE_TERRAIN frame in GUIDED mode posvel case

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -320,10 +320,15 @@ bool Copter::set_target_pos_NED(const Vector3f& target_pos_ned_m, bool use_yaw, 
 }
 
 // set target position and velocity (for use by scripting)
-bool Copter::set_target_posvel_NED(const Vector3f& target_pos_ned_m, const Vector3f& target_vel_ned_ms)
+bool Copter::set_target_posvel_NED(const Vector3f& target_pos_ned_m, const Vector3f& target_vel_ned_ms, Location::AltFrame alt_frame)
 {
     // exit if vehicle is not in Guided mode or Auto-Guided mode
     if (!flightmode->in_guided_mode()) {
+        return false;
+    }
+
+    // only support above origin frame for now
+    if (alt_frame != Location::AltFrame::ABOVE_ORIGIN) {
         return false;
     }
 

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -680,7 +680,7 @@ private:
     bool get_target_location(Location& target_loc) override;
     bool update_target_location(const Location &old_loc, const Location &new_loc) override;
     bool set_target_pos_NED(const Vector3f& target_pos_ned_m, bool use_yaw, float yaw_deg, bool use_yaw_rate, float yaw_rate_degs, bool yaw_relative, bool is_terrain_alt) override;
-    bool set_target_posvel_NED(const Vector3f& target_pos_ned_m, const Vector3f& target_vel_ned_ms) override;
+    bool set_target_posvel_NED(const Vector3f& target_pos_ned_m, const Vector3f& target_vel_ned_ms, Location::AltFrame alt_frame) override;
     bool set_target_posvelaccel_NED(const Vector3f& target_pos_ned_m, const Vector3f& target_vel_ned_ms, const Vector3f& target_accel_ned_mss, bool use_yaw, float yaw_deg, bool use_yaw_rate, float yaw_rate_degs, bool yaw_relative) override;
     bool set_target_velocity_NED(const Vector3f& vel_ned_ms, bool align_yaw_to_target) override;
     bool set_target_velaccel_NED(const Vector3f& target_vel_ned_ms, const Vector3f& target_accel_ned_mss, bool use_yaw, float yaw_deg, bool use_yaw_rate, float yaw_rate_degs, bool relative_yaw) override;

--- a/ArduSub/GCS_MAVLink_Sub.cpp
+++ b/ArduSub/GCS_MAVLink_Sub.cpp
@@ -166,8 +166,10 @@ bool GCS_MAVLINK_Sub::send_info()
     CHECK_PAYLOAD_SIZE(NAMED_VALUE_FLOAT);
     send_named_float("RollPitch", sub.roll_pitch_flag);
 
+#if AP_RANGEFINDER_ENABLED
     CHECK_PAYLOAD_SIZE(NAMED_VALUE_FLOAT);
-    send_named_float("RFTarget", sub.mode_surftrak.get_rangefinder_target_cm() * 0.01f);
+    send_named_float("RFTarget", sub.flightmode->get_rangefinder_target());
+#endif
 
     return true;
 }
@@ -706,9 +708,16 @@ void GCS_MAVLINK_Sub::handle_message(const mavlink_message_t &msg)
             break;
         }
 
-        Vector3f pos_neu_cm;  // position (North, East, Up coordinates) in centimeters
+        // Guided submodes do not support acceleration control
+        if (!acc_ignore) {
+            break;
+        }
 
-        if (!pos_ignore) {
+        if (pos_ignore) {
+            if (!vel_ignore) {
+                sub.mode_guided.guided_set_velocity(Vector3f(packet.vx * 100.0f, packet.vy * 100.0f, -packet.vz * 100.0f));
+            }
+        } else {
             // sanity check location
             if (!check_latlng(packet.lat_int, packet.lon_int)) {
                 break;
@@ -718,23 +727,45 @@ void GCS_MAVLINK_Sub::handle_message(const mavlink_message_t &msg)
                 // unknown coordinate frame
                 break;
             }
-            const Location loc{
-                packet.lat_int,
-                packet.lon_int,
-                int32_t(packet.alt*100),
-                frame,
-            };
-            if (!loc.get_vector_from_origin_NEU_cm(pos_neu_cm)) {
-                break;
-            }
-        }
 
-        if (!pos_ignore && !vel_ignore && acc_ignore) {
-            sub.mode_guided.guided_set_destination_posvel(pos_neu_cm, Vector3f(packet.vx * 100.0f, packet.vy * 100.0f, -packet.vz * 100.0f));
-        } else if (pos_ignore && !vel_ignore && acc_ignore) {
-            sub.mode_guided.guided_set_velocity(Vector3f(packet.vx * 100.0f, packet.vy * 100.0f, -packet.vz * 100.0f));
-        } else if (!pos_ignore && vel_ignore && acc_ignore) {
-            sub.mode_guided.guided_set_destination(pos_neu_cm);
+            const Vector3f vel_neu_cm{packet.vx * 100.0f, packet.vy * 100.0f, -packet.vz * 100.0f};
+
+            switch (frame) {
+                case Location::AltFrame::ABOVE_TERRAIN: {
+                    // transform global horizontal (lat, lon) input to a local (x, y) position
+                    const Location loc{packet.lat_int, packet.lon_int, 0, frame};
+                    Vector2f pos_ne_cm;
+                    if (!loc.get_vector_xy_from_origin_NE_cm(pos_ne_cm)) {
+                        break;
+                    }
+
+                    // velocity is required
+                    if (!vel_ignore) {
+                        // packet.alt is the target rangefinder range, not the target altitude
+                        sub.mode_guided.guided_set_destination_posvel(Vector3f(pos_ne_cm.x, pos_ne_cm.y, packet.alt * 100.0f), vel_neu_cm, frame);
+                    }
+                    break;
+                }
+                case Location::AltFrame::ABOVE_HOME: {
+                    // transform point from ABOVE_HOME to ABOVE_ORIGIN
+                    const Location loc{packet.lat_int, packet.lon_int, int32_t(packet.alt * 100.0f), frame};
+                    Vector3f pos_neu_cm;
+                    if (!loc.get_vector_from_origin_NEU_cm(pos_neu_cm)) {
+                        break;
+                    }
+
+                    if (vel_ignore) {
+                        sub.mode_guided.guided_set_destination(pos_neu_cm);
+                    } else {
+                        sub.mode_guided.guided_set_destination_posvel(pos_neu_cm, vel_neu_cm, Location::AltFrame::ABOVE_ORIGIN);
+                    }
+                    break;
+                }
+                case Location::AltFrame::ABSOLUTE:
+                case Location::AltFrame::ABOVE_ORIGIN:
+                    // not supported
+                    break;
+            }
         }
 
         break;

--- a/ArduSub/Log.cpp
+++ b/ArduSub/Log.cpp
@@ -47,7 +47,7 @@ void Sub::Log_Write_Control_Tuning()
         desired_alt         : pos_control.get_pos_target_U_cm() * 0.01f,
         inav_alt            : pos_control.get_pos_estimate_U_m(),
         baro_alt            : barometer.get_altitude(),
-        desired_rangefinder_alt   : mode_surftrak.get_rangefinder_target_cm() * 0.01,
+        desired_rangefinder_alt   : flightmode->get_rangefinder_target(),
         rangefinder_alt           : rangefinder_state.alt,
         terr_alt            : terr_alt,
         target_climb_rate   : (int16_t)pos_control.get_vel_target_U_cms(),
@@ -176,6 +176,7 @@ struct PACKED log_GuidedTarget {
     LOG_PACKET_HEADER;
     uint64_t time_us;
     uint8_t type;
+    uint8_t alt_frame;
     float pos_target_x;
     float pos_target_y;
     float pos_target_z;
@@ -185,12 +186,14 @@ struct PACKED log_GuidedTarget {
 };
 
 // Write a Guided mode target
-void Sub::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target)
+void Sub::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target,
+                                 Location::AltFrame alt_frame)
 {
     struct log_GuidedTarget pkt = {
         LOG_PACKET_HEADER_INIT(LOG_GUIDEDTARGET_MSG),
         time_us         : AP_HAL::micros64(),
         type            : target_type,
+        alt_frame       : static_cast<uint8_t>(alt_frame),
         pos_target_x    : pos_target.x,
         pos_target_y    : pos_target.y,
         pos_target_z    : pos_target.z,
@@ -251,6 +254,7 @@ void Sub::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target
 // @Description: Guided mode target information
 // @Field: TimeUS: Time since system startup
 // @Field: Type: Type of guided mode
+// @Field: Frame: Location.AltFrame
 // @Field: pX: Target position, X-Axis
 // @Field: pY: Target position, Y-Axis
 // @Field: pZ: Target position, Z-Axis
@@ -276,7 +280,7 @@ const struct LogStructure Sub::log_structure[] = {
     { LOG_DATA_FLOAT_MSG, sizeof(log_Data_Float),         
       "DFLT",  "QBf",         "TimeUS,Id,Value", "s--", "F--" },
     { LOG_GUIDEDTARGET_MSG, sizeof(log_GuidedTarget),
-      "GUIP",  "QBffffff",    "TimeUS,Type,pX,pY,pZ,vX,vY,vZ", "s-mmmnnn", "F-000000" },
+      "GUIP",  "QBBffffff",    "TimeUS,Type,Frame,pX,pY,pZ,vX,vY,vZ", "s--mmmnnn", "F--000000" },
 };
 
 uint8_t Sub::get_num_log_structures() const

--- a/ArduSub/Sub.cpp
+++ b/ArduSub/Sub.cpp
@@ -465,6 +465,37 @@ void Sub::rc_loop()
 }
 #endif
 
+#if AP_SCRIPTING_ENABLED
+// set target position and velocity in supplied AltFrame
+bool Sub::set_target_posvel_NED(const Vector3f& target_pos_ned_m, const Vector3f& target_vel_ned_ms, Location::AltFrame alt_frame)
+{
+    // exit if the vehicle is not in Guided mode or Auto-Guided mode
+    if (!flightmode->in_guided_mode()) {
+        return false;
+    }
+
+    float dest_u_m = 0.0f;
+    switch (alt_frame) {
+        case Location::AltFrame::ABOVE_HOME:
+            // distance above home (usually at the water surface)
+            dest_u_m = -target_pos_ned_m.z;
+            break;
+        case Location::AltFrame::ABOVE_TERRAIN:
+            // distance above terrain
+            dest_u_m = target_pos_ned_m.z;
+            break;
+        case Location::AltFrame::ABSOLUTE:
+        case Location::AltFrame::ABOVE_ORIGIN:
+            // not supported
+            return false;
+    }
+
+    const Vector3f pos_neu_cm(target_pos_ned_m.x * 100.0f, target_pos_ned_m.y * 100.0f, dest_u_m * 100.0f);
+    const Vector3f vel_neu_cms(target_vel_ned_ms.x * 100.0f, target_vel_ned_ms.y * 100.0f, -target_vel_ned_ms.z * 100.0f);
+    return mode_guided.guided_set_destination_posvel(pos_neu_cm, vel_neu_cms, alt_frame);
+}
+#endif  // AP_SCRIPTING_ENABLED
+
 Sub *Sub::_singleton = nullptr;
 
 Sub sub;

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -646,6 +646,9 @@ public:
     float get_rangefinder_target_cm() const WARN_IF_UNUSED { return flightmode->get_rangefinder_target() * 100.0f; }
     bool set_rangefinder_target_cm(float new_target_cm) { return mode_surftrak.set_rangefinder_target_cm(new_target_cm); }
 #endif // AP_RANGEFINDER_ENABLED
+
+    // set target position and velocity
+    bool set_target_posvel_NED(const Vector3f& target_pos_ned_m, const Vector3f& target_vel_ned_ms, Location::AltFrame alt_frame) override;
 #endif // AP_SCRIPTING_ENABLED
 };
 

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -417,7 +417,7 @@ private:
     void Log_Write_Data(LogDataID id, int16_t value);
     void Log_Write_Data(LogDataID id, uint16_t value);
     void Log_Write_Data(LogDataID id, float value);
-    void Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target);
+    void Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target, Location::AltFrame alt_frame);
     void Log_Write_Vehicle_Startup_Messages();
 #endif
     void load_parameters(void) override;
@@ -643,7 +643,7 @@ public:
     uint8_t get_and_clear_button_count(uint8_t index);
 
 #if AP_RANGEFINDER_ENABLED
-    float get_rangefinder_target_cm() const WARN_IF_UNUSED { return mode_surftrak.get_rangefinder_target_cm(); }
+    float get_rangefinder_target_cm() const WARN_IF_UNUSED { return flightmode->get_rangefinder_target() * 100.0f; }
     bool set_rangefinder_target_cm(float new_target_cm) { return mode_surftrak.set_rangefinder_target_cm(new_target_cm); }
 #endif // AP_RANGEFINDER_ENABLED
 #endif // AP_SCRIPTING_ENABLED

--- a/ArduSub/mode.h
+++ b/ArduSub/mode.h
@@ -68,6 +68,7 @@ public:
     virtual bool allows_arming(bool from_gcs) const = 0;
     virtual bool is_autopilot() const { return false; }
     virtual bool in_guided_mode() const { return false; }
+    virtual float get_rangefinder_target() const { return 0; }
 
     // return a string for this flightmode
     virtual const char *name() const = 0;
@@ -225,7 +226,7 @@ public:
 
     bool init(bool ignore_checks) override;
 
-    float get_rangefinder_target_cm() const WARN_IF_UNUSED { return rangefinder_target_cm; }
+    float get_rangefinder_target() const override WARN_IF_UNUSED { return rangefinder_target_cm * 0.01f; }
     bool set_rangefinder_target_cm(float target_cm);
 
 protected:
@@ -261,12 +262,13 @@ public:
     bool allows_arming(bool from_gcs) const override { return true; }
     bool is_autopilot() const override { return true; }
     bool in_guided_mode() const override { return true; }
+    float get_rangefinder_target() const override WARN_IF_UNUSED;
     bool guided_limit_check();
     void guided_limit_init_time_and_pos();
     void guided_set_angle(const Quaternion &q, float climb_rate_cms, bool use_yaw_rate, float yaw_rate_rads);
     void guided_set_angle(const Quaternion&, float);
     void guided_limit_set(uint32_t timeout_ms, float alt_min_cm, float alt_max_cm, float horiz_max_cm);
-    bool guided_set_destination_posvel(const Vector3f& destination, const Vector3f& velocity);
+    bool guided_set_destination_posvel(const Vector3f& destination, const Vector3f& velocity, Location::AltFrame alt_frame);
     bool guided_set_destination_posvel(const Vector3f& destination, const Vector3f& velocity, bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_yaw);
     bool guided_set_destination(const Vector3f& destination);
     bool guided_set_destination(const Location&);
@@ -294,7 +296,7 @@ private:
     void guided_takeoff_run();
     void guided_pos_control_start();
     void guided_vel_control_start();
-    void guided_posvel_control_start();
+    void guided_posvel_control_start(Location::AltFrame alt_frame);
     void guided_angle_control_start();
 };
 

--- a/ArduSub/mode_guided.cpp
+++ b/ArduSub/mode_guided.cpp
@@ -9,6 +9,7 @@
 
 static Vector3p posvel_pos_target_cm;
 static Vector3f posvel_vel_target_cms;
+static Location::AltFrame posvel_frame;
 static uint32_t update_time_ms;
 
 struct {
@@ -118,10 +119,11 @@ void ModeGuided::guided_vel_control_start()
 }
 
 // initialise guided mode's posvel controller
-void ModeGuided::guided_posvel_control_start()
+void ModeGuided::guided_posvel_control_start(Location::AltFrame alt_frame)
 {
-    // set guided_mode to velocity controller
+    // set guided_mode to posvel controller
     sub.guided_mode = Guided_PosVel;
+    posvel_frame = alt_frame;
 
     // set vertical speed and acceleration
     // All limits must be positive
@@ -188,7 +190,7 @@ bool ModeGuided::guided_set_destination(const Vector3f& destination)
 
 #if HAL_LOGGING_ENABLED
     // log target
-    sub.Log_Write_GuidedTarget(sub.guided_mode, destination, Vector3f());
+    sub.Log_Write_GuidedTarget(sub.guided_mode, destination, Vector3f(), Location::AltFrame::ABOVE_ORIGIN);
 #endif
 
     return true;
@@ -223,7 +225,7 @@ bool ModeGuided::guided_set_destination(const Location& dest_loc)
 
 #if HAL_LOGGING_ENABLED
     // log target
-    sub.Log_Write_GuidedTarget(sub.guided_mode, Vector3f(dest_loc.lat, dest_loc.lng, dest_loc.alt),Vector3f());
+    sub.Log_Write_GuidedTarget(sub.guided_mode, Vector3f(dest_loc.lat, dest_loc.lng, dest_loc.alt),Vector3f(), Location::AltFrame::ABOVE_ORIGIN);
 #endif
 
     return true;
@@ -259,7 +261,7 @@ bool ModeGuided::guided_set_destination(const Vector3f& destination, bool use_ya
 
 #if HAL_LOGGING_ENABLED
     // log target
-    sub.Log_Write_GuidedTarget(sub.guided_mode, destination, Vector3f());
+    sub.Log_Write_GuidedTarget(sub.guided_mode, destination, Vector3f(), Location::AltFrame::ABOVE_ORIGIN);
 #endif
 
     return true;
@@ -298,11 +300,11 @@ void ModeGuided::guided_set_velocity(const Vector3f& velocity, bool use_yaw, flo
 }
 
 // set guided mode posvel target
-bool ModeGuided::guided_set_destination_posvel(const Vector3f& destination, const Vector3f& velocity)
+bool ModeGuided::guided_set_destination_posvel(const Vector3f& destination, const Vector3f& velocity, Location::AltFrame alt_frame)
 {
 #if AP_FENCE_ENABLED
     // reject destination if outside the fence
-    const Location dest_loc(destination, Location::AltFrame::ABOVE_ORIGIN);
+    const Location dest_loc(destination, alt_frame);
     if (!sub.fence.check_location_within_fence(dest_loc)) {
         LOGGER_WRITE_ERROR(LogErrorSubsystem::NAVIGATION, LogErrorCode::DEST_OUTSIDE_FENCE);
         // failure is propagated to GCS with NAK
@@ -310,23 +312,54 @@ bool ModeGuided::guided_set_destination_posvel(const Vector3f& destination, cons
     }
 #endif
 
-    // check we are in posvel control mode
-    if (sub.guided_mode != Guided_PosVel) {
-        guided_posvel_control_start();
+    // move into Guided_PosVel sub-mode with the specified frame (as necessary)
+    if (sub.guided_mode != Guided_PosVel || posvel_frame != alt_frame) {
+        switch (alt_frame) {
+            case Location::AltFrame::ABOVE_ORIGIN:
+                guided_posvel_control_start(alt_frame);
+                break;
+            case Location::AltFrame::ABOVE_TERRAIN:
+                if (!sub.rangefinder_alt_ok()) {
+                    gcs().send_text(MAV_SEVERITY_WARNING, "Terrain data (rangefinder) not available");
+                    return false;
+                }
+                guided_posvel_control_start(alt_frame);
+
+                // bumpless transfer
+                position_control->init_pos_terrain_D_m((destination.z - sub.rangefinder_state.inertial_alt_cm) * 0.01f);
+                position_control->set_pos_terrain_target_D_m(-sub.rangefinder_state.rangefinder_terrain_offset_cm * 0.01f);
+                break;
+            case Location::AltFrame::ABSOLUTE:
+            case Location::AltFrame::ABOVE_HOME:
+                // not supported
+                return false;
+        }
+    } else {  // already in the intended sub-mode + frame
+        if (alt_frame == Location::AltFrame::ABOVE_TERRAIN) {
+            // rangefinder target may have changed
+            position_control->init_pos_terrain_D_m(position_control->get_pos_terrain_D_m() + (destination.z - posvel_pos_target_cm.z) * 0.01f);
+        }
     }
 
     update_time_ms = AP_HAL::millis();
     posvel_pos_target_cm = destination.topostype();
     posvel_vel_target_cms = velocity;
 
-    position_control->input_pos_vel_accel_NE_cm(posvel_pos_target_cm.xy(), posvel_vel_target_cms.xy(), Vector2f());
-    float dz = posvel_pos_target_cm.z;
-    position_control->input_pos_vel_accel_U_cm(dz, posvel_vel_target_cms.z, 0);
-    posvel_pos_target_cm.z = dz;
+    Vector2p pos_ne_m = posvel_pos_target_cm.xy() * 0.01f;
+    Vector2f vel_ne_ms = posvel_vel_target_cms.xy() * 0.01f;
+    position_control->input_pos_vel_accel_NE_m(pos_ne_m, vel_ne_ms, Vector2f());
+    posvel_pos_target_cm.xy() = pos_ne_m * 100.0f;
+    posvel_vel_target_cms.xy() = vel_ne_ms * 100.0f;
+
+    float pz_d_m = -posvel_pos_target_cm.z * 0.01f;
+    float vz_d_ms = -posvel_vel_target_cms.z * 0.01f;
+    position_control->input_pos_vel_accel_D_m(pz_d_m, vz_d_ms, 0);
+    posvel_pos_target_cm.z = -pz_d_m * 100.0f;
+    posvel_vel_target_cms.z = -vz_d_ms * 100.0f;
 
 #if HAL_LOGGING_ENABLED
     // log target
-    sub.Log_Write_GuidedTarget(sub.guided_mode, destination, velocity);
+    sub.Log_Write_GuidedTarget(sub.guided_mode, destination, velocity, alt_frame);
 #endif
 
     return true;
@@ -347,7 +380,7 @@ bool ModeGuided::guided_set_destination_posvel(const Vector3f& destination, cons
 
     // check we are in posvel control mode
     if (sub.guided_mode != Guided_PosVel) {
-        guided_posvel_control_start();
+        guided_posvel_control_start(Location::AltFrame::ABOVE_ORIGIN);
     }
 
     // set yaw state
@@ -365,7 +398,7 @@ bool ModeGuided::guided_set_destination_posvel(const Vector3f& destination, cons
 
 #if HAL_LOGGING_ENABLED
     // log target
-    sub.Log_Write_GuidedTarget(sub.guided_mode, destination, velocity);
+    sub.Log_Write_GuidedTarget(sub.guided_mode, destination, velocity, Location::AltFrame::ABOVE_ORIGIN);
 #endif
 
     return true;
@@ -641,6 +674,14 @@ void ModeGuided::guided_posvel_control_run()
 
     // send position and velocity targets to position controller
     position_control->input_pos_vel_accel_NE_cm(posvel_pos_target_cm.xy(), posvel_vel_target_cms.xy(), Vector2f());
+
+#if AP_RANGEFINDER_ENABLED
+    if (posvel_frame == Location::AltFrame::ABOVE_TERRAIN && sub.rangefinder_alt_ok()) {
+        // surftrak: set the offset target to the current terrain altitude estimate
+        position_control->set_pos_terrain_target_U_cm(sub.rangefinder_state.rangefinder_terrain_offset_cm);
+    }
+#endif
+
     float pz = posvel_pos_target_cm.z;
     position_control->input_pos_vel_accel_U_cm(pz, posvel_vel_target_cms.z, 0);
     posvel_pos_target_cm.z = pz;
@@ -888,4 +929,13 @@ bool ModeGuided::guided_limit_check()
 
     // if we got this far we must be within limits
     return false;
+}
+
+// returns target for rangefinder, or 0 if there is no rangefinder target
+float ModeGuided::get_rangefinder_target() const
+{
+    if (sub.guided_mode == Guided_PosVel && posvel_frame == Location::AltFrame::ABOVE_TERRAIN) {
+        return posvel_pos_target_cm.z * 0.01f;
+    }
+    return 0.0f;
 }

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -7,7 +7,9 @@ Parameters are in-code defaults plus default_params/sub.parm
 AP_FLAKE8_CLEAN
 '''
 
+import math
 import os
+import re
 
 from math import degrees
 from math import radians
@@ -17,12 +19,16 @@ from pymavlink import mavutil
 
 import vehicle_test_suite
 
+from pysim import util
 from vehicle_test_suite import NotAchievedException
 
 # get location of scripts
 testdir = os.path.dirname(os.path.realpath(__file__))
 
 SITL_START_LOCATION = mavutil.location(33.810313, -118.393867, 0, 185)
+
+# Extract true range from STATUSTEXT messages sent by sub_test_synthetic_seafloor.lua
+RE_TR_SEARCH = re.compile(r'#TR#\s*([-+]?\d*\.?\d+)')
 
 
 class Joystick():
@@ -373,13 +379,11 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
 
         def get_true_distance():
             """Return the True distance from the simulated range finder"""
-            m_true = self.mav.recv_match(type='STATUSTEXT', blocking=True, timeout=3.0)
-            if m_true is None:
-                return m_true
-            idx_tr = m_true.text.find('#TR#')
-            if idx_tr < 0:
+            m_true = self.assert_receive_message('STATUSTEXT', timeout=3.0)
+            match = RE_TR_SEARCH.search(m_true.text)
+            if not match:
                 return None
-            return float(m_true.text[(idx_tr+4):(idx_tr+12)])
+            return float(match.group(1))
 
         tstart = self.get_sim_time_cached()
         self.progress('Distance to be watched: %.2f (+/- %.2f)' % (match_distance, delta))
@@ -420,7 +424,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         end_altitude = start_altitude - 10
         validation_delta = 1.5  # Largest allowed distance between sub height and desired height
 
-        self.context_push()
+        # Load the synthetic seafloor, this will push a context and reboot
         self.prepare_synthetic_seafloor_test(sea_floor_depth, match_distance)
 
         # Dive to match_distance off the bottom in preparation for the mission
@@ -452,9 +456,8 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
 
         self.set_rc(Joystick.Forward, 1500)
 
+        # Disarm before context pop
         self.disarm_vehicle()
-        self.context_pop()
-        self.reboot_sitl()  # e.g. revert rangefinder configuration
 
     def SimTerrainMission(self):
         """Mission at a constant height above synthetic sea floor"""
@@ -465,7 +468,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         end_altitude = start_altitude - 10
         validation_delta = 1.5  # Largest allowed distance between sub height and desired height
 
-        self.context_push()
+        # Load the synthetic seafloor, this will push a context and reboot
         self.prepare_synthetic_seafloor_test(sea_floor_depth, match_distance)
 
         # The synthetic seafloor has an east-west ridge south of the sub.
@@ -484,9 +487,127 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.wait_altitude(altitude_min=end_altitude-validation_delta/2, altitude_max=end_altitude+validation_delta/2,
                            relative=False, timeout=1)
 
+        # Disarm before context pop
         self.disarm_vehicle()
-        self.context_pop()
-        self.reboot_sitl()  # e.g. revert rangefinder configuration
+
+    def GuidedPosVel(self):
+        """Send SET_POSITION_TARGET_INT msgs at 10Hz with position and velocity targets"""
+
+        # GUIDED mode supports several sub-modes selected by the POSITION_TARGET_TYPE mask
+        # The Guided_PosVel sub-mode supports rapid updates and several altitude frames
+        posvel_mode = (mavutil.mavlink.POSITION_TARGET_TYPEMASK_AX_IGNORE |
+                       mavutil.mavlink.POSITION_TARGET_TYPEMASK_AY_IGNORE |
+                       mavutil.mavlink.POSITION_TARGET_TYPEMASK_AZ_IGNORE |
+                       mavutil.mavlink.POSITION_TARGET_TYPEMASK_YAW_IGNORE |
+                       mavutil.mavlink.POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE)
+
+        # Everything in meters and meters/second unless noted
+        seafloor_depth = 50
+        speed = 0.5
+
+        # Load the synthetic seafloor, this will push a context and reboot
+        self.prepare_synthetic_seafloor_test(seafloor_depth, 10)  # rf_target is not used
+
+        # Guided_PosVel uses WP_SPD (m/s)
+        self.set_parameter('WP_SPD', speed)
+
+        # Dive to starting altitude
+        self.dive(-15)
+
+        # Request GLOBAL_POSITION_INT, this will be our clock
+        self.context_set_message_rate_hz('GLOBAL_POSITION_INT', 10)
+
+        # Run back and forth between 2 locations
+        distance = 30
+        timeout = distance / speed + 5  # Add a little time to accelerate, etc.
+
+        runs = [{
+            # Hold depth as the terrain rises
+            'frame': mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT,
+            'bearing': 180,
+            'target_alt': -15,  # Altitude above origin
+            'max_error_allowed': 1.0,
+        }, {
+            # Hold range as the terrain falls
+            'frame': mavutil.mavlink.MAV_FRAME_GLOBAL_TERRAIN_ALT,
+            'bearing': 0,
+            'target_alt': 25,  # Distance to seafloor
+            'max_error_allowed': 1.0,
+        }, {
+            # Hold depth as the terrain rises
+            'frame': mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT,
+            'bearing': 180,
+            'target_alt': -25,  # Altitude above origin
+            'max_error_allowed': 1.0,
+        }, {
+            # Hold range as the terrain falls
+            'frame': mavutil.mavlink.MAV_FRAME_GLOBAL_TERRAIN_ALT,
+            'bearing': 0,
+            'target_alt': 15,  # Distance to seafloor
+            'max_error_allowed': 1.0,
+        }]
+
+        # Stay in GUIDED mode for the duration
+        self.change_mode('GUIDED')
+
+        for run in runs:
+            msg = self.assert_receive_message('GLOBAL_POSITION_INT')
+            start_loc = (msg.lat * 1e-7, msg.lon * 1e-7)
+            dest_loc = util.gps_newpos(start_loc[0], start_loc[1], run['bearing'], distance)
+
+            # current_alt = range (distance to seafloor) or altitude (distance above origin), depending on the frame
+            current_alt = None
+            max_error = 0.0
+
+            # Go!
+            start_time = self.get_sim_time()
+            while True:
+                msg = self.assert_receive_message(['GLOBAL_POSITION_INT', 'STATUSTEXT'])
+                # Get ground truth (sans noise) from the terrain generator
+                if msg.get_type() == 'STATUSTEXT':
+                    if run['frame'] == mavutil.mavlink.MAV_FRAME_GLOBAL_TERRAIN_ALT:
+                        match = RE_TR_SEARCH.search(msg.text)
+                        if match:
+                            current_alt = float(match.group(1))
+                    continue
+
+                current_loc = (msg.lat * 1e-7, msg.lon * 1e-7)
+                distance_remaining = util.gps_distance(
+                    dest_loc[0], dest_loc[1],
+                    current_loc[0], current_loc[1])
+
+                if run['frame'] == mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT:
+                    current_alt = msg.relative_alt * 0.001
+
+                if distance_remaining < 0.5:
+                    self.progress('Frame %u reached destination at time %f, max_error %f' %
+                                  (run['frame'], self.get_sim_time_cached() - start_time, max_error))
+                    break
+                elif self.get_sim_time_cached() - start_time > timeout:
+                    raise NotAchievedException('Frame %u took too long to reach the destination' % run['frame'])
+
+                if current_alt is None:
+                    continue
+
+                alt_error = abs(current_alt - run['target_alt'])
+                if alt_error > run['max_error_allowed']:
+                    raise NotAchievedException('Alt incorrect on frame %d: want %.2f (+/- %.2f) got=%.2f'
+                                               % (run['frame'], run['target_alt'], run['max_error_allowed'], current_alt))
+
+                if alt_error > max_error:
+                    max_error = alt_error
+
+                # Set the target ahead of the current location
+                target_loc = util.gps_newpos(current_loc[0], current_loc[1], run['bearing'], 10)
+                target_vel = [speed * math.cos(math.radians(run['bearing'])), speed * math.sin(math.radians(run['bearing']))]
+
+                self.mav.mav.set_position_target_global_int_send(
+                    0, 1, 1, run['frame'], posvel_mode,
+                    int(target_loc[0] * 1e7), int(target_loc[1] * 1e7), run['target_alt'],
+                    target_vel[0], target_vel[1], 0, 0, 0, 0, 0, 0)
+
+        # Disarm before the context pop
+        self.disarm_vehicle()
 
     def ModeChanges(self, delta=0.2):
         """Check if alternating between ALTHOLD, STABILIZE, POSHOLD and SURFTRAK (mode 21) affects altitude"""
@@ -1385,6 +1506,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
             self.Surftrak,
             self.SimTerrainSurftrak,
             self.SimTerrainMission,
+            self.GuidedPosVel,
             self.RngfndQuality,
             self.PositionHold,
             self.ModeChanges,

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -2799,8 +2799,9 @@ function vehicle:set_target_posvelaccel_NED(target_pos, target_vel, target_accel
 -- desc
 ---@param target_pos Vector3f_ud
 ---@param target_vel Vector3f_ud
+---@param alt_frame? number -- optional frame, defaults to 2 (ABOVE_ORIGIN), Sub supports 3 (ABOVE_TERRAIN)
 ---@return boolean
-function vehicle:set_target_posvel_NED(target_pos, target_vel) end
+function vehicle:set_target_posvel_NED(target_pos, target_vel, alt_frame) end
 
 -- desc
 ---@param target_pos Vector3f_ud

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -359,7 +359,7 @@ singleton AP_Vehicle method set_target_location boolean Location
 singleton AP_Vehicle method get_target_location boolean Location'Null
 singleton AP_Vehicle method update_target_location boolean Location Location
 singleton AP_Vehicle method set_target_pos_NED boolean Vector3f boolean float -360 +360 boolean float'skip_check boolean boolean
-singleton AP_Vehicle method set_target_posvel_NED boolean Vector3f Vector3f
+singleton AP_Vehicle manual set_target_posvel_NED lua_AP_Vehicle_set_target_posvel_NED 3 1
 singleton AP_Vehicle method set_target_posvelaccel_NED boolean Vector3f Vector3f Vector3f boolean float -360 +360 boolean float'skip_check boolean
 singleton AP_Vehicle method set_target_velaccel_NED boolean Vector3f Vector3f boolean float -360 +360 boolean float'skip_check boolean
 singleton AP_Vehicle manual set_target_velocity_NED lua_AP_Vehicle_set_target_velocity_NED 2 1

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -1255,6 +1255,39 @@ int lua_AP_Vehicle_set_target_velocity_NED(lua_State *L)
     lua_pushboolean(L, data);
     return 1;
 }
+
+int lua_AP_Vehicle_set_target_posvel_NED(lua_State *L) {
+    const int args = lua_gettop(L);
+
+    if (args > 4) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 3) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+
+    AP_Vehicle *ud = check_AP_Vehicle(L);
+    Vector3f &pos = *check_Vector3f(L, 2);
+    Vector3f &vel = *check_Vector3f(L, 3);
+
+    Location::AltFrame alt_frame = Location::AltFrame::ABOVE_ORIGIN;
+
+    if (args == 4) {
+        alt_frame = static_cast<Location::AltFrame>(get_uint8_t(L, 4));
+    }
+
+#if AP_SCHEDULER_ENABLED
+    AP::scheduler().get_semaphore().take_blocking();
+#endif
+
+    bool success = ud->set_target_posvel_NED(pos, vel, alt_frame);
+
+#if AP_SCHEDULER_ENABLED
+    AP::scheduler().get_semaphore().give();
+#endif
+
+    lua_pushboolean(L, success);
+    return 1;
+}
 #endif // AP_SCRIPTING_BINDING_VEHICLE_ENABLED
 
 #endif  // AP_SCRIPTING_ENABLED

--- a/libraries/AP_Scripting/lua_bindings.h
+++ b/libraries/AP_Scripting/lua_bindings.h
@@ -38,3 +38,4 @@ int lua_GCS_command_int(lua_State *L);
 int lua_DroneCAN_get_FlexDebug(lua_State *L);
 int lua_gps_inject_data(lua_State *L);
 int lua_AP_Vehicle_set_target_velocity_NED(lua_State *L);
+int lua_AP_Vehicle_set_target_posvel_NED(lua_State *L);

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -190,7 +190,7 @@ public:
       methods to control vehicle for use by scripting
     */
     virtual bool set_target_pos_NED(const Vector3f& target_pos_ned_m, bool use_yaw, float yaw_deg, bool use_yaw_rate, float yaw_rate_degs, bool yaw_relative, bool is_terrain_alt) { return false; }
-    virtual bool set_target_posvel_NED(const Vector3f& target_pos_ned_m, const Vector3f& target_vel_ned_ms) { return false; }
+    virtual bool set_target_posvel_NED(const Vector3f& target_pos_ned_m, const Vector3f& target_vel_ned_ms, Location::AltFrame alt_frame = Location::AltFrame::ABOVE_ORIGIN) { return false; }
     virtual bool set_target_posvelaccel_NED(const Vector3f& target_pos_ned_m, const Vector3f& target_vel_ned_ms, const Vector3f& target_accel_ned_mss, bool use_yaw, float yaw_deg, bool use_yaw_rate, float yaw_rate_degs, bool yaw_relative) { return false; }
     virtual bool set_target_velocity_NED(const Vector3f& vel_ned_ms, bool align_yaw_to_target = false) { return false; }
     virtual bool set_target_velaccel_NED(const Vector3f& target_vel_ned_ms, const Vector3f& target_accel_ned_mss, bool use_yaw, float yaw_deg, bool use_yaw_rate, float yaw_rate_degs, bool yaw_relative) { return false; }


### PR DESCRIPTION
Sub Guided_PosVel mode currently assumes `Location::AltFrame::ABOVE_ORIGIN`. This PR adds support for `Location::AltFrame::ABOVE_TERRAIN`.

This new functionality is exposed two ways:
* Using MAVLink: `SET_TARGET_POSITION_GLOBAL_INT.frame = MAV_FRAME_GLOBAL_TERRAIN_ALT_INT`
* Using Lua: `set_target_posvel_terrain(Vector3f, Vector3f)`

The motivation is to allow the development of scripts that drive the ROV at a constant xy velocity and at a constant height above the seafloor, while giving the pilot control over heading. There's a new autotest that demonstrates this.

Possible open issues / future PRs:
* Is it better to add an optional frame parameter to the `set_target_posvel_NED(Vector3f, Vector3f)` Lua binding?
* Sub Guided_WP mode could also support `Location::AltFrame::ABOVE_TERRAIN`, though this mode does not support rapid target updates
