### PR TITLE
Tools: Do not use system packages on openSUSE

### DIFF
--- a/Tools/environment_install/install-prereqs-openSUSE-Tumbleweed.sh
+++ b/Tools/environment_install/install-prereqs-openSUSE-Tumbleweed.sh
@@ -88,7 +88,7 @@ sudo usermod -a -G dialout "$USER"
 
 $ZYPPER $BASE_PKGS $SITL_PKGS || echo "Check zypper output for errors"
 
-python3 -m venv --system-site-packages "$HOME"/venv-ardupilot
+python3 -m venv "$HOME"/venv-ardupilot
 
 SHELL_LOGIN=".profile"
 # activate it:


### PR DESCRIPTION
* We only tested on apt, don't blindly change dev env stuff that's not tested in CI
* The original PR was only for APT, but the dev team thought we should try it on all the scripts for consistency

Motivation: https://github.com/ArduPilot/ardupilot/commit/d18a2b22f922bf9358f39a201010167853bb756e#commitcomment-147393965