### PR TITLE
Plane: Pass external HAGL to TECS

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -789,7 +789,16 @@ float Plane::tecs_hgt_afe(void)
       coming.
     */
     float hgt_afe;
+
     if (flight_stage == AP_FixedWing::FlightStage::LAND) {
+
+        #if AP_MAVLINK_MAV_CMD_SET_HAGL_ENABLED
+            // if external HAGL is active use that
+            if (get_external_HAGL(hgt_afe)) {
+                return hgt_afe;
+            }
+        #endif
+
         hgt_afe = height_above_target();
 #if AP_RANGEFINDER_ENABLED
         hgt_afe -= rangefinder_correction();


### PR DESCRIPTION
# Summary

This addresses #28704 by passing the external Height Above Ground Level (HAGL) to `Plane::tecs_hgt_afe()`.

# Testing

None so far. There is one candidate partner who's willing to try it.

# Alternatives

I've spent a couple of hours thinking how `Plane::tecs_hgt_afe()` and `Plane::get_landing_height()` are different from each other. They seemed like a good candidate for refactoring/consolidation, and that would save the introduction of these extra lines of code.

But in the end I failed to do so, hence the duplicate code.