### PR TITLE
hwdef: correct compilation for MFT-SEMA100

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/MFT-SEMA100/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MFT-SEMA100/hwdef.dat
@@ -11,8 +11,8 @@ APJ_BOARD_ID 2000
 
 FLASH_SIZE_KB 2048
 
-# with 2M flash we can afford to optimize for speed
-env OPTIMIZE -O2
+# 
+env OPTIMIZE -Os
 
 # ChibiOS system timer
 STM32_ST_USE_TIMER 2


### PR DESCRIPTION
this board uses 2 128kB sectors for storage, meaning it is very short on space

Remove features we are likely to remove for everyone in 4.7

![image](https://github.com/user-attachments/assets/a958aac7-9843-4bd9-8762-507b49485e3b)

@EternAlmox - those 128kB sectors really do hurt the available flash on these boards. 

We're looking at putting a feature in to use a single page of storage for parameters, but that's problematic from both a migration POV and from a data sanctity POV (there's a race condition when "compacting" storage when it fills up).  We'll see how we go.
