### PR TITLE
Tools: Remove bionic support for ubuntu setup

### DIFF
--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -83,10 +83,8 @@ PYTHON_V="python3"  # starting from ubuntu 20.04, python isn't symlink to defaul
 PIP=pip3
 
 if [ ${RELEASE_CODENAME} == 'bionic' ] ; then
-    SITLFML_VERSION="2.4"
-    SITLCFML_VERSION="2.4"
-    PYTHON_V="python3"
-    PIP=pip3
+    echo "ArduPilot no longer supports developing on this operating system that has reached end of standard support."
+    exit 1
 elif [ ${RELEASE_CODENAME} == 'bookworm' ]; then
     SITLFML_VERSION="2.5"
     SITLCFML_VERSION="2.5"


### PR DESCRIPTION
# Purpose

Remove  ubuntu bionic support. This makes https://github.com/ArduPilot/ardupilot/pull/28056 easer because `python3-pygame` is available in Ubuntu focal (20) and onward.

# Details

Ubuntu 18.04 (bionic) is EOL.
https://ubuntu.com/18-04

