### PR TITLE
AP_NavEKFx: apply -O2 to AP_NavEKFx.h

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1,6 +1,6 @@
-#include "AP_NavEKF2.h"
-
 #include "AP_NavEKF2_core.h"
+
+#include "AP_NavEKF2.h"
 
 #include <AP_DAL/AP_DAL.h>
 #include <AP_HAL/AP_HAL.h>

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1,8 +1,9 @@
+#include "AP_NavEKF3_core.h"
+
 #include "AP_NavEKF3.h"
 
 #include <AP_HAL/AP_HAL.h>
 
-#include "AP_NavEKF3_core.h"
 #include <GCS_MAVLink/GCS.h>
 #include <AP_Logger/AP_Logger.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>


### PR DESCRIPTION
the core.h file adjusts the optimisation level; use it when including the AP_NavEKFx.h header file

this should be done consistently across the .cpp files to ensure everything is compiled with the same optimisation level.

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                                                     
Durandal                            -80    *           -72     -72               -72    -80    -80
Hitec-Airspeed           *                                                                     
KakuteH7-bdshot                     -96    *           -88     -88               -88    -88    -88
MatekF405                           -72    *           -64     -64               -64    -64    -64
Pixhawk1-1M-bdshot                  -64                -64     -56               -56    -56    -56
f103-QiotekPeriph        *                                                                     
f303-Universal           *                                                                     
iomcu                                                                *                         
revo-mini                           -72    *           -64     -64               -64    -64    -64
skyviper-v2450                                         -64                                     
```
