### PR TITLE
HAL_ChibiOS: fixed cork/push

### DIFF
--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -737,7 +737,13 @@ void RCOutput::write(uint8_t chan, uint16_t period_us)
 
     chan -= chan_offset;
 
-    period[chan] = period_us;
+    if (corked) {
+        // when corked we put the updated period in a separate array which is
+        // copied to period[] when we push
+        period_corked[chan] = period_us;
+    } else {
+        period[chan] = period_us;
+    }
 
     if (chan < num_fmu_channels) {
         active_fmu_channels = MAX(chan+1, active_fmu_channels);
@@ -1344,6 +1350,7 @@ void RCOutput::push(void)
         INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
     }
     corked = false;
+    memcpy(period, period_corked, sizeof(period));
     push_local();
 #if HAL_WITH_IO_MCU
     if (iomcu_enabled) {

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -563,6 +563,7 @@ private:
     // these values are for the local channels. Non-local channels are handled by IOMCU
     uint32_t en_mask;
     uint16_t period[max_channels];
+    uint16_t period_corked[max_channels];
 
     // handling of bi-directional dshot
     struct {


### PR DESCRIPTION
ensure that period[] array is not updated until we push
this fixes the stuttering motors on tilt quadplanes, and may fix other issues
this is an alternative to #29518 