### PR TITLE
AP_RangeFinder: RDS02UF: avoid nuking partial messages after good parse

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_RDS02UF.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_RDS02UF.cpp
@@ -97,8 +97,9 @@ bool AP_RangeFinder_RDS02UF::get_reading(float &distance_m)
         }
     }
 
-    // reset buffer
-    body_length = 0;
+    // consume this message:
+    move_header_in_buffer(ARRAY_SIZE(u.parse_buffer));
+
     return true;
 }
 


### PR DESCRIPTION
there may be a fragment of another packet in the buffer