### PR TITLE
Swap -f for --model in JSON read me instructions

### DIFF
--- a/libraries/SITL/examples/JSON/readme.md
+++ b/libraries/SITL/examples/JSON/readme.md
@@ -1,8 +1,8 @@
 The JSON SITL backend allows software to easily interface with ArduPilot using a standard JSON interface.
 
-To launch the JSON backend run SITL with ```-f json:127.0.0.1``` where 127.0.0.1 is replaced with the IP the physics backend is running at.
+To launch the JSON backend run SITL with ```--model JSON:127.0.0.1``` where 127.0.0.1 is replaced with the IP the physics backend is running at. For example: ```sim_vehicle.py -v ArduCopter -f octaquad --model JSON:127.0.0.1 --map --console```
 
-Connection to SITL is made via a UDP link. The physics backend should listen for incoming messages on port 9002 it should then reply to the IP and port the messages were received from. This removes the need to configure the a target
+Connection to SITL is made via a UDP link. The physics backend should listen for incoming messages on port 9002 it should then reply to the IP and port the messages were received from. This removes the need to configure a target
 IP and port for SITL in the physics backend. SITL will send a output message every 10 seconds allowing the physics backend to auto detect.
 
 SITL output


### PR DESCRIPTION
The previous read me suggested using "-f json" to include the interface in SITL. This was difficult to work with as it replaced the vehicle's frame definition argument and prevented users from accessing the default parameters. By using "--model json" instead, the "-f" argument is left free for the vehicle's frame definition.