### PR TITLE
Par/airbound b trans

### DIFF
--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -866,7 +866,8 @@ void Tailsitter_Transition::update()
     }
 
     case TRANSITION_ANGLE_WAIT_VTOL:
-        // nothing to do, this is handled in the fixed wing attitude controller
+        // We are here by accident.
+        restart();
         break;
 
     case TRANSITION_DONE:


### PR DESCRIPTION
## Summary

This PR addresses the following case of a tailsitter:
1. Fly in FBWA.
2. Transition into QLOITER.
3. Before the transition completes, switch back into FBWA.
4. Later, transition into QLOITER.

At this point, the aircraft will not pitch up, will immediately transition and fly in VTOL at a very high speed sideways.

## Details

**Before**:
Due to what I think is a hole in our transition logic, when we abort a VTOL transition, the state is never correctly reset to `ANGLE_WAIT_FW`. Its last logged value is `ANGLE_WAIT_VTOL`.
Then, the next time a VTOL transition is started, the state gets stuck at `ANGLE_WAIT_FW`. This breaks the transition logic.

The aircraft is immediately transitioned in VTOL controls, but the state is wrong. And it does not pitch up before that.

![fail](https://github.com/user-attachments/assets/f1b4bef7-0e1e-43fd-94c1-0da8ed22c03a)

**After**:

This change intends to force-reset the transition state when flying in FW but the state is `WAIT_VTOL`. As far as I understand, this isn't a valid state anyways.
This will correctly set the transition to FW as `DONE=2`. Then the state machine gets kicked to work correctly.

![Screenshot from 2025-04-02 14-13-46](https://github.com/user-attachments/assets/9f9ade1b-8cbb-4e53-bbdb-17b746a32785)

This issue is not present when flying manual FW modes (manual, acro, training).

## Tests

SITL testing was done.
Before: https://www.dropbox.com/scl/fi/bz08yk4gst5m9oxtewu8n/11411_fail.bin?rlkey=3auyrowmsjktm783g0nlxfqzj&dl=0
After: https://www.dropbox.com/scl/fi/ggv3xj8lqq6ta2vazyyw2/11413_pass.bin?rlkey=kp5hzhymtf2p2i9grmeq3z5sy&dl=0

## Known issues

I'm not even willing to admit how many hours it took me to write that one line of code.
It goes to show that I have very little understanding of the tailsitter transition state machine.