### PR TITLE
AP_Scripting: video-stream-information param index fix

### DIFF
--- a/libraries/AP_Scripting/applets/video-stream-information.lua
+++ b/libraries/AP_Scripting/applets/video-stream-information.lua
@@ -2,7 +2,7 @@
     Populate the VIDEO_STREAM_INFORMATION message based on user parameters
  --]]
 
-local PARAM_TABLE_KEY = 87
+local PARAM_TABLE_KEY = 90
 local PARAM_TABLE_PREFIX = "VID1_"
 
 local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
@@ -21,10 +21,10 @@ function bind_add_param(name, idx, default_value)
     return Parameter(PARAM_TABLE_PREFIX .. name)
 end
 
- -- setup script specific parameters
- assert(param:add_table(PARAM_TABLE_KEY, PARAM_TABLE_PREFIX, 15), 'could not add param table')
+-- setup script specific parameters
+assert(param:add_table(PARAM_TABLE_KEY, PARAM_TABLE_PREFIX, 15), 'could not add param table')
 
- --[[
+--[[
   // @Param: VID1_CAMMODEL
   // @DisplayName: Camera1 Video Stream Camera Model
   // @Description: Video stream camera model


### PR DESCRIPTION
This fixes the video-stream-information.lua script's parameter table key so that it doesn't conflict with the [ahrs-set-origin.lua](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Scripting/applets/ahrs-set-origin.lua) script

This overlap is my fault but also quite recent (6 weeks ago)

- Nov 29th PR https://github.com/ArduPilot/ardupilot/pull/28770
- Nov 30th PR https://github.com/ArduPilot/ardupilot/pull/28780

I know of 1 partner using the ahrs-set-origin script and at most 2 developers using video-stream-information.lua.  I figure the two developers will be able to handle the change more easily which is why I've chosen to modify the video script.