### PR TITLE
Plane: scale the angle P gains in QLOITER

### DIFF
--- a/ArduPlane/mode_qloiter.cpp
+++ b/ArduPlane/mode_qloiter.cpp
@@ -126,6 +126,9 @@ void ModeQLoiter::run()
     // Pilot input, use yaw rate time constant
     quadplane.set_pilot_yaw_rate_time_constant();
 
+    // setup scaling of roll and pitch angle P gains to match fixed wing gains
+    quadplane.setup_rp_fw_angle_gains();
+
     // call attitude controller with conservative smoothing gain of 4.0f
     attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(plane.nav_roll_cd,
                                                                   plane.nav_pitch_cd,


### PR DESCRIPTION
During QLOITER mode switches from cruise flight oscillations were observed. These seem very similar to the oscillations that the angle P gain scaling in POS1 fixed due to the rate controller using the full multicopter angle P gains at fixed wing speeds. This change will scale the angle P gains in QLOITER in a similar manner as is done in AUTO mode on detransition.

NB: Change has not been tested outside of simulation.

Example of the pitch oscillations observed on mode switch.

![image](https://github.com/user-attachments/assets/fdab876e-1fd9-408a-92b8-22faa8af17bb)
