### PR TITLE
Tools: Added INA2xx parameters to ModalAI Sentinel M0065 frame params

### DIFF
--- a/Tools/Frame_params/ModalAI/SentinelM0065.parm
+++ b/Tools/Frame_params/ModalAI/SentinelM0065.parm
@@ -54,6 +54,10 @@ ATC_RAT_RLL_D 0.002
 ATC_RAT_RLL_I 0.08
 ATC_RAT_RLL_P 0.08
 
+# For external INA231 power monitor
+BATT_MONITOR 21
+BATT_I2C_BUS 1
+
 # battery setup
 BATT_LOW_VOLT    14.2
 BATT_OPTIONS     64


### PR DESCRIPTION
The voltage and current readings usually come from the ESC in VOXL 2 based designs. But in the case where the IO board is being used for PWM then voltage and current readings need to come from the external VOXL PM power module. This PR adds the configuration parameters needed to use the VOXL PM with the IO board to the frame params file.