### PR TITLE
Stop making python an alias for python3 in environment setups

### DIFF
--- a/.github/workflows/cygwin_build.yml
+++ b/.github/workflows/cygwin_build.yml
@@ -187,7 +187,6 @@ jobs:
           PATH: /usr/bin:$(cygpath ${SYSTEMROOT})/system32
         shell: C:\cygwin\bin\bash.exe -eo pipefail '{0}'
         run: >-
-          ln -sf /usr/bin/python3.7 /usr/bin/python && ln -sf /usr/bin/pip3.7 /usr/bin/pip &&
           python3 -m pip install --progress-bar off empy==3.3.4 pexpect &&
           python3 -m pip install --progress-bar off dronecan --upgrade &&
           cp /usr/bin/ccache /usr/local/bin/ &&

--- a/.github/workflows/esp32_build.yml
+++ b/.github/workflows/esp32_build.yml
@@ -176,8 +176,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install git wget libncurses-dev flex bison gperf python3 python3-pip python3-venv python3-setuptools python3-serial python3-gevent python3-cryptography python3-future python3-pyparsing python3-pyelftools cmake ninja-build ccache libffi-dev libssl-dev dfu-util libusb-1.0-0 cmake
-          sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
-          update-alternatives --query python
           python3 --version
           pip3 install gevent
 
@@ -186,13 +184,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install python3.11 python3.11-venv python3.11-distutils  -y
           sudo apt-get install python3 python3-pip python3-venv python3-setuptools python3-serial python3-cryptography python3-future python3-pyparsing python3-pyelftools
-          update-alternatives --query python
           pip3 install gevent
           python3 --version
           python3.11 --version
           which python3.11
-          sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.11 11
-          update-alternatives --query python
 
           git submodule update --init --recursive --depth=1
           ./Tools/scripts/esp32_get_idf.sh

--- a/Tools/environment_install/install-prereqs-alpine.sh
+++ b/Tools/environment_install/install-prereqs-alpine.sh
@@ -17,7 +17,6 @@ apk update && apk add --no-cache \
         libxml2-dev \
         libxslt-dev \
         git \
-    && ln -sf python3 /usr/bin/python \
     &&  rm -rf /var/cache/apk/*
 
 python3 -m pip install --user --no-deps --no-cache-dir empy==3.3.4 pexpect ptyprocess --break-system-packages

--- a/Tools/environment_install/install-prereqs-windows-andAPMSource.ps1
+++ b/Tools/environment_install/install-prereqs-windows-andAPMSource.ps1
@@ -15,8 +15,6 @@ Start-BitsTransfer -Source "https://firmware.ardupilot.org/Tools/STM32-tools/gcc
 
 Write-Output "Installing Cygwin x64 (4/8)"
 Start-Process -wait -FilePath $PSScriptRoot\setup-x86_64.exe -ArgumentList "--root=C:\cygwin64 --no-startmenu --local-package-dir=$env:USERPROFILE\Downloads --site=http://cygwin.mirror.constant.com --packages autoconf,automake,ccache,cygwin32-gcc-g++,gcc-g++=7.4.0-1,libgcc1=7.4.0.1,gcc-core=7.4.0-1,git,libtool,make,gawk,libexpat-devel,libxml2-devel,python37,python37-future,python37-lxml,python37-pip,libxslt-devel,python37-devel,procps-ng,zip,gdb,ddd --quiet-mode"
-Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'ln -sf /usr/bin/python3.7 /usr/bin/python'"
-Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'ln -sf /usr/bin/pip3.7 /usr/bin/pip'"
 
 Write-Output "Downloading extra Python packages (5/8)"
 Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'python3.7 -m pip install empy==3.3.4 pyserial pymavlink intelhex dronecan pexpect'"

--- a/Tools/environment_install/install-prereqs-windows.ps1
+++ b/Tools/environment_install/install-prereqs-windows.ps1
@@ -15,8 +15,6 @@ Start-BitsTransfer -Source "https://firmware.ardupilot.org/Tools/STM32-tools/gcc
 
 Write-Output "Installing Cygwin x64 (4/7)"
 Start-Process -wait -FilePath $PSScriptRoot\setup-x86_64.exe -ArgumentList "--root=C:\cygwin64 --no-startmenu --local-package-dir=$env:USERPROFILE\Downloads --site=http://cygwin.mirror.constant.com --packages autoconf,automake,ccache,cygwin32-gcc-g++,gcc-g++=7.4.0-1,libgcc1=7.4.0.1,gcc-core=7.4.0-1,git,libtool,make,gawk,libexpat-devel,libxml2-devel,python37,python37-future,python37-lxml,python37-pip,libxslt-devel,python37-devel,procps-ng,zip,gdb,ddd,xterm --quiet-mode"
-Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'ln -sf /usr/bin/python3.7 /usr/bin/python'"
-Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'ln -sf /usr/bin/pip3.7 /usr/bin/pip'"
 
 Write-Output "Downloading extra Python packages (5/7)"
 Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'python3.7 -m pip install empy==3.3.4 pyserial pymavlink intelhex dronecan pexpect'"

--- a/libraries/AP_HAL_ESP32/README.md
+++ b/libraries/AP_HAL_ESP32/README.md
@@ -20,7 +20,6 @@ Tools/environment_install/install-prereqs-arch.sh
 # from: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/linux-setup.html
 sudo apt-get install git wget flex bison gperf cmake ninja-build ccache libffi-dev libssl-dev dfu-util
 sudo apt-get install python3 python3-pip python3-setuptools
-sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
 #or
 sudo pacman -S --needed gcc git make flex bison gperf python-pip cmake ninja ccache dfu-util libusb


### PR DESCRIPTION
These were equivalents for installing python-is-python3 packages on Ubuntu.

We really shouldn't need these now - esp. since we don't do this on Ubuntu any more.

If we are invoking Python now we should be doing so as "python3".

