### PR TITLE
Sub: limit poshold xy velocity to PILOT_SPEED to avoid bounceback

### DIFF
--- a/ArduSub/Attitude.cpp
+++ b/ArduSub/Attitude.cpp
@@ -94,7 +94,6 @@ float Sub::get_pilot_desired_climb_rate(float throttle_control)
         return 0.0f;
     }
 
-    float desired_rate = 0.0f;
     float mid_stick = channel_throttle->get_control_mid();
     float deadband_top = mid_stick + g.throttle_deadzone * gain;
     float deadband_bottom = mid_stick - g.throttle_deadzone * gain;
@@ -108,19 +107,14 @@ float Sub::get_pilot_desired_climb_rate(float throttle_control)
     // check throttle is above, below or in the deadband
     if (throttle_control < deadband_bottom) {
         // below the deadband
-        desired_rate = get_pilot_speed_dn() * (throttle_control-deadband_bottom) / deadband_bottom;
+        return get_pilot_speed_dn() * (throttle_control-deadband_bottom) / deadband_bottom;
     } else if (throttle_control > deadband_top) {
         // above the deadband
-        desired_rate = g.pilot_speed_up * (throttle_control-deadband_top) / (1000.0f-deadband_top);
+        return g.pilot_speed_up * (throttle_control-deadband_top) / (1000.0f-deadband_top);
     } else {
         // must be in the deadband
-        desired_rate = 0.0f;
+        return 0.0f;
     }
-
-    // desired climb rate for logging
-    desired_climb_rate = desired_rate;
-
-    return desired_rate;
 }
 
 // rotate vector from vehicle's perspective to North-East frame

--- a/ArduSub/Attitude.cpp
+++ b/ArduSub/Attitude.cpp
@@ -117,6 +117,33 @@ float Sub::get_pilot_desired_climb_rate(float throttle_control)
     }
 }
 
+// behavior is similar to Sub::get_pilot_desired_climb_rate
+float Sub::get_pilot_desired_horizontal_rate(RC_Channel *channel) const
+{
+    if (failsafe.pilot_input) {
+        return 0;
+    }
+
+    // forward and lateral sticks have center trim, unlike throttle
+    auto control = channel->norm_input();
+
+    // normalize deadzone
+    auto dz = (float)g.throttle_deadzone * 2.0f / (float)(channel->get_radio_max() - channel->get_radio_min());
+    auto deadband_top = dz * gain;
+    auto deadband_bottom = -dz * gain;
+
+    if (control < deadband_bottom) {
+        // below the deadband
+        return (float)g.pilot_speed * (control - deadband_bottom);
+    } else if (control > deadband_top) {
+        // above the deadband
+        return (float)g.pilot_speed * (control - deadband_top);
+    } else {
+        // must be in the deadband
+        return 0;
+    }
+}
+
 // rotate vector from vehicle's perspective to North-East frame
 void Sub::rotate_body_frame_to_NE(float &x, float &y)
 {

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -175,6 +175,15 @@ const AP_Param::Info Sub::var_info[] = {
     // @User: Standard
     GSCALAR(pilot_speed_dn,     "PILOT_SPEED_DN",   0),
 
+    // @Param: PILOT_SPEED
+    // @DisplayName: Pilot maximum horizontal speed
+    // @Description: The maximum horizontal velocity the pilot may request in cm/s
+    // @Units: cm/s
+    // @Range: 10 500
+    // @Increment: 10
+    // @User: Standard
+    GSCALAR(pilot_speed,     "PILOT_SPEED",   PILOT_SPEED_DEFAULT),
+
     // @Param: PILOT_ACCEL_Z
     // @DisplayName: Pilot vertical acceleration
     // @Description: The vertical acceleration used when pilot is controlling the altitude

--- a/ArduSub/Parameters.h
+++ b/ArduSub/Parameters.h
@@ -231,6 +231,7 @@ public:
         k_param_pilot_speed_dn,
         k_param_rangefinder_signal_min,
         k_param_surftrak_depth,
+        k_param_pilot_speed,
 
         k_param_vehicle = 257, // vehicle common block of parameters
     };
@@ -267,9 +268,10 @@ public:
 
     // Waypoints
     //
-    AP_Int16        pilot_speed_up;        // maximum vertical ascending velocity the pilot may request
-    AP_Int16        pilot_speed_dn;        // maximum vertical descending velocity the pilot may request
-    AP_Int16        pilot_accel_z;               // vertical acceleration the pilot may request
+    AP_Int16        pilot_speed_up;             // maximum vertical ascending velocity the pilot may request
+    AP_Int16        pilot_speed_dn;             // maximum vertical descending velocity the pilot may request
+    AP_Int16        pilot_speed;                // maximum horizontal (xy) velocity the pilot may request
+    AP_Int16        pilot_accel_z;              // vertical acceleration the pilot may request
 
     // Throttle
     //

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -263,9 +263,6 @@ private:
     // Stores initial bearing when armed
     int32_t initial_armed_bearing;
 
-    // Throttle variables
-    int16_t desired_climb_rate;          // pilot desired climb rate - for logging purposes only
-
     // Loiter control
     uint16_t loiter_time_max;                // How long we should stay in Loiter Mode for mission scripting (time in seconds)
     uint32_t loiter_time;                    // How long have we been loitering - The start time in millis

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -403,6 +403,7 @@ private:
     float get_roi_yaw();
     float get_look_ahead_yaw();
     float get_pilot_desired_climb_rate(float throttle_control);
+    float get_pilot_desired_horizontal_rate(RC_Channel *channel) const;
     void rotate_body_frame_to_NE(float &x, float &y);
 #if HAL_LOGGING_ENABLED
     // methods for AP_Vehicle:

--- a/ArduSub/config.h
+++ b/ArduSub/config.h
@@ -167,9 +167,12 @@
 # define THR_DZ_DEFAULT         100             // the deadzone above and below mid throttle while in althold or loiter
 #endif
 
-// default maximum vertical velocity and acceleration the pilot may request
+// default maximum velocities and acceleration the pilot may request
 #ifndef PILOT_VELZ_MAX
 # define PILOT_VELZ_MAX    500     // maximum vertical velocity in cm/s
+#endif
+#ifndef PILOT_SPEED_DEFAULT
+# define PILOT_SPEED_DEFAULT 200 // maximum horizontal velocity in cm/s while under pilot control
 #endif
 #ifndef PILOT_ACCEL_Z_DEFAULT
 # define PILOT_ACCEL_Z_DEFAULT 100 // vertical acceleration in cm/s/s while altitude is under pilot control

--- a/ArduSub/mode.h
+++ b/ArduSub/mode.h
@@ -419,7 +419,7 @@ public:
 
     bool init(bool ignore_checks) override;
 
-    bool requires_GPS() const override { return false; }
+    bool requires_GPS() const override { return true; }
     bool has_manual_throttle() const override { return false; }
     bool allows_arming(bool from_gcs) const override { return true; }
     bool is_autopilot() const override { return true; }

--- a/ArduSub/mode.h
+++ b/ArduSub/mode.h
@@ -429,6 +429,10 @@ protected:
     const char *name() const override { return "POSHOLD"; }
     const char *name4() const override { return "POSH"; }
     Mode::Number number() const override { return Mode::Number::POSHOLD; }
+
+private:
+
+    void control_horizontal();
 };
 
 

