### PR TITLE
AP_Bootloader: reserve board ids and range for Karshak Drones

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -335,6 +335,9 @@ AP_HW_MFT-SEMA100                    2000
 
 AP_HW_SakuraRC-H743                  2714
 
+# IDs 4000-4009 reserved for Karshak Drones
+AP_HW_KRSHKF7_MINI                   4000
+
 # IDs 4200-4220 reserved for HAKRC
 AP_HW_HAKRC_F405                     4200
 AP_HW_HAKRC_F405Wing                 4201


### PR DESCRIPTION
This commit reserves the available board IDs within the given range of **189** to **211** for Karshak Drones. Changes are introduced after line 112 of the file **board_types.txt**, which is placed under **Tools/AP_Bootloader/board_types.txt**.