### PR TITLE
Copter: SystemID: Fix unutilized variables

### DIFF
--- a/ArduCopter/mode_systemid.cpp
+++ b/ArduCopter/mode_systemid.cpp
@@ -161,7 +161,8 @@ void ModeSystemId::exit()
 // should be called at 100hz or more
 void ModeSystemId::run()
 {
-    float target_roll, target_pitch;
+    float target_roll = 0.0f;
+    float target_pitch = 0.0f;
     float target_yaw_rate = 0.0f;
     float pilot_throttle_scaled = 0.0f;
     float target_climb_rate = 0.0f;


### PR DESCRIPTION
This PR addresses a problem found by Peter Barker:

Looking through some static analysis results and came across this one:

../../ArduCopter/mode_systemid.cpp:270:33: warning: The left expression of the compound assignment is an uninitialized value. The computed value will also be garbage [core.uninitialized.Assign]
                    target_roll += waveform_sample*100.0f;
                    ~~~~~~~~~~~ ^
../../ArduCopter/mode_systemid.cpp:273:34: warning: The left expression of the compound assignment is an uninitialized value. The computed value will also be garbage [core.uninitialized.Assign]
                    target_pitch += waveform_sample*100.0f;
                    ~~~~~~~~~~~~ ^
../../ArduCopter/mode_systemid.cpp:279:33: warning: The left expression of the compound assignment is an uninitialized value. The computed value will also be garbage [core.uninitialized.Assign]
                    target_roll += waveform_sample*100.0f;
                    ~~~~~~~~~~~ ^
../../ArduCopter/mode_systemid.cpp:283:34: warning: The left expression of the compound assignment is an uninitialized value. The computed value will also be garbage [core.uninitialized.Assign]
                    target_pitch += waveform_sample*100.0f;
                    ~~~~~~~~~~~~ ^
../../ArduCopter/mode_systemid.cpp:352:9: warning: 1st function call argument is an uninitialized value [core.CallAndMessage]
        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
.
What that's saying is that if this if we don't execute the block gated by if (!is_poscontrol_axis_type())  then both target_roll and target_pitch remain uniniitalised on the stack.  Which is bad....