### PR TITLE
SITL : ACC, ARSPD Parameter documentation

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -2559,13 +2559,6 @@ class TestSuite(ABC):
     def get_sim_parameter_documentation_get_whitelist(self):
         # common parameters
         ret = set([
-            "SIM_ACC_TRIM_X",
-            "SIM_ACC_TRIM_Y",
-            "SIM_ACC_TRIM_Z",
-            "SIM_ARSPD2_OFS",
-            "SIM_ARSPD2_RND",
-            "SIM_ARSPD_OFS",
-            "SIM_ARSPD_RND",
             "SIM_FTOWESC_ENA",
             "SIM_FTOWESC_POW",
             "SIM_IE24_ENABLE",

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -1119,6 +1119,11 @@ const AP_Param::GroupInfo SIM::var_ins[] = {
     // @Vector3Parameter: 1
     AP_GROUPINFO("ACC3_SCAL",    24, SIM, accel_scale[2], 0),
 #endif
+    // @Param: ACC_TRIM
+    // @DisplayName: Accelerometer trim
+    // @Description: Trim applied to simulated accelerometer
+    // @User: Advanced
+    // @Vector3Parameter: 1
     AP_GROUPINFO("ACC_TRIM",     25, SIM, accel_trim, 0),
 
 #if APM_BUILD_TYPE(APM_BUILD_Rover)

--- a/libraries/SITL/SITL_Airspeed.cpp
+++ b/libraries/SITL/SITL_Airspeed.cpp
@@ -5,8 +5,17 @@
 namespace SITL {
 // user settable parameters for airspeed sensors
 const AP_Param::GroupInfo SIM::AirspeedParm::var_info[] = {
-        // user settable parameters for the 1st airspeed sensor
+    // @Param: RND
+    // @DisplayName: Airspeed sensor noise
+    // @Description: Simulated Airspeed sensor noise
+    // @Units: Pa
+    // @User: Advanced
     AP_GROUPINFO("RND",     1, AirspeedParm,  noise, 2.0),
+    // @Param: OFS
+    // @DisplayName: Airspeed sensor offset
+    // @Description: Simulated Airspeed sensor offset
+    // @Units: m/s
+    // @User: Advanced
     AP_GROUPINFO("OFS",     2, AirspeedParm,  offset, 2013),
     // @Param: FAIL
     // @DisplayName: Airspeed sensor failure


### PR DESCRIPTION
Partially addressing https://github.com/ArduPilot/ardupilot/issues/22903 by adding documentation for ACC_TRIM, ARSPD parameters.

CI check:
![#2](https://github.com/user-attachments/assets/378f1511-e69a-4d4f-9614-ba5921b5fb0c)
