### PR TITLE
Board Types: reserve board-id for stellar H7V2

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -334,6 +334,7 @@ AP_HW_MountainEagleH743              1444
 AP_HW_StellarF4                      1500
 AP_HW_GEPRCF745BTHD                  1501
 AP_HW_GEPRC_TAKER_H743               1502
+AP_HW_StellarH7V2                    1503
 
 AP_HW_HGLRCF405V4                    1524
 


### PR DESCRIPTION
Reserve Board-ID for StingBee Stellar H7V2

https://github.com/betaflight/config/blob/master/configs/STELLARH7V2/config.h