### PR TITLE
AP_BattMonitor: make INA3221 parameters visible for metadata gen

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -69,6 +69,12 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_INA2xx.cpp
     // @Group: _
     // @Path: AP_BattMonitor_ESC.cpp
+    // @Group: _
+    // @Path: AP_BattMonitor_INA239.cpp
+    // @Group: _
+    // @Path: AP_BattMonitor_INA3221.cpp
+    // @Group: _
+    // @Path: AP_BattMonitor_AD7091R5.cpp
     AP_SUBGROUPVARPTR(drivers[0], "_", 41, AP_BattMonitor, backend_var_info[0]),
 
 #if AP_BATT_MONITOR_MAX_INSTANCES > 1
@@ -92,6 +98,12 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_INA2xx.cpp
     // @Group: 2_
     // @Path: AP_BattMonitor_ESC.cpp
+    // @Group: 2_
+    // @Path: AP_BattMonitor_INA239.cpp
+    // @Group: 2_
+    // @Path: AP_BattMonitor_INA3221.cpp
+    // @Group: 2_
+    // @Path: AP_BattMonitor_AD7091R5.cpp
     AP_SUBGROUPVARPTR(drivers[1], "2_", 42, AP_BattMonitor, backend_var_info[1]),
 #endif
 
@@ -116,6 +128,12 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_INA2xx.cpp
     // @Group: 3_
     // @Path: AP_BattMonitor_ESC.cpp
+    // @Group: 3_
+    // @Path: AP_BattMonitor_INA239.cpp
+    // @Group: 3_
+    // @Path: AP_BattMonitor_INA3221.cpp
+    // @Group: 3_
+    // @Path: AP_BattMonitor_AD7091R5.cpp
     AP_SUBGROUPVARPTR(drivers[2], "3_", 43, AP_BattMonitor, backend_var_info[2]),
 #endif
 
@@ -140,6 +158,12 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_INA2xx.cpp
     // @Group: 4_
     // @Path: AP_BattMonitor_ESC.cpp
+    // @Group: 4_
+    // @Path: AP_BattMonitor_INA239.cpp
+    // @Group: 4_
+    // @Path: AP_BattMonitor_INA3221.cpp
+    // @Group: 4_
+    // @Path: AP_BattMonitor_AD7091R5.cpp
     AP_SUBGROUPVARPTR(drivers[3], "4_", 44, AP_BattMonitor, backend_var_info[3]),
 #endif
 
@@ -164,6 +188,12 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_INA2xx.cpp
     // @Group: 5_
     // @Path: AP_BattMonitor_ESC.cpp
+    // @Group: 5_
+    // @Path: AP_BattMonitor_INA239.cpp
+    // @Group: 5_
+    // @Path: AP_BattMonitor_INA3221.cpp
+    // @Group: 5_
+    // @Path: AP_BattMonitor_AD7091R5.cpp
     AP_SUBGROUPVARPTR(drivers[4], "5_", 45, AP_BattMonitor, backend_var_info[4]),
 #endif
 
@@ -188,6 +218,12 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_INA2xx.cpp
     // @Group: 6_
     // @Path: AP_BattMonitor_ESC.cpp
+    // @Group: 6_
+    // @Path: AP_BattMonitor_INA239.cpp
+    // @Group: 6_
+    // @Path: AP_BattMonitor_INA3221.cpp
+    // @Group: 6_
+    // @Path: AP_BattMonitor_AD7091R5.cpp
     AP_SUBGROUPVARPTR(drivers[5], "6_", 46, AP_BattMonitor, backend_var_info[5]),
 #endif
 
@@ -212,6 +248,12 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_INA2xx.cpp
     // @Group: 7_
     // @Path: AP_BattMonitor_ESC.cpp
+    // @Group: 7_
+    // @Path: AP_BattMonitor_INA239.cpp
+    // @Group: 7_
+    // @Path: AP_BattMonitor_INA3221.cpp
+    // @Group: 7_
+    // @Path: AP_BattMonitor_AD7091R5.cpp
     AP_SUBGROUPVARPTR(drivers[6], "7_", 47, AP_BattMonitor, backend_var_info[6]),
 #endif
 
@@ -236,6 +278,12 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_INA2xx.cpp
     // @Group: 8_
     // @Path: AP_BattMonitor_ESC.cpp
+    // @Group: 8_
+    // @Path: AP_BattMonitor_INA239.cpp
+    // @Group: 8_
+    // @Path: AP_BattMonitor_INA3221.cpp
+    // @Group: 8_
+    // @Path: AP_BattMonitor_AD7091R5.cpp
     AP_SUBGROUPVARPTR(drivers[7], "8_", 48, AP_BattMonitor, backend_var_info[7]),
 #endif
 
