### PR TITLE
Plane: log whether throttle is suppressed or not 

### DIFF
--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -210,6 +210,7 @@ struct PACKED log_Status {
     bool is_still;
     uint8_t stage;
     bool impact;
+    bool throttle_supressed;
 };
 
 void Plane::Log_Write_Status()
@@ -225,6 +226,7 @@ void Plane::Log_Write_Status()
         ,is_still    : AP::ins().is_still()
         ,stage       : static_cast<uint8_t>(flight_stage)
         ,impact      : crash_state.impact_detected
+        ,throttle_supressed : throttle_suppressed
         };
 
     logger.WriteBlock(&pkt, sizeof(pkt));
@@ -382,8 +384,9 @@ const struct LogStructure Plane::log_structure[] = {
 // @Field: Still: True when vehicle is not moving in any axis
 // @Field: Stage: Current stage of the flight
 // @Field: Hit: True if impact is detected
+// @Field: Sup: True if throttle is suppressed
     { LOG_STATUS_MSG, sizeof(log_Status),
-      "STAT", "QBfBBBBBB",  "TimeUS,isFlying,isFlyProb,Armed,Safety,Crash,Still,Stage,Hit", "s--------", "F--------" , true },
+      "STAT", "QBfBBBBBBB",  "TimeUS,isFlying,isFlyProb,Armed,Safety,Crash,Still,Stage,Hit,Sup", "s---------", "F---------" , true },
 
 // @LoggerMessage: QTUN
 // @Description: QuadPlane vertical tuning message


### PR DESCRIPTION
This adds logging of whether the throttle is suppressed or not into the `STAT` message.

I've created a new field, "Bit" to hold a bitmask of boolean information about the vehicle - saves 40 bytes per message past me adding the new field.

I suggest we remove the old equivalent uint8_t fields in 4.8 - just have them in here for a bit of cross-over.

The new LogStatus class is perhaps overkill - but I think we might be able to templatise it and have a nice, compact way of doing similar bitmasks in log messages.


For this entire PR:
```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                                                     
CubeRedPrimary                      *      *           *       *                 120    *      *
Durandal                            *      *           *       *                 72     *      *
Hitec-Airspeed           *                                                                     
KakuteH7-bdshot                     *      *           *       *                 120    *      *
MatekF405                           *      *           *       *                 120    *      *
Pixhawk1-1M-bdshot                  *                  *       *                 120    *      *
f103-QiotekPeriph        *                                                                     
f303-Universal           *                                                                     
iomcu                                                                *                         
revo-mini                           *      *           *       *                 120    *      *
skyviper-journey                                       *                                       
skyviper-v2450                                         *                                       
```

Without the new column, just with the weird class and consolidating into status, removing the old fields:
```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                                                     
CubeRedPrimary                      *      *           *       *                 -32    *      *
Durandal                            *      *           *       *                 -24    *      *
Hitec-Airspeed           *                                                                     
KakuteH7-bdshot                     *      *           *       *                 -32    *      *
MatekF405                           *      *           *       *                 -32    *      *
Pixhawk1-1M-bdshot                  *                  *       *                 -32    *      *
f103-QiotekPeriph        *                                                                     
f303-Universal           *                                                                     
iomcu                                                                *                         
revo-mini                           *      *           *       *                 -32    *      *
skyviper-journey                                       *                                       
skyviper-v2450                                         *                                       
```

