### PR TITLE
GCS_MAVLink: move from `MAV_MODE` enum to `uint8_t`

### DIFF
--- a/AntennaTracker/GCS_MAVLink_Tracker.cpp
+++ b/AntennaTracker/GCS_MAVLink_Tracker.cpp
@@ -6,7 +6,7 @@ MAV_TYPE GCS_Tracker::frame_type() const
     return MAV_TYPE_ANTENNA_TRACKER;
 }
 
-MAV_MODE GCS_MAVLINK_Tracker::base_mode() const
+uint8_t GCS_MAVLINK_Tracker::base_mode() const
 {
     uint8_t _base_mode = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
     // work out the base_mode. This value is not very useful
@@ -47,7 +47,7 @@ MAV_MODE GCS_MAVLINK_Tracker::base_mode() const
         _base_mode |= MAV_MODE_FLAG_SAFETY_ARMED;
     }
 
-    return (MAV_MODE)_base_mode;
+    return _base_mode;
 }
 
 uint32_t GCS_Tracker::custom_mode() const

--- a/AntennaTracker/GCS_MAVLink_Tracker.h
+++ b/AntennaTracker/GCS_MAVLink_Tracker.h
@@ -48,7 +48,7 @@ private:
 
     void send_global_position_int() override;
 
-    MAV_MODE base_mode() const override;
+    uint8_t base_mode() const override;
     MAV_STATE vehicle_system_status() const override;
 
     bool waypoint_receiving;

--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -26,7 +26,7 @@ MAV_TYPE GCS_Copter::frame_type() const
     return mav_type;
 }
 
-MAV_MODE GCS_MAVLINK_Copter::base_mode() const
+uint8_t GCS_MAVLINK_Copter::base_mode() const
 {
     uint8_t _base_mode = MAV_MODE_FLAG_STABILIZE_ENABLED;
     // work out the base_mode. This value is not very useful
@@ -56,7 +56,7 @@ MAV_MODE GCS_MAVLINK_Copter::base_mode() const
     // indicate we have set a custom mode
     _base_mode |= MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
 
-    return (MAV_MODE)_base_mode;
+    return _base_mode;
 }
 
 uint32_t GCS_Copter::custom_mode() const

--- a/ArduCopter/GCS_MAVLink_Copter.h
+++ b/ArduCopter/GCS_MAVLink_Copter.h
@@ -85,7 +85,7 @@ private:
     void packetReceived(const mavlink_status_t &status,
                         const mavlink_message_t &msg) override;
 
-    MAV_MODE base_mode() const override;
+    uint8_t base_mode() const override;
     MAV_STATE vehicle_system_status() const override;
 
     float vfr_hud_airspeed() const override;

--- a/ArduPlane/GCS_MAVLink_Plane.cpp
+++ b/ArduPlane/GCS_MAVLink_Plane.cpp
@@ -14,7 +14,7 @@ MAV_TYPE GCS_Plane::frame_type() const
 #endif
 }
 
-MAV_MODE GCS_MAVLINK_Plane::base_mode() const
+uint8_t GCS_MAVLINK_Plane::base_mode() const
 {
     uint8_t _base_mode = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
 
@@ -101,7 +101,7 @@ MAV_MODE GCS_MAVLINK_Plane::base_mode() const
     // indicate we have set a custom mode
     _base_mode |= MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
 
-    return (MAV_MODE)_base_mode;
+    return _base_mode;
 }
 
 uint32_t GCS_Plane::custom_mode() const

--- a/ArduPlane/GCS_MAVLink_Plane.h
+++ b/ArduPlane/GCS_MAVLink_Plane.h
@@ -84,7 +84,7 @@ private:
     bool try_send_message(enum ap_message id) override;
     void packetReceived(const mavlink_status_t &status, const mavlink_message_t &msg) override;
 
-    MAV_MODE base_mode() const override;
+    uint8_t base_mode() const override;
     MAV_STATE vehicle_system_status() const override;
 
     float vfr_hud_airspeed() const override;

--- a/ArduSub/GCS_MAVLink_Sub.cpp
+++ b/ArduSub/GCS_MAVLink_Sub.cpp
@@ -8,7 +8,7 @@ MAV_TYPE GCS_Sub::frame_type() const
     return MAV_TYPE_SUBMARINE;
 }
 
