### PR TITLE
ArduPlane: add failsafe auto variant which skips loops 

### DIFF
--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -45,6 +45,7 @@ enum failsafe_action_long {
     FS_ACTION_LONG_GLIDE = 2,
     FS_ACTION_LONG_PARACHUTE = 3,
     FS_ACTION_LONG_AUTO = 4,
+    FS_ACTION_LONG_AUTO_SATISFY_JUMP_REPEATS = 5,
 };
 
 // type of stick mixing enabled

--- a/ArduPlane/events.cpp
+++ b/ArduPlane/events.cpp
@@ -145,6 +145,10 @@ void Plane::failsafe_long_on_event(enum failsafe_state fstype, ModeReason reason
             set_mode(mode_fbwa, reason);
         } else if (g.fs_action_long == FS_ACTION_LONG_AUTO) {
             set_mode(mode_auto, reason);
+        } else if (g.fs_action_long == FS_ACTION_LONG_AUTO_SATISFY_JUMP_REPEATS) {
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Marking all loops as satisfied");
+            mission.satisfy_jump_repeats();
+            set_mode(mode_auto, reason);
         } else {
             set_mode(mode_rtl, reason);
         }
@@ -194,6 +198,10 @@ void Plane::failsafe_long_on_event(enum failsafe_state fstype, ModeReason reason
             set_mode(mode_fbwa, reason);
         } else if (g.fs_action_long == FS_ACTION_LONG_AUTO) {
             set_mode(mode_auto, reason);
+        } else if (g.fs_action_long == FS_ACTION_LONG_AUTO_SATISFY_JUMP_REPEATS) {
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Marking all loops as satisfied");
+            mission.satisfy_jump_repeats();
+            set_mode(mode_auto, reason);
         } else if (g.fs_action_long == FS_ACTION_LONG_RTL) {
             set_mode(mode_rtl, reason);
         }
@@ -201,6 +209,10 @@ void Plane::failsafe_long_on_event(enum failsafe_state fstype, ModeReason reason
 
     case Mode::Number::RTL:
         if (g.fs_action_long == FS_ACTION_LONG_AUTO) {
+            set_mode(mode_auto, reason);
+        } else if (g.fs_action_long == FS_ACTION_LONG_AUTO_SATISFY_JUMP_REPEATS) {
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Marking all loops as satisfied");
+            mission.satisfy_jump_repeats();
             set_mode(mode_auto, reason);
         }
         break;

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -271,6 +271,7 @@ void AP_Mission::reset()
     _prev_nav_cmd_id       = AP_MISSION_CMD_ID_NONE;
     init_jump_tracking();
     reset_wp_history();
+    all_loops_satisified = false;
 }
 
 /// clear - clears out mission
@@ -2188,8 +2189,9 @@ bool AP_Mission::get_next_cmd(uint16_t start_index, Mission_Command& cmd, bool i
             }
 
             // get number of times jump command has already been run
-            if (temp_cmd.content.jump.num_times == AP_MISSION_JUMP_REPEAT_FOREVER ||
-                get_jump_times_run(temp_cmd) < temp_cmd.content.jump.num_times) {
+            if ((temp_cmd.content.jump.num_times == AP_MISSION_JUMP_REPEAT_FOREVER ||
+                 get_jump_times_run(temp_cmd) < temp_cmd.content.jump.num_times) &&
+                !all_loops_satisified) {
                 // update the record of the number of times run
                 if (increment_jump_num_times_if_found && !_flags.resuming_mission) {
                     increment_jump_times_run(temp_cmd, send_gcs_msg);

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -659,6 +659,11 @@ public:
         return _last_change_time_ms;
     }
 
+    // set all jump counters to the repeat count, so we no longer loop
+    void satisfy_jump_repeats() {
+        all_loops_satisified = true;
+    }
+
     // find the nearest landing sequence starting point (DO_LAND_START) and
     // return its index.  Returns 0 if no appropriate DO_LAND_START point can
     // be found.
@@ -958,6 +963,8 @@ private:
     // if not -1, this bit in LOG_BITMASK specifies whether to log a message each time we start a command:
     uint32_t log_start_mission_item_bit = -1;
 #endif
+
+    bool all_loops_satisified;
 };
 
 namespace AP


### PR DESCRIPTION
Sometimes a mission is specifically crafted to avoid terrain and other obstacles.

In the event of a failsafe, it may be better for the vehicle to continue on the plotted course, but consider any loops to be satisfied.  Naturally this may lead to the vehicle flying further in the case of a battery failsafe.

This PR adds a new failsafe type for Plane which pokes the AP_Mission library to indicate all loops should be satisfied.

A similar effect can be achieved by creating a "shadow" mission containing waypoints identical to the original mission and adding many  `DO_LAND_START` mission items to ensure the correct next waypoint is chosen.

I'm not 100% convinced this is the correct way to approach things.  One obvious issue is that if an RTL is issues then we won't continue to follow the mission, rather jump straight to the `DO_LAND_START`.

The original work was done on top of Plane-4.5, which was missing @IamPete1 's [`DO_RETURN_PATH_START`](https://github.com/ArduPilot/ardupilot/pull/26383) code.  It might be that we would be better-off adding an option into param 1 of that mission item type which specifies that all loop counters should be considered satisfied?  Would also need to add support to Plane for `DO_RETURN_PATH_START`.

@MichelleRos 