### PR TITLE
The Mother of All BLHeli Passthrough Fixes

### DIFF
--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -636,7 +636,7 @@ bool AP_BLHeli::BL_SendBuf(const uint8_t *buf, uint16_t len)
     EXPECT_DELAY_MS(1000);
     hal.scheduler->delay_microseconds(100);
     if (!hal.rcout->serial_setup_output(blheli_chan_to_output_chan(blheli.chan), 19200, motor_mask)) {
-        debug("serial_setup_output() failed\n");
+        debug_console("serial_setup_output() failed\n");
         blheli.ack = ACK_D_GENERAL_ERROR;
         return false;
     }
@@ -652,7 +652,7 @@ bool AP_BLHeli::BL_SendBuf(const uint8_t *buf, uint16_t len)
     blheli.buf[len] = uint8_t(crc & 0xFF);
     blheli.buf[len+1] = uint8_t(crc>>8);
     if (!hal.rcout->serial_write_bytes(blheli.buf, len+(send_crc?2:0))) {
-        debug("serial_write_bytes() failed\n");
+        debug_console("serial_write_bytes() failed\n");
         blheli.ack = ACK_D_GENERAL_ERROR;
         return false;
     }

--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -46,6 +46,11 @@
 extern const AP_HAL::HAL& hal;
 
 #define debug(fmt, args ...) do { if (debug_level) { GCS_SEND_TEXT(MAV_SEVERITY_INFO, "ESC: " fmt, ## args); } } while (0)
+#ifdef BLHELI_DEBUG
+#define debug_console(fmt, args ...) do { hal.console->printf(fmt "\n", ## args); } while (0)
+#else
+#define debug_console(fmt, args ...) do {} while(0)
+#endif
 
 // key for locking UART for exclusive use. This prevents any other writes from corrupting
 // the MSP protocol on hal.console
@@ -390,9 +395,8 @@ void AP_BLHeli::msp_process_command(void)
 
     case MSP_REBOOT:
         debug("MSP: ignoring reboot command, end serial comms");
-        hal.rcout->serial_end();
+        serial_end();
         blheli.connected[blheli.chan] = false;
-        serial_start_ms = 0;
         break;
 
     case MSP_UID:
@@ -540,8 +544,7 @@ void AP_BLHeli::msp_process_command(void)
             break;
         default:
             n = 0;
-            hal.rcout->serial_end();
-            serial_start_ms = 0;
+            serial_end();
             break;
         }
         // doing the serial setup here avoids delays when doing it on demand and makes
@@ -622,10 +625,16 @@ bool AP_BLHeli::BL_SendBuf(const uint8_t *buf, uint16_t len)
         return false;
     }
     EXPECT_DELAY_MS(1000);
+    hal.scheduler->delay_microseconds(100);
     if (!hal.rcout->serial_setup_output(motor_map[blheli.chan], 19200, motor_mask)) {
+        debug("serial_setup_output() failed\n");
         blheli.ack = ACK_D_GENERAL_ERROR;
         return false;
     }
+    // ensure that the next write does not go out immediately in case the receiving side is not yet
+    // ready
+    hal.scheduler->delay_microseconds(100);
+
     if (serial_start_ms == 0) {
         serial_start_ms = AP_HAL::millis();
     }
@@ -634,6 +643,7 @@ bool AP_BLHeli::BL_SendBuf(const uint8_t *buf, uint16_t len)
     blheli.buf[len] = crc;
     blheli.buf[len+1] = crc>>8;
     if (!hal.rcout->serial_write_bytes(blheli.buf, len+(send_crc?2:0))) {
+        debug("serial_write_bytes() failed\n");
         blheli.ack = ACK_D_GENERAL_ERROR;
         return false;
     }
