### PR TITLE
AP_DDS: Set GPS instance ID in the GPS frame ID

### DIFF
--- a/Tools/ros2/README.md
+++ b/Tools/ros2/README.md
@@ -29,7 +29,7 @@ To see all current options, use the `-s` argument:
 ros2 launch ardupilot_sitl sitl.launch.py -s
 ```
 
-#### `ardupilot_dds_test`
+#### `ardupilot_dds_tests`
 
 A `colcon` package for testing communication between `micro_ros_agent` and the
 ArduPilot `AP_DDS` client library.

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_navsat_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_navsat_msg_received.py
@@ -30,7 +30,7 @@ from rclpy.qos import QoSHistoryPolicy
 
 from sensor_msgs.msg import NavSatFix
 
-TOPIC = "ap/navsat/navsat0"
+TOPIC = "ap/navsat"
 
 
 class NavSatFixListener(rclpy.node.Node):

--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -190,7 +190,8 @@ bool AP_DDS_Client::update_topic(sensor_msgs_msg_NavSatFix& msg, const uint8_t i
 
 
     update_topic(msg.header.stamp);
-    strcpy(msg.header.frame_id, WGS_84_FRAME_ID);
+    static_assert(GPS_MAX_RECEIVERS <= 9, "GPS_MAX_RECEIVERS is greater than 9");
+    hal.util->snprintf(msg.header.frame_id, 2, "%u", instance);
     msg.status.service = 0; // SERVICE_GPS
     msg.status.status = -1; // STATUS_NO_FIX
 

--- a/libraries/AP_DDS/AP_DDS_Topic_Table.h
+++ b/libraries/AP_DDS/AP_DDS_Topic_Table.h
@@ -96,7 +96,7 @@ constexpr struct AP_DDS_Client::Topic_table AP_DDS_Client::topics[] = {
         .dw_id = uxrObjectId{.id=to_underlying(TopicIndex::NAV_SAT_FIX_PUB), .type=UXR_DATAWRITER_ID},
         .dr_id = uxrObjectId{.id=to_underlying(TopicIndex::NAV_SAT_FIX_PUB), .type=UXR_DATAREADER_ID},
         .topic_rw = Topic_rw::DataWriter,
-        .topic_name = "rt/ap/navsat/navsat0",
+        .topic_name = "rt/ap/navsat",
         .type_name = "sensor_msgs::msg::dds_::NavSatFix_",
         .qos = {
             .durability = UXR_DURABILITY_VOLATILE,

--- a/libraries/AP_DDS/README.md
+++ b/libraries/AP_DDS/README.md
@@ -178,7 +178,7 @@ Published topics:
  * /ap/geopose/filtered [geographic_msgs/msg/GeoPoseStamped] 1 publisher
  * /ap/gps_global_origin/filtered [geographic_msgs/msg/GeoPointStamped] 1 publisher
  * /ap/imu/experimental/data [sensor_msgs/msg/Imu] 1 publisher
- * /ap/navsat/navsat0 [sensor_msgs/msg/NavSatFix] 1 publisher
+ * /ap/navsat [sensor_msgs/msg/NavSatFix] 1 publisher
  * /ap/pose/filtered [geometry_msgs/msg/PoseStamped] 1 publisher
  * /ap/tf_static [tf2_msgs/msg/TFMessage] 1 publisher
  * /ap/time [builtin_interfaces/msg/Time] 1 publisher
@@ -354,7 +354,7 @@ The table below provides example mappings for topics and services
 | ROS 2 | DDS |
 | --- | --- |
 | ap/clock | rt/ap/clock |
-| ap/navsat/navsat0 | rt/ap/navsat/navsat0 |
+| ap/navsat | rt/ap/navsat |
 | ap/arm_motors | rq/ap/arm_motorsRequest, rr/ap/arm_motorsReply |
 
 Refer to existing mappings in [`AP_DDS_Topic_Table`](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_DDS/AP_DDS_Topic_Table.h)


### PR DESCRIPTION
# Purpose

Match battery behavior by setting the GPS instance number in the frame ID.

# Other changes

Remove the `0` from the topic. We are doing multiple GPS's on the same topic now.

# Demo

```bash
ros2 topic echo /ap/navsat --once
```
```yaml
header:
  stamp:
    sec: 1729471218
    nanosec: 41276000
  frame_id: '0'
status:
  status: 2
  service: 1
latitude: -35.36326217651367
longitude: 149.1652374267578
altitude: 584.0899658203125
position_covariance:
- 0.09000000357627869
- 0.0
- 0.0
- 0.0
- 0.09000000357627869
- 0.0
- 0.0
- 0.0
- 0.09000000357627869
position_covariance_type: 2
---
```

# Based on 

https://github.com/ArduPilot/ardupilot/pull/28291/files#diff-21a2f7a8c86c0d8903e0c8c3e48a7a8ae29fe5afa11878a8cd4b58224f31d94bR307

^ This does the same thing but allows two digits of instance number. I assume we will have less than 10 GPS's.

FYI @tizianofiorenzani 