### PR TITLE
AP_Mission: better deal with home being in index 0.

### DIFF
--- a/ArduCopter/RC_Channel_Copter.cpp
+++ b/ArduCopter/RC_Channel_Copter.cpp
@@ -228,7 +228,7 @@ bool RC_Channel_Copter::do_aux_function(const AuxFuncTrigger &trigger)
                 }
 
                 // do not allow saving the first waypoint with zero throttle
-                if ((copter.mode_auto.mission.num_commands() == 0) && (copter.channel_throttle->get_control_in() == 0)) {
+                if (!copter.mode_auto.mission.present() && (copter.channel_throttle->get_control_in() == 0)) {
                     break;
                 }
 
@@ -236,7 +236,7 @@ bool RC_Channel_Copter::do_aux_function(const AuxFuncTrigger &trigger)
                 AP_Mission::Mission_Command cmd  = {};
 
                 // if the mission is empty save a takeoff command
-                if (copter.mode_auto.mission.num_commands() == 0) {
+                if (!copter.mode_auto.mission.present()) {
                     // set our location ID to 16, MAV_CMD_NAV_WAYPOINT
                     cmd.id = MAV_CMD_NAV_TAKEOFF;
                     cmd.content.location.alt = MAX(copter.current_loc.alt,100);

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -23,7 +23,7 @@
 bool ModeAuto::init(bool ignore_checks)
 {
     auto_RTL = false;
-    if (mission.num_commands() > 1 || ignore_checks) {
+    if (mission.present() || ignore_checks) {
         // reject switching to auto mode if landed with motors armed but first command is not a takeoff (reduce chance of flips)
         if (motors->armed() && copter.ap.land_complete && !mission.starts_with_takeoff_cmd()) {
             gcs().send_text(MAV_SEVERITY_CRITICAL, "Auto: Missing Takeoff Cmd");

--- a/ArduPlane/commands.cpp
+++ b/ArduPlane/commands.cpp
@@ -163,8 +163,5 @@ bool Plane::set_home_persistently(const Location &loc)
         return false;
     }
 
-    // Save Home to EEPROM
-    mission.write_home_to_storage();
-
     return true;
 }

--- a/ArduSub/mode_auto.cpp
+++ b/ArduSub/mode_auto.cpp
@@ -8,7 +8,7 @@
  *  Code in this file implements the navigation commands
  */
 bool ModeAuto::init(bool ignore_checks) {
-     if (!sub.position_ok() || sub.mission.num_commands() < 2) {
+     if (!sub.position_ok() || !sub.mission.present()) {
         return false;
     }
 

--- a/Rover/RC_Channel_Rover.cpp
+++ b/Rover/RC_Channel_Rover.cpp
@@ -154,15 +154,7 @@ bool RC_Channel_Rover::do_aux_function(const AuxFuncTrigger &trigger)
                 }
                 break;
             }
-
-            // record the waypoint if not in auto mode
-            if (rover.control_mode != &rover.mode_auto) {
-                if (rover.mode_auto.mission.num_commands() == 0) {
-                    // add a home location....
-                    add_waypoint_for_current_loc();
-                }
-                add_waypoint_for_current_loc();
-            }
+            add_waypoint_for_current_loc();
         }
         break;
 

--- a/Rover/commands.cpp
+++ b/Rover/commands.cpp
@@ -29,9 +29,6 @@ bool Rover::set_home(const Location& loc, bool lock)
         ahrs.lock_home();
     }
 
-    // Save Home to EEPROM
-    mode_auto.mission.write_home_to_storage();
-
     // send text of home position to ground stations
     gcs().send_text(MAV_SEVERITY_INFO, "Set HOME to %.6f %.6f at %.2fm",
             static_cast<double>(loc.lat * 1.0e-7f),

--- a/Rover/mode_auto.cpp
+++ b/Rover/mode_auto.cpp
@@ -5,7 +5,7 @@
 bool ModeAuto::_enter()
 {
     // fail to enter auto if no mission commands
-    if (mission.num_commands() <= 1) {
+    if (!mission.present()) {
         gcs().send_text(MAV_SEVERITY_NOTICE, "No Mission. Can't set AUTO.");
         return false;
     }
@@ -47,7 +47,7 @@ void ModeAuto::update()
     // check if mission exists (due to being cleared while disarmed in AUTO,
     // if no mission, then stop...needs mode change out of AUTO, mission load,
     // and change back to AUTO to run a mission at this point
-    if (!hal.util->get_soft_armed() && mission.num_commands() <= 1) {
+    if (!hal.util->get_soft_armed() && !mission.present()) {
         start_stop();
     }
     // start or update mission

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -377,6 +377,11 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_rc(3, 1500)
         self.save_wp()
 
+        # Disarm and reset before testing mission
+        self.land_and_disarm()
+        self.set_rc(3, 1000)
+        self.change_mode('LOITER')
+
         # save the stored mission to file
         mavproxy = self.start_mavproxy()
         num_wp = self.save_mission_to_file_using_mavproxy(
@@ -386,9 +391,11 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         if not num_wp:
             raise NotAchievedException("save_mission_to_file failed")
 
+        self.arm_vehicle()
         self.progress("test: Fly a mission from 1 to %u" % num_wp)
         self.change_mode('AUTO')
-        self.set_current_waypoint(1)
+        # Raise throttle in auto to trigger takeoff
+        self.set_rc(3, 1500)
         self.wait_waypoint(0, num_wp-1, timeout=500)
         self.progress("test: MISSION COMPLETE: passed!")
         self.land_and_disarm()

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -39,6 +39,12 @@
 #include <GCS_MAVLink/GCS.h>
 #include <AP_InertialSensor/AP_InertialSensor.h>
 #include <AP_CustomRotations/AP_CustomRotations.h>
+
+#include <AP_Mission/AP_Mission_config.h>
+#if AP_MISSION_ENABLED
+#include <AP_Mission/AP_Mission.h>
+#endif
+
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 #include <SITL/SITL.h>
 #endif
@@ -2984,6 +2990,14 @@ bool AP_AHRS::set_home(const Location &loc)
     pd.home_lat = loc.lat;
     pd.home_lon = loc.lng;
     pd.home_alt_cm = loc.alt;
+
+#if AP_MISSION_ENABLED
+    // Save home to mission
+    AP_Mission *mission = AP::mission();
+    if (mission != nullptr) {
+        mission->write_home_to_storage();
+    }
+#endif
 
     return true;
 }

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -897,7 +897,7 @@ bool AP_Arming::mission_checks(bool report)
     // do not allow arming if there are no mission items and we are in
     // (e.g.) AUTO mode
     if (AP::vehicle()->current_mode_requires_mission() &&
-        (mission == nullptr || mission->num_commands() <= 1)) {
+        (mission == nullptr || !mission->present())) {
         check_failed(ARMING_CHECK_MISSION, report, "Mode requires mission");
         return false;
     }

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -971,6 +971,11 @@ void AP_Mission::write_home_to_storage()
     home_cmd.id = MAV_CMD_NAV_WAYPOINT;
     home_cmd.content.location = AP::ahrs().get_home();
     write_cmd_to_storage(0,home_cmd);
+
+    // Make sure command total reflects that home has been added
+    if (_cmd_total < 1) {
+        _cmd_total.set_and_save(1);
+    }
 }
 
 MAV_MISSION_RESULT AP_Mission::sanity_check_params(const mavlink_mission_item_int_t& packet)

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -498,6 +498,11 @@ bool AP_Mission::start_command(const Mission_Command& cmd)
 ///     cmd.index is updated with it's new position in the mission
 bool AP_Mission::add_cmd(Mission_Command& cmd)
 {
+    // Add home if its not already present
+    if (_cmd_total < 1) {
+        write_home_to_storage();
+    }
+
     // attempt to write the command to storage
     bool ret = write_cmd_to_storage(_cmd_total, cmd);
 
@@ -519,6 +524,12 @@ bool AP_Mission::replace_cmd(uint16_t index, const Mission_Command& cmd)
     // sanity check index
     if (index >= (unsigned)_cmd_total) {
         return false;
+    }
+
+    // Writing index zero is not allowed, it must be home
+    if (index == 0) {
+        // Really should be returning false in this case, but in order to not break things we return true
+        return true;
     }
 
     // attempt to write the command to storage
@@ -715,6 +726,16 @@ bool AP_Mission::set_item(uint16_t index, mavlink_mission_item_int_t& src_packet
     // convert from mavlink-ish format to storage format, if we can.
     if (mavlink_int_to_mission_cmd(src_packet, cmd) != MAV_MISSION_ACCEPTED) {
         return false;
+    }
+
+    // Writing index zero is not allowed, it must be home
+    if (index == 0) {
+        // If home is not already loaded add it so cmd_total is incremented to 1 as would be expected when the returning true
+        if (_cmd_total < 1) {
+            write_home_to_storage();
+        }
+        // Really should be returning false in this case, but in order to not break things we return true
+        return true;
     }
 
     // A request to set the 'next' item after the end is how we add an extra

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -978,7 +978,10 @@ bool AP_Mission::write_cmd_to_storage(uint16_t index, const Mission_Command& cmd
     }
 
     // remember when the mission last changed
-    _last_change_time_ms = AP_HAL::millis();
+    if (index != 0) {
+        // Update of home location is not a true change
+        _last_change_time_ms = AP_HAL::millis();
+    }
 
     // return success
     return true;

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -631,11 +631,6 @@ public:
     ///     true is return if successful
     bool read_cmd_from_storage(uint16_t index, Mission_Command& cmd) const;
 
-    /// write_cmd_to_storage - write a command to storage
-    ///     cmd.index is used to calculate the storage location
-    ///     true is returned if successful
-    bool write_cmd_to_storage(uint16_t index, const Mission_Command& cmd);
-
     /// write_home_to_storage - writes the special purpose cmd 0 (home) to storage
     ///     home is taken directly from ahrs
     void write_home_to_storage();
@@ -810,6 +805,11 @@ private:
     ///
     /// private methods
     ///
+
+    /// write_cmd_to_storage - write a command to storage
+    ///     cmd.index is used to calculate the storage location
+    ///     true is returned if successful
+    bool write_cmd_to_storage(uint16_t index, const Mission_Command& cmd);
 
     /// complete - mission is marked complete and clean-up performed including calling the mission_complete_fn
     void complete();

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -507,6 +507,9 @@ public:
         return _commands_max;
     }
 
+    // Present - returns true if there is a mission currently loaded, ignoring home which is stored in index 0
+    bool present() const { return _cmd_total > 1; }
+
     /// start - resets current commands to point to the beginning of the mission
     ///     To-Do: should we validate the mission first and return true/false?
     void start();

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -658,7 +658,7 @@ void GCS_MAVLINK::handle_mission_request(const mavlink_message_t &msg)
 // current mission state.
 MISSION_STATE GCS_MAVLINK::mission_state(const AP_Mission &mission) const
 {
-    if (mission.num_commands() < 2) {  // 1 means just home is present
+    if (!mission.present()) {
         return MISSION_STATE_NO_MISSION;
     }
     switch (mission.state()) {


### PR DESCRIPTION
This is a result of the discussion on https://github.com/ArduPilot/ardupilot/pull/29039. The two key things are:

- `AP_Mission::add_cmd` will add home if needed and then add the passed in command so that the passed in command is always added and not lost in index 0.
- `AP_Mission::replace_cmd` will not replace the command in index 0, but it does still return true in that case.
- `AP_Mission::write_home_to_storage` will set `_cmd_total` to 1 if it is 0.

There are also a number of clean ups and bug fixes:

- new `present()` method on mission which consolidates all the places that were trying to tell if there was a mission. We had been using `mission.num_commands() > 1` and `mission.num_commands() <= 1` or ` mission.num_commands() < 2`  for not present. This also replaces `mission.num_commands() == 0` which copter was using incorrectly for `AUX_FUNC::SAVE_WP`
- Fixes the lack of a workaround in copter `AUX_FUNC::SAVE_WP` and remove the need for the workaround in rover `AUX_FUNC::SAVE_WP`
- AHRS now directly calls mission `write_home_to_storage` so it will always be upto date and we don't have to do it in rover and plane manually.

The AHRS auto set of the home mission item is the only one users might notice, this was only done on plane and rover previously. Because it now also updates `_cmd_total` it is now more likely to be 1 than 0 with no mission loaded.