### PR TITLE
Use HAL_GCS_ENABLED in place of HAL_NO_UARTDRIVER

### DIFF
--- a/libraries/AP_HAL_ChibiOS/GPIO.cpp
+++ b/libraries/AP_HAL_ChibiOS/GPIO.cpp
@@ -24,9 +24,7 @@
 #ifndef HAL_BOOTLOADER_BUILD
 #include <SRV_Channel/SRV_Channel.h>
 #endif
-#ifndef HAL_NO_UARTDRIVER
 #include <GCS_MAVLink/GCS.h>
-#endif
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 #include <AP_Math/AP_Math.h>
 
@@ -621,9 +619,7 @@ void GPIO::timer_tick()
         // INTERNAL_ERROR() to get the reporting mechanism
 
         if (_gpio_tab[i].isr_disabled_ticks == 0) {
-#ifndef HAL_NO_UARTDRIVER
             GCS_SEND_TEXT(MAV_SEVERITY_ERROR,"ISR flood on pin %u", _gpio_tab[i].pin_num);
-#endif
             // Only trigger internal error if armed
             if (hal.util->get_soft_armed()) {
                 INTERNAL_ERROR(AP_InternalError::error_t::gpio_isr);
@@ -644,9 +640,7 @@ void GPIO::timer_tick()
         const uint8_t ISR_retry_ticks = 100U;
         if ((_gpio_tab[i].isr_disabled_ticks > ISR_retry_ticks) && (_gpio_tab[i].fn != nullptr)) {
             // Try re-enabling
-#ifndef HAL_NO_UARTDRIVER
             GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Retrying pin %d after ISR flood", _gpio_tab[i].pin_num);
-#endif
             if (attach_interrupt(_gpio_tab[i].pin_num, _gpio_tab[i].fn, _gpio_tab[i].isr_mode)) {
                 // Success, reset quota
                 _gpio_tab[i].isr_quota = quota;

--- a/libraries/AP_HAL_ChibiOS/RCInput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCInput.cpp
@@ -31,9 +31,7 @@ extern AP_IOMCU iomcu;
 
 #include <AP_Math/AP_Math.h>
 
-#ifndef HAL_NO_UARTDRIVER
 #include <GCS_MAVLink/GCS.h>
-#endif
 
 #define SIG_DETECT_TIMEOUT_US 500000
 using namespace ChibiOS;
@@ -129,7 +127,7 @@ void RCInput::_timer_tick(void)
     if (!_init) {
         return;
     }
-#ifndef HAL_NO_UARTDRIVER
+#if AP_HAVE_GCS_SEND_TEXT
     const char *rc_protocol = nullptr;
     RCSource source = last_source;
 #endif
@@ -178,7 +176,7 @@ void RCInput::_timer_tick(void)
         rcprot.read(_rc_values, _num_channels);
         _rssi = rcprot.get_RSSI();
         _rx_link_quality = rcprot.get_rx_link_quality();
-#ifndef HAL_NO_UARTDRIVER
+#if AP_HAVE_GCS_SEND_TEXT
         rc_protocol = rcprot.protocol_name();
         source = rcprot.using_uart() ? RCSource::RCPROT_BYTES : RCSource::RCPROT_PULSES;
 #endif
@@ -192,7 +190,7 @@ void RCInput::_timer_tick(void)
             iomcu.check_rcinput(last_iomcu_us, _num_channels, _rc_values, RC_INPUT_MAX_CHANNELS)) {
             _rcin_timestamp_last_signal = last_iomcu_us;
             _rcin_last_iomcu_ms = now;
-#ifndef HAL_NO_UARTDRIVER
+#if AP_HAVE_GCS_SEND_TEXT
             rc_protocol = iomcu.get_rc_protocol();
             _rssi = iomcu.get_RSSI();
             source = RCSource::IOMCU;
@@ -201,7 +199,7 @@ void RCInput::_timer_tick(void)
     }
 #endif
 
-#ifndef HAL_NO_UARTDRIVER
+#if AP_HAVE_GCS_SEND_TEXT
     if (rc_protocol && (rc_protocol != last_protocol || source != last_source)) {
         last_protocol = rc_protocol;
         last_source = source;

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -40,9 +40,7 @@
 #include <AP_InternalError/AP_InternalError.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 #include <AP_Common/ExpandingString.h>
-#ifndef HAL_NO_UARTDRIVER
 #include <GCS_MAVLink/GCS.h>
-#endif
 
 #if AP_SIM_ENABLED
 #include <AP_HAL/SIMState.h>
@@ -903,7 +901,7 @@ bool RCOutput::mode_requires_dma(enum output_mode mode) const
 
 void RCOutput::print_group_setup_error(pwm_group &group, const char* error_string)
 {
-#ifndef HAL_NO_UARTDRIVER
+#if AP_HAVE_GCS_SEND_TEXT
     uint8_t min_chan = UINT8_MAX;
     uint8_t max_chan = 0;
     for (uint8_t j = 0; j < 4; j++) {
@@ -921,7 +919,7 @@ void RCOutput::print_group_setup_error(pwm_group &group, const char* error_strin
     } else {
         GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Chan %i to %i, %s: %s",min_chan+1,max_chan+1,get_output_mode_string(group.current_mode),error_string);
     }
-#endif
+#endif  // AP_HAVE_GCS_SEND_TEXT
 }
 
 /*

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/defaults_iofirmware.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/defaults_iofirmware.h
@@ -73,3 +73,7 @@
 #ifndef HAL_MONITOR_THREAD_ENABLED
 #define HAL_MONITOR_THREAD_ENABLED 0
 #endif
+
+#ifndef HAL_GCS_ENABLED
+#define HAL_GCS_ENABLED 0
+#endif

--- a/libraries/AP_HAL_ESP32/RCInput.cpp
+++ b/libraries/AP_HAL_ESP32/RCInput.cpp
@@ -22,10 +22,6 @@
 
 #include <AP_Math/AP_Math.h>
 
-#ifndef HAL_NO_UARTDRIVER
-#include <GCS_MAVLink/GCS.h>
-#endif
-
 using namespace ESP32;
 
 extern const AP_HAL::HAL& hal;
@@ -118,7 +114,7 @@ void RCInput::_timer_tick(void)
     if (!_init) {
         return;
     }
-#ifndef HAL_NO_UARTDRIVER
+#if AP_HAVE_GCS_SEND_TEXT
     const char *rc_protocol = nullptr;
     RCSource source = last_source;
 #endif
@@ -146,7 +142,7 @@ void RCInput::_timer_tick(void)
         rcprot.read(_rc_values, _num_channels);
         _rssi = rcprot.get_RSSI();
         _rx_link_quality = rcprot.get_rx_link_quality();
-#ifndef HAL_NO_UARTDRIVER
+#if AP_HAVE_GCS_SEND_TEXT
         rc_protocol = rcprot.protocol_name();
         source = rcprot.using_uart() ? RCSource::RCPROT_BYTES : RCSource::RCPROT_PULSES;
         // printf("RCInput: decoding %s", last_protocol);
@@ -154,7 +150,7 @@ void RCInput::_timer_tick(void)
     }
 #endif // AP_RCPROTOCOL_ENABLED
 
-#ifndef HAL_NO_UARTDRIVER
+#if AP_HAVE_GCS_SEND_TEXT
     if (rc_protocol && (rc_protocol != last_protocol || source != last_source)) {
         last_protocol = rc_protocol;
         last_source = source;


### PR DESCRIPTION
```
pbarker@threads:~/rc/ardupilot$ ~/rc/ardupilot/Tools/scripts/filter_size_compare_branches_csv.py --hide /tmp/some.csv  
------------------------  ---------  -----  ------  ----  -----  -----  ---
Board                     AP_Periph  blimp  copter  heli  plane  rover  sub
SITL_arm_linux_gnueabihf             0      0       0     0      0      0
SITL_x86_64_linux_gnu                0      0       0     0      0      0
sw-nav-f405               112
------------------------  ---------  -----  ------  ----  -----  -----  ---
pbarker@threads:~/rc/ardupilot$ 
```

Past this the sw-nav-f405 will emit a warning via DroneCAN about any ISR flood that might occur.  That looks unlikely given the hwdef.
