### PR TITLE
AP_BattMonitor: add option minimum volt option

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
@@ -154,7 +154,7 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: Battery monitor options
     // @Description: This sets options to change the behaviour of the battery monitor
-    // @Bitmask: 0:Ignore DroneCAN SoC, 1:MPPT reports input voltage and current, 2:MPPT Powered off when disarmed, 3:MPPT Powered on when armed, 4:MPPT Powered off at boot, 5:MPPT Powered on at boot, 6:Send resistance compensated voltage to GCS, 7:Allow DroneCAN InfoAux to be from a different CAN node
+    // @Bitmask: 0:Ignore DroneCAN SoC, 1:MPPT reports input voltage and current, 2:MPPT Powered off when disarmed, 3:MPPT Powered on when armed, 4:MPPT Powered off at boot, 5:MPPT Powered on at boot, 6:Send resistance compensated voltage to GCS, 7:Allow DroneCAN InfoAux to be from a different CAN node, 9:Sum monitor measures minimum voltage instead of average
     // @User: Advanced
     AP_GROUPINFO("OPTIONS", 21, AP_BattMonitor_Params, _options, 0),
 #endif // HAL_BUILD_AP_PERIPH

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
@@ -27,6 +27,7 @@ public:
         GCS_Resting_Voltage                 = (1U<<6),  // send resistance resting voltage to GCS
         AllowSplitAuxInfo                   = (1U<<7),  // allow different node to provide aux info for DroneCAN
         InternalUseOnly                     = (1U<<8),  // for use internally to ArduPilot, not to be (eg.) sent via MAVLink BATTERY_STATUS
+        Minimum_Voltage                     = (1U<<9),  // sum monitor measures minimum voltage rather than average
     };
 
     BattMonitor_LowVoltage_Source failsafe_voltage_source(void) const { return (enum BattMonitor_LowVoltage_Source)_failsafe_voltage_source.get(); }


### PR DESCRIPTION
Alternative approach to #28148

This solves the race condition issue and the Wh consumption calculation. Instead of calling `update_consumed` again, it sums the consumption calculation from the other monitors. This is actually much better than integrating it again manually, especially if the underlying monitors are better at calculating the consumption.

I also removed the implementation on the ESC battmon backend (and updated the param docs and comments to match). I don't think it was nearly as important to have this option for the ESC backend and I couldn't use the same trick with that one.