### PR TITLE
Add support for deca frame in QuadPlane::setup

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -695,6 +695,9 @@ bool QuadPlane::setup(void)
     case AP_Motors::MOTOR_FRAME_Y6:
         setup_default_channels(7);
         break;
+    case AP_Motors::MOTOR_FRAME_DECA:
+        setup_default_channels(10);
+        break;
     case AP_Motors::MOTOR_FRAME_TRI:
         SRV_Channels::set_default_function(CH_5, SRV_Channel::k_motor1);
         SRV_Channels::set_default_function(CH_6, SRV_Channel::k_motor2);


### PR DESCRIPTION
Resolves issue #27846 .

Looking at the full parameter list for Plane, Q_Frame_Class = 14 (Deca) is a valid option and going over the AP_MotorsMatrix, Deca seems to be supported for types 'Plus' and 'X'.
However when I configure my AP's frame class to be Deca, I get messages saying "Config Error: fix problem then reboot" and "Config Error: Unsupported Q_Frame_Class 14".

The deca frame is properly supported for Copter and as the quadplane vtol setup calls upon the copter frames, it should also be supported for arduplane vtol for anyone who wants to work 10 vertical motors.