### PR TITLE
ardupilotwaf: properly configure double precision tasks

### DIFF
--- a/Tools/ardupilotwaf/ap_library.py
+++ b/Tools/ardupilotwaf/ap_library.py
@@ -277,13 +277,7 @@ def double_precision_check(tasks):
             double_library = t.env.DOUBLE_PRECISION_LIBRARIES.get(src[0],False)
 
             if double_library or src in double_tasks:
-                t.env.CXXFLAGS = t.env.CXXFLAGS[:]
-                for opt in ['-fsingle-precision-constant', '-cl-single-precision-constant']:
-                    try:
-                        t.env.CXXFLAGS.remove(opt)
-                    except ValueError:
-                        pass
-                t.env.CXXFLAGS.append("-DALLOW_DOUBLE_MATH_FUNCTIONS")
+                t.env.CXXFLAGS = ap.set_double_precision_flags(t.env.CXXFLAGS)
 
 
 def gsoap_library_check(bld, tasks):

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -146,6 +146,24 @@ def get_legacy_defines(sketch_name, bld):
         'AP_BUILD_TARGET_NAME="' + sketch_name + '"',
     ]
 
+def set_double_precision_flags(flags):
+    # set up flags for double precision files:
+    # * remove all single precision constant flags
+    # * set define to allow double precision math in AP headers
+
+    flags = flags[:] # copy the list to avoid affecting other builds
+
+    # remove GCC and clang single precision constant flags
+    for opt in ('-fsingle-precision-constant', '-cl-single-precision-constant'):
+        while True: # might have multiple copies from different sources
+            try:
+                flags.remove(opt)
+            except ValueError:
+                break
+    flags.append("-DALLOW_DOUBLE_MATH_FUNCTIONS")
+
+    return flags
+
 IGNORED_AP_LIBRARIES = [
     'doc',
     'AP_Scripting', # this gets explicitly included when it is needed and should otherwise never be globbed in

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -494,14 +494,7 @@ def ap_find_tests(bld, use=[], DOUBLE_PRECISION_SOURCES=[]):
         )
         filename = os.path.basename(f.abspath())
         if filename in DOUBLE_PRECISION_SOURCES:
-            t.env.CXXFLAGS = t.env.CXXFLAGS[:]
-            single_precision_option='-fsingle-precision-constant'
-            if single_precision_option in t.env.CXXFLAGS:
-                t.env.CXXFLAGS.remove(single_precision_option)
-            single_precision_option='-cl-single-precision-constant'
-            if single_precision_option in t.env.CXXFLAGS:
-                t.env.CXXFLAGS.remove(single_precision_option)
-            t.env.CXXFLAGS.append("-DALLOW_DOUBLE_MATH_FUNCTIONS")
+            t.env.CXXFLAGS = set_double_precision_flags(t.env.CXXFLAGS)
 
 _versions = []
 


### PR DESCRIPTION
There might be multiple copies of the flags, so remove all of them. Also pull the setup into a helper function to avoid duplicating the logic. On ChibiOS boards, this fixes SITL (which had issues with position quantization) and affects the SBF GPS driver (which was probably fine before but does change slightly).

Sim on hardware now flies smoothly instead of jittering about all over the place. SBF requires a handful more bytes but I don't think this meaningfully affects the function based on a brief read-through; the important lat/lon casts were already done manually.

Many thanks to tridge for working with me to debug this. Assuming it should be backported so that SBF works as written even if the change in behavior is negligible.