### PR TITLE
AP_BattMonitor: add option minimum volt option

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_ESC.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_ESC.cpp
@@ -57,6 +57,7 @@ void AP_BattMonitor_ESC::read(void)
     uint8_t voltage_escs = 0;     // number of ESCs with valid voltage
     uint8_t temperature_escs = 0; // number of ESCs with valid temperature
     float voltage_sum = 0;
+    float voltage_min = 0;
     float current_sum = 0;
     float temperature_sum = 0;
     float consumed_mah_sum = 0.0;
@@ -82,6 +83,9 @@ void AP_BattMonitor_ESC::read(void)
         }
 
         if (telem.get_voltage(i, voltage)) {
+            if (voltage_escs == 0 || voltage_min > voltage) {
+                voltage_min = voltage;
+            }
             voltage_sum += voltage;
             voltage_escs++;
         }
@@ -132,6 +136,12 @@ void AP_BattMonitor_ESC::read(void)
         // ESCs provide current but not consumed mah, integrate manually
         update_consumed(_state, dt_us);
 
+    }
+
+    // Check if we want to report the minimum voltage instead of the average
+    // (we do this after calculating consumed Wh so this doesn't affect that calculation)
+    if (option_is_set(AP_BattMonitor_Params::Options::Minimum_Voltage)) {
+        _state.voltage = voltage_min;
     }
 }
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
@@ -154,7 +154,7 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: Battery monitor options
     // @Description: This sets options to change the behaviour of the battery monitor
-    // @Bitmask: 0:Ignore DroneCAN SoC, 1:MPPT reports input voltage and current, 2:MPPT Powered off when disarmed, 3:MPPT Powered on when armed, 4:MPPT Powered off at boot, 5:MPPT Powered on at boot, 6:Send resistance compensated voltage to GCS, 7:Allow DroneCAN InfoAux to be from a different CAN node
+    // @Bitmask: 0:Ignore DroneCAN SoC, 1:MPPT reports input voltage and current, 2:MPPT Powered off when disarmed, 3:MPPT Powered on when armed, 4:MPPT Powered off at boot, 5:MPPT Powered on at boot, 6:Send resistance compensated voltage to GCS, 7:Allow DroneCAN InfoAux to be from a different CAN node, 9:Report minimum voltage instead of average (ESC/SUM monitors only)
     // @User: Advanced
     AP_GROUPINFO("OPTIONS", 21, AP_BattMonitor_Params, _options, 0),
 #endif // HAL_BUILD_AP_PERIPH

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
@@ -27,6 +27,7 @@ public:
         GCS_Resting_Voltage                 = (1U<<6),  // send resistance resting voltage to GCS
         AllowSplitAuxInfo                   = (1U<<7),  // allow different node to provide aux info for DroneCAN
         InternalUseOnly                     = (1U<<8),  // for use internally to ArduPilot, not to be (eg.) sent via MAVLink BATTERY_STATUS
+        Minimum_Voltage                     = (1U<<9),  // aggregate monitors report minimum voltage rather than average
     };
 
     BattMonitor_LowVoltage_Source failsafe_voltage_source(void) const { return (enum BattMonitor_LowVoltage_Source)_failsafe_voltage_source.get(); }


### PR DESCRIPTION
Allows aggregate monitors like Sum and ESC to report the minimum voltage instead of the average voltage. This is useful for systems with multiple isolated batteries where the lowest voltage is the limiting factor.

@robertlong13 