### PR TITLE
AP_HAL_Linux: ease access to verbose output by outputting on stdout aswell

### DIFF
--- a/libraries/AP_HAL/utility/BetterStream.cpp
+++ b/libraries/AP_HAL/utility/BetterStream.cpp
@@ -1,6 +1,11 @@
 #include "BetterStream.h"
+#include <AP_HAL/AP_HAL.h>
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
+#include <cstdio>
+#endif
 #include "print_vprintf.h"
+
 
 void AP_HAL::BetterStream::printf(const char *fmt, ...)
 {
@@ -13,6 +18,9 @@ void AP_HAL::BetterStream::printf(const char *fmt, ...)
 void AP_HAL::BetterStream::vprintf(const char *fmt, va_list ap)
 {
     print_vprintf(this, fmt, ap);
+#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
+    std::vprintf(fmt, ap);
+#endif
 }
 
 size_t AP_HAL::BetterStream::write(const char *str)

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -27,6 +27,10 @@
 
 extern const AP_HAL::HAL& hal;
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
+#include <cstdio>
+#endif
+
 #ifndef MAV_SYSID_DEFAULT
 #if APM_BUILD_TYPE(APM_BUILD_AntennaTracker)
 #define MAV_SYSID_DEFAULT 2
@@ -177,6 +181,40 @@ void GCS::send_text(MAV_SEVERITY severity, const char *fmt, ...)
     va_list arg_list;
     va_start(arg_list, fmt);
     send_textv(severity, fmt, arg_list);
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
+    switch(severity) {
+        case MAV_SEVERITY_EMERGENCY:
+            std::printf("EMERGENCY: ");
+            break;
+        case MAV_SEVERITY_ALERT:
+            std::printf("ALERT: ");
+            break;
+        case MAV_SEVERITY_CRITICAL:
+            std::printf("CRITICAL: ");
+            break;
+        case MAV_SEVERITY_ERROR:
+            std::printf("ERROR: ");
+            break;
+        case MAV_SEVERITY_WARNING:
+            std::printf("WARNING: ");
+            break;
+        case MAV_SEVERITY_NOTICE:
+            std::printf("NOTICE: ");
+            break;
+        case MAV_SEVERITY_INFO:
+            std::printf("INFO: ");
+            break;
+        case MAV_SEVERITY_DEBUG:
+            std::printf("DEBUG: ");
+            break;
+        default:
+            break;
+    }
+    std::vprintf(fmt, arg_list);
+    std::printf("\n");
+#endif
+
     va_end(arg_list);
 }
 


### PR DESCRIPTION
...because, why not? There's a lot of useful info that's not easily accessible (for obvious reasons). On linux, we got stdout & stderr with pipes and everything.

While this naive attempt is useful for my debugging purposes, it should be seen more as a RFC than as PR.

At least the `#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX` should probably be replaced by something like `CONFIG_USE_STDOUT` and set for boards that support it. But I'm not sure of an optimal solution and would kindly ask for advice from ppl with deeper knowledge of the codebase.

Maybe this could be done cleanly and at more places that output status messages, since I think it's *really* useful for debugging and it's basically free.