### PR TITLE
AP_Scripting: Generalize BattEstimate SoC model for more battery chemistries

### DIFF
--- a/Tools/scripts/battery_fit.py
+++ b/Tools/scripts/battery_fit.py
@@ -31,10 +31,13 @@ def SOC_model(cell_volt, c):
     '''simple model of state of charge versus resting voltage.
     With thanks to Roho for the form of the equation
     https://electronics.stackexchange.com/questions/435837/calculate-battery-percentage-on-lipo-battery
+
+    Adjusted to also fit other battery chemistries such as Li-ion.
     '''
-    p0 = 80.0
+    p0 = c[3]
     p1 = c[2]
-    return constrain(c[0]*(1.0-1.0/math.pow(1+math.pow(cell_volt/c[1],p0),p1)),0,100)
+
+    return constrain(c[0] * (1.0 - 1.0 / math.pow(1 + math.pow(cell_volt / c[1], p0), p1)), 0, 100)
 
 def fit_batt(data):
     '''fit a set of battery data to the SOC model'''
@@ -50,8 +53,8 @@ def fit_batt(data):
         ret /= len(data)
         return ret
 
-    p = [123.0, 3.7, 0.165]
-    bounds = [(100.0, 10000.0), (3.0,3.9), (0.001, 0.4)]
+    p = [123.0, 3.7, 0.165, 80.0]
+    bounds = [(100.0, 10000.0), (3.0, 3.9), (0.001, 0.4), (5.0, 100.0)]
 
     (p,err,iterations,imode,smode) = optimize.fmin_slsqp(fit_error, p, bounds=bounds, iter=10000, full_output=True)
     if imode != 0:
@@ -140,7 +143,7 @@ def BattFit(fit_data, num_cells):
     fit_data = [ (v/num_cells,p) for (v,p) in fit_data ]
 
     c = fit_batt(fit_data)
-    print("Coefficients C1=%.4f C2=%.4f C3=%.4f" % (c[0], c[1], c[2]))
+    print("Coefficients C1=%.4f C2=%.4f C3=%.4f C4=%.4f" % (c[0], c[1], c[2], c[3]))
 
     if args.no_graph:
         return

--- a/Tools/scripts/battery_fit.py
+++ b/Tools/scripts/battery_fit.py
@@ -74,7 +74,12 @@ def ExtractDataLog(logfile):
         if msg is None:
             break
 
-        if msg.get_type() == 'BAT' and msg.Instance == args.batidx-1 and msg.VoltR > 1:
+        if (
+            msg.get_type() == 'BAT'
+            and (getattr(msg, 'Inst', None) == args.batidx - 1
+                 or getattr(msg, 'Instance', None) == args.batidx - 1)
+            and msg.VoltR > 1
+        ):
             current = msg.Curr
             voltR = msg.VoltR
             if last_voltR is not None and voltR > last_voltR:

--- a/libraries/AP_Scripting/applets/BattEstimate.lua
+++ b/libraries/AP_Scripting/applets/BattEstimate.lua
@@ -4,9 +4,6 @@
    See Tools/scripts/battery_fit.py for a tool to calculate the coefficients from a log
 --]]
 
----@diagnostic disable: param-type-mismatch
----@diagnostic disable: cast-local-type
-
 local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
 
 local PARAM_TABLE_KEY = 14
@@ -82,6 +79,14 @@ end
 --]]
 
 --[[
+  // @Param: BATT_SOC1_C4
+  // @DisplayName: Battery estimator coefficient4
+  // @Description: Battery estimator coefficient4
+  // @Range: 5 100
+  // @User: Standard
+--]]
+
+--[[
   // @Param: BATT_SOC2_IDX
   // @DisplayName: Battery estimator index
   // @Description: Battery estimator index
@@ -118,6 +123,14 @@ end
   // @DisplayName: Battery estimator coefficient3
   // @Description: Battery estimator coefficient3
   // @Range: 0.01 0.5
+  // @User: Standard
+--]]
+
+--[[
+  // @Param: BATT_SOC2_C4
+  // @DisplayName: Battery estimator coefficient4
+  // @Description: Battery estimator coefficient4
+  // @Range: 5 100
   // @User: Standard
 --]]
 
@@ -162,6 +175,14 @@ end
 --]]
 
 --[[
+  // @Param: BATT_SOC3_C4
+  // @DisplayName: Battery estimator coefficient4
+  // @Description: Battery estimator coefficient4
+  // @Range: 5 100
+  // @User: Standard
+--]]
+
+--[[
   // @Param: BATT_SOC4_IDX
   // @DisplayName: Battery estimator index
   // @Description: Battery estimator index
@@ -201,8 +222,16 @@ end
   // @User: Standard
 --]]
 
+--[[
+  // @Param: BATT_SOC4_C4
+  // @DisplayName: Battery estimator coefficient4
+  // @Description: Battery estimator coefficient4
+  // @Range: 5 100
+  // @User: Standard
+--]]
+
 local params = {}