@@ -260,6 +308,12 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_INA2xx.cpp
     // @Group: 9_
     // @Path: AP_BattMonitor_ESC.cpp
+    // @Group: 9_
+    // @Path: AP_BattMonitor_INA239.cpp
+    // @Group: 9_
+    // @Path: AP_BattMonitor_INA3221.cpp
+    // @Group: 9_
+    // @Path: AP_BattMonitor_AD7091R5.cpp
     AP_SUBGROUPVARPTR(drivers[8], "9_", 49, AP_BattMonitor, backend_var_info[8]),
 #endif
 
@@ -284,6 +338,12 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_INA2xx.cpp
     // @Group: A_
     // @Path: AP_BattMonitor_ESC.cpp
+    // @Group: A_
+    // @Path: AP_BattMonitor_INA239.cpp
+    // @Group: A_
+    // @Path: AP_BattMonitor_INA3221.cpp
+    // @Group: A_
+    // @Path: AP_BattMonitor_AD7091R5.cpp
     AP_SUBGROUPVARPTR(drivers[9], "A_", 50, AP_BattMonitor, backend_var_info[9]),
 #endif
 
@@ -308,6 +368,12 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_INA2xx.cpp
     // @Group: B_
     // @Path: AP_BattMonitor_ESC.cpp
+    // @Group: B_
+    // @Path: AP_BattMonitor_INA239.cpp
+    // @Group: B_
+    // @Path: AP_BattMonitor_INA3221.cpp
+    // @Group: B_
+    // @Path: AP_BattMonitor_AD7091R5.cpp
     AP_SUBGROUPVARPTR(drivers[10], "B_", 51, AP_BattMonitor, backend_var_info[10]),
 #endif
 
@@ -332,6 +398,12 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_INA2xx.cpp
     // @Group: C_
     // @Path: AP_BattMonitor_ESC.cpp
+    // @Group: C_
+    // @Path: AP_BattMonitor_INA239.cpp
+    // @Group: C_
+    // @Path: AP_BattMonitor_INA3221.cpp
+    // @Group: C_
+    // @Path: AP_BattMonitor_AD7091R5.cpp
     AP_SUBGROUPVARPTR(drivers[11], "C_", 52, AP_BattMonitor, backend_var_info[11]),
 #endif
 
@@ -356,6 +428,12 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_INA2xx.cpp
     // @Group: D_
     // @Path: AP_BattMonitor_ESC.cpp
+    // @Group: D_
+    // @Path: AP_BattMonitor_INA239.cpp
+    // @Group: D_
+    // @Path: AP_BattMonitor_INA3221.cpp
+    // @Group: D_
+    // @Path: AP_BattMonitor_AD7091R5.cpp
     AP_SUBGROUPVARPTR(drivers[12], "D_", 53, AP_BattMonitor, backend_var_info[12]),
 #endif
 
@@ -380,6 +458,12 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_INA2xx.cpp
     // @Group: E_
     // @Path: AP_BattMonitor_ESC.cpp
+    // @Group: E_
+    // @Path: AP_BattMonitor_INA239.cpp
+    // @Group: E_
+    // @Path: AP_BattMonitor_INA3221.cpp
+    // @Group: E_
+    // @Path: AP_BattMonitor_AD7091R5.cpp
     AP_SUBGROUPVARPTR(drivers[13], "E_", 54, AP_BattMonitor, backend_var_info[13]),
 #endif
 
@@ -404,6 +488,12 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_INA2xx.cpp
     // @Group: F_
     // @Path: AP_BattMonitor_ESC.cpp
+    // @Group: F_
+    // @Path: AP_BattMonitor_INA239.cpp
+    // @Group: F_
+    // @Path: AP_BattMonitor_INA3221.cpp
+    // @Group: F_
+    // @Path: AP_BattMonitor_AD7091R5.cpp
     AP_SUBGROUPVARPTR(drivers[14], "F_", 55, AP_BattMonitor, backend_var_info[14]),
 #endif
 
