### PR TITLE
AP_Frsky_D: Enhanced, add power, time, temperature, acceleration etc

### DIFF
--- a/libraries/AP_Frsky_Telem/AP_Frsky_Backend.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Backend.h
@@ -58,6 +58,11 @@ protected:
     void calc_nav_alt(void);
     void calc_gps_position(void);
     bool calc_rpm(const uint8_t instance, int32_t &value) const;
+    void calc_power(uint8_t cell_count);
+    void calc_acc(void);
+    void calc_time(void);
+    void calc_temp(void);
+
 
     float get_vspeed_ms(void);
 
@@ -77,7 +82,35 @@ protected:
         uint16_t alt_nav_cm;
         int16_t speed_in_meter;
         uint16_t speed_in_centimeter;
-        uint16_t yaw;
+        uint16_t yaw; //course
+        
+        uint16_t batt_volt; //mV
+        uint16_t cells_mvolts[10]; //mV
+
+        uint8_t fuel;
+
+        float   power_ampers;
+        float   power_volts;
+
+        float acc_x;
+        float acc_y;
+        float acc_z;
+
+        uint8_t hours;
+        uint8_t minutes;
+        uint8_t seconds;
+
+        // uint16_t day;
+        // uint16_t month;
+        // uint16_t year;
+
+        int32_t rpm;
+
+        float temp1;
+        float temp2;
+
+
+
     } _SPort_data;
 
     /*
@@ -86,25 +119,42 @@ protected:
     // FrSky sensor hub data IDs
     static const uint8_t DATA_ID_GPS_ALT_BP        = 0x01;
     static const uint8_t DATA_ID_TEMP1             = 0x02;
+    static const uint8_t DATA_ID_RPM               = 0x03; 
     static const uint8_t DATA_ID_FUEL              = 0x04;
     static const uint8_t DATA_ID_TEMP2             = 0x05;
+    static const uint8_t DATA_ID_VOLTS             = 0x06; //0,01-4.2V  4bit cell No, other 12bits in decimal 0-2100 range is 0-4.2V range
     static const uint8_t DATA_ID_GPS_ALT_AP        = 0x09;
     static const uint8_t DATA_ID_BARO_ALT_BP       = 0x10;
     static const uint8_t DATA_ID_GPS_SPEED_BP      = 0x11;
     static const uint8_t DATA_ID_GPS_LONG_BP       = 0x12;
     static const uint8_t DATA_ID_GPS_LAT_BP        = 0x13;
     static const uint8_t DATA_ID_GPS_COURS_BP      = 0x14;
+    static const uint8_t DATA_ID_DAY_MONTH         = 0x15;
+    static const uint8_t DATA_ID_YEAR_0            = 0x16; //1B: years from 2000    2B:0
+    static const uint8_t DATA_ID_HOURS_MINUTE      = 0x17; //1B: hours              2B:minutes
+    static const uint8_t DATA_ID_SECONDS_0         = 0x18; //1B: seconds            2B:0
     static const uint8_t DATA_ID_GPS_SPEED_AP      = 0x19;
     static const uint8_t DATA_ID_GPS_LONG_AP       = 0x1A;
     static const uint8_t DATA_ID_GPS_LAT_AP        = 0x1B;
+    static const uint8_t DATA_ID_GPS_COURS_AP      = 0x1C;
     static const uint8_t DATA_ID_BARO_ALT_AP       = 0x21;
     static const uint8_t DATA_ID_GPS_LONG_EW       = 0x22;
     static const uint8_t DATA_ID_GPS_LAT_NS        = 0x23;
-    static const uint8_t DATA_ID_CURRENT           = 0x28;
+    static const uint8_t DATA_ID_ACC_X             = 0x24;
+    static const uint8_t DATA_ID_ACC_Y             = 0x25;
+    static const uint8_t DATA_ID_ACC_Z             = 0x26;
+
     static const uint8_t DATA_ID_VFAS              = 0x39;
+    
+    //voltage and current sensor
+    static const uint8_t DATA_ID_VOLTAGE_BP           = 0x3A; // 0,5-48V  
+    static const uint8_t DATA_ID_VOLTAGE_AP           = 0x3B; // voltage used to calculate watts only AP has to be <10
+    static const uint8_t DATA_ID_CURRENT              = 0x28; // 0,1-100A
 
     static const uint8_t START_STOP_D              = 0x5E;
     static const uint8_t BYTESTUFF_D               = 0x5D;
+
+
 
     /*
       for FrSky X protocol (X-receivers)

--- a/libraries/AP_Frsky_Telem/AP_Frsky_D.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_D.cpp
@@ -3,9 +3,9 @@
 #if AP_FRSKY_D_TELEM_ENABLED
 
 #include <AP_AHRS/AP_AHRS.h>
-#include <AP_BattMonitor/AP_BattMonitor.h>
-#include <AP_GPS/AP_GPS.h>
 #include <GCS_MAVLink/GCS.h>
+#include <AP_Baro/AP_Baro.h>
+
 
 /*
   send 1 byte and do byte stuffing
@@ -37,40 +37,69 @@ void AP_Frsky_D::send_uint16(uint16_t id, uint16_t data)
 }
 
 /*
- * send frame1 and frame2 telemetry data
- * one frame (frame1) is sent every 200ms with baro alt, nb sats, batt volts and amp, control_mode
- * a second frame (frame2) is sent every second (1000ms) with gps position data, and ahrs.yaw_sensor heading (instead of GPS heading)
+ * send frame1/2/3 telemetry data
  * for FrSky D protocol (D-receivers)
  */
 void AP_Frsky_D::send(void)
 {
-    const AP_BattMonitor &_battery = AP::battery();
+
     uint32_t now = AP_HAL::millis();
-    // send frame1 every 200ms
-    if (now - _D.last_200ms_frame >= 200) {
-        _D.last_200ms_frame = now;
-        send_uint16(DATA_ID_TEMP2, (uint16_t)(AP::gps().num_sats() * 10 + AP::gps().status())); // send GPS status and number of satellites as num_sats*10 + status (to fit into a uint8_t)
-        send_uint16(DATA_ID_TEMP1, gcs().custom_mode()); // send flight mode
-        uint8_t percentage = 0;
-        IGNORE_RETURN(_battery.capacity_remaining_pct(percentage));
-        send_uint16(DATA_ID_FUEL, (uint16_t)roundf(percentage)); // send battery remaining
-        send_uint16(DATA_ID_VFAS, (uint16_t)roundf(_battery.voltage() * 10.0f)); // send battery voltage
-        float current;
-        if (!_battery.current_amps(current)) {
-            current = 0;
-        }
-        send_uint16(DATA_ID_CURRENT, (uint16_t)roundf(current * 10.0f)); // send current consumption
+    uint8_t cells_count = 3; //hard coded for now
+    uint16_t cell_id_voltage;
+    
+    // send fast FRAME1
+    if (now - _D.last_fast_frame >= FAST_FRAME_INTERVAL) {
+        _D.last_fast_frame = now;
+        
+        
+        calc_acc();
+ 
+        send_uint16(DATA_ID_ACC_X, (uint16_t)(_SPort_data.acc_x)); 
+        send_uint16(DATA_ID_ACC_Y, (uint16_t)(_SPort_data.acc_y)); 
+        send_uint16(DATA_ID_ACC_Z, (uint16_t)(_SPort_data.acc_z)); 
+
         calc_nav_alt();
-        send_uint16(DATA_ID_BARO_ALT_BP, _SPort_data.alt_nav_meters); // send nav altitude integer part
-        send_uint16(DATA_ID_BARO_ALT_AP, _SPort_data.alt_nav_cm); // send nav altitude decimal part
+        
+        send_uint16(DATA_ID_BARO_ALT_BP, _SPort_data.alt_nav_meters);      
+        send_uint16(DATA_ID_BARO_ALT_AP, _SPort_data.alt_nav_cm);          
+        
+        calc_temp();
+        
+        send_uint16(DATA_ID_TEMP1, _SPort_data.temp1);                   
+        send_uint16(DATA_ID_TEMP2, _SPort_data.temp2); 
+
+        calc_power(cells_count);
+
+        //send per cell voltages
+        for (uint8_t i = 0; i < cells_count; i++) {
+            // make it FrSky style (id and volts in 2 bytes)
+            cell_id_voltage = (uint16_t) (0x1000*i+(float)_SPort_data.cells_mvolts[i]/1000/4.2*0x0834); //magic number 0x0834 means 2100 ADC steps per 4.2V            
+            // cell_id_voltage = (uint16_t) 0x1000*i+3.85/4.2*0x0834; //magic number 0x0834 = 2100 steps per 4.2V
+            cell_id_voltage = (cell_id_voltage >> 8) | (cell_id_voltage << 8); //swap bytes
+
+            send_uint16(DATA_ID_VOLTS, (uint16_t) cell_id_voltage);      //send cell voltages
+        }
+       
+        send_uint16(DATA_ID_CURRENT, (uint16_t)_SPort_data.power_ampers); // send current consumption);      
+        send_uint16(DATA_ID_VOLTAGE_BP, (uint16_t)(int)(_SPort_data.power_volts));        // 
+        send_uint16(DATA_ID_VOLTAGE_AP, (uint16_t)(_SPort_data.power_volts-(int)_SPort_data.power_volts)*10);   // Has to be less 10 
+        
+        //end FRAME1 data
+        
     }
-    // send frame2 every second
-    if (now - _D.last_1000ms_frame >= 1000) {
-        _D.last_1000ms_frame = now;
-        AP_AHRS &_ahrs = AP::ahrs();
-        send_uint16(DATA_ID_GPS_COURS_BP, (uint16_t)((_ahrs.yaw_sensor / 100) % 360)); // send heading in degree based on AHRS and not GPS
-        calc_gps_position();
+    // send mid FRAME2
+    if (now - _D.last_mid_frame >= MID_FRAME_INTERVAL) {
+        
+        _D.last_mid_frame = now;
+
+        AP_AHRS &_ahrs = AP::ahrs();        
+        send_uint16(DATA_ID_GPS_COURS_BP, (uint16_t)((_ahrs.yaw_sensor / 100) % 360));  // send heading in degree based on AHRS and not GPS
+        send_uint16(DATA_ID_GPS_COURS_AP, (uint16_t)(0));                              // .0 
+        
         if (AP::gps().status() >= 3) {
+            
+            calc_gps_position();        
+        
             send_uint16(DATA_ID_GPS_LAT_BP, _SPort_data.latdddmm); // send gps latitude degree and minute integer part
             send_uint16(DATA_ID_GPS_LAT_AP, _SPort_data.latmmmm); // send gps latitude minutes decimal part
             send_uint16(DATA_ID_GPS_LAT_NS, _SPort_data.lat_ns); // send gps North / South information
@@ -82,7 +111,53 @@ void AP_Frsky_D::send(void)
             send_uint16(DATA_ID_GPS_ALT_BP, _SPort_data.alt_gps_meters); // send gps altitude integer part
             send_uint16(DATA_ID_GPS_ALT_AP, _SPort_data.alt_gps_cm); // send gps altitude decimal part
         }
+
+        // uint8_t percentage = 0;
+        // const AP_BattMonitor &_battery = AP::battery();
+        // IGNORE_RETURN(_battery.capacity_remaining_pct(percentage));
+        // uint8_t battery_fuel = ((percentage / 25) +1) * 25 ; // 0-25, 26-50, 51-75, 76-100
+        // if (battery_fuel > 100) {
+        //     battery_fuel = 100;
+        // }   
+        // send_uint16(DATA_ID_FUEL, (uint16_t) battery_fuel); // send battery remaining
+        // // send_uint16(DATA_ID_VFAS, (uint16_t)roundf(_battery.voltage() * 10.0f)); // send battery voltage
+
     }
+  
+  
+  
+    // send slow FRAME3
+
+    if ((now - _D.last_slow_frame >= SLOW_FRAME_INTERVAL)) {
+
+        _D.last_slow_frame = now;
+        
+        calc_time();
+
+        // send date - not used
+        // send_uint16(DATA_ID_DAY_MONTH, (uint16_t)(0x0101));             // 01.01        
+        // send_uint16(DATA_ID_YEAR_0, (uint16_t)(0x01));                  // 2001
+       
+        //  send time
+        send_uint16(DATA_ID_HOURS_MINUTE, (uint16_t)((_SPort_data.minutes << 8) | _SPort_data.hours));    // send hours & mins       
+        send_uint16(DATA_ID_SECONDS_0, (uint16_t)(_SPort_data.seconds));                                  // seconds
+
+        uint8_t inst = 0;
+        calc_rpm(inst,_SPort_data.rpm);
+        
+        // Baro alt as RPM (1000 is 0m)
+        _SPort_data.rpm = 1000+(uint16_t)AP::baro().get_altitude(); 
+        // GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Baro:  %0.2f",(double)(_SPort_data.rpm));
+
+       
+        send_uint16(DATA_ID_RPM, (uint16_t)(_SPort_data.rpm));              
+        
+    }
+
+
+        
+
+
 }
 
 #endif  // AP_FRSKY_D_TELEM_ENABLED

--- a/libraries/AP_Frsky_Telem/AP_Frsky_D.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_D.h
@@ -4,6 +4,10 @@
 
 #if AP_FRSKY_D_TELEM_ENABLED
 
+#define FAST_FRAME_INTERVAL     300
+#define MID_FRAME_INTERVAL      1500
+#define SLOW_FRAME_INTERVAL     3000
+
 class AP_Frsky_D : public AP_Frsky_Backend
 {
 
@@ -26,8 +30,9 @@ private:
     void send_uint16(uint16_t id, uint16_t data);
 
     struct {
-        uint32_t last_200ms_frame;
-        uint32_t last_1000ms_frame;
+        uint32_t last_fast_frame;
+        uint32_t last_mid_frame;
+        uint32_t last_slow_frame;
     } _D;
 
 };


### PR DESCRIPTION
Some enhancements to the very old FrSky D telemetry.

- Few datagrams added (time, power, battery per cell, barometric altitude etc)
- Transmission divided into 3 frames as per documentation
- User can define periods for every frame types to balance transmission payload.
- Some comments on how to manipulate data, as each solution can vary.