### PR TITLE
Tools: extract_features.py: correct extraction of MS56XX features

### DIFF
--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -96,7 +96,7 @@ class ExtractFeatures(object):
             ('AP_OPTICALFLOW_ENABLED', 'AP_OpticalFlow::AP_OpticalFlow',),
             ('AP_OPTICALFLOW_{type}_ENABLED', r'AP_OpticalFlow_(?P<type>.*)::update\b',),
 
-            ('AP_BARO_{type}_ENABLED', r'AP_Baro_(?P<type>.*)::update\b',),
+            ('AP_BARO_{type}_ENABLED', r'AP_Baro_(?P<type>.*)::(_calculate|update)\b',),
 
             ('AP_MOTORS_FRAME_{type}_ENABLED', r'AP_MotorsMatrix::setup_(?P<type>.*)_matrix\b',),
 


### PR DESCRIPTION
these never had that update symbol

Before:
```
pbarker@crun:~/rc/ardupilot(master)$ ./Tools/scripts/extract_features.py build/MatekH743-bdshot/bin/arduplane | grep AP_BARO
AP_BARO_BMP085_ENABLED
AP_BARO_BMP280_ENABLED
AP_BARO_BMP388_ENABLED
AP_BARO_BMP581_ENABLED
AP_BARO_DPS280_ENABLED
AP_BARO_DRONECAN_ENABLED
AP_BARO_EXTERNALAHRS_ENABLED
AP_BARO_FBM320_ENABLED
!AP_BARO_KELLERLD_ENABLED
AP_BARO_LPS2XH_ENABLED
!AP_BARO_MS5607_ENABLED
!AP_BARO_MS5611_ENABLED
!AP_BARO_MS5637_ENABLED
!AP_BARO_MS5837_ENABLED
AP_BARO_MSP_ENABLED
AP_BARO_PROBE_EXTERNAL_I2C_BUSES
AP_BARO_SPL06_ENABLED
!AP_BARO_THST_COMP_ENABLED
```

After:
```
pbarker@crun:~/rc/ardupilot(pr/ms56xx-feature-extraction-fix)$ ./Tools/scripts/extract_features.py build/MatekH743-bdshot/bin/arduplane | grep AP_BARO
AP_BARO_BMP085_ENABLED
AP_BARO_BMP280_ENABLED
AP_BARO_BMP388_ENABLED
AP_BARO_BMP581_ENABLED
AP_BARO_DPS280_ENABLED
AP_BARO_DRONECAN_ENABLED
AP_BARO_EXTERNALAHRS_ENABLED
AP_BARO_FBM320_ENABLED
!AP_BARO_KELLERLD_ENABLED
AP_BARO_LPS2XH_ENABLED
AP_BARO_MS5607_ENABLED
AP_BARO_MS5611_ENABLED
AP_BARO_MS5637_ENABLED
!AP_BARO_MS5837_ENABLED
AP_BARO_MSP_ENABLED
AP_BARO_PROBE_EXTERNAL_I2C_BUSES
AP_BARO_SPL06_ENABLED
!AP_BARO_THST_COMP_ENABLED
```

Closes https://github.com/ArduPilot/CustomBuild/issues/157
