### PR TITLE
AC_AutoTune: fix tracking of maximum angular acceleration

### DIFF
--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -644,7 +644,7 @@ void AC_AutoTune_Multi::twitching_test_angle(float angle, float rate, float angl
 }
 
 // twitching_measure_acceleration - measure rate of change of measurement
-void AC_AutoTune_Multi::twitching_measure_acceleration(float &accel_average, float rate, float rate_max) const
+void AC_AutoTune_Multi::twitching_measure_acceleration(float &accel_average, float rate, float &rate_max) const
 {
     if (rate_max < rate) {
         rate_max = rate;

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.h
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.h
@@ -156,7 +156,7 @@ private:
     void twitching_test_angle(float angle, float rate, float angle_target, float &meas_angle_min, float &meas_angle_max, float &meas_rate_min, float &meas_rate_max);
 
     // measure acceleration during twitch test
-    void twitching_measure_acceleration(float &accel_average, float rate, float rate_max) const;
+    void twitching_measure_acceleration(float &accel_average, float rate, float &rate_max) const;
 
     // updating_rate_d_up - increase D and adjust P to optimize the D term for a little bounce back
     // optimize D term while keeping the maximum just below the target by adjusting P


### PR DESCRIPTION
Issue introduced in https://github.com/ArduPilot/ardupilot/pull/27370 and partially fixed in https://github.com/ArduPilot/ardupilot/pull/27762, though evidently not properly tested. Fixes #28799 .

Failing to track the maximum can result in dangerously low values being calculated for `ATC_ACCEL_[RPY]_MAX` and the vehicle becoming unflyable.

Make the variable a reference so that the maximum value is preserved between function calls.

I have tested tuning in SITL, though I have not tested flyability and I have not tested on a real vehicle. I also have not searched for similar missing reference sigils.

I observed the following tuning result differences after this fix, as compared to Copter 4.5.7 (non-listed results are virtually identical):
* roll/pitch rate D is 50% lower
* yaw E rate P/I are 10% lower
* yaw E angle P is 30% higher
* yaw E max accel is 35% lower
* no more warnings during yaw of "please tune manually"

Would appreciate a more thorough look at the code, and confirmation that these value changes are expected improvements and not another (less severe) problem with autotune.