### PR TITLE
HAL_ChibiOS: cleanup cube IMUs and compasses

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/hwdef.inc
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/hwdef.inc
@@ -212,17 +212,8 @@ PE15 VDD_5V_PERIPH_nOC INPUT PULLUP
 
 SPIDEV ms5611         SPI1 DEVID3  BARO_CS      MODE3 20*MHZ 20*MHZ
 SPIDEV ms5611_ext     SPI4 DEVID2  BARO_EXT_CS  MODE3 20*MHZ 20*MHZ
-SPIDEV mpu6000        SPI1 DEVID4  MPU_CS       MODE3  2*MHZ  8*MHZ
-SPIDEV icm20608-am    SPI1 DEVID2  ACCEL_EXT_CS MODE3  4*MHZ  8*MHZ
-SPIDEV mpu9250        SPI1 DEVID4  MPU_CS       MODE3  4*MHZ  8*MHZ
-SPIDEV mpu9250_ext    SPI4 DEVID1  MPU_EXT_CS   MODE3  4*MHZ  8*MHZ
 SPIDEV icm20948       SPI1 DEVID4  MPU_CS       MODE3  4*MHZ  8*MHZ
 SPIDEV icm20948_ext   SPI4 DEVID1  MPU_EXT_CS   MODE3  4*MHZ  8*MHZ
-SPIDEV hmc5843        SPI1 DEVID5  MAG_CS       MODE3 11*MHZ 11*MHZ
-SPIDEV lsm9ds0_g      SPI1 DEVID1  GYRO_EXT_CS  MODE3 11*MHZ 11*MHZ
-SPIDEV lsm9ds0_am     SPI1 DEVID2  ACCEL_EXT_CS MODE3 11*MHZ 11*MHZ
-SPIDEV lsm9ds0_ext_g  SPI4 DEVID4  GYRO_EXT_CS  MODE3 11*MHZ 11*MHZ
-SPIDEV lsm9ds0_ext_am SPI4 DEVID3  ACCEL_EXT_CS MODE3 11*MHZ 11*MHZ
 SPIDEV icm20602_ext   SPI4 DEVID4  GYRO_EXT_CS  MODE3  4*MHZ  8*MHZ
 SPIDEV ramtron        SPI2 DEVID10 FRAM_CS      MODE3  8*MHZ  8*MHZ
 SPIDEV external0m0    SPI4 DEVID5  MPU_EXT_CS   MODE0  2*MHZ  2*MHZ
@@ -231,18 +222,7 @@ SPIDEV external0m2    SPI4 DEVID5  MPU_EXT_CS   MODE2  2*MHZ  2*MHZ
 SPIDEV external0m3    SPI4 DEVID5  MPU_EXT_CS   MODE3  2*MHZ  2*MHZ
 SPIDEV pixartPC15     SPI4 DEVID13 ACCEL_EXT_CS MODE3  2*MHZ  2*MHZ
 
-# three IMUs, but allow for different variants. First two IMUs are
-# isolated, 3rd isn't
-IMU Invensense SPI:mpu9250_ext ROTATION_PITCH_180
-
-# the 3 rotations for the LSM9DS0 driver are for the accel, the gyro
-# and the H variant of the gyro
-IMU LSM9DS0 SPI:lsm9ds0_ext_g SPI:lsm9ds0_ext_am ROTATION_ROLL_180_YAW_270 ROTATION_ROLL_180_YAW_90 ROTATION_ROLL_180_YAW_90
-
-# 3rd non-isolated IMU
-IMU Invensense SPI:mpu9250 ROTATION_YAW_270
-
-# alternative IMU set for newer cubes
+# IMU set for newer cubes
 IMU Invensense SPI:icm20602_ext ROTATION_ROLL_180_YAW_270
 IMU Invensensev2 SPI:icm20948_ext ROTATION_PITCH_180
 IMU Invensensev2 SPI:icm20948 ROTATION_YAW_270
@@ -270,12 +250,7 @@ define HAL_DEFAULT_INS_FAST_SAMPLE 7
 BARO MS56XX SPI:ms5611_ext
 BARO MS56XX SPI:ms5611
 
-# two compasses. First is in the LSM303D
-COMPASS LSM303D SPI:lsm9ds0_ext_am ROTATION_YAW_270
-# 2nd compass is part of the 2nd invensense IMU
-COMPASS AK8963:probe_mpu9250 1 ROTATION_YAW_270
-
-# compass as part of ICM20948 on newer cubes
+# one internal compass
 COMPASS AK09916:probe_ICM20948 0 ROTATION_ROLL_180_YAW_90
 
 # offset the internal compass for EM impact of the IMU heater

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeYellow/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeYellow/hwdef.dat
@@ -351,17 +351,8 @@ PE15 VDD_5V_PERIPH_nOC INPUT PULLUP
 
 SPIDEV ms5611         SPI1 DEVID3  BARO_CS      MODE3 20*MHZ 20*MHZ
 SPIDEV ms5611_ext     SPI4 DEVID2  BARO_EXT_CS  MODE3 20*MHZ 20*MHZ
-SPIDEV mpu6000        SPI1 DEVID4  MPU_CS       MODE3  2*MHZ  8*MHZ
-SPIDEV icm20608-am    SPI1 DEVID2  ACCEL_EXT_CS MODE3  4*MHZ  8*MHZ
-SPIDEV mpu9250        SPI1 DEVID4  MPU_CS       MODE3  4*MHZ  8*MHZ
-SPIDEV mpu9250_ext    SPI4 DEVID1  MPU_EXT_CS   MODE3  4*MHZ  8*MHZ
 SPIDEV icm20948       SPI1 DEVID4  MPU_CS       MODE3  4*MHZ  8*MHZ
 SPIDEV icm20948_ext   SPI4 DEVID1  MPU_EXT_CS   MODE3  4*MHZ  8*MHZ
