### PR TITLE
GCS_MAVLink: Support requesting MESSAGE_INTERVAL via REQUEST_MESSAGE cmd

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3200,6 +3200,12 @@ uint8_t GCS::get_channel_from_port_number(uint8_t port_num)
 MAV_RESULT GCS_MAVLINK::handle_command_request_message(const mavlink_command_int_t &packet)
 {
     const uint32_t mavlink_id = (uint32_t)packet.param1;
+
+    if (mavlink_id == MAVLINK_MSG_ID_MESSAGE_INTERVAL) {
+        const mavlink_command_int_t msg_interval_cmd = { .param1 = packet.param2, };
+        return handle_command_get_message_interval(msg_interval_cmd);
+    }
+
     const ap_message id = mavlink_id_to_ap_message_id(mavlink_id);
     if (id == MSG_LAST) {
         return MAV_RESULT_FAILED;


### PR DESCRIPTION
Updates the `MAV_CMD_REQUEST_MESSAGE` handler with a special case for requesting the `MESSAGE_INTERVAL` message. The old method of using `MAV_CMD_GET_MESSAGE_INTERVAL` is deprecated.

Raised in this Discord message: https://discord.com/channels/674039678562861068/728017546313466047/1293342302261219329