### PR TITLE
Mission: Do not send notifications about messages for completed missions

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -2230,7 +2230,9 @@ bool ModeAuto::verify_nav_wp(const AP_Mission::Mission_Command& cmd)
             // play a tone
             AP_Notify::events.waypoint_complete = 1;
         }
+#if 0  // enable to send reached commands
         gcs().send_text(MAV_SEVERITY_INFO, "Reached command #%i",cmd.index);
+#endif
         return true;
     }
     return false;

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -422,7 +422,9 @@ bool AP_Mission::start_command(const Mission_Command& cmd)
         break;
 
     default:
+#if 0  // enable to send mission commands
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Mission: %u %s", cmd.index, cmd.type());
+#endif
         break;
 
     }


### PR DESCRIPTION
The GCS can download a MISSION from the FC before executing it. 
The MISSION contains sequence numbers. Each time the FC completes a MISSION item, it sends a MISSION_ITEM_REACHED notification. 
The GCS can obtain commands and other information from the notified sequence numbers. 
Therefore, I want to prevent the FC from sending messages.

AFTER
![Screenshot from 2024-09-29 12-59-35](https://github.com/user-attachments/assets/7ffdf4fa-2252-4afc-8d7e-0004c700fe8e)


BEFORE
![Screenshot from 2024-09-29 11-52-56](https://github.com/user-attachments/assets/9f345b98-25ec-441d-bec6-81e2ea9eae1a)

MISSION_ITEM_REACHED
![Screenshot from 2024-09-29 13-01-18](https://github.com/user-attachments/assets/0c9ceb46-19ca-4206-89e6-71605c678b75)
