### PR TITLE
AP_HAL_ChibiOS: exclude chprintf from fastramfunc

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/common_extf.ld
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/common_extf.ld
@@ -105,8 +105,8 @@ SECTIONS
         . = ALIGN(4);
         __ram3_init_text__ = LOADADDR(.fastramfunc);
         __ram3_init__ = .;
-        /* ChibiOS won't boot unless these are excluded */
-        EXCLUDE_FILE (*vectors.o *crt0_v7m.o *crt1.o *board.o)
+        /* ChibiOS won't boot unless some of these are excluded */
+        EXCLUDE_FILE (*vectors.o *crt0_v7m.o *crt1.o *board.o *chprintf.o)
         /* performance critical sections of ChibiOS */
         *libch.a:ch*.*(.text*)
         *libch.a:nvic.*(.text*)

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/common_extf_h730.ld
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/common_extf_h730.ld
@@ -106,8 +106,8 @@ SECTIONS
         __ram3_init_text__ = LOADADDR(.fastramfunc);
         __ram3_init__ = .;
         /* performance critical sections of ChibiOS */
-        /* ChibiOS won't boot unless these are excluded */
-        EXCLUDE_FILE (*vectors.o *crt0_v7m.o *crt1.o) *libch.a:ch*.*(.text*)
+        /* ChibiOS won't boot unless some of these are excluded */
+        EXCLUDE_FILE (*vectors.o *crt0_v7m.o *crt1.o  *chprintf.o) *libch.a:ch*.*(.text*)
         *libch.a:nvic.*(.text*)
         *libch.a:bouncebuffer.*(.text*)
         *libch.a:stm32_util.*(.text*)

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/common_extf_h750.ld
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/common_extf_h750.ld
@@ -106,8 +106,8 @@ SECTIONS
         __ram3_init_text__ = LOADADDR(.fastramfunc);
         __ram3_init__ = .;
         /* performance critical sections of ChibiOS */
-        /* ChibiOS won't boot unless these are excluded */
-        EXCLUDE_FILE (*vectors.o *crt0_v7m.o *crt1.o) *libch.a:ch*.*(.text*)
+        /* ChibiOS won't boot unless some of these are excluded */
+        EXCLUDE_FILE (*vectors.o *crt0_v7m.o *crt1.o  *chprintf.o) *libch.a:ch*.*(.text*)
         *libch.a:nvic.*(.text*)
         *libch.a:bouncebuffer.*(.text*)
         *libch.a:stm32_util.*(.text*)


### PR DESCRIPTION
on H730 we are overflowing the ITCM area for SPRacingH7RF and other H750 boards are not far behind.

Step away from the edge by removing this function which should never be in a fast path

I've tested on H750 (`YJUAV_A6SE`) and it still boots.  I do not have SPRacingH7RF to test.
