### PR TITLE
AP_Mount: tidy header includes

### DIFF
--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -1,8 +1,10 @@
+#include "AP_Mount_config.h"
+
+#if HAL_MOUNT_ENABLED
+
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
 #include "AP_Mount.h"
-
-#if HAL_MOUNT_ENABLED
 
 #include "AP_Mount_Backend.h"
 #include "AP_Mount_Servo.h"

--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -1,6 +1,9 @@
-#include "AP_Mount_Alexmos.h"
+#include "AP_Mount_config.h"
 
 #if HAL_MOUNT_ALEXMOS_ENABLED
+
+#include "AP_Mount_Alexmos.h"
+
 #include <AP_SerialManager/AP_SerialManager.h>
 
 //definition of the commands id for the Alexmos Serial Protocol

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -3,9 +3,12 @@
 */
 #pragma once
 
-#include "AP_Mount_Backend.h"
+#include "AP_Mount_config.h"
 
 #if HAL_MOUNT_ALEXMOS_ENABLED
+
+#include "AP_Mount_Backend.h"
+
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -1,5 +1,9 @@
-#include "AP_Mount_Backend.h"
+#include "AP_Mount_config.h"
+
 #if HAL_MOUNT_ENABLED
+
+#include "AP_Mount_Backend.h"
+
 #include <AP_AHRS/AP_AHRS.h>
 #include <GCS_MAVLink/GCS.h>
 #include <AP_Logger/AP_Logger.h>

--- a/libraries/AP_Mount/AP_Mount_Backend_Serial.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend_Serial.cpp
@@ -1,6 +1,9 @@
-#include "AP_Mount_Backend_Serial.h"
+#include "AP_Mount_config.h"
 
 #if HAL_MOUNT_ENABLED
+
+#include "AP_Mount_Backend_Serial.h"
+
 #include <AP_SerialManager/AP_SerialManager.h>
 
 // Default init function for every mount

--- a/libraries/AP_Mount/AP_Mount_Gremsy.cpp
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.cpp
@@ -1,6 +1,8 @@
-#include "AP_Mount_Gremsy.h"
+#include "AP_Mount_config.h"
 
 #if HAL_MOUNT_GREMSY_ENABLED
+
+#include "AP_Mount_Gremsy.h"
 
 #include <AP_HAL/AP_HAL.h>
 #include <GCS_MAVLink/GCS.h>

--- a/libraries/AP_Mount/AP_Mount_Gremsy.h
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.h
@@ -3,9 +3,11 @@
  */
 #pragma once
 
-#include "AP_Mount_Backend.h"
+#include "AP_Mount_config.h"
 
 #if HAL_MOUNT_GREMSY_ENABLED
+
+#include "AP_Mount_Backend.h"
 
 #include <AP_Math/AP_Math.h>
 #include <AP_Common/AP_Common.h>

--- a/libraries/AP_Mount/AP_Mount_SToRM32.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.cpp
@@ -1,6 +1,9 @@
-#include "AP_Mount_SToRM32.h"
+#include "AP_Mount_config.h"
 
 #if HAL_MOUNT_STORM32MAVLINK_ENABLED
+
+#include "AP_Mount_SToRM32.h"
+
 #include <AP_HAL/AP_HAL.h>
 #include <GCS_MAVLink/GCS.h>
 

--- a/libraries/AP_Mount/AP_Mount_SToRM32.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.h
@@ -3,9 +3,11 @@
  */
 #pragma once
 
-#include "AP_Mount_Backend.h"
+#include "AP_Mount_config.h"
 
 #if HAL_MOUNT_STORM32MAVLINK_ENABLED
+
+#include "AP_Mount_Backend.h"
 
 #include <AP_Math/AP_Math.h>
 #include <AP_Common/AP_Common.h>

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
@@ -1,6 +1,9 @@
-#include "AP_Mount_SToRM32_serial.h"
+#include "AP_Mount_config.h"
 
 #if HAL_MOUNT_STORM32SERIAL_ENABLED
+
+#include "AP_Mount_SToRM32_serial.h"
+
 #include <AP_HAL/AP_HAL.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <GCS_MAVLink/include/mavlink/v2.0/checksum.h>

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
@@ -3,9 +3,11 @@
  */
 #pragma once
 
