### PR TITLE
Rover: Fixes for (very) small vehicles

### DIFF
--- a/Rover/mode.h
+++ b/Rover/mode.h
@@ -419,6 +419,9 @@ public:
     Number mode_number() const override { return Number::CIRCLE; }
     const char *name4() const override { return "CIRC"; }
 
+    // return the distance at which the vehicle is considered to be on track along the circle
+    float get_reached_distance() const;
+
     // initialise with specific center location, radius (in meters) and direction
     // replaces use of _enter when initialised from within Auto mode
     bool set_center(const Location& center_loc, float radius_m, bool dir_ccw);

--- a/Rover/mode_circle.cpp
+++ b/Rover/mode_circle.cpp
@@ -1,8 +1,7 @@
 #include "Rover.h"
 
 #define AR_CIRCLE_ACCEL_DEFAULT         1.0 // default acceleration in m/s/s if not specified by user
-#define AR_CIRCLE_RADIUS_MIN            0.5 // minimum radius in meters
-#define AR_CIRCLE_REACHED_EDGE_DIST     0.2 // vehicle has reached edge if within 0.2m
+#define AR_CIRCLE_RADIUS_MIN            0.1 // minimum radius in meters
 
 const AP_Param::GroupInfo ModeCircle::var_info[] = {
 
@@ -37,6 +36,15 @@ const AP_Param::GroupInfo ModeCircle::var_info[] = {
 ModeCircle::ModeCircle() : Mode()
 {
     AP_Param::setup_object_defaults(this, var_info);
+}
+
+// get the distance at which the vehicle is considered to be on track along the circle
+float ModeCircle::get_reached_distance() const
+{
+    if (config.radius >= 0.5) {
+        return 0.2;
+    }
+    return 0.1;
 }
 
 // initialise with specific center location, radius (in meters) and direction
@@ -158,12 +166,12 @@ void ModeCircle::update()
     // Update depending on stage
     if (!reached_edge) {
         update_drive_to_radius();
-    } else if (dist_to_edge_m > 2 * MAX(g2.turn_radius, AR_CIRCLE_REACHED_EDGE_DIST) && !tracking_back) {
+    } else if (dist_to_edge_m > 2 * MAX(g2.turn_radius, get_reached_distance()) && !tracking_back) {
         // if more than 2* turn_radius outside circle radius, slow vehicle by 20%
         config.speed = 0.8 * config.speed;
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Circle: cannot keep up, slowing to %.1fm/s", config.speed);
         tracking_back = true;
-    } else if (dist_to_edge_m < MAX(g2.turn_radius, AR_CIRCLE_REACHED_EDGE_DIST) && tracking_back) {
+    } else if (dist_to_edge_m < MAX(g2.turn_radius, get_reached_distance()) && tracking_back) {
         // if within turn_radius, call the vehicle back on track
         tracking_back = false;
     } else {
@@ -184,7 +192,7 @@ void ModeCircle::update()
 void ModeCircle::update_drive_to_radius()
 {
     // check if vehicle has reached edge of circle
-    const float dist_thresh_m = MAX(g2.turn_radius, AR_CIRCLE_REACHED_EDGE_DIST);
+    const float dist_thresh_m = MAX(g2.turn_radius, get_reached_distance());
     reached_edge |= dist_to_edge_m <= dist_thresh_m;
 
     // calculate target point's position, velocity and acceleration

--- a/libraries/AP_Scripting/applets/rover-quicktune.lua
+++ b/libraries/AP_Scripting/applets/rover-quicktune.lua
@@ -26,7 +26,7 @@ local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTI
 
 local PARAM_TABLE_KEY = 15
 local PARAM_TABLE_PREFIX = "RTUN_"
-local PARAM_TABLE_SIZE = 11
+local PARAM_TABLE_SIZE = 12
 
 -- bind a parameter to a variable
 function bind_param(name)
@@ -143,6 +143,16 @@ local RTUN_AUTO_SAVE = bind_add_param('AUTO_SAVE', 10, 5)
 --]]
 local RTUN_RC_FUNC = bind_add_param('RC_FUNC', 11, 300)
 
+--[[
+  // @Param: RTUN_SPEED_MIN
+  // @DisplayName: Rover Quicktune minimum speed for tuning
+  // @Description: The mimimum speed in m/s required for tuning to start
+  // @Units: m/s
+  // @Range: 0.1 0.5
+  // @User: Standard
+--]]
+local SPEED_FF_SPEED_MIN = bind_add_param('SPEED_MIN', 12, 0.5)
+
 -- other vehicle parameters used by this script
 local INS_GYRO_FILTER  = bind_param("INS_GYRO_FILTER")
 local GCS_PID_MASK     = bind_param("GCS_PID_MASK")
@@ -159,7 +169,6 @@ local FLTD_MUL = 0.5                -- ATC_STR_RAT_FLTD set to 0.5 * INS_GYRO_FI
 local FLTT_MUL = 0.5                -- ATC_STR_RAT_FLTT set to 0.5 * INS_GYRO_FILTER
 local STR_RAT_FF_TURNRATE_MIN = math.rad(10)    -- steering rate feedforward min vehicle turn rate (in radians/sec)
 local STR_RAT_FF_STEERING_MIN = 0.10            -- steering rate feedforward min steering output (in the range 0 to 1)
-local SPEED_FF_SPEED_MIN = 0.5      -- speed feedforward minimum vehicle speed (in m/s)
 local SPEED_FF_THROTTLE_MIN = 0.20  -- speed feedforward requires throttle output (in the range 0 to 1)
 
 -- get time in seconds since boot
@@ -458,7 +467,7 @@ function update_speed_ff(ff_pname)
 
   -- check throttle and speed
   local throttle_ok = throttle_out >= SPEED_FF_THROTTLE_MIN
-  local speed_ok = speed > SPEED_FF_SPEED_MIN
+  local speed_ok = speed > SPEED_FF_SPEED_MIN:get()
   if (throttle_ok and speed_ok) then
     ff_throttle_sum = ff_throttle_sum + throttle_out
     ff_speed_sum = ff_speed_sum + speed
@@ -471,7 +480,7 @@ function update_speed_ff(ff_pname)
       if not throttle_ok then
         gcs:send_text(MAV_SEVERITY.WARNING, string.format("RTun: increase throttle (%d < %d)", math.floor(throttle_out * 100), math.floor(SPEED_FF_THROTTLE_MIN * 100)))
       elseif not speed_ok then
-        gcs:send_text(MAV_SEVERITY.WARNING, string.format("RTun: increase speed (%3.1f < %3.1f)", speed, SPEED_FF_SPEED_MIN))
+        gcs:send_text(MAV_SEVERITY.WARNING, string.format("RTun: increase speed (%3.1f < %3.1f)", speed, SPEED_FF_SPEED_MIN:get()))
       end
     end
   end

--- a/libraries/AP_Scripting/applets/rover-quicktune.md
+++ b/libraries/AP_Scripting/applets/rover-quicktune.md
@@ -60,6 +60,8 @@ If you move the switch to the low position at any time in the tune before gains 
 
 If the pilot gives steering or throttle input during tuning then tuning is paused for 4 seconds.  Tuning restarts once the pilot returns to the input to the neutral position.
 
+If the vehicle is not able to turn correctly to enter or track the circle, the ``PSC`` parameters may be to be increased. For example ``PSC_VEL_P`` to 20 for very slow (<0.4m/s) vehicles.
+
 # Parameters
 
 The script has the following parameters to configure its behaviour
@@ -120,3 +122,8 @@ completes unless the pilot move the RC switch low to revert the tune.
 Setting this to a non-zero value allows you to use quicktune with a 2-position
 switch, with the switch settings as low and mid positions. A zero
 value disables auto-save and you need to have a 3 position switch.
+
+## RTUN_SPEED_MIN
+
+The minimum speed at which tuning will occur. The vehicle must be able to
+run in Circle mode at this speed or greater.


### PR DESCRIPTION
A set of patches as I go through the rover quicktune process for very small vehicles (https://discuss.ardupilot.org/t/visual-navigation-on-the-cheap/91700).

For reference, I'm running rover quicktune at 0.15m/s velocity and 0.2m radius circle.

Still a few stability issues with the circle mode when tuning speed to investigate.

WIP