### PR TITLE
AP_Scripting: reset aux auths on start

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1464,6 +1464,27 @@ void AP_Arming::set_aux_auth_failed(uint8_t auth_id, const char* fail_msg)
     }
 }
 
+void AP_Arming::reset_all_aux_auths()
+{
+    WITH_SEMAPHORE(aux_auth_sem);
+
+    // clear all auxiliary authorisation ids
+    aux_auth_count = 0;
+    // clear any previous allocation errors
+    aux_auth_error = false;
+
+    // reset states for all auxiliary authorisation ids
+    for (uint8_t i = 0; i < aux_auth_count_max; i++) {
+        aux_auth_state[i] = AuxAuthStates::NO_RESPONSE;
+    }
+
+    // free up the failure message buffer
+    if (aux_auth_fail_msg != nullptr) {
+        free(aux_auth_fail_msg);
+        aux_auth_fail_msg = nullptr;
+    }
+}
+
 bool AP_Arming::aux_auth_checks(bool display_failure)
 {
     // handle error cases

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -129,6 +129,7 @@ public:
     bool get_aux_auth_id(uint8_t& auth_id);
     void set_aux_auth_passed(uint8_t auth_id);
     void set_aux_auth_failed(uint8_t auth_id, const char* fail_msg);
+    void reset_all_aux_auths();
 #endif
 
     static const struct AP_Param::GroupInfo        var_info[];

--- a/libraries/AP_Scripting/AP_Scripting.cpp
+++ b/libraries/AP_Scripting/AP_Scripting.cpp
@@ -20,6 +20,7 @@
 #include <AP_Scripting/AP_Scripting.h>
 #include <AP_HAL/AP_HAL.h>
 #include <GCS_MAVLink/GCS.h>
+#include <AP_Arming/AP_Arming.h>
 
 #include "lua_scripts.h"
 
@@ -316,6 +317,10 @@ void AP_Scripting::thread(void) {
             // clear data in serial buffers that the script wasn't ready to
             // receive
             _serialdevice.clear();
+#endif
+#if AP_ARMING_ENABLED && AP_ARMING_AUX_AUTH_ENABLED
+            // Clear any dangling pre-arms from previous script loads
+            AP_Arming::get_singleton()->reset_all_aux_auths();
 #endif
             // run won't return while scripting is still active
             lua->run();


### PR DESCRIPTION
Allows a scripting restart to reset any auxiliary prearms, and clear out all the old previous aux id allocations.

This is very helpful during development of lua scripts that have prearm checks in them, as without this you can only restart a maximum of three times before you run out of aux auth ids ("PreArm: Too many auxiliary authorisers") and have to reboot. Additionally, if a prearm check was failing before the scripting restart, there was no way to clear it without rebooting.