### PR TITLE
Tools: Recommend what to do when astyle fails

### DIFF
--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -473,7 +473,11 @@ for t in $CI_BUILD_TARGET; do
 
     if [ "$t" == "astyle-cleanliness" ]; then
         echo "Checking AStyle code cleanliness"
+
         ./Tools/scripts/run_astyle.py --dry-run
+        if [ $? -ne 0 ]; then
+            echo The code failed astyle cleanliness checks. Please run ./Tools/scripts/run_astyle.py
+        fi
         continue
     fi
 

--- a/Tools/scripts/run_astyle.py
+++ b/Tools/scripts/run_astyle.py
@@ -60,7 +60,7 @@ class AStyleChecker(object):
             self.progress("astyle check failed: (%s)" % (ret.stdout))
             self.retcode = 1
         if "Formatted" in ret.stdout:
-            self.progress("Files needing formatting found")
+            self.progress("Files needing formatting found.")
             print(ret.stdout)
             self.retcode = 1
 

--- a/libraries/AP_DDS/README.md
+++ b/libraries/AP_DDS/README.md
@@ -364,10 +364,10 @@ for additional details.
 ### Development Requirements
 
 Astyle is used to format the C++ code in AP_DDS. This is required for CI to pass the build.
-See [Tools/CodeStyle/ardupilot-astyle.sh](../../Tools/CodeStyle/ardupilot-astyle.sh).
+To run the automated formatter, run:
 
 ```bash
-./Tools/CodeStyle/ardupilot-astyle.sh libraries/AP_DDS/*.h libraries/AP_DDS/*.cpp
+./Tools/scripts/run_astyle.py
 ```
 
 Pre-commit is used for other things like formatting python and XML code.


### PR DESCRIPTION
# Purpose

Tell developers what to do if the astyle check fails. 

# Motivation

https://github.com/ArduPilot/ardupilot_wiki/pull/6292#discussion_r1777897717

# Demo

This is what a developer will see if they push code and CI fails. 

Specifically, we went from:
```
****** Files needing formatting found.
```
to:
```
****** Files needing formatting found. Please run ./Tools/scripts/run_astyle.py
```

In the screenshot below, I intentionally broke formatting in AP_DDS_Client.h. This is what the script will display in CI.
![image](https://github.com/user-attachments/assets/80848188-96f8-4a44-8ef9-e489b346e822)
