### PR TITLE
AP_Camera/AP_Mount/AP_Scripting: add change settings method

### DIFF
--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -780,6 +780,19 @@ bool AP_Camera::get_state(uint8_t instance, camera_state_t& cam_state)
     }
     return backend->get_state(cam_state);
 }
+
+// change camera settings not normally used by autopilot
+bool AP_Camera::change_setting(uint8_t instance, CameraSetting setting, float value)
+{
+    WITH_SEMAPHORE(_rsem);
+
+    auto *backend = get_instance(instance);
+    if (backend == nullptr) {
+        return false;
+    }
+    return backend->change_setting(setting, value);
+}
+
 #endif // #if AP_CAMERA_SCRIPTING_ENABLED
 
 // return backend for instance number

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -181,6 +181,9 @@ public:
     // accessor to allow scripting backend to retrieve state
     // returns true on success and cam_state is filled in
     bool get_state(uint8_t instance, camera_state_t& cam_state);
+
+    // change camera settings not normally used by autopilot
+    bool change_setting(uint8_t instance, CameraSetting setting, float value);
 #endif
 
     // Return true and the relay index if relay camera backend is selected, used for conversion to relay functions

--- a/libraries/AP_Camera/AP_Camera_Backend.h
+++ b/libraries/AP_Camera/AP_Camera_Backend.h
@@ -130,6 +130,9 @@ public:
     // accessor to allow scripting backend to retrieve state
     // returns true on success and cam_state is filled in
     virtual bool get_state(AP_Camera::camera_state_t& cam_state) { return false; }
+
+    // change camera settings not normally used by autopilot
+    virtual bool change_setting(CameraSetting setting, float value) { return false; }
 #endif
 
 protected:

--- a/libraries/AP_Camera/AP_Camera_Mount.cpp
+++ b/libraries/AP_Camera/AP_Camera_Mount.cpp
@@ -109,4 +109,16 @@ void AP_Camera_Mount::send_camera_capture_status(mavlink_channel_t chan) const
     }
 }
 
+#if AP_CAMERA_SCRIPTING_ENABLED
+// change camera settings not normally used by autopilot
+bool AP_Camera_Mount::change_setting(CameraSetting setting, float value)
+{
+    AP_Mount* mount = AP::mount();
+    if (mount != nullptr) {
+        return mount->change_setting(get_mount_instance(), setting, value);
+    }
+    return false;
+}
+#endif
+
 #endif // AP_CAMERA_MOUNT_ENABLED

--- a/libraries/AP_Camera/AP_Camera_Mount.h
+++ b/libraries/AP_Camera/AP_Camera_Mount.h
@@ -69,6 +69,11 @@ public:
 
     // send camera capture status message to GCS
     void send_camera_capture_status(mavlink_channel_t chan) const override;
+
+#if AP_CAMERA_SCRIPTING_ENABLED
+    // change camera settings not normally used by autopilot
+    bool change_setting(CameraSetting setting, float value) override;
+#endif
 };
 
 #endif // AP_CAMERA_MOUNT_ENABLED

--- a/libraries/AP_Camera/AP_Camera_shareddefs.h
+++ b/libraries/AP_Camera/AP_Camera_shareddefs.h
@@ -36,3 +36,9 @@ enum class TrackingType : uint8_t {
     TRK_RECTANGLE = 2   // tracking a rectangle
 };
 
+// camera settings not normally used by the autopilot
+enum class CameraSetting {
+    THERMAL_PALETTE = 0,    // set thermal palette
+    THERMAL_GAIN = 1,       // set thermal gain, value of 0:low gain, 1:high gain
+    THERMAL_RAW_DATA = 2,   // enable/disable thermal raw data
+};

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -907,6 +907,17 @@ void AP_Mount::send_camera_capture_status(uint8_t instance, mavlink_channel_t ch
     backend->send_camera_capture_status(chan);
 }
 
