### PR TITLE
AP_Scripting, AC_PosControl: add follow-target-send.lua applet

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -1208,6 +1208,28 @@ bool AC_PosControl::get_posvelaccel_offset(Vector3f &pos_offset_NED, Vector3f &v
     accel_offset_NED.z = -_accel_offset_target.z * 0.01;
     return true;
 }
+
+// get target velocity in m/s in NED frame
+bool AC_PosControl::get_vel_target(Vector3f &vel_target_NED)
+{
+    if (!is_active_xy() || !is_active_z()) {
+        return false;
+    }
+    vel_target_NED.xy() = _vel_target.xy() * 0.01;
+    vel_target_NED.z = -_vel_target.z * 0.01;
+    return true;
+}
+
+// get target acceleration in m/s/s in NED frame
+bool AC_PosControl::get_accel_target(Vector3f &accel_target_NED)
+{
+    if (!is_active_xy() || !is_active_z()) {
+        return false;
+    }
+    accel_target_NED.xy() = _accel_target.xy() * 0.01;
+    accel_target_NED.z = -_accel_target.z * 0.01;
+    return true;
+}
 #endif
 
 /// set the horizontal position, velocity and acceleration offset targets in cm, cms and cm/s/s from EKF origin in NE frame

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -339,6 +339,12 @@ public:
     // units are m, m/s and m/s/s in NED frame
     bool set_posvelaccel_offset(const Vector3f &pos_offset_NED, const Vector3f &vel_offset_NED, const Vector3f &accel_offset_NED);
     bool get_posvelaccel_offset(Vector3f &pos_offset_NED, Vector3f &vel_offset_NED, Vector3f &accel_offset_NED);
+
+    // get target velocity in m/s in NED frame
+    bool get_vel_target(Vector3f &vel_target_NED);
+
+    // get target acceleration in m/s/s in NED frame
+    bool get_accel_target(Vector3f &accel_target_NED);
 #endif
 
     /// set the horizontal position, velocity and acceleration offset targets in cm, cms and cm/s/s from EKF origin in NE frame

