### PR TITLE
Plane: Add tkoff. and land. to landed_state method

### DIFF
--- a/ArduPlane/GCS_MAVLink_Plane.cpp
+++ b/ArduPlane/GCS_MAVLink_Plane.cpp
@@ -1554,6 +1554,13 @@ MAV_VTOL_STATE GCS_MAVLINK_Plane::vtol_state() const
 MAV_LANDED_STATE GCS_MAVLINK_Plane::landed_state() const
 {
     if (plane.is_flying()) {
+        if (plane.is_taking_off()) {
+            return MAV_LANDED_STATE_TAKEOFF;
+        }
+        if (plane.is_landing()) {
+            return MAV_LANDED_STATE_LANDING;
+        }
+
         // note that Q-modes almost always consider themselves as flying
         return MAV_LANDED_STATE_IN_AIR;
     }


### PR DESCRIPTION
Updated the landed_state method in the MAVLink GCS module to accurately reflect the vehicle's status during takeoff and landing in the MAV_LANDED_STATE field of EXTENDED_SYS_STATE. The method now returns MAV_LANDED_STATE_TAKEOFF if the vehicle is taking off and MAV_LANDED_STATE_LANDING if it is landing, matching the ArduCopter and Blimp implementations.

In combination with mavlink/qgroundcontrol#12567, this makes it possible to abort landings in QGroundControl with ArduPilot aircraft.