### PR TITLE
AC_WPNav: avoid use of Location alt attribute in AC_WPNAV_OA

### DIFF
--- a/libraries/AC_WPNav/AC_WPNav_OA.cpp
+++ b/libraries/AC_WPNav/AC_WPNav_OA.cpp
@@ -212,7 +212,13 @@ bool AC_WPNav_OA::update_wpnav()
                     INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
                     return false;
                 }
-                Vector3p dest_NEU{dest_NE.x, dest_NE.y, (float)target_alt_loc.alt};
+                // target_alt_loc may be AltFrame::ABOVE_TERRAIN or
+                // AltFrame::ABOVE_ORIGIN here.  So it is distinctly
+                // odd that we are putting it into a relative-origin
+                // vector here without canonicalising it:
+                int32_t target_alt_loc_alt = 0;
+                UNUSED_RESULT(target_alt_loc.get_alt_cm(target_alt_loc.get_alt_frame(), target_alt_loc_alt));
+                Vector3p dest_NEU{dest_NE.x, dest_NE.y, (float)target_alt_loc_alt};
 
                 // pass the desired position directly to the position controller
                 _pos_control.input_pos_xyz(dest_NEU, terr_offset, 1000.0);


### PR DESCRIPTION
this is mostly a comment, as I am trying to preserve existing behaviour while pointing out something that does look quite right