### PR TITLE
Plane: Add fwd. throttle cutoff voltage parameter

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1309,7 +1309,16 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("RNGFND_LND_ORNT", 36, ParametersG2, rangefinder_land_orient, ROTATION_PITCH_270),
 #endif
-    
+
+    // @Param: FWD_BAT_THR_CUT
+    // @DisplayName: Forward throttle cutoff battery voltage
+    // @Description: The estimated battery resting voltage below which the throttle is cut in auto-throttle modes. Measured on the battery used for forward throttle compensation (FWD_BAT_IDX). If set to zero, the throttle will not be cut due to low voltage, allowing the motor(s) to continue running until the battery is depleted. This should be set to the minimum operating voltage of you motor(s) or to a voltage level where minimal thrust is produced, to conserve the remaining battery power for the electronics and actuators.
+    // @Range: 0 35
+    // @Units: V
+    // @Increment: 0.1
+    // @User: Standard
+    AP_GROUPINFO("FWD_BAT_THR_CUT", 37, ParametersG2, fwd_batt_cmp.batt_voltage_throttle_cutoff, 0.0f),
+
     AP_GROUPEND
 };
 

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -556,6 +556,7 @@ public:
 
         AP_Float batt_voltage_max;
         AP_Float batt_voltage_min;
+        AP_Float batt_voltage_throttle_cutoff;
         AP_Int8  batt_idx;
 
     private:


### PR DESCRIPTION
# Plane: Add fwd. throttle cutoff voltage parameter

Updated the forward throttle battery voltage compensation feature to disable the throttle entirely when the sag-compensated voltage drops below the new parameter FWD_BAT_THR_CUT.

Key changes:
- Added new parameter FWD_BAT_THR_CUT to control the voltage threshold for this feature. The default value of 0 matches the original behavior of never cutting the throttle due to low voltage.
- Modified forward throttle battery voltage compensation logic in the servos code to cut off the throttle if the resting voltage estimate of the FWD_BAT_IDX battery is under FWD_BAT_THR_CUT.