### PR TITLE
Plane Interlock DRAFT

### DIFF
--- a/ArduPlane/AP_Arming.cpp
+++ b/ArduPlane/AP_Arming.cpp
@@ -250,6 +250,9 @@ bool AP_Arming_Plane::ins_checks(bool display_failure)
 
 bool AP_Arming_Plane::arm_checks(AP_Arming::Method method)
 {
+    if(!plane.interlock_option_allowed(InterlockOptions::Arm)) {
+            return false;
+    }
     if (method == AP_Arming::Method::RUDDER) {
         const AP_Arming::RudderArming arming_rudder = get_rudder_arming_type();
 
@@ -260,6 +263,11 @@ bool AP_Arming_Plane::arm_checks(AP_Arming::Method method)
             // checks may be bothered by the message being emitted.
             // check_failed(true, "Rudder arming disabled");
             return false;
+        }
+        if(!plane.interlock_option_allowed(InterlockOptions::RudderArm)) {
+                GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Interlock %s %s", "RudderArm", "denied");
+                check_failed(true, "Interlock rudder arm denied");
+                return false;
         }
 
         // if throttle is not down, then pilot cannot rudder arm/disarm
@@ -344,6 +352,11 @@ bool AP_Arming_Plane::disarm(const AP_Arming::Method method, bool do_disarm_chec
         // option must be enabled:
         if (get_rudder_arming_type() != AP_Arming::RudderArming::ARMDISARM) {
             gcs().send_text(MAV_SEVERITY_INFO, "Rudder disarm: disabled");
+            return false;
+        }
+        if(!plane.interlock_option_allowed(InterlockOptions::RudderDisarm)) {
+            GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Interlock %s %s", "Rudder disarm", "denied");
+            check_failed(true, "Interlock Rudder disarm denied");
             return false;
         }
     }

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1309,7 +1309,14 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("RNGFND_LND_ORNT", 36, ParametersG2, rangefinder_land_orient, ROTATION_PITCH_270),
 #endif
-    
+
+    // @Param: ILCK_OPTIONS
+    // @DisplayName: Interlock Options
+    // @Description: A bitmask that determines what an RCx_OPTION = MOTOR_INTERLOCK applies to
+    // @User: Standard
+    // @Bitmask: 0: Arm, 1: Disarm, 2: Rudder Arming (reqires 0), 3: Rudder disarm (requires 1), 4: Emergency Stop
+    AP_GROUPINFO("ILCK_OPTIONS", 37, ParametersG2, interlock_options, 19),
+
     AP_GROUPEND
 };
 

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -590,6 +590,8 @@ public:
     // orientation of rangefinder to use for landing
     AP_Int8 rangefinder_land_orient;
 #endif
+
+    AP_Int8         interlock_options;
 };
 
 extern const AP_Param::Info var_info[];

--- a/ArduPlane/Plane.cpp
+++ b/ArduPlane/Plane.cpp
@@ -1066,6 +1066,8 @@ Plane::Plane(void)
 {
     // C++11 doesn't allow in-class initialisation of bitfields
     auto_state.takeoff_complete = true;
+    // Default to regular behavior, arm/disarm/estop are allowed. If MOTOR_INTERLOCK RC option is defined this will be updated in RC_CHAnnel::init
+    interlock_allowed();
 }
 
 Plane plane;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -895,6 +895,23 @@ private:
     void update_quicktune(void);
 #endif
 
+    /*
+    // plane interlock state
+    struct {
+        // allow for an interlock RC switch to prevent arming unless High
+        bool arm_allowed;
+        // allow for an interlock RC switch to prevent arming unless High
+        bool disarm_allowed;
+        // allow for an interlock RC switch to prevent emergency stop unless High
+        bool estop_allowed;
+        // allow for an interlock RC switch to prevent/allow rudder arming unless High
+        bool rudder_arm_allowed;
+        // allow for an interlock RC switch to prevent/allow rudder disarm unless High
+        bool rudder_disarm_allowed;
+    } interlock;
+    */
+    int16_t interlock_denied;
+
     // Attitude.cpp
     void adjust_nav_pitch_throttle(void);
     void update_load_factor(void);
@@ -1103,6 +1120,16 @@ private:
     void update_flight_stage();
     void set_flight_stage(AP_FixedWing::FlightStage fs);
     bool flight_option_enabled(FlightOptions flight_option) const;
