### PR TITLE
MAVLink: add support for the `AVAILABLE_MODES` message

### DIFF
--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -315,7 +315,8 @@ static const ap_message STREAM_EXTRA3_msgs[] = {
     MSG_BATTERY_STATUS,
 };
 static const ap_message STREAM_PARAMS_msgs[] = {
-    MSG_NEXT_PARAM
+    MSG_NEXT_PARAM,
+    MSG_AVAILABLE_MODES
 };
 
 const struct GCS_MAVLINK::stream_entries GCS_MAVLINK::all_stream_entries[] = {
@@ -642,4 +643,44 @@ void GCS_MAVLINK_Tracker::send_global_position_int()
         0,                        // Y speed cm/s (+ve East)
         0,                        // Z speed cm/s (+ve Down)
         tracker.ahrs.yaw_sensor); // compass heading in 1/100 degree
+}
+
+// Send the mode with the given index (not mode number!) return the total number of modes
+// Index starts at 1
+uint8_t GCS_MAVLINK_Tracker::send_available_mode(uint8_t index) const
+{
+    const Mode* modes[] {
+        &tracker.mode_manual,
+        &tracker.mode_stop,
+        &tracker.mode_scan,
+        &tracker.mode_guided,
+        &tracker.mode_servotest,
+        &tracker.mode_auto,
+        &tracker.mode_initialising,
+    };
+
+    const uint8_t mode_count = ARRAY_SIZE(modes);
+
+    // Convert to zero indexed
+    const uint8_t index_zero = index - 1;
+    if (index_zero >= mode_count) {
+        // Mode does not exist!?
+        return mode_count;
+    }
+
+    // Ask the mode for its name and number
+    const char* name = modes[index_zero]->name();
+    const uint8_t mode_number = (uint8_t)modes[index_zero]->number();
+
+    mavlink_msg_available_modes_send(
+        chan,
+        mode_count,
+        index,
+        MAV_STANDARD_MODE::MAV_STANDARD_MODE_NON_STANDARD,
+        mode_number,
+        0, // MAV_MODE_PROPERTY bitmask
+        name
+    );
+
+    return mode_count;
 }

--- a/AntennaTracker/GCS_Mavlink.h
+++ b/AntennaTracker/GCS_Mavlink.h
@@ -30,6 +30,10 @@ protected:
     void send_nav_controller_output() const override;
     void send_pid_tuning() override;
 
+    // Send the mode with the given index (not mode number!) return the total number of modes
+    // Index starts at 1
+    uint8_t send_available_mode(uint8_t index) const override;
+
 private:
 
     void packetReceived(const mavlink_status_t &status, const mavlink_message_t &msg) override;

--- a/AntennaTracker/mode.h
+++ b/AntennaTracker/mode.h
@@ -22,6 +22,7 @@ public:
 
     // returns a unique number specific to this mode
     virtual Mode::Number number() const = 0;
+    virtual const char* name() const = 0;
 
     virtual bool requires_armed_servos() const = 0;
 
@@ -41,6 +42,7 @@ protected:
 class ModeAuto : public Mode {
 public:
     Mode::Number number() const override { return Mode::Number::AUTO; }
+    const char* name() const override { return "Auto"; }
     bool requires_armed_servos() const override { return true; }
     void update() override;
 };
