### PR TITLE
ROS2: Update from Humble to Jazzy

### DIFF
--- a/.github/workflows/colcon.yml
+++ b/.github/workflows/colcon.yml
@@ -178,7 +178,7 @@ jobs:
           # Workaround for flake8 attribute error
           # https://github.com/ArduPilot/ardupilot/pull/24277#issuecomment-1632833433
           python -m pip install flake8==3.7.9
-          source /opt/ros/humble/setup.bash
+          source /opt/ros/jazzy/setup.bash
           rosdep install --from-paths src --ignore-src --default-yes
       - name: Install MAVProxy
         run: |
@@ -192,7 +192,7 @@ jobs:
       - name: Build with colcon
         shell: 'bash'
         run: |
-          source /opt/ros/humble/setup.bash
+          source /opt/ros/jazzy/setup.bash
           colcon build --packages-up-to ardupilot_dds_tests --cmake-args -DBUILD_TESTING=ON
       - name: Test with colcon
         shell: 'bash'

--- a/Tools/ros2/README.md
+++ b/Tools/ros2/README.md
@@ -38,7 +38,7 @@ ArduPilot `AP_DDS` client library.
 
 The packages depend on:
 
-- [ROS 2 Humble](https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html)
+- [ROS 2 jazzy](https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debians.html)
 
 
 ## Install Ubuntu
@@ -49,7 +49,7 @@ The packages depend on:
 mkdir -p ~/ros2_ws/src && cd ~/ros2_ws/src
 ```
 
-The ROS 2 tutorials contain more details regarding [ROS 2 workspaces](https://docs.ros.org/en/humble/Tutorials/Workspace/Creating-A-Workspace.html).
+The ROS 2 tutorials contain more details regarding [ROS 2 workspaces](https://docs.ros.org/en/jazzy/Tutorials/Workspace/Creating-A-Workspace.html).
 
 #### 2. Get the `ros2.repos` file
 
@@ -63,7 +63,7 @@ vcs import --recursive < ros2.repos
 
 ```bash
 cd ~/ros2_ws
-source /opt/ros/humble/setup.bash
+source /opt/ros/jazzy/setup.bash
 sudo apt update
 rosdep update
 rosdep install --rosdistro ${ROS_DISTRO} --from-paths src
@@ -71,12 +71,12 @@ rosdep install --rosdistro ${ROS_DISTRO} --from-paths src
 
 #### 4. Build
 
