### PR TITLE
Plane: proposed changes for 4.6.0-beta5

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -871,7 +871,7 @@ bool Plane::set_target_location(const Location &target_loc)
         return false;
     }
     // add home alt if needed
-    if (loc.relative_alt) {
+    if (loc.relative_alt && !loc.terrain_alt) {
         loc.alt += plane.home.alt;
         loc.relative_alt = 0;
     }

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -749,7 +749,7 @@ bool GCS_MAVLINK_Plane::handle_guided_request(AP_Mission::Mission_Command &cmd)
 void GCS_MAVLINK_Plane::handle_change_alt_request(AP_Mission::Mission_Command &cmd)
 {
     plane.next_WP_loc.alt = cmd.content.location.alt;
-    if (cmd.content.location.relative_alt) {
+    if (cmd.content.location.relative_alt && !cmd.content.location.terrain_alt) {
         plane.next_WP_loc.alt += plane.home.alt;
     }
     plane.next_WP_loc.relative_alt = false;
@@ -865,7 +865,7 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_command_int_do_reposition(const mavlink_com
         plane.set_mode(plane.mode_guided, ModeReason::GCS_COMMAND);
 
         // add home alt if needed
-        if (requested_position.relative_alt) {
+        if (requested_position.relative_alt && !requested_position.terrain_alt) {
             requested_position.alt += plane.home.alt;
             requested_position.relative_alt = 0;
         }

--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -147,6 +147,12 @@ bool Mode::enter()
             bool have_airspeed = quadplane.ahrs.airspeed_estimate(aspeed);
             quadplane.assisted_flight = quadplane.assist.should_assist(aspeed, have_airspeed);
         }
+
+        if (is_vtol_mode() && !quadplane.tailsitter.enabled()) {
+            // if flying inverted and entering a VTOL mode cancel
+            // inverted flight
+            plane.inverted_flight = false;
+        }
 #endif
     }
 

--- a/ArduPlane/mode_guided.cpp
+++ b/ArduPlane/mode_guided.cpp
@@ -109,7 +109,7 @@ void ModeGuided::navigate()
 bool ModeGuided::handle_guided_request(Location target_loc)
 {
     // add home alt if needed
-    if (target_loc.relative_alt) {
+    if (target_loc.relative_alt && !target_loc.terrain_alt) {
         target_loc.alt += plane.home.alt;
         target_loc.relative_alt = 0;
     }

--- a/ArduPlane/mode_qautotune.cpp
+++ b/ArduPlane/mode_qautotune.cpp
@@ -35,6 +35,9 @@ void ModeQAutotune::run()
     // Stabilize with fixed wing surfaces
     plane.stabilize_roll();
     plane.stabilize_pitch();
+
+    // Center rudder
+    output_rudder_and_steering(0.0);
 }
 
 void ModeQAutotune::_exit()

--- a/ArduPlane/mode_qhover.cpp
+++ b/ArduPlane/mode_qhover.cpp
@@ -44,6 +44,9 @@ void ModeQHover::run()
     // Stabilize with fixed wing surfaces
     plane.stabilize_roll();
     plane.stabilize_pitch();
+
+    // Center rudder
+    output_rudder_and_steering(0.0);
 }
 
 #endif

--- a/ArduPlane/mode_qloiter.cpp
+++ b/ArduPlane/mode_qloiter.cpp
@@ -162,6 +162,9 @@ void ModeQLoiter::run()
     // Stabilize with fixed wing surfaces
     plane.stabilize_roll();
     plane.stabilize_pitch();
+
+    // Center rudder
+    output_rudder_and_steering(0.0);
 }
 
 #endif

--- a/ArduPlane/mode_qrtl.cpp
+++ b/ArduPlane/mode_qrtl.cpp
@@ -179,6 +179,7 @@ void ModeQRTL::run()
     // Stabilize with fixed wing surfaces
     plane.stabilize_roll();
     plane.stabilize_pitch();
+    plane.stabilize_yaw();
 }
 
 /*

--- a/ArduPlane/mode_qstabilize.cpp
+++ b/ArduPlane/mode_qstabilize.cpp
@@ -64,6 +64,9 @@ void ModeQStabilize::run()
     // Stabilize with fixed wing surfaces
     plane.stabilize_roll();
     plane.stabilize_pitch();
+
+    // Center rudder
+    output_rudder_and_steering(0.0);
 }
 
 // set the desired roll and pitch for a tailsitter

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -983,7 +983,7 @@ void QuadPlane::multicopter_attitude_rate_update(float yaw_rate_cds)
         // disable yaw time constant for 1:1 match of desired rates
         disable_yaw_rate_time_constant();
 
-        attitude_control->input_rate_bf_roll_pitch_yaw_2(bf_input_cd.x, bf_input_cd.y, bf_input_cd.z);
+        attitude_control->input_rate_bf_roll_pitch_yaw_no_shaping(bf_input_cd.x, bf_input_cd.y, bf_input_cd.z);
     }
 }
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -899,7 +899,7 @@ void QuadPlane::run_esc_calibration(void)
  */
 void QuadPlane::multicopter_attitude_rate_update(float yaw_rate_cds)
 {
-    bool use_multicopter_control = in_vtol_mode() && !tailsitter.in_vtol_transition();
+    bool use_multicopter_control = in_vtol_mode() && !tailsitter.in_vtol_transition() && !force_fw_control_recovery;
     bool use_yaw_target = false;
 
     float yaw_target_cd = 0.0;
@@ -1961,7 +1961,40 @@ void QuadPlane::motors_output(bool run_rate_controller)
         if (now - last_att_control_ms > 100) {
             // relax if have been inactive
             relax_attitude_control();
+            /*
+              when starting the VTOL motors force use of the fixed
+              wing controller for attitude control if we are outside
+              of the Q_ANGLE_MAX limit. We keep it forced until we
+              have recovered to within the limit
+
+              This avoids an issue with the attitude controller
+              limiting the rate of recovery and also an issue with the
+              quaternion controller trying to fix the attitude in a
+              way that is bad for fixed wing aircraft (eg. putting
+              nose down when inverted, leading to rapid loss of
+              height)
+
+              we don't do this in QACRO or tailsitter modes, as this
+              type of attitude is expected
+            */
+            if (!tailsitter.enabled() &&
+                plane.control_mode != &plane.mode_qacro &&
+                (abs(ahrs.roll_sensor) > aparm.angle_max ||
+                 abs(ahrs.pitch_sensor) > aparm.angle_max)) {
+                force_fw_control_recovery = true;
+            }
         }
+        if (force_fw_control_recovery) {
+            // see if we have recovered attitude
+            if (abs(ahrs.roll_sensor) <= aparm.angle_max &&
+                abs(ahrs.pitch_sensor) <= aparm.angle_max) {
+                force_fw_control_recovery = false;
+                // reset the attitude target to the new attitude so
+                // the VTOL controller doesn't pull us back
+                attitude_control->reset_target_and_rate(false);
+            }
+        }
+
         // run low level rate controllers that only require IMU data and set loop time
         const float last_loop_time_s = AP::scheduler().get_last_loop_time_s();
         motors->set_dt(last_loop_time_s);
@@ -3621,6 +3654,7 @@ void QuadPlane::Log_Write_QControl_Tuning()
         speed              = 1U<<2, // true if assistance due to low airspeed
         alt                = 1U<<3, // true if assistance due to low altitude
         angle              = 1U<<4, // true if assistance due to attitude error
+        fw_force           = 1U<<5, // true if forcing use of fixed wing controllers
     };
 
     uint8_t assist_flags = 0;
@@ -3638,6 +3672,9 @@ void QuadPlane::Log_Write_QControl_Tuning()
     }
     if (assist.in_angle_assist()) {
         assist_flags |= (uint8_t)log_assistance_flags::angle;
+    }
+    if (force_fw_control_recovery) {
+        assist_flags |= (uint8_t)log_assistance_flags::fw_force;
     }
 
     struct log_QControl_Tuning pkt = {
@@ -4216,7 +4253,8 @@ bool QuadPlane::use_fw_attitude_controllers(void) const
         motors->get_desired_spool_state() >= AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED &&
         in_vtol_mode() &&
         !tailsitter.enabled() &&
-        poscontrol.get_state() != QPOS_AIRBRAKE) {
+        poscontrol.get_state() != QPOS_AIRBRAKE &&
+        !force_fw_control_recovery) {
         // we want the desired rates for fixed wing slaved to the
         // multicopter rates
         return false;

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -631,6 +631,9 @@ private:
     // ignored unless OPTION_DELAY_ARMING or OPTION_TILT_DISARMED is set
     bool delay_arming;
 
+    // should we force use of fixed wing controller for attitude upset recovery?
+    bool force_fw_control_recovery;
+
     /*
       return true if current mission item is a vtol takeoff
      */

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -556,6 +556,9 @@ bool Tailsitter::transition_vtol_complete(void) const
     const float trans_angle = get_transition_angle_vtol();
     if (labs(plane.ahrs.pitch_sensor) > trans_angle*100) {
         gcs().send_text(MAV_SEVERITY_INFO, "Transition VTOL done");
+        // clear inverted flight flag to make behaviour consistent
+        // with other quadplane types
+        plane.inverted_flight = false;
         return true;
     }
     int32_t roll_cd = labs(plane.ahrs.roll_sensor);

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -5667,7 +5667,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         '''test handling of MAV_CMD_GUIDED_CHANGE_ALTITUDE'''
         target_alt = 750
         # this location is chosen to be fairly flat, but at a different terrain height to home
-        higher_ground = mavutil.location(-35.35465024,149.13974996, target_alt, 0)
+        higher_ground = mavutil.location(-35.35465024, 149.13974996, target_alt, 0)
         self.install_terrain_handlers_context()
         self.start_subtest("set home relative altitude")
         self.takeoff(30, relative=True)
@@ -5685,7 +5685,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             timeout=600,
             height_accuracy=10,
         )
