### PR TITLE
Correct Jamming simulator use of accuracies

### DIFF
--- a/libraries/SITL/SIM_GPS.cpp
+++ b/libraries/SITL/SIM_GPS.cpp
@@ -356,6 +356,7 @@ void GPS::update()
 
     last_write_update_ms = now_ms;
 
+    d.num_sats = _sitl->gps_numsats[idx];
     d.latitude = latitude;
     d.longitude = longitude;
     d.yaw_deg = _sitl->state.yawDeg;
@@ -370,7 +371,13 @@ void GPS::update()
     d.speedN = speedN + (velErrorNED.x * rand_float());
     d.speedE = speedE + (velErrorNED.y * rand_float());
     d.speedD = speedD + (velErrorNED.z * rand_float());
+
     d.have_lock = have_lock;
+
+    // fill in accuracies
+    d.horizontal_acc = _sitl->gps_accuracy[idx];
+    d.vertical_acc = _sitl->gps_accuracy[idx];
+    d.speed_acc = _sitl->gps_vel_err[instance].get().xy().length();
 
     if (_sitl->gps_drift_alt[idx] > 0) {
         // add slow altitude drift controlled by a slow sine wave

--- a/libraries/SITL/SIM_GPS_MSP.cpp
+++ b/libraries/SITL/SIM_GPS_MSP.cpp
@@ -63,9 +63,9 @@ void GPS_MSP::publish(const GPS_Data *d)
     msp_gps.gps_week = t.week;
     msp_gps.ms_tow = t.ms;
     msp_gps.fix_type = d->have_lock?3:0;
-    msp_gps.satellites_in_view = d->have_lock ? _sitl->gps_numsats[instance] : 3;
-    msp_gps.horizontal_pos_accuracy = _sitl->gps_accuracy[instance]*100;
-    msp_gps.vertical_pos_accuracy = _sitl->gps_accuracy[instance]*100;
+    msp_gps.satellites_in_view = d->have_lock ? d->num_sats : 3;
+    msp_gps.horizontal_pos_accuracy = d->horizontal_acc*100;
+    msp_gps.vertical_pos_accuracy = d->vertical_acc*100;
     msp_gps.horizontal_vel_accuracy = 30;
     msp_gps.hdop = 100;
     msp_gps.longitude = d->longitude * 1.0e7;

--- a/libraries/SITL/SIM_GPS_NMEA.cpp
+++ b/libraries/SITL/SIM_GPS_NMEA.cpp
@@ -74,7 +74,7 @@ void GPS_NMEA::publish(const GPS_Data *d)
                      lat_string,
                      lng_string,
                      d->have_lock?1:0,
-                     d->have_lock?_sitl->gps_numsats[instance]:3,
+                     d->have_lock?d->num_sats:3,
                      1.2,
                      d->altitude);
 
@@ -118,8 +118,8 @@ void GPS_NMEA::publish(const GPS_Data *d)
                     d->roll_deg,
                     d->have_lock?1:0, // 2=rtkfloat 3=rtkfixed,
                     3, // fixed rtk yaw solution,
-                    d->have_lock?_sitl->gps_numsats[instance]:3,
-                    d->have_lock?_sitl->gps_numsats[instance]:3,
+                    d->have_lock?d->num_sats:3,
+                    d->have_lock?d->num_sats:3,
                     d->speedE * 3.6,
                     d->speedN * 3.6,
                     -d->speedD * 3.6);

--- a/libraries/SITL/SIM_GPS_NOVA.cpp
+++ b/libraries/SITL/SIM_GPS_NOVA.cpp
@@ -129,7 +129,7 @@ void GPS_NOVA::publish(const GPS_Data *d)
     bestpos.lat = d->latitude;
     bestpos.lng = d->longitude;
     bestpos.hgt = d->altitude;
-    bestpos.svsused = d->have_lock ? _sitl->gps_numsats[instance] : 3;
+    bestpos.svsused = d->have_lock ? d->num_sats : 3;
     bestpos.latsdev=0.2;
     bestpos.lngsdev=0.2;
     bestpos.hgtsdev=0.2;

--- a/libraries/SITL/SIM_GPS_SBF.cpp
+++ b/libraries/SITL/SIM_GPS_SBF.cpp
@@ -134,7 +134,7 @@ void GPS_SBF::publish_PVTGeodetic(const GPS_Data *d)
     pvtGeod_buf.rxclkdrift = DNU_FLOAT;
     pvtGeod_buf.timesystem = DNU_UINT8; 
     pvtGeod_buf.datum = DNU_UINT8; 
