### PR TITLE
Copter: remove throttle check for arming in guided

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -976,7 +976,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: GUID_OPTIONS
     // @DisplayName: Guided mode options
     // @Description: Options that can be applied to change guided mode behaviour
-    // @Bitmask: 0:Allow Arming from Transmitter,2:Ignore pilot yaw,3:SetAttitudeTarget interprets Thrust As Thrust,4:Do not stabilize PositionXY,5:Do not stabilize VelocityXY,6:Waypoint navigation used for position targets,7:Allow weathervaning
+    // @Bitmask: 0:Allow Arming from Transmitter,2:Ignore pilot yaw,3:SetAttitudeTarget interprets Thrust As Thrust,4:Do not stabilize PositionXY,5:Do not stabilize VelocityXY,6:Waypoint navigation used for position targets,7:Allow weathervaning,8:Require zero-throttle for arming
     // @User: Advanced
     AP_GROUPINFO("GUID_OPTIONS", 41, ParametersG2, guided_options, 0),
 #endif

--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -60,6 +60,9 @@ bool RC_Channels_Copter::arming_check_throttle() const {
         // Copter already checks this case in its own arming checks
         return false;
     }
+    if (!copter.flightmode->arming_check_throttle()) {
+        return false;
+    }
     return RC_Channels::arming_check_throttle();
 }
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -121,6 +121,8 @@ public:
     virtual bool requires_GPS() const = 0;
     virtual bool has_manual_throttle() const = 0;
     virtual bool allows_arming(AP_Arming::Method method) const = 0;
+    virtual bool arming_check_throttle() const { return true; }
+
     virtual bool is_autopilot() const { return false; }
     virtual bool has_user_takeoff(bool must_navigate) const { return false; }
     virtual bool in_guided_mode() const { return false; }
@@ -1120,6 +1122,8 @@ public:
     bool allows_weathervaning(void) const override;
 #endif
 
+    bool arming_check_throttle() const override;
+
 protected:
 
     const char *name() const override { return "GUIDED"; }
@@ -1140,7 +1144,8 @@ private:
         DoNotStabilizePositionXY = (1U << 4),
         DoNotStabilizeVelocityXY = (1U << 5),
         WPNavUsedForPosControl = (1U << 6),
-        AllowWeatherVaning = (1U << 7)
+        AllowWeatherVaning = (1U << 7),
+        ArmingCheckThrottle = (1U << 8),
     };
 
     // returns true if the Guided-mode-option is set (see GUID_OPTIONS)

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -114,6 +114,11 @@ bool ModeGuided::allows_arming(AP_Arming::Method method) const
     return option_is_enabled(Option::AllowArmingFromTX);
 };
 
+bool ModeGuided::arming_check_throttle() const
+{
+    return option_is_enabled(Option::ArmingCheckThrottle);
+}
+
 #if WEATHERVANE_ENABLED
 bool ModeGuided::allows_weathervaning() const
 {

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -11889,6 +11889,23 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_rc(10, 2000)
         self.wait_statustext('Using EKF Source Set 3', check_context=True)
 
+    def GUIDEDArmingCheckThrottle(self):
+        '''check the way throttle is handled when arming in guided mode'''
+        self.change_mode('GUIDED')
+        self.wait_ready_to_arm()
+        self.start_subtest("With zero throttle should be able to arm")
+        self.arm_vehicle()
+        self.disarm_vehicle()
+
+        self.start_subtest("Without option set we should be able to arm with non-zero throttle in guided")
+        self.set_rc(3, 1600)
+        self.arm_vehicle()
+        self.disarm_vehicle()
+
+        self.start_subtest("With option enabled should not be able to arm with non-zero throttle")
+        self.set_parameter("GUID_OPTIONS", 1 << 8)
+        self.assert_arm_failure("is not neutral")
+
     def tests2b(self):  # this block currently around 9.5mins here
         '''return list of all tests'''
         ret = ([
@@ -11992,6 +12009,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             self.BatteryInternalUseOnly,
             self.MAV_CMD_MISSION_START_p1_p2,
             self.ScriptingAHRSSource,
+            self.GUIDEDArmingCheckThrottle,
         ])
         return ret
 


### PR DESCRIPTION
Co-authored-by: muramura <ma2maru@gmail.com>

.... but add a guided option to put it back.

Replaces https://github.com/ArduPilot/ardupilot/pull/20999
Closes https://github.com/ArduPilot/ardupilot/issues/20995

We could ignore throttle unconditionally instead of adding the option bit?

New autotest fails before / passes after.
