### PR TITLE
AP_Logger: File: clean up fsync code

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem.cpp
@@ -286,6 +286,14 @@ int AP_Filesystem::closedir(DirHandle *dirp)
     return ret;
 }
 
+// return number of bytes that should be written before fsync for optimal
+// streaming performance/robustness. if zero, any number can be written.
+uint32_t AP_Filesystem::bytes_until_fsync(int fd)
+{
+    const Backend &backend = backend_by_fd(fd);
+    return backend.fs.bytes_until_fsync(fd);
+}
+
 // return free disk space in bytes
 int64_t AP_Filesystem::disk_free(const char *path)
 {

--- a/libraries/AP_Filesystem/AP_Filesystem.h
+++ b/libraries/AP_Filesystem/AP_Filesystem.h
@@ -110,6 +110,10 @@ public:
     struct dirent *readdir(DirHandle *dirp);
     int closedir(DirHandle *dirp);
 
+    // return number of bytes that should be written before fsync for optimal
+    // streaming performance/robustness. if zero, any number can be written.
+    uint32_t bytes_until_fsync(int fd);
+
     // return free disk space in bytes, -1 on error
     int64_t disk_free(const char *path);
 

--- a/libraries/AP_Filesystem/AP_Filesystem_ESP32.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_ESP32.cpp
@@ -135,6 +135,22 @@ int AP_Filesystem_ESP32::closedir(void *dirp)
     //	return 0;
 }
 
+// return number of bytes that should be written before fsync for optimal
+// streaming performance/robustness. if zero, any number can be written.
+// assume that ESP32 is similar to FAT and 4K boundaries are good.
+uint32_t AP_Filesystem_ESP32::bytes_until_fsync(int fd)
+{
+    int32_t pos = ::lseek(fd, 0, SEEK_CUR);
+    if (pos < 0) {
+        return 0;
+    }
+
+    const uint32_t block_size = 4096;
+
+    uint32_t block_pos = (uint32_t)pos % block_size;
+    return block_size - block_pos;
+}
+
 // return free disk space in bytes
 int64_t AP_Filesystem_ESP32::disk_free(const char *path)
 {

--- a/libraries/AP_Filesystem/AP_Filesystem_ESP32.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_ESP32.h
@@ -35,6 +35,8 @@ public:
     int closedir(void *dirp) override;
     int rename(const char *oldpath, const char *newpath) override;
 
+    uint32_t bytes_until_fsync(int fd) override;
+
     // return free disk space in bytes, -1 on error
     int64_t disk_free(const char *path) override;
 

--- a/libraries/AP_Filesystem/AP_Filesystem_FATFS.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_FATFS.h
@@ -36,6 +36,8 @@ public:
     struct dirent *readdir(void *dirp) override;
     int closedir(void *dirp) override;
 
+    uint32_t bytes_until_fsync(int fd) override;
+
     // return free disk space in bytes, -1 on error
     int64_t disk_free(const char *path) override;
 

--- a/libraries/AP_Filesystem/AP_Filesystem_FlashMemory_LittleFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_FlashMemory_LittleFS.cpp
@@ -64,16 +64,6 @@ static int lfs_flags_from_flags(int flags);
 
 const extern AP_HAL::HAL& hal;
 
-AP_Filesystem_FlashMemory_LittleFS* AP_Filesystem_FlashMemory_LittleFS::singleton;
-
-AP_Filesystem_FlashMemory_LittleFS::AP_Filesystem_FlashMemory_LittleFS()
-{
-    if (singleton) {
-        AP_HAL::panic("Too many AP_Filesystem_FlashMemory_LittleFS instances");
-    }
-    singleton = this;
-}
-
 int AP_Filesystem_FlashMemory_LittleFS::open(const char *pathname, int flags, bool allow_absolute_path)
 {
     FS_CHECK_ALLOWED(-1);
@@ -1258,20 +1248,6 @@ static int lfs_flags_from_flags(int flags)
     }
 
     return outflags;
-}
-
-// get_singleton for access from logging layer
-AP_Filesystem_FlashMemory_LittleFS *AP_Filesystem_FlashMemory_LittleFS::get_singleton(void)
-{
-    return singleton;
-}
-
-namespace AP
-{
-AP_Filesystem_FlashMemory_LittleFS &littlefs()
-{
-    return *AP_Filesystem_FlashMemory_LittleFS::get_singleton();
-}
 }
 
 #endif  // AP_FILESYSTEM_LITTLEFS_ENABLED

--- a/libraries/AP_Filesystem/AP_Filesystem_FlashMemory_LittleFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_FlashMemory_LittleFS.cpp
@@ -412,6 +412,28 @@ int AP_Filesystem_FlashMemory_LittleFS::closedir(void *ptr)
     return 0;
 }
 
