### PR TITLE
Create and use AP::srv(), singleton for SRV_Channels

### DIFF
--- a/AntennaTracker/Tracker.cpp
+++ b/AntennaTracker/Tracker.cpp
@@ -82,7 +82,7 @@ void Tracker::one_second_loop()
     mavlink_system.sysid = g.sysid_this_mav;
 
     // update assigned functions and enable auxiliary servos
-    SRV_Channels::enable_aux_servos();
+    AP::srv().enable_aux_servos();
 
     // updated armed/disarmed status LEDs
     update_armed_disarmed();

--- a/AntennaTracker/servos.cpp
+++ b/AntennaTracker/servos.cpp
@@ -8,7 +8,7 @@
 void Tracker::init_servos()
 {
     // update assigned functions and enable auxiliary servos
-    SRV_Channels::enable_aux_servos();
+    AP::srv().enable_aux_servos();
 
     SRV_Channels::set_default_function(CH_YAW, SRV_Channel::k_tracker_yaw);
     SRV_Channels::set_default_function(CH_PITCH, SRV_Channel::k_tracker_pitch);

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -727,7 +727,7 @@ void Copter::one_hz_loop()
     }
 
     // update assigned functions and enable auxiliary servos
-    SRV_Channels::enable_aux_servos();
+    AP::srv().enable_aux_servos();
 
 #if HAL_LOGGING_ENABLED
     // log terrain data

--- a/ArduCopter/compassmot.cpp
+++ b/ArduCopter/compassmot.cpp
@@ -146,9 +146,10 @@ MAV_RESULT Copter::mavlink_compassmot(const GCS_MAVLINK &gcs_chan)
         read_radio();
 
         // pass through throttle to motors
-        SRV_Channels::cork();
+        auto &srv = AP::srv();
+        srv.cork();
         motors->set_throttle_passthrough_for_esc_calibration(channel_throttle->get_control_in() * 0.001f);
-        AP::srv().push();
+        srv.push();
 
         // read some compass values
         compass.read();

--- a/ArduCopter/compassmot.cpp
+++ b/ArduCopter/compassmot.cpp
@@ -148,7 +148,7 @@ MAV_RESULT Copter::mavlink_compassmot(const GCS_MAVLINK &gcs_chan)
         // pass through throttle to motors
         SRV_Channels::cork();
         motors->set_throttle_passthrough_for_esc_calibration(channel_throttle->get_control_in() * 0.001f);
-        SRV_Channels::push();
+        AP::srv().push();
 
         // read some compass values
         compass.read();

--- a/ArduCopter/esc_calibration.cpp
+++ b/ArduCopter/esc_calibration.cpp
@@ -97,7 +97,7 @@ void Copter::esc_calibration_passthrough()
         // pass through to motors
         SRV_Channels::cork();
         motors->set_throttle_passthrough_for_esc_calibration(channel_throttle->get_control_in() * 0.001f);
-        SRV_Channels::push();
+        AP::srv().push();
     }
 #endif  // FRAME_CONFIG != HELI_FRAME
 }
@@ -114,14 +114,14 @@ void Copter::esc_calibration_auto()
     // raise throttle to maximum
     SRV_Channels::cork();
     motors->set_throttle_passthrough_for_esc_calibration(1.0f);
-    SRV_Channels::push();
+    AP::srv().push();
 
     // delay for 5 seconds while outputting pulses
     uint32_t tstart = millis();
     while (millis() - tstart < 5000) {
         SRV_Channels::cork();
         motors->set_throttle_passthrough_for_esc_calibration(1.0f);
-        SRV_Channels::push();
+        AP::srv().push();
         esc_calibration_notify();
         hal.scheduler->delay(3);
     }
@@ -130,7 +130,7 @@ void Copter::esc_calibration_auto()
     while(1) {
         SRV_Channels::cork();
         motors->set_throttle_passthrough_for_esc_calibration(0.0f);
-        SRV_Channels::push();
+        AP::srv().push();
         esc_calibration_notify();
         hal.scheduler->delay(3);
     }

--- a/ArduCopter/esc_calibration.cpp
+++ b/ArduCopter/esc_calibration.cpp
@@ -95,9 +95,10 @@ void Copter::esc_calibration_passthrough()
         hal.scheduler->delay(3);
 
         // pass through to motors
-        SRV_Channels::cork();
+        auto &srv = AP::srv();
+        srv.cork();
         motors->set_throttle_passthrough_for_esc_calibration(channel_throttle->get_control_in() * 0.001f);
-        AP::srv().push();
+        srv.push();
     }
 #endif  // FRAME_CONFIG != HELI_FRAME
 }
@@ -112,25 +113,26 @@ void Copter::esc_calibration_auto()
     esc_calibration_setup();
 
     // raise throttle to maximum
-    SRV_Channels::cork();
+    auto &srv = AP::srv();
+    srv.cork();
     motors->set_throttle_passthrough_for_esc_calibration(1.0f);
-    AP::srv().push();
+    srv.push();
 
     // delay for 5 seconds while outputting pulses
     uint32_t tstart = millis();
     while (millis() - tstart < 5000) {
-        SRV_Channels::cork();
+        srv.cork();
         motors->set_throttle_passthrough_for_esc_calibration(1.0f);
-        AP::srv().push();
+        srv.push();
         esc_calibration_notify();
         hal.scheduler->delay(3);
     }
 
     // block until we restart
     while(1) {
-        SRV_Channels::cork();
+        srv.cork();
         motors->set_throttle_passthrough_for_esc_calibration(0.0f);
-        AP::srv().push();
+        srv.push();
         esc_calibration_notify();
         hal.scheduler->delay(3);
     }

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -156,8 +156,10 @@ void Copter::motors_output()
     // output any servo channels
     SRV_Channels::calc_pwm();
 
