### PR TITLE
AP_Scripting: ESC_slew_rate: fix lua warning

### DIFF
--- a/libraries/AP_Scripting/examples/ESC_slew_rate.lua
+++ b/libraries/AP_Scripting/examples/ESC_slew_rate.lua
@@ -44,7 +44,7 @@ function update()
       local pwm_mid = 0.5*(pwm_min+pwm_max)
       local pwm = math.floor(pwm_mid + (pwm_max-pwm_mid) * output)
       SRV_Channels:set_output_pwm_chan_timeout(chan-1, pwm, 100)
-      logger.write('ESLW', 'PWM,Freq', 'If', pwm, freq)
+      logger:write('ESLW', 'PWM,Freq', 'If', pwm, freq)
       gcs:send_named_float('PWN',pwm)
       gcs:send_named_float('FREQ',freq)
    end


### PR DESCRIPTION
Docs say that logger must be called with `:`.

Not sure why this didn't get caught on the initial merge. Perhaps the checker upgraded.