### PR TITLE
AP_Logger: add metadata giving enum for RFND.Orient

### DIFF
--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -997,6 +997,7 @@ struct PACKED log_VER {
 // @Field: Stat: Sensor state
 // @FieldValueEnum: Stat: RangeFinder::Status
 // @Field: Orient: Sensor orientation
+// @FieldValueEnum: Orient: Rotation
 // @Field: Quality: Signal quality. -1 means invalid, 0 is no signal, 100 is perfect signal
 
 // @LoggerMessage: RSSI


### PR DESCRIPTION
```
2024-12-18 02:20:27.446: RFND
    TimeUS: 3111687840 µs
    Instance: 0 instance
    Dist: 0.23 m
    Stat: 4 (Good)
    Orient: 25 (ROTATION_PITCH_270)
```

(allows ROTATION_PITCH_270 to be filled in)