### PR TITLE
AP_Scripting: Examples: message_interval: give checker a hint about types

### DIFF
--- a/libraries/AP_Scripting/examples/message_interval.lua
+++ b/libraries/AP_Scripting/examples/message_interval.lua
@@ -44,6 +44,12 @@ gcs:send_text(MAV_SEVERITY.INFO, "Loaded message_interval.lua")
 function update() -- this is the loop which periodically runs
   for i = 1, #intervals do -- we want to iterate over every specified interval
     local channel, message, interval_hz = table.unpack(intervals[i]) -- this extracts the channel, MAVLink ID, and interval
+
+    -- Lua checks get the unpacked types wrong, these are the correct types
+    ---@cast channel integer
+    ---@cast message uint32_t_ud
+    ---@cast interval_hz number
+
     local interval_us = -1
     if interval_hz > 0 then
       interval_us = math.floor(1000000 / interval_hz) -- convert the interval to microseconds


### PR DESCRIPTION
A new [release](https://github.com/LuaLS/lua-language-server/releases) of the lua language server results in this invalid CI failure:
```
Diagnosis complete, 2 problems found, see /__w/ardupilot/ardupilot/lualogs/check.json
/__w/ardupilot/ardupilot/libraries/AP_Scripting/examples/message_interval.lua:51:30
	Code: param-type-mismatch
	Cannot assign `number|uint32_t_ud` to parameter `integer`.
	- `uint32_t_ud` cannot match `integer`
	- Type `uint32_t_ud` cannot match `integer`
/__w/ardupilot/ardupilot/libraries/AP_Scripting/examples/message_interval.lua:49:32
	Code: param-type-mismatch
	Cannot assign `uint32_t_ud` to parameter `number`.
	- `uint32_t_ud` cannot match `number`
	- Type `uint32_t_ud` cannot match `number`
```

Previously it would not try and guess the types from a table unpack, so we got the benefit of the doubt. Now it seems to try but gets it a bit wrong in this case. Adding the cast annotation means the variables have the correct type so the rest of the file can be checked as normal.

We maybe able to remove the checks again at some point in the future if the checker is improved so it can extract the correct types. 