+    auto &srv = AP::srv();
+
     // cork now, so that all channel outputs happen at once
-    SRV_Channels::cork();
+    srv.cork();
 
     // update output on any aux channels, for manual passthru
     SRV_Channels::output_ch_all();
@@ -181,7 +183,7 @@ void Copter::motors_output()
     }
 
     // push all channels
-    AP::srv().push();
+    srv.push();
 }
 
 // check for pilot stick input to trigger lost vehicle alarm

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -181,7 +181,7 @@ void Copter::motors_output()
     }
 
     // push all channels
-    SRV_Channels::push();
+    AP::srv().push();
 }
 
 // check for pilot stick input to trigger lost vehicle alarm

--- a/ArduCopter/radio.cpp
+++ b/ArduCopter/radio.cpp
@@ -45,7 +45,7 @@ void Copter::init_rc_out()
     motors->init((AP_Motors::motor_frame_class)g2.frame_class.get(), (AP_Motors::motor_frame_type)g.frame_type.get());
 
     // enable aux servos to cope with multiple output channels per motor
-    SRV_Channels::enable_aux_servos();
+    AP::srv().enable_aux_servos();
 
     // update rate must be set after motors->init() to allow for motor mapping
     motors->set_update_rate(g.rc_speed);

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -346,7 +346,7 @@ void Plane::one_second_loop()
     // sync MAVLink system ID
     mavlink_system.sysid = g.sysid_this_mav;
 
-    SRV_Channels::enable_aux_servos();
+    AP::srv().enable_aux_servos();
 
     // update notify flags
     AP_Notify::flags.pre_arm_check = arming.pre_arm_checks(false);

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -107,7 +107,7 @@ void Plane::init_rc_out_main()
  */
 void Plane::init_rc_out_aux()
 {
-    SRV_Channels::enable_aux_servos();
+    AP::srv().enable_aux_servos();
 
     servos_output();
     

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -1050,7 +1050,7 @@ void Plane::servos_output(void)
 
     SRV_Channels::output_ch_all();
 
-    SRV_Channels::push();
+    AP::srv().push();
 
     if (g2.servo_channels.auto_trim_enabled()) {
         servos_auto_trim();

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -853,8 +853,8 @@ void Plane::set_servos(void)
     // start with output corked. the cork is released when we run
     // servos_output(), which is run from all code paths in this
     // function
-    SRV_Channels::cork();
-    
+    AP::srv().cork();
+
     // this is to allow the failsafe module to deliberately crash 
     // the plane. Only used in extreme circumstances to meet the
     // OBC rules
@@ -1012,7 +1012,8 @@ void Plane::indicate_waiting_for_rud_neutral_to_takeoff(void)
  */
 void Plane::servos_output(void)
 {
-    SRV_Channels::cork();
+    auto &srv = AP::srv();
+    srv.cork();
 
     // support twin-engine aircraft
     servos_twin_engine_mix();
@@ -1050,7 +1051,7 @@ void Plane::servos_output(void)
 
     SRV_Channels::output_ch_all();
 
-    AP::srv().push();
+    srv.push();
 
     if (g2.servo_channels.auto_trim_enabled()) {
         servos_auto_trim();

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -290,7 +290,7 @@ void Sub::one_hz_loop()
     }
 
     // update assigned functions and enable auxiliary servos
-    SRV_Channels::enable_aux_servos();
+    AP::srv().enable_aux_servos();
 
 #if HAL_LOGGING_ENABLED
     // log terrain data

--- a/ArduSub/motors.cpp
+++ b/ArduSub/motors.cpp
@@ -22,7 +22,7 @@ void Sub::motors_output()
         SRV_Channels::calc_pwm();
         SRV_Channels::output_ch_all();
         motors.output();
-        SRV_Channels::push();
+        AP::srv().push();
     }
 }
 

--- a/ArduSub/motors.cpp
+++ b/ArduSub/motors.cpp
@@ -18,11 +18,12 @@ void Sub::motors_output()
         verify_motor_test();
     } else {
         motors.set_interlock(true);
-        SRV_Channels::cork();
+        auto &srv = AP::srv();
+        srv.cork();
         SRV_Channels::calc_pwm();
         SRV_Channels::output_ch_all();
         motors.output();
-        AP::srv().push();
+        srv.push();
     }
 }
 

--- a/Blimp/Blimp.cpp
+++ b/Blimp/Blimp.cpp
@@ -210,7 +210,7 @@ void Blimp::one_hz_loop()
 #endif
 
     // update assigned functions and enable auxiliary servos
-    SRV_Channels::enable_aux_servos();
+    AP::srv().enable_aux_servos();
 
     AP_Notify::flags.flying = !ap.land_complete;
 

--- a/Blimp/motors.cpp
+++ b/Blimp/motors.cpp
@@ -78,8 +78,10 @@ void Blimp::motors_output()
     // output any servo channels
     SRV_Channels::calc_pwm();
 
+    auto &srv = AP::srv();
+
     // cork now, so that all channel outputs happen at once
-    SRV_Channels::cork();
+    srv.cork();
 
     // update output on any aux channels, for manual passthru
     SRV_Channels::output_ch_all();
@@ -88,5 +90,5 @@ void Blimp::motors_output()
     motors->output();
 
     // push all channels
-    AP::srv().push();
+    srv.push();
 }

--- a/Blimp/motors.cpp
+++ b/Blimp/motors.cpp
@@ -88,5 +88,5 @@ void Blimp::motors_output()
     motors->output();
 
     // push all channels
-    SRV_Channels::push();
+    AP::srv().push();
 }

