### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/Tools/Replay/CheckLogs.py
+++ b/Tools/Replay/CheckLogs.py
@@ -41,7 +41,7 @@ def get_log_list():
     import glob, sys
     pattern = os.path.join(opts.logdir, "*-checked.bin")
     file_list = glob.glob(pattern)
-    print("Found %u logs to processs" % len(file_list))
+    print("Found %u logs to process" % len(file_list))
     if len(file_list) == 0:
         print("No logs to process matching %s" % pattern)
         sys.exit(1)

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -679,7 +679,7 @@ arducopter and upload it to my board".
         action='store',
         dest='upload_port',
         default=None,
-        help='''Specify the port to be used with the --upload option. For example a port of /dev/ttyS10 indicates that serial port 10 shuld be used.
+        help='''Specify the port to be used with the --upload option. For example a port of /dev/ttyS10 indicates that serial port 10 should be used.
 ''')
 
     g.add_option('--upload-blueos',

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -582,15 +582,15 @@ class Board:
 Board = BoardMeta('Board', Board.__bases__, dict(Board.__dict__))
 
 def add_dynamic_boards_chibios():
-    '''add boards based on existance of hwdef.dat in subdirectories for ChibiOS'''
+    '''add boards based on existence of hwdef.dat in subdirectories for ChibiOS'''
     add_dynamic_boards_from_hwdef_dir(chibios, 'libraries/AP_HAL_ChibiOS/hwdef')
 
 def add_dynamic_boards_linux():
-    '''add boards based on existance of hwdef.dat in subdirectories for '''
+    '''add boards based on existence of hwdef.dat in subdirectories for '''
     add_dynamic_boards_from_hwdef_dir(linux, 'libraries/AP_HAL_Linux/hwdef')
 
 def add_dynamic_boards_from_hwdef_dir(base_type, hwdef_dir):
-    '''add boards based on existance of hwdef.dat in subdirectory'''
+    '''add boards based on existence of hwdef.dat in subdirectory'''
     dirname, dirlist, filenames = next(os.walk(hwdef_dir))
     for d in dirlist:
         if d in _board_classes.keys():
@@ -600,7 +600,7 @@ def add_dynamic_boards_from_hwdef_dir(base_type, hwdef_dir):
             newclass = type(d, (base_type,), {'name': d})
 
 def add_dynamic_boards_esp32():
-    '''add boards based on existance of hwdef.dat in subdirectories for ESP32'''
+    '''add boards based on existence of hwdef.dat in subdirectories for ESP32'''
     dirname, dirlist, filenames = next(os.walk('libraries/AP_HAL_ESP32/hwdef'))
     for d in dirlist:
         if d in _board_classes.keys():
@@ -624,7 +624,7 @@ def is_board_based(board, cls):
     return issubclass(_board_classes[board], cls)
 
 def get_ap_periph_boards():
-    '''Add AP_Periph boards based on existance of periph keywork in hwdef.dat or board name'''
+    '''Add AP_Periph boards based on existence of periph keyword in hwdef.dat or board name'''
     list_ap = [s for s in list(_board_classes.keys()) if "periph" in s]
     dirname, dirlist, filenames = next(os.walk('libraries/AP_HAL_ChibiOS/hwdef'))
     for d in dirlist:

--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -364,7 +364,7 @@ class generate_apj(Task.Task):
             d["brand_name"] = self.env.BRAND_NAME
         if self.env.build_dates:
             # we omit build_time when we don't have build_dates so that apj
-            # file is idential for same git hash and compiler
+            # file is identical for same git hash and compiler
             d["build_time"] = int(time.time())
         apj_file = self.outputs[0].abspath()
         f = open(apj_file, "w")
@@ -753,7 +753,7 @@ def build(bld):
     wraplist = ['sscanf', 'fprintf', 'snprintf', 'vsnprintf', 'vasprintf', 'asprintf', 'vprintf', 'scanf', 'printf']
 
     # list of functions that we will give a link error for if they are
-    # used. This is to prevent accidential use of these functions
+    # used. This is to prevent accidental use of these functions
     blacklist = ['_sbrk', '_sbrk_r', '_malloc_r', '_calloc_r', '_free_r', 'ftell',
                  'fopen', 'fflush', 'fwrite', 'fread', 'fputs', 'fgets',
                  'clearerr', 'fseek', 'ferror', 'fclose', 'tmpfile', 'getc', 'ungetc', 'feof',

--- a/Tools/ardupilotwaf/toolchain.py
+++ b/Tools/ardupilotwaf/toolchain.py
@@ -1,5 +1,5 @@
 """
-WAF Tool to select the correct toolchain based on the target archtecture.
+WAF Tool to select the correct toolchain based on the target architecture.
 
 This tool loads compiler_c and compiler_cxx, so you don't need to load them
 (and you must not load them before this tool). Use the environment variable
@@ -50,7 +50,7 @@ def _clang_cross_support(cfg):
     try:
         cfg.find_program(prefix + 'gcc', var='CROSS_GCC')
     except Errors.ConfigurationError as e:
-        cfg.fatal('toolchain: clang: couldn\'t find cross GCC', ex=e)
+        cfg.fatal("toolchain: clang: couldn't find cross GCC", ex=e)
 
     environ = dict(os.environ)
     if 'TOOLCHAIN_CROSS_AR' in environ:
@@ -63,7 +63,7 @@ def _clang_cross_support(cfg):
             environ=environ,
         )
     except Errors.ConfigurationError as e:
-        cfg.fatal('toolchain: clang: couldn\'t find toolchain path', ex=e)
+        cfg.fatal("toolchain: clang: couldn't find toolchain path", ex=e)
 
     toolchain_path = os.path.join(cfg.env.TOOLCHAIN_CROSS_AR[0], '..', '..')
     toolchain_path = os.path.abspath(toolchain_path)

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -500,7 +500,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.end_subtest("Completed Radio failsafe disabled test")
 
         # Trigger an RC failure, verify radio failsafe triggers,
-        # restore radio, verify RC function by changing modes to cicle
+        # restore radio, verify RC function by changing modes to circle
         # and stabilize.
         self.start_subtest("Radio failsafe recovery test")
         self.set_parameter('FS_THR_ENABLE', 1)
@@ -938,7 +938,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         if self.get_parameter("CC_TYPE") != 2 :
             raise NotAchievedException("Custom controller is not switched to PID backend.")
 
-        # check if we can retrive any param inside PID backend
+        # check if we can retrieve any param inside PID backend
         self.get_parameter("CC2_RAT_YAW_P")
 
         # takeoff in GPS mode and switch to CIRCLE
@@ -1666,7 +1666,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.takeoff(10, mode="LOITER")
         """Hold loiter position."""
 
-        # enable fence, only max altitude, defualt is 100m
+        # enable fence, only max altitude, default is 100m
         # No action, rely on avoidance to prevent the breach
         self.set_parameters({
             "FENCE_ENABLE": 1,
@@ -1694,7 +1694,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             if m_type != 'VFR_HUD':
                 return
             if m.climb < max_descent_rate:
-                raise NotAchievedException("Decending too fast want %f got %f" % (max_descent_rate, m.climb))
+                raise NotAchievedException("Descending too fast want %f got %f" % (max_descent_rate, m.climb))
 
         self.context_push()
         self.install_message_hook_context(get_climb_rate)
@@ -2780,7 +2780,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         # autotune changes a set of parameters on the vehicle which
         # are not in our context.  That changes the flight
-        # characterstics, which we can't afford between runs.  So
+        # characteristics, which we can't afford between runs.  So
         # completely reset the simulated vehicle after the run is
         # complete by "customising" the commandline here:
         self.customise_SITL_commandline([])
@@ -2957,7 +2957,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.reboot_sitl()
 
     def TerrainDBPreArm(self):
-        '''test that pre-arm checks are working corrctly for terrain database'''
+        '''test that pre-arm checks are working correctly for terrain database'''
         self.context_push()
 
         self.progress("# Load msission with terrain alt")
@@ -5018,7 +5018,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.arm_vehicle()
 
-        self.wait_text("Gripper load releas", timeout=90)
+        self.wait_text("Gripper load release", timeout=90)
         dist_limit = 1
         # this is a copy of the point in the mission file:
         target_loc = mavutil.location(-35.363106,
@@ -5373,7 +5373,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         )
 
     def test_mount_rc_targetting(self, pitch_rc_neutral=1500, do_rate_tests=True):
-        '''called in multipleplaces to make sure that mount RC targetting works'''
+        '''called in multipleplaces to make sure that mount RC targeting works'''
         if True:
             self.context_push()
             self.set_parameters({
@@ -5494,7 +5494,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 raise NotAchievedException("Mount stabilising when not requested")
 
             # center RC tilt control and change mount to RC_TARGETING mode
-            self.progress("Gimbal to RC Targetting mode")
+            self.progress("Gimbal to RC Targeting mode")
             self.set_rc(6, pitch_rc_neutral)
             self.set_mount_mode(mavutil.mavlink.MAV_MOUNT_MODE_RC_TARGETING)
 
@@ -5537,8 +5537,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
             self.wait_groundspeed(0, 1)
 
-            # now test RC targetting
-            self.progress("Testing mount RC targetting")
+            # now test RC targeting
+            self.progress("Testing mount RC targeting")
 
             self.set_mount_mode(mavutil.mavlink.MAV_MOUNT_MODE_RC_TARGETING)
             self.test_mount_rc_targetting(
@@ -5781,7 +5781,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
             self.progress("start=%s" % str(takeoff_loc))
             t = self.offset_location_ne(takeoff_loc, 20, 0)
-            self.progress("targetting=%s" % str(t))
+            self.progress("targeting=%s" % str(t))
 
             # this command is *weird* as the lat/lng is *always* 1e7,
             # even when transported via COMMAND_LONG!
@@ -6280,7 +6280,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 "Notch-per-motor peak was higher than single-notch peak %fdB > %fdB" %
                 (esc_peakdb2, esc_peakdb1))
 
-        # check that the noise is being squashed at all. this needs to be an aggresive check so that failure happens easily
+        # check that the noise is being squashed at all. this needs to be an aggressive check so that failure happens easily
         # testing shows this to be -58dB on average
         if esc_peakdb2 > -25:
             raise NotAchievedException(
@@ -6391,7 +6391,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 "Notch-per-motor peak was higher than single-notch peak %fdB > %fdB" %
                 (esc_peakdb2, esc_peakdb1))
 
-        # check that the noise is being squashed at all. this needs to be an aggresive check so that failure happens easily
+        # check that the noise is being squashed at all. this needs to be an aggressive check so that failure happens easily
         # testing shows this to be -58dB on average
         if esc_peakdb2 > -25:
             raise NotAchievedException(
@@ -6553,7 +6553,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.progress("Flying with gyro FFT harmonic - Gyro sample rate")
         self.context_push()
         ex = None
-        # we are dealing with probabalistic scenarios involving threads
+        # we are dealing with probabilistic scenarios involving threads
         try:
             self.start_subtest("Hover to calculate approximate hover frequency")
             # magic tridge EKF type that dramatically speeds up the test
@@ -7001,7 +7001,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
     def GyroFFTPostFilter(self):
         """Use FFT-driven dynamic harmonic notch to control post-RPM filter motor noise."""
         # basic gyro sample rate test
-        self.progress("Flying with gyro FFT post-filter supression - Gyro sample rate")
+        self.progress("Flying with gyro FFT post-filter suppression - Gyro sample rate")
         self.context_push()
         ex = None
         try:
@@ -8059,7 +8059,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             self.set_rc(4, 1400)
             self.delay_sim_time(30)
 
-            # check wind esitmates
+            # check wind estimates
             m = self.assert_receive_message('WIND')
             speed_error = abs(m.speed - wind_spd_truth)
             angle_error = abs(m.direction - wind_dir_truth)
@@ -8199,7 +8199,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.start_subtest("Protocol %i: ensure that BATTERY_STATUS for electrical generator message looks right" % proto_ver)
         self.start_subsubtest("Protocol %i: Checking original voltage (electrical)" % proto_ver)
         # ArduPilot spits out essentially uninitialised battery
-        # messages until we read things fromthe battery:
+        # messages until we read things from the battery:
         self.delay_sim_time(30)
         original_elec_m = self.wait_message_field_values('BATTERY_STATUS', {
             "charge_state": mavutil.mavlink.MAV_BATTERY_CHARGE_STATE_OK
@@ -8218,7 +8218,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.start_subtest("Protocol %i: ensure that BATTERY_STATUS for fuel generator message looks right" % proto_ver)
         self.start_subsubtest("Protocol %i: Checking original voltage (fuel)" % proto_ver)
         # ArduPilot spits out essentially uninitialised battery
-        # messages until we read things fromthe battery:
+        # messages until we read things from the battery:
         if original_fuel_m.battery_remaining <= 90:
             raise NotAchievedException("Bad original percentage (want=>%f got %f" % (90, original_fuel_m.battery_remaining))
         self.start_subsubtest("Protocol %i: Ensure percentage is counting down" % proto_ver)
@@ -8272,7 +8272,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_rc(7, 1000)
 
     def AuxFunctionsInMission(self):
-        '''Test use of auxilliary functions in missions'''
+        '''Test use of auxiliary functions in missions'''
         self.load_mission("aux_functions.txt")
         self.change_mode('LOITER')
         self.wait_ready_to_arm()
@@ -9868,7 +9868,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.progress("arm the vehicle and takeoff in Guided")
         self.takeoff(20, mode='GUIDED')
 
-        # Set home current location, this gives a large home vs orgin difference
+        # Set home current location, this gives a large home vs origin difference
         self.set_home(self.mav.location())
 
         self.progress("fly 50m North (or whatever)")
@@ -10470,7 +10470,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.do_RTL(timeout=120)
 
     def DO_CHANGE_SPEED(self):
-        '''Change speed during misison using waypoint items'''
+        '''Change speed during mission using waypoint items'''
         self.load_mission("mission.txt", strict=False)
 
         self.set_parameters({
@@ -10914,7 +10914,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.wait_ready_to_arm()
         self.arm_vehicle()
 
-        self.progress("test bootup state - it's zero-output!")
+        self.progress("test boot-up state - it's zero-output!")
         self.wait_servo_channel_value(spinner_ch, 0)
         self.wait_servo_channel_value(pump_ch, 0)
 
@@ -11383,7 +11383,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.change_mode('LAND')
         self.wait_disarmed()
 
-        # test turning safty on/off using explicit MAVLink command:
+        # test turning safety on/off using explicit MAVLink command:
         self.run_cmd_int(mavutil.mavlink.MAV_CMD_DO_SET_SAFETY_SWITCH_STATE, mavutil.mavlink.SAFETY_SWITCH_STATE_SAFE)
         self.assert_prearm_failure("safety switch")
         self.run_cmd_int(mavutil.mavlink.MAV_CMD_DO_SET_SAFETY_SWITCH_STATE, mavutil.mavlink.SAFETY_SWITCH_STATE_DANGEROUS)
@@ -12558,7 +12558,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # Takeoff in loiter
         self.takeoff(10, mode="LOITER")
 
-        # Try and switch to flip, should not be posible from loiter
+        # Try and switch to flip, should not be possible from loiter
         try:
             self.change_mode(100, timeout=10)
         except AutoTestTimeoutException:
@@ -12932,7 +12932,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.start_subtest("Swap UAVCAN backend at runtime")
         self.set_parameters({
             "CAN_P1_DRIVER": 1,
-            "BATT_MONITOR": 4,  # 4 is ananlog volt+curr
+            "BATT_MONITOR": 4,  # 4 is analog volt+curr
             "BATT2_MONITOR": 8,  # 8 is UAVCAN_BatteryInfo
             "BATT_SERIAL_NUM": 0,
             "BATT2_SERIAL_NUM": 0,
@@ -12962,7 +12962,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.start_subtest("Replace UAVCAN backend at runtime")
         self.set_parameters({
             "CAN_P1_DRIVER": 1,
-            "BATT_MONITOR": 11,  # 4 is ananlog volt+curr
+            "BATT_MONITOR": 11,  # 4 is analog volt+curr
         })
         self.reboot_sitl()
         self.delay_sim_time(2)
@@ -12997,7 +12997,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "GroundEffectCompensation_touchDownExpected": "Flapping",
             "FlyMissionTwice": "See https://github.com/ArduPilot/ardupilot/pull/18561",
             "GPSForYawCompassLearn": "Vehicle currently crashed in spectacular fashion",
-            "CompassMot": "Cuases an arithmetic exception in the EKF",
+            "CompassMot": "Causes an arithmetic exception in the EKF",
             "SMART_RTL_EnterLeave": "Causes a panic",
             "SMART_RTL_Repeat": "Currently fails due to issue with loop detection",
             "RTLStoppingDistanceSpeed": "Currently fails due to vehicle going off-course",

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -5018,7 +5018,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.arm_vehicle()
 
-        self.wait_text("Gripper load release", timeout=90)
+        self.wait_text("Gripper load releas(ed|ing)", timeout=90, regex=True)
         dist_limit = 1
         # this is a copy of the point in the mission file:
         target_loc = mavutil.location(-35.363106,
@@ -12306,7 +12306,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "FLIGHT_OPTIONS": 4,
         })
 
-        self.wait_statustext("Gripper Load Released", timeout=60)
+        self.wait_statustext("Gripper load released", regex=True, timeout=60)
         self.context_pop()
 
         self.do_RTL()

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -361,7 +361,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
                                             timeout=0.1)
                     now = self.get_sim_time_cached()
                     if now - step_start > 30:
-                        raise AutoTestTimeoutException("Manuevers not completed")
+                        raise AutoTestTimeoutException("Maneuvers not completed")
                     if m is None:
                         continue
 
@@ -807,7 +807,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             "BATT_MONITOR": 16, # Maxell battery monitor
         })
 
-        # Must reboot sitl after setting montior type for SMBus parameters to be set due to dynamic group
+        # Must reboot sitl after setting monitor type for SMBus parameters to be set due to dynamic group
         self.reboot_sitl()
         self.set_parameters({
             "BATT_I2C_BUS": 2,      # specified in SIM_I2C.cpp
@@ -1902,7 +1902,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         self.run_subtest("Inside loop", self.inside_loop)
 
-        self.run_subtest("Stablize test", self.test_stabilize)
+        self.run_subtest("Stabilize test", self.test_stabilize)
 
         self.run_subtest("ACRO test", self.test_acro)
 
@@ -2036,7 +2036,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.delay_sim_time(20)
             self.change_mode("RTL")
             self.wait_distance_to_home(100, 200, timeout=200)
-            # go into LOITER to create additonal time for a GPS re-enable test
+            # go into LOITER to create additional time for a GPS re-enable test
             self.change_mode("LOITER")
             self.set_parameter("SIM_GPS1_ENABLE", 1)
             t_enabled = self.get_sim_time()
@@ -2460,7 +2460,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
     def LOITER(self):
         '''Test Loiter mode'''
-        # first test old loiter behavour
+        # first test old loiter behaviour
         self.set_parameter("FLIGHT_OPTIONS", 0)
         self.takeoff(alt=200)
         self.set_rc(3, 1500)
@@ -2505,9 +2505,9 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.progress("Centering elevator and ensuring we get back to loiter altitude")
         self.set_rc(2, 1500)
         self.wait_altitude(initial_alt-1, initial_alt+1)
-        # Test new loiter behavour
+        # Test new loiter behaviour
         self.set_parameter("FLIGHT_OPTIONS", 1 << 12)
-        # should decend at max stick
+        # should descend at max stick
         self.set_rc(2, int(rc2_max))
         self.wait_altitude(initial_alt - 110, initial_alt - 90, timeout=90)
         # should not climb back at mid stick
@@ -2607,7 +2607,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.set_parameter("SOAR_ENABLE", 0)
         self.delay_sim_time(10)
 
-        # And reenable. This should force throttle-down
+        # And re-enable. This should force throttle-down
         self.set_parameter("SOAR_ENABLE", 1)
         self.delay_sim_time(10)
 
@@ -2620,7 +2620,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         # Back to auto
         self.change_mode('AUTO')
 
-        # Reenable thermals
+        # Re-enable thermals
         self.set_parameter("SIM_THML_SCENARI", 1)
 
         # Disable soaring using RC channel.
@@ -3359,7 +3359,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
     def EKFlaneswitch(self):
         '''Test EKF3 Affinity and Lane Switching'''
 
-        # new lane swtich available only with EK3
+        # new lane switch available only with EK3
         self.set_parameters({
             "EK3_ENABLE": 1,
             "EK2_ENABLE": 0,
@@ -4053,8 +4053,8 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         self.progress("User mode change to cruise should retrigger fence action")
         try:
-            # mode change should time out, 'WaitModeTimeout' exception is the desired resut
-            # cant wait too long or the vehicle will be inside fence and allow the mode change
+            # mode change should time out, 'WaitModeTimeout' exception is the desired result
+            # can't wait too long or the vehicle will be inside fence and allow the mode change
             self.change_mode("CRUISE", timeout=10)
             raise NotAchievedException("Should not change mode in fence breach")
         except WaitModeTimeout:
@@ -4411,10 +4411,10 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.run_autotune()
 
         # Values that are set to constants
-        # If these are changed then the expected tune paramters should also change
+        # If these are changed then the expected tune parameters should also change
         self.assert_parameter_value_pct("RLL2SRV_TCONST", 0.5, 0)
         self.assert_parameter_value_pct("RLL2SRV_RMAX", 75, 0)
-        self.assert_parameter_value_pct("RLL_RATE_IMAX", 0.666, 0.01) # allow some small error to acount for floating point stuff  # noqa:E501
+        self.assert_parameter_value_pct("RLL_RATE_IMAX", 0.666, 0.01) # allow some small error to account for floating point stuff  # noqa:E501
         self.assert_parameter_value_pct("RLL_RATE_FLTT", 3.183, 0.01)
         self.assert_parameter_value_pct("RLL_RATE_FLTE", 0, 0)
         self.assert_parameter_value_pct("RLL_RATE_FLTD", 10.0, 0)
@@ -4429,7 +4429,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.assert_parameter_value_pct("PTCH_RATE_FLTD", 10, 0)
         self.assert_parameter_value_pct("PTCH_RATE_SMAX", 150, 0)
 
-        # Check tunned values, targets derived from running tests multiple times and taking average
+        # Check tuned values, targets derived from running tests multiple times and taking average
         # Expect within 2%
         # Note that I is not checked directly, its value is derived from P, FF, and TCONST which are all checked.
         self.assert_parameter_value_pct("RLL_RATE_P", 1.222702146, 2)
@@ -4439,7 +4439,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.assert_parameter_value_pct("PTCH_RATE_FF", 0.503520715, 5)
 
         # There seem to be multiple solutions for pitch. I'm not sure why this is.
-        # Each value is quite consistent becasue of the fixed steps that autotune takes
+        # Each value is quite consistent because of the fixed steps that autotune takes
         try:
             # Expect this about 84% of the time
             self.assert_parameter_value_pct("PTCH_RATE_P", 1.746079683, 2)
@@ -4482,12 +4482,12 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
                 self.progress("Got %s" % str(m))
                 if axis == "Roll":
                     axis = "Pitch"
-                    # Center sticks to allow roll to return to nuetral before starting pitch
+                    # Center sticks to allow roll to return to neutral before starting pitch
                     self.set_rc(1, 1500)
                     self.set_rc(2, 1500)
                     self.delay_sim_time(15)
 
-                    # Reset toggle value so the initial input is in a consistent directon
+                    # Reset toggle value so the initial input is in a consistent direction
                     rc_value = 1000
 
                 elif axis == "Pitch":
@@ -5328,7 +5328,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             seq = self.mav.waypoint_current()
             self.progress("Waiting for wp=%u current=%u" % (wpnum, seq))
             if seq == wpnum:
-                raise NotAchievedException("Reached desired waypoint without first decending 10m,\
+                raise NotAchievedException("Reached desired waypoint without first descending 10m,\
  indicating slope was replanned unexpectedly")
 
             if (self.get_altitude(relative=True, timeout=2) - init_altitude) < -10:
@@ -7010,7 +7010,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         while True:
             m = dfreader.recv_match()
             if m is None:
-                raise NotAchievedException("Did not see csrv Pos/PosCmd discrepency")
+                raise NotAchievedException("Did not see csrv Pos/PosCmd discrepancy")
             if m.get_type() != 'CSRV':
                 continue
             if m.Id != 1:

--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -829,7 +829,7 @@ if __name__ == "__main__":
         """Custom option parse class."""
 
         def format_epilog(self, formatter):
-            """Retun customized option parser epilog."""
+            """Return customized option parser epilog."""
             return self.epilog
 
     parser = MyOptionParser(

--- a/Tools/autotest/examples.py
+++ b/Tools/autotest/examples.py
@@ -66,7 +66,7 @@ def run_example(name, filepath, valgrind=False, gdb=False):
         print("process exited with -15, indicating it didn't catch the TERM signal and exit properly")
     elif retcode != 0:
         # note that process could exit with code 0 and we couldn't tell...
-        raise ValueError("Process exitted with non-zero exitcode %s" % str(retcode))
+        raise ValueError("Process exited with non-zero exitcode %s" % str(retcode))
 
     print("Ran: (%s)" % str(cmd))
 

--- a/Tools/autotest/helicopter.py
+++ b/Tools/autotest/helicopter.py
@@ -765,7 +765,7 @@ class AutoTestHelicopter(AutoTestCopter):
             "SERVO%u_FUNCTION" % roll_servo: 8,  # pitch
             "SERVO%u_FUNCTION" % open_servo: 9,  # mount open
             "MNT1_OPTIONS": 2,  # retract
-            "MNT1_DEFLT_MODE": 3,  # RC targettting
+            "MNT1_DEFLT_MODE": 3,  # RC targeting
             "MNT1_ROLL_MIN": -roll_limit,
             "MNT1_ROLL_MAX": roll_limit,
         })

--- a/Tools/autotest/logger_metadata/parse.py
+++ b/Tools/autotest/logger_metadata/parse.py
@@ -226,7 +226,7 @@ class LoggerDocco(object):
                 # Check if we have a defined prefix for this multiplier
                 elif mult_num in mult_prefix_lookup:
                     self.fields[f]["units"] = f"{mult_prefix_lookup[mult_num]}{baseunit}"
-                # If all else fails, set the unit as the multipler and base unit together
+                # If all else fails, set the unit as the multiplier and base unit together
                 else:
                     self.fields[f]["units"] = f"{mult} {baseunit}"
 
@@ -285,7 +285,7 @@ class LoggerDocco(object):
             self.search_for_files(_next)
 
     def parse_messagedef(self, messagedef):
-        # Merge concatinated strings and remove comments
+        # Merge concatenated strings and remove comments
         messagedef = re.sub(r'"\s+"', '', messagedef)
         messagedef = re.sub(r'//[^\n]*', '', messagedef)
         # Extract details from a structure definition

--- a/Tools/autotest/param_metadata/htmlemit.py
+++ b/Tools/autotest/param_metadata/htmlemit.py
@@ -80,7 +80,7 @@ DO NOT EDIT
                     elif field == 'Units':
                         abreviated_units = param.__dict__[field]
                         if abreviated_units != '':
-                            units = known_units[abreviated_units]   # use the known_units dictionary to convert the abreviated unit into a full textual one
+                            units = known_units[abreviated_units]   # use the known_units dictionary to convert the abbreviated unit into a full textual one
                             t += "<li>%s: %s</li>\n" % (field, cescape(units))
                     else:
                         t += "<li>%s: %s</li>\n" % (field, cescape(param.__dict__[field]))

--- a/Tools/autotest/param_metadata/param.py
+++ b/Tools/autotest/param_metadata/param.py
@@ -64,7 +64,7 @@ known_param_fields = [
 # http://www1.bipm.org/en/CGPM/db/3/2/   g_n unit for G-force
 # one further constrain is that only printable (7bit) ASCII characters are allowed
 known_units = {
-#          abreviation : full-text (used in .html .rst and .wiki files)
+#          abbreviation : full-text (used in .html .rst and .wiki files)
 # time
              's'       : 'seconds'               ,
              'ds'      : 'deciseconds'           ,

--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -29,7 +29,7 @@ parser.add_argument("--no-emit",
                     dest='emit_params',
                     action='store_false',
                     default=True,
-                    help="don't emit parameter documention, just validate")
+                    help="don't emit parameter documentation, just validate")
 parser.add_argument("--format",
                     dest='output_format',
                     action='store',

--- a/Tools/autotest/param_metadata/xmlemit.py
+++ b/Tools/autotest/param_metadata/xmlemit.py
@@ -96,13 +96,13 @@ class XmlEmit(Emit):
             if hasattr(param, 'Calibration'):
                 xml_param.set('calibration', param.Calibration)
 
-            # Add values as chidren of this node
+            # Add values as children of this node
             for field in param.__dict__.keys():
                 if not self.should_emit_field(param, field):
                     continue
                 if field not in ['name', 'DisplayName', 'Description', 'User', 'SortValues'] and field in known_param_fields:
                     # we emit Bitmask as both a sub-element (so that
-                    # consumers don't need to parse the Bimask list),
+                    # consumers don't need to parse the Bitmask list),
                     # but also as a text so we don't break existing
                     # implementations.  Contrast with "values", which
                     # is only emitted as a sub-element.
@@ -127,7 +127,7 @@ class XmlEmit(Emit):
                     elif field == 'Units':
                         abreviated_units = param.__dict__[field]
                         if abreviated_units != '':
-                            units = known_units[abreviated_units]   # use the known_units dictionary to convert the abreviated unit into a full textual one
+                            units = known_units[abreviated_units]   # use the known_units dictionary to convert the abbreviated unit into a full textual one
                             xml_field1 = etree.SubElement(xml_param, 'field', name=field)  # i.e. A/s
                             xml_field1.text = abreviated_units
                             xml_field2 = etree.SubElement(xml_param, 'field', name='UnitText')  # i.e. ampere per second

--- a/Tools/autotest/pysim/vehicleinfo.py
+++ b/Tools/autotest/pysim/vehicleinfo.py
@@ -518,7 +518,7 @@ class VehicleInfo(object):
         return self.options[vehicle]["frames"][default_frame]["waf_target"]
 
     def options_for_frame(self, frame, vehicle, opts):
-        """Return informatiom about how to sitl for frame e.g. build-type==sitl"""
+        """Return information about how to sitl for frame e.g. build-type==sitl"""
         ret = None
         frames = self.options[vehicle]["frames"]
         if frame in frames:

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -262,7 +262,7 @@ class AutoTestRover(vehicle_test_suite.TestSuite):
         self.wait_ready_to_arm()
         self.arm_vehicle()
 
-        self.progress("test bootup state - it's zero-output!")
+        self.progress("test boot-up state - it's zero-output!")
         self.wait_servo_channel_value(spinner_ch, 0)
         self.wait_servo_channel_value(pump_ch, 0)
 
@@ -681,7 +681,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                     (2, 'MANUAL'),
                     (3, 'RTL'),
                     (4, 'AUTO'),
-                    (5, 'AUTO'),  # non-existant mode, should stay in RTL
+                    (5, 'AUTO'),  # non-existent mode, should stay in RTL
                     (6, 'MANUAL')]
             mavproxy = self.start_mavproxy(sitl_rcin_port=port)
             for (num, expected) in fnoo:
@@ -1046,7 +1046,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.progress("Wait for override value")
         self.wait_rc_channel_value(ch, ch_override_value, timeout=10)
 
-        # make we keep the override vaue for at least 10 seconds:
+        # make we keep the override value for at least 10 seconds:
         tstart = self.get_sim_time()
         while True:
             if self.get_sim_time_cached() - tstart > 10:
@@ -2105,7 +2105,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.clear_fence_using_mavproxy(mavproxy)
         self.delay_sim_time(1)
         pointcount = 7
-        mavproxy.send("fence addpoly inc 20 %u 37.2\n" % pointcount) # radius, pointcount, rotaiton
+        mavproxy.send("fence addpoly inc 20 %u 37.2\n" % pointcount) # radius, pointcount, rotation
         self.delay_sim_time(5)
         downloaded_items = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_FENCE)
         if len(downloaded_items) != pointcount:
@@ -2304,7 +2304,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                                          target_component=target_component)
 
     def GCSFenceInvalidPoint(self):
-        '''Test fetch non-existant fencepoint'''
+        '''Test fetch non-existent fencepoint'''
         target_system = 1
         target_component = 1
 
@@ -2556,10 +2556,10 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             verbose=True,
         )
         if m.target_system != target_system:
-            raise NotAchievedException("ACK not targetted at correct system want=%u got=%u" %
+            raise NotAchievedException("ACK not targeted at correct system want=%u got=%u" %
                                        (target_system, m.target_system))
         if m.target_component != target_component:
-            raise NotAchievedException("ACK not targetted at correct component")
+            raise NotAchievedException("ACK not targeted at correct component")
         if m.mission_type != mission_type:
             raise NotAchievedException("Unexpected mission type %u want=%u" %
                                        (m.mission_type, mission_type))
@@ -3035,7 +3035,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                     "resetting rally point count didn't change items returned")
             if downloaded[2].x != new_item2_lat:
                 raise NotAchievedException(
-                    "Bad lattitude in downloaded item: want=%u got=%u" %
+                    "Bad latitude in downloaded item: want=%u got=%u" %
                     (new_item2_lat, downloaded[2].x))
 
             self.progress("Grabbing original item 1 using original protocol")
@@ -5965,7 +5965,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             raise NotAchievedException("Expected %fm got %fm" % (want_range, m.distance))
 
     def DepthFinder(self):
-        '''Test mulitple depthfinders for boats'''
+        '''Test multiple depthfinders for boats'''
         # Setup rangefinders
         self.customise_SITL_commandline([
             "--serial7=sim:nmea", # NMEA Rangefinder
@@ -6159,7 +6159,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
         self.assert_receive_message("HEARTBEAT", mav=mav2)
 
-        # ensure a targetted message is received:
+        # ensure a targeted message is received:
         self.install_message_hook_context(heartbeat_on_mav2)
 
         self.progress("Ensuring we can get a message normally")
@@ -6461,7 +6461,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         if board_status.find('0 hours') == -1:
             raise NotAchievedException("Expected uptime in board status")
         if board_status.find('40.713') == -1:
-            raise NotAchievedException("Expected lattitude in board status")
+            raise NotAchievedException("Expected latitude in board status")
 
         self.progress("WebServer tests OK")
 

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -929,7 +929,7 @@ def start_mavproxy(opts, stuff):
             if '=' in x:
                 mavargs[i] = x.split('=')[0]
                 mavargs.insert(i+1, x.split('=')[1])
-        # Use this flag to tell if parsing character inbetween a pair
+        # Use this flag to tell if parsing character in between a pair
         # of quotation marks
         inString = False
         beginStringIndex = []

--- a/Tools/autotest/test_build_options.py
+++ b/Tools/autotest/test_build_options.py
@@ -195,8 +195,8 @@ class TestBuildOptions(object):
         # should say so:
         for target in self.build_targets:
             path = self.target_to_elf_path(target)
-            extracter = extract_features.ExtractFeatures(path)
-            (compiled_in_feature_defines, not_compiled_in_feature_defines) = extracter.extract()
+            extractor = extract_features.ExtractFeatures(path)
+            (compiled_in_feature_defines, not_compiled_in_feature_defines) = extractor.extract()
             for define in defines:
                 # the following defines are known not to work on some
                 # or all vehicles:
@@ -402,8 +402,8 @@ class TestBuildOptions(object):
         # should say so:
         for target in self.build_targets:
             path = self.target_to_elf_path(target)
-            extracter = extract_features.ExtractFeatures(path)
-            (compiled_in_feature_defines, not_compiled_in_feature_defines) = extracter.extract()
+            extractor = extract_features.ExtractFeatures(path)
+            (compiled_in_feature_defines, not_compiled_in_feature_defines) = extractor.extract()
             for define in defines:
                 if not defines[define]:
                     continue

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -1527,7 +1527,7 @@ class FRSkySPort(FRSky):
             0x020F: "CURR", # current dA
             0x011F: "VSPD", # vertical speed cm/s
             0x021F: "VFAS", # battery 1 voltage cV
-            # 0x800: "GPS", ## comments as duplicated dictrionary key
+            # 0x800: "GPS", ## comments as duplicated dictionary key
             0x050E: "RPM1",
 
             0x34: "DOWNLINK1_ID",
@@ -3815,7 +3815,7 @@ class TestSuite(ABC):
                                 timeout=2)
         if m is not None:
             raise NotAchievedException("Received extra LOG_ENTRY?!")
-        # shouldbe: m = self.assert_not_receive_message('LOG_ENTRY', timeout=2)
+        # should be: m = self.assert_not_receive_message('LOG_ENTRY', timeout=2)
 
         return logs
 
@@ -4298,7 +4298,7 @@ class TestSuite(ABC):
         self.assert_mission_count(0)
 
     def log_list(self):
-        '''return a list of log files present in POSIX-style loging dir'''
+        '''return a list of log files present in POSIX-style logging dir'''
         ret = sorted(glob.glob("logs/00*.BIN"))
         self.progress("log list: %s" % str(ret))
         return ret
@@ -4684,7 +4684,7 @@ class TestSuite(ABC):
         #  print(f"{m_type} OK")
 
     def LoggingFormat(self):
-        '''ensure formats are emmitted appropriately'''
+        '''ensure formats are emitted appropriately'''
 
         self.context_push()
         self.set_parameter('LOG_FILE_DSRMROT', 1)
@@ -6273,7 +6273,7 @@ class TestSuite(ABC):
         error_ratio = max_error_percent / 100
         limits = [expected_value * (1 + error_ratio), expected_value * (1 - error_ratio)]
 
-        # Ensure that min and max are always the corret way round
+        # Ensure that min and max are always the correct way round
         upper_limit = max(limits)
         lower_limit = min(limits)
 
@@ -6895,7 +6895,7 @@ class TestSuite(ABC):
     def assert_no_capability(self, capability):
         if self.capable(capability):
             name = mavutil.mavlink.enums["MAV_PROTOCOL_CAPABILITY"][capability].name
-            raise NotAchievedException("AutoPilot has feature %s (when it shouln't)" % (name,))
+            raise NotAchievedException("AutoPilot has feature %s (when it shouldn't)" % (name,))
 
     def get_autopilot_capabilities(self):
         # Cannot use run_cmd otherwise the respond is lost during the wait for ACK
@@ -8549,7 +8549,7 @@ Also, ignores heartbeats not from our target system'''
         # Statustexts are often triggered by something we've just
         # done, so we have to be careful not to read any traffic that
         # isn't checked for being our statustext.  That doesn't work
