### PR TITLE
AP_ESC_Telem: log DroneCAN power percentage in extended ESC message

### DIFF
--- a/libraries/AP_DroneCAN/AP_DroneCAN.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.cpp
@@ -1447,14 +1447,21 @@ void AP_DroneCAN::handle_ESC_status(const CanardRxTransfer& transfer, const uavc
         .temperature_cdeg = int16_t((KELVIN_TO_C(msg.temperature)) * 100),
         .voltage = msg.voltage,
         .current = msg.current,
+#if AP_EXTENDED_ESC_TELEM_ENABLED
+        .power_percentage = msg.power_rating_pct,
+#endif
     };
 
     update_rpm(esc_index, msg.rpm, msg.error_count);
     update_telem_data(esc_index, t,
         (isnan(msg.current) ? 0 : AP_ESC_Telem_Backend::TelemetryType::CURRENT)
             | (isnan(msg.voltage) ? 0 : AP_ESC_Telem_Backend::TelemetryType::VOLTAGE)
-            | (isnan(msg.temperature) ? 0 : AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE));
+            | (isnan(msg.temperature) ? 0 : AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE)
+#if AP_EXTENDED_ESC_TELEM_ENABLED
+            | AP_ESC_Telem_Backend::TelemetryType::POWER_PERCENTAGE
 #endif
+        );
+#endif // HAL_WITH_ESC_TELEM
 }
 
 #if AP_EXTENDED_ESC_TELEM_ENABLED

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -502,6 +502,9 @@ void AP_ESC_Telem::update_telem_data(const uint8_t esc_index, const AP_ESC_Telem
     if (data_mask & AP_ESC_Telem_Backend::TelemetryType::FLAGS) {
         _telem_data[esc_index].flags = new_data.flags;
     }
+    if (data_mask & AP_ESC_Telem_Backend::TelemetryType::POWER_PERCENTAGE) {
+        _telem_data[esc_index].power_percentage = new_data.power_percentage;
+    }
 #endif //AP_EXTENDED_ESC_TELEM_ENABLED
 
 #if AP_EXTENDED_DSHOT_TELEM_V2_ENABLED
@@ -657,7 +660,8 @@ void AP_ESC_Telem::update()
                 const bool has_ext_data = telemdata.types & 
                         (AP_ESC_Telem_Backend::TelemetryType::INPUT_DUTY |
                          AP_ESC_Telem_Backend::TelemetryType::OUTPUT_DUTY |
-                         AP_ESC_Telem_Backend::TelemetryType::FLAGS);
+                         AP_ESC_Telem_Backend::TelemetryType::FLAGS |
+                         AP_ESC_Telem_Backend::TelemetryType::POWER_PERCENTAGE);
                 if (has_ext_data) {
                     // @LoggerMessage: ESCX
                     // @Description: ESC extended telemetry data
@@ -666,16 +670,18 @@ void AP_ESC_Telem::update()
                     // @Field: inpct: input duty cycle in percent
                     // @Field: outpct: output duty cycle in percent
                     // @Field: flags: manufacturer-specific status flags
+                    // @Field: Pwr: Power percentage
                     AP::logger().WriteStreaming("ESCX",
-                                                "TimeUS,Instance,inpct,outpct,flags",
-                                                "s"     "#"      "%"   "%"    "-",
-                                                "F"     "-"      "-"   "-"    "-",
-                                                "Q"     "B"      "B"   "B"    "I",
+                                                "TimeUS,Instance,inpct,outpct,flags,Pwr",
+                                                "s"     "#"      "%"   "%"    "-"   "%",
+                                                "F"     "-"      "-"   "-"    "-"   "-",
+                                                "Q"     "B"      "B"   "B"    "I"   "B",
                                                 AP_HAL::micros64(),
                                                 i,
                                                 telemdata.input_duty,
                                                 telemdata.output_duty,
-                                                telemdata.flags);
+                                                telemdata.flags,
+                                                telemdata.power_percentage);
                 }
 #endif //AP_EXTENDED_ESC_TELEM_ENABLED
             }

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem_Backend.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem_Backend.h
@@ -27,6 +27,7 @@ public:
         uint8_t input_duty;         // input duty cycle
         uint8_t output_duty;        // output duty cycle
         uint32_t flags;             // Status flags
+        uint8_t power_percentage;   // Percentage of output power
 #endif // AP_EXTENDED_ESC_TELEM_ENABLED
 
         // return true if the data is stale
@@ -58,7 +59,8 @@ public:
 #if AP_EXTENDED_ESC_TELEM_ENABLED
         INPUT_DUTY  = 1 << 10,
         OUTPUT_DUTY = 1 << 11,
-        FLAGS       = 1 << 12
+        FLAGS       = 1 << 12,
+        POWER_PERCENTAGE = 1 << 13,
 #endif // AP_EXTENDED_ESC_TELEM_ENABLED
     };
 


### PR DESCRIPTION
Power percentage is a field in the standard ESC status DroneCAN message that didn't really have a good place in the existing logging, we now have extended logging for the DroenCAN extended status message which is a better fit.   