### PR TITLE
AP_DDS: Publish all available GPS instances

### DIFF
--- a/libraries/AP_DDS/AP_DDS_Client.h
+++ b/libraries/AP_DDS/AP_DDS_Client.h
@@ -15,6 +15,7 @@
 #endif // AP_DDS_TIME_PUB_ENABLED
 #if AP_DDS_NAVSATFIX_PUB_ENABLED
 #include "sensor_msgs/msg/NavSatFix.h"
+#include <AP_GPS/AP_GPS_config.h>
 #endif // AP_DDS_NAVSATFIX_PUB_ENABLED
 #if AP_DDS_NEEDS_TRANSFORMS
 #include "tf2_msgs/msg/TFMessage.h"
@@ -172,7 +173,7 @@ private:
 #if AP_DDS_NAVSATFIX_PUB_ENABLED
     sensor_msgs_msg_NavSatFix nav_sat_fix_topic;
     // The last ms timestamp AP_DDS wrote a NavSatFix message
-    uint64_t last_nav_sat_fix_time_ms;
+    uint64_t last_nav_sat_fix_time_ms[GPS_MAX_INSTANCES];
     //! @brief Serialize the current nav_sat_fix state and publish to the IO stream(s)
     void write_nav_sat_fix_topic();
     bool update_topic(sensor_msgs_msg_NavSatFix& msg, const uint8_t instance) WARN_IF_UNUSED;


### PR DESCRIPTION
Allow all GPS instances to be published on the `/ap/navsat` topic. All instances are published, each with their `instance` represented in the `header.frame_id` field.

This approach follows what has been already implemented for the `/ap/battery` topic.

# Test

Simulation parameters need to be updated in order to enable a second GPS instance to be found.

- `GPS2_TYPE` = 1
- `SIM_GPS2_ENABLE` = 1
- Restart the simulator and micro-ros.
- On another terminal, publish the topic with: `ros2 topic echo /ap/navsat`
```
---
header:
  stamp:
    sec: 1741022473
    nanosec: 424456000
  frame_id: '0'
status:
  status: 2
  service: 1
latitude: -35.36326217651367
longitude: 149.1652374267578
altitude: 584.0899658203125
position_covariance:
- 0.09000000357627869
- 0.0
- 0.0
- 0.0
- 0.09000000357627869
- 0.0
- 0.0
- 0.0
- 0.09000000357627869
position_covariance_type: 2
---
header:
  stamp:
    sec: 1741022473
    nanosec: 424456000
  frame_id: '1'
status:
  status: 2
  service: 1
latitude: -35.36326217651367
longitude: 149.1652374267578
altitude: 584.0899658203125
position_covariance:
- 0.09000000357627869
- 0.0
- 0.0
- 0.0
- 0.09000000357627869
- 0.0
- 0.0
- 0.0
- 0.09000000357627869
position_covariance_type: 2
---
```
