### PR TITLE
Plane: Add trim pitch to minimum takeoff pitch

### DIFF
--- a/ArduPlane/takeoff.cpp
+++ b/ArduPlane/takeoff.cpp
@@ -204,7 +204,7 @@ void Plane::takeoff_calc_pitch(void)
 
     // We are now past the rotation.
     // Initialize pitch limits for TECS.
-    int16_t pitch_min_cd = get_takeoff_pitch_min_cd();
+    int16_t pitch_min_cd = get_takeoff_pitch_min_cd() + int16_t(g.pitch_trim * 100.0);
     bool pitch_clipped_max = false;
 
     // If we're using an airspeed sensor, we consult TECS.


### PR DESCRIPTION
We have a report [here](https://github.com/ArduPilot/ardupilot/pull/28352) that a small flying wing (a ZOHD) failed to climb to altitude during an AUTO takeoff.

The issue was that this plane does not climb when it's at full throttle and ~0deg pitch. Hence when the code for tapering off the pitch setpoint in the last few meters of the climb kicked in, the plane settled at around 3m below the target altitude, unable to climb more.

This PR applies `PTCH_TRIM_DEG` to the result of `get_takeoff_pitch_min_cd()`, so that it is in par with the result of `calc_nav_pitch()`.
Reminder, the result of `get_takeoff_pitch_min_cd()` is directly written as a pitch setpoint when there is no airspeed sensor or when `TKOFF_OPTIONS[0]=0`; `PTCH_TRIM_DEG` is never employed currently in this case.

I'm not 100% convinced that this will solve the problem effectively. The alternative is to write sort of an integrating term controller to monitor this steady-state error and wind the pitch setpoint back up. But I don't want to make this so complex.

The reason we didn't have this problem in 4.5 is that the code was bugged and the demanded pitch would always be the takeoff pitch, no taper.