### PR TITLE
Fixed typo in description of RC_PROTOCOL

### DIFF
--- a/Tools/AP_Periph/rc_in.cpp
+++ b/Tools/AP_Periph/rc_in.cpp
@@ -35,7 +35,7 @@ const AP_Param::GroupInfo Parameters_RCIN::var_info[] {
     // RC_PROTOCOLS copied from RC_Channel/RC_Channels_Varinfo.h
     // @Param: _PROTOCOLS
     // @DisplayName: RC protocols enabled
-    // @Description: Bitmask of enabled RC protocols. Allows narrowing the protocol detection to only specific types of RC receivers which can avoid issues with incorrect detection. Set to 1 to enable all protocols.
+    // @Description: Bitmask of enabled RC protocols. Allows narrowing the protocol detection to only specific types of RC receivers which can avoid issues with incorrect detection. Set to 0 to enable all protocols.
     // @User: Advanced
     // @Bitmask: 0:All,1:PPM,2:IBUS,3:SBUS,4:SBUS_NI,5:DSM,6:SUMD,7:SRXL,8:SRXL2,9:CRSF,10:ST24,11:FPORT,12:FPORT2,13:FastSBUS
     AP_GROUPINFO("_PROTOCOLS", 1, Parameters_RCIN, rcin_protocols, 1),

--- a/libraries/RC_Channel/RC_Channels_VarInfo.h
+++ b/libraries/RC_Channel/RC_Channels_VarInfo.h
@@ -99,7 +99,7 @@ const AP_Param::GroupInfo RC_Channels::var_info[] = {
     // _PROTOCOLS copied to AP_Periph/Parameters.cpp
     // @Param: _PROTOCOLS
     // @DisplayName: RC protocols enabled
-    // @Description: Bitmask of enabled RC protocols. Allows narrowing the protocol detection to only specific types of RC receivers which can avoid issues with incorrect detection. Set to 1 to enable all protocols.
+    // @Description: Bitmask of enabled RC protocols. Allows narrowing the protocol detection to only specific types of RC receivers which can avoid issues with incorrect detection. Set to 0 to enable all protocols.
     // @User: Advanced
     // @Bitmask: 0:All,1:PPM,2:IBUS,3:SBUS,4:SBUS_NI,5:DSM,6:SUMD,7:SRXL,8:SRXL2,9:CRSF,10:ST24,11:FPORT,12:FPORT2,13:FastSBUS,14:DroneCAN,15:Ghost,16:MAVRadio
     AP_GROUPINFO("_PROTOCOLS", 34, RC_CHANNELS_SUBCLASS, _protocols, 1),


### PR DESCRIPTION
Fixed typo in value description of RC_PROTOCOL parameter for enabling all protocols