### PR TITLE
Plane: change loc alt frame in set_guided_WP rather than callers

### DIFF
--- a/ArduPlane/GCS_MAVLink_Plane.cpp
+++ b/ArduPlane/GCS_MAVLink_Plane.cpp
@@ -874,11 +874,6 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_command_int_do_reposition(const mavlink_com
 #endif
 
         // add home alt if needed
-        if (requested_position.relative_alt && !requested_position.terrain_alt) {
-            requested_position.alt += plane.home.alt;
-            requested_position.relative_alt = 0;
-        }
-
         plane.set_guided_WP(requested_position);
 
         // Loiter radius for planes. Positive radius in meters, direction is controlled by Yaw (param4) value, parsed above

--- a/ArduPlane/Plane.cpp
+++ b/ArduPlane/Plane.cpp
@@ -868,18 +868,11 @@ bool Plane::get_wp_crosstrack_error_m(float &xtrack_error) const
 // set target location (for use by external control and scripting)
 bool Plane::set_target_location(const Location &target_loc)
 {
-    Location loc{target_loc};
-
     if (plane.control_mode != &plane.mode_guided) {
         // only accept position updates when in GUIDED mode
         return false;
     }
-    // add home alt if needed
-    if (loc.relative_alt && !loc.terrain_alt) {
-        loc.alt += plane.home.alt;
-        loc.relative_alt = 0;
-    }
-    plane.set_guided_WP(loc);
+    plane.set_guided_WP(target_loc);
     return true;
 }
 #endif //AP_SCRIPTING_ENABLED || AP_EXTERNAL_CONTROL_ENABLED

--- a/ArduPlane/commands.cpp
+++ b/ArduPlane/commands.cpp
@@ -85,6 +85,13 @@ void Plane::set_guided_WP(const Location &loc)
     // ---------------------
     next_WP_loc = loc;
 
+    // Plane can cope with next_WP_loc being in either terrain or
+    // absolute altitude, but *not* home altitude:
+    if (next_WP_loc.relative_alt && !next_WP_loc.terrain_alt) {
+        next_WP_loc.alt += plane.home.alt;
+        next_WP_loc.relative_alt = 0;
+    }
+
     // used to control FBW and limit the rate of climb
     // -----------------------------------------------
     set_target_altitude_current();

--- a/ArduPlane/mode_guided.cpp
+++ b/ArduPlane/mode_guided.cpp
@@ -108,12 +108,6 @@ void ModeGuided::navigate()
 
 bool ModeGuided::handle_guided_request(Location target_loc)
 {
-    // add home alt if needed
-    if (target_loc.relative_alt && !target_loc.terrain_alt) {
-        target_loc.alt += plane.home.alt;
-        target_loc.relative_alt = 0;
-    }
-
     plane.set_guided_WP(target_loc);
 
     return true;


### PR DESCRIPTION
centralise this to reduce accesses to the attributes

This changes our logic around mode_LoiterAltQLand - if terrain is not enabled then we would set the altitude relatve-to-home in `next_WP_loc`.  There are many places in the code which assume that next_WP_loc is in either terrain-relative or absolute frames.

@IamPete1 do you see any problems if we instantly convert the home-relative next-wp-loc for loiteraltqland to the absolute frame rather than home-relative frame?
 