### PR TITLE
AP_RAMTRON: stop using OwnPtr

### DIFF
--- a/libraries/AP_RAMTRON/AP_RAMTRON.cpp
+++ b/libraries/AP_RAMTRON/AP_RAMTRON.cpp
@@ -48,7 +48,7 @@ const AP_RAMTRON::ramtron_id AP_RAMTRON::ramtron_ids[] = {
 // initialise the driver
 bool AP_RAMTRON::init(void)
 {
-    dev = hal.spi->get_device("ramtron");
+    dev = hal.spi->get_device_ptr("ramtron");
     if (!dev) {
         DEV_PRINTF("No RAMTRON device\n");
         return false;

--- a/libraries/AP_RAMTRON/AP_RAMTRON.h
+++ b/libraries/AP_RAMTRON/AP_RAMTRON.h
@@ -23,7 +23,7 @@ public:
     bool write(uint32_t offset, uint8_t const * const buf, uint32_t size);
 
 private:
-    AP_HAL::OwnPtr<AP_HAL::SPIDevice> dev;
+    AP_HAL::SPIDevice *dev;
 
     enum class RDID_type :uint8_t {
         Cypress,


### PR DESCRIPTION
```
Board,plane
CubeOrange,-144
```

... parameters are still persisted on CubeOrange
