### PR TITLE
QURT: allow for external compasses

### DIFF
--- a/libraries/AP_HAL/board/qurt.h
+++ b/libraries/AP_HAL/board/qurt.h
@@ -82,6 +82,8 @@
 #define HAL_BATT_VOLT_SCALE 1
 #define HAL_BATT_CURR_SCALE 1
 
+#define HAL_PROBE_EXTERNAL_I2C_COMPASSES
+
 /*
   compass list
  */


### PR DESCRIPTION
this allows for additional compasses on I2C