### PR TITLE
Plane: fixed fence re-enable after fence breach

### DIFF
--- a/Tools/environment_install/install-prereqs-mac.sh
+++ b/Tools/environment_install/install-prereqs-mac.sh
@@ -172,7 +172,7 @@ if [[ $SKIP_AP_GRAPHIC_ENV -ne 1 ]]; then
 fi
 
 $PIP install --upgrade pip
-$PIP install wheel
+$PIP install --force-reinstall wheel
 $PIP install $PYTHON_PKGS
 
 echo "Adding ArduPilot Tools to environment"

--- a/libraries/AP_Vehicle/ModeReason.h
+++ b/libraries/AP_Vehicle/ModeReason.h
@@ -72,4 +72,5 @@ enum class ModeReason : uint8_t {
   DDS_COMMAND = 52,
   AUX_FUNCTION = 53,
   FIXED_WING_AUTOLAND = 54,
+  FENCE_REENABLE = 55,
 };


### PR DESCRIPTION
If after a fence breach the user commands a WP change to a WP not in the landing sequence in AUTO mode or disables and re-enables the fence then the fence should be re-activated
