### PR TITLE
AP_NavEKF3: Manual Lane switching 

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -328,6 +328,9 @@ public:
      */
     void checkLaneSwitch(void);
 
+    // switch to a new lane
+    void switchLane(uint8_t new_lane_index);
+
     /*
       Request a reset of the EKF yaw. This is called when the vehicle code is about to
       trigger an EKF failsafe, and it would like to avoid that.
@@ -455,6 +458,7 @@ private:
     // enum for processing options
     enum class Option {
         JammingExpected     = (1<<0),
+        ManualLaneSwitch   = (1<<1),
     };
     bool option_is_enabled(Option option) const {
         return (_options & (uint32_t)option) != 0;


### PR DESCRIPTION
While doing EKF-based tests, this is helpful. 
When the EK3_OPTIONS second bit is enabled, automatic lane switching will be disabled (unless the core becomes "unhealthy", which is very extreme and we should never be flying with that). And EK3_PRIMIARY core will be enforced. This also means we can select the active core from a Lua Script mid flight.  

Might also have some use cases when lane switches are happening often because of small timing difference in the core. Example, flying with a single baro on a windy day and seeing lane switches isn't uncommon. 

I personally also have a usecase for this PR where I am working on another branch that allows different types of sensors to be used in different lanes, for example GPS on lane 1, Ext Nav on lane 2. For testing Ext Nav, it'll be helpful to disable lane switching. 