### PR TITLE
AP_HAL_Linux: set BOTHER c_cflag to choose other baudrates

### DIFF
--- a/libraries/AP_HAL_Linux/UARTDevice.cpp
+++ b/libraries/AP_HAL_Linux/UARTDevice.cpp
@@ -119,9 +119,12 @@ void UARTDevice::set_speed(uint32_t baudrate)
         return;
     }
 
-    // use CBAUDEX to gain access to "non-standard" rates that are common for eg. RC receivers
+    // use CBAUDEX and B(aud)OTHER to gain access to "non-standard" rates that are common for eg. RC receivers
     tio.c_cflag &= ~CBAUD;
     tio.c_cflag |= CBAUDEX;
+#if defined BOTHER    
+    tio.c_cflag |= BOTHER;
+#endif
     tio.c_ispeed = baudrate;
     tio.c_ospeed = baudrate;
 


### PR DESCRIPTION
I found that on an RPi5 (raspberrypi kernel) reliably setting non-standard baudrates needs the BOTHER flag

References:
* https://man7.org/linux/man-pages/man2/TCSETS.2const.html (how I did it)
* https://www.downtowndougbrown.com/2013/11/linux-custom-serial-baud-rates/ (why I did it)