### PR TITLE
Correct use of AIRSPEED flags 

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -4380,7 +4380,10 @@ class TestSuite(ABC):
                         shift_value += 1
                         value_copy = value_copy >> 1
                     value_string = f"{value_string} {'|'.join(value_strings)}"
-                else:
+                elif enum_name != 'AIRSPEED_SENSOR_FLAGS':
+                    # once the ".bitmask" attribute on enumerations
+                    # becomes uniquitous the check the
+                    # AIRSPEED_SENSOR_FLAGS can be removed.
                     if value not in enum:
                         raise ValueError(f"Expected value {value} not in enum {enum}")
                     if got not in enum:

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2401,14 +2401,14 @@ void GCS_MAVLINK::send_airspeed()
         uint8_t flags = 0;
         // Set unhealthy flag
         if (!airspeed->healthy(index)) {
-            flags |= 1U << AIRSPEED_SENSOR_FLAGS::AIRSPEED_SENSOR_UNHEALTHY;
+            flags |= AIRSPEED_SENSOR_FLAGS::AIRSPEED_SENSOR_UNHEALTHY;
         }
 
 #if AP_AHRS_ENABLED
         // Set using flag if the AHRS is using this sensor
         const AP_AHRS &ahrs = AP::ahrs();
         if (ahrs.using_airspeed_sensor() && (ahrs.get_active_airspeed_index() == index)) {
-            flags |= 1U << AIRSPEED_SENSOR_FLAGS::AIRSPEED_SENSOR_USING;
+            flags |= AIRSPEED_SENSOR_FLAGS::AIRSPEED_SENSOR_USING;
         }
 #endif
 


### PR DESCRIPTION
 - updates mavlink to reference commit with corrected flags (shifted values not bit offsets)
 - add airspeed tests
 - random patch to use bitmask attribute on enumerations for sanity checks
 - 