### PR TITLE
Plane: Enable quadplane dead reckoning navigation to start earlier

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -505,6 +505,11 @@ void Plane::update_fly_forward(void)
         return;
     }
 
+    if (quadplane.in_transition()) {
+        ahrs.set_fly_forward(true);
+        return;
+    }
+
     if (quadplane.in_vtol_mode() ||
         quadplane.in_assisted_flight()) {
         ahrs.set_fly_forward(false);


### PR DESCRIPTION
This reduces EKF errors during transition fromVTOL to FW flight when operating without a GPS fix.