### PR TITLE
AP_Bootloader: ID reserve for HGLRCF405V4

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -321,6 +321,8 @@ AP_HW_MountainEagleH743              1444
 AP_HW_StellarF4                      1500
 AP_HW_GEPRCF745BTHD                  1501
 
+AP_HW_HGLRCF405V4                    1524
+
 AP_HW_MFT-SEMA100                    2000
 
 AP_HW_SakuraRC-H743                  2714


### PR DESCRIPTION
Request a new ID for the board , HGLRCF405V4