--- a/Blimp/radio.cpp
+++ b/Blimp/radio.cpp
@@ -38,7 +38,7 @@ void Blimp::init_rc_in()
 void Blimp::init_rc_out()
 {
     // enable aux servos to cope with multiple output channels per motor
-    SRV_Channels::enable_aux_servos();
+    AP::srv().enable_aux_servos();
 
     // refresh auxiliary channel to function map
     SRV_Channels::update_aux_servo_function();

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -435,7 +435,7 @@ void Rover::one_second_loop(void)
     set_control_channels();
 
     // cope with changes to aux functions
-    SRV_Channels::enable_aux_servos();
+    AP::srv().enable_aux_servos();
 
     // update notify flags
     AP_Notify::flags.pre_arm_check = arming.pre_arm_checks(false);

--- a/Rover/system.cpp
+++ b/Rover/system.cpp
@@ -70,7 +70,7 @@ void Rover::init_ardupilot()
 
     init_rc_in();            // sets up rc channels deadzone
     g2.motors.init(get_frame_type());        // init motors including setting servo out channels ranges
-    SRV_Channels::enable_aux_servos();
+    AP::srv().enable_aux_servos();
 
     // init wheel encoders
     g2.wheel_encoder.init();

--- a/Tools/AP_Periph/rc_out.cpp
+++ b/Tools/AP_Periph/rc_out.cpp
@@ -71,7 +71,7 @@ void AP_Periph_FW::rcout_init()
     hal.rcout->set_freq(esc_mask, g.esc_rate.get());
 
     // setup ESCs with the desired PWM type, allowing for DShot
-    SRV_Channels::init(esc_mask, (AP_HAL::RCOutput::output_mode)g.esc_pwm_type.get());
+    AP::srv().init(esc_mask, (AP_HAL::RCOutput::output_mode)g.esc_pwm_type.get());
 
     // run DShot at 1kHz
     hal.rcout->set_dshot_rate(SRV_Channels::get_dshot_rate(), 400);
@@ -83,7 +83,7 @@ void AP_Periph_FW::rcout_init()
 void AP_Periph_FW::rcout_init_1Hz()
 {
     // this runs at 1Hz to allow for run-time param changes
-    SRV_Channels::enable_aux_servos();
+    AP::srv().enable_aux_servos();
 
     for (uint8_t i=0; i<SERVO_OUT_MOTOR_MAX; i++) {
         servo_channels.set_esc_scaling_for(SRV_Channels::get_motor_function(i));
@@ -159,7 +159,7 @@ void AP_Periph_FW::rcout_update()
     SRV_Channels::calc_pwm();
     SRV_Channels::cork();
     SRV_Channels::output_ch_all();
-    SRV_Channels::push();
+    AP::srv().push();
 #if HAL_WITH_ESC_TELEM
     if (now_ms - last_esc_telem_update_ms >= esc_telem_update_period_ms) {
         last_esc_telem_update_ms = now_ms;

--- a/Tools/AP_Periph/rc_out.cpp
+++ b/Tools/AP_Periph/rc_out.cpp
@@ -156,10 +156,11 @@ void AP_Periph_FW::rcout_update()
     }
     rcout_has_new_data_to_update = false;
 
+    auto &srv = AP::srv();
     SRV_Channels::calc_pwm();
-    SRV_Channels::cork();
+    srv.cork();
     SRV_Channels::output_ch_all();
-    AP::srv().push();
+    srv.push();
 #if HAL_WITH_ESC_TELEM
     if (now_ms - last_esc_telem_update_ms >= esc_telem_update_period_ms) {
         last_esc_telem_update_ms = now_ms;

--- a/libraries/AP_Motors/examples/AP_Motors_test/AP_Motors_test.cpp
+++ b/libraries/AP_Motors/examples/AP_Motors_test/AP_Motors_test.cpp
@@ -518,7 +518,7 @@ void stability_test()
     // arm motors
     motors->armed(true);
     motors->set_interlock(true);
-    SRV_Channels::enable_aux_servos();
+    AP::srv().enable_aux_servos();
 
     hal.console->printf("Roll,Pitch,Yaw,Thr,");
     for (uint8_t i=0; i<num_outputs; i++) {

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -438,7 +438,7 @@ void AP_Vehicle::setup()
 
 
 #if AP_SRV_CHANNELS_ENABLED
-    SRV_Channels::init();
+    AP::srv().init();
 #endif
 
     // gyro FFT needs to be initialized really late

--- a/libraries/AR_Motors/AP_MotorsUGV.cpp
+++ b/libraries/AR_Motors/AP_MotorsUGV.cpp
@@ -343,7 +343,7 @@ void AP_MotorsUGV::output(bool armed, float ground_speed, float dt)
     SRV_Channels::calc_pwm();
     SRV_Channels::cork();
     SRV_Channels::output_ch_all();
-    SRV_Channels::push();
+    AP::srv().push();
 }
 
 // test steering or throttle output as a percentage of the total (range -100 to +100)
@@ -411,7 +411,7 @@ bool AP_MotorsUGV::output_test_pct(motor_test_order motor_seq, float pct)
     SRV_Channels::calc_pwm();
     SRV_Channels::cork();
     SRV_Channels::output_ch_all();
-    SRV_Channels::push();
+    AP::srv().push();
     return true;
 }
 
@@ -477,7 +477,7 @@ bool AP_MotorsUGV::output_test_pwm(motor_test_order motor_seq, float pwm)
     SRV_Channels::calc_pwm();
     SRV_Channels::cork();
     SRV_Channels::output_ch_all();
-    SRV_Channels::push();
+    AP::srv().push();
     return true;
 }
 

--- a/libraries/AR_Motors/AP_MotorsUGV.cpp
+++ b/libraries/AR_Motors/AP_MotorsUGV.cpp
@@ -340,10 +340,11 @@ void AP_MotorsUGV::output(bool armed, float ground_speed, float dt)
     output_sail();
 
     // send values to the PWM timers for output
+    auto &srv = AP::srv();
     SRV_Channels::calc_pwm();
-    SRV_Channels::cork();
+    srv.cork();
     SRV_Channels::output_ch_all();
-    AP::srv().push();
+    srv.push();
 }
 
 // test steering or throttle output as a percentage of the total (range -100 to +100)
@@ -408,10 +409,11 @@ bool AP_MotorsUGV::output_test_pct(motor_test_order motor_seq, float pct)
         case MOTOR_TEST_LAST:
             return false;
     }
