### PR TITLE
hwdef: remove 'HAL_WATCHDOG_ENABLED_DEFAULT true' from periphs

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/Sierra-F405/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Sierra-F405/hwdef.dat
@@ -19,9 +19,6 @@ env AP_PERIPH 1
 define STM32_ST_USE_TIMER 5
 define CH_CFG_ST_RESOLUTION 32
 
-# enable watchdog
-define HAL_WATCHDOG_ENABLED_DEFAULT true
-
 # crystal frequency
 OSCILLATOR_HZ 16000000
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/Sierra-F412/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Sierra-F412/hwdef.dat
@@ -20,9 +20,6 @@ env AP_PERIPH 1
 
 STM32_ST_USE_TIMER 5
 
-# enable watchdog
-define HAL_WATCHDOG_ENABLED_DEFAULT true
-
 # crystal frequency
 OSCILLATOR_HZ 16000000
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/Sierra-F9P/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Sierra-F9P/hwdef.dat
@@ -20,9 +20,6 @@ env AP_PERIPH 1
 
 STM32_ST_USE_TIMER 5
 
-# enable watchdog
-define HAL_WATCHDOG_ENABLED_DEFAULT true
-
 # crystal frequency
 OSCILLATOR_HZ 16000000
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/mRo-M10095/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/mRo-M10095/hwdef.dat
@@ -18,9 +18,6 @@ define HAL_STORAGE_SIZE 800
 # setup build for a peripheral firmware
 env AP_PERIPH 1
 
-# enable watchdog
-define HAL_WATCHDOG_ENABLED_DEFAULT true
-
 # crystal frequency
 OSCILLATOR_HZ 8000000
 


### PR DESCRIPTION
this is the default for peripherals

```
Board,AP_Periph
Sierra-F405,*
Sierra-F412,*
Sierra-F9P,*
mRo-M10095,*
```
