### PR TITLE
AP_Generator: apply -Os to all cpp files

### DIFF
--- a/libraries/AP_Generator/AP_Generator.cpp
+++ b/libraries/AP_Generator/AP_Generator.cpp
@@ -13,6 +13,8 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma GCC optimize("Os")
+
 #include "AP_Generator.h"
 
 #if HAL_GENERATOR_ENABLED

--- a/libraries/AP_Generator/AP_Generator_Backend.cpp
+++ b/libraries/AP_Generator/AP_Generator_Backend.cpp
@@ -12,6 +12,8 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#pragma GCC optimize("Os")
+
 #include "AP_Generator_Backend.h"
 
 #if HAL_GENERATOR_ENABLED

--- a/libraries/AP_Generator/AP_Generator_IE_2400.cpp
+++ b/libraries/AP_Generator/AP_Generator_IE_2400.cpp
@@ -13,6 +13,8 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma GCC optimize("Os")
+
 #include "AP_Generator_IE_2400.h"
 
 #if AP_GENERATOR_IE_2400_ENABLED

--- a/libraries/AP_Generator/AP_Generator_IE_650_800.cpp
+++ b/libraries/AP_Generator/AP_Generator_IE_650_800.cpp
@@ -13,6 +13,8 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma GCC optimize("Os")
+
 #include "AP_Generator_IE_650_800.h"
 
 #if AP_GENERATOR_IE_650_800_ENABLED

--- a/libraries/AP_Generator/AP_Generator_IE_FuelCell.cpp
+++ b/libraries/AP_Generator/AP_Generator_IE_FuelCell.cpp
@@ -13,6 +13,8 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma GCC optimize("Os")
+
 #include "AP_Generator_IE_FuelCell.h"
 
 #if AP_GENERATOR_IE_ENABLED

--- a/libraries/AP_Generator/AP_Generator_RichenPower.cpp
+++ b/libraries/AP_Generator/AP_Generator_RichenPower.cpp
@@ -13,6 +13,8 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma GCC optimize("Os")
+
 #include "AP_Generator_config.h"
 
 #if AP_GENERATOR_RICHENPOWER_ENABLED


### PR DESCRIPTION
```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeBlack                           -656   *           -664    -656              -664   -664   -656
CubeOrange-periph-heavy  *                                                                     
CubeOrangePlus                      -672   *           -664    -672              -672   -672   -664
CubeRedPrimary                      -32    *           -40     -40               -40    -40    -32
Durandal                            -664   *           -672    -664              -672   -672   -664
Hitec-Airspeed           *                                                                     
KakuteH7-bdshot                     -40    *           -32     -40               -40    -32    -32
MatekF405                           *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *                  *       *                 *      *      *
f103-QiotekPeriph        *                                                                     
f303-Universal           *                                                                     
iomcu                                                                *                         
revo-mini                           *      *           *       *                 *      *      *
skyviper-journey                                       -32                                     
skyviper-v2450                                         *                                       
111
