### PR TITLE
AP_Baro: Fix BMP581 initialization error

### DIFF
--- a/libraries/AP_Baro/AP_Baro_BMP581.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP581.cpp
@@ -114,7 +114,7 @@ bool AP_Baro_BMP581::init()
         return false;
     }
 
-    if ((status & 0b10) == 0  || (status & 0b100) == 1) {
+    if ((status & 0b10) == 0 || (status & 0b100)) {
         return false;
     }
 


### PR DESCRIPTION
Fixed a BMP581 driver initialization error, thanks to @peterbarker pointing out the problem.

https://github.com/ArduPilot/ardupilot/pull/27249#discussion_r1932916640