### PR TITLE
Fix CCACHE hits when toolchain is not under system directories

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -1104,6 +1104,14 @@ class chibios(Board):
             'AP_HAL_ChibiOS',
         ]
 
+        # get location of nano.specs and nosys.specs
+        cfg.msg("Toolchain Location", cfg.env.AR)
+        # location of nosys.specs relative to the toolchain
+        env.NOSYS_SPECS = os.path.dirname(cfg.env.AR[0]) + '/../arm-none-eabi/lib/nosys.specs'
+        cfg.msg("ARM GCC nosys.specs", env.NOSYS_SPECS)
+        env.NANO_SPECS = os.path.dirname(cfg.env.AR[0]) + '/../arm-none-eabi/lib/nano.specs'
+        cfg.msg("ARM GCC nano.specs", env.NANO_SPECS)
+
         # make board name available for USB IDs
         env.CHIBIOS_BOARD_NAME = 'HAL_BOARD_NAME="%s"' % self.name
         env.HAL_MAX_STACK_FRAME_SIZE = 'HAL_MAX_STACK_FRAME_SIZE=%d' % 1300 # set per Wframe-larger-than, ensure its same
@@ -1139,8 +1147,8 @@ class chibios(Board):
             '-fno-builtin-puts',
             '-mno-thumb-interwork',
             '-mthumb',
-            '--specs=nano.specs',
-            '--specs=nosys.specs',
+            '--specs=%s' % env.NANO_SPECS,
+            '--specs=%s' % env.NOSYS_SPECS,
             '-D__USE_CMSIS',
             '-Werror=deprecated-declarations',
             '-DNDEBUG=1'
@@ -1183,8 +1191,8 @@ class chibios(Board):
             '-nostartfiles',
             '-mno-thumb-interwork',
             '-mthumb',
-            '--specs=nano.specs',
-            '--specs=nosys.specs',
+            '--specs=%s' % env.NANO_SPECS,
+            '--specs=%s' % env.NOSYS_SPECS,
             '-L%s' % env.BUILDROOT,
             '-L%s' % cfg.srcnode.make_node('modules/ChibiOS/os/common/startup/ARMCMx/compilers/GCC/ld/').abspath(),
             '-L%s' % cfg.srcnode.make_node('libraries/AP_HAL_ChibiOS/hwdef/common/').abspath(),


### PR DESCRIPTION
Following error is shown when not including path:
```
[2024-10-16T11:03:34.106740 1906419] Detected input file: ../../libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
[2024-10-16T11:03:34.106803 1906419] Source file: ../../libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
[2024-10-16T11:03:34.106804 1906419] Dependency file: libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp.0.d
[2024-10-16T11:03:34.106805 1906419] Object file: libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp.0.o
[2024-10-16T11:03:34.108073 1906419] Trying direct lookup
[2024-10-16T11:03:34.108127 1906419] Failed to lstat nano.specs: No such file or directory
[2024-10-16T11:03:34.108128 1906419] While processing --specs=nano.specs: nano.specs is missing
[2024-10-16T11:03:34.108140 1906419] Failed; falling back to running the real compiler
```

I believe this happens when toolchain is not installed in system folders. In any case I believe we should specify the path to the specs, to avoid ccache doing false match with what it suspects are the specs being used vs what actually will be used. 