### PR TITLE
AP_Bootloader: Reserve ID range for TM IT-Systemhaus

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -357,6 +357,13 @@ AP_HW_UAV-DEV-UM982-G4               5224
 AP_HW_UAV-DEV-M20D-G4                5225
 AP_HW_UAV-DEV-Sensorboard-G4         5226
 
+# IDs 5240-5249 reserved for TM IT-Systemhaus
+AP_HW_TM-SYS-BeastFC                 5240
+AP_HW_TM-SYS-Sensornode              5241
+AP_HW_TM-SYS-OpenHDFPV               5242
+AP_HW_TM-SYS-VisualNAV               5243
+AP_HW_TM-SYS-Airspeed                5244
+
 # IDs 5250-5269 reserved for Team Black Sheep
 AP_HW_TBS_LUCID_H7                   5250
 AP_HW_TBS_LUCID_PRO                  5251


### PR DESCRIPTION
Reserve ID range for TM IT-Systemhaus