### PR TITLE
AP_Math: move zeroing to header, use memset, reuse in identity

### DIFF
--- a/libraries/AP_Math/matrix3.cpp
+++ b/libraries/AP_Math/matrix3.cpp
@@ -227,14 +227,6 @@ bool Matrix3<T>::invert()
     return success;
 }
 
-template <typename T>
-void Matrix3<T>::zero(void)
-{
-    a.x = a.y = a.z = 0;
-    b.x = b.y = b.z = 0;
-    c.x = c.y = c.z = 0;
-}
-
 // create rotation matrix for rotation about the vector v by angle theta
 // See: http://www.euclideanspace.com/maths/geometry/rotations/conversions/angleToMatrix/
 template <typename T>

--- a/libraries/AP_Math/matrix3.h
+++ b/libraries/AP_Math/matrix3.h
@@ -219,14 +219,14 @@ public:
     bool invert() WARN_IF_UNUSED;
 
     // zero the matrix
-    void        zero(void);
+    void        zero(void) {
+        memset((void*)this, 0, sizeof(*this));
+    }
 
     // setup the identity matrix
     void        identity(void) {
+        zero();
         a.x = b.y = c.z = 1;
-        a.y = a.z = 0;
-        b.x = b.z = 0;
-        c.x = c.y = 0;
     }
 
     // check if any elements are NAN


### PR DESCRIPTION
this method is in ITCM memory on STM32 - which makes small optimisations worthwhile
```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                                                     
CubeRedPrimary                      -72    *           -72     -64               -72    -72    -64
Durandal                            -64    *           -64     -64               -64    -64    -64
Hitec-Airspeed           *                                                                     
KakuteH7-bdshot                     -64    *           -64     -64               -64    -64    -64
MatekF405                           -48    *           -40     -48               -40    -32    -40
Pixhawk1-1M-bdshot                  -40                -40     -48               -40    -40    -48
f103-QiotekPeriph        *                                                                     
f303-Universal           *                                                                     
iomcu                                                                *                         
revo-mini                           -40    *           -40     -40               -48    -40    -48
skyviper-v2450                                         -48                                     
```
