### PR TITLE
Remove command-line option enabling synthetic clock 

### DIFF
--- a/Tools/autotest/pysim/util.py
+++ b/Tools/autotest/pysim/util.py
@@ -416,7 +416,6 @@ def start_SITL(binary,
                gdb=False,
                gdb_no_tui=False,
                wipe=False,
-               synthetic_clock=True,
                home=None,
                model=None,
                speedup=1,
@@ -516,8 +515,6 @@ def start_SITL(binary,
     if not supplementary:
         if wipe:
             cmd.append('-w')
-        if synthetic_clock:
-            cmd.append('-S')
         if home is not None:
             cmd.extend(['--home', home])
         cmd.extend(['--model', model])

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -766,7 +766,6 @@ def start_vehicle(binary, opts, stuff, spawns=None):
         cmd.extend(strace_options)
 
     cmd.append(binary)
-    cmd.append("-S")
     if opts.wipe_eeprom:
         cmd.append("-w")
     cmd.extend(["--model", stuff["model"]])

--- a/libraries/AP_HAL/SIMState.cpp
+++ b/libraries/AP_HAL/SIMState.cpp
@@ -266,7 +266,6 @@ void SIMState::fdm_input_local(void)
 
     set_height_agl();
 
-    _synthetic_clock_mode = true;
     _update_count++;
 }
 

--- a/libraries/AP_HAL/SIMState.h
+++ b/libraries/AP_HAL/SIMState.h
@@ -99,8 +99,6 @@ private:
     uint16_t _irlock_port;
     float _current;
 
-    bool _synthetic_clock_mode;
-
     bool _use_rtscts;
     bool _use_fg_view;
     

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -106,10 +106,8 @@ void SITL_State::_sitl_setup()
         _sitl->rcin_port = _rcin_port;
     }
 
-    if (_synthetic_clock_mode) {
-        // start with non-zero clock
-        hal.scheduler->stop_clock(1);
-    }
+    // start with non-zero clock
+    hal.scheduler->stop_clock(1);
 }
 
 
@@ -284,7 +282,6 @@ void SITL_State::_fdm_input_local(void)
 
     set_height_agl();
 
-    _synthetic_clock_mode = true;
     _update_count++;
 }
 

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -87,8 +87,6 @@ private:
     uint16_t _fg_view_port;
     uint16_t _irlock_port;
 
-    bool _synthetic_clock_mode;
-
     bool _use_rtscts;
     bool _use_fg_view;
     

--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -209,7 +209,6 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
     float speedup = 1.0f;
     float sim_rate_hz = 0;
     _instance = 0;
-    _synthetic_clock_mode = false;
     // default to CMAC
     const char *home_str = nullptr;
     const char *model_str = nullptr;
@@ -422,7 +421,7 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
             _set_param_default(gopt.optarg);
             break;
         case 'S':
-            _synthetic_clock_mode = true;
+            printf("Ignoring stale command-line parameter '-S'");
             break;
         case 'O':
             home_str = gopt.optarg;
@@ -586,7 +585,6 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
             sitl_model->set_instance(_instance);
             sitl_model->set_autotest_dir(autotest_dir);
             sitl_model->set_config(config);
-            _synthetic_clock_mode = true;
             break;
         }
     }


### PR DESCRIPTION
It's always on