### PR TITLE
Copter: RTL with rally point finds shortest path using Dijkstras (WIP)

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1441,7 +1441,7 @@ public:
 
     // RTL states
     enum class SubMode : uint8_t {
-        STARTING,
+        BUILD_PATH,
         INITIAL_CLIMB,
         RETURN_HOME,
         LOITER_AT_HOME,
@@ -1489,7 +1489,7 @@ private:
     void loiterathome_start();
     void loiterathome_run();
     void build_path();
-    void compute_return_target();
+    bool compute_return_target();
 
     SubMode _state = SubMode::INITIAL_CLIMB;  // records state of rtl (initial climb, returning home, etc)
     bool _state_complete = false; // set to true if the current state is completed

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1488,7 +1488,7 @@ private:
     void climb_return_run();
     void loiterathome_start();
     void loiterathome_run();
-    void build_path();
+    void build_path_run();
     bool compute_return_target();
 
     SubMode _state = SubMode::INITIAL_CLIMB;  // records state of rtl (initial climb, returning home, etc)

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -19,9 +19,14 @@ bool ModeRTL::init(bool ignore_checks)
     }
     // initialise waypoint and spline controller
     wp_nav->wp_and_spline_init(g.rtl_speed_cms);
-    _state = SubMode::STARTING;
-    _state_complete = true; // see run() method below
+
+    // initialise state
+    _state = SubMode::BUILD_PATH;
+    _state_complete = false;
+
+    // allow terrain following unless in terrain failsafe
     terrain_following_allowed = !copter.failsafe.terrain;
+
     // reset flag indicating if pilot has applied roll or pitch inputs during landing
     copter.ap.land_repo_active = false;
 
@@ -42,9 +47,15 @@ void ModeRTL::restart_without_terrain()
 #if HAL_LOGGING_ENABLED
     LOGGER_WRITE_ERROR(LogErrorSubsystem::NAVIGATION, LogErrorCode::RESTARTED_RTL);
 #endif
+
+    // disable terrain following
     terrain_following_allowed = false;
-    _state = SubMode::STARTING;
-    _state_complete = true;
+
+    // initialise state
+    _state = SubMode::BUILD_PATH;
+    _state_complete = false;
+
+    // notify user
     gcs().send_text(MAV_SEVERITY_CRITICAL,"Restarting RTL - Terrain data missing");
 }
 
