### PR TITLE
Tidy AP_DAL memory allocation and freeing

### DIFF
--- a/libraries/AP_DAL/AP_DAL.cpp
+++ b/libraries/AP_DAL/AP_DAL.cpp
@@ -272,9 +272,13 @@ int AP_DAL::snprintf(char* str, size_t size, const char *format, ...) const
     return res;
 }
 
-void *AP_DAL::malloc_type(size_t size, Memory_Type mem_type) const
+void *AP_DAL::malloc_type(size_t size, MemoryType mem_type) const
 {
     return hal.util->malloc_type(size, AP_HAL::Util::Memory_Type(mem_type));
+}
+void AP_DAL::free_type(void *ptr, size_t size, MemoryType mem_type) const
+{
+    return hal.util->free_type(ptr, size, AP_HAL::Util::Memory_Type(mem_type));
 }
 
 // map core number for replay

--- a/libraries/AP_DAL/AP_DAL.h
+++ b/libraries/AP_DAL/AP_DAL.h
@@ -121,11 +121,12 @@ public:
     int snprintf(char* str, size_t size, const char *format, ...) const;
 
     // copied in AP_HAL/Util.h
-    enum Memory_Type {
-        MEM_DMA_SAFE,
-        MEM_FAST
+    enum class MemoryType : uint8_t {
+        DMA_SAFE = 0,
+        FAST     = 1,
     };
-    void *malloc_type(size_t size, enum Memory_Type mem_type) const;
+    void *malloc_type(size_t size, MemoryType mem_type) const;
+    void free_type(void *ptr, size_t size, MemoryType memtype) const;
 
     AP_DAL_InertialSensor &ins() { return _ins; }
     AP_DAL_Baro &baro() { return _baro; }

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -675,7 +675,7 @@ bool NavEKF2::InitialiseFilter(void)
         }
 
         // try to allocate from CCM RAM, fallback to Normal RAM if not available or full
-        core = (NavEKF2_core*)AP::dal().malloc_type(sizeof(NavEKF2_core)*num_cores, AP_DAL::MEM_FAST);
+        core = (NavEKF2_core*)AP::dal().malloc_type(sizeof(NavEKF2_core)*num_cores, AP_DAL::MemoryType::FAST);
         if (core == nullptr) {
             initFailure = InitFailures::NO_MEM;
             core_malloc_failed = true;
@@ -695,7 +695,7 @@ bool NavEKF2::InitialiseFilter(void)
             if (_imuMask & (1U<<i)) {
                 if(!core[num_cores].setup_core(i, num_cores)) {
                     // if any core setup fails, free memory, zero the core pointer and abort
-                    hal.util->free_type(core, sizeof(NavEKF2_core)*num_cores, AP_HAL::Util::MEM_FAST);
+                    AP::dal().free_type(core, sizeof(NavEKF2_core)*num_cores, AP_DAL::MemoryType::FAST);
                     core = nullptr;
                     initFailure = InitFailures::NO_SETUP;
                     GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "NavEKF2: core %d setup failed", num_cores);

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -816,7 +816,7 @@ bool NavEKF3::InitialiseFilter(void)
         }
 
         //try to allocate from CCM RAM, fallback to Normal RAM if not available or full
-        core = (NavEKF3_core*)dal.malloc_type(sizeof(NavEKF3_core)*num_cores, dal.MEM_FAST);
+        core = (NavEKF3_core*)dal.malloc_type(sizeof(NavEKF3_core)*num_cores, AP_DAL::MemoryType::FAST);
         if (core == nullptr) {
             _enable.set(0);
             num_cores = 0;


### PR DESCRIPTION
```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                                                     
Durandal                            -8     *           -16     -16               -16    -8     -8
Hitec-Airspeed           *                                                                     
KakuteH7-bdshot                     -16    *           -8      -8                -16    -16    -8
MatekF405                           -8     *           -16     -8                -16    -8     -8
Pixhawk1-1M-bdshot                  -8                 -8      -8                -8     -16    -8
f103-QiotekPeriph        *                                                                     
f303-Universal           *                                                                     
iomcu                                                                *                         
revo-mini                           -16    *           -16     -16               -16    -8     -16
skyviper-v2450                                         -8                                      
```

Be consistent in the way we use the enumeration (and which enumeration we use...)

Make sure we're symmetric for allocation/free calls by adding a free_type method to the DAL.