+// return number of bytes that should be written before fsync for optimal
+// streaming performance/robustness. if zero, any number can be written.
+// LittleFS needs to copy the block contents to a new one if fsync is called
+// in the middle of a block. LittleFS also is guaranteed to not remember any
+// file contents until fsync is called!
+uint32_t AP_Filesystem_FlashMemory_LittleFS::bytes_until_fsync(int fd)
+{
+    FS_CHECK_ALLOWED(0);
+    WITH_SEMAPHORE(fs_sem);
+
+    FileDescriptor* fp = lfs_file_from_fd(fd);
+    if (!mounted || fp == nullptr) {
+        return 0;
+    }
+
+    uint32_t write_amt = fs_cfg.block_size;
+    // calculate how much allowed if a full block would be written
+    sync_block(fd, fp->file.pos, write_amt);
+    return write_amt; // return that amount
+}
+
+
 int64_t AP_Filesystem_FlashMemory_LittleFS::disk_free(const char *path)
 {
     FS_CHECK_ALLOWED(-1);

--- a/libraries/AP_Filesystem/AP_Filesystem_FlashMemory_LittleFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_FlashMemory_LittleFS.cpp
@@ -201,6 +201,10 @@ int AP_Filesystem_FlashMemory_LittleFS::fsync(int fd)
         return -1;
     }
 
+    if (fp->file.off != fs_cfg.block_size) {
+        debug("misaligned fsync: %lu\n", fp->file.off);
+    }
+
     LFS_CHECK(lfs_file_sync(&fs, &(fp->file)));
     return 0;
 }

--- a/libraries/AP_Filesystem/AP_Filesystem_FlashMemory_LittleFS.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_FlashMemory_LittleFS.h
@@ -42,6 +42,8 @@ public:
     struct dirent *readdir(void *dirp) override;
     int closedir(void *dirp) override;
 
+    uint32_t bytes_until_fsync(int fd) override;
+
     int64_t disk_free(const char *path) override;
     int64_t disk_space(const char *path) override;
 

--- a/libraries/AP_Filesystem/AP_Filesystem_FlashMemory_LittleFS.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_FlashMemory_LittleFS.h
@@ -25,7 +25,6 @@
 class AP_Filesystem_FlashMemory_LittleFS : public AP_Filesystem_Backend
 {
 public:
-    AP_Filesystem_FlashMemory_LittleFS();
     // functions that closely match the equivalent posix calls
     int open(const char *fname, int flags, bool allow_absolute_paths = false) override;
     int close(int fd) override;
@@ -62,9 +61,6 @@ public:
     int _flashmem_prog(lfs_block_t block, lfs_off_t off, const void* buffer, lfs_size_t size);
     int _flashmem_erase(lfs_block_t block);
     int _flashmem_sync();
-
-    // get_singleton for scripting
-    static AP_Filesystem_FlashMemory_LittleFS *get_singleton(void);
 
 private:
     // Semaphore to protect against concurrent accesses to fs
@@ -108,8 +104,6 @@ private:
     bool use_32bit_address;
     FormatStatus format_status;
 
-    static AP_Filesystem_FlashMemory_LittleFS* singleton;
-
     int allocate_fd();
     int free_fd(int fd);
     void free_all_fds();
@@ -128,10 +122,6 @@ private:
     void write_status_register(uint8_t reg, uint8_t bits);
     void format_handler(void);
     void mark_dead();
-};
-
-namespace AP {
-    AP_Filesystem_FlashMemory_LittleFS &littlefs();
 };
 
 #endif  // #if AP_FILESYSTEM_LITTLEFS_ENABLED

--- a/libraries/AP_Filesystem/AP_Filesystem_backend.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_backend.h
@@ -59,6 +59,10 @@ public:
     virtual int closedir(void *dirp) { return -1; }
     virtual int rename(const char *oldpath, const char *newpath) { return -1; }
 
+    // return number of bytes that should be written before fsync for optimal
+    // streaming performance/robustness. if zero, any number can be written.
+    virtual uint32_t bytes_until_fsync(int fd) { return 0; }
+
     // return free disk space in bytes, -1 on error
     virtual int64_t disk_free(const char *path) { return 0; }
 


### PR DESCRIPTION
See commits for details.

Costs <200 bytes on ChibiOS in general but simplifies the code and allows for further cleanup. I intend to come back and do this as well, I think some of these assumptions are outdated.

Tested on Cube Orange and KakuteH7Mini-Nand. Log behavior and performance is identical before and after.