### PR TITLE
Copter/AC_PosControl/Scripting: slung payload oscillation suppression

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -266,9 +266,9 @@ private:
         //   measured ground or ceiling level measured using the range finder.
         void update_surface_offset();
 
-        // get/set target altitude (in cm) above ground
-        bool get_target_alt_cm(float &target_alt_cm) const;
-        void set_target_alt_cm(float target_alt_cm);
+        // target has already been set by terrain following so do not initalise again
+        // this should be called by flight modes when switching from terrain following to surface tracking (e.g. ZigZag)
+        void external_init();
 
         // get target and actual distances (in m) for logging purposes
         bool get_target_dist_for_logging(float &target_dist) const;

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -182,12 +182,6 @@ public:
     // altitude fence
     float get_avoidance_adjusted_climbrate(float target_rate);
 
-    const Vector3f& get_vel_desired_cms() {
-        // note that position control isn't used in every mode, so
-        // this may return bogus data:
-        return pos_control->get_vel_desired_cms();
-    }
-
     // send output to the motors, can be overridden by subclasses
     virtual void output_to_motors();
 
@@ -650,6 +644,10 @@ private:
     SubMode _mode = SubMode::TAKEOFF;   // controls which auto controller is run
 
     bool shift_alt_to_current_alt(Location& target_loc) const;
+
+    // subtract position controller offsets from target location
+    // should be used when the location will be used as a target for the position controller
+    void subtract_pos_offsets(Location& target_loc) const;
 
     void do_takeoff(const AP_Mission::Mission_Command& cmd);
     void do_nav_wp(const AP_Mission::Mission_Command& cmd);

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -498,7 +498,7 @@ void ModeAuto::land_start()
     set_submode(SubMode::LAND);
 }
 
-// auto_circle_movetoedge_start - initialise waypoint controller to move to edge of a circle with it's center at the specified location
+// circle_movetoedge_start - initialise waypoint controller to move to edge of a circle with it's center at the specified location
 //  we assume the caller has performed all required GPS_ok checks
 void ModeAuto::circle_movetoedge_start(const Location &circle_center, float radius_m, bool ccw_turn)
 {

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1419,7 +1419,7 @@ void PayloadPlace::run()
         // vel_threshold_fraction * max velocity
         const float vel_threshold_fraction = 0.1;
         const float stop_distance = 0.5 * sq(vel_threshold_fraction * copter.pos_control->get_max_speed_up_cms()) / copter.pos_control->get_max_accel_z_cmss();
-        bool reached_altitude = copter.pos_control->get_pos_target_z_cm() >= descent_start_altitude_cm - stop_distance;
+        bool reached_altitude = copter.pos_control->get_pos_desired_z_cm() >= descent_start_altitude_cm - stop_distance;
         if (reached_altitude) {
             state = State::Done;
         }
@@ -1472,6 +1472,8 @@ bool ModeAuto::shift_alt_to_current_alt(Location& target_loc) const
         (wp_nav->get_terrain_source() == AC_WPNav::TerrainSource::TERRAIN_FROM_RANGEFINDER)) {
         int32_t curr_rngfnd_alt_cm;
         if (copter.get_rangefinder_height_interpolated_cm(curr_rngfnd_alt_cm)) {
+            // subtract position offset (if any)
+            curr_rngfnd_alt_cm -= pos_control->get_pos_offset_z_cm();
             // wp_nav is using rangefinder so use current rangefinder alt
             target_loc.set_alt_cm(MAX(curr_rngfnd_alt_cm, 200), Location::AltFrame::ABOVE_TERRAIN);
             return true;
@@ -1486,9 +1488,19 @@ bool ModeAuto::shift_alt_to_current_alt(Location& target_loc) const
         return false;
     }
 
-    // set target_loc's alt
-    target_loc.set_alt_cm(currloc.alt, currloc.get_alt_frame());
+    // set target_loc's alt minus position offset (if any)
+    target_loc.set_alt_cm(currloc.alt - pos_control->get_pos_offset_z_cm(), currloc.get_alt_frame());
     return true;
+}
+
+// subtract position controller offsets from target location
+// should be used when the location will be used as a target for the position controller
+void ModeAuto::subtract_pos_offsets(Location& target_loc) const
+{
+    // subtract position controller offsets from target location
+    const Vector3p& pos_ofs_neu_cm = pos_control->get_pos_offset_cm();
+    Vector3p pos_ofs_ned_m = Vector3p{pos_ofs_neu_cm.x * 0.01, pos_ofs_neu_cm.y * 0.01, -pos_ofs_neu_cm.z * 0.01};
+    target_loc.offset(-pos_ofs_ned_m);
 }
 
 /********************************************************************************/
