### PR TITLE
Rename Location get-vector-from-origin methods

### DIFF
--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -1211,7 +1211,7 @@ void GCS_MAVLINK_Copter::handle_message_set_position_target_global_int(const mav
                 return;
             }
             Vector3f pos_neu_cm;
-            if (!loc.get_vector_from_origin_NEU(pos_neu_cm)) {
+            if (!loc.get_vector_from_origin_NEU_cm(pos_neu_cm)) {
                 // input is not valid so stop
                 copter.mode_guided.init(true);
                 return;

--- a/ArduCopter/autoyaw.cpp
+++ b/ArduCopter/autoyaw.cpp
@@ -176,7 +176,7 @@ void Mode::AutoYaw::set_roi(const Location &roi_location)
 #if HAL_MOUNT_ENABLED
         // check if mount type requires us to rotate the quad
         if (!copter.camera_mount.has_pan_control()) {
-            if (roi_location.get_vector_from_origin_NEU(roi)) {
+            if (roi_location.get_vector_from_origin_NEU_cm(roi)) {
                 auto_yaw.set_mode(Mode::ROI);
             }
         }
@@ -191,7 +191,7 @@ void Mode::AutoYaw::set_roi(const Location &roi_location)
         //      4: point at a target given a target id (can't be implemented)
 #else
         // if we have no camera mount aim the quad at the location
-        if (roi_location.get_vector_from_origin_NEU(roi)) {
+        if (roi_location.get_vector_from_origin_NEU_cm(roi)) {
             auto_yaw.set_mode(Mode::ROI);
         }
 #endif  // HAL_MOUNT_ENABLED

--- a/ArduPlane/mode_qloiter.cpp
+++ b/ArduPlane/mode_qloiter.cpp
@@ -54,7 +54,7 @@ void ModeQLoiter::run()
     if (last_pos_set_ms != 0 && now - last_pos_set_ms < precland_timeout_ms) {
         // we have an active landing target override
         Vector2f rel_origin;
-        if (plane.next_WP_loc.get_vector_xy_from_origin_NE(rel_origin)) {
+        if (plane.next_WP_loc.get_vector_xy_from_origin_NE_cm(rel_origin)) {
             quadplane.pos_control->set_pos_desired_NE_cm(rel_origin);
             last_target_loc_set_ms = 0;
         }

--- a/ArduPlane/mode_thermal.cpp
+++ b/ArduPlane/mode_thermal.cpp
@@ -60,8 +60,8 @@ void ModeThermal::update_soaring()
         AP_Mission::Mission_Command prev_nav_cmd;
 
         if (!(plane.mission.get_next_nav_cmd(plane.mission.get_prev_nav_cmd_with_wp_index(), prev_nav_cmd) &&
-            prev_nav_cmd.content.location.get_vector_xy_from_origin_NE(prev_wp) &&
-            current_nav_cmd.content.location.get_vector_xy_from_origin_NE(next_wp))) {
+            prev_nav_cmd.content.location.get_vector_xy_from_origin_NE_cm(prev_wp) &&
+            current_nav_cmd.content.location.get_vector_xy_from_origin_NE_cm(next_wp))) {
             prev_wp.zero();
             next_wp.zero();
         }

--- a/ArduSub/GCS_MAVLink_Sub.cpp
+++ b/ArduSub/GCS_MAVLink_Sub.cpp
@@ -656,7 +656,7 @@ void GCS_MAVLINK_Sub::handle_message(const mavlink_message_t &msg)
                 int32_t(packet.alt*100),
                 frame,
             };
-            if (!loc.get_vector_from_origin_NEU(pos_neu_cm)) {
+            if (!loc.get_vector_from_origin_NEU_cm(pos_neu_cm)) {
                 break;
             }
         }

--- a/ArduSub/commands_logic.cpp
+++ b/ArduSub/commands_logic.cpp
@@ -525,7 +525,7 @@ bool Sub::verify_circle(const AP_Mission::Mission_Command& cmd)
     if (auto_mode == Auto_CircleMoveToEdge) {
         if (wp_nav.reached_wp_destination()) {
             Vector3f circle_center;
-            UNUSED_RESULT(cmd.content.location.get_vector_from_origin_NEU(circle_center));
+            UNUSED_RESULT(cmd.content.location.get_vector_from_origin_NEU_cm(circle_center));
 
             // set target altitude if not provided
             if (is_zero(circle_center.z)) {

--- a/ArduSub/mode_auto.cpp
+++ b/ArduSub/mode_auto.cpp
@@ -401,7 +401,7 @@ void ModeAuto::set_auto_yaw_roi(const Location &roi_location)
 #if HAL_MOUNT_ENABLED
         // check if mount type requires us to rotate the sub
         if (!sub.camera_mount.has_pan_control()) {
-            if (roi_location.get_vector_from_origin_NEU(sub.roi_WP)) {
+            if (roi_location.get_vector_from_origin_NEU_cm(sub.roi_WP)) {
                 set_auto_yaw_mode(AUTO_YAW_ROI);
             }
         }
@@ -416,7 +416,7 @@ void ModeAuto::set_auto_yaw_roi(const Location &roi_location)
         //      4: point at a target given a target id (can't be implemented)
 #else
         // if we have no camera mount aim the sub at the location
-        if (roi_location.get_vector_from_origin_NEU(sub.roi_WP)) {
+        if (roi_location.get_vector_from_origin_NEU_cm(sub.roi_WP)) {
             set_auto_yaw_mode(AUTO_YAW_ROI);
         }
 #endif  // HAL_MOUNT_ENABLED

--- a/Rover/mode_circle.cpp
+++ b/Rover/mode_circle.cpp
@@ -52,7 +52,7 @@ float ModeCircle::get_reached_distance() const
 bool ModeCircle::set_center(const Location& center_loc, float radius_m, bool dir_ccw)
 {
     Vector2f center_pos_cm;
-    if (!center_loc.get_vector_xy_from_origin_NE(center_pos_cm)) {
+    if (!center_loc.get_vector_xy_from_origin_NE_cm(center_pos_cm)) {
         return false;
     }
     if (!_enter()) {

--- a/libraries/AC_Avoidance/AP_OABendyRuler.cpp
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.cpp
@@ -547,7 +547,8 @@ bool AP_OABendyRuler::calc_margin_from_inclusion_and_exclusion_polygons(const Lo
 
     // convert start and end to offsets from EKF origin
     Vector2f start_NE, end_NE;
-    if (!start.get_vector_xy_from_origin_NE(start_NE) || !end.get_vector_xy_from_origin_NE(end_NE)) {
+    if (!start.get_vector_xy_from_origin_NE_cm(start_NE) ||
+        !end.get_vector_xy_from_origin_NE_cm(end_NE)) {
         return false;
     }
 
@@ -618,7 +619,8 @@ bool AP_OABendyRuler::calc_margin_from_inclusion_and_exclusion_circles(const Loc
 
     // convert start and end to offsets from EKF origin
     Vector2f start_NE, end_NE;
-    if (!start.get_vector_xy_from_origin_NE(start_NE) || !end.get_vector_xy_from_origin_NE(end_NE)) {
+    if (!start.get_vector_xy_from_origin_NE_cm(start_NE) ||
+        !end.get_vector_xy_from_origin_NE_cm(end_NE)) {
         return false;
     }
 
@@ -685,7 +687,8 @@ bool AP_OABendyRuler::calc_margin_from_object_database(const Location &start, co
 
     // convert start and end to offsets (in cm) from EKF origin
     Vector3f start_NEU,end_NEU;
-    if (!start.get_vector_from_origin_NEU(start_NEU) || !end.get_vector_from_origin_NEU(end_NEU)) {
+    if (!start.get_vector_from_origin_NEU_cm(start_NEU) ||
+        !end.get_vector_from_origin_NEU_cm(end_NEU)) {
         return false;
     }
     if (start_NEU == end_NEU) {

--- a/libraries/AC_Avoidance/AP_OADijkstra.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra.cpp
@@ -174,7 +174,8 @@ AP_OADijkstra::AP_OADijkstra_State AP_OADijkstra::update(const Location &current
         _dest_to_next_dest_clear = false;
         if (!next_destination.is_zero()) {
             Vector2f seg_start, seg_end;
-            if (destination.get_vector_xy_from_origin_NE(seg_start) && next_destination.get_vector_xy_from_origin_NE(seg_end)) {
+            if (destination.get_vector_xy_from_origin_NE_cm(seg_start) &&
+                next_destination.get_vector_xy_from_origin_NE_cm(seg_end)) {
                 _dest_to_next_dest_clear = !intersects_fence(seg_start, seg_end);
             }
         }
@@ -879,7 +880,8 @@ bool AP_OADijkstra::find_closest_node_idx(node_index &node_idx) const
 bool AP_OADijkstra::calc_shortest_path(const Location &origin, const Location &destination, AP_OADijkstra_Error &err_id)
 {
     // convert origin and destination to offsets from EKF origin
-    if (!origin.get_vector_xy_from_origin_NE(_path_source) || !destination.get_vector_xy_from_origin_NE(_path_destination)) {
+    if (!origin.get_vector_xy_from_origin_NE_cm(_path_source) ||
+        !destination.get_vector_xy_from_origin_NE_cm(_path_destination)) {
         err_id = AP_OADijkstra_Error::DIJKSTRA_ERROR_NO_POSITION_ESTIMATE;
         return false;
     }

--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -110,7 +110,8 @@ void AC_Circle::set_center(const Location& center)
         // convert Location with terrain altitude
         Vector2f center_xy;
         int32_t terr_alt_cm;
-        if (center.get_vector_xy_from_origin_NE(center_xy) && center.get_alt_cm(Location::AltFrame::ABOVE_TERRAIN, terr_alt_cm)) {
+        if (center.get_vector_xy_from_origin_NE_cm(center_xy) &&
+            center.get_alt_cm(Location::AltFrame::ABOVE_TERRAIN, terr_alt_cm)) {
             set_center(Vector3f(center_xy.x, center_xy.y, terr_alt_cm), true);
         } else {
             // failed to convert location so set to current position and log error
@@ -120,7 +121,7 @@ void AC_Circle::set_center(const Location& center)
     } else {
         // convert Location with alt-above-home, alt-above-origin or absolute alt
         Vector3f circle_center_neu;
-        if (!center.get_vector_from_origin_NEU(circle_center_neu)) {
+        if (!center.get_vector_from_origin_NEU_cm(circle_center_neu)) {
             // default to current position and log error
             circle_center_neu = _inav.get_position_neu_cm();
             LOGGER_WRITE_ERROR(LogErrorSubsystem::NAVIGATION, LogErrorCode::FAILED_CIRCLE_INIT);

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -871,7 +871,7 @@ bool AC_WPNav::get_vector_NEU(const Location &loc, Vector3f &vec, bool &terrain_
 {
     // convert location to NE vector2f
     Vector2f res_vec;
-    if (!loc.get_vector_xy_from_origin_NE(res_vec)) {
+    if (!loc.get_vector_xy_from_origin_NE_cm(res_vec)) {
         return false;
     }
 

--- a/libraries/AC_WPNav/AC_WPNav_OA.cpp
+++ b/libraries/AC_WPNav/AC_WPNav_OA.cpp
@@ -207,7 +207,7 @@ bool AC_WPNav_OA::update_wpnav()
 
                 // calculate final destination as an offset from EKF origin in NEU
                 Vector2f dest_NE;
-                if (!_oa_destination.get_vector_xy_from_origin_NE(dest_NE)) {
+                if (!_oa_destination.get_vector_xy_from_origin_NE_cm(dest_NE)) {
                     // this should never happen because we can only get here if we have an EKF origin
                     INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
                     return false;
@@ -230,7 +230,7 @@ bool AC_WPNav_OA::update_wpnav()
 
                 // calculate final destination as an offset from EKF origin in NEU
                 Vector3f dest_NEU;
-                if (!_oa_destination.get_vector_from_origin_NEU(dest_NEU)) {
+                if (!_oa_destination.get_vector_from_origin_NEU_cm(dest_NEU)) {
                     // this should never happen because we can only get here if we have an EKF origin
                     INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
                     return false;

--- a/libraries/AP_Common/Location.cpp
+++ b/libraries/AP_Common/Location.cpp
@@ -236,7 +236,7 @@ bool Location::get_alt_m(AltFrame desired_frame, float &ret_alt) const
 // converts location to a vector from origin; if this method returns
 // false then vec_ne is unmodified
 template<typename T>
-bool Location::get_vector_xy_from_origin_NE(T &vec_ne) const
+bool Location::get_vector_xy_from_origin_NE_cm(T &vec_ne) const
 {
     Location ekf_origin;
     if (!AP::ahrs().get_origin(ekf_origin)) {
@@ -248,15 +248,15 @@ bool Location::get_vector_xy_from_origin_NE(T &vec_ne) const
 }
 
 // define for float and position vectors
-template bool Location::get_vector_xy_from_origin_NE<Vector2f>(Vector2f &vec_ne) const;
+template bool Location::get_vector_xy_from_origin_NE_cm<Vector2f>(Vector2f &vec_ne) const;
 #if HAL_WITH_POSTYPE_DOUBLE
-template bool Location::get_vector_xy_from_origin_NE<Vector2p>(Vector2p &vec_ne) const;
+template bool Location::get_vector_xy_from_origin_NE_cm<Vector2p>(Vector2p &vec_ne) const;
 #endif
 
 // converts location to a vector from origin; if this method returns
 // false then vec_neu is unmodified
 template<typename T>
-bool Location::get_vector_from_origin_NEU(T &vec_neu) const
+bool Location::get_vector_from_origin_NEU_cm(T &vec_neu) const
 {
     // convert altitude
     int32_t alt_above_origin_cm = 0;
@@ -265,7 +265,7 @@ bool Location::get_vector_from_origin_NEU(T &vec_neu) const
     }
 
     // convert lat, lon
-    if (!get_vector_xy_from_origin_NE(vec_neu.xy())) {
+    if (!get_vector_xy_from_origin_NE_cm(vec_neu.xy())) {
         return false;
     }
 
@@ -273,12 +273,49 @@ bool Location::get_vector_from_origin_NEU(T &vec_neu) const
 
     return true;
 }
+template<typename T>
+bool Location::get_vector_from_origin_NEU(T &vec_neu) const
+{
+    return get_vector_from_origin_NEU_cm(vec_neu);
+}
 
 // define for float and position vectors
+template bool Location::get_vector_from_origin_NEU_cm<Vector3f>(Vector3f &vec_neu) const;
 template bool Location::get_vector_from_origin_NEU<Vector3f>(Vector3f &vec_neu) const;
 #if HAL_WITH_POSTYPE_DOUBLE
+template bool Location::get_vector_from_origin_NEU_cm<Vector3p>(Vector3p &vec_neu) const;
 template bool Location::get_vector_from_origin_NEU<Vector3p>(Vector3p &vec_neu) const;
 #endif
+
+template<typename T>
+bool Location::get_vector_xy_from_origin_NE_m(T &vec_ne) const
+{
+    if (!get_vector_xy_from_origin_NE_cm(vec_ne)) {
+        return false;
+    }
+    vec_ne *= 0.01;
+    return true;
+}
+template bool Location::get_vector_xy_from_origin_NE_m<Vector2f>(Vector2f &vec_ne) const;
+#if HAL_WITH_POSTYPE_DOUBLE
+template bool Location::get_vector_xy_from_origin_NE_m<Vector2p>(Vector2p &vec_ne) const;
+#endif
+
+template<typename T>
+bool Location::get_vector_from_origin_NEU_m(T &vec_neu) const
+{
+    if (!get_vector_from_origin_NEU_cm(vec_neu)) {
+        return false;
+    }
+    vec_neu *= 0.01;
+    return true;
+}
+// define for float and position vectors
+template bool Location::get_vector_from_origin_NEU_m<Vector3f>(Vector3f &vec_neu) const;
+#if HAL_WITH_POSTYPE_DOUBLE
+template bool Location::get_vector_from_origin_NEU_m<Vector3p>(Vector3p &vec_neu) const;
+#endif
+
 
 #endif  // AP_AHRS_ENABLED
 

--- a/libraries/AP_Common/Location.h
+++ b/libraries/AP_Common/Location.h
@@ -69,11 +69,25 @@ public:
     // centimetres.  If this method returns false then vec_ne is
     // unmodified.
     template<typename T>
-    bool get_vector_xy_from_origin_NE(T &vec_ne) const WARN_IF_UNUSED;
+    bool get_vector_xy_from_origin_NE_cm(T &vec_ne) const WARN_IF_UNUSED;
     // converts location to a vector from origin; if this method returns
     // false then vec_neu is unmodified
     template<typename T>
+    bool get_vector_from_origin_NEU_cm(T &vec_neu) const WARN_IF_UNUSED;
+    // same as get_vector_from_origin_NEU_cm, but only here so we can
+    // continue to use it in LUA scripts:
+    template<typename T>
     bool get_vector_from_origin_NEU(T &vec_neu) const WARN_IF_UNUSED;
+
+    // get position as a vector (in metres) from origin (x,y only or
+    // x,y,z) return false on failure to get the vector which can only
+    // happen if the EKF origin has not been set yet x, y and z are in
+    // metres.  If this method returns false then vec_ne is
+    // unmodified.
+    template<typename T>
+    bool get_vector_xy_from_origin_NE_m(T &vec_ne) const;
+    template<typename T>
+    bool get_vector_from_origin_NEU_m(T &vec_neu) const;
 
     // return horizontal distance in meters between two locations
     ftype get_distance(const Location &loc2) const;

--- a/libraries/AP_Common/tests/test_location.cpp
+++ b/libraries/AP_Common/tests/test_location.cpp
@@ -261,9 +261,9 @@ TEST(Location, Tests)
     }
 
     Vector2f test_vec2;
-    EXPECT_FALSE(test_home.get_vector_xy_from_origin_NE(test_vec2));
+    EXPECT_FALSE(test_home.get_vector_xy_from_origin_NE_cm(test_vec2));
     Vector3f test_vec3;
-    EXPECT_FALSE(test_home.get_vector_from_origin_NEU(test_vec3));
+    EXPECT_FALSE(test_home.get_vector_from_origin_NEU_cm(test_vec3));
 
     Location test_origin = test_home;
     test_origin.offset(2, 2);
@@ -286,7 +286,7 @@ TEST(Location, Tests)
 
     // can't create a Location using a vector here as there's no origin for the vector to be relative to:
     // const Location test_location_empty{test_vect, Location::AltFrame::ABOVE_HOME};
-    // EXPECT_FALSE(test_location_empty.get_vector_from_origin_NEU(test_vec3));
+    // EXPECT_FALSE(test_location_empty.get_vector_from_origin_NEU_cm(test_vec3));
 }
 
 TEST(Location, Distance)

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -381,8 +381,8 @@ private:
     // load backend drivers
     bool _add_backend(AP_Compass_Backend *backend);
     __INITFUNC__ void _probe_external_i2c_compasses(void);
-    void _detect_backends(void);
-    void probe_i2c_spi_compasses(void);
+    __INITFUNC__ void _detect_backends(void);
+    __INITFUNC__ void probe_i2c_spi_compasses(void);
 #if AP_COMPASS_DRONECAN_ENABLED
     void probe_dronecan_compasses(void);
 #endif

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1157,9 +1157,19 @@ function Location_ud:get_distance_NED(loc) end
 ---@return number -- bearing in radians
 function Location_ud:get_bearing(loc) end
 
--- Returns the offset from the EKF origin to this location.
+-- Returns the offset from the EKF origin to this location (in cm)
+-- Returns nil if the EKF origin wasn’t available at the time this was called.
+---@return Vector3f_ud|nil -- Vector between origin and location north east up in cm
+function Location_ud:get_vector_from_origin_NEU_cm() end
+
+-- Returns the offset from the EKF origin to this location (in metres).
 -- Returns nil if the EKF origin wasn’t available at the time this was called.
 ---@return Vector3f_ud|nil -- Vector between origin and location north east up in meters
+function Location_ud:get_vector_from_origin_NEU_m() end
+
+--- Deprecated method returning offset from EKF origin
+---@return Vector3f_ud|nil -- Vector between origin and location north east up in centimetres
+---@deprecated -- Use get_vector_from_origin_NEU_cm or get_vector_from_origin_NEU_m
 function Location_ud:get_vector_from_origin_NEU() end
 
 -- Translates this Location by the specified  distance given a bearing.

--- a/libraries/AP_Scripting/examples/set_target_posvel_circle.lua
+++ b/libraries/AP_Scripting/examples/set_target_posvel_circle.lua
@@ -72,7 +72,7 @@ function update()
         -- calculate test starting location in NED
         local cur_loc = ahrs:get_location()        
         if cur_loc then
-             test_start_location = cur_loc.get_vector_from_origin_NEU(cur_loc)             
+             test_start_location = cur_loc.get_vector_from_origin_NEU_cm(cur_loc)             
              if test_start_location then
                 test_start_location:x(test_start_location:x() * 0.01) 
                 test_start_location:y(test_start_location:y() * 0.01) 

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -14,8 +14,13 @@ userdata Location method get_distance float Location
 userdata Location method offset void float'skip_check float'skip_check
 userdata Location method offset_bearing void float'skip_check float'skip_check
 userdata Location method offset_bearing_and_pitch void float'skip_check float'skip_check float'skip_check
+userdata Location method get_vector_from_origin_NEU_m boolean Vector3f'Null
+userdata Location method get_vector_from_origin_NEU_m depends AP_AHRS_ENABLED
+userdata Location method get_vector_from_origin_NEU_cm boolean Vector3f'Null
+userdata Location method get_vector_from_origin_NEU_cm depends AP_AHRS_ENABLED
 userdata Location method get_vector_from_origin_NEU boolean Vector3f'Null
 userdata Location method get_vector_from_origin_NEU depends AP_AHRS_ENABLED
+userdata Location method get_vector_from_origin_NEU deprecate Use get_vector_from_origin_NEU_cm or get_vector_from_origin_NEU_m
 userdata Location method get_bearing float Location
 userdata Location method get_distance_NED Vector3f Location
 userdata Location method get_distance_NE Vector2f Location

--- a/libraries/AR_WPNav/AR_WPNav.cpp
+++ b/libraries/AR_WPNav/AR_WPNav.cpp
@@ -234,8 +234,8 @@ bool AR_WPNav::set_desired_location(const Location& destination, Location next_d
     // convert origin and destination to offset from EKF origin
     Vector2f origin_NE;
     Vector2f destination_NE;
-    if (!_origin.get_vector_xy_from_origin_NE(origin_NE) ||
-        !_destination.get_vector_xy_from_origin_NE(destination_NE)) {
+    if (!_origin.get_vector_xy_from_origin_NE_cm(origin_NE) ||
+        !_destination.get_vector_xy_from_origin_NE_cm(destination_NE)) {
         INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
         return false;
     }
@@ -269,7 +269,7 @@ bool AR_WPNav::set_desired_location(const Location& destination, Location next_d
         if (!_pivot_at_next_wp) {
             // convert next_destination to offset from EKF origin
             Vector2f next_destination_NE;
-            if (!next_destination.get_vector_xy_from_origin_NE(next_destination_NE)) {
+            if (!next_destination.get_vector_xy_from_origin_NE_cm(next_destination_NE)) {
                 INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
                 return false;
             }
@@ -411,7 +411,7 @@ void AR_WPNav::advance_wp_target_along_track(const Location &current_loc, float 
 
     // exit immediately if we can't convert waypoint origin to offset from ekf origin
     Vector2f origin_NE;
-    if (!_origin.get_vector_xy_from_origin_NE(origin_NE)) {
+    if (!_origin.get_vector_xy_from_origin_NE_cm(origin_NE)) {
         return;
     }
     // convert from cm to meters
@@ -467,7 +467,7 @@ void AR_WPNav::update_psc_input_shaping(float dt)
 {
     // convert destination location to offset from EKF origin (in meters)
     Vector2f pos_target_cm;
-    if (!_destination.get_vector_xy_from_origin_NE(pos_target_cm)) {
+    if (!_destination.get_vector_xy_from_origin_NE_cm(pos_target_cm)) {
         return;
     }
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3036,7 +3036,7 @@ void GCS_MAVLINK::send_home_position() const
 
     // get home position from origin
     Vector3f home_pos_ned;
-    if (home.get_vector_from_origin_NEU(home_pos_ned)) {
+    if (home.get_vector_from_origin_NEU_cm(home_pos_ned)) {
         // convert NEU in cm to NED in meters
         home_pos_ned *= 0.01f;
         home_pos_ned.z *= -1;

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -1483,7 +1483,7 @@ float SIM::measure_distance_at_angle_bf(const Location &location, float angle) c
 {
     // should we populate state.rangefinder_m[...] from this?
     Vector2f vehicle_pos_cm;
-    if (!location.get_vector_xy_from_origin_NE(vehicle_pos_cm)) {
+    if (!location.get_vector_xy_from_origin_NE_cm(vehicle_pos_cm)) {
         // should probably use SITL variables...
         return 0.0f;
     }
@@ -1511,7 +1511,7 @@ float SIM::measure_distance_at_angle_bf(const Location &location, float angle) c
     Location location2 = location;
     location2.offset_bearing(wrap_180(angle + state.yawDeg), 200);
     Vector2f ray_endpos_cm;
-    if (!location2.get_vector_xy_from_origin_NE(ray_endpos_cm)) {
+    if (!location2.get_vector_xy_from_origin_NE_cm(ray_endpos_cm)) {
         // should probably use SITL variables...
         return 0.0f;
     }
@@ -1548,7 +1548,7 @@ float SIM::measure_distance_at_angle_bf(const Location &location, float angle) c
             }
 #endif
             Vector2f post_position_cm;
-            if (!post_location.get_vector_xy_from_origin_NE(post_position_cm)) {
+            if (!post_location.get_vector_xy_from_origin_NE_cm(post_position_cm)) {
                 // should probably use SITL variables...
                 min_dist_cm = 0;
                 goto OUT;


### PR DESCRIPTION
Moves us closer to using metres in this interface

Several places `*= 0.01`the result of this method already.

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                                                     
Durandal                            0      *           8       0                 8      8      8
Hitec-Airspeed           *                                                                     
KakuteH7-bdshot                     0      *           8       8                 8      8      0
MatekF405                           *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *                  *       *                 *      *      *
f103-QiotekPeriph        *                                                                     
f303-Universal           *                                                                     
iomcu                                                                *                         
revo-mini                           *      *           *       *                 *      *      *
skyviper-v2450                                         *                                       
```

Bindings have changed for vehicles that run scripting.

Need compatibility code for scripts.  Somehow.
