### PR TITLE
AP_HAL_ChibiOS: do not run through SPI_RX and TX as well

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -2404,6 +2404,8 @@ INCLUDE common.ld
         gpioset = set()
         for label in self.bylabel:
             p = self.bylabel[label]
+            if 'SPI' in label and ('RX' in label or 'TX' in label):
+                continue
             gpio = p.extra_value('GPIO', type=int)
             if gpio is None:
                 continue


### PR DESCRIPTION
 This fixes a bug where we run GPIO loop through SPI two times per pin as we duplicate MISO and MOSI name with RX and TX as well. So if we have GPIO(x) next to SPI the hwdef fails to compile, and does not allow SPI lines to also be treated as GPIO.  