### PR TITLE
waf: embed.py: add sanity check for non-zero-lenght-contents

### DIFF
--- a/Tools/ardupilotwaf/embed.py
+++ b/Tools/ardupilotwaf/embed.py
@@ -44,6 +44,8 @@ def embed_file(out, f, idx, embedded_name, uncompressed):
         # decompressed data will be null terminated at runtime, nothing to do here
         null_terminate = False
 
+    if len(b) == 0:
+        raise ValueError(f"Zero-length ROMFS contents ({embedded_name}) not permitted")
     write_encode(out, ",".join(str(c) for c in b))
     if null_terminate:
         write_encode(out, ",0")


### PR DESCRIPTION
I don't think this structure in its current form permits zero-length.

Would be nice to have it.

OTOH, including a zero-lengthg defaults.parm (which picked this bug up) would mean you perhaps include a chunk of code to pull that file apart which you might not otherwise need.

```
In file included from ../../libraries/AP_ROMFS/AP_ROMFS.cpp:29: ./ap_romfs_embedded.h:5:55: error: expected primary-expression before ',' token
    5 | __EXTFLASHFUNC__ static const uint8_t ap_romfs_1[] = {,0};
      |                                                       ^
compilation terminated due to -Wfatal-errors.
```