+// change camera settings not normally used by autopilot
+// setting values from AP_Camera::Setting enum
+bool AP_Mount::change_setting(uint8_t instance, CameraSetting setting, float value)
+{
+    auto *backend = get_instance(instance);
+    if (backend == nullptr) {
+        return false;
+    }
+    return backend->change_setting(setting, value);
+}
+
 // get rangefinder distance.  Returns true on success
 bool AP_Mount::get_rangefinder_distance(uint8_t instance, float& distance_m) const
 {

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -271,6 +271,10 @@ public:
     // send camera capture status message to GCS
     void send_camera_capture_status(uint8_t instance, mavlink_channel_t chan) const;
 
+    // change camera settings not normally used by autopilot
+    // setting values from AP_Camera::Setting enum
+    bool change_setting(uint8_t instance, CameraSetting setting, float value);
+
     //
     // rangefinder
     //

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -198,6 +198,9 @@ public:
     // send camera capture status message to GCS
     virtual void send_camera_capture_status(mavlink_channel_t chan) const {}
 
+    // change camera settings not normally used by autopilot
+    virtual bool change_setting(CameraSetting setting, float value) { return false; }
+
 #if AP_MOUNT_POI_TO_LATLONALT_ENABLED
     // get poi information.  Returns true on success and fills in gimbal attitude, location and poi location
     bool get_poi(uint8_t instance, Quaternion &quat, Location &loc, Location &poi_loc);

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -1098,6 +1098,25 @@ void AP_Mount_Siyi::send_camera_settings(mavlink_channel_t chan) const
         NaN);               // focusLevel float, percentage from 0 to 100, NaN if unknown
 }
 
+// change camera settings not normally used by autopilot
+// THERMAL_PALETTE: 0:WhiteHot, 2:Sepia, 3:IronBow, 4:Rainbow, 5:Night, 6:Aurora, 7:RedHot, 8:Jungle, 9:Medical, 10:BlackHot, 11:GloryHot
+// THERMAL_GAIN: 0:Low gain (50C ~ 550C), 1:High gain (-20C ~ 150C)
+// THERMAL_RAW_DATA: 0:Disable Raw Data (30fps), 1:Enable Raw Data (25fps)
+bool AP_Mount_Siyi::change_setting(CameraSetting setting, float value)
+{
+    switch (setting) {
+    case CameraSetting::THERMAL_PALETTE:
+        return send_1byte_packet(SiyiCommandId::SET_THERMAL_PALETTE, (uint8_t)value);
+    case CameraSetting::THERMAL_GAIN:
+        return send_1byte_packet(SiyiCommandId::SET_THERMAL_GAIN, (uint8_t)value);
+    case CameraSetting::THERMAL_RAW_DATA:
+        return send_1byte_packet(SiyiCommandId::SET_THERMAL_RAW_DATA, (uint8_t)value);
+    }
+
+    // invalid setting so return false
+    return false;
+}
+
 // get model name string. returns "Unknown" if hardware model is not yet known
 const char* AP_Mount_Siyi::get_model_name() const
 {

--- a/libraries/AP_Mount/AP_Mount_Siyi.h
+++ b/libraries/AP_Mount/AP_Mount_Siyi.h
@@ -82,6 +82,12 @@ public:
     // send camera settings message to GCS
     void send_camera_settings(mavlink_channel_t chan) const override;
 
+    // change camera settings not normally used by autopilot
+    // THERMAL_PALETTE: 0:WhiteHot, 2:Sepia, 3:IronBow, 4:Rainbow, 5:Night, 6:Aurora, 7:RedHot, 8:Jungle, 9:Medical, 10:BlackHot, 11:GloryHot
+    // THERMAL_GAIN: 0:Low gain (50C ~ 550C), 1:High gain (-20C ~ 150C)
+    // THERMAL_RAW_DATA: 0:Disable Raw Data (30fps), 1:Enable Raw Data (25fps)
+    bool change_setting(CameraSetting setting, float value) override;
+
     //
     // rangefinder
     //
@@ -118,8 +124,11 @@ private:
         ABSOLUTE_ZOOM = 0x0F,
         SET_CAMERA_IMAGE_TYPE = 0x11,
         READ_RANGEFINDER = 0x15,
+        SET_THERMAL_PALETTE = 0x1B,
         EXTERNAL_ATTITUDE = 0x22,
         SET_TIME = 0x30,
+        SET_THERMAL_RAW_DATA = 0x34,
+        SET_THERMAL_GAIN = 0x38,
         POSITION_DATA = 0x3e,
     };
 

