### PR TITLE
AP_Mission: don't allow waypoint 0 (home) to be changed

### DIFF
--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -631,11 +631,6 @@ public:
     ///     true is return if successful
     bool read_cmd_from_storage(uint16_t index, Mission_Command& cmd) const;
 
-    /// write_cmd_to_storage - write a command to storage
-    ///     cmd.index is used to calculate the storage location
-    ///     true is returned if successful
-    bool write_cmd_to_storage(uint16_t index, const Mission_Command& cmd);
-
     /// write_home_to_storage - writes the special purpose cmd 0 (home) to storage
     ///     home is taken directly from ahrs
     void write_home_to_storage();
@@ -947,6 +942,11 @@ private:
     bool start_command_do_scripting(const AP_Mission::Mission_Command& cmd);
     bool start_command_do_gimbal_manager_pitchyaw(const AP_Mission::Mission_Command& cmd);
     bool start_command_fence(const AP_Mission::Mission_Command& cmd);
+
+    /// write_cmd_to_storage - write a command to storage
+    ///     cmd.index is used to calculate the storage location
+    ///     true is returned if successful
+    bool write_cmd_to_storage(uint16_t index, const Mission_Command& cmd);
 
     /*
       handle format conversion of storage format to allow us to update


### PR DESCRIPTION
This highlights what is a tricky problem to fix. The main problem is that this will break most scripts which try and upload missions. 

The problem is that mission allows you to set way-point 0, however when you try and read way point 0 you just get home. 

https://github.com/ArduPilot/ardupilot/blob/6efe2105496ff9ffeca2ba13c0d80b1f9212c308/libraries/AP_Mission/AP_Mission.cpp#L817-L822

This is the key this issue. You can write whatever you like to waypoint 0, but there is no way to read it back or for it to be used in anyway. (The only way I can think is that if you have a eeprom copy you could read it out manualy)

This makes the change that your no longer allowed to write to waypoint 0, this give users a clue that there throwing away there first point, it will never be used.

Maybe the more complete fix is to stop storing home completely, this would require doing param conversion on the total mission item count. 

A nice example of something that does not work as expected on master is the copter save way point switch (you have to make sure your mission is fully cleared and MIS_TOTAL is 0). In this case it carefully checks for there being 0 waypoints and tries to add a takeoff.

https://github.com/ArduPilot/ardupilot/blob/6efe2105496ff9ffeca2ba13c0d80b1f9212c308/ArduCopter/RC_Channel_Copter.cpp#L238-L250  

However, that takeoff is written to index 0 so it is never used. If you read the mission back again you will find only a single mission item and no take off:
![image](https://github.com/user-attachments/assets/ae1cb17c-7b94-4c1e-a43c-d13a4c7c935d)



