### PR TITLE
ArduPlane: clean up guided heading type initialization

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -980,16 +980,15 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_command_int_guided_slew_commands(const mavl
         // normal vehicle heading
         } else if (int(packet.param1) == HEADING_TYPE_HEADING) { // compare as nearest int
             plane.guided_state.target_heading_type = GUIDED_HEADING_HEADING;
+            plane.g2.guidedHeading.reset_I();
+            plane.guided_state.target_heading = new_target_heading;
+            plane.guided_state.target_heading_accel_limit = MAX(packet.param3, 0.05f);
         } else {
             //  MAV_RESULT_DENIED  means Command is invalid (is supported but has invalid parameters).
             return MAV_RESULT_DENIED;
         }
-
-        plane.g2.guidedHeading.reset_I();
-
-        plane.guided_state.target_heading = new_target_heading;
-        plane.guided_state.target_heading_accel_limit = MAX(packet.param3, 0.05f);
         plane.guided_state.target_heading_time_ms = AP_HAL::millis();
+
         return MAV_RESULT_ACCEPTED;
     }
   }


### PR DESCRIPTION
CMD_GUIDED_CHANGE_HEADING was initializing heading values even if not using HEADING_TYPE_HEADING.