-        
+
         for alt in 50, 70:
             self.run_cmd_int(
                 mavutil.mavlink.MAV_CMD_GUIDED_CHANGE_ALTITUDE,
@@ -5834,7 +5834,6 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             relative=False,
             altitude_source="TERRAIN_REPORT.current_height"
         )
-        
 
         self.delay_sim_time(5)
         self.fly_home_land_and_disarm()

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -2161,6 +2161,46 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
                 self.progress("Wind estimates correlated")
                 break
 
+    def FastInvertedRecovery(self):
+        '''test recovery from inverted flight is fast'''
+
+        self.set_parameters({
+            "Q_A_ACCEL_R_MAX": 20000,
+            "Q_A_ACCEL_P_MAX": 20000,
+            "Q_A_ACCEL_Y_MAX": 20000,
+            "Q_A_RATE_R_MAX": 50,
+            "Q_A_RATE_P_MAX": 50,
+            "Q_A_RATE_Y_MAX": 50,
+        })
+
+        self.wait_ready_to_arm()
+        self.takeoff(60, mode='GUIDED', timeout=100)
+
+        self.context_collect('STATUSTEXT')
+        self.set_rc(3, 1500)
+        self.change_mode('CRUISE')
+        self.wait_statustext("Transition done", check_context=True)
+
+        self.progress("Go to inverted flight")
+        self.run_auxfunc(43, 2)
+        self.wait_roll(180, 3, absolute_value=True)
+        self.delay_sim_time(10)
+
+        initial_altitude = self.get_altitude(relative=True, timeout=2)
+        self.change_mode('QHOVER')
+
+        self.wait_roll(0, 3, absolute_value=True)
+
+        recovery_altitude = self.get_altitude(relative=True, timeout=2)
+        alt_change = initial_altitude - recovery_altitude
+
+        self.progress("Recovery AltChange %.1fm" % alt_change)
+
+        max_alt_change = 3
+        if alt_change > max_alt_change:
+            raise NotAchievedException("Recovery AltChange too high %.1f > %.1f" % (alt_change, max_alt_change))
+        self.fly_home_land_and_disarm()
+
     def tests(self):
         '''return list of all tests'''
 
