### PR TITLE
AP_Proximity: LD19/LD06 data length sanity check fix

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity_LD06.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LD06.cpp
@@ -107,8 +107,8 @@ void AP_Proximity_LD06::get_readings()
             }
 
             // total_packet_length = sizeof(header) + datalength + sizeof(footer):
-            const uint32_t total_packet_length = 6 + 3*_response[START_DATA_LENGTH] + 5;
-            if (_response[START_DATA_LENGTH] != PAYLOAD_COUNT ||
+            const uint32_t total_packet_length = 6 + 3*(_response[START_DATA_LENGTH] & 0x1F) + 5;
+            if ((_response[START_DATA_LENGTH] & 0x1F) != PAYLOAD_COUNT ||
                 total_packet_length > ARRAY_SIZE(_response)) {
                 // invalid packet received; throw away all data and
                 // start again.


### PR DESCRIPTION
AP_Rangefinder: LD19/LD06 data length sanity check fix

root cause: number of data points in frame stored only on 5bits. value been used without proper bitmask
to sanity check number of datapoints in frame
