### PR TITLE
GCS_MAVLink: Remove unnecessary decisions

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -958,7 +958,7 @@ void GCS_MAVLINK::handle_mission_item(const mavlink_message_t &msg)
             // waypoint and not for the mission
             result = (handle_guided_request(cmd) ? MAV_MISSION_ACCEPTED
                       : MAV_MISSION_ERROR) ;
-        } else if (current == 3) {
+        } else {
             //current = 3 is a flag to tell us this is a alt change only
             // add home alt if needed
             handle_change_alt_request(cmd.content.location);


### PR DESCRIPTION
The only condition for entering the else block is current == 3.
Therefore, the conditional check can be removed.