### PR TITLE
Add airspeed control to AP_DDS for plane in GUIDED

### DIFF
--- a/ArduPlane/AP_ExternalControl_Plane.cpp
+++ b/ArduPlane/AP_ExternalControl_Plane.cpp
@@ -19,4 +19,23 @@ bool AP_ExternalControl_Plane::set_global_position(const Location& loc)
     return plane.set_target_location(loc);
 }
 
+/*
+  Sets the target airspeed.
+*/
+bool AP_ExternalControl_Plane::set_airspeed(const float airspeed)
+{
+#if AP_PLANE_OFFBOARD_GUIDED_SLEW_ENABLED
+    // The command is only valid in guided mode.
+    if (plane.control_mode != &plane.mode_guided) {
+        return false;
+    }
+
+    // Assume the user wanted maximum acceleration.
+    const float acc_instant = 0.0;
+    return plane.mode_guided.handle_change_airspeed(airspeed, acc_instant);
+#else 
+  return false;
+#endif
+}
+
 #endif // AP_EXTERNAL_CONTROL_ENABLED

--- a/ArduPlane/AP_ExternalControl_Plane.h
+++ b/ArduPlane/AP_ExternalControl_Plane.h
@@ -16,6 +16,12 @@ public:
         Sets the target global position for a loiter point.
     */
     bool set_global_position(const Location& loc) override WARN_IF_UNUSED;
+
+    /*
+        Sets the target airspeed.
+    */
+    bool set_airspeed(const float airspeed) override WARN_IF_UNUSED;
+
 };
 
 #endif // AP_EXTERNAL_CONTROL_ENABLED

--- a/libraries/AP_DDS/AP_DDS_ExternalControl.cpp
+++ b/libraries/AP_DDS/AP_DDS_ExternalControl.cpp
@@ -65,6 +65,14 @@ bool AP_DDS_External_Control::handle_velocity_control(geometry_msgs_msg_TwistSta
             float(cmd_vel.twist.linear.x),
             float(cmd_vel.twist.linear.y),
             float(-cmd_vel.twist.linear.z) };
+
+        if (isnan(linear_velocity_base_link.y) && isnan(linear_velocity_base_link.z)) {
+            // Assume it's an airspeed command so ignore the angular data.
+            // While MAV_CMD_GUIDED_CHANGE_SPEED supports commands of ground speed and airspeed,
+            // ROS users likely care more about airspeed control for a low level velocity control interface like this.
+            return external_control->set_airspeed(linear_velocity_base_link.x);
+        }
+
         const float yaw_rate = -cmd_vel.twist.angular.z;
 
         auto &ahrs = AP::ahrs();

--- a/libraries/AP_ExternalControl/AP_ExternalControl.h
+++ b/libraries/AP_ExternalControl/AP_ExternalControl.h
@@ -17,6 +17,13 @@ class AP_ExternalControl
 public:
 
     AP_ExternalControl();
+
+    /*
+        Sets the target airspeed.
+    */
+    virtual bool set_airspeed(const float airspeed) WARN_IF_UNUSED {
+        return false;
+    }
     /*
       Set linear velocity and yaw rate. Pass NaN for yaw_rate_rads to not control yaw.
       Velocity is in earth frame, NED [m/s].


### PR DESCRIPTION
# Purpose

I want to control plane's airspeed from DDS while in GUIDED mode, similar to [MAV_CMD_GUIDED_CHANGE_SPEED](https://mavlink.io/en/messages/ardupilotmega.html#MAV_CMD_GUIDED_CHANGE_SPEED).

# Description

We already have low level velocity control in the DDS interface, currently implemented on copter. We can use the same topic for airspeed commands, assuming the linear Y and Z components are NaN, and it's in the body frame obeying the [ROS REP-103 FLU convention](https://www.ros.org/reps/rep-0103.html#axis-orientation). I assume that ROS users will want airspeed control in plane rather than local GPS speed control.

The guided code was pulled from GCS_Mavlink_Plane::handle_command_int_guided_slew_commands where it handled MAV_CMD_GUIDED_CHANGE_SPEED: https://github.com/ArduPilot/ardupilot/blob/8e34fd19324389d4838ff2c86cc77466d501a55a/ArduPlane/GCS_MAVLink_Plane.cpp#L672-L709

# Example Command

```yaml
header:
  stamp:
    sec: 0
    nanosec: 0
  frame_id: base_link
twist:
  linear:
    x: 30.0
    y: .nan
    z: .nan
  angular:
    x: 0.0
    y: 0.0
    z: 0.0
```

# Tests Performed

```
colcon build --packages-up-to ardupilot_sitl
source install/setup.bash
ros2 launch ardupilot_sitl sitl_dds_udp.launch.py command:=arduplane model:=plane defaults:=$(ros2 pkg prefix --share ardupilot_sitl)/config/models/plane.parm
```

In another terminal, take off and get the vehicle into GUIDED so it's ready to accept airspeed commands
```bash
mavproxy.py --master :14551
mode takeoff
arm throttle
# wait till at altitude
mode guided
```

In another terminal, send the airspeed command to 26 m/s.
```bash
source install/setup.bash
ros2 topic pub /ap/cmd_vel geometry_msgs/msg/TwistStamped "{header: {stamp: now, frame_id: base_link}, twist: {linear: {x: 26.0, y: .nan, z: .nan}}}" --once
```

Observe the plane speed up from 23 to 26 m/s in mavproxy's console.
![image](https://github.com/user-attachments/assets/a8fc6a0f-68a6-4ecc-b601-f98a29b84681)

Now, slow it down to 15 m/S.

```bash
ros2 topic pub /ap/cmd_vel geometry_msgs/msg/TwistStamped "{header: {stamp: now, frame_id: base_link}, twist: {linear: {x: 15.0, y: .nan, z: .nan}}}" --once
```

Observe it slow down.

YOu can also try with 9 to see it's rejected (too slow) and 31 (too fast), or in another mode like FBWB to see it's rejected.

