### PR TITLE
SITL: AP_Periph: `sim_update_actuator` report IDs that match AP channel indexes

### DIFF
--- a/Tools/AP_Periph/rc_out.cpp
+++ b/Tools/AP_Periph/rc_out.cpp
@@ -187,7 +187,7 @@ void AP_Periph_FW::rcout_update()
 */
 void AP_Periph_FW::sim_update_actuator(uint8_t actuator_id)
 {
-    sim_actuator.mask |= 1U << actuator_id;
+    sim_actuator.mask |= 1U << (actuator_id - 1);
 
     // send status at 10Hz
     const uint32_t period_ms = 100;
@@ -202,7 +202,7 @@ void AP_Periph_FW::sim_update_actuator(uint8_t actuator_id)
         if ((sim_actuator.mask & (1U<<i)) == 0) {
             continue;
         }
-        const SRV_Channel::Aux_servo_function_t function = SRV_Channel::Aux_servo_function_t(SRV_Channel::k_rcin1 + actuator_id - 1);
+        const SRV_Channel::Aux_servo_function_t function = SRV_Channel::Aux_servo_function_t(SRV_Channel::k_rcin1 + i);
         uavcan_equipment_actuator_Status pkt {};
         pkt.actuator_id = i;
         // assume 45 degree angle for simulation


### PR DESCRIPTION
I found this was required to get the channel numbers reported by the servos to match those set in the can servo bitmask.