### PR TITLE
Plane:mode AUTOLAND enhancements

### DIFF
--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -321,6 +321,10 @@ bool AP_Arming_Plane::arm(const AP_Arming::Method method, const bool do_arming_c
     // rising edge of delay_arming oneshot
     delay_arming = true;
 
+#if MODE_AUTOLAND_ENABLED
+    plane.mode_autoland.arm_check();
+#endif
+
     send_arm_disarm_statustext("Throttle armed");
 
     return true;

--- a/ArduPlane/Plane.cpp
+++ b/ArduPlane/Plane.cpp
@@ -514,6 +514,10 @@ void Plane::update_control_mode(void)
     update_fly_forward();
 
     control_mode->update();
+
+#if MODE_AUTOLAND_ENABLED
+    mode_autoland.check_takeoff_direction();
+#endif
 }
 
 

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1333,6 +1333,11 @@ public:
 
 #endif // AP_SCRIPTING_ENABLED
 
+    bool tkoff_option_is_set(AP_FixedWing::TakeoffOption option) const {
+        return (aparm.takeoff_options & int32_t(option)) != 0;
+    }
+   
+
 };
 
 extern Plane plane;

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -26,15 +26,18 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
         // reset loiter start time. New command is a new loiter
         loiter.start_time_ms = 0;
 
-        AP_Mission::Mission_Command next_nav_cmd;
-        const uint16_t next_index = mission.get_current_nav_index() + 1;
-        const bool have_next_cmd = mission.get_next_nav_cmd(next_index, next_nav_cmd);
-        auto_state.wp_is_land_approach = have_next_cmd && (next_nav_cmd.id == MAV_CMD_NAV_LAND);
+        // Mission lookahead is only valid in auto
+        if (control_mode == &mode_auto) {
+            AP_Mission::Mission_Command next_nav_cmd;
+            const uint16_t next_index = mission.get_current_nav_index() + 1;
+            const bool have_next_cmd = mission.get_next_nav_cmd(next_index, next_nav_cmd);
+            auto_state.wp_is_land_approach = have_next_cmd && (next_nav_cmd.id == MAV_CMD_NAV_LAND);
 #if HAL_QUADPLANE_ENABLED
-        if (have_next_cmd && quadplane.is_vtol_land(next_nav_cmd.id)) {
-            auto_state.wp_is_land_approach = false;
-        }
+            if (have_next_cmd && quadplane.is_vtol_land(next_nav_cmd.id)) {
+                auto_state.wp_is_land_approach = false;
+            }
 #endif
+        }
     }
 
     switch(cmd.id) {
@@ -382,9 +385,6 @@ void Plane::do_takeoff(const AP_Mission::Mission_Command& cmd)
     // zero locked course
     steer_state.locked_course_err = 0;
     steer_state.hold_course_cd = -1;
-#if MODE_AUTOLAND_ENABLED
-    takeoff_state.initial_direction.initialized = false;
-#endif
     auto_state.baro_takeoff_alt = barometer.get_altitude();
 }
 
@@ -559,11 +559,6 @@ bool Plane::verify_takeoff()
             gps.ground_speed() > min_gps_speed &&
             hal.util->safety_switch_state() != AP_HAL::Util::SAFETY_DISARMED) {
             auto_state.takeoff_speed_time_ms = millis();
-#if MODE_AUTOLAND_ENABLED
-            plane.takeoff_state.initial_direction.heading = wrap_360(plane.gps.ground_course() + plane.mode_autoland.landing_dir_off);
-            takeoff_state.initial_direction.initialized = true;
-            gcs().send_text(MAV_SEVERITY_INFO, "Autoland direction= %u",int(takeoff_state.initial_direction.heading));
-#endif
         }
         if (auto_state.takeoff_speed_time_ms != 0 &&
             millis() - auto_state.takeoff_speed_time_ms >= 2000) {
@@ -1170,6 +1165,13 @@ bool Plane::verify_loiter_heading(bool init)
     if (quadplane.in_vtol_auto()) {
         // skip heading verify if in VTOL auto
         return true;
+    }
+#endif
+
+#if MODE_AUTOLAND_ENABLED
+    if (control_mode == &mode_autoland) {
+        // autoland mode has its own lineup criterion
+        return mode_autoland.landing_lined_up();
     }
 #endif
 

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -156,6 +156,11 @@ public:
 
     // true if voltage correction should be applied to throttle
     virtual bool use_battery_compensation() const;
+ 
+#if MODE_AUTOLAND_ENABLED   
+    // true if mode allows landing direction to be set on first takeoff after arm in this mode 
+    virtual bool allows_autoland_direction_capture() const { return false; }
+#endif
 
 #if AP_QUICKTUNE_ENABLED
     // does this mode support VTOL quicktune?
@@ -212,6 +217,11 @@ public:
 
     void stabilize_quaternion();
 
+#if MODE_AUTOLAND_ENABLED   
+    // true if mode allows landing direction to be set on first takeoff after arm in this mode 
+    bool allows_autoland_direction_capture() const override { return true; }
+#endif
+
 protected:
 
     // ACRO controller state
@@ -262,6 +272,11 @@ public:
 
     void run() override;
 
+#if MODE_AUTOLAND_ENABLED   
+    // true if mode allows landing direction to be set on first takeoff after arm in this mode 
+    bool allows_autoland_direction_capture() const override { return true; }
+#endif
+
 #if AP_PLANE_GLIDER_PULLUP_ENABLED
     bool in_pullup() const { return pullup.in_pullup(); }
 #endif
@@ -308,6 +323,11 @@ public:
 
     void run() override;
 
+#if MODE_AUTOLAND_ENABLED   
+    // true if mode allows landing direction to be set on first takeoff after arm in this mode 
+    bool allows_autoland_direction_capture() const override { return true; }
+#endif
+    
 protected:
 
     bool _enter() override;
@@ -449,6 +469,11 @@ public:
     // true if voltage correction should be applied to throttle
     bool use_battery_compensation() const override { return false; }
 
+#if MODE_AUTOLAND_ENABLED   
+    // true if mode allows landing direction to be set on first takeoff after arm in this mode 
+    bool allows_autoland_direction_capture() const override { return true; }
+#endif
+
 };
 
 
