### PR TITLE
Remove vestiges of LearnType::LEARN_INTERNAL

### DIFF
--- a/AntennaTracker/Tracker.cpp
+++ b/AntennaTracker/Tracker.cpp
@@ -53,7 +53,6 @@ const AP_Scheduler::Task Tracker::scheduler_tasks[] = {
     SCHED_TASK(update_tracking,        50,    1000, 15),
     SCHED_TASK(update_GPS,             10,    4000, 20),
     SCHED_TASK(update_compass,         10,    1500, 25),
-    SCHED_TASK(compass_save,            0.02,  200, 30),
     SCHED_TASK_CLASS(AP_BattMonitor,    &tracker.battery,   read,           10, 1500, 35),
     SCHED_TASK_CLASS(AP_Baro,          &tracker.barometer,  update,         10, 1500, 40),
     SCHED_TASK_CLASS(GCS,              (GCS*)&tracker._gcs, update_receive, 50, 1700, 45),

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -177,7 +177,6 @@ private:
 
     // sensors.cpp
     void update_ahrs();
-    void compass_save();
     void update_compass(void);
     void update_GPS(void);
     void handle_battery_failsafe(const char* type_str, const int8_t action);

--- a/AntennaTracker/sensors.cpp
+++ b/AntennaTracker/sensors.cpp
@@ -16,15 +16,6 @@ void Tracker::update_compass(void)
     compass.read();
 }
 
-// Save compass offsets
-void Tracker::compass_save() {
-    if (AP::compass().available() &&
-        compass.get_learn_type() >= Compass::LEARN_INTERNAL &&
-        !hal.util->get_soft_armed()) {
-        compass.save_offsets();
-    }
-}
-
 /*
   read the GPS
  */

--- a/ArduPlane/Plane.cpp
+++ b/ArduPlane/Plane.cpp
@@ -114,7 +114,6 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
 #if HAL_LOGGING_ENABLED
     SCHED_TASK_CLASS(AP_Scheduler, &plane.scheduler, update_logging,         0.2,    100, 111),
 #endif
-    SCHED_TASK(compass_save,          0.1,    200, 114),
 #if HAL_LOGGING_ENABLED
     SCHED_TASK(Log_Write_FullRate,        400,    300, 117),
     SCHED_TASK(update_logging10,        10,    300, 120),
@@ -403,18 +402,6 @@ void Plane::three_hz_loop()
 #if AP_FENCE_ENABLED
     fence_check();
 #endif
-}
-
-void Plane::compass_save()
-{
-    if (AP::compass().available() &&
-        compass.get_learn_type() >= Compass::LEARN_INTERNAL &&
-        !hal.util->get_soft_armed()) {
-        /*
-          only save offsets when disarmed
-         */
-        compass.save_offsets();
-    }
 }
 
 #if AP_AIRSPEED_AUTOCAL_ENABLE

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1095,7 +1095,6 @@ private:
 #if AP_AIRSPEED_AUTOCAL_ENABLE
     void airspeed_ratio_update(void);
 #endif
-    void compass_save(void);
     void update_logging10(void);
     void update_logging25(void);
     void update_control_mode(void);

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -121,7 +121,6 @@ const AP_Scheduler::Task Rover::scheduler_tasks[] = {
 #if HAL_SPRAYER_ENABLED
     SCHED_TASK_CLASS(AC_Sprayer,          &rover.g2.sprayer,       update,          3,  90,  99),
 #endif
-    SCHED_TASK(compass_save,            0.1,  200, 105),
 #if HAL_LOGGING_ENABLED
     SCHED_TASK_CLASS(AP_Logger,           &rover.logger,           periodic_tasks, 50,  300, 108),
 #endif

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -372,7 +372,6 @@ private:
 
     // sensors.cpp
     void update_compass(void);
-    void compass_save(void);
     void update_wheel_encoder();
 #if AP_RANGEFINDER_ENABLED
     void read_rangefinders(void);

--- a/Rover/sensors.cpp
+++ b/Rover/sensors.cpp
@@ -8,15 +8,6 @@ void Rover::update_compass(void)
     compass.read();
 }
 
-// Save compass offsets
-void Rover::compass_save() {
-    if (AP::compass().available() &&
-        compass.get_learn_type() >= Compass::LEARN_INTERNAL &&
-        !arming.is_armed()) {
-        compass.save_offsets();
-    }
-}
-
 // update wheel encoders
 void Rover::update_wheel_encoder()
 {

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -117,7 +117,7 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @Param: LEARN
     // @DisplayName: Learn compass offsets automatically
     // @Description: Enable or disable the automatic learning of compass offsets. You can enable learning either using a compass-only method that is suitable only for fixed wing aircraft or using the offsets learnt by the active EKF state estimator. If this option is enabled then the learnt offsets are saved when you disarm the vehicle. If InFlight learning is enabled then the compass with automatically start learning once a flight starts (must be armed). While InFlight learning is running you cannot use position control modes.
-    // @Values: 0:Disabled,1:Internal-Learning,2:EKF-Learning,3:InFlight-Learning
+    // @Values: 0:Disabled,2:EKF-Learning,3:InFlight-Learning
     // @User: Advanced
     AP_GROUPINFO("LEARN",  3, Compass, _learn, COMPASS_LEARN_DEFAULT),
 #endif

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -320,7 +320,7 @@ public:
 
     enum LearnType {
         LEARN_NONE=0,
-        LEARN_INTERNAL=1,
+        // LEARN_INTERNAL=1,
         LEARN_EKF=2,
         LEARN_INFLIGHT=3
     };


### PR DESCRIPTION
57a3bc1397239cbd66e5b32d59dcc467003e4bad changed the code from "internal" to "in-flight

It seems the old value of "1" was no longer valid

It also changed things so that the learning system saved the offsets.

We have two sorts of compass learning:
 - in-flight compass learning, type=3
 - copy-values-from-EKF, type=2

Copy-values-from-EKF sets-and-saves offsets on a per-vehicle basis at the moment, eg. https://github.com/ardupilot/ardupilot/blob/master/ArduCopter/AP_Arming.cpp#L814 so it doesn't want or need this code.

The in-flight learning system sets-and-saves the offsets via a called to fixed-mag-cal-yaw code here: https://github.com/ardupilot/ardupilot/blob/master/libraries/AP_Compass/Compass_learn.cpp#L65 (https://github.com/ardupilot/ardupilot/master/libraries/AP_Compass/AP_Compass_Calibration.cpp#L566)

This does seem to have been some sort of back-door for saving compass offsets on Rover, Plane and Tracker, bypassing "forcecal" requirements.
