### PR TITLE
Remove unused AHRS methods

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -2518,7 +2518,8 @@ bool AP_AHRS::getMagOffsets(uint8_t mag_idx, Vector3f &magOffsets) const
 
 #if AP_AHRS_SIM_ENABLED
     case EKFType::SIM:
-        return sim.get_mag_offsets(mag_idx, magOffsets);
+        magOffsets.zero();
+        return true;
 #endif
 #if AP_AHRS_EXTERNAL_ENABLED
     case EKFType::EXTERNAL:

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -136,12 +136,6 @@ public:
         return true;
     }
 
-    // return estimate of true airspeed vector in body frame in m/s
-    // returns false if estimate is unavailable
-    virtual bool airspeed_vector_true(Vector3f &vec) const WARN_IF_UNUSED {
-        return false;
-    }
-
     // get apparent to true airspeed ratio
     static float get_EAS2TAS(void);
     static float get_TAS2EAS(void) { return 1.0/get_EAS2TAS(); }

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -72,18 +72,6 @@ public:
     // init sets up INS board orientation
     virtual void init();
 
-    // return the index of the primary core or -1 if no primary core selected
-    virtual int8_t get_primary_core_index() const { return -1; }
-
-    // get the index of the current primary accelerometer sensor
-    virtual uint8_t get_primary_accel_index(void) const {
-#if AP_INERTIALSENSOR_ENABLED
-        return AP::ins().get_first_usable_accel();
-#else
-        return 0;
-#endif
-    }
-
     // get the index of the current primary gyro sensor
     virtual uint8_t get_primary_gyro_index(void) const {
 #if AP_INERTIALSENSOR_ENABLED

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -231,12 +231,6 @@ public:
     // return the quaternion defining the rotation from NED to XYZ (body) axes
     virtual bool get_quaternion(Quaternion &quat) const WARN_IF_UNUSED = 0;
 
-    // return true if the AHRS object supports inertial navigation,
-    // with very accurate position and velocity
-    virtual bool have_inertial_nav(void) const {
-        return false;
-    }
-
     // is the AHRS subsystem healthy?
     virtual bool healthy(void) const = 0;
 

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -176,19 +176,6 @@ public:
     // This is different to the vertical velocity from the EKF which is not always consistent with the vertical position due to the various errors that are being corrected for.
     virtual bool get_vert_pos_rate_D(float &velocity) const = 0;
 
-    // returns the estimated magnetic field offsets in body frame
-    virtual bool get_mag_field_correction(Vector3f &ret) const WARN_IF_UNUSED {
-        return false;
-    }
-
-    virtual bool get_mag_field_NED(Vector3f &vec) const {
-        return false;
-    }
-
-    virtual bool get_mag_offsets(uint8_t mag_idx, Vector3f &magOffsets) const {
-        return false;
-    }
-
     //
     virtual bool set_origin(const Location &loc) {
         return false;

--- a/libraries/AP_AHRS/AP_AHRS_SIM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_SIM.cpp
@@ -172,13 +172,6 @@ void AP_AHRS_SIM::get_control_limits(float &ekfGndSpdLimit, float &ekfNavVelGain
     ekfNavVelGainScaler = 1.0f;
 }
 
-bool AP_AHRS_SIM::get_mag_offsets(uint8_t mag_idx, Vector3f &magOffsets) const
-{
-    magOffsets.zero();
-
-    return true;
-}
-
 void AP_AHRS_SIM::send_ekf_status_report(GCS_MAVLINK &link) const
 {
 #if HAL_GCS_ENABLED

--- a/libraries/AP_AHRS/AP_AHRS_SIM.h
+++ b/libraries/AP_AHRS/AP_AHRS_SIM.h
@@ -98,10 +98,6 @@ public:
     // get_filter_status - returns filter status as a series of flags
     bool get_filter_status(nav_filter_status &status) const override;
 
-    // get compass offset estimates
-    // true if offsets are valid
-    bool get_mag_offsets(uint8_t mag_idx, Vector3f &magOffsets) const override;
-
     // relative-origin functions for fallback in AP_InertialNav
     bool get_origin(Location &ret) const override;
     bool get_relative_position_NED_origin(Vector3f &vec) const override;


### PR DESCRIPTION
```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                                                     
CubeRedPrimary                      -96    *           -96     -96               -96    -96    -96
Durandal                            -104   *           -104    -104              -104   -104   -104
Hitec-Airspeed           *                                                                     
KakuteH7-bdshot                     -96    *           -96     -96               -96    -96    -96
MatekF405                           -64    *           -72     -64               -64    -64    -64
Pixhawk1-1M-bdshot                  -64                -72     -72               -72    -64    -72
bebop                               -588               -588    -588              -588   -620   -588
f103-QiotekPeriph        *                                                                     
f303-Universal           *                                                                     
iomcu                                                                *                         
revo-mini                           -72    *           -72     -64               -64    -64    -64
skyviper-v2450                                         -64                                     
```

If we need this information we're likely to return it in the results object rather than as separate methods like we currently do.
