### PR TITLE
AP_HAL_ESP32: esp32nick - clean up hwdef

### DIFF
--- a/libraries/AP_HAL_ESP32/boards/esp32nick.h
+++ b/libraries/AP_HAL_ESP32/boards/esp32nick.h
@@ -15,12 +15,10 @@
 #pragma once
 
 #define HAL_ESP32_BOARD_NAME "esp32-nick"
-// CONFIG_HAL_BOARD_SUBTYPE HAL_BOARD_SUBTYPE_ESP32_NICK
+#define CONFIG_HAL_BOARD_SUBTYPE HAL_BOARD_SUBTYPE_ESP32_NICK
 
-#define TRUE						1
-#define FALSE						0
-
-// make sensor selection clearer
+//some helper macros
+//---make sensor selection clearer
 #define PROBE_IMU_I2C(driver, bus, addr, args ...) ADD_BACKEND(AP_InertialSensor_ ## driver::probe(*this,GET_I2C_DEVICE(bus, addr),##args))
 #define PROBE_IMU_SPI(driver, devname, args ...) ADD_BACKEND(AP_InertialSensor_ ## driver::probe(*this,hal.spi->get_device(devname),##args))
 #define PROBE_IMU_SPI2(driver, devname1, devname2, args ...) ADD_BACKEND(AP_InertialSensor_ ## driver::probe(*this,hal.spi->get_device(devname1),hal.spi->get_device(devname2),##args))
@@ -32,45 +30,57 @@
 #define PROBE_MAG_SPI(driver, devname, args ...) ADD_BACKEND(DRIVER_ ##driver, AP_Compass_ ## driver::probe(hal.spi->get_device(devname),##args))
 #define PROBE_MAG_IMU(driver, imudev, imu_instance, args ...) ADD_BACKEND(DRIVER_ ##driver, AP_Compass_ ## driver::probe_ ## imudev(imu_instance,##args))
 #define PROBE_MAG_IMU_I2C(driver, imudev, bus, addr, args ...) ADD_BACKEND(DRIVER_ ##driver, AP_Compass_ ## driver::probe_ ## imudev(GET_I2C_DEVICE(bus,addr),##args))
-//------------------------------------
 
-#define CONFIG_HAL_BOARD_SUBTYPE HAL_BOARD_SUBTYPE_ESP32_NICK
+//---readability
+#define TRUE					1
+#define FALSE					0
+#define WIFI_TYPE_TCP			1
+#define WIFI_TYPE_UDP			2
+#define ADC1_GAIN 				11
+//---auto wifi ssid from board name
+#define WIFI_CONCAT(x, y) x y
+#define WIFI_PREFIX 			"ardupilot-"
+#define WIFI_SUFFIX 			HAL_ESP32_BOARD_NAME
+#define WIFI_SSID_NAME 			WIFI_CONCAT(WIFI_PREFIX, WIFI_SUFFIX)
 
 //-----INS/IMU-----
-#define HAL_INS_DEFAULT HAL_INS_MPU9250_SPI
-#define HAL_INS_MPU9250_NAME "mpu9250"
+#define HAL_INS_DEFAULT 		HAL_INS_MPU9250_SPI
+#define HAL_INS_MPU9250_NAME 	"mpu9250"
 #define HAL_INS_PROBE_LIST PROBE_IMU_SPI( Invensense, HAL_INS_MPU9250_NAME, ROTATION_NONE)
 
 // -----BARO-----
-#define HAL_BARO_DEFAULT HAL_BARO_BMP280_SPI
-#define HAL_BARO_BMP280_NAME "BMP280"
+#define HAL_BARO_DEFAULT 		HAL_BARO_BMP280_SPI
+#define HAL_BARO_BMP280_NAME 	"BMP280"
 #define HAL_BARO_PROBE_LIST PROBE_BARO_SPI(BMP280, "bmp280")
+
 // allow boot without a baro
-#define HAL_BARO_ALLOW_INIT_NO_BARO 1
+#define HAL_BARO_ALLOW_INIT_NO_BARO TRUE
 
 //-----ADC-----
-#define HAL_USE_ADC TRUE
+#define HAL_USE_ADC 			TRUE
 
 // 	pin number,
 //	gain/multiplier,
 //	the ardupilot name for the pin in parameter/s.
 #define HAL_ESP32_ADC_PINS {\
-	{ADC1_GPIO35_CHANNEL, 11, 34},\
-	{ADC1_GPIO34_CHANNEL, 11, 35},\
-	{ADC1_GPIO39_CHANNEL, 11, 39},\
-	{ADC1_GPIO36_CHANNEL, 11, 36}\
+	{ADC1_GPIO34_CHANNEL, ADC1_GAIN, 34},\
+	{ADC1_GPIO35_CHANNEL, ADC1_GAIN, 35},\
+	{ADC1_GPIO39_CHANNEL, ADC1_GAIN, 39},\
+	{ADC1_GPIO36_CHANNEL, ADC1_GAIN, 36}\
 }
 
 //-----COMPASS-----
 #define HAL_MAG_PROBE_LIST PROBE_MAG_IMU(AK8963, mpu9250, 0, ROTATION_NONE)
