### PR TITLE
Filter: SlewCalculator2D typo fix

### DIFF
--- a/libraries/Filter/SlewCalculator2D.cpp
+++ b/libraries/Filter/SlewCalculator2D.cpp
@@ -39,5 +39,5 @@ void SlewCalculator2D::update(const Vector2f& sample, float dt)
 // get last oscillation slew rate
 float SlewCalculator2D::get_slew_rate() const
 {
-    return safe_sqrt(sq(xlimiter.get_slew_rate()) + sq(xlimiter.get_slew_rate()));
+    return safe_sqrt(sq(xlimiter.get_slew_rate()) + sq(ylimiter.get_slew_rate()));
 }


### PR DESCRIPTION
This fixes a typo in the 2D Slew Calculator used by the AC_PID_2D class which is used in Copter, Rover and Blimp's XY velocity controller.  This means it's also used by QuadPlanes in QLoiter, etc but surely it has nothing to do with the recent questions around quad plane attitude control because the bug was in 4.5 as well.

This was added in PR https://github.com/ArduPilot/ardupilot/pull/23981 but it is only used for reporting so I think this does not cause any actual performance issue.  In fact, since this PR went in we've simplified the Rover autotune and we don't use this is anymore so we could potentially backout the slew reporting completely and save some flash and a very small amount of CPU

This resolves issue https://github.com/ArduPilot/ardupilot/issues/29272

I've done some minor testing in copter in SITL and there is a difference in the logged slew rate.  For example in the "before" we see consistently low slew rate while in "after" it is much much larger.
![srate-before-vs-after](https://github.com/user-attachments/assets/58327650-0aa7-4508-b0e4-711e9bccc41b)

I think this is correct though because if I greatly reduce the PSC_VELXY_P and I values I can produce similarly huge numbers with master
![image](https://github.com/user-attachments/assets/dd7dee99-3847-4eec-8199-55e2984cb09c)