+    auto &srv = AP::srv();
     SRV_Channels::calc_pwm();
-    SRV_Channels::cork();
+    srv.cork();
     SRV_Channels::output_ch_all();
-    AP::srv().push();
+    srv.push();
     return true;
 }
 
@@ -474,10 +476,11 @@ bool AP_MotorsUGV::output_test_pwm(motor_test_order motor_seq, float pwm)
         default:
             return false;
     }
+    auto &srv = AP::srv();
     SRV_Channels::calc_pwm();
-    SRV_Channels::cork();
+    srv.cork();
     SRV_Channels::output_ch_all();
-    AP::srv().push();
+    srv.push();
     return true;
 }
 

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -473,7 +473,7 @@ public:
                            int16_t value, int16_t angle_min, int16_t angle_max);
 
     // assign and enable auxiliary channels
-    static void enable_aux_servos(void);
+    void enable_aux_servos(void);
 
     // enable channels by mask
     static void enable_by_mask(uint32_t mask);
@@ -541,7 +541,7 @@ public:
     
     static void cork();
 
-    static void push();
+    void push();
 
     // disable PWM output to a set of channels given by a mask. This is used by the AP_BLHeli code
     static void set_disabled_channel_mask(uint32_t mask) { disabled_mask = mask; }
@@ -570,7 +570,7 @@ public:
     static void zero_rc_outputs();
 
     // initialize before any call to push
-    static void init(uint32_t motor_mask = 0, AP_HAL::RCOutput::output_mode mode = AP_HAL::RCOutput::MODE_PWM_NONE);
+    void init(uint32_t motor_mask = 0, AP_HAL::RCOutput::output_mode mode = AP_HAL::RCOutput::MODE_PWM_NONE);
 
     // return true if a channel is set to type GPIO
     static bool is_GPIO(uint8_t channel);
@@ -610,30 +610,25 @@ private:
 #if AP_VOLZ_ENABLED
     // support for Volz protocol
     AP_Volz_Protocol volz;
-    static AP_Volz_Protocol *volz_ptr;
 #endif
 
 #if AP_SBUSOUTPUT_ENABLED
     // support for SBUS protocol
     AP_SBusOut sbus;
-    static AP_SBusOut *sbus_ptr;
 #endif
 
 #if AP_ROBOTISSERVO_ENABLED
     // support for Robotis servo protocol
     AP_RobotisServo robotis;
-    static AP_RobotisServo *robotis_ptr;
 #endif
 
 #if HAL_SUPPORT_RCOUT_SERIAL
     // support for BLHeli protocol
     AP_BLHeli blheli;
-    static AP_BLHeli *blheli_ptr;
 #endif
 
 #if AP_FETTEC_ONEWIRE_ENABLED
     AP_FETtecOneWire fetteconwire;
-    static AP_FETtecOneWire *fetteconwire_ptr;
 #endif  // AP_FETTEC_ONEWIRE_ENABLED
 
     // mask of disabled channels
@@ -691,4 +686,8 @@ private:
 
     // semaphore for multi-thread use of override_counter array
     HAL_Semaphore override_counter_sem;
+};
+
+namespace AP {
+    SRV_Channels &srv();
 };

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -538,9 +538,8 @@ public:
         }
         return SRV_Channel::Aux_servo_function_t((SRV_Channel::k_motor9+(channel-8)));
     }
-    
-    static void cork();
 
+    void cork();
     void push();
 
     // disable PWM output to a set of channels given by a mask. This is used by the AP_BLHeli code

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -270,7 +270,7 @@ void SRV_Channels::enable_aux_servos()
     hal.rcout->update_channel_masks();
 
 #if HAL_SUPPORT_RCOUT_SERIAL
-    blheli_ptr->update();
+    blheli.update();
 #endif
 }
 

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -545,11 +545,12 @@ void SRV_Channels::zero_rc_outputs()
      * send an invalid signal to all channels to prevent
      * undesired/unexpected behavior
      */
-    cork();
+    auto &srv = AP::srv();
+    srv.cork();
     for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
         hal.rcout->write(i, 0);
     }
