### PR TITLE
GCS_MAVLink: remove 'No ap_message for mavlink id' warning

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1175,7 +1175,9 @@ bool GCS_MAVLINK::set_mavlink_message_id_interval(const uint32_t mavlink_id,
 {
     const ap_message id = mavlink_id_to_ap_message_id(mavlink_id);
     if (id == MSG_LAST) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "No ap_message for mavlink id (%u)", (unsigned int)mavlink_id);
+#endif  // CONFIG_HAL_BOARD == HAL_BOARD_SITL
         return false;
     }
     return set_ap_message_interval(id, interval_ms);


### PR DESCRIPTION
Even just the first response to a probing message is annoying to the user