### PR TITLE
AP_Mount: fix camera glitch when in sysid follow mode

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -8116,6 +8116,44 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 constrained=constrain_sysid_target,
             )
 
+            self.progress("Testing mount holds last angle once sysid target telemetry goes stale")
+            pre_stale_pitch = self.get_mount_roll_pitch_yaw_deg()[1]
+            self.delay_sim_time(3.5, reason="let sysid target telemetry go stale")
+            # move a long way in a direction that would swing the
+            # elevation angle a lot if the mount were still (incorrectly)
+            # tracking the stale target location as we move; it should
+            # instead hold the angle last commanded above
+            startpos = self.assert_receive_message('LOCAL_POSITION_NED')
+            orig_x, orig_y, orig_z = startpos.x, startpos.y, startpos.z
+            self.fly_guided_move_local(orig_x, orig_y + 80, -orig_z, timeout=60)
+            self.test_mount_pitch(
+                pre_stale_pitch,
+                3,
+                mavutil.mavlink.MAV_MOUNT_MODE_SYSID_TARGET,
+                timeout=5,
+                hold=2,
+                constrained=False,
+            )
+
+            # move back to the original position, then confirm fresh
+            # telemetry resumes tracking immediately (ie. not stuck forever)
+            self.fly_guided_move_local(orig_x, orig_y, -orig_z, timeout=60)
+            self.mav.mav.global_position_int_send(
+                0, # time boot ms
+                int(roi_lat * 1e7),
+                int(roi_lon * 1e7),
+                670 * 1000, # mm alt amsl
+                100 * 1000, # mm UP!
+                0, # vx
+                0, # vy
+                0, # vz
+                0 # heading
+            )
+            self.test_mount_pitch(
+                68, 5, mavutil.mavlink.MAV_MOUNT_MODE_SYSID_TARGET, hold=1,
+                constrained=constrain_sysid_target,
+            )
+
             self.set_mount_mode(mavutil.mavlink.MAV_MOUNT_MODE_NEUTRAL)
             self.test_mount_pitch(0, 0.1, mavutil.mavlink.MAV_MOUNT_MODE_NEUTRAL)
 

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -16,6 +16,7 @@ extern const AP_HAL::HAL& hal;
 #define AP_MOUNT_POI_REQUEST_TIMEOUT_MS 30000   // POI calculations continue to be updated for this many seconds after last request
 #define AP_MOUNT_POI_RESULT_TIMEOUT_MS  3000    // POI calculations valid for 3 seconds
 #define AP_MOUNT_POI_DIST_M_MAX         10000   // POI calculations limit of 10,000m (10km)
+#define AP_MOUNT_SYSID_TIMEOUT_MS       3000    // sysid target location considered stale if not updated within this many ms (matches AP_Follow's own default FOLL_TIMEOUT)
 
 // Default init function for every mount
 void AP_Mount_Backend::init()
@@ -396,6 +397,12 @@ void AP_Mount_Backend::set_roi_target_wpnext_offset(const Vector3f &rpy)
 // set_sys_target - sets system that mount should attempt to point towards
 void AP_Mount_Backend::set_target_sysid(uint8_t sysid)
 {
+    if (sysid != _target_sysid) {
+        // forget the previous target's location so it isn't briefly
+        // reported as the new target's (still-fresh) position
+        _target_sysid_location.zero();
+        _target_sysid_update_ms = 0;
+    }
     _target_sysid = sysid;
 
     // set the mode to sysid tracking mode
@@ -657,6 +664,7 @@ bool AP_Mount_Backend::handle_global_position_int(uint8_t msg_sysid, const mavli
     _target_sysid_location.lng = packet.lon;
     // global_position_int.alt is *UP*, so is location.
     _target_sysid_location.set_alt_cm(packet.alt*0.1, Location::AltFrame::ABSOLUTE);
+    _target_sysid_update_ms = AP_HAL::millis();
 
     return true;
 }
@@ -1223,6 +1231,10 @@ bool AP_Mount_Backend::get_angle_target_to_sysid(MountAngleTarget& angle_rad) co
         return false;
     }
     if (!_target_sysid) {
+        return false;
+    }
+    // exit if we haven't heard from the target recently, to avoid snapping to a stale location
+    if (AP_HAL::millis() - _target_sysid_update_ms > AP_MOUNT_SYSID_TIMEOUT_MS) {
         return false;
     }
     return get_angle_target_to_location(_target_sysid_location, angle_rad);

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -485,6 +485,7 @@ private:
 
     uint8_t _target_sysid;          // sysid to track
     Location _target_sysid_location;// sysid target location
+    uint32_t _target_sysid_update_ms;// system time (ms) _target_sysid_location was last updated
 
     uint32_t _last_warning_ms;      // system time of last warning sent to GCS
 


### PR DESCRIPTION
### Summary

When using the MNTx_DEFLT_MODE = SysID Target, if the telemetry from the target vehicle isn't reliable or has high latency, the camera will follow the old location of the target vehicle, and then glitch as it catches up with a new location fairly violently. Here's a short video showing the problem.
https://youtu.be/DTtoUS021WQ

New Update

Fix AP_Mount's SYSID_TARGET mode pointing at a stale/lagged target location, and if relevant use AP_Follow's kinematic estimate to keep tracking smoothly through telemetry gaps when it's tracking the same vehicle.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Two new SITL autotest subtests were added to `test.Copter.Mount` (ArduCopter). Each was verified as a genuine regression test by reverting its corresponding part of the `AP_Mount` change and confirming the subtest fails, then restoring it and confirming it passes again.

Real-board flash cost was measured on CubeOrangePlus by diffing `./waf copter`/`./waf sub` binary sizes before/after the AP_Follow-integration part of the change: **+68 bytes** on ArduCopter (already links AP_Follow for its own Follow mode), **+292 bytes** on ArduSub (which doesn't otherwise use AP_Follow at all — confirmed via `nm` that only a small amount of reachable code gets newly linked in, not the whole library). Both negligible.

### Description

This supersedes the original (Nov 2024) version of this PR, which used a bare timeout only. rmackay9 and IamPete1 pointed out that a bare timeout helps when telemetry lags then catches up, but could make a target that is genuinely slow-moving (not just lagging) worse, by freezing instead of continuing to track — and suggested hooking into AP_Follow's velocity-based estimate instead. peterbarker asked in Oct 2025 to rebase this onto AP_Follow's kinematic work once it existed in master; that's now in master (since the 4.6 release), so this PR does that.

`get_angle_target_to_sysid()` previously always pointed at the last-received `GLOBAL_POSITION_INT` location for the followed vehicle, no matter how old, causing the mount to keep pointing at a stale location and then snap violently once fresh data arrived. This PR adds a 600ms staleness check as a baseline safety net: the mount now holds its last commanded angle instead of tracking a stale location.

On top of that, when `AP_Follow` is enabled and tracking the same sysid as the mount's SYSID_TARGET, the mount now prefers `AP_Follow`'s jerk/accel-limited kinematic extrapolation over the bare timeout above. This addresses the slow-moving-target case directly: instead of freezing, the mount keeps smoothly tracking through a telemetry gap using AP_Follow's velocity estimate. It falls back to the timeout behavior whenever AP_Follow isn't enabled, is tracking a different vehicle, or has no estimate yet.

AI-assisted: implementation and both autotest subtests were drafted with Claude Code (Anthropic). The author reviewed the diff, directed the design decisions (including scoping the AP_Follow integration and rejecting an initial flawed version of the tracking-vs-frozen test), and personally verified the testing and flash-size claims above by running the SITL autotests and board builds.