### PR TITLE
autotest: avoid use of non-ascii characters in test output

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -4349,59 +4349,59 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         # Values that are set to constants
         # If these are changed then the expected tune paramters should also change
-        self.check_parameter_value("RLL2SRV_TCONST", 0.5, 0)
-        self.check_parameter_value("RLL2SRV_RMAX", 75, 0)
-        self.check_parameter_value("RLL_RATE_IMAX", 0.666, 0.01) # allow some small error to acount for floating point stuff
-        self.check_parameter_value("RLL_RATE_FLTT", 3.183, 0.01)
-        self.check_parameter_value("RLL_RATE_FLTE", 0, 0)
-        self.check_parameter_value("RLL_RATE_FLTD", 10.0, 0)
-        self.check_parameter_value("RLL_RATE_SMAX", 150.0, 0)
+        self.assert_parameter_value_pct("RLL2SRV_TCONST", 0.5, 0)
+        self.assert_parameter_value_pct("RLL2SRV_RMAX", 75, 0)
+        self.assert_parameter_value_pct("RLL_RATE_IMAX", 0.666, 0.01) # allow some small error to acount for floating point stuff  # noqa:E501
+        self.assert_parameter_value_pct("RLL_RATE_FLTT", 3.183, 0.01)
+        self.assert_parameter_value_pct("RLL_RATE_FLTE", 0, 0)
+        self.assert_parameter_value_pct("RLL_RATE_FLTD", 10.0, 0)
+        self.assert_parameter_value_pct("RLL_RATE_SMAX", 150.0, 0)
 
-        self.check_parameter_value("PTCH2SRV_TCONST", 0.75, 0)
-        self.check_parameter_value("PTCH2SRV_RMAX_UP", 75, 0)
-        self.check_parameter_value("PTCH2SRV_RMAX_DN", 75, 0)
-        self.check_parameter_value("PTCH_RATE_IMAX", 0.666, 0.01)
-        self.check_parameter_value("PTCH_RATE_FLTT", 2.122, 0.01)
-        self.check_parameter_value("PTCH_RATE_FLTE", 0, 0)
-        self.check_parameter_value("PTCH_RATE_FLTD", 10, 0)
-        self.check_parameter_value("PTCH_RATE_SMAX", 150, 0)
+        self.assert_parameter_value_pct("PTCH2SRV_TCONST", 0.75, 0)
+        self.assert_parameter_value_pct("PTCH2SRV_RMAX_UP", 75, 0)
+        self.assert_parameter_value_pct("PTCH2SRV_RMAX_DN", 75, 0)
+        self.assert_parameter_value_pct("PTCH_RATE_IMAX", 0.666, 0.01)
+        self.assert_parameter_value_pct("PTCH_RATE_FLTT", 2.122, 0.01)
+        self.assert_parameter_value_pct("PTCH_RATE_FLTE", 0, 0)
+        self.assert_parameter_value_pct("PTCH_RATE_FLTD", 10, 0)
+        self.assert_parameter_value_pct("PTCH_RATE_SMAX", 150, 0)
 
         # Check tunned values, targets derived from running tests multiple times and taking average
         # Expect within 2%
         # Note that I is not checked directly, its value is derived from P, FF, and TCONST which are all checked.
-        self.check_parameter_value("RLL_RATE_P", 1.222702146, 2)
-        self.check_parameter_value("RLL_RATE_D", 0.070284024, 2)
-        self.check_parameter_value("RLL_RATE_FF", 0.229291457, 2)
+        self.assert_parameter_value_pct("RLL_RATE_P", 1.222702146, 2)
+        self.assert_parameter_value_pct("RLL_RATE_D", 0.070284024, 2)
+        self.assert_parameter_value_pct("RLL_RATE_FF", 0.229291457, 2)
 
-        self.check_parameter_value("PTCH_RATE_FF", 0.503520715, 5)
+        self.assert_parameter_value_pct("PTCH_RATE_FF", 0.503520715, 5)
 
         # There seem to be multiple solutions for pitch. I'm not sure why this is.
         # Each value is quite consistent becasue of the fixed steps that autotune takes
         try:
             # Expect this about 84% of the time
-            self.check_parameter_value("PTCH_RATE_P", 1.746079683, 2)
+            self.assert_parameter_value_pct("PTCH_RATE_P", 1.746079683, 2)
         except ValueError:
             try:
                 # 12%
