### PR TITLE
AP_Mount: Topotek pitch rate direction fix

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Topotek.cpp
+++ b/libraries/AP_Mount/AP_Mount_Topotek.cpp
@@ -845,7 +845,7 @@ void AP_Mount_Topotek::send_rate_target(const MountTarget& rate_rads)
 
     // convert and constrain rates
     const uint8_t roll_angle_speed = constrain_int16(degrees(rate_rads.roll) * ANGULAR_VELOCITY_CONVERSION, -99, 99);
-    const uint8_t pitch_angle_speed = constrain_int16(degrees(rate_rads.pitch) * ANGULAR_VELOCITY_CONVERSION, -99, 99);
+    const uint8_t pitch_angle_speed = constrain_int16(-degrees(rate_rads.pitch) * ANGULAR_VELOCITY_CONVERSION, -99, 99);
     const uint8_t yaw_angle_speed = constrain_int16(degrees(rate_rads.yaw) * ANGULAR_VELOCITY_CONVERSION, -99, 99);
 
     // send stop rotation command three times if target roll, pitch and yaw are zero


### PR DESCRIPTION
This fixes the direction of pitch **rate** control in the Topotek gimbal driver (**angle** control is fine).

This bug has existed since the driver was first created in PR https://github.com/ArduPilot/ardupilot/pull/27053 but we somehow missed it during testing.  If you look closely the bug is fairly obvious from inspection because we can see the [angle control includes the minus](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Mount/AP_Mount_Topotek.cpp#L819) while the [rate control does not](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Mount/AP_Mount_Topotek.cpp#L848).

This has been tested on real hardware and was discovered during testing of the new Mission Planner Gimbal Control interface (see https://github.com/ArduPilot/MissionPlanner/pull/3386)