### PR TITLE
waf: allow any custom build option to be specified in waf configure

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -16,6 +16,7 @@ _board = None
 # modify our search path:
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../libraries/AP_HAL_ChibiOS/hwdef/scripts'))
 import chibios_hwdef
+import build_options
 
 class BoardMeta(type):
     def __init__(cls, name, bases, dct):
@@ -159,8 +160,16 @@ class Board:
             )
             cfg.msg("Enabled custom controller", 'no', color='YELLOW')
 
-        if cfg.options.enable_ppp:
-            env.CXXFLAGS += ['-DAP_NETWORKING_BACKEND_PPP=1']
+        # support enabling any option in build_options.py
+        for opt in build_options.BUILD_OPTIONS:
+            enable_option = opt.config_option().replace("-","_")
+            disable_option = "disable_" + enable_option[len("enable-"):]
+            if getattr(cfg.options, enable_option, False):
+                env.CXXFLAGS += ['-D%s=1' % opt.define]
+                cfg.msg("Enabled %s" % opt.label, 'yes', color='GREEN')
+            elif getattr(cfg.options, disable_option, False):
+                env.CXXFLAGS += ['-D%s=0' % opt.define]
+                cfg.msg("Enabled %s" % opt.label, 'no', color='YELLOW')
 
         if cfg.options.disable_networking:
             env.CXXFLAGS += ['-DAP_NETWORKING_ENABLED=0']
@@ -486,12 +495,6 @@ class Board:
 
         # We always want to use PRI format macros
         cfg.define('__STDC_FORMAT_MACROS', 1)
-
-        if cfg.options.enable_ekf2:
-            env.CXXFLAGS += ['-DHAL_NAVEKF2_AVAILABLE=1']
-
-        if cfg.options.disable_ekf3:
-            env.CXXFLAGS += ['-DHAL_NAVEKF3_AVAILABLE=0']
 
         if cfg.options.postype_single:
             env.CXXFLAGS += ['-DHAL_WITH_POSTYPE_DOUBLE=0']

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6603,7 +6603,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.progress('rebuilding rover with ppp enabled')
         import shutil
         shutil.copy('build/sitl/bin/ardurover', 'build/sitl/bin/ardurover.noppp')
-        util.build_SITL('bin/ardurover', clean=False, configure=True, extra_configure_args=['--enable-ppp', '--debug'])
+        util.build_SITL('bin/ardurover', clean=False, configure=True, extra_configure_args=['--enable-PPP', '--debug'])
 
         self.reboot_sitl()
 

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -379,10 +379,10 @@ def do_build(opts, frame_options):
         cmd_configure.append("--enable-math-check-indexes")
 
     if opts.enable_ekf2:
-        cmd_configure.append("--enable-ekf2")
+        cmd_configure.append("--enable-EKF2")
 
     if opts.disable_ekf3:
-        cmd_configure.append("--disable-ekf3")
+        cmd_configure.append("--disable-EKF3")
 
     if opts.postype_single:
         cmd_configure.append("--postype-single")
@@ -415,7 +415,7 @@ def do_build(opts, frame_options):
         cmd_configure.append("--disable-networking")
 
     if opts.enable_ppp:
-        cmd_configure.append("--enable-ppp")
+        cmd_configure.append("--enable-PPP")
 
     if opts.enable_networking_tests:
         cmd_configure.append("--enable-networking-tests")

