### PR TITLE
Adjust includes to help prevent loops

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_config.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_config.h
@@ -2,8 +2,6 @@
 
 #include <AP_HAL/AP_HAL_Boards.h>
 
-#include <AP_Mission/AP_Mission_config.h>
-
 // backends:
 
 #ifndef AP_FILESYSTEM_ESP32_ENABLED
@@ -12,10 +10,6 @@
 
 #ifndef AP_FILESYSTEM_FATFS_ENABLED
 #define AP_FILESYSTEM_FATFS_ENABLED HAL_OS_FATFS_IO
-#endif
-
-#ifndef AP_FILESYSTEM_MISSION_ENABLED
-#define AP_FILESYSTEM_MISSION_ENABLED AP_MISSION_ENABLED
 #endif
 
 #ifndef AP_FILESYSTEM_PARAM_ENABLED
@@ -61,4 +55,9 @@
 
 #ifndef AP_FILESYSTEM_HAVE_DIRENT_DTYPE
 #define AP_FILESYSTEM_HAVE_DIRENT_DTYPE 1
+#endif
+
+#ifndef AP_FILESYSTEM_MISSION_ENABLED
+#include <AP_Mission/AP_Mission_config.h>
+#define AP_FILESYSTEM_MISSION_ENABLED AP_MISSION_ENABLED
 #endif

--- a/libraries/AP_Mount/AP_Mount_config.h
+++ b/libraries/AP_Mount/AP_Mount_config.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <AP_HAL/AP_HAL_Boards.h>
-#include <AP_Terrain/AP_Terrain.h>
+#include <AP_Terrain/AP_Terrain_config.h>
 
 #ifndef HAL_MOUNT_ENABLED
 #define HAL_MOUNT_ENABLED 1

--- a/libraries/AP_SerialManager/AP_SerialManager_config.h
+++ b/libraries/AP_SerialManager/AP_SerialManager_config.h
@@ -19,7 +19,7 @@
  */
 #pragma once
 
-#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/AP_HAL_Boards.h>
 #include <AP_Networking/AP_Networking_Config.h>
 #include <AP_InertialSensor/AP_InertialSensor_config.h>
 

--- a/libraries/AP_Terrain/AP_Terrain.h
+++ b/libraries/AP_Terrain/AP_Terrain.h
@@ -14,12 +14,7 @@
  */
 #pragma once
 
-#include <AP_HAL/AP_HAL_Boards.h>
-#include <AP_Filesystem/AP_Filesystem_config.h>
-
-#ifndef AP_TERRAIN_AVAILABLE
-#define AP_TERRAIN_AVAILABLE AP_FILESYSTEM_FILE_READING_ENABLED
-#endif
+#include "AP_Terrain_config.h"
 
 #if AP_TERRAIN_AVAILABLE
 

--- a/libraries/AP_Terrain/AP_Terrain_config.h
+++ b/libraries/AP_Terrain/AP_Terrain_config.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <AP_HAL/AP_HAL_Boards.h>
+#include <AP_Filesystem/AP_Filesystem_config.h>
+
+#ifndef AP_TERRAIN_AVAILABLE
+#define AP_TERRAIN_AVAILABLE AP_FILESYSTEM_FILE_READING_ENABLED
+#endif


### PR DESCRIPTION
Having trouble avoiding loops involving filesystem config and logger; adjust includes to prevent unnecessary include paths.
