### PR TITLE
Copter: allow auto trim in position hold modes

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -132,6 +132,7 @@ public:
     virtual bool in_guided_mode() const { return false; }
     virtual bool logs_attitude() const { return false; }
     virtual bool allows_save_trim() const { return false; }
+    virtual bool allows_auto_trim() const { return false; }
     virtual bool allows_autotune() const { return false; }
     virtual bool allows_flip() const { return false; }
     virtual bool crash_check_enabled() const { return true; }
@@ -485,6 +486,8 @@ public:
     }
     bool allows_autotune() const override { return true; }
     bool allows_flip() const override { return true; }
+    bool allows_auto_trim() const override { return true; }
+    bool allows_save_trim() const override { return true; }
 #if FRAME_CONFIG == HELI_FRAME
     bool allows_inverted() const override { return true; };
 #endif
@@ -1313,6 +1316,7 @@ public:
     bool is_autopilot() const override { return false; }
     bool has_user_takeoff(bool must_navigate) const override { return true; }
     bool allows_autotune() const override { return true; }
+    bool allows_auto_trim() const override { return true; }
 
 #if FRAME_CONFIG == HELI_FRAME
     bool allows_inverted() const override { return true; };
@@ -1362,6 +1366,7 @@ public:
     bool is_autopilot() const override { return false; }
     bool has_user_takeoff(bool must_navigate) const override { return true; }
     bool allows_autotune() const override { return true; }
+    bool allows_auto_trim() const override { return true;}
 
 protected:
 
@@ -1651,6 +1656,7 @@ public:
     bool allows_arming(AP_Arming::Method method) const override { return true; };
     bool is_autopilot() const override { return false; }
     bool allows_save_trim() const override { return true; }
+    bool allows_auto_trim() const override { return true; }
     bool allows_autotune() const override { return true; }
     bool allows_flip() const override { return true; }
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -12695,8 +12695,9 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                     trim_x = self.get_parameter('AHRS_TRIM_X', verbose=False)
                     trim_y = self.get_parameter('AHRS_TRIM_Y', verbose=False)
                     self.progress(f"trim_x={trim_x} trim_y={trim_y}")
-                    if abs(trim_x) < 0.02 and abs(trim_y) < 0.02:
+                    if abs(trim_x) < 0.01 and abs(trim_y) < 0.01:
                         self.progress("Good AHRS trims")
+                        self.progress(f"vx={lpn.vx} vy={lpn.vy}")
                         if abs(lpn.vx) > 1 or abs(lpn.vy) > 1:
                             raise NotAchievedException("Velocity after trimming?!")
                         break

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -261,7 +261,7 @@ public:
         ICE_START_STOP =     179, // AP_ICEngine start stop
         AUTOTUNE_TEST_GAINS = 180, // auto tune tuning switch to test or revert gains
         QUICKTUNE =          181,  //quicktune 3 position switch
-        AHRS_AUTO_TRIM =     182,  // in-flight trim Copter AHRS using manual levelling
+        AHRS_AUTO_TRIM =     182,  // in-flight AHRS autotrim
         AUTOLAND =           183,  //Fixed Wing AUTOLAND Mode
 
         // inputs from 200 will eventually used to replace RCMAP


### PR DESCRIPTION
This:
1. Fixes  bugs in #28881 (aux func was not init'd and auto trim not saved properly)
2. refactors to use an "allows_auto_trim" bool to avoid entering autotrim and then immediately cancelling; and neaten the code a bit
3. Adds Loiter/PosHold to autotrim for hands off trimming
4. Add a warning on attempting to enable autotrim when allowed, but not flying, rather than just entering and exiting immediately leaving a user to wonder why.
5. adjust marginally failing autotest
6. driveby that PeterB requested to fix comment on aux function for autotrim

Flight tested by myself and Peter Barker