### PR TITLE
AP_Scripting: EFI HALO6000 enable fix

### DIFF
--- a/libraries/AP_Scripting/drivers/EFI_Halo6000.lua
+++ b/libraries/AP_Scripting/drivers/EFI_Halo6000.lua
@@ -274,6 +274,7 @@ local function engine_control()
        local msg = CANFrame()
        msg:id(0x1A0)
        msg:data(0,1)
+       msg:data(7,1)
        self.write_frame_checksum(msg)
     end
 


### PR DESCRIPTION
Sets the "is flying" bit of the 1A0 control message to 1. This should force the engine to think the aircraft is in the air and start producing power.

This is based on the following data:
![image](https://github.com/user-attachments/assets/8c5a45a2-29a3-4542-a7b3-fff272e3b4bb)


Has been tested by the partner who asked for it. They reported
> I finished testing it and it works fine
thank you