### PR TITLE
AP_Logger: force formats for Write(...) messages out to buffer

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
@@ -401,6 +401,15 @@ void NavEKF3_core::Log_Write(uint64_t time_us)
     Log_Write_XKFS(time_us);
     Log_Write_Quaternion(time_us);
 
+    AP::logger().WriteStreaming(
+        "PBDG",
+        "TimeUS," "Flags",
+        "s"       "-",   // units
+        "F"       "-",   // multipliers
+        "Q"       "H",   // storage type
+        AP_HAL::micros64(),
+        17
+    );
 
 #if EK3_FEATURE_BEACON_FUSION
     // write range beacon fusion debug packet if the range value is non-zero


### PR DESCRIPTION
Up for discussion.

If you replay a log which was created on the branch these patches are based on then you will end up getting vast swathes of unknown "13 bytes" messages as we don't send WriteStreaming messages to the buffer in Replay (13 bytes being the size of `PBDG`
