### PR TITLE
Stop compiling old rally/fencepoint protocols in by default

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -696,6 +696,12 @@ class sitl(Board):
         cfg.define('AP_NOTIFY_LP5562_BUS', 2)
         cfg.define('AP_NOTIFY_LP5562_ADDR', 0x30)
 
+        # turn on fencepoint and rallypoint protocols so they're still tested:
+        env.CXXFLAGS.extend([
+            '-DAP_MAVLINK_RALLY_POINT_PROTOCOL_ENABLED=HAL_GCS_ENABLED&&HAL_RALLY_ENABLED',
+            '-DAC_POLYFENCE_FENCE_POINT_PROTOCOL_SUPPORT=HAL_GCS_ENABLED&&AP_FENCE_ENABLED'
+        ])
+
         try:
             env.CXXFLAGS.remove('-DHAL_NAVEKF2_AVAILABLE=0')
         except ValueError:

--- a/libraries/AC_Fence/AC_Fence_config.h
+++ b/libraries/AC_Fence/AC_Fence_config.h
@@ -17,5 +17,5 @@
 // ArduPilot 4.7 stops compiling them in
 // ArduPilot 4.8 removes the code entirely
 #ifndef AC_POLYFENCE_FENCE_POINT_PROTOCOL_SUPPORT
-#define AC_POLYFENCE_FENCE_POINT_PROTOCOL_SUPPORT HAL_GCS_ENABLED && AP_FENCE_ENABLED
+#define AC_POLYFENCE_FENCE_POINT_PROTOCOL_SUPPORT 0
 #endif

--- a/libraries/GCS_MAVLink/GCS_config.h
+++ b/libraries/GCS_MAVLink/GCS_config.h
@@ -68,7 +68,7 @@
 // ArduPilot 4.7 stops compiling them in by default
 // ArduPilot 4.8 removes the code entirely
 #ifndef AP_MAVLINK_RALLY_POINT_PROTOCOL_ENABLED
-#define AP_MAVLINK_RALLY_POINT_PROTOCOL_ENABLED HAL_GCS_ENABLED && HAL_RALLY_ENABLED
+#define AP_MAVLINK_RALLY_POINT_PROTOCOL_ENABLED 0
 #endif
 
 // CODE_REMOVAL


### PR DESCRIPTION
Per our goal of removing support from the codebase:
```
// CODE_REMOVAL
// ArduPilot 4.6 sends deprecation warnings for RALLY_POINT/RALLY_FETCH_POINT
// ArduPilot 4.7 stops compiling them in by default
// ArduPilot 4.8 removes the code entirely
#ifndef AP_MAVLINK_RALLY_POINT_PROTOCOL_ENABLED
#define AP_MAVLINK_RALLY_POINT_PROTOCOL_ENABLED 0
#endif
```

(similarly for fencepoint)
