### PR TITLE
Avoid including AP_InertialSensor.h in headers

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -37,7 +37,6 @@
 #include <AP_Logger/AP_Logger.h>            // ArduPilot Mega Flash Memory Library
 #include <AP_Math/AP_Math.h>                // ArduPilot Mega Vector/Matrix math Library
 #include <AP_AccelCal/AP_AccelCal.h>        // interface and maths for accelerometer calibration
-#include <AP_InertialSensor/AP_InertialSensor.h>                // ArduPilot Mega Inertial Sensor (accel & gyro) Library
 #include <AP_AHRS/AP_AHRS.h>                                    // AHRS (Attitude Heading Reference System) interface library for ArduPilot
 #include <AP_Mission/AP_Mission.h>                              // Mission command library
 #include <AP_Mission/AP_Mission_ChangeDetector.h>               // Mission command change detection library

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -35,7 +35,6 @@
 #include <AP_Param/AP_Param.h>
 #include <StorageManager/StorageManager.h>
 #include <AP_Math/AP_Math.h>        // ArduPilot Mega Vector/Matrix math Library
-#include <AP_InertialSensor/AP_InertialSensor.h> // Inertial Sensor Library
 #include <AP_AccelCal/AP_AccelCal.h>                // interface and maths for accelerometer calibration
 #include <AP_AHRS/AP_AHRS.h>         // ArduPilot Mega DCM Library
 #include <SRV_Channel/SRV_Channel.h>

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -41,7 +41,6 @@
 #include <AP_Logger/AP_Logger.h>          // ArduPilot Mega Flash Memory Library
 #include <AP_Baro/AP_Baro.h>
 #include <AP_Compass/AP_Compass.h>         // ArduPilot Mega Magnetometer Library
-#include <AP_InertialSensor/AP_InertialSensor.h>  // ArduPilot Mega Inertial Sensor (accel & gyro) Library
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Mission/AP_Mission.h>         // Mission command library
 #include <AC_AttitudeControl/AC_AttitudeControl_Sub.h> // Attitude control library

--- a/Blimp/Blimp.h
+++ b/Blimp/Blimp.h
@@ -36,8 +36,6 @@
 // Application dependencies
 #include <AP_Logger/AP_Logger.h>          // ArduPilot Mega Flash Memory Library
 #include <AP_Math/AP_Math.h>            // ArduPilot Mega Vector/Matrix math Library
-// #include <AP_AccelCal/AP_AccelCal.h>                // interface and maths for accelerometer calibration
-// #include <AP_InertialSensor/AP_InertialSensor.h>  // ArduPilot Mega Inertial Sensor (accel & gyro) Library
 #include <AP_AHRS/AP_AHRS.h>
 #include <Filter/Filter.h>             // Filter library
 #include <AP_Vehicle/AP_Vehicle.h>         // needed for AHRS build

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -14,6 +14,7 @@
 #include <AP_Logger/AP_Logger.h>
 #include <GCS_MAVLink/GCS.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
+#include <AP_InertialSensor/AP_InertialSensor.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/APM_Control/AP_YawController.cpp
+++ b/libraries/APM_Control/AP_YawController.cpp
@@ -22,6 +22,7 @@
 #include <AP_AHRS/AP_AHRS.h>
 #include <GCS_MAVLink/GCS.h>
 #include <AP_Scheduler/AP_Scheduler.h>
+#include <AP_InertialSensor/AP_InertialSensor.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -278,6 +278,14 @@ void AP_AHRS::init()
 #endif  // AP_CUSTOMROTATIONS_ENABLED
 }
 
+const Vector3f &AP_AHRS::get_accel(void) const {
+#if AP_INERTIALSENSOR_ENABLED
+    return AP::ins().get_accel(_get_primary_accel_index());
+#else
+    return Vector3f();
+#endif
+}
+
 // updates matrices responsible for rotating vectors from vehicle body
 // frame to autopilot body frame from _trim variables
 void AP_AHRS::update_trim_rotation_matrices()

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -619,9 +619,7 @@ public:
     Vector3f get_vibration(void) const;
 
     // return primary accels
