### PR TITLE
AP_Periph: Prepare reboot before rebooting via AP_Periph:reboot()

### DIFF
--- a/Tools/AP_Periph/AP_Periph.cpp
+++ b/Tools/AP_Periph/AP_Periph.cpp
@@ -627,6 +627,7 @@ void AP_Periph_FW::prepare_reboot()
  */
 void AP_Periph_FW::reboot(bool hold_in_bootloader)
 {
+    prepare_reboot();
     hal.scheduler->reboot(hold_in_bootloader);
 }
 


### PR DESCRIPTION
Call AP_Periph:prepare_reboot() before rebooting via AP_Periph:reboot(). 

Added as parameters were not being saved in time.

Tested on: CubeNode-ETH, AP_Periph