### PR TITLE
AP_Scripting: added bindings for ipv4 address

### DIFF
--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -517,9 +517,19 @@ function motor_factor_table_ud:roll(index, value) end
 local SocketAPM_ud = {}
 
 -- Get a new socket
----@param datagram boolean
+---@param datagram integer -- set to 1 for UDP, 0 for TCP
 ---@return SocketAPM_ud
 function Socket(datagram) end
+
+-- return an IPv4 address given a string
+---@param str_address string -- ipv4 address as string
+---@return uint32_t_ud -- ipv4 address
+function string_to_ipv4_addr(str_address) end
+
+-- return a string representation of ipv4 address
+---@param addr uint32_t_ud|integer|number -- ipv4 address
+---@return string -- string representation of address
+function ipv4_addr_to_string(addr) end
 
 -- return true if a socket is connected
 ---@return boolean
@@ -540,6 +550,14 @@ function SocketAPM_ud:listen(backlog) end
 ---@param len uint32_t_ud|integer|number
 ---@return integer
 function SocketAPM_ud:send(str, len) end
+
+-- send a lua string to a specified address. May contain binary data
+---@param str string
+---@param len uint32_t_ud|integer|number
+---@param ipaddr uint32_t_ud|integer|number -- ipv4 address
+---@param port integer -- ipv4 port
+---@return integer
+function SocketAPM_ud:sendto(str, len, ipaddr, port) end
 
 -- bind to an address. Use "0.0.0.0" for wildcard bind
 ---@param IP_address string
@@ -562,6 +580,8 @@ function SocketAPM_ud:accept() end
 -- receive data from a socket
 ---@param length integer
 ---@return string|nil
+---@return uint32_t_ud|nil -- source IP
+---@return integer|nil -- source port
 function SocketAPM_ud:recv(length) end
 
 -- check for available input

--- a/libraries/AP_Scripting/examples/net_test.lua
+++ b/libraries/AP_Scripting/examples/net_test.lua
@@ -2,8 +2,6 @@
    example script to test lua socket API
 --]]
 
----@diagnostic disable: param-type-mismatch
-
 local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
 
 PARAM_TABLE_KEY = 46
@@ -103,9 +101,12 @@ local function test_server(name, sock)
       sock = sock_tcp_in2
    end
 
-   local r = sock:recv(1024)
+   local r, ip, port = sock:recv(1024)
    if r and #r > 0 then
       gcs:send_text(MAV_SEVERITY.ERROR, string.format("test_server(%s): got input '%s'", name, r))
+   end
+   if ip then
+      gcs:send_text(MAV_SEVERITY.INFO, string.format("packet from %s:%u", ipv4_addr_to_string(ip), port))
    end
 end
 

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -599,11 +599,14 @@ ap_object AP_HAL::I2CDevice method set_address void uint8_t'skip_check
 
 include AP_HAL/utility/Socket.h depends (AP_NETWORKING_ENABLED==1)
 global manual Socket lua_get_SocketAPM 1 1 depends (AP_NETWORKING_ENABLED==1)
+global manual ipv4_addr_to_string SocketAPM_ipv4_addr_to_string 1 1 depends (AP_NETWORKING_ENABLED==1)
+global manual string_to_ipv4_addr SocketAPM_string_to_ipv4_addr 1 1 depends (AP_NETWORKING_ENABLED==1)
 
 ap_object SocketAPM depends (AP_NETWORKING_ENABLED==1)
 ap_object SocketAPM method connect boolean string uint16_t'skip_check
 ap_object SocketAPM method bind boolean string uint16_t'skip_check
 ap_object SocketAPM method send int32_t string uint32_t'skip_check
+ap_object SocketAPM method sendto int32_t string uint32_t'skip_check uint32_t'skip_check uint16_t'skip_check
 ap_object SocketAPM method listen boolean uint8_t'skip_check
 ap_object SocketAPM method set_blocking boolean boolean
 ap_object SocketAPM method is_connected boolean
@@ -612,7 +615,7 @@ ap_object SocketAPM method pollin boolean uint32_t'skip_check
 ap_object SocketAPM method reuseaddress boolean
 ap_object SocketAPM manual sendfile SocketAPM_sendfile 1 1
 ap_object SocketAPM manual close SocketAPM_close 0 0
-ap_object SocketAPM manual recv SocketAPM_recv 1 1
+ap_object SocketAPM manual recv SocketAPM_recv 1 3
 ap_object SocketAPM manual accept SocketAPM_accept 0 1
 
 ap_object AP_HAL::AnalogSource depends !defined(HAL_DISABLE_ADC_DRIVER)

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -1004,11 +1004,23 @@ int SocketAPM_recv(lua_State *L) {
         return 0;
     }
 
-    // push to lua string
+    int retcount = 1;
+
+    // push data to lua string
     lua_pushlstring(L, (const char *)data, ret);
+
+    // also push the address and port if available
+    uint32_t ip_addr;
+    uint16_t port;
+    if (ud->last_recv_address(ip_addr, port)) {
+        *new_uint32_t(L) = ip_addr;
+        lua_pushinteger(L, port);
+        retcount += 2;
+    }
+
     free(data);
 
-    return 1;
+    return retcount;
 }
 
 /*
@@ -1035,6 +1047,31 @@ int SocketAPM_accept(lua_State *L) {
 
     // out of socket slots, return nil, caller can retry
     return 0;
+}
+
+/*
+  convert a uint32_t ipv4 address to a string
+ */
+int SocketAPM_ipv4_addr_to_string(lua_State *L) {
+    binding_argcheck(L, 1);
+    const uint32_t ip_addr = get_uint32(L, 1, 0, UINT32_MAX);
+    char buf[IP4_STR_LEN];
+    const char *ret = SocketAPM::inet_addr_to_str(ip_addr, buf, sizeof(buf));
+    if (ret == nullptr) {
+        return 0;
+    }
+    lua_pushlstring(L, (const char *)ret, strlen(ret));
+    return 1;
+}
+
+/*
+  convert a ipv4 string address to a uint32_t
+ */
+int SocketAPM_string_to_ipv4_addr(lua_State *L) {
+    binding_argcheck(L, 1);
+    const char *str = luaL_checkstring(L, 1);
+    *new_uint32_t(L) = SocketAPM::inet_str_to_addr(str);
+    return 1;
 }
 
 #endif // AP_NETWORKING_ENABLED

--- a/libraries/AP_Scripting/lua_bindings.h
+++ b/libraries/AP_Scripting/lua_bindings.h
@@ -24,6 +24,8 @@ int SocketAPM_recv(lua_State *L);
 int SocketAPM_accept(lua_State *L);
 int SocketAPM_close(lua_State *L);
 int SocketAPM_sendfile(lua_State *L);
+int SocketAPM_ipv4_addr_to_string(lua_State *L);
+int SocketAPM_string_to_ipv4_addr(lua_State *L);
 int lua_mavlink_init(lua_State *L);
 int lua_mavlink_receive_chan(lua_State *L);
 int lua_mavlink_register_rx_msgid(lua_State *L);


### PR DESCRIPTION
This makes a UDP server that responds back to individual clients possible by allowing recv to know the source address of the sender. It also allows for conversion between the string and uint32_t form of IPv4 addresses
