### PR TITLE
CI: build CubeRed-EKF2 not CubeOrange-EKF2 in CI

### DIFF
--- a/.github/workflows/test_chibios.yml
+++ b/.github/workflows/test_chibios.yml
@@ -156,7 +156,7 @@ jobs:
             build-options-defaults-test,
             signing,
             CubeOrange-PPP,
-            CubeOrange-EKF2,
+            CubeRed-EKF2,
             SOHW,
             Pixhawk6X-PPPGW,
             new-check,

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -327,9 +327,9 @@ for t in $CI_BUILD_TARGET; do
         continue
     fi
 
-    if [ "$t" == "CubeOrange-EKF2" ]; then
-        echo "Building CubeOrange with EKF2 enabled"
-        $waf configure --board CubeOrange --enable-EKF2
+    if [ "$t" == "CubeRed-EKF2" ]; then
+        echo "Building CubeRed with EKF2 enabled"
+        $waf configure --board CubeRedPrimary --enable-EKF2
         $waf clean
         $waf copter
         continue


### PR DESCRIPTION
we really just care that EKF2 builds here, the board really isn't that important