### PR TITLE
AP_BattMonitor: use state rather than params for type

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -88,38 +88,7 @@ public:
     };
 
     // Battery monitor driver types
-    enum class Type {
-        NONE                           = 0,
-        ANALOG_VOLTAGE_ONLY            = 3,
-        ANALOG_VOLTAGE_AND_CURRENT     = 4,
-        SOLO                           = 5,
-        BEBOP                          = 6,
-        SMBus_Generic                  = 7,
-        UAVCAN_BatteryInfo             = 8,
-        BLHeliESC                      = 9,
-        Sum                            = 10,
-        FuelFlow                       = 11,
-        FuelLevel_PWM                  = 12,
-        SUI3                           = 13,
-        SUI6                           = 14,
-        NeoDesign                      = 15,
-        MAXELL                         = 16,
-        GENERATOR_ELEC                 = 17,
-        GENERATOR_FUEL                 = 18,
-        Rotoye                         = 19,
-        // 20 was MPPT_PacketDigital
-        INA2XX                         = 21,
-        LTC2946                        = 22,
-        Torqeedo                       = 23,
-        FuelLevel_Analog               = 24,
-        Analog_Volt_Synthetic_Current  = 25,
-        INA239_SPI                     = 26,
-        EFI                            = 27,
-        AD7091R5                       = 28,
-        Scripting                      = 29,
-        INA3221                        = 30,
-        ANALOG_CURRENT_ONLY            = 31,
-    };
+    using Type = AP_BattMonitor_Params::Type;
 
     FUNCTOR_TYPEDEF(battery_failsafe_handler_fn_t, void, const char *, const int8_t);
 
@@ -226,11 +195,11 @@ public:
     int8_t get_highest_failsafe_priority(void) const { return _highest_failsafe_priority; };
 
     /// configured_type - returns battery monitor type as configured in parameters
