### PR TITLE
AP_Airspeed: allow skipping startup cal but requiring manual cal, improve arming checks.

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -955,6 +955,21 @@ bool AP_Airspeed::get_hygrometer(uint8_t i, uint32_t &last_sample_ms, float &tem
 }
 #endif // AP_AIRSPEED_HYGROMETER_ENABLE
 
+// returns false if we fail arming checks, in which case the buffer will be populated with a failure message
+#ifndef HAL_BUILD_AP_PERIPH
+bool AP_Airspeed::arming_checks(size_t buflen, char *buffer) const
+{
+    for (uint8_t i=0; i<AIRSPEED_MAX_SENSORS; i++) {
+        if (enabled(i) && use(i) && !healthy(i)) {
+            hal.util->snprintf(buffer, buflen, " %d not healthy", i + 1);
+            return false;
+        }
+    }
+
+    return true;
+}
+#endif
+
 #else  // build type is not appropriate; provide a dummy implementation:
 const AP_Param::GroupInfo AP_Airspeed::var_info[] = { AP_GROUPEND };
 
@@ -967,6 +982,7 @@ bool AP_Airspeed::enabled(uint8_t i) const { return false; }
 bool AP_Airspeed::healthy(uint8_t i) const { return false; }
 float AP_Airspeed::get_airspeed(uint8_t i) const { return 0.0; }
 float AP_Airspeed::get_differential_pressure(uint8_t i) const { return 0.0; }
+bool AP_Airspeed::arming_checks(size_t buflen, char *buffer) const { return true; }
 
 #if AP_AIRSPEED_MSP_ENABLED
 void AP_Airspeed::handle_msp(const MSP::msp_airspeed_data_message_t &pkt) {}

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -31,7 +31,19 @@ public:
 #ifndef HAL_BUILD_AP_PERIPH
     AP_Int8  use;
     AP_Int8  pin;
-    AP_Int8  skip_cal;
+
+    enum class SkipCalType : int8_t {
+        // Do not skip boot calibration, this is the default
+        None = 0,
+
+        // Skip boot calibration, use saved offset, no calibration is required (but can be performed manually)
+        NoCalRequired = 1,
+
+        // Skip boot calibration, require manual calibration once per boot
+        SkipBootCal = 2,
+    };
+    AP_Enum<SkipCalType> skip_cal;
+
     AP_Int8  tube_order;
 #endif
     AP_Int8  type;

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -218,13 +218,15 @@ public:
 #if AP_AIRSPEED_EXTERNAL_ENABLED
     void handle_external(const AP_ExternalAHRS::airspeed_data_message_t &pkt);
 #endif
-    
+
     enum class CalibrationState {
         NOT_STARTED,
+        NOT_REQUIRED_ZERO_OFFSET,
         IN_PROGRESS,
         SUCCESS,
         FAILED
     };
+
     // get aggregate calibration state for the Airspeed library:
     CalibrationState get_calibration_state() const;
 
@@ -250,10 +252,9 @@ private:
         float   filtered_pressure;
         float	corrected_pressure;
         uint32_t last_update_ms;
-        bool use_zero_offset;
         bool	healthy;
 
-        // state of runtime calibration
+        // Pre-flight offset calibration
         struct {
             uint32_t start_ms;
             float    sum;
@@ -263,6 +264,7 @@ private:
         } cal;
 
 #if AP_AIRSPEED_AUTOCAL_ENABLE
+        // In flight ratio calibration
         Airspeed_Calibration calibration;
         float last_saved_ratio;
         uint8_t counter;
@@ -314,13 +316,7 @@ private:
     void update_calibration(uint8_t i, const Vector3f &vground, int16_t max_airspeed_allowed_during_cal);
     void send_airspeed_calibration(const Vector3f &vg);
     // return the current calibration offset
-    float get_offset(uint8_t i) const {
-#ifndef HAL_BUILD_AP_PERIPH
-        return param[i].offset;
-#else
-        return 0.0;
-#endif
-    }
+    float get_offset(uint8_t i) const;
     float get_offset(void) const { return get_offset(primary); }
 
     void check_sensor_failures();

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -230,6 +230,9 @@ public:
     // get aggregate calibration state for the Airspeed library:
     CalibrationState get_calibration_state() const;
 
+    // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
+    bool arming_checks(size_t buflen, char *buffer) const;
+
 private:
     static AP_Airspeed *_singleton;
 

