### PR TITLE
ArduPlane: parameterize lookahead climb ratio

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1309,7 +1309,15 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("RNGFND_LND_ORNT", 36, ParametersG2, rangefinder_land_orient, ROTATION_PITCH_270),
 #endif
-    
+
+    // @Param: TERRAIN_LKA_CLMB
+    // @DisplayName: terrain lookahead climb pitch ratio
+    // @Description: The ratio of climb rate to use when doing a terrain lookahead so the plane is not constantly at 100% throttle. 100% is the maximum climb rate which should give maximum ground clearance, and 0% should give the minimum climb rate and the minimum ground clearance, the default is 50% to try to balance safety vs battery usage. User TERRAIN_LOOKAHD=0 to disable lookahead.
+    // @Range: 0 100
+    // @Units: %
+    // @User: Standard
+    AP_GROUPINFO("TERRAIN_LKA_CLMB", 37, ParametersG2, terrain_lookahead_pitch_climb_rate, 50),
+
     AP_GROUPEND
 };
 

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -590,6 +590,8 @@ public:
     // orientation of rangefinder to use for landing
     AP_Int8 rangefinder_land_orient;
 #endif
+
+    AP_Float        terrain_lookahead_pitch_climb_rate;
 };
 
 extern const AP_Param::Info var_info[];

--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -602,10 +602,13 @@ float Plane::lookahead_adjustment(void)
         // we're not moving
         return 0;
     }
-    // we need to know the climb ratio. We use 50% of the maximum
+    // we need to know the climb ratio. We use TERRAIN_LKA_CLMB % of the maximum
     // climb rate so we are not constantly at 100% throttle and to
     // give a bit more margin on terrain
-    float climb_ratio = 0.5f * TECS_controller.get_max_climbrate() / groundspeed;
+    // we inverse the provided ratio because it gives the best result and is easiest for the user to understand
+    // maximum rate = maximum climb rate = maximum ground clearance
+    float pitch_ratio = constrain_float(1.0 - g2.terrain_lookahead_pitch_climb_rate * 0.01, .01, 1.0);
+    float climb_ratio = pitch_ratio * TECS_controller.get_max_climbrate() / groundspeed;
 
     if (climb_ratio <= 0) {
         // lookahead makes no sense for negative climb rates


### PR DESCRIPTION
Plane altitude terrain lookahead currently uses a fairly arbitrary but safe 50% factor when calculating the maximum pitch to assume when calculating the if the plane can safely fly over the approaching terrain.

Some users want to be more aggressive than the default. so this makes the 50% factor into a parameter. The default is no-change to current behavior, but by changing TERRAIN_LKA_CLMB users can now chose a more (or less) aggressive factor for the percentage of maximum climb factor to use when calculating terrain lookahead.