### PR TITLE
Plane: added fast attitude recovery for inverted flight in Q modes

### DIFF
--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -1858,6 +1858,47 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
 
         self.fly_home_land_and_disarm()
 
+    def FastInvertedRecovery(self):
+        '''test recovery from inverted flight is fast'''
+
+        self.set_parameters({
+            "Q_A_ACCEL_R_MAX": 20000,
+            "Q_A_ACCEL_P_MAX": 20000,
+            "Q_A_ACCEL_Y_MAX": 20000,
+            "Q_A_RATE_R_MAX": 50,
+            "Q_A_RATE_P_MAX": 50,
+            "Q_A_RATE_Y_MAX": 50,
+        })
+
+        self.wait_ready_to_arm()
+        self.takeoff(60, mode='GUIDED', timeout=100)
+
+        self.context_collect('STATUSTEXT')
+        self.set_rc(3, 1500)
+        self.change_mode('CRUISE')
+        self.wait_statustext("Transition done", check_context=True)
+
+        self.progress("Go to inverted flight")
+        self.run_auxfunc(43, 2)
+        self.wait_roll(180, 3, absolute_value=True)
+
+        initial_altitude = self.get_altitude(relative=True, timeout=2)
+        self.change_mode('QHOVER')
+
+        self.wait_statustext("Fast attitude recovery", check_context=True)
+        self.wait_roll(0, 3, absolute_value=True)
+
+        recovery_altitude = self.get_altitude(relative=True, timeout=2)
+        alt_change = initial_altitude - recovery_altitude
+
+        self.progress("Recovery AltChange %.1fm" % alt_change)
+
+        max_alt_change = 16 # normally 14.5, added 1.5 margin
+        if alt_change > max_alt_change:
+            raise NotAchievedException("Recovery AltChange too high %.1f > %.1f" % (alt_change, max_alt_change))
+        self.run_auxfunc(43, 0)
+        self.fly_home_land_and_disarm()
+
     def tests(self):
         '''return list of all tests'''
 
@@ -1906,5 +1947,6 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.DCMClimbRate,
             self.RTL_AUTOLAND_1,  # as in fly-home then go to landing sequence
             self.RTL_AUTOLAND_1_FROM_GUIDED,  # as in fly-home then go to landing sequence
+            self.FastInvertedRecovery,
         ])
         return ret

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -7383,12 +7383,14 @@ class TestSuite(ABC):
             **kwargs
         )
 
-    def wait_roll(self, roll, accuracy, timeout=30, **kwargs):
+    def wait_roll(self, roll, accuracy, timeout=30, absolute_value=False, **kwargs):
         """Wait for a given roll in degrees."""
         def get_roll(timeout2):
             msg = self.assert_receive_message('ATTITUDE', timeout=timeout2)
             p = math.degrees(msg.pitch)
             r = math.degrees(msg.roll)
+            if absolute_value:
+                r = abs(r)
             self.progress("Roll %d Pitch %d" % (r, p))
             return r
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -275,6 +275,78 @@ void AC_AttitudeControl::landed_gain_reduction(bool landed)
     set_angle_P_scale_mult(scale_mult);
 }
 
