### PR TITLE
AP_TECS: Fix Regression  of TKOFF_IGAIN

### DIFF
--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -226,7 +226,7 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
     // @Range: 0.0 0.5
     // @Increment: 0.02
     // @User: Advanced
-    AP_GROUPINFO("TKOFF_IGAIN", 25, AP_TECS, _integGain_takeoff, 0),
+    AP_GROUPINFO("TKOFF_IGAIN", 25, AP_TECS, _integGain_takeoff, 0.3f),
 
     // @Param: LAND_PDAMP
     // @DisplayName: Pitch damping gain when landing


### PR DESCRIPTION
The referenced commit below did remove an is_zero() check which in my case made a belly landing out of an  auto takeoff because the parameter TECS_TKOFF_IGAIN is 0 (default) and pitch error is not corrected.

fixes: b163e139642bac450f45dfed9155009ff62ed0de (AP_TECS: Fixes to reset state )