### PR TITLE
AP_L1_Control: Add wind compensation for 90 degree turn distance

### DIFF
--- a/libraries/AP_L1_Control/AP_L1_Control.cpp
+++ b/libraries/AP_L1_Control/AP_L1_Control.cpp
@@ -119,38 +119,60 @@ int32_t AP_L1_Control::target_bearing_cd(void) const
 }
 
 /*
-  this is the turn distance assuming a 90 degree turn
+  This is the turn distance assuming a 90 degree turn
  */
 float AP_L1_Control::turn_distance(float wp_radius) const
 {
-    const float eas2tas_sq = sq(_ahrs.get_EAS2TAS()); // true airspeed correction
+    // True airspeed correction
+    const float eas2tas_sq = sq(_ahrs.get_EAS2TAS());
 
-    const float scaled_turn_distance = wp_radius * eas2tas_sq; // distance scaled to true airspeed
+    // Distance scaled to true airspeed
+    float turn_distance_m = wp_radius * eas2tas_sq;
 
-    /** Wind effect i.e. forward crosstrack error correction for the leg to the next waypoint.
-     *  turn early on tail-wind
+    // The L1-distance can be closer then the waypoint radius because we are off-track.
+    turn_distance_m = MIN(turn_distance_m, _L1_dist);
+
+    /** Forward correct the crosstrack error caused by the lateral shift by the wind during the turn.
+     *  Simplified for a rectangle turn, the head-wind (or tail-wind) before the turn is the crosswind after the turn.
+     *  Turn early on tail-wind, because it works against the turn and this may exceed the plane's turn capability.
+     *
+     *  An overly simplified example:
+     *      wp_radius = 50m
+     *      tail_wind_mps = 10m/s
+     *      arc_distance_m = 0.5*3.14*50 = 78,5m
+     *      air_speed_mps = 10m/s
+     *      turn_duration_s = 7,85s
+     *      lateral_shift_m = 78,5m
+     *      turn_distance_m = 50m + 78,5m = 128,5m
+     *
+     *  Note: Head-wind condition is not corrected because is creates the mathmatical problem of possibly negative turn distances.
      */
-    float headwind = _ahrs.head_wind(); // forward head-wind component in m/s. Negative means tail-wind.
 
-    float arc_distance_for_90_degree_turn_in_meters = 0.5f * M_PI * wp_radius;
+    const float tail_wind_mps = -(_ahrs.head_wind());
 
-    float current_speed = 0.0f;
+    float air_speed_mps = 0.0f;
 
-    if (!_ahrs.airspeed_estimate_true(current_speed))
+    // Only apply correction is airspeed is available and for tail-wind condition.
+    if ((tail_wind_mps > 0.0f) && (_ahrs.airspeed_estimate_true(air_speed_mps)))
     {
-        // fallback to groundspeed
-        current_speed = _ahrs.groundspeed_vector().length();
-    };
+        /** The flight distance on the arc segment.
+         *  By assuming an ideal rectangle turn that starts when the distance to the waypoint equals wp_radius,
+         *  the turn radius also equals wp_radius.
+         *  The distance therefore is a quarter of the circumfence (2*PI*R)
+         */
+        const float arc_distance_m = 0.5f * M_PI * wp_radius;
 
-    float seconds_needed_for_90_degree_turn = arc_distance_for_90_degree_turn_in_meters / current_speed;
+        // the time needed for the turn
+        const float turn_duration_s = arc_distance_m / air_speed_mps;
 
-    float estimated_lateral_shift_by_wind_during_turn = seconds_needed_for_90_degree_turn * headwind;
+        // the resulting lateral shift during the turn
+        const float lateral_shift_m = turn_duration_s * tail_wind_mps;
 
-    float scaled_and_wind_corrected_turn_distance = scaled_turn_distance - estimated_lateral_shift_by_wind_during_turn;
-    
-    float sanitized_turn_distance = MIN(scaled_and_wind_corrected_turn_distance, _L1_dist); // presumably some invariant of the L1 algo
+        // the resulting turn distance
+        turn_distance_m += lateral_shift_m;
+    }
 
-    return sanitized_turn_distance;
+    return turn_distance_m
 }
 
 /*

--- a/libraries/AP_L1_Control/AP_L1_Control.cpp
+++ b/libraries/AP_L1_Control/AP_L1_Control.cpp
@@ -172,7 +172,7 @@ float AP_L1_Control::turn_distance(float wp_radius) const
         turn_distance_m += lateral_shift_m;
     }
 
-    return turn_distance_m
+    return turn_distance_m;
 }
 
 /*


### PR DESCRIPTION
This is a Request for Comments for a Work in Progress Enhancement. Please add tags WIP and RFC respectively.

# Abstract
Shift waypoint turn-in to compensate for wind.

## Observation:
When a plane enters a 90 degree turn to the next waypoint while flying with tailwind, the plane overshoots and has to correct after the turn.
The overshoot is caused by the crosswind the plane experiences relative to the new course.

## Goal:
Forward-correct the crosstrack error after the turn by an earlier turn-in.

## Assumptions and classifications:
1. WP_RADIUS is bigger or equal to plane minimal radius (Physical constraint of the plane's turn ability)
2. Wind does not change direction during the turn (Physical constraint to establish forward error correction ability)
3. If the plane flys with tailwind at start of turn, it will overshoot the leg to the next waypoint (Conditional evaluation if correction is necessary)
4. The amount of overshoot is the "crosswind component of the new course" multiplied by the time needed for the turn (Error component). 
5. The time needed for the turn is the distance traveled on WP_RADIUS divided by the ground speed (Error component).

## Simplifications:
1. For a 90 degree turn, the tailwind at the start of turn is equivalent to the crosswind at the end of the turn.