### PR TITLE
AP_InertialSensor: support fast rate primary on MPU6000

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -26,6 +26,7 @@
 #include <AP_InternalError/AP_InternalError.h>
 #include <AP_Logger/AP_Logger.h>
 
+#include "AP_InertialSensor_rate_config.h"
 #include "AP_InertialSensor_Invensense.h"
 #include <GCS_MAVLink/GCS.h>
 
@@ -436,7 +437,7 @@ void AP_InertialSensor_Invensense::start()
     }
 
     // start the timer process to read samples, using the fastest rate avilable
-    _dev->register_periodic_callback(1000000UL / _gyro_backend_rate_hz, FUNCTOR_BIND_MEMBER(&AP_InertialSensor_Invensense::_poll_data, void));
+    periodic_handle = _dev->register_periodic_callback(1000000UL / _gyro_backend_rate_hz, FUNCTOR_BIND_MEMBER(&AP_InertialSensor_Invensense::_poll_data, void));
 }
 
 // get a startup banner to output to the GCS
@@ -481,6 +482,21 @@ bool AP_InertialSensor_Invensense::update() /* front end */
     }
 
     return true;
+}
+
+void AP_InertialSensor_Invensense::set_primary(bool _is_primary)
+{
+#if AP_INERTIALSENSOR_FAST_SAMPLE_WINDOW_ENABLED
+    if (_imu.is_dynamic_fifo_enabled(gyro_instance)) {
+        if (_is_primary) {
+            _dev->adjust_periodic_callback(periodic_handle, 1000000UL / _gyro_backend_rate_hz);
+        } else {
+            // scale down non-primary to 2x loop rate, but no greater than the default sampling rate
+            _dev->adjust_periodic_callback(periodic_handle,
+                                           1000000UL / constrain_int16(get_loop_rate_hz() * 2, 400, 1000));
+        }
+    }
+#endif
 }
 
 /*

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -74,6 +74,9 @@ extern const AP_HAL::HAL& hal;
 #define MPU_SAMPLE_SIZE 14
 #define MPU_FIFO_BUFFER_LEN 8
 
+// rate the FIFO is filled at when fast sampling, independent of the backend rate
+#define MPU_FAST_SAMPLE_RATE_HZ 8000
+
 #define int16_val(v, idx) ((int16_t)(((uint16_t)v[2*idx] << 8) | v[2*idx+1]))
 #define uint16_val(v, idx)(((uint16_t)v[2*idx] << 8) | v[2*idx+1])
 
@@ -490,6 +493,11 @@ void AP_InertialSensor_Invensense::set_primary(bool _is_primary)
     if (_imu.is_dynamic_fifo_enabled(gyro_instance)) {
         if (_is_primary) {
             _dev->adjust_periodic_callback(periodic_handle, 1000000UL / _gyro_backend_rate_hz);
+        } else if (_fast_sampling) {
+            // unlike the v3 IMUs the FIFO fills at the 8kHz sensor rate rather than the backend rate,
+            // so keep a non-primary at one _fifo_buffer of samples per beat to stay well clear of the
+            // depth beyond which _read_fifo() finds corrupt samples
+            _dev->adjust_periodic_callback(periodic_handle, 1000000UL / (MPU_FAST_SAMPLE_RATE_HZ / MPU_FIFO_BUFFER_LEN));
         } else {
             // scale down non-primary to 2x loop rate, but no greater than the default sampling rate
             _dev->adjust_periodic_callback(periodic_handle,

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
@@ -79,6 +79,9 @@ public:
     // 16G
     const uint16_t multiplier_accel = INT16_MAX/(26*GRAVITY_MSS);
 
+protected:
+    void set_primary(bool _is_primary) override;
+
 private:
     AP_InertialSensor_Invensense(AP_InertialSensor &imu,
                               AP_HAL::OwnPtr<AP_HAL::Device> dev,
@@ -149,6 +152,7 @@ private:
 
     AP_HAL::DigitalSource *_drdy_pin;
     AP_HAL::OwnPtr<AP_HAL::Device> _dev;
+    AP_HAL::Device::PeriodicHandle periodic_handle;
     AP_Invensense_AuxiliaryBus *_auxiliary_bus;
 
     // which sensor type this is


### PR DESCRIPTION
### Summary

Give the Invensense v1 driver the same set_primary() handling as v3 so the fast rate loop's dynamic FIFO works on an MPU6000: a non-primary v1 IMU is read at a reduced rate and the primary at the full backend rate. Split out from #27029.

### Classification & Testing

- [x] Tested on hardware
- [x] Logs available on request

Tested on a Matek H743 Slim (MPU6000 primary) and on a client board with an MPU6000 in the second slot, fast sampling on and off. The current head differs from what was flown only by removing the resync described below, which review showed never fired in steady state.

### Description

Testing with an MPU6000 in the second slot found that the v3 bound of 2x loop rate is too slow for v1: the v1 FIFO fills at the 8kHz sensor rate whatever the backend rate, and at 400Hz beats it reached the depth where the driver already discards corrupt samples ("stop at 8 of 48" and temperature resets). A fast-sampling non-primary is now held at 1kHz, one read buffer per beat; the 2x loop rate scaling applies only without fast sampling, where the FIFO fills at the backend rate as on v3.

An earlier version also resynced the primary's beat to the FIFO when a read came up short. The check compared the raw gyro count with the downsample rate, and since the count is only reset by the accel block it never fired in steady state. Fixing it is the wrong answer: adjust_periodic_callback() moves the next beat to now + period, and now is after the wake latency and the count read, so each correction overshoots the drift it is fixing and is undone within a few beats. A model of the DeviceBus timer gives roughly 50 empty beats and 50 double emits per second at 1-4kHz with an IMU clock 0.1% slower than the MCU, against a handful with no resync, and with the rate thread on the backend's 200ms re-anchor in update_primary() dominates anyway. The resync has been dropped.
