### PR TITLE
AP_Common: fixed cygwin for non-SITL builds

### DIFF
--- a/libraries/AP_Common/c++.cpp
+++ b/libraries/AP_Common/c++.cpp
@@ -84,7 +84,7 @@ void operator delete[](void * ptr)
     if (ptr) free(ptr);
 }
 
-#ifdef CYGWIN_BUILD
+#if defined(CYGWIN_BUILD) && CONFIG_HAL_BOARD == HAL_BOARD_SITL
 /*
   wrapper around malloc to ensure all memory is initialised as zero
   cygwin needs to wrap _malloc_r


### PR DESCRIPTION
@olliw42 this may fix the issue in #27867