### PR TITLE
[README] Clarify DShot support on MAIN outputs for OrangeCubePlus

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrangePlus/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrangePlus/README.md
@@ -537,9 +537,7 @@ Spektrum satellite receivers.
 
 ## PWM Output
 
-The CubeOrangePlus supports up to 14 PWM outputs. First first 8 outputs (labelled
-"MAIN") are controlled by a dedicated STM32F100 IO controller. These 8
-outputs support all PWM output formats, but not DShot.
+The CubeOrangePlus supports up to 14 PWM outputs, with the first 8 ("MAIN") managed by an STM32F100 IO controller. These support all PWM formats, and DShot can be enabled by setting BRD_IO_DSHOT to 1, which loads the DShot firmware on the IO co-processor.
 
 The remaining 6 outputs (labelled AUX1 to AUX6) are the "auxiliary"
 outputs. These are directly attached to the STM32H743 and support all


### PR DESCRIPTION
Tested on Orange Cube Plus today, confirming that DShot works as expected when BRD_IO_DSHOT is set to 1 which is DShot fw