### PR TITLE
Copter: avoid nullptr deref in config_error_loop

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -2330,7 +2330,7 @@ bool ModeAuto::resume()
 
 bool ModeAuto::paused() const
 {
-    return wp_nav->paused();
+    return (wp_nav != nullptr) && wp_nav->paused();
 }
 
 #endif


### PR DESCRIPTION
we may neter the config_error_loop before we cann Copter's methods which allocate the wpnav object.

We send mavlink messages in the config error loop, one of which calls this method - so we end up with a nullptr dereference.

We might be able to find a way to stop sending this message in the config error loop, but that's likely to take some time to do....