### PR TITLE
AP_Periph: Add restart acknowledgement for UAVCAN

### DIFF
--- a/Tools/AP_Periph/AP_Periph.h
+++ b/Tools/AP_Periph/AP_Periph.h
@@ -602,6 +602,8 @@ public:
     AP_AHRS ahrs;
 #endif
 
+    uint32_t reboot_request_ms = 0;
+
     HAL_Semaphore canard_broadcast_semaphore;
 };
 


### PR DESCRIPTION
There was no acknowledgement for UAVCAN so we add it here.

Tested on: CubeNode, AP_Periph