### PR TITLE
AP_VideoTX: Fix _configuration_finished indication for Tramp VTX

### DIFF
--- a/libraries/AP_VideoTX/AP_Tramp.cpp
+++ b/libraries/AP_VideoTX/AP_Tramp.cpp
@@ -143,6 +143,8 @@ char AP_Tramp::handle_response(void)
             debug("device config: freq: %u, cfg pwr: %umw, act pwr: %umw, pitmode: %u",
                 unsigned(freq), unsigned(power), unsigned(cur_act_power), unsigned(pit_mode));
 
+            // update the "_configuration_finished" flag, otherwise OSD item VTX_POWER blinks forever
+            vtx.set_configuration_finished(!update_pending);
 
             return 'v';
         }


### PR DESCRIPTION
This patch fixes a minor bug in the Tramp VTX status propagation.

The flag `_configuration_finished` in class AP_VideoTX is not set by AP_Tramp class.
Therefore VTX Power blinks in OSD forever.