### PR TITLE
AP_Airspeed: Don't fail on REG_WHOAMI_RECHECK_ID

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed_ASP5033.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_ASP5033.cpp
@@ -78,7 +78,7 @@ bool AP_Airspeed_ASP5033::confirm_sensor_id(void)
 {
     uint8_t part_id;
     if (!dev->read_registers(REG_PART_ID_SET, &part_id, 1) ||
-        part_id != REG_WHOAMI_DEFAULT_ID) {
+        ( (part_id != REG_WHOAMI_DEFAULT_ID) && (part_id != REG_WHOAMI_RECHECK_ID) ) ) {
         return false;
     }
     if (!dev->write_register(REG_PART_ID_SET, REG_WHOAMI_RECHECK_ID)) {


### PR DESCRIPTION
This prevents a false negative ID check for the cases when the AP is rebooted independently of the sensor, with the latter keeping a temporary ID that was set during initialization