### PR TITLE
Fix and move get_fwd_pitch_is_limited()

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -445,7 +445,7 @@ public:
     float get_z_accel_cmss() const { return -(_ahrs.get_accel_ef().z + GRAVITY_MSS) * 100.0f; }
 
     /// returns true when the forward pitch demand is limited by the maximum allowed tilt
-    bool get_fwd_pitch_is_limited() const { return _fwd_pitch_is_limited; }
+    bool get_fwd_pitch_is_limited() const;
     
     // set disturbance north
     void set_disturb_pos_cm(Vector2f disturb_pos) {_disturb_pos = disturb_pos;}
@@ -561,8 +561,6 @@ protected:
     Vector3f    _accel_desired;         // desired acceleration in NEU cm/s/s (feed forward)
     Vector3f    _accel_target;          // acceleration target in NEU cm/s/s
     Vector3f    _limit_vector;          // the direction that the position controller is limited, zero when not limited
-
-    bool        _fwd_pitch_is_limited;     // true when the forward pitch demand is being limited to meet acceleration limits
 
     // terrain handling variables
     float    _pos_terrain_target;       // position terrain target in cm relative to the EKF origin in NEU frame


### PR DESCRIPTION
This fixes a couple problems:

- get_fwd_pitch_is_limited can be stuck on true if it becomes unsaturated while being true,
- it is only used in quadplane but runs on every loop in Copter,
- it was added to the main update XY position controller loop.

This PR fixes the bug and lest us only run it when called. I also want to remove it at compile time from copter but need some help to do this.