### PR TITLE
Copter: Change enum values to int type

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -690,7 +690,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Description: Used by Throw mode. Controls whether motors will run at the speed set by MOT_SPIN_MIN or will be stopped when armed and waiting for the throw.
     // @Values: 0:Stopped,1:Running
     // @User: Standard
-    GSCALAR(throw_motor_start, "THROW_MOT_START", (float)ModeThrow::PreThrowMotorState::STOPPED),
+    GSCALAR(throw_motor_start, "THROW_MOT_START", static_cast<int32_t>(ModeThrow::PreThrowMotorState::STOPPED)),
 
     // @Param: THROW_ALT_MIN
     // @DisplayName: Throw mode minimum altitude
@@ -761,7 +761,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Description: Used by Throw mode. Specifies whether Copter is thrown upward or dropped.
     // @Values: 0:Upward Throw,1:Drop
     // @User: Standard
-    AP_GROUPINFO("THROW_TYPE", 4, ParametersG2, throw_type, (float)ModeThrow::ThrowType::Upward),
+    AP_GROUPINFO("THROW_TYPE", 4, ParametersG2, throw_type, static_cast<int32_t>(ModeThrow::ThrowType::Upward)),
 #endif
 
     // @Param: GND_EFFECT_COMP
@@ -940,7 +940,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Description: Bitmask of additional options for battery, radio, & GCS failsafes. 0 (default) disables all options.
     // @Bitmask: 0:Continue if in Auto on RC failsafe, 1:Continue if in Auto on GCS failsafe, 2:Continue if in Guided on RC failsafe, 3:Continue if landing on any failsafe, 4:Continue if in pilot controlled modes on GCS failsafe, 5:Release Gripper
     // @User: Advanced
-    AP_GROUPINFO("FS_OPTIONS", 36, ParametersG2, fs_options, (float)Copter::FailsafeOption::GCS_CONTINUE_IF_PILOT_CONTROL),
+    AP_GROUPINFO("FS_OPTIONS", 36, ParametersG2, fs_options, static_cast<int32_t>(Copter::FailsafeOption::GCS_CONTINUE_IF_PILOT_CONTROL)),
 
 #if MODE_AUTOROTATE_ENABLED
     // @Group: AROT_

--- a/ArduCopter/toy_mode.cpp
+++ b/ArduCopter/toy_mode.cpp
@@ -31,14 +31,14 @@ const AP_Param::GroupInfo ToyMode::var_info[] = {
     // @Description: This is the initial mode when the vehicle is first turned on. This mode is assumed to not require GPS
     // @Values: 0:Stabilize,1:Acro,2:AltHold,3:Auto,4:Guided,5:Loiter,6:RTL,7:Circle,9:Land,11:Drift,13:Sport,14:Flip,15:AutoTune,16:PosHold,17:Brake,18:Throw,19:Avoid_ADSB,20:Guided_NoGPS,21:FlowHold
     // @User: Standard
-    AP_GROUPINFO("_MODE1", 2, ToyMode, primary_mode[0], (float)Mode::Number::ALT_HOLD),
+    AP_GROUPINFO("_MODE1", 2, ToyMode, primary_mode[0], static_cast<int8_t>(Mode::Number::ALT_HOLD)),
 
     // @Param: _MODE2
     // @DisplayName: Tmode second mode
     // @Description: This is the secondary mode. This mode is assumed to require GPS
     // @Values: 0:Stabilize,1:Acro,2:AltHold,3:Auto,4:Guided,5:Loiter,6:RTL,7:Circle,9:Land,11:Drift,13:Sport,14:Flip,15:AutoTune,16:PosHold,17:Brake,18:Throw,19:Avoid_ADSB,20:Guided_NoGPS,21:FlowHold
     // @User: Standard
-    AP_GROUPINFO("_MODE2", 3, ToyMode, primary_mode[1], (float)Mode::Number::LOITER),
+    AP_GROUPINFO("_MODE2", 3, ToyMode, primary_mode[1], static_cast<int8_t>(Mode::Number::LOITER)),
 
     // @Param: _ACTION1
     // @DisplayName: Tmode action 1

--- a/libraries/AC_Avoidance/AP_OADatabase.cpp
+++ b/libraries/AC_Avoidance/AP_OADatabase.cpp
@@ -72,7 +72,7 @@ const AP_Param::GroupInfo AP_OADatabase::var_info[] = {
     // @Description: OADatabase output level to configure which database objects are sent to the ground station. All data is always available internally for avoidance algorithms.
     // @Values: 0:Disabled,1:Send only HIGH importance items,2:Send HIGH and NORMAL importance items,3:Send all items
     // @User: Advanced
-    AP_GROUPINFO("OUTPUT", 4, AP_OADatabase, _output_level, (float)OutputLevel::HIGH),
+    AP_GROUPINFO("OUTPUT", 4, AP_OADatabase, _output_level, static_cast<int32_t>(OutputLevel::HIGH)),
 
     // @Param: BEAM_WIDTH
     // @DisplayName: OADatabase beam width


### PR DESCRIPTION
AP_Enum is an ENUM variable.
The FLOAT type is incorrect.
Change it to the INT type.