### PR TITLE
AC_WPNav: reduce WPNAV_SPEED min to 10 cm/s

### DIFF
--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -5,7 +5,7 @@ extern const AP_HAL::HAL& hal;
 
 // maximum velocities and accelerations
 #define WPNAV_WP_SPEED                 1000.0f      // default horizontal speed between waypoints in cm/s
-#define WPNAV_WP_SPEED_MIN               20.0f      // minimum horizontal speed between waypoints in cm/s
+#define WPNAV_WP_SPEED_MIN               10.0f      // minimum horizontal speed between waypoints in cm/s
 #define WPNAV_WP_RADIUS                 200.0f      // default waypoint radius in cm
 #define WPNAV_WP_RADIUS_MIN               5.0f      // minimum waypoint radius in cm
 #define WPNAV_WP_SPEED_UP               250.0f      // default maximum climb velocity
@@ -19,7 +19,7 @@ const AP_Param::GroupInfo AC_WPNav::var_info[] = {
     // @DisplayName: Waypoint Horizontal Speed Target
     // @Description: Defines the speed in cm/s which the aircraft will attempt to maintain horizontally during a WP mission
     // @Units: cm/s
-    // @Range: 20 2000
+    // @Range: 10 2000
     // @Increment: 50
     // @User: Standard
     AP_GROUPINFO("SPEED",       0, AC_WPNav, _wp_speed_cms, WPNAV_WP_SPEED),


### PR DESCRIPTION
We are using ArduSub to run transects close to the seafloor (as low as 75 cm) while timed cameras capture high resolution stills. We get the best results when we move at 10 cm/s.

We are now starting to automate transects using GUIDED mode, but we've run into the lower speed limit of 20 cm/s. This limit seems arbitrary, so I'd like to reduce it to 10 cm/s.