### PR TITLE
AP_InertialSensor: Fixed the IMU measurement range of the sensor IIM42653

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
@@ -337,6 +337,10 @@ void AP_InertialSensor_Invensensev3::start()
             temp_sensitivity = 1.0 / 128.0;
             accel_scale = ACCEL_SCALE_HIGHRES_32G;
             gyro_scale = GYRO_SCALE_HIGHRES_4000DPS;
+        } else if (inv3_type == Invensensev3_Type::IIM42653) {
+            accel_scale = ACCEL_SCALE_HIGHRES_32G;
+            gyro_scale = GYRO_SCALE_HIGHRES_4000DPS;
+            temp_sensitivity = 1.0 / 132.48;
         } else if (inv3_type == Invensensev3_Type::ICM42670) {
             temp_sensitivity = 1.0 / 128.0;
         }


### PR DESCRIPTION
Dear Developers,

We are testing TDK’s IIM-42653 sensor，and we identified an issue in the current code: under normal conditions, the accelerometer and gyroscope output data only half the expected values (likely due to range configuration errors).

Initial analysis suggests an incorrect full-scale range (FSR) setting. The IIM-42653’s specified ranges are ±32g (accelerometer) and ±4000dps (gyroscope). We’ve modified the code and conducted preliminary tests—updates will be shared soon.

Tested on the ZeroOneX6 ( IMU1:IIM42653、IMU2:BMI088、IMU3:IIM42653 )
![Abnormal sensor data](https://github.com/user-attachments/assets/caf3cde8-7fbf-460c-9c0a-243597001440)
![Abnormal sensor data 2](https://github.com/user-attachments/assets/83e4ec99-cd32-4ca9-870d-83a29bed0b89)
