### PR TITLE
SRV_Channel: alphabetise function param desc

### DIFF
--- a/libraries/SRV_Channel/SRV_Channel.cpp
+++ b/libraries/SRV_Channel/SRV_Channel.cpp
@@ -64,6 +64,7 @@ const AP_Param::GroupInfo SRV_Channel::var_info[] = {
     // @Param: FUNCTION
     // @DisplayName: Servo output function
     // @Description: Function assigned to this servo. Setting this to Disabled(0) will setup this output for control by auto missions or MAVLink servo set commands. any other value will enable the corresponding function
+    // @SortValues: AlphabeticalZeroAtTop
     // @Values: -1:GPIO
     // @Values{Plane, Copter, Rover}: -1:GPIO
     // @Values: 0:Disabled


### PR DESCRIPTION
Similar to PR https://github.com/ArduPilot/ardupilot/pull/29075 this alphabetises the SERVOx_FUNCTION parameter description to make selecting from a drop-down easier for the user.  As with previous changes this only affects the apm.pdef.xml file meaning the GCSs show the change but the wiki's full parameter list is not affected

In some ways its not perfect in that "Motor10" appears immediately after "Motor1".  Similarly "Scripting10" appears immediately after "Scripting1".  Still, it's easier to maintain than a fully manual list

After the change:
```
      <param humanName="Servo output function" name="SERVO1_FUNCTION" documentation="Function assigned to this servo. Setting this to Disabled(0) will setup this output for control by auto missions or MAVLink servo set commands. any other value will enable the corresponding function" user="Standard">
        <values>
          <value code="-1">GPIO</value>
          <value code="0">Disabled</value>
          <value code="138">Alarm</value>
          <value code="139">Alarm Inverted</value>
          <value code="81">BoostThrottle</value>
          <value code="91">CameraAperture</value>
          <value code="92">CameraFocus</value>
          <value code="90">CameraISO</value>
          <value code="93">CameraShutterSpeed</value>
          <value code="10">CameraTrigger</value>
          <value code="30">EngineRunEnable</value>
          <value code="28">Gripper</value>
          <value code="31">HeliRSC</value>
          <value code="32">HeliTailRSC</value>
          <value code="29">LandingGear</value>
          <value code="33">Motor1</value>
          <value code="83">Motor10</value>
          <value code="84">Motor11</value>
          <value code="85">Motor12</value>
          <value code="34">Motor2</value>
          <value code="35">Motor3</value>
          <value code="36">Motor4</value>
          <value code="37">Motor5</value>
          <value code="38">Motor6</value>
          <value code="39">Motor7</value>
          <value code="40">Motor8</value>
          <value code="82">Motor9</value>
          <value code="7">Mount1Pitch</value>
          <value code="9">Mount1Retract</value>
          <value code="8">Mount1Roll</value>
          <value code="6">Mount1Yaw</value>
          <value code="13">Mount2Pitch</value>
          <value code="15">Mount2Retract</value>
          <value code="14">Mount2Roll</value>
          <value code="12">Mount2Yaw</value>
          <value code="120">NeoPixel1</value>
          <value code="121">NeoPixel2</value>
          <value code="122">NeoPixel3</value>
          <value code="123">NeoPixel4</value>
          <value code="27">Parachute</value>
          <value code="129">ProfiLED1</value>
          <value code="130">ProfiLED2</value>
          <value code="131">ProfiLED3</value>
          <value code="132">ProfiLEDClock</value>
          <value code="51">RCIN1</value>
          <value code="60">RCIN10</value>
          <value code="149">RCIN10Scaled</value>
          <value code="61">RCIN11</value>
          <value code="150">RCIN11Scaled</value>
          <value code="62">RCIN12</value>
          <value code="151">RCIN12Scaled</value>
          <value code="63">RCIN13</value>
          <value code="152">RCIN13Scaled</value>
          <value code="64">RCIN14</value>
          <value code="153">RCIN14Scaled</value>
          <value code="65">RCIN15</value>
          <value code="154">RCIN15Scaled</value>
          <value code="66">RCIN16</value>
          <value code="155">RCIN16Scaled</value>
          <value code="140">RCIN1Scaled</value>
          <value code="52">RCIN2</value>
          <value code="141">RCIN2Scaled</value>
          <value code="53">RCIN3</value>
          <value code="142">RCIN3Scaled</value>
          <value code="54">RCIN4</value>
          <value code="143">RCIN4Scaled</value>
          <value code="55">RCIN5</value>
          <value code="144">RCIN5Scaled</value>
          <value code="56">RCIN6</value>
          <value code="145">RCIN6Scaled</value>
          <value code="57">RCIN7</value>
          <value code="146">RCIN7Scaled</value>
          <value code="58">RCIN8</value>
          <value code="147">RCIN8Scaled</value>
          <value code="59">RCIN9</value>
          <value code="148">RCIN9Scaled</value>
          <value code="1">RCPassThru</value>
          <value code="125">RatePitch</value>
          <value code="124">RateRoll</value>
          <value code="126">RateThrust</value>
          <value code="127">RateYaw</value>
          <value code="136">SERVOn_MAX</value>
          <value code="134">SERVOn_MIN</value>
          <value code="135">SERVOn_TRIM</value>
          <value code="94">Script1</value>
          <value code="103">Script10</value>
          <value code="104">Script11</value>
          <value code="105">Script12</value>
          <value code="106">Script13</value>
          <value code="107">Script14</value>
          <value code="108">Script15</value>
          <value code="109">Script16</value>
          <value code="95">Script2</value>
          <value code="96">Script3</value>
          <value code="97">Script4</value>
          <value code="98">Script5</value>
          <value code="99">Script6</value>
          <value code="100">Script7</value>
          <value code="101">Script8</value>
          <value code="102">Script9</value>
          <value code="22">SprayerPump</value>
          <value code="23">SprayerSpinner</value>
          <value code="73">ThrottleLeft</value>
          <value code="74">ThrottleRight</value>
          <value code="75">TiltMotorFrontLeft</value>
          <value code="76">TiltMotorFrontRight</value>
          <value code="88">Winch</value>
          <value code="133">Winch Clutch</value>
        </values>
        <field name="RebootRequired">True</field>
      </param>
```

Before the change:

```
      <param humanName="Servo output function" name="SERVO1_FUNCTION" documentation="Function assigned to this servo. Setting this to Disabled(0) will setup this output for control by auto missions or MAVLink servo set commands. any other value will enable the corresponding function" user="Standard">
        <values>
          <value code="-1">GPIO</value>
          <value code="0">Disabled</value>
          <value code="1">RCPassThru</value>
          <value code="6">Mount1Yaw</value>
          <value code="7">Mount1Pitch</value>
          <value code="8">Mount1Roll</value>
          <value code="9">Mount1Retract</value>
          <value code="10">CameraTrigger</value>
          <value code="12">Mount2Yaw</value>
          <value code="13">Mount2Pitch</value>
          <value code="14">Mount2Roll</value>
          <value code="15">Mount2Retract</value>
          <value code="22">SprayerPump</value>
          <value code="23">SprayerSpinner</value>
          <value code="27">Parachute</value>
          <value code="28">Gripper</value>
          <value code="29">LandingGear</value>
          <value code="30">EngineRunEnable</value>
          <value code="31">HeliRSC</value>
          <value code="32">HeliTailRSC</value>
          <value code="33">Motor1</value>
          <value code="34">Motor2</value>
          <value code="35">Motor3</value>
          <value code="36">Motor4</value>
          <value code="37">Motor5</value>
          <value code="38">Motor6</value>
          <value code="39">Motor7</value>
          <value code="40">Motor8</value>
          <value code="51">RCIN1</value>
          <value code="52">RCIN2</value>
          <value code="53">RCIN3</value>
          <value code="54">RCIN4</value>
          <value code="55">RCIN5</value>
          <value code="56">RCIN6</value>
          <value code="57">RCIN7</value>
          <value code="58">RCIN8</value>
          <value code="59">RCIN9</value>
          <value code="60">RCIN10</value>
          <value code="61">RCIN11</value>
          <value code="62">RCIN12</value>
          <value code="63">RCIN13</value>
          <value code="64">RCIN14</value>
          <value code="65">RCIN15</value>
          <value code="66">RCIN16</value>
          <value code="73">ThrottleLeft</value>
          <value code="74">ThrottleRight</value>
          <value code="75">TiltMotorFrontLeft</value>
          <value code="76">TiltMotorFrontRight</value>
          <value code="81">BoostThrottle</value>
          <value code="82">Motor9</value>
          <value code="83">Motor10</value>
          <value code="84">Motor11</value>
          <value code="85">Motor12</value>
          <value code="88">Winch</value>
          <value code="90">CameraISO</value>
          <value code="91">CameraAperture</value>
          <value code="92">CameraFocus</value>
          <value code="93">CameraShutterSpeed</value>
          <value code="94">Script1</value>
          <value code="95">Script2</value>
          <value code="96">Script3</value>
          <value code="97">Script4</value>
          <value code="98">Script5</value>
          <value code="99">Script6</value>
          <value code="100">Script7</value>
          <value code="101">Script8</value>
          <value code="102">Script9</value>
          <value code="103">Script10</value>
          <value code="104">Script11</value>
          <value code="105">Script12</value>
          <value code="106">Script13</value>
          <value code="107">Script14</value>
          <value code="108">Script15</value>
          <value code="109">Script16</value>
          <value code="120">NeoPixel1</value>
          <value code="121">NeoPixel2</value>
          <value code="122">NeoPixel3</value>
          <value code="123">NeoPixel4</value>
          <value code="124">RateRoll</value>
          <value code="125">RatePitch</value>
          <value code="126">RateThrust</value>
          <value code="127">RateYaw</value>
          <value code="129">ProfiLED1</value>
          <value code="130">ProfiLED2</value>
          <value code="131">ProfiLED3</value>
          <value code="132">ProfiLEDClock</value>
          <value code="133">Winch Clutch</value>
          <value code="134">SERVOn_MIN</value>
          <value code="135">SERVOn_TRIM</value>
          <value code="136">SERVOn_MAX</value>
          <value code="138">Alarm</value>
          <value code="139">Alarm Inverted</value>
          <value code="140">RCIN1Scaled</value>
          <value code="141">RCIN2Scaled</value>
          <value code="142">RCIN3Scaled</value>
          <value code="143">RCIN4Scaled</value>
          <value code="144">RCIN5Scaled</value>
          <value code="145">RCIN6Scaled</value>
          <value code="146">RCIN7Scaled</value>
          <value code="147">RCIN8Scaled</value>
          <value code="148">RCIN9Scaled</value>
          <value code="149">RCIN10Scaled</value>
          <value code="150">RCIN11Scaled</value>
          <value code="151">RCIN12Scaled</value>
          <value code="152">RCIN13Scaled</value>
          <value code="153">RCIN14Scaled</value>
          <value code="154">RCIN15Scaled</value>
          <value code="155">RCIN16Scaled</value>
        </values>
        <field name="RebootRequired">True</field>
      </param>
```