### PR TITLE
AP_Generator: FuelCell: increase max data rate

### DIFF
--- a/libraries/AP_Generator/AP_Generator_IE_FuelCell.cpp
+++ b/libraries/AP_Generator/AP_Generator_IE_FuelCell.cpp
@@ -35,7 +35,7 @@ void AP_Generator_IE_FuelCell::init()
     _health_warn_last_ms = AP_HAL::millis();
 }
 
-// Update fuelcell, expected to be called at 20hz
+// Update fuelcell, expected to be called at 10hz
 void AP_Generator_IE_FuelCell::update()
 {
     if (_uart == nullptr) {
@@ -44,8 +44,8 @@ void AP_Generator_IE_FuelCell::update()
 
     const uint32_t now = AP_HAL::millis();
 
-   // Read any available data
-    for (uint8_t i=0; i<30; i++) {  // process at most n bytes
+    // Read any available data
+    for (uint8_t i = 0; i < UINT8_MAX; i++) {  // process at most n bytes
         uint8_t c;
         if (!_uart->read(c)) {
             break;


### PR DESCRIPTION
At some point between when the comment was added on the function and now the generator scheduler rate was dropped to 10Hz. 30 bytes read per call at 10Hz means a max of 300 bytes per second rather than the 600 bytes per second it would have been originally. 

This bumps it up to 255 bytes for a max of 2550 bytes per second. These typically ruin on a serial port at 9600 baud so a max of 960 bytes per second. We could go lower, 50 or 100 bytes per call would be fine for the existing units, but this was a PITA to debug so some headroom is nice.

