### PR TITLE
Plane: Reset TECS along with the rest of the controllers

### DIFF
--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -255,6 +255,9 @@ void Mode::reset_controllers()
     // reset steering controls
     plane.steer_state.locked_course = false;
     plane.steer_state.locked_course_err = 0;
+
+    // reset TECS
+    plane.TECS_controller.reset();
 }
 
 bool Mode::is_taking_off() const

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -81,7 +81,7 @@ public:
     // returns true if the vehicle can be armed in this mode
     bool pre_arm_checks(size_t buflen, char *buffer) const;
 
-    // Reset rate and steering controllers
+    // Reset rate and steering and TECS controllers
     void reset_controllers();
 
     //


### PR DESCRIPTION
For the balloon drop use-case, I've noticed that TECS would initialize on the ground. That meant that the desired altitude (which is under an LPF) would not start close to the actual altitude, rendering itself useless for an RTL:
![image](https://github.com/user-attachments/assets/fce51ee9-1023-416e-810b-b0456923fc4d)

With this commit TECS starts at the release altitude, resulting in reasonable altitude error:
![image](https://github.com/user-attachments/assets/f3bc4bfb-caa0-4446-8bc6-4e82bb632aa8)

:warning: Requires https://github.com/ArduPilot/ardupilot/pull/27758 .