### PR TITLE
AP_NavEKF3: pos and vel resets default to user defined source

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -13,6 +13,26 @@
 // Do not reset vertical velocity using GPS as there is baro alt available to constrain drift
 void NavEKF3_core::ResetVelocity(resetDataSource velResetSource)
 {
+    // if reset source is not specified then use user defined velocity source
+    if (velResetSource == resetDataSource::DEFAULT) {
+        switch (frontend->sources.getVelXYSource()) {
+        case AP_NavEKF_Source::SourceXY::GPS:
+            velResetSource = resetDataSource::GPS;
+            break;
+        case AP_NavEKF_Source::SourceXY::BEACON:
+            velResetSource = resetDataSource::RNGBCN;
+            break;
+        case AP_NavEKF_Source::SourceXY::EXTNAV:
+            velResetSource = resetDataSource::EXTNAV;
+            break;
+        case AP_NavEKF_Source::SourceXY::NONE:
+        case AP_NavEKF_Source::SourceXY::OPTFLOW:
+        case AP_NavEKF_Source::SourceXY::WHEEL_ENCODER:
+            // unhandled sources so stick with the default
+            break;
+        }
+    }
+
     // Store the velocity before the reset so that we can record the reset delta
     velResetNE.x = stateStruct.velocity.x;
     velResetNE.y = stateStruct.velocity.y;
@@ -73,6 +93,26 @@ void NavEKF3_core::ResetVelocity(resetDataSource velResetSource)
 // resets position states to last GPS measurement or to zero if in constant position mode
 void NavEKF3_core::ResetPosition(resetDataSource posResetSource)
 {
+    // if reset source is not specified thenn use the user defined position source
+    if (posResetSource == resetDataSource::DEFAULT) {
+        switch (frontend->sources.getPosXYSource()) {
+        case AP_NavEKF_Source::SourceXY::GPS:
+            posResetSource = resetDataSource::GPS;
+            break;
+        case AP_NavEKF_Source::SourceXY::BEACON:
+            posResetSource = resetDataSource::RNGBCN;
+            break;
+        case AP_NavEKF_Source::SourceXY::EXTNAV:
+            posResetSource = resetDataSource::EXTNAV;
+            break;
+        case AP_NavEKF_Source::SourceXY::NONE:
+        case AP_NavEKF_Source::SourceXY::OPTFLOW:
+        case AP_NavEKF_Source::SourceXY::WHEEL_ENCODER:
+            // invalid sources so stick with the default
+            break;
+        }
+    }
+
     // Store the position before the reset so that we can record the reset delta
     posResetNE.x = stateStruct.position.x;
     posResetNE.y = stateStruct.position.y;


### PR DESCRIPTION
This resolves issue https://github.com/ArduPilot/ardupilot/issues/27729 by using the user defined position or velocity source (e.g. EK3_SRCx_POSXY, EK3_SRCx_VELXY) whenever the caller does not specify the source.

This solution is a minimal-change solution to the problem.  Another possible solution would be to remove ResetVelocity and ResetPosition's xxxResetSoiurce argument completely and instead always just use the user defined source.

This has been lightly tested in SITL to confirm that it resolves the issue.  Below are before and after screen shots of SITL testing where the Vicon has been turned 90degrees from reality.

Before we see terrible behaviour (even worse than described in [the issue](https://github.com/ArduPilot/ardupilot/issues/27729 )) where the lane switches every 7 seconds and the vehicle resets to the GPS location.  This results in the vehicle flying an ever expanding circle around the target at full speed
![before-map-and-console](https://github.com/user-attachments/assets/2cd2d311-3a45-496f-b3dc-2642670f1874)

After we see nearly twitch-less transitions between Optical flow and External Nav.  The two vehicles shown are the EKF's estimated position and the actual position and their positions are stable
![after-map-and-console](https://github.com/user-attachments/assets/98068474-2ce8-49ca-9b41-39f1a16a11d8)

