### PR TITLE
Fix build for CubeNode ETH

### DIFF
--- a/Tools/AP_Periph/GCS_MAVLink.h
+++ b/Tools/AP_Periph/GCS_MAVLink.h
@@ -41,6 +41,7 @@ protected:
 
     void send_nav_controller_output() const override {};
     void send_pid_tuning() override {};
+    virtual uint8_t send_available_mode(uint8_t index) const override { return 0; }
 };
 
 /*

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -243,6 +243,10 @@ for t in $CI_BUILD_TARGET; do
         $waf configure --board FreeflyRTK
         $waf clean
         $waf AP_Periph
+        echo "Building CubeNode-ETH peripheral fw"
+        $waf configure --board CubeNode-ETH
+        $waf clean
+        $waf AP_Periph
         continue
     fi
 


### PR DESCRIPTION
* build was broken as a mandatory virtual method was added under GCS_MAVLink, without update AP_Periph/GCS_Mavlink
* also adds CubeNode-ETH to the CI to ensure that we have a periph firmware built with GCS_MAVLink and scripting enabled. 