### PR TITLE
Gsof bitmask flexible parser

### DIFF
--- a/libraries/AP_Common/Bitmask.h
+++ b/libraries/AP_Common/Bitmask.h
@@ -53,6 +53,18 @@ public:
 
     Bitmask(const Bitmask &other) = delete;
 
+
+    // Construct a bitmask with some bits enabled.
+    template<size_t N>
+    Bitmask(const uint16_t (&enabled_bits)[N]) {
+        clearall();
+        for (size_t i = 0; i < N; ++i) {
+            if (enabled_bits[i] < NUMBITS) {
+                set(enabled_bits[i]);
+            }
+        }
+    }
+
     // set given bitnumber
     void set(uint16_t bit) {
         if (!validate(bit)) {

--- a/libraries/AP_GPS/AP_GPS_GSOF.cpp
+++ b/libraries/AP_GPS/AP_GPS_GSOF.cpp
@@ -22,8 +22,12 @@
 //    param set GPS1_TYPE 11 // GSOF
 //    param set SERIAL3_PROTOCOL 5 // GPS
 //
-//  Pure SITL usage
-//     param set SIM_GPS_TYPE 11 // GSOF
+//  Pure SITL usage:
+//    sim_vehicle.py -v Plane --console --map -DG
+//    param set SIM_GPS1_TYPE 11 // GSOF
+//    param set GPS1_TYPE 11 // GSOF
+//    param set SERIAL3_PROTOCOL 5 // GPS
+
 #define ALLOW_DOUBLE_MATH_FUNCTIONS
 
 #include "AP_GPS.h"
@@ -36,28 +40,25 @@
 
 extern const AP_HAL::HAL& hal;
 
-#define gsof_DEBUGGING 0
-
-#if gsof_DEBUGGING
-# define Debug(fmt, args ...)                  \
-do {                                            \
-    hal.console->printf("%s:%d: " fmt "\n",     \
-                        __FUNCTION__, __LINE__, \
-                        ## args);               \
-    hal.scheduler->delay(1);                    \
-} while(0)
-#else
-# define Debug(fmt, args ...)
-#endif
-
 AP_GPS_GSOF::AP_GPS_GSOF(AP_GPS &_gps,
                          AP_GPS::Params &_params,
                          AP_GPS::GPS_State &_state,
                          AP_HAL::UARTDriver *_port) :
     AP_GPS_Backend(_gps, _params, _state, _port)
 {
+
+    const uint16_t gsofmsgreq[5] = {
+        AP_GSOF::POS_TIME,
+        AP_GSOF::POS,
+        AP_GSOF::VEL,
+        AP_GSOF::DOP,
+        AP_GSOF::POS_SIGMA
+    };
     // https://receiverhelp.trimble.com/oem-gnss/index.html#GSOFmessages_Overview.html?TocPath=Output%2520Messages%257CGSOF%2520Messages%257COverview%257C_____0
+    // The maximum number of outputs allowed with GSOF is 10
     static_assert(ARRAY_SIZE(gsofmsgreq) <= 10, "The maximum number of outputs allowed with GSOF is 10.");
+    requested_msgs = AP_GSOF::MsgTypes(gsofmsgreq);
+    
 
     constexpr uint8_t default_com_port = static_cast<uint8_t>(HW_Port::COM2);
     params.com_port.set_default(default_com_port);
@@ -80,38 +81,48 @@ AP_GPS_GSOF::read(void)
 {
     const uint32_t now = AP_HAL::millis();
 
-    if (gsofmsgreq_index < (sizeof(gsofmsgreq))) {
+    if (gsofmsgreq_index < (requested_msgs.count())) {
         const auto com_port = params.com_port.get();
         if (!validate_com_port(com_port)) {
             // The user parameter for COM port is not a valid GSOF port
             return false;
         }
         if (now > gsofmsg_time) {
-            requestGSOF(gsofmsgreq[gsofmsgreq_index], static_cast<HW_Port>(com_port), Output_Rate::FREQ_10_HZ);
+            for (uint16_t i = next_req_gsof; i < requested_msgs.size(); i++){
+                if (requested_msgs.get(i)) {
+                    next_req_gsof = i;
+                    break;
+                }
+            }
+            requestGSOF(next_req_gsof, static_cast<HW_Port>(com_port), Output_Rate::FREQ_10_HZ);
             gsofmsg_time = now + 110;
             gsofmsgreq_index++;
+            next_req_gsof++;
         }
     }
 
-    bool ret = false;
     while (port->available() > 0) {
         const uint8_t temp = port->read();
 #if AP_GPS_DEBUG_LOGGING_ENABLED
         log_data(&temp, 1);
 #endif
-        const int n_gsof_received = parse(temp, ARRAY_SIZE(gsofmsgreq));
-        if(n_gsof_received == UNEXPECTED_NUM_GSOF_PACKETS) {
-            state.status = AP_GPS::NO_FIX;
-            continue;
-        }
-        const bool got_expected_packets = n_gsof_received == ARRAY_SIZE(gsofmsgreq);
-        ret |= got_expected_packets;
-    }
-    if (ret) {
-        pack_state_data();
+        AP_GSOF::MsgTypes parsed;
+        const int parse_status = parse(temp, parsed);
+        if(parse_status == PARSED_GSOF_DATA) {
+            if (parsed.get(AP_GSOF::POS_TIME) &&
+                parsed.get(AP_GSOF::POS) && 
+                parsed.get(AP_GSOF::VEL) && 
+                parsed.get(AP_GSOF::DOP) && 
+                parsed.get(AP_GSOF::POS_SIGMA)
+            )
+            {
+                pack_state_data();
+                return true;
+            }
+        }          
     }
 
-    return ret;
+    return false;
 }
 
 void

--- a/libraries/AP_GPS/AP_GPS_GSOF.h
+++ b/libraries/AP_GPS/AP_GPS_GSOF.h
@@ -73,6 +73,7 @@ private:
     uint8_t packetcount;
     uint32_t gsofmsg_time;
     uint8_t gsofmsgreq_index;
-    const uint8_t gsofmsgreq[5] = {1,2,8,9,12};
+    uint16_t next_req_gsof;
+    AP_GSOF::MsgTypes requested_msgs;
 };
 #endif

--- a/libraries/AP_GSOF/AP_GSOF.h
+++ b/libraries/AP_GSOF/AP_GSOF.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "AP_GSOF_config.h"
+#include <AP_Common/Bitmask.h>
 
 #if AP_GSOF_ENABLED
 
@@ -11,14 +12,15 @@ class AP_GSOF
 public:
 
     static constexpr int NO_GSOF_DATA = 0;
-    static constexpr int UNEXPECTED_NUM_GSOF_PACKETS = -1;
+    static constexpr int PARSED_GSOF_DATA = 1;
+
+    // A type alias for which packets have been parsed.
+    using MsgTypes = Bitmask<71>;
 
     // Parse a single byte into the buffer.
-    // When enough data has arrived, it returns the number of GSOF packets parsed in the GENOUT packet.
-    // If an unexpected number of GSOF packets were parsed, returns UNEXPECTED_NUM_GSOF_PACKETS.
-    // This means there is no fix.
+    // When enough data has arrived, it populates a bitmask of which GSOF packets were parsed in the GENOUT packet and returns PARSED_GSOF_DATA.
     // If it returns NO_GSOF_DATA, the parser just needs more data.
-    int parse(const uint8_t temp, const uint8_t n_expected) WARN_IF_UNUSED;
+    int parse(const uint8_t temp, MsgTypes& parsed_msgs) WARN_IF_UNUSED;
 
     // GSOF packet numbers.
     enum msg_idx_t {
@@ -91,8 +93,10 @@ public:
 
 private:
 
-    // Parses current data and returns the number of parsed GSOF messages.
-    int process_message() WARN_IF_UNUSED;
+    // Parses current data.
+    // Returns true if, and only if, the expected packets were parsed.
+    // Unexpected/unparsed data will make this return false.
+    bool process_message(MsgTypes& parsed_msgs) WARN_IF_UNUSED;
 
     void parse_pos_time(uint32_t a);
     void parse_pos(uint32_t a);

--- a/libraries/AP_GSOF/tests/test_gsof.cpp
+++ b/libraries/AP_GSOF/tests/test_gsof.cpp
@@ -16,7 +16,8 @@ const AP_HAL::HAL &hal = AP_HAL::get_HAL();
 TEST(AP_GSOF, incomplete_packet)
 {
     AP_GSOF gsof;
-    EXPECT_FALSE(gsof.parse(0, 5));
+    AP_GSOF::MsgTypes expected;
+    EXPECT_FALSE(gsof.parse(0, expected));
 }
 
 TEST(AP_GSOF, packet1)
@@ -27,9 +28,17 @@ TEST(AP_GSOF, packet1)
     AP_GSOF gsof;
     char c = 0;
     bool parsed = false;
+
+    AP_GSOF::MsgTypes expected;
+    expected.set(1);
+    expected.set(2);
+    expected.set(8);
+    expected.set(9);
+    expected.set(12);
+
     while (c != EOF) {
         c = fgetc (fp);
-        parsed |= gsof.parse((uint8_t)c, 5);
+        parsed |= gsof.parse((uint8_t)c, expected);
     }
     
     EXPECT_TRUE(parsed);


### PR DESCRIPTION
# Purpose

Refactor the GSOF parser to instead return a bitmask of which packets were parsed. Compared to before, where we used a counter for packets, which was not robust to duplicate packets, or flexible to different sets of packets. It now mirrors more commonly accepted ways of parsing such as in the inertial labs EAHRS by using a Bitmask to keep track of received packets. 

The upcoming EAHRS uses this to keep track of the **time_ms** of each required packet, and only reports `healthy` when all tracked packets have arrived recently.

# Details

* Removed unused debug macro
* Clean up docs
* The GPS driver's expected packets now has to be set at runtime, since you can't initialize an AP bitmask at compile time

# Behavioral changes

The GSOF GPS driver expects packets 1,2,8,9,12 enabled. 

Previously, if it received packets [1,1,1,1,1] all in a row, the parser would return success, which is terrible behavior because it's missing important data. Now, it fails. This is the main improvement.
Previously, if received packets [1,2,8,9,12, **18**] (ie, unexpected unparsed data), the parser would fail. It still fails, but now we can easily change the behavior. 

Because the driver is in control of configuration, we only expect data that was configured. 


# Next Up

The upcoming Trimble External AHRS will re-use this parser, but with different packets. 
See https://github.com/ArduPilot/ardupilot/compare/master...Ryanf55:ardupilot:27033-gsof-add-eahrs-driver?expand=1 for a preview.

# Testing Performed

* Autotest covers GSOF quite well, including configuration
* Run the SITL driver per the instructions in AP_GPS_GSOF.cpp and fly around. Ensure the EKF tracks as expected by observing a stable loiter.

Run the unit test, uncommenting the skip line. 

```bash
ryan@ryan-thinkpad:~/Dev/ardupilot_ws/src/ardupilot$ ./build/sitl/tests/test_gsof
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from AP_GSOF
[ RUN      ] AP_GSOF.incomplete_packet
[       OK ] AP_GSOF.incomplete_packet (0 ms)
[ RUN      ] AP_GSOF.packet1
[       OK ] AP_GSOF.packet1 (0 ms)
[----------] 2 tests from AP_GSOF (0 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 2 tests.
```
