### PR TITLE
AP_Scripting: allow setting throttle factor from add_motor_raw

### DIFF
--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -561,7 +561,7 @@ include AP_Motors/AP_MotorsMatrix.h depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)|
 singleton AP_MotorsMatrix depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_COPTER_OR_HELI
 singleton AP_MotorsMatrix rename MotorsMatrix
 singleton AP_MotorsMatrix method init boolean uint8_t 0 AP_MOTORS_MAX_NUM_MOTORS
-singleton AP_MotorsMatrix method add_motor_raw void int8_t 0 (AP_MOTORS_MAX_NUM_MOTORS-1) float'skip_check float'skip_check float'skip_check uint8_t 0 AP_MOTORS_MAX_NUM_MOTORS
+singleton AP_MotorsMatrix method add_motor_raw void int8_t 0 (AP_MOTORS_MAX_NUM_MOTORS-1) float'skip_check float'skip_check float'skip_check uint8_t 0 AP_MOTORS_MAX_NUM_MOTORS float'skip_check
 singleton AP_MotorsMatrix method set_throttle_factor boolean int8_t 0 (AP_MOTORS_MAX_NUM_MOTORS-1) float 0 FLT_MAX
 singleton AP_MotorsMatrix method get_lost_motor uint8_t
 singleton AP_MotorsMatrix method get_thrust_boost boolean


### PR DESCRIPTION
`add_motor_raw` defaults throttle factor to 1: https://github.com/ArduPilot/ardupilot/blob/bb2249f7667bfbf8dee724c2b0591d9a67f1b86d/libraries/AP_Motors/AP_MotorsMatrix.h#L79

There is a scripting `set_throttle_factor`. This does not seem to be working with frame class (https://ardupilot.org/plane/docs/parameters-Plane-stable-V4.5.6.html#q-frame-class-frame-class) 15 though.