### PR TITLE
AP_Mount: fix CADDX RC update rate

### DIFF
--- a/libraries/AP_Mount/AP_Mount_CADDX.cpp
+++ b/libraries/AP_Mount/AP_Mount_CADDX.cpp
@@ -63,6 +63,7 @@ void AP_Mount_CADDX::update()
                 mnt_target.rate_rads = rc_target;
                 break;
             }
+            resend_now = true;
             break;
         }
 


### PR DESCRIPTION
This fixes an issue with the CADDX driver that causes the gimbal to move at only 1hz towards its target when the user is controlling the gimbal via RC input.

This has been lightly tested on real hardware

Thanks very much to @boa-pe for finding and reporting this issue!