### PR TITLE
QuadPlane: Fix QLand getting stuck in pilot repositioning

### DIFF
--- a/ArduPlane/mode_qland.cpp
+++ b/ArduPlane/mode_qland.cpp
@@ -9,7 +9,6 @@ bool ModeQLand::_enter()
     quadplane.throttle_wait = false;
     quadplane.setup_target_position();
     poscontrol.set_state(QuadPlane::QPOS_LAND_DESCEND);
-    poscontrol.pilot_correction_done = false;
     quadplane.last_land_final_agl = plane.relative_ground_altitude(plane.g.rangefinder_landing);
     quadplane.landing_detect.lower_limit_start_ms = 0;
     quadplane.landing_detect.land_start_ms = 0;

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -4596,6 +4596,11 @@ void QuadPlane::mode_enter(void)
     poscontrol.last_velocity_match_ms = 0;
     poscontrol.set_state(QuadPlane::QPOS_NONE);
 
+    // Clear any pilot corrections
+    poscontrol.pilot_correction_done = false;
+    poscontrol.pilot_correction_active = false;
+    poscontrol.target_vel_cms.zero();
+
     // clear guided takeoff wait on any mode change, but remember the
     // state for special behaviour
     guided_wait_takeoff_on_mode_enter = guided_wait_takeoff;


### PR DESCRIPTION
This fixes a bug where Qland will never land if it is entered when pilot repositioning is active.

Qland uses `landing_descent_rate_cms` which is called here: 

https://github.com/ArduPilot/ardupilot/blob/863b6222de8a3a2f8b9ffe44ab64e148a337d64e/ArduPlane/mode_qloiter.cpp#L146

This function checks `poscontrol.pilot_correction_active` and prevents descent if true here:

https://github.com/ArduPilot/ardupilot/blob/863b6222de8a3a2f8b9ffe44ab64e148a337d64e/ArduPlane/quadplane.cpp#L1279-L1282

However, `poscontrol.pilot_correction_active` is not reset on mode change, it is normally updated by `update_land_positioning` however this is never called in Qland because it does not support land repositioning.

The fix is to make sure the pilot correction is reset on entry to QLand. 