### PR TITLE
waf: stop clang complaining about variable-length stack arrays

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -287,6 +287,7 @@ class Board:
                 '-Wno-gnu-variable-sized-type-not-at-end',
                 '-Werror=implicit-fallthrough',
                 '-cl-single-precision-constant',
+                '-Wno-vla-cxx-extension',
             ]
         else:
             env.CFLAGS += [
@@ -419,6 +420,7 @@ class Board:
 
                 '-Wno-gnu-designator',
                 '-Wno-mismatched-tags',
+                '-Wno-vla-cxx-extension',
                 '-Wno-gnu-variable-sized-type-not-at-end',
                 '-Werror=implicit-fallthrough',
                 '-cl-single-precision-constant',


### PR DESCRIPTION
Gets rid of all of these:
```
../../libraries/AP_BattMonitor/AP_BattMonitor_SMBus.cpp:156:18: warning: variable length arrays in C++ are a Clang extension [-Wvla-cxx-extension]
  156 |     uint8_t buff[read_size];    // buffer to hold results
      |                  ^~~~~~~~~
```

.... which there are a lot of in ArduPilot!
