### PR TITLE
Added Linux Mint translations for Ubuntu Jammy and Noble

### DIFF
--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -62,10 +62,10 @@ RELEASE_CODENAME=$(lsb_release -c -s)
 
 # translate Mint-codenames to Ubuntu-codenames based on https://www.linuxmint.com/download_all.php
 case ${RELEASE_CODENAME} in
-    wilma)
+    wilma | xia)
         RELEASE_CODENAME='noble'
         ;;
-    vanessa)
+    vanessa | vera | victoria | virginia)
         RELEASE_CODENAME='jammy'
         ;;
     una | uma | ulyssa | ulyana | jolnir)


### PR DESCRIPTION
As of checking Linux Mint's releases page, there were the following versions of Linux Mint missing translations, which I've appended onto the install script:

| Linux Mint      | Ubuntu        |
|-----------------|---------------|
| Xia (22.1)      | Noble (24.XX) |
| Vera (21.1)     | Jammy (22.XX) |
| Victoria (21.2) | Jammy (22.XX) |
| Virginia (21.3) | Jammy (22.XX) |

For context, I was on Linux Mint Xia, and not having this translation causes the script to assume the release codename of "bullseye", which yields the error "Unable to locate package python-argparse".

As a side-note, I think it would help to add some insight as to why it should default to that specific Debian release instead of fast-failing outright. I understand that there are many flavors of Linux out there but at least a warning or a way to specify a custom release codename would help with installation problems like above.