### PR TITLE
Plane: Fix pitch stick mixing full override

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -301,6 +301,10 @@ void Plane::stabilize_stick_mixing_fbw()
         return;
     }
 
+    // do FBW-A style pitch stick mixing. Use the same non-linear approach as
+    // roll, but based on the pitch range rather than the limits to ensure full
+    // stick deflection can override either limit regardless of current
+    // attitude.
     float pitch_input = channel_pitch->norm_input_dz();
     if (pitch_input > 0.5f) {
         pitch_input = (3*pitch_input - 1);
@@ -310,11 +314,8 @@ void Plane::stabilize_stick_mixing_fbw()
     if (fly_inverted()) {
         pitch_input = -pitch_input;
     }
-    if (pitch_input > 0) {
-        nav_pitch_cd += pitch_input * aparm.pitch_limit_max*100;
-    } else {
-        nav_pitch_cd += -(pitch_input * pitch_limit_min*100);
-    }
+    const float pitch_range = aparm.pitch_limit_max.get() - pitch_limit_min;
+    nav_pitch_cd += pitch_input * (pitch_range / 2.0f) * 100;
     nav_pitch_cd = constrain_int32(nav_pitch_cd, pitch_limit_min*100, aparm.pitch_limit_max.get()*100);
 }
 


### PR DESCRIPTION
Fixed a bug where, in certain cases, the pitch setpoint couldn't be fully overridden via stick mixing as intended. The issue occurred because the pitch offset applied at full stick deflection was calculated as twice the maximum pitch angle in the nudge direction, and since pitch limits are often asymmetric, this could be insufficient.

For example, with the default pitch range of [-25, 20], if the commanded pitch is -25º and the user nudges it fully upwards, the maximum resulting pitch would be -25 + 20 * 2 = 15º, falling short of the intended 20º.