### PR TITLE
Tools:add build option for baro thrust correction

### DIFF
--- a/Tools/autotest/test_build_options.py
+++ b/Tools/autotest/test_build_options.py
@@ -268,6 +268,7 @@ class TestBuildOptions(object):
             'AP_PLANE_BLACKBOX_LOGGING',  # entirely elided if no user
             'AP_COMPASS_AK8963_ENABLED',  # probed on a board-by-board basis, not on CubeOrange for example
             'AP_COMPASS_LSM303D_ENABLED',  # probed on a board-by-board basis, not on CubeOrange for example
+            'AP_BARO_THST_COMP_ENABLED',  # compiler is optimising this symbol away
         ])
         if target.lower() != "copter":
             feature_define_whitelist.add('MODE_ZIGZAG_ENABLED')

--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -326,6 +326,7 @@ BUILD_OPTIONS = [
     # Feature('Baro', 'ICP201XX', 'AP_BARO_ICP201XX_ENABLED', 'Enable ICP201XX Barometric Sensor', 0, None),
     Feature('Baro', 'BARO_TEMPCAL', 'AP_TEMPCALIBRATION_ENABLED', 'Enable Baro Temperature Calibration', 0, None),
     Feature('Baro', 'BARO_PROBEXT', 'AP_BARO_PROBE_EXTERNAL_I2C_BUSES', 'Enable Probing of External i2c buses', 0, None),
+    Feature('Baro', 'BARO_THRUST_COMP', 'AP_BARO_THST_COMP_ENABLED', 'Enable thrust compensation on BARO1', 0, None),
 
     Feature('Sensors', 'RPM', 'AP_RPM_ENABLED', 'Enable RPM sensors', 0, None),
     Feature('Sensors', 'RPM_EFI', 'AP_RPM_EFI_ENABLED', 'Enable RPM EFI sensors', 0, 'RPM,EFI'),

--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -218,6 +218,7 @@ class ExtractFeatures(object):
             ('HAL_DISPLAY_ENABLED', r'Display::init\b',),
             ('HAL_NMEA_OUTPUT_ENABLED', r'AP_NMEA_Output::update\b',),
             ('HAL_BARO_WIND_COMP_ENABLED', r'AP_Baro::wind_pressure_correction\b',),
+            ('AP_BARO_THST_COMP_ENABLED', r'AP_Baro::thrust_pressure_correction\b',),
             ('AP_TEMPCALIBRATION_ENABLED', r'AP_TempCalibration::apply_calibration',),
 
             ('HAL_PICCOLO_CAN_ENABLE', r'AP_PiccoloCAN::update',),


### PR DESCRIPTION
Don't see the point that only one board has this, and any user would need to build locally a new board def and firmware to use it...if its worth having in the code, we should let users access it