### PR TITLE
Plane: Fix level-off and throttle without airspeed sensor

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -454,6 +454,9 @@ private:
         float throttle_lim_min;
         uint32_t throttle_max_timer_ms;
         // Good candidate for keeping the initial time for TKOFF_THR_MAX_T.
+
+        bool in_level_off_phase;
+        // The Flag to indicate the last phase of takeoff, the pitch level-off to neutral.
     } takeoff_state;
 
     // ground steering controller state


### PR DESCRIPTION
This PR does intend to fix Issues https://github.com/ArduPilot/ardupilot/issues/28685 and https://github.com/ArduPilot/ardupilot/issues/28775

This patch intends to fix two issues with auto takeoff mission item for
planes without an airspeed sensor.

Level-off fix:
- Correct the level-off condition by factor 2 because during level-off,
  the pitch and therefore the climb-rate decreses linearly.
  Mathmatically the plane therefore only climbs half of the altitude in the expected time
  and is not guaranteed to converge to target altitude by itself.
- Add flag for level-off stage and let TECS handle the final climb.

Throttle without airspeed sensor:
- Remove conditional evaluation of airspeed sensor to enable traditional
  TECS-controlled throttle range also without airspeed sensor.
  This restores the behavior of ArduPlane 4.5.7.

It is to be discussed if the flag THROTTLE_RANGE in parameter TKOFF_OPTIONS is to be reversed to keep
the behavior from Plane 4.5.7 consistent with Plane 4.6 onwards.
It could be something like FORCE_MAX_THROTTLE instead.

Latest measurements with this change cherry-picked onto ArduPilot-4.6:

[24-12-01_09-12-18.bin](https://github.com/menschel/ardupilot/blob/stash/build/bin/Arduplane/24-12-01_09-12-18.bin)
[24-12-01_09-16-52.bin](https://github.com/menschel/ardupilot/blob/stash/build/bin/Arduplane/24-12-01_09-16-52.bin)
[24-12-01_09-21-56.bin](https://github.com/menschel/ardupilot/blob/stash/build/bin/Arduplane/24-12-01_09-21-56.bin)
![level_off_fix](https://github.com/user-attachments/assets/2720ddf1-c1dc-4042-a8e7-08200ef167a7)
![throttle_fix](https://github.com/user-attachments/assets/e500c83e-35fa-4f5b-93dc-b8a64e5c8f5a)
