### PR TITLE
SITL: follow standard pattern for including ENABLED guards

### DIFF
--- a/libraries/SITL/SIM_Airspeed_DLVR.cpp
+++ b/libraries/SITL/SIM_Airspeed_DLVR.cpp
@@ -1,6 +1,8 @@
-#include "SIM_Airspeed_DLVR.h"
+#include "SIM_config.h"
 
 #if AP_SIM_AIRSPEED_DLVR_ENABLED
+
+#include "SIM_Airspeed_DLVR.h"
 
 #include "SITL.h"
 

--- a/libraries/SITL/SIM_BattMonitor_SMBus_Maxell.cpp
+++ b/libraries/SITL/SIM_BattMonitor_SMBus_Maxell.cpp
@@ -1,6 +1,8 @@
-#include "SIM_BattMonitor_SMBus_Maxell.h"
+#include "SIM_config.h"
 
 #if AP_SIM_BATT_MONITOR_SMBUS_MAXELL_ENABLED
+
+#include "SIM_BattMonitor_SMBus_Maxell.h"
 
 SITL::Maxell::Maxell() :
     SIM_BattMonitor_SMBus_Generic()

--- a/libraries/SITL/SIM_BattMonitor_SMBus_Rotoye.cpp
+++ b/libraries/SITL/SIM_BattMonitor_SMBus_Rotoye.cpp
@@ -1,6 +1,8 @@
-#include "SIM_BattMonitor_SMBus_Rotoye.h"
+#include "SIM_config.h"
 
 #if AP_SIM_BATT_MONITOR_SMBUS_ROTOYE_ENABLED
+
+#include "SIM_BattMonitor_SMBus_Rotoye.h"
 
 #include <AP_HAL/utility/sparse-endian.h>
 

--- a/libraries/SITL/SIM_MS5525.cpp
+++ b/libraries/SITL/SIM_MS5525.cpp
@@ -1,6 +1,8 @@
-#include "SIM_MS5525.h"
+#include "SIM_config.h"
 
 #if AP_SIM_MS5525_ENABLED
+
+#include "SIM_MS5525.h"
 
 #include <SITL/SITL.h>
 

--- a/libraries/SITL/SIM_MS5611.cpp
+++ b/libraries/SITL/SIM_MS5611.cpp
@@ -1,6 +1,8 @@
-#include "SIM_MS5611.h"
+#include "SIM_config.h"
 
 #if AP_SIM_MS5611_ENABLED
+
+#include "SIM_MS5611.h"
 
 #include <SITL/SITL.h>
 

--- a/libraries/SITL/SIM_Temperature_MCP9600.cpp
+++ b/libraries/SITL/SIM_Temperature_MCP9600.cpp
@@ -1,6 +1,8 @@
-#include "SIM_Temperature_MCP9600.h"
+#include "SIM_config.h"
 
 #if AP_SIM_TEMPERATURE_MCP9600_ENABLED
+
+#include "SIM_Temperature_MCP9600.h"
 
 using namespace SITL;
 

--- a/libraries/SITL/SIM_Temperature_TSYS01.cpp
+++ b/libraries/SITL/SIM_Temperature_TSYS01.cpp
@@ -1,6 +1,8 @@
-#include "SIM_Temperature_TSYS01.h"
+#include "SIM_config.h"
 
 #if AP_SIM_TEMPERATURE_TSYS01_ENABLED
+
+#include "SIM_Temperature_TSYS01.h"
 
 #include <stdio.h>
 


### PR DESCRIPTION
Follow up to https://github.com/ArduPilot/ardupilot/pull/28848 to use standard include pattern.