### PR TITLE
AP_Soaring: Add named value float publisher of soaring thermal EKF state

### DIFF
--- a/libraries/AP_Soaring/AP_Soaring.cpp
+++ b/libraries/AP_Soaring/AP_Soaring.cpp
@@ -369,6 +369,12 @@ void SoaringController::update_thermalling()
                                            (double)wind_drift.x,
                                            (double)wind_drift.y,
                                            (double)_thermalability);
+#if HAL_SOARING_NVF_EKF_ENABLED
+    gcs().send_named_float("SOAREKFX0", (float)_ekf.X[0]);
+    gcs().send_named_float("SOAREKFX1", (float)_ekf.X[1]);
+    gcs().send_named_float("SOAREKFX2", (float)_ekf.X[2]);
+    gcs().send_named_float("SOAREKFX3", (float)_ekf.X[3]);
+#endif // HAL_SOARING_NVF_EKF_ENABLED
 #endif
 }
 

--- a/libraries/AP_Soaring/AP_Soaring_config.h
+++ b/libraries/AP_Soaring/AP_Soaring_config.h
@@ -3,3 +3,9 @@
 #ifndef HAL_SOARING_ENABLED
 #define HAL_SOARING_ENABLED 1
 #endif
+
+// Whether to publish named-value-float of the kalman filter thermal estimator.
+// This is used with the mavproxy_soar plugin.
+#ifndef HAL_SOARING_NVF_EKF_ENABLED
+#define HAL_SOARING_NVF_EKF_ENABLED 0
+#endif


### PR DESCRIPTION
# Purpose

* This sends the EKF estimate of the thermal to mavproxy_soar so a dev can visualize where AP thinks the thermal is and how big it is
* Useful until we have proper mavlink packets for soaring state
* I threw in the strength, which I may scale the line thickness on color it different colors depending on strength like the thermal estimators on flight instruments do. The strength is not yet used in mavproxy.

# Question

Should they be throttled to something like 4HZ? 

# Demo

See https://github.com/ArduPilot/MAVProxy/pull/1500

Make sure to define HAL_SOARING_NVF_EKF_ENABLED to 1