### PR TITLE
AP_Mount: Use logical operator instead of bitwise

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -95,7 +95,7 @@ void AP_Mount_Servo::update()
             FALLTHROUGH;
         case MountTargetType::ANGLE:
             // update _angle_bf_output_rad based on angle target
-            if ((mount_mode != MAV_MOUNT_MODE_RETRACT) & (mount_mode != MAV_MOUNT_MODE_NEUTRAL)) {
+            if ((mount_mode != MAV_MOUNT_MODE_RETRACT) && (mount_mode != MAV_MOUNT_MODE_NEUTRAL)) {
                 update_angle_outputs(mnt_target.angle_rad);
             }
             break;


### PR DESCRIPTION
afaict, bitwise and (`&`) will always evaluate both sides, logical and (`&&`) will be able to short-circuit evaluate.

we're checking conditions, not bits.