### PR TITLE
Tools: add bebop to Python all-boards list

### DIFF
--- a/Tools/scripts/board_list.py
+++ b/Tools/scripts/board_list.py
@@ -69,6 +69,7 @@ class BoardList(object):
             Board("obal"),
             Board("pxf"),
             Board("bbbmini"),
+            Board("bebop"),
             Board("blue"),
             Board("pxfmini"),
             Board("canzero"),


### PR DESCRIPTION
Whoops.  Bit of an omission.
