### PR TITLE
correct initialisation of PrecLand buffers

### DIFF
--- a/ArduCopter/precision_landing.cpp
+++ b/ArduCopter/precision_landing.cpp
@@ -8,7 +8,9 @@
 
 void Copter::init_precland()
 {
-    copter.precland.init(400);
+    // scheduler table specifies 400Hz, but we can call it no faster
+    // than the scheduler loop rate:
+    copter.precland.init(MIN(400, scheduler.get_loop_rate_hz()));
 }
 
 void Copter::update_precland()

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -162,7 +162,9 @@ void Plane::init_ardupilot()
 #endif
 
 #if AC_PRECLAND_ENABLED
-    g2.precland.init(scheduler.get_loop_rate_hz());
+    // scheduler table specifies 400Hz, but we can call it no faster
+    // than the scheduler loop rate:
+    g2.precland.init(MIN(400, scheduler.get_loop_rate_hz()));
 #endif
 
 #if AP_ICENGINE_ENABLED

--- a/Rover/precision_landing.cpp
+++ b/Rover/precision_landing.cpp
@@ -8,7 +8,9 @@
 
 void Rover::init_precland()
 {
-    rover.precland.init(400);
+    // scheduler table specifies 400Hz, but we can call it no faster
+    // than the scheduler loop rate:
+    rover.precland.init(MIN(400, scheduler.get_loop_rate_hz()));
 }
 
 void Rover::update_precland()

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -4,7 +4,6 @@
 
 #include "AC_PrecLand.h"
 #include <AP_HAL/AP_HAL.h>
-#include <AP_Scheduler/AP_Scheduler.h>
 #include <AP_AHRS/AP_AHRS.h>
 
 #include "AC_PrecLand_Backend.h"
@@ -226,7 +225,7 @@ void AC_PrecLand::init(uint16_t update_rate_hz)
     _lag.set(constrain_float(_lag, 0.02f, 0.25f));  // must match LAG parameter range at line 124
 
     // calculate inertial buffer size from lag and minimum of main loop rate and update_rate_hz argument
-    const uint16_t inertial_buffer_size = MAX((uint16_t)roundf(_lag * MIN(update_rate_hz, AP::scheduler().get_loop_rate_hz())), 1);
+    const uint16_t inertial_buffer_size = MAX((uint16_t)roundf(_lag * update_rate_hz), 1);
 
     // instantiate ring buffer to hold inertial history, return on failure so no backends are created
     _inertial_history = NEW_NOTHROW ObjectArray<inertial_data_frame_s>(inertial_buffer_size);


### PR DESCRIPTION
this value determines the size of buffers allocated.

Too high and you waste RAM.  Too low and you probably won't store data correctly.

Replaces https://github.com/ArduPilot/ardupilot/pull/13842/files 


