### PR TITLE
AP_HAL_ESP32: reduce sdcard mount config max_files

### DIFF
--- a/libraries/AP_HAL_ESP32/SdCard.cpp
+++ b/libraries/AP_HAL_ESP32/SdCard.cpp
@@ -207,7 +207,7 @@ void mount_sdcard_spi()
     ESP_LOGI(TAG, "Initializing SD card as SDSPI");
     esp_vfs_fat_sdmmc_mount_config_t mount_config = {
         .format_if_mount_failed = false,
-        .max_files = 10,
+        .max_files = 5,
         .allocation_unit_size = 16 * 1024
     };
 


### PR DESCRIPTION
Reduce the `esp_vfs_fat_sdmmc_mount_config_t` `max_files` from 10 to 5 to prevent a malloc failure. 

### How to replicate

- Chip: ESP32-D0WD-V3 (revision v3.1) 
- Board: `esp32empty` modified to enable SDCard with

```bash
#define HAL_ESP32_SDCARD 1
#define HAL_ESP32_SDSPI {.host=HSPI_HOST, .dma_ch=1, .mosi=GPIO_NUM_13, .miso=GPIO_NUM_15, .sclk=GPIO_NUM_14, .cs=GPIO_NUM_4}
```

The console trace below illustrates the issue (additional printf's added to `vfs_fat.c`):

```bash
Init ArduCopter V4.7.0-dev (b7ace6c6)

Free RAM: 110592
OK created task _main_thread on FASTCPU
I (2172) wifi:wifi driver task: 3ffe7264, prio:23, stack:6656, core=0
I (2172) wifi:wifi firmware version: ccaebfa
I (2174) wifi:wifi certification version: v7.0
I (2178) wifi:config NVS flash: disabled
I (2182) wifi:config nano formating: disabled
I (2186) wifi:Init data frame dynamic rx buffer num: 16
I (2190) wifi:Init static rx mgmt buffer num: 5
I (2194) wifi:Init management short buffer num: 32
I (2200) wifi:Init dynamic tx buffer num: 16
I (2204) wifi:Init static rx buffer size: 1600
I (2208) wifi:Init static rx buffer num: 2
I (2212) wifi:Init dynamic rx buffer num: 16
I (2216) wifi_init: accept mbox: 6
I (2220) wifi_init: tcpip mbox: 32
I (2224) wifi_init: udp mbox: 6
I (2228) wifi_init: tcp mbox: 6
I (2230) wifi_init: tcp tx win: 5744
I (2236) wifi_init: tcp rx win: 5744
I (2240) wifi_init: tcp mss: 1436
I (2244) wifi_init: WiFi RX IRAM OP enabled
I (2484) phy_init: phy_version 4830,54550f7,Jun 20 2024,14:22:08
I (2552) wifi:mode : softAP (b2:b2:1c:97:a6:9c)
I (2554) wifi:Total power save buffer number: 8
I (2554) wifi:Init max length of beacon: 752/752
I (2554) wifi:Init max length of beacon: 752/752
WiFi softAP init finished. SSID: ardupilot-esp32 password: ardupilot-esp32 channel: 1
OK created task _wifi_thread for TCP with PORT 5760 on SLOWCPU
I (2574) esp_netif_lwip: DHCP server started on interface WIFI_AP_DEF with IP: 192.168.4.1
OK created task _timer_thread on FASTCPU
OK created task _rcout_thread on SLOWCPU
OK created task _rcin_thread on SLOWCPU
OK created task _uart_thread on FASTCPU
OK created task _io_thread on SLOWCPU
sdcard: mounting sdcard as sdspi
OK created task _storage_thread
I (2618) SD...: Initializing SD card as SDSPI
I (2620) main_task: Returned from app_main()
sdcard: spi bus initialised
I (2634) gpio: GPIO[4]| InputEn: 0| OutputEn: 1| OpenDrain: 0| Pullup: 0| Pulldown: 0| Intr:0 
I (2642) sdspi_transaction: cmd=52, R1 response: command not supported
I (2690) sdspi_transaction: cmd=5, R1 response: command not supported
VFS_FAT: ff_memalloc failed to allocate: 47600
VFS_FAT: sizeof(vfs_fat_ctx_t): 6240
VFS_FAT: sizeof(FIL):           4136
VFS_FAT: heap available:        40780
E (2732) vfs_fat_sdmmc: mount_to_vfs failed (0x101).
I (2738) gpio: GPIO[4]| InputEn: 1| OutputEn: 0| OpenDrain: 0| Pullup: 0| Pulldown: 0| Intr:0 
sdcard: sdcard not mounted
```
