### PR TITLE
Allow reverse channel positions on stick gesture channels

### DIFF
--- a/libraries/AP_Camera/AP_RunCam.cpp
+++ b/libraries/AP_Camera/AP_RunCam.cpp
@@ -462,10 +462,10 @@ void AP_RunCam::handle_in_menu(Event ev)
 // map rc input to an event
 AP_RunCam::Event AP_RunCam::map_rc_input_to_event() const
 {
-    const RC_Channel::AuxSwitchPos throttle = rc().get_throttle_channel().get_aux_switch_pos();
-    const RC_Channel::AuxSwitchPos yaw = rc().get_yaw_channel().get_aux_switch_pos();
-    const RC_Channel::AuxSwitchPos roll = rc().get_roll_channel().get_aux_switch_pos();
-    const RC_Channel::AuxSwitchPos pitch = rc().get_pitch_channel().get_aux_switch_pos();
+    const RC_Channel::AuxSwitchPos throttle = rc().get_throttle_channel().get_stick_gesture_pos();
+    const RC_Channel::AuxSwitchPos yaw = rc().get_yaw_channel().get_stick_gesture_pos();
+    const RC_Channel::AuxSwitchPos roll = rc().get_roll_channel().get_stick_gesture_pos();
+    const RC_Channel::AuxSwitchPos pitch = rc().get_pitch_channel().get_stick_gesture_pos();
 
     Event result = Event::NONE;
 

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -503,7 +503,6 @@ private:
 
 #if AP_RC_CHANNEL_ENABLED
     Event map_rc_input_to_event() const;
-    RC_Channel::AuxSwitchPos get_channel_pos(const class RC_Channel &chan) const;
 #endif
 
     uint8_t _selected_param = 1;

--- a/libraries/AP_OSD/AP_OSD_ParamScreen.cpp
+++ b/libraries/AP_OSD/AP_OSD_ParamScreen.cpp
@@ -388,37 +388,13 @@ void AP_OSD_ParamScreen::modify_configured_parameter(uint8_t number, Event ev)
     }
 }
 
-// return radio values as LOW, MIDDLE, HIGH
-// this function uses different threshold values to RC_Chanel::get_aux_switch_pos()
-// to avoid glitching on the stick travel
-RC_Channel::AuxSwitchPos AP_OSD_ParamScreen::get_channel_pos(const RC_Channel &chanref) const
-{
-    const auto *chan = &chanref;
-
-    const uint16_t in = chan->get_radio_in();
-    if (in <= 900 || in >= 2200) {
-        return RC_Channel::AuxSwitchPos::LOW;
-    }
-
-    // switch is reversed if 'reversed' option set on channel and switches reverse is allowed by RC_OPTIONS
-    bool switch_reversed = chan->get_reverse() && rc().option_is_enabled(RC_Channels::Option::ALLOW_SWITCH_REV);
-
-    if (in < RC_Channel::AUX_PWM_TRIGGER_LOW) {
-        return switch_reversed ? RC_Channel::AuxSwitchPos::HIGH : RC_Channel::AuxSwitchPos::LOW;
-    } else if (in > RC_Channel::AUX_PWM_TRIGGER_HIGH) {
-        return switch_reversed ? RC_Channel::AuxSwitchPos::LOW : RC_Channel::AuxSwitchPos::HIGH;
-    } else {
-        return RC_Channel::AuxSwitchPos::MIDDLE;
-    }
-}
-
 // map rc input to an event
 AP_OSD_ParamScreen::Event AP_OSD_ParamScreen::map_rc_input_to_event() const
 {
-    const RC_Channel::AuxSwitchPos throttle = get_channel_pos(rc().get_throttle_channel());
-    const RC_Channel::AuxSwitchPos yaw = get_channel_pos(rc().get_yaw_channel());
-    const RC_Channel::AuxSwitchPos roll = get_channel_pos(rc().get_roll_channel());
-    const RC_Channel::AuxSwitchPos pitch = get_channel_pos(rc().get_pitch_channel());
+    const RC_Channel::AuxSwitchPos throttle = rc().get_throttle_channel().get_stick_gesture_pos();
+    const RC_Channel::AuxSwitchPos yaw = rc().get_yaw_channel().get_stick_gesture_pos();
+    const RC_Channel::AuxSwitchPos roll = rc().get_roll_channel().get_stick_gesture_pos();
+    const RC_Channel::AuxSwitchPos pitch = rc().get_pitch_channel().get_stick_gesture_pos();
 
     Event result = Event::NONE;
 

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -1952,6 +1952,28 @@ RC_Channel::AuxSwitchPos RC_Channel::get_aux_switch_pos() const
     return position;
 }
 
+// return stick gesture pos as LOW, MIDDLE, HIGH
+// this function uses different threshold values to RC_Chanel::get_aux_switch_pos()
+// to avoid glitching on the stick travel and also always honours channel reversal
+RC_Channel::AuxSwitchPos RC_Channel::get_stick_gesture_pos() const
+{
+    const uint16_t in = get_radio_in();
+    if (in <= 900 || in >= 2200) {
+        return RC_Channel::AuxSwitchPos::LOW;
+    }
+
+    // switch is reversed if 'reversed' option set on channel and switches reverse is allowed by RC_OPTIONS
+    bool switch_reversed = get_reverse();
+
+    if (in < RC_Channel::AUX_PWM_TRIGGER_LOW) {
+        return switch_reversed ? RC_Channel::AuxSwitchPos::HIGH : RC_Channel::AuxSwitchPos::LOW;
+    }
+    if (in > RC_Channel::AUX_PWM_TRIGGER_HIGH) {
+        return switch_reversed ? RC_Channel::AuxSwitchPos::LOW : RC_Channel::AuxSwitchPos::HIGH;
+    }
+    return RC_Channel::AuxSwitchPos::MIDDLE;
+}
+
 RC_Channel *RC_Channels::find_channel_for_option(const RC_Channel::AUX_FUNC option)
 {
     for (uint8_t i=0; i<NUM_RC_CHANNELS; i++) {

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -332,6 +332,9 @@ public:
 
     AuxSwitchPos get_aux_switch_pos() const;
 
+    // aux position for stick gestures used by RunCam menus etc
+    AuxSwitchPos get_stick_gesture_pos() const;
+
     // wrapper function around do_aux_function which allows us to log
     bool run_aux_function(AUX_FUNC ch_option, AuxSwitchPos pos, AuxFuncTrigger::Source source, uint16_t source_index);
 


### PR DESCRIPTION
This fixes a long standing bug, where TX stick commands do not obey AP reversal settings