### PR TITLE
AP_HAL_ESP32: fix up I2C and SPI port drivers

### DIFF
--- a/libraries/AP_HAL_ESP32/I2CDevice.cpp
+++ b/libraries/AP_HAL_ESP32/I2CDevice.cpp
@@ -61,7 +61,8 @@ I2CDeviceManager::I2CDeviceManager(void)
 I2CDevice::I2CDevice(uint8_t busnum, uint8_t address, uint32_t bus_clock, bool use_smbus, uint32_t timeout_ms) :
     bus(I2CDeviceManager::businfo[busnum]),
     _retries(10),
-    _address(address)
+    _address(address),
+    _timeout_ms(timeout_ms)
 {
     set_device_bus(busnum);
     set_device_address(address);
@@ -118,9 +119,10 @@ bool I2CDevice::transfer(const uint8_t *send, uint32_t send_len,
         }
         i2c_master_stop(cmd);
 
-        TickType_t timeout = 1 + 16L * (send_len + recv_len) * 1000 / bus.bus_clock / portTICK_PERIOD_MS;
+        uint32_t timeout_ms = 1 + 16L * (send_len + recv_len) * 1000 / bus.bus_clock;
+        timeout_ms = MAX(timeout_ms, _timeout_ms);
         for (int i = 0; !result && i < _retries; i++) {
-            result = (i2c_master_cmd_begin(bus.port, cmd, timeout) == ESP_OK);
+            result = (i2c_master_cmd_begin(bus.port, cmd, pdMS_TO_TICKS(timeout_ms)) == ESP_OK);
             if (!result) {
                 i2c_reset_tx_fifo(bus.port);
                 i2c_reset_rx_fifo(bus.port);

--- a/libraries/AP_HAL_ESP32/I2CDevice.h
+++ b/libraries/AP_HAL_ESP32/I2CDevice.h
@@ -106,7 +106,7 @@ protected:
     uint8_t _retries;
     uint8_t _address;
     char *pname;
-
+    uint32_t _timeout_ms;
 };
 
 class I2CDeviceManager : public AP_HAL::I2CDeviceManager

--- a/libraries/AP_HAL_ESP32/SPIDevice.cpp
+++ b/libraries/AP_HAL_ESP32/SPIDevice.cpp
@@ -116,7 +116,7 @@ bool SPIDevice::transfer(const uint8_t *send, uint32_t send_len,
 #ifdef SPIDEBUG
     printf("%s:%d \n", __PRETTY_FUNCTION__, __LINE__);
 #endif
-    if (!send || !recv) {
+    if ((send_len == recv_len && send == recv) || !send || !recv) {
         // simplest cases
         transfer_fullduplex(send, recv, recv_len?recv_len:send_len);
         return true;

--- a/libraries/AP_HAL_ESP32/SPIDevice.cpp
+++ b/libraries/AP_HAL_ESP32/SPIDevice.cpp
@@ -60,9 +60,6 @@ SPIDevice::SPIDevice(SPIBus &_bus, SPIDeviceDesc &_device_desc)
     set_device_bus(bus.bus);
     set_device_address(_device_desc.device);
     set_speed(AP_HAL::Device::SPEED_LOW);
-    esp_rom_gpio_pad_select_gpio(device_desc.cs);
-    gpio_set_direction(device_desc.cs, GPIO_MODE_OUTPUT);
-    gpio_set_level(device_desc.cs, 1);
 
     spi_device_interface_config_t cfg_low;
     memset(&cfg_low, 0, sizeof(cfg_low));
@@ -226,6 +223,15 @@ SPIDeviceManager::get_device(const char *name)
         }
         busp->next = buses;
         busp->bus = desc.bus;
+        // deassert all CSes on the bus
+        for (i = 0; i<ARRAY_SIZE(device_desc); i++) {
+            SPIDeviceDesc &curr_desc = device_desc[i];
+            if (desc.bus == curr_desc.bus) {
+                esp_rom_gpio_pad_select_gpio(curr_desc.cs);
+                gpio_set_direction(curr_desc.cs, GPIO_MODE_OUTPUT);
+                gpio_set_level(curr_desc.cs, 1);
+            }
+        }
         buses = busp;
     }
 


### PR DESCRIPTION
Lessons learned from the stampfly to make ESP32 more similar to ChibiOS. Please see commits for details. These have been tested on there for a while now.