### PR TITLE
AP_Compass: throw away all samples which aren't acceptable in thinning

### DIFF
--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -513,13 +513,22 @@ void CompassCalibrator::thin_samples()
         _sample_buffer[j] = temp;
     }
 
-    // remove any samples that are close together
-    for (uint16_t i=0; i < _samples_collected; i++) {
+    // remove any samples that are close together.  There are two
+    // cases here - where we throw a sample away and when we keep the
+    // sample.  In the former case we MUST move the end-offset
+    // (_samples_collected) towards the loop iterator (i).  In the
+    // lattter case we MUST move the loop iterator forward (towards
+    // _samples_collected).
+    uint16_t i = 0;
+    while (i != _samples_collected) {
         if (!accept_sample(_sample_buffer[i], i)) {
+            // throw sample away
             _sample_buffer[i] = _sample_buffer[_samples_collected-1];
             _samples_collected--;
             _samples_thinned++;
+            continue;
         }
+        i++;
     }
 
     update_completion_mask();


### PR DESCRIPTION
From my 5-year-old notes:
```
+Getting a good list of samples for the fits to run across is probably a good thing to get working well.
+
+I don't think we're doing that at the moment.
+
+At the moment: we test a sample, and if it is no good then we copy a random one in from the end of the list.  We do not test the sample we just copied in, rather move on through the list.
+
+This PR changes things such that we test every sample in the buffer as part of the thinning step.
+
+```
+2019-12-06 10:07:40.92: STATUSTEXT {severity : 6, text : Threw away 247/300 samples}
+2019-12-06 10:07:41.54: STATUSTEXT {severity : 6, text : Threw away 232/300 samples}
+```
+
+There are 576 faces on the default polyhedron.   This test shows that we're only hitting 50-70 of them in the initial collect-samples pass.

+After the initial collect samples pass we fill the buffer up with completely untested samples - I can't imagine we'd do better than the same again.  So overall we'll be hitting 20% of the faces with no guarantee on face distribution, except inasmuch
```

I have no idea how I was going to finish that sentence.

The "threw away line was extra debug in the thinning_samples method recording before/after sample counts.

I've tested this on a Durandal quadcopter here and the calibration result is similar to what was on there.
