### PR TITLE
AP_Filesystem: FATFS: remove redundant delay expectations

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
@@ -254,7 +254,6 @@ static bool remount_file_system(void)
     }
     if (!sdcard_retry()) {
         remount_needed = true;
-        EXPECT_DELAY_MS(0);
         return false;
     }
     remount_needed = false;
@@ -278,7 +277,6 @@ static bool remount_file_system(void)
             f_lseek(fh, offset);
         }
     }
-    EXPECT_DELAY_MS(0);
     return true;
 }
 


### PR DESCRIPTION
The delays will be canceled on return by the EXPECT_DELAY_MS(3000) destructor at the start of the function. The current behavior will unexpectedly cancel delays from higher levels up the stack and is likely not what was intended.

Tested that filesystem operations still work on SD card on Cube Orange.

Is it possible to do filesystem ops from the main thread? Should that other EXPECT_DELAY_MS be removed too?