### PR TITLE
AP_Mission: stop populating command with -1 on failure

### DIFF
--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -699,17 +699,14 @@ bool AP_Mission::set_item(uint16_t index, mavlink_mission_item_int_t& src_packet
     return AP_Mission::replace_cmd(index, cmd);
 }
 
+// the contents of ret_packet are undefined when this method returns false
 bool AP_Mission::get_item(uint16_t index, mavlink_mission_item_int_t& ret_packet) const
 {
-    // setting ret_packet.command = -1  and/or returning false
-    //  means it contains invalid data after it leaves here.
-
     // this is the on-storage format
     AP_Mission::Mission_Command cmd {};
 
     // can't handle request for anything bigger than the mission size...
     if (index >= num_commands()) {
-        ret_packet.command = -1;
         return false;
     }
 
@@ -722,12 +719,10 @@ bool AP_Mission::get_item(uint16_t index, mavlink_mission_item_int_t& ret_packet
 
     // retrieve mission from eeprom
     if (!read_cmd_from_storage(ret_packet.seq, cmd)) {
-        ret_packet.command = -1;
         return false;
     }
     // convert into mavlink-ish format for lua and friends.
     if (!mission_cmd_to_mavlink_int(cmd, ret_packet)) {
-        ret_packet.command = -1;
         return false;
     }
 

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -752,6 +752,7 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
     // allow lua to get/set any WP items in any order in a mavlink-ish kinda way.
+    // the contents of ret_packet are undefined when get_item returns false
     bool get_item(uint16_t index, mavlink_mission_item_int_t& result) const ;
     bool set_item(uint16_t index, mavlink_mission_item_int_t& source) ;
 


### PR DESCRIPTION
Just indicate in the comments that the contents are undefined after this call.

Nothing appears to be relying on this.  The method's nullable, so i don't think scripting cares, and the mavlink ftp transfer stuff doesn't look.
