### PR TITLE
Remove unused private member to get rid of compiler warning in Qurt build

### DIFF
--- a/libraries/AP_GPS/AP_GPS_Blended.h
+++ b/libraries/AP_GPS/AP_GPS_Blended.h
@@ -64,7 +64,6 @@ private:
     Vector3f _blended_antenna_offset; // blended antenna offset
     float _blended_lag_sec; // blended receiver lag in seconds
     float _blend_weights[GPS_MAX_RECEIVERS]; // blend weight for each GPS. The blend weights must sum to 1.0 across all instances.
-    bool _output_is_blended; // true when a blended GPS solution being output
     uint8_t _blend_health_counter;  // 0 = perfectly health, 100 = very unhealthy
 
     AP_GPS::GPS_timing &timing;


### PR DESCRIPTION
An unused private member variable was removed to get rid of the following Qurt compiler warning:

In file included from ../../libraries/AP_GPS/AP_GPS_Blended.cpp:5:
../../libraries/AP_GPS/AP_GPS_Blended.h:67:10: warning: private field '_output_is_blended' is not used [-Wunused-private-field]
    bool _output_is_blended; // true when a blended GPS solution being output
         ^

