### PR TITLE
AP_DDS: Make GPS DDS features depend on GPS

### DIFF
--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -4,7 +4,9 @@
 #if AP_DDS_ENABLED
 #include <uxr/client/util/ping.h>
 
+#if AP_DDS_NEEDS_GPS
 #include <AP_GPS/AP_GPS.h>
+#endif // AP_DDS_NEEDS_GPS
 #include <AP_HAL/AP_HAL.h>
 #include <RC_Channel/RC_Channel.h>
 #include <AP_RTC/AP_RTC.h>

--- a/libraries/AP_DDS/AP_DDS_config.h
+++ b/libraries/AP_DDS/AP_DDS_config.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <AP_GPS/AP_GPS_config.h>
 #include <AP_HAL/AP_HAL_Boards.h>
 #include <AP_Networking/AP_Networking_Config.h>
+#include <AP_VisualOdom/AP_VisualOdom_config.h>
 
 #ifndef AP_DDS_ENABLED
 #define AP_DDS_ENABLED 1
@@ -39,11 +41,11 @@
 #endif
 
 #ifndef AP_DDS_NAVSATFIX_PUB_ENABLED
-#define AP_DDS_NAVSATFIX_PUB_ENABLED 1
+#define AP_DDS_NAVSATFIX_PUB_ENABLED AP_GPS_ENABLED
 #endif
 
 #ifndef AP_DDS_STATIC_TF_PUB_ENABLED
-#define AP_DDS_STATIC_TF_PUB_ENABLED 1
+#define AP_DDS_STATIC_TF_PUB_ENABLED AP_GPS_ENABLED
 #endif
 
 #ifndef AP_DDS_GPS_GLOBAL_ORIGIN_PUB_ENABLED
@@ -166,6 +168,9 @@
 
 // Whether to include Transform support
 #define AP_DDS_NEEDS_TRANSFORMS AP_DDS_DYNAMIC_TF_SUB_ENABLED || AP_DDS_STATIC_TF_PUB_ENABLED
+
+// Whether DDS needs GPS
+#define AP_DDS_NEEDS_GPS AP_DDS_NAVSATFIX_PUB_ENABLED || AP_DDS_STATIC_TF_PUB_ENABLED
 
 #ifndef AP_DDS_DEFAULT_UDP_IP_ADDR
 #if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS


### PR DESCRIPTION
# Purpose

Make the DDS features that depend on GPS rely on `AP_GPS_ENABLED`. 

# Details

Follow up to https://github.com/ArduPilot/ardupilot/pull/28177 where we hard-coded navsatfix enable flag to `1`. 
If you disabled GPS on `master` now and enabled DDS, you would get a compile error,