### PR TITLE
AP_Notify: Fix compilation error in GPIO_LED_1.cpp

### DIFF
--- a/libraries/AP_Notify/GPIO_LED_1.cpp
+++ b/libraries/AP_Notify/GPIO_LED_1.cpp
@@ -48,7 +48,7 @@ void GPIO_LED_1::update(void)
     if (AP_Notify::flags.initialising) {
         new_pattern = INITIALIZING;
     } else if (AP_Notify::flags.failsafe_radio || AP_Notify::flags.failsafe_gcs || AP_Notify::flags.failsafe_battery) {
-        new pattern = FAILSAFE;
+        new_pattern = FAILSAFE;
     } else if (AP_Notify::flags.armed) {
         new_pattern = ARMED;
     } else if (AP_Notify::flags.pre_arm_check) {


### PR DESCRIPTION
There was a space instead of an underscore.
I have no idea how this passed continuous integration.