### PR TITLE
AP_GPS: UBLOX: fix memory leak when "F9" GNSS configuration is used

### DIFF
--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -129,6 +129,8 @@ AP_GPS_UBLOX::~AP_GPS_UBLOX()
 #if GPS_MOVING_BASELINE
     delete rtcm3_parser;
 #endif
+
+    delete config_GNSS;
 }
 
 #if GPS_MOVING_BASELINE


### PR DESCRIPTION
pointer persists in the object and is re-used, but never freed.

Not really a problem if you're only detecting once, could be a problem if you've got intermittent connectivity to your GPS...