### PR TITLE
Add AP_HAL::I2CDeviceManager->get_device_ptr

### DIFF
--- a/libraries/AP_HAL/I2CDevice.h
+++ b/libraries/AP_HAL/I2CDevice.h
@@ -70,11 +70,21 @@ public:
 
 class I2CDeviceManager {
 public:
-    /* Get a device handle */
-    virtual OwnPtr<AP_HAL::I2CDevice> get_device(uint8_t bus, uint8_t address,
-                                                 uint32_t bus_clock=400000,
-                                                 bool use_smbus = false,
-                                                 uint32_t timeout_ms=4) = 0;
+    /* Get a pointer to a newly-allocated I2CDevice handle.  Lifetime
+     * is externally handled */
+    virtual AP_HAL::I2CDevice *get_device_ptr(uint8_t bus, uint8_t address,
+                                              uint32_t bus_clock=400000,
+                                              bool use_smbus = false,
+                                              uint32_t timeout_ms=4) = 0;
+    /* Get a device handle.  Lifetime is handled by OwnPtr system.
+     * Progressively being eliminated */
+    OwnPtr<AP_HAL::I2CDevice> get_device(uint8_t bus, uint8_t address,
+                                         uint32_t bus_clock=400000,
+                                         bool use_smbus = false,
+                                         uint32_t timeout_ms=4) {
+        return AP_HAL::OwnPtr<AP_HAL::I2CDevice>(get_device_ptr(bus, address, bus_clock, use_smbus, timeout_ms));
+    }
+;
     /*
       get mask of bus numbers for all configured I2C buses
      */

--- a/libraries/AP_HAL_ChibiOS/I2CDevice.cpp
+++ b/libraries/AP_HAL_ChibiOS/I2CDevice.cpp
@@ -449,18 +449,17 @@ bool I2CDevice::adjust_periodic_callback(AP_HAL::Device::PeriodicHandle h, uint3
     return bus.adjust_timer(h, period_usec);
 }
 
-AP_HAL::OwnPtr<AP_HAL::I2CDevice>
-I2CDeviceManager::get_device(uint8_t bus, uint8_t address,
-                             uint32_t bus_clock,
-                             bool use_smbus,
-                             uint32_t timeout_ms)
+AP_HAL::I2CDevice *
+I2CDeviceManager::get_device_ptr(uint8_t bus, uint8_t address,
+                                 uint32_t bus_clock,
+                                 bool use_smbus,
+                                 uint32_t timeout_ms)
 {
     bus -= HAL_I2C_BUS_BASE;
     if (bus >= ARRAY_SIZE(I2CD)) {
-        return AP_HAL::OwnPtr<AP_HAL::I2CDevice>(nullptr);
+        return nullptr;
     }
-    auto dev = AP_HAL::OwnPtr<AP_HAL::I2CDevice>(NEW_NOTHROW I2CDevice(bus, address, bus_clock, use_smbus, timeout_ms));
-    return dev;
+    return NEW_NOTHROW I2CDevice(bus, address, bus_clock, use_smbus, timeout_ms);
 }
 
 /*

--- a/libraries/AP_HAL_ChibiOS/I2CDevice.h
+++ b/libraries/AP_HAL_ChibiOS/I2CDevice.h
@@ -126,10 +126,12 @@ public:
         return static_cast<I2CDeviceManager*>(i2c_mgr);
     }
 
-    AP_HAL::OwnPtr<AP_HAL::I2CDevice> get_device(uint8_t bus, uint8_t address,
-                                                 uint32_t bus_clock=400000,
-                                                 bool use_smbus = false,
-                                                 uint32_t timeout_ms=4) override;
+    /* Get a pointer to a newly-allocated I2CDevice handle.  Lifetime
+     * is externally handled */
+    AP_HAL::I2CDevice *get_device_ptr(uint8_t bus, uint8_t address,
+                                  uint32_t bus_clock=400000,
+                                  bool use_smbus = false,
+                                  uint32_t timeout_ms=4) override;
 
     /*
       get mask of bus numbers for all configured I2C buses

--- a/libraries/AP_HAL_ESP32/I2CDevice.cpp
+++ b/libraries/AP_HAL_ESP32/I2CDevice.cpp
@@ -150,17 +150,16 @@ bool I2CDevice::adjust_periodic_callback(AP_HAL::Device::PeriodicHandle h, uint3
     return bus.adjust_timer(h, period_usec);
 }
 
-AP_HAL::OwnPtr<AP_HAL::I2CDevice>
-I2CDeviceManager::get_device(uint8_t bus, uint8_t address,
-                             uint32_t bus_clock,
-                             bool use_smbus,
-                             uint32_t timeout_ms)
+AP_HAL::I2CDevice *
+I2CDeviceManager::get_device_ptr(uint8_t bus, uint8_t address,
+                                 uint32_t bus_clock,
+                                 bool use_smbus,
+                                 uint32_t timeout_ms)
 {
     if (bus >= ARRAY_SIZE(i2c_bus_desc)) {
-        return AP_HAL::OwnPtr<AP_HAL::I2CDevice>(nullptr);
+        return nullptr;
     }
-    auto dev = AP_HAL::OwnPtr<AP_HAL::I2CDevice>(NEW_NOTHROW I2CDevice(bus, address, bus_clock, use_smbus, timeout_ms));
-    return dev;
+    return NEW_NOTHROW I2CDevice(bus, address, bus_clock, use_smbus, timeout_ms);
 }
 
 /*

--- a/libraries/AP_HAL_ESP32/I2CDevice.h
+++ b/libraries/AP_HAL_ESP32/I2CDevice.h
@@ -124,7 +124,7 @@ public:
         return static_cast<I2CDeviceManager*>(i2c_mgr);
     }
 
-    AP_HAL::OwnPtr<AP_HAL::I2CDevice> get_device(uint8_t bus, uint8_t address,
+    AP_HAL::I2CDevice *get_device_ptr(uint8_t bus, uint8_t address,
             uint32_t bus_clock=400000,
             bool use_smbus = false,
             uint32_t timeout_ms=4) override;

--- a/libraries/AP_HAL_Empty/I2CDevice.h
+++ b/libraries/AP_HAL_Empty/I2CDevice.h
@@ -83,10 +83,10 @@ public:
     I2CDeviceManager() { }
 
     /* AP_HAL::I2CDeviceManager implementation */
-    AP_HAL::OwnPtr<AP_HAL::I2CDevice> get_device(uint8_t bus, uint8_t address,
-                                                 uint32_t bus_clock=400000,
-                                                 bool use_smbus = false,
-                                                 uint32_t timeout_ms=4) override
+    AP_HAL::I2CDevice *get_device_ptr(uint8_t bus, uint8_t address,
+                                      uint32_t bus_clock=400000,
+                                      bool use_smbus = false,
+                                      uint32_t timeout_ms=4) override
     {
         return nullptr;
     }

--- a/libraries/AP_HAL_Linux/I2CDevice.cpp
+++ b/libraries/AP_HAL_Linux/I2CDevice.cpp
@@ -280,11 +280,11 @@ I2CDeviceManager::I2CDeviceManager()
     _buses.reserve(4);
 }
 
