### PR TITLE
AP_NavEKF3: ignore VelZ of body odometry if SRCn_VELZ is set to None

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -2031,7 +2031,10 @@ void NavEKF3_core::SelectBodyOdomFusion()
     // Check for body odometry data (aka visual position delta) at the fusion time horizon
     const bool bodyOdomDataToFuse = storedBodyOdm.recall(bodyOdmDataDelayed, imuDataDelayed.time_ms);
     if (bodyOdomDataToFuse && frontend->sources.useVelXYSource(AP_NavEKF_Source::SourceXY::EXTNAV)) {
-
+        // If VelZ source is set to none, don't use the odometry data for Z velocity
+        if (!frontend->sources.haveVelZSource()) {
+            bodyOdmDataDelayed.vel.z = stateStruct.velocity.z;
+        }
         // Fuse data into the main filter
         FuseBodyVel();
     }


### PR DESCRIPTION
This was found by using a dvl which was outputting bad VISION_POSITION_DELTA messages. it was losing locks and outputting bogus (0,0,0) readings fox xyz speed.
Cosuming the bad data caused the baro depth to be somewhat ignored and the vehicle to bounce a lot.

I'm actually not sure of how right this is. is the time of stateStrct the same of bodyOdmDelayed?