### PR TITLE
AP_DDS: Rally Get and Set

### DIFF
--- a/Tools/ros2/ardupilot_msgs/CMakeLists.txt
+++ b/Tools/ros2/ardupilot_msgs/CMakeLists.txt
@@ -6,6 +6,7 @@ project(ardupilot_msgs)
 
 find_package(ament_cmake REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(geographic_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
@@ -14,9 +15,12 @@ find_package(rosidl_default_generators REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/GlobalPosition.msg"
+  "msg/Rally.msg"
   "srv/ArmMotors.srv"
   "srv/ModeSwitch.srv"
-  DEPENDENCIES geometry_msgs std_msgs
+  "srv/RallyGet.srv"
+  "srv/RallySet.srv"
+  DEPENDENCIES geometry_msgs std_msgs geographic_msgs
   ADD_LINTER_TESTS
 )
 

--- a/Tools/ros2/ardupilot_msgs/msg/Rally.msg
+++ b/Tools/ros2/ardupilot_msgs/msg/Rally.msg
@@ -1,0 +1,13 @@
+geographic_msgs/GeoPoint point
+float32 break_altitude # when autolanding, break out of loiter at this alt (meters)
+float32 land_dir # when the time comes to auto-land, try to land in this direction (degrees)
+
+# uint8_t flags; 
+# struct {
+#     uint8_t favorable_winds : 1; // bit 0 = seek favorable winds when choosing a landing poi
+#     uint8_t do_auto_land    : 1; // bit 1 = do auto land after arriving
+#     uint8_t alt_frame_valid : 1; // bit 2 = true if following alt frame value should be used, else Location::AltFrame::ABOVE_HOME
+#     uint8_t alt_frame       : 2; // Altitude frame following Location::AltFrame enum
+#     uint8_t unused          : 3;
+# };
+uint8 flags

--- a/Tools/ros2/ardupilot_msgs/srv/RallyGet.srv
+++ b/Tools/ros2/ardupilot_msgs/srv/RallyGet.srv
@@ -1,0 +1,10 @@
+
+# This service requests a Rally point from its ID.
+
+# Rally Point ID.
+uint8 index
+---
+# True is the retrieved point is valid.
+bool success
+# Rally point.
+ardupilot_msgs/Rally rally

--- a/Tools/ros2/ardupilot_msgs/srv/RallySet.srv
+++ b/Tools/ros2/ardupilot_msgs/srv/RallySet.srv
@@ -1,0 +1,13 @@
+
+# This service appends a Rally Point to the list or clears the whole list.
+
+# Rally Point.
+ardupilot_msgs/Rally rally
+
+# True to clear the whole list (rally entry is ignored).
+bool clear
+---
+# True if the action is successful.
+uint8 success
+# Size of Rally Points list.
+uint8 size

--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -15,9 +15,12 @@
 #include <AP_Arming/AP_Arming.h>
 #include <AP_Vehicle/AP_Vehicle.h>
 #include <AP_ExternalControl/AP_ExternalControl_config.h>
+#include <AP_Rally/AP_Rally.h>
 
 #include "ardupilot_msgs/srv/ArmMotors.h"
 #include "ardupilot_msgs/srv/ModeSwitch.h"
+#include "ardupilot_msgs/srv/RallyGet.h"
+#include "ardupilot_msgs/srv/RallySet.h"
 
 #if AP_EXTERNAL_CONTROL_ENABLED
 #include "AP_DDS_ExternalControl.h"
@@ -787,6 +790,107 @@ void AP_DDS_Client::on_request(uxrSession* uxr_session, uxrObjectId object_id, u
 
         uxr_buffer_reply(uxr_session, reliable_out, replier_id, sample_id, reply_buffer, ucdr_buffer_length(&reply_ub));
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s Request for Mode Switch : %s", msg_prefix, mode_switch_response.status ? "SUCCESS" : "FAIL");
+        break;
+    }
+    case services[to_underlying(ServiceIndex::GET_RALLY)].rep_id: {
+        ardupilot_msgs_srv_RallyGet_Request rally_get_request;
+        ardupilot_msgs_srv_RallyGet_Response rally_get_response;
+        const bool deserialize_success = ardupilot_msgs_srv_RallyGet_Request_deserialize_topic(ub, &rally_get_request);
+        if (deserialize_success == false) {
+            break;
+        }
+
+        const uxrObjectId replier_id = {
+            .id = services[to_underlying(ServiceIndex::GET_RALLY)].rep_id,
+            .type = UXR_REPLIER_ID
+        };
+
+        RallyLocation rally_location {};
+        const AP_Rally *rally = AP::rally();
+        if (rally->get_rally_point_with_index(rally_get_request.index, rally_location)) {
+            rally_get_response.success = true;
+            rally_get_response.rally.point.latitude = rally_location.lat * 1e-7;
+            rally_get_response.rally.point.longitude = rally_location.lng * 1e-7;
+            rally_get_response.rally.point.altitude = rally_location.alt;
+            rally_get_response.rally.break_altitude = rally_location.break_alt;
+            rally_get_response.rally.land_dir = rally_location.land_dir * 1e-2f;
+            rally_get_response.rally.flags = rally_location.flags;
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s Request Rally index %u is valid: lat: %f  lon: %f",
+                          msg_prefix, rally_get_request.index, rally_get_response.rally.point.latitude, rally_get_response.rally.point.longitude);
+        } else {
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s Request Rally index %u is invalid", msg_prefix, rally_get_request.index);
+            rally_get_response.success = false;
+        }
+
+        uint8_t reply_buffer[ardupilot_msgs_srv_RallyGet_Response_size_of_topic(&rally_get_response, 0)] {};
+        ucdrBuffer reply_ub;
+
+        ucdr_init_buffer(&reply_ub, reply_buffer, sizeof(reply_buffer));
+        const bool serialize_success = ardupilot_msgs_srv_RallyGet_Response_serialize_topic(&reply_ub, &rally_get_response);
+        if (serialize_success == false) {
+            break;
+        }
+
+        uxr_buffer_reply(uxr_session, reliable_out, replier_id, sample_id, reply_buffer, ucdr_buffer_length(&reply_ub));
+
+        break;
+    }
+    case services[to_underlying(ServiceIndex::SET_RALLY)].rep_id: {
+
+        ardupilot_msgs_srv_RallySet_Request rally_set_request;
+        ardupilot_msgs_srv_RallySet_Response rally_set_response;
+        const bool deserialize_success = ardupilot_msgs_srv_RallySet_Request_deserialize_topic(ub, &rally_set_request);
+        if (deserialize_success == false) {
+            break;
+        }
+
+        const uxrObjectId replier_id = {
+            .id = services[to_underlying(ServiceIndex::SET_RALLY)].rep_id,
+            .type = UXR_REPLIER_ID
+        };
+
+        RallyLocation rally_location{};
+        AP_Rally *rally = AP::rally();
+
+        if (rally_set_request.clear) {
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s Clear Rally List", msg_prefix);
+            rally->truncate(0);
+            rally_set_response.success = rally->get_rally_total() == 0;
+        } else {
+            rally_location.lat = static_cast<int32_t>(rally_set_request.rally.point.latitude * 1e7);
+            rally_location.lng = static_cast<int32_t>(rally_set_request.rally.point.longitude * 1e7);
+            rally_location.alt = static_cast<int16_t>(rally_set_request.rally.point.altitude);
+            rally_location.break_alt = static_cast<int16_t>(rally_set_request.rally.break_altitude);
+            rally_location.land_dir = static_cast<int16_t>(rally_set_request.rally.land_dir);
+            rally_location.flags = rally_set_request.rally.flags;
+
+            if (rally_location.lat != 0 && rally_location.lng != 0) {
+                if (rally->append(rally_location)) {
+                    rally_set_response.success = true;
+                    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s Rally Point appended", msg_prefix);
+                } else {
+                    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s Failed to append Rally Point", msg_prefix);
+                    rally_set_response.success = false;
+                }
+            } else {
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s Invalid Rally requested", msg_prefix);
+                rally_set_response.success = false;
+            }
+        }
+
+        rally_set_response.size = rally->get_rally_total();
+
+        uint8_t reply_buffer[ardupilot_msgs_srv_RallySet_Response_size_of_topic(&rally_set_response, 0)] {};
+        ucdrBuffer reply_ub;
+
+        ucdr_init_buffer(&reply_ub, reply_buffer, sizeof(reply_buffer));
+        const bool serialize_success = ardupilot_msgs_srv_RallySet_Response_serialize_topic(&reply_ub, &rally_set_response);
+        if (serialize_success == false) {
+            break;
+        }
+
+        uxr_buffer_reply(uxr_session, reliable_out, replier_id, sample_id, reply_buffer, ucdr_buffer_length(&reply_ub));
+
         break;
     }
     }

