### PR TITLE
AP_NavEKF3: do not log DefaultAirspeed if logging not started

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -2043,12 +2043,15 @@ void NavEKF3::updateLaneSwitchPosDownResetData(uint8_t new_primary, uint8_t old_
 // Writes the default equivalent airspeed and 1-sigma uncertainty in m/s to be used in forward flight if a measured airspeed is required and not available.
 void NavEKF3::writeDefaultAirSpeed(float airspeed, float uncertainty)
 {
+    // ignore any data if the EKF is not started
+    if (!core) {
+        return;
+    }
+
     AP::dal().log_writeDefaultAirSpeed3(airspeed, uncertainty);
 
-    if (core) {
-        for (uint8_t i=0; i<num_cores; i++) {
-            core[i].writeDefaultAirSpeed(airspeed, uncertainty);
-        }
+    for (uint8_t i=0; i<num_cores; i++) {
+        core[i].writeDefaultAirSpeed(airspeed, uncertainty);
     }
 }
 


### PR DESCRIPTION
if we are not going to use this value ourselves then we certainly should not add it to the replay log

A similar problem was causing replay to not work correctly.

There's the additional thing that logging may be preventing the EKF from starting, so logging here can cause Logger to throw a fatal error in SITL as it can't log the replay block.

