### PR TITLE
AP_HAL_ChibiOS: correct logging of MAV_POWER_STATUS_CHANGED

### DIFF
--- a/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
+++ b/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
@@ -894,7 +894,7 @@ void AnalogIn::update_power_flags(void)
 #endif
 
     if (_power_flags != 0 &&
-        _power_flags != flags &&
+        (_power_flags&~MAV_POWER_STATUS_CHANGED) != (flags&~MAV_POWER_STATUS_CHANGED) &&
         hal.util->get_soft_armed()) {
         // the power status has changed while armed
         flags |= MAV_POWER_STATUS_CHANGED;


### PR DESCRIPTION
need to exclude the changed flag from the comparison!