-#include "AP_Mount_Backend_Serial.h"
+#include "AP_Mount_config.h"
 
 #if HAL_MOUNT_STORM32SERIAL_ENABLED
+
+#include "AP_Mount_Backend_Serial.h"
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>

--- a/libraries/AP_Mount/AP_Mount_Scripting.cpp
+++ b/libraries/AP_Mount/AP_Mount_Scripting.cpp
@@ -1,6 +1,9 @@
-#include "AP_Mount_Scripting.h"
+#include "AP_Mount_config.h"
 
 #if HAL_MOUNT_SCRIPTING_ENABLED
+
+#include "AP_Mount_Scripting.h"
+
 #include <AP_HAL/AP_HAL.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <GCS_MAVLink/GCS.h>

--- a/libraries/AP_Mount/AP_Mount_Scripting.h
+++ b/libraries/AP_Mount/AP_Mount_Scripting.h
@@ -4,9 +4,11 @@
 
 #pragma once
 
-#include "AP_Mount_Backend.h"
+#include "AP_Mount_config.h"
 
 #if HAL_MOUNT_SCRIPTING_ENABLED
+
+#include "AP_Mount_Backend.h"
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
@@ -50,4 +52,4 @@ private:
     bool target_loc_valid;          // true if target_loc holds a valid target location
 };
 
-#endif // HAL_MOUNT_SIYISERIAL_ENABLED
+#endif // HAL_MOUNT_SCRIPTING_ENABLED

--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -1,5 +1,8 @@
-#include "AP_Mount_Servo.h"
+#include "AP_Mount_config.h"
+
 #if HAL_MOUNT_SERVO_ENABLED
+
+#include "AP_Mount_Servo.h"
 
 #include <AP_AHRS/AP_AHRS.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>

--- a/libraries/AP_Mount/AP_Mount_Servo.h
+++ b/libraries/AP_Mount/AP_Mount_Servo.h
@@ -3,9 +3,11 @@
  */
 #pragma once
 
-#include "AP_Mount_Backend.h"
+#include "AP_Mount_config.h"
 
 #if HAL_MOUNT_SERVO_ENABLED
+
+#include "AP_Mount_Backend.h"
 
 #include <AP_Math/AP_Math.h>
 #include <AP_Common/AP_Common.h>

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -1,6 +1,9 @@
-#include "AP_Mount_Siyi.h"
+#include "AP_Mount_config.h"
 
 #if HAL_MOUNT_SIYI_ENABLED
+
+#include "AP_Mount_Siyi.h"
+
 #include <AP_HAL/AP_HAL.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <GCS_MAVLink/GCS.h>

--- a/libraries/AP_Mount/AP_Mount_Siyi.h
+++ b/libraries/AP_Mount/AP_Mount_Siyi.h
@@ -19,9 +19,11 @@
 
 #pragma once
 
-#include "AP_Mount_Backend_Serial.h"
+#include "AP_Mount_config.h"
 
 #if HAL_MOUNT_SIYI_ENABLED
+
+#include "AP_Mount_Backend_Serial.h"
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
@@ -381,4 +383,4 @@ private:
     uint8_t sent_time_count;
 };
 
-#endif // HAL_MOUNT_SIYISERIAL_ENABLED
+#endif // HAL_MOUNT_SIYI_ENABLED

--- a/libraries/AP_Mount/AP_Mount_Topotek.cpp
+++ b/libraries/AP_Mount/AP_Mount_Topotek.cpp
@@ -1,6 +1,8 @@
-#include "AP_Mount_Topotek.h"
+#include "AP_Mount_config.h"
 
 #if HAL_MOUNT_TOPOTEK_ENABLED
+
+#include "AP_Mount_Topotek.h"
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_AHRS/AP_AHRS.h>

--- a/libraries/AP_Mount/AP_Mount_Viewpro.cpp
+++ b/libraries/AP_Mount/AP_Mount_Viewpro.cpp
@@ -1,6 +1,9 @@
-#include "AP_Mount_Viewpro.h"
+#include "AP_Mount_config.h"
 
 #if HAL_MOUNT_VIEWPRO_ENABLED
+
+#include "AP_Mount_Viewpro.h"
+
 #include <AP_HAL/AP_HAL.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_GPS/AP_GPS.h>