@@ -841,16 +851,19 @@ uint8_t AP_BLHeli::BL_SendCMDSetBuffer(const uint8_t *buf, uint16_t nbytes)
 {
     uint8_t sCMD[] = {CMD_SET_BUFFER, 0, uint8_t(nbytes>>8), uint8_t(nbytes&0xff)};
     if (!BL_SendBuf(sCMD, 4)) {
+        debug_console("BL_SendCMDSetBuffer send cmd failed");
         return false;
     }
-    uint8_t ack;
-    if ((ack = BL_GetACK()) != brNONE) {
-        debug("BL_SendCMDSetBuffer ack failed 0x%02x", ack);
+    uint8_t ack = BL_GetACK();
+    // generally no ack returned for CMD_SET_BUFFER when flashing firmware
+    if (ack != brNONE && ack != brSUCCESS) {
+        debug_console("BL_SendCMDSetBuffer ack failed 0x%02x", ack);
         blheli.ack = ACK_D_GENERAL_ERROR;
         return false;
     }
+
     if (!BL_SendBuf(buf, nbytes)) {
-        debug("BL_SendCMDSetBuffer send failed");
+        debug_console("BL_SendCMDSetBuffer send failed");
         blheli.ack = ACK_D_GENERAL_ERROR;
         return false;
     }
@@ -861,6 +874,7 @@ bool AP_BLHeli::BL_WriteA(uint8_t cmd, const uint8_t *buf, uint16_t nbytes, uint
 {
     if (BL_SendCMDSetAddress()) {
         if (!BL_SendCMDSetBuffer(buf, nbytes)) {
+            debug_console("BL_SendCMDSetBuffer failed\n");
             blheli.ack = ACK_D_GENERAL_ERROR;
             return false;
         }
@@ -870,11 +884,12 @@ bool AP_BLHeli::BL_WriteA(uint8_t cmd, const uint8_t *buf, uint16_t nbytes, uint
         }
         return (BL_GetACK(timeout_ms) == brSUCCESS);
     }
+    debug_console("BL_SendCMDSetAddress failed\n");
     blheli.ack = ACK_D_GENERAL_ERROR;
     return false;
 }
 
-uint8_t AP_BLHeli::BL_WriteFlash(const uint8_t *buf, uint16_t n)
+bool AP_BLHeli::BL_WriteFlash(const uint8_t *buf, uint16_t n)
 {
     return BL_WriteA(CMD_PROG_FLASH, buf, n, 500);
 }
@@ -952,8 +967,7 @@ void AP_BLHeli::blheli_process_command(void)
         msp.escMode = PROTOCOL_NONE;
         uint8_t b = 0;
         blheli_send_reply(&b, 1);
-        hal.rcout->serial_end();
-        serial_start_ms = 0;
+        serial_end();
         if (motors_disabled) {
             motors_disabled = false;
             SRV_Channels::set_disabled_channel_mask(motors_disabled_mask);
@@ -1079,7 +1093,11 @@ void AP_BLHeli::blheli_process_command(void)
         case imSIL_BLB:
         case imATM_BLB:
         case imARM_BLB: {
-            BL_WriteFlash(buf, nbytes);
+            if (!BL_WriteFlash(buf, nbytes)) {
+                // For reasons unknown BL_WriteFlash can bork the DMA engine, make some attempt to get
+                // back to a sane state if this happens
+                serial_end();
+            }
             break;
         }
         case imSK: {
@@ -1175,8 +1193,7 @@ bool AP_BLHeli::process_input(uint8_t b)
     if (msp.escMode == PROTOCOL_4WAY && blheli.state == BLHELI_IDLE && b == '$') {
         debug("Change to MSP mode");
         msp.escMode = PROTOCOL_NONE;
-        hal.rcout->serial_end();
-        serial_start_ms = 0;
+        serial_end();
     }
     if (msp.escMode != PROTOCOL_4WAY && msp.state == MSP_IDLE && b == '/') {
         debug("Change to BLHeli mode");
@@ -1269,10 +1286,9 @@ void AP_BLHeli::run_connection_test(uint8_t chan)
             break;
         }
     }
-    hal.rcout->serial_end();
+    serial_end();
     SRV_Channels::set_disabled_channel_mask(motors_disabled_mask);
     motors_disabled = false;
-    serial_start_ms = 0;
     blheli.chan = saved_chan;
     GCS_SEND_TEXT(MAV_SEVERITY_INFO, "ESC: Test %s", passed?"PASSED":"FAILED");
     debug_uart = nullptr;
@@ -1298,8 +1314,7 @@ void AP_BLHeli::update(void)
         // we're not processing requests any more, shutdown serial
         // output
         if (serial_start_ms) {
-            hal.rcout->serial_end();
-            serial_start_ms = 0;
+            serial_end();
         }
         if (motors_disabled) {
             motors_disabled = false;
@@ -1323,6 +1338,12 @@ void AP_BLHeli::update(void)
             run_connection_test(run_test.get() - 1);
         }
     }
+}
+
+void AP_BLHeli::serial_end()
+{
+    hal.rcout->serial_end(motor_mask);
+    serial_start_ms = 0;
 }
 
 /*

--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -854,7 +854,7 @@ uint8_t AP_BLHeli::BL_SendCMDSetBuffer(const uint8_t *buf, uint16_t nbytes)
         debug_console("BL_SendCMDSetBuffer send cmd failed");
         return false;
     }
-    uint8_t ack = BL_GetACK();
+    uint8_t ack = BL_GetACK(5); // match betaflight timing
     // generally no ack returned for CMD_SET_BUFFER when flashing firmware
     if (ack != brNONE && ack != brSUCCESS) {
         debug_console("BL_SendCMDSetBuffer ack failed 0x%02x", ack);

--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -42,6 +42,7 @@
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_ESC_Telem/AP_ESC_Telem.h>
 #include <SRV_Channel/SRV_Channel.h>
+#include <AP_BattMonitor/AP_BattMonitor.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -174,11 +175,12 @@ AP_BLHeli::AP_BLHeli(void)
 }
 
 // map an incoming BLHeli motor request to the appropriate 
-// output channel for use in serial output
+// output channel for use in serial output so that motor numbers
+// are observed
 uint8_t AP_BLHeli::blheli_chan_to_output_chan(uint8_t motor)
 {
-    uint8_t chan = 0;
-    SRV_Channels::find_channel(SRV_Channel::Function(motor + uint16_t(SRV_Channel::k_motor1)), chan);
+    uint8_t chan = 0;   // 0 means motor 1 and is ok as a fallback
+    SRV_Channels::find_channel(SRV_Channels::get_motor_function(motor), chan);
     return chan;
 }
 
@@ -470,12 +472,34 @@ void AP_BLHeli::msp_process_command(void)
 
     case MSP_BATTERY_STATE: {
         debug("MSP_BATTERY_STATE");
-        uint8_t buf[8];
-        buf[0] = 4; // cell count
-        putU16(&buf[1], 1500); // mAh
-        buf[3] = 16; // V
-        putU16(&buf[4], 1500); // mAh
-        putU16(&buf[6], 1); // A
+        // ESC configurator seems to care a lot about the battery state,
+        // try and at least provide something believable
+        uint8_t buf[11] {};
+#if AP_BATTERY_ENABLED
+        AP_BattMonitor &battery = AP::battery();
+        float v;
+#if HAL_WITH_ESC_TELEM
+        if (!AP::esc_telem().get_voltage(blheli_chan_to_output_chan(blheli.chan), v)) {
+            v = battery.voltage();
+        }        
+#else
+            v = battery.voltage();
+#endif
+        buf[0] = battery.healthy() ? uint8_t(roundf(v / 3.85)) : 0; // cell count, 0 means no battery
+        putU16(&buf[1], uint16_t(battery.pack_capacity_mah())); // capacity in mAh
+        buf[3] = uint8_t(roundf(v * 10.0)); // legacy V in 0.1V steps
+
+        float cons = 0;
+        UNUSED_RESULT(battery.consumed_mah(cons));
+        putU16(&buf[4], uint16_t(roundf(cons))); // mAh used
+
+        float amps = 0.0;
+        UNUSED_RESULT(battery.current_amps(amps));
+        putU16(&buf[6], uint16_t(roundf(amps * 100.0))); // A in 0.01A steps
+        buf[8] = battery.healthy(); // alerts/state
+        // We are advertising MSP v1.42 which means supporting the new voltage field
+        putU16(&buf[9], uint16_t(roundf(v * 100.0))); // Voltage in 0.01V steps
+#endif
         msp_send_reply(msp.cmdMSP, buf, sizeof(buf));
         break;
     }
@@ -858,7 +882,7 @@ uint8_t AP_BLHeli::BL_SendCMDSetBuffer(const uint8_t *buf, uint16_t nbytes)
 {
     uint8_t sCMD[] = {CMD_SET_BUFFER, 0, uint8_t(nbytes>>8), uint8_t(nbytes&0xff)};
     if (nbytes == 0) {
-        // set high byte
+        // set high byte since 0 bytes == 256 bytes in this protocol
         sCMD[2] = 1;
     }
     if (!BL_SendBuf(sCMD, 4)) {
@@ -868,13 +892,13 @@ uint8_t AP_BLHeli::BL_SendCMDSetBuffer(const uint8_t *buf, uint16_t nbytes)
     uint8_t ack = BL_GetACK(5); // match betaflight timing
     // generally no ack returned for CMD_SET_BUFFER when flashing firmware
     if (ack != brNONE && ack != brSUCCESS) {
-        debug_console("BL_SendCMDSetBuffer ack failed 0x%02x", ack);
+        debug("BL_SendCMDSetBuffer ack failed 0x%02x", ack);
         blheli.ack = ACK_D_GENERAL_ERROR;
         return false;
     }
 
     if (!BL_SendBuf(buf, nbytes)) {
-        debug_console("BL_SendCMDSetBuffer send failed");
+        debug("BL_SendCMDSetBuffer send failed");
         blheli.ack = ACK_D_GENERAL_ERROR;
         return false;
     }

--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -850,6 +850,10 @@ void AP_BLHeli::BL_SendCMDRunRestartBootloader(void)
 uint8_t AP_BLHeli::BL_SendCMDSetBuffer(const uint8_t *buf, uint16_t nbytes)
 {
     uint8_t sCMD[] = {CMD_SET_BUFFER, 0, uint8_t(nbytes>>8), uint8_t(nbytes&0xff)};
+    if (nbytes == 0) {
+        // set high byte
+        sCMD[2] = 1;
+    }
     if (!BL_SendBuf(sCMD, 4)) {
         debug_console("BL_SendCMDSetBuffer send cmd failed");
         return false;
@@ -1095,8 +1099,9 @@ void AP_BLHeli::blheli_process_command(void)
         case imARM_BLB: {
             if (!BL_WriteFlash(buf, nbytes)) {
                 // For reasons unknown BL_WriteFlash can bork the DMA engine, make some attempt to get
-                // back to a sane state if this happens
-                serial_end();
+                // back to a sane state if this happens. We can't call serial_end() as that will 
+                // restart dshot output
+                hal.rcout->serial_reset(motor_mask);
             }
             break;
         }

--- a/libraries/AP_BLHeli/AP_BLHeli.h
+++ b/libraries/AP_BLHeli/AP_BLHeli.h
@@ -261,6 +261,7 @@ private:
     bool msp_process_byte(uint8_t c);
     void blheli_crc_update(uint8_t c);
     bool blheli_4way_process_byte(uint8_t c);
+    uint8_t blheli_chan_to_output_chan(uint8_t motor);
     void msp_send_ack(uint8_t cmd);
     void msp_send_reply(uint8_t cmd, const uint8_t *buf, uint8_t len);
     void putU16(uint8_t *b, uint16_t v);

--- a/libraries/AP_BLHeli/AP_BLHeli.h
+++ b/libraries/AP_BLHeli/AP_BLHeli.h
@@ -257,6 +257,7 @@ private:
     uint32_t last_telem_byte_read_us;
     int8_t last_control_port;
 
+    void serial_end();
     bool msp_process_byte(uint8_t c);
     void blheli_crc_update(uint8_t c);
     bool blheli_4way_process_byte(uint8_t c);
@@ -282,7 +283,7 @@ private:
     void BL_SendCMDRunRestartBootloader(void);
     uint8_t BL_SendCMDSetBuffer(const uint8_t *buf, uint16_t nbytes);
     bool BL_WriteA(uint8_t cmd, const uint8_t *buf, uint16_t nbytes, uint32_t timeout);
-    uint8_t BL_WriteFlash(const uint8_t *buf, uint16_t n);
+    bool BL_WriteFlash(const uint8_t *buf, uint16_t n);
     bool BL_VerifyFlash(const uint8_t *buf, uint16_t n);
     void blheli_process_command(void);
     void run_connection_test(uint8_t chan);

--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -204,6 +204,12 @@ public:
     virtual void serial_end(uint32_t chanmask) {}
     
     /*
+      reset serial output. This re-initializes the DMA configuration to that configured by
+      serial_setup_output()
+     */
+    virtual void serial_reset(uint32_t chanmask) {}
+
+     /*
       output modes. Allows for support of PWM, oneshot and dshot 
     */
     // this enum is used by BLH_OTYPE and ESC_PWM_TYPE on AP_Periph

--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -201,7 +201,7 @@ public:
       the channel and any other channels that were stopped by
       serial_setup_output()
      */
-    virtual void serial_end(void) {}
+    virtual void serial_end(uint32_t chanmask) {}
     
     /*
       output modes. Allows for support of PWM, oneshot and dshot 

--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -194,7 +194,7 @@ public:
       read a series of bytes from a port, using serial parameters from serial_setup_output()
       return the number of bytes read. This is a blocking call
      */
-    virtual uint16_t serial_read_bytes(uint8_t *buf, uint16_t len) { return 0; }
+    virtual uint16_t serial_read_bytes(uint8_t *buf, uint16_t len, uint32_t timeout_us) { return 0; }
     
     /*
       stop serial output. This restores the previous output mode for

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -1976,6 +1976,11 @@ bool RCOutput::serial_setup_output(uint8_t chan, uint32_t baudrate, uint32_t cha
         return false;
     }
 
+#if RCOU_SERIAL_TIMING_DEBUG
+    hal.gpio->pinMode(54, 1);
+    hal.gpio->pinMode(55, 1);
+#endif
+
     if (!in_soft_serial()) {
         // keep a record of the line mode so that it can be reliably restored after input
         // not resetting the linemode properly after input is absolutely fatal
@@ -2221,12 +2226,12 @@ void RCOutput::serial_byte_timeout(virtual_timer_t* vt, void *ctx)
 /*
   read a byte from a port, using serial parameters from serial_setup_output()
 */
-bool RCOutput::serial_read_byte(uint8_t &b)
+bool RCOutput::serial_read_byte(uint8_t &b, uint32_t timeout_us)
 {
     while (true) {
         // consumer/producer pattern
         if (serial_buffer.is_empty()) {
-            if (!serial_sem.wait(START_BIT_TIMEOUT)) {
+            if (!serial_sem.wait(timeout_us)) {
                 return false;  // no data after 2ms
             }
         }
@@ -2251,8 +2256,11 @@ bool RCOutput::serial_read_byte(uint8_t &b)
 
 /*
   read a byte from a port, using serial parameters from serial_setup_output()
+  timeout_us is the maximum time to wait for input - it is important to timeout
+  at this level rather than doing multiple reads as its possible to miss acks
+  in the thin slice of time during re-setup.
 */
-uint16_t RCOutput::serial_read_bytes(uint8_t *buf, uint16_t len)
+uint16_t RCOutput::serial_read_bytes(uint8_t *buf, uint16_t len, uint32_t timeout_us)
 {
     if (!in_soft_serial()) {
         return 0;
@@ -2266,14 +2274,6 @@ uint16_t RCOutput::serial_read_bytes(uint8_t *buf, uint16_t len)
 #else
     uint32_t gpio_mode = PAL_STM32_MODE_INPUT | PAL_STM32_OTYPE_PUSHPULL | PAL_STM32_PUPDR_PULLUP | PAL_STM32_OSPEED_LOWEST;
 #endif
-
-    uint16_t i = 0;
-
-#if RCOU_SERIAL_TIMING_DEBUG
-    hal.gpio->pinMode(54, 1);
-    hal.gpio->pinMode(55, 1);
-#endif
-
     // assume GPIO mappings for PWM outputs start at 50
     palSetLineMode(line, gpio_mode);
 
@@ -2287,21 +2287,25 @@ uint16_t RCOutput::serial_read_bytes(uint8_t *buf, uint16_t len)
     irq.bit_time_tick = serial_group->serial.bit_time_us;
     irq.last_bit = 0;
 
-#if RCOU_SERIAL_TIMING_DEBUG
-    palWriteLine(HAL_GPIO_LINE_GPIO54, 1);
-#endif
-
     if (!((GPIO *)hal.gpio)->_attach_interrupt(line, serial_bit_irq, AP_HAL::GPIO::INTERRUPT_BOTH)) {
-#if RCOU_SERIAL_TIMING_DEBUG
-        palWriteLine(HAL_GPIO_LINE_GPIO54, 0);
-#endif
         chThdSetPriority(serial_priority);
         palSetLineMode(line, serial_mode);
         return 0;
     }
 
+#if RCOU_SERIAL_TIMING_DEBUG
+    palToggleLine(HAL_GPIO_LINE_GPIO54);
+#endif
+
+    uint16_t i = 0;
+    uint32_t start_us = AP_HAL::micros();
+
     for (i=0; i<len; i++) {
-        if (!serial_read_byte(buf[i])) {
+        uint32_t spent_us = AP_HAL::micros() - start_us;
+        if (spent_us > timeout_us) {
+            break;
+        }
+        if (!serial_read_byte(buf[i], timeout_us)) {
             break;
         }
     }
@@ -2315,7 +2319,7 @@ uint16_t RCOutput::serial_read_bytes(uint8_t *buf, uint16_t len)
     chThdSetPriority(serial_priority);
 
 #if RCOU_SERIAL_TIMING_DEBUG
-    palWriteLine(HAL_GPIO_LINE_GPIO54, 0);
+    palToggleLine(HAL_GPIO_LINE_GPIO54);
 #endif
     return i;
 }

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -2279,7 +2279,7 @@ uint16_t RCOutput::serial_read_bytes(uint8_t *buf, uint16_t len)
         palWriteLine(HAL_GPIO_LINE_GPIO54, 0);
 #endif
         palSetLineMode(line, serial_mode);
-        return false;
+        return 0;
     }
 
     for (i=0; i<len; i++) {
@@ -2287,11 +2287,15 @@ uint16_t RCOutput::serial_read_bytes(uint8_t *buf, uint16_t len)
             break;
         }
     }
-    chVTReset(&irq.serial_timeout);
-    palDisableLineEvent(line);
-    palSetLineMode(line, serial_mode);
 
-    #if RCOU_SERIAL_TIMING_DEBUG
+    chSysLock();
+    palDisableLineEventI(line);
+    chEvtGetAndClearEvents(serial_event_mask);
+    chVTReset(&irq.serial_timeout);
+    palSetLineMode(line, serial_mode);
+    chSysUnlock();
+
+#if RCOU_SERIAL_TIMING_DEBUG
     palWriteLine(HAL_GPIO_LINE_GPIO54, 0);
 #endif
     return i;

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -2303,7 +2303,7 @@ uint16_t RCOutput::serial_read_bytes(uint8_t *buf, uint16_t len)
 
 /*
   end serial output
-*/
+ */
 void RCOutput::serial_end(uint32_t chanmask)
 {
     osalDbgAssert(hal.scheduler->in_main_thread(), "serial_end(): not called from main thread");
@@ -2326,6 +2326,23 @@ void RCOutput::serial_end(uint32_t chanmask)
     }
     serial_group = nullptr;
     serial_chanmask = 0;
+}
+
+/*
+  reset serial output
+ */
+void RCOutput::serial_reset(uint32_t chanmask)
+{
+    osalDbgAssert(hal.scheduler->in_main_thread(), "serial_reset(): not called from main thread");
+    chanmask >>= chan_offset;
+    // reset settings as best we can
+    if (in_soft_serial()) {
+        palSetLineMode(serial_group->pal_lines[serial_group->serial.chan], serial_mode);
+        dma_cancel(*serial_group);
+        chEvtGetAndClearEvents(serial_event_mask);
+        pwmStop(serial_group->pwm_drv);
+        pwmStart(serial_group->pwm_drv, &serial_group->pwm_cfg);
+    }
 }
 #endif // HAL_SERIAL_ESC_COMM_ENABLED
 

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -1930,12 +1930,16 @@ void RCOutput::dma_cancel(pwm_group& group)
   until serial_end() has been called
 */
 #if HAL_SERIAL_ESC_COMM_ENABLED
+#define BYTE_BITS 10
+
 bool RCOutput::serial_setup_output(uint8_t chan, uint32_t baudrate, uint32_t chanmask)
 {
+    osalDbgAssert(hal.scheduler->in_main_thread(), "serial_setup_output(): not called from main thread");
     // account for IOMCU channels
     chan -= chan_offset;
     chanmask >>= chan_offset;
     pwm_group *new_serial_group = nullptr;
+    uint8_t new_serial_chan = 0;
 
     // find the channel group for the next output
     for (auto &group : pwm_group_list) {
@@ -1947,24 +1951,40 @@ bool RCOutput::serial_setup_output(uint8_t chan, uint32_t baudrate, uint32_t cha
             new_serial_group = &group;
             for (uint8_t j=0; j<4; j++) {
                 if (group.chan[j] == chan) {
-                    group.serial.chan = j;
+                    new_serial_chan = j;
                 }
             }
             break;
         }
     }
-
+#if 0
+    // check for no-op
+    if (in_soft_serial() && chanmask == serial_chanmask
+        && new_serial_group == serial_group
+        && new_serial_chan == serial_group->serial.chan) {
+        return true;
+    }
+#endif
     // couldn't find a group, shutdown everything
     if (!new_serial_group) {
         if (in_soft_serial()) {
             // shutdown old group
-            serial_end();
+            serial_end(chanmask);
         }
         return false;
     }
 
+    // preserve the original thread priority and line state
+    if (!in_soft_serial()) {
+        serial_priority = chThdGetSelfX()->realprio;
+        // keep a record of the line mode so that it can be reliably restored after input
+        // not resetting the linemode properly after input is absolutely fatal
+        serial_mode = palReadLineMode(new_serial_group->pal_lines[new_serial_chan]);
+    }
+
     // stop further dshot output before we reconfigure the DMA
     serial_group = new_serial_group;
+    serial_group->serial.chan = new_serial_chan;
 
     // setup the unconfigured groups for serial output. We ask for a bit width of 1, which gets modified by the
     // we setup all groups so they all are setup with the right polarity, and to make switching between
@@ -1973,7 +1993,7 @@ bool RCOutput::serial_setup_output(uint8_t chan, uint32_t baudrate, uint32_t cha
         if ((group.ch_mask & chanmask) && !(group.ch_mask & serial_chanmask)) {
             const uint32_t pulse_time_us = 1000000UL * 10 / baudrate;
             if (!setup_group_DMA(group, baudrate, 10, false, DSHOT_BUFFER_LENGTH, pulse_time_us, false)) {
-                serial_end();
+                serial_end(chanmask);
                 return false;
             }
         }
@@ -1981,7 +2001,6 @@ bool RCOutput::serial_setup_output(uint8_t chan, uint32_t baudrate, uint32_t cha
     // run the thread doing serial IO at highest priority. This is needed to ensure we don't
     // lose bytes when we switch between output and input
     serial_thread = chThdGetSelfX();
-    serial_priority  = chThdGetSelfX()->realprio;
     // mask of channels currently configured
     serial_chanmask |= chanmask;
     chThdSetPriority(HIGHPRIO);
@@ -2010,10 +2029,10 @@ void RCOutput::fill_DMA_buffer_byte(dmar_uint_t *buffer, uint8_t stride, uint8_t
     buffer[0] = BIT_0;
 
     // stop bit
-    buffer[9*stride] = BIT_1;
+    buffer[(BYTE_BITS-1)*stride] = BIT_1;
 
     // 8 data bits
-    for (uint8_t i = 0; i < 8; i++) {
+    for (uint8_t i = 0; i < (BYTE_BITS-2); i++) {
         buffer[(1 + i) * stride] = (b & 1) ? BIT_1 : BIT_0;
         b >>= 1;
     }
@@ -2026,12 +2045,13 @@ bool RCOutput::serial_write_byte(uint8_t b)
 {
     chEvtGetAndClearEvents(serial_event_mask);
 
-    fill_DMA_buffer_byte(serial_group->dma_buffer+serial_group->serial.chan, 4, b, serial_group->bit_width_mul*10);
+    memset(serial_group->dma_buffer, 0, DSHOT_BUFFER_LENGTH);
+    fill_DMA_buffer_byte(serial_group->dma_buffer+serial_group->serial.chan, 4, b, serial_group->bit_width_mul*BYTE_BITS);
 
     serial_group->in_serial_dma = true;
 
     // start sending the pulses out
-    send_pulses_DMAR(*serial_group, 10*4*sizeof(uint32_t));
+    send_pulses_DMAR(*serial_group, BYTE_BITS*4*sizeof(uint32_t));
 
     // wait for the event
     eventmask_t mask = chEvtWaitAnyTimeout(serial_event_mask, chTimeMS2I(2));
@@ -2050,12 +2070,16 @@ bool RCOutput::serial_write_bytes(const uint8_t *bytes, uint16_t len)
     if (!in_soft_serial()) {
         return false;
     }
+#if AP_HAL_SHARED_DMA_ENABLED
+    // first make sure we have the DMA channel before anything else
+    osalDbgAssert(!serial_group->dma_handle->is_locked(), "DMA handle is already locked");
     serial_group->dma_handle->lock();
-    memset(serial_group->dma_buffer, 0, DSHOT_BUFFER_LENGTH);
+#endif
     while (len--) {
         if (!serial_write_byte(*bytes++)) {
-            hal.console->printf("serial_write_bytes() failed!\n");
+#if AP_HAL_SHARED_DMA_ENABLED
             serial_group->dma_handle->unlock();
+#endif
             return false;
         }
     }
@@ -2063,8 +2087,9 @@ bool RCOutput::serial_write_bytes(const uint8_t *bytes, uint16_t len)
     // add a small delay for last word of output to have completely
     // finished
     hal.scheduler->delay_microseconds(25);
-
+#if AP_HAL_SHARED_DMA_ENABLED
     serial_group->dma_handle->unlock();
+#endif
     return true;
 #else
     return false;
@@ -2072,7 +2097,6 @@ bool RCOutput::serial_write_bytes(const uint8_t *bytes, uint16_t len)
 }
 
 #define BAD_BYTE 0xFFFF
-#define BYTE_BITS 10
 #define BYTE_TIME(bitus) (bitus *  (BYTE_BITS + 2))   // timeout should come well after the next start bit
 #define START_BIT_TIMEOUT 2000 // 2ms
 
@@ -2225,8 +2249,7 @@ uint16_t RCOutput::serial_read_bytes(uint8_t *buf, uint16_t len)
 #else
     uint32_t gpio_mode = PAL_STM32_MODE_INPUT | PAL_STM32_OTYPE_PUSHPULL | PAL_STM32_PUPDR_PULLUP | PAL_STM32_OSPEED_LOWEST;
 #endif
-    // restore the line to what it was before
-    iomode_t restore_mode = palReadLineMode(line);
+
     uint16_t i = 0;
 
 #if RCOU_SERIAL_TIMING_DEBUG
@@ -2246,7 +2269,6 @@ uint16_t RCOutput::serial_read_bytes(uint8_t *buf, uint16_t len)
     irq.bitmask = 0;
     irq.bit_time_tick = serial_group->serial.bit_time_us;
     irq.last_bit = 0;
-    irq.waiter = chThdGetSelfX();
 
 #if RCOU_SERIAL_TIMING_DEBUG
     palWriteLine(HAL_GPIO_LINE_GPIO54, 1);
@@ -2256,6 +2278,7 @@ uint16_t RCOutput::serial_read_bytes(uint8_t *buf, uint16_t len)
 #if RCOU_SERIAL_TIMING_DEBUG
         palWriteLine(HAL_GPIO_LINE_GPIO54, 0);
 #endif
+        palSetLineMode(line, serial_mode);
         return false;
     }
 
@@ -2266,10 +2289,9 @@ uint16_t RCOutput::serial_read_bytes(uint8_t *buf, uint16_t len)
     }
     chVTReset(&irq.serial_timeout);
     palDisableLineEvent(line);
-    irq.waiter = nullptr;
+    palSetLineMode(line, serial_mode);
 
-    palSetLineMode(line, restore_mode);
-#if RCOU_SERIAL_TIMING_DEBUG
+    #if RCOU_SERIAL_TIMING_DEBUG
     palWriteLine(HAL_GPIO_LINE_GPIO54, 0);
 #endif
     return i;
@@ -2278,21 +2300,24 @@ uint16_t RCOutput::serial_read_bytes(uint8_t *buf, uint16_t len)
 /*
   end serial output
 */
-void RCOutput::serial_end(void)
+void RCOutput::serial_end(uint32_t chanmask)
 {
-    if (in_soft_serial() || true) {
+    osalDbgAssert(hal.scheduler->in_main_thread(), "serial_end(): not called from main thread");
+    chanmask >>= chan_offset;
+    // restore settings as best we can
+    if (in_soft_serial()) {
         if (serial_thread == chThdGetSelfX()) {
             chThdSetPriority(serial_priority);
             serial_thread = nullptr;
         }
-        irq.waiter = nullptr;
-        for (uint8_t i = 0; i < NUM_GROUPS; i++ ) {
-            pwm_group &group = pwm_group_list[i];
-            // re-configure groups that were previous configured
-            if ((group.ch_mask & serial_chanmask) || true) {
-                dma_cancel(group);  // this ensures the DMA is in a sane state
-                set_group_mode(group);
-            }
+        palSetLineMode(serial_group->pal_lines[serial_group->serial.chan], serial_mode);
+    }
+    irq.waiter = nullptr;
+    for (auto &group : pwm_group_list) {
+        // re-configure groups that were previous configured
+        if ((group.ch_mask & chanmask)) {
+            dma_cancel(group);  // this ensures the DMA is in a sane state
+            set_group_mode(group);  // stops the timer
         }
     }
     serial_group = nullptr;

--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -2186,7 +2186,7 @@ void RCOutput::serial_bit_irq(void)
 void RCOutput::serial_byte_timeout(virtual_timer_t* vt, void *ctx)
 {
     chSysLockFromISR();
-    uint16_t byteval = irq.bitmask | 0x200;
+    uint16_t byteval = irq.bitmask | (((1U<<BYTE_BITS)-1) & ~((1U<<irq.nbits)-1));
     // we can accept a byte with a timeout if the last bit was 1
     // and the start bit is set correctly
     if (irq.last_bit == 0) {

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -518,7 +518,6 @@ private:
   
     // the group being used for serial output
     struct pwm_group *serial_group;
-    thread_t *serial_thread;
     // preserved state
     tprio_t serial_priority;
     iomode_t serial_mode;

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -163,6 +163,13 @@ public:
       serial_setup_output()
      */
     void serial_end(uint32_t chanmask) override;
+
+    /*
+      reset serial output. This re-initializes the DMA configuration to that configured by
+      serial_setup_output()
+     */
+    void serial_reset(uint32_t chanmask) override;
+
 #endif
 
     /*

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -162,7 +162,7 @@ public:
       the channel and any other channels that were stopped by
       serial_setup_output()
      */
-    void serial_end(void) override;
+    void serial_end(uint32_t chanmask) override;
 #endif
 
     /*
@@ -512,7 +512,9 @@ private:
     // the group being used for serial output
     struct pwm_group *serial_group;
     thread_t *serial_thread;
+    // preserved state
     tprio_t serial_priority;
+    iomode_t serial_mode;
     // mask of channels configured for serial output
     uint32_t serial_chanmask;
 #endif // HAL_SERIAL_ESC_COMM_ENABLED

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -155,7 +155,7 @@ public:
       read a byte from a port, using serial parameters from serial_setup_output()
       return the number of bytes read
      */
-    uint16_t serial_read_bytes(uint8_t *buf, uint16_t len) override;
+    uint16_t serial_read_bytes(uint8_t *buf, uint16_t len, uint32_t timeout_us) override;
 
     /*
       stop serial output. This restores the previous output mode for
@@ -769,9 +769,11 @@ private:
     void _set_profiled_clock(pwm_group *grp, uint8_t idx, uint8_t led);
     void _set_profiled_blank_frame(pwm_group *grp, uint8_t idx, uint8_t led);
 #if AP_HAL_SHARED_DMA_ENABLED
-    // serial output support
+    /*
+      serial output support
+     */
     bool serial_write_byte(uint8_t b);
-    bool serial_read_byte(uint8_t &b);
+    bool serial_read_byte(uint8_t &b, uint32_t timeout_us);
     void fill_DMA_buffer_byte(dmar_uint_t *buffer, uint8_t stride, uint8_t b , uint32_t bitval);
     static void serial_bit_irq(void);
     static void serial_byte_timeout(virtual_timer_t* vt, void *ctx);

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -491,9 +491,6 @@ private:
         // bitmask of bits so far (includes start and stop bits)
         uint16_t bitmask;
 
-        // value of completed byte (includes start and stop bits)
-        uint16_t byteval;
-
         // expected time per bit in micros
         uint16_t bit_time_tick;
 
@@ -505,9 +502,13 @@ private:
 
         // timeout for byte read
         virtual_timer_t serial_timeout;
-        bool timed_out;
     } irq;
 
+    // ring buffer to hold soft serial input
+    static ByteBuffer serial_buffer;
+    // binary semaphore to mediate consumer/producer access to the serial buffer
+    static HAL_BinarySemaphore serial_sem;
+  
     // the group being used for serial output
     struct pwm_group *serial_group;
     thread_t *serial_thread;

--- a/libraries/AP_HAL_ChibiOS/RCOutput_bdshot.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput_bdshot.cpp
@@ -121,7 +121,7 @@ bool RCOutput::bdshot_setup_group_ic_DMA(pwm_group &group)
             // when switching from output to input
 #if defined(STM32F1)
             // on F103 the line mode has to be managed manually
-            // PAL_MODE_STM32_ALTERNATE_PUSHPULL is 50Mhz, similar to the medieum speed on other MCUs
+            // PAL_MODE_STM32_ALTERNATE_PUSHPULL is 50Mhz, similar to the medium speed on other MCUs
             palSetLineMode(group.pal_lines[i], PAL_MODE_STM32_ALTERNATE_PUSHPULL);
 #else
             palSetLineMode(group.pal_lines[i], PAL_MODE_ALTERNATE(group.alt_functions[i])

--- a/libraries/AP_HAL_ChibiOS/RCOutput_bdshot.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput_bdshot.cpp
@@ -645,8 +645,10 @@ __RAMFUNC__ void RCOutput::dma_up_irq_callback(void *p, uint32_t flags)
 
     if (soft_serial_waiting()) {
 #if HAL_SERIAL_ESC_COMM_ENABLED
-        // tell the waiting process we've done the DMA
-        chEvtSignalI(irq.waiter, serial_event_mask);
+        if (group->in_serial_dma) {
+            // tell the waiting process we've done the DMA
+            chEvtSignalI(irq.waiter, serial_event_mask);
+        }
 #endif
     } else if (!group->in_serial_dma && group->bdshot.enabled) {
         group->dshot_state = DshotState::SEND_COMPLETE;


### PR DESCRIPTION
soft serial input was both racy and prone to resetting the line mode incorrectly.
soft serial input was decoding input with trailing 1's incorrectly
soft serial input could miss data when timing out and restarting
DMA output could be left in a bad state