### PR TITLE
AP_ExternalAHRS: Protect against uninitialized location and origin

### DIFF
--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS.cpp
@@ -174,6 +174,11 @@ bool AP_ExternalAHRS::get_origin(Location &loc)
 {
     if (state.have_origin) {
         WITH_SEMAPHORE(state.sem);
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+        if (!state.origin.initialised()) {
+            AP_HAL::panic("Uninitialized origin in AP_ExternalAHRS.");
+        }
+#endif
         loc = state.origin;
         return true;
     }
@@ -198,6 +203,11 @@ bool AP_ExternalAHRS::get_location(Location &loc)
     }
     WITH_SEMAPHORE(state.sem);
     loc = state.location;
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    if (!loc.initialised()) {
+        AP_HAL::panic("Uninitialized location in AP_ExternalAHRS.");
+    }
+#endif
 
     if (state.last_location_update_us != 0 &&
         state.have_velocity) {


### PR DESCRIPTION
* Add protections in AP_ExternalAHRS against improperly initialized EAHRS drivers
* Without this, you get faults deep inside DCM that are much less obvious
* An uninitialed origin or location, just after the `have_origin` or `have_location`, is likely a bug

Continuation of https://github.com/ArduPilot/ardupilot/pull/29628
