### PR TITLE
AP_HAL_ChibiOS: disable GCS in CubeNode-ETH

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeNode-ETH/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeNode-ETH/hwdef.dat
@@ -5,6 +5,7 @@ undef PE0
 undef PE1
 undef PC11
 undef HAL_PERIPH_ENABLE_IMU
+undef HAL_GCS_ENABLED
 
 # need to use UART8 to get RTS/CTS
 PE1 UART8_TX UART8


### PR DESCRIPTION
For some reason enabling GCS is breaking the PPPGW in AP_Periph