### PR TITLE
Restart logging after transfer complete when LOG_DISARMED=1

### DIFF
--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -966,6 +966,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
             self.SET_POSITION_TARGET_GLOBAL_INT,
             self.TestLogDownloadMAVProxy,
             self.TestLogDownloadMAVProxyNetwork,
+            self.TestLogDownloadLogRestart,
             self.MAV_CMD_NAV_LOITER_UNLIM,
             self.MAV_CMD_NAV_LAND,
             self.MAV_CMD_MISSION_START,

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -591,6 +591,7 @@ private:
     void handle_log_request_data(class GCS_MAVLINK &, const mavlink_message_t &msg);
     void handle_log_request_erase(class GCS_MAVLINK &, const mavlink_message_t &msg);
     void handle_log_request_end(class GCS_MAVLINK &, const mavlink_message_t &msg);
+    void end_log_transfer();
     void handle_log_send_listing(); // handle LISTING state
     void handle_log_sending(); // handle SENDING state
     bool handle_log_send_data(); // send data chunk to client

--- a/libraries/AP_Logger/AP_Logger_Backend.h
+++ b/libraries/AP_Logger/AP_Logger_Backend.h
@@ -76,6 +76,7 @@ public:
     virtual void get_log_boundaries(uint16_t list_entry, uint32_t & start_page, uint32_t & end_page) = 0;
     virtual void get_log_info(uint16_t list_entry, uint32_t &size, uint32_t &time_utc) = 0;
     virtual int16_t get_log_data(uint16_t list_entry, uint16_t page, uint32_t offset, uint16_t len, uint8_t *data) = 0;
+    virtual void end_log_transfer() = 0;
     virtual uint16_t get_num_logs() = 0;
     virtual uint16_t find_oldest_log();
 

--- a/libraries/AP_Logger/AP_Logger_Block.h
+++ b/libraries/AP_Logger/AP_Logger_Block.h
@@ -24,6 +24,7 @@ public:
     void get_log_boundaries(uint16_t list_entry, uint32_t & start_page, uint32_t & end_page) override;
     void get_log_info(uint16_t list_entry, uint32_t &size, uint32_t &time_utc) override;
     int16_t get_log_data(uint16_t list_entry, uint16_t page, uint32_t offset, uint16_t len, uint8_t *data) override WARN_IF_UNUSED;
+    void end_log_transfer() override { }
     uint16_t get_num_logs() override;
     void start_new_log(void) override;
     uint32_t bufferspace_available() override;

--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -642,6 +642,14 @@ int16_t AP_Logger_File::get_log_data(const uint16_t list_entry, const uint16_t p
     return ret;
 }
 
+void AP_Logger_File::end_log_transfer()
+{
+    if (_read_fd != -1) {
+        AP::FS().close(_read_fd);
+        _read_fd = -1;
+    }
+}
+
 /*
   find size and date of a log
  */

--- a/libraries/AP_Logger/AP_Logger_File.h
+++ b/libraries/AP_Logger/AP_Logger_File.h
@@ -45,6 +45,7 @@ public:
     void get_log_boundaries(uint16_t log_num, uint32_t & start_page, uint32_t & end_page) override;
     void get_log_info(uint16_t log_num, uint32_t &size, uint32_t &time_utc) override;
     int16_t get_log_data(uint16_t log_num, uint16_t page, uint32_t offset, uint16_t len, uint8_t *data) override;
+    void end_log_transfer() override;
     uint16_t get_num_logs() override;
     void start_new_log(void) override;
     uint16_t find_oldest_log() override;

--- a/libraries/AP_Logger/AP_Logger_MAVLink.h
+++ b/libraries/AP_Logger/AP_Logger_MAVLink.h
@@ -50,6 +50,7 @@ public:
     void get_log_boundaries(uint16_t log_num, uint32_t & start_page, uint32_t & end_page) override {}
     void get_log_info(uint16_t log_num, uint32_t &size, uint32_t &time_utc) override {}
     int16_t get_log_data(uint16_t log_num, uint16_t page, uint32_t offset, uint16_t len, uint8_t *data) override { return 0; }
+    void end_log_transfer() override { };
     uint16_t get_num_logs(void) override { return 0; }
 
     void remote_log_block_status_msg(const GCS_MAVLINK &link, const mavlink_message_t& msg) override;

--- a/libraries/AP_Logger/AP_Logger_MAVLinkLogTransfer.cpp
+++ b/libraries/AP_Logger/AP_Logger_MAVLinkLogTransfer.cpp
@@ -128,7 +128,7 @@ void AP_Logger::handle_log_request_data(GCS_MAVLINK &link, const mavlink_message
         uint16_t num_logs = get_num_logs();
         if (packet.id > num_logs || packet.id < 1) {
             // request for an invalid log; cancel any current download
-            transfer_activity = TransferActivity::IDLE;
+            end_log_transfer();
             return;
         }
 
@@ -174,11 +174,16 @@ void AP_Logger::handle_log_request_erase(GCS_MAVLINK &link, const mavlink_messag
 void AP_Logger::handle_log_request_end(GCS_MAVLINK &link, const mavlink_message_t &msg)
 {
     WITH_SEMAPHORE(_log_send_sem);
-    mavlink_log_request_end_t packet;
-    mavlink_msg_log_request_end_decode(&msg, &packet);
+    // mavlink_log_request_end_t packet;
+    // mavlink_msg_log_request_end_decode(&msg, &packet);
+    end_log_transfer();
+}
 
+void AP_Logger::end_log_transfer()
+{
     transfer_activity = TransferActivity::IDLE;
     _log_sending_link = nullptr;
+    backends[0]->end_log_transfer();
 }
 
 /**
@@ -323,8 +328,7 @@ bool AP_Logger::handle_log_send_data()
     _log_data_offset += nbytes;
     _log_data_remaining -= nbytes;
     if (nbytes < MAVLINK_MSG_LOG_DATA_FIELD_DATA_LEN || _log_data_remaining == 0) {
-        transfer_activity = TransferActivity::IDLE;
-        _log_sending_link = nullptr;
+        end_log_transfer();
     }
     return true;
 }


### PR DESCRIPTION
_read_fd was never unset from -1 after the log transfer was complete.
