### PR TITLE
Copter: Keep FIXED mode when WP_YAW_BEHAVIOR is NONE

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -449,7 +449,7 @@ bool ModeAuto::wp_start(const Location& dest_loc)
 
     // initialise yaw
     // To-Do: reset the yaw only when the previous navigation command is not a WP.  this would allow removing the special check for ROI
-    if (auto_yaw.mode() != AutoYaw::Mode::ROI) {
+    if (auto_yaw.mode() != AutoYaw::Mode::ROI && !(auto_yaw.mode() == AutoYaw::Mode::FIXED && copter.g.wp_yaw_behavior == WP_YAW_BEHAVIOR_NONE)) {
         auto_yaw.set_mode_to_default(false);
     }
 
@@ -1795,7 +1795,7 @@ void ModeAuto::do_spline_wp(const AP_Mission::Mission_Command& cmd)
 
     // initialise yaw
     // To-Do: reset the yaw only when the previous navigation command is not a WP.  this would allow removing the special check for ROI
-    if (auto_yaw.mode() != AutoYaw::Mode::ROI) {
+    if (auto_yaw.mode() != AutoYaw::Mode::ROI && !(auto_yaw.mode() == AutoYaw::Mode::FIXED && copter.g.wp_yaw_behavior == WP_YAW_BEHAVIOR_NONE)) {
         auto_yaw.set_mode_to_default(false);
     }
 


### PR DESCRIPTION
This PR improves the `CONDITION_YAW` behavior when `WP_YAW_BEHAVIOR` is set to NONE.

Previously, Yaw Mode would switch to `HOLD` when reaching a waypoint.
This meant that even if `CONDITION_YAW` was used, its effect would be reset upon reaching each WAYPOINT. As a result, the vehicle's yaw could potentially drift due to external factors like wind.

With this change, when `WP_YAW_BEHAVIOR` is NONE and `CONDITION_YAW` has been used (resulting in FIXED mode), the yaw remains in `FIXED` mode even after reaching WAYPOINT, maintaining the desired heading as specified by `CONDITION_YAW`.

Before
![image](https://github.com/user-attachments/assets/fcfe341d-0d35-4d29-a44c-309617f9e0fa)

After
![image](https://github.com/user-attachments/assets/2d34d552-76ce-4523-9d30-04c5899678ba)

Settings:
- `WP_YAW_BEHAVIOR=0` (None)
- Used `CONDITION_YAW` with `Deg = 10`, `Speed = 0`, `Dir = 0`, `Abs = 0`.

Testing:
SITL testing was performed to confirm the behavior. To create a challenging environment for yaw control and to introduce yaw error, the following parameters were used to simulate wind and turbulence.

- `SIM_WIND_SPD = 10`
- `SIM_WIND_TURB = 10`

With these settings, the updated implementation successfully maintained the yaw as expected, with `FIXED` mode persisting throughout WAYPOINT without reverting to `HOLD`.