### PR TITLE
AP_TemperatureSensor: new MLX90614 sensor backend driver conversion fix

### DIFF
--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_MLX90614.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_MLX90614.cpp
@@ -48,7 +48,7 @@ void AP_TemperatureSensor_MLX90614::_timer()
     WITH_SEMAPHORE(_dev->get_semaphore());
         
     // temp * 0.02 - 273.15 = degrees, temp * 0.02 is temperature in kelvin
-    const float tmp = KELVIN_TO_C(_crude_value) * 0.02;
+    const float tmp = KELVIN_TO_C(_crude_value * 0.02);
     set_temperature(tmp);
 }
 


### PR DESCRIPTION
There was conversion error in the PR #26886 which I fixed here, while testing I haven't used `KELVIN_TO_C` for conversion from kelvin to Celsius degrees.

Correct formula for conversion:
`Temperature_read(in celsius degrees) = _crude_value * 0.02 - 273.15`

I have just tested the corrected one. I apologize for the inconvenience caused.
![temp_fixure](https://github.com/user-attachments/assets/669aa63e-e9d9-4e2a-8405-7b9804d04718)
