### PR TITLE
AP_Peript: correct function name for detected protocol name

### DIFF
--- a/Tools/AP_Periph/rc_in.cpp
+++ b/Tools/AP_Periph/rc_in.cpp
@@ -114,7 +114,7 @@ void AP_Periph_FW::rcin_update()
     }
 
     // log discovered protocols:
-    auto new_rc_protocol = rc.protocol_name();
+    auto new_rc_protocol = rc.detected_protocol_name();
     if (new_rc_protocol != rcin_rc_protocol) {
         can_printf("Decoding (%s)", new_rc_protocol);
         rcin_rc_protocol = new_rc_protocol;


### PR DESCRIPTION
```
 ../../Tools/AP_Periph/rc_in.cpp: In member function 'void AP_Periph_FW::rcin_update()':
../../Tools/AP_Periph/rc_in.cpp:117:31: error: 'class AP_RCProtocol' has no member named 'protocol_name'; did you mean 'protocol_enabled'?
  117 |     auto new_rc_protocol = rc.protocol_name();
      |                               ^~~~~~~~~~~~~
      |                               protocol_enabled
compilation terminated due to -Wfatal-errors.
```