### PR TITLE
AP_Precland::added two backend

### DIFF
--- a/ArduCopter/precision_landing.cpp
+++ b/ArduCopter/precision_landing.cpp
@@ -13,8 +13,8 @@ void Copter::init_precland()
 
 void Copter::update_precland()
 {
-    // alt will be unused if we pass false through as the second parameter:
+    // alt will be unused if we pass false through as the second parameter: you can change backend type by sending 1 or 2 as per condition
     return precland.update(rangefinder_state.alt_cm_glitch_protected,
-                           rangefinder_alt_ok());
+                           rangefinder_alt_ok(), 1);
 }
 #endif

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -189,6 +189,12 @@ const AP_Param::GroupInfo AC_PrecLand::var_info[] = {
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO_FRAME("ORIENT", 18, AC_PrecLand, _orient, AC_PRECLAND_ORIENT_DEFAULT, AP_PARAM_FRAME_ROVER),
+    // @Param: TYPE2
+    // @DisplayName: Precision Land Type
+    // @Description: Precision Land Type
+    // @Values: 0:None, 1:CompanionComputer, 2:IRLock, 3:SITL_Gazebo, 4:SITL
+    // @User: Advanced
+    AP_GROUPINFO("TYPE2",    19, AC_PrecLand, _type2, 0),
 
     AP_GROUPEND
 };
@@ -210,6 +216,14 @@ AC_PrecLand::AC_PrecLand()
 void AC_PrecLand::init(uint16_t update_rate_hz)
 {
     // exit immediately if init has already been run
+    if (_backend1 != nullptr) {
+        return;
+    }
+
+    if (_backend2 != nullptr) {
+        return;
+    }
+
     if (_backend != nullptr) {
         return;
     }
@@ -219,6 +233,8 @@ void AC_PrecLand::init(uint16_t update_rate_hz)
 
     // default health to false
     _backend = nullptr;
+    _backend1 = nullptr;
+    _backend2 = nullptr;
     _backend_state.healthy = false;
 
     // create inertial history buffer
@@ -243,39 +259,90 @@ void AC_PrecLand::init(uint16_t update_rate_hz)
         // companion computer
 #if AC_PRECLAND_COMPANION_ENABLED
         case Type::COMPANION:
-            _backend = new AC_PrecLand_Companion(*this, _backend_state);
+            _backend1 = new AC_PrecLand_Companion(*this, _backend_state);
             break;
         // IR Lock
 #endif
 #if AC_PRECLAND_IRLOCK_ENABLED
         case Type::IRLOCK:
-            _backend = new AC_PrecLand_IRLock(*this, _backend_state);
+            _backend1 = new AC_PrecLand_IRLock(*this, _backend_state);
             break;
 #endif
 #if AC_PRECLAND_SITL_GAZEBO_ENABLED
         case Type::SITL_GAZEBO:
-            _backend = new AC_PrecLand_SITL_Gazebo(*this, _backend_state);
+            _backend1 = new AC_PrecLand_SITL_Gazebo(*this, _backend_state);
             break;
 #endif
 #if AC_PRECLAND_SITL_ENABLED
         case Type::SITL:
-            _backend = new AC_PrecLand_SITL(*this, _backend_state);
+            _backend1 = new AC_PrecLand_SITL(*this, _backend_state);
             break;
 #endif
     }
 
+    // check wether both backend type are not same 
+    if(_type.get() != _type2.get()) {
+
+        switch ((Type)(_type.get())) {
+            // no type defined
+            case Type::NONE:
+            default:
+                return;
+            // companion computer
+#if AC_PRECLAND_COMPANION_ENABLED
+            case Type::COMPANION:
+                _backend2 = new AC_PrecLand_Companion(*this, _backend_state);
+                break;
+            // IR Lock
+#endif
+#if AC_PRECLAND_IRLOCK_ENABLED
+            case Type::IRLOCK:
+                _backend2 = new AC_PrecLand_IRLock(*this, _backend_state);
+                break;
+#endif
+#if AC_PRECLAND_SITL_GAZEBO_ENABLED
+            case Type::SITL_GAZEBO:
+                _backend2 = new AC_PrecLand_SITL_Gazebo(*this, _backend_state);
+                break;
+#endif
+#if AC_PRECLAND_SITL_ENABLED
+            case Type::SITL:
+                _backend2 = new AC_PrecLand_SITL(*this, _backend_state);
+                break;
+#endif
+        }
+
+    }
+
     // init backend
-    if (_backend != nullptr) {
-        _backend->init();
+    if (_backend1 != nullptr) {
+        _backend1->init();
+    }
+
+    if (_backend2 != nullptr) {
+        _backend2->init();
     }
 
     _approach_vector_body.x = 1;
     _approach_vector_body.rotate(_orient);
 }
 
-// update - give chance to driver to get updates from sensor
-void AC_PrecLand::update(float rangefinder_alt_cm, bool rangefinder_alt_valid)
+// update - give chance to driver to get updates from sensor, also added option to select multiple backend
+void AC_PrecLand::update(float rangefinder_alt_cm, bool rangefinder_alt_valid, uint8_t backend_number)
 {
+    // select appropriate backend
+    switch (backend_number)
+    {
+        case 1:
+        default:
+            _backend = _backend1;
+            break;
+
+        case 2:
+            _backend = _backend2;
+            break;
+    }
+
     // exit immediately if not enabled
     if (_backend == nullptr || _inertial_history == nullptr) {
         return;

--- a/libraries/AC_PrecLand/AC_PrecLand.h
+++ b/libraries/AC_PrecLand/AC_PrecLand.h
@@ -64,8 +64,8 @@ public:
     // returns ekf outlier count
     uint32_t ekf_outlier_count() const { return _outlier_reject_count; }
 
-    // give chance to driver to get updates from sensor, should be called at 400hz
-    void update(float rangefinder_alt_cm, bool rangefinder_alt_valid);
+    // give chance to driver to get updates from sensor, should be called at 400hz, also added option to select multiple backend
+    void update(float rangefinder_alt_cm, bool rangefinder_alt_valid, uint8_t backend_number);
 
     // returns target position relative to the EKF origin
     bool get_target_position_cm(Vector2f& ret);
@@ -190,6 +190,7 @@ private:
     // parameters
     AP_Int8                     _enabled;           // enabled/disabled
     AP_Enum<Type>               _type;              // precision landing sensor type
+    AP_Enum<Type>               _type2;              // precision landing sensor type2
     AP_Int8                     _bus;               // which sensor bus
     AP_Enum<EstimatorType>      _estimator_type;    // precision landing estimator type
     AP_Float                    _lag;               // sensor lag in seconds
@@ -248,6 +249,8 @@ private:
     struct precland_state {
         bool    healthy;
     } _backend_state;
+    AC_PrecLand_Backend         *_backend1;  // pointers to backend precision landing driver1
+    AC_PrecLand_Backend         *_backend2;  // pointers to backend precision landing driver2
     AC_PrecLand_Backend         *_backend;  // pointers to backend precision landing driver
 
     // write out PREC message to log:


### PR DESCRIPTION
Hey everyone,
I have experimentally found that IR_Lock is helpful in low altitude and vision based precland works fine for higher altitude but as it reaches close to aruco-marker, it lost as it goes out of FOV of camera. Hence tried both backend and found good results hence putting PR here.

I have made option to have two backend type running as per choice [condition].