### PR TITLE
hwdef: remove SMBus battery support from all minimize-fpv boards

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteF7/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteF7/hwdef.dat
@@ -149,11 +149,6 @@ define AP_BARO_BACKEND_DEFAULT_ENABLED 0
 undef define AP_BARO_BMP280_ENABLED
 define AP_BARO_BMP280_ENABLED 1
 
-# disable SMBUS battery monitors to save flash
-undef AP_BATTERY_SMBUS_ENABLED
-define AP_BATTERY_SMBUS_ENABLED 0
-
-
 # setup for OSD
 define HAL_OSD_TYPE_DEFAULT 1
 ROMFS_WILDCARD libraries/AP_OSD/fonts/font*.bin

--- a/libraries/AP_HAL_ChibiOS/hwdef/OMNIBUSF7V2/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/OMNIBUSF7V2/hwdef.dat
@@ -132,10 +132,6 @@ include ../include/minimize_fpv_osd.inc
 #not useable for quadplane
 define HAL_QUADPLANE_ENABLED 0
 
-# disable SMBUS monitors to save flash
-undef AP_BATTERY_SMBUS_ENABLED
-define AP_BATTERY_SMBUS_ENABLED 0
-
 # one baro
 BARO BMP280 SPI:bmp280
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/include/minimize_fpv_osd.inc
+++ b/libraries/AP_HAL_ChibiOS/hwdef/include/minimize_fpv_osd.inc
@@ -28,3 +28,7 @@ define AP_TRAMP_ENABLED AP_VIDEOTX_ENABLED && OSD_ENABLED
 
 # force CRSF Telem text support even in face of normal 1MB limit:
 define HAL_CRSF_TELEM_TEXT_SELECTION_ENABLED OSD_ENABLED && OSD_PARAM_ENABLED && HAL_CRSF_TELEM_ENABLED
+
+# disable SMBUS battery monitors to save flash
+undef AP_BATTERY_SMBUS_ENABLED
+define AP_BATTERY_SMBUS_ENABLED 0


### PR DESCRIPTION
I doubt there's a single one of these boards on the planet using stock firmware and smbus batteries.  If they exist, the custom build server can re-add this