### PR TITLE
AP_Scripting: Follow binding enabled for Rover

### DIFF
--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -757,7 +757,7 @@ singleton AP::fwversion() field fw_hash_str string read
 singleton AP::fwversion() field fw_hash_str rename hash
 
 include AP_Follow/AP_Follow.h
-singleton AP_Follow depends AP_FOLLOW_ENABLED && (APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_COPTER_OR_HELI)
+singleton AP_Follow depends AP_FOLLOW_ENABLED && (APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BUILD_COPTER_OR_HELI||APM_BUILD_TYPE(APM_BUILD_Rover))
 singleton AP_Follow rename follow
 singleton AP_Follow method have_target boolean
 singleton AP_Follow method get_last_update_ms uint32_t


### PR DESCRIPTION
This enables the AP_Scripting bindings for the AP_Follow library for Rovers and Boats as requested [here in the 4.6 forums](https://discuss.ardupilot.org/t/issue-with-follow-object-in-lua-script-for-rover-to-follow-copter/131666).

This has been lightly tested in SITL to confirm that a simple script that calls **follow:have_target()** fails before this change and succeeds aftwards
**BEFORE**
![image](https://github.com/user-attachments/assets/683563ea-c27b-4f1e-8636-d2bae79b80b5)

**AFTER**
![image](https://github.com/user-attachments/assets/b029ad85-9755-4c1c-a6a3-6dcc97603001)

