### PR TITLE
AP_Terrain: Protect against division by 0 when TERRAIN_SPACING is less then 1

### DIFF
--- a/libraries/AP_Terrain/AP_Terrain.cpp
+++ b/libraries/AP_Terrain/AP_Terrain.cpp
@@ -441,6 +441,10 @@ bool AP_Terrain::pre_arm_checks(char *failure_msg, uint8_t failure_msg_len) cons
         hal.util->snprintf(failure_msg, failure_msg_len, "waiting for terrain data");
         return false;
     }
+    if (grid_spacing <= 0) {
+        hal.util->snprintf(failure_msg, failure_msg_len, "TERRAIN_SPACING can't be <= 0");
+        return false;
+    }
 
     return true;
 }


### PR DESCRIPTION
This fixes #29392. In the calculate_grid_info function and the east_blocks function of AP_Terrain, the TERRAIN_SPACING parameter is used to determine grid spacing and how many blocks are needed in a stride for a given location. 

When this parameter is set to a value less than 1, a division by zero occurs, leading to an arithmetic exception. This fix   ensures that grid_spacing is properly handled when its value is below 1. Specifically, if grid_spacing is less than 1, the system defaults to using a value of 1 instead.

This fix has been tested in SITL environment and seems to be working fine.