### PR TITLE
Tools: correct powr_change.py output for accumulated flags

### DIFF
--- a/Tools/scripts/powr_change.py
+++ b/Tools/scripts/powr_change.py
@@ -70,8 +70,6 @@ class POWRChange(object):
 
                     if new_acc_bit_set and not old_acc_bit_set:
                         line += " ACCFLAGS+%s" % self.bit_description(bit)
-                    elif not new_bit_set and old_bit_set:
-                        line += " ACCFLAGS-%s" % self.bit_description(bit)
 
             if len(line) == 0:
                 continue


### PR DESCRIPTION
Was looking at Flags values when determining AccFlags output.

Old:
```
2024-11-12 19:56:17.93:  +BRICK_VALID ACCFLAGS+BRICK_VALID +SERVO_VALID ACCFLAGS+SERVO_VALID
2024-11-12 19:56:49.83:  -SERVO_VALID ACCFLAGS-SERVO_VALID +CHANGED ACCFLAGS+CHANGED
2024-11-12 19:56:50.23:  +SERVO_VALID
2024-11-12 19:56:54.93:  -SERVO_VALID ACCFLAGS-SERVO_VALID
2024-11-12 19:56:55.13:  +SERVO_VALID
2024-11-12 19:57:02.23:  -SERVO_VALID ACCFLAGS-SERVO_VALID
2024-11-12 19:57:02.43:  +SERVO_VALID
2024-11-12 19:57:05.43:  -SERVO_VALID ACCFLAGS-SERVO_VALID
2024-11-12 19:57:05.73:  +SERVO_VALID
2024-11-12 19:57:18.73:  -SERVO_VALID ACCFLAGS-SERVO_VALID
2024-11-12 19:57:19.03:  +SERVO_VALID
2024-11-12 19:57:20.93:  -SERVO_VALID ACCFLAGS-SERVO_VALID
2024-11-12 19:57:21.23:  +SERVO_VALID
2024-11-12 19:57:22.23:  -SERVO_VALID ACCFLAGS-SERVO_VALID
2024-11-12 19:57:22.43:  +SERVO_VALID
2024-11-12 19:57:22.83:  -SERVO_VALID ACCFLAGS-SERVO_VALID
```


New:
```
2024-11-12 19:56:17.93:  +BRICK_VALID ACCFLAGS+BRICK_VALID +SERVO_VALID ACCFLAGS+SERVO_VALID
2024-11-12 19:56:49.83:  -SERVO_VALID +CHANGED ACCFLAGS+CHANGED
2024-11-12 19:56:50.23:  +SERVO_VALID
2024-11-12 19:56:54.93:  -SERVO_VALID
2024-11-12 19:56:55.13:  +SERVO_VALID
2024-11-12 19:57:02.23:  -SERVO_VALID
2024-11-12 19:57:02.43:  +SERVO_VALID
2024-11-12 19:57:05.43:  -SERVO_VALID
2024-11-12 19:57:05.73:  +SERVO_VALID
2024-11-12 19:57:18.73:  -SERVO_VALID
2024-11-12 19:57:19.03:  +SERVO_VALID
2024-11-12 19:57:20.93:  -SERVO_VALID
2024-11-12 19:57:21.23:  +SERVO_VALID
2024-11-12 19:57:22.23:  -SERVO_VALID
2024-11-12 19:57:22.43:  +SERVO_VALID
2024-11-12 19:57:22.83:  -SERVO_VALID
```
