### PR TITLE
Copter: switch off fast rate while doing temperature calibration

### DIFF
--- a/ArduCopter/rate_thread.cpp
+++ b/ArduCopter/rate_thread.cpp
@@ -215,7 +215,11 @@ void Copter::rate_controller_thread()
 #endif
 
         // allow changing option at runtime
-        if (get_fast_rate_type() == FastRateType::FAST_RATE_DISABLED) {
+        if (get_fast_rate_type() == FastRateType::FAST_RATE_DISABLED
+#if HAL_INS_TEMPERATURE_CAL_ENABLE
+            || ins.temperature_cal_running()
+#endif
+            ) {
             if (was_using_rate_thread) {
                 disable_fast_rate_loop(rates);
                 was_using_rate_thread = false;


### PR DESCRIPTION
Tested on an F405 with an ICM42688.

This *may* not be required, but are not running the fast rate code when the gyros are initialized/calibrated and it makes me nervous that the increased CPU load may warp the results.