### PR TITLE
AP_NavEKF: Allow EK3 cores to run different sources

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -2867,6 +2867,76 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         raise NotAchievedException("AUTOTUNE failed (%u seconds)" %
                                    (self.get_sim_time() - tstart))
 
+    def EKF3SRCPerCore(self):
+        '''Check SP/SH values in XKF4 for GPS (core 0) vs VICON (core 1) with targeted glitches.'''
+        self.set_parameters({
+            "EK3_ENABLE": 1,
+            "AHRS_EKF_TYPE": 3,
+            "VISO_TYPE": 1,
+            "SERIAL5_PROTOCOL": 2,
+            "EK3_SRC2_POSXY": 6,
+            "EK3_SRC2_VELXY": 6,
+            "EK3_SRC2_POSZ": 6,
+            "EK3_SRC2_VELZ": 6,
+            "EK3_SRC_OPTIONS": 8  # bitmask: enable multiple EKF cores
+        })
+
+        self.customise_SITL_commandline(["--serial5=sim:vicon"])
+        self.reboot_sitl()
+
+        self.wait_ready_to_arm()
+        self.takeoff(3)
+        self.delay_sim_time(5)
+
+        self.progress("Injecting VICON glitch")
+        self.set_parameter("SIM_VICON_GLIT_X", 100)
+        self.set_parameter("SIM_VICON_GLIT_Y", 100)
+        self.delay_sim_time(5)
+        self.set_parameter("SIM_VICON_GLIT_X", 0)
+        self.set_parameter("SIM_VICON_GLIT_Y", 0)
+
+        self.progress("Injecting BARO glitch")
+        self.set_parameter("SIM_BARO_GLITCH", 10)
+        self.delay_sim_time(5)
+        self.set_parameter("SIM_BARO_GLITCH", 0)
+
+        self.do_RTL()
+        self.wait_disarmed(timeout=100)
+
+        dfreader = self.dfreader_for_current_onboard_log()
+
+        max_SP_core0 = 0
+        max_SP_core1 = 0
+        max_SH_core0 = 0
+        max_SH_core1 = 0
+
+        while True:
+            m = dfreader.recv_match(type="XKF4")
+            if m is None:
+                break
+            if not hasattr(m, "C"):
+                continue
+            if m.C == 0:
+                max_SP_core0 = max(max_SP_core0, m.SP)
+                max_SH_core0 = max(max_SH_core0, m.SH)
+            elif m.C == 1:
+                max_SP_core1 = max(max_SP_core1, m.SP)
+                max_SH_core1 = max(max_SH_core1, m.SH)
+
+        self.progress(f"Core 0 (GPS): SP={max_SP_core0:.2f}, SH={max_SH_core0:.2f}")
+        self.progress(f"Core 1 (VICON): SP={max_SP_core1:.2f}, SH={max_SH_core1:.2f}")
+
+        # Validate: horizontal glitch only on core 1, vertical glitch only on core 0
+        if max_SP_core0 > 0.1:
+            raise NotAchievedException("Unexpected high SP in core 0 (GPS) during VICON glitch")
+        if max_SP_core1 < 0.9:
+            raise NotAchievedException("VICON glitch did not raise SP in core 1")
+
+        if max_SH_core1 > 0.5:
+            raise NotAchievedException("Unexpected high SH in core 1 (VICON) during BARO glitch")
+        if max_SH_core0 < 0.9:
+            raise NotAchievedException("BARO glitch did not raise SH in core 0")
+
     def AutoTuneSwitch(self):
         """Test autotune on a switch with gains being saved"""
 
@@ -13413,6 +13483,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             self.CompassLearnCopyFromEKF,
             self.AHRSAutoTrim,
             self.Ch6TuningLoitMaxXYSpeed,