-Check that the [ROS environment](https://docs.ros.org/en/humble/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html#check-environment-variables) is configured correctly:
+Check that the [ROS environment](https://docs.ros.org/en/jazzy/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html#check-environment-variables) is configured correctly:
 
 ```bash
 ROS_VERSION=2
 ROS_PYTHON_VERSION=3
-ROS_DISTRO=humble
+ROS_DISTRO=jazzy
 ```
 
 ```bash

--- a/Tools/ros2/ros2.repos
+++ b/Tools/ros2/ros2.repos
@@ -6,4 +6,4 @@ repositories:
   micro_ros_agent:
     type: git
     url: https://github.com/micro-ROS/micro-ROS-Agent.git
-    version: humble
+    version: jazzy

--- a/Tools/ros2/ros2.repos
+++ b/Tools/ros2/ros2.repos
@@ -1,7 +1,7 @@
 repositories:
   ardupilot:
     type: git
-    url: https://github.com/ArduPilot/ardupilot.git
+    url: https://github.com/andrewkwolek/ardupilot.git
     version: master
   micro_ros_agent:
     type: git

--- a/Tools/ros2/ros2_macos.repos
+++ b/Tools/ros2/ros2_macos.repos
@@ -14,4 +14,4 @@ repositories:
   micro_ros_msgs:
     type: git
     url: https://github.com/micro-ROS/micro_ros_msgs.git
-    version: humble
+    version: jazzy

--- a/libraries/AP_DDS/AP_DDS_External_Odom.cpp
+++ b/libraries/AP_DDS/AP_DDS_External_Odom.cpp
@@ -66,7 +66,7 @@ void AP_DDS_External_Odom::convert_transform(const geometry_msgs_msg_Transform& 
 
     // In AP, q1 is the quaternion's scalar component.
     // In ROS, w is the quaternion's scalar component.
-    // https://docs.ros.org/en/humble/Tutorials/Intermediate/Tf2/Quaternion-Fundamentals.html#components-of-a-quaternion
+    // https://docs.ros.org/en/jazzy/Tutorials/Intermediate/Tf2/Quaternion-Fundamentals.html#components-of-a-quaternion
     rotation.q1 = ros_transform.rotation.w;
     rotation.q2 = ros_transform.rotation.x;
     rotation.q3 = -ros_transform.rotation.y;

--- a/libraries/AP_DDS/README.md
+++ b/libraries/AP_DDS/README.md
@@ -98,16 +98,16 @@ REBOOT
 
 Follow the steps to use the microROS Agent
 
-- Install ROS Humble (as described here)
+- Install ROS jazzy (as described here)
 
-  - https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html
+  - https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debians.html
 
 - Install geographic_msgs
   ```console
-  sudo apt install ros-humble-geographic-msgs
+  sudo apt install ros-jazzy-geographic-msgs
   ```
 
-- Install and run the microROS agent (as described here). Make sure to use the `humble` branch.
+- Install and run the microROS agent (as described here). Make sure to use the `jazzy` branch.
   - Follow [the instructions](https://micro.ros.org/docs/tutorials/core/first_application_linux/) for the following:
 
     - Do "Installing ROS 2 and the micro-ROS build system"
@@ -122,7 +122,7 @@ Follow the steps to use the microROS Agent
 After your setups are complete, do the following:
 - Source the ROS 2 installation
   ```console
-  source /opt/ros/humble/setup.bash
+  source /opt/ros/jazzy/setup.bash
   ```
 
 Next, follow the associated section for your chosen transport, and finally you can use the ROS 2 CLI.
@@ -220,7 +220,7 @@ The static transforms for enabled sensors are also published, and can be receive
 ros2 topic echo /ap/tf_static --qos-depth 1 --qos-history keep_last --qos-reliability reliable --qos-durability transient_local --once
 ```
 
-In order to consume the transforms, it's highly recommended to [create and run a transform broadcaster in ROS 2](https://docs.ros.org/en/humble/Concepts/About-Tf2.html#tutorials).
+In order to consume the transforms, it's highly recommended to [create and run a transform broadcaster in ROS 2](https://docs.ros.org/en/jazzy/Concepts/About-Tf2.html#tutorials).
 
 ## Using ROS 2 services
 
@@ -322,7 +322,7 @@ To get a new IDL file from ROS 2, follow this process:
 
 ```bash
 cd ardupilot
-source /opt/ros/humble/setup.bash
+source /opt/ros/jazzy/setup.bash
 
 # Find the IDL file
 find /opt/ros/$ROS_DISTRO -type f -wholename \*builtin_interfaces/msg/Time.idl
@@ -331,7 +331,7 @@ find /opt/ros/$ROS_DISTRO -type f -wholename \*builtin_interfaces/msg/Time.idl
 mkdir -p libraries/AP_DDS/Idl/builtin_interfaces/msg/
 
 # Copy the IDL
-cp /opt/ros/humble/share/builtin_interfaces/msg/Time.idl libraries/AP_DDS/Idl/builtin_interfaces/msg/
+cp /opt/ros/jazzy/share/builtin_interfaces/msg/Time.idl libraries/AP_DDS/Idl/builtin_interfaces/msg/
 
 # Build the code again with the `--enable-dds` flag as described above
 ```


### PR DESCRIPTION
I made some changes to make the repo compatible with Jazzy Jalisco which is the most recent build of ROS2. Most of these changes involved changing dependencies from `humble` to `jazzy`. I also changed micro_ros_agent to use the jazzy branch instead of the humble branch in Tools/ros2/ros2.repos.

I was able to successfully run the installation and SITL in the documentation (https://ardupilot.org/dev/docs/ros2-sitl.html). This did not take much time, so it makes me curious why this hasn't been done yet? It is possible there are some low level changes that need to be made that I am unaware of. Thanks!