### PR TITLE
Fix shadowed-variable problem in ChibiOS HAL

### DIFF
--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -263,9 +263,10 @@ protected:
     virtual uint32_t get_total_dropped_rx_bytes() const { return 0; }
 #endif
 
-private:
     // option bits for port
     uint16_t _last_options;
+
+private:
 
 #if AP_UART_MONITOR_ENABLED
     ByteBuffer *_monitor_read_buffer;

--- a/libraries/AP_HAL_ChibiOS/UARTDriver.h
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.h
@@ -223,7 +223,6 @@ private:
     uint32_t _cr1_options;
     uint32_t _cr2_options;
     uint32_t _cr3_options;
-    uint16_t _last_options;
 
     // half duplex control. After writing we throw away bytes for 4 byte widths to
     // prevent reading our own bytes back


### PR DESCRIPTION
We have two variables named `_last_options`, meaning updates in the base class wouldn't be seen in the ChibiOS HAL.
