### PR TITLE
AP_Filesystem: Don't try and rename between backends

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem.cpp
@@ -192,8 +192,17 @@ int AP_Filesystem::mkdir(const char *pathname)
 
 int AP_Filesystem::rename(const char *oldpath, const char *newpath)
 {
-    const Backend &backend = backend_by_path(oldpath);
-    return backend.fs.rename(oldpath, newpath);
+    const Backend &oldbackend = backend_by_path(oldpath);
+
+    // Don't need the backend again, but we also need to remove the backend pre-fix from the new path.
+    const Backend &newbackend = backend_by_path(newpath);
+
+    // Don't try and rename between backends.
+    if (&oldbackend != &newbackend) {
+        return -1;
+    }
+
+    return oldbackend.fs.rename(oldpath, newpath);
 }
 
 AP_Filesystem::DirHandle *AP_Filesystem::opendir(const char *pathname)


### PR DESCRIPTION
Extract from https://github.com/ArduPilot/ardupilot/pull/28977. Currently only the old name is passed to `backend_by_path`. This function will remove the backed prefix. This means the two file names are no longer comparable. This also disallows trying to rename between two backends.