### PR TITLE
Plane: Do not apply minimum throttle during SLT VTOL airbrake

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -4374,7 +4374,9 @@ bool SLT_Transition::allow_update_throttle_mix() const
 
 bool SLT_Transition::active_frwd() const
 {
-    return quadplane.assisted_flight && ((transition_state == TRANSITION_AIRSPEED_WAIT) || (transition_state == TRANSITION_TIMER));
+    return quadplane.assisted_flight && // We need to be in assisted flight...
+        ((transition_state == TRANSITION_AIRSPEED_WAIT) || (transition_state == TRANSITION_TIMER)) // ... and a transition must be active...
+        && !quadplane.in_vtol_airbrake(); // ... but not executing an QPOS_AIRBRAKE maneuver during an automated landing.
 }
 
 /*


### PR DESCRIPTION
## Summary

This PR ensures that the `bool SLT_Transition::active_frwd()` check does not return true during a back-transition airbrake.

## Details

The existing code would cause `active_frwd()` to return true during a back transition.
In turn, `servos.cpp:553` would trigger:
```c++
#if HAL_QUADPLANE_ENABLED
    if (quadplane.in_frwd_transition()) {
```
and would set the minimum throttle to the **forwards** transition throttle: `THR_TRIM` or `TKOFF_THR_MIN`.

This would lead to undesired increase in airspeed and eventually altitude during the back transition.

The TECS minimum throttle can be used as a proxy to see the effect of that setting.
This is a snapshot during the airbrake phase.

Before:
![image](https://github.com/user-attachments/assets/14e8924d-9079-4b5e-bd8e-477d9db443f1)

After:
![image](https://github.com/user-attachments/assets/b567778f-9f73-4d9a-a9d2-1221bbb0a90b)