+
+    // Interlock Option Enabled if the ILCK_OPTION bit for the action is set in the parameters
+    bool interlock_option_enabled(InterlockOptions interlock_action) { return g2.interlock_options & interlock_action; };
+    // Interlock Option Enabled if the option is set AND the interlock button has been pressed/activated by the pilot for the action
+    bool interlock_option_allowed(InterlockOptions interlock_action) { return interlock_action & ~interlock_denied; };
+
+    // Interlock allowed - arm/disarm/estop are all allowed - so nothing will be denied
+    void interlock_allowed() { interlock_denied = 0; };
+    // Interlock denied - arm/disarm/estop are disallowed for the options selected in ILCK_OPTIONS
+    void interlock_disallowed() { interlock_denied  = g2.interlock_options; };
 
     // navigation.cpp
     void loiter_angle_reset(void);

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -188,3 +188,11 @@ enum class FenceAutoEnable : uint8_t {
     AutoDisableFloorOnly=2,
     WhenArmed=3
 };
+
+enum InterlockOptions {
+    Arm   = (1 << 0),
+    Disarm = (1 << 1),
+    RudderArm = (1 << 2),
+    RudderDisarm = (1 << 3),
+    EStop = (1 << 4),
+};

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -10649,6 +10649,63 @@ Also, ignores heartbeats not from our target system'''
                             self.set_rc(interlock_channel, 1000)
                             raise NotAchievedException("Motor interlock was changed while disarmed")
                 self.set_rc(interlock_channel, 1000)
+            elif self.is_plane():
+                self.start_subtest("Test arming failure with interlock enabled")
+
+                interlock_channel = 9
+                self.set_parameter("RC%u_OPTION" % interlock_channel, 32)
+                # enable all plane interlock optons, 31 turns on all flags
+                self.set_parameter("ILCK_OPTIONS", 31)
+                # interlock must be help high to disable arm/disarm/interlock
+                self.reboot_sitl() # needed for CAM1_TYPE to take effect
+                if self.log_name() ==  "QuadPlane":
+                    self.send_cmd_do_set_mode("QLOITER")
+
+                self.set_rc(interlock_channel, 2000)
+                try:
+                    self.arm_motors_with_rc_input()
+                except NotAchievedException:
+                    pass
+                if self.armed():
+                    raise NotAchievedException(
+                        "Armed with RC input when interlock enabled")
+                try:
+                    self.arm_motors_with_switch(arming_switch)
+                except NotAchievedException:
+                    pass
+                if self.armed():
+                    raise NotAchievedException("Armed with switch when interlock enabled")
+                self.disarm_vehicle()
+
+                self.progress("arm with mavproxy")
+                mavproxy = self.start_mavproxy()
+                try:
+                    self.mavproxy_arm_vehicle(mavproxy)
+                except AutoTestTimeoutException:
+                    pass
+                if self.armed():
+                    raise NotAchievedException("Armed with mavproxy with interlock enabled")
+                # Now arm and make sure we can't disarm withouth interlock
+                self.set_rc(interlock_channel, 1000)
+                self.mavproxy_arm_vehicle(mavproxy)
+                self.set_rc(interlock_channel, 2000)
+                try:
+                    self.mavproxy_disarm_vehicle(mavproxy)
+                except AutoTestTimeoutException:
+                    pass
+                if self.armed():
+                    raise NotAchievedException("DisArmed with mavproxy with interlock enabled")
+                self.set_rc(interlock_channel, 2000)
+                self.stop_mavproxy(mavproxy)
+
+                self.wait_heartbeat()
+                self.set_rc(arming_switch, 1000)
+                self.set_rc(interlock_channel, 1000)
+                self.set_parameter("RC%u_OPTION" % interlock_channel, 0)
+                # enable all plane interlock optons, 31 turns on all flags
+                self.set_parameter("ILCK_OPTIONS", 19)
+                # interlock must be help high to disable arm/disarm/interlock
+                self.reboot_sitl() # needed to disable the interlock channel
 
         self.start_subtest("Test all mode arming")
         self.wait_ready_to_arm()


### PR DESCRIPTION
On my TX16S I have arming and estop protected by momentary switch. Unless I hold the switch on/up the plane can't arm. This works great so I can't accidentally arm/disarm or emergency stop the motors unless I also hold the switch at the same time. I am setting up a SiYi UniRC7 which doesn't have a way to do this like on the TX16S which uses a whole mess of special functions and global variables to make it work. So I want to implement this protection in ArduPlane. 

This PR implements the MOTOR_INTERLOCK RCx_OPTION for Plane and adds an ILCK_OPTIONS bitmask to allow the user what it applies to. The options are:

-     Arm 
-     Disarm 
-     RudderArm
-     RudderDisarm
-     Emergency Stop

And the interlock applies no matter how it is used, so Arm via RC, rudder, Mission Planner Aux function or mavproxy will all require the interlock RC channel (if set) to be low. 

This would usually be set on a momentary switch so the pilot has to hold the switch or button in order to allow Arming etc.

If there is no RC channel set to MOTOR_INTERLOCK then existing behavior works as it currently does.