-    const Vector3f &get_accel(void) const {
-        return AP::ins().get_accel(_get_primary_accel_index());
-    }
+    const Vector3f &get_accel(void) const;
 
     // return primary accel bias. This should be subtracted from
     // get_accel() vector to get best current body frame accel

--- a/libraries/AP_AHRS/AP_AHRS_Backend.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.cpp
@@ -19,6 +19,7 @@
 
 #include <AP_Common/Location.h>
 #include <AP_HAL/AP_HAL.h>
+#include <AP_InertialSensor/AP_InertialSensor.h>
 #include <AP_Logger/AP_Logger.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_Baro/AP_Baro.h>
@@ -29,6 +30,24 @@ extern const AP_HAL::HAL& hal;
 
 void AP_AHRS_Backend::init()
 {
+}
+
+// get the index of the current primary accelerometer sensor
+uint8_t AP_AHRS_Backend::get_primary_accel_index(void) const {
+#if AP_INERTIALSENSOR_ENABLED
+    return AP::ins().get_first_usable_accel();
+#else
+    return 0;
+#endif
+}
+
+// get the index of the current primary gyro sensor
+uint8_t AP_AHRS_Backend::get_primary_gyro_index(void) const {
+#if AP_INERTIALSENSOR_ENABLED
+    return AP::ins().get_first_usable_gyro();
+#else
+    return 0;
+#endif
 }
 
 // return a smoothed and corrected gyro vector using the latest ins data (which may not have been consumed by the EKF yet)

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -23,7 +23,6 @@
 #include <AP_Math/AP_Math.h>
 #include <inttypes.h>
 #include <AP_Airspeed/AP_Airspeed.h>
-#include <AP_InertialSensor/AP_InertialSensor.h>
 #include <AP_Common/Location.h>
 #include <AP_NavEKF/AP_NavEKF_Source.h>
 
@@ -76,22 +75,10 @@ public:
     virtual int8_t get_primary_core_index() const { return -1; }
 
     // get the index of the current primary accelerometer sensor
-    virtual uint8_t get_primary_accel_index(void) const {
-#if AP_INERTIALSENSOR_ENABLED
-        return AP::ins().get_first_usable_accel();
-#else
-        return 0;
-#endif
-    }
+    virtual uint8_t get_primary_accel_index(void) const;
 
     // get the index of the current primary gyro sensor
-    virtual uint8_t get_primary_gyro_index(void) const {
-#if AP_INERTIALSENSOR_ENABLED
-        return AP::ins().get_first_usable_gyro();
-#else
-        return 0;
-#endif
-    }
+    virtual uint8_t get_primary_gyro_index(void) const;
 
     // Methods
     virtual void update() = 0;

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -31,6 +31,7 @@
 #include <AP_GPS/AP_GPS.h>
 #include <AP_Baro/AP_Baro.h>
 #include <AP_Compass/AP_Compass.h>
+#include <AP_InertialSensor/AP_InertialSensor.h>
 #include <AP_Logger/AP_Logger.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 

--- a/libraries/AP_AHRS/AP_AHRS_External.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_External.cpp
@@ -4,6 +4,7 @@
 
 #include <AP_ExternalAHRS/AP_ExternalAHRS.h>
 #include <AP_AHRS/AP_AHRS.h>
+#include <AP_InertialSensor/AP_InertialSensor.h>
 
 // true if the AHRS has completed initialisation
 bool AP_AHRS_External::initialised(void) const

--- a/libraries/AP_GyroFFT/AP_GyroFFT.cpp
+++ b/libraries/AP_GyroFFT/AP_GyroFFT.cpp
@@ -25,6 +25,7 @@
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_Arming/AP_Arming.h>
 #include <AP_Vehicle/AP_Vehicle.h>
