### PR TITLE
AP_Mission: reset loop counter when loop completed

### DIFF
--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -736,6 +736,7 @@ public:
         CLEAR_ON_BOOT            = (1U<<0), // clear mission on vehicle boot
         FAILSAFE_TO_BEST_LANDING = (1U<<1), // on failsafe, find fastest path along mission home
         CONTINUE_AFTER_LAND      = (1U<<2), // continue running mission (do not disarm) after land if takeoff is next waypoint
+        DONT_ZERO_COUNTER        = (1U<<3), // don't zero counter on completion
     };
     bool option_is_set(Option option) const {
         return (_options.get() & (uint16_t)option) != 0;


### PR DESCRIPTION
this is a change of behaviour, but I think more closely aligns with expected behaviour (ie. principle of least surprise)

Should we have a MIS_OPTIONS bit for this?