### PR TITLE
AP_HAL_ChibiOS: drop HAL_FORWARD_OTG2_SERIAL

### DIFF
--- a/Tools/AP_Bootloader/support.cpp
+++ b/Tools/AP_Bootloader/support.cpp
@@ -494,7 +494,7 @@ static SerialConfig forward_sercfg;
 static uint32_t otg2_serial_deadline_ms;
 bool update_otg2_serial_forward()
 {
-    // get baudrate set on SDU2 and set it on HAL_FORWARD_OTG2_SERIAL if changed
+    // get baudrate set on SDU2 and set it on BOOTLOADER_FORWARD_OTG2_SERIAL if changed
     if (forward_sercfg.speed != BOOTLOADER_FORWARD_OTG2_SERIAL_BAUDRATE) {
         forward_sercfg.speed = BOOTLOADER_FORWARD_OTG2_SERIAL_BAUDRATE;
 #if defined(BOOTLOADER_FORWARD_OTG2_SERIAL_SWAP) && BOOTLOADER_FORWARD_OTG2_SERIAL_SWAP
@@ -502,11 +502,11 @@ bool update_otg2_serial_forward()
 #endif
         sdStart(&BOOTLOADER_FORWARD_OTG2_SERIAL, &forward_sercfg);
     }
-    // check how many bytes are available to read from HAL_FORWARD_OTG2_SERIAL
+    // check how many bytes are available to read from BOOTLOADER_FORWARD_OTG2_SERIAL
     uint8_t data[SERIAL_BUFFERS_SIZE]; // read upto SERIAL_BUFFERS_SIZE at a time
     int n = chnReadTimeout(&SDU2, data, SERIAL_BUFFERS_SIZE, TIME_IMMEDIATE);
     if (n > 0) {
-        // do a blocking write to HAL_FORWARD_OTG2_SERIAL
+        // do a blocking write to BOOTLOADER_FORWARD_OTG2_SERIAL
         chnWriteTimeout(&BOOTLOADER_FORWARD_OTG2_SERIAL, data, n, TIME_IMMEDIATE);
         otg2_serial_deadline_ms = AP_HAL::millis() + 1000;
     }

--- a/libraries/AP_HAL/AP_HAL_Boards.h
+++ b/libraries/AP_HAL/AP_HAL_Boards.h
@@ -272,10 +272,6 @@
 #define HAL_SUPPORT_RCOUT_SERIAL 0
 #endif
 
-#ifndef HAL_FORWARD_OTG2_SERIAL
-#define HAL_FORWARD_OTG2_SERIAL 0
-#endif
-
 #ifndef HAL_HAVE_DUAL_USB_CDC
 #define HAL_HAVE_DUAL_USB_CDC 0
 #endif

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -50,9 +50,6 @@ public:
     uint32_t txspace() override;
     void _rx_timer_tick(void);
     void _tx_timer_tick(void);
-#if HAL_FORWARD_OTG2_SERIAL
-    void fwd_otg2_serial(void);
-#endif
 
     // control optional features
     bool set_options(uint16_t options) override;


### PR DESCRIPTION
This is no longer used with the advent of PPP from CubeRedPrimary to CubeRedSecondary. There is a similar version still in the bootloader which is still useful.

Not using it in the future is beneficial so that OTG2 (SERIAL6) can be used for other purposes. The feature can also be replaced using the serial passthrough options.