### PR TITLE
AP_Scripting: update HFE EFI driver script

### DIFF
--- a/libraries/AP_Scripting/drivers/EFI_HFE.lua
+++ b/libraries/AP_Scripting/drivers/EFI_HFE.lua
@@ -1,5 +1,5 @@
 --[[ 
-  EFI Scripting backend driver for HFE based on HFEDCN0191 Rev E
+  EFI Scripting backend driver for HFE based on HFEDCN0191 Rev L
 --]]
 -- luacheck: only 0
 ---@diagnostic disable: param-type-mismatch
@@ -64,14 +64,72 @@ end
 local efi_backend = nil
 
 -- Setup EFI Parameters
-assert(param:add_table(PARAM_TABLE_KEY, PARAM_TABLE_PREFIX, 6), 'could not add EFI_HFE param table')
+assert(param:add_table(PARAM_TABLE_KEY, PARAM_TABLE_PREFIX, 10), 'could not add EFI_HFE param table')
 
+--[[
+  // @Param: EFI_HFE_ENABLE
+  // @DisplayName: Enable HFE EFI driver
+  // @Description: Enable HFE EFI driver
+  // @Values: 0:Disabled,1:Enabled
+  // @User: Standard
+--]]
 local EFI_HFE_ENABLE = bind_add_param('ENABLE',  1, 0)
-local EFI_HFE_RATE_HZ  = bind_add_param('RATE_HZ',  2, 200)    -- Script update frequency in Hz
-local EFI_HFE_ECU_IDX = bind_add_param('ECU_IDX',  3, 0)   -- ECU index on CAN bus, 0 for automatic
-local EFI_HFE_FUEL_DTY = bind_add_param('FUEL_DTY',  4, 740)   -- fuel density, g/litre
-local EFI_HFE_REL_IDX = bind_add_param('REL_IDX',  5, 0)   -- relay number for engine enable
-local EFI_HFE_CANDRV = bind_add_param('CANDRV',  6, 0)   -- CAN driver number
+
+--[[
+  // @Param: EFI_HFE_RATE_HZ
+  // @DisplayName: HFI EFI Update rate
+  // @Description: HFI EFI Update rate
+  // @Range: 0:Disabled,1:Enabled
+  // @User: Standard
+--]]
+local EFI_HFE_RATE_HZ  = bind_add_param('RATE_HZ',  2, 200)
+
+--[[
+  // @Param: EFI_HFE_ECU_IDX
+  // @DisplayName: HFI EFI ECU index
+  // @Description: HFI EFI ECU index, 0 for automatic
+  // @Range: 0 10
+  // @User: Standard
+--]]
+local EFI_HFE_ECU_IDX = bind_add_param('ECU_IDX',  3, 0)
+
+--[[
+  // @Param: EFI_HFE_FUEL_DTY
+  // @DisplayName: HFI EFI fuel density
+  // @Description: HFI EFI fuel density in gram per litre
+  // @Range: 0 2000
+  // @User: Standard
+--]]
+local EFI_HFE_FUEL_DTY = bind_add_param('FUEL_DTY',  4, 740)
+
+--[[
+  // @Param: EFI_HFE_REL_IDX
+  // @DisplayName: HFI EFI relay index
+  // @Description: HFI EFI relay index
+  // @Range: 0 10
+  // @User: Standard
+--]]
+local EFI_HFE_REL_IDX = bind_add_param('REL_IDX',  5, 0)
+
+--[[
+  // @Param: EFI_HFE_CANDRV
+  // @DisplayName: HFI EFI CAN driver
+  // @Description: HFI EFI CAN driver
+  // @Values: 0:None,1:1stCANDriver,2:2ndCanDriver
+  // @User: Standard
+--]]
+local EFI_HFE_CANDRV = bind_add_param('CANDRV',  6, 0)
+
+--[[
+  // @Param: EFI_HFE_OPTIONS
+  // @DisplayName: HFI EFI options
+  // @Description: HFI EFI options
+  // @Bitmask: 1:EnableCANLogging
+  // @User: Standard
+--]]
+local EFI_HFE_OPTIONS = bind_add_param('OPTIONS',  7, 0)
+
+local OPTION_LOGALLFRAMES = 0x01
 
 local ICE_PWM_IGN_ON = bind_param("ICE_PWM_IGN_ON")
 
@@ -92,6 +150,20 @@ if not driver1 then
     return
 end
 
+local frame_count = 0
+
+--[[
+   frame logging - can be replayed with Tools/scripts/CAN/CAN_playback.py
+--]]
+local function log_can_frame(frame)
+    logger:write("CANF",'Id,DLC,FC,B0,B1,B2,B3,B4,B5,B6,B7','IBIBBBBBBBB',
+                 frame:id(),
+                 frame:dlc(),
+                 frame_count,
+                 frame:data(0), frame:data(1), frame:data(2), frame:data(3),
+                 frame:data(4), frame:data(5), frame:data(6), frame:data(7))
+    frame_count = frame_count + 1
+end
 
 local now_s = get_time_sec()
 
@@ -145,6 +217,9 @@ local function engine_control(_driver)
             count = count + 1
             if not frame then
                 break
+            end
+            if EFI_HFE_OPTIONS:get() & OPTION_LOGALLFRAMES ~= 0 then
+                log_can_frame(frame)
             end
 
             -- All Frame IDs for this EFI Engine are in the 29-bit extended address space


### PR DESCRIPTION
added option to log all CAN frames for debugging new protocols

user has reported new HFE firmware doesn't work, logging will help us work out why