### PR TITLE
hwdef: f103-GPS: explicltly nominiate compass backends supported

### DIFF
--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -166,6 +166,7 @@ BUILD_OPTIONS = [
     Feature('Compass', 'HMC5843', 'AP_COMPASS_HMC5843_ENABLED', 'Enable HMC5843 compasses', 1, None),
     Feature('Compass', 'ICM20948', 'AP_COMPASS_ICM20948_ENABLED', 'Enable AK09916 on ICM20948 compasses', 1, "AK09916"),
     Feature('Compass', 'IST8308', 'AP_COMPASS_IST8308_ENABLED', 'Enable IST8308 compasses', 1, None),
+    Feature('Compass', 'IST8310', 'AP_COMPASS_IST8310_ENABLED', 'Enable IST8310 compasses', 1, None),
     Feature('Compass', 'LIS3MDL', 'AP_COMPASS_LIS3MDL_ENABLED', 'Enable LIS3MDL compasses', 1, None),
     Feature('Compass', 'LSM303D', 'AP_COMPASS_LSM303D_ENABLED', 'Enable LSM303D compasses', 1, None),
     Feature('Compass', 'LSM9DS1', 'AP_COMPASS_LSM9DS1_ENABLED', 'Enable LSM9DS1 compasses', 1, None),

--- a/libraries/AP_HAL_ChibiOS/hwdef/f103-GPS/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/f103-GPS/hwdef.dat
@@ -1,10 +1,18 @@
 include ../f103-periph/hwdef.inc
 
 
-# and support all external compass types
 define HAL_PROBE_EXTERNAL_I2C_COMPASSES
-# .... except BMM150:
-define AP_COMPASS_BMM150_ENABLED 0
+
+# support an expliclty defined set of compasses:
+define AP_COMPASS_BACKEND_DEFAULT_ENABLED 0
+define AP_COMPASS_AK09916_ENABLED 1
+define AP_COMPASS_HMC5843_ENABLED 1
+define AP_COMPASS_IST8308_ENABLED 1
+define AP_COMPASS_IST8310_ENABLED 1
+define AP_COMPASS_LIS3MDL_ENABLED 1
+define AP_COMPASS_MMC3416_ENABLED 1
+define AP_COMPASS_QMC5883L_ENABLED 1
+define AP_COMPASS_RM3100_ENABLED 1
 
 # increase TX size for RTCM
 undef HAL_UART_MIN_TX_SIZE


### PR DESCRIPTION
this target is overflowing as someone is trying to add a new compass..

this set was determined using `extract_features.py` on a compiled binary
