### PR TITLE
AP_TECS: Fix flare height demand when using a rangefinder

### DIFF
--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -606,7 +606,7 @@ void AP_TECS::_update_height_demand(void)
 
         if (!_flare_initialised) {
             _flare_hgt_dem_adj = _hgt_dem;
-            _flare_hgt_dem_ideal = _hgt_afe;
+            _flare_hgt_dem_ideal = _height;
             _hgt_at_start_of_flare = _hgt_afe;
             _hgt_rate_at_flare_entry = _climb_rate;
             _flare_initialised = true;
@@ -629,9 +629,6 @@ void AP_TECS::_update_height_demand(void)
 
         // fade across to the ideal height profile
         _hgt_dem = _flare_hgt_dem_adj * (1.0f - p) + _flare_hgt_dem_ideal * p;
-
-        // correct for offset between height above ground and height above datum used by control loops
-        _hgt_dem += (_hgt_afe - _height);
     }
 }
 


### PR DESCRIPTION
# AP_TECS: Fix flare height demand when using a rangefinder

Addressed an issue in the flaring behavior when using a rangefinder. Previously, the aircraft would pitch down instead of slowing its descent during the flare stage, diverging from the height rate demand considerably and resulting in a hard landing.

The root cause of this issue was an incorrect calculation of the height demand from the sink rate. The rangefinder correction was being accounted for when it shouldn't, causing a mismatch between the intended sink rate and the height demand. Since the latter drives the pitch demand, this led to an unintended pitch down command right after starting the flare. The rangefinder has already been used to adjust the glide slope and to determine when to start the flare, so the aircraft should flare normally.

Key changes:
- Removed invalid rangefinder correction in the height demand calculation during the flare
- Ensured consistent flare behavior regardless of whether a rangefinder is used

## Flare comparison (graph cursor placed at the start of the flare)

### Flare w/o rangefinder in master (good)

![imagen](https://github.com/user-attachments/assets/b37f516b-52fc-4536-afd6-4fd3883934be)

### Flare w/ rangefinder in master (bad, see the nonsensical height demand and the complete divergence in height rate)

![imagen](https://github.com/user-attachments/assets/03241a98-6b96-452e-b681-3e602ca67f18)

### Flare w/ rangefinder in this PR (identical to the master behavior w/o rangefinder)

![imagen](https://github.com/user-attachments/assets/de3a2ae3-c99d-4bf6-beca-264df793d91e)