### PR TITLE
AP_ADSB: uAvionix Transponder Updates

### DIFF
--- a/libraries/AP_ADSB/AP_ADSB_uAvionix_UCP.cpp
+++ b/libraries/AP_ADSB/AP_ADSB_uAvionix_UCP.cpp
@@ -58,6 +58,8 @@ bool AP_ADSB_uAvionix_UCP::init()
     }
 
     _frontend.out_state.ctrl.squawkCode = 1200;
+    _frontend.out_state.tx_status.squawk = 1200;
+    _frontend.out_state.tx_status.fault |= UAVIONIX_ADSB_OUT_STATUS_FAULT_STATUS_MESSAGE_UNAVAIL;
 
     return true;
 }

--- a/libraries/AP_ADSB/AP_ADSB_uAvionix_UCP.cpp
+++ b/libraries/AP_ADSB/AP_ADSB_uAvionix_UCP.cpp
@@ -105,13 +105,6 @@ void AP_ADSB_uAvionix_UCP::update()
         _frontend.out_state.tx_status.fault |= UAVIONIX_ADSB_OUT_STATUS_FAULT_STATUS_MESSAGE_UNAVAIL;
         // TODO reset the data for each message when timeout occurs
     }
-#if AP_MAVLINK_MSG_UAVIONIX_ADSB_OUT_STATUS_ENABLED
-    if (now_ms - run_state.last_gcs_send_message_Transponder_Status_ms >= 10000)
-    {
-        GCS_SEND_MESSAGE(MSG_UAVIONIX_ADSB_OUT_STATUS);
-        run_state.last_gcs_send_message_Transponder_Status_ms = now_ms;
-    }
-#endif
 }
 
 

--- a/libraries/AP_ADSB/AP_ADSB_uAvionix_UCP.h
+++ b/libraries/AP_ADSB/AP_ADSB_uAvionix_UCP.h
@@ -79,12 +79,19 @@ private:
     } rx;
 
     struct {
-        uint32_t last_packet_GPS_ms;
-        uint32_t last_packet_Transponder_Control_ms;
-        uint32_t last_packet_Transponder_Status_ms;
-        uint32_t last_packet_Transponder_Heartbeat_ms;
-        uint32_t last_packet_Transponder_Ownship_ms;
-        uint32_t last_gcs_send_message_Transponder_Status_ms;
+        uint32_t last_packet_GPS_ms; // out
+        uint32_t last_packet_Transponder_Control_ms; // out
+        uint32_t last_packet_Transponder_Status_ms; // in
+        uint32_t last_packet_Transponder_Heartbeat_ms; // in
+        uint32_t last_packet_Transponder_Ownship_ms; // in
+        uint32_t last_gcs_send_message_Transponder_Status_ms; // out
+        uint32_t last_packet_Request_Transponder_Config_ms;  // out
+        uint32_t last_packet_Transponder_Config_ms; // in
+        uint32_t request_Transponder_Config_tries; 
+        uint32_t last_packet_Request_Transponder_Id_ms; // out
+        uint32_t last_packet_Transponder_Id_ms; // in
+        uint32_t request_Transponder_Id_tries;
+
     } run_state;
 
 };

--- a/libraries/AP_ADSB/AP_ADSB_uAvionix_UCP.h
+++ b/libraries/AP_ADSB/AP_ADSB_uAvionix_UCP.h
@@ -84,6 +84,7 @@ private:
         uint32_t last_packet_Transponder_Status_ms;
         uint32_t last_packet_Transponder_Heartbeat_ms;
         uint32_t last_packet_Transponder_Ownship_ms;
+        uint32_t last_gcs_send_message_Transponder_Status_ms;
     } run_state;
 
 };