--- a/ArduSub/mode_poshold.cpp
+++ b/ArduSub/mode_poshold.cpp
@@ -15,8 +15,8 @@ bool ModePoshold::init(bool ignore_checks)
     }
 
     // initialize vertical speeds and acceleration
-    position_control->set_max_speed_accel_xy(sub.wp_nav.get_default_speed_xy(), sub.wp_nav.get_wp_acceleration());
-    position_control->set_correction_speed_accel_xy(sub.wp_nav.get_default_speed_xy(), sub.wp_nav.get_wp_acceleration());
+    position_control->set_max_speed_accel_xy(g.pilot_speed, g.pilot_accel_z);
+    position_control->set_correction_speed_accel_xy(g.pilot_speed, g.pilot_accel_z);
     position_control->set_max_speed_accel_z(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
     position_control->set_correction_speed_accel_z(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
@@ -54,26 +54,6 @@ void ModePoshold::run()
     // set motors to full range
     motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
-    ///////////////////////
-    // update xy outputs //
-    float pilot_lateral = channel_lateral->norm_input();
-    float pilot_forward = channel_forward->norm_input();
-
-    float lateral_out = 0;
-    float forward_out = 0;
-
-    if (sub.position_ok()) {
-        // Allow pilot to reposition the sub
-        if (fabsf(pilot_lateral) > 0.1 || fabsf(pilot_forward) > 0.1) {
-            position_control->init_xy_controller_stopping_point();
-        }
-        sub.translate_pos_control_rp(lateral_out, forward_out);
-        position_control->update_xy_controller();
-    } else {
-        position_control->init_xy_controller_stopping_point();
-    }
-    motors.set_forward(forward_out + pilot_forward);
-    motors.set_lateral(lateral_out + pilot_lateral);
     /////////////////////
     // Update attitude //
 
@@ -103,12 +83,51 @@ void ModePoshold::run()
             attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
             sub.last_pilot_heading = ahrs.yaw_sensor; // update heading to hold
 
-        } else { // call attitude controller holding absolute absolute bearing
+        } else { // call attitude controller holding absolute bearing
             attitude_control->input_euler_angle_roll_pitch_yaw(target_roll, target_pitch, sub.last_pilot_heading, true);
         }
     }
 
-    // Update z axis //
+    // update z axis
     control_depth();
