### PR TITLE
Rover: allow WATER_DEPTH mavlink message rate to be specified

### DIFF
--- a/Rover/GCS_Mavlink.cpp
+++ b/Rover/GCS_Mavlink.cpp
@@ -589,6 +589,7 @@ static const ap_message STREAM_EXTRA3_msgs[] = {
     MSG_WIND,
 #if AP_RANGEFINDER_ENABLED
     MSG_RANGEFINDER,
+    MSG_WATER_DEPTH,
 #endif
     MSG_DISTANCE_SENSOR,
     MSG_SYSTEM_TIME,

--- a/Rover/GCS_Mavlink.cpp
+++ b/Rover/GCS_Mavlink.cpp
@@ -199,9 +199,14 @@ void GCS_MAVLINK_Rover::send_water_depth() const
 
     RangeFinder *rangefinder = RangeFinder::get_singleton();
 
-    if (rangefinder == nullptr || !rangefinder->has_orientation(ROTATION_PITCH_270)){
+    if (rangefinder == nullptr) {
         return;
-    } 
+    }
+
+    // depth can only be measured by a downward-facing rangefinder:
+    if (!rangefinder->has_orientation(ROTATION_PITCH_270)) {
+        return;
+    }
 
     // get position
     const AP_AHRS &ahrs = AP::ahrs();

--- a/Rover/GCS_Mavlink.cpp
+++ b/Rover/GCS_Mavlink.cpp
@@ -192,6 +192,11 @@ void GCS_MAVLINK_Rover::send_water_depth() const
         return;
     }
 
+    // only send for boats:
+    if (!rover.is_boat()) {
+        return;
+    }
+
     RangeFinder *rangefinder = RangeFinder::get_singleton();
 
     if (rangefinder == nullptr || !rangefinder->has_orientation(ROTATION_PITCH_270)){

--- a/Rover/GCS_Mavlink.h
+++ b/Rover/GCS_Mavlink.h
@@ -44,6 +44,9 @@ protected:
     // Index starts at 1
     uint8_t send_available_mode(uint8_t index) const override;
 
+    // send WATER_DEPTH - metres and temperature
+    void send_water_depth() const;
+
 private:
 
     void handle_message(const mavlink_message_t &msg) override;

--- a/Rover/Log.cpp
+++ b/Rover/Log.cpp
@@ -79,10 +79,6 @@ void Rover::Log_Write_Depth()
                             (double)(s->distance()),
                             temp_C);
     }
-#if AP_RANGEFINDER_ENABLED
-    // send water depth and temp to ground station
-    gcs().send_message(MSG_WATER_DEPTH);
-#endif
 }
 #endif
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -403,7 +403,6 @@ public:
 #if AP_WINCH_ENABLED
     virtual void send_winch_status() const {};
 #endif
-    void send_water_depth() const;
     int8_t battery_remaining_pct(const uint8_t instance) const;
 
 #if HAL_HIGH_LATENCY2_ENABLED

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -5966,57 +5966,6 @@ void GCS_MAVLINK::send_generator_status() const
 }
 #endif
 
-#if AP_RANGEFINDER_ENABLED && APM_BUILD_TYPE(APM_BUILD_Rover)
-void GCS_MAVLINK::send_water_depth() const
-{
-    if (!HAVE_PAYLOAD_SPACE(chan, WATER_DEPTH)) {
-        return;
-    }
-
-    RangeFinder *rangefinder = RangeFinder::get_singleton();
-
-    if (rangefinder == nullptr || !rangefinder->has_orientation(ROTATION_PITCH_270)){
-        return;
-    } 
-
-    // get position
-    const AP_AHRS &ahrs = AP::ahrs();
-    Location loc;
-    IGNORE_RETURN(ahrs.get_location(loc));
-
-    for (uint8_t i=0; i<rangefinder->num_sensors(); i++) {
-        const AP_RangeFinder_Backend *s = rangefinder->get_backend(i);
-        
-        if (s == nullptr || s->orientation() != ROTATION_PITCH_270 || !s->has_data()) {
-            continue;
-        }
-
-        // get temperature
-        float temp_C;
-        if (!s->get_temp(temp_C)) {
-            temp_C = 0.0f;
-        }
-
-        const bool sensor_healthy = (s->status() == RangeFinder::Status::Good);
-
-        mavlink_msg_water_depth_send(
-            chan,
-            AP_HAL::millis(),   // time since system boot TODO: take time of measurement
-            i,                  // rangefinder instance
-            sensor_healthy,     // sensor healthy
-            loc.lat,            // latitude of vehicle
-            loc.lng,            // longitude of vehicle
-            loc.alt * 0.01f,    // altitude of vehicle (MSL)
-            ahrs.get_roll(),    // roll in radians
-            ahrs.get_pitch(),   // pitch in radians
-            ahrs.get_yaw(),     // yaw in radians
-            s->distance(),    // distance in meters
-            temp_C);            // temperature in degC
-    }
-
-}
-#endif  // AP_RANGEFINDER_ENABLED && APM_BUILD_TYPE(APM_BUILD_Rover)
-
 #if HAL_ADSB_ENABLED
 void GCS_MAVLINK::send_uavionix_adsb_out_status() const
 {
@@ -6544,13 +6493,6 @@ bool GCS_MAVLINK::try_send_message(const enum ap_message id)
     case MSG_WINCH_STATUS:
         CHECK_PAYLOAD_SIZE(WINCH_STATUS);
         send_winch_status();
-        break;
-#endif
-
-#if AP_RANGEFINDER_ENABLED && APM_BUILD_TYPE(APM_BUILD_Rover)
-    case MSG_WATER_DEPTH:
-        CHECK_PAYLOAD_SIZE(WATER_DEPTH);
-        send_water_depth();
         break;
 #endif
 


### PR DESCRIPTION
... and reduce the default rate

this is currently unconditionally streamed at 50Hz, chewing up all available bandwidth on some telemetry radios.