### PR TITLE
AP_HAL_ESP32: ADC timer tick moved into scheduler timer process

### DIFF
--- a/libraries/AP_HAL_ESP32/AnalogIn.cpp
+++ b/libraries/AP_HAL_ESP32/AnalogIn.cpp
@@ -347,6 +347,7 @@ void AnalogSource::_add_value()
    */
 void AnalogIn::init()
 {
+    hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AnalogIn::_timer_tick, void));
 }
 
 /*

--- a/libraries/AP_HAL_ESP32/Scheduler.cpp
+++ b/libraries/AP_HAL_ESP32/Scheduler.cpp
@@ -15,7 +15,6 @@
 
 #include "AP_HAL_ESP32/Scheduler.h"
 #include "AP_HAL_ESP32/RCInput.h"
-#include "AP_HAL_ESP32/AnalogIn.h"
 #include "AP_Math/AP_Math.h"
 #include "SdCard.h"
 #include "Profile.h"
@@ -318,10 +317,6 @@ void IRAM_ATTR Scheduler::_timer_thread(void *arg)
     while (true) {
         sched->delay_microseconds(1000);
         sched->_run_timers();
-        //analog in
-#ifndef HAL_DISABLE_ADC_DRIVER
-        ((AnalogIn*)hal.analogin)->_timer_tick();
-#endif
     }
 }
 


### PR DESCRIPTION
Move the ADC timer tick into timer process to make scheduler code looks tidier