### PR TITLE
Do not allow users to set throttle-based notch in Heli 

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1006,6 +1006,16 @@ AP_InertialSensor::init(uint16_t loop_rate)
 #endif
 
 #if AP_INERTIALSENSOR_HARMONICNOTCH_ENABLED
+
+#if APM_BUILD_TYPE(APM_BUILD_Heli)
+    // Throttle tracking does not make sense with heli because "throttle" is actually collective position in AP_MotorsHeli
+    for (auto &notch : harmonic_notches) {
+        if (notch.params.enabled() && notch.params.tracking_mode() == HarmonicNotchDynamicMode::UpdateThrottle) {
+            AP_BoardConfig::config_error("Throttle notch unavailable with heli");
+        }
+    }
+#endif
+
     // the center frequency of the harmonic notch is always taken from the calculated value so that it can be updated
     // dynamically, the calculated value is always some multiple of the configured center frequency, so start with the
     // configured value

--- a/libraries/Filter/HarmonicNotchFilter.cpp
+++ b/libraries/Filter/HarmonicNotchFilter.cpp
@@ -21,6 +21,7 @@
 #include "HarmonicNotchFilter.h"
 #include <GCS_MAVLink/GCS.h>
 #include <AP_Logger/AP_Logger.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 
 #define HNF_MAX_FILTERS HAL_HNF_MAX_FILTERS // must be even for double-notch filters
 
@@ -47,6 +48,13 @@
   point at which the harmonic notch goes to zero attenuation
  */
 #define NOTCHFILTER_ATTENUATION_CUTOFF 0.25
+
+#if APM_BUILD_TYPE(APM_BUILD_Heli)
+    // We cannot use throttle based notch on helis
+    #define NOTCHFILTER_DEFAULT_MODE float(HarmonicNotchDynamicMode::Fixed) // fixed
+#else
+    #define NOTCHFILTER_DEFAULT_MODE float(HarmonicNotchDynamicMode::UpdateThrottle) // throttle based
+#endif
 
 
 // table of user settable parameters
@@ -120,7 +128,7 @@ const AP_Param::GroupInfo HarmonicNotchFilterParams::var_info[] = {
     // @Range: 0 5
     // @Values: 0:Fixed,1:Throttle,2:RPM Sensor,3:ESC Telemetry,4:Dynamic FFT,5:Second RPM Sensor
     // @User: Advanced
-    AP_GROUPINFO("MODE", 7, HarmonicNotchFilterParams, _tracking_mode, int8_t(HarmonicNotchDynamicMode::UpdateThrottle)),
+    AP_GROUPINFO("MODE", 7, HarmonicNotchFilterParams, _tracking_mode, NOTCHFILTER_DEFAULT_MODE),
 
     // @Param: OPTS
     // @DisplayName: Harmonic Notch Filter options


### PR DESCRIPTION
My attempt at fixing issue: #28841

Throttle is not "Throttle" in AP_MotorsHeli, it is actually collective position.  Therefore, throttle-based tracking does not make any sense for Heli.

This is a subtly that most users will not appreciate, therefore we should help users to not make this mistake by throwing a config error if selected.

Have also changed the default notch mode for heli.

Tested in SITL only.  This is how it presents to the user upon miss-configuration:

![image](https://github.com/user-attachments/assets/cce1783a-0ff0-448d-960b-6192cf9b0304)