### PR TITLE
Create a python installer for required deps on Ubuntu 22.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 *.d
 *.dfu
 *.dll
+*.egg-info
 *.elf
 *.exe
 *.generated.h

--- a/Tools/environment_install/install-python.sh
+++ b/Tools/environment_install/install-python.sh
@@ -1,0 +1,11 @@
+#/usr/bin/env bash
+set -euxo pipefail
+
+PYTHON=$(which python)
+echo "Installing all sub-libraries with $PYTHON"
+
+git submodule update --init --recursive
+$PYTHON -m ensurepip
+$PYTHON -m pip install --upgrade pip setuptools wheel
+$PYTHON -m pip install --upgrade empy==3.3.4 pexpect
+find . | egrep -v '/build/' | grep setup.py | xargs readlink -e | xargs dirname | xargs -I{} bash -c "pushd {} ; $PYTHON -m pip install . ; popd"


### PR DESCRIPTION
I was doing the following on Ubuntu 22.04 and ran into various python issues. Here is a script which should initialize git submodules and install dependencies as needed on the platform. I have tested this with python3 installed with `pyenv` AND with python3 installed with Ubuntu/Apt with AND without virtual environments on two separate machines.

Before, one of the denoted errors is produced:
```
$ ./waf bootloader 
...
# ERROR(1):
you need to install empy with 'python -m pip install empy==3.3.4'
# ERROR(2):
you need to install pexpect with 'python -m pip install pexpect'
```

After:
```
$ ./waf bootloader
...
BUILD SUMMARY
Build directory: ...
Target                    Text (B)  Data (B)  BSS (B)  Total Flash Used (B)  Free Flash (B)  External Flash Used (B)
--------------------------------------------------------------------------------------------------------------------
bootloader/AP_Bootloader     14416        64   131008                 14480            1904  Not Applicable         

'bootloader' finished successfully (1.112s)
```
