### PR TITLE
AP_Notify: tidy defaulting of DEFAULT_NTF_LED_TYPES

### DIFF
--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -89,11 +89,7 @@ AP_Notify *AP_Notify::_singleton;
 #endif
 
 #ifndef DEFAULT_NTF_LED_TYPES
-#if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
-  #define DEFAULT_NTF_LED_TYPES (Notify_LED_Board | I2C_LEDS)
-
-// Linux boards
-#elif CONFIG_HAL_BOARD == HAL_BOARD_LINUX
+#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
   #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO
     #define DEFAULT_NTF_LED_TYPES (Notify_LED_Board | I2C_LEDS |\
                                     Notify_LED_PCA9685LED_I2C_External)

--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -113,17 +113,12 @@ AP_Notify *AP_Notify::_singleton;
 
   #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_RST_ZYNQ
     #define DEFAULT_NTF_LED_TYPES (Notify_LED_ToshibaLED_I2C_External)
+  #endif  // board subtype
+#endif  // CONFIG_HAL_BOARD == HAL_BOARD_LINUX
+#endif  // defined (DEFAULT_NTF_LED_TYPES)
 
-  #else // other linux
+#ifndef DEFAULT_NTF_LED_TYPES
     #define DEFAULT_NTF_LED_TYPES (Notify_LED_Board | I2C_LEDS)
-  #endif
-
-// All other builds
-#else
-    #define DEFAULT_NTF_LED_TYPES (Notify_LED_Board | I2C_LEDS)
-
-#endif // board selection
-
 #endif // DEFAULT_NTF_LED_TYPES
 
 #ifndef BUZZER_ENABLE_DEFAULT

--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -94,9 +94,6 @@ AP_Notify *AP_Notify::_singleton;
     #define DEFAULT_NTF_LED_TYPES (Notify_LED_Board | I2C_LEDS |\
                                     Notify_LED_PCA9685LED_I2C_External)
 
-  #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO2
-    #define DEFAULT_NTF_LED_TYPES (Notify_LED_Board | I2C_LEDS)
-
   #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_EDGE
     #define DEFAULT_NTF_LED_TYPES (Notify_LED_Board | I2C_LEDS |\
                                     DRONECAN_LEDS)


### PR DESCRIPTION
ChibiOS was just setting the same as the default.


    now have two ifndef blocks, one of which defaults things on recognized linux boards, the other generically.
    
    Preparation for removing the defaultin for Linux boards in this file
