### PR TITLE
AP_DDS: provide clock_gettime only for HAL_BOARD_CHIBIOS

### DIFF
--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -1767,7 +1767,7 @@ void AP_DDS_Client::update()
     status_ok = uxr_run_session_time(&session, 1);
 }
 
-#if CONFIG_HAL_BOARD != HAL_BOARD_SITL && CONFIG_HAL_BOARD != HAL_BOARD_ESP32
+#if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
 extern "C" {
     int clock_gettime(clockid_t clockid, struct timespec *ts);
 }
@@ -1784,6 +1784,6 @@ int clock_gettime(clockid_t clockid, struct timespec *ts)
     ts->tv_nsec = (utc_usec % 1000000ULL) * 1000UL;
     return 0;
 }
-#endif // CONFIG_HAL_BOARD != HAL_BOARD_SITL && CONFIG_HAL_BOARD != HAL_BOARD_ESP32
+#endif // CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
 
 #endif // AP_DDS_ENABLED


### PR DESCRIPTION
This fixes a stack overflow on a Raspberry Pi (or any other HAL_Linux) when compiled with `--enable_dds`.

Without this change, the stack fills with recursive calls to `clock_gettime` and `micros64`:

~~~
... etc.
AP_HAL::micros64 system.cpp:69
clock_gettime AP_DDS_Client.cpp:1782
AP_HAL::micros64 system.cpp:69
clock_gettime AP_DDS_Client.cpp:1782
AP_HAL::init system.cpp:28
AP_HAL::HAL::HAL HAL.h:99
HAL_Linux::HAL_Linux HAL_Linux_Class.cpp:299
static_initialization_and_destruction_0 HAL_Linux_Class.cpp:539
_GLOBALsub_I__ZN9HAL_LinuxC2Ev HAL_Linux_Class.cpp:554
~~~

Proposed change is thanks to @peterbarker 

Flipping the compile guard from negative to positive means that all HAL_BOARDs except SITL, ESP32 and CHIBIOS will see a change.

I tested this with ArduSub built with `--enable_dds` running on a Raspberry Pi 4.

This passes CI, but I wonder how many tests are running with `--enable_dds`? Anything else I should check? @Ryanf55 

Thanks.