### PR TITLE
Tools: autotest: Test guided altitude commands in Plane

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -6437,6 +6437,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.MAV_CMD_EXTERNAL_WIND_ESTIMATE,
             self.GliderPullup,
             self.BadRollChannelDefined,
+            self.SetpointGlobalPos
         ]
 
     def disabled_tests(self):


### PR DESCRIPTION
# Purpose

Add a test for `master` to preserve existing behavior of planes guided  [SET_POSITION_TARGET_GLOBAL_INT](https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_GLOBAL_INT) support where you set the bitmask to only change the vehicle altitude.

This is to be sure that the small cleanup in https://github.com/ArduPilot/ardupilot/pull/28479 does not cause regressions.
As far as I can tell, the guided change altitude plane API in MAVLink is not tested in CI.

# Details 

The existing `SetpointGlobalPos` class is used on copter and rover tests, but not in Plane. Although it has some conditions for plane in the code, those are likely leftovers from something else. None of the existing tests will pass on plane because they aren't implemented. 

I'm hung up right now on why
*  The `MAV_FRAMES_TO_TEST` list includes `MAV_FRAME_GLOBAL`, but the `to_alt_frame`  function does not include a converter.
* If the vehicle type is plane, `FS_GCS_ENABLE` cannot be set to 0
* Whether it's ok to call `AutoTestPlane.fly_home_land_and_disarm` in `vehicle_test_suite`, which couples the classes


Logs right now show that the vehicle is trying to climb to 750m, starting at CMAC, and I suspect it's because MAV_FRAME_GLOBAL is not havin the home altitude taken off. 

# Logs

[ArduPlane-SetpointGlobalPos.txt](https://github.com/user-attachments/files/17549045/ArduPlane-SetpointGlobalPos.txt)
