### PR TITLE
AP_AHRS: remove stale comment

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -767,9 +767,6 @@ private:
     void update_EKF3(void);
 #endif
 
-    // rotation from vehicle body to NED frame
-
-
     const uint16_t startup_delay_ms = 1000;
     uint32_t start_time_ms;
     uint8_t _ekf_flags; // bitmask from Flags enumeration


### PR DESCRIPTION
not associated with relevant state; the relevant state names make things clearer than this comment does