+
+    // update xy axis
+    // call this after Sub::get_pilot_desired_climb_rate is called so that THR_DZ is reasonable
+    control_horizontal();
+}
+
+void ModePoshold::control_horizontal() {
+    float lateral_out = 0;
+    float forward_out = 0;
+
+    // get desired rates in the body frame
+    Vector2f body_rates_cm_s = {
+        sub.get_pilot_desired_horizontal_rate(channel_forward),
+        sub.get_pilot_desired_horizontal_rate(channel_lateral)
+    };
+
+    if (sub.position_ok()) {
+        if (!position_control->is_active_xy()) {
+            // the xy controller timed out, re-initialize
+            position_control->init_xy_controller_stopping_point();
+        }
+
+        // convert to the earth frame and set target rates
+        auto earth_rates_cm_s = ahrs.body_to_earth2D(body_rates_cm_s);
+        position_control->input_vel_accel_xy(earth_rates_cm_s, {0, 0});
+
+        // convert pos control roll and pitch angles back to lateral and forward efforts
+        sub.translate_pos_control_rp(lateral_out, forward_out);
+
+        // udpate the xy controller
+        position_control->update_xy_controller();
+    } else if (g.pilot_speed > 0) {
+        // allow the pilot to reposition manually
+        forward_out = body_rates_cm_s.x / (float)g.pilot_speed;
+        lateral_out = body_rates_cm_s.y / (float)g.pilot_speed;
+    }
+
+    motors.set_forward(forward_out);
+    motors.set_lateral(lateral_out);
 }
 #endif  // POSHOLD_ENABLED

--- a/ArduSub/mode_surface.cpp
+++ b/ArduSub/mode_surface.cpp
@@ -50,9 +50,6 @@ void ModeSurface::run()
     // set target climb rate
     float cmb_rate = constrain_float(fabsf(sub.wp_nav.get_default_speed_up()), 1, position_control->get_max_speed_up_cms());
 
-    // record desired climb rate for logging
-    sub.desired_climb_rate = cmb_rate;
-
     // update altitude target and call position controller
     position_control->set_pos_target_z_from_climb_rate_cm(cmb_rate);
     position_control->update_z_controller();

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -995,6 +995,61 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
                 }, epsilon=10) # allow rounding
                 seen_3 = True
 
+    def wait_for_stop(self):
+        """Watch the sub slow down and stop"""
+        tstart = self.get_sim_time_cached()
+        lstart = self.mav.location()
+
+        dmax = 0
+        dprev = 0
+
+        while True:
+            self.delay_sim_time(1)
+
+            dcurr = self.get_distance(lstart, self.mav.location())
+
+            if dcurr - dmax < -0.2:
+                raise NotAchievedException("Bounced back from %.2fm to %.2fm" % (dmax, dcurr))
+            if dcurr > dmax:
+                dmax = dcurr
+
+            if abs(dcurr - dprev) < 0.1:
+                self.progress("Stopping distance %.2fm, less than %.2fs" % (dcurr, self.get_sim_time_cached() - tstart))
+                return
+
+            if self.get_sim_time_cached() - tstart > 10:
+                raise NotAchievedException("Took to long to stop")
+
+            dprev = dcurr
+
+    def PosHoldBounceBack(self):
+        """Test for bounce back in POSHOLD mode"""
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+
+        # dive a little
+        self.set_rc(Joystick.Throttle, 1300)
+        self.delay_sim_time(3)
+        self.set_rc(Joystick.Throttle, 1500)
+        self.delay_sim_time(2)
+
+        # hold position
+        self.change_mode('POSHOLD')
+
+        for pilot_speed in range(50, 251, 100):
+            # set max speed
+            self.set_parameter('PILOT_SPEED', pilot_speed)
+
+            # try different stick values, resulting speed is ~ max_speed * effort * gain
+            for pwm in range(1700, 1901, 100):
+                self.progress('PILOT_SPEED %d, forward pwm %d' % (pilot_speed, pwm))
+                self.set_rc(Joystick.Forward, pwm)
+                self.delay_sim_time(3)
+                self.set_rc(Joystick.Forward, 1500)
+                self.wait_for_stop()
+
+        self.disarm_vehicle()
+
     def tests(self):
         '''return list of all tests'''
         ret = super(AutoTestSub, self).tests()
@@ -1027,6 +1082,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
             self.BackupOrigin,
             self.FuseMag,
             self.INA3221,
+            self.PosHoldBounceBack,
         ])
 
         return ret


### PR DESCRIPTION
This PR limits horizontal velocity in poshold mode, even when the pilot is using the forward and lateral sticks to reposition the sub. This eliminates the possibility of a PSC-caused bounceback. This is verified by an autotest.

The PR also adds a PILOT_SPEED parameter, so there are now 3 WPNAV_SPEED* parameters and 3 PILOT_SPEED* parameters. Previously, poshold was using WPNAV_SPEED for xy and PILOT_SPEED_UP/DN for z, this PR changes it to use PILOT_SPEED* for both xy and z.

(Circle mode also uses WPNAV_SPEED for xy and PILOT_SPEED_UP/DN for z, but I would argue that it should be using WPNAV_SPEED* for both xy and z. This can be a separate PR.)

There are 2 additional small fixes:
* removes unused variable `Sub::desired_climb_rate`
* `ModePoshold::requires_GPS` returns true, so `Sub::set_mode` will call `sub.position_ok` before accepting a mode switch. (`ModePoshold::init()` function also calls `sub.position_ok`, so this doesn't change behavior.)

This should probably be tested on real hardware.

Fixes #28120