### PR TITLE
AP_BattMonitor: dynamic node ID update on hot-swap for telemetry

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_DroneCAN.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_DroneCAN.cpp
@@ -74,8 +74,16 @@ AP_BattMonitor_DroneCAN* AP_BattMonitor_DroneCAN::get_dronecan_backend(AP_DroneC
             continue;
         }
         AP_BattMonitor_DroneCAN* driver = (AP_BattMonitor_DroneCAN*)batt.drivers[i];
-        if (driver->_ap_dronecan == ap_dronecan && driver->_node_id == node_id && match_battery_id(i, battery_id)) {
-            return driver;
+        if (driver->_ap_dronecan == ap_dronecan && match_battery_id(i, battery_id)) {
+            if (driver->_node_id == node_id) {
+                return driver;
+            } else if (driver->_node_id != node_id && !driver->_interim_state.healthy) {
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Battery %u: Node change from %d to %d for Id %d",
+                    (unsigned)i+1, driver->_node_id, node_id, battery_id);
+                driver->_node_id = node_id;
+                driver->init();
+                return driver;
+            }
         }
     }
     // find empty uavcan driver


### PR DESCRIPTION
This change fixes an issue where telemetry was lost when a battery with a different node ID was connected during a hot-swap.

With this update, swapping in a battery that has the same battery ID will correctly resume telemetry. The system now only accepts a battery with a different node ID if the current battery is no longer healthy.

For example, consider a vehicle initially equipped with Battery A (battery.id = 1) and Battery B (battery.id = 2). If Battery B is removed and correctly replaced with Battery D (battery.id = 2), telemetry will resume normally. However, if Battery B is mistakenly replaced with Battery C (battery.id = 1), telemetry from Battery A will continue while Battery C is ignored.

This ensures that an active battery’s mapping is preserved and telemetry resumes correctly after a hot-swap.