### PR TITLE
AP_HAL_ChibiOS:New board id added for NeutronRC Mini F405

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -302,6 +302,7 @@ AP_HW_CBU_StampH743_LC               1182
 AP_HW_NarinH7                        1183
 AP_HW_BrahmaF4                       1184
 AP_HW_X-MAV-AP-F405Mini              1185
+AP_HW_ NeutronRCF405                 1186
 
 AP_HW_JFB200                         1200
 

--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -302,7 +302,7 @@ AP_HW_CBU_StampH743_LC               1182
 AP_HW_NarinH7                        1183
 AP_HW_BrahmaF4                       1184
 AP_HW_X-MAV-AP-F405Mini              1185
-AP_HW_ NeutronRCF405                 1186
+AP_HW_NeutronRCF405                 1186
 
 AP_HW_JFB200                         1200
 


### PR DESCRIPTION
Added the board id for [**NeutronRC Mini F405**](https://www.6sfull.cz/en/neutronrc-mini-f405-2-6s-20--20-30--30/).