### PR TITLE
Tools/ardupilotwaf: improve dronecangen dependency tracking

### DIFF
--- a/Tools/ardupilotwaf/dronecangen.py
+++ b/Tools/ardupilotwaf/dronecangen.py
@@ -20,10 +20,10 @@ class dronecangen(Task.Task):
         python = self.env.get_flat('PYTHON')
         out = self.env.get_flat('OUTPUT_DIR')
         src = self.env.get_flat('SRC')
-        dsdlc = self.env.get_flat("DC_DSDL_COMPILER")
+        dsdlc = self.env.get_flat("DC_DSDL_COMPILER_DIR")
 
         cmd = ['{}'.format(python),
-               '{}'.format(dsdlc),
+               '{}/dronecan_dsdlc.py'.format(dsdlc),
                '-O{}'.format(out)] + [x.abspath() for x in self.inputs]
         ret = self.exec_command(cmd)
         if ret != 0:
@@ -55,6 +55,16 @@ def process_dronecangen(self):
         self.bld.fatal('dronecangen: missing option output_dir')
 
     inputs = self.to_nodes(self.source)
+    # depend on each message file in the source so rebuilds will occur properly
+    deps = []
+    for inp in inputs:
+        deps.extend(inp.ant_glob("**/*.uavcan"))
+    # also depend on the generator source itself
+    dsdlc_dir = self.env.get_flat("DC_DSDL_COMPILER_DIR")
+    dsdlc = self.bld.root.find_node(dsdlc_dir) # expected to be absolute
+    if dsdlc is None:
+        self.bld.fatal("dronecangen: waf couldn't find dsdlc at abspath {}".format(dsdlc_dir))
+    deps.extend(dsdlc.ant_glob("**/*.py **/*.em"))
     outputs = []
 
     self.source = []
@@ -63,6 +73,7 @@ def process_dronecangen(self):
         self.output_dir = self.bld.bldnode.find_or_declare(self.output_dir)
 
     task = self.create_task('dronecangen', inputs, outputs)
+    task.dep_nodes = deps
     task.env['OUTPUT_DIR'] = self.output_dir.abspath()
 
     task.env.env = dict(os.environ)
@@ -73,5 +84,4 @@ def configure(cfg):
     """
     env = cfg.env
     env.DC_DSDL_COMPILER_DIR = cfg.srcnode.make_node('modules/DroneCAN/dronecan_dsdlc/').abspath()
-    env.DC_DSDL_COMPILER = env.DC_DSDL_COMPILER_DIR + '/dronecan_dsdlc.py'
-    cfg.msg('DC_DSDL compiler', env.DC_DSDL_COMPILER)
+    cfg.msg('DC_DSDL compiler in', env.DC_DSDL_COMPILER_DIR)


### PR DESCRIPTION
Have the build depend on the input message definition files and the generator source code so that the code is regenerated if either change.

Also remove the separate env variable for the compiler path as we want to look through the directory and neither can be set by the user anyway AFAIK.