### PR TITLE
AP_Mount_Siyi: Bugfix for GPS position in EXIF from Siyi camera

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -1180,7 +1180,7 @@ void AP_Mount_Siyi::send_attitude_position(void)
         uint32_t time_boot_ms;
         int32_t lat, lon;
         int32_t alt_msl, alt_ellipsoid;
-        Vector3l velocity_ned_int32;
+        Vector3f velocity_ned_int32;
     } position;
     Location loc;
     Vector3f velocity_ned;


### PR DESCRIPTION
The longitude in the EXIF data was not being saved correctly when shooting with the Siyi A8 mini*, so I made a slight modification to the code.
I will show the properties of the captured images before and after the code modification below(Please forgive that this is a Japanese-language environment).

- Before(Longitude is an abnormal value)
![before](https://github.com/user-attachments/assets/37d0f7bd-1011-4360-bba5-8aae4ca66604)

- After(Longitude was corrected to the appropriate value)
![after](https://github.com/user-attachments/assets/494534d7-0cd2-45fc-a3c5-5747f2124a13)

The shooting location is Tokyo, Japan. Normally, the latitude should be around 35.6, and the longitude should be around 139.6.

Please confirm this modification.

*Camera Firmware: v0.2.6, Gimbal Firmware: v0.3.7