### PR TITLE
gitignore: Add correct crash dump patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,7 +151,8 @@ segv_*out
 /ArduSub/scripts/
 /ArduSub/repl/
 persistent.dat
-dumpstack_*out
+dumpstack*out
+dumpcore*out
 build.tmp.binaries/
 tasklist.json
 modules/esp_idf


### PR DESCRIPTION
Adds pattern for core dumps and makes existing pattern for stack dumps more lenient, as depending on the environment they could be generated with a filename the old pattern didn't match