### PR TITLE
AP_NavEKF3: elevate compass change statustext alert

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -260,7 +260,7 @@ void NavEKF3_core::tryChangeCompass(void)
         // if the magnetometer is allowed to be used for yaw and has a different index, we start using it
         if (compass.healthy(tempIndex) && compass.use_for_yaw(tempIndex) && tempIndex != magSelectIndex) {
             magSelectIndex = tempIndex;
-            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "EKF3 IMU%u switching to compass %u",(unsigned)imu_index,magSelectIndex);
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "EKF3 IMU%u switching to compass %u",(unsigned)imu_index,magSelectIndex);
             // reset the timeout flag and timer
             magTimeout = false;
             lastHealthyMagTime_ms = imuSampleTime_ms;


### PR DESCRIPTION
This shows up on the GCS very silently and often gets missed by the pilot.  When landing in an area with lots of magnetic interference, the primary compass might change automatically. 

I recently saw a crash where the secondary compass wasn't well calibrated, and the switch caused a crash. 
This alertness level is in line with an EKF Lane switch. 
