### PR TITLE
waf: add defaults.parm support to esp32 using ROMFS

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -1064,6 +1064,14 @@ class esp32(Board):
         # wrap malloc to ensure memory is zeroed
         env.LINKFLAGS += ['-Wl,--wrap,malloc']
 
+        # TODO: remove once hwdef.dat support is in place
+        defaults_file = 'libraries/AP_HAL_ESP32/hwdef/%s/defaults.parm' % self.get_name()
+        if os.path.exists(defaults_file):
+            env.ROMFS_FILES += [('defaults.parm', defaults_file)]
+            env.DEFINES.update(
+                HAL_PARAM_DEFAULTS_PATH='"@ROMFS/defaults.parm"',
+            )
+
         env.INCLUDES += [
                 cfg.srcnode.find_dir('libraries/AP_HAL_ESP32/boards').abspath(),
             ]

--- a/libraries/AP_HAL_ESP32/RCOutput.h
+++ b/libraries/AP_HAL_ESP32/RCOutput.h
@@ -21,7 +21,6 @@
 
 #include <AP_HAL/RCOutput.h>
 #include "HAL_ESP32_Namespace.h"
-#define HAL_PARAM_DEFAULTS_PATH nullptr
 #include <AP_HAL/Util.h>
 
 #include "driver/gpio.h"

--- a/libraries/AP_HAL_ESP32/boards/defaults.parm
+++ b/libraries/AP_HAL_ESP32/boards/defaults.parm
@@ -1,3 +1,0 @@
-#defaults for all ESP32 boards unless overwridden elsewhere
-LOG_DISARMED 1
-SERIAL0_PROTOCOL 0


### PR DESCRIPTION
And drop broken remnants of code using apj_tool to do it. Now just load the file at `libraries/AP_HAL_ESP32/hwdef/<board>/defaults.parm` until we get hwdef.dat support in.

According to tridge, apj_tool is deprecated anyway. It's difficult to use because the .bin has an XOR checksum and SHA256 checksum that would have to be patched up. So just switch to using the already-working ROMFS.

Tested on the stampfly.