### PR TITLE
AP_Scripting: Add mcu_voltage

### DIFF
--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1942,6 +1942,10 @@ analog = {}
 ---@return number -- MCU temperature
 function analog:mcu_temperature() end
 
+-- return The current MCU voltage
+---@return number -- MCU voltage
+function analog:mcu_voltage() end
+
 -- desc
 ---@return AP_HAL__AnalogSource_ud|nil
 function analog:channel() end

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -647,6 +647,8 @@ singleton hal.analogin literal
 singleton hal.analogin method channel AP_HAL::AnalogSource ANALOG_INPUT_NONE'literal
 singleton hal.analogin method mcu_temperature float
 singleton hal.analogin method mcu_temperature depends HAL_WITH_MCU_MONITORING
+singleton hal.analogin method mcu_voltage float
+singleton hal.analogin method mcu_voltage depends HAL_WITH_MCU_MONITORING
 
 include AP_Motors/AP_MotorsMatrix_Scripting_Dynamic.h depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_COPTER_OR_HELI
 singleton AP_MotorsMatrix_Scripting_Dynamic depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_COPTER_OR_HELI


### PR DESCRIPTION
Add analog:mcu_voltage() to get a reading of the mcu voltage

Tested on CubeOrangePlus
![image](https://github.com/user-attachments/assets/b5efb9af-c0c7-42ab-b05f-0597d32fd5e5)