+            self.EKF3SRCPerCore,
         ])
         return ret
 

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
@@ -135,7 +135,7 @@ const AP_Param::GroupInfo AP_NavEKF_Source::var_info[] = {
     // @Param: _OPTIONS
     // @DisplayName: EKF Source Options
     // @Description: EKF Source Options
-    // @Bitmask: 0:FuseAllVelocities, 1:AlignExtNavPosWhenUsingOptFlow
+    // @Bitmask: 0:FuseAllVelocities, 1:AlignExtNavPosWhenUsingOptFlow, 2: Reserved , 3: Use SRC per core
     // @User: Advanced
     AP_GROUPINFO("_OPTIONS", 16, AP_NavEKF_Source, _options, (int16_t)SourceOptions::FUSE_ALL_VELOCITIES),
 
@@ -165,9 +165,9 @@ void AP_NavEKF_Source::setPosVelYawSourceSet(AP_NavEKF_Source::SourceSetSelectio
 }
 
 // true/false of whether velocity source should be used
-bool AP_NavEKF_Source::useVelXYSource(SourceXY velxy_source) const
+bool AP_NavEKF_Source::useVelXYSource(SourceXY velxy_source, uint8_t core_number) const
 {
-    if (velxy_source == _source_set[active_source_set].velxy) {
+    if (velxy_source == _source_set[getActiveSourceSet(core_number)].velxy) {
         return true;
     }
 
@@ -184,9 +184,9 @@ bool AP_NavEKF_Source::useVelXYSource(SourceXY velxy_source) const
     return false;
 }
 
-bool AP_NavEKF_Source::useVelZSource(SourceZ velz_source) const
+bool AP_NavEKF_Source::useVelZSource(SourceZ velz_source, uint8_t core_number) const
 {
-    if (velz_source == _source_set[active_source_set].velz) {
+    if (velz_source == _source_set[getActiveSourceSet(core_number)].velz) {
         return true;
     }
 
@@ -204,9 +204,9 @@ bool AP_NavEKF_Source::useVelZSource(SourceZ velz_source) const
 }
 
 // true if a velocity source is configured
-bool AP_NavEKF_Source::haveVelZSource() const
+bool AP_NavEKF_Source::haveVelZSource(uint8_t core_number) const
 {
-    if (_source_set[active_source_set].velz != SourceZ::NONE) {
+    if (_source_set[getActiveSourceSet(core_number)].velz != SourceZ::NONE) {
         return true;
     }
 
@@ -224,10 +224,10 @@ bool AP_NavEKF_Source::haveVelZSource() const
 }
 
 // get yaw source
-AP_NavEKF_Source::SourceYaw AP_NavEKF_Source::getYawSource() const
+AP_NavEKF_Source::SourceYaw AP_NavEKF_Source::getYawSource(uint8_t core_number) const
 {
     // check for special case of disabled compasses
-    if ((_source_set[active_source_set].yaw == SourceYaw::COMPASS) && (AP::dal().compass().get_num_enabled() == 0)) {
+    if ((_source_set[getActiveSourceSet(core_number)].yaw == SourceYaw::COMPASS) && (AP::dal().compass().get_num_enabled() == 0)) {
         return SourceYaw::NONE;
     }
 
@@ -235,19 +235,19 @@ AP_NavEKF_Source::SourceYaw AP_NavEKF_Source::getYawSource() const
 }
 
 // get pos Z source
-AP_NavEKF_Source::SourceZ AP_NavEKF_Source::getPosZSource() const
+AP_NavEKF_Source::SourceZ AP_NavEKF_Source::getPosZSource(uint8_t core_number) const
 {
 #ifdef HAL_BARO_ALLOW_INIT_NO_BARO
     // check for special case of missing baro
-    if ((_source_set[active_source_set].posz == SourceZ::BARO) && (AP::dal().baro().num_instances() == 0)) {
+    if ((_source_set[getActiveSourceSet(core_number)].posz == SourceZ::BARO) && (AP::dal().baro().num_instances() == 0)) {
         return SourceZ::NONE;
     }
 #endif
-    return _source_set[active_source_set].posz;
+    return _source_set[getActiveSourceSet(core_number)].posz;
 }
 
 // align position of inactive sources to ahrs
-void AP_NavEKF_Source::align_inactive_sources()
+void AP_NavEKF_Source::align_inactive_sources(uint8_t core_number)
 {
     // align visual odometry
 #if HAL_VISUALODOM_ENABLED
@@ -259,9 +259,9 @@ void AP_NavEKF_Source::align_inactive_sources()
 
     // consider aligning ExtNav XY position:
     bool align_posxy = false;
-    if ((getPosXYSource() == SourceXY::GPS) ||
-        (getPosXYSource() == SourceXY::BEACON) ||
-        ((getVelXYSource() == SourceXY::OPTFLOW) && option_is_set(SourceOptions::ALIGN_EXTNAV_POS_WHEN_USING_OPTFLOW))) {
+    if ((getPosXYSource(core_number) == SourceXY::GPS) ||
+        (getPosXYSource(core_number) == SourceXY::BEACON) ||
+        ((getVelXYSource(core_number) == SourceXY::OPTFLOW) && option_is_set(SourceOptions::ALIGN_EXTNAV_POS_WHEN_USING_OPTFLOW))) {
         // align ExtNav position if active source is GPS, Beacon or (optionally) Optflow
         for (uint8_t i=0; i<AP_NAKEKF_SOURCE_SET_MAX; i++) {
             if (_source_set[i].posxy == SourceXY::EXTNAV) {
@@ -274,10 +274,10 @@ void AP_NavEKF_Source::align_inactive_sources()
 
     // consider aligning Z position:
     bool align_posz = false;
-    if ((getPosZSource() == SourceZ::BARO) ||
-        (getPosZSource() == SourceZ::RANGEFINDER) ||
-        (getPosZSource() == SourceZ::GPS) ||
-        (getPosZSource() == SourceZ::BEACON)) {
+    if ((getPosZSource(core_number) == SourceZ::BARO) ||
+        (getPosZSource(core_number) == SourceZ::RANGEFINDER) ||
+        (getPosZSource(core_number) == SourceZ::GPS) ||
+        (getPosZSource(core_number) == SourceZ::BEACON)) {
         // ExtNav is not the active source; we do not want to align active source!
         for (uint8_t i=0; i<AP_NAKEKF_SOURCE_SET_MAX; i++) {
             if (_source_set[i].posz == SourceZ::EXTNAV) {
@@ -292,13 +292,13 @@ void AP_NavEKF_Source::align_inactive_sources()
 }
 
 // sensor specific helper functions
-bool AP_NavEKF_Source::usingGPS() const
+bool AP_NavEKF_Source::usingGPS(uint8_t core_number) const
 {
-    return getPosXYSource() == SourceXY::GPS ||
-           getPosZSource() == SourceZ::GPS ||
-           getVelXYSource() == SourceXY::GPS ||
-           getVelZSource() == SourceZ::GPS ||
-           getYawSource() == SourceYaw::GSF;
+    return getPosXYSource(core_number) == SourceXY::GPS ||
+           getPosZSource(core_number) == SourceZ::GPS ||
+           getVelXYSource(core_number) == SourceXY::GPS ||
+           getVelZSource(core_number) == SourceZ::GPS ||
+           getYawSource(core_number) == SourceYaw::GSF;
 }
 
 // true if some parameters have been configured (used during parameter conversion)

--- a/libraries/AP_NavEKF/AP_NavEKF_Source.h
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.h
@@ -48,7 +48,8 @@ public:
     // enum for OPTIONS parameter
     enum class SourceOptions {
         FUSE_ALL_VELOCITIES = (1 << 0),                 // fuse all velocities configured in source sets
-        ALIGN_EXTNAV_POS_WHEN_USING_OPTFLOW = (1 << 1)  // align position of inactive sources to ahrs when using optical flow
+        ALIGN_EXTNAV_POS_WHEN_USING_OPTFLOW = (1 << 1),  // align position of inactive sources to ahrs when using optical flow
+        SRC_PER_CORE = (1 << 3)                         // use a separate source set for each core
     };
 
     enum class SourceSetSelection : uint8_t {
@@ -60,35 +61,48 @@ public:
     // initialisation
     void init();
 
+    uint8_t getActiveSourceSet(uint8_t core_number) const {
+        // check if we are using a separate source set for each core
+        if (_options.get() & int16_t(SourceOptions::SRC_PER_CORE)) {
+            if (core_number >= AP_NAKEKF_SOURCE_SET_MAX) {
+                // this is a bit of a hack, but we need to return a valid source set
+                return active_source_set;
+            }
+            return core_number;
+        }
+        return active_source_set;
+     }
+
     // get current position source
-    SourceXY getPosXYSource() const { return _source_set[active_source_set].posxy; }
-    SourceZ getPosZSource() const;
+    SourceXY getPosXYSource(uint8_t core_number) const { return _source_set[getActiveSourceSet(core_number)].posxy; }
+
+    SourceZ getPosZSource(uint8_t core_number) const;
 
     // set position, velocity and yaw sources to either 0=primary, 1=secondary, 2=tertiary
     void setPosVelYawSourceSet(SourceSetSelection source_set_idx);
     uint8_t getPosVelYawSourceSet() const { return active_source_set; }
 
     // get/set velocity source
-    SourceXY getVelXYSource() const { return _source_set[active_source_set].velxy; }
-    SourceZ getVelZSource() const { return _source_set[active_source_set].velz; }
+    SourceXY getVelXYSource(uint8_t core_number) const { return _source_set[getActiveSourceSet(core_number)].velxy; }
+    SourceZ getVelZSource(uint8_t core_number) const { return _source_set[getActiveSourceSet(core_number)].velz; }
 
     // true/false of whether velocity source should be used
-    bool useVelXYSource(SourceXY velxy_source) const;
-    bool useVelZSource(SourceZ velz_source) const;
+    bool useVelXYSource(SourceXY velxy_source, uint8_t core_number) const;
+    bool useVelZSource(SourceZ velz_source, uint8_t core_number) const;
 
     // true if a velocity source is configured
-    bool haveVelZSource() const;
+    bool haveVelZSource(uint8_t core_number) const;
 
     // get yaw source
-    SourceYaw getYawSource() const;
+    SourceYaw getYawSource(uint8_t core_number) const;
 
     // align position of inactive sources to ahrs
-    void align_inactive_sources();
+    void align_inactive_sources(uint8_t core_number);
 
     // sensor-specific helper functions
 
     // true if any source is GPS
-    bool usingGPS() const;
+    bool usingGPS(uint8_t core_number) const;
 
     // true if source parameters have been configured (used for parameter conversion)
     bool configured();

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -632,7 +632,7 @@ void NavEKF3_core::readGpsData()
     }
 
     // Check if GPS can output vertical velocity, vertical velocity use is permitted and set GPS fusion mode accordingly
-    if (gpsDataNew.have_vz && frontend->sources.useVelZSource(AP_NavEKF_Source::SourceZ::GPS)) {
+    if (gpsDataNew.have_vz && frontend->sources.useVelZSource(AP_NavEKF_Source::SourceZ::GPS, core_index)) {
         useGpsVertVel = true;
     } else {
         useGpsVertVel = false;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -59,7 +59,7 @@ void NavEKF3_core::SelectFlowFusion()
 
     // Fuse optical flow data into the main filter
     if (flowDataToFuse && tiltOK) {
-        const bool fuse_optflow = (frontend->_flowUse == FLOW_USE_NAV) && frontend->sources.useVelXYSource(AP_NavEKF_Source::SourceXY::OPTFLOW);
+        const bool fuse_optflow = (frontend->_flowUse == FLOW_USE_NAV) && frontend->sources.useVelXYSource(AP_NavEKF_Source::SourceXY::OPTFLOW, core_index);
         // Set the flow noise used by the fusion processes
         R_LOS = sq(MAX(frontend->_flowNoise, 0.05f));
         // Fuse the optical flow X and Y axis data into the main filter sequentially

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -44,7 +44,7 @@ bool NavEKF3_core::pre_arm_check(bool requires_position, char *failure_msg, uint
         const float max_vel_innovation = 2.0;
         const float hvel_innovation = sqrtf(sq(innovVelPos[0])+sq(innovVelPos[1]));
         if (onGround && PV_AidingMode == AID_ABSOLUTE &&
-            frontend->sources.useVelXYSource(AP_NavEKF_Source::SourceXY::GPS) &&
+            frontend->sources.useVelXYSource(AP_NavEKF_Source::SourceXY::GPS, core_index) &&
             hvel_innovation > max_vel_innovation) {
             // more than 2 m/s horizontal velocity innovation on the ground
             dal.snprintf(failure_msg, failure_msg_len,
@@ -91,7 +91,7 @@ float NavEKF3_core::errorScore() const
 bool NavEKF3_core::getHeightControlLimit(float &height) const
 {
     // only ask for limiting if we are doing optical flow navigation
-    if (frontend->sources.useVelXYSource(AP_NavEKF_Source::SourceXY::OPTFLOW) && (PV_AidingMode == AID_RELATIVE) && flowDataValid) {
+    if (frontend->sources.useVelXYSource(AP_NavEKF_Source::SourceXY::OPTFLOW, core_index) && (PV_AidingMode == AID_RELATIVE) && flowDataValid) {
         // If are doing optical flow nav, ensure the height above ground is within range finder limits after accounting for vehicle tilt and control errors
 #if AP_RANGEFINDER_ENABLED
         const auto *_rng = dal.rangefinder();
@@ -104,7 +104,7 @@ bool NavEKF3_core::getHeightControlLimit(float &height) const
         return false;
 #endif
         // If we are are not using the range finder as the height reference, then compensate for the difference between terrain and EKF origin
-        if (frontend->sources.getPosZSource() != AP_NavEKF_Source::SourceZ::RANGEFINDER) {
+        if (frontend->sources.getPosZSource(core_index) != AP_NavEKF_Source::SourceZ::RANGEFINDER) {
             height -= terrainState;
         }
         return true;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_RngBcnFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_RngBcnFusion.cpp
@@ -67,7 +67,7 @@ void NavEKF3_core::SelectRngBcnFusion()
     // Determine if we need to fuse range beacon data on this time step
     if (rngBcn.dataToFuse) {
         if (PV_AidingMode == AID_ABSOLUTE) {
-            if ((frontend->sources.getPosXYSource() == AP_NavEKF_Source::SourceXY::BEACON) && rngBcn.alignmentCompleted) {
+            if ((frontend->sources.getPosXYSource(core_index) == AP_NavEKF_Source::SourceXY::BEACON) && rngBcn.alignmentCompleted) {
                 if (!rngBcn.originEstInit) {
                     rngBcn.originEstInit = true;
                     rngBcn.posOffsetNED.x = rngBcn.receiverPos.x - stateStruct.position.x;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -47,7 +47,7 @@ bool NavEKF3_core::setup_core(uint8_t _imu_index, uint8_t _core_index)
                                   ))));
 
     // GPS sensing can have large delays and should not be included if disabled
-    if (frontend->sources.usingGPS()) {
+    if (frontend->sources.usingGPS(core_index)) {
         // Wait for the configuration of all GPS units to be confirmed. Until this has occurred the GPS driver cannot provide a correct time delay
         float gps_delay_sec = 0;
         if (!dal.gps().get_lag(selected_gps, gps_delay_sec)) {
@@ -544,8 +544,8 @@ bool NavEKF3_core::InitialiseFilterBootstrap(void)
     ResetHeight();
 
     // initialise sources
-    posxy_source_last = frontend->sources.getPosXYSource();
-    yaw_source_last = frontend->sources.getYawSource();
+    posxy_source_last = frontend->sources.getPosXYSource(core_index);
+    yaw_source_last = frontend->sources.getYawSource(core_index);
 
     // define Earth rotation vector in the NED navigation frame
     calcEarthRateNED(earthRateNED, dal.get_home().lat);


### PR DESCRIPTION
By setting EK3_SRC_OPTIONS, this PR allows different EK3 cores to have different sensor sources.
As an example, when the correct bit is set,
First core will use the sensor set corresponding to EK3_SRC1
Second core will use sensor set corresponding to EK3_SRC2
And so on.. 