### PR TITLE
Tools: size_compare_branches.py: blacklist build of Pixhack-V3 bootlo…

### DIFF
--- a/Tools/scripts/size_compare_branches.py
+++ b/Tools/scripts/size_compare_branches.py
@@ -166,6 +166,7 @@ class SizeCompareBranches(object):
             'SITL_arm_linux_gnueabihf',
             'RADIX2HD',
             'canzero',
+            'CUAV-Pixhack-v3',  # uses USE_BOOTLOADER_FROM_BOARD
         ])
 
         # blacklist all linux boards for bootloader build:


### PR DESCRIPTION
…ader

we don't have a hwdef-bl.dat for this board as it uses a bootloader from elsewhere.

This should be done on the hwdef content, but that's still coming...