### PR TITLE
Tools: update WSL2 use in uploader.py

### DIFF
--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -103,7 +103,7 @@ class upload_fw(Task.Task):
         except subprocess.CalledProcessError:
             #if where.exe can't find the file it returns a non-zero result which throws this exception
             where_python = ""
-        if not where_python or "\Python\Python" not in where_python or "python.exe" not in where_python:
+        if "python.exe" not in where_python:
             print(self.get_full_wsl2_error_msg("Windows python.exe not found"))
             return False
         return True


### PR DESCRIPTION
I just got a new Windows 11 computer and did a fresh WSL2 install and could not push a binary to USB because "Python/Python" wasn't in the python.exe path. Not sure why that's in there, maybe it's because I installed 3.13 on the Windows side. Anyways, it's a stricter check that is unnecessary, all we care about is if we can call python.exe.