### PR TITLE
waf: move setting of -cl-single-precision-constant into cxx-flags block

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -288,9 +288,6 @@ class Board:
                 '-Werror=implicit-fallthrough',
                 '-cl-single-precision-constant',
             ]
-            env.CXXFLAGS += [
-                '-cl-single-precision-constant',
-            ]
         else:
             env.CFLAGS += [
                 '-Wno-format-contains-nul',
@@ -424,6 +421,7 @@ class Board:
                 '-Wno-mismatched-tags',
                 '-Wno-gnu-variable-sized-type-not-at-end',
                 '-Werror=implicit-fallthrough',
+                '-cl-single-precision-constant',
             ]
         else:
             env.CXXFLAGS += [


### PR DESCRIPTION
we have two separate blocks, one for setting c flags, one for setting cxx flags.

Move cxx set into correct area