### PR TITLE
AP_HAL_QURT: Fix SPI transfer special case

### DIFF
--- a/libraries/AP_HAL_QURT/SPIDevice.cpp
+++ b/libraries/AP_HAL_QURT/SPIDevice.cpp
@@ -67,6 +67,12 @@ bool SPIDevice::transfer(const uint8_t *send, uint32_t send_len,
         return transfer_fullduplex(send, (uint8_t*) send, send_len);
     }
 
+    // Special case handling. This can happen when a send buffer is specified
+    // even though we are doing only a read.
+    if (send == recv && send_len == recv_len) {
+        return transfer_fullduplex(send, recv, send_len);
+    }
+
     // This is a read transaction
     uint8_t buf[send_len+recv_len];
     if (send_len > 0) {


### PR DESCRIPTION
Fix the SPI transfer special case where a send buffer is passed in even though it is a read transaction. This happens in the IMU
driver now that it has been optimized. The send buffer is the same as the read buffer even though it's just doing a read. This is
perfectly fine by SPI standards but needs special case handling in the Qurt SPI driver.