### PR TITLE
Avoid use of OwnPtr in MaxsonarI2CXL driver

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -307,11 +307,13 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
             addr = params[instance].address;
         }
         FOREACH_I2C(i) {
+            auto *device_ptr = hal.i2c_mgr->get_device_ptr(i, addr);
             if (_add_backend(AP_RangeFinder_MaxsonarI2CXL::detect(state[instance], params[instance],
-                                                                  hal.i2c_mgr->get_device(i, addr)),
+                                                                  device_ptr),
                              instance)) {
                 break;
             }
+            delete device_ptr;
         }
         break;
     }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.cpp
@@ -34,9 +34,9 @@ extern const AP_HAL::HAL& hal;
 
 AP_RangeFinder_MaxsonarI2CXL::AP_RangeFinder_MaxsonarI2CXL(RangeFinder::RangeFinder_State &_state,
                                                            AP_RangeFinder_Params &_params,
-                                                           AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)
+                                                           AP_HAL::I2CDevice *dev)
     : AP_RangeFinder_Backend(_state, _params)
-    , _dev(std::move(dev))
+    , _dev(dev)
 {
 }
 
@@ -47,14 +47,14 @@ AP_RangeFinder_MaxsonarI2CXL::AP_RangeFinder_MaxsonarI2CXL(RangeFinder::RangeFin
 */
 AP_RangeFinder_Backend *AP_RangeFinder_MaxsonarI2CXL::detect(RangeFinder::RangeFinder_State &_state,
 																AP_RangeFinder_Params &_params,
-                                                             AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)
+                                                             AP_HAL::I2CDevice *dev)
 {
     if (!dev) {
         return nullptr;
     }
 
     AP_RangeFinder_MaxsonarI2CXL *sensor
-        = NEW_NOTHROW AP_RangeFinder_MaxsonarI2CXL(_state, _params, std::move(dev));
+        = NEW_NOTHROW AP_RangeFinder_MaxsonarI2CXL(_state, _params, dev);
     if (!sensor) {
         return nullptr;
     }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.h
@@ -18,7 +18,7 @@ public:
     // static detection function
     static AP_RangeFinder_Backend *detect(RangeFinder::RangeFinder_State &_state,
                                           AP_RangeFinder_Params &_params,
-                                          AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
+                                          AP_HAL::I2CDevice *dev);
 
     // update state
     void update(void) override;
@@ -33,7 +33,7 @@ private:
     // constructor
     AP_RangeFinder_MaxsonarI2CXL(RangeFinder::RangeFinder_State &_state,
     								AP_RangeFinder_Params &_params,
-                                 AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
+                                 AP_HAL::I2CDevice *dev);
 
     bool _init(void);
     void _timer(void);
@@ -44,7 +44,7 @@ private:
     // start a reading
     bool start_reading(void);
     bool get_reading(uint16_t &reading_cm);
-    AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev;
+    AP_HAL::I2CDevice *_dev;
 };
 
 #endif  // AP_RANGEFINDER_MAXSONARI2CXL_ENABLED

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -619,6 +619,11 @@ float Aircraft::rangefinder_range() const
     // Add some noise on reading
     altitude += sitl->sonar_noise * rand_float();
 
+    // our starting positions can disagree with the terrain database:
+    if (altitude < 0) {
+        altitude = 0;
+    }
+
     return altitude;
 }
 

--- a/libraries/SITL/SIM_MaxSonarI2CXL.h
+++ b/libraries/SITL/SIM_MaxSonarI2CXL.h
@@ -1,5 +1,19 @@
 #pragma once
 
+/*
+  Simulator for the MaxsonarI2XL rangefinder
+
+./Tools/autotest/sim_vehicle.py --gdb --debug -v ArduCopter --speedup=1
+
+param set RNGFND1_TYPE 2
+graph RANGEFINDER.distance
+graph GLOBAL_POSITION_INT.relative_alt/1000-RANGEFINDER.distance
+reboot
+
+arm throttle
+rc 3 1600
+*/
+
 #include "SIM_config.h"
 
 #if AP_SIM_MAXSONAR_I2C_XL_ENABLED


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/23a68707-afe7-457d-9f38-1185d4410898)

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                 *                               
CubeRedPrimary                      0      *           -88     -88               -88    -88    -88
Durandal                            *      *           -72     -72               -72    -72    -64
Hitec-Airspeed           *                 *                               
KakuteH7-bdshot                     *      *           -88     -88               -88    -88    -88
MatekF405                           *      *           -88     -88               -88    -88    -88
Pixhawk1-1M-bdshot                  *                  -88     -88               -88    -88    -88
f103-QiotekPeriph        *                 *                               
f303-Universal           -80               *                               
iomcu                                                                *     
revo-mini                           *      *           -88     -88               -88    -88    -88
skyviper-journey                                       -88                 
skyviper-v2450                                         *                   
```

No errors under Valgrind.
