### PR TITLE
AP_Arming_Copter: Allow arming with unhealthy visodom in non-gps modes

### DIFF
--- a/ArduCopter/AP_Arming_Copter.cpp
+++ b/ArduCopter/AP_Arming_Copter.cpp
@@ -399,6 +399,31 @@ bool AP_Arming_Copter::gps_checks(bool display_failure)
     return true;
 }
 
+#if HAL_VISUALODOM_ENABLED
+// performs pre_arm visodom related checks and returns true if passed
+bool AP_Arming_Copter::visodom_checks(bool display_failure)
+{
+    // check if fence requires GPS/position
+    bool fence_requires_pos = false;
+#if AP_FENCE_ENABLED
+    // if circular or polygon fence is enabled we need GPS/position
+    fence_requires_pos = (copter.fence.get_enabled_fences() & (AC_FENCE_TYPE_CIRCLE | AC_FENCE_TYPE_POLYGON)) > 0;
+#endif
+
+    // check if flight mode requires GPS/position
+    bool mode_requires_pos = copter.flightmode->requires_GPS() || fence_requires_pos || (copter.simple_mode == Copter::SimpleMode::SUPERSIMPLE);
+
+    // return true if position is not required
+    if (!mode_requires_pos) {
+        return true;
+    } else {
+        // call parent visodom checks
+        return AP_Arming::visodom_checks(display_failure);
+    }
+
+}
+#endif
+
 // check ekf attitude is acceptable
 bool AP_Arming_Copter::pre_arm_ekf_attitude_check()
 {

--- a/ArduCopter/AP_Arming_Copter.h
+++ b/ArduCopter/AP_Arming_Copter.h
@@ -40,6 +40,9 @@ protected:
     bool gps_checks(bool display_failure) override;
     bool barometer_checks(bool display_failure) override;
     bool board_voltage_checks(bool display_failure) override;
+#if HAL_VISUALODOM_ENABLED
+    bool visodom_checks(bool display_failure) override;
+#endif
 
     // NOTE! the following check functions *DO NOT* call into AP_Arming!
     bool parameter_checks(bool display_failure);

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1930,7 +1930,7 @@ bool AP_Arming::rc_checks_copter_sub(const bool display_failure, const RC_Channe
 
 #if HAL_VISUALODOM_ENABLED
 // check visual odometry is working
-bool AP_Arming::visodom_checks(bool display_failure) const
+bool AP_Arming::visodom_checks(bool display_failure)
 {
     if (!check_enabled(ARMING_CHECK_VISION)) {
         return true;

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -257,7 +257,7 @@ protected:
     bool servo_checks(bool report) const;
     bool rc_checks_copter_sub(bool display_failure, const class RC_Channel *channels[4]) const;
 
-    bool visodom_checks(bool report) const;
+    virtual bool visodom_checks(bool report);
     bool disarm_switch_checks(bool report) const;
 
     // mandatory checks that cannot be bypassed.  This function will only be called if ARMING_CHECK is zero or arming forced


### PR DESCRIPTION
This allows arming in non-GPS flight modes like Stabilize, even if the visual odometry is unhealthy. The behavior is mostly copied from gps_checks. 

It was compiled for copter for sitl and fmuv3 and also tested on a barebone fmuv3. With 
- VISO_TYPE=1 
- EK3_SRC1_POSXY = 6
- EK3_SRC1_VELXY = 0
- EK3_SRC1_POSZ = 1
- EK3_SRC1_VELZ = 0
on Copter 4.5.7. the prearm message _visodom unhealthy_ is shown in Stabilize. With this branch the message disappears in Stabilize, but appears again when changing to Loiter.