### PR TITLE
Feature/GitHub clean

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -3318,7 +3318,7 @@ class TestSuite(ABC):
             os.link(self.logfile, self.buildlog)
         except OSError as error:
             self.progress("OSError [%d]: %s" % (error.errno, error.strerror))
-            self.progress("WARN: Failed to create link: %s => %s, "
+            self.progress("Problem: Failed to create link: %s => %s, "
                           "will copy tlog manually to target location" %
                           (self.logfile, self.buildlog))
             self.copy_tlog = True

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -62,7 +62,7 @@ function install_mavproxy() {
         popd
         mavproxy_installed=1
         # now uninstall the version of pymavlink pulled in by MAVProxy deps:
-        python3 -m pip uninstall -y pymavlink
+        python3 -m pip uninstall -y pymavlink --cache-dir /tmp/pip-cache
     fi
 }
 


### PR DESCRIPTION
fix a pip warning on CI
use a tag to not catch false issue on github. in this case, it prevents spamming from the log symlink failure.