### PR TITLE
Scripting: added sim:set_pose() binding and example

### DIFF
--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -4101,3 +4101,14 @@ function AP_Servo_Telem_Data_ud:measured_position() end
 -- get commanded position
 ---@return number|nil -- comanded position in degrees or nil if not available
 function AP_Servo_Telem_Data_ud:command_position() end
+
+-- simulator specific bindings
+sim = {}
+
+-- set pose of simulated vehicle. Requires AHRS_EKF_TYPE=10
+---@param instance integer -- 0 for first vehicle
+---@param loc Location_ud
+---@param orient Quaternion_ud
+---@param velocity_bf Vector3f_ud -- body frame velocity
+---@return boolean
+function sim:set_pose(instance, loc, orient, velocity_bf) end

--- a/libraries/AP_Scripting/examples/sim_arming_pos.lua
+++ b/libraries/AP_Scripting/examples/sim_arming_pos.lua
@@ -1,0 +1,75 @@
+--[[
+    allow for force the position of the simulated vehicle when armed
+--]]
+
+local PARAM_TABLE_KEY = 16
+local PARAM_TABLE_PREFIX = "SIM_APOS_"
+
+-- setup package place specific parameters
+assert(param:add_table(PARAM_TABLE_KEY, PARAM_TABLE_PREFIX, 16), 'could not add param table')
+
+-- add a parameter and bind it to a variable
+function bind_add_param(name, idx, default_value)
+   assert(param:add_param(PARAM_TABLE_KEY, idx, name, default_value), string.format('could not add param %s', name))
+   return Parameter(PARAM_TABLE_PREFIX .. name)
+end
+
+local SIM_APOS_ENABLE = bind_add_param('ENABLE', 1, 0)
+local SIM_APOS_POS_N = bind_add_param('POS_N', 2, 0)
+local SIM_APOS_POS_E = bind_add_param('POS_E', 3, 0)
+local SIM_APOS_POS_D = bind_add_param('POS_D', 4, 0)
+local SIM_APOS_VEL_X = bind_add_param('VEL_X', 5, 0)
+local SIM_APOS_VEL_Y = bind_add_param('VEL_Y', 6, 0)
+local SIM_APOS_VEL_Z = bind_add_param('VEL_Z', 7, 0)
+local SIM_APOS_RLL = bind_add_param('RLL', 8, 0)
+local SIM_APOS_PIT = bind_add_param('PIT', 9, 0)
+local SIM_APOS_YAW = bind_add_param('YAW', 10, 0)
+local SIM_APOS_MODE = bind_add_param('MODE', 11, -1)
+
+local was_armed = false
+
+local function update()
+    if SIM_APOS_ENABLE:get() == 0 then
+        return
+    end
+    local armed = arming:is_armed()
+    local set_pos = armed and not was_armed
+
+    if set_pos then
+        gcs:send_text(0, "Forcing arm pose")
+        local quat = Quaternion()
+        quat:from_euler(math.rad(SIM_APOS_RLL:get()), math.rad(SIM_APOS_PIT:get()), math.rad(SIM_APOS_YAW:get()))
+
+        local vel = Vector3f()
+        vel:x(SIM_APOS_VEL_X:get())
+        vel:y(SIM_APOS_VEL_Y:get())
+        vel:z(SIM_APOS_VEL_Z:get())
+        quat:earth_to_body(vel)
+
+        local loc = ahrs:get_origin()
+        if not loc then
+            return
+        end
+        loc:offset(SIM_APOS_POS_N:get(), SIM_APOS_POS_E:get())
+        loc:alt(loc:alt() - SIM_APOS_POS_D:get()*100)
+
+        sim:set_pose(0, loc, quat, vel)
+
+        if SIM_APOS_MODE:get() >= 0 then
+            vehicle:set_mode(SIM_APOS_MODE:get())
+        end
+    end
+
+    was_armed = armed
+end
+
+local function loop()
+    if SIM_APOS_ENABLE:get() == 0 then
+        return loop, 500
+    end
+    update()
+    return loop, 50
+end
+
+gcs:send_text(0, "Loaded arm pose")
+return loop,1000

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -1071,3 +1071,10 @@ userdata AP_Servo_Telem::TelemetryData field motor_temperature_cdeg int16_t'skip
 userdata AP_Servo_Telem::TelemetryData field pcb_temperature_cdeg int16_t'skip_check read valid_mask present_types AP_Servo_Telem::TelemetryData::Types::PCB_TEMP
 userdata AP_Servo_Telem::TelemetryData field status_flags uint8_t'skip_check read valid_mask present_types AP_Servo_Telem::TelemetryData::Types::STATUS
 userdata AP_Servo_Telem::TelemetryData field last_update_ms uint32_t'skip_check read
