### PR TITLE
AP_VideoTX / AP_OSD: Make VTX temperature available for OSD

### DIFF
--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -353,6 +353,10 @@ private:
         bool load_attempted;
         const char *str;
     } callsign_data;
+
+    // VTX temperature for AP_Tramp
+    AP_OSD_Setting vtx_temp;
+    void draw_vtx_temp(uint8_t x, uint8_t y);
 };
 #endif // OSD_ENABLED
 

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -1045,6 +1045,23 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info[] = {
 	AP_SUBGROUPINFO(rrpm, "RPM", 62, AP_OSD_Screen, AP_OSD_Setting),
 #endif
 
+
+    // @Param: VTX_TEMP_EN
+    // @DisplayName: VTX_TEMP_EN
+    // @Description: Displays the VTX Temperature. A Value of '-1' indicates that temperature is not available.
+    // @Values: 0:Disabled,1:Enabled
+
+    // @Param: VTX_TEMP_X
+    // @DisplayName: VTX_TEMP_X
+    // @Description: Horizontal position on screen for VTX_TEMP item
+    // @Range: 0 59
+
+    // @Param: VTX_TEMP_Y
+    // @DisplayName: VTX_TEMP_Y
+    // @Description: Vertical position on screen for VTX_TEMP item
+    // @Range: 0 21
+    AP_SUBGROUPINFO(vtx_temp, "VTX_TEMP", 63, AP_OSD_Screen, AP_OSD_Setting),
+
     AP_GROUPEND
 };
 
@@ -2550,6 +2567,17 @@ void AP_OSD_Screen::draw_rngf(uint8_t x, uint8_t y)
 }
 #endif
 
+
+void AP_OSD_Screen::draw_vtx_temp(uint8_t x, uint8_t y)
+{
+    AP_VideoTX *vtx = AP_VideoTX::get_singleton();
+    if (!vtx) {
+        return;
+    }
+    float vtx_temperature = vtx->get_temperature();
+    backend->write(x, y, false, "%3.1f%c", u_scale(TEMPERATURE, vtx_temperature), u_icon(TEMPERATURE));
+}
+
 #define DRAW_SETTING(n) if (n.enabled) draw_ ## n(n.xpos, n.ypos)
 
 #if HAL_WITH_OSD_BITMAP || HAL_WITH_MSP_DISPLAYPORT
@@ -2648,6 +2676,9 @@ void AP_OSD_Screen::draw(void)
     DRAW_SETTING(rc_snr);
     DRAW_SETTING(rc_active_antenna);
     DRAW_SETTING(rc_lq);
+#endif
+#if AP_VIDEOTX_ENABLED
+    DRAW_SETTING(vtx_temp);
 #endif
 }
 #endif

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -1045,23 +1045,6 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info[] = {
 	AP_SUBGROUPINFO(rrpm, "RPM", 62, AP_OSD_Screen, AP_OSD_Setting),
 #endif
 
-
-    // @Param: VTX_TEMP_EN
-    // @DisplayName: VTX_TEMP_EN
-    // @Description: Displays the VTX Temperature. A Value of '-1' indicates that temperature is not available.
-    // @Values: 0:Disabled,1:Enabled
-
-    // @Param: VTX_TEMP_X
-    // @DisplayName: VTX_TEMP_X
-    // @Description: Horizontal position on screen for VTX_TEMP item
-    // @Range: 0 59
-
-    // @Param: VTX_TEMP_Y
-    // @DisplayName: VTX_TEMP_Y
-    // @Description: Vertical position on screen for VTX_TEMP item
-    // @Range: 0 21
-    AP_SUBGROUPINFO(vtx_temp, "VTX_TEMP", 63, AP_OSD_Screen, AP_OSD_Setting),
-
     AP_GROUPEND
 };
 
@@ -1190,6 +1173,22 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info2[] = {
     // @Range: 0 32
     AP_GROUPINFO("ESC_IDX", 10, AP_OSD_Screen, esc_index, 0),
 #endif
+
+    // @Param: VTX_TEMP_EN
+    // @DisplayName: VTX_TEMP_EN
+    // @Description: Displays the VTX Temperature. A Value of '-1' indicates that temperature is not available.
+    // @Values: 0:Disabled,1:Enabled
+
+    // @Param: VTX_TEMP_X
+    // @DisplayName: VTX_TEMP_X
+    // @Description: Horizontal position on screen for VTX_TEMP item
+    // @Range: 0 59
+
+    // @Param: VTX_TEMP_Y
+    // @DisplayName: VTX_TEMP_Y
+    // @Description: Vertical position on screen for VTX_TEMP item
+    // @Range: 0 21
+    AP_SUBGROUPINFO(vtx_temp, "VTX_TEMP", 11, AP_OSD_Screen, AP_OSD_Setting),
 
     AP_GROUPEND
 };

--- a/libraries/AP_VideoTX/AP_Tramp.cpp
+++ b/libraries/AP_VideoTX/AP_Tramp.cpp
@@ -156,6 +156,11 @@ char AP_Tramp::handle_response(void)
         if (temp != 0) {
             // Got response, update device status
             cur_temp = temp;
+
+            // propagate temperature to AP_VideoTX
+            AP_VideoTX& vtx = AP::vtx();
+            vtx.set_temperature((float) cur_temp);
+
             return 's';
         }
         break;

--- a/libraries/AP_VideoTX/AP_VideoTX.h
+++ b/libraries/AP_VideoTX/AP_VideoTX.h
@@ -178,6 +178,11 @@ public:
 
     static AP_VideoTX *singleton;
 
+    // set the vtx temperature from backend, at the moment only AP_Tramp provides temperature
+    void set_temperature(float temperature) { _internal_temperature = temperature; }
+    // get the vtx temperature, consumer is OSD, a value of -1.0f indicates an invalid value, i.e. the backend does not provide it.
+    float get_temperature() const { return _internal_temperature; }
+
 private:
     uint8_t find_current_power() const;
     // channel frequency
@@ -212,6 +217,9 @@ private:
 
     // types of VTX providers
     uint8_t _types;
+
+    // VTX temperature provided by AP_Tramp backend, not by AP_SmartAudio
+    float _internal_temperature = -1.0f;
 };
 
 namespace AP {


### PR DESCRIPTION
This patch adds VTX temperature forwarding from AP_Tramp through AP_VideoTX to AP_OSD.

I would appreciate feedback about style and correct use of methods because I merely copied code sections based on assumptions without digging too deep into the macros etc.