--- a/libraries/AP_DDS/AP_DDS_Service_Table.h
+++ b/libraries/AP_DDS/AP_DDS_Service_Table.h
@@ -2,7 +2,9 @@
 
 enum class ServiceIndex: uint8_t {
     ARMING_MOTORS,
-    MODE_SWITCH
+    MODE_SWITCH,
+    GET_RALLY,
+    SET_RALLY
 };
 
 static inline constexpr uint8_t to_underlying(const ServiceIndex index)
@@ -37,5 +39,25 @@ constexpr struct AP_DDS_Client::Service_table AP_DDS_Client::services[] = {
         .reply_type = "ardupilot_msgs::srv::dds_::ModeSwitch_Response_",
         .request_topic_name = "rq/ap/mode_switchRequest",
         .reply_topic_name = "rr/ap/mode_switchReply",
+    },
+    {
+        .req_id = to_underlying(ServiceIndex::GET_RALLY),
+        .rep_id = to_underlying(ServiceIndex::GET_RALLY),
+        .service_rr = Service_rr::Replier,
+        .service_name = "rs/ap/rally_getService",
+        .request_type = "ardupilot_msgs::srv::dds_::RallyGet_Request_",
+        .reply_type = "ardupilot_msgs::srv::dds_::RallyGet_Response_",
+        .request_topic_name = "rq/ap/rally_getRequest",
+        .reply_topic_name = "rr/ap/rally_getReply",
+    },
+    {
+        .req_id = to_underlying(ServiceIndex::SET_RALLY),
+        .rep_id = to_underlying(ServiceIndex::SET_RALLY),
+        .service_rr = Service_rr::Replier,
+        .service_name = "rs/ap/rally_setService",
+        .request_type = "ardupilot_msgs::srv::dds_::RallySet_Request_",
+        .reply_type = "ardupilot_msgs::srv::dds_::RallySet_Response_",
+        .request_topic_name = "rq/ap/rally_setRequest",
+        .reply_topic_name = "rr/ap/rally_setReply",
     },
 };

