### PR TITLE
AP_DDS: add params for ping timeout and max retries

### DIFF
--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -84,6 +84,25 @@ const AP_Param::GroupInfo AP_DDS_Client::var_info[] {
     // @User: Standard
     AP_GROUPINFO("_DOMAIN_ID", 4, AP_DDS_Client, domain_id, 0),
 
+    // @Param: _TIMEOUT_MS
+    // @DisplayName: DDS ping timeout
+    // @Description: The time in milliseconds the DDS client will wait for a response from the XRCE agent before reattempting.
+    // @Units: ms
+    // @Range: 1 10000
+    // @RebootRequired: True
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("_TIMEOUT_MS", 5, AP_DDS_Client, ping_timeout_ms, 1000),
+
+    // @Param: _MAX_RETRY
+    // @DisplayName: DDS ping max attempts
+    // @Description: The maximum number of times the DDS client will attempt to ping the XRCE agent before exiting.
+    // @Range: 1 100
+    // @RebootRequired: True
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("_MAX_RETRY", 6, AP_DDS_Client, ping_max_retry, 10),
+
     AP_GROUPEND
 };
 
@@ -699,9 +718,7 @@ void AP_DDS_Client::main_loop(void)
         }
 
         // check ping
-        const uint64_t ping_timeout_ms{1000};
-        const uint8_t ping_max_attempts{10};
-        if (!uxr_ping_agent_attempts(comm, ping_timeout_ms, ping_max_attempts)) {
+        if (!uxr_ping_agent_attempts(comm, ping_timeout_ms, ping_max_retry)) {
             GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s No ping response, exiting", msg_prefix);
             return;
         }

--- a/libraries/AP_DDS/AP_DDS_Client.h
+++ b/libraries/AP_DDS/AP_DDS_Client.h
@@ -225,6 +225,12 @@ public:
     //! @brief ROS_DOMAIN_ID
     AP_Int32 domain_id;
 
+    //! @brief Timeout in milliseconds when pinging the XRCE agent
+    AP_Int32 ping_timeout_ms;
+
+    //! @brief Maximum number of attempts to ping the XRCE agent before exiting
+    AP_Int8 ping_max_retry;
+
     //! @brief Enum used to mark a topic as a data reader or writer
     enum class Topic_rw : uint8_t {
         DataReader = 0,


### PR DESCRIPTION
Add parameters to set the time out and number of retries when the DDS client attempts to ping the XRCE agent. Allows the user to increase the timeout before the client exits.

Currently with a RPi4 companion using a PPP connection to a FC, the DDS client times out and exits before the network, PPP daemon and micro-ROS agent are up after a power cycle. 

## Testing

Tested in SITL / Gazebo:

```bash
sim_vehicle.py --debug -v ArduCopter -f gazebo-iris --model json --enable-dds --console
```

```bash
# DDS params with increased number of retries
STABILIZE>  param show *DDS*
DDS_DOMAIN_ID    0
DDS_ENABLE       1           # Enabled
DDS_IP0          127
DDS_IP1          0
DDS_IP2          0
DDS_IP3          1
DDS_MAX_RETRY    60
DDS_TIMEOUT_MS   1000
DDS_UDP_PORT     2019
```
