### PR TITLE
SITL: handle case where servo is disabled in servo angle filtering

### DIFF
--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -1001,7 +1001,8 @@ void Aircraft::smooth_sensors(void)
  */
 float Aircraft::filtered_servo_angle(const struct sitl_input &input, uint8_t idx)
 {
-    return servo_filter[idx].filter_angle(input.servos[idx], frame_time_us * 1.0e-6);
+    uint16_t pwm = input.servos[idx] == 0 ? 1500 : input.servos[idx];
+    return servo_filter[idx].filter_angle(pwm, frame_time_us * 1.0e-6);
 }
 
 /*

--- a/libraries/SITL/tests/test_sim_aircraft_filtered_servo_angle.cpp
+++ b/libraries/SITL/tests/test_sim_aircraft_filtered_servo_angle.cpp
@@ -1,0 +1,62 @@
+#include <AP_gtest.h>
+
+#include <SITL/SIM_Aircraft.h>
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+using namespace SITL;
+
+// Dummy class to access protected functions through a public interface for unit tests
+class dummy : public SITL::Aircraft {
+
+public:
+    dummy(const char *frame_str) : SITL::Aircraft(frame_str) {}
+
+    float filtered_servo_angle_pub(const struct sitl_input &input, uint8_t idx);
+
+    // Implement required pure virtual functions
+    void update(const struct sitl_input &input) override
+    {
+        // Do nothing
+    }
+
+    float perpendicular_distance_to_rangefinder_surface() const override
+    {
+        return 0.0;  // Return a default value
+    }
+
+    bool on_ground() const override
+    {
+        return true; // Assume it's on the ground by default
+    }
+};
+
+float dummy::filtered_servo_angle_pub(const struct sitl_input &input, uint8_t idx)
+{
+    return dummy::filtered_servo_angle(input, idx);
+}
+
+const struct servo_test_values {
+    sitl_input input;
+    uint8_t idx;
+    float expected_angle;
+} servo_test_data[] = {
+    {{1100}, 0, -0.8},
+    {{1190}, 0, -0.62},
+    {{1500}, 0, 0.0},
+    {{1642}, 0, 0.28},
+    {{1900}, 0, 0.8},
+    {{0}, 0, 0.0}
+};
+
+TEST(Aircraft, filtered_servo_angle)
+{
+    dummy aircraft("plane");  
+    float accuracy = 0.01;
+
+    for (auto elem : servo_test_data) {
+        float result = aircraft.filtered_servo_angle_pub(elem.input, elem.idx);
+        EXPECT_NEAR(result, elem.expected_angle, accuracy);
+    }
+}
+
+AP_GTEST_MAIN()


### PR DESCRIPTION
Fixes #12293. If the servo is disabled (value 0), assign the default trim value of 1500 before applying filtering.

In the filtered_servo_angle function of the Aircraft class, servo signals are expected to range from 1000 to 2000, with a neutral trim position at 1500. However, when a servo is disabled (value 0), the function incorrectly processes it as a valid PWM value, leading to unexpected behavior.

This fix ensures that disabled servos are correctly handled by explicitly setting their value to 1500 before filtering. As a result, the plane no longer goes around in circles in the simulation when the rudder servo is disabled.

Added a unit-test for the modified function that tests it with some input values in the 1000-2000 range and with value 0.