### PR TITLE
Update clang pragma that is causing trouble

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -1,7 +1,7 @@
 #include "Copter.h"
 
 #pragma GCC diagnostic push
-#if defined(__clang__)
+#if defined(__clang_major__) && __clang_major__ >= 14
 #pragma GCC diagnostic ignored "-Wbitwise-instead-of-logical"
 #endif
 

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -175,7 +175,7 @@ extern AP_IOMCU iomcu;
 #endif
 
 #pragma GCC diagnostic push
-#if defined (__clang__)
+#if defined(__clang_major__) && __clang_major__ >= 14
 #pragma GCC diagnostic ignored "-Wbitwise-instead-of-logical"
 #endif
 


### PR DESCRIPTION
Update a clang pragma to check for the proper version of clang that introduces the warning.