### PR TITLE
AP_Mission: get_item: ensure returned item is clean

### DIFF
--- a/libraries/GCS_MAVLink/MissionItemProtocol.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol.cpp
@@ -154,13 +154,7 @@ void MissionItemProtocol::handle_mission_request_int(GCS_MAVLINK &_link,
         return;
     }
 
-    mavlink_mission_item_int_t ret_packet{};
-
-    ret_packet.target_system = msg.sysid;
-    ret_packet.target_component = msg.compid;
-    ret_packet.seq = packet.seq;
-    ret_packet.mission_type = packet.mission_type;
-
+    mavlink_mission_item_int_t ret_packet;
     const MAV_MISSION_RESULT result_code = get_item(_link, msg, packet, ret_packet);
 
     if (result_code != MAV_MISSION_ACCEPTED) {
@@ -168,6 +162,9 @@ void MissionItemProtocol::handle_mission_request_int(GCS_MAVLINK &_link,
         send_mission_ack(_link, msg, result_code);
         return;
     }
+
+    ret_packet.target_system = msg.sysid;
+    ret_packet.target_component = msg.compid;
 
     _link.send_message(MAVLINK_MSG_ID_MISSION_ITEM_INT, (const char*)&ret_packet);
 }
@@ -189,17 +186,15 @@ void MissionItemProtocol::handle_mission_request(GCS_MAVLINK &_link,
     request_int.seq = packet.seq;
     request_int.mission_type = packet.mission_type;
 
-    mavlink_mission_item_int_t item_int{};
-    item_int.target_system = msg.sysid;
-    item_int.target_component = msg.compid;
-    item_int.mission_type = packet.mission_type;
-    item_int.seq = packet.seq;
-
+    mavlink_mission_item_int_t item_int;
     MAV_MISSION_RESULT ret = get_item(_link, msg, request_int, item_int);
     if (ret != MAV_MISSION_ACCEPTED) {
         send_mission_ack(_link, msg, ret);
         return;
     }
+
+    item_int.target_system = msg.sysid;
+    item_int.target_component = msg.compid;
 
     mavlink_mission_item_t ret_packet{};
     ret = AP_Mission::convert_MISSION_ITEM_INT_to_MISSION_ITEM(item_int, ret_packet);

--- a/libraries/GCS_MAVLink/MissionItemProtocol_Fence.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol_Fence.cpp
@@ -61,12 +61,15 @@ bool MissionItemProtocol_Fence::get_item_as_mission_item(uint16_t seq,
         return false;
     }
 
-    ret_packet.command = ret_cmd;
-    ret_packet.param1 = p1;
-    ret_packet.x = fenceitem.loc.x;
-    ret_packet.y = fenceitem.loc.y;
-    ret_packet.z = 0;
-    ret_packet.mission_type = MAV_MISSION_TYPE_FENCE;
+    ret_packet = {
+        param1: p1,
+        x: fenceitem.loc.x,
+        y: fenceitem.loc.y,
+        z: 0,
+        seq: seq,
+        command: uint16_t(ret_cmd),
+        mission_type: MAV_MISSION_TYPE_FENCE,
+    };
 
     return true;
 }

--- a/libraries/GCS_MAVLink/MissionItemProtocol_Rally.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol_Rally.cpp
@@ -117,7 +117,15 @@ bool MissionItemProtocol_Rally::get_item_as_mission_item(uint16_t seq,
     }
 
     // Default to relative to home
-    ret_packet.frame = MAV_FRAME_GLOBAL_RELATIVE_ALT;
+    ret_packet = {
+        x: rallypoint.lat,
+        y: rallypoint.lng,
+        z: float(rallypoint.alt),
+        seq: seq,
+        command: MAV_CMD_NAV_RALLY_POINT,
+        frame: MAV_FRAME_GLOBAL_RELATIVE_ALT,
+        mission_type: MAV_MISSION_TYPE_RALLY,
+    };
 
     if (rallypoint.alt_frame_valid == 1) {
         switch (Location::AltFrame(rallypoint.alt_frame)) {
@@ -138,12 +146,6 @@ bool MissionItemProtocol_Rally::get_item_as_mission_item(uint16_t seq,
                 break;
         }
     }
-
-    ret_packet.command = MAV_CMD_NAV_RALLY_POINT;
-    ret_packet.x = rallypoint.lat;
-    ret_packet.y = rallypoint.lng;
-    ret_packet.z = rallypoint.alt;
-    ret_packet.mission_type = MAV_MISSION_TYPE_RALLY;
 
     return true;
 }

--- a/libraries/GCS_MAVLink/MissionItemProtocol_Waypoints.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol_Waypoints.cpp
@@ -93,6 +93,7 @@ MAV_MISSION_RESULT MissionItemProtocol_Waypoints::get_item(const GCS_MAVLINK &_l
     if (!AP_Mission::mission_cmd_to_mavlink_int(cmd, ret_packet)) {
         return MAV_MISSION_ERROR;
     }
+    ret_packet.mission_type = MAV_MISSION_TYPE_MISSION;
 
     // set packet's current field to 1 if this is the command being executed
     if (cmd.id == (uint16_t)mission.get_current_nav_cmd().index) {

--- a/libraries/GCS_MAVLink/MissionItemProtocol_Waypoints.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol_Waypoints.cpp
@@ -97,12 +97,7 @@ MAV_MISSION_RESULT MissionItemProtocol_Waypoints::get_item(const GCS_MAVLINK &_l
     // set packet's current field to 1 if this is the command being executed
     if (cmd.id == (uint16_t)mission.get_current_nav_cmd().index) {
         ret_packet.current = 1;
-    } else {
-        ret_packet.current = 0;
     }
-
-    // set auto continue to 1
-    ret_packet.autocontinue = 1;     // 1 (true), 0 (false)
 
     return MAV_MISSION_ACCEPTED;
 }


### PR DESCRIPTION
Mission does not fill in all fields of the returned item, this means you can get random data. This results in getting bad data via misison ftp or scripting. The mavlink mission item protocol does not use this method. The other mission ftp types are OK because they always fill in the full set of information. 

To reproduce, upload a misison and then read it back again. For example [before.txt](https://github.com/user-attachments/files/18379386/before.txt). Testing shown for SITL but the bug also exists on real hardware.

This is what we upload:
![image](https://github.com/user-attachments/assets/9da0f87b-67eb-4a0d-8ed6-d7c0aa946ecc)

This is what we read back on master:
![image](https://github.com/user-attachments/assets/9107f19e-e64a-4a17-92b1-df6718350ef6)

With the fix we get the same as what is written:
![image](https://github.com/user-attachments/assets/fcd50324-827e-4899-8263-b39b6e9b25b7)

This only shows up in the x,y,z fields of a item without location because the other fields are defaulted here:

https://github.com/ArduPilot/ardupilot/blob/6efe2105496ff9ffeca2ba13c0d80b1f9212c308/libraries/AP_Mission/AP_Mission.cpp#L1574-L1585

A alternate (or complementary) fix would be to also set default values for the x,y and z values there.

