### PR TITLE
Run tests sequentially and enforce tests in ROS 2

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -4,3 +4,6 @@
 
 # Tools: ros2: Run ament_black on all files
 85172b56467668bee9fa0e68081027b13bc18c4a
+
+# Tools: ros2: Reformat
+4d9822131354dc7dc3351f24660969f58720a1de

--- a/.github/workflows/colcon.yml
+++ b/.github/workflows/colcon.yml
@@ -198,7 +198,7 @@ jobs:
         shell: 'bash'
         run: |
           source install/setup.bash
-          colcon test --packages-select ardupilot_dds_tests --event-handlers=console_cohesion+
+          colcon test --executor sequential --parallel-workers 0 --base-paths src/ardupilot --event-handlers=console_cohesion+
       - name: Report colcon test results
         run: |
           colcon test-result --all --verbose

--- a/Tools/ros2/ardupilot_dds_tests/ardupilot_dds_tests/plane_waypoint_follower.py
+++ b/Tools/ros2/ardupilot_dds_tests/ardupilot_dds_tests/plane_waypoint_follower.py
@@ -144,7 +144,7 @@ def achieved_goal(goal_global_pos, cur_geopose):
     p2 = (cur_pos.latitude, cur_pos.longitude, cur_pos.altitude)
 
     flat_distance = distance.distance(p1[:2], p2[:2]).m
-    euclidian_distance = math.sqrt(flat_distance**2 + (p2[2] - p1[2]) ** 2)
+    euclidian_distance = math.sqrt(flat_distance ** 2 + (p2[2] - p1[2]) ** 2)
     print(f"Goal is {euclidian_distance} meters away")
     return euclidian_distance < 150
 

--- a/Tools/ros2/ardupilot_sitl/src/ardupilot_sitl/launch.py
+++ b/Tools/ros2/ardupilot_sitl/src/ardupilot_sitl/launch.py
@@ -35,6 +35,7 @@ TRUE_STRING = "True"
 FALSE_STRING = "False"
 BOOL_STRING_CHOICES = set([TRUE_STRING, FALSE_STRING])
 
+
 class VirtualPortsLaunch:
     """Launch functions for creating virtual ports using `socat`."""
 
@@ -369,16 +370,10 @@ class MAVProxyLaunch:
                 description="SITL output port.",
             ),
             DeclareLaunchArgument(
-                "map",
-                default_value="False",
-                description="Enable MAVProxy Map.",
-                choices=BOOL_STRING_CHOICES
+                "map", default_value="False", description="Enable MAVProxy Map.", choices=BOOL_STRING_CHOICES
             ),
             DeclareLaunchArgument(
-                "console",
-                default_value="False",
-                description="Enable MAVProxy Console.",
-                choices=BOOL_STRING_CHOICES
+                "console", default_value="False", description="Enable MAVProxy Console.", choices=BOOL_STRING_CHOICES
             ),
         ]
 


### PR DESCRIPTION
# Purpose

Use sequential testing in ROS to prevent multiple tests from communicating traffic.
We also were only testing the test package, rather than ardupilot_sitl and ardupilot_msgs. 
Because pre-commit isn't enforced, we had some style regressions I fixed, and now it's enforced in CI.