### PR TITLE
[backport 4.6] AP_Filesystem: ROMFS: fix open race conditions

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_ROMFS.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_ROMFS.h
@@ -19,6 +19,8 @@
 
 #if AP_FILESYSTEM_ROMFS_ENABLED
 
+#include <AP_HAL/Semaphores.h>
+
 #include "AP_Filesystem_backend.h"
 
 class AP_Filesystem_ROMFS : public AP_Filesystem_Backend
@@ -56,6 +58,9 @@ public:
     void unload_file(FileData *fd) override;
     
 private:
+    // protect searching for free file/dir records when opening/closing
+    HAL_Semaphore record_sem;
+
     // only allow up to 4 files at a time
     static constexpr uint8_t max_open_file = 4;
     static constexpr uint8_t max_open_dir = 4;


### PR DESCRIPTION
Lua opens scripts to load them into memory, then the logger opens them after to stream them into the dataflash log. When loading multiple large Lua scripts from ROMFS, decompression takes a significant amount of time. This creates the opportunity for the Lua interpreter and logging threads to both be inside `AP_Filesystem_ROMFS::open()` decompressing a file.

If this happens, the function can return the same `fd` for two different calls as the `fd` is chosen before decompression starts, but only marked as being used after that finishes. The read pointers then stomp on each other, so Lua loads garbled scripts (usually resulting in a syntax error) and the logger dumps garbled data.

Fix the issue by locking before searching for a free record (or marking a record as free). Apply the same fix to directories as well. This doesn't protect against using the same `fd`/`dirp` from multiple threads, but that behavior is to be discouraged anyway and is not the root cause here.

Backport of #29201 