### PR TITLE
autotest: add test for Copter stopping distance calculation issue

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -7901,6 +7901,12 @@ class TestSuite(ABC):
             **kwargs
         )
 
+    def get_local_position_NED(self):
+        '''return a Vector3 repreesenting vehicle position relative to
+        origin in metres, NED'''
+        pos = self.assert_receive_message('LOCAL_POSITION_NED', timeout=1)
+        return Vector3(pos.x, pos.y, pos.z)
+
     def distance_to_local_position(self, local_pos, timeout=30):
         (x, y, z_down) = local_pos  # alt is *up*
 


### PR DESCRIPTION
having a really slow RTL speed should not cause stopping-distance problems, but it does.  The vehicle goes off track as the PSC can't achieve the stopping distance demanded

This test has been added into the "currently fails" list of tests we expect to fail.
