### PR TITLE
AP_Scripting: BatteryMonitor: allow setting state of health

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
@@ -133,6 +133,7 @@ struct BattMonitorScript_State {
     bool healthy; // True if communicating properly
     uint8_t cell_count; // Number of valid cells in state
     uint8_t capacity_remaining_pct=UINT8_MAX; // Remaining battery capacity in percent, 255 for invalid
+    uint8_t state_of_health_pct=UINT8_MAX; // Remaining battery health in percent, 255 for invalid
     uint16_t cell_voltages[32]; // allow script to have up to 32 cells, will be limited internally
     uint16_t cycle_count=UINT16_MAX; // Battery cycle count, 65535 for unavailable
     /*

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Scripting.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Scripting.cpp
@@ -63,6 +63,12 @@ void AP_BattMonitor_Scripting::read()
         _state.temperature = internal_state.temperature;
     }
 
+    // Set state of health if provided
+    _state.has_state_of_health_pct = internal_state.state_of_health_pct != UINT8_MAX;
+    if (_state.has_state_of_health_pct) {
+        _state.state_of_health_pct = internal_state.state_of_health_pct;
+    }
+
     _state.healthy = internal_state.healthy;
 
     // Update the timestamp (has to be done after the consumed_mah calculation)

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -3477,6 +3477,10 @@ function BattMonitorScript_State_ud:voltage(value) end
 ---@param value boolean
 function BattMonitorScript_State_ud:healthy(value) end
 
+-- set state of health, 255 if not available (this is the defualt)
+---@param value integer
+function BattMonitorScript_State_ud:state_of_health_pct(value) end
+
 -- The temperature library provides access to information about the currently connected temperature sensors on the vehicle.
 temperature_sensor = {}
 

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -91,6 +91,7 @@ userdata BattMonitorScript_State field current_amps float'skip_check write
 userdata BattMonitorScript_State field consumed_mah float'skip_check write
 userdata BattMonitorScript_State field consumed_wh float'skip_check write
 userdata BattMonitorScript_State field temperature float'skip_check write
+userdata BattMonitorScript_State field state_of_health_pct uint8_t'skip_check write
 
 singleton AP_BattMonitor rename battery
 singleton AP_BattMonitor depends AP_BATTERY_ENABLED


### PR DESCRIPTION
Allows a script to set state of health for a scripting battery monitor.