### PR TITLE
AP_HAL_ChibiOS: don't throw an internal error on mismatched cork/push

### DIFF
--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -1329,9 +1329,6 @@ bool RCOutput::get_output_mode_banner(char banner_msg[], uint8_t banner_msg_len)
  */
 void RCOutput::cork(void)
 {
-    if (corked) {
-        INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
-    }
     corked = true;
 #if HAL_WITH_IO_MCU
     if (iomcu_enabled) {


### PR DESCRIPTION
Please decide if you want this or #28825 