### PR TITLE
AP_DDS: status topic to report RC failsafe with callback function

### DIFF
--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -632,15 +632,17 @@ bool AP_DDS_Client::update_topic(ardupilot_msgs_msg_Status& msg)
     msg.external_control = true; // Always true for now. To be filled after PR#28429.
     uint8_t fs_iter = 0;
     msg.failsafe_size = 0;
-    if (AP_Notify::flags.failsafe_radio) {
+    if (rc().in_rc_failsafe()) {
         msg.failsafe[fs_iter++] = FS_RADIO;
     }
     if (battery.has_failsafed()) {
         msg.failsafe[fs_iter++] = FS_BATTERY;
     }
+    // TODO: replace flag with function.
     if (AP_Notify::flags.failsafe_gcs) {
         msg.failsafe[fs_iter++] = FS_GCS;
     }
+    // TODO: replace flag with function.
     if (AP_Notify::flags.failsafe_ekf) {
         msg.failsafe[fs_iter++] = FS_EKF;
     }


### PR DESCRIPTION
# What Changed

Follow Up to https://github.com/ArduPilot/ardupilot/pull/28337.

The Status topic is now populated with the function `in_rc_failsafe()`, which is implemented as virtual in the `RC_Channel` class.

# Test

Tested in SITL: set the parameter `SIM_RC_FAIL` to 1 and then 0. 
You should see the following texts on the GCS:

![image](https://github.com/user-attachments/assets/f45b311c-881c-4010-a1ca-2d017c005cdb)

And the following result when the status topic is echoed with `ros2 topic echo /ap/status`

![image](https://github.com/user-attachments/assets/e6fcfb23-9b2d-4dae-8b93-2be77033b15b)

