### PR TITLE
MissionRotation LUA - Load one of up to 10 mission files

### DIFF
--- a/libraries/AP_Scripting/applets/MissionRotation.lua
+++ b/libraries/AP_Scripting/applets/MissionRotation.lua
@@ -1,15 +1,18 @@
 -- Script to load one of up to 10 mission files based on AUX switch state
--- Always loads mission0.txt at boot, then cycles through files on AUX high transitions
+-- Always loads mission0.txt at boot, cycles missions on AUX high if held less than 3 seconds
+-- Reset the mission0.txt if AUX is high for more than 3 seconds.
 
+local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
 local rc_switch = rc:find_channel_for_option(24)  -- AUX FUNC switch for mission loading
 if not rc_switch then
-    gcs:send_text(6, "Mission Reset switch not assigned.")
+    gcs:send_text(MAV_SEVERITY.ERROR, "Mission Reset switch not assigned.")
     return
 end
 
 local last_sw_pos = -1  -- Track the last switch position
 local current_mission_index = 0  -- Start with mission0.txt
 local max_missions = 9  -- Maximum mission index (mission0.txt to mission9.txt)
+local high_timer = 0  -- Timer to track how long AUX stays high
 
 local function read_mission(file_name)
     local file = io.open(file_name, "r")
@@ -31,7 +34,7 @@ local function read_mission(file_name)
             data[i] = file:read('n')
             if data[i] == nil then
                 if i == 1 then
-                    gcs:send_text(6, "Loaded mission: " .. file_name)
+                    gcs:send_text(MAV_SEVERITY.WARNING, "Loaded mission: " .. file_name)
                     file:close()
                     return true
                 else
@@ -62,33 +65,39 @@ end
 
 -- Ensure mission0.txt exists and load it; stop if not found
 if not read_mission("mission0.txt") then
-    gcs:send_text(6, "Critical error: mission0.txt not found. Script stopped.")
+    gcs:send_text(MAV_SEVERITY.CRITICAL, "Critical error: mission0.txt not found, script stopped.")
     return
 end
 
 local function load_next_mission()
-    while true do
-        local file_name = string.format("mission%d.txt", current_mission_index)
-        if read_mission(file_name) then
-            break
-        end
-        current_mission_index = (current_mission_index + 1) % (max_missions + 1)
+    current_mission_index = (current_mission_index + 1) % (max_missions + 1)
+    local file_name = string.format("mission%d.txt", current_mission_index)
+    if read_mission(file_name) then
+        gcs:send_text(MAV_SEVERITY.WARNING, "Loaded mission: " .. file_name)
     end
 end
 
 function update()
     local sw_pos = rc_switch:get_aux_switch_pos()
 
-    -- Check if AUX switch transitioned from low to high
-    if sw_pos == 2 and last_sw_pos ~= 2 then
-        current_mission_index = (current_mission_index + 1) % (max_missions + 1)
-        load_next_mission()
+    if sw_pos == 2 then  -- AUX high position
+        high_timer = high_timer + 1
+        if high_timer >= 3 then  -- 3 seconds elapsed
+            current_mission_index = 0
+            read_mission("mission0.txt")
+            gcs:send_text(MAV_SEVERITY.WARNING, "Reset to mission0.txt")
+            high_timer = 0  -- Reset the timer after reset
+        end
+    else
+        if high_timer > 0 and high_timer < 3 then
+            load_next_mission()  -- Load next mission only if held high for less than 3 seconds
+        end
+        high_timer = 0  -- Reset timer when AUX is not high
     end
 
     last_sw_pos = sw_pos
-
-    return update, 1000
+    return update, 1000  -- Run every second
 end
 
-gcs:send_text(5, "MissionRotation.lua loaded")
+gcs:send_text(MAV_SEVERITY.NOTICE, "MissionSelector loaded")
 return update, 1000

--- a/libraries/AP_Scripting/applets/MissionRotation.lua
+++ b/libraries/AP_Scripting/applets/MissionRotation.lua
@@ -11,9 +11,8 @@ if not rc_switch then
 end
 
 local current_mission_index = 0
-local max_missions = 6  -- Aggiornato a 6 poiché hai fino a mission6.txt
+local max_missions = 9
 local high_timer = 0
-local latest_mission_loaded = -1  -- Track the last loaded mission
 
 local function read_mission(file_name)
     if vehicle:get_mode() == 3 then
@@ -79,14 +78,14 @@ if not read_mission("mission0.txt") then
 end
 
 local function load_next_mission()
+    if vehicle:get_mode() == 3 then
+        return
+    end
+
     current_mission_index = (current_mission_index + 1) % (max_missions + 1)
     local file_name = string.format("mission%d.txt", current_mission_index)
-
     if read_mission(file_name) then
-        if latest_mission_loaded ~= current_mission_index then
-            gcs:send_text(MAV_SEVERITY.WARNING, "Loaded mission: " .. file_name)
-            latest_mission_loaded = current_mission_index
-        end
+        gcs:send_text(MAV_SEVERITY.WARNING, "Loaded mission: " .. file_name)
     end
 end
 
