### PR TITLE
AP_HAL_ChibiOS: enable scripting on KakuteH7Mini-Nand

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteH7Mini-Nand/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteH7Mini-Nand/hwdef.dat
@@ -11,3 +11,6 @@ IMU BMI270 SPI:bmi270 ROTATION_PITCH_180_YAW_90
 
 undef HAL_LOGGING_DATAFLASH_ENABLED
 DATAFLASH littlefs:w25nxx
+
+# KakuteH7Mini disables due to smaller flash chip; allow the enabled default
+undef AP_SCRIPTING_ENABLED


### PR DESCRIPTION
It has LittleFS now so it can easily use scripting.

Missed on the LittleFS PR but has worked great for me.