### PR TITLE
Plane: ATT.DesPitch now reports actual target, not nav output

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -209,7 +209,7 @@ float Plane::stabilize_pitch_get_pitch_out()
     const bool quadplane_in_frwd_transition = false;
 #endif
 
-    int32_t demanded_pitch = nav_pitch_cd + int32_t(g.pitch_trim * 100.0) + SRV_Channels::get_output_scaled(SRV_Channel::k_throttle) * g.kff_throttle_to_pitch;
+    demanded_pitch_cd = nav_pitch_cd + int32_t(g.pitch_trim * 100.0) + SRV_Channels::get_output_scaled(SRV_Channel::k_throttle) * g.kff_throttle_to_pitch;
     bool disable_integrator = false;
     if (control_mode == &mode_stabilize && channel_pitch->get_control_in() != 0) {
         disable_integrator = true;
@@ -224,10 +224,10 @@ float Plane::stabilize_pitch_get_pitch_out()
         !control_mode->does_auto_throttle() &&
         flare_mode == FlareMode::ENABLED_PITCH_TARGET &&
         throttle_at_zero()) {
-        demanded_pitch = landing.get_pitch_cd();
+        demanded_pitch_cd = landing.get_pitch_cd();
     }
 
-    return pitchController.get_servo_out(demanded_pitch - ahrs.pitch_sensor, speed_scaler, disable_integrator,
+    return pitchController.get_servo_out(demanded_pitch_cd - ahrs.pitch_sensor, speed_scaler, disable_integrator,
                                          ground_mode && !(plane.flight_option_enabled(FlightOptions::DISABLE_GROUND_PID_SUPPRESSION)));
 }
 

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -7,9 +7,12 @@ void Plane::Log_Write_Attitude(void)
 {
     Vector3f targets {       // Package up the targets into a vector for commonality with Copter usage of Log_Wrote_Attitude
         nav_roll_cd * 0.01f,
-        nav_pitch_cd * 0.01f,
+        demanded_pitch_cd * 0.01f,
         0 //Plane does not have the concept of navyaw. This is a placeholder.
     };
+    if (!flag_demanded_pitch_used) {
+        targets.y = NAN;
+    }
 
 #if HAL_QUADPLANE_ENABLED
     if (quadplane.show_vtol_view()) {

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -668,8 +668,11 @@ private:
     // The instantaneous desired bank angle.  Hundredths of a degree
     int32_t nav_roll_cd;
 
-    // The instantaneous desired pitch angle.  Hundredths of a degree
+    // The instantaneous navigator-commanded pitch angle. Hundredths of a degree
     int32_t nav_pitch_cd;
+
+    int32_t demanded_pitch_cd; // The instantaneous desired pitch angle. Hundredths of a degree.
+    bool flag_demanded_pitch_used; // For logging purposes, declares if active pitch control is happening.
 
     // the aerodynamic load factor. This is calculated from the demanded
     // roll before the roll is clipped, using 1/sqrt(cos(nav_roll))

--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -71,6 +71,9 @@ bool Mode::enter()
     plane.auto_state.highest_airspeed = 0;
     plane.auto_state.initial_pitch_cd = ahrs.pitch_sensor;
 
+    // Declare that pitch is actively controlled, unless children ovewrite.
+    plane.flag_demanded_pitch_used = true;
+
     // disable taildrag takeoff on mode change
     plane.auto_state.fbwa_tdrag_takeoff_mode = false;
 

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -439,6 +439,8 @@ public:
     const char *name4() const override { return "MANU"; }
 
     // methods that affect movement of the vehicle in this mode
+    bool _enter() override;
+
     void update() override;
 
     void run() override;

--- a/ArduPlane/mode_acro.cpp
+++ b/ArduPlane/mode_acro.cpp
@@ -5,6 +5,7 @@ bool ModeAcro::_enter()
 {
     acro_state.locked_roll = false;
     acro_state.locked_pitch = false;
+    plane.flag_demanded_pitch_used = false; // ACRO does not control pitch through demanded_pitch_cd.
     IGNORE_RETURN(ahrs.get_quaternion(acro_state.q));
     return true;
 }

--- a/ArduPlane/mode_manual.cpp
+++ b/ArduPlane/mode_manual.cpp
@@ -1,6 +1,12 @@
 #include "mode.h"
 #include "Plane.h"
 
+bool ModeManual::_enter()
+{
+    plane.flag_demanded_pitch_used = false;
+    return true;
+}
+
 void ModeManual::update()
 {
     SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, plane.roll_in_expo(false));

--- a/ArduPlane/mode_training.cpp
+++ b/ArduPlane/mode_training.cpp
@@ -54,8 +54,10 @@ void ModeTraining::run()
 
     if (plane.training_manual_pitch) {
         SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, pexpo);
+        plane.flag_demanded_pitch_used = false;
     } else {
         plane.stabilize_pitch();
+        plane.flag_demanded_pitch_used = true;
         if ((plane.nav_pitch_cd > 0 && pexpo < SRV_Channels::get_output_scaled(SRV_Channel::k_elevator)) ||
             (plane.nav_pitch_cd < 0 && pexpo > SRV_Channels::get_output_scaled(SRV_Channel::k_elevator))) {
             // allow user to get back to level


### PR DESCRIPTION
## Summary

This PR changes the logged quantity in `ATT.DesPitch` from `Plane::nav_pitch_cd` to the target value that actually gets passed to the pitch controller.

## Details

Logging `Plane::nav_pitch_cd` in `ATT.DesPitch` gives the false impression that there's steady-state error in the pitch controller.

This PR improves log readability, as it already includes `PTCH_TRIM_DEG` and the contribution of `KFF_THR2PTCH`.

`Plane::nav_pitch_cd` is already logged in `CTUN`.

## Testing

`sim_vehicle.py` was spun up and `PTCH_TRIM_DEG=3` was set.
TAKEOFF mode was armed.

**Before**:
`ATT.DesPitch` and `CTUN.NavPitch` overlap.
Steady-state error is falsely logged.
![Screenshot from 2025-01-02 11-59-11](https://github.com/user-attachments/assets/35a4db4d-c8ad-484b-bed2-d6dadda44c57)

**After**:
The three pitch quantites are clearly discernible.
![Screenshot from 2025-01-02 11-58-48](https://github.com/user-attachments/assets/07b7e199-51b7-4f49-9ca7-a3f358865032)

---
**EDIT**

The PR was updated to write NaN on every loop, when a mode does not employ `demanded_pitch_cd` to control pitch. The log viewers handle this gracefully:
![Screenshot from 2025-01-14 12-55-15](https://github.com/user-attachments/assets/a433f3fd-1b44-4a71-b6be-81a167a11d41)
![Screenshot from 2025-01-14 12-56-22](https://github.com/user-attachments/assets/29648f9a-2435-4315-9476-86051d139a3d)


