### PR TITLE
Use get_channel_yaw() and friends in AP_Arming

### DIFF
--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -26,6 +26,12 @@ public:
         RANGE = 1,
     };
 
+    // ch returns the radio channel be read, starting at 1.  so
+    // typically Roll=1, Pitch=2, throttle=3, yaw=4.  If this returns
+    // 0 then this is the dummy object which means that one of roll,
+    // pitch, yaw or throttle has not been configured correctly.
+    uint8_t ch() const { return ch_in + 1; }
+
     // setup the control preferences
     void        set_range(uint16_t high);
     uint16_t    get_range() const { return high_in; }


### PR DESCRIPTION
We have methods which return you the relevant channels (or a dummy if your vehicle is mis-configured).

Use them.

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                                       
Durandal                            -48    *           -48     -48               -48    -48    -48
Hitec-Airspeed           *                                                       
KakuteH7-bdshot                     -64    *           -56     -64               -64    -64    -64
MatekF405                           -56    *           -56     -64               -56    -56    -56
Pixhawk1-1M-bdshot                  -64                -56     -64               -64    -40    40
f103-QiotekPeriph        *                                                       
f303-Universal           *                                                       
iomcu                                                                *           
revo-mini                           -56    *           -64     -64               -64    -56    -56
skyviper-v2450                                         -64                       
```

We appear to faithfully copy what master does here:
```
MANUAL> arm throttle
MANUAL> Got COMMAND_ACK: COMPONENT_ARM_DISARM: ACCEPTED
AP: Throttle armed
ARMED

MANUAL> 
MANUAL> param show RCMAP*
MANUAL> RCMAP_PITCH      2
RCMAP_ROLL       45
RCMAP_THROTTLE   3
RCMAP_YAW        56
Flight battery 100 percent
```

We'll need to get a lot more complicated than a single-bit "enforce RPY are neutral" to do better here.
