### PR TITLE
ArduPlane: remove unused terrain enum

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -340,7 +340,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: TERRAIN_FOLLOW
     // @DisplayName: Use terrain following
     // @Description: This enables terrain following for CRUISE mode, FBWB mode, RTL and for rally points. To use this option you also need to set TERRAIN_ENABLE to 1, which enables terrain data fetching from the GCS, and you need to have a GCS that supports sending terrain data to the aircraft. When terrain following is enabled then CRUISE and FBWB mode will hold height above terrain rather than height above home. In RTL the return to launch altitude will be considered to be a height above the terrain. Rally point altitudes will be taken as height above the terrain. This option does not affect mission items, which have a per-waypoint flag for whether they are height above home or height above the terrain. To use terrain following missions you need a ground station which can set the waypoint type to be a terrain height waypoint when creating the mission.
-    // @Bitmask: 0: Enable all modes, 1:FBWB, 2:Cruise, 3:Auto, 4:RTL, 5:Avoid_ADSB, 6:Guided, 7:Loiter, 8:Circle, 9:QRTL, 10:QLand, 11:Qloiter
+    // @Bitmask: 0: Enable all modes, 1:FBWB, 2:Cruise, 3:Reserved, 4:RTL, 5:Avoid_ADSB, 6:Guided, 7:Loiter, 8:Circle, 9:QRTL, 10:QLand, 11:Qloiter
     // @User: Standard
     GSCALAR(terrain_follow, "TERRAIN_FOLLOW",  0),
 

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -866,7 +866,7 @@ private:
         ALL             = 1U << 0,
         FLY_BY_WIRE_B   = 1U << 1,
         CRUISE          = 1U << 2,
-        AUTO            = 1U << 3,
+        //AUTO            = 1U << 3, this has no effect in the code
         RTL             = 1U << 4,
         AVOID_ADSB      = 1U << 5,
         GUIDED          = 1U << 6,

--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -796,7 +796,7 @@ bool Plane::terrain_disabled()
 const Plane::TerrainLookupTable Plane::Terrain_lookup[] = {
     {Mode::Number::FLY_BY_WIRE_B, terrain_bitmask::FLY_BY_WIRE_B},
     {Mode::Number::CRUISE, terrain_bitmask::CRUISE},
-    {Mode::Number::AUTO, terrain_bitmask::AUTO},
+    //{Mode::Number::AUTO, terrain_bitmask::AUTO}, not used by code
     {Mode::Number::RTL, terrain_bitmask::RTL},
     {Mode::Number::AVOID_ADSB, terrain_bitmask::AVOID_ADSB},
     {Mode::Number::GUIDED, terrain_bitmask::GUIDED},


### PR DESCRIPTION
The AUTO enum is not used in the TerrainFollow table. Terrain following in AUTO is exclusively controlled by the next_WP alt frame