### PR TITLE
AP_Scripting: Applets: MissionSelector: fix error on file open and checker errors

### DIFF
--- a/libraries/AP_Scripting/applets/MissionSelector.lua
+++ b/libraries/AP_Scripting/applets/MissionSelector.lua
@@ -84,4 +84,6 @@ function update()
   return update, 1000
 end
 
+gcs:send_text(5,"Loaded MissionSelector.lua")
+
 return update, 5000

--- a/libraries/AP_Scripting/applets/MissionSelector.lua
+++ b/libraries/AP_Scripting/applets/MissionSelector.lua
@@ -2,9 +2,6 @@
 -- Must have Mission Reset switch assigned, it will function normally when armed or disarmed
 -- but also on the disarm to arm transition, it will load (if file exists) a file in the root named
 -- missionH.txt, missionM.txt, or missionH.txt corresponding to the the Mission Reset switch position of High/Mid/Low
--- luacheck: only 0
----@diagnostic disable: need-check-nil
-
 
 local mission_loaded = false
 local rc_switch = rc:find_channel_for_option(24)  --AUX FUNC sw for mission restart
@@ -15,12 +12,12 @@ end
 
 local function read_mission(file_name)
 
-   -- Open file try and read header
+  -- Open file try and read header
   local file = io.open(file_name,"r")
-  local header = file:read('l')
-  if not header then
+  if not file then
     return update, 1000 --could not read, file probably does not exist
   end
+  local header = file:read('l')
 
   -- check header
   assert(string.find(header,'QGC WPL 110') == 1, file_name .. ': incorrect format')
@@ -64,7 +61,6 @@ local function read_mission(file_name)
     end
     index = index + 1
   end
-  file:close()
 end
 
 function update()


### PR DESCRIPTION
Ages ago file open would always succeed, we fixed the other scripts and missed this one. Now file can be `nil` so we need to check for that. This fixes the script so we can run the static checkers. 