### PR TITLE
AP_Airspeed: keep references to state and params in backend

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -667,16 +667,15 @@ void AP_Airspeed_Backend::update()
     bool prev_healthy = state.healthy;
 #endif
 
-    float raw_pressure = 0;
-    state.healthy = get_differential_pressure(raw_pressure);
-    float airspeed_pressure = raw_pressure - frontend.get_offset(state.instance);
+    state.healthy = get_differential_pressure(state.raw_pressure);
+    float airspeed_pressure = state.raw_pressure - frontend.get_offset(state.instance);
 
     // remember raw pressure for logging
     state.corrected_pressure = airspeed_pressure;
 
 #ifndef HAL_BUILD_AP_PERIPH
     if (state.cal.start_ms != 0) {
-        frontend.update_calibration(state.instance, raw_pressure);
+        frontend.update_calibration(state.instance, state.raw_pressure);
     }
 
     // filter before clamping positive
@@ -891,24 +890,30 @@ void AP_Airspeed::Log_Airspeed()
         if (!enabled(i) || sensor[i] == nullptr) {
             continue;
         }
+        sensor[i]->Log_Airspeed(now);
+    }
+}
+
+void AP_Airspeed_Backend::Log_Airspeed(uint64_t now)
+{
         float temperature;
-        if (!get_temperature(i, temperature)) {
+        if (!get_temperature(temperature)) {
             temperature = 0;
         }
         const struct log_ARSP pkt{
             LOG_PACKET_HEADER_INIT(LOG_ARSP_MSG),
             time_us       : now,
-            instance      : i,
-            airspeed      : get_raw_airspeed(i),
-            diffpressure  : get_differential_pressure(i),
+            instance      : state.instance,
+            airspeed      : state.raw_airspeed,
+            diffpressure  : state.raw_pressure,
             temperature   : (int16_t)(temperature * 100.0f),
-            rawpressure   : get_corrected_pressure(i),
-            offset        : get_offset(i),
-            use           : use(i),
-            healthy       : healthy(i),
-            health_prob   : get_health_probability(i),
-            test_ratio    : get_test_ratio(i),
-            primary       : get_primary()
+            rawpressure   : state.corrected_pressure,
+            offset        : frontend.get_offset(state.instance),
+            use           : frontend.use(state.instance),
+            healthy       : state.healthy,
+            health_prob   : state.failures.health_probability,
+            test_ratio    : frontend.get_test_ratio(state.instance),
+            primary       : frontend.get_primary()
         };
         AP::logger().WriteBlock(&pkt, sizeof(pkt));
 
@@ -918,23 +923,22 @@ void AP_Airspeed::Log_Airspeed()
             float temperature;
             float humidity;
         } hygrometer;
-        if (sensor[i]->get_hygrometer(hygrometer.sample_ms, hygrometer.temperature, hygrometer.humidity) &&
-            hygrometer.sample_ms != state[i].last_hygrometer_log_ms) {
+        if (get_hygrometer(hygrometer.sample_ms, hygrometer.temperature, hygrometer.humidity) &&
+            hygrometer.sample_ms != state.last_hygrometer_log_ms) {
             AP::logger().WriteStreaming("HYGR",
                                         "TimeUS,Id,Humidity,Temp",
                                         "s#%O",
                                         "F---",
                                         "QBff",
                                         AP_HAL::micros64(),
-                                        i,
+                                        state.instance,
                                         hygrometer.humidity,
                                         hygrometer.temperature);
-            state[i].last_hygrometer_log_ms = hygrometer.sample_ms;
+            state.last_hygrometer_log_ms = hygrometer.sample_ms;
         }
-#endif
-    }
+#endif  // AP_AIRSPEED_HYGROMETER_ENABLE
 }
