### PR TITLE
AP_DDS: Added Micro-XRCE-DDS-GEN instal to Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     lsb-release \
     sudo \
     tzdata \
+    git \
+    default-jre \
     bash-completion
 
 COPY Tools/environment_install/install-prereqs-ubuntu.sh /ardupilot/Tools/environment_install/
@@ -41,6 +43,13 @@ RUN SKIP_AP_EXT_ENV=$SKIP_AP_EXT_ENV SKIP_AP_GRAPHIC_ENV=$SKIP_AP_GRAPHIC_ENV SK
 
 # Check that local/bin are in PATH for pip --user installed package
 RUN echo "if [ -d \"\$HOME/.local/bin\" ] ; then\nPATH=\"\$HOME/.local/bin:\$PATH\"\nfi" >> ~/.ardupilot_env
+
+# Clone & install Micro-XRCE-DDS-Gen dependancy
+RUN git clone --recurse-submodules https://github.com/ardupilot/Micro-XRCE-DDS-Gen.git /home/${USER_NAME}/Micro-XRCE-DDS-Gen \
+    && cd /home/${USER_NAME}/Micro-XRCE-DDS-Gen \
+    && ./gradlew assemble \
+    && export AP_ENV_LOC="/home/${USER_NAME}/.ardupilot_env" \
+    && echo "export PATH=\$PATH:$PWD/scripts" >> $AP_ENV_LOC
 
 # Create entrypoint as docker cannot do shell substitution correctly
 RUN export ARDUPILOT_ENTRYPOINT="/home/${USER_NAME}/ardupilot_entrypoint.sh" \


### PR DESCRIPTION
# Associated Issue #
[#28348](https://github.com/ArduPilot/ardupilot/issues/28348)

# What Changed #
Update to Ardupilot Dockerfile used to build ardupilot code base with --enable-dds flag. The update is an installation of the Micro-XRCE-DDS-Gen dependency to use the enable-dds flag.

# How to run #
* Browse to the `ardupilot` source code folder.
* Build the docker developer image **the first time**:
```bash
docker build . -t ardupilot --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g)
```
* Run the developer container with:
```bash
docker run --rm -it -v "$(pwd):/ardupilot" -u "$(id -u):$(id -g)" ardupilot:latest bash
```
* The container will mount the ardupilot source code as volume. Now configure the target board:
```bash
./waf configure --board <board-name> --enable-dds
```
where `<board-name>` must be one of the supported boards, like `pixracer`.
* Once Configuration is successful build the code with:
```bash
./waf <type>
```
where `<type>` is one of the supported vehicle types, like `copter` or `plane`.

**Note** It might be convenient to delete the `build` folder before building new software.