### PR TITLE
Tools: Use apt for pexpect and allow system packages in the virtual environment

### DIFF
--- a/Tools/environment_install/install-prereqs-arch.sh
+++ b/Tools/environment_install/install-prereqs-arch.sh
@@ -54,7 +54,7 @@ sudo usermod -a -G uucp "$USER"
 
 sudo pacman -Syu --noconfirm --needed $BASE_PKGS $SITL_PKGS $PX4_PKGS
 
-python3 -m venv "$HOME"/venv-ardupilot
+python3 -m venv --system-site-packages "$HOME"/venv-ardupilot
 
 # activate it:
 SOURCE_LINE="source $HOME/venv-ardupilot/bin/activate"

--- a/Tools/environment_install/install-prereqs-openSUSE-Tumbleweed.sh
+++ b/Tools/environment_install/install-prereqs-openSUSE-Tumbleweed.sh
@@ -88,7 +88,7 @@ sudo usermod -a -G dialout "$USER"
 
 $ZYPPER $BASE_PKGS $SITL_PKGS || echo "Check zypper output for errors"
 
-python3 -m venv "$HOME"/venv-ardupilot
+python3 -m venv --system-site-packages "$HOME"/venv-ardupilot
 
 SHELL_LOGIN=".profile"
 # activate it:

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -164,8 +164,8 @@ else
 fi
 
 # Lists of packages to install
-BASE_PKGS="build-essential ccache g++ gawk git make wget valgrind screen"
-PYTHON_PKGS="future lxml pymavlink pyserial MAVProxy pexpect geocoder empy==3.3.4 ptyprocess dronecan"
+BASE_PKGS="build-essential ccache g++ gawk git make wget valgrind screen python3-pexpect"
+PYTHON_PKGS="future lxml pymavlink pyserial MAVProxy geocoder empy==3.3.4 ptyprocess dronecan"
 PYTHON_PKGS="$PYTHON_PKGS flake8 junitparser"
 
 # add some Python packages required for commonly-used MAVProxy modules and hex file generation:

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -386,7 +386,7 @@ fi
 
 if [ -n "$PYTHON_VENV_PACKAGE" ]; then
     $APT_GET install $PYTHON_VENV_PACKAGE
-    python3 -m venv $HOME/venv-ardupilot
+    python3 -m venv --system-site-packages $HOME/venv-ardupilot
 
     # activate it:
     SOURCE_LINE="source $HOME/venv-ardupilot/bin/activate"


### PR DESCRIPTION
# Purpose

If an apt package is available for a python dependency, I think we should try to use that.

Doing `python3 -m pip install pexpect` opens us to completely breaking as soon as the next major version comes out.
Instead, we can rely on our packaging team at canonical to ensure our packages are compatible.

Let's see how CI does. 

If we like this approach, it's an alternative to virtual environments for Ubuntu jammy: https://github.com/ArduPilot/ardupilot/issues/26137

Same for 
* python3-future
* python3-pexpect
* And I propose all the rest of the python packages that we can, we switch to apt, especially setuptools