### PR TITLE
Plane: added TKOFF_THR_MIN for quadplane SLT

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -148,6 +148,15 @@ const AP_Param::Info Plane::var_info[] = {
     // @Increment: 0.5
     // @User: Standard
     ASCALAR(takeoff_throttle_max_t,     "TKOFF_THR_MAX_T",  4),
+
+    // @Param: TKOFF_THR_MIN
+    // @DisplayName: Takeoff minimum throttle
+    // @Description: The minimum throttle to use in takeoffs in AUTO and TAKEOFF flight modes, when TKOFF_OPTIONS bit 0 is set. Also, the minimum throttle to use in a quadpane forward transition. This can be useful to ensure faster takeoffs or transitions on aircraft where the normal throttle control leads to a slow takeoff or transition. It is used when it is larger than THR_MIN, otherwise THR_MIN is used instead.
+    // @Units: %
+    // @Range: 0 100
+    // @Increment: 1
+    // @User: Standard
+    ASCALAR(takeoff_throttle_min,       "TKOFF_THR_MIN",    60),
     
     // @Param: TKOFF_TDRAG_ELEV
     // @DisplayName: Takeoff tail dragger elevator

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -357,6 +357,7 @@ public:
         k_param_acro_yaw_rate,
         k_param_takeoff_throttle_max_t,
         k_param_autotune_options,
+        k_param_takeoff_throttle_min,
     };
 
     AP_Int16 format_version;

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -4065,6 +4065,21 @@ bool QuadPlane::in_transition(void) const
 }
 
 /*
+  return true if we are in a fwd transition for a SLT quadplane
+  and in an auto-throttle mode
+ */
+bool QuadPlane::in_slt_fwd_transition(void) const
+{
+    if (!in_transition() || tiltrotor.enabled() || tailsitter.enabled()) {
+        return false;
+    }
+    if (!plane.control_mode->does_auto_throttle()) {
+        return false;
+    }
+    return transition->in_fwd_transition();
+}
+
+/*
   calculate current stopping distance for a quadplane in fixed wing flight
  */
 float QuadPlane::stopping_distance(float ground_speed_squared) const
@@ -4552,6 +4567,15 @@ void SLT_Transition::set_last_fw_pitch()
 {
     last_fw_mode_ms = AP_HAL::millis();
     last_fw_nav_pitch_cd = plane.nav_pitch_cd;
+}
+
+/*
+  return true if in a forward transition
+ */
+bool SLT_Transition::in_fwd_transition() const
+{
+    return transition_state == TRANSITION_AIRSPEED_WAIT ||
+        transition_state == TRANSITION_TIMER;
 }
 
 void SLT_Transition::force_transition_complete() {

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -106,6 +106,12 @@ public:
     */
     bool in_transition(void) const;
 
+    /*
+      return true if we are in a fwd transition for a SLT quadplane
+      and in an auto-throttle mode
+     */
+    bool in_slt_fwd_transition(void) const;
+
     bool handle_do_vtol_transition(enum MAV_VTOL_STATE state) const;
 
     bool do_vtol_takeoff(const AP_Mission::Mission_Command& cmd);

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -517,7 +517,7 @@ float Plane::apply_throttle_limits(float throttle_in)
 
     const bool use_takeoff_throttle_max =
 #if HAL_QUADPLANE_ENABLED
-        quadplane.in_transition() ||
+        quadplane.in_slt_fwd_transition() ||
 #endif
         (flight_stage == AP_FixedWing::FlightStage::TAKEOFF) ||
         (flight_stage == AP_FixedWing::FlightStage::ABORT_LANDING);
@@ -538,7 +538,20 @@ float Plane::apply_throttle_limits(float throttle_in)
     throttle_watt_limiter(min_throttle, max_throttle);
 #endif
 
-    return constrain_float(throttle_in, min_throttle, max_throttle);
+    /*
+      apply TKOFF_THR_MIN if enabled and in an auto-throttle forward
+      transition
+     */
+    if (use_takeoff_throttle_max) {
+        const auto tmin_thr = aparm.takeoff_throttle_min;
+        if (tmin_thr > throttle_in) {
+            throttle_in = MAX(throttle_in, tmin_thr);
+        }
+    }
+
+    auto throttle = constrain_float(throttle_in, min_throttle, max_throttle);
+
+    return throttle;
 }
 
 /*

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -1034,4 +1034,12 @@ bool Tailsitter_Transition::allow_weathervane()
     return !tailsitter.in_vtol_transition() && (vtol_limit_start_ms == 0);
 }
 
+/*
+  return true if in a forward transition
+ */
+bool Tailsitter_Transition::in_fwd_transition() const
+{
+    return transition_state == TRANSITION_ANGLE_WAIT_FW;
+}
+
 #endif  // HAL_QUADPLANE_ENABLED

--- a/ArduPlane/tailsitter.h
+++ b/ArduPlane/tailsitter.h
@@ -189,6 +189,8 @@ public:
 
     bool allow_weathervane() override;
 
+    bool in_fwd_transition() const override;
+
 private:
 
     enum {

--- a/ArduPlane/transition.h
+++ b/ArduPlane/transition.h
@@ -58,6 +58,8 @@ public:
 
     virtual bool allow_stick_mixing() const { return true; }
 
+    virtual bool in_fwd_transition() const = 0;
+
 protected:
 
     // refences for convenience
@@ -100,6 +102,8 @@ public:
     bool set_VTOL_roll_pitch_limit(int32_t& nav_roll_cd, int32_t& nav_pitch_cd) override;
 
     void set_last_fw_pitch(void) override;
+
+    bool in_fwd_transition() const override;
 
 protected:
 

--- a/libraries/AP_Vehicle/AP_FixedWing.h
+++ b/libraries/AP_Vehicle/AP_FixedWing.h
@@ -11,6 +11,7 @@ struct AP_FixedWing {
     AP_Int8 throttle_slewrate;
     AP_Int8 throttle_cruise;
     AP_Int8 takeoff_throttle_max;
+    AP_Int8 takeoff_throttle_min;
     AP_Int16 airspeed_min;
     AP_Int16 airspeed_max;
     AP_Float airspeed_cruise;


### PR DESCRIPTION
this allows for a minimum throttle to be applied during a takeoff or a forward transition in auto throttle modes. This is useful on high drag aircraft where normal TECS throttle control results in a slow transition or takeoff