### PR TITLE
AP_DDS: airspeed message to include eas_2_tas factor

### DIFF
--- a/Tools/ros2/ardupilot_msgs/CMakeLists.txt
+++ b/Tools/ros2/ardupilot_msgs/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(rosidl_default_generators REQUIRED)
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/GlobalPosition.msg"
   "msg/Status.msg"
+  "msg/Airspeed.msg"
   "srv/ArmMotors.srv"
   "srv/ModeSwitch.srv"
   "srv/Takeoff.srv"

--- a/Tools/ros2/ardupilot_msgs/msg/Airspeed.msg
+++ b/Tools/ros2/ardupilot_msgs/msg/Airspeed.msg
@@ -1,0 +1,8 @@
+std_msgs/Header header
+
+# True Airspeed vector in ROS REP103 axis orientation
+# x: forward; y: left; z: up
+geometry_msgs/Vector3 true_airspeed
+
+# Equivalent to True airspeed conversion factor.
+float32 eas_2_tas

--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -496,7 +496,7 @@ void AP_DDS_Client::update_topic(geometry_msgs_msg_TwistStamped& msg)
 }
 #endif // AP_DDS_LOCAL_VEL_PUB_ENABLED
 #if AP_DDS_AIRSPEED_PUB_ENABLED
-bool AP_DDS_Client::update_topic(geometry_msgs_msg_Vector3Stamped& msg)
+bool AP_DDS_Client::update_topic(ardupilot_msgs_msg_Airspeed& msg)
 {
     update_topic(msg.header.stamp);
     STRCPY(msg.header.frame_id, BASE_LINK_FRAME_ID);
@@ -515,9 +515,10 @@ bool AP_DDS_Client::update_topic(geometry_msgs_msg_Vector3Stamped& msg)
     Vector3f true_airspeed_vec_bf;
     bool is_airspeed_available {false};
     if (ahrs.airspeed_vector_true(true_airspeed_vec_bf)) {
-        msg.vector.x = true_airspeed_vec_bf[0];
-        msg.vector.y = -true_airspeed_vec_bf[1];
-        msg.vector.z = -true_airspeed_vec_bf[2];
+        msg.true_airspeed.x = true_airspeed_vec_bf[0];
+        msg.true_airspeed.y = -true_airspeed_vec_bf[1];
+        msg.true_airspeed.z = -true_airspeed_vec_bf[2];
+        msg.eas_2_tas = ahrs.get_EAS2TAS();
         is_airspeed_available = true;
     }
     return is_airspeed_available;
@@ -1557,9 +1558,9 @@ void AP_DDS_Client::write_tx_local_airspeed_topic()
     WITH_SEMAPHORE(csem);
     if (connected) {
         ucdrBuffer ub {};
-        const uint32_t topic_size = geometry_msgs_msg_Vector3Stamped_size_of_topic(&tx_local_airspeed_topic, 0);
+        const uint32_t topic_size = ardupilot_msgs_msg_Airspeed_size_of_topic(&tx_local_airspeed_topic, 0);
         uxr_prepare_output_stream(&session, reliable_out, topics[to_underlying(TopicIndex::LOCAL_AIRSPEED_PUB)].dw_id, &ub, topic_size);
-        const bool success = geometry_msgs_msg_Vector3Stamped_serialize_topic(&ub, &tx_local_airspeed_topic);
+        const bool success = ardupilot_msgs_msg_Airspeed_serialize_topic(&ub, &tx_local_airspeed_topic);
         if (!success) {
             // TODO sometimes serialization fails on bootup. Determine why.
             // AP_HAL::panic("FATAL: DDS_Client failed to serialize");

--- a/libraries/AP_DDS/AP_DDS_Client.h
+++ b/libraries/AP_DDS/AP_DDS_Client.h
@@ -42,7 +42,7 @@
 #include "geographic_msgs/msg/GeoPointStamped.h"
 #endif // AP_DDS_GPS_GLOBAL_ORIGIN_PUB_ENABLED
 #if AP_DDS_AIRSPEED_PUB_ENABLED
-#include "geometry_msgs/msg/Vector3Stamped.h"
+#include "ardupilot_msgs/msg/Airspeed.h"
 #endif // AP_DDS_AIRSPEED_PUB_ENABLED
 #if AP_DDS_GEOPOSE_PUB_ENABLED
 #include "geographic_msgs/msg/GeoPoseStamped.h"
@@ -153,12 +153,12 @@ private:
 #endif // AP_DDS_LOCAL_VEL_PUB_ENABLED
 
 #if AP_DDS_AIRSPEED_PUB_ENABLED
-    geometry_msgs_msg_Vector3Stamped tx_local_airspeed_topic;
+    ardupilot_msgs_msg_Airspeed tx_local_airspeed_topic;
     // The last ms timestamp AP_DDS wrote a airspeed message
     uint64_t last_airspeed_time_ms;
     //! @brief Serialize the current local airspeed and publish to the IO stream(s)
     void write_tx_local_airspeed_topic();
-    static bool update_topic(geometry_msgs_msg_Vector3Stamped& msg);
+    static bool update_topic(ardupilot_msgs_msg_Airspeed& msg);
 #endif //AP_DDS_AIRSPEED_PUB_ENABLED
 
 #if AP_DDS_BATTERY_STATE_PUB_ENABLED

--- a/libraries/AP_DDS/AP_DDS_Topic_Table.h
+++ b/libraries/AP_DDS/AP_DDS_Topic_Table.h
@@ -211,7 +211,7 @@ constexpr struct AP_DDS_Client::Topic_table AP_DDS_Client::topics[] = {
         .dr_id = uxrObjectId{.id=to_underlying(TopicIndex::LOCAL_AIRSPEED_PUB), .type=UXR_DATAREADER_ID},
         .topic_rw = Topic_rw::DataWriter,
         .topic_name = "rt/ap/airspeed",
-        .type_name = "geometry_msgs::msg::dds_::Vector3Stamped_",
+        .type_name = "ardupilot_msgs::msg::dds_::Airspeed_",
         .qos = {
             .durability = UXR_DURABILITY_VOLATILE,
             .reliability = UXR_RELIABILITY_BEST_EFFORT,

--- a/libraries/AP_DDS/Idl/ardupilot_msgs/msg/Airspeed.idl
+++ b/libraries/AP_DDS/Idl/ardupilot_msgs/msg/Airspeed.idl
@@ -1,0 +1,23 @@
+// generated from rosidl_adapter/resource/msg.idl.em
+// with input from ardupilot_msgs/msg/Airspeed.msg
+// generated code does not contain a copyright notice
+
+#include "geometry_msgs/msg/Vector3.idl"
+#include "std_msgs/msg/Header.idl"
+
+module ardupilot_msgs {
+  module msg {
+    struct Airspeed {
+      std_msgs::msg::Header header;
+
+      @verbatim (language="comment", text=
+        "True Airspeed vector in ROS REP103 axis orientation" "\n"
+        "x: forward; y: left; z: up")
+      geometry_msgs::msg::Vector3 true_airspeed;
+
+      @verbatim (language="comment", text=
+        "Equivalent to True airspeed conversion factor.")
+      float eas_2_tas;
+    };
+  };
+};

--- a/libraries/AP_DDS/README.md
+++ b/libraries/AP_DDS/README.md
@@ -153,7 +153,7 @@ Depending on what's configured, you will see something similar to this:
 ```bash
 $ ros2 topic list -v
 Published topics:
- * /ap/airspeed [geometry_msgs/msg/Vector3] 1 publisher
+ * /ap/airspeed [ardupilot_msgs/msg/Airspeed] 1 publisher
  * /ap/battery [sensor_msgs/msg/BatteryState] 1 publisher
  * /ap/clock [rosgraph_msgs/msg/Clock] 1 publisher
  * /ap/geopose/filtered [geographic_msgs/msg/GeoPoseStamped] 1 publisher


### PR DESCRIPTION
# What Changed

Current `/ap/airspeed` topic publishes the true airspeed vector, but many user need to operate in Equivalent Airspeed. It is then useful to provide users with the same scale factor that Ardupilot uses internally to obtain the Equivalent Airspeed, rather then asking developers to use their own conversion algorithm which could result in errors.

- Created a new message type `Airspeed`, which contains the same vector as before, plus the scale factor `eas_2_tas`.

# Test

```
ros2 topic info /ap/airspeed
Type: ardupilot_msgs/msg/Airspeed
Publisher count: 1
Subscription count: 0
```

```
ros2 topic echo /ap/airspeed --once
header:
  stamp:
    sec: 1741905800
    nanosec: 131471000
  frame_id: base_link
true_airspeed:
  x: -0.015433487482368946
  y: -0.015331915579736233
  z: -0.003518373006954789
eas_2_tas: 1.0286216735839844
---
```

