### PR TITLE
Plane: fast attitude recovery for quadplanes

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -378,6 +378,10 @@ void Plane::stabilize_yaw()
         SRV_Channels::set_output_scaled(SRV_Channel::k_steering, steering_output);
     }
 
+#if HAL_QUADPLANE_ENABLED
+    // possibly recover from a spin
+    quadplane.assist.output_spin_recovery();
+#endif
 }
 
 /*

--- a/ArduPlane/VTOL_Assist.cpp
+++ b/ArduPlane/VTOL_Assist.cpp
@@ -158,16 +158,16 @@ bool VTOL_Assist::check_VTOL_recovery(void)
     // see if the attitude is outside twice the Q_ANGLE_MAX
     const auto &ahrs = plane.ahrs;
     const int16_t angle_max_cd = quadplane.aparm.angle_max;
-    if ((abs(ahrs.roll_sensor) > 2*angle_max_cd ||
-         abs(ahrs.pitch_sensor) > 2*angle_max_cd)) {
-            // we are 2x the angle limits trigger fw recovery
+    const float abs_angle_cd = fabsf(Vector2f{float(ahrs.roll_sensor), float(ahrs.pitch_sensor)}.length());
+
+    if (abs_angle_cd > 2*angle_max_cd) {
+        // we are 2x the angle limits, trigger fw recovery
         quadplane.force_fw_control_recovery = true;
     }
 
     if (quadplane.force_fw_control_recovery) {
         // stop fixed wing recovery if inside Q_ANGLE_MAX
-        if ((abs(ahrs.roll_sensor) <= angle_max_cd &&
-             abs(ahrs.pitch_sensor) <= angle_max_cd)) {
+        if (abs_angle_cd <= angle_max_cd) {
             quadplane.force_fw_control_recovery = false;
             quadplane.attitude_control->reset_target_and_rate(false);
 

--- a/ArduPlane/VTOL_Assist.h
+++ b/ArduPlane/VTOL_Assist.h
@@ -25,6 +25,19 @@ public:
     // Time hysteresis for triggering of assistance
     AP_Float delay;
 
+    // special options
+    AP_Int16 options;
+
+    // assist options
+    enum class OPTION {
+        FW_FORCE_DISABLED=(1U<<0),
+        SPIN_DISABLED=(1U<<1),
+    };
+    
+    bool option_is_set(OPTION option) const {
+        return (options.get() & int32_t(option)) != 0;
+    }
+    
     // State from pilot
     enum class STATE {
         ASSIST_DISABLED,
@@ -39,6 +52,12 @@ public:
     bool in_alt_assist() const { return alt_error.is_active(); }
     bool in_angle_assist() const { return angle_error.is_active(); }
 
+    // check if we are in VTOL recovery
+    bool check_VTOL_recovery(void);
+
+    // output rudder and elevator for spin recovery
+    void output_spin_recovery(void);
+    
 private:
 
     // Default to enabled

--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -156,6 +156,12 @@ bool Mode::enter()
             bool have_airspeed = quadplane.ahrs.airspeed_estimate(aspeed);
             quadplane.assisted_flight = quadplane.assist.should_assist(aspeed, have_airspeed);
         }
+
+        if (is_vtol_mode() && !quadplane.tailsitter.enabled()) {
+            // if flying inverted and entering a VTOL mode cancel
+            // inverted flight
+            plane.inverted_flight = false;
+        }
 #endif
     }
 

--- a/ArduPlane/mode_qhover.cpp
+++ b/ArduPlane/mode_qhover.cpp
@@ -24,6 +24,8 @@ void ModeQHover::update()
  */
 void ModeQHover::run()
 {
+    quadplane.assist.check_VTOL_recovery();
+
     const uint32_t now = AP_HAL::millis();
     if (quadplane.tailsitter.in_vtol_transition(now)) {
         // Tailsitters in FW pull up phase of VTOL transition run FW controllers
@@ -47,6 +49,9 @@ void ModeQHover::run()
 
     // Center rudder
     output_rudder_and_steering(0.0);
+
+    // possibly apply spin recovery
+    quadplane.assist.output_spin_recovery();
 }
 
 #endif

--- a/ArduPlane/mode_qloiter.cpp
+++ b/ArduPlane/mode_qloiter.cpp
@@ -32,6 +32,13 @@ void ModeQLoiter::update()
 // run quadplane loiter controller
 void ModeQLoiter::run()
 {
+    if (quadplane.assist.check_VTOL_recovery()) {
+        // use QHover to recover from extreme attitudes, this allows
+        // for the fixed wing controller to handle the recovery
+        plane.mode_qhover.run();
+        return;
+    }
+
     const uint32_t now = AP_HAL::millis();
 
 #if AC_PRECLAND_ENABLED

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -4244,14 +4244,25 @@ bool QuadPlane::use_fw_attitude_controllers(void) const
     if (available() &&
         motors->armed() &&
         motors->get_desired_spool_state() >= AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED &&
-        in_vtol_mode() &&
         !tailsitter.enabled() &&
         poscontrol.get_state() != QPOS_AIRBRAKE &&
         !force_fw_control_recovery) {
-        // we want the desired rates for fixed wing slaved to the
-        // multicopter rates
-        return false;
+
+        if (in_vtol_mode()) {
+            // in VTOL modes always slave fixed wing to VTOL rate control
+            return false;
+        }
+
+        if (transition->use_multirotor_control_in_fwd_transition()) {
+            /*
+              special case for vectored yaw tiltrotors in forward
+              transition, keep multicopter control until we reach
+              target transition airspeed. This condition needs to
+            */
+            return false;
+        }
     }
+
     return true;
 }
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -246,7 +246,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("ASSIST_OPTIONS", 47, QuadPlane, assist.options, 0),
     
-    // 47: TILT_TYPE
+    // 47: TILT_TYPE // was AP_Int8, re-used by AP_Int16 ASSIST_OPTIONS
     // 48: TAILSIT_ANGLE
     // 61: TAILSIT_ANG_VT
     // 49: TILT_RATE_DN

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -879,7 +879,8 @@ void QuadPlane::multicopter_attitude_rate_update(float yaw_rate_cds)
     bool use_yaw_target = false;
 
     float yaw_target_cd = 0.0;
-    if (!use_multicopter_control && transition->update_yaw_target(yaw_target_cd)) {
+    if (!use_multicopter_control && transition->update_yaw_target(yaw_target_cd) &&
+        !force_fw_control_recovery) {
         use_multicopter_control = true;
         use_yaw_target = true;
     }
@@ -4257,7 +4258,9 @@ bool QuadPlane::use_fw_attitude_controllers(void) const
             /*
               special case for vectored yaw tiltrotors in forward
               transition, keep multicopter control until we reach
-              target transition airspeed. This condition needs to
+              target transition airspeed. This can result in loss of
+              yaw control on some tilt-vectored airframes without
+              strong VTOL yaw control
             */
             return false;
         }

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -968,7 +968,7 @@ void QuadPlane::multicopter_attitude_rate_update(float yaw_rate_cds)
         // disable yaw time constant for 1:1 match of desired rates
         disable_yaw_rate_time_constant();
 
-        attitude_control->input_rate_bf_roll_pitch_yaw_2(bf_input_cd.x, bf_input_cd.y, bf_input_cd.z);
+        attitude_control->input_rate_bf_roll_pitch_yaw_no_shaping(bf_input_cd.x, bf_input_cd.y, bf_input_cd.z);
     }
 }
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1986,6 +1986,18 @@ void QuadPlane::motors_output(bool run_rate_controller)
                 // reset the attitude target to the new attitude so
                 // the VTOL controller doesn't pull us back
                 attitude_control->reset_target_and_rate(false);
