### PR TITLE
SITL: SIM_FlightAxis: use an objectbuffer for holding connections to FlightAxis

### DIFF
--- a/libraries/SITL/SIM_FlightAxis.h
+++ b/libraries/SITL/SIM_FlightAxis.h
@@ -204,8 +204,11 @@ private:
 
     const char *controller_ip = "127.0.0.1";
     uint16_t controller_port = 18083;
-    SocketAPM_native *socknext;
+
+    // a list of sockets used to reduce inter-packet latency
+    ObjectBuffer_TS<SocketAPM_native*> socks{2};
     SocketAPM_native *sock;
+
     char replybuf[10000];
     pid_t socket_pid;
     uint32_t sock_error_count;


### PR DESCRIPTION
So the existing code was doing a bang-up job of double-buffering... using three pthread mutexes.

We have an ObjectBuffer_TS we can use to get the same effect, but it's simpler and generalises to having more waiting connections.

This *also* doesn't use pthread constructions, meaning it's more portable.

There's no discernible performance difference between this and master.  *Perhaps* a little better when running with a three socket queue - but there's a *lot* of noise!