-MAV_MODE GCS_MAVLINK_Sub::base_mode() const
+uint8_t GCS_MAVLINK_Sub::base_mode() const
 {
     uint8_t _base_mode = MAV_MODE_FLAG_STABILIZE_ENABLED;
 
@@ -45,7 +45,7 @@ MAV_MODE GCS_MAVLINK_Sub::base_mode() const
     // indicate we have set a custom mode
     _base_mode |= MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
 
-    return (MAV_MODE)_base_mode;
+    return _base_mode;
 }
 
 uint32_t GCS_Sub::custom_mode() const

--- a/ArduSub/GCS_MAVLink_Sub.h
+++ b/ArduSub/GCS_MAVLink_Sub.h
@@ -49,7 +49,7 @@ private:
 
     bool send_info(void);
 
-    MAV_MODE base_mode() const override;
+    uint8_t base_mode() const override;
     MAV_STATE vehicle_system_status() const override;
 
     int16_t vfr_hud_throttle() const override;

--- a/Blimp/GCS_MAVLink_Blimp.cpp
+++ b/Blimp/GCS_MAVLink_Blimp.cpp
@@ -9,7 +9,7 @@ MAV_TYPE GCS_Blimp::frame_type() const
     return blimp.get_frame_mav_type();
 }
 
-MAV_MODE GCS_MAVLINK_Blimp::base_mode() const
+uint8_t GCS_MAVLINK_Blimp::base_mode() const
 {
     uint8_t _base_mode = MAV_MODE_FLAG_STABILIZE_ENABLED;
     _base_mode |= MAV_MODE_FLAG_MANUAL_INPUT_ENABLED;
@@ -22,7 +22,7 @@ MAV_MODE GCS_MAVLINK_Blimp::base_mode() const
     // indicate we have set a custom mode
     _base_mode |= MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
 
-    return (MAV_MODE)_base_mode;
+    return _base_mode;
 }
 
 uint32_t GCS_Blimp::custom_mode() const

--- a/Blimp/GCS_MAVLink_Blimp.h
+++ b/Blimp/GCS_MAVLink_Blimp.h
@@ -60,7 +60,7 @@ private:
     void packetReceived(const mavlink_status_t &status,
                         const mavlink_message_t &msg) override;
 
-    MAV_MODE base_mode() const override;
+    uint8_t base_mode() const override;
     MAV_STATE vehicle_system_status() const override;
 
     float vfr_hud_airspeed() const override;

--- a/Rover/GCS_MAVLink_Rover.cpp
+++ b/Rover/GCS_MAVLink_Rover.cpp
@@ -15,7 +15,7 @@ MAV_TYPE GCS_Rover::frame_type() const
     return MAV_TYPE_GROUND_ROVER;
 }
 
-MAV_MODE GCS_MAVLINK_Rover::base_mode() const
+uint8_t GCS_MAVLINK_Rover::base_mode() const
 {
     uint8_t _base_mode = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
 
@@ -49,7 +49,7 @@ MAV_MODE GCS_MAVLINK_Rover::base_mode() const
     // indicate we have set a custom mode
     _base_mode |= MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
 
-    return (MAV_MODE)_base_mode;
+    return _base_mode;
 }
 
 uint32_t GCS_Rover::custom_mode() const

--- a/Rover/GCS_MAVLink_Rover.h
+++ b/Rover/GCS_MAVLink_Rover.h
@@ -59,7 +59,7 @@ private:
 
     void packetReceived(const mavlink_status_t &status, const mavlink_message_t &msg) override;
 
-    MAV_MODE base_mode() const override;
+    uint8_t base_mode() const override;
     MAV_STATE vehicle_system_status() const override;
 
     int16_t vfr_hud_throttle() const override;

--- a/Tools/AP_Periph/GCS_MAVLink.h
+++ b/Tools/AP_Periph/GCS_MAVLink.h
@@ -36,7 +36,7 @@ private:
 protected:
 
     // Periph information:
-    MAV_MODE base_mode() const override { return (MAV_MODE)MAV_MODE_FLAG_CUSTOM_MODE_ENABLED; }
+    uint8_t base_mode() const override { return MAV_MODE_FLAG_CUSTOM_MODE_ENABLED; }
     MAV_STATE vehicle_system_status() const override { return MAV_STATE_CALIBRATING; }
 
     void send_nav_controller_output() const override {};

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -506,7 +506,7 @@ protected:
     bool accept_packet(const mavlink_status_t &status, const mavlink_message_t &msg) const;
     void set_ekf_origin(const Location& loc);
 
