### PR TITLE
Fix for ArduPilot/ardupilot#28826 and #28827

### DIFF
--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -792,7 +792,7 @@ def start_vehicle(binary, opts, stuff, spawns=None):
                 print("The parameter file (%s) does not exist" % (x,))
                 sys.exit(1)
         path = ",".join(paths)
-        if cmd_opts.count > 1 or opts.auto_sysid:
+        if cmd_opts.count > 1:
             # we are in a subdirectory when using -n
             path = os.path.join("..", path)
         progress("Using defaults from (%s)" % (path,))
@@ -809,6 +809,10 @@ def start_vehicle(binary, opts, stuff, spawns=None):
                       (file,))
                 sys.exit(1)
 
+            if cmd_opts.count > 1 and not os.path.isabs(file):
+                # we are in a subdirectory when using -n
+                file = os.path.join("..", file)
+            
             if path is not None:
                 path += "," + str(file)
             else:

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -812,7 +812,7 @@ def start_vehicle(binary, opts, stuff, spawns=None):
             if cmd_opts.count > 1 and not os.path.isabs(file):
                 # we are in a subdirectory when using -n
                 file = os.path.join("..", file)
-            
+
             if path is not None:
                 path += "," + str(file)
             else:


### PR DESCRIPTION
Addresses #28826 and #28827 by adding a check for relative param file paths in sim_vehicle.py when simulating multiple agents.

Expected behaviour is that running either
- `sim_vehicle.py` with `--count` > 1 and `--add-param-file=<relative path>`, or
- `sim_vehicle.py --auto-sysid --count 1`

no longer fail.