@@ -1531,6 +1543,10 @@ void ModeAuto::do_nav_wp(const AP_Mission::Mission_Command& cmd)
 {
     // calculate default location used when lat, lon or alt is zero
     Location default_loc = copter.current_loc;
+
+    // subtract position offsets
+    subtract_pos_offsets(default_loc);
+
     if (wp_nav->is_active() && wp_nav->reached_wp_destination()) {
         if (!wp_nav->get_wp_destination_loc(default_loc)) {
             // this should never happen
@@ -1651,32 +1667,22 @@ void ModeAuto::do_land(const AP_Mission::Mission_Command& cmd)
 // note: caller should set yaw_mode
 void ModeAuto::do_loiter_unlimited(const AP_Mission::Mission_Command& cmd)
 {
-    // convert back to location
-    Location target_loc(cmd.content.location);
+    // calculate default location used when lat, lon or alt is zero
+    Location default_loc = copter.current_loc;
 
-    // use current location if not provided
-    if (target_loc.lat == 0 && target_loc.lng == 0) {
-        // To-Do: make this simpler
-        Vector3f temp_pos;
-        copter.wp_nav->get_wp_stopping_point_xy(temp_pos.xy());
-        const Location temp_loc(temp_pos, Location::AltFrame::ABOVE_ORIGIN);
-        target_loc.lat = temp_loc.lat;
-        target_loc.lng = temp_loc.lng;
-    }
+    // subtract position offsets
+    subtract_pos_offsets(default_loc);
 
-    // use current altitude if not provided
-    // To-Do: use z-axis stopping point instead of current alt
-    if (target_loc.alt == 0) {
-        // set to current altitude but in command's alt frame
-        int32_t curr_alt;
-        if (copter.current_loc.get_alt_cm(target_loc.get_alt_frame(),curr_alt)) {
-            target_loc.set_alt_cm(curr_alt, target_loc.get_alt_frame());
-        } else {
-            // default to current altitude as alt-above-home
-            target_loc.set_alt_cm(copter.current_loc.alt,
-                                  copter.current_loc.get_alt_frame());
+    // use previous waypoint destination as default if available
+    if (wp_nav->is_active() && wp_nav->reached_wp_destination()) {
+        if (!wp_nav->get_wp_destination_loc(default_loc)) {
+            // this should never happen
+            INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
         }
     }
+
+    // get waypoint's location from command and send to wp_nav
+    const Location target_loc = loc_from_cmd(cmd, default_loc);
 
     // start way point navigator and provide it the desired location
     if (!wp_start(target_loc)) {
@@ -1689,7 +1695,13 @@ void ModeAuto::do_loiter_unlimited(const AP_Mission::Mission_Command& cmd)
 // do_circle - initiate moving in a circle
 void ModeAuto::do_circle(const AP_Mission::Mission_Command& cmd)
 {
-    const Location circle_center = loc_from_cmd(cmd, copter.current_loc);
+    // calculate default location used when lat, lon or alt is zero
+    Location default_loc = copter.current_loc;
+
+    // subtract position offsets
+    subtract_pos_offsets(default_loc);
+
+    const Location circle_center = loc_from_cmd(cmd, default_loc);
 
     // calculate radius
     uint16_t circle_radius_m = HIGHBYTE(cmd.p1); // circle radius held in high byte of p1
@@ -1757,6 +1769,10 @@ void ModeAuto::do_spline_wp(const AP_Mission::Mission_Command& cmd)
 {
     // calculate default location used when lat, lon or alt is zero
     Location default_loc = copter.current_loc;
+
+    // subtract position offsets
+    subtract_pos_offsets(default_loc);
+
     if (wp_nav->is_active() && wp_nav->reached_wp_destination()) {
         if (!wp_nav->get_wp_destination_loc(default_loc)) {
             // this should never happen

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -517,8 +517,8 @@ void ModeAuto::circle_movetoedge_start(const Location &circle_center, float radi
 
     // check our distance from edge of circle
     Vector3f circle_edge_neu;
-    copter.circle_nav->get_closest_point_on_circle(circle_edge_neu);
-    float dist_to_edge = (inertial_nav.get_position_neu_cm() - circle_edge_neu).length();
+    float dist_to_edge;
+    copter.circle_nav->get_closest_point_on_circle(circle_edge_neu, dist_to_edge);
 
     // if more than 3m then fly to edge
     if (dist_to_edge > 300.0f) {

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -383,10 +383,10 @@ bool ModeGuided::set_destination(const Vector3f& destination, bool use_yaw, floa
         // convert origin to alt-above-terrain if necessary
         if (!guided_pos_terrain_alt) {
             // new destination is alt-above-terrain, previous destination was alt-above-ekf-origin
-            pos_control->set_pos_offset_z_cm(origin_terr_offset);
+            pos_control->init_pos_terrain_cm(origin_terr_offset);
         }
     } else {
-        pos_control->set_pos_offset_z_cm(0.0);
+        pos_control->init_pos_terrain_cm(0.0);
     }
 
     // set yaw state
@@ -496,10 +496,10 @@ bool ModeGuided::set_destination(const Location& dest_loc, bool use_yaw, float y
         // convert origin to alt-above-terrain if necessary
         if (!guided_pos_terrain_alt) {
             // new destination is alt-above-terrain, previous destination was alt-above-ekf-origin
-            pos_control->set_pos_offset_z_cm(origin_terr_offset);
+            pos_control->init_pos_terrain_cm(origin_terr_offset);
         }
     } else {
-        pos_control->set_pos_offset_z_cm(0.0);
+        pos_control->init_pos_terrain_cm(0.0);
     }
 
     guided_pos_target_cm = pos_target_f.topostype();
@@ -825,8 +825,7 @@ void ModeGuided::velaccel_control_run()
 
     if (!stabilizing_vel_xy() && !do_avoid) {
         // set the current commanded xy vel to the desired vel
-        guided_vel_target_cms.x = pos_control->get_vel_desired_cms().x;
-        guided_vel_target_cms.y = pos_control->get_vel_desired_cms().y;
+        guided_vel_target_cms.xy() = pos_control->get_vel_desired_cms().xy();
     }
     pos_control->input_vel_accel_xy(guided_vel_target_cms.xy(), guided_accel_target_cmss.xy(), false);
     if (!stabilizing_vel_xy() && !do_avoid) {
@@ -903,14 +902,11 @@ void ModeGuided::posvelaccel_control_run()
     // send position and velocity targets to position controller
     if (!stabilizing_vel_xy()) {
         // set the current commanded xy pos to the target pos and xy vel to the desired vel
-        guided_pos_target_cm.x = pos_control->get_pos_target_cm().x;
-        guided_pos_target_cm.y = pos_control->get_pos_target_cm().y;
-        guided_vel_target_cms.x = pos_control->get_vel_desired_cms().x;
-        guided_vel_target_cms.y = pos_control->get_vel_desired_cms().y;
+        guided_pos_target_cm.xy() = pos_control->get_pos_desired_cm().xy();
+        guided_vel_target_cms.xy() = pos_control->get_vel_desired_cms().xy();
     } else if (!stabilizing_pos_xy()) {
         // set the current commanded xy pos to the target pos
-        guided_pos_target_cm.x = pos_control->get_pos_target_cm().x;
-        guided_pos_target_cm.y = pos_control->get_pos_target_cm().y;
+        guided_pos_target_cm.xy() = pos_control->get_pos_desired_cm().xy();
     }
     pos_control->input_pos_vel_accel_xy(guided_pos_target_cm.xy(), guided_vel_target_cms.xy(), guided_accel_target_cmss.xy(), false);
     if (!stabilizing_vel_xy()) {

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -377,7 +377,7 @@ void ModePosHold::run()
         pitch_mode = RPMode::BRAKE_TO_LOITER;
         brake.to_loiter_timer = POSHOLD_BRAKE_TO_LOITER_TIMER;
         // init loiter controller
-        loiter_nav->init_target(inertial_nav.get_position_xy_cm());
+        loiter_nav->init_target(inertial_nav.get_position_xy_cm() - pos_control->get_pos_offset_cm().xy().tofloat());
         // set delay to start of wind compensation estimate updates
         wind_comp_start_timer = POSHOLD_WIND_COMP_START_TIMER;
     }

--- a/ArduCopter/mode_throw.cpp
+++ b/ArduCopter/mode_throw.cpp
@@ -72,9 +72,9 @@ void ModeThrow::run()
         // initialise the demanded height to 3m above the throw height
         // we want to rapidly clear surrounding obstacles
         if (g2.throw_type == ThrowType::Drop) {
-            pos_control->set_pos_target_z_cm(inertial_nav.get_position_z_up_cm() - 100);
+            pos_control->set_pos_desired_z_cm(inertial_nav.get_position_z_up_cm() - 100);
         } else {
-            pos_control->set_pos_target_z_cm(inertial_nav.get_position_z_up_cm() + 300);
+            pos_control->set_pos_desired_z_cm(inertial_nav.get_position_z_up_cm() + 300);
         }
 
         // Set the auto_arm status to true to avoid a possible automatic disarm caused by selection of an auto mode with throttle at minimum

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -161,7 +161,7 @@ void ModeZigZag::run()
 void ModeZigZag::save_or_move_to_destination(Destination ab_dest)
 {
     // get current position as an offset from EKF origin
-    const Vector2f curr_pos {inertial_nav.get_position_xy_cm()};
+    const Vector2f curr_pos = pos_control->get_pos_desired_cm().xy().tofloat();
 
     // handle state machine changes
     switch (stage) {
@@ -431,7 +431,7 @@ bool ModeZigZag::calculate_next_dest(Destination ab_dest, bool use_wpnav_alt, Ve
     }
 
     // get distance from vehicle to start_pos
-    const Vector2f curr_pos2d {inertial_nav.get_position_xy_cm()};
+    const Vector2f curr_pos2d = pos_control->get_pos_desired_cm().xy().tofloat();
     Vector2f veh_to_start_pos = curr_pos2d - start_pos;
 
     // lengthen AB_diff so that it is at least as long as vehicle is from start point
@@ -499,7 +499,7 @@ bool ModeZigZag::calculate_side_dest(Vector3f& next_dest, bool& terrain_alt) con
     float scalar = constrain_float(_side_dist, 0.1f, 100.0f) * 100 / safe_sqrt(AB_side.length_squared());
 
     // get distance from vehicle to start_pos
-    const Vector2f curr_pos2d {inertial_nav.get_position_xy_cm()};
+    const Vector2f curr_pos2d = pos_control->get_pos_desired_cm().xy().tofloat();
     next_dest.xy() = curr_pos2d + (AB_side * scalar);
 
     // if we have a downward facing range finder then use terrain altitude targets

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -245,8 +245,8 @@ void ModeZigZag::return_to_manual_control(bool maintain_target)
             const Vector3f& wp_dest = wp_nav->get_wp_destination();
             loiter_nav->init_target(wp_dest.xy());
 #if AP_RANGEFINDER_ENABLED
-            if (wp_nav->origin_and_destination_are_terrain_alt()) {
-                copter.surface_tracking.set_target_alt_cm(wp_dest.z);
+            if (copter.rangefinder_alt_ok() && wp_nav->rangefinder_used_and_healthy()) {
+                copter.surface_tracking.external_init();
             }
 #endif
         } else {
@@ -455,16 +455,10 @@ bool ModeZigZag::calculate_next_dest(Destination ab_dest, bool use_wpnav_alt, Ve
         terrain_alt = wp_nav->origin_and_destination_are_terrain_alt();
         next_dest.z = wp_nav->get_wp_destination().z;
     } else {
-        // if we have a downward facing range finder then use terrain altitude targets
         terrain_alt = copter.rangefinder_alt_ok() && wp_nav->rangefinder_used_and_healthy();
-        if (terrain_alt) {
-#if AP_RANGEFINDER_ENABLED
-            if (!copter.surface_tracking.get_target_alt_cm(next_dest.z)) {
-                next_dest.z = copter.rangefinder_state.alt_cm_filt.get();
-            }
-#endif
-        } else {
-            next_dest.z = pos_control->is_active_z() ? pos_control->get_pos_target_z_cm() : inertial_nav.get_position_z_up_cm();
+        next_dest.z = pos_control->get_pos_desired_z_cm();
+        if (!terrain_alt) {
+            next_dest.z += pos_control->get_pos_terrain_cm();
         }
     }
 
@@ -506,20 +500,11 @@ bool ModeZigZag::calculate_side_dest(Vector3f& next_dest, bool& terrain_alt) con
 
     // get distance from vehicle to start_pos
     const Vector2f curr_pos2d {inertial_nav.get_position_xy_cm()};
-    next_dest.x = curr_pos2d.x + (AB_side.x * scalar);
-    next_dest.y = curr_pos2d.y + (AB_side.y * scalar);
+    next_dest.xy() = curr_pos2d + (AB_side * scalar);
 
     // if we have a downward facing range finder then use terrain altitude targets
     terrain_alt = copter.rangefinder_alt_ok() && wp_nav->rangefinder_used_and_healthy();
-    if (terrain_alt) {
-#if AP_RANGEFINDER_ENABLED
-        if (!copter.surface_tracking.get_target_alt_cm(next_dest.z)) {
-            next_dest.z = copter.rangefinder_state.alt_cm_filt.get();
-        }
-#endif
-    } else {
-        next_dest.z = pos_control->is_active_z() ? pos_control->get_pos_target_z_cm() : inertial_nav.get_position_z_up_cm();
-    }
+    next_dest.z = pos_control->get_pos_desired_z_cm();
 
     return true;
 }

--- a/ArduCopter/surface_tracking.cpp
+++ b/ArduCopter/surface_tracking.cpp
@@ -18,7 +18,7 @@ void Copter::SurfaceTracking::update_surface_offset()
         AP_SurfaceDistance &rf_state = (surface == Surface::GROUND) ? copter.rangefinder_state : copter.rangefinder_up_state;
 
         // update position controller target offset to the surface's alt above the EKF origin
-        copter.pos_control->set_pos_offset_target_z_cm(rf_state.terrain_offset_cm);
+        copter.pos_control->set_pos_terrain_target_cm(rf_state.terrain_offset_cm);
         last_update_ms = now_ms;
         valid_for_logging = true;
 
@@ -28,7 +28,7 @@ void Copter::SurfaceTracking::update_surface_offset()
         if (timeout ||
             reset_target ||
             (last_glitch_cleared_ms != rf_state.glitch_cleared_ms)) {
-            copter.pos_control->set_pos_offset_z_cm(rf_state.terrain_offset_cm);
+            copter.pos_control->init_pos_terrain_cm(rf_state.terrain_offset_cm);
             reset_target = false;
             last_glitch_cleared_ms = rf_state.glitch_cleared_ms;
         }
@@ -36,40 +36,22 @@ void Copter::SurfaceTracking::update_surface_offset()
     } else {
         // reset position controller offsets if surface tracking is inactive
         // flag target should be reset when/if it next becomes active
-        if (timeout) {
-            copter.pos_control->set_pos_offset_z_cm(0);
-            copter.pos_control->set_pos_offset_target_z_cm(0);
+        if (timeout && !reset_target) {
+            copter.pos_control->init_pos_terrain_cm(0);
+            valid_for_logging = false;
             reset_target = true;
         }
     }
 }
 
-
-// get target altitude (in cm) above ground
-// returns true if there is a valid target
-bool Copter::SurfaceTracking::get_target_alt_cm(float &target_alt_cm) const
+// target has already been set by terrain following so do not initalise again
+// this should be called by flight modes when switching from terrain following to surface tracking (e.g. ZigZag)
+void Copter::SurfaceTracking::external_init()
 {
-    // fail if we are not tracking downwards
-    if (surface != Surface::GROUND) {
-        return false;
+    if ((surface == Surface::GROUND) && copter.rangefinder_alt_ok() && (copter.rangefinder_state.glitch_count == 0)) {
+        last_update_ms = millis();
+        reset_target = false;
     }
-    // check target has been updated recently
-    if (AP_HAL::millis() - last_update_ms > SURFACE_TRACKING_TIMEOUT_MS) {
-        return false;
-    }
-    target_alt_cm = (copter.pos_control->get_pos_target_z_cm() - copter.pos_control->get_pos_offset_z_cm());
-    return true;
-}
-
-// set target altitude (in cm) above ground
-void Copter::SurfaceTracking::set_target_alt_cm(float _target_alt_cm)
-{
-    // fail if we are not tracking downwards
-    if (surface != Surface::GROUND) {
-        return;
-    }
-    copter.pos_control->set_pos_offset_z_cm(copter.inertial_nav.get_position_z_up_cm() - _target_alt_cm);
-    last_update_ms = AP_HAL::millis();
 }
 
 bool Copter::SurfaceTracking::get_target_dist_for_logging(float &target_dist) const
@@ -79,7 +61,7 @@ bool Copter::SurfaceTracking::get_target_dist_for_logging(float &target_dist) co
     }
 
     const float dir = (surface == Surface::GROUND) ? 1.0f : -1.0f;
-    target_dist = dir * (copter.pos_control->get_pos_target_z_cm() - copter.pos_control->get_pos_offset_z_cm()) * 0.01f;
+    target_dist = dir * copter.pos_control->get_pos_desired_z_cm() * 0.01f;
     return true;
 }
 

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -52,7 +52,7 @@ void Mode::_TakeOff::start(float alt_cm)
 {
     // initialise takeoff state
     _running = true;
-    take_off_start_alt = copter.pos_control->get_pos_target_z_cm();
+    take_off_start_alt = copter.pos_control->get_pos_desired_z_cm();
     take_off_complete_alt  = take_off_start_alt + alt_cm;
 }
 
@@ -87,7 +87,7 @@ void Mode::_TakeOff::do_pilot_takeoff(float& pilot_climb_rate_cm)
         if (throttle >= MIN(copter.g2.takeoff_throttle_max, 0.9) || 
             (copter.pos_control->get_z_accel_cmss() >= 0.5 * copter.pos_control->get_max_accel_z_cmss()) ||
             (copter.pos_control->get_vel_desired_cms().z >= constrain_float(pilot_climb_rate_cm, copter.pos_control->get_max_speed_up_cms() * 0.1, copter.pos_control->get_max_speed_up_cms() * 0.5)) || 
-            (is_positive(take_off_complete_alt - take_off_start_alt) && copter.pos_control->get_pos_target_z_cm() - take_off_start_alt > 0.5 * (take_off_complete_alt - take_off_start_alt))) {
+            (is_positive(take_off_complete_alt - take_off_start_alt) && copter.pos_control->get_pos_desired_z_cm() - take_off_start_alt > 0.5 * (take_off_complete_alt - take_off_start_alt))) {
             // throttle > 90%
             // acceleration > 50% maximum acceleration
             // velocity > 10% maximum velocity && commanded climb rate
@@ -104,7 +104,7 @@ void Mode::_TakeOff::do_pilot_takeoff(float& pilot_climb_rate_cm)
 
         // stop take off early and return if negative climb rate is commanded or we are within 0.1% of our take off altitude
         if (is_negative(pilot_climb_rate_cm) ||
-            (take_off_complete_alt  - take_off_start_alt) * 0.999f < copter.pos_control->get_pos_target_z_cm() - take_off_start_alt) {
+            (take_off_complete_alt  - take_off_start_alt) * 0.999f < copter.pos_control->get_pos_desired_z_cm() - take_off_start_alt) {
             stop();
         }
     }
@@ -210,13 +210,13 @@ void _AutoTakeoff::run()
     const float vel_threshold_fraction = 0.1;
     // stopping distance from vel_threshold_fraction * max velocity
     const float stop_distance = 0.5 * sq(vel_threshold_fraction * copter.pos_control->get_max_speed_up_cms()) / copter.pos_control->get_max_accel_z_cmss();
-    bool reached_altitude = copter.pos_control->get_pos_target_z_cm() >= pos_z - stop_distance;
+    bool reached_altitude = copter.pos_control->get_pos_desired_z_cm() >= pos_z - stop_distance;
     bool reached_climb_rate = copter.pos_control->get_vel_desired_cms().z < copter.pos_control->get_max_speed_up_cms() * vel_threshold_fraction;
     complete = reached_altitude && reached_climb_rate;
 
     // calculate completion for location in case it is needed for a smooth transition to wp_nav
     if (complete) {
-        const Vector3p& _complete_pos = copter.pos_control->get_pos_target_cm();
+        const Vector3p& _complete_pos = copter.pos_control->get_pos_desired_cm();
         complete_pos = Vector3p{_complete_pos.x, _complete_pos.y, pos_z};
     }
 }

--- a/ArduPlane/mode_qloiter.cpp
+++ b/ArduPlane/mode_qloiter.cpp
@@ -48,7 +48,7 @@ void ModeQLoiter::run()
         // we have an active landing target override
         Vector2f rel_origin;
         if (plane.next_WP_loc.get_vector_xy_from_origin_NE(rel_origin)) {
-            quadplane.pos_control->set_pos_target_xy_cm(rel_origin.x, rel_origin.y);
+            quadplane.pos_control->set_pos_desired_xy_cm(rel_origin);
             last_target_loc_set_ms = 0;
         }
     }

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3609,7 +3609,7 @@ void QuadPlane::Log_Write_QControl_Tuning()
     float des_alt_m = 0.0f;
     int16_t target_climb_rate_cms = 0;
     if (plane.control_mode != &plane.mode_qstabilize) {
-        des_alt_m = pos_control->get_pos_target_z_cm() * 0.01f;
+        des_alt_m = pos_control->get_pos_desired_z_cm() * 0.01f;
         target_climb_rate_cms = pos_control->get_vel_target_z_cms();
     }
 
@@ -3902,7 +3902,7 @@ bool QuadPlane::guided_mode_enabled(void)
  */
 void QuadPlane::set_alt_target_current(void)
 {
-    pos_control->set_pos_target_z_cm(inertial_nav.get_position_z_up_cm());
+    pos_control->set_pos_desired_z_cm(inertial_nav.get_position_z_up_cm());
 }
 
 // user initiated takeoff for guided mode

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -822,7 +822,7 @@ void GCS_MAVLINK_Sub::handle_message(const mavlink_message_t &msg)
          */
 
         if (!z_ignore && sub.control_mode == Mode::Number::ALT_HOLD) { // Control only target depth when in ALT_HOLD
-            sub.pos_control.set_pos_target_z_cm(packet.alt*100);
+            sub.pos_control.set_pos_desired_z_cm(packet.alt*100);
             break;
         }
 

--- a/ArduSub/mode_acro.cpp
+++ b/ArduSub/mode_acro.cpp
@@ -7,7 +7,7 @@
 
 bool ModeAcro::init(bool ignore_checks) {
     // set target altitude to zero for reporting
-    position_control->set_pos_target_z_cm(0);
+    position_control->set_pos_desired_z_cm(0);
 
     // attitude hold inputs become thrust inputs in acro mode
     // set to neutral to prevent chaotic behavior (esp. roll/pitch)

--- a/ArduSub/mode_althold.cpp
+++ b/ArduSub/mode_althold.cpp
@@ -111,9 +111,9 @@ void ModeAlthold::control_depth() {
     //we allow full control to the pilot, but as soon as there's no input, we handle being at surface/bottom
     if (fabsf(target_climb_rate_cm_s) < 0.05f)  {
         if (sub.ap.at_surface) {
-            position_control->set_pos_target_z_cm(MIN(position_control->get_pos_target_z_cm(), g.surface_depth - 5.0f)); // set target to 5 cm below surface level
+            position_control->set_pos_desired_z_cm(MIN(position_control->get_pos_desired_z_cm(), g.surface_depth - 5.0f)); // set target to 5 cm below surface level
         } else if (sub.ap.at_bottom) {
-            position_control->set_pos_target_z_cm(MAX(inertial_nav.get_position_z_up_cm() + 10.0f, position_control->get_pos_target_z_cm())); // set target to 10 cm above bottom
+            position_control->set_pos_desired_z_cm(MAX(inertial_nav.get_position_z_up_cm() + 10.0f, position_control->get_pos_desired_z_cm())); // set target to 10 cm above bottom
         }
     }
 

--- a/ArduSub/mode_auto.cpp
+++ b/ArduSub/mode_auto.cpp
@@ -187,8 +187,8 @@ void ModeAuto::auto_circle_movetoedge_start(const Location &circle_center, float
 
     // check our distance from edge of circle
     Vector3f circle_edge_neu;
-    sub.circle_nav.get_closest_point_on_circle(circle_edge_neu);
-    float dist_to_edge = (inertial_nav.get_position_neu_cm() - circle_edge_neu).length();
+    float dist_to_edge;
+    sub.circle_nav.get_closest_point_on_circle(circle_edge_neu, dist_to_edge);
 
     // if more than 3m then fly to edge
     if (dist_to_edge > 300.0f) {

--- a/ArduSub/mode_guided.cpp
+++ b/ArduSub/mode_guided.cpp
@@ -811,7 +811,7 @@ float ModeGuided::get_auto_heading()
         float track_bearing = get_bearing_cd(sub.wp_nav.get_wp_origin().xy(), sub.wp_nav.get_wp_destination().xy());
 
         // Bearing from current position towards intermediate position target (centidegrees)
-        const Vector2f target_vel_xy{position_control->get_vel_target_cms().x, position_control->get_vel_target_cms().y};
+        const Vector2f target_vel_xy = position_control->get_vel_target_cms().xy();
         float angle_error = 0.0f;
         if (target_vel_xy.length() >= position_control->get_max_speed_xy_cms() * 0.1f) {
             const float desired_angle_cd = degrees(target_vel_xy.angle()) * 100.0f;

--- a/ArduSub/mode_manual.cpp
+++ b/ArduSub/mode_manual.cpp
@@ -3,7 +3,7 @@
 
 bool ModeManual::init(bool ignore_checks) {
     // set target altitude to zero for reporting
-    position_control->set_pos_target_z_cm(0);
+    position_control->set_pos_desired_z_cm(0);
 
     // attitude hold inputs become thrust inputs in manual mode
     // set to neutral to prevent chaotic behavior (esp. roll/pitch)

--- a/ArduSub/mode_stabilize.cpp
+++ b/ArduSub/mode_stabilize.cpp
@@ -3,7 +3,7 @@
 
 bool ModeStabilize::init(bool ignore_checks) {
     // set target altitude to zero for reporting
-    position_control->set_pos_target_z_cm(0);
+    position_control->set_pos_desired_z_cm(0);
     sub.last_pilot_heading = ahrs.yaw_sensor;
 
     return true;

--- a/ArduSub/mode_surftrak.cpp
+++ b/ArduSub/mode_surftrak.cpp
@@ -81,8 +81,7 @@ bool ModeSurftrak::set_rangefinder_target_cm(float target_cm)
 
         // Initialize the terrain offset
         auto terrain_offset_cm = sub.inertial_nav.get_position_z_up_cm() - rangefinder_target_cm;
-        sub.pos_control.set_pos_offset_z_cm(terrain_offset_cm);
-        sub.pos_control.set_pos_offset_target_z_cm(terrain_offset_cm);
+        sub.pos_control.init_pos_terrain_cm(terrain_offset_cm);
 
     } else {
         reset();
@@ -97,8 +96,7 @@ void ModeSurftrak::reset()
     rangefinder_target_cm = INVALID_TARGET;
 
     // Reset the terrain offset
-    sub.pos_control.set_pos_offset_z_cm(0);
-    sub.pos_control.set_pos_offset_target_z_cm(0);
+    sub.pos_control.init_pos_terrain_cm(0);
 }
 
 /*
@@ -117,11 +115,11 @@ void ModeSurftrak::control_range() {
         }
         if (sub.ap.at_surface) {
             // Set target depth to 5 cm below SURFACE_DEPTH and reset
-            position_control->set_pos_target_z_cm(MIN(position_control->get_pos_target_z_cm(), g.surface_depth - 5.0f));
+            position_control->set_pos_desired_z_cm(MIN(position_control->get_pos_desired_z_cm(), g.surface_depth - 5.0f));
             reset();
         } else if (sub.ap.at_bottom) {
             // Set target depth to 10 cm above bottom and reset
-            position_control->set_pos_target_z_cm(MAX(inertial_nav.get_position_z_up_cm() + 10.0f, position_control->get_pos_target_z_cm()));
+            position_control->set_pos_desired_z_cm(MAX(inertial_nav.get_position_z_up_cm() + 10.0f, position_control->get_pos_desired_z_cm()));
             reset();
         } else {
             // Typical operation
@@ -164,7 +162,7 @@ void ModeSurftrak::update_surface_offset()
             }
 
             // Set the offset target, AC_PosControl will do the rest
-            sub.pos_control.set_pos_offset_target_z_cm(rangefinder_terrain_offset_cm);
+            sub.pos_control.set_pos_terrain_target_cm(rangefinder_terrain_offset_cm);
         }
     }
 #endif  // AP_RANGEFINDER_ENABLED

--- a/Blimp/Loiter.cpp
+++ b/Blimp/Loiter.cpp
@@ -125,9 +125,9 @@ void Loiter::run(Vector3f& target_pos, float& target_yaw, Vector4b axes_disabled
     }
 
 #if HAL_LOGGING_ENABLED
-    AC_PosControl::Write_PSCN(target_pos.x * 100.0, blimp.pos_ned.x * 100.0, 0.0, target_vel_ef_c.x * 100.0, blimp.vel_ned_filtd.x * 100.0, 0.0, 0.0, 0.0);
-    AC_PosControl::Write_PSCE(target_pos.y * 100.0, blimp.pos_ned.y * 100.0, 0.0, target_vel_ef_c.y * 100.0, blimp.vel_ned_filtd.y * 100.0, 0.0, 0.0, 0.0);
-    AC_PosControl::Write_PSCD(-target_pos.z * 100.0, -blimp.pos_ned.z * 100.0, 0.0, -target_vel_ef_c.z * 100.0, -blimp.vel_ned_filtd.z * 100.0, 0.0, 0.0, 0.0);
+    AC_PosControl::Write_PSCN(0.0, target_pos.x * 100.0, blimp.pos_ned.x * 100.0, 0.0, target_vel_ef_c.x * 100.0, blimp.vel_ned_filtd.x * 100.0, 0.0, 0.0, 0.0);
+    AC_PosControl::Write_PSCE(0.0, target_pos.y * 100.0, blimp.pos_ned.y * 100.0, 0.0, target_vel_ef_c.y * 100.0, blimp.vel_ned_filtd.y * 100.0, 0.0, 0.0, 0.0);
+    AC_PosControl::Write_PSCD(0.0, -target_pos.z * 100.0, -blimp.pos_ned.z * 100.0, 0.0, -target_vel_ef_c.z * 100.0, -blimp.vel_ned_filtd.z * 100.0, 0.0, 0.0, 0.0);
 #endif
 }
 
@@ -203,8 +203,8 @@ void Loiter::run_vel(Vector3f& target_vel_ef, float& target_vel_yaw, Vector4b ax
     }
 
 #if HAL_LOGGING_ENABLED
-    AC_PosControl::Write_PSCN(0.0, blimp.pos_ned.x * 100.0, 0.0, target_vel_ef_c.x * 100.0, blimp.vel_ned_filtd.x * 100.0, 0.0, 0.0, 0.0);
-    AC_PosControl::Write_PSCE(0.0, blimp.pos_ned.y * 100.0, 0.0, target_vel_ef_c.y * 100.0, blimp.vel_ned_filtd.y * 100.0, 0.0, 0.0, 0.0);
-    AC_PosControl::Write_PSCD(0.0, -blimp.pos_ned.z * 100.0, 0.0, -target_vel_ef_c.z * 100.0, -blimp.vel_ned_filtd.z * 100.0, 0.0, 0.0, 0.0);
+    AC_PosControl::Write_PSCN(0.0, 0.0, blimp.pos_ned.x * 100.0, 0.0, target_vel_ef_c.x * 100.0, blimp.vel_ned_filtd.x * 100.0, 0.0, 0.0, 0.0);
+    AC_PosControl::Write_PSCE(0.0, 0.0, blimp.pos_ned.y * 100.0, 0.0, target_vel_ef_c.y * 100.0, blimp.vel_ned_filtd.y * 100.0, 0.0, 0.0, 0.0);
+    AC_PosControl::Write_PSCD(0.0, 0.0, -blimp.pos_ned.z * 100.0, 0.0, -target_vel_ef_c.z * 100.0, -blimp.vel_ned_filtd.z * 100.0, 0.0, 0.0, 0.0);
 #endif
 }

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -77,6 +77,8 @@ extern const AP_HAL::HAL& hal;
 // velocity offset targets timeout if not updated within 3 seconds
 #define POSCONTROL_POSVELACCEL_OFFSET_TARGET_TIMEOUT_MS 3000
 
+AC_PosControl *AC_PosControl::_singleton;
+
 const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // 0 was used for HOVER
 
@@ -348,6 +350,8 @@ AC_PosControl::AC_PosControl(AP_AHRS_View& ahrs, const AP_InertialNav& inav,
     _jerk_max_z_cmsss(POSCONTROL_JERK_Z * 100.0)
 {
     AP_Param::setup_object_defaults(this, var_info);
+
+    _singleton = this;
 }
 
 

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -74,6 +74,9 @@ extern const AP_HAL::HAL& hal;
 #define POSCONTROL_VIBE_COMP_P_GAIN 0.250f
 #define POSCONTROL_VIBE_COMP_I_GAIN 0.125f
 
+// velocity offset targets timeout if not updated within 3 seconds
+#define POSCONTROL_POSVELACCEL_OFFSET_TARGET_TIMEOUT_MS 3000
+
 const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // 0 was used for HOVER
 
@@ -358,30 +361,26 @@ AC_PosControl::AC_PosControl(AP_AHRS_View& ahrs, const AP_InertialNav& inav,
 ///     The jerk limit defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
 ///     The jerk limit also defines the time taken to achieve the maximum acceleration.
 ///     The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time.
-void AC_PosControl::input_pos_xyz(const Vector3p& pos, float pos_offset_z, float pos_offset_z_buffer)
+void AC_PosControl::input_pos_xyz(const Vector3p& pos, float pos_terrain_target, float terrain_buffer)
 {
     // Terrain following velocity scalar must be calculated before we remove the position offset
-    const float offset_z_scaler = pos_offset_z_scaler(pos_offset_z, pos_offset_z_buffer);
-
-    // remove terrain offsets for flat earth assumption
-    _pos_target.z -= _pos_offset_z;
-    _vel_desired.z -= _vel_offset_z;
-    _accel_desired.z -= _accel_offset_z;
+    const float offset_z_scaler = pos_offset_z_scaler(pos_terrain_target, terrain_buffer);
+    set_pos_terrain_target_cm(pos_terrain_target);
 
     // calculated increased maximum acceleration and jerk if over speed
     const float overspeed_gain = calculate_overspeed_gain();
     const float accel_max_z_cmss = _accel_max_z_cmss * overspeed_gain;
     const float jerk_max_z_cmsss = _jerk_max_z_cmsss * overspeed_gain;
 
-    update_pos_vel_accel_xy(_pos_target.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy(), _p_pos_xy.get_error(), _pid_vel_xy.get_error());
+    update_pos_vel_accel_xy(_pos_desired.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy(), _p_pos_xy.get_error(), _pid_vel_xy.get_error());
 
     // adjust desired altitude if motors have not hit their limits
-    update_pos_vel_accel(_pos_target.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z, _p_pos_z.get_error(), _pid_vel_z.get_error());
+    update_pos_vel_accel(_pos_desired.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z, _p_pos_z.get_error(), _pid_vel_z.get_error());
 
     // calculate the horizontal and vertical velocity limits to travel directly to the destination defined by pos
     float vel_max_xy_cms = 0.0f;
     float vel_max_z_cms = 0.0f;
-    Vector3f dest_vector = (pos - _pos_target).tofloat();
+    Vector3f dest_vector = (pos - _pos_desired).tofloat();
     if (is_positive(dest_vector.length_squared()) ) {
         dest_vector.normalize();
         float dest_vector_xy_length = dest_vector.xy().length();
@@ -396,23 +395,15 @@ void AC_PosControl::input_pos_xyz(const Vector3p& pos, float pos_offset_z, float
 
     Vector2f vel;
     Vector2f accel;
-    shape_pos_vel_accel_xy(pos.xy(), vel, accel, _pos_target.xy(), _vel_desired.xy(), _accel_desired.xy(),
+    shape_pos_vel_accel_xy(pos.xy(), vel, accel, _pos_desired.xy(), _vel_desired.xy(), _accel_desired.xy(),
                            vel_max_xy_cms, _accel_max_xy_cmss, _jerk_max_xy_cmsss, _dt, false);
 
     float posz = pos.z;
     shape_pos_vel_accel(posz, 0, 0,
-                        _pos_target.z, _vel_desired.z, _accel_desired.z,
+                        _pos_desired.z, _vel_desired.z, _accel_desired.z,
                         -vel_max_z_cms, vel_max_z_cms,
                         -constrain_float(accel_max_z_cmss, 0.0f, 750.0f), accel_max_z_cmss,
                         jerk_max_z_cmsss, _dt, false);
-
-    // update the vertical position, velocity and acceleration offsets
-    update_pos_offset_z(pos_offset_z);
-
-    // add terrain offsets
-    _pos_target.z += _pos_offset_z;
-    _vel_desired.z += _vel_offset_z;
-    _accel_desired.z += _accel_offset_z;
 }
 
 
@@ -422,7 +413,7 @@ float AC_PosControl::pos_offset_z_scaler(float pos_offset_z, float pos_offset_z_
     if (is_zero(pos_offset_z_buffer)) {
         return 1.0;
     }
-    float pos_offset_error_z = _inav.get_position_z_up_cm() - (_pos_target.z - _pos_offset_z + pos_offset_z);
+    float pos_offset_error_z = _inav.get_position_z_up_cm() - (_pos_target.z + (pos_offset_z - _pos_terrain));
     return constrain_float((1.0 - (fabsf(pos_offset_error_z) - 0.5 * pos_offset_z_buffer) / (0.5 * pos_offset_z_buffer)), 0.01, 1.0);
 }
 
@@ -466,12 +457,13 @@ void AC_PosControl::set_correction_speed_accel_xy(float speed_cms, float accel_c
 
 /// init_xy_controller_stopping_point - initialise the position controller to the stopping point with zero velocity and acceleration.
 ///     This function should be used when the expected kinematic path assumes a stationary initial condition but does not specify a specific starting position.
-///     The starting position can be retrieved by getting the position target using get_pos_target_cm() after calling this function.
+///     The starting position can be retrieved by getting the position target using get_pos_desired_cm() after calling this function.
 void AC_PosControl::init_xy_controller_stopping_point()
 {
     init_xy_controller();
 
-    get_stopping_point_xy_cm(_pos_target.xy());
+    get_stopping_point_xy_cm(_pos_desired.xy());
+    _pos_target.xy() = _pos_desired.xy() + _pos_offset.xy();
     _vel_desired.xy().zero();
     _accel_desired.xy().zero();
 }
@@ -496,6 +488,7 @@ void AC_PosControl::soften_for_landing_xy()
     // decay position error to zero
     if (is_positive(_dt)) {
         _pos_target.xy() += (_inav.get_position_xy_cm().topostype() - _pos_target.xy()) * (_dt / (_dt + POSCONTROL_RELAX_TC));
+        _pos_desired.xy() = _pos_target.xy() - _pos_offset.xy();
     }
 
     // Prevent I term build up in xy velocity controller.
@@ -507,6 +500,9 @@ void AC_PosControl::soften_for_landing_xy()
 ///     This function is the default initialisation for any position control that provides position, velocity and acceleration.
 void AC_PosControl::init_xy_controller()
 {
+    // initialise offsets to target offsets and ensure offset targets are zero if they have not been updated.
+    init_offsets_xy();
+    
     // set roll, pitch lean angle targets to current attitude
     const Vector3f &att_target_euler_cd = _attitude_control.get_att_target_euler_cd();
     _roll_target = att_target_euler_cd.x;
@@ -516,10 +512,10 @@ void AC_PosControl::init_xy_controller()
     _angle_max_override_cd = 0.0;
 
     _pos_target.xy() = _inav.get_position_xy_cm().topostype();
+    _pos_desired.xy() = _pos_target.xy() - _pos_offset.xy();
 
-    const Vector2f &curr_vel = _inav.get_velocity_xy_cms();
-    _vel_desired.xy() = curr_vel;
-    _vel_target.xy() = curr_vel;
+    _vel_target.xy() = _inav.get_velocity_xy_cms();
+    _vel_desired.xy() = _vel_target.xy() - _vel_offset.xy();
 
     // Set desired accel to zero because raw acceleration is prone to noise
     _accel_desired.xy().zero();
@@ -553,11 +549,8 @@ void AC_PosControl::init_xy_controller()
 ///     The jerk limit also defines the time taken to achieve the maximum acceleration.
 void AC_PosControl::input_accel_xy(const Vector3f& accel)
 {
-    // check for ekf xy position reset
-    handle_ekf_xy_reset();
-
-    update_pos_vel_accel_xy(_pos_target.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy(), _p_pos_xy.get_error(), _pid_vel_xy.get_error());
-    shape_accel_xy(accel, _accel_desired, _jerk_max_xy_cmsss, _dt);
+    update_pos_vel_accel_xy(_pos_desired.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy(), _p_pos_xy.get_error(), _pid_vel_xy.get_error());
+    shape_accel_xy(accel.xy(), _accel_desired.xy(), _jerk_max_xy_cmsss, _dt);
 }
 
 /// input_vel_accel_xy - calculate a jerk limited path from the current position, velocity and acceleration to an input velocity and acceleration.
@@ -567,7 +560,7 @@ void AC_PosControl::input_accel_xy(const Vector3f& accel)
 ///     The parameter limit_output specifies if the velocity and acceleration limits are applied to the sum of commanded and correction values or just correction.
 void AC_PosControl::input_vel_accel_xy(Vector2f& vel, const Vector2f& accel, bool limit_output)
 {
-    update_pos_vel_accel_xy(_pos_target.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy(), _p_pos_xy.get_error(), _pid_vel_xy.get_error());
+    update_pos_vel_accel_xy(_pos_desired.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy(), _p_pos_xy.get_error(), _pid_vel_xy.get_error());
 
     shape_vel_accel_xy(vel, accel, _vel_desired.xy(), _accel_desired.xy(),
         _accel_max_xy_cmss, _jerk_max_xy_cmsss, _dt, limit_output);
@@ -582,29 +575,51 @@ void AC_PosControl::input_vel_accel_xy(Vector2f& vel, const Vector2f& accel, boo
 ///     The parameter limit_output specifies if the velocity and acceleration limits are applied to the sum of commanded and correction values or just correction.
 void AC_PosControl::input_pos_vel_accel_xy(Vector2p& pos, Vector2f& vel, const Vector2f& accel, bool limit_output)
 {
-    update_pos_vel_accel_xy(_pos_target.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy(), _p_pos_xy.get_error(), _pid_vel_xy.get_error());
+    update_pos_vel_accel_xy(_pos_desired.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy(), _p_pos_xy.get_error(), _pid_vel_xy.get_error());
 
-    shape_pos_vel_accel_xy(pos, vel, accel, _pos_target.xy(), _vel_desired.xy(), _accel_desired.xy(),
+    shape_pos_vel_accel_xy(pos, vel, accel, _pos_desired.xy(), _vel_desired.xy(), _accel_desired.xy(),
                            _vel_max_xy_cms, _accel_max_xy_cmss, _jerk_max_xy_cmsss, _dt, limit_output);
 
     update_pos_vel_accel_xy(pos, vel, accel, _dt, Vector2f(), Vector2f(), Vector2f());
+}
+
+/// update the horizontal position and velocity offsets
+/// this moves the offsets (e.g _pos_offset, _vel_offset, _accel_offset) towards the targets (e.g. _pos_offset_target, _vel_offset_target, _accel_offset_target)
+void AC_PosControl::update_offsets_xy()
+{
+    // check for offset target timeout
+    uint32_t now_ms = AP_HAL::millis();
+    if (now_ms - _posvelaccel_offset_target_xy_ms > POSCONTROL_POSVELACCEL_OFFSET_TARGET_TIMEOUT_MS) {
+        _pos_offset_target.xy().zero();
+        _vel_offset_target.xy().zero();
+        _accel_offset_target.xy().zero();
+    }
+
+    // update position, velocity, accel offsets for this iteration
+    update_pos_vel_accel_xy(_pos_offset_target.xy(), _vel_offset_target.xy(), _accel_offset_target.xy(), _dt, Vector2f(), Vector2f(), Vector2f());
+    update_pos_vel_accel_xy(_pos_offset.xy(), _vel_offset.xy(), _accel_offset.xy(), _dt, _limit_vector.xy(), _p_pos_xy.get_error(), _pid_vel_xy.get_error());
+
+    // input shape horizontal position, velocity and acceleration offsets
+    shape_pos_vel_accel_xy(_pos_offset_target.xy(), _vel_offset_target.xy(), _accel_offset_target.xy(),
+                            _pos_offset.xy(), _vel_offset.xy(), _accel_offset.xy(),
+                            _vel_max_xy_cms, _accel_max_xy_cmss, _jerk_max_xy_cmsss, _dt, false);
 }
 
 /// stop_pos_xy_stabilisation - sets the target to the current position to remove any position corrections from the system
 void AC_PosControl::stop_pos_xy_stabilisation()
 {
     _pos_target.xy() = _inav.get_position_xy_cm().topostype();
+    _pos_desired.xy() = _pos_target.xy() - _pos_offset.xy();
 }
 
 /// stop_vel_xy_stabilisation - sets the target to the current position and velocity to the current velocity to remove any position and velocity corrections from the system
 void AC_PosControl::stop_vel_xy_stabilisation()
 {
     _pos_target.xy() =  _inav.get_position_xy_cm().topostype();
-
-    const Vector2f &curr_vel = _inav.get_velocity_xy_cms();
-    _vel_desired.xy() = curr_vel;
-    // with zero position error _vel_target = _vel_desired
-    _vel_target.xy() = curr_vel;
+    _pos_desired.xy() = _pos_target.xy() - _pos_offset.xy();
+    
+    _vel_target.xy() = _inav.get_velocity_xy_cms();;
+    _vel_desired.xy() = _vel_target.xy() - _vel_offset.xy();
 
     // initialise I terms from lean angles
     _pid_vel_xy.reset_filter();
@@ -640,37 +655,44 @@ void AC_PosControl::update_xy_controller()
     float ahrsGndSpdLimit, ahrsControlScaleXY;
     AP::ahrs().getControlLimits(ahrsGndSpdLimit, ahrsControlScaleXY);
 
+    // update the position, velocity and acceleration offsets
+    update_offsets_xy();
+
     // Position Controller
 
-    const Vector3f &curr_pos = _inav.get_position_neu_cm();
+    _pos_target.xy() = _pos_desired.xy() + _pos_offset.xy();
+
     // determine the combined position of the actual position and the disturbance from system ID mode
+    const Vector3f &curr_pos = _inav.get_position_neu_cm();
     Vector3f comb_pos = curr_pos;
     comb_pos.xy() += _disturb_pos;
-    Vector2f vel_target = _p_pos_xy.update_all(_pos_target.x, _pos_target.y, comb_pos);
 
-    // add velocity feed-forward scaled to compensate for optical flow measurement induced EKF noise
-    vel_target *= ahrsControlScaleXY;
-    _vel_target.xy() = vel_target;
-    _vel_target.xy() += _vel_desired.xy();
+    Vector2f vel_target = _p_pos_xy.update_all(_pos_target.x, _pos_target.y, comb_pos);
+    _pos_desired.xy() = _pos_target.xy() - _pos_offset.xy();
 
     // Velocity Controller
 
-    const Vector2f &curr_vel = _inav.get_velocity_xy_cms();
+    // add velocity feed-forward scaled to compensate for optical flow measurement induced EKF noise
+    vel_target *= ahrsControlScaleXY;
+
+    _vel_target.xy() = vel_target;
+    _vel_target.xy() += _vel_desired.xy() + _vel_offset.xy();
+
     // determine the combined velocity of the actual velocity and the disturbance from system ID mode
+    const Vector2f &curr_vel = _inav.get_velocity_xy_cms();
     Vector2f comb_vel = curr_vel;
     comb_vel += _disturb_vel;
+
     Vector2f accel_target = _pid_vel_xy.update_all(_vel_target.xy(), comb_vel, _dt, _limit_vector.xy());
+
+    // Acceleration Controller
     
     // acceleration to correct for velocity error and scale PID output to compensate for optical flow measurement induced EKF noise
     accel_target *= ahrsControlScaleXY;
 
     // pass the correction acceleration to the target acceleration output
     _accel_target.xy() = accel_target;
-
-    // Add feed forward into the target acceleration output
-    _accel_target.xy() += _accel_desired.xy();
-
-    // Acceleration Controller
+    _accel_target.xy() += _accel_desired.xy() + _accel_offset.xy();
 
     // limit acceleration using maximum lean angles
     float angle_max = MIN(_attitude_control.get_althold_lean_angle_max_cd(), get_lean_angle_max_cd());
@@ -693,6 +715,7 @@ void AC_PosControl::update_xy_controller()
     accel_to_lean_angles(_accel_target.x, _accel_target.y, _roll_target, _pitch_target);
     calculate_yaw_and_rate_yaw();
 
+    // reset the disturbance from system ID mode to zero
     _disturb_pos.zero();
     _disturb_vel.zero();
 }
@@ -751,10 +774,14 @@ void AC_PosControl::init_z_controller_no_descent()
     init_z_controller();
 
     // remove all descent if present
-    _vel_desired.z = MAX(0.0, _vel_desired.z);
     _vel_target.z = MAX(0.0, _vel_target.z);
-    _accel_desired.z = MAX(0.0, _accel_desired.z);
+    _vel_desired.z = MAX(0.0, _vel_desired.z);
+    _vel_terrain = MAX(0.0, _vel_terrain);
+    _vel_offset.z = MAX(0.0, _vel_offset.z);
     _accel_target.z = MAX(0.0, _accel_target.z);
+    _accel_desired.z = MAX(0.0, _accel_desired.z);
+    _accel_terrain = MAX(0.0, _accel_terrain);
+    _accel_offset.z = MAX(0.0, _accel_offset.z);
 }
 
 /// init_z_controller_stopping_point - initialise the position controller to the stopping point with zero velocity and acceleration.
@@ -765,7 +792,8 @@ void AC_PosControl::init_z_controller_stopping_point()
     // Initialise the position controller to the current throttle, position, velocity and acceleration.
     init_z_controller();
 
-    get_stopping_point_z_cm(_pos_target.z);
+    get_stopping_point_z_cm(_pos_desired.z);
+    _pos_target.z = _pos_desired.z + _pos_offset.z;
     _vel_desired.z = 0.0f;
     _accel_desired.z = 0.0f;
 }
@@ -787,27 +815,25 @@ void AC_PosControl::relax_z_controller(float throttle_setting)
 ///     This function is private and contains all the shared z axis initialisation functions
 void AC_PosControl::init_z_controller()
 {
-    _pos_target.z = _inav.get_position_z_up_cm();
+    // initialise terrain targets and offsets to zero
+    init_terrain();
 
-    const float curr_vel_z = _inav.get_velocity_z_up_cms();
-    _vel_desired.z = curr_vel_z;
-    // with zero position error _vel_target = _vel_desired
-    _vel_target.z = curr_vel_z;
+    // initialise offsets to target offsets and ensure offset targets are zero if they have not been updated.
+    init_offsets_z();
+
+    _pos_target.z = _inav.get_position_z_up_cm();
+    _pos_desired.z = _pos_target.z - _pos_offset.z;
+
+    _vel_target.z = _inav.get_velocity_z_up_cms();
+    _vel_desired.z = _vel_target.z - _vel_offset.z;
 
     // Reset I term of velocity PID
     _pid_vel_z.reset_filter();
     _pid_vel_z.set_integrator(0.0f);
 
-    _accel_desired.z = constrain_float(get_z_accel_cmss(), -_accel_max_z_cmss, _accel_max_z_cmss);
-    // with zero position error _accel_target = _accel_desired
-    _accel_target.z = _accel_desired.z;
+    _accel_target.z = constrain_float(get_z_accel_cmss(), -_accel_max_z_cmss, _accel_max_z_cmss);
+    _accel_desired.z = _accel_target.z - (_accel_offset.z + _accel_terrain);
     _pid_accel_z.reset_filter();
-
-    // initialise vertical offsets
-    _pos_offset_target_z = 0.0;
-    _pos_offset_z = 0.0;
-    _vel_offset_z = 0.0;
-    _accel_offset_z = 0.0;
 
     // Set accel PID I term based on the current throttle
     // Remove the expected P term due to _accel_desired.z being constrained to _accel_max_z_cmss
@@ -831,7 +857,7 @@ void AC_PosControl::input_accel_z(float accel)
     float jerk_max_z_cmsss = _jerk_max_z_cmsss * calculate_overspeed_gain();
 
     // adjust desired alt if motors have not hit their limits
-    update_pos_vel_accel(_pos_target.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z, _p_pos_z.get_error(), _pid_vel_z.get_error());
+    update_pos_vel_accel(_pos_desired.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z, _p_pos_z.get_error(), _pid_vel_z.get_error());
 
     shape_accel(accel, _accel_desired.z, jerk_max_z_cmsss, _dt);
 }
@@ -848,7 +874,7 @@ void AC_PosControl::input_vel_accel_z(float &vel, float accel, bool limit_output
     const float jerk_max_z_cmsss = _jerk_max_z_cmsss * overspeed_gain;
 
     // adjust desired alt if motors have not hit their limits
-    update_pos_vel_accel(_pos_target.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z, _p_pos_z.get_error(), _pid_vel_z.get_error());
+    update_pos_vel_accel(_pos_desired.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z, _p_pos_z.get_error(), _pid_vel_z.get_error());
 
     shape_vel_accel(vel, accel,
                     _vel_desired.z, _accel_desired.z,
@@ -863,21 +889,7 @@ void AC_PosControl::input_vel_accel_z(float &vel, float accel, bool limit_output
 ///     The zero target altitude is varied to follow pos_offset_z
 void AC_PosControl::set_pos_target_z_from_climb_rate_cm(float vel)
 {
-    // remove terrain offsets for flat earth assumption
-    _pos_target.z -= _pos_offset_z;
-    _vel_desired.z -= _vel_offset_z;
-    _accel_desired.z -= _accel_offset_z;
-
-    float vel_temp = vel;
-    input_vel_accel_z(vel_temp, 0.0);
-
-    // update the vertical position, velocity and acceleration offsets
-    update_pos_offset_z(_pos_offset_target_z);
-
-    // add terrain offsets
-    _pos_target.z += _pos_offset_z;
-    _vel_desired.z += _vel_offset_z;
-    _accel_desired.z += _accel_offset_z;
+    input_vel_accel_z(vel, 0.0);
 }
 
 /// land_at_climb_rate_cm - adjusts target up or down using a commanded climb rate in cm/s
@@ -906,10 +918,10 @@ void AC_PosControl::input_pos_vel_accel_z(float &pos, float &vel, float accel, b
     const float jerk_max_z_cmsss = _jerk_max_z_cmsss * overspeed_gain;
 
     // adjust desired altitude if motors have not hit their limits
-    update_pos_vel_accel(_pos_target.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z, _p_pos_z.get_error(), _pid_vel_z.get_error());
+    update_pos_vel_accel(_pos_desired.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z, _p_pos_z.get_error(), _pid_vel_z.get_error());
 
     shape_pos_vel_accel(pos, vel, accel,
-                        _pos_target.z, _vel_desired.z, _accel_desired.z,
+                        _pos_desired.z, _vel_desired.z, _accel_desired.z,
                         _vel_max_down_cms, _vel_max_up_cms,
                         -constrain_float(accel_max_z_cmss, 0.0f, 750.0f), accel_max_z_cmss,
                         jerk_max_z_cmsss, _dt, limit_output);
@@ -927,19 +939,32 @@ void AC_PosControl::set_alt_target_with_slew(float pos)
     input_pos_vel_accel_z(pos, zero, 0);
 }
 
-/// update_pos_offset_z - updates the vertical offsets used by terrain following
-void AC_PosControl::update_pos_offset_z(float pos_offset_z)
+/// update_offsets_z - updates the vertical offsets used by terrain following
+void AC_PosControl::update_offsets_z()
 {
-    postype_t p_offset_z = _pos_offset_z;
-    update_pos_vel_accel(p_offset_z, _vel_offset_z, _accel_offset_z, _dt, MIN(_limit_vector.z, 0.0f), _p_pos_z.get_error(), _pid_vel_z.get_error());
-    _pos_offset_z = p_offset_z;
+    // check for offset target timeout
+    uint32_t now_ms = AP_HAL::millis();
+    if (now_ms - _posvelaccel_offset_target_z_ms > POSCONTROL_POSVELACCEL_OFFSET_TARGET_TIMEOUT_MS) {
+        _pos_offset_target.z = 0.0;
+        _vel_offset_target.z = 0.0;
+        _accel_offset_target.z = 0.0;
+    }
 
-    // input shape the terrain offset
-    shape_pos_vel_accel(pos_offset_z, 0.0f, 0.0f,
-        _pos_offset_z, _vel_offset_z, _accel_offset_z,
+    // update position, velocity, accel offsets for this iteration
+    postype_t p_offset_z = _pos_offset.z;
+    update_pos_vel_accel(p_offset_z, _vel_offset.z, _accel_offset.z, _dt, MIN(_limit_vector.z, 0.0f), _p_pos_z.get_error(), _pid_vel_z.get_error());
+    _pos_offset.z = p_offset_z;
+
+    // input shape vertical position, velocity and acceleration offsets
+    shape_pos_vel_accel(_pos_offset_target.z, _vel_offset_target.z, _accel_offset_target.z,
+        _pos_offset.z, _vel_offset.z, _accel_offset.z,
         get_max_speed_down_cms(), get_max_speed_up_cms(),
         -get_max_accel_z_cmss(), get_max_accel_z_cmss(),
         _jerk_max_z_cmsss, _dt, false);
+
+    p_offset_z = _pos_offset_target.z;
+    update_pos_vel_accel(p_offset_z, _vel_offset_target.z, _accel_offset_target.z, _dt, 0.0, 0.0, 0.0);
+    _pos_offset_target.z = p_offset_z;
 }
 
 // is_active_z - returns true if the z position controller has been run in the previous loop
@@ -968,6 +993,11 @@ void AC_PosControl::update_z_controller()
     }
     _last_update_z_ticks = AP::scheduler().ticks32();
 
+    // update the position, velocity and acceleration offsets
+    update_offsets_z();
+    update_terrain();
+    _pos_target.z = _pos_desired.z + _pos_offset.z + _pos_terrain;
+
     // calculate the target velocity correction
     float pos_target_zf = _pos_target.z;
 
@@ -975,9 +1005,10 @@ void AC_PosControl::update_z_controller()
     _vel_target.z *= AP::ahrs().getControlScaleZ();
 
     _pos_target.z = pos_target_zf;
+    _pos_desired.z = _pos_target.z - (_pos_offset.z + _pos_terrain);
 
     // add feed forward component
-    _vel_target.z += _vel_desired.z;
+    _vel_target.z += _vel_desired.z + _vel_offset.z + _vel_terrain;
 
     // Velocity Controller
 
@@ -986,7 +1017,7 @@ void AC_PosControl::update_z_controller()
     _accel_target.z *= AP::ahrs().getControlScaleZ();
 
     // add feed forward component
-    _accel_target.z += _accel_desired.z;
+    _accel_target.z += _accel_desired.z + _accel_offset.z + _accel_terrain;
 
     // Acceleration Controller
 
@@ -1045,18 +1076,18 @@ float AC_PosControl::get_lean_angle_max_cd() const
     return _lean_angle_max * 100.0f;
 }
 
-/// set position, velocity and acceleration targets
+/// set the desired position, velocity and acceleration targets
 void AC_PosControl::set_pos_vel_accel(const Vector3p& pos, const Vector3f& vel, const Vector3f& accel)
 {
-    _pos_target = pos;
+    _pos_desired = pos;
     _vel_desired = vel;
     _accel_desired = accel;
 }
 
-/// set position, velocity and acceleration targets
+/// set the desired position, velocity and acceleration targets
 void AC_PosControl::set_pos_vel_accel_xy(const Vector2p& pos, const Vector2f& vel, const Vector2f& accel)
 {
-    _pos_target.xy() = pos;
+    _pos_desired.xy() = pos;
     _vel_desired.xy() = vel;
     _accel_desired.xy() = accel;
 }
@@ -1079,6 +1110,136 @@ Vector3f AC_PosControl::lean_angles_to_accel(const Vector3f& att_target_euler) c
     };
 }
 
+/// Terrain
+
+/// set the terrain position, velocity and acceleration in cm, cms and cm/s/s from EKF origin in NE frame
+/// this is used to initiate the offsets when initialise the position controller or do an offset reset
+void AC_PosControl::init_terrain()
+{
+    // set terrain position and target to zero
+    _pos_terrain_target = 0.0;
+    _pos_terrain = 0.0;
+
+    // set velocity offset to zero
+    _vel_terrain = 0.0;
+
+    // set acceleration offset to zero
+    _accel_terrain = 0.0;
+}
+
+// init_pos_terrain_cm - initialises the current terrain altitude and target altitude to pos_offset_terrain_cm
+void AC_PosControl::init_pos_terrain_cm(float pos_terrain_cm)
+{
+    _pos_desired.z -= (pos_terrain_cm - _pos_terrain);
+    _pos_terrain_target = pos_terrain_cm;
+    _pos_terrain = pos_terrain_cm;
+}
+
+
+/// Offsets
+
+/// set the horizontal position, velocity and acceleration offsets in cm, cms and cm/s/s from EKF origin in NE frame
+/// this is used to initiate the offsets when initialise the position controller or do an offset reset
+void AC_PosControl::init_offsets_xy()
+{
+    // check for offset target timeout
+    uint32_t now_ms = AP_HAL::millis();
+    if (now_ms - _posvelaccel_offset_target_xy_ms > POSCONTROL_POSVELACCEL_OFFSET_TARGET_TIMEOUT_MS) {
+        _pos_offset_target.xy().zero();
+        _vel_offset_target.xy().zero();
+        _accel_offset_target.xy().zero();
+    }
+
+    // set position offset to target
+    _pos_offset.xy() = _pos_offset_target.xy();
+
+    // set velocity offset to target
+    _vel_offset.xy() = _vel_offset_target.xy();
+
+    // set acceleration offset to target
+    _accel_offset.xy() = _accel_offset_target.xy();
+}
+
+/// set the horizontal position, velocity and acceleration offsets in cm, cms and cm/s/s from EKF origin in NE frame
+/// this is used to initiate the offsets when initialise the position controller or do an offset reset
+void AC_PosControl::init_offsets_z()
+{
+    // check for offset target timeout
+    uint32_t now_ms = AP_HAL::millis();
+    if (now_ms - _posvelaccel_offset_target_z_ms > POSCONTROL_POSVELACCEL_OFFSET_TARGET_TIMEOUT_MS) {
+        _pos_offset_target.z = 0.0;
+        _vel_offset_target.z = 0.0;
+        _accel_offset_target.z = 0.0;
+    }
+    // set position offset to target
+    _pos_offset.z = _pos_offset_target.z;
+
+    // set velocity offset to target
+    _vel_offset.z = _vel_offset_target.z;
+
+    // set acceleration offset to target
+    _accel_offset.z = _accel_offset_target.z;
+}
+
+#if AP_SCRIPTING_ENABLED
+// add an additional offset to vehicle's target position, velocity and acceleration
+// units are m, m/s and m/s/s in NED frame
+// Z-axis is not currently supported and is ignored
+bool AC_PosControl::set_posvelaccel_offset(const Vector3f &pos_offset_NED, const Vector3f &vel_offset_NED, const Vector3f &accel_offset_NED)
+{
+    set_posvelaccel_offset_target_xy_cm(pos_offset_NED.topostype().xy() * 100.0, vel_offset_NED.xy() * 100.0, accel_offset_NED.xy() * 100.0);
+    set_posvelaccel_offset_target_z_cm(-pos_offset_NED.topostype().z * 100.0, -vel_offset_NED.z * 100, -accel_offset_NED.z * 100.0);
+    return true;
+}
+
+// get position and velocity offset to vehicle's target velocity and acceleration
+// units are m and m/s in NED frame
+bool AC_PosControl::get_posvelaccel_offset(Vector3f &pos_offset_NED, Vector3f &vel_offset_NED, Vector3f &accel_offset_NED)
+{
+    pos_offset_NED.xy() = _pos_offset_target.xy().tofloat() * 0.01;
+    pos_offset_NED.z = -_pos_offset_target.z * 0.01;
+    vel_offset_NED.xy() = _vel_offset_target.xy() * 0.01;
+    vel_offset_NED.z = -_vel_offset_target.z * 0.01;
+    accel_offset_NED.xy() = _accel_offset_target.xy() * 0.01;
+    accel_offset_NED.z = -_accel_offset_target.z * 0.01;
+    return true;
+}
+#endif
+
+/// set the horizontal position, velocity and acceleration offset targets in cm, cms and cm/s/s from EKF origin in NE frame
+/// these must be set every 3 seconds (or less) or they will timeout and return to zero
+void AC_PosControl::set_posvelaccel_offset_target_xy_cm(const Vector2p& pos_offset_target_xy_cm, const Vector2f& vel_offset_target_xy_cms, const Vector2f& accel_offset_target_xy_cmss)
+{
+    // set position offset target
+    _pos_offset_target.xy() = pos_offset_target_xy_cm;
+
+    // set velocity offset target
+    _vel_offset_target.xy() = vel_offset_target_xy_cms;
+
+    // set acceleration offset target
+    _accel_offset_target.xy() = accel_offset_target_xy_cmss;
+
+    // record time of update so we can detect timeouts
+    _posvelaccel_offset_target_xy_ms = AP_HAL::millis();
+}
+
+/// set the vertical position, velocity and acceleration offset targets in cm, cms and cm/s/s from EKF origin in NE frame
+/// these must be set every 3 seconds (or less) or they will timeout and return to zero
+void AC_PosControl::set_posvelaccel_offset_target_z_cm(float pos_offset_target_z_cm, float vel_offset_target_z_cms, const float accel_offset_target_z_cmss)
+{
+    // set position offset target
+    _pos_offset_target.z = pos_offset_target_z_cm;
+
+    // set velocity offset target
+    _vel_offset_target.z = vel_offset_target_z_cms;
+
+    // set acceleration offset target
+    _accel_offset_target.z = accel_offset_target_z_cmss;
+
+    // record time of update so we can detect timeouts
+    _posvelaccel_offset_target_z_ms = AP_HAL::millis();
+}
+
 // returns the NED target acceleration vector for attitude control
 Vector3f AC_PosControl::get_thrust_vector() const
 {
@@ -1091,10 +1252,12 @@ Vector3f AC_PosControl::get_thrust_vector() const
 ///    function does not change the z axis
 void AC_PosControl::get_stopping_point_xy_cm(Vector2p &stopping_point) const
 {
+    // todo: we should use the current target position and velocity if we are currently running the position controller
     stopping_point = _inav.get_position_xy_cm().topostype();
-    float kP = _p_pos_xy.kP();
+    stopping_point -= _pos_offset.xy();
 
     Vector2f curr_vel = _inav.get_velocity_xy_cms();
+    curr_vel -= _vel_offset.xy();
 
     // calculate current velocity
     float vel_total = curr_vel.length();
@@ -1102,7 +1265,8 @@ void AC_PosControl::get_stopping_point_xy_cm(Vector2p &stopping_point) const
     if (!is_positive(vel_total)) {
         return;
     }
-
+    
+    float kP = _p_pos_xy.kP();
     const float stopping_dist = stopping_distance(constrain_float(vel_total, 0.0, _vel_max_xy_cms), kP, _accel_max_xy_cmss);
     if (!is_positive(stopping_dist)) {
         return;
@@ -1116,7 +1280,11 @@ void AC_PosControl::get_stopping_point_xy_cm(Vector2p &stopping_point) const
 /// get_stopping_point_z_cm - calculates stopping point in NEU cm based on current position, velocity, vehicle acceleration
 void AC_PosControl::get_stopping_point_z_cm(postype_t &stopping_point) const
 {
-    const float curr_pos_z = _inav.get_position_z_up_cm();
+    float curr_pos_z = _inav.get_position_z_up_cm();
+    curr_pos_z -= _pos_offset.z;
+
+    float curr_vel_z = _inav.get_velocity_z_up_cms();
+    curr_vel_z -= _vel_offset.z;
 
     // avoid divide by zero by using current position if kP is very low or acceleration is zero
     if (!is_positive(_p_pos_z.kP()) || !is_positive(_accel_max_z_cmss)) {
@@ -1124,7 +1292,7 @@ void AC_PosControl::get_stopping_point_z_cm(postype_t &stopping_point) const
         return;
     }
 
-    stopping_point = curr_pos_z + constrain_float(stopping_distance(_inav.get_velocity_z_up_cms(), _p_pos_z.kP(), _accel_max_z_cmss), - POSCONTROL_STOPPING_DIST_DOWN_MAX, POSCONTROL_STOPPING_DIST_UP_MAX);
+    stopping_point = curr_pos_z + constrain_float(stopping_distance(curr_vel_z, _p_pos_z.kP(), _accel_max_z_cmss), - POSCONTROL_STOPPING_DIST_DOWN_MAX, POSCONTROL_STOPPING_DIST_UP_MAX);
 }
 
 /// get_bearing_to_target_cd - get bearing to target position in centi-degrees
@@ -1176,18 +1344,32 @@ void AC_PosControl::write_log()
     if (is_active_xy()) {
         float accel_x, accel_y;
         lean_angles_to_accel_xy(accel_x, accel_y);
-        Write_PSCN(get_pos_target_cm().x, _inav.get_position_neu_cm().x,
-                                get_vel_desired_cms().x, get_vel_target_cms().x, _inav.get_velocity_neu_cms().x,
-                                _accel_desired.x, get_accel_target_cmss().x, accel_x);
-        Write_PSCE(get_pos_target_cm().y, _inav.get_position_neu_cm().y,
-                                get_vel_desired_cms().y, get_vel_target_cms().y, _inav.get_velocity_neu_cms().y,
-                                _accel_desired.y, get_accel_target_cmss().y, accel_y);
+        Write_PSCN(_pos_desired.x, _pos_target.x, _inav.get_position_neu_cm().x,
+                   _vel_desired.x, _vel_target.x, _inav.get_velocity_neu_cms().x,
+                   _accel_desired.x, _accel_target.x, accel_x);
+        Write_PSCE(_pos_desired.y, _pos_target.y, _inav.get_position_neu_cm().y,
+                   _vel_desired.y, _vel_target.y, _inav.get_velocity_neu_cms().y,
+                   _accel_desired.y, _accel_target.y, accel_y);
+
+        // log offsets if they are being used
+        if (!_pos_offset.xy().is_zero()) {
+            Write_PSON(_pos_offset_target.x, _pos_offset.x, _vel_offset_target.x, _vel_offset.x, _accel_offset_target.x, _accel_offset.x);
+            Write_PSOE(_pos_offset_target.y, _pos_offset.y, _vel_offset_target.y, _vel_offset.y, _accel_offset_target.y, _accel_offset.y);
+        }
     }
 
     if (is_active_z()) {
-        Write_PSCD(-get_pos_target_cm().z, -_inav.get_position_z_up_cm(),
-                                -get_vel_desired_cms().z, -get_vel_target_cms().z, -_inav.get_velocity_z_up_cms(),
-                                -_accel_desired.z, -get_accel_target_cmss().z, -get_z_accel_cmss());
+        Write_PSCD(-_pos_desired.z, -_pos_target.z, -_inav.get_position_z_up_cm(),
+                   -_vel_desired.z, -_vel_target.z, -_inav.get_velocity_z_up_cms(),
+                   -_accel_desired.z, -_accel_target.z, -get_z_accel_cmss());
+
+        // log down and terrain offsets if they are being used
+        if (!is_zero(_pos_offset.z)) {
+            Write_PSOD(-_pos_offset_target.z, -_pos_offset.z, -_vel_offset_target.z, -_vel_offset.z, -_accel_offset_target.z, -_accel_offset.z);
+        }
+        if (!is_zero(_pos_terrain)) {
+            Write_PSOT(-_pos_terrain_target, -_pos_terrain, 0, -_vel_terrain, 0, -_accel_terrain);
+        }
     }
 }
 #endif  // HAL_LOGGING_ENABLED
@@ -1212,6 +1394,27 @@ float AC_PosControl::crosstrack_error() const
 ///
 /// private methods
 ///
+
+/// Terrain
+
+/// update_z_offsets - updates the vertical offsets used by terrain following
+void AC_PosControl::update_terrain()
+{
+    // update position, velocity, accel offsets for this iteration
+    postype_t pos_terrain = _pos_terrain;
+    update_pos_vel_accel(pos_terrain, _vel_terrain, _accel_terrain, _dt, MIN(_limit_vector.z, 0.0f), _p_pos_z.get_error(), _pid_vel_z.get_error());
+    _pos_terrain = pos_terrain;
+
+    // input shape horizontal position, velocity and acceleration offsets
+    shape_pos_vel_accel(_pos_terrain_target, 0.0, 0.0,
+        _pos_terrain, _vel_terrain, _accel_terrain,
+        get_max_speed_down_cms(), get_max_speed_up_cms(),
+        -get_max_accel_z_cmss(), get_max_accel_z_cmss(),
+        _jerk_max_z_cmsss, _dt, false);
+
+    // we do not have to update _pos_terrain_target because we assume the target velocity and acceleration are zero
+    // if we know how fast the terain altitude is changing we would add update_pos_vel_accel for _pos_terrain_target here
+}
 
 // get_lean_angles_to_accel - convert roll, pitch lean angles to NE frame accelerations in cm/s/s
 void AC_PosControl::accel_to_lean_angles(float accel_x_cmss, float accel_y_cmss, float& roll_target, float& pitch_target) const
@@ -1294,8 +1497,14 @@ void AC_PosControl::handle_ekf_xy_reset()
     uint32_t reset_ms = _ahrs.getLastPosNorthEastReset(pos_shift);
     if (reset_ms != _ekf_xy_reset_ms) {
 
+        // ToDo: move EKF steps into the offsets for modes setting absolute position and velocity
+        // for this we need some sort of switch to select what type of EKF handling we want to use
+
+        // To zero real position shift during relative position modes like Loiter, PosHold, Guided velocity and accleration control.
         _pos_target.xy() = (_inav.get_position_xy_cm() + _p_pos_xy.get_error()).topostype();
+        _pos_desired.xy() = _pos_target.xy() - _pos_offset.xy();
         _vel_target.xy() = _inav.get_velocity_xy_cms() + _pid_vel_xy.get_error();
+        _vel_desired.xy() = _vel_target.xy() - _vel_offset.xy();
 
         _ekf_xy_reset_ms = reset_ms;
     }
@@ -1316,8 +1525,14 @@ void AC_PosControl::handle_ekf_z_reset()
     uint32_t reset_ms = _ahrs.getLastPosDownReset(alt_shift);
     if (reset_ms != 0 && reset_ms != _ekf_z_reset_ms) {
 
+        // ToDo: move EKF steps into the offsets for modes setting absolute position and velocity
+        // for this we need some sort of switch to select what type of EKF handling we want to use
+
+        // To zero real position shift during relative position modes like Loiter, PosHold, Guided velocity and accleration control.
         _pos_target.z = _inav.get_position_z_up_cm() + _p_pos_z.get_error();
+        _pos_desired.z = _pos_target.z - (_pos_offset.z + _pos_terrain);
         _vel_target.z = _inav.get_velocity_z_up_cms() + _pid_vel_z.get_error();
+        _vel_desired.z = _vel_target.z - (_vel_offset.z + _vel_terrain);
 
         _ekf_z_reset_ms = reset_ms;
     }

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -11,6 +11,7 @@
 #include <AC_PID/AC_PID_Basic.h>    // PID library (1-axis)
 #include <AC_PID/AC_PID_2D.h>       // PID library (2-axis)
 #include <AP_InertialNav/AP_InertialNav.h>  // Inertial Navigation library
+#include <AP_Scripting/AP_Scripting_config.h>
 #include "AC_AttitudeControl.h"     // Attitude control library
 
 #include <AP_Logger/LogStructure.h>
@@ -52,7 +53,7 @@ public:
     float get_dt() const { return _dt; }
 
     /// get_shaping_jerk_xy_cmsss - gets the jerk limit of the xy kinematic path generation in cm/s/s/s
-    float get_shaping_jerk_xy_cmsss() const { return _shaping_jerk_xy*100.0; }
+    float get_shaping_jerk_xy_cmsss() const { return _shaping_jerk_xy * 100.0; }
 
 
     ///
@@ -62,7 +63,7 @@ public:
     /// input_pos_xyz - calculate a jerk limited path from the current position, velocity and acceleration to an input position.
     ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
     ///     The kinematic path is constrained by the maximum acceleration and jerk set using the function set_max_speed_accel_xy.
-    void input_pos_xyz(const Vector3p& pos, float pos_offset_z, float pos_offset_z_buffer);
+    void input_pos_xyz(const Vector3p& pos, float pos_terrain_target, float terrain_buffer);
 
     /// pos_offset_z_scaler - calculates a multiplier used to reduce the horizontal velocity to allow the z position controller to stay within the provided buffer range
     float pos_offset_z_scaler(float pos_offset_z, float pos_offset_z_buffer) const;
@@ -225,9 +226,6 @@ public:
     ///     using the default position control kinematic path.
     void set_alt_target_with_slew(float pos);
 
-    /// update_pos_offset_z - updates the vertical offsets used by terrain following
-    void update_pos_offset_z(float pos_offset);
-
     // is_active_z - returns true if the z position controller has been run in the previous 5 loop times
     bool is_active_z() const;
 
@@ -250,17 +248,26 @@ public:
 
     /// Position
 
-    /// set_pos_target_xy_cm - sets the position target, frame NEU in cm relative to the EKF origin
-    void set_pos_target_xy_cm(float pos_x, float pos_y) { _pos_target.x = pos_x; _pos_target.y = pos_y; }
-
     /// get_pos_target_cm - returns the position target, frame NEU in cm relative to the EKF origin
     const Vector3p& get_pos_target_cm() const { return _pos_target; }
 
-    /// set_pos_target_z_cm - set altitude target in cm above the EKF origin
-    void set_pos_target_z_cm(float pos_target) { _pos_target.z = pos_target; }
+    /// set_pos_desired_xy_cm - sets the position target, frame NEU in cm relative to the EKF origin
+    void set_pos_desired_xy_cm(const Vector2f& pos) { _pos_desired.xy() = pos.topostype(); }
+
+    /// get_pos_desired_cm - returns the position desired, frame NEU in cm relative to the EKF origin
+    const Vector3p& get_pos_desired_cm() const { return _pos_desired; }
 
     /// get_pos_target_z_cm - get target altitude (in cm above the EKF origin)
     float get_pos_target_z_cm() const { return _pos_target.z; }
+
+    /// set_pos_desired_z_cm - set altitude target in cm above the EKF origin
+    void set_pos_desired_z_cm(float pos_z) { _pos_desired.z = pos_z; }
+
+    /// get_pos_desired_z_cm - get target altitude (in cm above the EKF origin)
+    float get_pos_desired_z_cm() const { return _pos_desired.z; }
+
+
+    /// Stopping Point
 
     /// get_stopping_point_xy_cm - calculates stopping point in NEU cm based on current position, velocity, vehicle acceleration
     void get_stopping_point_xy_cm(Vector2p &stopping_point) const;
@@ -268,14 +275,17 @@ public:
     /// get_stopping_point_z_cm - calculates stopping point in NEU cm based on current position, velocity, vehicle acceleration
     void get_stopping_point_z_cm(postype_t &stopping_point) const;
 
+
+    /// Position Error
+
     /// get_pos_error_cm - get position error vector between the current and target position
-    const Vector3f get_pos_error_cm() const { return (_pos_target - _inav.get_position_neu_cm().topostype()).tofloat(); }
+    const Vector3f get_pos_error_cm() const { return Vector3f(_p_pos_xy.get_error().x, _p_pos_xy.get_error().y, _p_pos_z.get_error()); }
 
     /// get_pos_error_xy_cm - get the length of the position error vector in the xy plane
-    float get_pos_error_xy_cm() const { return get_horizontal_distance_cm(_inav.get_position_xy_cm().topostype(), _pos_target.xy()); }
+    float get_pos_error_xy_cm() const { return _p_pos_xy.get_error().length(); }
 
     /// get_pos_error_z_cm - returns altitude error in cm
-    float get_pos_error_z_cm() const { return (_pos_target.z - _inav.get_position_z_up_cm()); }
+    float get_pos_error_z_cm() const { return _p_pos_z.get_error(); }
 
 
     /// Velocity
@@ -286,7 +296,7 @@ public:
     /// set_vel_desired_xy_cms - sets horizontal desired velocity in NEU cm/s
     void set_vel_desired_xy_cms(const Vector2f &vel) {_vel_desired.xy() = vel; }
 
-    /// get_vel_desired_cms - returns desired velocity (i.e. feed forward) in cm/s in NEU
+    /// get_vel_desired_cms - returns desired velocity in cm/s in NEU
     const Vector3f& get_vel_desired_cms() { return _vel_desired; }
 
     // get_vel_target_cms - returns the target velocity in NEU cm/s
@@ -301,30 +311,56 @@ public:
 
     /// Acceleration
 
-    // set_accel_desired_xy_cmss set desired acceleration in cm/s in xy axis
+    // set_accel_desired_xy_cmss - set desired acceleration in cm/s in xy axis
     void set_accel_desired_xy_cmss(const Vector2f &accel_cms) { _accel_desired.xy() = accel_cms; }
 
     // get_accel_target_cmss - returns the target acceleration in NEU cm/s/s
     const Vector3f& get_accel_target_cmss() const { return _accel_target; }
 
 
+    /// Terrain
+
+    // set_pos_terrain_target_cm - set target terrain altitude in cm
+    void set_pos_terrain_target_cm(float pos_terrain_target) {_pos_terrain_target = pos_terrain_target;}
+
+    // init_pos_terrain_cm - initialises the current terrain altitude and target altitude to pos_offset_terrain_cm
+    void init_pos_terrain_cm(float pos_offset_terrain_cm);
+
+    // get_pos_terrain_cm - returns the current terrain altitude in cm
+    float get_pos_terrain_cm() { return _pos_terrain; }
+
+
     /// Offset
 
-    /// set_pos_offset_target_z_cm - set altitude offset target in cm above the EKF origin
-    void set_pos_offset_target_z_cm(float pos_offset_target_z) { _pos_offset_target_z = pos_offset_target_z; }
+#if AP_SCRIPTING_ENABLED
+    // position, velocity and acceleration offset target (only used by scripting)
+    // gets or sets an additional offset to the vehicle's target position, velocity and acceleration
+    // units are m, m/s and m/s/s in NED frame
+    bool set_posvelaccel_offset(const Vector3f &pos_offset_NED, const Vector3f &vel_offset_NED, const Vector3f &accel_offset_NED);
+    bool get_posvelaccel_offset(Vector3f &pos_offset_NED, Vector3f &vel_offset_NED, Vector3f &accel_offset_NED);
+#endif
+
+    /// set the horizontal position, velocity and acceleration offset targets in cm, cms and cm/s/s from EKF origin in NE frame
+    /// these must be set every 3 seconds (or less) or they will timeout and return to zero
+    void set_posvelaccel_offset_target_xy_cm(const Vector2p& pos_offset_target_xy_cm, const Vector2f& vel_offset_target_xy_cms, const Vector2f& accel_offset_target_xy_cmss);
+    void set_posvelaccel_offset_target_z_cm(float pos_offset_target_z_cm, float vel_offset_target_z_cms, float accel_offset_target_z_cmss);
+
+    /// get the position, velocity or acceleration offets in cm from EKF origin in NEU frame
+    const Vector3p& get_pos_offset_cm() const { return _pos_offset; }
+    const Vector3f& get_vel_offset_cms() const { return _vel_offset; }
+    const Vector3f& get_accel_offset_cmss() const { return _accel_offset; }
 
     /// set_pos_offset_z_cm - set altitude offset in cm above the EKF origin
-    void set_pos_offset_z_cm(float pos_offset_z) { _pos_offset_z = pos_offset_z; }
+    void set_pos_offset_z_cm(float pos_offset_z) { _pos_offset.z = pos_offset_z; }
 
     /// get_pos_offset_z_cm - returns altitude offset in cm above the EKF origin
-    float get_pos_offset_z_cm() const { return _pos_offset_z; }
+    float get_pos_offset_z_cm() const { return _pos_offset.z; }
 
     /// get_vel_offset_z_cm - returns current vertical offset speed in cm/s
-    float get_vel_offset_z_cms() const { return _vel_offset_z; }
+    float get_vel_offset_z_cms() const { return _vel_offset.z; }
 
     /// get_accel_offset_z_cm - returns current vertical offset acceleration in cm/s/s
-    float get_accel_offset_z_cmss() const { return _accel_offset_z; }
-
+    float get_accel_offset_z_cmss() const { return _accel_offset.z; }
 
     /// Outputs
 
@@ -407,9 +443,13 @@ public:
 
     static const struct AP_Param::GroupInfo var_info[];
 
-    static void Write_PSCN(float pos_target, float pos, float vel_desired, float vel_target, float vel, float accel_desired, float accel_target, float accel);
-    static void Write_PSCE(float pos_target, float pos, float vel_desired, float vel_target, float vel, float accel_desired, float accel_target, float accel);
-    static void Write_PSCD(float pos_target, float pos, float vel_desired, float vel_target, float vel, float accel_desired, float accel_target, float accel);
+    static void Write_PSCN(float pos_desired, float pos_target, float pos, float vel_desired, float vel_target, float vel, float accel_desired, float accel_target, float accel);
+    static void Write_PSCE(float pos_desired, float pos_target, float pos, float vel_desired, float vel_target, float vel, float accel_desired, float accel_target, float accel);
+    static void Write_PSCD(float pos_desired, float pos_target, float pos, float vel_desired, float vel_target, float vel, float accel_desired, float accel_target, float accel);
+    static void Write_PSON(float pos_target_offset_cm, float pos_offset_cm, float vel_target_offset_cms, float vel_offset_cms, float accel_target_offset_cmss, float accel_offset_cmss);
+    static void Write_PSOE(float pos_target_offset_cm, float pos_offset_cm, float vel_target_offset_cms, float vel_offset_cms, float accel_target_offset_cmss, float accel_offset_cmss);
+    static void Write_PSOD(float pos_target_offset_cm, float pos_offset_cm, float vel_target_offset_cms, float vel_offset_cms, float accel_target_offset_cmss, float accel_offset_cmss);
+    static void Write_PSOT(float pos_target_offset_cm, float pos_offset_cm, float vel_target_offset_cms, float vel_offset_cms, float accel_target_offset_cmss, float accel_offset_cmss);
 
 protected:
 
@@ -427,6 +467,32 @@ protected:
 
     // calculate_overspeed_gain - calculated increased maximum acceleration and jerk if over speed condition is detected
     float calculate_overspeed_gain();
+
+
+    /// Terrain Following
+
+    /// set the position, velocity and acceleration offsets in cm, cms and cm/s/s from EKF origin in NE frame
+    /// this is used to initiate the offsets when initialise the position controller or do an offset reset
+    /// note that this sets the actual offsets, not the offset targets
+    void init_terrain();
+
+    /// update_terrain - updates the terrain position, velocity and acceleration estimation
+    /// this moves the estimated terrain position _pos_terrain towards the target _pos_terrain_target
+    void update_terrain();
+
+
+    /// Offsets
+
+    /// init_offsets - set the position, velocity and acceleration offsets in cm, cms and cm/s/s from EKF origin in NE frame
+    /// this is used to initiate the offsets when initialise the position controller or do an offset reset
+    /// note that this sets the actual offsets, not the offset targets
+    void init_offsets_xy();
+    void init_offsets_z();
+
+    /// update_offsets - update the position and velocity offsets
+    /// this moves the offsets (e.g _pos_offset, _vel_offset, _accel_offset) towards the targets (e.g. _pos_offset_target or _vel_offset_target)
+    void update_offsets_xy();
+    void update_offsets_z();
 
     /// initialise and check for ekf position resets
     void init_ekf_xy_reset();
@@ -472,7 +538,8 @@ protected:
     float       _yaw_rate_target;       // desired yaw rate in centi-degrees per second calculated by position controller
 
     // position controller internal variables
-    Vector3p    _pos_target;            // target location, frame NEU in cm relative to the EKF origin
+    Vector3p    _pos_desired;           // desired location, frame NEU in cm relative to the EKF origin.  This is equal to the _pos_target minus offsets
+    Vector3p    _pos_target;            // target location, frame NEU in cm relative to the EKF origin.  This is equal to the _pos_desired plus offsets
     Vector3f    _vel_desired;           // desired velocity in NEU cm/s
     Vector3f    _vel_target;            // velocity target in NEU cm/s calculated by pos_to_rate step
     Vector3f    _accel_desired;         // desired acceleration in NEU cm/s/s (feed forward)
@@ -481,10 +548,21 @@ protected:
 
     bool        _fwd_pitch_is_limited;     // true when the forward pitch demand is being limited to meet acceleration limits
 
-    float       _pos_offset_target_z;   // vertical position offset target, frame NEU in cm relative to the EKF origin
-    float       _pos_offset_z;          // vertical position offset, frame NEU in cm relative to the EKF origin
-    float       _vel_offset_z;          // vertical velocity offset in NEU cm/s calculated by pos_to_rate step
-    float       _accel_offset_z;        // vertical acceleration offset in NEU cm/s/s
+    // terrain handling variables
+    float    _pos_terrain_target;       // position terrain target in cm relative to the EKF origin in NEU frame
+    float    _pos_terrain;              // position terrain in cm from the EKF origin in NEU frame.  this terrain moves towards _pos_terrain_target
+    float    _vel_terrain;              // velocity terrain in NEU cm/s calculated by pos_to_rate step.  this terrain moves towards _vel_terrain_target
+    float    _accel_terrain;            // acceleration terrain in NEU cm/s/s
+
+    // offset handling variables
+    Vector3p    _pos_offset_target;     // position offset target in cm relative to the EKF origin in NEU frame
+    Vector3p    _pos_offset;            // position offset in cm from the EKF origin in NEU frame.  this offset moves towards _pos_offset_target
+    Vector3f    _vel_offset_target;     // velocity offset target in cm/s in NEU frame
+    Vector3f    _vel_offset;            // velocity offset in NEU cm/s calculated by pos_to_rate step.  this offset moves towards _vel_offset_target
+    Vector3f    _accel_offset_target;   // acceleration offset target in cm/s/s in NEU frame
+    Vector3f    _accel_offset;          // acceleration offset in NEU cm/s/s
+    uint32_t    _posvelaccel_offset_target_xy_ms;   // system time that pos, vel, accel targets were set (used to implement timeouts)
+    uint32_t    _posvelaccel_offset_target_z_ms;    // system time that pos, vel, accel targets were set (used to implement timeouts)
 
     // ekf reset handling
     uint32_t    _ekf_xy_reset_ms;       // system time of last recorded ekf xy position reset
@@ -502,6 +580,11 @@ protected:
 private:
     // convenience method for writing out the identical PSCE, PSCN, PSCD - and
     // to save bytes
-    static void Write_PSCx(LogMessages ID, float pos_target, float pos, float vel_desired, float vel_target, float vel, float accel_desired, float accel_target, float accel);
+    static void Write_PSCx(LogMessages ID, float pos_desired, float pos_target, float pos, float vel_desired, float vel_target, float vel, float accel_desired, float accel_target, float accel);
+
+    // a convenience function for writing out the position controller offsets
+    static void Write_PSOx(LogMessages id, float pos_target_offset_cm, float pos_offset_cm,
+                           float vel_target_offset_cms, float vel_offset_cms,
+                           float accel_target_offset_cmss, float accel_offset_cmss);
 
 };

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -44,7 +44,8 @@ public:
     AC_PosControl(AP_AHRS_View& ahrs, const AP_InertialNav& inav,
                   const class AP_Motors& motors, AC_AttitudeControl& attitude_control);
 
-
+    // do not allow copying
+    CLASS_NO_COPY(AC_PosControl);
 
     /// set_dt / get_dt - dt is the time since the last time the position controllers were updated
     ///   _dt should be set based on the time of the last IMU read used by these controllers
@@ -451,6 +452,9 @@ public:
     static void Write_PSOD(float pos_target_offset_cm, float pos_offset_cm, float vel_target_offset_cms, float vel_offset_cms, float accel_target_offset_cmss, float accel_offset_cmss);
     static void Write_PSOT(float pos_target_offset_cm, float pos_offset_cm, float vel_target_offset_cms, float vel_offset_cms, float accel_target_offset_cmss, float accel_offset_cmss);
 
+    // singleton
+    static AC_PosControl *get_singleton(void) { return _singleton; }
+
 protected:
 
     // get throttle using vibration-resistant calculation (uses feed forward with manually calculated gain)
@@ -587,4 +591,6 @@ private:
                            float vel_target_offset_cms, float vel_offset_cms,
                            float accel_target_offset_cmss, float accel_offset_cmss);
 
+    // singleton
+    static AC_PosControl *_singleton;
 };

--- a/libraries/AC_AttitudeControl/AC_PosControl_Logging.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl_Logging.cpp
@@ -8,11 +8,12 @@
 #include "LogStructure.h"
 
 // a convenience function for writing out the position controller PIDs
-void AC_PosControl::Write_PSCx(LogMessages id, float pos_target, float pos, float vel_desired, float vel_target, float vel, float accel_desired, float accel_target, float accel)
+void AC_PosControl::Write_PSCx(LogMessages id, float pos_desired, float pos_target, float pos, float vel_desired, float vel_target, float vel, float accel_desired, float accel_target, float accel)
 {
     const struct log_PSCx pkt{
         LOG_PACKET_HEADER_INIT(id),
             time_us         : AP_HAL::micros64(),
+            pos_desired   : pos_desired * 0.01f,
             pos_target    : pos_target * 0.01f,
             pos           : pos * 0.01f,
             vel_desired   : vel_desired * 0.01f,
@@ -25,19 +26,65 @@ void AC_PosControl::Write_PSCx(LogMessages id, float pos_target, float pos, floa
     AP::logger().WriteBlock(&pkt, sizeof(pkt));
 }
 
-void AC_PosControl::Write_PSCN(float pos_target, float pos, float vel_desired, float vel_target, float vel, float accel_desired, float accel_target, float accel)
+void AC_PosControl::Write_PSCN(float pos_desired, float pos_target, float pos, float vel_desired, float vel_target, float vel, float accel_desired, float accel_target, float accel)
 {
-    Write_PSCx(LOG_PSCN_MSG, pos_target, pos, vel_desired, vel_target, vel, accel_desired, accel_target, accel);
+    Write_PSCx(LOG_PSCN_MSG, pos_desired, pos_target, pos, vel_desired, vel_target, vel, accel_desired, accel_target, accel);
 }
 
-void AC_PosControl::Write_PSCE(float pos_target, float pos, float vel_desired, float vel_target, float vel, float accel_desired, float accel_target, float accel)
+void AC_PosControl::Write_PSCE(float pos_desired, float pos_target, float pos, float vel_desired, float vel_target, float vel, float accel_desired, float accel_target, float accel)
 {
-    Write_PSCx(LOG_PSCE_MSG, pos_target, pos, vel_desired, vel_target, vel, accel_desired, accel_target, accel);
+    Write_PSCx(LOG_PSCE_MSG, pos_desired, pos_target, pos, vel_desired, vel_target, vel, accel_desired, accel_target, accel);
 }
 
-void AC_PosControl::Write_PSCD(float pos_target, float pos, float vel_desired, float vel_target, float vel, float accel_desired, float accel_target, float accel)
+void AC_PosControl::Write_PSCD(float pos_desired, float pos_target, float pos, float vel_desired, float vel_target, float vel, float accel_desired, float accel_target, float accel)
 {
-    Write_PSCx(LOG_PSCD_MSG, pos_target, pos, vel_desired, vel_target, vel, accel_desired, accel_target, accel);
+    Write_PSCx(LOG_PSCD_MSG, pos_desired, pos_target, pos, vel_desired, vel_target, vel, accel_desired, accel_target, accel);
+}
+
+// a convenience function for writing out the position controller offsets
+void AC_PosControl::Write_PSOx(LogMessages id, float pos_target_offset_cm, float pos_offset_cm,
+                               float vel_target_offset_cms, float vel_offset_cms,
+                               float accel_target_offset_cmss, float accel_offset_cmss)
+{
+    const struct log_PSOx pkt{
+        LOG_PACKET_HEADER_INIT(id),
+            time_us             : AP_HAL::micros64(),
+            pos_target_offset   : pos_target_offset_cm * 0.01f,
+            pos_offset          : pos_offset_cm * 0.01f,
+            vel_target_offset   : vel_target_offset_cms * 0.01f,
+            vel_offset          : vel_offset_cms * 0.01f,
+            accel_target_offset : accel_target_offset_cmss * 0.01f,
+            accel_offset        : accel_offset_cmss * 0.01f,
+    };
+    AP::logger().WriteBlock(&pkt, sizeof(pkt));
+}
+
+void AC_PosControl::Write_PSON(float pos_target_offset_cm, float pos_offset_cm,
+                               float vel_target_offset_cms, float vel_offset_cms,
+                               float accel_target_offset_cmss, float accel_offset_cmss)
+{
+    Write_PSOx(LOG_PSON_MSG, pos_target_offset_cm, pos_offset_cm, vel_target_offset_cms, vel_offset_cms, accel_target_offset_cmss, accel_offset_cmss);
+}
+
+void AC_PosControl::Write_PSOE(float pos_target_offset_cm, float pos_offset_cm,
+                               float vel_target_offset_cms, float vel_offset_cms,
+                               float accel_target_offset_cmss, float accel_offset_cmss)
+{
+    Write_PSOx(LOG_PSOE_MSG, pos_target_offset_cm, pos_offset_cm, vel_target_offset_cms, vel_offset_cms, accel_target_offset_cmss, accel_offset_cmss);
+}
+
+void AC_PosControl::Write_PSOD(float pos_target_offset_cm, float pos_offset_cm,
+                               float vel_target_offset_cms, float vel_offset_cms,
+                               float accel_target_offset_cmss, float accel_offset_cmss)
+{
+    Write_PSOx(LOG_PSOD_MSG, pos_target_offset_cm, pos_offset_cm, vel_target_offset_cms, vel_offset_cms, accel_target_offset_cmss, accel_offset_cmss);
+}
+
+void AC_PosControl::Write_PSOT(float pos_target_offset_cm, float pos_offset_cm,
+                               float vel_target_offset_cms, float vel_offset_cms,
+                               float accel_target_offset_cmss, float accel_offset_cmss)
+{
+    Write_PSOx(LOG_PSOT_MSG, pos_target_offset_cm, pos_offset_cm, vel_target_offset_cms, vel_offset_cms, accel_target_offset_cmss, accel_offset_cmss);
 }
 
 #endif  // HAL_LOGGING_ENABLED

--- a/libraries/AC_AttitudeControl/LogStructure.h
+++ b/libraries/AC_AttitudeControl/LogStructure.h
@@ -6,11 +6,16 @@
     LOG_PSCN_MSG, \
     LOG_PSCE_MSG, \
     LOG_PSCD_MSG, \
+    LOG_PSON_MSG, \
+    LOG_PSOE_MSG, \
+    LOG_PSOD_MSG, \
+    LOG_PSOT_MSG, \
     LOG_ANG_MSG
 
 // @LoggerMessage: PSCN
 // @Description: Position Control North
 // @Field: TimeUS: Time since system startup
+// @Field: DPN: Desired position relative to EKF origin
 // @Field: TPN: Target position relative to EKF origin
 // @Field: PN: Position relative to EKF origin
 // @Field: DVN: Desired velocity North
@@ -23,6 +28,7 @@
 // @LoggerMessage: PSCE
 // @Description: Position Control East
 // @Field: TimeUS: Time since system startup
+// @Field: DPE: Desired position relative to EKF origin + Offsets
 // @Field: TPE: Target position relative to EKF origin
 // @Field: PE: Position relative to EKF origin
 // @Field: DVE: Desired velocity East
@@ -35,6 +41,7 @@
 // @LoggerMessage: PSCD
 // @Description: Position Control Down
 // @Field: TimeUS: Time since system startup
+// @Field: DPD: Desired position relative to EKF origin + Offsets
 // @Field: TPD: Target position relative to EKF origin
 // @Field: PD: Position relative to EKF origin
 // @Field: DVD: Desired velocity Down
@@ -49,6 +56,7 @@
 struct PACKED log_PSCx {
     LOG_PACKET_HEADER;
     uint64_t time_us;
+    float pos_desired;
     float pos_target;
     float pos;
     float vel_desired;
@@ -57,6 +65,58 @@ struct PACKED log_PSCx {
     float accel_desired;
     float accel_target;
     float accel;
+};
+
+// @LoggerMessage: PSON
+// @Description: Position Control Offsets North
+// @Field: TimeUS: Time since system startup
+// @Field: TPON: Target position offset North
+// @Field: PON: Position offset North
+// @Field: TVON: Target velocity offset North
+// @Field: VON: Velocity offset North
+// @Field: TAON: Target acceleration offset North
+// @Field: AON: Acceleration offset North
+
+// @LoggerMessage: PSOE
+// @Description: Position Control Offsets East
+// @Field: TimeUS: Time since system startup
+// @Field: TPOE: Target position offset East
+// @Field: POE: Position offset East
+// @Field: TVOE: Target velocity offset East
+// @Field: VOE: Velocity offset East
+// @Field: TAOE: Target acceleration offset East
+// @Field: AOE: Acceleration offset East
+
+// @LoggerMessage: PSOD
+// @Description: Position Control Offsets Down
+// @Field: TimeUS: Time since system startup
+// @Field: TPOD: Target position offset Down
+// @Field: POD: Position offset Down
+// @Field: TVOD: Target velocity offset Down
+// @Field: VOD: Velocity offset Down
+// @Field: TAOD: Target acceleration offset Down
+// @Field: AOD: Acceleration offset Down
+
+// @LoggerMessage: PSOT
+// @Description: Position Control Offsets Terrain (Down)
+// @Field: TimeUS: Time since system startup
+// @Field: TPOT: Target position offset Terrain
+// @Field: POT: Position offset Terrain
+// @Field: TVOT: Target velocity offset Terrain
+// @Field: VOT: Velocity offset Terrain
+// @Field: TAOT: Target acceleration offset Terrain
+// @Field: AOT: Acceleration offset Terrain
+
+// position controller per-axis offset logging
+struct PACKED log_PSOx {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    float pos_target_offset;
+    float pos_offset;
+    float vel_target_offset;
+    float vel_offset;
+    float accel_target_offset;
+    float accel_offset;
 };
 
 // @LoggerMessage: RATE
@@ -115,17 +175,29 @@ struct PACKED log_ANG {
     float sensor_dt;
 };
 
-#define PSCx_FMT "Qffffffff"
-#define PSCx_UNITS "smmnnnooo"
-#define PSCx_MULTS "F00000000"
+#define PSCx_FMT "Qfffffffff"
+#define PSCx_UNITS "smmmnnnooo"
+#define PSCx_MULTS "F000000000"
+
+#define PSOx_FMT "Qffffff"
+#define PSOx_UNITS "smmnnoo"
+#define PSOx_MULTS "F000000"
 
 #define LOG_STRUCTURE_FROM_AC_ATTITUDECONTROL        \
     { LOG_PSCN_MSG, sizeof(log_PSCx), \
-      "PSCN", PSCx_FMT, "TimeUS,TPN,PN,DVN,TVN,VN,DAN,TAN,AN", PSCx_UNITS, PSCx_MULTS }, \
+      "PSCN", PSCx_FMT, "TimeUS,DPN,TPN,PN,DVN,TVN,VN,DAN,TAN,AN", PSCx_UNITS, PSCx_MULTS }, \
     { LOG_PSCE_MSG, sizeof(log_PSCx), \
-      "PSCE", PSCx_FMT, "TimeUS,TPE,PE,DVE,TVE,VE,DAE,TAE,AE", PSCx_UNITS, PSCx_MULTS }, \
+      "PSCE", PSCx_FMT, "TimeUS,DPE,TPE,PE,DVE,TVE,VE,DAE,TAE,AE", PSCx_UNITS, PSCx_MULTS }, \
     { LOG_PSCD_MSG, sizeof(log_PSCx), \
-      "PSCD", PSCx_FMT, "TimeUS,TPD,PD,DVD,TVD,VD,DAD,TAD,AD", PSCx_UNITS, PSCx_MULTS }, \
+      "PSCD", PSCx_FMT, "TimeUS,DPD,TPD,PD,DVD,TVD,VD,DAD,TAD,AD", PSCx_UNITS, PSCx_MULTS }, \
+    { LOG_PSON_MSG, sizeof(log_PSOx), \
+      "PSON", PSOx_FMT, "TimeUS,TPON,PON,TVON,VON,TAON,AON", PSOx_UNITS, PSOx_MULTS }, \
+    { LOG_PSOE_MSG, sizeof(log_PSOx), \
+      "PSOE", PSOx_FMT, "TimeUS,TPOE,POE,TVOE,VOE,TAOE,AOE", PSOx_UNITS, PSOx_MULTS }, \
+    { LOG_PSOD_MSG, sizeof(log_PSOx), \
+      "PSOD", PSOx_FMT, "TimeUS,TPOD,POD,TVOD,VOD,TAOD,AOD", PSOx_UNITS, PSOx_MULTS }, \
+    { LOG_PSOT_MSG, sizeof(log_PSOx), \
+      "PSOT", PSOx_FMT, "TimeUS,TPOT,POT,TVOT,VOT,TAOT,AOT", PSOx_UNITS, PSOx_MULTS }, \
     { LOG_RATE_MSG, sizeof(log_Rate), \
         "RATE", "Qfffffffffffff",  "TimeUS,RDes,R,ROut,PDes,P,POut,YDes,Y,YOut,ADes,A,AOut,AOutSlew", "skk-kk-kk-oo--", "F?????????BB--" , true }, \
     { LOG_ANG_MSG, sizeof(log_ANG),\

--- a/libraries/AC_PID/AC_P_2D.h
+++ b/libraries/AC_PID/AC_P_2D.h
@@ -55,7 +55,7 @@ private:
     AP_Float    _kp;
 
     // internal variables
-    Vector2f _error;    // time step in seconds
+    Vector2f _error;    // error between target and measured
     float _error_max;   // error limit in positive direction
     float _D1_max;      // maximum first derivative of output
 

--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -234,27 +234,28 @@ bool AC_Circle::update(float climb_rate_cms)
 
 // get_closest_point_on_circle - returns closest point on the circle
 //  circle's center should already have been set
-//  closest point on the circle will be placed in result
+//  closest point on the circle will be placed in result, dist_cm will be updated with the 3D distance to the center
 //  result's altitude (i.e. z) will be set to the circle_center's altitude
 //  if vehicle is at the center of the circle, the edge directly behind vehicle will be returned
-void AC_Circle::get_closest_point_on_circle(Vector3f &result) const
+void AC_Circle::get_closest_point_on_circle(Vector3f& result, float& dist_cm) const
 {
+    // get current position
+    Vector3p stopping_point;
+    _pos_control.get_stopping_point_xy_cm(stopping_point.xy());
+    _pos_control.get_stopping_point_z_cm(stopping_point.z);
+
+    // calc vector from stopping point to circle center
+    Vector3f vec = (stopping_point - _center).tofloat();
+    dist_cm = vec.length();
+
     // return center if radius is zero
     if (!is_positive(_radius)) {
         result = _center.tofloat();
         return;
     }
 
-    // get current position
-    Vector2p stopping_point;
-    _pos_control.get_stopping_point_xy_cm(stopping_point);
-
-    // calc vector from stopping point to circle center
-    Vector2f vec = (stopping_point - _center.xy()).tofloat();
-    float dist = vec.length();
-
     // if current location is exactly at the center of the circle return edge directly behind vehicle
-    if (is_zero(dist)) {
+    if (is_zero(dist_cm)) {
         result.x = _center.x - _radius * _ahrs.cos_yaw();
         result.y = _center.y - _radius * _ahrs.sin_yaw();
         result.z = _center.z;
@@ -262,8 +263,8 @@ void AC_Circle::get_closest_point_on_circle(Vector3f &result) const
     }
 
     // calculate closest point on edge of circle
-    result.x = _center.x + vec.x / dist * _radius;
-    result.y = _center.y + vec.y / dist * _radius;
+    result.x = _center.x + vec.x / dist_cm * _radius;
+    result.y = _center.y + vec.y / dist_cm * _radius;
     result.z = _center.z;
 }
 

--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -240,7 +240,7 @@ bool AC_Circle::update(float climb_rate_cms)
 void AC_Circle::get_closest_point_on_circle(Vector3f &result) const
 {
     // return center if radius is zero
-    if (_radius <= 0) {
+    if (!is_positive(_radius)) {
         result = _center.tofloat();
         return;
     }

--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -75,10 +75,10 @@ public:
 
     // get_closest_point_on_circle - returns closest point on the circle
     //  circle's center should already have been set
-    //  closest point on the circle will be placed in result
+    //  closest point on the circle will be placed in result, dist_cm will be updated with the distance to the center
     //  result's altitude (i.e. z) will be set to the circle_center's altitude
     //  if vehicle is at the center of the circle, the edge directly behind vehicle will be returned
-    void get_closest_point_on_circle(Vector3f &result) const;
+    void get_closest_point_on_circle(Vector3f& result, float& dist_cm) const;
 
     /// get horizontal distance to loiter target in cm
     float get_distance_to_target() const { return _pos_control.get_pos_error_xy_cm(); }

--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -123,8 +123,7 @@ void AC_Loiter::init_target()
     _pos_control.relax_velocity_controller_xy();
 
     // initialise predicted acceleration and angles from the position controller
-    _predicted_accel.x = _pos_control.get_accel_target_cmss().x;
-    _predicted_accel.y = _pos_control.get_accel_target_cmss().y;
+    _predicted_accel = _pos_control.get_accel_target_cmss().xy();
     _predicted_euler_angle.x = radians(_pos_control.get_roll_cd()*0.01f);
     _predicted_euler_angle.y = radians(_pos_control.get_pitch_cd()*0.01f);
     _brake_accel = 0.0f;

--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -107,7 +107,7 @@ void AC_Loiter::init_target(const Vector2f& position)
     _brake_accel = 0.0f;
 
     // set target position
-    _pos_control.set_pos_target_xy_cm(position.x, position.y);
+    _pos_control.set_pos_desired_xy_cm(position);
 }
 
 /// initialize's position and feed-forward velocity from current pos and velocity
@@ -221,12 +221,10 @@ void AC_Loiter::calc_desired_velocity(bool avoidance_on)
     }
 
     // get loiters desired velocity from the position controller where it is being stored.
-    const Vector3f &desired_vel_3d = _pos_control.get_vel_desired_cms();
-    Vector2f desired_vel{desired_vel_3d.x,desired_vel_3d.y};
+    Vector2f desired_vel = _pos_control.get_vel_desired_cms().xy();
 
     // update the desired velocity using our predicted acceleration
-    desired_vel.x += _predicted_accel.x * dt;
-    desired_vel.y += _predicted_accel.y * dt;
+    desired_vel += _predicted_accel * dt;
 
     Vector2f loiter_accel_brake;
     float desired_speed = desired_vel.length();
@@ -261,8 +259,7 @@ void AC_Loiter::calc_desired_velocity(bool avoidance_on)
     // Apply EKF limit to desired velocity -  this limit is calculated by the EKF and adjusted as required to ensure certain sensor limits are respected (eg optical flow sensing)
     float horizSpdDem = desired_vel.length();
     if (horizSpdDem > gnd_speed_limit_cms) {
-        desired_vel.x = desired_vel.x * gnd_speed_limit_cms / horizSpdDem;
-        desired_vel.y = desired_vel.y * gnd_speed_limit_cms / horizSpdDem;
+        desired_vel = desired_vel * gnd_speed_limit_cms / horizSpdDem;
     }
 
 #if AP_AVOIDANCE_ENABLED && !APM_BUILD_TYPE(APM_BUILD_ArduPlane)
@@ -279,11 +276,11 @@ void AC_Loiter::calc_desired_velocity(bool avoidance_on)
 #endif // !APM_BUILD_ArduPlane
 
     // get loiters desired velocity from the position controller where it is being stored.
-    Vector2p target_pos = _pos_control.get_pos_target_cm().xy();
+    Vector2p desired_pos = _pos_control.get_pos_desired_cm().xy();
 
-    // update the target position using our predicted velocity
-    target_pos += (desired_vel * dt).topostype();
+    // update the desired position using our desired velocity and acceleration
+    desired_pos += (desired_vel * dt).topostype();
 
     // send adjusted feed forward acceleration and velocity back to the Position Controller
-    _pos_control.set_pos_vel_accel_xy(target_pos, desired_vel, _desired_accel);
+    _pos_control.set_pos_vel_accel_xy(desired_pos, desired_vel, _desired_accel);
 }

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -323,11 +323,11 @@ bool AC_WPNav::set_wp_destination(const Vector3f& destination, bool terrain_alt)
         if (terrain_alt) {
             // new destination is alt-above-terrain, previous destination was alt-above-ekf-origin
             _origin.z -= origin_terr_offset;
-            _pos_control.set_pos_offset_z_cm(_pos_control.get_pos_offset_z_cm() + origin_terr_offset);
+            _pos_control.init_pos_terrain_cm(origin_terr_offset);
         } else {
             // new destination is alt-above-ekf-origin, previous destination was alt-above-terrain
             _origin.z += origin_terr_offset;
-            _pos_control.set_pos_offset_z_cm(_pos_control.get_pos_offset_z_cm() - origin_terr_offset);
+            _pos_control.init_pos_terrain_cm(0.0);
         }
     }
 
@@ -435,7 +435,7 @@ void AC_WPNav::shift_wp_origin_and_destination_to_stopping_point_xy()
     _destination.xy() = stopping_point;
 
     // move pos controller target horizontally
-    _pos_control.set_pos_target_xy_cm(stopping_point.x, stopping_point.y);
+    _pos_control.set_pos_desired_xy_cm(stopping_point);
 }
 
 /// get_wp_stopping_point_xy - returns vector to stopping point based on a horizontal position and velocity
@@ -466,10 +466,14 @@ bool AC_WPNav::advance_wp_target_along_track(float dt)
     const float offset_z_scaler = _pos_control.pos_offset_z_scaler(terr_offset, get_terrain_margin() * 100.0);
 
     // input shape the terrain offset
-    _pos_control.update_pos_offset_z(terr_offset);
+    _pos_control.set_pos_terrain_target_cm(terr_offset);
+
+    // get position controller's position offset (post input shaping) so it can be used in position error calculation
+    const Vector3p& psc_pos_offset = _pos_control.get_pos_offset_cm();
 
     // get current position and adjust altitude to origin and destination's frame (i.e. _frame)
-    const Vector3f &curr_pos = _inav.get_position_neu_cm() - Vector3f{0, 0, terr_offset};
+    Vector3f curr_pos = _inav.get_position_neu_cm() - psc_pos_offset.tofloat();
+    curr_pos.z -= terr_offset;
     Vector3f curr_target_vel = _pos_control.get_vel_desired_cms();
     curr_target_vel.z -= _pos_control.get_vel_offset_z_cms();
 
@@ -527,11 +531,6 @@ bool AC_WPNav::advance_wp_target_along_track(float dt)
     target_vel *= vel_scaler_dt;
     target_accel *= sq(vel_scaler_dt);
     target_accel += accel_offset;
-
-    // convert final_target.z to altitude above the ekf origin
-    target_pos.z += _pos_control.get_pos_offset_z_cm();
-    target_vel.z += _pos_control.get_vel_offset_z_cms();
-    target_accel.z += _pos_control.get_accel_offset_z_cmss();
 
     // pass new target to the position controller
     _pos_control.set_pos_vel_accel(target_pos.topostype(), target_vel, target_accel);
@@ -778,11 +777,11 @@ bool AC_WPNav::set_spline_destination(const Vector3f& destination, bool terrain_
         if (terrain_alt) {
             // new destination is alt-above-terrain, previous destination was alt-above-ekf-origin
             _origin.z -= origin_terr_offset;
-            _pos_control.set_pos_offset_z_cm(_pos_control.get_pos_offset_z_cm() + origin_terr_offset);
+            _pos_control.init_pos_terrain_cm(origin_terr_offset);
         } else {
             // new destination is alt-above-ekf-origin, previous destination was alt-above-terrain
             _origin.z += origin_terr_offset;
-            _pos_control.set_pos_offset_z_cm(_pos_control.get_pos_offset_z_cm() - origin_terr_offset);
+            _pos_control.init_pos_terrain_cm(0.0);
         }
     }
 

--- a/libraries/APM_Control/AR_PosControl.cpp
+++ b/libraries/APM_Control/AR_PosControl.cpp
@@ -389,7 +389,8 @@ void AR_PosControl::write_log()
     Vector2f pos_target_2d_cm = get_pos_target().tofloat() * 100.0;
 
     // reuse logging from AC_PosControl:
-    AC_PosControl::Write_PSCN(pos_target_2d_cm.x,     // position target
+    AC_PosControl::Write_PSCN(0.0,                  // position desired
+                            pos_target_2d_cm.x,     // position target
                             curr_pos_NED.x * 100.0, // position
                             _vel_desired.x * 100.0, // desired velocity
                             _vel_target.x * 100.0,  // target velocity
@@ -397,7 +398,8 @@ void AR_PosControl::write_log()
                             _accel_desired.x * 100.0,   // desired accel
                             _accel_target.x * 100.0,    // target accel
                             curr_accel_NED.x);      // accel
-    AC_PosControl::Write_PSCE(pos_target_2d_cm.y,     // position target
+    AC_PosControl::Write_PSCE(0.0,                  // position desired
+                            pos_target_2d_cm.y,     // position target
                             curr_pos_NED.y * 100.0, // position
                             _vel_desired.y * 100.0, // desired velocity
                             _vel_target.y * 100.0,  // target velocity

--- a/libraries/AP_Scripting/applets/copter-slung-payload.lua
+++ b/libraries/AP_Scripting/applets/copter-slung-payload.lua
@@ -1,0 +1,396 @@
+-- Move a Copter so as to reduce a slung payload's oscillation.  Requires the payload be capable of sending its position and velocity to the main vehicle
+--
+-- How To Use
+-- 1. copy this script to the autopilot's "scripts" directory
+-- 2. within the "scripts" directory create a "modules" directory
+-- 3. copy the MAVLink/mavlink_msgs_xxx files to the "scripts" directory
+-- 4. add an autopilot and GPS to the payload and configure it to send GLOBAL_POSITION_INT messages at 10hz to the vehicle
+-- 5. create a mission with a SCRIPT_TIME or PAYLOAD_PLACE command included
+-- 6. fly the mission and the vehicle should move so as to reduce the payload's oscillations while executing the SCRIPT_TIME or PAYLOAD_PLACE commands
+-- 7. optionally set SLUP_SYSID to the system id of the payload autopilot
+-- 8. optionally set WP_YAW_BEHAVIOR to 0 to prevent the vehicle from yawing while moving to the payload
+
+-- load mavlink message definitions from modules/MAVLink directory
+local mavlink_msgs = require("MAVLink/mavlink_msgs")
+
+-- global definitions
+local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
+local UPDATE_INTERVAL_MS = 10           -- update at about 100hz
+local COPTER_MODE_AUTO = 3
+local MAV_CMD_NAV_PAYLOAD_PLACE = 94
+local MAV_CMD_NAV_SCRIPT_TIME = 42702
+local PAYLOAD_OFFSET_COMP_VEL_MAX = 1   -- payload offset compensation will be active when the payload's horizontal velocity is no more than this speed in m/s
+local PAYLOAD_UPDATE_TIMEOUT_MS = 1000  -- payload update timeout, used to warn user on loss of connection
+local CONTROL_TIMEOUT_MS = 3000         -- control timeout, used to reset offsets if they have not been set for more than 3 seconds
+local TEXT_PREFIX_STR = "copter-slung-payload:"    -- prefix for all text messages
+
+ -- setup script specific parameters
+local PARAM_TABLE_KEY = 82
+local PARAM_TABLE_PREFIX = "SLUP_"
+assert(param:add_table(PARAM_TABLE_KEY, PARAM_TABLE_PREFIX, 7), 'could not add param table')
+
+-- add a parameter and bind it to a variable
+function bind_add_param(name, idx, default_value)
+    assert(param:add_param(PARAM_TABLE_KEY, idx, name, default_value), string.format('could not add param %s', PARAM_TABLE_PREFIX .. name))
+    return Parameter(PARAM_TABLE_PREFIX .. name)
+ end
+
+--[[
+  // @Param: SLUP_ENABLE
+  // @DisplayName: Slung Payload enable
+  // @Description: Slung Payload enable
+  // @Values: 0:Disabled,1:Enabled
+  // @User: Standard
+--]]
+local SLUP_ENABLE = bind_add_param("ENABLE", 1, 1)
+
+--[[
+  // @Param: SLUP_VEL_P
+  // @DisplayName: Slung Payload Velocity P gain
+  // @Description: Slung Payload Velocity P gain, higher values will result in faster movements in sync with payload
+  // @Range: 0 0.8
+  // @User: Standard
+--]]
+local SLUP_VEL_P = bind_add_param("VEL_P", 2, 0.5)
+
+--[[
+  // @Param: SLUP_DIST_MAX
+  // @DisplayName: Slung Payload horizontal distance max
+  // @Description: Oscillation is suppressed when vehicle and payload are no more than this distance horizontally.  Set to 0 to always suppress
+  // @Range: 0 30
+  // @User: Standard
+--]]
+local SLUP_DIST_MAX = bind_add_param("DIST_MAX", 3, 15)
+
+--[[
+  // @Param: SLUP_SYSID
+  // @DisplayName: Slung Payload mavlink system id
+  // @Description: Slung Payload mavlink system id.  0 to use any/all system ids
+  // @Range: 0 255
+  // @User: Standard
+--]]
+local SLUP_SYSID = bind_add_param("SYSID", 4, 0)
+
+--[[
+  // @Param: SLUP_WP_POS_P
+  // @DisplayName: Slung Payload return to WP position P gain
+  // @Description: WP position P gain. higher values will result in vehicle moving more quickly back to the original waypoint
+  // @Range: 0 1
+  // @User: Standard
+--]]
+local SLUP_WP_POS_P = bind_add_param("WP_POS_P", 5, 0.05)
+
+--[[
+  // @Param: SLUP_RESTOFS_TC
+  // @DisplayName: Slung Payload resting offset estimate filter time constant
+  // @Description: payload's position estimator's time constant used to compensate for GPS errors and wind.  Higher values result in smoother estimate but slower response
+  // @Range: 1 20
+  // @User: Standard
+--]]
+local SLUP_RESTOFS_TC = bind_add_param("RESTOFS_TC", 6, 10)
+
+--[[
+  // @Param: SLUP_DEBUG
+  // @DisplayName: Slung Payload debug output
+  // @Description: Slung payload debug output, set to 1 to enable debug
+  // @Values: 0:Disabled,1:Enabled
+  // @User: Standard
+--]]
+local SLUP_DEBUG = bind_add_param("DEBUG", 7, 0)
+
+-- mavlink definitions
+local GLOBAL_POSITION_INT_ID = 33
+local msg_map = {}
+msg_map[GLOBAL_POSITION_INT_ID] = "GLOBAL_POSITION_INT"
+
+-- initialize MAVLink rx with number of messages, and buffer depth
+mavlink:init(2, 5)
+
+-- register message id to receive
+mavlink:register_rx_msgid(GLOBAL_POSITION_INT_ID)
+
+-- variables
+local payload_sysid = nil                       -- holds sysid of payload once a matching global position int message has been received
+local payload_loc = Location()                  -- payload location
+local payload_vel = Vector3f()                  -- payload velocity
+local payload_acc = Vector3f()                  -- payload acceleration
+local payload_update_timeout_prev = true        -- payload update timeout state from previous iteration, used to detect loss/recovery of payload updates
+local payload_loc_update_ms = uint32_t(0)       -- system time that payload_loc was last updated
+local payload_dist_NED = Vector3f()             -- distance between vehicle and payload in NED frame
+local global_pos_int_timebootms_prev = 0        -- global position int message's time_boot_ms field from previous iteration (used to calc dt)
+local resting_offset_NED = Vector3f()           -- estimated position offset between payload and vehicle
+local resting_vel_NED = Vector3f()              -- estimated velocity offset.  should be near zero when hovering
+local resting_offset_valid = false              -- true if resting_offset_NED and resting_vel_NED can be used
+local resting_offset_update_ms = uint32_t(0)    -- system time that resting_offset_NED was last updated
+local resting_offset_notify_ms = uint32_t(0)    -- system time that the user was sent the resting_offset_NED
+local send_velocity_offsets = false             -- true if we should send vehicle velocity offset commands to reduce payload oscillation
+local sent_velocity_offsets_ms = uint32_t(0)    -- system time that the last velocity offset was sent to the vehicle
+local control_timeout_ms = uint32_t(0)          -- system time that the control timeout occurred
+local payload_vel_prev = Vector3f()             -- previous iterations payload velocity used to calculate acceleration
+local print_warning_ms = uint32_t(0)            -- system time that the last warning was printed.  used to prevent spamming the user with warnings
+
+-- display a text warning to the user.  only displays a warning every second
+-- prefix is automatically added
+function print_warning(text_warning)
+    local now_ms = millis()
+    if (now_ms - print_warning_ms > 1000) then
+        gcs:send_text(MAV_SEVERITY.WARNING, string.format("%s %s", TEXT_PREFIX_STR, text_warning))
+        print_warning_ms = now_ms
+    end
+end
+
+-- calculate sign of a number.  1 if positive, -1 if negative, 0 if exactly zero
+function get_sign(value)
+    if value > 0 then
+        return 1
+    elseif value < 0 then
+        return -1
+    end
+    return 0
+end
+
+-- calculate an alpha for a first order low pass filter
+function calc_lowpass_alpha(dt, time_constant)
+    local rc = time_constant/(math.pi*2)
+    return dt/(dt+rc)
+end
+
+-- handle global position int message
+-- returns true if the message was from the payload and updates payload_loc, payload_vel, payload_acc and payload_loc_update_ms
+function handle_global_position_int(msg)
+    -- check if message is from the correct system id
+    if (SLUP_SYSID:get() > 0 and msg.sysid ~= SLUP_SYSID:get()) then
+        return false
+    end
+
+    -- lock onto the first matching system id
+    if payload_sysid == nil then
+        payload_sysid = msg.sysid
+        gcs:send_text(MAV_SEVERITY.INFO, string.format("%s found sysid:%d", TEXT_PREFIX_STR, msg.sysid))
+    elseif payload_sysid ~= msg.sysid then
+        return false
+    end
+
+    -- check for duplicate messages and calculate dt
+    local time_boot_ms = msg.time_boot_ms
+    local dt = (time_boot_ms - global_pos_int_timebootms_prev) * 0.001
+    global_pos_int_timebootms_prev = time_boot_ms
+    if dt <= 0 or dt > 1 then
+        return false
+    end
+
+    -- update payload location
+    payload_loc:lat(msg.lat)
+    payload_loc:lng(msg.lon)
+    payload_loc:alt(msg.alt * 0.1)
+
+    -- update payload velocity
+    payload_vel:x(msg.vx * 0.01)
+    payload_vel:y(msg.vy * 0.01)
+    payload_vel:z(msg.vz * 0.01)
+
+    -- calc payload acceleration
+    payload_acc:x((payload_vel:x() - payload_vel_prev:x()) / dt)
+    payload_acc:y((payload_vel:y() - payload_vel_prev:y()) / dt)
+    payload_acc:z((payload_vel:z() - payload_vel_prev:z()) / dt)
+    payload_vel_prev = payload_vel:copy()
+
+    -- record time of update
+    payload_loc_update_ms = millis()
+    return true
+end
+
+-- estimate the payload's resting position offset based on its current offset and velocity
+-- relies on payload_dist_NED and payload_vel being updated
+function update_payload_resting_offset()
+
+    -- calculate dt since last update
+    local now_ms = millis()
+    local dt = (now_ms - resting_offset_update_ms):tofloat() * 0.001
+    resting_offset_update_ms = now_ms
+
+    -- sanity check dt
+    if (dt <= 0) then
+        resting_offset_valid = false
+        do return end
+    end
+
+    -- if not updated for more than 1 second, reset resting offset to current offset
+    if (dt > 1) then
+        resting_offset_NED = payload_dist_NED
+        resting_vel_NED = payload_vel
+        resting_offset_valid = false
+        do return end
+    end
+
+    -- use a low-pass filter to move the resting offset NED towards the pos_offset_NED
+    local alpha = calc_lowpass_alpha(dt, SLUP_RESTOFS_TC:get())
+    resting_offset_NED:x(resting_offset_NED:x() + (payload_dist_NED:x() - resting_offset_NED:x()) * alpha)
+    resting_offset_NED:y(resting_offset_NED:y() + (payload_dist_NED:y() - resting_offset_NED:y()) * alpha)
+    resting_offset_NED:z(resting_offset_NED:z() + (payload_dist_NED:z() - resting_offset_NED:z()) * alpha)
+    resting_vel_NED:x(resting_vel_NED:x() + (payload_vel:x() - resting_vel_NED:x()) * alpha)
+    resting_vel_NED:y(resting_vel_NED:y() + (payload_vel:y() - resting_vel_NED:y()) * alpha)
+    resting_vel_NED:z(resting_vel_NED:z() + (payload_vel:z() - resting_vel_NED:z()) * alpha)
+
+    -- debug output every 3 seconds
+    local print_debug = false
+    if (SLUP_DEBUG:get() > 0) and (now_ms - resting_offset_notify_ms > 3000) then
+        print_debug = true
+        resting_offset_notify_ms = now_ms
+    end
+
+    -- validate that resting offsets are valid
+    -- resting velocity should be low to ensure the resting position estimate is accurate
+    if (resting_vel_NED:xy():length() > PAYLOAD_OFFSET_COMP_VEL_MAX) then
+        resting_offset_valid = false
+        if print_debug then
+            print_warning("resting velocity too high")
+        end
+        return
+    end
+
+    -- resting position should be within SLUP_DIST_MAX of the vehicle
+    if resting_offset_NED:xy():length() > SLUP_DIST_MAX:get() then
+        resting_offset_valid = false
+        if print_debug then
+            print_warning("payload resting pos too far, ignoring");
+        end
+        return
+    end
+
+    -- update user
+    if (print_debug) then
+        gcs:send_text(MAV_SEVERITY.INFO, string.format("resting a:%f px:%4.1f py:%4.1f pz:%4.1f vx:%4.1f vy:%4.1f vz:%4.1f", alpha, resting_offset_NED:x(), resting_offset_NED:y(), resting_offset_NED:z(), resting_vel_NED:x(), resting_vel_NED:y(), resting_vel_NED:z()))
+    end
+
+    -- if set got this far the resting offsets must be valid
+    resting_offset_valid = true
+end
+
+-- move vehicle to reduce payload oscillation
+-- relies on payload_dist_NED, payload_vel, payload_acc, resting_offset_NED, resting_vel_NED being updated
+function move_vehicle()
+
+    -- check horizontal distance is less than SLUP_DIST_MAX
+    if SLUP_DIST_MAX:get() > 0 then
+        local dist_xy = payload_dist_NED:xy():length()
+        if (dist_xy > SLUP_DIST_MAX:get()) then
+            print_warning(string.format("payload too far %4.1fm", dist_xy));
+            do return end
+        end
+    end
+
+    -- get long-term payload offset used to compensate for GPS errors and wind
+    local payload_offset_NED = Vector3f()
+    if resting_offset_valid then
+        payload_offset_NED = resting_offset_NED
+    end
+
+    -- get position offset (cumulative effect of velocity offsets) and use to slowly move back to waypoint
+    local pos_offset_NED, _, _ = poscontrol:get_posvelaccel_offset()
+    if pos_offset_NED == nil then
+        print_warning("unable to get dist to waypoint")
+        pos_offset_NED = Vector3f()
+    end
+
+    -- calculate send velocity offsets in m/s in NED frame
+    local vel_offset_NED = Vector3f()
+    vel_offset_NED:x(-payload_acc:x() * SLUP_VEL_P:get() + (-pos_offset_NED:x() - payload_offset_NED:x()) * SLUP_WP_POS_P:get())
+    vel_offset_NED:y(-payload_acc:y() * SLUP_VEL_P:get() + (-pos_offset_NED:y() - payload_offset_NED:y()) * SLUP_WP_POS_P:get())
+    if poscontrol:set_posvelaccel_offset(pos_offset_NED, vel_offset_NED, Vector3f()) then
+        sent_velocity_offsets_ms = millis()
+    end
+end
+
+-- display welcome message
+gcs:send_text(MAV_SEVERITY.INFO, "copter-slung-payload script loaded")
+
+-- update function to receive location from payload and move vehicle to reduce payload's oscillation
+function update()
+
+    -- exit immediately if not enabled
+    if (SLUP_ENABLE:get() <= 0) then
+        return update, 1000
+    end
+
+    -- get vehicle location
+    local curr_loc = ahrs:get_location()
+    if curr_loc == nil then
+        return update, UPDATE_INTERVAL_MS
+    end
+
+    -- consume all available mavlink messages
+    local payload_update_received = false
+    local msg
+    repeat
+        msg, _ = mavlink:receive_chan()
+        if (msg ~= nil) then
+            local parsed_msg = mavlink_msgs.decode(msg, msg_map)
+            if (parsed_msg ~= nil) then
+                if parsed_msg.msgid == GLOBAL_POSITION_INT_ID then
+                    if handle_global_position_int(parsed_msg) then
+                        payload_update_received = true
+                    end
+                end
+            end
+        end
+    until msg == nil
+
+    -- warn user on loss of recovery of telemetry from payload
+    local payload_timeout = millis() - payload_loc_update_ms > PAYLOAD_UPDATE_TIMEOUT_MS
+    if payload_timeout ~= payload_update_timeout_prev then
+        if payload_timeout then
+            gcs:send_text(MAV_SEVERITY.WARNING, string.format("%s payload updates lost", TEXT_PREFIX_STR))
+        else
+            gcs:send_text(MAV_SEVERITY.INFO, string.format("%s payload updates received", TEXT_PREFIX_STR))
+        end
+    end
+    payload_update_timeout_prev = payload_timeout
+
+    if payload_update_received then
+        -- calculate position difference vs vehicle
+        payload_dist_NED = curr_loc:get_distance_NED(payload_loc)
+
+        -- estimate the payload's resting position offset based on its current offset and velocity
+        -- relies on payload_dist_NED and payload_vel being updated
+        update_payload_resting_offset()
+    end
+
+    -- check if we can control the vehicle
+    -- vehicle must be in Auto mode executing a SCRIPT_TIME or PAYLOAD_PLACE command
+    local send_velocity_offsets_prev = send_velocity_offsets
+    local armed_and_flying = arming:is_armed() and vehicle:get_likely_flying()
+    local takingoff_or_landing = vehicle:is_landing() or vehicle:is_taking_off()
+    local auto_mode = (vehicle:get_mode() == COPTER_MODE_AUTO)
+    local scripting_or_payloadplace = (mission:get_current_nav_id() == MAV_CMD_NAV_SCRIPT_TIME) or (mission:get_current_nav_id() == MAV_CMD_NAV_PAYLOAD_PLACE)
+    send_velocity_offsets = armed_and_flying and not takingoff_or_landing and auto_mode and scripting_or_payloadplace and not payload_timeout
+
+    -- alert user if we start or stop sending velocity offsets
+    if (send_velocity_offsets and not send_velocity_offsets_prev) then
+        gcs:send_text(MAV_SEVERITY.INFO, string.format("%s activated", TEXT_PREFIX_STR))
+    end
+    if (not send_velocity_offsets and send_velocity_offsets_prev) then
+        gcs:send_text(MAV_SEVERITY.INFO, string.format("%s deactivated", TEXT_PREFIX_STR))
+        poscontrol:set_posvelaccel_offset(Vector3f(), Vector3f(), Vector3f())
+    end
+
+    -- move vehicle to reduce payload oscillation
+    if send_velocity_offsets then
+        move_vehicle()
+
+        -- check for unexpected control timeout
+        -- reset vehicle offsets if not sent within last 3 seconds
+        local now_ms = millis()
+        local time_since_vel_offset_sent = now_ms - sent_velocity_offsets_ms
+        local time_since_last_control_timeout = now_ms - control_timeout_ms
+        if (time_since_vel_offset_sent > CONTROL_TIMEOUT_MS) and (time_since_last_control_timeout > CONTROL_TIMEOUT_MS) then
+            poscontrol:set_posvelaccel_offset(Vector3f(), Vector3f(), Vector3f())
+            control_timeout_ms = now_ms
+            print_warning("control timeout, clearing offsets")
+        end
+    end
+
+    return update, UPDATE_INTERVAL_MS
+end
+
+return update()

--- a/libraries/AP_Scripting/applets/copter-slung-payload.md
+++ b/libraries/AP_Scripting/applets/copter-slung-payload.md
@@ -1,0 +1,30 @@
+# Slung Payload
+
+This script moves a Copter so as to reduce a slung payload's oscillation.  Requires the payload be capable of sending its position and velocity to the main vehicle
+
+# Parameters
+
+SLUP_ENABLE : Set to 1 to enable this script
+SLUP_VEL_P : Oscillation controller velocity P gain.  Higher values will result in the vehicle moving more quickly in sync with the payload
+SLUP_DIST_MAX : maximum acceptable distance between vehicle and payload.  Within this distance oscillation suppression will operate
+SLUP_SYSID : System id of payload's autopilot.  If zero any system id is accepted
+SLUP_WP_POS_P : Return to waypoint position P gain.  Higher values result in the vehicle returning more quickly to the latest waypoint
+SLUP_RESTOFS_TC : Slung Payload resting offset estimate filter time constant.  Higher values result in smoother estimate but slower response
+SLUP_DEBUG : Slung payload debug output, set to 1 to enable debug
+
+# How To Use
+
+1. mount an autopilot on the payload connected to the main vehicle using telemetry
+2. ensure the vehicle and payload autopilots have unique system ids
+3. copy this script to the vehicle autopilot's "scripts" directory
+4. within the "scripts" directory create a "modules" directory
+5. copy the MAVLink/mavlink_msgs_xxx files to the "scripts" directory
+
+# How It Works
+
+The script's algorithm is implemented as follows
+
+1. Consume GLOBAL_POSITION_INT messages from the payload
+2. Calculate the payload's position vs the vehicle position
+3. Use a P controller to move the vehicle towards the payload to reduce oscillation
+4. Simultaneously the vehicle moves back towards the original location.  The speed depends upon the SLUP_WP_POS_P parameter

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -3723,6 +3723,22 @@ AR_AttitudeControl = {}
 ---@return number -- spees slew rate
 function AR_AttitudeControl:get_srate() end
 
+-- copter position controller
+poscontrol = {}
+
+-- add an offset to position controller's target position, velocity and acceleration
+---@param pos_offset_NED Vector3f_ud
+---@param vel_offset_NED Vector3f_ud
+---@param accel_offset_NED Vector3f_ud
+---@return boolean
+function poscontrol:set_posvelaccel_offset(pos_offset_NED, vel_offset_NED, accel_offset_NED) end
+
+-- get position controller's target position, velocity and acceleration offsets
+---@return Vector3f_ud|nil
+---@return Vector3f_ud|nil
+---@return Vector3f_ud|nil
+function poscontrol:get_posvelaccel_offset() end
+
 -- desc
 AR_PosControl = {}
 

--- a/libraries/AP_Scripting/examples/copter-posoffset.lua
+++ b/libraries/AP_Scripting/examples/copter-posoffset.lua
@@ -1,0 +1,160 @@
+-- Example showing how a position offset can be added to a Copter's auto mission plan
+--
+-- CAUTION: This script only works for Copter
+-- this script waits for the vehicle to be armed and in auto mode and then
+-- adds an offset to the position or velocity target
+--
+-- How To Use
+-- 1. copy this script to the autopilot's "scripts" directory
+-- 2. set PSC_OFS_xx parameter to the desired position OR velocity offsets desired
+-- 3. fly the vehicle in Auto mode (or almost any mode)
+-- 4. use the Scripting1 aux switch to enable and disable the offsets
+
+local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
+
+-- setup script specific parameters
+local PARAM_TABLE_KEY = 71
+local PARAM_TABLE_PREFIX = "PSC_OFS_"
+assert(param:add_table(PARAM_TABLE_KEY, PARAM_TABLE_PREFIX, 6), 'could not add param table')
+ 
+-- add a parameter and bind it to a variable
+function bind_add_param(name, idx, default_value)
+  assert(param:add_param(PARAM_TABLE_KEY, idx, name, default_value), string.format('could not add param %s', PARAM_TABLE_PREFIX .. name))
+  return Parameter(PARAM_TABLE_PREFIX .. name)
+end
+
+--[[
+  // @Param: PSC_OFS_POS_N
+  // @DisplayName: Position Controller Position Offset North
+  // @Description: Position controller offset North
+  // @Range: 0 1000
+  // @Units: m
+  // @User: Standard
+--]]
+local PSC_OFS_POS_N = bind_add_param("POS_N", 1, 0)
+
+--[[
+  // @Param: PSC_OFS_POS_E
+  // @DisplayName: Position Controller Position Offset East
+  // @Description: Position controller offset North
+  // @Range: 0 1000
+  // @Units: m
+  // @User: Standard
+--]]
+local PSC_OFS_POS_E = bind_add_param("POS_E", 2, 0)
+
+--[[
+  // @Param: PSC_OFS_POS_D
+  // @DisplayName: Position Controller Position Offset Down
+  // @Description: Position controller offset Down
+  // @Range: 0 1000
+  // @Units: m
+  // @User: Standard
+--]]
+local PSC_OFS_POS_D = bind_add_param("POS_D", 3, 0)
+
+--[[
+  // @Param: PSC_OFS_VEL_N
+  // @DisplayName: Position Controller Velocity Offset North
+  // @Description: Position controller velocity offset North
+  // @Range: 0 10
+  // @Units: m/s
+  // @User: Standard
+--]]
+local PSC_OFS_VEL_N = bind_add_param("VEL_N", 4, 0)
+
+--[[
+  // @Param: PSC_OFS_VEL_E
+  // @DisplayName: Position Controller Velocity Offset East
+  // @Description: Position controller velocity offset East
+  // @Range: 0 10
+  // @Units: m/s
+  // @User: Standard
+--]]
+local PSC_OFS_VEL_E = bind_add_param("VEL_E", 5, 0)
+
+--[[
+  // @Param: PSC_OFS_VEL_D
+  // @DisplayName: Position Controller Velocity Offset Down
+  // @Description: Position controller velocity offset Down
+  // @Range: 0 10
+  // @Units: m/s
+  // @User: Standard
+--]]
+local PSC_OFS_VEL_D = bind_add_param("VEL_D", 6, 0)
+
+-- local variables
+local aux_sw_pos_last = 0
+
+-- welcome message to user
+gcs:send_text(MAV_SEVERITY.INFO, "copter-posoffset.lua loaded")
+
+function update()
+
+  -- must be armed, flying and in auto mode
+  if (not arming:is_armed()) or (not vehicle:get_likely_flying()) then
+    return update, 1000
+  end
+
+  -- Scripting1 aux switch enables/disables offsets
+  local aux_sw_pos = rc:get_aux_cached(300)
+  if aux_sw_pos == nil then
+    aux_sw_pos = 0
+  end
+
+  -- check for change in aux switch position
+  if aux_sw_pos ~= aux_sw_pos_last then
+    aux_sw_pos_last = aux_sw_pos
+    if aux_sw_pos == 0 then
+      -- if switch is in low position clear offsets
+      if poscontrol:set_posvelaccel_offset(Vector3f(), Vector3f(), Vector3f()) then
+        gcs:send_text(MAV_SEVERITY.ERROR, "copter-posoffset: offsets cleared")
+        return update, 1000
+      else
+        gcs:send_text(MAV_SEVERITY.ERROR, "copter-posoffset: failed to clear offsets")
+      end
+    else
+      gcs:send_text(MAV_SEVERITY.ERROR, "copter-posoffset: offsets activated")
+    end
+  end
+
+  if aux_sw_pos == 0 then
+    return update, 1000
+  end
+
+  local pos_offsets_zero = PSC_OFS_POS_N:get() == 0 and PSC_OFS_POS_E:get() == 0 and PSC_OFS_POS_D:get() == 0
+  local vel_offsets_zero = PSC_OFS_VEL_N:get() == 0 and PSC_OFS_VEL_E:get() == 0 and PSC_OFS_VEL_D:get() == 0
+
+  -- if position offsets are non-zero or all offsets are zero then send position offsets
+  if not pos_offsets_zero or vel_offsets_zero then
+    -- set the position offset in meters in NED frame
+    local pos_offset_NED = Vector3f()
+    pos_offset_NED:x(PSC_OFS_POS_N:get())
+    pos_offset_NED:y(PSC_OFS_POS_E:get())
+    pos_offset_NED:z(PSC_OFS_POS_D:get())
+    if not poscontrol:set_posvelaccel_offset(pos_offset_NED, Vector3f(), Vector3f()) then
+      gcs:send_text(MAV_SEVERITY.ERROR, "copter-posoffset: failed to set pos offset")
+    end
+    test_position = not pos_offsets_zero
+  else
+    -- first get position offset (cumulative effect of velocity offsets)
+    local pos_offset_NED, _, _ = poscontrol:get_posvelaccel_offset()
+    if pos_offset_NED == nil then
+        print_warning("unable to get position offset")
+        pos_offset_NED = Vector3f()
+    end
+    -- test velocity offsets in m/s in NED frame
+    local vel_offset_NED = Vector3f()
+    vel_offset_NED:x(PSC_OFS_VEL_N:get())
+    vel_offset_NED:y(PSC_OFS_VEL_E:get())
+    vel_offset_NED:z(PSC_OFS_VEL_D:get())
+    if not poscontrol:set_posvelaccel_offset(pos_offset_NED, vel_offset_NED, Vector3f()) then
+      gcs:send_text(MAV_SEVERITY.ERROR, "copter-posoffset: failed to set vel offset")
+    end
+  end
+
+  -- update at 1hz
+  return update, 1000
+end
+
+return update()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -759,6 +759,12 @@ include AC_AttitudeControl/AC_AttitudeControl.h depends APM_BUILD_TYPE(APM_BUILD
 singleton AC_AttitudeControl depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_COPTER_OR_HELI
 singleton AC_AttitudeControl method get_rpy_srate void float'Ref float'Ref float'Ref
 
+include AC_AttitudeControl/AC_PosControl.h depends APM_BUILD_COPTER_OR_HELI
+singleton AC_PosControl depends APM_BUILD_COPTER_OR_HELI
+singleton AC_PosControl rename poscontrol
+singleton AC_PosControl method set_posvelaccel_offset boolean Vector3f Vector3f Vector3f
+singleton AC_PosControl method get_posvelaccel_offset boolean Vector3f'Null Vector3f'Null Vector3f'Null
+
 include APM_Control/AR_AttitudeControl.h depends APM_BUILD_TYPE(APM_BUILD_Rover)
 singleton AR_AttitudeControl depends APM_BUILD_TYPE(APM_BUILD_Rover)
 singleton AR_AttitudeControl method get_srate void float'Ref float'Ref

--- a/libraries/AP_Scripting/modules/MAVLink/mavlink_msg_GLOBAL_POSITION_INT.lua
+++ b/libraries/AP_Scripting/modules/MAVLink/mavlink_msg_GLOBAL_POSITION_INT.lua
@@ -1,0 +1,14 @@
+local GLOBAL_POSITION_INT = {}
+GLOBAL_POSITION_INT.id = 33
+GLOBAL_POSITION_INT.fields = {
+             { "time_boot_ms", "<I4" },
+             { "lat", "<i4" },
+             { "lon", "<i4" },
+             { "alt", "<i4" },
+             { "relative_alt", "<i4" },
+             { "vx", "<i2" },
+             { "vy", "<i2" },
+             { "vz", "<i2" },
+             { "hdg", "<I2" },
+             }
+return GLOBAL_POSITION_INT

--- a/libraries/AP_Scripting/modules/MAVLink/mavlink_msg_HEARTBEAT.lua
+++ b/libraries/AP_Scripting/modules/MAVLink/mavlink_msg_HEARTBEAT.lua
@@ -1,0 +1,11 @@
+local HEARTBEAT = {}
+HEARTBEAT.id = 0
+HEARTBEAT.fields = {
+             { "custom_mode", "<I4" },
+             { "type", "<B" },
+             { "autopilot", "<B" },
+             { "base_mode", "<B" },
+             { "system_status", "<B" },
+             { "mavlink_version", "<B" },
+             }
+return HEARTBEAT


### PR DESCRIPTION
This PR has expanded from its original scope to now add support for 3D position, velocity and acceleration offsets usable in all autonomous (e.g. Auto, Guide, RTL, etc) and semi-autonomous (e.g Loiter, PosHold, ZigZag, etc) modes.

This has been rigorously tested in SITL but it is a big change so any and all feedback is very welcome.

---------------------------

This adds slung payload oscillation suppression using a Lua script together with a new AC_PosControl feature that allows external callers (e.g. scripts) to add horizontal position or velocity offsets to the vehicle while flying in Auto mode.

The payload oscillation suppression only operates while the vehicle is in Auto mode executing a SCRIPT_TIME or PAYLOAD_PLACE command.  E.g. it does not trying to reduce oscillation while the vehicle if flying towards a waypoint nor in any other flight mode.  [A blog post including video is here](https://discuss.ardupilot.org/t/slung-payload-oscillation-suppression/123466).

Changes include:

1. SITL's slung payload simulator is enhance so that wind (e.g. SIM_WIND_SPD, SIM_WIND_DIR) affects the payload.  This allows us to create an offsets between the slung payload and vehicle
2. AC_PosControl gets new get/set methods for position and velocity offsets.  External callers (including scripting) can use these to add offsets to the vehicle's target position or velocity
3. AP_Vehicle/AP_Copter/AC_WPNav/AP_Scripting get equivalent new methods/bindings to set the position and velocity offsets (e.g. set_pos_offset, set_vel_offset).  Perhaps we should rename/replace these if we want to support more modes besides Auto
4. AP_Scripting's modules directory gets message definitions for GLOBAL_POSITION_INT and HEARTBEAT.  We haven't normally added these but without them it makes it very difficult for normal users to use scripts that consume or sends these mavlink messages
5. slung-payload.lua applet is added to AP_Scripting.  This script only operates while the vehicle is in Auto mode executing a SCRIPT_TIME or PAYLOAD_PLACE command.  It moves the vehicle towards the payload to reduce its oscillation with the speed of movement controlled by the SLUP_POS_P parameter.  It also tries to estimate the payload's long-term position offset from the vehicle and slowly moves the vehicle in the opposite direction so that the package lands right on the waypoint.  The speed of this movement can be adjusted using the SLUP_WP_POS_P parameter

This has been well tested in SITL and moderately well tested on a real vehicle:

- checked that AC_PosControl position and velocity targets result in the expected behaviour.  See screenshots below
![auto-offset-testing-screenshot](https://github.com/user-attachments/assets/c9d69a8e-f064-4401-9fa3-d68b2bcc0638)
- checked that the simulated payload lands precisely on the waypoint
- checked that simulated wind affects the payload as expected (e.g. payload is pushed by the wind)
- checked every navigation mission command with an offset of x=20m,y=20m to confirm they worked as expected

Video of SITL test: https://www.youtube.com/watch?v=jL2YUByYv2Y

Known issues we should fix before merging:

- [x] when switching between SCurve navigation and pure position control navigation the offsets are lost leading to a jump in the vehicle's position target.  This happens in Auto mode when switching from a WAYPOINT command and PAYLOAD_PLACE
- [x] when switching from takeoff to SCurve navigation the SCurves seem to use twice the expected position offset