### PR TITLE
Fix up includes to avoid nasty include loop

### DIFF
--- a/libraries/APM_Control/AP_AutoTune.cpp
+++ b/libraries/APM_Control/AP_AutoTune.cpp
@@ -28,6 +28,7 @@
 #include <AC_PID/AC_PID.h>
 #include <AP_Scheduler/AP_Scheduler.h>
 #include <GCS_MAVLink/GCS.h>
+#include <AP_InertialSensor/AP_InertialSensor.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_Camera/AP_Camera_Logging.cpp
+++ b/libraries/AP_Camera/AP_Camera_Logging.cpp
@@ -6,6 +6,7 @@
 
 #include <AP_Logger/AP_Logger.h>
 #include <AP_GPS/AP_GPS.h>
+#include <AP_AHRS/AP_AHRS.h>
 
 // Write a Camera packet.  Also writes a Mount packet if available
 void AP_Camera_Backend::Write_CameraInfo(enum LogMessages msg, uint64_t timestamp_us)

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Logging.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Logging.cpp
@@ -5,6 +5,7 @@
 #include "AP_InertialSensor.h"
 #include "AP_InertialSensor_Backend.h"
 
+#include <AP_AHRS/AP_AHRS.h>
 #include <AP_Logger/AP_Logger.h>
 
 // Write ACC data packet: raw accel data

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1,3 +1,5 @@
+#include "AP_NavEKF2.h"
+
 #include <AP_HAL/AP_HAL.h>
 
 #include "AP_NavEKF2_core.h"

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -1,13 +1,12 @@
-#include <AP_HAL/AP_HAL.h>
-
 #include "AP_NavEKF2_core.h"
+
+#include "AP_NavEKF2.h"
+
 #include <GCS_MAVLink/GCS.h>
 #include <AP_DAL/AP_DAL.h>
 #include <AP_InternalError/AP_InternalError.h>
 
 #if AP_RANGEFINDER_ENABLED
-
-extern const AP_HAL::HAL& hal;
 
 
 /********************************************************

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -1,9 +1,6 @@
-#include <AP_HAL/AP_HAL.h>
-
 #include "AP_NavEKF2_core.h"
 
-extern const AP_HAL::HAL& hal;
-
+#include "AP_NavEKF2.h"
 
 /* Monitor GPS data to see if quality is good enough to initialise the EKF
    Monitor magnetometer innovations to see if the heading is good enough to use GPS

--- a/libraries/AP_NavEKF2/LogStructure.h
+++ b/libraries/AP_NavEKF2/LogStructure.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <AP_Logger/LogStructure.h>
-#include <AP_AHRS/AP_AHRS.h>
+#include <AP_AHRS/AP_AHRS_config.h>
 
 #define LOG_IDS_FROM_NAVEKF2 \
     LOG_NKF0_MSG,  \

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1,3 +1,5 @@
+#include "AP_NavEKF3.h"
+
 #include <AP_HAL/AP_HAL.h>
 
 #include "AP_NavEKF3_core.h"

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -1,6 +1,7 @@
-#include <AP_HAL/AP_HAL.h>
-
 #include "AP_NavEKF3_core.h"
+
+#include "AP_NavEKF3.h"
+
 #include <GCS_MAVLink/GCS.h>
 #include <AP_Logger/AP_Logger.h>
 #include <AP_DAL/AP_DAL.h>

--- a/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
@@ -1,6 +1,7 @@
-#include <AP_HAL/AP_HAL.h>
-
 #include "AP_NavEKF3_core.h"
+
+#include "AP_NavEKF3.h"
+
 #include <AP_DAL/AP_DAL.h>
 
 /* Monitor GPS data to see if quality is good enough to initialise the EKF

--- a/libraries/AP_NavEKF3/LogStructure.h
+++ b/libraries/AP_NavEKF3/LogStructure.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <AP_Logger/LogStructure.h>
+#include <AP_AHRS/AP_AHRS_config.h>
 
 #define LOG_IDS_FROM_NAVEKF3 \
     LOG_XKF0_MSG, \


### PR DESCRIPTION
AP_NavEKF2's LogStructure was including AP_AHRS.h, which can cause some nasty loops.

Change it to use `AP_AHRS_config.h`, which is all that it needs.

Fix up places which only had AP_NavEKF{2,3}.h because they were getting it transitively from AP_NavEKF2/LogStructure.
