### PR TITLE
Plane: Fixed formulas for load factor and roll, also corrected _TASmin in AP_TECS accordingly

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -672,7 +672,7 @@ private:
     int32_t nav_pitch_cd;
 
     // the aerodynamic load factor. This is calculated from the demanded
-    // roll before the roll is clipped, using 1/sqrt(cos(nav_roll))
+    // roll before the roll is clipped, using 1/cos(nav_roll)
     float aerodynamic_load_factor = 1.0f;
 
     // a smoothed airspeed estimate, used for limiting roll angle

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -415,9 +415,9 @@ void AP_TECS::_update_speed(float DT)
         // when stall prevention is active we raise the minimum
         // airspeed based on aerodynamic load factor
         if (is_positive(aparm.airspeed_stall)) {
-            _TASmin = MAX(_TASmin, aparm.airspeed_stall*EAS2TAS*_load_factor);
+            _TASmin = MAX(_TASmin, aparm.airspeed_stall*EAS2TAS*sqrtf(_load_factor));
         } else {
-            _TASmin *= _load_factor;
+            _TASmin *= sqrtf(_load_factor);
         }
     }
 


### PR DESCRIPTION
This is a rebase of https://github.com/ArduPilot/ardupilot/pull/24509, see also https://github.com/ArduPilot/ardupilot/issues/24320 and https://github.com/ArduPilot/ardupilot/pull/29092

Were were passing about the sqrt of the laod factor. This changes to the standard definition.

There is no change in behavior.