### PR TITLE
Tools: update error message to use new AP_PERIPH_RELAY_ENABLED define

### DIFF
--- a/Tools/AP_Periph/AP_Periph.h
+++ b/Tools/AP_Periph/AP_Periph.h
@@ -53,7 +53,7 @@
 #endif
 #include <AP_Relay/AP_Relay.h>
 #if !AP_RELAY_ENABLED
-    #error "HAL_PERIPH_ENABLE_RELAY requires AP_RELAY_ENABLED"
+    #error "AP_PERIPH_RELAY_ENABLED requires AP_RELAY_ENABLED"
 #endif
 #endif
 


### PR DESCRIPTION
The commit name has changed now. I missed to update it here while submitting the PR that renamed it.