### PR TITLE
AP_RangeFinder: number enum entries

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.h
@@ -194,11 +194,11 @@ public:
     };
 
     enum class Status {
-        NotConnected = 0,
-        NoData,
-        OutOfRangeLow,
-        OutOfRangeHigh,
-        Good
+        NotConnected   = 0,
+        NoData         = 1,
+        OutOfRangeLow  = 2,
+        OutOfRangeHigh = 3,
+        Good           = 4,
     };
 
     static constexpr int8_t SIGNAL_QUALITY_MIN = 0;


### PR DESCRIPTION
we log these so they should be numbered