### PR TITLE
Copter: Consolidate processing

### DIFF
--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -535,11 +535,7 @@ void ModePosHold::update_brake_angle_from_velocity(float &brake_angle, float vel
     }
 
     // calculate velocity-only based lean angle
-    if (velocity >= 0) {
-        lean_angle = -brake.gain * velocity * (1.0f + 500.0f / (velocity + 60.0f));
-    } else {
-        lean_angle = -brake.gain * velocity * (1.0f + 500.0f / (-velocity + 60.0f));
-    }
+    lean_angle = -brake.gain * velocity * (1.0f + 500.0f / (fabsf(velocity) + 60.0f));
 
     // do not let lean_angle be too far from brake_angle
     brake_angle = constrain_float(lean_angle, brake_angle - brake_rate, brake_angle + brake_rate);


### PR DESCRIPTION
I can consolidate processing by using a ternary operator.
The free space has increased by 8 bytes.

AFTER
BUILD SUMMARY
Build directory: /home/parallels/work2/ardupilot/build/fmuv3
Target          Text (B)  Data (B)  BSS (B)  Total Flash Used (B)  Free Flash (B)  External Flash Used (B)

bin/arducopter   1567697      3892   192868               1571589          509164  Not Applicable   

BEFORE
BUILD SUMMARY
Build directory: /home/parallels/work2/ardupilot/build/fmuv3
Target          Text (B)  Data (B)  BSS (B)  Total Flash Used (B)  Free Flash (B)  External Flash Used (B)

bin/arducopter   1567705      3892   192868               1571597          509156  Not Applicable  
