### PR TITLE
AntennaTracker: logging option for telemetry radio status

### DIFF
--- a/AntennaTracker/GCS_Mavlink.h
+++ b/AntennaTracker/GCS_Mavlink.h
@@ -2,6 +2,8 @@
 
 #include <GCS_MAVLink/GCS.h>
 
+#include "defines.h"
+
 class GCS_MAVLINK_Tracker : public GCS_MAVLINK
 {
 
@@ -29,6 +31,10 @@ protected:
 
     void send_nav_controller_output() const override;
     void send_pid_tuning() override;
+
+#if HAL_LOGGING_ENABLED
+    uint32_t log_radio_bit() const override { return MASK_LOG_RADIO; }
+#endif
 
 private:
 

--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -264,7 +264,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: LOG_BITMASK
     // @DisplayName: Log bitmask
     // @Description: 4 byte bitmap of log types to enable
-    // @Bitmask: 0:ATTITUDE,1:GPS,2:RCIN,3:IMU,4:RCOUT,5:COMPASS,6:Battery
+    // @Bitmask: 0:ATTITUDE,1:GPS,2:RCIN,3:IMU,4:RCOUT,5:COMPASS,6:Battery,7:Radio
     // @User: Standard
     GSCALAR(log_bitmask, "LOG_BITMASK", DEFAULT_LOG_BITMASK),
 

--- a/AntennaTracker/defines.h
+++ b/AntennaTracker/defines.h
@@ -22,7 +22,7 @@ enum class PWMDisarmed {
 
 //  Filter
 #define SERVO_OUT_FILT_HZ               0.1f
-#define G_Dt                            0.02f
+#define SERVO_G_Dt                      0.02f
 
 //  Logging parameters
 #define MASK_LOG_ATTITUDE               (1<<0)
@@ -32,6 +32,7 @@ enum class PWMDisarmed {
 #define MASK_LOG_RCOUT                  (1<<4)
 #define MASK_LOG_COMPASS                (1<<5)
 #define MASK_LOG_CURRENT                (1<<6)
+#define MASK_LOG_RADIO                  (1<<7)
 #define MASK_LOG_ANY                    0xFFFF
 
 //  Logging messages - only 32 messages are available to the vehicle here.

--- a/AntennaTracker/servos.cpp
+++ b/AntennaTracker/servos.cpp
@@ -74,7 +74,7 @@ void Tracker::update_pitch_position_servo()
     // PITCH2SRV_IMAX   4000.000000
 
     // calculate new servo position
-    float new_servo_out = SRV_Channels::get_output_scaled(SRV_Channel::k_tracker_pitch) + g.pidPitch2Srv.update_error(nav_status.angle_error_pitch, G_Dt);
+    float new_servo_out = SRV_Channels::get_output_scaled(SRV_Channel::k_tracker_pitch) + g.pidPitch2Srv.update_error(nav_status.angle_error_pitch, SERVO_G_Dt);
 
     // position limit pitch servo
     if (new_servo_out <= pitch_min_cd) {
@@ -89,7 +89,7 @@ void Tracker::update_pitch_position_servo()
     SRV_Channels::set_output_scaled(SRV_Channel::k_tracker_pitch, new_servo_out);
 
     if (pitch_servo_out_filt_init) {
-        pitch_servo_out_filt.apply(new_servo_out, G_Dt);
+        pitch_servo_out_filt.apply(new_servo_out, SERVO_G_Dt);
     } else {
         pitch_servo_out_filt.reset(new_servo_out);
         pitch_servo_out_filt_init = true;
@@ -125,7 +125,7 @@ void Tracker::update_pitch_onoff_servo(float pitch) const
 */
 void Tracker::update_pitch_cr_servo(float pitch)
 {
-    const float pitch_out = constrain_float(g.pidPitch2Srv.update_error(nav_status.angle_error_pitch, G_Dt), -(-g.pitch_min+g.pitch_max) * 100/2, (-g.pitch_min+g.pitch_max) * 100/2);
+    const float pitch_out = constrain_float(g.pidPitch2Srv.update_error(nav_status.angle_error_pitch, SERVO_G_Dt), -(-g.pitch_min+g.pitch_max) * 100/2, (-g.pitch_min+g.pitch_max) * 100/2);
     SRV_Channels::set_output_scaled(SRV_Channel::k_tracker_pitch, pitch_out);
 }
 
@@ -187,7 +187,7 @@ void Tracker::update_yaw_position_servo()
       right direction
      */
 
-    float servo_change = g.pidYaw2Srv.update_error(nav_status.angle_error_yaw, G_Dt);
+    float servo_change = g.pidYaw2Srv.update_error(nav_status.angle_error_yaw, SERVO_G_Dt);
     servo_change = constrain_float(servo_change, -18000, 18000);
     float new_servo_out = constrain_float(SRV_Channels::get_output_scaled(SRV_Channel::k_tracker_yaw) + servo_change, -18000, 18000);
 
@@ -204,7 +204,7 @@ void Tracker::update_yaw_position_servo()
     SRV_Channels::set_output_scaled(SRV_Channel::k_tracker_yaw, new_servo_out);
 
     if (yaw_servo_out_filt_init) {
-        yaw_servo_out_filt.apply(new_servo_out, G_Dt);
+        yaw_servo_out_filt.apply(new_servo_out, SERVO_G_Dt);
     } else {
         yaw_servo_out_filt.reset(new_servo_out);
         yaw_servo_out_filt_init = true;
@@ -238,6 +238,6 @@ void Tracker::update_yaw_onoff_servo(float yaw) const
  */
 void Tracker::update_yaw_cr_servo(float yaw)
 {
-    const float yaw_out = constrain_float(-g.pidYaw2Srv.update_error(nav_status.angle_error_yaw, G_Dt), -g.yaw_range * 100/2, g.yaw_range * 100/2);
+    const float yaw_out = constrain_float(-g.pidYaw2Srv.update_error(nav_status.angle_error_yaw, SERVO_G_Dt), -g.yaw_range * 100/2, g.yaw_range * 100/2);
     SRV_Channels::set_output_scaled(SRV_Channel::k_tracker_yaw, yaw_out);
 }


### PR DESCRIPTION
I've noticed that Tracker did not log `RADIO_STATUS` packets from the telemetry radios, which is odd since its whole point revolves around telemetry radio handling. I saw that some unification work has been done on `master` to move all the relevant code outside of vehicle specific classes, but still the Tracker did not implement the flag it wouldn't auto-affect it. The tracker didn't have a `MAS_LOG_PM` define either so I took a bit of creative liberty with the define. I don't think anyone  would really need to debug `PM` on the Tracker, but in case it's also centrally handled now I can unify the define with other vehicles.

Not flight tested yet.

servo.cpp changes were needed since G_Dt is a variable in AP_Vehicle.h and to make it clear that it's a constant