### PR TITLE
ESP32: more accurately calculate loop rate

### DIFF
--- a/libraries/AP_HAL/board/esp32.h
+++ b/libraries/AP_HAL/board/esp32.h
@@ -116,3 +116,6 @@
 // other big things..
 #define HAL_QUADPLANE_ENABLED 0
 #define HAL_GYROFFT_ENABLED 0
+
+// remove once ESP32 isn't so chronically slow
+#define AP_SCHEDULER_OVERTIME_MARGIN_US 50000UL


### PR DESCRIPTION
Sadly it turns out the loop rate is so low in some situations that most/all samples were rejected as invalid and the loop rate converged very slowly or did not change. Increase the margin to be classified as such, and print out such excessively over loop times if the specific scheduling debug flag is enabled.