### PR TITLE
AP_Scripting: offset_bearing fixed in an example

### DIFF
--- a/libraries/AP_Scripting/examples/mission_spiral.lua
+++ b/libraries/AP_Scripting/examples/mission_spiral.lua
@@ -27,7 +27,7 @@ local MIN_RADIUS = 10.0
 function create_WP(i, center, radius, angle)
    local item = mavlink_mission_item_int_t()
    local loc = center:copy()
-   loc:offset_bearing(radius, angle)
+   loc:offset_bearing(angle, radius)
 
    item:seq(i)
    item:frame(FRAME_GLOBAL)


### PR DESCRIPTION
I was playing with Lua examples and I've noticed that `offset_bearing` wasn't called with correct arguments in the spiral test. And the autotest would still pass since it wasn't comparing the shape per se and just the fact that what was written would match the generated points.

This should be helpful for the next person who tries to write scripts by copying parts of examples.