@@ -48,6 +50,7 @@ public:
 class ModeGuided : public Mode {
 public:
     Mode::Number number() const override { return Mode::Number::GUIDED; }
+    const char* name() const override { return "Guided"; }
     bool requires_armed_servos() const override { return true; }
     void update() override;
 
@@ -66,6 +69,7 @@ private:
 class ModeInitialising : public Mode {
 public:
     Mode::Number number() const override { return Mode::Number::INITIALISING; }
+    const char* name() const override { return "Initialising"; }
     bool requires_armed_servos() const override { return false; }
     void update() override {};
 };
@@ -73,6 +77,7 @@ public:
 class ModeManual : public Mode {
 public:
     Mode::Number number() const override { return Mode::Number::MANUAL; }
+    const char* name() const override { return "Manual"; }
     bool requires_armed_servos() const override { return true; }
     void update() override;
 };
@@ -80,6 +85,7 @@ public:
 class ModeScan : public Mode {
 public:
     Mode::Number number() const override { return Mode::Number::SCAN; }
+    const char* name() const override { return "Scan"; }
     bool requires_armed_servos() const override { return true; }
     void update() override;
 };
@@ -87,6 +93,7 @@ public:
 class ModeServoTest : public Mode {
 public:
     Mode::Number number() const override { return Mode::Number::SERVOTEST; }
+    const char* name() const override { return "ServoTest"; }
     bool requires_armed_servos() const override { return true; }
     void update() override {};
 
@@ -96,6 +103,7 @@ public:
 class ModeStop : public Mode {
 public:
     Mode::Number number() const override { return Mode::Number::STOP; }
+    const char* name() const override { return "Stop"; }
     bool requires_armed_servos() const override { return false; }
     void update() override {};
 };

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -583,7 +583,8 @@ static const ap_message STREAM_EXTRA3_msgs[] = {
 #endif
 };
 static const ap_message STREAM_PARAMS_msgs[] = {
-    MSG_NEXT_PARAM
+    MSG_NEXT_PARAM,
+    MSG_AVAILABLE_MODES
 };
 static const ap_message STREAM_ADSB_msgs[] = {
     MSG_ADSB_VEHICLE,
@@ -1657,3 +1658,120 @@ uint8_t GCS_MAVLINK_Copter::high_latency_wind_direction() const
     return 0;
 }
 #endif // HAL_HIGH_LATENCY2_ENABLED
+
+// Send the mode with the given index (not mode number!) return the total number of modes
+// Index starts at 1
+uint8_t GCS_MAVLINK_Copter::send_available_mode(uint8_t index) const
+{
+    const Mode* modes[] {
+#if MODE_AUTO_ENABLED
+        &copter.mode_auto, // This auto is actually auto RTL!
+        &copter.mode_auto, // This one is really is auto!
+#endif
+#if MODE_ACRO_ENABLED
+        &copter.mode_acro,
+#endif
+        &copter.mode_stabilize,
+        &copter.mode_althold,
+#if MODE_CIRCLE_ENABLED
+        &copter.mode_circle,
+#endif
+#if MODE_LOITER_ENABLED
+        &copter.mode_loiter,
+#endif
+#if MODE_GUIDED_ENABLED
+        &copter.mode_guided,
+#endif
+        &copter.mode_land,
+#if MODE_RTL_ENABLED
+        &copter.mode_rtl,
+#endif
+#if MODE_DRIFT_ENABLED
+        &copter.mode_drift,
+#endif
+#if MODE_SPORT_ENABLED
+        &copter.mode_sport,
+#endif
+#if MODE_FLIP_ENABLED
+        &copter.mode_flip,
+#endif
+#if AUTOTUNE_ENABLED
+        &copter.mode_autotune,
+#endif
+#if MODE_POSHOLD_ENABLED
+        &copter.mode_poshold,
+#endif
+#if MODE_BRAKE_ENABLED
+        &copter.mode_brake,
+#endif
+#if MODE_THROW_ENABLED
+        &copter.mode_throw,
+#endif
+#if HAL_ADSB_ENABLED
+        &copter.mode_avoid_adsb,
+#endif
+#if MODE_GUIDED_NOGPS_ENABLED
+        &copter.mode_guided_nogps,
+#endif
+#if MODE_SMARTRTL_ENABLED
+        &copter.mode_smartrtl,
+#endif
+#if MODE_FLOWHOLD_ENABLED
+        (Mode*)copter.g2.mode_flowhold_ptr,
+#endif
+#if MODE_FOLLOW_ENABLED
+        &copter.mode_follow,
+#endif
+#if MODE_ZIGZAG_ENABLED
+        &copter.mode_zigzag,
+#endif
+#if MODE_SYSTEMID_ENABLED
+        (Mode *)copter.g2.mode_systemid_ptr,
+#endif
+#if MODE_AUTOROTATE_ENABLED
+        &copter.mode_autorotate,
+#endif
+#if MODE_TURTLE_ENABLED
+        &copter.mode_turtle,
+#endif
+    };
+
+    const uint8_t mode_count = ARRAY_SIZE(modes);
+
+    // Convert to zero indexed
+    const uint8_t index_zero = index - 1;
+    if (index_zero >= mode_count) {
+        // Mode does not exist!?
+        return mode_count;
+    }
+
+    // Ask the mode for its name and number
+    const char* name = modes[index_zero]->name();
+    uint8_t mode_number = (uint8_t)modes[index_zero]->mode_number();
+
+#if MODE_AUTO_ENABLED
+    // Auto RTL is odd
+    // Have to deal with is separately becase its number and name can change depending on if were in it or not
+    if (index_zero == 0) {
+        mode_number = (uint8_t)Mode::Number::AUTO_RTL;
+        name = "AUTO RTL";
+
+    } else if (index_zero == 1) {
+        mode_number = (uint8_t)Mode::Number::AUTO;
+        name = "AUTO";
+
+    }
+#endif
+
+    mavlink_msg_available_modes_send(
+        chan,
+        mode_count,
+        index,
+        MAV_STANDARD_MODE::MAV_STANDARD_MODE_NON_STANDARD,
+        mode_number,
+        0, // MAV_MODE_PROPERTY bitmask
+        name
+    );
+
+    return mode_count;
+}

--- a/ArduCopter/GCS_Mavlink.h
+++ b/ArduCopter/GCS_Mavlink.h
@@ -64,6 +64,10 @@ protected:
     uint32_t log_radio_bit() const override { return MASK_LOG_PM; }
 #endif
 
+    // Send the mode with the given index (not mode number!) return the total number of modes
+    // Index starts at 1
+    uint8_t send_available_mode(uint8_t index) const override;
+
 private:
 
     // sanity check velocity or acceleration vector components are numbers

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -710,7 +710,8 @@ static const ap_message STREAM_EXTRA3_msgs[] = {
     MSG_VIBRATION,
 };
 static const ap_message STREAM_PARAMS_msgs[] = {
-    MSG_NEXT_PARAM
+    MSG_NEXT_PARAM,
+    MSG_AVAILABLE_MODES
 };
 static const ap_message STREAM_ADSB_msgs[] = {
     MSG_ADSB_VEHICLE,
@@ -1539,3 +1540,99 @@ MAV_LANDED_STATE GCS_MAVLINK_Plane::landed_state() const
     return MAV_LANDED_STATE_ON_GROUND;
 }
 
+// Send the mode with the given index (not mode number!) return the total number of modes
+// Index starts at 1
+uint8_t GCS_MAVLINK_Plane::send_available_mode(uint8_t index) const
+{
+    // Fixed wing modes
+    const Mode* fw_modes[] {
+        &plane.mode_manual,
+        &plane.mode_circle,
+        &plane.mode_stabilize,
+        &plane.mode_training,
+        &plane.mode_acro,
+        &plane.mode_fbwa,
+        &plane.mode_fbwb,
+        &plane.mode_cruise,
+        &plane.mode_autotune,
+        &plane.mode_auto,
+        &plane.mode_rtl,
+        &plane.mode_loiter,
+#if HAL_ADSB_ENABLED
+        &plane.mode_avoidADSB,
+#endif
+        &plane.mode_guided,
+        &plane.mode_initializing,
+        &plane.mode_takeoff,
+#if HAL_SOARING_ENABLED
+        &plane.mode_thermal,
+#endif
+    };
+
+    const uint8_t fw_mode_count = ARRAY_SIZE(fw_modes);
+
+    // Fixedwing modes are always present
+    uint8_t mode_count = fw_mode_count;
+
+#if HAL_QUADPLANE_ENABLED
+    // Quadplane modes
+    const Mode* q_modes[] {
+        &plane.mode_qstabilize,
+        &plane.mode_qhover,
+        &plane.mode_qloiter,
+        &plane.mode_qland,
+        &plane.mode_qrtl,
+        &plane.mode_qacro,
+        &plane.mode_loiter_qland,
+#if QAUTOTUNE_ENABLED
+        &plane.mode_qautotune,
+#endif
+    };
+
+    // Quadplane modes must be enabled
+    if (plane.quadplane.available()) {
+        mode_count += ARRAY_SIZE(q_modes);
+    }
+#endif // HAL_QUADPLANE_ENABLED
+
+
+    // Convert to zero indexed
+    const uint8_t index_zero = index - 1;
+    if (index_zero >= mode_count) {
+        // Mode does not exist!?
+        return mode_count;
+    }
+
+    // Ask the mode for its name and number
+    const char* name;
+    uint8_t mode_number;
+
+    if (index_zero < fw_mode_count) {
+        // A fixedwing mode
+        name = fw_modes[index_zero]->name();
+        mode_number = (uint8_t)fw_modes[index_zero]->mode_number();
+
+    } else {
+#if HAL_QUADPLANE_ENABLED
+        // A Quadplane mode
+        const uint8_t q_index = index_zero - fw_mode_count;
+        name = q_modes[q_index]->name();
+        mode_number = (uint8_t)q_modes[q_index]->mode_number();
+#else
+        // Should not endup here
+        return mode_count;
+#endif
+    }
+
+    mavlink_msg_available_modes_send(
+        chan,
+        mode_count,
+        index,
+        MAV_STANDARD_MODE::MAV_STANDARD_MODE_NON_STANDARD,
+        mode_number,
+        0, // MAV_MODE_PROPERTY bitmask
+        name
+    );
+
+    return mode_count;
+}

--- a/ArduPlane/GCS_Mavlink.h
+++ b/ArduPlane/GCS_Mavlink.h
@@ -50,6 +50,10 @@ protected:
     void handle_manual_control_axes(const mavlink_manual_control_t &packet, const uint32_t tnow) override;
     void handle_landing_target(const mavlink_landing_target_t &packet, uint32_t timestamp_ms) override;
 
+    // Send the mode with the given index (not mode number!) return the total number of modes
+    // Index starts at 1
+    uint8_t send_available_mode(uint8_t index) const override;
+
 private:
 
     void send_pid_info(const struct AP_PIDInfo *pid_info, const uint8_t axis, const float achieved);

--- a/ArduSub/GCS_Mavlink.h
+++ b/ArduSub/GCS_Mavlink.h
@@ -37,6 +37,10 @@ protected:
 
     uint64_t capabilities() const override;
 
+    // Send the mode with the given index (not mode number!) return the total number of modes
+    // Index starts at 1
+    uint8_t send_available_mode(uint8_t index) const override;
+
 private:
 
     void handle_message(const mavlink_message_t &msg) override;

--- a/ArduSub/mode.h
+++ b/ArduSub/mode.h
@@ -72,6 +72,9 @@ public:
     virtual const char *name() const = 0;
     virtual const char *name4() const = 0;
 
+    // returns a unique number specific to this mode
+    virtual Mode::Number number() const = 0;
+
     // functions for reporting to GCS
     virtual bool get_wp(Location &loc) { return false; }
     virtual int32_t wp_bearing() const { return 0; }
@@ -202,6 +205,7 @@ protected:
 
     const char *name() const override { return "MANUAL"; }
     const char *name4() const override { return "MANU"; }
+    Mode::Number number() const override { return Mode::Number::MANUAL; }
 };
 
 
@@ -224,6 +228,7 @@ protected:
 
     const char *name() const override { return "ACRO"; }
     const char *name4() const override { return "ACRO"; }
+    Mode::Number number() const override { return Mode::Number::ACRO; }
 };
 
 
