### PR TITLE
AC_Avoidance: avoid use of location.alt in logging

### DIFF
--- a/libraries/AC_Avoidance/AC_Avoidance_Logging.cpp
+++ b/libraries/AC_Avoidance/AC_Avoidance_Logging.cpp
@@ -12,10 +12,17 @@
 #if AP_OAPATHPLANNER_BENDYRULER_ENABLED
 void AP_OABendyRuler::Write_OABendyRuler(const uint8_t type, const bool active, const float target_yaw, const float target_pitch, const bool resist_chg, const float margin, const Location &final_dest, const Location &oa_dest) const
 {
-    int32_t oa_dest_alt, final_alt;
-    const bool got_oa_dest = oa_dest.get_alt_cm(Location::AltFrame::ABOVE_ORIGIN, oa_dest_alt);
-    const bool got_final_dest = final_dest.get_alt_cm(Location::AltFrame::ABOVE_ORIGIN, final_alt);
-    
+    auto &logger = AP::logger();
+
+    float oa_dest_alt;
+    if (!oa_dest.get_alt_m(Location::AltFrame::ABOVE_ORIGIN, oa_dest_alt)) {
+        oa_dest_alt = logger.quiet_nanf();
+    }
+    float final_alt;
+    if (!final_dest.get_alt_m(Location::AltFrame::ABOVE_ORIGIN, final_alt)) {
+        final_alt = logger.quiet_nanf();
+    }
+
     const struct log_OABendyRuler pkt{
         LOG_PACKET_HEADER_INIT(LOG_OA_BENDYRULER_MSG),
         time_us     : AP_HAL::micros64(),
@@ -28,12 +35,12 @@ void AP_OABendyRuler::Write_OABendyRuler(const uint8_t type, const bool active, 
         margin      : margin,
         final_lat   : final_dest.lat,
         final_lng   : final_dest.lng,
-        final_alt   : got_final_dest ? final_alt : final_dest.alt,
+        final_alt   : final_alt,
         oa_lat      : oa_dest.lat,
         oa_lng      : oa_dest.lng,
-        oa_alt      : got_oa_dest ? oa_dest_alt : oa_dest.alt
+        oa_alt      : oa_dest_alt
     };
-    AP::logger().WriteBlock(&pkt, sizeof(pkt));
+    logger.WriteBlock(&pkt, sizeof(pkt));
 }
 #endif  // AP_OAPATHPLANNER_BENDYRULER_ENABLED
 

--- a/libraries/AC_Avoidance/LogStructure.h
+++ b/libraries/AC_Avoidance/LogStructure.h
@@ -37,10 +37,10 @@ struct PACKED log_OABendyRuler {
     float margin;
     int32_t final_lat;
     int32_t final_lng;
-    int32_t final_alt;
+    float final_alt;
     int32_t oa_lat;
     int32_t oa_lng;
-    int32_t oa_alt;
+    float oa_alt;
 };
 
 // @LoggerMessage: OADJ
@@ -110,7 +110,7 @@ struct PACKED log_OD_Visgraph {
 #if AP_AVOIDANCE_ENABLED
 #define LOG_STRUCTURE_FROM_AVOIDANCE \
     { LOG_OA_BENDYRULER_MSG, sizeof(log_OABendyRuler), \
-      "OABR","QBBHHHBfLLiLLi","TimeUS,Type,Act,DYaw,Yaw,DP,RChg,Mar,DLt,DLg,DAlt,OLt,OLg,OAlt", "s--ddd-mDUmDUm", "F-------GGBGGB" , true }, \
+      "OABR","QBBHHHBfLLfLLf","TimeUS,Type,Act,DYaw,Yaw,DP,RChg,Mar,DLt,DLg,DAlt,OLt,OLg,OAlt", "s--ddd-mDUmDUm", "F-------GG0GG0" , true }, \
     { LOG_OA_DIJKSTRA_MSG, sizeof(log_OADijkstra), \
       "OADJ","QBBBBLLLL","TimeUS,State,Err,CurrPoint,TotPoints,DLat,DLng,OALat,OALng", "s----DUDU", "F----GGGG" , true }, \
     { LOG_SIMPLE_AVOID_MSG, sizeof(log_SimpleAvoid), \


### PR DESCRIPTION
Changed to using floats.

Inspected lgos for test.Rover.PolyFenceObjectAvoidanceBendyRulerEasierGuided - altitudes are appropriate after this change considering what was in there beforehand.  Which appears to be garbage....
