### PR TITLE
Serial passthrough parity backport

### DIFF
--- a/libraries/AP_HAL/UARTDriver.cpp
+++ b/libraries/AP_HAL/UARTDriver.cpp
@@ -163,3 +163,9 @@ uint64_t AP_HAL::UARTDriver::receive_time_constraint_us(uint16_t nbytes)
 {
     return AP_HAL::micros64();
 }
+
+uint8_t AP_HAL::UARTDriver::get_parity(void)
+{
+    return AP_HAL::UARTDriver::parity;
+}
+

--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -77,6 +77,9 @@ public:
 
     // read buffer from a locked port. If port is locked and key is not correct then -1 is returned
     ssize_t read_locked(uint8_t *buf, size_t count, uint32_t key) WARN_IF_UNUSED;
+
+    // get current parity for passthrough use
+    uint8_t get_parity(void);
     
     // control optional features
     virtual bool set_options(uint16_t options) { _last_options = options; return options==0; }
@@ -166,6 +169,9 @@ public:
     // return true requested baud on USB port
     virtual uint32_t get_usb_baud(void) const { return 0; }
 
+    // return requested parity on USB port
+    virtual uint8_t get_usb_parity(void) const { return parity; }
+
     // disable TX/RX pins for unusued uart
     virtual void disable_rxtx(void) const {}
 
@@ -189,6 +195,8 @@ protected:
     // key for a locked port
     uint32_t lock_write_key;
     uint32_t lock_read_key;
+
+    uint8_t parity;
 
     /*
       backend begin method

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -672,6 +672,19 @@ uint32_t UARTDriver::get_usb_baud() const
     return 0;
 }
 
+/*
+    get the requested usb parity.  Valid if get_usb_baud() returned non-zero.
+*/
+uint8_t UARTDriver::get_usb_parity() const
+{
+#if HAL_USE_SERIAL_USB
+    if (sdef.is_usb) {
+        return ::get_usb_parity(sdef.endpoint_id);
+    }
+#endif
+    return 0;
+}
+
 uint32_t UARTDriver::_available()
 {
     if (!_rx_initialised || _uart_owner_thd != chThdGetSelfX()) {
@@ -1402,6 +1415,7 @@ void UARTDriver::configure_parity(uint8_t v)
         // not possible
         return;
     }
+    UARTDriver::parity = v;
 #if HAL_USE_SERIAL == TRUE
     // stop and start to take effect
     sdStop((SerialDriver*)sdef.serial);

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -38,6 +38,7 @@ public:
     bool is_initialized() override;
     bool tx_pending() override;
     uint32_t get_usb_baud() const override;
+    uint8_t get_usb_parity() const override;
 
     // disable TX/RX pins for unusued uart
     void disable_rxtx(void) const override;

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/usbcfg.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/usbcfg.c
@@ -251,6 +251,18 @@ uint32_t get_usb_baud(uint16_t endpoint_id)
     }
     return 0;
 }
