### PR TITLE
AP_EFI: Hirth: fix sensor health flags

### DIFF
--- a/libraries/AP_EFI/AP_EFI_Serial_Hirth.cpp
+++ b/libraries/AP_EFI/AP_EFI_Serial_Hirth.cpp
@@ -33,7 +33,6 @@
 
 #define ENGINE_RUNNING 4
 #define THROTTLE_POSITION_FACTOR 10
-#define CRANK_SHAFT_SENSOR_OK 0x0F
 #define INJECTION_TIME_RESOLUTION 0.8
 #define THROTTLE_POSITION_RESOLUTION 0.1
 #define VOLTAGE_RESOLUTION 0.0049       /* 5/1024 */
@@ -301,7 +300,6 @@ void AP_EFI_Serial_Hirth::decode_data()
 
         // EFI2 log
         internal_state.engine_state = (Engine_State)record1->engine_status;
-        internal_state.crankshaft_sensor_status = (record1->sensor_ok & CRANK_SHAFT_SENSOR_OK) ? Crankshaft_Sensor_Status::OK : Crankshaft_Sensor_Status::ERROR;
 
         // ECYL log
         internal_state.cylinder_status.injection_time_ms = record1->injection_time * INJECTION_TIME_RESOLUTION;

--- a/libraries/AP_EFI/AP_EFI_Serial_Hirth.h
+++ b/libraries/AP_EFI/AP_EFI_Serial_Hirth.h
@@ -47,10 +47,10 @@ public:
     };
 
     enum class Sensor_Status_Bitfield : uint8_t {
-        ENGINE_TEMP_SENSOR_OK = 1U<<0, // true if engine temperature sensor is OK
-        AIR_TEMP_SENSOR_OK = 1U<<1, // true if air temperature sensor is OK
-        AIR_PRESSURE_SENSOR_OK = 1U<<2, // true if intake air pressure sensor is OK
-        THROTTLE_SENSOR_OK = 1U<<3, // true if throttle sensor is OK
+        ENGINE_TEMP_SENSOR_OK = 1U<<1, // true if engine temperature sensor is OK
+        AIR_TEMP_SENSOR_OK = 1U<<2, // true if air temperature sensor is OK
+        AIR_PRESSURE_SENSOR_OK = 1U<<3, // true if intake air pressure sensor is OK
+        THROTTLE_SENSOR_OK = 1U<<4, // true if throttle sensor is OK
     };
 
 private:


### PR DESCRIPTION
There is no crankshaft sensor status reported by this EFI. This line is misleading and should be removed. The sensor health bitmask is already logged elsewhere.