### PR TITLE
ArduPlane: Remove unused radio_in_rssi function

### DIFF
--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -83,8 +83,6 @@ private:
     MAV_MODE base_mode() const override;
     MAV_STATE vehicle_system_status() const override;
 
-    uint8_t radio_in_rssi() const;
-
     float vfr_hud_airspeed() const override;
     int16_t vfr_hud_throttle() const override;
     float vfr_hud_climbrate() const override;


### PR DESCRIPTION
This is not used anywhere