### PR TITLE
Plane: Quadplane: only log `TILT` on tilt-rotors

### DIFF
--- a/ArduPlane/tiltrotor.cpp
+++ b/ArduPlane/tiltrotor.cpp
@@ -400,6 +400,11 @@ void Tiltrotor::update(void)
 // Write tiltrotor specific log
 void Tiltrotor::write_log()
 {
+    // Only valid on a tiltrotor
+    if (!enabled()) {
+        return;
+    }
+
     struct log_tiltrotor pkt {
         LOG_PACKET_HEADER_INIT(LOG_TILT_MSG),
         time_us      : AP_HAL::micros64(),


### PR DESCRIPTION
This is one of my bugs, we log `TILT` for all Quadplane types whether or not tilt rotor is enabled. This bug is in 4.6 I have marked for backport, not critical of course, just wasting a little log space.