### PR TITLE
autotest: change uses of recv_match to assert_receive_message

### DIFF
--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -108,10 +108,10 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
                 altitude range
         """
         tstart = self.get_sim_time_cached()
-        previous_altitude = self.mav.recv_match(type='VFR_HUD', blocking=True).alt
+        previous_altitude = self.assert_receive_message('VFR_HUD').alt
         self.progress('Altitude to be watched: %f' % (previous_altitude))
         while True:
-            m = self.mav.recv_match(type='VFR_HUD', blocking=True)
+            m = self.assert_receive_message('VFR_HUD')
             if self.get_sim_time_cached() - tstart > timeout:
                 self.progress('Altitude hold done: %f' % (previous_altitude))
                 return
@@ -126,9 +126,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.arm_vehicle()
         self.change_mode('ALT_HOLD')
 
-        msg = self.mav.recv_match(type='GLOBAL_POSITION_INT', blocking=True, timeout=5)
-        if msg is None:
-            raise NotAchievedException("Did not get GLOBAL_POSITION_INT")
+        msg = self.assert_receive_message('GLOBAL_POSITION_INT', timeout=5)
         pwm = 1300
         if msg.relative_alt/1000.0 < -6.0:
             # need to go up, not down!
@@ -227,13 +225,13 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
     def watch_distance_maintained(self, delta=0.3, timeout=5.0):
         """Watch and wait for the rangefinder reading to be maintained"""
         tstart = self.get_sim_time_cached()
-        previous_distance = self.mav.recv_match(type='RANGEFINDER', blocking=True).distance
+        previous_distance = self.assert_receive_message('RANGEFINDER').distance
         self.progress('Distance to be watched: %.2f' % previous_distance)
         while True:
-            m = self.mav.recv_match(type='RANGEFINDER', blocking=True)
             if self.get_sim_time_cached() - tstart > timeout:
                 self.progress('Distance hold done: %f' % previous_distance)
                 return
+            m = self.assert_receive_message('RANGEFINDER')
             if abs(m.distance - previous_distance) > delta:
                 raise NotAchievedException(
                     "Distance not maintained: want %.2f (+/- %.2f) got=%.2f" %
@@ -452,7 +450,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.set_rc(Joystick.Throttle, 1500)
         self.delay_sim_time(3)
         # start the test itself, go through some modes and check if anything changes
-        previous_altitude = self.mav.recv_match(type='VFR_HUD', blocking=True).alt
+        previous_altitude = self.assert_receive_message('VFR_HUD').alt
         self.change_mode('ALT_HOLD')
         self.delay_sim_time(2)
         self.change_mode('POSHOLD')
@@ -471,7 +469,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.delay_sim_time(2)
         self.change_mode('MANUAL')
         self.disarm_vehicle()
-        final_altitude = self.mav.recv_match(type='VFR_HUD', blocking=True).alt
+        final_altitude = self.assert_receive_message('VFR_HUD').alt
         if abs(previous_altitude - final_altitude) > delta:
             raise NotAchievedException(
                 "Changing modes affected depth with no throttle input!, started at {}, ended at {}"
@@ -493,9 +491,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.delay_sim_time(2)
 
         # Save starting point
-        msg = self.mav.recv_match(type='GLOBAL_POSITION_INT', blocking=True, timeout=5)
-        if msg is None:
-            raise NotAchievedException("Did not get GLOBAL_POSITION_INT")
+        self.assert_receive_message('GLOBAL_POSITION_INT', timeout=5)
         start_pos = self.mav.location()
         # Hold in perfect conditions
         self.progress("Testing position hold in perfect conditions")
@@ -609,8 +605,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.wait_ready_to_arm()
         self.arm_vehicle()
 
-        startpos = self.mav.recv_match(type='GLOBAL_POSITION_INT',
-                                       blocking=True)
+        startpos = self.assert_receive_message('GLOBAL_POSITION_INT')
 
         lat = 5
         lon = 5
@@ -640,8 +635,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         while True:
             if self.get_sim_time_cached() - tstart > 200:
                 raise NotAchievedException("Did not move far enough")
-            pos = self.mav.recv_match(type='GLOBAL_POSITION_INT',
-                                      blocking=True)
+            pos = self.assert_receive_message('GLOBAL_POSITION_INT')
             delta = self.get_distance_int(startpos, pos)
             self.progress("delta=%f (want >10)" % delta)
             if delta > 10:

--- a/Tools/autotest/helicopter.py
+++ b/Tools/autotest/helicopter.py
@@ -56,7 +56,7 @@ class AutoTestHelicopter(AutoTestCopter):
         self.progress("Skipping loiter-requires-position for heli; rotor runup issues")
 
     def get_collective_out(self):
-        servo = self.mav.recv_match(type='SERVO_OUTPUT_RAW', blocking=True)
+        servo = self.assert_receive_message('SERVO_OUTPUT_RAW')
         chan_pwm = (servo.servo1_raw + servo.servo2_raw + servo.servo3_raw)/3.0
         return chan_pwm
 
@@ -68,7 +68,7 @@ class AutoTestHelicopter(AutoTestCopter):
         self.change_mode('LOITER')
         self.wait_ready_to_arm()
         self.arm_vehicle()
-        servo = self.mav.recv_match(type='SERVO_OUTPUT_RAW', blocking=True)
+        servo = self.assert_receive_message('SERVO_OUTPUT_RAW')
         coll = servo.servo1_raw
         coll = coll + 50
         self.set_parameter("H_RSC_RUNUP_TIME", TARGET_RUNUP_TIME)
@@ -78,7 +78,10 @@ class AutoTestHelicopter(AutoTestCopter):
         self.progress("Collective threshold PWM %u" % coll)
         tstart = self.get_sim_time()
         self.progress("Wait that collective PWM pass threshold value")
-        servo = self.mav.recv_match(condition='SERVO_OUTPUT_RAW.servo1_raw>%u' % coll, blocking=True)
+        servo = self.assert_receive_message(
+            "SERVO_OUTPUT_RAW",
+            condition=f'SERVO_OUTPUT_RAW.servo1_raw>{coll}'
+        )
         runup_time = self.get_sim_time() - tstart
         self.progress("Collective is now at PWM %u" % servo.servo1_raw)
         self.mav.wait_heartbeat()
@@ -928,7 +931,7 @@ class AutoTestHelicopter(AutoTestCopter):
         self.set_rc(6, 2000)
         tstart = self.get_sim_time()
         while self.get_sim_time() - tstart < 2:
-            servo = self.mav.recv_match(type='SERVO_OUTPUT_RAW', blocking=True)
+            servo = self.assert_receive_message('SERVO_OUTPUT_RAW')
             if servo.servo8_raw > 1050:
                 raise NotAchievedException("Turbine Start activated while disarmed")
         self.set_rc(6, 1000)
@@ -941,7 +944,7 @@ class AutoTestHelicopter(AutoTestCopter):
         self.set_rc(6, 2000)
         tstart = self.get_sim_time()
         while self.get_sim_time() - tstart < 5:
-            servo = self.mav.recv_match(type='SERVO_OUTPUT_RAW', blocking=True)
+            servo = self.assert_receive_message('SERVO_OUTPUT_RAW')
             if servo.servo8_raw > 1660:
                 raise NotAchievedException("Turbine Start activated with interlock enabled")
 
@@ -959,7 +962,7 @@ class AutoTestHelicopter(AutoTestCopter):
         while True:
             if self.get_sim_time() - tstart > 5:
                 raise AutoTestTimeoutException("Turbine Start did not activate")
-            servo = self.mav.recv_match(type='SERVO_OUTPUT_RAW', blocking=True)
+            servo = self.assert_receive_message('SERVO_OUTPUT_RAW')
             if servo.servo8_raw > 1800:
                 break
 
@@ -972,7 +975,7 @@ class AutoTestHelicopter(AutoTestCopter):
         self.set_rc(6, 2000)
         tstart = self.get_sim_time()
         while self.get_sim_time() - tstart < 5:
-            servo = self.mav.recv_match(type='SERVO_OUTPUT_RAW', blocking=True)
+            servo = self.assert_receive_message('SERVO_OUTPUT_RAW')
             if servo.servo8_raw > 1660:
                 raise NotAchievedException("Turbine Start activated with interlock enabled")
         self.set_rc(6, 1000)

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -502,7 +502,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.set_rc(2, 1500)
         self.set_rc(4, 1500)
         while self.get_sim_time_cached() < tstart + timeout:
-            m = self.mav.recv_match(type='ATTITUDE', blocking=True)
+            m = self.assert_receive_message('ATTITUDE')
             roll = math.degrees(m.roll)
             pitch = math.degrees(m.pitch)
             self.progress("Roll=%.1f Pitch=%.1f" % (roll, pitch))
@@ -545,8 +545,8 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         tstart = self.get_sim_time()
         self.progress("Hovering for %u seconds" % hover_time)
         while self.get_sim_time_cached() < tstart + hover_time:
-            self.mav.recv_match(type='ATTITUDE', blocking=True)
-        vfr_hud = self.mav.recv_match(type='VFR_HUD', blocking=True)
+            self.assert_receive_message('ATTITUDE')
+        vfr_hud = self.assert_receive_message('VFR_HUD')
         tend = self.get_sim_time()
 
         self.do_RTL()
@@ -659,7 +659,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.progress("Hovering for %u seconds" % hover_time)
             tstart = self.get_sim_time()
             while self.get_sim_time_cached() < tstart + hover_time:
-                self.mav.recv_match(type='ATTITUDE', blocking=True)
+                self.assert_receive_message('ATTITUDE')
             tend = self.get_sim_time()
 
             self.do_RTL()
@@ -776,7 +776,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         if fwd_thr_pwm < 1150 :
             raise NotAchievedException("fwd motor pwm command low, want >= 1150 got %f" % (fwd_thr_pwm))
         # check that pitch is on limit
-        m = self.mav.recv_match(type='ATTITUDE', blocking=True)
+        m = self.assert_receive_message('ATTITUDE')
         pitch = math.degrees(m.pitch)
         if abs(pitch + 3.0) > 0.5 :
             raise NotAchievedException("pitch should be -3.0 +- 0.5 deg, got %f" % (pitch))

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -465,16 +465,14 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             now = self.get_sim_time_cached()
             if now - tstart > timeout:
                 raise AutoTestTimeoutException("Didn't see wp 3")
-            m = self.mav.recv_match(type='MISSION_CURRENT',
-                                    blocking=True,
-                                    timeout=1)
+            m = self.assert_receive_message('MISSION_CURRENT')
             self.progress("MISSION_CURRENT: %s" % str(m))
             if m.seq == 3:
                 break
 
         self.drain_mav()
 
-        m = self.assert_receive_message('NAV_CONTROLLER_OUTPUT', timeout=1)
+        m = self.assert_receive_message('NAV_CONTROLLER_OUTPUT')
 
         wp_dist_min = 5
         if m.wp_dist < wp_dist_min:
@@ -787,7 +785,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         while True:
             if self.get_sim_time_cached() - tstart > 10:
                 raise AutoTestTimeoutException("Did not get rc change")
-            m = self.mav.recv_match(type='RC_CHANNELS', blocking=True)
+            m = self.assert_receive_message('RC_CHANNELS')
             if m.chan3_raw == normal_rc_throttle:
                 break
 
@@ -810,7 +808,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 65535, # chan7_raw
                 65535) # chan8_raw
 
-            m = self.mav.recv_match(type='RC_CHANNELS', blocking=True)
+            m = self.assert_receive_message('RC_CHANNELS')
             self.progress("chan3=%f want=%f" % (m.chan3_raw, throttle_override))
             if m.chan3_raw == throttle_override:
                 break
@@ -834,7 +832,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 65535, # chan7_raw
                 65535) # chan8_raw
             self.do_timesync_roundtrip()
-            m = self.mav.recv_match(type='RC_CHANNELS', blocking=True)
+            m = self.assert_receive_message('RC_CHANNELS')
             self.progress("chan3=%f want=%f" % (m.chan3_raw, normal_rc_throttle))
             if m.chan3_raw == normal_rc_throttle:
                 break
@@ -878,7 +876,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 65535, # chan7_raw
                 65535) # chan8_raw
 
-            m = self.mav.recv_match(type='VFR_HUD', blocking=True)
+            m = self.assert_receive_message('VFR_HUD')
             want_speed = 2.0
             self.progress("Speed=%f want=<%f" % (m.groundspeed, want_speed))
             if m.groundspeed < want_speed:
@@ -907,7 +905,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 65535, # chan7_raw
                 65535) # chan8_raw
 
-            m = self.mav.recv_match(type='VFR_HUD', blocking=True)
+            m = self.assert_receive_message('VFR_HUD')
             want_speed = 5.0
             self.progress("Speed=%f want=>%f" % (m.groundspeed, want_speed))
 
@@ -999,7 +997,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             delta = self.get_sim_time() - tstart
             if delta > 20:
                 break
-            m = self.assert_receive_message('RC_CHANNELS', timeout=1)
+            m = self.assert_receive_message('RC_CHANNELS')
             channel_field = "chan%u_raw" % ch
             m_value = getattr(m, channel_field)
             if m_value != ch_override_value:
@@ -1108,7 +1106,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 32767, # r (yaw)
                 0) # button mask
 
-            m = self.mav.recv_match(type='VFR_HUD', blocking=True)
+            m = self.assert_receive_message('VFR_HUD')
             want_speed = 2.0
             self.progress("Speed=%f want=<%f  throttle=%u want=%u" %
                           (m.groundspeed, want_speed, m.throttle, expected_throttle))
@@ -1134,7 +1132,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 32767, # r (yaw)
                 0) # button mask
 
-            m = self.mav.recv_match(type='VFR_HUD', blocking=True)
+            m = self.assert_receive_message('VFR_HUD')
             want_speed = 5.0
 
             self.progress("Speed=%f want=>%f  throttle=%u want=%u" %
@@ -1162,7 +1160,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.arm_vehicle()
         prev_cf = None
         while True:
-            cf = self.mav.recv_match(type='CAMERA_FEEDBACK', blocking=True)
+            cf = self.assert_receive_message('CAMERA_FEEDBACK')
             if prev_cf is None:
                 prev_cf = cf
                 continue
@@ -1749,7 +1747,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         while True:
             if self.get_sim_time_cached() - tstart > timeout:
                 raise NotAchievedException("Did not get error message back")
-            m = self.mav.recv_match(type='STATUSTEXT', blocking=True, timeout=1)
+            m = self.assert_receive_message('STATUSTEXT')
             self.progress("statustext: %s (want='%s')" %
                           (str(m), statustext_fragment))
             if m is None:
@@ -2266,7 +2264,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.mav.mav.fence_fetch_point_send(target_system,
                                             target_component,
                                             0)
-        m = self.mav.recv_match(type="FENCE_POINT", blocking=True, timeout=1)
+        m = self.assert_receive_message("FENCE_POINT")
         print("m: %s" % str(m))
 
         self.clear_mission(mavutil.mavlink.MAV_MISSION_TYPE_FENCE,
@@ -2514,11 +2512,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                                      target_component,
                                      item,
                                      mission_type)
-        m = mav.recv_match(type='MISSION_ITEM',
-                           blocking=True,
-                           timeout=60)
-        if m is None:
-            raise NotAchievedException("Did not receive MISSION_ITEM")
+        m = self.assert_receive_message('MISSION_ITEM', timeout=60)
         if m.target_system != mav.mav.srcSystem:
             raise NotAchievedException("Unexpected target system %u want=%u" %
                                        (m.target_system, mav.mav.srcSystem))
@@ -2535,7 +2529,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
     def assert_receive_mission_item_request(self, mission_type, seq):
         self.progress("Expecting request for item %u" % seq)
-        m = self.assert_receive_message('MISSION_REQUEST', timeout=1)
+        m = self.assert_receive_message('MISSION_REQUEST')
         if m.mission_type != mission_type:
             raise NotAchievedException("Incorrect mission type (wanted=%u got=%u)" %
                                        (mission_type, m.mission_type))
@@ -2555,12 +2549,11 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         if target_component is None:
             target_component = mav.mav.srcComponent
         self.progress("Expecting mission ack")
-        m = mav.recv_match(type='MISSION_ACK',
-                           blocking=True,
-                           timeout=5)
-        self.progress("Received ACK (%s)" % str(m))
-        if m is None:
-            raise NotAchievedException("Expected mission ACK")
+        m = self.assert_receive_message(
+            'MISSION_ACK',
+            timeout=5,
+            verbose=True,
+        )
         if m.target_system != target_system:
             raise NotAchievedException("ACK not targetted at correct system want=%u got=%u" %
                                        (target_system, m.target_system))
@@ -3152,7 +3145,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             self.mav.mav.rally_fetch_point_send(target_system,
                                                 target_component,
                                                 1)
-            m = self.mav.recv_match(type="RALLY_POINT", blocking=True, timeout=1)
+            m = self.assert_receive_message("RALLY_POINT")
             if m.target_system != self.mav.source_system:
                 raise NotAchievedException(
                     "Bad target_system on received rally point (want=%u got=%u)" %
@@ -3354,7 +3347,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             mav2.mav.srcSystem = old_mav2_system
             mav2.mav.srcComponent = old_mav2_component
             # we continue to receive requests on the original link:
-            m = self.assert_receive_message('MISSION_REQUEST', timeout=1)
+            m = self.assert_receive_message('MISSION_REQUEST')
             if m.mission_type != mavutil.mavlink.MAV_MISSION_TYPE_RALLY:
                 raise NotAchievedException("Mission request of incorrect type")
             if m.seq != 1:
@@ -4305,13 +4298,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                                         target_component,
                                         1,
                                         mavutil.mavlink.MAV_MISSION_TYPE_FENCE)
-        m = self.mav.recv_match(type=['MISSION_REQUEST', 'MISSION_ACK'],
-                                blocking=True,
-                                timeout=1)
-        self.progress("Got (%s)" % str(m))
-        if m is None:
-            raise NotAchievedException("Did not get ACK or mission request")
-
+        m = self.assert_receive_message(['MISSION_REQUEST', 'MISSION_ACK'], verbose=True)
         if m.get_type() == "MISSION_ACK":
             raise NotAchievedException("Expected MISSION_REQUEST")
 
@@ -4364,13 +4351,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.end_subtest("fence upload timeouts 1")
 
     def expect_request_for_item(self, item):
-        m = self.mav.recv_match(type=['MISSION_REQUEST', 'MISSION_ACK'],
-                                blocking=True,
-                                timeout=1)
-        self.progress("Got (%s)" % str(m))
-        if m is None:
-            raise NotAchievedException("Did not get ACK or mission request")
-
+        m = self.assert_receive_message(['MISSION_REQUEST', 'MISSION_ACK'], verbose=-True)
         if m.get_type() == "MISSION_ACK":
             raise NotAchievedException("Expected MISSION_REQUEST")
 
@@ -5301,7 +5282,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         while not self.mode_is("HOLD"):
             if self.get_sim_time_cached() - tstart > 30:
                 raise NotAchievedException("Did not move to hold")
-            m = self.mav.recv_match(type='VFR_HUD', blocking=True, timeout=1)
+            m = self.assert_receive_message('VFR_HUD')
             if m is not None:
                 self.progress("Current speed: %f" % m.groundspeed)
         self.disarm_vehicle()
@@ -5782,9 +5763,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 0, # yaw rate
                 1) # thrust
 
-            msg = self.mav.recv_match(type='VFR_HUD', blocking=True, timeout=1)
-            if msg is None:
-                raise NotAchievedException("No VFR_HUD message")
+            msg = self.assert_receive_message('VFR_HUD')
             if msg.groundspeed > 5:
                 break
         self.disarm_vehicle()
@@ -6115,9 +6094,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.wait_ready_to_arm()
 
         # should not get WATER_DEPTH messages or DPTH logs when the FRAME_CLASS is not a boat
-        m = self.mav.recv_match(type="WATER_DEPTH", blocking=True, timeout=2)
-        if m is not None:
-            raise NotAchievedException("WATER_DEPTH: received message when FRAME_CLASS not a Boat")
+        self.assert_not_receive_message("WATER_DEPTH", timeout=2)
 
         # Set FRAME_CLASS to start receiving WATER_DEPTH messages & logging DPTH
         self.set_parameters({

--- a/Tools/autotest/sailboat.py
+++ b/Tools/autotest/sailboat.py
@@ -43,10 +43,7 @@ class AutoTestSailboat(AutoTestRover):
             now = self.get_sim_time_cached()
             if now - tstart > timeout:
                 raise AutoTestTimeoutException("Didn't see wp 3")
-            m = self.mav.recv_match(type='MISSION_CURRENT',
-                                    blocking=True,
-                                    timeout=1)
-            self.progress("MISSION_CURRENT: %s" % str(m))
+            m = self.assert_receive_message('MISSION_CURRENT', verbose=True)
             if m.seq == 3:
                 break
 

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -3220,9 +3220,8 @@ class TestSuite(ABC):
             set_streamrate_callback()
         else:
             self.set_streamrate(self.sitl_streamrate())
-        m = self.mav.recv_match(type='RC_CHANNELS', blocking=True, timeout=15)
-        if m is None:
-            raise NotAchievedException("No RC_CHANNELS message after restarting SITL")
+
+        self.assert_receive_message('RC_CHANNELS', timeout=15)
 
         # stash our arguments in case we need to preserve them in
         # reboot_sitl with Valgrind active:
@@ -3648,9 +3647,7 @@ class TestSuite(ABC):
         self.wait_sensor_state(mavutil.mavlink.MAV_SYS_STATUS_SENSOR_GPS, True, True, True, verbose=True, timeout=30)
 
         # should not be getting HIGH_LATENCY2 by default
-        m = self.mav.recv_match(type='HIGH_LATENCY2', blocking=True, timeout=2)
-        if m is not None:
-            raise NotAchievedException("Shouldn't be getting HIGH_LATENCY2 by default")
+        m = self.assert_not_receive_message('HIGH_LATENCY2', timeout=2)
         m = self.poll_message("HIGH_LATENCY2")
         if (m.failure_flags & mavutil.mavlink.HL_FAILURE_FLAG_GPS) != 0:
             raise NotAchievedException("Expected GPS to be OK")
@@ -3821,6 +3818,8 @@ class TestSuite(ABC):
                                 timeout=2)
         if m is not None:
             raise NotAchievedException("Received extra LOG_ENTRY?!")
+        # shouldbe: m = self.assert_not_receive_message('LOG_ENTRY', timeout=2)
+
         return logs
 
     def TestLogDownloadWrap(self):
@@ -4193,7 +4192,7 @@ class TestSuite(ABC):
 
     def sim_location(self):
         """Return current simulator location."""
-        m = self.mav.recv_match(type='SIMSTATE', blocking=True)
+        m = self.assert_receive_message('SIMSTATE')
         return mavutil.location(m.lat*1.0e-7,
                                 m.lng*1.0e-7,
                                 0,
@@ -4201,7 +4200,7 @@ class TestSuite(ABC):
 
     def sim_location_int(self):
         """Return current simulator location."""
-        m = self.mav.recv_match(type='SIMSTATE', blocking=True)
+        m = self.assert_receive_message('SIMSTATE')
         return mavutil.location(m.lat,
                                 m.lng,
                                 0,
@@ -6019,7 +6018,7 @@ class TestSuite(ABC):
         while True:
             if time.time() - start > timeout:
                 raise NotAchievedException("Did not achieve value")
-            m = self.assert_receive_message('SERVO_OUTPUT_RAW', timeout=1)
+            m = self.assert_receive_message('SERVO_OUTPUT_RAW')
             channel_field = "servo%u_raw" % channel
             m_value = getattr(m, channel_field, None)
             self.progress("Servo%u=%u want=%u" % (channel, m_value, value))
@@ -7131,7 +7130,7 @@ class TestSuite(ABC):
                 p3=1,  # -1 is counter-clockwise, 1 clockwise
                 p4=0,  # 1 for relative, 0 for absolute
             )
-            m = self.mav.recv_match(type='VFR_HUD', blocking=True)
+            m = self.assert_receive_message('VFR_HUD')
             self.progress("heading=%d want=%d" % (m.heading, int(heading)))
             if accuracy is not None:
                 delta = abs(m.heading - int(heading))
@@ -7268,7 +7267,7 @@ class TestSuite(ABC):
     def get_esc_rpm(self, esc):
         if esc > 4:
             raise ValueError("Only does 1-4")
-        m = self.assert_receive_message('ESC_TELEMETRY_1_TO_4', timeout=1, verbose=True)
+        m = self.assert_receive_message('ESC_TELEMETRY_1_TO_4', verbose=True)
         return m.rpm[esc-1]
 
     def find_first_set_bit(self, mask):
@@ -7762,8 +7761,8 @@ class TestSuite(ABC):
         )
 
     def get_body_frame_velocity(self):
-        gri = self.assert_receive_message('GPS_RAW_INT', timeout=1)
-        att = self.assert_receive_message('ATTITUDE', timeout=1)
+        gri = self.assert_receive_message('GPS_RAW_INT')
+        att = self.assert_receive_message('ATTITUDE')
         return mavextra.gps_velocity_body(gri, att)
 
     def wait_speed_vector_bf(self, speed_vector, accuracy=0.2, timeout=30, **kwargs):
@@ -7903,7 +7902,7 @@ class TestSuite(ABC):
     def get_local_position_NED(self):
         '''return a Vector3 repreesenting vehicle position relative to
         origin in metres, NED'''
-        pos = self.assert_receive_message('LOCAL_POSITION_NED', timeout=1)
+        pos = self.assert_receive_message('LOCAL_POSITION_NED')
         return Vector3(pos.x, pos.y, pos.z)
 
     def distance_to_local_position(self, local_pos, timeout=30):
@@ -8026,7 +8025,7 @@ class TestSuite(ABC):
         """assert channel value (default condition is equality)"""
         channel_field = "servo%u_raw" % channel
         opstring = ("%s" % comparator)[-3:-1]
-        m = self.assert_receive_message('SERVO_OUTPUT_RAW', timeout=1)
+        m = self.assert_receive_message('SERVO_OUTPUT_RAW')
         m_value = getattr(m, channel_field, None)
         if m_value is None:
             raise ValueError("message (%s) has no field %s" %
@@ -8040,7 +8039,7 @@ class TestSuite(ABC):
     def assert_servo_channel_range(self, channel, value_min, value_max):
         """assert channel value is within the range [value_min, value_max]"""
         channel_field = "servo%u_raw" % channel
-        m = self.assert_receive_message('SERVO_OUTPUT_RAW', timeout=1)
+        m = self.assert_receive_message('SERVO_OUTPUT_RAW')
         m_value = getattr(m, channel_field, None)
         if m_value is None:
             raise ValueError("message (%s) has no field %s" %
@@ -9309,7 +9308,7 @@ Also, ignores heartbeats not from our target system'''
 
             timeout += 10  # we received a good request for item; be generous with our timeouts
 
-        m = self.assert_receive_message('MISSION_ACK', timeout=1)
+        m = self.assert_receive_message('MISSION_ACK')
         if m.mission_type != mission_type:
             raise NotAchievedException("Mission ack not of expected mission type")
         if m.type != mavutil.mavlink.MAV_MISSION_ACCEPTED:
@@ -10238,7 +10237,7 @@ Also, ignores heartbeats not from our target system'''
             # wait until we definitely know where we are:
             self.poll_home_position(timeout=120)
 
-            ss = self.assert_receive_message('SIMSTATE', timeout=1, verbose=True)
+            ss = self.assert_receive_message('SIMSTATE', verbose=True)
 
             self.run_cmd(
                 mavutil.mavlink.MAV_CMD_FIXED_MAG_CAL_YAW,
@@ -10870,7 +10869,7 @@ Also, ignores heartbeats not from our target system'''
             run_cmd = self.run_cmd
 
         self.send_get_message_interval(victim_message, mav=mav)
-        m = self.assert_receive_message('MESSAGE_INTERVAL', timeout=1, mav=mav)
+        m = self.assert_receive_message('MESSAGE_INTERVAL', mav=mav)
 
         if isinstance(victim_message, str):
             victim_message = eval("mavutil.mavlink.MAVLINK_MSG_ID_%s" % victim_message)
@@ -12643,10 +12642,7 @@ switch value'''
         ])
         self.do_timesync_roundtrip()
         self.wait_gps_fix_type_gte(3)
-        gps1 = self.mav.recv_match(type="GPS_RAW_INT", blocking=True, timeout=10)
-        self.progress("gps1=(%s)" % str(gps1))
-        if gps1 is None:
-            raise NotAchievedException("Did not receive GPS_RAW_INT")
+        gps1 = self.assert_receive_message("GPS_RAW_INT", timeout=10, verbose=True)
         tstart = self.get_sim_time()
         while True:
             now = self.get_sim_time_cached()
@@ -12855,29 +12851,20 @@ switch value'''
         btn = 4
         pin = 3
         self.set_parameter("BTN_PIN%u" % btn, pin, verbose=True)
-        m = self.mav.recv_match(type='BUTTON_CHANGE', blocking=True, timeout=1)
-        self.progress("### m: %s" % str(m))
-        if m is not None:
-            # should not get a button-changed event here.  The pins
-            # are simulated pull-down
-            raise NotAchievedException("Received BUTTON_CHANGE event")
+        m = self.assert_not_receive_message('BUTTON_CHANGE')
         mask = 1 << pin
         self.set_parameter("SIM_PIN_MASK", mask)
-        m = self.assert_receive_message('BUTTON_CHANGE', timeout=1, verbose=True)
+        m = self.assert_receive_message('BUTTON_CHANGE', verbose=True)
         if not (m.state & mask):
             raise NotAchievedException("Bit not set in mask (got=%u want=%u)" % (m.state, mask))
-        m2 = self.mav.recv_match(type='BUTTON_CHANGE', blocking=True, timeout=10)
-        if m2 is None:
-            raise NotAchievedException("Did not get repeat message")
+        m2 = self.assert_receive_message('BUTTON_CHANGE', timeout=10)
         self.progress("### m2: %s" % str(m2))
         # wait for messages to stop coming:
         self.drain_mav_seconds(15)
 
         new_mask = 0
         self.send_set_parameter("SIM_PIN_MASK", new_mask, verbose=True)
-        m3 = self.mav.recv_match(type='BUTTON_CHANGE', blocking=True, timeout=1)
-        if m3 is None:
-            raise NotAchievedException("Did not get 'off' message")
+        m3 = self.assert_receive_message('BUTTON_CHANGE')
         self.progress("### m3: %s" % str(m3))
 
         if m.last_change_ms == m3.last_change_ms:
@@ -12971,13 +12958,7 @@ switch value'''
     def tf_validate_gps(self, value): # shared by proto 4 and proto 10
         self.progress("validating gps (0x%02x)" % value)
         lat = value
-        gpi = self.mav.recv_match(
-            type='GLOBAL_POSITION_INT',
-            blocking=True,
-            timeout=1
-        )
-        if gpi is None:
-            raise NotAchievedException("Did not get GLOBAL_POSITION_INT message")
+        gpi = self.assert_receive_message('GLOBAL_POSITION_INT')
         gpi_lat = self.tf_encode_gps_latitude(gpi.lat)
         self.progress("GLOBAL_POSITION_INT lat==%f frsky==%f" % (gpi_lat, lat))
         if gpi_lat == lat:
@@ -13056,13 +13037,7 @@ switch value'''
         roll = (min(self.bit_extract(value, 0, 11), 1800) - 900) * 0.2 # roll [0,1800] ==> [-180,180]
         pitch = (min(self.bit_extract(value, 11, 10), 900) - 450) * 0.2 # pitch [0,900] ==> [-90,90]
 #        rng_cm = self.bit_extract(value, 22, 10) * (10 ^ self.bit_extract(value, 21, 1)) # cm
-        atti = self.mav.recv_match(
-            type='ATTITUDE',
-            blocking=True,
-            timeout=1
-        )
-        if atti is None:
-            raise NotAchievedException("Did not get ATTITUDE message")
+        atti = self.assert_receive_message('ATTITUDE')
         atti_roll = round(atti.roll)
         self.progress("ATTITUDE roll==%f frsky==%f" % (atti_roll, roll))
         if abs(atti_roll - roll) >= 5:
@@ -13079,13 +13054,7 @@ switch value'''
 #        home_dist_m = self.bit_extract(value,2,10) * (10^self.bit_extract(value,0,2))
         home_alt_dm = self.bit_extract(value, 14, 10) * (10 ^ self.bit_extract(value, 12, 2)) * 0.1 * (self.bit_extract(value, 24, 1) == 1 and -1 or 1)  # noqa
         # home_angle_d = self.bit_extract(value, 25,  7) * 3
-        gpi = self.mav.recv_match(
-            type='GLOBAL_POSITION_INT',
-            blocking=True,
-            timeout=1
-        )
-        if gpi is None:
-            raise NotAchievedException("Did not get GLOBAL_POSITION_INT message")
+        gpi = self.assert_receive_message('GLOBAL_POSITION_INT')
         gpi_relative_alt_dm = gpi.relative_alt/100.0
         self.progress("GLOBAL_POSITION_INT rel_alt==%fm frsky_home_alt==%fm" % (gpi_relative_alt_dm, home_alt_dm))
         if abs(gpi_relative_alt_dm - home_alt_dm) < 10:
@@ -13099,13 +13068,7 @@ switch value'''
         gps_status = self.bit_extract(value, 4, 2) + self.bit_extract(value, 14, 2)
 #        gps_hdop = self.bit_extract(value, 7, 7) * (10 ^ self.bit_extract(value, 6, 1)) # dm
 #        gps_alt = self.bit_extract(value, 24, 7) * (10 ^ self.bit_extract(value, 22, 2)) * (self.bit_extract(value, 31, 1) == 1 and -1 or 1) # dm  # noqa
-        gri = self.mav.recv_match(
-            type='GPS_RAW_INT',
-            blocking=True,
-            timeout=1
-        )
-        if gri is None:
-            raise NotAchievedException("Did not get GPS_RAW_INT message")
+        gri = self.assert_receive_message('GPS_RAW_INT')
         gri_status = gri.fix_type
         self.progress("GPS_RAW_INT fix_type==%f frsky==%f" % (gri_status, gps_status))
         if gps_status == gri_status:
@@ -13140,14 +13103,11 @@ switch value'''
         # current = self.bit_extract(value, 10, 7) * (10 ^ self.bit_extract(value, 9, 1))
         # mah = self.bit_extract(value, 17, 15)
         voltage = value * 0.1
-        batt = self.mav.recv_match(
-            type='BATTERY_STATUS',
-            blocking=True,
+        batt = self.assert_receive_message(
+            'BATTERY_STATUS',
             timeout=5,
             condition="BATTERY_STATUS.id==0"
         )
-        if batt is None:
-            raise NotAchievedException("Did not get BATTERY_STATUS message")
         battery_status_value = batt.voltages[0]*0.001
         self.progress("BATTERY_STATUS voltage==%f frsky==%f" % (battery_status_value, voltage))
         if abs(battery_status_value - voltage) > 0.1:
@@ -13174,13 +13134,7 @@ switch value'''
     def tfp_validate_rpm(self, value):
         self.progress("validating rpm (0x%02x)" % value)
         tf_rpm = self.bit_extract(value, 0, 16)
-        rpm = self.mav.recv_match(
-            type='RPM',
-            blocking=True,
-            timeout=5
-        )
-        if rpm is None:
-            raise NotAchievedException("Did not get RPM message")
+        rpm = self.assert_receive_message(type='RPM', timeout=5)
         rpm_value = round(rpm.rpm1 * 0.1)
         self.progress("RPM rpm==%f frsky==%f" % (rpm_value, tf_rpm))
         if rpm_value != tf_rpm:
@@ -13190,13 +13144,7 @@ switch value'''
     def tfp_validate_terrain(self, value):
         self.progress("validating terrain(0x%02x)" % value)
         alt_above_terrain_dm = self.bit_extract(value, 2, 10) * (10 ^ self.bit_extract(value, 0, 2)) * 0.1 * (self.bit_extract(value, 12, 1) == 1 and -1 or 1)  # noqa
-        terrain = self.mav.recv_match(
-            type='TERRAIN_REPORT',
-            blocking=True,
-            timeout=1
-        )
-        if terrain is None:
-            raise NotAchievedException("Did not get TERRAIN_REPORT message")
+        terrain = self.assert_receive_message('TERRAIN_REPORT')
         altitude_terrain_dm = round(terrain.current_height*10)
         self.progress("TERRAIN_REPORT terrain_alt==%fdm frsky_terrain_alt==%fdm" % (altitude_terrain_dm, alt_above_terrain_dm))
         if abs(altitude_terrain_dm - alt_above_terrain_dm) < 1:
@@ -13206,13 +13154,7 @@ switch value'''
     def tfp_validate_wind(self, value):
         self.progress("validating wind(0x%02x)" % value)
         speed_m = self.bit_extract(value, 8, 7) * (10 ^ self.bit_extract(value, 7, 1)) * 0.1 # speed in m/s
-        wind = self.mav.recv_match(
-            type='WIND',
-            blocking=True,
-            timeout=1
-        )
-        if wind is None:
-            raise NotAchievedException("Did not get WIND message")
+        wind = self.assert_receive_message('WIND')
         self.progress("WIND mav==%f frsky==%f" % (speed_m, wind.speed))
         if abs(speed_m - wind.speed) < 0.5:
             return True
@@ -13579,11 +13521,7 @@ switch value'''
     def tfs_validate_gps_alt(self, value):
         self.progress("validating gps altitude (0x%02x)" % value)
         alt_m = value * 0.01 # cm -> m
-        gpi = self.mav.recv_match(
-            type='GLOBAL_POSITION_INT',
-            blocking=True,
-            timeout=1
-        )
+        gpi = self.assert_receive_message('GLOBAL_POSITION_INT')
         if gpi is None:
             raise NotAchievedException("Did not get GLOBAL_POSITION_INT message")
         gpi_alt_m = round(gpi.alt * 0.001) # mm-> m
@@ -13595,11 +13533,7 @@ switch value'''
     def tfs_validate_baro_alt(self, value):
         self.progress("validating baro altitude (0x%02x)" % value)
         alt_m = value * 0.01 # cm -> m
-        gpi = self.mav.recv_match(
-            type='GLOBAL_POSITION_INT',
-            blocking=True,
-            timeout=1
-        )
+        gpi = self.assert_receive_message('GLOBAL_POSITION_INT')
         if gpi is None:
             raise NotAchievedException("Did not get GLOBAL_POSITION_INT message")
         gpi_alt_m = round(gpi.relative_alt * 0.001) # mm -> m
@@ -13611,13 +13545,7 @@ switch value'''
     def tfs_validate_gps_speed(self, value):
         self.progress("validating gps speed (0x%02x)" % value)
         speed_ms = value * 0.001 # mm/s -> m/s
-        vfr_hud = self.mav.recv_match(
-            type='VFR_HUD',
-            blocking=True,
-            timeout=1
-        )
-        if vfr_hud is None:
-            raise NotAchievedException("Did not get VFR_HUD message")
+        vfr_hud = self.assert_receive_message('VFR_HUD')
         vfr_hud_speed_ms = round(vfr_hud.groundspeed)
         self.progress("VFR_HUD groundspeed==%f frsky==%f" % (vfr_hud_speed_ms, speed_ms))
         if self.compare_number_percent(vfr_hud_speed_ms, speed_ms, 10):
@@ -13627,13 +13555,7 @@ switch value'''
     def tfs_validate_yaw(self, value):
         self.progress("validating yaw (0x%02x)" % value)
         yaw_deg = value * 0.01 # cd -> deg
-        vfr_hud = self.mav.recv_match(
-            type='VFR_HUD',
-            blocking=True,
-            timeout=1
-        )
-        if vfr_hud is None:
-            raise NotAchievedException("Did not get VFR_HUD message")
+        vfr_hud = self.assert_receive_message('VFR_HUD')
         vfr_hud_yaw_deg = round(vfr_hud.heading)
         self.progress("VFR_HUD heading==%f frsky==%f" % (vfr_hud_yaw_deg, yaw_deg))
         if self.compare_number_percent(vfr_hud_yaw_deg, yaw_deg, 10):
@@ -13643,13 +13565,7 @@ switch value'''
     def tfs_validate_vspeed(self, value):
         self.progress("validating vspeed (0x%02x)" % value)
         vspeed_ms = value * 0.01 # cm/s -> m/s
-        vfr_hud = self.mav.recv_match(
-            type='VFR_HUD',
-            blocking=True,
-            timeout=1
-        )
-        if vfr_hud is None:
-            raise NotAchievedException("Did not get VFR_HUD message")
+        vfr_hud = self.assert_receive_message('VFR_HUD')
         vfr_hud_vspeed_ms = round(vfr_hud.climb)
         self.progress("VFR_HUD climb==%f frsky==%f" % (vfr_hud_vspeed_ms, vspeed_ms))
         if self.compare_number_percent(vfr_hud_vspeed_ms, vspeed_ms, 10):
@@ -13659,14 +13575,11 @@ switch value'''
     def tfs_validate_battery1(self, value):
         self.progress("validating battery1 (0x%02x)" % value)
         voltage_v = value * 0.01 # cV -> V
-        batt = self.mav.recv_match(
-            type='BATTERY_STATUS',
-            blocking=True,
+        batt = self.assert_receive_message(
+            'BATTERY_STATUS',
             timeout=5,
             condition="BATTERY_STATUS.id==0"
         )
-        if batt is None:
-            raise NotAchievedException("Did not get BATTERY_STATUS message")
         battery_status_voltage_v = batt.voltages[0] * 0.001 # mV -> V
         self.progress("BATTERY_STATUS volatge==%f frsky==%f" % (battery_status_voltage_v, voltage_v))
         if self.compare_number_percent(battery_status_voltage_v, voltage_v, 10):
@@ -13677,14 +13590,11 @@ switch value'''
         # test frsky current vs BATTERY_STATUS
         self.progress("validating battery1 (0x%02x)" % value)
         current_a = value * 0.1 # dA -> A
-        batt = self.mav.recv_match(
-            type='BATTERY_STATUS',
-            blocking=True,
+        batt = self.assert_receive_message(
+            'BATTERY_STATUS',
             timeout=5,
             condition="BATTERY_STATUS.id==0"
         )
-        if batt is None:
-            raise NotAchievedException("Did not get BATTERY_STATUS message")
         battery_status_current_a = batt.current_battery * 0.01 # cA -> A
         self.progress("BATTERY_STATUS current==%f frsky==%f" % (battery_status_current_a, current_a))
         if self.compare_number_percent(round(battery_status_current_a * 10), round(current_a * 10), 10):
@@ -13694,14 +13604,11 @@ switch value'''
     def tfs_validate_fuel(self, value):
         self.progress("validating fuel (0x%02x)" % value)
         fuel = value
-        batt = self.mav.recv_match(
-            type='BATTERY_STATUS',
-            blocking=True,
+        batt = self.assert_receive_message(
+            'BATTERY_STATUS',
             timeout=5,
             condition="BATTERY_STATUS.id==0"
         )
-        if batt is None:
-            raise NotAchievedException("Did not get BATTERY_STATUS message")
         battery_status_fuel = batt.battery_remaining
         self.progress("BATTERY_STATUS fuel==%f frsky==%f" % (battery_status_fuel, fuel))
         if self.compare_number_percent(battery_status_fuel, fuel, 10):
@@ -13721,13 +13628,7 @@ switch value'''
     def tfs_validate_tmp2(self, value):
         self.progress("validating tmp2 (0x%02x)" % value)
         tmp2 = value
-        gps_raw = self.mav.recv_match(
-            type='GPS_RAW_INT',
-            blocking=True,
-            timeout=1
-        )
-        if gps_raw is None:
-            raise NotAchievedException("Did not get GPS_RAW_INT message")
+        gps_raw = self.assert_receive_message('GPS_RAW_INT')
         gps_raw_tmp2 = gps_raw.satellites_visible*10 + gps_raw.fix_type
         self.progress("GPS_RAW_INT tmp2==%f frsky==%f" % (gps_raw_tmp2, tmp2))
         if gps_raw_tmp2 == tmp2:
@@ -13737,13 +13638,7 @@ switch value'''
     def tfs_validate_rpm(self, value):
         self.progress("validating rpm (0x%02x)" % value)
         tfs_rpm = value
-        rpm = self.mav.recv_match(
-            type='RPM',
-            blocking=True,
-            timeout=5
-        )
-        if rpm is None:
-            raise NotAchievedException("Did not get RPM message")
+        rpm = self.assert_receive_message('RPM', timeout=5)
         rpm_value = round(rpm.rpm1)
         self.progress("RPM rpm==%f frsky==%f" % (rpm_value, tfs_rpm))
         if rpm_value == tfs_rpm:
@@ -13856,7 +13751,7 @@ switch value'''
         ])
         frsky = FRSkyD(("127.0.0.1", port))
         self.wait_ready_to_arm()
-        m = self.assert_receive_message('GLOBAL_POSITION_INT', timeout=1)
+        m = self.assert_receive_message('GLOBAL_POSITION_INT')
         gpi_abs_alt = int((m.alt+500) / 1000) # mm -> m
 
         # grab a battery-remaining percentage
@@ -13865,7 +13760,7 @@ switch value'''
             p1=65535,   # battery mask
             p2=96,      # percentage
         )
-        m = self.assert_receive_message('BATTERY_STATUS', timeout=1)
+        m = self.assert_receive_message('BATTERY_STATUS')
         want_battery_remaining_pct = m.battery_remaining
 
         tstart = self.get_sim_time_cached()
@@ -13899,7 +13794,7 @@ switch value'''
         g = ltm.g()
         if g is None:
             return
-        m = self.mav.recv_match(type='GLOBAL_POSITION_INT', blocking=True)
+        m = self.assert_receive_message('GLOBAL_POSITION_INT')
         print("m: %s" % str(m))
 
         print("g.lat=%s m.lat=%s" % (str(g.lat()), str(m.lat)))
@@ -13920,7 +13815,7 @@ switch value'''
             return False
 
         print("sats: %s" % str(g.sats()))
-        m = self.mav.recv_match(type='GPS_RAW_INT', blocking=True)
+        m = self.assert_receive_message('GPS_RAW_INT')
         if m.satellites_visible != g.sats():
             return False
 
@@ -14018,7 +13913,7 @@ switch value'''
         ])
         devo = DEVO(("127.0.0.1", port))
         self.wait_ready_to_arm()
-        m = self.assert_receive_message('GLOBAL_POSITION_INT', timeout=1)
+        m = self.assert_receive_message('GLOBAL_POSITION_INT')
 
         tstart = self.get_sim_time_cached()
         while True:
@@ -14037,7 +13932,7 @@ switch value'''
             if frame is None:
                 continue
 
-            m = self.mav.recv_match(type='GLOBAL_POSITION_INT', blocking=True)
+            m = self.assert_receive_message('GLOBAL_POSITION_INT')
 
             loc = LocationInt(self.convertDmsToDdFormat(frame.lat()), self.convertDmsToDdFormat(frame.lon()), 0, 0)
 
@@ -14064,14 +13959,11 @@ switch value'''
                 continue
 
             # we match the received voltage with the voltage of primary instance
-            batt = self.mav.recv_match(
-                type='BATTERY_STATUS',
-                blocking=True,
+            batt = self.assert_receive_message(
+                'BATTERY_STATUS',
                 timeout=5,
                 condition="BATTERY_STATUS.id==0"
             )
-            if batt is None:
-                raise NotAchievedException("Did not get BATTERY_STATUS message")
             volt = batt.voltages[0]*0.001
             print("received voltage:%s expected voltage:%s" % (str(frame.volt()*0.1), str(volt)))
             if abs(frame.volt()*0.1 - volt) > 0.1:
@@ -14582,9 +14474,8 @@ SERIAL5_BAUD 128
         self._MotorTest(self.run_cmd_int, **kwargs)
 
     def test_ibus_voltage(self, message):
-        batt = self.mav.recv_match(
-            type='BATTERY_STATUS',
-            blocking=True,
+        batt = self.assert_receive_message(
+            'BATTERY_STATUS',
             timeout=5,
             condition="BATTERY_STATUS.id==0"
         )
@@ -14957,7 +14848,7 @@ SERIAL5_BAUD 128
         return self.enum_state_name("MAV_LANDED_STATE", state, pretrim="MAV_LANDED_STATE_")
 
     def assert_extended_sys_state(self, vtol_state, landed_state):
-        m = self.assert_receive_message('EXTENDED_SYS_STATE', timeout=1)
+        m = self.assert_receive_message('EXTENDED_SYS_STATE')
         if m.vtol_state != vtol_state:
             raise ValueError("Bad MAV_VTOL_STATE.  Want=%s got=%s" %
                              (self.vtol_state_name(vtol_state),


### PR DESCRIPTION
we prefer assert_receive_message as it's less verbose than using recv_match all the time, and more consistent in that if you don't receive a message you will get a good error message, as opposed to a lot of places in here which would give you an attribute-on-None exception in case a timeout occurs.  Also means that you *always* get a timeout so won't hang the test in case the message doesn'tcome