### PR TITLE
board_types.txt: reserve bootloader id for Stellar F4V2

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -337,6 +337,7 @@ AP_HW_StellarF4                      1500
 AP_HW_GEPRCF745BTHD                  1501
 AP_HW_GEPRC_TAKER_H743               1502
 AP_HW_StellarH7V2                    1503
+AP_HW_StellarF4V2                    1504
 
 AP_HW_HGLRCF405V4                    1524
 


### PR DESCRIPTION
reserve bootloader id for Stellar F4V2