### PR TITLE
CAN: mailboxes never timeout

### DIFF
--- a/libraries/AP_HAL_ChibiOS/CanIface.cpp
+++ b/libraries/AP_HAL_ChibiOS/CanIface.cpp
@@ -371,6 +371,8 @@ int16_t CANIface::send(const AP_HAL::CANFrame& frame, uint64_t tx_deadline,
         txi.loopback       = (flags & Loopback) != 0;
         txi.abort_on_error = (flags & AbortOnError) != 0;
         // setup frame initial state
+        txi.aborted        = false;
+        txi.setup          = true;
         txi.pushed         = false;
     }
 


### PR DESCRIPTION
CANIface::discardTimedOutTxMailboxes does not drop mailboxes unless they have been `setup`. CANFDIface handles that correctly.