### PR TITLE
AP_OpticalFlow: simplify condition used for building onboard optical …

### DIFF
--- a/libraries/AP_OpticalFlow/AP_OpticalFlow.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow.cpp
@@ -140,7 +140,7 @@ void AP_OpticalFlow::init(uint32_t log_bit)
 #endif
         break;
     case Type::BEBOP:
-#if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BEBOP
+#if AP_OPTICALFLOW_ONBOARD_ENABLED
         backend = NEW_NOTHROW AP_OpticalFlow_Onboard(*this);
 #endif
         break;


### PR DESCRIPTION
…flow in

we're not being consistent in the use of defines to protect this feature; fix that