### PR TITLE
Filter: LowPassFilter: use `calc_lowpass_alpha_dt` helper

### DIFF
--- a/libraries/Filter/LowPassFilter.cpp
+++ b/libraries/Filter/LowPassFilter.cpp
@@ -117,20 +117,7 @@ float LowPassFilter<T>::get_cutoff_freq() const {
 // add a new raw value to the filter, retrieve the filtered result
 template <class T>
 T LowPassFilter<T>::apply(const T &sample, const float &dt) {
-    if (is_negative(cutoff_freq) || is_negative(dt)) {
-        INTERNAL_ERROR(AP_InternalError::error_t::invalid_arg_or_result);
-        this->reset(sample);
-        return this->get();
-    }
-    if (is_zero(cutoff_freq)) {
-        this->reset(sample);
-        return this->get();
-    }
-    if (is_zero(dt)) {
-        return this->get();
-    }
-    const float rc = 1.0f/(M_2PI*cutoff_freq);
-    const float alpha = constrain_float(dt/(dt+rc), 0.0f, 1.0f);
+    const float alpha = calc_lowpass_alpha_dt(dt, cutoff_freq);
     return this->_apply(sample, alpha);
 }
 


### PR DESCRIPTION
This swaps to using the helper function for the LowPassFilter method. The helper is already used for the constant dt filter. 

The helper is here:
https://github.com/ArduPilot/ardupilot/blob/a65cd27435c2839e27d85a20549311ad63602dbd/libraries/AP_Math/AP_Math.cpp#L399-L416

This does mean we don't early return in the `dt` or `cutoff_freq` our of range cases. The return value is the same, we just now get a alpha of either 1.0 or 0.0 and apply the filter update. 

This replaces https://github.com/ArduPilot/ardupilot/pull/27582