### PR TITLE
AP_Bootloader: Reserving IDs for Lumenier

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -359,6 +359,9 @@ AP_HW_KRSHKF7_MINI                   4000
 AP_HW_HAKRC_F405                     4200
 AP_HW_HAKRC_F405Wing                 4201
 
+# IDs 4500-4509 reserved for Lumenier
+AP_HW_LUMENIER_LUX_F765_NDAA         4500
+
 # IDs 5000-5099 reserved for Carbonix
 # IDs 5100-5199 reserved for SYPAQ Systems
 # IDs 5200-5209 reserved for Airvolute


### PR DESCRIPTION
Reserving IDs for new Lumenier flight controllers. First new hardware will be LUX F765 NDAA. 