### PR TITLE
AP_BattMonitor: Set the number of battery monitors to the supported number

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -13,7 +13,7 @@
 
 // maximum number of battery monitors
 #ifndef AP_BATT_MONITOR_MAX_INSTANCES
-#define AP_BATT_MONITOR_MAX_INSTANCES       9
+#define AP_BATT_MONITOR_MAX_INSTANCES       16
 #endif
 
 // first monitor is always the primary monitor


### PR DESCRIPTION
The number of battery monitors is supported up to 16. 
The default maximum value is set to 9. For many devices, the maximum value is set to the supported number. 
I will adjust to match the others.

AFTER
![Screenshot from 2024-09-24 18-40-10](https://github.com/user-attachments/assets/7b3c3133-cbac-4110-b114-8e8c2b161a07)