@@ -495,6 +520,11 @@ public:
 
     void run() override;
 
+#if MODE_AUTOLAND_ENABLED   
+    // true if mode allows landing direction to be set on first takeoff after arm in this mode 
+    bool allows_autoland_direction_capture() const override { return true; }
+#endif
+
 private:
     void stabilize_stick_mixing_direct();
 
@@ -513,6 +543,10 @@ public:
 
     void run() override;
 
+#if MODE_AUTOLAND_ENABLED   
+    // true if mode allows landing direction to be set on first takeoff after arm in this mode 
+    bool allows_autoland_direction_capture() const override { return true; }
+#endif
 };
 
 class ModeInitializing : public Mode
@@ -551,6 +585,11 @@ public:
     bool mode_allows_autotuning() const override { return true; }
 
     void run() override;
+
+#if MODE_AUTOLAND_ENABLED   
+    // true if mode allows landing direction to be set on first takeoff after arm in this mode 
+    bool allows_autoland_direction_capture() const override { return true; }
+#endif
 
 };
 
@@ -844,6 +883,11 @@ public:
 
     bool does_auto_throttle() const override { return true; }
 
+#if MODE_AUTOLAND_ENABLED   
+    // true if mode allows landing direction to be set on first takeoff after arm in this mode 
+    bool allows_autoland_direction_capture() const override { return true; }
+#endif
+
     // var_info for holding parameter information
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -887,6 +931,13 @@ public:
 
     bool does_auto_throttle() const override { return true; }
     
+    void check_takeoff_direction(void);
+
+    // return true when lined up correctly from the LOITER_TO_ALT
+    bool landing_lined_up(void);
+
+    // see if we should capture the direction
+    void arm_check(void);
 
     // var_info for holding parameter information
     static const struct AP_Param::GroupInfo var_info[];
@@ -894,11 +945,29 @@ public:
     AP_Int16 final_wp_alt;
     AP_Int16 final_wp_dist;
     AP_Int16 landing_dir_off;
+    AP_Int8  options;
+
+    // Bitfields of AUTOLAND_OPTIONS
+    enum class AutoLandOption {
+        AUTOLAND_DIR_ON_ARM     = (1U << 0), // set dir for autoland on arm if compass in use.
+    };
+
+    enum class AutoLandStage {
+        LOITER,
+        LANDING
+    };
+
+    bool autoland_option_is_set(AutoLandOption option) const {
+        return (options & int8_t(option)) != 0;
+    }
 
 protected:
     bool _enter() override;
-    AP_Mission::Mission_Command cmd[3];
-    uint8_t stage;
+    AP_Mission::Mission_Command cmd_loiter;
+    AP_Mission::Mission_Command cmd_land;
+    Location land_start;
+    AutoLandStage stage;
+    void set_autoland_direction(const float heading);
 };
 #endif
 #if HAL_SOARING_ENABLED

--- a/ArduPlane/mode_takeoff.cpp
+++ b/ArduPlane/mode_takeoff.cpp
@@ -134,9 +134,6 @@ void ModeTakeoff::update()
                 plane.takeoff_state.throttle_max_timer_ms = millis();
                 takeoff_mode_setup = true;
                 plane.steer_state.hold_course_cd = wrap_360_cd(direction*100); // Necessary to allow Plane::takeoff_calc_roll() to function.