@@ -246,6 +251,7 @@ protected:
 
     const char *name() const override { return "STABILIZE"; }
     const char *name4() const override { return "STAB"; }
+    Mode::Number number() const override { return Mode::Number::STABILIZE; }
 };
 
 
@@ -272,6 +278,7 @@ protected:
 
     const char *name() const override { return "ALT_HOLD"; }
     const char *name4() const override { return "ALTH"; }
+    Mode::Number number() const override { return Mode::Number::ALT_HOLD; }
 };
 
 
@@ -293,6 +300,7 @@ protected:
 
     const char *name() const override { return "SURFTRAK"; }
     const char *name4() const override { return "STRK"; }
+    Mode::Number number() const override { return Mode::Number::SURFTRAK; }
 
 private:
 
@@ -342,6 +350,8 @@ protected:
 
     const char *name() const override { return "GUIDED"; }
     const char *name4() const override { return "GUID"; }
+    Mode::Number number() const override { return Mode::Number::GUIDED; }
+
     autopilot_yaw_mode get_default_auto_yaw_mode(bool rtl) const;
 
 private:
@@ -387,6 +397,7 @@ protected:
 
     const char *name() const override { return "AUTO"; }
     const char *name4() const override { return "AUTO"; }
+    Mode::Number number() const override { return Mode::Number::AUTO; }
 
 private:
     void auto_wp_run();