-    enum Type configured_type(uint8_t instance) const {
+    Type configured_type(uint8_t instance) const {
         return (Type)_params[instance]._type.get();
     }
     /// allocated_type - returns battery monitor type as allocated
-    enum Type allocated_type(uint8_t instance) const {
+    Type allocated_type(uint8_t instance) const {
         return state[instance].type;
     }
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
@@ -88,14 +88,14 @@ AP_BattMonitor_Analog::AP_BattMonitor_Analog(AP_BattMonitor &mon,
 #endif
     _state.var_info = var_info;
     
-    if ((AP_BattMonitor::Type)_params._type.get() != AP_BattMonitor::Type::ANALOG_CURRENT_ONLY) {
+    if (_params._type != AP_BattMonitor::Type::ANALOG_CURRENT_ONLY) {
         _volt_pin_analog_source = hal.analogin->channel(_volt_pin);
         if (_volt_pin_analog_source == nullptr) {
             AP_BoardConfig::config_error("No analog voltage channel for battery %d", mon_state.instance);
         }
     }
-    if (((AP_BattMonitor::Type)_params._type.get() == AP_BattMonitor::Type::ANALOG_VOLTAGE_AND_CURRENT)
-        || ((AP_BattMonitor::Type)_params._type.get() == AP_BattMonitor::Type::ANALOG_CURRENT_ONLY)) {
+    if (_params._type == AP_BattMonitor::Type::ANALOG_VOLTAGE_AND_CURRENT ||
+        _params._type == AP_BattMonitor::Type::ANALOG_CURRENT_ONLY) {
         _curr_pin_analog_source = hal.analogin->channel(_curr_pin);
         if (_curr_pin_analog_source == nullptr) {
             AP_BoardConfig::config_error("No analog current channel for battery %d", mon_state.instance);
@@ -108,7 +108,7 @@ AP_BattMonitor_Analog::AP_BattMonitor_Analog(AP_BattMonitor &mon,
 void
 AP_BattMonitor_Analog::read()
 {
-    if ((AP_BattMonitor::Type)_params._type.get() != AP_BattMonitor::Type::ANALOG_CURRENT_ONLY) {
+    if (_params._type != AP_BattMonitor::Type::ANALOG_CURRENT_ONLY) {
         // this copes with changing the pin at runtime
         _state.healthy = _volt_pin_analog_source->set_pin(_volt_pin);
 
@@ -142,8 +142,8 @@ AP_BattMonitor_Analog::read()
 bool AP_BattMonitor_Analog::has_current() const
 {
     return (_curr_pin_analog_source != nullptr) &&
-           (((AP_BattMonitor::Type)_params._type.get() == AP_BattMonitor::Type::ANALOG_VOLTAGE_AND_CURRENT)
-            || ((AP_BattMonitor::Type)_params._type.get() == AP_BattMonitor::Type::ANALOG_CURRENT_ONLY));
+        (_params._type == AP_BattMonitor::Type::ANALOG_VOLTAGE_AND_CURRENT ||
+         _params._type == AP_BattMonitor::Type::ANALOG_CURRENT_ONLY);
 }
 
 #endif  // AP_BATTERY_ANALOG_ENABLED

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
@@ -108,7 +108,7 @@ AP_BattMonitor_Analog::AP_BattMonitor_Analog(AP_BattMonitor &mon,
 void
 AP_BattMonitor_Analog::read()
 {
-    if (_params._type != AP_BattMonitor::Type::ANALOG_CURRENT_ONLY) {
+    if (_state.type != AP_BattMonitor::Type::ANALOG_CURRENT_ONLY) {
         // this copes with changing the pin at runtime
         _state.healthy = _volt_pin_analog_source->set_pin(_volt_pin);
 
@@ -142,8 +142,8 @@ AP_BattMonitor_Analog::read()
 bool AP_BattMonitor_Analog::has_current() const
 {
     return (_curr_pin_analog_source != nullptr) &&
-        (_params._type == AP_BattMonitor::Type::ANALOG_VOLTAGE_AND_CURRENT ||
-         _params._type == AP_BattMonitor::Type::ANALOG_CURRENT_ONLY);
+        (_state.type == AP_BattMonitor::Type::ANALOG_VOLTAGE_AND_CURRENT ||
+         _state.type == AP_BattMonitor::Type::ANALOG_CURRENT_ONLY);
 }
 
 #endif  // AP_BATTERY_ANALOG_ENABLED

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
@@ -12,6 +12,39 @@ public:
     /* Do not allow copies */
     CLASS_NO_COPY(AP_BattMonitor_Params);
 
+    enum class Type {
+        NONE                           = 0,
+        ANALOG_VOLTAGE_ONLY            = 3,
+        ANALOG_VOLTAGE_AND_CURRENT     = 4,
+        SOLO                           = 5,
+        BEBOP                          = 6,
+        SMBus_Generic                  = 7,
+        UAVCAN_BatteryInfo             = 8,
+        BLHeliESC                      = 9,
+        Sum                            = 10,
+        FuelFlow                       = 11,
+        FuelLevel_PWM                  = 12,
+        SUI3                           = 13,
+        SUI6                           = 14,
+        NeoDesign                      = 15,
+        MAXELL                         = 16,
+        GENERATOR_ELEC                 = 17,
+        GENERATOR_FUEL                 = 18,
+        Rotoye                         = 19,
+        // 20 was MPPT_PacketDigital
+        INA2XX                         = 21,
+        LTC2946                        = 22,
+        Torqeedo                       = 23,
+        FuelLevel_Analog               = 24,
+        Analog_Volt_Synthetic_Current  = 25,
+        INA239_SPI                     = 26,
+        EFI                            = 27,
+        AD7091R5                       = 28,
+        Scripting                      = 29,
+        INA3221                        = 30,
+        ANALOG_CURRENT_ONLY            = 31,
+    };
+
     // low voltage sources (used for BATT_LOW_TYPE parameter)
     enum BattMonitor_LowVoltage_Source {
         BattMonitor_LowVoltageSource_Raw            = 0,
@@ -44,7 +77,7 @@ public:
 #if AP_BATTERY_WATT_MAX_ENABLED
     AP_Int16 _watt_max;                 /// max battery power allowed. Reduce max throttle to reduce current to satisfy t    his limit
 #endif
-    AP_Int8  _type;                     /// 0=disabled, 3=voltage only, 4=voltage and current
+    AP_Enum<Type>  _type;                     /// 0=disabled, 3=voltage only, 4=voltage and current
     AP_Int8  _low_voltage_timeout;      /// timeout in seconds before a low voltage event will be triggered
     AP_Int8  _failsafe_voltage_source;  /// voltage type used for detection of low voltage event
     AP_Int8  _failsafe_low_action;      /// action to preform on a low battery failsafe


### PR DESCRIPTION
@andyp1per you might like this one after having to play around with the nasty casting stuff!

Type has to live in Params as Params can't see the AP_BattMonitor class to copy the enum from.

edit: now fixes an issue where we were using the configured type rather than allocated type.  The use of the enumeration made it much clearer what was going on.
