### PR TITLE
AC_Fence: fixed 2 regressions from 4.5.x

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1728,6 +1728,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "FENCE_ALT_MIN": 20,
             "FENCE_ACTION": 0,
         })
+        self.reboot_sitl()
 
         self.takeoff(30, mode="LOITER")
         """Hold loiter position."""

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1719,8 +1719,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
     # Also check that the vehicle will not try and ascend too fast when trying to backup from a min alt fence due to avoidance
     def MinAltFenceAvoid(self):
         '''Test Min Alt Fence Avoidance'''
-        self.takeoff(30, mode="LOITER")
-        """Hold loiter position."""
 
         # enable fence, only min altitude
         # No action, rely on avoidance to prevent the breach
@@ -1730,6 +1728,9 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "FENCE_ALT_MIN": 20,
             "FENCE_ACTION": 0,
         })
+
+        self.takeoff(30, mode="LOITER")
+        """Hold loiter position."""
 
         # Try and fly past the fence
         self.set_rc(3, 1120)

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -3696,20 +3696,23 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.set_rc(3, 1500)
         self.change_altitude(cruise_alt, relative=True)
 
-        self.progress("Fly below floor and check for no breach")
-        self.change_altitude(25, relative=True)
+        self.progress("Fly below floor and check for breach")
+        self.set_rc(2, 2000)
+        self.wait_mode("RTL")
         m = self.mav.recv_match(type='SYS_STATUS', blocking=True)
         self.progress("Got (%s)" % str(m))
-        if (not (m.onboard_control_sensors_health & fence_bit)):
-            raise NotAchievedException("Fence Ceiling breached")
+        if (m.onboard_control_sensors_health & fence_bit):
+            raise NotAchievedException("Fence floor not breached")
 
-        self.progress("Fly above floor and check fence is not re-enabled")
+        self.change_mode("FBWA")
+
+        self.progress("Fly above floor and check fence is enabled")
         self.set_rc(3, 2000)
         self.change_altitude(75, relative=True)
         m = self.mav.recv_match(type='SYS_STATUS', blocking=True)
         self.progress("Got (%s)" % str(m))
-        if (m.onboard_control_sensors_enabled & fence_bit):
-            raise NotAchievedException("Fence Ceiling re-enabled")
+        if (not (m.onboard_control_sensors_enabled & fence_bit)):
+            raise NotAchievedException("Fence Floor not enabled")
 
         self.progress("Return to cruise alt")
         self.set_rc(3, 1500)

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -250,16 +250,17 @@ uint8_t AC_Fence::enable(bool value, uint8_t fence_types, bool update_auto_mask)
         enabled_fences &= ~fences;
     }
 
-    // fences that were manually changed are no longer eligible for auto-enablement or disablement
-    if (update_auto_mask) {
-        _auto_enable_mask &= ~fences;
-    }
-
     uint8_t fences_to_change = _enabled_fences ^ enabled_fences;
 
     if (!fences_to_change) {
         return 0;
     }
+
+    // fences that were manually changed are no longer eligible for auto-enablement or disablement
+    if (update_auto_mask) {
+        _auto_enable_mask &= ~fences_to_change;
+    }
+
 #if HAL_LOGGING_ENABLED
     AP::logger().Write_Event(value ? LogEvent::FENCE_ENABLE : LogEvent::FENCE_DISABLE);
     if (fences_to_change & AC_FENCE_TYPE_ALT_MAX) {

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -524,7 +524,7 @@ bool AC_Fence::check_fence_alt_max()
 
     float alt;
     AP::ahrs().get_relative_position_D_home(alt);
-    _curr_alt = -alt; // translate Down to Up
+    const float _curr_alt = -alt; // translate Down to Up
 
     // check if we are over the altitude fence
     if (_curr_alt >= _alt_max) {
@@ -573,7 +573,7 @@ bool AC_Fence::check_fence_alt_min()
 
     float alt;
     AP::ahrs().get_relative_position_D_home(alt);
-    _curr_alt = -alt; // translate Down to Up
+    const float _curr_alt = -alt; // translate Down to Up
 
     // check if we are under the altitude fence
     if (_curr_alt <= _alt_min) {
@@ -625,7 +625,7 @@ bool AC_Fence::auto_enable_fence_floor()
 
     float alt;
     AP::ahrs().get_relative_position_D_home(alt);
-    _curr_alt = -alt; // translate Down to Up
+    const float _curr_alt = -alt; // translate Down to Up
 
     // check if we are over the altitude fence
     if (!floor_enabled() && _curr_alt >= _alt_min + _margin) {

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -249,7 +249,6 @@ private:
     float           _circle_breach_distance;    // distance beyond the circular fence
 
     // other internal variables
-    uint8_t         _auto_enable_mask = AC_FENCE_ALL_FENCES;  // fences that can be auto-enabled or auto-disabled
     float           _home_distance;         // distance from home in meters (provided by main code)
 
     // breach information

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -251,8 +251,6 @@ private:
     // other internal variables
     uint8_t         _auto_enable_mask = AC_FENCE_ALL_FENCES;  // fences that can be auto-enabled or auto-disabled
     float           _home_distance;         // distance from home in meters (provided by main code)
-    float           _curr_alt;
-
 
     // breach information
     uint8_t         _breached_fences;       // bitmask holding the fence type that was breached (i.e. AC_FENCE_TYPE_ALT_MIN, AC_FENCE_TYPE_CIRCLE)

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -259,6 +259,13 @@ private:
 
     uint32_t        _manual_recovery_start_ms;  // system time in milliseconds that pilot re-took manual control
 
+    enum class MinAltState
+    {
+        DEFAULT = 0,
+        MANUALLY_ENABLED,
+        MANUALLY_DISABLED
+    } _min_alt_state;
+    
 
     AC_PolyFence_loader _poly_loader{_total, _options}; // polygon fence
 };


### PR DESCRIPTION
This fixes 2 regressions in fence behaviour since 4.5.x.
- we had lost the pre-arm check on being inside the polygon fence for FENCE_AUTOENABLE=3
- if the user has both a RCn_OPTION=11 (FENCE) and FENCE_AUTOENABLE=3 then the autoenable did not happen
