### PR TITLE
AP_HAL_ESP32: RCOutput: add support for brushed PWM mode

### DIFF
--- a/libraries/AP_HAL_ESP32/RCOutput.cpp
+++ b/libraries/AP_HAL_ESP32/RCOutput.cpp
@@ -50,6 +50,8 @@ gpio_num_t outputs_pins[] = {};
 #endif
 
 #define MAX_CHANNELS ARRAY_SIZE(outputs_pins)
+static_assert(MAX_CHANNELS < 12, "overrunning _pending and safe_pwm"); // max for current chips
+static_assert(MAX_CHANNELS < 32, "overrunning bitfields");
 
 struct RCOutput::pwm_out RCOutput::pwm_group_list[MAX_CHANNELS];
 
@@ -324,7 +326,7 @@ void RCOutput::force_safety_off(void)
 */
 void RCOutput::set_safety_pwm(uint32_t chmask, uint16_t period_us)
 {
-    for (uint8_t i=0; i<16; i++) {
+    for (uint8_t i=0; i<ARRAY_SIZE(safe_pwm); i++) {
         if (chmask & (1U<<i)) {
             safe_pwm[i] = period_us;
         }

--- a/libraries/AP_HAL_ESP32/RCOutput.h
+++ b/libraries/AP_HAL_ESP32/RCOutput.h
@@ -55,6 +55,8 @@ public:
     uint16_t read(uint8_t ch) override;
     void read(uint16_t* period_us, uint8_t len) override;
 
+    void set_output_mode(uint32_t mask, const enum output_mode mode) override;
+
     void cork() override;
     void push() override;
 
@@ -108,6 +110,7 @@ private:
 
         uint32_t rc_frequency; // frequency in Hz
         uint32_t ch_mask; // mask of channels in this group
+        enum output_mode current_mode; // output mode (none, normal, brushed)
     };
 
     struct pwm_chan {
@@ -121,6 +124,10 @@ private:
     };
 
     uint32_t fast_channel_mask;
+
+    uint32_t constrain_freq(pwm_group &group);
+
+    void set_group_mode(pwm_group &group);
 
     void write_int(uint8_t chan, uint16_t period_us);
 

--- a/libraries/AP_HAL_ESP32/RCOutput.h
+++ b/libraries/AP_HAL_ESP32/RCOutput.h
@@ -119,10 +119,9 @@ private:
     static pwm_out pwm_group_list[];
 
     bool _corked;
-    uint16_t _pending[12]; //Max channel with 2 unit MCPWM
     uint32_t _pending_mask;
-
-    uint16_t safe_pwm[16]; // pwm to use when safety is on
+    uint16_t _pending[12];
+    uint16_t safe_pwm[12]; // pwm to use when safety is on
 
     uint16_t _max_channels;
 

--- a/libraries/AP_HAL_ESP32/RCOutput.h
+++ b/libraries/AP_HAL_ESP32/RCOutput.h
@@ -12,7 +12,8 @@
  * You should have received a copy of the GNU General Public License along
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Code by Charles "Silvanosky" Villard, David "Buzz" Bussenschutt and Andrey "ARg" Romanov
+ * Code by Charles "Silvanosky" Villard, David "Buzz" Bussenschutt,
+ * Andrey "ARg" Romanov, and Thomas "tpw_rules" Watson'
  *
  */
 
@@ -99,31 +100,37 @@ public:
 
 private:
 
-    struct pwm_out {
+    struct pwm_group {
+        // SDK objects for the group
+        uint8_t mcpwm_group_id;
+        mcpwm_timer_handle_t h_timer;
+        mcpwm_oper_handle_t h_oper;
 
-         uint8_t chan;
-         uint8_t gpio_num;
-         uint8_t group_id;
-         int     freq;
-         int     value;
-
-         mcpwm_timer_handle_t h_timer;
-         mcpwm_oper_handle_t  h_oper;
-         mcpwm_cmpr_handle_t  h_cmpr;
-         mcpwm_gen_handle_t   h_gen;        
+        uint32_t rc_frequency; // frequency in Hz
+        uint32_t ch_mask; // mask of channels in this group
     };
 
+    struct pwm_chan {
+        // SDK objects for the channel
+        mcpwm_cmpr_handle_t h_cmpr;
+        mcpwm_gen_handle_t h_gen;
+        pwm_group *group; // associated group
+
+        uint8_t gpio_num; // associated GPIO number (always defined)
+        int value; // output value in microseconds
+    };
+
+    uint32_t fast_channel_mask;
 
     void write_int(uint8_t chan, uint16_t period_us);
 
-    static pwm_out pwm_group_list[];
+    static pwm_group pwm_group_list[];
+    static pwm_chan pwm_chan_list[];
 
     bool _corked;
     uint32_t _pending_mask;
     uint16_t _pending[12];
     uint16_t safe_pwm[12]; // pwm to use when safety is on
-
-    uint16_t _max_channels;
 
     // safety switch state
     AP_HAL::Util::safety_state safety_state;


### PR DESCRIPTION
This is needed to fly the Stampfly. It's a significant re-engineering from the in-master state and the brushed hack that was used previously (though I've now rebased my stampfly branch to include this for those who want to try).

I tried to match the (somewhat vague) semantics of the ChibiOS HAL with regards to groups and frequencies, and I tested that the PWM output in "normal" mode still doesn't work the same way on the Stampfly, but someone needs to test it more thoroughly.