### PR TITLE
AP_HAL_ChibiOS: Refactor Flash Options and add Brownout Reset

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/board.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/board.c
@@ -303,6 +303,10 @@ void __late_init(void) {
   // ensure NRST_MODE is set correctly
   stm32_flash_set_NRST_MODE(HAL_FLASH_SET_NRST_MODE);
 #endif
+
+#ifdef HAL_FLASH_SET_BOR_LEVEL
+  stm32_flash_set_BOR_level(HAL_FLASH_SET_BOR_LEVEL);
+#endif
 }
 
 #if HAL_USE_SDC || defined(__DOXYGEN__)

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/flash.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/flash.h
@@ -33,6 +33,8 @@ void stm32_flash_set_NRST_MODE(uint8_t nrst_mode);
 #if defined(STM32H7)
 void stm32_flash_corrupt(uint32_t addr);
 #endif
+void stm32_flash_set_BOR_level(uint8_t bor_level);
+void stm32_flash_set_options(const uint32_t mask, const uint32_t pos, const uint32_t value);
 #ifndef HAL_BOOTLOADER_BUILD
 bool stm32_flash_recent_erase(void);
 #endif


### PR DESCRIPTION
Refactor Flash Options and add Brownout Reset. Upon abusing the power on/off requirements, I can "corrupt" my h757 based periph where it gets an ECC error and wipes the app. When enabling the Brownout reset (BOR) feature of the STM32, the problem goes away.

I'm reluctant to add this right now to any existing hwdef.dat but on my own boards the comment in the hwdef.dat is

```
# set Brownout Reset level to highest voltage rising:2.7V, falling:2.61V
define HAL_FLASH_SET_BOR_LEVEL 3
```
