### PR TITLE
Add AP_Servo_Telem

### DIFF
--- a/Tools/AP_Periph/AP_Periph.h
+++ b/Tools/AP_Periph/AP_Periph.h
@@ -568,6 +568,15 @@ public:
     uint16_t pool_peak_percent();
     void set_rgb_led(uint8_t red, uint8_t green, uint8_t blue);
 
+#if AP_SIM_ENABLED
+    // update simulation of servos
+    void sim_update_actuator(uint8_t actuator_id);
+    struct {
+        uint32_t mask;
+        uint32_t last_send_ms;
+    } sim_actuator;
+#endif
+    
     struct dronecan_protocol_t {
         CanardInstance canard;
         uint32_t canard_memory_pool[HAL_CAN_POOL_SIZE/sizeof(uint32_t)];

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -107,6 +107,7 @@ COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'AP_EFI',
     'AP_Hott_Telem',
     'AP_ESC_Telem',
+    'AP_Servo_Telem',
     'AP_Stats',
     'AP_GyroFFT',
     'AP_RCTelemetry',

--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -404,6 +404,7 @@ BUILD_OPTIONS = [
     Feature('Airspeed Drivers', 'SDP3X', 'AP_AIRSPEED_SDP3X_ENABLED', 'Enable SDP3X AIRSPEED', 0, 'AIRSPEED'),
     Feature('Airspeed Drivers', 'DRONECAN_ASPD', 'AP_AIRSPEED_DRONECAN_ENABLED', 'Enable DroneCAN AIRSPEED', 0, 'AIRSPEED,DroneCAN'),   # NOQA: E501
 
+    Feature('Actuators', 'Servo telem', 'AP_SERVO_TELEM_ENABLED', 'Enable servo telemetry library', 0, None),
     Feature('Actuators', 'Volz', 'AP_VOLZ_ENABLED', 'Enable Volz Protocol', 0, None),
     Feature('Actuators', 'Volz_DroneCAN', 'AP_DRONECAN_VOLZ_FEEDBACK_ENABLED', 'Enable Volz DroneCAN Feedback', 0, "DroneCAN,Volz"),  # noqa: E501
     Feature('Actuators', 'RobotisServo', 'AP_ROBOTISSERVO_ENABLED', 'Enable RobotisServo protocol', 0, None),

--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -190,6 +190,7 @@ class ExtractFeatures(object):
             ('AP_RCPROTOCOL_{type}_ENABLED', r'AP_RCProtocol_(?P<type>.*)::_process_byte\b',),
             ('AP_RCPROTOCOL_{type}_ENABLED', r'AP_RCProtocol_(?P<type>.*)::process_pulse\b',),
 
+            ('AP_SERVO_TELEM_ENABLED', r'AP_Servo_Telem::update\b',),
             ('AP_VOLZ_ENABLED', r'AP_Volz_Protocol::init\b',),
             ('AP_DRONECAN_VOLZ_FEEDBACK_ENABLED', r'AP_DroneCAN::handle_actuator_status_Volz\b',),
             ('AP_ROBOTISSERVO_ENABLED', r'AP_RobotisServo::init\b',),

--- a/libraries/AP_DroneCAN/AP_DroneCAN.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.cpp
@@ -1393,7 +1393,7 @@ void AP_DroneCAN::handle_actuator_status(const CanardRxTransfer& transfer, const
         .force = msg.force,
         .speed = msg.speed,
         .duty_cycle = msg.power_rating_pct,
-        .valid_types = AP_Servo_Telem::TelemetryData::Types::COMMANDED_POSITION |
+        .valid_types = AP_Servo_Telem::TelemetryData::Types::MEASURED_POSITION |
                        AP_Servo_Telem::TelemetryData::Types::FORCE |
                        AP_Servo_Telem::TelemetryData::Types::SPEED |
                        AP_Servo_Telem::TelemetryData::Types::DUTY_CYCLE

--- a/libraries/AP_DroneCAN/AP_DroneCAN.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.cpp
@@ -50,6 +50,7 @@
 #include <AP_OpenDroneID/AP_OpenDroneID.h>
 #include <AP_Mount/AP_Mount_Xacti.h>
 #include <string.h>
+#include <AP_Servo_Telem/AP_Servo_Telem.h>
 
 #if AP_DRONECAN_SERIAL_ENABLED
 #include "AP_DroneCAN_serial.h"
@@ -1379,62 +1380,83 @@ void AP_DroneCAN::handle_traffic_report(const CanardRxTransfer& transfer, const 
 /*
   handle actuator status message
  */
+#if AP_SERVO_TELEM_ENABLED
 void AP_DroneCAN::handle_actuator_status(const CanardRxTransfer& transfer, const uavcan_equipment_actuator_Status& msg)
 {
-#if HAL_LOGGING_ENABLED
-    // log as CSRV message
-    AP::logger().Write_ServoStatus(AP_HAL::micros64(),
-                                   msg.actuator_id,
-                                   msg.position,
-                                   msg.force,
-                                   msg.speed,
-                                   msg.power_rating_pct,
-                                   0, 0, 0, 0, 0, 0);
-#endif
-}
+    AP_Servo_Telem *servo_telem = AP_Servo_Telem::get_singleton();
+    if (servo_telem == nullptr) {
+        return;
+    }
 
-#if AP_DRONECAN_HIMARK_SERVO_SUPPORT
+    const AP_Servo_Telem::TelemetryData telem_data {
+        .measured_position = ToDeg(msg.position),
+        .force = msg.force,
+        .speed = msg.speed,
+        .duty_cycle = msg.power_rating_pct,
+        .valid_types = AP_Servo_Telem::TelemetryData::Types::COMMANDED_POSITION |
+                       AP_Servo_Telem::TelemetryData::Types::FORCE |
+                       AP_Servo_Telem::TelemetryData::Types::SPEED |
+                       AP_Servo_Telem::TelemetryData::Types::DUTY_CYCLE
+    };
+
+    servo_telem->update_telem_data(msg.actuator_id, telem_data);
+}
+#endif
+
+#if AP_DRONECAN_HIMARK_SERVO_SUPPORT && AP_SERVO_TELEM_ENABLED
 /*
   handle himark ServoInfo message
  */
 void AP_DroneCAN::handle_himark_servoinfo(const CanardRxTransfer& transfer, const com_himark_servo_ServoInfo &msg)
 {
-#if HAL_LOGGING_ENABLED
-    // log as CSRV message
-    AP::logger().Write_ServoStatus(AP_HAL::micros64(),
-                                   msg.servo_id,
-                                   msg.pos_sensor*0.01,
-                                   0,
-                                   0,
-                                   0,
-                                   msg.pos_cmd*0.01,
-                                   msg.voltage*0.01,
-                                   msg.current*0.01,
-                                   msg.motor_temp*0.2-40,
-                                   msg.pcb_temp*0.2-40,
-                                   msg.error_status);
-#endif
+    AP_Servo_Telem *servo_telem = AP_Servo_Telem::get_singleton();
+    if (servo_telem == nullptr) {
+        return;
+    }
+
+    const AP_Servo_Telem::TelemetryData telem_data {
+        .command_position = msg.pos_cmd * 0.01,
+        .measured_position = msg.pos_sensor * 0.01,
+        .voltage = msg.voltage * 0.01,
+        .current = msg.current * 0.01,
+        .motor_temperature_cdeg = int16_t(((msg.motor_temp * 0.2) - 40) * 100),
+        .pcb_temperature_cdeg = int16_t(((msg.pcb_temp * 0.2) - 40) * 100),
+        .status_flags = msg.error_status,
+        .valid_types = AP_Servo_Telem::TelemetryData::Types::COMMANDED_POSITION |
+                       AP_Servo_Telem::TelemetryData::Types::MEASURED_POSITION |
+                       AP_Servo_Telem::TelemetryData::Types::VOLTAGE |
+                       AP_Servo_Telem::TelemetryData::Types::CURRENT |
+                       AP_Servo_Telem::TelemetryData::Types::MOTOR_TEMP |
+                       AP_Servo_Telem::TelemetryData::Types::PCB_TEMP |
+                       AP_Servo_Telem::TelemetryData::Types::STATUS
+    };
+
+    servo_telem->update_telem_data(msg.servo_id, telem_data);
 }
 #endif // AP_DRONECAN_HIMARK_SERVO_SUPPORT
 
 #if AP_DRONECAN_VOLZ_FEEDBACK_ENABLED
 void AP_DroneCAN::handle_actuator_status_Volz(const CanardRxTransfer& transfer, const com_volz_servo_ActuatorStatus& msg)
 {
-#if HAL_LOGGING_ENABLED
-    AP::logger().WriteStreaming(
-        "CVOL",
-        "TimeUS,Id,Pos,Cur,V,Pow,T",
-        "s#dAv%O",
-        "F-00000",
-        "QBfffBh",
-        AP_HAL::micros64(),
-        msg.actuator_id,
-        ToDeg(msg.actual_position),
-        msg.current * 0.025f,
-        msg.voltage * 0.2f,
-        uint8_t(msg.motor_pwm * (100.0/255.0)),
-        int16_t(msg.motor_temperature) - 50);
-#endif
+    AP_Servo_Telem *servo_telem = AP_Servo_Telem::get_singleton();
+    if (servo_telem == nullptr) {
+        return;
+    }
+
+    const AP_Servo_Telem::TelemetryData telem_data {
+        .measured_position = ToDeg(msg.actual_position),
+        .voltage = msg.voltage * 0.2,
+        .current = msg.current * 0.025,
+        .duty_cycle = msg.motor_pwm * (100.0/255.0),
+        .motor_temperature_cdeg = (int16_t(msg.motor_temperature) - 50)) * 100,
+        .valid_types = AP_Servo_Telem::TelemetryData::Types::MEASURED_POSITION |
+                       AP_Servo_Telem::TelemetryData::Types::VOLTAGE |
+                       AP_Servo_Telem::TelemetryData::Types::CURRENT |
+                       AP_Servo_Telem::TelemetryData::Types::DUTY_CYCLE |
+                       AP_Servo_Telem::TelemetryData::Types::MOTOR_TEMP
+    };
+
+    servo_telem->update_telem_data(msg.actuator_id, telem_data);
 }
 #endif
 

--- a/libraries/AP_DroneCAN/AP_DroneCAN.h
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.h
@@ -36,6 +36,7 @@
 #include <dronecan_msgs.h>
 #include <AP_SerialManager/AP_SerialManager_config.h>
 #include <AP_Relay/AP_Relay_config.h>
+#include <AP_Servo_Telem/AP_Servo_Telem_config.h>
 
 #ifndef DRONECAN_SRV_NUMBER
 #define DRONECAN_SRV_NUMBER NUM_SERVO_CHANNELS
@@ -329,8 +330,10 @@ private:
     Canard::ObjCallback<AP_DroneCAN, ardupilot_equipment_trafficmonitor_TrafficReport> traffic_report_cb{this, &AP_DroneCAN::handle_traffic_report};
     Canard::Subscriber<ardupilot_equipment_trafficmonitor_TrafficReport> traffic_report_listener{traffic_report_cb, _driver_index};
 
+#if AP_SERVO_TELEM_ENABLED
     Canard::ObjCallback<AP_DroneCAN, uavcan_equipment_actuator_Status> actuator_status_cb{this, &AP_DroneCAN::handle_actuator_status};
     Canard::Subscriber<uavcan_equipment_actuator_Status> actuator_status_listener{actuator_status_cb, _driver_index};
+#endif
 
     Canard::ObjCallback<AP_DroneCAN, uavcan_equipment_esc_Status> esc_status_cb{this, &AP_DroneCAN::handle_ESC_status};
     Canard::Subscriber<uavcan_equipment_esc_Status> esc_status_listener{esc_status_cb, _driver_index};
@@ -343,7 +346,11 @@ private:
     Canard::ObjCallback<AP_DroneCAN, uavcan_protocol_debug_LogMessage> debug_cb{this, &AP_DroneCAN::handle_debug};
     Canard::Subscriber<uavcan_protocol_debug_LogMessage> debug_listener{debug_cb, _driver_index};
 
-#if AP_DRONECAN_VOLZ_FEEDBACK_ENABLED
+#if AP_DRONECAN_HIMARK_SERVO_SUPPORT && AP_SERVO_TELEM_ENABLED
+    Canard::ObjCallback<AP_DroneCAN, com_himark_servo_ServoInfo> himark_servo_ServoInfo_cb{this, &AP_DroneCAN::handle_himark_servoinfo};
+    Canard::Subscriber<com_himark_servo_ServoInfo> himark_servo_ServoInfo_cb_listener{himark_servo_ServoInfo_cb, _driver_index};
+#endif
+#if AP_DRONECAN_VOLZ_FEEDBACK_ENABLED && AP_SERVO_TELEM_ENABLED
     Canard::ObjCallback<AP_DroneCAN, com_volz_servo_ActuatorStatus> volz_servo_ActuatorStatus_cb{this, &AP_DroneCAN::handle_actuator_status_Volz};
     Canard::Subscriber<com_volz_servo_ActuatorStatus> volz_servo_ActuatorStatus_listener{volz_servo_ActuatorStatus_cb, _driver_index};
 #endif
@@ -401,15 +408,19 @@ private:
     void handle_hobbywing_StatusMsg2(const CanardRxTransfer& transfer, const com_hobbywing_esc_StatusMsg2& msg);
 #endif // AP_DRONECAN_HOBBYWING_ESC_SUPPORT
 
-#if AP_DRONECAN_HIMARK_SERVO_SUPPORT
+#if AP_DRONECAN_HIMARK_SERVO_SUPPORT && AP_SERVO_TELEM_ENABLED
     void handle_himark_servoinfo(const CanardRxTransfer& transfer, const com_himark_servo_ServoInfo &msg);
 #endif
-    
+
     // incoming button handling
     void handle_button(const CanardRxTransfer& transfer, const ardupilot_indication_Button& msg);
     void handle_traffic_report(const CanardRxTransfer& transfer, const ardupilot_equipment_trafficmonitor_TrafficReport& msg);
+#if AP_SERVO_TELEM_ENABLED
     void handle_actuator_status(const CanardRxTransfer& transfer, const uavcan_equipment_actuator_Status& msg);
+#endif
+#if AP_DRONECAN_VOLZ_FEEDBACK_ENABLED && AP_SERVO_TELEM_ENABLED
     void handle_actuator_status_Volz(const CanardRxTransfer& transfer, const com_volz_servo_ActuatorStatus& msg);
+#endif
     void handle_ESC_status(const CanardRxTransfer& transfer, const uavcan_equipment_esc_Status& msg);
 #if AP_EXTENDED_ESC_TELEM_ENABLED
     void handle_esc_ext_status(const CanardRxTransfer& transfer, const uavcan_equipment_esc_StatusExtended& msg);

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -262,8 +262,6 @@ public:
     void Write_Radio(const mavlink_radio_t &packet);
     void Write_Message(const char *message);
     void Write_MessageF(const char *fmt, ...);
-    void Write_ServoStatus(uint64_t time_us, uint8_t id, float position, float force, float speed, uint8_t power_pct,
-                           float pos_cmd, float voltage, float current, float mot_temp, float pcb_temp, uint8_t error);
     void Write_Compass();
     void Write_Mode(uint8_t mode, const ModeReason reason);
 

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -452,31 +452,6 @@ bool AP_Logger_Backend::Write_Mode(uint8_t mode, const ModeReason reason)
     return WriteCriticalBlock(&pkt, sizeof(pkt));
 }
 
-/*
-  write servo status from CAN servo
- */
-void AP_Logger::Write_ServoStatus(uint64_t time_us, uint8_t id, float position, float force, float speed, uint8_t power_pct,
-                                  float pos_cmd, float voltage, float current, float mot_temp, float pcb_temp, uint8_t error)
-{
-    const struct log_CSRV pkt {
-        LOG_PACKET_HEADER_INIT(LOG_CSRV_MSG),
-        time_us     : time_us,
-        id          : id,
-        position    : position,
-        force       : force,
-        speed       : speed,
-        power_pct   : power_pct,
-        pos_cmd     : pos_cmd,
-        voltage     : voltage,
-        current     : current,
-        mot_temp    : mot_temp,
-        pcb_temp    : pcb_temp,
-        error       : error,
-    };
-    WriteBlock(&pkt, sizeof(pkt));
-}
-
-
 // Write a Yaw PID packet
 void AP_Logger::Write_PID(uint8_t msg_type, const AP_PIDInfo &info)
 {

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -67,6 +67,7 @@ const struct UnitStructure log_Units[] = {
     { '%', "%" },             // percent
     { 'S', "satellites" },    // number of satellites
     { 's', "s" },             // seconds
+    { 't', "N.m" },           // Newton meters, torque
     { 'q', "rpm" },           // rounds per minute. Not SI, but sometimes more intuitive than Hertz
     { 'r', "rad" },           // radians
     { 'U', "deglongitude" },  // degrees of longitude

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -148,6 +148,7 @@ const struct MultiplierStructure log_Multipliers[] = {
 #include <AC_AttitudeControl/LogStructure.h>
 #include <AP_HAL/LogStructure.h>
 #include <AP_Mission/LogStructure.h>
+#include <AP_Servo_Telem/LogStructure.h>
 
 // structure used to define logging format
 // It is packed on ChibiOS to save flash space; however, this causes problems
@@ -477,22 +478,6 @@ struct PACKED log_TERRAIN {
     float reference_offset;
 };
 
-struct PACKED log_CSRV {
-    LOG_PACKET_HEADER;
-    uint64_t time_us;     
-    uint8_t id;
-    float position;
-    float force;
-    float speed;
-    uint8_t power_pct;
-    float pos_cmd;
-    float voltage;
-    float current;
-    float mot_temp;
-    float pcb_temp;
-    uint8_t error;
-};
-
 struct PACKED log_ARSP {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -698,21 +683,6 @@ struct PACKED log_VER {
 // @Field: Hp: Probability sensor is healthy
 // @Field: TR: innovation test ratio
 // @Field: Pri: True if sensor is the primary sensor
-
-// @LoggerMessage: CSRV
-// @Description: Servo feedback data
-// @Field: TimeUS: Time since system startup
-// @Field: Id: Servo number this data relates to
-// @Field: Pos: Current servo position
-// @Field: Force: Force being applied
-// @Field: Speed: Current servo movement speed
-// @Field: Pow: Amount of rated power being applied
-// @Field: PosCmd: commanded servo position
-// @Field: V: Voltage
-// @Field: A: Current
-// @Field: MotT: motor temperature
-// @Field: PCBT: PCB temperature
-// @Field: Err: error flags
 
 // @LoggerMessage: DMS
 // @Description: DataFlash-Over-MAVLink statistics
@@ -1223,8 +1193,7 @@ LOG_STRUCTURE_FROM_AVOIDANCE \
     { LOG_TERRAIN_MSG, sizeof(log_TERRAIN), \
       "TERR","QBLLHffHHf","TimeUS,Status,Lat,Lng,Spacing,TerrH,CHeight,Pending,Loaded,ROfs", "s-DU-mm--m", "F-GG-00--0", true }, \
 LOG_STRUCTURE_FROM_ESC_TELEM \
-    { LOG_CSRV_MSG, sizeof(log_CSRV), \
-      "CSRV","QBfffBfffffB","TimeUS,Id,Pos,Force,Speed,Pow,PosCmd,V,A,MotT,PCBT,Err", "s#---%dvAOO-", "F-000000000-", false }, \
+LOG_STRUCTURE_FROM_SERVO_TELEM \
     { LOG_PIDR_MSG, sizeof(log_PID), \
       "PIDR", PID_FMT,  PID_LABELS, PID_UNITS, PID_MULTS, true },  \
     { LOG_PIDP_MSG, sizeof(log_PID), \
@@ -1307,7 +1276,7 @@ enum LogMessages : uint8_t {
     LOG_IDS_FROM_CAMERA,
     LOG_IDS_FROM_MOUNT,
     LOG_TERRAIN_MSG,
-    LOG_CSRV_MSG,
+    LOG_IDS_FROM_SERVO_TELEM,
     LOG_IDS_FROM_ESC_TELEM,
     LOG_IDS_FROM_BATTMONITOR,
     LOG_IDS_FROM_HAL_CHIBIOS,

--- a/libraries/AP_Logger/README.md
+++ b/libraries/AP_Logger/README.md
@@ -68,6 +68,7 @@ Please keep the names consistent with Tools/autotest/param_metadata/param.py:33
 | 's' | "s" | seconds|
 | 'q' | "rpm" | revolutions per minute|  Not an SI unit, but sometimes more intuitive than Hertz|
 | 'r' | "rad" | radians|
+| 't' | "N.m" | Newton meters | torque |
 | 'U' | "deglongitude" | degrees of longitude|
 | 'u' | "ppm" | pulses per minute|
 | 'v' | "V" | Volt|

--- a/libraries/AP_PiccoloCAN/AP_PiccoloCAN.cpp
+++ b/libraries/AP_PiccoloCAN/AP_PiccoloCAN.cpp
@@ -31,10 +31,10 @@
 #include <AP_HAL/utility/sparse-endian.h>
 #include <SRV_Channel/SRV_Channel.h>
 #include <GCS_MAVLink/GCS.h>
-#include <AP_Logger/AP_Logger.h>
 #include <AP_CANManager/AP_CANManager.h>
 
 #include <AP_EFI/AP_EFI_Currawong_ECU.h>
+#include <AP_Servo_Telem/AP_Servo_Telem.h>
 
 #include <stdio.h>
 
@@ -320,8 +320,6 @@ bool AP_PiccoloCAN::read_frame(AP_HAL::CANFrame &recv_frame, uint32_t timeout_us
 // called from SRV_Channels
 void AP_PiccoloCAN::update()
 {
-    uint64_t timestamp = AP_HAL::micros64();
-
     /* Read out the servo commands from the channel mixer */
     for (uint8_t ii = 0; ii < PICCOLO_CAN_MAX_NUM_SERVO; ii++) {
 
@@ -361,46 +359,44 @@ void AP_PiccoloCAN::update()
     }
 #endif // AP_EFI_CURRAWONG_ECU_ENABLED
 
-#if HAL_LOGGING_ENABLED
-    AP_Logger *logger = AP_Logger::get_singleton();
-
-    // Push received telemetry data into the logging system
-    if (logger && logger->logging_enabled()) {
-
-        WITH_SEMAPHORE(_telem_sem);
-
+#if AP_SERVO_TELEM_ENABLED
+    AP_Servo_Telem *servo_telem = AP_Servo_Telem::get_singleton();
+    if (servo_telem != nullptr) {
         for (uint8_t ii = 0; ii < PICCOLO_CAN_MAX_NUM_SERVO; ii++) {
-
             AP_PiccoloCAN_Servo &servo = _servos[ii];
-
             if (servo.newTelemetry) {
                 union {
                     Servo_ErrorBits_t ebits;
                     uint8_t errors;
                 } err;
                 err.ebits = servo.status.statusA.errors;
-                logger->Write_ServoStatus(
-                    timestamp,
-                    ii,
-                    servo.position(),                       // Servo position (represented in microsecond units)
-                    servo.current() * 0.01f,                // Servo force (actually servo current, 0.01A per bit)
-                    servo.speed(),                          // Servo speed (degrees per second)
-                    servo.dutyCycle(),                      // Servo duty cycle (absolute value as it can be +/- 100%)
-                    uint16_t(servo.commandedPosition()),    // Commanded position
-                    servo.voltage(),                        // Servo voltage
-                    servo.current(),                        // Servo current
-                    servo.temperature(),                    // Servo temperature
-                    servo.temperature(),                    // 
-                    err.errors
-                );
+
+                const AP_Servo_Telem::TelemetryData telem_data {
+                    .command_position = servo.commandedPosition(),
+                    .measured_position = servo.position(),
+                    .speed = servo.speed(),
+                    .voltage = servo.voltage(),
+                    .current = servo.current(),
+                    .duty_cycle = servo.dutyCycle(),
+                    .motor_temperature_cdeg = int16_t(servo.temperature() * 100),
+                    .status_flags = err.errors,
+                    .valid_types = AP_Servo_Telem::TelemetryData::Types::COMMANDED_POSITION |
+                                   AP_Servo_Telem::TelemetryData::Types::MEASURED_POSITION |
+                                   AP_Servo_Telem::TelemetryData::Types::SPEED |
+                                   AP_Servo_Telem::TelemetryData::Types::VOLTAGE |
+                                   AP_Servo_Telem::TelemetryData::Types::CURRENT |
+                                   AP_Servo_Telem::TelemetryData::Types::DUTY_CYCLE |
+                                   AP_Servo_Telem::TelemetryData::Types::MOTOR_TEMP |
+                                   AP_Servo_Telem::TelemetryData::Types::STATUS
+                };
+
+                servo_telem->update_telem_data(ii, telem_data);
 
                 servo.newTelemetry = false;
             }
         }
     }
-#else
-    (void)timestamp;
-#endif  // HAL_LOGGING_ENABLED
+#endif
 }
 
 

--- a/libraries/AP_PiccoloCAN/AP_PiccoloCAN.h
+++ b/libraries/AP_PiccoloCAN/AP_PiccoloCAN.h
@@ -131,7 +131,6 @@ private:
     AP_Int16 _ecu_id;       //!< ECU Node ID
     AP_Int16 _ecu_hz;       //!< ECU update rate (Hz)
 
-    HAL_Semaphore _telem_sem;
 };
 
 #endif // HAL_PICCOLO_CAN_ENABLE

--- a/libraries/AP_Servo_Telem/AP_Servo_Telem.cpp
+++ b/libraries/AP_Servo_Telem/AP_Servo_Telem.cpp
@@ -1,0 +1,160 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_Servo_Telem.h"
+
+#if AP_SERVO_TELEM_ENABLED
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Logger/AP_Logger.h>
+#include <AP_BoardConfig/AP_BoardConfig.h>
+
+AP_Servo_Telem *AP_Servo_Telem::_singleton;
+
+AP_Servo_Telem::AP_Servo_Telem()
+{
+    if (_singleton) {
+        AP_HAL::panic("Too many AP_Servo_Telem instances");
+    }
+    _singleton = this;
+}
+
+// return true if the data is stale
+bool AP_Servo_Telem::TelemetryData::stale(uint32_t now_ms) const volatile
+{
+    return (last_update_ms == 0) || ((now_ms - last_update_ms) > 5000);
+}
+
+// return true if the requested types of data are available
+bool AP_Servo_Telem::TelemetryData::present(const uint16_t type_mask) const volatile
+{
+    return (valid_types & type_mask) != 0;
+}
+
+// return true if the requested types of data are available and not stale
+bool AP_Servo_Telem::TelemetryData::valid(const uint16_t type_mask) const volatile
+{
+    return present(type_mask) && !stale(AP_HAL::millis());
+}
+
+// record an update to the telemetry data together with timestamp
+// callback to update the data in the frontend, should be called by the driver when new data is available
+void AP_Servo_Telem::update_telem_data(const uint8_t servo_index, const TelemetryData& new_data)
+{
+    // telemetry data are not protected by a semaphore even though updated from different threads
+    // each element is a primitive type and the timestamp is only updated at the end, thus a caller
+    // can only get slightly more up-to-date information that perhaps they were expecting or might
+    // read data that has just gone stale - both of these are safe and avoid the overhead of locking
+
+    if (servo_index >= ARRAY_SIZE(_telem_data) || (new_data.valid_types == 0)) {
+        return;
+    }
+
+    volatile TelemetryData &telemdata = _telem_data[servo_index];
+
+    if (new_data.present(TelemetryData::Types::COMMANDED_POSITION)) {
+        telemdata.command_position = new_data.command_position;
+    }
+    if (new_data.present(TelemetryData::Types::MEASURED_POSITION)) {
+        telemdata.measured_position = new_data.measured_position;
+    }
+    if (new_data.present(TelemetryData::Types::FORCE)) {
+        telemdata.force = new_data.force;
+    }
+    if (new_data.present(TelemetryData::Types::SPEED)) {
+        telemdata.speed = new_data.speed;
+    }
+    if (new_data.present(TelemetryData::Types::VOLTAGE)) {
+        telemdata.voltage = new_data.voltage;
+    }
+    if (new_data.present(TelemetryData::Types::CURRENT)) {
+        telemdata.current = new_data.current;
+    }
+    if (new_data.present(TelemetryData::Types::DUTY_CYCLE)) {
+        telemdata.duty_cycle = new_data.duty_cycle;
+    }
+    if (new_data.present(TelemetryData::Types::MOTOR_TEMP)) {
+        telemdata.motor_temperature_cdeg = new_data.motor_temperature_cdeg;
+    }
+    if (new_data.present(TelemetryData::Types::PCB_TEMP)) {
+        telemdata.pcb_temperature_cdeg = new_data.pcb_temperature_cdeg;
+    }
+    if (new_data.present(TelemetryData::Types::PCB_TEMP)) {
+        telemdata.status_flags = new_data.status_flags;
+    }
+
+    telemdata.valid_types |= new_data.valid_types;
+    telemdata.last_update_ms = AP_HAL::millis();
+}
+
+void AP_Servo_Telem::update()
+{
+#if HAL_LOGGING_ENABLED
+    write_log();
+#endif
+}
+
+#if HAL_LOGGING_ENABLED
+void AP_Servo_Telem::write_log()
+{
+    AP_Logger *logger = AP_Logger::get_singleton();
+
+    // Check logging is available and enabled
+    if ((logger == nullptr) || !logger->logging_enabled()) {
+        return;
+    }
+
+    const uint64_t now_us = AP_HAL::micros64();
+
+    for (uint8_t i = 0; i < ARRAY_SIZE(_telem_data); i++) {
+        const volatile TelemetryData &telemdata = _telem_data[i];
+
+        if (telemdata.last_update_ms == _last_telem_log_ms[i]) {
+            // No new data since last log call, skip
+            continue;
+        }
+
+        // Update last log timestamp
+        _last_telem_log_ms[i] = telemdata.last_update_ms;
+
+        // Log, use nan for float values which are not available
+        const struct log_CSRV pkt {
+            LOG_PACKET_HEADER_INIT(LOG_CSRV_MSG),
+            time_us     : now_us,
+            id          : i,
+            position    : telemdata.present(TelemetryData::Types::MEASURED_POSITION) ? telemdata.measured_position             : AP::logger().quiet_nanf(),
+            force       : telemdata.present(TelemetryData::Types::FORCE)             ? telemdata.force                         : AP::logger().quiet_nanf(),
+            speed       : telemdata.present(TelemetryData::Types::SPEED)             ? telemdata.speed                         : AP::logger().quiet_nanf(),
+            power_pct   : telemdata.duty_cycle,
+            pos_cmd     : telemdata.present(TelemetryData::Types::MEASURED_POSITION) ? telemdata.command_position              : AP::logger().quiet_nanf(),
+            voltage     : telemdata.present(TelemetryData::Types::VOLTAGE)           ? telemdata.voltage                       : AP::logger().quiet_nanf(),
+            current     : telemdata.present(TelemetryData::Types::CURRENT)           ? telemdata.current                       : AP::logger().quiet_nanf(),
+            mot_temp    : telemdata.present(TelemetryData::Types::MOTOR_TEMP)        ? telemdata.motor_temperature_cdeg * 0.01 : AP::logger().quiet_nanf(),
+            pcb_temp    : telemdata.present(TelemetryData::Types::PCB_TEMP)          ? telemdata.pcb_temperature_cdeg * 0.01   : AP::logger().quiet_nanf(),
+            error       : telemdata.status_flags,
+        };
+        AP::logger().WriteBlock(&pkt, sizeof(pkt));
+    }
+
+}
+#endif  // HAL_LOGGING_ENABLED
+
+// Get the AP_Servo_Telem singleton
+AP_Servo_Telem *AP_Servo_Telem::get_singleton()
+{
+    return AP_Servo_Telem::_singleton;
+}
+
+#endif // AP_SERVO_TELEM_ENABLED

--- a/libraries/AP_Servo_Telem/AP_Servo_Telem.h
+++ b/libraries/AP_Servo_Telem/AP_Servo_Telem.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include "AP_Servo_Telem_config.h"
+
+#if AP_SERVO_TELEM_ENABLED
+
+#include <AP_HAL/AP_HAL.h>
+#include <SRV_Channel/SRV_Channel_config.h>
+
+
+#ifndef SERVO_TELEM_MAX_SERVOS
+    #define SERVO_TELEM_MAX_SERVOS NUM_SERVO_CHANNELS
+#endif
+static_assert(SERVO_TELEM_MAX_SERVOS > 0, "Cannot have 0 Servo telem instances");
+
+class AP_Servo_Telem {
+public:
+    AP_Servo_Telem();
+
+    /* Do not allow copies */
+    CLASS_NO_COPY(AP_Servo_Telem);
+
+    static AP_Servo_Telem *get_singleton();
+
+    struct TelemetryData {
+        // Telemetry values
+        float command_position;         // Commanded servo position in degrees
+        float measured_position;        // Measured Servo position in degrees
+        float force;                    // Force in Newton meters
+        float speed;                    // Speed degrees per second
+        float voltage;                  // Voltage in volts
+        float current;                  // Current draw in Ampere
+        uint8_t duty_cycle;             // duty cycle 0% to 100%
+        int16_t motor_temperature_cdeg; // centi-degrees C, negative values allowed
+        int16_t pcb_temperature_cdeg;   // centi-degrees C, negative values allowed
+        uint8_t status_flags;           // Type specific status flags
+
+        // last update time in milliseconds, determines data is stale
+        uint32_t last_update_ms;
+
+        // telemetry types present
+        enum Types {
+            COMMANDED_POSITION = 1 << 0,
+            MEASURED_POSITION  = 1 << 1,
+            FORCE              = 1 << 2,
+            SPEED              = 1 << 3,
+            VOLTAGE            = 1 << 4,
+            CURRENT            = 1 << 5,
+            DUTY_CYCLE         = 1 << 6,
+            MOTOR_TEMP         = 1 << 7,
+            PCB_TEMP           = 1 << 8,
+            STATUS             = 1 << 9,
+        };
+        uint16_t valid_types;
+
+        // return true if the data is stale
+        bool stale(uint32_t now_ms) const volatile;
+
+        // return true if the requested types of data are available
+        bool present(const uint16_t type_mask) const volatile;
+
+        //  return true if the requested type of data is available and not stale
+        bool valid(const uint16_t type_mask) const volatile;
+    };
+
+    // update at 10Hz to log telemetry
+    void update();
+
+    // record an update to the telemetry data together with timestamp
+    // callback to update the data in the frontend, should be called by the driver when new data is available
+    void update_telem_data(const uint8_t servo_index, const TelemetryData& new_data);
+
+private:
+
+    // Log telem of each servo
+    void write_log();
+
+    volatile TelemetryData _telem_data[SERVO_TELEM_MAX_SERVOS];
+
+    uint32_t _last_telem_log_ms[SERVO_TELEM_MAX_SERVOS];
+
+    static AP_Servo_Telem *_singleton;
+};
+#endif // AP_SERVO_TELEM_ENABLED

--- a/libraries/AP_Servo_Telem/AP_Servo_Telem.h
+++ b/libraries/AP_Servo_Telem/AP_Servo_Telem.h
@@ -80,5 +80,7 @@ private:
     uint32_t _last_telem_log_ms[SERVO_TELEM_MAX_SERVOS];
 
     static AP_Servo_Telem *_singleton;
+
+    uint32_t active_mask;
 };
 #endif // AP_SERVO_TELEM_ENABLED

--- a/libraries/AP_Servo_Telem/AP_Servo_Telem_config.h
+++ b/libraries/AP_Servo_Telem/AP_Servo_Telem_config.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <AP_HAL/AP_HAL_Boards.h>
+#include <SRV_Channel/SRV_Channel_config.h>
+
+#ifndef AP_SERVO_TELEM_ENABLED
+#define AP_SERVO_TELEM_ENABLED ((NUM_SERVO_CHANNELS > 0) && ((HAL_SUPPORT_RCOUT_SERIAL || HAL_MAX_CAN_PROTOCOL_DRIVERS)) && !defined(HAL_BUILD_AP_PERIPH))
+#endif

--- a/libraries/AP_Servo_Telem/LogStructure.h
+++ b/libraries/AP_Servo_Telem/LogStructure.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "AP_Servo_Telem_config.h"
+#include <AP_Logger/LogStructure.h>
+
+#define LOG_IDS_FROM_SERVO_TELEM \
+    LOG_CSRV_MSG
+
+// @LoggerMessage: CSRV
+// @Description: Servo feedback data
+// @Field: TimeUS: Time since system startup
+// @Field: Id: Servo number this data relates to
+// @Field: Pos: Current servo position
+// @Field: Force: Force being applied
+// @Field: Speed: Current servo movement speed
+// @Field: Pow: Amount of rated power being applied
+// @Field: PosCmd: commanded servo position
+// @Field: V: Voltage
+// @Field: A: Current
+// @Field: MotT: motor temperature
+// @Field: PCBT: PCB temperature
+// @Field: Err: error flags
+
+struct PACKED log_CSRV {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t id;
+    float position;
+    float force;
+    float speed;
+    uint8_t power_pct;
+    float pos_cmd;
+    float voltage;
+    float current;
+    float mot_temp;
+    float pcb_temp;
+    uint8_t error;
+};
+
+
+#if !AP_SERVO_TELEM_ENABLED
+#define LOG_STRUCTURE_FROM_SERVO_TELEM
+#else
+#define LOG_STRUCTURE_FROM_SERVO_TELEM \
+    { LOG_CSRV_MSG, sizeof(log_CSRV), \
+      "CSRV","QBfffBfffffB","TimeUS,Id,Pos,Force,Speed,Pow,PosCmd,V,A,MotT,PCBT,Err", "s#dtk%dvAOO-", "F-000000000-", true },
+#endif

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -634,6 +634,9 @@ const AP_Scheduler::Task AP_Vehicle::scheduler_tasks[] = {
 #if HAL_WITH_ESC_TELEM
     SCHED_TASK_CLASS(AP_ESC_Telem, &vehicle.esc_telem,      update,                  100,  50, 230),
 #endif
+#if AP_SERVO_TELEM_ENABLED
+    SCHED_TASK_CLASS(AP_Servo_Telem, &vehicle.servo_telem,  update,                   50,  50, 231),
+#endif
 #if HAL_GENERATOR_ENABLED
     SCHED_TASK_CLASS(AP_Generator, &vehicle.generator,      update,                   10,  50, 235),
 #endif

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -51,6 +51,7 @@
 #include <AP_OpenDroneID/AP_OpenDroneID.h>
 #include <AP_Hott_Telem/AP_Hott_Telem.h>
 #include <AP_ESC_Telem/AP_ESC_Telem.h>
+#include <AP_Servo_Telem/AP_Servo_Telem.h>
 #include <AP_GyroFFT/AP_GyroFFT.h>
 #include <AP_Networking/AP_Networking.h>
 #include <AP_VisualOdom/AP_VisualOdom.h>
@@ -407,6 +408,10 @@ protected:
 
 #if HAL_WITH_ESC_TELEM
     AP_ESC_Telem esc_telem;
+#endif
+
+#if AP_SERVO_TELEM_ENABLED
+    AP_Servo_Telem servo_telem;
 #endif
 
 #if AP_OPENDRONEID_ENABLED

--- a/libraries/AP_Volz_Protocol/AP_Volz_Protocol.cpp
+++ b/libraries/AP_Volz_Protocol/AP_Volz_Protocol.cpp
@@ -14,7 +14,7 @@
 #include <SRV_Channel/SRV_Channel.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
 
-#include <AP_Logger/AP_Logger.h>
+#include <AP_Servo_Telem/AP_Servo_Telem.h>
 
 // Extended Position Data Format defines -100 as 0x0080 decimal 128, we map this to a PWM of 1000 (if range is default)
 #define PWM_POSITION_MIN               1000
@@ -77,7 +77,7 @@ void AP_Volz_Protocol::init(void)
     }
 }
 
-#if HAL_LOGGING_ENABLED
+#if AP_SERVO_TELEM_ENABLED
 // Request telem data, cycling through each servo and telem item
 void AP_Volz_Protocol::request_telem()
 {
@@ -144,7 +144,7 @@ void AP_Volz_Protocol::loop()
             hal.scheduler->delay_microseconds(100);
         }
 
-#if HAL_LOGGING_ENABLED
+#if AP_SERVO_TELEM_ENABLED
         // Send a command for each servo, then one telem request
         const uint8_t num_servos = __builtin_popcount(bitmask.get());
         if (sent_count < num_servos) {
@@ -162,7 +162,7 @@ void AP_Volz_Protocol::loop()
             read_telem();
         }
 
-#else // No logging, send only
+#else // No telem, send only
         send_position_cmd();
 #endif
     }
@@ -208,7 +208,7 @@ void AP_Volz_Protocol::send_position_cmd()
 
         send_command(cmd);
 
-#if HAL_LOGGING_ENABLED
+#if AP_SERVO_TELEM_ENABLED
         {
             // Update the commanded angle
             WITH_SEMAPHORE(telem.sem);
@@ -221,7 +221,7 @@ void AP_Volz_Protocol::send_position_cmd()
     }
 }
 
-#if HAL_LOGGING_ENABLED
+#if AP_SERVO_TELEM_ENABLED
 void AP_Volz_Protocol::process_response(const CMD &cmd)
 {
     // Convert to 0 indexed
@@ -348,7 +348,7 @@ void AP_Volz_Protocol::read_telem()
     // Used up all attempts without running out of data.
     // Really should not end up here
 }
-#endif // HAL_LOGGING_ENABLED
+#endif // AP_SERVO_TELEM_ENABLED
 
 // Called each time the servo outputs are sent
 void AP_Volz_Protocol::update()
@@ -376,11 +376,11 @@ void AP_Volz_Protocol::update()
         servo_pwm[i] = (pwm == 0) ? c->get_trim() : pwm;
     }
 
-#if HAL_LOGGING_ENABLED
-    // take semaphore and log all channels at 5 Hz
-    const uint32_t now_ms = AP_HAL::millis();
-    if ((now_ms - telem.last_log_ms) > 200) {
-        telem.last_log_ms = now_ms;
+#if AP_SERVO_TELEM_ENABLED
+    // Report telem data
+    AP_Servo_Telem *servo_telem = AP_Servo_Telem::get_singleton();
+    if (servo_telem != nullptr) {
+        const uint32_t now_ms = AP_HAL::millis();
 
         WITH_SEMAPHORE(telem.sem);
         for (uint8_t i=0; i<ARRAY_SIZE(telem.data); i++) {
@@ -389,37 +389,25 @@ void AP_Volz_Protocol::update()
                 continue;
             }
 
-            // @LoggerMessage: VOLZ
-            // @Description: Volz servo data
-            // @Field: TimeUS: Time since system startup
-            // @Field: I: Instance
-            // @Field: Dang: desired angle
-            // @Field: ang: reported angle
-            // @Field: pc: primary supply current
-            // @Field: sc: secondary supply current
-            // @Field: pv: primary supply voltage
-            // @Field: sv: secondary supply voltage
-            // @Field: mt: motor temperature
-            // @Field: pt: pcb temperature
-            AP::logger().WriteStreaming("VOLZ",
-                "TimeUS,I,Dang,ang,pc,sc,pv,sv,mt,pt",
-                "s#ddAAvvOO",
-                "F000000000",
-                "QBffffffhh",
-                AP_HAL::micros64(),
-                i + 1, // convert to 1 indexed to match actuator IDs and SERVOx numbering
-                telem.data[i].desired_angle,
-                telem.data[i].angle,
-                telem.data[i].primary_current,
-                telem.data[i].secondary_current,
-                telem.data[i].primary_voltage,
-                telem.data[i].secondary_voltage,
-                telem.data[i].motor_temp_deg,
-                telem.data[i].pcb_temp_deg
-            );
+            const AP_Servo_Telem::TelemetryData telem_data {
+                .command_position = telem.data[i].desired_angle,
+                .measured_position = telem.data[i].angle,
+                .voltage = telem.data[i].primary_voltage,
+                .current = telem.data[i].primary_current,
+                .motor_temperature_cdeg = int16_t(telem.data[i].motor_temp_deg * 100),
+                .pcb_temperature_cdeg = int16_t(telem.data[i].pcb_temp_deg * 100),
+                .valid_types = AP_Servo_Telem::TelemetryData::Types::COMMANDED_POSITION |
+                               AP_Servo_Telem::TelemetryData::Types::MEASURED_POSITION |
+                               AP_Servo_Telem::TelemetryData::Types::VOLTAGE |
+                               AP_Servo_Telem::TelemetryData::Types::CURRENT |
+                               AP_Servo_Telem::TelemetryData::Types::MOTOR_TEMP |
+                               AP_Servo_Telem::TelemetryData::Types::PCB_TEMP
+            };
+
+            servo_telem->update_telem_data(i, telem_data);
         }
     }
-#endif // HAL_LOGGING_ENABLED
+#endif // AP_SERVO_TELEM_ENABLED
 }
 
 // Return the crc for a given command packet

--- a/libraries/AP_Volz_Protocol/AP_Volz_Protocol.h
+++ b/libraries/AP_Volz_Protocol/AP_Volz_Protocol.h
@@ -44,8 +44,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
 #include <SRV_Channel/SRV_Channel_config.h>
-#include <AP_Logger/AP_Logger_config.h>
-
+#include <AP_Servo_Telem/AP_Servo_Telem_config.h>
 
 class AP_Volz_Protocol {
 public:
@@ -110,7 +109,7 @@ private:
     AP_Int16 range;
     bool initialised;
 
-#if HAL_LOGGING_ENABLED
+#if AP_SERVO_TELEM_ENABLED
     // Request telem data, cycling through each servo and telem item
     void request_telem();
 
@@ -143,7 +142,6 @@ private:
             int16_t motor_temp_deg;
             int16_t pcb_temp_deg;
         } data[NUM_SERVO_CHANNELS];
-        uint32_t last_log_ms;
     } telem;
 #endif
 


### PR DESCRIPTION
This adds a servo telem library. Logging only at this stage. There are some benefits, DroneCAN servo logging can be rate limited, this is currently not possible as each instance is logged when it arrives, so it is rate limited individual rather than as a block of each instance.

In the longer term scripting bindings will be added to get and provide this data. That will allow servo health checking and failsafes. 