### PR TITLE
Copter: The failsafe enable flag should be cleared on cold reset

### DIFF
--- a/ArduCopter/failsafe.cpp
+++ b/ArduCopter/failsafe.cpp
@@ -7,7 +7,7 @@
 //  our failsafe strategy is to detect main loop lockup and disarm the motors
 //
 
-static bool failsafe_enabled = false;
+static bool failsafe_enabled;
 static uint16_t failsafe_last_ticks;
 static uint32_t failsafe_last_timestamp;
 static bool in_failsafe;


### PR DESCRIPTION
In the `init_ardupilot` method, failsafe is forced enabled after initialization. 
If previous settings are used on reboot, this forced enablement seems unnecessary. 
Therefore, assign the failsafe enable flag to a variable area that is initialized to 0 along with a cold reset. 
