### PR TITLE
Rename SRV_Channel::Aux_servo_function_t to SRV_Channel::Function

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1182,8 +1182,8 @@ private:
     void throttle_slew_limit();
     bool suppress_throttle(void);
     void update_throttle_hover();
-    void channel_function_mixer(SRV_Channel::Aux_servo_function_t func1_in, SRV_Channel::Aux_servo_function_t func2_in,
-                                SRV_Channel::Aux_servo_function_t func1_out, SRV_Channel::Aux_servo_function_t func2_out) const;
+    void channel_function_mixer(SRV_Channel::Function func1_in, SRV_Channel::Function func2_in,
+                                SRV_Channel::Function func1_out, SRV_Channel::Function func2_out) const;
     void flaperon_update();
     void indicate_waiting_for_rud_neutral_to_takeoff(void);
 

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -173,8 +173,8 @@ bool Plane::suppress_throttle(void)
   allowing the user to trim and limit individual servos using the
   SERVOn_* parameters
  */
-void Plane::channel_function_mixer(SRV_Channel::Aux_servo_function_t func1_in, SRV_Channel::Aux_servo_function_t func2_in,
-                                   SRV_Channel::Aux_servo_function_t func1_out, SRV_Channel::Aux_servo_function_t func2_out) const
+void Plane::channel_function_mixer(SRV_Channel::Function func1_in, SRV_Channel::Function func2_in,
+                                   SRV_Channel::Function func1_out, SRV_Channel::Function func2_out) const
 {
     // the order is setup so that non-reversed servos go "up", and
     // func1 is the "left" channel. Users can adjust with channel

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -470,10 +470,10 @@ void Tailsitter::output(void)
     SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, tilt_right);
 
     // Check for saturated limits
-    bool tilt_lim = _is_vectored && ((fabsf(SRV_Channels::get_output_scaled(SRV_Channel::Aux_servo_function_t::k_tiltMotorLeft)) >= SERVO_MAX) || (fabsf(SRV_Channels::get_output_scaled(SRV_Channel::Aux_servo_function_t::k_tiltMotorRight)) >= SERVO_MAX));
-    bool roll_lim = _have_rudder && (fabsf(SRV_Channels::get_output_scaled(SRV_Channel::Aux_servo_function_t::k_rudder)) >= SERVO_MAX);
-    bool pitch_lim = _have_elevator && (fabsf(SRV_Channels::get_output_scaled(SRV_Channel::Aux_servo_function_t::k_elevator)) >= SERVO_MAX);
-    bool yaw_lim = _have_aileron && (fabsf(SRV_Channels::get_output_scaled(SRV_Channel::Aux_servo_function_t::k_aileron)) >= SERVO_MAX);
+    bool tilt_lim = _is_vectored && ((fabsf(SRV_Channels::get_output_scaled(SRV_Channel::Function::k_tiltMotorLeft)) >= SERVO_MAX) || (fabsf(SRV_Channels::get_output_scaled(SRV_Channel::Function::k_tiltMotorRight)) >= SERVO_MAX));
+    bool roll_lim = _have_rudder && (fabsf(SRV_Channels::get_output_scaled(SRV_Channel::Function::k_rudder)) >= SERVO_MAX);
+    bool pitch_lim = _have_elevator && (fabsf(SRV_Channels::get_output_scaled(SRV_Channel::Function::k_elevator)) >= SERVO_MAX);
+    bool yaw_lim = _have_aileron && (fabsf(SRV_Channels::get_output_scaled(SRV_Channel::Function::k_aileron)) >= SERVO_MAX);
 
     // Mix elevons and V-tail, always giving full priority to pitch
     float elevator_mix = SRV_Channels::get_output_scaled(SRV_Channel::k_elevator) * (100.0 - plane.g.mixing_offset) * 0.01 * plane.g.mixing_gain;
@@ -763,15 +763,15 @@ void Tailsitter::speed_scaling(void)
         spd_scaler /= quadplane.ahrs.get_air_density_ratio();
     }
 
