### PR TITLE
Plane: evaluate assistance requirements on mode change

### DIFF
--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -140,6 +140,14 @@ bool Mode::enter()
 
         // Make sure the flight stage is correct for the new mode
         plane.update_flight_stage();
+
+#if HAL_QUADPLANE_ENABLED
+        if (quadplane.enabled()) {
+            float aspeed;
+            bool have_airspeed = quadplane.ahrs.airspeed_estimate(aspeed);
+            quadplane.assisted_flight = quadplane.assist.should_assist(aspeed, have_airspeed);
+        }
+#endif
     }
 
     return enter_result;


### PR DESCRIPTION
this avoid the AHRS being told we are flying forward - because we are no longer in a VTOL mode - and instantly being told we are not flying forward - because we are providing assistance

The following two plots are plotting the fly-forward flag being shoved into the Replay log.

Before:
![image](https://github.com/user-attachments/assets/e8f7c928-a4f6-4680-9185-7e3cec0801cc)

After:
![image](https://github.com/user-attachments/assets/895ef927-d101-4dee-be7a-577937a05796)

This is particularly important when an external wind estimate has been supplied to the vehicle, as setting the FF flag causes EKF3 to completely nuke the wind estimates.  The following graphs are from a different test where the wind estimate is set externally:


Before:
![image](https://github.com/user-attachments/assets/fcfec5dc-03d8-4ef1-bd24-1b0128e0ca64)


After:
![image](https://github.com/user-attachments/assets/b7ea005c-b0f7-4005-a3ed-963ff406df30)


... the EKF wind estimate is still suffering when the FF flag is finally set after FF is *correctly* set - but at least we have transitioned with the flag set!
