### PR TITLE
Removed unused private members to fix Qurt compiler warnings

### DIFF
--- a/libraries/AP_GSOF/AP_GSOF.h
+++ b/libraries/AP_GSOF/AP_GSOF.h
@@ -127,8 +127,5 @@ private:
 
     static const uint8_t STX = 0x02;
     static const uint8_t ETX = 0x03;
-
-    uint8_t packetcount;
-    uint32_t gsofmsg_time;
 };
 #endif // AP_GSOF_ENABLED


### PR DESCRIPTION
Removed unused private members in GSOF to fix these Qurt compiler warnings:

In file included from ../../libraries/AP_GSOF/AP_GSOF.cpp:4:
../../libraries/AP_GSOF/AP_GSOF.h:131:13: warning: private field 'packetcount' is not used [-Wunused-private-field]
    uint8_t packetcount;
            ^
../../libraries/AP_GSOF/AP_GSOF.h:132:14: warning: private field 'gsofmsg_time' is not used [-Wunused-private-field]
    uint32_t gsofmsg_time;
             ^