+
+/*
+    get the requested usb parity.  Valid if get_usb_baud() returned non-zero
+*/
+uint8_t get_usb_parity(uint16_t endpoint_id)
+{
+      if (endpoint_id == 0) {
+          return linecoding.bParityType;
+      }
+
+      return 0;
+}
 #endif
 /**
  * @brief   IN EP1 state.

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/usbcfg.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/usbcfg.h
@@ -46,6 +46,7 @@ extern SerialUSBDriver SDU2;
 extern const SerialUSBConfig serusbcfg2;
 #endif //HAL_HAVE_DUAL_USB_CDC
 uint32_t get_usb_baud(uint16_t endpoint_id);
+uint8_t get_usb_parity(uint16_t endpoint_id);
 #endif
 #define USB_DESC_MAX_STRLEN 100
 void setup_usb_strings(void);

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/usbcfg_dualcdc.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/usbcfg_dualcdc.c
@@ -315,6 +315,19 @@ uint32_t get_usb_baud(uint16_t endpoint_id)
   }
   return 0;
 }
+
+/*
+    get the requested usb parity.  Valid if get_usb_baud() returned non-zero
+*/
+uint8_t get_usb_parity(uint16_t endpoint_id)
+{
+  for (uint8_t i = 0; i < ARRAY_SIZE(linecoding); i++) {
+      if (endpoint_id == ep_index[i]) {
+          return linecoding[i].bParityType;
+      }
+  }
+  return 0;
+}
 #endif
 /**
  * @brief   IN EP1 state.

--- a/libraries/AP_HAL_Linux/UARTDriver.cpp
+++ b/libraries/AP_HAL_Linux/UARTDriver.cpp
@@ -417,6 +417,7 @@ void UARTDriver::_timer_tick(void)
 }
 
 void UARTDriver::configure_parity(uint8_t v) {
+    UARTDriver::parity = v;
     _device->set_parity(v);
 }
 

--- a/libraries/AP_HAL_SITL/UART_utils.cpp
+++ b/libraries/AP_HAL_SITL/UART_utils.cpp
@@ -73,6 +73,7 @@ void HALSITL::UARTDriver::configure_parity(uint8_t v)
     if (_fd < 0) {
         return;
     }
+    UARTDriver::parity = v;
 #ifdef USE_TERMIOS
     struct termios t;
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -1316,6 +1316,8 @@ private:
         uint32_t last_port1_data_ms;
         uint32_t baud1;
         uint32_t baud2;
+        uint8_t parity1;
+        uint8_t parity2;
         uint8_t timeout_s;
         HAL_Semaphore sem;
     } _passthru;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -6541,6 +6541,7 @@ void GCS::update_passthru(void)
     WITH_SEMAPHORE(_passthru.sem);
     uint32_t now = AP_HAL::millis();
     uint32_t baud1, baud2;
+    uint8_t parity1 = 0, parity2 = 0;
     bool enabled = AP::serialmanager().get_passthru(_passthru.port1, _passthru.port2, _passthru.timeout_s,
                                                     baud1, baud2);
     if (enabled && !_passthru.enabled) {
@@ -6550,6 +6551,8 @@ void GCS::update_passthru(void)
         _passthru.last_port1_data_ms = now;
         _passthru.baud1 = baud1;
         _passthru.baud2 = baud2;
+        _passthru.parity1 = parity1 = _passthru.port1->get_parity();
+        _passthru.parity2 = parity2 = _passthru.port2->get_parity();
         gcs().send_text(MAV_SEVERITY_INFO, "Passthru enabled");
         if (!_passthru.timer_installed) {
             _passthru.timer_installed = true;
@@ -6567,6 +6570,13 @@ void GCS::update_passthru(void)
         if (_passthru.baud2 != baud2) {
             _passthru.port2->end();
             _passthru.port2->begin(baud2);
+        }
+        // Restore original parity
+        if (_passthru.parity1 != parity1) {
+            _passthru.port1->configure_parity(parity1);
+        }
+        if (_passthru.parity2 != parity2) {
+            _passthru.port2->configure_parity(parity2);
         }
         gcs().send_text(MAV_SEVERITY_INFO, "Passthru disabled");
     } else if (enabled &&
@@ -6586,12 +6596,19 @@ void GCS::update_passthru(void)
             _passthru.port2->end();
             _passthru.port2->begin(baud2);
         }
+        // Restore original parity
+        if (_passthru.parity1 != parity1) {
+            _passthru.port1->configure_parity(parity1);
+        }
+        if (_passthru.parity2 != parity2) {
+            _passthru.port2->configure_parity(parity2);
+        }
         gcs().send_text(MAV_SEVERITY_INFO, "Passthru timed out");
     }
 }
 
 /*
-  called at 1kHz to handle pass-thru between SERIA0_PASSTHRU port and hal.console
+  called at 1kHz to handle pass-thru between SERIAL_PASS1 and SERIAL_PASS2 ports
  */
 void GCS::passthru_timer(void)
 {
@@ -6604,7 +6621,7 @@ void GCS::passthru_timer(void)
     if (_passthru.start_ms != 0) {
         uint32_t now = AP_HAL::millis();
         if (now - _passthru.start_ms < 1000) {
-            // delay for 1s so the reply for the SERIAL0_PASSTHRU param set can be seen by GCS
+            // delay for 1s so the reply for the SERIAL_PASS2 param set can be seen by GCS
             return;
         }
         _passthru.start_ms = 0;
@@ -6618,19 +6635,35 @@ void GCS::passthru_timer(void)
     _passthru.port1->lock_port(lock_key, lock_key);
     _passthru.port2->lock_port(lock_key, lock_key);
 
-    // Check for requested Baud rates over USB
+    // Check for requested Baud rates and parity over USB
     uint32_t baud = _passthru.port1->get_usb_baud();
-    if (_passthru.baud2 != baud && baud != 0) {
-        _passthru.baud2 = baud;
-        _passthru.port2->end();
-        _passthru.port2->begin_locked(baud, 0, 0, lock_key);
+    uint8_t parity = _passthru.port1->get_usb_parity();
+    if (baud != 0) { // port1 is USB
+        if (_passthru.baud2 != baud) {
+            _passthru.baud2 = baud;
+            _passthru.port2->end();
+            _passthru.port2->begin_locked(baud, 0, 0, lock_key);
+        }
+
+        if (_passthru.parity2 != parity) {
+            _passthru.parity2 = parity;
+            _passthru.port2->configure_parity(parity);
+        }
     }
 
     baud = _passthru.port2->get_usb_baud();
-    if (_passthru.baud1 != baud && baud != 0) {
-        _passthru.baud1 = baud;
-        _passthru.port1->end();
-        _passthru.port1->begin_locked(baud, 0, 0, lock_key);
+    parity = _passthru.port2->get_usb_parity();
+    if (baud != 0) { // port2 is USB
+        if (_passthru.baud1 != baud) {
+            _passthru.baud1 = baud;
+            _passthru.port1->end();
+            _passthru.port1->begin_locked(baud, 0, 0, lock_key);
+        }
+
+        if (_passthru.parity1 != parity) {
+            _passthru.parity1 = parity;
+            _passthru.port1->configure_parity(parity);
+        }
     }
 
     uint8_t buf[64];


### PR DESCRIPTION
These are cherry picked from my local Copter-4.5 branch which I use on a daily basis and to which I had previously backported #27152  . I've also tested it again just now in this new branch by using it to flash my MatekSys mR900-22 receiver via serial passthrough.

I've not done a backport PR before, so please let me know if there is anything else I should do to help get this released for all the vehicle types.

Thanks!