### PR TITLE
Plane: Add roll-only stick mixing

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -280,12 +280,10 @@ void Plane::stabilize_stick_mixing_fbw()
         control_mode == &mode_training) {
         return;
     }
-    // do FBW style stick mixing. We don't treat it linearly
-    // however. For inputs up to half the maximum, we use linear
-    // addition to the nav_roll and nav_pitch. Above that it goes
-    // non-linear and ends up as 2x the maximum, to ensure that
-    // the user can direct the plane in any direction with stick
-    // mixing.
+    // do FBW style roll stick mixing. We don't treat it linearly however. For
+    // inputs up to half the maximum, we use linear addition to the nav_roll.
+    // Above that it goes non-linear and ends up as 2x the maximum, to ensure
+    // that the user can direct the plane in any direction with stick mixing.
     float roll_input = channel_roll->norm_input_dz();
     if (roll_input > 0.5f) {
         roll_input = (3*roll_input - 1);
@@ -295,6 +293,9 @@ void Plane::stabilize_stick_mixing_fbw()
     nav_roll_cd += roll_input * roll_limit_cd;
     nav_roll_cd = constrain_int32(nav_roll_cd, -roll_limit_cd, roll_limit_cd);
 
+    if (plane.g.stick_mixing == StickMixing::FBW_NO_PITCH) {
+        return;
+    }
     if ((control_mode == &mode_loiter) && (plane.flight_option_enabled(FlightOptions::ENABLE_LOITER_ALT_CONTROL))) {
         // loiter is using altitude control based on the pitch stick, don't use it again here
         return;

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -90,8 +90,8 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Param: STICK_MIXING
     // @DisplayName: Stick Mixing
-    // @Description: When enabled, this adds user stick input to the control surfaces in auto modes, allowing the user to have some degree of flight control without changing modes.  There are two types of stick mixing available. If you set STICK_MIXING to 1 then it will use "fly by wire" mixing, which controls the roll and pitch in the same way that the FBWA mode does. This is the safest option if you usually fly ArduPlane in FBWA or FBWB mode. If you set STICK_MIXING to 3 then it will apply to the yaw while in quadplane modes only, such as while doing an automatic VTOL takeoff or landing.
-    // @Values: 0:Disabled,1:FBWMixing,3:VTOL Yaw only
+    // @Description: When enabled, this adds user stick input to the control surfaces in auto modes, allowing the user to have some degree of flight control without changing modes. There are 3 types of stick mixing available. If you set STICK_MIXING to 1 or 4 then it will use "fly by wire" mixing. 4 will provide roll and yaw control, while 1 also provides FBW-A style pitch control. If you set STICK_MIXING to 3 then it will apply to the yaw while in quadplane modes only, such as while doing an automatic VTOL takeoff or landing. WARNING: FBW-A pitch control does not offer flight envelope protections. Prolonged pitch inputs in mode 1 can result in a stall or overspeed condition, and should be avoided.
+    // @Values: 0:Disabled,1:FBW style,3:VTOL Yaw only,4:FBW style (no pitch)
     // @User: Advanced
     GSCALAR(stick_mixing,           "STICK_MIXING",   uint8_t(StickMixing::FBW)),
 

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -56,6 +56,7 @@ enum class StickMixing {
     FBW      = 1,
     DIRECT_REMOVED = 2,
     VTOL_YAW = 3,
+    FBW_NO_PITCH = 4,
 };
 
 // values for RTL_AUTOLAND

--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -260,8 +260,15 @@ void Mode::run()
 {
     // Direct stick mixing functionality has been removed, so as not to remove all stick mixing from the user completely
     // the old direct option is now used to enable fbw mixing, this is easier than doing a param conversion.
-    if ((plane.g.stick_mixing == StickMixing::FBW) || (plane.g.stick_mixing == StickMixing::DIRECT_REMOVED)) {
-        plane.stabilize_stick_mixing_fbw();
+    switch ((StickMixing)plane.g.stick_mixing) {
+        case StickMixing::FBW:
+        case StickMixing::FBW_NO_PITCH:
+        case StickMixing::DIRECT_REMOVED:
+            plane.stabilize_stick_mixing_fbw();
+            break;
+        case StickMixing::NONE:
+        case StickMixing::VTOL_YAW:
+            break;
     }
     plane.stabilize_roll();
     plane.stabilize_pitch();


### PR DESCRIPTION
The current implementation of pitch stick mixing is unsafe, as it introduces an attitude override that is decoupled from the TECS, and also lacks any stall and overspeed prevention mechanisms. This means that if a pitch nudge is held long enough, an overspeed or a stall will occur.

This commit introduces a "FBW style (roll only)" setting to the STICK_MIXING parameter. It behaves like the current "FBWMixing" option for roll, but doesn't provide any pitch mixing. This is set as the default for improved safety.

Pitch stick mixing can be re-enabled by setting STICK_MIXING to "FBW-A style". This option replaces the removed "Direct" stick mixing mode in the enum. A warning about the lack of flight envelope protections in this mode has also been added to the description.

Related issue: https://github.com/ArduPilot/ardupilot/issues/29778