-SPIDEV hmc5843        SPI1 DEVID5  MAG_CS       MODE3 11*MHZ 11*MHZ
-SPIDEV lsm9ds0_g      SPI1 DEVID1  GYRO_EXT_CS  MODE3 11*MHZ 11*MHZ
-SPIDEV lsm9ds0_am     SPI1 DEVID2  ACCEL_EXT_CS MODE3 11*MHZ 11*MHZ
-SPIDEV lsm9ds0_ext_g  SPI4 DEVID4  GYRO_EXT_CS  MODE3 11*MHZ 11*MHZ
-SPIDEV lsm9ds0_ext_am SPI4 DEVID3  ACCEL_EXT_CS MODE3 11*MHZ 11*MHZ
 SPIDEV icm20602_ext   SPI4 DEVID4  GYRO_EXT_CS  MODE3  4*MHZ  8*MHZ
 SPIDEV ramtron        SPI2 DEVID10 FRAM_CS      MODE3  8*MHZ  8*MHZ
 SPIDEV external0m0    SPI4 DEVID5  MPU_EXT_CS   MODE0  2*MHZ  2*MHZ
@@ -382,18 +373,7 @@ SPIDEV pixartPC15     SPI4 DEVID13 ACCEL_EXT_CS MODE3  2*MHZ  2*MHZ
 #SPIDEV clock8   SPI4 DEVID5  MPU_EXT_CS   MODE0  8*MHZ 8*MHZ     # gives 5.5MHz
 #SPIDEV clock16  SPI4 DEVID5  MPU_EXT_CS   MODE0  16*MHZ 16*MHZ   # gives 10.6MHz
 
-# three IMUs, but allow for different variants. First two IMUs are
-# isolated, 3rd isn't
-IMU Invensense SPI:mpu9250_ext ROTATION_PITCH_180
-
-# the 3 rotations for the LSM9DS0 driver are for the accel, the gyro
-# and the H variant of the gyro
-IMU LSM9DS0 SPI:lsm9ds0_ext_g SPI:lsm9ds0_ext_am ROTATION_ROLL_180_YAW_270 ROTATION_ROLL_180_YAW_90 ROTATION_ROLL_180_YAW_90
-
-# 3rd non-isolated IMU
-IMU Invensense SPI:mpu9250 ROTATION_YAW_270
-
-# alternative IMU set for newer cubes
+#IMU set for newer cubes
 IMU Invensense SPI:icm20602_ext ROTATION_ROLL_180_YAW_270
 IMU Invensensev2 SPI:icm20948_ext ROTATION_PITCH_180
 IMU Invensensev2 SPI:icm20948 ROTATION_YAW_270
@@ -404,12 +384,7 @@ define HAL_DEFAULT_INS_FAST_SAMPLE 5
 BARO MS56XX SPI:ms5611_ext
 BARO MS56XX SPI:ms5611
 
-# two compasses. First is in the LSM303D
-COMPASS LSM303D SPI:lsm9ds0_ext_am ROTATION_YAW_270
-# 2nd compass is part of the 2nd invensense IMU
-COMPASS AK8963:probe_mpu9250 1 ROTATION_YAW_270
-
-# compass as part of ICM20948 on newer cubes
+# one compass
 COMPASS AK09916:probe_ICM20948 0 ROTATION_ROLL_180_YAW_90
 
 # also probe for external compasses


### PR DESCRIPTION
don't probe for old sensor set

Replaces https://github.com/ArduPilot/ardupilot/pull/13135/files as the rebase was non-trivial and I didn't want to force-push that other branch.

I've flashed this onto a CubeOrange here and I still get a mag and three IMUs.

```
MANUAL> BARO1_DEVID: bus_type:SPI(2)  bus:4 address:2(0x2) devtype:11(0xb) BARO_MS5611 (721442)
BARO2_DEVID: bus_type:SPI(2)  bus:1 address:3(0x3) devtype:11(0xb) BARO_MS5611 (721674)
COMPASS_DEV_ID: bus_type:SPI(2)  bus:4 address:1(0x1) devtype:9(0x9) AK09916 (590114)
COMPASS_PRIO1_ID: bus_type:SPI(2)  bus:4 address:1(0x1) devtype:9(0x9) AK09916 (590114)
INS_GYR_ID: bus_type:SPI(2)  bus:4 address:4(0x4) devtype:47(0x2f) INS_ICM20602 (3081250)
INS_GYR2_ID: bus_type:SPI(2)  bus:4 address:1(0x1) devtype:44(0x2c) INS_ICM20948 (2883874)
INS_GYR3_ID: bus_type:SPI(2)  bus:1 address:4(0x4) devtype:46(0x2e) INS_ICM20649 (3015690)
INS_ACC_ID: bus_type:SPI(2)  bus:4 address:4(0x4) devtype:47(0x2f) INS_ICM20602 (3081250)
INS_ACC2_ID: bus_type:SPI(2)  bus:4 address:1(0x1) devtype:44(0x2c) INS_ICM20948 (2883874)
INS_ACC3_ID: bus_type:SPI(2)  bus:1 address:4(0x4) devtype:46(0x2e) INS_ICM20649 (3015690)
```

Note that @bugobliterator already approved tridge's PR.
