### PR TITLE
Re-init uart with configured baudrate

### DIFF
--- a/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
@@ -87,7 +87,8 @@ bool AP_MSP_Telem_Backend::init_uart()
 {
     if (_msp_port.uart != nullptr)  {
         // re-init port here for use in this thread
-        _msp_port.uart->begin(0);
+        const auto baudrate = _msp_port.uart->get_baud_rate();
+        _msp_port.uart->begin(baudrate);
         return true;
     }
     return false;


### PR DESCRIPTION
In `AP_MSP_Telem_Backend.cpp`, the uart is re-initialized with baudrate 0. I found this when I was investigating issue https://discuss.ardupilot.org/t/configuring-serial-port-as-msp-fails-on-linux-speed-0-baud/131984. In my case, the change in this PR fixes the MSP communication from the `AP_Periph` board to my Linux-based board.