### PR TITLE
Rover: add require-position-for-arming option

### DIFF
--- a/Rover/AP_Arming_Rover.cpp
+++ b/Rover/AP_Arming_Rover.cpp
@@ -34,7 +34,9 @@ bool AP_Arming_Rover::rc_calibration_checks(const bool display_failure)
 // performs pre_arm gps related checks and returns true if passed
 bool AP_Arming_Rover::gps_checks(bool display_failure)
 {
-    if (!rover.control_mode->requires_position() && !rover.control_mode->requires_velocity()) {
+    if (!require_location &&
+        !rover.control_mode->requires_position() &&
+        !rover.control_mode->requires_velocity()) {
         // we don't care!
         return true;
     }

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -12243,16 +12243,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.context_pop()
         self.reboot_sitl()
 
-    def assert_home_position_not_set(self):
-        try:
-            self.poll_home_position()
-        except NotAchievedException:
-            return
-
-        # if home.lng != 0: etc
-
-        raise NotAchievedException("Home is set when it shouldn't be")
-
     def REQUIRE_LOCATION_FOR_ARMING(self):
         '''check AP_Arming::Option::REQUIRE_LOCATION_FOR_ARMING works'''
         self.context_push()

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6947,6 +6947,31 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
         self.delay_sim_time(1000)
 
+    def REQUIRE_POSITION_FOR_ARMING(self):
+        '''check DriveOption::REQUIRE_POSITION_FOR_ARMING works'''
+        self.context_push()
+        self.set_parameters({
+            "SIM_GPS1_NUMSATS": 3,  # EKF does not like < 6
+            "AHRS_GPS_USE": 0,  # stop DCM supplying home
+        })
+        self.reboot_sitl()
+        self.change_mode('MANUAL')
+        self.wait_prearm_sys_status_healthy()
+        self.assert_home_position_not_set()
+        self.arm_vehicle()
+        self.disarm_vehicle()
+
+        self.change_mode('GUIDED')
+        self.assert_prearm_failure("waiting for home", other_prearm_failures_fatal=False)
+
+        self.change_mode('MANUAL')
+        self.set_parameters({
+            "DRIVE_OPTIONS": 1,
+        })
+        self.assert_prearm_failure("waiting for home", other_prearm_failures_fatal=False)
+        self.context_pop()
+        self.reboot_sitl()
+
     def tests(self):
         '''return list of all tests'''
         ret = super(AutoTestRover, self).tests()
@@ -7045,6 +7070,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             self.ClearMission,
             self.JammingSimulation,
             self.BatteryInvalid,
+            self.REQUIRE_POSITION_FOR_ARMING,
         ])
         return ret
 

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6947,7 +6947,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
         self.delay_sim_time(1000)
 
-    def REQUIRE_POSITION_FOR_ARMING(self):
+    def REQUIRE_LOCATION_FOR_ARMING(self):
         '''check DriveOption::REQUIRE_POSITION_FOR_ARMING works'''
         self.context_push()
         self.set_parameters({
@@ -6966,7 +6966,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
         self.change_mode('MANUAL')
         self.set_parameters({
-            "DRIVE_OPTIONS": 1,
+            "ARMING_NEED_LOC": 1,
         })
         self.assert_prearm_failure("waiting for home", other_prearm_failures_fatal=False)
         self.context_pop()
@@ -7070,7 +7070,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             self.ClearMission,
             self.JammingSimulation,
             self.BatteryInvalid,
-            self.REQUIRE_POSITION_FOR_ARMING,
+            self.REQUIRE_LOCATION_FOR_ARMING,
         ])
         return ret
 

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -3625,6 +3625,16 @@ class TestSuite(ABC):
             if bytes1[i] != bytes2[i]:
                 raise NotAchievedException("differ at offset %u" % i)
 
+    def assert_home_position_not_set(self):
+        try:
+            self.poll_home_position()
+        except NotAchievedException:
+            return
+
+        # if home.lng != 0: etc
+
+        raise NotAchievedException("Home is set when it shouldn't be")
+
     def HIGH_LATENCY2(self):
         '''test sending of HIGH_LATENCY2'''
 
@@ -8360,8 +8370,8 @@ class TestSuite(ABC):
             now = self.get_sim_time_cached()
             if now - tstart > timeout:
                 raise NotAchievedException(
-                    "Did not see failure-to-arm messages (statustext=%s command_ack=%s" %
-                    (seen_statustext, seen_command_ack))
+                    f"Did not see failure-to-arm messages ({seen_statustext=} {expected_statustext=} {seen_command_ack=})"
+                )
             if now - arm_last_send > 1:
                 arm_last_send = now
                 self.send_mavlink_run_prearms_command()

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -191,7 +191,7 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     // @DisplayName: Require vehicle location
     // @Description: Require that the vehicle have an absolute position before it arms.  This can help ensure that the vehicle can Return To Launch.
     // @User: Advanced
-    // @Values{Copter}: 0:Do not require location,1:Require Location
+    // @Values{Copter,Rover}: 0:Do not require location,1:Require Location
     AP_GROUPINFO("NEED_LOC", 12, AP_Arming, require_location, float(AP_ARMING_NEED_LOC_DEFAULT)),
 #endif  // AP_ARMING_NEED_LOC_PARAMETER_ENABLED
 

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -89,7 +89,7 @@
 // whether the parameter should be shown:
 #ifndef AP_ARMING_NEED_LOC_PARAMETER_ENABLED
 // determine whether ARMING_NEED_POS is shown:
-#if APM_BUILD_COPTER_OR_HELI
+#if APM_BUILD_COPTER_OR_HELI || APM_BUILD_TYPE(APM_BUILD_Rover)
 #define AP_ARMING_NEED_LOC_PARAMETER_ENABLED 1
 #else
 #define AP_ARMING_NEED_LOC_PARAMETER_ENABLED 0
@@ -98,7 +98,7 @@
 
 // if ARMING_NEED_POS is shown, determine what its default should be:
 #if AP_ARMING_NEED_LOC_PARAMETER_ENABLED
-#if APM_BUILD_COPTER_OR_HELI
+#if APM_BUILD_COPTER_OR_HELI || APM_BUILD_TYPE(APM_BUILD_Rover)
 #define AP_ARMING_NEED_LOC_DEFAULT 0
 #else
 #error "Unable to find value for AP_ARMING_NEED_LOC_DEFAULT"


### PR DESCRIPTION
Extracted from https://github.com/ArduPilot/ardupilot/pull/29066 as it's really a separate feature

Tested in SITL, including autotest
