### PR TITLE
AP_Mount: CADDX RC rate control fix

### DIFF
--- a/libraries/AP_Mount/AP_Mount_CADDX.cpp
+++ b/libraries/AP_Mount/AP_Mount_CADDX.cpp
@@ -47,9 +47,6 @@ void AP_Mount_CADDX::update()
         // point to the angles given by a mavlink message
         case MAV_MOUNT_MODE_MAVLINK_TARGETING:
             // mnt_target should have already been filled in by set_angle_target() or set_rate_target()
-            if (mnt_target.target_type == MountTargetType::RATE) {
-                update_angle_target_from_rate(mnt_target.rate_rads, mnt_target.angle_rad);
-            }
             resend_now = true;
             break;
 
@@ -88,6 +85,11 @@ void AP_Mount_CADDX::update()
         default:
             // we do not know this mode so do nothing
             break;
+    }
+
+    // update angle targets from angle rates
+    if (mnt_target.target_type == MountTargetType::RATE) {
+        update_angle_target_from_rate(mnt_target.rate_rads, mnt_target.angle_rad);
     }
 
     // resend target angles at least once per second


### PR DESCRIPTION
The CADDX mount driver is fairly new (see https://github.com/ArduPilot/ardupilot/pull/28942) and while it did go through alpha testing we apparently never tested RC rate control.  I think what must have happened is I must have tested rate control using QGC which means rate control was only done using the MAVLINK_TARGETING submode.

This change means that rate targets will always update the angle targets before being passed to the physical gimbal.

I've tested this lightly on real hardware and it works

This bug was found during testing of @peterbarker's backport PR https://github.com/ArduPilot/ardupilot/pull/29296,. thanks!