### PR TITLE
hwdef: remove AP_SERVO_TELEM_ENABLED on minimized boards

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/include/minimize_common.inc
+++ b/libraries/AP_HAL_ChibiOS/hwdef/include/minimize_common.inc
@@ -137,3 +137,7 @@ define AC_PAYLOAD_PLACE_ENABLED 0
 # disable extra camera messages
 define AP_CAMERA_INFO_FROM_SCRIPT_ENABLED 0
 define AP_MAVLINK_MSG_VIDEO_STREAM_INFORMATION_ENABLED 0
+
+
+# no servo feedback on minimized boards:
+define AP_SERVO_TELEM_ENABLED 0


### PR DESCRIPTION
```
Board                    AP_Periph  blimp  bootloader  copter  heli   iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                                                      
CubeRedPrimary                      *      *           *       *                  *      *      *
Durandal                            *      *           *       *                  *      *      *
Hitec-Airspeed           *                                                                      
KakuteH7-bdshot                     *      *           *       *                  *      *      *
MatekF405                           -680   *           -880    -880               -352   -528   -680
Pixhawk1-1M-bdshot                  -1656              -1536   -1528              -1976  -1488  -1736
bebop                               *                  *       *                  *      *      *
f103-QiotekPeriph        *                                                                      
f303-Universal           *                                                                      
iomcu                                                                 *                         
revo-mini                           -744   *           -848    -680               -32    -664   -640
skyviper-v2450                                         *                                        
```
