### PR TITLE
AP_Math: squelch fabsf warnings on qurt

### DIFF
--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -765,7 +765,14 @@ void ModeGuided::pos_control_run()
 
     float terrain_margin_m = 0.0; // Vertical buffer size in m
     if (guided_is_terrain_alt) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_QURT
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wabsolute-value"
+#endif
         terrain_margin_m = MIN(copter.wp_nav->get_terrain_margin_m(), 0.5 * fabsF(guided_pos_target_ned_m.z));
+#if CONFIG_HAL_BOARD == HAL_BOARD_QURT
+#pragma clang diagnostic pop
+#endif
     }
     pos_control->input_pos_NED_m(guided_pos_target_ned_m, terrain_d_m, terrain_margin_m);
 

--- a/libraries/AP_Math/ftype.h
+++ b/libraries/AP_Math/ftype.h
@@ -28,7 +28,6 @@ typedef double ftype;
 #define ceilF(x) ceil(x)
 #define fminF(x,y) fmin(x,y)
 #define fmodF(x,y) fmod(x,y)
-#define fabsF(x) fabs(x)
 #define toftype todouble
 #else
 typedef float ftype;
@@ -47,7 +46,6 @@ typedef float ftype;
 #define ceilF(x) ceilf(x)
 #define fminF(x,y) fminf(x,y)
 #define fmodF(x,y) fmodf(x,y)
-#define fabsF(x) fabsf(x)
 #define toftype tofloat
 #endif
 

--- a/libraries/AP_Math/matrix_alg.cpp
+++ b/libraries/AP_Math/matrix_alg.cpp
@@ -77,9 +77,16 @@ static void mat_pivot(const T* A, T* pivot, uint16_t n)
     for(uint16_t i = 0;i < n; i++) {
         uint16_t max_j = i;
         for(uint16_t j=i;j<n;j++){
+#if CONFIG_HAL_BOARD == HAL_BOARD_QURT
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wabsolute-value"
+#endif
             if(fabsF(A[j*n + i]) > fabsF(A[max_j*n + i])) {
                 max_j = j;
             }
+#if CONFIG_HAL_BOARD == HAL_BOARD_QURT
+#pragma clang diagnostic pop
+#endif
         }
 
         if(max_j != i) {

--- a/libraries/AP_Math/quaternion.cpp
+++ b/libraries/AP_Math/quaternion.cpp
@@ -694,7 +694,14 @@ void QuaternionT<T>::zero(void)
 template <typename T>
 bool QuaternionT<T>::is_unit_length(void) const
 {
+#if CONFIG_HAL_BOARD == HAL_BOARD_QURT
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wabsolute-value"
+#endif
     if (fabsF(length_squared() - 1) < 1E-3) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_QURT
+#pragma clang diagnostic pop
+#endif
         return true;
     }
 

--- a/libraries/AP_Math/vector2.h
+++ b/libraries/AP_Math/vector2.h
@@ -250,6 +250,10 @@ struct Vector2
         const T expected_run = seg_end.x-seg_start.x;
         const T intersection_run = point.x-seg_start.x;
         // check slopes are identical:
+#if CONFIG_HAL_BOARD == HAL_BOARD_QURT
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wabsolute-value"
+#endif
         if (::is_zero(expected_run)) {
             if (fabsF(intersection_run) > FLT_EPSILON) {
                 return false;
@@ -261,6 +265,9 @@ struct Vector2
                 return false;
             }
         }
+#if CONFIG_HAL_BOARD == HAL_BOARD_QURT
+#pragma clang diagnostic pop
+#endif
         // check for presence in bounding box
         if (seg_start.x < seg_end.x) {
             if (point.x < seg_start.x || point.x > seg_end.x) {


### PR DESCRIPTION
Add float cast to float version of fabsF to get rid of compiler warnings about demoting doubles to floats. Also removes the duplicate definitions of the fabsF macro.