### PR TITLE
Avoid using Baro in SITL library (nullptr deref running examples)

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -73,7 +73,6 @@ void SITL_State::_sitl_setup()
 
     fprintf(stdout, "Starting SITL input\n");
 
-    // find the barometer object if it exists
     _sitl = AP::sitl();
 
     if (_sitl != nullptr) {
@@ -319,7 +318,6 @@ void SITL_State::_simulator_servos(struct sitl_input &input)
     uint32_t now = AP_HAL::micros();
     last_update_usec = now;
 
-    float altitude = AP::baro().get_altitude();
     float wind_speed = 0;
     float wind_direction = 0;
     float wind_dir_z = 0;
@@ -346,6 +344,7 @@ void SITL_State::_simulator_servos(struct sitl_input &input)
         wind_dir_z =     _sitl->wind_dir_z_active;
         
         // pass wind into simulators using different wind types via param SIM_WIND_T*.
+        const float altitude = _sitl->state.height_agl;
         switch (_sitl->wind_type) {
         case SITL::SIM::WIND_TYPE_SQRT:
             if (altitude < _sitl->wind_type_alt) {

--- a/libraries/AP_Notify/examples/ToshibaLED_test/ToshibaLED_test.cpp
+++ b/libraries/AP_Notify/examples/ToshibaLED_test/ToshibaLED_test.cpp
@@ -25,7 +25,7 @@ void setup(void)
     hal.console->printf("Toshiba LED test ver 0.1\n");
 
     // initialise LED
-    if (toshiba_led.init()) {
+    if (!toshiba_led.init()) {
         hal.console->printf("Failed to initialise Toshiba LED\n");
     }
     toshiba_led.pNotify = &notify;

--- a/libraries/AP_Notify/examples/ToshibaLED_test/ToshibaLED_test.cpp
+++ b/libraries/AP_Notify/examples/ToshibaLED_test/ToshibaLED_test.cpp
@@ -1,6 +1,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Notify/AP_Notify.h>
 #include <AP_Notify/ToshibaLED_I2C.h>
+#include <SITL/SITL.h>
 
 void setup();
 void loop();
@@ -12,6 +13,11 @@ const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 AP_Notify notify;
 
 static ToshibaLED_I2C toshiba_led(1);
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#include <SITL/SITL.h>
+SITL::SIM sitl;
+#endif
 
 void setup(void)
 {

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -483,7 +483,13 @@ void Aircraft::fill_fdm(struct sitl_fdm &fdm)
 #endif
     // for EKF comparison log relhome pos and velocity at loop rate
     static uint16_t last_ticks;
-    uint16_t ticks = AP::scheduler().ticks();
+    // FIXME: stop using AP_Scheduler here!  It's from "the other side"
+    const auto *scheduler = AP_Scheduler::get_singleton();
+    if (scheduler == nullptr) {
+        // not instantiated in examples
+        return;
+    }
+    uint16_t ticks = scheduler->ticks();
     if (last_ticks != ticks) {
         last_ticks = ticks;
 // @LoggerMessage: SIM2


### PR DESCRIPTION
nullptr dereference in some examples.

We shouldn't be using it over there anyway.

Similarly for Scheduler

... and a couple of other issues raised in the ToshbibaLED example specifically
