### PR TITLE
Add get_device_ptr to AP_HAL::SPIDevice

### DIFF
--- a/libraries/AP_HAL/SPIDevice.h
+++ b/libraries/AP_HAL/SPIDevice.h
@@ -68,9 +68,9 @@ public:
 
 class SPIDeviceManager {
 public:
-    virtual OwnPtr<SPIDevice> get_device(const char *name)
-    {
-        return nullptr;
+    virtual SPIDevice *get_device_ptr(const char *name) = 0;
+    OwnPtr<SPIDevice> get_device(const char *name) {
+        return AP_HAL::OwnPtr<AP_HAL::SPIDevice>(get_device_ptr(name));
     }
 
     /* Return the number of SPI devices currently registered. */

--- a/libraries/AP_HAL_ChibiOS/Device.cpp
+++ b/libraries/AP_HAL_ChibiOS/Device.cpp
@@ -17,7 +17,6 @@
 #include "Device.h"
 
 #include <AP_HAL/AP_HAL.h>
-#include <AP_HAL/utility/OwnPtr.h>
 #include <stdio.h>
 
 #if HAL_USE_I2C == TRUE || HAL_USE_SPI == TRUE || HAL_USE_WSPI == TRUE

--- a/libraries/AP_HAL_ChibiOS/I2CDevice.h
+++ b/libraries/AP_HAL_ChibiOS/I2CDevice.h
@@ -23,7 +23,6 @@
 
 #include <AP_HAL/HAL.h>
 #include <AP_HAL/I2CDevice.h>
-#include <AP_HAL/utility/OwnPtr.h>
 #include "AP_HAL_ChibiOS.h"
 
 #if HAL_USE_I2C == TRUE

--- a/libraries/AP_HAL_ChibiOS/SPIDevice.cpp
+++ b/libraries/AP_HAL_ChibiOS/SPIDevice.cpp
@@ -18,7 +18,6 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
-#include <AP_HAL/utility/OwnPtr.h>
 #include <AP_InternalError/AP_InternalError.h>
 #include "Util.h"
 #include "Scheduler.h"
@@ -445,8 +444,8 @@ bool SPIDevice::set_chip_select(bool set) {
 /*
   return a SPIDevice given a string device name
  */
-AP_HAL::OwnPtr<AP_HAL::SPIDevice>
-SPIDeviceManager::get_device(const char *name)
+AP_HAL::SPIDevice *
+SPIDeviceManager::get_device_ptr(const char *name)
 {
     /* Find the bus description in the table */
     uint8_t i;
@@ -456,7 +455,7 @@ SPIDeviceManager::get_device(const char *name)
         }
     }
     if (i == ARRAY_SIZE(device_table)) {
-        return AP_HAL::OwnPtr<AP_HAL::SPIDevice>(nullptr);
+        return nullptr;
     }
 
     SPIDesc &desc = device_table[i];
@@ -480,7 +479,7 @@ SPIDeviceManager::get_device(const char *name)
         buses = busp;
     }
 
-    return AP_HAL::OwnPtr<AP_HAL::SPIDevice>(NEW_NOTHROW SPIDevice(*busp, desc));
+    return NEW_NOTHROW SPIDevice(*busp, desc);
 }
 
 void SPIDeviceManager::set_register_rw_callback(const char* name, AP_HAL::Device::RegisterRWCb cb)

--- a/libraries/AP_HAL_ChibiOS/SPIDevice.h
+++ b/libraries/AP_HAL_ChibiOS/SPIDevice.h
@@ -177,7 +177,7 @@ public:
         return static_cast<SPIDeviceManager*>(spi_mgr);
     }
 
-    AP_HAL::OwnPtr<AP_HAL::SPIDevice> get_device(const char *name) override;
+    AP_HAL::SPIDevice *get_device_ptr(const char *name) override;
 
     void set_register_rw_callback(const char* name, AP_HAL::Device::RegisterRWCb cb) override;
 

--- a/libraries/AP_HAL_ESP32/DeviceBus.cpp
+++ b/libraries/AP_HAL_ESP32/DeviceBus.cpp
@@ -16,7 +16,6 @@
 #include "DeviceBus.h"
 
 #include <AP_HAL/AP_HAL.h>
