### PR TITLE
AP_HAL_ChibiOS: chibios_hwdef.py tidy embedding of files into ROMFS

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -2980,13 +2980,19 @@ Please run: Tools/scripts/build_bootloaders.py %s
 
     def romfs_add_dir(self, subdirs, relative_to_base=False):
         '''add a filesystem directory to ROMFS'''
+        if self.is_bootloader_fw():
+            # FIXME: why were we called?!
+            return
         for dirname in subdirs:
             if relative_to_base:
                 romfs_dir = os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', dirname)
             else:
                 romfs_dir = os.path.join(os.path.dirname(self.hwdef[0]), dirname)
-            if not self.is_bootloader_fw() and os.path.exists(romfs_dir):
-                for root, d, files in os.walk(romfs_dir):
+            if not os.path.exists(romfs_dir):
+                continue
+
+            if True:
+                for root, dirs, files in os.walk(romfs_dir):
                     for f in files:
                         if fnmatch.fnmatch(f, '*~'):
                             # skip editor backup files


### PR DESCRIPTION
most notably this embed the "modules" directory so you can use modules in ROMFS

I've created a branch which shows this working here: https://github.com/ArduPilot/ardupilot/compare/master...peterbarker:ardupilot:DEBUG/demo-pr/modules-in-romfs?expand=1 .  It creates an OEM board which embeds a script and a library for it to use.  Note that there are several drive-by patches in that branch at this point.

![image](https://github.com/user-attachments/assets/c4987046-0e1d-4c2e-938e-dc9b67f76501)
