### PR TITLE
AP_NavEKF3: break circular takeoff-expected loop in Replay

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -784,7 +784,7 @@ void  NavEKF3_core::updateFilterStatus(void)
     status.flags.pred_horiz_pos_rel = status.flags.horiz_pos_rel; // EKF3 enters the required mode before flight
     status.flags.pred_horiz_pos_abs = status.flags.horiz_pos_abs; // EKF3 enters the required mode before flight
     status.flags.takeoff_detected = takeOffDetected; // takeoff for optical flow navigation has been detected
-    status.flags.takeoff = dal.get_takeoff_expected(); // The EKF has been told to expect takeoff is in a ground effect mitigation mode and has started the EKF-GSF yaw estimator
+    status.flags.takeoff = takeoff_expected; // The EKF has been told to expect takeoff is in a ground effect mitigation mode and has started the EKF-GSF yaw estimator
     status.flags.touchdown = dal.get_touchdown_expected(); // The EKF has been told to detect touchdown and is in a ground effect mitigation mode
     status.flags.using_gps = ((imuSampleTime_ms - lastGpsPosPassTime_ms) < 4000) && (PV_AidingMode == AID_ABSOLUTE);
     status.flags.gps_glitching = !gpsAccuracyGood && (PV_AidingMode == AID_ABSOLUTE) && (frontend->sources.getPosXYSource() == AP_NavEKF_Source::SourceXY::GPS); // GPS glitching is affecting navigation accuracy

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -970,7 +970,7 @@ void NavEKF3_core::FuseVelPosNED()
                     const ftype gndMaxBaroErr = MAX(frontend->_baroGndEffectDeadZone, 0.0);
                     const ftype gndBaroInnovFloor = -0.5;
 
-                    if ((dal.get_touchdown_expected() || dal.get_takeoff_expected()) && activeHgtSource == AP_NavEKF_Source::SourceZ::BARO) {
+                    if ((dal.get_touchdown_expected() || takeoff_expected) && activeHgtSource == AP_NavEKF_Source::SourceZ::BARO) {
                         // when baro positive pressure error due to ground effect is expected,
                         // floor the barometer innovation at gndBaroInnovFloor
                         // constrain the correction between 0 and gndBaroInnovFloor+gndMaxBaroErr
@@ -1248,7 +1248,7 @@ void NavEKF3_core::selectHeightForFusion()
         }
         // filtered baro data used to provide a reference for takeoff
         // it is is reset to last height measurement on disarming in performArmingChecks()
-        if (!dal.get_takeoff_expected()) {
+        if (!takeoff_expected) {
             const ftype gndHgtFiltTC = 0.5;
             const ftype dtBaro = frontend->hgtAvg_ms*1.0e-3;
             ftype alpha = constrain_ftype(dtBaro / (dtBaro+gndHgtFiltTC),0.0,1.0);
@@ -1323,7 +1323,7 @@ void NavEKF3_core::selectHeightForFusion()
         // set the observation noise
         posDownObsNoise = sq(constrain_ftype(frontend->_baroAltNoise, 0.1f, 100.0f));
         // reduce weighting (increase observation noise) on baro if we are likely to be experiencing rotor wash ground interaction
-        if (dal.get_takeoff_expected() || dal.get_touchdown_expected()) {
+        if (takeoff_expected || dal.get_touchdown_expected()) {
             posDownObsNoise *= frontend->gndEffectBaroScaler;
         }
         velPosObs[5] = -hgtMea;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
@@ -362,7 +362,7 @@ void NavEKF3_core::detectFlight()
 
         if (motorsArmed) {
             onGround = false;
-            if (highGndSpd && (dal.get_takeoff_expected() || highAirSpd || largeHgtChange)) {
+            if (highGndSpd && (takeoff_expected || highAirSpd || largeHgtChange)) {
                 // to a high certainty we are flying
                 inFlight = true;
             }
@@ -434,7 +434,7 @@ void NavEKF3_core::detectFlight()
     if ((!prevOnGround && onGround) || !gpsSpdAccPass) {
         // disable filter bank
         EKFGSF_run_filterbank = false;
-    } else if (yawEstimator != nullptr && !EKFGSF_run_filterbank && (inFlight || dal.get_takeoff_expected()) && gpsSpdAccPass) {
+    } else if (yawEstimator != nullptr && !EKFGSF_run_filterbank && (inFlight || takeoff_expected) && gpsSpdAccPass) {
         // flying or about to fly so reset counters and enable filter bank when GPS is good
         EKFGSF_yaw_reset_ms = 0;
         EKFGSF_yaw_reset_request_ms = 0;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -633,6 +633,11 @@ void NavEKF3_core::UpdateFilter(bool predict)
 
     fill_scratch_variables();
 
+    if (dal.get_takeoff_expected() != last_dal_takeoff_expected) {
+        last_dal_takeoff_expected = dal.get_takeoff_expected();
+        takeoff_expected = last_dal_takeoff_expected;
+    }
+
     // update sensor selection (for affinity)
     update_sensor_selection();
 
@@ -896,10 +901,10 @@ void NavEKF3_core::calcOutputStates()
 
     // Detect fixed wing launch acceleration using latest data from IMU to enable early startup of filter functions
     // that use launch acceleration to detect start of flight
-    if (!inFlight && !dal.get_takeoff_expected() && assume_zero_sideslip()) {
+    if (!inFlight && !takeoff_expected && assume_zero_sideslip()) {
         const ftype launchDelVel = imuDataNew.delVel.x + GRAVITY_MSS * imuDataNew.delVelDT * Tbn_temp.c.x;
         if (launchDelVel > GRAVITY_MSS * imuDataNew.delVelDT) {
-            dal.set_takeoff_expected();
+            takeoff_expected = true;
         }
     }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1433,6 +1433,13 @@ private:
     AP_NavEKF_Source::SourceZ activeHgtSource;  // active height source
     AP_NavEKF_Source::SourceZ prevHgtSource;    // previous height source used to detect changes in source
 
+    // takeoff expected; last-one-in-wins from either the AHRS state
+    // (as polled in UpdateFilter), or the EKF's own acceleration-based detection:
+    bool takeoff_expected;
+    // last state the DAL had; if the DAL state changes then we update
+    // our own state:
+    bool last_dal_takeoff_expected;
+
     // Movement detector
     bool takeOffDetected;           // true when takeoff for optical flow navigation has been detected
     ftype rngAtStartOfFlight;       // range finder measurement at start of flight


### PR DESCRIPTION
if NavEKF3 modifies the AHRS state then the next time we start a DAL frame we will record that new state in our Replay log file.

When we replay the log file we will make that value set - but that's *bad* because we're now priming the Replayed EKF3 with state output from the original run-through of the EKF