### PR TITLE
Plane: Allow lower speeds in landing final

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -305,7 +305,7 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Param: AIRSPEED_STALL
     // @DisplayName: Stall airspeed
-    // @Description: If stall prevention is enabled this speed is used for its calculations. If set to 0 then AIRSPEED_MIN is used instead. Typically set slightly higher than the true stall speed. Value is as an indicated (calibrated/apparent) airspeed.
+    // @Description: If stall prevention is enabled this speed is used to calculate the minimum airspeed while banking. It is also used during landing final as the minimum airspeed that can be demanded by the TECS, which allows using TECS_LAND_ARSPD or LAND_PF_ARSPD to achieve landings slower than AIRSPEED_MIN. If this is set to 0 then the stall speed is assumed to be the minimum airspeed speed. Typically set slightly higher then true stall speed.
     // @Units: m/s
     // @Range: 5 75
     // @User: Standard

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -267,8 +267,12 @@ void Plane::calc_airspeed_errors()
         target_airspeed_cm += airspeed_nudge_cm;
     }
 
+    float airspeed_lower_bound = is_positive(aparm.airspeed_stall)
+                                     ? aparm.airspeed_stall
+                                     : aparm.airspeed_min;
+
     // Apply airspeed limit
-    target_airspeed_cm = constrain_int32(target_airspeed_cm, aparm.airspeed_min*100, aparm.airspeed_max*100);
+    target_airspeed_cm = constrain_int32(target_airspeed_cm, airspeed_lower_bound*100, aparm.airspeed_max*100);
 
     // use the TECS view of the target airspeed for reporting, to take
     // account of the landing speed

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -347,6 +347,24 @@ bool AP_Landing::is_flaring(void) const
     }
 }
 
+// return true if the landing is at the pre-flare stage or later
+bool AP_Landing::is_on_final(void) const
+{
+    if (!flags.in_progress) {
+        return false;
+    }
+
+    switch (type) {
+    case TYPE_STANDARD_GLIDE_SLOPE:
+        return type_slope_is_on_final();
+#if HAL_LANDING_DEEPSTALL_ENABLED
+    case TYPE_DEEPSTALL:
+#endif
+    default:
+        return false;
+    }
+}
+
 // return true while the aircraft is performing a landing approach
 // when true the vehicle will:
 //   - disable ground steering

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -79,6 +79,7 @@ public:
     void check_if_need_to_abort(const AP_FixedWing::Rangefinder_State &rangefinder_state);
     bool request_go_around(void);
     bool is_flaring(void) const;
+    bool is_on_final(void) const;
     bool is_on_approach(void) const;
     bool is_ground_steering_allowed(void) const;
     bool is_throttle_suppressed(void) const;
@@ -206,6 +207,7 @@ private:
     void type_slope_log(void) const;
     bool type_slope_is_complete(void) const;
     bool type_slope_is_flaring(void) const;
+    bool type_slope_is_on_final(void) const;
     bool type_slope_is_on_approach(void) const;
     bool type_slope_is_expecting_impact(void) const;
     bool type_slope_is_throttle_suppressed(void) const;

--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -390,6 +390,12 @@ bool AP_Landing::type_slope_is_flaring(void) const
     return (type_slope_stage == SlopeStage::FINAL);
 }
 
+bool AP_Landing::type_slope_is_on_final(void) const
+{
+    return (type_slope_stage == SlopeStage::PREFLARE ||
+            type_slope_stage == SlopeStage::FINAL);
+}
+
 bool AP_Landing::type_slope_is_on_approach(void) const
 {
     return (type_slope_stage == SlopeStage::APPROACH ||
@@ -398,8 +404,7 @@ bool AP_Landing::type_slope_is_on_approach(void) const
 
 bool AP_Landing::type_slope_is_expecting_impact(void) const
 {
-    return (type_slope_stage == SlopeStage::PREFLARE ||
-            type_slope_stage == SlopeStage::FINAL);
+    return type_slope_is_on_final();
 }
 
 bool AP_Landing::type_slope_is_complete(void) const

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -411,6 +411,10 @@ void AP_TECS::_update_speed(float DT)
     _TASmax   = MIN(_TASmax, aparm.airspeed_max * EAS2TAS);
     _TASmin   = aparm.airspeed_min * EAS2TAS;
 
+    if (_landing.is_on_final() && is_positive(aparm.airspeed_stall)) {
+        _TASmin = aparm.airspeed_stall * EAS2TAS;
+    }
+
     if (aparm.stall_prevention) {
         // when stall prevention is active we raise the minimum
         // airspeed based on aerodynamic load factor


### PR DESCRIPTION
# Plane: Allow lower speeds in landing final

## Description
This PR allows for lower airspeeds during the landing final while maintaining appropriate limits during other phases of the flight, including the landing approach phase, if AIRSPEED_STALL is set. This enables smoother/slower landings when a conservative AIRSPEED_MIN is used, which previously resulted in fast touchdowns.

## Changes
- Relaxed target airspeed constraints in navigation.cpp to allow for target airspeeds as low as AIRSPEED_STALL if set. This enables the following changes while maintaining safety, as the TECS further constraints the target airspeed as appropriate.
- Added a method to the landing controller to determine if the aircraft is on landing final.
- Adjusted the TECS airspeed constraints during landing final to allow speeds as low as AIRSPEED_STALL, if set.
- Corrected an inaccuracy in the AIRSPEED_STALL parameter description (this can be moved to a separate PR if required, but I thought it was small enough to include here).
- Updated the AIRSPEED_STALL parameter description to explain its new role during landing.