### PR TITLE
AP_Filesystem: FATFS: drop tty check logic

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
@@ -47,14 +47,6 @@ typedef struct {
 #define MAX_FILES 16
 static FAT_FILE *file_table[MAX_FILES];
 
-static bool isatty_(int fileno)
-{
-    if (fileno >= 0 && fileno <= 2) {
-        return true;
-    }
-    return false;
-}
-
 /*
   allocate a file descriptor
 */
@@ -65,9 +57,6 @@ static int new_file_descriptor(const char *pathname)
     FIL *fh;
 
     for (i=0; i<MAX_FILES; ++i) {
-        if (isatty_(i)) {
-            continue;
-        }
         if (file_table[i] == NULL) {
             stream = (FAT_FILE *) calloc(sizeof(FAT_FILE),1);
             if (stream == NULL) {
@@ -120,11 +109,6 @@ static int free_file_descriptor(int fileno)
     FAT_FILE *stream;
     FIL *fh;
 
-    if (isatty_( fileno )) {
-        errno = EBADF;
-        return -1;
-    }
-
     // checks if fileno out of bounds
     stream = fileno_to_stream(fileno);
     if (stream == nullptr) {
@@ -149,11 +133,6 @@ static FIL *fileno_to_fatfs(int fileno)
 {
     FAT_FILE *stream;
     FIL *fh;
-
-    if (isatty_(fileno)) {
-        errno = EBADF;
-        return nullptr;
-    }
 
     // checks if fileno out of bounds
     stream = fileno_to_stream(fileno);
@@ -536,9 +515,6 @@ off_t AP_Filesystem_FATFS::lseek(int fileno, off_t position, int whence)
     fh = fileno_to_fatfs(fileno);
     if (fh == nullptr) {
         errno = EMFILE;
-        return -1;
-    }
-    if (isatty_(fileno)) {
         return -1;
     }
 


### PR DESCRIPTION
In Standard C, the first three file descriptors are usually standard in, out, and error. However, ArduPilot doesn't have a concept of this and other backends (such as LittleFS) don't bother to reject them.

Remove this logic to simplify implementation and allow use of more open files.

Tested on Cube Orange that scripting off SD card and logging still work.