### PR TITLE
Replay: fixed --force-ekf2 in Replay

### DIFF
--- a/Tools/Replay/Replay.h
+++ b/Tools/Replay/Replay.h
@@ -107,4 +107,7 @@ private:
     bool parse_param_line(char *line, char **vname, float &value);
     void load_param_file(const char *filename);
     void usage();
+
+    void Write_Format(const struct LogStructure &s);
+    void write_EKF_formats(void);
 };


### PR DESCRIPTION
when the original log used a firmware without EKF2 compiled in then the format messages are missing
this helps with diagnosis of #29384 