### PR TITLE
ardupilotwaf: fix ESP32 memory zero comment

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -1061,6 +1061,7 @@ class esp32(Board):
         env.CXXFLAGS.remove('-Werror=shadow')
 
         # wrap malloc to ensure memory is zeroed
+        # note that this also needs to be done in the CMakeLists.txt files
         env.LINKFLAGS += ['-Wl,--wrap,malloc']
 
         # TODO: remove once hwdef.dat support is in place
@@ -1390,7 +1391,6 @@ class linux(Board):
         ]
 
         # wrap malloc to ensure memory is zeroed
-        # note that this also needs to be done in the CMakeLists.txt files
         env.LINKFLAGS += ['-Wl,--wrap,malloc']
 
         if cfg.options.force_32bit:


### PR DESCRIPTION
Followup to PR #29005 (d9e5f2d8a7581b79430568bc7a8487df6b4f3a85).