### PR TITLE
AP_HAL_SITL: Periph: stop running SITL updates off main thread

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_Periph_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_Periph_State.cpp
@@ -123,10 +123,15 @@ void SITL_State::init(int argc, char * const argv[]) {
 void SITL_State::wait_clock(uint64_t wait_time_usec)
 {
     while (AP_HAL::micros64() < wait_time_usec) {
-        struct sitl_input input {};
-        sitl_model->update(input); // delays up to 1 millisecond
-        sim_update();
-        update_voltage_current(input, 0);
+        if (hal.scheduler->in_main_thread() ||
+            Scheduler::from(hal.scheduler)->semaphore_wait_hack_required()) {
+            struct sitl_input input {};
+            sitl_model->update(input); // delays up to 1 millisecond
+            sim_update();
+            update_voltage_current(input, 0);
+        } else {
+            usleep(1000);
+        }
     }
 }
 


### PR DESCRIPTION
the same code present in the normal HAL-SITL scheduler was not copied across when this method was created.

Without it, if a non-main thread called delay we will attempt to do things like update the sitl_model (ie. SIM_Aircraft) object.  We have no protections in place (nor should we have) for this happening when the main thread is in the middle of doing the SITL updates, so corruption is definitely going to happen at some stage!