### PR TITLE
scripts: Fixed extract_features.py not extracting ExternalAHRS or INS Temp Cal properly

### DIFF
--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -73,8 +73,8 @@ class ExtractFeatures(object):
             ('HAL_NAVEKF3_AVAILABLE', 'NavEKF3::NavEKF3',),
             ('HAL_NAVEKF2_AVAILABLE', 'NavEKF2::NavEKF2',),
             ('HAL_EXTERNAL_AHRS_ENABLED', r'AP_ExternalAHRS::init\b',),
-            ('AP_EXTERNAL_AHRS_{type}_ENABLED', r'AP_ExternalAHRS_{type}::healthy\b',),
-            ('HAL_INS_TEMPERATURE_CAL_ENABLE', 'AP_InertialSensor::TCal::Learn::save_calibration',),
+            ('AP_EXTERNAL_AHRS_{type}_ENABLED', r'AP_ExternalAHRS_(?P<type>.*)::healthy\b',),
+            ('HAL_INS_TEMPERATURE_CAL_ENABLE', 'AP_InertialSensor_TCal::Learn::save_calibration',),
             ('HAL_VISUALODOM_ENABLED', 'AP_VisualOdom::init',),
 
             ('AP_RANGEFINDER_ENABLED', 'RangeFinder::RangeFinder',),


### PR DESCRIPTION
`extract_features.py` is not detecting/correctly extracting:
* IMU Temperature Calibration
* ExternalAHRS

Tested against a local build of CubeOrangePlus with hwdef modifications disabling the feature.