### PR TITLE
AP_Bootloader: ID reserved for MicoAir743AIOv1

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -291,6 +291,7 @@ AP_HW_PhenixH7_Pro                   1172
 AP_HW_2RAWH743                       1173
 AP_HW_X-MAV-AP-H743V2                1174
 AP_HW_BETAFPV_F4_2-3S_20A            1175
+AP_HW_MicoAir743AIOv1                1176
 
 AP_HW_FlywooF405HD_AIOv2             1180
 AP_HW_FlywooH743Pro                  1181


### PR DESCRIPTION
Reserve an ID for the upcoming MicoAir743AIOv1.