### PR TITLE
AP_Periph: add support for extended ESC DroneCAN message. 

### DIFF
--- a/Tools/AP_Periph/AP_Periph.h
+++ b/Tools/AP_Periph/AP_Periph.h
@@ -334,9 +334,15 @@ public:
 #ifdef HAL_PERIPH_ENABLE_RC_OUT
 #if HAL_WITH_ESC_TELEM
     AP_ESC_Telem esc_telem;
+    uint8_t get_motor_number(const uint8_t esc_number) const;
     uint32_t last_esc_telem_update_ms;
     void esc_telem_update();
     uint32_t esc_telem_update_period_ms;
+#if AP_EXTENDED_ESC_TELEM_ENABLED
+    void esc_telem_extended_update(const uint32_t &now_ms);
+    uint32_t last_esc_telem_extended_update;
+    uint8_t last_esc_telem_extended_sent_id;
+#endif
 #endif
 
     SRV_Channels servo_channels;

--- a/Tools/AP_Periph/Parameters.cpp
+++ b/Tools/AP_Periph/Parameters.cpp
@@ -712,6 +712,17 @@ const AP_Param::Info AP_Periph_FW::var_info[] = {
     GSCALAR(rpm_msg_rate, "RPM_MSG_RATE", 0),
 #endif
 
+#if AP_EXTENDED_ESC_TELEM_ENABLED && HAL_WITH_ESC_TELEM
+    // @Param: ESC_EXT_TLM_RATE
+    // @DisplayName: ESC Extended telemetry message rate
+    // @Description: This is the rate at which extended ESC Telemetry will be sent across the CAN bus for each ESC
+    // @Units: Hz
+    // @Range: 0 50
+    // @Increment: 1
+    // @User: Advanced
+    GSCALAR(esc_extended_telem_rate, "ESC_EXT_TLM_RATE", AP_PERIPH_ESC_TELEM_RATE_DEFAULT / 10),
+#endif
+
     AP_VAREND
 };
 

--- a/Tools/AP_Periph/Parameters.h
+++ b/Tools/AP_Periph/Parameters.h
@@ -96,6 +96,7 @@ public:
         k_param_options,
         k_param_rpm_msg_rate,
         k_param_esc_rate,
+        k_param_esc_extended_telem_rate,
     };
 
     AP_Int16 format_version;
@@ -183,6 +184,9 @@ public:
 #endif
 #if HAL_WITH_ESC_TELEM
     AP_Int32 esc_telem_rate;
+#if AP_EXTENDED_ESC_TELEM_ENABLED
+    AP_Int16 esc_extended_telem_rate;
+#endif
 #endif
 #endif
 

--- a/Tools/AP_Periph/rc_out.cpp
+++ b/Tools/AP_Periph/rc_out.cpp
@@ -165,6 +165,9 @@ void AP_Periph_FW::rcout_update()
         last_esc_telem_update_ms = now_ms;
         esc_telem_update();
     }
+#if AP_EXTENDED_ESC_TELEM_ENABLED
+    esc_telem_extended_update(now_ms);
+#endif
 #endif
 }
 

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -941,6 +941,7 @@ class sitl_periph_universal(sitl_periph):
             AP_BATTERY_ESC_ENABLED = 1,
             HAL_PWM_COUNT = 32,
             HAL_WITH_ESC_TELEM = 1,
+            AP_EXTENDED_ESC_TELEM_ENABLED = 1,
             AP_TERRAIN_AVAILABLE = 1,
         )
 

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -240,8 +240,7 @@ bool AP_ESC_Telem::get_temperature(uint8_t esc_index, int16_t& temp) const
 {
     const volatile AP_ESC_Telem_Backend::TelemetryData& telemdata = _telem_data[esc_index];
     if (esc_index >= ESC_TELEM_MAX_ESCS
-        || telemdata.stale()
-        || !(telemdata.types & (AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE | AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE_EXTERNAL))) {
+        || !telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE | AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE_EXTERNAL)) {
         return false;
     }
     temp = telemdata.temperature_cdeg;
