### PR TITLE
AP_Logger: clarify behavior of log_file_content

### DIFF
--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -412,7 +412,8 @@ public:
         return _log_start_count;
     }
 
-    // add a filename to list of files to log. The name must be a constant string, not allocated
+    // add a filename to list of files to log. The name is copied internally so
+    // the pointer passed can be freed after return.
     void log_file_content(const char *name);
 
 protected:


### PR DESCRIPTION
It hasn't kept the passed pointer for a while now.