### PR TITLE
AP_Camera: avoid SITL panic if pic taken with no pos estimate

### DIFF
--- a/libraries/AP_Camera/AP_Camera_Logging.cpp
+++ b/libraries/AP_Camera/AP_Camera_Logging.cpp
@@ -30,14 +30,12 @@ void AP_Camera_Backend::Write_CameraInfo(enum LogMessages msg, uint64_t timestam
     }
 
     int32_t altitude_cm = 0;
-    if (!current_loc.get_alt_cm(Location::AltFrame::ABSOLUTE, altitude_cm)) {
-        // ignore this problem...
-    }
     int32_t altitude_rel_cm = 0;
-    if (!current_loc.get_alt_cm(Location::AltFrame::ABOVE_HOME, altitude_rel_cm)) {
-        // ignore this problem...
+    if (current_loc.initialised()) {
+        // ignore failures to get altitude
+        IGNORE_RETURN(current_loc.get_alt_cm(Location::AltFrame::ABSOLUTE, altitude_cm));
+        IGNORE_RETURN(current_loc.get_alt_cm(Location::AltFrame::ABOVE_HOME, altitude_rel_cm));
     }
-
 
     int32_t altitude_gps_cm = 0;
     const AP_GPS &gps = AP::gps();


### PR DESCRIPTION
This resolves issue https://github.com/ArduPilot/ardupilot/issues/29530 by checking that the current_loc has been initialised before attempting to get the altitude from it.

This fix is thanks to @blaab2 and the commit is co-authored with him, thanks!

I've lightly tested this in SITL by performing a before/after test to confirm the issue occurs before this fix and does not afterwards.

BTW, the issue can be reproduced in SITL by doing this:

1. rm eeprom.bin file
2. start SITL
3. param set LOG_DISARMED 1
4. param set GPS1_TYPE 0
5. restart SITL
6. right-mouse-button click on MP's map and select, "Trigger Camera NOW"

Below is a screenshot of what appears in the LOGS which is a mostly zero message
![image](https://github.com/user-attachments/assets/4362087f-53ea-4c7c-995f-57d84df3b31d)

