### PR TITLE
AP_Arming: Allow arming when forcing DCM and no GPS configured

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1130,6 +1130,8 @@ private:
     bool set_mode(Mode& new_mode, const ModeReason reason);
     bool set_mode(const uint8_t mode, const ModeReason reason) override;
     bool set_mode_by_number(const Mode::Number new_mode_number, const ModeReason reason);
+    // called when an attempt to change into a mode is unsuccessful
+    void mode_change_failed(const Mode *mode, const char *reason);
     void check_long_failsafe();
     void check_short_failsafe();
     void startup_INS(void);

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -110,6 +110,9 @@ public:
     // true if mode can have terrain following disabled by switch
     virtual bool allows_terrain_disable() const { return false; }
 
+    // true if mode requires the AHRS to have a home before using this mode.
+    virtual bool requires_home() const { return true; };
+
     // true if automatic switch to thermal mode is supported.
     virtual bool does_automatic_thermal_switch() const {return false; }
 
@@ -204,6 +207,8 @@ public:
     void stabilize();
 
     void stabilize_quaternion();
+
+    bool requires_home() const override { return false; };
 
 protected:
 
@@ -327,6 +332,10 @@ public:
 
     bool does_auto_throttle() const override { return true; }
 
+    // Once offboard mode exists, only global position control modes require home.
+    // Low level velocity and acceleration controls don't require home.
+    bool requires_home() const override { return true; };
+
     // handle a guided target request from GCS
     bool handle_guided_request(Location target_loc) override;
 
@@ -360,6 +369,8 @@ public:
     bool does_auto_navigation() const override { return true; }
 
     bool does_auto_throttle() const override { return true; }
+
+    bool requires_home() const override { return false; };
 
 protected:
 
@@ -442,6 +453,8 @@ public:
     // true if voltage correction should be applied to throttle
     bool use_battery_compensation() const override { return false; }
 
+    bool requires_home() const override { return false; };
+
 };
 
 
@@ -488,6 +501,8 @@ public:
 
     void run() override;
 
+    bool requires_home() const override { return false; };
+
 private:
     void stabilize_stick_mixing_direct();
 
@@ -500,6 +515,8 @@ public:
     Number mode_number() const override { return Number::TRAINING; }
     const char *name() const override { return "TRAINING"; }
     const char *name4() const override { return "TRAN"; }
+
+    bool requires_home() const override { return false; };
 
     // methods that affect movement of the vehicle in this mode
     void update() override;
@@ -525,6 +542,8 @@ public:
 
     bool does_auto_throttle() const override { return true; }
 
+    bool requires_home() const override { return false; };
+
 protected:
     bool _pre_arm_checks(size_t buflen, char *buffer) const override { return false; }
 
@@ -542,6 +561,8 @@ public:
     void update() override;
     
     bool mode_allows_autotuning() const override { return true; }
+
+    bool requires_home() const override { return false; };
 
     void run() override;
 
@@ -565,6 +586,8 @@ public:
     bool does_auto_throttle() const override { return true; }
     
     bool mode_allows_autotuning() const override { return true; }
+
+    bool requires_home() const override { return false; };
 
     void update_target_altitude() override {};
 
@@ -780,6 +803,7 @@ public:
     bool is_vtol_mode() const override { return true; }
     bool is_vtol_man_throttle() const override { return true; }
     virtual bool is_vtol_man_mode() const override { return true; }
+    bool requires_home() const override { return false; };
 
     // methods that affect movement of the vehicle in this mode
     void update() override;
@@ -836,6 +860,8 @@ public:
     bool does_auto_navigation() const override { return true; }
 
     bool does_auto_throttle() const override { return true; }
+
+    bool requires_home() const override { return false; };
 
     // var_info for holding parameter information
     static const struct AP_Param::GroupInfo var_info[];

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -286,6 +286,16 @@ bool Plane::set_mode(Mode &new_mode, const ModeReason reason)
         return false;
     }
 
