### PR TITLE
AP_ESC_Telem: fix RPM timeout race

### DIFF
--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.h
@@ -134,7 +134,7 @@ public:
 private:
 
     // helper that validates RPM data
-    static bool rpm_data_within_timeout (const volatile AP_ESC_Telem_Backend::RpmData &instance, const uint32_t now_us, const uint32_t timeout_us);
+    static bool rpm_data_within_timeout (const volatile AP_ESC_Telem_Backend::RpmData &instance, const uint32_t timeout_us);
     static bool was_rpm_data_ever_reported (const volatile AP_ESC_Telem_Backend::RpmData &instance);
 
 #if AP_EXTENDED_DSHOT_TELEM_V2_ENABLED

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -624,6 +624,8 @@ const AP_Scheduler::Task AP_Vehicle::scheduler_tasks[] = {
 #endif
     SCHED_TASK(send_watchdog_reset_statustext,         0.1,     20, 225),
 #if HAL_WITH_ESC_TELEM
+    // This update function is responsible for checking timeouts and invalidating the ESC telemetry data.
+    // Be mindful of this if you are planning to reduce the frequency from 100Hz.
     SCHED_TASK_CLASS(AP_ESC_Telem, &vehicle.esc_telem,      update,                  100,  50, 230),
 #endif
 #if AP_SERVO_TELEM_ENABLED


### PR DESCRIPTION
Alternative approach to #28987.

We don't need to worry about explicitly checking the timestamp in most places; they can just use the `data_valid` flag directly. This eliminates the race without harming the performance of `get_rpm` at all (in fact, it improves it, even if just barely). The only places that need to actually check the timestamp are `update`, where the `data_valid` gets cleared on timeout, and `are_motors_running`, which has a stricter timeout than `data_valid` does. These two run much less frequently than `get_rpm`, so the extra copying shouldn't be a problem.

This might change the timing of when the data is considered stale by a few microseconds, since it's checking the timestamp at 100Hz instead of every time we get RPM, but that should be absolutely fine. The other change you might notice is that previously `rpm_data_within_timeout` explicitly checked if `last_update_us` was zero and I don't. That check was unnecessary in there though, because `data_valid` cannot possibly be true if `last_update_us` is zero.

I actually really like this approach. I'll probably do something similar to solve the `TelemetryData::stale` race. And if we don't mind the signed-int stuff in my other PR, then I'll take this idea over to that PR.

This approach does not solve the potential race in the `slew` calculation, but I'm guessing that's probably fine. If it was a problem, we probably would have noticed by now. My other approach didn't fully fix the slew calculation either (if you interrupted the backend after it updated `prev_rpm` and `rpm`, but before it updates `last_update_us`, then you'll get a little jump; that should be very rare though).