### PR TITLE
waf: Fail if custom hwdef file doesn't exist

### DIFF
--- a/wscript
+++ b/wscript
@@ -506,6 +506,9 @@ def configure(cfg):
     cfg.env.ENABLE_STATS = cfg.options.enable_stats
     cfg.env.SAVE_TEMPS = cfg.options.save_temps
 
+    extra_hwdef = cfg.options.extra_hwdef
+    if extra_hwdef is not None and not os.path.exists(extra_hwdef):
+        raise FileNotFoundError(f"extra-hwdef file NOT found: '{cfg.options.extra_hwdef}'")
     cfg.env.HWDEF_EXTRA = cfg.options.extra_hwdef
     if cfg.env.HWDEF_EXTRA:
         cfg.env.HWDEF_EXTRA = os.path.abspath(cfg.env.HWDEF_EXTRA)


### PR DESCRIPTION
# Before 

```
$ ./waf configure --extra-hwdef=foo.dat
Setting top to                           : /home/ryan/Dev/ardupilot_ws/src/ardupilot 
Setting out to                           : /home/ryan/Dev/ardupilot_ws/src/ardupilot/build 
Autoconfiguration                        : enabled 
Checking for program 'python'            : /usr/bin/python3 
Checking for python version >= 3.6.9     : 3.10.12 
Setting board to                         : sitl 
Using toolchain                          : native 
Checking for 'g++' (C++ compiler)        : /usr/lib/ccache/g++ 
Checking for 'gcc' (C compiler)          : /usr/lib/ccache/gcc 
Checking for c flags '-MMD'              : yes 
Checking for cxx flags '-MMD'            : yes 
CXX Compiler                             : g++ 11.4.0 
Checking for need to link with librt     : not necessary 
Checking for feenableexcept              : yes 
Enabling -Werror                         : yes 
Enabled OpenDroneID                      : no 
Enabled firmware ID checking             : no 
GPS Debug Logging                        : no 
Enabled custom controller                : yes 
Checking for HAVE_CMATH_ISFINITE         : yes 
Checking for HAVE_CMATH_ISINF            : yes 
Checking for HAVE_CMATH_ISNAN            : yes 
Checking for NEED_CMATH_ISFINITE_STD_NAMESPACE : yes 
Checking for NEED_CMATH_ISINF_STD_NAMESPACE    : yes 
Checking for NEED_CMATH_ISNAN_STD_NAMESPACE    : yes 
Checking for header endian.h                   : yes 
Checking for header byteswap.h                 : yes 
Checking for HAVE_MEMRCHR                      : yes 
Configured VSCode Intellisense:                : no 
DC_DSDL compiler in                            : /home/ryan/Dev/ardupilot_ws/src/ardupilot/modules/DroneCAN/dronecan_dsdlc 
Source is git repository                       : yes 
Update submodules                              : yes 
Checking for program 'git'                     : /usr/bin/git 
Checking for program 'size'                    : /usr/bin/size 
Benchmarks                                     : disabled 
Unit tests                                     : enabled 
Scripting                                      : maybe 
Scripting runtime checks                       : enabled 
Debug build                                    : disabled 
Coverage build                                 : disabled 
Force 32-bit build                             : disabled 
Checking for program 'rsync'                   : /usr/bin/rsync 
Removing target_list file /home/ryan/Dev/ardupilot_ws/src/ardupilot/build/sitl/target_list
'configure' finished successfully (1.438s)
```
# After
```
$ ./waf configure --extra-hwdef=foo.dat
Setting top to                           : /home/ryan/Dev/ardupilot_ws/src/ardupilot 
Setting out to                           : /home/ryan/Dev/ardupilot_ws/src/ardupilot/build 
Traceback (most recent call last):
  File "/home/ryan/Dev/ardupilot_ws/src/ardupilot/modules/waf/waflib/Scripting.py", line 159, in waf_entry_point
    run_commands()
  File "/home/ryan/Dev/ardupilot_ws/src/ardupilot/modules/waf/waflib/Scripting.py", line 255, in run_commands
    ctx = run_command(cmd_name)
  File "/home/ryan/Dev/ardupilot_ws/src/ardupilot/modules/waf/waflib/Scripting.py", line 239, in run_command
    ctx.execute()
  File "/home/ryan/Dev/ardupilot_ws/src/ardupilot/modules/waf/waflib/Configure.py", line 159, in execute
    super(ConfigurationContext, self).execute()
  File "/home/ryan/Dev/ardupilot_ws/src/ardupilot/modules/waf/waflib/Context.py", line 214, in execute
    self.recurse([os.path.dirname(g_module.root_path)])
  File "/home/ryan/Dev/ardupilot_ws/src/ardupilot/modules/waf/waflib/Context.py", line 296, in recurse
    user_function(self)
  File "/home/ryan/Dev/ardupilot_ws/src/ardupilot/wscript", line 511, in configure
    raise FileNotFoundError(f"extra-hwdef file NOT found: '{cfg.options.extra_hwdef}'")
FileNotFoundError: extra-hwdef file NOT found: 'foo.dat'
````