-#include <AP_HAL/utility/OwnPtr.h>
 #include <stdio.h>
 
 #include "Scheduler.h"

--- a/libraries/AP_HAL_ESP32/I2CDevice.h
+++ b/libraries/AP_HAL_ESP32/I2CDevice.h
@@ -18,7 +18,6 @@
 
 #include <AP_HAL/HAL.h>
 #include <AP_HAL/I2CDevice.h>
-#include <AP_HAL/utility/OwnPtr.h>
 
 #include "Semaphores.h"
 #include "Scheduler.h"

--- a/libraries/AP_HAL_ESP32/SPIDevice.cpp
+++ b/libraries/AP_HAL_ESP32/SPIDevice.cpp
@@ -17,7 +17,6 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
-#include <AP_HAL/utility/OwnPtr.h>
 #include "Scheduler.h"
 #include "Semaphores.h"
 #include <stdio.h>
@@ -184,8 +183,8 @@ bool SPIDevice::adjust_periodic_callback(AP_HAL::Device::PeriodicHandle h, uint3
     return bus.adjust_timer(h, period_usec);
 }
 
-AP_HAL::OwnPtr<AP_HAL::SPIDevice>
-SPIDeviceManager::get_device(const char *name)
+AP_HAL::SPIDevice *
+SPIDeviceManager::get_device_ptr(const char *name)
 {
 #ifdef SPIDEBUG
     printf("%s:%d %s\n", __PRETTY_FUNCTION__, __LINE__, name);
@@ -197,7 +196,7 @@ SPIDeviceManager::get_device(const char *name)
         }
     }
     if (i == ARRAY_SIZE(device_desc)) {
-        return AP_HAL::OwnPtr<AP_HAL::SPIDevice>(nullptr);
+        return nullptr;
     }
     SPIDeviceDesc &desc = device_desc[i];
 
@@ -239,6 +238,6 @@ SPIDeviceManager::get_device(const char *name)
     printf("%s:%d 444\n", __PRETTY_FUNCTION__, __LINE__);
 #endif
 
-    return AP_HAL::OwnPtr<AP_HAL::SPIDevice>(NEW_NOTHROW SPIDevice(*busp, desc));
+    return NEW_NOTHROW SPIDevice(*busp, desc);
 }
 

--- a/libraries/AP_HAL_ESP32/SPIDevice.h
+++ b/libraries/AP_HAL_ESP32/SPIDevice.h
@@ -90,7 +90,7 @@ class SPIDeviceManager : public AP_HAL::SPIDeviceManager
 public:
     friend class SPIDevice;
 
-    AP_HAL::OwnPtr<AP_HAL::SPIDevice> get_device(const char *name) override;
+    AP_HAL::SPIDevice *get_device_ptr(const char *name) override;
 
 private:
     SPIBus *buses;

--- a/libraries/AP_HAL_Empty/I2CDevice.h
+++ b/libraries/AP_HAL_Empty/I2CDevice.h
@@ -20,7 +20,6 @@
 
 #include <AP_HAL/HAL.h>
 #include <AP_HAL/I2CDevice.h>
