### PR TITLE
autotest: fix race in getting statustext

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -5519,6 +5519,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
              "AUTOLAND_WP_ALT" : 55,
              "AUTOLAND_WP_DIST" : 400
             })
+        self.wait_ready_to_arm()
         self.scripting_restart()
         self.wait_text("Scripting: restarted", check_context=True)
 


### PR DESCRIPTION
we emit a lot of texts when starting up and getting lock.  Avoid missing our scripting restart message by waiting ready-to-arm before doing the restart