### PR TITLE
GCS_Mavlink: Set a minimum delay for FTP burst read

### DIFF
--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -493,7 +493,7 @@ void GCS_MAVLINK::ftp_worker(void) {
                           lost packets a lot, which results in overall
                           faster transfers
                          */
-                        uint32_t burst_delay_ms = 0;
+                        uint32_t burst_delay_ms = 5;
                         if (valid_channel(request.chan)) {
                             auto *port = mavlink_comm_port[request.chan];
                             if (port != nullptr && port->get_flow_control() != AP_HAL::UARTDriver::FLOW_CONTROL_ENABLE) {


### PR DESCRIPTION
burst_delay_ms is initialized to 0.

In case of using SITL with UDP direct connexion, it will stay to 0, pushing Mavlink packets at full speed. This drive to lost packets.

I made some tests with different receive buffer size (best for me is 512 Bytes) and it works with a minimum  value of 4ms, then I putted 5 to get some security.

This introduce a latency arround 350ms for a Copter full parameter ( SITL = 1454 parameters) FTP burst read (70 Mavlink messages) .