### PR TITLE
Plane: Allow wind relative dead reckoning when lift motors are assisting

### DIFF
--- a/ArduPlane/Plane.cpp
+++ b/ArduPlane/Plane.cpp
@@ -533,11 +533,6 @@ void Plane::update_fly_forward(void)
             ahrs.set_fly_forward(false);
             return;
         }
-
-        if (quadplane.in_assisted_flight()) {
-            ahrs.set_fly_forward(false);
-            return;
-        }
     }
 #endif
 


### PR DESCRIPTION
When lift motors are assisting the wing during forward flight, the airspeed and zero sideslip assumption are still sufficiently valid to keep navigating. Without this patch a VTOL operating in FW mode without GPS and reliant on air data for dead reckoning will stop navigating and lose its position estimate if the lift motors start assisting.


I'm extracting this from a larger piece of work.

This reasoning for this patch (abnove, as part of the patch comment) is in direct contravention of the reasoning in https://github.com/ArduPilot/ardupilot/pull/6153 , the patch which added this.
