### PR TITLE
Add and use AP_MotorMask

### DIFF
--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -336,7 +336,7 @@ void Tailsitter::output(void)
 
         if (!quadplane.assisted_flight) {
             // set AP_MotorsMatrix throttles for forward flight
-            motors->output_motor_mask(throttle, motor_mask, plane.rudder_dt);
+            motors->output_motor_mask(throttle, AP_MotorMask(motor_mask.get()), plane.rudder_dt);
 
             // No tilt output unless forward gain is set
             float tilt_left = 0.0;

--- a/ArduPlane/tiltrotor.cpp
+++ b/ArduPlane/tiltrotor.cpp
@@ -245,7 +245,7 @@ void Tiltrotor::continuous_update(void)
         }
         if (!quadplane.motor_test.running) {
             // the motors are all the way forward, start using them for fwd thrust
-            const uint16_t mask = is_zero(current_throttle)?0U:tilt_mask.get();
+            const AP_MotorMask mask = is_zero(current_throttle) ? 0U : tilt_mask.get();
             motors->output_motor_mask(current_throttle, mask, plane.rudder_dt);
         }
         return;
@@ -365,7 +365,7 @@ void Tiltrotor::binary_update(void)
 
         float new_throttle = SRV_Channels::get_output_scaled(SRV_Channel::k_throttle)*0.01f;
         if (current_tilt >= 1) {
-            const uint16_t mask = is_zero(new_throttle)?0U:tilt_mask.get();
+            AP_MotorMask mask = is_zero(new_throttle) ? 0 : tilt_mask.get();
             // the motors are all the way forward, start using them for fwd thrust
             motors->output_motor_mask(new_throttle, mask, plane.rudder_dt);
         }

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -740,7 +740,7 @@ void AP_MotorsMulticopter::set_throttle_passthrough_for_esc_calibration(float th
 // output a thrust to all motors that match a given motor mask. This
 // is used to control tiltrotor motors in forward flight. Thrust is in
 // the range 0 to 1
-void AP_MotorsMulticopter::output_motor_mask(float thrust, uint16_t mask, float rudder_dt)
+void AP_MotorsMulticopter::output_motor_mask(float thrust, AP_MotorMask mask, float rudder_dt)
 {
     const int16_t pwm_min = get_pwm_output_min();
     const int16_t pwm_range = get_pwm_output_max() - pwm_min;

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -60,7 +60,7 @@ public:
     // output a thrust to all motors that match a given motor
     // mask. This is used to control tiltrotor motors in forward
     // flight. Thrust is in the range 0 to 1
-    virtual void        output_motor_mask(float thrust, uint16_t mask, float rudder_dt);
+    virtual void        output_motor_mask(float thrust, AP_MotorMask mask, float rudder_dt);
 
     // get_motor_mask - returns a bitmask of which outputs are being used for motors (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
@@ -204,5 +204,5 @@ protected:
     }
 
     // mask of overridden motors (used by quadplane tiltrotors)
-    uint16_t _motor_mask_override;
+    AP_MotorMask _motor_mask_override;
 };

--- a/libraries/AP_Motors/AP_MotorsTri.cpp
+++ b/libraries/AP_Motors/AP_MotorsTri.cpp
@@ -351,7 +351,7 @@ void AP_MotorsTri::thrust_compensation(void)
 /*
   override tricopter tail servo output in output_motor_mask
  */
-void AP_MotorsTri::output_motor_mask(float thrust, uint16_t mask, float rudder_dt)
+void AP_MotorsTri::output_motor_mask(float thrust, AP_MotorMask mask, float rudder_dt)
 {
     // normal multicopter output
     AP_MotorsMulticopter::output_motor_mask(thrust, mask, rudder_dt);

--- a/libraries/AP_Motors/AP_MotorsTri.h
+++ b/libraries/AP_Motors/AP_MotorsTri.h
@@ -42,7 +42,7 @@ public:
     // mask. This is used to control tiltrotor motors in forward
     // flight. Thrust is in the range 0 to 1
     // rudder_dt applys diffential thrust for yaw in the range 0 to 1
-    void                output_motor_mask(float thrust, uint16_t mask, float rudder_dt) override;
+    void                output_motor_mask(float thrust, AP_MotorMask mask, float rudder_dt) override;
 
     // return the roll factor of any motor, this is used for tilt rotors and tail sitters
     // using copter motors for forward flight

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -52,17 +52,18 @@
 // motor update rate
 #define AP_MOTORS_SPEED_DEFAULT     490 // default output rate to the motors
 
-class AP_MotorMask16 {
-public:
-    AP_MotorMask16() {}
-    AP_MotorMask16(const short int value) { mask = value; }
-    bool operator &(uint16_t value) const { return mask & value; }
-    void operator =(uint16_t value) { mask = value; }
-    void operator |=(uint16_t value) { mask |= value; }
-    uint16_t mask;
-};
+// a class that AP_MotorMask can be typedef'd to to ensure type-safety:
+// class AP_MotorMask16 {
+// public:
+//     AP_MotorMask16() {}
+//     AP_MotorMask16(const short int value) { mask = value; }
+//     bool operator &(uint16_t value) const { return mask & value; }
+//     void operator =(uint16_t value) { mask = value; }
+//     void operator |=(uint16_t value) { mask |= value; }
+//     uint16_t mask;
+// };
 
-typedef AP_MotorMask16 AP_MotorMask;
+typedef uint16_t AP_MotorMask;
 
 /// @class      AP_Motors
 class AP_Motors {

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -52,6 +52,18 @@
 // motor update rate
 #define AP_MOTORS_SPEED_DEFAULT     490 // default output rate to the motors
 
+class AP_MotorMask16 {
+public:
+    AP_MotorMask16() {}
+    AP_MotorMask16(const short int value) { mask = value; }
+    bool operator &(uint16_t value) const { return mask & value; }
+    void operator =(uint16_t value) { mask = value; }
+    void operator |=(uint16_t value) { mask |= value; }
+    uint16_t mask;
+};
+
+typedef AP_MotorMask16 AP_MotorMask;
+
 /// @class      AP_Motors
 class AP_Motors {
 public:


### PR DESCRIPTION
@IamPete1 suggested on https://github.com/ArduPilot/ardupilot/pull/29020 that the output mask had to be adjusted for 32 motors.

This PR is two phases - the first moves the API to use a typedef rather than uint16_t for the mask.  It typedefs that new type to a class, so that a type error is raised if anyone tries to pass a uint16_t into the function.

The second patch just typedefs it back to 16, making this PR a no-compiler-output change:
```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                 *                                                   
CubeRedPrimary                      *      *           *       *                 *      *      *
Durandal                            *      *           *       *                 *      *      *
Hitec-Airspeed           *                 *                                                   
KakuteH7-bdshot                     *      *           *       *                 *      *      *
MatekF405                           *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *                  *       *                 *      *      *
f103-QiotekPeriph        *                 *                                                   
f303-Universal           *                 *                                                   
iomcu                                                                *                         
revo-mini                           *      *           *       *                 *      *      *
skyviper-journey                                       *                                       
skyviper-v2450                                         *                                       
```

This will allow us to move to 32 (or 64?! as hinted at in a DevCall) relatively easily.
