### PR TITLE
GCS_MAVLink: simplify MissionItemProtocol get_item interface

### DIFF
--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -2306,6 +2306,47 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.test_gcs_fence_via_mavproxy(target_system=target_system,
                                          target_component=target_component)
 
+    def GCSFenceInvalidPoint(self):
+        '''Test fetch non-existant fencepoint'''
+        target_system = 1
+        target_component = 1
+
+        here = self.mav.location()
+        self.upload_fences_from_locations([
+            (mavutil.mavlink.MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION, [
+                # east
+                self.offset_location_ne(here, -50, 20), # bl
+                self.offset_location_ne(here, 50, 20), # br
+                self.offset_location_ne(here, 50, 40), # tr
+            ]),
+        ])
+        for i in 0, 1, 2:
+            self.assert_fetch_mission_item_int(target_system, target_component, i, mavutil.mavlink.MAV_MISSION_TYPE_FENCE)
+        self.progress("Requesting invalid point")
+        self.mav.mav.mission_request_int_send(
+            target_system,
+            target_component,
+            3,
+            mavutil.mavlink.MAV_MISSION_TYPE_FENCE
+        )
+        self.context_push()
+        self.context_collect('MISSION_COUNT')
+        m = self.assert_receive_mission_ack(
+            mavutil.mavlink.MAV_MISSION_TYPE_FENCE,
+            want_type=mavutil.mavlink.MAV_MISSION_INVALID_SEQUENCE,
+        )
+        self.delay_sim_time(0.1)
+        found = False
+        for m in self.context_collection('MISSION_COUNT'):
+            if m.mission_type != mavutil.mavlink.MAV_MISSION_TYPE_FENCE:
+                continue
+            if m.count != 3:
+                raise NotAchievedException("Unexpected count in MISSION_COUNT")
+            found = True
+        self.context_pop()
+        if not found:
+            raise NotAchievedException("Did not see correction for fencepoint count")
+
     # explode the write_type_to_storage method
     # FIXME: test converting invalid fences / minimally valid fences / normal fences
     # FIXME: show that uploading smaller items take up less space
@@ -2533,6 +2574,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         if m.type != want_type:
             raise NotAchievedException("Expected ack type %u got %u" %
                                        (want_type, m.type))
+        return m
 
     def assert_filepath_content(self, filepath, want):
         with open(filepath) as f:
@@ -7015,6 +7057,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             self.Offboard,
             self.MAVProxyParam,
             self.GCSFence,
+            self.GCSFenceInvalidPoint,
             self.GCSMission,
             self.GCSRally,
             self.MotorTest,

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -9311,6 +9311,19 @@ Also, ignores heartbeats not from our target system'''
                                        (mavutil.mavlink.enums["MAV_MISSION_RESULT"][m.type].name),)
         self.progress("Upload of all %u items succeeded" % len(items))
 
+    def assert_fetch_mission_item_int(self, target_system, target_component, seq, mission_type):
+        self.mav.mav.mission_request_int_send(target_system,
+                                              target_component,
+                                              seq,
+                                              mission_type)
+        m = self.assert_receive_message(
+            'MISSION_ITEM_INT',
+            condition=f'MISSION_ITEM_INT.mission_type=={mission_type}',
+        )
+        if m is None:
+            raise NotAchievedException("Did not receive MISSION_ITEM_INT")
+        return m
+
     def download_using_mission_protocol(self, mission_type, verbose=False, timeout=10):
         '''mavlink2 required'''
         target_system = 1
@@ -9362,16 +9375,7 @@ Also, ignores heartbeats not from our target system'''
                 return items
             self.progress("Requesting item %u (remaining=%u)" %
                           (next_to_request, len(remaining_to_receive)))
-            self.mav.mav.mission_request_int_send(target_system,
-                                                  target_component,
-                                                  next_to_request,
-                                                  mission_type)
-            m = self.mav.recv_match(type='MISSION_ITEM_INT',
-                                    blocking=True,
-                                    timeout=5,
-                                    condition='MISSION_ITEM_INT.mission_type==%u' % mission_type)
-            if m is None:
-                raise NotAchievedException("Did not receive MISSION_ITEM_INT")
+            m = self.assert_fetch_mission_item_int(target_system, target_component, next_to_request, mission_type)
             if m.target_system != self.mav.source_system:
                 raise NotAchievedException("Wrong target system (want=%u got=%u)" %
                                            (self.mav.source_system, m.target_system))

--- a/libraries/GCS_MAVLink/MissionItemProtocol.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol.cpp
@@ -155,9 +155,19 @@ void MissionItemProtocol::handle_mission_request_int(GCS_MAVLINK &_link,
     }
 
     mavlink_mission_item_int_t ret_packet;