--- a/libraries/AP_Scripting/applets/camera-change-setting.lua
+++ b/libraries/AP_Scripting/applets/camera-change-setting.lua
@@ -1,0 +1,94 @@
+--[[
+script to allow users to more easily change camera settings
+--]]
+
+local PARAM_TABLE_KEY = 85
+local PARAM_TABLE_PREFIX = "CAM1_"
+
+local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
+local CAMERA_SETTINGS = {THERMAL_PALETTE=0, THERMAL_GAIN=1, THERMAL_RAW_DATA=2}  -- see AP_Camera_shareddefs.h
+
+-- add a parameter and bind it to a variable
+function bind_add_param(name, idx, default_value)
+   assert(param:add_param(PARAM_TABLE_KEY, idx, name, default_value), string.format('could not add param %s', name))
+   return Parameter(PARAM_TABLE_PREFIX .. name)
+end
+
+-- setup script specific parameters
+assert(param:add_table(PARAM_TABLE_KEY, PARAM_TABLE_PREFIX, 3), 'could not add param table')
+
+--[[
+  // @Param: CAM1_THERM_PAL
+  // @DisplayName: Camera1 Thermal Palette
+  // @Description: thermal image colour palette
+  // @Values: -1:Leave Unchanged, 0:WhiteHot, 2:Sepia, 3:IronBow, 4:Rainbow, 5:Night, 6:Aurora, 7:RedHot, 8:Jungle, 9:Medical, 10:BlackHot, 11:GloryHot
+  // @User: Standard
+--]]
+local CAM1_THERM_PAL = bind_add_param('THERM_PAL', 1, -1)
+
+--[[
+  // @Param: CAM1_THERM_GAIN
+  // @DisplayName: Camera1 Thermal Gain
+  // @Description: thermal image temperature range
+  // @Values: -1:Leave Unchanged, 0:LowGain (50C to 550C), 1:HighGain (-20C to 150C)
+  // @User: Standard
+--]]
+local CAM1_THERM_GAIN = bind_add_param('THERM_GAIN', 2, -1)
+
+--[[
+  // @Param: CAM1_THERM_RAW
+  // @DisplayName: Camera1 Thermal Raw Data
+  // @Description: save images with raw temperatures
+  // @Values: -1:Leave Unchanged, 0:Disabled (30fps), 1:Enabled (25 fps)
+  // @Units: m
+  // @User: Standard
+--]]
+local CAM1_THERM_RAW = bind_add_param('THERM_RAW', 3, -1)
+
+-- local variables
+local update_rate_ms = 3000            -- update every 3 seconds
+local CAM1_THERM_PAL_saved_value = -1  -- true if thermal palette has been saved
+local CAM1_THERM_GAIN_saved_value = -1 -- true if thermal gain has been saved
+local CAM1_THERM_RAW_saved_value = -1  -- true if thermal raw data has been saved
+
+--[[
+   main update function, called at 1Hz
+--]]
+function update()
+   
+   -- check if we should update any settings
+   if CAM1_THERM_PAL:get() >= 0 and CAM1_THERM_PAL:get() ~= CAM1_THERM_PAL_saved_value then
+      if camera:change_setting(0, CAMERA_SETTINGS.THERMAL_PALETTE, CAM1_THERM_PAL:get()) then
+         gcs:send_text(MAV_SEVERITY.INFO, string.format("Camera1 Thermal Palette to %d", CAM1_THERM_PAL:get()))
+         CAM1_THERM_PAL_saved_value = CAM1_THERM_PAL:get()
+      else
+         gcs:send_text(MAV_SEVERITY.ERROR, string.format("Failed to set Camera1 Thermal Palette to %d", CAM1_THERM_PAL:get()))
+      end
+   end
+
+   if CAM1_THERM_GAIN:get() >= 0 and CAM1_THERM_GAIN:get() ~= CAM1_THERM_GAIN_saved_value then
+      if camera:change_setting(0, CAMERA_SETTINGS.THERMAL_GAIN, CAM1_THERM_GAIN:get()) then
+         gcs:send_text(MAV_SEVERITY.INFO, string.format("Camera1 Thermal Gain to %d", CAM1_THERM_GAIN:get()))
+         CAM1_THERM_GAIN_saved_value = CAM1_THERM_GAIN:get()
+      else
+         gcs:send_text(MAV_SEVERITY.ERROR, string.format("Failed to set Camera1 Thermal Gain to %d", CAM1_THERM_GAIN:get()))
+      end
+   end
+
+   if CAM1_THERM_RAW:get() >= 0 and CAM1_THERM_RAW:get() ~= CAM1_THERM_RAW_saved_value then
+      if camera:change_setting(0, CAMERA_SETTINGS.THERMAL_RAW_DATA, CAM1_THERM_RAW:get()) then
+         gcs:send_text(MAV_SEVERITY.INFO, string.format("Camera1 Thermal Raw Data to %d", CAM1_THERM_RAW:get()))
+         CAM1_THERM_RAW_saved_value = CAM1_THERM_RAW:get()
+      else
+         gcs:send_text(MAV_SEVERITY.ERROR, string.format("Failed to set Camera1 Thermal Raw Data to %d", CAM1_THERM_RAW:get()))
+      end
+   end
+
+   return update, update_rate_ms
+end
+
+-- print welcome message
+gcs:send_text(MAV_SEVERITY.INFO, "Loaded camera-change-settings.lua")
+
+-- start running update loop
+return update, update_rate_ms