-        # well with getting the curent simulation time (which requires
+        # well with getting the current simulation time (which requires
         # a new SYSTEM_TIME message), so we install a message hook
         # which checks all incoming messages.
         self.progress("Waiting for text : %s" % text.lower())
@@ -9191,7 +9191,7 @@ Also, ignores heartbeats not from our target system'''
         return self.use_map
 
     def init(self):
-        """Initilialize autotest feature."""
+        """Initialize autotest feature."""
         self.mavproxy_logfile = self.open_mavproxy_logfile()
 
         if self.frame is None:
@@ -11270,14 +11270,14 @@ Also, ignores heartbeats not from our target system'''
         # non strict string matching because of catching text issue....
         self.context_collect('STATUSTEXT')
         self.set_rc(9, 1000)
-        self.wait_text("Gripper load releas", check_context=True)
+        self.wait_text("Gripper load release", check_context=True)
         self.progress("Grabbing load")
         self.set_rc(9, 2000)
         self.wait_text("Gripper load grabb", check_context=True)
         self.context_clear_collection('STATUSTEXT')
         self.progress("Releasing load")
         self.set_rc(9, 1000)
-        self.wait_text("Gripper load releas", check_context=True)
+        self.wait_text("Gripper load release", check_context=True)
         self.progress("Grabbing load")
         self.set_rc(9, 2000)
         self.wait_text("Gripper load grabb", check_context=True)