@@ -417,6 +428,7 @@ protected:
 
     const char *name() const override { return "POSHOLD"; }
     const char *name4() const override { return "POSH"; }
+    Mode::Number number() const override { return Mode::Number::POSHOLD; }
 };
 
 
@@ -439,6 +451,7 @@ protected:
 
     const char *name() const override { return "CIRCLE"; }
     const char *name4() const override { return "CIRC"; }
+    Mode::Number number() const override { return Mode::Number::CIRCLE; }
 };
 
 class ModeSurface : public Mode
@@ -460,6 +473,7 @@ protected:
 
     const char *name() const override { return "SURFACE"; }
     const char *name4() const override { return "SURF"; }
+    Mode::Number number() const override { return Mode::Number::CIRCLE; }
 };
 
 
@@ -482,4 +496,5 @@ protected:
 
     const char *name() const override { return "MOTORDETECT"; }
     const char *name4() const override { return "DETE"; }
+    Mode::Number number() const override { return Mode::Number::MOTOR_DETECT; }
 };

--- a/Blimp/GCS_Mavlink.cpp
+++ b/Blimp/GCS_Mavlink.cpp
@@ -395,7 +395,8 @@ static const ap_message STREAM_EXTRA3_msgs[] = {
 #endif
 };
 static const ap_message STREAM_PARAMS_msgs[] = {
-    MSG_NEXT_PARAM
+    MSG_NEXT_PARAM,
+    MSG_AVAILABLE_MODES
 };
 static const ap_message STREAM_ADSB_msgs[] = {
     MSG_ADSB_VEHICLE,
@@ -608,3 +609,41 @@ uint8_t GCS_MAVLINK_Blimp::high_latency_wind_direction() const
     return wrap_360(degrees(atan2f(-wind.y, -wind.x))) / 2;
 }
 #endif // HAL_HIGH_LATENCY2_ENABLED