-#if MODE_AUTOLAND_ENABLED
-                plane.takeoff_state.initial_direction.initialized = false;
-#endif
             }
         }
     }
@@ -145,16 +142,6 @@ void ModeTakeoff::update()
         plane.set_flight_stage(AP_FixedWing::FlightStage::NORMAL);
         takeoff_mode_setup = false;
     }
-#if MODE_AUTOLAND_ENABLED
-    // set initial_direction.heading
-    const float min_gps_speed = GPS_GND_CRS_MIN_SPD;
-    if (!(plane.takeoff_state.initial_direction.initialized) && (plane.gps.ground_speed() > min_gps_speed)
-       && (plane.flight_stage == AP_FixedWing::FlightStage::TAKEOFF)) {
-       plane.takeoff_state.initial_direction.heading = wrap_360(plane.gps.ground_course() + plane.mode_autoland.landing_dir_off);
-       plane.takeoff_state.initial_direction.initialized = true;
-       gcs().send_text(MAV_SEVERITY_INFO, "Autoland direction= %u",int(plane.takeoff_state.initial_direction.heading));
-    }
-#endif
     // We update the waypoint to follow once we're past TKOFF_LVL_ALT or we
     // pass the target location. The check for target location prevents us
     // flying towards a wrong location if we can't climb.

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -4241,17 +4241,28 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
     def AutoLandMode(self):
         '''Test AUTOLAND mode'''
+        self.set_parameters({
+            "AUTOLAND_DIR_OFF": 45,
+        })
         self.customise_SITL_commandline(["--home", "-35.362938,149.165085,585,173"])
         self.context_collect('STATUSTEXT')
         self.takeoff(alt=80, mode='TAKEOFF')
         self.wait_text("Autoland direction", check_context=True)
         self.change_mode(26)
         self.wait_disarmed(120)
-        self.progress("Check the landed heading matches takeoff")
-        self.wait_heading(173, accuracy=5, timeout=1)
-        loc = mavutil.location(-35.362938, 149.165085, 585, 173)
+        self.progress("Check the landed heading matches takeoff plus offset")
+        self.wait_heading(218, accuracy=5, timeout=1)
+        loc = mavutil.location(-35.362938, 149.165085, 585, 218)
         if self.get_distance(loc, self.mav.location()) > 35:
             raise NotAchievedException("Did not land close to home")
+        self.set_parameters({
+            "TKOFF_OPTIONS": 2,
+        })
+        self.wait_ready_to_arm()
+        self.set_autodisarm_delay(0)
+        self.arm_vehicle()
+        self.progress("Check the set dir on arm option")
+        self.wait_text("Autoland direction", check_context=True)
 
     def RCDisableAirspeedUse(self):
         '''Test RC DisableAirspeedUse option'''

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -99,7 +99,10 @@ public:
 
     // accessor functions for the params and states
     static const struct AP_Param::GroupInfo var_info[];
-    
+
+    // Return the landing type
+    Landing_Type get_type() const { return (Landing_Type)type.get(); }
+
     int16_t get_pitch_cd(void) const { return pitch_deg*100; }
     float get_flare_sec(void) const { return flare_sec; }
     int8_t get_disarm_delay(void) const { return disarm_delay; }


### PR DESCRIPTION
This PR enhances the new AUTOLAND mode. It adds the following new features:

1. Allows takeoff direction capture, and hence autoland direction and use, in ACRO, STABILIZE, FBWA, TRAINING, and MANUAL modes, in addition to Mode TAKEOFF and AUTO NAV_TAKEOFF, using the same criteria as currently used, the first time after arming.

2. Adds an AUTOLAND_OPTIONS option that will set this direction upon arming using a compass, if in use, instead of ground course, allowing the user to set it on the ground arbitrarily as desired, independent of the actual takeoff direction. The option is in the autoland module for future expansion
3.  the "base" leg is actually a WP_LOITER_RAD loiter to alt with tangent exit directly into the final approach waypoint and landing with proper loiter direction.

![image](https://github.com/user-attachments/assets/edf4349a-d623-46bb-8f29-f0c6e4812a5d)


changes to current behavior, besides the new features, is that once the direction is captured it persists until a disarm occurs. Therefore multiple auto takeoffs while armed no longer reset the direction captured by the first, on each subsequent takeoff. Originally, I thought this behavior was desirable, but I now believe it's not of much benefit and the new behavior avoids the current corner case issue of resetting the direction while in flight if a NAV_TAKEOFF autotakeoff is interrupted and then resumed. Also, this is not available for QudPlanes, even if fixed wing landing option  is used. We thought the possibility of getting the direction inappropriately wrong on transitions from a VTOL takeoff just too complex to get correct.

In addition, it removes the AUTOLAND code segments in the commands_logic and mode_takeoff modules, reducing the flash impact overall...

These changes have been tested in SITL and flight-tested in all configurations I could think of.