### PR TITLE
AP_Mount: Shifted open_mount servo functionality to AP_Mount_Backend

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -19,6 +19,14 @@ extern const AP_HAL::HAL& hal;
 // Default init function for every mount
 void AP_Mount_Backend::init()
 {
+    // assigning the correct servo mount function 
+    if (_instance == 0) {
+        _open_idx = SRV_Channel::k_mount_open;
+    } else {
+        // this must be the 2nd mount
+        _open_idx = SRV_Channel::k_mount2_open;
+    }
+
     // setting default target sysid from parameters
     _target_sysid = _params.sysid_default.get();
 
@@ -802,6 +810,15 @@ void AP_Mount_Backend::update_angle_target_from_rate(const MountTarget& rate_rad
         angle_rad.yaw = constrain_float(angle_rad.yaw, radians(_params.yaw_angle_min), radians(_params.yaw_angle_max));
     }
 }
+
+void AP_Mount_Backend::actuate_mount_open_servo()
+{
+    auto mount_mode = get_mode();
+    const int mount_open = (mount_mode == MAV_MOUNT_MODE_RETRACT) ? 0 : 1;
+    SRV_Channels::move_servo((SRV_Channel::Aux_servo_function_t)_open_idx, mount_open, 0, 1);
+    return;
+}
+
 
 // helper function to provide GIMBAL_DEVICE_FLAGS for use in GIMBAL_DEVICE_ATTITUDE_STATUS message
 uint16_t AP_Mount_Backend::get_gimbal_device_flags() const

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -28,6 +28,7 @@
 #include <AP_Common/Location.h>
 #include <RC_Channel/RC_Channel.h>
 #include <AP_Camera/AP_Camera_shareddefs.h>
+#include <SRV_Channel/SRV_Channel.h>
 #include "AP_Mount.h"
 
 class AP_Mount_Backend
@@ -37,7 +38,8 @@ public:
     AP_Mount_Backend(class AP_Mount &frontend, class AP_Mount_Params &params, uint8_t instance) :
         _frontend(frontend),
         _params(params),
-        _instance(instance)
+        _instance(instance),
+        _open_idx(SRV_Channel::k_none)
     {}
 
     // init - performs any required initialisation for this instance
@@ -282,6 +284,9 @@ protected:
     // assumes a 50hz update rate
     void update_angle_target_from_rate(const MountTarget& rate_rad, MountTarget& angle_rad) const;
 
+    // actuate the deploy/retract servo for the mount
+    void actuate_mount_open_servo();
+
     // helper function to provide GIMBAL_DEVICE_FLAGS for use in GIMBAL_DEVICE_ATTITUDE_STATUS message
     uint16_t get_gimbal_device_flags() const;
 
@@ -320,6 +325,10 @@ private:
 #endif
 
     bool _yaw_lock;                 // yaw_lock used in RC_TARGETING mode. True if the gimbal's yaw target is maintained in earth-frame, if false (aka "follow") it is maintained in body-frame
+
+    // Servo functionality for deploying/retracting the mounts
+    SRV_Channel::Aux_servo_function_t    _open_idx;  // SRV_Channel mount open function index
+
 
 #if AP_MOUNT_POI_TO_LATLONALT_ENABLED
     struct {

--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -16,13 +16,11 @@ void AP_Mount_Servo::init()
         _roll_idx = SRV_Channel::k_mount_roll;
         _tilt_idx = SRV_Channel::k_mount_tilt;
         _pan_idx  = SRV_Channel::k_mount_pan;
-        _open_idx = SRV_Channel::k_mount_open;
     } else {
         // this must be the 2nd mount
         _roll_idx = SRV_Channel::k_mount2_roll;
         _tilt_idx = SRV_Channel::k_mount2_tilt;
         _pan_idx  = SRV_Channel::k_mount2_pan;
-        _open_idx = SRV_Channel::k_mount2_open;
     }
     AP_Mount_Backend::init();
 }
@@ -102,8 +100,7 @@ void AP_Mount_Servo::update()
     }
 
     // move mount to a "retracted position" into the fuselage with a fourth servo
-    const bool mount_open = (mount_mode == MAV_MOUNT_MODE_RETRACT) ? 0 : 1;
-    move_servo(_open_idx, mount_open, 0, 1);
+    actuate_mount_open_servo();
 
     // write the results to the servos
     move_servo(_roll_idx, degrees(_angle_bf_output_rad.x)*10, _params.roll_angle_min*10, _params.roll_angle_max*10);

--- a/libraries/AP_Mount/AP_Mount_Servo.h
+++ b/libraries/AP_Mount/AP_Mount_Servo.h
@@ -11,7 +11,6 @@
 
 #include <AP_Math/AP_Math.h>
 #include <AP_Common/AP_Common.h>
-#include <SRV_Channel/SRV_Channel.h>
 
 class AP_Mount_Servo : public AP_Mount_Backend
 {
@@ -22,8 +21,7 @@ public:
         requires_stabilization(requires_stab),
         _roll_idx(SRV_Channel::k_none),
         _tilt_idx(SRV_Channel::k_none),
-        _pan_idx(SRV_Channel::k_none),
-        _open_idx(SRV_Channel::k_none)
+        _pan_idx(SRV_Channel::k_none)
     {
     }
 
@@ -59,10 +57,10 @@ private:
     const bool requires_stabilization;
 
     // SRV_Channel - different id numbers are used depending upon the instance number
+    // _open_idx shited to AP_Mount Backend to support funtionality for all mounts 
     SRV_Channel::Aux_servo_function_t    _roll_idx;  // SRV_Channel mount roll function index
     SRV_Channel::Aux_servo_function_t    _tilt_idx;  // SRV_Channel mount tilt function index
     SRV_Channel::Aux_servo_function_t    _pan_idx;   // SRV_Channel mount pan  function index
-    SRV_Channel::Aux_servo_function_t    _open_idx;  // SRV_Channel mount open function index
 
     Vector3f _angle_bf_output_rad;  // final body frame output angle in radians
 };


### PR DESCRIPTION
**Changes**
- Shifted ```_open_idx``` variable to ```AP_Mount_Backend``` and its initialisation to ```AP_Mount_Backend::init```.
- Introduced ```AP_Mount_Backend::actuate_mount_open_servo``` function to run the servo control routine, this can be called in ```AP_Mount::update``` wherever the functionality is required.
- Called the ```actuate_mount_open_servo``` in ```AP_Mount_Servo``` to replace the old lines actuating mount_open_ servo.

**Notes and Doubts**
- ```_open_idx``` will be initialised for every class of AP_Mount by default. Is this expected to be this way? If not, please let me know what condition to check for to initialise ```_open_idx```.
- So far, I have called ```actuate_mount_open_servo``` in ```AP_Mount_Servo``` only. Does it have to be called in all other implementations of AP_Mounts or in some specific ones? Please let me know and I will add the statements to those implementations too.