### PR TITLE
AHRS: added common origin between backends

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -1024,6 +1024,9 @@ private:
     bool option_set(Options option) const {
         return (_options & uint16_t(option)) != 0;
     }
+
+    // true when we have completed the common origin setup
+    bool done_common_origin;
 };
 
 namespace AP {

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS.cpp
@@ -180,6 +180,17 @@ bool AP_ExternalAHRS::get_origin(Location &loc)
     return false;
 }
 
+bool AP_ExternalAHRS::set_origin(const Location &loc)
+{
+    WITH_SEMAPHORE(state.sem);
+    if (state.have_origin) {
+        return false;
+    }
+    state.origin = loc;
+    state.have_origin = true;
+    return true;
+}
+
 bool AP_ExternalAHRS::get_location(Location &loc)
 {
     if (!state.have_location) {
@@ -312,19 +323,7 @@ void AP_ExternalAHRS::update(void)
         backend->update();
     }
 
-    /*
-      if backend has not supplied an origin and AHRS has an origin
-      then use that origin so we get a common origin for minimum
-      disturbance when switching backends
-     */
     WITH_SEMAPHORE(state.sem);
-    if (!state.have_origin) {
-        Location origin;
-        if (AP::ahrs().get_origin(origin)) {
-            state.origin = origin;
-            state.have_origin = true;
-        }
-    }
 #if HAL_LOGGING_ENABLED
     const uint32_t now_ms = AP_HAL::millis();
     if (log_rate.get() > 0 && now_ms - last_log_ms >= uint32_t(1000U/log_rate.get())) {

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS.h
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS.h
@@ -109,6 +109,7 @@ public:
     bool initialised(void) const;
     bool get_quaternion(Quaternion &quat);
     bool get_origin(Location &loc);
+    bool set_origin(const Location &loc);
     bool get_location(Location &loc);
     Vector2f get_groundspeed_vector();
     bool get_velocity_NED(Vector3f &vel);

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1099,6 +1099,10 @@ bool NavEKF2::getOriginLLH(Location &loc) const
     if (!core) {
         return false;
     }
+    if (common_origin_valid) {
+        loc = common_EKF_origin;
+        return true;
+    }
     return core[primary].getOriginLLH(loc);
 }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1113,11 +1113,9 @@ bool NavEKF2::setOriginLLH(const Location &loc)
     if (!core) {
         return false;
     }
-    if (_fusionModeGPS != 3 || common_origin_valid) {
-        // we don't allow setting of the EKF origin if using GPS
-        // or if the EKF origin has already been set.
-        // This is to prevent accidental setting of EKF origin with an
-        // invalid position or height or causing upsets from a shifting origin.
+    if (common_origin_valid) {
+        // we don't allow setting of the EKF origin if the EKF origin
+        // has already been set.
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "EKF2 refusing set origin");
         return false;
     }


### PR DESCRIPTION
This ensures that EKF2, EKF3 and ExternalAHRS all have a common origin

Note that the origin will come from the first running backend that gets an origin, even if it is not the active backend. This is needed because EKF2 and EKF3 refuse to change origin once it is set.
The placement of this code in the update function for each backend is done as two backends may get an origin on the same loop, so we must check for an origin as soon as we call the backends update
