### PR TITLE
AP_Logger: retitle LOG_MAV_Stats to log_DMS

### DIFF
--- a/libraries/AP_Logger/AP_Logger_MAVLink.cpp
+++ b/libraries/AP_Logger/AP_Logger_MAVLink.cpp
@@ -327,13 +327,13 @@ void AP_Logger_MAVLink::stats_reset() {
     stats.collection_count = 0;
 }
 
-void AP_Logger_MAVLink::Write_logger_MAV(AP_Logger_MAVLink &logger_mav)
+void AP_Logger_MAVLink::Write_DMS(AP_Logger_MAVLink &logger_mav)
 {
     if (logger_mav.stats.collection_count == 0) {
         return;
     }
-    const struct log_MAV_Stats pkt{
-        LOG_PACKET_HEADER_INIT(LOG_MAV_STATS),
+    const struct log_DMS pkt{
+        LOG_PACKET_HEADER_INIT(LOG_DMS),
         timestamp         : AP_HAL::micros64(),
         seqno             : logger_mav._next_seq_num-1,
         dropped           : logger_mav._dropped,
@@ -360,7 +360,7 @@ void AP_Logger_MAVLink::stats_log()
     if (stats.collection_count == 0) {
         return;
     }
-    Write_logger_MAV(*this);
+    Write_DMS(*this);
 #if REMOTE_LOG_DEBUGGING
     printf("D:%d Retry:%d Resent:%d SF:%d/%d/%d SP:%d/%d/%d SS:%d/%d/%d SR:%d/%d/%d\n",
            _dropped,

--- a/libraries/AP_Logger/AP_Logger_MAVLink.h
+++ b/libraries/AP_Logger/AP_Logger_MAVLink.h
@@ -139,7 +139,7 @@ private:
     uint8_t _next_block_number_to_resend;
     bool _sending_to_client;
 
-    void Write_logger_MAV(AP_Logger_MAVLink &logger);
+    void Write_DMS(AP_Logger_MAVLink &logger);
 
     uint32_t bufferspace_available() override; // in bytes
     uint8_t remaining_space_in_current_block() const;

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -495,7 +495,7 @@ struct PACKED log_ARSP {
     uint8_t primary;
 };
 
-struct PACKED log_MAV_Stats {
+struct PACKED log_DMS {
     LOG_PACKET_HEADER;
     uint64_t timestamp;
     uint32_t seqno;
@@ -1186,7 +1186,7 @@ LOG_STRUCTURE_FROM_MOUNT \
       "MODE", "QMBB",         "TimeUS,Mode,ModeNum,Rsn", "s---", "F---" }, \
     { LOG_RFND_MSG, sizeof(log_RFND), \
       "RFND", "QBfBBb", "TimeUS,Instance,Dist,Stat,Orient,Quality", "s#m--%", "F-0---", true }, \
-    { LOG_MAV_STATS, sizeof(log_MAV_Stats), \
+    { LOG_DMS, sizeof(log_DMS), \
       "DMS", "QIIIIBBBBBBBBB",         "TimeUS,N,Dp,RT,RS,Fa,Fmn,Fmx,Pa,Pmn,Pmx,Sa,Smn,Smx", "s-------------", "F-------------" }, \
     LOG_STRUCTURE_FROM_BEACON                                       \
     LOG_STRUCTURE_FROM_PROXIMITY                                    \
@@ -1304,7 +1304,7 @@ enum LogMessages : uint8_t {
     LOG_ARSP_MSG,
     LOG_IDS_FROM_RPM,
     LOG_RFND_MSG,
-    LOG_MAV_STATS,
+    LOG_DMS,
     LOG_FORMAT_UNITS_MSG,
     LOG_UNIT_MSG,
     LOG_MULT_MSG,


### PR DESCRIPTION
no user-visible change here.  The log message is DMS (Dataflash MAVLink Stats".  We have another log message "MAV" which logs mavlink statistics, so the current naming is confusing

no compiler output change
