### PR TITLE
Fix incorrect astyle option that breaks in astyle 3.6.4

### DIFF
--- a/Tools/CodeStyle/astylerc
+++ b/Tools/CodeStyle/astylerc
@@ -1,6 +1,6 @@
 style=linux
 keep-one-line-statements
-add-brackets
+add-braces
 indent=spaces=4
 indent-col1-comments
 min-conditional-indent=0


### PR DESCRIPTION
# Purpose

* It should be called add-braces not add-brackets
* https://astyle.sourceforge.net/astyle.html
* Running newer astyle fails on this option
* Enforcing it has no effect on existing astyle-formatted code

# Proof

I downloaded the latest version of astyle, rather than the one installed from apt on Ubuntu 22. I ran it on our code. 
It errored out. This PR fixes the error. Code style works the same in the latest astyle as it does with our current version in Ubuntu 22. This is a pre-requisite to installing astyle in our setup scripts and starting to enforce automatically.

# Demo

I installed the latest `astyle`, version `3.6.4`.
```
ryan@B650-970:~/Dev/ardu_ws/src/ardupilot$ which astyle 
/home/ryan/Dev/ardu_ws/src/astyle/build/AStyle/astyle
ryan@B650-970:~/Dev/ardu_ws/src/ardupilot$ astyle --version
Artistic Style Version 3.6.4
```

Then I ran it against ardupilot `master`. It had this error.
```
ryan@B650-970:~/Dev/ardu_ws/src/ardupilot$ ./Tools/scripts/run_astyle.py 
****** astyle check failed: (Invalid Artistic Style options:
        add-brackets
For help on options type 'astyle -h'
Artistic Style has terminated

)
```

With this PR, the error is fixed, and style is not impacted. 