### PR TITLE
AP_RangeFinder: alphabetise type parm docs

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
@@ -14,6 +14,7 @@ const AP_Param::GroupInfo AP_RangeFinder_Params::var_info[] = {
     // @Param: TYPE
     // @DisplayName: Rangefinder type
     // @Description: Type of connected rangefinder
+    // @SortValues: AlphabeticalZeroAtTop
     // @Values: 0:None,1:Analog,2:MaxbotixI2C,3:LidarLite-I2C,5:PWM,6:BBB-PRU,7:LightWareI2C,8:LightWareSerial,9:Bebop,10:MAVLink,11:USD1_Serial,12:LeddarOne,13:MaxbotixSerial,14:TeraRangerI2C,15:LidarLiteV3-I2C,16:VL53L0X or VL53L1X,17:NMEA,18:WASP-LRF,19:BenewakeTF02,20:Benewake-Serial,21:LidarLightV3HP,22:PWM,23:BlueRoboticsPing,24:DroneCAN,25:BenewakeTFminiPlus-I2C,26:LanbaoPSK-CM8JL65-CC5,27:BenewakeTF03,28:VL53L1X-ShortRange,29:LeddarVu8-Serial,30:HC-SR04,31:GYUS42v2,32:MSP,33:USD1_CAN,34:Benewake_CAN,35:TeraRangerSerial,36:Lua_Scripting,37:NoopLoop_TOFSense,38:NoopLoop_TOFSense_CAN,39:NRA24_CAN,40:NoopLoop_TOFSenseF_I2C,41:JRE_Serial,42:Ainstein_LR_D1,43:RDS02UF,100:SITL
     // @User: Standard
     AP_GROUPINFO_FLAGS("TYPE", 1, AP_RangeFinder_Params, type, 0, AP_PARAM_FLAG_ENABLE),


### PR DESCRIPTION
This sorts the list of rangefinders alphabetically which I hope will make it easier for users to find which one they want in the long list.  The only imperfection is perhaps 100:SITL appearing near the bottom instead of right at the bottom.

If people don't like this I could manually re-order them.


<html>
<body>

Before | After
-- | --
0:None | 0:None
1:Analog | 42:Ainstein_LR_D1
2:MaxbotixI2C | 1:Analog
3:LidarLite-I2C | 6:BBB-PRU
5:PWM | 9:Bebop
6:BBB-PRU | 34:Benewake_CAN
7:LightWareI2C | 20:Benewake-Serial
8:LightWareSerial | 19:BenewakeTF02
9:Bebop | 27:BenewakeTF03
10:MAVLink | 25:BenewakeTFminiPlus-I2C
11:USD1_Serial | 23:BlueRoboticsPing
12:LeddarOne | 24:DroneCAN
13:MaxbotixSerial | 31:GYUS42v2
14:TeraRangerI2C | 30:HC-SR04
15:LidarLiteV3-I2C | 41:JRE_Serial
16:VL53L0X or VL53L1X | 26:LanbaoPSK-CM8JL65-CC5
17:NMEA | 12:LeddarOne
18:WASP-LRF | 29:LeddarVu8-Serial
19:BenewakeTF02 | 21:LidarLightV3HP
20:Benewake-Serial | 3:LidarLite-I2C
21:LidarLightV3HP | 15:LidarLiteV3-I2C
22:PWM | 7:LightWareI2C
23:BlueRoboticsPing | 8:LightWareSerial
24:DroneCAN | 36:Lua_Scripting
25:BenewakeTFminiPlus-I2C | 10:MAVLink
26:LanbaoPSK-CM8JL65-CC5 | 2:MaxbotixI2C
27:BenewakeTF03 | 13:MaxbotixSerial
28:VL53L1X-ShortRange | 32:MSP
29:LeddarVu8-Serial | 17:NMEA
30:HC-SR04 | 37:NoopLoop_TOFSense
31:GYUS42v2 | 38:NoopLoop_TOFSense_CAN
32:MSP | 40:NoopLoop_TOFSenseF_I2C
33:USD1_CAN | 39:NRA24_CAN
34:Benewake_CAN | 5:PWM
35:TeraRangerSerial | 22:PWM
36:Lua_Scripting | 43:RDS02UF
37:NoopLoop_TOFSense | 100:SITL
38:NoopLoop_TOFSense_CAN | 14:TeraRangerI2C
39:NRA24_CAN | 35:TeraRangerSerial
40:NoopLoop_TOFSenseF_I2C | 33:USD1_CAN
41:JRE_Serial | 11:USD1_Serial
42:Ainstein_LR_D1 | 16:VL53L0X or VL53L1X
43:RDS02UF | 28:VL53L1X-ShortRange
100:SITL | 18:WASP-LRF


</body>

</html>
