### PR TITLE
Fully expose DDS in build_options.py

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -40,6 +40,7 @@ COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'AP_Declination',
     'AP_GPS',
     'AP_GSOF',
+    # 'AP_DDS',
     'AP_HAL',
     'AP_HAL_Empty',
     'AP_InertialSensor',
@@ -147,7 +148,7 @@ def get_legacy_defines(sketch_name, bld):
 IGNORED_AP_LIBRARIES = [
     'doc',
     'AP_Scripting', # this gets explicitly included when it is needed and should otherwise never be globbed in
-    'AP_DDS',
+    # 'AP_DDS',
 ]
 
 
@@ -249,6 +250,7 @@ def ap_get_all_libraries(bld):
         libraries.append(name)
     libraries.extend(['AP_HAL', 'AP_HAL_Empty'])
     libraries.append('AP_PiccoloCAN/piccolo_protocol')
+    # print("LIBS:", libraries)
     return libraries
 
 @conf
@@ -258,6 +260,7 @@ def ap_common_vehicle_libraries(bld):
     if bld.env.with_can or bld.env.HAL_NUM_CAN_IFACES:
         libraries.extend(COMMON_VEHICLE_DEPENDENT_CAN_LIBRARIES)
 
+    # raise Exception("FOO")
     return libraries
 
 _grouped_programs = {}

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -84,18 +84,20 @@ class Board:
             env.CXXFLAGS += ['-DHAL_GCS_ENABLED=0']
 
         # configurations for XRCE-DDS
-        if cfg.options.enable_dds:
-            cfg.recurse('libraries/AP_DDS')
-            env.ENABLE_DDS = True
-            env.AP_LIBRARIES += [
-                'AP_DDS'
-            ]
-            env.DEFINES.update(AP_DDS_ENABLED = 1)
-            # check for microxrceddsgen
-            cfg.find_program('microxrceddsgen',mandatory=True)
-        else:
-            env.ENABLE_DDS = False
-            env.DEFINES.update(AP_DDS_ENABLED = 0)
+        # if cfg.options.enable_DDS:
+        #     cfg.msg("Enabled DDS???", 'yes')
+        #     pass
+        #     cfg.recurse('libraries/AP_DDS')
+        #     env.ENABLE_DDS = True
+        #     env.AP_LIBRARIES += [
+        #         'AP_DDS'
+        #     ]
+        #     env.DEFINES.update(AP_DDS_ENABLED = 1)
+        #     # check for microxrceddsgen
+        #     cfg.find_program('microxrceddsgen',mandatory=True)
+        # else:
+        #     env.ENABLE_DDS = False
+        #     env.DEFINES.update(AP_DDS_ENABLED = 0)
 
         # setup for supporting onvif cam control
         if cfg.options.enable_onvif:

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -409,7 +409,7 @@ def do_build(opts, frame_options):
         cmd_configure.append("--define=%s" % nv)
 
     if opts.enable_dds:
-        cmd_configure.append("--enable-dds")
+        cmd_configure.append("--enable-DDS")
 
     if opts.disable_networking:
         cmd_configure.append("--disable-networking")

--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -430,6 +430,9 @@ BUILD_OPTIONS = [
     Feature('Networking', 'CAN MCAST', 'AP_NETWORKING_CAN_MCAST_ENABLED', 'Enable CAN multicast bridge', 0, None),
 
     Feature('DroneCAN', 'DroneCAN', 'HAL_ENABLE_DRONECAN_DRIVERS', 'Enable DroneCAN support', 0, None),
+
+    Feature('DDS', 'DDS', 'AP_DDS_ENABLED', 'Enable DDS support', 0, None),
+
 ]
 
 BUILD_OPTIONS.sort(key=lambda x: (x.category + x.label))

--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -281,6 +281,8 @@ class ExtractFeatures(object):
 
             ('AP_PLANE_OFFBOARD_GUIDED_SLEW_ENABLED', r'GCS_MAVLINK_Plane::handle_command_int_guided_slew_commands'),
             ('AP_SERIALMANAGER_REGISTER_ENABLED', r'AP_SerialManager::register_port'),
+            ('AP_DDS_ENABLED', r'AP_DDS_Client::start'),
+
         ]
 
     def progress(self, msg):

--- a/libraries/AP_DDS/gen_config_h.py
+++ b/libraries/AP_DDS/gen_config_h.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 '''
- process a *.h.in file to produce a *.h file
+ process config.h.in file to produce a <uxr/client/config.h> file
 '''
 
 # TODO move to AP_DDS_Client/tools