-local last_armed_ms = 0
+local last_armed_ms = uint32_t(0)
 
 --[[
    add parameters for an estimator
@@ -216,9 +245,14 @@ function add_estimator(i)
    params[i]['C1']    = bind_add_param(id .. "C1", pidx+2, 111.56)
    params[i]['C2']    = bind_add_param(id .. "C2", pidx+3, 3.65)
    params[i]['C3']    = bind_add_param(id .. "C3", pidx+4, 0.205)
+
+   -- place the 4th coefficients at the end for backwards compatibility
+   c4_pidx = 2+4*5+(i-1)
+   params[i]['C4']    = bind_add_param(id .. "C4", c4_pidx, 80.0)
 end
 
-local count = math.floor(BATT_SOC_COUNT:get())
+-- limit to 4 estimators even if the parameter specifies more
+local count = math.min(math.floor(BATT_SOC_COUNT:get() or 0), 4)
 for i = 1, count do
    add_estimator(i)
 end
@@ -231,10 +265,11 @@ end
    simple model of state of charge versus resting voltage.
    With thanks to Roho for the form of the equation
    https://electronics.stackexchange.com/questions/435837/calculate-battery-percentage-on-lipo-battery
+
+   Adjusted to also fit other battery chemistries such as Li-ion.
 --]]
-local function SOC_model(cell_volt, c1, c2, c3)
-    local p0 = 80.0
-    local soc = c1*(1.0-1.0/(1+(cell_volt/c2)^p0)^c3)
+local function SOC_model(cell_volt, c1, c2, c3, c4)
+    local soc = c1*(1.0-1.0/(1+(cell_volt/c2)^c4)^c3)
     return constrain(soc, 0, 100)
 end
 
@@ -250,12 +285,13 @@ local function update_estimator(i)
    local C1 = params[i]['C1']:get()
    local C2 = params[i]['C2']:get()
    local C3 = params[i]['C3']:get()
+   local C4 = params[i]['C4']:get()
    local num_batts = battery:num_instances()
    if idx > num_batts then
       return
    end
    local voltR = battery:voltage_resting_estimate(idx-1)
-   local soc = SOC_model(voltR/ncell, C1, C2, C3)
+   local soc = SOC_model(voltR/ncell, C1, C2, C3, C4)
    battery:reset_remaining(idx-1, soc)
 end
 

--- a/libraries/AP_Scripting/applets/BattEstimate.md
+++ b/libraries/AP_Scripting/applets/BattEstimate.md
@@ -1,7 +1,7 @@
 # Battery State of Charge Estimator
 
 This script implements a battery state of charge estimator based on
-resting voltage and a simple LiPo cell model.
+resting voltage and a simple cell model.
 
 This allows the remaining battery percentage to be automatically set
 based on the resting voltage when disarmed.
@@ -33,28 +33,36 @@ C2 is the second coefficient from your fit of your battery
 
 ## BATT_SOCn_C3
 
-C3 is the second coefficient from your fit of your battery
+C3 is the third coefficient from your fit of your battery
+
+## BATT_SOCn_C4
+
+C4 is the fourth coefficient from your fit of your battery
 
 # Usage
 
-You need to start by working out the coefficients C1, C2 and C3 for your
-battery. You can do this by starting with a fully charged battery and
-slowly discharging it with LOG_DISARMED set to 1. Alternatively you
+You need to start by working out the coefficients C1, C2, C3 and C4 for
+your battery. You can do this by starting with a fully charged battery
+and slowly discharging it with LOG_DISARMED set to 1. Alternatively you
 can provide a CSV file with battery percentage in the first column and
 voltage in the 2nd column.
 
 Then run the resulting log or csv file through the script at
-Tools/scripts/battery_fit.py. You will need to tell the script the
-following:
+Tools/scripts/battery_fit.py. The fitting process is designed to work
+reliably with LiPo and Li-ion batteries and is generally effective for
+other battery chemistries as well, but users should verify that the fit
+is accurate for their specific case.
+
+You will need to tell the script the following:
 
  - the number of cells
  - the final percentage charge your log stops at
  - the battery index you want to fit to (1 is the first battery)
 
 That will produce a graph and a set of coefficients like this:
- - Coefficients C1=111.5629 C2=3.6577 C3=0.2048
+ - Coefficients C1=111.5629 C2=3.6577 C3=0.2048 C4=80.0000
 
-Use the C1, C2 and C3 parameters in the parameters for this script.
+Use the C1, C2, C3 and C4 parameters in the parameters for this script.
 
 The remaining battery percentage is only set when disarmed, and won't
 be set till 10 seconds after you disarm from a flight.


### PR DESCRIPTION
# AP_Scripting: Generalize BattEstimate SoC model for more battery chemistries

Made the SoC model used by the BattEstimate script more flexible by turning the previously fixed parameter p0 into a free coefficient C4. This parameter controls the steepness of the SoC curve transition, so this change allows the model to also fit other battery technologies such as Li-ion.

The battery_fit.py script has also been fixed to support logs that use 'Inst' instead of 'Instance' for battery messages.