### PR TITLE
hwdef: remove bad flashing-last-sector comment

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/Airvolute-DCS2/hwdef-bl.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Airvolute-DCS2/hwdef-bl.dat
@@ -10,7 +10,6 @@ OSCILLATOR_HZ 16000000
 # board ID for firmware load
 APJ_BOARD_ID 5200
 
-# the nucleo seems to have trouble with flashing the last sector?
 FLASH_SIZE_KB 2048
 
 # bootloader is installed at zero offset

--- a/libraries/AP_HAL_ChibiOS/hwdef/Airvolute-DCS2/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Airvolute-DCS2/hwdef.dat
@@ -12,7 +12,6 @@ OSCILLATOR_HZ 16000000
 # board ID for firmware load
 APJ_BOARD_ID 5200
 
-# the nucleo seems to have trouble with flashing the last sector?
 FLASH_SIZE_KB 2048
 
 # This is the STM32 timer that ChibiOS will use for the low level

--- a/libraries/AP_HAL_ChibiOS/hwdef/NucleoH743/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/NucleoH743/hwdef.dat
@@ -14,7 +14,6 @@ define STM32_HSE_BYPASS
 # board ID for firmware load
 APJ_BOARD_ID 139
 
-# the nucleo seems to have trouble with flashing the last sector?
 FLASH_SIZE_KB 2048
 
 FLASH_RESERVE_START_KB 128

--- a/libraries/AP_HAL_ChibiOS/hwdef/NucleoH755/hwdef-bl.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/NucleoH755/hwdef-bl.dat
@@ -13,7 +13,6 @@ define SMPS_PWR
 # board ID for firmware load
 APJ_BOARD_ID 139
 
-# the nucleo seems to have trouble with flashing the last sector?
 FLASH_SIZE_KB 2048
 
 # the location where the bootloader will put the firmware

--- a/libraries/AP_HAL_ChibiOS/hwdef/NucleoH755/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/NucleoH755/hwdef.dat
@@ -17,7 +17,6 @@ define SMPS_PWR
 # board ID for firmware load
 APJ_BOARD_ID 139
 
-# the nucleo seems to have trouble with flashing the last sector?
 FLASH_SIZE_KB 2048
 
 FLASH_BOOTLOADER_LOAD_KB 256


### PR DESCRIPTION
the original file these were copied from has a lower limit, so deserves this comment.  These hwdefs are making the entire space available, so remove this comment.