### PR TITLE
AP_AccelCal:Remove an unusable return

### DIFF
--- a/libraries/AP_AccelCal/AP_AccelCal.cpp
+++ b/libraries/AP_AccelCal/AP_AccelCal.cpp
@@ -354,7 +354,6 @@ void AP_AccelCal::update_status() {
     }
 
     _status = ACCEL_CAL_SUCCESS;    // we have succeeded calibration if all the calibrators have
-    return;
 }
 
 bool AP_AccelCal::client_active(uint8_t client_num)


### PR DESCRIPTION
At the end of void `AP_AccelCal::update_status()` there is a `return;` that shouldn't be there.