### PR TITLE
autotest: set parameter value so context pop resets it

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -12542,6 +12542,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             'COMPASS_USE3': 0,
         })
         self.assert_parameter_value("COMPASS_OFS_X", 20, epsilon=30)
+        # set the parameter so it gets reset at context pop time:
+        self.set_parameter("COMPASS_OFS_X", 20)
         new_compass_ofs_x = 200
         self.set_parameters({
             "SIM_MAG1_OFS_X": new_compass_ofs_x,


### PR DESCRIPTION
if a vehicle magically sets a parameter (eg. via compass learn) then it can persist pat test end and reboots and everything,.

In this case it can randomly cause the next test to fail with a megneti field difference error