### PR TITLE
Fix FW transition throttle glitch for tilting rotor quadplanes

### DIFF
--- a/ArduPlane/tiltrotor.h
+++ b/ArduPlane/tiltrotor.h
@@ -70,6 +70,9 @@ public:
     // always return true if not enabled or not a continuous type
     bool tilt_angle_achieved() const { return !enabled() || (type != TILT_TYPE_CONTINUOUS) || angle_achieved; }
 
+    // throttle of tilting motors used for forward flight
+    bool get_forward_throttle(float &throttle) const;
+
     // Write tiltrotor specific log
     void write_log();
 

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -830,6 +830,17 @@ bool AP_MotorsMulticopter::arming_checks(size_t buflen, char *buffer) const
     return true;
 }
 
+// return raw throttle out fraction for motor motor_num, returns true if value is valid, false otherwise
+bool AP_MotorsMulticopter::get_raw_motor_throttle(uint8_t motor_num, float& thr_out) const
+{
+    if (motor_num >= AP_MOTORS_MAX_NUM_MOTORS || !motor_enabled[motor_num]) {
+        return false;
+    }
+
+    thr_out = constrain_float(_actuator[motor_num], 0.0f, 1.0f);
+    return true;
+}
+
 #if APM_BUILD_TYPE(APM_BUILD_UNKNOWN)
 // Getters for AP_Motors example, not used by vehicles
 float AP_MotorsMulticopter::get_throttle_avg_max() const

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -92,6 +92,8 @@ public:
     // return thrust for motor motor_num, returns true if value is valid false otherwise
     bool                get_thrust(uint8_t motor_num, float& thr_out) const override;
 
+    bool                get_raw_motor_throttle(uint8_t motor_num, float& thr_out) const override;
+
 #if HAL_LOGGING_ENABLED
     // 10hz logging of voltage scaling and max trust
     void                Log_Write() override;

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -200,6 +200,7 @@ public:
     float               get_yaw_ff() const { return _yaw_in_ff; }
     float               get_throttle_out() const { return _throttle_out; }
     virtual bool        get_thrust(uint8_t motor_num, float& thr_out) const { return false; }
+    virtual bool        get_raw_motor_throttle(uint8_t motor_num, float& thr_out) const { return false; }
     float               get_throttle() const { return constrain_float(_throttle_filter.get(), 0.0f, 1.0f); }
     float               get_throttle_bidirectional() const { return constrain_float(2 * (_throttle_filter.get() - 0.5f), -1.0f, 1.0f); }
     float               get_throttle_slew_rate() const { return _throttle_slew_rate; }

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -264,7 +264,15 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("PTCH_FF_K", 30, AP_TECS, _pitch_ff_k, 0.0),
 
-    // 31 previously used by TECS_LAND_PTRIM
+    // 31 previously used by AP_Int8 TECS_LAND_PTRIM which was removed in November 2022
+
+    // @Param: THR_ERATE
+    // @DisplayName: Forward throttle external limit slew rate
+    // @Description: The externally set forward throttle lower limit applied within TECS will be reduced by this many percentage points per second after being set. Set to a non positive value to hold the lower limit for one frame only.
+    // @Units: %/s
+    // @Range: 0 100
+    // @User: Advanced
+    AP_GROUPINFO("THR_ERATE", 31, AP_TECS, _thr_min_pct_ext_rate_lim, 20),
 
     // @Param: FLARE_HGT
     // @DisplayName: Flare holdoff height
@@ -1378,11 +1386,16 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
 }
 
 // set minimum throttle override, [-1, -1] range
-// it is applicable for one control cycle only
-void AP_TECS::set_throttle_min(const float thr_min) {
+// if reset_output is true the output slew limiter will also be reset to respect the lower limit
+// its decay is controlled by TECS_THR_ERATE
+void AP_TECS::set_throttle_min(const float thr_min, bool reset_output) {
     // Don't change the limit if it is already covered.
     if (thr_min > _THRminf_ext) {
         _THRminf_ext = thr_min;
+        if (reset_output) {
+            _last_throttle_dem = MAX(_last_throttle_dem, _THRminf_ext);
+            _throttle_dem = _last_throttle_dem;
+        }
     }
 }
 
@@ -1417,7 +1430,12 @@ void AP_TECS::_update_throttle_limits() {
     
     // Reset the external throttle limits.
     // Caller will have to reset them in the next iteration.
-    _THRminf_ext = -1.0f;
+    if (_thr_min_pct_ext_rate_lim > 0) {
+        _THRminf_ext -= 0.01f * float(_thr_min_pct_ext_rate_lim) * _DT;
+        _THRminf_ext = MAX(_THRminf_ext, -1.0f);
+    } else {
+        _THRminf_ext = -1.0f;
+    }
     _THRmaxf_ext = 1.0f;
 }
 

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -129,8 +129,9 @@ public:
     }
 
     // set minimum throttle override, [-1, -1] range
