### PR TITLE
GCS_MAVLink: Remove unnecessary variable assignments

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1382,8 +1382,7 @@ int8_t GCS_MAVLINK::deferred_message_to_send_index(uint16_t now16_ms)
         return -1;
     }
 
-    const uint16_t ms_since_last_sent = now16_ms - deferred_message[next_deferred_message_to_send_cache].last_sent_ms;
-    if (ms_since_last_sent < deferred_message[next_deferred_message_to_send_cache].interval_ms) {
+    if ((now16_ms - deferred_message[next_deferred_message_to_send_cache].last_sent_ms) < deferred_message[next_deferred_message_to_send_cache].interval_ms) {
         return -1;
     }
 


### PR DESCRIPTION
This variable is used for a conditional check.
You can use it directly in the condition without assigning it to a separate variable.
There is no need to create an unnecessary variable just for the condition.