### PR TITLE
waf: Delete `.pydevproject` with legacy Python 2

### DIFF
--- a/.pydevproject
+++ b/.pydevproject
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?eclipse-pydev version="1.0"?><pydev_project>
-<pydev_property name="org.python.pydev.PYTHON_PROJECT_INTERPRETER">Default</pydev_property>
-<pydev_property name="org.python.pydev.PYTHON_PROJECT_VERSION">python 2.7</pydev_property>
-</pydev_project>


### PR DESCRIPTION
Last modified 11 years ago...
```diff
- <?xml version="1.0" encoding="UTF-8" standalone="no"?>
- <?eclipse-pydev version="1.0"?><pydev_project>
- <pydev_property name="org.python.pydev.PYTHON_PROJECT_INTERPRETER">Default</pydev_property>
- <pydev_property name="org.python.pydev.PYTHON_PROJECT_VERSION">python 2.7</pydev_property>
- </pydev_project>
```
Python 2 died 1,925 days ago on 1/1/2020.

Files modified in the root directory should have a git commit prefix of `waf:`.
* https://github.com/ArduPilot/ardupilot/pull/29733#issuecomment-2791726204