### PR TITLE
Add logging of data coming through uarts

### DIFF
--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -369,6 +369,7 @@ BUILD_OPTIONS = [
     Feature('Other', 'Logging', 'HAL_LOGGING_ENABLED', 'Enable Logging', 0, None),
     Feature('Other', 'CUSTOM_ROTATIONS', 'AP_CUSTOMROTATIONS_ENABLED', 'Enable Custom  sensor rotations', 0, None),
     Feature('Other', 'PID_FILTERING', 'AP_FILTER_ENABLED', 'Enable PID filtering', 0, None),
+    Feature('Other', 'UART_RAW_LOGGING', 'HAL_UART_DEBUG_LOGGING_ENABLED', 'Enable UART Raw logging', 0, None),
 
     # MAVLink section for mavlink features and/or message handling,
     # rather than for e.g. mavlink-based sensor drivers

--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -291,6 +291,8 @@ class ExtractFeatures(object):
             ('AP_FILTER_ENABLED', r'AP_Filters::update'),
             ('AP_CAN_LOGGING_ENABLED', r'AP_CANManager::can_logging_callback'),
             ('AP_PLANE_SYSTEMID_ENABLED', r'AP_SystemID::start'),
+
+            ('HAL_UART_DEBUG_LOGGING_ENABLED', r'AP_HAL::UARTDriver::log_written_data'),
         ]
 
     def progress(self, msg):

--- a/Tools/scripts/uart_rawlog_to_tlog.py
+++ b/Tools/scripts/uart_rawlog_to_tlog.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+'''
+Convert a serial capture file into a mavlink tlog.
+
+AP_FLAKE8_CLEAN
+'''
+
+import argparse
+import os
+import pathlib
+import struct
+import sys
+
+from pymavlink import mavutil
+
+
+class UARTRawLogToTLog():
+    def __init__(self, filepath, output_filepath=None):
+        self.filepath = filepath
+        self.output_filepath = output_filepath
+
+    def run(self):
+        input_fh = sys.stdin
+        if self.filepath is not None:
+            input_fh = pathlib.Path(self.filepath).open('rb')
+
+        output_fh = sys.stdout.buffer
+        if self.output_filepath is not None:
+            output_fh = pathlib.Path(self.output_filepath).open('wb')
+
+        HEADER_FORMAT = "<I I H B"  # Little-endian: uint32_t, uint32_t, uint16_t, uint8_t
+        HEADER_SIZE = struct.calcsize(HEADER_FORMAT)
+        MAGIC_NUMBER = 0x7fe53b04
+
+        os.environ['MAVLINK20'] = '1'
+        read_mav = mavutil.mavlink.MAVLink(self)
+        read_mav.robust_parsing = True
+        write_mav = mavutil.mavlink.MAVLink(self)
+        write_mav.robust_parsing = True
+        while True:
+            header = input_fh.read(HEADER_SIZE)
+            if len(header) < HEADER_SIZE:
+                break
+            magic, time_ms, length, flags = struct.unpack(HEADER_FORMAT, header)
+            if magic != MAGIC_NUMBER:
+                raise ValueError(f"{hex(magic)}")
+            data = input_fh.read(length)
+
+            if flags & 0x1:
+                msgs = write_mav.parse_buffer(data)
+            else:
+                msgs = read_mav.parse_buffer(data)
+            if msgs is None:
+                continue
+            for msg in msgs:
+                output_fh.write(struct.pack(">Q", int(time_ms*1000)))
+                output_fh.write(msg.get_msgbuf())
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser(
+        description='turn a captured serial stream into a tlog',
+    )
+    parser.add_argument('file', nargs='?', default=None, help='serial capture file')
+    parser.add_argument('--output', '-o', default=None, help='output file')
+
+    args = parser.parse_args()
+
+    u = UARTRawLogToTLog(args.file, output_filepath=args.output)
+    u.run()

--- a/libraries/AP_HAL/UARTDriver.cpp
+++ b/libraries/AP_HAL/UARTDriver.cpp
@@ -4,6 +4,12 @@
 #include "AP_HAL.h"
 #include <AP_Logger/AP_Logger.h>
 
