### PR TITLE
AP_MultiHeap: initialize only if heap allocation succeeded

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -1390,6 +1390,7 @@ class linux(Board):
         ]
 
         # wrap malloc to ensure memory is zeroed
+        # note that this also needs to be done in the CMakeLists.txt files
         env.LINKFLAGS += ['-Wl,--wrap,malloc']
 
         if cfg.options.force_32bit:

--- a/libraries/AP_HAL_ESP32/targets/esp32/esp-idf/CMakeLists.txt
+++ b/libraries/AP_HAL_ESP32/targets/esp32/esp-idf/CMakeLists.txt
@@ -121,6 +121,9 @@ target_link_libraries(${elf_file}
 # linker script generation, partition_table generation, etc.
 idf_build_executable(${elf_file})
 
+# wrap malloc to ensure memory is zeroed
+target_link_options(${elf_file} PRIVATE "-Wl,--wrap,malloc")
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 
 # Additional targets for measuring RAM use: size, size-components, size-files

--- a/libraries/AP_HAL_ESP32/targets/esp32s3/esp-idf/CMakeLists.txt
+++ b/libraries/AP_HAL_ESP32/targets/esp32s3/esp-idf/CMakeLists.txt
@@ -121,6 +121,9 @@ target_link_libraries(${elf_file}
 # linker script generation, partition_table generation, etc.
 idf_build_executable(${elf_file})
 
+# wrap malloc to ensure memory is zeroed
+target_link_options(${elf_file} PRIVATE "-Wl,--wrap,malloc")
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 
 # Additional targets for measuring RAM use: size, size-components, size-files

--- a/libraries/AP_MultiHeap/MultiHeap_malloc.cpp
+++ b/libraries/AP_MultiHeap/MultiHeap_malloc.cpp
@@ -36,9 +36,9 @@ void *MultiHeap::heap_create(uint32_t size)
 {
     struct heap *new_heap = (struct heap*)malloc(sizeof(struct heap));
     if (new_heap != nullptr) {
+        new_heap->magic = HEAP_MAGIC;
         new_heap->max_heap_size = size;
     }
-    new_heap->magic = HEAP_MAGIC;
     return (void *)new_heap;
 }
 


### PR DESCRIPTION
Ensure new_heap is not null before accessing, and initialise current heap usage.

### Motivation

- On ESP32 S3 the heap allocator is failing when attempting to create a new Lua state.
- The variable `current_heap_usage` is not initialised to zero.