### PR TITLE
AP_InertialSensor: Remove two unused defines

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -3,8 +3,6 @@
 #include "AP_InertialSensor_config.h"
 
 // Gyro and Accelerometer calibration criteria
-#define AP_INERTIAL_SENSOR_ACCEL_TOT_MAX_OFFSET_CHANGE  4.0f
-#define AP_INERTIAL_SENSOR_ACCEL_MAX_OFFSET             250.0f
 #define AP_INERTIAL_SENSOR_ACCEL_VIBE_FLOOR_FILT_HZ     5.0f    // accel vibration floor filter hz
 #define AP_INERTIAL_SENSOR_ACCEL_VIBE_FILT_HZ           2.0f    // accel vibration filter hz
 #define AP_INERTIAL_SENSOR_ACCEL_PEAK_DETECT_TIMEOUT_MS 500     // peak-hold detector timeout


### PR DESCRIPTION
The definitions `AP_INERTIAL_SENSOR_ACCEL_TOT_MAX_OFFSET_CHANGE` and `AP_INERTIAL_SENSOR_ACCEL_MAX_OFFSET` apparently it is no longer used in the library.