--- a/libraries/AP_ADSB/AP_ADSB_uAvionix_UCP.h
+++ b/libraries/AP_ADSB/AP_ADSB_uAvionix_UCP.h
@@ -69,6 +69,7 @@ private:
             GDL90_TRANSPONDER_CONFIG_MSG_V4_V5 transponder_config;
             GDL90_HEARTBEAT heartbeat;
             GDL90_TRANSPONDER_STATUS_MSG transponder_status;
+            GDL90_TRANSPONDER_STATUS_MSG_V3 transponder_status_v3;
 #if AP_ADSB_UAVIONIX_UCP_CAPTURE_ALL_RX_PACKETS
             GDL90_OWNSHIP_REPORT ownship_report;
             GDL90_OWNSHIP_GEO_ALTITUDE ownship_geometric_altitude;

--- a/libraries/AP_ADSB/GDL90_protocol/GDL90_Message_Structs.h
+++ b/libraries/AP_ADSB/GDL90_protocol/GDL90_Message_Structs.h
@@ -103,10 +103,8 @@ typedef struct __attribute__((__packed__))
 } GDL90_TRANSPONDER_CONTROL_MSG;
 #endif
 
-#define GDL90_TRANSPONDER_STATUS_VERSION (1) // Version 1 is the correct UCP format; version 3 is half-duplex and not used by the ping200x
 #define GDL90_STATUS_MAX_ALTITUDE_FT (101338)
 #define GDL90_STATUS_MIN_ALTITUDE_FT (-1000)
-#if GDL90_TRANSPONDER_STATUS_VERSION == 1
 typedef struct __attribute__((__packed__))
 {
   GDL90_MESSAGE_ID              messageId;
@@ -122,9 +120,9 @@ typedef struct __attribute__((__packed__))
   uint16_t                      modecRepliesPerSecond;
   uint16_t                      modeSRepliesPerSecond;
   uint16_t                      squawkCode;
+  uint16_t                      crc;
 } GDL90_TRANSPONDER_STATUS_MSG;
-#endif
-#if GDL90_TRANSPONDER_STATUS_VERSION == 3
+
 typedef struct __attribute__((__packed__))
 {
   GDL90_MESSAGE_ID              messageId;
@@ -147,8 +145,7 @@ typedef struct __attribute__((__packed__))
   uint8_t                       NACp                  : 4;
   uint8_t                       temperature;
   uint16_t                      crc;
-} GDL90_TRANSPONDER_STATUS_MSG;
-#endif
+} GDL90_TRANSPONDER_STATUS_MSG_V3;
 
 
 typedef struct __attribute__((__packed__))


### PR DESCRIPTION

This PR contains updates to the interface with the ping200X. Co-requisite with the MissionPlanner PR https://github.com/ArduPilot/MissionPlanner/pull/3429

Changes:

- Added parsing for GDL90 Transponder Status V3
  - Fixes buggy behavior when ping200X has both UCP and UCP-HD out protocols enabled
  - Includes new fields for on-ground state, board temperature, NIC, and NACp.
- Improved behavior when ping200X times out (due to power loss, serial connection error, etc.)
  - `UAVIONIX_ADSB_OUT_STATUS_FAULT_STATUS_MESSAGE_UNAVAIL` is now `1` if the GDL90 ownship, transponder status, and heartbeat have been missed for 10 seconds, and is otherwise `0` when one of those messages is received. See the co-requisite MissionPlanner PR for changes to how the GCS handles that field. 
- Added support for using the ArduPilot's GPS as a GPS source for the ping200X
  - Previously, the ping200X needed its own GPS (usually a truFYX) connected to it in order to work properly
  - Setting `ADSB_OPTIONS=1`, which forwarded the AP's GPS data to the transponder, would result in a NIC of `UNKNOWN` due to an invalid HPL
    - HPL is now estimated using the horizontal accuracy
- Improved initialization of control message and frontend status
  - Attempts to poll ping200X for config message to set the control message defaults
  - Fixes a display error where a squawk of 0 was listed when the transponder had never been powered before connecting to the GCS