### PR TITLE
SITL: remove stale parameter metadata

### DIFF
--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -660,45 +660,6 @@ const AP_Param::GroupInfo SIM::var_info3[] = {
     // @User: Advanced
     AP_GROUPINFO("TIME_JITTER",  37, SIM,  loop_time_jitter_us, 0),
 
-    // user settable parameters for the 1st barometer
-    // @Param: BARO_RND
-    // @DisplayName: Baro Noise
-    // @Description: Amount of (evenly-distributed) noise injected into the 1st baro
-    // @Units: m
-    // @User: Advanced
-
-    // @Param: BARO_GLITCH
-    // @DisplayName: Baro Glitch
-    // @Description: Glitch for 1st baro
-    // @Units: m
-    // @User: Advanced
-
-    // user settable parameters for the 2nd barometer
-    // @Param: BAR2_RND
-    // @DisplayName: Baro2 Noise
-    // @Description: Amount of (evenly-distributed) noise injected into the 2nd baro
-    // @Units: m
-    // @User: Advanced
-
-    // @Param: BAR2_GLITCH
-    // @DisplayName: Baro2 Glitch
-    // @Description: Glitch for 2nd baro
-    // @Units: m
-    // @User: Advanced
-
-    // user settable parameters for the 3rd barometer
-    // @Param: BAR3_RND
-    // @DisplayName: Baro3 Noise
-    // @Description: Amount of (evenly-distributed) noise injected into the 3rd baro
-    // @Units: m
-    // @User: Advanced
-
-    // @Param: BAR3_GLITCH
-    // @DisplayName: Baro3 Glitch
-    // @Description: Glitch for 2nd baro
-    // @Units: m
-    // @User: Advanced
-
     // @Param: ESC_TELEM
     // @DisplayName: Simulated ESC Telemetry
     // @Description: enable perfect simulated ESC telemetry


### PR DESCRIPTION
now done by having the subgroup in its own file