### PR TITLE
AP_Bootloader: reserve a board ID for JFB200

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -296,6 +296,8 @@ AP_HW_CrazyF405                      1177
 AP_HW_FlywooF405HD_AIOv2             1180
 AP_HW_FlywooH743Pro                  1181
 
+AP_HW_JFB200                         1200
+
 AP_HW_ESP32_PERIPH                   1205
 AP_HW_ESP32S3_PERIPH                 1206
 


### PR DESCRIPTION
This ID is for a new board developping by JAE.