### PR TITLE
GCS_MAVLink: raise number of MAVLink ports

### DIFF
--- a/libraries/GCS_MAVLink/GCS_MAVLink.h
+++ b/libraries/GCS_MAVLink/GCS_MAVLink.h
@@ -15,9 +15,9 @@
 #define MAVLINK_START_UART_SEND(chan, size) comm_send_lock(chan, size)
 #define MAVLINK_END_UART_SEND(chan, size) comm_send_unlock(chan)
 
-#if AP_NETWORKING_ENABLED
-// allow 7 telemetry ports with networking
-#define MAVLINK_COMM_NUM_BUFFERS 7
+#if BOARD_FLASH_SIZE > 1024
+// allow 8 telemetry ports, allowing for extra networking or CAN ports
+#define MAVLINK_COMM_NUM_BUFFERS 8
 #else
 // allow five telemetry ports
 #define MAVLINK_COMM_NUM_BUFFERS 5


### PR DESCRIPTION
with CAN serial ports and network serial ports sometimes need more
@lthall hit this with a Durandal with 2 CAN serial ports doing MAVLink