### PR TITLE
AP_Rely: allow RELAYn_DEFAULT values on DroneCAN Periphs

### DIFF
--- a/libraries/AP_Relay/AP_Relay.cpp
+++ b/libraries/AP_Relay/AP_Relay.cpp
@@ -353,7 +353,11 @@ void AP_Relay::init()
             continue;
         }
 
-        if (function == AP_Relay_Params::FUNCTION::RELAY) {
+        bool use_default_param = (function == AP_Relay_Params::FUNCTION::RELAY);
+#ifdef HAL_BUILD_AP_PERIPH
+        use_default_param |= (function >= AP_Relay_Params::FUNCTION::DroneCAN_HARDPOINT_0 && function <= AP_Relay_Params::FUNCTION::DroneCAN_HARDPOINT_15);
+#endif
+        if (use_default_param) {
             // relay by instance number, set the state to match our output
             const AP_Relay_Params::DefaultState default_state = _params[instance].default_state;
             if ((default_state == AP_Relay_Params::DefaultState::OFF) ||


### PR DESCRIPTION
When using DroneCAN Hardpoint on a vehicle to control GPIO/Relay pins on a periph, the periph's default pin param value is ignored. This enables that.