+// limit_target_thrust_angle - 
+bool AC_AttitudeControl::limit_target_thrust_angle(float thrust_angle_max_cd)
+{
+    float thrust_angle_max_rad = radians(thrust_angle_max_cd * 0.01f);
+
+    // attitude_body represents a quaternion rotation in NED frame to the body
+    Quaternion attitude_body;
+    _ahrs.get_quat_body_to_ned(attitude_body);
+    
+    Vector3f gyro = _ahrs.get_gyro_latest();
+
+    // angle_delta is the estimated rotation that the aircraft will experience during the correction
+    Vector3f angle_delta = Vector3f{gyro.x / get_angle_roll_p().kP(), gyro.y / get_angle_pitch_p().kP(), gyro.z / get_angle_yaw_p().kP() };
+
+    // attitude_update represents a quaternion rotation representing the expected rotation in the next time_constant
+    Quaternion attitude_update;
+    attitude_update.from_axis_angle(angle_delta);
+    attitude_body *= attitude_update;
+
+    // The direction of thrust is [0,0,-1] is any body-fixed frame, inc. body frame and target frame.
+    const Vector3f thrust_vector_up{0.0f, 0.0f, -1.0f};
+    
+    // Rotating [0,0,-1] by attitude_body expresses (gets a view of) the thrust vector in the inertial frame
+    Vector3f thrust_vec = attitude_body * thrust_vector_up;
+
+    // the dot product is used to calculate the current lean angle
+    float thrust_correction_angle = acosf(constrain_float(thrust_vec * thrust_vector_up, -1.0f, 1.0f));
+
+    if (abs(thrust_correction_angle) <= thrust_angle_max_rad) {
+        return false;
+    }
+
+    // the cross product of the current thrust vector and vertical thrust vector defines the rotation vector
+    Vector3f thrust_vec_cross = thrust_vec % thrust_vector_up;
+
+    // Normalize the thrust rotation vector
+    if (thrust_vec_cross.is_zero()) {
+        thrust_vec_cross.xy() = gyro.xy();
+        thrust_vec_cross.z = 0.0;
+        if (thrust_vec_cross.is_zero()) {
+            // choose recovery in the pitch axis
+            const Vector3f y_axis{0.0f, 1.0f, 0.0f};
+            thrust_vec_cross = _attitude_target * y_axis;
+        } else {
+            // choose recovery in the current rotation direction
+            thrust_vec_cross.normalize();
+        }
+    } else {
+        thrust_vec_cross.normalize();
+    }
+
+    // subtract the maximum lean angle from the current thrust angle
+    thrust_correction_angle -= constrain_float(thrust_correction_angle, -thrust_angle_max_rad, thrust_angle_max_rad);
+
+    // calculate the closest _attitude_target using roll and pitch only, with a thrust angle of thrust_angle_max_rad
+    Quaternion attitude_target_offset;
+    attitude_target_offset.from_axis_angle(thrust_vec_cross, thrust_correction_angle);
+    _attitude_target = attitude_target_offset * attitude_body;
+
+    // Set angular velocity targets when further than 1.25 * thrust_angle_max_cd
+    // this ensures small angles past thrust_angle_max_cd do not zero angular velocity targets and prevent full recovery
+    // angular velocity targets must be zeroed at large thrust angles to prevent them from preventing efficient recovery
+    float ang_vel_scalar = 0.0;
+    if (!is_zero(thrust_angle_max_rad)) {
+        ang_vel_scalar = MAX( 0.0, 1.0f - (abs(thrust_correction_angle) / (0.25 * thrust_angle_max_rad)));
+    }
+    _ang_vel_target *= ang_vel_scalar;
+    ang_vel_to_euler_rate(_attitude_target, _ang_vel_target, _euler_rate_target);
+
+    return true;
+}
+
 // The attitude controller works around the concept of the desired attitude, target attitude
 // and measured attitude. The desired attitude is the attitude input into the attitude controller
 // that expresses where the higher level code would like the aircraft to move to. The target attitude is moved

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -168,6 +168,8 @@ public:
     // Reduce attitude control gains while landed to stop ground resonance
     void landed_gain_reduction(bool landed);
 
+    bool limit_target_thrust_angle(float thrust_angle_max_cd);
+
     // Sets attitude target to vehicle attitude and sets all rates to zero
     // If reset_rate is false rates are not reset to allow the rate controllers to run
     void reset_target_and_rate(bool reset_rate = true);


### PR DESCRIPTION
This makes recovery to level a lot faster from an upset attitude when using a Q mode as a recovery mode. It resets the target thrust angle to be within the limits set for the vehicle, which prevents the input shaping from trying to keep the vehicle inverted

builds on https://github.com/ArduPilot/ardupilot/pull/28316 
thanks to @lthall 

With GriffinPro in RealFlight
![image](https://github.com/user-attachments/assets/06f02ba0-c0e1-4322-bc5c-3b1b31e98564)
without this change:
![image](https://github.com/user-attachments/assets/86bb3ba5-fd62-4c28-90fe-80dd84b6b76b)

