### PR TITLE
AP_HAL_ChibiOS: check nullptr 'name' variable

### DIFF
--- a/libraries/AP_HAL_ChibiOS/Device.cpp
+++ b/libraries/AP_HAL_ChibiOS/Device.cpp
@@ -111,6 +111,9 @@ AP_HAL::Device::PeriodicHandle DeviceBus::register_periodic_callback(uint32_t pe
         // setup a name for the thread
         const uint8_t name_len = 7;
         char *name = (char *)malloc(name_len);
+        if (name == nullptr){
+            return nullptr;
+        }
         switch (hal_device->bus_type()) {
         case AP_HAL::Device::BUS_TYPE_I2C:
             snprintf(name, name_len, "I2C%u",


### PR DESCRIPTION
HI there
This PR description.
-> Check nullptr before using the  'name' variable assigned from malloc()