### PR TITLE
Make compass LearnType enum-class and parameter AP_Enum

### DIFF
--- a/ArduCopter/AP_Arming_Copter.cpp
+++ b/ArduCopter/AP_Arming_Copter.cpp
@@ -807,7 +807,7 @@ bool AP_Arming_Copter::disarm(const AP_Arming::Method method, bool do_disarm_che
 
     // save compass offsets learned by the EKF if enabled
     Compass &compass = AP::compass();
-    if (ahrs.use_compass() && compass.get_learn_type() == Compass::LEARN_EKF) {
+    if (ahrs.use_compass() && compass.get_learn_type() == Compass::LearnType::COPY_FROM_EKF) {
         for(uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
             Vector3f magOffsets;
             if (ahrs.getMagOffsets(i, magOffsets)) {

--- a/ArduCopter/toy_mode.cpp
+++ b/ArduCopter/toy_mode.cpp
@@ -1079,9 +1079,9 @@ void ToyMode::arm_check_compass(void)
     if (offsets.length() > copter.compass.get_offsets_max() ||
         field < 200 || field > 800 ||
         !copter.compass.configured(unused_compass_configured_error_message, ARRAY_SIZE(unused_compass_configured_error_message))) {
-        if (copter.compass.get_learn_type() != Compass::LEARN_INFLIGHT) {
+        if (copter.compass.get_learn_type() != Compass::LearnType::INFLIGHT) {
             gcs().send_text(MAV_SEVERITY_INFO, "Tmode: enable compass learning");
-            copter.compass.set_learn_type(Compass::LEARN_INFLIGHT, false);
+            copter.compass.set_learn_type(Compass::LearnType::INFLIGHT, false);
         }
     }
 }

--- a/ArduSub/AP_Arming_Sub.cpp
+++ b/ArduSub/AP_Arming_Sub.cpp
@@ -179,7 +179,7 @@ bool AP_Arming_Sub::disarm(const AP_Arming::Method method, bool do_disarm_checks
     auto &ahrs = AP::ahrs();
 
     // save compass offsets learned by the EKF if enabled
-    if (ahrs.use_compass() && AP::compass().get_learn_type() == Compass::LEARN_EKF) {
+    if (ahrs.use_compass() && AP::compass().get_learn_type() == Compass::LearnType::COPY_FROM_EKF) {
         for (uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
             Vector3f magOffsets;
             if (ahrs.getMagOffsets(i, magOffsets)) {

--- a/Blimp/AP_Arming_Blimp.cpp
+++ b/Blimp/AP_Arming_Blimp.cpp
@@ -383,7 +383,7 @@ bool AP_Arming_Blimp::disarm(const AP_Arming::Method method, bool do_disarm_chec
 
     // save compass offsets learned by the EKF if enabled
     Compass &compass = AP::compass();
-    if (ahrs.use_compass() && compass.get_learn_type() == Compass::LEARN_EKF) {
+    if (ahrs.use_compass() && compass.get_learn_type() == Compass::LearnType::COPY_FROM_EKF) {
         for (uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
             Vector3f magOffsets;
             if (ahrs.getMagOffsets(i, magOffsets)) {

--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -1611,7 +1611,7 @@ void AP_Periph_FW::can_start()
         }
     }
     if (!has_uavcan_at_1MHz) {
-        g.can_protocol[0].set_and_save(uint8_t(AP_CAN::Protocol::DroneCAN));
+        g.can_protocol[0].set_and_save(AP_CAN::Protocol::DroneCAN);
         g.can_baudrate[0].set_and_save(1000000);
     }
 #endif // HAL_PERIPH_ENFORCE_AT_LEAST_ONE_PORT_IS_UAVCAN_1MHz

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -56,7 +56,7 @@ extern const AP_HAL::HAL& hal;
 #endif
 
 #ifndef COMPASS_LEARN_DEFAULT
-#define COMPASS_LEARN_DEFAULT Compass::LEARN_NONE
+#define COMPASS_LEARN_DEFAULT Compass::LearnType::NONE
 #endif
 
 #ifndef AP_COMPASS_OFFSETS_MAX_DEFAULT
@@ -119,7 +119,7 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @Description: Enable or disable the automatic learning of compass offsets. You can enable learning either using a compass-only method that is suitable only for fixed wing aircraft or using the offsets learnt by the active EKF state estimator. If this option is enabled then the learnt offsets are saved when you disarm the vehicle. If InFlight learning is enabled then the compass with automatically start learning once a flight starts (must be armed). While InFlight learning is running you cannot use position control modes.
     // @Values: 0:Disabled,2:EKF-Learning,3:InFlight-Learning
     // @User: Advanced
-    AP_GROUPINFO("LEARN",  3, Compass, _learn, COMPASS_LEARN_DEFAULT),
+    AP_GROUPINFO("LEARN",  3, Compass, _learn, float(COMPASS_LEARN_DEFAULT)),
 #endif
 
 #ifndef HAL_BUILD_AP_PERIPH
@@ -1793,11 +1793,11 @@ Compass::read(void)
         any_healthy |= _state[i].healthy;
     }
 #if COMPASS_LEARN_ENABLED
-    if (_learn == LEARN_INFLIGHT && !learn_allocated) {
+    if (_learn == LearnType::INFLIGHT && !learn_allocated) {
         learn_allocated = true;
         learn = NEW_NOTHROW CompassLearn(*this);
     }
-    if (_learn == LEARN_INFLIGHT && learn != nullptr) {
+    if (_learn == LearnType::INFLIGHT && learn != nullptr) {
         learn->update();
     }
 #endif
@@ -1985,7 +1985,7 @@ Compass::use_for_yaw(uint8_t i) const
     // when we are doing in-flight compass learning the state
     // estimator must not use the compass. The learning code turns off
     // inflight learning when it has converged
-    return _use_for_yaw[Priority(i)] && _learn.get() != LEARN_INFLIGHT;
+    return _use_for_yaw[Priority(i)] && _learn != LearnType::INFLIGHT;
 }
 
 /*

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -226,7 +226,7 @@ public:
 #endif  // AP_COMPASS_DIAGONALS_ENABLED
 
     // learn offsets accessor
-    bool learn_offsets_enabled() const { return _learn == LEARN_INFLIGHT; }
+    bool learn_offsets_enabled() const { return _learn == LearnType::INFLIGHT; }
 
     /// return true if the compass should be used for yaw calculations
     bool use_for_yaw(uint8_t i) const;
@@ -318,24 +318,24 @@ public:
 
     static const struct AP_Param::GroupInfo var_info[];
 
-    enum LearnType {
-        LEARN_NONE=0,
-        // LEARN_INTERNAL=1,
-        LEARN_EKF=2,
-        LEARN_INFLIGHT=3
+    enum class LearnType {
+        NONE          = 0,
+        // INTERNAL   = 1,
+        COPY_FROM_EKF = 2,
+        INFLIGHT      = 3,
     };
 
     // return the chosen learning type
-    enum LearnType get_learn_type(void) const {
-        return (enum LearnType)_learn.get();
+    LearnType get_learn_type(void) const {
+        return (LearnType)_learn.get();
     }
 
     // set the learning type
-    void set_learn_type(enum LearnType type, bool save) {
+    void set_learn_type(LearnType type, bool save) {
         if (save) {
-            _learn.set_and_save((int8_t)type);
+            _learn.set_and_save(type);
         } else {
-            _learn.set((int8_t)type);
+            _learn.set(type);
         }
     }
     
@@ -520,7 +520,7 @@ private:
     uint8_t     _unreg_compass_count;
 
     // settable parameters
-    AP_Int8 _learn;
+    AP_Enum<LearnType> _learn;
 
     // board orientation from AHRS
     enum Rotation _board_orientation = ROTATION_NONE;

--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -105,7 +105,7 @@ bool Compass::_start_calibration(uint8_t i, bool retry, float delay)
     }
 
     // disable compass learning both for calibration and after completion
-    _learn.set_and_save(0);
+    _learn.set_and_save(LearnType::NONE);
 
     return true;
 }

--- a/libraries/AP_Compass/Compass_learn.cpp
+++ b/libraries/AP_Compass/Compass_learn.cpp
@@ -29,7 +29,7 @@ CompassLearn::CompassLearn(Compass &_compass) :
 void CompassLearn::update(void)
 {
     const AP_Vehicle *vehicle = AP::vehicle();
-    if (compass.get_learn_type() != Compass::LEARN_INFLIGHT ||
+    if (compass.get_learn_type() != Compass::LearnType::INFLIGHT ||
         !hal.util->get_soft_armed() ||
         vehicle->get_time_flying_ms() < 3000) {
         // only learn when flying and with enough time to be clear of
@@ -65,7 +65,7 @@ void CompassLearn::update(void)
     const bool result = compass.mag_cal_fixed_yaw(degrees(yaw_rad), (1U<<HAL_COMPASS_MAX_SENSORS)-1, 0, 0, true);
     if (result) {
         AP_Notify::flags.compass_cal_running = false;
-        compass.set_learn_type(Compass::LEARN_NONE, true);
+        compass.set_learn_type(Compass::LearnType::NONE, true);
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "CompassLearn: Finished");
     }
 }

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -1090,6 +1090,9 @@ public:
     void set(eclass v) {
         AP_Int8::set(int8_t(v));
     }
+    void set_and_save(eclass v) {
+        AP_Int8::set_and_save(int8_t(v));
+    }
 };
 
 template<typename eclass>
@@ -1101,5 +1104,8 @@ public:
     }
     void set(eclass v) {
         AP_Int16::set(int16_t(v));
+    }
+    void set_and_save(eclass v) {
+        AP_Int16::set_and_save(int16_t(v));
     }
 };

--- a/libraries/AP_Relay/AP_Relay.cpp
+++ b/libraries/AP_Relay/AP_Relay.cpp
@@ -243,7 +243,7 @@ void AP_Relay::convert_params()
 #endif
 
     // Find old default param
-    int8_t default_state = 0; // off was the old behaviour
+    AP_Relay_Params::DefaultState default_state = AP_Relay_Params::DefaultState::OFF; // off was the old behaviour
     const bool have_default = AP_Param::get_param_by_index(this, 4, AP_PARAM_INT8, &default_state);
 
     // grab the old values if they were set
@@ -300,7 +300,7 @@ void AP_Relay::convert_params()
             new_fun = AP_Relay_Params::FUNCTION::RELAY;
 
         }
-        _params[i].function.set_and_save(int8_t(new_fun));
+        _params[i].function.set_and_save(new_fun);
 
 
         // Set the default state

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -1563,7 +1563,7 @@ bool RC_Channel::do_aux_function(const AuxFuncTrigger &trigger)
     case AUX_FUNC::COMPASS_LEARN:
         if (ch_flag == AuxSwitchPos::HIGH) {
             Compass &compass = AP::compass();
-            compass.set_learn_type(Compass::LEARN_INFLIGHT, false);
+            compass.set_learn_type(Compass::LearnType::INFLIGHT, false);
         }
         break;
 

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -284,11 +284,6 @@ public:
     // return the motor number of a channel, or -1 if not a motor
     int8_t get_motor_num(void) const;
 
-    // set and save function for channel. Used in upgrade of parameters in plane
-    void function_set_and_save(Function f) {
-        function.set_and_save(int8_t(f));
-    }
-
     // set and save function for reversed. Used in upgrade of parameters in plane
     void reversed_set_and_save_ifchanged(bool r) {
         reversed.set_and_save_ifchanged(r?1:0);


### PR DESCRIPTION
 - also adds set_and_save to AP_Enum and fixes some problems around that increased type safety.

Removes an old unused method with a bug in it.
