### PR TITLE
OSD should display ESC temp rather than motor temp

### DIFF
--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -262,13 +262,13 @@ bool AP_ESC_Telem::get_motor_temperature(uint8_t esc_index, int16_t& temp) const
 }
 
 // get the highest ESC temperature in centi-degrees if available, returns true if there is valid data for at least one ESC
-bool AP_ESC_Telem::get_highest_motor_temperature(int16_t& temp) const
+bool AP_ESC_Telem::get_highest_temperature(int16_t& temp) const
 {
     uint8_t valid_escs = 0;
 
     for (uint8_t i = 0; i < ESC_TELEM_MAX_ESCS; i++) {
         int16_t temp_temp;
-        if (get_motor_temperature(i, temp_temp)) {
+        if (get_temperature(i, temp_temp)) {
             temp = MAX(temp, temp_temp);
             valid_escs++;
         }

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.h
@@ -55,7 +55,7 @@ public:
     bool get_motor_temperature(uint8_t esc_index, int16_t& temp) const;
 
     // get the highest ESC temperature in centi-degrees if available, returns true if there is valid data for at least one ESC
-    bool get_highest_motor_temperature(int16_t& temp) const;
+    bool get_highest_temperature(int16_t& temp) const;
 
     // get an individual ESC's current in Ampere if available, returns true on success
     bool get_current(uint8_t esc_index, float& amps) const;

--- a/libraries/AP_MSP/AP_MSP_Telem_DJI.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_DJI.cpp
@@ -91,7 +91,7 @@ MSPCommandResult AP_MSP_Telem_DJI::msp_process_out_esc_sensor_data(sbuf_t *dst)
     int16_t highest_temperature = 0;
     AP_ESC_Telem& telem = AP::esc_telem();
     if (!displaying_stats_screen()) {
-        telem.get_highest_motor_temperature(highest_temperature);
+        telem.get_highest_temperature(highest_temperature);
     } else {
 #if OSD_ENABLED
         AP_OSD *osd = AP::osd();

--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -506,7 +506,7 @@ void AP_OSD::update_stats()
     // max esc temp
     AP_ESC_Telem& telem = AP::esc_telem();
     int16_t highest_temperature = 0;
-    telem.get_highest_motor_temperature(highest_temperature);
+    telem.get_highest_temperature(highest_temperature);
     _stats.max_esc_temp = MAX(_stats.max_esc_temp, highest_temperature);
 #endif
 }

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -2013,11 +2013,11 @@ void AP_OSD_Screen::draw_esc_temp(uint8_t x, uint8_t y)
     int16_t etemp;
 
     if (esc_index > 0) {
-        if (!AP::esc_telem().get_motor_temperature(esc_index-1, etemp)) {
+        if (!AP::esc_telem().get_temperature(esc_index-1, etemp)) {
             return;
         }
     }
-    else if (!AP::esc_telem().get_highest_motor_temperature(etemp)) {
+    else if (!AP::esc_telem().get_highest_temperature(etemp)) {
         return;
     }
 


### PR DESCRIPTION
Motor temp is rarely implemented and was used before.