### PR TITLE
Rover: reject position targets if acceleration supplied

### DIFF
--- a/Rover/GCS_MAVLink_Rover.cpp
+++ b/Rover/GCS_MAVLink_Rover.cpp
@@ -675,6 +675,14 @@ void GCS_MAVLINK_Rover::handle_set_attitude_target(const mavlink_message_t &msg)
     }
 }
 
+// if we receive a message where the user has not masked out
+// acceleration from the input packet we send a curt message
+// informing them:
+void GCS_MAVLINK_Rover::send_acc_ignore_must_be_set_message(const char *msgname)
+{
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Ignoring %s; set ACC_IGNORE in mask", msgname);
+}
+
 void GCS_MAVLINK_Rover::handle_set_position_target_local_ned(const mavlink_message_t &msg)
 {
     // decode packet
@@ -782,6 +790,7 @@ void GCS_MAVLINK_Rover::handle_set_position_target_local_ned(const mavlink_messa
 
     if (!acc_ignore) {
         // ignore any command where acceleration is not ignored
+        send_acc_ignore_must_be_set_message("SET_POSITION_TARGET_LOCAL_NED");
         return;
     }
 
@@ -891,6 +900,7 @@ void GCS_MAVLINK_Rover::handle_set_position_target_global_int(const mavlink_mess
 
     if (!acc_ignore) {
         // ignore any command where acceleration is not ignored
+        send_acc_ignore_must_be_set_message("SET_POSITION_TARGET_GLOBAL_INT");
         return;
     }
 

--- a/Rover/GCS_MAVLink_Rover.cpp
+++ b/Rover/GCS_MAVLink_Rover.cpp
@@ -780,6 +780,11 @@ void GCS_MAVLINK_Rover::handle_set_position_target_local_ned(const mavlink_messa
         }
     }
 
+    if (!acc_ignore) {
+        // ignore any command where acceleration is not ignored
+        return;
+    }
+
     // set guided mode targets
     if (!pos_ignore) {
         // consume position target
@@ -787,19 +792,22 @@ void GCS_MAVLINK_Rover::handle_set_position_target_local_ned(const mavlink_messa
             // GCS will need to monitor desired location to
             // see if they are having an effect.
         }
-    } else if (!vel_ignore && acc_ignore && yaw_ignore && yaw_rate_ignore) {
+        return;
+    }
+
+    if (!vel_ignore && yaw_ignore && yaw_rate_ignore) {
         // consume velocity
         rover.mode_guided.set_desired_heading_and_speed(target_yaw_cd, speed_dir * target_speed);
-    } else if (!vel_ignore && acc_ignore && yaw_ignore && !yaw_rate_ignore) {
+    } else if (!vel_ignore && yaw_ignore && !yaw_rate_ignore) {
         // consume velocity and turn rate
         rover.mode_guided.set_desired_turn_rate_and_speed(target_turn_rate_cds, speed_dir * target_speed);
-    } else if (!vel_ignore && acc_ignore && !yaw_ignore && yaw_rate_ignore) {
+    } else if (!vel_ignore && !yaw_ignore && yaw_rate_ignore) {
         // consume velocity and heading
         rover.mode_guided.set_desired_heading_and_speed(target_yaw_cd, speed_dir * target_speed);
-    } else if (vel_ignore && acc_ignore && !yaw_ignore && yaw_rate_ignore) {
+    } else if (vel_ignore && !yaw_ignore && yaw_rate_ignore) {
         // consume just target heading (probably only skid steering vehicles can do this)
         rover.mode_guided.set_desired_heading_and_speed(target_yaw_cd, 0.0f);
-    } else if (vel_ignore && acc_ignore && yaw_ignore && !yaw_rate_ignore) {
+    } else if (vel_ignore && yaw_ignore && !yaw_rate_ignore) {
         // consume just turn rate (probably only skid steering vehicles can do this)
         rover.mode_guided.set_desired_turn_rate_and_speed(target_turn_rate_cds, 0.0f);
     }

--- a/Rover/GCS_MAVLink_Rover.cpp
+++ b/Rover/GCS_MAVLink_Rover.cpp
@@ -889,6 +889,11 @@ void GCS_MAVLINK_Rover::handle_set_position_target_global_int(const mavlink_mess
         }
     }
 
+    if (!acc_ignore) {
+        // ignore any command where acceleration is not ignored
+        return;
+    }
+
     // set guided mode targets
     if (!pos_ignore) {
         // consume position target
@@ -896,19 +901,22 @@ void GCS_MAVLINK_Rover::handle_set_position_target_global_int(const mavlink_mess
             // GCS will just need to look at desired location
             // outputs to see if it having an effect.
         }
-    } else if (!vel_ignore && acc_ignore && yaw_ignore && yaw_rate_ignore) {
+        return;
+    }
+
+    if (!vel_ignore && yaw_ignore && yaw_rate_ignore) {
         // consume velocity
         rover.mode_guided.set_desired_heading_and_speed(target_yaw_cd, speed_dir * target_speed);
-    } else if (!vel_ignore && acc_ignore && yaw_ignore && !yaw_rate_ignore) {
+    } else if (!vel_ignore && yaw_ignore && !yaw_rate_ignore) {
         // consume velocity and turn rate
         rover.mode_guided.set_desired_turn_rate_and_speed(target_turn_rate_cds, speed_dir * target_speed);
-    } else if (!vel_ignore && acc_ignore && !yaw_ignore && yaw_rate_ignore) {
+    } else if (!vel_ignore && !yaw_ignore && yaw_rate_ignore) {
         // consume velocity
         rover.mode_guided.set_desired_heading_and_speed(target_yaw_cd, speed_dir * target_speed);
-    } else if (vel_ignore && acc_ignore && !yaw_ignore && yaw_rate_ignore) {
+    } else if (vel_ignore && !yaw_ignore && yaw_rate_ignore) {
         // consume just target heading (probably only skid steering vehicles can do this)
         rover.mode_guided.set_desired_heading_and_speed(target_yaw_cd, 0.0f);
-    } else if (vel_ignore && acc_ignore && yaw_ignore && !yaw_rate_ignore) {
+    } else if (vel_ignore && yaw_ignore && !yaw_rate_ignore) {
         // consume just turn rate(probably only skid steering vehicles can do this)
         rover.mode_guided.set_desired_turn_rate_and_speed(target_turn_rate_cds, 0.0f);
     }

--- a/Rover/GCS_MAVLink_Rover.h
+++ b/Rover/GCS_MAVLink_Rover.h
@@ -52,6 +52,10 @@ private:
 
     void send_servo_out();
 
+    // if we receive a message where the user has not masked out
+    // acceleration from the input packet we send a curt message
+    // informing them:
+    void send_acc_ignore_must_be_set_message(const char *msgname);
     uint8_t base_mode() const override;
     MAV_STATE vehicle_system_status() const override;
 


### PR DESCRIPTION
Replaces https://github.com/ArduPilot/ardupilot/pull/26955/files which simply factored the check out.

This both factors the check out and stops us accepting the position target if acceleration is set.

We should probably also reject if other bits and pieces are set.
