### PR TITLE
AP_HAL_ESP32: disable define of HAL_ESP32_RCIN on esp32empty

### DIFF
--- a/libraries/AP_HAL_ESP32/boards/esp32empty.h
+++ b/libraries/AP_HAL_ESP32/boards/esp32empty.h
@@ -78,8 +78,10 @@
 //SPI Devices
 #define HAL_ESP32_SPI_DEVICES {}
 
-//RCIN
-#define HAL_ESP32_RCIN GPIO_NUM_36
+//RMT pin number
+#define HAL_ESP32_RMT_RX_PIN_NUMBER 4
+//RCIN pin number - NOTE: disabled due to issue with legacy rmt library.
+// #define HAL_ESP32_RCIN GPIO_NUM_36
 
 //RCOUT
 #define HAL_ESP32_RCOUT {GPIO_NUM_25, GPIO_NUM_27, GPIO_NUM_33, GPIO_NUM_32, GPIO_NUM_22, GPIO_NUM_21}
@@ -123,9 +125,6 @@
 
 //LED
 #define DEFAULT_NTF_LED_TYPES Notify_LED_None
-
-//RMT pin number
-#define HAL_ESP32_RMT_RX_PIN_NUMBER 4
 
 //SD CARD
 // Do u want to use mmc or spi mode for the sd card, this is board specific,


### PR DESCRIPTION
`RMTSigReader` uses the legacy `rmt` library which is repeatedly reporting a `RMT RX BUFFER FULL` error.

Comment the `#define HAL_ESP32_RCIN` line in `esp32empty.h` to provid a temporary resolution. A full fix probably requires updating `RMTSigReader` to use the esp-idf 5.3.1 version of the `rmt` library.

### Reproduce

Build for esp32empty

```bash
$ ./waf configure --board esp32empty --debug
$ ESPBAUD=921600 ./waf copter --upload 
```

Inspect console:

```bash
$ screen /dev/cu.usbserial-0001 115200

Init ArduCopter V4.7.0-dev (1b4ac6ae)

Free RAM: 110592
OK created task _main_thread on FASTCPU
OK created task _timer_thread on FASTCPU
OK created task _rcout_thread on SLOWCPU
OK created task _rcin_thread on SLOWCPU
I (1586) wifi:wifi driver task: 3ffe7f30, prio:23, stack:6656, core=1
OK created task _uart_thread on FASTCPU
OK created task _io_thread on SLOWCPU
OK created task _storage_thread
I (1600) wifi:wifi firmware version: ccaebfaI (1603) main_task: Returned from ap
p_main()

I (1612) wifi:wifi certification version: v7.0
I (1616) wifi:config NVS flash: enabled
I (1619) wifi:config nano formating: disabled
I (1623) wifi:Init data frame dynamic rx buffer num: 16
I (1628) wifi:Init static rx mgmt buffer num: 5
I (1633) wifi:Init management short buffer num: 32
I (1637) wifi:Init dynamic tx buffer num: 16
I (1641) wifi:Init static rx buffer size: 1600
I (1645) wifi:Init static rx buffer num: 2
I (1649) wifi:Init dynamic rx buffer num: 16
No sdcard setup.
I (1654) wifi_init: rx ba win: 4
I (1658) wifi_init: accept mbox: 6
I (1663) wifi_init: tcpip mbox: 32
I (1667) wifi_init: udp mbox: 6
I (1670) wifi_init: tcp mbox: 6
I (1674) wifi_init: tcp tx win: 5744
I (1679) wifi_init: tcp rx win: 5744
I (1683) wifi_init: tcp mss: 1436
I (1687) wifi_init: WiFi IRAM OP enabled
I (1691) wifi_init: WiFi RX IRAM OP enabled
I (1700) phy_init: phy_version 4830,54550f7,Jun 20 2024,14:22:08
I (1771) wifi:mode : softAP (b2:b2:1c:97:a6:9c)
I (1774) wifi:Total power save buffer number: 8
I (1774) wifi:Init max length of beacon: 752/752
I (1775) wifi:Init max length of beacon: 752/752
WiFi softAP init finished. SSID: ardupilot-esp32 password: ardupilot-esp32 channel: 1
OK created task _wifi_thread for TCP with PORT 5760 on SLOWCPU
I (1794) esp_netif_lwip: DHCP server started on interface WIFI_AP_DEF with IP: 192.168.4.1
Init Gyro**
Suggested EK3_DRAG_BCOEF_* = 17.209, EK3_DRAG_MCOEF = 0.209
Home: -35.363262 149.165237 alt=584.000000m hdg=353.000000
Smoothing reset at 0.001
loop_rate: actual: 150.000000Hz, expected: 150Hz
E rmt(legacy): RMT RX BUFFER FULL
E rmt(legacy): RMT RX BUFFER FULL
```
