### PR TITLE
Fetch RPTY channels directly from AP::rc() rather than asking RCMap first

### DIFF
--- a/libraries/AP_Camera/AP_RunCam.cpp
+++ b/libraries/AP_Camera/AP_RunCam.cpp
@@ -451,10 +451,10 @@ void AP_RunCam::handle_in_menu(Event ev)
 // map rc input to an event
 AP_RunCam::Event AP_RunCam::map_rc_input_to_event() const
 {
-    const RC_Channel::AuxSwitchPos throttle = rc().get_channel_pos(AP::rcmap()->throttle());
-    const RC_Channel::AuxSwitchPos yaw = rc().get_channel_pos(AP::rcmap()->yaw());
-    const RC_Channel::AuxSwitchPos roll = rc().get_channel_pos(AP::rcmap()->roll());
-    const RC_Channel::AuxSwitchPos pitch = rc().get_channel_pos(AP::rcmap()->pitch());
+    const RC_Channel::AuxSwitchPos throttle = rc().get_throttle_channel().get_aux_switch_pos();
+    const RC_Channel::AuxSwitchPos yaw = rc().get_yaw_channel().get_aux_switch_pos();
+    const RC_Channel::AuxSwitchPos roll = rc().get_roll_channel().get_aux_switch_pos();
+    const RC_Channel::AuxSwitchPos pitch = rc().get_pitch_channel().get_aux_switch_pos();
 
     Event result = Event::NONE;
 

--- a/libraries/AP_Camera/AP_RunCam.h
+++ b/libraries/AP_Camera/AP_RunCam.h
@@ -27,7 +27,6 @@
 
 #include <AP_Param/AP_Param.h>
 #include <RC_Channel/RC_Channel.h>
-#include <AP_RCMapper/AP_RCMapper.h>
 #include <AP_Arming/AP_Arming.h>
 #include <AP_OSD/AP_OSD.h>
 

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -503,7 +503,7 @@ private:
 
 #if AP_RC_CHANNEL_ENABLED
     Event map_rc_input_to_event() const;
-    RC_Channel::AuxSwitchPos get_channel_pos(uint8_t rcmapchan) const;
+    RC_Channel::AuxSwitchPos get_channel_pos(const class RC_Channel &chan) const;
 #endif
 
     uint8_t _selected_param = 1;

--- a/libraries/AP_OSD/AP_OSD_ParamScreen.cpp
+++ b/libraries/AP_OSD/AP_OSD_ParamScreen.cpp
@@ -26,7 +26,6 @@
 #include <AP_HAL/Util.h>
 #include <limits.h>
 #include <ctype.h>
-#include <AP_RCMapper/AP_RCMapper.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 #include <AP_Arming/AP_Arming.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
@@ -390,14 +389,11 @@ void AP_OSD_ParamScreen::modify_configured_parameter(uint8_t number, Event ev)
 }
 
 // return radio values as LOW, MIDDLE, HIGH
-// this function uses different threshold values to RC_Chanel::get_channel_pos()
+// this function uses different threshold values to RC_Chanel::get_aux_switch_pos()
 // to avoid glitching on the stick travel
-RC_Channel::AuxSwitchPos AP_OSD_ParamScreen::get_channel_pos(uint8_t rcmapchan) const
+RC_Channel::AuxSwitchPos AP_OSD_ParamScreen::get_channel_pos(const RC_Channel &chanref) const
 {
-    const RC_Channel* chan = rc().channel(rcmapchan-1);
-    if (chan == nullptr) {
-        return RC_Channel::AuxSwitchPos::LOW;
-    }
+    const auto chan = &chanref;
 
     const uint16_t in = chan->get_radio_in();
     if (in <= 900 || in >= 2200) {
@@ -419,10 +415,10 @@ RC_Channel::AuxSwitchPos AP_OSD_ParamScreen::get_channel_pos(uint8_t rcmapchan) 
 // map rc input to an event
 AP_OSD_ParamScreen::Event AP_OSD_ParamScreen::map_rc_input_to_event() const
 {
-    const RC_Channel::AuxSwitchPos throttle = get_channel_pos(AP::rcmap()->throttle());
-    const RC_Channel::AuxSwitchPos yaw = get_channel_pos(AP::rcmap()->yaw());
-    const RC_Channel::AuxSwitchPos roll = get_channel_pos(AP::rcmap()->roll());
-    const RC_Channel::AuxSwitchPos pitch = get_channel_pos(AP::rcmap()->pitch());
+    const RC_Channel::AuxSwitchPos throttle = get_channel_pos(rc().get_throttle_channel());
+    const RC_Channel::AuxSwitchPos yaw = get_channel_pos(rc().get_yaw_channel());
+    const RC_Channel::AuxSwitchPos roll = get_channel_pos(rc().get_roll_channel());
+    const RC_Channel::AuxSwitchPos pitch = get_channel_pos(rc().get_pitch_channel());
 
     Event result = Event::NONE;
 

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -1921,14 +1921,6 @@ RC_Channel::AuxSwitchPos RC_Channel::get_aux_switch_pos() const
     return position;
 }
 
-// return switch position value as LOW, MIDDLE, HIGH
-// if reading the switch fails then it returns LOW
-RC_Channel::AuxSwitchPos RC_Channels::get_channel_pos(const uint8_t rcmapchan) const
-{
-    const RC_Channel* chan = rc().channel(rcmapchan-1);
-    return chan != nullptr ? chan->get_aux_switch_pos() : RC_Channel::AuxSwitchPos::LOW;
-}
-
 RC_Channel *RC_Channels::find_channel_for_option(const RC_Channel::AUX_FUNC option)
 {
     for (uint8_t i=0; i<NUM_RC_CHANNELS; i++) {

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -498,7 +498,6 @@ public:
 
     class RC_Channel *find_channel_for_option(const RC_Channel::AUX_FUNC option);
     bool duplicate_options_exist();
-    RC_Channel::AuxSwitchPos get_channel_pos(const uint8_t rcmapchan) const;
     void convert_options(const RC_Channel::AUX_FUNC old_option, const RC_Channel::AUX_FUNC new_option);
 
     void init_aux_all();


### PR DESCRIPTION
RC_Channels can consult the mapper.

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                                                     
Durandal                            -96    *           -112    -112              -112   -112   -104
Hitec-Airspeed           *                                                                     
KakuteH7-bdshot                     -64    *           -64     -64               -64    -56    -64
MatekF405                           -56    *           -64     -64               -56    -64    -56
Pixhawk1-1M-bdshot                  *                  *       *                 *      *      *
f103-QiotekPeriph        *                                                                     
f303-Universal           *                                                                     
iomcu                                                                *                         
revo-mini                           -56    *           -56     -64               -56    -64    -64
skyviper-v2450                                         *                                       
```
