### PR TITLE
AP_Compass: use memcmp to check whoami result code from HMC5843 device

### DIFF
--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -334,9 +334,7 @@ bool AP_Compass_HMC5843::_check_whoami()
         // can't talk on bus
         return false;        
     }
-    if (id[0] != 'H' ||
-        id[1] != '4' ||
-        id[2] != '3') {
+    if (memcmp(id, "H43", 3) != 0) {
         // not a HMC5x83 device
         return false;
     }


### PR DESCRIPTION
Replaces https://github.com/ArduPilot/ardupilot/pull/24832/files

Tested on a revo-mini (broke it / fixed it to make sure this codepath was crossed)