+
+                if (plane.ahrs.groundspeed() > wp_nav->get_default_speed_xy()*0.01) {
+                    /* if moving at high speed also reset position
+                       controller and height controller
+
+                       this avoids an issue where the position
+                       controller may limit pitch after a strong
+                       acceleration event
+                    */
+                    pos_control->init_z_controller();
+                    pos_control->init_xy_controller();
+                }
             }
         }
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -238,6 +238,14 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("ASSIST_ANGLE", 45, QuadPlane, assist.angle, 30),
 
+    // @Param: ASSIST_OPTIONS
+    // @DisplayName: Quadplane assistance options
+    // @Description: Options for special QAssist features
+    // @Bitmask: 0: Disable force fixed wing controller recovery
+    // @Bitmask: 1: Disable quadplane spin recovery
+    // @User: Standard
+    AP_GROUPINFO("ASSIST_OPTIONS", 47, QuadPlane, assist.options, 0),
+    
     // 47: TILT_TYPE
     // 48: TAILSIT_ANGLE
     // 61: TAILSIT_ANG_VT
@@ -1955,51 +1963,10 @@ void QuadPlane::motors_output(bool run_rate_controller)
         if (now - last_att_control_ms > 100) {
             // relax if have been inactive
             relax_attitude_control();
-            /*
-              when starting the VTOL motors force use of the fixed
-              wing controller for attitude control if we are outside
-              of the Q_ANGLE_MAX limit. We keep it forced until we
-              have recovered to within the limit
-
-              This avoids an issue with the attitude controller
-              limiting the rate of recovery and also an issue with the
-              quaternion controller trying to fix the attitude in a
-              way that is bad for fixed wing aircraft (eg. putting
-              nose down when inverted, leading to rapid loss of
-              height)
-
-              we don't do this in QACRO or tailsitter modes, as this
-              type of attitude is expected
-            */
-            if (!tailsitter.enabled() &&
-                plane.control_mode != &plane.mode_qacro &&
-                (abs(ahrs.roll_sensor) > aparm.angle_max ||
-                 abs(ahrs.pitch_sensor) > aparm.angle_max)) {
-                force_fw_control_recovery = true;
-            }
         }