--- a/libraries/AP_Mount/AP_Mount_Viewpro.h
+++ b/libraries/AP_Mount/AP_Mount_Viewpro.h
@@ -16,9 +16,11 @@
 
 #pragma once
 
-#include "AP_Mount_Backend_Serial.h"
+#include "AP_Mount_config.h"
 
 #if HAL_MOUNT_VIEWPRO_ENABLED
+
+#include "AP_Mount_Backend_Serial.h"
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>

--- a/libraries/AP_Mount/AP_Mount_Xacti.cpp
+++ b/libraries/AP_Mount/AP_Mount_Xacti.cpp
@@ -1,6 +1,9 @@
-#include "AP_Mount_Xacti.h"
+#include "AP_Mount_config.h"
 
 #if HAL_MOUNT_XACTI_ENABLED
+
+#include "AP_Mount_Xacti.h"
+
 #include <AP_HAL/AP_HAL.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <GCS_MAVLink/GCS.h>

--- a/libraries/AP_Mount/AP_Mount_Xacti.h
+++ b/libraries/AP_Mount/AP_Mount_Xacti.h
@@ -8,9 +8,11 @@
 
 #pragma once
 
-#include "AP_Mount_Backend.h"
+#include "AP_Mount_config.h"
 
 #if HAL_MOUNT_XACTI_ENABLED
+
+#include "AP_Mount_Backend.h"
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>

--- a/libraries/AP_Mount/AP_Mount_config.h
+++ b/libraries/AP_Mount/AP_Mount_config.h
@@ -2,6 +2,8 @@
 
 #include <AP_HAL/AP_HAL_Boards.h>
 #include <AP_Terrain/AP_Terrain_config.h>
+#include <GCS_MAVLink/GCS_config.h>
+#include <AP_Scripting/AP_Scripting_config.h>
 
 #ifndef HAL_MOUNT_ENABLED
 #define HAL_MOUNT_ENABLED 1

--- a/libraries/AP_Mount/SoloGimbal.cpp
+++ b/libraries/AP_Mount/SoloGimbal.cpp
@@ -1,8 +1,10 @@
+#include "AP_Mount_config.h"
+
+#if HAL_SOLO_GIMBAL_ENABLED
+
 #include <AP_HAL/AP_HAL.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include "SoloGimbal.h"
-
-#if HAL_SOLO_GIMBAL_ENABLED
 
 #include <stdio.h>
 #include <GCS_MAVLink/GCS.h>

--- a/libraries/AP_Mount/SoloGimbalEKF.cpp
+++ b/libraries/AP_Mount/SoloGimbalEKF.cpp
@@ -1,3 +1,7 @@
+#include "AP_Mount_config.h"
+
+#if HAL_SOLO_GIMBAL_ENABLED
+
 #include <AP_HAL/AP_HAL.h>
 
 // uncomment this to force the optimisation of this code, note that
@@ -9,7 +13,6 @@
 #endif
 
 #include "SoloGimbalEKF.h"
-#if HAL_SOLO_GIMBAL_ENABLED
 #include <AP_Param/AP_Param.h>
 #include <AP_NavEKF/AP_Nav_Common.h>
 #include <AP_AHRS/AP_AHRS.h>

--- a/libraries/AP_Mount/SoloGimbal_Parameters.cpp
+++ b/libraries/AP_Mount/SoloGimbal_Parameters.cpp
@@ -1,5 +1,8 @@
-#include "SoloGimbal_Parameters.h"
+#include "AP_Mount_config.h"
+
 #if HAL_SOLO_GIMBAL_ENABLED
+
+#include "SoloGimbal_Parameters.h"
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Logger/AP_Logger.h>
 #include <GCS_MAVLink/GCS.h>


### PR DESCRIPTION
our pattern is to include the config file and then use the relevant define, with nothing in between

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                                                     
CubeRedPrimary                      *      *           *       *                 *      *      *
Durandal                            *      *           *       *                 *      *      *
Hitec-Airspeed           *                                                                     
KakuteH7-bdshot                     *      *           *       *                 *      *      *
MatekF405                           *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *                  *       *                 *      *      *
f103-QiotekPeriph        *                                                                     
f303-Universal           *                                                                     
iomcu                                                                *                         
revo-mini                           *      *           *       *                 *      *      *
skyviper-journey                                       *                                       
skyviper-v2450                                         *                                       
```
