### PR TITLE
Rename get_alt_distance -> get_height_above

### DIFF
--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -421,7 +421,7 @@ void Plane::reset_offset_altitude(void)
 void Plane::set_offset_altitude_location(const Location &start_loc, const Location &destination_loc)
 {
     ftype alt_difference_m = 0;
-    if (destination_loc.get_alt_distance(start_loc, alt_difference_m)) {
+    if (destination_loc.get_height_above(start_loc, alt_difference_m)) {
         target_altitude.offset_cm = alt_difference_m * 100;
     } else {
         target_altitude.offset_cm = 0;

--- a/ArduPlane/mode_LoiterAltQLand.cpp
+++ b/ArduPlane/mode_LoiterAltQLand.cpp
@@ -33,7 +33,7 @@ void ModeLoiterAltQLand::navigate()
 void ModeLoiterAltQLand::switch_qland()
 {
     ftype dist;
-    if ((!plane.current_loc.get_alt_distance(plane.next_WP_loc, dist) || is_negative(dist)) && plane.nav_controller->reached_loiter_target()) {
+    if ((!plane.current_loc.get_height_above(plane.next_WP_loc, dist) || is_negative(dist)) && plane.nav_controller->reached_loiter_target()) {
         plane.set_mode(plane.mode_qland, ModeReason::LOITER_ALT_REACHED_QLAND);
     }
 }

--- a/ArduPlane/mode_autoland.cpp
+++ b/ArduPlane/mode_autoland.cpp
@@ -224,7 +224,7 @@ void ModeAutoLand::navigate()
         plane.update_loiter(cmd_climb.p1);
 
         ftype dist;
-        if (plane.reached_loiter_target() || !cmd_climb.content.location.get_alt_distance(plane.current_loc, dist) || (dist < fast_climb_extra_alt)) {
+        if (plane.reached_loiter_target() || !cmd_climb.content.location.get_height_above(plane.current_loc, dist) || (dist < fast_climb_extra_alt)) {
             // Reached destination or Climb is done, move onto loiter
             plane.auto_state.next_wp_crosstrack = true;
             stage = AutoLandStage::LOITER;

--- a/ArduPlane/mode_qrtl.cpp
+++ b/ArduPlane/mode_qrtl.cpp
@@ -125,7 +125,7 @@ void ModeQRTL::run()
             Location stopping_loc = Location(stopping_point.tofloat(), Location::AltFrame::ABOVE_ORIGIN);
 
             ftype alt_diff;
-            if (!stopping_loc.get_alt_distance(plane.next_WP_loc, alt_diff) || is_positive(alt_diff)) {
+            if (!stopping_loc.get_height_above(plane.next_WP_loc, alt_diff) || is_positive(alt_diff)) {
                 // climb finished or cant get alt diff, head home
                 submode = SubMode::RTL;
                 plane.prev_WP_loc = plane.current_loc;
@@ -146,7 +146,7 @@ void ModeQRTL::run()
 
                 plane.do_RTL(RTL_alt_abs_cm);
                 quadplane.poscontrol_init_approach();
-                if (plane.current_loc.get_alt_distance(plane.next_WP_loc, alt_diff)) {
+                if (plane.current_loc.get_height_above(plane.next_WP_loc, alt_diff)) {
                     poscontrol.slow_descent = is_positive(alt_diff);
                 } else {
                     // default back to old method

--- a/libraries/AP_Common/Location.cpp
+++ b/libraries/AP_Common/Location.cpp
@@ -274,8 +274,11 @@ ftype Location::get_distance(const Location &loc2) const
     return norm(dlat, dlng) * LOCATION_SCALING_FACTOR;
 }
 
-// return the altitude difference in meters taking into account alt frame.
-bool Location::get_alt_distance(const Location &loc2, ftype &distance) const
+// return the altitude difference in meters taking into account alt
+// frame.  if loc2 is below this location then "distance" will be
+// positive.  ie. this method returns how far above loc2 this location
+// is.
+bool Location::get_height_above(const Location &loc2, ftype &distance) const
 {
     if (get_alt_frame() == loc2.get_alt_frame()) {
         switch (get_alt_frame()) {
@@ -467,7 +470,7 @@ bool Location::same_alt_as(const Location &loc2) const
     }
 
     ftype alt_diff;
-    bool have_diff = this->get_alt_distance(loc2, alt_diff);
+    bool have_diff = this->get_height_above(loc2, alt_diff);
 
     const ftype tolerance = FLT_EPSILON;
     return have_diff && (fabsF(alt_diff) < tolerance);

--- a/libraries/AP_Common/Location.h
+++ b/libraries/AP_Common/Location.h
@@ -75,8 +75,11 @@ public:
     // return horizontal distance in meters between two locations
     ftype get_distance(const Location &loc2) const;
 
-    // return the altitude difference in meters taking into account alt frame.
-    bool get_alt_distance(const Location &loc2, ftype &distance) const WARN_IF_UNUSED;
+    // return the altitude difference in meters taking into account
+    // alt frame.  if loc2 is below this location then "distance" will
+    // be positive.  ie. this method returns how far above loc2 this
+    // location is.
+    bool get_height_above(const Location &loc2, ftype &distance) const WARN_IF_UNUSED;
 
     // return the distance in meters in North/East/Down plane as a N/E/D vector to loc2
     // NOT CONSIDERING ALT FRAME!

--- a/libraries/AP_Common/tests/test_location.cpp
+++ b/libraries/AP_Common/tests/test_location.cpp
@@ -364,6 +364,22 @@ TEST(Location, Sanitize)
     EXPECT_NE(test_default_loc.alt, test_loc.alt);
 }
 
+TEST(Location, GetHeightAbove)
+{
+    // we will sanitize test_loc with test_default_loc
+    // test_home is just for reference
+    const Location test_loc{-35362938, 149165085, 37900, Location::AltFrame::ABSOLUTE};
+    const Location test_origin{-35362938, 149165085, 20000, Location::AltFrame::ABSOLUTE};
+
+    ftype alt_delta;
+    EXPECT_EQ(true, test_loc.get_height_above(test_origin, alt_delta));
+    EXPECT_FLOAT_EQ(179, alt_delta);
+
+    EXPECT_EQ(true, test_origin.get_height_above(test_loc, alt_delta));
+    EXPECT_FLOAT_EQ(-179, alt_delta);
+}
+
+
 TEST(Location, Line)
 {
     const Location test_home{35362938, 149165085, 100, Location::AltFrame::ABSOLUTE};


### PR DESCRIPTION
I'm wondering if we can do better than this.
```
if (current_loc.get_height_above(some_other_loc)
```

No compiler output change:

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                 *                                                   
Durandal                            *      *           *       *                 *      *      *
Hitec-Airspeed           *                 *                                                   
KakuteH7-bdshot                     *      *           *       *                 *      *      *
MatekF405                           *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *                  *       *                 *      *      *
f103-QiotekPeriph        *                 *                                                   
f303-Universal           *                 *                                                   
iomcu                                                                *                         
revo-mini                           *      *           *       *                 *      *      *
skyviper-v2450                                         *                                       
```
