### PR TITLE
Fix/corrrect smart rtl internal error by preserving home srtl point

### DIFF
--- a/ArduCopter/mode_smart_rtl.cpp
+++ b/ArduCopter/mode_smart_rtl.cpp
@@ -11,6 +11,13 @@
 
 bool ModeSmartRTL::init(bool ignore_checks)
 {
+    // Add check to prevent SmartRTL activation when disarmed
+    if (!motors->armed()) {
+        // Send a warning message to the GCS
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Cannot engage SmartRTL while disarmed");
+        return false;  // Prevent initialization
+    }
+
     if (g2.smart_rtl.is_active()) {
         // initialise waypoint and spline controller
         wp_nav->wp_and_spline_init();
@@ -174,8 +181,12 @@ void ModeSmartRTL::pre_land_position_run()
 // save current position for use by the smart_rtl flight mode
 void ModeSmartRTL::save_position()
 {
-    const bool should_save_position = motors->armed() && (copter.flightmode->mode_number() != Mode::Number::SMART_RTL);
+    // Prevent saving positions when the drone is disarmed
+    if (!motors->armed()) {
+        return;
+    }
 
+    const bool should_save_position = motors->armed() && (copter.flightmode->mode_number() != Mode::Number::SMART_RTL);
     copter.g2.smart_rtl.update(copter.position_ok(), should_save_position);
 }
 

--- a/ArduCopter/mode_smart_rtl.cpp
+++ b/ArduCopter/mode_smart_rtl.cpp
@@ -11,14 +11,12 @@
 
 bool ModeSmartRTL::init(bool ignore_checks)
 {
-    // Add check to prevent SmartRTL activation when disarmed
-    if (!motors->armed()) {
-        // Send a warning message to the GCS
-        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Cannot engage SmartRTL while disarmed");
-        return false;  // Prevent initialization
-    }
-
     if (g2.smart_rtl.is_active()) {
+        // Save the RTL home point if not already saved
+        if (!g2.smart_rtl.is_rtl_point_locked()) {
+            g2.smart_rtl.lock_rtl_point(copter.position());
+        }
+
         // initialise waypoint and spline controller
         wp_nav->wp_and_spline_init();
 
@@ -42,7 +40,7 @@ bool ModeSmartRTL::init(bool ignore_checks)
 // perform cleanup required when leaving smart_rtl
 void ModeSmartRTL::exit()
 {
-    // restore last point if we hadn't reached it
+    // Preserve the current RTL point before exiting SmartRTL
     if (smart_rtl_state == SubMode::PATH_FOLLOW && !dest_NED_backup.is_zero()) {
         if (!g2.smart_rtl.add_point(dest_NED_backup)) {
             GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "SmartRTL: lost one point");
@@ -50,7 +48,11 @@ void ModeSmartRTL::exit()
     }
     dest_NED_backup.zero();
 
+    // Cancel any requests for path cleanup
     g2.smart_rtl.cancel_request_for_thorough_cleanup();
+
+    // Unlock the RTL point when exiting to allow future modifications
+    g2.smart_rtl.unlock_rtl_point();
 }
 
 void ModeSmartRTL::run()
@@ -109,6 +111,12 @@ void ModeSmartRTL::path_follow_run()
             // backup destination in case we exit smart_rtl mode and need to restore it to the path
             dest_NED_backup = dest_NED;
             path_follow_last_pop_fail_ms = 0;
+
+            // Restore the last locked RTL point if we are resuming the path
+            if (g2.smart_rtl.is_rtl_point_locked()) {
+                dest_NED = g2.smart_rtl.get_locked_rtl_point();
+            }
+
             if (g2.smart_rtl.get_num_points() == 0) {
                 // this is the very last point, add 2m to the target alt and move to pre-land state
                 dest_NED.z -= 2.0f;
@@ -181,8 +189,8 @@ void ModeSmartRTL::pre_land_position_run()
 // save current position for use by the smart_rtl flight mode
 void ModeSmartRTL::save_position()
 {
-    // Prevent saving positions when the drone is disarmed
-    if (!motors->armed()) {
+    // Prevent saving positions when the drone is disarmed or in SMART_RTL mode
+    if (!motors->armed() || copter.flightmode->mode_number() == Mode::Number::SMART_RTL) {
         return;
     }
 


### PR DESCRIPTION
fixes #17419 

Changes:

    init(): Added logic to lock the RTL home point when entering SMART_RTL mode if it's not already locked.
    exit(): Unlocked the RTL point and preserved the current RTL point when exiting SMART_RTL.
    save_position(): Modified to prevent overwriting the RTL point when the drone is in SMART_RTL mode.
    path_follow_run(): Restored the locked RTL point during the path-following phase.