### PR TITLE
AP_BoardConfig: protect enumeration and get_board_type with #if

### DIFF
--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -792,11 +792,13 @@ void AP_Baro::_probe_i2c_barometers(void)
     uint32_t probe = _baro_probe_ext.get();
     (void)probe;  // may be unused if most baros compiled out
     uint32_t mask = hal.i2c_mgr->get_bus_mask_external();
+#if AP_FEATURE_BOARD_DETECT
     if (AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_PIXHAWK2) {
         // for the purpose of baro probing, treat CubeBlack internal i2c as external. It has
         // no internal i2c baros, so this is safe
         mask |= hal.i2c_mgr->get_bus_mask_internal();
     }
+#endif  // AP_FEATURE_BOARD_DETECT
     // if the user has set BARO_EXT_BUS then probe the bus given by that parameter
     int8_t ext_bus = _ext_bus;
     if (ext_bus >= 0) {

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -40,6 +40,7 @@ public:
     // that we're never going to boot properly:
     static bool in_config_error(void) { return _in_error_loop; }
 
+#if AP_FEATURE_BOARD_DETECT
     // valid types for BRD_TYPE: these values need to be in sync with the
     // values from the param description
     enum px4_board_type {
@@ -73,16 +74,13 @@ public:
         PX4_BOARD_OLDDRIVERS = 100,
     };
 
+    static enum px4_board_type get_board_type(void) {
+        return px4_configured_board;
+    }
+#endif  // AP_FEATURE_BOARD_DETECT
+
     // set default value for BRD_SAFETY_MASK
     void set_default_safety_ignore_mask(uint32_t mask);
-
-    static enum px4_board_type get_board_type(void) {
-#if AP_FEATURE_BOARD_DETECT
-        return px4_configured_board;
-#else
-        return BOARD_TYPE_UNKNOWN;
-#endif
-    }
 
     // ask if IOMCU is enabled. This is a uint8_t to allow
     // developer debugging by setting BRD_IO_ENABLE=100 to avoid the

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -1118,7 +1118,11 @@ void Compass::add_backend(Compass::DriverType driver_type, AP_Compass_Backend *b
 void Compass::_probe_external_i2c_compasses(void)
 {
 #if AP_COMPASS_INTERNAL_BUS_PROBING_ENABLED
+#if AP_FEATURE_BOARD_DETECT
     bool all_external = (AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_PIXHAWK2);
+#else
+    const bool all_external = false;
+#endif  // AP_FEATURE_BOARD_DETECT
     (void)all_external;  // in case all backends using this are compiled out
 #endif  // AP_COMPASS_INTERNAL_BUS_PROBING_ENABLED
 
@@ -1130,14 +1134,18 @@ void Compass::_probe_external_i2c_compasses(void)
     }
 
 #if AP_COMPASS_HMC5843_INTERNAL_BUS_PROBING_ENABLED
-    if (AP_BoardConfig::get_board_type() != AP_BoardConfig::PX4_BOARD_AEROFC) {
+#if AP_FEATURE_BOARD_DETECT
+    if (AP_BoardConfig::get_board_type() != AP_BoardConfig::PX4_BOARD_AEROFC)
+#endif  // AP_FEATURE_BOARD_DETECT
+    {
         // internal i2c bus
         FOREACH_I2C_INTERNAL(i) {
             probe_i2c_dev(DRIVER_HMC5843, AP_Compass_HMC5843::probe, i, HAL_COMPASS_HMC5843_I2C_ADDR, all_external, all_external?ROTATION_ROLL_180:ROTATION_YAW_270);
             RETURN_IF_NO_SPACE;
         }
+#if AP_FEATURE_BOARD_DETECT
     }
-#endif  // AP_COMPASS_KMC5843_INTERNAL_BUS_PROBING_ENABLED
+#endif  // AP_COMPASS_HMC5843_INTERNAL_BUS_PROBING_ENABLED
 #endif  // AP_COMPASS_HMC5843_ENABLED
 
 #if AP_COMPASS_QMC5883L_ENABLED
@@ -1276,12 +1284,16 @@ void Compass::_probe_external_i2c_compasses(void)
 
 #if AP_COMPASS_IST8310_EXTERNAL_BUS_PROBING_ENABLED || AP_COMPASS_IST8310_INTERNAL_BUS_PROBING_ENABLED
     // IST8310 on external and internal bus
+#if AP_FEATURE_BOARD_DETECT
     if (AP_BoardConfig::get_board_type() != AP_BoardConfig::PX4_BOARD_FMUV6) {
+#endif  // AP_FEATURE_BOARD_DETECT
         enum Rotation default_rotation = AP_COMPASS_IST8310_DEFAULT_ROTATION;
 
+#if AP_FEATURE_BOARD_DETECT
         if (AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_AEROFC) {
             default_rotation = ROTATION_PITCH_180_YAW_90;
         }
+#endif  // AP_FEATURE_BOARD_DETECT
         // probe all 4 possible addresses
         const uint8_t ist8310_addr[] = { 0x0C, 0x0D, 0x0E, 0x0F };
 
@@ -1299,7 +1311,9 @@ void Compass::_probe_external_i2c_compasses(void)
             }
 #endif  // AP_COMPASS_IST8310_INTERNAL_BUS_PROBING_ENABLED
         }
+#if AP_FEATURE_BOARD_DETECT
     }
+#endif  // AP_FEATURE_BOARD_DETECT
 #endif  // AP_COMPASS_IST8310_EXTERNAL_BUS_PROBING_ENABLED || AP_COMPASS_IST8310_INTERNAL_BUS_PROBING_ENABLED
 
 #if AP_COMPASS_IST8308_ENABLED

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4Flow.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4Flow.cpp
@@ -60,7 +60,11 @@ bool AP_OpticalFlow_PX4Flow::scan_buses(void)
     uint8_t retry_attempt = 0;
 
     while (!success && retry_attempt < PX4FLOW_INIT_RETRIES) {
+#if AP_FEATURE_BOARD_DETECT
         bool all_external = (AP_BoardConfig::get_board_type() == AP_BoardConfig::PX4_BOARD_PIXHAWK2);
+#else
+        const bool all_external = false;
+#endif  // AP_FEATURE_BOARD_DETECT
         uint32_t bus_mask = all_external? hal.i2c_mgr->get_bus_mask() : hal.i2c_mgr->get_bus_mask_external();
         FOREACH_I2C_MASK(bus, bus_mask) {
     #ifdef HAL_OPTFLOW_PX4FLOW_I2C_BUS


### PR DESCRIPTION
avoid using these if this board does not do auto-detect

... also group them together