--- a/Tools/ros2/ardupilot_sitl/CMakeLists.txt
+++ b/Tools/ros2/ardupilot_sitl/CMakeLists.txt
@@ -34,7 +34,7 @@ set(WAF_DISABLE_SCRIPTING $<$<BOOL:${ARDUPILOT_DISABLE_SCRIPTING}>:"--disable-sc
 set(WAF_DISABLE_WATCHDOG $<$<BOOL:${ARDUPILOT_DISABLE_WATCHDOG}>:"--disable-watchdog">)
 set(WAF_ENABLE_DDS $<$<BOOL:${ARDUPILOT_ENABLE_DDS}>:"--enable-dds">)
 set(WAF_ENABLE_NETWORKING_TESTS $<$<BOOL:${ARDUPILOT_ENABLE_NETWORKING_TESTS}>:"--enable-networking-tests">)
-set(WAF_ENABLE_PPP $<$<BOOL:${ARDUPILOT_ENABLE_PPP}>:"--enable-ppp">)
+set(WAF_ENABLE_PPP $<$<BOOL:${ARDUPILOT_ENABLE_PPP}>:"--enable-PPP">)
 
 add_custom_target(ardupilot_configure ALL
   ${WAF_COMMAND} configure --board sitl

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -321,7 +321,7 @@ for t in $CI_BUILD_TARGET; do
 
     if [ "$t" == "CubeOrange-PPP" ]; then
         echo "Building CubeOrange-PPP"
-        $waf configure --board CubeOrange --enable-ppp
+        $waf configure --board CubeOrange --enable-PPP
         $waf clean
         $waf copter
         continue
@@ -329,7 +329,7 @@ for t in $CI_BUILD_TARGET; do
 
     if [ "$t" == "CubeOrange-EKF2" ]; then
         echo "Building CubeOrange with EKF2 enabled"
-        $waf configure --board CubeOrange --enable-ekf2
+        $waf configure --board CubeOrange --enable-EKF2
         $waf clean
         $waf copter
         continue

--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -417,7 +417,7 @@ BUILD_OPTIONS = [
     Feature('Filesystem', 'FILESYSTEM_SYS', 'AP_FILESYSTEM_SYS_ENABLED', 'Enable @SYS/ filesystem', 0, None),
     Feature('Filesystem', 'APJ_TOOL_PARAMETERS', 'FORCE_APJ_DEFAULT_PARAMETERS', 'Enable apj_tool parameter area', 0, None),
 
-    Feature('Networking', 'PPP Support', 'AP_NETWORKING_BACKEND_PPP', 'Enable PPP networking', 0, None),
+    Feature('Networking', 'PPP', 'AP_NETWORKING_BACKEND_PPP', 'Enable PPP networking', 0, None),
 
     Feature('DroneCAN', 'DroneCAN', 'HAL_ENABLE_DRONECAN_DRIVERS', 'Enable DroneCAN support', 0, None),
 ]

--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -23,6 +23,10 @@ class Feature:
         self.default = default
         self.dependency = dependency
 
+    def config_option(self):
+        '''the name of the configure option to be used by waf'''
+        return "enable-" + self.label.replace(" ", "-")
+
 
 # list of build options to offer NOTE: the dependencies must be
 # written as a single string with commas and no spaces,
@@ -382,14 +386,14 @@ BUILD_OPTIONS = [
 
 
     Feature('Airspeed Drivers', 'Analog', 'AP_AIRSPEED_ANALOG_ENABLED', 'Enable Analog Airspeed', 0, 'AIRSPEED'),
-    Feature('Airspeed Drivers', 'ASP5033', 'AP_AIRSPEED_ASP5033_ENABLED', 'ENABLE ASP5033 AIRSPEED', 0, 'AIRSPEED'),  # NOQA: E501
-    Feature('Airspeed Drivers', 'DLVR', 'AP_AIRSPEED_DLVR_ENABLED', 'ENABLE DLVR AIRSPEED', 0, 'AIRSPEED'),
-    Feature('Airspeed Drivers', 'MS4525', 'AP_AIRSPEED_MS4525_ENABLED', 'ENABLE MS4525 AIRSPEED', 0, 'AIRSPEED'),
-    Feature('Airspeed Drivers', 'MS5525', 'AP_AIRSPEED_MS5525_ENABLED', 'ENABLE MS5525 AIRSPEED', 0, 'AIRSPEED'),
-    Feature('Airspeed Drivers', 'MSP_AIRSPEED', 'AP_AIRSPEED_MSP_ENABLED', 'ENABLE MSP AIRSPEED', 0, 'AIRSPEED,MSP,OSD'),
-    Feature('Airspeed Drivers', 'NMEA_AIRSPEED', 'AP_AIRSPEED_NMEA_ENABLED', 'ENABLE NMEA AIRSPEED', 0, 'AIRSPEED'),
-    Feature('Airspeed Drivers', 'SDP3X', 'AP_AIRSPEED_SDP3X_ENABLED', 'ENABLE SDP3X AIRSPEED', 0, 'AIRSPEED'),
-    Feature('Airspeed Drivers', 'DRONECAN_ASPD', 'AP_AIRSPEED_DRONECAN_ENABLED', 'ENABLE DroneCAN AIRSPEED', 0, 'AIRSPEED,DroneCAN'),   # NOQA: E501
+    Feature('Airspeed Drivers', 'ASP5033', 'AP_AIRSPEED_ASP5033_ENABLED', 'Enable ASP5033 AIRSPEED', 0, 'AIRSPEED'),  # NOQA: E501
+    Feature('Airspeed Drivers', 'DLVR', 'AP_AIRSPEED_DLVR_ENABLED', 'Enable DLVR AIRSPEED', 0, 'AIRSPEED'),
+    Feature('Airspeed Drivers', 'MS4525', 'AP_AIRSPEED_MS4525_ENABLED', 'Enable MS4525 AIRSPEED', 0, 'AIRSPEED'),
+    Feature('Airspeed Drivers', 'MS5525', 'AP_AIRSPEED_MS5525_ENABLED', 'Enable MS5525 AIRSPEED', 0, 'AIRSPEED'),
+    Feature('Airspeed Drivers', 'MSP_AIRSPEED', 'AP_AIRSPEED_MSP_ENABLED', 'Enable MSP AIRSPEED', 0, 'AIRSPEED,MSP,OSD'),
+    Feature('Airspeed Drivers', 'NMEA_AIRSPEED', 'AP_AIRSPEED_NMEA_ENABLED', 'Enable NMEA AIRSPEED', 0, 'AIRSPEED'),
+    Feature('Airspeed Drivers', 'SDP3X', 'AP_AIRSPEED_SDP3X_ENABLED', 'Enable SDP3X AIRSPEED', 0, 'AIRSPEED'),
+    Feature('Airspeed Drivers', 'DRONECAN_ASPD', 'AP_AIRSPEED_DRONECAN_ENABLED', 'Enable DroneCAN AIRSPEED', 0, 'AIRSPEED,DroneCAN'),   # NOQA: E501
 
     Feature('Actuators', 'Volz', 'AP_VOLZ_ENABLED', 'Enable Volz Protocol', 0, None),
     Feature('Actuators', 'Volz_DroneCAN', 'AP_DRONECAN_VOLZ_FEEDBACK_ENABLED', 'Enable Volz DroneCAN Feedback', 0, "DroneCAN,Volz"),  # noqa: E501

--- a/libraries/AP_Networking/AP_Networking_Config.h
+++ b/libraries/AP_Networking/AP_Networking_Config.h
@@ -2,7 +2,7 @@
 #include <AP_SerialManager/AP_SerialManager_config.h>
 
 #if defined(AP_NETWORKING_BACKEND_PPP) && !defined(AP_NETWORKING_ENABLED)
-// allow --enable-ppp to enable networking
+// allow --enable-PPP to enable networking
 #define AP_NETWORKING_ENABLED AP_NETWORKING_BACKEND_PPP
 #endif
 

--- a/wscript
+++ b/wscript
@@ -10,10 +10,12 @@ import subprocess
 import json
 import fnmatch
 sys.path.insert(0, 'Tools/ardupilotwaf/')
+sys.path.insert(0, 'Tools/scripts/')
 
 import ardupilotwaf
 import boards
 import shutil
+import build_options
 
 from waflib import Build, ConfigSet, Configure, Context, Utils
 from waflib.Configure import conf
@@ -204,11 +206,6 @@ def options(opt):
         default=False,
         help='enable OS level thread statistics.')
 
-    g.add_option('--enable-ppp',
-        action='store_true',
-        default=False,
-        help='enable PPP networking.')
-    
     g.add_option('--bootloader',
         action='store_true',
         default=False,
@@ -388,16 +385,6 @@ configuration in order to save typing.
         default=False,
         help='Use flash storage emulation.')
 
-    g.add_option('--enable-ekf2',
-        action='store_true',
-        default=False,
-        help='Configure with EKF2.')
-
-    g.add_option('--disable-ekf3',
-        action='store_true',
-        default=False,
-        help='Configure without EKF3.')
-
     g.add_option('--ekf-double',
         action='store_true',
         default=False,
@@ -446,6 +433,24 @@ configuration in order to save typing.
         action='store_true',
         default=False,
         help='enables checking of new to ensure NEW_NOTHROW is used')
+
+    # support enabling any option in build_options.py
+    for opt in build_options.BUILD_OPTIONS:
+        enable_option = "--" + opt.config_option()
+        disable_option = enable_option.replace("--enable", "--disable")
+        enable_description = opt.description
+        if not enable_description.lower().startswith("enable"):
+            enable_description = "Enable " + enable_description
+        disable_description = "Disable " + enable_description[len("Enable "):]
+        g.add_option(enable_option,
+                     action='store_true',
+                     default=False,
+                     help=enable_description)
+        g.add_option(disable_option,
+                     action='store_true',
+                     default=False,
+                     help=disable_description)
+    
     
 def _collect_autoconfig_files(cfg):
     for m in sys.modules.values():


### PR DESCRIPTION
this makes it easy to configure with any option from build_options.py, with tab completion

Note that the build_options.py table takes an optional enable-XXX label to allow us to replace some of the existing options (eg. --enable-ppp and --disable-ekf3)

we end up with options like this: 
```
    --enable-ppp        Enable PPP networking
    --disable-ppp       Disable PPP networking
    --enable-DISPLAY    Enable I2C Displays
    --disable-DISPLAY   Disable I2C Displays
    --enable-LED_CONTROL
                        Enable MAVLink LED Control
    --disable-LED_CONTROL
                        Disable MAVLink LED Control
    --enable-NOTIFY_NCP5623
                        Enable NCP5623 LED
    --disable-NOTIFY_NCP5623
                        Disable NCP5623 LED
    --enable-NOTIFY_NEOPIXEL
                        Enable NeoPixel
    --disable-NOTIFY_NEOPIXEL
                        Disable NeoPixel
    --enable-NOTIFY_PROFILED
                        Enable ProfiLED
    --disable-NOTIFY_PROFILED
                        Disable ProfiLED
    --enable-NOTIFY_PROFILED_SPI
                        Enable ProfiLED (SPI)
    --disable-NOTIFY_PROFILED_SPI
                        Disable ProfiLED (SPI)
    --enable-PLAY_TUNE  Enable MAVLink Play Tune
    --disable-PLAY_TUNE
                        Disable MAVLink Play Tune
    --enable-TONEALARM  Enable ToneAlarm on PWM
    --disable-TONEALARM
                        Disable ToneAlarm on PWM
    --enable-OSD        Enable OSD
    --disable-OSD       Disable OSD
    --enable-OSD_EXTENDED_LINK_STATS
                        Enable OSD panels with extended link stats data
    --disable-OSD_EXTENDED_LINK_STATS
                        Disable OSD panels with extended link stats data
    --enable-OSD_PARAM  Enable OSD param
    --disable-OSD_PARAM
                        Disable OSD param
```
