### PR TITLE
AntennaTracker: refuse to track (0;0)

### DIFF
--- a/AntennaTracker/tracking.cpp
+++ b/AntennaTracker/tracking.cpp
@@ -131,6 +131,11 @@ void Tracker::update_tracking(void)
  */
 void Tracker::tracking_update_position(const mavlink_global_position_int_t &msg)
 {
+    // reject (0;0) coordinates
+    if (!msg.lat && !msg.lon) {
+        return;
+    }
+
     vehicle.location.lat = msg.lat;
     vehicle.location.lng = msg.lon;
     vehicle.location.alt = msg.alt/10;
@@ -139,7 +144,7 @@ void Tracker::tracking_update_position(const mavlink_global_position_int_t &msg)
     vehicle.last_update_us = AP_HAL::micros();
     vehicle.last_update_ms = AP_HAL::millis();
 #if HAL_LOGGING_ENABLED
-    // log vehicle as GPS2
+    // log vehicle as VPOS
     if (should_log(MASK_LOG_GPS)) {
         Log_Write_Vehicle_Pos(vehicle.location.lat, vehicle.location.lng, vehicle.location.alt, vehicle.vel);
     }


### PR DESCRIPTION
I'm playing with Olimex g-Link GPS/LTE (Qualcomm EC25) unit for my setup and I've noticed that it seem to be throwing zero coordinates at some stage during the module startup. I can't seem to pinpoint the exact source of the message in my telemetry log, but the dataflash log from the tracker pretty convincingly shows that there were a couple of zero datapoints incoming so it's definitely that can somehow happen in the wild:
![VPOS Lat](https://github.com/user-attachments/assets/f8b3086d-92ac-453f-8568-9196e9619cce)

Consequently, the tracker wanted to execute a sharp turn since its target jumped about 130° and since it's in the middle of the ocean very far away from me, the minimum tracking distance condition did not help either.

This change prevents such behavior from ever taking place.

I wanted to add this to my [bigger WIP PR on the tracker](https://github.com/ArduPilot/ardupilot/pull/27676) but it's probably a benign change that can be applied as is. Will fly-test on the weekend if there are doubts that it might break anything.

I also changed an outdated comment since both the code, the log and the documentation seem to agree that the vehicle position is logged as `VPOS` and not as `GPS2`.