### PR TITLE
In RTL, set wp velocity after controller is initialised

### DIFF
--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -17,8 +17,7 @@ bool ModeRTL::init(bool ignore_checks)
             return false;
         }
     }
-    // initialise waypoint and spline controller
-    wp_nav->wp_and_spline_init(g.rtl_speed_cms);
+    // do not initialise waypoint and spline controller yet, controller will initialize itself when the first waypoint is passed
     _state = SubMode::STARTING;
     _state_complete = true; // see run() method below
     terrain_following_allowed = !copter.failsafe.terrain;
@@ -150,6 +149,9 @@ void ModeRTL::return_start()
 {
     _state = SubMode::RETURN_HOME;
     _state_complete = false;
+
+    // set RTL speed for return path
+    wp_nav->set_speed_xy(g.rtl_speed_cms);
 
     if (!wp_nav->set_wp_destination_loc(rtl_path.return_target)) {
         // failure must be caused by missing terrain data, restart RTL

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -12977,7 +12977,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "CompassMot": "Cuases an arithmetic exception in the EKF",
             "SMART_RTL_EnterLeave": "Causes a panic",
             "SMART_RTL_Repeat": "Currently fails due to issue with loop detection",
-            "RTLStoppingDistanceSpeed": "Currently fails due to vehicle going off-course",
         }
 
 


### PR DESCRIPTION
Alternative to https://github.com/ArduPilot/ardupilot/pull/29285/commits/1b29468a89b2a6ebe5cfda9954a0c5f8b05d9489

```
When mode_rtl init() is called, don't explicitly call wp_nav->wp_and_spline_init(g.rtl_speed_cms). I think this is redundant anyway since as soon as we pass the first wapoint to AC_WPNav, it will call wp_and_spline_init on it's own anyway. Critically, we don't send WPNav the RTL speed at this point, because this seems to be crux of the issue. If we pass WPNav a slow speed here then the vehicle always does a harsh stop, regardless of how far away the stopping point actually is.

To actually get the RTL speed to work, we instead set it explicitly ONLY after the vehicle has started the return back home (in return_start()).
```

Not my patch - I need to add the correct author on it yet.
