### PR TITLE
AP_Motors: fixed motor knocking issue on tilt quadplanes

### DIFF
--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -176,7 +176,7 @@ void AP_MotorsMatrix::output_to_motors()
 
     // convert output to PWM and send to each motor
     for (i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
-        if (motor_enabled[i]) {
+        if (motor_enabled_mask(i)) {
             rc_write(i, output_to_pwm(_actuator[i]));
         }
     }

--- a/libraries/AP_Motors/AP_MotorsTri.cpp
+++ b/libraries/AP_Motors/AP_MotorsTri.cpp
@@ -109,9 +109,15 @@ void AP_MotorsTri::output_to_motors()
             break;
     }
 
-    rc_write(AP_MOTORS_MOT_1, output_to_pwm(_actuator[AP_MOTORS_MOT_1]));
-    rc_write(AP_MOTORS_MOT_2, output_to_pwm(_actuator[AP_MOTORS_MOT_2]));
-    rc_write(AP_MOTORS_MOT_4, output_to_pwm(_actuator[AP_MOTORS_MOT_4]));
+    if (motor_enabled_mask(AP_MOTORS_MOT_1)) {
+        rc_write(AP_MOTORS_MOT_1, output_to_pwm(_actuator[AP_MOTORS_MOT_1]));
+    }
+    if (motor_enabled_mask(AP_MOTORS_MOT_2)) {
+        rc_write(AP_MOTORS_MOT_2, output_to_pwm(_actuator[AP_MOTORS_MOT_2]));
+    }
+    if (motor_enabled_mask(AP_MOTORS_MOT_4)) {
+        rc_write(AP_MOTORS_MOT_4, output_to_pwm(_actuator[AP_MOTORS_MOT_4]));
+    }
 }
 
 // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)


### PR DESCRIPTION
the motor output was happening twice per loop with different values for tilt quadplanes using motor matrix

not tested yet