### PR TITLE
Plane: Output rudder in VTOL modes

### DIFF
--- a/ArduPlane/mode_qautotune.cpp
+++ b/ArduPlane/mode_qautotune.cpp
@@ -35,6 +35,9 @@ void ModeQAutotune::run()
     // Stabilize with fixed wing surfaces
     plane.stabilize_roll();
     plane.stabilize_pitch();
+
+    // Center rudder
+    output_rudder_and_steering(0.0);
 }
 
 void ModeQAutotune::_exit()

--- a/ArduPlane/mode_qhover.cpp
+++ b/ArduPlane/mode_qhover.cpp
@@ -44,6 +44,9 @@ void ModeQHover::run()
     // Stabilize with fixed wing surfaces
     plane.stabilize_roll();
     plane.stabilize_pitch();
+
+    // Center rudder
+    output_rudder_and_steering(0.0);
 }
 
 #endif

--- a/ArduPlane/mode_qloiter.cpp
+++ b/ArduPlane/mode_qloiter.cpp
@@ -162,6 +162,9 @@ void ModeQLoiter::run()
     // Stabilize with fixed wing surfaces
     plane.stabilize_roll();
     plane.stabilize_pitch();
+
+    // Center rudder
+    output_rudder_and_steering(0.0);
 }
 
 #endif

--- a/ArduPlane/mode_qrtl.cpp
+++ b/ArduPlane/mode_qrtl.cpp
@@ -179,6 +179,7 @@ void ModeQRTL::run()
     // Stabilize with fixed wing surfaces
     plane.stabilize_roll();
     plane.stabilize_pitch();
+    plane.stabilize_yaw();
 }
 
 /*

--- a/ArduPlane/mode_qstabilize.cpp
+++ b/ArduPlane/mode_qstabilize.cpp
@@ -64,6 +64,9 @@ void ModeQStabilize::run()
     // Stabilize with fixed wing surfaces
     plane.stabilize_roll();
     plane.stabilize_pitch();
+
+    // Center rudder
+    output_rudder_and_steering(0.0);
 }
 
 // set the desired roll and pitch for a tailsitter


### PR DESCRIPTION
Currently rudder is not output at all in VTOL modes. This means it is stuck at whatever the output was when the mode was entered. For example full rudder due to stick mixing in guided then switch to QRTL, rudder output remains even after pilot stick is centered.

![image](https://github.com/user-attachments/assets/ccbb6264-a658-4d15-ae93-2a2a4cb28bb6)

This results in the vehicle crabbing all the way home.

![image](https://github.com/user-attachments/assets/b6afcd2a-3468-4507-a060-9099d08536d5)

With this PR the rudder it output as normal in QRTL. This includes the VTOL phases which is inline with what a nav land would do in AUTO.

![image](https://github.com/user-attachments/assets/65b8e4c7-e299-4b8a-91c0-48524b855ecc)

For the other VTOL modes the rudder is now held centered. Using coordinated turn value seems a bit nonsense when we could be moving backwards or sideways. 