### PR TITLE
Copter: free allocations in case of allocation failure

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -451,6 +451,8 @@ AP_Vehicle::custom_mode_state* Copter::register_custom_mode(const uint8_t num, c
             }
             if (mode_guided_custom[i] == nullptr) {
                 // Allocation failure
+                free((void*)full_name_copy);
+                free((void*)short_name_copy);
                 return nullptr;
             }
 


### PR DESCRIPTION
these would be leaked if the "new" call for the ModeGuidedCustom object failed.

Since resgister_custom_mode may be called multiple times we could leak memory continuously


```
../../ArduCopter/Copter.cpp:450:41: warning: Potential leak of memory pointed to by 'full_name_copy' [unix.Malloc]
                mode_guided_custom[i] = NEW_NOTHROW ModeGuidedCustom(number, full_name_copy, short_name_copy);
                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../libraries/AP_Common/AP_Common.h:192:21: note: expanded from macro 'NEW_NOTHROW'
#define NEW_NOTHROW new(std::nothrow)
                    ^
../../ArduCopter/Copter.cpp:452:17: warning: Potential leak of memory pointed to by 'short_name_copy' [unix.Malloc]
            if (mode_guided_custom[i] == nullptr) {
                ^~~~~~~~~~~~~~~~~~
2 warnings generated.
```
