### PR TITLE
Implement TKOFF_THR_IDLE

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -158,6 +158,15 @@ const AP_Param::Info Plane::var_info[] = {
     // @User: Standard
     ASCALAR(takeoff_throttle_min,       "TKOFF_THR_MIN",    0),
 
+    // @Param: TKOFF_THR_IDLE
+    // @DisplayName: Takeoff idle throttle
+    // @Description: The idle throttle to hold after arming and before a takeoff. Applicable in TAKEOFF and AUTO modes.
+    // @Units: %
+    // @Range: 0 100
+    // @Increment: 1
+    // @User: Standard
+    ASCALAR(takeoff_throttle_idle,       "TKOFF_THR_IDLE",    0),
+
     // @Param: TKOFF_OPTIONS
     // @DisplayName: Takeoff options
     // @Description: This selects the mode of the takeoff in AUTO and TAKEOFF flight modes. 

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -359,6 +359,7 @@ public:
         k_param_autotune_options,
         k_param_takeoff_throttle_min,
         k_param_takeoff_options,
+        k_param_takeoff_throttle_idle,
 
         k_param_pullup = 270,
     };

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -619,6 +619,11 @@ void Plane::set_throttle(void)
             // throttle is suppressed (above) to zero in final flare in auto mode, but we allow instead thr_min if user prefers, eg turbines:
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, aparm.throttle_min.get());
 
+        } else if ((flight_stage == AP_FixedWing::FlightStage::TAKEOFF)
+                    && (aparm.takeoff_throttle_idle.get() > 0)
+                  ) {
+            // we want to spin at idle throttle before the takeoff conditions are met
+            SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, aparm.takeoff_throttle_idle.get());
         } else {
             // default
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, 0.0);

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -4831,6 +4831,34 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         self.fly_home_land_and_disarm()
 
+    def TakeoffIdleThrottle(self):
+        '''Apply idle throttle before takeoff.'''
+        self.customise_SITL_commandline(
+            [],
+            model='plane-catapult',
+            defaults_filepath=self.model_defaults_filepath("plane")
+        )
+        self.set_parameters({
+            "TKOFF_THR_IDLE": 20.0,
+            "TKOFF_THR_MINSPD": 3.0,
+        })
+        self.change_mode("TAKEOFF")
+
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+
+        # Ensure that the throttle rises to idle throttle.
+        expected_idle_throttle = 1000+10*self.get_parameter("TKOFF_THR_IDLE")
+        self.assert_servo_channel_range(3, expected_idle_throttle-10, expected_idle_throttle+10)
+
+        # Launch the catapult
+        self.set_servo(6, 1000)
+
+        self.delay_sim_time(5)
+        self.change_mode('RTL')
+
+        self.fly_home_land_and_disarm()
+
     def DCMFallback(self):
         '''Really annoy the EKF and force fallback'''
         self.reboot_sitl()
@@ -6389,6 +6417,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.TakeoffTakeoff3,
             self.TakeoffTakeoff4,
             self.TakeoffGround,
+            self.TakeoffIdleThrottle,
             self.ForcedDCM,
             self.DCMFallback,
             self.MAVFTP,

--- a/libraries/AP_Vehicle/AP_FixedWing.h
+++ b/libraries/AP_Vehicle/AP_FixedWing.h
@@ -12,6 +12,7 @@ struct AP_FixedWing {
     AP_Int8 throttle_cruise;
     AP_Int8 takeoff_throttle_max;
     AP_Int8 takeoff_throttle_min;
+    AP_Int8 takeoff_throttle_idle;
     AP_Int32 takeoff_options;
     AP_Int16 airspeed_min;
     AP_Int16 airspeed_max;


### PR DESCRIPTION
I thought I'd tackle https://github.com/ArduPilot/ardupilot/issues/20754.

A new parameter `TKOFF_THR_IDLE` has been added and a new option bit 1 to `TKOFF_OPTIONS` to enable it (off by default).

In TAKEOFF and AUTO modes, while in `FlightStage::TAKEOFF` and while the throttle is suppressed, `TKOFF_THR_IDLE` is output to the throttle.

Here's how it looks like in a catapult takeoff, for `TKOFF_THR_IDLE=20`:
![image](https://github.com/user-attachments/assets/402b91f3-4cdc-40d3-8ec7-f350487681f4)
