### PR TITLE
Fix floating point math in AP_Declination get_mag_field_ef method

### DIFF
--- a/libraries/AP_Declination/AP_Declination.cpp
+++ b/libraries/AP_Declination/AP_Declination.cpp
@@ -36,10 +36,9 @@ bool AP_Declination::get_mag_field_ef(float latitude_deg, float longitude_deg, f
 {
     bool valid_input_data = true;
 
-    /* round down to nearest sampling resolution. On some platforms (e.g. clang on macOS),
-        the behaviour of implicit casts from int32 to float can be undefined thus making it explicit here. */
-    float min_lat = float(static_cast<int32_t>(static_cast<int32_t>(floorf(latitude_deg / SAMPLING_RES)) * SAMPLING_RES));
-    float min_lon = float(static_cast<int32_t>(static_cast<int32_t>(floorf(longitude_deg / SAMPLING_RES)) * SAMPLING_RES));
+    /* round down to nearest sampling resolution */
+    float min_lat = floorf(latitude_deg / SAMPLING_RES) * SAMPLING_RES;
+    float min_lon = floorf(longitude_deg / SAMPLING_RES) * SAMPLING_RES;
 
     /* for the rare case of hitting the bounds exactly
      * the rounding logic wouldn't fit, so enforce it.


### PR DESCRIPTION
When running a quadcopter in SITL it would crash right after startup with the following error:

```
Process 5645 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGTERM
    frame #0: 0x00007ff81236afae libsystem_kernel.dylib`__semwait_signal + 10
libsystem_kernel.dylib`:
->  0x7ff81236afae <+10>: jae    0x7ff81236afb8            ; <+20>
    0x7ff81236afb0 <+12>: movq   %rax, %rdi
    0x7ff81236afb3 <+15>: jmp    0x7ff8123699d4            ; cerror
    0x7ff81236afb8 <+20>: retq   
Target 0: (arducopter) stopped.
```

Not sure if this crash could also happen in non-SITL builds. Anyway, this PR simplifies the rounding logic to avoid a situation where, if the `latitude_deg` or `longitude_deg` produce a value outside of int32_t range, the cast would crash the app. The resulting logic should produce the same result.