### PR TITLE
.github: esp32_build: use default cmake package

### DIFF
--- a/.github/workflows/esp32_build.yml
+++ b/.github/workflows/esp32_build.yml
@@ -175,7 +175,7 @@ jobs:
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install git wget libncurses-dev flex bison gperf python3 python3-pip python3-venv python3-setuptools python3-serial python3-gevent python3-cryptography python3-future python3-pyparsing python3-pyelftools cmake ninja-build ccache libffi-dev libssl-dev dfu-util libusb-1.0-0
+          sudo apt-get install git wget libncurses-dev flex bison gperf python3 python3-pip python3-venv python3-setuptools python3-serial python3-gevent python3-cryptography python3-future python3-pyparsing python3-pyelftools cmake ninja-build ccache libffi-dev libssl-dev dfu-util libusb-1.0-0 cmake
           sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
           update-alternatives --query python
           python3 --version
@@ -193,17 +193,6 @@ jobs:
           which python3.11
           sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.11 11
           update-alternatives --query python
-
-          rm -rf /usr/local/bin/cmake
-          sudo apt-get remove --purge --auto-remove cmake
-          sudo apt-get update && \
-          sudo apt-get install -y software-properties-common lsb-release && \
-          sudo apt-get clean all
-          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
-          sudo apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main"
-          sudo apt-get update
-          sudo apt-get install cmake
-
 
           git submodule update --init --recursive --depth=1
           ./Tools/scripts/esp32_get_idf.sh

--- a/libraries/AP_HAL_ESP32/targets/esp32/esp-idf/CMakeLists.txt
+++ b/libraries/AP_HAL_ESP32/targets/esp32/esp-idf/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 set(CMAKE_TOOLCHAIN_FILE $ENV{IDF_PATH}/tools/cmake/toolchain-esp32.cmake CACHE STRING "")
 

--- a/libraries/AP_HAL_ESP32/targets/esp32s3/esp-idf/CMakeLists.txt
+++ b/libraries/AP_HAL_ESP32/targets/esp32s3/esp-idf/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 set(CMAKE_TOOLCHAIN_FILE $ENV{IDF_PATH}/tools/cmake/toolchain-esp32s3.cmake CACHE STRING "")
 


### PR DESCRIPTION
Use the default Ubuntu package for cmake rather than install the latest from kitware.

- The esp-idf requires a cmake minimum version of 3.16 (https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/build-system.html#mandatory-parts)
- The Ubuntu 22.04 package for cmake installs version 3.22.1 (https://launchpad.net/ubuntu/jammy/+source/cmake).
- => default package from `sudo apt install cmake` meets requirements
