### PR TITLE
ardupilotwaf: require minimum Python 3.8

### DIFF
--- a/.github/workflows/cygwin_build.yml
+++ b/.github/workflows/cygwin_build.yml
@@ -160,7 +160,7 @@ jobs:
 
       - uses: cygwin/cygwin-install-action@v5
         with:
-          packages: cygwin64 gcc-g++=10.2.0-1 ccache python37 python37-future python37-lxml python37-pip python37-setuptools python37-wheel git procps gettext
+          packages: cygwin64 gcc-g++=10.2.0-1 ccache python39 python39-future python39-lxml python39-pip python39-setuptools python39-wheel git procps gettext
           add-to-path: false
       # Put ccache into github cache for faster build
       - name: setup ccache

--- a/Tools/environment_install/install-prereqs-windows-andAPMSource.ps1
+++ b/Tools/environment_install/install-prereqs-windows-andAPMSource.ps1
@@ -14,10 +14,10 @@ Write-Output "Downloading ARM GCC Compiler 10-2020-Q4-Major (3/8)"
 Start-BitsTransfer -Source "https://firmware.ardupilot.org/Tools/STM32-tools/gcc-arm-none-eabi-10-2020-q4-major-win32.exe" -Destination "$PSScriptRoot\gcc-arm-none-eabi-10-2020-q4-major-win32.exe"
 
 Write-Output "Installing Cygwin x64 (4/8)"
-Start-Process -wait -FilePath $PSScriptRoot\setup-x86_64.exe -ArgumentList "--root=C:\cygwin64 --no-startmenu --local-package-dir=$env:USERPROFILE\Downloads --site=http://cygwin.mirror.constant.com --packages autoconf,automake,ccache,cygwin32-gcc-g++,gcc-g++=7.4.0-1,libgcc1=7.4.0.1,gcc-core=7.4.0-1,git,libtool,make,gawk,libexpat-devel,libxml2-devel,python37,python37-future,python37-lxml,python37-pip,libxslt-devel,python37-devel,procps-ng,zip,gdb,ddd --quiet-mode"
+Start-Process -wait -FilePath $PSScriptRoot\setup-x86_64.exe -ArgumentList "--root=C:\cygwin64 --no-startmenu --local-package-dir=$env:USERPROFILE\Downloads --site=http://cygwin.mirror.constant.com --packages autoconf,automake,ccache,cygwin32-gcc-g++,gcc-g++=7.4.0-1,libgcc1=7.4.0.1,gcc-core=7.4.0-1,git,libtool,make,gawk,libexpat-devel,libxml2-devel,python39,python39-future,python39-lxml,python39-pip,libxslt-devel,python39-devel,procps-ng,zip,gdb,ddd --quiet-mode"
 
 Write-Output "Downloading extra Python packages (5/8)"
-Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'python3.7 -m pip install empy==3.3.4 pyserial pymavlink intelhex dronecan pexpect'"
+Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'python3.9 -m pip install empy==3.3.4 pyserial pymavlink intelhex dronecan pexpect'"
 
 Write-Output "Downloading APM source (6/8)"
 Copy-Item "APM_install.sh" -Destination "C:\cygwin64\home"

--- a/Tools/environment_install/install-prereqs-windows.ps1
+++ b/Tools/environment_install/install-prereqs-windows.ps1
@@ -14,10 +14,10 @@ Write-Output "Downloading ARM GCC Compiler 10-2020-Q4-Major (3/7)"
 Start-BitsTransfer -Source "https://firmware.ardupilot.org/Tools/STM32-tools/gcc-arm-none-eabi-10-2020-q4-major-win32.exe" -Destination "$PSScriptRoot\gcc-arm-none-eabi-10-2020-q4-major-win32.exe"
 
 Write-Output "Installing Cygwin x64 (4/7)"
-Start-Process -wait -FilePath $PSScriptRoot\setup-x86_64.exe -ArgumentList "--root=C:\cygwin64 --no-startmenu --local-package-dir=$env:USERPROFILE\Downloads --site=http://cygwin.mirror.constant.com --packages autoconf,automake,ccache,cygwin32-gcc-g++,gcc-g++=7.4.0-1,libgcc1=7.4.0.1,gcc-core=7.4.0-1,git,libtool,make,gawk,libexpat-devel,libxml2-devel,python37,python37-future,python37-lxml,python37-pip,libxslt-devel,python37-devel,procps-ng,zip,gdb,ddd,xterm --quiet-mode"
+Start-Process -wait -FilePath $PSScriptRoot\setup-x86_64.exe -ArgumentList "--root=C:\cygwin64 --no-startmenu --local-package-dir=$env:USERPROFILE\Downloads --site=http://cygwin.mirror.constant.com --packages autoconf,automake,ccache,cygwin32-gcc-g++,gcc-g++=7.4.0-1,libgcc1=7.4.0.1,gcc-core=7.4.0-1,git,libtool,make,gawk,libexpat-devel,libxml2-devel,python39,python39-future,python39-lxml,python39-pip,libxslt-devel,python39-devel,procps-ng,zip,gdb,ddd,xterm --quiet-mode"
 
 Write-Output "Downloading extra Python packages (5/7)"
-Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'python3.7 -m pip install empy==3.3.4 pyserial pymavlink intelhex dronecan pexpect'"
+Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'python3.9 -m pip install empy==3.3.4 pyserial pymavlink intelhex dronecan pexpect'"
 
 Write-Output "Installing ARM GCC Compiler 10-2020-Q4-Major (6/7)"
 & $PSScriptRoot\gcc-arm-none-eabi-10-2020-q4-major-win32.exe /S /P /R

--- a/wscript
+++ b/wscript
@@ -548,7 +548,7 @@ def configure(cfg):
 
     # require python 3.8.x or later
     cfg.load('python')
-    cfg.check_python_version(minver=(3,6,9))
+    cfg.check_python_version(minver=(3,8,0))
 
     cfg.load('ap_library')
 


### PR DESCRIPTION
Makes the comment honest.

Requires upgrading Cygwin to Python 3.9. Python 3.12 is available but it doesn't have all our packages. I think we will have to modernize a bit more.