### PR TITLE
Plane: fixed incorrect set of location alt fields

### DIFF
--- a/ArduPlane/avoidance_adsb.cpp
+++ b/ArduPlane/avoidance_adsb.cpp
@@ -176,14 +176,14 @@ bool AP_Avoidance_Plane::handle_avoidance_vertical(const AP_Avoidance::Obstacle 
 
      // get best vector away from obstacle
      if (plane.current_loc.alt > obstacle->_location.alt) {
-         // should climb
-         new_loc.alt = plane.current_loc.alt + 1000; // set alt demand to be 10m above us, climb rate will be TECS_CLMB_MAX
+         // should climb, set alt demand to be 10m above us, climb rate will be TECS_CLMB_MAX
+         new_loc.set_alt_cm(plane.current_loc.alt + 1000, Location::AltFrame::ABSOLUTE);
          return true;
 
      } else if (plane.current_loc.alt > plane.g.RTL_altitude*100) {
          // should descend while above RTL alt
          // TODO: consider using a lower altitude than RTL_altitude since it's default (100m) is quite high
-         new_loc.alt = plane.current_loc.alt - 1000; // set alt demand to be 10m below us, sink rate will be TECS_SINK_MAX
+         new_loc.set_alt_cm(plane.current_loc.alt - 1000, Location::AltFrame::ABSOLUTE);
          return true;
      }
 

--- a/ArduPlane/commands.cpp
+++ b/ArduPlane/commands.cpp
@@ -140,7 +140,8 @@ bool Plane::update_home()
             // altitude or we can end up perpetuating a bias in
             // altitude, as AHRS alt depends on home alt, which means
             // we would have a circular dependency
-            loc.alt = gps.location().alt;
+            loc.set_alt_cm(gps.location().alt,
+                           Location::AltFrame::ABSOLUTE);
             ret = AP::ahrs().set_home(loc);
         }
     }

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -503,7 +503,17 @@ void Plane::do_continue_and_change_alt(const AP_Mission::Mission_Command& cmd)
         next_WP_loc.offset_bearing(bearing, 1000); // push it out 1km
     }
 
-    next_WP_loc.alt = cmd.content.location.alt + home.alt;
+    if (cmd.content.location.get_alt_frame() == Location::AltFrame::ABOVE_TERRAIN) {
+        next_WP_loc.set_alt_cm(cmd.content.location.alt,
+                               Location::AltFrame::ABOVE_TERRAIN);
+    } else {
+        int32_t alt_abs_cm;
+        // if this fails we don't change alt
+        if (cmd.content.location.get_alt_cm(Location::AltFrame::ABSOLUTE, alt_abs_cm)) {
+            next_WP_loc.set_alt_cm(alt_abs_cm,
+                                   Location::AltFrame::ABSOLUTE);
+        }
+    }
     condition_value = cmd.p1;
     reset_offset_altitude();
 }

--- a/ArduPlane/fence.cpp
+++ b/ArduPlane/fence.cpp
@@ -145,14 +145,17 @@ void Plane::fence_check()
                 //return to fence return point, not a rally point
                 if (fence.get_return_altitude() > 0) {
                     // fly to the return point using _retalt
-                    loc.alt = home.alt + 100.0f * fence.get_return_altitude();
+                    loc.set_alt_cm(home.alt + 100.0 * fence.get_return_altitude(),
+                                   Location::AltFrame::ABSOLUTE);
                 } else if (fence.get_safe_alt_min() >= fence.get_safe_alt_max()) {
                     // invalid min/max, use RTL_altitude
-                    loc.alt = home.alt + g.RTL_altitude*100;
+                    loc.set_alt_cm(home.alt + g.RTL_altitude*100,
+                                   Location::AltFrame::ABSOLUTE);
                 } else {
                     // fly to the return point, with an altitude half way between
                     // min and max
-                    loc.alt = home.alt + 100.0f * (fence.get_safe_alt_min() + fence.get_safe_alt_max()) / 2;
+                    loc.set_alt_cm(home.alt + 100.0f * (fence.get_safe_alt_min() + fence.get_safe_alt_max()) / 2,
+                                   Location::AltFrame::ABSOLUTE);
                 }
 
                 Vector2l return_point;

--- a/ArduPlane/mode_circle.cpp
+++ b/ArduPlane/mode_circle.cpp
@@ -4,7 +4,7 @@
 bool ModeCircle::_enter()
 {
     // the altitude to circle at is taken from the current altitude
-    plane.next_WP_loc.alt = plane.current_loc.alt;
+    plane.next_WP_loc = plane.current_loc;
 
     return true;
 }

--- a/ArduPlane/mode_qrtl.cpp
+++ b/ArduPlane/mode_qrtl.cpp
@@ -160,7 +160,7 @@ void ModeQRTL::run()
             quadplane.vtol_position_controller();
             if (poscontrol.get_state() > QuadPlane::QPOS_POSITION2) {
                 // change target altitude to home alt
-                plane.next_WP_loc.alt = plane.home.alt;
+                plane.next_WP_loc.set_alt_cm(plane.home.alt, Location::AltFrame::ABSOLUTE);
             }
             if (poscontrol.get_state() >= QuadPlane::QPOS_POSITION2) {
                 // start landing logic

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3289,7 +3289,8 @@ bool QuadPlane::do_vtol_takeoff(const AP_Mission::Mission_Command& cmd)
             return false;
         }
     } else {
-        plane.next_WP_loc.alt = plane.current_loc.alt + cmd.content.location.alt;
+        plane.next_WP_loc.set_alt_cm(plane.current_loc.alt + cmd.content.location.alt,
+                                     Location::AltFrame::ABSOLUTE);
     }
     throttle_wait = false;
 
@@ -3340,7 +3341,8 @@ bool QuadPlane::do_vtol_land(const AP_Mission::Mission_Command& cmd)
 
     plane.set_next_WP(cmd.content.location);
     // initially aim for current altitude
-    plane.next_WP_loc.alt = plane.current_loc.alt;
+    plane.next_WP_loc.set_alt_cm(plane.current_loc.alt,
+                                 Location::AltFrame::ABSOLUTE);
 
     // initialise the position controller
     pos_control->init_xy_controller();
@@ -3560,7 +3562,8 @@ bool QuadPlane::verify_vtol_land(void)
                 plane.set_next_WP(plane.mission.get_current_nav_cmd().content.location);
             } else {
                 plane.set_next_WP(plane.next_WP_loc);
-                plane.next_WP_loc.alt = ahrs.get_home().alt;
+                plane.next_WP_loc.set_alt_cm(ahrs.get_home().alt,
+                                             Location::AltFrame::ABSOLUTE);
             }
         }
     }

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3284,7 +3284,9 @@ bool QuadPlane::do_vtol_takeoff(const AP_Mission::Mission_Command& cmd)
     loc.lng = 0;
     plane.set_next_WP(loc);
     if (option_is_set(QuadPlane::OPTION::RESPECT_TAKEOFF_FRAME)) {
-        if (plane.current_loc.alt >= plane.next_WP_loc.alt) {
+        // convert to absolute frame for takeoff
+        if (!plane.next_WP_loc.change_alt_frame(Location::AltFrame::ABSOLUTE) ||
+            plane.current_loc.alt >= plane.next_WP_loc.alt) {
             // we are above the takeoff already, no need to do anything
             return false;
         }


### PR DESCRIPTION
this fixes several places that set the alt field directly. The only one that is a real bug is in CIRCLE where if we were terrain following and change into CIRCLE mode we would climb to current alt + home alt absolute alt
This removes all sets of a alt field in a Location object in plane
This CIRCLE bug is also in 4.5.x