### PR TITLE
AP_ESC_Telem: fix other timeout race

### DIFF
--- a/libraries/AP_ESC_Telem/AP_ESC_Telem_Backend.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem_Backend.cpp
@@ -48,9 +48,9 @@ void AP_ESC_Telem_Backend::update_telem_data(const uint8_t esc_index, const Tele
 /*
   return true if the data is stale
  */
-bool AP_ESC_Telem_Backend::TelemetryData::stale(uint32_t now_ms) const volatile
+bool AP_ESC_Telem_Backend::TelemetryData::stale() const volatile
 {
-    return last_update_ms == 0 || now_ms - last_update_ms > ESC_TELEM_DATA_TIMEOUT_MS;
+    return last_update_ms == 0 || !any_data_valid;
 }
 
 /*
@@ -62,7 +62,7 @@ bool AP_ESC_Telem_Backend::TelemetryData::valid(const uint16_t type_mask) const 
         // Requested type not available
         return false;
     }
-    return !stale(AP_HAL::millis());
+    return !stale();
 }
 
 #endif

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem_Backend.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem_Backend.h
@@ -30,8 +30,11 @@ public:
         uint8_t power_percentage;   // Percentage of output power
 #endif // AP_EXTENDED_ESC_TELEM_ENABLED
 
+        // set to false if no data has been received within the timeout period
+        bool any_data_valid;
+
         // return true if the data is stale
-        bool stale(uint32_t now_ms) const volatile;
+        bool stale() const volatile;
 
         //  return true if the requested type of data is available and not stale
         bool valid(const uint16_t type_mask) const volatile;


### PR DESCRIPTION
Prerequisite PR: #28999

The timeout for non-RPM telemetry is vulnerable to a similar race to the RPM one above. This PR makes the timeout logic consistent between the two, adding a validity flag to track the timeout instead of explicitly subtracting timestamps (one of which is volatile).

I broke this PR into a separate dependent PR in case this is considered too risky of a change. I have an alternative PR ready, mirroring how Pete is binding AP_Servo_Telem in the soon-to-be-merged #28857. That PR would be guaranteed not to change any behavior outside of Lua, however, I think this PR is vastly a better approach.