### PR TITLE
Copter: auto mode takeoff complete pos fix

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -15,7 +15,7 @@ class _AutoTakeoff {
 public:
     void run();
     void start(float complete_alt_cm, bool terrain_alt);
-    bool get_position(Vector3p& completion_pos);
+    bool get_completion_pos(Vector3p& pos_neu_cm);
 
     bool complete;          // true when takeoff is complete
 

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -427,7 +427,7 @@ bool ModeAuto::wp_start(const Location& dest_loc)
         Vector3f stopping_point;
         if (_mode == SubMode::TAKEOFF) {
             Vector3p takeoff_complete_pos;
-            if (auto_takeoff.get_position(takeoff_complete_pos)) {
+            if (auto_takeoff.get_completion_pos(takeoff_complete_pos)) {
                 stopping_point = takeoff_complete_pos.tofloat();
             }
         }

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -239,15 +239,15 @@ void _AutoTakeoff::start(float _complete_alt_cm, bool _terrain_alt)
     }
 }
 
-// return takeoff final position if takeoff has completed successfully
-bool _AutoTakeoff::get_position(Vector3p& _complete_pos)
+// return takeoff final target position in cm from the EKF origin if takeoff has completed successfully
+bool _AutoTakeoff::get_completion_pos(Vector3p& pos_neu_cm)
 {
     // only provide location if takeoff has completed
     if (!complete) {
         return false;
     }
 
-    complete_pos = _complete_pos;
+    pos_neu_cm = complete_pos;
     return true;
 }
 


### PR DESCRIPTION
This resolves issue https://github.com/ArduPilot/ardupilot/issues/28060 by resolving the mixup of variable names in _AutoTakeoff::get_position() method.

I've also renamed the method and added some comments in the hope that this makes its purpose a little more clear.

This has been lightly tested in SITL using a simple mission consisting of just a takeoff and a waypoint command.
![test-mission](https://github.com/user-attachments/assets/e24e859c-d77e-4f14-9a6e-bee7178bf857)

Below is a screenshot of the target position (in the Easterly direction) and "before" we see a slight jump while "after" it is gone.
![before](https://github.com/user-attachments/assets/77c35e5b-4c5a-4b84-9b69-bab9a71a051a)
![after](https://github.com/user-attachments/assets/6f1efe79-068c-4b9a-9b99-ce54ca724ca6)

Thanks to @peterbarker for helping with the investigation and fix

