### PR TITLE
Stop using location.alt field in AHRS logging

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_Logging.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Logging.cpp
@@ -18,13 +18,17 @@ void AP_AHRS::Write_AHRS2() const
     if (!get_secondary_attitude(euler) || !get_secondary_position(loc) || !get_secondary_quaternion(quat)) {
         return;
     }
+    float alt;
+    if (!loc.initialised() || !loc.get_alt_m(Location::AltFrame::ABSOLUTE, alt)) {
+        alt = AP::logger().quiet_nanf();
+    }
     const struct log_AHRS pkt{
         LOG_PACKET_HEADER_INIT(LOG_AHR2_MSG),
         time_us : AP_HAL::micros64(),
         roll  : (int16_t)(degrees(euler.x)*100),
         pitch : (int16_t)(degrees(euler.y)*100),
         yaw   : (uint16_t)(wrap_360_cd(degrees(euler.z)*100)),
-        alt   : loc.alt*1.0e-2f,
+        alt   : alt,
         lat   : loc.lat,
         lng   : loc.lng,
         q1    : quat.q1,
@@ -67,13 +71,17 @@ void AP_AHRS::Write_Attitude(const Vector3f &targets) const
 
 void AP_AHRS::Write_Origin(LogOriginType origin_type, const Location &loc) const
 {
+    int32_t alt_cm;
+    if (!loc.initialised() || !loc.get_alt_cm(Location::AltFrame::ABSOLUTE, alt_cm)) {
+        alt_cm = 0;
+    }
     const struct log_ORGN pkt{
         LOG_PACKET_HEADER_INIT(LOG_ORGN_MSG),
         time_us     : AP_HAL::micros64(),
         origin_type : (uint8_t)origin_type,
         latitude    : loc.lat,
         longitude   : loc.lng,
-        altitude    : loc.alt
+        altitude    : alt_cm
     };
     AP::logger().WriteBlock(&pkt, sizeof(pkt));
 }
@@ -85,16 +93,28 @@ void AP_AHRS::Write_POS() const
     if (!get_location(loc)) {
         return;
     }
-    float home, origin;
+    float home;
     AP::ahrs().get_relative_position_D_home(home);
+
+    const auto nanf = AP::logger().quiet_nanf();
+    float origin_pos_up;
+    if (get_relative_position_D_origin(origin_pos_up)) {
+        origin_pos_up *= -1;  // down -> up
+    } else {
+        origin_pos_up = nanf;
+    }
+    float alt;
+    if (!loc.get_alt_m(Location::AltFrame::ABSOLUTE, alt)) {
+        alt = nanf;
+    }
     const struct log_POS pkt{
         LOG_PACKET_HEADER_INIT(LOG_POS_MSG),
         time_us        : AP_HAL::micros64(),
         lat            : loc.lat,
         lng            : loc.lng,
-        alt            : loc.alt*1.0e-2f,
+        alt            : alt,
         rel_home_alt   : -home,
-        rel_origin_alt : get_relative_position_D_origin(origin) ? -origin : AP::logger().quiet_nanf(),
+        rel_origin_alt : origin_pos_up,
     };
     AP::logger().WriteBlock(&pkt, sizeof(pkt));
 }

--- a/libraries/AP_Common/Location.cpp
+++ b/libraries/AP_Common/Location.cpp
@@ -101,7 +101,7 @@ Location::AltFrame Location::get_alt_frame() const
     return AltFrame::ABSOLUTE;
 }
 
-/// get altitude in desired frame
+/// get altitude in desired frame.  Must not change ret_alt_cm unless true is returned!
 bool Location::get_alt_cm(AltFrame desired_frame, int32_t &ret_alt_cm) const
 {
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
@@ -205,6 +205,7 @@ bool Location::get_alt_cm(AltFrame desired_frame, int32_t &ret_alt_cm) const
     }
     return false;  // LCOV_EXCL_LINE  - not reachable
 }
+//  Must not change ret_alt_cm unless true is returned!
 bool Location::get_alt_m(AltFrame desired_frame, float &ret_alt) const
 {
     int32_t ret_alt_cm;

--- a/libraries/AP_Common/Location.h
+++ b/libraries/AP_Common/Location.h
@@ -41,6 +41,7 @@ public:
     }
 
     // get altitude (in cm) in the desired frame
+    // does not modify ret_alt_cm unless true is returned
     // returns false on failure to get altitude in the desired frame which can only happen if the original frame or desired frame is:
     // - above-terrain and the terrain database can't supply terrain height amsl
     // - above-home and home is not set


### PR DESCRIPTION
I've checked the logs before/after this patch and the same data is present.

DCM doesn't seem to do well with altitude - the discretisation here is weird.

![image](https://github.com/user-attachments/assets/c9e1d061-aeb7-4c25-81a4-357118328930)

That log was created by right-clicking on a ~600m-high hill to the north-west of CMAC (the quarry) and "set home with height".

Looks like we may not be resetting the barometer zero datum correctly on a set-home.