--- a/libraries/AP_Airspeed/AP_Airspeed_Backend.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_Backend.h
@@ -89,20 +89,9 @@ protected:
 
     // some sensors use zero offsets
     void set_use_zero_offset(void) {
-        frontend.state[instance].use_zero_offset = true;
-    }
-
-    // set to no zero cal, which makes sense for some sensors
-    void set_skip_cal(void) {
+        frontend.state[instance].cal.state = AP_Airspeed::CalibrationState::NOT_REQUIRED_ZERO_OFFSET;
 #ifndef HAL_BUILD_AP_PERIPH
-        frontend.param[instance].skip_cal.set(1);
-#endif
-    }
-
-    // set zero offset
-    void set_offset(float ofs) {
-#ifndef HAL_BUILD_AP_PERIPH
-        frontend.param[instance].offset.set(ofs);
+        frontend.param[instance].offset.set(0.0);
 #endif
     }
 

--- a/libraries/AP_Airspeed/AP_Airspeed_Params.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_Params.cpp
@@ -96,8 +96,10 @@ const AP_Param::GroupInfo AP_Airspeed_Params::var_info[] = {
 
     // @Param: SKIP_CAL
     // @DisplayName: Skip airspeed offset calibration on startup
-    // @Description: This parameter allows you to skip airspeed offset calibration on startup, instead using the offset from the last calibration. This may be desirable if the offset variance between flights for your sensor is low and you want to avoid having to cover the pitot tube on each boot.
-    // @Values: 0:Disable,1:Enable
+    // @Description: This parameter allows you to skip airspeed offset calibration on startup, instead using the offset from the last calibration or requiring a manual calibration. This may be desirable if the offset variance between flights for your sensor is low and you want to avoid having to cover the pitot tube on each boot.
+    // @Values: 0:Disable
+    // @Values: 1:Do not require offset calibration before flight. Manual calibration should be performed during initial setup.
+    // @Values: 2:Do not calibrate on start up. Manual calibration must be performed once per boot.
     // @User: Advanced
     AP_GROUPINFO("SKIP_CAL", 8, AP_Airspeed_Params, skip_cal, 0),
 #endif // HAL_BUILD_AP_PERIPH

--- a/libraries/AP_Airspeed/AP_Airspeed_SDP3X.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_SDP3X.cpp
@@ -136,13 +136,9 @@ __INITFUNC__ bool AP_Airspeed_SDP3X::init()
         return false;
     }
 
-    /*
-      this sensor uses zero offset and skips cal
-     */
+    // this sensor uses zero offset
     set_use_zero_offset();
-    set_skip_cal();
-    set_offset(0);
-    
+
     _dev->set_device_type(uint8_t(DevType::SDP3X));
     set_bus_id(_dev->get_bus_id());
 

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -373,11 +373,10 @@ bool AP_Arming::airspeed_checks(bool report)
             // not an airspeed capable vehicle
             return true;
         }
-        for (uint8_t i=0; i<AIRSPEED_MAX_SENSORS; i++) {
-            if (airspeed->enabled(i) && airspeed->use(i) && !airspeed->healthy(i)) {
-                check_failed(ARMING_CHECK_AIRSPEED, report, "Airspeed %d not healthy", i + 1);
-                return false;
-            }
+        char buffer[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1] {};
+        if (!airspeed->arming_checks(sizeof(buffer), buffer)) {
+            check_failed(ARMING_CHECK_AIRSPEED, report, "Airspeed: %s", buffer);
+            return false;
         }
     }
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1464,6 +1464,7 @@ void GCS_MAVLINK_InProgress::check_tasks()
             const AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
             switch (airspeed->get_calibration_state()) {
             case AP_Airspeed::CalibrationState::NOT_STARTED:
+            case AP_Airspeed::CalibrationState::NOT_REQUIRED_ZERO_OFFSET:
                 // we shouldn't get here
                 task.conclude(MAV_RESULT_FAILED);
                 break;


### PR DESCRIPTION
Some re-structuring `set_use_zero_offset` now sets the calibration state rather than using a separate bool. If set it will also force return 0.0 in the `get_offset` function. 

Setting skip-cal no longer allows a 0 offset to be healthy. The only way for 0 to be allowed is if the calibration state is the new `NOT_REQUIRED_ZERO_OFFSET`.

Arming checks are moved down to AP_Airspeed and made more verbose.

A new option is added to the skip cal parameter to skip the startup calibration but still require a manual calibration. This can be useful in some operations, especially if heated pitots need some time to warm up. The new arming checks mean you will not be allowed to arm in this case until a manual calibration has been done.