### PR TITLE
update install-prepreqs-ubuntu.sh to support Ubuntu 24.10 Oracular

### DIFF
--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -120,6 +120,11 @@ elif [ ${RELEASE_CODENAME} == 'noble' ]; then
     SITLCFML_VERSION="2.6"
     PYTHON_V="python3"
     PIP=pip3
+elif [ ${RELEASE_CODENAME} == 'oracular' ]; then
+    SITLFML_VERSION="2.6"
+    SITLCFML_VERSION="2.6"
+    PYTHON_V="python3"
+    PIP=pip3
 elif [ ${RELEASE_CODENAME} == 'groovy' ] ||
          [ ${RELEASE_CODENAME} == 'bullseye' ]; then
     SITLFML_VERSION="2.5"
@@ -176,7 +181,8 @@ ARM_LINUX_PKGS="g++-arm-linux-gnueabihf $INSTALL_PKG_CONFIG"
 if [ ${RELEASE_CODENAME} == 'bookworm' ] ||
    [ ${RELEASE_CODENAME} == 'lunar' ] ||
    [ ${RELEASE_CODENAME} == 'mantic' ] ||
-   [ ${RELEASE_CODENAME} == 'noble' ]; then
+   [ ${RELEASE_CODENAME} == 'noble' ] ||
+   [ ${RELEASE_CODENAME} == 'oracular' ]; then
     # on Lunar (and presumably later releases), we install in venv, below
     PYTHON_PKGS+=" numpy pyparsing psutil"
     SITL_PKGS="python3-dev"
@@ -189,7 +195,8 @@ if [[ $SKIP_AP_GRAPHIC_ENV -ne 1 ]]; then
     if [ ${RELEASE_CODENAME} == 'bookworm' ] ||
        [ ${RELEASE_CODENAME} == 'lunar' ] ||
        [ ${RELEASE_CODENAME} == 'mantic' ] ||
-       [ ${RELEASE_CODENAME} == 'noble' ]; then
+       [ ${RELEASE_CODENAME} == 'noble' ] ||
+       [ ${RELEASE_CODENAME} == 'oracular' ]; then
         PYTHON_PKGS+=" matplotlib scipy opencv-python pyyaml"
         SITL_PKGS+=" xterm libcsfml-dev libcsfml-audio${SITLCFML_VERSION} libcsfml-dev libcsfml-graphics${SITLCFML_VERSION} libcsfml-network${SITLCFML_VERSION} libcsfml-system${SITLCFML_VERSION} libcsfml-window${SITLCFML_VERSION} libsfml-audio${SITLFML_VERSION} libsfml-dev libsfml-graphics${SITLFML_VERSION} libsfml-network${SITLFML_VERSION} libsfml-system${SITLFML_VERSION} libsfml-window${SITLFML_VERSION}"
   else
@@ -283,8 +290,9 @@ elif [ ${RELEASE_CODENAME} == 'lunar' ]; then
 elif [ ${RELEASE_CODENAME} == 'buster' ]; then
     SITL_PKGS+=" libpython3-stdlib" # for argparse
 elif [ ${RELEASE_CODENAME} != 'mantic' ] &&
-     [ ${RELEASE_CODENAME} != 'noble' ]; then
-  SITL_PKGS+=" python-argparse"
+     [ ${RELEASE_CODENAME} != 'noble' ] && 
+     [ ${RELEASE_CODENAME} != 'oracular' ]; then
+    SITL_PKGS+=" python-argparse"
 fi
 
 # Check for graphical package for MAVProxy
@@ -303,6 +311,9 @@ if [[ $SKIP_AP_GRAPHIC_ENV -ne 1 ]]; then
     SITL_PKGS+=" libgtk-3-dev libwxgtk3.2-dev "
     # see below
   elif [ ${RELEASE_CODENAME} == 'noble' ]; then
+    SITL_PKGS+=" libgtk-3-dev libwxgtk3.2-dev "
+    # see below
+  elif [ ${RELEASE_CODENAME} == 'oracular' ]; then
     SITL_PKGS+=" libgtk-3-dev libwxgtk3.2-dev "
     # see below
   elif apt-cache search python-wxgtk3.0 | grep wx; then
@@ -325,7 +336,8 @@ if [[ $SKIP_AP_GRAPHIC_ENV -ne 1 ]]; then
       SITL_PKGS+=" python3-wxgtk4.0"
       SITL_PKGS+=" fonts-freefont-ttf libfreetype6-dev libpng16-16 libportmidi-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev"  # for pygame
   elif [ ${RELEASE_CODENAME} == 'mantic' ] ||
-       [ ${RELEASE_CODENAME} == 'noble' ]; then
+       [ ${RELEASE_CODENAME} == 'noble' ] ||
+       [ ${RELEASE_CODENAME} == 'oracular' ]; then
       PYTHON_PKGS+=" wxpython opencv-python"
       SITL_PKGS+=" python3-wxgtk4.0"
       SITL_PKGS+=" fonts-freefont-ttf libfreetype6-dev libpng16-16 libportmidi-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev"  # for pygame
@@ -380,6 +392,8 @@ if [ ${RELEASE_CODENAME} == 'bookworm' ] ||
     PYTHON_VENV_PACKAGE=python3.11-venv
 elif [ ${RELEASE_CODENAME} == 'noble' ]; then
     PYTHON_VENV_PACKAGE=python3.12-venv
+elif [ ${RELEASE_CODENAME} == 'oracular' ]; then
+    PYTHON_VENV_PACKAGE=python3.12-venv
 fi
 
 if [ -n "$PYTHON_VENV_PACKAGE" ]; then
@@ -416,7 +430,8 @@ fi
 if [ ${RELEASE_CODENAME} == 'bookworm' ] ||
    [ ${RELEASE_CODENAME} == 'lunar' ] ||
    [ ${RELEASE_CODENAME} == 'mantic' ] ||
-   [ ${RELEASE_CODENAME} == 'noble' ]; then
+   [ ${RELEASE_CODENAME} == 'noble' ] ||
+   [ ${RELEASE_CODENAME} == 'oracular' ]; then
     # must do this ahead of wxPython pip3 run :-/
     $PIP install $PIP_USER_ARGUMENT -U attrdict3
 fi


### PR DESCRIPTION
With these changes a fresh install of Ubuntu 24.10 could use the setup script in 'Tools/environment_install/install-prepreqs-ubuntu.sh'. I tested running the SITL afterwards and everything seems to work.