### PR TITLE
AP_Baro: Allow setting field elevation to 0

### DIFF
--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -962,8 +962,8 @@ void AP_Baro::update_field_elevation(void)
             // auto-set based on origin
             Location origin;
             if (!armed && AP::ahrs().get_origin(origin)) {
+                new_field_elev = !is_equal(_field_elevation_active, origin.alt * 0.01f);
                 _field_elevation_active = origin.alt * 0.01;
-                new_field_elev = true;
             }
         } else if (fabsf(_field_elevation_active-_field_elevation) > 1.0 &&
                    !is_zero(_field_elevation)) {


### PR DESCRIPTION
This came up when using a vision-based vehicle (no GPS).

When using ``set_gps_global_origin_send`` to set the GPS origin of a vehicle, if the set altitude is _exactly_ 0 then ``AP_Baro`` will continually keep resetting the field elevation.

~~This patch will warn the user if they try to do this.~~

This patch will allow setting the altitude to 0, but only once per boot.

Example pymavlink code to demonstrate issue:

```python3
#!/usr/bin/env python3
'''
Quick test script to send origin

'''
import argparse
import time
from pymavlink import mavutil


if __name__ == '__main__':
    parser = argparse.ArgumentParser()
    parser.add_argument(
        "--device", type=str, default="udpin:127.0.0.1:14550", help="MAVLink connection string")
    parser.add_argument("--baud", type=int, default=115200,
                        help="MAVLink baud rate, if using serial")
    parser.add_argument("--source-system", type=int,
                        default=1, help="MAVLink Source system")
    args = parser.parse_args()

    # Start mavlink connection
    try:
        conn = mavutil.mavlink_connection(args.device, autoreconnect=True, source_system=args.source_system,
                                          baud=args.baud, force_connected=False,
                                          source_component=mavutil.mavlink.MAV_COMP_ID_VISUAL_INERTIAL_ODOMETRY)
    except Exception as msg:
        print("Failed to start mavlink connection on %s: %s" %
              (args.device, msg,))
        raise

    # wait for the heartbeat msg to find the system ID. Need to exit from here too
    # We are sending a heartbeat signal too, to allow ardupilot to init the comms channel
    while True:
        conn.mav.heartbeat_send(mavutil.mavlink.MAV_TYPE_ONBOARD_CONTROLLER,
                                mavutil.mavlink.MAV_AUTOPILOT_GENERIC,
                                0,
                                0,
                                0)
        if conn.wait_heartbeat(timeout=0.5) is not None:
            # Got a hearbeart, go to next loop
            break

    print("Got Heartbeat from APM (system %u component %u)" %
          (conn.target_system, conn.target_component))

    time.sleep(0.05)
    print("Setting EKF origin")
    current_time_us = int(round(time.time() * 1000000))
    conn.mav.set_gps_global_origin_send(conn.target_system,
                                        int(-35.363261*1.0e7),
                                        int(149.165230*1.0e7),
                                        int(0*1.0e3),
                                        current_time_us)
```