### PR TITLE
AP_DroneCAN: properly convert timeout to deadline for aux frames

### DIFF
--- a/libraries/AP_DroneCAN/AP_Canard_iface.cpp
+++ b/libraries/AP_DroneCAN/AP_Canard_iface.cpp
@@ -458,12 +458,13 @@ bool CanardInterface::add_11bit_driver(CANSensor *sensor)
 // handler for outgoing frames for auxillary drivers
 bool CanardInterface::write_aux_frame(AP_HAL::CANFrame &out_frame, const uint64_t timeout_us)
 {
+    const uint64_t tx_deadline_us = AP_HAL::micros64() + timeout_us;
     bool ret = false;
     for (uint8_t iface = 0; iface < num_ifaces; iface++) {
         if (ifaces[iface] == NULL) {
             continue;
         }
-        ret |= ifaces[iface]->send(out_frame, timeout_us, 0) > 0;
+        ret |= ifaces[iface]->send(out_frame, tx_deadline_us, 0) > 0;
     }
     return ret;
 }


### PR DESCRIPTION
The timeout specified for auxiliary driver frames was passed to the driver where a deadline was expected. The transmission was then started after its "deadline", thereby causing it to be canceled and the data lost if the frame could not be sent immediately.

Fix by converting the timeout to a deadline before passing to the driver. The conversion is done in the Canard interface code as it already does other conversions from timeouts to deadlines.

Tested that my setup used to get timeouts registered in `@SYS/can0_stats.txt` and doesn't anymore.