### PR TITLE
Dds arm through external control

### DIFF
--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -815,7 +815,13 @@ void AP_DDS_Client::on_request(uxrSession* uxr_session, uxrObjectId object_id, u
         }
 
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s Request for %sing received", msg_prefix, arm_motors_request.arm ? "arm" : "disarm");
-        arm_motors_response.result = arm_motors_request.arm ? AP::arming().arm(AP_Arming::Method::DDS) : AP::arming().disarm(AP_Arming::Method::DDS);
+#if AP_EXTERNAL_CONTROL_ENABLED
+        const bool do_checks = true;
+        arm_motors_response.result = arm_motors_request.arm ? AP_DDS_External_Control::arm(AP_Arming::Method::DDS, do_checks) : AP_DDS_External_Control::disarm(AP_Arming::Method::DDS, do_checks);
+        if (!arm_motors_response.result) {
+            // TODO #23430 handle arm failure through rosout, throttled.
+        }
+#endif // AP_EXTERNAL_CONTROL_ENABLED
 
         const uxrObjectId replier_id = {
             .id = services[to_underlying(ServiceIndex::ARMING_MOTORS)].rep_id,

--- a/libraries/AP_DDS/AP_DDS_ExternalControl.cpp
+++ b/libraries/AP_DDS/AP_DDS_ExternalControl.cpp
@@ -85,6 +85,26 @@ bool AP_DDS_External_Control::handle_velocity_control(geometry_msgs_msg_TwistSta
     return false;
 }
 
+bool AP_DDS_External_Control::arm(AP_Arming::Method method, bool do_arming_checks)
+{
+    auto *external_control = AP::externalcontrol();
+    if (external_control == nullptr) {
+        return false;
+    }
+
+    return external_control->arm(method, do_arming_checks);
+}
+
+bool AP_DDS_External_Control::disarm(AP_Arming::Method method, bool do_disarm_checks)
+{
+    auto *external_control = AP::externalcontrol();
+    if (external_control == nullptr) {
+        return false;
+    }
+
+    return external_control->disarm(method, do_disarm_checks);
+}
+
 bool AP_DDS_External_Control::convert_alt_frame(const uint8_t frame_in,  Location::AltFrame& frame_out)
 {
 

--- a/libraries/AP_DDS/AP_DDS_ExternalControl.h
+++ b/libraries/AP_DDS/AP_DDS_ExternalControl.h
@@ -3,7 +3,7 @@
 #if AP_DDS_ENABLED
 #include "ardupilot_msgs/msg/GlobalPosition.h"
 #include "geometry_msgs/msg/TwistStamped.h"
-
+#include <AP_Arming/AP_Arming.h>
 #include <AP_Common/Location.h>
 
 class AP_DDS_External_Control
@@ -13,6 +13,9 @@ public:
     // https://ros.org/reps/rep-0147.html#goal-interface
     static bool handle_global_position_control(ardupilot_msgs_msg_GlobalPosition& cmd_pos);
     static bool handle_velocity_control(geometry_msgs_msg_TwistStamped& cmd_vel);
+    static bool arm(AP_Arming::Method method, bool do_arming_checks);
+    static bool disarm(AP_Arming::Method method, bool do_disarm_checks);
+
 private:
     static bool convert_alt_frame(const uint8_t frame_in,  Location::AltFrame& frame_out);
 };

--- a/libraries/AP_ExternalControl/AP_ExternalControl.cpp
+++ b/libraries/AP_ExternalControl/AP_ExternalControl.cpp
@@ -5,6 +5,16 @@
 // singleton instance
 AP_ExternalControl *AP_ExternalControl::singleton;
 
+bool AP_ExternalControl::arm(AP_Arming::Method method, bool do_arming_checks)
+{
+    return AP::arming().arm(method, do_arming_checks);
+}
+
+bool AP_ExternalControl::disarm(AP_Arming::Method method, bool do_disarm_checks)
+{
+    return AP::arming().disarm(method, do_disarm_checks);
+}
+
 AP_ExternalControl::AP_ExternalControl()
 {
     singleton = this;

--- a/libraries/AP_ExternalControl/AP_ExternalControl.h
+++ b/libraries/AP_ExternalControl/AP_ExternalControl.h
@@ -8,6 +8,7 @@
 
 #if AP_EXTERNAL_CONTROL_ENABLED
 
+#include <AP_Arming/AP_Arming.h>
 #include <AP_Common/Location.h>
 #include <AP_Math/AP_Math.h>
 
@@ -31,6 +32,16 @@ public:
     virtual bool set_global_position(const Location& loc) WARN_IF_UNUSED {
         return false;
     }
+
+    /*
+        Arm the vehicle
+    */
+    virtual bool arm(AP_Arming::Method method, bool do_arming_checks) WARN_IF_UNUSED;
+
+    /*
+        Disarm the vehicle
+    */
+    virtual bool disarm(AP_Arming::Method method, bool do_disarm_checks) WARN_IF_UNUSED;
 
     static AP_ExternalControl *get_singleton(void) WARN_IF_UNUSED {
         return singleton;


### PR DESCRIPTION
# Purpose

Make arming from DDS go through external control. That way, we can prevent a companion computer from arming using https://github.com/ArduPilot/ardupilot/pull/28429

We want all services that control the state of the vehicle to go through external control so we can gate them in a single place.

# Size (Durandal)

```
Binary Name      Text [B]       Data [B]     BSS (B)      Total Flash Change [B] (%)      Flash Free After PR (B)
---------------  -------------  -----------  -----------  ----------------------------  -------------------------
arducopter-heli  72 (+0.0040%)  0 (0.0000%)  0 (0.0000%)  72 (+0.0039%)                                    141248
antennatracker   0 (0.0000%)    0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                      613396
arducopter       72 (+0.0040%)  0 (0.0000%)  0 (0.0000%)  72 (+0.0039%)                                    140792
ardurover        72 (+0.0043%)  0 (0.0000%)  0 (0.0000%)  72 (+0.0043%)                                    [29](https://github.com/ArduPilot/ardupilot/actions/runs/11826461468/job/32952516727?pr=28609#step:10:30)4832
arduplane        72 (+0.0040%)  0 (0.0000%)  0 (0.0000%)  72 (+0.0040%)                                    143680
blimp            0 (0.0000%)    0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                      591472
ardusub          0 (0.0000%)    0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                      350564
```

# Motivation

https://github.com/ArduPilot/ardupilot/pull/28429#discussion_r1829759857


