### PR TITLE
Copter: fixed landing gear deploys and retracts when rangefinder is out of range

### DIFF
--- a/ArduCopter/landing_gear.cpp
+++ b/ArduCopter/landing_gear.cpp
@@ -18,15 +18,10 @@ void Copter::landinggear_update()
     switch (rangefinder.status_orient(ROTATION_PITCH_270)) {
     case RangeFinder::Status::NotConnected:
     case RangeFinder::Status::NoData:
-        // use altitude above home for non-functioning rangefinder
-        break;
-
-    case RangeFinder::Status::OutOfRangeLow:
-        // altitude is close to zero (gear should deploy)
-        height_cm = 0;
-        break;
-
     case RangeFinder::Status::OutOfRangeHigh:
+    case RangeFinder::Status::OutOfRangeLow:
+        // use altitude above home for non-functioning or out of range rangefinder
+        break;
     case RangeFinder::Status::Good:
         // use last good reading
         height_cm = rangefinder_state.alt_cm_filt.get();


### PR DESCRIPTION
When the drone height exceeds the working range of the rangefinder, the status of the range finder is set to OutOfRangeLow even if the drone height is greater than the maximum distance the rangefinder can detect, this causes the drone height to be set to 0 and the landing gear to deploy and then retract and so on infinitely. In the modified part, the value detected by the rangefinder when it goes out of the working range defined by the parameters RNGFND_MIN_CM and RNGFND_MAX_CM is ignored to take into account other values.