### PR TITLE
[4.6] AP_Camera: fix truncation of FOV stored in parameters

### DIFF
--- a/libraries/AP_Camera/AP_Camera_Backend.h
+++ b/libraries/AP_Camera/AP_Camera_Backend.h
@@ -94,8 +94,8 @@ public:
 #endif
 
     // get camera image horizontal or vertical field of view in degrees.  returns 0 if unknown
-    float horizontal_fov() const { return MAX(0, _params.hfov); }
-    float vertical_fov() const { return MAX(0, _params.vfov); }
+    float horizontal_fov() const { return MAX(0.0f, _params.hfov); }
+    float vertical_fov() const { return MAX(0.0f, _params.vfov); }
 
     // handle MAVLink messages from the camera
     virtual void handle_message(mavlink_channel_t chan, const mavlink_message_t &msg) {}


### PR DESCRIPTION
Due to the strange casting rules of AP_Float parameters, the parameter value was converted to an integer because the other argument was an integer. Change the other argument to a float to cause the correct float cast instead.

Tested on Cube Orange that the `CAMERA_FOV_STATUS` message now does not truncate the FOV values specified in the corresponding parameters.