+
+-- simulator only bindings
+include SITL/SITL.h depends AP_SIM_ENABLED
+singleton SITL::SIM depends AP_SIM_ENABLED
+singleton SITL::SIM rename sim
+singleton SITL::SIM method set_pose boolean uint8_t'skip_check Location Quaternion Vector3f
+

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -44,6 +44,8 @@ extern const AP_HAL::HAL& hal;
 extern const HAL_SITL& hal_sitl;
 #endif
 
+Aircraft *Aircraft::instances[MAX_SIM_INSTANCES];
+
 /*
   parent class for all simulator types
  */
@@ -691,6 +693,8 @@ void Aircraft::update_model(const struct sitl_input &input)
  */
 void Aircraft::update_dynamics(const Vector3f &rot_accel)
 {
+    WITH_SEMAPHORE(pose_sem);
+
     // update eas2tas and air density
 #if AP_AHRS_ENABLED
     eas2tas = AP::ahrs().get_EAS2TAS();
@@ -1363,3 +1367,35 @@ void Aircraft::update_eas_airspeed()
         airspeed_pitot *= cosf((pitot_aoa - max_pitot_aoa) * gain_factor);
     }
 }
+
+/*
+  set pose on the aircraft, called from scripting
+ */
+bool Aircraft::set_pose(uint8_t instance, const Location &loc, const Quaternion &quat, const Vector3f &velocity_ef)
+{
+    if (instance >= MAX_SIM_INSTANCES || instances[instance] == nullptr) {
+        return false;
+    }
+    auto &aircraft = *instances[instance];
+    WITH_SEMAPHORE(aircraft.pose_sem);
+
+    quat.rotation_matrix(aircraft.dcm);
+    aircraft.velocity_ef = velocity_ef;
+    aircraft.location = loc;
+    aircraft.position = aircraft.home.get_distance_NED_double(loc);
+    aircraft.smoothing.position = aircraft.position;
+    aircraft.smoothing.rotation_b2e = aircraft.dcm;
+    aircraft.smoothing.velocity_ef = velocity_ef;
+    aircraft.smoothing.location = loc;
+
+    return true;
+}
+
+/*
+  wrapper for scripting access
+ */
+bool SITL::SIM::set_pose(uint8_t instance, const Location &loc, const Quaternion &quat, const Vector3f &velocity_ef)
+{
+    return Aircraft::set_pose(instance, loc, quat, velocity_ef);
+}
+

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -44,6 +44,8 @@
 #include "SIM_GPIO_LED_3.h"
 #include "SIM_GPIO_LED_RGB.h"
 
+#define MAX_SIM_INSTANCES 16
+
 namespace SITL {
 
 /*
@@ -67,6 +69,9 @@ public:
      */
     void set_instance(uint8_t _instance) {
         instance = _instance;
+        if (instance < MAX_SIM_INSTANCES) {
+            instances[instance] = this;
+        }
     }
 
     /*
@@ -178,6 +183,11 @@ public:
     ServoModel servo_filter[16];
 
     float get_airspeed_pitot() const { return airspeed_pitot; }
+
+    /*
+      used by scripting to control simulated aircraft position
+     */
+    static bool set_pose(uint8_t instance, const Location &loc, const Quaternion &quat, const Vector3f &velocity_ef);
 
 protected:
     SIM *sitl;
@@ -405,6 +415,8 @@ private:
     GPIO_LED_RGB sim_ledrgb{8, 9, 10};  // pins to match sitl.h
 #endif
 
+    static Aircraft *instances[MAX_SIM_INSTANCES];
+    HAL_Semaphore pose_sem;
 };
 
 } // namespace SITL

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -604,6 +604,11 @@ public:
     // This gives more realistic data rates for testing links
     void set_stop_MAVLink_sim_state() { stop_MAVLink_sim_state = true; }
     bool stop_MAVLink_sim_state;
+
+    /*
+      used by scripting to control simulated aircraft position
+     */
+    bool set_pose(uint8_t instance, const Location &loc, const Quaternion &quat, const Vector3f &velocity_ef);
 };
 
 } // namespace SITL


### PR DESCRIPTION
This allows scripting in SITL to override the vehicle position, velocity and attitude. It can be used to reproduce tricky issues in attitude recovery
