### PR TITLE
Plane: Fix crash detection false positive on "shake to launch"

### DIFF
--- a/ArduPlane/is_flying.cpp
+++ b/ArduPlane/is_flying.cpp
@@ -261,11 +261,12 @@ void Plane::crash_detection_update(void)
             switch (flight_stage)
             {
             case AP_FixedWing::FlightStage::TAKEOFF:
-                if (g.takeoff_throttle_min_accel > 0 &&
-                        !throttle_suppressed) {
-                    // if you have an acceleration holding back throttle, but you met the
-                    // accel threshold but still not flying, then you either shook/hit the
-                    // plane or it was a failed launch.
+                if (g2.takeoff_throttle_accel_count == 1 && g.takeoff_throttle_min_accel > 0 &&
+                    !throttle_suppressed) {
+                    // if launching requires a single acceleration event and it
+                    // has already happened but the aircraft is still not
+                    // flying, then you either shook/hit the plane or it was a
+                    // failed launch.
                     crashed = true;
                     crash_state.debounce_time_total_ms = CRASH_DETECTION_DELAY_MS;
                 }


### PR DESCRIPTION
# Plane: Fix crash detection false positive on "shake to launch"

Fixed a bug where, if the "shake to launch" functionality is configured, a crash would instantly be detected after the final acceleration event. The issue occurred because if a minimum acceleration threshold was set, a crash was detected if the aircraft wasn't flying immediately after reaching that threshold. This holds for single event acceleration launches but usually not when "shaking to launch".

In addition to this, the CRASH_ACC_THRESH parameter description has been adjusted to fix a small typo, and to clarify that setting it to 0 does not fully disable crash detection, but instead only the impact detection.