### PR TITLE
Fix for Qurt DSP to Apps Proc link message sequence checking

### DIFF
--- a/libraries/AP_HAL_QURT/UARTDriver.h
+++ b/libraries/AP_HAL_QURT/UARTDriver.h
@@ -83,6 +83,8 @@ public:
 
     bool _write_pending_bytes(void) override;
 
+    void check_rx_seq(uint32_t seq);
+
     uint32_t bw_in_bytes_per_second() const override
     {
         return 250000 * 3;
@@ -95,7 +97,8 @@ public:
 private:
     static void _mavlink_data_cb(const struct qurt_rpc_msg *msg, void *p);
     uint8_t inst;
-    uint32_t seq;
+    uint32_t tx_seq;
+    uint32_t rx_seq;
 };
 
 /*

--- a/libraries/AP_HAL_QURT/replace.cpp
+++ b/libraries/AP_HAL_QURT/replace.cpp
@@ -151,7 +151,6 @@ typedef void (*mavlink_data_callback_t)(const struct qurt_rpc_msg *msg, void* p)
 
 static mavlink_data_callback_t mav_cb[MAX_MAVLINK_INSTANCES];
 static void *mav_cb_ptr[MAX_MAVLINK_INSTANCES];
-static uint32_t expected_seq;
 
 void register_mavlink_data_callback(uint8_t instance, mavlink_data_callback_t func, void *p)
 {
@@ -172,10 +171,6 @@ int slpi_link_client_receive(const uint8_t *data, int data_len_in_bytes)
     if (msg->data_length + QURT_RPC_MSG_HEADER_LEN != data_len_in_bytes) {
         return 0;
     }
-    if (msg->seq != expected_seq) {
-        HAP_PRINTF("Bad sequence %u %u", msg->seq, expected_seq);
-    }
-    expected_seq = msg->seq + 1;
 
     switch (msg->msg_id) {
     case QURT_MSG_ID_MAVLINK_MSG: {


### PR DESCRIPTION
Make the receive sequence number checking on Qurt DSP per link to match what is done on the application processor side so that we don't get annoying sequence number mismatch warnings in the mini-dm output. This has no affect on functionality, just cleans up the warning messages.