### PR TITLE
AP_GPS: Protect against nullptr port

### DIFF
--- a/libraries/AP_GPS/AP_GPS_GSOF.cpp
+++ b/libraries/AP_GPS/AP_GPS_GSOF.cpp
@@ -47,6 +47,11 @@ AP_GPS_GSOF::AP_GPS_GSOF(AP_GPS &_gps,
     AP_GPS_Backend(_gps, _params, _state, _port)
 {
 
+    if (port == nullptr) {
+        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "GSOF instance %d has no port", state.instance);
+        return;
+    }
+
     const uint16_t gsofmsgreq[5] = {
         AP_GSOF::POS_TIME,
         AP_GSOF::POS,


### PR DESCRIPTION
![Screenshot from 2025-03-28 23-36-01](https://github.com/user-attachments/assets/2954c6da-3983-4a55-a9ee-8efa338b01e0)

Saw this when mucking with NET_* ports and GPS. I would prefer to protect against this earlier in the stack, but we can't because it's a switch/case where the backend gets allocated. The nullptr port check in the frontend is currently here: https://github.com/ArduPilot/ardupilot/blob/2a5bc6223ebbec935789b9cabf608dd3469a3afc/libraries/AP_GPS/AP_GPS.cpp#L680

No all GPS's need a port. 