### PR TITLE
Allow inlining of Location constructor

### DIFF
--- a/libraries/AP_Common/Location.cpp
+++ b/libraries/AP_Common/Location.cpp
@@ -9,12 +9,6 @@
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Terrain/AP_Terrain.h>
 
-/// constructors
-Location::Location()
-{
-    zero();
-}
-
 const Location definitely_zero{};
 bool Location::is_zero(void) const
 {

--- a/libraries/AP_Common/Location.h
+++ b/libraries/AP_Common/Location.h
@@ -28,7 +28,7 @@ public:
     };
 
     /// constructors
-    Location();
+    Location() { zero(); }
     Location(int32_t latitude, int32_t longitude, int32_t alt_in_cm, AltFrame frame);
     Location(const Vector3f &ekf_offset_neu, AltFrame frame);
     Location(const Vector3d &ekf_offset_neu, AltFrame frame);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -5502,7 +5502,7 @@ MAV_RESULT GCS_MAVLINK::handle_command_int_packet(const mavlink_command_int_t &p
 #endif
 
     case MAV_CMD_DO_SET_ROI_NONE: {
-        const Location zero_loc = Location();
+        const Location zero_loc;
         return handle_command_do_set_roi(zero_loc);
     }
 


### PR DESCRIPTION

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  0                                                                     
CubeRedPrimary                      -128   *           -128    -120              -128   -120   -128
Durandal                            -112   *           -104    -96               -112   -112   -112
Hitec-Airspeed           *                                                                     
KakuteH7-bdshot                     -112   *           -120    -120              -112   -120   -120
MatekF405                           -136   *           -144    -144              -136   -144   -144
Pixhawk1-1M-bdshot                  -144               -144    -136              -144   -144   -136
f103-QiotekPeriph        *                                                                     
f303-Universal           -16                                                                   
iomcu                                                                *                         
revo-mini                           -136   *           -136    -144              -144   -144   -144
skyviper-journey                                       -136                                    
skyviper-v2450                                         -144                                    
```

... also remove pointless assignment from a stack-constructed location object
