### PR TITLE
Allow configuration of device periodic delay

### DIFF
--- a/libraries/AP_HAL/Device.h
+++ b/libraries/AP_HAL/Device.h
@@ -260,6 +260,12 @@ public:
     virtual PeriodicHandle register_periodic_callback(uint32_t period_usec, PeriodicCb) = 0;
 
     /*
+     * Adjust the minimum time allowed between cycles of the periodic callback registered with
+     * #register_periodic_callback.
+     */
+    virtual void set_periodic_minimum(uint32_t min_usec) = 0;
+
+    /*
      * Adjust the time for the periodic callback registered with
      * #register_periodic_callback. Note that the time will be re-calculated
      * from the moment this call is made and expire after @period_usec.

--- a/libraries/AP_HAL/I2CDevice.h
+++ b/libraries/AP_HAL/I2CDevice.h
@@ -57,6 +57,9 @@ public:
     virtual bool adjust_periodic_callback(
         Device::PeriodicHandle h, uint32_t period_usec) override = 0;
 
+    /* See AP_HAL::Device::set_periodic_minimum() */
+    void set_periodic_minimum(uint32_t min_period_usec) override {}
+
     /*
      * Force I2C transfers to be split between send and receive parts, with a
      * stop condition between them. Setting this allows to conveniently

--- a/libraries/AP_HAL/SPIDevice.h
+++ b/libraries/AP_HAL/SPIDevice.h
@@ -62,6 +62,9 @@ public:
     virtual bool adjust_periodic_callback(
         PeriodicHandle h, uint32_t period_usec) override { return false; }
 
+    /* See AP_HAL::Device::set_periodic_minimum() */
+    void set_periodic_minimum(uint32_t min_period_usec) override {}
+
     // setup a bus clock slowdown factor (optional interface)
     virtual void set_slowdown(uint8_t slowdown) {}
 };

--- a/libraries/AP_HAL/WSPIDevice.h
+++ b/libraries/AP_HAL/WSPIDevice.h
@@ -147,6 +147,9 @@ public:
 
     virtual bool is_busy() = 0;
 
+   /* See AP_HAL::Device::set_periodic_minimum() */
+    void set_periodic_minimum(uint32_t min_period_usec) override {}
+
     virtual AP_HAL::Semaphore* get_semaphore() override = 0;
 
 protected:

--- a/libraries/AP_HAL_ChibiOS/Device.cpp
+++ b/libraries/AP_HAL_ChibiOS/Device.cpp
@@ -31,19 +31,25 @@
 #define HAL_DEVICE_THREAD_STACK 1024
 #endif
 
+#ifndef DEFAULT_MIN_PERIOD_US
+#define DEFAULT_MIN_PERIOD_US 100
+#endif
+
 using namespace ChibiOS;
 
 extern const AP_HAL::HAL& hal;
 
 DeviceBus::DeviceBus(uint8_t _thread_priority) :
-        thread_priority(_thread_priority)
+        thread_priority(_thread_priority),
+        periodic_min_us(DEFAULT_MIN_PERIOD_US)
 {
     bouncebuffer_init(&bounce_buffer_tx, 10, false);
     bouncebuffer_init(&bounce_buffer_rx, 10, false);
 }
 
 DeviceBus::DeviceBus(uint8_t _thread_priority, bool axi_sram) :
-        thread_priority(_thread_priority)
+        thread_priority(_thread_priority),
+        periodic_min_us(DEFAULT_MIN_PERIOD_US)
 {
     bouncebuffer_init(&bounce_buffer_tx, 10, axi_sram);
     bouncebuffer_init(&bounce_buffer_rx, 10, axi_sram);
@@ -93,8 +99,8 @@ void DeviceBus::bus_thread(void *arg)
         }
         // don't delay for less than 100usec, so one thread doesn't
         // completely dominate the CPU
-        if (delay < 100) {
-            delay = 100;
+        if (delay < binfo->periodic_min_us) {
+            delay = binfo->periodic_min_us;
         }
         hal.scheduler->delay_microseconds(delay);
     }

--- a/libraries/AP_HAL_ChibiOS/Device.h
+++ b/libraries/AP_HAL_ChibiOS/Device.h
@@ -53,6 +53,9 @@ public:
                             uint8_t *&buf_rx, uint16_t rx_len) WARN_IF_UNUSED;
     void bouncebuffer_finish(const uint8_t *buf_tx, uint8_t *buf_rx, uint16_t rx_len);
 
+    // control the minimum separation between cycles
+    void set_periodic_minimum(uint32_t min_usec) { periodic_min_us = min_usec; }
+
 private:
     struct callback_info {
         struct callback_info *next;
@@ -61,6 +64,7 @@ private:
         uint64_t next_usec;
     } *callbacks;
     uint8_t thread_priority;
