### PR TITLE
Plane: prevent learning bad ARSPD_RATIO

### DIFF
--- a/ArduPlane/Plane.cpp
+++ b/ArduPlane/Plane.cpp
@@ -410,7 +410,10 @@ void Plane::three_hz_loop()
  */
 void Plane::airspeed_ratio_update(void)
 {
-    if (!airspeed.enabled() ||
+    if (!hal.util->get_soft_armed() ||
+        !ahrs.get_fly_forward() ||
+        !is_flying() ||
+        !airspeed.enabled() ||
         gps.status() < AP_GPS::GPS_OK_FIX_3D ||
         gps.ground_speed() < 4) {
         // don't calibrate when not moving


### PR DESCRIPTION
this prevents learning of ARSPD_RATIO when not in fly-forward or not armed

the scenario that happened on a real aircraft was gps glitches in a hanger combined with airspeed offset causing the learning of an ARSPD_RATIO of 4.0, resulting in a stall in an AUTO mission and a crash