@@ -428,6 +518,12 @@ const AP_Param::GroupInfo AP_BattMonitor::var_info[] = {
     // @Path: AP_BattMonitor_INA2xx.cpp
     // @Group: G_
     // @Path: AP_BattMonitor_ESC.cpp
+    // @Group: G_
+    // @Path: AP_BattMonitor_INA239.cpp
+    // @Group: G_
+    // @Path: AP_BattMonitor_INA3221.cpp
+    // @Group: G_
+    // @Path: AP_BattMonitor_AD7091R5.cpp
     AP_SUBGROUPVARPTR(drivers[15], "G_", 56, AP_BattMonitor, backend_var_info[15]),
 #endif
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_AD7091R5.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_AD7091R5.cpp
@@ -84,7 +84,7 @@ const AP_Param::GroupInfo AP_BattMonitor_AD7091R5::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("VLT_OFFSET", 61, AP_BattMonitor_AD7091R5, _volt_offset, 0),
 
-    // Param indexes must be 56 to 61 to avoid conflict with other battery monitor param tables loaded by pointer
+    // CHECK/UPDATE INDEX TABLE IN AP_BattMonitor_Backend.cpp WHEN CHANGING OR ADDING PARAMETERS
 
     AP_GROUPEND
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
@@ -55,7 +55,7 @@ const AP_Param::GroupInfo AP_BattMonitor_Analog::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("VLT_OFFSET", 6, AP_BattMonitor_Analog, _volt_offset, 0),
     
-    // Param indexes must be less than 10 to avoid conflict with other battery monitor param tables loaded by pointer
+    // CHECK/UPDATE INDEX TABLE IN AP_BattMonitor_Backend.cpp WHEN CHANGING OR ADDING PARAMETERS
 
     AP_GROUPEND
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
@@ -27,6 +27,27 @@
 #endif
 
 /*
+  All backends use the same parameter table and set of indices. Therefore, two
+  backends must not use the same index. The list of used indices and
+  corresponding backends is below.
+
+    1-6:    AP_BattMonitor_Analog.cpp
+    10-11:  AP_BattMonitor_SMBus.cpp
+    20:     AP_BattMonitor_Sum.cpp
+    25-26:  AP_BattMonitor_INA2xx.cpp
+    27-28:  AP_BattMonitor_INA2xx.cpp, AP_BattMonitor_INA239.cpp (legacy duplication)
+    30:     AP_BattMonitor_DroneCAN.cpp
+    36:     AP_BattMonitor_ESC.cpp
+    40-43:  AP_BattMonitor_FuelLevel_Analog.cpp
+    45-48:  AP_BattMonitor_FuelLevel_Analog.cpp
+    50-51:  AP_BattMonitor_Synthetic_Current.cpp
+    56-58:  AP_BattMonitor_INA3221.cpp
+    56-61:  AP_BattMonitor_AD7091R5.cpp
+
+  Usage does not need to be contiguous. The maximum possible index is 63.
+*/
+
+/*
   base class constructor.
   This incorporates initialisation as well.
 */

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
@@ -34,6 +34,7 @@
     1-6:    AP_BattMonitor_Analog.cpp
     10-11:  AP_BattMonitor_SMBus.cpp
     20:     AP_BattMonitor_Sum.cpp
+    22-24:  AP_BattMonitor_INA3221.cpp
     25-26:  AP_BattMonitor_INA2xx.cpp
     27-28:  AP_BattMonitor_INA2xx.cpp, AP_BattMonitor_INA239.cpp (legacy duplication)
     30:     AP_BattMonitor_DroneCAN.cpp
@@ -41,7 +42,6 @@
     40-43:  AP_BattMonitor_FuelLevel_Analog.cpp
     45-48:  AP_BattMonitor_FuelLevel_Analog.cpp
     50-51:  AP_BattMonitor_Synthetic_Current.cpp
-    56-58:  AP_BattMonitor_INA3221.cpp
     56-61:  AP_BattMonitor_AD7091R5.cpp
 
   Usage does not need to be contiguous. The maximum possible index is 63.

--- a/libraries/AP_BattMonitor/AP_BattMonitor_DroneCAN.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_DroneCAN.cpp
@@ -26,7 +26,7 @@ const AP_Param::GroupInfo AP_BattMonitor_DroneCAN::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("CURR_MULT", 30, AP_BattMonitor_DroneCAN, _curr_mult, 1.0),
 
-    // Param indexes must be between 30 and 35 to avoid conflict with other battery monitor param tables loaded by pointer
+    // CHECK/UPDATE INDEX TABLE IN AP_BattMonitor_Backend.cpp WHEN CHANGING OR ADDING PARAMETERS
 
     AP_GROUPEND
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_ESC.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_ESC.cpp
@@ -22,8 +22,6 @@
 
 const AP_Param::GroupInfo AP_BattMonitor_ESC::var_info[] = {
 
-    // Param indexes must be between 36 and 39 to avoid conflict with other battery monitor param tables loaded by pointer
-
     // @Param: ESC_MASK
     // @DisplayName: ESC mask
     // @Description: If 0 all connected ESCs will be used. If non-zero, only those selected in will be used.
@@ -31,7 +29,7 @@ const AP_Param::GroupInfo AP_BattMonitor_ESC::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("ESC_MASK", 36, AP_BattMonitor_ESC, _mask, 0),
 
-    // Param indexes must be between 36 and 39 to avoid conflict with other battery monitor param tables loaded by pointer
+    // CHECK/UPDATE INDEX TABLE IN AP_BattMonitor_Backend.cpp WHEN CHANGING OR ADDING PARAMETERS
 
     AP_GROUPEND
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_FuelLevel_Analog.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_FuelLevel_Analog.cpp
@@ -58,8 +58,6 @@ const AP_Param::GroupInfo AP_BattMonitor_FuelLevel_Analog::var_info[] = {
      // @Values: -1:Disabled, 2:Pixhawk/Pixracer/Navio2/Pixhawk2_PM1, 5:Navigator, 13:Pixhawk2_PM2/CubeOrange_PM2, 14:CubeOrange, 16:Durandal, 100:PX4-v1
     AP_GROUPINFO("FL_PIN", 43, AP_BattMonitor_FuelLevel_Analog, _pin, -1),
 
- // index 44 unused and available
-
     // @Param: FL_FF
     // @DisplayName: First order term
     // @Description: First order polynomial fit term
@@ -88,7 +86,7 @@ const AP_Param::GroupInfo AP_BattMonitor_FuelLevel_Analog::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("FL_OFF", 48, AP_BattMonitor_FuelLevel_Analog, _fuel_fit_offset, 0),    
 
-    // Param indexes must be between 40 and 49 to avoid conflict with other battery monitor param tables loaded by pointer
+    // CHECK/UPDATE INDEX TABLE IN AP_BattMonitor_Backend.cpp WHEN CHANGING OR ADDING PARAMETERS
 
     AP_GROUPEND
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_INA239.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_INA239.cpp
@@ -47,7 +47,9 @@ const AP_Param::GroupInfo AP_BattMonitor_INA239::var_info[] = {
     // @Units: Ohm
     // @User: Advanced
     AP_GROUPINFO("SHUNT", 28, AP_BattMonitor_INA239, rShunt, HAL_BATTMON_INA239_SHUNT_RESISTANCE),
-    
+
+    // CHECK/UPDATE INDEX TABLE IN AP_BattMonitor_Backend.cpp WHEN CHANGING OR ADDING PARAMETERS
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_INA2xx.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_INA2xx.cpp
@@ -108,7 +108,9 @@ const AP_Param::GroupInfo AP_BattMonitor_INA2XX::var_info[] = {
     // @Units: Ohm
     // @User: Advanced
     AP_GROUPINFO("SHUNT", 28, AP_BattMonitor_INA2XX, rShunt, DEFAULT_BATTMON_INA2XX_SHUNT),
-    
+
+    // CHECK/UPDATE INDEX TABLE IN AP_BattMonitor_Backend.cpp WHEN CHANGING OR ADDING PARAMETERS
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_INA3221.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_INA3221.cpp
@@ -67,8 +67,6 @@ uint8_t AP_BattMonitor_INA3221::address_driver_count;
 
 const AP_Param::GroupInfo AP_BattMonitor_INA3221::var_info[] = {
 
-    // Param indexes must be between 56 and 61 to avoid conflict with other battery monitor param tables loaded by pointer
-
     // @Param: I2C_BUS
     // @DisplayName: Battery monitor I2C bus number
     // @Description: Battery monitor I2C bus number
@@ -92,6 +90,8 @@ const AP_Param::GroupInfo AP_BattMonitor_INA3221::var_info[] = {
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO("CHANNEL", 58, AP_BattMonitor_INA3221, channel, 1),
+
+    // CHECK/UPDATE INDEX TABLE IN AP_BattMonitor_Backend.cpp WHEN CHANGING OR ADDING PARAMETERS
 
     AP_GROUPEND
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_INA3221.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_INA3221.cpp
@@ -73,7 +73,7 @@ const AP_Param::GroupInfo AP_BattMonitor_INA3221::var_info[] = {
     // @Range: 0 3
     // @User: Advanced
     // @RebootRequired: True
-    AP_GROUPINFO("I2C_BUS", 56, AP_BattMonitor_INA3221, i2c_bus, HAL_BATTMON_INA3221_BUS),
+    AP_GROUPINFO("I2C_BUS", 22, AP_BattMonitor_INA3221, i2c_bus, HAL_BATTMON_INA3221_BUS),
 
     // @Param: I2C_ADDR
     // @DisplayName: Battery monitor I2C address
@@ -81,7 +81,7 @@ const AP_Param::GroupInfo AP_BattMonitor_INA3221::var_info[] = {
     // @Range: 0 127
     // @User: Advanced
     // @RebootRequired: True
-    AP_GROUPINFO("I2C_ADDR", 57, AP_BattMonitor_INA3221, i2c_address, HAL_BATTMON_INA3221_ADDR),
+    AP_GROUPINFO("I2C_ADDR", 23, AP_BattMonitor_INA3221, i2c_address, HAL_BATTMON_INA3221_ADDR),
 
     // @Param: CHANNEL
     // @DisplayName: INA3221 channel
@@ -89,7 +89,7 @@ const AP_Param::GroupInfo AP_BattMonitor_INA3221::var_info[] = {
     // @Range: 1 3
     // @User: Advanced
     // @RebootRequired: True
-    AP_GROUPINFO("CHANNEL", 58, AP_BattMonitor_INA3221, channel, 1),
+    AP_GROUPINFO("CHANNEL", 24, AP_BattMonitor_INA3221, channel, 1),
 
     // CHECK/UPDATE INDEX TABLE IN AP_BattMonitor_Backend.cpp WHEN CHANGING OR ADDING PARAMETERS
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp
@@ -10,8 +10,6 @@ extern const AP_HAL::HAL& hal;
 
 const AP_Param::GroupInfo AP_BattMonitor_SMBus::var_info[] = {
 
-    // Param indexes must be between 10 and 19 to avoid conflict with other battery monitor param tables loaded by pointer
-
     // @Param: I2C_BUS
     // @DisplayName: Battery monitor I2C bus number
     // @Description: Battery monitor I2C bus number
@@ -28,7 +26,7 @@ const AP_Param::GroupInfo AP_BattMonitor_SMBus::var_info[] = {
     // @RebootRequired: True
     AP_GROUPINFO("I2C_ADDR", 11, AP_BattMonitor_SMBus, _address, AP_BATTMONITOR_SMBUS_I2C_ADDR),
 
-    // Param indexes must be between 10 and 19 to avoid conflict with other battery monitor param tables loaded by pointer
+    // CHECK/UPDATE INDEX TABLE IN AP_BattMonitor_Backend.cpp WHEN CHANGING OR ADDING PARAMETERS
 
     AP_GROUPEND
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Sum.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Sum.cpp
@@ -19,8 +19,6 @@ extern const AP_HAL::HAL& hal;
 
 const AP_Param::GroupInfo AP_BattMonitor_Sum::var_info[] = {
 
-    // Param indexes must be between 20 and 29 to avoid conflict with other battery monitor param tables loaded by pointer
-
     // @Param: SUM_MASK
     // @DisplayName: Battery Sum mask
     // @Description: 0: sum of remaining battery monitors, If none 0 sum of specified monitors. Current will be summed and voltages averaged.
@@ -28,7 +26,7 @@ const AP_Param::GroupInfo AP_BattMonitor_Sum::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("SUM_MASK", 20, AP_BattMonitor_Sum, _sum_mask, 0),
 
-    // Param indexes must be between 20 and 29 to avoid conflict with other battery monitor param tables loaded by pointer
+    // CHECK/UPDATE INDEX TABLE IN AP_BattMonitor_Backend.cpp WHEN CHANGING OR ADDING PARAMETERS
 
     AP_GROUPEND
 };

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Synthetic_Current.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Synthetic_Current.cpp
@@ -27,7 +27,7 @@ const AP_Param::GroupInfo AP_BattMonitor_Synthetic_Current::var_info[] = {
     // also inherit analog backend parameters
     AP_SUBGROUPEXTENSION("", 51, AP_BattMonitor_Synthetic_Current, AP_BattMonitor_Analog::var_info),
 
-    // Param indexes must be between 50 and 55 to avoid conflict with other battery monitor param tables loaded by pointer
+    // CHECK/UPDATE INDEX TABLE IN AP_BattMonitor_Backend.cpp WHEN CHANGING OR ADDING PARAMETERS
 
     AP_GROUPEND
 };


### PR DESCRIPTION
Not sure if more files need to be added for other battery monitor types? I suppose as long as the file list has the union of all possible parameters... It doesn't look like the metadata generator deduplicates anyway, c.f. `BATTn_I2C_BUS`.