### PR TITLE
SITL: Support JSON aero coefficients

### DIFF
--- a/Tools/autotest/models/skywalker_2013.json
+++ b/Tools/autotest/models/skywalker_2013.json
@@ -1,0 +1,56 @@
+# This is an example plane coeffient file used in Ardupilot SITL.
+# This allows ArduPilot developers to change SITL plane aerodynamic properties
+# without having to change the hard-coded source code values directly.
+
+# These coefficients are from last_letter skywalker_2013/aerodynamics.yaml.
+# Thanks to Georacer!
+
+{
+    "s": 0.45,
+    "b": 1.88,
+    "c": 0.24,
+    "c_lift_0": 0.56,
+    "c_lift_deltae": 0,
+    "c_lift_a": 6.9,
+    "c_lift_q": 0,
+    "mcoeff": 50,
+    "oswald": 0.9,
+    "alpha_stall": 0.4712,
+    "c_drag_q": 0,
+    "c_drag_deltae": 0.0,
+    "c_drag_p": 0.1,
+    "c_y_0": 0,
+    "c_y_b": -0.98,
+    "c_y_p": 0,
+    "c_y_r": 0,
+    "c_y_deltaa": 0,
+    "c_y_deltar": -0.2,
+    "c_l_0": 0,
+    "c_l_p": -1.0,
+    "c_l_b": -0.12,
+    "c_l_r": 0.14,
+    "c_l_deltaa": 0.25,
+    "c_l_deltar": -0.037,
+    "c_m_0": 0.045,
+    "c_m_a": -0.7,
+    "c_m_q": -20,
+    "c_m_deltae": 1.0,
+    "c_n_0": 0,
+    "c_n_b": 0.25,
+    "c_n_p": 0.022,
+    "c_n_r": -1,
+    "c_n_deltaa": 0.00,
+    "c_n_deltar": 0.1,
+    "deltaa_max": 0.3491,
+    "deltae_max": 0.3491,
+    "deltar_max": 0.3491,
+
+    # The X CoG offset should be -0.02, but that makes the plane too tail heavy
+    # in manual flight. Adjusted to -0.15 gives reasonable flight.
+    # CGOffset is in X,Y,Z.
+    "CGOffset": [
+        -0.15,
+        0.0,
+        -0.05
+    ]
+}

--- a/libraries/AP_JSON/AP_JSON.h
+++ b/libraries/AP_JSON/AP_JSON.h
@@ -80,7 +80,8 @@ public:
 
     static std::string parse(value &out, const std::string &s);
 
-    // load a json file, returning a value object
+    // load a json file, returning a value object.
+    // caller must delete the returned pointer when done.
     static value *load_json(const char *filename);
 };
 

--- a/libraries/SITL/SIM_Plane.h
+++ b/libraries/SITL/SIM_Plane.h
@@ -21,6 +21,7 @@
 #include "SIM_Aircraft.h"
 #include "SIM_ICEngine.h"
 #include <Filter/LowPassFilter.h>
+#include <AP_JSON/AP_JSON.h>
 
 namespace SITL {
 
@@ -44,7 +45,7 @@ protected:
     float angle_of_attack;
     float beta;
 
-    struct {
+    const struct Coefficients {
         // from last_letter skywalker_2013/aerodynamics.yaml
         // thanks to Georacer!
         float s = 0.45;
@@ -88,7 +89,9 @@ protected:
         // the X CoG offset should be -0.02, but that makes the plane too tail heavy
         // in manual flight. Adjusted to -0.15 gives reasonable flight
         Vector3f CGOffset{-0.15, 0, -0.05};
-    } coefficient;
+    } default_coefficients;
+
+    struct Coefficients coefficient;
 
     float thrust_scale;
     bool reverse_thrust;
@@ -121,11 +124,18 @@ protected:
         true
     };
 
+    // load aero coefficients from a json model file
+    void load_coeffs(const char *model_json);
     float liftCoeff(float alpha) const;
     float dragCoeff(float alpha) const;
     Vector3f getForce(float inputAileron, float inputElevator, float inputRudder) const;
     Vector3f getTorque(float inputAileron, float inputElevator, float inputRudder, float inputThrust, const Vector3f &force) const;
     void calculate_forces(const struct sitl_input &input, Vector3f &rot_accel);
+
+private:
+    // json parsing helpers (TODO reduce code duplication)
+    void parse_float(AP_JSON::value val, const char* label, float &param);
+    void parse_vector3(AP_JSON::value val, const char* label, Vector3f &param);
 };
 
 } // namespace SITL


### PR DESCRIPTION
# Purpose

For simulations, we want to run SITL with our own aero model without recompiling the code.
This makes it easier to maintain than forks with modified coefficients, one for each vehicle.

# Tests performed

First, run with the default model which is loaded as JSON now. Arm and takeoff and observe it flies the same.

```bash
./Tools/autotest/sim_vehicle.py -v Plane  --console -DG
# wait some time
arm throttle
mode takeoff
```

Now, specify a json file to load, which loads the same file as the default.

```bash
./Tools/autotest/sim_vehicle.py -v Plane --model plane:@ROMFS/models/skywalker_2013.json  --console -DG
```

Finally, add your own aero model by copying skywalker_2013.json to a new file, and change a value.
```bash
cp Tools/autotest/models/skywalker_2013.json  Tools/autotest/models/custom_plane_aero.json
```

Now, raise the stall angle `"alpha_stall": 0.8`.

Finally, rerun with the model, and set a breakpoint to ensure we changed the value.
```bash
./Tools/autotest/sim_vehicle.py -v Plane --model plane:@ROMFS/models/custom_plane_aero.json  --console -DGB SIM_Plane.cpp:41
```

Then, print the stall angle to see it's been updated.


![image](https://github.com/user-attachments/assets/357144db-0d5f-442c-adfa-af9975c76a2f)

# Further improvements

Reduce code duplication

# Related

* Inspired by https://github.com/ArduPilot/ardupilot/pull/29462


