### PR TITLE
AP_HAL_ChibiOS: Fix regression in MCU max and min volt logging

### DIFF
--- a/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
+++ b/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
@@ -761,6 +761,10 @@ void AnalogIn::_timer_tick(void)
         // note min/max swap due to inversion
         _mcu_voltage_min = 3.3 * VREFINT_CAL / float(_mcu_vrefint_max+0.001);
         _mcu_voltage_max = 3.3 * VREFINT_CAL / float(_mcu_vrefint_min+0.001);
+        
+        // reset min and max
+        _mcu_vrefint_max = 0;
+        _mcu_vrefint_min = 0;
     }
 #endif
 }


### PR DESCRIPTION
This fixes the regression in the max and min MCU voltage in the logs, as described in this issue: https://github.com/ArduPilot/ardupilot/issues/29147

Tested on CubeOrangePlus and MatekH743 with copter firmware.

Master:
![00000056 master](https://github.com/user-attachments/assets/3b8bc8a1-54a1-4dc4-b165-709153877057)

This PR:
![00000058 my pr](https://github.com/user-attachments/assets/7d9ba296-4fcc-450f-ba56-178a76f303be)

Note, however that this does reset it at 20 Hz, whereas MCU only gets logged at 10 Hz (on copter, at any rate).
AFAICT this was the previous behaviour as well though.