### PR TITLE
SITL: correct documentation metadata for FETTechOneWireESC and Richen…

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -2559,11 +2559,6 @@ class TestSuite(ABC):
     def get_sim_parameter_documentation_get_whitelist(self):
         # common parameters
         ret = set([
-            "SIM_FTOWESC_ENA",
-            "SIM_FTOWESC_POW",
-            "SIM_IE24_ENABLE",
-            "SIM_IE24_ERROR",
-            "SIM_IE24_STATE",
             "SIM_IMUT1_ACC1_X",
             "SIM_IMUT1_ACC1_Y",
             "SIM_IMUT1_ACC1_Z",
@@ -2704,8 +2699,6 @@ class TestSuite(ABC):
             "SIM_MAG1_OFS_Z",
             "SIM_PARA_ENABLE",
             "SIM_PARA_PIN",
-            "SIM_RICH_CTRL",
-            "SIM_RICH_ENABLE",
             "SIM_SHIP_DSIZE",
             "SIM_SHIP_ENABLE",
             "SIM_SHIP_OFS_X",

--- a/libraries/SITL/SIM_FETtecOneWireESC.cpp
+++ b/libraries/SITL/SIM_FETtecOneWireESC.cpp
@@ -64,7 +64,7 @@ const AP_Param::GroupInfo FETtecOneWireESC::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("ENA", 1, FETtecOneWireESC, _enabled, 0),
 
-    // @Param: PWOF
+    // @Param: POW
     // @DisplayName: Power off FETtec ESC mask
     // @Description: Allows you to turn power off to the simulated ESCs.  Bits correspond to the ESC ID, *NOT* their servo channel.
     // @User: Advanced

--- a/libraries/SITL/SIM_RichenPower.cpp
+++ b/libraries/SITL/SIM_RichenPower.cpp
@@ -39,7 +39,7 @@ const AP_Param::GroupInfo RichenPower::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("ENABLE", 0, RichenPower, _enabled, 0),
 
-    // @Param: CTRL_PIN
+    // @Param: CTRL
     // @DisplayName: Pin RichenPower is connectred to
     // @Description: The pin number that the RichenPower spinner servo is connected to. (start at 1)
     // @Range: 0 15

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -628,12 +628,15 @@ const AP_Param::GroupInfo SIM::var_info3[] = {
     // @Description: Number of simulated IMUs to create
     AP_GROUPINFO("IMU_COUNT",    23, SIM,  imu_count,  2),
 
+    // @Group: FTOWESC_
     // @Path: ./SIM_FETtecOneWireESC.cpp
     AP_SUBGROUPINFO(fetteconewireesc_sim, "FTOWESC_", 30, SIM, FETtecOneWireESC),
 
+    // @Group: RICH_
     // @Path: ./SIM_RichenPower.cpp
     AP_SUBGROUPINFO(richenpower_sim, "RICH_", 31, SIM, RichenPower),
 
+    // @Group: IE24_
     // @Path: ./SIM_IntelligentEnergy24.cpp
     AP_SUBGROUPINFO(ie24_sim, "IE24_", 32, SIM, IntelligentEnergy24),
 


### PR DESCRIPTION
…Power and IE24

.... we had documentation for these parameters but it wasn't being used!