### PR TITLE
Stop including AP_AHRS.h in header files

### DIFF
--- a/libraries/AP_ADSB/AP_ADSB_uAvionix_UCP.cpp
+++ b/libraries/AP_ADSB/AP_ADSB_uAvionix_UCP.cpp
@@ -32,6 +32,8 @@
 #include <ctype.h>
 #include <AP_Notify/AP_Notify.h>
 
+#include <AP_GPS/AP_GPS.h>
+
 extern const AP_HAL::HAL &hal;
 
 #define AP_ADSB_UAVIONIX_HEALTH_TIMEOUT_MS                     (5000UL)

--- a/libraries/AP_ADSB/AP_ADSB_uAvionix_UCP.h
+++ b/libraries/AP_ADSB/AP_ADSB_uAvionix_UCP.h
@@ -24,11 +24,6 @@
 
 #define AP_ADSB_UAVIONIX_UCP_CAPTURE_ALL_RX_PACKETS         1
 
-
-#include <AP_GPS/AP_GPS.h>
-#include <AP_Baro/AP_Baro.h>
-#include <AP_AHRS/AP_AHRS.h>
-
 #include "GDL90_protocol/GDL90_Message_Structs.h"
 #include "GDL90_protocol/hostGDL90Support.h"
 

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -13,6 +13,7 @@
 #include <AP_ExternalAHRS/AP_ExternalAHRS.h>
 #include <AP_CustomRotations/AP_CustomRotations.h>
 #include <GCS_MAVLink/GCS.h>
+#include <AP_AHRS/AP_AHRS.h>
 
 #include "AP_Compass_config.h"
 

--- a/libraries/AP_Compass/Compass_learn.h
+++ b/libraries/AP_Compass/Compass_learn.h
@@ -1,14 +1,12 @@
 #pragma once
 
-#include <AP_AHRS/AP_AHRS.h>
-
 /*
   compass learning using magnetic field tables from AP_Declination and GSF
  */
 
 class CompassLearn {
 public:
-    CompassLearn(Compass &compass);
+    CompassLearn(class Compass &compass);
 
     // called on each compass read
     void update(void);

--- a/libraries/AP_DDS/AP_DDS_Client.h
+++ b/libraries/AP_DDS/AP_DDS_Client.h
@@ -24,7 +24,6 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/Scheduler.h>
 #include <AP_HAL/Semaphores.h>
-#include <AP_AHRS/AP_AHRS.h>
 
 #include "fcntl.h"
 

--- a/libraries/AP_InertialNav/AP_InertialNav.cpp
+++ b/libraries/AP_InertialNav/AP_InertialNav.cpp
@@ -1,6 +1,6 @@
-#include <AP_HAL/AP_HAL.h>
-#include <AP_Baro/AP_Baro.h>
 #include "AP_InertialNav.h"
+
+#include <AP_AHRS/AP_AHRS.h>
 
 /*
   A wrapper around the AP_InertialNav class which uses the NavEKF

--- a/libraries/AP_InertialNav/AP_InertialNav.h
+++ b/libraries/AP_InertialNav/AP_InertialNav.h
@@ -5,14 +5,13 @@
  */
 #pragma once
 
-#include <AP_AHRS/AP_AHRS.h>
 #include <AP_NavEKF/AP_Nav_Common.h>              // definitions shared by inertial and ekf nav filters
 
 class AP_InertialNav
 {
 public:
     // Constructor
-    AP_InertialNav(AP_AHRS &ahrs) :
+    AP_InertialNav(class AP_AHRS &ahrs) :
         _ahrs_ekf(ahrs)
         {}
 

--- a/libraries/AP_L1_Control/AP_L1_Control.h
+++ b/libraries/AP_L1_Control/AP_L1_Control.h
@@ -14,7 +14,6 @@
  */
 
 #include <AP_Math/AP_Math.h>
-#include <AP_AHRS/AP_AHRS.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Navigation/AP_Navigation.h>
 #include <AP_TECS/AP_TECS.h>

--- a/libraries/AP_Module/AP_Module.cpp
+++ b/libraries/AP_Module/AP_Module.cpp
@@ -17,6 +17,8 @@
 
 #if AP_MODULE_SUPPORTED
 
+#include <AP_AHRS/AP_AHRS.h>
+
 /*
   support for external modules
  */

--- a/libraries/AP_Module/AP_Module.h
+++ b/libraries/AP_Module/AP_Module.h
@@ -29,7 +29,7 @@
 
 #if AP_MODULE_SUPPORTED
 
-#include <AP_AHRS/AP_AHRS.h>
+#include <AP_Math/vector3.h>
 
 #ifndef AP_MODULE_DEFAULT_DIRECTORY
 #define AP_MODULE_DEFAULT_DIRECTORY "/usr/lib/ardupilot/modules"
@@ -48,7 +48,7 @@ public:
     static void call_hook_setup_complete(void);
     
     // call any AHRS_update hooks
-    static void call_hook_AHRS_update(const AP_AHRS &ahrs);
+    static void call_hook_AHRS_update(const class AP_AHRS &ahrs);
 
     // call any gyro_sample hooks
     static void call_hook_gyro_sample(uint8_t instance, float dt, const Vector3f &gyro);

--- a/libraries/AP_Soaring/AP_Soaring.cpp
+++ b/libraries/AP_Soaring/AP_Soaring.cpp
@@ -2,6 +2,7 @@
 
 #if HAL_SOARING_ENABLED
 
+#include <AP_AHRS/AP_AHRS.h>
 #include <AP_Logger/AP_Logger.h>
 #include <AP_TECS/AP_TECS.h>
 #include <GCS_MAVLink/GCS.h>

--- a/libraries/AP_Soaring/Variometer.cpp
+++ b/libraries/AP_Soaring/Variometer.cpp
@@ -4,6 +4,7 @@ Manages the estimation of aircraft total energy, drag and vertical air velocity.
 */
 #include "Variometer.h"
 
+#include <AP_AHRS/AP_AHRS.h>
 #include <AP_Logger/AP_Logger.h>
 
 Variometer::Variometer(const AP_FixedWing &parms, const PolarParams &polarParams) :

--- a/libraries/AP_Soaring/Variometer.h
+++ b/libraries/AP_Soaring/Variometer.h
@@ -5,10 +5,11 @@ Manages the estimation of aircraft total energy, drag and vertical air velocity.
 */
 #pragma once
 
-#include <AP_AHRS/AP_AHRS.h>
 #include <AP_Param/AP_Param.h>
 #include <Filter/AverageFilter.h>
+#include <Filter/LowPassFilter.h>
 #include <AP_Vehicle/AP_FixedWing.h>
+#include <AP_Common/Location.h>
 
 class Variometer {
 


### PR DESCRIPTION
AP_TECS.h is the only library header which uses it after this - it needs to know the shape as it makes a method call on the singleton.
