### PR TITLE
AC_Fence: do not store radius as integers if they look like integers

### DIFF
--- a/libraries/AC_Fence/AC_PolyFence_loader.cpp
+++ b/libraries/AC_Fence/AC_PolyFence_loader.cpp
@@ -1096,30 +1096,13 @@ bool AC_PolyFence_loader::write_fence(const AC_PolyFenceItem *new_items, uint16_
         case AC_PolyFenceType::CIRCLE_INCLUSION:
         case AC_PolyFenceType::CIRCLE_EXCLUSION: {
             total_vertex_count++; // useful to make number of lines in QGC file match FENCE_TOTAL
-            const bool store_as_int = (new_item.radius - int(new_item.radius) < 0.001);
-            AC_PolyFenceType store_type = new_item.type;
-            if (store_as_int) {
-                if (new_item.type == AC_PolyFenceType::CIRCLE_INCLUSION) {
-                    store_type = AC_PolyFenceType::CIRCLE_INCLUSION_INT;
-                } else {
-                    store_type = AC_PolyFenceType::CIRCLE_EXCLUSION_INT;
-                }
-            }
-
-            if (!write_type_to_storage(offset, store_type)) {
+            if (!write_type_to_storage(offset, new_item.type)) {
                 return false;
             }
             if (!write_latlon_to_storage(offset, new_item.loc)) {
                 return false;
             }
-            // store the radius.  If the radius is very close to an
-            // integer then we store it as an integer so users moving
-            // from 4.1 back to 4.0 might be less-disrupted.
-            if (store_as_int) {
-                fence_storage.write_uint32(offset, new_item.radius);
-            } else {
-                fence_storage.write_float(offset, new_item.radius);
-            }
+            fence_storage.write_float(offset, new_item.radius);
             offset += 4;
             break;
         }

--- a/libraries/AC_Fence/AC_PolyFence_loader.h
+++ b/libraries/AC_Fence/AC_PolyFence_loader.h
@@ -9,6 +9,15 @@
 // radius looks like an integer as a backwards-compatibility measure.
 // For 4.2 we might consider only loading _INT and always saving as
 // float, and in 4.3 considering _INT invalid
+
+// CODE_REMOVAL
+// ArduPilot 4.7 no longer stores circle radiuses that look like
+//   integers as integer item types, so any time a fence is saved the
+//   use of the deprecated types is fixed.
+// ArduPilot 4.8 warns if it loads an integer item, warns user to re-upload the fence
+// ArduPilot 4.9 warns if it loads an integer item, warns user to re-upload the fence
+// ArduPilot 4.10 removes support for them
+
 enum class AC_PolyFenceType : uint8_t {
     END_OF_STORAGE        = 99,
     POLYGON_INCLUSION     = 98,


### PR DESCRIPTION
... and a plan to get rid of this compatability code

This is why we have these two types (copied from the code):
```
// CIRCLE_INCLUSION_INT stores the radius an a 32-bit integer in
// metres.  This was a bug, and CIRCLE_INCLUSION was created to store
// as a 32-bit float instead.  We save as _INT in the case that the
// radius looks like an integer as a backwards-compatibility measure.
// For 4.2 we might consider only loading _INT and always saving as
// float, and in 4.3 considering _INT invalid
```

I don't think this is a good candidate for build_options.py - we should just auto-fix the thing in storage for a couple of versions.
