### PR TITLE
Fix git perms issue during docker copter build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ ARG SKIP_AP_COV_ENV=1
 ARG SKIP_AP_GIT_CHECK=1
 ARG DO_AP_STM_ENV=1
 
+RUN git config --global --add safe.directory $PWD
+
 RUN groupadd ${USER_NAME} --gid ${USER_GID}\
     && useradd -l -m ${USER_NAME} -u ${USER_UID} -g ${USER_GID} -s /bin/bash
 


### PR DESCRIPTION
I encountered the follow issue during the docker build:
```
ardupilot@35af3dd2b3ee:/ardupilot$ ./waf copter
Waf: Entering directory `/ardupilot/build/sitl'
Embedding file locations.txt:Tools/autotest/locations.txt
Embedding file models/Callisto.json:Tools/autotest/models/Callisto.json
Embedding file models/freestyle.json:Tools/autotest/models/freestyle.json
Embedding file models/plane-3d.parm:Tools/autotest/models/plane-3d.parm
Embedding file models/plane.parm:Tools/autotest/models/plane.parm
Embedding file models/xplane_heli.json:Tools/autotest/models/xplane_heli.json
Embedding file models/xplane_plane.json:Tools/autotest/models/xplane_plane.json
Command ['/usr/bin/git', 'rev-parse', '--short=8', 'HEAD'] returned 128
```

My system:
- OSX `15.0.1 (24A348)`
- Docker Desktop `4.33.0 (160616)`
- Fresh clone of ardupilot [145cc4b](https://github.com/ArduPilot/ardupilot/commit/145cc4bb260c56fb92632886a624bc06b56b0e4d)