@@ -106,11 +105,11 @@ function update()
         end
     else
         if high_timer > 0 and high_timer < 3 then
-            load_next_mission()  -- Load next mission if switched back before 3 seconds
+            load_next_mission()
         end
         high_timer = 0
     end
-    
+
     return update, 1000
 end
 

--- a/libraries/AP_Scripting/applets/MissionRotation.lua
+++ b/libraries/AP_Scripting/applets/MissionRotation.lua
@@ -5,7 +5,7 @@
 local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
 local rc_switch = rc:find_channel_for_option(24)
 if not rc_switch then
-    gcs:send_text(MAV_SEVERITY.ERROR, "Mission Reset switch not assigned.")
+    gcs:send_text(MAV_SEVERITY.ERROR, "Mission Reset switch not assigned")
     return
 end
 
@@ -14,6 +14,11 @@ local max_missions = 9
 local high_timer = 0
 
 local function read_mission(file_name)
+    if vehicle:get_mode() == 10 then  -- 10 = AUTO mode
+        gcs:send_text(MAV_SEVERITY.ERROR, "Cannot load mission in AUTO mode")
+        return false
+    end
+
     local file = io.open(file_name, "r")
     if not file then
         return false
@@ -62,7 +67,7 @@ local function read_mission(file_name)
 end
 
 if not read_mission("mission0.txt") then
-    gcs:send_text(MAV_SEVERITY.CRITICAL, "Critical error: mission0.txt not found, script stopped.")
+    gcs:send_text(MAV_SEVERITY.CRITICAL, "Critical error: mission0.txt not found, script stopped")
     return
 end
 
@@ -95,5 +100,5 @@ function update()
     return update, 1000
 end
 
-gcs:send_text(MAV_SEVERITY.NOTICE, "MissionSelector loaded")
+gcs:send_text(MAV_SEVERITY.NOTICE, "Mission Rotation loaded")
 return update, 1000

--- a/libraries/AP_Scripting/applets/MissionRotation.lua
+++ b/libraries/AP_Scripting/applets/MissionRotation.lua
@@ -1,0 +1,94 @@
+-- Script to load one of up to 10 mission files based on AUX switch state
+-- Always loads mission0.txt at boot, then cycles through files on AUX high transitions
+
+local rc_switch = rc:find_channel_for_option(24)  -- AUX FUNC switch for mission loading
+if not rc_switch then
+    gcs:send_text(6, "Mission Reset switch not assigned.")
+    return
+end
+
+local last_sw_pos = -1  -- Track the last switch position
+local current_mission_index = 0  -- Start with mission0.txt
+local max_missions = 9  -- Maximum mission index (mission0.txt to mission9.txt)
+
+local function read_mission(file_name)
+    local file = io.open(file_name, "r")
+    if not file then
+        return false
+    end
+
+    local header = file:read('l')
+    assert(string.find(header, 'QGC WPL 110') == 1, file_name .. ': incorrect format')
+
+    assert(mission:clear(), 'Could not clear current mission')
+
+    local item = mavlink_mission_item_int_t()
+    local index = 0
+
+    while true do
+        local data = {}
+        for i = 1, 12 do
+            data[i] = file:read('n')
+            if data[i] == nil then
+                if i == 1 then
+                    gcs:send_text(6, "Loaded mission: " .. file_name)
+                    file:close()
+                    return true
+                else
+                    mission:clear()
+                    error('Failed to read file: premature end of data')
+                end
+            end
+        end
+
+        item:seq(data[1])
+        item:frame(data[3])
+        item:command(data[4])
+        item:param1(data[5])
+        item:param2(data[6])
+        item:param3(data[7])
+        item:param4(data[8])
+        item:x(data[9] * 10^7)
+        item:y(data[10] * 10^7)
+        item:z(data[11])
+
+        if not mission:set_item(index, item) then
+            mission:clear()
+            error(string.format('Failed to set mission item %i', index))
+        end
+        index = index + 1
+    end
+end
+
+-- Ensure mission0.txt exists and load it; stop if not found
+if not read_mission("mission0.txt") then
+    gcs:send_text(6, "Critical error: mission0.txt not found. Script stopped.")
+    return
+end
+
+local function load_next_mission()
+    while true do
+        local file_name = string.format("mission%d.txt", current_mission_index)
+        if read_mission(file_name) then
+            break
+        end
+        current_mission_index = (current_mission_index + 1) % (max_missions + 1)
+    end
+end
+
+function update()
+    local sw_pos = rc_switch:get_aux_switch_pos()
+
+    -- Check if AUX switch transitioned from low to high
+    if sw_pos == 2 and last_sw_pos ~= 2 then
+        current_mission_index = (current_mission_index + 1) % (max_missions + 1)
+        load_next_mission()
+    end
+
+    last_sw_pos = sw_pos
+
+    return update, 1000
+end
+
+gcs:send_text(5, "MissionRotation.lua loaded")
+return update, 1000

