### PR TITLE
AP_Scripting: remove dependency on tmpnam

### DIFF
--- a/libraries/AP_Filesystem/posix_compat.h
+++ b/libraries/AP_Filesystem/posix_compat.h
@@ -58,7 +58,6 @@ long apfs_ftell(APFS_FILE *stream);
 APFS_FILE *apfs_freopen(const char *pathname, const char *mode, APFS_FILE *stream);
 int apfs_remove(const char *pathname);
 int apfs_rename(const char *oldpath, const char *newpath);
-char *tmpnam(char s[L_tmpnam]);
 
 #undef stdin
 #undef stdout

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stdio.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stdio.h
@@ -48,8 +48,6 @@ void *realloc(void* ptr, size_t size) __attribute__((deprecated));
 extern int (*vprintf_console_hook)(const char *fmt, va_list arg);
 void malloc_check(const void *ptr);
 
-#define L_tmpnam 32
-
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/AP_Scripting/lua/src/loslib.c
+++ b/libraries/AP_Scripting/lua/src/loslib.c
@@ -106,6 +106,19 @@ static time_t l_checktime (lua_State *L, int arg) {
 ** it uses mkstemp.
 ** ===================================================================
 */
+
+#if defined(ARDUPILOT_BUILD)
+
+/* os lib is not available in ArduPilot, and tmpnam is not available on some
+   platforms, so define useless but harmless lua_tmpnam to avoid needing it */
+
+#define LUA_TMPNAMBUFSIZE 1
+
+/* always report error */
+#define lua_tmpnam(b, e) { e = 1; }
+
+#endif // defined(ARDUPILOT_BUILD)
+
 #if !defined(lua_tmpnam)	/* { */
 
 #if defined(LUA_USE_POSIX)	/* { */


### PR DESCRIPTION
tmpnam is never linked and not necessary, and naming it/redefining it introduces problems on platforms that do have a definition.

Additionally remove the definition as it was only ever used by Lua.

No compiler output change. Part of #28080 