### PR TITLE
Use ifdefs to remove more code around RC option code

### DIFF
--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -87,7 +87,9 @@ void RC_Channel_Copter::init_aux_function(const AUX_FUNC ch_option, const AuxSwi
     case AUX_FUNC::GUIDED:
     case AUX_FUNC::LAND:
     case AUX_FUNC::LOITER:
+#if HAL_PARACHUTE_ENABLED
     case AUX_FUNC::PARACHUTE_RELEASE:
+#endif
     case AUX_FUNC::POSHOLD:
     case AUX_FUNC::RESETTOARMEDYAW:
     case AUX_FUNC::RTL:
@@ -99,7 +101,9 @@ void RC_Channel_Copter::init_aux_function(const AUX_FUNC ch_option, const AuxSwi
     case AUX_FUNC::USER_FUNC1:
     case AUX_FUNC::USER_FUNC2:
     case AUX_FUNC::USER_FUNC3:
+#if AP_WINCH_ENABLED
     case AUX_FUNC::WINCH_CONTROL:
+#endif
     case AUX_FUNC::ZIGZAG:
     case AUX_FUNC::ZIGZAG_Auto:
     case AUX_FUNC::ZIGZAG_SaveWP:
@@ -116,15 +120,21 @@ void RC_Channel_Copter::init_aux_function(const AUX_FUNC ch_option, const AuxSwi
     case AUX_FUNC::ATTCON_FEEDFWD:
     case AUX_FUNC::INVERTED:
     case AUX_FUNC::MOTOR_INTERLOCK:
+#if HAL_PARACHUTE_ENABLED
     case AUX_FUNC::PARACHUTE_3POS:      // we trust the vehicle will be disarmed so even if switch is in release position the chute will not release
     case AUX_FUNC::PARACHUTE_ENABLE:
+#endif
     case AUX_FUNC::PRECISION_LOITER:
+#if AP_RANGEFINDER_ENABLED
     case AUX_FUNC::RANGEFINDER:
+#endif
     case AUX_FUNC::SIMPLE_MODE:
     case AUX_FUNC::STANDBY:
     case AUX_FUNC::SUPERSIMPLE_MODE:
     case AUX_FUNC::SURFACE_TRACKING:
+#if AP_WINCH_ENABLED
     case AUX_FUNC::WINCH_ENABLE:
+#endif
     case AUX_FUNC::AIRMODE:
     case AUX_FUNC::FORCEFLYING:
     case AUX_FUNC::CUSTOM_CONTROLLER:
@@ -270,7 +280,7 @@ bool RC_Channel_Copter::do_aux_function(const AUX_FUNC ch_option, const AuxSwitc
                 copter.rangefinder_state.enabled = false;
             }
             break;
-#endif
+#endif // AP_RANGEFINDER_ENABLED
 
 #if MODE_ACRO_ENABLED
         case AUX_FUNC::ACRO_TRAINER:
@@ -343,7 +353,7 @@ bool RC_Channel_Copter::do_aux_function(const AUX_FUNC ch_option, const AuxSwitc
                     break;
             }
             break;
-#endif
+#endif  // HAL_PARACHUTE_ENABLED
 
         case AUX_FUNC::ATTCON_FEEDFWD:
             // enable or disable feed forward
@@ -451,11 +461,11 @@ bool RC_Channel_Copter::do_aux_function(const AUX_FUNC ch_option, const AuxSwitc
                     break;
                 }
             break;
-#endif
 
         case AUX_FUNC::WINCH_CONTROL:
             // do nothing, used to control the rate of the winch and is processed within AP_Winch
             break;
+#endif  // AP_WINCH_ENABLED
 
 #ifdef USERHOOK_AUXSWITCH
         case AUX_FUNC::USER_FUNC1:

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1362,9 +1362,15 @@ struct RCConversionInfo {
 static const RCConversionInfo rc_option_conversion[] = {
     { Parameters::k_param_flapin_channel_old, 0, RC_Channel::AUX_FUNC::FLAP},
     { Parameters::k_param_g2, 968, RC_Channel::AUX_FUNC::SOARING},
+#if AP_FENCE_ENABLED
     { Parameters::k_param_fence_channel, 0, RC_Channel::AUX_FUNC::FENCE},
+#endif
+#if AP_MISSION_ENABLED
     { Parameters::k_param_reset_mission_chan, 0, RC_Channel::AUX_FUNC::MISSION_RESET},
+#endif
+#if HAL_PARACHUTE_ENABLED
     { Parameters::k_param_parachute_channel, 0, RC_Channel::AUX_FUNC::PARACHUTE_RELEASE},
+#endif
     { Parameters::k_param_fbwa_tdrag_chan, 0, RC_Channel::AUX_FUNC::FBWA_TAILDRAGGER},
     { Parameters::k_param_reset_switch_chan, 0, RC_Channel::AUX_FUNC::MODE_SWITCH_RESET},
 };

--- a/ArduPlane/RC_Channel.cpp
+++ b/ArduPlane/RC_Channel.cpp
@@ -157,7 +157,9 @@ void RC_Channel_Plane::init_aux_function(const RC_Channel::AUX_FUNC ch_option,
     case AUX_FUNC::FBWA_TAILDRAGGER:
     case AUX_FUNC::FWD_THR:
     case AUX_FUNC::LANDING_FLARE:
+#if HAL_PARACHUTE_ENABLED
     case AUX_FUNC::PARACHUTE_RELEASE:
+#endif
     case AUX_FUNC::MODE_SWITCH_RESET:
     case AUX_FUNC::CRUISE:
 #if HAL_QUADPLANE_ENABLED

--- a/libraries/AP_Parachute/AP_Parachute.h
+++ b/libraries/AP_Parachute/AP_Parachute.h
@@ -2,6 +2,10 @@
 /// @brief  Parachute release library
 #pragma once
 
+#include "AP_Parachute_config.h"
+
+#if HAL_PARACHUTE_ENABLED
+
 #include <AP_Param/AP_Param.h>
 #include <AP_Common/AP_Common.h>
 
@@ -21,13 +25,6 @@
 
 #define AP_PARACHUTE_CRITICAL_SINK_DEFAULT      0      // default critical sink speed in m/s to trigger emergency parachute
 #define AP_PARACHUTE_OPTIONS_DEFAULT            0      // default parachute options: enabled disarm after parachute release
-
-#ifndef HAL_PARACHUTE_ENABLED
-// default to parachute enabled to match previous configs
-#define HAL_PARACHUTE_ENABLED 1
-#endif
-
-#if HAL_PARACHUTE_ENABLED
 
 /// @class  AP_Parachute
 /// @brief  Class managing the release of a parachute

--- a/libraries/AP_Parachute/AP_Parachute_config.h
+++ b/libraries/AP_Parachute/AP_Parachute_config.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <AP_HAL/AP_HAL_Boards.h>
+
+#ifndef HAL_PARACHUTE_ENABLED
+// default to parachute enabled to match previous configs
+#define HAL_PARACHUTE_ENABLED 1
+#endif

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -59,6 +59,7 @@ extern const AP_HAL::HAL& hal;
 #include <AP_VideoTX/AP_VideoTX.h>
 #include <AP_Torqeedo/AP_Torqeedo.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
+#include <AP_Parachute/AP_Parachute_config.h>
 #define SWITCH_DEBOUNCE_TIME_MS  200
 
 const AP_Param::GroupInfo RC_Channel::var_info[] = {
@@ -628,17 +629,23 @@ void RC_Channel::init_aux_function(const AUX_FUNC ch_option, const AuxSwitchPos 
     // init channel options
     switch (ch_option) {
     // the following functions do not need to be initialised:
+#if AP_ARMING_ENABLED
     case AUX_FUNC::ARMDISARM:
     case AUX_FUNC::ARMDISARM_AIRMODE:
+#endif
 #if AP_BATTERY_ENABLED
     case AUX_FUNC::BATTERY_MPPT_ENABLE:
 #endif
 #if AP_CAMERA_ENABLED
     case AUX_FUNC::CAMERA_TRIGGER:
 #endif
+#if AP_MISSION_ENABLED
     case AUX_FUNC::CLEAR_WP:
+#endif
     case AUX_FUNC::COMPASS_LEARN:
+#if AP_ARMING_ENABLED
     case AUX_FUNC::DISARM:
+#endif
     case AUX_FUNC::DO_NOTHING:
 #if AP_LANDINGGEAR_ENABLED
     case AUX_FUNC::LANDING_GEAR:
@@ -655,12 +662,16 @@ void RC_Channel::init_aux_function(const AUX_FUNC ch_option, const AuxSwitchPos 
 #if HAL_VISUALODOM_ENABLED
     case AUX_FUNC::VISODOM_ALIGN:
 #endif
+#if AP_AHRS_ENABLED
     case AUX_FUNC::EKF_LANE_SWITCH:
     case AUX_FUNC::EKF_YAW_RESET:
+#endif
 #if HAL_GENERATOR_ENABLED
     case AUX_FUNC::GENERATOR: // don't turn generator on or off initially
 #endif
+#if AP_AHRS_ENABLED
     case AUX_FUNC::EKF_POS_SOURCE:
+#endif
 #if HAL_TORQEEDO_ENABLED
     case AUX_FUNC::TORQEEDO_CLEAR_ERR:
 #endif
@@ -689,19 +700,23 @@ void RC_Channel::init_aux_function(const AUX_FUNC ch_option, const AuxSwitchPos 
     case AUX_FUNC::MOUNT2_PITCH:
     case AUX_FUNC::MOUNT2_YAW:
 #endif
+#if HAL_GENERATOR_ENABLED
     case AUX_FUNC::LOWEHEISER_STARTER:
+#endif
+#if COMPASS_CAL_ENABLED
     case AUX_FUNC::MAG_CAL:
+#endif
 #if AP_CAMERA_ENABLED
     case AUX_FUNC::CAMERA_IMAGE_TRACKING:
 #endif
 #if HAL_MOUNT_ENABLED
     case AUX_FUNC::MOUNT_LRF_ENABLE:
 #endif
+#if HAL_GENERATOR_ENABLED
+    case AUX_FUNC::LOWEHEISER_THROTTLE:
+#endif
         break;
 
-    // not really aux functions:
-    case AUX_FUNC::LOWEHEISER_THROTTLE:
-        break;
 #if HAL_ADSB_ENABLED
     case AUX_FUNC::AVOID_ADSB:
 #endif
@@ -721,7 +736,9 @@ void RC_Channel::init_aux_function(const AUX_FUNC ch_option, const AuxSwitchPos 
     case AUX_FUNC::KILL_IMU2:
     case AUX_FUNC::KILL_IMU3:
 #endif
+#if AP_MISSION_ENABLED
     case AUX_FUNC::MISSION_RESET:
+#endif
     case AUX_FUNC::MOTOR_ESTOP:
     case AUX_FUNC::RC_OVERRIDE_ENABLE:
 #if HAL_RUNCAM_ENABLED
@@ -731,7 +748,9 @@ void RC_Channel::init_aux_function(const AUX_FUNC ch_option, const AuxSwitchPos 
 #if HAL_SPRAYER_ENABLED
     case AUX_FUNC::SPRAYER:
 #endif
+#if AP_AIRSPEED_ENABLED
     case AUX_FUNC::DISABLE_AIRSPEED_USE:
+#endif
     case AUX_FUNC::FFT_NOTCH_TUNE:
 #if HAL_MOUNT_ENABLED
     case AUX_FUNC::RETRACT_MOUNT1:
@@ -749,9 +768,11 @@ void RC_Channel::init_aux_function(const AUX_FUNC ch_option, const AuxSwitchPos 
     case AUX_FUNC::CAMERA_AUTO_FOCUS:
     case AUX_FUNC::CAMERA_LENS:
 #endif
+#if AP_AHRS_ENABLED
     case AUX_FUNC::AHRS_TYPE:
         run_aux_function(ch_option, ch_flag, AuxFuncTriggerSource::INIT);
         break;
+#endif
     default:
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Failed to init: RC%u_OPTION: %u\n",
                         (unsigned)(this->ch_in+1), (unsigned)ch_option);
@@ -766,61 +787,111 @@ void RC_Channel::init_aux_function(const AUX_FUNC ch_option, const AuxSwitchPos 
 #if AP_RC_CHANNEL_AUX_FUNCTION_STRINGS_ENABLED
 
 const RC_Channel::LookupTable RC_Channel::lookuptable[] = {
+#if AP_MISSION_ENABLED
     { AUX_FUNC::SAVE_WP,"SaveWaypoint"},
+#endif
+#if AP_CAMERA_ENABLED
     { AUX_FUNC::CAMERA_TRIGGER,"CameraTrigger"},
+#endif
+#if AP_RANGEFINDER_ENABLED
     { AUX_FUNC::RANGEFINDER,"Rangefinder"},
+#endif
+#if AP_FENCE_ENABLED
     { AUX_FUNC::FENCE,"Fence"},
+#endif
+#if HAL_SPRAYER_ENABLED
     { AUX_FUNC::SPRAYER,"Sprayer"},
+#endif
+#if HAL_PARACHUTE_ENABLED
     { AUX_FUNC::PARACHUTE_ENABLE,"ParachuteEnable"},
     { AUX_FUNC::PARACHUTE_RELEASE,"ParachuteRelease"},
     { AUX_FUNC::PARACHUTE_3POS,"Parachute3Position"},
+#endif
+#if AP_MISSION_ENABLED
     { AUX_FUNC::MISSION_RESET,"MissionReset"},
+#endif
 #if HAL_MOUNT_ENABLED
     { AUX_FUNC::RETRACT_MOUNT1,"RetractMount1"},
     { AUX_FUNC::RETRACT_MOUNT2,"RetractMount2"},
 #endif
+#if AP_SERVORELAYEVENTS_ENABLED && AP_RELAY_ENABLED
     { AUX_FUNC::RELAY,"Relay1"},
+#endif
     { AUX_FUNC::MOTOR_ESTOP,"MotorEStop"},
     { AUX_FUNC::MOTOR_INTERLOCK,"MotorInterlock"},
+#if AP_SERVORELAYEVENTS_ENABLED && AP_RELAY_ENABLED
     { AUX_FUNC::RELAY2,"Relay2"},
     { AUX_FUNC::RELAY3,"Relay3"},
     { AUX_FUNC::RELAY4,"Relay4"},
+#endif
     { AUX_FUNC::PRECISION_LOITER,"PrecisionLoiter"},
     { AUX_FUNC::AVOID_PROXIMITY,"AvoidProximity"},
+#if AP_WINCH_ENABLED
     { AUX_FUNC::WINCH_ENABLE,"WinchEnable"},
     { AUX_FUNC::WINCH_CONTROL,"WinchControl"},
+#endif
+#if AP_MISSION_ENABLED
     { AUX_FUNC::CLEAR_WP,"ClearWaypoint"},
+#endif
     { AUX_FUNC::COMPASS_LEARN,"CompassLearn"},
     { AUX_FUNC::SAILBOAT_TACK,"SailboatTack"},
+#if AP_GPS_ENABLED
     { AUX_FUNC::GPS_DISABLE,"GPSDisable"},
     { AUX_FUNC::GPS_DISABLE_YAW,"GPSDisableYaw"},
+#endif
+#if AP_AIRSPEED_ENABLED
     { AUX_FUNC::DISABLE_AIRSPEED_USE,"DisableAirspeedUse"},
+#endif
+#if AP_SERVORELAYEVENTS_ENABLED && AP_RELAY_ENABLED
     { AUX_FUNC::RELAY5,"Relay5"},
     { AUX_FUNC::RELAY6,"Relay6"},
+#endif
     { AUX_FUNC::SAILBOAT_MOTOR_3POS,"SailboatMotor"},
     { AUX_FUNC::SURFACE_TRACKING,"SurfaceTracking"},
+#if HAL_RUNCAM_ENABLED
     { AUX_FUNC::RUNCAM_CONTROL,"RunCamControl"},
     { AUX_FUNC::RUNCAM_OSD_CONTROL,"RunCamOSDControl"},
+#endif
+#if HAL_VISUALODOM_ENABLED
     { AUX_FUNC::VISODOM_ALIGN,"VisOdomAlign"},
+#endif
     { AUX_FUNC::AIRMODE, "AirMode"},
+#if AP_CAMERA_ENABLED
     { AUX_FUNC::CAM_MODE_TOGGLE,"CamModeToggle"},
+#endif
+#if HAL_GENERATOR_ENABLED
     { AUX_FUNC::GENERATOR,"Generator"},
+#endif
+#if AP_BATTERY_ENABLED
     { AUX_FUNC::BATTERY_MPPT_ENABLE,"Battery MPPT Enable"},
+#endif
+#if AP_AIRSPEED_AUTOCAL_ENABLE
     { AUX_FUNC::ARSPD_CALIBRATE,"Calibrate Airspeed"},
+#endif
+#if HAL_TORQEEDO_ENABLED
     { AUX_FUNC::TORQEEDO_CLEAR_ERR, "Torqeedo Clear Err"},
+#endif
     { AUX_FUNC::EMERGENCY_LANDING_EN, "Emergency Landing"},
     { AUX_FUNC::WEATHER_VANE_ENABLE, "Weathervane"},
     { AUX_FUNC::TURBINE_START, "Turbine Start"},
     { AUX_FUNC::FFT_NOTCH_TUNE, "FFT Notch Tuning"},
+#if HAL_MOUNT_ENABLED
     { AUX_FUNC::MOUNT_LOCK, "MountLock"},
+#endif
+#if HAL_LOGGING_ENABLED
     { AUX_FUNC::LOG_PAUSE, "Pause Stream Logging"},
+#endif
+#if AP_CAMERA_ENABLED
     { AUX_FUNC::CAMERA_REC_VIDEO, "Camera Record Video"},
     { AUX_FUNC::CAMERA_ZOOM, "Camera Zoom"},
     { AUX_FUNC::CAMERA_MANUAL_FOCUS, "Camera Manual Focus"},
     { AUX_FUNC::CAMERA_AUTO_FOCUS, "Camera Auto Focus"},
     { AUX_FUNC::CAMERA_IMAGE_TRACKING, "Camera Image Tracking"},
     { AUX_FUNC::CAMERA_LENS, "Camera Lens"},
+#endif
+#if HAL_MOUNT_ENABLED
     { AUX_FUNC::MOUNT_LRF_ENABLE, "Mount LRF Enable"},
+#endif
 };
 
 /* lookup the announcement for switch change */
@@ -910,10 +981,14 @@ bool RC_Channel::read_aux()
 bool RC_Channel::init_position_on_first_radio_read(AUX_FUNC func) const
 {
     switch (func) {
+#if AP_ARMING_ENABLED
     case AUX_FUNC::ARMDISARM_AIRMODE:
     case AUX_FUNC::ARMDISARM:
     case AUX_FUNC::ARM_EMERGENCY_STOP:
+#endif
+#if HAL_PARACHUTE_ENABLED
     case AUX_FUNC::PARACHUTE_RELEASE:
+#endif
 
         // we do not want to process 
         return true;
@@ -1408,12 +1483,14 @@ bool RC_Channel::do_aux_function(const AUX_FUNC ch_option, const AuxSwitchPos ch
         break;
 #endif
 
+#if AP_MISSION_ENABLED
     case AUX_FUNC::CLEAR_WP:
         do_aux_function_clear_wp(ch_flag);
         break;
     case AUX_FUNC::MISSION_RESET:
         do_aux_function_mission_reset(ch_flag);
         break;
+#endif
 
 #if HAL_ADSB_ENABLED
     case AUX_FUNC::AVOID_ADSB:
@@ -1449,6 +1526,7 @@ bool RC_Channel::do_aux_function(const AUX_FUNC ch_option, const AuxSwitchPos ch
         do_aux_function_lost_vehicle_sound(ch_flag);
         break;
 
+#if AP_ARMING_ENABLED
     case AUX_FUNC::ARMDISARM:
         do_aux_function_armdisarm(ch_flag);
         break;
@@ -1458,6 +1536,7 @@ bool RC_Channel::do_aux_function(const AUX_FUNC ch_option, const AuxSwitchPos ch
             AP::arming().disarm(AP_Arming::Method::AUXSWITCH);
         }
         break;
+#endif
 
     case AUX_FUNC::COMPASS_LEARN:
         if (ch_flag == AuxSwitchPos::HIGH) {
@@ -1734,6 +1813,7 @@ bool RC_Channel::do_aux_function(const AUX_FUNC ch_option, const AuxSwitchPos ch
         break;
     }
 
+#if AP_AHRS_ENABLED
     case AUX_FUNC::EKF_LANE_SWITCH:
         // used to test emergency lane switch
         AP::ahrs().check_lane_switch();
@@ -1750,7 +1830,7 @@ bool RC_Channel::do_aux_function(const AUX_FUNC ch_option, const AuxSwitchPos ch
 #endif
         break;
     }
-        
+#endif  // AP_AHRS_ENABLED
 
 #if HAL_TORQEEDO_ENABLED
     // clear torqeedo error
@@ -1766,12 +1846,15 @@ bool RC_Channel::do_aux_function(const AUX_FUNC ch_option, const AuxSwitchPos ch
 #endif
 
     // do nothing for these functions
+#if HAL_MOUNT_ENABLED
     case AUX_FUNC::MOUNT1_ROLL:
     case AUX_FUNC::MOUNT1_PITCH:
     case AUX_FUNC::MOUNT1_YAW:
     case AUX_FUNC::MOUNT2_ROLL:
     case AUX_FUNC::MOUNT2_PITCH:
     case AUX_FUNC::MOUNT2_YAW:
+#endif
+#if AP_SCRIPTING_ENABLED
     case AUX_FUNC::SCRIPTING_1:
     case AUX_FUNC::SCRIPTING_2:
     case AUX_FUNC::SCRIPTING_3:
@@ -1780,12 +1863,15 @@ bool RC_Channel::do_aux_function(const AUX_FUNC ch_option, const AuxSwitchPos ch
     case AUX_FUNC::SCRIPTING_6:
     case AUX_FUNC::SCRIPTING_7:
     case AUX_FUNC::SCRIPTING_8:
+#endif
         break;
 
+#if HAL_GENERATOR_ENABLED
     case AUX_FUNC::LOWEHEISER_THROTTLE:
     case AUX_FUNC::LOWEHEISER_STARTER:
         // monitored by the library itself
         break;
+#endif
 
     default:
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Invalid channel option (%u)", (unsigned int)ch_option);


### PR DESCRIPTION
Moves us closer to being able to remove `default:` clauses.

```
Board               AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                       *      *           *       *                 *      *      *
KakuteH7-bdshot                *      *           *       *                 *      *      *
MatekF405                      -16    *           -56     -48               -40    -16    -8
Pixhawk1-1M-bdshot             -16                -16     -16               -16    -16    -16
f303-Universal      *
iomcu                                                           *
revo-mini                      -8     *           -8      -8                -16    -8     -16

real    5m21.096s
user    133m52.460s
sys     18m32.352s
```
