### PR TITLE
AP_Scripting: copter-slung-payload minor format fix

### DIFF
--- a/libraries/AP_Scripting/applets/copter-slung-payload.md
+++ b/libraries/AP_Scripting/applets/copter-slung-payload.md
@@ -4,13 +4,13 @@ This script moves a Copter so as to reduce a slung payload's oscillation.  Requi
 
 # Parameters
 
-SLUP_ENABLE : Set to 1 to enable this script
-SLUP_VEL_P : Oscillation controller velocity P gain.  Higher values will result in the vehicle moving more quickly in sync with the payload
-SLUP_DIST_MAX : maximum acceptable distance between vehicle and payload.  Within this distance oscillation suppression will operate
-SLUP_SYSID : System id of payload's autopilot.  If zero any system id is accepted
-SLUP_WP_POS_P : Return to waypoint position P gain.  Higher values result in the vehicle returning more quickly to the latest waypoint
-SLUP_RESTOFS_TC : Slung Payload resting offset estimate filter time constant.  Higher values result in smoother estimate but slower response
-SLUP_DEBUG : Slung payload debug output, set to 1 to enable debug
+- SLUP_ENABLE : Set to 1 to enable this script
+- SLUP_VEL_P : Oscillation controller velocity P gain.  Higher values will result in the vehicle moving more quickly in sync with the payload
+- SLUP_DIST_MAX : maximum acceptable distance between vehicle and payload.  Within this distance oscillation suppression will operate
+- SLUP_SYSID : System id of payload's autopilot.  If zero any system id is accepted
+- SLUP_WP_POS_P : Return to waypoint position P gain.  Higher values result in the vehicle returning more quickly to the latest waypoint
+- SLUP_RESTOFS_TC : Slung Payload resting offset estimate filter time constant.  Higher values result in smoother estimate but slower response
+- SLUP_DEBUG : Slung payload debug output, set to 1 to enable debug
 
 # How To Use
 


### PR DESCRIPTION
This NFC fixes up the formatting of the copter-sluing-payload.md file

Before:
![image](https://github.com/user-attachments/assets/cfb6d7ea-619e-4969-aee9-ea0255dd8940)

After:
![image](https://github.com/user-attachments/assets/7fbbfdad-622e-48d6-9f31-af90f3ead60c)