-                self.check_parameter_value("PTCH_RATE_P", 1.343138218, 2)
+                self.assert_parameter_value_pct("PTCH_RATE_P", 1.343138218, 2)
             except ValueError:
                 # 4%
-                self.check_parameter_value("PTCH_RATE_P", 2.26990366, 2)
+                self.assert_parameter_value_pct("PTCH_RATE_P", 2.26990366, 2)
 
         try:
             # 64%
-            self.check_parameter_value("PTCH_RATE_D", 0.108, 2)
+            self.assert_parameter_value_pct("PTCH_RATE_D", 0.108, 2)
         except ValueError:
             try:
                 # 28%
-                self.check_parameter_value("PTCH_RATE_D", 0.141, 2)
+                self.assert_parameter_value_pct("PTCH_RATE_D", 0.141, 2)
             except ValueError:
                 try:
                     # 4%
-                    self.check_parameter_value("PTCH_RATE_D", 0.049, 2)
+                    self.assert_parameter_value_pct("PTCH_RATE_D", 0.049, 2)
                 except ValueError:
                     # 4%
-                    self.check_parameter_value("PTCH_RATE_D", 0.0836, 2)
+                    self.assert_parameter_value_pct("PTCH_RATE_D", 0.0836, 2)
 
     def run_autotune(self):
         self.takeoff(100)

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -6281,7 +6281,8 @@ class TestSuite(ABC):
             return
         raise ValueError("Failed to set parameters (%s)" % want)
 
-    def check_parameter_value(self, name, expected_value, max_error_percent):
+    # FIXME: modify assert_parameter_value to take epsilon_pct instead:
+    def assert_parameter_value_pct(self, name, expected_value, max_error_percent):
         value = self.get_parameter_direct(name, verbose=False)
 
         # Convert to ratio and find limits

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -6300,7 +6300,7 @@ class TestSuite(ABC):
 
         # Check value is within limits
         if (value > upper_limit) or (value < lower_limit):
-            raise ValueError("%s expected %f ± %f%% (%f to %f) got %s with %f%% error" % (
+            raise ValueError("%s expected %f +/- %f%% (%f to %f) got %s with %f%% error" % (
                 name,
                 expected_value,
                 max_error_percent,


### PR DESCRIPTION
```
AT-0741.0: Exception caught: RLL_RATE_D expected 0.070284 ± 2.000000% (0.068878 to 0.071690) got 0.09136922657489777 with 29.999993% error
Traceback (most recent call last):
  File "/__w/ardupilot/ardupilot/Tools/autotest/vehicle_test_suite.py", line 8915, in run_one_test_attempt
    test_function(**test_kwargs)
  File "/__w/ardupilot/ardupilot/Tools/autotest/arduplane.py", line 4373, in AUTOTUNE
    self.check_parameter_value("RLL_RATE_D", 0.070284024, 2)
  File "/__w/ardupilot/ardupilot/Tools/autotest/vehicle_test_suite.py", line 6302, in check_parameter_value
    raise ValueError("%s expected %f ± %f%% (%f to %f) got %s with %f%% error" % (
ValueError: RLL_RATE_D expected 0.070284 ± 2.000000% (0.068878 to 0.071690) got 0.09136922657489777 with 29.999993% error

>>>> FAILED STEP: test.PlaneTests1b at Wed Mar 12 10:07:55 2025 ('ascii' codec can't encode character '\xb1' in position 58: ordinal not in range(128))
Traceback (most recent call last):
  File "/__w/ardupilot/ardupilot/Tools/autotest/vehicle_test_suite.py", line 8915, in run_one_test_attempt
    test_function(**test_kwargs)
  File "/__w/ardupilot/ardupilot/Tools/autotest/arduplane.py", line 4373, in AUTOTUNE
    self.check_parameter_value("RLL_RATE_D", 0.070284024, 2)
  File "/__w/ardupilot/ardupilot/Tools/autotest/vehicle_test_suite.py", line 6302, in check_parameter_value
    raise ValueError("%s expected %f ± %f%% (%f to %f) got %s with %f%% error" % (
ValueError: RLL_RATE_D expected 0.070284 ± 2.000000% (0.068878 to 0.071690) got 0.09136922657489777 with 29.999993% error
```
