### PR TITLE
Fix Documentation Generating Parameters Incorrectly

### DIFF
--- a/Tools/AP_Periph/Parameters.cpp
+++ b/Tools/AP_Periph/Parameters.cpp
@@ -732,7 +732,7 @@ const AP_Param::Info AP_Periph_FW::var_info[] = {
     // @User: Standard
     GSCALAR(imu_sample_rate, "INS_SAMPLE_RATE", 0),
 
-    // @Group: INS_
+    // @Group: INS
     // @Path: ../libraries/AP_InertialSensor/AP_InertialSensor.cpp
     GOBJECT(imu, "INS", AP_InertialSensor),
 #endif

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
@@ -143,7 +143,7 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
 
     // @Param: ARM_MAH
     // @DisplayName: Required arming remaining capacity
-    // @Description: Battery capacity remaining which is required to arm the aircraft. Set to 0 to allow arming at any capacity. Note that execept for smart batteries rebooting the vehicle will always reset the remaining capacity estimate, which can lead to this check not providing sufficent protection, it is recommended to always use this in conjunction with the @PREFIX@_ARM_VOLT parameter.
+    // @Description: Battery capacity remaining which is required to arm the aircraft. Set to 0 to allow arming at any capacity. Note that execept for smart batteries rebooting the vehicle will always reset the remaining capacity estimate, which can lead to this check not providing sufficent protection, it is recommended to always use this in conjunction with the @PREFIX@ARM_VOLT parameter.
     // @Units: mAh
     // @Increment: 50
     // @User: Advanced


### PR DESCRIPTION
Parameters are being generated as `INS_` as the group, so `INS_USE` is actually documented as `INS__USE` (note the double underscore). (See: [INS__USE: Use first IMU for attitude, velocity and position estimates](https://ardupilot.org/dev/docs/AP_Periph-Parameters.html#ins-use-use-first-imu-for-attitude-velocity-and-position-estimates)

Also fixes documentation in the battery library where the generated referenced parameter contains double underscores: (see: [BATT2_ARM_MAH: Required arming remaining capacity](https://ardupilot.org/plane/docs/parameters.html#batt2-arm-mah-required-arming-remaining-capacity))