### PR TITLE
Added explicit casts to get rid of Qurt compiler warning about implicit casts

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_ADIS1647x.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_ADIS1647x.cpp
@@ -171,22 +171,22 @@ bool AP_InertialSensor_ADIS1647x::check_product_id(uint16_t &prod_id)
         opmode = OpMode::Delta32;
         expected_sample_rate_hz = 1200;
         accel_scale = 392.0 / 2097152000.0;
-        dvel_scale = 400.0 / 0x7FFFFFFF;
+        dvel_scale = 400.0 / (float)0x7FFFFFFF;
         _clip_limit = (40.0f - 0.5f) * GRAVITY_MSS;
         // RANG_MDL register used for gyro range
         uint16_t rang_mdl = read_reg16(REG_RANG_MDL);
         switch ((rang_mdl >> 2) & 3) {
         case 0:
             gyro_scale = radians(125) / 0x4E200000;
-            dangle_scale = radians(360.0 / 0x7FFFFFFF);
+            dangle_scale = radians(360.0 / (float)0x7FFFFFFF);
             break;
         case 1:
             gyro_scale = radians(500) / 0x4E200000;
-            dangle_scale = radians(720.0 / 0x7FFFFFFF);
+            dangle_scale = radians(720.0 / (float)0x7FFFFFFF);
             break;
         case 3:
             gyro_scale = radians(2000) / 0x4E200000;
-            dangle_scale = radians(2160.0 / 0x7FFFFFFF);
+            dangle_scale = radians(2160.0 / (float)0x7FFFFFFF);
             break;
         default:
             return false;


### PR DESCRIPTION
Added explicit casts to get rid of the following Qurt compiler warnings:

../../libraries/AP_InertialSensor/AP_InertialSensor_ADIS1647x.cpp:174:30: warning: implicit conversion from 'int' to 'float' changes value from 2147483647 to 2147483648 [-Wimplicit-int-float-conversion]
        dvel_scale = 400.0 / 0x7FFFFFFF;
                           ~ ^~~~~~~~~~
../../libraries/AP_InertialSensor/AP_InertialSensor_ADIS1647x.cpp:181:44: warning: implicit conversion from 'int' to 'float' changes value from 2147483647 to 2147483648 [-Wimplicit-int-float-conversion]
            dangle_scale = radians(360.0 / 0x7FFFFFFF);
                                         ~ ^~~~~~~~~~
../../libraries/AP_InertialSensor/AP_InertialSensor_ADIS1647x.cpp:185:44: warning: implicit conversion from 'int' to 'float' changes value from 2147483647 to 2147483648 [-Wimplicit-int-float-conversion]
            dangle_scale = radians(720.0 / 0x7FFFFFFF);
                                         ~ ^~~~~~~~~~
../../libraries/AP_InertialSensor/AP_InertialSensor_ADIS1647x.cpp:189:45: warning: implicit conversion from 'int' to 'float' changes value from 2147483647 to 2147483648 [-Wimplicit-int-float-conversion]
            dangle_scale = radians(2160.0 / 0x7FFFFFFF);
