### PR TITLE
WIP: Add IMMEDIATE_DESCEND_IN_AUTO FLIGHT_OPTION

### DIFF
--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -87,6 +87,11 @@ void Plane::setup_glide_slope(void)
             reset_offset_altitude();
             break;
         }
+        //descend without doing glide slope if option is enabled
+        if (above_location_current(next_WP_loc) && plane.flight_option_enabled(FlightOptions::IMMEDIATE_DESCEND_IN_AUTO)) {
+            reset_offset_altitude();
+            break;
+        }
 
         // we only do glide slide handling in AUTO when above 20m or
         // when descending. The 20 meter threshold is arbitrary, and

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -169,6 +169,7 @@ enum FlightOptions {
     ENABLE_LOITER_ALT_CONTROL = (1<<12),
     INDICATE_WAITING_FOR_RUDDER_NEUTRAL = (1<<13),
     IMMEDIATE_CLIMB_IN_AUTO = (1<<14),
+    IMMEDIATE_DESCEND_IN_AUTO = (1<<15),
 };
 
 enum CrowFlapOptions {

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -6180,6 +6180,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             "SERVO6_FUNCTION": 0, # balloon lift
             "SERVO10_FUNCTION": 156, # lift release
             "EK3_IMU_MASK": 1, # lane switches just make log harder to read
+            "FLIGHT_OPTIONS": 32768 # Do not build glideslope.
         })
 
         self.set_servo(6, 1000)


### PR DESCRIPTION
# Summary

This PR attempts to address a vulnerability in the case of a glider being let loose from a balloon.

Typically in the first moments of the flight the glider will operate with `TECS_SPDWEIGHT=0` and will also fly below its target altitude. Therefore it will pitch up and stall.

The proposed solution is to ensure that the target altitude will always be lower than the current altitude, via the use of a new FLIGHT_OPTION bit.

# Issue details

When a glider is let loose from a balloon, the airspeed sensor will be marked as unhealthy. I don't know of a good way to ensure that this will not happen.
As a result, TECS will not use it and TECS will switch to the equivalent of `TECS_SPDWEIGHT=0` (https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_TECS/AP_TECS.cpp#L946).

Therefore, the pitch setpoint will take into account only altitude errors.

Now, right after getting released from the balloon, it is typical to run a complete mission, sometimes with a takeoff waypoint as well. The current waypoint is initialized at a high altitude.
When planning an altitude profile to the next (low down) waypoint, `Mode::update_target_altitude()` at `mode.cpp:191` is passing an altitude reference to TECS that starts at the altitude of the previous waypoint (high up) and gradually reduces to the target altitude.
The slider is the `wp_state.wp_proportion`.

If the glider starts its drop to the opposite side of the next waypoint, `wp_proportion` will be 0 for a significant amount of time, while the plane tries to turn around.
This will result in the target altitude staying high for long and causing the pitch setpoint to increase while the aircraft sinks:
![image](https://github.com/user-attachments/assets/2f3cd4d9-2a80-46df-b53e-dee3bbb9de6f)

This PR is an attempt to prevent this and this is the result that it achieves:
![image](https://github.com/user-attachments/assets/5929ce65-86cc-4229-b294-4e6f17052558)

## Drawbacks

I think this is quite a crude way to ensure that the target altitude will never be above us in this particular use case of a glider.
Probably a smarter (and less heavy-handed way) to achieve it would be better.