### PR TITLE
Tools: create_OEM_board: use argparse to parse command-line arguments

### DIFF
--- a/Tools/scripts/create_OEM_board.py
+++ b/Tools/scripts/create_OEM_board.py
@@ -24,14 +24,14 @@ class OEMCreate:
 
     def run(self):
         hwdef_dir = "libraries/AP_HAL_ChibiOS/hwdef"
-        oem_board_dirpath = f"{hwdef_dir}/{oem_board_name}"
+        oem_board_dirpath = f"{hwdef_dir}/{self.oem_board_name}"
 
         if os.path.exists(oem_board_dirpath):
-            raise ValueError(f"{oem_board_dirpath} already exists")  # FIXME exception type
+            raise ValueError(f"{self.oem_board_dirpath} already exists")  # FIXME exception type
 
         hwdef_include_relpath = None
         for extension in "dat", "inc":
-            tmp = f"../{board_name}/hwdef.{extension}"
+            tmp = f"../{self.board_name}/hwdef.{extension}"
             tmp_norm = os.path.normpath(f"{oem_board_dirpath}/{tmp}")
             if os.path.exists(tmp_norm):
                 hwdef_include_relpath = tmp
@@ -44,7 +44,7 @@ class OEMCreate:
         use_bootloader_from_board = ch.get_config('USE_BOOTLOADER_FROM_BOARD', default=None, required=False)
         if use_bootloader_from_board is None:
             hwdef_content += "\n"
-            hwdef_content += f"USE_BOOTLOADER_FROM_BOARD {board_name}\n"
+            hwdef_content += f"USE_BOOTLOADER_FROM_BOARD {self.board_name}\n"
 
         subprocess.run(["mkdir",  oem_board_dirpath])
 
@@ -52,17 +52,23 @@ class OEMCreate:
         new_hwdef = pathlib.Path(oem_board_dirpath, "hwdef.dat")
 
         if hwdef_include_relpath is None:
-            raise ValueError(f"Could not find .inc or .dat for {board_name}")
+            raise ValueError(f"Could not find .inc or .dat for {self.board_name}")
 
         new_hwdef.write_text(hwdef_content)
 
-        if os.path.exists(f"{hwdef_dir}/{board_name}/defaults.parm"):
-            path = pathlib.Path(f"{hwdef_dir}/{oem_board_name}/defaults.parm")
-            path.write_text(f"@include ../{board_name}/defaults.parm\n")  # noqa
+        if os.path.exists(f"{hwdef_dir}/{self.board_name}/defaults.parm"):
+            path = pathlib.Path(f"{hwdef_dir}/{self.oem_board_name}/defaults.parm")
+            path.write_text(f"@include ../{self.board_name}/defaults.parm\n")  # noqa
 
 
-board_name = sys.argv[1]
-oem_board_name = sys.argv[2]
+if __name__ == '__main__':
+    import argparse
 
-oemcreate = OEMCreate(board_name, oem_board_name)
-oemcreate.run()
+    parser = argparse.ArgumentParser(description='ArduPilot IMU Filter Tester Tool. Input one log file from ')
+    parser.add_argument('board_name', default=None, help='board to inherit from')
+    parser.add_argument('oem_board_name', default=None, help='new board name')
+
+    args = parser.parse_args()
+
+    oemcreate = OEMCreate(args.oem_board_name, args.board_name)
+    oemcreate.run()


### PR DESCRIPTION
also fix use of global variables from within the class scope