### PR TITLE
AP_Filesystem: LittleFS: fix and clean up flash driver

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_FlashMemory_LittleFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_FlashMemory_LittleFS.cpp
@@ -1059,8 +1059,6 @@ int AP_Filesystem_FlashMemory_LittleFS::_flashmem_read(
             WITH_SEMAPHORE(dev_sem);
             send_command_addr(JEDEC_PAGE_DATA_READ, address / fs_cfg.read_size);
         }
-        // position address within the internal buffer for the actual read
-        address %= fs_cfg.read_size;
 #endif
         if (!wait_until_device_is_ready()) {
             return LFS_ERR_IO;
@@ -1069,7 +1067,12 @@ int AP_Filesystem_FlashMemory_LittleFS::_flashmem_read(
         WITH_SEMAPHORE(dev_sem);
 
         dev->set_chip_select(true);
+#if AP_FILESYSTEM_LITTLEFS_FLASH_TYPE == AP_FILESYSTEM_FLASH_W25NXX
+        // position address within the internal buffer for the actual read
+        send_command_addr(JEDEC_READ_DATA, address % fs_cfg.read_size);
+#else
         send_command_addr(JEDEC_READ_DATA, address);
+#endif
         dev->transfer(nullptr, 0, static_cast<uint8_t*>(buffer)+read_off, size);
         dev->set_chip_select(false);
 

--- a/libraries/AP_Filesystem/AP_Filesystem_FlashMemory_LittleFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_FlashMemory_LittleFS.cpp
@@ -1040,10 +1040,6 @@ int AP_Filesystem_FlashMemory_LittleFS::_flashmem_read(
     uint32_t address;
     lfs_off_t read_off = 0;
 
-    if (dead) {
-        return LFS_ERR_IO;
-    }
-
     address = lfs_block_and_offset_to_raw_flash_address(block, off);
 
     EXPECT_DELAY_MS((25*size)/(fs_cfg.read_size*1000));
@@ -1090,10 +1086,6 @@ int AP_Filesystem_FlashMemory_LittleFS::_flashmem_prog(
 ) {
     uint32_t address;
     lfs_off_t prog_off = 0;
-
-    if (dead) {
-        return LFS_ERR_IO;
-    }
 
     EXPECT_DELAY_MS((250*size)/(fs_cfg.read_size*1000));
 
@@ -1142,10 +1134,6 @@ int AP_Filesystem_FlashMemory_LittleFS::_flashmem_prog(
 }
 
 int AP_Filesystem_FlashMemory_LittleFS::_flashmem_erase(lfs_block_t block) {
-    if (dead) {
-        return LFS_ERR_IO;
-    }
-
     for (lfs_off_t fblock = 0; fblock < LFS_FLASH_BLOCKS_PER_BLOCK; fblock++) {
 
         if (!write_enable()) {

--- a/libraries/AP_Filesystem/AP_Filesystem_FlashMemory_LittleFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_FlashMemory_LittleFS.cpp
@@ -998,11 +998,12 @@ bool AP_Filesystem_FlashMemory_LittleFS::write_enable()
 
 bool AP_Filesystem_FlashMemory_LittleFS::init_flash()
 {
-#if AP_FILESYSTEM_LITTLEFS_FLASH_TYPE == AP_FILESYSTEM_FLASH_W25NXX
-    // reset the device
     if (!wait_until_device_is_ready()) {
         return false;
     }
+
+#if AP_FILESYSTEM_LITTLEFS_FLASH_TYPE == AP_FILESYSTEM_FLASH_W25NXX
+    // reset the device
     {
         WITH_SEMAPHORE(dev_sem);
         uint8_t b = JEDEC_DEVICE_RESET;

--- a/libraries/AP_Filesystem/AP_Filesystem_FlashMemory_LittleFS.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_FlashMemory_LittleFS.h
@@ -69,8 +69,6 @@ private:
 
     // The configuration of the filesystem
     struct lfs_config fs_cfg;
-    lfs_size_t flash_block_size;
-    lfs_size_t flash_block_count;
 
     // Maximum number of files that may be open at the same time
     static constexpr int MAX_OPEN_FILES = 16;
@@ -107,8 +105,6 @@ private:
     void free_all_fds();
     FileDescriptor* lfs_file_from_fd(int fd) const;
 
-    uint32_t lfs_block_and_offset_to_raw_flash_address(lfs_block_t block, lfs_off_t off = 0, lfs_off_t flash_block = 0);
-    uint32_t lfs_block_to_raw_flash_page_index(lfs_block_t block, lfs_off_t flash_block = 0);
     uint32_t find_block_size_and_count();
     bool init_flash() WARN_IF_UNUSED;
     bool write_enable() WARN_IF_UNUSED;


### PR DESCRIPTION
Fixes a couple potential bugs and cleans up unused functionality to save a bit of flash.

Tested on KakuteH7Mini and KakuteH7Mini-Nand that logging and scripting still work properly.