-    pvtGeod_buf.nrsv = _sitl->gps_numsats[instance];
+    pvtGeod_buf.nrsv = d->num_sats;
     pvtGeod_buf.wacorrinfo = 0; //default value
     pvtGeod_buf.referenceid = DNU_UINT16; 
     pvtGeod_buf.meancorrage = DNU_UINT16; 

--- a/libraries/SITL/SIM_GPS_SBP.cpp
+++ b/libraries/SITL/SIM_GPS_SBP.cpp
@@ -77,9 +77,9 @@ void GPS_SBP::publish(const GPS_Data *d)
     pos.lon = d->longitude;
     pos.lat= d->latitude;
     pos.height = d->altitude;
-    pos.h_accuracy = _sitl->gps_accuracy[instance]*1000;
-    pos.v_accuracy = _sitl->gps_accuracy[instance]*1000;
-    pos.n_sats = d->have_lock ? _sitl->gps_numsats[instance] : 3;
+    pos.h_accuracy = d->horizontal_acc*1000;
+    pos.v_accuracy = d->vertical_acc*1000;
+    pos.n_sats = d->have_lock ? d->num_sats : 3;
 
     // Send single point position solution
     pos.flags = 0;
@@ -94,7 +94,7 @@ void GPS_SBP::publish(const GPS_Data *d)
     velned.d = 1e3 * d->speedD;
     velned.h_accuracy = 5e3;
     velned.v_accuracy = 5e3;
-    velned.n_sats = d->have_lock ? _sitl->gps_numsats[instance] : 3;
+    velned.n_sats = d->have_lock ? d->num_sats : 3;
     velned.flags = 0;
     sbp_send_message(SBP_VEL_NED_MSGTYPE, 0x2222, sizeof(velned), (uint8_t*)&velned);
 

--- a/libraries/SITL/SIM_GPS_SBP2.cpp
+++ b/libraries/SITL/SIM_GPS_SBP2.cpp
@@ -77,9 +77,9 @@ void GPS_SBP2::publish(const GPS_Data *d)
     pos.lon = d->longitude;
     pos.lat= d->latitude;
     pos.height = d->altitude;
-    pos.h_accuracy = _sitl->gps_accuracy[instance]*1000;
-    pos.v_accuracy = _sitl->gps_accuracy[instance]*1000;
-    pos.n_sats = d->have_lock ? _sitl->gps_numsats[instance] : 3;
+    pos.h_accuracy = d->horizontal_acc*1000;
+    pos.v_accuracy = d->vertical_acc*1000;
+    pos.n_sats = d->have_lock ? d->num_sats : 3;
 
     // Send single point position solution
     pos.flags = 1;
@@ -94,7 +94,7 @@ void GPS_SBP2::publish(const GPS_Data *d)
     velned.d = 1e3 * d->speedD;
     velned.h_accuracy = 1e3 * 0.5;
     velned.v_accuracy = 1e3 * 0.5;
-    velned.n_sats = d->have_lock ? _sitl->gps_numsats[instance] : 3;
+    velned.n_sats = d->have_lock ? d->num_sats : 3;
     velned.flags = 1;
     sbp_send_message(SBP_VEL_NED_MSGTYPE, 0x2222, sizeof(velned), (uint8_t*)&velned);
 

--- a/libraries/SITL/SIM_GPS_Trimble.cpp
+++ b/libraries/SITL/SIM_GPS_Trimble.cpp
@@ -93,7 +93,7 @@ void GPS_Trimble::publish(const GPS_Data *d)
                 GSOF_POS_TIME_LEN,
                 htobe32(gps_tow.ms),
                 htobe16(gps_tow.week),
-                d->have_lock ? _sitl->gps_numsats[instance] : uint8_t(3),
+                d->have_lock ? d->num_sats : uint8_t(3),
                 pos_flags_1,
                 pos_flags_2,
                 bootcount


### PR DESCRIPTION
Replaces https://github.com/ArduPilot/ardupilot/pull/23173/files , which got forgotten and https://github.com/ArduPilot/ardupilot/pull/23173 was merged instead.

The merged PR didn't change the backends to use the information out of the supplied simulated GPS state object, so while position might move around due to jamming the accuracies did not.

Add a test that everything goes wonky.
