### PR TITLE
Rover: mavlink stream rate requests not saved to params

### DIFF
--- a/Rover/GCS_Mavlink.h
+++ b/Rover/GCS_Mavlink.h
@@ -29,8 +29,6 @@ protected:
 
     void send_position_target_global_int() override;
 
-    bool persist_streamrates() const override { return true; }
-
     uint64_t capabilities() const override;
 
     void send_nav_controller_output() const override;


### PR DESCRIPTION
This changes means that if the user or GCS uses the [REQUEST_DATA_STREAM mavlink message](https://ardupilot.org/dev/docs/mavlink-requesting-data.html#using-request-data-stream) to set the desired stream rates, the SRx_xxx parameter changes will not be saved to eeprom.  The parameters are still updated (which is probably not good) but they're not saved so they return to their defaults when the vehicle is rebooted.

This makes Rover consistent with Copter

I can imagine that in the distant past we may have received support requests from user asking, "why isn't my telemetry appearing?" but I think those days are long gone and this is no longer necessary

This has been lightly tested in SITL