### PR TITLE
ChibiOS: avoid bdshot fault on null event waiter

### DIFF
--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -1842,10 +1842,11 @@ __RAMFUNC__ void RCOutput::dma_unlock(virtual_timer_t* vt, void *p)
     pwm_group *group = (pwm_group *)p;
 
     group->dshot_state = DshotState::IDLE;
-    if (group->dshot_waiter != nullptr) {
+    auto *waiter = group->dshot_waiter;
+    if (waiter != nullptr) {
         // tell the waiting process we've done the DMA. Note that
         // dshot_waiter can be null if we have cancelled the send
-        chEvtSignalI(group->dshot_waiter, group->dshot_event_mask);
+        chEvtSignalI(waiter, group->dshot_event_mask);
     }
     chSysUnlockFromISR();
 }

--- a/libraries/AP_HAL_ChibiOS/RCOutput_bdshot.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput_bdshot.cpp
@@ -515,8 +515,11 @@ __RAMFUNC__ void RCOutput::bdshot_finish_dshot_gcr_transaction(virtual_timer_t* 
     // although it should be possible to start the next DMAR transaction concurrently with receiving 
     // telemetry, in practice it seems to interfere with the DMA engine
     if (group->shared_up_dma && group->bdshot.enabled) {
-        // next dshot pulse can go out now
-        chEvtSignalI(group->dshot_waiter, DSHOT_CASCADE);
+        auto *waiter = group->dshot_waiter;
+        if (waiter != nullptr) {
+            // next dshot pulse can go out now
+            chEvtSignalI(waiter, DSHOT_CASCADE);
+        }
     }
 #endif
     // if using input capture DMA and sharing the UP and CH channels then clean up
@@ -541,7 +544,10 @@ __RAMFUNC__ void RCOutput::bdshot_finish_dshot_gcr_transaction(virtual_timer_t* 
     }
 
     // tell the waiting process we've done the DMA
-    chEvtSignalI(group->dshot_waiter, group->dshot_event_mask);
+    auto *waiter = group->dshot_waiter;
+    if (waiter != nullptr) {
+        chEvtSignalI(waiter, group->dshot_event_mask);
+    }
 #ifdef HAL_GPIO_LINE_GPIO56
     TOGGLE_PIN_DEBUG(56);
 #endif

--- a/libraries/AP_HAL_ChibiOS/Scheduler.cpp
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.cpp
@@ -623,6 +623,19 @@ void Scheduler::check_low_memory_is_zero()
         }
 #pragma GCC diagnostic pop
     }
+
+#if 0
+    /*
+      enable this on H7 to make writes to the first 1k of RAM on H7
+      produce a hard fault and crash dump
+     */
+    mpuConfigureRegion(MPU_REGION_7,
+                       0x0,
+                       MPU_RASR_ATTR_AP_RO_RO |
+                       MPU_RASR_SIZE_1K |
+                       MPU_RASR_ENABLE);
+    mpuEnable(MPU_CTRL_PRIVDEFENA | MPU_CTRL_ENABLE);
+#endif
 }
 #endif // STM32H7
 


### PR DESCRIPTION
This avoids a write to a null pointer in bdshot if the waiter is set to null while a timer is still pending

@andyp1per it would be good to get your input. This fix is more of a bandaid than a real fix

This fixes #29370 