-    // it is applicable for one control cycle only
-    void set_throttle_min(const float thr_min);
+    // if reset_output is true the output slew limiter will also be reset to respect the lower limit
+    // its decay is controlled by TECS_THR_ERATE
+    void set_throttle_min(const float thr_min, bool reset_output = false);
 
     // set maximum throttle override, [0, -1] range
     // it is applicable for one control cycle only
@@ -218,6 +219,7 @@ private:
     AP_Float _pitch_ff_v0;
     AP_Float _pitch_ff_k;
     AP_Float _accel_gf;
+    AP_Int8 _thr_min_pct_ext_rate_lim;
 
     // current height estimate (above field elevation)
     float _height;

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -424,6 +424,9 @@ public:
     // limit slew rate to given limit in percent per second
     static void set_slew_rate(SRV_Channel::Function function, float slew_rate, uint16_t range, float dt);
 
+    // update channels last_scaled_output to match value
+    static void set_slew_last_scaled_output(SRV_Channel::Function function, float value);
+
     // call output_ch() on all channels
     static void output_ch_all(void);
 

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -822,6 +822,18 @@ void SRV_Channels::set_slew_rate(SRV_Channel::Function function, float slew_rate
     _slew = new_slew;
 }
 
+// update channels last_scaled_output to match value
+void SRV_Channels::set_slew_last_scaled_output(SRV_Channel::Function function, float value)
+{
+    for (slew_list *slew = _slew; slew; slew = slew->next) {
+        if (slew->func == function) {
+            // found existing item, update slew limiter value
+            slew->last_scaled_output = value;
+            return;
+        }
+    }
+}
+
 // call set_angle() on matching channels
 void SRV_Channels::set_angle(SRV_Channel::Function function, uint16_t angle)
 {


### PR DESCRIPTION
This is a fix for the instant forward motor(s) throttle drop that can occur when a quadplane with tilting rotors completes the transition from VTOL to FW flight. This issue was reported here https://github.com/ArduPilot/ardupilot/issues/28957

This fix:

Extends the functionality of the set_throttle_min function such that the rate that the lower limit releases can be controlled by a TECS_THR_ERATE parameter and the throttle out previous value used by the TECS throttle rate limiter can also be optionally reset. If TECS_THR_ERATE is <=0 the legacy behaviour will be observed, ie the minimum throttle will be held for one TECS frame after the function is called.

Adds a function to the motors library that enables the raw normalised throttle demand to be obtained for a specified motor index.

Adds a function to the SRV_Channels library that enables the slew rate limiter state to be set for a specified channel function. 

Adds a function to the tiltrotor class that provides the mean throttle of all tilting motors.

When the transition into FW flight is ready to complete it checks for a throttle demand from tilting rotors or if not available the forward motor throttle demand. The TECS minimum throttle and SRV_Channels forward throttle are both set to this value.

Testing on a multirotor  VTOL with forrward tilting motors shows that the TECS throttle lower limit is set and releases at the specified 0.2 rate.

<img width="1040" alt="Screenshot 2025-04-04 at 9 58 10 PM" src="https://github.com/user-attachments/assets/577242e4-a1ad-497a-8223-caa61236b1e5" />

<img width="1040" alt="Screenshot 2025-04-04 at 9 57 40 PM" src="https://github.com/user-attachments/assets/c2ec7a1a-c221-4f33-a5b0-01ccdb2f1708" />

<img width="1044" alt="Screenshot 2025-04-04 at 9 57 00 PM" src="https://github.com/user-attachments/assets/16c76817-4f35-4a7e-9afa-a6af7c1922c5" />

Here's a before and after for a SITL test using the -v Plane -f quadplane-tilthvec option

Before - the throttles of the tilting motors step to 0 before increasing
<img width="1057" alt="Screenshot 2025-04-07 at 8 06 41 AM" src="https://github.com/user-attachments/assets/beff4e09-856e-4f86-be7a-74006f536f19" />


After - the throttles of the tilting motors ramp down smoothly
<img width="1051" alt="Screenshot 2025-04-07 at 8 04 35 AM" src="https://github.com/user-attachments/assets/e8003727-a244-44bd-a202-c37abefd0a89" />

