### PR TITLE
AC_AttitudeControl: Add function to limit target attitude thrust angle

### DIFF
--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -168,6 +168,8 @@ public:
     // Reduce attitude control gains while landed to stop ground resonance
     void landed_gain_reduction(bool landed);
 
+    bool limit_target_thrust_angle(float thrust_angle_max_cd);
+
     // Sets attitude target to vehicle attitude and sets all rates to zero
     // If reset_rate is false rates are not reset to allow the rate controllers to run
     void reset_target_and_rate(bool reset_rate = true);


### PR DESCRIPTION
This PR provides a feature for use in plane to limit the maximum target angle.

When the target angle is above a given value the current attitude is used to determine the minimum rotation vector back to within the allowable lean angle using only roll and pitch.