### PR TITLE
AP_NavEKF3: remove takeoff-detection code

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -894,15 +894,6 @@ void NavEKF3_core::calcOutputStates()
         posOffsetNED.zero();
     }
 
-    // Detect fixed wing launch acceleration using latest data from IMU to enable early startup of filter functions
-    // that use launch acceleration to detect start of flight
-    if (!inFlight && !dal.get_takeoff_expected() && assume_zero_sideslip()) {
-        const ftype launchDelVel = imuDataNew.delVel.x + GRAVITY_MSS * imuDataNew.delVelDT * Tbn_temp.c.x;
-        if (launchDelVel > GRAVITY_MSS * imuDataNew.delVelDT) {
-            dal.set_takeoff_expected();
-        }
-    }
-
     // store INS states in a ring buffer that with the same length and time coordinates as the IMU data buffer
     if (runUpdates) {
         // store the states at the output time horizon


### PR DESCRIPTION
the current implementation pokes data back into the DAL, which is in the not-good category.


This is an alternative to https://github.com/ArduPilot/ardupilot/pull/28376 .  Instead of breaking the loop we just remove the offending code.

I'm not sure about this one, but talking with @tridge he thought it a reasonable step.  OTOH, this code wasn't added just for fun, it might have solved a real problem.  tridge and I both thought the vehicle probably has more information to do this sort of calculation...
