### PR TITLE
AP_Motors: MOT_THST_HOVER param desc min/max fixed

### DIFF
--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -133,7 +133,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @Param: THST_HOVER
     // @DisplayName: Thrust Hover Value
     // @Description: Motor thrust needed to hover expressed as a number from 0 to 1
-    // @Range: 0.2 0.8
+    // @Range: 0.125 0.6875
     // @User: Advanced
     AP_GROUPINFO("THST_HOVER", 21, AP_MotorsMulticopter, _throttle_hover, AP_MOTORS_THST_HOVER_DEFAULT),
 


### PR DESCRIPTION
This updates the MOT_THST_HOVER parameter descriptions to match the actual limits enforced in the code ([see here](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Motors/AP_MotorsMulticopter.h#L12))

This inconsistency came up in [this discussion during 4.6 beta testing](https://discuss.ardupilot.org/t/copter-4-6-0-beta4-released-for-beta-testing/130471/54)

This change has been tested by running, "./Tools/autotest/autotest.py build.Copter test.Copter.Parameters" and reviewing the output of the "buildlogs/apm.pdef.xml" file before and after.

**BEFORE**
```
      <param humanName="Thrust Hover Value" name="MOT_THST_HOVER" documentation="Motor thrust needed to hover expressed as a number from 0 to 1" user="Advanced">
        <field name="Range">0.2 0.8</field>
      </param>
```

**AFTER**
```
      <param humanName="Thrust Hover Value" name="MOT_THST_HOVER" documentation="Motor thrust needed to hover expressed as a number from 0 to 1" user="Advanced">
        <field name="Range">0.125 0.6875</field>
      </param>
```