### PR TITLE
AP_Networking: parm fix for ipaddr 3rd octet

### DIFF
--- a/libraries/AP_Networking/AP_Networking_address.cpp
+++ b/libraries/AP_Networking/AP_Networking_address.cpp
@@ -27,7 +27,7 @@ const AP_Param::GroupInfo AP_Networking_IPV4::var_info[] = {
 
     // @Param: 2
     // @DisplayName: IPv4 Address 3rd byte
-    // @Description: IPv4 address. Example: xxx.xxx.13.xxx
+    // @Description: IPv4 address. Example: xxx.xxx.144.xxx
     // @Range: 0 255
     // @RebootRequired: True
     AP_GROUPINFO("2", 3,  AP_Networking_IPV4, addr[2], 0),


### PR DESCRIPTION
This is a tiny fix to the networking parameter docs.  I probably should have caught this as part of PR https://github.com/ArduPilot/ardupilot/pull/28815

I haven't tested this but surely it's fine