### PR TITLE
defaults_periph.h: Removed duplication for AP_STATS_ENABLED

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/defaults_periph.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/defaults_periph.h
@@ -114,10 +114,6 @@
 #endif
 #endif
 
-#ifndef AP_STATS_ENABLED
-#define AP_STATS_ENABLED 0
-#endif
-
 #ifndef AP_BATTERY_ESC_ENABLED
 #define AP_BATTERY_ESC_ENABLED 0
 #endif


### PR DESCRIPTION
Removed duplication for AP_STATS_ENABLED in AP_Periph defaults