### PR TITLE
Rover: remove handling of prearm empty-string case

### DIFF
--- a/Rover/AP_Arming.cpp
+++ b/Rover/AP_Arming.cpp
@@ -168,12 +168,7 @@ bool AP_Arming_Rover::oa_check(bool report)
         return true;
     }
 
-    // display failure
-    if (strlen(failure_msg) == 0) {
-        check_failed(report, "Check Object Avoidance");
-    } else {
-        check_failed(report, "%s", failure_msg);
-    }
+    check_failed(report, "%s", failure_msg);
     return false;
 }
 #endif  // AP_OAPATHPLANNER_ENABLED


### PR DESCRIPTION
it is clear by inspection that this string can never be empty when the called function returns false.  AP_OAPathPlanner::pre_arm_check is not that complicated!

Lightly tested in SITL by setting `OA_TYPE` to an invalid value

Replaces https://github.com/ArduPilot/ardupilot/pull/26963/files
