### PR TITLE
Heli autorotation restructure mode and improve speed controller

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -50,6 +50,14 @@ bool AP_Arming_Copter::run_pre_arm_checks(bool display_failure)
         passed = false;
     }
 
+#if FRAME_CONFIG == HELI_FRAME && MODE_AUTOROTATE_ENABLED
+    // check on autorotation config
+    if (!copter.g2.arot.arming_checks(ARRAY_SIZE(failure_msg), failure_msg)) {
+        check_failed(display_failure, "AROT: %s", failure_msg);
+        passed = false;
+    }
+#endif
+
     // If not passed all checks return false
     if (!passed) {
         return false;

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -716,12 +716,6 @@ void Copter::twentyfive_hz_logging()
         AP::ins().Write_IMU();
     }
 
-#if MODE_AUTOROTATE_ENABLED
-    if (should_log(MASK_LOG_ATTITUDE_MED) || should_log(MASK_LOG_ATTITUDE_FAST)) {
-        //update autorotation log
-        g2.arot.Log_Write_Autorotation();
-    }
-#endif
 #if HAL_GYROFFT_ENABLED
     if (should_log(MASK_LOG_FTN_FAST)) {
         gyro_fft.write_log_messages();

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -164,6 +164,10 @@
   #error AP_OAPathPlanner relies on AP_FENCE_ENABLED which is disabled
 #endif
 
+#if MODE_AUTOROTATE_ENABLED && !AP_RPM_ENABLED
+  #error AC_Autorotation relies on AP_RPM_ENABLED which is disabled
+#endif
+
 #if HAL_ADSB_ENABLED
 #include "avoidance_adsb.h"
 #endif

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1293,7 +1293,7 @@ ParametersG2::ParametersG2(void) :
     ,mode_systemid_ptr(&copter.mode_systemid)
 #endif
 #if MODE_AUTOROTATE_ENABLED
-    ,arot()
+    ,arot(copter.motors, copter.attitude_control)
 #endif
 #if MODE_ZIGZAG_ENABLED
     ,mode_zigzag_ptr(&copter.mode_zigzag)

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -2033,46 +2033,21 @@ protected:
 
 private:
 
-    // --- Internal variables ---
-    float _initial_rpm;             // Head speed recorded at initiation of flight mode (RPM)
-    float _target_head_speed;       // The terget head main rotor head speed.  Normalised by main rotor set point
-    float _desired_v_z;             // Desired vertical
-    int32_t _pitch_target;          // Target pitch attitude to pass to attitude controller
-    uint32_t _entry_time_start_ms;  // Time remaining until entry phase moves on to glide phase
-    float _hs_decay;                // The head accerleration during the entry phase
+    uint32_t _entry_time_start_ms;  // time remaining until entry phase moves on to glide phase
+    uint32_t _last_logged_ms;       // used for timing slow rate autorotation log
 
-    enum class Autorotation_Phase {
+    enum class Phase {
+        ENTRY_INIT,
         ENTRY,
-        SS_GLIDE,
+        GLIDE_INIT,
+        GLIDE,
+        FLARE_INIT,
         FLARE,
+        TOUCH_DOWN_INIT,
         TOUCH_DOWN,
-        LANDED } phase_switch;
-
-    enum class Navigation_Decision {
-        USER_CONTROL_STABILISED,
-        STRAIGHT_AHEAD,
-        INTO_WIND,
-        NEAREST_RALLY} nav_pos_switch;
-
-    // --- Internal flags ---
-    struct controller_flags {
-            bool entry_initial             : 1;
-            bool ss_glide_initial          : 1;
-            bool flare_initial             : 1;
-            bool touch_down_initial        : 1;
-            bool landed_initial            : 1;
-            bool straight_ahead_initial    : 1;
-            bool level_initial             : 1;
-            bool break_initial             : 1;
-            bool bad_rpm                   : 1;
-    } _flags;
-
-    struct message_flags {
-            bool bad_rpm                   : 1;
-    } _msg_flags;
-
-    //--- Internal functions ---
-    void warning_message(uint8_t message_n);    //Handles output messages to the terminal
+        LANDED_INIT,
+        LANDED,
+    } current_phase;
 
 };
 #endif

--- a/ArduCopter/mode_autorotate.cpp
+++ b/ArduCopter/mode_autorotate.cpp
@@ -26,7 +26,7 @@ bool ModeAutorotate::init(bool ignore_checks)
 
     // Check that mode is enabled, make sure this is the first check as this is the most
     // important thing for users to fix if they are planning to use autorotation mode
-    if (!g2.arot.is_enable()) {
+    if (!g2.arot.enabled()) {
         gcs().send_text(MAV_SEVERITY_WARNING, "Autorot Mode Not Enabled");
         return false;
     }

--- a/ArduCopter/mode_autorotate.cpp
+++ b/ArduCopter/mode_autorotate.cpp
@@ -9,13 +9,7 @@
 #include <AC_Autorotation/AC_Autorotation.h>
 #include "mode.h"
 
-#include <utility>
-
 #if MODE_AUTOROTATE_ENABLED
-
-#define AUTOROTATE_ENTRY_TIME          2.0f    // (s) number of seconds that the entry phase operates for
-#define HEAD_SPEED_TARGET_RATIO        1.0f    // Normalised target main rotor head speed (unit: -)
-#define AUTOROTATION_MIN_MOVING_SPEED  100.0    // (cm/s) minimum speed used for "is moving" check
 
 bool ModeAutorotate::init(bool ignore_checks)
 {
@@ -27,77 +21,55 @@ bool ModeAutorotate::init(bool ignore_checks)
     // Check that mode is enabled, make sure this is the first check as this is the most
     // important thing for users to fix if they are planning to use autorotation mode
     if (!g2.arot.enabled()) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Autorot Mode Not Enabled");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "AROT: Mode not enabled");
         return false;
     }
 
     // Must be armed to use mode, prevent triggering state machine on the ground
     if (!motors->armed() || copter.ap.land_complete || copter.ap.land_complete_maybe) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Autorot: Must be Armed and Flying");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "AROT: Must be armed and flying");
         return false;
     }
 
-    // Initialise controllers
-    // This must be done before RPM value is fetched
-    g2.arot.init_hs_controller();
-    g2.arot.init_fwd_spd_controller();
+    // Initialise controller
+    g2.arot.init();
 
-    // Retrieve rpm and start rpm sensor health checks
-    _initial_rpm = g2.arot.get_rpm(true);
-
-    // Display message 
-    gcs().send_text(MAV_SEVERITY_INFO, "Autorotation initiated");
-
-     // Set all intial flags to on
-    _flags.entry_initial = true;
-    _flags.ss_glide_initial = true;
-    _flags.flare_initial = true;
-    _flags.touch_down_initial = true;
-    _flags.landed_initial = true;
-    _flags.level_initial = true;
-    _flags.break_initial = true;
-    _flags.straight_ahead_initial = true;
-    _msg_flags.bad_rpm = true;
-
-    // Setting default starting switches
-    phase_switch = Autorotation_Phase::ENTRY;
+    // Setting default starting state
+    current_phase = Phase::ENTRY_INIT;
 
     // Set entry timer
     _entry_time_start_ms = millis();
 
-    // The decay rate to reduce the head speed from the current to the target
-    _hs_decay = ((_initial_rpm/g2.arot.get_hs_set_point()) - HEAD_SPEED_TARGET_RATIO) / AUTOROTATE_ENTRY_TIME;
+    // reset logging timer
+    _last_logged_ms = 0;
 
     return true;
 }
 
