### PR TITLE
AR_Motors: fix brushed motor support for omni vehicles

### DIFF
--- a/libraries/AR_Motors/AP_MotorsUGV.cpp
+++ b/libraries/AR_Motors/AP_MotorsUGV.cpp
@@ -132,6 +132,11 @@ void AP_MotorsUGV::init(uint8_t frtype)
 {
     _frame_type = frame_type(frtype);
 
+    // setup for omni vehicles
+    if (_frame_type != FRAME_TYPE_UNDEFINED) {
+        setup_omni();
+    }
+    
     // setup servo output
     setup_servo_output();
 
@@ -141,10 +146,6 @@ void AP_MotorsUGV::init(uint8_t frtype)
     // set safety output
     setup_safety_output();
 
-    // setup for omni vehicles
-    if (_frame_type != FRAME_TYPE_UNDEFINED) {
-        setup_omni();
-    }
 }
 
 bool AP_MotorsUGV::get_legacy_relay_index(int8_t &index1, int8_t &index2, int8_t &index3, int8_t &index4) const


### PR DESCRIPTION
Fixes an issue where omni motors (BrushedWithRelay/BrushedBiplor) are not configured correctly.

I ran into the same problem another user mentioned [here](https://discuss.ardupilot.org/t/mot-pwm-type-3-brushedwithrelay-doesnt-work-with-frame-type-2-omnix/67182):  OmniX frame using MOT_PWM_TYPE = 3 (BrushedWithRelay) only outputs RC servo pulses instead of a duty cycle PWM.

Proposed fix worked great when tested with [Cytron MDD10A](https://www.cytron.io/p-10amp-5v-30v-dc-motor-driver-2-channels) motor driver.