### PR TITLE
AP_GPS: Backport correct satellite count for SBF DNU NrSv value

### DIFF
--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -453,8 +453,10 @@ AP_GPS_SBF::process_message(void)
             set_alt_amsl_cm(state, ((float)temp.Height - temp.Undulation) * 1e2f);
         }
 
-        if (temp.NrSV != 255) {
-            state.num_sats = temp.NrSV;
+        state.num_sats = temp.NrSV;
+        if (temp.NrSV == 255) {
+            //Do-Not-Use value for NrSv field in PVTGeodetic message
+            state.num_sats = 0;
         }
 
         Debug("temp.Mode=0x%02x\n", (unsigned)temp.Mode);


### PR DESCRIPTION
Backport to Copter 4.5 of  [PR 26628 ](https://github.com/ArduPilot/ardupilot/pull/26628): it sets the satellite count to 0 rather than ignoring it