### PR TITLE
Plane: Attitude stall prevention adjustments

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -659,7 +659,12 @@ void Plane::update_load_factor(void)
     }
 #endif
 
-    float max_load_factor = sq(smoothed_airspeed / MAX(aparm.airspeed_min, 1));
+    float stall_airspeed_1g = is_positive(aparm.airspeed_stall)
+                                  ? aparm.airspeed_stall
+                                  : aparm.airspeed_min;
+
+    float max_load_factor =
+        sq(smoothed_airspeed / MAX(stall_airspeed_1g, 1));
 
     if (max_load_factor <= 1) {
         // our airspeed is below the minimum airspeed. Limit roll to
@@ -671,7 +676,7 @@ void Plane::update_load_factor(void)
         // load limit. Limit our roll to a bank angle that will keep
         // the load within what the airframe can handle. We always
         // allow at least 25 degrees of roll however, to ensure the
-        // aircraft can be manoeuvred with a bad airspeed estimate. At
+        // aircraft can be manoeuvered with a bad airspeed estimate. At
         // 25 degrees the load factor is 1.1 (10%)
         int32_t roll_limit = degrees(acosf(1.0f / max_load_factor))*100;
         if (roll_limit < 2500) {

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -323,7 +323,7 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Param: AIRSPEED_STALL
     // @DisplayName: Stall airspeed
-    // @Description: If stall prevention is enabled this speed is used to calculate the minimum airspeed while banking. If this is set to 0 then the stall speed is assumed to be the minimum airspeed speed. Typically set slightly higher then true stall speed. Value is as an indicated (calibrated/apparent) airspeed.
+    // @Description: If stall prevention is enabled this speed is used for its calculations. If set to 0 then AIRSPEED_MIN is used instead. Typically set slightly higher than the true stall speed. Value is as an indicated (calibrated/apparent) airspeed.
     // @Units: m/s
     // @Range: 5 75
     // @User: Standard


### PR DESCRIPTION
# Plane: Attitude stall prevention adjustments

Description
-----------
### [Plane: Use stall speed for roll stall prevention](https://github.com/ArduPilot/ardupilot/pull/29092/commits/6f8f1ae984c23078405f0c64cfa08e338db4d4ea):

Applied the new AIRSPEED_STALL parameter to roll stall prevention, to enable tighter turns at lower airspeeds when this parameter is set. For accurate behavior, it should be set at the stall IAS on level flight at sea level, plus the desired safety margin.