### PR TITLE
Prevent rotation pitch calculations from running post-rotation

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -550,6 +550,9 @@ private:
 
         // last home altitude for detecting changes
         int32_t last_home_alt_cm;
+
+        // have we finished the takeoff ratation (when it applies)?
+        bool rotation_complete;
     } auto_state;
 
 #if AP_SCRIPTING_ENABLED

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -382,6 +382,7 @@ void Plane::do_takeoff(const AP_Mission::Mission_Command& cmd)
     next_WP_loc.lng = home.lng + 10;
     auto_state.takeoff_speed_time_ms = 0;
     auto_state.takeoff_complete = false; // set flag to use gps ground course during TO. IMU will be doing yaw drift correction.
+    auto_state.rotation_complete = false;
     auto_state.height_below_takeoff_to_level_off_cm = 0;
     // Flag also used to override "on the ground" throttle disable
 

--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -73,6 +73,9 @@ bool Mode::enter()
     // disable taildrag takeoff on mode change
     plane.auto_state.fbwa_tdrag_takeoff_mode = false;
 
+    // wipe the takeoff rotation complete state
+    plane.auto_state.rotation_complete = false;
+
     // start with previous WP at current location
     plane.prev_WP_loc = plane.current_loc;
 

--- a/ArduPlane/takeoff.cpp
+++ b/ArduPlane/takeoff.cpp
@@ -183,7 +183,7 @@ void Plane::takeoff_calc_pitch(void)
 {
     // First see if TKOFF_ROTATE_SPD applies.
     // This will set the pitch for the first portion of the takeoff, up until cruise speed is reached.
-    if (g.takeoff_rotate_speed > 0) {
+    if (!auto_state.rotation_complete && g.takeoff_rotate_speed > 0) {
         // A non-zero rotate speed is recommended for ground takeoffs.
         if (auto_state.highest_airspeed < g.takeoff_rotate_speed) {
             // We have not reached rotate speed, use the specified takeoff target pitch angle.
@@ -202,6 +202,7 @@ void Plane::takeoff_calc_pitch(void)
             return;
         }
     }
+    auto_state.rotation_complete = true;
 
     // We are now past the rotation.
     // Initialize pitch limits for TECS.

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -1016,7 +1016,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         self.fly_home_land_and_disarm(timeout=240)
 
-    def fly_home_land_and_disarm(self, timeout=120):
+    def fly_home_land_and_disarm(self, timeout=180):
         filename = "flaps.txt"
         self.progress("Using %s to fly home" % filename)
         self.load_generic_mission(filename)
@@ -5014,6 +5014,38 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         self.disarm_vehicle(force=True)
 
+    def TakeoffLevelOffWind(self):
+        '''Ensure the level-off functionality works.'''
+        '''
+        This is primarily targeted to test whether the level-off angle works
+        correctly even though the groundspeed eventually drops in face of wind.
+        '''
+        tkoff_alt = 100.
+        self.set_parameters({
+            "TKOFF_ROTATE_SPD": 15.0,
+            "TKOFF_ALT": tkoff_alt,
+            "TKOFF_DIST": 500,  # Ensure stall prevention doesn't interfere with the test.
+            "TKOFF_PLIM_SEC": 5  # Give some more time to detect the level-off.
+        })
+        self.change_mode("TAKEOFF")
+
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+
+        # Wait until we're well past the rotation.
+        self.wait_groundspeed(24, 25)
+
+        self.set_parameters({
+            "SIM_WIND_DIR": 0.0,  # Set North wind.
+            "SIM_WIND_SPD": 10.0  # Enough to bring groundspeed below cruise speed.
+        })
+
+        self.wait_altitude(tkoff_alt-10, tkoff_alt, relative=True)
+        self.wait_level_flight(accuracy=10, timeout=1)  # Ensure we have roughly level-off.
+        self.delay_sim_time(5)
+
+        self.fly_home_land_and_disarm()
+
     def DCMFallback(self):
         '''Really annoy the EKF and force fallback'''
         self.reboot_sitl()
@@ -6706,6 +6738,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.TakeoffTakeoff5,
             self.TakeoffGround,
             self.TakeoffBadLevelOff,
+            self.TakeoffLevelOffWind,
             self.ForcedDCM,
             self.DCMFallback,
             self.MAVFTP,

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -4949,6 +4949,9 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         self.set_parameters({
             "TKOFF_ROTATE_SPD": 15.0,
+            "TKOFF_PLIM_SEC": 0,  # Ensure TKOFF_PLIM_SEC doesn't interfere with the test.
+            "TKOFF_DIST": 500,  # Ensure stall prevention doesn't interfere with the test.
+            "TKOFF_ALT": 100  # Ditto
         })
         self.change_mode("TAKEOFF")
 
@@ -4963,7 +4966,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             raise NotAchievedException(f"Did not achieve correct takeoff pitch ({nav_pitch}).")
 
         # Check whether we've achieved correct target pitch after rotation.
-        self.wait_groundspeed(23, 24)
+        self.wait_groundspeed(24, 25)
         m = self.assert_receive_message('NAV_CONTROLLER_OUTPUT', timeout=5)
         nav_pitch = m.nav_pitch
         if nav_pitch > 15.1 or nav_pitch < 14.9:


### PR DESCRIPTION
# Summary

This PR prevents the nav_pitch calculations related to takeoff rotation (`Plane::takeoff_calc_pitch()`) from taking place after the plane has completed the rotation.

It addresses an [issue reported for ArduPlane 4.6beta](https://discuss.ardupilot.org/t/plane-4-6-0-beta/126358/165).

# Details

The nav pitch during rotation is set to scale linearly based on the groundspeed/airspeed_cruise ratio.
After that, the rest of the pitch calculations (e.g. `calc_nav_pitch()` when airspeed is enabled) can resume.
Also, at some point, if enabled, the level-off calculations will take over and reduce the demanded pitch.

But, if due to misconfiguration or a sudden strong headwind the groundspeed falls below cruise airspeed, the rotation calculations will take effect again and override the rest.

One result can be that pitch will be held high and the level-off calculations will be ignored.
In the following SITL test, the red cursor is set on the point where a strong headwind is turned on:
![Screenshot from 2025-04-20 17-57-26](https://github.com/user-attachments/assets/df73ae98-08ef-4261-9092-36362724b799)

Another user has reported that there's also a chance to lead to a ping-pong effect, when the groundspeed oscillates around cruise airspeed:
![image](https://github.com/user-attachments/assets/9a87efff-917f-493c-a9f8-e5aaa51105bc)

The fix declares a new state flag, which gets set when the rotation is first complete.
Then, it will never let the rotation calculations to run again in the same takeoff.

![Screenshot from 2025-04-20 17-54-41](https://github.com/user-attachments/assets/947289d3-d634-4641-8b8d-555b0bf08b79)

An autotest has been created to prevent future regression.

## Additional test fix

In my local testing the autotest `Plane.TakeoffGround()` would fail locally, even though it has recently passed in CI.

I have found that this is related to the difference between `VHR_HUD.groundspeed` and `gps().groundspeed()`, both in value and publication rate.

The autotest waits for the `VFR_HUD.groundspeed` to check the nav_pitch angle, which comes from `AHRS.grounspeed`.
But `Plane::takeoff_calc_pitch()` uses `gps().groundspeed()`, which is both lower and has lower refresh rate.
As a result, at the time of the check, the nav_pitch angle was outside of the test interval (14.69<14.9) and fail the test:
![image](https://github.com/user-attachments/assets/32988489-a7ce-4a8a-a8dc-15398f620fe7)

The test shifts the check for a bit later.
It was also necessary to push back the loiter part of the takeoff, to remove the effects of level-off and stall prevention (during banks) on nav_pitch.

# Testing

Testing in SITL has been done:
[takeoff_rotation_vs_leveloff_tests.zip](https://github.com/user-attachments/files/19826072/takeoff_rotation_vs_leveloff_tests.zip)

