### PR TITLE
matrix_alg: Probable redundancy

### DIFF
--- a/libraries/AP_Math/matrix_alg.cpp
+++ b/libraries/AP_Math/matrix_alg.cpp
@@ -77,14 +77,8 @@ static void mat_pivot(const T* A, T* pivot, uint16_t n)
     for(uint16_t i = 0;i < n; i++) {
         uint16_t max_j = i;
         for(uint16_t j=i;j<n;j++){
-            if (std::is_same<T, double>::value) {
-                if(fabsF(A[j*n + i]) > fabsF(A[max_j*n + i])) {
-                    max_j = j;
-                }
-            } else {
-                if(fabsF(A[j*n + i]) > fabsF(A[max_j*n + i])) {
-                    max_j = j;
-                }
+            if(fabsF(A[j*n + i]) > fabsF(A[max_j*n + i])) {
+                max_j = j;
             }
         }
 


### PR DESCRIPTION
A comparison is made whether `T` is defined as float or double, but the logic here seems to be redundant, there being no need to use `std::is_same`.