### PR TITLE
AP_Filesystem: FATFS: clean up allocations and error handling

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
@@ -50,7 +50,7 @@ static FAT_FILE *file_table[MAX_FILES];
 /*
   allocate a file descriptor
 */
-static int new_file_descriptor(const char *pathname)
+static int new_file_descriptor(const char *pathname, FIL * &fh)
 {
     int i;
     FAT_FILE *stream;
@@ -70,6 +70,7 @@ static int new_file_descriptor(const char *pathname)
             }
 
             file_table[i]  = stream;
+            fh = &stream->fobj;
             return i;
         }
     }
@@ -93,30 +94,23 @@ static FAT_FILE *fileno_to_stream(int fileno)
     return stream;
 }
 
-static int free_file_descriptor(int fileno)
+static void free_file_descriptor(int fileno)
 {
-    FAT_FILE *stream;
-
-    // checks if fileno out of bounds
-    stream = fileno_to_stream(fileno);
-    if (stream == nullptr) {
-        return -1;
+    FAT_FILE *stream = fileno_to_stream(fileno);
+    if (stream != nullptr) {
+        file_table[fileno] = NULL;
+        free(stream->name);
+        free(stream);
     }
-
-    file_table[fileno]  = NULL;
-    free(stream->name);
-    free(stream);
-    return fileno;
 }
 
 static FIL *fileno_to_fatfs(int fileno)
 {
     FAT_FILE *stream;
 
-    // checks if fileno out of bounds
     stream = fileno_to_stream(fileno);
-    if (stream == nullptr) {
-        return nullptr;
+    if (stream == nullptr) { // unknown fileno?
+        return nullptr; // errno already set
     }
 
     return &stream->fobj;
@@ -237,7 +231,6 @@ int AP_Filesystem_FATFS::open(const char *pathname, int flags, bool allow_absolu
 {
     int fileno;
     int fatfs_modes;
-    FAT_FILE *stream;
     FIL *fh;
     int res;
 
@@ -265,22 +258,11 @@ int AP_Filesystem_FATFS::open(const char *pathname, int flags, bool allow_absolu
         }
     }
 
-    fileno = new_file_descriptor(pathname);
-
-    // checks if fileno out of bounds
-    stream = fileno_to_stream(fileno);
-    if (stream == nullptr) {
-        free_file_descriptor(fileno);
-        return -1;
+    fileno = new_file_descriptor(pathname, fh);
+    if (fileno < 0) { // creation failed?
+        return -1; // errno already set
     }
 
-    // fileno_to_fatfs checks for fileno out of bounds
-    fh = fileno_to_fatfs(fileno);
-    if (fh == nullptr) {
-        free_file_descriptor(fileno);
-        errno = EBADF;
-        return -1;
-    }
     res = f_open(fh, pathname, (BYTE) (fatfs_modes & 0xff));
     if (res == FR_DISK_ERR && RETRY_ALLOWED()) {
         // one retry on disk error
@@ -312,7 +294,6 @@ int AP_Filesystem_FATFS::open(const char *pathname, int flags, bool allow_absolu
 
 int AP_Filesystem_FATFS::close(int fileno)
 {
-    FAT_FILE *stream;
     FIL *fh;
     int res;
 
@@ -321,16 +302,9 @@ int AP_Filesystem_FATFS::close(int fileno)
 
     errno = 0;
 
-    // checks if fileno out of bounds
-    stream = fileno_to_stream(fileno);
-    if (stream == nullptr) {
-        return -1;
-    }
-
-    // fileno_to_fatfs checks for fileno out of bounds
     fh = fileno_to_fatfs(fileno);
-    if (fh == nullptr) {
-        return -1;
+    if (fh == nullptr) { // unknown fileno?
+        return -1; // errno already set
     }
     res = f_close(fh);
     free_file_descriptor(fileno);
@@ -358,11 +332,9 @@ int32_t AP_Filesystem_FATFS::read(int fd, void *buf, uint32_t count)
 
     errno = 0;
 
-    // fileno_to_fatfs checks for fd out of bounds
     fh = fileno_to_fatfs(fd);
-    if (fh == nullptr) {
-        errno = EBADF;
-        return -1;
+    if (fh == nullptr) { // unknown fd?
+        return -1; // errno already set
     }
 
     UINT total = 0;
@@ -406,11 +378,9 @@ int32_t AP_Filesystem_FATFS::write(int fd, const void *buf, uint32_t count)
 
     CHECK_REMOUNT();
 
-    // fileno_to_fatfs checks for fd out of bounds
     fh = fileno_to_fatfs(fd);
-    if (fh == nullptr) {
-        errno = EBADF;
-        return -1;
+    if (fh == nullptr) { // unknown fd?
+        return -1; // errno already set
     }
 
     UINT total = 0;
@@ -448,7 +418,6 @@ int32_t AP_Filesystem_FATFS::write(int fd, const void *buf, uint32_t count)
 
 int AP_Filesystem_FATFS::fsync(int fileno)
 {
-    FAT_FILE *stream;
     FIL *fh;
     int res;
 
@@ -457,16 +426,9 @@ int AP_Filesystem_FATFS::fsync(int fileno)
 
     errno = 0;
 
-    // checks if fileno out of bounds
-    stream = fileno_to_stream(fileno);
-    if (stream == nullptr) {
-        return -1;
-    }
-
-    // fileno_to_fatfs checks for fileno out of bounds
     fh = fileno_to_fatfs(fileno);
-    if (fh == nullptr) {
-        return -1;
+    if (fh == nullptr) { // unknown fileno?
+        return -1; // errno already set
     }
     res = f_sync(fh);
     if (res != FR_OK) {
@@ -485,11 +447,9 @@ off_t AP_Filesystem_FATFS::lseek(int fileno, off_t position, int whence)
     FS_CHECK_ALLOWED(-1);
     WITH_SEMAPHORE(sem);
 
-    // fileno_to_fatfs checks for fd out of bounds
     fh = fileno_to_fatfs(fileno);
-    if (fh == nullptr) {
-        errno = EMFILE;
-        return -1;
+    if (fh == nullptr) { // unknown fileno?
+        return -1; // errno already set
     }
 
     if (whence == SEEK_END) {
@@ -735,10 +695,9 @@ uint32_t AP_Filesystem_FATFS::bytes_until_fsync(int fd)
     FS_CHECK_ALLOWED(0);
     WITH_SEMAPHORE(sem);
 
-    // fileno_to_fatfs checks for fd out of bounds
     FIL *fh = fileno_to_fatfs(fd);
-    if (fh == nullptr) {
-        return 0;
+    if (fh == nullptr) { // unknown fd?
+        return 0; // return "any number", the write/fsync will fail anyway
     }
 
     const uint32_t block_size = MAX_IO_SIZE;


### PR DESCRIPTION
Saves 100-200 bytes and makes the code a bit more straightforward.

Tested on CubeOrange that scripting and logging still work, that I can remove the SD card and get reasonable errors, and that I can put it back in and the use it without rebooting.