### PR TITLE
board_types.txt: reservie ID for F4 2-3S 20A AIO FC V1

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -290,6 +290,7 @@ AP_HW_PhenixH7_lite                  1171
 AP_HW_PhenixH7_Pro                   1172
 AP_HW_2RAWH743                       1173
 AP_HW_X-MAV-AP-H743V2                1174
+AP_HW_BETAFPV_F4_2-3S_20A            1175
 
 AP_HW_FlywooF405HD_AIOv2             1180
 AP_HW_FlywooH743Pro                  1181


### PR DESCRIPTION
I want to add full support for this board:
https://betafpv.com/products/f4-2-3s-20a-aio-fc-v1 
I have all other files ready but want to reserve a board id first