### PR TITLE
Plane: Use accurate roll limits if airspd. sensor

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -685,34 +685,34 @@ void Plane::apply_load_factor_roll_limits(void)
         flight_option_enabled(FlightOptions::ENABLE_FULL_AERO_LF_ROLL_LIMITS) &&
         ahrs.using_airspeed_sensor() && is_positive(aparm.airspeed_stall);
 
-    const int32_t level_roll_limit_cd = g.level_roll_limit * 100;
-    int32_t lf_roll_limit_cd = aparm.roll_limit * 100;
+    const float level_roll_limit_deg = g.level_roll_limit;
+    float lf_roll_limit_deg = aparm.roll_limit;
     if (max_load_factor <= 1) {
         if (enforce_full_roll_limit) {
-            lf_roll_limit_cd = level_roll_limit_cd;
+            lf_roll_limit_deg = level_roll_limit_deg;
         } else {
             // 25° limit to ensure maneuverability if airspeed estimate is wrong
-            lf_roll_limit_cd = 2500;
+            lf_roll_limit_deg = 25;
         }
     } else if (max_load_factor < aerodynamic_load_factor) {
         // the demanded nav_roll would take us past the aerodynamic
         // load limit. Limit our roll to a bank angle that will keep
         // the load within what the airframe can handle.
-        lf_roll_limit_cd = degrees(acosf(1.0f / max_load_factor))*100;
+        lf_roll_limit_deg = degrees(acosf(1.0f / max_load_factor));
 
         // unless enforcing full limits, allow at least 25 degrees of roll to
         // ensure the aircraft can be manoeuvered with a bad airspeed estimate.
         // At 25 degrees the load factor is 1.1 (10%)
-        if (!enforce_full_roll_limit && lf_roll_limit_cd < 2500) {
-            lf_roll_limit_cd = 2500;
+        if (!enforce_full_roll_limit && lf_roll_limit_deg < 25) {
+            lf_roll_limit_deg = 25;
         }
 
         // always allow at least the wings level threshold to prevent flyaways
-        if (lf_roll_limit_cd < level_roll_limit_cd) {
-            lf_roll_limit_cd = level_roll_limit_cd;
+        if (lf_roll_limit_deg < level_roll_limit_deg) {
+            lf_roll_limit_deg = level_roll_limit_deg;
         }
     }
 
-    nav_roll_cd = constrain_int32(nav_roll_cd, -lf_roll_limit_cd, lf_roll_limit_cd);
-    roll_limit_cd = MIN(roll_limit_cd, lf_roll_limit_cd);
+    nav_roll_cd = constrain_int32(nav_roll_cd, -lf_roll_limit_deg * 100, lf_roll_limit_deg * 100);
+    roll_limit_cd = MIN(roll_limit_cd, lf_roll_limit_deg * 100);
 }

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -671,23 +671,41 @@ void Plane::update_load_factor(void)
     float max_load_factor =
         sq(smoothed_airspeed / MAX(stall_airspeed_1g, 1));
 
+    // allow limiting roll command down to wings-level when necessary if
+    // airspeed is accurate and airspeed stall is set (implying low load factor
+    // overhead)
+    const bool enforce_full_roll_limit =
+        flight_option_enabled(FlightOptions::ENABLE_FULL_AERO_LF_ROLL_LIMITS) &&
+        ahrs.using_airspeed_sensor() && is_positive(aparm.airspeed_stall);
+
+    const int32_t level_roll_limit_cd = g.level_roll_limit * 100;
+    int32_t lf_roll_limit_cd = aparm.roll_limit * 100;
     if (max_load_factor <= 1) {
-        // our airspeed is below the minimum airspeed. Limit roll to
-        // 25 degrees
-        nav_roll_cd = constrain_int32(nav_roll_cd, -2500, 2500);
-        roll_limit_cd = MIN(roll_limit_cd, 2500);
+        if (enforce_full_roll_limit) {
+            lf_roll_limit_cd = level_roll_limit_cd;
+        } else {
+            // 25° limit to ensure maneuverability if airspeed estimate is wrong
+            lf_roll_limit_cd = 2500;
+        }
     } else if (max_load_factor < aerodynamic_load_factor) {
         // the demanded nav_roll would take us past the aerodynamic
         // load limit. Limit our roll to a bank angle that will keep
-        // the load within what the airframe can handle. We always
-        // allow at least 25 degrees of roll however, to ensure the
-        // aircraft can be manoeuvered with a bad airspeed estimate. At
-        // 25 degrees the load factor is 1.1 (10%)
-        int32_t roll_limit = degrees(acosf(1.0f / max_load_factor))*100;
-        if (roll_limit < 2500) {
-            roll_limit = 2500;
+        // the load within what the airframe can handle.
+        lf_roll_limit_cd = degrees(acosf(1.0f / max_load_factor))*100;
+
+        // unless enforcing full limits, allow at least 25 degrees of roll to
+        // ensure the aircraft can be manoeuvered with a bad airspeed estimate.
+        // At 25 degrees the load factor is 1.1 (10%)
+        if (!enforce_full_roll_limit && lf_roll_limit_cd < 2500) {
+            lf_roll_limit_cd = 2500;
         }
-        nav_roll_cd = constrain_int32(nav_roll_cd, -roll_limit, roll_limit);
-        roll_limit_cd = MIN(roll_limit_cd, roll_limit);
+
+        // always allow at least the wings level threshold to prevent flyaways
+        if (lf_roll_limit_cd < level_roll_limit_cd) {
+            lf_roll_limit_cd = level_roll_limit_cd;
+        }
     }
+
+    nav_roll_cd = constrain_int32(nav_roll_cd, -lf_roll_limit_cd, lf_roll_limit_cd);
+    roll_limit_cd = MIN(roll_limit_cd, lf_roll_limit_cd);
 }

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -627,9 +627,7 @@ void Plane::adjust_nav_pitch_throttle(void)
 
 
 /*
-  calculate a new aerodynamic_load_factor and limit nav_roll_cd to
-  ensure that the load factor does not take us below the sustainable
-  airspeed
+  calculate a new aerodynamic_load_factor
  */
 void Plane::update_load_factor(void)
 {
@@ -642,6 +640,15 @@ void Plane::update_load_factor(void)
     // loadFactor = liftForce / gravityForce, where gravityForce = liftForce * cos(roll) on balanced horizontal turn
     aerodynamic_load_factor = 1.0f / cosf(radians(demanded_roll));
 
+    apply_load_factor_roll_limits();
+}
+
+/*
+  limit nav_roll_cd to ensure that the load factor does not take us below the
+  sustainable airspeed
+ */
+void Plane::apply_load_factor_roll_limits(void)
+{
 #if HAL_QUADPLANE_ENABLED
     if (quadplane.available() && quadplane.transition->set_FW_roll_limit(roll_limit_cd)) {
         nav_roll_cd = constrain_int32(nav_roll_cd, -roll_limit_cd, roll_limit_cd);

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1082,6 +1082,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Bitmask: 13: Indicate takeoff waiting for neutral rudder with flight control surfaces
     // @Bitmask: 14: In AUTO - climb to next waypoint altitude immediately instead of linear climb
     // @Bitmask: 15: Use minimum of target and actual speed for flap setting
+    // @Bitmask: 16: Enable full aerodynamic load factor-based roll limits when an airspeed sensor is enabled and AIRSPEED_STALL is set
     // @User: Advanced
     AP_GROUPINFO("FLIGHT_OPTIONS", 13, ParametersG2, flight_options, 0),
 

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -892,6 +892,7 @@ private:
     // Attitude.cpp
     void adjust_nav_pitch_throttle(void);
     void update_load_factor(void);
+    void apply_load_factor_roll_limits(void);
     void adjust_altitude_target();
     void setup_alt_slope(void);
     int32_t get_RTL_altitude_cm() const;

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -161,6 +161,7 @@ enum FlightOptions {
     INDICATE_WAITING_FOR_RUDDER_NEUTRAL = (1<<13),
     IMMEDIATE_CLIMB_IN_AUTO = (1<<14),
     FLAP_ACTUAL_SPEED = (1<<15),
+    ENABLE_FULL_AERO_LF_ROLL_LIMITS = (1<<16),
 };
 
 enum CrowFlapOptions {


### PR DESCRIPTION
Aerodynamic load factor-based roll demand limits were only applied down to ±25º to keep the aircraft maneuverable with a bad airspeed estimate. However, with the addition of the AIRSPEED_STALL parameter, this is unsafe if the aircraft is actually flying very close to its stall speed, and can result in a spin (this has actually happened to us in a real flight flying with a bit of wind and turbulence with the airspeed target set to AIRSPEED_MIN).

This PR makes it possible for the roll demand limits to go all the way down to 0º if an airspeed sensor is fitted and in use and the AIRSPEED_STALL parameter is set, as under these conditions, the airspeed estimate is accurate and there is very little bank angle overhead to prevent a stall.