### PR TITLE
Plane: ICE: fully move to aux function 

### DIFF
--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -140,7 +140,7 @@ void RC_Channel_Copter::init_aux_function(const AUX_FUNC ch_option, const AuxSwi
     case AUX_FUNC::CUSTOM_CONTROLLER:
     case AUX_FUNC::WEATHER_VANE_ENABLE:
     case AUX_FUNC::TRANSMITTER_TUNING:
-        run_aux_function(ch_option, ch_flag, AuxFuncTrigger::Source::INIT);
+        run_aux_function(ch_option, ch_flag, AuxFuncTrigger::Source::INIT, ch_in);
         break;
     default:
         RC_Channel::init_aux_function(ch_option, ch_flag);

--- a/ArduCopter/RC_Channel.cpp
+++ b/ArduCopter/RC_Channel.cpp
@@ -140,7 +140,7 @@ void RC_Channel_Copter::init_aux_function(const AUX_FUNC ch_option, const AuxSwi
     case AUX_FUNC::CUSTOM_CONTROLLER:
     case AUX_FUNC::WEATHER_VANE_ENABLE:
     case AUX_FUNC::TRANSMITTER_TUNING:
-        run_aux_function(ch_option, ch_flag, AuxFuncTriggerSource::INIT);
+        run_aux_function(ch_option, ch_flag, AuxFuncTrigger::Source::INIT);
         break;
     default:
         RC_Channel::init_aux_function(ch_option, ch_flag);
@@ -169,8 +169,11 @@ void RC_Channel_Copter::do_aux_function_change_mode(const Mode::Number mode,
 }
 
 // do_aux_function - implement the function invoked by auxiliary switches
-bool RC_Channel_Copter::do_aux_function(const AUX_FUNC ch_option, const AuxSwitchPos ch_flag)
+bool RC_Channel_Copter::do_aux_function(const AuxFuncTrigger &trigger)
 {
+    const AUX_FUNC &ch_option = trigger.func;
+    const AuxSwitchPos &ch_flag = trigger.pos;
+
     switch(ch_option) {
         case AUX_FUNC::FLIP:
             // flip if switch is on, positive throttle and we're actually flying
@@ -668,7 +671,7 @@ bool RC_Channel_Copter::do_aux_function(const AUX_FUNC ch_option, const AuxSwitc
         break;
 
     default:
-        return RC_Channel::do_aux_function(ch_option, ch_flag);
+        return RC_Channel::do_aux_function(trigger);
     }
     return true;
 }

--- a/ArduCopter/RC_Channel.h
+++ b/ArduCopter/RC_Channel.h
@@ -12,7 +12,7 @@ public:
 protected:
 
     void init_aux_function(AUX_FUNC ch_option, AuxSwitchPos) override;
-    bool do_aux_function(AUX_FUNC ch_option, AuxSwitchPos) override;
+    bool do_aux_function(const AuxFuncTrigger &trigger) override;
 
 private:
 

--- a/ArduPlane/RC_Channel.cpp
+++ b/ArduPlane/RC_Channel.cpp
@@ -470,7 +470,7 @@ bool RC_Channel_Plane::do_aux_function(const AuxFuncTrigger &trigger)
 
 #if AP_ICENGINE_ENABLED
     case AUX_FUNC::ICE_START_STOP:
-        plane.g2.ice_control.do_aux_function(ch_flag);
+        plane.g2.ice_control.do_aux_function(trigger);
         break;
 #endif
 

--- a/ArduPlane/RC_Channel.cpp
+++ b/ArduPlane/RC_Channel.cpp
@@ -172,9 +172,6 @@ void RC_Channel_Plane::init_aux_function(const RC_Channel::AUX_FUNC ch_option,
     case AUX_FUNC::FW_AUTOTUNE:
     case AUX_FUNC::VFWD_THR_OVERRIDE:
     case AUX_FUNC::PRECISION_LOITER:
-#if AP_ICENGINE_ENABLED
-    case AUX_FUNC::ICE_START_STOP:
-#endif
 #if QAUTOTUNE_ENABLED
     case AUX_FUNC::AUTOTUNE_TEST_GAINS:
 #endif
@@ -194,6 +191,9 @@ void RC_Channel_Plane::init_aux_function(const RC_Channel::AUX_FUNC ch_option,
 #endif
     case AUX_FUNC::TER_DISABLE:
     case AUX_FUNC::CROW_SELECT:
+#if AP_ICENGINE_ENABLED
+    case AUX_FUNC::ICE_START_STOP:
+#endif
         run_aux_function(ch_option, ch_flag, AuxFuncTriggerSource::INIT);
         break;
 
@@ -296,9 +296,6 @@ bool RC_Channel_Plane::do_aux_function(const AUX_FUNC ch_option, const AuxSwitch
     case AUX_FUNC::FLAP:
     case AUX_FUNC::FBWA_TAILDRAGGER:
     case AUX_FUNC::AIRBRAKE:
-#if AP_ICENGINE_ENABLED
-    case AUX_FUNC::ICE_START_STOP:
-#endif
         break; // input labels, nothing to do
 
 #if HAL_QUADPLANE_ENABLED
@@ -465,6 +462,12 @@ bool RC_Channel_Plane::do_aux_function(const AUX_FUNC ch_option, const AuxSwitch
 #if AP_QUICKTUNE_ENABLED
     case AUX_FUNC::QUICKTUNE:
         plane.quicktune.update_switch_pos(ch_flag);
+        break;
+#endif
+
+#if AP_ICENGINE_ENABLED
+    case AUX_FUNC::ICE_START_STOP:
+        plane.g2.ice_control.do_aux_function(ch_flag);
         break;
 #endif
 

--- a/ArduPlane/RC_Channel.cpp
+++ b/ArduPlane/RC_Channel.cpp
@@ -194,7 +194,7 @@ void RC_Channel_Plane::init_aux_function(const RC_Channel::AUX_FUNC ch_option,
 #if AP_ICENGINE_ENABLED
     case AUX_FUNC::ICE_START_STOP:
 #endif
-        run_aux_function(ch_option, ch_flag, AuxFuncTriggerSource::INIT);
+        run_aux_function(ch_option, ch_flag, AuxFuncTrigger::Source::INIT);
         break;
 
     case AUX_FUNC::REVERSE_THROTTLE:
@@ -216,8 +216,11 @@ void RC_Channel_Plane::init_aux_function(const RC_Channel::AUX_FUNC ch_option,
 }
 
 // do_aux_function - implement the function invoked by auxiliary switches
-bool RC_Channel_Plane::do_aux_function(const AUX_FUNC ch_option, const AuxSwitchPos ch_flag)
+bool RC_Channel_Plane::do_aux_function(const AuxFuncTrigger &trigger)
 {
+    const AUX_FUNC &ch_option = trigger.func;
+    const AuxSwitchPos &ch_flag = trigger.pos;
+
     switch(ch_option) {
     case AUX_FUNC::INVERTED:
         plane.inverted_flight = (ch_flag == AuxSwitchPos::HIGH);
@@ -472,7 +475,7 @@ bool RC_Channel_Plane::do_aux_function(const AUX_FUNC ch_option, const AuxSwitch
 #endif
 
     default:
-        return RC_Channel::do_aux_function(ch_option, ch_flag);
+        return RC_Channel::do_aux_function(trigger);
     }
 
     return true;

--- a/ArduPlane/RC_Channel.cpp
+++ b/ArduPlane/RC_Channel.cpp
@@ -194,7 +194,7 @@ void RC_Channel_Plane::init_aux_function(const RC_Channel::AUX_FUNC ch_option,
 #if AP_ICENGINE_ENABLED
     case AUX_FUNC::ICE_START_STOP:
 #endif
-        run_aux_function(ch_option, ch_flag, AuxFuncTrigger::Source::INIT);
+        run_aux_function(ch_option, ch_flag, AuxFuncTrigger::Source::INIT, ch_in);
         break;
 
     case AUX_FUNC::REVERSE_THROTTLE:

--- a/ArduPlane/RC_Channel.h
+++ b/ArduPlane/RC_Channel.h
@@ -11,7 +11,7 @@ protected:
 
     void init_aux_function(AUX_FUNC ch_option,
                            AuxSwitchPos ch_flag) override;
-    bool do_aux_function(AUX_FUNC ch_option, AuxSwitchPos) override;
+    bool do_aux_function(const AuxFuncTrigger &trigger) override;
 
     // called when the mode switch changes position:
     void mode_switch_changed(modeswitch_pos_t new_pos) override;

--- a/Blimp/RC_Channel.cpp
+++ b/Blimp/RC_Channel.cpp
@@ -99,8 +99,11 @@ void RC_Channel_Blimp::do_aux_function_change_mode(const Mode::Number mode,
 }
 
 // do_aux_function - implement the function invoked by auxiliary switches
-bool RC_Channel_Blimp::do_aux_function(const AUX_FUNC ch_option, const AuxSwitchPos ch_flag)
+bool RC_Channel_Blimp::do_aux_function(const AuxFuncTrigger &trigger)
 {
+    const AUX_FUNC &ch_option = trigger.func;
+    const AuxSwitchPos &ch_flag = trigger.pos;
+
     switch (ch_option) {
 
     case AUX_FUNC::SAVE_TRIM:
@@ -120,7 +123,7 @@ bool RC_Channel_Blimp::do_aux_function(const AUX_FUNC ch_option, const AuxSwitch
         break;
 
     default:
-        return RC_Channel::do_aux_function(ch_option, ch_flag);
+        return RC_Channel::do_aux_function(trigger);
     }
     return true;
 }

--- a/Blimp/RC_Channel.h
+++ b/Blimp/RC_Channel.h
@@ -12,7 +12,7 @@ public:
 protected:
 
     void init_aux_function(AUX_FUNC ch_option, AuxSwitchPos) override;
-    bool do_aux_function(AUX_FUNC ch_option, AuxSwitchPos) override;
+    bool do_aux_function(const AuxFuncTrigger &trigger) override;
 
 private:
 

--- a/Rover/RC_Channel.cpp
+++ b/Rover/RC_Channel.cpp
@@ -130,8 +130,11 @@ void RC_Channel_Rover::do_aux_function_sailboat_motor_3pos(const AuxSwitchPos ch
     }
 }
 
-bool RC_Channel_Rover::do_aux_function(const AUX_FUNC ch_option, const AuxSwitchPos ch_flag)
+bool RC_Channel_Rover::do_aux_function(const AuxFuncTrigger &trigger)
 {
+    const AUX_FUNC &ch_option = trigger.func;
+    const AuxSwitchPos &ch_flag = trigger.pos;
+
     switch (ch_option) {
     case AUX_FUNC::DO_NOTHING:
         break;
@@ -261,7 +264,7 @@ bool RC_Channel_Rover::do_aux_function(const AUX_FUNC ch_option, const AuxSwitch
         break;
 
     default:
-        return RC_Channel::do_aux_function(ch_option, ch_flag);
+        return RC_Channel::do_aux_function(trigger);
 
     }
 

--- a/Rover/RC_Channel.h
+++ b/Rover/RC_Channel.h
@@ -12,7 +12,7 @@ public:
 protected:
 
     void init_aux_function(AUX_FUNC ch_option, AuxSwitchPos) override;
-    bool do_aux_function(AUX_FUNC ch_option, AuxSwitchPos) override;
+    bool do_aux_function(const AuxFuncTrigger &trigger) override;
 
     // called when the mode switch changes position:
     void mode_switch_changed(modeswitch_pos_t new_pos) override;

--- a/Tools/autotest/logger_metadata/enum_parse.py
+++ b/Tools/autotest/logger_metadata/enum_parse.py
@@ -168,7 +168,7 @@ class EnumDocco(object):
                         continue
 
                     # // @LoggerEnum: NAME  -  can be used around for #define sets
-                    m = re.match(r".*@LoggerEnum: *([\w]+)", line)
+                    m = re.match(r".*@LoggerEnum: *([\w:]+)", line)
                     if m is not None:
                         enum_name = m.group(1)
                         debug("%s: %s" % (source_file, enum_name))
@@ -180,6 +180,9 @@ class EnumDocco(object):
 
                     continue
                 if state == "inside":
+                    if re.match(r"\s*enum.*$", line):
+                        # Allow @LoggerEnum around Enum for name override
+                        continue
                     if re.match(r"\s*$", line):
                         continue
                     if re.match(r"#if", line):

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -1233,6 +1233,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.start_subtest("Check start chan control disable")
             old_start_channel_value = self.get_rc_channel_value(rc_engine_start_chan)
             self.set_rc(rc_engine_start_chan, 1000)
+            self.delay_sim_time(1) # Make sure the RC change has registered
             self.context_collect('STATUSTEXT')
             method(mavutil.mavlink.MAV_CMD_DO_ENGINE_CONTROL, p1=1, want_result=mavutil.mavlink.MAV_RESULT_FAILED)
             self.wait_statustext("start control disabled", check_context=True)

--- a/libraries/AP_Button/AP_Button.cpp
+++ b/libraries/AP_Button/AP_Button.cpp
@@ -278,7 +278,7 @@ void AP_Button::run_aux_functions(bool force)
             GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Button %i: executing (%s %s)", i+1, str, rc_channel->string_for_aux_pos(pos));
         }
 #endif
-        rc_channel->run_aux_function(func, pos, RC_Channel::AuxFuncTrigger::Source::BUTTON);
+        rc_channel->run_aux_function(func, pos, RC_Channel::AuxFuncTrigger::Source::BUTTON, i);
     }
 }
 

--- a/libraries/AP_Button/AP_Button.cpp
+++ b/libraries/AP_Button/AP_Button.cpp
@@ -278,7 +278,7 @@ void AP_Button::run_aux_functions(bool force)
             GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Button %i: executing (%s %s)", i+1, str, rc_channel->string_for_aux_pos(pos));
         }
 #endif
-        rc_channel->run_aux_function(func, pos, RC_Channel::AuxFuncTriggerSource::BUTTON);
+        rc_channel->run_aux_function(func, pos, RC_Channel::AuxFuncTrigger::Source::BUTTON);
     }
 }
 

--- a/libraries/AP_ICEngine/AP_ICEngine.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine.cpp
@@ -30,8 +30,6 @@
 
 extern const AP_HAL::HAL& hal;
 
-#define AP_ICENGINE_START_CHAN_DEBOUNCE_MS          300
-
 const AP_Param::GroupInfo AP_ICEngine::var_info[] = {
 
     // @Param: ENABLE
@@ -163,7 +161,8 @@ const AP_Param::GroupInfo AP_ICEngine::var_info[] = {
     // @Description: This is a minimum PWM value for engine start channel for an engine stop to be commanded. Setting this value will avoid RC input glitches with low PWM values from causing an unwanted engine stop. A value of zero means any PWM above 800 and below 1300 triggers an engine stop. To stop the engine start channel must above the larger of this value and 800 and below 1300.
     // @User: Standard
     // @Range: 0 1300
-    AP_GROUPINFO("STARTCHN_MIN", 16, AP_ICEngine, start_chan_min_pwm, 0),
+
+    // 16 was STARTCHN_MIN
 
 #if AP_RPM_ENABLED
     // @Param: REDLINE_RPM
@@ -282,6 +281,12 @@ void AP_ICEngine::param_conversion()
     }
 }
 
+// Handle incoming aux function
+void AP_ICEngine::do_aux_function(const RC_Channel::AuxSwitchPos ch_flag)
+{
+    aux_pos = ch_flag;
+}
+
 /*
   update engine state
  */
@@ -291,51 +296,20 @@ void AP_ICEngine::update(void)
         return;
     }
 
-    uint16_t cvalue = 1500;
-    RC_Channel *c = rc().find_channel_for_option(RC_Channel::AUX_FUNC::ICE_START_STOP);
-    if (c != nullptr && rc().has_valid_input()) {
-        // get starter control channel
-        cvalue = c->get_radio_in();
-
-        if (cvalue < start_chan_min_pwm) {
-            cvalue = start_chan_last_value;
-        }
-
-        // snap the input to either 1000, 1500, or 2000
-        // this is useful to compare a debounce changed value
-        // while ignoring tiny noise
-        if (cvalue >= RC_Channel::AUX_PWM_TRIGGER_HIGH) {
-            cvalue = 2000;
-        } else if ((cvalue > 800) && (cvalue <= RC_Channel::AUX_PWM_TRIGGER_LOW)) {
-            cvalue = 1300;
-        } else {
-            cvalue = 1500;
-        }
-    }
-
     bool should_run = false;
     uint32_t now = AP_HAL::millis();
 
 
-    // debounce timer to protect from spurious changes on start_chan rc input
-    // If the cached value is the same, reset timer
-    if (start_chan_last_value == cvalue) {
-        start_chan_last_ms = now;
-    } else if (now - start_chan_last_ms >= AP_ICENGINE_START_CHAN_DEBOUNCE_MS) {
-        // if it has changed, and stayed changed for the duration, then use that new value
-        start_chan_last_value = cvalue;
-    }
-
-    if (state == ICE_START_HEIGHT_DELAY && start_chan_last_value >= RC_Channel::AUX_PWM_TRIGGER_HIGH) {
+    if ((state == ICE_START_HEIGHT_DELAY) && (aux_pos == RC_Channel::AuxSwitchPos::HIGH)) {
         // user is overriding the height start delay and asking for
         // immediate start. Put into ICE_OFF so that the logic below
         // can start the engine now
         state = ICE_OFF;
     }
 
-    if (state == ICE_OFF && start_chan_last_value >= RC_Channel::AUX_PWM_TRIGGER_HIGH) {
+    if ((state == ICE_OFF) && (aux_pos == RC_Channel::AuxSwitchPos::HIGH)) {
         should_run = true;
-    } else if (start_chan_last_value <= RC_Channel::AUX_PWM_TRIGGER_LOW) {
+    } else if (aux_pos == RC_Channel::AuxSwitchPos::LOW) {
         should_run = false;
 
         // clear the single start flag now that we will be stopping the engine
@@ -622,15 +596,13 @@ bool AP_ICEngine::engine_control(float start_control, float cold_start, float he
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Engine: already running");
         return false;
     }
-    RC_Channel *c = rc().find_channel_for_option(RC_Channel::AUX_FUNC::ICE_START_STOP);
-    if (c != nullptr && rc().has_valid_input()) {
-        // get starter control channel
-        uint16_t cvalue = c->get_radio_in();
-        if (cvalue >= start_chan_min_pwm && cvalue <= RC_Channel::AUX_PWM_TRIGGER_LOW) {
-            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Engine: start control disabled");
-            return false;
-        }
+
+    // get starter control channel
+    if (aux_pos == RC_Channel::AuxSwitchPos::LOW) {
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Engine: start control disabled by aux function");
+        return false;
     }
+
     if (height_delay > 0) {
         height_pending = true;
         initial_height = 0;

--- a/libraries/AP_ICEngine/AP_ICEngine.h
+++ b/libraries/AP_ICEngine/AP_ICEngine.h
@@ -27,6 +27,7 @@
 #include <AP_RPM/AP_RPM_config.h>
 #include <AP_HAL/I2CDevice.h>
 #include <AP_Relay/AP_Relay_config.h>
+#include <RC_Channel/RC_Channel.h>
 
 #if AP_ICENGINE_TCA9554_STARTER_ENABLED
 #include "AP_ICEngine_TCA9554.h"
@@ -69,6 +70,9 @@ public:
     // do we have throttle while disarmed enabled?
     bool allow_throttle_while_disarmed(void) const;
 
+    // Handle incoming aux function trigger
+    void do_aux_function(const RC_Channel::AuxSwitchPos ch_flag);
+
 #if AP_RELAY_ENABLED
     // Needed for param conversion from relay numbers to functions
     bool get_legacy_ignition_relay_index(int8_t &num);
@@ -93,9 +97,6 @@ private:
     // enable library
     AP_Int8 enable;
 
-    // min pwm on start channel for engine stop
-    AP_Int16 start_chan_min_pwm;
-    
 #if AP_RPM_ENABLED
     // which RPM instance to use
     AP_Int8 rpm_instance;
@@ -169,9 +170,8 @@ private:
         return (options & uint16_t(option)) != 0;
     }
 
-    // start_chan debounce
-    uint16_t start_chan_last_value = 1500;
-    uint32_t start_chan_last_ms;
+    // Last aux function value
+    RC_Channel::AuxSwitchPos aux_pos = RC_Channel::AuxSwitchPos::MIDDLE;
 
 #if AP_ICENGINE_TCA9554_STARTER_ENABLED
     AP_ICEngine_TCA9554 tca9554_starter;

--- a/libraries/AP_ICEngine/AP_ICEngine.h
+++ b/libraries/AP_ICEngine/AP_ICEngine.h
@@ -71,7 +71,7 @@ public:
     bool allow_throttle_while_disarmed(void) const;
 
     // Handle incoming aux function trigger
-    void do_aux_function(const RC_Channel::AuxSwitchPos ch_flag);
+    void do_aux_function(const RC_Channel::AuxFuncTrigger &trigger);
 
 #if AP_RELAY_ENABLED
     // Needed for param conversion from relay numbers to functions
@@ -96,6 +96,9 @@ private:
 
     // enable library
     AP_Int8 enable;
+
+    // min pwm on start channel for engine stop
+    AP_Int16 start_chan_min_pwm;
 
 #if AP_RPM_ENABLED
     // which RPM instance to use

--- a/libraries/AP_Mission/AP_Mission_Commands.cpp
+++ b/libraries/AP_Mission/AP_Mission_Commands.cpp
@@ -31,7 +31,7 @@ bool AP_Mission::start_command_do_aux_function(const AP_Mission::Mission_Command
     default:
         return false;
     }
-    rc().run_aux_function(function, pos, RC_Channel::AuxFuncTriggerSource::MISSION);
+    rc().run_aux_function(function, pos, RC_Channel::AuxFuncTrigger::Source::MISSION);
     return true;
 }
 #endif  // AP_RC_CHANNEL_ENABLED

--- a/libraries/AP_Mission/AP_Mission_Commands.cpp
+++ b/libraries/AP_Mission/AP_Mission_Commands.cpp
@@ -31,7 +31,7 @@ bool AP_Mission::start_command_do_aux_function(const AP_Mission::Mission_Command
     default:
         return false;
     }
-    rc().run_aux_function(function, pos, RC_Channel::AuxFuncTrigger::Source::MISSION);
+    rc().run_aux_function(function, pos, RC_Channel::AuxFuncTrigger::Source::MISSION, cmd.index);
     return true;
 }
 #endif  // AP_RC_CHANNEL_ENABLED

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -398,7 +398,7 @@ singleton RC_Channels rename rc
 singleton RC_Channels scheduler-semaphore
 singleton RC_Channels method get_pwm boolean uint8_t 1 NUM_RC_CHANNELS uint16_t'Null
 singleton RC_Channels method find_channel_for_option RC_Channel RC_Channel::AUX_FUNC'enum 0 UINT16_MAX
-singleton RC_Channels method run_aux_function boolean RC_Channel::AUX_FUNC'enum 0 UINT16_MAX RC_Channel::AuxSwitchPos'enum RC_Channel::AuxSwitchPos::LOW RC_Channel::AuxSwitchPos::HIGH RC_Channel::AuxFuncTrigger::Source::SCRIPTING'literal
+singleton RC_Channels method run_aux_function boolean RC_Channel::AUX_FUNC'enum 0 UINT16_MAX RC_Channel::AuxSwitchPos'enum RC_Channel::AuxSwitchPos::LOW RC_Channel::AuxSwitchPos::HIGH RC_Channel::AuxFuncTrigger::Source::SCRIPTING'literal 0'literal
 singleton RC_Channels method has_valid_input boolean
 singleton RC_Channels method lua_rc_channel RC_Channel uint8_t 1 NUM_RC_CHANNELS
 singleton RC_Channels method lua_rc_channel rename get_channel

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -398,7 +398,7 @@ singleton RC_Channels rename rc
 singleton RC_Channels scheduler-semaphore
 singleton RC_Channels method get_pwm boolean uint8_t 1 NUM_RC_CHANNELS uint16_t'Null
 singleton RC_Channels method find_channel_for_option RC_Channel RC_Channel::AUX_FUNC'enum 0 UINT16_MAX
-singleton RC_Channels method run_aux_function boolean RC_Channel::AUX_FUNC'enum 0 UINT16_MAX RC_Channel::AuxSwitchPos'enum RC_Channel::AuxSwitchPos::LOW RC_Channel::AuxSwitchPos::HIGH RC_Channel::AuxFuncTriggerSource::SCRIPTING'literal
+singleton RC_Channels method run_aux_function boolean RC_Channel::AUX_FUNC'enum 0 UINT16_MAX RC_Channel::AuxSwitchPos'enum RC_Channel::AuxSwitchPos::LOW RC_Channel::AuxSwitchPos::HIGH RC_Channel::AuxFuncTrigger::Source::SCRIPTING'literal
 singleton RC_Channels method has_valid_input boolean
 singleton RC_Channels method lua_rc_channel RC_Channel uint8_t 1 NUM_RC_CHANNELS
 singleton RC_Channels method lua_rc_channel rename get_channel

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3110,7 +3110,7 @@ MAV_RESULT GCS_MAVLINK::handle_command_do_aux_function(const mavlink_command_int
     }
     const RC_Channel::AUX_FUNC aux_func = (RC_Channel::AUX_FUNC)packet.param1;
     const RC_Channel::AuxSwitchPos position = (RC_Channel::AuxSwitchPos)packet.param2;
-    if (!rc().run_aux_function(aux_func, position, RC_Channel::AuxFuncTriggerSource::MAVLINK)) {
+    if (!rc().run_aux_function(aux_func, position, RC_Channel::AuxFuncTrigger::Source::MAVLINK)) {
         // note that this is not quite right; we could be more nuanced
         // about our return code here.
         return MAV_RESULT_FAILED;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3110,7 +3110,7 @@ MAV_RESULT GCS_MAVLINK::handle_command_do_aux_function(const mavlink_command_int
     }
     const RC_Channel::AUX_FUNC aux_func = (RC_Channel::AUX_FUNC)packet.param1;
     const RC_Channel::AuxSwitchPos position = (RC_Channel::AuxSwitchPos)packet.param2;
-    if (!rc().run_aux_function(aux_func, position, RC_Channel::AuxFuncTrigger::Source::MAVLINK)) {
+    if (!rc().run_aux_function(aux_func, position, RC_Channel::AuxFuncTrigger::Source::MAVLINK, chan)) {
         // note that this is not quite right; we could be more nuanced
         // about our return code here.
         return MAV_RESULT_FAILED;

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -779,7 +779,7 @@ void RC_Channel::init_aux_function(const AUX_FUNC ch_option, const AuxSwitchPos 
 #endif
 #if AP_AHRS_ENABLED
     case AUX_FUNC::AHRS_TYPE:
-        run_aux_function(ch_option, ch_flag, AuxFuncTrigger::Source::INIT);
+        run_aux_function(ch_option, ch_flag, AuxFuncTrigger::Source::INIT, ch_in);
         break;
 #endif
     default:
@@ -977,7 +977,7 @@ bool RC_Channel::read_aux()
 #endif
 
     // debounced; undertake the action:
-    run_aux_function(_option, new_position, AuxFuncTrigger::Source::RC, get_radio_in());
+    run_aux_function(_option, new_position, AuxFuncTrigger::Source::RC, ch_in);
     return true;
 }
 
@@ -1402,7 +1402,7 @@ void RC_Channel::do_aux_function_retract_mount(const AuxSwitchPos ch_flag, const
 }
 #endif  // HAL_MOUNT_ENABLED
 
-bool RC_Channel::run_aux_function(AUX_FUNC ch_option, AuxSwitchPos pos, AuxFuncTrigger::Source source, int16_t pwm)
+bool RC_Channel::run_aux_function(AUX_FUNC ch_option, AuxSwitchPos pos, AuxFuncTrigger::Source source, uint16_t source_index)
 {
 #if AP_SCRIPTING_ENABLED
     rc().set_aux_cached(ch_option, pos);
@@ -1412,7 +1412,7 @@ bool RC_Channel::run_aux_function(AUX_FUNC ch_option, AuxSwitchPos pos, AuxFuncT
         func: ch_option,
         pos: pos,
         source: source,
-        pwm: pwm,
+        source_index: source_index,
     };
 
     const bool ret = do_aux_function(trigger);
@@ -1427,17 +1427,19 @@ bool RC_Channel::run_aux_function(AUX_FUNC ch_option, AuxSwitchPos pos, AuxFuncT
     // @FieldValueEnum: pos: RC_Channel::AuxSwitchPos
     // @Field: source: source of auxiliary function invocation
     // @FieldValueEnum: source: RC_Channel::AuxFuncTrigger::Source
+    // @Field: index: index within source. 0 indexed. Invalid for scripting.
     // @Field: result: true if function was successful
     AP::logger().Write(
         "AUXF",
-        "TimeUS,function,pos,source,result",
-        "s#---",
-        "F----",
-        "QHBBB",
+        "TimeUS,function,pos,source,index,result",
+        "s#----",
+        "F-----",
+        "QHBBHB",
         AP_HAL::micros64(),
         uint16_t(ch_option),
         uint8_t(pos),
         uint8_t(source),
+        source_index,
         uint8_t(ret)
     );
 #endif
@@ -1915,7 +1917,8 @@ void RC_Channel::init_aux()
     if (!read_3pos_switch(position)) {
         position = AuxSwitchPos::LOW;
     }
-    init_aux_function((AUX_FUNC)option.get(), position);
+
+    run_aux_function((AUX_FUNC)option.get(), position, AuxFuncTrigger::Source::INIT, ch_in);
 }
 
 // read_3pos_switch

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -314,19 +314,19 @@ public:
         HIGH       // indicates auxiliary switch is in the high position (pwm >1800)
     };
 
-    // Trigger structure containing the function, position and pwm (if applicable)
+    // Trigger structure containing the function, position, source and source index
     struct AuxFuncTrigger {
         AUX_FUNC func;
         AuxSwitchPos pos;
+        // @LoggerEnum: AuxFuncTrigger::Source
         enum class Source : uint8_t {
-            INIT,
-            RC,
-            BUTTON,
-            MAVLINK,
-            MISSION,
-            SCRIPTING,
+            INIT,      // Source index is RC channel index
+            RC,        // Source index is RC channel index
+            BUTTON,    // Source index is button index
+            MAVLINK,   // Source index is MAVLink channel number
+            MISSION,   // Source index is mission item index
+            SCRIPTING, // Source index is not used (always 0)
         } source;
-        // Index within source
         uint16_t source_index;
     };
 

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -314,19 +314,26 @@ public:
         HIGH       // indicates auxiliary switch is in the high position (pwm >1800)
     };
 
-    enum class AuxFuncTriggerSource : uint8_t {
-        INIT,
-        RC,
-        BUTTON,
-        MAVLINK,
-        MISSION,
-        SCRIPTING,
+    // Trigger structure containing the function, position and pwm (if applicable)
+    struct AuxFuncTrigger {
+        AUX_FUNC func;
+        AuxSwitchPos pos;
+        enum class Source : uint8_t {
+            INIT,
+            RC,
+            BUTTON,
+            MAVLINK,
+            MISSION,
+            SCRIPTING,
+        } source;
+        // Trigger PWM, only valid for RC source
+        int16_t pwm;
     };
 
     AuxSwitchPos get_aux_switch_pos() const;
 
     // wrapper function around do_aux_function which allows us to log
-    bool run_aux_function(AUX_FUNC ch_option, AuxSwitchPos pos, AuxFuncTriggerSource source);
+    bool run_aux_function(AUX_FUNC ch_option, AuxSwitchPos pos, AuxFuncTrigger::Source source, int16_t pwm = 0);
 
 #if AP_RC_CHANNEL_AUX_FUNCTION_STRINGS_ENABLED
     const char *string_for_aux_function(AUX_FUNC function) const;
@@ -357,7 +364,7 @@ protected:
     virtual void init_aux_function(AUX_FUNC ch_option, AuxSwitchPos);
 
     // virtual function to be overridden my subclasses
-    virtual bool do_aux_function(AUX_FUNC ch_option, AuxSwitchPos);
+    virtual bool do_aux_function(const AuxFuncTrigger &trigger);
 
     void do_aux_function_armdisarm(const AuxSwitchPos ch_flag);
     void do_aux_function_avoid_adsb(const AuxSwitchPos ch_flag);
@@ -597,7 +604,7 @@ public:
 
     // method for other parts of the system (e.g. Button and mavlink)
     // to trigger auxiliary functions
-    bool run_aux_function(RC_Channel::AUX_FUNC ch_option, RC_Channel::AuxSwitchPos pos, RC_Channel::AuxFuncTriggerSource source) {
+    bool run_aux_function(RC_Channel::AUX_FUNC ch_option, RC_Channel::AuxSwitchPos pos, RC_Channel::AuxFuncTrigger::Source source) {
         return rc_channel(0)->run_aux_function(ch_option, pos, source);
     }
 

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -326,14 +326,14 @@ public:
             MISSION,
             SCRIPTING,
         } source;
-        // Trigger PWM, only valid for RC source
-        int16_t pwm;
+        // Index within source
+        uint16_t source_index;
     };
 
     AuxSwitchPos get_aux_switch_pos() const;
 
     // wrapper function around do_aux_function which allows us to log
-    bool run_aux_function(AUX_FUNC ch_option, AuxSwitchPos pos, AuxFuncTrigger::Source source, int16_t pwm = 0);
+    bool run_aux_function(AUX_FUNC ch_option, AuxSwitchPos pos, AuxFuncTrigger::Source source, uint16_t source_index);
 
 #if AP_RC_CHANNEL_AUX_FUNCTION_STRINGS_ENABLED
     const char *string_for_aux_function(AUX_FUNC function) const;
@@ -395,6 +395,8 @@ protected:
         // no action by default (e.g. Tracker, Sub, who do their own thing)
     };
 
+    // the input channel this corresponds to
+    uint8_t ch_in;
 
 private:
 
@@ -413,9 +415,6 @@ private:
 
     ControlType type_in;
     int16_t     high_in;
-
-    // the input channel this corresponds to
-    uint8_t     ch_in;
 
     // overrides
     uint16_t override_value;
@@ -604,8 +603,8 @@ public:
 
     // method for other parts of the system (e.g. Button and mavlink)
     // to trigger auxiliary functions
-    bool run_aux_function(RC_Channel::AUX_FUNC ch_option, RC_Channel::AuxSwitchPos pos, RC_Channel::AuxFuncTrigger::Source source) {
-        return rc_channel(0)->run_aux_function(ch_option, pos, source);
+    bool run_aux_function(RC_Channel::AUX_FUNC ch_option, RC_Channel::AuxSwitchPos pos, RC_Channel::AuxFuncTrigger::Source source, uint16_t source_index) {
+        return rc_channel(0)->run_aux_function(ch_option, pos, source, source_index);
     }
 
     // check if flight mode channel is assigned RC option


### PR DESCRIPTION
This removes the ICE `STARTCHN_MIN` protections and RC input thresholds instead moving over to those that are applied to all aux functions. 

Aux functions do have a min value of 800. 

https://github.com/ArduPilot/ardupilot/blob/4d75b4477550e3fccb6a1917dd8a49594d3d2c9b/libraries/RC_Channel/RC_Channel.cpp#L1897

This also moves to the aux function threshold values of 1200 and 1800 rather than the 1300 and 1700 that are used now. ICE was also using a longer de-bounce time, 300ms vs 200ms in the RC lib.

This could mean a change in behavior for some users. 

We also loose the low PWM on RC failure protection of `STARTCHN_MIN`.

We gain the ability to trigger the aux function directly from the GCS, so if RC dropout was a issue the recommendation would be to use the MAVLink command. 

I don't really see any other nice way of moving forward. One option would be to add a `STARTCHN_MIN` parameter to the RC_Channel library and apply it to all switches.

A second option would be to add another aux function that would be sent from the GCS and would be ignored if the existing option is setup. So you could do RC switch or GCS, but not both.