### PR TITLE
TECS: Correctly handle Home altitude change

### DIFF
--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -44,7 +44,7 @@ void Plane::check_home_alt_change(void)
             next_WP_loc.alt += alt_change_cm;
         }
         // reset TECS to force the field elevation estimate to reset
-        TECS_controller.reset();
+        TECS_controller.offset_altitude(alt_change_cm * 0.01f);
     }
     auto_state.last_home_alt_cm = home_alt_cm;
 }

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -1124,7 +1124,6 @@ void AP_TECS::_initialise_states(float hgt_afe)
         _integKE              = 0.0f;
         _last_throttle_dem    = aparm.throttle_cruise * 0.01f;
         _last_pitch_dem       = _ahrs.get_pitch();
-        _hgt_afe              = hgt_afe;
         _hgt_dem_in_prev      = hgt_afe;
         _hgt_dem_lpf          = hgt_afe;
         _hgt_dem_rate_ltd     = hgt_afe;

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -1527,4 +1527,5 @@ void AP_TECS::offset_altitude(const float alt_offset)
     // _hgt_dem
     // _hgt_dem_in_raw
     // _hgt_dem_in
+    // Energies
 }

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -1501,3 +1501,30 @@ void AP_TECS::_update_pitch_limits(const int32_t ptchMinCO_cd) {
     // don't allow max pitch to go below min pitch
     _PITCHmaxf = MAX(_PITCHmaxf, _PITCHminf);
 }
+
+void AP_TECS::offset_altitude(const float alt_offset)
+{
+    // Convention: When alt_offset is positive it means that the altitude of
+    // home has increased. Thus, the relative altitude of the vehicle has
+    // decreased.
+    //
+    // Assumption: This method is called more often and before
+    // `update_pitch_throttle()`. This is necessary to ensure that new height
+    // demands which incorporate the home change are compatible with the
+    // (now updated) internal height state.
+
+    _flare_hgt_dem_ideal    -= alt_offset;
+    _flare_hgt_dem_adj      -= alt_offset;
+    _hgt_at_start_of_flare  -= alt_offset;
+    _hgt_dem_in_prev        -= alt_offset;
+    _hgt_dem_lpf            -= alt_offset;
+    _hgt_dem_rate_ltd       -= alt_offset;
+    _hgt_dem_prev           -= alt_offset;
+    _height_filter.height   -= alt_offset;
+
+    // The following variables are updated anew in every call of
+    // `update_pitch_throttle()`. There's no need to update those.
+    // _hgt_dem
+    // _hgt_dem_in_raw
+    // _hgt_dem_in
+}

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -154,6 +154,9 @@ public:
         _need_reset = true;
     }
 
+    // Apply an altitude offset, to compensate for changes in home alt.
+    void offset_altitude(const float alt_offset);
+
     // this supports the TECS_* user settable parameters
     static const struct AP_Param::GroupInfo var_info[];
 


### PR DESCRIPTION
## Summary

In case where the Home altitude is changed, TECS will now not reset, but offset the relevant attributes instead.

## Background

Recently one of our partners flying a quadplane reported that while doing a ship landing, their plane would continuously lose altitude.
![image](https://github.com/user-attachments/assets/6e922be9-c278-4f77-860d-148a1d96e897)

## Details

The reason is that the most minute home altitude changes [trigger a TECS reset](https://github.com/ArduPilot/ardupilot/blob/master/ArduPlane/altitude.cpp#L47). This behaviour is about 1 year old.

In the meantime, the ship landing lua script continuously [updates the home location](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Scripting/applets/plane_ship_landing.lua#L432).
This code is ~2years old.

The combination results in the TECS constantly switching into a state of rest and becoming effectively paralyzed.

## Solution

I added a new method `AP_TECS::offset_altitude(const float alt_offset)` where TECS is made aware of the change in home altitude and offsets all internal attributes accordingly.

This is a pretty wide-reaching change, so all comments and test proposals are welcome.

## Testing

An autotest was created for Plane (`SetHomeAltChange2`) that, once the plane comes to altitude, it wiggles the home altitude over 10s.
The MAVLink command is set at 10Hz, but it seems to get parsed only at 2Hz.

Still, the results are conclusive:

**Before**:
- When the wiggle starts, TECS starts resetting (bottom right)
- The actual altitude starts climbing, since the trims cause the plane to climb (bottom middle).
- All TECS quantities start wiggling too, including throttle and pitch. Still, this is an exaggerated case, since home is wiggled by +-40m.

![Screenshot from 2024-11-25 16-16-34](https://github.com/user-attachments/assets/9fc22746-7063-494d-8716-075ee0caeb33)

**After**:
- When the wiggle starts, TECS does not reset (bottom right).
- The actual altitude stays on target (bottom middle).
- All TECS quantities are stable, except for altitude (middle left). This is expected, since its frame is home-relative.

![Screenshot from 2024-11-25 16-18-47](https://github.com/user-attachments/assets/170d0f28-df94-4229-9a34-f625e7d33623)

## Alternatives

An alternative would be to just not reset TECS as often in case of home altitude change. But what is a "good" interval? Are we happy with TECS resetting every 10s? 20s?

Another alternative would be to just not allow the user to update home while TECS is running, but that sounds a bit silly to me.