### PR TITLE
Added conditional compiling to errno declarations for QURT

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_Mission.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Mission.cpp
@@ -30,7 +30,11 @@
 #include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL& hal;
+
+// QURT HAL already has a declaration of errno in errno.h
+#if CONFIG_HAL_BOARD != HAL_BOARD_QURT
 extern int errno;
+#endif
 
 #define IDLE_TIMEOUT_MS 30000
 

--- a/libraries/AP_Filesystem/AP_Filesystem_Param.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Param.cpp
@@ -29,7 +29,11 @@
 #define PACKED_NAME "param.pck"
 
 extern const AP_HAL::HAL& hal;
+
+// QURT HAL already has a declaration of errno in errno.h
+#if CONFIG_HAL_BOARD != HAL_BOARD_QURT
 extern int errno;
+#endif
 
 int AP_Filesystem_Param::open(const char *fname, int flags, bool allow_absolute_path)
 {


### PR DESCRIPTION
Added conditional compile tags for QURT on errno external declarations since QURT already has this. Fixes the following Qurt compiler warnings:

../../libraries/AP_Filesystem/AP_Filesystem_Param.cpp:32:12: warning: extra qualification on member '_Geterrno' [-Wextra-qualification]
extern int errno;
           ^
/opt/hexagon-sdk/4.1.0.4-lite/tools/HEXAGON_Tools/8.4.05/Tools/bin/../target/hexagon/include/errno.h:158:25: note: expanded from macro 'errno'
  #define errno (*_CSTD _Geterrno())
                        ^
1 warning generated.

../../libraries/AP_Filesystem/AP_Filesystem_Mission.cpp:33:12: warning: extra qualification on member '_Geterrno' [-Wextra-qualification]
extern int errno;
           ^
/opt/hexagon-sdk/4.1.0.4-lite/tools/HEXAGON_Tools/8.4.05/Tools/bin/../target/hexagon/include/errno.h:158:25: note: expanded from macro 'errno'
  #define errno (*_CSTD _Geterrno())
                        ^
