### PR TITLE
Tools: param_metadata: do not emit Legacy fields to rst/Wiki

### DIFF
--- a/Tools/autotest/param_metadata/ednemit.py
+++ b/Tools/autotest/param_metadata/ednemit.py
@@ -49,6 +49,9 @@ class EDNEmit(Emit):
             # remove any keys we don't really care to share
             for key in self.remove_keys:
                 output_dict.pop(key, None)
+            for key in list(output_dict.keys()):
+                if not self.should_emit_field(param, key):
+                    output_dict.pop(key, None)
 
             # rearrange bitmasks to be a vector with nil's if the bit doesn't have meaning
             if "bitmask" in output_dict:

--- a/Tools/autotest/param_metadata/emit.py
+++ b/Tools/autotest/param_metadata/emit.py
@@ -19,3 +19,6 @@ class Emit:
 
     def emit(self, g):
         pass
+
+    def should_emit_field(self, param, field):
+        return field not in ['Legacy']

--- a/Tools/autotest/param_metadata/htmlemit.py
+++ b/Tools/autotest/param_metadata/htmlemit.py
@@ -65,6 +65,8 @@ DO NOT EDIT
             t += "<ul>\n"
 
             for field in param.__dict__.keys():
+                if not self.should_emit_field(param, field):
+                    continue
                 if field not in ['name', 'DisplayName', 'Description', 'User', 'SortValues'] and field in known_param_fields:
                     if field == 'Values' and Emit.prog_values_field.match(param.__dict__[field]):
                         values = (param.__dict__[field]).split(',')

--- a/Tools/autotest/param_metadata/jsonemit.py
+++ b/Tools/autotest/param_metadata/jsonemit.py
@@ -56,6 +56,9 @@ class JSONEmit(Emit):
                 name = name.split(':')[1]
 
             # Remove various unwanted keys
+            for key in list(param.__dict__.keys()):
+                if not self.should_emit_field(param, key):
+                    param.__dict__.pop(key)
             for key in 'real_path', 'SortValues', '__field_text':
                 try:
                     param.__dict__.pop(key)

--- a/Tools/autotest/param_metadata/mdemit.py
+++ b/Tools/autotest/param_metadata/mdemit.py
@@ -90,6 +90,8 @@ class MDEmit(Emit):
             t += "\n\n%s" % param.Description
             
             for field in param.__dict__.keys():
+                if not self.should_emit_field(param, field):
+                    continue
                 if field not in ['name', 'DisplayName', 'Description', 'User', 'SortValues'] and field in known_param_fields:
                     if field == 'Values' and Emit.prog_values_field.match(param.__dict__[field]):
                         values = (param.__dict__[field]).split(',')

--- a/Tools/autotest/param_metadata/param.py
+++ b/Tools/autotest/param_metadata/param.py
@@ -51,7 +51,8 @@ known_param_fields = [
              'ReadOnly',
              'Calibration',
              'Vector3Parameter',
-             'SortValues'
+             'SortValues',
+             'Legacy',
                       ]
 
 # Follow SI units conventions from:

--- a/Tools/autotest/param_metadata/rstemit.py
+++ b/Tools/autotest/param_metadata/rstemit.py
@@ -225,6 +225,9 @@ This list is automatically generated from the latest ardupilot source code, and 
            reference=reference)
 
         for param in g.params:
+            if getattr(param, "Legacy", False):
+                # do not emit legacy parameters to the Wiki
+                continue
             if not hasattr(param, 'DisplayName') or not hasattr(param, 'Description'):
                 continue
             d = param.__dict__
@@ -263,6 +266,8 @@ This list is automatically generated from the latest ardupilot source code, and 
             headings = []
             row = []
             for field in sorted(param.__dict__.keys()):
+                if not self.should_emit_field(param, field):
+                    continue
                 if (field not in ['name', 'DisplayName', 'Description', 'User', 'SortValues', 'RebootRequired'] and
                         field in known_param_fields):
                     headings.append(field)

--- a/Tools/autotest/param_metadata/xmlemit.py
+++ b/Tools/autotest/param_metadata/xmlemit.py
@@ -63,6 +63,8 @@ class XmlEmit(Emit):
 
             # Add values as chidren of this node
             for field in param.__dict__.keys():
+                if not self.should_emit_field(param, field):
+                    continue
                 if field not in ['name', 'DisplayName', 'Description', 'User', 'SortValues'] and field in known_param_fields:
                     if field == 'Values' and Emit.prog_values_field.match(param.__dict__[field]):
                         xml_values = etree.SubElement(xml_param, 'values')

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -2002,6 +2002,7 @@ bool AP_GPS::gps_yaw_deg(uint8_t instance, float &yaw_deg, float &accuracy_deg, 
     // @Values: 0:None,1:AUTO,2:uBlox,5:NMEA,6:SiRF,7:HIL,8:SwiftNav,9:DroneCAN,10:SBF,11:GSOF,13:ERB,14:MAV,15:NOVA,16:HemisphereNMEA,17:uBlox-MovingBaseline-Base,18:uBlox-MovingBaseline-Rover,19:MSP,20:AllyStar,21:ExternalAHRS,22:DroneCAN-MovingBaseline-Base,23:DroneCAN-MovingBaseline-Rover,24:UnicoreNMEA,25:UnicoreMovingBaselineNMEA,26:SBF-DualAntenna
     // @RebootRequired: True
     // @User: Advanced
+    // @Legacy: only included here so GCSs running stable can get the description.  Omitted in the Wiki.
 
     // @Param: _TYPE2
     // @CopyFieldsFrom: GPS_TYPE


### PR DESCRIPTION
Allows a marker to be added to parameter markup so that it isn't emitted to the RST, but is to everywhere else.

In lieu of doing proper parameter versioning on the build server...
