### PR TITLE
Fix clang compiler warning

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.h
@@ -128,11 +128,13 @@ public:
         _disabled_for_pulses |= (1U<<(uint8_t)protocol);
     }
 
+#if !defined(__clang__)
 // in the case we've disabled most backends then the "return true" in
 // the following method can never be reached, and the compiler gets
 // annoyed at that.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wswitch-unreachable"
+#endif
 
     // for protocols without strong CRCs we require 3 good frames to lock on
     bool requires_3_frames(enum rcprotocol_t p) {
@@ -203,7 +205,9 @@ public:
         }
         return false;
     }
+#if !defined(__clang__)
 #pragma GCC diagnostic pop
+#endif
 
     uint8_t num_channels();
     uint16_t read(uint8_t chan);


### PR DESCRIPTION
Fix for compiler warning from clang about unknown warning group -Wswitch-unreachable. This warning is prevalent in both Qurt and MacOS SITL builds.