### PR TITLE
AP_HAL_ESP32: add targets to measure static memory sizes

### DIFF
--- a/libraries/AP_HAL_ESP32/targets/esp32/esp-idf/CMakeLists.txt
+++ b/libraries/AP_HAL_ESP32/targets/esp32/esp-idf/CMakeLists.txt
@@ -123,3 +123,76 @@ idf_build_executable(${elf_file})
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 
+# Additional targets for measuring RAM use: size, size-components, size-files
+#   - Adapted from ${IDF_PATH}/tools/cmake/project.cmake
+#
+# Reference:
+#   - https://docs.espressif.com/projects/esp-idf/en/v5.0/esp32s3/api-guides/performance/size.html#minimizing-binary-size
+#
+# Usage:
+#   cd ./build/esp32s3xxx/esp-idf_build
+#   ninja -v -v size
+#
+set(mapfile "${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.map")
+# Add cross-reference table to the map file
+target_link_options(${elf_file} PRIVATE "-Wl,--cref")
+# Add this symbol as a hint for esp_idf_size to guess the target name
+target_link_options(${elf_file} PRIVATE "-Wl,--defsym=IDF_TARGET_${idf_target}=0")
+# Enable map file output
+target_link_options(${elf_file} PRIVATE "-Wl,--Map=${mapfile}")
+# Check if linker supports --no-warn-rwx-segments
+execute_process(COMMAND ${CMAKE_LINKER} "--no-warn-rwx-segments" "--version"
+    RESULT_VARIABLE result
+    OUTPUT_QUIET
+    ERROR_QUIET)
+if(${result} EQUAL 0)
+    # Do not print RWX segment warnings
+    target_link_options(${elf_file} PRIVATE "-Wl,--no-warn-rwx-segments")
+endif()
+if(CONFIG_ESP_ORPHAN_SECTION_WARNING)
+    # Print warnings if orphan sections are found
+    target_link_options(${elf_file} PRIVATE "-Wl,--orphan-handling=warn")
+endif()
+
+idf_build_get_property(idf_path IDF_PATH)
+idf_build_get_property(python PYTHON)
+
+set(idf_size ${python} -m esp_idf_size)
+
+# Add size targets, depend on map file, run esp_idf_size
+# OUTPUT_JSON is passed for compatibility reasons, SIZE_OUTPUT_FORMAT
+# environment variable is recommended and has higher priority
+add_custom_target(size
+    COMMAND ${CMAKE_COMMAND}
+    -D "IDF_SIZE_TOOL=${idf_size}"
+    -D "MAP_FILE=${mapfile}"
+    -D "OUTPUT_JSON=${OUTPUT_JSON}"
+    -P "${idf_path}/tools/cmake/run_size_tool.cmake"
+    DEPENDS ${mapfile}
+    USES_TERMINAL
+    VERBATIM
+)
+
+add_custom_target(size-files
+    COMMAND ${CMAKE_COMMAND}
+    -D "IDF_SIZE_TOOL=${idf_size}"
+    -D "IDF_SIZE_MODE=--files"
+    -D "MAP_FILE=${mapfile}"
+    -D "OUTPUT_JSON=${OUTPUT_JSON}"
+    -P "${idf_path}/tools/cmake/run_size_tool.cmake"
+    DEPENDS ${mapfile}
+    USES_TERMINAL
+    VERBATIM
+)
+
+add_custom_target(size-components
+    COMMAND ${CMAKE_COMMAND}
+    -D "IDF_SIZE_TOOL=${idf_size}"
+    -D "IDF_SIZE_MODE=--archives"
+    -D "MAP_FILE=${mapfile}"
+    -D "OUTPUT_JSON=${OUTPUT_JSON}"
+    -P "${idf_path}/tools/cmake/run_size_tool.cmake"
+    DEPENDS ${mapfile}
+    USES_TERMINAL
+    VERBATIM
+)

