### PR TITLE
AP_TECS: Removed an unused variable to get rid of a compiler warning

### DIFF
--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -219,9 +219,6 @@ private:
     AP_Float _pitch_ff_k;
     AP_Float _accel_gf;
 
-    // temporary _pitch_max_limit. Cleared on each loop. Clear when >= 90
-    int8_t _pitch_max_limit = 90;
-    
     // current height estimate (above field elevation)
     float _height;
 


### PR DESCRIPTION
In the Qurt ardupilot build there is a warning for the unused variable. So, I removed it to get rid of the warning.
