### PR TITLE
SCurve: Fix speed and accel checks to include z component when transitioning fast waypoints

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -12354,12 +12354,12 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_rc(1, 1200)
         self.delay_sim_time(1)  # build up some pilot desired stuff
         self.change_mode('AUTO')
-        self.wait_waypoint(2, 2)
+        self.wait_waypoint(2, 2, max_dist=3)
         self.set_parameters({
             'SIM_RC_FAIL': 1,
         })
 #        self.set_rc(1, 1500)  # note we are still in RC fail!
-        self.wait_waypoint(3, 3)
+        self.wait_waypoint(3, 3, max_dist=3)
         self.assert_mode_is('AUTO')
         self.change_mode('LOITER')
         self.wait_groundspeed(0, 0.1, minimum_duration=30, timeout=450)

--- a/libraries/AP_Math/SCurve.cpp
+++ b/libraries/AP_Math/SCurve.cpp
@@ -30,11 +30,10 @@ extern const AP_HAL::HAL &hal;
 
 #define SEG_INIT                0
 #define SEG_ACCEL_MAX           4
-#define SEG_TURN_IN             7
 #define SEG_ACCEL_END           7
 #define SEG_SPEED_CHANGE_END    14
 #define SEG_CONST               15
-#define SEG_TURN_OUT            15
+#define SEG_DECEL_START         15
 #define SEG_DECEL_END           22
 
 // constructor
@@ -496,8 +495,8 @@ bool SCurve::advance_target_along_track(SCurve &prev_leg, SCurve &next_leg, floa
     const float time_to_destination = get_time_remaining();
     if (fast_waypoint 
         && is_zero(next_leg.get_time_elapsed()) // The next leg has not started
-        && (get_time_elapsed() >= time_turn_out()) // The current leg has started the deceleration phase
-        && (get_time_remaining() <= next_leg.time_turn_in()) // The current leg will finish before completion of the acceleration phase of the next leg
+        && (get_time_elapsed() >= time_decel_start()) // The current leg has started the deceleration phase
+        && (get_time_remaining() <= next_leg.time_accel_end()) // The current leg will finish before completion of the acceleration phase of the next leg
         ) {
 
         // Calculate the position, velocity and acceleration at the turn mid point
@@ -605,22 +604,24 @@ bool SCurve::braking() const
     return time >= segment[SEG_CONST].end_time;
 }
 
-// return time offset used to initiate the turn onto leg
-float SCurve::time_turn_in() const
+// return time offset for the start of the constant speed section and end of the acceleration section
+// used to initiate the turn onto leg
+float SCurve::time_accel_end() const
 {
     if (num_segs != segments_max) {
         return 0.0;
     }
-    return segment[SEG_TURN_IN].end_time;
+    return segment[SEG_ACCEL_END].end_time;
 }
 
-// return time offset used to initiate the turn from leg
-float SCurve::time_turn_out() const
+// return time offset for the end of the constant speed section and start of the deceleration section
+// used to initiate the turn from leg
+float SCurve::time_decel_start() const
 {
     if (num_segs != segments_max) {
         return 0.0;
     }
-    return segment[SEG_TURN_OUT].end_time;
+    return segment[SEG_DECEL_START].end_time;
 }
 
 // increment the internal time

--- a/libraries/AP_Math/SCurve.h
+++ b/libraries/AP_Math/SCurve.h
@@ -111,6 +111,9 @@ private:
     // get desired maximum acceleration along track
     float get_accel_along_track() const WARN_IF_UNUSED { return accel_max; }
 
+    // get desired maximum acceleration along track
+    float get_accel_z_max() const WARN_IF_UNUSED { return accel_z_max; }
+
     // return the change in position from origin to destination
     const Vector3f& get_track() const WARN_IF_UNUSED { return track; };
 
@@ -194,6 +197,7 @@ private:
     float snap_max;     // maximum snap magnitude
     float jerk_max;     // maximum jerk magnitude
     float accel_max;    // maximum acceleration magnitude
+    float accel_z_max;    // maximum acceleration magnitude
     float vel_max;      // maximum velocity magnitude
     float time;         // time that defines position on the path
     float position_sq;  // position (squared) on the path at the last time step (used to detect finish)

--- a/libraries/AP_Math/SCurve.h
+++ b/libraries/AP_Math/SCurve.h
@@ -133,10 +133,10 @@ private:
     bool braking() const WARN_IF_UNUSED;
 
     // return time offset used to initiate the turn onto leg
-    float time_turn_in() const WARN_IF_UNUSED;
+    float time_accel_end() const WARN_IF_UNUSED;
 
     // return time offset used to initiate the turn from leg
-    float time_turn_out() const WARN_IF_UNUSED;
+    float time_decel_start() const WARN_IF_UNUSED;
 
     // increment the internal time
     void advance_time(float dt);


### PR DESCRIPTION
This addresses the issue in #29509.