@@ -2213,5 +2253,6 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.RTL_AUTOLAND_1,  # as in fly-home then go to landing sequence
             self.RTL_AUTOLAND_1_FROM_GUIDED,  # as in fly-home then go to landing sequence
             self.AHRSFlyForwardFlag,
+            self.FastInvertedRecovery,
         ])
         return ret

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -9,6 +9,7 @@ from __future__ import print_function
 import os
 import numpy
 import math
+import copy
 
 from pymavlink import mavutil
 from pymavlink.rotmat import Vector3
@@ -2201,6 +2202,43 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             raise NotAchievedException("Recovery AltChange too high %.1f > %.1f" % (alt_change, max_alt_change))
         self.fly_home_land_and_disarm()
 
+    def DoRepositionTerrain(self):
+        '''test handling of DO_REPOSITION with terrain alt'''
+        # this location is chosen to be fairly flat, but at a different terrain height to home
+        self.install_terrain_handlers_context()
+        self.start_subtest("test reposition with terrain alt")
+        self.wait_ready_to_arm()
+
+        dest = copy.copy(SITL_START_LOCATION)
+        dest.alt = 45
+
+        self.set_parameters({
+            'Q_GUIDED_MODE': 1,
+        })
+
+        self.takeoff(30, mode='GUIDED')
+
+        # fly to higher ground
+        self.send_do_reposition(dest, frame=mavutil.mavlink.MAV_FRAME_GLOBAL_TERRAIN_ALT)
+        self.wait_location(
+            dest,
+            accuracy=200,
+            timeout=600,
+            height_accuracy=10,
+        )
+        self.delay_sim_time(20)
+
+        self.wait_altitude(
+            dest.alt-10,  # NOTE: reuse of alt from abovE
+            dest.alt+10,  # use a 10m buffer as the plane needs to go up and down a bit to maintain terrain distance
+            minimum_duration=10,
+            timeout=30,
+            relative=False,
+            altitude_source="TERRAIN_REPORT.current_height"
+        )
+        self.change_mode("QLAND")
+        self.mav.motors_disarmed_wait()
+
     def tests(self):
         '''return list of all tests'''
 
