### PR TITLE
AC_Avoidance: add missing AP_AHR.h include

### DIFF
--- a/libraries/AC_Avoidance/AC_Avoidance_Logging.cpp
+++ b/libraries/AC_Avoidance/AC_Avoidance_Logging.cpp
@@ -2,6 +2,7 @@
 
 #if HAL_LOGGING_ENABLED
 
+#include <AP_AHRS/AP_AHRS.h>
 #include "AC_Avoid.h"
 #include "AP_OADijkstra.h"
 #include "AP_OABendyRuler.h"


### PR DESCRIPTION
We use the AHRS singleton
