### PR TITLE
AP_HAL_ChibiOS: Fix using the incorrect pin after checking the correct pin is defined

### DIFF
--- a/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
+++ b/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
@@ -814,7 +814,7 @@ void AnalogIn::update_power_flags(void)
       for backup power)
     */
 #if defined(HAL_GPIO_PIN_VDD_BRICK2_VALID)
-    if (palReadLine(HAL_GPIO_PIN_VDD_BRICK_VALID) == 1) {
+    if (palReadLine(HAL_GPIO_PIN_VDD_BRICK2_VALID) == 1) {
         flags |= MAV_POWER_STATUS_SERVO_VALID;
     }
 #elif defined(HAL_GPIO_PIN_VDD_BRICK2_nVALID)


### PR DESCRIPTION
Tested with PixC4-Jetson, commenting VDD_BRICK_VALID out causes build to break. This change fixes the build.