### PR TITLE
Tools: Add wsproto to ubuntu python deps

### DIFF
--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -164,7 +164,7 @@ fi
 # Lists of packages to install
 BASE_PKGS="build-essential ccache g++ gawk git make wget valgrind screen python3-pexpect"
 PYTHON_PKGS="future lxml pymavlink pyserial MAVProxy geocoder empy==3.3.4 ptyprocess dronecan"
-PYTHON_PKGS="$PYTHON_PKGS flake8 junitparser"
+PYTHON_PKGS="$PYTHON_PKGS flake8 junitparser wsproto"
 
 # add some Python packages required for commonly-used MAVProxy modules and hex file generation:
 if [[ $SKIP_AP_EXT_ENV -ne 1 ]]; then


### PR DESCRIPTION
* Used in pymavlink to add websocket output

The changes to add wsproto in https://github.com/ArduPilot/pymavlink/pull/967/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552R10 do not affect the standard dev workflow.

If you fail to install wsproto, you get this in sim_vehicle.py:
![image](https://github.com/user-attachments/assets/df01a0ee-1f62-4feb-a46f-6fff361c81b2)


Context: 
https://discord.com/channels/674039678562861068/715368769983348806/1304555852891557971


Relates to https://github.com/ArduPilot/pymavlink/pull/975