### PR TITLE
AP_NavEKF2: stop including AP_DAL.h in header

### DIFF
--- a/.github/workflows/test_chibios.yml
+++ b/.github/workflows/test_chibios.yml
@@ -156,6 +156,7 @@ jobs:
             build-options-defaults-test,
             signing,
             CubeOrange-PPP,
+            CubeOrange-EKF2,
             SOHW,
             Pixhawk6X-PPPGW,
             new-check,

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -327,6 +327,14 @@ for t in $CI_BUILD_TARGET; do
         continue
     fi
 
+    if [ "$t" == "CubeOrange-EKF2" ]; then
+        echo "Building CubeOrange with EKF2 enabled"
+        $waf configure --board CubeOrange --enable-ekf2
+        $waf clean
+        $waf copter
+        continue
+    fi
+
     if [ "$t" == "SOHW" ]; then
         echo "Building CubeOrange-SOHW"
         Tools/scripts/sitl-on-hardware/sitl-on-hw.py --board CubeOrange --vehicle copter --simclass MultiCopter

--- a/libraries/APM_Control/AP_AutoTune.cpp
+++ b/libraries/APM_Control/AP_AutoTune.cpp
@@ -28,6 +28,7 @@
 #include <AC_PID/AC_PID.h>
 #include <AP_Scheduler/AP_Scheduler.h>
 #include <GCS_MAVLink/GCS.h>
+#include <AP_InertialSensor/AP_InertialSensor.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_Camera/AP_Camera_Logging.cpp
+++ b/libraries/AP_Camera/AP_Camera_Logging.cpp
@@ -6,6 +6,7 @@
 
 #include <AP_Logger/AP_Logger.h>
 #include <AP_GPS/AP_GPS.h>
+#include <AP_AHRS/AP_AHRS.h>
 
 // Write a Camera packet.  Also writes a Mount packet if available
 void AP_Camera_Backend::Write_CameraInfo(enum LogMessages msg, uint64_t timestamp_us)

--- a/libraries/AP_DAL/examples/AP_DAL_Standalone/main.cpp
+++ b/libraries/AP_DAL/examples/AP_DAL_Standalone/main.cpp
@@ -4,6 +4,7 @@
 //
 
 #include <AP_DAL/AP_DAL.h>
+#include <AP_NavEKF2/AP_NavEKF2.h>
 #include <AP_NavEKF3/AP_NavEKF3.h>
 #include <AP_Logger/AP_Logger.h>
 

--- a/libraries/AP_HAL/examples/DSP_test/DSP_test.cpp
+++ b/libraries/AP_HAL/examples/DSP_test/DSP_test.cpp
@@ -4,6 +4,7 @@
 #include <GCS_MAVLink/GCS_Dummy.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_Logger/AP_Logger.h>
+#include <AP_InertialSensor/AP_InertialSensor.h>
 #include "GyroFrame.h"
 
 #if HAL_WITH_DSP

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Logging.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Logging.cpp
@@ -5,6 +5,7 @@
 #include "AP_InertialSensor.h"
 #include "AP_InertialSensor_Backend.h"
 
+#include <AP_AHRS/AP_AHRS.h>
 #include <AP_Logger/AP_Logger.h>
 
 // Write ACC data packet: raw accel data

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1,3 +1,5 @@
+#include "AP_NavEKF2.h"
+
 #include "AP_NavEKF2_core.h"
 
 #include <AP_DAL/AP_DAL.h>

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1,6 +1,7 @@
-#include <AP_HAL/AP_HAL.h>
-
 #include "AP_NavEKF2_core.h"
+
+#include <AP_DAL/AP_DAL.h>
+#include <AP_HAL/AP_HAL.h>
 #include <GCS_MAVLink/GCS.h>
 #include <AP_Logger/AP_Logger.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>

--- a/libraries/AP_NavEKF2/AP_NavEKF2_AirDataFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_AirDataFusion.cpp
@@ -1,9 +1,8 @@
-#include <AP_HAL/AP_HAL.h>
-
-#include "AP_NavEKF2.h"
 #include "AP_NavEKF2_core.h"
 
