### PR TITLE
Tools: use /usr/bin/env to find python3

### DIFF
--- a/Tools/autotest/run_mission.py
+++ b/Tools/autotest/run_mission.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 '''
 Run a mission in SITL

--- a/Tools/autotest/test_param_upgrade.py
+++ b/Tools/autotest/test_param_upgrade.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 '''
 Test parameter upgrade, master vs branch

--- a/Tools/autotest/unittest/annotate_params_unittest.py
+++ b/Tools/autotest/unittest/annotate_params_unittest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 '''
 These are the unit tests for the python script that fetches online ArduPilot

--- a/Tools/autotest/unittest/extract_param_defaults_unittest.py
+++ b/Tools/autotest/unittest/extract_param_defaults_unittest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 '''
 Extracts parameter default values from an ArduPilot .bin log file. Unittests.

--- a/Tools/scripts/annotate_params.py
+++ b/Tools/scripts/annotate_params.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 """
 This script fetches online ArduPilot parameter documentation (if not cached) and adds it to the specified file

--- a/Tools/scripts/extract_param_defaults.py
+++ b/Tools/scripts/extract_param_defaults.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 '''
 Extracts parameter default values from an ArduPilot .bin log file.

--- a/Tools/scripts/generate_pdef.xml_metadata.py
+++ b/Tools/scripts/generate_pdef.xml_metadata.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 '''
 Rsync apm.pdef.xml files for different versions of the ArduPilot firmware


### PR DESCRIPTION
going directly to /usr/bin/python3 means we don't use the venv python