### PR TITLE
AP_Volz_Protocol: bugfix with scaling integer

### DIFF
--- a/libraries/AP_Volz_Protocol/AP_Volz_Protocol.cpp
+++ b/libraries/AP_Volz_Protocol/AP_Volz_Protocol.cpp
@@ -405,7 +405,7 @@ void AP_Volz_Protocol::update()
                 "TimeUS,I,Dang,ang,pc,sc,pv,sv,mt,pt",
                 "s#ddAAvvOO",
                 "F000000000",
-                "QBffffffHH",
+                "QBffffffhh",
                 AP_HAL::micros64(),
                 i + 1, // convert to 1 indexed to match actuator IDs and SERVOx numbering
                 telem.data[i].desired_angle,

--- a/libraries/AP_Volz_Protocol/AP_Volz_Protocol.h
+++ b/libraries/AP_Volz_Protocol/AP_Volz_Protocol.h
@@ -140,8 +140,8 @@ private:
             float secondary_current;
             float primary_voltage;
             float secondary_voltage;
-            uint16_t motor_temp_deg;
-            uint16_t pcb_temp_deg;
+            int16_t motor_temp_deg;
+            int16_t pcb_temp_deg;
         } data[NUM_SERVO_CHANNELS];
         uint32_t last_log_ms;
     } telem;


### PR DESCRIPTION
Bugfix to the recent Volz protocol implementation. _motor_temp_deg_ and _pcb_temp_deg_ are both defined as uint16_t which is valid pre-scaling (ie. receiving the message from the buffer) but with scaling being done below (range -49 to +204) this will need to account for signed values.

```
case CMD_ID::TEMPERATURE_RESPONSE:
      // Temperature is reported relative to -50 deg C
      telem.data[index].motor_temp_deg = -50 + cmd.arg1;
      telem.data[index].pcb_temp_deg = -50 + cmd.arg2;
      break;
```