-    const MAV_MISSION_RESULT result_code = get_item(_link, msg, packet, ret_packet);
-
+    const MAV_MISSION_RESULT result_code = get_item(packet.seq, ret_packet);
     if (result_code != MAV_MISSION_ACCEPTED) {
+        if (result_code == MAV_MISSION_INVALID_SEQUENCE) {
+            // try to educate the GCS on the actual size of the mission:
+            const mavlink_channel_t chan = _link.get_chan();
+            if (HAVE_PAYLOAD_SPACE(chan, MISSION_COUNT)) {
+                mavlink_msg_mission_count_send(chan,
+                                               msg.sysid,
+                                               msg.compid,
+                                               item_count(),
+                                               mission_type());
+            }
+        }
         // send failure message
         send_mission_ack(_link, msg, result_code);
         return;
@@ -179,15 +189,8 @@ void MissionItemProtocol::handle_mission_request(GCS_MAVLINK &_link,
         return;
     }
 
-    // convert into a MISSION_REQUEST_INT and reuse its handling code
-    mavlink_mission_request_int_t request_int;
-    request_int.target_system = packet.target_system;
-    request_int.target_component = packet.target_component;
-    request_int.seq = packet.seq;
-    request_int.mission_type = packet.mission_type;
-
     mavlink_mission_item_int_t item_int;
-    MAV_MISSION_RESULT ret = get_item(_link, msg, request_int, item_int);
+    MAV_MISSION_RESULT ret = get_item(packet.seq, item_int);
     if (ret != MAV_MISSION_ACCEPTED) {
         send_mission_ack(_link, msg, ret);
         return;

--- a/libraries/GCS_MAVLink/MissionItemProtocol.h
+++ b/libraries/GCS_MAVLink/MissionItemProtocol.h
@@ -102,9 +102,7 @@ private:
     bool mission_item_warning_sent = false;
 
     // support for GCS getting waypoints etc from us:
-    virtual MAV_MISSION_RESULT get_item(const GCS_MAVLINK &_link,
-                                        const mavlink_message_t &msg,
-                                        const mavlink_mission_request_int_t &packet,
+    virtual MAV_MISSION_RESULT get_item(uint16_t seq,
                                         mavlink_mission_item_int_t &ret_packet) = 0;
 
     void init_send_requests(GCS_MAVLINK &_link,

--- a/libraries/GCS_MAVLink/MissionItemProtocol_Fence.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol_Fence.cpp
@@ -74,17 +74,13 @@ bool MissionItemProtocol_Fence::get_item_as_mission_item(uint16_t seq,
     return true;
 }
 
-MAV_MISSION_RESULT MissionItemProtocol_Fence::get_item(const GCS_MAVLINK &_link,
-                                                       const mavlink_message_t &msg,
-                                                       const mavlink_mission_request_int_t &packet,
-                                                       mavlink_mission_item_int_t &ret_packet)
+MAV_MISSION_RESULT MissionItemProtocol_Fence::get_item(uint16_t seq, mavlink_mission_item_int_t &ret_packet)
 {
-    const auto num_stored_items = _fence.polyfence().num_stored_items();
-    if (packet.seq > num_stored_items) {
+    if (seq >= _fence.polyfence().num_stored_items()) {
         return MAV_MISSION_INVALID_SEQUENCE;
     }
 
-    if (!get_item_as_mission_item(packet.seq, ret_packet)) {
+    if (!get_item_as_mission_item(seq, ret_packet)) {
         return MAV_MISSION_ERROR;
     }
 

--- a/libraries/GCS_MAVLink/MissionItemProtocol_Fence.h
+++ b/libraries/GCS_MAVLink/MissionItemProtocol_Fence.h
@@ -42,10 +42,7 @@ private:
     MAV_MISSION_RESULT replace_item(const mavlink_mission_item_int_t&) override WARN_IF_UNUSED;
     MAV_MISSION_RESULT append_item(const mavlink_mission_item_int_t&) override WARN_IF_UNUSED;
 
-    MAV_MISSION_RESULT get_item(const GCS_MAVLINK &_link,
-                                const mavlink_message_t &msg,
-                                const mavlink_mission_request_int_t &packet,
-                                mavlink_mission_item_int_t &ret_packet) override WARN_IF_UNUSED;
+    MAV_MISSION_RESULT get_item(uint16_t seq, mavlink_mission_item_int_t &ret_packet) override WARN_IF_UNUSED;
 
     void free_upload_resources() override;
     MAV_MISSION_RESULT allocate_receive_resources(const uint16_t count) override WARN_IF_UNUSED;

--- a/libraries/GCS_MAVLink/MissionItemProtocol_Rally.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol_Rally.cpp
@@ -150,12 +150,13 @@ bool MissionItemProtocol_Rally::get_item_as_mission_item(uint16_t seq,
     return true;
 }
 
-MAV_MISSION_RESULT MissionItemProtocol_Rally::get_item(const GCS_MAVLINK &_link,
-                                                       const mavlink_message_t &msg,
-                                                       const mavlink_mission_request_int_t &packet,
-                                                       mavlink_mission_item_int_t &ret_packet)
+MAV_MISSION_RESULT MissionItemProtocol_Rally::get_item(uint16_t seq, mavlink_mission_item_int_t &ret_packet)
 {
-    if (!get_item_as_mission_item(packet.seq, ret_packet)) {
+    if (seq >= item_count()) {
+        return MAV_MISSION_INVALID_SEQUENCE;
+    }
+
+    if (!get_item_as_mission_item(seq, ret_packet)) {
         return MAV_MISSION_INVALID_SEQUENCE;
     }
     return MAV_MISSION_ACCEPTED;

--- a/libraries/GCS_MAVLink/MissionItemProtocol_Rally.h
+++ b/libraries/GCS_MAVLink/MissionItemProtocol_Rally.h
@@ -39,10 +39,7 @@ private:
     MAV_MISSION_RESULT replace_item(const mavlink_mission_item_int_t&) override WARN_IF_UNUSED;
     MAV_MISSION_RESULT append_item(const mavlink_mission_item_int_t&) override WARN_IF_UNUSED;
 
-    MAV_MISSION_RESULT get_item(const GCS_MAVLINK &_link,
-                                const mavlink_message_t &msg,
-                                const mavlink_mission_request_int_t &packet,
-                                mavlink_mission_item_int_t &ret_packet) override WARN_IF_UNUSED;
+    MAV_MISSION_RESULT get_item(uint16_t seq, mavlink_mission_item_int_t &ret_packet) override WARN_IF_UNUSED;
 
 };
 

--- a/libraries/GCS_MAVLink/MissionItemProtocol_Waypoints.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol_Waypoints.cpp
@@ -64,29 +64,17 @@ MAV_MISSION_RESULT MissionItemProtocol_Waypoints::complete(const GCS_MAVLINK &_l
     return MAV_MISSION_ACCEPTED;
 }
 
-MAV_MISSION_RESULT MissionItemProtocol_Waypoints::get_item(const GCS_MAVLINK &_link,
-                                                           const mavlink_message_t &msg,
-                                                           const mavlink_mission_request_int_t &packet,
-                                                           mavlink_mission_item_int_t &ret_packet)
+MAV_MISSION_RESULT MissionItemProtocol_Waypoints::get_item(uint16_t seq, mavlink_mission_item_int_t &ret_packet)
 {
-    if (packet.seq != 0 && // always allow HOME to be read
-        packet.seq >= mission.num_commands()) {
-        // try to educate the GCS on the actual size of the mission:
-        const mavlink_channel_t chan = _link.get_chan();
-        if (HAVE_PAYLOAD_SPACE(chan, MISSION_COUNT)) {
-            mavlink_msg_mission_count_send(chan,
-                                           msg.sysid,
-                                           msg.compid,
-                                           mission.num_commands(),
-                                           MAV_MISSION_TYPE_MISSION);
-        }
-        return MAV_MISSION_ERROR;
+    if (seq != 0 && // always allow HOME to be read
+        seq >= mission.num_commands()) {
+        return MAV_MISSION_INVALID_SEQUENCE;
     }
 
     AP_Mission::Mission_Command cmd;
 
     // retrieve mission from eeprom
-    if (!mission.read_cmd_from_storage(packet.seq, cmd)) {
+    if (!mission.read_cmd_from_storage(seq, cmd)) {
         return MAV_MISSION_ERROR;
     }
 

--- a/libraries/GCS_MAVLink/MissionItemProtocol_Waypoints.h
+++ b/libraries/GCS_MAVLink/MissionItemProtocol_Waypoints.h
@@ -45,14 +45,8 @@ private:
     // item to the end of the list of stored items.
     MAV_MISSION_RESULT append_item(const mavlink_mission_item_int_t &) override WARN_IF_UNUSED;
 
-    // get_item() fills in ret_packet based on packet; _link is the
-    // link the request was received on, and msg is the undecoded
-    // request.  Note that msg may not actually decode to a
-    // request_int_t!
-    MAV_MISSION_RESULT get_item(const GCS_MAVLINK &_link,
-                                const mavlink_message_t &msg,
-                                const mavlink_mission_request_int_t &packet,
-                                mavlink_mission_item_int_t &ret_packet) override WARN_IF_UNUSED;
+    // support for GCS getting waypoints etc from us:
+    MAV_MISSION_RESULT get_item(uint16_t seq, mavlink_mission_item_int_t &ret_packet) override WARN_IF_UNUSED;
 
     // item_count() returns the number of stored items
     uint16_t item_count() const override;


### PR DESCRIPTION
stop passing through _link and the original msg, move use to the base class instead.

starts fence and rally also using the "correct the GCS's count" code.

This also corrects the error code when correcting the GCS's count to INVALID_SEQUENCE rather than just ERROR

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  144               *
CubeRedPrimary                      24     *           24      24                24     24     24
Durandal                            64     *           64      64                64     64     64
Hitec-Airspeed           *                 *
KakuteH7-bdshot                     24     *           24      24                24     24     24
MatekF405                           24     *           24      24                24     24     24
Pixhawk1-1M-bdshot                  24                 24      24                24     24     24
f103-QiotekPeriph        *                 *
f303-Universal           *                 *
iomcu                                                                *
revo-mini                           24     *           24      24                24     24     24
skyviper-journey                                       24
skyviper-v2450                                         24
```

This should allow for cleanups in the AP_Filesystem_Mission code in the future.
