### PR TITLE
Tool: generate_manifest: correct output in error path

### DIFF
--- a/Tools/scripts/generate_manifest.py
+++ b/Tools/scripts/generate_manifest.py
@@ -523,7 +523,7 @@ class ManifestGenerator():
                 tag = firstlevel
                 if not self.valid_release_type(tag):
                     print("Unknown tag (%s) in directory (%s)" %
-                          (tag, os.path.join(vdir)), file=sys.stderr)
+                          (tag, os.path.join(*vdir)), file=sys.stderr)
                     continue
                 tag_path = os.path.join(basedir, vehicletype, tag)
                 if not os.path.isdir(tag_path):


### PR DESCRIPTION
beta-4.3 was removed as a valid tag a couple of weeks ago, but this should yield a warning in the build script.... except there's a bug in that error path....

```
Traceback (most recent call last):
  File "/mnt/volume_nyc3_01/autotest/APM/APM/./build_binaries.py", line 771, in
<module>
    bb.run()
  File "/mnt/volume_nyc3_01/autotest/APM/APM/./build_binaries.py", line 751, in
run
    self.generate_manifest()
  File "/mnt/volume_nyc3_01/autotest/APM/APM/./build_binaries.py", line 662, in
generate_manifest
    generator.run()
  File "/mnt/volume_nyc3_01/autotest/APM/APM/generate_manifest.py", line 614, in
 run
    self.structure, self.features_structure = self.walk_directory(self.basedir)
  File "/mnt/volume_nyc3_01/autotest/APM/APM/generate_manifest.py", line 526, in
 walk_directory
    (tag, os.path.join(vdir)), file=sys.stderr)
  File "/usr/lib/python3.10/posixpath.py", line 76, in join
    a = os.fspath(a)
TypeError: expected str, bytes or os.PathLike object, not list
```