-#endif
+#endif  // HAL_LOGGING_ENABLED
 
 bool AP_Airspeed::use(uint8_t i) const
 {

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -668,7 +668,7 @@ void AP_Airspeed_Backend::update()
 #endif
 
     state.healthy = get_differential_pressure(state.raw_pressure);
-    float airspeed_pressure = state.raw_pressure - frontend.get_offset(state.instance);
+    float airspeed_pressure = state.raw_pressure - get_offset();
 
     // remember raw pressure for logging
     state.corrected_pressure = airspeed_pressure;
@@ -908,7 +908,7 @@ void AP_Airspeed_Backend::Log_Airspeed(uint64_t now)
             diffpressure  : state.raw_pressure,
             temperature   : (int16_t)(temperature * 100.0f),
             rawpressure   : state.corrected_pressure,
-            offset        : frontend.get_offset(state.instance),
+            offset        : get_offset(),
             use           : frontend.use(state.instance),
             healthy       : state.healthy,
             health_prob   : state.failures.health_probability,

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -668,8 +668,7 @@ void AP_Airspeed_Backend::update()
 #endif
 
     float raw_pressure = 0;
-    state[i].healthy = sensor[i]->get_differential_pressure(raw_pressure);
-
+    state.healthy = get_differential_pressure(raw_pressure);
     float airspeed_pressure = raw_pressure - frontend.get_offset(state.instance);
 
     // remember raw pressure for logging

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -373,95 +373,98 @@ void AP_Airspeed::allocate()
 #else
     // look for sensors based on type parameters
     for (uint8_t i=0; i<AIRSPEED_MAX_SENSORS; i++) {
+        auto &_state = state[i];
+        auto &_param = param[i];
+        _state.instance = i;
 #if AP_AIRSPEED_AUTOCAL_ENABLE
-        state[i].calibration.init(param[i].ratio);
-        state[i].last_saved_ratio = param[i].ratio;
+        _state.calibration.init(_param.ratio);
+        _state.last_saved_ratio = _param.ratio;
 #endif
 
         // Set the enable automatically to false and set the probability that the airspeed is healhy to start with
-        state[i].failures.health_probability = 1.0f;
+        _state.failures.health_probability = 1.0f;
 
-        switch ((enum airspeed_type)param[i].type.get()) {
+        switch ((enum airspeed_type)_param.type.get()) {
         case TYPE_NONE:
             // nothing to do
             break;
 #if AP_AIRSPEED_MS4525_ENABLED
         case TYPE_I2C_MS4525:
-            sensor[i] = NEW_NOTHROW AP_Airspeed_MS4525(*this, i);
+            sensor[i] = NEW_NOTHROW AP_Airspeed_MS4525(*this, _state, _param);
             break;
 #endif  // AP_AIRSPEED_MS4525_ENABLED
 #if AP_AIRSPEED_SITL_ENABLED
         case TYPE_SITL:
-            sensor[i] = NEW_NOTHROW AP_Airspeed_SITL(*this, i);
+            sensor[i] = NEW_NOTHROW AP_Airspeed_SITL(*this, _state, _param);
             break;
 #endif  // AP_AIRSPEED_SITL_ENABLED
 #if AP_AIRSPEED_ANALOG_ENABLED
         case TYPE_ANALOG:
-            sensor[i] = NEW_NOTHROW AP_Airspeed_Analog(*this, i);
+            sensor[i] = NEW_NOTHROW AP_Airspeed_Analog(*this, _state, _param);
             break;
 #endif  // AP_AIRSPEED_ANALOG_ENABLED
 #if AP_AIRSPEED_MS5525_ENABLED
         case TYPE_I2C_MS5525:
-            sensor[i] = NEW_NOTHROW AP_Airspeed_MS5525(*this, i, AP_Airspeed_MS5525::MS5525_ADDR_AUTO);
+            sensor[i] = NEW_NOTHROW AP_Airspeed_MS5525(*this, _state, _param, AP_Airspeed_MS5525::MS5525_ADDR_AUTO);
             break;
 #endif  // AP_AIRSPEED_MS5525_ENABLED
 #if AP_AIRSPEED_MS5525_ENABLED
         case TYPE_I2C_MS5525_ADDRESS_1:
-            sensor[i] = NEW_NOTHROW AP_Airspeed_MS5525(*this, i, AP_Airspeed_MS5525::MS5525_ADDR_1);
+            sensor[i] = NEW_NOTHROW AP_Airspeed_MS5525(*this, _state, _param, AP_Airspeed_MS5525::MS5525_ADDR_1);
             break;
 #endif  // AP_AIRSPEED_MS5525_ENABLED
 #if AP_AIRSPEED_MS5525_ENABLED
         case TYPE_I2C_MS5525_ADDRESS_2:
-            sensor[i] = NEW_NOTHROW AP_Airspeed_MS5525(*this, i, AP_Airspeed_MS5525::MS5525_ADDR_2);
+            sensor[i] = NEW_NOTHROW AP_Airspeed_MS5525(*this, _state, _param, AP_Airspeed_MS5525::MS5525_ADDR_2);
             break;
 #endif  // AP_AIRSPEED_MS5525_ENABLED
 #if AP_AIRSPEED_SDP3X_ENABLED
         case TYPE_I2C_SDP3X:
-            sensor[i] = NEW_NOTHROW AP_Airspeed_SDP3X(*this, i);
+            sensor[i] = NEW_NOTHROW AP_Airspeed_SDP3X(*this, _state, _param);
             break;
 #endif  // AP_AIRSPEED_SDP3X_ENABLED
 #if AP_AIRSPEED_DLVR_ENABLED
         case TYPE_I2C_DLVR_5IN:
-            sensor[i] = NEW_NOTHROW AP_Airspeed_DLVR(*this, i, 5);
+            sensor[i] = NEW_NOTHROW AP_Airspeed_DLVR(*this, _state, _param, 5);
             break;
         case TYPE_I2C_DLVR_10IN:
-            sensor[i] = NEW_NOTHROW AP_Airspeed_DLVR(*this, i, 10);
+            sensor[i] = NEW_NOTHROW AP_Airspeed_DLVR(*this, _state, _param, 10);
             break;
         case TYPE_I2C_DLVR_20IN:
-            sensor[i] = NEW_NOTHROW AP_Airspeed_DLVR(*this, i, 20);
+            sensor[i] = NEW_NOTHROW AP_Airspeed_DLVR(*this, _state, _param, 20);
             break;
         case TYPE_I2C_DLVR_30IN:
-            sensor[i] = NEW_NOTHROW AP_Airspeed_DLVR(*this, i, 30);
+            sensor[i] = NEW_NOTHROW AP_Airspeed_DLVR(*this, _state, _param, 30);
             break;
         case TYPE_I2C_DLVR_60IN:
-            sensor[i] = NEW_NOTHROW AP_Airspeed_DLVR(*this, i, 60);
+            sensor[i] = NEW_NOTHROW AP_Airspeed_DLVR(*this, _state, _param, 60);
             break;
 #endif  // AP_AIRSPEED_DLVR_ENABLED
 #if AP_AIRSPEED_ASP5033_ENABLED
         case TYPE_I2C_ASP5033:
-            sensor[i] = NEW_NOTHROW AP_Airspeed_ASP5033(*this, i);
+            sensor[i] = NEW_NOTHROW AP_Airspeed_ASP5033(*this, _state, _param);
             break;
 #endif  // AP_AIRSPEED_ASP5033_ENABLED
 #if AP_AIRSPEED_DRONECAN_ENABLED
         case TYPE_UAVCAN:
-            sensor[i] = AP_Airspeed_DroneCAN::probe(*this, i, uint32_t(param[i].bus_id.get()));
+            sensor[i] = AP_Airspeed_DroneCAN::probe(*this, _state, _param, uint32_t(_param.bus_id.get()));
             break;
 #endif  // AP_AIRSPEED_DRONECAN_ENABLED
 #if AP_AIRSPEED_NMEA_ENABLED
         case TYPE_NMEA_WATER:
 #if APM_BUILD_TYPE(APM_BUILD_Rover) || APM_BUILD_TYPE(APM_BUILD_ArduSub) 
-            sensor[i] = NEW_NOTHROW AP_Airspeed_NMEA(*this, i);
+            sensor[i] = NEW_NOTHROW AP_Airspeed_NMEA(*this, _state, _param);
 #endif
             break;
 #endif  // AP_AIRSPEED_NMEA_ENABLED
 #if AP_AIRSPEED_MSP_ENABLED
         case TYPE_MSP:
-            sensor[i] = NEW_NOTHROW AP_Airspeed_MSP(*this, i, 0);
+            sensor[i] = NEW_NOTHROW AP_Airspeed_MSP(*this, _state, _param, 0);
             break;
 #endif  // AP_AIRSPEED_MSP_ENABLED
 #if AP_AIRSPEED_EXTERNAL_ENABLED
         case TYPE_EXTERNAL:
-            sensor[i] = NEW_NOTHROW AP_Airspeed_External(*this, i);
+            sensor[i] = NEW_NOTHROW AP_Airspeed_External(*this, _state, _param);
             break;
 #endif  // AP_AIRSPEED_EXTERNAL_ENABLED
 #if AP_AIRSPEED_AUAV_ENABLED
@@ -490,8 +493,10 @@ void AP_Airspeed::allocate()
     // we need a 2nd pass for DroneCAN sensors so we can match order by DEVID
     // the 2nd pass accepts any devid
     for (uint8_t i=0; i<AIRSPEED_MAX_SENSORS; i++) {
-        if (sensor[i] == nullptr && (enum airspeed_type)param[i].type.get() == TYPE_UAVCAN) {
-            sensor[i] = AP_Airspeed_DroneCAN::probe(*this, i, 0);
+        auto &_state = state[i];
+        auto &_param = param[i];
+        if (sensor[i] == nullptr && (enum airspeed_type)_param.type.get() == TYPE_UAVCAN) {
+            sensor[i] = AP_Airspeed_DroneCAN::probe(*this, _state, _param, 0);
             if (sensor[i] != nullptr) {
                 num_sensors = i+1;
             }
@@ -506,7 +511,8 @@ void AP_Airspeed::allocate()
         if (sensor[i] == nullptr) {
             // note we use set() not set_and_save() to allow a sensor to be temporarily
             // removed for one boot without losing its slot
-            param[i].bus_id.set(0);
+            auto &_param = param[i];
+            _param.bus_id.set(0);
         }
     }
 }

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -649,17 +649,14 @@ AP_Airspeed::CalibrationState AP_Airspeed::get_calibration_state() const
 }
 
 // read one airspeed sensor
-void AP_Airspeed::read(uint8_t i)
+void AP_Airspeed_Backend::update()
 {
-    if (!enabled(i) || !sensor[i]) {
-        return;
-    }
-    state[i].last_update_ms = AP_HAL::millis();
+    state.last_update_ms = AP_HAL::millis();
 
     // try and get a direct reading of airspeed
-    if (sensor[i]->has_airspeed()) {
-        state[i].healthy = sensor[i]->get_airspeed(state[i].airspeed);
-        state[i].raw_airspeed = state[i].airspeed;  // for logging
+    if (has_airspeed()) {
+        state.healthy = get_airspeed(state.airspeed);
+        state.raw_airspeed = state.airspeed;  // for logging
         return;
     }
 
@@ -667,20 +664,20 @@ void AP_Airspeed::read(uint8_t i)
     /*
       remember the old healthy state
      */
-    bool prev_healthy = state[i].healthy;
+    bool prev_healthy = state.healthy;
 #endif
 
     float raw_pressure = 0;
     state[i].healthy = sensor[i]->get_differential_pressure(raw_pressure);
 
-    float airspeed_pressure = raw_pressure - get_offset(i);
+    float airspeed_pressure = raw_pressure - frontend.get_offset(state.instance);
 
     // remember raw pressure for logging
-    state[i].corrected_pressure = airspeed_pressure;
+    state.corrected_pressure = airspeed_pressure;
 
 #ifndef HAL_BUILD_AP_PERIPH
-    if (state[i].cal.start_ms != 0) {
-        update_calibration(i, raw_pressure);
+    if (state.cal.start_ms != 0) {
+        frontend.update_calibration(state.instance, raw_pressure);
     }
 
     // filter before clamping positive
@@ -688,31 +685,31 @@ void AP_Airspeed::read(uint8_t i)
         // if the previous state was not healthy then we should not
         // use an IIR filter, otherwise a bad reading will last for
         // some time after the sensor becomes healthy again
-        state[i].filtered_pressure = airspeed_pressure;
+        state.filtered_pressure = airspeed_pressure;
     } else {
-        state[i].filtered_pressure = 0.7f * state[i].filtered_pressure + 0.3f * airspeed_pressure;
+        state.filtered_pressure = 0.7f * state.filtered_pressure + 0.3f * airspeed_pressure;
     }
 
     /*
       we support different pitot tube setups so user can choose if
       they want to be able to detect pressure on the static port
      */
-    switch ((enum pitot_tube_order)param[i].tube_order.get()) {
-    case PITOT_TUBE_ORDER_NEGATIVE:
-        state[i].last_pressure  = -airspeed_pressure;
-        state[i].raw_airspeed   = sqrtf(MAX(-airspeed_pressure, 0) * param[i].ratio);
-        state[i].airspeed       = sqrtf(MAX(-state[i].filtered_pressure, 0) * param[i].ratio);
+    switch ((enum AP_Airspeed::pitot_tube_order)params.tube_order.get()) {
+    case AP_Airspeed::pitot_tube_order::PITOT_TUBE_ORDER_NEGATIVE:
+        state.last_pressure  = -airspeed_pressure;
+        state.raw_airspeed   = sqrtf(MAX(-airspeed_pressure, 0) * params.ratio);
+        state.airspeed       = sqrtf(MAX(-state.filtered_pressure, 0) * params.ratio);
         break;
-    case PITOT_TUBE_ORDER_POSITIVE:
-        state[i].last_pressure  = airspeed_pressure;
-        state[i].raw_airspeed   = sqrtf(MAX(airspeed_pressure, 0) * param[i].ratio);
-        state[i].airspeed       = sqrtf(MAX(state[i].filtered_pressure, 0) * param[i].ratio);
+    case AP_Airspeed::pitot_tube_order::PITOT_TUBE_ORDER_POSITIVE:
+        state.last_pressure  = airspeed_pressure;
+        state.raw_airspeed   = sqrtf(MAX(airspeed_pressure, 0) * params.ratio);
+        state.airspeed       = sqrtf(MAX(state.filtered_pressure, 0) * params.ratio);
         break;
-    case PITOT_TUBE_ORDER_AUTO:
+    case AP_Airspeed::pitot_tube_order::PITOT_TUBE_ORDER_AUTO:
     default:
-        state[i].last_pressure  = fabsf(airspeed_pressure);
-        state[i].raw_airspeed   = sqrtf(fabsf(airspeed_pressure) * param[i].ratio);
-        state[i].airspeed       = sqrtf(fabsf(state[i].filtered_pressure) * param[i].ratio);
+        state.last_pressure  = fabsf(airspeed_pressure);
+        state.raw_airspeed   = sqrtf(fabsf(airspeed_pressure) * params.ratio);
+        state.airspeed       = sqrtf(fabsf(state.filtered_pressure) * params.ratio);
         break;
     }
 #endif // HAL_BUILD_AP_PERIPH
@@ -801,7 +798,13 @@ void AP_Airspeed::update()
     }
 
     for (uint8_t i=0; i<AIRSPEED_MAX_SENSORS; i++) {
-        read(i);
+        if (!enabled(i)) {
+            continue;
+        }
+        if (sensor[i] == nullptr) {
+            continue;
+        }
+        sensor[i]->update();
     }
 
 #if HAL_GCS_ENABLED

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -912,7 +912,7 @@ void AP_Airspeed_Backend::Log_Airspeed(uint64_t now)
             use           : frontend.use(state.instance),
             healthy       : state.healthy,
             health_prob   : state.failures.health_probability,
-            test_ratio    : frontend.get_test_ratio(state.instance),
+            test_ratio    : state.failures.test_ratio,
             primary       : frontend.get_primary()
         };
         AP::logger().WriteBlock(&pkt, sizeof(pkt));

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -286,7 +286,11 @@ private:
 
     AP_Airspeed_Params param[AIRSPEED_MAX_SENSORS];
 
+    CalibrationState calibration_state[AIRSPEED_MAX_SENSORS];
+
+public:
     struct airspeed_state {
+        uint8_t instance;
         float   raw_airspeed;
         float   airspeed;
         float	last_pressure;
@@ -322,7 +326,11 @@ private:
 #if AP_AIRSPEED_HYGROMETER_ENABLE
         uint32_t last_hygrometer_log_ms;
 #endif
-    } state[AIRSPEED_MAX_SENSORS];
+    };
+
+private:
+
+    airspeed_state state[AIRSPEED_MAX_SENSORS];
 
     bool calibration_enabled;
 

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -346,8 +346,6 @@ private:
 
     uint32_t _log_bit = -1;     // stores which bit in LOG_BITMASK is used to indicate we should log airspeed readings
 
-    void read(uint8_t i);
-
     // get the health probability
     float get_health_probability(uint8_t i) const {
         return state[i].failures.health_probability;

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -358,9 +358,6 @@ private:
     void update_calibration(uint8_t i, float raw_pressure);
     void update_calibration(uint8_t i, const Vector3f &vground, int16_t max_airspeed_allowed_during_cal);
     void send_airspeed_calibration(const Vector3f &vg);
-    // return the current calibration offset
-    float get_offset(uint8_t i) const;
-    float get_offset(void) const { return get_offset(primary); }
 
     void check_sensor_failures();
     void check_sensor_ahrs_wind_max_failures(uint8_t i);

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -347,14 +347,6 @@ private:
 
     uint32_t _log_bit = -1;     // stores which bit in LOG_BITMASK is used to indicate we should log airspeed readings
 
-    // get the consistency test ratio
-    float get_test_ratio(uint8_t i) const {
-        return state[i].failures.test_ratio;
-    }
-    float get_test_ratio(void) const {
-        return get_test_ratio(primary);
-    }
-
     void update_calibration(uint8_t i, float raw_pressure);
     void update_calibration(uint8_t i, const Vector3f &vground, int16_t max_airspeed_allowed_during_cal);
     void send_airspeed_calibration(const Vector3f &vg);

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -291,6 +291,7 @@ private:
 public:
     struct airspeed_state {
         uint8_t instance;
+        float   raw_pressure;
         float   raw_airspeed;
         float   airspeed;
         float	last_pressure;
@@ -345,14 +346,6 @@ private:
     uint8_t last_user_primary;
 
     uint32_t _log_bit = -1;     // stores which bit in LOG_BITMASK is used to indicate we should log airspeed readings
-
-    // get the health probability
-    float get_health_probability(uint8_t i) const {
-        return state[i].failures.health_probability;
-    }
-    float get_health_probability(void) const {
-        return get_health_probability(primary);
-    }
 
     // get the consistency test ratio
     float get_test_ratio(uint8_t i) const {

--- a/libraries/AP_Airspeed/AP_Airspeed_Backend.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_Backend.cpp
@@ -28,16 +28,17 @@
 
 extern const AP_HAL::HAL &hal;
 
-AP_Airspeed_Backend::AP_Airspeed_Backend(AP_Airspeed &_frontend, uint8_t _instance) :
+AP_Airspeed_Backend::AP_Airspeed_Backend(AP_Airspeed &_frontend, AP_Airspeed::airspeed_state &_state, AP_Airspeed_Params &_params) :
     frontend(_frontend),
-    instance(_instance)
+    state(_state),
+    params(_params)
 {
 }
 
 int8_t AP_Airspeed_Backend::get_pin(void) const
 {
 #ifndef HAL_BUILD_AP_PERIPH
-    return frontend.param[instance].pin;
+    return params.pin;
 #else
     return 0;
 #endif
@@ -45,22 +46,22 @@ int8_t AP_Airspeed_Backend::get_pin(void) const
 
 float AP_Airspeed_Backend::get_psi_range(void) const
 {
-    return frontend.param[instance].psi_range;
+    return params.psi_range;
 }
 
 uint8_t AP_Airspeed_Backend::get_bus(void) const
 {
-    return frontend.param[instance].bus;
+    return params.bus;
 }
 
 bool AP_Airspeed_Backend::bus_is_configured(void) const
 {
-    return frontend.param[instance].bus.configured();
+    return params.bus.configured();
 }
 
 void AP_Airspeed_Backend::set_bus_id(uint32_t id)
 {
-    frontend.param[instance].bus_id.set_and_save(int32_t(id));
+    params.bus_id.set_and_save(int32_t(id));
 }
 
 #endif  // AP_AIRSPEED_ENABLED

--- a/libraries/AP_Airspeed/AP_Airspeed_Backend.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_Backend.h
@@ -36,6 +36,9 @@ public:
     // probe and initialise the sensor
     virtual bool init(void) = 0;
 
+    // method called by the frontend in the main thread:
+    void update();
+
     // return the current differential_pressure in Pascal
     virtual bool get_differential_pressure(float &pressure) {return false;}
 
@@ -66,6 +69,8 @@ protected:
     uint8_t get_instance(void) const {
         return state.instance;
     }
+
+    float get_pressure();
 
     // see if voltage correction should be disabled
     bool disable_voltage_correction(void) const {

--- a/libraries/AP_Airspeed/AP_Airspeed_Backend.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_Backend.h
@@ -61,6 +61,10 @@ public:
     virtual bool get_hygrometer(uint32_t &last_sample_ms, float &temperature, float &humidity) { return false; }
 #endif
 
+#if HAL_LOGGING_ENABLED
+    void Log_Airspeed(uint64_t now);
+#endif  // HAL_LOGGING_ENABLED
+
 protected:
     int8_t get_pin(void) const;
     float get_psi_range(void) const;

--- a/libraries/AP_Airspeed/AP_Airspeed_Backend.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_Backend.h
@@ -116,6 +116,15 @@ protected:
 #endif
     }
 
+    // return the current calibration offset
+    float get_offset() const {
+#ifndef HAL_BUILD_AP_PERIPH
+        return params.offset;
+#else
+        return 0.0;
+#endif
+    }
+
     // set use
     void set_use(int8_t use) {
 #ifndef HAL_BUILD_AP_PERIPH

--- a/libraries/AP_Airspeed/AP_Airspeed_Backend.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_Backend.h
@@ -70,8 +70,6 @@ protected:
         return state.instance;
     }
 
-    float get_pressure();
-
     // see if voltage correction should be disabled
     bool disable_voltage_correction(void) const {
         return (frontend._options.get() & AP_Airspeed::OptionsMask::DISABLE_VOLTAGE_CORRECTION) != 0;

--- a/libraries/AP_Airspeed/AP_Airspeed_DLVR.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_DLVR.cpp
@@ -34,8 +34,8 @@ extern const AP_HAL::HAL &hal;
 #endif
 
 
-AP_Airspeed_DLVR::AP_Airspeed_DLVR(AP_Airspeed &_frontend, uint8_t _instance, const float _range_inH2O) :
-    AP_Airspeed_Backend(_frontend, _instance),
+AP_Airspeed_DLVR::AP_Airspeed_DLVR(AP_Airspeed &_frontend, class AP_Airspeed::airspeed_state &_state, class AP_Airspeed_Params &_params, const float _range_inH2O) :
+    AP_Airspeed_Backend(_frontend, _state, _params),
     range_inH2O(_range_inH2O)
 {}
 
@@ -43,14 +43,15 @@ AP_Airspeed_DLVR::AP_Airspeed_DLVR(AP_Airspeed &_frontend, uint8_t _instance, co
   probe for a sensor on a given i2c address
  */
 AP_Airspeed_Backend *AP_Airspeed_DLVR::probe(AP_Airspeed &_frontend,
-                                             uint8_t _instance,
+                                             class AP_Airspeed::airspeed_state &_state,
+                                             class AP_Airspeed_Params &_params,
                                              AP_HAL::I2CDevice *_dev,
                                              const float _range_inH2O)
 {
     if (!_dev) {
         return nullptr;
     }
-    AP_Airspeed_DLVR *sensor = NEW_NOTHROW AP_Airspeed_DLVR(_frontend, _instance, _range_inH2O);
+    AP_Airspeed_DLVR *sensor = NEW_NOTHROW AP_Airspeed_DLVR(_frontend, _state, _params, _range_inH2O);
     if (!sensor) {
         return nullptr;
     }

--- a/libraries/AP_Airspeed/AP_Airspeed_DLVR.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_DLVR.h
@@ -31,12 +31,12 @@ class AP_Airspeed_DLVR : public AP_Airspeed_Backend
 {
 public:
 
-    AP_Airspeed_DLVR(AP_Airspeed &frontend, uint8_t _instance, const float _range_inH2O);
-    static AP_Airspeed_Backend *probe(AP_Airspeed &frontend, uint8_t _instance, AP_HAL::I2CDevice *_dev, const float _range_inH2O);
-
-    ~AP_Airspeed_DLVR(void) {
-        delete dev;
-    }
+    AP_Airspeed_DLVR(AP_Airspeed &frontend, class AP_Airspeed::airspeed_state &state, class AP_Airspeed_Params &params, const float _range_inH2O);
+    static AP_Airspeed_Backend *probe(AP_Airspeed &frontend,
+                                      class AP_Airspeed::airspeed_state &state,
+                                      class AP_Airspeed_Params &params,
+                                      AP_HAL::I2CDevice *_dev,
+                                      const float _range_inH2O);
 
     // probe and initialise the sensor
     bool init() override;

--- a/libraries/AP_Airspeed/AP_Airspeed_DroneCAN.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_DroneCAN.cpp
@@ -22,7 +22,7 @@ bool AP_Airspeed_DroneCAN::subscribe_msgs(AP_DroneCAN* ap_dronecan)
     ;
 }
 
-AP_Airspeed_Backend* AP_Airspeed_DroneCAN::probe(AP_Airspeed &_frontend, uint8_t _instance, uint32_t previous_devid)
+AP_Airspeed_Backend* AP_Airspeed_DroneCAN::probe(AP_Airspeed &_frontend, class AP_Airspeed::airspeed_state &_state, class AP_Airspeed_Params &_params, uint32_t previous_devid)
 {
     WITH_SEMAPHORE(_sem_registry);
 

--- a/libraries/AP_Airspeed/AP_Airspeed_DroneCAN.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_DroneCAN.h
@@ -28,7 +28,7 @@ public:
 
     static bool subscribe_msgs(AP_DroneCAN* ap_dronecan);
 
-    static AP_Airspeed_Backend* probe(AP_Airspeed &_frontend, uint8_t _instance, uint32_t previous_devid);
+    static AP_Airspeed_Backend* probe(AP_Airspeed &_frontend, class AP_Airspeed::airspeed_state &_state, class AP_Airspeed_Params &_params, uint32_t previous_devid);
 
 private:
 

--- a/libraries/AP_Airspeed/AP_Airspeed_External.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_External.cpp
@@ -2,10 +2,10 @@
 
 #if AP_AIRSPEED_EXTERNAL_ENABLED
 
-AP_Airspeed_External::AP_Airspeed_External(AP_Airspeed &_frontend, uint8_t _instance) :
-    AP_Airspeed_Backend(_frontend, _instance)
+AP_Airspeed_External::AP_Airspeed_External(AP_Airspeed &_frontend, class AP_Airspeed::airspeed_state &_state, class AP_Airspeed_Params &_params) :
+    AP_Airspeed_Backend(_frontend, _state, _params)
 {
-    set_bus_id(AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_SERIAL,0,_instance,0));
+    set_bus_id(AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_SERIAL,0,_state.instance,0));
 }
 
 // return the current differential_pressure in Pascal

--- a/libraries/AP_Airspeed/AP_Airspeed_External.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_External.h
@@ -13,7 +13,7 @@
 class AP_Airspeed_External : public AP_Airspeed_Backend
 {
 public:
-    AP_Airspeed_External(AP_Airspeed &airspeed, uint8_t instance);
+    AP_Airspeed_External(AP_Airspeed &airspeed, class AP_Airspeed::airspeed_state &state, class AP_Airspeed_Params &params);
 
     bool init(void) override {
         return true;

--- a/libraries/AP_Airspeed/AP_Airspeed_MS5525.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_MS5525.cpp
@@ -55,8 +55,8 @@ extern const AP_HAL::HAL &hal;
 #define REG_CONVERT_PRESSURE    REG_CONVERT_D1_OSR_1024
 #define REG_CONVERT_TEMPERATURE REG_CONVERT_D2_OSR_1024
 
-AP_Airspeed_MS5525::AP_Airspeed_MS5525(AP_Airspeed &_frontend, uint8_t _instance, MS5525_ADDR address) :
-    AP_Airspeed_Backend(_frontend, _instance)
+AP_Airspeed_MS5525::AP_Airspeed_MS5525(AP_Airspeed &_frontend, class AP_Airspeed::airspeed_state &_state, class AP_Airspeed_Params &_params, MS5525_ADDR address) :
+    AP_Airspeed_Backend(_frontend, _state, _params)
 {
     _address = address;
 }

--- a/libraries/AP_Airspeed/AP_Airspeed_MS5525.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_MS5525.h
@@ -37,11 +37,10 @@ public:
         MS5525_ADDR_AUTO = 255, // does not need to be 255, just needs to be out of the address array
     };
 
-    AP_Airspeed_MS5525(AP_Airspeed &frontend, uint8_t _instance, MS5525_ADDR address);
+    AP_Airspeed_MS5525(AP_Airspeed &frontend, class AP_Airspeed::airspeed_state &state, class AP_Airspeed_Params &params, MS5525_ADDR address);
     ~AP_Airspeed_MS5525(void) {
         delete dev;
     }
-
     // probe and initialise the sensor
     bool init() override;
 

--- a/libraries/AP_Airspeed/AP_Airspeed_MSP.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_MSP.cpp
@@ -2,8 +2,8 @@
 
 #if AP_AIRSPEED_MSP_ENABLED
 
-AP_Airspeed_MSP::AP_Airspeed_MSP(AP_Airspeed &_frontend, uint8_t _instance, uint8_t _msp_instance) :
-    AP_Airspeed_Backend(_frontend, _instance),
+AP_Airspeed_MSP::AP_Airspeed_MSP(AP_Airspeed &_frontend, class AP_Airspeed::airspeed_state &_state, class AP_Airspeed_Params &_params, uint8_t _msp_instance) :
+    AP_Airspeed_Backend(_frontend, _state, _params),
     msp_instance(_msp_instance)
 {
     set_bus_id(AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_MSP,0,msp_instance,0));

--- a/libraries/AP_Airspeed/AP_Airspeed_MSP.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_MSP.h
@@ -14,7 +14,7 @@
 class AP_Airspeed_MSP : public AP_Airspeed_Backend
 {
 public:
-    AP_Airspeed_MSP(AP_Airspeed &airspeed, uint8_t instance, uint8_t msp_instance);
+    AP_Airspeed_MSP(AP_Airspeed &airspeed, class AP_Airspeed::airspeed_state &state, class AP_Airspeed_Params &params, uint8_t msp_instance);
 
     bool init(void) override {
         return true;

--- a/libraries/AP_Airspeed/AP_Airspeed_analog.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_analog.cpp
@@ -30,8 +30,8 @@ extern const AP_HAL::HAL &hal;
 // scaling for 3DR analog airspeed sensor
 #define VOLTS_TO_PASCAL 819
 
-AP_Airspeed_Analog::AP_Airspeed_Analog(AP_Airspeed &_frontend, uint8_t _instance) :
-    AP_Airspeed_Backend(_frontend, _instance)
+AP_Airspeed_Analog::AP_Airspeed_Analog(AP_Airspeed &_frontend, class AP_Airspeed::airspeed_state &_state, class AP_Airspeed_Params &_params) :
+    AP_Airspeed_Backend(_frontend, _state, _params)
 {
     _source = hal.analogin->channel(get_pin());
 }

--- a/libraries/AP_Airspeed/AP_Airspeed_analog.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_analog.h
@@ -11,7 +11,7 @@
 class AP_Airspeed_Analog : public AP_Airspeed_Backend
 {
 public:
-    AP_Airspeed_Analog(AP_Airspeed &frontend, uint8_t _instance);
+    AP_Airspeed_Analog(AP_Airspeed &frontend, class AP_Airspeed::airspeed_state &state, class AP_Airspeed_Params &params);
 
     // probe and initialise the sensor
     bool init(void) override;

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -1621,7 +1621,7 @@ INCLUDE common.ld
                     (wrapper, dev[i]) = self.parse_i2c_device(dev[i])
             n = len(devlist)+1
             devlist.append('HAL_AIRSPEED_PROBE%u' % n)
-            args = ['*this', str(idx)] + dev[1:]
+            args = ['*this', f"state[{str(idx)}]", f"param[{str(idx)}]"] + dev[1:]
             f.write(
                 '#define HAL_AIRSPEED_PROBE%u %s ADD_BACKEND(AP_Airspeed_%s::probe(%s))\n'
                 % (n, wrapper, driver, ','.join(args)))


### PR DESCRIPTION
... much as we do for GPS, rangefinder and several other libraries