### PR TITLE
AP_Filesystem: littlefs: fix lseek

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_FlashMemory_LittleFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_FlashMemory_LittleFS.cpp
@@ -230,14 +230,13 @@ int32_t AP_Filesystem_FlashMemory_LittleFS::lseek(int fd, int32_t position, int 
         break;
     }
 
-    lfs_soff_t size = lfs_file_size(&fs, &(fp->file));
-    // emulate SEEK_SET past the end by truncating and filling with zeros
-    if (position > size && whence == SEEK_SET) {
-        LFS_CHECK(lfs_file_truncate(&fs, &(fp->file), position));
+    lfs_soff_t pos = lfs_file_seek(&fs, &(fp->file), position, lfs_whence);
+    if (pos < 0) {
+        errno = errno_from_lfs_error(pos);
+        return -1;
     }
 
-    LFS_CHECK(lfs_file_seek(&fs, &(fp->file), position, lfs_whence));
-    return 0;
+    return pos;
 }
 
 int AP_Filesystem_FlashMemory_LittleFS::stat(const char *name, struct stat *buf)


### PR DESCRIPTION
lseek must return the current file position. Previously, the littlefs version always returned 0, which broke terrain I/O as it checks that the position returned is the one it seeked to. Fix to return the current position, which is correctly returned from littlefs.

This problem was originally and incorrectly diagnosed as an issue with littlefs seeking past the end of the file, but this functionality works fine and fixing the incorrect return completely fixes terrain.

Terrain functionality was verified using `TERRAIN_DEBUG` on KakuteH7Mini-Nand running sim on HW. Terrain data is correctly downloaded from the GCS and loaded from the filesystem after reboot.