### PR TITLE
AP_RCProtocol: IBUS hack for FlySky IA6 receiver

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol_IBUS.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_IBUS.h
@@ -36,6 +36,8 @@ public:
     void process_byte(uint8_t byte, uint32_t baudrate) override;
 private:
     void _process_byte(uint32_t timestamp_us, uint8_t byte);
+    bool ibus_decode_std(const uint8_t frame[IBUS_FRAME_SIZE], uint16_t *values, bool *ibus_failsafe);
+    bool ibus_decode_ia6(const uint8_t frame[IBUS_FRAME_SIZE], uint16_t *values, bool *ibus_failsafe);
     bool ibus_decode(const uint8_t frame[IBUS_FRAME_SIZE], uint16_t *values, bool *ibus_failsafe);
 
     SoftSerial ss{115200, SoftSerial::SERIAL_CONFIG_8N1};


### PR DESCRIPTION
This PR adds support for slightly modified IBUS protocol  for cheap FlySky IA6 receiver.
See https://www.youtube.com/watch?v=qEUB6GJQmRc