### PR TITLE
AP_TemperatureSensor: avoid use of OwnPtr

### DIFF
--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Backend.h
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Backend.h
@@ -41,7 +41,7 @@ public:
     // logging functions
     void Log_Write_TEMP() const;
 
-    AP_HAL::OwnPtr<AP_HAL::Device> _dev;
+    AP_HAL::Device *_dev;
 
 
 protected:

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_MAX31865.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_MAX31865.cpp
@@ -80,7 +80,7 @@ void AP_TemperatureSensor_MAX31865::init()
         name[10] = 0;
     }
 
-    _dev = std::move(hal.spi->get_device(name));
+    _dev = hal.spi->get_device_ptr(name);
     if (!_dev) {
         return;
     }

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_MCP9600.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_MCP9600.cpp
@@ -64,7 +64,7 @@ void AP_TemperatureSensor_MCP9600::init()
 {
     constexpr char name[] = "MCP9600";
 
-    _dev = std::move(hal.i2c_mgr->get_device(_params.bus, _params.bus_address));
+    _dev = hal.i2c_mgr->get_device_ptr(_params.bus, _params.bus_address);
     if (!_dev) {
         // device not found
         return;

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_MLX90614.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_MLX90614.cpp
@@ -25,7 +25,7 @@ void AP_TemperatureSensor_MLX90614::init()
 {
     _params.bus_address.set_default(MLX90614_I2CDEFAULTADDR);
     
-    _dev = std::move(hal.i2c_mgr->get_device(_params.bus, _params.bus_address));
+    _dev = hal.i2c_mgr->get_device_ptr(_params.bus, _params.bus_address);
     if (!_dev) {
         return;
     }

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_SHT3x.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_SHT3x.cpp
@@ -33,7 +33,7 @@ void AP_TemperatureSensor_SHT3x::init()
     constexpr char name[] = "SHT3x";
     (void)name;  // sometimes this is unused (e.g. HAL_GCS_ENABLED false)
 
-    _dev = std::move(hal.i2c_mgr->get_device(_params.bus, _params.bus_address));
+    _dev = hal.i2c_mgr->get_device_ptr(_params.bus, _params.bus_address);
     if (!_dev) {
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "%s device is null!", name);
         return;

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_TSYS01.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_TSYS01.cpp
@@ -44,7 +44,7 @@ void AP_TemperatureSensor_TSYS01::init()
     }
 #endif
 
-    _dev = std::move(hal.i2c_mgr->get_device(_params.bus, _params.bus_address));
+    _dev = hal.i2c_mgr->get_device_ptr(_params.bus, _params.bus_address);
     if (!_dev) {
         printf("%s device is null!", name);
         return;

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_TSYS03.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_TSYS03.cpp
@@ -46,7 +46,7 @@ void AP_TemperatureSensor_TSYS03::init()
     }
 #endif
 
-    _dev = std::move(hal.i2c_mgr->get_device(_params.bus, _params.bus_address));
+    _dev = hal.i2c_mgr->get_device_ptr(_params.bus, _params.bus_address);
     if (!_dev) {
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "%s device is null!", name);
         return;


### PR DESCRIPTION
I've tested this on MLX90614