@@ -2254,5 +2292,6 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.RTL_AUTOLAND_1_FROM_GUIDED,  # as in fly-home then go to landing sequence
             self.AHRSFlyForwardFlag,
             self.FastInvertedRecovery,
+            self.DoRepositionTerrain,
         ])
         return ret

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -7383,12 +7383,14 @@ class TestSuite(ABC):
             **kwargs
         )
 
-    def wait_roll(self, roll, accuracy, timeout=30, **kwargs):
+    def wait_roll(self, roll, accuracy, timeout=30, absolute_value=False, **kwargs):
         """Wait for a given roll in degrees."""
         def get_roll(timeout2):
             msg = self.assert_receive_message('ATTITUDE', timeout=timeout2)
             p = math.degrees(msg.pitch)
             r = math.degrees(msg.roll)
+            if absolute_value:
+                r = abs(r)
             self.progress("Roll %d Pitch %d" % (r, p))
             return r
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -625,6 +625,33 @@ void AC_AttitudeControl::input_rate_bf_roll_pitch_yaw_3(float roll_rate_bf_cds, 
     _ang_vel_body = ang_vel_body;
 }
 
+/*
+  set the body frame target rates to the specified rates, used by the
+  quadplane code when we want to slave the VTOL controller rates to
+  the fixed wing rates
+ */
+void AC_AttitudeControl::input_rate_bf_roll_pitch_yaw_no_shaping(float roll_rate_bf_cds, float pitch_rate_bf_cds, float yaw_rate_bf_cds)
+{
+    // Convert from centidegrees on public interface to radians
+    const float roll_rate_rads = radians(roll_rate_bf_cds * 0.01f);
+    const float pitch_rate_rads = radians(pitch_rate_bf_cds * 0.01f);
+    const float yaw_rate_rads = radians(yaw_rate_bf_cds * 0.01f);
+
+    _ang_vel_target.x = roll_rate_rads;
+    _ang_vel_target.y = pitch_rate_rads;
+    _ang_vel_target.z = yaw_rate_rads;
+
+    // Update the unused targets attitude based on current attitude to condition mode change
+    _ahrs.get_quat_body_to_ned(_attitude_target);
+    _attitude_target.to_euler(_euler_angle_target);
+
+    // Convert body-frame angular velocity into euler angle derivative of desired attitude
+    ang_vel_to_euler_rate(_attitude_target, _ang_vel_target, _euler_rate_target);
+
+    // finally update the attitude target
+    _ang_vel_body = _ang_vel_target;
+}
+
 // Command an angular step (i.e change) in body frame angle
 // Used to command a step in angle without exciting the orthogonal axis during autotune
 void AC_AttitudeControl::input_angle_step_bf_roll_pitch_yaw(float roll_angle_step_bf_cd, float pitch_angle_step_bf_cd, float yaw_angle_step_bf_cd)

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -221,6 +221,11 @@ public:
     // Command an angular velocity with angular velocity smoothing using rate loops only with integrated rate error stabilization
     virtual void input_rate_bf_roll_pitch_yaw_3(float roll_rate_bf_cds, float pitch_rate_bf_cds, float yaw_rate_bf_cds);
 
