### PR TITLE
ardupilotwaf: add -fno-math-errno to ChibiOS boards

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -1155,6 +1155,7 @@ class chibios(Board):
             '-fno-builtin-vprintf',
             '-fno-builtin-vfprintf',
             '-fno-builtin-puts',
+            '-fno-math-errno',
             '-mno-thumb-interwork',
             '-mthumb',
             '--specs=nano.specs',


### PR DESCRIPTION
Allows better use of math instructions as opposed to calling library functions to implement math like `sqrt`. This saves flash and increases speed. ArduPilot does not use EDOM or ERANGE anyway.

Might cause issues with malloc errno:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88576 but ArduPilot does not check for ENOMEM or use errno much anyway.

```
Board                    AP_Periph  blimp  bootloader  copter  heli   iofirmware  plane  rover  sub
CubeOrange-periph-heavy  -400              *
Durandal                            -352   *           -1216   -1000              -1344  -744   -640
Hitec-Airspeed           *                 *
KakuteH7-bdshot                     368    *           0       208                216    352    400
MatekF405                           16     *           -120    -24                -112   96     0
Pixhawk1-1M-bdshot                  0                  32      -48                -48    32     -16
f103-QiotekPeriph        *                 *
f303-Universal           -160              *
iomcu                                                                 *
revo-mini                           8      *           -120    -32                -120   88     0
skyviper-v2450                                         -168
```

Seems this results in really bad inlining decisions on `-Os` targets. I have a followup but am curious if this is a desired flag.

Tested on CubeOrange using scripting aerobatics in SITL on HW.