### PR TITLE
Tuning indication on OSD(and GCS)

### DIFF
--- a/ArduPlane/tuning.cpp
+++ b/ArduPlane/tuning.cpp
@@ -37,6 +37,9 @@ const uint8_t AP_Tuning_Plane::tuning_set_az[] =               { TUNING_AZ_P, TU
 const uint8_t AP_Tuning_Plane::tuning_set_rate_pitchDP[]=      { TUNING_RATE_PITCH_D, TUNING_RATE_PITCH_P };
 const uint8_t AP_Tuning_Plane::tuning_set_rate_rollDP[]=       { TUNING_RATE_ROLL_D, TUNING_RATE_ROLL_P };
 const uint8_t AP_Tuning_Plane::tuning_set_rate_yawDP[]=        { TUNING_RATE_YAW_D, TUNING_RATE_YAW_P };
+const uint8_t AP_Tuning_Plane::tuning_set_dp_roll_pitch[] =    { TUNING_RLL_D, TUNING_RLL_P, TUNING_PIT_D, TUNING_PIT_P };
+const uint8_t AP_Tuning_Plane::tuning_set_pidff_roll[] =       { TUNING_RLL_P, TUNING_RLL_I, TUNING_RLL_D, TUNING_RLL_FF };
+const uint8_t AP_Tuning_Plane::tuning_set_pidff_pitch[] =      { TUNING_PIT_P, TUNING_PIT_I, TUNING_PIT_D, TUNING_PIT_FF };
 
 // macro to prevent getting the array length wrong
 #define TUNING_ARRAY(v) ARRAY_SIZE(v), v
@@ -53,6 +56,9 @@ const AP_Tuning_Plane::tuning_set AP_Tuning_Plane::tuning_sets[] = {
     { TUNING_SET_RATE_PITCHDP,          TUNING_ARRAY(tuning_set_rate_pitchDP) },
     { TUNING_SET_RATE_ROLLDP,           TUNING_ARRAY(tuning_set_rate_rollDP) },
     { TUNING_SET_RATE_YAWDP,            TUNING_ARRAY(tuning_set_rate_yawDP) },
+    { TUNING_SET_DP_ROLL_PITCH,         TUNING_ARRAY(tuning_set_dp_roll_pitch) },
+    { TUNING_SET_PIDFF_ROLL,            TUNING_ARRAY(tuning_set_pidff_roll) },
+    { TUNING_SET_PIDFF_PITCH,           TUNING_ARRAY(tuning_set_pidff_pitch) },
     { 0, 0, nullptr }
 };
 

--- a/ArduPlane/tuning.h
+++ b/ArduPlane/tuning.h
@@ -94,6 +94,9 @@ private:
         TUNING_SET_RATE_PITCHDP =            8,
         TUNING_SET_RATE_ROLLDP =             9,
         TUNING_SET_RATE_YAWDP =             10,
+        TUNING_SET_DP_ROLL_PITCH =          11,
+        TUNING_SET_PIDFF_ROLL =             12,
+        TUNING_SET_PIDFF_PITCH =            13,
     };
 
     AP_Float *get_param_pointer(uint8_t parm) override;
@@ -112,6 +115,9 @@ private:
     static const uint8_t tuning_set_rate_pitchDP[];
     static const uint8_t tuning_set_rate_rollDP[];
     static const uint8_t tuning_set_rate_yawDP[];
+    static const uint8_t tuning_set_dp_roll_pitch[];
+    static const uint8_t tuning_set_pidff_roll[];
+    static const uint8_t tuning_set_pidff_pitch[];
 
     // mask of what params have been set
     uint64_t have_set;

--- a/libraries/AP_Tuning/AP_Tuning.cpp
+++ b/libraries/AP_Tuning/AP_Tuning.cpp
@@ -218,6 +218,7 @@ void AP_Tuning::check_input(uint8_t flightmode)
     last_channel_value = chan_value;
 
     float new_value;
+    static float old_value;
     if (chan_value > 0) {
         new_value = linear_interpolate(center_value, range*center_value, chan_value, 0, 1);
     } else {
@@ -227,11 +228,14 @@ void AP_Tuning::check_input(uint8_t flightmode)
     need_revert |= (1U << current_parm_index);
     set_value(current_parm, new_value);
 
-    GCS_SEND_TEXT(MAV_SEVERITY_INFO, 
-        "Tuning %s%s%0.5f", 
-        get_tuning_name(current_parm), 
-        ((chan_value < dead_zone) && (chan_value > -dead_zone)) ? "> " : ": ", 
-        (double)(new_value));
+    if ( fabsf(new_value-old_value) > (0.05 * old_value) ) {
+        old_value = new_value;
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, 
+            "Tuning %s%s%0.4f", 
+            get_tuning_name(current_parm), 
+            ((chan_value < dead_zone) && (chan_value > -dead_zone)) ? "> " : ": ", 
+            (double)(new_value));
+    }
 
 #if HAL_LOGGING_ENABLED
     Log_Write_Parameter_Tuning(new_value);

