### PR TITLE
AP_Logger: correctly read file header for block logger

### DIFF
--- a/libraries/AP_Logger/AP_Logger_Block.cpp
+++ b/libraries/AP_Logger/AP_Logger_Block.cpp
@@ -200,7 +200,7 @@ uint16_t AP_Logger_Block::ReadHeaders()
     // we are at the start of a file, read the file header
     if (df_FilePage == 1) {
         struct FileHeader fh;
-        BlockRead(0, &fh, sizeof(fh));
+        BlockRead(sizeof(ph), &fh, sizeof(fh));
         df_FileTime = fh.utc_secs;
         df_Read_BufferIdx += sizeof(fh);
     }


### PR DESCRIPTION
This fixes the issue where log files do not have timestamps when using flash logging