+    // set the body frame target rates to the specified rates, used by the
+    // quadplane code when we want to slave the VTOL controller rates to
+    // the fixed wing rates
+    void input_rate_bf_roll_pitch_yaw_no_shaping(float roll_rate_bf_cds, float pitch_rate_bf_cds, float yaw_rate_bf_cds);
+
     // Command an angular step (i.e change) in body frame angle
     virtual void input_angle_step_bf_roll_pitch_yaw(float roll_angle_step_bf_cd, float pitch_angle_step_bf_cd, float yaw_angle_step_bf_cd);
 

--- a/libraries/APM_Control/AP_RollController.h
+++ b/libraries/APM_Control/AP_RollController.h
@@ -66,6 +66,7 @@ private:
     float ff_scale = 1.0;
 
     AP_PIDInfo _pid_info;
+    float last_desired_rate;
 
     float _get_rate_out(float desired_rate, float scaler, bool disable_integrator, bool ground_mode);
 };

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -558,6 +558,7 @@ private:
     // these values are for the local channels. Non-local channels are handled by IOMCU
     uint32_t en_mask;
     uint16_t period[max_channels];
+    uint16_t period_corked[max_channels];
 
     // handling of bi-directional dshot
     struct {


### PR DESCRIPTION
This rolls up some key PRs that are being considered for beta5.
 - https://github.com/ArduPilot/ardupilot/pull/29521
 - https://github.com/ArduPilot/ardupilot/pull/29498
 - https://github.com/ArduPilot/ardupilot/pull/28406
 - https://github.com/ArduPilot/ardupilot/pull/29494

I have test flown the 3rd change myself. The other two have only been SITL or bench tested so far. 
The fast attitude recovery PR needs more consideration as it will impact VTOL control during a forward transition. It fixes an issue where VTOL rate control does not match fixed wing control due to the input shaping in the VTOL control. Before considering this for beta5 we need some flight tests to look at any possible impacts

I will create a custom build tag for this PR to help users do testing