+    uint32_t periodic_min_us;
     thread_t* thread_ctx;
     bool thread_started;
     AP_HAL::Device *hal_device;

--- a/libraries/AP_HAL_ChibiOS/I2CDevice.cpp
+++ b/libraries/AP_HAL_ChibiOS/I2CDevice.cpp
@@ -440,6 +440,10 @@ AP_HAL::Device::PeriodicHandle I2CDevice::register_periodic_callback(uint32_t pe
     return bus.register_periodic_callback(period_usec, cb, this);
 }
 
+void I2CDevice::set_periodic_minimum(uint32_t min_period_usec)
+{
+    return bus.set_periodic_minimum(min_period_usec);
+}
 
 /*
   adjust a periodic callback

--- a/libraries/AP_HAL_ChibiOS/I2CDevice.h
+++ b/libraries/AP_HAL_ChibiOS/I2CDevice.h
@@ -86,6 +86,9 @@ public:
     AP_HAL::Device::PeriodicHandle register_periodic_callback(
         uint32_t period_usec, AP_HAL::Device::PeriodicCb) override;
 
+    /* See AP_HAL::Device::set_periodic_minimum() */
+    void set_periodic_minimum(uint32_t min_period_usec) override;
+
     /* See AP_HAL::Device::adjust_periodic_callback() */
     bool adjust_periodic_callback(AP_HAL::Device::PeriodicHandle h, uint32_t period_usec) override;
 

--- a/libraries/AP_HAL_ChibiOS/SPIDevice.cpp
+++ b/libraries/AP_HAL_ChibiOS/SPIDevice.cpp
@@ -336,6 +336,11 @@ AP_HAL::Device::PeriodicHandle SPIDevice::register_periodic_callback(uint32_t pe
     return bus.register_periodic_callback(period_usec, cb, this);
 }
 
+void SPIDevice::set_periodic_minimum(uint32_t min_period_usec)
+{
+    return bus.set_periodic_minimum(min_period_usec);
+}
+
 bool SPIDevice::adjust_periodic_callback(AP_HAL::Device::PeriodicHandle h, uint32_t period_usec)
 {
     return bus.adjust_timer(h, period_usec);

--- a/libraries/AP_HAL_ChibiOS/SPIDevice.h
+++ b/libraries/AP_HAL_ChibiOS/SPIDevice.h
@@ -138,6 +138,9 @@ public:
     /* See AP_HAL::Device::adjust_periodic_callback() */
     bool adjust_periodic_callback(AP_HAL::Device::PeriodicHandle h, uint32_t period_usec) override;
 
+    /* See AP_HAL::Device::set_periodic_minimum() */
+    void set_periodic_minimum(uint32_t min_period_usec) override;
+
     bool set_chip_select(bool set) override;
 
     bool acquire_bus(bool acquire, bool skip_cs);


### PR DESCRIPTION
Split out from https://github.com/ArduPilot/ardupilot/pull/27029

Currently the value is hardcoded and fairly arbitrary. This allows devices to decide.

Here is the motor output using a 0 minimum on the MPU6000. You can see that the output rate is the desired 4Khz (this is the gyro sample rate) and is pretty regular:

![image](https://github.com/user-attachments/assets/811f95bf-e80e-4593-b37b-74c3e4b4bcae)

Here is with the default 100us. You can see that the output is not able to keep up with the inbound rate because a fixed 100us delay is being added after the SPI thread callback has run and we only get 2Khz output and worse we will be dropping samples.

![image](https://github.com/user-attachments/assets/64842318-e928-47f4-b02e-d6f94c1d6334)

Interestingly the ICM42688 *is* able to cope:

![image](https://github.com/user-attachments/assets/4493ddb4-5053-461c-aada-5938f55feaa0)

I think this is to do with the SPI bus speed. On the Matek H743 we have:

```
SPIDEV icm42688  SPI1 DEVID1 IMU1_CS      MODE3  2*MHZ 16*MHZ 
SPIDEV mpu6000   SPI1 DEVID1 IMU1_CS      MODE3  1*MHZ  4*MHZ
SPIDEV icm20602  SPI4 DEVID1 IMU2_CS      MODE3  1*MHZ  4*MHZ
SPIDEV icm42605  SPI4 DEVID1 IMU3_CS      MODE3  2*MHZ 16*MHZ
```

So MPU6000 running really pretty slowly. If I put some simple timing capture in the INS thread the MPU6000 takes about 240us to process a FIFO read and the ICM24688 takes about 120us - so quite a substantial difference and of course easily explains why one can keep up and the other cannot. I think perhaps on that basis the answer is not to modify the periodic delay but simply not allow the fast rate code to be run at higher rates on these slow IMUs. I guess we might be able to put something in the chibios_hwdef.py script that figures out whether the INS read is fast enough,






