### PR TITLE
Add arming check that all defaults in defaults files are used 

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1046,7 +1046,12 @@ bool AP_Arming::system_checks(bool report)
             check_failed(ARMING_CHECK_PARAMETERS, report, "parameter storage full");
             return false;
         }
-        
+
+        if (!AP_Param::all_defaultfile_parameter_values_used()) {
+            check_failed(ARMING_CHECK_PARAMETERS, report, "unknown param %s in parameter defaults file", AP_Param::unused_defaultfile_parameter_name());
+            return false;
+        }
+
         // check main loop rate is at least 90% of expected value
         const float actual_loop_rate = AP::scheduler().get_filtered_loop_rate_hz();
         const uint16_t expected_loop_rate = AP::scheduler().get_loop_rate_hz();

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -119,6 +119,7 @@ ObjectBuffer_TS<AP_Param::param_save> AP_Param::save_queue{30};
 bool AP_Param::registered_save_handler;
 
 bool AP_Param::done_all_default_params;
+char AP_Param::unknown_defaultfile_parameter_name[17];
 
 AP_Param::defaults_list *AP_Param::default_list;
 
@@ -2341,6 +2342,7 @@ bool AP_Param::read_param_defaults_file(const char *filename, bool last_pass, ui
                          "Ignored unknown param %s in defaults file %s\n",
                          pname, filename);
 #endif
+                strncpy(unknown_defaultfile_parameter_name, pname, sizeof(unknown_defaultfile_parameter_name)-1);
             }
             done_all = false;
             continue;

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -614,6 +614,13 @@ public:
 
     static bool load_defaults_file(const char *filename, bool last_pass);
 
+    static bool all_defaultfile_parameter_values_used() {
+        return done_all_default_params;
+    }
+    static const char *unused_defaultfile_parameter_name() {
+        return unknown_defaultfile_parameter_name;
+    }
+
 protected:
 
     // store default value in linked list
@@ -671,6 +678,7 @@ private:
       this is true if when scanning a defaults file we find all of the parameters
      */
     static bool done_all_default_params;
+    static char unknown_defaultfile_parameter_name[17];
 
     /*
       structure for built-in defaults file that can be modified using apj_tool.py


### PR DESCRIPTION
Instant problem on CubeOrange:
```
AP: PreArm: unknown param BATT2_VOLT_MULT in parameter defaults fil
```
