### PR TITLE
AC_Avoidance: add missing include

### DIFF
--- a/libraries/AC_Avoidance/AC_Avoidance_Logging.cpp
+++ b/libraries/AC_Avoidance/AC_Avoidance_Logging.cpp
@@ -6,6 +6,7 @@
 #include "AP_OADijkstra.h"
 #include "AP_OABendyRuler.h"
 #include <AP_Logger/AP_Logger.h>
+#include <AP_AHRS/AP_AHRS.h>
 
 #if AP_OAPATHPLANNER_BENDYRULER_ENABLED
 void AP_OABendyRuler::Write_OABendyRuler(const uint8_t type, const bool active, const float target_yaw, const float target_pitch, const bool resist_chg, const float margin, const Location &final_dest, const Location &oa_dest) const


### PR DESCRIPTION
```
../../libraries/AC_Avoidance/AC_Avoidance_Logging.cpp: In member function 'void AP_OABendyRuler::Write_OABendyRuler(uint8_t, bool, float, float, bool, float, const Location&, const Location&) const': ../../libraries/AC_Avoidance/AC_Avoidance_Logging.cpp:23:46: error: 'ahrs' is not a member of 'AP'
   23 |         yaw         : (uint16_t)wrap_360(AP::ahrs().yaw_sensor * 0.01f),
      |                                              ^~~~
compilation terminated due to -Wfatal-errors.
```