### PR TITLE
Rover: Circle mode enhancements

### DIFF
--- a/Rover/mode.h
+++ b/Rover/mode.h
@@ -499,6 +499,7 @@ protected:
     float angle_total_rad;  // total angle in radians that vehicle has circled
     bool reached_edge;      // true once vehicle has reached edge of circle
     float dist_to_edge_m;   // distance to edge of circle in meters (equivalent to crosstrack error)
+    bool tracking_back;     // true if the vehicle is trying to track back onto the circle
 };
 
 class ModeGuided : public Mode


### PR DESCRIPTION
Two fixes for circle mode in Rover:
- Correct reporting of target position and distance/bearing to target
- Stop circling (stop the vehicle) if it's unable to properly track the circle. This is usually due to the vehicle not being able to turn fast enough for a given speed/radius circle.