### PR TITLE
AP_OpticalFlow: correct includes for AP_OpticalFlow_MSP

### DIFF
--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_MSP.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_MSP.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "AP_OpticalFlow.h"
-#include <AP_HAL/utility/OwnPtr.h>
+#include "AP_OpticalFlow_config.h"
 
 #if HAL_MSP_OPTICALFLOW_ENABLED
+
+#include "AP_OpticalFlow.h"
 
 class AP_OpticalFlow_MSP : public OpticalFlow_backend
 {


### PR DESCRIPTION
unused ownptr header