--- a/libraries/AP_Scripting/applets/follow-target-send.lua
+++ b/libraries/AP_Scripting/applets/follow-target-send.lua
@@ -1,0 +1,121 @@
+-- Send the FOLLOW_TARGET mavlink message to allow other vehicles to follow this one
+--
+-- How To Use
+-- 1. copy this script to the autopilot's "scripts" directory
+-- 2. within the "scripts" directory create a "modules" directory
+-- 3. copy the MAVLink/mavlink_msgs_xxx files to the "scripts" directory
+-- 4. the FOLLOW_TARGET message will be published at 10hz
+
+-- load mavlink message definitions from modules/MAVLink directory
+local mavlink_msgs = require("MAVLink/mavlink_msgs")
+
+-- global definitions
+local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
+local UPDATE_INTERVAL_MS = 100                  -- update at about 10hz
+local FOLLOW_TARGET_CAPABILITIES = {POS=2^0, VEL=2^1, ACCEL=2^2, ATT_RATES=2^3}
+
+ -- setup script specific parameters
+local PARAM_TABLE_KEY = 88
+local PARAM_TABLE_PREFIX = "FOLT_"
+assert(param:add_table(PARAM_TABLE_KEY, PARAM_TABLE_PREFIX, 2), 'could not add param table')
+
+-- add a parameter and bind it to a variable
+local function bind_add_param(name, idx, default_value)
+    assert(param:add_param(PARAM_TABLE_KEY, idx, name, default_value), string.format('could not add param %s', PARAM_TABLE_PREFIX .. name))
+    return Parameter(PARAM_TABLE_PREFIX .. name)
+end
+
+--[[
+  // @Param: FOLT_ENABLE
+  // @DisplayName: Follow Target Send Enable
+  // @Description: Follow Target Send Enable
+  // @Values: 0:Disabled,1:Enabled
+  // @User: Standard
+--]]
+local FOLT_ENABLE = bind_add_param("ENABLE", 1, 1)
+
+--[[
+  // @Param: FOLT_MAV_CHAN
+  // @DisplayName: Follow Target Send MAVLink Channel
+  // @Description: MAVLink channel to which FOLLOW_TARGET should be sent
+  // @Range: 0 10
+  // @User: Standard
+--]]
+local FOLT_MAV_CHAN = bind_add_param("MAV_CHAN", 2, 0)
+
+-- initialize MAVLink rx with number of messages, and buffer depth
+mavlink:init(2, 5)
+
+-- send FOLLOW_TARGET message
+local function send_follow_target_msg()
+
+    -- get vehicle location
+    local curr_loc = ahrs:get_location()
+    if curr_loc == nil then
+        do return end
+    end
+    local capabilities = FOLLOW_TARGET_CAPABILITIES.POS
+
+    -- get vehicle target velocity in m/s in NED frame
+    local vel_target_NED = poscontrol:get_vel_target()
+    if vel_target_NED ~= nil then
+        capabilities = capabilities + FOLLOW_TARGET_CAPABILITIES.VEL
+    else
+        vel_target_NED = Vector3f()
+    end
+
+    -- get vehicle target acceleration in m/s/s in NED frame
+    local accel_target_NED = poscontrol:get_accel_target()
+    if accel_target_NED ~= nil then
+        capabilities = capabilities + FOLLOW_TARGET_CAPABILITIES.ACCEL
+    else
+        accel_target_NED = Vector3f()
+    end
+
+    -- get vehicle current attitude as quaternion and rates
+    local attitude_quat = ahrs:get_quaternion()
+    local curr_rot_rate = ahrs:get_gyro()
+    if attitude_quat ~= nil and curr_rot_rate ~= nil then
+        capabilities = capabilities + FOLLOW_TARGET_CAPABILITIES.ATT_RATES
+    else
+        attitude_quat = Quaternion()
+        curr_rot_rate = Vector3f()
+    end
+    local curr_rot_rate_NED = ahrs:body_to_earth(curr_rot_rate)
+
+    -- prepare FOLLOW_TARGET message
+    local follow_target_msg = {}
+    follow_target_msg.timestamp = millis():toint()
+    follow_target_msg.est_capabilities = capabilities
+    follow_target_msg.lat = curr_loc:lat()
+    follow_target_msg.lon = curr_loc:lng()
+    follow_target_msg.alt = curr_loc:alt() * 0.01
+    follow_target_msg.vel = {vel_target_NED:x(), vel_target_NED:y(), vel_target_NED:z()}
+    follow_target_msg.acc = {accel_target_NED:x(), accel_target_NED:y(), accel_target_NED:z()}
+    follow_target_msg.attitude_q = {attitude_quat:q1(), attitude_quat:q2(), attitude_quat:q3(), attitude_quat:q4()}
+    follow_target_msg.rates = {curr_rot_rate_NED:x(), curr_rot_rate_NED:y(), curr_rot_rate_NED:z()}
+    follow_target_msg.position_cov = {0, 0, 0}
+    follow_target_msg.custom_state = 0
+
+    -- send FOLLOW_TARGET message
+    mavlink:send_chan(FOLT_MAV_CHAN:get(), mavlink_msgs.encode("FOLLOW_TARGET", follow_target_msg))
+end
+
+-- display welcome message
+gcs:send_text(MAV_SEVERITY.INFO, "follow-target-send script loaded")
+
+-- update function to receive location from payload and move vehicle to reduce payload's oscillation
+local function update()
+
+    -- exit immediately if not enabled
+    if (FOLT_ENABLE:get() <= 0) then
+        return update, 1000
+    end
+
+    -- send FOLLOW_TARGET message
+    send_follow_target_msg()
+
+    return update, UPDATE_INTERVAL_MS
+end
+
+return update()

