### PR TITLE
AP_Baro: remove unnecessary "#ifdef HAL_BUILD_AP_PERIPH"

### DIFF
--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -56,12 +56,8 @@ public:
 
     // healthy - returns true if sensor and derived altitude are good
     bool healthy(void) const { return healthy(_primary); }
-#ifdef HAL_BUILD_AP_PERIPH
-    // calibration and alt check not valid for AP_Periph
+
     bool healthy(uint8_t instance) const;
-#else
-    bool healthy(uint8_t instance) const;
-#endif
 
     // check if all baros are healthy - used for SYS_STATUS report
     bool all_healthy(void) const;


### PR DESCRIPTION
Since there are already two implementations of the "healthy" method in file "AP_Baro.cpp", and they are both with clear comments, I think that "#ifdef" thing should be removed from the header file :P