--- a/libraries/AP_DDS/Idl/ardupilot_msgs/msg/Rally.idl
+++ b/libraries/AP_DDS/Idl/ardupilot_msgs/msg/Rally.idl
@@ -1,0 +1,32 @@
+// generated from rosidl_adapter/resource/msg.idl.em
+// with input from ardupilot_msgs/msg/Rally.msg
+// generated code does not contain a copyright notice
+
+#include "geographic_msgs/msg/GeoPoint.idl"
+
+module ardupilot_msgs {
+  module msg {
+    struct Rally {
+      geographic_msgs::msg::GeoPoint point;
+
+      @verbatim (language="comment", text=
+        "when autolanding, break out of loiter at this alt (meters)")
+      float break_altitude;
+
+      @verbatim (language="comment", text=
+        "when the time comes to auto-land, try to land in this direction (degrees)")
+      float land_dir;
+
+      @verbatim (language="comment", text=
+        "uint8_t flags;" "\n"
+        "struct {" "\n"
+        "    uint8_t favorable_winds : 1; // bit 0 = seek favorable winds when choosing a landing poi" "\n"
+        "    uint8_t do_auto_land    : 1; // bit 1 = do auto land after arriving" "\n"
+        "    uint8_t alt_frame_valid : 1; // bit 2 = true if following alt frame value should be used, else Location::AltFrame::ABOVE_HOME" "\n"
+        "    uint8_t alt_frame       : 2; // Altitude frame following Location::AltFrame enum" "\n"
+        "    uint8_t unused          : 3;" "\n"
+        "};")
+      uint8 flags;
+    };
+  };
+};

--- a/libraries/AP_DDS/Idl/ardupilot_msgs/srv/RallyGet.idl
+++ b/libraries/AP_DDS/Idl/ardupilot_msgs/srv/RallyGet.idl
@@ -1,0 +1,25 @@
+// generated from rosidl_adapter/resource/srv.idl.em
+// with input from ardupilot_msgs/srv/RallyGet.srv
+// generated code does not contain a copyright notice
+
+#include "ardupilot_msgs/msg/Rally.idl"
+
+module ardupilot_msgs {
+  module srv {
+    struct RallyGet_Request {
+      @verbatim (language="comment", text=
+        "This service requests a Rally point from its ID." "\n"
+        "Rally Point ID.")
+      uint8 index;
+    };
+    @verbatim (language="comment", text=
+      "True is the retrieved point is valid.")
+    struct RallyGet_Response {
+      boolean success;
+
+      @verbatim (language="comment", text=
+        "Rally point.")
+      ardupilot_msgs::msg::Rally rally;
+    };
+  };
+};

--- a/libraries/AP_DDS/Idl/ardupilot_msgs/srv/RallySet.idl
+++ b/libraries/AP_DDS/Idl/ardupilot_msgs/srv/RallySet.idl
@@ -1,0 +1,29 @@
+// generated from rosidl_adapter/resource/srv.idl.em
+// with input from ardupilot_msgs/srv/RallySet.srv
+// generated code does not contain a copyright notice
+
+#include "ardupilot_msgs/msg/Rally.idl"
+
+module ardupilot_msgs {
+  module srv {
+    struct RallySet_Request {
+      @verbatim (language="comment", text=
+        "This service appends a Rally Point to the list or clears the whole list." "\n"
+        "Rally Point.")
+      ardupilot_msgs::msg::Rally rally;
+
+      @verbatim (language="comment", text=
+        "True to clear the whole list (rally entry is ignored).")
+      boolean clear;
+    };
+    @verbatim (language="comment", text=
+      "True if the action is successful.")
+    struct RallySet_Response {
+      uint8 success;
+
+      @verbatim (language="comment", text=
+        "Size of Rally Points list.")
+      uint8 size;
+    };
+  };
+};

