### PR TITLE
AP_Mount: XFRobot pic-in-pic switch

### DIFF
--- a/libraries/AP_Mount/AP_Mount_XFRobot.cpp
+++ b/libraries/AP_Mount/AP_Mount_XFRobot.cpp
@@ -222,6 +222,12 @@ bool AP_Mount_XFRobot::take_picture()
     return send_simple_command(FunctionOrder::SHUTTER, 0x01);
 }
 
+//cycle pic-in-pic
+bool AP_Mount_XFRobot::set_lens(uint8_t lens)
+{
+    return send_simple_command(FunctionOrder::PIC_IN_PIC, 0x00);
+}
+
 // start or stop video recording.  returns true on success
 // set start_recording = true to start record, false to stop recording
 bool AP_Mount_XFRobot::record_video(bool start_recording)

--- a/libraries/AP_Mount/AP_Mount_XFRobot.h
+++ b/libraries/AP_Mount/AP_Mount_XFRobot.h
@@ -48,6 +48,9 @@ public:
     // set zoom specified as a rate or percentage
     bool set_zoom(ZoomType zoom_type, float zoom_value) override;
 
+    // set camera lens to cycle through pic-in-pic modes
+    bool set_lens(uint8_t lens) override;
+
     // set focus specified as rate, percentage or auto
     // focus in = -1, focus hold = 0, focus out = 1
     SetFocusResult set_focus(FocusType focus_type, float focus_value) override;


### PR DESCRIPTION
Adds capability of toggling between pic-in-pic modes using camera lens auxiliary function.
Tested on XF-Robot Z-2 micro gimbal
