### PR TITLE
Tools/environment_install: print how to activate venv if not default

### DIFF
--- a/Tools/environment_install/install-prereqs-arch.sh
+++ b/Tools/environment_install/install-prereqs-arch.sh
@@ -66,6 +66,8 @@ fi
 
 if [[ $DO_PYTHON_VENV_ENV -eq 1 ]]; then
     echo "$SOURCE_LINE" >> ~/.bashrc
+else
+    echo "Please use \`$SOURCE_LINE\` to activate the ArduPilot venv"
 fi
 
 pip3 -q install -U $PYTHON_PKGS

--- a/Tools/environment_install/install-prereqs-openSUSE-Tumbleweed.sh
+++ b/Tools/environment_install/install-prereqs-openSUSE-Tumbleweed.sh
@@ -102,6 +102,8 @@ if ! grep -Fxq "$SOURCE_LINE" ~/.bashrc; then
 
     if [[ $DO_PYTHON_VENV_ENV -eq 1 ]]; then
         echo $SOURCE_LINE >> ~/.bashrc
+    else
+        echo "Please use \`$SOURCE_LINE\` to activate the ArduPilot venv"
     fi
 fi
 

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -397,6 +397,8 @@ if [ -n "$PYTHON_VENV_PACKAGE" ]; then
 
     if [[ $DO_PYTHON_VENV_ENV -eq 1 ]]; then
         echo $SOURCE_LINE >> ~/$SHELL_LOGIN
+    else
+        echo "Please use \`$SOURCE_LINE\` to activate the ArduPilot venv"
     fi
 fi
 


### PR DESCRIPTION
Nicer for the users. Split out from https://github.com/ArduPilot/ardupilot/pull/28080/ .