--- a/libraries/AP_Scripting/applets/follow-target-send.md
+++ b/libraries/AP_Scripting/applets/follow-target-send.md
@@ -1,0 +1,15 @@
+# Follow Target Send
+
+Sends the FOLLOW_TARGET mavlink message to allow other vehicles to follow this one
+
+# Parameters
+
+- FOLT_ENABLE : Set to 1 to enable this script
+- FOLT_MAV_CHAN : MAVLink channel to which FOLLOW_TARGET should be sent
+
+# How To Use
+
+1. copy this script to the autopilot's "scripts" directory
+2. within the "scripts" directory create a "modules" directory
+3. copy the MAVLink/mavlink_msgs_xxx files to the "scripts" directory
+4. the FOLLOW_TARGET message will be published at 10hz

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -3785,6 +3785,14 @@ function poscontrol:set_posvelaccel_offset(pos_offset_NED, vel_offset_NED, accel
 ---@return Vector3f_ud|nil
 function poscontrol:get_posvelaccel_offset() end
 
+-- get position controller's target velocity in m/s in NED frame
+---@return Vector3f_ud|nil
+function poscontrol:get_vel_target() end
+
+-- get position controller's target acceleration in m/s/s in NED frame
+---@return Vector3f_ud|nil
+function poscontrol:get_accel_target() end
+
 -- desc
 AR_PosControl = {}
 

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -774,6 +774,8 @@ singleton AC_PosControl depends APM_BUILD_COPTER_OR_HELI
 singleton AC_PosControl rename poscontrol
 singleton AC_PosControl method set_posvelaccel_offset boolean Vector3f Vector3f Vector3f
 singleton AC_PosControl method get_posvelaccel_offset boolean Vector3f'Null Vector3f'Null Vector3f'Null
+singleton AC_PosControl method get_vel_target boolean Vector3f'Null
+singleton AC_PosControl method get_accel_target boolean Vector3f'Null
 
 include APM_Control/AR_AttitudeControl.h depends APM_BUILD_TYPE(APM_BUILD_Rover)
 singleton AR_AttitudeControl depends APM_BUILD_TYPE(APM_BUILD_Rover)

--- a/libraries/AP_Scripting/modules/MAVLink/mavlink_msg_FOLLOW_TARGET.lua
+++ b/libraries/AP_Scripting/modules/MAVLink/mavlink_msg_FOLLOW_TARGET.lua
@@ -1,0 +1,16 @@
+local FOLLOW_TARGET = {}
+FOLLOW_TARGET.id = 144
+FOLLOW_TARGET.fields = {
+             { "timestamp", "<I8" },
+             { "custom_state", "<I8" },
+             { "lat", "<i4" },
+             { "lon", "<i4" },
+             { "alt", "<f" },
+             { "vel", "<f", 3 },
+             { "acc", "<f", 3 },
+             { "attitude_q", "<f", 4 },
+             { "rates", "<f", 3 },
+             { "position_cov", "<f", 3 },
+             { "est_capabilities", "<B" },
+             }
+return FOLLOW_TARGET


### PR DESCRIPTION
This adds a follow-target-send.lua applet which can send the [FOLLOW_TARGET](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L5532) mavlink message to other vehicles.  This will be used in the cooperative lift and/or copter-ship-landing work.

This has been lightly tested in SITL and below is a screenshot from MP's MAVLink inspector sent from a vehicle flying North at 10m/s in Guided mode
![follow-target-send-16Dec2024](https://github.com/user-attachments/assets/a9c94c35-bcf0-4c95-ad8c-93572509bf06)

I was hoping to test [Follow mode](https://ardupilot.org/copter/docs/follow-mode.html) with [multiple vehicles in SITL](https://ardupilot.org/dev/docs/using-sitl-for-ardupilot-testing.html#swarming-with-sitl) but it looks like mavlink messages are not passed between them.

BTW the mavlink spec for the [FOLLOW_TARGET](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L5532) message is not too clear on the frame of each field.  I've assumed everything is NED