--- a/libraries/AP_Tuning/AP_Tuning.cpp
+++ b/libraries/AP_Tuning/AP_Tuning.cpp
@@ -123,6 +123,7 @@ void AP_Tuning::re_center(void)
     AP_Float *f = get_param_pointer(current_parm);
     if (f != nullptr) {
         center_value = f->get();
+        old_value = 0.0;
     }
     mid_point_wait = true;
 }
@@ -218,7 +219,6 @@ void AP_Tuning::check_input(uint8_t flightmode)
     last_channel_value = chan_value;
 
     float new_value;
-    static float old_value;
     if (chan_value > 0) {
         new_value = linear_interpolate(center_value, range*center_value, chan_value, 0, 1);
     } else {
@@ -231,7 +231,7 @@ void AP_Tuning::check_input(uint8_t flightmode)
     if ( fabsf(new_value-old_value) > (0.05 * old_value) ) {
         old_value = new_value;
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, 
-            "Tuning %s%s%0.4f", 
+            "Tuning: %s%s%0.4f", 
             get_tuning_name(current_parm), 
             ((chan_value < dead_zone) && (chan_value > -dead_zone)) ? "> " : ": ", 
             (double)(new_value));

--- a/libraries/AP_Tuning/AP_Tuning.cpp
+++ b/libraries/AP_Tuning/AP_Tuning.cpp
@@ -202,10 +202,10 @@ void AP_Tuning::check_input(uint8_t flightmode)
 
     //hal.console->printf("chan_value %.2f last_channel_value %.2f\n", chan_value, last_channel_value);
 
+    const float dead_zone = 0.02;
     if (mid_point_wait) {
         // see if we have crossed the mid-point. We use a small deadzone to make it easier
         // to move to the "indent" portion of a slider to start tuning
-        const float dead_zone = 0.02;
         if ((chan_value > dead_zone && last_channel_value > 0) ||
             (chan_value < -dead_zone && last_channel_value < 0)) {
             // still waiting
@@ -213,7 +213,6 @@ void AP_Tuning::check_input(uint8_t flightmode)
         }
         // starting tuning
         mid_point_wait = false;
-        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Tuning: mid-point %s", get_tuning_name(current_parm));
         AP_Notify::events.tune_started = 1;
     }
     last_channel_value = chan_value;
@@ -227,6 +226,12 @@ void AP_Tuning::check_input(uint8_t flightmode)
     changed = true;
     need_revert |= (1U << current_parm_index);
     set_value(current_parm, new_value);
+
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, 
+        "Tuning %s%s%0.5f", 
+        get_tuning_name(current_parm), 
+        ((chan_value < dead_zone) && (chan_value > -dead_zone)) ? "> " : ": ", 
+        (double)(new_value));
 
 #if HAL_LOGGING_ENABLED
     Log_Write_Parameter_Tuning(new_value);

--- a/libraries/AP_Tuning/AP_Tuning.h
+++ b/libraries/AP_Tuning/AP_Tuning.h
@@ -64,6 +64,9 @@ private:
 
     uint32_t last_check_ms;
 
+    // last tuning value scaled
+    float old_value;
+    
     void Log_Write_Parameter_Tuning(float value);
     
     // the parameter we are tuning


### PR DESCRIPTION
This PR includes:

Displaying the current value of the parameter being tuned
![image](https://github.com/user-attachments/assets/a0164f60-5b6e-401c-907b-8e42c6bb215c)

When tuning knob is in the middle (note `>` instead of `:`):
![image](https://github.com/user-attachments/assets/ffafb0d5-d4ca-448d-a428-fe2da507e13c)


Adding PIDFF tuning sets for FixedWing mode:

1. D and P for Roll and Pitch (for quick post-autotune adjustments)
2. PIDFF for Roll
3. PIDFF for Pitch

These additions are primarily designed for tuning via FPV without requiring MAVLink modems.

I'll add PR for wiki once everything is settled, currently it is here https://github.com/Yury-MonZon/ardupilot_wiki/tree/patch-1
