### PR TITLE
AP_ExternalAHRS: Change GPS to GNSS

### DIFF
--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_InertialLabs.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_InertialLabs.cpp
@@ -254,13 +254,13 @@ bool AP_ExternalAHRS_InertialLabs::check_uart()
         msg_types.set(unsigned(mtype));
 
         switch (mtype) {
-        case MessageType::GPS_INS_TIME_MS: {
-            // this is the GPS tow timestamp in ms for when the IMU data was sampled
+        case MessageType::GNSS_INS_TIME_MS: {
+            // this is the GNSS tow timestamp in ms for when the IMU data was sampled
             CHECK_SIZE(u.gnss_time_ms);
             gps_data.ms_tow = u.gnss_time_ms;
             break;
         }
-        case MessageType::GPS_WEEK: {
+        case MessageType::GNSS_WEEK: {
             CHECK_SIZE(u.gnss_week);
             gps_data.gps_week = u.gnss_week;
             break;
@@ -505,7 +505,7 @@ bool AP_ExternalAHRS_InertialLabs::check_uart()
 #endif // HAL_LOGGING_ENABLED
     }
 
-    if (GOT_MSG(GPS_INS_TIME_MS) &&
+    if (GOT_MSG(GNSS_INS_TIME_MS) &&
         GOT_MSG(NUM_SATS) &&
         GOT_MSG(GNSS_POSITION) &&
         GOT_MSG(GNSS_NEW_DATA) &&

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_InertialLabs.h
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_InertialLabs.h
@@ -50,8 +50,8 @@ public:
     }
 
     enum class MessageType : uint8_t {
-        GPS_INS_TIME_MS = 0x01,
-        GPS_WEEK = 0x3C,
+        GNSS_INS_TIME_MS = 0x01,
+        GNSS_WEEK = 0x3C,
         ACCEL_DATA_HR = 0x23,
         GYRO_DATA_HR = 0x21,
         BARO_DATA = 0x25,


### PR DESCRIPTION
The element name in message_ofs is set to GNSS.
I will change the definition name to match the element name.

