### PR TITLE
Tools: raise build time limit

### DIFF
--- a/Tools/scripts/build_autotest.sh
+++ b/Tools/scripts/build_autotest.sh
@@ -100,7 +100,7 @@ export BUILD_BINARIES_PATH=$HOME/build/tmp
 # exit on panic so we don't waste time waiting around
 export SITL_PANIC_EXIT=1
 
-timelimit 72000 python3 APM/Tools/autotest/autotest.py --autotest-server --timeout=70000 > buildlogs/autotest-output.txt 2>&1
+timelimit 144000 python3 APM/Tools/autotest/autotest.py --autotest-server --timeout=143000 > buildlogs/autotest-output.txt 2>&1
 
 mkdir -p "buildlogs/history/$hdate"
 


### PR DESCRIPTION
our build is taking over 20hrs now, which means it gets killed and restarted at 20 hours, and if another commit has come in it means that AP_Periph may never get built at all

raise to 40 hrs