### PR TITLE
GCS_MAVLink: log sent named value floats 

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -6675,6 +6675,27 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self._MAV_CMD_EXTERNAL_WIND_ESTIMATE(self.run_cmd)
         self._MAV_CMD_EXTERNAL_WIND_ESTIMATE(self.run_cmd_int)
 
+    def LoggedNamedValueFloat(self):
+        '''ensure that sent named value floats are logged'''
+        self.context_push()
+        self.install_example_script_context('simple_loop.lua')
+        self.set_parameters({
+            'SCR_ENABLE': 1,
+        })
+        self.reboot_sitl()
+        self.wait_ready_to_arm()
+        self.wait_statustext('hello, world')
+        m = self.assert_received_message_field_values('NAMED_VALUE_FLOAT', {
+            "name": "Lua Float",
+        })
+        dfreader = self.dfreader_for_current_onboard_log()
+        self.context_pop()
+
+        m = dfreader.recv_match(type='NVF')
+        if m is None:
+            raise NotAchievedException("Did not find NVF message")
+        self.progress(f"Received NVF with value {m.Value}")
+
     def GliderPullup(self):
         '''test pullup of glider after ALTITUDE_WAIT'''
         self.start_subtest("test glider pullup")
@@ -7051,6 +7072,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.BadRollChannelDefined,
             self.VolzMission,
             self.Volz,
+            self.LoggedNamedValueFloat,
         ]
 
     def disabled_tests(self):

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -119,6 +119,24 @@ void GCS::send_named_float(const char *name, float value) const
 
     gcs().send_to_active_channels(MAVLINK_MSG_ID_NAMED_VALUE_FLOAT,
                                   (const char *)&packet);
+
+#if HAL_LOGGING_ENABLED
+// @LoggerMessage: NVF
+// @Description: Named Value Float messages; messages sent to GCS via NAMED_VALUE_FLOAT
+// @Field: TimeUS: Time since system startup
+// @Field: Name: Name of float
+// @Field: Value: Value of float
+    AP::logger().WriteStreaming(
+        "NVF",
+        "TimeUS," "Name," "Value",
+        "s"       "#"     "-",
+        "F"       "-"     "-",
+        "Q"       "N"     "f",
+        AP_HAL::micros64(),
+        name,
+        value
+    );
+#endif  // HAL_LOGGING_ENABLED
 }
 
 #if HAL_HIGH_LATENCY2_ENABLED


### PR DESCRIPTION
Logs all named value floats sent.

Includes autotest for same.

```
pbarker@fx:~/rc/ardupilot(pr/log-NVF)$ mavlogdump.py logs/00000003.BIN  --t NVF | head -2
2025-03-13 18:41:21.70: NVF {TimeUS : 2744735, Name : Lua Float, Value : 1.3891880512237549}
2025-03-13 18:41:22.71: NVF {TimeUS : 3759329, Name : Lua Float, Value : 1.6240872144699097}
pbarker@fx:~/rc/ardupilot(pr/log-NVF)$ 
```
