### PR TITLE
AP_ICEngine: If surfaces are disabled do not allow a disarmed start

### DIFF
--- a/libraries/AP_ICEngine/AP_ICEngine.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine.cpp
@@ -357,7 +357,8 @@ void AP_ICEngine::update(void)
             allow_single_start_while_disarmed = false;
         } else {
             // check if we are blocking disarmed starts
-            if (!allow_single_start_while_disarmed) {
+            if ((hal.util->safety_switch_state() == AP_HAL::Util::SAFETY_DISARMED) ||
+                !allow_single_start_while_disarmed) {
                 should_run = false;
             }
         }


### PR DESCRIPTION
We don't want to allow AP_ICEngine to start an engine while disarmed if the surfaces are locked, as in this case we should have little to no control over the engine. This is particularly evident when using relay control for starter/ignition control, as it's now easy to enable both of these without having active throttle control.

Bench tested with relay outputs from AP_ICE, with a relay control for ignition power, and a scope connected to the throttle signal.