-        if (force_fw_control_recovery) {
-            // see if we have recovered attitude
-            if (abs(ahrs.roll_sensor) <= aparm.angle_max &&
-                abs(ahrs.pitch_sensor) <= aparm.angle_max) {
-                force_fw_control_recovery = false;
-                // reset the attitude target to the new attitude so
-                // the VTOL controller doesn't pull us back
-                attitude_control->reset_target_and_rate(false);
 
-                if (plane.ahrs.groundspeed() > wp_nav->get_default_speed_xy()*0.01) {
-                    /* if moving at high speed also reset position
-                       controller and height controller
-
-                       this avoids an issue where the position
-                       controller may limit pitch after a strong
-                       acceleration event
-                    */
-                    pos_control->init_z_controller();
-                    pos_control->init_xy_controller();
-                }
-            }
-        }
+        // see if we need to be in VTOL recovery
+        assist.check_VTOL_recovery();
 
         // run low level rate controllers that only require IMU data and set loop time
         const float last_loop_time_s = AP::scheduler().get_last_loop_time_s();
@@ -3661,6 +3628,7 @@ void QuadPlane::Log_Write_QControl_Tuning()
         alt                = 1U<<3, // true if assistance due to low altitude
         angle              = 1U<<4, // true if assistance due to attitude error
         fw_force           = 1U<<5, // true if forcing use of fixed wing controllers
+        spin_recovery      = 1U<<6, // true if recovering from a spin
     };
 
     uint8_t assist_flags = 0;
@@ -3681,6 +3649,9 @@ void QuadPlane::Log_Write_QControl_Tuning()
     }
     if (force_fw_control_recovery) {
         assist_flags |= (uint8_t)log_assistance_flags::fw_force;
+    }
+    if (in_spin_recovery) {
+        assist_flags |= (uint8_t)log_assistance_flags::spin_recovery;
     }
 
     struct log_QControl_Tuning pkt = {
@@ -4227,7 +4198,7 @@ bool QuadPlane::in_vtol_airbrake(void) const
 // return true if we should show VTOL view
 bool QuadPlane::show_vtol_view() const
 {
-    return available() && transition->show_vtol_view();
+    return available() && transition->show_vtol_view() && !force_fw_control_recovery;
 }
 
 // return true if we should show VTOL view
@@ -4661,6 +4632,9 @@ void QuadPlane::mode_enter(void)
 
     q_fwd_throttle = 0.0f;
     q_fwd_pitch_lim_cd = 100.0f * q_fwd_pitch_lim;
+
+    force_fw_control_recovery = false;
+    in_spin_recovery = false;
 }
 
 // Set attitude control yaw rate time constant to pilot input command model value

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -638,6 +638,9 @@ private:
     // should we force use of fixed wing controller for attitude upset recovery?
     bool force_fw_control_recovery;
 
+    // are we in spin recovery?
+    bool in_spin_recovery;
+
     /*
       return true if current mission item is a vtol takeoff
      */

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -635,6 +635,9 @@ private:
     // ignored unless OPTION_DELAY_ARMING or OPTION_TILT_DISARMED is set
     bool delay_arming;
 
+    // should we force use of fixed wing controller for attitude upset recovery?
+    bool force_fw_control_recovery;
+
     /*
       return true if current mission item is a vtol takeoff
      */

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -562,6 +562,9 @@ bool Tailsitter::transition_vtol_complete(void) const
     const float trans_angle = get_transition_angle_vtol();
     if (labs(plane.ahrs.pitch_sensor) > trans_angle*100) {
         gcs().send_text(MAV_SEVERITY_INFO, "Transition VTOL done");
+        // clear inverted flight flag to make behaviour consistent
+        // with other quadplane types
+        plane.inverted_flight = false;
         return true;
     }
     int32_t roll_cd = labs(plane.ahrs.roll_sensor);

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -562,9 +562,6 @@ bool Tailsitter::transition_vtol_complete(void) const
     const float trans_angle = get_transition_angle_vtol();
     if (labs(plane.ahrs.pitch_sensor) > trans_angle*100) {
         gcs().send_text(MAV_SEVERITY_INFO, "Transition VTOL done");
-        // clear inverted flight flag to make behaviour consistent
-        // with other quadplane types
-        plane.inverted_flight = false;
         return true;
     }
     int32_t roll_cd = labs(plane.ahrs.roll_sensor);
@@ -905,6 +902,10 @@ void Tailsitter_Transition::VTOL_update()
             vtol_limit_start_ms = now;
             vtol_limit_initial_pitch = quadplane.ahrs_view->pitch_sensor;
         }
+
+        // clear inverted flight flag to make behaviour consistent
+        // with other quadplane types
+        plane.inverted_flight = false;
     } else {
         // Keep assistance reset while not checking
         quadplane.assist.reset();

--- a/ArduPlane/tiltrotor.cpp
+++ b/ArduPlane/tiltrotor.cpp
@@ -742,10 +742,18 @@ void Tiltrotor::update_yaw_target(void)
     transition_yaw_set_ms = now;
 }
 
