### PR TITLE
Tools: size_compare_branches.py: do not try to compile bl for CubeRedSecondary-IO

### DIFF
--- a/Tools/scripts/size_compare_branches.py
+++ b/Tools/scripts/size_compare_branches.py
@@ -139,6 +139,7 @@ class SizeCompareBranches(object):
         self.bootloader_blacklist = set([
             'CubeOrange-SimOnHardWare',
             'CubeOrangePlus-SimOnHardWare',
+            'CubeRedSecondary-IO',
             'fmuv2',
             'fmuv3-bdshot',
             'iomcu',


### PR DESCRIPTION
.... we don't compile bootloader for the IOMCU at this point