### PR TITLE
AP_ExternalControl: Only enable external control when DDS is enabled

### DIFF
--- a/libraries/AP_ExternalControl/AP_ExternalControl_config.h
+++ b/libraries/AP_ExternalControl/AP_ExternalControl_config.h
@@ -2,9 +2,10 @@
 
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL_Boards.h>
+#include <AP_DDS/AP_DDS_config.h>
 
 #ifndef AP_EXTERNAL_CONTROL_ENABLED
-#define AP_EXTERNAL_CONTROL_ENABLED 1
+#define AP_EXTERNAL_CONTROL_ENABLED AP_DDS_ENABLED
 #endif
 
 


### PR DESCRIPTION
# Purpose

Only enable external control when it's needed by DDS. We don't want AP_ExternalControl taking up flash unless it's called. 

# Details

* https://github.com/ArduPilot/ardupilot/pull/28429#issuecomment-2495139799
* https://github.com/ArduPilot/ardupilot/pull/26911#issuecomment-2495131562