+
+/*
+  control use of multirotor rate control in forward transition
+ */
+bool Tiltrotor_Transition::use_multirotor_control_in_fwd_transition() const
+{
+    return tiltrotor.is_vectored() && transition_state <= TRANSITION_TIMER;
+}
+
 bool Tiltrotor_Transition::update_yaw_target(float& yaw_target_cd)
 {
-    if (!(tiltrotor.is_vectored() &&
-        transition_state <= TRANSITION_TIMER)) {
+    if (!use_multirotor_control_in_fwd_transition()) {
         return false;
     }
     tiltrotor.update_yaw_target();

--- a/ArduPlane/tiltrotor.h
+++ b/ArduPlane/tiltrotor.h
@@ -143,6 +143,8 @@ public:
 
     bool show_vtol_view() const override;
 
+    bool use_multirotor_control_in_fwd_transition() const override;
+
 private:
 
     Tiltrotor& tiltrotor;

--- a/ArduPlane/transition.h
+++ b/ArduPlane/transition.h
@@ -58,6 +58,8 @@ public:
 
     virtual bool allow_stick_mixing() const { return true; }
 
+    virtual bool use_multirotor_control_in_fwd_transition() const { return false; }
+
 protected:
 
     // refences for convenience

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -2301,6 +2301,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         '''test QLOITER recovery from bad attitude'''
         self.context_push()
         self.install_example_script_context("sim_arming_pos.lua")
+        self.install_terrain_handlers_context()
 
         self.set_parameters({
             "SCR_ENABLE": 1,
@@ -2317,7 +2318,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.set_parameters({
             "SIM_APOS_ENABLE" : 1,
             "SIM_APOS_PIT" : -70,
-            "SIM_APOS_POS_D" : -300,
+            "SIM_APOS_POS_D" : -200,
             "SIM_APOS_POS_E" : 400,
             "SIM_APOS_POS_N" : 200,
             "SIM_APOS_RLL" : 150,
@@ -2338,13 +2339,154 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         # try to climb once in QLOITER
         self.set_rc(3, 2000)
 
-        NTESTS=20
+        # don't start QAssist, let QLOITER do the recovery
+        self.set_parameter("Q_ASSIST_SPEED", 0)
+
+        NTESTS = 20
         for t in range(NTESTS):
             self.change_mode("FBWA")
             self.delay_sim_time(3)
-            self.progress("Recovery test %u" % t)
+            self.progress("Fast Recovery test %u" % t)
             self.arm_vehicle(force=True)
             self.wait_groundspeed(0, 2, timeout=15)
+            final_alt = self.assert_receive_message('TERRAIN_REPORT').current_height
+            if final_alt < 100:
+                raise NotAchievedException(f"Final alt {final_alt:.1f}")
+
+            self.disarm_vehicle(force=True)
+
+        self.progress("Setup for inverted slow recovery")
+        self.set_parameters({
+            "SIM_APOS_ENABLE" : 1,
+            "SIM_APOS_PIT" : 0,
+            "SIM_APOS_POS_D" : -200,
+            "SIM_APOS_POS_E" : 400,
+            "SIM_APOS_POS_N" : 200,
+            "SIM_APOS_RLL" : 180,
+            "SIM_APOS_VEL_X" : 0.0,
+            "SIM_APOS_VEL_Y" : 0.0,
+            "SIM_APOS_VEL_Z" : 0.0,
+            "SIM_APOS_GX" : 0,
+            "SIM_APOS_GY" : 0,
+            "SIM_APOS_GZ" : 0,
+            "SIM_APOS_MODE" : 19, # QLOITER
+            })
+
+        for t in range(NTESTS):
+            self.change_mode("FBWA")
+            self.delay_sim_time(3)
+            self.progress("Slow Recovery test %u" % t)
+            self.arm_vehicle(force=True)
+            self.wait_attitude(desroll=0, despitch=0, timeout=10, tolerance=5)
+            self.wait_groundspeed(0, 2, timeout=10)
+            final_alt = self.assert_receive_message('TERRAIN_REPORT').current_height
+            if final_alt < 100:
+                raise NotAchievedException(f"Final alt {final_alt:.1f}")
+            self.disarm_vehicle(force=True)
+
+        self.set_parameter("SIM_APOS_ENABLE", 0)
+        self.arm_vehicle(force=True)
+        self.change_mode("QLAND")
+        self.wait_disarmed(timeout=300) # give quadplane a long time to land
+        self.context_pop()
+
+    def CruiseRecovery(self):
+        '''test QAssist recovery in CRUISE mode from bad attitude'''
+        self.context_push()
+        self.install_example_script_context("sim_arming_pos.lua")
+        self.install_terrain_handlers_context()
+
+        self.set_parameters({
+            "SCR_ENABLE": 1,
+            "AHRS_EKF_TYPE": 10,
+            "EK3_ENABLE": 0,
+            "LOG_DISARMED": 1,
+            "Q_LAND_FINAL_SPD" : 2,
+            "HOME_RESET_ALT" : -1,
+        })
+
+        self.reboot_sitl(check_position=True)
+
+        self.context_collect('STATUSTEXT')
+        self.set_parameters({
+            "SIM_APOS_ENABLE" : 1,
+            "SIM_APOS_PIT" : -70,
+            "SIM_APOS_POS_D" : -200,
+            "SIM_APOS_POS_E" : 400,
+            "SIM_APOS_POS_N" : 200,
+            "SIM_APOS_RLL" : 150,
+            "SIM_APOS_VEL_X" : 40.0,
+            "SIM_APOS_VEL_Y" : 0.0,
+            "SIM_APOS_VEL_Z" : 0.0,
+            "SIM_APOS_YAW" : 250,
+            "SIM_APOS_GX" : 0,
+            "SIM_APOS_GY" : 0,
+            "SIM_APOS_GZ" : 0,
+            "SIM_APOS_MODE" : 7, # CRUISE
+            })
+
+        self.scripting_restart()
+        self.wait_text("Loaded arm pose", check_context=True)
+        self.wait_ready_to_arm()
+
+        # set cruise target airspeed
+        self.set_rc(3, 1500)
+
+        target_airspeed = self.get_parameter("AIRSPEED_CRUISE")
+
+        NTESTS = 20
+        for t in range(NTESTS):
+            self.change_mode("FBWA")
+            self.delay_sim_time(3)
+            self.progress("Fast CRUISE Recovery test %u" % t)
+            self.arm_vehicle(force=True)
+            self.delay_sim_time(3)
+            # reset target alt and heading using stick inputs
+            self.set_rc(2, 1600)
+            self.set_rc(2, 1500)
+            self.set_rc(1, 1600)
+            self.set_rc(1, 1500)
+            self.wait_attitude(desroll=0, despitch=0, timeout=10, tolerance=10)
+            self.wait_airspeed(target_airspeed-1, target_airspeed+1)
+            final_alt = self.assert_receive_message('TERRAIN_REPORT').current_height
+            if final_alt < 100:
+                raise NotAchievedException(f"Final alt {final_alt:.1f}")
+
+            self.disarm_vehicle(force=True)
+
+        self.progress("Setup for inverted slow recovery")
+        self.set_parameters({
+            "SIM_APOS_ENABLE" : 1,
+            "SIM_APOS_PIT" : 0,
+            "SIM_APOS_POS_D" : -200,
+            "SIM_APOS_POS_E" : 400,
+            "SIM_APOS_POS_N" : 200,
+            "SIM_APOS_RLL" : 180,
+            "SIM_APOS_VEL_X" : 0.0,
+            "SIM_APOS_VEL_Y" : 0.0,
+            "SIM_APOS_VEL_Z" : 0.0,
+            "SIM_APOS_GX" : 0,
+            "SIM_APOS_GY" : 0,
+            "SIM_APOS_GZ" : 0,
+            "SIM_APOS_MODE" : 7, # CRUISE
+            })
+
+        for t in range(NTESTS):
+            self.change_mode("FBWA")
+            self.delay_sim_time(3)
+            self.progress("Slow CRUISE Recovery test %u" % t)
+            self.arm_vehicle(force=True)
+            self.delay_sim_time(3)
+            # reset target alt and heading using stick inputs
+            self.set_rc(2, 1600)
+            self.set_rc(2, 1500)
+            self.set_rc(1, 1600)
+            self.set_rc(1, 1500)
+            self.wait_attitude(desroll=0, despitch=0, timeout=10, tolerance=10)
+            self.wait_airspeed(target_airspeed-1, target_airspeed+1)
+            final_alt = self.assert_receive_message('TERRAIN_REPORT').current_height
+            if final_alt < 100:
+                raise NotAchievedException(f"Final alt {final_alt:.1f}")
             self.disarm_vehicle(force=True)
 
         self.set_parameter("SIM_APOS_ENABLE", 0)
@@ -2448,5 +2590,6 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.DoRepositionTerrain,
             self.QLoiterRecovery,
             self.FastInvertedRecovery,
+            self.CruiseRecovery,
         ])
         return ret

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -2349,6 +2349,46 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.wait_disarmed(timeout=120) # give quadplane a long time to land
         self.context_pop()
 
+    def FastInvertedRecovery(self):
+        '''test recovery from inverted flight is fast'''
+
+        self.set_parameters({
+            "Q_A_ACCEL_R_MAX": 20000,
+            "Q_A_ACCEL_P_MAX": 20000,
+            "Q_A_ACCEL_Y_MAX": 20000,
+            "Q_A_RATE_R_MAX": 50,
+            "Q_A_RATE_P_MAX": 50,
+            "Q_A_RATE_Y_MAX": 50,
+        })
+
+        self.wait_ready_to_arm()
+        self.takeoff(60, mode='GUIDED', timeout=100)
+
+        self.context_collect('STATUSTEXT')
+        self.set_rc(3, 1500)
+        self.change_mode('CRUISE')
+        self.wait_statustext("Transition done", check_context=True)
+
+        self.progress("Go to inverted flight")
+        self.run_auxfunc(43, 2)
+        self.wait_roll(180, 3, absolute_value=True)
+        self.delay_sim_time(10)
+
+        initial_altitude = self.get_altitude(relative=True, timeout=2)
+        self.change_mode('QHOVER')
+
+        self.wait_roll(0, 3, absolute_value=True)
+
+        recovery_altitude = self.get_altitude(relative=True, timeout=2)
+        alt_change = initial_altitude - recovery_altitude
+
+        self.progress("Recovery AltChange %.1fm" % alt_change)
+
+        max_alt_change = 3
+        if alt_change > max_alt_change:
+            raise NotAchievedException("Recovery AltChange too high %.1f > %.1f" % (alt_change, max_alt_change))
+        self.fly_home_land_and_disarm()
+
     def tests(self):
         '''return list of all tests'''
 
@@ -2403,5 +2443,6 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.AHRSFlyForwardFlag,
             self.DoRepositionTerrain,
             self.QLoiterRecovery,
+            self.FastInvertedRecovery,
         ])
         return ret

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -2306,15 +2306,18 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             "SCR_ENABLE": 1,
             "AHRS_EKF_TYPE": 10,
             "EK3_ENABLE": 0,
+            "LOG_DISARMED": 1,
+            "Q_LAND_FINAL_SPD" : 2,
+            "HOME_RESET_ALT" : -1,
         })
 