-extern const AP_HAL::HAL& hal;
+#include <AP_DAL/AP_DAL.h>
+
+#include "AP_NavEKF2.h"
 
 /********************************************************
 *                   RESET FUNCTIONS                     *

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -1,11 +1,9 @@
-#include <AP_HAL/AP_HAL.h>
+#include "AP_NavEKF2_core.h"
+
+#include <GCS_MAVLink/GCS.h>
+#include <AP_DAL/AP_DAL.h>
 
 #include "AP_NavEKF2.h"
-#include "AP_NavEKF2_core.h"
-#include <GCS_MAVLink/GCS.h>
-
-extern const AP_HAL::HAL& hal;
-
 
 // Control filter mode transitions
 void NavEKF2_core::controlFilterModes()

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -1,13 +1,12 @@
-#include <AP_HAL/AP_HAL.h>
-
 #include "AP_NavEKF2_core.h"
+
+#include "AP_NavEKF2.h"
+
 #include <GCS_MAVLink/GCS.h>
 #include <AP_DAL/AP_DAL.h>
 #include <AP_InternalError/AP_InternalError.h>
 
 #if AP_RANGEFINDER_ENABLED
-
-extern const AP_HAL::HAL& hal;
 
 
 /********************************************************

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -1,5 +1,7 @@
 #include "AP_NavEKF2_core.h"
 
+#include "AP_NavEKF2.h"
+
 #include <AP_DAL/AP_DAL.h>
 
 /* Monitor GPS data to see if quality is good enough to initialise the EKF

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -1,9 +1,6 @@
-#include <AP_HAL/AP_HAL.h>
-
 #include "AP_NavEKF2_core.h"
 
-extern const AP_HAL::HAL& hal;
-
+#include <AP_DAL/AP_DAL.h>
 
 /* Monitor GPS data to see if quality is good enough to initialise the EKF
    Monitor magnetometer innovations to see if the heading is good enough to use GPS

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -1,8 +1,10 @@
+#include "AP_NavEKF2_core.h"
+
 #include <AP_HAL/AP_HAL.h>
+#include <AP_DAL/AP_DAL.h>
+#include <GCS_MAVLink/GCS.h>
 
 #include "AP_NavEKF2.h"
-#include "AP_NavEKF2_core.h"
-#include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -29,7 +29,8 @@
 #include <AP_Math/vectorN.h>
 #include <AP_NavEKF/AP_NavEKF_core_common.h>
 #include <AP_NavEKF/EKF_Buffer.h>
-#include <AP_DAL/AP_DAL.h>
+#include <AP_RangeFinder/AP_RangeFinder.h>
+#include <AP_Beacon/AP_Beacon_config.h>
 
 #include "AP_NavEKF/EKFGSF_yaw.h"
 
@@ -341,7 +342,7 @@ public:
     
 private:
     EKFGSF_yaw *yawEstimator;
-    AP_DAL &dal;
+    class AP_DAL &dal;
 
     // Reference to the global EKF frontend for parameters
     class NavEKF2 *frontend;

--- a/libraries/AP_NavEKF2/LogStructure.h
+++ b/libraries/AP_NavEKF2/LogStructure.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <AP_Logger/LogStructure.h>
-#include <AP_AHRS/AP_AHRS.h>
+#include <AP_AHRS/AP_AHRS_config.h>
 
 #define LOG_IDS_FROM_NAVEKF2 \
     LOG_NKF0_MSG,  \

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1,3 +1,5 @@
+#include "AP_NavEKF3.h"
+
 #include <AP_HAL/AP_HAL.h>
 
 #include "AP_NavEKF3_core.h"

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -1,6 +1,7 @@
-#include <AP_HAL/AP_HAL.h>
-
 #include "AP_NavEKF3_core.h"
+
+#include "AP_NavEKF3.h"
+
 #include <GCS_MAVLink/GCS.h>
 #include <AP_Logger/AP_Logger.h>
 #include <AP_DAL/AP_DAL.h>

--- a/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
@@ -1,6 +1,7 @@
-#include <AP_HAL/AP_HAL.h>
-
 #include "AP_NavEKF3_core.h"
+
+#include "AP_NavEKF3.h"
+
 #include <AP_DAL/AP_DAL.h>
 
 /* Monitor GPS data to see if quality is good enough to initialise the EKF

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -128,7 +128,7 @@ class NavEKF3_core : public NavEKF_core_common
 {
 public:
     // Constructor
-    NavEKF3_core(class NavEKF3 *_frontend, AP_DAL &dal);
+    NavEKF3_core(class NavEKF3 *_frontend, class AP_DAL &dal);
 
     // setup this core backend
     bool setup_core(uint8_t _imu_index, uint8_t _core_index);

--- a/libraries/AP_NavEKF3/LogStructure.h
+++ b/libraries/AP_NavEKF3/LogStructure.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <AP_Logger/LogStructure.h>
+#include <AP_AHRS/AP_AHRS_config.h>
 
 #define LOG_IDS_FROM_NAVEKF3 \
     LOG_XKF0_MSG, \


### PR DESCRIPTION
it's not needed and will slow compilation down

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                                 
Durandal                            *      *           *       *                 *      *      *
Hitec-Airspeed           *                                                 
KakuteH7-bdshot                     *      *           *       *                 *      *      *
MatekF405                           *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *                  *       *                 *      *      *
f103-QiotekPeriph        *                                                 
f303-Universal           *                                                 
iomcu                                                                *     
revo-mini                           *      *           *       *                 *      *      *
skyviper-v2450                                         *                   
```
