### PR TITLE
AP_InertialSensor: Fix temperature conversion for SCHA63T

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_SCHA63T.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SCHA63T.cpp
@@ -381,7 +381,7 @@ void AP_InertialSensor_SCHA63T::read_gyro()
         return;
     }
     due_temp = combine(rsp_due_temper[1], rsp_due_temper[2]);
-    set_temperature(gyro_instance, (uno_temp + due_temp) * 0.5);
+    set_temperature(gyro_instance, (int16_t)((uno_temp + due_temp) * 0.5f));
 
     // change coordinate system from left hand too right hand
     gyro_z = (gyro_z == INT16_MIN) ? INT16_MAX : -gyro_z;
@@ -399,9 +399,9 @@ void AP_InertialSensor_SCHA63T::read_gyro()
     }
 }
 
-void AP_InertialSensor_SCHA63T::set_temperature(uint8_t instance, uint16_t temper)
+void AP_InertialSensor_SCHA63T::set_temperature(uint8_t instance, int16_t temper)
 {
-    const float temperature = 25.0f + ( temper / 30 );
+    const float temperature = 25.0f + ((float)temper / 30.0f);
     const float temp_degc = (0.5f * temperature) + 23.0f;
     _publish_temperature(instance, temp_degc);
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SCHA63T.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SCHA63T.h
@@ -78,7 +78,7 @@ private:
 
     bool read_register(uint8_t tp, reg_scha63t reg, uint8_t* val);
     bool write_register(uint8_t tp, reg_scha63t reg, uint16_t val);
-    void set_temperature(uint8_t instance, uint16_t temper);
+    void set_temperature(uint8_t instance, int16_t temper);
     bool check_startup();
 
     AP_HAL::OwnPtr<AP_HAL::Device> dev_uno;


### PR DESCRIPTION
This change fixes the temperature conversion issue in the SCHA63T driver.
Previously, the temperature value was calculated using an unsigned data type.
However, since a sensor output of 0 corresponds to 35.5°C, values below that should yield a negative sensor output.
As a result, the temperature values were interpreted as large positive numbers (e.g., 1127.5°C).
Changing the data type from uint16_t to int16_t now correctly processes these negative sensor outputs.

Before
![image](https://github.com/user-attachments/assets/97e3554b-df5d-4f2f-a951-3e9d18b96764)

After
![image](https://github.com/user-attachments/assets/10f63b5c-efcc-45c3-bd76-b741d2ce4d6f)