@@ -253,8 +252,7 @@ bool AP_ESC_Telem::get_motor_temperature(uint8_t esc_index, int16_t& temp) const
 {
     const volatile AP_ESC_Telem_Backend::TelemetryData& telemdata = _telem_data[esc_index];
     if (esc_index >= ESC_TELEM_MAX_ESCS
-        || telemdata.stale()
-        || !(telemdata.types & (AP_ESC_Telem_Backend::TelemetryType::MOTOR_TEMPERATURE | AP_ESC_Telem_Backend::TelemetryType::MOTOR_TEMPERATURE_EXTERNAL))) {
+         || !telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::MOTOR_TEMPERATURE | AP_ESC_Telem_Backend::TelemetryType::MOTOR_TEMPERATURE_EXTERNAL)) {
         return false;
     }
     temp = telemdata.motor_temp_cdeg;
@@ -282,8 +280,7 @@ bool AP_ESC_Telem::get_current(uint8_t esc_index, float& amps) const
 {
     const volatile AP_ESC_Telem_Backend::TelemetryData& telemdata = _telem_data[esc_index];
     if (esc_index >= ESC_TELEM_MAX_ESCS
-        || telemdata.stale()
-        || !(telemdata.types & AP_ESC_Telem_Backend::TelemetryType::CURRENT)) {
+        || !telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::CURRENT)) {
         return false;
     }
     amps = telemdata.current;
@@ -295,8 +292,7 @@ bool AP_ESC_Telem::get_voltage(uint8_t esc_index, float& volts) const
 {
     const volatile AP_ESC_Telem_Backend::TelemetryData& telemdata = _telem_data[esc_index];
     if (esc_index >= ESC_TELEM_MAX_ESCS
-        || telemdata.stale()
-        || !(telemdata.types & AP_ESC_Telem_Backend::TelemetryType::VOLTAGE)) {
+        || !telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::VOLTAGE)) {
         return false;
     }
     volts = telemdata.voltage;
