### PR TITLE
AP_NavEKF3: revert to primary compass on ground

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -799,6 +799,9 @@ private:
     // try changing compasses on compass failure or timeout
     void tryChangeCompass(void);
 
+    // try changing to a specific compass index
+    void tryChangeCompass(uint8_t compass_index);
+
     // check for new airspeed data and update stored measurements if available
     void readAirSpdData();
 


### PR DESCRIPTION
Revert to the primary compass if it was changed in flight. The compass might have changed because of landing in an area with high mag interference causing a timeout in the magfusion. 
Its more than likely the user wants to go back to flying on the primary mag on subsequent takeoff.  

Pushed on top of #29299