### PR TITLE
Tools: flake8 fixes for global keyword

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -6192,7 +6192,6 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         }, epsilon=10)
 
         def check_altitude(mav, m):
-            global initial_airspeed_threshold_reached
             m_type = m.get_type()
             if m_type != 'GLOBAL_POSITION_INT':
                 return

--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -235,7 +235,6 @@ def test_prerequisites():
 
 def alarm_handler(signum, frame):
     """Handle test timeout."""
-    global results, opts, tester
     try:
         print("Alarm handler called")
         if tester is not None:
@@ -659,7 +658,6 @@ def write_webresults(results_to_write):
 
 def write_fullresults():
     """Write out full results set."""
-    global results
     results.addglob("Google Earth track", '*.kmz')
     results.addfile('Full Logs', 'autotest-output.txt')
     results.addglob('DataFlash Log', '*-log.bin')
@@ -699,7 +697,6 @@ def write_fullresults():
 
 def run_tests(steps):
     """Run a list of steps."""
-    global results
 
     corefiles = glob.glob("core*")
     corefiles.extend(glob.glob("ap-*.core"))
@@ -753,7 +750,6 @@ def run_tests(steps):
                         '<span class="failed-text">FAILED</span>',
                         time.time() - t1)
 
-        global tester
         if tester is not None and tester.rc_thread is not None:
             if passed:
                 print("BAD: RC Thread still alive after run_step")

--- a/Tools/autotest/pysim/util.py
+++ b/Tools/autotest/pysim/util.py
@@ -280,13 +280,11 @@ close_list = []
 
 def pexpect_autoclose(p):
     """Mark for autoclosing."""
-    global close_list
     close_list.append(p)
 
 
 def pexpect_close(p):
     """Close a pexpect child."""
-    global close_list
 
     ex = None
     if p is None:
@@ -318,7 +316,6 @@ def pexpect_close(p):
 
 def pexpect_close_all():
     """Close all pexpect children."""
-    global close_list
     for p in close_list[:]:
         pexpect_close(p)
 
@@ -353,7 +350,6 @@ def kill_screen_gdb():
 
 
 def kill_mac_terminal():
-    global windowID
     for window in windowID:
         cmd = ("osascript -e \'tell application \"Terminal\" to close "
                "(window(get index of window id %s))\'" % window)
@@ -546,7 +542,6 @@ def start_SITL(binary,
     pexpect_logfile = PSpawnStdPrettyPrinter(prefix=pexpect_logfile_prefix)
 
     if (gdb or lldb) and sys.platform == "darwin" and os.getenv('DISPLAY'):
-        global windowID
         # on MacOS record the window IDs so we can close them later
         atexit.register(kill_mac_terminal)
         child = None
@@ -640,7 +635,6 @@ def start_MAVProxy_SITL(atype,
     if old is not None:
         env['PYTHONPATH'] += os.path.pathsep + old
 
-    global close_list
     cmd = []
     cmd.append(mavproxy_cmd())
     cmd.extend(['--master', master])
@@ -665,7 +659,6 @@ def start_MAVProxy_SITL(atype,
 def start_PPP_daemon(ips, sockaddr):
     """Start pppd for networking"""
 
-    global close_list
     cmd = "sudo pppd socket %s debug noauth nodetach %s" % (sockaddr, ips)
     cmd = cmd.split()
     print("Running: %s" % cmd_as_shell(cmd))

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6146,7 +6146,6 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
         def heartbeat_on_mav2(mav, m):
             '''send a heartbeat on mav2 whenever we get one on mav'''
-            global mav2
             if mav == mav2:
                 return
             if m.get_type() == 'HEARTBEAT':
@@ -6192,7 +6191,6 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 break
 
         def printmessage(mav, m):
-            global mav2
             if mav == mav2:
                 return
 

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -608,7 +608,6 @@ def run_cmd_blocking(what, cmd, quiet=False, check=False, **kw):
 def run_in_terminal_window(name, cmd, **kw):
 
     """Execute the run_in_terminal_window.sh command for cmd"""
-    global windowID
     runme = [os.path.join(autotest_dir, "run_in_terminal_window.sh"), name]
     runme.extend(cmd)
     progress_cmd("Run " + name, runme)
@@ -908,7 +907,6 @@ def start_mavproxy(opts, stuff):
 
     if opts.tracker:
         cmd.extend(["--load-module", "tracker"])
-        global tracker_serial0
         # tracker_serial0 is set when we start the tracker...
         extra_cmd += ("module load map;"
                       "tracker set port %s; "

--- a/Tools/scripts/sitl-on-hardware/sitl-on-hw.py
+++ b/Tools/scripts/sitl-on-hardware/sitl-on-hw.py
@@ -55,7 +55,6 @@ def run_program(cmd_list):
     retcode = subprocess.call(cmd_list)
     if retcode != 0:
         print("FAILED: %s" % (' '.join(cmd_list)))
-        global extra_hwdef
         if extra_hwdef is not None:
             extra_hwdef.close()
             os.unlink(extra_hwdef.name)


### PR DESCRIPTION
flake8 became more strict

eg.

Tools/autotest/sim_vehicle.py:911:9: F824 `global tracker_serial0` is unused: name is never assigned in scope
        global tracker_serial0