### PR TITLE
AP_Airspeed: Refuse to calibrate sensors if a device was not initialized

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -526,7 +526,8 @@ void AP_Airspeed::calibrate(bool in_startup)
             continue;
         }
         if (sensor[i] == nullptr) {
-            GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Airspeed %u not initalized, cannot cal", i+1);
+            GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Airspeed %u not initialized, cannot calibrate", i+1);
+            calibration_state[i] = CalibrationState::FAILED;
             continue;
         }
         state[i].cal.start_ms = AP_HAL::millis();


### PR DESCRIPTION
This helps catch the case where a GCS commands a calibration, and the command is reported as MAV_RESULT_ACCEPTED, even though the actual state is that at least one sensor backend failed. We are still letting the other sensors be calibrated in this situation as a GCS may not be paying proper attention to what happens with the MAV_RESULT and a user could miss the status text, so it's safer to calibrate everything we can, and then report a failure afterwards.

This was initially found with a dronecan airspeed sensor found, but not connected to the bus. The existing status text was insufficient as it was easily lost amongst other messages (prearm checks and the like). Tested on an autopilot on the desk with a I2C sensor connected, disconnected, and a disconnected dronecan sensor.