### PR TITLE
Copter: Add 'Unknown' to the flight mode

### DIFF
--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -281,22 +281,22 @@
 //
 
 #ifndef FLIGHT_MODE_1
- # define FLIGHT_MODE_1                  Mode::Number::STABILIZE
+ # define FLIGHT_MODE_1                  Mode::Number::UNKNOWN
 #endif
 #ifndef FLIGHT_MODE_2
- # define FLIGHT_MODE_2                  Mode::Number::STABILIZE
+ # define FLIGHT_MODE_2                  Mode::Number::UNKNOWN
 #endif
 #ifndef FLIGHT_MODE_3
- # define FLIGHT_MODE_3                  Mode::Number::STABILIZE
+ # define FLIGHT_MODE_3                  Mode::Number::UNKNOWN
 #endif
 #ifndef FLIGHT_MODE_4
- # define FLIGHT_MODE_4                  Mode::Number::STABILIZE
+ # define FLIGHT_MODE_4                  Mode::Number::UNKNOWN
 #endif
 #ifndef FLIGHT_MODE_5
- # define FLIGHT_MODE_5                  Mode::Number::STABILIZE
+ # define FLIGHT_MODE_5                  Mode::Number::UNKNOWN
 #endif
 #ifndef FLIGHT_MODE_6
- # define FLIGHT_MODE_6                  Mode::Number::STABILIZE
+ # define FLIGHT_MODE_6                  Mode::Number::UNKNOWN
 #endif
 
 

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -179,6 +179,10 @@ Mode *Copter::mode_from_mode_num(const Mode::Number mode)
             break;
 #endif
 
+        case Mode::Number::UNKNOWN:
+        	// Do not set the flight mode
+            break;
+
         default:
             break;
     }
@@ -238,7 +242,9 @@ bool Copter::gcs_mode_enabled(const Mode::Number mode_num)
     if (new_flightmode != nullptr) {
         mode_change_failed(new_flightmode, "GCS entry disabled (FLTMODE_GCSBLOCK)");
     } else {
-        notify_no_such_mode((uint8_t)mode_num);
+        if (mode_num != Mode::Number::UNKNOWN) {
+            notify_no_such_mode((uint8_t)mode_num);
+        }
     }
 
     return false;
@@ -283,7 +289,9 @@ bool Copter::set_mode(Mode::Number mode, ModeReason reason)
 
     Mode *new_flightmode = mode_from_mode_num(mode);
     if (new_flightmode == nullptr) {
-        notify_no_such_mode((uint8_t)mode);
+        if (mode != Mode::Number::UNKNOWN) {
+            notify_no_such_mode((uint8_t)mode);
+        }
         return false;
     }
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -100,6 +100,7 @@ public:
         AUTOROTATE =   26,  // Autonomous autorotation
         AUTO_RTL =     27,  // Auto RTL, this is not a true mode, AUTO will report as this mode if entered to perform a DO_LAND_START Landing sequence
         TURTLE =       28,  // Flip over after crash
+        UNKNOWN =     255,  // unknown
 
         // Mode number 127 reserved for the "drone show mode" in the Skybrush
         // fork at https://github.com/skybrush-io/ardupilot


### PR DESCRIPTION
By adding 'Unknown' to the flight mode, the assignment of the flight mode switch will be clarified. 
Currently, the same flight mode is set for positions of the switch that are not in use. 
By setting the default flight mode switch to 'Unknown,' the initial flight mode will be inherited.