-
-
 void ModeAutorotate::run()
 {
     // Current time
-    uint32_t now = millis(); //milliseconds
+    const uint32_t now_ms = millis();
+
+    // Set dt in library
+    float const last_loop_time_s = AP::scheduler().get_last_loop_time_s();
+    g2.arot.set_dt(last_loop_time_s);
 
     //----------------------------------------------------------------
     //                  State machine logic
     //----------------------------------------------------------------
+    // State machine progresses through the autorotation phases as you read down through the if statements.
+    // More urgent phases (the ones closer to the ground) take precedence later in the if statements.
 
-     // Setting default phase switch positions
-     nav_pos_switch = Navigation_Decision::USER_CONTROL_STABILISED;
-
-    // Timer from entry phase to progress to glide phase
-    if (phase_switch == Autorotation_Phase::ENTRY){
-        if ((now - _entry_time_start_ms)/1000.0f > AUTOROTATE_ENTRY_TIME) {
-            // Flight phase can be progressed to steady state glide
-            phase_switch = Autorotation_Phase::SS_GLIDE;
-        }
+    if (current_phase < Phase::GLIDE_INIT && ((now_ms - _entry_time_start_ms) > g2.arot.entry_time_ms)) {
+        // Flight phase can be progressed to steady state glide
+        current_phase = Phase::GLIDE_INIT;
     }
 
-    // Check if we believe we have landed. We need the landed state to zero all controls and make sure that the copter landing detector will trip
-    bool speed_check = inertial_nav.get_velocity_z_up_cms() < AUTOROTATION_MIN_MOVING_SPEED &&
-                     inertial_nav.get_speed_xy_cms() < AUTOROTATION_MIN_MOVING_SPEED;
-    if (motors->get_below_land_min_coll() && AP::ins().is_still() && speed_check) {
-        phase_switch = Autorotation_Phase::LANDED;
+    // Check if we believe we have landed. We need the landed state to zero all
+    // controls and make sure that the copter landing detector will trip
+    if (current_phase < Phase::LANDED && g2.arot.check_landed()) {
+        current_phase = Phase::LANDED_INIT;
     }
 
     // Check if we are bailing out and need to re-set the spool state
@@ -105,162 +77,60 @@ void ModeAutorotate::run()
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
     }
 
+    // Get norm input from yaw channel
+    const float pilot_norm_input = channel_yaw->norm_input_dz();
 
     //----------------------------------------------------------------
     //                  State machine actions
     //----------------------------------------------------------------
-    switch (phase_switch) {
+    switch (current_phase) {
 
-        case Autorotation_Phase::ENTRY:
-        {
+        case Phase::ENTRY_INIT:
             // Entry phase functions to be run only once
-            if (_flags.entry_initial == true) {
+            g2.arot.init_entry();
+            current_phase = Phase::ENTRY;
+            FALLTHROUGH;
 
-                #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-                    gcs().send_text(MAV_SEVERITY_INFO, "Entry Phase");
-                #endif
-
-                // Set following trim low pass cut off frequency
-                g2.arot.set_col_cutoff_freq(g2.arot.get_col_entry_freq());
-
-                // Target head speed is set to rpm at initiation to prevent unwanted changes in attitude
-                _target_head_speed = _initial_rpm/g2.arot.get_hs_set_point();
-
-                // Set desired forward speed target
-                g2.arot.set_desired_fwd_speed();
-
-                // Prevent running the initial entry functions again
-                _flags.entry_initial = false;
-
-            }
-
-            // Slowly change the target head speed until the target head speed matches the parameter defined value
-            if (g2.arot.get_rpm() > HEAD_SPEED_TARGET_RATIO*1.005f  ||  g2.arot.get_rpm() < HEAD_SPEED_TARGET_RATIO*0.995f) {
-                _target_head_speed -= _hs_decay*G_Dt;
-            } else {
-                _target_head_speed = HEAD_SPEED_TARGET_RATIO;
-            }
-
-            // Set target head speed in head speed controller
-            g2.arot.set_target_head_speed(_target_head_speed);
-
-            // Run airspeed/attitude controller
-            g2.arot.set_dt(G_Dt);
-            g2.arot.update_forward_speed_controller();
-
-            // Retrieve pitch target
-            _pitch_target = g2.arot.get_pitch();
-
-            // Update controllers
-            _flags.bad_rpm = g2.arot.update_hs_glide_controller(G_Dt); //run head speed/ collective controller
-
+        case Phase::ENTRY:
+            // Smoothly transition the collective to enter autorotation regime and begin forward speed control
+            g2.arot.run_entry(pilot_norm_input);
             break;
-        }
 
-        case Autorotation_Phase::SS_GLIDE:
-        {
-            // Steady state glide functions to be run only once
-            if (_flags.ss_glide_initial == true) {
+        case Phase::GLIDE_INIT:
+            // Glide phase functions to be run only once
+            g2.arot.init_glide();
+            current_phase = Phase::GLIDE;
+            FALLTHROUGH;
 
-                #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-                    gcs().send_text(MAV_SEVERITY_INFO, "SS Glide Phase");
-                #endif
-
-                // Set following trim low pass cut off frequency
-                g2.arot.set_col_cutoff_freq(g2.arot.get_col_glide_freq());
-
-                // Set desired forward speed target
-                g2.arot.set_desired_fwd_speed();
-
-                // Set target head speed in head speed controller
-                _target_head_speed = HEAD_SPEED_TARGET_RATIO;  //Ensure target hs is set to glide in case hs has not reached target for glide
-                g2.arot.set_target_head_speed(_target_head_speed);
-
-                // Prevent running the initial glide functions again
-                _flags.ss_glide_initial = false;
-            }
-
-            // Run airspeed/attitude controller
-            g2.arot.set_dt(G_Dt);
-            g2.arot.update_forward_speed_controller();
-
-            // Retrieve pitch target 
-            _pitch_target = g2.arot.get_pitch();
-
-            // Update head speed/ collective controller
-            _flags.bad_rpm = g2.arot.update_hs_glide_controller(G_Dt); 
-            // Attitude controller is updated in navigation switch-case statements
-
+        case Phase::GLIDE:
+            // Maintain head speed and forward speed as we glide to the ground
+            g2.arot.run_glide(pilot_norm_input);
             break;
-        }
 
-        case Autorotation_Phase::FLARE:
-        case Autorotation_Phase::TOUCH_DOWN:
-        {
+        case Phase::FLARE_INIT:
+        case Phase::FLARE:
+        case Phase::TOUCH_DOWN_INIT:
+        case Phase::TOUCH_DOWN:
             break;
-        }
-        case Autorotation_Phase::LANDED:
-        {
-            // Entry phase functions to be run only once
-            if (_flags.landed_initial == true) {
 
-                #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-                    gcs().send_text(MAV_SEVERITY_INFO, "Landed");
-                #endif
-                _flags.landed_initial = false;
-            }
-            // don't allow controller to continually ask for more pitch to build speed when we are on the ground, decay to zero smoothly
-            _pitch_target *= 0.95;
+        case Phase::LANDED_INIT:
+            // Landed phase functions to be run only once
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AROT: Landed");
+            current_phase = Phase::LANDED;
+            FALLTHROUGH;
+
+        case Phase::LANDED:
+            // Don't allow controller to continually ask for more pitch to build speed when we are on the ground, decay to zero smoothly
+            g2.arot.run_landed();
             break;
-        }
     }
 
-    switch (nav_pos_switch) {
-
-        case Navigation_Decision::USER_CONTROL_STABILISED:
-        {
-            // Operator is in control of roll and yaw.  Controls act as if in stabilise flight mode.  Pitch 
-            // is controlled by speed-height controller.
-            float pilot_roll, pilot_pitch;
-            get_pilot_desired_lean_angles(pilot_roll, pilot_pitch, copter.aparm.angle_max, copter.aparm.angle_max);
-
-            // Get pilot's desired yaw rate
-            float pilot_yaw_rate = get_pilot_desired_yaw_rate();
-
-            // Pitch target is calculated in autorotation phase switch above
-            attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(pilot_roll, _pitch_target, pilot_yaw_rate);
-            break;
-        }
-
-        case Navigation_Decision::STRAIGHT_AHEAD:
-        case Navigation_Decision::INTO_WIND:
-        case Navigation_Decision::NEAREST_RALLY:
-        {
-            break;
-        }
-    }
-
-    // Output warning messaged if rpm signal is bad
-    if (_flags.bad_rpm) {
-        warning_message(1);
+    // Slow rate (25 Hz) logging for the mode
+    if (now_ms - _last_logged_ms > 40U) {
+        g2.arot.log_write_autorotation();
+        _last_logged_ms = now_ms;
     }
 
 } // End function run()
-
-void ModeAutorotate::warning_message(uint8_t message_n)
-{
-    switch (message_n) {
-        case 1:
-        {
-            if (_msg_flags.bad_rpm) {
-                // Bad rpm sensor health.
-                gcs().send_text(MAV_SEVERITY_INFO, "Warning: Poor RPM Sensor Health");
-                gcs().send_text(MAV_SEVERITY_INFO, "Action: Minimum Collective Applied");
-                _msg_flags.bad_rpm = false;
-            }
-            break;
-        }
-    }
-}
 
 #endif

--- a/Tools/autotest/helicopter.py
+++ b/Tools/autotest/helicopter.py
@@ -309,6 +309,7 @@ class AutoTestHelicopter(AutoTestCopter):
         self.set_parameters({
             "AROT_ENABLE": 1,
             "H_RSC_AROT_ENBL": 1,
+            "H_COL_LAND_MIN" : -2.0
         })
         bail_out_time = self.get_parameter('H_RSC_AROT_RUNUP')
         self.change_mode('POSHOLD')
@@ -333,13 +334,12 @@ class AutoTestHelicopter(AutoTestCopter):
         # Change to the autorotation flight mode
         self.progress("Triggering autorotate mode")
         self.change_mode('AUTOROTATE')
-        self.delay_sim_time(2)
 
         # Disengage the interlock to remove power
         self.set_rc(8, 1000)
 
         # Ensure we have progressed through the mode's state machine
-        self.wait_statustext("SS Glide Phase", check_context=True)
+        self.wait_statustext("Glide Phase", check_context=True)
 
         self.progress("Testing bailout from autorotation")
         self.set_rc(8, 2000)
@@ -359,6 +359,43 @@ class AutoTestHelicopter(AutoTestCopter):
         self.set_rc(3, 1000)
 
         self.wait_disarmed()
+        self.context_pop()
+
+    def AutorotationPreArm(self):
+        """Check autorotation pre-arms are working"""
+        self.context_push()
+        self.start_subtest("Check pass when autorotation mode not enabled")
+        self.set_parameters({
+            "AROT_ENABLE": 0,
+            "RPM1_TYPE": 0
+        })
+        self.reboot_sitl()
+        try:
+            self.wait_statustext("PreArm: AROT: RPM1 not enabled", timeout=50)
+            raise NotAchievedException("Received AROT prearm when not AROT not enabled")
+        except AutoTestTimeoutException:
+            # We want to hit the timeout on wait_statustext()
+            pass
+
+        self.start_subtest("Check pre-arm fails when autorotation mode enabled")
+        self.set_parameter("AROT_ENABLE", 1)
+        self.wait_statustext("PreArm: AROT: RPM1 not enabled", timeout=50)
+        self.set_parameter("RPM1_TYPE", 10) # reboot required to take effect
+        self.reboot_sitl()
+
+        self.start_subtest("Check pre-arm fails with bad HS_Sensor config")
+        self.context_push()
+        self.set_parameter("AROT_HS_SENSOR", -1)
+        self.wait_statustext("PreArm: AROT: RPM instance <0", timeout=50)
+        self.context_pop()
+
+        self.start_subtest("Check pre-arm fails with bad RSC config")
+        self.wait_statustext("PreArm: AROT: H_RSC_AROT_* not configured", timeout=50)
+
+        self.start_subtest("Check pre-arms clear with all issues corrected")
+        self.set_parameter("H_RSC_AROT_ENBL", 1)
+        self.wait_ready_to_arm()
+
         self.context_pop()
 
     def ManAutorotation(self, timeout=600):
@@ -473,19 +510,19 @@ class AutoTestHelicopter(AutoTestCopter):
 
         # We test the bailout behavior of two different configs
         # First we test config with a regular throttle curve
-        self.progress("testing autorotation with throttle curve config")
+        self.start_subtest("testing autorotation with throttle curve config")
         self.context_push()
         TestAutorotationConfig(self, rsc_idle=5.0, arot_ramp_time=2.0, arot_idle=0, cool_down=0)
 
         # Now we test a config that would be used with an ESC with internal governor and an autorotation window
-        self.progress("testing autorotation with ESC autorotation window config")
+        self.start_subtest("testing autorotation with ESC autorotation window config")
         TestAutorotationConfig(self, rsc_idle=0.0, arot_ramp_time=0.0, arot_idle=20.0, cool_down=0)
 
         # Check rsc output behavior when using the cool down feature
-        self.progress("testing autorotation with cool down enabled and zero autorotation idle")
+        self.start_subtest("testing autorotation with cool down enabled and zero autorotation idle")
         TestAutorotationConfig(self, rsc_idle=5.0, arot_ramp_time=2.0, arot_idle=0, cool_down=5.0)
 
-        self.progress("testing that H_RSC_AROT_IDLE is used over RSC_IDLE when cool down is enabled")
+        self.start_subtest("testing that H_RSC_AROT_IDLE is used over RSC_IDLE when cool down is enabled")
         TestAutorotationConfig(self, rsc_idle=5.0, arot_ramp_time=2.0, arot_idle=10, cool_down=5.0)
 
         self.context_pop()
@@ -1154,6 +1191,7 @@ class AutoTestHelicopter(AutoTestCopter):
             self.PosHoldTakeOff,
             self.StabilizeTakeOff,
             self.SplineWaypoint,
+            self.AutorotationPreArm,
             self.Autorotation,
             self.ManAutorotation,
             self.governortest,

--- a/libraries/AC_Autorotation/AC_Autorotation.cpp
+++ b/libraries/AC_Autorotation/AC_Autorotation.cpp
@@ -2,20 +2,12 @@
 #include <AP_Logger/AP_Logger.h>
 #include <AP_RPM/AP_RPM.h>
 #include <AP_AHRS/AP_AHRS.h>
+#include <GCS_MAVLink/GCS.h>
+
+extern const AP_HAL::HAL& hal;
 
 // Autorotation controller defaults
-// Head Speed (HS) controller specific default definitions
-#define HS_CONTROLLER_COLLECTIVE_CUTOFF_FREQ          2.0f     // low-pass filter on accel error (unit: hz)
-#define HS_CONTROLLER_HEADSPEED_P                     0.7f     // Default P gain for head speed controller (unit: -)
-#define HS_CONTROLLER_ENTRY_COL_FILTER                0.7f    // Default low pass filter frequency during the entry phase (unit: Hz)
-#define HS_CONTROLLER_GLIDE_COL_FILTER                0.1f    // Default low pass filter frequency during the glide phase (unit: Hz)
-
-// Speed Height controller specific default definitions for autorotation use
-#define FWD_SPD_CONTROLLER_GND_SPEED_TARGET           1100     // Default target ground speed for speed height controller (unit: cm/s)
-#define FWD_SPD_CONTROLLER_MAX_ACCEL                  60      // Default acceleration limit for speed height controller (unit: cm/s/s)
-#define AP_FW_VEL_P                       0.9f
-#define AP_FW_VEL_FF                      0.15f
-
+#define HEAD_SPEED_TARGET_RATIO 1.0 // Normalised target main rotor head speed
 
 const AP_Param::GroupInfo AC_Autorotation::var_info[] = {
 
@@ -23,7 +15,7 @@ const AP_Param::GroupInfo AC_Autorotation::var_info[] = {
     // @DisplayName: Enable settings for RSC Setpoint
     // @Description: Allows you to enable (1) or disable (0) the autonomous autorotation capability.
     // @Values: 0:Disabled,1:Enabled
-    // @User: Advanced
+    // @User: Standard
     AP_GROUPINFO_FLAGS("ENABLE", 1, AC_Autorotation, _param_enable, 0, AP_PARAM_FLAG_ENABLE),
 
     // @Param: HS_P
@@ -31,349 +23,433 @@ const AP_Param::GroupInfo AC_Autorotation::var_info[] = {
     // @Description: Increase value to increase sensitivity of head speed controller during autonomous autorotation.
     // @Range: 0.3 1
     // @Increment: 0.01
-    // @User: Advanced
+    // @User: Standard
     AP_SUBGROUPINFO(_p_hs, "HS_", 2, AC_Autorotation, AC_P),
 
     // @Param: HS_SET_PT
     // @DisplayName: Target Head Speed
-    // @Description: The target head speed in RPM during autorotation.  Start by setting to desired hover speed and tune from there as necessary.
+    // @Description: The target head speed in RPM during autorotation. Start by setting to desired hover speed and tune from there as necessary.
     // @Units: RPM
     // @Range: 1000 2800
     // @Increment: 1
-    // @User: Advanced
+    // @User: Standard
     AP_GROUPINFO("HS_SET_PT", 3, AC_Autorotation, _param_head_speed_set_point, 1500),
 
-    // @Param: TARG_SP
-    // @DisplayName: Target Glide Ground Speed
+    // @Param: FWD_SP_TARG
+    // @DisplayName: Target Glide Body Frame Forward Speed
     // @Description: Target ground speed in cm/s for the autorotation controller to try and achieve/ maintain during the glide phase.
-    // @Units: cm/s
-    // @Range: 800 2000
-    // @Increment: 50
-    // @User: Advanced
-    AP_GROUPINFO("TARG_SP", 4, AC_Autorotation, _param_target_speed, FWD_SPD_CONTROLLER_GND_SPEED_TARGET),
+    // @Units: m/s
+    // @Range: 8 20
+    // @Increment: 0.5
+    // @User: Standard
+    AP_GROUPINFO("FWD_SP_TARG", 4, AC_Autorotation, _param_target_speed, 11),
 
     // @Param: COL_FILT_E
     // @DisplayName: Entry Phase Collective Filter
-    // @Description: Cut-off frequency for collective low pass filter.  For the entry phase.  Acts as a following trim.  Must be higher than AROT_COL_FILT_G.
+    // @Description: Cut-off frequency for collective low pass filter. For the entry phase. Acts as a following trim.  Must be higher than AROT_COL_FILT_G.
     // @Units: Hz
     // @Range: 0.2 0.5
     // @Increment: 0.01
-    // @User: Advanced
-    AP_GROUPINFO("COL_FILT_E", 5, AC_Autorotation, _param_col_entry_cutoff_freq, HS_CONTROLLER_ENTRY_COL_FILTER),
+    // @User: Standard
+    AP_GROUPINFO("COL_FILT_E", 5, AC_Autorotation, _param_col_entry_cutoff_freq, 0.7),
 
     // @Param: COL_FILT_G
     // @DisplayName: Glide Phase Collective Filter
-    // @Description: Cut-off frequency for collective low pass filter.  For the glide phase.  Acts as a following trim.  Must be lower than AROT_COL_FILT_E.
+    // @Description: Cut-off frequency for collective low pass filter. For the glide phase. Acts as a following trim.  Must be lower than AROT_COL_FILT_E.
     // @Units: Hz
     // @Range: 0.03 0.15
     // @Increment: 0.01
-    // @User: Advanced
-    AP_GROUPINFO("COL_FILT_G", 6, AC_Autorotation, _param_col_glide_cutoff_freq, HS_CONTROLLER_GLIDE_COL_FILTER),
+    // @User: Standard
+    AP_GROUPINFO("COL_FILT_G", 6, AC_Autorotation, _param_col_glide_cutoff_freq, 0.1),
 
-    // @Param: AS_ACC_MAX
-    // @DisplayName: Forward Acceleration Limit
-    // @Description: Maximum forward acceleration to apply in speed controller.
-    // @Units: cm/s/s
-    // @Range: 30 60
-    // @Increment: 10
-    // @User: Advanced
-    AP_GROUPINFO("AS_ACC_MAX", 7, AC_Autorotation, _param_accel_max, FWD_SPD_CONTROLLER_MAX_ACCEL),
+    // @Param: XY_ACC_MAX
+    // @DisplayName: Body Frame XY Acceleration Limit
+    // @Description: Maximum body frame acceleration allowed in the in speed controller. This limit defines a circular constraint in accel. Minimum used is 0.5 m/s/s.
+    // @Units: m/s/s
+    // @Range: 0.5 8.0
+    // @Increment: 0.1
+    // @User: Standard
+    AP_GROUPINFO("XY_ACC_MAX", 7, AC_Autorotation, _param_accel_max, 2.0),
 
     // @Param: HS_SENSOR
     // @DisplayName: Main Rotor RPM Sensor 
-    // @Description: Allocate the RPM sensor instance to use for measuring head speed.  RPM1 = 0.  RPM2 = 1.
+    // @Description: Allocate the RPM sensor instance to use for measuring head speed. RPM1 = 0.  RPM2 = 1.
     // @Units: s
     // @Range: 0.5 3
     // @Increment: 0.1
-    // @User: Advanced
+    // @User: Standard
     AP_GROUPINFO("HS_SENSOR", 8, AC_Autorotation, _param_rpm_instance, 0),
 
-    // @Param: FW_V_P
-    // @DisplayName: Velocity (horizontal) P gain
-    // @Description: Velocity (horizontal) P gain.  Determines the proportion of the target acceleration based on the velocity error.
-    // @Range: 0.1 6.0
-    // @Increment: 0.1
-    // @User: Advanced
-    AP_SUBGROUPINFO(_p_fw_vel, "FW_V_", 9, AC_Autorotation, AC_P),
+    // @Param: FWD_P
+    // @DisplayName: Forward Speed Controller P Gain
+    // @Description: Converts the difference between desired forward speed and actual speed into an acceleration target that is passed to the pitch angle controller.
+    // @Range: 1.000 8.000
+    // @User: Standard
 
-    // @Param: FW_V_FF
-    // @DisplayName: Velocity (horizontal) feed forward
-    // @Description: Velocity (horizontal) input filter.  Corrects the target acceleration proportionally to the desired velocity.
+    // @Param: FWD_I
+    // @DisplayName: Forward Speed Controller I Gain
+    // @Description: Corrects long-term difference in desired velocity to a target acceleration.
+    // @Range: 0.02 1.00
+    // @Increment: 0.01
+    // @User: Advanced
+
+    // @Param: FWD_IMAX
+    // @DisplayName: Forward Speed Controller I Gain Maximum
+    // @Description: Constrains the target acceleration that the I gain will output.
+    // @Range: 1.000 8.000
+    // @User: Standard
+
+    // @Param: FWD_D
+    // @DisplayName: Forward Speed Controller D Gain
+    // @Description: Provides damping to velocity controller.
+    // @Range: 0.00 1.00
+    // @Increment: 0.001
+    // @User: Advanced
+
+    // @Param: FWD_FF
+    // @DisplayName: Forward Speed Controller Feed Forward Gain
+    // @Description: Produces an output that is proportional to the magnitude of the target.
     // @Range: 0 1
     // @Increment: 0.01
     // @User: Advanced
-    AP_GROUPINFO("FW_V_FF", 10, AC_Autorotation, _param_fwd_k_ff, AP_FW_VEL_FF),
+
+    // @Param: FWD_FLTE
+    // @DisplayName: Forward Speed Controller Error Filter
+    // @Description: This filter low pass filter is applied to the input for P and I terms.
+    // @Range: 0 100
+    // @Units: Hz
+    // @User: Advanced
+
+    // @Param: FWD_FLTD
+    // @DisplayName: Forward Speed Controller input filter for D term
+    // @Description: This filter low pass filter is applied to the input for D terms.
+    // @Range: 0 100
+    // @Units: Hz
+    // @User: Advanced
+    AP_SUBGROUPINFO(_fwd_speed_pid, "FWD_", 9, AC_Autorotation, AC_PID_Basic),
 
     AP_GROUPEND
 };
 
 // Constructor
-AC_Autorotation::AC_Autorotation() :
-    _p_hs(HS_CONTROLLER_HEADSPEED_P),
-    _p_fw_vel(AP_FW_VEL_P)
+AC_Autorotation::AC_Autorotation(AP_MotorsHeli*& motors, AC_AttitudeControl*& att_crtl) :
+    _motors_heli(motors),
+    _attitude_control(att_crtl)
     {
         AP_Param::setup_object_defaults(this, var_info);
     }
 
-
-// Initialisation of head speed controller
-void AC_Autorotation::init_hs_controller()
+void AC_Autorotation::init(void)
 {
-    // Set initial collective position to be the collective position on initialisation
-    _collective_out = 0.4f;
+    // Initialisation of head speed controller
+    // Set initial collective position to be the current collective position for smooth init
+    const float collective_out = _motors_heli->get_throttle_out();
 
     // Reset feed forward filter
-    col_trim_lpf.reset(_collective_out);
+    col_trim_lpf.reset(collective_out);
 
-    // Reset flags
-    _flags.bad_rpm = false;
+    // Protect against divide by zero TODO: move this to an accessor function
+    _param_head_speed_set_point.set(MAX(_param_head_speed_set_point, 500.0));
 
-    // Reset RPM health monitoring
-    _unhealthy_rpm_counter = 0;
-    _healthy_rpm_counter = 0;
-
-    // Protect against divide by zero
-    _param_head_speed_set_point.set(MAX(_param_head_speed_set_point,500));
+    // Reset the landed reason
+    _landed_reason.min_speed = false;
+    _landed_reason.land_col = false;
+    _landed_reason.is_still = false;
 }
 
-
-bool AC_Autorotation::update_hs_glide_controller(float dt)
+// Functions and config that are only to be done once at the beginning of the entry
+void AC_Autorotation::init_entry(void)
 {
-    // Reset rpm health flag
-    _flags.bad_rpm = false;
-    _flags.bad_rpm_warning = false;
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AROT: Entry Phase");
 
-    // Get current rpm and update healthy signal counters
-    _current_rpm = get_rpm(true);
-
-    if (_unhealthy_rpm_counter <=30) {
-        // Normalised head speed
-        float head_speed_norm = _current_rpm / _param_head_speed_set_point;
-
-        // Set collective trim low pass filter cut off frequency
-        col_trim_lpf.set_cutoff_frequency(_col_cutoff_freq);
-
-        // Calculate the head speed error.  Current rpm is normalised by the set point head speed.  
-        // Target head speed is defined as a percentage of the set point.
-        _head_speed_error = head_speed_norm - _target_head_speed;
-
-        _p_term_hs = _p_hs.get_p(_head_speed_error);
-
-        // Adjusting collective trim using feed forward (not yet been updated, so this value is the previous time steps collective position)
-        _ff_term_hs = col_trim_lpf.apply(_collective_out, dt);
-
-        // Calculate collective position to be set
-        _collective_out = _p_term_hs + _ff_term_hs;
-
-    } else {
-        // RPM sensor is bad set collective to minimum
-        _collective_out = -1.0f;
-
-        _flags.bad_rpm_warning = true;
+    // Target head speed is set to rpm at initiation to prevent steps in controller
+    if (!get_norm_head_speed(_target_head_speed)) {
+        // Cannot get a valid RPM sensor reading so we default to not slewing the head speed target
+        _target_head_speed = HEAD_SPEED_TARGET_RATIO;
     }
+
+    // The rate to move the head speed from the current measurement to the target
+    _hs_accel = (HEAD_SPEED_TARGET_RATIO - _target_head_speed) / (float(entry_time_ms)*1e-3);
+
+    // Set collective following trim low pass filter cut off frequency
+    col_trim_lpf.set_cutoff_frequency(_param_col_entry_cutoff_freq.get());
+
+    // Set collective low-pass cut off filter at 2 Hz
+    _motors_heli->set_throttle_filter_cutoff(2.0);
+
+    // Set speed target to maintain the current speed whilst we enter the autorotation
+    _desired_vel = _param_target_speed.get();
+    _target_vel = get_speed_forward();
+
+    // Reset I term of velocity PID
+    _fwd_speed_pid.reset_filter();
+    _fwd_speed_pid.set_integrator(0.0);
+}
+
+// The entry controller just a special case of the glide controller with head speed target slewing
+void AC_Autorotation::run_entry(float pilot_norm_accel)
+{
+    // Slowly change the target head speed until the target head speed matches the parameter defined value
+    float head_speed_norm;
+    if (!get_norm_head_speed(head_speed_norm)) {
+        // RPM sensor is bad, so we don't attempt to slew the head speed target as we do not know what head speed actually is
+        // The collective output handling of the rpm sensor failure is handled later in the head speed controller 
+         head_speed_norm = HEAD_SPEED_TARGET_RATIO;
+    }
+
+    // Slew the head speed target from the initial condition to the target head speed ratio for the glide
+    const float max_change = _hs_accel * _dt;
+    _target_head_speed = constrain_float(HEAD_SPEED_TARGET_RATIO, _target_head_speed - max_change, _target_head_speed + max_change);
+
+    run_glide(pilot_norm_accel);
+}
+
+// Functions and config that are only to be done once at the beginning of the glide
+void AC_Autorotation::init_glide(void)
+{
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AROT: Glide Phase");
+
+    // Set collective following trim low pass filter cut off frequency
+    col_trim_lpf.set_cutoff_frequency(_param_col_glide_cutoff_freq.get());
+
+    // Ensure target head speed is set to setpoint, in case it didn't reach the target during entry
+    _target_head_speed = HEAD_SPEED_TARGET_RATIO;
+
+    // Ensure desired forward speed target is set to param value
+    _desired_vel = _param_target_speed.get();
+}
+
+// Maintain head speed and forward speed as we glide to the ground
+void AC_Autorotation::run_glide(float pilot_norm_accel)
+{
+    update_headspeed_controller();
+
+    update_forward_speed_controller(pilot_norm_accel);
+}
+
+void AC_Autorotation::update_headspeed_controller(void)
+{
+    // Get current rpm and update healthy signal counters
+    float head_speed_norm;
+    if (!get_norm_head_speed(head_speed_norm)) {
+        // RPM sensor is bad, set collective to angle of -2 deg and hope for the best
+         _motors_heli->set_coll_from_ang(-2.0);
+         return;
+    }
+
+    // Calculate the head speed error.
+    _head_speed_error = head_speed_norm - _target_head_speed;
+
+    _p_term_hs = _p_hs.get_p(_head_speed_error);
+
+    // Adjusting collective trim using feed forward (not yet been updated, so this value is the previous time steps collective position)
+    _ff_term_hs = col_trim_lpf.apply(_motors_heli->get_throttle(), _dt);
+
+    // Calculate collective position to be set
+    const float collective_out = constrain_value((_p_term_hs + _ff_term_hs), 0.0f, 1.0f);
 
     // Send collective to setting to motors output library
-    set_collective(HS_CONTROLLER_COLLECTIVE_CUTOFF_FREQ);
+    _motors_heli->set_throttle(collective_out);
 
-    return _flags.bad_rpm_warning;
+#if HAL_LOGGING_ENABLED
+    // @LoggerMessage: ARHS
+    // @Vehicles: Copter
+    // @Description: helicopter AutoRotation Head Speed (ARHS) controller information
+    // @Field: TimeUS: Time since system startup
+    // @Field: Tar: Normalised target head speed
+    // @Field: Act: Normalised measured head speed
+    // @Field: Err: Head speed controller error
+    // @Field: P: P-term for head speed controller response
+    // @Field: FF: FF-term for head speed controller response
+
+    // Write to data flash log
+    AP::logger().WriteStreaming("ARHS",
+                                "TimeUS,Tar,Act,Err,P,FF",
+                                "s-----",
+                                "F00000",
+                                "Qfffff",
+                                AP_HAL::micros64(),
+                                _target_head_speed,
+                                head_speed_norm,
+                                _head_speed_error,
+                                _p_term_hs,
+                                _ff_term_hs);
+#endif
 }
 
-
-// Function to set collective and collective filter in motor library
-void AC_Autorotation::set_collective(float collective_filter_cutoff) const
+// Get measured head speed and normalise by head speed set point. Returns false if a valid rpm measurement cannot be obtained
+bool AC_Autorotation::get_norm_head_speed(float& norm_rpm) const
 {
-    AP_Motors *motors = AP::motors();
-    if (motors) {
-        motors->set_throttle_filter_cutoff(collective_filter_cutoff);
-        motors->set_throttle(_collective_out);
-    }
-}
-
-
-//function that gets rpm and does rpm signal checking to ensure signal is reliable
-//before using it in the controller
-float AC_Autorotation::get_rpm(bool update_counter)
-{
-    float current_rpm = 0.0f;
+    // Assuming zero rpm is safer as it will drive collective in the direction of increasing head speed
+    float current_rpm = 0.0;
 
 #if AP_RPM_ENABLED
     // Get singleton for RPM library
     const AP_RPM *rpm = AP_RPM::get_singleton();
 
-    //Get current rpm, checking to ensure no nullptr
-    if (rpm != nullptr) {
-        //Check requested rpm instance to ensure either 0 or 1.  Always defaults to 0.
-        if ((_param_rpm_instance > 1) || (_param_rpm_instance < 0)) {
-            _param_rpm_instance.set(0);
-        }
-
-        //Get RPM value
-        uint8_t instance = _param_rpm_instance;
-
-        //Check RPM sensor is returning a healthy status
-        if (!rpm->get_rpm(instance, current_rpm) || current_rpm <= -1) {
-            //unhealthy, rpm unreliable
-            _flags.bad_rpm = true;
-        }
-
-    } else {
-        _flags.bad_rpm = true;
+    // Checking to ensure no nullptr, we do have a pre-arm check for this so it will be very bad if RPM has gone away
+    if (rpm == nullptr) {
+        return false;
     }
-#else
-    _flags.bad_rpm = true;
+
+    // Check RPM sensor is returning a healthy status
+    if (!rpm->get_rpm(_param_rpm_instance.get(), current_rpm)) {
+        return false;
+    }
 #endif
 
-    if (_flags.bad_rpm) {
-        //count unhealthy rpm updates and reset healthy rpm counter
-        _unhealthy_rpm_counter++;
-        _healthy_rpm_counter = 0;
+    // Protect against div by zeros later in the code
+    float head_speed_set_point = MAX(1.0, _param_head_speed_set_point.get());
 
-    } else if (!_flags.bad_rpm && _unhealthy_rpm_counter > 0) {
-        //poor rpm reading may have cleared.  Wait 10 update cycles to clear.
-        _healthy_rpm_counter++;
-
-        if (_healthy_rpm_counter >= 10) {
-            //poor rpm health has cleared, reset counters
-            _unhealthy_rpm_counter = 0;
-            _healthy_rpm_counter = 0;
-        }
-    }
-    return current_rpm;
+    // Normalize the RPM by the setpoint
+    norm_rpm = current_rpm/head_speed_set_point;
+    return true;
 }
 
+// Update speed controller
+void AC_Autorotation::update_forward_speed_controller(float pilot_norm_accel)
+{
+    // Limiting the desired velocity based on the max acceleration limit to get an update target
+    const float min_vel = _target_vel - get_accel_max() * _dt;
+    const float max_vel = _target_vel + get_accel_max() * _dt;
+    _target_vel = constrain_float(_desired_vel, min_vel, max_vel); // (m/s)
+
+    // Calculate acceleration target
+    const float fwd_accel_target  = _fwd_speed_pid.update_all(_target_vel, get_speed_forward(), _dt, _limit_accel); // (m/s/s)
+
+    // Build the body frame XY accel vector.
+    // Pilot can request as much as 1/2 of the max accel laterally to perform a turn.
+    // We only allow up to half as we need to prioritize building/maintaining airspeed.
+    Vector2f bf_accel_target = {fwd_accel_target, pilot_norm_accel * get_accel_max() * 0.5};
+
+    // Ensure we do not exceed the accel limit
+    _limit_accel = bf_accel_target.limit_length(get_accel_max());
+
+    // Calculate roll and pitch targets from angles, negative accel for negative pitch (pitch forward)
+    Vector2f angle_target = { accel_to_angle(-bf_accel_target.x), // Pitch
+                              accel_to_angle(bf_accel_target.y)}; // Roll
+
+    // Ensure that the requested angles do not exceed angle max
+    _limit_accel |= angle_target.limit_length(_attitude_control->lean_angle_max_cd());
+
+    // we may have scaled the lateral accel in the angle limit scaling, so we need to
+    // back calculate the resulting accel from this constrained angle for the yaw rate calc
+    const float bf_lat_accel_target = angle_to_accel(angle_target.y);
+
+    // Calc yaw rate from desired body-frame accels
+    // this seems suspiciously simple, but it is correct
+    // accel = r * w^2, r = radius and w = angular rate
+    // radius can be calculated as the distance traveled in the time it takes to do 360 deg
+    // One rotation takes: (2*pi)/w seconds
+    // Distance traveled in that time: (s*2*pi)/w
+    // radius for that distance: ((s*2*pi)/w) / (2*pi)
+    // r = s / w
+    // accel = (s / w) * w^2
+    // accel = s * w
+    // w = accel / s
+    float yaw_rate_cds = 0.0;
+    if (!is_zero(_target_vel)) {
+        yaw_rate_cds = degrees(bf_lat_accel_target / _target_vel) * 100.0;
+    }
+
+    // Output to attitude controller
+    _attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(angle_target.y * 100.0, angle_target.x * 100.0, yaw_rate_cds);
 
 #if HAL_LOGGING_ENABLED
-void AC_Autorotation::Log_Write_Autorotation(void) const
-{
-// @LoggerMessage: AROT
-// @Vehicles: Copter
-// @Description: Helicopter AutoRotation information
-// @Field: TimeUS: Time since system startup
-// @Field: P: P-term for headspeed controller response
-// @Field: hserr: head speed error; difference between current and desired head speed
-// @Field: ColOut: Collective Out
-// @Field: FFCol: FF-term for headspeed controller response
-// @Field: CRPM: current headspeed RPM
-// @Field: SpdF: current forward speed
-// @Field: CmdV: desired forward speed
-// @Field: p: p-term of velocity response
-// @Field: ff: ff-term of velocity response
-// @Field: AccO: forward acceleration output
-// @Field: AccT: forward acceleration target
-// @Field: PitT: pitch target
+    // @LoggerMessage: ARSC
+    // @Vehicles: Copter
+    // @Description: Helicopter AutoRotation Speed Controller (ARSC) information 
+    // @Field: TimeUS: Time since system startup
+    // @Field: Des: Desired forward velocity
+    // @Field: Tar: Target forward velocity
+    // @Field: Act: Measured forward velocity
+    // @Field: P: Velocity to acceleration P-term component
+    // @Field: I: Velocity to acceleration I-term component
+    // @Field: D: Velocity to acceleration D-term component
+    // @Field: FF: Velocity to acceleration feed forward component
+    // @Field: Lim: Accel limit flag
+    // @Field: FA: Forward acceleration target
+    // @Field: LA: Lateral acceleration target
 
-    //Write to data flash log
+    const AP_PIDInfo& pid_info = _fwd_speed_pid.get_pid_info();
+    AP::logger().WriteStreaming("ARSC",
+                                "TimeUS,Des,Tar,Act,P,I,D,FF,Lim,FA,LA",
+                                "snnn-----oo",
+                                "F0000000-00",
+                                "QfffffffBff",
+                                AP_HAL::micros64(),
+                                _desired_vel,
+                                pid_info.target,
+                                pid_info.actual,
+                                pid_info.P,
+                                pid_info.I,
+                                pid_info.D,
+                                pid_info.FF,
+                                uint8_t(_limit_accel),
+                                bf_accel_target.x,
+                                bf_accel_target.y);
+#endif
+}
+
+// smoothly zero velocity and accel
+void AC_Autorotation::run_landed(void)
+{
+    _desired_vel *= 0.95;
+    update_forward_speed_controller(0.0);
+}
+
+// Determine the body frame forward speed
+float AC_Autorotation::get_speed_forward(void) const
+{
+    Vector3f vel_NED = {0,0,0};
+    const AP_AHRS &ahrs = AP::ahrs();
+    if (ahrs.get_velocity_NED(vel_NED)) {
+        vel_NED = ahrs.earth_to_body(vel_NED);
+    }
+    // TODO: need to improve the handling of the velocity NED not ok case
+    return vel_NED.x;
+}
+
+#if HAL_LOGGING_ENABLED
+// Logging of lower rate autorotation specific variables. This is meant for stuff that
+// doesn't need a high rate, e.g. controller variables that are need for tuning.
+void AC_Autorotation::log_write_autorotation(void) const
+{
+    // enum class for bitmask documentation in logging
+    enum class AC_Autorotation_Landed_Reason : uint8_t {
+        LOW_SPEED = 1<<0, // true if below 1 m/s
+        LAND_COL  = 1<<1, // true if collective below land col min
+        IS_STILL  = 1<<2, // passes inertial nav is_still() check
+    };
+
+    uint8_t reason = 0;
+    if (_landed_reason.min_speed) {
+        reason |= uint8_t(AC_Autorotation_Landed_Reason::LOW_SPEED);
+    }
+    if (_landed_reason.land_col) {
+        reason |= uint8_t(AC_Autorotation_Landed_Reason::LAND_COL);
+    }
+    if (_landed_reason.is_still) {
+        reason |= uint8_t(AC_Autorotation_Landed_Reason::IS_STILL);
+    }
+
+    // @LoggerMessage: AROT
+    // @Vehicles: Copter
+    // @Description: Helicopter AutoROTation (AROT) information
+    // @Field: TimeUS: Time since system startup
+    // @Field: LR: Landed Reason state flags
+    // @FieldBitmaskEnum: LR: AC_Autorotation_Landed_Reason
+
+    // Write to data flash log
     AP::logger().WriteStreaming("AROT",
-                       "TimeUS,P,hserr,ColOut,FFCol,CRPM,SpdF,CmdV,p,ff,AccO,AccT,PitT",
-                         "Qffffffffffff",
-                        AP_HAL::micros64(),
-                        (double)_p_term_hs,
-                        (double)_head_speed_error,
-                        (double)_collective_out,
-                        (double)_ff_term_hs,
-                        (double)_current_rpm,
-                        (double)_speed_forward,
-                        (double)_cmd_vel,
-                        (double)_vel_p,
-                        (double)_vel_ff,
-                        (double)_accel_out,
-                        (double)_accel_target,
-                        (double)_pitch_target);
+                                "TimeUS,LR",
+                                "s-",
+                                "F-",
+                                "QB",
+                                AP_HAL::micros64(),
+                                _landed_reason);
 }
 #endif  // HAL_LOGGING_ENABLED
-
-// Initialise forward speed controller
-void AC_Autorotation::init_fwd_spd_controller(void)
-{
-    // Reset I term and acceleration target
-    _accel_target = 0.0f;
-    
-    // Ensure parameter acceleration doesn't exceed hard-coded limit
-    _accel_max = MIN(_param_accel_max, 60.0f);
-
-    // Reset cmd vel and last accel to sensible values
-    _cmd_vel = calc_speed_forward(); //(cm/s)
-    _accel_out_last = _cmd_vel*_param_fwd_k_ff;
-}
-
-
-// set_dt - sets time delta in seconds for all controllers
-void AC_Autorotation::set_dt(float delta_sec)
-{
-    _dt = delta_sec;
-}
-
-
-// update speed controller
-void AC_Autorotation::update_forward_speed_controller(void)
-{
-    // Specify forward velocity component and determine delta velocity with respect to time
-    _speed_forward = calc_speed_forward(); //(cm/s)
-
-    _delta_speed_fwd = _speed_forward - _speed_forward_last; //(cm/s)
-    _speed_forward_last = _speed_forward; //(cm/s)
-
-    // Limiting the target velocity based on the max acceleration limit
-    if (_cmd_vel < _vel_target) {
-        _cmd_vel += _accel_max * _dt;
-        if (_cmd_vel > _vel_target) {
-            _cmd_vel = _vel_target;
-        }
-    } else {
-        _cmd_vel -= _accel_max * _dt;
-        if (_cmd_vel < _vel_target) {
-            _cmd_vel = _vel_target;
-        }
-    }
-
-    // get p
-    _vel_p = _p_fw_vel.get_p(_cmd_vel-_speed_forward);
-
-    // get ff
-    _vel_ff = _cmd_vel*_param_fwd_k_ff;
-
-    //calculate acceleration target based on PI controller
-    _accel_target = _vel_ff + _vel_p;
-
-    // filter correction acceleration
-    _accel_target_filter.set_cutoff_frequency(10.0f);
-    _accel_target_filter.apply(_accel_target, _dt);
-
-    //Limits the maximum change in pitch attitude based on acceleration
-    if (_accel_target > _accel_out_last + _accel_max) {
-        _accel_target = _accel_out_last + _accel_max;
-    } else if (_accel_target < _accel_out_last - _accel_max) {
-        _accel_target = _accel_out_last - _accel_max;
-    }
-
-    //Limiting acceleration based on velocity gained during the previous time step 
-    if (fabsf(_delta_speed_fwd) > _accel_max * _dt) {
-        _flag_limit_accel = true;
-    } else {
-        _flag_limit_accel = false;
-    }
-
-    if ((_flag_limit_accel && fabsf(_accel_target) < fabsf(_accel_out_last)) || !_flag_limit_accel) {
-        _accel_out = _accel_target;
-    } else {
-        _accel_out = _accel_out_last;
-    }
-    _accel_out_last = _accel_out;
-
-    // update angle targets that will be passed to stabilize controller
-    _pitch_target = accel_to_angle(-_accel_out*0.01) * 100;
-
-}
-
-
-// Determine the forward ground speed component from measured components
-float AC_Autorotation::calc_speed_forward(void)
-{
-    auto &ahrs = AP::ahrs();
-    Vector2f groundspeed_vector = ahrs.groundspeed_vector();
-    float speed_forward = (groundspeed_vector.x*ahrs.cos_yaw() + groundspeed_vector.y*ahrs.sin_yaw())* 100; //(c/s)
-    return speed_forward;
-}
 
 // Arming checks for autorotation, mostly checking for miss-configurations
 bool AC_Autorotation::arming_checks(size_t buflen, char *buffer) const
@@ -382,8 +458,6 @@ bool AC_Autorotation::arming_checks(size_t buflen, char *buffer) const
         // Don't run arming checks if not enabled
         return true;
     }
-
-    const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
     // Check for correct RPM sensor config
 #if AP_RPM_ENABLED
@@ -397,7 +471,7 @@ bool AC_Autorotation::arming_checks(size_t buflen, char *buffer) const
     }
 
     // Sanity check that the designated rpm sensor instance is there
-    if ((_param_rpm_instance.get() < 0)) {
+    if (_param_rpm_instance.get() < 0) {
         hal.util->snprintf(buffer, buflen, "RPM instance <0");
         return false;
     }
@@ -408,6 +482,37 @@ bool AC_Autorotation::arming_checks(size_t buflen, char *buffer) const
     }
 #endif
 
+    // Check that heli motors is configured for autorotation
+    if (!_motors_heli->rsc_autorotation_enabled()) {
+        hal.util->snprintf(buffer, buflen, "H_RSC_AROT_* not configured");
+        return false;
+    }
+
     return true;
 }
 
+// Check if we believe we have landed. We need the landed state to zero all
+// controls and make sure that the copter landing detector will trip
+bool AC_Autorotation::check_landed(void)
+{
+    // minimum speed (m/s) used for "is moving" check
+    const float min_moving_speed = 1.0;
+
+    Vector3f velocity;
+    const AP_AHRS &ahrs = AP::ahrs();
+    _landed_reason.min_speed = ahrs.get_velocity_NED(velocity) && (velocity.length() < min_moving_speed);
+    _landed_reason.land_col = _motors_heli->get_below_land_min_coll();
+    _landed_reason.is_still = AP::ins().is_still();
+
+    return _landed_reason.min_speed && _landed_reason.land_col && _landed_reason.is_still;
+}
+
+// Dynamically update time step used in autorotation controllers
+void AC_Autorotation::set_dt(float delta_sec)
+{
+    if (is_positive(delta_sec)) {
+        _dt = delta_sec;
+        return;
+    }
+    _dt = 2.5e-3; // Assume 400 Hz
+}

--- a/libraries/AC_Autorotation/AC_Autorotation.h
+++ b/libraries/AC_Autorotation/AC_Autorotation.h
@@ -18,6 +18,16 @@ public:
     AC_Autorotation();
 
     //--------Functions--------
+    bool enabled(void) const { return _param_enable.get() > 0; }
+
+
+
+    // Arming checks for autorotation, mostly checking for miss-configurations
+    bool arming_checks(size_t buflen, char *buffer) const;
+
+
+
+    // not yet checked
     void init_hs_controller(void);  // Initialise head speed controller
     void init_fwd_spd_controller(void);  // Initialise forward speed controller
     bool update_hs_glide_controller(float dt);  // Update head speed controller
@@ -29,7 +39,6 @@ public:
     float get_col_entry_freq(void) { return _param_col_entry_cutoff_freq; }
     float get_col_glide_freq(void) { return _param_col_glide_cutoff_freq; }
     float get_last_collective() const { return _collective_out; }
-    bool is_enable(void) { return _param_enable; }
     void Log_Write_Autorotation(void) const;
     void update_forward_speed_controller(void);  // Update forward speed controller
     void set_desired_fwd_speed(void) { _vel_target = _param_target_speed; } // Overloaded: Set desired speed for forward controller to parameter value

--- a/libraries/AC_Autorotation/AC_Autorotation.h
+++ b/libraries/AC_Autorotation/AC_Autorotation.h
@@ -5,102 +5,99 @@
 #include <AP_Math/AP_Math.h>
 #include <AP_Motors/AP_Motors.h>
 #include <AP_Motors/AP_MotorsHeli_RSC.h>
-#include <Filter/Filter.h>
 #include <Filter/LowPassFilter.h>
 #include <AC_PID/AC_P.h>
-
+#include <AC_PID/AC_PID_Basic.h>
+#include <AC_AttitudeControl/AC_AttitudeControl.h>
 
 class AC_Autorotation
 {
 public:
 
     //Constructor
-    AC_Autorotation();
+    AC_Autorotation(AP_MotorsHeli*& motors, AC_AttitudeControl*& att_crtl);
 
-    //--------Functions--------
+    void init(void);
+
     bool enabled(void) const { return _param_enable.get() > 0; }
 
+    // Init and run entry phase controller
+    void init_entry(void);
+    void run_entry(float pilot_norm_accel);
 
+    // Init and run the glide phase controller
+    void init_glide(void);
+    void run_glide(float pilot_norm_accel);
+
+    // Run the landed phase controller to zero the desired vels and accels
+    void run_landed(void);
 
     // Arming checks for autorotation, mostly checking for miss-configurations
     bool arming_checks(size_t buflen, char *buffer) const;
 
+    // Logging of lower rate autorotation specific variables
+    void log_write_autorotation(void) const;
 
+    // Returns true if we have met the autorotation-specific reasons to think we have landed
+    bool check_landed(void);
 
-    // not yet checked
-    void init_hs_controller(void);  // Initialise head speed controller
-    void init_fwd_spd_controller(void);  // Initialise forward speed controller
-    bool update_hs_glide_controller(float dt);  // Update head speed controller
-    float get_rpm(void) const { return _current_rpm; }  // Function just returns the rpm as last read in this library
-    float get_rpm(bool update_counter);  // Function fetches fresh rpm update and continues sensor health monitoring
-    void set_target_head_speed(float ths) { _target_head_speed = ths; }  // Sets the normalised target head speed
-    void set_col_cutoff_freq(float freq) { _col_cutoff_freq = freq; }  // Sets the collective low pass filter cut off frequency
-    int16_t get_hs_set_point(void) { return _param_head_speed_set_point; }
-    float get_col_entry_freq(void) { return _param_col_entry_cutoff_freq; }
-    float get_col_glide_freq(void) { return _param_col_glide_cutoff_freq; }
-    float get_last_collective() const { return _collective_out; }
-    void Log_Write_Autorotation(void) const;
-    void update_forward_speed_controller(void);  // Update forward speed controller
-    void set_desired_fwd_speed(void) { _vel_target = _param_target_speed; } // Overloaded: Set desired speed for forward controller to parameter value
-    void set_desired_fwd_speed(float speed) { _vel_target = speed; } // Overloaded: Set desired speed to argument value
-    int32_t get_pitch(void) const { return _pitch_target; }  // Get pitch target
-    float calc_speed_forward(void);  // Calculates the forward speed in the horizontal plane
+    // Dynamically update time step used in autorotation controllers
     void set_dt(float delta_sec);
+
+    // Helper to get measured head speed that has been normalised by head speed set point
+    bool get_norm_head_speed(float& norm_rpm) const;
 
     // User Settable Parameters
     static const struct AP_Param::GroupInfo var_info[];
 
+    static const uint32_t entry_time_ms = 2000; // (ms) Number of milliseconds that the entry phase operates for
+
 private:
 
-    //--------Internal Variables--------
-    float _current_rpm;
-    float _collective_out;
-    float _head_speed_error;         // Error between target head speed and current head speed.  Normalised by head speed set point RPM.
-    float _col_cutoff_freq;          // Lowpass filter cutoff frequency (Hz) for collective.
-    uint8_t _unhealthy_rpm_counter;  // Counter used to track RPM sensor unhealthy signal.
-    uint8_t _healthy_rpm_counter;    // Counter used to track RPM sensor healthy signal.
-    float _target_head_speed;        // Normalised target head speed.  Normalised by head speed set point RPM.
-    float _p_term_hs;                // Proportional contribution to collective setting.
-    float _ff_term_hs;               // Following trim feed forward contribution to collective setting.
+    // References to other libraries
+    AP_MotorsHeli*&    _motors_heli;
+    AC_AttitudeControl*& _attitude_control;
 
-    float _vel_target;               // Forward velocity target.
-    float _pitch_target;             // Pitch angle target.
-    float _accel_max;                // Maximum acceleration limit.
-    int16_t _speed_forward_last;       // The forward speed calculated in the previous cycle.
-    bool _flag_limit_accel;          // Maximum acceleration limit reached flag.
-    float _accel_out_last;           // Acceleration value used to calculate pitch target in previous cycle.
-    float _cmd_vel;                  // Command velocity, used to get PID values for acceleration calculation.
-    float _accel_target;             // Acceleration target, calculated from PID.
-    float _delta_speed_fwd;          // Change in forward speed between computation cycles.
-    float _dt;                       // Time step.
-    int16_t _speed_forward;            // Measured forward speed.
-    float _vel_p;                    // Forward velocity P term.
-    float _vel_ff;                   // Forward velocity Feed Forward term.
-    float _accel_out;                // Acceleration value used to calculate pitch target.
+    // Calculates the forward ground speed in the horizontal plane
+    float get_speed_forward(void) const;
 
-    LowPassFilterFloat _accel_target_filter; // acceleration target filter
+    // (s) Time step, updated dynamically from vehicle
+    float _dt; 
 
-    //--------Parameter Values--------
+    // Parameter values
     AP_Int8  _param_enable;
-    AC_P _p_hs;
-    AC_P _p_fw_vel;
-    AP_Int16 _param_head_speed_set_point;
-    AP_Int16 _param_target_speed;
+    AC_P _p_hs{1.0};
+    AP_Float _param_head_speed_set_point;
+    AP_Float _param_target_speed;
     AP_Float _param_col_entry_cutoff_freq;
     AP_Float _param_col_glide_cutoff_freq;
-    AP_Int16 _param_accel_max;
+    AP_Float _param_accel_max;
     AP_Int8  _param_rpm_instance;
     AP_Float _param_fwd_k_ff;
 
-    //--------Internal Flags--------
-    struct controller_flags {
-            bool bad_rpm             : 1;
-            bool bad_rpm_warning     : 1;
-    } _flags;
+    // Forward speed controller
+    void update_forward_speed_controller(float pilot_norm_accel);
+    AC_PID_Basic _fwd_speed_pid{2.0, 2.0, 0.2, 0.1, 4.0, 0.0, 10.0};  // PID object for vel to accel controller, Default values for kp, ki, kd, kff, imax, filt E Hz, filt D Hz
+    bool _limit_accel;            // flag used for limiting integrator wind up if vehicle is against an accel or angle limit
+    float _desired_vel;           // (m/s) This is the velocity that we want.  This is the variable that is set by the invoking function to request a certain speed
+    float _target_vel;            // (m/s) This is the acceleration constrained velocity that we are allowed
 
-    //--------Internal Functions--------
-    void set_collective(float _collective_filter_cutoff) const;
+    // Head speed controller variables
+    void update_headspeed_controller(void);  // Update controller used to drive head speed with collective
+    float _hs_accel;                         // The head speed target acceleration during the entry phase
+    float _head_speed_error;                 // Error between target head speed and current head speed. Normalised by head speed set point RPM.
+    float _target_head_speed;                // Normalised target head speed.  Normalised by head speed set point RPM.
+    float _p_term_hs;                        // Proportional contribution to collective setting.
+    float _ff_term_hs;                       // Following trim feed forward contribution to collective setting.
+    LowPassFilterFloat col_trim_lpf;         // Low pass filter for collective trim
 
-    // low pass filter for collective trim
-    LowPassFilterFloat col_trim_lpf;
+    // Flags used to check if we believe the aircraft has landed
+    struct {
+        bool min_speed;
+        bool land_col;
+        bool is_still;
+    } _landed_reason;
+
+    // Parameter accessors that provide value constraints
+    float get_accel_max(void) const { return MAX(_param_accel_max.get(), 0.5); }
 };

--- a/libraries/AC_Autorotation/RSC_Autorotation.cpp
+++ b/libraries/AC_Autorotation/RSC_Autorotation.cpp
@@ -56,7 +56,7 @@ RSC_Autorotation::RSC_Autorotation(void)
 // to force the state to be immediately deactivated, then the force_state bool is used
 void RSC_Autorotation::set_active(bool active, bool force_state)
 {
-    if (enable.get() != 1) {
+    if (!enabled()) {
         return;
     }
 

--- a/libraries/AC_Autorotation/RSC_Autorotation.h
+++ b/libraries/AC_Autorotation/RSC_Autorotation.h
@@ -20,6 +20,7 @@ public:
     // state accessors
     bool active(void) const { return state == State::ACTIVE; }
     bool bailing_out(void) const { return state == State::BAILING_OUT; }
+    bool enabled(void) const { return enable.get() == 1; }
 
     // update idle throttle when in autorotation
     bool get_idle_throttle(float& idle_throttle);

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -648,3 +648,10 @@ void AP_MotorsHeli::heli_motors_param_conversions(void)
         AP_Param::convert_old_parameter(&rsc_arot_conversion_info[i], 1.0);
     }
 }
+
+// function to calculate and set the normalised collective position given a desired blade pitch angle (deg)
+void AP_MotorsHeli::set_coll_from_ang(float col_ang_deg)
+{
+    const float col_norm = (col_ang_deg - _collective_min_deg.get()) / MAX((_collective_max_deg.get() - _collective_min_deg.get()), 1.0);
+    set_throttle(constrain_float(col_norm, 0.0, 1.0));
+}

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -130,10 +130,16 @@ public:
     // true if bailing out autorotation
     bool autorotation_bailout(void) const { return _main_rotor.autorotation.bailing_out(); }
 
+    // true if the autorotation functionality within the rsc has been enabled
+    bool rsc_autorotation_enabled(void) const { return _main_rotor.autorotation.enabled(); }
+
     // set land complete flag
     void set_land_complete(bool landed) { _heliflags.land_complete = landed; }
-	
-	//return zero lift collective position
+
+    // function to calculate and set the normalised collective position given a desired blade pitch angle (deg)
+    void set_coll_from_ang(float col_ang_deg);
+
+    //return zero lift collective position
     float get_coll_mid() const { return _collective_zero_thrust_pct; }
 
     // enum for heli optional features

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -427,11 +427,7 @@ void AP_MotorsHeli_Dual::move_actuators(float roll_out, float pitch_out, float c
     }
 
     // updates below land min collective flag
-    if (collective_out <= _collective_land_min_pct) {
-        _heliflags.below_land_min_coll = true;
-    } else {
-        _heliflags.below_land_min_coll = false;
-    }
+    _heliflags.below_land_min_coll = !is_positive(collective_out - _collective_land_min_pct);
 
     // updates takeoff collective flag based on 50% hover collective
     update_takeoff_collective_flag(collective_out);

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -189,11 +189,7 @@ void AP_MotorsHeli_Quad::move_actuators(float roll_out, float pitch_out, float c
     }
 
     // updates below land min collective flag
-    if (collective_out <= _collective_land_min_pct) {
-        _heliflags.below_land_min_coll = true;
-    } else {
-        _heliflags.below_land_min_coll = false;
-    }
+    _heliflags.below_land_min_coll = !is_positive(collective_out - _collective_land_min_pct);
 
     // updates takeoff collective flag based on 50% hover collective
     update_takeoff_collective_flag(collective_out);

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -394,11 +394,7 @@ void AP_MotorsHeli_Single::move_actuators(float roll_out, float pitch_out, float
     }
 
     // updates below land min collective flag
-    if (collective_out <= _collective_land_min_pct) {
-        _heliflags.below_land_min_coll = true;
-    } else {
-        _heliflags.below_land_min_coll = false;
-    }
+    _heliflags.below_land_min_coll = !is_positive(collective_out - _collective_land_min_pct);
 
     // updates takeoff collective flag based on 50% hover collective
     update_takeoff_collective_flag(collective_out);


### PR DESCRIPTION
This PR is the next step in bringing on the autorotation flight mode.  It builds on the work done in #27786 and is dependant upon it.  Hence, the diff looks very large at the moment.

The following changes have been made:
- A much needed re-structure to move more of the code out of the mode and down into the autorotation library
- Add pre-arm checks specific to the autorotation mode
- Improvement of the speed controller by moving to a full PID instead of just P and FF.  Also, the accel limiting that I had previously implemented was a bit weird, so I have improved that.
- Move from a stabilise style control where pilot has to do both yaw and roll control, to a lateral acceleration controller, whereby pilot requests a lateral accel component and the controller figures out the roll angle and yaw rate needed to do a co-ordinated turn.

Testing has been in Real flight only.

The majority of this PR is still behind the SITL only wall.

**Special attention should be paid to the changes in AP_MotorsHeli_Single, _Dual & _Quad** whereby I have slightly modified the way we detect the collective is on land col min.  A modification to the autorotation auto test highlighted that this flag was not tripping when collective was being constrained to land col min. **This bit is not SITL only**