### PR TITLE
AP_Periph: BatteryMonitor: report state of health

### DIFF
--- a/Tools/AP_Periph/battery.cpp
+++ b/Tools/AP_Periph/battery.cpp
@@ -54,7 +54,13 @@ void AP_Periph_FW::can_battery_update(void)
             pkt.temperature = C_TO_KELVIN(temperature);
         }
 
+        // Populate state of health
         pkt.state_of_health_pct = UAVCAN_EQUIPMENT_POWER_BATTERYINFO_STATE_OF_HEALTH_UNKNOWN;
+        uint8_t state_of_health_pct = 0;
+        if (battery_lib.get_state_of_health_pct(i, state_of_health_pct)) {
+            pkt.state_of_health_pct = state_of_health_pct;
+        }
+
         uint8_t percentage = 0;
         if (battery_lib.capacity_remaining_pct(percentage, i)) {
             pkt.state_of_charge_pct = percentage;


### PR DESCRIPTION
Does what it says on the tin. The DroneCAN message and the battery lib both support state of health we just need to fill it in.