### PR TITLE
Fix method of accessing character string to fix Qurt compiler warning

### DIFF
--- a/libraries/AP_Scripting/lua/src/lundump.c
+++ b/libraries/AP_Scripting/lua/src/lundump.c
@@ -241,7 +241,7 @@ static void fchecksize (LoadState *S, size_t size, const char *tname) {
 #define checksize(S,t)	fchecksize(S,sizeof(t),#t)
 
 static void checkHeader (LoadState *S) {
-  checkliteral(S, LUA_SIGNATURE + 1, "not a");  /* 1st char already checked */
+  checkliteral(S, &LUA_SIGNATURE[1], "not a");  /* 1st char already checked */
   if (LoadByte(S) != LUAC_VERSION)
     error(S, "version mismatch in");
   if (LoadByte(S) != LUAC_FORMAT)


### PR DESCRIPTION
Changed character pointer access from pointer addition to address of array subscript to get rid of Qurt compiler warning:

../../libraries/AP_Scripting/lua/src/lundump.c:244:33: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
  checkliteral(S, LUA_SIGNATURE + 1, "not a");  /* 1st char already checked */
                  ~~~~~~~~~~~~~~^~~
../../libraries/AP_Scripting/lua/src/lundump.c:244:33: note: use array indexing to silence this warning
  checkliteral(S, LUA_SIGNATURE + 1, "not a");  /* 1st char already checked */
                                ^
                  &             [  ]

