### PR TITLE
AP_DroneCAN: DNAServer: remove preferred allocation support

### DIFF
--- a/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.h
+++ b/libraries/AP_DroneCAN/AP_DroneCAN_DNA_Server.h
@@ -60,14 +60,9 @@ class AP_DroneCAN_DNA_Server
         bool handle_node_info(uint8_t source_node_id, const uint8_t unique_id[]);
 
         // handle the allocation message. returns the allocated node ID, or 0 if allocation failed
-        uint8_t handle_allocation(uint8_t node_id, const uint8_t unique_id[]);
+        uint8_t handle_allocation(const uint8_t unique_id[]);
 
     private:
-        // search for a free node ID, starting at the preferred ID (which can be 0 if
-        // none are preferred). returns 0 if none found. based on pseudocode in
-        // uavcan/protocol/dynamic_node_id/1.Allocation.uavcan
-        uint8_t find_free_node_id(uint8_t preferred);
-
         // retrieve node ID that matches the given unique ID. returns 0 if not found
         uint8_t find_node_id(const uint8_t unique_id[], uint8_t size);
 


### PR DESCRIPTION
Nothing is known to support it so it can't be tested. Removing it saves flash and reduces complexity.

I would prefer to add support for it to AP_Periph so it can be tested but tridge said he would prefer to just remove support. Saves 168 bytes of flash on Cube Orange. Would consume 32 bytes to add support to AP_Periph.

Tested on the bench that allocation of new and existing nodes works properly still.