+#if HAL_UART_DEBUG_LOGGING_ENABLED
+#include <AP_Filesystem/AP_Filesystem.h>
+#endif // HAL_UART_DEBUG_LOGGING_ENABLED
+
+extern const AP_HAL::HAL& hal;
+
 void AP_HAL::UARTDriver::begin(uint32_t baud, uint16_t rxSpace, uint16_t txSpace)
 {
     if (lock_write_key != 0) {
@@ -226,3 +232,128 @@ void AP_HAL::UARTDriver::log_stats(const uint8_t inst, StatsTracker &stats, cons
 }
 #endif // HAL_LOGGING_ENABLED
 #endif // HAL_UART_STATS_ENABLED
+
+
+/*
+ * Support for logging all incoming/outgoing data from a serial port
+ */
+
+#if HAL_UART_DEBUG_LOGGING_ENABLED
+
+/*
+  log some data for debugging
+*/
+void AP_HAL::UARTDriver::log_read_data(const uint8_t *data, uint16_t length)
+{
+    log_data(data, length, false);
+}
+void AP_HAL::UARTDriver::log_written_data(const uint8_t *data, uint16_t length)
+{
+    log_data(data, length, true);
+}
+void AP_HAL::UARTDriver::log_data(const uint8_t *data, uint16_t length, bool is_written_data)
+{
+    // first see if we actually do want to log:
+    if ((_last_options & OPTION_LOGGING) == 0) {
+        return;
+    }
+
+    // find logging instance corresponding to this UART:
+    if (loginfo == nullptr) {
+        loginfo = NEW_NOTHROW LogInfo();
+        if (loginfo == nullptr) {
+            return;
+        }
+        loginfo->instance = instance;
+        loginfo->next = backend_loginfos;
+        backend_loginfos = loginfo;
+    }
+    if (!log_thread_created) {
+        log_thread_created = true;
+        hal.scheduler->thread_create(FUNCTOR_BIND_MEMBER(&AP_HAL::UARTDriver::logging_start, void), "uart_log", 4096, AP_HAL::Scheduler::PRIORITY_IO, 0);
+    }
+
+    // write packet into buffer:
+    struct PACKED Header {
+        enum class Flag {
+            IS_WRITTEN_DATA = 1,
+        };
+        uint32_t magic = 0x7fe53b04U;
+        uint32_t time_ms;
+        uint16_t length;
+        uint8_t flags;
+    };
+
+    // note that we are assuming we can do this writing atomically.
+    // If there are multiple writers to the serial port that won't be
+    // the case.  We could reserve, write to and commit an iovec
+    // instead of this:
+
+    const auto space_required = sizeof(Header) + length;
+
+    if (loginfo->buf.space() < space_required) {
+        return;
+    }
+
+    Header header;
+    header.time_ms = AP_HAL::millis();
+    header.length = length;
+    if (is_written_data) {
+        header.flags |= uint8_t(Header::Flag::IS_WRITTEN_DATA);
+    }
+
+    loginfo->buf.write((uint8_t*)&header, sizeof(header));
+    loginfo->buf.write(data, length);
+}
+
+// a linked list of backends which are currently logging:
+AP_HAL::UARTDriver::LogInfo *AP_HAL::UARTDriver::backend_loginfos;
+bool AP_HAL::UARTDriver::log_thread_created;
+
+// logging loop, needs to be static to allow for re-alloc of GPS backends
+void AP_HAL::UARTDriver::logging_loop(void)
+{
+    while (true) {
+        hal.scheduler->delay(10);
+        for (auto *loginfo_ptr = backend_loginfos; loginfo_ptr != nullptr; loginfo_ptr = loginfo_ptr->next) {
+            auto &loginfo = *loginfo_ptr;
+            if (loginfo.fd == -2) {
+                // previously failed; ignore.
+                continue;
+            }
+            // check we have a log file open:
+            if (loginfo.fd == -1) {
+                char fname[] = "uartN_XXX.log";
+                fname[4] = '0' + loginfo.instance;
+                uint32_t lognum;
+                for (lognum=0; lognum<1000; lognum++) {
+                    struct stat st;
+                    hal.util->snprintf(&fname[6], 8, "%03u.log", (unsigned)lognum);
+                    if (AP::FS().stat(fname, &st) != 0) {
+                        break;
+                    }
+                }
+                loginfo.fd = AP::FS().open(fname, O_WRONLY|O_CREAT|O_APPEND);
+                if (loginfo.fd == -1) {
+                    // convert into a permanent failure:
+                    loginfo.fd = -2;
+                }
+            }
+            uint32_t n = 0;
+            const uint8_t *p;
+            while ((p = loginfo.buf.readptr(n)) != nullptr && n != 0) {
+                // short writes are unlikely and are ignored (only FS full errors)
+                AP::FS().write(loginfo.fd, p, n);
+                loginfo.buf.advance(n);
+                AP::FS().fsync(loginfo.fd);
+            }
+        }
+    }
+}
+
+// logging thread start, needs to be non-static for thread_create
+void AP_HAL::UARTDriver::logging_start(void)
+{
+    logging_loop();
+}
+#endif // HAL_UART_DEBUG_LOGGING_ENABLED

--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -263,9 +263,11 @@ protected:
     virtual uint32_t get_total_dropped_rx_bytes() const { return 0; }
 #endif
 
-private:
     // option bits for port
     uint16_t _last_options;
+
+private:
+    uint8_t index;
 
 #if AP_UART_MONITOR_ENABLED
     ByteBuffer *_monitor_read_buffer;

--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -5,6 +5,7 @@
 #include "AP_HAL_Namespace.h"
 #include "utility/BetterStream.h"
 #include <AP_Logger/AP_Logger_config.h>
+#include <AP_HAL/utility/RingBuffer.h>
 
 #ifndef HAL_UART_STATS_ENABLED
 #define HAL_UART_STATS_ENABLED AP_HAL_UARTDRIVER_ENABLED
@@ -13,6 +14,10 @@
 #ifndef AP_UART_MONITOR_ENABLED
 #define AP_UART_MONITOR_ENABLED 0
 #endif
+
+#ifndef HAL_UART_DEBUG_LOGGING_ENABLED
+#define HAL_UART_DEBUG_LOGGING_ENABLED 0
+#endif  // HAL_UART_DEBUG_LOGGING_ENABLED
 
 class ExpandingString;
 class ByteBuffer;
@@ -41,6 +46,10 @@ public:
       be used
      */
     void begin_locked(uint32_t baud, uint16_t rxSpace, uint16_t txSpace, uint32_t write_key);
+
+#if HAL_UART_DEBUG_LOGGING_ENABLED
+    void set_instance(uint8_t _instance) { instance = _instance; }
+#endif  // HAL_UART_DEBUG_LOGGING_ENABLED
 
     /*
       single and multi-byte write methods
@@ -100,6 +109,7 @@ public:
         OPTION_MAVLINK_NO_FORWARD = (1U<<10), // don't forward MAVLink data to or from this device
         OPTION_NOFIFO             = (1U<<11), // disable hardware FIFO
         OPTION_NOSTREAMOVERRIDE   = (1U<<12), // don't allow GCS to override streamrates
+        OPTION_LOGGING            = (1U<<13), // enable raw logging
     };
 
     enum flow_control {
@@ -263,6 +273,11 @@ protected:
     virtual uint32_t get_total_dropped_rx_bytes() const { return 0; }
 #endif
 
+#if HAL_UART_DEBUG_LOGGING_ENABLED
+    void log_read_data(const uint8_t *data, uint16_t length);
+    void log_written_data(const uint8_t *data, uint16_t length);
+#endif  // HAL_UART_DEBUG_LOGGING_ENABLED
+
     // option bits for port
     uint16_t _last_options;
 
@@ -272,4 +287,25 @@ private:
 #if AP_UART_MONITOR_ENABLED
     ByteBuffer *_monitor_read_buffer;
 #endif
+
+#if HAL_UART_DEBUG_LOGGING_ENABLED
+    void log_data(const uint8_t *data, uint16_t length, bool is_written_data);
+
+    uint8_t instance;
+
+    // support raw serial logging
+    struct LogInfo {
+        struct LogInfo *next;
+        int fd = -1;
+        ByteBuffer buf{16000};
+        uint8_t instance;
+    };
+    struct LogInfo *loginfo;  // log info for *this* backend
+
+    static LogInfo *backend_loginfos;  // linked list of all backend log infos
+    static bool log_thread_created;
+    static void logging_loop(void);
+    void logging_start(void);
+#endif  // HAL_UART_DEBUG_LOGGING_ENABLED
+
 };

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -763,6 +763,10 @@ ssize_t UARTDriver::_read(uint8_t *buffer, uint16_t count)
         update_rts_line();
     }
 
+#if HAL_UART_DEBUG_LOGGING_ENABLED
+    log_read_data(buffer, count);
+#endif
+
     return ret;
 }
 
@@ -772,6 +776,10 @@ size_t UARTDriver::_write(const uint8_t *buffer, size_t size)
     if (!_tx_initialised) {
 		return 0;
 	}
+
+#if HAL_UART_DEBUG_LOGGING_ENABLED
+    log_written_data(buffer, size);
+#endif
 
     WITH_SEMAPHORE(_write_mutex);
 

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -223,7 +223,6 @@ private:
     uint32_t _cr1_options;
     uint32_t _cr2_options;
     uint32_t _cr3_options;
-    uint16_t _last_options;
 
     // half duplex control. After writing we throw away bytes for 4 byte widths to
     // prevent reading our own bytes back

--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -230,6 +230,11 @@ ssize_t UARTDriver::_read(uint8_t *buffer, uint16_t count)
 {
     const ssize_t ret = _readbuffer.read(buffer, count);
     _rx_stats_bytes += ret;
+
+#if HAL_UART_DEBUG_LOGGING_ENABLED
+    log_read_data(buffer, count);
+#endif
+
     return ret;
 }
 
@@ -272,6 +277,10 @@ size_t UARTDriver::_write(const uint8_t *buffer, size_t size)
     if (size <= 0) {
         return 0;
     }
+
+#if HAL_UART_DEBUG_LOGGING_ENABLED
+    log_written_data(buffer, size);
+#endif
 
         /*
           simulate byte loss at the link layer

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -444,6 +444,9 @@ void AP_SerialManager::init()
     // initialise serial ports
     for (uint8_t i=1; i<SERIALMANAGER_NUM_PORTS; i++) {
         auto *uart = hal.serial(i);
+#if HAL_UART_DEBUG_LOGGING_ENABLED
+        uart->set_instance(i);
+#endif  // HAL_UART_DEBUG_LOGGING_ENABLED
 
         state[i].idx = i;
 


### PR DESCRIPTION
Roughly based on the raw GPS logging.

Notable difference is that the packing into chunks is done in the caller, not the thread loop.  This is because we log which direction the data travelled in, and we don't want to run two buffers!

Second notable difference is that the thread moves through a linked list of allocated doing-raw-logging structures, which the backends may allocate based on parameters.

Also includes a utility which translates from one of these capture files into a .tlog.

Tested in SITL and on Durandal.

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  -24               *                                                   
CubeRedPrimary                      -48    *           -80     -56               -80    -24    -136
Durandal                            -24    *           -24     -16               -32    -48    40
Hitec-Airspeed           0                 *                                                   
KakuteH7-bdshot                     -16    *           -8      -8                -16    -16    -8
MatekF405                           8      *           8       8                 8      8      8
OMNIBUSF7V2                         -8     *           -8      -8                -8     -8     -8
Pixhawk1-1M-bdshot                  8                  8       8                 8      8      8
f103-QiotekPeriph        0                 *                                                   
f303-Universal           -8                *                                                   
iomcu                                                                0                         
revo-mini                           8      *           8       8                 8      8      8
skyviper-journey                                       0                                       
skyviper-v2450                                         8                                       
```

... only the fix for the _last_options has effect on compiler output, when testing this PR vs just those two commits.


When the feature is enabled:
```
pbarker@threads:~$ ~/rc/ardupilot/Tools/scripts/filter_size_compare_branches_csv.py --hide /tmp/some.csv  
-----------------------  ---------  -----  ----------  ------  ----  ----------  -----  -----  ---
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  584               *
CubeRedPrimary                      632    *           624     632               712    592    512
Durandal                            648    *           664     640               640    656    656
Hitec-Airspeed           4560              *
KakuteH7-bdshot                     536    *           536     536               536    536    536
MatekF405                           552    *           552     552               552    552    552
OMNIBUSF7V2                         536    *           536     536               536    536    536
Pixhawk1-1M-bdshot                  552                552     552               552    552    552
f103-QiotekPeriph        5740              *
f303-Universal           5564              *
iomcu                                                                0
revo-mini                           576    *           576     576               576    576    584
skyviper-journey                                       584
skyviper-v2450                                         584
```