--- a/libraries/AP_Scripting/applets/camera-change-settings.md
+++ b/libraries/AP_Scripting/applets/camera-change-settings.md
@@ -1,0 +1,47 @@
+# Camera Change Settings
+
+Allows changing some camera settings that are not normallly used by the autopilot
+
+# Parameters
+
+## CAM1_THERM_PAL
+
+Set the camera's thermal palette
+
+Supported values are
+-1: leave unchanged
+0: WhiteHot
+2: Sepia
+3: IronBow
+4: Rainbow
+5: Night
+6: Aurora
+7: RedHot
+8: Jungle
+9: Medical
+10: BlackHot
+11: GloryHot
+
+## CAM1_THERM_GAIN
+
+Set the camera's thermal gain
+
+Supported values are
+-1: leave unchanged
+0: LowGain (50C to 550C)
+1: HighGain (-20C to 150C)
+
+## CAM1_THERM_RAW
+
+Enable/Disable the saving of raw thermal images.  Enabling raw iamges slightly slows the live video feed
+
+Supported values are
+-1: leave unchanged
+0: Disabled (30fps)
+1: Enabled (25 fps)
+
+# Operation
+
+Install the lua script in the APM/SCRIPTS directory on the flight
+controllers microSD card. Review the above parameter descriptions and
+decide on the right parameter values for your vehicle and operations.

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1409,6 +1409,16 @@ function AP_Camera__camera_state_t_ud:take_pic_incr() end
 ---@return AP_Camera__camera_state_t_ud|nil
 function camera:get_state(instance) end
 
+-- Change a camera setting to a given value
+---@param instance integer
+---@param setting integer
+---| '0' # THERMAL_PALETTE
+---| '1' # THERMAL_GAIN
+---| '2' # THERMAL_RAW_DATA
+---@param value number
+---@return boolean
+function camera:change_setting(instance, setting, value) end
+
 -- desc
 mount = {}
 

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -789,6 +789,7 @@ userdata AP_Camera::camera_state_t field tracking_type uint8_t'skip_check read
 userdata AP_Camera::camera_state_t field tracking_p1 Vector2f read
 userdata AP_Camera::camera_state_t field tracking_p2 Vector2f read
 singleton AP_Camera method get_state boolean uint8_t'skip_check AP_Camera::camera_state_t'Null
+singleton AP_Camera method change_setting boolean uint8_t'skip_check CameraSetting'enum CameraSetting::THERMAL_PALETTE CameraSetting::THERMAL_RAW_DATA float'skip_check
 
 include AP_Winch/AP_Winch.h
 singleton AP_Winch depends AP_WINCH_ENABLED && APM_BUILD_COPTER_OR_HELI


### PR DESCRIPTION
This adds a new general purpose "change_settings" method to AP_Camera (and AP_Mount) which allows us to add support for various camera settings without creating methods for each.  The vast majority of camera settings are simply a number.

The new method is used to implement three commonly used settings for the Siyi ZT6 and ZT30 thermal cameras:

- Thermal Palette (e.g. WhiteHot, BlackHot, Rainbow, etc)
- Thermal Gain (aka temperature range)
- Thermal Raw Data (stores raw temp data along with thermal images when a picture is taken)

A new change_camera_settings.lua script is also added which creates user visible parameters for these settings.

This has been tested on real hardware and below is a picture of a test where I changed the thermal palette on a ZT6 between "4" (Rainbow) and "10" (BlackHot)

![image](https://github.com/user-attachments/assets/2ae3e645-1cfd-4f74-ac7d-c2c4d4508d14)
![image](https://github.com/user-attachments/assets/5fa8ef18-e6d2-45d9-92f0-386ddee4de97)
![image](https://github.com/user-attachments/assets/e063f568-d491-417f-a57d-074faa4b2fa8)

We should eventually implement the change for the ViewPro and Topotek drivers as well which also support these features.  Topotek in particular has specifically mentioned they would like the ability to easily change the Palette.
