### PR TITLE
Plane: Updated QTUN and NTUN units to modern multiplier

### DIFF
--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -341,7 +341,7 @@ const struct LogStructure Plane::log_structure[] = {
 // @Field: TAT: target altitude TECS
 // @Field: TAsp: target airspeed
     { LOG_NTUN_MSG, sizeof(log_Nav_Tuning),         
-      "NTUN", "QfcccfffLLeee",  "TimeUS,Dist,TBrg,NavBrg,AltE,XT,XTi,AsE,TLat,TLng,TAW,TAT,TAsp", "smddmmmnDUmmn", "F0BBB0B0GG000" , true },
+      "NTUN", "QfcccfffLLeee",  "TimeUS,Dist,TBrg,NavBrg,AltE,XT,XTi,AsE,TLat,TLng,TAW,TAT,TAsp", "smddmmmnDUmmn", "F0BBB0B0GGBB0" , true },
 
 // @LoggerMessage: ATRP
 // @Description: Plane AutoTune
@@ -395,7 +395,7 @@ const struct LogStructure Plane::log_structure[] = {
 // @FieldBitmaskEnum: Ast: log_assistance_flags
 #if HAL_QUADPLANE_ENABLED
     { LOG_QTUN_MSG, sizeof(QuadPlane::log_QControl_Tuning),
-      "QTUN", "QffffffeccfBB", "TimeUS,ThI,ABst,ThO,ThH,DAlt,Alt,BAlt,DCRt,CRt,TMix,Trn,Ast", "s----mmmnn---", "F----00000---" , true },
+      "QTUN", "QffffffeccfBB", "TimeUS,ThI,ABst,ThO,ThH,DAlt,Alt,BAlt,DCRt,CRt,TMix,Trn,Ast", "s----mmmnn---", "F----000BB---" , true },
 #endif
 
 // @LoggerMessage: PIQR


### PR DESCRIPTION
Did not change the format character, as pymavlink seems to need it, due to a bug.

Before:
![Screenshot from 2024-08-20 16-37-12](https://github.com/user-attachments/assets/be237811-95bd-451a-b918-01dc8d098b85)
![Screenshot from 2024-08-20 16-39-23](https://github.com/user-attachments/assets/08481b3e-ca98-41c2-a5c4-3f7504056d71)


After:
![Screenshot from 2024-08-20 16-37-37](https://github.com/user-attachments/assets/69eddd71-4fc4-4158-9f6a-dfb8000c1c53)
![Screenshot from 2024-08-20 16-44-27](https://github.com/user-attachments/assets/be8bf8ef-987d-43a1-b11c-e56c034ca234)
