### PR TITLE
AP_ExternalAHRS: Correct VN100 pre-arm handling

### DIFF
--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS.cpp
@@ -271,7 +271,16 @@ bool AP_ExternalAHRS::pre_arm_check(char *failure_msg, uint8_t failure_msg_len) 
         }
     }
 
-    if (!state.have_origin) {
+    bool check_origin = true;
+    // don't run this check for VN100 Series since its IMU only
+    if (DevType(devtype) == DevType::VecNav) {
+        const char* name = get_name();
+        if (name && !strncmp(name, "VN-1", 4)) {
+            check_origin = false;
+        }
+    }
+
+    if (check_origin && !state.have_origin) {
         hal.util->snprintf(failure_msg, failure_msg_len, "ExternalAHRS: No origin");
 	    return false;
     }

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.cpp
@@ -446,6 +446,11 @@ void AP_ExternalAHRS_VectorNav::initialize() {
         // These assumes unit is still configured at its default rate of 800hz
         run_command("VNWRG,75,3,%u,01,0721", unsigned(800 / get_rate()));
         run_command("VNWRG,76,3,16,11,0001,0106");
+
+        WITH_SEMAPHORE(state.sem);
+        set_default_sensors(uint16_t(AP_ExternalAHRS::AvailableSensor::IMU) |
+                            uint16_t(AP_ExternalAHRS::AvailableSensor::BARO) |
+                            uint16_t(AP_ExternalAHRS::AvailableSensor::COMPASS));
     } else {
         // Default to setup for sensors other than VN-100 or VN-110
         // This assumes unit is still configured at its default IMU rate of 400hz for VN-300, 800hz for others
@@ -459,6 +464,12 @@ void AP_ExternalAHRS_VectorNav::initialize() {
         run_command("VNWRG,75,3,%u,01,0721", unsigned(imu_rate / get_rate()));
         run_command("VNWRG,76,3,%u,31,0001,0106,0613", unsigned(imu_rate / 50));
         run_command("VNWRG,77,3,%u,49,0003,26B8,0018", unsigned(imu_rate / 5));
+
+        WITH_SEMAPHORE(state.sem);
+        set_default_sensors(uint16_t(AP_ExternalAHRS::AvailableSensor::IMU) |
+                            uint16_t(AP_ExternalAHRS::AvailableSensor::BARO) |
+                            uint16_t(AP_ExternalAHRS::AvailableSensor::COMPASS) |
+                            uint16_t(AP_ExternalAHRS::AvailableSensor::GPS));
     }
 
     // Resume asynchronous communications
@@ -758,6 +769,11 @@ bool AP_ExternalAHRS_VectorNav::pre_arm_check(char *failure_msg, uint8_t failure
         }
     }
     return true;
+}
+
+uint8_t AP_ExternalAHRS_VectorNav::num_gps_sensors(void) const
+{
+    return type == TYPE::VN_INS ? 1 + has_dual_gnss : 0;
 }
 
 /*

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.h
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.h
@@ -49,9 +49,8 @@ public:
 
 protected:
 
-    uint8_t num_gps_sensors(void) const override {
-        return 1;
-    }
+    uint8_t num_gps_sensors(void) const override;
+
 private:
     AP_HAL::UARTDriver *uart;
     int8_t port_num;


### PR DESCRIPTION
The VN100 does not have a GPS, is an IMU only device. 

Users running 4.5 were able to get the sensor working without any pre-arm errors, but upgrading to master gave two pre-arm checks, one related to setting GPS properly, and other related to setting origin.  This PR makes it possible for VN100 users to go back to the 4.5 behaviour. 