### PR TITLE
Copter: remove global ap.new_radio_frame state 

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -772,13 +772,15 @@ void Copter::update_simple_mode(void)
 {
     float rollx, pitchx;
 
-    // exit immediately if no new radio frame or not in simple mode
-    if (simple_mode == SimpleMode::NONE || !ap.new_radio_frame) {
+    // exit immediately if not in simple mode:
+    if (simple_mode == SimpleMode::NONE) {
         return;
     }
 
-    // mark radio frame as consumed
-    ap.new_radio_frame = false;
+    // exit immediately if RC input is invalid:
+    if (!rc().has_valid_input()) {
+        return;
+    }
 
     if (simple_mode == SimpleMode::SIMPLE) {
         // rotate roll, pitch input by -initial simple heading (i.e. north facing)

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -365,7 +365,7 @@ private:
         bool auto_armed;                     //  5 stops auto missions from beginning until throttle is raised
         bool unused_log_started;             //  6
         bool land_complete;                  //  7 true if we have detected a landing
-        bool new_radio_frame;                //  8 Set true if we have new PWM data to act on from the Radio
+        bool unused_new_radio_frame;         //  8 was: Set true if we have new PWM data to act on from the Radio
         bool unused_usb_connected;           //  9
         bool unused_receiver_present;        // 10
         bool compass_mot;                    // 11 true if we are currently performing compassmot calibration

--- a/ArduCopter/radio.cpp
+++ b/ArduCopter/radio.cpp
@@ -83,8 +83,6 @@ void Copter::read_radio()
     const uint32_t tnow_ms = millis();
 
     if (rc().read_input()) {
-        ap.new_radio_frame = true;
-
         set_throttle_and_failsafe(channel_throttle->get_radio_in());
         set_throttle_zero_flag(channel_throttle->get_control_in());
 


### PR DESCRIPTION
we have better means to determine if you have valid input

Rebase/push after https://github.com/ArduPilot/ardupilot/pull/28354 is merged - in the meantime only the most recent patch is interesting