@@ -70,8 +81,7 @@ void ModeRTL::run(bool disarm_on_land)
     // check if we need to move to next state
     if (_state_complete) {
         switch (_state) {
-        case SubMode::STARTING:
-            build_path();
+        case SubMode::BUILD_PATH:
             climb_start();
             break;
         case SubMode::INITIAL_CLIMB:
@@ -99,10 +109,9 @@ void ModeRTL::run(bool disarm_on_land)
     // call the correct run function
     switch (_state) {
 
-    case SubMode::STARTING:
-        // should not be reached:
-        _state = SubMode::INITIAL_CLIMB;
-        FALLTHROUGH;
+    case SubMode::BUILD_PATH:
+        build_path();
+        break;
 
     case SubMode::INITIAL_CLIMB:
         climb_return_run();
@@ -374,14 +383,18 @@ void ModeRTL::land_run(bool disarm_on_land)
     land_run_normal_or_precland();
 }
 
+// build RTL return path
+// _state_complete set to true on success
 void ModeRTL::build_path()
 {
+    // compute return target
+    if (!compute_return_target()) {
+        return;
+    }
+
     // origin point is our stopping point
     rtl_path.origin_point = get_stopping_point();
     rtl_path.origin_point.change_alt_frame(Location::AltFrame::ABOVE_HOME);
-
-    // compute return target
-    compute_return_target();
 
     // climb target is above our origin point at the return altitude
     rtl_path.climb_target = Location(rtl_path.origin_point.lat, rtl_path.origin_point.lng, rtl_path.return_target.alt, rtl_path.return_target.get_alt_frame());
@@ -391,15 +404,26 @@ void ModeRTL::build_path()
 
     // set land flag
     rtl_path.land = g.rtl_alt_final <= 0;
+
+    // state is complete
+    _state_complete = true;
 }
 
 // compute the return target - home or rally point
-//   return target's altitude is updated to a higher altitude that the vehicle can safely return at (frame may also be set)
-void ModeRTL::compute_return_target()
+//   rtl_path.return_target's altitude is updated to a higher altitude that the vehicle can safely return at (frame may also be set)
+//   returns true on success and fills in rtl_path structure
+bool ModeRTL::compute_return_target()
 {
     // set return target to nearest rally point or home position
 #if HAL_RALLY_ENABLED
-    rtl_path.return_target = copter.rally.calc_best_rally_or_home_location(copter.current_loc, ahrs.get_home().alt);
+    if (!copter.rally.find_nearest_rally_or_home_with_dijkstras(copter.current_loc, ahrs.get_home().alt, rtl_path.return_target)) {
+        return false;
+    }
+    if (!rtl_path.return_target.initialised()) {
+        // sanity check return target, this should never happen
+        rtl_path.return_target = ahrs.get_home();
+        INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
+    }
     rtl_path.return_target.change_alt_frame(Location::AltFrame::ABSOLUTE);
 #else
     rtl_path.return_target = ahrs.get_home();
@@ -510,13 +534,15 @@ void ModeRTL::compute_return_target()
 
     // ensure we do not descend
     rtl_path.return_target.alt = MAX(rtl_path.return_target.alt, curr_alt);
+
+    return true;
 }
 
 bool ModeRTL::get_wp(Location& destination) const
 {
     // provide target in states which use wp_nav
     switch (_state) {
-    case SubMode::STARTING:
+    case SubMode::BUILD_PATH:
     case SubMode::INITIAL_CLIMB:
     case SubMode::RETURN_HOME:
     case SubMode::LOITER_AT_HOME:

--- a/libraries/AC_Avoidance/AC_Avoidance_Logging.cpp
+++ b/libraries/AC_Avoidance/AC_Avoidance_Logging.cpp
@@ -55,7 +55,7 @@ void AP_OADijkstra::Write_OADijkstra(const uint8_t state, const uint8_t error_id
 #endif
 
 #if AP_OAPATHPLANNER_ENABLED
-void AP_OADijkstra::Write_Visgraph_point(const uint8_t version, const uint8_t point_num, const int32_t Lat, const int32_t Lon) const
+void AP_OADijkstra_StaticData::Write_Visgraph_point(const uint8_t version, const uint8_t point_num, const int32_t Lat, const int32_t Lon) const
 {
     const struct log_OD_Visgraph pkt{
         LOG_PACKET_HEADER_INIT(LOG_OD_VISGRAPH_MSG),

--- a/libraries/AC_Avoidance/AP_OADijkstra.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra.cpp
@@ -167,6 +167,20 @@ AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current
     return DIJKSTRA_STATE_NOT_REQUIRED;
 }
 
+// calculate the length of a path between origin and destination in meters
+// this calculation takes time and should only be run from a background thread
+// returns true on success and fills in path_length argument
+// called by AP_OAPathPlanner::get_path_length()
+bool AP_OADijkstra::get_path_length(const Location &origin, const Location& destination, float& path_length)
+{
+    AP_OADijkstra_Common::ErrorId error_id;
+    if (_calcpath.calc_shortest_path(origin, destination, _secondary_path, error_id)) {
+        path_length = _secondary_path.length_cm * 0.01;
+        return true;
+    }
+    return false;
+}
+
 #endif // AP_FENCE_ENABLED
 
 

--- a/libraries/AC_Avoidance/AP_OADijkstra.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra.cpp
@@ -30,16 +30,12 @@
 
 #define OA_DIJKSTRA_EXPANDING_ARRAY_ELEMENTS_PER_CHUNK  32      // expanding arrays for fence points and paths to destination will grow in increments of 20 elements
 #define OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX        255     // index use to indicate we do not have a tentative short path for a node
-#define OA_DIJKSTRA_ERROR_REPORTING_INTERVAL_MS         5000    // failure messages sent to GCS every 5 seconds
 
 /// Constructor
-AP_OADijkstra::AP_OADijkstra(AP_Int16 &options) :
-        _inclusion_polygon_pts(OA_DIJKSTRA_EXPANDING_ARRAY_ELEMENTS_PER_CHUNK),
-        _exclusion_polygon_pts(OA_DIJKSTRA_EXPANDING_ARRAY_ELEMENTS_PER_CHUNK),
-        _exclusion_circle_pts(OA_DIJKSTRA_EXPANDING_ARRAY_ELEMENTS_PER_CHUNK),
-        _short_path_data(OA_DIJKSTRA_EXPANDING_ARRAY_ELEMENTS_PER_CHUNK),
-        _path(OA_DIJKSTRA_EXPANDING_ARRAY_ELEMENTS_PER_CHUNK),
-        _options(options)
+AP_OADijkstra::AP_OADijkstra(const AP_Int16 &options) :
+        _options(options),
+        _static_data(_common, options),
+        _calcpath(_static_data)
 {
 }
 
@@ -57,11 +53,24 @@ AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current
 {
     WITH_SEMAPHORE(AP::fence()->polyfence().get_loaded_fence_semaphore());
 
-    // avoidance is not required if no fences
-    if (!some_fences_enabled()) {
+    // check static data (e.g. fences)
+    AP_OADijkstra_Common::ErrorId error_id;
+    switch (_static_data.update(error_id)) {
+    case AP_OADijkstra_StaticData::UpdateState::NOT_REQUIRED:
         dest_to_next_dest_clear = _dest_to_next_dest_clear = true;
         Write_OADijkstra(DIJKSTRA_STATE_NOT_REQUIRED, 0, 0, 0, destination, destination);
         return DIJKSTRA_STATE_NOT_REQUIRED;
+    case AP_OADijkstra_StaticData::UpdateState::READY:
+        // all static data is already up-to-date
+        break;
+    case AP_OADijkstra_StaticData::UpdateState::UPDATED:
+        // static data has changed so recalculate path
+        _shortest_path_ok = false;
+        break;
+    case AP_OADijkstra_StaticData::UpdateState::ERROR:
+        _common.report_error(error_id);
+        Write_OADijkstra(DIJKSTRA_STATE_ERROR, (uint8_t)error_id, 0, 0, destination, destination);
+        return DIJKSTRA_STATE_ERROR;
     }
 
     // no avoidance required if destination is same as current location
@@ -70,85 +79,6 @@ AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current
         dest_to_next_dest_clear = _dest_to_next_dest_clear = false;
         Write_OADijkstra(DIJKSTRA_STATE_NOT_REQUIRED, 0, 0, 0, destination, destination);
         return DIJKSTRA_STATE_NOT_REQUIRED;
-    }
-
-    // check for inclusion polygon updates
-    if (check_inclusion_polygon_updated()) {
-        _inclusion_polygon_with_margin_ok = false;
-        _polyfence_visgraph_ok = false;
-        _shortest_path_ok = false;
-    }
-
-    // check for exclusion polygon updates
-    if (check_exclusion_polygon_updated()) {
-        _exclusion_polygon_with_margin_ok = false;
-        _polyfence_visgraph_ok = false;
-        _shortest_path_ok = false;
-    }
-
-    // check for exclusion circle updates
-    if (check_exclusion_circle_updated()) {
-        _exclusion_circle_with_margin_ok = false;
-        _polyfence_visgraph_ok = false;
-        _shortest_path_ok = false;
-    }
-
-    // create inner polygon fence
-    if (!_inclusion_polygon_with_margin_ok) {
-        _inclusion_polygon_with_margin_ok = create_inclusion_polygon_with_margin(_polyfence_margin * 100.0f, _error_id);
-        if (!_inclusion_polygon_with_margin_ok) {
-            dest_to_next_dest_clear = _dest_to_next_dest_clear = false;
-            report_error(_error_id);
-            Write_OADijkstra(DIJKSTRA_STATE_ERROR, (uint8_t)_error_id, 0, 0, destination, destination);
-            return DIJKSTRA_STATE_ERROR;
-        }
-    }
-
-    // create exclusion polygon outer fence
-    if (!_exclusion_polygon_with_margin_ok) {
-        _exclusion_polygon_with_margin_ok = create_exclusion_polygon_with_margin(_polyfence_margin * 100.0f, _error_id);
-        if (!_exclusion_polygon_with_margin_ok) {
-            dest_to_next_dest_clear = _dest_to_next_dest_clear = false;
-            report_error(_error_id);
-            Write_OADijkstra(DIJKSTRA_STATE_ERROR, (uint8_t)_error_id, 0, 0, destination, destination);
-            return DIJKSTRA_STATE_ERROR;
-        }
-    }
-
-    // create exclusion circle points
-    if (!_exclusion_circle_with_margin_ok) {
-        _exclusion_circle_with_margin_ok = create_exclusion_circle_with_margin(_polyfence_margin * 100.0f, _error_id);
-        if (!_exclusion_circle_with_margin_ok) {
-            dest_to_next_dest_clear = _dest_to_next_dest_clear = false;
-            report_error(_error_id);
-            Write_OADijkstra(DIJKSTRA_STATE_ERROR, (uint8_t)_error_id, 0, 0, destination, destination);
-            return DIJKSTRA_STATE_ERROR;
-        }
-    }
-
-    // create visgraph for all fence (with margin) points
-    if (!_polyfence_visgraph_ok) {
-        _polyfence_visgraph_ok = create_fence_visgraph(_error_id);
-        if (!_polyfence_visgraph_ok) {
-            _shortest_path_ok = false;
-            dest_to_next_dest_clear = _dest_to_next_dest_clear = false;
-            report_error(_error_id);
-            Write_OADijkstra(DIJKSTRA_STATE_ERROR, (uint8_t)_error_id, 0, 0, destination, destination);
-            return DIJKSTRA_STATE_ERROR;
-        }
-        // reset logging count to restart logging updated graph
-        _log_num_points = 0;
-        _log_visgraph_version++;
-    }
-
-    // Log one visgraph point per loop
-    if (_polyfence_visgraph_ok && (_log_num_points < total_numpoints()) && (_options & AP_OAPathPlanner::OARecoveryOptions::OA_OPTION_LOG_DIJKSTRA_POINTS) ) {
-        Vector2f vis_point;
-        if (get_point(_log_num_points, vis_point)) {
-            Location log_location(Vector3f{vis_point.x, vis_point.y, 0.0}, Location::AltFrame::ABOVE_ORIGIN);
-            Write_Visgraph_point(_log_visgraph_version, _log_num_points, log_location.lat, log_location.lng);
-            _log_num_points++;
-        }
     }
 
     // rebuild path if destination or next_destination has changed
@@ -160,11 +90,11 @@ AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current
 
     // calculate shortest path from current_loc to destination
     if (!_shortest_path_ok) {
-        _shortest_path_ok = calc_shortest_path(current_loc, destination, _error_id);
+        _shortest_path_ok = _calcpath.calc_shortest_path(current_loc, destination, _shortest_path, error_id);
         if (!_shortest_path_ok) {
             dest_to_next_dest_clear = _dest_to_next_dest_clear = false;
-            report_error(_error_id);
-            Write_OADijkstra(DIJKSTRA_STATE_ERROR, (uint8_t)_error_id, 0, 0, destination, destination);
+            _common.report_error(error_id);
+            Write_OADijkstra(DIJKSTRA_STATE_ERROR, (uint8_t)error_id, 0, 0, destination, destination);
             return DIJKSTRA_STATE_ERROR;
         }
         // start from 2nd point on path (first is the original origin)
@@ -175,19 +105,19 @@ AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current
         if (!next_destination.is_zero()) {
             Vector2f seg_start, seg_end;
             if (destination.get_vector_xy_from_origin_NE(seg_start) && next_destination.get_vector_xy_from_origin_NE(seg_end)) {
-                _dest_to_next_dest_clear = !intersects_fence(seg_start, seg_end);
+                _dest_to_next_dest_clear = !_static_data.intersects_fence(seg_start, seg_end);
             }
         }
     }
 
     // path has been created, return latest point
     Vector2f dest_pos;
-    const uint8_t path_length = get_shortest_path_numpoints() > 0 ? (get_shortest_path_numpoints() - 1) : 0;
-    if ((_path_idx_returned < path_length) && get_shortest_path_point(_path_idx_returned, dest_pos)) {
+    const uint8_t path_length = _shortest_path.num_pos > 0 ? (_shortest_path.num_pos - 1) : 0;
+    if ((_path_idx_returned < path_length) && _shortest_path.get_position(_path_idx_returned, dest_pos)) {
 
         // for the first point return origin as current_loc
         Vector2f origin_pos;
-        if ((_path_idx_returned > 0) && get_shortest_path_point(_path_idx_returned-1, origin_pos)) {
+        if ((_path_idx_returned > 0) && _shortest_path.get_position(_path_idx_returned-1, origin_pos)) {
             // convert offset from ekf origin to Location
             Location temp_loc(Vector3f{origin_pos.x, origin_pos.y, 0.0}, Location::AltFrame::ABOVE_ORIGIN);
             origin_new = temp_loc;
@@ -205,7 +135,7 @@ AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current
         // provide next destination to allow smooth cornering
         next_destination_new.zero();
         Vector2f next_dest_pos;
-        if ((_path_idx_returned + 1 < path_length) && get_shortest_path_point(_path_idx_returned + 1, next_dest_pos)) {
+        if ((_path_idx_returned + 1 < path_length) && _shortest_path.get_position(_path_idx_returned + 1, next_dest_pos)) {
             // convert offset from ekf origin to Location
             Location next_loc(Vector3f{next_dest_pos.x, next_dest_pos.y, 0.0}, Location::AltFrame::ABOVE_ORIGIN);
             next_destination_new = destination;
@@ -226,7 +156,7 @@ AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current
             _path_idx_returned++;
         }
         // log success
-        Write_OADijkstra(DIJKSTRA_STATE_SUCCESS, 0, _path_idx_returned, get_shortest_path_numpoints(), destination, destination_new);
+        Write_OADijkstra(DIJKSTRA_STATE_SUCCESS, 0, _path_idx_returned, _shortest_path.num_pos, destination, destination_new);
         return DIJKSTRA_STATE_SUCCESS;
     }
 
@@ -237,782 +167,6 @@ AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current
     return DIJKSTRA_STATE_NOT_REQUIRED;
 }
 
-// returns true if at least one inclusion or exclusion zone is enabled
-bool AP_OADijkstra::some_fences_enabled() const
-{
-    const AC_Fence *fence = AC_Fence::get_singleton();
-    if (fence == nullptr) {
-        return false;
-    }
-    if ((fence->polyfence().get_inclusion_polygon_count() == 0) &&
-        (fence->polyfence().get_exclusion_polygon_count() == 0) &&
-        (fence->polyfence().get_exclusion_circle_count() == 0)) {
-        return false;
-    }
-    return ((fence->get_enabled_fences() & AC_FENCE_TYPE_POLYGON) > 0);
-}
-
-// return error message for a given error id
-const char* AP_OADijkstra::get_error_msg(AP_OADijkstra_Error error_id) const
-{
-    switch (error_id) {
-    case AP_OADijkstra_Error::DIJKSTRA_ERROR_NONE:
-        return "no error";
-        break;
-    case AP_OADijkstra_Error::DIJKSTRA_ERROR_OUT_OF_MEMORY:
-        return "out of memory";
-        break;
-    case AP_OADijkstra_Error::DIJKSTRA_ERROR_OVERLAPPING_POLYGON_POINTS:
-        return "overlapping polygon points";
-        break;
-    case AP_OADijkstra_Error::DIJKSTRA_ERROR_FAILED_TO_BUILD_INNER_POLYGON:
-        return "failed to build inner polygon";
-        break;
-    case AP_OADijkstra_Error::DIJKSTRA_ERROR_OVERLAPPING_POLYGON_LINES:
-        return "overlapping polygon lines";
-        break;
-    case AP_OADijkstra_Error::DIJKSTRA_ERROR_FENCE_DISABLED:
-        return "fence disabled";
-        break;
-    case AP_OADijkstra_Error::DIJKSTRA_ERROR_TOO_MANY_FENCE_POINTS:
-        return "too many fence points";
-        break;
-    case AP_OADijkstra_Error::DIJKSTRA_ERROR_NO_POSITION_ESTIMATE:
-        return "no position estimate";
-        break;
-    case AP_OADijkstra_Error::DIJKSTRA_ERROR_COULD_NOT_FIND_PATH:
-        return "could not find path";
-        break;
-    }
-
-    // we should never reach here but just in case
-    return "unknown error";
-}
-
-void AP_OADijkstra::report_error(AP_OADijkstra_Error error_id)
-{
-    // report errors to GCS every 5 seconds
-    uint32_t now_ms = AP_HAL::millis();
-    if ((error_id != AP_OADijkstra_Error::DIJKSTRA_ERROR_NONE) &&
-        ((error_id != _error_last_id) || ((now_ms - _error_last_report_ms) > OA_DIJKSTRA_ERROR_REPORTING_INTERVAL_MS))) {
-        const char* error_msg = get_error_msg(error_id);
-        (void)error_msg;  // in case !HAL_GCS_ENABLED
-        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Dijkstra: %s", error_msg);
-        _error_last_id = error_id;
-        _error_last_report_ms = now_ms;
-    }
-}
-
-// check if polygon fence has been updated since we created the inner fence. returns true if changed
-bool AP_OADijkstra::check_inclusion_polygon_updated() const
-{
-    // exit immediately if polygon fence is not enabled
-    const AC_Fence *fence = AC_Fence::get_singleton();
-    if (fence == nullptr) {
-        return false;
-    }
-    return (_inclusion_polygon_update_ms != fence->polyfence().get_inclusion_polygon_update_ms());
-}
-
-// create polygons inside the existing inclusion polygons
-// returns true on success.  returns false on failure and err_id is updated
-bool AP_OADijkstra::create_inclusion_polygon_with_margin(float margin_cm, AP_OADijkstra_Error &err_id)
-{
-    const AC_Fence *fence = AC_Fence::get_singleton();
-
-    if (fence == nullptr) {
-        err_id = AP_OADijkstra_Error::DIJKSTRA_ERROR_FENCE_DISABLED;
-        return false;
-    }
-
-    // skip unnecessary retry to build inclusion polygon if previous fence points have not changed 
-    if (_inclusion_polygon_update_ms == fence->polyfence().get_inclusion_polygon_update_ms()) {
-        return false;
-    }
-
-    _inclusion_polygon_update_ms = fence->polyfence().get_inclusion_polygon_update_ms();
-
-    // clear all points
-    _inclusion_polygon_numpoints = 0;
-
-    // return immediately if no polygons
-    const uint8_t num_inclusion_polygons = fence->polyfence().get_inclusion_polygon_count();
-
-    // iterate through polygons and create inner points
-    for (uint8_t i = 0; i < num_inclusion_polygons; i++) {
-        uint16_t num_points;
-        const Vector2f* boundary = fence->polyfence().get_inclusion_polygon(i, num_points);
-
-        // for each point in inclusion polygon
-        // Note: boundary is "unclosed" meaning the last point is *not* the same as the first
-        uint16_t new_points = 0;
-        for (uint16_t j = 0; j < num_points; j++) {
-
-            // find points before and after current point (relative to current point)
-            const uint16_t before_idx = (j == 0) ? num_points-1 : j-1;
-            const uint16_t after_idx = (j == num_points-1) ? 0 : j+1;
-            Vector2f before_pt = boundary[before_idx] - boundary[j];
-            Vector2f after_pt = boundary[after_idx] - boundary[j];
-
-            // if points are overlapping fail
-            if (before_pt.is_zero() || after_pt.is_zero() || (before_pt == after_pt)) {
-                err_id = AP_OADijkstra_Error::DIJKSTRA_ERROR_OVERLAPPING_POLYGON_POINTS;
-                return false;
-            }
-
-            // scale points to be unit vectors
-            before_pt.normalize();
-            after_pt.normalize();
-
-            // calculate intermediate point and scale to margin
-            Vector2f intermediate_pt = after_pt + before_pt;
-            intermediate_pt.normalize();
-            intermediate_pt *= margin_cm;
-
-            // find final point which is outside the inside polygon
-            Vector2f temp_point = boundary[j] + intermediate_pt;
-            if (Polygon_outside(temp_point, boundary, num_points)) {
-                intermediate_pt *= -1.0;
-                temp_point = boundary[j] + intermediate_pt;
-                if (Polygon_outside(temp_point, boundary, num_points)) {
-                    // could not find a point on either side that was outside the exclusion polygon so fail
-                    // this may happen if the exclusion polygon has overlapping lines
-                    err_id = AP_OADijkstra_Error::DIJKSTRA_ERROR_OVERLAPPING_POLYGON_LINES;
-                    return false;
-                }
-            }
-
-            // don't add points in corners
-            if (fabsf(intermediate_pt.angle() - before_pt.angle()) < M_PI_2) {
-                continue;
-            }
-
-            // expand array if required
-            if (!_inclusion_polygon_pts.expand_to_hold(_inclusion_polygon_numpoints + new_points + 1)) {
-                err_id = AP_OADijkstra_Error::DIJKSTRA_ERROR_OUT_OF_MEMORY;
-                return false;
-            }
-            // add point
-            _inclusion_polygon_pts[_inclusion_polygon_numpoints + new_points] = temp_point;
-            new_points++;
-        }
-
-        // update total number of points
-        _inclusion_polygon_numpoints += new_points;
-    }
-    return true;
-}
-
-// check if exclusion polygons have been updated since create_exclusion_polygon_with_margin was run
-// returns true if changed
-bool AP_OADijkstra::check_exclusion_polygon_updated() const
-{
-    const AC_Fence *fence = AC_Fence::get_singleton();
-    if (fence == nullptr) {
-        return false;
-    }
-    return (_exclusion_polygon_update_ms != fence->polyfence().get_exclusion_polygon_update_ms());
-}
-
-// create polygons around existing exclusion polygons
-// returns true on success.  returns false on failure and err_id is updated
-bool AP_OADijkstra::create_exclusion_polygon_with_margin(float margin_cm, AP_OADijkstra_Error &err_id)
-{
-    const AC_Fence *fence = AC_Fence::get_singleton();
-
-    if (fence == nullptr) {
-        err_id = AP_OADijkstra_Error::DIJKSTRA_ERROR_FENCE_DISABLED;
-        return false;
-    }
-
-    // skip unnecessary retry to build exclusion polygon if previous fence points have not changed 
-    if (_exclusion_polygon_update_ms == fence->polyfence().get_exclusion_polygon_update_ms()) {
-        return false;
-    }
-
-    _exclusion_polygon_update_ms = fence->polyfence().get_exclusion_polygon_update_ms();
-
-
-    // clear all points
-    _exclusion_polygon_numpoints = 0;
-
-    // return immediately if no exclusion polygons
-    const uint8_t num_exclusion_polygons = fence->polyfence().get_exclusion_polygon_count();
-
-    // iterate through exclusion polygons and create outer points
-    for (uint8_t i = 0; i < num_exclusion_polygons; i++) {
-        uint16_t num_points;
-        const Vector2f* boundary = fence->polyfence().get_exclusion_polygon(i, num_points);
-   
-        // for each point in exclusion polygon
-        // Note: boundary is "unclosed" meaning the last point is *not* the same as the first
-        uint16_t new_points = 0;
-        for (uint16_t j = 0; j < num_points; j++) {
-
-            // find points before and after current point (relative to current point)
-            const uint16_t before_idx = (j == 0) ? num_points-1 : j-1;
-            const uint16_t after_idx = (j == num_points-1) ? 0 : j+1;
-            Vector2f before_pt = boundary[before_idx] - boundary[j];
-            Vector2f after_pt = boundary[after_idx] - boundary[j];
-
-            // if points are overlapping fail
-            if (before_pt.is_zero() || after_pt.is_zero() || (before_pt == after_pt)) {
-                err_id = AP_OADijkstra_Error::DIJKSTRA_ERROR_OVERLAPPING_POLYGON_POINTS;
-                return false;
-            }
-
-            // scale points to be unit vectors
-            before_pt.normalize();
-            after_pt.normalize();
-
-            // calculate intermediate point and scale to margin
-            Vector2f intermediate_pt = after_pt + before_pt;
-            intermediate_pt.normalize();
-            intermediate_pt *= margin_cm;
-
-            // find final point which is outside the original polygon
-            Vector2f temp_point = boundary[j] + intermediate_pt;
-            if (!Polygon_outside(temp_point, boundary, num_points)) {
-                intermediate_pt *= -1;
-                temp_point = boundary[j] + intermediate_pt;
-                if (!Polygon_outside(temp_point, boundary, num_points)) {
-                    // could not find a point on either side that was outside the exclusion polygon so fail
-                    // this may happen if the exclusion polygon has overlapping lines
-                    err_id = AP_OADijkstra_Error::DIJKSTRA_ERROR_OVERLAPPING_POLYGON_LINES;
-                    return false;
-                }
-            }
-
-            // don't add points in corners
-            if (fabsf(intermediate_pt.angle() - before_pt.angle()) < M_PI_2) {
-                continue;
-            }
-
-            // expand array if required
-            if (!_exclusion_polygon_pts.expand_to_hold(_exclusion_polygon_numpoints + new_points + 1)) {
-                err_id = AP_OADijkstra_Error::DIJKSTRA_ERROR_OUT_OF_MEMORY;
-                return false;
-            }
-            // add point
-            _exclusion_polygon_pts[_exclusion_polygon_numpoints + new_points] = temp_point;
-            new_points++;
-        }
-
-        // update total number of points
-        _exclusion_polygon_numpoints += new_points;
-    }
-    return true;
-}
-
-// check if exclusion circles have been updated since create_exclusion_circle_with_margin was run
-// returns true if changed
-bool AP_OADijkstra::check_exclusion_circle_updated() const
-{
-    // exit immediately if fence is not enabled
-    const AC_Fence *fence = AC_Fence::get_singleton();
-    if (fence == nullptr) {
-        return false;
-    }
-    return (_exclusion_circle_update_ms != fence->polyfence().get_exclusion_circle_update_ms());
-}
-
-// create polygons around existing exclusion circles
-// returns true on success.  returns false on failure and err_id is updated
-bool AP_OADijkstra::create_exclusion_circle_with_margin(float margin_cm, AP_OADijkstra_Error &err_id)
-{
-    // exit immediately if fence is not enabled
-    const AC_Fence *fence = AC_Fence::get_singleton();
-    if (fence == nullptr) {
-        err_id = AP_OADijkstra_Error::DIJKSTRA_ERROR_FENCE_DISABLED;
-        return false;
-    }
-
-    // clear all points
-    _exclusion_circle_numpoints = 0;
-
-    // unit length offsets for polygon points around circles
-    const Vector2f unit_offsets[] = {
-            {cosf(radians(30)), cosf(radians(30-90))},  // north-east
-            {cosf(radians(90)), cosf(radians(90-90))},  // east
-            {cosf(radians(150)), cosf(radians(150-90))},// south-east
-            {cosf(radians(210)), cosf(radians(210-90))},// south-west
-            {cosf(radians(270)), cosf(radians(270-90))},// west
-            {cosf(radians(330)), cosf(radians(330-90))},// north-west
-    };
-    const uint8_t num_points_per_circle = ARRAY_SIZE(unit_offsets);
-
-    // expand polygon point array if required
-    const uint8_t num_exclusion_circles = fence->polyfence().get_exclusion_circle_count();
-    if (!_exclusion_circle_pts.expand_to_hold(num_exclusion_circles * num_points_per_circle)) {
-        err_id = AP_OADijkstra_Error::DIJKSTRA_ERROR_OUT_OF_MEMORY;
-        return false;
-    }
-
-    // iterate through exclusion circles and create outer polygon points
-    for (uint8_t i = 0; i < num_exclusion_circles; i++) {
-        Vector2f circle_pos_cm;
-        float radius;
-        if (fence->polyfence().get_exclusion_circle(i, circle_pos_cm, radius)) {
-            // scaler to ensure lines between points do not intersect circle
-            const float scaler = (1.0f / cosf(radians(180.0f / (float)num_points_per_circle))) * ((radius * 100.0f) + margin_cm);
-
-            // add points to array
-            for (uint8_t j = 0; j < num_points_per_circle; j++) {
-                _exclusion_circle_pts[_exclusion_circle_numpoints] = circle_pos_cm + (unit_offsets[j] * scaler);
-                _exclusion_circle_numpoints++;
-            }
-        }
-    }
-
-    // record fence update time so we don't process these exclusion circles again
-    _exclusion_circle_update_ms = fence->polyfence().get_exclusion_circle_update_ms();
-
-    return true;
-}
-
-// returns total number of points across all fence types
-uint16_t AP_OADijkstra::total_numpoints() const
-{
-    return _inclusion_polygon_numpoints + _exclusion_polygon_numpoints + _exclusion_circle_numpoints;
-}
-
-// get a single point across the total list of points from all fence types
-bool AP_OADijkstra::get_point(uint16_t index, Vector2f &point) const
-{
-    // sanity check index
-    if (index >= total_numpoints()) {
-        return false;
-    }
-
-    // return an inclusion polygon point
-    if (index < _inclusion_polygon_numpoints) {
-        point = _inclusion_polygon_pts[index];
-        return true;
-    }
-    index -= _inclusion_polygon_numpoints;
-
-    // return an exclusion polygon point
-    if (index < _exclusion_polygon_numpoints) {
-        point = _exclusion_polygon_pts[index];
-        return true;
-    }
-    index -= _exclusion_polygon_numpoints;
-
-    // return an exclusion circle point
-    if (index < _exclusion_circle_numpoints) {
-        point = _exclusion_circle_pts[index];
-        return true;
-    }
-
-    // we should never get here but just in case
-    return false;
-}
-
-// returns true if line segment intersects polygon or circular fence
-bool AP_OADijkstra::intersects_fence(const Vector2f &seg_start, const Vector2f &seg_end) const
-{
-    // return immediately if fence is not enabled
-    const AC_Fence *fence = AC_Fence::get_singleton();
-    if (fence == nullptr) {
-        return false;
-    }
-
-    // determine if segment crosses any of the inclusion polygons
-    uint16_t num_points = 0;
-    for (uint8_t i = 0; i < fence->polyfence().get_inclusion_polygon_count(); i++) {
-        const Vector2f* boundary = fence->polyfence().get_inclusion_polygon(i, num_points);
-        if (boundary != nullptr) {
-            Vector2f intersection;
-            if (Polygon_intersects(boundary, num_points, seg_start, seg_end, intersection)) {
-                return true;
-            }
-        }
-    }
-
-    // determine if segment crosses any of the exclusion polygons
-    for (uint8_t i = 0; i < fence->polyfence().get_exclusion_polygon_count(); i++) {
-        const Vector2f* boundary = fence->polyfence().get_exclusion_polygon(i, num_points);
-        if (boundary != nullptr) {
-            Vector2f intersection;
-            if (Polygon_intersects(boundary, num_points, seg_start, seg_end, intersection)) {
-                return true;
-            }
-        }
-    }
-
-    // determine if segment crosses any of the inclusion circles
-    for (uint8_t i = 0; i < fence->polyfence().get_inclusion_circle_count(); i++) {
-        Vector2f center_pos_cm;
-        float radius;
-        if (fence->polyfence().get_inclusion_circle(i, center_pos_cm, radius)) {
-            // intersects circle if either start or end is further from the center than the radius
-            const float radius_cm_sq = sq(radius * 100.0f) ;
-            if ((seg_start - center_pos_cm).length_squared() > radius_cm_sq) {
-                return true;
-            }
-            if ((seg_end - center_pos_cm).length_squared() > radius_cm_sq) {
-                return true;
-            }
-        }
-    }
-
-    // determine if segment crosses any of the exclusion circles
-    for (uint8_t i = 0; i < fence->polyfence().get_exclusion_circle_count(); i++) {
-        Vector2f center_pos_cm;
-        float radius;
-        if (fence->polyfence().get_exclusion_circle(i, center_pos_cm, radius)) {
-            // calculate distance between circle's center and segment
-            const float dist_cm = Vector2f::closest_distance_between_line_and_point(seg_start, seg_end, center_pos_cm);
-
-            // intersects if distance is less than radius
-            if (dist_cm <= (radius * 100.0f)) {
-                return true;
-            }
-        }
-    }
-
-    // if we got this far then no intersection
-    return false;
-}
-
-// create visibility graph for all fence (with margin) points
-// returns true on success.  returns false on failure and err_id is updated
-// requires these functions to have been run create_inclusion_polygon_with_margin, create_exclusion_polygon_with_margin, create_exclusion_circle_with_margin
-bool AP_OADijkstra::create_fence_visgraph(AP_OADijkstra_Error &err_id)
-{
-    // exit immediately if fence is not enabled
-    const AC_Fence *fence = AC_Fence::get_singleton();
-    if (fence == nullptr) {
-        err_id = AP_OADijkstra_Error::DIJKSTRA_ERROR_FENCE_DISABLED;
-        return false;
-    }
-
-    // fail if more fence points than algorithm can handle
-    if (total_numpoints() >= OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX) {
-        err_id = AP_OADijkstra_Error::DIJKSTRA_ERROR_TOO_MANY_FENCE_POINTS;
-        return false;
-    }
-
-    // clear fence points visibility graph
-    _fence_visgraph.clear();
-
-    // calculate distance from each point to all other points
-    for (uint8_t i = 0; i < total_numpoints() - 1; i++) {
-        Vector2f start_seg;
-        if (get_point(i, start_seg)) {
-            for (uint8_t j = i + 1; j < total_numpoints(); j++) {
-                Vector2f end_seg;
-                if (get_point(j, end_seg)) {
-                    // if line segment does not intersect with any inclusion or exclusion zones add to visgraph
-                    if (!intersects_fence(start_seg, end_seg)) {
-                        if (!_fence_visgraph.add_item({AP_OAVisGraph::OATYPE_INTERMEDIATE_POINT, i},
-                                                      {AP_OAVisGraph::OATYPE_INTERMEDIATE_POINT, j},
-                                                      (start_seg - end_seg).length())) {
-                            // failure to add a point can only be caused by out-of-memory
-                            err_id = AP_OADijkstra_Error::DIJKSTRA_ERROR_OUT_OF_MEMORY;
-                            return false;
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    return true;
-}
-
-// updates visibility graph for a given position which is an offset (in cm) from the ekf origin
-// to add an additional position (i.e. the destination) set add_extra_position = true and provide the position in the extra_position argument
-// requires create_inclusion_polygon_with_margin to have been run
-// returns true on success
-bool AP_OADijkstra::update_visgraph(AP_OAVisGraph& visgraph, const AP_OAVisGraph::OAItemID& oaid, const Vector2f &position, bool add_extra_position, Vector2f extra_position)
-{
-    // clear visibility graph
-    visgraph.clear();
-
-    // calculate distance from position to all inclusion/exclusion fence points
-    for (uint8_t i = 0; i < total_numpoints(); i++) {
-        Vector2f seg_end;
-        if (get_point(i, seg_end)) {
-            if (!intersects_fence(position, seg_end)) {
-                // line segment does not intersect with fences so add to visgraph
-                if (!visgraph.add_item(oaid, {AP_OAVisGraph::OATYPE_INTERMEDIATE_POINT, i}, (position - seg_end).length())) {
-                    return false;
-                }
-            }
-        }
-    }
-
-    // add extra point to visibility graph if it doesn't intersect with polygon fence or exclusion polygons
-    if (add_extra_position) {
-        if (!intersects_fence(position, extra_position)) {
-            if (!visgraph.add_item(oaid, {AP_OAVisGraph::OATYPE_DESTINATION, 0}, (position - extra_position).length())) {
-                return false;
-            }
-        }
-    }
-
-    return true;
-}
-
-// update total distance for all nodes visible from current node
-// curr_node_idx is an index into the _short_path_data array
-void AP_OADijkstra::update_visible_node_distances(node_index curr_node_idx)
-{
-    // sanity check
-    if (curr_node_idx >= _short_path_data_numpoints) {
-        return;
-    }
-
-    // get current node for convenience
-    const ShortPathNode &curr_node = _short_path_data[curr_node_idx];
-
-    // for each visibility graph
-    const AP_OAVisGraph* visgraphs[] = {&_fence_visgraph, &_destination_visgraph};
-    for (uint8_t v=0; v<ARRAY_SIZE(visgraphs); v++) {
-
-        // skip if empty
-        const AP_OAVisGraph &curr_visgraph = *visgraphs[v];
-        if (curr_visgraph.num_items() == 0) {
-            continue;
-        }
-
-        // search visibility graph for items visible from current_node
-        for (uint16_t i = 0; i < curr_visgraph.num_items(); i++) {
-            const AP_OAVisGraph::VisGraphItem &item = curr_visgraph[i];
-            // match if current node's id matches either of the id's in the graph (i.e. either end of the vector)
-            if ((curr_node.id == item.id1) || (curr_node.id == item.id2)) {
-                AP_OAVisGraph::OAItemID matching_id = (curr_node.id == item.id1) ? item.id2 : item.id1;
-                // find item's id in node array
-                node_index item_node_idx;
-                if (find_node_from_id(matching_id, item_node_idx)) {
-                    // if current node's distance + distance to item is less than item's current distance, update item's distance
-                    const float dist_to_item_via_current_node = _short_path_data[curr_node_idx].distance_cm + item.distance_cm;
-                    if (dist_to_item_via_current_node < _short_path_data[item_node_idx].distance_cm) {
-                        // update item's distance and set "distance_from_idx" to current node's index
-                        _short_path_data[item_node_idx].distance_cm = dist_to_item_via_current_node;
-                        _short_path_data[item_node_idx].distance_from_idx = curr_node_idx;
-                    }
-                }
-            }
-        }
-    }
-}
-
-// find a node's index into _short_path_data array from it's id (i.e. id type and id number)
-// returns true if successful and node_idx is updated
-bool AP_OADijkstra::find_node_from_id(const AP_OAVisGraph::OAItemID &id, node_index &node_idx) const
-{
-    switch (id.id_type) {
-    case AP_OAVisGraph::OATYPE_SOURCE:
-        // source node is always the first node
-        if (_short_path_data_numpoints > 0) {
-            node_idx = 0;
-            return true;
-        }
-        break;
-    case AP_OAVisGraph::OATYPE_DESTINATION:
-        // destination is always the 2nd node
-        if (_short_path_data_numpoints > 1) {
-            node_idx = 1;
-            return true;
-        }
-        break;
-    case AP_OAVisGraph::OATYPE_INTERMEDIATE_POINT:
-        // intermediate nodes start from 3rd node
-        if (_short_path_data_numpoints > id.id_num + 2) {
-            node_idx = id.id_num + 2;
-            return true;
-        }
-        break;
-    }
-
-    // could not find node
-    return false;
-}
-
-// find index of node with lowest tentative distance (ignore visited nodes)
-// returns true if successful and node_idx argument is updated
-bool AP_OADijkstra::find_closest_node_idx(node_index &node_idx) const
-{
-    node_index lowest_idx = 0;
-    float lowest_dist = FLT_MAX;
-
-    // scan through all nodes looking for closest
-    for (node_index i=0; i<_short_path_data_numpoints; i++) {
-        const ShortPathNode &node = _short_path_data[i];
-        if (node.visited || is_equal(_short_path_data[i].distance_cm, FLT_MAX)) {
-            // if node is already visited OR cannot be reached yet, we can't use it
-            continue;
-        }
-        // figure out the pos of this node
-        Vector2f node_pos;
-        float dist_with_heuristics = FLT_MAX;
-        if (convert_node_to_point(node.id, node_pos)) {
-            // heuristics is is simple Euclidean distance from the node to the destination
-            // This should be admissible, therefore optimal path is guaranteed
-            const float heuristics = (node_pos-_path_destination).length();
-            dist_with_heuristics = node.distance_cm + heuristics;
-        } else {
-            // shouldn't happen
-            return false;
-        }
-        if (dist_with_heuristics < lowest_dist) {
-            // for NOW, this is the closest node
-            lowest_idx = i;
-            lowest_dist = dist_with_heuristics;
-        }
-    }
-
-    if (lowest_dist < FLT_MAX) {
-        // found the closest node
-        node_idx = lowest_idx;
-        return true;
-    }
-    return false;
-}
-
-// calculate shortest path from origin to destination
-// returns true on success.  returns false on failure and err_id is updated
-// requires these functions to have been run: create_inclusion_polygon_with_margin, create_exclusion_polygon_with_margin, create_exclusion_circle_with_margin, create_polygon_fence_visgraph
-// resulting path is stored in _shortest_path array as vector offsets from EKF origin
-bool AP_OADijkstra::calc_shortest_path(const Location &origin, const Location &destination, AP_OADijkstra_Error &err_id)
-{
-    // convert origin and destination to offsets from EKF origin
-    if (!origin.get_vector_xy_from_origin_NE(_path_source) || !destination.get_vector_xy_from_origin_NE(_path_destination)) {
-        err_id = AP_OADijkstra_Error::DIJKSTRA_ERROR_NO_POSITION_ESTIMATE;
-        return false;
-    }
-
-    // create visgraphs of origin and destination to fence points
-    if (!update_visgraph(_source_visgraph, {AP_OAVisGraph::OATYPE_SOURCE, 0}, _path_source, true, _path_destination)) {
-        err_id = AP_OADijkstra_Error::DIJKSTRA_ERROR_OUT_OF_MEMORY;
-        return false;
-    }
-    if (!update_visgraph(_destination_visgraph, {AP_OAVisGraph::OATYPE_DESTINATION, 0}, _path_destination)) {
-        err_id = AP_OADijkstra_Error::DIJKSTRA_ERROR_OUT_OF_MEMORY;
-        return false;
-    }
-
-    // expand _short_path_data if necessary
-    if (!_short_path_data.expand_to_hold(2 + total_numpoints())) {
-        err_id = AP_OADijkstra_Error::DIJKSTRA_ERROR_OUT_OF_MEMORY;
-        return false;
-    }
-
-    // add origin and destination (node_type, id, visited, distance_from_idx, distance_cm) to short_path_data array
-    _short_path_data[0] = {{AP_OAVisGraph::OATYPE_SOURCE, 0}, false, 0, 0};
-    _short_path_data[1] = {{AP_OAVisGraph::OATYPE_DESTINATION, 0}, false, OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX, FLT_MAX};
-    _short_path_data_numpoints = 2;
-
-    // add all inclusion and exclusion fence points to short_path_data array (node_type, id, visited, distance_from_idx, distance_cm)
-    for (uint8_t i=0; i<total_numpoints(); i++) {
-        _short_path_data[_short_path_data_numpoints++] = {{AP_OAVisGraph::OATYPE_INTERMEDIATE_POINT, i}, false, OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX, FLT_MAX};
-    }
-
-    // start algorithm from source point
-    node_index current_node_idx = 0;
-
-    // update nodes visible from source point
-    for (uint16_t i = 0; i < _source_visgraph.num_items(); i++) {
-        node_index node_idx;
-        if (find_node_from_id(_source_visgraph[i].id2, node_idx)) {
-            _short_path_data[node_idx].distance_cm = _source_visgraph[i].distance_cm;
-            _short_path_data[node_idx].distance_from_idx = current_node_idx;
-        } else {
-            err_id = AP_OADijkstra_Error::DIJKSTRA_ERROR_COULD_NOT_FIND_PATH;
-            return false;
-        }
-    }
-    // mark source node as visited
-    _short_path_data[current_node_idx].visited = true;
-
-    // move current_node_idx to node with lowest distance
-    while (find_closest_node_idx(current_node_idx)) {
-        node_index dest_node;
-        // See if this next "closest" node is actually the destination
-        if (find_node_from_id({AP_OAVisGraph::OATYPE_DESTINATION,0}, dest_node) && current_node_idx == dest_node) {
-            // We have discovered destination.. Don't bother with the rest of the graph
-            break;
-        }
-        // update distances to all neighbours of current node
-        update_visible_node_distances(current_node_idx);
-
-        // mark current node as visited
-        _short_path_data[current_node_idx].visited = true;
-    }
-
-    // extract path starting from destination
-    bool success = false;
-    node_index nidx;
-    if (!find_node_from_id({AP_OAVisGraph::OATYPE_DESTINATION,0}, nidx)) {
-        err_id = AP_OADijkstra_Error::DIJKSTRA_ERROR_COULD_NOT_FIND_PATH;
-        return false;
-    }
-    _path_numpoints = 0;
-    while (true) {
-        if (!_path.expand_to_hold(_path_numpoints + 1)) {
-            err_id = AP_OADijkstra_Error::DIJKSTRA_ERROR_OUT_OF_MEMORY;
-            return false;
-        }
-        // fail if newest node has invalid distance_from_index
-        if ((_short_path_data[nidx].distance_from_idx == OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX) ||
-            (_short_path_data[nidx].distance_cm >= FLT_MAX)) {
-            break;
-        } else {
-            // add node's id to path array
-            _path[_path_numpoints] = _short_path_data[nidx].id;
-            _path_numpoints++;
-
-            // we are done if node is the source
-            if (_short_path_data[nidx].id.id_type == AP_OAVisGraph::OATYPE_SOURCE) {
-                success = true;
-                break;
-            } else {
-                // follow node's "distance_from_idx" to previous node on path
-                nidx = _short_path_data[nidx].distance_from_idx;
-            }
-        }
-    }
-    // report error in case path not found
-    if (!success) {
-        err_id = AP_OADijkstra_Error::DIJKSTRA_ERROR_COULD_NOT_FIND_PATH;
-    }
-
-    return success;
-}
-
-// return point from final path as an offset (in cm) from the ekf origin
-bool AP_OADijkstra::get_shortest_path_point(uint8_t point_num, Vector2f& pos) const
-{
-    if ((_path_numpoints == 0) || (point_num >= _path_numpoints)) {
-        return false;
-    }
-
-    // get id from path
-    AP_OAVisGraph::OAItemID id = _path[_path_numpoints - point_num - 1];
-
-    return convert_node_to_point(id, pos);
-}
-
-// find the position of a node as an offset (in cm) from the ekf origin
-bool AP_OADijkstra::convert_node_to_point(const AP_OAVisGraph::OAItemID& id, Vector2f& pos) const
-{
-    // convert id to a position offset from EKF origin
-    switch (id.id_type) {
-    case AP_OAVisGraph::OATYPE_SOURCE:
-        pos = _path_source;
-        return true;
-    case AP_OAVisGraph::OATYPE_DESTINATION:
-        pos = _path_destination;
-        return true;
-    case AP_OAVisGraph::OATYPE_INTERMEDIATE_POINT:
-        return get_point(id.id_num, pos);
-    }
-
-    // we should never reach here but just in case
-    return false;
-}
 #endif // AP_FENCE_ENABLED
 
 

--- a/libraries/AC_Avoidance/AP_OADijkstra.h
+++ b/libraries/AC_Avoidance/AP_OADijkstra.h
@@ -7,7 +7,9 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Common/Location.h>
 #include <AP_Math/AP_Math.h>
-#include "AP_OAVisGraph.h"
+#include "AP_OADijkstra_Common.h"
+#include "AP_OADijkstra_StaticData.h"
+#include "AP_OADijkstra_CalcPath.h"
 #include <AP_Logger/AP_Logger_config.h>
 
 /*
@@ -17,12 +19,12 @@
 class AP_OADijkstra {
 public:
 
-    AP_OADijkstra(AP_Int16 &options);
+    AP_OADijkstra(const AP_Int16 &options);
 
     CLASS_NO_COPY(AP_OADijkstra);  /* Do not allow copies */
 
     // set fence margin (in meters) used when creating "safe positions" within the polygon fence
-    void set_fence_margin(float margin) { _polyfence_margin = MAX(margin, 0.0f); }
+    void set_fence_margin(float margin) { _static_data.set_fence_margin(margin); }
 
     // trigger Dijkstra's to recalculate shortest path based on current location 
     void recalculate_path() { _shortest_path_ok = false; }
@@ -46,182 +48,31 @@ public:
                                Location& next_destination_new,
                                bool& dest_to_next_dest_clear);
 
+    // return the path length in meters
+    float get_path_length() const { return _shortest_path_ok ? _shortest_path.length_cm * 0.01 : 0; }
+
 private:
 
-    // returns true if at least one inclusion or exclusion zone is enabled
-    bool some_fences_enabled() const;
-
-    enum class AP_OADijkstra_Error : uint8_t {
-        DIJKSTRA_ERROR_NONE = 0,
-        DIJKSTRA_ERROR_OUT_OF_MEMORY,
-        DIJKSTRA_ERROR_OVERLAPPING_POLYGON_POINTS,
-        DIJKSTRA_ERROR_FAILED_TO_BUILD_INNER_POLYGON,
-        DIJKSTRA_ERROR_OVERLAPPING_POLYGON_LINES,
-        DIJKSTRA_ERROR_FENCE_DISABLED,
-        DIJKSTRA_ERROR_TOO_MANY_FENCE_POINTS,
-        DIJKSTRA_ERROR_NO_POSITION_ESTIMATE,
-        DIJKSTRA_ERROR_COULD_NOT_FIND_PATH
-    } _error_id;
-
-    // return error message for a given error id
-    const char* get_error_msg(AP_OADijkstra_Error error_id) const;
-
-    // report error to ground station
-    void report_error(AP_OADijkstra_Error error_id);
-
-    //
-    // inclusion polygon methods
-    //
-
-    // check if inclusion polygons have been updated since create_inclusion_polygon_with_margin was run
-    // returns true if changed
-    bool check_inclusion_polygon_updated() const;
-
-    // create polygons inside the existing inclusion polygons
-    // returns true on success.  returns false on failure and err_id is updated
-    bool create_inclusion_polygon_with_margin(float margin_cm, AP_OADijkstra_Error &err_id);
-
-    //
-    // exclusion polygon methods
-    //
-
-    // check if exclusion polygons have been updated since create_exclusion_polygon_with_margin was run
-    // returns true if changed
-    bool check_exclusion_polygon_updated() const;
-
-    // create polygons around existing exclusion polygons
-    // returns true on success.  returns false on failure and err_id is updated
-    bool create_exclusion_polygon_with_margin(float margin_cm, AP_OADijkstra_Error &err_id);
-
-    //
-    // exclusion circle methods
-    //
-
-    // check if exclusion circles have been updated since create_exclusion_circle_with_margin was run
-    // returns true if changed
-    bool check_exclusion_circle_updated() const;
-
-    // create polygons around existing exclusion circles
-    // returns true on success.  returns false on failure and err_id is updated
-    bool create_exclusion_circle_with_margin(float margin_cm, AP_OADijkstra_Error &err_id);
-
-    //
-    // other methods
-    //
-
-    // returns total number of points across all fence types
-    uint16_t total_numpoints() const;
-
-    // get a single point across the total list of points from all fence types
-    // also returns the type of point
-    bool get_point(uint16_t index, Vector2f& point) const;
-
-    // returns true if line segment intersects polygon or circular fence
-    bool intersects_fence(const Vector2f &seg_start, const Vector2f &seg_end) const;
-
-    // create visibility graph for all fence (with margin) points
-    // returns true on success.  returns false on failure and err_id is updated
-    bool create_fence_visgraph(AP_OADijkstra_Error &err_id);
-
-    // calculate shortest path from origin to destination
-    // returns true on success.  returns false on failure and err_id is updated
-    // requires create_polygon_fence_with_margin and create_polygon_fence_visgraph to have been run
-    // resulting path is stored in _shortest_path array as vector offsets from EKF origin
-    bool calc_shortest_path(const Location &origin, const Location &destination, AP_OADijkstra_Error &err_id);
-
-    // shortest path state variables
-    bool _inclusion_polygon_with_margin_ok;
-    bool _exclusion_polygon_with_margin_ok;
-    bool _exclusion_circle_with_margin_ok;
-    bool _polyfence_visgraph_ok;
-    bool _shortest_path_ok;
+    bool _shortest_path_ok;                         // shortest path is up-to-date
+    AP_OADijkstra_CalcPath::Path _shortest_path;    // shortest path from source to destination
 
     Location _destination_prev;     // destination of previous iterations (used to determine if path should be re-calculated)
     Location _next_destination_prev;// next_destination of previous iterations (used to determine if path should be re-calculated)
     uint8_t _path_idx_returned;     // index into _path array which gives location vehicle should be currently moving towards
     bool _dest_to_next_dest_clear;  // true if path from dest to next_dest is clear (i.e. does not intersects a fence)
 
-    // inclusion polygon (with margin) related variables
-    float _polyfence_margin = 10;           // margin around polygon defaults to 10m but is overriden with set_fence_margin
-    AP_ExpandingArray<Vector2f> _inclusion_polygon_pts; // array of nodes corresponding to inclusion polygon points plus a margin
-    uint8_t _inclusion_polygon_numpoints;   // number of points held in above array
-    uint32_t _inclusion_polygon_update_ms;  // system time of boundary update from AC_Fence (used to detect changes to polygon fence)
-
-    // exclusion polygon related variables
-    AP_ExpandingArray<Vector2f> _exclusion_polygon_pts; // array of nodes corresponding to exclusion polygon points plus a margin
-    uint8_t _exclusion_polygon_numpoints;   // number of points held in above array
-    uint32_t _exclusion_polygon_update_ms;  // system time exclusion polygon was updated (used to detect changes)
-
-    // exclusion circle related variables
-    AP_ExpandingArray<Vector2f> _exclusion_circle_pts; // array of nodes surrounding exclusion circles plus a margin
-    uint8_t _exclusion_circle_numpoints;    // number of points held in above array
-    uint32_t _exclusion_circle_update_ms;   // system time exclusion circles were updated (used to detect changes)
-
-    // visibility graphs
-    AP_OAVisGraph _fence_visgraph;          // holds distances between all inclusion/exclusion fence points (with margin)
-    AP_OAVisGraph _source_visgraph;         // holds distances from source point to all other nodes
-    AP_OAVisGraph _destination_visgraph;    // holds distances from the destination to all other nodes
-
-    // updates visibility graph for a given position which is an offset (in cm) from the ekf origin
-    // to add an additional position (i.e. the destination) set add_extra_position = true and provide the position in the extra_position argument
-    // requires create_polygon_fence_with_margin to have been run
-    // returns true on success
-    bool update_visgraph(AP_OAVisGraph& visgraph, const AP_OAVisGraph::OAItemID& oaid, const Vector2f &position, bool add_extra_position = false, Vector2f extra_position = Vector2f(0,0));
-
-    typedef uint8_t node_index;         // indices into short path data
-    struct ShortPathNode {
-        AP_OAVisGraph::OAItemID id;     // unique id for node (combination of type and id number)
-        bool visited;                   // true if all this node's neighbour's distances have been updated
-        node_index distance_from_idx;   // index into _short_path_data from where distance was updated (or 255 if not set)
-        float distance_cm;              // distance from source (number is tentative until this node is the current node and/or visited = true)
-    };
-    AP_ExpandingArray<ShortPathNode> _short_path_data;
-    node_index _short_path_data_numpoints;  // number of elements in _short_path_data array
-
-    // update total distance for all nodes visible from current node
-    // curr_node_idx is an index into the _short_path_data array
-    void update_visible_node_distances(node_index curr_node_idx);
-
-    // find a node's index into _short_path_data array from it's id (i.e. id type and id number)
-    // returns true if successful and node_idx is updated
-    bool find_node_from_id(const AP_OAVisGraph::OAItemID &id, node_index &node_idx) const;
-
-    // find index of node with lowest tentative distance (ignore visited nodes)
-    // returns true if successful and node_idx argument is updated
-    bool find_closest_node_idx(node_index &node_idx) const;
-
-    // final path variables and functions
-    AP_ExpandingArray<AP_OAVisGraph::OAItemID> _path;   // ids of points on return path in reverse order (i.e. destination is first element)
-    uint8_t _path_numpoints;                            // number of points on return path
-    Vector2f _path_source;                              // source point used in shortest path calculations (offset in cm from EKF origin)
-    Vector2f _path_destination;                         // destination position used in shortest path calculations (offset in cm from EKF origin)
-
-    // return number of points on path
-    uint8_t get_shortest_path_numpoints() const { return _path_numpoints; }
-
-    // return point from final path as an offset (in cm) from the ekf origin
-    bool get_shortest_path_point(uint8_t point_num, Vector2f& pos) const;
-
-    // find the position of a node as an offset (in cm) from the ekf origin
-    // returns true if successful and pos is updated
-    bool convert_node_to_point(const AP_OAVisGraph::OAItemID& id, Vector2f& pos) const;
-
-    AP_OADijkstra_Error _error_last_id;                 // last error id sent to GCS
-    uint32_t _error_last_report_ms;                     // last time an error message was sent to GCS
-
 #if HAL_LOGGING_ENABLED
     // Logging functions
     void Write_OADijkstra(const uint8_t state, const uint8_t error_id, const uint8_t curr_point, const uint8_t tot_points, const Location &final_dest, const Location &oa_dest) const;
-    void Write_Visgraph_point(const uint8_t version, const uint8_t point_num, const int32_t Lat, const int32_t Lon) const;
 #else
     void Write_OADijkstra(const uint8_t state, const uint8_t error_id, const uint8_t curr_point, const uint8_t tot_points, const Location &final_dest, const Location &oa_dest) const {}
-    void Write_Visgraph_point(const uint8_t version, const uint8_t point_num, const int32_t Lat, const int32_t Lon) const {}
 #endif
-    uint8_t _log_num_points;
-    uint8_t _log_visgraph_version;
 
-    // reference to AP_OAPathPlanner options param
-    AP_Int16 &_options;
+    // reference to AP_OAPathPlanner options param, static data and calc path
+    const AP_Int16 &_options;
+    AP_OADijkstra_Common _common;
+    AP_OADijkstra_StaticData _static_data;
+    AP_OADijkstra_CalcPath _calcpath;
 };
 
 #endif  // AP_OAPATHPLANNER_DIJKSTRA_ENABLED

--- a/libraries/AC_Avoidance/AP_OADijkstra.h
+++ b/libraries/AC_Avoidance/AP_OADijkstra.h
@@ -51,10 +51,17 @@ public:
     // return the path length in meters
     float get_path_length() const { return _shortest_path_ok ? _shortest_path.length_cm * 0.01 : 0; }
 
+    // calculate the length of a path between origin and destination in meters
+    // this calculation takes time and should only be run from a background thread
+    // returns true on success and fills in path_length argument
+    // called by AP_OAPathPlanner::get_path_length()
+    bool get_path_length(const Location &origin, const Location& destination, float& path_length);
+
 private:
 
     bool _shortest_path_ok;                         // shortest path is up-to-date
     AP_OADijkstra_CalcPath::Path _shortest_path;    // shortest path from source to destination
+    AP_OADijkstra_CalcPath::Path _secondary_path;   // secondary path used to reply to get_path_length requests
 
     Location _destination_prev;     // destination of previous iterations (used to determine if path should be re-calculated)
     Location _next_destination_prev;// next_destination of previous iterations (used to determine if path should be re-calculated)

--- a/libraries/AC_Avoidance/AP_OADijkstra_CalcPath.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra_CalcPath.cpp
@@ -1,0 +1,349 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AC_Avoidance_config.h"
+
+#if AP_OAPATHPLANNER_DIJKSTRA_ENABLED
+
+#include "AP_OADijkstra_CalcPath.h"
+#include "AP_OAPathPlanner.h"
+
+#include <AC_Fence/AC_Fence.h>
+
+#if AP_FENCE_ENABLED
+
+#include <AP_AHRS/AP_AHRS.h>
+#include <AP_Logger/AP_Logger.h>
+#include <GCS_MAVLink/GCS.h>
+
+#define OA_DIJKSTRA_EXPANDING_ARRAY_ELEMENTS_PER_CHUNK  32      // expanding arrays for fence points and paths to destination will grow in increments of 20 elements
+#define OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX        255     // index use to indicate we do not have a tentative short path for a node
+
+/// constructor
+AP_OADijkstra_CalcPath::AP_OADijkstra_CalcPath(const AP_OADijkstra_StaticData& static_data) :
+    _short_path_data(OA_DIJKSTRA_EXPANDING_ARRAY_ELEMENTS_PER_CHUNK),
+    _static_data(static_data)
+{
+}
+
+    // path structure
+AP_OADijkstra_CalcPath::Path::Path() :
+    pos(OA_DIJKSTRA_EXPANDING_ARRAY_ELEMENTS_PER_CHUNK)
+{
+}
+
+// return a position from the path as an offset (in cm) from the ekf origin
+// index 0 is the first point (e.g the source), index of nums_pos-1 is the destination
+// returns true on success and fills in the pos_ne argument
+bool AP_OADijkstra_CalcPath::Path::get_position(uint8_t index, Vector2f& pos_ne) const
+{
+    // sanitcy check index
+    if (index >= num_pos) {
+        return false;
+    }
+    pos_ne = pos[num_pos - index - 1];
+    return true;
+}
+
+// calculate shortest path from origin to destination
+// returns true on success.  returns false on failure and err_id is updated
+// requires these functions to have been run: create_inclusion_polygon_with_margin, create_exclusion_polygon_with_margin, create_exclusion_circle_with_margin, create_polygon_fence_visgraph
+// resulting path is stored in _shortest_path array as vector offsets from EKF origin
+bool AP_OADijkstra_CalcPath::calc_shortest_path(const Location &origin, const Location &destination, Path& path, AP_OADijkstra_Common::ErrorId &err_id)
+{
+    // convert origin and destination to offsets from EKF origin
+    if (!origin.get_vector_xy_from_origin_NE(path.source) || !destination.get_vector_xy_from_origin_NE(path.destination)) {
+        err_id = AP_OADijkstra_Common::ErrorId::DIJKSTRA_ERROR_NO_POSITION_ESTIMATE;
+        return false;
+    }
+
+    // create visgraphs of origin and destination to fence points
+    if (!update_visgraph(_source_visgraph, {AP_OAVisGraph::OATYPE_SOURCE, 0}, path.source, true, path.destination)) {
+        err_id = AP_OADijkstra_Common::ErrorId::DIJKSTRA_ERROR_OUT_OF_MEMORY;
+        return false;
+    }
+    if (!update_visgraph(_destination_visgraph, {AP_OAVisGraph::OATYPE_DESTINATION, 0}, path.destination)) {
+        err_id = AP_OADijkstra_Common::ErrorId::DIJKSTRA_ERROR_OUT_OF_MEMORY;
+        return false;
+    }
+
+    // expand _short_path_data if necessary
+    if (!_short_path_data.expand_to_hold(2 + _static_data.total_numpoints())) {
+        err_id = AP_OADijkstra_Common::ErrorId::DIJKSTRA_ERROR_OUT_OF_MEMORY;
+        return false;
+    }
+
+    // add origin and destination (node_type, id, visited, distance_from_idx, distance_cm) to short_path_data array
+    _short_path_data[0] = {{AP_OAVisGraph::OATYPE_SOURCE, 0}, false, 0, 0};
+    _short_path_data[1] = {{AP_OAVisGraph::OATYPE_DESTINATION, 0}, false, OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX, FLT_MAX};
+    _short_path_data_numpoints = 2;
+
+    // add all inclusion and exclusion fence points to short_path_data array (node_type, id, visited, distance_from_idx, distance_cm)
+    for (uint8_t i=0; i<_static_data.total_numpoints(); i++) {
+        _short_path_data[_short_path_data_numpoints++] = {{AP_OAVisGraph::OATYPE_INTERMEDIATE_POINT, i}, false, OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX, FLT_MAX};
+    }
+
+    // start algorithm from source point
+    node_index current_node_idx = 0;
+
+    // update nodes visible from source point
+    for (uint16_t i = 0; i < _source_visgraph.num_items(); i++) {
+        node_index node_idx;
+        if (find_node_from_id(_source_visgraph[i].id2, node_idx)) {
+            _short_path_data[node_idx].distance_cm = _source_visgraph[i].distance_cm;
+            _short_path_data[node_idx].distance_from_idx = current_node_idx;
+        } else {
+            err_id = AP_OADijkstra_Common::ErrorId::DIJKSTRA_ERROR_COULD_NOT_FIND_PATH;
+            return false;
+        }
+    }
+    // mark source node as visited
+    _short_path_data[current_node_idx].visited = true;
+
+    // move current_node_idx to node with lowest distance
+   while (find_closest_node_idx(path, current_node_idx)) {
+        node_index dest_node;
+        // see if this next "closest" node is actually the destination
+        if (find_node_from_id({AP_OAVisGraph::OATYPE_DESTINATION,0}, dest_node) && current_node_idx == dest_node) {
+            // We have discovered destination.. Don't bother with the rest of the graph
+            break;
+        }
+        // update distances to all neighbours of current node
+        update_visible_node_distances(current_node_idx);
+
+        // mark current node as visited
+        _short_path_data[current_node_idx].visited = true;
+    }
+
+    // extract path starting from destination
+    bool success = false;
+    node_index nidx;
+    if (!find_node_from_id({AP_OAVisGraph::OATYPE_DESTINATION,0}, nidx)) {
+        err_id = AP_OADijkstra_Common::ErrorId::DIJKSTRA_ERROR_COULD_NOT_FIND_PATH;
+        return false;
+    }
+    path.num_pos = 0;
+    path.length_cm = 0;
+    while (true) {
+        if (!path.pos.expand_to_hold(path.num_pos + 1)) {
+            err_id = AP_OADijkstra_Common::ErrorId::DIJKSTRA_ERROR_OUT_OF_MEMORY;
+            return false;
+        }
+        // fail if newest node has invalid distance_from_index
+        if ((_short_path_data[nidx].distance_from_idx == OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX) ||
+            (_short_path_data[nidx].distance_cm >= FLT_MAX)) {
+            break;
+        } else {
+            // add position to path array
+            Vector2f next_pos;
+            if (!convert_node_to_point(path, _short_path_data[nidx].id, next_pos)) {
+                // this should never happen
+                err_id = AP_OADijkstra_Common::ErrorId::DIJKSTRA_ERROR_COULD_NOT_FIND_PATH;
+                return false;
+            }
+            path.pos[path.num_pos] = next_pos;
+            path.num_pos++;
+            path.length_cm += _short_path_data[nidx].distance_cm;
+
+            // we are done if node is the source
+            if (_short_path_data[nidx].id.id_type == AP_OAVisGraph::OATYPE_SOURCE) {
+                success = true;
+                break;
+            } else {
+                // follow node's "distance_from_idx" to previous node on path
+                nidx = _short_path_data[nidx].distance_from_idx;
+            }
+        }
+    }
+    // report error in case path not found
+    if (!success) {
+        err_id = AP_OADijkstra_Common::ErrorId::DIJKSTRA_ERROR_COULD_NOT_FIND_PATH;
+    }
+
+    return success;
+}
+
+// updates visibility graph for a given position which is an offset (in cm) from the ekf origin
+// to add an additional position (i.e. the destination) set add_extra_position = true and provide the position in the extra_position argument
+// requires create_inclusion_polygon_with_margin to have been run
+// returns true on success
+bool AP_OADijkstra_CalcPath::update_visgraph(AP_OAVisGraph& visgraph, const AP_OAVisGraph::OAItemID& oaid, const Vector2f &position, bool add_extra_position, Vector2f extra_position)
+{
+    // clear visibility graph
+    visgraph.clear();
+
+    // calculate distance from position to all inclusion/exclusion fence points
+    for (uint8_t i = 0; i < _static_data.total_numpoints(); i++) {
+        Vector2f seg_end;
+        if (_static_data.get_point(i, seg_end)) {
+            if (!_static_data.intersects_fence(position, seg_end)) {
+                // line segment does not intersect with fences so add to visgraph
+                if (!visgraph.add_item(oaid, {AP_OAVisGraph::OATYPE_INTERMEDIATE_POINT, i}, (position - seg_end).length())) {
+                    return false;
+                }
+            }
+        }
+    }
+
+    // add extra point to visibility graph if it doesn't intersect with polygon fence or exclusion polygons
+    if (add_extra_position) {
+        if (!_static_data.intersects_fence(position, extra_position)) {
+            if (!visgraph.add_item(oaid, {AP_OAVisGraph::OATYPE_DESTINATION, 0}, (position - extra_position).length())) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+// update total distance for all nodes visible from current node
+// curr_node_idx is an index into the _short_path_data array
+void AP_OADijkstra_CalcPath::update_visible_node_distances(node_index curr_node_idx)
+{
+    // sanity check
+    if (curr_node_idx >= _short_path_data_numpoints) {
+        return;
+    }
+
+    // get current node for convenience
+    const ShortPathNode &curr_node = _short_path_data[curr_node_idx];
+
+    // for each visibility graph
+    const AP_OAVisGraph* visgraphs[] = {&_static_data.get_fence_visgraph(), &_destination_visgraph};
+    for (uint8_t v=0; v<ARRAY_SIZE(visgraphs); v++) {
+
+        // skip if empty
+        const AP_OAVisGraph &curr_visgraph = *visgraphs[v];
+        if (curr_visgraph.num_items() == 0) {
+            continue;
+        }
+
+        // search visibility graph for items visible from current_node
+        for (uint16_t i = 0; i < curr_visgraph.num_items(); i++) {
+            const AP_OAVisGraph::VisGraphItem &item = curr_visgraph[i];
+            // match if current node's id matches either of the id's in the graph (i.e. either end of the vector)
+            if ((curr_node.id == item.id1) || (curr_node.id == item.id2)) {
+                AP_OAVisGraph::OAItemID matching_id = (curr_node.id == item.id1) ? item.id2 : item.id1;
+                // find item's id in node array
+                node_index item_node_idx;
+                if (find_node_from_id(matching_id, item_node_idx)) {
+                    // if current node's distance + distance to item is less than item's current distance, update item's distance
+                    const float dist_to_item_via_current_node = _short_path_data[curr_node_idx].distance_cm + item.distance_cm;
+                    if (dist_to_item_via_current_node < _short_path_data[item_node_idx].distance_cm) {
+                        // update item's distance and set "distance_from_idx" to current node's index
+                        _short_path_data[item_node_idx].distance_cm = dist_to_item_via_current_node;
+                        _short_path_data[item_node_idx].distance_from_idx = curr_node_idx;
+                    }
+                }
+            }
+        }
+    }
+}
+
+// find a node's index into _short_path_data array from it's id (i.e. id type and id number)
+// returns true if successful and node_idx is updated
+bool AP_OADijkstra_CalcPath::find_node_from_id(const AP_OAVisGraph::OAItemID &id, node_index &node_idx) const
+{
+    switch (id.id_type) {
+    case AP_OAVisGraph::OATYPE_SOURCE:
+        // source node is always the first node
+        if (_short_path_data_numpoints > 0) {
+            node_idx = 0;
+            return true;
+        }
+        break;
+    case AP_OAVisGraph::OATYPE_DESTINATION:
+        // destination is always the 2nd node
+        if (_short_path_data_numpoints > 1) {
+            node_idx = 1;
+            return true;
+        }
+        break;
+    case AP_OAVisGraph::OATYPE_INTERMEDIATE_POINT:
+        // intermediate nodes start from 3rd node
+        if (_short_path_data_numpoints > id.id_num + 2) {
+            node_idx = id.id_num + 2;
+            return true;
+        }
+        break;
+    }
+
+    // could not find node
+    return false;
+}
+
+// find index of node with lowest tentative distance (ignore visited nodes)
+// returns true if successful and node_idx argument is updated
+bool AP_OADijkstra_CalcPath::find_closest_node_idx(const Path& path, node_index &node_idx) const
+{
+    node_index lowest_idx = 0;
+    float lowest_dist = FLT_MAX;
+
+    // scan through all nodes looking for closest
+    for (node_index i=0; i<_short_path_data_numpoints; i++) {
+        const ShortPathNode &node = _short_path_data[i];
+        if (node.visited || is_equal(_short_path_data[i].distance_cm, FLT_MAX)) {
+            // if node is already visited OR cannot be reached yet, we can't use it
+            continue;
+        }
+        // figure out the pos of this node
+        Vector2f node_pos;
+        float dist_with_heuristics = FLT_MAX;
+        if (convert_node_to_point(path, node.id, node_pos)) {
+            // heuristics is is simple Euclidean distance from the node to the destination
+            // This should be admissible, therefore optimal path is guaranteed
+            const float heuristics = (node_pos-path.destination).length();
+            dist_with_heuristics = node.distance_cm + heuristics;
+        } else {
+            // shouldn't happen
+            return false;
+        }
+        if (dist_with_heuristics < lowest_dist) {
+            // for NOW, this is the closest node
+            lowest_idx = i;
+            lowest_dist = dist_with_heuristics;
+        }
+    }
+
+    if (lowest_dist < FLT_MAX) {
+        // found the closest node
+        node_idx = lowest_idx;
+        return true;
+    }
+    return false;
+}
+
+// find the position of a node as an offset (in cm) from the ekf origin
+bool AP_OADijkstra_CalcPath::convert_node_to_point(const Path& path, const AP_OAVisGraph::OAItemID& id, Vector2f& pos) const
+{
+    // convert id to a position offset from EKF origin
+    switch (id.id_type) {
+    case AP_OAVisGraph::OATYPE_SOURCE:
+        pos = path.source;
+        return true;
+    case AP_OAVisGraph::OATYPE_DESTINATION:
+        pos = path.destination;
+        return true;
+    case AP_OAVisGraph::OATYPE_INTERMEDIATE_POINT:
+        return _static_data.get_point(id.id_num, pos);
+    }
+
+    // we should never reach here but just in case
+    return false;
+}
+#endif // AP_FENCE_ENABLED
+
+#endif  // AP_OAPATHPLANNER_DIJKSTRA_ENABLED

--- a/libraries/AC_Avoidance/AP_OADijkstra_CalcPath.h
+++ b/libraries/AC_Avoidance/AP_OADijkstra_CalcPath.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include "AC_Avoidance_config.h"
+
+#if AP_OAPATHPLANNER_DIJKSTRA_ENABLED
+
+#include <AP_Common/AP_Common.h>
+#include <AP_Common/Location.h>
+#include <AP_Math/AP_Math.h>
+#include "AP_OADijkstra_Common.h"
+#include "AP_OAVisGraph.h"
+#include "AP_OADijkstra_StaticData.h"
+#include <AP_Logger/AP_Logger_config.h>
+
+/*
+ * Dijkstra's algorithm for path planning around polygon fence
+ */
+
+class AP_OADijkstra_CalcPath {
+public:
+
+    // constructor
+    AP_OADijkstra_CalcPath(const AP_OADijkstra_StaticData& static_data);
+
+    CLASS_NO_COPY(AP_OADijkstra_CalcPath);  /* Do not allow copies */
+
+    // path structure
+    class Path {
+        public:
+        // constuctor
+        Path();
+
+        CLASS_NO_COPY(Path);                 /* Do not allow copies */
+        uint8_t num_pos;                    // number of position on return path
+        Vector2f source;                    // source point used in shortest path calculations (offset in cm from EKF origin)
+        Vector2f destination;               // destination position used in shortest path calculations (offset in cm from EKF origin)
+        float length_cm;                    // length of path to destination in cm
+        AP_ExpandingArray<Vector2f> pos;    // positions on return path in reverse order (i.e. destination is first element)
+
+        // return a position from the path as an offset (in cm) from the ekf origin
+        // index 0 is the first point (e.g the source), index of nums_pos-1 is the destination
+        // returns true on success and fills in the pos_ne argument
+        bool get_position(uint8_t index, Vector2f& pos_ne) const;
+    };
+
+    // calculate shortest path from origin to destination
+    // returns true on success.  returns false on failure and err_id is updated
+    // requires create_polygon_fence_with_margin and create_polygon_fence_visgraph to have been run
+    // path argument is updated with resulting path, an array of vector offsets from EKF origin
+    bool calc_shortest_path(const Location &origin, const Location &destination, Path& path, AP_OADijkstra_Common::ErrorId &err_id);
+
+private:
+
+    //
+    // other methods
+    //
+
+    // visibility graphs
+    AP_OAVisGraph _source_visgraph;         // holds distances from source point to all other nodes
+    AP_OAVisGraph _destination_visgraph;    // holds distances from the destination to all other nodes
+
+    // updates visibility graph for a given position which is an offset (in cm) from the ekf origin
+    // to add an additional position (i.e. the destination) set add_extra_position = true and provide the position in the extra_position argument
+    // requires create_polygon_fence_with_margin to have been run
+    // returns true on success
+    bool update_visgraph(AP_OAVisGraph& visgraph, const AP_OAVisGraph::OAItemID& oaid, const Vector2f &position, bool add_extra_position = false, Vector2f extra_position = Vector2f(0,0));
+
+    typedef uint8_t node_index;         // indices into short path data
+    struct ShortPathNode {
+        AP_OAVisGraph::OAItemID id;     // unique id for node (combination of type and id number)
+        bool visited;                   // true if all this node's neighbour's distances have been updated
+        node_index distance_from_idx;   // index into _short_path_data from where distance was updated (or 255 if not set)
+        float distance_cm;              // distance from source (number is tentative until this node is the current node and/or visited = true)
+    };
+    AP_ExpandingArray<ShortPathNode> _short_path_data;
+    node_index _short_path_data_numpoints;  // number of elements in _short_path_data array
+
+    // update total distance for all nodes visible from current node
+    // curr_node_idx is an index into the _short_path_data array
+    void update_visible_node_distances(node_index curr_node_idx);
+
+    // find a node's index into _short_path_data array from it's id (i.e. id type and id number)
+    // returns true if successful and node_idx is updated
+    bool find_node_from_id(const AP_OAVisGraph::OAItemID &id, node_index &node_idx) const;
+
+    // find index of node with lowest tentative distance (ignore visited nodes)
+    // path is required because destination is used
+    // returns true if successful and node_idx argument is updated
+    bool find_closest_node_idx(const Path& path, node_index &node_idx) const;
+
+    // find the position of a node as an offset (in cm) from the ekf origin
+    // path is required because source or destination may be returned
+    // returns true if successful and pos is updated
+    bool convert_node_to_point(const Path& path, const AP_OAVisGraph::OAItemID& id, Vector2f& pos) const;
+
+    // references
+    const AP_OADijkstra_StaticData& _static_data;
+};
+
+#endif  // AP_OAPATHPLANNER_DIJKSTRA_ENABLED

--- a/libraries/AC_Avoidance/AP_OADijkstra_Common.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra_Common.cpp
@@ -1,0 +1,80 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AC_Avoidance_config.h"
+
+#if AP_OAPATHPLANNER_DIJKSTRA_ENABLED
+#if AP_FENCE_ENABLED
+
+#include <AP_AHRS/AP_AHRS.h>
+#include <AP_Logger/AP_Logger.h>
+#include <GCS_MAVLink/GCS.h>
+#include "AP_OADijkstra_Common.h"
+
+#define OA_DIJKSTRA_ERROR_REPORTING_INTERVAL_MS         5000    // failure messages sent to GCS every 5 seconds
+
+// return error message for a given error id
+const char* AP_OADijkstra_Common::get_error_msg(ErrorId error_id) const
+{
+    switch (error_id) {
+    case ErrorId::DIJKSTRA_ERROR_NONE:
+        return "no error";
+        break;
+    case ErrorId::DIJKSTRA_ERROR_OUT_OF_MEMORY:
+        return "out of memory";
+        break;
+    case ErrorId::DIJKSTRA_ERROR_OVERLAPPING_POLYGON_POINTS:
+        return "overlapping polygon points";
+        break;
+    case ErrorId::DIJKSTRA_ERROR_FAILED_TO_BUILD_INNER_POLYGON:
+        return "failed to build inner polygon";
+        break;
+    case ErrorId::DIJKSTRA_ERROR_OVERLAPPING_POLYGON_LINES:
+        return "overlapping polygon lines";
+        break;
+    case ErrorId::DIJKSTRA_ERROR_FENCE_DISABLED:
+        return "fence disabled";
+        break;
+    case ErrorId::DIJKSTRA_ERROR_TOO_MANY_FENCE_POINTS:
+        return "too many fence points";
+        break;
+    case ErrorId::DIJKSTRA_ERROR_NO_POSITION_ESTIMATE:
+        return "no position estimate";
+        break;
+    case ErrorId::DIJKSTRA_ERROR_COULD_NOT_FIND_PATH:
+        return "could not find path";
+        break;
+    }
+
+    // we should never reach here but just in case
+    return "unknown error";
+}
+
+void AP_OADijkstra_Common::report_error(ErrorId error_id)
+{
+    // report errors to GCS every 5 seconds
+    uint32_t now_ms = AP_HAL::millis();
+    if ((error_id != ErrorId::DIJKSTRA_ERROR_NONE) &&
+        ((error_id != _error_last_id) || ((now_ms - _error_last_report_ms) > OA_DIJKSTRA_ERROR_REPORTING_INTERVAL_MS))) {
+        const char* error_msg = get_error_msg(error_id);
+        (void)error_msg;  // in case !HAL_GCS_ENABLED
+        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Dijkstra: %s", error_msg);
+        _error_last_id = error_id;
+        _error_last_report_ms = now_ms;
+    }
+}
+
+#endif // AP_FENCE_ENABLED
+#endif // AP_OAPATHPLANNER_DIJKSTRA_ENABLED

--- a/libraries/AC_Avoidance/AP_OADijkstra_Common.h
+++ b/libraries/AC_Avoidance/AP_OADijkstra_Common.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "AC_Avoidance_config.h"
+
+#if AP_OAPATHPLANNER_DIJKSTRA_ENABLED
+
+#include <AP_Common/AP_Common.h>
+#include <AP_Common/Location.h>
+#include <AP_Math/AP_Math.h>
+
+/*
+ * Dijkstra's algorithm for path planning around polygon fence
+ */
+
+class AP_OADijkstra_Common {
+public:
+
+    // constructor
+    AP_OADijkstra_Common() {}
+
+    CLASS_NO_COPY(AP_OADijkstra_Common);  /* Do not allow copies */
+
+    // update return status enum
+    enum class State : uint8_t {
+        DIJKSTRA_STATE_NOT_REQUIRED = 0,
+        DIJKSTRA_STATE_ERROR,
+        DIJKSTRA_STATE_SUCCESS
+    };
+
+    enum class ErrorId : uint8_t {
+        DIJKSTRA_ERROR_NONE = 0,
+        DIJKSTRA_ERROR_OUT_OF_MEMORY,
+        DIJKSTRA_ERROR_OVERLAPPING_POLYGON_POINTS,
+        DIJKSTRA_ERROR_FAILED_TO_BUILD_INNER_POLYGON,
+        DIJKSTRA_ERROR_OVERLAPPING_POLYGON_LINES,
+        DIJKSTRA_ERROR_FENCE_DISABLED,
+        DIJKSTRA_ERROR_TOO_MANY_FENCE_POINTS,
+        DIJKSTRA_ERROR_NO_POSITION_ESTIMATE,
+        DIJKSTRA_ERROR_COULD_NOT_FIND_PATH
+    };
+
+    // return error message for a given error id
+    const char* get_error_msg(ErrorId error_id) const;
+
+    // report error to ground station
+    void report_error(ErrorId error_id);
+
+    private:
+
+    ErrorId _error_last_id;         // last error id sent to GCS
+    uint32_t _error_last_report_ms; // last time an error message was sent to GCS
+};
+
+#endif  // AP_OAPATHPLANNER_DIJKSTRA_ENABLED

--- a/libraries/AC_Avoidance/AP_OADijkstra_StaticData.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra_StaticData.cpp
@@ -1,0 +1,538 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AC_Avoidance_config.h"
+
+#if AP_OAPATHPLANNER_DIJKSTRA_ENABLED
+
+#include "AP_OADijkstra_StaticData.h"
+#include "AP_OAPathPlanner.h"
+
+#include <AC_Fence/AC_Fence.h>
+
+#if AP_FENCE_ENABLED
+
+#include <AP_AHRS/AP_AHRS.h>
+#include <AP_Logger/AP_Logger.h>
+#include <GCS_MAVLink/GCS.h>
+
+#define OA_DIJKSTRA_EXPANDING_ARRAY_ELEMENTS_PER_CHUNK  32      // expanding arrays for fence points and paths to destination will grow in increments of 20 elements
+#define OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX        255     // index use to indicate we do not have a tentative short path for a node
+
+/// Constructor
+AP_OADijkstra_StaticData::AP_OADijkstra_StaticData(AP_OADijkstra_Common& common, const AP_Int16 &options):
+        _common(common),
+        _options(options),
+        _inclusion_polygon_pts(OA_DIJKSTRA_EXPANDING_ARRAY_ELEMENTS_PER_CHUNK),
+        _exclusion_polygon_pts(OA_DIJKSTRA_EXPANDING_ARRAY_ELEMENTS_PER_CHUNK),
+        _exclusion_circle_pts(OA_DIJKSTRA_EXPANDING_ARRAY_ELEMENTS_PER_CHUNK)
+{
+}
+
+// returns true if at least one inclusion or exclusion zone is enabled
+bool AP_OADijkstra_StaticData::some_fences_enabled() const
+{
+    const AC_Fence *fence = AC_Fence::get_singleton();
+    if (fence == nullptr) {
+        return false;
+    }
+    if ((fence->polyfence().get_inclusion_polygon_count() == 0) &&
+        (fence->polyfence().get_exclusion_polygon_count() == 0) &&
+        (fence->polyfence().get_exclusion_circle_count() == 0)) {
+        return false;
+    }
+    return ((fence->get_enabled_fences() & AC_FENCE_TYPE_POLYGON) > 0);
+}
+
+// updates static data required for Dijkstra's algorithm
+// returns READY on success, UPDATED if change in static data since previous call means path should be re-calculated
+AP_OADijkstra_StaticData::UpdateState AP_OADijkstra_StaticData::update(AP_OADijkstra_Common::ErrorId& error_id)
+{
+    WITH_SEMAPHORE(AP::fence()->polyfence().get_loaded_fence_semaphore());
+
+    // if no fences then no static data is required
+    if (!some_fences_enabled()) {
+        return UpdateState::NOT_REQUIRED;
+    }
+
+    // check for inclusion polygon updates
+    bool updated = false;
+    if (check_inclusion_polygon_updated()) {
+        if (!create_inclusion_polygon_with_margin(_polyfence_margin * 100.0f, error_id)) {
+            _common.report_error(error_id);
+            return UpdateState::ERROR;
+        }
+        updated = true;
+    }
+
+    // check for exclusion polygon updates
+    if (check_exclusion_polygon_updated()) {
+        if (!create_exclusion_polygon_with_margin(_polyfence_margin * 100.0f, error_id)) {
+            _common.report_error(error_id);
+            return UpdateState::ERROR;
+        }
+        updated = true;
+    }
+
+    // check for exclusion circle updates
+    if (check_exclusion_circle_updated()) {
+        if (!create_exclusion_circle_with_margin(_polyfence_margin * 100.0f, error_id)) {
+            _common.report_error(error_id);
+            return UpdateState::ERROR;
+        }
+        updated = true;
+    }
+
+    // create visgraph for all fence (with margin) points
+    if (!_polyfence_visgraph_ok || updated) {
+        _polyfence_visgraph_ok = create_fence_visgraph(error_id);
+        if (!_polyfence_visgraph_ok) {
+            _common.report_error(error_id);
+            return UpdateState::ERROR;
+        }
+        // reset logging count to restart logging updated graph
+        _log_num_points = 0;
+        _log_visgraph_version++;
+    }
+
+    // Log one visgraph point per loop
+    if (_polyfence_visgraph_ok && (_log_num_points < total_numpoints()) && (_options & AP_OAPathPlanner::OARecoveryOptions::OA_OPTION_LOG_DIJKSTRA_POINTS) ) {
+        Vector2f vis_point;
+        if (get_point(_log_num_points, vis_point)) {
+            Location log_location(Vector3f{vis_point.x, vis_point.y, 0.0}, Location::AltFrame::ABOVE_ORIGIN);
+            Write_Visgraph_point(_log_visgraph_version, _log_num_points, log_location.lat, log_location.lng);
+            _log_num_points++;
+        }
+    }
+
+    return updated ? UpdateState::UPDATED : UpdateState::READY;
+}
+
+// check if polygon fence has been updated since we created the inner fence. returns true if changed
+bool AP_OADijkstra_StaticData::check_inclusion_polygon_updated() const
+{
+    // exit immediately if polygon fence is not enabled
+    const AC_Fence *fence = AC_Fence::get_singleton();
+    if (fence == nullptr) {
+        return false;
+    }
+    return (_inclusion_polygon_update_ms != fence->polyfence().get_inclusion_polygon_update_ms());
+}
+
+// create polygons inside the existing inclusion polygons
+// returns true on success.  returns false on failure and err_id is updated
+bool AP_OADijkstra_StaticData::create_inclusion_polygon_with_margin(float margin_cm, AP_OADijkstra_Common::ErrorId &error_id)
+{
+    const AC_Fence *fence = AC_Fence::get_singleton();
+
+    if (fence == nullptr) {
+        error_id = AP_OADijkstra_Common::ErrorId::DIJKSTRA_ERROR_FENCE_DISABLED;
+        return false;
+    }
+
+    _inclusion_polygon_update_ms = fence->polyfence().get_inclusion_polygon_update_ms();
+
+    // clear all points
+    _inclusion_polygon_numpoints = 0;
+
+    // return immediately if no polygons
+    const uint8_t num_inclusion_polygons = fence->polyfence().get_inclusion_polygon_count();
+
+    // iterate through polygons and create inner points
+    for (uint8_t i = 0; i < num_inclusion_polygons; i++) {
+        uint16_t num_points;
+        const Vector2f* boundary = fence->polyfence().get_inclusion_polygon(i, num_points);
+
+        // for each point in inclusion polygon
+        // Note: boundary is "unclosed" meaning the last point is *not* the same as the first
+        uint16_t new_points = 0;
+        for (uint16_t j = 0; j < num_points; j++) {
+
+            // find points before and after current point (relative to current point)
+            const uint16_t before_idx = (j == 0) ? num_points-1 : j-1;
+            const uint16_t after_idx = (j == num_points-1) ? 0 : j+1;
+            Vector2f before_pt = boundary[before_idx] - boundary[j];
+            Vector2f after_pt = boundary[after_idx] - boundary[j];
+
+            // if points are overlapping fail
+            if (before_pt.is_zero() || after_pt.is_zero() || (before_pt == after_pt)) {
+                error_id = AP_OADijkstra_Common::ErrorId::DIJKSTRA_ERROR_OVERLAPPING_POLYGON_POINTS;
+                return false;
+            }
+
+            // scale points to be unit vectors
+            before_pt.normalize();
+            after_pt.normalize();
+
+            // calculate intermediate point and scale to margin
+            Vector2f intermediate_pt = after_pt + before_pt;
+            intermediate_pt.normalize();
+            intermediate_pt *= margin_cm;
+
+            // find final point which is outside the inside polygon
+            Vector2f temp_point = boundary[j] + intermediate_pt;
+            if (Polygon_outside(temp_point, boundary, num_points)) {
+                intermediate_pt *= -1.0;
+                temp_point = boundary[j] + intermediate_pt;
+                if (Polygon_outside(temp_point, boundary, num_points)) {
+                    // could not find a point on either side that was outside the exclusion polygon so fail
+                    // this may happen if the exclusion polygon has overlapping lines
+                    error_id = AP_OADijkstra_Common::ErrorId::DIJKSTRA_ERROR_OVERLAPPING_POLYGON_LINES;
+                    return false;
+                }
+            }
+
+            // don't add points in corners
+            if (fabsf(intermediate_pt.angle() - before_pt.angle()) < M_PI_2) {
+                continue;
+            }
+
+            // expand array if required
+            if (!_inclusion_polygon_pts.expand_to_hold(_inclusion_polygon_numpoints + new_points + 1)) {
+                error_id = AP_OADijkstra_Common::ErrorId::DIJKSTRA_ERROR_OUT_OF_MEMORY;
+                return false;
+            }
+            // add point
+            _inclusion_polygon_pts[_inclusion_polygon_numpoints + new_points] = temp_point;
+            new_points++;
+        }
+
+        // update total number of points
+        _inclusion_polygon_numpoints += new_points;
+    }
+    return true;
+}
+
+// check if exclusion polygons have been updated since create_exclusion_polygon_with_margin was run
+// returns true if changed
+bool AP_OADijkstra_StaticData::check_exclusion_polygon_updated() const
+{
+    const AC_Fence *fence = AC_Fence::get_singleton();
+    if (fence == nullptr) {
+        return false;
+    }
+    return (_exclusion_polygon_update_ms != fence->polyfence().get_exclusion_polygon_update_ms());
+}
+
+// create polygons around existing exclusion polygons
+// returns true on success.  returns false on failure and err_id is updated
+bool AP_OADijkstra_StaticData::create_exclusion_polygon_with_margin(float margin_cm, AP_OADijkstra_Common::ErrorId &err_id)
+{
+    const AC_Fence *fence = AC_Fence::get_singleton();
+
+    if (fence == nullptr) {
+        err_id = AP_OADijkstra_Common::ErrorId::DIJKSTRA_ERROR_FENCE_DISABLED;
+        return false;
+    }
+
+    // skip unnecessary retry to build exclusion polygon if previous fence points have not changed 
+    if (_exclusion_polygon_update_ms == fence->polyfence().get_exclusion_polygon_update_ms()) {
+        return false;
+    }
+
+    _exclusion_polygon_update_ms = fence->polyfence().get_exclusion_polygon_update_ms();
+
+
+    // clear all points
+    _exclusion_polygon_numpoints = 0;
+
+    // return immediately if no exclusion polygons
+    const uint8_t num_exclusion_polygons = fence->polyfence().get_exclusion_polygon_count();
+
+    // iterate through exclusion polygons and create outer points
+    for (uint8_t i = 0; i < num_exclusion_polygons; i++) {
+        uint16_t num_points;
+        const Vector2f* boundary = fence->polyfence().get_exclusion_polygon(i, num_points);
+   
+        // for each point in exclusion polygon
+        // Note: boundary is "unclosed" meaning the last point is *not* the same as the first
+        uint16_t new_points = 0;
+        for (uint16_t j = 0; j < num_points; j++) {
+
+            // find points before and after current point (relative to current point)
+            const uint16_t before_idx = (j == 0) ? num_points-1 : j-1;
+            const uint16_t after_idx = (j == num_points-1) ? 0 : j+1;
+            Vector2f before_pt = boundary[before_idx] - boundary[j];
+            Vector2f after_pt = boundary[after_idx] - boundary[j];
+
+            // if points are overlapping fail
+            if (before_pt.is_zero() || after_pt.is_zero() || (before_pt == after_pt)) {
+                err_id = AP_OADijkstra_Common::ErrorId::DIJKSTRA_ERROR_OVERLAPPING_POLYGON_POINTS;
+                return false;
+            }
+
+            // scale points to be unit vectors
+            before_pt.normalize();
+            after_pt.normalize();
+
+            // calculate intermediate point and scale to margin
+            Vector2f intermediate_pt = after_pt + before_pt;
+            intermediate_pt.normalize();
+            intermediate_pt *= margin_cm;
+
+            // find final point which is outside the original polygon
+            Vector2f temp_point = boundary[j] + intermediate_pt;
+            if (!Polygon_outside(temp_point, boundary, num_points)) {
+                intermediate_pt *= -1;
+                temp_point = boundary[j] + intermediate_pt;
+                if (!Polygon_outside(temp_point, boundary, num_points)) {
+                    // could not find a point on either side that was outside the exclusion polygon so fail
+                    // this may happen if the exclusion polygon has overlapping lines
+                    err_id = AP_OADijkstra_Common::ErrorId::DIJKSTRA_ERROR_OVERLAPPING_POLYGON_LINES;
+                    return false;
+                }
+            }
+
+            // don't add points in corners
+            if (fabsf(intermediate_pt.angle() - before_pt.angle()) < M_PI_2) {
+                continue;
+            }
+
+            // expand array if required
+            if (!_exclusion_polygon_pts.expand_to_hold(_exclusion_polygon_numpoints + new_points + 1)) {
+                err_id = AP_OADijkstra_Common::ErrorId::DIJKSTRA_ERROR_OUT_OF_MEMORY;
+                return false;
+            }
+            // add point
+            _exclusion_polygon_pts[_exclusion_polygon_numpoints + new_points] = temp_point;
+            new_points++;
+        }
+
+        // update total number of points
+        _exclusion_polygon_numpoints += new_points;
+    }
+    return true;
+}
+
+// check if exclusion circles have been updated since create_exclusion_circle_with_margin was run
+// returns true if changed
+bool AP_OADijkstra_StaticData::check_exclusion_circle_updated() const
+{
+    // exit immediately if fence is not enabled
+    const AC_Fence *fence = AC_Fence::get_singleton();
+    if (fence == nullptr) {
+        return false;
+    }
+    return (_exclusion_circle_update_ms != fence->polyfence().get_exclusion_circle_update_ms());
+}
+
+// create polygons around existing exclusion circles
+// returns true on success.  returns false on failure and err_id is updated
+bool AP_OADijkstra_StaticData::create_exclusion_circle_with_margin(float margin_cm, AP_OADijkstra_Common::ErrorId &err_id)
+{
+    // exit immediately if fence is not enabled
+    const AC_Fence *fence = AC_Fence::get_singleton();
+    if (fence == nullptr) {
+        err_id = AP_OADijkstra_Common::ErrorId::DIJKSTRA_ERROR_FENCE_DISABLED;
+        return false;
+    }
+
+    // clear all points
+    _exclusion_circle_numpoints = 0;
+
+    // unit length offsets for polygon points around circles
+    const Vector2f unit_offsets[] = {
+            {cosf(radians(30)), cosf(radians(30-90))},  // north-east
+            {cosf(radians(90)), cosf(radians(90-90))},  // east
+            {cosf(radians(150)), cosf(radians(150-90))},// south-east
+            {cosf(radians(210)), cosf(radians(210-90))},// south-west
+            {cosf(radians(270)), cosf(radians(270-90))},// west
+            {cosf(radians(330)), cosf(radians(330-90))},// north-west
+    };
+    const uint8_t num_points_per_circle = ARRAY_SIZE(unit_offsets);
+
+    // expand polygon point array if required
+    const uint8_t num_exclusion_circles = fence->polyfence().get_exclusion_circle_count();
+    if (!_exclusion_circle_pts.expand_to_hold(num_exclusion_circles * num_points_per_circle)) {
+        err_id = AP_OADijkstra_Common::ErrorId::DIJKSTRA_ERROR_OUT_OF_MEMORY;
+        return false;
+    }
+
+    // iterate through exclusion circles and create outer polygon points
+    for (uint8_t i = 0; i < num_exclusion_circles; i++) {
+        Vector2f circle_pos_cm;
+        float radius;
+        if (fence->polyfence().get_exclusion_circle(i, circle_pos_cm, radius)) {
+            // scaler to ensure lines between points do not intersect circle
+            const float scaler = (1.0f / cosf(radians(180.0f / (float)num_points_per_circle))) * ((radius * 100.0f) + margin_cm);
+
+            // add points to array
+            for (uint8_t j = 0; j < num_points_per_circle; j++) {
+                _exclusion_circle_pts[_exclusion_circle_numpoints] = circle_pos_cm + (unit_offsets[j] * scaler);
+                _exclusion_circle_numpoints++;
+            }
+        }
+    }
+
+    // record fence update time so we don't process these exclusion circles again
+    _exclusion_circle_update_ms = fence->polyfence().get_exclusion_circle_update_ms();
+
+    return true;
+}
+
+// returns total number of points across all fence types
+uint16_t AP_OADijkstra_StaticData::total_numpoints() const
+{
+    return _inclusion_polygon_numpoints + _exclusion_polygon_numpoints + _exclusion_circle_numpoints;
+}
+
+// get a single point across the total list of points from all fence types
+bool AP_OADijkstra_StaticData::get_point(uint16_t index, Vector2f &point) const
+{
+    // sanity check index
+    if (index >= total_numpoints()) {
+        return false;
+    }
+
+    // return an inclusion polygon point
+    if (index < _inclusion_polygon_numpoints) {
+        point = _inclusion_polygon_pts[index];
+        return true;
+    }
+    index -= _inclusion_polygon_numpoints;
+
+    // return an exclusion polygon point
+    if (index < _exclusion_polygon_numpoints) {
+        point = _exclusion_polygon_pts[index];
+        return true;
+    }
+    index -= _exclusion_polygon_numpoints;
+
+    // return an exclusion circle point
+    if (index < _exclusion_circle_numpoints) {
+        point = _exclusion_circle_pts[index];
+        return true;
+    }
+
+    // we should never get here but just in case
+    return false;
+}
+
+// returns true if line segment intersects polygon or circular fence
+bool AP_OADijkstra_StaticData::intersects_fence(const Vector2f &seg_start, const Vector2f &seg_end) const
+{
+    // return immediately if fence is not enabled
+    const AC_Fence *fence = AC_Fence::get_singleton();
+    if (fence == nullptr) {
+        return false;
+    }
+
+    // determine if segment crosses any of the inclusion polygons
+    uint16_t num_points = 0;
+    for (uint8_t i = 0; i < fence->polyfence().get_inclusion_polygon_count(); i++) {
+        const Vector2f* boundary = fence->polyfence().get_inclusion_polygon(i, num_points);
+        if (boundary != nullptr) {
+            Vector2f intersection;
+            if (Polygon_intersects(boundary, num_points, seg_start, seg_end, intersection)) {
+                return true;
+            }
+        }
+    }
+
+    // determine if segment crosses any of the exclusion polygons
+    for (uint8_t i = 0; i < fence->polyfence().get_exclusion_polygon_count(); i++) {
+        const Vector2f* boundary = fence->polyfence().get_exclusion_polygon(i, num_points);
+        if (boundary != nullptr) {
+            Vector2f intersection;
+            if (Polygon_intersects(boundary, num_points, seg_start, seg_end, intersection)) {
+                return true;
+            }
+        }
+    }
+
+    // determine if segment crosses any of the inclusion circles
+    for (uint8_t i = 0; i < fence->polyfence().get_inclusion_circle_count(); i++) {
+        Vector2f center_pos_cm;
+        float radius;
+        if (fence->polyfence().get_inclusion_circle(i, center_pos_cm, radius)) {
+            // intersects circle if either start or end is further from the center than the radius
+            const float radius_cm_sq = sq(radius * 100.0f) ;
+            if ((seg_start - center_pos_cm).length_squared() > radius_cm_sq) {
+                return true;
+            }
+            if ((seg_end - center_pos_cm).length_squared() > radius_cm_sq) {
+                return true;
+            }
+        }
+    }
+
+    // determine if segment crosses any of the exclusion circles
+    for (uint8_t i = 0; i < fence->polyfence().get_exclusion_circle_count(); i++) {
+        Vector2f center_pos_cm;
+        float radius;
+        if (fence->polyfence().get_exclusion_circle(i, center_pos_cm, radius)) {
+            // calculate distance between circle's center and segment
+            const float dist_cm = Vector2f::closest_distance_between_line_and_point(seg_start, seg_end, center_pos_cm);
+
+            // intersects if distance is less than radius
+            if (dist_cm <= (radius * 100.0f)) {
+                return true;
+            }
+        }
+    }
+
+    // if we got this far then no intersection
+    return false;
+}
+
+// create visibility graph for all fence (with margin) points
+// returns true on success.  returns false on failure and err_id is updated
+// requires these functions to have been run create_inclusion_polygon_with_margin, create_exclusion_polygon_with_margin, create_exclusion_circle_with_margin
+bool AP_OADijkstra_StaticData::create_fence_visgraph(AP_OADijkstra_Common::ErrorId &err_id)
+{
+    // exit immediately if fence is not enabled
+    const AC_Fence *fence = AC_Fence::get_singleton();
+    if (fence == nullptr) {
+        err_id = AP_OADijkstra_Common::ErrorId::DIJKSTRA_ERROR_FENCE_DISABLED;
+        return false;
+    }
+
+    // fail if more fence points than algorithm can handle
+    if (total_numpoints() >= OA_DIJKSTRA_POLYGON_SHORTPATH_NOTSET_IDX) {
+        err_id = AP_OADijkstra_Common::ErrorId::DIJKSTRA_ERROR_TOO_MANY_FENCE_POINTS;
+        return false;
+    }
+
+    // clear fence points visibility graph
+    _fence_visgraph.clear();
+
+    // calculate distance from each point to all other points
+    for (uint8_t i = 0; i < total_numpoints() - 1; i++) {
+        Vector2f start_seg;
+        if (get_point(i, start_seg)) {
+            for (uint8_t j = i + 1; j < total_numpoints(); j++) {
+                Vector2f end_seg;
+                if (get_point(j, end_seg)) {
+                    // if line segment does not intersect with any inclusion or exclusion zones add to visgraph
+                    if (!intersects_fence(start_seg, end_seg)) {
+                        if (!_fence_visgraph.add_item({AP_OAVisGraph::OATYPE_INTERMEDIATE_POINT, i},
+                                                      {AP_OAVisGraph::OATYPE_INTERMEDIATE_POINT, j},
+                                                      (start_seg - end_seg).length())) {
+                            // failure to add a point can only be caused by out-of-memory
+                            err_id = AP_OADijkstra_Common::ErrorId::DIJKSTRA_ERROR_OUT_OF_MEMORY;
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return true;
+}
+
+#endif // AP_FENCE_ENABLED
+
+#endif  // AP_OAPATHPLANNER_DIJKSTRA_ENABLED

--- a/libraries/AC_Avoidance/AP_OADijkstra_StaticData.h
+++ b/libraries/AC_Avoidance/AP_OADijkstra_StaticData.h
@@ -1,0 +1,136 @@
+#pragma once
+
+#include "AC_Avoidance_config.h"
+
+#if AP_OAPATHPLANNER_DIJKSTRA_ENABLED
+
+#include <AP_Common/AP_Common.h>
+#include <AP_Common/Location.h>
+#include <AP_Math/AP_Math.h>
+#include "AP_OADijkstra_Common.h"
+#include "AP_OAVisGraph.h"
+#include <AP_Logger/AP_Logger_config.h>
+
+/*
+ * Dijkstra's algorithm's static data handler (e.g fences)
+ */
+
+class AP_OADijkstra_StaticData {
+public:
+
+    AP_OADijkstra_StaticData(AP_OADijkstra_Common& common, const AP_Int16 &options);
+
+    CLASS_NO_COPY(AP_OADijkstra_StaticData);  /* Do not allow copies */
+
+    // returns true if at least one inclusion or exclusion zone is enabled
+    bool some_fences_enabled() const;
+
+    // set fence margin (in meters) used when creating "safe positions" within the polygon fence
+    void set_fence_margin(float margin) { _polyfence_margin = MAX(margin, 0.0f); }
+
+    // updates static data required for Dijkstra's algorithm
+    // returns READY on success, UPDATED if change in static data since previous call means path should be re-calculated
+    enum class UpdateState : uint8_t {
+        NOT_REQUIRED = 0,
+        READY,
+        UPDATED,
+        ERROR
+    };
+    UpdateState update(AP_OADijkstra_Common::ErrorId& error_id);
+
+    // returns total number of points across all fence types
+    uint16_t total_numpoints() const;
+
+    // get a single point across the total list of points from all fence types
+    // also returns the type of point
+    bool get_point(uint16_t index, Vector2f& point) const;
+
+    // returns true if line segment intersects polygon or circular fence
+    bool intersects_fence(const Vector2f &seg_start, const Vector2f &seg_end) const;
+
+    // return fence visibility graph
+    const AP_OAVisGraph& get_fence_visgraph() const { return _fence_visgraph; }
+
+private:
+
+    //
+    // inclusion polygon methods
+    //
+
+    // check if inclusion polygons have been updated since create_inclusion_polygon_with_margin was run
+    // returns true if changed
+    bool check_inclusion_polygon_updated() const;
+
+    // create polygons inside the existing inclusion polygons
+    // returns true on success.  returns false on failure and err_id is updated
+    bool create_inclusion_polygon_with_margin(float margin_cm, AP_OADijkstra_Common::ErrorId &err_id);
+
+    //
+    // exclusion polygon methods
+    //
+
+    // check if exclusion polygons have been updated since create_exclusion_polygon_with_margin was run
+    // returns true if changed
+    bool check_exclusion_polygon_updated() const;
+
+    // create polygons around existing exclusion polygons
+    // returns true on success.  returns false on failure and err_id is updated
+    bool create_exclusion_polygon_with_margin(float margin_cm, AP_OADijkstra_Common::ErrorId &err_id);
+
+    //
+    // exclusion circle methods
+    //
+
+    // check if exclusion circles have been updated since create_exclusion_circle_with_margin was run
+    // returns true if changed
+    bool check_exclusion_circle_updated() const;
+
+    // create polygons around existing exclusion circles
+    // returns true on success.  returns false on failure and err_id is updated
+    bool create_exclusion_circle_with_margin(float margin_cm, AP_OADijkstra_Common::ErrorId &err_id);
+
+    //
+    // other methods
+    //
+
+    // create visibility graph for all fence (with margin) points
+    // returns true on success.  returns false on failure and err_id is updated
+    bool create_fence_visgraph(AP_OADijkstra_Common::ErrorId &err_id);
+
+    // shortest path state variables
+    bool _polyfence_visgraph_ok;
+
+    // inclusion polygon (with margin) related variables
+    float _polyfence_margin = 10;           // margin around polygon defaults to 10m but is overriden with set_fence_margin
+    AP_ExpandingArray<Vector2f> _inclusion_polygon_pts; // array of nodes corresponding to inclusion polygon points plus a margin
+    uint8_t _inclusion_polygon_numpoints;   // number of points held in above array
+    uint32_t _inclusion_polygon_update_ms;  // system time of boundary update from AC_Fence (used to detect changes to polygon fence)
+
+    // exclusion polygon related variables
+    AP_ExpandingArray<Vector2f> _exclusion_polygon_pts; // array of nodes corresponding to exclusion polygon points plus a margin
+    uint8_t _exclusion_polygon_numpoints;   // number of points held in above array
+    uint32_t _exclusion_polygon_update_ms;  // system time exclusion polygon was updated (used to detect changes)
+
+    // exclusion circle related variables
+    AP_ExpandingArray<Vector2f> _exclusion_circle_pts; // array of nodes surrounding exclusion circles plus a margin
+    uint8_t _exclusion_circle_numpoints;    // number of points held in above array
+    uint32_t _exclusion_circle_update_ms;   // system time exclusion circles were updated (used to detect changes)
+
+    // visibility graphs
+    AP_OAVisGraph _fence_visgraph;          // holds distances between all inclusion/exclusion fence points (with margin)
+
+#if HAL_LOGGING_ENABLED
+    // Logging functions
+    void Write_Visgraph_point(const uint8_t version, const uint8_t point_num, const int32_t Lat, const int32_t Lon) const;
+#else
+    void Write_Visgraph_point(const uint8_t version, const uint8_t point_num, const int32_t Lat, const int32_t Lon) const {}
+#endif
+    uint8_t _log_num_points;
+    uint8_t _log_visgraph_version;
+
+    // references
+    AP_OADijkstra_Common& _common;
+    const AP_Int16 &_options;
+};
+
+#endif  // AP_OAPATHPLANNER_DIJKSTRA_ENABLED

--- a/libraries/AC_Avoidance/AP_OAPathPlanner.h
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.h
@@ -83,6 +83,12 @@ public:
 
     uint16_t get_options() const { return _options;}
 
+    // get path length to arbitrary Location using Dijkstra's algorithm
+    // the request is processed in a background thread and returns OA_PROCESSING until the path length is calculated
+    // returns OA_SUCCESS once the path length is calculated and fills in the path_length argument
+    // only supports a single caller at a time
+    OA_RetState get_path_length(const Location &origin, const Location &destination, float &path_length) WARN_IF_UNUSED;
+
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
@@ -93,6 +99,9 @@ private:
 
     // handle avoidance requests in the avoidance thread
     void handle_avoidance_requests();
+
+    // handle path length requests in the avoidance thread
+    void handle_path_length_requests();
 
     // helper function to map OABendyType to OAPathPlannerUsed
     OAPathPlannerUsed map_bendytype_to_pathplannerused(AP_OABendyRuler::OABendyType bendy_type);
@@ -119,6 +128,23 @@ private:
         OAPathPlannerUsed path_planner_used;    // path planner that produced the result
         OA_RetState ret_state;      // OA_SUCCESS if the vehicle should move along the path from origin_new to destination_new
     } avoidance_result;
+
+    // request and reply for path length (using Dijkstras)
+    struct PathLengthRequest {
+        Location origin;
+        Location destination;
+        uint32_t request_time_ms;
+    } path_length_request;
+    HAL_Semaphore path_length_request_sem;  // semaphore for multi-thread use of path_length_request
+    uint32_t path_length_first_ms;  // system time that the first path length request was made.  Used to avoid timeout error on first run
+
+    struct PathLengthReply {
+        Location destination;       // destination (used to compare against request)
+        OA_RetState ret_state;      // OA_SUCCESS if the path length could be calculated
+        float path_length_m;        // path length in meters
+        uint32_t result_time_ms;    // system time the result was calculated (used to verify the result is recent)
+    } path_length_reply = {ret_state : OA_PROCESSING};
+    HAL_Semaphore path_length_reply_sem;    // semaphore for multi-thread use of path_length_reply
 
     // parameters
     AP_Int8 _type;                  // avoidance algorithm to be used

--- a/libraries/AC_Avoidance/AP_OAPathPlanner.h
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.h
@@ -91,6 +91,9 @@ private:
     void avoidance_thread();
     bool start_thread();
 
+    // handle avoidance requests in the avoidance thread
+    void handle_avoidance_requests();
+
     // helper function to map OABendyType to OAPathPlannerUsed
     OAPathPlannerUsed map_bendytype_to_pathplannerused(AP_OABendyRuler::OABendyType bendy_type);
 

--- a/libraries/AP_Rally/AP_Rally.cpp
+++ b/libraries/AP_Rally/AP_Rally.cpp
@@ -8,6 +8,8 @@
 #include <AP_Logger/AP_Logger.h>
 #include <StorageManager/StorageManager.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
+#include <AC_Avoidance/AC_Avoidance_config.h>
+#include <AC_Avoidance/AP_OAPathPlanner.h>
 
 // storage object
 StorageAccess AP_Rally::_storage(StorageManager::StorageRally);
@@ -47,6 +49,13 @@ const AP_Param::GroupInfo AP_Rally::var_info[] = {
     // @User: Standard
     // @Values: 0:DoNotIncludeHome,1:IncludeHome
     AP_GROUPINFO("INCL_HOME", 2, AP_Rally, _rally_incl_home, RALLY_INCLUDE_HOME_DEFAULT),
+
+    // @Param: OPTIONS
+    // @DisplayName: Rally Options
+    // @Description: Options to Rally point usage
+    // @User: Standard
+    // @Values: 0:Use Dijkstras to decide closest point
+    AP_GROUPINFO("OPTIONS", 3, AP_Rally, _options, 0),
 
     AP_GROUPEND
 };
@@ -182,6 +191,100 @@ Location AP_Rally::calc_best_rally_or_home_location(const Location &current_loc,
     }
 
     return return_loc;
+}
+
+// find rally point or home with shortest flight path distance calculated using Dijkstras
+// returns true on completion and fills in ret with the Location of the closest rally point or home
+// returns false if the calculation has not yet completed
+// should be called continuously until it returns true.  only one caller is supported at a time
+// if dijkstras is disabled or "Use Dikstras" options bit is not set then it will fall back to calc_best_rally_or_home_location()
+bool AP_Rally::find_nearest_rally_or_home_with_dijkstras(const Location &current_loc, float rtl_home_alt_amsl_cm, Location& ret)
+{
+#if AP_OAPATHPLANNER_ENABLED
+    // get oa singleton
+    AP_OAPathPlanner *oa_ptr = AP_OAPathPlanner::get_singleton();
+    
+    // fallback to calc_best_rally_or_home_location if dijkstras is disabled or not rally points
+    if (!option_is_set(Options::USE_DIJKSTRAS) || (oa_ptr == nullptr) || (get_rally_total() == 0)) {
+        ret = calc_best_rally_or_home_location(current_loc, rtl_home_alt_amsl_cm);
+        return true;
+    }
+
+    // initialise state
+    if (_find_with_dijkstras.state != FindWithDijkstras::State::PROCESSING) {
+        _find_with_dijkstras.state = FindWithDijkstras::State::PROCESSING;
+        _find_with_dijkstras.home_dist_calced = false;
+        _find_with_dijkstras.rally_index = 0;
+    }
+
+    // get destination location (e.g. home or next rally point)
+    Location search_loc;
+    if (!_find_with_dijkstras.home_dist_calced) {
+        // calculating path length to home
+        search_loc = AP::ahrs().get_home();
+    } else {
+        // calculating path length to a rally point
+        RallyLocation rallyloc;
+        if (!get_rally_point_with_index(_find_with_dijkstras.rally_index, rallyloc)) {
+            // unexpected failure to get rally point, fall back to calc_best_rally_or_home_location
+            _find_with_dijkstras.state = FindWithDijkstras::State::COMPLETED;
+            ret = calc_best_rally_or_home_location(current_loc, rtl_home_alt_amsl_cm);
+            return true;
+        }
+
+        // convert rally location to Location
+        search_loc = rally_location_to_location(rallyloc);
+    }
+
+    // get path length to search_loc
+    float path_length = 0;
+    AP_OAPathPlanner::OA_RetState oa_ret = oa_ptr->get_path_length(current_loc, search_loc, path_length);
+
+    // check response
+    switch (oa_ret) {
+    case AP_OAPathPlanner::OA_NOT_REQUIRED:
+    case AP_OAPathPlanner::OA_ERROR:
+        // object avoidance is not required or unrecoverable error during calculation
+        // fall back to calc_best_rally_or_home_location
+        _find_with_dijkstras.state = FindWithDijkstras::State::COMPLETED;
+        ret = calc_best_rally_or_home_location(current_loc, rtl_home_alt_amsl_cm);
+        return true;
+    case AP_OAPathPlanner::OA_PROCESSING:
+        // still calculating path length
+        return false;
+    case AP_OAPathPlanner::OA_SUCCESS:
+        if (!_find_with_dijkstras.home_dist_calced) {
+            // path length to home calculated, default to this being shortest path
+            _find_with_dijkstras.home_dist_calced = true;
+            _find_with_dijkstras.shortest_path_loc = search_loc;
+            _find_with_dijkstras.shortest_path_length = path_length;
+        } else {
+            // path length to a rally point calculated
+            if (path_length < _find_with_dijkstras.shortest_path_length) {
+                _find_with_dijkstras.shortest_path_loc = search_loc;
+                _find_with_dijkstras.shortest_path_length = path_length;
+            }
+
+            // advance to the next rally point
+            _find_with_dijkstras.rally_index++;
+        }
+
+        // if home and all rally points have been checked then complete
+        if (_find_with_dijkstras.home_dist_calced && _find_with_dijkstras.rally_index >= get_rally_total()) {
+            _find_with_dijkstras.state = FindWithDijkstras::State::COMPLETED;
+            ret = _find_with_dijkstras.shortest_path_loc;
+            return true;
+        }
+        return false;
+    }
+
+    // we should never get here but just in case, raise internal error and keep processing
+    INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
+    return false;
+#else
+    ret = calc_best_rally_or_home_location(current_loc, rtl_home_alt_amsl_cm);
+    return true;
+#endif
 }
 
 // singleton instance

--- a/libraries/AP_Rally/AP_Rally.h
+++ b/libraries/AP_Rally/AP_Rally.h
@@ -77,6 +77,13 @@ public:
     Location calc_best_rally_or_home_location(const Location &current_loc, float rtl_home_alt_amsl_cm) const;
     bool find_nearest_rally_point(const Location &myloc, RallyLocation &ret) const;
 
+    // find rally point or home with shortest flight path distance calculated using Dijkstras
+    // returns true on completion and fills in ret with the Location of the closest rally point or home
+    // returns false if the calculation has not yet completed
+    // should be called continuously until it returns true.  only one caller is supported at a time
+    // if dijkstras is disabled or "Use Dikstras" options bit is not set then it will fall back to calc_best_rally_or_home_location()
+    bool find_nearest_rally_or_home_with_dijkstras(const Location &current_loc, float rtl_home_alt_amsl_cm, Location& ret);
+
     // last time rally points changed
     uint32_t last_change_time_ms(void) const { return _last_change_time_ms; }
 
@@ -94,12 +101,36 @@ private:
 
     static StorageAccess _storage;
 
+    // options bitmask
+    enum class Options : uint8_t {
+        USE_DIJKSTRAS = (1U << 0),
+    };
+
+    // check if a option is set
+    bool option_is_set(Options option) const {
+        return (uint8_t(_options.get()) & uint8_t(option)) != 0;
+    }
+
     // parameters
     AP_Int8  _rally_point_total_count;
     AP_Float _rally_limit_km;
     AP_Int8  _rally_incl_home;
+    AP_Int8  _options;
 
     uint32_t _last_change_time_ms = 0xFFFFFFFF;
+
+    // find_nearest_rally_or_home_with_dijkstras related variables
+    struct FindWithDijkstras {
+        enum class State {
+            NOT_STARTED = 0,
+            PROCESSING,
+            COMPLETED
+        } state;                    // state of search for shortest path
+        bool home_dist_calced;      // true once path length to home has been calculated
+        uint8_t rally_index;        // rally point index used for while iteratively searching for shortest path using Dijkstra's
+        float shortest_path_length; // shortest path length to rally point or home
+        Location shortest_path_loc; // Location of home or rally point with shortest path length distance
+    } _find_with_dijkstras;
 };
 
 namespace AP {


### PR DESCRIPTION
This enhancement causes RTL to fly to the Rally point with the shortest flight distance instead of the closest Rally point.  Normally these are the same but if a fence separates the vehicle from a rally point it can actually be quicker to fly to another.

The change appears to be very large but most of it is just moving code as part of separating Dijkatras into more manageable pieces.  These pieces are:

1. AP_OADijkstra_Common : shared enums and error reporting
2. AP_OADijkstra_StaticData: handling of fences including calculating inner fences
3. AP_OADijkstra_CalcPath: the heart of Dijkstras which involves finding the shortest safe path

Other changes are:

- AP_OADijkstra_CalcPathis enhanced to allow multiple callers to request the shortest path to different destinations
- AP_Rally is enhanced to use Dijkstras when calculating the the "closets" rally point
- Copter's ModeRTL's build_path method essentially becomes asyncronous so the vehicle waits until AP_Rally calculates the shortest Rally point (previously this was all done immediately in the main thread)
- AP_OAPathPlanner is simply updated to use the slightly modified Dijkstras interface

This video demonstrates the enhancement
https://youtu.be/nH_pnZ0FbP0

This has been tested in SITL but not yet on a real vehicle