### PR TITLE
Tradheli: offset collective from landed min when landed in non-manual collective modes

### DIFF
--- a/ArduCopter/heli.cpp
+++ b/ArduCopter/heli.cpp
@@ -76,18 +76,23 @@ void Copter::check_dynamic_flight(void)
 void Copter::update_heli_control_dynamics(void)
 {
 
+    if (ap.land_complete) {
+        motors->set_land_complete(true);
+    } else {
+        motors->set_land_complete(false);
+    }
+    if (ap.land_complete_maybe) {
+        motors->set_land_complete_maybe(true);
+    } else {
+        motors->set_land_complete_maybe(false);
+    }
+    
     if (!motors->using_leaky_integrator()) {
         //turn off leaky_I
         attitude_control->use_leaky_i(false);
-        if (ap.land_complete || ap.land_complete_maybe) {
-            motors->set_land_complete(true);
-        } else {
-            motors->set_land_complete(false);
-        }
     } else {
         // Use Leaky_I if we are not moving fast
         attitude_control->use_leaky_i(!heli_flags.dynamic_flight);
-        motors->set_land_complete(false);
     }
 
     if (ap.land_complete || (is_zero(motors->get_desired_rotor_speed()))) {

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -152,6 +152,15 @@ const AP_Param::GroupInfo AP_MotorsHeli::var_info[] = {
     // @Path: ../AC_Autorotation/RSC_Autorotation.cpp
     AP_SUBGROUPINFO(_main_rotor.autorotation, "RSC_AROT_", 33, AP_MotorsHeli, RSC_Autorotation),
 
+    // @Param: COL_LAND_OFSET
+    // @DisplayName: Offset of Collective Blade Pitch when Landed
+    // @Description: Offset of the collective blade pitch angle when landed in degrees for non-manual collective modes (i.e. modes that use altitude hold).
+    // @Range: -2 2
+    // @Units: deg
+    // @Increment: 0.1
+    // @User: Standard
+    AP_GROUPINFO("COL_LAND_OFSET", 34, AP_MotorsHeli, _collective_land_offset_deg, 0.0),
+
     AP_GROUPEND
 };
 
@@ -349,7 +358,7 @@ void AP_MotorsHeli::output_logic()
         case SpoolState::GROUND_IDLE: {
             // Motors should be stationary or at ground idle.
             // set limits flags
-            if (_heliflags.land_complete && !using_leaky_integrator()) {
+            if ((_heliflags.land_complete || _heliflags.land_complete_maybe) && !using_leaky_integrator()) {
                 set_limit_flag_pitch_roll_yaw(true);
             } else {
                 set_limit_flag_pitch_roll_yaw(false);
@@ -371,7 +380,7 @@ void AP_MotorsHeli::output_logic()
             // Servos should exhibit normal flight behavior.
 
             // set limits flags
-            if (_heliflags.land_complete && !using_leaky_integrator()) {
+            if ((_heliflags.land_complete || _heliflags.land_complete_maybe) && !using_leaky_integrator()) {
                 set_limit_flag_pitch_roll_yaw(true);
             } else {
                 set_limit_flag_pitch_roll_yaw(false);
@@ -393,7 +402,7 @@ void AP_MotorsHeli::output_logic()
             // Servos should exhibit normal flight behavior.
 
             // set limits flags
-            if (_heliflags.land_complete && !using_leaky_integrator()) {
+            if ((_heliflags.land_complete || _heliflags.land_complete_maybe) && !using_leaky_integrator()) {
                 set_limit_flag_pitch_roll_yaw(true);
             } else {
                 set_limit_flag_pitch_roll_yaw(false);
@@ -413,7 +422,7 @@ void AP_MotorsHeli::output_logic()
             // Servos should exhibit normal flight behavior.
 
             // set limits flags
-            if (_heliflags.land_complete && !using_leaky_integrator()) {
+            if ((_heliflags.land_complete || _heliflags.land_complete_maybe) && !using_leaky_integrator()) {
                 set_limit_flag_pitch_roll_yaw(true);
             } else {
                 set_limit_flag_pitch_roll_yaw(false);

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -132,7 +132,10 @@ public:
 
     // set land complete flag
     void set_land_complete(bool landed) { _heliflags.land_complete = landed; }
-	
+
+    // set land complete maybe flag
+    void set_land_complete_maybe(bool landed) { _heliflags.land_complete_maybe = landed; }
+
 	//return zero lift collective position
     float get_coll_mid() const { return _collective_zero_thrust_pct; }
 
@@ -254,6 +257,7 @@ protected:
         uint8_t below_land_min_coll     : 1;    // true if collective is below H_COL_LAND_MIN
         uint8_t rotor_spooldown_complete : 1;    // true if the rotors have spooled down completely
         uint8_t start_engine            : 1;    // true if turbine start RC option is initiated
+        uint8_t land_complete_maybe     : 1;    // true if aircraft is landed_maybe
     } _heliflags;
 
     // parameters
@@ -269,11 +273,14 @@ protected:
     AP_Float        _collective_land_min_deg;   // Minimum Landed collective blade pitch in degrees for non-manual collective modes (i.e. modes that use altitude hold)
     AP_Float        _collective_max_deg;        // Maximum collective blade pitch angle in deg that corresponds to the PWM set for maximum collective pitch (H_COL_MAX)
     AP_Float        _collective_min_deg;        // Minimum collective blade pitch angle in deg that corresponds to the PWM set for minimum collective pitch (H_COL_MIN)
+    AP_Float        _collective_land_offset_deg;// Offset of Landed collective blade pitch in degrees for non-manual collective modes (i.e. modes that use altitude hold)
 
     // internal variables
     float           _collective_zero_thrust_pct;      // collective zero thrutst parameter value converted to 0 ~ 1 range
     float           _collective_land_min_pct;      // collective land min parameter value converted to 0 ~ 1 range
+    float           _collective_land_offset_pct;   // collective land offset parameter value converted to fraction of collective range
     uint8_t         _servo_test_cycle_counter = 0;   // number of test cycles left to run after bootup
+    float           _collective_offset_landed;  // current value of collective offset
 
     motor_frame_type _frame_type;
     motor_frame_class _frame_class;

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -284,6 +284,7 @@ void AP_MotorsHeli_Single::calculate_scalars()
     _collective_zero_thrust_deg.set(constrain_float(_collective_zero_thrust_deg, _collective_min_deg, _collective_max_deg));
 
     _collective_land_min_deg.set(constrain_float(_collective_land_min_deg, _collective_min_deg, _collective_max_deg));
+    _collective_land_offset_deg.set(constrain_float(_collective_land_offset_deg, _collective_min_deg, _collective_max_deg));
 
     if (!is_equal((float)_collective_max_deg, (float)_collective_min_deg)) {
         // calculate collective zero thrust point as a number from 0 to 1
@@ -291,6 +292,7 @@ void AP_MotorsHeli_Single::calculate_scalars()
 
         // calculate collective land min point as a number from 0 to 1
         _collective_land_min_pct = (_collective_land_min_deg-_collective_min_deg)/(_collective_max_deg-_collective_min_deg);
+        _collective_land_offset_pct = _collective_land_offset_deg/(_collective_max_deg-_collective_min_deg);
     } else {
         _collective_zero_thrust_pct = 0.0f;
         _collective_land_min_pct = 0.0f;
@@ -388,13 +390,23 @@ void AP_MotorsHeli_Single::move_actuators(float roll_out, float pitch_out, float
     }
 
     // ensure not below landed/landing collective
-    if (_heliflags.landing_collective && collective_out < _collective_land_min_pct && !_main_rotor.in_autorotation()) {
+    if (_heliflags.land_complete && _heliflags.landing_collective && collective_out < _collective_land_min_pct + _collective_offset_landed) {
+        _collective_offset_landed += 0.0001 * (_collective_land_offset_pct - _collective_offset_landed);
+        collective_out = _collective_land_min_pct + _collective_offset_landed;
+        limit.throttle_lower = true;
+    } else if (_heliflags.landing_collective && collective_out < _collective_land_min_pct && !_main_rotor.in_autorotation()) {
         collective_out = _collective_land_min_pct;
         limit.throttle_lower = true;
+    } else {
+        _collective_offset_landed = 0.0;
     }
 
     // updates below land min collective flag
-    if (collective_out <= _collective_land_min_pct) {
+    float collective_land_min = _collective_land_min_pct;
+    if (_heliflags.land_complete && _heliflags.landing_collective) {
+        collective_land_min += _collective_offset_landed;
+    }
+    if (collective_out <= collective_land_min) {
         _heliflags.below_land_min_coll = true;
     } else {
         _heliflags.below_land_min_coll = false;


### PR DESCRIPTION
This PR adds the ability for the user to offset the collective from the landed min collective position when landed in non-manual collective modes.  This will enable users to minimize vibrations when landed by being able to have the collective raised after the land complete flag is true.  