### PR TITLE
AP_HAL_ESP32: reduce scheduler stack sizes

### DIFF
--- a/libraries/AP_HAL_ESP32/Scheduler.h
+++ b/libraries/AP_HAL_ESP32/Scheduler.h
@@ -85,16 +85,16 @@ public:
     static const int IO_PRIO      = 5;
     static const int STORAGE_PRIO = 4;
 
-    static const int TIMER_SS 	  = 4096;
-    static const int MAIN_SS      = 8192;
-    static const int RCIN_SS      = 4096;
-    static const int RCOUT_SS     = 4096;
-    static const int WIFI_SS1     = 6192;
-    static const int WIFI_SS2     = 6192;
-    static const int UART_SS      = 2048;
-    static const int DEVICE_SS    = 4096;
-    static const int IO_SS        = 4096;
-    static const int STORAGE_SS   = 8192;
+    static const int TIMER_SS   = 1024*3;
+    static const int MAIN_SS    = 1024*5;
+    static const int RCIN_SS    = 1024*3;
+    static const int RCOUT_SS   = 1024*1.5;
+    static const int WIFI_SS1    = 1024*2.25;
+    static const int WIFI_SS2    = 1024*2.25;
+    static const int UART_SS    = 1024*2.25;
+    static const int DEVICE_SS  = 1024*4;   //       (DEVICEBUS/s)
+    static const int IO_SS      = 1024*3.5; //       (APM_IO)
+    static const int STORAGE_SS = 1024*2;   //       (APM_STORAGE)
 
 private:
     AP_HAL::HAL::Callbacks *callbacks;

--- a/libraries/AP_HAL_ESP32/Scheduler.h
+++ b/libraries/AP_HAL_ESP32/Scheduler.h
@@ -85,16 +85,16 @@ public:
     static const int IO_PRIO      = 5;
     static const int STORAGE_PRIO = 4;
 
-    static const int TIMER_SS   = 1024*3;
-    static const int MAIN_SS    = 1024*5;
-    static const int RCIN_SS    = 1024*3;
-    static const int RCOUT_SS   = 1024*1.5;
-    static const int WIFI_SS1    = 1024*2.25;
-    static const int WIFI_SS2    = 1024*2.25;
-    static const int UART_SS    = 1024*2.25;
-    static const int DEVICE_SS  = 1024*4;   //       (DEVICEBUS/s)
-    static const int IO_SS      = 1024*3.5; //       (APM_IO)
-    static const int STORAGE_SS = 1024*2;   //       (APM_STORAGE)
+    static const int TIMER_SS     = 1024*3;
+    static const int MAIN_SS      = 1024*5;
+    static const int RCIN_SS      = 1024*3;
+    static const int RCOUT_SS     = 1024*1.5;
+    static const int WIFI_SS1     = 1024*2.25;
+    static const int WIFI_SS2     = 1024*2.25;
+    static const int UART_SS      = 1024*2.25;
+    static const int DEVICE_SS    = 1024*4;     // DEVICEBUS/s
+    static const int IO_SS        = 1024*3.5;   // APM_IO
+    static const int STORAGE_SS   = 1024*2;     // APM_STORAGE
 
 private:
     AP_HAL::HAL::Callbacks *callbacks;


### PR DESCRIPTION
Breaking out https://github.com/ArduPilot/ardupilot/commit/2f86e145a83d0c07dfe60880a866aedf0266f41b from @davidbuzz's larger PR https://github.com/ArduPilot/ardupilot/pull/28514 and adding minor alignment formatting.

| name | prev | new | change |
| --- | --- | --- | --- |
| TIMER_SS | 4096 | 1024*3 | -1024 |
| MAIN_SS | 8192 | 1024*5 | -3072 |
| RCIN_SS | 4096 | 1024*3 | -1024 |
| RCOUT_SS | 4096 | 1024*1.5 | -2560 |
| WIFI_SS1 | 6192 | 1024*2.25 | -3888 |
| WIFI_SS2 | 6192 | 1024*2.25 | -3888 |
| UART_SS | 2048 | 1024*2.25 | -256 |
| DEVICE_SS | 4096 | 1024*4 | 0 |
| IO_SS | 4096 | 1024*3.5 | -512 |
| STORAGE_SS | 8192 | 1024*2 | -6144 |

### Testing

- Tested on esp32 (esp32empty) and esp32s3 (esp32s2stampfly).
