### PR TITLE
autotest: AutoContinueOnRCFailsafe extend auto leg to avoid race

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -11715,7 +11715,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             (mavutil.mavlink.MAV_CMD_NAV_TAKEOFF,   0, 0, 10),
             (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 20, 0, 10),
             (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 40, 0, 10),
-            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 60, 0, 10),
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 120, 0, 10),
         ])
 
         self.takeoff(mode='LOITER')


### PR DESCRIPTION
saw an instance where it made it to waypoint four before we registered the RC failsafe