### PR TITLE
AP_Baro: To prevent incorrect warnings

### DIFF
--- a/libraries/AP_Baro/AP_Baro_BMP388.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP388.cpp
@@ -129,7 +129,8 @@ bool AP_Baro_BMP388::init()
 }
 
 
-
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdangling-pointer"
 //  accumulate a new sensor reading
 void AP_Baro_BMP388::timer(void)
 {
@@ -150,6 +151,7 @@ void AP_Baro_BMP388::timer(void)
 
     dev->check_next_register();
 }
+#pragma GCC diagnostic pop
 
 // transfer data to the frontend
 void AP_Baro_BMP388::update(void)


### PR DESCRIPTION
BUF is a stack variable. 
It is not used after being released. Suppress the compiler warning.


[  84/1342] Compiling libraries/AP_Baro/AP_Baro_BMP388.cpp
../../libraries/AP_Baro/AP_Baro_BMP388.cpp: In member function ‘void AP_Baro_BMP388::timer()’:
../../libraries/AP_Baro/AP_Baro_BMP388.cpp:148:34: warning: dangling pointer to ‘buf’ may be used [-Wdangling-pointer=]
  148 |         update_temperature((buf[6] << 16) | (buf[5] << 8) | buf[4]);
      |                             ~~~~~^
../../libraries/AP_Baro/AP_Baro_BMP388.cpp:136:13: note: ‘buf’ declared here
  136 |     uint8_t buf[7];
      |             ^~~
