### PR TITLE
AP_PiccoloCAN: use 32 bit microsecond timeouts

### DIFF
--- a/libraries/AP_PiccoloCAN/AP_PiccoloCAN.cpp
+++ b/libraries/AP_PiccoloCAN/AP_PiccoloCAN.cpp
@@ -687,26 +687,26 @@ bool AP_PiccoloCAN::is_esc_channel_active(uint8_t chan)
 /**
  * Determine if a servo is present on the CAN bus (has telemetry data been received)
  */
-bool AP_PiccoloCAN::is_servo_present(uint8_t chan, uint64_t timeout_ms)
+bool AP_PiccoloCAN::is_servo_present(uint8_t chan, uint32_t timeout_us)
 {
     if (chan >= PICCOLO_CAN_MAX_NUM_SERVO) {
         return false;
     }
 
-    return _servos[chan].is_connected(timeout_ms);
+    return _servos[chan].is_connected(timeout_us);
 }
 
 
 /**
  * Determine if an ESC is present on the CAN bus (has telemetry data been received)
  */
-bool AP_PiccoloCAN::is_esc_present(uint8_t chan, uint64_t timeout_ms)
+bool AP_PiccoloCAN::is_esc_present(uint8_t chan, uint32_t timeout_us)
 {
     if (chan >= PICCOLO_CAN_MAX_NUM_ESC) {
         return false;
     }
 
-    return _escs[chan].is_connected(timeout_ms);
+    return _escs[chan].is_connected(timeout_us);
 }
 
 

--- a/libraries/AP_PiccoloCAN/AP_PiccoloCAN.h
+++ b/libraries/AP_PiccoloCAN/AP_PiccoloCAN.h
@@ -83,7 +83,7 @@ private:
     void loop();
 
     // write frame on CAN bus, returns true on success
-    bool write_frame(AP_HAL::CANFrame &out_frame, uint64_t timeout);
+    bool write_frame(AP_HAL::CANFrame &out_frame, uint32_t timeout_us);
 
     // read frame on CAN bus, returns true on succses
     bool read_frame(AP_HAL::CANFrame &recv_frame, uint32_t timeout_us);

--- a/libraries/AP_PiccoloCAN/AP_PiccoloCAN.h
+++ b/libraries/AP_PiccoloCAN/AP_PiccoloCAN.h
@@ -86,7 +86,7 @@ private:
     bool write_frame(AP_HAL::CANFrame &out_frame, uint64_t timeout);
 
     // read frame on CAN bus, returns true on succses
-    bool read_frame(AP_HAL::CANFrame &recv_frame, uint64_t timeout);
+    bool read_frame(AP_HAL::CANFrame &recv_frame, uint32_t timeout_us);
 
     // send ESC commands over CAN
     void send_esc_messages(void);

--- a/libraries/AP_PiccoloCAN/AP_PiccoloCAN.h
+++ b/libraries/AP_PiccoloCAN/AP_PiccoloCAN.h
@@ -63,10 +63,10 @@ public:
     bool is_esc_channel_active(uint8_t chan);
 
     // return true if a particular servo has been detected on the CAN interface
-    bool is_servo_present(uint8_t chan, uint64_t timeout_ms = 2000);
+    bool is_servo_present(uint8_t chan, uint32_t timeout_us = 2000000);
 
     // return true if a particular ESC has been detected on the CAN interface
-    bool is_esc_present(uint8_t chan, uint64_t timeout_ms = 2000);
+    bool is_esc_present(uint8_t chan, uint32_t timeout_us = 2000000);
 
     // return true if a particular servo is enabled
     bool is_servo_enabled(uint8_t chan);

--- a/libraries/AP_PiccoloCAN/AP_PiccoloCAN_Device.h
+++ b/libraries/AP_PiccoloCAN/AP_PiccoloCAN_Device.h
@@ -58,10 +58,10 @@ public:
     virtual bool is_enabled(void) const { return false; }
 
     // Determine if this device has been seen within a specified timeframe
-    virtual bool is_connected(int64_t timeout_ms) const {
+    virtual bool is_connected(uint32_t timeout_us) const {
         uint64_t now = AP_HAL::micros64();
 
-        return now < (last_msg_timestamp + (1000ULL * timeout_ms));
+        return now < (last_msg_timestamp + timeout_us);
     }
 
     // Reset the received message timestamp


### PR DESCRIPTION
For consistency with other parts of the code. Saves a handful of bytes.

Please see commit messages for caveats with this change; this does change protocol semantics ever so slightly. Needs testing with real hardware.