-AP_HAL::OwnPtr<AP_HAL::I2CDevice>
-I2CDeviceManager::get_device(uint8_t bus, uint8_t address,
-                             uint32_t bus_clock,
-                             bool use_smbus,
-                             uint32_t timeout_ms)
+AP_HAL::I2CDevice *
+I2CDeviceManager::get_device_ptr(uint8_t bus, uint8_t address,
+                                 uint32_t bus_clock,
+                                 bool use_smbus,
+                                 uint32_t timeout_ms)
 {
     for (uint8_t i = 0, n = _buses.size(); i < n; i++) {
         if (_buses[i]->bus == bus) {
@@ -313,10 +313,10 @@ I2CDeviceManager::get_device(uint8_t bus, uint8_t address,
 }
 
 /* Create a new device increasing the bus reference */
-AP_HAL::OwnPtr<AP_HAL::I2CDevice>
+AP_HAL::I2CDevice *
 I2CDeviceManager::_create_device(I2CBus &b, uint8_t address) const
 {
-    auto dev = AP_HAL::OwnPtr<AP_HAL::I2CDevice>(NEW_NOTHROW I2CDevice(b, address));
+    auto *dev = NEW_NOTHROW I2CDevice(b, address);
     if (!dev) {
         return nullptr;
     }

--- a/libraries/AP_HAL_Linux/I2CDevice.h
+++ b/libraries/AP_HAL_Linux/I2CDevice.h
@@ -95,10 +95,10 @@ public:
     I2CDeviceManager();
 
     /* AP_HAL::I2CDeviceManager implementation */
-    AP_HAL::OwnPtr<AP_HAL::I2CDevice> get_device(uint8_t bus, uint8_t address,
-                                                 uint32_t bus_clock=400000,
-                                                 bool use_smbus = false,
-                                                 uint32_t timeout_ms=4) override;
+    AP_HAL::I2CDevice *get_device_ptr(uint8_t bus, uint8_t address,
+                                     uint32_t bus_clock=400000,
+                                     bool use_smbus = false,
+                                     uint32_t timeout_ms=4) override;
 
     /*
      * Stop all I2C threads and block until they are finalized. This doesn't
@@ -124,7 +124,7 @@ public:
     
 protected:
     void _unregister(I2CBus &b);
-    AP_HAL::OwnPtr<AP_HAL::I2CDevice> _create_device(I2CBus &b, uint8_t address) const;
+    AP_HAL::I2CDevice *_create_device(I2CBus &b, uint8_t address) const;
 
     std::vector<I2CBus*> _buses;
 };

--- a/libraries/AP_HAL_QURT/I2CDevice.cpp
+++ b/libraries/AP_HAL_QURT/I2CDevice.cpp
@@ -98,17 +98,16 @@ bool I2CDevice::adjust_periodic_callback(AP_HAL::Device::PeriodicHandle h, uint3
     return bus.adjust_timer(h, period_usec);
 }
 
-AP_HAL::OwnPtr<AP_HAL::I2CDevice>
-I2CDeviceManager::get_device(uint8_t bus, uint8_t address,
-                             uint32_t bus_clock,
-                             bool use_smbus,
-                             uint32_t timeout_ms)
+AP_HAL::I2CDevice *
+I2CDeviceManager::get_device_ptr(uint8_t bus, uint8_t address,
+                                 uint32_t bus_clock,
+                                 bool use_smbus,
+                                 uint32_t timeout_ms)
 {
     if (bus >= ARRAY_SIZE(i2c_bus_ids)) {
-        return AP_HAL::OwnPtr<AP_HAL::I2CDevice>(nullptr);
+        return nullptr;
     }
-    auto dev = AP_HAL::OwnPtr<AP_HAL::I2CDevice>(new I2CDevice(bus, address, bus_clock, use_smbus, timeout_ms));
-    return dev;
+    return new I2CDevice(bus, address, bus_clock, use_smbus, timeout_ms);
 }
 
 /*

--- a/libraries/AP_HAL_QURT/I2CDevice.h
+++ b/libraries/AP_HAL_QURT/I2CDevice.h
@@ -111,7 +111,7 @@ public:
         return static_cast<I2CDeviceManager*>(i2c_mgr);
     }
 
-    AP_HAL::OwnPtr<AP_HAL::I2CDevice> get_device(uint8_t bus, uint8_t address,
+    AP_HAL::I2CDevice *get_device_ptr(uint8_t bus, uint8_t address,
             uint32_t bus_clock=100000,
             bool use_smbus = false,
             uint32_t timeout_ms=4) override;

--- a/libraries/AP_HAL_SITL/I2CDevice.cpp
+++ b/libraries/AP_HAL_SITL/I2CDevice.cpp
@@ -106,18 +106,17 @@ I2CDeviceManager::I2CDeviceManager()
     }
 }
 
-AP_HAL::OwnPtr<AP_HAL::I2CDevice>
-I2CDeviceManager::get_device(uint8_t bus,
-                             uint8_t address,
-                             uint32_t bus_clock,
-                             bool use_smbus,
-                             uint32_t timeout_ms)
+AP_HAL::I2CDevice *
+I2CDeviceManager::get_device_ptr(uint8_t bus,
+                                 uint8_t address,
+                                 uint32_t bus_clock,
+                                 bool use_smbus,
+                                 uint32_t timeout_ms)
 {
     if (bus >= ARRAY_SIZE(buses)) {
-        return AP_HAL::OwnPtr<AP_HAL::I2CDevice>(nullptr);
+        return nullptr;
     }
-    auto dev = AP_HAL::OwnPtr<AP_HAL::I2CDevice>(NEW_NOTHROW I2CDevice(buses[bus], address));
-    return dev;
+    return NEW_NOTHROW I2CDevice(buses[bus], address);
 }
 
 void I2CDeviceManager::_timer_tick()

--- a/libraries/AP_HAL_SITL/I2CDevice.h
+++ b/libraries/AP_HAL_SITL/I2CDevice.h
@@ -118,10 +118,10 @@ public:
     void _timer_tick(); // in lieu of a thread-per-bus
 
     /* AP_HAL::I2CDeviceManager implementation */
-    AP_HAL::OwnPtr<AP_HAL::I2CDevice> get_device(uint8_t bus, uint8_t address,
-                                                 uint32_t bus_clock=400000,
-                                                 bool use_smbus = false,
-                                                 uint32_t timeout_ms=4) override;
+    AP_HAL::I2CDevice *get_device_ptr(uint8_t bus, uint8_t address,
+                                      uint32_t bus_clock=400000,
+                                      bool use_smbus = false,
+                                      uint32_t timeout_ms=4) override;
 
 protected:
 

--- a/libraries/AP_Notify/ToshibaLED_I2C.cpp
+++ b/libraries/AP_Notify/ToshibaLED_I2C.cpp
@@ -49,7 +49,7 @@ ToshibaLED_I2C::ToshibaLED_I2C(uint8_t bus)
 bool ToshibaLED_I2C::init(void)
 {
     // first look for led on external bus
-    _dev = std::move(hal.i2c_mgr->get_device(_bus, TOSHIBA_LED_I2C_ADDR));
+    _dev = hal.i2c_mgr->get_device_ptr(_bus, TOSHIBA_LED_I2C_ADDR);
     if (!_dev) {
         return false;
     }

--- a/libraries/AP_Notify/ToshibaLED_I2C.h
+++ b/libraries/AP_Notify/ToshibaLED_I2C.h
@@ -27,12 +27,13 @@ class ToshibaLED_I2C : public RGBLed
 {
 public:
     ToshibaLED_I2C(uint8_t bus);
+    ~ToshibaLED_I2C() { delete _dev; }
     bool init(void) override;
 protected:
     bool hw_set_rgb(uint8_t r, uint8_t g, uint8_t b) override;
 
 private:
-    AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev;
+    AP_HAL::I2CDevice *_dev;
     void _timer(void);
     bool _need_update;
     struct {


### PR DESCRIPTION
This PR is an alternative path forward for https://github.com/ArduPilot/ardupilot/pull/16138 ; that one's been stalled for many years.

This PR adds an alternate interface for working with I2CDevice objects as allocated by AP_HAL's device manager.

The new method, `get_device_ptr` returns a pointer to an instance of I2CDevice.  This is in contrast to the existing `get_device` method which returns that pointer wrapped in an OwnPtr object.

This new interface allows the code to handle the lifetime in the same way we manage most of our objects in ArduPilot, by `delete`ing what you don't need.

This PR coverts only a single class, the ToshibaLED driver.  This patch saves about 24 bytes.  There are ~150 instances of get_device (both SPI and i2c) in the codebase, so if each use saves this amount of flash that will be about 3kB of flash saved.  Note that the original PR lacked a `delete` call on the I2CDevice member in the ToshibaLED destructor, meaning it would have leaked the memory allocated in `_dev`.  This shows if we are to adopt this pattern we need to be *careful* about object lifetimes!

This entire PR saves ~168 bytes on Pixhawk1-1M`.  I'm assuming the hiding of the virtual function behind a non-virtual function explains that.  

![image](https://github.com/user-attachments/assets/c53f8102-4fb3-4732-b875-e55b0ea999e7)

Durandal's 1kB saving seems to come from better optimisation made when dealing with the ownptrs.

I'm suggesting we merge this and gradually change users of `get_device` over to use `get_device_ptr`.

Currently the only testing this has had is compilation, CI and flashing onto a Pixhawk-1M to make sure the ToshibaLED still works, and flashing to a Pixhawk6x as representative of a board which doesn't have a ToshibaLED.

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  -632              *                                                   
CubeRedPrimary                      -104   *           -216    -216              -216   -216   -296
Durandal                            -744   *           -968    -976              -968   -968   -1088
Hitec-Airspeed           -16               *                                                   
KakuteH7-bdshot                     -144   *           -200    -200              -200   -200   -264
MatekF405                           -72    *           -96     -96               -120   -112   -112
Pixhawk1-1M-bdshot                  -80                -176    -176              -192   -192   -176
f103-QiotekPeriph        16                *                                                   
f303-Universal           0                 *                                                   
iomcu                                                                0                         
revo-mini                           -32    *           -64     -64               -80    -80    -80
skyviper-journey                                       -136                                    
skyviper-v2450                                         -32                                     
```
