### PR TITLE
Copter: GCS_MAVLink: populate flags using position controller active flags

### DIFF
--- a/ArduCopter/GCS_Copter.cpp
+++ b/ArduCopter/GCS_Copter.cpp
@@ -42,39 +42,22 @@ void GCS_Copter::update_vehicle_sensor_status_flags(void)
         MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION |
         MAV_SYS_STATUS_SENSOR_YAW_POSITION;
 
-    // update flightmode-specific flags:
-    control_sensors_present |= MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL;
-    control_sensors_present |= MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL;
+    // Update position controller flags
+    if (copter.pos_control != nullptr) {
+        control_sensors_present |= MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL;
+        control_sensors_present |= MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL;
 
-    switch (copter.flightmode->mode_number()) {
-    case Mode::Number::AUTO:
-    case Mode::Number::AUTO_RTL:
-    case Mode::Number::AVOID_ADSB:
-    case Mode::Number::GUIDED:
-    case Mode::Number::LOITER:
-    case Mode::Number::RTL:
-    case Mode::Number::CIRCLE:
-    case Mode::Number::LAND:
-    case Mode::Number::POSHOLD:
-    case Mode::Number::BRAKE:
-    case Mode::Number::THROW:
-    case Mode::Number::SMART_RTL:
-        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL;
-        control_sensors_health |= MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL;
-        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL;
-        control_sensors_health |= MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL;
-        break;
-    case Mode::Number::ALT_HOLD:
-    case Mode::Number::GUIDED_NOGPS:
-    case Mode::Number::SPORT:
-    case Mode::Number::AUTOTUNE:
-    case Mode::Number::FLOWHOLD:
-        control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL;
-        control_sensors_health |= MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL;
-        break;
-    default:
-        // stabilize, acro, drift, and flip have no automatic x,y or z control (i.e. all manual)
-        break;
+        // XY position controller
+        if (copter.pos_control->is_active_xy()) {
+            control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL;
+            control_sensors_health |= MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL;
+        }
+
+        // Z altitude controller
+        if (copter.pos_control->is_active_z()) {
+            control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL;
+            control_sensors_health |= MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL;
+        }
     }
 
     // optional sensors, some of which are essentially always

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -37,25 +37,11 @@ MAV_MODE GCS_MAVLINK_Copter::base_mode() const
     // only get useful information from the custom_mode, which maps to
     // the APM flight mode and has a well defined meaning in the
     // ArduPlane documentation
-    switch (copter.flightmode->mode_number()) {
-    case Mode::Number::AUTO:
-    case Mode::Number::AUTO_RTL:
-    case Mode::Number::RTL:
-    case Mode::Number::LOITER:
-    case Mode::Number::AVOID_ADSB:
-    case Mode::Number::FOLLOW:
-    case Mode::Number::GUIDED:
-    case Mode::Number::CIRCLE:
-    case Mode::Number::POSHOLD:
-    case Mode::Number::BRAKE:
-    case Mode::Number::SMART_RTL:
+    if ((copter.pos_control != nullptr) && copter.pos_control->is_active_xy()) {
         _base_mode |= MAV_MODE_FLAG_GUIDED_ENABLED;
         // note that MAV_MODE_FLAG_AUTO_ENABLED does not match what
         // APM does in any mode, as that is defined as "system finds its own goal
         // positions", which APM does not currently do
-        break;
-    default:
-        break;
     }
 
     // all modes except INITIALISING have some form of manual


### PR DESCRIPTION
This means we don't need to switch on the mode number, extracted from https://github.com/ArduPilot/ardupilot/pull/28110 

This is the first time we will be using these flags for reporting, until now it is used internally only. There are some changes in behaviour, for example you can be landed in auto mode in which case the pos controller may not report as active (i need to check). 