### PR TITLE
AP_Logger: improve LOG_FILE_BUFSIZE param docs

### DIFF
--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -101,8 +101,10 @@ const AP_Param::GroupInfo AP_Logger::var_info[] = {
     AP_GROUPINFO("_BACKEND_TYPE",  0, AP_Logger, _params.backend_types,       uint8_t(HAL_LOGGING_BACKENDS_DEFAULT)),
 
     // @Param: _FILE_BUFSIZE
-    // @DisplayName: Maximum AP_Logger File and Block Backend buffer size (in kilobytes)
-    // @Description: The File and Block backends use a buffer to store data before writing to the block device.  Raising this value may reduce "gaps" in your SD card logging.  This buffer size may be reduced depending on available memory.  PixHawk requires at least 4 kilobytes.  Maximum value available here is 64 kilobytes.
+    // @DisplayName: Logging File and Block Backend buffer size max (in kilobytes)
+    // @Description: The File and Block backends use a buffer to store data before writing to the block device.  Raising this value may reduce "gaps" in your SD card logging but increases memory usage.  This buffer size may be reduced to free up available memory
+    // @Units: kB
+    // @Range: 4 200
     // @User: Standard
     AP_GROUPINFO("_FILE_BUFSIZE",  1, AP_Logger, _params.file_bufsize,       HAL_LOGGING_FILE_BUFSIZE),
 


### PR DESCRIPTION
This improves the LOG_FILE_BUFSIZE parameter description a little bit by:

1. adding units
2. adding the range of 4~200 which is taken from the comments and the defines at the top of the file
3. removed a reference to Pixhawk which is now just one of more than 200 boards that we support

This resolves issue https://github.com/ArduPilot/ardupilot/issues/29621 which was also discussed here https://discuss.ardupilot.org/t/log-file-bufsize/132358