-    const SRV_Channel::Aux_servo_function_t functions[] = {
-        SRV_Channel::Aux_servo_function_t::k_aileron,
-        SRV_Channel::Aux_servo_function_t::k_elevator,
-        SRV_Channel::Aux_servo_function_t::k_rudder,
-        SRV_Channel::Aux_servo_function_t::k_tiltMotorLeft,
-        SRV_Channel::Aux_servo_function_t::k_tiltMotorRight};
+    const SRV_Channel::Function functions[] = {
+        SRV_Channel::Function::k_aileron,
+        SRV_Channel::Function::k_elevator,
+        SRV_Channel::Function::k_rudder,
+        SRV_Channel::Function::k_tiltMotorLeft,
+        SRV_Channel::Function::k_tiltMotorRight};
     for (uint8_t i=0; i<ARRAY_SIZE(functions); i++) {
         float v = SRV_Channels::get_output_scaled(functions[i]);
-        if ((functions[i] == SRV_Channel::Aux_servo_function_t::k_tiltMotorLeft) || (functions[i] == SRV_Channel::Aux_servo_function_t::k_tiltMotorRight)) {
+        if ((functions[i] == SRV_Channel::Function::k_tiltMotorLeft) || (functions[i] == SRV_Channel::Function::k_tiltMotorRight)) {
             // always apply throttle scaling to tilts
             v *= throttle_scaler;
         } else {

--- a/Tools/AP_Periph/rc_out.cpp
+++ b/Tools/AP_Periph/rc_out.cpp
@@ -48,12 +48,12 @@ void AP_Periph_FW::rcout_init()
 
 #if HAL_PWM_COUNT > 0
     for (uint8_t i=0; i<HAL_PWM_COUNT; i++) {
-        servo_channels.set_default_function(i, SRV_Channel::Aux_servo_function_t(SRV_Channel::k_rcin1 + i));
+        servo_channels.set_default_function(i, SRV_Channel::Function(SRV_Channel::k_rcin1 + i));
     }
 #endif
 
     for (uint8_t i=0; i<SERVO_OUT_RCIN_MAX; i++) {
-        SRV_Channels::set_angle(SRV_Channel::Aux_servo_function_t(SRV_Channel::k_rcin1 + i), 1000);
+        SRV_Channels::set_angle(SRV_Channel::Function(SRV_Channel::k_rcin1 + i), 1000);
     }
 
     uint32_t esc_mask = 0;
@@ -113,7 +113,7 @@ void AP_Periph_FW::rcout_esc(int16_t *rc, uint8_t num_channels)
 void AP_Periph_FW::rcout_srv_unitless(uint8_t actuator_id, const float command_value)
 {
 #if HAL_PWM_COUNT > 0
-    const SRV_Channel::Aux_servo_function_t function = SRV_Channel::Aux_servo_function_t(SRV_Channel::k_rcin1 + actuator_id - 1);
+    const SRV_Channel::Function function = SRV_Channel::Function(SRV_Channel::k_rcin1 + actuator_id - 1);
     SRV_Channels::set_output_norm(function, command_value);
 
     rcout_has_new_data_to_update = true;
@@ -126,7 +126,7 @@ void AP_Periph_FW::rcout_srv_unitless(uint8_t actuator_id, const float command_v
 void AP_Periph_FW::rcout_srv_PWM(uint8_t actuator_id, const float command_value)
 {
 #if HAL_PWM_COUNT > 0
-    const SRV_Channel::Aux_servo_function_t function = SRV_Channel::Aux_servo_function_t(SRV_Channel::k_rcin1 + actuator_id - 1);
+    const SRV_Channel::Function function = SRV_Channel::Function(SRV_Channel::k_rcin1 + actuator_id - 1);
     SRV_Channels::set_output_pwm(function, uint16_t(command_value+0.5));
 
     rcout_has_new_data_to_update = true;
@@ -204,7 +204,7 @@ void AP_Periph_FW::sim_update_actuator(uint8_t actuator_id)
         if ((sim_actuator.mask & (1U<<i)) == 0) {
             continue;
         }
-        const SRV_Channel::Aux_servo_function_t function = SRV_Channel::Aux_servo_function_t(SRV_Channel::k_rcin1 + i);
+        const SRV_Channel::Function function = SRV_Channel::Function(SRV_Channel::k_rcin1 + i);
         uavcan_equipment_actuator_Status pkt {};
         pkt.actuator_id = i;
         // assume 45 degree angle for simulation

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -949,7 +949,7 @@ bool AP_Arming::servo_checks(bool report) const
 
         // check functions using PWM are enabled
         if (SRV_Channels::get_disabled_channel_mask() & 1U<<i) {
-            const SRV_Channel::Aux_servo_function_t ch_function = c->get_function();
+            const SRV_Channel::Function ch_function = c->get_function();
 
             // motors, e-stoppable functions, neopixels and ProfiLEDs may be digital outputs and thus can be disabled
             // scripting can use its functions as labels for LED setup

--- a/libraries/AP_ICEngine/AP_ICEngine.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine.cpp
@@ -239,7 +239,7 @@ void AP_ICEngine::param_conversion()
     // Conversion table giving the old on and off pwm parameter indexes and the function for both starter and ignition
     const struct convert_table {
         uint32_t element[2];
-        SRV_Channel::Aux_servo_function_t fuction;
+        SRV_Channel::Function fuction;
     } conversion_table[] = {
         { {450, 514}, SRV_Channel::k_starter },  // PWM_STRT_ON, PWM_STRT_OFF
         { {322, 386}, SRV_Channel::k_ignition }, // PWM_IGN_ON, PWM_IGN_OFF

--- a/libraries/AP_IOMCU/iofirmware/mixer.cpp
+++ b/libraries/AP_IOMCU/iofirmware/mixer.cpp
@@ -142,7 +142,7 @@ void AP_IOMCU_FW::run_mixer(void)
     }
 
     for (uint8_t i=0; i<IOMCU_MAX_RC_CHANNELS; i++) {
-        SRV_Channel::Aux_servo_function_t function = (SRV_Channel::Aux_servo_function_t)mixing.servo_function[i];
+        SRV_Channel::Function function = (SRV_Channel::Function)mixing.servo_function[i];
         uint16_t &pwm = reg_direct_pwm.pwm[i];
 
         if (mixing.manual_rc_mask & (1U<<i)) {

--- a/libraries/AP_KDECAN/AP_KDECAN.cpp
+++ b/libraries/AP_KDECAN/AP_KDECAN.cpp
@@ -161,7 +161,7 @@ void AP_KDECAN_Driver::update(const uint8_t num_poles)
     
     WITH_SEMAPHORE(_output.sem);
     for (uint8_t i = 0; i < ARRAY_SIZE(_output.pwm); i++) {
-        if ((_init.detected_bitmask & (1UL<<i)) == 0 || SRV_Channels::channel_function(i) <= SRV_Channel::Aux_servo_function_t::k_none) {
+        if ((_init.detected_bitmask & (1UL<<i)) == 0 || SRV_Channels::channel_function(i) <= SRV_Channel::Function::k_none) {
             _output.pwm[i] = 0;
             continue;
         }

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -22,7 +22,7 @@ public:
     friend class AP_MotorsHeli_Dual;
     friend class AP_MotorsHeli_Quad;
 
-    AP_MotorsHeli_RSC(SRV_Channel::Aux_servo_function_t aux_fn,
+    AP_MotorsHeli_RSC(SRV_Channel::Function aux_fn,
                       uint8_t default_channel,
                       uint8_t inst) :
         _instance(inst),
@@ -117,7 +117,7 @@ private:
     const uint8_t   _instance;
 
     // channel setup for aux function
-    const SRV_Channel::Aux_servo_function_t _aux_fn;
+    const SRV_Channel::Function _aux_fn;
     const uint8_t _default_channel;
 
     // internal variables

--- a/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
@@ -198,7 +198,7 @@ void AP_MotorsHeli_Swash::add_servo_raw(uint8_t num, float roll, float pitch, fl
     _collectiveFactor[num] = collective;
 
     // Setup output function
-    SRV_Channel::Aux_servo_function_t function = SRV_Channels::get_motor_function(_motor_num[num]);
+    SRV_Channel::Function function = SRV_Channels::get_motor_function(_motor_num[num]);
     SRV_Channels::set_aux_channel_default(function, _motor_num[num]);
 
     // outputs are defined on a -500 to 500 range for swash servos
@@ -272,7 +272,7 @@ void AP_MotorsHeli_Swash::output()
 void AP_MotorsHeli_Swash::rc_write(uint8_t chan, float swash_in)
 {
     uint16_t pwm = (uint16_t)(1500 + 500 * swash_in);
-    SRV_Channel::Aux_servo_function_t function = SRV_Channels::get_motor_function(chan);
+    SRV_Channel::Function function = SRV_Channels::get_motor_function(chan);
     SRV_Channels::set_output_pwm_trimmed(function, pwm);
 }
 

--- a/libraries/AP_Motors/AP_MotorsMatrix_6DoF_Scripting.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix_6DoF_Scripting.cpp
@@ -261,7 +261,7 @@ void AP_MotorsMatrix_6DoF_Scripting::add_motor(int8_t motor_num, float roll_fact
         _test_order[motor_num] = testing_order;
 
         // ensure valid motor number is provided
-        SRV_Channel::Aux_servo_function_t function = SRV_Channels::get_motor_function(motor_num);
+        SRV_Channel::Function function = SRV_Channels::get_motor_function(motor_num);
         SRV_Channels::set_aux_channel_default(function, motor_num);
 
         uint8_t chan;

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -806,7 +806,7 @@ bool AP_MotorsMulticopter::arming_checks(size_t buflen, char *buffer) const
             continue;
         }
         uint8_t chan;
-        SRV_Channel::Aux_servo_function_t function = SRV_Channels::get_motor_function(i);
+        SRV_Channel::Function function = SRV_Channels::get_motor_function(i);
         if (!SRV_Channels::find_channel(function, chan)) {
             hal.util->snprintf(buffer, buflen, "no SERVOx_FUNCTION set to Motor%u", i + 1);
             return false;

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -104,7 +104,7 @@ void AP_Motors::set_radio_passthrough(float roll_input, float pitch_input, float
  */
 void AP_Motors::rc_write(uint8_t chan, uint16_t pwm)
 {
-    SRV_Channel::Aux_servo_function_t function = SRV_Channels::get_motor_function(chan);
+    SRV_Channel::Function function = SRV_Channels::get_motor_function(chan);
     if ((1U<<chan) & _motor_pwm_scaled.mask) {
         // note that PWM_MIN/MAX has been forced to 1000/2000
         SRV_Channels::set_output_scaled(function, float(pwm) - _motor_pwm_scaled.offset);
@@ -118,7 +118,7 @@ void AP_Motors::rc_write(uint8_t chan, uint16_t pwm)
  */
 void AP_Motors::rc_write_angle(uint8_t chan, int16_t angle_cd)
 {
-    SRV_Channel::Aux_servo_function_t function = SRV_Channels::get_motor_function(chan);
+    SRV_Channel::Function function = SRV_Channels::get_motor_function(chan);
     SRV_Channels::set_output_scaled(function, angle_cd);
 }
 
@@ -210,7 +210,7 @@ uint32_t AP_Motors::motor_mask_to_srv_channel_mask(uint32_t mask) const
     for (uint8_t i = 0; i < 32; i++) {
         uint32_t bit = 1UL << i;
         if (mask & bit) {
-            SRV_Channel::Aux_servo_function_t function = SRV_Channels::get_motor_function(i);
+            SRV_Channel::Function function = SRV_Channels::get_motor_function(i);
             mask2 |= SRV_Channels::get_output_channel_mask(function);
         }
     }
@@ -224,7 +224,7 @@ void AP_Motors::add_motor_num(int8_t motor_num)
 {
     // ensure valid motor number is provided
     if (motor_num >= 0 && motor_num < AP_MOTORS_MAX_NUM_MOTORS) {
-        SRV_Channel::Aux_servo_function_t function = SRV_Channels::get_motor_function(motor_num);
+        SRV_Channel::Function function = SRV_Channels::get_motor_function(motor_num);
         SRV_Channels::set_aux_channel_default(function, motor_num);
     }
 }

--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -203,6 +203,6 @@ void AP_Mount_Servo::update_angle_outputs(const MountTarget& angle_rad)
 // move_servo - moves servo with the given id to the specified angle.  all angles are in degrees * 10
 void AP_Mount_Servo::move_servo(uint8_t function_idx, int16_t angle, int16_t angle_min, int16_t angle_max)
 {
-	SRV_Channels::move_servo((SRV_Channel::Aux_servo_function_t)function_idx, angle, angle_min, angle_max);
+	SRV_Channels::move_servo((SRV_Channel::Function)function_idx, angle, angle_min, angle_max);
 }
 #endif // HAL_MOUNT_SERVO_ENABLED

--- a/libraries/AP_Mount/AP_Mount_Servo.h
+++ b/libraries/AP_Mount/AP_Mount_Servo.h
@@ -59,10 +59,10 @@ private:
     const bool requires_stabilization;
 
     // SRV_Channel - different id numbers are used depending upon the instance number
-    SRV_Channel::Aux_servo_function_t    _roll_idx;  // SRV_Channel mount roll function index
-    SRV_Channel::Aux_servo_function_t    _tilt_idx;  // SRV_Channel mount tilt function index
-    SRV_Channel::Aux_servo_function_t    _pan_idx;   // SRV_Channel mount pan  function index
-    SRV_Channel::Aux_servo_function_t    _open_idx;  // SRV_Channel mount open function index
+    SRV_Channel::Function    _roll_idx;  // SRV_Channel mount roll function index
+    SRV_Channel::Function    _tilt_idx;  // SRV_Channel mount tilt function index
+    SRV_Channel::Function    _pan_idx;   // SRV_Channel mount pan  function index
+    SRV_Channel::Function    _open_idx;  // SRV_Channel mount open function index
 
     Vector3f _angle_bf_output_rad;  // final body frame output angle in radians
 };

--- a/libraries/AP_Notify/NeoPixel.cpp
+++ b/libraries/AP_Notify/NeoPixel.cpp
@@ -43,7 +43,7 @@ uint16_t NeoPixel::init_ports()
 {
     uint16_t mask = 0;
     for (uint16_t i=0; i<AP_NOTIFY_NEOPIXEL_MAX_INSTANCES; i++) {
-        const SRV_Channel::Aux_servo_function_t fn = (SRV_Channel::Aux_servo_function_t)((uint8_t)SRV_Channel::k_LED_neopixel1 + i);
+        const SRV_Channel::Function fn = (SRV_Channel::Function)((uint8_t)SRV_Channel::k_LED_neopixel1 + i);
         if (!SRV_Channels::function_assigned(fn)) {
             continue;
         }

--- a/libraries/AP_Notify/ProfiLED.cpp
+++ b/libraries/AP_Notify/ProfiLED.cpp
@@ -42,7 +42,7 @@ uint16_t ProfiLED::init_ports()
 {
     uint16_t mask = 0;
     for (uint16_t i=0; i<AP_NOTIFY_ProfiLED_MAX_INSTANCES; i++) {
-        const SRV_Channel::Aux_servo_function_t fn = (SRV_Channel::Aux_servo_function_t)((uint8_t)SRV_Channel::k_ProfiLED_1 + i);
+        const SRV_Channel::Function fn = (SRV_Channel::Function)((uint8_t)SRV_Channel::k_ProfiLED_1 + i);
         if (!SRV_Channels::function_assigned(fn)) {
             continue;
         }

--- a/libraries/AP_PiccoloCAN/AP_PiccoloCAN.cpp
+++ b/libraries/AP_PiccoloCAN/AP_PiccoloCAN.cpp
@@ -327,7 +327,7 @@ void AP_PiccoloCAN::update()
 
             uint16_t output = 0;
 
-            SRV_Channel::Aux_servo_function_t function = SRV_Channels::channel_function(ii);
+            SRV_Channel::Function function = SRV_Channels::channel_function(ii);
 
             if (SRV_Channels::get_output_pwm(function, output)) {
                 _servos[ii].command = output;
@@ -343,7 +343,7 @@ void AP_PiccoloCAN::update()
 
             uint16_t output = 0;
             
-            SRV_Channel::Aux_servo_function_t motor_function = SRV_Channels::get_motor_function(ii);
+            SRV_Channel::Function motor_function = SRV_Channels::get_motor_function(ii);
 
             if (SRV_Channels::get_output_pwm(motor_function, output)) {
                 _escs[ii].command = output;
@@ -637,7 +637,7 @@ bool AP_PiccoloCAN::is_servo_channel_active(uint8_t chan)
         return false;
     }
 
-    SRV_Channel::Aux_servo_function_t function = SRV_Channels::channel_function(chan);
+    SRV_Channel::Function function = SRV_Channels::channel_function(chan);
 
     // Ignore if the servo channel does not have a function assigned
     if (function <= SRV_Channel::k_none) {
@@ -664,7 +664,7 @@ bool AP_PiccoloCAN::is_esc_channel_active(uint8_t chan)
     }
 
     // Check if a motor function is assigned for this motor channel
-    SRV_Channel::Aux_servo_function_t motor_function = SRV_Channels::get_motor_function(chan);
+    SRV_Channel::Function motor_function = SRV_Channels::get_motor_function(chan);
 
     if (SRV_Channels::function_assigned(motor_function)) {
         return true;

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -378,18 +378,18 @@ singleton AP_SerialLED method send boolean uint8_t 1 16
 include SRV_Channel/SRV_Channel.h
 singleton SRV_Channels depends (!defined(HAL_BUILD_AP_PERIPH) || defined(HAL_PERIPH_ENABLE_RC_OUT))
 singleton SRV_Channels rename SRV_Channels
-singleton SRV_Channels method find_channel boolean SRV_Channel::Aux_servo_function_t'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1 uint8_t'Null
-singleton SRV_Channels method set_output_pwm void SRV_Channel::Aux_servo_function_t'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1 uint16_t'skip_check
+singleton SRV_Channels method find_channel boolean SRV_Channel::Function'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1 uint8_t'Null
+singleton SRV_Channels method set_output_pwm void SRV_Channel::Function'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1 uint16_t'skip_check
 singleton SRV_Channels method set_output_pwm_chan void uint8_t 0 NUM_SERVO_CHANNELS-1 uint16_t'skip_check
 singleton SRV_Channels method set_output_pwm_chan_timeout void uint8_t 0 NUM_SERVO_CHANNELS-1 uint16_t'skip_check uint16_t'skip_check
 singleton SRV_Channels method set_output_pwm_chan_timeout depends (!defined(HAL_BUILD_AP_PERIPH))
-singleton SRV_Channels method set_output_scaled void SRV_Channel::Aux_servo_function_t'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1 float'skip_check
-singleton SRV_Channels method get_output_pwm boolean SRV_Channel::Aux_servo_function_t'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1 uint16_t'Null
+singleton SRV_Channels method set_output_scaled void SRV_Channel::Function'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1 float'skip_check
+singleton SRV_Channels method get_output_pwm boolean SRV_Channel::Function'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1 uint16_t'Null
 singleton SRV_Channels method get_output_pwm_chan boolean uint8_t 0 NUM_SERVO_CHANNELS-1 uint16_t'Null
-singleton SRV_Channels method get_output_scaled float SRV_Channel::Aux_servo_function_t'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1
-singleton SRV_Channels method set_output_norm void SRV_Channel::Aux_servo_function_t'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1 float -1 1
-singleton SRV_Channels method set_angle void SRV_Channel::Aux_servo_function_t'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1 uint16_t'skip_check
-singleton SRV_Channels method set_range void SRV_Channel::Aux_servo_function_t'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1 uint16_t'skip_check
+singleton SRV_Channels method get_output_scaled float SRV_Channel::Function'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1
+singleton SRV_Channels method set_output_norm void SRV_Channel::Function'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1 float -1 1
+singleton SRV_Channels method set_angle void SRV_Channel::Function'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1 uint16_t'skip_check
+singleton SRV_Channels method set_range void SRV_Channel::Function'enum SRV_Channel::k_none SRV_Channel::k_nr_aux_servo_functions-1 uint16_t'skip_check
 singleton SRV_Channels method get_emergency_stop boolean
 singleton SRV_Channels manual get_safety_state SRV_Channels_get_safety_state 0 1
 

--- a/libraries/AP_SerialLED/AP_SerialLED.cpp
+++ b/libraries/AP_SerialLED/AP_SerialLED.cpp
@@ -51,10 +51,10 @@ bool AP_SerialLED::set_num_profiled(uint8_t chan, uint8_t num_leds)
     if (chan >= 1 && chan <= 16 && num_leds <= AP_SERIALLED_MAX_LEDS - 2) {
         // must have a clock
         uint32_t Clock_mask = 0;
-        if (!SRV_Channels::function_assigned((SRV_Channel::Aux_servo_function_t)((uint8_t)SRV_Channel::k_ProfiLED_Clock))) {
+        if (!SRV_Channels::function_assigned((SRV_Channel::Function)((uint8_t)SRV_Channel::k_ProfiLED_Clock))) {
             return false;
         }
-        Clock_mask = SRV_Channels::get_output_channel_mask((SRV_Channel::Aux_servo_function_t)((uint8_t)SRV_Channel::k_ProfiLED_Clock));
+        Clock_mask = SRV_Channels::get_output_channel_mask((SRV_Channel::Function)((uint8_t)SRV_Channel::k_ProfiLED_Clock));
 
         return hal.rcout->set_serial_led_num_LEDs(chan-1, num_leds, AP_HAL::RCOutput::MODE_PROFILED, Clock_mask);
     }

--- a/libraries/AP_Torqeedo/AP_Torqeedo_TQBus.cpp
+++ b/libraries/AP_Torqeedo/AP_Torqeedo_TQBus.cpp
@@ -875,7 +875,7 @@ void AP_Torqeedo_TQBus::send_motor_speed_cmd()
     } else {
         // convert throttle output to motor output in range -1000 to +1000
         // ToDo: convert PWM output to motor output so that SERVOx_MIN, MAX and TRIM take effect
-        _motor_speed_desired = constrain_int16(SRV_Channels::get_output_norm((SRV_Channel::Aux_servo_function_t)_params.servo_fn.get()) * 1000.0, -1000, 1000);
+        _motor_speed_desired = constrain_int16(SRV_Channels::get_output_norm((SRV_Channel::Function)_params.servo_fn.get()) * 1000.0, -1000, 1000);
     }
 
     // updated limited motor speed
@@ -1055,7 +1055,7 @@ void AP_Torqeedo_TQBus::update_esc_telem(float rpm, float voltage, float current
 #if HAL_WITH_ESC_TELEM
     // find servo output channel
     uint8_t telem_esc_index = 0;
-    IGNORE_RETURN(SRV_Channels::find_channel((SRV_Channel::Aux_servo_function_t)_params.servo_fn.get(), telem_esc_index));
+    IGNORE_RETURN(SRV_Channels::find_channel((SRV_Channel::Function)_params.servo_fn.get(), telem_esc_index));
 
     // fill in telemetry data structure
     AP_ESC_Telem_Backend::TelemetryData telem_dat {};

--- a/libraries/AR_Motors/AP_MotorsUGV.cpp
+++ b/libraries/AR_Motors/AP_MotorsUGV.cpp
@@ -206,7 +206,7 @@ void AP_MotorsUGV::setup_servo_output()
 
     // omni motors set in power percent so -100 ... 100
     for (uint8_t i=0; i<AP_MOTORS_NUM_MOTORS_MAX; i++) {
-        SRV_Channel::Aux_servo_function_t function = SRV_Channels::get_motor_function(i);
+        SRV_Channel::Function function = SRV_Channels::get_motor_function(i);
         SRV_Channels::set_angle(function, 100);
     }
 
@@ -520,7 +520,7 @@ bool AP_MotorsUGV::pre_arm_check(bool report) const
     }
     // check all omni motor outputs have been configured
     for (uint8_t i=0; i<_motors_num; i++) {
-        SRV_Channel::Aux_servo_function_t function = SRV_Channels::get_motor_function(i);
+        SRV_Channel::Function function = SRV_Channels::get_motor_function(i);
         if (!SRV_Channels::function_assigned(function)) {
             if (report) {
                 GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "PreArm: servo function %u unassigned", function);
@@ -681,7 +681,7 @@ void AP_MotorsUGV::add_omni_motor_num(int8_t motor_num)
     // ensure a valid motor number is provided
     if (motor_num >= 0 && motor_num < AP_MOTORS_NUM_MOTORS_MAX) {
         uint8_t chan;
-        SRV_Channel::Aux_servo_function_t function = SRV_Channels::get_motor_function(motor_num);
+        SRV_Channel::Function function = SRV_Channels::get_motor_function(motor_num);
         SRV_Channels::set_aux_channel_default(function, motor_num);
         if (!SRV_Channels::find_channel(function, chan)) {
             GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Motors: unable to setup motor %u", motor_num);
@@ -975,7 +975,7 @@ void AP_MotorsUGV::output_omni(bool armed, float steering, float throttle, float
 }
 
 // output throttle value to main throttle channel, left throttle or right throttle.  throttle should be scaled from -100 to 100
-void AP_MotorsUGV::output_throttle(SRV_Channel::Aux_servo_function_t function, float throttle, float dt)
+void AP_MotorsUGV::output_throttle(SRV_Channel::Function function, float throttle, float dt)
 {
     // sanity check servo function
     if (function != SRV_Channel::k_throttle && function != SRV_Channel::k_throttleLeft && function != SRV_Channel::k_throttleRight && function != SRV_Channel::k_motor1 && function != SRV_Channel::k_motor2 && function != SRV_Channel::k_motor3 && function!= SRV_Channel::k_motor4) {
@@ -1110,7 +1110,7 @@ float AP_MotorsUGV::get_scaled_throttle(float throttle) const
 }
 
 // use rate controller to achieve desired throttle
-float AP_MotorsUGV::get_rate_controlled_throttle(SRV_Channel::Aux_servo_function_t function, float throttle, float dt)
+float AP_MotorsUGV::get_rate_controlled_throttle(SRV_Channel::Function function, float throttle, float dt)
 {
     // require non-zero dt
     if (!is_positive(dt)) {

--- a/libraries/AR_Motors/AP_MotorsUGV.h
+++ b/libraries/AR_Motors/AP_MotorsUGV.h
@@ -172,7 +172,7 @@ private:
 
     // output throttle (-100 ~ +100) to a throttle channel.  Sets relays if required
     // dt is the main loop time interval and is required when rate control is required
-    void output_throttle(SRV_Channel::Aux_servo_function_t function, float throttle, float dt = 0.0f);
+    void output_throttle(SRV_Channel::Function function, float throttle, float dt = 0.0f);
 
     // output for sailboat's mainsail in the range of 0 to 100 and wing sail in the range +- 100
     void output_sail();
@@ -190,7 +190,7 @@ private:
     float get_scaled_throttle(float throttle) const;
 
     // use rate controller to achieve desired throttle
-    float get_rate_controlled_throttle(SRV_Channel::Aux_servo_function_t function, float throttle, float dt);
+    float get_rate_controlled_throttle(SRV_Channel::Function function, float throttle, float dt);
 
     // external references
     AP_WheelRateControl &_rate_controller;

--- a/libraries/SRV_Channel/SRV_Channel.cpp
+++ b/libraries/SRV_Channel/SRV_Channel.cpp
@@ -309,7 +309,7 @@ uint16_t SRV_Channel::get_limit_pwm(Limit limit) const
 }
 
 // return true if function is for a multicopter motor
-bool SRV_Channel::is_motor(SRV_Channel::Aux_servo_function_t function)
+bool SRV_Channel::is_motor(SRV_Channel::Function function)
 {
     return ((function >= SRV_Channel::k_motor1 && function <= SRV_Channel::k_motor8) ||
             (function >= SRV_Channel::k_motor9 && function <= SRV_Channel::k_motor12) ||
@@ -317,30 +317,30 @@ bool SRV_Channel::is_motor(SRV_Channel::Aux_servo_function_t function)
 }
 
 // return true if function is for anything that should be stopped in a e-stop situation, ie is dangerous
-bool SRV_Channel::should_e_stop(SRV_Channel::Aux_servo_function_t function)
+bool SRV_Channel::should_e_stop(SRV_Channel::Function function)
 {
     switch (function) {
-    case Aux_servo_function_t::k_heli_rsc:  
-    case Aux_servo_function_t::k_heli_tail_rsc:
-    case Aux_servo_function_t::k_motor1:
-    case Aux_servo_function_t::k_motor2:
-    case Aux_servo_function_t::k_motor3:
-    case Aux_servo_function_t::k_motor4:
-    case Aux_servo_function_t::k_motor5:
-    case Aux_servo_function_t::k_motor6:
-    case Aux_servo_function_t::k_motor7:
-    case Aux_servo_function_t::k_motor8:
-    case Aux_servo_function_t::k_starter:
-    case Aux_servo_function_t::k_throttle:
-    case Aux_servo_function_t::k_throttleLeft:
-    case Aux_servo_function_t::k_throttleRight:
-    case Aux_servo_function_t::k_boost_throttle:
-    case Aux_servo_function_t::k_motor9:
-    case Aux_servo_function_t::k_motor10:
-    case Aux_servo_function_t::k_motor11:
-    case Aux_servo_function_t::k_motor12:
-    case Aux_servo_function_t::k_motor13 ... Aux_servo_function_t::k_motor32:
-    case Aux_servo_function_t::k_engine_run_enable:
+    case Function::k_heli_rsc:  
+    case Function::k_heli_tail_rsc:
+    case Function::k_motor1:
+    case Function::k_motor2:
+    case Function::k_motor3:
+    case Function::k_motor4:
+    case Function::k_motor5:
+    case Function::k_motor6:
+    case Function::k_motor7:
+    case Function::k_motor8:
+    case Function::k_starter:
+    case Function::k_throttle:
+    case Function::k_throttleLeft:
+    case Function::k_throttleRight:
+    case Function::k_boost_throttle:
+    case Function::k_motor9:
+    case Function::k_motor10:
+    case Function::k_motor11:
+    case Function::k_motor12:
+    case Function::k_motor13 ... Function::k_motor32:
+    case Function::k_engine_run_enable:
         return true;
     default:
         return false;
@@ -349,26 +349,25 @@ bool SRV_Channel::should_e_stop(SRV_Channel::Aux_servo_function_t function)
 }
 
 // return true if function is for a control surface
-bool SRV_Channel::is_control_surface(SRV_Channel::Aux_servo_function_t function)
+bool SRV_Channel::is_control_surface(SRV_Channel::Function function)
 {
-    switch (function)
-    {
-    case SRV_Channel::Aux_servo_function_t::k_flap:  
-    case SRV_Channel::Aux_servo_function_t::k_flap_auto:
-    case SRV_Channel::Aux_servo_function_t::k_aileron:
-    case SRV_Channel::Aux_servo_function_t::k_dspoilerLeft1:
-    case SRV_Channel::Aux_servo_function_t::k_dspoilerLeft2:
-    case SRV_Channel::Aux_servo_function_t::k_dspoilerRight1:
-    case SRV_Channel::Aux_servo_function_t::k_dspoilerRight2:
-    case SRV_Channel::Aux_servo_function_t::k_elevator:
-    case SRV_Channel::Aux_servo_function_t::k_rudder:
-    case SRV_Channel::Aux_servo_function_t::k_flaperon_left:
-    case SRV_Channel::Aux_servo_function_t::k_flaperon_right:
-    case SRV_Channel::Aux_servo_function_t::k_elevon_left:
-    case SRV_Channel::Aux_servo_function_t::k_elevon_right:
-    case SRV_Channel::Aux_servo_function_t::k_vtail_left:
-    case SRV_Channel::Aux_servo_function_t::k_vtail_right:
-    case SRV_Channel::Aux_servo_function_t::k_airbrake:
+    switch (function) {
+    case Function::k_flap:
+    case Function::k_flap_auto:
+    case Function::k_aileron:
+    case Function::k_dspoilerLeft1:
+    case Function::k_dspoilerLeft2:
+    case Function::k_dspoilerRight1:
+    case Function::k_dspoilerRight2:
+    case Function::k_elevator:
+    case Function::k_rudder:
+    case Function::k_flaperon_left:
+    case Function::k_flaperon_right:
+    case Function::k_elevon_left:
+    case Function::k_elevon_right:
+    case Function::k_vtail_left:
+    case Function::k_vtail_right:
+    case Function::k_airbrake:
         return true;
 
     default:

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -210,10 +210,10 @@ public:
         k_motor31               = 178,
         k_motor32               = 179,
         k_nr_aux_servo_functions         ///< This must be the last enum value (only add new values _before_ this one)
-    } Aux_servo_function_t;
+    } Function;
 
     // check if a function is valid for indexing into functions
-    static bool valid_function(Aux_servo_function_t fn) {
+    static bool valid_function(Function fn) {
         return fn >= k_none && fn < k_nr_aux_servo_functions;
     }
     bool valid_function(void) const {
@@ -268,24 +268,24 @@ public:
     }
 
     // return true if function is for a multicopter motor
-    static bool is_motor(SRV_Channel::Aux_servo_function_t function);
+    static bool is_motor(Function function);
 
     // return true if function is for anything that should be stopped in a e-stop situation, ie is dangerous
-    static bool should_e_stop(SRV_Channel::Aux_servo_function_t function);
+    static bool should_e_stop(Function function);
 
     // return true if function is for a control surface
-    static bool is_control_surface(SRV_Channel::Aux_servo_function_t function);
+    static bool is_control_surface(Function function);
 
     // return the function of a channel
-    SRV_Channel::Aux_servo_function_t get_function(void) const {
-        return (SRV_Channel::Aux_servo_function_t)function.get();
+    SRV_Channel::Function get_function(void) const {
+        return (SRV_Channel::Function)function.get();
     }
 
     // return the motor number of a channel, or -1 if not a motor
     int8_t get_motor_num(void) const;
 
     // set and save function for channel. Used in upgrade of parameters in plane
-    void function_set_and_save(SRV_Channel::Aux_servo_function_t f) {
+    void function_set_and_save(Function f) {
         function.set_and_save(int8_t(f));
     }
 
@@ -314,7 +314,7 @@ private:
     AP_Int16 servo_trim;
     // reversal, following convention that 1 means reversed, 0 means normal
     AP_Int8 reversed;
-    AP_Enum16<Aux_servo_function_t> function;
+    AP_Enum16<Function> function;
 
     // a pending output value as PWM
     uint16_t output_pwm;
@@ -385,10 +385,10 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
     // set the default function for a channel
-    static void set_default_function(uint8_t chan, SRV_Channel::Aux_servo_function_t function);
+    static void set_default_function(uint8_t chan, SRV_Channel::Function function);
 
     // set output value for a function channel as a pwm value
-    static void set_output_pwm(SRV_Channel::Aux_servo_function_t function, uint16_t value);
+    static void set_output_pwm(SRV_Channel::Function function, uint16_t value);
 
     // set output value for a specific function channel as a pwm value
     static void set_output_pwm_chan(uint8_t chan, uint16_t value);
@@ -401,50 +401,50 @@ public:
 
     // set output value for a function channel as a scaled value. This
     // this should be followed by a call to calc_pwm() to output the pwm values
-    static void set_output_scaled(SRV_Channel::Aux_servo_function_t function, float value);
+    static void set_output_scaled(SRV_Channel::Function function, float value);
 
     // get scaled output for the given function type.
-    static float get_output_scaled(SRV_Channel::Aux_servo_function_t function);
+    static float get_output_scaled(SRV_Channel::Function function);
 
     // get slew limited scaled output for the given function type
-    static float get_slew_limited_output_scaled(SRV_Channel::Aux_servo_function_t function);
+    static float get_slew_limited_output_scaled(SRV_Channel::Function function);
 
     // get pwm output for the first channel of the given function type.
-    static bool get_output_pwm(SRV_Channel::Aux_servo_function_t function, uint16_t &value);
+    static bool get_output_pwm(SRV_Channel::Function function, uint16_t &value);
 
     // get normalised output (-1 to 1 with 0 at mid point of servo_min/servo_max)
     // Value is taken from pwm value.  Returns zero on error.
-    static float get_output_norm(SRV_Channel::Aux_servo_function_t function);
+    static float get_output_norm(SRV_Channel::Function function);
 
     // set normalised output (-1 to 1 with 0 at mid point of servo_min/servo_max) for the given function
-    static void set_output_norm(SRV_Channel::Aux_servo_function_t function, float value);
+    static void set_output_norm(SRV_Channel::Function function, float value);
 
     // get output channel mask for a function
-    static uint32_t get_output_channel_mask(SRV_Channel::Aux_servo_function_t function);
+    static uint32_t get_output_channel_mask(SRV_Channel::Function function);
 
     // limit slew rate to given limit in percent per second
-    static void set_slew_rate(SRV_Channel::Aux_servo_function_t function, float slew_rate, uint16_t range, float dt);
+    static void set_slew_rate(SRV_Channel::Function function, float slew_rate, uint16_t range, float dt);
 
     // call output_ch() on all channels
     static void output_ch_all(void);
 
     // setup output ESC scaling based on a channels MIN/MAX
-    void set_esc_scaling_for(SRV_Channel::Aux_servo_function_t function);
+    void set_esc_scaling_for(SRV_Channel::Function function);
 
     // return true when auto_trim enabled
     bool auto_trim_enabled(void) const { return auto_trim; }
 
     // adjust trim of a channel by a small increment
-    void adjust_trim(SRV_Channel::Aux_servo_function_t function, float v);
+    void adjust_trim(SRV_Channel::Function function, float v);
 
     // set MIN/MAX parameters for a function
-    static void set_output_min_max(SRV_Channel::Aux_servo_function_t function, uint16_t min_pwm, uint16_t max_pwm);
+    static void set_output_min_max(SRV_Channel::Function function, uint16_t min_pwm, uint16_t max_pwm);
 
     // set MIN/MAX parameter defaults for a function
-    static void set_output_min_max_defaults(SRV_Channel::Aux_servo_function_t function, uint16_t min_pwm, uint16_t max_pwm);
+    static void set_output_min_max_defaults(SRV_Channel::Function function, uint16_t min_pwm, uint16_t max_pwm);
 
     // Save MIN/MAX/REVERSED parameters for a function
-    static void save_output_min_max(SRV_Channel::Aux_servo_function_t function, uint16_t min_pwm, uint16_t max_pwm);
+    static void save_output_min_max(SRV_Channel::Function function, uint16_t min_pwm, uint16_t max_pwm);
 
     // save trims
     void save_trim(void);
@@ -453,46 +453,46 @@ public:
     static void setup_failsafe_trim_all_non_motors(void);
 
     // set output for all channels matching the given function type, allow radio_trim to center servo
-    static void set_output_pwm_trimmed(SRV_Channel::Aux_servo_function_t function, int16_t value);
+    static void set_output_pwm_trimmed(SRV_Channel::Function function, int16_t value);
 
     // set and save the trim for a function channel to the output value
-    static void set_trim_to_servo_out_for(SRV_Channel::Aux_servo_function_t function);
+    static void set_trim_to_servo_out_for(SRV_Channel::Function function);
 
     // set the trim for a function channel to min of the channel honnoring reverse unless ignore_reversed is true
-    static void set_trim_to_min_for(SRV_Channel::Aux_servo_function_t function, bool ignore_reversed = false);
+    static void set_trim_to_min_for(SRV_Channel::Function function, bool ignore_reversed = false);
 
     // set the trim for a function channel to given pwm
-    static void set_trim_to_pwm_for(SRV_Channel::Aux_servo_function_t function, int16_t pwm);
+    static void set_trim_to_pwm_for(SRV_Channel::Function function, int16_t pwm);
 
     // set output to min value
-    static void set_output_to_min(SRV_Channel::Aux_servo_function_t function);
+    static void set_output_to_min(SRV_Channel::Function function);
 
     // set output to max value
-    static void set_output_to_max(SRV_Channel::Aux_servo_function_t function);
+    static void set_output_to_max(SRV_Channel::Function function);
 
     // set output to trim value
-    static void set_output_to_trim(SRV_Channel::Aux_servo_function_t function);
+    static void set_output_to_trim(SRV_Channel::Function function);
 
     // copy radio_in to servo out
-    static void copy_radio_in_out(SRV_Channel::Aux_servo_function_t function, bool do_input_output=false);
+    static void copy_radio_in_out(SRV_Channel::Function function, bool do_input_output=false);
 
     // copy radio_in to servo_out by channel mask
     static void copy_radio_in_out_mask(uint32_t mask);
 
     // setup failsafe for an auxiliary channel function, by pwm
-    static void set_failsafe_pwm(SRV_Channel::Aux_servo_function_t function, uint16_t pwm);
+    static void set_failsafe_pwm(SRV_Channel::Function function, uint16_t pwm);
 
     // setup failsafe for an auxiliary channel function
-    static void set_failsafe_limit(SRV_Channel::Aux_servo_function_t function, SRV_Channel::Limit limit);
+    static void set_failsafe_limit(SRV_Channel::Function function, SRV_Channel::Limit limit);
 
     // set servo to a Limit
-    static void set_output_limit(SRV_Channel::Aux_servo_function_t function, SRV_Channel::Limit limit);
+    static void set_output_limit(SRV_Channel::Function function, SRV_Channel::Limit limit);
 
     // return true if a function is assigned to a channel
-    static bool function_assigned(SRV_Channel::Aux_servo_function_t function);
+    static bool function_assigned(SRV_Channel::Function function);
 
     // set a servo_out value, and angle range, then calc_pwm
-    static void move_servo(SRV_Channel::Aux_servo_function_t function,
+    static void move_servo(SRV_Channel::Function function,
                            int16_t value, int16_t angle_min, int16_t angle_max);
 
     // assign and enable auxiliary channels
@@ -502,28 +502,28 @@ public:
     static void enable_by_mask(uint32_t mask);
 
     // return the current function for a channel
-    static SRV_Channel::Aux_servo_function_t channel_function(uint8_t channel);
+    static SRV_Channel::Function channel_function(uint8_t channel);
 
     // refresh aux servo to function mapping
     static void update_aux_servo_function(void);
 
     // set default channel for an auxiliary function
-    static bool set_aux_channel_default(SRV_Channel::Aux_servo_function_t function, uint8_t channel);
+    static bool set_aux_channel_default(SRV_Channel::Function function, uint8_t channel);
 
     // find first channel that a function is assigned to
-    static bool find_channel(SRV_Channel::Aux_servo_function_t function, uint8_t &chan);
+    static bool find_channel(SRV_Channel::Function function, uint8_t &chan);
 
     // find first channel that a function is assigned to, returning SRV_Channel object
-    static SRV_Channel *get_channel_for(SRV_Channel::Aux_servo_function_t function);
+    static SRV_Channel *get_channel_for(SRV_Channel::Function function);
 
     // call set_angle() on matching channels
-    static void set_angle(SRV_Channel::Aux_servo_function_t function, uint16_t angle);
+    static void set_angle(SRV_Channel::Function function, uint16_t angle);
 
     // call set_range() on matching channels
-    static void set_range(SRV_Channel::Aux_servo_function_t function, uint16_t range);
+    static void set_range(SRV_Channel::Function function, uint16_t range);
 
     // set output refresh frequency on a servo function
-    static void set_rc_frequency(SRV_Channel::Aux_servo_function_t function, uint16_t frequency);
+    static void set_rc_frequency(SRV_Channel::Function function, uint16_t frequency);
 
     // control pass-thru of channels
     void disable_passthrough(bool disable) {
@@ -531,7 +531,7 @@ public:
     }
 
     // constrain to output min/max for function
-    static void constrain_pwm(SRV_Channel::Aux_servo_function_t function);
+    static void constrain_pwm(SRV_Channel::Function function);
 
     // calculate PWM for all channels
     static void calc_pwm(void);
@@ -555,14 +555,14 @@ public:
     static void upgrade_parameters(void);
 
     // given a zero-based motor channel, return the k_motor function for that channel
-    static SRV_Channel::Aux_servo_function_t get_motor_function(uint8_t channel) {
+    static SRV_Channel::Function get_motor_function(uint8_t channel) {
         if (channel < 8) {
-            return SRV_Channel::Aux_servo_function_t(SRV_Channel::k_motor1+channel);
+            return SRV_Channel::Function(SRV_Channel::k_motor1+channel);
         }
         if (channel < 12) {
-            return SRV_Channel::Aux_servo_function_t((SRV_Channel::k_motor9+(channel-8)));
+            return SRV_Channel::Function((SRV_Channel::k_motor9+(channel-8)));
         }
-        return SRV_Channel::Aux_servo_function_t((SRV_Channel::k_motor13+(channel-12)));
+        return SRV_Channel::Function((SRV_Channel::k_motor13+(channel-12)));
     }
 
     void cork();
@@ -701,8 +701,8 @@ private:
 
     // linked list for slew rate handling
     struct slew_list {
-        slew_list(SRV_Channel::Aux_servo_function_t _func) : func(_func) {};
-        const SRV_Channel::Aux_servo_function_t func;
+        slew_list(SRV_Channel::Function _func) : func(_func) {};
+        const SRV_Channel::Function func;
         float last_scaled_output;
         float max_change;
         slew_list * next;

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -120,7 +120,7 @@ void SRV_Channels::output_ch_all(void)
 /*
   return the current function for a channel
 */
-SRV_Channel::Aux_servo_function_t SRV_Channels::channel_function(uint8_t channel)
+SRV_Channel::Function SRV_Channels::channel_function(uint8_t channel)
 {
     if (channel < NUM_SERVO_CHANNELS) {
         return channels[channel].function;
@@ -336,7 +336,7 @@ void SRV_Channels::enable_by_mask(uint32_t mask)
 /*
   set radio_out for all channels matching the given function type
  */
-void SRV_Channels::set_output_pwm(SRV_Channel::Aux_servo_function_t function, uint16_t value)
+void SRV_Channels::set_output_pwm(SRV_Channel::Function function, uint16_t value)
 {
     if (!function_assigned(function)) {
         return;
@@ -355,7 +355,7 @@ void SRV_Channels::set_output_pwm(SRV_Channel::Aux_servo_function_t function, ui
   reverses pwm output based on channel reversed property
  */
 void
-SRV_Channels::set_output_pwm_trimmed(SRV_Channel::Aux_servo_function_t function, int16_t value)
+SRV_Channels::set_output_pwm_trimmed(SRV_Channel::Function function, int16_t value)
 {
     if (!function_assigned(function)) {
         return;
@@ -379,7 +379,7 @@ SRV_Channels::set_output_pwm_trimmed(SRV_Channel::Aux_servo_function_t function,
   the given function type
  */
 void
-SRV_Channels::set_trim_to_servo_out_for(SRV_Channel::Aux_servo_function_t function)
+SRV_Channels::set_trim_to_servo_out_for(SRV_Channel::Function function)
 {
     if (!function_assigned(function)) {
         return;
@@ -396,7 +396,7 @@ SRV_Channels::set_trim_to_servo_out_for(SRV_Channel::Aux_servo_function_t functi
   copy radio_in to radio_out for a given function
  */
 void
-SRV_Channels::copy_radio_in_out(SRV_Channel::Aux_servo_function_t function, bool do_input_output)
+SRV_Channels::copy_radio_in_out(SRV_Channel::Function function, bool do_input_output)
 {
     if (!function_assigned(function)) {
         return;
@@ -438,7 +438,7 @@ SRV_Channels::copy_radio_in_out_mask(uint32_t mask)
   setup failsafe value for an auxiliary function type to a Limit
  */
 void
-SRV_Channels::set_failsafe_pwm(SRV_Channel::Aux_servo_function_t function, uint16_t pwm)
+SRV_Channels::set_failsafe_pwm(SRV_Channel::Function function, uint16_t pwm)
 {
     if (!function_assigned(function)) {
         return;
@@ -455,7 +455,7 @@ SRV_Channels::set_failsafe_pwm(SRV_Channel::Aux_servo_function_t function, uint1
   setup failsafe value for an auxiliary function type to a Limit
  */
 void
-SRV_Channels::set_failsafe_limit(SRV_Channel::Aux_servo_function_t function, SRV_Channel::Limit limit)
+SRV_Channels::set_failsafe_limit(SRV_Channel::Function function, SRV_Channel::Limit limit)
 {
     if (!function_assigned(function)) {
         return;
@@ -473,7 +473,7 @@ SRV_Channels::set_failsafe_limit(SRV_Channel::Aux_servo_function_t function, SRV
   set radio output value for an auxiliary function type to a Limit
  */
 void
-SRV_Channels::set_output_limit(SRV_Channel::Aux_servo_function_t function, SRV_Channel::Limit limit)
+SRV_Channels::set_output_limit(SRV_Channel::Function function, SRV_Channel::Limit limit)
 {
     if (!function_assigned(function)) {
         return;
@@ -501,7 +501,7 @@ SRV_Channels::set_output_limit(SRV_Channel::Aux_servo_function_t function, SRV_C
   return true if a particular function is assigned to at least one RC channel
  */
 bool
-SRV_Channels::function_assigned(SRV_Channel::Aux_servo_function_t function)
+SRV_Channels::function_assigned(SRV_Channel::Function function)
 {
     if (!initialised) {
         update_aux_servo_function();
@@ -514,7 +514,7 @@ SRV_Channels::function_assigned(SRV_Channel::Aux_servo_function_t function)
   value. This is used to move a AP_Mount servo
  */
 void
-SRV_Channels::move_servo(SRV_Channel::Aux_servo_function_t function,
+SRV_Channels::move_servo(SRV_Channel::Function function,
                          int16_t value, int16_t angle_min, int16_t angle_max)
 {
     if (!function_assigned(function)) {
@@ -538,7 +538,7 @@ SRV_Channels::move_servo(SRV_Channel::Aux_servo_function_t function,
 /*
   set the default channel an auxiliary output function should be on
  */
-bool SRV_Channels::set_aux_channel_default(SRV_Channel::Aux_servo_function_t function, uint8_t channel)
+bool SRV_Channels::set_aux_channel_default(SRV_Channel::Function function, uint8_t channel)
 {
     if (function_assigned(function)) {
         // already assigned
@@ -565,7 +565,7 @@ bool SRV_Channels::set_aux_channel_default(SRV_Channel::Aux_servo_function_t fun
 }
 
 // find first channel that a function is assigned to
-bool SRV_Channels::find_channel(SRV_Channel::Aux_servo_function_t function, uint8_t &chan)
+bool SRV_Channels::find_channel(SRV_Channel::Function function, uint8_t &chan)
 {
     // Must have populated channel masks
     if (!initialised) {
@@ -591,7 +591,7 @@ bool SRV_Channels::find_channel(SRV_Channel::Aux_servo_function_t function, uint
 /*
   get a pointer to first auxiliary channel for a channel function
 */
-SRV_Channel *SRV_Channels::get_channel_for(SRV_Channel::Aux_servo_function_t function)
+SRV_Channel *SRV_Channels::get_channel_for(SRV_Channel::Function function)
 {
     uint8_t chan;
     if (!find_channel(function, chan)) {
@@ -600,7 +600,7 @@ SRV_Channel *SRV_Channels::get_channel_for(SRV_Channel::Aux_servo_function_t fun
     return &channels[chan];
 }
 
-void SRV_Channels::set_output_scaled(SRV_Channel::Aux_servo_function_t function, float value)
+void SRV_Channels::set_output_scaled(SRV_Channel::Function function, float value)
 {
     if (SRV_Channel::valid_function(function)) {
         functions[function].output_scaled = value;
@@ -608,7 +608,7 @@ void SRV_Channels::set_output_scaled(SRV_Channel::Aux_servo_function_t function,
     }
 }
 
-float SRV_Channels::get_output_scaled(SRV_Channel::Aux_servo_function_t function)
+float SRV_Channels::get_output_scaled(SRV_Channel::Function function)
 {
     if (SRV_Channel::valid_function(function)) {
         return functions[function].output_scaled;
@@ -617,7 +617,7 @@ float SRV_Channels::get_output_scaled(SRV_Channel::Aux_servo_function_t function
 }
 
 // get slew limited scaled output for the given function type
-float SRV_Channels::get_slew_limited_output_scaled(SRV_Channel::Aux_servo_function_t function)
+float SRV_Channels::get_slew_limited_output_scaled(SRV_Channel::Function function)
 {
     if (!SRV_Channel::valid_function(function)) {
         return 0.0;
@@ -638,7 +638,7 @@ float SRV_Channels::get_slew_limited_output_scaled(SRV_Channel::Aux_servo_functi
 /*
   get mask of output channels for a function
  */
-uint32_t SRV_Channels::get_output_channel_mask(SRV_Channel::Aux_servo_function_t function)
+uint32_t SRV_Channels::get_output_channel_mask(SRV_Channel::Function function)
 {
     if (!initialised) {
         update_aux_servo_function();
@@ -651,7 +651,7 @@ uint32_t SRV_Channels::get_output_channel_mask(SRV_Channel::Aux_servo_function_t
 
 
 // set the trim for a function channel to given pwm
-void SRV_Channels::set_trim_to_pwm_for(SRV_Channel::Aux_servo_function_t function, int16_t pwm)
+void SRV_Channels::set_trim_to_pwm_for(SRV_Channel::Function function, int16_t pwm)
 {
     for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
         if (channels[i].function == function) {
@@ -661,7 +661,7 @@ void SRV_Channels::set_trim_to_pwm_for(SRV_Channel::Aux_servo_function_t functio
 }
 
 // set the trim for a function channel to min output of the channel honnoring reverse unless ignore_reversed is true
-void SRV_Channels::set_trim_to_min_for(SRV_Channel::Aux_servo_function_t function, bool ignore_reversed)
+void SRV_Channels::set_trim_to_min_for(SRV_Channel::Function function, bool ignore_reversed)
 {
     for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
         if (channels[i].function == function) {
@@ -673,10 +673,10 @@ void SRV_Channels::set_trim_to_min_for(SRV_Channel::Aux_servo_function_t functio
 /*
   set the default function for a channel
 */
-void SRV_Channels::set_default_function(uint8_t chan, SRV_Channel::Aux_servo_function_t function)
+void SRV_Channels::set_default_function(uint8_t chan, SRV_Channel::Function function)
 {
     if (chan < NUM_SERVO_CHANNELS) {
-        const SRV_Channel::Aux_servo_function_t old = channels[chan].function;
+        const SRV_Channel::Function old = channels[chan].function;
         channels[chan].function.set_default(function);
         if (old != channels[chan].function && channels[chan].function == function) {
             function_mask.set((uint16_t)function);
@@ -684,7 +684,7 @@ void SRV_Channels::set_default_function(uint8_t chan, SRV_Channel::Aux_servo_fun
     }
 }
 
-void SRV_Channels::set_esc_scaling_for(SRV_Channel::Aux_servo_function_t function)
+void SRV_Channels::set_esc_scaling_for(SRV_Channel::Function function)
 {
     uint8_t chan;
     if (find_channel(function, chan)) {
@@ -696,7 +696,7 @@ void SRV_Channels::set_esc_scaling_for(SRV_Channel::Aux_servo_function_t functio
   auto-adjust channel trim from an integrator value. Positive v means
   adjust trim up. Negative means decrease
  */
-void SRV_Channels::adjust_trim(SRV_Channel::Aux_servo_function_t function, float v)
+void SRV_Channels::adjust_trim(SRV_Channel::Function function, float v)
 {
     if (is_zero(v)) {
         return;
@@ -726,7 +726,7 @@ void SRV_Channels::adjust_trim(SRV_Channel::Aux_servo_function_t function, float
 }
 
 // get pwm output for the first channel of the given function type.
-bool SRV_Channels::get_output_pwm(SRV_Channel::Aux_servo_function_t function, uint16_t &value)
+bool SRV_Channels::get_output_pwm(SRV_Channel::Function function, uint16_t &value)
 {
     uint8_t chan;
     if (!find_channel(function, chan)) {
@@ -741,7 +741,7 @@ bool SRV_Channels::get_output_pwm(SRV_Channel::Aux_servo_function_t function, ui
 }
 
 // set output pwm to trim for the given function
-void SRV_Channels::set_output_to_trim(SRV_Channel::Aux_servo_function_t function)
+void SRV_Channels::set_output_to_trim(SRV_Channel::Function function)
 {
     for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
         if (channels[i].function == function) {
@@ -754,7 +754,7 @@ void SRV_Channels::set_output_to_trim(SRV_Channel::Aux_servo_function_t function
   get the normalised output for a channel function from the pwm value
   of the first matching channel
  */
-float SRV_Channels::get_output_norm(SRV_Channel::Aux_servo_function_t function)
+float SRV_Channels::get_output_norm(SRV_Channel::Function function)
 {
     uint8_t chan;
     if (!find_channel(function, chan)) {
@@ -767,7 +767,7 @@ float SRV_Channels::get_output_norm(SRV_Channel::Aux_servo_function_t function)
 }
 
 // set normalised output (-1 to 1 with 0 at mid point of servo_min/servo_max) for the given function
-void SRV_Channels::set_output_norm(SRV_Channel::Aux_servo_function_t function, float value)
+void SRV_Channels::set_output_norm(SRV_Channel::Function function, float value)
 {
     if (!function_assigned(function)) {
         return;
@@ -784,7 +784,7 @@ void SRV_Channels::set_output_norm(SRV_Channel::Aux_servo_function_t function, f
   limit slew rate for an output function to given rate in percent per
   second. This assumes output has not yet done to the hal
  */
-void SRV_Channels::set_slew_rate(SRV_Channel::Aux_servo_function_t function, float slew_rate, uint16_t range, float dt)
+void SRV_Channels::set_slew_rate(SRV_Channel::Function function, float slew_rate, uint16_t range, float dt)
 {
     if (!SRV_Channel::valid_function(function)) {
         return;
@@ -816,7 +816,7 @@ void SRV_Channels::set_slew_rate(SRV_Channel::Aux_servo_function_t function, flo
 }
 
 // call set_angle() on matching channels
-void SRV_Channels::set_angle(SRV_Channel::Aux_servo_function_t function, uint16_t angle)
+void SRV_Channels::set_angle(SRV_Channel::Function function, uint16_t angle)
 {
     for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
         if (channels[i].function == function) {
@@ -826,7 +826,7 @@ void SRV_Channels::set_angle(SRV_Channel::Aux_servo_function_t function, uint16_
 }
 
 // call set_range() on matching channels
-void SRV_Channels::set_range(SRV_Channel::Aux_servo_function_t function, uint16_t range)
+void SRV_Channels::set_range(SRV_Channel::Function function, uint16_t range)
 {
     for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
         if (channels[i].function == function) {
@@ -836,7 +836,7 @@ void SRV_Channels::set_range(SRV_Channel::Aux_servo_function_t function, uint16_
 }
 
 // set MIN parameter for a function
-void SRV_Channels::set_output_min_max(SRV_Channel::Aux_servo_function_t function, uint16_t min_pwm, uint16_t max_pwm)
+void SRV_Channels::set_output_min_max(SRV_Channel::Function function, uint16_t min_pwm, uint16_t max_pwm)
 {
     for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
         if (channels[i].function == function) {
@@ -847,7 +847,7 @@ void SRV_Channels::set_output_min_max(SRV_Channel::Aux_servo_function_t function
 }
 
 // set MIN/MAX parameter defaults for a function
-void SRV_Channels::set_output_min_max_defaults(SRV_Channel::Aux_servo_function_t function, uint16_t min_pwm, uint16_t max_pwm)
+void SRV_Channels::set_output_min_max_defaults(SRV_Channel::Function function, uint16_t min_pwm, uint16_t max_pwm)
 {
     for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
         if (channels[i].function == function) {
@@ -858,7 +858,7 @@ void SRV_Channels::set_output_min_max_defaults(SRV_Channel::Aux_servo_function_t
 }
 
 // Save MIN/MAX/REVERSED parameters for a function
-void SRV_Channels::save_output_min_max(SRV_Channel::Aux_servo_function_t function, uint16_t min_pwm, uint16_t max_pwm)
+void SRV_Channels::save_output_min_max(SRV_Channel::Function function, uint16_t min_pwm, uint16_t max_pwm)
 {
     for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
         if (channels[i].function == function) {
@@ -872,7 +872,7 @@ void SRV_Channels::save_output_min_max(SRV_Channel::Aux_servo_function_t functio
 }
 
 // constrain to output min/max for function
-void SRV_Channels::constrain_pwm(SRV_Channel::Aux_servo_function_t function)
+void SRV_Channels::constrain_pwm(SRV_Channel::Function function)
 {
     for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
         SRV_Channel &c = channels[i];
@@ -898,7 +898,7 @@ void SRV_Channels::upgrade_parameters(void)
 }
 
 // set RC output frequency on a function output
-void SRV_Channels::set_rc_frequency(SRV_Channel::Aux_servo_function_t function, uint16_t frequency_hz)
+void SRV_Channels::set_rc_frequency(SRV_Channel::Function function, uint16_t frequency_hz)
 {
     uint32_t mask = 0;
     for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {


### PR DESCRIPTION
Not only is the new name shorter, it's also more in-keeping with the way we do enum-class names elsewhere in the code.

Additionally, the word "aux" in the old name is completely misleading - this covers all servo functions, not just "auxiliary" functions!

This is a no-compiler-output-change PR:

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                 *                                                   
CubeRedPrimary                      *      *           *       *                 *      *      *
Durandal                            *      *           *       *                 *      *      *
Hitec-Airspeed           *                 *                                                   
KakuteH7-bdshot                     *      *           *       *                 *      *      *
MatekF405                           *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *                  *       *                 *      *      *
f103-QiotekPeriph        *                 *                                                   
f303-Universal           *                 *                                                   
iomcu                                                                *                         
revo-mini                           *      *           *       *                 *      *      *
skyviper-journey                                       *                                       
skyviper-v2450                                         *                                       
```
