### PR TITLE
add integer bound check

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -5151,7 +5151,11 @@ static int32_t convert_COMMAND_LONG_loc_param(float param, bool stores_location)
     }
 
     if (stores_location) {
-        return param *1e7;
+     	float convertedValue = param *1e7;
+        if (convertedValue < INT32_MIN || convertedValue > INT32_MAX) {
+            return 0;
+        }
+        return convertedValue;
     }
 
     return param;


### PR DESCRIPTION
When sending mavlink command_long messages with some arbitrary parameters, I noticed random crashes in the simulation. I looked into it and found, that the simulation always crashes, when I send a parameter >215 or <-215 for a coordinate. This was due to a integer over/underflow in the conversion from long to int. 

I added the necessary checks to the converting function and now I do not longer notice the problem. 