### PR TITLE
AP_Frsky_Telem: remove dead variable write

### DIFF
--- a/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.cpp
@@ -235,7 +235,6 @@ bool AP_Frsky_SPort_Passthrough::is_packet_ready(uint8_t idx, bool queue_empty)
         break;
     case TERRAIN:
         {
-            packet_ready = false;
 #if AP_TERRAIN_AVAILABLE
             const AP_Terrain *terrain = AP::terrain();
             packet_ready = terrain && terrain->enabled();


### PR DESCRIPTION
this is falsified at the top of the function

../../libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.cpp:238:13: warning: Value stored to 'packet_ready' is never read [deadcode.DeadStores]
            packet_ready = false;
            ^              ~~~~~
1 warning generated.