### PR TITLE
AP_Airspeed: inline get_pressure

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -493,19 +493,6 @@ void AP_Airspeed::allocate()
     }
 }
 
-// read the airspeed sensor
-float AP_Airspeed::get_pressure(uint8_t i)
-{
-    if (!enabled(i)) {
-        return 0;
-    }
-    float pressure = 0;
-    if (sensor[i]) {
-        state[i].healthy = sensor[i]->get_differential_pressure(pressure);
-    }
-    return pressure;
-}
-
 // get a temperature reading if possible
 bool AP_Airspeed::get_temperature(uint8_t i, float &temperature)
 {
@@ -637,13 +624,14 @@ void AP_Airspeed::read(uint8_t i)
 
 #ifndef HAL_BUILD_AP_PERIPH
     /*
-      get the healthy state before we call get_pressure() as
-      get_pressure() overwrites the healthy state
+      remember the old healthy state
      */
     bool prev_healthy = state[i].healthy;
 #endif
 
-    float raw_pressure = get_pressure(i);
+    float raw_pressure = 0;
+    state[i].healthy = sensor[i]->get_differential_pressure(raw_pressure);
+
     float airspeed_pressure = raw_pressure - get_offset(i);
 
     // remember raw pressure for logging

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -294,9 +294,6 @@ private:
     uint32_t _log_bit = -1;     // stores which bit in LOG_BITMASK is used to indicate we should log airspeed readings
 
     void read(uint8_t i);
-    // return the differential pressure in Pascal for the last airspeed reading for the requested instance
-    // returns 0 if the sensor is not enabled
-    float get_pressure(uint8_t i);
 
     // get the health probability
     float get_health_probability(uint8_t i) const {


### PR DESCRIPTION
this doesn't gain us anything; it's a private function which is only called in one place and replicates checks that the caller already makes (it devolves into a one-liner, essentially!)

This method is also confusing as it sits next to "get_temperature" in the code, which is actually a match for get_differential_pressure, not get_pressure

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                 *                                                   
CubeRedPrimary                      *      *           -40     -40               -40    -40    -40
Durandal                            *      *           -80     -80               -72    -80    -72
Hitec-Airspeed           -32               *                                                   
KakuteH7-bdshot                     *      *           -40     -40               -40    -40    -40
MatekF405                           *      *           *       *                 -40    -40    -40
Pixhawk1-1M-bdshot                  *                  *       *                 -40    -40    -40
f103-QiotekPeriph        -24               *                                                   
f303-Universal           -32               *                                                   
iomcu                                                                *                         
revo-mini                           *      *           *       *                 -40    -40    -40
skyviper-journey                                       *                                       
skyviper-v2450                                         *                                       
```
