### PR TITLE
Copter: guided: `set_angle` call `init_z_controller` when changing from thrust to climb rate control to avoid flow of control error

### DIFF
--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -652,6 +652,9 @@ void ModeGuided::set_angle(const Quaternion &attitude_quat, const Vector3f &ang_
     // check we are in velocity control mode
     if (guided_mode != SubMode::Angle) {
         angle_control_start();
+    } else if (!use_thrust && guided_angle_state.use_thrust) {
+        // Already angle control but changing from thrust to climb rate
+        pos_control->init_z_controller();
     }
 
     guided_angle_state.attitude_quat = attitude_quat;


### PR DESCRIPTION
We init the Z controller when we fist enter the angle sub mode of guided. However if you send throttle commands the Z controller is not used, if you then change to sending climb rate commands while remaining in angle sub mode you trigger this flow of control error in the pos controller:

https://github.com/ArduPilot/ardupilot/blob/a9ea760cadfddf39434cb3b7dbcf8533f6c4fb1a/libraries/AC_AttitudeControl/AC_PosControl.cpp#L961-L969

extract from https://github.com/ArduPilot/ardupilot/pull/28110