### PR TITLE
AP_Mission: fix option_is_set

### DIFF
--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -733,9 +733,9 @@ public:
       disarm and mission logic should stop
      */
     enum class Option {
-        CLEAR_ON_BOOT            =  0,  // clear mission on vehicle boot
-        FAILSAFE_TO_BEST_LANDING =  1,  // on failsafe, find fastest path along mission home
-        CONTINUE_AFTER_LAND      =  2,  // continue running mission (do not disarm) after land if takeoff is next waypoint
+        CLEAR_ON_BOOT            = (1U<<0), // clear mission on vehicle boot
+        FAILSAFE_TO_BEST_LANDING = (1U<<1), // on failsafe, find fastest path along mission home
+        CONTINUE_AFTER_LAND      = (1U<<2), // continue running mission (do not disarm) after land if takeoff is next waypoint
     };
     bool option_is_set(Option option) const {
         return (_options.get() & (uint16_t)option) != 0;


### PR DESCRIPTION
This is the alternative to https://github.com/ArduPilot/ardupilot/pull/29435

This has been lightly tested in SITL using the two options that Copter supports:

1. Clear On Boot ---> the mission was correctly cleared after SITL was restarted
2. Continue After Land ---> with this set (and only when this was set) the vehicle was able to fly, land and takeoff again in a single mission

