### PR TITLE
.github: remove mantic test from environnement testing EOL

### DIFF
--- a/.github/workflows/test_environment.yml
+++ b/.github/workflows/test_environment.yml
@@ -33,8 +33,6 @@ jobs:
           - os: ubuntu
             name: jammy
           - os: ubuntu
-            name: mantic
-          - os: ubuntu
             name: noble
           - os: archlinux
             name: latest


### PR DESCRIPTION
mantic is EOL since July but the apt repo aren't working anymore