### PR TITLE
DroneCAN, Networking: Log virtual UART data rates.

### DIFF
--- a/libraries/AP_DroneCAN/AP_DroneCAN_serial.h
+++ b/libraries/AP_DroneCAN/AP_DroneCAN_serial.h
@@ -58,7 +58,21 @@ public:
         uint32_t last_size_rx;
         uint64_t last_recv_us;
 
+        // statistics
+        uint32_t tx_stats_bytes;
+        uint32_t rx_stats_bytes;
+        uint32_t rx_stats_dropped_bytes;
+
         HAL_Semaphore sem;
+
+    protected:
+
+#if HAL_UART_STATS_ENABLED
+        // Getters for cumulative tx and rx counts
+        uint32_t get_total_tx_bytes() const override { return tx_stats_bytes; }
+        uint32_t get_total_rx_bytes() const override { return rx_stats_bytes; }
+        uint32_t get_total_dropped_rx_bytes() const override { return rx_stats_dropped_bytes; }
+#endif
     };
 
     Port ports[AP_DRONECAN_SERIAL_NUM_PORTS];

--- a/libraries/AP_Networking/AP_Networking.h
+++ b/libraries/AP_Networking/AP_Networking.h
@@ -287,7 +287,19 @@ private:
         bool have_received;
         bool close_on_recv_error;
         uint32_t last_udp_srv_recv_time_ms;
+
+        // statistics
+        uint32_t tx_stats_bytes;
+        uint32_t rx_stats_bytes;
+
         HAL_Semaphore sem;
+
+    protected:
+#if HAL_UART_STATS_ENABLED
+        // Getters for cumulative tx and rx counts
+        uint32_t get_total_tx_bytes() const override { return tx_stats_bytes; }
+        uint32_t get_total_rx_bytes() const override { return rx_stats_bytes; }
+#endif
     };
 #endif // AP_NETWORKING_REGISTER_PORT_ENABLED
 

--- a/libraries/AP_Networking/AP_Networking_port.cpp
+++ b/libraries/AP_Networking/AP_Networking_port.cpp
@@ -341,6 +341,11 @@ bool AP_Networking::Port::send_receive(void)
         if (ret > 0) {
             WITH_SEMAPHORE(sem);
             readbuffer->write(buf, ret);
+
+            // Cant track dropped read packets because we only read in what there is space for
+            // The socket buffer becomes full and data is lost there
+            rx_stats_bytes += ret;
+
             active = true;
             have_received = true;
         }
@@ -413,6 +418,7 @@ bool AP_Networking::Port::send_receive(void)
         if (ret > 0) {
             WITH_SEMAPHORE(sem);
             writebuffer->advance(ret);
+            tx_stats_bytes += ret;
             active = true;
         } else if (errno == ENOTCONN &&
             (type == NetworkPortType::TCP_CLIENT || type == NetworkPortType::TCP_SERVER)) {

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -866,6 +866,25 @@ void AP_SerialManager::register_port(RegisteredPort *port)
         }
     }
 }
+
+#if HAL_LOGGING_ENABLED && HAL_UART_STATS_ENABLED
+// Log UART message for each registered serial port
+void AP_SerialManager::registered_ports_log()
+{
+    // Calculate time since last call
+    const uint32_t now_ms = AP_HAL::millis();
+    const uint32_t dt_ms = now_ms - registered_ports_last_log_ms;
+    registered_ports_last_log_ms = now_ms;
+
+    WITH_SEMAPHORE(port_sem);
+
+    // Loop over ports
+    for (auto p = registered_ports; p; p = p->next) {
+        p->log_stats(p->state.idx, p->state.stats, dt_ms);
+    }
+}
+#endif
+
 #endif // AP_SERIALMANAGER_REGISTER_ENABLED
 
 namespace AP {

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -158,6 +158,10 @@ public:
 
         // serial index number
         uint8_t idx;
+
+#if HAL_LOGGING_ENABLED && HAL_UART_STATS_ENABLED
+        AP_HAL::UARTDriver::StatsTracker stats;
+#endif
     };
 
     // get a state from serial index
@@ -188,6 +192,12 @@ public:
 
     // register an externally managed port
     void register_port(RegisteredPort *port);
+
+#if HAL_LOGGING_ENABLED && HAL_UART_STATS_ENABLED
+    // Log UART message for each registered serial port
+    void registered_ports_log();
+    uint32_t registered_ports_last_log_ms;
+#endif
 
 #endif // AP_SERIALMANAGER_REGISTER_ENABLED
 

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -1078,8 +1078,12 @@ void AP_Vehicle::one_Hz_update(void)
     scripting.update();
 #endif
 
-#if HAL_LOGGING_ENABLED
+#if HAL_LOGGING_ENABLED && HAL_UART_STATS_ENABLED
+    // Log data rates of physical and virtual serial ports
     hal.util->uart_log();
+#if AP_SERIALMANAGER_REGISTER_ENABLED
+    serial_manager.registered_ports_log();
+#endif
 #endif
 
 }


### PR DESCRIPTION
Builds on https://github.com/ArduPilot/ardupilot/pull/29473 to allow logging of the data rates of virtual serial ports. https://github.com/ArduPilot/WebTools/pull/238 Adds support to the HardwareReport WebTool. That results in plots like this:

![image](https://github.com/user-attachments/assets/6636dc05-0519-44a9-be4b-4f17cc3b1846)

![image](https://github.com/user-attachments/assets/6fe3091a-f188-4507-b467-84d8355ffdb8)
