### PR TITLE
hwdef: remove non-ublox GPSes from MatekL431-Periph

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekL431-Periph/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekL431-Periph/hwdef.dat
@@ -23,6 +23,10 @@ define HAL_PERIPH_GPS_PORT_DEFAULT 2
 # allow for F9P GPS modules with moving baseline
 define GPS_MOVING_BASELINE 1
 
+# restrict backends available to save flash (i.e. only UBLOX)
+define AP_GPS_NOVA_ENABLED 0
+define AP_GPS_SBF_ENABLED 0
+define AP_GPS_GSOF_ENABLED 0
 
 # ---------------------- COMPASS ---------------------------
 define HAL_PERIPH_ENABLE_MAG


### PR DESCRIPTION
Saves enough flash to get it building again (11K now free). These backends are default for other boards and so are built in CI.

Tested that it builds and still works with a ublox GPS. Solution as discussed on dev call and https://github.com/ArduPilot/ardupilot/pull/27659 .