### PR TITLE
AP_HAL_ESP32: add AP_MOTORS_FRAME_xxx_ENABLED guards

### DIFF
--- a/libraries/AP_HAL_ESP32/boards/esp32empty.h
+++ b/libraries/AP_HAL_ESP32/boards/esp32empty.h
@@ -148,3 +148,7 @@
 #define HAL_LOGGING_BACKENDS_DEFAULT 1
 
 #define AP_RCPROTOCOL_ENABLED 0
+
+// disable all frames for sim on hw except quad to save DRAM .bss
+#define AP_MOTORS_FRAME_DEFAULT_ENABLED 0
+#define AP_MOTORS_FRAME_QUAD_ENABLED 1

--- a/libraries/AP_HAL_ESP32/boards/esp32s3empty.h
+++ b/libraries/AP_HAL_ESP32/boards/esp32s3empty.h
@@ -93,3 +93,6 @@
 #define AP_SCRIPTING_ENABLED 0
 #define HAL_USE_EMPTY_STORAGE 1
 
+// disable all frames for sim on hw except quad to save DRAM .bss
+#define AP_MOTORS_FRAME_DEFAULT_ENABLED 0
+#define AP_MOTORS_FRAME_QUAD_ENABLED 1


### PR DESCRIPTION
Add `AP_MOTORS_FRAME_xxx_ENABLED` guards to `SIM_Frame.cpp` as they are applied in `AP_Motors_Matrix.cpp`. This does not change default behaviour and allows the majority of the motor mixes to be disabled in the `esp32xxempty` boards which frees up RAM.

### Related

- https://github.com/ArduPilot/ardupilot/pull/28848

### Testing

#### esp32empty

Before

```bash
Total sizes:
Used static DRAM:  147848 bytes (  32888 remain, 81.8% used)
      .data size:   19368 bytes
      .bss  size:  128480 bytes
Used static IRAM:  113718 bytes (  17354 remain, 86.8% used)
      .text size:  112691 bytes
   .vectors size:    1027 bytes
Used Flash size : 1856264 bytes
           .text: 1548788 bytes
         .rodata:  307220 bytes
Total image size: 1989350 bytes (.bin may be padded larger)
```

After

```bash
Total sizes:
Used static DRAM:  120488 bytes (  60248 remain, 66.7% used)
      .data size:   19368 bytes
      .bss  size:  101120 bytes
Used static IRAM:  113718 bytes (  17354 remain, 86.8% used)
      .text size:  112691 bytes
   .vectors size:    1027 bytes
Used Flash size : 1849596 bytes
           .text: 1545128 bytes
         .rodata:  304212 bytes
Total image size: 1982682 bytes (.bin may be padded larger)
```

#### esp32s3empty

Before

```bash
Total sizes:
Used stat D/IRAM:  236610 bytes ( 105150 remain, 69.2% used)
      .data size:   21960 bytes
      .bss  size:  109784 bytes
      .text size:  103839 bytes
   .vectors size:    1027 bytes
Used Flash size : 1636580 bytes
           .text: 1354860 bytes
         .rodata:  281464 bytes
Total image size: 1763406 bytes (.bin may be padded larger)
```

After

```bash
Total sizes:
Used stat D/IRAM:  209250 bytes ( 132510 remain, 61.2% used)
      .data size:   21960 bytes
      .bss  size:   82424 bytes
      .text size:  103839 bytes
   .vectors size:    1027 bytes
Used Flash size : 1629848 bytes
           .text: 1351152 bytes
         .rodata:  278440 bytes
Total image size: 1756674 bytes (.bin may be padded larger)
```
