### PR TITLE
AP_DDS: move closing #endif for status publisher

### DIFF
--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -1615,10 +1615,11 @@ void AP_DDS_Client::update()
         }
         last_status_check_time_ms = cur_time_ms;
     }
+#endif // AP_DDS_STATUS_PUB_ENABLED
 
     status_ok = uxr_run_session_time(&session, 1);
 }
-#endif // AP_DDS_STATUS_PUB_ENABLED
+
 #if CONFIG_HAL_BOARD != HAL_BOARD_SITL
 extern "C" {
     int clock_gettime(clockid_t clockid, struct timespec *ts);


### PR DESCRIPTION
Must be before the closing brace and `status_ok` check.