### PR TITLE
Tools: fix Cygwin CI build

### DIFF
--- a/.github/workflows/cygwin_build.yml
+++ b/.github/workflows/cygwin_build.yml
@@ -156,7 +156,7 @@ jobs:
           NAME_DASHED=${WORKFLOWNAME//+( )/_}
           echo "cache-key=${NAME_DASHED}" >> $GITHUB_OUTPUT
 
-      - uses: cygwin/cygwin-install-action@master
+      - uses: cygwin/cygwin-install-action@v5
         with:
           packages: cygwin64 gcc-g++=10.2.0-1 ccache python37 python37-future python37-lxml python37-pip python37-setuptools python37-wheel git procps gettext
           add-to-path: false

--- a/Tools/scripts/cygwin_build.sh
+++ b/Tools/scripts/cygwin_build.sh
@@ -33,19 +33,12 @@ WAF_OPTIONS="-j8"
     python ./waf sub $WAF_OPTIONS 2>&1
 ) | tee artifacts/build.txt
 
-# copy both with exe and without to cope with differences
-# between windows versions in CI
+# artifacts are expected to have .exe as they are executable
 cp -v build/sitl/bin/arduplane artifacts/ArduPlane.elf.exe
 cp -v build/sitl/bin/arducopter artifacts/ArduCopter.elf.exe
 cp -v build/sitl/bin/arducopter-heli artifacts/ArduHeli.elf.exe
 cp -v build/sitl/bin/ardurover artifacts/ArduRover.elf.exe
 cp -v build/sitl/bin/ardusub artifacts/ArduSub.elf.exe
-
-cp -v build/sitl/bin/arduplane artifacts/ArduPlane.elf
-cp -v build/sitl/bin/arducopter artifacts/ArduCopter.elf
-cp -v build/sitl/bin/arducopter-heli artifacts/ArduHeli.elf
-cp -v build/sitl/bin/ardurover artifacts/ArduRover.elf
-cp -v build/sitl/bin/ardusub artifacts/ArduSub.elf
 
 # Find all cyg*.dll files returned by cygcheck for each exe in artifacts
 # and copy them over


### PR DESCRIPTION
There are currently issues where the non-.exe-suffixed files can't be copied into the `artifacts` folder; `cp` claims "File exists". Previously this worked but the suffix was added by Cygwin so all files in `artifacts` had a `.exe` suffix anyway.

This is evidently intended, though non-intuitive, behavior: https://sourceware.org/legacy-ml/cygwin/2009-08/msg00293.html

> On Cygwin, you should avoid having a file "foo" and a file "foo.exe" in the same directory at all cost to avoid puzzeling POSIX borderline behaviour like this.  What you do is essentially in the "not supported" class of problems.

> [...] Cygwin does not check for a file "foo", if the name of the file is explicitely given as "foo.exe".

Apparently something similar was addressed in PR #20926; the current code installs files with both suffixes, but that fix contradicts the info above and now has broken.

This PR changes the code to only install .exe-suffixed files, as opposed to only non-.exe-suffixed files, which was the behavior before that PR. The set of installed files should not actually change.