### PR TITLE
SITL: correct compilation when doing coverage analysis

### DIFF
--- a/libraries/SITL/SIM_Volz.cpp
+++ b/libraries/SITL/SIM_Volz.cpp
@@ -66,6 +66,13 @@ const AP_Param::GroupInfo Volz::var_info[] = {
     AP_GROUPEND
 };
 
+// this isn't in the header as inlcuding sparse_endian in the header
+// causes compilation issues with redefinition of bswap16
+void Volz::Command::update_checksum()
+{
+    crc = htobe16(calculate_checksum());
+}
+
 Volz::Volz() : SerialDevice::SerialDevice()
 {
     AP_Param::setup_object_defaults(this, var_info);

--- a/libraries/SITL/SIM_Volz.h
+++ b/libraries/SITL/SIM_Volz.h
@@ -44,8 +44,6 @@ param fetch
 
 #include "SIM_SerialDevice.h"
 
-#include <AP_HAL/utility/sparse-endian.h>
-
 namespace SITL {
 
 class Volz : public SerialDevice {
@@ -91,9 +89,7 @@ private:
         uint16_t calculate_checksum() const {
             return crc_crc16_ibm(0xffff, (uint8_t*)this, 4);
         }
-        void update_checksum() {
-            crc = htobe16(calculate_checksum());
-        }
+        void update_checksum();
     };
 
     // reading-from-autopilot support:


### PR DESCRIPTION
Including sparse-endian causes redefinition problems.  It shouldn't, but it does.  Just work around the problem by moving the method to the cpp

```
In file included from /usr/include/netinet/in.h:408,
                 from ../../libraries/AP_HAL_SITL/CAN_Multicast.cpp:14:
/usr/include/x86_64-linux-gnu/bits/byteswap.h:34:1: error: redefinition of ‘__uint16_t __bswap_16(__uint16_t)’
   34 | __bswap_16 (__uint16_t __bsx)
      | ^~~~~~~~~~
compilation terminated due to -Wfatal-errors.

In file included from /usr/include/netinet/in.h:408,
                 from ../../libraries/AP_HAL_SITL/SITL_State.cpp:20:
/usr/include/x86_64-linux-gnu/bits/byteswap.h:34:1: error: redefinition of ‘__uint16_t __bswap_16(__uint16_t)’
   34 | __bswap_16 (__uint16_t __bsx)
      | ^~~~~~~~~~
compilation terminated due to -Wfatal-errors.

In file included from ../../libraries/AP_HAL/utility/sparse-endian.h:28,
                 from ../../libraries/SITL/SIM_Volz.h:47,
                 from ../../libraries/SITL/SITL.h:35,
                 from ../../libraries/SITL/SIM_Aircraft.h:25,
                 from ../../libraries/SITL/SIM_ADSB.h:27,
                 from ../../libraries/AP_HAL_SITL/SITL_State_common.h:13,
                 from ../../libraries/AP_HAL_SITL/SITL_State.h:8,
                 from ../../libraries/AP_HAL_SITL/UARTDriver.cpp:42:
../../libraries/AP_Common/missing/byteswap.h:9:24: error: redefinition of ‘uint16_t __bswap_16(uint16_t)’
    9 | static inline uint16_t __bswap_16(uint16_t u)
      |                        ^~~~~~~~~~
compilation terminated due to -Wfatal-errors.
```
