### PR TITLE
Baro thrust scaling

### DIFF
--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -75,6 +75,9 @@ public:
     // dynamic pressure in Pascal. Divide by 100 for millibars or hectopascals
     const Vector3f& get_dynamic_pressure(uint8_t instance) const { return sensors[instance].dynamic_pressure; }
 #endif
+#if (HAL_BARO_WIND_COMP_ENABLED || AP_BARO_THST_COMP_ENABLED)
+    float get_corrected_pressure(uint8_t instance) const { return sensors[instance].corrected_pressure; }
+#endif
 
     // temperature in degrees C
     float get_temperature(void) const { return get_temperature(_primary); }
@@ -299,6 +302,12 @@ private:
         WindCoeff wind_coeff;
         Vector3f dynamic_pressure;      // calculated dynamic pressure
 #endif
+#if AP_BARO_THST_COMP_ENABLED
+        AP_Float mot_scale;             // thrust-based pressure scaling
+#endif
+#if (HAL_BARO_WIND_COMP_ENABLED || AP_BARO_THST_COMP_ENABLED)
+        float corrected_pressure;
+#endif
     } sensors[BARO_MAX_INSTANCES];
 
     AP_Float                            _alt_offset;
@@ -340,7 +349,9 @@ private:
     */
     float wind_pressure_correction(uint8_t instance);
 #endif
-
+#if AP_BARO_THST_COMP_ENABLED
+    float thrust_pressure_correction(uint8_t instance);
+#endif
     // Logging function
     void Write_Baro(void);
     void Write_Baro_instance(uint64_t time_us, uint8_t baro_instance);

--- a/libraries/AP_Baro/AP_Baro_Logging.cpp
+++ b/libraries/AP_Baro/AP_Baro_Logging.cpp
@@ -21,6 +21,11 @@ void AP_Baro::Write_Baro_instance(uint64_t time_us, uint8_t baro_instance)
         drift_offset  : get_baro_drift_offset(),
         ground_temp   : get_ground_temperature(),
         healthy       : (uint8_t)healthy(baro_instance),
+#if (HAL_BARO_WIND_COMP_ENABLED || AP_BARO_THST_COMP_ENABLED)
+        corrected_pressure : get_corrected_pressure(baro_instance),
+#else
+        corrected_pressure : get_pressure(baro_instance),
+#endif
     };
     AP::logger().WriteBlock(&pkt, sizeof(pkt));
 #if HAL_BARO_WIND_COMP_ENABLED

--- a/libraries/AP_Baro/AP_Baro_config.h
+++ b/libraries/AP_Baro/AP_Baro_config.h
@@ -103,3 +103,7 @@
 // this allows for using the simple model with the --ekf-single configure option
 #define AP_BARO_1976_STANDARD_ATMOSPHERE_ENABLED HAL_WITH_EKF_DOUBLE || AP_SIM_ENABLED
 #endif
+
+#ifndef AP_BARO_THST_COMP_ENABLED
+#define AP_BARO_THST_COMP_ENABLED 0
+#endif

--- a/libraries/AP_Baro/LogStructure.h
+++ b/libraries/AP_Baro/LogStructure.h
@@ -18,7 +18,8 @@
 // @Field: SMS: time last sample was taken
 // @Field: Offset: raw adjustment of barometer altitude, zeroed on calibration, possibly set by GCS
 // @Field: GndTemp: temperature on ground, specified by parameter or measured while on ground
-// @Field: Health: true if barometer is considered healthy
+// @Field: H: true if barometer is considered healthy
+// @Field: CPress: compensated atmospheric pressure
 struct PACKED log_BARO {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -32,6 +33,7 @@ struct PACKED log_BARO {
     float   drift_offset;
     float   ground_temp;
     uint8_t healthy;
+    float   corrected_pressure;
 };
 
 // @LoggerMessage: BARD
@@ -53,10 +55,10 @@ struct PACKED log_BARD {
 #define LOG_STRUCTURE_FROM_BARO                                         \
     { LOG_BARO_MSG, sizeof(log_BARO),                                   \
             "BARO",                                                     \
-            "Q"       "B"  "f"    "f"        "f"      "c"     "f"    "I"    "f"       "f"        "B", \
-            "TimeUS," "I," "Alt," "AltAMSL," "Press," "Temp," "CRt," "SMS," "Offset," "GndTemp," "Health", \
-            "s"       "#"  "m"    "m"        "P"      "O"     "n"    "s"    "m"       "O"        "-", \
-            "F"       "-"  "0"    "0"        "0"      "B"     "0"    "C"    "?"       "0"        "-", \
+            "Q"       "B"  "f"    "f"        "f"      "c"     "f"    "I"    "f"       "f"        "B"      "f", \
+            "TimeUS," "I," "Alt," "AltAMSL," "Press," "Temp," "CRt," "SMS," "Offset," "GndTemp," "H,"     "CPress", \
+            "s"       "#"  "m"    "m"        "P"      "O"     "n"    "s"    "m"       "O"        "-"      "P", \
+            "F"       "-"  "0"    "0"        "0"      "B"     "0"    "C"    "?"       "0"        "-"      "0", \
             true                                                        \
             },                                                          \
     { LOG_BARD_MSG, sizeof(log_BARD),                                   \

--- a/libraries/AP_HAL_ChibiOS/hwdef/BETAFPV-F405/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BETAFPV-F405/hwdef.dat
@@ -154,5 +154,8 @@ define AP_BARO_SPL06_BACKGROUND_ENABLE 1
 # 4S version has no baro
 define HAL_BARO_ALLOW_INIT_NO_BARO 1
 
+# enable baro thrust scaling
+define AP_BARO_THST_COMP_ENABLED 1
+
 include ../include/minimize_fpv_osd.inc
 AUTOBUILD_TARGETS Copter


### PR DESCRIPTION
This allows a user to apply a linear pressure compensation to a baro based on thrust output. On a small whoop there is a very causal relationship between pressure and throttle:

![image](https://github.com/user-attachments/assets/cec8a9aa-3893-4120-8b8a-c88a59611539)

By applying this offset the effect can be normalized:

![image](https://github.com/user-attachments/assets/388b19e8-d9ad-46a7-85b0-94cd1dc0f99c)

Set by using ```BAROx_THST_SCALE"