-        self.reboot_sitl(check_position=False)
+        self.reboot_sitl(check_position=True)
 
         self.context_collect('STATUSTEXT')
         self.set_parameters({
             "SIM_APOS_ENABLE" : 1,
             "SIM_APOS_PIT" : -70,
-            "SIM_APOS_POS_D" : -1000,
+            "SIM_APOS_POS_D" : -300,
             "SIM_APOS_POS_E" : 400,
             "SIM_APOS_POS_N" : 200,
             "SIM_APOS_RLL" : 150,
@@ -2338,6 +2341,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         NTESTS=20
         for t in range(NTESTS):
             self.change_mode("FBWA")
+            self.delay_sim_time(3)
             self.progress("Recovery test %u" % t)
             self.arm_vehicle(force=True)
             self.wait_groundspeed(0, 2, timeout=15)
@@ -2346,7 +2350,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.set_parameter("SIM_APOS_ENABLE", 0)
         self.arm_vehicle(force=True)
         self.change_mode("QLAND")
-        self.wait_disarmed(timeout=120) # give quadplane a long time to land
+        self.wait_disarmed(timeout=300) # give quadplane a long time to land
         self.context_pop()
 
     def FastInvertedRecovery(self):

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -2297,6 +2297,58 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.change_mode("QLAND")
         self.mav.motors_disarmed_wait()
 
+    def QLoiterRecovery(self):
+        '''test QLOITER recovery from bad attitude'''
+        self.context_push()
+        self.install_example_script_context("sim_arming_pos.lua")
+
+        self.set_parameters({
+            "SCR_ENABLE": 1,
+            "AHRS_EKF_TYPE": 10,
+            "EK3_ENABLE": 0,
+        })
+
+        self.reboot_sitl(check_position=False)
+
+        self.context_collect('STATUSTEXT')
+        self.set_parameters({
+            "SIM_APOS_ENABLE" : 1,
+            "SIM_APOS_PIT" : -70,
+            "SIM_APOS_POS_D" : -1000,
+            "SIM_APOS_POS_E" : 400,
+            "SIM_APOS_POS_N" : 200,
+            "SIM_APOS_RLL" : 150,
+            "SIM_APOS_VEL_X" : 40.0,
+            "SIM_APOS_VEL_Y" : 0.0,
+            "SIM_APOS_VEL_Z" : 0.0,
+            "SIM_APOS_YAW" : 250,
+            "SIM_APOS_GX" : 0,
+            "SIM_APOS_GY" : 0,
+            "SIM_APOS_GZ" : 0,
+            "SIM_APOS_MODE" : 19, # QLOITER
+            })
+
+        self.scripting_restart()
+        self.wait_text("Loaded arm pose", check_context=True)
+        self.wait_ready_to_arm()
+
+        # try to climb once in QLOITER
+        self.set_rc(3, 2000)
+
+        NTESTS=20
+        for t in range(NTESTS):
+            self.change_mode("FBWA")
+            self.progress("Recovery test %u" % t)
+            self.arm_vehicle(force=True)
+            self.wait_groundspeed(0, 2, timeout=15)
+            self.disarm_vehicle(force=True)
+
+        self.set_parameter("SIM_APOS_ENABLE", 0)
+        self.arm_vehicle(force=True)
+        self.change_mode("QLAND")
+        self.wait_disarmed(timeout=120) # give quadplane a long time to land
+        self.context_pop()
+
     def tests(self):
         '''return list of all tests'''
 
@@ -2350,5 +2402,6 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.RTL_AUTOLAND_1_FROM_GUIDED,  # as in fly-home then go to landing sequence
             self.AHRSFlyForwardFlag,
             self.DoRepositionTerrain,
+            self.QLoiterRecovery,
         ])
         return ret

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -7384,12 +7384,14 @@ class TestSuite(ABC):
             **kwargs
         )
 