+
+// Send the mode with the given index (not mode number!) return the total number of modes
+// Index starts at 1
+uint8_t GCS_MAVLINK_Blimp::send_available_mode(uint8_t index) const
+{
+    const Mode* modes[] {
+        &blimp.mode_land,
+        &blimp.mode_manual,
+        &blimp.mode_velocity,
+        &blimp.mode_loiter,
+        &blimp.mode_rtl,
+    };
+
+    const uint8_t mode_count = ARRAY_SIZE(modes);
+
+    // Convert to zero indexed
+    const uint8_t index_zero = index - 1;
+    if (index_zero >= mode_count) {
+        // Mode does not exist!?
+        return mode_count;
+    }
+
+    // Ask the mode for its name and number
+    const char* name = modes[index_zero]->name();
+    const uint8_t mode_number = (uint8_t)modes[index_zero]->number();
+
+    mavlink_msg_available_modes_send(
+        chan,
+        mode_count,
+        index,
+        MAV_STANDARD_MODE::MAV_STANDARD_MODE_NON_STANDARD,
+        mode_number,
+        0, // MAV_MODE_PROPERTY bitmask
+        name
+    );
+
+    return mode_count;
+}

--- a/Blimp/GCS_Mavlink.h
+++ b/Blimp/GCS_Mavlink.h
@@ -48,6 +48,10 @@ protected:
     uint32_t log_radio_bit() const override { return MASK_LOG_PM; }
 #endif
 
+    // Send the mode with the given index (not mode number!) return the total number of modes
+    // Index starts at 1
+    uint8_t send_available_mode(uint8_t index) const override;
+
 private:
 
     void handle_message(const mavlink_message_t &msg) override;

--- a/Blimp/mode.h
+++ b/Blimp/mode.h
@@ -52,6 +52,9 @@ public:
     virtual const char *name() const = 0;
     virtual const char *name4() const = 0;
 
+    // returns a unique number specific to this mode
+    virtual Mode::Number number() const = 0;
+
     virtual bool is_landing() const
     {
         return false;
@@ -159,6 +162,8 @@ protected:
         return "MANU";
     }
 
+    Mode::Number number() const override { return Mode::Number::MANUAL; }
+
 private:
 
 };
@@ -200,6 +205,8 @@ protected:
     {
         return "VELY";
     }
