### PR TITLE
GCS_MAVLink: Add conditions and delete the same processing

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3212,13 +3212,8 @@ MAV_RESULT GCS_MAVLINK::handle_command_get_message_interval(const mavlink_comman
     }
 
     uint16_t interval_ms = 0;
-    if (!get_ap_message_interval(id, interval_ms)) {
+    if (!get_ap_message_interval(id, interval_ms) || interval_ms == 0) {
         // not streaming this message at the moment...
-        mavlink_msg_message_interval_send(chan, mavlink_id, -1); // disabled
-        return MAV_RESULT_ACCEPTED;
-    }
-
-    if (interval_ms == 0) {
         mavlink_msg_message_interval_send(chan, mavlink_id, -1); // disabled
         return MAV_RESULT_ACCEPTED;
     }


### PR DESCRIPTION
Since it returns the same result, we'll add it to the condition of the IF statement. 
Regarding memory, the TEXT segment decreases, the BSS segment increases, and the overall size remains unchanged.


AFTER
BUILD SUMMARY
Build directory: /home/parallels/work2/ardupilot/build/fmuv3
Target          Text (B)  Data (B)  BSS (B)  Total Flash Used (B)  Free Flash (B)  External Flash Used (B)

bin/arducopter   1558257      3892   192868               1562149          518604  Not Applicable  

BEFORE
BUILD SUMMARY
Build directory: /home/parallels/work2/ardupilot/build/fmuv3
Target          Text (B)  Data (B)  BSS (B)  Total Flash Used (B)  Free Flash (B)  External Flash Used (B)

bin/arducopter   1558261      3892   192864               1562153          518604  Not Applicable  