### PR TITLE
hwdef: GEPRCF745BTHD: rely on custom builds for non-BMP280 baros

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/GEPRCF745BTHD/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/GEPRCF745BTHD/hwdef.dat
@@ -170,5 +170,13 @@ ROMFS_WILDCARD libraries/AP_OSD/fonts/font0.bin
 # save some flash
 include ../include/minimize_fpv_osd.inc
 
+
+#only enable BMP280 Baro
+define AP_BARO_BACKEND_DEFAULT_ENABLED 0
+undef define AP_BARO_BMP280_ENABLED
+define AP_BARO_BMP280_ENABLED 1
+define AP_BARO_MS56XX_ENABLED 1
+
+# need to probe external baros even 'though we're minimised to allow custom build options:
 undef AP_BARO_PROBE_EXTERNAL_I2C_BUSES
 define AP_BARO_PROBE_EXTERNAL_I2C_BUSES 1


### PR DESCRIPTION
this is overflowing - it has an onboard baro, that will have to do..

@andyp1per @Hwurzburg @YI-BOYANG this board did not compile for ArduPlane when support was merged in https://github.com/ArduPilot/ardupilot/pull/27491

