### PR TITLE
Fixed an explicit initializer to get rid of Qurt compiler warning

### DIFF
--- a/libraries/AP_RCProtocol/spm_srxl.cpp
+++ b/libraries/AP_RCProtocol/spm_srxl.cpp
@@ -1304,7 +1304,7 @@ void srxlOnFrameError(uint8_t busIndex)
 
 SrxlFullID srxlGetTelemetryEndpoint(void)
 {
-    SrxlFullID retVal = {0};
+    SrxlFullID retVal = {{0}};
     if(srxlRx.pTelemRcvr)
     {
         retVal.deviceID = srxlRx.pTelemRcvr->deviceID;


### PR DESCRIPTION
Added another set of braces to an initializer for a local variable to get rid of the following Qurt compiler warning:

../../libraries/AP_RCProtocol/spm_srxl.cpp:1307:26: warning: suggest braces around initialization of subobject [-Wmissing-braces]
    SrxlFullID retVal = {0};
                         ^
                         {}

