### PR TITLE
AP_Scripting: no warning if no ./scripts and no real filesystem

### DIFF
--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -255,10 +255,13 @@ void lua_scripts::load_all_scripts_in_dir(lua_State *L, const char *dirname) {
     if (dirname == nullptr) {
         return;
     }
-
     auto *d = AP::FS().opendir(dirname);
     if (d == nullptr) {
-        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Lua: open directory (%s) failed", dirname);
+        // this disk_space check will return 0 if we don't have a real
+        // filesystem (ie. no Posix or FatFs).  Do not warn in this case.
+        if (AP::FS().disk_space(dirname) != 0) {
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Lua: open directory (%s) failed", dirname);
+        }
         return;
     }
 


### PR DESCRIPTION
it is possible to build for boards without storage (so no Posix, no Fatafs), but still have scripts in ROMFS.

In this case we will use the backend AP_Filesystem_backend base class when doing file operations.  This will alway fail to open directories, so when we try to load scripts from SCRIPTS_DIRECTORY it will always fail.

This leads to a warning being emitted:

Lua: State memory usage: 2796 + 5227
AP: Lua: open directory (./scripts) failed
AP: hello, world
Time has wrapped

Which isn't great.

Detect we are working on this filesystem and don't warn.


Alternative to https://github.com/ArduPilot/ardupilot/pull/27404/files

I've tested this on CubeOrange - warning is still emitted there (even if you're running scripts out of ROMFS already!)
```
STABILIZE> Got COMMAND_ACK: SCRIPTING: ACCEPTED
AP: Scripting: stopped
AP: Scripting: restarted
Lua: State memory usage: 2796 + 5431
AP: Lua: open directory (/APM/scripts) failed
AP: hello, world
AP: PreArm: RC not found
```