-    AP::srv().push();
+    srv.push();
 }
 
 /*

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -41,27 +41,7 @@ extern const AP_HAL::HAL& hal;
 SRV_Channel *SRV_Channels::channels;
 SRV_Channels *SRV_Channels::_singleton;
 
-#if AP_VOLZ_ENABLED
-AP_Volz_Protocol *SRV_Channels::volz_ptr;
-#endif
-
-#if AP_SBUSOUTPUT_ENABLED
-AP_SBusOut *SRV_Channels::sbus_ptr;
-#endif
-
-#if AP_ROBOTISSERVO_ENABLED
-AP_RobotisServo *SRV_Channels::robotis_ptr;
-#endif
-
-#if AP_FETTEC_ONEWIRE_ENABLED
-AP_FETtecOneWire *SRV_Channels::fetteconwire_ptr;
-#endif
-
 uint16_t SRV_Channels::override_counter[NUM_SERVO_CHANNELS];
-
-#if HAL_SUPPORT_RCOUT_SERIAL
-AP_BLHeli *SRV_Channels::blheli_ptr;
-#endif
 
 uint32_t SRV_Channels::disabled_mask;
 uint32_t SRV_Channels::digital_mask;
@@ -379,26 +359,6 @@ SRV_Channels::SRV_Channels(void)
         }
 #endif
     }
-
-#if AP_FETTEC_ONEWIRE_ENABLED
-    fetteconwire_ptr = &fetteconwire;
-#endif
-
-#if AP_VOLZ_ENABLED
-    volz_ptr = &volz;
-#endif
-
-#if AP_SBUSOUTPUT_ENABLED
-    sbus_ptr = &sbus;
-#endif
-
-#if AP_ROBOTISSERVO_ENABLED
-    robotis_ptr = &robotis;
-#endif // AP_ROBOTISSERVO_ENABLED
-
-#if HAL_SUPPORT_RCOUT_SERIAL
-    blheli_ptr = &blheli;
-#endif
 }
 
 // SRV_Channels initialization
@@ -406,7 +366,7 @@ void SRV_Channels::init(uint32_t motor_mask, AP_HAL::RCOutput::output_mode mode)
 {
     // initialize BLHeli late so that all of the masks it might setup don't get trodden on by motor initialization
 #if HAL_SUPPORT_RCOUT_SERIAL
-    blheli_ptr->init(motor_mask, mode);
+    blheli.init(motor_mask, mode);
 #endif
 #ifndef HAL_BUILD_AP_PERIPH
     hal.rcout->set_dshot_rate(_singleton->dshot_rate, AP::scheduler().get_loop_rate_hz());
@@ -519,26 +479,26 @@ void SRV_Channels::push()
 
 #if AP_VOLZ_ENABLED
     // give volz library a chance to update
-    volz_ptr->update();
+    volz.update();
 #endif
 
 #if AP_SBUSOUTPUT_ENABLED
     // give sbus library a chance to update
-    sbus_ptr->update();
+    sbus.update();
 #endif
 
 #if AP_ROBOTISSERVO_ENABLED
     // give robotis library a chance to update
-    robotis_ptr->update();
+    robotis.update();
 #endif
 
 #if HAL_SUPPORT_RCOUT_SERIAL
     // give blheli telemetry a chance to update
-    blheli_ptr->update_telemetry();
+    blheli.update_telemetry();
 #endif
 
 #if AP_FETTEC_ONEWIRE_ENABLED
-    fetteconwire_ptr->update();
+    fetteconwire.update();
 #endif
 
 #if AP_KDECAN_ENABLED
@@ -589,7 +549,7 @@ void SRV_Channels::zero_rc_outputs()
     for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
         hal.rcout->write(i, 0);
     }
-    push();
+    AP::srv().push();
 }
 
 /*
@@ -619,3 +579,12 @@ void SRV_Channels::set_emergency_stop(bool state) {
 #endif
     emergency_stop = state;
 }
+
+namespace AP {
+
+SRV_Channels &srv()
+{
+    return *SRV_Channels::get_singleton();
+}
+
+};


### PR DESCRIPTION
Primarily to remove the (eg.) `blheli_ptr` hacks we have to make this class work kind-of-sort-of statically.

```
----------------------------  ---------  -----  ----------  ------  ----  ----------  -----  -----  ----
Board                         AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
3DRControlZeroG                          -72    *           -48     -72               -72    -64    -72
ACNS-CM4Pilot                            -8     *           16      -8                -8     0      -16
ACNS-F405AIO                             -8     *           16      0                 -8     0      -16
AIRLink                                  -72    *           -48     -64               -72    -64    -80
AR-F407SmartBat               *
ARKV6X                                   -72    *           -48     -64               -80    -64    -72
ARK_CANNODE                   -8
ARK_GPS                       24
ARK_RTK_GPS                   24
AeroFox-Airspeed              *
AeroFox-Airspeed-DLVR         *
AeroFox-GNSS_F9P              24
AeroFox-PMU                   -8
Airvolute-DCS2                           -64    *           -40     -56               -64    -56    -72
AnyleafH7                                -64    *           -48     -64               -64    -56    -64
Aocoda-RC-H743Dual                       -64    *           -48     -64               -64    -56    -64
AtomRCF405NAVI                           8      *           24      8                 8      8      0
BETAFPV-F405                                    *           24
BeastF7                                  0      *           24      8                 8      16     0
BeastF7v2                                8      *           24      0                 0      8      0
BeastH7                                  -72    *           -48     -64               -80    -64    -80
BeastH7v2                                -72    *           -48     -64               -80    -64    -80
BirdCANdy                     24
BlitzF745                                0      *           24      8                 0      8      0
BlitzF745AIO                             8      *           24      8                 0      8      0
BlitzH743Pro                             -64    *           -40     -64               -64    -56    -64
BlitzMiniF745                            0      *           24      8                 0      8      0
BlitzWingH743                            -64    *           -48     -64               -64    -56    -72
BotBloxDroneNet               *
C-RTK2-HP                     *
CBU-H7-Stamp                             -64    *           -40     -64               -64    -56    -64
CSKY405                                  8      *           24      8                 0      16     0
CUAV-7-Nano                              -72    *           -48     -64               -80    -64    -72
CUAV-Nora                                -72    *           -48     -64               -72    -64    -72
CUAV-Nora-bdshot                         -72    *           -48     -64               -80    -64    -80
CUAV-Pixhack-v3                          -64                -40     -64               -64    -56    -72
CUAV-X7                                  -72    *           -48     -64               -72    -64    -80
CUAV-X7-bdshot                           -72    *           -48     -64               -80    -64    -72
CUAV_GPS                      *
CUAVv5                                   -72    *           -48     -64               -72    -64    -72
CUAVv5-bdshot                            -72    *           -48     -64               -80    -64    -80
CUAVv5Nano                               -72    *           -48     -72               -80    -64    -72
CUAVv5Nano-bdshot                        -72    *           -48     -72               -80    -64    -80
CarbonixF405                  0
CarbonixL496                  0
CubeBlack                                -80    *           -56     -72               -88    -72    -88
CubeBlack+                               -80    *           -56     -80               -80    -72    -80
CubeBlack-periph              24
CubeGreen-solo                                  *           -56
CubeNode                      *
CubeNode-ETH                  *
CubeOrange                               -72    *           -48     -64               -72    -64    -72
CubeOrange-ODID                          -72    *           -48     -64               -80    -64    -72
CubeOrange-SimOnHardWare                                    -16
CubeOrange-bdshot                        -72    *           -48     -64               -72    -64    -72
CubeOrange-joey                          -72    *           -48     -72               -80    -64    -80
CubeOrange-periph             32
CubeOrange-periph-heavy       24
CubeOrangePlus                           -72    *           -48     -72               -80    -64    -80
CubeOrangePlus-SimOnHardWare                                -16
CubeOrangePlus-bdshot                    -72    *           -48     -64               -80    -64    -72
CubePurple                               -64    *           -48     -64               -64    -56    -72
CubeRedPrimary                           -64    *           -48     -64               -64    -56    -72
CubeRedPrimary-PPPGW          *
CubeRedSecondary                         -64    *           -40     -64               -64    -56    -72
CubeSolo                                        *           -56
CubeYellow                               -72    *           -48     -72               -80    -64    -72
CubeYellow-bdshot                        -72    *           -48     -72               -72    -64    -72
DevEBoxH7v2                              -8     *           8       -8                -8     0      -16
DrotekP3Pro                              -80    *           -56     -80               -88    -72    -80
Durandal                                 -72    *           -48     -64               -80    -64    -80
Durandal-bdshot                          -72    *           -48     -72               -72    -64    -72
F35Lightning                             0      *           24      0                 8      16     0
F4BY                                     -8     *           8       -8                -8     0      -16
FlyingMoonF407                           -8     *           8       -8                -8     0      -16
FlyingMoonF427                           -80    *           -56     -80               -80    -72    -80
FlyingMoonH743                           -72    *           -48     -72               -80    -64    -72
FlywooF405HD-AIOv2                              *           24
FlywooF405Pro                            0      *           24      0                 8      8      0
FlywooF405S-AIO                                 *           24
FlywooF745                               0      *           24      8                 0      8      0
FlywooF745Nano                           0      *           24      8                 0      8      0
FlywooH743Pro                            -64    *           -40     -64               -64    -56    -72
FoxeerF405v2                             8      *           24      0                 0      16     0
FoxeerH743v1                             -64    *           -48     -64               -64    -56    -72
FreeflyRTK                    24
G4-ESC                        24
GEPRCF745BTHD                            8      *           24      0                 0      8      0
H757I_EVAL                                      *
H757I_EVAL_intf                                 *
HEEWING-F405                                    *                                     8
HEEWING-F405v2                                  *                                     8
Here4AP                       24
Hitec-Airspeed                *
HitecMosaic                   *
HolybroF4_PMU                 *
HolybroG4_Airspeed            *
HolybroG4_Compass             *
HolybroG4_GPS                 24
HolybroGPS                    24
IFLIGHT_2RAW_H7                          -64    *           -40     -64               -64    -56    -64
JFB100                                   -72    *           -48     -64               -72    -64    -80
JFB110                                   -72    *           -48     -72               -80    -64    -80
JHEMCU-GSF405A                                  *           24
JHEMCU-GSF405A-RX2                              *           24
JHEMCU-H743HD                            -64    *           -40     -64               -64    -56    -64
JHEM_JHEF405                             -8     *           8       -8                -8     0      -8
KakuteF4                                 8      *           24      0                 8      8      0
KakuteF4-Wing                            0      *           24      0                 0      16     0
KakuteF4Mini                             0      *           24      8                 8      8      0
KakuteF7                                 8      *           24      0                 8      8      0
KakuteF7-bdshot                          8      *           24      8                 0      8      0
KakuteF7Mini                             8      *           24      8                 0      8      0
KakuteH7                                 -64    *           -40     -64               -64    -56    -72
KakuteH7-Wing                            -64    *           -48     -64               -64    -56    -64
KakuteH7-bdshot                          -64    *           -48     -64               -64    -56    -64
KakuteH7Mini                             -64    *           -48     -64               -64    -56    -64
KakuteH7Mini-Nand                        -64    *           -48     -64               -64    -56    -72
KakuteH7v2                               -64    *           -40     -64               -64    -56    -72
LongBowF405WING                          0      *           24      8                 0      16     0
MFT-SEMA100                              -64    *           -48     -64               -64    -56    -72
MUPilot                                  -72    *           -48     -64               -80    -64    -72
MambaF405-2022                           8      *           24      0                 0      8      0
MambaF405US-I2C                          0      *           24      8                 0      8      0
MambaF405v2                              0      *           24      8                 0      8      0
MambaH743v4                              -64    *           -40     -64               -64    -56    -72
MatekF405                                8      *           24      8                 0      8      0
MatekF405-CAN                            -8     *           8       -8                -8     0      -16
MatekF405-STD                            0      *           24      0                 8      16     0
MatekF405-TE                             8      *           24      0                 8      8      0
MatekF405-TE-bdshot                      0      *           24      0                 0      16     0
MatekF405-Wing                           8      *           24      8                 0      8      0
MatekF405-Wing-bdshot                    0      *           24      8                 8      16     0
MatekF405-bdshot                         0      *           24      8                 0      16     0
MatekF765-SE                             -64    *           -48     -64               -64    -56    -72
MatekF765-Wing                           -64    *           -40     -64               -64    -56    -72
MatekF765-Wing-bdshot                    -64    *           -40     -64               -64    -56    -64
MatekG474-DShot               0
MatekG474-Periph              *
MatekH743                                -64    *           -40     -64               -64    -56    -72
MatekH743-bdshot                         -64    *           -40     -64               -64    -56    -72
MatekH743-periph              24
MatekH7A3                                -64    *           -40     -64               -64    -56    -64
MatekL431-ADSB                *
MatekL431-APDTelem            24
MatekL431-Airspeed            *
MatekL431-BattMon             *
MatekL431-DShot               0
MatekL431-EFI                 *
MatekL431-GPS                 *
MatekL431-HWTelem             *
MatekL431-MagHiRes            *
MatekL431-Periph              24
MatekL431-Proximity           *
MatekL431-RC                  0
MatekL431-Rangefinder         *
MatekL431-Serial              *
MatekL431-bdshot              0
MazzyStarDrone                           -8     *           16      -8                -8     0      -16
MicoAir405Mini                           0      *           24      8                 0      8      0
MicoAir405v2                             0      *           24      8                 0      8      0
MicoAir743                               -64    *           -40     -64               -64    -56    -72
Nucleo-G491                   *
Nucleo-L476                   *
Nucleo-L496                   *
NucleoH743                                      *
NucleoH755                                      *
NxtPX4v2                                 -64    *           -48     -64               -64    -56    -64
OMNIBUSF7V2                              8      *           24      0                 8      16     0
OmnibusNanoV6                            0      *           24      8                 8      16     0
OmnibusNanoV6-bdshot                     0      *           24      0                 8      16     0
OrqaF405Pro                              8      *           24      8                 8      8      0
PH4-mini                                 -72    *           -48     -64               -72    -64    -72
PH4-mini-bdshot                          -72    *           -48     -72               -80    -64    -80
Pix32v5                                  -72    *           -48     -64               -72    -64    -72
PixC4-Jetson                             -72    *           -48     -64               -72    -64    -80
PixFlamingo                              -80    *           -56     -80               -88    -72    -80
PixFlamingo-F767                         -72    *           -48     -72               -80    -64    -80
PixPilot-C3                              -80    *           -56     -72               -88    -72    -88
PixPilot-V3                              -80    *           -56     -80               -80    -72    -80
PixPilot-V6                              -72    *           -48     -64               -72    -64    -72
PixPilot-V6PRO                           -72    *           -48     -72               -80    -64    -72
PixSurveyA1                              -64    *           -40     -64               -64    -56    -64
PixSurveyA1-IND                          -80    *           -56     -80               -80    -72    -80
PixSurveyA2                              -72    *           -48     -64               -72    -64    -72
Pixhawk1                                 -64    *           -40     -64               -64    -56    -72
Pixhawk1-1M                              -8     *           16      -8                -8     0      -16
Pixhawk1-1M-bdshot                       -8                 8       -8                -8     0      -16
Pixhawk1-bdshot                          -64                -40     -64               -64    -56    -64
Pixhawk4                                 -72    *           -48     -64               -80    -64    -80
Pixhawk4-bdshot                          -72    *           -48     -64               -72    -64    -80
Pixhawk5X                                -72    *           -48     -72               -72    -64    -80
Pixhawk6C                                -72    *           -48     -72               -80    -64    -80
Pixhawk6C-bdshot                         -72    *           -48     -72               -72    -64    -72
Pixhawk6X                                -72    *           -48     -72               -80    -64    -72
Pixhawk6X-ODID                           -72    *           -48     -72               -80    -64    -72
Pixhawk6X-PPPGW               *
Pixhawk6X-bdshot                         -72    *           -48     -64               -80    -64    -72
Pixracer                                 -80    *           -56     -80               -80    -72    -80
Pixracer-bdshot                          -80    *           -56     -80               -80    -72    -80
Pixracer-periph               24
QioTekAdeptF407                          -8     *           16      -8                -8     0      -16
QioTekZealotF427                         -80    *           -56     -80               -80    -72    -88
QioTekZealotH743                         -72    *           -48     -64               -72    -64    -72
QioTekZealotH743-bdshot                  -72    *           -48     -64               -80    -64    -80
R9Pilot                                  -64    *           -40     -64               -64    -56    -64
RADIX2HD                                 -16                16      -8                -16    0      -16
RadiolinkPIX6                            -64    *           -48     -64               -64    -56    -72
ReaperF745                               0      *           24      8                 0      8      0
SDMODELH7V1                              -64    *           -40     -64               -64    -56    -72
SDMODELH7V2                              -64    *           -48     -64               -64    -56    -72
SITL_arm_linux_gnueabihf                 -224               -144    -80               -144   -192   -112
SITL_x86_64_linux_gnu                    -184               -184    -184              -184   -184   -184
SIYI_N7                                  -72    *           -48     -72               -80    -64    -80
SPRacingH7                               -24    *           0       -24               -32    -16    -24
SPRacingH7RF                             -8     *           16      0                 -8     0      -8
Sierra-F405                   24
Sierra-F412                   24
Sierra-F9P                    24
Sierra-L431                   *
Sierra-PrecisionPoint         24
Sierra-TrueNavIC              *
Sierra-TrueNavPro             24
Sierra-TrueNavPro-G4          *
Sierra-TrueNorth              *
Sierra-TrueSpeed              *
SkySakuraH743                            -64    *           -48     -64               -64    -56    -64
SkystarsH7HD                             -72    *           -48     -72               -80    -64    -72
SkystarsH7HD-bdshot                      -72    *           -48     -64               -72    -64    -80
SpeedyBeeF405Mini                        0      *           24      0                 8      16     0
SpeedyBeeF405WING                        0      *           24      0                 0      8      0
SuccexF4                                 0      *           24      0                 8      16     0
Swan-K1                                         *                                     -72
TBS-Colibri-F7                           -72    *           -48     -72               -80    -64    -80
TBS_LUCID_H7                             -64    *           -48     -64               -64    -56    -72
TMotorH743                               -64    *           -48     -64               -64    -56    -72
VRBrain-v51                              -8     *           16      -8                -8     0      -16
VRBrain-v52                              -8     *           8       -8                -8     0      -8
VRBrain-v54                              -64    *           -40     -64               -64    -56    -64
VRCore-v10                               -8     *           16      -8                -8     0      -16
VRUBrain-v51                             -8     *           16      -8                -8     0      -8
VUAV-V7pro                               -72    *           -48     -64               -80    -64    -72
X-MAV-AP-H743v2                          -64    *           -40     -64               -64    -56    -64
YJUAV_A6                                 -72    *           -48     -72               -72    -64    -72
YJUAV_A6SE                               -16    *           16      -8                -16    0      -16
YJUAV_A6SE_H743                          -72    *           -48     -72               -72    -64    -72
YJUAV_A6Ultra                            -72    *           -48     -72               -72    -64    -72
ZeroOneX6                                -72    *           -48     -64               -72    -64    -72
ZubaxGNSS                     *
airbotf4                                 -8     *           16      -8                -8     0      -8
bbbmini                                  -192               -192    -192              -192   -192   -192
bebop                                    -192               -224    -160              -192   -224   -192
blue                                     -192               -240    -192              -192   -192   -240
canzero                                  -240               -192    -128              -208   -240   -224
crazyflie2                                      *           8
edge                                     -224               -224    -128              -192   -192   -272
erlebrain2                               -144               -192    -160              -240   -192   -192
f103-ADSB                     *
f103-Airspeed                 *
f103-GPS                      *
f103-HWESC                    *
f103-QiotekPeriph             *
f103-RangeFinder              *
f103-Trigger                  *
f303-GPS                      *
f303-HWESC                    *
f303-M10025                   *
f303-M10070                   *
f303-MatekGPS                 *
f303-PWM                      24
f303-TempSensor               24
f303-Universal                *
f405-MatekAirspeed            24
f405-MatekGPS                 24
fmuv2                                    -8                 16      -8                -8     0      -16
fmuv3                                    -64    *           -48     -64               -64    -56    -64
fmuv3-bdshot                             -64                -48     -64               -64    -56    -72
fmuv5                                    -72    *           -48     -64               -80    -64    -72
iomcu                                                                     *
iomcu-dshot                                                               *
iomcu-f103                                                                *
iomcu-f103-8MHz-dshot                                                     *
iomcu-f103-dshot                                                          *
iomcu_f103_8MHz                                                           *
kha_eth                       *
luminousbee4                             -96                -72     -88               -96    -88    -104
luminousbee5                             -72    *           -48     -72               -72    -64    -72
mRo-M10095                    *
mRoCANPWM-M10126              -8
mRoCZeroOEMH7-bdshot                     -72    *           -48     -64               -80    -64    -72
mRoControlZeroClassic                    -72    *           -48     -72               -72    -64    -72
mRoControlZeroF7                         -72    *           -48     -72               -72    -64    -72
mRoControlZeroH7                         -72    *           -48     -64               -80    -64    -80
mRoControlZeroH7-bdshot                  -72    *           -48     -64               -80    -64    -72
mRoControlZeroOEMH7                      -72    *           -48     -64               -72    -64    -80
mRoKitCANrevC                 *
mRoNexus                                 -72    *           -48     -72               -72    -64    -80
mRoPixracerPro                           -72    *           -48     -72               -80    -64    -72
mRoPixracerPro-bdshot                    -72    *           -48     -72               -72    -64    -72
mRoX21                                   -80    *           -56     -80               -80    -72    -80
mRoX21-777                               -72    *           -48     -72               -80    -64    -72
mindpx-v2                                -64    *           -40     -64               -64    -56    -72
mini-pix                                 -8     *           16      -8                -8     0      -8
modalai_fc-v1                            -72    *           -48     -72               -72    -64    -80
navigator                                -160               -192    -112              -192   -192   -192
navio                                    -144               -224    -160              -192   -192   -192
navio2                                   -192               -176    -192              -192   -192   -192
obal                                     -144               -176    -192              -192   -192   -144
omnibusf4                                8      *           24      8                 0      16     0
omnibusf4pro                             8      *           24      8                 0      16     0
omnibusf4pro-bdshot                      0      *           24      0                 0      16     0
omnibusf4pro-one                         0      *           24      0                 0      8      0
omnibusf4v6                              0      *           24      8                 0      8      0
pxf                                      -192               -240    -128              -192   -192   -240
pxfmini                                  -144               -192    -160              -240   -192   -192
rFCU                                            *
rGNSS                         24
revo-mini                                0      *           24      0                 8      16     0
revo-mini-bdshot                         8      *           24      8                 8      8      0
revo-mini-i2c                            8      *           24      0                 8      16     0
revo-mini-i2c-bdshot                     8      *           24      8                 8      16     0
revo-mini-sd                                    *
skyviper-f412-rev1                                          16
skyviper-journey                                            8
skyviper-v2450                                              40
sparky2                                  -8     *           16      -8                -8     0      -8
speedybeef4                              0      *           24      8                 8      16     0
speedybeef4v3                            0      *           24      8                 0      16     0
speedybeef4v4                            8      *           24      0                 8      16     0
sw-boom-f407                  24
sw-nav-f405                   24
sw-spar-f407                  24
thepeach-k1                              -64    *           -48     -64               -64    -56    -64
thepeach-r1                              -64    *           -48     -64               -64    -56    -64
----------------------------  ---------  -----  ----------  ------  ----  ----------  -----  -----  ----
```