+    // Block mode changes to modes that require home if we don't have a home, we need a home, and we're armed.
+    // Mode changes without a home, while disarmed, are always ok.
+    if (new_mode.requires_home() &&
+        !ahrs.home_is_set() && 
+        hal.util->get_soft_armed()
+        ) {
+        mode_change_failed(&new_mode, "requires home");
+        return false;
+    }
+
     // backup current control_mode and previous_mode
     Mode &old_previous_mode = *previous_mode;
     Mode &old_mode = *control_mode;

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -189,8 +189,8 @@ const AP_Param::GroupInfo AP_AHRS::var_info[] = {
 
     // @Param: OPTIONS
     // @DisplayName: Optional AHRS behaviour
-    // @Description: This controls optional AHRS behaviour. Setting DisableDCMFallbackFW will change the AHRS behaviour for fixed wing aircraft in fly-forward flight to not fall back to DCM when the EKF stops navigating. Setting DisableDCMFallbackVTOL will change the AHRS behaviour for fixed wing aircraft in non fly-forward (VTOL) flight to not fall back to DCM when the EKF stops navigating. Setting DontDisableAirspeedUsingEKF disables the EKF based innovation check for airspeed consistency
-    // @Bitmask: 0:DisableDCMFallbackFW, 1:DisableDCMFallbackVTOL, 2:DontDisableAirspeedUsingEKF
+    // @Description: This controls optional AHRS behaviour. Setting DisableDCMFallbackFW will change the AHRS behaviour for fixed wing aircraft in fly-forward flight to not fall back to DCM when the EKF stops navigating. Setting DisableDCMFallbackVTOL will change the AHRS behaviour for fixed wing aircraft in non fly-forward (VTOL) flight to not fall back to DCM when the EKF stops navigating. Setting DontDisableAirspeedUsingEKF disables the EKF based innovation check for airspeed consistency. Setting AllowArmingWithoutHome lets you arm a fixed wing in modes that don't require GPS such as MANUAL or FBWA.
+    // @Bitmask: 0:DisableDCMFallbackFW, 1:DisableDCMFallbackVTOL, 2:DontDisableAirspeedUsingEKF, 3:AllowArmingWithoutHome
     // @User: Advanced
     AP_GROUPINFO("OPTIONS",  18, AP_AHRS, _options, 0),
     

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -683,6 +683,12 @@ public:
     // get access to an EKFGSF_yaw estimator
     const EKFGSF_yaw *get_yaw_estimator(void) const;
 
+    // get whether the AHRS allows arming without a home set in modes that don't require a home.
+    // used in plane for flying in modes such as MANUAL and FBWA.
+    bool allows_arming_without_home() {
+        return option_set(Options::ALLOW_ARMING_WITHOUT_HOME);
+    }
+
 private:
 
     // roll/pitch/yaw euler angles, all in radians
@@ -1016,6 +1022,7 @@ private:
         DISABLE_DCM_FALLBACK_FW=(1U<<0),
         DISABLE_DCM_FALLBACK_VTOL=(1U<<1),
         DISABLE_AIRSPEED_EKF_CHECK=(1U<<2),
+        ALLOW_ARMING_WITHOUT_HOME=(1U<<3),
     };
     AP_Int16 _options;
     

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -636,7 +636,8 @@ bool AP_Arming::gps_checks(bool report)
             }
         }
 
-        if (!AP::ahrs().home_is_set()) {
+        // Plane uses an option to allow users to fly without a home.
+        if (!AP::ahrs().allows_arming_without_home() && !AP::ahrs().home_is_set()) {
             check_failed(ARMING_CHECK_GPS, report, "AHRS: waiting for home");
             return false;
         }


### PR DESCRIPTION
# Purpose

If I do not have a GPS and don't use "Set Home Here” in mission planner because I'm just flying FPV without a GCS, I want to be able to keep all arming checks enabled. This is for running AP as a simple stabilizer (FBWA) with minimal peripherals. 

I never expect a home location, and do NOT expect AUTO, RTL, and other GPS-reliant modes to be allowed. 
Seems like having a home location is merely a convenience for the GCS, and I shouldn't rely on global position or local position if I only fly in FBWA and ACRO, so why do we make it required?


# Approach 

This PR introduces mode transition rejection into Plane based on needing a home. I have re-used the mode rejection from Copter, modeled after `ArduCopter/Mode::requires_GPS()`. Mode changes in plane can now be rejected, but only while armed.
While disarmed, like Copter, you can change to any mode, but arming checks in Plane now check whether your mode requires a home. If home is not set, you can't arm.

Note - without changes to the EKF, I recommend using DCM to fly without any position aiding. It won't fly as well.

# Wiki

This change will allow this wiki to be complete: https://github.com/ArduPilot/ardupilot_wiki/pull/6508

# Details

* If we force AP to use DCM, and disable all GPS's, we never expect a home location. Currently, AP will prevent arming.
* Allow users to arm DCM with all pre-arm checks enabled in this special case
* This allows using AP as a simple stabilizer (FBWA) on plane

# Testing performed

This sets up a no-gps plane that is locked to DCM, and then demonstrates we can now arm.

```bash
./Tools/autotest/sim_vehicle.py -v Plane --console --map -D -w
param set STALL_PREVENTION 0
param set GPS1_TYPE 0
param set AHRS_EKF_TYPE 0
# Enable the new no-home-required for arming
param bitmask set AHRS_OPTIONS 3
map set showsimpos 1
reboot
# Move the map to follow the sim position.
mode fbwa
# Wait for "pre-arm good"
arm throttle
rc 2 2000
rc 3 1500
```

![image](https://github.com/user-attachments/assets/381c74c9-ab4f-4af7-9896-50f7cdaaddb7)

If you cause an RC failsafe, then you see it will stay in circle, instead of have a flyaway in RTL. This is because the short failsafe is circle, and the long failsafe is RTL. I assert this is an improvement to not fly to 0, 0. 

```
rc 3 900
```
![image](https://github.com/user-attachments/assets/1ed4590a-5260-4bf7-993c-7fa9e3f31626)


# To discuss

* If we do **NOT** have a GPS, but we **DO HAVE** visual odom enabled, but we don't have a home, should we be allowed to arm? I suspect no currently -> Correct
* If we are using EKF3, and **DO NOT** have any GPS's configured, and no other position sources, should we require a home position to arm?  I suspect yes. -> Unless the user enables the no home required option. 
* Do we want to allow plane users to arm without a home, and add protection in mode change to block change from FBWA to AUTO if there's no home? -> Yes, added.

# Follow up

Improve mode transitions to cope with some modes not having a home, such as RTL long action should go to GLIDE rather than stay in circle.