### PR TITLE
AP_HAL_Linux: Enforce line buffering

### DIFF
--- a/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
+++ b/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
@@ -340,6 +340,10 @@ void HAL_Linux::run(int argc, char* const argv[], Callbacks* callbacks) const
         CMDLINE_SERIAL9,
     };
 
+    // set explicit line buffering for e.g. logging via systemd
+    setvbuf(stdout, (char *)0, _IOLBF, 0);
+    setvbuf(stderr, (char *)0, _IOLBF, 0);
+
     int opt;
     const struct GetOptLong::option options[] = {
         {"uartA",         true,  0, 'A'},


### PR DESCRIPTION
Helpful when run via systemd or other tool that captures stdout for logging purpose
Similar code already exists in SITL