### PR TITLE
Github: add Lua problem matcher

### DIFF
--- a/.github/problem-matchers/Lua.json
+++ b/.github/problem-matchers/Lua.json
@@ -1,0 +1,32 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "Luacheck-problem-matcher",
+            "fileLocation": [ "relative", "${GITHUB_WORKSPACE}" ],
+            "pattern": [
+                {
+                    "regexp": "^( *)(.+.lua):(\\d+):(\\d+): (.*)$",
+                    "file": 2,
+                    "line": 3,
+                    "column": 4,
+                    "message": 5
+                }
+            ]
+        },
+        {
+            "owner": "Lua-language-server-problem-matcher",
+            "pattern": [
+                {
+                    "regexp": "^(.+.lua):(\\d+):(\\d+)",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3
+                },
+                {
+                    "regexp": "^(.*)",
+                    "message": 1
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/test_scripting.yml
+++ b/.github/workflows/test_scripting.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           submodules: 'recursive'
 
+      - name: Register lua problem matcher
+        run: echo "::add-matcher::.github/problem-matchers/Lua.json"
+
       - name: Lua Linter
         shell: bash
         run: |


### PR DESCRIPTION
This adds a problem matcher for the lua CI check. 

![image](https://github.com/user-attachments/assets/d5784169-ae78-4090-a465-02df0da54332)

Its not perfect, the lua language server check regex only gets the first line of the message. There is also a limit of 10 annotations per step, so we only get 10 errors. But hopefully its a little easier than what we have now.
