### PR TITLE
AP_Param: fix unexpected truncation of AP_Float parameters in expressions

### DIFF
--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -381,7 +381,7 @@ void Plane::check_long_failsafe()
             failsafe_long_on_event(FAILSAFE_GCS, ModeReason::GCS_FAILSAFE);
         }
     } else {
-        uint32_t timeout_seconds = g.fs_timeout_long;
+        float timeout_seconds = g.fs_timeout_long;
         if (g.fs_action_short != FS_ACTION_SHORT_DISABLED) {
             // avoid dropping back into short timeout
             timeout_seconds = g.fs_timeout_short;

--- a/libraries/AP_DAL/examples/AP_DAL_Standalone/main.cpp
+++ b/libraries/AP_DAL/examples/AP_DAL_Standalone/main.cpp
@@ -11,8 +11,8 @@
 void AP_Param::setup_object_defaults(void const*, AP_Param::GroupInfo const*) {}
 
 template<typename T, ap_var_type PT>
-void AP_ParamT<T, PT>::set_and_default(const T &v) {}
-template class AP_ParamT<int8_t, AP_PARAM_INT8>;
+void AP_ParamTBase<T, PT>::set_and_default(const T &v) {}
+template class AP_ParamTBase<int8_t, AP_PARAM_INT8>;
 
 
 int AP_HAL::Util::vsnprintf(char*, size_t, char const*, va_list) { return -1; }

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -839,7 +839,7 @@ void NavEKF2_core::readRngBcnData()
 
             // set the range noise
             // TODO the range library should provide the noise/accuracy estimate for each beacon
-            rngBcnDataNew.rngErr = frontend->_rngBcnNoise;
+            rngBcnDataNew.rngErr = frontend->_rngBcnNoise.get();
 
             // set the range measurement
             rngBcnDataNew.rng = beacon->beacon_distance(index);

--- a/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
@@ -114,7 +114,7 @@ void NavEKF2_core::EstimateTerrainOffset()
             ftype q3 = stateStruct.quat[3]; // quaternion at optical flow measurement time
 
             // Set range finder measurement noise variance. TODO make this a function of range and tilt to allow for sensor, alignment and AHRS errors
-            ftype R_RNG = frontend->_rngNoise;
+            ftype R_RNG = frontend->_rngNoise.get();
 
             // calculate Kalman gain
             ftype SK_RNG = sq(q0) - sq(q1) - sq(q2) + sq(q3);

--- a/libraries/AP_NavEKF3/AP_NavEKF3_AirDataFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_AirDataFusion.cpp
@@ -475,8 +475,8 @@ void NavEKF3_core::FuseSideslip()
 void NavEKF3_core::FuseDragForces()
 {
     // drag model parameters
-    const ftype bcoef_x = frontend->_ballisticCoef_x;
-    const ftype bcoef_y = frontend->_ballisticCoef_y;
+    const ftype bcoef_x = frontend->_ballisticCoef_x.get();
+    const ftype bcoef_y = frontend->_ballisticCoef_y.get();
     const ftype mcoef = frontend->_momentumDragCoef.get();
     const bool using_bcoef_x = bcoef_x > 1.0f;
     const bool using_bcoef_y = bcoef_y > 1.0f;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -943,7 +943,7 @@ void NavEKF3_core::readRngBcnData()
 
             // set the range noise
             // TODO the range library should provide the noise/accuracy estimate for each beacon
-            rngBcnDataNew.rngErr = frontend->_rngBcnNoise;
+            rngBcnDataNew.rngErr = frontend->_rngBcnNoise.get();
 
             // set the range measurement
             rngBcnDataNew.rng = beacon->beacon_distance(index);
@@ -1443,8 +1443,8 @@ void NavEKF3_core::SampleDragData(const imu_elements &imu)
 {
 #if EK3_FEATURE_DRAG_FUSION
     // Average and down sample to 5Hz
-    const ftype bcoef_x = frontend->_ballisticCoef_x;
-    const ftype bcoef_y = frontend->_ballisticCoef_y;
+    const ftype bcoef_x = frontend->_ballisticCoef_x.get();
+    const ftype bcoef_y = frontend->_ballisticCoef_y.get();
     const ftype mcoef = frontend->_momentumDragCoef.get();
     const bool using_bcoef_x = bcoef_x > 1.0f;
     const bool using_bcoef_y = bcoef_y > 1.0f;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -121,7 +121,7 @@ void NavEKF3_core::EstimateTerrainOffset(const of_elements &ofDataDelayed)
             ftype q3 = stateStruct.quat[3]; // quaternion at optical flow measurement time
 
             // Set range finder measurement noise variance. TODO make this a function of range and tilt to allow for sensor, alignment and AHRS errors
-            ftype R_RNG = frontend->_rngNoise;
+            ftype R_RNG = frontend->_rngNoise.get();
 
             // calculate Kalman gain
             ftype SK_RNG = sq(q0) - sq(q1) - sq(q2) + sq(q3);

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -539,7 +539,7 @@ void NavEKF3_core::SelectVelPosFusion()
     if (gpsDataToFuse) {
         CorrectGPSForAntennaOffset(gpsDataDelayed);
         // calculate innovations and variances for reporting purposes only
-        CalculateVelInnovationsAndVariances(gpsDataDelayed.vel, frontend->_gpsHorizVelNoise, frontend->gpsNEVelVarAccScale, gpsVelInnov, gpsVelVarInnov);
+        CalculateVelInnovationsAndVariances(gpsDataDelayed.vel, frontend->_gpsHorizVelNoise.get(), frontend->gpsNEVelVarAccScale, gpsVelInnov, gpsVelVarInnov);
         // record time GPS data was retrieved from the buffer (for timeout checks)
         gpsRetrieveTime_ms = dal.millis();
     }
@@ -2092,7 +2092,7 @@ void NavEKF3_core::SelectBodyOdomFusion()
             // TODO write a dedicated observation model for wheel encoders
             bodyOdmDataDelayed.vel = prevTnb * velNED;
             bodyOdmDataDelayed.body_offset = wheelOdmDataDelayed.hub_offset;
-            bodyOdmDataDelayed.velErr = frontend->_wencOdmVelErr;
+            bodyOdmDataDelayed.velErr = frontend->_wencOdmVelErr.get();
 
             // Fuse data into the main filter
             FuseBodyVel();

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -880,14 +880,14 @@ namespace AP {
 
 /// Template class for scalar variables.
 ///
-/// Objects of this type have a value, and can be treated in many ways as though they
-/// were the value.
+/// Objects of this type have a value, though the infrastructure to actually
+/// treat them as a value is delegated to a type-specialized subclass.
 ///
 /// @tparam T			The scalar type of the variable
 /// @tparam PT			The AP_PARAM_* type
 ///
 template<typename T, ap_var_type PT>
-class AP_ParamT : public AP_Param
+class AP_ParamTBase : public AP_Param
 {
 public:
     static const ap_var_type        vtype = PT;
@@ -930,15 +930,7 @@ public:
     /// updated correctly.
     void set_and_save_ifchanged(const T &v);
 
-    /// Conversion to T returns a reference to the value.
-    ///
-    /// This allows the class to be used in many situations where the value would be legal.
-    ///
-    operator const T &() const {
-        return _value;
-    }
-
-    /// AP_ParamT types can implement AP_Param::cast_to_float
+    /// AP_ParamTBase types can implement AP_Param::cast_to_float
     ///
     float cast_to_float(void) const;
 
@@ -946,11 +938,25 @@ protected:
     T _value;
 };
 
+template<typename T, ap_var_type PT>
+class AP_ParamT : public AP_ParamTBase<T, PT>
+{
+public:
+    /// Conversion to T returns a reference to the value. A reference is
+    /// necessary as some users expect to pass a reference around.
+    ///
+    /// This allows the class to be used in many situations where the value
+    /// would be legal.
+    ///
+    operator const T &() const {
+        return this->_value;
+    }
+};
 
-/// Template class for non-scalar variables.
+/// Template class for non-scalar variables, intended for non-C types.
 ///
-/// Objects of this type have a value, and can be treated in many ways as though they
-/// were the value.
+/// Objects of this type have an object value, and can be treated in many ways
+/// as though they were the value.
 ///
 /// @tparam T			The scalar type of the variable
 /// @tparam PT			AP_PARAM_* type
@@ -990,9 +996,11 @@ public:
     void set_and_save_ifchanged(const T &v);
 
 
-    /// Conversion to T returns a reference to the value.
+    /// Conversion to T returns a reference to the value. A reference is
+    /// necessary as some users expect to pass a reference around.
     ///
-    /// This allows the class to be used in many situations where the value would be legal.
+    /// This allows the class to be used in many situations where the value
+    /// would be legal.
     ///
     operator const T &() const {
         return _value;

--- a/libraries/AP_Param/AP_ParamT.cpp
+++ b/libraries/AP_Param/AP_ParamT.cpp
@@ -20,7 +20,7 @@
 
 // set a parameter that is an ENABLE param
 template<typename T, ap_var_type PT>
-void AP_ParamT<T, PT>::set_enable(const T &v) {
+void AP_ParamTBase<T, PT>::set_enable(const T &v) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfloat-equal"
     if (v != _value) {
@@ -32,7 +32,7 @@ void AP_ParamT<T, PT>::set_enable(const T &v) {
 
 // Sets if the parameter is unconfigured
 template<typename T, ap_var_type PT>
-void AP_ParamT<T, PT>::set_default(const T &v) {
+void AP_ParamTBase<T, PT>::set_default(const T &v) {
 #if AP_PARAM_DEFAULTS_ENABLED
     add_default(this, (float)v);
 #endif
@@ -43,7 +43,7 @@ void AP_ParamT<T, PT>::set_default(const T &v) {
 
 // Sets parameter and default
 template<typename T, ap_var_type PT>
-void AP_ParamT<T, PT>::set_and_default(const T &v) {
+void AP_ParamTBase<T, PT>::set_and_default(const T &v) {
 #if AP_PARAM_DEFAULTS_ENABLED
     add_default(this, (float)v);
 #endif
@@ -52,7 +52,7 @@ void AP_ParamT<T, PT>::set_and_default(const T &v) {
 
 // Value setter - set value, tell GCS
 template<typename T, ap_var_type PT>
-void AP_ParamT<T, PT>::set_and_notify(const T &v) {
+void AP_ParamTBase<T, PT>::set_and_notify(const T &v) {
 // We do want to compare each value, even floats, since it being the same here
 // is the result of previously setting it.
 #pragma GCC diagnostic push
@@ -66,7 +66,7 @@ void AP_ParamT<T, PT>::set_and_notify(const T &v) {
 
 // Combined set and save
 template<typename T, ap_var_type PT>
-void AP_ParamT<T, PT>::set_and_save(const T &v) {
+void AP_ParamTBase<T, PT>::set_and_save(const T &v) {
     bool force = fabsf((float)(_value - v)) < FLT_EPSILON;
     set(v);
     save(force);
@@ -78,7 +78,7 @@ void AP_ParamT<T, PT>::set_and_save(const T &v) {
 // value separately, as otherwise the value in EEPROM won't be
 // updated correctly.
 template<typename T, ap_var_type PT>
-void AP_ParamT<T, PT>::set_and_save_ifchanged(const T &v) {
+void AP_ParamTBase<T, PT>::set_and_save_ifchanged(const T &v) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfloat-equal"
     if (v == _value) {
@@ -89,16 +89,16 @@ void AP_ParamT<T, PT>::set_and_save_ifchanged(const T &v) {
     save(true);
 }
 
-// AP_ParamT types can implement AP_Param::cast_to_float
+// AP_ParamTBase types can implement AP_Param::cast_to_float
 template<typename T, ap_var_type PT>
-float AP_ParamT<T, PT>::cast_to_float(void) const {
+float AP_ParamTBase<T, PT>::cast_to_float(void) const {
     return (float)_value;
 }
 
-template class AP_ParamT<float, AP_PARAM_FLOAT>;
-template class AP_ParamT<int8_t, AP_PARAM_INT8>;
-template class AP_ParamT<int16_t, AP_PARAM_INT16>;
-template class AP_ParamT<int32_t, AP_PARAM_INT32>;
+template class AP_ParamTBase<float, AP_PARAM_FLOAT>;
+template class AP_ParamTBase<int8_t, AP_PARAM_INT8>;
+template class AP_ParamTBase<int16_t, AP_PARAM_INT16>;
+template class AP_ParamTBase<int32_t, AP_PARAM_INT32>;
 
 // Value setter - set value, tell GCS
 template<typename T, ap_var_type PT>

--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
@@ -1329,8 +1329,8 @@ void AP_CRSF_Telem::calc_parameter() {
         AP_Int8* p = (AP_Int8*)setting->_param;
         _telem.ext.param_entry.payload[1] = ParameterType::INT8;
         _telem.ext.param_entry.payload[idx] = p->get();  // value
-        _telem.ext.param_entry.payload[idx+1] = int8_t(setting->_param_min);  // min
-        _telem.ext.param_entry.payload[idx+2] = int8_t(setting->_param_max); // max
+        _telem.ext.param_entry.payload[idx+1] = int8_t(setting->_param_min.get());  // min
+        _telem.ext.param_entry.payload[idx+2] = int8_t(setting->_param_max.get()); // max
         _telem.ext.param_entry.payload[idx+3] = int8_t(0);  // default
         idx += 4;
         break;
@@ -1339,8 +1339,8 @@ void AP_CRSF_Telem::calc_parameter() {
         AP_Int16* p = (AP_Int16*)setting->_param;
         _telem.ext.param_entry.payload[1] = ParameterType::INT16;
         put_be16_ptr(&_telem.ext.param_entry.payload[idx], p->get());  // value
-        put_be16_ptr(&_telem.ext.param_entry.payload[idx+2], setting->_param_min);  // min
-        put_be16_ptr(&_telem.ext.param_entry.payload[idx+4], setting->_param_max); // max
+        put_be16_ptr(&_telem.ext.param_entry.payload[idx+2], setting->_param_min.get());  // min
+        put_be16_ptr(&_telem.ext.param_entry.payload[idx+4], setting->_param_max.get()); // max
         put_be16_ptr(&_telem.ext.param_entry.payload[idx+6], 0);  // default
         idx += 8;
         break;

--- a/libraries/SITL/SIM_ADSB.cpp
+++ b/libraries/SITL/SIM_ADSB.cpp
@@ -53,8 +53,8 @@ void ADSB_Vehicle::update(const class Aircraft &aircraft, float delta_t)
         const Vector2f aircraft_offset_ne = aircraft_location.get_distance_NE(origin);
         position.x = aircraft_offset_ne[1];
         position.y = aircraft_offset_ne[0];
-        position.x += Aircraft::rand_normal(0, _sitl->adsb_radius_m);
-        position.y += Aircraft::rand_normal(0, _sitl->adsb_radius_m);
+        position.x += Aircraft::rand_normal(0, _sitl->adsb_radius_m.get());
+        position.y += Aircraft::rand_normal(0, _sitl->adsb_radius_m.get());
         position.z = -fabsf(_sitl->adsb_altitude_m);
 
         double vel_min = 5, vel_max = 20;


### PR DESCRIPTION
Fixes #29660 for floats at least. An expression like `float v = true ? float_param : 0;` would cause `float_param` to be truncated to an integer to match the other type. Fix by only letting `AP_Float` be converted to a float. It is still possible to get truncation with integer parameter types, e.g. `int16_t v = true ? int16_param : (int8_t)0;` but I don't think it's a problem at this point.

There is a bunch of subtlety and some caveats, please see the commit contents and messages for details. The issue contains a list of areas of the code whose behavior will be changed by this, but problems are exclusive to the ternary operator and overloaded functions, not standard arithmetic operators.

Tested on Cube Orange that the `CAMERA_FOV_STATUS` message now does not truncate the FOV values specified in the corresponding parameters.
