### PR TITLE
CANManager, Mount, OpticalFlow, Proximity, SerialManager: alphabetise protocol and type param values

### DIFF
--- a/Tools/autotest/param_metadata/xmlemit.py
+++ b/Tools/autotest/param_metadata/xmlemit.py
@@ -69,9 +69,12 @@ class XmlEmit(Emit):
         keys = nv_pairs.keys()
         def sort_key(value):
             description = nv_pairs[value]
-            if zero_at_top and value == "0":
-                # make sure this item goes at the top of the list:
-                return "AAAAAAA"
+            if zero_at_top:
+                # make sure -1 and 0 appear at the top of the list
+                if value == "-1":
+                    return "0000000"
+                if value == "0":
+                    return "0000001"
             return description
         return sorted(keys, key=sort_key)
 

--- a/libraries/AP_CANManager/AP_CANManager_CANDriver_Params.cpp
+++ b/libraries/AP_CANManager/AP_CANManager_CANDriver_Params.cpp
@@ -27,6 +27,7 @@ const AP_Param::GroupInfo AP_CANManager::CANDriver_Params::var_info[] = {
     // @Param: PROTOCOL
     // @DisplayName: Enable use of specific protocol over virtual driver
     // @Description: Enabling this option starts selected protocol that will use this virtual driver
+    // @SortValues: AlphabeticalZeroAtTop
     // @Values: 0:Disabled,1:DroneCAN,4:PiccoloCAN,6:EFI_NWPMU,7:USD1,8:KDECAN,10:Scripting,11:Benewake,12:Scripting2,13:TOFSenseP,14:NanoRadar
     // @User: Advanced
     // @RebootRequired: True
@@ -51,6 +52,7 @@ const AP_Param::GroupInfo AP_CANManager::CANDriver_Params::var_info[] = {
     // @Param: PROTOCOL2
     // @DisplayName: Secondary protocol with 11 bit CAN addressing
     // @Description: Secondary protocol with 11 bit CAN addressing
+    // @SortValues: AlphabeticalZeroAtTop
     // @Values: 0:Disabled,7:USD1,10:Scripting,11:Benewake,12:Scripting2,13:TOFSenseP,14:NanoRadar
     // @User: Advanced
     // @RebootRequired: True

--- a/libraries/AP_Mount/AP_Mount_Params.cpp
+++ b/libraries/AP_Mount/AP_Mount_Params.cpp
@@ -9,6 +9,7 @@ const AP_Param::GroupInfo AP_Mount_Params::var_info[] = {
     // @Param: _TYPE
     // @DisplayName: Mount Type
     // @Description: Mount Type
+    // @SortValues: AlphabeticalZeroAtTop
     // @Values: 0:None, 1:Servo, 2:3DR Solo, 3:Alexmos Serial, 4:SToRM32 MAVLink, 5:SToRM32 Serial, 6:Gremsy, 7:BrushlessPWM, 8:Siyi, 9:Scripting, 10:Xacti, 11:Viewpro, 12:Topotek, 13:CADDX
     // @RebootRequired: True
     // @User: Standard

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow.cpp
@@ -26,6 +26,7 @@ const AP_Param::GroupInfo AP_OpticalFlow::var_info[] = {
     // @Param: _TYPE
     // @DisplayName: Optical flow sensor type
     // @Description: Optical flow sensor type
+    // @SortValues: AlphabeticalZeroAtTop
     // @Values: 0:None, 1:PX4Flow, 2:Pixart, 3:Bebop, 4:CXOF, 5:MAVLink, 6:DroneCAN, 7:MSP, 8:UPFLOW
     // @User: Standard
     // @RebootRequired: True

--- a/libraries/AP_Proximity/AP_Proximity_Params.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Params.cpp
@@ -8,6 +8,7 @@ const AP_Param::GroupInfo AP_Proximity_Params::var_info[] = {
     // @Param: _TYPE
     // @DisplayName: Proximity type
     // @Description: What type of proximity sensor is connected
+    // @SortValues: AlphabeticalZeroAtTop
     // @Values: 0:None,7:LightwareSF40c,2:MAVLink,3:TeraRangerTower,4:RangeFinder,5:RPLidarA2,6:TeraRangerTowerEvo,8:LightwareSF45B,10:SITL,12:AirSimSITL,13:CygbotD1, 14:DroneCAN, 15:Scripting, 16:LD06, 17: MR72_CAN
     // @RebootRequired: True
     // @User: Standard

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -183,6 +183,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] = {
     // @Param: 1_PROTOCOL
     // @DisplayName: Telem1 protocol selection
     // @Description: Control what protocol to use on the Telem1 port. Note that the Frsky options require external converter hardware. See the wiki for details.
+    // @SortValues: AlphabeticalZeroAtTop
     // @Values: -1:None, 1:MAVLink1, 2:MAVLink2, 3:Frsky D, 4:Frsky SPort, 5:GPS, 7:Alexmos Gimbal Serial, 8:Gimbal, 9:Rangefinder, 10:FrSky SPort Passthrough (OpenTX), 11:Lidar360, 13:Beacon, 14:Volz servo out, 15:SBus servo out, 16:ESC Telemetry, 17:Devo Telemetry, 18:OpticalFlow, 19:RobotisServo, 20:NMEA Output, 21:WindVane, 22:SLCAN, 23:RCIN, 24:EFI Serial, 25:LTM, 26:RunCam, 27:HottTelem, 28:Scripting, 29:Crossfire VTX, 30:Generator, 31:Winch, 32:MSP, 33:DJI FPV, 34:AirSpeed, 35:ADSB, 36:AHRS, 37:SmartAudio, 38:FETtecOneWire, 39:Torqeedo, 40:AIS, 41:CoDevESC, 42:DisplayPort, 43:MAVLink High Latency, 44:IRC Tramp, 45:DDS XRCE, 46:IMUDATA, 48:PPP
     // @User: Standard
     // @RebootRequired: True


### PR DESCRIPTION
This makes a small improvement in user usability by alphabetising the _PROTOCOL and _TYPE values displayed to users in GCS drop-downs.  This does not affect the order displayed in the wiki pages

This change has been tested by running, "./Tools/autotest/autotest.py build.Copter test.Copter.Parameters" and reviewing the output of the "buildlogs/apm.pdef.xml" file before and after.

The only downside of this change is perhaps that sometimes the most common items are no longer near the top.  So for example, with the SERIALx_PROTOCOL parameter, MAVLink2 is in the middle instead of at the top.  If we think this is an issue then I'm happy to manually resort them.  Personally I think the purely alphabetical order is fine but I don't feel strongly about it

Below are the changes found:

- CAN_D1_PROTOCOL, CAN_D2_PROTOCOL

          <value code="0">Disabled</value>
          <value code="11">Benewake</value>
          <value code="1">DroneCAN</value>
          <value code="6">EFI_NWPMU</value>
          <value code="8">KDECAN</value>
          <value code="14">NanoRadar</value>
          <value code="4">PiccoloCAN</value>
          <value code="10">Scripting</value>
          <value code="12">Scripting2</value>
          <value code="13">TOFSenseP</value>
          <value code="7">USD1</value>

- CAN_D1_PROTOCOL2, CAN_D3_PROTOCOL

          <value code="0">Disabled</value>
          <value code="11">Benewake</value>
          <value code="14">NanoRadar</value>
          <value code="10">Scripting</value>
          <value code="12">Scripting2</value>
          <value code="13">TOFSenseP</value>
          <value code="7">USD1</value>

- FLOW_TYPE

          <value code="0">None</value>
          <value code="3">Bebop</value>
          <value code="4">CXOF</value>
          <value code="6">DroneCAN</value>
          <value code="5">MAVLink</value>
          <value code="7">MSP</value>
          <value code="1">PX4Flow</value>
          <value code="2">Pixart</value>
          <value code="8">UPFLOW</value>

- MNT1_TYPE, MNT2_TYPE

          <value code="0">None</value>
          <value code="2">3DR Solo</value>
          <value code="3">Alexmos Serial</value>
          <value code="7">BrushlessPWM</value>
          <value code="13">CADDX</value>
          <value code="6">Gremsy</value>
          <value code="4">SToRM32 MAVLink</value>
          <value code="5">SToRM32 Serial</value>
          <value code="9">Scripting</value>
          <value code="1">Servo</value>
          <value code="8">Siyi</value>
          <value code="12">Topotek</value>
          <value code="11">Viewpro</value>
          <value code="10">Xacti</value>

- PRX1_TYPE, PRX2_TYPE, PRX3_TYPE, PRX4_TYPE

          <value code="0">None</value>
          <value code="12">AirSimSITL</value>
          <value code="13">CygbotD1</value>
          <value code="14">DroneCAN</value>
          <value code="16">LD06</value>
          <value code="7">LightwareSF40c</value>
          <value code="8">LightwareSF45B</value>
          <value code="2">MAVLink</value>
          <value code="17">MR72_CAN</value>
          <value code="5">RPLidarA2</value>
          <value code="4">RangeFinder</value>
          <value code="10">SITL</value>
          <value code="15">Scripting</value>
          <value code="3">TeraRangerTower</value>
          <value code="6">TeraRangerTowerEvo</value>

- CAN_D1_UC_S1_PRO, CAN_D1_UC_S2_PRO, CAN_D1_UC_S3_PRO, CAN_D2_UC_S1_PRO, CAN_D2_UC_S2_PRO, CAN_D2_UC_S3_PRO, CAN_D3_UC_S1_PRO, CAN_D3_UC_S2_PRO, CAN_D3_UC_S3_PRO, NET_P1_PROTOCOL, NET_P2_PROTOCOL, NET_P3_PROTOCOL, NET_P4_PROTOCOL, SCR_SDEV1_PROTO, SCR_SDEV2_PROTO, SCR_SDEV3_PROTO, SERIAL1_PROTOCOL, SERIAL1_PROTOCOL, SERIAL2_PROTOCOL, SERIAL3_PROTOCOL, SERIAL4_PROTOCOL, SERIAL5_PROTOCOL, SERIAL6_PROTOCOL, SERIAL7_PROTOCOL,  SERIAL8_PROTOCOL, SERIAL9_PROTOCOL

          <value code="-1">None</value>
          <value code="35">ADSB</value>
          <value code="36">AHRS</value>
          <value code="40">AIS</value>
          <value code="34">AirSpeed</value>
          <value code="7">Alexmos Gimbal Serial</value>
          <value code="13">Beacon</value>
          <value code="41">CoDevESC</value>
          <value code="29">Crossfire VTX</value>
          <value code="45">DDS XRCE</value>
          <value code="33">DJI FPV</value>
          <value code="17">Devo Telemetry</value>
          <value code="42">DisplayPort</value>
          <value code="24">EFI Serial</value>
          <value code="16">ESC Telemetry</value>
          <value code="38">FETtecOneWire</value>
          <value code="10">FrSky SPort Passthrough (OpenTX)</value>
          <value code="3">Frsky D</value>
          <value code="4">Frsky SPort</value>
          <value code="5">GPS</value>
          <value code="30">Generator</value>
          <value code="8">Gimbal</value>
          <value code="27">HottTelem</value>
          <value code="46">IMUDATA</value>
          <value code="44">IRC Tramp</value>
          <value code="25">LTM</value>
          <value code="11">Lidar360</value>
          <value code="43">MAVLink High Latency</value>
          <value code="1">MAVLink1</value>
          <value code="2">MAVLink2</value>
          <value code="32">MSP</value>
          <value code="20">NMEA Output</value>
          <value code="18">OpticalFlow</value>
          <value code="48">PPP</value>
          <value code="23">RCIN</value>
          <value code="9">Rangefinder</value>
          <value code="19">RobotisServo</value>
          <value code="26">RunCam</value>
          <value code="15">SBus servo out</value>
          <value code="22">SLCAN</value>
          <value code="28">Scripting</value>
          <value code="37">SmartAudio</value>
          <value code="39">Torqeedo</value>
          <value code="14">Volz servo out</value>
          <value code="31">Winch</value>
          <value code="21">WindVane</value>

Note: the parameter sorting feature doesn't appear to work with GPS1_TYPE and GPS2_TYPE so I've removed that change from the PR