### PR TITLE
AP_HAL_ESP32: ensure task is deleted if member proc returns

### DIFF
--- a/libraries/AP_HAL_ESP32/Scheduler.cpp
+++ b/libraries/AP_HAL_ESP32/Scheduler.cpp
@@ -140,6 +140,9 @@ void IRAM_ATTR Scheduler::thread_create_trampoline(void *ctx)
     AP_HAL::MemberProc *t = (AP_HAL::MemberProc *)ctx;
     (*t)();
     free(t);
+
+    // delete the calling task
+    vTaskDelete(NULL);
 }
 
 /*


### PR DESCRIPTION
Resolve issue where an illegal instruction error occurs if a task member function returns.

- FreeRTOS task functions must not return or exit while the task is active.
- vTaskDelete(NULL) deletes the calling task.

See: 
- https://www.freertos.org/Documentation/02-Kernel/04-API-references/01-Task-creation/01-xTaskCreate
- https://www.freertos.org/Documentation/02-Kernel/04-API-references/01-Task-creation/03-vTaskDelete

### Motivation

To replicate the issue:
- Requires https://github.com/ArduPilot/ardupilot/pull/29009.
- Configure `esp32s3empty` with the `--enable-dds` flag, build and flash.
- If the DDS transport initialisation fails, or the `AP_DDS_Client::main_loop` otherwise returns, an illegal instruction occurs. 

