### PR TITLE
AP_Param: throw error if we lose parameters

### DIFF
--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -1266,6 +1266,7 @@ void AP_Param::save(bool force_save)
         if (hal.util->get_soft_armed() && hal.scheduler->in_main_thread()) {
             // if we are armed in main thread then don't sleep, instead we lose the
             // parameter save
+            INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
             return;
         }
         // when we are disarmed then loop waiting for a slot to become


### PR DESCRIPTION
if we can't save a parameter due to the queue size not being large enough then there is a coding error, likely the code trying to save large numbers of parameters from main thread while armed