-    def wait_roll(self, roll, accuracy, timeout=30, **kwargs):
+    def wait_roll(self, roll, accuracy, timeout=30, absolute_value=False, **kwargs):
         """Wait for a given roll in degrees."""
         def get_roll(timeout2):
             msg = self.assert_receive_message('ATTITUDE', timeout=timeout2)
             p = math.degrees(msg.pitch)
             r = math.degrees(msg.roll)
+            if absolute_value:
+                r = abs(r)
             self.progress("Roll %d Pitch %d" % (r, p))
             return r
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -625,6 +625,33 @@ void AC_AttitudeControl::input_rate_bf_roll_pitch_yaw_3(float roll_rate_bf_cds, 
     _ang_vel_body = ang_vel_body;
 }
 
+/*
+  set the body frame target rates to the specified rates, used by the
+  quadplane code when we want to slave the VTOL controller rates to
+  the fixed wing rates
+ */
+void AC_AttitudeControl::input_rate_bf_roll_pitch_yaw_no_shaping(float roll_rate_bf_cds, float pitch_rate_bf_cds, float yaw_rate_bf_cds)
+{
+    // Convert from centidegrees on public interface to radians
+    const float roll_rate_rads = radians(roll_rate_bf_cds * 0.01f);
+    const float pitch_rate_rads = radians(pitch_rate_bf_cds * 0.01f);
+    const float yaw_rate_rads = radians(yaw_rate_bf_cds * 0.01f);
+
+    _ang_vel_target.x = roll_rate_rads;
+    _ang_vel_target.y = pitch_rate_rads;
+    _ang_vel_target.z = yaw_rate_rads;
+
+    // Update the unused targets attitude based on current attitude to condition mode change
+    _ahrs.get_quat_body_to_ned(_attitude_target);
+    _attitude_target.to_euler(_euler_angle_target);
+
+    // Convert body-frame angular velocity into euler angle derivative of desired attitude
+    ang_vel_to_euler_rate(_attitude_target, _ang_vel_target, _euler_rate_target);
+
+    // finally update the attitude target
+    _ang_vel_body = _ang_vel_target;
+}
+
 // Command an angular step (i.e change) in body frame angle
 // Used to command a step in angle without exciting the orthogonal axis during autotune
 void AC_AttitudeControl::input_angle_step_bf_roll_pitch_yaw(float roll_angle_step_bf_cd, float pitch_angle_step_bf_cd, float yaw_angle_step_bf_cd)

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -221,6 +221,11 @@ public:
     // Command an angular velocity with angular velocity smoothing using rate loops only with integrated rate error stabilization
     virtual void input_rate_bf_roll_pitch_yaw_3(float roll_rate_bf_cds, float pitch_rate_bf_cds, float yaw_rate_bf_cds);
 
