### PR TITLE
Correct default OSD types

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/ARK_FPV/defaults.parm
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ARK_FPV/defaults.parm
@@ -1,5 +1,3 @@
 # CAN
 CAN_P1_DRIVER 1  # Enables the use of CAN
 
-# Onboard OSD
-OSD_TYPE 5 # MSP

--- a/libraries/AP_HAL_ChibiOS/hwdef/BROTHERHOBBYH743/defaults.parm
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BROTHERHOBBYH743/defaults.parm
@@ -3,3 +3,6 @@ RELAY2_DEFAULT 1
 
 # Default CAM to first camera
 RELAY3_DEFAULT 0
+
+#Enable DisplayPort OSD
+OSD_TYPE2 5

--- a/libraries/AP_HAL_ChibiOS/hwdef/BROTHERHOBBYH743/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BROTHERHOBBYH743/hwdef.dat
@@ -196,5 +196,5 @@ define HAL_OS_FATFS_IO 1
 
 # setup for OSD
 define OSD_ENABLED 1
-define HAL_OSD_TYPE_DEFAULT 5
+define HAL_OSD_TYPE_DEFAULT 1
 ROMFS_WILDCARD libraries/AP_OSD/fonts/font*.bin

--- a/libraries/AP_HAL_ChibiOS/hwdef/LumenierLUXF765-NDAA/defaults.parm
+++ b/libraries/AP_HAL_ChibiOS/hwdef/LumenierLUXF765-NDAA/defaults.parm
@@ -1,0 +1,2 @@
+#Enable DisplayPort OSD
+OSD_TYPE2 5

--- a/libraries/AP_HAL_ChibiOS/hwdef/LumenierLUXF765-NDAA/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/LumenierLUXF765-NDAA/hwdef.dat
@@ -183,5 +183,5 @@ define HAL_STORAGE_SIZE 16384
 
 # setup for OSD
 define OSD_ENABLED 1
-define HAL_OSD_TYPE_DEFAULT 5
+define HAL_OSD_TYPE_DEFAULT 1
 ROMFS_WILDCARD libraries/AP_OSD/fonts/font0.bin

--- a/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743-AIO/defaults.parm
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743-AIO/defaults.parm
@@ -1,0 +1,2 @@
+#Enable DisplayPort OSD
+OSD_TYPE2 5

--- a/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743-AIO/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743-AIO/hwdef.dat
@@ -154,7 +154,7 @@ define DEFAULT_SERIAL6_PROTOCOL SerialProtocol_ESCTelemetry
 
 # setup for OSD
 define OSD_ENABLED 1
-define HAL_OSD_TYPE_DEFAULT 5
+define HAL_OSD_TYPE_DEFAULT 1
 
 # setup for BF migration
 define HAL_FRAME_TYPE_DEFAULT 12

--- a/libraries/AP_HAL_ChibiOS/hwdef/StellarF4/defaults.parm
+++ b/libraries/AP_HAL_ChibiOS/hwdef/StellarF4/defaults.parm
@@ -1,0 +1,2 @@
+#Enable DisplayPort OSD
+OSD_TYPE2 5

--- a/libraries/AP_HAL_ChibiOS/hwdef/StellarF4/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/StellarF4/hwdef.dat
@@ -143,7 +143,7 @@ STORAGE_FLASH_PAGE 1
 
 # setup for OSD
 define OSD_ENABLED 1
-define HAL_OSD_TYPE_DEFAULT 5
+define HAL_OSD_TYPE_DEFAULT 1
 ROMFS_WILDCARD libraries/AP_OSD/fonts/font*.bin
 
 # minimal drivers to reduce flash usage

--- a/libraries/AP_HAL_ChibiOS/hwdef/StellarF4V2/defaults.parm
+++ b/libraries/AP_HAL_ChibiOS/hwdef/StellarF4V2/defaults.parm
@@ -1,0 +1,2 @@
+#Enable DisplayPort OSD
+OSD_TYPE2 5

--- a/libraries/AP_HAL_ChibiOS/hwdef/StellarF4V2/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/StellarF4V2/hwdef.dat
@@ -135,7 +135,7 @@ STORAGE_FLASH_PAGE 1
 
 # setup for OSD
 define OSD_ENABLED 1
-define HAL_OSD_TYPE_DEFAULT 5
+define HAL_OSD_TYPE_DEFAULT 1
 ROMFS_WILDCARD libraries/AP_OSD/fonts/font*.bin
 
 # minimal drivers to reduce flash usage

--- a/libraries/AP_HAL_ChibiOS/hwdef/X-MAV-AP-H743v2/defaults.parm
+++ b/libraries/AP_HAL_ChibiOS/hwdef/X-MAV-AP-H743v2/defaults.parm
@@ -1,0 +1,2 @@
+#Enable DisplayPort OSD
+OSD_TYPE2 5

--- a/libraries/AP_HAL_ChibiOS/hwdef/X-MAV-AP-H743v2/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/X-MAV-AP-H743v2/hwdef.dat
@@ -180,5 +180,5 @@ define DEFAULT_SERIAL8_PROTOCOL SerialProtocol_ESCTelemetry
 
 # setup for OSD
 define OSD_ENABLED 1
-define HAL_OSD_TYPE_DEFAULT 5
+define HAL_OSD_TYPE_DEFAULT 1
 ROMFS_WILDCARD libraries/AP_OSD/fonts/font*.bin


### PR DESCRIPTION
I misunderstood (or forgot) that osd type 5 does not automatically include the analog OSD
in fact, the analog OSD includes MSP type (3) when enabled

this corrects any hwdefs that have both analog OSD and DisplayPort defaults to set OSD type to 1
will also update their wiki pages (including pending for 4.7) to say to enable OSD_TYPE2 to 5

also noted that some bds with no analog OSD define OSD_TYPE 5 correctly in hwdef but also duplicate in their params file, fixed it here also