### PR TITLE
AP_HAL_ESP32: During task creation, the others indicate which core th…

### DIFF
--- a/libraries/AP_HAL_ESP32/Scheduler.cpp
+++ b/libraries/AP_HAL_ESP32/Scheduler.cpp
@@ -121,9 +121,9 @@ void Scheduler::init()
     }	 
 
     if (xTaskCreatePinnedToCore(_storage_thread, "APM_STORAGE", STORAGE_SS, this, STORAGE_PRIO, &_storage_task_handle,SLOWCPU) != pdPASS) { //no actual flash writes without this, storage kinda appears to work, but does an erase on every boot and params don't persist over reset etc.
-        hal.console->printf("FAILED to create task _storage_thread\n");
+        hal.console->printf("FAILED to create task _storage_thread on SLOWCPU\n");
     } else {
-    	hal.console->printf("OK created task _storage_thread\n");
+    	hal.console->printf("OK created task _storage_thread on SLOWCPU\n");
     }
 
     //   xTaskCreatePinnedToCore(_print_profile, "APM_PROFILE", IO_SS, this, IO_PRIO, nullptr,SLOWCPU);


### PR DESCRIPTION
…ey were created on, but _storage_thread does not indicate this. This PR adds this indication to printf.