### PR TITLE
GCS_MAVLink: fix includes to ap_message

### DIFF
--- a/libraries/GCS_MAVLink/ap_message.h
+++ b/libraries/GCS_MAVLink/ap_message.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include "GCS_config.h"
+
 #include <AP_AHRS/AP_AHRS_config.h>
 
 enum ap_message : uint8_t {


### PR DESCRIPTION
In ap_message.h we use the flag `AP_MAVLINK_MSG_HIGHRES_IMU_ENABLED` without having it defined yet. This can be solved by either including "GSC_config.h" or removing the flag from the enum definition.

Open to discuss the alternatives!

Referencing comment #27007
May relate to [https://github.com/chobitsfan/mavlink-udp-proxy/issues/3](chobitsfan/mavlink-udp-proxy/issues/3)