### PR TITLE
RC_Channel: re-instate init_aux_function call.

### DIFF
--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -1918,7 +1918,7 @@ void RC_Channel::init_aux()
         position = AuxSwitchPos::LOW;
     }
 
-    run_aux_function((AUX_FUNC)option.get(), position, AuxFuncTrigger::Source::INIT, ch_in);
+    init_aux_function((AUX_FUNC)option.get(), position);
 }
 
 // read_3pos_switch


### PR DESCRIPTION
This fixs a bug added by me in https://github.com/ArduPilot/ardupilot/pull/28655. The init aux function call was replaced by run aux function. Init mostly just calls run, however for invalid options it does not. This fixes the "Invalid channel option (0)" warning.

In the longer term I would like to consolidate the init calls such that each function can decide based on the trigger source. 