### PR TITLE
AP_ESC_Telem: fix RPM timeout race

### DIFF
--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.h
@@ -13,7 +13,7 @@
 static_assert(ESC_TELEM_MAX_ESCS > 0, "Cannot have 0 ESC telemetry instances");
 
 #define ESC_TELEM_DATA_TIMEOUT_MS 5000UL
-#define ESC_RPM_DATA_TIMEOUT_US 1000000UL
+#define ESC_RPM_DATA_TIMEOUT_US 1000000L
 
 class AP_ESC_Telem {
 public:
@@ -134,7 +134,7 @@ public:
 private:
 
     // helper that validates RPM data
-    static bool rpm_data_within_timeout (const volatile AP_ESC_Telem_Backend::RpmData &instance, const uint32_t now_us, const uint32_t timeout_us);
+    static bool rpm_data_within_timeout (const volatile AP_ESC_Telem_Backend::RpmData &instance, const uint32_t now_us, const int32_t timeout_us);
     static bool was_rpm_data_ever_reported (const volatile AP_ESC_Telem_Backend::RpmData &instance);
 
 #if AP_EXTENDED_DSHOT_TELEM_V2_ENABLED


### PR DESCRIPTION
The RPM telemetry data structure can get updated by another thread at any time. This can cause `(now - last_update_us)` to be negative, which looks like the data is nearly `UINT32_MAX` microseconds stale, causing perfectly fine ESCs to be marked as timed-out. This causes lua scripts to get nil values when they call `esc_telem:get_rpm` even when the RPM data is fine. I'd imagine this can cause minor problems elsewhere too, but not sure.

There are a few ways we could fix this. Using a signed time difference is the simplest and has the least overhead. We don't need to worry about this signed time difference wrapping around when the rpm is 36 minutes stale, because the `data_valid` flag gets set false as soon as the data is 1s stale, and it can't get set to true until new data comes in.

The easiest way to demonstrate the problem (and fix) is with the following lua script running in SITL at 100x speed.
```
local ever_had_rpm = false
local function update()
    local rpm = esc_telem:get_rpm(2)
    -- Try to get RPM 20 times to increase our odds of hitting the race condition
    for _ = 1, 20 do
        rpm = rpm and esc_telem:get_rpm(2)
    end
    -- Make sure we don't complain until we've gotten a non-nil RPM at least once
    if rpm then
        if not ever_had_rpm then
            print("Got an RPM")
        end
        ever_had_rpm = true
    end
    -- Complain about a nil RPM
    if not rpm and ever_had_rpm then
        print("RPM is nil")
    end
    return update, 0
end

print("loaded rpm_nil_test.lua")

return update, 0
```

Note `AP_ESC_Telem_Backend::TelemetryData::stale` is just as vulnerable to this, but `TelemetryData` doesn't have the same wraparound protection (though it's not as bad since it's using millis), so I can't use this same trick to fix it.