--- a/libraries/AP_HAL_ESP32/targets/esp32s3/esp-idf/CMakeLists.txt
+++ b/libraries/AP_HAL_ESP32/targets/esp32s3/esp-idf/CMakeLists.txt
@@ -122,3 +122,77 @@ target_link_libraries(${elf_file}
 idf_build_executable(${elf_file})
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
+
+# Additional targets for measuring RAM use: size, size-components, size-files
+#   - Adapted from ${IDF_PATH}/tools/cmake/project.cmake
+#
+# Reference:
+#   - https://docs.espressif.com/projects/esp-idf/en/v5.0/esp32s3/api-guides/performance/size.html#minimizing-binary-size
+#
+# Usage:
+#   cd ./build/esp32s3xxx/esp-idf_build
+#   ninja -v -v size
+#
+set(mapfile "${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.map")
+# Add cross-reference table to the map file
+target_link_options(${elf_file} PRIVATE "-Wl,--cref")
+# Add this symbol as a hint for esp_idf_size to guess the target name
+target_link_options(${elf_file} PRIVATE "-Wl,--defsym=IDF_TARGET_${idf_target}=0")
+# Enable map file output
+target_link_options(${elf_file} PRIVATE "-Wl,--Map=${mapfile}")
+# Check if linker supports --no-warn-rwx-segments
+execute_process(COMMAND ${CMAKE_LINKER} "--no-warn-rwx-segments" "--version"
+    RESULT_VARIABLE result
+    OUTPUT_QUIET
+    ERROR_QUIET)
+if(${result} EQUAL 0)
+    # Do not print RWX segment warnings
+    target_link_options(${elf_file} PRIVATE "-Wl,--no-warn-rwx-segments")
+endif()
+if(CONFIG_ESP_ORPHAN_SECTION_WARNING)
+    # Print warnings if orphan sections are found
+    target_link_options(${elf_file} PRIVATE "-Wl,--orphan-handling=warn")
+endif()
+
+idf_build_get_property(idf_path IDF_PATH)
+idf_build_get_property(python PYTHON)
+
+set(idf_size ${python} -m esp_idf_size)
+
+# Add size targets, depend on map file, run esp_idf_size
+# OUTPUT_JSON is passed for compatibility reasons, SIZE_OUTPUT_FORMAT
+# environment variable is recommended and has higher priority
+add_custom_target(size
+    COMMAND ${CMAKE_COMMAND}
+    -D "IDF_SIZE_TOOL=${idf_size}"
+    -D "MAP_FILE=${mapfile}"
+    -D "OUTPUT_JSON=${OUTPUT_JSON}"
+    -P "${idf_path}/tools/cmake/run_size_tool.cmake"
+    DEPENDS ${mapfile}
+    USES_TERMINAL
+    VERBATIM
+)
+
+add_custom_target(size-files
+    COMMAND ${CMAKE_COMMAND}
+    -D "IDF_SIZE_TOOL=${idf_size}"
+    -D "IDF_SIZE_MODE=--files"
+    -D "MAP_FILE=${mapfile}"
+    -D "OUTPUT_JSON=${OUTPUT_JSON}"
+    -P "${idf_path}/tools/cmake/run_size_tool.cmake"
+    DEPENDS ${mapfile}
+    USES_TERMINAL
+    VERBATIM
+)
+
+add_custom_target(size-components
+    COMMAND ${CMAKE_COMMAND}
+    -D "IDF_SIZE_TOOL=${idf_size}"
+    -D "IDF_SIZE_MODE=--archives"
+    -D "MAP_FILE=${mapfile}"
+    -D "OUTPUT_JSON=${OUTPUT_JSON}"
+    -P "${idf_path}/tools/cmake/run_size_tool.cmake"
+    DEPENDS ${mapfile}
+    USES_TERMINAL
+    VERBATIM
+)


### PR DESCRIPTION
Add targets from `${IDF_PATH}/tools/cmake/project.cmake` to measure the allocation of static memory.

These targets: `size`, `size-components`, `size-files`, may be used in the board build directory. For example if `board=esp32s3empty`:

```bash
$ cd ./build/esp32s3empty/esp-idf_build
$ ninja -v -v size

Total sizes:
Used stat D/IRAM:  243738 bytes (  98022 remain, 71.3% used)
      .data size:   14796 bytes
      .bss  size:  130256 bytes
      .text size:   97659 bytes
   .vectors size:    1027 bytes
Used Flash size : 1122994 bytes
           .text:  925938 bytes
         .rodata:  196800 bytes
Total image size: 1236476 bytes (.bin may be padded larger)
```
