### PR TITLE
AP_Notify: stop using OwnPtr in IS31FL3195

### DIFF
--- a/libraries/AP_Notify/IS31FL3195.cpp
+++ b/libraries/AP_Notify/IS31FL3195.cpp
@@ -54,7 +54,7 @@ IS31FL3195::IS31FL3195(uint8_t bus, uint8_t addr)
 
 bool IS31FL3195::init(void)
 {
-    _dev = std::move(hal.i2c_mgr->get_device(_bus, _addr));
+    _dev = hal.i2c_mgr->get_device_ptr(_bus, _addr);
     if (!_dev) {
         return false;
     }

--- a/libraries/AP_Notify/IS31FL3195.h
+++ b/libraries/AP_Notify/IS31FL3195.h
@@ -30,12 +30,14 @@ class IS31FL3195 : public RGBLed
 {
 public:
     IS31FL3195(uint8_t bus, uint8_t addr);
+    ~IS31FL3195() { delete _dev; }
+
     bool init(void) override;
 protected:
     bool hw_set_rgb(uint8_t r, uint8_t g, uint8_t b) override;
 
 private:
-    AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev;
+    AP_HAL::I2CDevice *_dev;
     uint8_t _bus;
     uint8_t _addr;
 


### PR DESCRIPTION
Tested on external i2c device

