### PR TITLE
GCS_MAVLink: allow uploading GCS to cancel upload using mission_clear_all

### DIFF
--- a/libraries/GCS_MAVLink/MissionItemProtocol.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol.cpp
@@ -33,7 +33,7 @@ void MissionItemProtocol::handle_mission_clear_all(const GCS_MAVLINK &_link,
                                                    const mavlink_message_t &msg)
 {
     bool success = true;
-    success = success && !receiving;
+    success = success && cancel_upload(_link, msg);
     success = success && clear_all_items();
     send_mission_ack(_link, msg, success ? MAV_MISSION_ACCEPTED : MAV_MISSION_ERROR);
 }

--- a/libraries/GCS_MAVLink/MissionItemProtocol.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol.cpp
@@ -52,6 +52,29 @@ bool MissionItemProtocol::mavlink2_requirement_met(const GCS_MAVLINK &_link, con
     return false;
 }
 
+// returns true if we are either not receiving, or we successfully
+// cancelled an existing upload:
+bool MissionItemProtocol::cancel_upload(const GCS_MAVLINK &_link, const mavlink_message_t &msg)
+{
+    if (receiving) {
+        // someone is already uploading a mission.  If we are
+        // receiving from someone then we will allow them to restart -
+        // otherwise we deny.
+        if (msg.sysid != dest_sysid || msg.compid != dest_compid) {
+            // reject another upload until
+            send_mission_ack(_link, msg, MAV_MISSION_DENIED);
+            return false;
+        }
+        // the upload count may have changed; free resources and
+        // allocate them again:
+        free_upload_resources();
+        receiving = false;
+        link = nullptr;
+    }
+
+    return true;
+}
+
 void MissionItemProtocol::handle_mission_count(
     GCS_MAVLINK &_link,
     const mavlink_mission_count_t &packet,
@@ -61,20 +84,8 @@ void MissionItemProtocol::handle_mission_count(
         return;
     }
 
-    if (receiving) {
-        // someone is already uploading a mission.  If we are
-        // receiving from someone then we will allow them to restart -
-        // otherwise we deny.
-        if (msg.sysid != dest_sysid || msg.compid != dest_compid) {
-            // reject another upload until
-            send_mission_ack(_link, msg, MAV_MISSION_DENIED);
-            return;
-        }
-        // the upload count may have changed; free resources and
-        // allocate them again:
-        free_upload_resources();
-        receiving = false;
-        link = nullptr;
+    if (!cancel_upload(_link, msg)) {
+        return;
     }
 
     if (packet.count > max_items()) {

--- a/libraries/GCS_MAVLink/MissionItemProtocol.h
+++ b/libraries/GCS_MAVLink/MissionItemProtocol.h
@@ -79,6 +79,10 @@ protected:
 
 private:
 
+    // returns true if we are either not receiving, or we successfully
+    // cancelled an existing upload:
+    bool cancel_upload(const GCS_MAVLINK &_link, const mavlink_message_t &msg);
+
     virtual void truncate(const mavlink_mission_count_t &packet) = 0;
 
     uint16_t        request_i; // request index


### PR DESCRIPTION
~these would appear to be identical operations.~  clear differs from a 0-item-upload in the "clear" is only allowed disarmed, and resets a whole bunch of mission state (e.g. the loaded item).

Replaces https://github.com/ArduPilot/ardupilot/pull/15669 .  Like the PR it replaces, this allows a GCS to cancel an upload with a clear-all command as if they'd issues a mission-upload with zero items.
