### PR TITLE
Sub: reduce PILOT_SPEED_ minimums

### DIFF
--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -161,7 +161,7 @@ const AP_Param::Info Sub::var_info[] = {
     // @DisplayName: Pilot maximum vertical ascending speed
     // @Description: The maximum vertical ascending velocity the pilot may request in cm/s
     // @Units: cm/s
-    // @Range: 50 500
+    // @Range: 20 500
     // @Increment: 10
     // @User: Standard
     GSCALAR(pilot_speed_up,     "PILOT_SPEED_UP",   PILOT_VELZ_MAX),
@@ -170,7 +170,7 @@ const AP_Param::Info Sub::var_info[] = {
     // @DisplayName: Pilot maximum vertical descending speed
     // @Description: The maximum vertical descending velocity the pilot may request in cm/s
     // @Units: cm/s
-    // @Range: 50 500
+    // @Range: 20 500
     // @Increment: 10
     // @User: Standard
     GSCALAR(pilot_speed_dn,     "PILOT_SPEED_DN",   0),


### PR DESCRIPTION
We are running transects close to the seafloor (as low as 75 cm) and using timed cameras to capture high resolution stills. We have found it helpful to move fairly slowly while running SURFTRAK: 10 cm/s fwd, with 20 cm/s up/down.

This PR lowers the minimum for PILOT_SPEED_UP and PILOT_SPEED_DN from 50 cm/s to 20 cm/s. These values are used by SURFTRAK. The code doesn't enforce the minimums, but QGC does bark if you are outside of the range, which is confusing. This PR is a pre-req to updating QGC. (I am not sure what Cockpit does.)

We would also like to reduce the minimums for WPNAV_SPEED values. The WPNAV_SPEED minimums _are_ enforced. I'll do that in a separate PR.