--- a/libraries/AP_Scripting/applets/MissionRotation.lua
+++ b/libraries/AP_Scripting/applets/MissionRotation.lua
@@ -1,6 +1,6 @@
 -- Script to load one of up to 10 mission files based on AUX switch state
 -- Always loads mission0.txt at boot, cycles missions on AUX high if held less than 3 seconds
--- Reset the mission0.txt if AUX is high for more than 3 seconds.
+-- Reset the mission0.txt if AUX is high for more than 3 seconds
 
 local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
 local rc_switch = rc:find_channel_for_option(24)  -- AUX FUNC switch for mission loading

--- a/libraries/AP_Scripting/applets/MissionRotation.md
+++ b/libraries/AP_Scripting/applets/MissionRotation.md
@@ -4,7 +4,7 @@ This LUA script is an evolution on the MissionSelector.LUA.
 
 Allows you to select up to 10 missions, either while arming or in the unarmed state.
 
-Requires that an RC_xFUNCTION be set to 24 (Mission Reset).
+Requires that an RCx_OPTION be set to 24 (Mission Reset).
 
 The scripts should be installed in the SCRIPTS folder on the MicroSD, and the mission files in the root.
 

--- a/libraries/AP_Scripting/applets/MissionRotation.md
+++ b/libraries/AP_Scripting/applets/MissionRotation.md
@@ -10,8 +10,10 @@ The scripts should be installed in the SCRIPTS folder on the MicroSD, and the mi
 
 The mission file called mission0.txt (the default mission) must exist and is loaded at boot, if the script does not find it it stops working.
 
-To load to the next mission file just bring AUX switch from low to high, each switch loads the next mission file in numerical order.
+To load to the next mission file just bring AUX switch from low to high for no more than three seconds, each switch high-low loads the next mission file in numerical order.
 
 If the next mission file numerically does not exist load the next one, at the end of the rotation it returns to load mission0.txt.
+
+If AUX is held at high state for more than three seconds the script will restart by loading mission0.txt.
 
 Provides for sending messages under any condition, load or error.

--- a/libraries/AP_Scripting/applets/MissionRotation.md
+++ b/libraries/AP_Scripting/applets/MissionRotation.md
@@ -16,4 +16,6 @@ If the next mission file numerically does not exist load the next one, at the en
 
 If AUX is held at high state for more than three seconds the script will restart by loading mission0.txt.
 
+If a mission switch is attempted in AUTO flight mode, a warning “Could not clear current mission” will be shown and no operation will be performed.
+
 Provides for sending messages under any condition, load or error.

--- a/libraries/AP_Scripting/applets/MissionRotation.md
+++ b/libraries/AP_Scripting/applets/MissionRotation.md
@@ -1,0 +1,17 @@
+# MissionRotation LUA script
+
+This LUA script is an evolution on the MissionSelector.LUA.
+
+Allows you to select up to 10 missions, either while arming or in the unarmed state.
+
+Requires that an RC_xFUNCTION be set to 24 (Mission Reset).
+
+The scripts should be installed in the SCRIPTS folder on the MicroSD, and the mission files in the root.
+
+The mission file called mission0.txt (the default mission) must exist and is loaded at boot, if the script does not find it it stops working.
+
+To load to the next mission file just bring AUX switch from low to high, each switch loads the next mission file in numerical order.
+
+If the next mission file numerically does not exist load the next one, at the end of the rotation it returns to load mission0.txt.
+
+Provides for sending messages under any condition, load or error.


### PR DESCRIPTION
This LUA script is an evolution on the MissionSelector.LUA.
Allows you to select up to 10 missions, either while arming or in the unarmed state.
Requires that an RCx_OPTION be set to 24 (Mission Reset).
The scripts should be installed in the SCRIPTS folder on the MicroSD, and the mission files in the root.
The mission file called mission0.txt (the default mission) must exist and is loaded at boot, if the script does not find it it stops working.
To load to the next mission file just bring AUX switch from low to high for no more than three seconds, each switch loads the next mission file in numerical order.
If the next mission file numerically does not exist load the next one, at the end of the rotation it returns to load mission0.txt.
If AUX is held at high state for more than three seconds the script will restart by loading mission0.txt.
If a mission switch is attempted in AUTO flight mode, a warning “Could not clear current mission” will be shown and no operation will be performed
Provides for sending messages under any condition, load or error.

Classic example of use, i.e. how do i use this rotation:

- mission0.txt is my automatic takeoff mission with home setting at a different point from arming followed by RTL, this way after manually launching my fpv plane I can put on my goggles, exit RTL and execute my flight
- mission1.txt is a full circuit mission for automatic landing, I load it if I want Ardupilot to perform an automated landing from the R side of the runway. This comes in handy, for example, if video transmission is interrupted and visibility on the ground is not optimal
- mission2.txt is like mission1.txt but executes the circuit for landing runway L
- the other mission files I use to perform specific automated flights

In my case if any failsafe intervenes the chosen mission is then executed.
In this way by pre scheduling the appropriate missions for the location where I fly I can afford to handle any emergencies without using GCS, simply choosing with the script the most appropriate mission, and in case changing it on the fly.