### PR TITLE
Add get_airspeed methode

### DIFF
--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -3209,6 +3209,13 @@ function battery:num_instances() end
 ---@return number|nil
 function battery:get_cell_voltage(instance, cell) end
 
+-- The Airspeed library provides access to airspeed sensors information.
+airspeed = {}
+
+-- desc
+---@param instance integer
+---@return airspeed float
+function airspeed:get_airspeed(instance) end
 
 -- The Arming library provides access to arming status and commands.
 arming = {}

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -62,6 +62,10 @@ singleton AP_AHRS method initialised boolean
 singleton AP_AHRS method get_posvelyaw_source_set uint8_t
 singleton AP_AHRS method get_quaternion boolean Quaternion'Null
 
+include AP_Airspeed/AP_Airspeed.h
+singleton AP_Airspeed rename airspeed
+singleton AP_Airspeed method get_airspeed float uint8_t'skip_check
+
 include AP_Arming/AP_Arming.h
 
 singleton AP_Arming rename arming


### PR DESCRIPTION
Add get_airspeed(instance) method, useful for planes with multiple sensors (currently, only the primary sensor is available).
- Added AP_Airspeed chapter in docs.lua and bindings.desc.
- Implemented airspeed:get_airspeed method.
- Tested in SITL with the following_script:

-- This script gives airspeed value if available

function state_init()
    gcs:send_text(6, 'script initiated')
    return state_update, 500
end

function state_update()
    
    local message = string.format("Airspeed: %.2f m/s", airspeed:get_airspeed(0))
    gcs:send_text(6,message)
    return state_update, 6000
end


return state_init,500