### PR TITLE
AP_Math: split `radians` into float and double variants

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -889,7 +889,7 @@ void Copter::update_super_simple_bearing(bool force_update)
     }
 
     super_simple_last_bearing = bearing;
-    const float angle_rad = radians((super_simple_last_bearing+18000)/100);
+    const float angle_rad = radians((super_simple_last_bearing+18000)*0.01f);
     super_simple_cos_yaw = cosf(angle_rad);
     super_simple_sin_yaw = sinf(angle_rad);
 }

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -212,7 +212,17 @@ inline double constrain_double(const double amt, const double low, const double 
 }
 
 // degrees -> radians
-static inline constexpr ftype radians(ftype deg)
+static inline constexpr double radians(double deg)
+{
+    return deg * DEG_TO_RAD;
+}
+
+static inline constexpr float radians(float deg)
+{
+    return deg * DEG_TO_RAD;
+}
+
+static inline constexpr float radians(int deg)
 {
     return deg * DEG_TO_RAD;
 }


### PR DESCRIPTION
Most `radians` uses give a float argument and use a float return type. On `HAL_WITH_EKF_DOUBLE` boards this results in a bunch of unnecessary conversions. Create separate double and float variants of the function to eliminate the impact. The `DEG_TO_RAD` constant is already a float, therefore there is no loss of precision in the operation.

We also need a variant that takes an `int` argument as these are supplied in several places, primarily as constants, and the `int` conversion is otherwise ambiguous.

Saves a few hundred bytes of flash on such boards.

Prerequisite for candidate fix of #29660 .