### PR TITLE
SCurve: Add Z component to speed and accel constraints before starting next SCurve

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -12416,12 +12416,12 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_rc(1, 1200)
         self.delay_sim_time(1)  # build up some pilot desired stuff
         self.change_mode('AUTO')
-        self.wait_waypoint(2, 2)
+        self.wait_waypoint(2, 2, max_dist=3)
         self.set_parameters({
             'SIM_RC_FAIL': 1,
         })
 #        self.set_rc(1, 1500)  # note we are still in RC fail!
-        self.wait_waypoint(3, 3)
+        self.wait_waypoint(3, 3, max_dist=3)
         self.assert_mode_is('AUTO')
         self.change_mode('LOITER')
         self.wait_groundspeed(0, 0.1, minimum_duration=30, timeout=450)

--- a/libraries/AP_Math/SCurve.cpp
+++ b/libraries/AP_Math/SCurve.cpp
@@ -505,8 +505,8 @@ bool SCurve::advance_target_along_track(SCurve &prev_leg, SCurve &next_leg, floa
         next_leg.move_from_time_pos_vel_accel(time_to_destination * 0.5f, turn_pos, turn_vel, turn_accel);
         const float speed_min = MIN(get_speed_along_track(), next_leg.get_speed_along_track());
         if ((get_time_remaining() < next_leg.time_end() * 0.5f) && (turn_pos.length() < wp_radius) &&
-             (Vector2f{turn_vel.x, turn_vel.y}.length() < speed_min) &&
-             (Vector2f{turn_accel.x, turn_accel.y}.length() < accel_corner)) {
+             (turn_vel.length() < speed_min) &&
+             (turn_accel.length() < accel_corner)) {
             next_leg.move_from_pos_vel_accel(dt, target_pos, target_vel, target_accel);
         }
     } else if (!is_zero(next_leg.get_time_elapsed())) {


### PR DESCRIPTION
I do not think we were correctly accounting for the z-component in the turning point comparison with speed and accel constraints.  This leads to the behaviour whereby we can temporarily exceed the speed up or down limits in WP nav when transiting through a fast waypoints.

**Behaviour Before Proposed Fix:**

Using a mission with waypoints that only vary in height.  My example here:
[s_curves_test_mission_pure_z.txt](https://github.com/user-attachments/files/19214752/s_curves_test_mission_pure_z.txt)

In this example WPNAV_SPEED_UP = 250 cm/s and WPNAV_SPEED_DN = 150 cm/s.

On the ascent:
![image](https://github.com/user-attachments/assets/113ca262-e643-4a89-9831-a7858ef27433)
Desired climb rate temporarily exceeds WPNAV_SPEED_UP as the vehicle transits through the waypoint.

On the descent:
![image](https://github.com/user-attachments/assets/cab82e27-9fdf-4abf-8afe-bdaf9e1c1fd9)
Desired climb rate temporarily exceeds WPNAV_SPEED_DN as the vehicle transits through the waypoint.

Comparing this to the behaviour in XY, I used a mission with waypoints only varying in North:
[s_curves_test_mission_pure_x.txt](https://github.com/user-attachments/files/19214932/s_curves_test_mission_pure_x.txt)

This behaviour cannot be seen when transiting through WP (WPNAV_SPEED = 1000 cm/s): 
![image](https://github.com/user-attachments/assets/954c71eb-64eb-4a53-a074-fb6595def794)

Having added some hacky logging to a working branch you can see the contributions of the SCurves which highlight the issue when doing the purely vertical mission:

![image](https://github.com/user-attachments/assets/b0c07607-c4a5-4664-a0a4-f40f43096195)

**Behaviour With Proposed Fix:**

Vertical only mission:


I have checked and XY behaviour remains unchanged.
![image](https://github.com/user-attachments/assets/b551fb35-ae7b-404e-85a7-ddc514e86ded)


Only testing SITL thus far.
