### PR TITLE
Copter: Configurable yaw offset for DO_SET_ROI

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1232,6 +1232,14 @@ const AP_Param::GroupInfo ParametersG2::var_info2[] = {
     // @User: Advanced
     AP_GROUPINFO("FS_EKF_FILT", 8, ParametersG2, fs_ekf_filt_hz, FS_EKF_FILT_DEFAULT),
 
+    // @Param: ROI_YAW_OFFSET
+    // @DisplayName: ROI yaw offset
+    // @Description: Offset applied to yaw when pointing to region of interest. Zero offset points nose at ROI.
+    // @Range: -18000 18000
+    // @Units: cdeg
+    // @User: Advanced
+    AP_GROUPINFO("ROI_YAW_OFFSET", 9, ParametersG2, roi_yaw_offset, 0),
+
     // ID 62 is reserved for the AP_SUBGROUPEXTENSION
 
     AP_GROUPEND

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -676,6 +676,8 @@ public:
     // EKF variance filter cutoff
     AP_Float fs_ekf_filt_hz;
 
+    AP_Float roi_yaw_offset;
+
 #if WEATHERVANE_ENABLED
     AC_WeatherVane weathervane;
 #endif

--- a/ArduCopter/autoyaw.cpp
+++ b/ArduCopter/autoyaw.cpp
@@ -5,7 +5,9 @@ Mode::AutoYaw Mode::auto_yaw;
 // roi_yaw - returns heading towards location held in roi
 float Mode::AutoYaw::roi_yaw() const
 {
-    return get_bearing_cd(copter.inertial_nav.get_position_xy_cm(), roi.xy());
+    float yaw = get_bearing_cd(copter.inertial_nav.get_position_xy_cm(), roi.xy());
+    yaw += copter.g2.roi_yaw_offset;
+    return wrap_360_cd(yaw);
 }
 
 // returns a yaw in degrees, direction of vehicle travel:


### PR DESCRIPTION
Currently DO_SET_ROI command always points nose of the vehicle towards the ROI. This PR adds parameter `ROI_YAW_OFFSET` that can be used to control yaw angle that points towards ROI.

Earlier forum question about this feature: https://discuss.ardupilot.org/t/offset-drone-heading-with-do-set-roi/88787