### PR TITLE
New MAVx_OPTIONS parameter to enable channel-specific signing

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -512,6 +512,14 @@ protected:
     virtual bool persist_streamrates() const { return false; }
     void handle_request_data_stream(const mavlink_message_t &msg);
 
+    AP_Int16 options;
+    enum class Option : uint16_t {
+        MAVLINK2_SIGNING_DISABLED = (1U << 0),
+    };
+    bool option_enabled(Option option) const {
+        return options & static_cast<uint16_t>(option);
+    }
+
     virtual void handle_command_ack(const mavlink_message_t &msg);
     void handle_set_mode(const mavlink_message_t &msg);
     void handle_command_int(const mavlink_message_t &msg);

--- a/libraries/GCS_MAVLink/GCS_MAVLink_Parameters.cpp
+++ b/libraries/GCS_MAVLink/GCS_MAVLink_Parameters.cpp
@@ -202,6 +202,18 @@ const AP_Param::GroupInfo GCS_MAVLINK::var_info[] = {
     // @RebootRequired: True
     // @User: Advanced
     AP_GROUPINFO("_ADSB",   10, GCS_MAVLINK, streamRates[GCS_MAVLINK::STREAM_ADSB], DRATE(GCS_MAVLINK::STREAM_ADSB)),
+
+    // ------------
+    // IMPORTANT: Add new stream rates *before* the _OPTIONS parameter.
+    // ------------
+
+    // @Param: _OPTIONS
+    // @DisplayName: Bitmask for configuring this telemetry channel
+    // @Description: Bitmask for configuring this telemetry channel. For having effect on all channels, set the relevant mask in all MAVx_OPTIONS parameters. Keep in mind that part of the flags may require a reboot to take action.
+    // @RebootRequired: True
+    // @User: Standard
+    // @Bitmask: 0:Accept unsigned MAVLink2 messages
+    AP_GROUPINFO("_OPTIONS",   20, GCS_MAVLINK, options, 0),
     AP_GROUPEND
 };
 #undef DRATE

--- a/libraries/GCS_MAVLink/GCS_Signing.cpp
+++ b/libraries/GCS_MAVLink/GCS_Signing.cpp
@@ -133,7 +133,7 @@ static bool accept_unsigned_callback(const mavlink_status_t *status, uint32_t ms
 void GCS_MAVLINK::load_signing_key(void)
 {
     struct SigningKey key;
-    if (!signing_key_load(key)) {
+    if (option_enabled(Option::MAVLINK2_SIGNING_DISABLED) || !signing_key_load(key)) {
         return;
     }
     memcpy(signing.secret_key, key.secret_key, 32);


### PR DESCRIPTION
**Implements issue #28736** (opened by @IdoBuchman).

Instead of using a bitmask as initially suggested in the issue, this implementation integrates the new parameter into the existing GCS_MAVLINK_Parameters group, which I believe is the most suitable place for it. 😊