### PR TITLE
Copter, Rover, Tracker, Plane-4.5.7 release

### DIFF
--- a/AntennaTracker/ReleaseNotes.txt
+++ b/AntennaTracker/ReleaseNotes.txt
@@ -1,5 +1,11 @@
 Antenna Tracker Release Notes:
 ------------------------------------------------------------------
+Release 4.5.7 08 Oct 2024
+
+Changes from 4.5.7-beta1
+
+1) Reverted Septentrio GPS sat count correctly drops to zero when 255 received
+------------------------------------------------------------------
 Release 4.5.7-beta1 26 Sep 2024
 
 Changes from 4.5.6

--- a/AntennaTracker/version.h
+++ b/AntennaTracker/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "AntennaTracker V4.5.7-beta1"
+#define THISFIRMWARE "AntennaTracker V4.5.7"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,5,7,FIRMWARE_VERSION_TYPE_BETA
+#define FIRMWARE_VERSION 4,5,7,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 5
 #define FW_PATCH 7
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,5 +1,11 @@
 ArduPilot Copter Release Notes:
 ------------------------------------------------------------------
+Release 4.5.7 08 Oct 2024
+
+Changes from 4.5.7-beta1
+
+1) Reverted Septentrio GPS sat count correctly drops to zero when 255 received
+------------------------------------------------------------------
 Release 4.5.7-beta1 26 Sep 2024
 
 Changes from 4.5.6

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.5.7-beta1"
+#define THISFIRMWARE "ArduCopter V4.5.7"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,5,7,FIRMWARE_VERSION_TYPE_BETA
+#define FIRMWARE_VERSION 4,5,7,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 5
 #define FW_PATCH 7
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/ArduPlane/ReleaseNotes.txt
+++ b/ArduPlane/ReleaseNotes.txt
@@ -1,5 +1,11 @@
 ArduPilot Plane Release Notes:
 ------------------------------------------------------------------
+Release 4.5.7 08 Oct 2024
+
+Changes from 4.5.7-beta1
+
+1) Reverted Septentrio GPS sat count correctly drops to zero when 255 received
+------------------------------------------------------------------
 Release 4.5.7-beta1 26 Sep 2024
 
 Changes from 4.5.6

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduPlane V4.5.7-beta1"
+#define THISFIRMWARE "ArduPlane V4.5.7"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,5,7,FIRMWARE_VERSION_TYPE_BETA
+#define FIRMWARE_VERSION 4,5,7,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 5
 #define FW_PATCH 7
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/Rover/ReleaseNotes.txt
+++ b/Rover/ReleaseNotes.txt
@@ -1,5 +1,11 @@
 Rover Release Notes:
 ------------------------------------------------------------------
+Release 4.5.7 08 Oct 2024
+
+Changes from 4.5.7-beta1
+
+1) Reverted Septentrio GPS sat count correctly drops to zero when 255 received
+------------------------------------------------------------------
 Release 4.5.7-beta1 26 Sep 2024
 
 Changes from 4.5.6

--- a/Rover/version.h
+++ b/Rover/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduRover V4.5.7-beta1"
+#define THISFIRMWARE "ArduRover V4.5.7"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,5,7,FIRMWARE_VERSION_TYPE_BETA
+#define FIRMWARE_VERSION 4,5,7,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 5
 #define FW_PATCH 7
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -453,10 +453,8 @@ AP_GPS_SBF::process_message(void)
             set_alt_amsl_cm(state, ((float)temp.Height - temp.Undulation) * 1e2f);
         }
 
-        state.num_sats = temp.NrSV;
-        if (temp.NrSV == 255) {
-            //Do-Not-Use value for NrSv field in PVTGeodetic message
-            state.num_sats = 0;
+        if (temp.NrSV != 255) {
+            state.num_sats = temp.NrSV;
         }
 
         Debug("temp.Mode=0x%02x\n", (unsigned)temp.Mode);


### PR DESCRIPTION
This is the Copter, Rover, Tracker, Plane-4.5.7 release.  The contents of that release can be found in the [4.5.7-beta1 column of this project](https://github.com/orgs/ArduPilot/projects/8/views/8?layout=board).

This is the same as the 4.5.7-beta1 release but with PR https://github.com/ArduPilot/ardupilot/pull/27799 reverted.  I have not actually determined if [the user report](https://discuss.ardupilot.org/t/coper-4-5-7-beta1-available-for-testing/124355) is correct but I think at this stage it is best to remove it and proceed with the release.

