### PR TITLE
Sub: small guided mode fixes

### DIFF
--- a/ArduSub/mode_guided.cpp
+++ b/ArduSub/mode_guided.cpp
@@ -165,11 +165,6 @@ void ModeGuided::guided_angle_control_start()
 // else return false if the waypoint is outside the fence
 bool ModeGuided::guided_set_destination(const Vector3f& destination)
 {
-    // ensure we are in position control mode
-    if (sub.guided_mode != Guided_WP) {
-        guided_pos_control_start();
-    }
-
 #if AP_FENCE_ENABLED
     // reject destination if outside the fence
     const Location dest_loc(destination, Location::AltFrame::ABOVE_ORIGIN);
@@ -179,6 +174,11 @@ bool ModeGuided::guided_set_destination(const Vector3f& destination)
         return false;
     }
 #endif
+
+    // ensure we are in position control mode
+    if (sub.guided_mode != Guided_WP) {
+        guided_pos_control_start();
+    }
 
     // no need to check return status because terrain data is not used
     sub.wp_nav.set_wp_destination(destination, false);
@@ -196,11 +196,6 @@ bool ModeGuided::guided_set_destination(const Vector3f& destination)
 // or if the fence is enabled and guided waypoint is outside the fence
 bool ModeGuided::guided_set_destination(const Location& dest_loc)
 {
-    // ensure we are in position control mode
-    if (sub.guided_mode != Guided_WP) {
-        guided_pos_control_start();
-    }
-
 #if AP_FENCE_ENABLED
     // reject destination outside the fence.
     // Note: there is a danger that a target specified as a terrain altitude might not be checked if the conversion to alt-above-home fails
@@ -210,6 +205,11 @@ bool ModeGuided::guided_set_destination(const Location& dest_loc)
         return false;
     }
 #endif
+
+    // ensure we are in position control mode
+    if (sub.guided_mode != Guided_WP) {
+        guided_pos_control_start();
+    }
 
     if (!sub.wp_nav.set_wp_destination_loc(dest_loc)) {
         // failure to set destination can only be because of missing terrain data
@@ -231,11 +231,6 @@ bool ModeGuided::guided_set_destination(const Location& dest_loc)
 // else return false if the waypoint is outside the fence
 bool ModeGuided::guided_set_destination(const Vector3f& destination, bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_yaw)
 {
-    // ensure we are in position control mode
-    if (sub.guided_mode != Guided_WP) {
-        guided_pos_control_start();
-    }
-
 #if AP_FENCE_ENABLED
     // reject destination if outside the fence
     const Location dest_loc(destination, Location::AltFrame::ABOVE_ORIGIN);
@@ -245,6 +240,11 @@ bool ModeGuided::guided_set_destination(const Vector3f& destination, bool use_ya
         return false;
     }
 #endif
+
+    // ensure we are in position control mode
+    if (sub.guided_mode != Guided_WP) {
+        guided_pos_control_start();
+    }
 
     // set yaw state
     guided_set_yaw_state(use_yaw, yaw_cd, use_yaw_rate, yaw_rate_cds, relative_yaw);
@@ -297,11 +297,6 @@ void ModeGuided::guided_set_velocity(const Vector3f& velocity, bool use_yaw, flo
 // set guided mode posvel target
 bool ModeGuided::guided_set_destination_posvel(const Vector3f& destination, const Vector3f& velocity)
 {
-    // check we are in velocity control mode
-    if (sub.guided_mode != Guided_PosVel) {
-        guided_posvel_control_start();
-    }
-
 #if AP_FENCE_ENABLED
     // reject destination if outside the fence
     const Location dest_loc(destination, Location::AltFrame::ABOVE_ORIGIN);
@@ -311,6 +306,11 @@ bool ModeGuided::guided_set_destination_posvel(const Vector3f& destination, cons
         return false;
     }
 #endif
+
+    // check we are in posvel control mode
+    if (sub.guided_mode != Guided_PosVel) {
+        guided_posvel_control_start();
+    }
 
     update_time_ms = AP_HAL::millis();
     posvel_pos_target_cm = destination.topostype();
@@ -332,11 +332,6 @@ bool ModeGuided::guided_set_destination_posvel(const Vector3f& destination, cons
 // set guided mode posvel target
 bool ModeGuided::guided_set_destination_posvel(const Vector3f& destination, const Vector3f& velocity, bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_yaw)
 {
-    // check we are in velocity control mode
-    if (sub.guided_mode != Guided_PosVel) {
-        guided_posvel_control_start();
-    }
-
     #if AP_FENCE_ENABLED
     // reject destination if outside the fence
     const Location dest_loc(destination, Location::AltFrame::ABOVE_ORIGIN);
@@ -346,6 +341,11 @@ bool ModeGuided::guided_set_destination_posvel(const Vector3f& destination, cons
         return false;
     }
     #endif
+
+    // check we are in posvel control mode
+    if (sub.guided_mode != Guided_PosVel) {
+        guided_posvel_control_start();
+    }
 
     // set yaw state
     guided_set_yaw_state(use_yaw, yaw_cd, use_yaw_rate, yaw_rate_cds, relative_yaw);
@@ -371,7 +371,7 @@ bool ModeGuided::guided_set_destination_posvel(const Vector3f& destination, cons
 // set guided mode angle target
 void ModeGuided::guided_set_angle(const Quaternion &q, float climb_rate_cms)
 {
-    // check we are in velocity control mode
+    // check we are in angle control mode
     if (sub.guided_mode != Guided_Angle) {
         guided_angle_control_start();
     }

--- a/ArduSub/mode_guided.cpp
+++ b/ArduSub/mode_guided.cpp
@@ -93,6 +93,7 @@ void ModeGuided::guided_pos_control_start()
     sub.wp_nav.set_wp_destination(stopping_point, false);
 
     // initialise yaw
+    sub.yaw_rate_only = false;
     set_auto_yaw_mode(get_default_auto_yaw_mode(false));
 }
 
@@ -111,6 +112,7 @@ void ModeGuided::guided_vel_control_start()
     position_control->init_xy_controller();
 
     // pilot always controls yaw
+    sub.yaw_rate_only = false;
     set_auto_yaw_mode(AUTO_YAW_HOLD);
 }
 
@@ -129,6 +131,7 @@ void ModeGuided::guided_posvel_control_start()
     position_control->init_xy_controller();
 
     // pilot always controls yaw
+    sub.yaw_rate_only = false;
     set_auto_yaw_mode(AUTO_YAW_HOLD);
 }
 
@@ -153,6 +156,7 @@ void ModeGuided::guided_angle_control_start()
     guided_angle_state.climb_rate_cms = 0.0f;
 
     // pilot always controls yaw
+    sub.yaw_rate_only = false;
     set_auto_yaw_mode(AUTO_YAW_HOLD);
 }
 


### PR DESCRIPTION
This PR slightly improves sub guided mode:
* Test the destination against the fence before changing the submode. With this change, the submode is not changed if we return false. This matches the behavior in copter.
* Initialize `sub.yaw_rate_only` in all `guided_set_*` calls, so that any submode change starts from the same default
* Fix a few comments