@@ -11290,7 +11290,7 @@ Also, ignores heartbeats not from our target system'''
             p1=1,
             p2=mavutil.mavlink.GRIPPER_ACTION_RELEASE
         )
-        self.wait_text("Gripper load releas", check_context=True)
+        self.wait_text("Gripper load release", check_context=True)
         self.progress("Grabbing load")
         self.run_cmd(
             mavutil.mavlink.MAV_CMD_DO_GRIPPER,
@@ -11306,7 +11306,7 @@ Also, ignores heartbeats not from our target system'''
             p1=1,
             p2=mavutil.mavlink.GRIPPER_ACTION_RELEASE
         )
-        self.wait_text("Gripper load releas", check_context=True)
+        self.wait_text("Gripper load release", check_context=True)
 
         self.progress("Grabbing load")
         self.run_cmd_int(
@@ -11516,7 +11516,7 @@ Also, ignores heartbeats not from our target system'''
             testpos(self, targetpos, test_alt, frame_name, frame)
 
             if test_heading:
-                self.start_subtest("Testing Yaw targetting in %s" % frame_name)
+                self.start_subtest("Testing Yaw targeting in %s" % frame_name)
                 self.progress("Changing Latitude and Heading")
                 targetpos.lat += 0.0001
                 if test_alt:
@@ -11584,7 +11584,7 @@ Also, ignores heartbeats not from our target system'''
                 self.wait_heading(0, minimum_duration=5, timeout=timeout)
 
             if test_yaw_rate:
-                self.start_subtest("Testing Yaw Rate targetting in %s" % frame_name)
+                self.start_subtest("Testing Yaw Rate targeting in %s" % frame_name)
 
                 def send_yaw_rate(rate, target=None):
                     self.mav.mav.set_position_target_global_int_send(
@@ -11847,7 +11847,7 @@ Also, ignores heartbeats not from our target system'''
             )
 
             if test_heading:
-                self.start_subtest("Testing Yaw targetting in %s" % frame_name)
+                self.start_subtest("Testing Yaw targeting in %s" % frame_name)
 
                 def send_yaw_target(yaw, mav_frame):
                     self.mav.mav.set_position_target_global_int_send(
@@ -11944,7 +11944,7 @@ Also, ignores heartbeats not from our target system'''
                 )
 
             if test_yaw_rate:
-                self.start_subtest("Testing Yaw Rate targetting in %s" % frame_name)
+                self.start_subtest("Testing Yaw Rate targeting in %s" % frame_name)
 
                 def send_yaw_rate(rate, mav_frame):
                     self.mav.mav.set_position_target_global_int_send(
@@ -12189,7 +12189,7 @@ one specified in the vehicle constructor)'''
 
     def wait_for_mode_switch_poll(self):
         '''look for a transition from boot-up-mode (e.g. the flightmode
-specificied in Copter's constructor) to the one specified by the mode
+specified in Copter's constructor) to the one specified by the mode
 switch value'''
         want = self.initial_mode_switch_mode()
         if want is None:
@@ -12508,7 +12508,7 @@ switch value'''
             mav = self.mav
         m = mav.recv_match(type=message, blocking=True, timeout=timeout)
         if m is not None:
-            raise PreconditionFailedException("Receiving %s messags" % message)
+            raise PreconditionFailedException("Receiving %s messages" % message)
 
     def PIDTuning(self):
         '''Test PID Tuning'''
@@ -13591,7 +13591,7 @@ switch value'''
             condition="BATTERY_STATUS.id==0"
         )
         battery_status_voltage_v = batt.voltages[0] * 0.001 # mV -> V
-        self.progress("BATTERY_STATUS volatge==%f frsky==%f" % (battery_status_voltage_v, voltage_v))
+        self.progress("BATTERY_STATUS voltage==%f frsky==%f" % (battery_status_voltage_v, voltage_v))
         if self.compare_number_percent(battery_status_voltage_v, voltage_v, 10):
             return True
         return False

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -11270,14 +11270,14 @@ Also, ignores heartbeats not from our target system'''
         # non strict string matching because of catching text issue....
         self.context_collect('STATUSTEXT')
         self.set_rc(9, 1000)
-        self.wait_text("Gripper load release", check_context=True)
+        self.wait_text("Gripper load releas(ed|ing)", regex=True, check_context=True)
         self.progress("Grabbing load")
         self.set_rc(9, 2000)
         self.wait_text("Gripper load grabb", check_context=True)
         self.context_clear_collection('STATUSTEXT')
         self.progress("Releasing load")
         self.set_rc(9, 1000)
-        self.wait_text("Gripper load release", check_context=True)
+        self.wait_text("Gripper load releas(ed|ing)", regex=True, check_context=True)
         self.progress("Grabbing load")
         self.set_rc(9, 2000)
         self.wait_text("Gripper load grabb", check_context=True)
@@ -11290,7 +11290,7 @@ Also, ignores heartbeats not from our target system'''
             p1=1,
             p2=mavutil.mavlink.GRIPPER_ACTION_RELEASE
         )
-        self.wait_text("Gripper load release", check_context=True)
+        self.wait_text("Gripper load releas(ed|ing)", check_context=True, regex=True)
         self.progress("Grabbing load")
         self.run_cmd(
             mavutil.mavlink.MAV_CMD_DO_GRIPPER,
@@ -11306,7 +11306,7 @@ Also, ignores heartbeats not from our target system'''
             p1=1,
             p2=mavutil.mavlink.GRIPPER_ACTION_RELEASE
         )
-        self.wait_text("Gripper load release", check_context=True)
+        self.wait_text("Gripper load releas(ed|ing)", regex=True, check_context=True)
 
         self.progress("Grabbing load")
         self.run_cmd_int(

--- a/Tools/cameras_gimbals/siyi-download/siyi-download.py
+++ b/Tools/cameras_gimbals/siyi-download/siyi-download.py
@@ -18,7 +18,7 @@ from urllib.parse import urlencode
 from urllib.error import URLError, HTTPError
 from enum import Enum
 
-# prefix string for text outout to user
+# prefix string for text output to user
 prefix_str = "siyi-download.py: "
 ip_address_default = "192.168.144.25"
 

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_parameter_service.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_parameter_service.py
@@ -73,7 +73,7 @@ class ParameterClient(rclpy.node.Node):
 
         self.set_cli = self.create_client(SetParameters, 'ap/set_parameters')
         while not self.set_cli.wait_for_service(timeout_sec=1.0):
-            self.get_logger().info('SetParameters service not availabel, waiting again...')
+            self.get_logger().info('SetParameters service not available, waiting again...')
 
         # Add a spin thread
         self.ros_spin_thread = threading.Thread(target=lambda node: rclpy.spin(node), args=(self,))

--- a/Tools/scripts/bin2hex.py
+++ b/Tools/scripts/bin2hex.py
@@ -33,7 +33,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 # EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-'''Intel HEX file format bin2hex convertor utility.'''
+'''Intel HEX file format bin2hex converter utility.'''
 
 VERSION = '1.5'
 
@@ -44,7 +44,7 @@ if __name__ == '__main__':
 
     from intelhex import bin2hex
 
-    usage = '''Bin2Hex convertor utility.
+    usage = '''Bin2Hex converter utility.
 Usage:
     python bin2hex.py [options] INFILE [OUTFILE]
 

--- a/Tools/scripts/build_binaries.py
+++ b/Tools/scripts/build_binaries.py
@@ -546,7 +546,7 @@ is bob we will attempt to checkout bob-AVR'''
                         if not os.path.exists(tdir):
                             self.mkpath(tdir)
                         # must addfwversion even if path already
-                        # exists as we re-use the "beta" directories
+                        # exists as we reuse the "beta" directories
                         self.addfwversion(tdir, vehicle)
                         features_filepath = os.path.join(tdir, "features.txt")
                         if features_text is not None:

--- a/Tools/scripts/build_bootloaders.py
+++ b/Tools/scripts/build_bootloaders.py
@@ -51,7 +51,7 @@ def is_ap_periph(hwdef):
     return False
 
 def get_board_list():
-    '''add boards based on existance of hwdef-bl.dat in subdirectories for ChibiOS'''
+    '''add boards based on existence of hwdef-bl.dat in subdirectories for ChibiOS'''
     board_list = []
     dirname, dirlist, filenames = next(os.walk('libraries/AP_HAL_ChibiOS/hwdef'))
     for d in dirlist:

--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -76,7 +76,7 @@ BUILD_OPTIONS = [
     Feature('Telemetry', 'HOTT', 'HAL_HOTT_TELEM_ENABLED', 'Enable HOTT telemetry', 0, None),
     Feature('Telemetry', 'SPEKTRUM', 'HAL_SPEKTRUM_TELEM_ENABLED', 'Enable Spektrum telemetry', 0, None),
     Feature('Telemetry', 'LTM', 'AP_LTM_TELEM_ENABLED', 'Enable LTM telemetry', 0, None),
-    Feature('Telemetry', 'AUX_FUNCTION_STRINGS', 'AP_RC_CHANNEL_AUX_FUNCTION_STRINGS_ENABLED', 'Enable Auxilliary function activation text messages', 0, None),  # noqa
+    Feature('Telemetry', 'AUX_FUNCTION_STRINGS', 'AP_RC_CHANNEL_AUX_FUNCTION_STRINGS_ENABLED', 'Enable Auxiliary function activation text messages', 0, None),  # noqa
     Feature('Telemetry', 'FrSky', 'AP_FRSKY_TELEM_ENABLED', 'Enable FrSky telemetry', 0, None),
     Feature('Telemetry', 'FrSky D', 'AP_FRSKY_D_TELEM_ENABLED', 'Enable FrSkyD telemetry', 0, 'FrSky'),
     Feature('Telemetry', 'FrSky SPort', 'AP_FRSKY_SPORT_TELEM_ENABLED', 'Enable FrSkySPort telemetry', 0, 'FrSky'),  # noqa

--- a/Tools/scripts/configure_all.py
+++ b/Tools/scripts/configure_all.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 """
-script to run configre for all hwdef.dat, to check for syntax errors
+script to run configure for all hwdef.dat, to check for syntax errors
 """
 
 import os
@@ -36,7 +36,7 @@ done = []
 board_list = []
 
 def get_board_list():
-    '''add boards based on existance of hwdef-bl.dat in subdirectories for ChibiOS'''
+    '''add boards based on existence of hwdef-bl.dat in subdirectories for ChibiOS'''
     board_list = []
     # these are base builds, and don't build directly
     omit = []

--- a/Tools/scripts/decode_ICSR.py
+++ b/Tools/scripts/decode_ICSR.py
@@ -78,7 +78,7 @@ class DecodeICSR(object):
         if value:
             out = "Interrupt pending"
         else:
-            out = "No pending interupt"
+            out = "No pending interrupt"
         return (" (%s)" % out)
 
     def decoder_m4_pendstclr(self, value):

--- a/Tools/scripts/gen_stable.py
+++ b/Tools/scripts/gen_stable.py
@@ -37,7 +37,7 @@ def make_stable(basedir, vehicle):
         shutil.copytree(old_dir, new_dir)
 
 def make_stable_from_beta(basedir, vehicle, beta_dir):
-    '''make stable version from a beta with OFFICAL tag'''
+    '''make stable version from a beta with OFFICIAL tag'''
     beta_dir = os.path.join(basedir, vehicle, beta_dir)
     if not os.path.exists(beta_dir):
         return

--- a/Tools/scripts/run_coverage.py
+++ b/Tools/scripts/run_coverage.py
@@ -112,7 +112,7 @@ class CoverageRunner(object):
             for line in searchfile:
                 if "-ftest-coverage" in line:
                     return True
-            self.progress("%s was't built with coverage support" % name)
+            self.progress("%s wasn't built with coverage support" % name)
             return False
 
     def run_build(self, use_example=False) -> None:
@@ -199,7 +199,7 @@ class CoverageRunner(object):
         with open(self.LCOV_LOG, 'a') as log_file:
             # we cannot use subprocess.PIPE and result.stdout to get the output as it will be too long and trigger
             # BlockingIOError: [Errno 11] write could not complete without blocking
-            # thus we ouput to temp file, and print the file line by line...
+            # thus we output to temp file, and print the file line by line...
             with tempfile.NamedTemporaryFile(mode="w+") as tmp_file:
                 try:
                     self.progress("Capturing Coverage statistics")
@@ -225,7 +225,7 @@ class CoverageRunner(object):
                         tmp_file.seek(0)
                         content = tmp_file.read().splitlines()
                         for line in content:
-                            # print(line, flush=True)  # not usefull to print
+                            # print(line, flush=True)  # not useful to print
                             log_file.write(line)
                     # remove files we do not intentionally test:
                     self.progress("Removing unwanted coverage statistics")
@@ -248,7 +248,7 @@ class CoverageRunner(object):
                         tmp_file.seek(0)
                         content = tmp_file.read().splitlines()
                         for line in content:
-                            # print(line, flush=True)  # not usefull to print
+                            # print(line, flush=True)  # not useful to print
                             log_file.write(line)
 
                 except subprocess.CalledProcessError as err:

--- a/Tools/scripts/solution_status_change.py
+++ b/Tools/scripts/solution_status_change.py
@@ -47,7 +47,7 @@ class SolutionStatusChange(object):
             "using_gps": 13,
             "gps_glitching": 14,
             "gps_quality_good": 15,
-            "initalized": 16,
+            "initialized": 16,
             "rejecting_airspeed": 17,
             "deadreckoning": 18,
         }

--- a/Tools/scripts/uploader.py
+++ b/Tools/scripts/uploader.py
@@ -387,7 +387,7 @@ class uploader(object):
             return True
 
         except NotImplementedError:
-            raise RuntimeError("Programing not supported for this version of silicon!\n"
+            raise RuntimeError("Programming not supported for this version of silicon!\n"
                                "See https://pixhawk.org/help/errata")
         except RuntimeError:
             # timeout, no response yet
@@ -431,8 +431,8 @@ class uploader(object):
         self.__getSync()
         if runningPython3:
             value = value.decode('ascii')
-        peices = value.split(",")
-        return peices
+        pieces = value.split(",")
+        return pieces
 
     def __drawProgressBar(self, label, progress, maxVal):
         if maxVal < progress:

--- a/libraries/AP_HAL/hwdef/scripts/hwdef.py
+++ b/libraries/AP_HAL/hwdef/scripts/hwdef.py
@@ -214,7 +214,7 @@ class HWDef:
             self.progress("Removing %s" % u)
             self.config.pop(u, '')
             self.intdefines.pop(u, '')
-            # also remove all occurences of defines in previous lines if any
+            # also remove all occurrences of defines in previous lines if any
             for line in self.alllines[:]:
                 if line.startswith('define') and u == line.split()[1]:
                     self.alllines.remove(line)

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H730xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H730xx.py
@@ -29,7 +29,7 @@ mcu = {
     # flags of 2 means faster memory for CPU intensive work
     # flags of 4 means memory can be used for SDMMC DMA
 
-	# overall ram map for information only, board not useable without external flash
+	# overall ram map for information only, board not usable without external flash
     #'RAM_MAP' : [
     #    (0x24000000, 320, 4), # AXI SRAM. Use this for SDMMC IDMA ops
     #    (0x30000000,  32, 0), # SRAM1, SRAM2

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -1710,7 +1710,7 @@ INCLUDE common.ld
                 self.error("Need io_firmware.bin in ROMFS for IOMCU")
 
             self.write_defaulting_define(f, 'HAL_WITH_IO_MCU', 1)
-            
+
             if self.config['IOMCU_UART'][0]:
                 # get index of serial port in serial_list
                 index = serial_list.index(self.config['IOMCU_UART'][0])
@@ -1719,7 +1719,7 @@ INCLUDE common.ld
                     '#define HAL_UART_IO_DRIVER constexpr ChibiOS::UARTDriver &uart_io = serial%sDriver;\n' % (index)
                 )
 
-            f.write('#define HAL_HAVE_SERVO_VOLTAGE 1\n') # make the assumption that IO gurantees servo monitoring
+            f.write('#define HAL_HAVE_SERVO_VOLTAGE 1\n') # make the assumption that IO guarantees servo monitoring
             # all IOMCU capable boards have SBUS out
             f.write('#define AP_FEATURE_SBUS_OUT 1\n')
         else:
@@ -1812,9 +1812,9 @@ INCLUDE common.ld
                 # USB endpoint ID, not used
                 f.write("0, ")
 
-                # Find and add RTS alt fuction number if avalable
+                # Find and add RTS alt function number if available
                 def get_RTS_alt_function():
-                    # Typicaly we do software RTS control, so there is
+                    # Typically we do software RTS control, so there is
                     # no requirement for the pin to have valid UART
                     # RTS alternative function
                     # If it does this enables hardware flow control for RS-485
@@ -2293,7 +2293,7 @@ INCLUDE common.ld
                 gpioset.add(gpio)
                 port = p.port
                 pin = p.pin
-                # aux config disabled by defualt
+                # aux config disabled by default
                 gpios.append((gpio, pwm, port, pin, p, 'false'))
         gpios = sorted(gpios)
         for (gpio, pwm, port, pin, p, enabled) in gpios:
@@ -2323,7 +2323,7 @@ INCLUDE common.ld
         this_dir = os.path.realpath(__file__)
         rootdir = os.path.relpath(os.path.join(this_dir, "../../../../.."))
         hwdef_dirname = os.path.basename(os.path.dirname(self.hwdef[0]))
-        # allow re-using of bootloader from different build:
+        # allow reusing of bootloader from different build:
         use_bootloader_from_board = self.get_config('USE_BOOTLOADER_FROM_BOARD', default=None, required=False)
         if use_bootloader_from_board is not None:
             hwdef_dirname = use_bootloader_from_board
@@ -2903,7 +2903,7 @@ Please run: Tools/scripts/build_bootloaders.py %s
             for dev in self.spidev:
                 if u == dev[0]:
                     self.spidev.remove(dev)
-            # also remove all occurences of defines in previous lines if any
+            # also remove all occurrences of defines in previous lines if any
             for line in self.alllines[:]:
                 if line.startswith('STM32_') and u == line.split()[0]:
                     self.alllines.remove(line)

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/dma_parse.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/dma_parse.py
@@ -45,7 +45,7 @@ def error(str):
 
 def check_full_table(table):
     '''check the table is not missing rows or columns
-       we should have at least one entry in every row and one entry in every colum of each dma table
+       we should have at least one entry in every row and one entry in every column of each dma table
     '''
     stream_mask = [0,0]
     channel_mask = [0,0]

--- a/libraries/AP_MSP/Tools/pymsp.py
+++ b/libraries/AP_MSP/Tools/pymsp.py
@@ -276,7 +276,7 @@ class PyMSP:
         msgName = a[0]
         fieldName = a[1]
         if not msgName in self.by_name:
-            # default to zero for simplicty of display
+            # default to zero for simplicity of display
             return 0
         msg = self.by_name[msgName]
         if not fieldName in msg.values:

--- a/libraries/AP_NavEKF3/derivation/generate_1.py
+++ b/libraries/AP_NavEKF3/derivation/generate_1.py
@@ -386,7 +386,7 @@ def mag_observation(P,state,R_to_body,i,ib):
 
     mag_code_generator.close()
 
-    # calculate a combined set of equations for a possible reduction in operations, but will use slighlty more stack
+    # calculate a combined set of equations for a possible reduction in operations, but will use slightly more stack
     equations = generate_observation_vector_equations(P,state,m_mag,obs_var,3)
 
     mag_code_generator_alt  = CodeGenerator("./generated/3Dmag_generated_alt.cpp")

--- a/libraries/AP_NavEKF3/derivation/generate_2.py
+++ b/libraries/AP_NavEKF3/derivation/generate_2.py
@@ -373,7 +373,7 @@ def mag_observation(P,state,R_to_body,i,ib):
 
     mag_code_generator.close()
 
-    # calculate a combined set of equations for a possible reduction in operations, but will use slighlty more stack
+    # calculate a combined set of equations for a possible reduction in operations, but will use slightly more stack
     equations = generate_observation_vector_equations(P,state,m_mag,obs_var,3)
 
     mag_code_generator_alt  = CodeGenerator("./generated/3Dmag_generated_alt.cpp")

--- a/libraries/SITL/examples/Webots_Python/scripts/example_aruco_detection.py
+++ b/libraries/SITL/examples/Webots_Python/scripts/example_aruco_detection.py
@@ -2,7 +2,7 @@
 
 #
 # An example script that receives images from a WebotsArduVehicle on port 5599 
-# and displays them overlayed with any ArUco markers using OpenCV.
+# and displays them overlaid with any ArUco markers using OpenCV.
 # Requires opencv-python (`pip3 install opencv-python`)
 #
 


### PR DESCRIPTION
```
codespell **/*.py  --write-changes \
  --ignore-words-list=afile,bodgy,chek,commitish,edn,empy,finis,fram,mot,ned,parm,parms,rin,ser,sitl,siz
```
https://pypi.org/project/codespell