### PR TITLE
Plane: tailsitter: ensure none-masked motors are zeroed in forward flight

### DIFF
--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -289,6 +289,12 @@ void Tailsitter::output(void)
         return;
     }
 
+    if (!hal.util->get_soft_armed() ||
+        SRV_Channels::get_emergency_stop()) {
+        // Ensure motors stop on disarm
+        motors->output_min();
+    }
+
     // throttle 0 to 1
     float throttle = SRV_Channels::get_output_scaled(SRV_Channel::k_throttle) * 0.01;
 


### PR DESCRIPTION
fixes https://github.com/ArduPilot/ardupilot/issues/29555. Thanks to https://github.com/ArduPilot/ardupilot/pull/26249 we were leaving the motors not masked for forward flight to be smoothly ramped back to zero for tiltrotors. However we overlooked the tailsitter case. Because the normal motor output is not called the motors were not being zeroed. The fix is to call the output function. 