### PR TITLE
autotest: test_build_options.py: exempt AP_COMPASS_AK8963_ENABLED fro…

### DIFF
--- a/Tools/autotest/test_build_options.py
+++ b/Tools/autotest/test_build_options.py
@@ -268,6 +268,8 @@ class TestBuildOptions(object):
             'AP_OPTICALFLOW_ONBOARD_ENABLED',  # only instantiated on Linux
             'HAL_WITH_FRSKY_TELEM_BIDIRECTIONAL',  # entirely elided if no user
             'AP_PLANE_BLACKBOX_LOGGING',  # entirely elided if no user
+            'AP_COMPASS_AK8963_ENABLED',  # probed on a board-by-board basis, not on CubeOrange for example
+            'AP_COMPASS_LSM303D_ENABLED',  # probed on a board-by-board basis, not on CubeOrange for example
         ])
         if target.lower() != "copter":
             feature_define_whitelist.add('MODE_ZIGZAG_ENABLED')


### PR DESCRIPTION
…m check

we recently removed this sensor on CubeOrange, so the test fails