### PR TITLE
Set mavlink system ID in GCS library on all vehicles

### DIFF
--- a/AntennaTracker/Tracker.cpp
+++ b/AntennaTracker/Tracker.cpp
@@ -77,9 +77,6 @@ void Tracker::get_scheduler_tasks(const AP_Scheduler::Task *&tasks,
 
 void Tracker::one_second_loop()
 {
-    // sync MAVLink system ID
-    mavlink_system.sysid = gcs().sysid_this_mav();
-
     // update assigned functions and enable auxiliary servos
     AP::srv().enable_aux_servos();
 

--- a/ArduPlane/Plane.cpp
+++ b/ArduPlane/Plane.cpp
@@ -351,9 +351,6 @@ void Plane::one_second_loop()
                                   (float)((aparm.airspeed_max - aparm.airspeed_min)/2));
     }
 
-    // sync MAVLink system ID
-    mavlink_system.sysid = gcs().sysid_this_mav();
-
     AP::srv().enable_aux_servos();
 
     // update notify flags

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -271,9 +271,6 @@ void Sub::three_hz_loop()
 // one_hz_loop - runs at 1Hz
 void Sub::one_hz_loop()
 {
-    // sync MAVLink system ID
-    mavlink_system.sysid = gcs().sysid_this_mav();
-
     bool arm_check = arming.pre_arm_checks(false);
     ap.pre_arm_check = arm_check;
     AP_Notify::flags.pre_arm_check = arm_check;

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -444,9 +444,6 @@ void Rover::one_second_loop(void)
     AP_Notify::flags.armed = arming.is_armed();
     AP_Notify::flags.flying = hal.util->get_soft_armed();
 
-    // cope with changes to mavlink system ID
-    mavlink_system.sysid = gcs().sysid_this_mav();
-
     // attempt to update home position and baro calibration if not armed:
     if (!hal.util->get_soft_armed()) {
         update_home();

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2670,6 +2670,9 @@ void GCS::send_message(enum ap_message id)
 
 void GCS::update_send()
 {
+    // cope with changes to mavlink system ID parameter
+    mavlink_system.sysid = sysid;
+
     update_send_has_been_called = true;
 
     if (!initialised_missionitemprotocol_objects) {


### PR DESCRIPTION
Four of our six vehicles updated their mavlink system ID from the parameter at 1Hz.

Instead, do it for all vehicles at the rate GCS update() is called.  It's a cheap operation.

This is a change in behaviour for Copter and Blimp which previously required a reboot for the parameter change to take effect.

See also https://github.com/mavlink/mavlink/blob/master/message_definitions/v1.0/development.xml#L176 (`MAV_CMD_DO_SET_SYS_CMP_ID`) for a standardised way of changing a vehicle's system ID, rather than setting a parameter.
