### PR TITLE
Tools: fix building environment on macos

### DIFF
--- a/Tools/completion/completion.zsh
+++ b/Tools/completion/completion.zsh
@@ -1,5 +1,4 @@
 #!/usr/bin/env zsh
 
-_AP_COMPLETION_DIR=$(builtin cd -q "`dirname "$0"`" > /dev/null && pwd)
+_AP_COMPLETION_DIR=$(builtin cd "`dirname "$0"`" > /dev/null && pwd)
 fpath+=$_AP_COMPLETION_DIR/zsh/
-


### PR DESCRIPTION
Fix invalid option error in cd command by removing unsupported -q flag.