### PR TITLE
Use RC_Channel to populate IOMCU mappings

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -329,7 +329,7 @@ void Plane::one_second_loop()
     set_control_channels();
 
 #if HAL_WITH_IO_MCU
-    iomcu.setup_mixing(&rcmap, g.override_channel.get(), g.mixing_gain, g2.manual_rc_mask);
+    iomcu.setup_mixing(g.override_channel.get(), g.mixing_gain, g2.manual_rc_mask);
 #endif
 
 #if HAL_ADSB_ENABLED

--- a/libraries/AP_IOMCU/AP_IOMCU.h
+++ b/libraries/AP_IOMCU/AP_IOMCU.h
@@ -11,7 +11,6 @@
 #if HAL_WITH_IO_MCU
 
 #include "iofirmware/ioprotocol.h"
-#include <AP_RCMapper/AP_RCMapper.h>
 #include <AP_HAL/RCOutput.h>
 #include <AP_ESC_Telem/AP_ESC_Telem_Backend.h>
 
@@ -151,7 +150,7 @@ public:
     void soft_reboot();
 
     // setup for FMU failsafe mixing
-    bool setup_mixing(RCMapper *rcmap, int8_t override_chan,
+    bool setup_mixing(int8_t override_chan,
                       float mixing_gain, uint16_t manual_rc_mask);
 
     // Check if pin number is valid and configured for GPIO


### PR DESCRIPTION
Bench-tested using an OrangeRX and a CubeOrangePlus and a servo.  All seems right compared to master.

```
Board,plane
CubeOrangePlus,-32
```
