### PR TITLE
Copter: Consolidate version number settings into a single definition

### DIFF
--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,15 +6,19 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.6.0-dev"
-
-// the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,6,0,FIRMWARE_VERSION_TYPE_DEV
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
 
 #define FW_MAJOR 4
 #define FW_MINOR 6
 #define FW_PATCH 0
+#define FW_TYPE_STR "-dev"
 #define FW_TYPE FIRMWARE_VERSION_TYPE_DEV
+
+#define THISFIRMWARE "ArduCopter V" TOSTRING(FW_MAJOR) "." TOSTRING(FW_MINOR) "." TOSTRING(FW_PATCH) FW_TYPE_STR
+
+// the following line is parsed by the autotest scripts
+#define FIRMWARE_VERSION FW_MAJOR,FW_MINOR,FW_PATCH,FW_TYPE
 
 #include <AP_Common/AP_FWVersionDefine.h>
 #include <AP_CheckFirmware/AP_CheckFirmwareDefine.h>


### PR DESCRIPTION
I want to stop writing the version number in three separate places. 
I will set the version number only in a definition.

TEXT MASSAGE
![Screenshot from 2024-10-23 02-08-54](https://github.com/user-attachments/assets/0791c662-755a-4abb-adf7-958a3dfb5315)


Binary(AUTOPILOT_VERSION)
![Screenshot from 2024-10-23 02-09-22](https://github.com/user-attachments/assets/a3e3c942-ebad-4847-bbb5-eeb7e41988bb)