### PR TITLE
AP_DDS: use memset to initialise variable size array

### DIFF
--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -955,8 +955,9 @@ void AP_DDS_Client::on_request(uxrSession* uxr_session, uxrObjectId object_id, u
             .type = UXR_REPLIER_ID
         };
 
-        uint32_t reply_size = rcl_interfaces_srv_SetParameters_Response_size_of_topic(&set_parameter_response, 0U);
-        uint8_t reply_buffer[reply_size] {};
+        const uint32_t reply_size = rcl_interfaces_srv_SetParameters_Response_size_of_topic(&set_parameter_response, 0U);
+        uint8_t reply_buffer[reply_size];
+        memset(reply_buffer, 0, reply_size * sizeof(uint8_t));
         ucdrBuffer reply_ub;
 
         ucdr_init_buffer(&reply_ub, reply_buffer, reply_size);
@@ -1040,8 +1041,9 @@ void AP_DDS_Client::on_request(uxrSession* uxr_session, uxrObjectId object_id, u
             .type = UXR_REPLIER_ID
         };
 
-        uint32_t reply_size = rcl_interfaces_srv_GetParameters_Response_size_of_topic(&get_parameters_response, 0U);
-        uint8_t reply_buffer[reply_size] {};
+        const uint32_t reply_size = rcl_interfaces_srv_GetParameters_Response_size_of_topic(&get_parameters_response, 0U);
+        uint8_t reply_buffer[reply_size];
+        memset(reply_buffer, 0, reply_size * sizeof(uint8_t));
         ucdrBuffer reply_ub;
 
         ucdr_init_buffer(&reply_ub, reply_buffer, reply_size);


### PR DESCRIPTION
The macOS version of `clang`does not support initialisation of variable length arrays. Use `memset` instead.

System:
MacBook Pro M1
macOS Sonoma 14.5
Xcode 15.3 (15E204a)

Compiler details from `./waf configure`

```
% ./waf configure --board sitl --enable-dds --debug
Setting top to                           : /Users/rhys/Code/ros2/rolling/ros2-ardupilot/src/ardupilot 
Setting out to                           : /Users/rhys/Code/ros2/rolling/ros2-ardupilot/src/ardupilot/build 
Autoconfiguration                        : enabled 
Checking for program 'python'            : /Users/rhys/.venv/ros2-rolling/bin/python3 
Checking for python version >= 3.6.9     : 3.12.7 
Setting board to                         : sitl 
Using toolchain                          : native 
Checking for 'g++' (C++ compiler)        : not found 
Checking for 'clang++' (C++ compiler)    : /usr/bin/clang++ 
Checking for 'gcc' (C compiler)          : not found 
Checking for 'clang' (C compiler)        : /usr/bin/clang 
Checking for c flags '-MMD'              : yes 
Checking for cxx flags '-MMD'            : yes 
CXX Compiler                             : clang++ 15.0.0 
Checking for feenableexcept              : no 
Disabling SLP for clang++
Enabling -Werror                         : no 
Checking for program 'microxrceddsgen'   : /Users/rhys/Code/ros2/rolling/ros2-ardupilot/src/microxrcedds_gen/scripts/microxrceddsgen 
Enabled OpenDroneID                      : no 
Enabled firmware ID checking             : no 
GPS Debug Logging                        : no 
Enabled custom controller                : yes 
Checking for HAVE_CMATH_ISFINITE         : yes 
Checking for HAVE_CMATH_ISINF            : yes 
Checking for HAVE_CMATH_ISNAN            : yes 
Checking for NEED_CMATH_ISFINITE_STD_NAMESPACE : yes 
Checking for NEED_CMATH_ISINF_STD_NAMESPACE    : yes 
Checking for NEED_CMATH_ISNAN_STD_NAMESPACE    : yes 
Checking for header endian.h                   : not found 
Checking for header byteswap.h                 : not found 
Checking for HAVE_MEMRCHR                      : no 
Configured VSCode Intellisense:                : no 
DC_DSDL compiler in                            : /Users/rhys/Code/ros2/rolling/ros2-ardupilot/src/ardupilot/modules/DroneCAN/dronecan_dsdlc 
Source is git repository                       : yes 
Update submodules                              : yes 
Checking for program 'git'                     : /opt/homebrew/bin/git 
Checking for program 'size'                    : /usr/bin/size 
Benchmarks                                     : disabled 
Unit tests                                     : enabled 
Scripting                                      : maybe 
Scripting runtime checks                       : enabled 
Debug build                                    : enabled 
Coverage build                                 : disabled 
Force 32-bit build                             : disabled 
Checking for program 'rsync'                   : /opt/homebrew/bin/rsync 
Removing target_list file /Users/rhys/Code/ros2/rolling/ros2-ardupilot/src/ardupilot/build/sitl/target_list
'configure' finished successfully (2.052s)
```