### PR TITLE
AP_Logger: use GCS_SEND_TEXT for error message rather than stdout

### DIFF
--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -67,7 +67,7 @@ void AP_Logger_File::ensure_log_directory_exists()
         ret = AP::FS().mkdir(_log_directory);
     }
     if (ret == -1 && errno != EEXIST) {
-        printf("Failed to create log directory %s : %s\n", _log_directory, strerror(errno));
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Failed to create log directory %s : %s", _log_directory, strerror(errno));
     }
 }
 


### PR DESCRIPTION
This one is line noise before this patch:
Failed to create log directory /APM/LOGS : ENOSPC