### PR TITLE
AP_VideoTX: Feat: Add RC Switch to VTX Power Mapping

### DIFF
--- a/libraries/AP_VideoTX/AP_VideoTX.h
+++ b/libraries/AP_VideoTX/AP_VideoTX.h
@@ -188,6 +188,12 @@ private:
     AP_Int16 _power_mw;
     uint16_t _current_power;
     AP_Int16 _max_power_mw;
+    AP_Int16 _vtx_power_1;
+    AP_Int16 _vtx_power_2;
+    AP_Int16 _vtx_power_3;
+    AP_Int16 _vtx_power_4;
+    AP_Int16 _vtx_power_5;
+    AP_Int16 _vtx_power_6;
 
     // frequency band
     AP_Int8 _band;


### PR DESCRIPTION
This patch does both enhance and simplify the vtx power selection via RC switch.

The RC Option VTX Power expects a 6 position switch and is therefore useless if any other sort of switch is used.

The typical setup found on a radio is a 3 position switch and up until now, position 1 results in pit mode which is not accessible if armed and typically pit mode is tied to arm state through option bits. So Position 1 is lost for no reason!
Position 3 is the MAX POWER value and Position 2 is some arbitrary value in between.

This patch makes use of the same concept as the flight-mode switch with configurable positional values.

It also removes obscure code to find power levels that also seems to have code duplicates.

NOTE: Betaflight features the concept of a "Label" / Value array. Is this feasible for ardupilot?
In that case I'll rework to some sort of VTX_POWER_1_LABEL / VTX_POWER_1_VALUE concept.
It would also open the door to import the VTX table json files in betaflight format.