### PR TITLE
Rover: add pid_info Lua bindings

### DIFF
--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -268,6 +268,25 @@ bool Rover::get_control_output(AP_Vehicle::ControlOutput control_output, float &
     return false;
 }
 
+// get steering rate pid info (for use in scripting)
+bool Rover::get_steering_rate_pid_info(float& target, float& actual) {
+    const AP_PIDInfo *pid_info;
+    pid_info = &g2.attitude_control.get_steering_rate_pid().get_pid_info();
+    target = degrees(pid_info->target);
+    actual = degrees(pid_info->actual);
+    return true;
+}
+
+// get throttle/speed pid info (for use in scripting)
+bool Rover::get_throttle_speed_pid_info(float &target, float &actual)
+{
+    const AP_PIDInfo *pid_info;
+    pid_info = &g2.attitude_control.get_throttle_speed_pid_info();
+    target = pid_info->target;
+    actual = pid_info->actual;
+    return true;
+}
+
 // returns true if mode supports NAV_SCRIPT_TIME mission commands
 bool Rover::nav_scripting_enable(uint8_t mode)
 {

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -283,6 +283,8 @@ private:
     bool set_desired_turn_rate_and_speed(float turn_rate, float speed) override;
     bool set_desired_speed(float speed) override;
     bool get_control_output(AP_Vehicle::ControlOutput control_output, float &control_value) override;
+    bool get_steering_rate_pid_info(float &target, float &actual) override;
+    bool get_throttle_speed_pid_info(float &target, float &actual) override;
     bool nav_scripting_enable(uint8_t mode) override;
     bool nav_script_time(uint16_t &id, uint8_t &cmd, float &arg1, float &arg2, int16_t &arg3, int16_t &arg4) override;
     void nav_script_time_done(uint16_t id) override;

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -2631,6 +2631,16 @@ function vehicle:set_steering_and_throttle(steering, throttle) end
 ---@return number|nil
 function vehicle:get_steering_and_throttle() end
 
+-- returns target (desired) and actual steering rate
+---@return number|nil
+---@return number|nil
+function get_steering_rate_pid_info() end
+
+--returns target (desired) and actual speed
+---@return number|nil
+---@return number|nil
+function get_throttle_speed_pid_info() end
+
 -- desc
 ---@param rate_dps number
 ---@return boolean

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -334,6 +334,8 @@ singleton AP_Vehicle method get_circle_radius boolean float'Null
 singleton AP_Vehicle method set_circle_rate boolean float'skip_check
 singleton AP_Vehicle method set_steering_and_throttle boolean float -1 1 float -1 1
 singleton AP_Vehicle method get_steering_and_throttle boolean float'Null float'Null
+singleton AP_Vehicle method get_steering_rate_pid_info boolean float'Null float'Null
+singleton AP_Vehicle method get_throttle_speed_pid_info boolean float'Null float'Null
 singleton AP_Vehicle method get_wp_distance_m boolean float'Null
 singleton AP_Vehicle method get_wp_bearing_deg boolean float'Null
 singleton AP_Vehicle method get_wp_crosstrack_error_m boolean float'Null

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -212,8 +212,18 @@ public:
    // set auto mode speed in meters/sec (for use by scripting with Copter/Rover)
     virtual bool set_desired_speed(float speed) { return false; }
 
+    // get steering rate PID info (for use by scripting with Rover)
+    virtual bool get_steering_rate_pid_info(float &target, float &actual) { return false; }
+
+    // get throttle/speed PID info (for use by scripting with Rover)
+    virtual bool get_throttle_speed_pid_info(float &target, float &actual) { return false; }
+
     // support for NAV_SCRIPT_TIME mission command
-    virtual bool nav_script_time(uint16_t &id, uint8_t &cmd, float &arg1, float &arg2, int16_t &arg3, int16_t &arg4) { return false; }
+    virtual bool
+    nav_script_time(uint16_t &id, uint8_t &cmd, float &arg1, float &arg2, int16_t &arg3, int16_t &arg4)
+    {
+        return false;
+    }
     virtual void nav_script_time_done(uint16_t id) {}
 
     // allow for VTOL velocity matching of a target


### PR DESCRIPTION
Adds bindings for `get_steering_rate_pid_info` and `get_throttle_speed_pid_info` for use in tuning/analysis scripts.