### PR TITLE
Servo output optimization

### DIFF
--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -57,6 +57,9 @@ public:
     // return true if spool up is complete
     bool spool_up_complete() const { return _spool_state == SpoolState::THROTTLE_UNLIMITED; }
 
+    // update the servo map
+    void                update_servo_map();
+
     // output a thrust to all motors that match a given motor
     // mask. This is used to control tiltrotor motors in forward
     // flight. Thrust is in the range 0 to 1
@@ -195,6 +198,9 @@ protected:
 
     // array of motor output values
     float _actuator[AP_MOTORS_MAX_NUM_MOTORS];
+
+    // last time the servo map was updated
+    uint32_t last_servo_map_update_ms;
 
     /* motor enabled, checking the override mask
        _motor_mask_override is only set for tilt quadplanes

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -109,7 +109,7 @@ void AP_Motors::rc_write(uint8_t chan, uint16_t pwm)
         // note that PWM_MIN/MAX has been forced to 1000/2000
         SRV_Channels::set_output_scaled(function, float(pwm) - _motor_pwm_scaled.offset);
     } else {
-        SRV_Channels::set_output_pwm(function, pwm);
+        SRV_Channels::output_pwm_chan(chan, pwm);
     }
 }
 

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -109,7 +109,7 @@ void AP_Motors::rc_write(uint8_t chan, uint16_t pwm)
         // note that PWM_MIN/MAX has been forced to 1000/2000
         SRV_Channels::set_output_scaled(function, float(pwm) - _motor_pwm_scaled.offset);
     } else {
-        SRV_Channels::output_pwm_chan(chan, pwm);
+        SRV_Channels::output_pwm_chan(motor_servo_map[chan], pwm);
     }
 }
 
@@ -226,6 +226,7 @@ void AP_Motors::add_motor_num(int8_t motor_num)
     if (motor_num >= 0 && motor_num < AP_MOTORS_MAX_NUM_MOTORS) {
         SRV_Channel::Aux_servo_function_t function = SRV_Channels::get_motor_function(motor_num);
         SRV_Channels::set_aux_channel_default(function, motor_num);
+        SRV_Channels::find_channel(function, motor_servo_map[motor_num]);
     }
 }
 

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -6,6 +6,7 @@
 #include <Filter/DerivativeFilter.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <AP_Logger/AP_Logger_config.h>
+#include <SRV_Channel/SRV_Channel.h>
 
 // offsets for motors in motor_out and _motor_filtered arrays
 #define AP_MOTORS_MOT_1 0U

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -401,6 +401,7 @@ private:
     bool _interlock;         // 1 if the motor interlock is enabled (i.e. motors run), 0 if disabled (motors don't run)
     bool _initialised_ok;    // 1 if initialisation was successful
     bool _spoolup_block;     // true if spoolup is blocked
+    uint8_t motor_servo_map[AP_MOTORS_MAX_NUM_MOTORS];  // map of motor channels to servo channels to expedite lookups
 
     static AP_Motors *_singleton;
 };

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -376,6 +376,8 @@ protected:
 
     MAV_TYPE _mav_type; // MAV_TYPE_GENERIC = 0;
 
+    uint8_t motor_servo_map[AP_MOTORS_MAX_NUM_MOTORS];  // map of motor channels to servo channels to expedite lookups
+
     // return string corresponding to frame_class
     virtual const char* _get_frame_string() const = 0;
 
@@ -401,7 +403,6 @@ private:
     bool _interlock;         // 1 if the motor interlock is enabled (i.e. motors run), 0 if disabled (motors don't run)
     bool _initialised_ok;    // 1 if initialisation was successful
     bool _spoolup_block;     // true if spoolup is blocked
-    uint8_t motor_servo_map[AP_MOTORS_MAX_NUM_MOTORS];  // map of motor channels to servo channels to expedite lookups
 
     static AP_Motors *_singleton;
 };

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -372,6 +372,9 @@ public:
     // set output value for a specific function channel as a pwm value
     static void set_output_pwm_chan(uint8_t chan, uint16_t value);
 
+    // set and output value for a specific function channel as a pwm value
+    static void output_pwm_chan(uint8_t chan, uint16_t value);
+
     // set output value for a specific function channel as a pwm value for specified override time in ms
     static void set_output_pwm_chan_timeout(uint8_t chan, uint16_t value, uint16_t timeout_ms);
 

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -341,7 +341,7 @@ void SRV_Channels::set_output_pwm(SRV_Channel::Aux_servo_function_t function, ui
         return;
     }
     for (uint8_t i = 0; i < NUM_SERVO_CHANNELS; i++) {
-        if (channels[i].function == function) {
+        if (channels[i].function.get() == function) {
             channels[i].set_output_pwm(value);
             channels[i].output_ch();
         }

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -474,6 +474,15 @@ void SRV_Channels::set_output_pwm_chan(uint8_t chan, uint16_t value)
     }
 }
 
+// set and output value for a specific function channel as a pwm value
+void SRV_Channels::output_pwm_chan(uint8_t chan, uint16_t value)
+{
+    if (chan < NUM_SERVO_CHANNELS) {
+        channels[chan].set_output_pwm(value);
+        channels[chan].output_ch();
+    }
+}
+
 #if AP_SCRIPTING_ENABLED && AP_SCHEDULER_ENABLED
 // set output value for a specific function channel as a pwm value with loop based timeout
 // timeout_ms of zero will clear override of the channel

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -449,14 +449,14 @@ void SRV_Channels::calc_pwm(void)
         slew->last_scaled_output = functions[slew->func].output_scaled;
     }
 
-    WITH_SEMAPHORE(_singleton->override_counter_sem);
-
     for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
         // check if channel has been locked out for this loop
         // if it has, decrement the loop count for that channel
         if (override_counter[i] == 0) {
             channels[i].set_override(false);
         } else {
+            WITH_SEMAPHORE(_singleton->override_counter_sem);
+
             channels[i].set_override(true);
             override_counter[i]--;
         }


### PR DESCRIPTION
Split out from https://github.com/ArduPilot/ardupilot/pull/27029

This is an optimization that avoids a repeated N^2 lookup in motor output that proves to be quite expensive at high rates (i.e. involving dshot).