### PR TITLE
Copter: Suppress multiple anomaly alerts

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -34,18 +34,18 @@ bool AP_Arming_Copter::run_pre_arm_checks(bool display_failure)
     // check if motor interlock aux switch is in use
     // if it is, switch needs to be in disabled position to arm
     // otherwise exit immediately.
-    if (copter.ap.using_interlock && copter.ap.motor_interlock_switch) {
+    if (passed && copter.ap.using_interlock && copter.ap.motor_interlock_switch) {
         check_failed(display_failure, "Motor Interlock Enabled");
         passed = false;
     }
 
-    if (!disarm_switch_checks(display_failure)) {
+    if (passed && !disarm_switch_checks(display_failure)) {
         passed = false;
     }
 
     // always check motors
     char failure_msg[50] {};
-    if (!copter.motors->arming_checks(ARRAY_SIZE(failure_msg), failure_msg)) {
+    if (passed && !copter.motors->arming_checks(ARRAY_SIZE(failure_msg), failure_msg)) {
         check_failed(display_failure, "Motors: %s", failure_msg);
         passed = false;
     }


### PR DESCRIPTION
The telemetry transmitter uses UART at 57600 BPS or 38400 BPS.
The signal lines are only TX and RX for the telemetry transmitter.
Sending many messages in a short time is prone to overflow.
If an error is detected in the order, I don't think other processing is necessary.
If it gets better, execute the next process.