--- a/libraries/AP_DDS/wscript
+++ b/libraries/AP_DDS/wscript
@@ -5,6 +5,13 @@ import pathlib
 
 
 def configure(cfg):
+    if not cfg.options.enable_DDS:
+        print("CONFIGURE: DDS IS DISABLED")
+        return
+    
+    # check for microxrceddsgen
+    cfg.find_program('microxrceddsgen', mandatory=True)
+
     extra_src = [
         'modules/Micro-XRCE-DDS-Client/src/c/core/session/stream/*.c',
         'modules/Micro-XRCE-DDS-Client/src/c/core/session/*.c',
@@ -38,6 +45,9 @@ def configure(cfg):
 
 
 def build(bld):
+    print(f"DDS -  BUILD enable_DDS {bld.env.OPTIONS['enable_DDS']}")
+    if not bld.env.OPTIONS["enable_DDS"]:
+        return
     config_h_in = [
         'modules/Micro-XRCE-DDS-Client/include/uxr/client/config.h.in',
         'modules/Micro-CDR/include/ucdr/config.h.in',
@@ -55,9 +65,9 @@ def build(bld):
         bld.env.INCLUDES += [bld.bldnode.find_or_declare(inc).abspath()]
 
     for i in range(len(config_h_nodes)):
-        print(f"building {config_h_nodes[i].abspath()}")
+        print(f"Building {config_h_nodes[i].abspath()}")
         bld(
-            # build config.h file
+            # Generate config.h file
             source=config_h_in_nodes[i],
             target=config_h_nodes[i],
             rule="%s %s/%s %s %s"

--- a/wscript
+++ b/wscript
@@ -291,8 +291,8 @@ submodules at specific revisions.
                  default=False,
                  help="Enables GPS logging")
     
-    g.add_option('--enable-dds', action='store_true',
-                 help="Enable the dds client to connect with ROS2/DDS.")
+    # g.add_option('--enable-dds', action='store_true',
+    #              help="Enable the dds client to connect with ROS2/DDS.")
 
     g.add_option('--disable-networking', action='store_true',
                  help="Disable the networking API code")
@@ -586,6 +586,7 @@ def configure(cfg):
     cfg.recurse('libraries/SITL')
 
     cfg.recurse('libraries/AP_Networking')
+    cfg.recurse('libraries/AP_DDS')
 
     cfg.start_msg('Scripting runtime checks')
     if cfg.options.scripting_checks:
@@ -758,8 +759,8 @@ def _build_dynamic_sources(bld):
             ]
         )
 
-    if bld.env.ENABLE_DDS:
-        bld.recurse("libraries/AP_DDS")
+    # if bld.env.ENABLE_DDS:
+    #     bld.recurse("libraries/AP_DDS")
 
     def write_version_header(tsk):
         bld = tsk.generator.bld
@@ -832,6 +833,7 @@ def _build_recursion(bld):
             dirs_to_recurse.append('Tools/AP_Periph')
 
     dirs_to_recurse.append('libraries/AP_Scripting')
+    dirs_to_recurse.append('libraries/AP_DDS')
 
     if bld.env.ENABLE_ONVIF:
         dirs_to_recurse.append('libraries/AP_ONVIF')
@@ -848,6 +850,7 @@ def _build_recursion(bld):
     dirs_to_recurse.sort()
 
     for d in dirs_to_recurse:
+        print(f"Recursing in {d}")
         bld.recurse(d)
 
 def _build_post_funs(bld):


### PR DESCRIPTION
# Purpose

Expose DDS enabling in build_options.py such that we can let our users enable it on the custom build server.

# Current Status

You can enable and disable DDS, but there is a linker failure - AP_DDS_Client.cpp does not seem to be compiled.

```bash
./waf configure --board sitl --enable-DDS
nice ./waf plane
```

```
[1372/1373] Linking build/sitl/bin/arduplane
/usr/bin/ld: lib/libArduPlane_libs.a(AP_Vehicle.cpp.4.o): in function `AP_Vehicle::setup()':
AP_Vehicle.cpp:(.text._ZN10AP_Vehicle5setupEv+0x44a): undefined reference to `AP_DDS_Client::start()'
/usr/bin/ld: lib/libArduPlane_libs.a(AP_Vehicle.cpp.4.o):(.data.rel.ro._ZN10AP_Vehicle8var_infoE+0x230): undefined reference to `AP_DDS_Client::var_info'
collect2: error: ld returned 1 exit status
```

# Issue

Relates to #23280
Relates to #28159