### PR TITLE
autotest: Enabled old test and added new test on home alt reset

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -6185,14 +6185,18 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
     def SetHomeAltChange(self):
         '''check modes retain altitude when home alt changed'''
         for mode in 'FBWB', 'CRUISE', 'LOITER':
+            self.set_rc(3, 1000)
             self.wait_ready_to_arm()
             home = self.home_position_as_mav_location()
-            self.takeoff(20)
-            higher_home = home
+            target_alt = 20
+            self.takeoff(target_alt, mode="TAKEOFF")
+            self.delay_sim_time(20)  # Give some time to altitude to stabilize.
+            self.set_rc(3, 1500)
+            self.change_mode(mode)
+            higher_home = copy.copy(home)
             higher_home.alt += 40
             self.set_home(higher_home)
-            self.change_mode(mode)
-            self.wait_altitude(15, 25, relative=True, minimum_duration=10)
+            self.wait_altitude(home.alt+target_alt-5, home.alt+target_alt+5, relative=False, minimum_duration=10, timeout=11)
             self.disarm_vehicle(force=True)
             self.reboot_sitl()
 
@@ -6225,6 +6229,23 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         # Test if the altitude is still within bounds.
         self.wait_altitude(home.alt+target_alt-5, home.alt+target_alt+5, relative=False, minimum_duration=1, timeout=2)
+        self.disarm_vehicle(force=True)
+        self.reboot_sitl()
+
+    def SetHomeAltChange3(self):
+        '''same as SetHomeAltChange, but the home alt change occurs during TECS operation'''
+        self.wait_ready_to_arm()
+        home = self.home_position_as_mav_location()
+        target_alt = 20
+        self.takeoff(target_alt, mode="TAKEOFF")
+        self.change_mode("LOITER")
+        self.delay_sim_time(20) # Let the plane settle.
+
+        higher_home = copy.copy(home)
+        higher_home.alt += 40
+        self.set_home(higher_home)
+        self.wait_altitude(home.alt+target_alt-5, home.alt+target_alt+5, relative=False, minimum_duration=10, timeout=10.1)
+
         self.disarm_vehicle(force=True)
         self.reboot_sitl()
 
@@ -6497,6 +6518,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.GPSPreArms,
             self.SetHomeAltChange,
             self.SetHomeAltChange2,
+            self.SetHomeAltChange3,
             self.ForceArm,
             self.MAV_CMD_EXTERNAL_WIND_ESTIMATE,
             self.GliderPullup,
@@ -6508,7 +6530,6 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             "LandingDrift": "Flapping test. See https://github.com/ArduPilot/ardupilot/issues/20054",
             "InteractTest": "requires user interaction",
             "ClimbThrottleSaturation": "requires https://github.com/ArduPilot/ardupilot/pull/27106 to pass",
-            "SetHomeAltChange": "https://github.com/ArduPilot/ardupilot/issues/5672",
         }
 
 


### PR DESCRIPTION
# Summary

Regarding Plane tests on Home Alt change during flight:
- Enabled old disabled test that was already passing, but was malformed.
- Created new test variant, where the altitude change occurs during stable level flight.

# Details

## Old test

The existing test should be passing since https://github.com/ArduPilot/ardupilot/pull/24487, but it was malformed. It should be checking for the absolute altitude to be constant. The relative one is supposed to change.

Additionally, before it would perform an FBWA takeoff and would switch to FBWB/CRUISE/LOITER at an altitude that might not be exactly takeoff alt. Since these modes reset the altitude setpoint upon entry, it would be hard to test for a specific altitude.
Now the takeoff happens upon TAKEOFF mode, waits for the altitude to settle and then switches the mode.
@peterbarker let me know if you had intended for this autotest to test something different.

## New test

The new test tries to make the check a bit more explicit, by doing the Home alt change during a stable, level flight, instead of the end of the takeoff climb.

# Testing

## Before

The new test was passing even before https://github.com/ArduPilot/ardupilot/pull/28675, as expected.
The cursor is at the moment of Home Alt change.

The TECS altitude was correctly changed:
![Screenshot from 2024-11-27 12-19-15](https://github.com/user-attachments/assets/38bf3bee-aaa9-497f-a67a-99df3e117bed)

TECS was getting reset, as expected:
![Screenshot from 2024-11-27 12-19-23](https://github.com/user-attachments/assets/b20c52a6-8002-4588-bee6-9447a2d30796)

The absolute altitude was roughly stable, but the TECS reset caused a dampened oscillation:
![Screenshot from 2024-11-27 12-19-19](https://github.com/user-attachments/assets/791565a5-f8ca-4c5b-bbd8-9e8404b1de1f)

## After

After https://github.com/ArduPilot/ardupilot/pull/28675 TECS is shifting again:
![Screenshot from 2024-11-27 12-20-48](https://github.com/user-attachments/assets/18ee121f-f87e-4500-80f4-104bb324536d)

but TECS does not reset:
![Screenshot from 2024-11-27 12-20-55](https://github.com/user-attachments/assets/d9d3526c-57c6-487c-ac70-97279b86f902)

and the altitude does not have a transient anymore:
![Screenshot from 2024-11-27 12-20-51](https://github.com/user-attachments/assets/cf922f6f-daa0-4b11-bb36-d1dfc90ed7de)
