### PR TITLE
Remove extraneous zero initializers to clean up Qurt compiler warnings

### DIFF
--- a/libraries/AP_RCProtocol/spm_srxl.cpp
+++ b/libraries/AP_RCProtocol/spm_srxl.cpp
@@ -74,27 +74,27 @@ const uint16_t srxlCRCTable[] =
 
 /// PUBLIC VARIABLES ///
 
-SrxlChannelData srxlChData = {0, 0, 0, {0}};
-SrxlTelemetryData srxlTelemData = {0};
+SrxlChannelData srxlChData;
+SrxlTelemetryData srxlTelemData;
 SrxlVtxData srxlVtxData = {0, 0, 1, 0, 0, 1};
 
 /// LOCAL VARIABLES ///
 
-static SrxlDevice srxlThisDev = {0};
+static SrxlDevice srxlThisDev;
 static SrxlBus srxlBus[SRXL_NUM_OF_BUSES];
 static bool srxlChDataIsFailsafe = false;
 static bool srxlTelemetryPhase = false;
 #ifdef SRXL_INCLUDE_MASTER_CODE
-static uint32_t srxlFailsafeChMask = 0;  // Tracks all active channels for use during failsafe transmission
+static uint32_t srxlFailsafeChMask;  // Tracks all active channels for use during failsafe transmission
 #endif
-static SrxlBindData srxlBindInfo = {0, 0, 0, 0};
-static SrxlReceiverStats srxlRx = {0};
-static uint16_t srxlTelemSuppressCount = 0;
+static SrxlBindData srxlBindInfo;
+static SrxlReceiverStats srxlRx;
+static uint16_t srxlTelemSuppressCount;
 
 #ifdef SRXL_INCLUDE_FWD_PGM_CODE
-static SrxlFullID srxlFwdPgmDevice = {0, 0};  // Device that should accept Forward Programming connection by default
-static uint8_t srxlFwdPgmBuffer[FWD_PGM_MAX_DATA_SIZE] = {0};
-static uint8_t srxlFwdPgmBufferLength = 0;
+static SrxlFullID srxlFwdPgmDevice;  // Device that should accept Forward Programming connection by default
+static uint8_t srxlFwdPgmBuffer[FWD_PGM_MAX_DATA_SIZE];
+static uint8_t srxlFwdPgmBufferLength;
 #endif
 
 // Include additional header and externs if using STM32 hardware acceleration


### PR DESCRIPTION
Extraneous zero initializers for global / static variables were removed to get rid of the following Qurt compiler warnings:

../../libraries/AP_RCProtocol/spm_srxl.cpp:78:36: warning: suggest braces around initialization of subobject [-Wmissing-braces]
SrxlTelemetryData srxlTelemData = {0};
                                   ^
                                   {}
../../libraries/AP_RCProtocol/spm_srxl.cpp:83:34: warning: suggest braces around initialization of subobject [-Wmissing-braces]
static SrxlDevice srxlThisDev = {0};
                                 ^
                                 {}
../../libraries/AP_RCProtocol/spm_srxl.cpp:91:36: warning: suggest braces around initialization of subobject [-Wmissing-braces]
static SrxlReceiverStats srxlRx = {0};
                                   ^
                                   {}
../../libraries/AP_RCProtocol/spm_srxl.cpp:91:36: warning: suggest braces around initialization of subobject [-Wmissing-braces]
static SrxlReceiverStats srxlRx = {0};
                                   ^
                                   {}

Since this data will end up in .bss and be zeroed out it does not need explicit zero initializers.