-    virtual MAV_MODE base_mode() const = 0;
+    virtual uint8_t base_mode() const = 0;
     MAV_STATE system_status() const;
     virtual MAV_STATE vehicle_system_status() const = 0;
 
@@ -794,7 +794,7 @@ private:
     };
     void log_mavlink_stats();
 
-    MAV_RESULT _set_mode_common(const MAV_MODE base_mode, const uint32_t custom_mode);
+    MAV_RESULT _set_mode_common(const uint8_t base_mode, const uint32_t custom_mode);
 
     // send a (textual) message to the GCS that a received message has
     // been deprecated

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2784,7 +2784,7 @@ void GCS_MAVLINK::handle_set_mode(const mavlink_message_t &msg)
     mavlink_set_mode_t packet;
     mavlink_msg_set_mode_decode(&msg, &packet);
 
-    const MAV_MODE _base_mode = (MAV_MODE)packet.base_mode;
+    const uint8_t _base_mode = (uint8_t)packet.base_mode;
     const uint32_t _custom_mode = packet.custom_mode;
 
     _set_mode_common(_base_mode, _custom_mode);
@@ -2793,11 +2793,11 @@ void GCS_MAVLINK::handle_set_mode(const mavlink_message_t &msg)
 /*
   code common to both SET_MODE mavlink message and command long set_mode msg
 */
-MAV_RESULT GCS_MAVLINK::_set_mode_common(const MAV_MODE _base_mode, const uint32_t _custom_mode)
+MAV_RESULT GCS_MAVLINK::_set_mode_common(const uint8_t _base_mode, const uint32_t _custom_mode)
 {
     // only accept custom modes because there is no easy mapping from Mavlink flight modes to AC flight modes
 #if AP_VEHICLE_ENABLED
-    if (uint32_t(_base_mode) & MAV_MODE_FLAG_CUSTOM_MODE_ENABLED) {
+    if ((_base_mode & MAV_MODE_FLAG_CUSTOM_MODE_ENABLED) != 0) {
         if (!AP::vehicle()->set_mode(_custom_mode, ModeReason::GCS_COMMAND)) {
             // often we should be returning DENIED rather than FAILED
             // here.  Perhaps a "has_mode" callback on AP_::vehicle()
@@ -2808,7 +2808,7 @@ MAV_RESULT GCS_MAVLINK::_set_mode_common(const MAV_MODE _base_mode, const uint32
     }
 #endif
 
-    if (_base_mode == (MAV_MODE)MAV_MODE_FLAG_DECODE_POSITION_SAFETY) {
+    if (_base_mode == MAV_MODE_FLAG_DECODE_POSITION_SAFETY) {
         // set the safety switch position. Must be in a command by itself
         if (_custom_mode == 0) {
             // turn safety off (pwm outputs flow to the motors)
@@ -4841,7 +4841,7 @@ MAV_RESULT GCS_MAVLINK::handle_command_request_autopilot_capabilities(const mavl
 
 MAV_RESULT GCS_MAVLINK::handle_command_do_set_mode(const mavlink_command_int_t &packet)
 {
-    const MAV_MODE _base_mode = (MAV_MODE)packet.param1;
+    const uint8_t _base_mode = (uint8_t)packet.param1;
     const uint32_t _custom_mode = (uint32_t)packet.param2;
 
     return _set_mode_common(_base_mode, _custom_mode);

--- a/libraries/GCS_MAVLink/GCS_Dummy.h
+++ b/libraries/GCS_MAVLink/GCS_Dummy.h
@@ -30,7 +30,7 @@ private:
 protected:
 
     // dummy information:
-    MAV_MODE base_mode() const override { return (MAV_MODE)MAV_MODE_FLAG_CUSTOM_MODE_ENABLED; }
+    uint8_t base_mode() const override { return (uint8_t)MAV_MODE_FLAG_CUSTOM_MODE_ENABLED; }
     MAV_STATE vehicle_system_status() const override { return MAV_STATE_CALIBRATING; }
 
     void send_nav_controller_output() const override {};


### PR DESCRIPTION
Were putting values not in the `MAV_MODE` enum into it, better to use a uint8_t.

See: https://github.com/mavlink/mavlink/pull/2195
