### PR TITLE
Make ArmingChecks enum class AP_Arming::Check

### DIFF
--- a/ArduCopter/AP_Arming_Copter.cpp
+++ b/ArduCopter/AP_Arming_Copter.cpp
@@ -83,7 +83,7 @@ bool AP_Arming_Copter::run_pre_arm_checks(bool display_failure)
 
 bool AP_Arming_Copter::rc_throttle_failsafe_checks(bool display_failure) const
 {
-    if (!check_enabled(ARMING_CHECK_RC)) {
+    if (!check_enabled(Check::RC)) {
         // this check has been disabled
         return true;
     }
@@ -106,13 +106,13 @@ bool AP_Arming_Copter::rc_throttle_failsafe_checks(bool display_failure) const
 #endif
 
     if (!rc().has_had_rc_receiver() && !rc().has_had_rc_override()) {
-        check_failed(ARMING_CHECK_RC, display_failure, "RC not found");
+        check_failed(Check::RC, display_failure, "RC not found");
         return false;
     }
 
     // check throttle is not too low - must be above failsafe throttle
     if (copter.channel_throttle->get_radio_in() < copter.g.failsafe_throttle_value) {
-        check_failed(ARMING_CHECK_RC, display_failure, "%s below failsafe", rc_item);
+        check_failed(Check::RC, display_failure, "%s below failsafe", rc_item);
         return false;
     }
 
@@ -127,7 +127,7 @@ bool AP_Arming_Copter::barometer_checks(bool display_failure)
 
     bool ret = true;
     // check Baro
-    if (check_enabled(ARMING_CHECK_BARO)) {
+    if (check_enabled(Check::BARO)) {
         // Check baro & inav alt are within 1m if EKF is operating in an absolute position mode.
         // Do not check if intending to operate in a ground relative height mode as EKF will output a ground relative height
         // that may differ from the baro height due to baro drift.
@@ -135,7 +135,7 @@ bool AP_Arming_Copter::barometer_checks(bool display_failure)
         bool using_baro_ref = (!filt_status.flags.pred_horiz_pos_rel && filt_status.flags.pred_horiz_pos_abs);
         if (using_baro_ref) {
             if (fabsf(copter.inertial_nav.get_position_z_up_cm() - copter.baro_alt) > PREARM_MAX_ALT_DISPARITY_CM) {
-                check_failed(ARMING_CHECK_BARO, display_failure, "Altitude disparity");
+                check_failed(Check::BARO, display_failure, "Altitude disparity");
                 ret = false;
             }
         }
@@ -147,11 +147,11 @@ bool AP_Arming_Copter::ins_checks(bool display_failure)
 {
     bool ret = AP_Arming::ins_checks(display_failure);
 
-    if (check_enabled(ARMING_CHECK_INS)) {
+    if (check_enabled(Check::INS)) {
 
         // get ekf attitude (if bad, it's usually the gyro biases)
         if (!pre_arm_ekf_attitude_check()) {
-            check_failed(ARMING_CHECK_INS, display_failure, "EKF attitude is bad");
+            check_failed(Check::INS, display_failure, "EKF attitude is bad");
             ret = false;
         }
     }
@@ -166,9 +166,9 @@ bool AP_Arming_Copter::board_voltage_checks(bool display_failure)
     }
 
     // check battery voltage
-    if (check_enabled(ARMING_CHECK_VOLTAGE)) {
+    if (check_enabled(Check::VOLTAGE)) {
         if (copter.battery.has_failsafed()) {
-            check_failed(ARMING_CHECK_VOLTAGE, display_failure, "Battery failsafe");
+            check_failed(Check::VOLTAGE, display_failure, "Battery failsafe");
             return false;
         }
     }
@@ -196,38 +196,38 @@ bool AP_Arming_Copter::terrain_database_required() const
 bool AP_Arming_Copter::parameter_checks(bool display_failure)
 {
     // check various parameter values
-    if (check_enabled(ARMING_CHECK_PARAMETERS)) {
+    if (check_enabled(Check::PARAMETERS)) {
 
         // failsafe parameter checks
         if (copter.g.failsafe_throttle) {
             // check throttle min is above throttle failsafe trigger and that the trigger is above ppm encoder's loss-of-signal value of 900
             if (copter.channel_throttle->get_radio_min() <= copter.g.failsafe_throttle_value+10 || copter.g.failsafe_throttle_value < 910) {
-                check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Check FS_THR_VALUE");
+                check_failed(Check::PARAMETERS, display_failure, "Check FS_THR_VALUE");
                 return false;
             }
         }
         if (copter.g.failsafe_gcs == FS_GCS_ENABLED_CONTINUE_MISSION) {
             // FS_GCS_ENABLE == 2 has been removed
-            check_failed(ARMING_CHECK_PARAMETERS, display_failure, "FS_GCS_ENABLE=2 removed, see FS_OPTIONS");
+            check_failed(Check::PARAMETERS, display_failure, "FS_GCS_ENABLE=2 removed, see FS_OPTIONS");
         }
 
         // lean angle parameter check
         if (copter.aparm.angle_max < 1000 || copter.aparm.angle_max > 8000) {
-            check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Check ANGLE_MAX");
+            check_failed(Check::PARAMETERS, display_failure, "Check ANGLE_MAX");
             return false;
         }
 
         // acro balance parameter check
 #if MODE_ACRO_ENABLED || MODE_SPORT_ENABLED
         if ((copter.g.acro_balance_roll > copter.attitude_control->get_angle_roll_p().kP()) || (copter.g.acro_balance_pitch > copter.attitude_control->get_angle_pitch_p().kP())) {
-            check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Check ACRO_BAL_ROLL/PITCH");
+            check_failed(Check::PARAMETERS, display_failure, "Check ACRO_BAL_ROLL/PITCH");
             return false;
         }
 #endif
 
         // pilot-speed-up parameter check
         if (copter.g.pilot_speed_up <= 0) {
-            check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Check PILOT_SPEED_UP");
+            check_failed(Check::PARAMETERS, display_failure, "Check PILOT_SPEED_UP");
             return false;
         }
 
@@ -235,13 +235,13 @@ bool AP_Arming_Copter::parameter_checks(bool display_failure)
         char fail_msg[100]{};
         // check input manager parameters
         if (!copter.input_manager.parameter_check(fail_msg, ARRAY_SIZE(fail_msg))) {
-            check_failed(ARMING_CHECK_PARAMETERS, display_failure, "%s", fail_msg);
+            check_failed(Check::PARAMETERS, display_failure, "%s", fail_msg);
             return false;
         }
 
         // Ensure an Aux Channel is configured for motor interlock
         if (rc().find_channel_for_option(RC_Channel::AUX_FUNC::MOTOR_INTERLOCK) == nullptr) {
-            check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Motor Interlock not configured");
+            check_failed(Check::PARAMETERS, display_failure, "Motor Interlock not configured");
             return false;
         }
 
@@ -250,7 +250,7 @@ bool AP_Arming_Copter::parameter_checks(bool display_failure)
         case AP_Motors::MOTOR_FRAME_HELI_QUAD:
         case AP_Motors::MOTOR_FRAME_HELI_DUAL:
         case AP_Motors::MOTOR_FRAME_HELI:
-            check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Invalid MultiCopter FRAME_CLASS");
+            check_failed(Check::PARAMETERS, display_failure, "Invalid MultiCopter FRAME_CLASS");
             return false;
 
         default:
@@ -265,22 +265,22 @@ bool AP_Arming_Copter::parameter_checks(bool display_failure)
             const char *failure_template = "RTL_ALT_TYPE is above-terrain but %s";
             switch (copter.wp_nav->get_terrain_source()) {
             case AC_WPNav::TerrainSource::TERRAIN_UNAVAILABLE:
-                check_failed(ARMING_CHECK_PARAMETERS, display_failure, failure_template, "no terrain data");
+                check_failed(Check::PARAMETERS, display_failure, failure_template, "no terrain data");
                 return false;
                 break;
             case AC_WPNav::TerrainSource::TERRAIN_FROM_RANGEFINDER:
 #if AP_RANGEFINDER_ENABLED
                 if (!copter.rangefinder_state.enabled || !copter.rangefinder.has_orientation(ROTATION_PITCH_270)) {
-                    check_failed(ARMING_CHECK_PARAMETERS, display_failure, failure_template, "no rangefinder");
+                    check_failed(Check::PARAMETERS, display_failure, failure_template, "no rangefinder");
                     return false;
                 }
                 // check if RTL_ALT is higher than rangefinder's max range
                 if (copter.g.rtl_altitude > copter.rangefinder.max_distance_orient(ROTATION_PITCH_270) * 100) {
-                    check_failed(ARMING_CHECK_PARAMETERS, display_failure, failure_template, "RTL_ALT (in cm) above RNGFND_MAX (in metres)");
+                    check_failed(Check::PARAMETERS, display_failure, failure_template, "RTL_ALT (in cm) above RNGFND_MAX (in metres)");
                     return false;
                 }
 #else
-                check_failed(ARMING_CHECK_PARAMETERS, display_failure, failure_template, "rangefinder not in firmware");
+                check_failed(Check::PARAMETERS, display_failure, failure_template, "rangefinder not in firmware");
 #endif
                 break;
             case AC_WPNav::TerrainSource::TERRAIN_FROM_TERRAINDATABASE:
@@ -293,7 +293,7 @@ bool AP_Arming_Copter::parameter_checks(bool display_failure)
         // check adsb avoidance failsafe
 #if HAL_ADSB_ENABLED
         if (copter.failsafe.adsb) {
-            check_failed(ARMING_CHECK_PARAMETERS, display_failure, "ADSB threat detected");
+            check_failed(Check::PARAMETERS, display_failure, "ADSB threat detected");
             return false;
         }
 #endif
@@ -301,11 +301,11 @@ bool AP_Arming_Copter::parameter_checks(bool display_failure)
         // ensure controllers are OK with us arming:
         char failure_msg[100] = {};
         if (!copter.pos_control->pre_arm_checks("PSC", failure_msg, ARRAY_SIZE(failure_msg))) {
-            check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Bad parameter: %s", failure_msg);
+            check_failed(Check::PARAMETERS, display_failure, "Bad parameter: %s", failure_msg);
             return false;
         }
         if (!copter.attitude_control->pre_arm_checks("ATC", failure_msg, ARRAY_SIZE(failure_msg))) {
-            check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Bad parameter: %s", failure_msg);
+            check_failed(Check::PARAMETERS, display_failure, "Bad parameter: %s", failure_msg);
             return false;
         }
     }
@@ -382,14 +382,14 @@ bool AP_Arming_Copter::gps_checks(bool display_failure)
     }
 
     // return true immediately if gps check is disabled
-    if (!check_enabled(ARMING_CHECK_GPS)) {
+    if (!check_enabled(Check::GPS)) {
         AP_Notify::flags.pre_arm_gps_check = true;
         return true;
     }
 
     // warn about hdop separately - to prevent user confusion with no gps lock
     if ((copter.gps.num_sensors() > 0) && (copter.gps.get_hdop() > copter.g.gps_hdop_good)) {
-        check_failed(ARMING_CHECK_GPS, display_failure, "High GPS HDOP");
+        check_failed(Check::GPS, display_failure, "High GPS HDOP");
         AP_Notify::flags.pre_arm_gps_check = false;
         return false;
     }
@@ -417,7 +417,7 @@ bool AP_Arming_Copter::proximity_checks(bool display_failure) const
         return false;
     }
 
-    if (!check_enabled(ARMING_CHECK_PARAMETERS)) {
+    if (!check_enabled(Check::PARAMETERS)) {
         // check is disabled
         return true;
     }
@@ -429,7 +429,7 @@ bool AP_Arming_Copter::proximity_checks(bool display_failure) const
         // display error if something is within 60cm
         const float tolerance = 0.6f;
         if (distance <= tolerance) {
-            check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Proximity %d deg, %4.2fm (want > %0.1fm)", (int)angle_deg, (double)distance, (double)tolerance);
+            check_failed(Check::PARAMETERS, display_failure, "Proximity %d deg, %4.2fm (want > %0.1fm)", (int)angle_deg, (double)distance, (double)tolerance);
             return false;
         }
     }
@@ -528,7 +528,7 @@ bool AP_Arming_Copter::winch_checks(bool display_failure) const
 {
 #if AP_WINCH_ENABLED
     // pass if parameter or all arming checks disabled
-    if (!check_enabled(ARMING_CHECK_PARAMETERS)) {
+    if (!check_enabled(Check::PARAMETERS)) {
         return true;
     }
 
@@ -594,25 +594,25 @@ bool AP_Arming_Copter::arm_checks(AP_Arming::Method method)
     }
 
     // check lean angle
-    if (check_enabled(ARMING_CHECK_INS)) {
+    if (check_enabled(Check::INS)) {
         if (degrees(acosf(ahrs.cos_roll()*ahrs.cos_pitch()))*100.0f > copter.aparm.angle_max) {
-            check_failed(ARMING_CHECK_INS, true, "Leaning");
+            check_failed(Check::INS, true, "Leaning");
             return false;
         }
     }
 
     // check adsb
 #if HAL_ADSB_ENABLED
-    if (check_enabled(ARMING_CHECK_PARAMETERS)) {
+    if (check_enabled(Check::PARAMETERS)) {
         if (copter.failsafe.adsb) {
-            check_failed(ARMING_CHECK_PARAMETERS, true, "ADSB threat detected");
+            check_failed(Check::PARAMETERS, true, "ADSB threat detected");
             return false;
         }
     }
 #endif
 
     // check throttle
-    if (check_enabled(ARMING_CHECK_RC)) {
+    if (check_enabled(Check::RC)) {
 #if FRAME_CONFIG == HELI_FRAME
         const char *rc_item = "Collective";
 #else
@@ -622,13 +622,13 @@ bool AP_Arming_Copter::arm_checks(AP_Arming::Method method)
         if (!((AP_Arming::method_is_GCS(method) || method == AP_Arming::Method::SCRIPTING) && copter.flightmode->allows_GCS_or_SCR_arming_with_throttle_high())) {
             // above top of deadband is too always high
             if (copter.get_pilot_desired_climb_rate(copter.channel_throttle->get_control_in()) > 0.0f) {
-                check_failed(ARMING_CHECK_RC, true, "%s too high", rc_item);
+                check_failed(Check::RC, true, "%s too high", rc_item);
                 return false;
             }
             // in manual modes throttle must be at zero
 #if FRAME_CONFIG != HELI_FRAME
             if ((copter.flightmode->has_manual_throttle() || copter.flightmode->mode_number() == Mode::Number::DRIFT) && copter.channel_throttle->get_control_in() > 0) {
-                check_failed(ARMING_CHECK_RC, true, "%s too high", rc_item);
+                check_failed(Check::RC, true, "%s too high", rc_item);
                 return false;
             }
 #endif

--- a/ArduPlane/AP_Arming_Plane.cpp
+++ b/ArduPlane/AP_Arming_Plane.cpp
@@ -179,41 +179,41 @@ bool AP_Arming_Plane::quadplane_checks(bool display_failure)
 
     // lean angle parameter check
     if (plane.quadplane.aparm.angle_max < 1000 || plane.quadplane.aparm.angle_max > 8000) {
-        check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Check Q_ANGLE_MAX");
+        check_failed(Check::PARAMETERS, display_failure, "Check Q_ANGLE_MAX");
         ret = false;
     }
 
     if ((plane.quadplane.tailsitter.enable > 0) && (plane.quadplane.tiltrotor.enable > 0)) {
-        check_failed(ARMING_CHECK_PARAMETERS, display_failure, "set TAILSIT_ENABLE 0 or TILT_ENABLE 0");
+        check_failed(Check::PARAMETERS, display_failure, "set TAILSIT_ENABLE 0 or TILT_ENABLE 0");
         ret = false;
 
     } else {
 
         if ((plane.quadplane.tailsitter.enable > 0) && !plane.quadplane.tailsitter.enabled()) {
-            check_failed(ARMING_CHECK_PARAMETERS, display_failure, "tailsitter setup not complete, reboot");
+            check_failed(Check::PARAMETERS, display_failure, "tailsitter setup not complete, reboot");
             ret = false;
         }
 
         if ((plane.quadplane.tiltrotor.enable > 0) && !plane.quadplane.tiltrotor.enabled()) {
-            check_failed(ARMING_CHECK_PARAMETERS, display_failure, "tiltrotor setup not complete, reboot");
+            check_failed(Check::PARAMETERS, display_failure, "tiltrotor setup not complete, reboot");
             ret = false;
         }
     }
 
     // ensure controllers are OK with us arming:
     if (!plane.quadplane.pos_control->pre_arm_checks("PSC", failure_msg, ARRAY_SIZE(failure_msg))) {
-        check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Bad parameter: %s", failure_msg);
+        check_failed(Check::PARAMETERS, display_failure, "Bad parameter: %s", failure_msg);
         ret = false;
     }
     if (!plane.quadplane.attitude_control->pre_arm_checks("ATC", failure_msg, ARRAY_SIZE(failure_msg))) {
-        check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Bad parameter: %s", failure_msg);
+        check_failed(Check::PARAMETERS, display_failure, "Bad parameter: %s", failure_msg);
         ret = false;
     }
 
     /*
       Q_ASSIST_SPEED really should be enabled for all quadplanes except tailsitters
      */
-    if (check_enabled(ARMING_CHECK_PARAMETERS) &&
+    if (check_enabled(Check::PARAMETERS) &&
         is_zero(plane.quadplane.assist.speed) &&
         !plane.quadplane.tailsitter.enabled()) {
         check_failed(display_failure,"Q_ASSIST_SPEED is not set");
@@ -221,7 +221,7 @@ bool AP_Arming_Plane::quadplane_checks(bool display_failure)
     }
 
     if ((plane.quadplane.tailsitter.enable > 0) && (plane.quadplane.q_fwd_thr_use != QuadPlane::FwdThrUse::OFF)) {
-        check_failed(ARMING_CHECK_PARAMETERS, display_failure, "set Q_FWD_THR_USE to 0");
+        check_failed(Check::PARAMETERS, display_failure, "set Q_FWD_THR_USE to 0");
         ret = false;
     }
 
@@ -237,10 +237,10 @@ bool AP_Arming_Plane::ins_checks(bool display_failure)
     }
 
     // additional plane specific checks
-    if (check_enabled(ARMING_CHECK_INS)) {
+    if (check_enabled(Check::INS)) {
         char failure_msg[50] = {};
         if (!AP::ahrs().pre_arm_check(true, failure_msg, sizeof(failure_msg))) {
-            check_failed(ARMING_CHECK_INS, display_failure, "AHRS: %s", failure_msg);
+            check_failed(Check::INS, display_failure, "AHRS: %s", failure_msg);
             return false;
         }
     }
@@ -443,11 +443,11 @@ bool AP_Arming_Plane::mission_checks(bool report)
     if (plane.g.rtl_autoland == RtlAutoland::RTL_DISABLE) {
         if (plane.mission.contains_item(MAV_CMD_DO_LAND_START)) {
             ret = false;
-            check_failed(ARMING_CHECK_MISSION, report, "DO_LAND_START set and RTL_AUTOLAND disabled");
+            check_failed(Check::MISSION, report, "DO_LAND_START set and RTL_AUTOLAND disabled");
         }
         if (plane.mission.contains_item(MAV_CMD_DO_RETURN_PATH_START)) {
             ret = false;
-            check_failed(ARMING_CHECK_MISSION, report, "DO_RETURN_PATH_START set and RTL_AUTOLAND disabled");
+            check_failed(Check::MISSION, report, "DO_RETURN_PATH_START set and RTL_AUTOLAND disabled");
         }
     }
 #if HAL_QUADPLANE_ENABLED
@@ -467,7 +467,7 @@ bool AP_Arming_Plane::mission_checks(bool report)
                 const float min_dist = 0.75 * plane.quadplane.stopping_distance(sq(landing_speed));
                 if (dist < min_dist) {
                     ret = false;
-                    check_failed(ARMING_CHECK_MISSION, report, "VTOL land too short, min %.0fm", min_dist);
+                    check_failed(Check::MISSION, report, "VTOL land too short, min %.0fm", min_dist);
                 }
             }
             prev_cmd = cmd;

--- a/ArduSub/AP_Arming_Sub.cpp
+++ b/ArduSub/AP_Arming_Sub.cpp
@@ -63,10 +63,10 @@ bool AP_Arming_Sub::ins_checks(bool display_failure)
     }
 
     // additional sub-specific checks
-    if (check_enabled(ARMING_CHECK_INS)) {
+    if (check_enabled(Check::INS)) {
         char failure_msg[50] = {};
         if (!AP::ahrs().pre_arm_check(false, failure_msg, sizeof(failure_msg))) {
-            check_failed(ARMING_CHECK_INS, display_failure, "AHRS: %s", failure_msg);
+            check_failed(Check::INS, display_failure, "AHRS: %s", failure_msg);
             return false;
         }
     }
@@ -152,8 +152,8 @@ bool AP_Arming_Sub::arm(AP_Arming::Method method, bool do_arming_checks)
     // if we do not have an ekf origin then we can't use the WMM tables
     if (!sub.ensure_ekf_origin()) {
         gcs().send_text(MAV_SEVERITY_WARNING, "Compass performance degraded");
-        if (check_enabled(ARMING_CHECK_PARAMETERS)) {
-            check_failed(ARMING_CHECK_PARAMETERS, true, "No world position, check ORIGIN_* parameters");
+        if (check_enabled(Check::PARAMETERS)) {
+            check_failed(Check::PARAMETERS, true, "No world position, check ORIGIN_* parameters");
             return false;
         }
     }

--- a/ArduSub/Parameters.h
+++ b/ArduSub/Parameters.h
@@ -378,9 +378,9 @@ extern const AP_Param::Info        var_info[];
 // Sub-specific default parameters
 static const struct AP_Param::defaults_table_struct defaults_table[] = {
     { "BRD_SAFETY_DEFLT",    0 },
-    { "ARMING_CHECK",        AP_Arming::ARMING_CHECK_RC |
-                             AP_Arming::ARMING_CHECK_VOLTAGE |
-                             AP_Arming::ARMING_CHECK_BATTERY},
+    { "ARMING_CHECK",        uint32_t(AP_Arming::Check::RC) |
+                             uint32_t(AP_Arming::Check::VOLTAGE) |
+                             uint32_t(AP_Arming::Check::BATTERY)},
     { "CIRCLE_RATE",         2.0f},
     { "ATC_ACCEL_Y_MAX",     110000.0f},
     { "ATC_RATE_Y_MAX",      180.0f},

--- a/Blimp/AP_Arming_Blimp.cpp
+++ b/Blimp/AP_Arming_Blimp.cpp
@@ -47,7 +47,7 @@ bool AP_Arming_Blimp::barometer_checks(bool display_failure)
 
     bool ret = true;
     // check Baro
-    if (check_enabled(ARMING_CHECK_BARO)) {
+    if (check_enabled(Check::BARO)) {
         // Check baro & inav alt are within 1m if EKF is operating in an absolute position mode.
         // Do not check if intending to operate in a ground relative height mode as EKF will output a ground relative height
         // that may differ from the baro height due to baro drift.
@@ -55,7 +55,7 @@ bool AP_Arming_Blimp::barometer_checks(bool display_failure)
         bool using_baro_ref = (!filt_status.flags.pred_horiz_pos_rel && filt_status.flags.pred_horiz_pos_abs);
         if (using_baro_ref) {
             if (fabsf(blimp.inertial_nav.get_position_z_up_cm() - blimp.baro_alt) > PREARM_MAX_ALT_DISPARITY_CM) {
-                check_failed(ARMING_CHECK_BARO, display_failure, "Altitude disparity");
+                check_failed(Check::BARO, display_failure, "Altitude disparity");
                 ret = false;
             }
         }
@@ -67,11 +67,11 @@ bool AP_Arming_Blimp::ins_checks(bool display_failure)
 {
     bool ret = AP_Arming::ins_checks(display_failure);
 
-    if (check_enabled(ARMING_CHECK_INS)) {
+    if (check_enabled(Check::INS)) {
 
         // get ekf attitude (if bad, it's usually the gyro biases)
         if (!pre_arm_ekf_attitude_check()) {
-            check_failed(ARMING_CHECK_INS, display_failure, "EKF attitude is bad");
+            check_failed(Check::INS, display_failure, "EKF attitude is bad");
             ret = false;
         }
     }
@@ -86,9 +86,9 @@ bool AP_Arming_Blimp::board_voltage_checks(bool display_failure)
     }
 
     // check battery voltage
-    if (check_enabled(ARMING_CHECK_VOLTAGE)) {
+    if (check_enabled(Check::VOLTAGE)) {
         if (blimp.battery.has_failsafed()) {
-            check_failed(ARMING_CHECK_VOLTAGE, display_failure, "Battery failsafe");
+            check_failed(Check::VOLTAGE, display_failure, "Battery failsafe");
             return false;
         }
 
@@ -104,13 +104,13 @@ bool AP_Arming_Blimp::board_voltage_checks(bool display_failure)
 bool AP_Arming_Blimp::parameter_checks(bool display_failure)
 {
     // check various parameter values
-    if (check_enabled(ARMING_CHECK_PARAMETERS)) {
+    if (check_enabled(Check::PARAMETERS)) {
 
         // failsafe parameter checks
         if (blimp.g.failsafe_throttle) {
             // check throttle min is above throttle failsafe trigger and that the trigger is above ppm encoder's loss-of-signal value of 900
             if (blimp.channel_up->get_radio_min() <= blimp.g.failsafe_throttle_value+10 || blimp.g.failsafe_throttle_value < 910) {
-                check_failed(ARMING_CHECK_PARAMETERS, display_failure, "Check FS_THR_VALUE");
+                check_failed(Check::PARAMETERS, display_failure, "Check FS_THR_VALUE");
                 return false;
             }
         }
@@ -129,7 +129,7 @@ bool AP_Arming_Blimp::motor_checks(bool display_failure)
     }
 
     // further checks enabled with parameters
-    if (!check_enabled(ARMING_CHECK_PARAMETERS)) {
+    if (!check_enabled(Check::PARAMETERS)) {
         return true;
     }
 
@@ -161,14 +161,14 @@ bool AP_Arming_Blimp::gps_checks(bool display_failure)
     }
 
     // return true immediately if gps check is disabled
-    if (!check_enabled(ARMING_CHECK_GPS)) {
+    if (!check_enabled(Check::GPS)) {
         AP_Notify::flags.pre_arm_gps_check = true;
         return true;
     }
 
     // warn about hdop separately - to prevent user confusion with no gps lock
     if (blimp.gps.get_hdop() > blimp.g.gps_hdop_good) {
-        check_failed(ARMING_CHECK_GPS, display_failure, "High GPS HDOP");
+        check_failed(Check::GPS, display_failure, "High GPS HDOP");
         AP_Notify::flags.pre_arm_gps_check = false;
         return false;
     }

--- a/Rover/AP_Arming_Rover.cpp
+++ b/Rover/AP_Arming_Rover.cpp
@@ -5,7 +5,7 @@
 bool AP_Arming_Rover::rc_calibration_checks(const bool display_failure)
 {
     // set rc-checks to success if RC checks are disabled
-    if (!check_enabled(ARMING_CHECK_RC)) {
+    if (!check_enabled(Check::RC)) {
         return true;
     }
 
@@ -20,11 +20,11 @@ bool AP_Arming_Rover::rc_calibration_checks(const bool display_failure)
         const char *channel_name = channel_names[i];
         // check if radio has been calibrated
         if (channel->get_radio_min() > RC_Channel::RC_CALIB_MIN_LIMIT_PWM) {
-            check_failed(ARMING_CHECK_RC, display_failure, "%s radio min too high", channel_name);
+            check_failed(Check::RC, display_failure, "%s radio min too high", channel_name);
             return false;
         }
         if (channel->get_radio_max() < RC_Channel::RC_CALIB_MAX_LIMIT_PWM) {
-            check_failed(ARMING_CHECK_RC, display_failure, "%s radio max too low", channel_name);
+            check_failed(Check::RC, display_failure, "%s radio max too low", channel_name);
             return false;
         }
     }
@@ -179,13 +179,13 @@ bool AP_Arming_Rover::oa_check(bool report)
 bool AP_Arming_Rover::parameter_checks(bool report)
 {
     // success if parameter checks are disabled
-    if (!check_enabled(ARMING_CHECK_PARAMETERS)) {
+    if (!check_enabled(Check::PARAMETERS)) {
         return true;
     }
 
     // check waypoint speed is positive
     if (!is_positive(rover.g2.wp_nav.get_default_speed())) {
-        check_failed(ARMING_CHECK_PARAMETERS, report, "WP_SPEED too low");
+        check_failed(Check::PARAMETERS, report, "WP_SPEED too low");
         return false;
     }
 

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -160,7 +160,7 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     // @Bitmask: 0:All,1:Barometer,2:Compass,3:GPS lock,4:INS,5:Parameters,6:RC Channels,7:Board voltage,8:Battery Level,10:Logging Available,11:Hardware safety switch,12:GPS Configuration,13:System,14:Mission,15:Rangefinder,16:Camera,17:AuxAuth,18:VisualOdometry,19:FFT
     // @Bitmask{Plane}: 0:All,1:Barometer,2:Compass,3:GPS lock,4:INS,5:Parameters,6:RC Channels,7:Board voltage,8:Battery Level,9:Airspeed,10:Logging Available,11:Hardware safety switch,12:GPS Configuration,13:System,14:Mission,15:Rangefinder,16:Camera,17:AuxAuth,19:FFT
     // @User: Standard
-    AP_GROUPINFO("CHECK",        8,     AP_Arming,  checks_to_perform,       ARMING_CHECK_ALL),
+    AP_GROUPINFO("CHECK",        8,     AP_Arming,  checks_to_perform,       float(Check::ALL)),
 
     // @Param: OPTIONS
     // @DisplayName: Arming options
@@ -281,15 +281,15 @@ uint32_t AP_Arming::get_enabled_checks() const
     return checks_to_perform;
 }
 
-bool AP_Arming::check_enabled(const enum AP_Arming::ArmingChecks check) const
+bool AP_Arming::check_enabled(const AP_Arming::Check check) const
 {
-    if (checks_to_perform & ARMING_CHECK_ALL) {
+    if (checks_to_perform & uint32_t(Check::ALL)) {
         return true;
     }
-    return (checks_to_perform & check);
+    return (checks_to_perform & uint32_t(check));
 }
 
-void AP_Arming::check_failed(const enum AP_Arming::ArmingChecks check, bool report, const char *fmt, ...) const
+void AP_Arming::check_failed(const AP_Arming::Check check, bool report, const char *fmt, ...) const
 {
     if (!report) {
         return;
@@ -353,10 +353,10 @@ bool AP_Arming::barometer_checks(bool report)
         return true;
     }
 #endif
-    if (check_enabled(ARMING_CHECK_BARO)) {
+    if (check_enabled(Check::BARO)) {
         char buffer[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1] {};
         if (!AP::baro().arming_checks(sizeof(buffer), buffer)) {
-            check_failed(ARMING_CHECK_BARO, report, "Baro: %s", buffer);
+            check_failed(Check::BARO, report, "Baro: %s", buffer);
             return false;
         }
     }
@@ -367,7 +367,7 @@ bool AP_Arming::barometer_checks(bool report)
 #if AP_AIRSPEED_ENABLED
 bool AP_Arming::airspeed_checks(bool report)
 {
-    if (check_enabled(ARMING_CHECK_AIRSPEED)) {
+    if (check_enabled(Check::AIRSPEED)) {
         const AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
         if (airspeed == nullptr) {
             // not an airspeed capable vehicle
@@ -375,7 +375,7 @@ bool AP_Arming::airspeed_checks(bool report)
         }
         char buffer[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1] {};
         if (!airspeed->arming_checks(sizeof(buffer), buffer)) {
-            check_failed(ARMING_CHECK_AIRSPEED, report, "Airspeed: %s", buffer);
+            check_failed(Check::AIRSPEED, report, "Airspeed: %s", buffer);
             return false;
         }
     }
@@ -387,21 +387,21 @@ bool AP_Arming::airspeed_checks(bool report)
 #if HAL_LOGGING_ENABLED
 bool AP_Arming::logging_checks(bool report)
 {
-    if (check_enabled(ARMING_CHECK_LOGGING)) {
+    if (check_enabled(Check::LOGGING)) {
         if (!AP::logger().logging_present()) {
             // Logging is disabled, so nothing to check.
             return true;
         }
         if (AP::logger().logging_failed()) {
-            check_failed(ARMING_CHECK_LOGGING, report, "Logging failed");
+            check_failed(Check::LOGGING, report, "Logging failed");
             return false;
         }
         if (!AP::logger().CardInserted()) {
-            check_failed(ARMING_CHECK_LOGGING, report, "No SD card");
+            check_failed(Check::LOGGING, report, "No SD card");
             return false;
         }
         if (AP::logger().in_log_download()) {
-            check_failed(ARMING_CHECK_LOGGING, report, "Downloading logs");
+            check_failed(Check::LOGGING, report, "Downloading logs");
             return false;
         }
     }
@@ -461,53 +461,53 @@ bool AP_Arming::ins_gyros_consistent(const AP_InertialSensor &ins)
 
 bool AP_Arming::ins_checks(bool report)
 {
-    if (check_enabled(ARMING_CHECK_INS)) {
+    if (check_enabled(Check::INS)) {
         const AP_InertialSensor &ins = AP::ins();
         if (!ins.get_gyro_health_all()) {
-            check_failed(ARMING_CHECK_INS, report, "Gyros not healthy");
+            check_failed(Check::INS, report, "Gyros not healthy");
             return false;
         }
         if (!ins.gyro_calibrated_ok_all()) {
-            check_failed(ARMING_CHECK_INS, report, "Gyros not calibrated");
+            check_failed(Check::INS, report, "Gyros not calibrated");
             return false;
         }
         if (!ins.get_accel_health_all()) {
-            check_failed(ARMING_CHECK_INS, report, "Accels not healthy");
+            check_failed(Check::INS, report, "Accels not healthy");
             return false;
         }
         if (!ins.accel_calibrated_ok_all()) {
-            check_failed(ARMING_CHECK_INS, report, "3D Accel calibration needed");
+            check_failed(Check::INS, report, "3D Accel calibration needed");
             return false;
         }
         
         //check if accelerometers have calibrated and require reboot
         if (ins.accel_cal_requires_reboot()) {
-            check_failed(ARMING_CHECK_INS, report, "Accels calibrated requires reboot");
+            check_failed(Check::INS, report, "Accels calibrated requires reboot");
             return false;
         }
 
         // check all accelerometers point in roughly same direction
         if (!ins_accels_consistent(ins)) {
-            check_failed(ARMING_CHECK_INS, report, "Accels inconsistent");
+            check_failed(Check::INS, report, "Accels inconsistent");
             return false;
         }
 
         // check all gyros are giving consistent readings
         if (!ins_gyros_consistent(ins)) {
-            check_failed(ARMING_CHECK_INS, report, "Gyros inconsistent");
+            check_failed(Check::INS, report, "Gyros inconsistent");
             return false;
         }
 
         // no arming while doing temp cal
         if (ins.temperature_cal_running()) {
-            check_failed(ARMING_CHECK_INS, report, "temperature cal running");
+            check_failed(Check::INS, report, "temperature cal running");
             return false;
         }
 
 #if AP_INERTIALSENSOR_BATCHSAMPLER_ENABLED
         // If Batch sampling enabled it must be initialized
         if (ins.batchsampler.enabled() && !ins.batchsampler.is_initialised()) {
-            check_failed(ARMING_CHECK_INS, report, "Batch sampling requires reboot");
+            check_failed(Check::INS, report, "Batch sampling requires reboot");
             return false;
         }
 #endif
@@ -515,20 +515,20 @@ bool AP_Arming::ins_checks(bool report)
         // check if IMU gyro updates are greater than or equal to Ardupilot Loop rate
         char fail_msg[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
         if (!ins.pre_arm_check_gyro_backend_rate_hz(fail_msg, ARRAY_SIZE(fail_msg))) {
-            check_failed(ARMING_CHECK_INS, report, "%s", fail_msg);
+            check_failed(Check::INS, report, "%s", fail_msg);
             return false;
         }
     }
 
 #if HAL_GYROFFT_ENABLED
     // gyros are healthy so check the FFT
-    if (check_enabled(ARMING_CHECK_FFT)) {
+    if (check_enabled(Check::FFT)) {
         // Check that the noise analyser works
         AP_GyroFFT *fft = AP::fft();
 
         char fail_msg[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
         if (fft != nullptr && !fft->pre_arm_check(fail_msg, ARRAY_SIZE(fail_msg))) {
-            check_failed(ARMING_CHECK_INS, report, "%s", fail_msg);
+            check_failed(Check::INS, report, "%s", fail_msg);
             return false;
         }
     }
@@ -556,7 +556,7 @@ bool AP_Arming::compass_checks(bool report)
     }
 #endif
 
-    if (check_enabled(ARMING_CHECK_COMPASS)) {
+    if (check_enabled(Check::COMPASS)) {
 
         // avoid Compass::use_for_yaw(void) as it implicitly calls healthy() which can
         // incorrectly skip the remaining checks, pass the primary instance directly
@@ -566,7 +566,7 @@ bool AP_Arming::compass_checks(bool report)
         }
 
         if (!_compass.healthy()) {
-            check_failed(ARMING_CHECK_COMPASS, report, "Compass not healthy");
+            check_failed(Check::COMPASS, report, "Compass not healthy");
             return false;
         }
         // check compass learning is on or offsets have been set
@@ -578,7 +578,7 @@ bool AP_Arming::compass_checks(bool report)
         {
             char failure_msg[100] = {};
             if (!_compass.configured(failure_msg, ARRAY_SIZE(failure_msg))) {
-                check_failed(ARMING_CHECK_COMPASS, report, "%s", failure_msg);
+                check_failed(Check::COMPASS, report, "%s", failure_msg);
                 return false;
             }
         }
@@ -586,20 +586,20 @@ bool AP_Arming::compass_checks(bool report)
         // check for unreasonable compass offsets
         const Vector3f offsets = _compass.get_offsets();
         if (offsets.length() > _compass.get_offsets_max()) {
-            check_failed(ARMING_CHECK_COMPASS, report, "Compass offsets too high");
+            check_failed(Check::COMPASS, report, "Compass offsets too high");
             return false;
         }
 
         // check for unreasonable mag field length
         const float mag_field = _compass.get_field().length();
         if (mag_field > AP_ARMING_COMPASS_MAGFIELD_MAX || mag_field < AP_ARMING_COMPASS_MAGFIELD_MIN) {
-            check_failed(ARMING_CHECK_COMPASS, report, "Check mag field: %4.0f, max %d, min %d", (double)mag_field, AP_ARMING_COMPASS_MAGFIELD_MAX, AP_ARMING_COMPASS_MAGFIELD_MIN);
+            check_failed(Check::COMPASS, report, "Check mag field: %4.0f, max %d, min %d", (double)mag_field, AP_ARMING_COMPASS_MAGFIELD_MAX, AP_ARMING_COMPASS_MAGFIELD_MIN);
             return false;
         }
 
         // check all compasses point in roughly same direction
         if (!_compass.consistent()) {
-            check_failed(ARMING_CHECK_COMPASS, report, "Compasses inconsistent");
+            check_failed(Check::COMPASS, report, "Compasses inconsistent");
             return false;
         }
 
@@ -612,12 +612,12 @@ bool AP_Arming::compass_checks(bool report)
             const Vector3f earth_field_mgauss = AP_Declination::get_earth_field_ga(ahrs_loc) * 1000.0;
             const Vector3f diff_mgauss = veh_mag_field_ef - earth_field_mgauss;
             if (MAX(fabsf(diff_mgauss.x), fabsf(diff_mgauss.y)) > magfield_error_threshold) {
-                check_failed(ARMING_CHECK_COMPASS, report, "Check mag field (xy diff:%.0f>%d)",
+                check_failed(Check::COMPASS, report, "Check mag field (xy diff:%.0f>%d)",
                              (double)MAX(fabsf(diff_mgauss.x), (double)fabsf(diff_mgauss.y)), (int)magfield_error_threshold);
                 return false;
             }
             if (fabsf(diff_mgauss.z) > magfield_error_threshold*2.0) {
-                check_failed(ARMING_CHECK_COMPASS, report, "Check mag field (z diff:%.0f>%d)",
+                check_failed(Check::COMPASS, report, "Check mag field (z diff:%.0f>%d)",
                              (double)fabsf(diff_mgauss.z), (int)magfield_error_threshold*2);
                 return false;
             }
@@ -632,13 +632,13 @@ bool AP_Arming::compass_checks(bool report)
 bool AP_Arming::gps_checks(bool report)
 {
     const AP_GPS &gps = AP::gps();
-    if (check_enabled(ARMING_CHECK_GPS)) {
+    if (check_enabled(Check::GPS)) {
 
         // Any failure messages from GPS backends
         char failure_msg[100] = {};
         if (!AP::gps().pre_arm_checks(failure_msg, ARRAY_SIZE(failure_msg))) {
             if (failure_msg[0] != '\0') {
-                check_failed(ARMING_CHECK_GPS, report, "%s", failure_msg);
+                check_failed(Check::GPS, report, "%s", failure_msg);
             }
             return false;
         }
@@ -651,7 +651,7 @@ bool AP_Arming::gps_checks(bool report)
 #endif
                     (gps.get_type(i) == AP_GPS::GPS_Type::GPS_TYPE_NONE)) {
                 if (gps.primary_sensor() == i) {
-                    check_failed(ARMING_CHECK_GPS, report, "GPS %i: primary but TYPE 0", i+1);
+                    check_failed(Check::GPS, report, "GPS %i: primary but TYPE 0", i+1);
                     return false;
                 }
                 continue;
@@ -659,26 +659,26 @@ bool AP_Arming::gps_checks(bool report)
 
             //GPS OK?
             if (gps.status(i) < AP_GPS::GPS_OK_FIX_3D) {
-                check_failed(ARMING_CHECK_GPS, report, "GPS %i: Bad fix", i+1);
+                check_failed(Check::GPS, report, "GPS %i: Bad fix", i+1);
                 return false;
             }
 
             //GPS update rate acceptable
             if (!gps.is_healthy(i)) {
-                check_failed(ARMING_CHECK_GPS, report, "GPS %i: not healthy", i+1);
+                check_failed(Check::GPS, report, "GPS %i: not healthy", i+1);
                 return false;
             }
         }
 
         if (!AP::ahrs().home_is_set()) {
-            check_failed(ARMING_CHECK_GPS, report, "AHRS: waiting for home");
+            check_failed(Check::GPS, report, "AHRS: waiting for home");
             return false;
         }
 
         // check GPSs are within 50m of each other and that blending is healthy
         float distance_m;
         if (!gps.all_consistent(distance_m)) {
-            check_failed(ARMING_CHECK_GPS, report, "GPS positions differ by %4.1fm",
+            check_failed(Check::GPS, report, "GPS positions differ by %4.1fm",
                          (double)distance_m);
             return false;
         }
@@ -690,17 +690,17 @@ bool AP_Arming::gps_checks(bool report)
             if (AP::ahrs().get_location(ahrs_loc)) {
                 const float distance = gps_loc.get_distance(ahrs_loc);
                 if (distance > AP_ARMING_AHRS_GPS_ERROR_MAX) {
-                    check_failed(ARMING_CHECK_GPS, report, "GPS and AHRS differ by %4.1fm", (double)distance);
+                    check_failed(Check::GPS, report, "GPS and AHRS differ by %4.1fm", (double)distance);
                     return false;
                 }
             }
         }
     }
 
-    if (check_enabled(ARMING_CHECK_GPS_CONFIG)) {
+    if (check_enabled(Check::GPS_CONFIG)) {
         uint8_t first_unconfigured;
         if (gps.first_unconfigured_gps(first_unconfigured)) {
-            check_failed(ARMING_CHECK_GPS_CONFIG,
+            check_failed(Check::GPS_CONFIG,
                          report,
                          "GPS %d still configuring this GPS",
                          first_unconfigured + 1);
@@ -718,11 +718,11 @@ bool AP_Arming::gps_checks(bool report)
 #if AP_BATTERY_ENABLED
 bool AP_Arming::battery_checks(bool report)
 {
-    if (check_enabled(ARMING_CHECK_BATTERY)) {
+    if (check_enabled(Check::BATTERY)) {
 
         char buffer[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1] {};
         if (!AP::battery().arming_checks(sizeof(buffer), buffer)) {
-            check_failed(ARMING_CHECK_BATTERY, report, "%s", buffer);
+            check_failed(Check::BATTERY, report, "%s", buffer);
             return false;
         }
      }
@@ -732,11 +732,11 @@ bool AP_Arming::battery_checks(bool report)
 
 bool AP_Arming::hardware_safety_check(bool report) 
 {
-    if (check_enabled(ARMING_CHECK_SWITCH)) {
+    if (check_enabled(Check::SWITCH)) {
 
       // check if safety switch has been pushed
       if (hal.util->safety_switch_state() == AP_HAL::Util::SAFETY_DISARMED) {
-          check_failed(ARMING_CHECK_SWITCH, report, "Hardware safety switch");
+          check_failed(Check::SWITCH, report, "Hardware safety switch");
           return false;
       }
     }
@@ -762,11 +762,11 @@ bool AP_Arming::rc_arm_checks(AP_Arming::Method method)
     bool check_passed = true;
     // ensure all rc channels have different functions
     if (rc().duplicate_options_exist()) {
-        check_failed(ARMING_CHECK_PARAMETERS, true, "Duplicate Aux Switch Options");
+        check_failed(Check::PARAMETERS, true, "Duplicate Aux Switch Options");
         check_passed = false;
     }
     if (rc().flight_mode_channel_conflicts_with_rc_option()) {
-        check_failed(ARMING_CHECK_PARAMETERS, true, "Mode channel and RC%d_OPTION conflict", rc().flight_mode_channel_number());
+        check_failed(Check::PARAMETERS, true, "Mode channel and RC%d_OPTION conflict", rc().flight_mode_channel_number());
         check_passed = false;
     }
     {
@@ -783,7 +783,7 @@ bool AP_Arming::rc_arm_checks(AP_Arming::Method method)
                 const auto *c = channel_to_check.channel;
                 if (c->get_control_in() != 0) {
                     if ((method != Method::RUDDER) || (c != rc().get_arming_channel())) { // ignore the yaw input channel if rudder arming
-                        check_failed(ARMING_CHECK_RC, true, "%s (RC%d) is not neutral", channel_to_check.name, c->ch());
+                        check_failed(Check::RC, true, "%s (RC%d) is not neutral", channel_to_check.name, c->ch());
                         check_passed = false;
                     }
                 }
@@ -794,7 +794,7 @@ bool AP_Arming::rc_arm_checks(AP_Arming::Method method)
         if (rc().arming_check_throttle()) {
             const RC_Channel *c = &rc().get_throttle_channel();
                 if (c->get_control_in() != 0) {
-                    check_failed(ARMING_CHECK_RC, true, "%s (RC%d) is not neutral", "Throttle", c->ch());
+                    check_failed(Check::RC, true, "%s (RC%d) is not neutral", "Throttle", c->ch());
                     check_passed = false;
                 }
             c = rc().find_channel_for_option(RC_Channel::AUX_FUNC::FWD_THR);
@@ -802,7 +802,7 @@ bool AP_Arming::rc_arm_checks(AP_Arming::Method method)
                 uint8_t fwd_thr = c->percent_input();
                 // require channel input within 2% of minimum
                 if (fwd_thr > 2) {
-                    check_failed(ARMING_CHECK_RC, true, "VTOL Fwd Throttle is not zero");
+                    check_failed(Check::RC, true, "VTOL Fwd Throttle is not zero");
                     check_passed = false;
                 }
             }
@@ -825,11 +825,11 @@ bool AP_Arming::rc_calibration_checks(bool report)
         }
         const uint16_t trim = c->get_radio_trim();
         if (c->get_radio_min() > trim) {
-            check_failed(ARMING_CHECK_RC, report, "RC%d_MIN is greater than RC%d_TRIM", i + 1, i + 1);
+            check_failed(Check::RC, report, "RC%d_MIN is greater than RC%d_TRIM", i + 1, i + 1);
             check_passed = false;
         }
         if (c->get_radio_max() < trim) {
-            check_failed(ARMING_CHECK_RC, report, "RC%d_MAX is less than RC%d_TRIM", i + 1, i + 1);
+            check_failed(Check::RC, report, "RC%d_MAX is less than RC%d_TRIM", i + 1, i + 1);
             check_passed = false;
         }
     }
@@ -840,7 +840,7 @@ bool AP_Arming::rc_calibration_checks(bool report)
 bool AP_Arming::rc_in_calibration_check(bool report)
 {
     if (rc().calibrating()) {
-        check_failed(ARMING_CHECK_RC, report, "RC calibrating");
+        check_failed(Check::RC, report, "RC calibrating");
         return false;
     }
     return true;
@@ -848,10 +848,10 @@ bool AP_Arming::rc_in_calibration_check(bool report)
 
 bool AP_Arming::manual_transmitter_checks(bool report)
 {
-    if (check_enabled(ARMING_CHECK_RC)) {
+    if (check_enabled(Check::RC)) {
 
         if (AP_Notify::flags.failsafe_radio) {
-            check_failed(ARMING_CHECK_RC, report, "Radio failsafe on");
+            check_failed(Check::RC, report, "Radio failsafe on");
             return false;
         }
 
@@ -868,9 +868,9 @@ bool AP_Arming::manual_transmitter_checks(bool report)
 bool AP_Arming::mission_checks(bool report)
 {
     AP_Mission *mission = AP::mission();
-    if (check_enabled(ARMING_CHECK_MISSION) && _required_mission_items) {
+    if (check_enabled(Check::MISSION) && _required_mission_items) {
         if (mission == nullptr) {
-            check_failed(ARMING_CHECK_MISSION, report, "No mission library present");
+            check_failed(Check::MISSION, report, "No mission library present");
             return false;
         }
 
@@ -889,7 +889,7 @@ bool AP_Arming::mission_checks(bool report)
         for (uint8_t i = 0; i < ARRAY_SIZE(misChecks); i++) {
             if (_required_mission_items & misChecks[i].check) {
                 if (!mission->contains_item(misChecks[i].mis_item_type)) {
-                    check_failed(ARMING_CHECK_MISSION, report, "Missing mission item: %s", misChecks[i].type);
+                    check_failed(Check::MISSION, report, "Missing mission item: %s", misChecks[i].type);
                     return false;
                 }
             }
@@ -898,31 +898,31 @@ bool AP_Arming::mission_checks(bool report)
 #if HAL_RALLY_ENABLED
             AP_Rally *rally = AP::rally();
             if (rally == nullptr) {
-                check_failed(ARMING_CHECK_MISSION, report, "No rally library present");
+                check_failed(Check::MISSION, report, "No rally library present");
                 return false;
             }
             Location ahrs_loc;
             if (!AP::ahrs().get_location(ahrs_loc)) {
-                check_failed(ARMING_CHECK_MISSION, report, "Can't check rally without position");
+                check_failed(Check::MISSION, report, "Can't check rally without position");
                 return false;
             }
             RallyLocation rally_loc = {};
             if (!rally->find_nearest_rally_point(ahrs_loc, rally_loc)) {
-                check_failed(ARMING_CHECK_MISSION, report, "No sufficiently close rally point located");
+                check_failed(Check::MISSION, report, "No sufficiently close rally point located");
                 return false;
             }
 #else
-            check_failed(ARMING_CHECK_MISSION, report, "No rally library present");
+            check_failed(Check::MISSION, report, "No rally library present");
             return false;
 #endif
         }
     }
 
 #if AP_SDCARD_STORAGE_ENABLED
-    if (check_enabled(ARMING_CHECK_MISSION) &&
+    if (check_enabled(Check::MISSION) &&
         mission != nullptr &&
         (mission->failed_sdcard_storage() || StorageManager::storage_failed())) {
-        check_failed(ARMING_CHECK_MISSION, report, "Failed to open %s", AP_MISSION_SDCARD_FILENAME);
+        check_failed(Check::MISSION, report, "Failed to open %s", AP_MISSION_SDCARD_FILENAME);
         return false;
     }
 #endif
@@ -932,7 +932,7 @@ bool AP_Arming::mission_checks(bool report)
     // (e.g.) AUTO mode
     if (AP::vehicle()->current_mode_requires_mission() &&
         (mission == nullptr || !mission->present())) {
-        check_failed(ARMING_CHECK_MISSION, report, "Mode requires mission");
+        check_failed(Check::MISSION, report, "Mode requires mission");
         return false;
     }
 #endif
@@ -944,7 +944,7 @@ bool AP_Arming::mission_checks(bool report)
 bool AP_Arming::rangefinder_checks(bool report)
 {
 #if AP_RANGEFINDER_ENABLED
-    if (check_enabled(ARMING_CHECK_RANGEFINDER)) {
+    if (check_enabled(Check::RANGEFINDER)) {
         RangeFinder *range = RangeFinder::get_singleton();
         if (range == nullptr) {
             return true;
@@ -952,7 +952,7 @@ bool AP_Arming::rangefinder_checks(bool report)
 
         char buffer[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
         if (!range->prearm_healthy(buffer, ARRAY_SIZE(buffer))) {
-            check_failed(ARMING_CHECK_RANGEFINDER, report, "%s", buffer);
+            check_failed(Check::RANGEFINDER, report, "%s", buffer);
             return false;
         }
     }
@@ -1017,12 +1017,12 @@ bool AP_Arming::servo_checks(bool report) const
 bool AP_Arming::board_voltage_checks(bool report)
 {
     // check board voltage
-    if (check_enabled(ARMING_CHECK_VOLTAGE)) {
+    if (check_enabled(Check::VOLTAGE)) {
 #if HAL_HAVE_BOARD_VOLTAGE
         const float bus_voltage =  hal.analogin->board_voltage();
         const float vbus_min = AP_BoardConfig::get_minimum_board_voltage();
         if(((bus_voltage < vbus_min) || (bus_voltage > AP_ARMING_BOARD_VOLTAGE_MAX))) {
-            check_failed(ARMING_CHECK_VOLTAGE, report, "Board (%1.1fv) out of range %1.1f-%1.1fv", (double)bus_voltage, (double)vbus_min, (double)AP_ARMING_BOARD_VOLTAGE_MAX);
+            check_failed(Check::VOLTAGE, report, "Board (%1.1fv) out of range %1.1f-%1.1fv", (double)bus_voltage, (double)vbus_min, (double)AP_ARMING_BOARD_VOLTAGE_MAX);
             return false;
         }
 #endif // HAL_HAVE_BOARD_VOLTAGE
@@ -1032,7 +1032,7 @@ bool AP_Arming::board_voltage_checks(bool report)
         if (is_positive(vservo_min)) {
             const float servo_voltage =  hal.analogin->servorail_voltage();
             if (servo_voltage < vservo_min) {
-                check_failed(ARMING_CHECK_VOLTAGE, report, "Servo voltage to low (%1.2fv < %1.2fv)", (double)servo_voltage, (double)vservo_min);
+                check_failed(Check::VOLTAGE, report, "Servo voltage to low (%1.2fv < %1.2fv)", (double)servo_voltage, (double)vservo_min);
                 return false;
             }
         }
@@ -1045,7 +1045,7 @@ bool AP_Arming::board_voltage_checks(bool report)
 #if HAL_HAVE_IMU_HEATER
 bool AP_Arming::heater_min_temperature_checks(bool report)
 {
-    if (checks_to_perform & ARMING_CHECK_ALL) {
+    if (checks_to_perform & uint32_t(Check::ALL)) {
         AP_BoardConfig *board = AP::boardConfig();
         if (board) {
             float temperature;
@@ -1053,7 +1053,7 @@ bool AP_Arming::heater_min_temperature_checks(bool report)
             if (board->get_board_heater_temperature(temperature) &&
                 board->get_board_heater_arming_temperature(min_temperature) &&
                 (temperature < min_temperature)) {
-                check_failed(ARMING_CHECK_SYSTEM, report, "heater temp low (%0.1f < %i)", temperature, min_temperature);
+                check_failed(Check::SYSTEM, report, "heater temp low (%0.1f < %i)", temperature, min_temperature);
                 return false;
             }
         }
@@ -1069,14 +1069,14 @@ bool AP_Arming::system_checks(bool report)
 {
     char buffer[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1] {};
 
-    if (check_enabled(ARMING_CHECK_SYSTEM)) {
+    if (check_enabled(Check::SYSTEM)) {
         if (!hal.storage->healthy()) {
-            check_failed(ARMING_CHECK_SYSTEM, report, "Param storage failed");
+            check_failed(Check::SYSTEM, report, "Param storage failed");
             return false;
         }
 
         if (AP_Param::get_eeprom_full()) {
-            check_failed(ARMING_CHECK_PARAMETERS, report, "parameter storage full");
+            check_failed(Check::PARAMETERS, report, "parameter storage full");
             return false;
         }
         
@@ -1085,28 +1085,28 @@ bool AP_Arming::system_checks(bool report)
         const uint16_t expected_loop_rate = AP::scheduler().get_loop_rate_hz();
         const float loop_rate_pct =  actual_loop_rate / expected_loop_rate;
         if (loop_rate_pct < 0.90) {
-            check_failed(ARMING_CHECK_SYSTEM, report, "Main loop slow (%uHz < %uHz)", (unsigned)actual_loop_rate, (unsigned)expected_loop_rate);
+            check_failed(Check::SYSTEM, report, "Main loop slow (%uHz < %uHz)", (unsigned)actual_loop_rate, (unsigned)expected_loop_rate);
             return false;
         }
 
 #if AP_TERRAIN_AVAILABLE
         const AP_Terrain *terrain = AP_Terrain::get_singleton();
         if ((terrain != nullptr) && terrain->init_failed()) {
-            check_failed(ARMING_CHECK_SYSTEM, report, "Terrain out of memory");
+            check_failed(Check::SYSTEM, report, "Terrain out of memory");
             return false;
         }
 #endif
 #if AP_SCRIPTING_ENABLED
         const AP_Scripting *scripting = AP_Scripting::get_singleton();
         if ((scripting != nullptr) && !scripting->arming_checks(sizeof(buffer), buffer)) {
-            check_failed(ARMING_CHECK_SYSTEM, report, "%s", buffer);
+            check_failed(Check::SYSTEM, report, "%s", buffer);
             return false;
         }
 #endif
 #if HAL_ADSB_ENABLED
         AP_ADSB *adsb = AP::ADSB();
         if ((adsb != nullptr) && adsb->enabled() && adsb->init_failed()) {
-            check_failed(ARMING_CHECK_SYSTEM, report, "ADSB out of memory");
+            check_failed(Check::SYSTEM, report, "ADSB out of memory");
             return false;
         }
 #endif
@@ -1122,7 +1122,7 @@ bool AP_Arming::system_checks(bool report)
         return false;
     }
 
-    if (check_enabled(ARMING_CHECK_PARAMETERS)) {
+    if (check_enabled(Check::PARAMETERS)) {
 #if !AP_GPS_BLENDED_ENABLED
         if (!blending_auto_switch_checks(report)) {
             return false;
@@ -1131,28 +1131,28 @@ bool AP_Arming::system_checks(bool report)
 #if AP_RPM_ENABLED
         auto *rpm = AP::rpm();
         if (rpm && !rpm->arming_checks(sizeof(buffer), buffer)) {
-            check_failed(ARMING_CHECK_PARAMETERS, report, "%s", buffer);
+            check_failed(Check::PARAMETERS, report, "%s", buffer);
             return false;
         }
 #endif
 #if AP_RELAY_ENABLED
         auto *relay = AP::relay();
         if (relay && !relay->arming_checks(sizeof(buffer), buffer)) {
-            check_failed(ARMING_CHECK_PARAMETERS, report, "%s", buffer);
+            check_failed(Check::PARAMETERS, report, "%s", buffer);
             return false;
         }
 #endif
 #if HAL_PARACHUTE_ENABLED
         auto *chute = AP::parachute();
         if (chute && !chute->arming_checks(sizeof(buffer), buffer)) {
-            check_failed(ARMING_CHECK_PARAMETERS, report, "%s", buffer);
+            check_failed(Check::PARAMETERS, report, "%s", buffer);
             return false;
         }
 #endif
 #if HAL_BUTTON_ENABLED
         const auto &button = AP::button();
         if (!button.arming_checks(sizeof(buffer), buffer)) {
-            check_failed(ARMING_CHECK_PARAMETERS, report, "%s", buffer);
+            check_failed(Check::PARAMETERS, report, "%s", buffer);
             return false;
         }
 #endif
@@ -1179,7 +1179,7 @@ bool AP_Arming::terrain_database_required() const
 // check terrain database is fit-for-purpose
 bool AP_Arming::terrain_checks(bool report) const
 {
-    if (!check_enabled(ARMING_CHECK_PARAMETERS)) {
+    if (!check_enabled(Check::PARAMETERS)) {
         return true;
     }
 
@@ -1197,20 +1197,20 @@ bool AP_Arming::terrain_checks(bool report) const
     }
 
     if (!terrain->enabled()) {
-        check_failed(ARMING_CHECK_PARAMETERS, report, "terrain disabled");
+        check_failed(Check::PARAMETERS, report, "terrain disabled");
         return false;
     }
 
     char fail_msg[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
     if (!terrain->pre_arm_checks(fail_msg, sizeof(fail_msg))) {
-        check_failed(ARMING_CHECK_PARAMETERS, report, "%s", fail_msg);
+        check_failed(Check::PARAMETERS, report, "%s", fail_msg);
         return false;
     }
 
     return true;
 
 #else
-    check_failed(ARMING_CHECK_PARAMETERS, report, "terrain required but disabled");
+    check_failed(Check::PARAMETERS, report, "terrain required but disabled");
     return false;
 #endif
 }
@@ -1237,7 +1237,7 @@ bool AP_Arming::proximity_checks(bool report) const
 #if HAL_MAX_CAN_PROTOCOL_DRIVERS && HAL_CANMANAGER_ENABLED
 bool AP_Arming::can_checks(bool report)
 {
-    if (check_enabled(ARMING_CHECK_SYSTEM)) {
+    if (check_enabled(Check::SYSTEM)) {
         char fail_msg[100] = {};
         (void)fail_msg; // might be left unused
         uint8_t num_drivers = AP::can().get_num_drivers();
@@ -1249,12 +1249,12 @@ bool AP_Arming::can_checks(bool report)
                     AP_PiccoloCAN *ap_pcan = AP_PiccoloCAN::get_pcan(i);
 
                     if (ap_pcan != nullptr && !ap_pcan->pre_arm_check(fail_msg, ARRAY_SIZE(fail_msg))) {
-                        check_failed(ARMING_CHECK_SYSTEM, report, "PiccoloCAN: %s", fail_msg);
+                        check_failed(Check::SYSTEM, report, "PiccoloCAN: %s", fail_msg);
                         return false;
                     }
 
 #else
-                    check_failed(ARMING_CHECK_SYSTEM, report, "PiccoloCAN not enabled");
+                    check_failed(Check::SYSTEM, report, "PiccoloCAN not enabled");
                     return false;
 #endif
                     break;
@@ -1264,7 +1264,7 @@ bool AP_Arming::can_checks(bool report)
 #if HAL_ENABLE_DRONECAN_DRIVERS
                     AP_DroneCAN *ap_dronecan = AP_DroneCAN::get_dronecan(i);
                     if (ap_dronecan != nullptr && !ap_dronecan->prearm_check(fail_msg, ARRAY_SIZE(fail_msg))) {
-                        check_failed(ARMING_CHECK_SYSTEM, report, "DroneCAN: %s", fail_msg);
+                        check_failed(Check::SYSTEM, report, "DroneCAN: %s", fail_msg);
                         return false;
                     }
 #endif
@@ -1277,7 +1277,7 @@ bool AP_Arming::can_checks(bool report)
                 {
                     for (uint8_t j = i; j; j--) {
                         if (AP::can().get_driver_type(i) == AP::can().get_driver_type(j-1)) {
-                            check_failed(ARMING_CHECK_SYSTEM, report, "Same rfnd on different CAN ports");
+                            check_failed(Check::SYSTEM, report, "Same rfnd on different CAN ports");
                             return false;
                         }
                     }
@@ -1328,7 +1328,7 @@ bool AP_Arming::fence_checks(bool display_failure)
 #if AP_CAMERA_RUNCAM_ENABLED
 bool AP_Arming::camera_checks(bool display_failure)
 {
-    if (check_enabled(ARMING_CHECK_CAMERA)) {
+    if (check_enabled(Check::CAMERA)) {
         AP_RunCam *runcam = AP::runcam();
         if (runcam == nullptr) {
             return true;
@@ -1337,7 +1337,7 @@ bool AP_Arming::camera_checks(bool display_failure)
         // check camera is ready
         char fail_msg[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
         if (!runcam->pre_arm_check(fail_msg, ARRAY_SIZE(fail_msg))) {
-            check_failed(ARMING_CHECK_CAMERA, display_failure, "%s", fail_msg);
+            check_failed(Check::CAMERA, display_failure, "%s", fail_msg);
             return false;
         }
     }
@@ -1348,7 +1348,7 @@ bool AP_Arming::camera_checks(bool display_failure)
 #if OSD_ENABLED
 bool AP_Arming::osd_checks(bool display_failure) const
 {
-    if (check_enabled(ARMING_CHECK_OSD)) {
+    if (check_enabled(Check::OSD)) {
         // if no OSD then pass
         const AP_OSD *osd = AP::osd();
         if (osd == nullptr) {
@@ -1357,7 +1357,7 @@ bool AP_Arming::osd_checks(bool display_failure) const
         // do osd checks for configuration
         char fail_msg[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
         if (!osd->pre_arm_check(fail_msg, ARRAY_SIZE(fail_msg))) {
-            check_failed(ARMING_CHECK_OSD, display_failure, "%s", fail_msg);
+            check_failed(Check::OSD, display_failure, "%s", fail_msg);
             return false;
         }
    }
@@ -1368,14 +1368,14 @@ bool AP_Arming::osd_checks(bool display_failure) const
 #if HAL_MOUNT_ENABLED
 bool AP_Arming::mount_checks(bool display_failure) const
 {
-    if (check_enabled(ARMING_CHECK_CAMERA)) {
+    if (check_enabled(Check::CAMERA)) {
         AP_Mount *mount = AP::mount();
         if (mount == nullptr) {
             return true;
         }
         char fail_msg[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1] = {};
         if (!mount->pre_arm_checks(fail_msg, sizeof(fail_msg))) {
-            check_failed(ARMING_CHECK_CAMERA, display_failure, "Mount: %s", fail_msg);
+            check_failed(Check::CAMERA, display_failure, "Mount: %s", fail_msg);
             return false;
         }
     }
@@ -1394,7 +1394,7 @@ bool AP_Arming::fettec_checks(bool display_failure) const
     // check ESCs are ready
     char fail_msg[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
     if (!f->pre_arm_check(fail_msg, ARRAY_SIZE(fail_msg))) {
-        check_failed(ARMING_CHECK_ALL, display_failure, "FETtec: %s", fail_msg);
+        check_failed(Check::ALL, display_failure, "FETtec: %s", fail_msg);
         return false;
     }
     return true;
@@ -1495,9 +1495,9 @@ bool AP_Arming::aux_auth_checks(bool display_failure)
     // handle error cases
     if (aux_auth_error) {
         if (aux_auth_fail_msg == nullptr) {
-            check_failed(ARMING_CHECK_AUX_AUTH, display_failure, "memory low for auxiliary authorisation");
+            check_failed(Check::AUX_AUTH, display_failure, "memory low for auxiliary authorisation");
         } else {
-            check_failed(ARMING_CHECK_AUX_AUTH, display_failure, "Too many auxiliary authorisers");
+            check_failed(Check::AUX_AUTH, display_failure, "Too many auxiliary authorisers");
         }
         return false;
     }
@@ -1516,7 +1516,7 @@ bool AP_Arming::aux_auth_checks(bool display_failure)
         case AuxAuthStates::AUTH_FAILED:
             some_failures = true;
             if (i == aux_auth_fail_msg_source) {
-                check_failed(ARMING_CHECK_AUX_AUTH, display_failure, "%s", aux_auth_fail_msg);
+                check_failed(Check::AUX_AUTH, display_failure, "%s", aux_auth_fail_msg);
                 failure_msg_sent = true;
             }
             break;
@@ -1528,11 +1528,11 @@ bool AP_Arming::aux_auth_checks(bool display_failure)
     // send failure or waiting message
     if (some_failures) {
         if (!failure_msg_sent) {
-            check_failed(ARMING_CHECK_AUX_AUTH, display_failure, "Auxiliary authorisation refused");
+            check_failed(Check::AUX_AUTH, display_failure, "Auxiliary authorisation refused");
         }
         return false;
     } else if (waiting_for_responses) {
-        check_failed(ARMING_CHECK_AUX_AUTH, display_failure, "Waiting for auxiliary authorisation");
+        check_failed(Check::AUX_AUTH, display_failure, "Waiting for auxiliary authorisation");
         return false;
     }
 
@@ -1702,7 +1702,7 @@ bool AP_Arming::pre_arm_checks(bool report)
 bool AP_Arming::arm_checks(AP_Arming::Method method)
 {
 #if AP_RC_CHANNEL_ENABLED
-    if (check_enabled(ARMING_CHECK_RC)) {
+    if (check_enabled(Check::RC)) {
         if (!rc_arm_checks(method)) {
             return false;
         }
@@ -1710,7 +1710,7 @@ bool AP_Arming::arm_checks(AP_Arming::Method method)
 #endif
 
     // ensure the GPS drivers are ready on any final changes
-    if (check_enabled(ARMING_CHECK_GPS_CONFIG)) {
+    if (check_enabled(Check::GPS_CONFIG)) {
         if (!AP::gps().prepare_for_arming()) {
             return false;
         }
@@ -1729,8 +1729,8 @@ bool AP_Arming::arm_checks(AP_Arming::Method method)
         // If we're configured to log, prep it
         logger->PrepForArming();
         if (!logger->logging_started() &&
-            check_enabled(ARMING_CHECK_LOGGING)) {
-            check_failed(ARMING_CHECK_LOGGING, true, "Logging not started");
+            check_enabled(Check::LOGGING)) {
+            check_failed(Check::LOGGING, true, "Logging not started");
             return false;
         }
     }
@@ -1744,7 +1744,7 @@ bool AP_Arming::blending_auto_switch_checks(bool report)
 {
     if (AP::gps().get_auto_switch_type() == 2) {
         if (report) {
-            check_failed(ARMING_CHECK_GPS, true, "GPS_AUTO_SWITCH==2 but no blending");
+            check_failed(Check::GPS, true, "GPS_AUTO_SWITCH==2 but no blending");
         }
         return false;
     }
@@ -1770,7 +1770,7 @@ bool AP_Arming::crashdump_checks(bool report)
         return true;
     }
 
-    check_failed(ARMING_CHECK_PARAMETERS, true, "CrashDump data detected");
+    check_failed(Check::PARAMETERS, true, "CrashDump data detected");
 
     return false;
 }
@@ -1930,7 +1930,7 @@ AP_Arming::Required AP_Arming::arming_required() const
 bool AP_Arming::rc_checks_copter_sub(const bool display_failure, const RC_Channel *channels[4]) const
 {
     // set rc-checks to success if RC checks are disabled
-    if (!check_enabled(ARMING_CHECK_RC)) {
+    if (!check_enabled(Check::RC)) {
         return true;
     }
 
@@ -1943,11 +1943,11 @@ bool AP_Arming::rc_checks_copter_sub(const bool display_failure, const RC_Channe
         const char *channel_name = channel_names[i];
         // check if radio has been calibrated
         if (channel->get_radio_min() > RC_Channel::RC_CALIB_MIN_LIMIT_PWM) {
-            check_failed(ARMING_CHECK_RC, display_failure, "%s radio min too high", channel_name);
+            check_failed(Check::RC, display_failure, "%s radio min too high", channel_name);
             ret = false;
         }
         if (channel->get_radio_max() < RC_Channel::RC_CALIB_MAX_LIMIT_PWM) {
-            check_failed(ARMING_CHECK_RC, display_failure, "%s radio max too low", channel_name);
+            check_failed(Check::RC, display_failure, "%s radio max too low", channel_name);
             ret = false;
         }
     }
@@ -1959,7 +1959,7 @@ bool AP_Arming::rc_checks_copter_sub(const bool display_failure, const RC_Channe
 // check visual odometry is working
 bool AP_Arming::visodom_checks(bool display_failure) const
 {
-    if (!check_enabled(ARMING_CHECK_VISION)) {
+    if (!check_enabled(Check::VISION)) {
         return true;
     }
 
@@ -1967,7 +1967,7 @@ bool AP_Arming::visodom_checks(bool display_failure) const
     if (visual_odom != nullptr) {
         char fail_msg[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
         if (!visual_odom->pre_arm_check(fail_msg, ARRAY_SIZE(fail_msg))) {
-            check_failed(ARMING_CHECK_VISION, display_failure, "VisOdom: %s", fail_msg);
+            check_failed(Check::VISION, display_failure, "VisOdom: %s", fail_msg);
             return false;
         }
     }

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -21,28 +21,28 @@ public:
 
     void update();
 
-    enum ArmingChecks {
-        ARMING_CHECK_ALL         = (1U << 0),
-        ARMING_CHECK_BARO        = (1U << 1),
-        ARMING_CHECK_COMPASS     = (1U << 2),
-        ARMING_CHECK_GPS         = (1U << 3),
-        ARMING_CHECK_INS         = (1U << 4),
-        ARMING_CHECK_PARAMETERS  = (1U << 5),
-        ARMING_CHECK_RC          = (1U << 6),
-        ARMING_CHECK_VOLTAGE     = (1U << 7),
-        ARMING_CHECK_BATTERY     = (1U << 8),
-        ARMING_CHECK_AIRSPEED    = (1U << 9),
-        ARMING_CHECK_LOGGING     = (1U << 10),
-        ARMING_CHECK_SWITCH      = (1U << 11),
-        ARMING_CHECK_GPS_CONFIG  = (1U << 12),
-        ARMING_CHECK_SYSTEM      = (1U << 13),
-        ARMING_CHECK_MISSION     = (1U << 14),
-        ARMING_CHECK_RANGEFINDER = (1U << 15),
-        ARMING_CHECK_CAMERA      = (1U << 16),
-        ARMING_CHECK_AUX_AUTH    = (1U << 17),
-        ARMING_CHECK_VISION      = (1U << 18),
-        ARMING_CHECK_FFT         = (1U << 19),
-        ARMING_CHECK_OSD         = (1U << 20),
+    enum class Check {
+        ALL         = (1U << 0),
+        BARO        = (1U << 1),
+        COMPASS     = (1U << 2),
+        GPS         = (1U << 3),
+        INS         = (1U << 4),
+        PARAMETERS  = (1U << 5),
+        RC          = (1U << 6),
+        VOLTAGE     = (1U << 7),
+        BATTERY     = (1U << 8),
+        AIRSPEED    = (1U << 9),
+        LOGGING     = (1U << 10),
+        SWITCH      = (1U << 11),
+        GPS_CONFIG  = (1U << 12),
+        SYSTEM      = (1U << 13),
+        MISSION     = (1U << 14),
+        RANGEFINDER = (1U << 15),
+        CAMERA      = (1U << 16),
+        AUX_AUTH    = (1U << 17),
+        VISION      = (1U << 18),
+        FFT         = (1U << 19),
+        OSD         = (1U << 20),
     };
 
     enum class Method {
@@ -268,9 +268,9 @@ protected:
     virtual bool mandatory_checks(bool report);
 
     // returns true if a particular check is enabled
-    bool check_enabled(const enum AP_Arming::ArmingChecks check) const;
+    bool check_enabled(const AP_Arming::Check check) const;
     // handle the case where a check fails
-    void check_failed(const enum AP_Arming::ArmingChecks check, bool report, const char *fmt, ...) const FMT_PRINTF(4, 5);
+    void check_failed(const AP_Arming::Check check, bool report, const char *fmt, ...) const FMT_PRINTF(4, 5);
     void check_failed(bool report, const char *fmt, ...) const FMT_PRINTF(3, 4);
 
     void Log_Write_Arm(bool forced, AP_Arming::Method method);

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -667,7 +667,7 @@ struct PACKED log_VER {
 // @Field: TimeUS: Time since system startup
 // @Field: ArmState: true if vehicle is now armed
 // @Field: ArmChecks: arming bitmask at time of arming
-// @FieldBitmaskEnum: ArmChecks: AP_Arming::ArmingChecks
+// @FieldBitmaskEnum: ArmChecks: AP_Arming::Check
 // @Field: Forced: true if arm/disarm was forced
 // @Field: Method: method used for arming
 // @FieldValueEnum: Method: AP_Arming::Method


### PR DESCRIPTION
This is a no-compiler-output change:

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                 *                                                   
Durandal                            *      *           *       *                 *      *      *
Hitec-Airspeed           *                 *                                                   
KakuteH7-bdshot                     *      *           *       *                 *      *      *
MatekF405                           *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *                  *       *                 *      *      *
f103-QiotekPeriph        *                 *                                                   
f303-Universal           *                 *                                                   
iomcu                                                                *                         
revo-mini                           *      *           *       *                 *      *      *
skyviper-v2450                                         *                                       
```
