### PR TITLE
AP_Filesystem: LittleFS: clarify fsync bytes logic

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_FlashMemory_LittleFS.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_FlashMemory_LittleFS.h
@@ -49,8 +49,6 @@ public:
     // set modification time on a file
     bool set_mtime(const char *filename, const uint32_t mtime_sec) override;
 
-    bool sync_block(int _write_fd, uint32_t _write_offset, uint32_t& nbytes);
-
     bool retry_mount(void) override;
     void unmount(void) override;
     // format flash.  This is async, monitor get_format_status for progress


### PR DESCRIPTION
Removes some impossible cases and better documents it.

Tested on KakuteH7Mini-Nand that there are no performance regressions or misaligned fsyncs.