### PR TITLE
AP_DroneCAN: DNAServer: don't "allocate" broadcast ID

### DIFF
--- a/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.cpp
@@ -458,7 +458,6 @@ void AP_DroneCAN_DNA_Server::handleAllocation(const CanardRxTransfer& transfer, 
         (now - last_alloc_msg_ms) > 500) {
         if (msg.first_part_of_unique_id) {
             rcvd_unique_id_offset = 0;
-            memset(rcvd_unique_id, 0, sizeof(rcvd_unique_id));
         } else {
             //we are only accepting first part
             return;
@@ -482,7 +481,6 @@ void AP_DroneCAN_DNA_Server::handleAllocation(const CanardRxTransfer& transfer, 
     if ((rcvd_unique_id_offset + msg.unique_id.len) > 16) {
         //This request is malformed, Reset!
         rcvd_unique_id_offset = 0;
-        memset(rcvd_unique_id, 0, sizeof(rcvd_unique_id));
         return;
     }
 
@@ -505,7 +503,6 @@ void AP_DroneCAN_DNA_Server::handleAllocation(const CanardRxTransfer& transfer, 
         rsp.node_id = db.handle_allocation(msg.node_id, (const uint8_t*)rcvd_unique_id);
         //reset states as well        
         rcvd_unique_id_offset = 0;
-        memset(rcvd_unique_id, 0, sizeof(rcvd_unique_id));
     }
 
     allocation_pub.broadcast(rsp, false); // never publish allocation message with CAN FD

--- a/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.h
+++ b/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.h
@@ -123,7 +123,7 @@ class AP_DroneCAN_DNA_Server
     char fault_node_name[15];
 
 
-    //Allocation params
+    // dynamic node ID allocation state variables
     uint8_t rcvd_unique_id[16];
     uint8_t rcvd_unique_id_offset;
     uint32_t last_alloc_msg_ms;
@@ -133,7 +133,7 @@ class AP_DroneCAN_DNA_Server
 
     Canard::Publisher<uavcan_protocol_dynamic_node_id_Allocation> allocation_pub{_canard_iface};
 
-    Canard::ObjCallback<AP_DroneCAN_DNA_Server, uavcan_protocol_dynamic_node_id_Allocation> allocation_cb{this, &AP_DroneCAN_DNA_Server::handleAllocation};
+    Canard::ObjCallback<AP_DroneCAN_DNA_Server, uavcan_protocol_dynamic_node_id_Allocation> allocation_cb{this, &AP_DroneCAN_DNA_Server::handle_allocation};
     Canard::Subscriber<uavcan_protocol_dynamic_node_id_Allocation> allocation_sub;
 
     Canard::ObjCallback<AP_DroneCAN_DNA_Server, uavcan_protocol_NodeStatus> node_status_cb{this, &AP_DroneCAN_DNA_Server::handleNodeStatus};
@@ -159,8 +159,8 @@ public:
     //report the server state, along with failure message if any
     bool prearm_check(char* fail_msg, uint8_t fail_msg_len) const;
 
-    //Callbacks
-    void handleAllocation(const CanardRxTransfer& transfer, const uavcan_protocol_dynamic_node_id_Allocation& msg);
+    // canard message handler callbacks
+    void handle_allocation(const CanardRxTransfer& transfer, const uavcan_protocol_dynamic_node_id_Allocation& msg);
     void handleNodeStatus(const CanardRxTransfer& transfer, const uavcan_protocol_NodeStatus& msg);
     void handleNodeInfo(const CanardRxTransfer& transfer, const uavcan_protocol_GetNodeInfoResponse& rsp);
 


### PR DESCRIPTION
While technically legal, it's unlikely to have been tested and an allocatee might do silly things.

Also makes the logic a bit more clear, improves the failure message, and some other minor savings.

Tested on CubeOrange (with artificially limited DNA database size) and a pile of MatekL431 boards. Saves a couple hundred bytes.