### PR TITLE
AP_GPS: speed up ublox configuration

### DIFF
--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -653,12 +653,9 @@ AP_GPS_UBLOX::read(void)
     if (millis_now - _last_config_time >= _delay_time) {
         _request_next_config();
         _last_config_time = millis_now;
-        if (_unconfigured_messages) { // send the updates faster until fully configured
-            if (!havePvtMsg && (_unconfigured_messages & CONFIG_REQUIRED_INITIAL)) {
-                _delay_time = 300;
-            } else {
-                _delay_time = 750;
-            }
+        if (_unconfigured_messages) {
+            // send the updates faster until fully configured
+            _delay_time = 200;
         } else {
             _delay_time = 2000;
         }


### PR DESCRIPTION
we have a lot more steps now to configure a ublox, and it is taking an annoyingly long time. There is really not a good reason to do the configuration so slowly

on a F9P this reduces the time for configuration from detection of the ublox to fully configured from 35s to 10s