+
+    Mode::Number number() const override { return Mode::Number::VELOCITY; }
 
 private:
 
@@ -244,6 +251,8 @@ protected:
         return "LOIT";
     }
 
+    Mode::Number number() const override { return Mode::Number::LOITER; }
+
 private:
     Vector3f target_pos;
     float target_yaw;
@@ -285,6 +294,8 @@ protected:
     {
         return "LAND";
     }
+
+    Mode::Number number() const override { return Mode::Number::LAND; }
 
 private:
 
@@ -328,4 +339,7 @@ protected:
     {
         return "RTL";
     }
+
+    Mode::Number number() const override { return Mode::Number::RTL; }
+
 };

--- a/Rover/GCS_Mavlink.h
+++ b/Rover/GCS_Mavlink.h
@@ -40,6 +40,10 @@ protected:
     uint32_t log_radio_bit() const override { return MASK_LOG_PM; }
 #endif
 
+    // Send the mode with the given index (not mode number!) return the total number of modes
+    // Index starts at 1
+    uint8_t send_available_mode(uint8_t index) const override;
+
 private:
 
     void handle_message(const mavlink_message_t &msg) override;

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -412,6 +412,10 @@ public:
     void send_uavionix_adsb_out_status() const;
     void send_autopilot_state_for_gimbal_device() const;
 
+    // Send the mode with the given index (not mode number!) return the total number of modes
+    // Index starts at 1
+    virtual uint8_t send_available_mode(uint8_t index) const = 0;
+
     // lock a channel, preventing use by MAVLink
     void lock(bool _lock) {
         _locked = _lock;
@@ -1126,6 +1130,16 @@ private:
     // true if we should NOT do MAVLink on this port (usually because
     // someone's doing SERIAL_CONTROL over mavlink)
     bool _locked;
+
+    // Handling of AVAILABLE_MODES
+    struct {
+        bool should_send;
+        // Note these start at 1
+        uint8_t requested_index;
+        uint8_t next_index;
+    } available_modes;
+    bool send_available_modes();
+
 };
 
 /// @class GCS

--- a/libraries/GCS_MAVLink/GCS_Dummy.h
+++ b/libraries/GCS_MAVLink/GCS_Dummy.h
@@ -35,6 +35,7 @@ protected:
 
     void send_nav_controller_output() const override {};
     void send_pid_tuning() override {};
+    uint8_t send_available_mode(uint8_t index) const override { return 0; }
 };
 
 /*

--- a/libraries/GCS_MAVLink/ap_message.h
+++ b/libraries/GCS_MAVLink/ap_message.h
@@ -103,5 +103,6 @@ enum ap_message : uint8_t {
     MSG_HIGHRES_IMU,
 #endif
     MSG_AIRSPEED,
+    MSG_AVAILABLE_MODES,
     MSG_LAST // MSG_LAST must be the last entry in this enum
 };


### PR DESCRIPTION
This message allows the GCS to get the list of available modes at runtime. In the future this allows things like https://github.com/ArduPilot/ardupilot/pull/28110

This requires: https://github.com/ArduPilot/mavlink/pull/374

This message is supported by the QGC daily build and has been tested using it.

For example if you connect to a plane without Quadplane enabled it will only show the fixed wing modes:
![image](https://github.com/user-attachments/assets/9105c8e5-08ac-465c-8b83-d5dcca4b0207)

If you enable quadplane and re-connect you will then see all modes:
![image](https://github.com/user-attachments/assets/888f4a93-b311-4789-80b9-644d614865ff)

Current master shows a preconfigured subset of modes:
![image](https://github.com/user-attachments/assets/4c9a0d7e-40a9-46f6-8251-569133129378)

Editing a mode name in the cpp proves that it is updated with the new message:
![image](https://github.com/user-attachments/assets/a778ecb9-d2ff-46f1-80e6-62b976995cb7)

Future work (not for this PR):

- Fillout the message more completely:
  - Set `MAV_MODE_PROPERTY` bitmask for each mode.
  - Set `MAV_STANDARD_MODE` enum for each mode

- Report the current mode with the new `CURRENT_MODE` message

- Send `AVAILABLE_MODES_MONITOR` to allow the GCS to notice and re-request if the number of modes changes.

- Support `MAV_CMD_DO_SET_STANDARD_MODE`

- Addition of new modes from scripting and more.