+    // set the body frame target rates to the specified rates, used by the
+    // quadplane code when we want to slave the VTOL controller rates to
+    // the fixed wing rates
+    void input_rate_bf_roll_pitch_yaw_no_shaping(float roll_rate_bf_cds, float pitch_rate_bf_cds, float yaw_rate_bf_cds);
+
     // Command an angular step (i.e change) in body frame angle
     virtual void input_angle_step_bf_roll_pitch_yaw(float roll_angle_step_bf_cd, float pitch_angle_step_bf_cd, float yaw_angle_step_bf_cd);
 

--- a/libraries/APM_Control/AP_RollController.cpp
+++ b/libraries/APM_Control/AP_RollController.cpp
@@ -202,6 +202,24 @@ float AP_RollController::get_servo_out(int32_t angle_err, float scaler, bool dis
     angle_err_deg = angle_err * 0.01;
     float desired_rate = angle_err_deg/ gains.tau;
 
+    /*
+      prevent indecision in the roll controller when target roll is
+      close to 180 degrees from the current roll
+     */
+    const float indecision_threshold_deg = 160;
+    const float last_desired_rate = _pid_info.target;
+    const float abs_angle_err_deg = fabsf(angle_err_deg);
+    if (abs_angle_err_deg > indecision_threshold_deg &&
+        angle_err_deg <= 180) {
+        if (desired_rate * last_desired_rate < 0) {
+            desired_rate = -desired_rate;
+            // increase the desired rate in proportion to the extra
+            // angle we are requesting
+            const float new_angle_err_deg = abs_angle_err_deg + (180 - abs_angle_err_deg)*2;
+            desired_rate *= new_angle_err_deg / abs_angle_err_deg;
+        }
+    }
+
     // Limit the demanded roll rate
     if (gains.rmax_pos && desired_rate < -gains.rmax_pos) {
         desired_rate = - gains.rmax_pos;

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -4103,5 +4103,6 @@ sim = {}
 ---@param loc Location_ud
 ---@param orient Quaternion_ud
 ---@param velocity_bf Vector3f_ud -- body frame velocity
+---@param gyro_rads Vector3f_ud -- gyro body rate in rad/s
 ---@return boolean
-function sim:set_pose(instance, loc, orient, velocity_bf) end
+function sim:set_pose(instance, loc, orient, velocity_bf, gyro_rads) end

--- a/libraries/AP_Scripting/examples/sim_arming_pos.lua
+++ b/libraries/AP_Scripting/examples/sim_arming_pos.lua
@@ -24,7 +24,10 @@ local SIM_APOS_VEL_Z = bind_add_param('VEL_Z', 7, 0)
 local SIM_APOS_RLL = bind_add_param('RLL', 8, 0)
 local SIM_APOS_PIT = bind_add_param('PIT', 9, 0)
 local SIM_APOS_YAW = bind_add_param('YAW', 10, 0)
-local SIM_APOS_MODE = bind_add_param('MODE', 11, -1)
+local SIM_APOS_GX = bind_add_param('GX', 11, 0)
+local SIM_APOS_GY = bind_add_param('GY', 12, 0)
+local SIM_APOS_GZ = bind_add_param('GZ', 13, 0)
+local SIM_APOS_MODE = bind_add_param('MODE', 14, -1)
 
 local was_armed = false
 
@@ -53,7 +56,12 @@ local function update()
         loc:offset(SIM_APOS_POS_N:get(), SIM_APOS_POS_E:get())
         loc:alt(loc:alt() - SIM_APOS_POS_D:get()*100)
 
-        sim:set_pose(0, loc, quat, vel)
+        local gyro = Vector3f()
+        gyro:x(math.rad(SIM_APOS_GX:get()))
+        gyro:y(math.rad(SIM_APOS_GY:get()))
+        gyro:z(math.rad(SIM_APOS_GZ:get()))
+
+        sim:set_pose(0, loc, quat, vel, gyro)
 
         if SIM_APOS_MODE:get() >= 0 then
             vehicle:set_mode(SIM_APOS_MODE:get())

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -1072,5 +1072,6 @@ userdata AP_Servo_Telem::TelemetryData field last_update_ms uint32_t'skip_check 
 include SITL/SITL.h depends AP_SIM_ENABLED
 singleton SITL::SIM depends AP_SIM_ENABLED
 singleton SITL::SIM rename sim
-singleton SITL::SIM method set_pose boolean uint8_t'skip_check Location Quaternion Vector3f
+singleton SITL::SIM method set_pose boolean uint8_t'skip_check Location Quaternion Vector3f Vector3f
+
 

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -1372,7 +1372,7 @@ void Aircraft::update_eas_airspeed()
 /*
   set pose on the aircraft, called from scripting
  */
-bool Aircraft::set_pose(uint8_t instance, const Location &loc, const Quaternion &quat, const Vector3f &velocity_ef)
+bool Aircraft::set_pose(uint8_t instance, const Location &loc, const Quaternion &quat, const Vector3f &velocity_ef, const Vector3f &gyro_rads)
 {
     if (instance >= MAX_SIM_INSTANCES || instances[instance] == nullptr) {
         return false;
@@ -1388,6 +1388,7 @@ bool Aircraft::set_pose(uint8_t instance, const Location &loc, const Quaternion 
     aircraft.smoothing.rotation_b2e = aircraft.dcm;
     aircraft.smoothing.velocity_ef = velocity_ef;
     aircraft.smoothing.location = loc;
+    aircraft.gyro = gyro_rads;
 
     return true;
 }
@@ -1395,8 +1396,8 @@ bool Aircraft::set_pose(uint8_t instance, const Location &loc, const Quaternion 
 /*
   wrapper for scripting access
  */
-bool SITL::SIM::set_pose(uint8_t instance, const Location &loc, const Quaternion &quat, const Vector3f &velocity_ef)
+bool SITL::SIM::set_pose(uint8_t instance, const Location &loc, const Quaternion &quat, const Vector3f &velocity_ef, const Vector3f &gyro_rads)
 {
-    return Aircraft::set_pose(instance, loc, quat, velocity_ef);
+    return Aircraft::set_pose(instance, loc, quat, velocity_ef, gyro_rads);
 }
 

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -187,7 +187,8 @@ public:
     /*
       used by scripting to control simulated aircraft position
      */
-    static bool set_pose(uint8_t instance, const Location &loc, const Quaternion &quat, const Vector3f &velocity_ef);
+    static bool set_pose(uint8_t instance, const Location &loc, const Quaternion &quat,
+                         const Vector3f &velocity_ef, const Vector3f &gyro_rads);
 
 protected:
     SIM *sitl;

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -608,7 +608,8 @@ public:
     /*
       used by scripting to control simulated aircraft position
      */
-    bool set_pose(uint8_t instance, const Location &loc, const Quaternion &quat, const Vector3f &velocity_ef);
+    bool set_pose(uint8_t instance, const Location &loc, const Quaternion &quat,
+                  const Vector3f &velocity_ef, const Vector3f &gyro_rads);
 };
 
 } // namespace SITL


### PR DESCRIPTION
This is a rework of #28320 which uses the fixed wing attitude controller for recovery instead of modifying the VTOL controller. This gives much faster attitude recovery and also avoids an issue with the way the quaternion controller may try to pitch down while inverted, leading to a large amount of altitude loss
This approach builds on the way we already use the fixed wing controller during forward transitions, so it is very little code change, and testing shows it produces a very small amount of altitude loss (eg. in the autotest the alt loss is usually around 2m from fully inverted)

Update: this PR now makes the use of the forced fixed wing controller optional using Q_ASSIST_OPTIONS (defaults enabled) and adds spin recovery, also optional.