@@ -308,8 +304,7 @@ bool AP_ESC_Telem::get_consumption_mah(uint8_t esc_index, float& consumption_mah
 {
     const volatile AP_ESC_Telem_Backend::TelemetryData& telemdata = _telem_data[esc_index];
     if (esc_index >= ESC_TELEM_MAX_ESCS
-        || telemdata.stale()
-        || !(telemdata.types & AP_ESC_Telem_Backend::TelemetryType::CONSUMPTION)) {
+        || !telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::CONSUMPTION)) {
         return false;
     }
     consumption_mah = telemdata.consumption_mah;
@@ -321,8 +316,7 @@ bool AP_ESC_Telem::get_usage_seconds(uint8_t esc_index, uint32_t& usage_s) const
 {
     const volatile AP_ESC_Telem_Backend::TelemetryData& telemdata = _telem_data[esc_index];
     if (esc_index >= ESC_TELEM_MAX_ESCS
-        || telemdata.stale()
-        || !(telemdata.types & AP_ESC_Telem_Backend::TelemetryType::USAGE)) {
+        || !telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::USAGE)) {
         return false;
     }
     usage_s = telemdata.usage_s;
@@ -335,8 +329,7 @@ bool AP_ESC_Telem::get_input_duty(uint8_t esc_index, uint8_t& input_duty) const
 {
     const volatile AP_ESC_Telem_Backend::TelemetryData& telemdata = _telem_data[esc_index];
     if (esc_index >= ESC_TELEM_MAX_ESCS
-        || telemdata.stale()
-        || !(telemdata.types & AP_ESC_Telem_Backend::TelemetryType::INPUT_DUTY)) {
+        || !telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::INPUT_DUTY)) {
         return false;
     }
     input_duty = telemdata.input_duty;
@@ -348,8 +341,7 @@ bool AP_ESC_Telem::get_output_duty(uint8_t esc_index, uint8_t& output_duty) cons
 {
     const volatile AP_ESC_Telem_Backend::TelemetryData& telemdata = _telem_data[esc_index];
     if (esc_index >= ESC_TELEM_MAX_ESCS
-        || telemdata.stale()
-        || !(telemdata.types & AP_ESC_Telem_Backend::TelemetryType::OUTPUT_DUTY)) {
+        || !telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::OUTPUT_DUTY)) {
         return false;
     }
     output_duty = telemdata.output_duty;
@@ -361,8 +353,7 @@ bool AP_ESC_Telem::get_flags(uint8_t esc_index, uint32_t& flags) const
 {
     const volatile AP_ESC_Telem_Backend::TelemetryData& telemdata = _telem_data[esc_index];
     if (esc_index >= ESC_TELEM_MAX_ESCS
-        || telemdata.stale()
-        || !(telemdata.types & AP_ESC_Telem_Backend::TelemetryType::FLAGS)) {
+        || !telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::FLAGS)) {
         return false;
     }
     flags = telemdata.flags;
@@ -374,8 +365,7 @@ bool AP_ESC_Telem::get_power_percentage(uint8_t esc_index, uint8_t& power_percen
 {
     const volatile AP_ESC_Telem_Backend::TelemetryData& telemdata = _telem_data[esc_index];
     if (esc_index >= ESC_TELEM_MAX_ESCS
-        || telemdata.stale()
-        || !(telemdata.types & AP_ESC_Telem_Backend::TelemetryType::POWER_PERCENTAGE)) {
+        || !telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::POWER_PERCENTAGE)) {
         return false;
     }
     power_percentage = telemdata.power_percentage;

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -238,9 +238,12 @@ bool AP_ESC_Telem::get_raw_rpm(uint8_t esc_index, float& rpm) const
 // get an individual ESC's temperature in centi-degrees if available, returns true on success
 bool AP_ESC_Telem::get_temperature(uint8_t esc_index, int16_t& temp) const
 {
+    if (esc_index >= ESC_TELEM_MAX_ESCS) {
+        return false;
+    }
+
     const volatile AP_ESC_Telem_Backend::TelemetryData& telemdata = _telem_data[esc_index];
-    if (esc_index >= ESC_TELEM_MAX_ESCS
-        || !telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE | AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE_EXTERNAL)) {
+    if (!telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE | AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE_EXTERNAL)) {
         return false;
     }
     temp = telemdata.temperature_cdeg;
@@ -250,9 +253,12 @@ bool AP_ESC_Telem::get_temperature(uint8_t esc_index, int16_t& temp) const
 // get an individual motor's temperature in centi-degrees if available, returns true on success
 bool AP_ESC_Telem::get_motor_temperature(uint8_t esc_index, int16_t& temp) const
 {
+    if (esc_index >= ESC_TELEM_MAX_ESCS) {
+        return false;
+    }
+
     const volatile AP_ESC_Telem_Backend::TelemetryData& telemdata = _telem_data[esc_index];
-    if (esc_index >= ESC_TELEM_MAX_ESCS
-         || !telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::MOTOR_TEMPERATURE | AP_ESC_Telem_Backend::TelemetryType::MOTOR_TEMPERATURE_EXTERNAL)) {
+    if (!telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::MOTOR_TEMPERATURE | AP_ESC_Telem_Backend::TelemetryType::MOTOR_TEMPERATURE_EXTERNAL)) {
         return false;
     }
     temp = telemdata.motor_temp_cdeg;
@@ -278,9 +284,12 @@ bool AP_ESC_Telem::get_highest_temperature(int16_t& temp) const
 // get an individual ESC's current in Ampere if available, returns true on success
 bool AP_ESC_Telem::get_current(uint8_t esc_index, float& amps) const
 {
+    if (esc_index >= ESC_TELEM_MAX_ESCS) {
+        return false;
+    }
+
     const volatile AP_ESC_Telem_Backend::TelemetryData& telemdata = _telem_data[esc_index];
-    if (esc_index >= ESC_TELEM_MAX_ESCS
-        || !telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::CURRENT)) {
+    if (!telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::CURRENT)) {
         return false;
     }
     amps = telemdata.current;
@@ -290,9 +299,12 @@ bool AP_ESC_Telem::get_current(uint8_t esc_index, float& amps) const
 // get an individual ESC's voltage in Volt if available, returns true on success
 bool AP_ESC_Telem::get_voltage(uint8_t esc_index, float& volts) const
 {
+    if (esc_index >= ESC_TELEM_MAX_ESCS) {
+        return false;
+    }
+
     const volatile AP_ESC_Telem_Backend::TelemetryData& telemdata = _telem_data[esc_index];
-    if (esc_index >= ESC_TELEM_MAX_ESCS
-        || !telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::VOLTAGE)) {
+    if (!telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::VOLTAGE)) {
         return false;
     }
     volts = telemdata.voltage;
@@ -302,9 +314,12 @@ bool AP_ESC_Telem::get_voltage(uint8_t esc_index, float& volts) const
 // get an individual ESC's energy consumption in milli-Ampere.hour if available, returns true on success
 bool AP_ESC_Telem::get_consumption_mah(uint8_t esc_index, float& consumption_mah) const
 {
+    if (esc_index >= ESC_TELEM_MAX_ESCS) {
+        return false;
+    }
+
     const volatile AP_ESC_Telem_Backend::TelemetryData& telemdata = _telem_data[esc_index];
-    if (esc_index >= ESC_TELEM_MAX_ESCS
-        || !telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::CONSUMPTION)) {
+    if (!telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::CONSUMPTION)) {
         return false;
     }
     consumption_mah = telemdata.consumption_mah;
@@ -314,9 +329,12 @@ bool AP_ESC_Telem::get_consumption_mah(uint8_t esc_index, float& consumption_mah
 // get an individual ESC's usage time in seconds if available, returns true on success
 bool AP_ESC_Telem::get_usage_seconds(uint8_t esc_index, uint32_t& usage_s) const
 {
+    if (esc_index >= ESC_TELEM_MAX_ESCS) {
+        return false;
+    }
+
     const volatile AP_ESC_Telem_Backend::TelemetryData& telemdata = _telem_data[esc_index];
-    if (esc_index >= ESC_TELEM_MAX_ESCS
-        || !telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::USAGE)) {
+    if (!telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::USAGE)) {
         return false;
     }
     usage_s = telemdata.usage_s;
@@ -327,9 +345,12 @@ bool AP_ESC_Telem::get_usage_seconds(uint8_t esc_index, uint32_t& usage_s) const
 // get an individual ESC's input duty cycle if available, returns true on success
 bool AP_ESC_Telem::get_input_duty(uint8_t esc_index, uint8_t& input_duty) const
 {
+    if (esc_index >= ESC_TELEM_MAX_ESCS) {
+        return false;
+    }
+
     const volatile AP_ESC_Telem_Backend::TelemetryData& telemdata = _telem_data[esc_index];
-    if (esc_index >= ESC_TELEM_MAX_ESCS
-        || !telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::INPUT_DUTY)) {
+    if (!telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::INPUT_DUTY)) {
         return false;
     }
     input_duty = telemdata.input_duty;
@@ -339,9 +360,12 @@ bool AP_ESC_Telem::get_input_duty(uint8_t esc_index, uint8_t& input_duty) const
 // get an individual ESC's output duty cycle if available, returns true on success
 bool AP_ESC_Telem::get_output_duty(uint8_t esc_index, uint8_t& output_duty) const
 {
+    if (esc_index >= ESC_TELEM_MAX_ESCS) {
+        return false;
+    }
+
     const volatile AP_ESC_Telem_Backend::TelemetryData& telemdata = _telem_data[esc_index];
-    if (esc_index >= ESC_TELEM_MAX_ESCS
-        || !telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::OUTPUT_DUTY)) {
+    if (!telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::OUTPUT_DUTY)) {
         return false;
     }
     output_duty = telemdata.output_duty;
@@ -351,9 +375,12 @@ bool AP_ESC_Telem::get_output_duty(uint8_t esc_index, uint8_t& output_duty) cons
 // get an individual ESC's status flags if available, returns true on success
 bool AP_ESC_Telem::get_flags(uint8_t esc_index, uint32_t& flags) const
 {
+    if (esc_index >= ESC_TELEM_MAX_ESCS) {
+        return false;
+    }
+
     const volatile AP_ESC_Telem_Backend::TelemetryData& telemdata = _telem_data[esc_index];
-    if (esc_index >= ESC_TELEM_MAX_ESCS
-        || !telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::FLAGS)) {
+    if (!telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::FLAGS)) {
         return false;
     }
     flags = telemdata.flags;
@@ -363,9 +390,12 @@ bool AP_ESC_Telem::get_flags(uint8_t esc_index, uint32_t& flags) const
 // get an individual ESC's percentage of output power if available, returns true on success
 bool AP_ESC_Telem::get_power_percentage(uint8_t esc_index, uint8_t& power_percentage) const
 {
+    if (esc_index >= ESC_TELEM_MAX_ESCS) {
+        return false;
+    }
+
     const volatile AP_ESC_Telem_Backend::TelemetryData& telemdata = _telem_data[esc_index];
-    if (esc_index >= ESC_TELEM_MAX_ESCS
-        || !telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::POWER_PERCENTAGE)) {
+    if (!telemdata.valid(AP_ESC_Telem_Backend::TelemetryType::POWER_PERCENTAGE)) {
         return false;
     }
     power_percentage = telemdata.power_percentage;

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -329,6 +329,60 @@ bool AP_ESC_Telem::get_usage_seconds(uint8_t esc_index, uint32_t& usage_s) const
     return true;
 }
 
+#if AP_EXTENDED_ESC_TELEM_ENABLED
+// get an individual ESC's input duty cycle if available, returns true on success
+bool AP_ESC_Telem::get_input_duty(uint8_t esc_index, uint8_t& input_duty) const
+{
+    const volatile AP_ESC_Telem_Backend::TelemetryData& telemdata = _telem_data[esc_index];
+    if (esc_index >= ESC_TELEM_MAX_ESCS
+        || telemdata.stale()
+        || !(telemdata.types & AP_ESC_Telem_Backend::TelemetryType::INPUT_DUTY)) {
+        return false;
+    }
+    input_duty = telemdata.input_duty;
+    return true;
+}
+
+// get an individual ESC's output duty cycle if available, returns true on success
+bool AP_ESC_Telem::get_output_duty(uint8_t esc_index, uint8_t& output_duty) const
+{
+    const volatile AP_ESC_Telem_Backend::TelemetryData& telemdata = _telem_data[esc_index];
+    if (esc_index >= ESC_TELEM_MAX_ESCS
+        || telemdata.stale()
+        || !(telemdata.types & AP_ESC_Telem_Backend::TelemetryType::OUTPUT_DUTY)) {
+        return false;
+    }
+    output_duty = telemdata.output_duty;
+    return true;
+}
+
+// get an individual ESC's status flags if available, returns true on success
+bool AP_ESC_Telem::get_flags(uint8_t esc_index, uint32_t& flags) const
+{
+    const volatile AP_ESC_Telem_Backend::TelemetryData& telemdata = _telem_data[esc_index];
+    if (esc_index >= ESC_TELEM_MAX_ESCS
+        || telemdata.stale()
+        || !(telemdata.types & AP_ESC_Telem_Backend::TelemetryType::FLAGS)) {
+        return false;
+    }
+    flags = telemdata.flags;
+    return true;
+}
+
+// get an individual ESC's percentage of output power if available, returns true on success
+bool AP_ESC_Telem::get_power_percentage(uint8_t esc_index, uint8_t& power_percentage) const
+{
+    const volatile AP_ESC_Telem_Backend::TelemetryData& telemdata = _telem_data[esc_index];
+    if (esc_index >= ESC_TELEM_MAX_ESCS
+        || telemdata.stale()
+        || !(telemdata.types & AP_ESC_Telem_Backend::TelemetryType::POWER_PERCENTAGE)) {
+        return false;
+    }
+    power_percentage = telemdata.power_percentage;
+    return true;
+}
+#endif // AP_EXTENDED_ESC_TELEM_ENABLED
+
 // send ESC telemetry messages over MAVLink
 void AP_ESC_Telem::send_esc_telemetry_mavlink(uint8_t mav_chan)
 {

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.h
@@ -69,6 +69,20 @@ public:
     // get an individual ESC's consumption in milli-Ampere.hour if available, returns true on success
     bool get_consumption_mah(uint8_t esc_index, float& consumption_mah) const;
 
+#if AP_EXTENDED_ESC_TELEM_ENABLED
+    // get an individual ESC's input duty cycle if available, returns true on success
+    bool get_input_duty(uint8_t esc_index, uint8_t& input_duty) const;
+
+    // get an individual ESC's output duty cycle if available, returns true on success
+    bool get_output_duty(uint8_t esc_index, uint8_t& output_duty) const;
+
+    // get an individual ESC's status flags if available, returns true on success
+    bool get_flags(uint8_t esc_index, uint32_t& flags) const;
+
+    // get an individual ESC's percentage of output power if available, returns true on success
+    bool get_power_percentage(uint8_t esc_index, uint8_t& power_percentage) const;
+#endif
+
     // return the average motor frequency in Hz for dynamic filtering
     float get_average_motor_frequency_hz(uint32_t servo_channel_mask) const { return get_average_motor_rpm(servo_channel_mask) * (1.0f / 60.0f); };
 

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem_Backend.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem_Backend.cpp
@@ -50,10 +50,19 @@ void AP_ESC_Telem_Backend::update_telem_data(const uint8_t esc_index, const Tele
  */
 bool AP_ESC_Telem_Backend::TelemetryData::stale(uint32_t now_ms) const volatile
 {
-    if (now_ms == 0) {
-        now_ms = AP_HAL::millis();
-    }
     return last_update_ms == 0 || now_ms - last_update_ms > ESC_TELEM_DATA_TIMEOUT_MS;
+}
+
+/*
+  return true if the requested types of data are available and not stale
+ */
+bool AP_ESC_Telem_Backend::TelemetryData::valid(const uint16_t type_mask) const volatile
+{
+    if ((types & type_mask) == 0) {
+        // Requested type not available
+        return false;
+    }
+    return !stale(AP_HAL::millis());
 }
 
 #endif

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem_Backend.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem_Backend.h
@@ -31,7 +31,10 @@ public:
 #endif // AP_EXTENDED_ESC_TELEM_ENABLED
 
         // return true if the data is stale
-        bool stale(uint32_t now_ms=0) const volatile;
+        bool stale(uint32_t now_ms) const volatile;
+
+        //  return true if the requested type of data is available and not stale
+        bool valid(const uint16_t type_mask) const volatile;
     };
 
     struct RpmData {

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem_SITL.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem_SITL.cpp
@@ -71,13 +71,28 @@ void AP_ESC_Telem_SITL::update()
             .voltage = 16.8f,
             .current = 0.8f,
             .consumption_mah = 1.0f,
+            .motor_temp_cdeg = 3500,
+#if AP_EXTENDED_ESC_TELEM_ENABLED
+            .input_duty = 1,
+            .output_duty = 2,
+            .flags = 3,
+            .power_percentage = 4,
+#endif
         };
 
         update_telem_data(motor, t,
             AP_ESC_Telem_Backend::TelemetryType::CURRENT
                 | AP_ESC_Telem_Backend::TelemetryType::VOLTAGE
                 | AP_ESC_Telem_Backend::TelemetryType::CONSUMPTION
-                | AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE);
+                | AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE
+                | AP_ESC_Telem_Backend::TelemetryType::MOTOR_TEMPERATURE
+#if AP_EXTENDED_ESC_TELEM_ENABLED
+                | AP_ESC_Telem_Backend::TelemetryType::POWER_PERCENTAGE
+                | AP_ESC_Telem_Backend::TelemetryType::INPUT_DUTY
+                | AP_ESC_Telem_Backend::TelemetryType::OUTPUT_DUTY
+                | AP_ESC_Telem_Backend::TelemetryType::FLAGS
+#endif
+                );
     }
 #endif
 }


### PR DESCRIPTION
This builds on https://github.com/ArduPilot/ardupilot/pull/27771 to allow testing of both it and https://github.com/ArduPilot/ardupilot/pull/27755.

They do work:
![image](https://github.com/user-attachments/assets/c9bd1cc1-d5b9-4aee-9119-5981a5606933)

On Periph this is not enabled by default. If it is enabled it sends each ESC in turn such that they are each sent at the set `ESC_EXT_TLM_RATE`, by default this is 10 times lower than the default ESC status message rate.  

I had to add getters into AP_ESC_Telem for periph to read the values. I also added some token values to the SITL esc backend. 

I have also added a helper to ESC telem for the get functions to check the type bitmask and if the data is stale in one call. 

