### PR TITLE
Tools: autotest: Use GLOBAL keyword to match WGS-84 MSL alt frames

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -11404,10 +11404,8 @@ Also, ignores heartbeats not from our target system'''
             raise ValueError()
 
         def to_alt_frame(alt, mav_frame):
-            if mav_frame in ["MAV_FRAME_GLOBAL_RELATIVE_ALT",
-                             "MAV_FRAME_GLOBAL_RELATIVE_ALT_INT",
-                             "MAV_FRAME_GLOBAL_TERRAIN_ALT",
-                             "MAV_FRAME_GLOBAL_TERRAIN_ALT_INT"]:
+            # Per MAVLink spec, GLOBAL is a keyword to represent MSL.
+            if "GLOBAL" in mav_frame:
                 home = self.home_position_as_mav_location()
                 return alt - home.alt
             else:


### PR DESCRIPTION
# Purpose

This fixes the missing `MAV_FRAME_GLOBAL` from the conversion from absolute to relative alt.

I observed when using this conversion on [some new plane tests](https://github.com/ArduPilot/ardupilot/pull/28487), repeat tests result in long climbs that slow the test down and even fail it without longer timeouts. 

# Using the "in" keyword for substring containment
![image](https://github.com/user-attachments/assets/5d7e0a01-8051-491e-a414-726187f62aaa)

# Docs
https://mavlink.io/en/messages/common.html#MAV_FRAME

# Tests Performed

Copter autotest

This causes test failures:
https://github.com/ArduPilot/ardupilot/actions/runs/11565307247/job/32192397166?pr=28489#step:11:15192

This seems like very odd behavior. Perhaps it could use some docs on why `MAV_FRAME_GLOBAL` must be treated different?
