### PR TITLE
Plane: add rangefinder engagement distance parameter

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1279,6 +1279,17 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("GUIDED_TIMEOUT", 40, ParametersG2, guided_timeout, 3.0f),
 
+#if AP_RANGEFINDER_ENABLED
+    // @Param: RNGFND_LND_DIST
+    // @DisplayName: Rangefinder landing engagement distance
+    // @Description: The horizontal distance to the landing point at which the rangefinder engages when RNGFND_LANDING is enabled. This is useful for landing on platforms or small plateaus, and to avoid interference from uneven terrain or obstacles on approach. A value of 0 engages the rangefinder as soon as it reports valid readings within its range limits. Very small values are not recommended unless required by the landing scenario, as they can force large slope corrections near the ground, increase auto-abort frequency if LAND_ABORT_DEG is set, and provide no slope-correction benefit if the rangefinder is engaged after flare.
+    // @Range: 0 500
+    // @Units: m
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("RNGFND_LND_DIST", 41, ParametersG2, rangefinder_land_engage_dist_m, 0),
+#endif
+
     AP_GROUPEND
 };
 

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -590,6 +590,9 @@ public:
 #if AP_RANGEFINDER_ENABLED
     // orientation of rangefinder to use for landing
     AP_Int8 rangefinder_land_orient;
+
+    // distance to the landing point to engage the rangefinder for landing
+    AP_Int16 rangefinder_land_engage_dist_m;
 #endif
 
 #if AP_PLANE_SYSTEMID_ENABLED

--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -686,8 +686,10 @@ float Plane::rangefinder_correction(void)
         return 0;
     }
 
-    // for now we only support the rangefinder for landing 
-    bool using_rangefinder = (rangefinder_use(RangeFinderUse::TAKEOFF_LANDING) && flight_stage == AP_FixedWing::FlightStage::LAND);
+    // for now we only support the rangefinder for landing
+    bool using_rangefinder = (rangefinder_use(RangeFinderUse::TAKEOFF_LANDING) &&
+                              flight_stage == AP_FixedWing::FlightStage::LAND &&
+                              rangefinder_state.in_use);
     if (!using_rangefinder) {
         return 0;
     }
@@ -783,9 +785,18 @@ void Plane::rangefinder_height_update(void)
                 flightstage_good_for_rangefinder_landing = true;
             }
 #endif
+
+            // Check if the aircraft is within RNGFND_LND_DIST meters from the
+            // landing point to engage it
+            const int16_t land_engage_dist_m = g2.rangefinder_land_engage_dist_m;
+            const bool is_within_engagement_distance =
+                (land_engage_dist_m <= 0) ||
+                (auto_state.wp_distance <= land_engage_dist_m);
+
             if (!rangefinder_state.in_use &&
                 flightstage_good_for_rangefinder_landing &&
-                rangefinder_use(RangeFinderUse::TAKEOFF_LANDING)) {
+                rangefinder_use(RangeFinderUse::TAKEOFF_LANDING) &&
+                is_within_engagement_distance) {
                 rangefinder_state.in_use = true;
                 gcs().send_text(MAV_SEVERITY_INFO, "Rangefinder engaged at %.2fm", (double)rangefinder_state.height_estimate);
             }
@@ -951,7 +962,8 @@ float Plane::get_landing_height(bool &rangefinder_active)
 #if AP_RANGEFINDER_ENABLED
     // possibly correct with rangefinder
     height -= rangefinder_correction();
-    rangefinder_active = rangefinder_use(RangeFinderUse::TAKEOFF_LANDING) && rangefinder_state.in_range;
+    rangefinder_active = rangefinder_use(RangeFinderUse::TAKEOFF_LANDING) &&
+                         rangefinder_state.in_use && rangefinder_state.in_range;
 #endif
 
     return height;


### PR DESCRIPTION
# Summary

Introduces the RNGFND_LND_DIST parameter, which defines the horizontal distance to the landing point at which the rangefinder engages when RNGFND_LANDING is enabled.

## Testing (more checks increases chance of being merged)

- [X] Checked by a human programmer
- [X] Tested in SITL
- [X] Tested on hardware
- [ ] Logs attached
- [X] Logs available on request
- [ ] Autotest included

## Description

This is useful for landing on top of platforms or small plateaus, and to avoid interference from uneven terrain or obstacles during the approach.

When set to the default value of 0, the rangefinder engages as soon as it is within range, matching existing behavior.

### Key changes
- Adds RNGFND_LND_DIST parameter to control rangefinder engagement horizontal distance during landing.
- Updates rangefinder logic to engage only when within the specified distance.
- Requires rangefinder_state.in_use for rangefinder correction to be applied.
- Requires both in_use and in_range for rangefinder_active to be true.