### PR TITLE
AP_Bootloader: reserve new board ID for FlysparkF4

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -298,6 +298,8 @@ AP_HW_CBUnmanned-CM405-FC            1301
 
 AP_HW_KHA_ETH                        1315
 
+AP_HW_FlysparkF4                     1361
+
 AP_HW_CUBEORANGE_PERIPH              1400
 AP_HW_CUBEBLACK_PERIPH               1401
 AP_HW_PIXRACER_PERIPH                1402


### PR DESCRIPTION
Reserve bootloader ID FlysparkF4 1361. The hwdef is under development and a new PR will be coming soon