--- a/libraries/AP_DDS/README.md
+++ b/libraries/AP_DDS/README.md
@@ -209,6 +209,8 @@ nanosec: 729410000
 $ ros2 service list
 /ap/arm_motors
 /ap/mode_switch
+/ap/rally_get
+/ap/rally_set
 ---
 ```
 
@@ -234,6 +236,8 @@ List the available services:
 $ ros2 service list -t
 /ap/arm_motors [ardupilot_msgs/srv/ArmMotors]
 /ap/mode_switch [ardupilot_msgs/srv/ModeSwitch]
+/ap/rally_get [ardupilot_msgs/srv/RallyGet]
+/ap/rally_set [ardupilot_msgs/srv/RallySet]
 ```
 
 Call the arm motors service:
@@ -255,6 +259,37 @@ requester: making request: ardupilot_msgs.srv.ModeSwitch_Request(mode=4)
 response:
 ardupilot_msgs.srv.ModeSwitch_Response(status=True, curr_mode=4)
 ```
+
+Append a Rally Point:
+
+```bash
+ros2 service call /ap/rally_set ardupilot_msgs/srv/RallySet "{rally: {point: {latitude: -35, longitude: 151, altitude: 400}}}"
+requester: making request: ardupilot_msgs.srv.RallySet_Request(rally=ardupilot_msgs.msg.Rally(point=geographic_msgs.msg.GeoPoint(latitude=-35.0, longitude=151.0, altitude=400.0), break_altitude=0.0, land_dir=0.0, flags=0), clear=False)
+
+response:
+ardupilot_msgs.srv.RallySet_Response(success=1, size=2)
+```
+
+Clear the Rally Points list:
+
+```bash
+ros2 service call /ap/rally_set ardupilot_msgs/srv/RallySet "{clear: true}"
+requester: making request: ardupilot_msgs.srv.RallySet_Request(rally=ardupilot_msgs.msg.Rally(point=geographic_msgs.msg.GeoPoint(latitude=-35.0, longitude=150.0, altitude=400.0), break_altitude=0.0, land_dir=0.0, flags=0), clear=True)
+
+response:
+ardupilot_msgs.srv.RallySet_Response(success=1, size=0)
+```
+
+Get a specific Rally Point:
+
+```bash
+ros2 service call /ap/rally_get ardupilot_msgs/srv/RallyGet "index: 0"
+requester: making request: ardupilot_msgs.srv.RallyGet_Request(index=0)
+
+response:
+ardupilot_msgs.srv.RallyGet_Response(success=True, rally=ardupilot_msgs.msg.Rally(point=geographic_msgs.msg.GeoPoint(latitude=-35.0, longitude=150.0, altitude=400.0), break_altitude=0.0, land_dir=0.0, flags=0))
+```
+
 
 ## Commanding using ROS 2 Topics
 


### PR DESCRIPTION
# Issue

https://github.com/ArduPilot/ardupilot/issues/28444

# What Changed

- Service `/ap/rally_set` appends a Rally Point to the list or clears the list (using the `clear` flag). Replies with:
  - `success` is the action is successfull;
  - `size` is the list's size.  
- Service `/ap/rally_get` gets the Rally Point at a given index. Returns:
  - `success`
  - `rally` the rally point as `ardupilot_msgs/Rally` type.
 - New `ardupilot_msgs/Rally` type is defined, that copies the structure definition in `AP_Rally`.

# Test
I plan to add a automatic test: For now it can be tested with SITL.

- run the SITL
- Call the service to clear the rally list `ros2 service call /ap/rally_set ardupilot_msgs/srv/RallySet "{clear: true}"`
- Open up Mavproxy with map and make sure the rally list is clear.
- Append a new Rally Point: `ros2 service call /ap/rally_set ardupilot_msgs/srv/RallySet "{rally: {point: {latitude: -35.36, longitude: 149.17, altitude: 400}}}"`
- In mavproxy, update the rally list and make sure the rally point appears on the map

![image](https://github.com/user-attachments/assets/f35937f6-0eb7-4e0e-a26e-8055f74a5360)

- use the service call to get the Rally at index 0: `ros2 service call /ap/rally_get ardupilot_msgs/srv/RallyGet "index: 0"`
