### PR TITLE
AP_Soaring: Use constexpr instead of define for constants

### DIFF
--- a/libraries/AP_Soaring/AP_Soaring.h
+++ b/libraries/AP_Soaring/AP_Soaring.h
@@ -23,10 +23,10 @@
 #include "Variometer.h"
 #include "SpeedToFly.h"
 
-#define INITIAL_THERMAL_RADIUS 80.0
-#define INITIAL_STRENGTH_COVARIANCE 0.0049
-#define INITIAL_RADIUS_COVARIANCE 400.0
-#define INITIAL_POSITION_COVARIANCE 400.0
+static constexpr float INITIAL_THERMAL_RADIUS = 80.0;
+static constexpr float INITIAL_STRENGTH_COVARIANCE = 0.0049;
+static constexpr float INITIAL_RADIUS_COVARIANCE = 400.0;
+static constexpr float INITIAL_POSITION_COVARIANCE = 400.0;
 
 
 class SoaringController {


### PR DESCRIPTION
# Purpose

Switch to constexpr floats instead of defines which provide better compile time safety and editor support.

# Editor Support (VSCode)
## Before
![image](https://github.com/user-attachments/assets/558f8447-83d2-4280-ab41-fecbbf0a1df6)

## After

You can see it's a float now.

![image](https://github.com/user-attachments/assets/ce5897cb-6a39-4ef0-b03f-c0e9a223a76d)
