### PR TITLE
AP_Bootloader: correct compilation when signing enabled

### DIFF
--- a/Tools/AP_Bootloader/support.h
+++ b/Tools/AP_Bootloader/support.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <AP_HAL_ChibiOS/AP_HAL_ChibiOS.h>
+
 #define LED_ACTIVITY	1
 #define LED_BOOTLOADER	2
 


### PR DESCRIPTION
```
In file included from ../../libraries/AP_CheckFirmware/AP_CheckFirmware.cpp:13: ../../libraries/AP_CheckFirmware/../../Tools/AP_Bootloader/support.h:57:25: error: "CH_CFG_USE_HEAP" is not defined, evaluates to 0 [-Werror=undef]
   57 | #if defined(STM32H7) && CH_CFG_USE_HEAP
      |                         ^~~~~~~~~~~~~~~
compilation terminated due to -Wfatal-errors.
cc1plus: all warnings being treated as errors
```
