### PR TITLE
Replace fabsF macro with std::abs call to avoid having float / double mismatch warnings

### DIFF
--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -733,7 +733,7 @@ void ModeGuided::pos_control_run()
 
     float pos_offset_z_buffer = 0.0; // Vertical buffer size in m
     if (guided_pos_terrain_alt) {
-        pos_offset_z_buffer = MIN(copter.wp_nav->get_terrain_margin() * 100.0, 0.5 * fabsF(guided_pos_target_cm.z));
+        pos_offset_z_buffer = MIN(copter.wp_nav->get_terrain_margin() * 100.0, 0.5 * std::abs(guided_pos_target_cm.z));
     }
     pos_control->input_pos_xyz(guided_pos_target_cm, terr_offset, pos_offset_z_buffer);
 

--- a/libraries/AP_Math/matrix_alg.cpp
+++ b/libraries/AP_Math/matrix_alg.cpp
@@ -78,11 +78,11 @@ static void mat_pivot(const T* A, T* pivot, uint16_t n)
         uint16_t max_j = i;
         for(uint16_t j=i;j<n;j++){
             if (std::is_same<T, double>::value) {
-                if(fabsF(A[j*n + i]) > fabsF(A[max_j*n + i])) {
+                if(std::abs(A[j*n + i]) > std::abs(A[max_j*n + i])) {
                     max_j = j;
                 }
             } else {
-                if(fabsF(A[j*n + i]) > fabsF(A[max_j*n + i])) {
+                if(std::abs(A[j*n + i]) > std::abs(A[max_j*n + i])) {
                     max_j = j;
                 }
             }

--- a/libraries/AP_Math/quaternion.cpp
+++ b/libraries/AP_Math/quaternion.cpp
@@ -694,7 +694,7 @@ void QuaternionT<T>::zero(void)
 template <typename T>
 bool QuaternionT<T>::is_unit_length(void) const
 {
-    if (fabsF(length_squared() - 1) < 1E-3) {
+    if (std::abs(length_squared() - 1) < 1E-3) {
         return true;
     }
 

--- a/libraries/AP_Math/vector2.h
+++ b/libraries/AP_Math/vector2.h
@@ -251,13 +251,13 @@ struct Vector2
         const T intersection_run = point.x-seg_start.x;
         // check slopes are identical:
         if (::is_zero(expected_run)) {
-            if (fabsF(intersection_run) > FLT_EPSILON) {
+            if (std::abs(intersection_run) > FLT_EPSILON) {
                 return false;
             }
         } else {
             const T expected_slope = (seg_end.y-seg_start.y)/expected_run;
             const T intersection_slope = (point.y-seg_start.y)/intersection_run;
-            if (fabsF(expected_slope - intersection_slope) > FLT_EPSILON) {
+            if (std::abs(expected_slope - intersection_slope) > FLT_EPSILON) {
                 return false;
             }
         }


### PR DESCRIPTION
The fabsF macro is defined as either the float version or double version in ftype.h depending on HAL_WITH_EKF_DOUBLE. If it is defined as the float version and a double is used as the argument then we get a compiler warning in the Qurt build. If those are replaced with std:abs calls then that clears up the warnings since it is overloaded for both floats and doubles.