### PR TITLE
AC_AttitudeControl: update comment in is_active_xy() (NFC)

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -611,7 +611,7 @@ void AC_PosControl::stop_vel_xy_stabilisation()
     _pid_vel_xy.reset_I();
 }
 
-// is_active_xy - returns true if the xy position controller has bee n run in the previous 5 loop times
+// is_active_xy - returns true if the xy position controller has been run in the previous loop
 bool AC_PosControl::is_active_xy() const
 {
     const uint32_t dt_ticks = AP::scheduler().ticks32() - _last_update_xy_ticks;
@@ -942,7 +942,7 @@ void AC_PosControl::update_pos_offset_z(float pos_offset_z)
         _jerk_max_z_cmsss, _dt, false);
 }
 
-// is_active_z - returns true if the z position controller has been run in the previous 5 loop times
+// is_active_z - returns true if the z position controller has been run in the previous loop
 bool AC_PosControl::is_active_z() const
 {
     const uint32_t dt_ticks = AP::scheduler().ticks32() - _last_update_z_ticks;


### PR DESCRIPTION
This PR updates the comment in the is_active_xy() and is_active_z() function to accurately reflect the current logic. 

Previously, the comment mentioned that the position controller would return true if it had run in the previous 5 loop times, which was based on an older implementation with a timeout of 5000000 microseconds.
https://github.com/ArduPilot/ardupilot/commit/3c69d282373a42e79b9655d7ebedf924571e9ab3#diff-9fe7f1dfc4ef9b28922f55104d879c4b78656bc70293cde53f3c114dad535eeeR593

However, the current implementation uses a tick-based system and returns true if the position controller has been run in the previous loop (i.e., within 1 tick).
https://github.com/ArduPilot/ardupilot/pull/22766