### PR TITLE
SITL: reboot at different location

### DIFF
--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
@@ -305,6 +305,22 @@ void HAL_SITL::run(int argc, char * const argv[], Callbacks* callbacks) const
     actually_reboot();
 }
 
+void HAL_SITL::update_new_args(const char* opt, const char* val)
+{
+    for (uint8_t i=0; i<ARRAY_SIZE(new_argv)-1; i++) {
+        if (new_argv[i] == nullptr && new_argv[i+1] == nullptr) {
+            // add new option and value
+            new_argv[i] = (char*)opt;
+            new_argv[i+1] = (char*)val;
+            return;
+        } else if (!strcmp(new_argv[i], opt)) {
+            // update existing value
+            strncpy(new_argv[i+1], val, 100);
+            return;
+        }
+    }
+}
+
 void HAL_SITL::actually_reboot()
 {
     execv(new_argv[0], new_argv);

--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.h
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.h
@@ -13,6 +13,7 @@ public:
     HAL_SITL();
     void run(int argc, char * const argv[], Callbacks* callbacks) const override;
     static void actually_reboot();
+    static void update_new_args(const char* opt, const char* val);
 
     void set_storage_posix_enabled(bool _enabled) {
         storage_posix_enabled = _enabled;


### PR DESCRIPTION
This allows including a Lat/long/alt and heading into the PREFLIGHT_REBOOT_SHUTDOWN message to then override the home position that is used when launching the next SITL instance. The helper function is flexible to allow not just editing existing, but adding new entries for future use.

Requirements:

- p1 = 1
- p2 = 0
- p3 = 0
- p4 = valid heading: 0 - 360
- p5/x = valid latitude: +/- 90
- p6/y = valid longitude: +/- 180
- p7/z = valid altitude in meters: +/- (2^23cm / 100)
- non-zero position
- longitude isn't the magic force reboot value