### PR TITLE
GCS_Common: fix send_sys_status() to send correct current

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -5766,7 +5766,7 @@ void GCS_MAVLINK::send_sys_status()
     float battery_current;
     const int8_t battery_remaining = battery_remaining_pct(AP_BATT_PRIMARY_INSTANCE);
 
-    if (battery.healthy() && battery.current_amps(battery_current)) {
+    if (battery.healthy(AP_BATT_PRIMARY_INSTANCE) && battery.current_amps(battery_current, AP_BATT_PRIMARY_INSTANCE)) {
         battery_current = constrain_float(battery_current * 100,-INT16_MAX,INT16_MAX);
     } else {
         battery_current = -1;
@@ -5795,7 +5795,7 @@ void GCS_MAVLINK::send_sys_status()
         0,
 #endif
 #if AP_BATTERY_ENABLED
-        battery.gcs_voltage() * 1000,  // mV
+        battery.gcs_voltage(AP_BATT_PRIMARY_INSTANCE) * 1000,  // mV
         battery_current,        // in 10mA units
         battery_remaining,      // in %
 #else


### PR DESCRIPTION
Current behavior: If you have multiple batteries and ANY of them are unhealthy then the SYS_STATUS msg shows a current of -1A. All the other battery member functions have a default index == AP_BATT_PRIMARY_INSTANCE except healthy() which applies to all instances.

New behavior: battery index [AP_BATT_PRIMARY_INSTANCE] (usually 0) current is always shown for SYS_STATUS regardless of the state of other battery indexes