### PR TITLE
HAL: Add logging of dropped incoming serial data 

### DIFF
--- a/libraries/AP_HAL/LogStructure.h
+++ b/libraries/AP_HAL/LogStructure.h
@@ -11,19 +11,21 @@
 // @Field: TimeUS: Time since system startup
 // @Field: I: instance
 // @Field: Tx: transmitted data rate bytes per second
-// @Field: Rx: received data rate bytes per second
+// @Field: Rx: received data rate bytes per second, this is all incoming data, it may not all be processed by the driver using this port.
+// @Field: RxDp: Data rate of dropped received bytes, ideally should be 0. This is the difference between the received data rate and the processed data rate.
 struct PACKED log_UART {
     LOG_PACKET_HEADER;
     uint64_t time_us;
     uint8_t instance;
     float tx_rate;
     float rx_rate;
+    float rx_drop_rate;
 };
 
 #if HAL_UART_STATS_ENABLED
 #define LOG_STRUCTURE_FROM_HAL                          \
     { LOG_UART_MSG, sizeof(log_UART),                   \
-      "UART","QBff","TimeUS,I,Tx,Rx", "s#BB", "F---" },
+      "UART","QBfff","TimeUS,I,Tx,Rx,RxDp", "s#BBB", "F----" },
 #else
 #define LOG_STRUCTURE_FROM_HAL
 #endif

--- a/libraries/AP_HAL/UARTDriver.cpp
+++ b/libraries/AP_HAL/UARTDriver.cpp
@@ -211,6 +211,7 @@ void AP_HAL::UARTDriver::log_stats(const uint8_t inst, StatsTracker &stats, cons
     // Update tracking
     const uint32_t tx_bytes = stats.tx.update(total_tx_bytes);
     const uint32_t rx_bytes = stats.rx.update(total_rx_bytes);
+    const uint32_t rx_dropped_bytes = stats.rx_dropped.update(get_total_dropped_rx_bytes());
 
     // Assemble struct and log
     struct log_UART pkt {
@@ -219,6 +220,7 @@ void AP_HAL::UARTDriver::log_stats(const uint8_t inst, StatsTracker &stats, cons
         instance : inst,
         tx_rate  : float((tx_bytes * 1000) / dt_ms),
         rx_rate  : float((rx_bytes * 1000) / dt_ms),
+        rx_drop_rate : float((rx_dropped_bytes * 1000) / dt_ms),
     };
     AP::logger().WriteBlock(&pkt, sizeof(pkt));
 }

--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -171,6 +171,7 @@ public:
         };
         ByteTracker tx;
         ByteTracker rx;
+        ByteTracker rx_dropped;
     };
 
     // request information on uart I/O for this uart, for @SYS/uarts.txt
@@ -259,6 +260,7 @@ protected:
     // Getters for cumulative tx and rx counts
     virtual uint32_t get_total_tx_bytes() const { return 0; }
     virtual uint32_t get_total_rx_bytes() const { return 0; }
+    virtual uint32_t get_total_dropped_rx_bytes() const { return 0; }
 #endif
 
 private:

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -217,6 +217,7 @@ private:
     // statistics
     uint32_t _tx_stats_bytes;
     uint32_t _rx_stats_bytes;
+    uint32_t _rx_stats_dropped_bytes;
 
     // we remember config options from set_options to apply on sdStart()
     uint32_t _cr1_options;
@@ -287,6 +288,7 @@ protected:
     // Getters for cumulative tx and rx counts
     uint32_t get_total_tx_bytes() const override { return _tx_stats_bytes; }
     uint32_t get_total_rx_bytes() const override { return _rx_stats_bytes; }
+    uint32_t get_total_dropped_rx_bytes() const override { return _rx_stats_dropped_bytes; }
 #if CH_CFG_USE_EVENTS == TRUE
     uint32_t _rx_stats_framing_errors;
     uint32_t _rx_stats_overrun_errors;


### PR DESCRIPTION
This adds tracking and logging of dropped incoming data. This is data that we received but could not fit in the receive buffer. This would make tracking down issues such as this one much easier. https://github.com/ArduPilot/ardupilot/pull/29414

We currently log the incoming data rate, but that may not all fit in the read buffer. In that case we will start to see some dropped packets. 

We could do the same with TX bytes, but its not so clear cut, the write call returns the length written, so the individual driver may not loose data, it can retry later. 

UART logging is only 1Hz, so this adds another float, we could add a uint8 flags and just set a bit if any data is lost since the last call.

Currently this is only ChibiOS. SITL is harder because it would need to be worked out for each individual connection type. 

This is a test of a serial port loopback with nothing reading. UART1 Tx into UART2 Rx. Tx rate always matches RX rate. About half way through the serial buffer becomes full and the drop rate then increaes to match the Rx rate, so all incoming data is lost. 

![image](https://github.com/user-attachments/assets/3bc1c2e7-d68b-4a22-8d49-71ced7e7bc83)
