### PR TITLE
AP_BattMonitor: remove use of ownptr

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_INA3221.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_INA3221.cpp
@@ -207,10 +207,11 @@ void AP_BattMonitor_INA3221::init()
     }
 
     AddressDriver *d = &address_driver[address_driver_count];
-    d->dev = std::move(hal.i2c_mgr->get_device(i2c_bus, i2c_address, 100000, true, 20));
+    d->dev = hal.i2c_mgr->get_device_ptr(i2c_bus, i2c_address, 100000, true, 20);
     if (!d->dev) {
         return;
     }
+
     d->bus = i2c_bus;
     d->address = i2c_address;
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_INA3221.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_INA3221.h
@@ -81,7 +81,7 @@ private:
         void timer(void);
         void register_timer();
 
-        AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev;
+        AP_HAL::I2CDevice *dev;
         uint8_t bus;
         uint8_t address;
         uint8_t channel_mask;


### PR DESCRIPTION
@tpwrules there's no in-tree user of this still :-)

The simulation still finds the device:

![image](https://github.com/user-attachments/assets/f3e50daa-bf6f-4c60-ab75-5f8daf7772ba)