-#define HAL_PROBE_EXTERNAL_I2C_COMPASSES 1
-#define ALLOW_ARM_NO_COMPASS				1
-#define AP_COMPASS_AK8963_ENABLED TRUE
-//-----WIFI-----
+#define HAL_PROBE_EXTERNAL_I2C_COMPASSES 	TRUE
+#define ALLOW_ARM_NO_COMPASS 				TRUE
+#define AP_COMPASS_AK8963_ENABLED 			TRUE
+#define HAL_COMPASS_DEFAULT 				HAL_COMPASS_AK8963_MPU9250
 
-#define HAL_ESP32_WIFI 1  // 2 use udp, 1 use tcp
-#define WIFI_SSID "ardupilot123"
-#define WIFI_PWD "ardupilot123"
+//-----WIFI-----
+#define HAL_ESP32_WIFI 	WIFI_TYPE_UDP
+
+#define WIFI_SSID 		WIFI_SSID_NAME // ardupilot-<HAL_ESP32_BOARD_NAME>
+#define WIFI_PWD  		"ardupilot123"
 
 //-----RCOUT-----
 #define HAL_ESP32_RCOUT { \
@@ -94,31 +104,35 @@
 	{.port=I2C_NUM_0, .sda=GPIO_NUM_13, .scl=GPIO_NUM_12, .speed=400*KHZ, .internal=true}
 
 //-----RCIN-----
-#define HAL_ESP32_RCIN GPIO_NUM_4
-//RMT pin number
-#define HAL_ESP32_RMT_RX_PIN_NUMBER			4
+#define HAL_ESP32_RCIN 					GPIO_NUM_4
+#define HAL_ESP32_RMT_RX_PIN_NUMBER		GPIO_NUM_4
+
 //-----UARTS-----
 #define HAL_ESP32_UART_DEVICES \
-  {.port=UART_NUM_0, .rx=GPIO_NUM_3, .tx=GPIO_NUM_1 } \
-  ,{.port=UART_NUM_1, .rx=GPIO_NUM_16, .tx=GPIO_NUM_17 }
+  {	.port=UART_NUM_0, .rx=GPIO_NUM_3, 	.tx=GPIO_NUM_1 } \
+  ,{.port=UART_NUM_1, .rx=GPIO_NUM_16, 	.tx=GPIO_NUM_17 }
 
 //FILESYSTEM SUPPORT
-#define HAVE_FILESYSTEM_SUPPORT 1
-#define HAL_OS_POSIX_IO 1
-#define HAL_BOARD_STORAGE_DIRECTORY "/SDCARD/APM/STORAGE"
-#define HAL_ESP32_SDMMC 1
-#define HAL_ESP32_SDCARD 1
+#define HAVE_FILESYSTEM_SUPPORT 		TRUE
+#define HAL_OS_POSIX_IO 				TRUE
+#define HAL_BOARD_STORAGE_DIRECTORY 	"/SDCARD/APM/STORAGE"
+#define HAL_ESP32_SDMMC 				TRUE
+#define HAL_ESP32_SDCARD 				TRUE
 
 //LOGGING
-#define HAL_BOARD_LOG_DIRECTORY "/SDCARD/APM/LOGS"
-#define LOGGER_MAVLINK_SUPPORT 1
-#define HAL_LOGGING_BACKENDS_DEFAULT 1
-#define HAL_LOGGING_DATAFLASH_ENABLED			0
-#define HAL_LOGGING_MAVLINK_ENABLED			0
+#define HAL_BOARD_LOG_DIRECTORY 		"/SDCARD/APM/LOGS"
+#define LOGGER_MAVLINK_SUPPORT 			TRUE
+#define HAL_LOGGING_BACKENDS_DEFAULT 	TRUE
+#define HAL_LOGGING_DATAFLASH_ENABLED	FALSE
+#define HAL_LOGGING_MAVLINK_ENABLED		FALSE
+
 //TERRAIN
-#define HAL_BOARD_TERRAIN_DIRECTORY "/SDCARD/APM/TERRAIN"
+#define HAL_BOARD_TERRAIN_DIRECTORY 	"/SDCARD/APM/TERRAIN"
 
 // see boards.py
 #ifndef ENABLE_HEAP
-#define ENABLE_HEAP 1
+#define ENABLE_HEAP TRUE
 #endif
+
+//OTHER DEFAULTS
+#define AP_SCRIPTING_ENABLED 			FALSE


### PR DESCRIPTION
some general cleanup of the hwdef for my classic esp32 board.

explicitly no scripting

move board subtype to top

use defines instead of magic numbers

general formatting update

change to udp from tcpip 

auto wifi ssid name from board name

fix adc channels