### PR TITLE
GCS_MAVLink: zero signing key structure for valgrind

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Signing.cpp
+++ b/libraries/GCS_MAVLink/GCS_Signing.cpp
@@ -80,7 +80,7 @@ void GCS_MAVLINK::handle_setup_signing(const mavlink_message_t &msg) const
     mavlink_setup_signing_t packet;
     mavlink_msg_setup_signing_decode(&msg, &packet);
 
-    struct SigningKey key;
+    struct SigningKey key {};
     key.magic = SIGNING_KEY_MAGIC;
     key.timestamp = packet.initial_timestamp;
     memcpy(key.secret_key, packet.secret_key, 32);


### PR DESCRIPTION
the signing key structure is not marked as packed, which means it has a 4 byte padding between the uint32_t magic and the uint64_t timestamp. This gets written to the database and valgrind warns about a write of uninitialised bytes. It is harmless as when the structure is read the field is not used