### PR TITLE
Fix clang compiler warnings

### DIFF
--- a/ArduPlane/mode_autoland.cpp
+++ b/ArduPlane/mode_autoland.cpp
@@ -127,7 +127,7 @@ bool ModeAutoLand::_enter()
     const float bearing_offset_deg = (bearing_err_deg > 0) ? -90 : 90;
 
     // Try and minimize loiter radius by using the smaller of the waypoint loiter radius or 1/3 of the final WP distance
-    const float loiter_radius = MIN(final_wp_dist * 0.333, fabsf(plane.aparm.loiter_radius));
+    const float loiter_radius = MIN(final_wp_dist * 0.333, abs(plane.aparm.loiter_radius));
 
     // corrected_loiter_radius is the radius the vehicle will actually fly, this gets larger as altitude increases.
     // Strictly this gets the loiter radius at the current altitude, really we want the loiter radius at final_wp_alt.

--- a/libraries/AP_Airspeed/AP_Airspeed_AUAV.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_AUAV.h
@@ -65,7 +65,6 @@ private:
     float D_TC50L; // Diff coeffs
 
     float pressure_digital;
-    float pressure_abs_L;
     float temp_C;
     const float range_inH2O;
 };

--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
@@ -42,7 +42,7 @@ static Storage sitlStorage;
 static SITL_State sitlState;
 static Scheduler sitlScheduler(&sitlState);
 #if AP_RCPROTOCOL_ENABLED
-static RCInput sitlRCInput(&sitlState);
+static RCInput sitlRCInput;
 #else
 static Empty::RCInput  sitlRCInput;
 #endif

--- a/libraries/AP_HAL_SITL/RCInput.h
+++ b/libraries/AP_HAL_SITL/RCInput.h
@@ -9,7 +9,7 @@
 
 class HALSITL::RCInput : public AP_HAL::RCInput {
 public:
-    explicit RCInput(SITL_State *sitlState): _sitlState(sitlState) {}
+    explicit RCInput() {}
     void init() override;
     bool new_input() override;
     uint8_t num_channels() override;
@@ -17,10 +17,6 @@ public:
     uint8_t read(uint16_t* periods, uint8_t len) override;
 
     const char *protocol() const override { return "SITL"; }
-
-private:
-    SITL_State *_sitlState;
-    bool using_rc_protocol;
 };
 
 #endif

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
@@ -155,7 +155,7 @@ bool AP_RangeFinder_LightWareI2C::sf20_send_and_expect(const char* send_msg, con
   send a native command and fill a reply into a buffer. Used for
   version string
  */
-void AP_RangeFinder_LightWareI2C::sf20_get_version(const char* send_msg, const char *reply_prefix, char reply[15])
+void AP_RangeFinder_LightWareI2C::sf20_get_version(const char* send_msg, const char *reply_prefix, char *reply, uint8_t reply_len)
 {
     const size_t expected_reply_len = 16;
     uint8_t rx_bytes[expected_reply_len + 1];
@@ -181,7 +181,7 @@ void AP_RangeFinder_LightWareI2C::sf20_get_version(const char* send_msg, const c
         // give a bit of time for the remaining bytes to be available
         hal.scheduler->delay(1);
     }
-    memcpy(reply, &rx_bytes[2], 14);
+    memcpy(reply, &rx_bytes[2], reply_len);
 }
 
 /* Driver first attempts to initialize the sf20.
@@ -242,7 +242,8 @@ bool AP_RangeFinder_LightWareI2C::sf20_init()
     // version strings for reporting
     char version[15] {};
 
-    sf20_get_version("?P\r\n", "p:", version);
+    // -1 here preserves null termination on the version string:
+    sf20_get_version("?P\r\n", "p:", version, ARRAY_SIZE(version)-1);
 
     if (version[0]) {
         DEV_PRINTF("SF20 Lidar version %s\n", version);

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.h
@@ -44,7 +44,7 @@ private:
     void sf20_disable_address_tagging();
     bool sf20_send_and_expect(const char* send, const char* expected_reply);
     bool sf20_set_lost_signal_confirmations();
-    void sf20_get_version(const char* send_msg, const char *reply_prefix, char reply[5]);
+    void sf20_get_version(const char* send_msg, const char *reply_prefix, char *reply, uint8_t reply_len);
     bool sf20_wait_on_reply(uint8_t *rx_two_bytes);
     bool init();
     bool legacy_init();

--- a/libraries/AP_Scripting/AP_Scripting.h
+++ b/libraries/AP_Scripting/AP_Scripting.h
@@ -96,7 +96,7 @@ public:
 
     // the number of and storage for i2c devices
     uint8_t num_i2c_devices;
-    AP_HAL::OwnPtr<AP_HAL::I2CDevice> *_i2c_dev[SCRIPTING_MAX_NUM_I2C_DEVICE];
+    AP_HAL::I2CDevice *_i2c_dev[SCRIPTING_MAX_NUM_I2C_DEVICE];
 
 #if AP_SCRIPTING_CAN_SENSOR_ENABLED
     // Scripting CAN sensor

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -591,18 +591,13 @@ int lua_get_i2c_device(lua_State *L) {
         return luaL_argerror(L, 1, "no i2c devices available");
     }
 
-    scripting->_i2c_dev[scripting->num_i2c_devices] = NEW_NOTHROW AP_HAL::OwnPtr<AP_HAL::I2CDevice>;
+    scripting->_i2c_dev[scripting->num_i2c_devices] = hal.i2c_mgr->get_device_ptr(bus, address, bus_clock, use_smbus);
+
     if (scripting->_i2c_dev[scripting->num_i2c_devices] == nullptr) {
         return luaL_argerror(L, 1, "i2c device nullptr");
     }
 
-    *scripting->_i2c_dev[scripting->num_i2c_devices] = std::move(hal.i2c_mgr->get_device(bus, address, bus_clock, use_smbus));
-
-    if (scripting->_i2c_dev[scripting->num_i2c_devices] == nullptr || scripting->_i2c_dev[scripting->num_i2c_devices]->get() == nullptr) {
-        return luaL_argerror(L, 1, "i2c device nullptr");
-    }
-
-    *new_AP_HAL__I2CDevice(L) = scripting->_i2c_dev[scripting->num_i2c_devices]->get();
+    *new_AP_HAL__I2CDevice(L) = scripting->_i2c_dev[scripting->num_i2c_devices];
 
     scripting->num_i2c_devices++;
 


### PR DESCRIPTION
Unused variables and wrong abs function used.

CI-tested only.  And locally for compilation...

.... also now stops scripting using OwnPtr for i2c devices; this was tested on a ZeroOneX6 with an RM3100 and an example script which triggers a self-test on the device.
