### PR TITLE
Plane: Tiltrotor: fix `has_vtol_motor` function

### DIFF
--- a/ArduPlane/tiltrotor.cpp
+++ b/ArduPlane/tiltrotor.cpp
@@ -119,7 +119,7 @@ void Tiltrotor::setup()
 
     // check if there are any permanent VTOL motors
     for (uint8_t i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; ++i) {
-        if (motors->is_motor_enabled(i) && ((tilt_mask & (1U<<1)) == 0)) {
+        if (motors->is_motor_enabled(i) && !is_motor_tilting(i)) {
             // enabled motor not set in tilt mask
             _have_vtol_motor = true;
             break;


### PR DESCRIPTION
This fixes a by reported by @jcproulx in https://github.com/ArduPilot/ardupilot/issues/29404.

It was always checking the first motor rather than any motor. The `_have_vtol_motor` bool is used in the `has_vtol_motor` function which is only used here: 

https://github.com/ArduPilot/ardupilot/blob/076951f003703f178523cd2e122fd54fffcaefff/ArduPlane/quadplane.cpp#L1591-L1594

The goal of that code is to smooth the handover of throttle control from VTOL to FW in the transition timer phase on vehicles that had all motors tilting.