### PR TITLE
AP_GPS: discard SBF packets with claimed length > 256 bytes

### DIFF
--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -321,6 +321,14 @@ AP_GPS_SBF::parse(uint8_t temp)
                                      // indicates not enough bytes to do a crc
                 break;
             }
+            if (sbf_msg.length > 256) {
+                // no SBF packet is this big!  serial corruption may
+                // cause the length to get very large; 24320 has been
+                // seen (0x5F00).  Discard and go back to looking for
+                // preamble.
+                sbf_msg.sbf_state = sbf_msg_parser_t::PREAMBLE1;
+                crc_error_counter++; // this is a probable serial corruption
+            }
             break;
         case sbf_msg_parser_t::DATA:
             if (sbf_msg.read < sizeof(sbf_msg.data)) {

--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -31,12 +31,12 @@ extern const AP_HAL::HAL& hal;
 #define SBF_DEBUGGING 0
 
 #if SBF_DEBUGGING
+// INFO rather than debug because MP filters DEBUG
  # define Debug(fmt, args ...)                  \
 do {                                            \
-    hal.console->printf("%s:%d: " fmt "\n",     \
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s:%d: " fmt, \
                         __FUNCTION__, __LINE__, \
                         ## args);               \
-    hal.scheduler->delay(1);                    \
 } while(0)
 #else
  # define Debug(fmt, args ...)


### PR DESCRIPTION
Many thanks to 3DR for supplying the hardware used to debug this!


    messages coming in with a size of 24320 bytes.  It takes so long to try to read those bytes in (at the device's message rate) that we time out the GCS and try detecting again

    messages coming in with a size of 24320 bytes.  It takes so long to try to read those bytes in (at the device's message rate) that we time out the GCS and try detecting again

@chiara-septentrio this is a MosaicX5 module connected to an ArduPilot periph node.  We're reliably seeing bad bytes in the length field; this fix is necessary in case of true corruption, but it's a bit worrying how reliable this problem is!
