### PR TITLE
AP_HAL_ESP32: UART driver tweaks and making closer in shape to chibios

### DIFF
--- a/libraries/AP_HAL_ESP32/UARTDriver.h
+++ b/libraries/AP_HAL_ESP32/UARTDriver.h
@@ -39,9 +39,8 @@ public:
 
     UARTDriver(uint8_t serial_num);
 
-    /* todo Do not allow copies */
-    //UARTDriver(const UARTDriver &other) = delete;
-    //UARTDriver &operator=(const UARTDriver&) = delete;
+    /* Do not allow copies */
+    CLASS_NO_COPY(UARTDriver);
 
     virtual ~UARTDriver() = default;
 
@@ -104,18 +103,17 @@ private:
     void read_data();
     void write_data();
 
-    uint8_t uart_num;
-    HAL_Semaphore sem;
+    HAL_Semaphore _sem;
 
     // table to find UARTDrivers from serial number, used for event handling
-    static UARTDriver *uart_drivers[UART_MAX_DRIVERS];
+    static UARTDriver *serial_drivers[UART_MAX_DRIVERS];
 
     // unused stuff from chibios - do we want it in the future?
     //const SerialDef &sdef;
     //static const SerialDef _serial_tab[];
 
-    // index into uart_drivers table
-    uint8_t serial_num;
+    // index into serial_drivers table
+    uint8_t _serial_num;
 
     // timestamp for receiving data on the UART, avoiding a lock
     uint64_t _receive_timestamp[2];
@@ -123,7 +121,6 @@ private:
     uint32_t _baudrate;
 
     void _receive_timestamp_update(void);
-    void begin(uint32_t b, uint16_t rxS, uint16_t txS) ;
 
 protected:
     void _begin(uint32_t b, uint16_t rxS, uint16_t txS) override;


### PR DESCRIPTION
Break out https://github.com/ArduPilot/ardupilot/pull/28514/commits/9e0ada6db14467bb65324b2017364b0015be7bed from @davidbuzz's larger PR https://github.com/ArduPilot/ardupilot/pull/28514 and apply fixes.

## Testing

Tested on `esp32empty`. The console print in `UARTDriver::_begin` is suppressed because the message is displayed repeatedly for `UART1 = SERIAL3` (default params set SERIAL3_PROTOCOL = 5 (GPS), which is not available).