### PR TITLE
GCS_MAVLink: correct compilation on heavy-periph

### DIFF
--- a/libraries/GCS_MAVLink/GCS_config.h
+++ b/libraries/GCS_MAVLink/GCS_config.h
@@ -4,6 +4,7 @@
 #include <AP_Relay/AP_Relay_config.h>
 #include <AP_Mission/AP_Mission_config.h>
 #include <AP_InertialSensor/AP_InertialSensor_config.h>
+#include <AP_Arming/AP_Arming_config.h>
 
 #ifndef HAL_GCS_ENABLED
 #define HAL_GCS_ENABLED 1
@@ -112,5 +113,5 @@
 #endif
 
 #ifndef AP_MAVLINK_MSG_FLIGHT_INFORMATION_ENABLED
-#define AP_MAVLINK_MSG_FLIGHT_INFORMATION_ENABLED 1
+#define AP_MAVLINK_MSG_FLIGHT_INFORMATION_ENABLED HAL_GCS_ENABLED && AP_ARMING_ENABLED
 #endif


### PR DESCRIPTION
arming may not be present on periph