### PR TITLE
Correct version of python invoked by clang-scan-build

### DIFF
--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -154,17 +154,17 @@ def run_unit_tests():
 
 def run_clang_scan_build():
     """Run Clang Scan-build utility."""
-    if util.run_cmd("scan-build python waf configure",
+    if util.run_cmd("scan-build python3 waf configure",
                     directory=util.reltopdir('.')) != 0:
         print("Failed scan-build-configure")
         return False
 
-    if util.run_cmd("scan-build python waf clean",
+    if util.run_cmd("scan-build python3 waf clean",
                     directory=util.reltopdir('.')) != 0:
         print("Failed scan-build-clean")
         return False
 
-    if util.run_cmd("scan-build python waf build",
+    if util.run_cmd("scan-build python3 waf build",
                     directory=util.reltopdir('.')) != 0:
         print("Failed scan-build-build")
         return False

--- a/Tools/scripts/create_OEM_board.py
+++ b/Tools/scripts/create_OEM_board.py
@@ -64,7 +64,7 @@ class OEMCreate:
 if __name__ == '__main__':
     import argparse
 
-    parser = argparse.ArgumentParser(description='ArduPilot IMU Filter Tester Tool. Input one log file from ')
+    parser = argparse.ArgumentParser(description='ArduPilot OEM board creator')
     parser.add_argument('board_name', default=None, help='board to inherit from')
     parser.add_argument('oem_board_name', default=None, help='new board name')
 


### PR DESCRIPTION
Need python3 rather than just python

Also fix the help string on the create_EOM script...