+#include <AP_InertialSensor/AP_InertialSensor.h>
 #if APM_BUILD_COPTER_OR_HELI || APM_BUILD_TYPE(APM_BUILD_ArduPlane)
 #include <AP_Motors/AP_Motors.h>
 #endif
@@ -426,6 +427,11 @@ void AP_GyroFFT::update()
     if (!_rpy_health.z) {
         _health.z = 0;
     }
+}
+
+uint16_t AP_GyroFFT::get_available_samples(uint8_t axis)
+{
+    return _sample_mode == 0 ?_ins->get_raw_gyro_window(axis).available() : _downsampled_gyro_data[axis].available();
 }
 
 // analyse gyro data using FFT, returns number of samples still held

--- a/libraries/AP_GyroFFT/AP_GyroFFT.h
+++ b/libraries/AP_GyroFFT/AP_GyroFFT.h
@@ -24,7 +24,6 @@
 #include <AP_HAL/utility/RingBuffer.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
-#include <AP_InertialSensor/AP_InertialSensor.h>
 #include <Filter/LowPassFilter.h>
 #include <Filter/FilterWithBuffer.h>
 
@@ -221,9 +220,7 @@ private:
     // whether analysis can be run again or not
     bool start_analysis();
     // return samples available in the gyro window
-    uint16_t get_available_samples(uint8_t axis) {
-        return _sample_mode == 0 ?_ins->get_raw_gyro_window(axis).available() : _downsampled_gyro_data[axis].available();
-    }
+    uint16_t get_available_samples(uint8_t axis);
     void update_parameters(bool force);
     // semaphore for access to shared FFT data
     HAL_Semaphore _sem;
@@ -358,7 +355,7 @@ private:
     AP_Int8 _num_frames;
     // mask of IMUs to record gyro frames after the filter bank
     AP_Int32 _options;
-    AP_InertialSensor* _ins;
+    class AP_InertialSensor* _ins;
 #if DEBUG_FFT
     uint32_t _last_output_ms;
     EngineState _debug_state;

--- a/libraries/AP_InertialSensor/FastRateBuffer.h
+++ b/libraries/AP_InertialSensor/FastRateBuffer.h
@@ -14,7 +14,7 @@
 */
 #pragma once
 
-#include "AP_InertialSensor.h"
+#include "AP_InertialSensor_rate_config.h"
 
 #if AP_INERTIALSENSOR_FAST_SAMPLE_WINDOW_ENABLED
 

--- a/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
+++ b/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
@@ -5,6 +5,7 @@
 #include "AP_Mount_SoloGimbal.h"
 
 #include "SoloGimbal.h"
+#include <AP_InertialSensor/AP_InertialSensor.h>
 #include <AP_Logger/AP_Logger.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <GCS_MAVLink/GCS.h>

--- a/libraries/AP_Mount/SoloGimbal.cpp
+++ b/libraries/AP_Mount/SoloGimbal.cpp
@@ -8,6 +8,7 @@
 
 #include <stdio.h>
 #include <GCS_MAVLink/GCS.h>
+#include <AP_InertialSensor/AP_InertialSensor.h>
 #include <AP_Logger/AP_Logger.h>
 
 extern const AP_HAL::HAL& hal;

--- a/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp
+++ b/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp
@@ -31,6 +31,7 @@
 #include <stdio.h>
 #include <time.h>
 #include <AP_AHRS/AP_AHRS_config.h>
+#include <AP_InertialSensor/AP_InertialSensor.h>
 
 #if AP_AHRS_ENABLED
 #include <AP_AHRS/AP_AHRS.h>

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -31,7 +31,6 @@
 #include <AP_NavEKF/AP_NavEKF_core_common.h>
 #include <AP_NavEKF/AP_NavEKF_Source.h>
 #include <AP_NavEKF/EKF_Buffer.h>
-#include <AP_InertialSensor/AP_InertialSensor.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>
 
 #include "AP_NavEKF/EKFGSF_yaw.h"

