### PR TITLE
Eahrs remove gps serial assumption

### DIFF
--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS.h
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS.h
@@ -86,6 +86,11 @@ public:
     // get serial port number, -1 for not enabled
     int8_t get_port(AvailableSensor sensor) const;
 
+    // check if a sensor type is enabled
+    bool has_sensor(AvailableSensor sensor) const {
+        return (uint16_t(sensors.get()) & uint16_t(sensor)) != 0;
+    }
+
     struct state_t {
         HAL_Semaphore sem;
 
@@ -189,11 +194,6 @@ private:
     AP_Int16         sensors;
 
     static AP_ExternalAHRS *_singleton;
-
-    // check if a sensor type is enabled
-    bool has_sensor(AvailableSensor sensor) const {
-        return (uint16_t(sensors.get()) & uint16_t(sensor)) != 0;
-    }
 
     // set default of EAHRS_SENSORS
     void set_default_sensors(uint16_t _sensors) {

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -662,7 +662,7 @@ AP_GPS_Backend *AP_GPS::_detect_instance(uint8_t instance)
 #endif
 #if HAL_EXTERNAL_AHRS_ENABLED
     case GPS_TYPE_EXTERNAL_AHRS:
-        if (AP::externalAHRS().get_port(AP_ExternalAHRS::AvailableSensor::GPS) >= 0) {
+        if (!AP::externalAHRS().has_sensor(AP_ExternalAHRS::AvailableSensor::GPS)) {
             dstate->auto_detected_baud = false; // specified, not detected
             return NEW_NOTHROW AP_GPS_ExternalAHRS(*this, params[instance], state[instance], nullptr);
         }


### PR DESCRIPTION
As discussed in Trimble partner chat, we are looking to add a new EAHRS that uses ethernet connection. The GPS is not connected via serial, there is no serial port. It uses UDP network API instead.

I propose we only check that the EARHS has the GPS sensor enabled.

The call to `get_port` prevents the upcoming Trimble PX-1 from being able to initialize, because `get_port` returns `-1`. 