-#include <AP_HAL/utility/OwnPtr.h>
 
 namespace Empty {
 

--- a/libraries/AP_HAL_Empty/SPIDevice.h
+++ b/libraries/AP_HAL_Empty/SPIDevice.h
@@ -75,9 +75,8 @@ private:
 class SPIDeviceManager : public AP_HAL::SPIDeviceManager {
 public:
     SPIDeviceManager() { }
-    AP_HAL::OwnPtr<AP_HAL::SPIDevice> get_device(const char *name) override
-    {
-        return AP_HAL::OwnPtr<AP_HAL::SPIDevice>(NEW_NOTHROW SPIDevice());
+    AP_HAL::SPIDevice *get_device_ptr(const char *name) override {
+        return NEW_NOTHROW SPIDevice();
     }
 };
 

--- a/libraries/AP_HAL_Linux/I2CDevice.h
+++ b/libraries/AP_HAL_Linux/I2CDevice.h
@@ -21,7 +21,6 @@
 
 #include <AP_HAL/HAL.h>
 #include <AP_HAL/I2CDevice.h>
-#include <AP_HAL/utility/OwnPtr.h>
 
 #include "Semaphores.h"
 

--- a/libraries/AP_HAL_Linux/SPIDevice.cpp
+++ b/libraries/AP_HAL_Linux/SPIDevice.cpp
@@ -342,8 +342,8 @@ bool SPIDevice::adjust_periodic_callback(
 }
 
 
-AP_HAL::OwnPtr<AP_HAL::SPIDevice>
-SPIDeviceManager::get_device(const char *name)
+AP_HAL::SPIDevice *
+SPIDeviceManager::get_device_ptr(const char *name)
 {
     SPIDesc *desc = nullptr;
 
@@ -356,7 +356,7 @@ SPIDeviceManager::get_device(const char *name)
     }
 
     if (!desc) {
-        return AP_HAL::OwnPtr<AP_HAL::SPIDevice>(nullptr);
+        return nullptr;
     }
 
     /* Find if bus already exists */
@@ -393,13 +393,13 @@ const char* SPIDeviceManager::get_device_name(uint8_t idx)
 }
 
 /* Create a new device increasing the bus reference */
-AP_HAL::OwnPtr<AP_HAL::SPIDevice>
+AP_HAL::SPIDevice *
 SPIDeviceManager::_create_device(SPIBus &b, SPIDesc &desc) const
 {
     // Ensure bus is open
     b.open(desc.subdev);
 
-    auto dev = AP_HAL::OwnPtr<AP_HAL::SPIDevice>(NEW_NOTHROW SPIDevice(b, desc));
+    auto *dev = NEW_NOTHROW SPIDevice(b, desc);
     if (!dev) {
         return nullptr;
     }

--- a/libraries/AP_HAL_Linux/SPIDevice.h
+++ b/libraries/AP_HAL_Linux/SPIDevice.h
@@ -110,7 +110,7 @@ public:
     }
 
     /* AP_HAL::SPIDeviceManager implementation */
-    AP_HAL::OwnPtr<AP_HAL::SPIDevice> get_device(const char *name) override;
+    AP_HAL::SPIDevice *get_device_ptr(const char *name) override;
 
     /*
      * Stop all SPI threads and block until they are finalized. This doesn't
@@ -127,7 +127,7 @@ public:
 
 protected:
     void _unregister(SPIBus &b);
-    AP_HAL::OwnPtr<AP_HAL::SPIDevice> _create_device(SPIBus &b, SPIDesc &device_desc) const;
+    AP_HAL::SPIDevice *_create_device(SPIBus &b, SPIDesc &device_desc) const;
 
     std::vector<SPIBus*> _buses;
 

--- a/libraries/AP_HAL_QURT/DeviceBus.cpp
+++ b/libraries/AP_HAL_QURT/DeviceBus.cpp
@@ -16,7 +16,6 @@
 #include "DeviceBus.h"
 
 #include <AP_HAL/AP_HAL.h>
-#include <AP_HAL/utility/OwnPtr.h>
 #include <stdio.h>
 
 #include "Scheduler.h"

--- a/libraries/AP_HAL_QURT/I2CDevice.h
+++ b/libraries/AP_HAL_QURT/I2CDevice.h
@@ -18,7 +18,6 @@
 
 #include <AP_HAL/HAL.h>
 #include <AP_HAL/I2CDevice.h>
-#include <AP_HAL/utility/OwnPtr.h>
 
 #include "Semaphores.h"
 #include "Scheduler.h"

--- a/libraries/AP_HAL_QURT/SPIDevice.cpp
+++ b/libraries/AP_HAL_QURT/SPIDevice.cpp
@@ -17,7 +17,6 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
-#include <AP_HAL/utility/OwnPtr.h>
 #include "Scheduler.h"
 #include "Semaphores.h"
 #include "interface.h"
@@ -112,8 +111,8 @@ bool SPIDevice::adjust_periodic_callback(AP_HAL::Device::PeriodicHandle h, uint3
     return bus.adjust_timer(h, period_usec);
 }
 
-AP_HAL::OwnPtr<AP_HAL::SPIDevice>
-SPIDeviceManager::get_device(const char *name)
+AP_HAL::SPIDevice *
+SPIDeviceManager::get_device_ptr(const char *name)
 {
     uint8_t i;
     for (i = 0; i<ARRAY_SIZE(device_names); i++) {
@@ -122,13 +121,13 @@ SPIDeviceManager::get_device(const char *name)
         }
     }
     if (i == ARRAY_SIZE(device_names)) {
-        return AP_HAL::OwnPtr<AP_HAL::SPIDevice>(nullptr);
+        return nullptr;
     }
 
     if (spi_bus == nullptr) {
         spi_bus = new SPIBus();
     }
 
-    return AP_HAL::OwnPtr<AP_HAL::SPIDevice>(new SPIDevice(name, *spi_bus));
+    return new SPIDevice(name, *spi_bus);
 }
 

--- a/libraries/AP_HAL_QURT/SPIDevice.h
+++ b/libraries/AP_HAL_QURT/SPIDevice.h
@@ -59,7 +59,7 @@ class SPIDeviceManager : public AP_HAL::SPIDeviceManager
 public:
     friend class SPIDevice;
 
-    AP_HAL::OwnPtr<AP_HAL::SPIDevice> get_device(const char *name) override;
+    AP_HAL::SPIDevice *get_device_ptr(const char *name) override;
 };
 }
 

--- a/libraries/AP_HAL_SITL/I2CDevice.h
+++ b/libraries/AP_HAL_SITL/I2CDevice.h
@@ -22,7 +22,6 @@
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 
 #include <AP_HAL/I2CDevice.h>
-#include <AP_HAL/utility/OwnPtr.h>
 
 #include "AP_HAL_SITL_Namespace.h"
 #include "Semaphores.h"

--- a/libraries/AP_HAL_SITL/SPIDevice.cpp
+++ b/libraries/AP_HAL_SITL/SPIDevice.cpp
@@ -123,8 +123,8 @@ SPIDesc SPIDeviceManager::device_table[] = {
     { "dataflash", 1, 0}
 };
 
-AP_HAL::OwnPtr<AP_HAL::SPIDevice>
-SPIDeviceManager::get_device(const char *name)
+AP_HAL::SPIDevice *
+SPIDeviceManager::get_device_ptr(const char *name)
 {
     // this was swiped from AP_HAL_ChibiOS
 
@@ -136,7 +136,7 @@ SPIDeviceManager::get_device(const char *name)
         }
     }
     if (i == ARRAY_SIZE(device_table)) {
-        return AP_HAL::OwnPtr<AP_HAL::SPIDevice>(nullptr);
+        return nullptr;
     }
 
     SPIDesc &desc = device_table[i];
@@ -160,7 +160,7 @@ SPIDeviceManager::get_device(const char *name)
         buses = busp;
     }
 
-    return AP_HAL::OwnPtr<AP_HAL::SPIDevice>(NEW_NOTHROW SPIDevice(*busp, desc));
+    return NEW_NOTHROW SPIDevice(*busp, desc);
 }
 
 // void SPIDeviceManager::_timer_tick()

--- a/libraries/AP_HAL_SITL/SPIDevice.h
+++ b/libraries/AP_HAL_SITL/SPIDevice.h
@@ -72,7 +72,7 @@ public:
 
     SPIDeviceManager();
 
-    AP_HAL::OwnPtr<AP_HAL::SPIDevice> get_device(const char *name) override;
+    AP_HAL::SPIDevice *get_device_ptr(const char *name) override;
 
     static SPIDesc device_table[];
     static SPIBus *buses;


### PR DESCRIPTION
Similar to what we did the I2CDevice, allow callers to get a pointer not wrapped in OwnPtr.

Tested using QiotekZealotF427 which uses an SPI-connected SD card.  Everything works fine, including ejecting and reinserting.