--- a/libraries/AP_Soaring/Variometer.cpp
+++ b/libraries/AP_Soaring/Variometer.cpp
@@ -5,6 +5,7 @@ Manages the estimation of aircraft total energy, drag and vertical air velocity.
 #include "Variometer.h"
 
 #include <AP_AHRS/AP_AHRS.h>
+#include <AP_InertialSensor/AP_InertialSensor.h>
 #include <AP_Logger/AP_Logger.h>
 
 Variometer::Variometer(const AP_FixedWing &parms, const PolarParams &polarParams) :

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -4,6 +4,7 @@
 #include <AP_Baro/AP_Baro.h>
 #include <AP_Logger/AP_Logger.h>
 #include <AP_Landing/AP_Landing.h>
+#include <AP_InertialSensor/AP_InertialSensor.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -22,6 +22,7 @@
 #include <AP_Param/AP_Param.h>
 #include <AP_Vehicle/AP_FixedWing.h>
 #include <Filter/AverageFilter.h>
+#include <Filter/LowPassFilter.h>
 
 class AP_Landing;
 class AP_TECS {

--- a/libraries/AP_TempCalibration/AP_TempCalibration.cpp
+++ b/libraries/AP_TempCalibration/AP_TempCalibration.cpp
@@ -23,6 +23,8 @@
 #include "AP_TempCalibration.h"
 #include <stdio.h>
 #include <AP_Baro/AP_Baro.h>
+#include <AP_HAL/AP_HAL.h>
+#include <AP_InertialSensor/AP_InertialSensor.h>
 
 extern const AP_HAL::HAL& hal;
 

--- a/libraries/AP_TempCalibration/AP_TempCalibration.h
+++ b/libraries/AP_TempCalibration/AP_TempCalibration.h
@@ -22,9 +22,8 @@
 
 #if AP_TEMPCALIBRATION_ENABLED
 
-#include <AP_HAL/AP_HAL.h>
+#include <AP_Math/vector3.h>
 #include <AP_Param/AP_Param.h>
-#include <AP_InertialSensor/AP_InertialSensor.h>
 
 class AP_TempCalibration
 {

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -19,6 +19,7 @@
 #include <AP_OpticalFlow/AP_OpticalFlow.h>
 #include <AP_GPS/AP_GPS.h>
 #include <RC_Channel/RC_Channel.h>
+#include <AP_InertialSensor/AP_InertialSensor.h>
 
 #include "MissionItemProtocol_Waypoints.h"
 #include "MissionItemProtocol_Rally.h"

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -29,6 +29,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Arming/AP_Arming.h>
 #include <AP_InternalError/AP_InternalError.h>
+#include <AP_InertialSensor/AP_InertialSensor.h>
 #include <AP_Logger/AP_Logger.h>
 #include <AP_OpticalFlow/AP_OpticalFlow.h>
 #include <AP_Vehicle/AP_Vehicle.h>

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -40,6 +40,7 @@ extern const AP_HAL::HAL& hal;
 #include <AP_Generator/AP_Generator.h>
 #include <AP_Gripper/AP_Gripper.h>
 #include <AP_GyroFFT/AP_GyroFFT.h>
+#include <AP_InertialSensor/AP_InertialSensor.h>
 #include <AP_ADSB/AP_ADSB.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_BattMonitor/AP_BattMonitor.h>


### PR DESCRIPTION
increases amount of work compiler needs to do for no good reason

... particularly when including in AP_AHRS.h, which is used a lot.

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                                                     
CubeRedPrimary                      8      *           0       0                 -16    0      16
Durandal                            -8     *           -24     -24               -32    -24    0
Hitec-Airspeed           *                                                                     
KakuteH7-bdshot                     16     *           0       -8                -16    -8     16
MatekF405                           0      *           8       16                0      16     0
Pixhawk1-1M-bdshot                  0                  8       16                -8     8      0
bebop                               32                 16      48                -4     -16    -16
f103-QiotekPeriph        *                                                                     
f303-Universal           *                                                                     
iomcu                                                                *                         
revo-mini                           0      *           8       8                 0      8      0
skyviper-v2450                                         8                                       
```
