### PR TITLE
AP_Logger: Ensure that the units are specified accurately

### DIFF
--- a/Tools/autotest/param_metadata/param.py
+++ b/Tools/autotest/param_metadata/param.py
@@ -118,6 +118,7 @@ known_units = {
 # compound
 
              'kB'      : 'kilobytes'               ,
+             'KiB'     : 'kibibytes',
              'MB'      : 'megabyte'                ,
              'm.m/s/s' : 'square meter per square second',
              'deg/m/s' : 'degrees per meter per second'  ,

--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -101,9 +101,9 @@ const AP_Param::GroupInfo AP_Logger::var_info[] = {
     AP_GROUPINFO("_BACKEND_TYPE",  0, AP_Logger, _params.backend_types,       uint8_t(HAL_LOGGING_BACKENDS_DEFAULT)),
 
     // @Param: _FILE_BUFSIZE
-    // @DisplayName: Logging File and Block Backend buffer size max (in kilobytes)
+    // @DisplayName: Logging File and Block Backend buffer size max (in kibibytes)
     // @Description: The File and Block backends use a buffer to store data before writing to the block device.  Raising this value may reduce "gaps" in your SD card logging but increases memory usage.  This buffer size may be reduced to free up available memory
-    // @Units: kB
+    // @Units: KiB
     // @Range: 4 200
     // @User: Standard
     AP_GROUPINFO("_FILE_BUFSIZE",  1, AP_Logger, _params.file_bufsize,       HAL_LOGGING_FILE_BUFSIZE),


### PR DESCRIPTION
This value is converted to bytes using 1024 as the divisor. Therefore, the unit is KiB.

WIKI:
https://en.wikipedia.org/wiki/Kilobyte