### PR TITLE
Fixes for enabling/disbling various build options

### DIFF
--- a/ArduPlane/systemid.h
+++ b/ArduPlane/systemid.h
@@ -10,6 +10,9 @@
 #if AP_PLANE_SYSTEMID_ENABLED
 
 #include <AP_Math/chirp.h>
+#include <AP_Param/AP_Param.h>
+#include <AP_Math/vector3.h>
+#include <AP_Math/vector2.h>
 
 class AP_SystemID {
 

--- a/Tools/autotest/test_build_options.py
+++ b/Tools/autotest/test_build_options.py
@@ -320,6 +320,7 @@ class TestBuildOptions(object):
             feature_define_whitelist.add('MODE_AUTOLAND_ENABLED')
             feature_define_whitelist.add('AP_PLANE_GLIDER_PULLUP_ENABLED')
             feature_define_whitelist.add('AP_QUICKTUNE_ENABLED')
+            feature_define_whitelist.add('AP_PLANE_SYSTEMID_ENABLED')
 
         if target.lower() not in ["plane", "copter"]:
             feature_define_whitelist.add('HAL_ADSB_ENABLED')

--- a/Tools/autotest/test_build_options.py
+++ b/Tools/autotest/test_build_options.py
@@ -295,6 +295,14 @@ class TestBuildOptions(object):
             feature_define_whitelist.add('AP_INERTIALSENSOR_FAST_SAMPLE_WINDOW_ENABLED')
             feature_define_whitelist.add('AP_COPTER_AHRS_AUTO_TRIM_ENABLED')
 
+        if target.lower() in ['antennatracker', 'blimp', 'sub', 'plane', 'copter']:
+            # plane has a dependency for AP_Follow which is not
+            # declared in build_options.py; we don't compile follow
+            # support for Follow into Plane unless scripting is also
+            # enabled.  Copter manages to elide everything is
+            # MODE_FOLLOW isn't enabled.
+            feature_define_whitelist.add('AP_FOLLOW_ENABLED')
+
         if target.lower() != "plane":
             # only on Plane:
             feature_define_whitelist.add('AP_ICENGINE_ENABLED')

--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -231,7 +231,7 @@ BUILD_OPTIONS = [
     Feature('Plane', 'PLANE_GLIDER_PULLUP', 'AP_PLANE_GLIDER_PULLUP_ENABLED', 'Enable Glider pullup support', 0, None),
     Feature('Plane', 'QUICKTUNE', 'AP_QUICKTUNE_ENABLED', 'Enable VTOL quicktune', 0, None),
     Feature('Plane', 'AUTOLAND_MODE', 'MODE_AUTOLAND_ENABLED', 'Enable Fixed Wing Autolanding mode', 0, None),
-    Feature('Plane', 'PLANE_SYSTEMID', 'AP_PLANE_SYSTEMID_ENABLED', 'Enable systemID support for quadplanes', 0, None),
+    Feature('Plane', 'PLANE_SYSTEMID', 'AP_PLANE_SYSTEMID_ENABLED', 'Enable systemID support for quadplanes', 0, 'QUADPLANE,Logging'),  # NOQA:E501
 
     Feature('RC', 'RC_Protocol', 'AP_RCPROTOCOL_ENABLED', "Enable Serial RC Protocols", 0, None),   # NOQA: E501
     Feature('RC', 'RC_CRSF', 'AP_RCPROTOCOL_CRSF_ENABLED', "Enable CRSF", 0, "RC_Protocol"),   # NOQA: E501

--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -88,6 +88,7 @@ class ExtractFeatures(object):
             ('AP_RANGEFINDER_TRI2C_ENABLED', r'AP_RangeFinder_TeraRangerI2C::update\b',),
             ('AP_RANGEFINDER_JRE_SERIAL_ENABLED', r'AP_RangeFinder_JRE_Serial::get_reading\b',),
             ('AP_RANGEFINDER_RDS02UF_ENABLED', r'AP_RangeFinder_RDS02UF::get_reading\b',),
+            ('AP_RANGEFINDER_HEXSOONRADAR_ENABLED', r'AP_RangeFinder_NRA24_CAN::handle_frame'),
 
             ('AP_GPS_NMEA_UNICORE_ENABLED', r'AP_GPS_NMEA::parse_agrica_field',),
             ('AP_GPS_{type}_ENABLED', r'AP_GPS_(?P<type>.*)::read\b',),


### PR DESCRIPTION
 - more hexsoon/nanoradar fixes
 - many fixes around Plane systemid stuff
 - exempt follow library for most checks as it's problematic.
 

`test_build_options.py` runs successfully again past these patches.
