### PR TITLE
autotest: restart MAVProxy if it exits when running under gdb

### DIFF
--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -986,6 +986,17 @@ def start_mavproxy(opts, stuff):
     run_cmd_blocking("Run MavProxy", cmd, env=env)
     progress("MAVProxy exited")
 
+    if opts.gdb:
+        # in the case that MAVProxy exits (as opposed to being
+        # killed), restart it if we are running under GDB.  This
+        # allows ArduPilot to stop (eg. via a very early panic call)
+        # and have you debugging session not be killed.
+        while True:
+            progress("Running under GDB; restarting MAVProxy")
+            run_cmd_blocking("Run MavProxy", cmd, env=env)
+            progress("MAVProxy exited; sleeping 10")
+            time.sleep(10)
+
 
 vehicle_options_string = '|'.join(vinfo.options.keys())
 


### PR DESCRIPTION
this is useful if you are running under GDB and ArduPilot fails early (eg. parameter sanity checks or SITL device configuration issues)

![image](https://github.com/user-attachments/assets/5e21a4c5-0fd0-4ced-84d6-7fe41900d752)
