### PR TITLE
Add axis and units to AC_PosControl

### DIFF
--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -42,7 +42,7 @@ void Copter::update_throttle_hover()
     }
 
     // do not update while climbing or descending
-    if (!is_zero(pos_control->get_vel_desired_cms().z)) {
+    if (!is_zero(pos_control->get_vel_desired_NEU_cms().z)) {
         return;
     }
 
@@ -115,7 +115,7 @@ void Copter::set_accel_throttle_I_from_pilot_throttle()
     // get last throttle input sent to attitude controller
     float pilot_throttle = constrain_float(attitude_control->get_throttle_in(), 0.0f, 1.0f);
     // shift difference between pilot's throttle and hover throttle into accelerometer I
-    pos_control->get_accel_z_pid().set_integrator((pilot_throttle-motors->get_throttle_hover()) * 1000.0f);
+    pos_control->get_accel_U_pid().set_integrator((pilot_throttle-motors->get_throttle_hover()) * 1000.0f);
 }
 
 // rotate vector from vehicle's perspective to North-East frame

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -802,7 +802,7 @@ void Copter::one_hz_loop()
     if (!using_rate_thread) {
         attitude_control->set_notch_sample_rate(AP::scheduler().get_filtered_loop_rate_hz());
     }
-    pos_control->get_accel_z_pid().set_notch_sample_rate(AP::scheduler().get_filtered_loop_rate_hz());
+    pos_control->get_accel_U_pid().set_notch_sample_rate(AP::scheduler().get_filtered_loop_rate_hz());
 #if AC_CUSTOMCONTROL_MULTI_ENABLED
     custom_control.set_notch_sample_rate(AP::scheduler().get_filtered_loop_rate_hz());
 #endif

--- a/ArduCopter/GCS_Copter.cpp
+++ b/ArduCopter/GCS_Copter.cpp
@@ -43,13 +43,13 @@ void GCS_Copter::update_vehicle_sensor_status_flags(void)
         control_sensors_present |= MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL;
 
         // XY position controller
-        if (copter.pos_control->is_active_xy()) {
+        if (copter.pos_control->is_active_NE()) {
             control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL;
             control_sensors_health |= MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL;
         }
 
         // Z altitude controller
-        if (copter.pos_control->is_active_z()) {
+        if (copter.pos_control->is_active_U()) {
             control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL;
             control_sensors_health |= MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL;
         }

--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -37,7 +37,7 @@ uint8_t GCS_MAVLINK_Copter::base_mode() const
     // only get useful information from the custom_mode, which maps to
     // the APM flight mode and has a well defined meaning in the
     // ArduPlane documentation
-    if ((copter.pos_control != nullptr) && copter.pos_control->is_active_xy()) {
+    if ((copter.pos_control != nullptr) && copter.pos_control->is_active_NE()) {
         _base_mode |= MAV_MODE_FLAG_GUIDED_ENABLED;
         // note that MAV_MODE_FLAG_AUTO_ENABLED does not match what
         // APM does in any mode, as that is defined as "system finds its own goal
@@ -217,7 +217,7 @@ void GCS_MAVLINK_Copter::send_nav_controller_output() const
         targets.z * 1.0e-2f,
         flightmode->wp_bearing() * 1.0e-2f,
         MIN(flightmode->wp_distance() * 1.0e-2f, UINT16_MAX),
-        copter.pos_control->get_pos_error_z_cm() * 1.0e-2f,
+        copter.pos_control->get_pos_error_U_cm() * 1.0e-2f,
         0,
         flightmode->crosstrack_error() * 1.0e-2f);
 }
@@ -281,7 +281,7 @@ void GCS_MAVLINK_Copter::send_pid_tuning()
             pid_info = &copter.attitude_control->get_rate_yaw_pid().get_pid_info();
             break;
         case PID_TUNING_ACCZ:
-            pid_info = &copter.pos_control->get_accel_z_pid().get_pid_info();
+            pid_info = &copter.pos_control->get_accel_U_pid().get_pid_info();
             break;
         default:
             continue;
@@ -1340,7 +1340,7 @@ int16_t GCS_MAVLINK_Copter::high_latency_target_altitude() const
 
     //return units are m
     if (copter.ap.initialised) {
-        return 0.01 * (global_position_current.alt + copter.pos_control->get_pos_error_z_cm());
+        return 0.01 * (global_position_current.alt + copter.pos_control->get_pos_error_U_cm());
     }
     return 0;
     
@@ -1371,7 +1371,7 @@ uint8_t GCS_MAVLINK_Copter::high_latency_tgt_airspeed() const
 {
     if (copter.ap.initialised) {
         // return units are m/s*5
-        return MIN(copter.pos_control->get_vel_target_cms().length() * 5.0e-2, UINT8_MAX);
+        return MIN(copter.pos_control->get_vel_target_NEU_cms().length() * 5.0e-2, UINT8_MAX);
     }
     return 0;  
 }

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -36,8 +36,8 @@ void Copter::Log_Write_Control_Tuning()
     float des_alt_m = 0.0f;
     int16_t target_climb_rate_cms = 0;
     if (!flightmode->has_manual_throttle()) {
-        des_alt_m = pos_control->get_pos_target_z_cm() * 0.01f;
-        target_climb_rate_cms = pos_control->get_vel_target_z_cms();
+        des_alt_m = pos_control->get_pos_target_U_cm() * 0.01f;
+        target_climb_rate_cms = pos_control->get_vel_target_U_cms();
     }
 
     float desired_rangefinder_alt;
@@ -91,10 +91,10 @@ void Copter::Log_Write_PIDS()
         logger.Write_PID(LOG_PIDR_MSG, attitude_control->get_rate_roll_pid().get_pid_info());
         logger.Write_PID(LOG_PIDP_MSG, attitude_control->get_rate_pitch_pid().get_pid_info());
         logger.Write_PID(LOG_PIDY_MSG, attitude_control->get_rate_yaw_pid().get_pid_info());
-        logger.Write_PID(LOG_PIDA_MSG, pos_control->get_accel_z_pid().get_pid_info() );
+        logger.Write_PID(LOG_PIDA_MSG, pos_control->get_accel_U_pid().get_pid_info() );
         if (should_log(MASK_LOG_NTUN) && (flightmode->requires_GPS() || landing_with_GPS())) {
-            logger.Write_PID(LOG_PIDN_MSG, pos_control->get_vel_xy_pid().get_pid_info_x());
-            logger.Write_PID(LOG_PIDE_MSG, pos_control->get_vel_xy_pid().get_pid_info_y());
+            logger.Write_PID(LOG_PIDN_MSG, pos_control->get_vel_NE_pid().get_pid_info_x());
+            logger.Write_PID(LOG_PIDE_MSG, pos_control->get_vel_NE_pid().get_pid_info_y());
         }
     }
 }

--- a/ArduCopter/baro_ground_effect.cpp
+++ b/ArduCopter/baro_ground_effect.cpp
@@ -15,10 +15,10 @@ void Copter::update_ground_effect_detector(void)
     uint32_t tnow_ms = millis();
     float xy_des_speed_cms = 0.0f;
     float xy_speed_cms = 0.0f;
-    float des_climb_rate_cms = pos_control->get_vel_desired_cms().z;
+    float des_climb_rate_cms = pos_control->get_vel_desired_NEU_cms().z;
 
-    if (pos_control->is_active_xy()) {
-        Vector3f vel_target = pos_control->get_vel_target_cms();
+    if (pos_control->is_active_NE()) {
+        Vector3f vel_target = pos_control->get_vel_target_NEU_cms();
         vel_target.z = 0.0f;
         xy_des_speed_cms = vel_target.length();
     }
@@ -56,10 +56,10 @@ void Copter::update_ground_effect_detector(void)
     Vector3f angle_target_rad = attitude_control->get_att_target_euler_cd() * radians(0.01f);
     bool small_angle_request = cosf(angle_target_rad.x)*cosf(angle_target_rad.y) > cosf(radians(7.5f));
     bool xy_speed_low = (position_ok() || ekf_has_relative_position()) && xy_speed_cms <= 125.0f;
-    bool xy_speed_demand_low = pos_control->is_active_xy() && xy_des_speed_cms <= 125.0f;
-    bool slow_horizontal = xy_speed_demand_low || (xy_speed_low && !pos_control->is_active_xy()) || (flightmode->mode_number() == Mode::Number::ALT_HOLD && small_angle_request);
+    bool xy_speed_demand_low = pos_control->is_active_NE() && xy_des_speed_cms <= 125.0f;
+    bool slow_horizontal = xy_speed_demand_low || (xy_speed_low && !pos_control->is_active_NE()) || (flightmode->mode_number() == Mode::Number::ALT_HOLD && small_angle_request);
 
-    bool descent_demanded = pos_control->is_active_z() && des_climb_rate_cms < 0.0f;
+    bool descent_demanded = pos_control->is_active_U() && des_climb_rate_cms < 0.0f;
     bool slow_descent_demanded = descent_demanded && des_climb_rate_cms >= -100.0f;
     bool z_speed_low = fabsf(inertial_nav.get_velocity_z_up_cms()) <= 60.0f;
     bool slow_descent = (slow_descent_demanded || (z_speed_low && descent_demanded));

--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -86,7 +86,7 @@ void Copter::update_land_detector()
 #if MODE_AUTOROTATE_ENABLED
                                     || (flightmode->mode_number() == Mode::Number::AUTOROTATE && motors->get_below_land_min_coll())
 #endif
-                                    || ((!get_force_flying() || landing) && motors->limit.throttle_lower && pos_control->get_vel_desired_cms().z < 0.0f);
+                                    || ((!get_force_flying() || landing) && motors->limit.throttle_lower && pos_control->get_vel_desired_NEU_cms().z < 0.0f);
         bool throttle_mix_at_min = true;
 #else
         // check that the average throttle output is near minimum (less than 12.5% hover throttle)
@@ -307,13 +307,13 @@ void Copter::update_throttle_mix()
         const bool accel_moving = (land_accel_ef_filter.get().length() > LAND_CHECK_ACCEL_MOVING);
 
         // check for requested descent
-        bool descent_not_demanded = pos_control->get_vel_desired_cms().z >= 0.0f;
+        bool descent_not_demanded = pos_control->get_vel_desired_NEU_cms().z >= 0.0f;
 
         // check if landing
         const bool landing = flightmode->is_landing();
 
         if (((large_angle_request || get_force_flying()) && !landing) || large_angle_error || accel_moving || descent_not_demanded) {
-            attitude_control->set_throttle_mix_max(pos_control->get_vel_z_control_ratio());
+            attitude_control->set_throttle_mix_max(pos_control->get_vel_U_control_ratio());
         } else {
             attitude_control->set_throttle_mix_min();
         }

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -592,10 +592,10 @@ void Mode::make_safe_ground_handling(bool force_throttle_unlimited)
         break;
     }
 
-    pos_control->relax_velocity_controller_xy();
-    pos_control->update_xy_controller();
-    pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
-    pos_control->update_z_controller();
+    pos_control->relax_velocity_controller_NE();
+    pos_control->update_NE_controller();
+    pos_control->relax_U_controller(0.0f);   // forces throttle output to decay to zero
+    pos_control->update_U_controller();
     // we may need to move this out
     attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(0.0f, 0.0f, 0.0f);
 }
@@ -609,7 +609,7 @@ int32_t Mode::get_alt_above_ground_cm(void)
     if (copter.get_rangefinder_height_interpolated_cm(alt_above_ground_cm)) {
         return alt_above_ground_cm;
     }
-    if (!pos_control->is_active_xy()) {
+    if (!pos_control->is_active_NE()) {
         return copter.current_loc.alt;
     }
     if (copter.current_loc.get_alt_cm(Location::AltFrame::ABOVE_TERRAIN, alt_above_ground_cm)) {
@@ -640,13 +640,13 @@ void Mode::land_run_vertical_control(bool pause_descent)
         max_land_descent_velocity = MIN(max_land_descent_velocity, -abs(g.land_speed));
 
         // Compute a vertical velocity demand such that the vehicle approaches g2.land_alt_low. Without the below constraint, this would cause the vehicle to hover at g2.land_alt_low.
-        cmb_rate = sqrt_controller(MAX(g2.land_alt_low,100)-get_alt_above_ground_cm(), pos_control->get_pos_z_p().kP(), pos_control->get_max_accel_z_cmss(), G_Dt);
+        cmb_rate = sqrt_controller(MAX(g2.land_alt_low,100)-get_alt_above_ground_cm(), pos_control->get_pos_U_p().kP(), pos_control->get_max_accel_U_cmss(), G_Dt);
 
         // Constrain the demanded vertical velocity so that it is between the configured maximum descent speed and the configured minimum descent speed.
         cmb_rate = constrain_float(cmb_rate, max_land_descent_velocity, -abs(g.land_speed));
 
 #if AC_PRECLAND_ENABLED
-        const bool navigating = pos_control->is_active_xy();
+        const bool navigating = pos_control->is_active_NE();
         bool doing_precision_landing = !copter.ap.land_repo_active && copter.precland.target_acquired() && navigating;
 
         if (doing_precision_landing) {
@@ -681,7 +681,7 @@ void Mode::land_run_vertical_control(bool pause_descent)
 
     // update altitude target and call position controller
     pos_control->land_at_climb_rate_cm(cmb_rate, ignore_descent_limit);
-    pos_control->update_z_controller();
+    pos_control->update_U_controller();
 }
 
 void Mode::land_run_horizontal_control()
@@ -690,7 +690,7 @@ void Mode::land_run_horizontal_control()
 
     // relax loiter target if we might be landed
     if (copter.ap.land_complete_maybe) {
-        pos_control->soften_for_landing_xy();
+        pos_control->soften_for_landing_NE();
     }
 
     // process pilot inputs
@@ -746,17 +746,17 @@ void Mode::land_run_horizontal_control()
         Vector2f zero;
         Vector2p landing_pos = target_pos.topostype();
         // target vel will remain zero if landing target is stationary
-        pos_control->input_pos_vel_accel_xy(landing_pos, target_vel, zero);
+        pos_control->input_pos_vel_accel_NE_cm(landing_pos, target_vel, zero);
     }
 #endif
 
     if (!copter.ap.prec_land_active) {
         Vector2f accel;
-        pos_control->input_vel_accel_xy(vel_correction, accel);
+        pos_control->input_vel_accel_NE_cm(vel_correction, accel);
     }
 
     // run pos controller
-    pos_control->update_xy_controller();
+    pos_control->update_NE_controller();
     Vector3f thrust_vector = pos_control->get_thrust_vector();
 
     if (g2.wp_navalt_min > 0) {
@@ -776,7 +776,7 @@ void Mode::land_run_horizontal_control()
             thrust_vector.y *= ratio;
 
             // tell position controller we are applying an external limit
-            pos_control->set_externally_limited_xy();
+            pos_control->set_externally_limited_NE();
         }
     }
 
@@ -840,11 +840,11 @@ void Mode::precland_retry_position(const Vector3f &retry_pos)
     Vector3p retry_pos_NEU{retry_pos.x, retry_pos.y, retry_pos.z * -1.0f};
     // pos controller expects input in NEU cm's
     retry_pos_NEU = retry_pos_NEU * 100.0f;
-    pos_control->input_pos_xyz(retry_pos_NEU, 0.0f, 1000.0f);
+    pos_control->input_pos_NEU_cm(retry_pos_NEU, 0.0f, 1000.0f);
 
     // run position controllers
-    pos_control->update_xy_controller();
-    pos_control->update_z_controller();
+    pos_control->update_NE_controller();
+    pos_control->update_U_controller();
 
     // call attitude controller
     attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), auto_yaw.get_heading());
@@ -937,7 +937,7 @@ float Mode::get_pilot_desired_throttle() const
 float Mode::get_avoidance_adjusted_climbrate(float target_rate)
 {
 #if AP_AVOIDANCE_ENABLED
-    AP::ac_avoid()->adjust_velocity_z(pos_control->get_pos_z_p().kP(), pos_control->get_max_accel_z_cmss(), target_rate, G_Dt);
+    AP::ac_avoid()->adjust_velocity_z(pos_control->get_pos_U_p().kP(), pos_control->get_max_accel_U_cmss(), target_rate, G_Dt);
     return target_rate;
 #else
     return target_rate;
@@ -1059,7 +1059,7 @@ uint16_t Mode::get_pilot_speed_dn()
 Location Mode::get_stopping_point() const
 {
     Vector3p stopping_point_NEU;
-    copter.pos_control->get_stopping_point_xy_cm(stopping_point_NEU.xy());
-    copter.pos_control->get_stopping_point_z_cm(stopping_point_NEU.z);
+    copter.pos_control->get_stopping_point_NE_cm(stopping_point_NEU.xy());
+    copter.pos_control->get_stopping_point_U_cm(stopping_point_NEU.z);
     return Location { stopping_point_NEU.tofloat(), Location::AltFrame::ABOVE_ORIGIN };
 }

--- a/ArduCopter/mode_althold.cpp
+++ b/ArduCopter/mode_althold.cpp
@@ -10,13 +10,13 @@ bool ModeAltHold::init(bool ignore_checks)
 {
 
     // initialise the vertical position controller
-    if (!pos_control->is_active_z()) {
-        pos_control->init_z_controller();
+    if (!pos_control->is_active_U()) {
+        pos_control->init_U_controller();
     }
 
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
-    pos_control->set_correction_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_max_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_correction_speed_accel_U_cmss(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     return true;
 }
@@ -26,7 +26,7 @@ bool ModeAltHold::init(bool ignore_checks)
 void ModeAltHold::run()
 {
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_max_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // apply SIMPLE mode transform to pilot inputs
     update_simple_mode();
@@ -51,7 +51,7 @@ void ModeAltHold::run()
     case AltHoldModeState::MotorStopped:
         attitude_control->reset_rate_controller_I_terms();
         attitude_control->reset_yaw_target_and_rate(false);
-        pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
+        pos_control->relax_U_controller(0.0f);   // forces throttle output to decay to zero
         break;
 
     case AltHoldModeState::Landed_Ground_Idle:
@@ -60,7 +60,7 @@ void ModeAltHold::run()
 
     case AltHoldModeState::Landed_Pre_Takeoff:
         attitude_control->reset_rate_controller_I_terms_smoothly();
-        pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
+        pos_control->relax_U_controller(0.0f);   // forces throttle output to decay to zero
         break;
 
     case AltHoldModeState::Takeoff:
@@ -93,7 +93,7 @@ void ModeAltHold::run()
 #endif
 
         // Send the commanded climb rate to the position controller
-        pos_control->set_pos_target_z_from_climb_rate_cm(target_climb_rate);
+        pos_control->set_pos_target_U_from_climb_rate_cm(target_climb_rate);
         break;
     }
 
@@ -101,5 +101,5 @@ void ModeAltHold::run()
     attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(target_roll, target_pitch, target_yaw_rate);
 
     // run the vertical position controller and set output throttle
-    pos_control->update_z_controller();
+    pos_control->update_U_controller();
 }

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -410,7 +410,7 @@ void ModeAuto::takeoff_start(const Location& dest_loc)
     auto_yaw.set_mode(AutoYaw::Mode::HOLD);
 
     // clear i term when we're taking off
-    pos_control->init_z_controller();
+    pos_control->init_U_controller();
 
     // initialise alt for WP_NAVALT_MIN and set completion alt
     auto_takeoff.start(alt_target_cm, alt_target_terrain);
@@ -463,21 +463,21 @@ bool ModeAuto::wp_start(const Location& dest_loc)
 void ModeAuto::land_start()
 {
     // set horizontal speed and acceleration limits
-    pos_control->set_max_speed_accel_xy(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
-    pos_control->set_correction_speed_accel_xy(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
+    pos_control->set_max_speed_accel_NE_cm(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
+    pos_control->set_correction_speed_accel_NE_cm(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
 
     // initialise the vertical position controller
-    if (!pos_control->is_active_xy()) {
-        pos_control->init_xy_controller();
+    if (!pos_control->is_active_NE()) {
+        pos_control->init_NE_controller();
     }
 
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_z(wp_nav->get_default_speed_down(), wp_nav->get_default_speed_up(), wp_nav->get_accel_z());
-    pos_control->set_correction_speed_accel_z(wp_nav->get_default_speed_down(), wp_nav->get_default_speed_up(), wp_nav->get_accel_z());
+    pos_control->set_max_speed_accel_U_cm(wp_nav->get_default_speed_down(), wp_nav->get_default_speed_up(), wp_nav->get_accel_z());
+    pos_control->set_correction_speed_accel_U_cmss(wp_nav->get_default_speed_down(), wp_nav->get_default_speed_up(), wp_nav->get_accel_z());
 
     // initialise the vertical position controller
-    if (!pos_control->is_active_z()) {
-        pos_control->init_z_controller();
+    if (!pos_control->is_active_U()) {
+        pos_control->init_U_controller();
     }
 
     // initialise yaw
@@ -614,21 +614,21 @@ void PayloadPlace::start_descent()
     auto *wp_nav = copter.wp_nav;
 
     // set horizontal speed and acceleration limits
-    pos_control->set_max_speed_accel_xy(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
-    pos_control->set_correction_speed_accel_xy(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
+    pos_control->set_max_speed_accel_NE_cm(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
+    pos_control->set_correction_speed_accel_NE_cm(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
 
     // initialise the vertical position controller
-    if (!pos_control->is_active_xy()) {
-        pos_control->init_xy_controller();
+    if (!pos_control->is_active_NE()) {
+        pos_control->init_NE_controller();
     }
 
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_z(wp_nav->get_default_speed_down(), wp_nav->get_default_speed_up(), wp_nav->get_accel_z());
-    pos_control->set_correction_speed_accel_z(wp_nav->get_default_speed_down(), wp_nav->get_default_speed_up(), wp_nav->get_accel_z());
+    pos_control->set_max_speed_accel_U_cm(wp_nav->get_default_speed_down(), wp_nav->get_default_speed_up(), wp_nav->get_accel_z());
+    pos_control->set_correction_speed_accel_U_cmss(wp_nav->get_default_speed_down(), wp_nav->get_default_speed_up(), wp_nav->get_accel_z());
 
     // initialise the vertical position controller
-    if (!pos_control->is_active_z()) {
-        pos_control->init_z_controller();
+    if (!pos_control->is_active_U()) {
+        pos_control->init_U_controller();
     }
 
     // initialise yaw
@@ -1062,7 +1062,7 @@ void ModeAuto::wp_run()
 
     // WP_Nav has set the vertical position control targets
     // run the vertical position controller and set output throttle
-    pos_control->update_z_controller();
+    pos_control->update_U_controller();
 
     // call attitude controller with auto yaw
     attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), auto_yaw.get_heading());
@@ -1103,7 +1103,7 @@ void ModeAuto::circle_run()
 
     // WP_Nav has set the vertical position control targets
     // run the vertical position controller and set output throttle
-    pos_control->update_z_controller();
+    pos_control->update_U_controller();
 
     // call attitude controller with auto yaw
     attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), auto_yaw.get_heading());
@@ -1135,7 +1135,7 @@ void ModeAuto::loiter_run()
     // run waypoint and z-axis position controller
     copter.failsafe_terrain_set_status(wp_nav->update_wpnav());
 
-    pos_control->update_z_controller();
+    pos_control->update_U_controller();
 
     // call attitude controller with auto yaw
     attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), auto_yaw.get_heading());
@@ -1162,11 +1162,11 @@ void ModeAuto::loiter_to_alt_run()
 
     if (!loiter_to_alt.loiter_start_done) {
         // set horizontal speed and acceleration limits
-        pos_control->set_max_speed_accel_xy(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
-        pos_control->set_correction_speed_accel_xy(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
+        pos_control->set_max_speed_accel_NE_cm(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
+        pos_control->set_correction_speed_accel_NE_cm(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
 
-        if (!pos_control->is_active_xy()) {
-            pos_control->init_xy_controller();
+        if (!pos_control->is_active_NE()) {
+            pos_control->init_NE_controller();
         }
 
         loiter_to_alt.loiter_start_done = true;
@@ -1188,8 +1188,8 @@ void ModeAuto::loiter_to_alt_run()
     // approaches the desired altitude.
     float target_climb_rate = sqrt_controller(
         -alt_error_cm,
-        pos_control->get_pos_z_p().kP(),
-        pos_control->get_max_accel_z_cmss(),
+        pos_control->get_pos_U_p().kP(),
+        pos_control->get_max_accel_U_cmss(),
         G_Dt);
     target_climb_rate = constrain_float(target_climb_rate, pos_control->get_max_speed_down_cms(), pos_control->get_max_speed_up_cms());
 
@@ -1202,9 +1202,9 @@ void ModeAuto::loiter_to_alt_run()
 #endif
 
     // Send the commanded climb rate to the position controller
-    pos_control->set_pos_target_z_from_climb_rate_cm(target_climb_rate);
+    pos_control->set_pos_target_U_from_climb_rate_cm(target_climb_rate);
 
-    pos_control->update_z_controller();
+    pos_control->update_U_controller();
 }
 
 // maintain an attitude for a specified time
@@ -1231,9 +1231,9 @@ void ModeAuto::nav_attitude_time_run()
     attitude_control->input_euler_angle_roll_pitch_yaw(target_rp_cd.x, target_rp_cd.y, nav_attitude_time.yaw_deg * 100, true);
 
     // Send the commanded climb rate to the position controller
-    pos_control->set_pos_target_z_from_climb_rate_cm(target_climb_rate_cms);
+    pos_control->set_pos_target_U_from_climb_rate_cm(target_climb_rate_cms);
 
-    pos_control->update_z_controller();
+    pos_control->update_U_controller();
 }
 
 #if AC_PAYLOAD_PLACE_ENABLED
@@ -1267,7 +1267,7 @@ void PayloadPlace::run()
     // relax position target if we might be landed
     // if we discover we've landed then immediately release the load:
     if (copter.ap.land_complete || copter.ap.land_complete_maybe) {
-        pos_control->soften_for_landing_xy();
+        pos_control->soften_for_landing_NE();
         switch (state) {
         case State::FlyToLocation:
             // this is handled in wp_run()
@@ -1297,7 +1297,7 @@ void PayloadPlace::run()
         case State::Descent_Start:
             gcs().send_text(MAV_SEVERITY_INFO, "%s Abort: Gripper Open", prefix_str);
             // Descent_Start has not run so we must also initalise descent_start_altitude_cm
-            descent_start_altitude_cm = pos_control->get_pos_desired_z_cm();
+            descent_start_altitude_cm = pos_control->get_pos_desired_U_cm();
             state = State::Done;
             break;
         case State::Descent:
@@ -1324,7 +1324,7 @@ void PayloadPlace::run()
 
     case State::Descent_Start:
         descent_established_time_ms = now_ms;
-        descent_start_altitude_cm = pos_control->get_pos_desired_z_cm();
+        descent_start_altitude_cm = pos_control->get_pos_desired_U_cm();
         // limiting the decent rate to the limit set in wp_nav is not necessary but done for safety
         descent_speed_cms = MIN((is_positive(g2.pldp_descent_speed_ms)) ? g2.pldp_descent_speed_ms * 100.0 : abs(g.land_speed), wp_nav->get_default_speed_down());
         descent_thrust_level = 1.0;
@@ -1334,13 +1334,13 @@ void PayloadPlace::run()
     case State::Descent:
         // check maximum decent distance
         if (!is_zero(descent_max_cm) &&
-            descent_start_altitude_cm - pos_control->get_pos_desired_z_cm() > descent_max_cm) {
+            descent_start_altitude_cm - pos_control->get_pos_desired_U_cm() > descent_max_cm) {
             state = State::Ascent_Start;
             gcs().send_text(MAV_SEVERITY_WARNING, "%s Reached maximum descent", prefix_str);
             break;
         }
         // calibrate the decent thrust after aircraft has reached constant decent rate and release if threshold is reached
-        if (pos_control->get_vel_desired_cms().z > -0.95 * descent_speed_cms) {
+        if (pos_control->get_vel_desired_NEU_cms().z > -0.95 * descent_speed_cms) {
             // decent rate has not reached descent_speed_cms
             descent_established_time_ms = now_ms;
             break;
@@ -1383,7 +1383,7 @@ void PayloadPlace::run()
 
     case State::Release:
         // Reinitialise vertical position controller to remove discontinuity due to touch down of payload
-        pos_control->init_z_controller_no_descent();
+        pos_control->init_U_controller_no_descent();
 #if AP_GRIPPER_ENABLED
         if (AP::gripper().valid()) {
             gcs().send_text(MAV_SEVERITY_INFO, "%s Releasing the gripper", prefix_str);
@@ -1422,8 +1422,8 @@ void PayloadPlace::run()
         // distance from the target altitude stopping distance from
         // vel_threshold_fraction * max velocity
         const float vel_threshold_fraction = 0.1;
-        const float stop_distance = 0.5 * sq(vel_threshold_fraction * copter.pos_control->get_max_speed_up_cms()) / copter.pos_control->get_max_accel_z_cmss();
-        bool reached_altitude = pos_control->get_pos_desired_z_cm() >= descent_start_altitude_cm - stop_distance;
+        const float stop_distance = 0.5 * sq(vel_threshold_fraction * copter.pos_control->get_max_speed_up_cms()) / copter.pos_control->get_max_accel_U_cmss();
+        bool reached_altitude = pos_control->get_pos_desired_U_cm() >= descent_start_altitude_cm - stop_distance;
         if (reached_altitude) {
             state = State::Done;
         }
@@ -1459,10 +1459,10 @@ void PayloadPlace::run()
     case State::Done:
         float vel = 0.0;
         copter.flightmode->land_run_horizontal_control();
-        pos_control->input_pos_vel_accel_z(descent_start_altitude_cm, vel, 0.0);
+        pos_control->input_pos_vel_accel_U_cm(descent_start_altitude_cm, vel, 0.0);
         break;
     }
-    pos_control->update_z_controller();
+    pos_control->update_U_controller();
 }
 #endif
 
@@ -1477,7 +1477,7 @@ bool ModeAuto::shift_alt_to_current_alt(Location& target_loc) const
         int32_t curr_rngfnd_alt_cm;
         if (copter.get_rangefinder_height_interpolated_cm(curr_rngfnd_alt_cm)) {
             // subtract position offset (if any)
-            curr_rngfnd_alt_cm -= pos_control->get_pos_offset_z_cm();
+            curr_rngfnd_alt_cm -= pos_control->get_pos_offset_U_cm();
             // wp_nav is using rangefinder so use current rangefinder alt
             target_loc.set_alt_cm(MAX(curr_rngfnd_alt_cm, 200), Location::AltFrame::ABOVE_TERRAIN);
             return true;
@@ -1493,7 +1493,7 @@ bool ModeAuto::shift_alt_to_current_alt(Location& target_loc) const
     }
 
     // set target_loc's alt minus position offset (if any)
-    target_loc.set_alt_cm(currloc.alt - pos_control->get_pos_offset_z_cm(), currloc.get_alt_frame());
+    target_loc.set_alt_cm(currloc.alt - pos_control->get_pos_offset_U_cm(), currloc.get_alt_frame());
     return true;
 }
 
@@ -1502,7 +1502,7 @@ bool ModeAuto::shift_alt_to_current_alt(Location& target_loc) const
 void ModeAuto::subtract_pos_offsets(Location& target_loc) const
 {
     // subtract position controller offsets from target location
-    const Vector3p& pos_ofs_neu_cm = pos_control->get_pos_offset_cm();
+    const Vector3p& pos_ofs_neu_cm = pos_control->get_pos_offset_NEU_cm();
     Vector3p pos_ofs_ned_m = Vector3p{pos_ofs_neu_cm.x * 0.01, pos_ofs_neu_cm.y * 0.01, -pos_ofs_neu_cm.z * 0.01};
     target_loc.offset(-pos_ofs_ned_m);
 }
@@ -1762,8 +1762,8 @@ void ModeAuto::do_loiter_to_alt(const AP_Mission::Mission_Command& cmd)
     loiter_to_alt.alt_error_cm = 0;
 
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_z(wp_nav->get_default_speed_down(), wp_nav->get_default_speed_up(), wp_nav->get_accel_z());
-    pos_control->set_correction_speed_accel_z(wp_nav->get_default_speed_down(), wp_nav->get_default_speed_up(), wp_nav->get_accel_z());
+    pos_control->set_max_speed_accel_U_cm(wp_nav->get_default_speed_down(), wp_nav->get_default_speed_up(), wp_nav->get_accel_z());
+    pos_control->set_correction_speed_accel_U_cmss(wp_nav->get_default_speed_down(), wp_nav->get_default_speed_up(), wp_nav->get_accel_z());
 
     // set submode
     set_submode(SubMode::LOITER_TO_ALT);

--- a/ArduCopter/mode_autotune.cpp
+++ b/ArduCopter/mode_autotune.cpp
@@ -84,8 +84,8 @@ void AutoTune::get_pilot_desired_rp_yrate_cd(float &des_roll_cd, float &des_pitc
 void AutoTune::init_z_limits()
 {
     // set vertical speed and acceleration limits
-    copter.pos_control->set_max_speed_accel_z(-copter.get_pilot_speed_dn(), copter.g.pilot_speed_up, copter.g.pilot_accel_z);
-    copter.pos_control->set_correction_speed_accel_z(-copter.get_pilot_speed_dn(), copter.g.pilot_speed_up, copter.g.pilot_accel_z);
+    copter.pos_control->set_max_speed_accel_U_cm(-copter.get_pilot_speed_dn(), copter.g.pilot_speed_up, copter.g.pilot_accel_z);
+    copter.pos_control->set_correction_speed_accel_U_cmss(-copter.get_pilot_speed_dn(), copter.g.pilot_speed_up, copter.g.pilot_accel_z);
 }
 
 #if HAL_LOGGING_ENABLED

--- a/ArduCopter/mode_brake.cpp
+++ b/ArduCopter/mode_brake.cpp
@@ -10,19 +10,19 @@
 bool ModeBrake::init(bool ignore_checks)
 {
     // initialise pos controller speed and acceleration
-    pos_control->set_max_speed_accel_xy(inertial_nav.get_velocity_neu_cms().length(), BRAKE_MODE_DECEL_RATE);
-    pos_control->set_correction_speed_accel_xy(inertial_nav.get_velocity_neu_cms().length(), BRAKE_MODE_DECEL_RATE);
+    pos_control->set_max_speed_accel_NE_cm(inertial_nav.get_velocity_neu_cms().length(), BRAKE_MODE_DECEL_RATE);
+    pos_control->set_correction_speed_accel_NE_cm(inertial_nav.get_velocity_neu_cms().length(), BRAKE_MODE_DECEL_RATE);
 
     // initialise position controller
-    pos_control->init_xy_controller();
+    pos_control->init_NE_controller();
 
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_z(BRAKE_MODE_SPEED_Z, BRAKE_MODE_SPEED_Z, BRAKE_MODE_DECEL_RATE);
-    pos_control->set_correction_speed_accel_z(BRAKE_MODE_SPEED_Z, BRAKE_MODE_SPEED_Z, BRAKE_MODE_DECEL_RATE);
+    pos_control->set_max_speed_accel_U_cm(BRAKE_MODE_SPEED_Z, BRAKE_MODE_SPEED_Z, BRAKE_MODE_DECEL_RATE);
+    pos_control->set_correction_speed_accel_U_cmss(BRAKE_MODE_SPEED_Z, BRAKE_MODE_SPEED_Z, BRAKE_MODE_DECEL_RATE);
 
     // initialise the vertical position controller
-    if (!pos_control->is_active_z()) {
-        pos_control->init_z_controller();
+    if (!pos_control->is_active_U()) {
+        pos_control->init_U_controller();
     }
 
     _timeout_ms = 0;
@@ -37,7 +37,7 @@ void ModeBrake::run()
     // if not armed set throttle to zero and exit immediately
     if (is_disarmed_or_landed()) {
         make_safe_ground_handling();
-        pos_control->relax_z_controller(0.0f);
+        pos_control->relax_U_controller(0.0f);
         return;
     }
 
@@ -46,20 +46,20 @@ void ModeBrake::run()
 
     // relax stop target if we might be landed
     if (copter.ap.land_complete_maybe) {
-        pos_control->soften_for_landing_xy();
+        pos_control->soften_for_landing_NE();
     }
 
     // use position controller to stop
     Vector2f vel;
     Vector2f accel;
-    pos_control->input_vel_accel_xy(vel, accel);
-    pos_control->update_xy_controller();
+    pos_control->input_vel_accel_NE_cm(vel, accel);
+    pos_control->update_NE_controller();
 
     // call attitude controller
     attitude_control->input_thrust_vector_rate_heading(pos_control->get_thrust_vector(), 0.0f);
 
-    pos_control->set_pos_target_z_from_climb_rate_cm(0.0f);
-    pos_control->update_z_controller();
+    pos_control->set_pos_target_U_from_climb_rate_cm(0.0f);
+    pos_control->update_U_controller();
 
     // MAV_CMD_SOLO_BTN_PAUSE_CLICK (Solo only) is used to set the timeout.
     if (_timeout_ms != 0 && millis()-_timeout_start >= _timeout_ms) {

--- a/ArduCopter/mode_circle.cpp
+++ b/ArduCopter/mode_circle.cpp
@@ -13,10 +13,10 @@ bool ModeCircle::init(bool ignore_checks)
     speed_changing = false;
 
     // set speed and acceleration limits
-    pos_control->set_max_speed_accel_xy(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
-    pos_control->set_correction_speed_accel_xy(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
-    pos_control->set_max_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
-    pos_control->set_correction_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_max_speed_accel_NE_cm(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
+    pos_control->set_correction_speed_accel_NE_cm(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
+    pos_control->set_max_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_correction_speed_accel_U_cmss(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // initialise circle controller including setting the circle center based on vehicle speed
     copter.circle_nav->init();
@@ -47,8 +47,8 @@ bool ModeCircle::init(bool ignore_checks)
 void ModeCircle::run()
 {
     // set speed and acceleration limits
-    pos_control->set_max_speed_accel_xy(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
-    pos_control->set_max_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_max_speed_accel_NE_cm(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
+    pos_control->set_max_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // Check for any change in params and update in real time
     copter.circle_nav->check_param_change();
@@ -120,7 +120,7 @@ void ModeCircle::run()
 #endif
 
     copter.failsafe_terrain_set_status(copter.circle_nav->update(target_climb_rate));
-    pos_control->update_z_controller();
+    pos_control->update_U_controller();
 
     // call attitude controller with auto yaw
     attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), auto_yaw.get_heading());

--- a/ArduCopter/mode_flowhold.cpp
+++ b/ArduCopter/mode_flowhold.cpp
@@ -89,12 +89,12 @@ bool ModeFlowHold::init(bool ignore_checks)
     }
 
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
-    pos_control->set_correction_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_max_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_correction_speed_accel_U_cmss(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // initialise the vertical position controller
-    if (!copter.pos_control->is_active_z()) {
-        pos_control->init_z_controller();
+    if (!copter.pos_control->is_active_U()) {
+        pos_control->init_U_controller();
     }
 
     flow_filter.set_cutoff_frequency(copter.scheduler.get_loop_rate_hz(), flow_filter_hz.get());
@@ -233,7 +233,7 @@ void ModeFlowHold::run()
     update_height_estimate();
 
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_max_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // apply SIMPLE mode transform to pilot inputs
     update_simple_mode();
@@ -267,7 +267,7 @@ void ModeFlowHold::run()
         copter.motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::SHUT_DOWN);
         copter.attitude_control->reset_rate_controller_I_terms();
         copter.attitude_control->reset_yaw_target_and_rate();
-        copter.pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
+        copter.pos_control->relax_U_controller(0.0f);   // forces throttle output to decay to zero
         flow_pi_xy.reset_I();
         break;
 
@@ -293,7 +293,7 @@ void ModeFlowHold::run()
 
     case AltHoldModeState::Landed_Pre_Takeoff:
         attitude_control->reset_rate_controller_I_terms_smoothly();
-        pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
+        pos_control->relax_U_controller(0.0f);   // forces throttle output to decay to zero
         break;
 
     case AltHoldModeState::Flying:
@@ -308,7 +308,7 @@ void ModeFlowHold::run()
 #endif
 
         // Send the commanded climb rate to the position controller
-        pos_control->set_pos_target_z_from_climb_rate_cm(target_climb_rate);
+        pos_control->set_pos_target_U_from_climb_rate_cm(target_climb_rate);
         break;
     }
 
@@ -343,7 +343,7 @@ void ModeFlowHold::run()
     copter.attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(bf_angles.x, bf_angles.y, target_yaw_rate);
 
     // run the vertical position controller and set output throttle
-    pos_control->update_z_controller();
+    pos_control->update_U_controller();
 }
 
 /*

--- a/ArduCopter/mode_follow.cpp
+++ b/ArduCopter/mode_follow.cpp
@@ -81,12 +81,12 @@ void ModeFollow::run()
 
         // slow down horizontally as we approach target (use 1/2 of maximum deceleration for gentle slow down)
         const float dist_to_target_xy = Vector2f(dist_vec_offs_neu.x, dist_vec_offs_neu.y).length();
-        copter.avoid.limit_velocity_2D(pos_control->get_pos_xy_p().kP().get(), pos_control->get_max_accel_xy_cmss() * 0.5f, desired_velocity_xy_cms, dir_to_target_xy, dist_to_target_xy, copter.G_Dt);
+        copter.avoid.limit_velocity_2D(pos_control->get_pos_NE_p().kP().get(), pos_control->get_max_accel_NE_cmss() * 0.5f, desired_velocity_xy_cms, dir_to_target_xy, dist_to_target_xy, copter.G_Dt);
         // copy horizontal velocity limits back to 3d vector
         desired_velocity_neu_cms.xy() = desired_velocity_xy_cms;
 
         // limit vertical desired_velocity_neu_cms to slow as we approach target (we use 1/2 of maximum deceleration for gentle slow down)
-        const float des_vel_z_max = copter.avoid.get_max_speed(pos_control->get_pos_z_p().kP().get(), pos_control->get_max_accel_z_cmss() * 0.5f, fabsf(dist_vec_offs_neu.z), copter.G_Dt);
+        const float des_vel_z_max = copter.avoid.get_max_speed(pos_control->get_pos_U_p().kP().get(), pos_control->get_max_accel_U_cmss() * 0.5f, fabsf(dist_vec_offs_neu.z), copter.G_Dt);
         desired_velocity_neu_cms.z = constrain_float(desired_velocity_neu_cms.z, -des_vel_z_max, des_vel_z_max);
 
         // Add the target velocity baseline.
@@ -94,13 +94,13 @@ void ModeFollow::run()
         desired_velocity_neu_cms.z += -vel_of_target.z * 100.0f;
 
         // scale desired velocity to stay within horizontal speed limit
-        desired_velocity_neu_cms.xy().limit_length(pos_control->get_max_speed_xy_cms());
+        desired_velocity_neu_cms.xy().limit_length(pos_control->get_max_speed_NE_cms());
 
         // limit desired velocity to be between maximum climb and descent rates
         desired_velocity_neu_cms.z = constrain_float(desired_velocity_neu_cms.z, -fabsf(pos_control->get_max_speed_down_cms()), pos_control->get_max_speed_up_cms());
 
         // limit the velocity for obstacle/fence avoidance
-        copter.avoid.adjust_velocity(desired_velocity_neu_cms, pos_control->get_pos_xy_p().kP().get(), pos_control->get_max_accel_xy_cmss(), pos_control->get_pos_z_p().kP().get(), pos_control->get_max_accel_z_cmss(), G_Dt);
+        copter.avoid.adjust_velocity(desired_velocity_neu_cms, pos_control->get_pos_NE_p().kP().get(), pos_control->get_max_accel_NE_cmss(), pos_control->get_pos_U_p().kP().get(), pos_control->get_max_accel_U_cmss(), G_Dt);
 
         // calculate vehicle heading
         switch (g2.follow.get_yaw_behave()) {

--- a/ArduCopter/mode_land.cpp
+++ b/ArduCopter/mode_land.cpp
@@ -7,21 +7,21 @@ bool ModeLand::init(bool ignore_checks)
     control_position = copter.position_ok();
 
     // set horizontal speed and acceleration limits
-    pos_control->set_max_speed_accel_xy(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
-    pos_control->set_correction_speed_accel_xy(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
+    pos_control->set_max_speed_accel_NE_cm(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
+    pos_control->set_correction_speed_accel_NE_cm(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
 
     // initialise the horizontal position controller
-    if (control_position && !pos_control->is_active_xy()) {
-        pos_control->init_xy_controller();
+    if (control_position && !pos_control->is_active_NE()) {
+        pos_control->init_NE_controller();
     }
 
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_z(wp_nav->get_default_speed_down(), wp_nav->get_default_speed_up(), wp_nav->get_accel_z());
-    pos_control->set_correction_speed_accel_z(wp_nav->get_default_speed_down(), wp_nav->get_default_speed_up(), wp_nav->get_accel_z());
+    pos_control->set_max_speed_accel_U_cm(wp_nav->get_default_speed_down(), wp_nav->get_default_speed_up(), wp_nav->get_accel_z());
+    pos_control->set_correction_speed_accel_U_cmss(wp_nav->get_default_speed_down(), wp_nav->get_default_speed_up(), wp_nav->get_accel_z());
 
     // initialise the vertical position controller
-    if (!pos_control->is_active_z()) {
-        pos_control->init_z_controller();
+    if (!pos_control->is_active_U()) {
+        pos_control->init_U_controller();
     }
 
     land_start_time = millis();

--- a/ArduCopter/mode_loiter.cpp
+++ b/ArduCopter/mode_loiter.cpp
@@ -26,13 +26,13 @@ bool ModeLoiter::init(bool ignore_checks)
     loiter_nav->init_target();
 
     // initialise the vertical position controller
-    if (!pos_control->is_active_z()) {
-        pos_control->init_z_controller();
+    if (!pos_control->is_active_U()) {
+        pos_control->init_U_controller();
     }
 
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
-    pos_control->set_correction_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_max_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_correction_speed_accel_U_cmss(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
 #if AC_PRECLAND_ENABLED
     _precision_loiter_active = false;
@@ -73,9 +73,9 @@ void ModeLoiter::precision_loiter_xy()
     Vector2f zero;
     Vector2p landing_pos = target_pos.topostype();
     // target vel will remain zero if landing target is stationary
-    pos_control->input_pos_vel_accel_xy(landing_pos, target_vel, zero);
+    pos_control->input_pos_vel_accel_NE_cm(landing_pos, target_vel, zero);
     // run pos controller
-    pos_control->update_xy_controller();
+    pos_control->update_NE_controller();
 }
 #endif
 
@@ -88,7 +88,7 @@ void ModeLoiter::run()
     float target_climb_rate = 0.0f;
 
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_max_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // process pilot inputs unless we are in radio failsafe
     if (!copter.failsafe.radio) {
@@ -126,7 +126,7 @@ void ModeLoiter::run()
     case AltHoldModeState::MotorStopped:
         attitude_control->reset_rate_controller_I_terms();
         attitude_control->reset_yaw_target_and_rate();
-        pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
+        pos_control->relax_U_controller(0.0f);   // forces throttle output to decay to zero
         loiter_nav->init_target();
         attitude_control->input_thrust_vector_rate_heading(loiter_nav->get_thrust_vector(), target_yaw_rate, false);
         break;
@@ -139,7 +139,7 @@ void ModeLoiter::run()
         attitude_control->reset_rate_controller_I_terms_smoothly();
         loiter_nav->init_target();
         attitude_control->input_thrust_vector_rate_heading(loiter_nav->get_thrust_vector(), target_yaw_rate, false);
-        pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
+        pos_control->relax_U_controller(0.0f);   // forces throttle output to decay to zero
         break;
 
     case AltHoldModeState::Takeoff:
@@ -197,12 +197,12 @@ void ModeLoiter::run()
 #endif
 
         // Send the commanded climb rate to the position controller
-        pos_control->set_pos_target_z_from_climb_rate_cm(target_climb_rate);
+        pos_control->set_pos_target_U_from_climb_rate_cm(target_climb_rate);
         break;
     }
 
     // run the vertical position controller and set output throttle
-    pos_control->update_z_controller();
+    pos_control->update_U_controller();
 }
 
 uint32_t ModeLoiter::wp_distance() const

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -28,12 +28,12 @@
 bool ModePosHold::init(bool ignore_checks)
 {
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
-    pos_control->set_correction_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_max_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_correction_speed_accel_U_cmss(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // initialise the vertical position controller
-    if (!pos_control->is_active_z()) {
-        pos_control->init_z_controller();
+    if (!pos_control->is_active_U()) {
+        pos_control->init_U_controller();
     }
 
     // initialise lean angles to current attitude
@@ -72,7 +72,7 @@ void ModePosHold::run()
     const Vector3f& vel = inertial_nav.get_velocity_neu_cms();
 
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_max_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
     loiter_nav->clear_pilot_desired_acceleration();
 
     // apply SIMPLE mode transform to pilot inputs
@@ -103,7 +103,7 @@ void ModePosHold::run()
     case AltHoldModeState::MotorStopped:
         attitude_control->reset_rate_controller_I_terms();
         attitude_control->reset_yaw_target_and_rate(false);
-        pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
+        pos_control->relax_U_controller(0.0f);   // forces throttle output to decay to zero
         loiter_nav->clear_pilot_desired_acceleration();
         loiter_nav->init_target();
 
@@ -124,7 +124,7 @@ void ModePosHold::run()
 
     case AltHoldModeState::Landed_Pre_Takeoff:
         attitude_control->reset_rate_controller_I_terms_smoothly();
-        pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
+        pos_control->relax_U_controller(0.0f);   // forces throttle output to decay to zero
 
         // set poshold state to pilot override
         roll_mode = RPMode::PILOT_OVERRIDE;
@@ -164,7 +164,7 @@ void ModePosHold::run()
 #endif
 
         // Send the commanded climb rate to the position controller
-        pos_control->set_pos_target_z_from_climb_rate_cm(target_climb_rate);
+        pos_control->set_pos_target_U_from_climb_rate_cm(target_climb_rate);
         break;
     }
 
@@ -377,7 +377,7 @@ void ModePosHold::run()
         pitch_mode = RPMode::BRAKE_TO_LOITER;
         brake.to_loiter_timer = POSHOLD_BRAKE_TO_LOITER_TIMER;
         // init loiter controller
-        loiter_nav->init_target(inertial_nav.get_position_xy_cm() - pos_control->get_pos_offset_cm().xy().tofloat());
+        loiter_nav->init_target(inertial_nav.get_position_xy_cm() - pos_control->get_pos_offset_NEU_cm().xy().tofloat());
         // set delay to start of wind compensation estimate updates
         wind_comp_start_timer = POSHOLD_WIND_COMP_START_TIMER;
     }
@@ -489,7 +489,7 @@ void ModePosHold::run()
     attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(roll, pitch, target_yaw_rate);
 
     // run the vertical position controller and set output throttle
-    pos_control->update_z_controller();
+    pos_control->update_U_controller();
 }
 
 // poshold_update_pilot_lean_angle - update the pilot's filtered lean angle with the latest raw input received
@@ -569,7 +569,7 @@ void ModePosHold::update_wind_comp_estimate()
     }
 
     // get position controller accel target
-    const Vector3f& accel_target = pos_control->get_accel_target_cmss();
+    const Vector3f& accel_target = pos_control->get_accel_target_NEU_cmss();
 
     // update wind compensation in earth-frame lean angles
     if (is_zero(wind_comp_ef.x)) {

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -178,7 +178,7 @@ void ModeRTL::climb_return_run()
 
     // WP_Nav has set the vertical position control targets
     // run the vertical position controller and set output throttle
-    pos_control->update_z_controller();
+    pos_control->update_U_controller();
 
     // call attitude controller with auto yaw
     attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), auto_yaw.get_heading());
@@ -220,7 +220,7 @@ void ModeRTL::loiterathome_run()
 
     // WP_Nav has set the vertical position control targets
     // run the vertical position controller and set output throttle
-    pos_control->update_z_controller();
+    pos_control->update_U_controller();
 
     // call attitude controller with auto yaw
     attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), auto_yaw.get_heading());
@@ -246,7 +246,7 @@ void ModeRTL::descent_start()
     _state_complete = false;
 
     // initialise altitude target to stopping point
-    pos_control->init_z_controller_stopping_point();
+    pos_control->init_U_controller_stopping_point();
 
     // initialise yaw
     auto_yaw.set_mode(AutoYaw::Mode::HOLD);
@@ -300,13 +300,13 @@ void ModeRTL::descent_run()
     motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
     Vector2f accel;
-    pos_control->input_vel_accel_xy(vel_correction, accel);
-    pos_control->update_xy_controller();
+    pos_control->input_vel_accel_NE_cm(vel_correction, accel);
+    pos_control->update_NE_controller();
 
     // WP_Nav has set the vertical position control targets
     // run the vertical position controller and set output throttle
-    pos_control->set_alt_target_with_slew(rtl_path.descent_target.alt);
-    pos_control->update_z_controller();
+    pos_control->set_alt_target_with_slew_cm(rtl_path.descent_target.alt);
+    pos_control->update_U_controller();
 
     // roll & pitch from waypoint controller, yaw rate from pilot
     attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), auto_yaw.get_heading());
@@ -322,17 +322,17 @@ void ModeRTL::land_start()
     _state_complete = false;
 
     // set horizontal speed and acceleration limits
-    pos_control->set_max_speed_accel_xy(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
-    pos_control->set_correction_speed_accel_xy(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
+    pos_control->set_max_speed_accel_NE_cm(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
+    pos_control->set_correction_speed_accel_NE_cm(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
 
     // initialise loiter target destination
-    if (!pos_control->is_active_xy()) {
-        pos_control->init_xy_controller();
+    if (!pos_control->is_active_NE()) {
+        pos_control->init_NE_controller();
     }
 
     // initialise the vertical position controller
-    if (!pos_control->is_active_z()) {
-        pos_control->init_z_controller();
+    if (!pos_control->is_active_U()) {
+        pos_control->init_U_controller();
     }
 
     // initialise yaw
@@ -409,7 +409,7 @@ void ModeRTL::compute_return_target()
 #endif
 
     // get position controller Z-axis offset in cm above EKF origin
-    int32_t pos_offset_z = pos_control->get_pos_offset_z_cm();
+    int32_t pos_offset_z = pos_control->get_pos_offset_U_cm();
 
     // curr_alt is current altitude above home or above terrain depending upon use_terrain
     int32_t curr_alt = copter.current_loc.alt - pos_offset_z;

--- a/ArduCopter/mode_smart_rtl.cpp
+++ b/ArduCopter/mode_smart_rtl.cpp
@@ -17,8 +17,8 @@ bool ModeSmartRTL::init(bool ignore_checks)
 
         // set current target to a reasonable stopping point
         Vector3p stopping_point;
-        pos_control->get_stopping_point_xy_cm(stopping_point.xy());
-        pos_control->get_stopping_point_z_cm(stopping_point.z);
+        pos_control->get_stopping_point_NE_cm(stopping_point.xy());
+        pos_control->get_stopping_point_U_cm(stopping_point.z);
         wp_nav->set_wp_destination(stopping_point.tofloat());
 
         // initialise yaw to obey user parameter
@@ -77,7 +77,7 @@ void ModeSmartRTL::wait_cleanup_run()
     // hover at current target position
     motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
     wp_nav->update_wpnav();
-    pos_control->update_z_controller();
+    pos_control->update_U_controller();
     attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), auto_yaw.get_heading());
 
     // check if return path is computed and if yes, begin journey home
@@ -143,7 +143,7 @@ void ModeSmartRTL::path_follow_run()
     // update controllers
     motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
     wp_nav->update_wpnav();
-    pos_control->update_z_controller();
+    pos_control->update_U_controller();
 
     // call attitude controller with auto yaw
     attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), auto_yaw.get_heading());
@@ -167,7 +167,7 @@ void ModeSmartRTL::pre_land_position_run()
     // update controllers
     motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
     wp_nav->update_wpnav();
-    pos_control->update_z_controller();
+    pos_control->update_U_controller();
     attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), auto_yaw.get_heading());
 }
 

--- a/ArduCopter/mode_sport.cpp
+++ b/ArduCopter/mode_sport.cpp
@@ -10,12 +10,12 @@
 bool ModeSport::init(bool ignore_checks)
 {
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
-    pos_control->set_correction_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_max_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_correction_speed_accel_U_cmss(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // initialise the vertical position controller
-    if (!pos_control->is_active_z()) {
-        pos_control->init_z_controller();
+    if (!pos_control->is_active_U()) {
+        pos_control->init_U_controller();
     }
 
     return true;
@@ -26,7 +26,7 @@ bool ModeSport::init(bool ignore_checks)
 void ModeSport::run()
 {
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_max_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // apply SIMPLE mode transform
     update_simple_mode();
@@ -77,7 +77,7 @@ void ModeSport::run()
     case AltHoldModeState::MotorStopped:
         attitude_control->reset_rate_controller_I_terms();
         attitude_control->reset_yaw_target_and_rate(false);
-        pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
+        pos_control->relax_U_controller(0.0f);   // forces throttle output to decay to zero
         break;
 
     case AltHoldModeState::Landed_Ground_Idle:
@@ -86,7 +86,7 @@ void ModeSport::run()
 
     case AltHoldModeState::Landed_Pre_Takeoff:
         attitude_control->reset_rate_controller_I_terms_smoothly();
-        pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
+        pos_control->relax_U_controller(0.0f);   // forces throttle output to decay to zero
         break;
 
     case AltHoldModeState::Takeoff:
@@ -114,7 +114,7 @@ void ModeSport::run()
 #endif
 
         // Send the commanded climb rate to the position controller
-        pos_control->set_pos_target_z_from_climb_rate_cm(target_climb_rate);
+        pos_control->set_pos_target_U_from_climb_rate_cm(target_climb_rate);
         break;
     }
 
@@ -122,7 +122,7 @@ void ModeSport::run()
     attitude_control->input_euler_rate_roll_pitch_yaw(target_roll_rate, target_pitch_rate, target_yaw_rate);
 
     // run the vertical position controller and set output throttle
-    pos_control->update_z_controller();
+    pos_control->update_U_controller();
 }
 
 #endif

--- a/ArduCopter/mode_systemid.cpp
+++ b/ArduCopter/mode_systemid.cpp
@@ -112,21 +112,21 @@ bool ModeSystemId::init(bool ignore_checks)
         }
 
         // set horizontal speed and acceleration limits
-        pos_control->set_max_speed_accel_xy(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
-        pos_control->set_correction_speed_accel_xy(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
+        pos_control->set_max_speed_accel_NE_cm(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
+        pos_control->set_correction_speed_accel_NE_cm(wp_nav->get_default_speed_xy(), wp_nav->get_wp_acceleration());
 
         // initialise the horizontal position controller
-        if (!pos_control->is_active_xy()) {
-            pos_control->init_xy_controller();
+        if (!pos_control->is_active_NE()) {
+            pos_control->init_NE_controller();
         }
 
         // set vertical speed and acceleration limits
-        pos_control->set_max_speed_accel_z(wp_nav->get_default_speed_down(), wp_nav->get_default_speed_up(), wp_nav->get_accel_z());
-        pos_control->set_correction_speed_accel_z(wp_nav->get_default_speed_down(), wp_nav->get_default_speed_up(), wp_nav->get_accel_z());
+        pos_control->set_max_speed_accel_U_cm(wp_nav->get_default_speed_down(), wp_nav->get_default_speed_up(), wp_nav->get_accel_z());
+        pos_control->set_correction_speed_accel_U_cmss(wp_nav->get_default_speed_down(), wp_nav->get_default_speed_up(), wp_nav->get_accel_z());
 
         // initialise the vertical position controller
-        if (!pos_control->is_active_z()) {
-            pos_control->init_z_controller();
+        if (!pos_control->is_active_U()) {
+            pos_control->init_U_controller();
         }
         Vector3f curr_pos;
         curr_pos = inertial_nav.get_position_neu_cm();
@@ -313,25 +313,25 @@ void ModeSystemId::run()
                     disturb_state.x = 0.0f;
                     disturb_state.y = waveform_sample * 100.0f;
                     disturb_state.rotate(attitude_control->get_att_target_euler_rad().z);
-                    pos_control->set_disturb_pos_cm(disturb_state);
+                    pos_control->set_disturb_pos_NE_cm(disturb_state);
                     break;
                 case AxisType::DISTURB_POS_LONG:
                     disturb_state.x = waveform_sample * 100.0f;
                     disturb_state.y = 0.0f;
                     disturb_state.rotate(attitude_control->get_att_target_euler_rad().z);
-                    pos_control->set_disturb_pos_cm(disturb_state);
+                    pos_control->set_disturb_pos_NE_cm(disturb_state);
                     break;
                 case AxisType::DISTURB_VEL_LAT:
                     disturb_state.x = 0.0f;
                     disturb_state.y = waveform_sample * 100.0f;
                     disturb_state.rotate(attitude_control->get_att_target_euler_rad().z);
-                    pos_control->set_disturb_vel_cms(disturb_state);
+                    pos_control->set_disturb_vel_NE_cms(disturb_state);
                     break;
                 case AxisType::DISTURB_VEL_LONG:
                     disturb_state.x = waveform_sample * 100.0f;
                     disturb_state.y = 0.0f;
                     disturb_state.rotate(attitude_control->get_att_target_euler_rad().z);
-                    pos_control->set_disturb_vel_cms(disturb_state);
+                    pos_control->set_disturb_vel_NE_cms(disturb_state);
                     break;
                 case AxisType::INPUT_VEL_LAT:
                     input_vel.x = 0.0f;
@@ -359,7 +359,7 @@ void ModeSystemId::run()
 
         // relax loiter target if we might be landed
         if (copter.ap.land_complete_maybe) {
-            pos_control->soften_for_landing_xy();
+            pos_control->soften_for_landing_NE();
         }
 
         Vector2f accel;
@@ -368,19 +368,19 @@ void ModeSystemId::run()
             accel = (input_vel - input_vel_last) / G_Dt;
             input_vel_last = input_vel;
         }
-        pos_control->set_pos_vel_accel_xy(target_pos.topostype(), input_vel, accel);
+        pos_control->set_pos_vel_accel_NE_cm(target_pos.topostype(), input_vel, accel);
 
         // run pos controller
-        pos_control->update_xy_controller();
+        pos_control->update_NE_controller();
 
         // call attitude controller
         attitude_control->input_thrust_vector_rate_heading(pos_control->get_thrust_vector(), target_yaw_rate, false);
 
         // Send the commanded climb rate to the position controller
-        pos_control->set_pos_target_z_from_climb_rate_cm(target_climb_rate);
+        pos_control->set_pos_target_U_from_climb_rate_cm(target_climb_rate);
 
         // run the vertical position controller and set output throttle
-        pos_control->update_z_controller();
+        pos_control->update_U_controller();
     }
 
     if (log_subsample <= 0) {
@@ -420,8 +420,8 @@ void ModeSystemId::log_data() const
 
     if (is_poscontrol_axis_type()) {
         pos_control->write_log();
-        copter.logger.Write_PID(LOG_PIDN_MSG, pos_control->get_vel_xy_pid().get_pid_info_x());
-        copter.logger.Write_PID(LOG_PIDE_MSG, pos_control->get_vel_xy_pid().get_pid_info_y());
+        copter.logger.Write_PID(LOG_PIDN_MSG, pos_control->get_vel_NE_pid().get_pid_info_x());
+        copter.logger.Write_PID(LOG_PIDE_MSG, pos_control->get_vel_NE_pid().get_pid_info_y());
 
     }
 }

--- a/ArduCopter/mode_throw.cpp
+++ b/ArduCopter/mode_throw.cpp
@@ -20,12 +20,12 @@ bool ModeThrow::init(bool ignore_checks)
     nextmode_attempted = false;
 
     // initialise pos controller speed and acceleration
-    pos_control->set_max_speed_accel_xy(wp_nav->get_default_speed_xy(), BRAKE_MODE_DECEL_RATE);
-    pos_control->set_correction_speed_accel_xy(wp_nav->get_default_speed_xy(), BRAKE_MODE_DECEL_RATE);
+    pos_control->set_max_speed_accel_NE_cm(wp_nav->get_default_speed_xy(), BRAKE_MODE_DECEL_RATE);
+    pos_control->set_correction_speed_accel_NE_cm(wp_nav->get_default_speed_xy(), BRAKE_MODE_DECEL_RATE);
 
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_z(BRAKE_MODE_SPEED_Z, BRAKE_MODE_SPEED_Z, BRAKE_MODE_DECEL_RATE);
-    pos_control->set_correction_speed_accel_z(BRAKE_MODE_SPEED_Z, BRAKE_MODE_SPEED_Z, BRAKE_MODE_DECEL_RATE);
+    pos_control->set_max_speed_accel_U_cm(BRAKE_MODE_SPEED_Z, BRAKE_MODE_SPEED_Z, BRAKE_MODE_DECEL_RATE);
+    pos_control->set_correction_speed_accel_U_cmss(BRAKE_MODE_SPEED_Z, BRAKE_MODE_SPEED_Z, BRAKE_MODE_DECEL_RATE);
 
     return true;
 }
@@ -67,14 +67,14 @@ void ModeThrow::run()
         stage = Throw_HgtStabilise;
 
         // initialise the z controller
-        pos_control->init_z_controller_no_descent();
+        pos_control->init_U_controller_no_descent();
 
         // initialise the demanded height to 3m above the throw height
         // we want to rapidly clear surrounding obstacles
         if (g2.throw_type == ThrowType::Drop) {
-            pos_control->set_pos_desired_z_cm(inertial_nav.get_position_z_up_cm() - 100);
+            pos_control->set_pos_desired_U_cm(inertial_nav.get_position_z_up_cm() - 100);
         } else {
-            pos_control->set_pos_desired_z_cm(inertial_nav.get_position_z_up_cm() + 300);
+            pos_control->set_pos_desired_U_cm(inertial_nav.get_position_z_up_cm() + 300);
         }
 
         // Set the auto_arm status to true to avoid a possible automatic disarm caused by selection of an auto mode with throttle at minimum
@@ -85,7 +85,7 @@ void ModeThrow::run()
         stage = Throw_PosHold;
 
         // initialise position controller
-        pos_control->init_xy_controller();
+        pos_control->init_NE_controller();
 
         // Set the auto_arm status to true to avoid a possible automatic disarm caused by selection of an auto mode with throttle at minimum
         copter.set_auto_armed(true);
@@ -174,8 +174,8 @@ void ModeThrow::run()
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(0.0f, 0.0f, 0.0f);
 
         // call height controller
-        pos_control->set_pos_target_z_from_climb_rate_cm(0.0f);
-        pos_control->update_z_controller();
+        pos_control->set_pos_target_U_from_climb_rate_cm(0.0f);
+        pos_control->update_U_controller();
 
         break;
 
@@ -187,15 +187,15 @@ void ModeThrow::run()
         // use position controller to stop
         Vector2f vel;
         Vector2f accel;
-        pos_control->input_vel_accel_xy(vel, accel);
-        pos_control->update_xy_controller();
+        pos_control->input_vel_accel_NE_cm(vel, accel);
+        pos_control->update_NE_controller();
 
         // call attitude controller
         attitude_control->input_thrust_vector_rate_heading(pos_control->get_thrust_vector(), 0.0f);
 
         // call height controller
-        pos_control->set_pos_target_z_from_climb_rate_cm(0.0f);
-        pos_control->update_z_controller();
+        pos_control->set_pos_target_U_from_climb_rate_cm(0.0f);
+        pos_control->update_U_controller();
 
         break;
     }
@@ -313,13 +313,13 @@ bool ModeThrow::throw_attitude_good() const
 bool ModeThrow::throw_height_good() const
 {
     // Check that we are within 0.5m of the demanded height
-    return (pos_control->get_pos_error_z_cm() < 50.0f);
+    return (pos_control->get_pos_error_U_cm() < 50.0f);
 }
 
 bool ModeThrow::throw_position_good() const
 {
     // check that our horizontal position error is within 50cm
-    return (pos_control->get_pos_error_xy_cm() < 50.0f);
+    return (pos_control->get_pos_error_NE_cm() < 50.0f);
 }
 
 #endif

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -84,12 +84,12 @@ bool ModeZigZag::init(bool ignore_checks)
     loiter_nav->init_target();
 
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
-    pos_control->set_correction_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_max_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_correction_speed_accel_U_cmss(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // initialise the vertical position controller
-    if (!pos_control->is_active_z()) {
-        pos_control->init_z_controller();
+    if (!pos_control->is_active_U()) {
+        pos_control->init_U_controller();
     }
 
     // initialise waypoint state
@@ -115,7 +115,7 @@ void ModeZigZag::exit()
 void ModeZigZag::run()
 {
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_z(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_max_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // set the direction and the total number of lines
     zigzag_direction = (Direction)constrain_int16(_direction, 0, 3);
@@ -161,7 +161,7 @@ void ModeZigZag::run()
 void ModeZigZag::save_or_move_to_destination(Destination ab_dest)
 {
     // get current position as an offset from EKF origin
-    const Vector2f curr_pos = pos_control->get_pos_desired_cm().xy().tofloat();
+    const Vector2f curr_pos = pos_control->get_pos_desired_NEU_cm().xy().tofloat();
 
     // handle state machine changes
     switch (stage) {
@@ -275,7 +275,7 @@ void ModeZigZag::auto_control()
 
     // WP_Nav has set the vertical position control targets
     // run the vertical position controller and set output throttle
-    pos_control->update_z_controller();
+    pos_control->update_U_controller();
 
     // call attitude controller
     // roll & pitch from waypoint controller, yaw rate from pilot
@@ -331,7 +331,7 @@ void ModeZigZag::manual_control()
     case AltHoldModeState::MotorStopped:
         attitude_control->reset_rate_controller_I_terms();
         attitude_control->reset_yaw_target_and_rate();
-        pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
+        pos_control->relax_U_controller(0.0f);   // forces throttle output to decay to zero
         loiter_nav->init_target();
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(loiter_nav->get_roll(), loiter_nav->get_pitch(), target_yaw_rate);
         break;
@@ -363,7 +363,7 @@ void ModeZigZag::manual_control()
         attitude_control->reset_rate_controller_I_terms_smoothly();
         loiter_nav->init_target();
         attitude_control->input_thrust_vector_rate_heading(loiter_nav->get_thrust_vector(), target_yaw_rate);
-        pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
+        pos_control->relax_U_controller(0.0f);   // forces throttle output to decay to zero
         break;
 
     case AltHoldModeState::Flying:
@@ -385,12 +385,12 @@ void ModeZigZag::manual_control()
 #endif
 
         // Send the commanded climb rate to the position controller
-        pos_control->set_pos_target_z_from_climb_rate_cm(target_climb_rate);
+        pos_control->set_pos_target_U_from_climb_rate_cm(target_climb_rate);
         break;
     }
 
     // run the vertical position controller and set output throttle
-    pos_control->update_z_controller();
+    pos_control->update_U_controller();
 }
 
 // return true if vehicle is within a small area around the destination
@@ -431,7 +431,7 @@ bool ModeZigZag::calculate_next_dest(Destination ab_dest, bool use_wpnav_alt, Ve
     }
 
     // get distance from vehicle to start_pos
-    const Vector2f curr_pos2d = pos_control->get_pos_desired_cm().xy().tofloat();
+    const Vector2f curr_pos2d = pos_control->get_pos_desired_NEU_cm().xy().tofloat();
     Vector2f veh_to_start_pos = curr_pos2d - start_pos;
 
     // lengthen AB_diff so that it is at least as long as vehicle is from start point
@@ -456,9 +456,9 @@ bool ModeZigZag::calculate_next_dest(Destination ab_dest, bool use_wpnav_alt, Ve
         next_dest.z = wp_nav->get_wp_destination().z;
     } else {
         terrain_alt = copter.rangefinder_alt_ok() && wp_nav->rangefinder_used_and_healthy();
-        next_dest.z = pos_control->get_pos_desired_z_cm();
+        next_dest.z = pos_control->get_pos_desired_U_cm();
         if (!terrain_alt) {
-            next_dest.z += pos_control->get_pos_terrain_cm();
+            next_dest.z += pos_control->get_pos_terrain_U_cm();
         }
     }
 
@@ -499,12 +499,12 @@ bool ModeZigZag::calculate_side_dest(Vector3f& next_dest, bool& terrain_alt) con
     float scalar = constrain_float(_side_dist, 0.1f, 100.0f) * 100 / safe_sqrt(AB_side.length_squared());
 
     // get distance from vehicle to start_pos
-    const Vector2f curr_pos2d = pos_control->get_pos_desired_cm().xy().tofloat();
+    const Vector2f curr_pos2d = pos_control->get_pos_desired_NEU_cm().xy().tofloat();
     next_dest.xy() = curr_pos2d + (AB_side * scalar);
 
     // if we have a downward facing range finder then use terrain altitude targets
     terrain_alt = copter.rangefinder_alt_ok() && wp_nav->rangefinder_used_and_healthy();
-    next_dest.z = pos_control->get_pos_desired_z_cm();
+    next_dest.z = pos_control->get_pos_desired_U_cm();
 
     return true;
 }

--- a/ArduCopter/standby.cpp
+++ b/ArduCopter/standby.cpp
@@ -19,5 +19,5 @@ void Copter::standby_update()
 
     attitude_control->reset_rate_controller_I_terms();
     attitude_control->reset_yaw_target_and_rate();
-    pos_control->standby_xyz_reset();
+    pos_control->standby_NEU_reset();
 }

--- a/ArduCopter/surface_tracking.cpp
+++ b/ArduCopter/surface_tracking.cpp
@@ -18,7 +18,7 @@ void Copter::SurfaceTracking::update_surface_offset()
         AP_SurfaceDistance &rf_state = (surface == Surface::GROUND) ? copter.rangefinder_state : copter.rangefinder_up_state;
 
         // update position controller target offset to the surface's alt above the EKF origin
-        copter.pos_control->set_pos_terrain_target_cm(rf_state.terrain_offset_cm);
+        copter.pos_control->set_pos_terrain_target_U_cm(rf_state.terrain_offset_cm);
         last_update_ms = now_ms;
         valid_for_logging = true;
 
@@ -28,7 +28,7 @@ void Copter::SurfaceTracking::update_surface_offset()
         if (timeout ||
             reset_target ||
             (last_glitch_cleared_ms != rf_state.glitch_cleared_ms)) {
-            copter.pos_control->init_pos_terrain_cm(rf_state.terrain_offset_cm);
+            copter.pos_control->init_pos_terrain_U_cm(rf_state.terrain_offset_cm);
             reset_target = false;
             last_glitch_cleared_ms = rf_state.glitch_cleared_ms;
         }
@@ -37,7 +37,7 @@ void Copter::SurfaceTracking::update_surface_offset()
         // reset position controller offsets if surface tracking is inactive
         // flag target should be reset when/if it next becomes active
         if (timeout && !reset_target) {
-            copter.pos_control->init_pos_terrain_cm(0);
+            copter.pos_control->init_pos_terrain_U_cm(0);
             valid_for_logging = false;
             reset_target = true;
         }
@@ -61,7 +61,7 @@ bool Copter::SurfaceTracking::get_target_dist_for_logging(float &target_dist) co
     }
 
     const float dir = (surface == Surface::GROUND) ? 1.0f : -1.0f;
-    target_dist = dir * copter.pos_control->get_pos_desired_z_cm() * 0.01f;
+    target_dist = dir * copter.pos_control->get_pos_desired_U_cm() * 0.01f;
     return true;
 }
 

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -52,7 +52,7 @@ void Mode::_TakeOff::start(float alt_cm)
 {
     // initialise takeoff state
     _running = true;
-    take_off_start_alt = copter.pos_control->get_pos_desired_z_cm();
+    take_off_start_alt = copter.pos_control->get_pos_desired_U_cm();
     take_off_complete_alt  = take_off_start_alt + alt_cm;
 }
 
@@ -83,11 +83,11 @@ void Mode::_TakeOff::do_pilot_takeoff(float& pilot_climb_rate_cm)
         float throttle = constrain_float(copter.attitude_control->get_throttle_in() + copter.G_Dt / copter.g2.takeoff_throttle_slew_time, 0.0, 1.0);
         copter.attitude_control->set_throttle_out(throttle, true, 0.0);
         // tell position controller to reset alt target and reset I terms
-        copter.pos_control->init_z_controller();
+        copter.pos_control->init_U_controller();
         if (throttle >= MIN(copter.g2.takeoff_throttle_max, 0.9) || 
-            (copter.pos_control->get_z_accel_cmss() >= 0.5 * copter.pos_control->get_max_accel_z_cmss()) ||
-            (copter.pos_control->get_vel_desired_cms().z >= constrain_float(pilot_climb_rate_cm, copter.pos_control->get_max_speed_up_cms() * 0.1, copter.pos_control->get_max_speed_up_cms() * 0.5)) || 
-            (is_positive(take_off_complete_alt - take_off_start_alt) && copter.pos_control->get_pos_desired_z_cm() - take_off_start_alt > 0.5 * (take_off_complete_alt - take_off_start_alt))) {
+            (copter.pos_control->get_measured_accel_U_cmss() >= 0.5 * copter.pos_control->get_max_accel_U_cmss()) ||
+            (copter.pos_control->get_vel_desired_NEU_cms().z >= constrain_float(pilot_climb_rate_cm, copter.pos_control->get_max_speed_up_cms() * 0.1, copter.pos_control->get_max_speed_up_cms() * 0.5)) || 
+            (is_positive(take_off_complete_alt - take_off_start_alt) && copter.pos_control->get_pos_desired_U_cm() - take_off_start_alt > 0.5 * (take_off_complete_alt - take_off_start_alt))) {
             // throttle > 90%
             // acceleration > 50% maximum acceleration
             // velocity > 10% maximum velocity && commanded climb rate
@@ -100,11 +100,11 @@ void Mode::_TakeOff::do_pilot_takeoff(float& pilot_climb_rate_cm)
         float vel_z = pilot_climb_rate_cm;
 
         // command the aircraft to the take off altitude and current pilot climb rate
-        copter.pos_control->input_pos_vel_accel_z(pos_z, vel_z, 0);
+        copter.pos_control->input_pos_vel_accel_U_cm(pos_z, vel_z, 0);
 
         // stop take off early and return if negative climb rate is commanded or we are within 0.1% of our take off altitude
         if (is_negative(pilot_climb_rate_cm) ||
-            (take_off_complete_alt  - take_off_start_alt) * 0.999f < copter.pos_control->get_pos_desired_z_cm() - take_off_start_alt) {
+            (take_off_complete_alt  - take_off_start_alt) * 0.999f < copter.pos_control->get_pos_desired_U_cm() - take_off_start_alt) {
             stop();
         }
     }
@@ -144,10 +144,10 @@ void _AutoTakeoff::run()
     // aircraft stays in landed state until rotor speed run up has finished
     if (motors->get_spool_state() != AP_Motors::SpoolState::THROTTLE_UNLIMITED) {
         // motors have not completed spool up yet so relax navigation and position controllers
-        pos_control->relax_velocity_controller_xy();
-        pos_control->update_xy_controller();
-        pos_control->relax_z_controller(0.0f);   // forces throttle output to decay to zero
-        pos_control->update_z_controller();
+        pos_control->relax_velocity_controller_NE();
+        pos_control->update_NE_controller();
+        pos_control->relax_U_controller(0.0f);   // forces throttle output to decay to zero
+        pos_control->update_U_controller();
         attitude_control->reset_yaw_target_and_rate();
         attitude_control->reset_rate_controller_I_terms();
         attitude_control->input_thrust_vector_rate_heading(pos_control->get_thrust_vector(), 0.0);
@@ -162,14 +162,14 @@ void _AutoTakeoff::run()
         float throttle = constrain_float(copter.attitude_control->get_throttle_in() + copter.G_Dt / copter.g2.takeoff_throttle_slew_time, 0.0, 1.0);
         copter.attitude_control->set_throttle_out(throttle, true, 0.0);
         // tell position controller to reset alt target and reset I terms
-        copter.pos_control->init_z_controller();
-        pos_control->relax_velocity_controller_xy();
-        pos_control->update_xy_controller();
+        copter.pos_control->init_U_controller();
+        pos_control->relax_velocity_controller_NE();
+        pos_control->update_NE_controller();
         attitude_control->reset_rate_controller_I_terms();
         attitude_control->input_thrust_vector_rate_heading(pos_control->get_thrust_vector(), 0.0);
         if (throttle >= MIN(copter.g2.takeoff_throttle_max, 0.9) || 
-            (copter.pos_control->get_z_accel_cmss() >= 0.5 * copter.pos_control->get_max_accel_z_cmss()) ||
-            (copter.pos_control->get_vel_desired_cms().z >= 0.1 * copter.pos_control->get_max_speed_up_cms()) || 
+            (copter.pos_control->get_measured_accel_U_cmss() >= 0.5 * copter.pos_control->get_max_accel_U_cmss()) ||
+            (copter.pos_control->get_vel_desired_NEU_cms().z >= 0.1 * copter.pos_control->get_max_speed_up_cms()) || 
             ( no_nav_active && (inertial_nav.get_position_z_up_cm() >= no_nav_alt_cm))) {
             // throttle > 90%
             // acceleration > 50% maximum acceleration
@@ -186,21 +186,21 @@ void _AutoTakeoff::run()
         if (inertial_nav.get_position_z_up_cm() >= no_nav_alt_cm) {
             no_nav_active = false;
         }
-        pos_control->relax_velocity_controller_xy();
+        pos_control->relax_velocity_controller_NE();
     } else {
         Vector2f vel;
         Vector2f accel;
-        pos_control->input_vel_accel_xy(vel, accel);
+        pos_control->input_vel_accel_NE_cm(vel, accel);
     }
-    pos_control->update_xy_controller();
+    pos_control->update_NE_controller();
 
     // command the aircraft to the take off altitude
     float pos_z = complete_alt_cm + terr_offset;
     float vel_z = 0.0;
-    copter.pos_control->input_pos_vel_accel_z(pos_z, vel_z, 0.0);
+    copter.pos_control->input_pos_vel_accel_U_cm(pos_z, vel_z, 0.0);
     
     // run the vertical position controller and set output throttle
-    pos_control->update_z_controller();
+    pos_control->update_U_controller();
 
     // call attitude controller with auto yaw
     attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), copter.flightmode->auto_yaw.get_heading());
@@ -209,14 +209,14 @@ void _AutoTakeoff::run()
     // and 10% our maximum climb rate
     const float vel_threshold_fraction = 0.1;
     // stopping distance from vel_threshold_fraction * max velocity
-    const float stop_distance = 0.5 * sq(vel_threshold_fraction * copter.pos_control->get_max_speed_up_cms()) / copter.pos_control->get_max_accel_z_cmss();
-    bool reached_altitude = copter.pos_control->get_pos_desired_z_cm() >= pos_z - stop_distance;
-    bool reached_climb_rate = copter.pos_control->get_vel_desired_cms().z < copter.pos_control->get_max_speed_up_cms() * vel_threshold_fraction;
+    const float stop_distance = 0.5 * sq(vel_threshold_fraction * copter.pos_control->get_max_speed_up_cms()) / copter.pos_control->get_max_accel_U_cmss();
+    bool reached_altitude = copter.pos_control->get_pos_desired_U_cm() >= pos_z - stop_distance;
+    bool reached_climb_rate = copter.pos_control->get_vel_desired_NEU_cms().z < copter.pos_control->get_max_speed_up_cms() * vel_threshold_fraction;
     complete = reached_altitude && reached_climb_rate;
 
     // calculate completion for location in case it is needed for a smooth transition to wp_nav
     if (complete) {
-        const Vector3p& _complete_pos = copter.pos_control->get_pos_desired_cm();
+        const Vector3p& _complete_pos = copter.pos_control->get_pos_desired_NEU_cm();
         complete_pos = Vector3p{_complete_pos.x, _complete_pos.y, pos_z};
     }
 }

--- a/ArduCopter/tuning.cpp
+++ b/ArduCopter/tuning.cpp
@@ -71,36 +71,36 @@ void Copter::tuning()
 
     // Altitude and throttle tuning
     case TUNING_ALTITUDE_HOLD_KP:
-        pos_control->get_pos_z_p().set_kP(tuning_value);
+        pos_control->get_pos_U_p().set_kP(tuning_value);
         break;
 
     case TUNING_THROTTLE_RATE_KP:
-        pos_control->get_vel_z_pid().set_kP(tuning_value);
+        pos_control->get_vel_U_pid().set_kP(tuning_value);
         break;
 
     case TUNING_ACCEL_Z_KP:
-        pos_control->get_accel_z_pid().set_kP(tuning_value);
+        pos_control->get_accel_U_pid().set_kP(tuning_value);
         break;
 
     case TUNING_ACCEL_Z_KI:
-        pos_control->get_accel_z_pid().set_kI(tuning_value);
+        pos_control->get_accel_U_pid().set_kI(tuning_value);
         break;
 
     case TUNING_ACCEL_Z_KD:
-        pos_control->get_accel_z_pid().set_kD(tuning_value);
+        pos_control->get_accel_U_pid().set_kD(tuning_value);
         break;
 
     // Loiter and navigation tuning
     case TUNING_LOITER_POSITION_KP:
-        pos_control->get_pos_xy_p().set_kP(tuning_value);
+        pos_control->get_pos_NE_p().set_kP(tuning_value);
         break;
 
     case TUNING_VEL_XY_KP:
-        pos_control->get_vel_xy_pid().set_kP(tuning_value);
+        pos_control->get_vel_NE_pid().set_kP(tuning_value);
         break;
 
     case TUNING_VEL_XY_KI:
-        pos_control->get_vel_xy_pid().set_kI(tuning_value);
+        pos_control->get_vel_NE_pid().set_kI(tuning_value);
         break;
 
     case TUNING_WP_SPEED:

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -32,14 +32,14 @@ void Plane::Log_Write_Attitude(void)
         logger.Write_PID(LOG_PIQR_MSG, quadplane.attitude_control->get_rate_roll_pid().get_pid_info());
         logger.Write_PID(LOG_PIQP_MSG, quadplane.attitude_control->get_rate_pitch_pid().get_pid_info());
         logger.Write_PID(LOG_PIQY_MSG, quadplane.attitude_control->get_rate_yaw_pid().get_pid_info());
-        logger.Write_PID(LOG_PIQA_MSG, quadplane.pos_control->get_accel_z_pid().get_pid_info() );
+        logger.Write_PID(LOG_PIQA_MSG, quadplane.pos_control->get_accel_U_pid().get_pid_info() );
 
         // Write tailsitter specific log at same rate as PIDs
         quadplane.tailsitter.write_log();
     }
-    if (quadplane.in_vtol_mode() && quadplane.pos_control->is_active_xy()) {
-        logger.Write_PID(LOG_PIDN_MSG, quadplane.pos_control->get_vel_xy_pid().get_pid_info_x());
-        logger.Write_PID(LOG_PIDE_MSG, quadplane.pos_control->get_vel_xy_pid().get_pid_info_y());
+    if (quadplane.in_vtol_mode() && quadplane.pos_control->is_active_NE()) {
+        logger.Write_PID(LOG_PIDN_MSG, quadplane.pos_control->get_vel_NE_pid().get_pid_info_x());
+        logger.Write_PID(LOG_PIDE_MSG, quadplane.pos_control->get_vel_NE_pid().get_pid_info_y());
     }
 #endif
 

--- a/ArduPlane/VTOL_Assist.cpp
+++ b/ArduPlane/VTOL_Assist.cpp
@@ -179,8 +179,8 @@ bool VTOL_Assist::check_VTOL_recovery(void)
                    controller may limit pitch after a strong
                    acceleration event
                 */
-                quadplane.pos_control->init_z_controller();
-                quadplane.pos_control->init_xy_controller();
+                quadplane.pos_control->init_U_controller();
+                quadplane.pos_control->init_NE_controller();
             }
         }
     }

--- a/ArduPlane/mode_qhover.cpp
+++ b/ArduPlane/mode_qhover.cpp
@@ -6,8 +6,8 @@
 bool ModeQHover::_enter()
 {
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_z(-quadplane.get_pilot_velocity_z_max_dn(), quadplane.pilot_speed_z_max_up*100, quadplane.pilot_accel_z*100);
-    pos_control->set_correction_speed_accel_z(-quadplane.get_pilot_velocity_z_max_dn(), quadplane.pilot_speed_z_max_up*100, quadplane.pilot_accel_z*100);
+    pos_control->set_max_speed_accel_U_cm(-quadplane.get_pilot_velocity_z_max_dn(), quadplane.pilot_speed_z_max_up*100, quadplane.pilot_accel_z*100);
+    pos_control->set_correction_speed_accel_U_cmss(-quadplane.get_pilot_velocity_z_max_dn(), quadplane.pilot_speed_z_max_up*100, quadplane.pilot_accel_z*100);
     quadplane.set_climb_rate_cms(0);
 
     quadplane.init_throttle_wait();
@@ -37,7 +37,7 @@ void ModeQHover::run()
         quadplane.set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
         attitude_control->set_throttle_out(0, true, 0);
         quadplane.relax_attitude_control();
-        pos_control->relax_z_controller(0);
+        pos_control->relax_U_controller(0);
     } else {
         plane.quadplane.assign_tilt_to_fwd_thr();
         quadplane.hold_hover(quadplane.get_pilot_desired_climb_rate_cms());

--- a/ArduPlane/mode_qloiter.cpp
+++ b/ArduPlane/mode_qloiter.cpp
@@ -10,8 +10,8 @@ bool ModeQLoiter::_enter()
     loiter_nav->init_target();
 
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_z(-quadplane.get_pilot_velocity_z_max_dn(), quadplane.pilot_speed_z_max_up*100, quadplane.pilot_accel_z*100);
-    pos_control->set_correction_speed_accel_z(-quadplane.get_pilot_velocity_z_max_dn(), quadplane.pilot_speed_z_max_up*100, quadplane.pilot_accel_z*100);
+    pos_control->set_max_speed_accel_U_cm(-quadplane.get_pilot_velocity_z_max_dn(), quadplane.pilot_speed_z_max_up*100, quadplane.pilot_accel_z*100);
+    pos_control->set_correction_speed_accel_U_cmss(-quadplane.get_pilot_velocity_z_max_dn(), quadplane.pilot_speed_z_max_up*100, quadplane.pilot_accel_z*100);
 
     quadplane.init_throttle_wait();
 
@@ -55,7 +55,7 @@ void ModeQLoiter::run()
         // we have an active landing target override
         Vector2f rel_origin;
         if (plane.next_WP_loc.get_vector_xy_from_origin_NE(rel_origin)) {
-            quadplane.pos_control->set_pos_desired_xy_cm(rel_origin);
+            quadplane.pos_control->set_pos_desired_NE_cm(rel_origin);
             last_target_loc_set_ms = 0;
         }
     }
@@ -65,7 +65,7 @@ void ModeQLoiter::run()
         // we have an active landing velocity override
         Vector2f target_accel;
         Vector2f target_speed_xy_cms{quadplane.poscontrol.velocity_match.x*100, quadplane.poscontrol.velocity_match.y*100};
-        quadplane.pos_control->input_vel_accel_xy(target_speed_xy_cms, target_accel);
+        quadplane.pos_control->input_vel_accel_NE_cm(target_speed_xy_cms, target_accel);
         quadplane.poscontrol.last_velocity_match_ms = 0;
     }
 #endif // AC_PRECLAND_ENABLED
@@ -80,7 +80,7 @@ void ModeQLoiter::run()
         quadplane.set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
         attitude_control->set_throttle_out(0, true, 0);
         quadplane.relax_attitude_control();
-        pos_control->relax_z_controller(0);
+        pos_control->relax_U_controller(0);
         loiter_nav->clear_pilot_desired_acceleration();
         loiter_nav->init_target();
 
@@ -107,7 +107,7 @@ void ModeQLoiter::run()
     quadplane.set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_z(-quadplane.get_pilot_velocity_z_max_dn(), quadplane.pilot_speed_z_max_up*100, quadplane.pilot_accel_z*100);
+    pos_control->set_max_speed_accel_U_cm(-quadplane.get_pilot_velocity_z_max_dn(), quadplane.pilot_speed_z_max_up*100, quadplane.pilot_accel_z*100);
 
     // process pilot's roll and pitch input
     float target_roll_cd, target_pitch_cd;
@@ -115,8 +115,8 @@ void ModeQLoiter::run()
     loiter_nav->set_pilot_desired_acceleration(target_roll_cd, target_pitch_cd);
     
     // run loiter controller
-    if (!pos_control->is_active_xy()) {
-        pos_control->init_xy_controller();
+    if (!pos_control->is_active_NE()) {
+        pos_control->init_NE_controller();
     }
     loiter_nav->update();
 
@@ -127,7 +127,7 @@ void ModeQLoiter::run()
     plane.quadplane.assign_tilt_to_fwd_thr();
 
     if (quadplane.transition->set_VTOL_roll_pitch_limit(plane.nav_roll_cd, plane.nav_pitch_cd)) {
-        pos_control->set_externally_limited_xy();
+        pos_control->set_externally_limited_NE();
     }
 
     // Pilot input, use yaw rate time constant

--- a/ArduPlane/mode_qrtl.cpp
+++ b/ArduPlane/mode_qrtl.cpp
@@ -97,7 +97,7 @@ void ModeQRTL::run()
         case SubMode::climb: {
             // request zero velocity
             Vector2f vel, accel;
-            pos_control->input_vel_accel_xy(vel, accel);
+            pos_control->input_vel_accel_NE_cm(vel, accel);
             quadplane.run_xy_controller();
 
             // nav roll and pitch are controller by position controller
@@ -107,7 +107,7 @@ void ModeQRTL::run()
             plane.quadplane.assign_tilt_to_fwd_thr();
 
             if (quadplane.transition->set_VTOL_roll_pitch_limit(plane.nav_roll_cd, plane.nav_pitch_cd)) {
-                pos_control->set_externally_limited_xy();
+                pos_control->set_externally_limited_NE();
             }
             // weathervane with no pilot input
             quadplane.disable_yaw_rate_time_constant();
@@ -121,7 +121,7 @@ void ModeQRTL::run()
 
             // Climb done when stopping point reaches target altitude
             Vector3p stopping_point;
-            pos_control->get_stopping_point_z_cm(stopping_point.z);
+            pos_control->get_stopping_point_U_cm(stopping_point.z);
             Location stopping_loc = Location(stopping_point.tofloat(), Location::AltFrame::ABOVE_ORIGIN);
 
             ftype alt_diff;

--- a/ArduPlane/qautotune.cpp
+++ b/ArduPlane/qautotune.cpp
@@ -42,10 +42,10 @@ void QAutoTune::get_pilot_desired_rp_yrate_cd(float &des_roll_cd, float &des_pit
 void QAutoTune::init_z_limits()
 {
     // set vertical speed and acceleration limits
-    plane.quadplane.pos_control->set_max_speed_accel_z(-plane.quadplane.get_pilot_velocity_z_max_dn(),
+    plane.quadplane.pos_control->set_max_speed_accel_U_cm(-plane.quadplane.get_pilot_velocity_z_max_dn(),
                                                        plane.quadplane.pilot_speed_z_max_up*100,
                                                        plane.quadplane.pilot_accel_z*100);
-    plane.quadplane.pos_control->set_correction_speed_accel_z(-plane.quadplane.get_pilot_velocity_z_max_dn(),
+    plane.quadplane.pos_control->set_correction_speed_accel_U_cmss(-plane.quadplane.get_pilot_velocity_z_max_dn(),
                                                               plane.quadplane.pilot_speed_z_max_up*100,
                                                               plane.quadplane.pilot_accel_z*100);
 }

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1016,21 +1016,21 @@ void QuadPlane::run_z_controller(void)
         // never run Z controller in tailsitter transtion
         return;
     }
-    if ((now - last_pidz_active_ms) > 20 || !pos_control->is_active_z()) {
+    if ((now - last_pidz_active_ms) > 20 || !pos_control->is_active_U()) {
         // set vertical speed and acceleration limits
-        pos_control->set_max_speed_accel_z(-get_pilot_velocity_z_max_dn(), pilot_speed_z_max_up*100, pilot_accel_z*100);
+        pos_control->set_max_speed_accel_U_cm(-get_pilot_velocity_z_max_dn(), pilot_speed_z_max_up*100, pilot_accel_z*100);
 
         // initialise the vertical position controller
         if (!tailsitter.enabled()) {
-            pos_control->init_z_controller();
+            pos_control->init_U_controller();
         } else {
             // initialise the vertical position controller with no descent
-            pos_control->init_z_controller_no_descent();
+            pos_control->init_U_controller_no_descent();
         }
         last_pidz_init_ms = now;
     }
     last_pidz_active_ms = now;
-    pos_control->update_z_controller();
+    pos_control->update_U_controller();
 }
 
 void QuadPlane::relax_attitude_control()
@@ -1059,7 +1059,7 @@ void QuadPlane::check_yaw_reset(void)
 
 void QuadPlane::set_climb_rate_cms(float target_climb_rate_cms)
 {
-    pos_control->input_vel_accel_z(target_climb_rate_cms, 0, false);
+    pos_control->input_vel_accel_U_cm(target_climb_rate_cms, 0, false);
 }
 
 /*
@@ -1071,7 +1071,7 @@ void QuadPlane::hold_hover(float target_climb_rate_cms)
     set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_z(-get_pilot_velocity_z_max_dn(), pilot_speed_z_max_up*100, pilot_accel_z*100);
+    pos_control->set_max_speed_accel_U_cm(-get_pilot_velocity_z_max_dn(), pilot_speed_z_max_up*100, pilot_accel_z*100);
 
     // call attitude controller
     multicopter_attitude_rate_update(get_desired_yaw_rate_cds(false));
@@ -1714,7 +1714,7 @@ void QuadPlane::update(void)
             attitude_control->relax_attitude_controllers();
         }
         // todo: do you want to set the throttle at this point?
-        pos_control->relax_z_controller(0);
+        pos_control->relax_U_controller(0);
     }
 
     const uint32_t now = AP_HAL::millis();
@@ -1884,7 +1884,7 @@ void QuadPlane::update_throttle_hover()
     }
 
     // do not update while climbing or descending
-    if (!is_zero(pos_control->get_vel_desired_cms().z)) {
+    if (!is_zero(pos_control->get_vel_desired_NEU_cms().z)) {
         return;
     }
 
@@ -2162,17 +2162,17 @@ void QuadPlane::run_xy_controller(float accel_limit)
         accel_cmss = MAX(accel_cmss, accel_limit*100);
     }
     const float speed_cms = wp_nav->get_default_speed_xy();
-    pos_control->set_max_speed_accel_xy(speed_cms, accel_cmss);
-    pos_control->set_correction_speed_accel_xy(speed_cms, accel_cmss);
-    if (!pos_control->is_active_xy()) {
-        pos_control->init_xy_controller();
+    pos_control->set_max_speed_accel_NE_cm(speed_cms, accel_cmss);
+    pos_control->set_correction_speed_accel_NE_cm(speed_cms, accel_cmss);
+    if (!pos_control->is_active_NE()) {
+        pos_control->init_NE_controller();
     }
     pos_control->set_lean_angle_max_cd(MIN(4500, MAX(accel_to_angle(accel_limit)*100, aparm.angle_max)));
     if (q_fwd_throttle > 0.95f) {
         // prevent wind up of the velocity controller I term due to a saturated forward throttle
-        pos_control->set_externally_limited_xy();
+        pos_control->set_externally_limited_NE();
     }
-    pos_control->update_xy_controller();
+    pos_control->update_NE_controller();
 }
 
 /*
@@ -2258,7 +2258,7 @@ void QuadPlane::PosControlState::set_state(enum position_control_state s)
             done_accel_init = false;
         } else if (s == QPOS_AIRBRAKE) {
             // start with zero integrator on vertical throttle
-            qp.pos_control->get_accel_z_pid().set_integrator(0);
+            qp.pos_control->get_accel_U_pid().set_integrator(0);
         } else if (s == QPOS_LAND_DESCEND) {
             // reset throttle descent control
             qp.thr_ctrl_land = false;
@@ -2575,7 +2575,7 @@ void QuadPlane::vtol_position_controller(void)
                 gcs().send_text(MAV_SEVERITY_INFO,"VTOL Overshoot d=%.1f cs=%.1f yerr=%.1f",
                                 distance, closing_groundspeed, yaw_err_deg);
                 poscontrol.overshoot = true;
-                pos_control->set_accel_desired_xy_cmss(Vector2f());
+                pos_control->set_accel_desired_NE_cmss(Vector2f());
             }
             if (poscontrol.overshoot) {
                 /* we have overshot the landing point or our nose is
@@ -2621,7 +2621,7 @@ void QuadPlane::vtol_position_controller(void)
         }
 
         // use input shaping and abide by accel and jerk limits
-        pos_control->input_vel_accel_xy(target_speed_xy_cms, target_accel_cms);
+        pos_control->input_vel_accel_NE_cm(target_speed_xy_cms, target_accel_cms);
 
         // run horizontal velocity controller
         run_xy_controller(MAX(target_accel, transition_decel)*1.5);
@@ -2633,7 +2633,7 @@ void QuadPlane::vtol_position_controller(void)
               quickly at the start of POSITION1
              */
             poscontrol.done_accel_init = true;
-            pos_control->set_accel_desired_xy_cmss(target_accel_cms);
+            pos_control->set_accel_desired_NE_cmss(target_accel_cms);
         }
         
         // nav roll and pitch are controller by position controller
@@ -2643,7 +2643,7 @@ void QuadPlane::vtol_position_controller(void)
         assign_tilt_to_fwd_thr();
 
         if (transition->set_VTOL_roll_pitch_limit(plane.nav_roll_cd, plane.nav_pitch_cd)) {
-            pos_control->set_externally_limited_xy();
+            pos_control->set_externally_limited_NE();
         }
 
         // call attitude controller
@@ -2682,7 +2682,7 @@ void QuadPlane::vtol_position_controller(void)
          */
         Vector2f zero;
         Vector2f vel_cms = poscontrol.target_vel_cms.xy() + landing_velocity*100;
-        pos_control->input_pos_vel_accel_xy(poscontrol.target_cm.xy(), vel_cms, zero);
+        pos_control->input_pos_vel_accel_NE_cm(poscontrol.target_cm.xy(), vel_cms, zero);
 
         // also run fixed wing navigation
         plane.nav_controller->update_waypoint(plane.current_loc, loc);
@@ -2698,7 +2698,7 @@ void QuadPlane::vtol_position_controller(void)
         assign_tilt_to_fwd_thr();
 
         if (transition->set_VTOL_roll_pitch_limit(plane.nav_roll_cd, plane.nav_pitch_cd)) {
-            pos_control->set_externally_limited_xy();
+            pos_control->set_externally_limited_NE();
         }
 
         // call attitude controller
@@ -2714,7 +2714,7 @@ void QuadPlane::vtol_position_controller(void)
 
         // relax when close to the ground
         if (should_relax()) {
-            pos_control->relax_velocity_controller_xy();
+            pos_control->relax_velocity_controller_NE();
         } else {
             Vector2f zero;
             Vector2f vel_cms = poscontrol.target_vel_cms.xy() + landing_velocity*100;
@@ -2728,10 +2728,10 @@ void QuadPlane::vtol_position_controller(void)
             if (motors->limit.throttle_lower ||
                 motors->get_throttle() < 0.5*motors->get_throttle_hover() ||
                 last_reset_ms != poscontrol.last_pos_reset_ms) {
-                pos_control->input_vel_accel_xy(vel_cms, zero);
+                pos_control->input_vel_accel_NE_cm(vel_cms, zero);
             } else {
                 // otherwise use full pos control
-                pos_control->input_pos_vel_accel_xy(poscontrol.target_cm.xy(), vel_cms, zero);
+                pos_control->input_pos_vel_accel_NE_cm(poscontrol.target_cm.xy(), vel_cms, zero);
             }
         }
 
@@ -2768,12 +2768,12 @@ void QuadPlane::vtol_position_controller(void)
         // phases of landing, so relax the Z controller, unless we are
         // providing assistance
         if (transition->complete()) {
-            pos_control->relax_z_controller(0);
+            pos_control->relax_U_controller(0);
         }
         break;
     case QPOS_POSITION1:
         if (tailsitter.in_vtol_transition(now_ms)) {
-            pos_control->relax_z_controller(0);
+            pos_control->relax_U_controller(0);
             break;
         }
         FALLTHROUGH;
@@ -2809,13 +2809,13 @@ void QuadPlane::vtol_position_controller(void)
             }
             float zero = 0;
             float target_z = target_altitude_cm;
-            pos_control->input_pos_vel_accel_z(target_z, zero, 0);
+            pos_control->input_pos_vel_accel_U_cm(target_z, zero, 0);
         } else if (plane.control_mode == &plane.mode_qrtl) {
             Location loc2 = loc;
             loc2.change_alt_frame(Location::AltFrame::ABOVE_ORIGIN);
             float target_z = loc2.alt;
             float zero = 0;
-            pos_control->input_pos_vel_accel_z(target_z, zero, 0);
+            pos_control->input_pos_vel_accel_U_cm(target_z, zero, 0);
         } else {
             set_climb_rate_cms(0);
         }
@@ -2891,11 +2891,11 @@ QuadPlane::ActiveFwdThr QuadPlane::get_vfwd_method(void) const
         if (q_fwd_thr_use == FwdThrUse::ALL) {
             return ActiveFwdThr::NEW;
         }
-        if (q_fwd_thr_use == FwdThrUse::POSCTRL && pos_control->is_active_xy()) {
+        if (q_fwd_thr_use == FwdThrUse::POSCTRL && pos_control->is_active_NE()) {
             return ActiveFwdThr::NEW;
         }
     }
-    if (have_vfwd_gain && pos_control->is_active_xy()) {
+    if (have_vfwd_gain && pos_control->is_active_NE()) {
         return ActiveFwdThr::OLD;
     }
     return ActiveFwdThr::NONE;
@@ -2926,7 +2926,7 @@ void QuadPlane::assign_tilt_to_fwd_thr(void)
         if (is_positive(fwd_tilt_range_cd)) {
             // rate limit the forward tilt change to slew between the motor good and motor failed
             // value over 10 seconds
-            const bool fwd_limited = plane.quadplane.pos_control->is_active_xy() and plane.quadplane.pos_control->get_fwd_pitch_is_limited();
+            const bool fwd_limited = plane.quadplane.pos_control->is_active_NE() and plane.quadplane.pos_control->get_fwd_pitch_is_limited();
             const float fwd_pitch_lim_cd_tgt = fwd_limited ? (float)aparm.angle_max : 100.0f * q_fwd_pitch_lim;
             const float delta_max = 0.1f * fwd_tilt_range_cd * plane.G_Dt;
             q_fwd_pitch_lim_cd += constrain_float((fwd_pitch_lim_cd_tgt - q_fwd_pitch_lim_cd), -delta_max, delta_max);
@@ -3046,8 +3046,8 @@ void QuadPlane::setup_target_position(void)
     poscontrol.target_cm.z = plane.next_WP_loc.alt - origin.alt;
 
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_z(-get_pilot_velocity_z_max_dn(), pilot_speed_z_max_up*100, pilot_accel_z*100);
-    pos_control->set_correction_speed_accel_z(-get_pilot_velocity_z_max_dn(), pilot_speed_z_max_up*100, pilot_accel_z*100);
+    pos_control->set_max_speed_accel_U_cm(-get_pilot_velocity_z_max_dn(), pilot_speed_z_max_up*100, pilot_accel_z*100);
+    pos_control->set_correction_speed_accel_U_cmss(-get_pilot_velocity_z_max_dn(), pilot_speed_z_max_up*100, pilot_accel_z*100);
 }
 
 /*
@@ -3120,9 +3120,9 @@ void QuadPlane::takeoff_controller(void)
     takeoff_last_run_ms = now;
 
     if (no_navigation) {
-        pos_control->relax_velocity_controller_xy();
+        pos_control->relax_velocity_controller_NE();
     } else {
-        pos_control->input_vel_accel_xy(vel, zero);
+        pos_control->input_vel_accel_NE_cm(vel, zero);
 
         // nav roll and pitch are controller by position controller
         plane.nav_roll_cd = pos_control->get_roll_cd();
@@ -3149,7 +3149,7 @@ void QuadPlane::takeoff_controller(void)
             const int32_t margin_cm = 5;
             float pos_z = margin_cm + plane.next_WP_loc.alt - origin.alt;
             vel_z = 0;
-            pos_control->input_pos_vel_accel_z(pos_z, vel_z, 0);
+            pos_control->input_pos_vel_accel_U_cm(pos_z, vel_z, 0);
         } else {
             set_climb_rate_cms(vel_z);
         }
@@ -3189,7 +3189,7 @@ void QuadPlane::waypoint_controller(void)
     assign_tilt_to_fwd_thr();
 
     if (transition->set_VTOL_roll_pitch_limit(plane.nav_roll_cd, plane.nav_pitch_cd)) {
-        pos_control->set_externally_limited_xy();
+        pos_control->set_externally_limited_NE();
     }
 
     // call attitude controller
@@ -3297,11 +3297,11 @@ bool QuadPlane::do_vtol_takeoff(const AP_Mission::Mission_Command& cmd)
     throttle_wait = false;
 
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_z(-get_pilot_velocity_z_max_dn(), pilot_speed_z_max_up*100, pilot_accel_z*100);
-    pos_control->set_correction_speed_accel_z(-get_pilot_velocity_z_max_dn(), pilot_speed_z_max_up*100, pilot_accel_z*100);
+    pos_control->set_max_speed_accel_U_cm(-get_pilot_velocity_z_max_dn(), pilot_speed_z_max_up*100, pilot_accel_z*100);
+    pos_control->set_correction_speed_accel_U_cmss(-get_pilot_velocity_z_max_dn(), pilot_speed_z_max_up*100, pilot_accel_z*100);
 
     // initialise the vertical position controller
-    pos_control->init_z_controller();
+    pos_control->init_U_controller();
 
     // also update nav_controller for status output
     plane.nav_controller->update_waypoint(plane.current_loc, plane.next_WP_loc);
@@ -3347,8 +3347,8 @@ bool QuadPlane::do_vtol_land(const AP_Mission::Mission_Command& cmd)
                                  Location::AltFrame::ABSOLUTE);
 
     // initialise the position controller
-    pos_control->init_xy_controller();
-    pos_control->init_z_controller();
+    pos_control->init_NE_controller();
+    pos_control->init_U_controller();
 
     throttle_wait = false;
     landing_detect.lower_limit_start_ms = 0;
@@ -3614,8 +3614,8 @@ void QuadPlane::Log_Write_QControl_Tuning()
     float des_alt_m = 0.0f;
     int16_t target_climb_rate_cms = 0;
     if (plane.control_mode != &plane.mode_qstabilize) {
-        des_alt_m = pos_control->get_pos_desired_z_cm() * 0.01f;
-        target_climb_rate_cms = pos_control->get_vel_target_z_cms();
+        des_alt_m = pos_control->get_pos_desired_U_cm() * 0.01f;
+        target_climb_rate_cms = pos_control->get_vel_target_U_cms();
     }
 
     // Asemble assistance bitmask, defintion here is used to generate log documentation
@@ -3736,7 +3736,7 @@ float QuadPlane::forward_throttle_pct()
     vel_forward.last_ms = AP_HAL::millis();
     
     // work out the desired speed in forward direction
-    Vector3f desired_velocity_cms = pos_control->get_vel_desired_cms();
+    Vector3f desired_velocity_cms = pos_control->get_vel_desired_NEU_cms();
 
     // convert to NED m/s
     desired_velocity_cms.z *= -1;
@@ -3915,7 +3915,7 @@ bool QuadPlane::guided_mode_enabled(void)
  */
 void QuadPlane::set_alt_target_current(void)
 {
-    pos_control->set_pos_desired_z_cm(inertial_nav.get_position_z_up_cm());
+    pos_control->set_pos_desired_U_cm(inertial_nav.get_position_z_up_cm());
 }
 
 // user initiated takeoff for guided mode
@@ -4090,7 +4090,7 @@ void QuadPlane::update_throttle_mix(void)
         bool accel_moving = (throttle_mix_accel_ef_filter.get().length() > LAND_CHECK_ACCEL_MOVING);
 
         // check for requested descent
-        bool descent_not_demanded = pos_control->get_vel_desired_cms().z >= 0.0f;
+        bool descent_not_demanded = pos_control->get_vel_desired_NEU_cms().z >= 0.0f;
 
         bool use_mix_max = large_angle_request || large_angle_error || accel_moving || descent_not_demanded;
 

--- a/ArduPlane/systemid.cpp
+++ b/ArduPlane/systemid.cpp
@@ -160,10 +160,10 @@ void AP_SystemID::stop()
         attitude_control->rate_bf_roll_sysid(0);
         attitude_control->rate_bf_pitch_sysid(0);
         attitude_control->rate_bf_yaw_sysid(0);
-        plane.quadplane.pos_control->set_xy_control_scale_factor(1);
+        plane.quadplane.pos_control->set_NE_control_scale_factor(1);
 
         // re-initialise the XY controller so we take current position as target
-        plane.quadplane.pos_control->init_xy_controller();
+        plane.quadplane.pos_control->init_NE_controller();
 
         gcs().send_text(MAV_SEVERITY_INFO, "SystemID stopped");
     }
@@ -239,7 +239,7 @@ void AP_SystemID::update()
     }
 
     // reduce control in XY axis when in position controlled modes
-    plane.quadplane.pos_control->set_xy_control_scale_factor(xy_control_mul);
+    plane.quadplane.pos_control->set_NE_control_scale_factor(xy_control_mul);
 
     if (log_subsample <= 0) {
         log_data();

--- a/ArduPlane/tuning.cpp
+++ b/ArduPlane/tuning.cpp
@@ -166,28 +166,28 @@ AP_Float *AP_Tuning_Plane::get_param_pointer(uint8_t parm)
         return &plane.quadplane.attitude_control->get_angle_yaw_p().kP();
 
     case TUNING_PXY_P:
-        return &plane.quadplane.pos_control->get_pos_xy_p().kP();
+        return &plane.quadplane.pos_control->get_pos_NE_p().kP();
 
     case TUNING_PZ_P:
-        return &plane.quadplane.pos_control->get_pos_z_p().kP();
+        return &plane.quadplane.pos_control->get_pos_U_p().kP();
 
     case TUNING_VXY_P:
-        return &plane.quadplane.pos_control->get_vel_xy_pid().kP();
+        return &plane.quadplane.pos_control->get_vel_NE_pid().kP();
 
     case TUNING_VXY_I:
-        return &plane.quadplane.pos_control->get_vel_xy_pid().kI();
+        return &plane.quadplane.pos_control->get_vel_NE_pid().kI();
 
     case TUNING_VZ_P:
-        return &plane.quadplane.pos_control->get_vel_z_pid().kP();
+        return &plane.quadplane.pos_control->get_vel_U_pid().kP();
 
     case TUNING_AZ_P:
-        return &plane.quadplane.pos_control->get_accel_z_pid().kP();
+        return &plane.quadplane.pos_control->get_accel_U_pid().kP();
 
     case TUNING_AZ_I:
-        return &plane.quadplane.pos_control->get_accel_z_pid().kI();
+        return &plane.quadplane.pos_control->get_accel_U_pid().kI();
 
     case TUNING_AZ_D:
-        return &plane.quadplane.pos_control->get_accel_z_pid().kD();
+        return &plane.quadplane.pos_control->get_accel_U_pid().kD();
 
     case TUNING_RATE_PITCH_FF:
         return &plane.quadplane.attitude_control->get_rate_pitch_pid().ff();

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -190,7 +190,7 @@ void Sub::ten_hz_logging_loop()
             logger.Write_PID(LOG_PIDR_MSG, attitude_control.get_rate_roll_pid().get_pid_info());
             logger.Write_PID(LOG_PIDP_MSG, attitude_control.get_rate_pitch_pid().get_pid_info());
             logger.Write_PID(LOG_PIDY_MSG, attitude_control.get_rate_yaw_pid().get_pid_info());
-            logger.Write_PID(LOG_PIDA_MSG, pos_control.get_accel_z_pid().get_pid_info());
+            logger.Write_PID(LOG_PIDA_MSG, pos_control.get_accel_U_pid().get_pid_info());
         }
     }
     if (should_log(MASK_LOG_MOTBATT)) {
@@ -227,7 +227,7 @@ void Sub::twentyfive_hz_logging()
             logger.Write_PID(LOG_PIDR_MSG, attitude_control.get_rate_roll_pid().get_pid_info());
             logger.Write_PID(LOG_PIDP_MSG, attitude_control.get_rate_pitch_pid().get_pid_info());
             logger.Write_PID(LOG_PIDY_MSG, attitude_control.get_rate_yaw_pid().get_pid_info());
-            logger.Write_PID(LOG_PIDA_MSG, pos_control.get_accel_z_pid().get_pid_info());
+            logger.Write_PID(LOG_PIDA_MSG, pos_control.get_accel_U_pid().get_pid_info());
         }
     }
 
@@ -300,7 +300,7 @@ void Sub::one_hz_loop()
     set_likely_flying(hal.util->get_soft_armed());
 
     attitude_control.set_notch_sample_rate(AP::scheduler().get_filtered_loop_rate_hz());
-    pos_control.get_accel_z_pid().set_notch_sample_rate(AP::scheduler().get_filtered_loop_rate_hz());
+    pos_control.get_accel_U_pid().set_notch_sample_rate(AP::scheduler().get_filtered_loop_rate_hz());
 }
 
 void Sub::read_AHRS()

--- a/ArduSub/GCS_MAVLink_Sub.cpp
+++ b/ArduSub/GCS_MAVLink_Sub.cpp
@@ -86,7 +86,7 @@ void GCS_MAVLINK_Sub::send_nav_controller_output() const
         targets.z * 1.0e-2f,
         sub.wp_nav.get_wp_bearing_to_destination() * 1.0e-2f,
         MIN(sub.wp_nav.get_wp_distance_to_destination() * 1.0e-2f, UINT16_MAX),
-        sub.pos_control.get_pos_error_z_cm() * 1.0e-2f,
+        sub.pos_control.get_pos_error_U_cm() * 1.0e-2f,
         0,
         0);
 }
@@ -214,7 +214,7 @@ void GCS_MAVLINK_Sub::send_pid_tuning()
         }
     }
     if (g.gcs_pid_mask & 8) {
-        const AP_PIDInfo &pid_info = sub.pos_control.get_accel_z_pid().get_pid_info();
+        const AP_PIDInfo &pid_info = sub.pos_control.get_accel_U_pid().get_pid_info();
         mavlink_msg_pid_tuning_send(chan, PID_TUNING_ACCZ,
                                     pid_info.target*0.01f,
                                     -(ahrs.get_accel_ef().z + GRAVITY_MSS),
@@ -634,7 +634,7 @@ void GCS_MAVLINK_Sub::handle_message(const mavlink_message_t &msg)
          */
 
         if (!z_ignore && sub.control_mode == Mode::Number::ALT_HOLD) { // Control only target depth when in ALT_HOLD
-            sub.pos_control.set_pos_desired_z_cm(packet.alt*100);
+            sub.pos_control.set_pos_desired_U_cm(packet.alt*100);
             break;
         }
 
@@ -740,7 +740,7 @@ int16_t GCS_MAVLINK_Sub::high_latency_target_altitude() const
 
     //return units are m
     if (sub.control_mode == Mode::Number::AUTO || sub.control_mode == Mode::Number::GUIDED) {
-        return 0.01 * (global_position_current.alt + sub.pos_control.get_pos_error_z_cm());
+        return 0.01 * (global_position_current.alt + sub.pos_control.get_pos_error_U_cm());
     }
     return 0;
     
@@ -769,7 +769,7 @@ uint8_t GCS_MAVLINK_Sub::high_latency_tgt_airspeed() const
 {
     // return units are m/s*5
     if (sub.control_mode == Mode::Number::AUTO || sub.control_mode == Mode::Number::GUIDED) {
-        return MIN((sub.pos_control.get_vel_desired_cms().length()/100) * 5, UINT8_MAX);
+        return MIN((sub.pos_control.get_vel_desired_NEU_cms().length()/100) * 5, UINT8_MAX);
     }
     return 0;
 }

--- a/ArduSub/Log.cpp
+++ b/ArduSub/Log.cpp
@@ -44,13 +44,13 @@ void Sub::Log_Write_Control_Tuning()
         angle_boost         : attitude_control.angle_boost(),
         throttle_out        : motors.get_throttle(),
         throttle_hover      : motors.get_throttle_hover(),
-        desired_alt         : pos_control.get_pos_target_z_cm() * 0.01f,
+        desired_alt         : pos_control.get_pos_target_U_cm() * 0.01f,
         inav_alt            : inertial_nav.get_position_z_up_cm() * 0.01f,
         baro_alt            : barometer.get_altitude(),
         desired_rangefinder_alt   : mode_surftrak.get_rangefinder_target_cm() * 0.01,
         rangefinder_alt           : rangefinder_state.alt,
         terr_alt            : terr_alt,
-        target_climb_rate   : (int16_t)pos_control.get_vel_target_z_cms(),
+        target_climb_rate   : (int16_t)pos_control.get_vel_target_U_cms(),
         climb_rate          : climb_rate
     };
     logger.WriteBlock(&pkt, sizeof(pkt));

--- a/ArduSub/mode_acro.cpp
+++ b/ArduSub/mode_acro.cpp
@@ -7,7 +7,7 @@
 
 bool ModeAcro::init(bool ignore_checks) {
     // set target altitude to zero for reporting
-    position_control->set_pos_desired_z_cm(0);
+    position_control->set_pos_desired_U_cm(0);
 
     // attitude hold inputs become thrust inputs in acro mode
     // set to neutral to prevent chaotic behavior (esp. roll/pitch)

--- a/ArduSub/mode_auto.cpp
+++ b/ArduSub/mode_auto.cpp
@@ -148,7 +148,7 @@ void ModeAuto::auto_wp_run()
 
     // WP_Nav has set the vertical position control targets
     // run the vertical position controller and set output throttle
-    position_control->update_z_controller();
+    position_control->update_U_controller();
 
     ////////////////////////////
     // update attitude output //
@@ -246,7 +246,7 @@ void ModeAuto::auto_circle_run()
 
     // WP_Nav has set the vertical position control targets
     // run the vertical position controller and set output throttle
-    position_control->update_z_controller();
+    position_control->update_U_controller();
 
     // roll & pitch from waypoint controller, yaw rate from pilot
     attitude_control->input_euler_angle_roll_pitch_yaw(channel_roll->get_control_in(), channel_pitch->get_control_in(), sub.circle_nav.get_yaw(), true);
@@ -332,7 +332,7 @@ void ModeAuto::auto_loiter_run()
 
     // WP_Nav has set the vertical position control targets
     // run the vertical position controller and set output throttle
-    position_control->update_z_controller();
+    position_control->update_U_controller();
 
     // get pilot desired lean angles
     float target_roll, target_pitch;
@@ -455,11 +455,11 @@ bool ModeAuto::auto_terrain_recover_start()
     sub.loiter_nav.init_target();
 
     // Reset z axis controller
-    position_control->relax_z_controller(motors.get_throttle_hover());
+    position_control->relax_U_controller(motors.get_throttle_hover());
 
     // initialize vertical maximum speeds and acceleration
-    position_control->set_max_speed_accel_z(sub.wp_nav.get_default_speed_down(), sub.wp_nav.get_default_speed_up(), sub.wp_nav.get_accel_z());
-    position_control->set_correction_speed_accel_z(sub.wp_nav.get_default_speed_down(), sub.wp_nav.get_default_speed_up(), sub.wp_nav.get_accel_z());
+    position_control->set_max_speed_accel_U_cm(sub.wp_nav.get_default_speed_down(), sub.wp_nav.get_default_speed_up(), sub.wp_nav.get_accel_z());
+    position_control->set_correction_speed_accel_U_cmss(sub.wp_nav.get_default_speed_down(), sub.wp_nav.get_default_speed_up(), sub.wp_nav.get_accel_z());
 
     gcs().send_text(MAV_SEVERITY_WARNING, "Attempting auto failsafe recovery");
     return true;
@@ -482,7 +482,7 @@ void ModeAuto::auto_terrain_recover_run()
         attitude_control->relax_attitude_controllers();
 
         sub.loiter_nav.init_target();                                                   // Reset xy target
-        position_control->relax_z_controller(motors.get_throttle_hover());                // Reset z axis controller
+        position_control->relax_U_controller(motors.get_throttle_hover());                // Reset z axis controller
         return;
     }
 
@@ -509,7 +509,7 @@ void ModeAuto::auto_terrain_recover_run()
             // Start timer as soon as rangefinder is healthy
             if (rangefinder_recovery_ms == 0) {
                 rangefinder_recovery_ms = AP_HAL::millis();
-                position_control->relax_z_controller(motors.get_throttle_hover()); // Reset alt hold targets
+                position_control->relax_U_controller(motors.get_throttle_hover()); // Reset alt hold targets
             }
 
             // 1.5 seconds of healthy rangefinder means we can resume mission with terrain enabled
@@ -560,8 +560,8 @@ void ModeAuto::auto_terrain_recover_run()
 
     /////////////////////
     // update z target //
-    position_control->set_pos_target_z_from_climb_rate_cm(target_climb_rate);
-    position_control->update_z_controller();
+    position_control->set_pos_target_U_from_climb_rate_cm(target_climb_rate);
+    position_control->update_U_controller();
 
     ////////////////////////////
     // update angular targets //

--- a/ArduSub/mode_circle.cpp
+++ b/ArduSub/mode_circle.cpp
@@ -14,10 +14,10 @@ bool ModeCircle::init(bool ignore_checks)
     sub.circle_pilot_yaw_override = false;
 
     // initialize speeds and accelerations
-    position_control->set_max_speed_accel_xy(sub.wp_nav.get_default_speed_xy(), sub.wp_nav.get_wp_acceleration());
-    position_control->set_correction_speed_accel_xy(sub.wp_nav.get_default_speed_xy(), sub.wp_nav.get_wp_acceleration());
-    position_control->set_max_speed_accel_z(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
-    position_control->set_correction_speed_accel_z(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    position_control->set_max_speed_accel_NE_cm(sub.wp_nav.get_default_speed_xy(), sub.wp_nav.get_wp_acceleration());
+    position_control->set_correction_speed_accel_NE_cm(sub.wp_nav.get_default_speed_xy(), sub.wp_nav.get_wp_acceleration());
+    position_control->set_max_speed_accel_U_cm(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    position_control->set_correction_speed_accel_U_cmss(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // initialise circle controller including setting the circle center based on vehicle speed
     sub.circle_nav.init();
@@ -33,8 +33,8 @@ void ModeCircle::run()
     float target_climb_rate = 0;
 
     // update parameters, to allow changing at runtime
-    position_control->set_max_speed_accel_xy(sub.wp_nav.get_default_speed_xy(), sub.wp_nav.get_wp_acceleration());
-    position_control->set_max_speed_accel_z(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    position_control->set_max_speed_accel_NE_cm(sub.wp_nav.get_default_speed_xy(), sub.wp_nav.get_wp_acceleration());
+    position_control->set_max_speed_accel_U_cm(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // if not armed set throttle to zero and exit immediately
     if (!motors.armed()) {
@@ -81,6 +81,6 @@ void ModeCircle::run()
     }
 
     // update altitude target and call position controller
-    position_control->set_pos_target_z_from_climb_rate_cm(target_climb_rate);
-    position_control->update_z_controller();
+    position_control->set_pos_target_U_from_climb_rate_cm(target_climb_rate);
+    position_control->update_U_controller();
 }

--- a/ArduSub/mode_manual.cpp
+++ b/ArduSub/mode_manual.cpp
@@ -3,7 +3,7 @@
 
 bool ModeManual::init(bool ignore_checks) {
     // set target altitude to zero for reporting
-    position_control->set_pos_desired_z_cm(0);
+    position_control->set_pos_desired_U_cm(0);
 
     // attitude hold inputs become thrust inputs in manual mode
     // set to neutral to prevent chaotic behavior (esp. roll/pitch)

--- a/ArduSub/mode_poshold.cpp
+++ b/ArduSub/mode_poshold.cpp
@@ -15,19 +15,19 @@ bool ModePoshold::init(bool ignore_checks)
     }
 
     // initialize vertical speeds and acceleration
-    position_control->set_max_speed_accel_xy(g.pilot_speed, g.pilot_accel_z);
-    position_control->set_correction_speed_accel_xy(g.pilot_speed, g.pilot_accel_z);
-    position_control->set_max_speed_accel_z(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
-    position_control->set_correction_speed_accel_z(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    position_control->set_max_speed_accel_NE_cm(g.pilot_speed, g.pilot_accel_z);
+    position_control->set_correction_speed_accel_NE_cm(g.pilot_speed, g.pilot_accel_z);
+    position_control->set_max_speed_accel_U_cm(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    position_control->set_correction_speed_accel_U_cmss(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // initialise position and desired velocity
-    position_control->init_xy_controller_stopping_point();
-    position_control->init_z_controller();
+    position_control->init_NE_controller_stopping_point();
+    position_control->init_U_controller();
 
     // Stop all thrusters
     attitude_control->set_throttle_out(0.5f ,true, g.throttle_filt);
     attitude_control->relax_attitude_controllers();
-    position_control->relax_z_controller(0.5f);
+    position_control->relax_U_controller(0.5f);
 
     sub.last_pilot_heading = ahrs.yaw_sensor;
 
@@ -45,8 +45,8 @@ void ModePoshold::run()
         // Sub vehicles do not stabilize roll/pitch/yaw when not auto-armed (i.e. on the ground, pilot has never raised throttle)
         attitude_control->set_throttle_out(0.5f ,true, g.throttle_filt);
         attitude_control->relax_attitude_controllers();
-        position_control->init_xy_controller_stopping_point();
-        position_control->relax_z_controller(0.5f);
+        position_control->init_NE_controller_stopping_point();
+        position_control->relax_U_controller(0.5f);
         sub.last_pilot_heading = ahrs.yaw_sensor;
         return;
     }
@@ -107,20 +107,20 @@ void ModePoshold::control_horizontal() {
     };
 
     if (sub.position_ok()) {
-        if (!position_control->is_active_xy()) {
+        if (!position_control->is_active_NE()) {
             // the xy controller timed out, re-initialize
-            position_control->init_xy_controller_stopping_point();
+            position_control->init_NE_controller_stopping_point();
         }
 
         // convert to the earth frame and set target rates
         auto earth_rates_cm_s = ahrs.body_to_earth2D(body_rates_cm_s);
-        position_control->input_vel_accel_xy(earth_rates_cm_s, {0, 0});
+        position_control->input_vel_accel_NE_cm(earth_rates_cm_s, {0, 0});
 
         // convert pos control roll and pitch angles back to lateral and forward efforts
         sub.translate_pos_control_rp(lateral_out, forward_out);
 
         // udpate the xy controller
-        position_control->update_xy_controller();
+        position_control->update_NE_controller();
     } else if (g.pilot_speed > 0) {
         // allow the pilot to reposition manually
         forward_out = body_rates_cm_s.x / (float)g.pilot_speed;

--- a/ArduSub/mode_stabilize.cpp
+++ b/ArduSub/mode_stabilize.cpp
@@ -3,7 +3,7 @@
 
 bool ModeStabilize::init(bool ignore_checks) {
     // set target altitude to zero for reporting
-    position_control->set_pos_desired_z_cm(0);
+    position_control->set_pos_desired_U_cm(0);
     sub.last_pilot_heading = ahrs.yaw_sensor;
 
     return true;

--- a/ArduSub/mode_surface.cpp
+++ b/ArduSub/mode_surface.cpp
@@ -8,11 +8,11 @@ bool ModeSurface::init(bool ignore_checks)
     }
 
     // initialize vertical speeds and acceleration
-    position_control->set_max_speed_accel_z(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
-    position_control->set_correction_speed_accel_z(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    position_control->set_max_speed_accel_U_cm(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    position_control->set_correction_speed_accel_U_cmss(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // initialise position and desired velocity
-    position_control->init_z_controller();
+    position_control->init_U_controller();
 
     return true;
 
@@ -28,7 +28,7 @@ void ModeSurface::run()
         motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
         attitude_control->set_throttle_out(0,true,g.throttle_filt);
         attitude_control->relax_attitude_controllers();
-        position_control->init_z_controller();
+        position_control->init_U_controller();
         return;
     }
 
@@ -51,8 +51,8 @@ void ModeSurface::run()
     float cmb_rate = constrain_float(fabsf(sub.wp_nav.get_default_speed_up()), 1, position_control->get_max_speed_up_cms());
 
     // update altitude target and call position controller
-    position_control->set_pos_target_z_from_climb_rate_cm(cmb_rate);
-    position_control->update_z_controller();
+    position_control->set_pos_target_U_from_climb_rate_cm(cmb_rate);
+    position_control->update_U_controller();
 
     // pilot has control for repositioning
     motors.set_forward(channel_forward->norm_input());

--- a/ArduSub/mode_surftrak.cpp
+++ b/ArduSub/mode_surftrak.cpp
@@ -81,7 +81,7 @@ bool ModeSurftrak::set_rangefinder_target_cm(float target_cm)
 
         // Initialize the terrain offset
         auto terrain_offset_cm = sub.inertial_nav.get_position_z_up_cm() - rangefinder_target_cm;
-        sub.pos_control.init_pos_terrain_cm(terrain_offset_cm);
+        sub.pos_control.init_pos_terrain_U_cm(terrain_offset_cm);
 
     } else {
         reset();
@@ -96,7 +96,7 @@ void ModeSurftrak::reset()
     rangefinder_target_cm = INVALID_TARGET;
 
     // Reset the terrain offset
-    sub.pos_control.init_pos_terrain_cm(0);
+    sub.pos_control.init_pos_terrain_U_cm(0);
 }
 
 /*
@@ -115,11 +115,11 @@ void ModeSurftrak::control_range() {
         }
         if (sub.ap.at_surface) {
             // Set target depth to 5 cm below SURFACE_DEPTH and reset
-            position_control->set_pos_desired_z_cm(MIN(position_control->get_pos_desired_z_cm(), g.surface_depth - 5.0f));
+            position_control->set_pos_desired_U_cm(MIN(position_control->get_pos_desired_U_cm(), g.surface_depth - 5.0f));
             reset();
         } else if (sub.ap.at_bottom) {
             // Set target depth to 10 cm above bottom and reset
-            position_control->set_pos_desired_z_cm(MAX(inertial_nav.get_position_z_up_cm() + 10.0f, position_control->get_pos_desired_z_cm()));
+            position_control->set_pos_desired_U_cm(MAX(inertial_nav.get_position_z_up_cm() + 10.0f, position_control->get_pos_desired_U_cm()));
             reset();
         } else {
             // Typical operation
@@ -132,10 +132,10 @@ void ModeSurftrak::control_range() {
     }
 
     // Set the target altitude from the climb rate and the terrain offset
-    position_control->set_pos_target_z_from_climb_rate_cm(target_climb_rate_cm_s);
+    position_control->set_pos_target_U_from_climb_rate_cm(target_climb_rate_cm_s);
 
     // Run the PID controllers
-    position_control->update_z_controller();
+    position_control->update_U_controller();
 }
 
 /*
@@ -162,7 +162,7 @@ void ModeSurftrak::update_surface_offset()
             }
 
             // Set the offset target, AC_PosControl will do the rest
-            sub.pos_control.set_pos_terrain_target_cm(rangefinder_terrain_offset_cm);
+            sub.pos_control.set_pos_terrain_target_U_cm(rangefinder_terrain_offset_cm);
         }
     }
 #endif  // AP_RANGEFINDER_ENABLED

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Logging.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Logging.cpp
@@ -31,7 +31,7 @@ void AC_AttitudeControl::Write_ANG() const
 void AC_AttitudeControl::Write_Rate(const AC_PosControl &pos_control) const
 {
     const Vector3f rate_targets = rate_bf_targets() * RAD_TO_DEG;
-    const Vector3f &accel_target = pos_control.get_accel_target_cmss();
+    const Vector3f &accel_target = pos_control.get_accel_target_NEU_cmss();
     const Vector3f gyro_rate = _rate_gyro * RAD_TO_DEG;
     const struct log_Rate pkt_rate{
         LOG_PACKET_HEADER_INIT(LOG_RATE_MSG),

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -95,7 +95,7 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // @Description: Position (vertical) controller P gain.  Converts the difference between the desired altitude and actual altitude into a climb or descent rate which is passed to the throttle rate controller
     // @Range: 1.000 3.000
     // @User: Standard
-    AP_SUBGROUPINFO(_p_pos_z, "_POSZ_", 2, AC_PosControl, AC_P_1D),
+    AP_SUBGROUPINFO(_p_pos_u, "_POSZ_", 2, AC_PosControl, AC_P_1D),
 
     // @Param: _VELZ_P
     // @DisplayName: Velocity (vertical) controller P gain
@@ -143,7 +143,7 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // @Range: 0 100
     // @Units: Hz
     // @User: Advanced
-    AP_SUBGROUPINFO(_pid_vel_z, "_VELZ_", 3, AC_PosControl, AC_PID_Basic),
+    AP_SUBGROUPINFO(_pid_vel_u, "_VELZ_", 3, AC_PosControl, AC_PID_Basic),
 
     // @Param: _ACCZ_P
     // @DisplayName: Acceleration (vertical) controller P gain
@@ -234,14 +234,14 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // @Range: 1 8
     // @User: Advanced
 
-    AP_SUBGROUPINFO(_pid_accel_z, "_ACCZ_", 4, AC_PosControl, AC_PID),
+    AP_SUBGROUPINFO(_pid_accel_u, "_ACCZ_", 4, AC_PosControl, AC_PID),
 
     // @Param: _POSXY_P
     // @DisplayName: Position (horizontal) controller P gain
     // @Description: Position controller P gain.  Converts the distance (in the latitude direction) to the target location into a desired speed which is then passed to the loiter latitude rate controller
     // @Range: 0.500 2.000
     // @User: Standard
-    AP_SUBGROUPINFO(_p_pos_xy, "_POSXY_", 5, AC_PosControl, AC_P_2D),
+    AP_SUBGROUPINFO(_p_pos_ne, "_POSXY_", 5, AC_PosControl, AC_P_2D),
 
     // @Param: _VELXY_P
     // @DisplayName: Velocity (horizontal) P gain
@@ -292,7 +292,7 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // @Range: 0 6
     // @Increment: 0.01
     // @User: Advanced
-    AP_SUBGROUPINFO(_pid_vel_xy, "_VELXY_", 6, AC_PosControl, AC_PID_2D),
+    AP_SUBGROUPINFO(_pid_vel_ne, "_VELXY_", 6, AC_PosControl, AC_PID_2D),
 
     // @Param: _ANGLE_MAX
     // @DisplayName: Position Control Angle Max
@@ -301,7 +301,7 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // @Range: 0 45
     // @Increment: 1
     // @User: Advanced
-    AP_GROUPINFO("_ANGLE_MAX", 7, AC_PosControl, _lean_angle_max, 0.0f),
+    AP_GROUPINFO("_ANGLE_MAX", 7, AC_PosControl, _lean_angle_max_deg, 0.0f),
 
     // IDs 8,9 used for _TC_XY and _TC_Z in beta release candidate
 
@@ -312,7 +312,7 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // @Range: 1 20
     // @Increment: 1
     // @User: Advanced
-    AP_GROUPINFO("_JERK_XY", 10, AC_PosControl, _shaping_jerk_xy, POSCONTROL_JERK_XY),
+    AP_GROUPINFO("_JERK_XY", 10, AC_PosControl, _shaping_jerk_ne_msss, POSCONTROL_JERK_NE),
 
     // @Param: _JERK_Z
     // @DisplayName: Jerk limit for the vertical kinematic input shaping
@@ -321,7 +321,7 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // @Range: 5 50
     // @Increment: 1
     // @User: Advanced
-    AP_GROUPINFO("_JERK_Z", 11, AC_PosControl, _shaping_jerk_z, POSCONTROL_JERK_Z),
+    AP_GROUPINFO("_JERK_Z", 11, AC_PosControl, _shaping_jerk_u_msss, POSCONTROL_JERK_U),
 
     AP_GROUPEND
 };
@@ -336,18 +336,18 @@ AC_PosControl::AC_PosControl(AP_AHRS_View& ahrs, const AP_InertialNav& inav,
     _inav(inav),
     _motors(motors),
     _attitude_control(attitude_control),
-    _p_pos_xy(POSCONTROL_POS_XY_P),
-    _p_pos_z(POSCONTROL_POS_Z_P),
-    _pid_vel_xy(POSCONTROL_VEL_XY_P, POSCONTROL_VEL_XY_I, POSCONTROL_VEL_XY_D, 0.0f, POSCONTROL_VEL_XY_IMAX, POSCONTROL_VEL_XY_FILT_HZ, POSCONTROL_VEL_XY_FILT_D_HZ),
-    _pid_vel_z(POSCONTROL_VEL_Z_P, 0.0f, 0.0f, 0.0f, POSCONTROL_VEL_Z_IMAX, POSCONTROL_VEL_Z_FILT_HZ, POSCONTROL_VEL_Z_FILT_D_HZ),
-    _pid_accel_z(POSCONTROL_ACC_Z_P, POSCONTROL_ACC_Z_I, POSCONTROL_ACC_Z_D, 0.0f, POSCONTROL_ACC_Z_IMAX, 0.0f, POSCONTROL_ACC_Z_FILT_HZ, 0.0f),
-    _vel_max_xy_cms(POSCONTROL_SPEED),
+    _p_pos_ne(POSCONTROL_POS_XY_P),
+    _p_pos_u(POSCONTROL_POS_Z_P),
+    _pid_vel_ne(POSCONTROL_VEL_XY_P, POSCONTROL_VEL_XY_I, POSCONTROL_VEL_XY_D, 0.0f, POSCONTROL_VEL_XY_IMAX, POSCONTROL_VEL_XY_FILT_HZ, POSCONTROL_VEL_XY_FILT_D_HZ),
+    _pid_vel_u(POSCONTROL_VEL_Z_P, 0.0f, 0.0f, 0.0f, POSCONTROL_VEL_Z_IMAX, POSCONTROL_VEL_Z_FILT_HZ, POSCONTROL_VEL_Z_FILT_D_HZ),
+    _pid_accel_u(POSCONTROL_ACC_Z_P, POSCONTROL_ACC_Z_I, POSCONTROL_ACC_Z_D, 0.0f, POSCONTROL_ACC_Z_IMAX, 0.0f, POSCONTROL_ACC_Z_FILT_HZ, 0.0f),
+    _vel_max_ne_cms(POSCONTROL_SPEED),
     _vel_max_up_cms(POSCONTROL_SPEED_UP),
     _vel_max_down_cms(POSCONTROL_SPEED_DOWN),
-    _accel_max_xy_cmss(POSCONTROL_ACCEL_XY),
-    _accel_max_z_cmss(POSCONTROL_ACCEL_Z),
-    _jerk_max_xy_cmsss(POSCONTROL_JERK_XY * 100.0),
-    _jerk_max_z_cmsss(POSCONTROL_JERK_Z * 100.0)
+    _accel_max_ne_cmss(POSCONTROL_ACCEL_NE),
+    _accel_max_u_cmss(POSCONTROL_ACCEL_U),
+    _jerk_max_ne_cmsss(POSCONTROL_JERK_NE * 100.0),
+    _jerk_max_u_cmsss(POSCONTROL_JERK_U * 100.0)
 {
     AP_Param::setup_object_defaults(this, var_info);
 
@@ -359,366 +359,365 @@ AC_PosControl::AC_PosControl(AP_AHRS_View& ahrs, const AP_InertialNav& inav,
 /// 3D position shaper
 ///
 
-/// input_pos_xyz - calculate a jerk limited path from the current position, velocity and acceleration to an input position.
-///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
-///     The kinematic path is constrained by the maximum jerk parameter and the velocity and acceleration limits set using the function set_max_speed_accel_xy.
+/// input_pos_NEU_cm - computes a jerk-limited trajectory from the current NEU position, velocity, and acceleration to a new position input (in cm).
+/// This function updates the desired acceleration using a smooth kinematic path constrained by acceleration and jerk limits.
 ///     The jerk limit defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
 ///     The jerk limit also defines the time taken to achieve the maximum acceleration.
 ///     The function alters the input velocity to be the velocity that the system could reach zero acceleration in the minimum time.
-void AC_PosControl::input_pos_xyz(const Vector3p& pos, float pos_terrain_target, float terrain_buffer)
+void AC_PosControl::input_pos_NEU_cm(const Vector3p& pos_neu_cm, float pos_terrain_target_u_cm, float terrain_buffer_cm)
 {
     // Terrain following velocity scalar must be calculated before we remove the position offset
-    const float offset_z_scaler = pos_offset_z_scaler(pos_terrain_target, terrain_buffer);
-    set_pos_terrain_target_cm(pos_terrain_target);
+    const float offset_u_scaler = pos_terrain_U_scaler(pos_terrain_target_u_cm, terrain_buffer_cm);
+    set_pos_terrain_target_U_cm(pos_terrain_target_u_cm);
 
     // calculated increased maximum acceleration and jerk if over speed
     const float overspeed_gain = calculate_overspeed_gain();
-    const float accel_max_z_cmss = _accel_max_z_cmss * overspeed_gain;
-    const float jerk_max_z_cmsss = _jerk_max_z_cmsss * overspeed_gain;
+    const float accel_max_u_cmss = _accel_max_u_cmss * overspeed_gain;
+    const float jerk_max_u_cmsss = _jerk_max_u_cmsss * overspeed_gain;
 
-    update_pos_vel_accel_xy(_pos_desired.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy(), _p_pos_xy.get_error(), _pid_vel_xy.get_error());
+    update_pos_vel_accel_xy(_pos_desired_neu_cm.xy(), _vel_desired_neu_cms.xy(), _accel_desired_neu_cmss.xy(), _dt, _limit_vector.xy(), _p_pos_ne.get_error(), _pid_vel_ne.get_error());
 
     // adjust desired altitude if motors have not hit their limits
-    update_pos_vel_accel(_pos_desired.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z, _p_pos_z.get_error(), _pid_vel_z.get_error());
+    update_pos_vel_accel(_pos_desired_neu_cm.z, _vel_desired_neu_cms.z, _accel_desired_neu_cmss.z, _dt, _limit_vector.z, _p_pos_u.get_error(), _pid_vel_u.get_error());
 
-    // calculate the horizontal and vertical velocity limits to travel directly to the destination defined by pos
-    float vel_max_xy_cms = 0.0f;
-    float vel_max_z_cms = 0.0f;
-    Vector3f dest_vector = (pos - _pos_desired).tofloat();
-    if (is_positive(dest_vector.length_squared()) ) {
-        dest_vector.normalize();
-        float dest_vector_xy_length = dest_vector.xy().length();
+    // calculate the horizontal and vertical velocity limits to travel directly to the destination defined by pos_ne_cm
+    float vel_max_ne_cms = 0.0f;
+    float vel_max_u_cms = 0.0f;
+    Vector3f travel_dir_unit = (pos_neu_cm - _pos_desired_neu_cm).tofloat();
+    if (is_positive(travel_dir_unit.length_squared()) ) {
+        travel_dir_unit.normalize();
+        float travel_dir_unit_ne_length = travel_dir_unit.xy().length();
 
-        float vel_max_cms = kinematic_limit(dest_vector, _vel_max_xy_cms, _vel_max_up_cms, _vel_max_down_cms);
-        vel_max_xy_cms = vel_max_cms * dest_vector_xy_length;
-        vel_max_z_cms = fabsf(vel_max_cms * dest_vector.z);
+        float vel_max_cms = kinematic_limit(travel_dir_unit, _vel_max_ne_cms, _vel_max_up_cms, _vel_max_down_cms);
+        vel_max_ne_cms = vel_max_cms * travel_dir_unit_ne_length;
+        vel_max_u_cms = fabsf(vel_max_cms * travel_dir_unit.z);
     }
 
     // reduce speed if we are reaching the edge of our vertical buffer
-    vel_max_xy_cms *= offset_z_scaler;
+    vel_max_ne_cms *= offset_u_scaler;
 
-    Vector2f vel;
-    Vector2f accel;
-    shape_pos_vel_accel_xy(pos.xy(), vel, accel, _pos_desired.xy(), _vel_desired.xy(), _accel_desired.xy(),
-                           vel_max_xy_cms, _accel_max_xy_cmss, _jerk_max_xy_cmsss, _dt, false);
+    Vector2f vel_ne_cms;
+    Vector2f accel_ne_cmss;
+    shape_pos_vel_accel_xy(pos_neu_cm.xy(), vel_ne_cms, accel_ne_cmss, _pos_desired_neu_cm.xy(), _vel_desired_neu_cms.xy(), _accel_desired_neu_cmss.xy(),
+                           vel_max_ne_cms, _accel_max_ne_cmss, _jerk_max_ne_cmsss, _dt, false);
 
-    float posz = pos.z;
-    shape_pos_vel_accel(posz, 0, 0,
-                        _pos_desired.z, _vel_desired.z, _accel_desired.z,
-                        -vel_max_z_cms, vel_max_z_cms,
-                        -constrain_float(accel_max_z_cmss, 0.0f, 750.0f), accel_max_z_cmss,
-                        jerk_max_z_cmsss, _dt, false);
+    float pos_u_cm = pos_neu_cm.z;
+    shape_pos_vel_accel(pos_u_cm, 0, 0,
+                        _pos_desired_neu_cm.z, _vel_desired_neu_cms.z, _accel_desired_neu_cmss.z,
+                        -vel_max_u_cms, vel_max_u_cms,
+                        -constrain_float(accel_max_u_cmss, 0.0f, 750.0f), accel_max_u_cmss,
+                        jerk_max_u_cmsss, _dt, false);
 }
 
 
-/// pos_offset_z_scaler - calculates a multiplier used to reduce the horizontal velocity to allow the z position controller to stay within the provided buffer range
-float AC_PosControl::pos_offset_z_scaler(float pos_offset_z, float pos_offset_z_buffer) const
+/// pos_terrain_U_scaler - computes a scaling factor applied to horizontal velocity limits to ensure the vertical position controller remains within its terrain buffer.
+float AC_PosControl::pos_terrain_U_scaler(float pos_terrain_u_cm, float pos_terrain_u_buffer_cm) const
 {
-    if (is_zero(pos_offset_z_buffer)) {
+    if (is_zero(pos_terrain_u_buffer_cm)) {
         return 1.0;
     }
-    float pos_offset_error_z = _inav.get_position_z_up_cm() - (_pos_target.z + (pos_offset_z - _pos_terrain));
-    return constrain_float((1.0 - (fabsf(pos_offset_error_z) - 0.5 * pos_offset_z_buffer) / (0.5 * pos_offset_z_buffer)), 0.01, 1.0);
+    float pos_offset_error_u_cm = _inav.get_position_z_up_cm() - (_pos_target_neu_cm.z + (pos_terrain_u_cm - _pos_terrain_u_cm));
+    return constrain_float((1.0 - (fabsf(pos_offset_error_u_cm) - 0.5 * pos_terrain_u_buffer_cm) / (0.5 * pos_terrain_u_buffer_cm)), 0.01, 1.0);
 }
 
 ///
 /// Lateral position controller
 ///
 
-/// set_max_speed_accel_xy - set the maximum horizontal speed in cm/s and acceleration in cm/s/s
+/// set_max_speed_accel_NE_cm - set the maximum horizontal speed in cm/s and acceleration in cm/s/s
 ///     This function only needs to be called if using the kinematic shaping.
 ///     This can be done at any time as changes in these parameters are handled smoothly
 ///     by the kinematic shaping.
-void AC_PosControl::set_max_speed_accel_xy(float speed_cms, float accel_cmss)
+void AC_PosControl::set_max_speed_accel_NE_cm(float speed_ne_cms, float accel_ne_cmss)
 {
-    _vel_max_xy_cms = speed_cms;
-    _accel_max_xy_cmss = accel_cmss;
+    _vel_max_ne_cms = speed_ne_cms;
+    _accel_max_ne_cmss = accel_ne_cmss;
 
     // ensure the horizontal jerk is less than the vehicle is capable of
     const float jerk_max_cmsss = MIN(_attitude_control.get_ang_vel_roll_max_rads(), _attitude_control.get_ang_vel_pitch_max_rads()) * GRAVITY_MSS * 100.0;
     const float snap_max_cmssss = MIN(_attitude_control.get_accel_roll_max_radss(), _attitude_control.get_accel_pitch_max_radss()) * GRAVITY_MSS * 100.0;
 
     // get specified jerk limit
-    _jerk_max_xy_cmsss = _shaping_jerk_xy * 100.0;
+    _jerk_max_ne_cmsss = _shaping_jerk_ne_msss * 100.0;
 
     // limit maximum jerk based on maximum angular rate
     if (is_positive(jerk_max_cmsss) && _attitude_control.get_bf_feedforward()) {
-        _jerk_max_xy_cmsss = MIN(_jerk_max_xy_cmsss, jerk_max_cmsss);
+        _jerk_max_ne_cmsss = MIN(_jerk_max_ne_cmsss, jerk_max_cmsss);
     }
 
     // limit maximum jerk to maximum possible average jerk based on angular acceleration
     if (is_positive(snap_max_cmssss) && _attitude_control.get_bf_feedforward()) {
-        _jerk_max_xy_cmsss = MIN(0.5 * safe_sqrt(_accel_max_xy_cmss * snap_max_cmssss), _jerk_max_xy_cmsss);
+        _jerk_max_ne_cmsss = MIN(0.5 * safe_sqrt(_accel_max_ne_cmss * snap_max_cmssss), _jerk_max_ne_cmsss);
     }
 }
 
-/// set_max_speed_accel_xy - set the position controller correction velocity and acceleration limit
+/// set_correction_speed_accel_xy_cm - set the position controller correction velocity and acceleration limit
 ///     This should be done only during initialisation to avoid discontinuities
-void AC_PosControl::set_correction_speed_accel_xy(float speed_cms, float accel_cmss)
+void AC_PosControl::set_correction_speed_accel_NE_cm(float speed_ne_cms, float accel_ne_cmss)
 {
-    _p_pos_xy.set_limits(speed_cms, accel_cmss, 0.0f);
+    _p_pos_ne.set_limits(speed_ne_cms, accel_ne_cmss, 0.0f);
 }
 
-/// init_xy_controller_stopping_point - initialise the position controller to the stopping point with zero velocity and acceleration.
+/// init_NE_controller_stopping_point - initialise the position controller to the stopping point with zero velocity and acceleration.
 ///     This function should be used when the expected kinematic path assumes a stationary initial condition but does not specify a specific starting position.
-///     The starting position can be retrieved by getting the position target using get_pos_desired_cm() after calling this function.
-void AC_PosControl::init_xy_controller_stopping_point()
+///     The starting position can be retrieved by getting the position target using get_pos_desired_NEU_cm() after calling this function.
+void AC_PosControl::init_NE_controller_stopping_point()
 {
-    init_xy_controller();
+    init_NE_controller();
 
-    get_stopping_point_xy_cm(_pos_desired.xy());
-    _pos_target.xy() = _pos_desired.xy() + _pos_offset.xy();
-    _vel_desired.xy().zero();
-    _accel_desired.xy().zero();
+    get_stopping_point_NE_cm(_pos_desired_neu_cm.xy());
+    _pos_target_neu_cm.xy() = _pos_desired_neu_cm.xy() + _pos_offset_neu_cm.xy();
+    _vel_desired_neu_cms.xy().zero();
+    _accel_desired_neu_cmss.xy().zero();
 }
 
-// relax_velocity_controller_xy - initialise the position controller to the current position and velocity with decaying acceleration.
+// relax_velocity_controller_NE - initialise the position controller to the current position and velocity with decaying acceleration.
 ///     This function decays the output acceleration by 95% every half second to achieve a smooth transition to zero requested acceleration.
-void AC_PosControl::relax_velocity_controller_xy()
+void AC_PosControl::relax_velocity_controller_NE()
 {
     // decay acceleration and therefore current attitude target to zero
-    // this will be reset by init_xy_controller() if !is_active_xy()
+    // this will be reset by init_NE_controller() if !is_active_NE()
     if (is_positive(_dt)) {
         float decay = 1.0 - _dt / (_dt + POSCONTROL_RELAX_TC);
-        _accel_target.xy() *= decay;
+        _accel_target_neu_cmss.xy() *= decay;
     }
 
-    init_xy_controller();
+    init_NE_controller();
 }
 
-/// reduce response for landing
-void AC_PosControl::soften_for_landing_xy()
+/// Reduces controller response for landing by decaying position error and preventing I-term windup.
+void AC_PosControl::soften_for_landing_NE()
 {
     // decay position error to zero
     if (is_positive(_dt)) {
-        _pos_target.xy() += (_inav.get_position_xy_cm().topostype() - _pos_target.xy()) * (_dt / (_dt + POSCONTROL_RELAX_TC));
-        _pos_desired.xy() = _pos_target.xy() - _pos_offset.xy();
+        _pos_target_neu_cm.xy() += (_inav.get_position_xy_cm().topostype() - _pos_target_neu_cm.xy()) * (_dt / (_dt + POSCONTROL_RELAX_TC));
+        _pos_desired_neu_cm.xy() = _pos_target_neu_cm.xy() - _pos_offset_neu_cm.xy();
     }
 
     // Prevent I term build up in xy velocity controller.
-    // Note that this flag is reset on each loop in update_xy_controller()
-    set_externally_limited_xy();
+    // Note that this flag is reset on each loop in update_NE_controller()
+    set_externally_limited_NE();
 }
 
-/// init_xy_controller - initialise the position controller to the current position, velocity, acceleration and attitude.
+/// init_NE_controller - initialise the position controller to the current position, velocity, acceleration and attitude.
 ///     This function is the default initialisation for any position control that provides position, velocity and acceleration.
-void AC_PosControl::init_xy_controller()
+void AC_PosControl::init_NE_controller()
 {
     // initialise offsets to target offsets and ensure offset targets are zero if they have not been updated.
-    init_offsets_xy();
+    init_offsets_NE();
     
     // set roll, pitch lean angle targets to current attitude
     const Vector3f &att_target_euler_cd = _attitude_control.get_att_target_euler_cd();
-    _roll_target = att_target_euler_cd.x;
-    _pitch_target = att_target_euler_cd.y;
-    _yaw_target = att_target_euler_cd.z; // todo: this should be thrust vector heading, not yaw.
-    _yaw_rate_target = 0.0f;
+    _roll_target_cd = att_target_euler_cd.x;
+    _pitch_target_cd = att_target_euler_cd.y;
+    _yaw_target_cd = att_target_euler_cd.z; // todo: this should be thrust vector heading, not yaw.
+    _yaw_rate_target_cds = 0.0f;
     _angle_max_override_cd = 0.0;
 
-    _pos_target.xy() = _inav.get_position_xy_cm().topostype();
-    _pos_desired.xy() = _pos_target.xy() - _pos_offset.xy();
+    _pos_target_neu_cm.xy() = _inav.get_position_xy_cm().topostype();
+    _pos_desired_neu_cm.xy() = _pos_target_neu_cm.xy() - _pos_offset_neu_cm.xy();
 
-    _vel_target.xy() = _inav.get_velocity_xy_cms();
-    _vel_desired.xy() = _vel_target.xy() - _vel_offset.xy();
+    _vel_target_neu_cms.xy() = _inav.get_velocity_xy_cms();
+    _vel_desired_neu_cms.xy() = _vel_target_neu_cms.xy() - _vel_offset_neu_cms.xy();
 
-    // Set desired accel to zero because raw acceleration is prone to noise
-    _accel_desired.xy().zero();
+    // Set desired acceleration to zero because raw acceleration is prone to noise
+    _accel_desired_neu_cmss.xy().zero();
 
-    if (!is_active_xy()) {
-        lean_angles_to_accel_xy(_accel_target.x, _accel_target.y);
+    if (!is_active_NE()) {
+        lean_angles_to_accel_NE_cmss(_accel_target_neu_cmss.x, _accel_target_neu_cmss.y);
     }
 
     // limit acceleration using maximum lean angles
     float angle_max = MIN(_attitude_control.get_althold_lean_angle_max_cd(), get_lean_angle_max_cd());
     float accel_max = angle_to_accel(angle_max * 0.01) * 100.0;
-    _accel_target.xy().limit_length(accel_max);
+    _accel_target_neu_cmss.xy().limit_length(accel_max);
 
     // initialise I terms from lean angles
-    _pid_vel_xy.reset_filter();
-    // initialise the I term to _accel_target - _accel_desired
-    // _accel_desired is zero and can be removed from the equation
-    _pid_vel_xy.set_integrator(_accel_target.xy() - _vel_target.xy() * _pid_vel_xy.ff());
+    _pid_vel_ne.reset_filter();
+    // initialise the I term to (_accel_target_neu_cmss - _accel_desired_neu_cmss)
+    // _accel_desired_neu_cmss is zero and can be removed from the equation
+    _pid_vel_ne.set_integrator(_accel_target_neu_cmss.xy() - _vel_target_neu_cms.xy() * _pid_vel_ne.ff());
 
     // initialise ekf xy reset handler
-    init_ekf_xy_reset();
+    init_ekf_NE_reset();
 
     // initialise z_controller time out
-    _last_update_xy_ticks = AP::scheduler().ticks32();
+    _last_update_ne_ticks = AP::scheduler().ticks32();
 }
 
-/// input_accel_xy - calculate a jerk limited path from the current position, velocity and acceleration to an input acceleration.
+/// input_accel_NE_cm - calculate a jerk limited path from the current position, velocity and acceleration to an input acceleration.
 ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
-///     The kinematic path is constrained by the maximum acceleration and jerk set using the function set_max_speed_accel_xy.
+///     The kinematic path is constrained by the maximum acceleration and jerk set using the function set_max_speed_accel_ne.
 ///     The jerk limit defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
 ///     The jerk limit also defines the time taken to achieve the maximum acceleration.
-void AC_PosControl::input_accel_xy(const Vector3f& accel)
+void AC_PosControl::input_accel_NE_cm(const Vector3f& accel_neu_cmss)
 {
-    update_pos_vel_accel_xy(_pos_desired.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy(), _p_pos_xy.get_error(), _pid_vel_xy.get_error());
-    shape_accel_xy(accel.xy(), _accel_desired.xy(), _jerk_max_xy_cmsss, _dt);
+    update_pos_vel_accel_xy(_pos_desired_neu_cm.xy(), _vel_desired_neu_cms.xy(), _accel_desired_neu_cmss.xy(), _dt, _limit_vector.xy(), _p_pos_ne.get_error(), _pid_vel_ne.get_error());
+    shape_accel_xy(accel_neu_cmss.xy(), _accel_desired_neu_cmss.xy(), _jerk_max_ne_cmsss, _dt);
 }
 
-/// input_vel_accel_xy - calculate a jerk limited path from the current position, velocity and acceleration to an input velocity and acceleration.
-///     The vel is projected forwards in time based on a time step of dt and acceleration accel.
+/// input_vel_accel_NE_cm - calculate a jerk limited path from the current position, velocity and acceleration to an input velocity and acceleration.
 ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
-///     The kinematic path is constrained by the maximum acceleration and jerk set using the function set_max_speed_accel_xy.
+///     The kinematic path is constrained by the maximum acceleration and jerk set using the function set_max_speed_accel_ne.
+///     The function modifies vel_ne_cms to follow the kinematic trajectory toward accel_cmss.
 ///     The parameter limit_output specifies if the velocity and acceleration limits are applied to the sum of commanded and correction values or just correction.
-void AC_PosControl::input_vel_accel_xy(Vector2f& vel, const Vector2f& accel, bool limit_output)
+void AC_PosControl::input_vel_accel_NE_cm(Vector2f& vel_ne_cms, const Vector2f& accel_ne_cmss, bool limit_output)
 {
-    update_pos_vel_accel_xy(_pos_desired.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy(), _p_pos_xy.get_error(), _pid_vel_xy.get_error());
+    update_pos_vel_accel_xy(_pos_desired_neu_cm.xy(), _vel_desired_neu_cms.xy(), _accel_desired_neu_cmss.xy(), _dt, _limit_vector.xy(), _p_pos_ne.get_error(), _pid_vel_ne.get_error());
 
-    shape_vel_accel_xy(vel, accel, _vel_desired.xy(), _accel_desired.xy(),
-        _accel_max_xy_cmss, _jerk_max_xy_cmsss, _dt, limit_output);
+    shape_vel_accel_xy(vel_ne_cms, accel_ne_cmss, _vel_desired_neu_cms.xy(), _accel_desired_neu_cmss.xy(),
+        _accel_max_ne_cmss, _jerk_max_ne_cmsss, _dt, limit_output);
 
-    update_vel_accel_xy(vel, accel, _dt, Vector2f(), Vector2f());
+    update_vel_accel_xy(vel_ne_cms, accel_ne_cmss, _dt, Vector2f(), Vector2f());
 }
 
-/// input_pos_vel_accel_xy - calculate a jerk limited path from the current position, velocity and acceleration to an input position velocity and acceleration.
-///     The pos and vel are projected forwards in time based on a time step of dt and acceleration accel.
+/// input_pos_vel_accel_NE_cm - calculate a jerk limited path from the current position, velocity and acceleration to an input position velocity and acceleration.
 ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
-///     The function alters the pos and vel to be the kinematic path based on accel
+///     The kinematic path is constrained by the maximum acceleration and jerk set using the function set_max_speed_accel_ne.
+///     The function modifies pos_ne_cm and vel_ne_cms to follow the jerk-limited trajectory defined by accel_ne_cmss.
 ///     The parameter limit_output specifies if the velocity and acceleration limits are applied to the sum of commanded and correction values or just correction.
-void AC_PosControl::input_pos_vel_accel_xy(Vector2p& pos, Vector2f& vel, const Vector2f& accel, bool limit_output)
+void AC_PosControl::input_pos_vel_accel_NE_cm(Vector2p& pos_ne_cm, Vector2f& vel_ne_cms, const Vector2f& accel_ne_cmss, bool limit_output)
 {
-    update_pos_vel_accel_xy(_pos_desired.xy(), _vel_desired.xy(), _accel_desired.xy(), _dt, _limit_vector.xy(), _p_pos_xy.get_error(), _pid_vel_xy.get_error());
+    update_pos_vel_accel_xy(_pos_desired_neu_cm.xy(), _vel_desired_neu_cms.xy(), _accel_desired_neu_cmss.xy(), _dt, _limit_vector.xy(), _p_pos_ne.get_error(), _pid_vel_ne.get_error());
 
-    shape_pos_vel_accel_xy(pos, vel, accel, _pos_desired.xy(), _vel_desired.xy(), _accel_desired.xy(),
-                           _vel_max_xy_cms, _accel_max_xy_cmss, _jerk_max_xy_cmsss, _dt, limit_output);
+    shape_pos_vel_accel_xy(pos_ne_cm, vel_ne_cms, accel_ne_cmss, _pos_desired_neu_cm.xy(), _vel_desired_neu_cms.xy(), _accel_desired_neu_cmss.xy(),
+                           _vel_max_ne_cms, _accel_max_ne_cmss, _jerk_max_ne_cmsss, _dt, limit_output);
 
-    update_pos_vel_accel_xy(pos, vel, accel, _dt, Vector2f(), Vector2f(), Vector2f());
+    update_pos_vel_accel_xy(pos_ne_cm, vel_ne_cms, accel_ne_cmss, _dt, Vector2f(), Vector2f(), Vector2f());
 }
 
 /// update the horizontal position and velocity offsets
-/// this moves the offsets (e.g _pos_offset, _vel_offset, _accel_offset) towards the targets (e.g. _pos_offset_target, _vel_offset_target, _accel_offset_target)
-void AC_PosControl::update_offsets_xy()
+/// this moves the offsets (e.g _pos_offset_neu_cm, _vel_offset_neu_cms, _accel_offset_neu_cmss) towards the targets (e.g. _pos_offset_target_neu_cm, _vel_offset_target_neu_cms, _accel_offset_target_neu_cmss)
+void AC_PosControl::update_offsets_NE()
 {
     // check for offset target timeout
     uint32_t now_ms = AP_HAL::millis();
-    if (now_ms - _posvelaccel_offset_target_xy_ms > POSCONTROL_POSVELACCEL_OFFSET_TARGET_TIMEOUT_MS) {
-        _pos_offset_target.xy().zero();
-        _vel_offset_target.xy().zero();
-        _accel_offset_target.xy().zero();
+    if (now_ms - _posvelaccel_offset_target_ne_ms > POSCONTROL_POSVELACCEL_OFFSET_TARGET_TIMEOUT_MS) {
+        _pos_offset_target_neu_cm.xy().zero();
+        _vel_offset_target_neu_cms.xy().zero();
+        _accel_offset_target_neu_cmss.xy().zero();
     }
 
-    // update position, velocity, accel offsets for this iteration
-    update_pos_vel_accel_xy(_pos_offset_target.xy(), _vel_offset_target.xy(), _accel_offset_target.xy(), _dt, Vector2f(), Vector2f(), Vector2f());
-    update_pos_vel_accel_xy(_pos_offset.xy(), _vel_offset.xy(), _accel_offset.xy(), _dt, _limit_vector.xy(), _p_pos_xy.get_error(), _pid_vel_xy.get_error());
+    // update position, velocity, acceleration offsets for this iteration
+    update_pos_vel_accel_xy(_pos_offset_target_neu_cm.xy(), _vel_offset_target_neu_cms.xy(), _accel_offset_target_neu_cmss.xy(), _dt, Vector2f(), Vector2f(), Vector2f());
+    update_pos_vel_accel_xy(_pos_offset_neu_cm.xy(), _vel_offset_neu_cms.xy(), _accel_offset_neu_cmss.xy(), _dt, _limit_vector.xy(), _p_pos_ne.get_error(), _pid_vel_ne.get_error());
 
     // input shape horizontal position, velocity and acceleration offsets
-    shape_pos_vel_accel_xy(_pos_offset_target.xy(), _vel_offset_target.xy(), _accel_offset_target.xy(),
-                            _pos_offset.xy(), _vel_offset.xy(), _accel_offset.xy(),
-                            _vel_max_xy_cms, _accel_max_xy_cmss, _jerk_max_xy_cmsss, _dt, false);
+    shape_pos_vel_accel_xy(_pos_offset_target_neu_cm.xy(), _vel_offset_target_neu_cms.xy(), _accel_offset_target_neu_cmss.xy(),
+                            _pos_offset_neu_cm.xy(), _vel_offset_neu_cms.xy(), _accel_offset_neu_cmss.xy(),
+                            _vel_max_ne_cms, _accel_max_ne_cmss, _jerk_max_ne_cmsss, _dt, false);
 }
 
-/// stop_pos_xy_stabilisation - sets the target to the current position to remove any position corrections from the system
-void AC_PosControl::stop_pos_xy_stabilisation()
+/// stop_pos_NE_stabilisation - sets the target to the current position to remove any position corrections from the system
+void AC_PosControl::stop_pos_NE_stabilisation()
 {
-    _pos_target.xy() = _inav.get_position_xy_cm().topostype();
-    _pos_desired.xy() = _pos_target.xy() - _pos_offset.xy();
+    _pos_target_neu_cm.xy() = _inav.get_position_xy_cm().topostype();
+    _pos_desired_neu_cm.xy() = _pos_target_neu_cm.xy() - _pos_offset_neu_cm.xy();
 }
 
-/// stop_vel_xy_stabilisation - sets the target to the current position and velocity to the current velocity to remove any position and velocity corrections from the system
-void AC_PosControl::stop_vel_xy_stabilisation()
+/// stop_vel_NE_stabilisation - sets the target to the current position and velocity to the current velocity to remove any position and velocity corrections from the system
+void AC_PosControl::stop_vel_NE_stabilisation()
 {
-    _pos_target.xy() =  _inav.get_position_xy_cm().topostype();
-    _pos_desired.xy() = _pos_target.xy() - _pos_offset.xy();
+    _pos_target_neu_cm.xy() =  _inav.get_position_xy_cm().topostype();
+    _pos_desired_neu_cm.xy() = _pos_target_neu_cm.xy() - _pos_offset_neu_cm.xy();
     
-    _vel_target.xy() = _inav.get_velocity_xy_cms();;
-    _vel_desired.xy() = _vel_target.xy() - _vel_offset.xy();
+    _vel_target_neu_cms.xy() = _inav.get_velocity_xy_cms();;
+    _vel_desired_neu_cms.xy() = _vel_target_neu_cms.xy() - _vel_offset_neu_cms.xy();
 
     // initialise I terms from lean angles
-    _pid_vel_xy.reset_filter();
-    _pid_vel_xy.reset_I();
+    _pid_vel_ne.reset_filter();
+    _pid_vel_ne.reset_I();
 }
 
-// is_active_xy - returns true if the xy position controller has been run in the previous loop
-bool AC_PosControl::is_active_xy() const
+// is_active_NE - returns true if the xy position controller has been run in the previous loop
+bool AC_PosControl::is_active_NE() const
 {
-    const uint32_t dt_ticks = AP::scheduler().ticks32() - _last_update_xy_ticks;
+    const uint32_t dt_ticks = AP::scheduler().ticks32() - _last_update_ne_ticks;
     return dt_ticks <= 1;
 }
 
-/// update_xy_controller - runs the horizontal position controller correcting position, velocity and acceleration errors.
+/// update_NE_controller - runs the horizontal position controller correcting position, velocity and acceleration errors.
 ///     Position and velocity errors are converted to velocity and acceleration targets using PID objects
 ///     Desired velocity and accelerations are added to these corrections as they are calculated
 ///     Kinematically consistent target position and desired velocity and accelerations should be provided before calling this function
-void AC_PosControl::update_xy_controller()
+void AC_PosControl::update_NE_controller()
 {
     // check for ekf xy position reset
-    handle_ekf_xy_reset();
+    handle_ekf_NE_reset();
 
     // Check for position control time out
-    if (!is_active_xy()) {
-        init_xy_controller();
+    if (!is_active_NE()) {
+        init_NE_controller();
         if (has_good_timing()) {
             // call internal error because initialisation has not been done
             INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
         }
     }
-    _last_update_xy_ticks = AP::scheduler().ticks32();
+    _last_update_ne_ticks = AP::scheduler().ticks32();
 
     float ahrsGndSpdLimit, ahrsControlScaleXY;
     AP::ahrs().getControlLimits(ahrsGndSpdLimit, ahrsControlScaleXY);
 
     // update the position, velocity and acceleration offsets
-    update_offsets_xy();
+    update_offsets_NE();
 
     // Position Controller
 
-    _pos_target.xy() = _pos_desired.xy() + _pos_offset.xy();
+    _pos_target_neu_cm.xy() = _pos_desired_neu_cm.xy() + _pos_offset_neu_cm.xy();
 
     // determine the combined position of the actual position and the disturbance from system ID mode
     const Vector3f &curr_pos = _inav.get_position_neu_cm();
     Vector3f comb_pos = curr_pos;
-    comb_pos.xy() += _disturb_pos;
+    comb_pos.xy() += _disturb_pos_ne_cm;
 
-    Vector2f vel_target = _p_pos_xy.update_all(_pos_target.x, _pos_target.y, comb_pos);
-    _pos_desired.xy() = _pos_target.xy() - _pos_offset.xy();
+    Vector2f vel_target = _p_pos_ne.update_all(_pos_target_neu_cm.x, _pos_target_neu_cm.y, comb_pos);
+    _pos_desired_neu_cm.xy() = _pos_target_neu_cm.xy() - _pos_offset_neu_cm.xy();
 
     // Velocity Controller
 
     // add velocity feed-forward scaled to compensate for optical flow measurement induced EKF noise
     vel_target *= ahrsControlScaleXY;
-    vel_target *= _xy_control_scale_factor;
+    vel_target *= _ne_control_scale_factor;
 
-    _vel_target.xy() = vel_target;
-    _vel_target.xy() += _vel_desired.xy() + _vel_offset.xy();
+    _vel_target_neu_cms.xy() = vel_target;
+    _vel_target_neu_cms.xy() += _vel_desired_neu_cms.xy() + _vel_offset_neu_cms.xy();
 
     // determine the combined velocity of the actual velocity and the disturbance from system ID mode
     const Vector2f &curr_vel = _inav.get_velocity_xy_cms();
     Vector2f comb_vel = curr_vel;
-    comb_vel += _disturb_vel;
+    comb_vel += _disturb_vel_ne_cms;
 
-    Vector2f accel_target = _pid_vel_xy.update_all(_vel_target.xy(), comb_vel, _dt, _limit_vector.xy());
+    Vector2f accel_target_ne_cmss = _pid_vel_ne.update_all(_vel_target_neu_cms.xy(), comb_vel, _dt, _limit_vector.xy());
 
     // Acceleration Controller
     
     // acceleration to correct for velocity error and scale PID output to compensate for optical flow measurement induced EKF noise
-    accel_target *= ahrsControlScaleXY;
-    accel_target *= _xy_control_scale_factor;
+    accel_target_ne_cmss *= ahrsControlScaleXY;
+    accel_target_ne_cmss *= _ne_control_scale_factor;
 
-    _xy_control_scale_factor = 1.0;
+    _ne_control_scale_factor = 1.0;
 
     // pass the correction acceleration to the target acceleration output
-    _accel_target.xy() = accel_target;
-    _accel_target.xy() += _accel_desired.xy() + _accel_offset.xy();
+    _accel_target_neu_cmss.xy() = accel_target_ne_cmss;
+    _accel_target_neu_cmss.xy() += _accel_desired_neu_cmss.xy() + _accel_offset_neu_cmss.xy();
 
     // limit acceleration using maximum lean angles
     float angle_max = MIN(_attitude_control.get_althold_lean_angle_max_cd(), get_lean_angle_max_cd());
     float accel_max = angle_to_accel(angle_max * 0.01) * 100;
-    // Define the limit vector before we constrain _accel_target 
-    _limit_vector.xy() = _accel_target.xy();
-    if (!limit_accel_xy(_vel_desired.xy(), _accel_target.xy(), accel_max)) {
-        // _accel_target was not limited so we can zero the xy limit vector
+    // Define the limit vector before we constrain _accel_target_neu_cmss 
+    _limit_vector.xy() = _accel_target_neu_cmss.xy();
+    if (!limit_accel_xy(_vel_desired_neu_cms.xy(), _accel_target_neu_cmss.xy(), accel_max)) {
+        // _accel_target_neu_cmss was not limited so we can zero the xy limit vector
         _limit_vector.xy().zero();
     }
 
     // update angle targets that will be passed to stabilize controller
-    accel_to_lean_angles(_accel_target.x, _accel_target.y, _roll_target, _pitch_target);
+    accel_NE_cmss_to_lean_angles(_accel_target_neu_cmss.x, _accel_target_neu_cmss.y, _roll_target_cd, _pitch_target_cd);
     calculate_yaw_and_rate_yaw();
 
     // reset the disturbance from system ID mode to zero
-    _disturb_pos.zero();
-    _disturb_vel.zero();
+    _disturb_pos_ne_cm.zero();
+    _disturb_vel_ne_cms.zero();
 }
 
 
@@ -726,315 +725,317 @@ void AC_PosControl::update_xy_controller()
 /// Vertical position controller
 ///
 
-/// set_max_speed_accel_z - set the maximum vertical speed in cm/s and acceleration in cm/s/s
-///     speed_down can be positive or negative but will always be interpreted as a descent speed.
+/// set_max_speed_accel_U_cm - set the maximum vertical speed in cm/s and acceleration in cm/s/s
+///     speed_down_cms can be positive or negative but will always be interpreted as a descent speed.
 ///     This function only needs to be called if using the kinematic shaping.
 ///     This can be done at any time as changes in these parameters are handled smoothly
 ///     by the kinematic shaping.
-void AC_PosControl::set_max_speed_accel_z(float speed_down, float speed_up, float accel_cmss)
+void AC_PosControl::set_max_speed_accel_U_cm(float speed_down_cms, float speed_up_cms, float accel_cmss)
 {
-    // ensure speed_down is always negative
-    speed_down = -fabsf(speed_down);
+    // ensure speed_down_cms is always negative
+    speed_down_cms = -fabsf(speed_down_cms);
 
     // sanity check and update
-    if (is_negative(speed_down)) {
-        _vel_max_down_cms = speed_down;
+    if (is_negative(speed_down_cms)) {
+        _vel_max_down_cms = speed_down_cms;
     }
-    if (is_positive(speed_up)) {
-        _vel_max_up_cms = speed_up;
+    if (is_positive(speed_up_cms)) {
+        _vel_max_up_cms = speed_up_cms;
     }
     if (is_positive(accel_cmss)) {
-        _accel_max_z_cmss = accel_cmss;
+        _accel_max_u_cmss = accel_cmss;
     }
 
-    // ensure the vertical Jerk is not limited by the filters in the Z accel PID object
-    _jerk_max_z_cmsss = _shaping_jerk_z * 100.0;
-    if (is_positive(_pid_accel_z.filt_T_hz())) {
-        _jerk_max_z_cmsss = MIN(_jerk_max_z_cmsss, MIN(GRAVITY_MSS * 100.0, _accel_max_z_cmss) * (M_2PI * _pid_accel_z.filt_T_hz()) / 5.0);
+    // ensure the vertical Jerk is not limited by the filters in the Z acceleration PID object
+    _jerk_max_u_cmsss = _shaping_jerk_u_msss * 100.0;
+    if (is_positive(_pid_accel_u.filt_T_hz())) {
+        _jerk_max_u_cmsss = MIN(_jerk_max_u_cmsss, MIN(GRAVITY_MSS * 100.0, _accel_max_u_cmss) * (M_2PI * _pid_accel_u.filt_T_hz()) / 5.0);
     }
-    if (is_positive(_pid_accel_z.filt_E_hz())) {
-        _jerk_max_z_cmsss = MIN(_jerk_max_z_cmsss, MIN(GRAVITY_MSS * 100.0, _accel_max_z_cmss) * (M_2PI * _pid_accel_z.filt_E_hz()) / 5.0);
+    if (is_positive(_pid_accel_u.filt_E_hz())) {
+        _jerk_max_u_cmsss = MIN(_jerk_max_u_cmsss, MIN(GRAVITY_MSS * 100.0, _accel_max_u_cmss) * (M_2PI * _pid_accel_u.filt_E_hz()) / 5.0);
     }
 }
 
-/// set_correction_speed_accel_z - set the position controller correction velocity and acceleration limit
-///     speed_down can be positive or negative but will always be interpreted as a descent speed.
+/// set_correction_speed_accel_U_cmss - set the position controller correction velocity and acceleration limit
+///     speed_down_cms can be positive or negative but will always be interpreted as a descent speed.
 ///     This should be done only during initialisation to avoid discontinuities
-void AC_PosControl::set_correction_speed_accel_z(float speed_down, float speed_up, float accel_cmss)
+void AC_PosControl::set_correction_speed_accel_U_cmss(float speed_down_cms, float speed_up_cms, float accel_cmss)
 {
     // define maximum position error and maximum first and second differential limits
-    _p_pos_z.set_limits(-fabsf(speed_down), speed_up, accel_cmss, 0.0f);
+    _p_pos_u.set_limits(-fabsf(speed_down_cms), speed_up_cms, accel_cmss, 0.0f);
 }
 
-/// init_z_controller - initialise the position controller to the current position, velocity, acceleration and attitude.
+/// init_U_controller - initialise the position controller to the current position, velocity, acceleration and attitude.
 ///     This function is the default initialisation for any position control that provides position, velocity and acceleration.
 ///     This function does not allow any negative velocity or acceleration
-void AC_PosControl::init_z_controller_no_descent()
+void AC_PosControl::init_U_controller_no_descent()
 {
     // Initialise the position controller to the current throttle, position, velocity and acceleration.
-    init_z_controller();
+    init_U_controller();
 
     // remove all descent if present
-    _vel_target.z = MAX(0.0, _vel_target.z);
-    _vel_desired.z = MAX(0.0, _vel_desired.z);
-    _vel_terrain = MAX(0.0, _vel_terrain);
-    _vel_offset.z = MAX(0.0, _vel_offset.z);
-    _accel_target.z = MAX(0.0, _accel_target.z);
-    _accel_desired.z = MAX(0.0, _accel_desired.z);
-    _accel_terrain = MAX(0.0, _accel_terrain);
-    _accel_offset.z = MAX(0.0, _accel_offset.z);
+    _vel_target_neu_cms.z = MAX(0.0, _vel_target_neu_cms.z);
+    _vel_desired_neu_cms.z = MAX(0.0, _vel_desired_neu_cms.z);
+    _vel_terrain_u_cms = MAX(0.0, _vel_terrain_u_cms);
+    _vel_offset_neu_cms.z = MAX(0.0, _vel_offset_neu_cms.z);
+    _accel_target_neu_cmss.z = MAX(0.0, _accel_target_neu_cmss.z);
+    _accel_desired_neu_cmss.z = MAX(0.0, _accel_desired_neu_cmss.z);
+    _accel_terrain_u_cmss = MAX(0.0, _accel_terrain_u_cmss);
+    _accel_offset_neu_cmss.z = MAX(0.0, _accel_offset_neu_cmss.z);
 }
 
-/// init_z_controller_stopping_point - initialise the position controller to the stopping point with zero velocity and acceleration.
+/// init_U_controller_stopping_point - initialise the position controller to the stopping point with zero velocity and acceleration.
 ///     This function should be used when the expected kinematic path assumes a stationary initial condition but does not specify a specific starting position.
-///     The starting position can be retrieved by getting the position target using get_pos_target_cm() after calling this function.
-void AC_PosControl::init_z_controller_stopping_point()
+///     The starting position can be retrieved by getting the position target using get_pos_target_NEU_cm() after calling this function.
+void AC_PosControl::init_U_controller_stopping_point()
 {
     // Initialise the position controller to the current throttle, position, velocity and acceleration.
-    init_z_controller();
+    init_U_controller();
 
-    get_stopping_point_z_cm(_pos_desired.z);
-    _pos_target.z = _pos_desired.z + _pos_offset.z;
-    _vel_desired.z = 0.0f;
-    _accel_desired.z = 0.0f;
+    get_stopping_point_U_cm(_pos_desired_neu_cm.z);
+    _pos_target_neu_cm.z = _pos_desired_neu_cm.z + _pos_offset_neu_cm.z;
+    _vel_desired_neu_cms.z = 0.0f;
+    _accel_desired_neu_cmss.z = 0.0f;
 }
 
-// relax_z_controller - initialise the position controller to the current position and velocity with decaying acceleration.
+// relax_U_controller - initialise the position controller to the current position and velocity with decaying acceleration.
 ///     This function decays the output acceleration by 95% every half second to achieve a smooth transition to zero requested acceleration.
-void AC_PosControl::relax_z_controller(float throttle_setting)
+void AC_PosControl::relax_U_controller(float throttle_setting)
 {
     // Initialise the position controller to the current position, velocity and acceleration.
-    init_z_controller();
+    init_U_controller();
 
-    // init_z_controller has set the accel PID I term to generate the current throttle set point
+    // init_U_controller has set the acceleration PID I term to generate the current throttle set point
     // Use relax_integrator to decay the throttle set point to throttle_setting
-    _pid_accel_z.relax_integrator((throttle_setting - _motors.get_throttle_hover()) * 1000.0f, _dt, POSCONTROL_RELAX_TC);
+    _pid_accel_u.relax_integrator((throttle_setting - _motors.get_throttle_hover()) * 1000.0f, _dt, POSCONTROL_RELAX_TC);
 }
 
-/// init_z_controller - initialise the position controller to the current position, velocity, acceleration and attitude.
+/// init_U_controller - initialise the position controller to the current position, velocity, acceleration and attitude.
 ///     This function is the default initialisation for any position control that provides position, velocity and acceleration.
 ///     This function is private and contains all the shared z axis initialisation functions
-void AC_PosControl::init_z_controller()
+void AC_PosControl::init_U_controller()
 {
     // initialise terrain targets and offsets to zero
     init_terrain();
 
     // initialise offsets to target offsets and ensure offset targets are zero if they have not been updated.
-    init_offsets_z();
+    init_offsets_U();
 
-    _pos_target.z = _inav.get_position_z_up_cm();
-    _pos_desired.z = _pos_target.z - _pos_offset.z;
+    _pos_target_neu_cm.z = _inav.get_position_z_up_cm();
+    _pos_desired_neu_cm.z = _pos_target_neu_cm.z - _pos_offset_neu_cm.z;
 
-    _vel_target.z = _inav.get_velocity_z_up_cms();
-    _vel_desired.z = _vel_target.z - _vel_offset.z;
+    _vel_target_neu_cms.z = _inav.get_velocity_z_up_cms();
+    _vel_desired_neu_cms.z = _vel_target_neu_cms.z - _vel_offset_neu_cms.z;
 
     // Reset I term of velocity PID
-    _pid_vel_z.reset_filter();
-    _pid_vel_z.set_integrator(0.0f);
+    _pid_vel_u.reset_filter();
+    _pid_vel_u.set_integrator(0.0f);
 
-    _accel_target.z = constrain_float(get_z_accel_cmss(), -_accel_max_z_cmss, _accel_max_z_cmss);
-    _accel_desired.z = _accel_target.z - (_accel_offset.z + _accel_terrain);
-    _pid_accel_z.reset_filter();
+    _accel_target_neu_cmss.z = constrain_float(get_measured_accel_U_cmss(), -_accel_max_u_cmss, _accel_max_u_cmss);
+    _accel_desired_neu_cmss.z = _accel_target_neu_cmss.z - (_accel_offset_neu_cmss.z + _accel_terrain_u_cmss);
+    _pid_accel_u.reset_filter();
 
-    // Set accel PID I term based on the current throttle
-    // Remove the expected P term due to _accel_desired.z being constrained to _accel_max_z_cmss
-    // Remove the expected FF term due to non-zero _accel_target.z
-    _pid_accel_z.set_integrator((_attitude_control.get_throttle_in() - _motors.get_throttle_hover()) * 1000.0f
-        - _pid_accel_z.kP() * (_accel_target.z - get_z_accel_cmss())
-        - _pid_accel_z.ff() * _accel_target.z);
+    // Set acceleration PID I term based on the current throttle
+    // Remove the expected P term due to _accel_desired_neu_cmss.z being constrained to _accel_max_u_cmss
+    // Remove the expected FF term due to non-zero _accel_target_neu_cmss.z
+    _pid_accel_u.set_integrator((_attitude_control.get_throttle_in() - _motors.get_throttle_hover()) * 1000.0f
+        - _pid_accel_u.kP() * (_accel_target_neu_cmss.z - get_measured_accel_U_cmss())
+        - _pid_accel_u.ff() * _accel_target_neu_cmss.z);
 
     // initialise ekf z reset handler
-    init_ekf_z_reset();
+    init_ekf_U_reset();
 
     // initialise z_controller time out
-    _last_update_z_ticks = AP::scheduler().ticks32();
+    _last_update_u_ticks = AP::scheduler().ticks32();
 }
 
-/// input_accel_z - calculate a jerk limited path from the current position, velocity and acceleration to an input acceleration.
+/// input_accel_U_cm - calculate a jerk limited path from the current position, velocity and acceleration to an input acceleration.
 ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
-void AC_PosControl::input_accel_z(float accel)
+///     The kinematic path is constrained by the maximum acceleration and jerk set using the function set_max_speed_accel_U_cmss.
+void AC_PosControl::input_accel_U_cm(float accel_cmss)
 {
     // calculated increased maximum jerk if over speed
-    float jerk_max_z_cmsss = _jerk_max_z_cmsss * calculate_overspeed_gain();
+    float jerk_max_u_cmsss = _jerk_max_u_cmsss * calculate_overspeed_gain();
 
     // adjust desired alt if motors have not hit their limits
-    update_pos_vel_accel(_pos_desired.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z, _p_pos_z.get_error(), _pid_vel_z.get_error());
+    update_pos_vel_accel(_pos_desired_neu_cm.z, _vel_desired_neu_cms.z, _accel_desired_neu_cmss.z, _dt, _limit_vector.z, _p_pos_u.get_error(), _pid_vel_u.get_error());
 
-    shape_accel(accel, _accel_desired.z, jerk_max_z_cmsss, _dt);
+    shape_accel(accel_cmss, _accel_desired_neu_cmss.z, jerk_max_u_cmsss, _dt);
 }
 
-/// input_accel_z - calculate a jerk limited path from the current position, velocity and acceleration to an input acceleration.
+/// input_vel_accel_U_cm - calculate a jerk limited path from the current position, velocity and acceleration to an input velocity and acceleration.
 ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
-///     The kinematic path is constrained by the maximum acceleration and jerk set using the function set_max_speed_accel_z.
+///     The kinematic path is constrained by the maximum acceleration and jerk set using the function set_max_speed_accel_U_cmss.
+///     The function modifies vel_u_cms to follow the jerk-limited trajectory defined by accel_u_cmss.
 ///     The parameter limit_output specifies if the velocity and acceleration limits are applied to the sum of commanded and correction values or just correction.
-void AC_PosControl::input_vel_accel_z(float &vel, float accel, bool limit_output)
+void AC_PosControl::input_vel_accel_U_cm(float &vel_u_cms, float accel_cmss, bool limit_output)
 {
     // calculated increased maximum acceleration and jerk if over speed
     const float overspeed_gain = calculate_overspeed_gain();
-    const float accel_max_z_cmss = _accel_max_z_cmss * overspeed_gain;
-    const float jerk_max_z_cmsss = _jerk_max_z_cmsss * overspeed_gain;
+    const float accel_max_u_cmss = _accel_max_u_cmss * overspeed_gain;
+    const float jerk_max_u_cmsss = _jerk_max_u_cmsss * overspeed_gain;
 
     // adjust desired alt if motors have not hit their limits
-    update_pos_vel_accel(_pos_desired.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z, _p_pos_z.get_error(), _pid_vel_z.get_error());
+    update_pos_vel_accel(_pos_desired_neu_cm.z, _vel_desired_neu_cms.z, _accel_desired_neu_cmss.z, _dt, _limit_vector.z, _p_pos_u.get_error(), _pid_vel_u.get_error());
 
-    shape_vel_accel(vel, accel,
-                    _vel_desired.z, _accel_desired.z,
-                    -constrain_float(accel_max_z_cmss, 0.0f, 750.0f), accel_max_z_cmss,
-                    jerk_max_z_cmsss, _dt, limit_output);
+    shape_vel_accel(vel_u_cms, accel_cmss,
+                    _vel_desired_neu_cms.z, _accel_desired_neu_cmss.z,
+                    -constrain_float(accel_max_u_cmss, 0.0f, 750.0f), accel_max_u_cmss,
+                    jerk_max_u_cmsss, _dt, limit_output);
 
-    update_vel_accel(vel, accel, _dt, 0.0, 0.0);
+    update_vel_accel(vel_u_cms, accel_cmss, _dt, 0.0, 0.0);
 }
 
-/// set_pos_target_z_from_climb_rate_cm - adjusts target up or down using a commanded climb rate in cm/s
+/// set_pos_target_U_from_climb_rate_cm - adjusts target up or down using a commanded climb rate in cm/s
 ///     using the default position control kinematic path.
 ///     The zero target altitude is varied to follow pos_offset_z
-void AC_PosControl::set_pos_target_z_from_climb_rate_cm(float vel)
+void AC_PosControl::set_pos_target_U_from_climb_rate_cm(float vel_u_cms)
 {
-    input_vel_accel_z(vel, 0.0);
+    input_vel_accel_U_cm(vel_u_cms, 0.0);
 }
 
 /// land_at_climb_rate_cm - adjusts target up or down using a commanded climb rate in cm/s
 ///     using the default position control kinematic path.
 ///     ignore_descent_limit turns off output saturation handling to aid in landing detection. ignore_descent_limit should be false unless landing.
-void AC_PosControl::land_at_climb_rate_cm(float vel, bool ignore_descent_limit)
+void AC_PosControl::land_at_climb_rate_cm(float vel_u_cms, bool ignore_descent_limit)
 {
     if (ignore_descent_limit) {
         // turn off limits in the negative z direction
         _limit_vector.z = MAX(_limit_vector.z, 0.0f);
     }
 
-    input_vel_accel_z(vel, 0.0);
+    input_vel_accel_U_cm(vel_u_cms, 0.0);
 }
 
-/// input_pos_vel_accel_z - calculate a jerk limited path from the current position, velocity and acceleration to an input position velocity and acceleration.
-///     The pos and vel are projected forwards in time based on a time step of dt and acceleration accel.
+/// input_pos_vel_accel_U_cm - calculate a jerk limited path from the current position, velocity and acceleration to an input position velocity and acceleration.
+///     The pos_u_cm and vel_u_cms are projected forwards in time based on a time step of dt and acceleration accel_cmss.
 ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
-///     The function alters the pos and vel to be the kinematic path based on accel
+///     The function alters the pos_u_cm and vel_u_cms to be the kinematic path based on accel_cmss
 ///     The parameter limit_output specifies if the velocity and acceleration limits are applied to the sum of commanded and correction values or just correction.
-void AC_PosControl::input_pos_vel_accel_z(float &pos, float &vel, float accel, bool limit_output)
+void AC_PosControl::input_pos_vel_accel_U_cm(float &pos_u_cm, float &vel_u_cms, float accel_cmss, bool limit_output)
 {
     // calculated increased maximum acceleration and jerk if over speed
     const float overspeed_gain = calculate_overspeed_gain();
-    const float accel_max_z_cmss = _accel_max_z_cmss * overspeed_gain;
-    const float jerk_max_z_cmsss = _jerk_max_z_cmsss * overspeed_gain;
+    const float accel_max_u_cmss = _accel_max_u_cmss * overspeed_gain;
+    const float jerk_max_u_cmsss = _jerk_max_u_cmsss * overspeed_gain;
 
     // adjust desired altitude if motors have not hit their limits
-    update_pos_vel_accel(_pos_desired.z, _vel_desired.z, _accel_desired.z, _dt, _limit_vector.z, _p_pos_z.get_error(), _pid_vel_z.get_error());
+    update_pos_vel_accel(_pos_desired_neu_cm.z, _vel_desired_neu_cms.z, _accel_desired_neu_cmss.z, _dt, _limit_vector.z, _p_pos_u.get_error(), _pid_vel_u.get_error());
 
-    shape_pos_vel_accel(pos, vel, accel,
-                        _pos_desired.z, _vel_desired.z, _accel_desired.z,
+    shape_pos_vel_accel(pos_u_cm, vel_u_cms, accel_cmss,
+                        _pos_desired_neu_cm.z, _vel_desired_neu_cms.z, _accel_desired_neu_cmss.z,
                         _vel_max_down_cms, _vel_max_up_cms,
-                        -constrain_float(accel_max_z_cmss, 0.0f, 750.0f), accel_max_z_cmss,
-                        jerk_max_z_cmsss, _dt, limit_output);
+                        -constrain_float(accel_max_u_cmss, 0.0f, 750.0f), accel_max_u_cmss,
+                        jerk_max_u_cmsss, _dt, limit_output);
 
-    postype_t posp = pos;
-    update_pos_vel_accel(posp, vel, accel, _dt, 0.0, 0.0, 0.0);
-    pos = posp;
+    postype_t posp = pos_u_cm;
+    update_pos_vel_accel(posp, vel_u_cms, accel_cmss, _dt, 0.0, 0.0, 0.0);
+    pos_u_cm = posp;
 }
 
-/// set_alt_target_with_slew - adjusts target up or down using a commanded altitude in cm
+/// set_alt_target_with_slew_cm - adjusts target up or down using a commanded altitude in cm
 ///     using the default position control kinematic path.
-void AC_PosControl::set_alt_target_with_slew(float pos)
+void AC_PosControl::set_alt_target_with_slew_cm(float pos_u_cm)
 {
     float zero = 0;
-    input_pos_vel_accel_z(pos, zero, 0);
+    input_pos_vel_accel_U_cm(pos_u_cm, zero, 0);
 }
 
-/// update_offsets_z - updates the vertical offsets used by terrain following
-void AC_PosControl::update_offsets_z()
+/// update_offsets_U - updates the vertical offsets used by terrain following
+void AC_PosControl::update_offsets_U()
 {
     // check for offset target timeout
     uint32_t now_ms = AP_HAL::millis();
-    if (now_ms - _posvelaccel_offset_target_z_ms > POSCONTROL_POSVELACCEL_OFFSET_TARGET_TIMEOUT_MS) {
-        _pos_offset_target.z = 0.0;
-        _vel_offset_target.z = 0.0;
-        _accel_offset_target.z = 0.0;
+    if (now_ms - _posvelaccel_offset_target_u_ms > POSCONTROL_POSVELACCEL_OFFSET_TARGET_TIMEOUT_MS) {
+        _pos_offset_target_neu_cm.z = 0.0;
+        _vel_offset_target_neu_cms.z = 0.0;
+        _accel_offset_target_neu_cmss.z = 0.0;
     }
 
-    // update position, velocity, accel offsets for this iteration
-    postype_t p_offset_z = _pos_offset.z;
-    update_pos_vel_accel(p_offset_z, _vel_offset.z, _accel_offset.z, _dt, MIN(_limit_vector.z, 0.0f), _p_pos_z.get_error(), _pid_vel_z.get_error());
-    _pos_offset.z = p_offset_z;
+    // update position, velocity, acceleration offsets for this iteration
+    postype_t p_offset_u_cm = _pos_offset_neu_cm.z;
+    update_pos_vel_accel(p_offset_u_cm, _vel_offset_neu_cms.z, _accel_offset_neu_cmss.z, _dt, MIN(_limit_vector.z, 0.0f), _p_pos_u.get_error(), _pid_vel_u.get_error());
+    _pos_offset_neu_cm.z = p_offset_u_cm;
 
     // input shape vertical position, velocity and acceleration offsets
-    shape_pos_vel_accel(_pos_offset_target.z, _vel_offset_target.z, _accel_offset_target.z,
-        _pos_offset.z, _vel_offset.z, _accel_offset.z,
+    shape_pos_vel_accel(_pos_offset_target_neu_cm.z, _vel_offset_target_neu_cms.z, _accel_offset_target_neu_cmss.z,
+        _pos_offset_neu_cm.z, _vel_offset_neu_cms.z, _accel_offset_neu_cmss.z,
         get_max_speed_down_cms(), get_max_speed_up_cms(),
-        -get_max_accel_z_cmss(), get_max_accel_z_cmss(),
-        _jerk_max_z_cmsss, _dt, false);
+        -get_max_accel_U_cmss(), get_max_accel_U_cmss(),
+        _jerk_max_u_cmsss, _dt, false);
 
-    p_offset_z = _pos_offset_target.z;
-    update_pos_vel_accel(p_offset_z, _vel_offset_target.z, _accel_offset_target.z, _dt, 0.0, 0.0, 0.0);
-    _pos_offset_target.z = p_offset_z;
+    p_offset_u_cm = _pos_offset_target_neu_cm.z;
+    update_pos_vel_accel(p_offset_u_cm, _vel_offset_target_neu_cms.z, _accel_offset_target_neu_cmss.z, _dt, 0.0, 0.0, 0.0);
+    _pos_offset_target_neu_cm.z = p_offset_u_cm;
 }
 
-// is_active_z - returns true if the z position controller has been run in the previous loop
-bool AC_PosControl::is_active_z() const
+// is_active_U - returns true if the z position controller has been run in the previous loop
+bool AC_PosControl::is_active_U() const
 {
-    const uint32_t dt_ticks = AP::scheduler().ticks32() - _last_update_z_ticks;
+    const uint32_t dt_ticks = AP::scheduler().ticks32() - _last_update_u_ticks;
     return dt_ticks <= 1;
 }
 
-/// update_z_controller - runs the vertical position controller correcting position, velocity and acceleration errors.
+/// update_U_controller - runs the vertical position controller correcting position, velocity and acceleration errors.
 ///     Position and velocity errors are converted to velocity and acceleration targets using PID objects
 ///     Desired velocity and accelerations are added to these corrections as they are calculated
 ///     Kinematically consistent target position and desired velocity and accelerations should be provided before calling this function
-void AC_PosControl::update_z_controller()
+void AC_PosControl::update_U_controller()
 {
     // check for ekf z-axis position reset
-    handle_ekf_z_reset();
+    handle_ekf_U_reset();
 
     // Check for z_controller time out
-    if (!is_active_z()) {
-        init_z_controller();
+    if (!is_active_U()) {
+        init_U_controller();
         if (has_good_timing()) {
             // call internal error because initialisation has not been done
             INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
         }
     }
-    _last_update_z_ticks = AP::scheduler().ticks32();
+    _last_update_u_ticks = AP::scheduler().ticks32();
 
     // update the position, velocity and acceleration offsets
-    update_offsets_z();
+    update_offsets_U();
     update_terrain();
-    _pos_target.z = _pos_desired.z + _pos_offset.z + _pos_terrain;
+    _pos_target_neu_cm.z = _pos_desired_neu_cm.z + _pos_offset_neu_cm.z + _pos_terrain_u_cm;
 
     // calculate the target velocity correction
-    float pos_target_zf = _pos_target.z;
+    float pos_target_zf = _pos_target_neu_cm.z;
 
-    _vel_target.z = _p_pos_z.update_all(pos_target_zf, _inav.get_position_z_up_cm());
-    _vel_target.z *= AP::ahrs().getControlScaleZ();
+    _vel_target_neu_cms.z = _p_pos_u.update_all(pos_target_zf, _inav.get_position_z_up_cm());
+    _vel_target_neu_cms.z *= AP::ahrs().getControlScaleZ();
 
-    _pos_target.z = pos_target_zf;
-    _pos_desired.z = _pos_target.z - (_pos_offset.z + _pos_terrain);
+    _pos_target_neu_cm.z = pos_target_zf;
+    _pos_desired_neu_cm.z = _pos_target_neu_cm.z - (_pos_offset_neu_cm.z + _pos_terrain_u_cm);
 
     // add feed forward component
-    _vel_target.z += _vel_desired.z + _vel_offset.z + _vel_terrain;
+    _vel_target_neu_cms.z += _vel_desired_neu_cms.z + _vel_offset_neu_cms.z + _vel_terrain_u_cms;
 
     // Velocity Controller
 
-    const float curr_vel_z = _inav.get_velocity_z_up_cms();
-    _accel_target.z = _pid_vel_z.update_all(_vel_target.z, curr_vel_z, _dt, _motors.limit.throttle_lower, _motors.limit.throttle_upper);
-    _accel_target.z *= AP::ahrs().getControlScaleZ();
+    const float curr_vel_u_cms = _inav.get_velocity_z_up_cms();
+    _accel_target_neu_cmss.z = _pid_vel_u.update_all(_vel_target_neu_cms.z, curr_vel_u_cms, _dt, _motors.limit.throttle_lower, _motors.limit.throttle_upper);
+    _accel_target_neu_cmss.z *= AP::ahrs().getControlScaleZ();
 
     // add feed forward component
-    _accel_target.z += _accel_desired.z + _accel_offset.z + _accel_terrain;
+    _accel_target_neu_cmss.z += _accel_desired_neu_cmss.z + _accel_offset_neu_cmss.z + _accel_terrain_u_cmss;
 
     // Acceleration Controller
 
     // Calculate vertical acceleration
-    const float z_accel_meas = get_z_accel_cmss();
+    const float measured_accel_u_cmss = get_measured_accel_U_cmss();
 
     // ensure imax is always large enough to overpower hover throttle
-    if (_motors.get_throttle_hover() * 1000.0f > _pid_accel_z.imax()) {
-        _pid_accel_z.set_imax(_motors.get_throttle_hover() * 1000.0f);
+    if (_motors.get_throttle_hover() * 1000.0f > _pid_accel_u.imax()) {
+        _pid_accel_u.set_imax(_motors.get_throttle_hover() * 1000.0f);
     }
     float thr_out;
     if (_vibe_comp_enabled) {
         thr_out = get_throttle_with_vibration_override();
     } else {
-        thr_out = _pid_accel_z.update_all(_accel_target.z, z_accel_meas, _dt, (_motors.limit.throttle_lower || _motors.limit.throttle_upper)) * 0.001f;
-        thr_out += _pid_accel_z.get_ff() * 0.001f;
+        thr_out = _pid_accel_u.update_all(_accel_target_neu_cmss.z, measured_accel_u_cmss, _dt, (_motors.limit.throttle_lower || _motors.limit.throttle_upper)) * 0.001f;
+        thr_out += _pid_accel_u.get_ff() * 0.001f;
     }
     thr_out += _motors.get_throttle_hover();
 
@@ -1046,9 +1047,9 @@ void AC_PosControl::update_z_controller()
     // Check for vertical controller health
 
     // _speed_down_cms is checked to be non-zero when set
-    float error_ratio = _pid_vel_z.get_error() / _vel_max_down_cms;
-    _vel_z_control_ratio += _dt * 0.1f * (0.5 - error_ratio);
-    _vel_z_control_ratio = constrain_float(_vel_z_control_ratio, 0.0f, 2.0f);
+    float error_ratio = _pid_vel_u.get_error() / _vel_max_down_cms;
+    _vel_u_control_ratio += _dt * 0.1f * (0.5 - error_ratio);
+    _vel_u_control_ratio = constrain_float(_vel_u_control_ratio, 0.0f, 2.0f);
 
     // set vertical component of the limit vector
     if (_motors.limit.throttle_upper) {
@@ -1071,26 +1072,26 @@ float AC_PosControl::get_lean_angle_max_cd() const
     if (is_positive(_angle_max_override_cd)) {
         return _angle_max_override_cd;
     }
-    if (!is_positive(_lean_angle_max)) {
+    if (!is_positive(_lean_angle_max_deg)) {
         return _attitude_control.lean_angle_max_cd();
     }
-    return _lean_angle_max * 100.0f;
+    return _lean_angle_max_deg * 100.0f;
 }
 
 /// set the desired position, velocity and acceleration targets
-void AC_PosControl::set_pos_vel_accel(const Vector3p& pos, const Vector3f& vel, const Vector3f& accel)
+void AC_PosControl::set_pos_vel_accel_NEU_cm(const Vector3p& pos_neu_cm, const Vector3f& vel_neu_cms, const Vector3f& accel_neu_cmss)
 {
-    _pos_desired = pos;
-    _vel_desired = vel;
-    _accel_desired = accel;
+    _pos_desired_neu_cm = pos_neu_cm;
+    _vel_desired_neu_cms = vel_neu_cms;
+    _accel_desired_neu_cmss = accel_neu_cmss;
 }
 
 /// set the desired position, velocity and acceleration targets
-void AC_PosControl::set_pos_vel_accel_xy(const Vector2p& pos, const Vector2f& vel, const Vector2f& accel)
+void AC_PosControl::set_pos_vel_accel_NE_cm(const Vector2p& pos_ne_cm, const Vector2f& vel_ne_cms, const Vector2f& accel_ne_cmss)
 {
-    _pos_desired.xy() = pos;
-    _vel_desired.xy() = vel;
-    _accel_desired.xy() = accel;
+    _pos_desired_neu_cm.xy() = pos_ne_cm;
+    _vel_desired_neu_cms.xy() = vel_ne_cms;
+    _accel_desired_neu_cmss.xy() = accel_ne_cmss;
 }
 
 // get_lean_angles_to_accel - convert roll, pitch lean target angles to lat/lon frame accelerations in cm/s/s
@@ -1118,22 +1119,22 @@ Vector3f AC_PosControl::lean_angles_to_accel(const Vector3f& att_target_euler) c
 void AC_PosControl::init_terrain()
 {
     // set terrain position and target to zero
-    _pos_terrain_target = 0.0;
-    _pos_terrain = 0.0;
+    _pos_terrain_target_u_cm = 0.0;
+    _pos_terrain_u_cm = 0.0;
 
     // set velocity offset to zero
-    _vel_terrain = 0.0;
+    _vel_terrain_u_cms = 0.0;
 
     // set acceleration offset to zero
-    _accel_terrain = 0.0;
+    _accel_terrain_u_cmss = 0.0;
 }
 
-// init_pos_terrain_cm - initialises the current terrain altitude and target altitude to pos_offset_terrain_cm
-void AC_PosControl::init_pos_terrain_cm(float pos_terrain_cm)
+// init_pos_terrain_U_cm - initialises the current terrain altitude and target altitude to pos_offset_terrain_cm
+void AC_PosControl::init_pos_terrain_U_cm(float pos_terrain_u_cm)
 {
-    _pos_desired.z -= (pos_terrain_cm - _pos_terrain);
-    _pos_terrain_target = pos_terrain_cm;
-    _pos_terrain = pos_terrain_cm;
+    _pos_desired_neu_cm.z -= (pos_terrain_u_cm - _pos_terrain_u_cm);
+    _pos_terrain_target_u_cm = pos_terrain_u_cm;
+    _pos_terrain_u_cm = pos_terrain_u_cm;
 }
 
 
@@ -1141,45 +1142,45 @@ void AC_PosControl::init_pos_terrain_cm(float pos_terrain_cm)
 
 /// set the horizontal position, velocity and acceleration offsets in cm, cms and cm/s/s from EKF origin in NE frame
 /// this is used to initiate the offsets when initialise the position controller or do an offset reset
-void AC_PosControl::init_offsets_xy()
+void AC_PosControl::init_offsets_NE()
 {
     // check for offset target timeout
     uint32_t now_ms = AP_HAL::millis();
-    if (now_ms - _posvelaccel_offset_target_xy_ms > POSCONTROL_POSVELACCEL_OFFSET_TARGET_TIMEOUT_MS) {
-        _pos_offset_target.xy().zero();
-        _vel_offset_target.xy().zero();
-        _accel_offset_target.xy().zero();
+    if (now_ms - _posvelaccel_offset_target_ne_ms > POSCONTROL_POSVELACCEL_OFFSET_TARGET_TIMEOUT_MS) {
+        _pos_offset_target_neu_cm.xy().zero();
+        _vel_offset_target_neu_cms.xy().zero();
+        _accel_offset_target_neu_cmss.xy().zero();
     }
 
     // set position offset to target
-    _pos_offset.xy() = _pos_offset_target.xy();
+    _pos_offset_neu_cm.xy() = _pos_offset_target_neu_cm.xy();
 
     // set velocity offset to target
-    _vel_offset.xy() = _vel_offset_target.xy();
+    _vel_offset_neu_cms.xy() = _vel_offset_target_neu_cms.xy();
 
     // set acceleration offset to target
-    _accel_offset.xy() = _accel_offset_target.xy();
+    _accel_offset_neu_cmss.xy() = _accel_offset_target_neu_cmss.xy();
 }
 
 /// set the horizontal position, velocity and acceleration offsets in cm, cms and cm/s/s from EKF origin in NE frame
 /// this is used to initiate the offsets when initialise the position controller or do an offset reset
-void AC_PosControl::init_offsets_z()
+void AC_PosControl::init_offsets_U()
 {
     // check for offset target timeout
     uint32_t now_ms = AP_HAL::millis();
-    if (now_ms - _posvelaccel_offset_target_z_ms > POSCONTROL_POSVELACCEL_OFFSET_TARGET_TIMEOUT_MS) {
-        _pos_offset_target.z = 0.0;
-        _vel_offset_target.z = 0.0;
-        _accel_offset_target.z = 0.0;
+    if (now_ms - _posvelaccel_offset_target_u_ms > POSCONTROL_POSVELACCEL_OFFSET_TARGET_TIMEOUT_MS) {
+        _pos_offset_target_neu_cm.z = 0.0;
+        _vel_offset_target_neu_cms.z = 0.0;
+        _accel_offset_target_neu_cmss.z = 0.0;
     }
     // set position offset to target
-    _pos_offset.z = _pos_offset_target.z;
+    _pos_offset_neu_cm.z = _pos_offset_target_neu_cm.z;
 
     // set velocity offset to target
-    _vel_offset.z = _vel_offset_target.z;
+    _vel_offset_neu_cms.z = _vel_offset_target_neu_cms.z;
 
     // set acceleration offset to target
-    _accel_offset.z = _accel_offset_target.z;
+    _accel_offset_neu_cmss.z = _accel_offset_target_neu_cmss.z;
 }
 
 #if AP_SCRIPTING_ENABLED
@@ -1188,8 +1189,8 @@ void AC_PosControl::init_offsets_z()
 // Z-axis is not currently supported and is ignored
 bool AC_PosControl::set_posvelaccel_offset(const Vector3f &pos_offset_NED, const Vector3f &vel_offset_NED, const Vector3f &accel_offset_NED)
 {
-    set_posvelaccel_offset_target_xy_cm(pos_offset_NED.topostype().xy() * 100.0, vel_offset_NED.xy() * 100.0, accel_offset_NED.xy() * 100.0);
-    set_posvelaccel_offset_target_z_cm(-pos_offset_NED.topostype().z * 100.0, -vel_offset_NED.z * 100, -accel_offset_NED.z * 100.0);
+    set_posvelaccel_offset_target_NE_cm(pos_offset_NED.topostype().xy() * 100.0, vel_offset_NED.xy() * 100.0, accel_offset_NED.xy() * 100.0);
+    set_posvelaccel_offset_target_U_cm(-pos_offset_NED.topostype().z * 100.0, -vel_offset_NED.z * 100, -accel_offset_NED.z * 100.0);
     return true;
 }
 
@@ -1197,90 +1198,90 @@ bool AC_PosControl::set_posvelaccel_offset(const Vector3f &pos_offset_NED, const
 // units are m and m/s in NED frame
 bool AC_PosControl::get_posvelaccel_offset(Vector3f &pos_offset_NED, Vector3f &vel_offset_NED, Vector3f &accel_offset_NED)
 {
-    pos_offset_NED.xy() = _pos_offset_target.xy().tofloat() * 0.01;
-    pos_offset_NED.z = -_pos_offset_target.z * 0.01;
-    vel_offset_NED.xy() = _vel_offset_target.xy() * 0.01;
-    vel_offset_NED.z = -_vel_offset_target.z * 0.01;
-    accel_offset_NED.xy() = _accel_offset_target.xy() * 0.01;
-    accel_offset_NED.z = -_accel_offset_target.z * 0.01;
+    pos_offset_NED.xy() = _pos_offset_target_neu_cm.xy().tofloat() * 0.01;
+    pos_offset_NED.z = -_pos_offset_target_neu_cm.z * 0.01;
+    vel_offset_NED.xy() = _vel_offset_target_neu_cms.xy() * 0.01;
+    vel_offset_NED.z = -_vel_offset_target_neu_cms.z * 0.01;
+    accel_offset_NED.xy() = _accel_offset_target_neu_cmss.xy() * 0.01;
+    accel_offset_NED.z = -_accel_offset_target_neu_cmss.z * 0.01;
     return true;
 }
 
 // get target velocity in m/s in NED frame
 bool AC_PosControl::get_vel_target(Vector3f &vel_target_NED)
 {
-    if (!is_active_xy() || !is_active_z()) {
+    if (!is_active_NE() || !is_active_U()) {
         return false;
     }
-    vel_target_NED.xy() = _vel_target.xy() * 0.01;
-    vel_target_NED.z = -_vel_target.z * 0.01;
+    vel_target_NED.xy() = _vel_target_neu_cms.xy() * 0.01;
+    vel_target_NED.z = -_vel_target_neu_cms.z * 0.01;
     return true;
 }
 
 // get target acceleration in m/s/s in NED frame
 bool AC_PosControl::get_accel_target(Vector3f &accel_target_NED)
 {
-    if (!is_active_xy() || !is_active_z()) {
+    if (!is_active_NE() || !is_active_U()) {
         return false;
     }
-    accel_target_NED.xy() = _accel_target.xy() * 0.01;
-    accel_target_NED.z = -_accel_target.z * 0.01;
+    accel_target_NED.xy() = _accel_target_neu_cmss.xy() * 0.01;
+    accel_target_NED.z = -_accel_target_neu_cmss.z * 0.01;
     return true;
 }
 #endif
 
 /// set the horizontal position, velocity and acceleration offset targets in cm, cms and cm/s/s from EKF origin in NE frame
 /// these must be set every 3 seconds (or less) or they will timeout and return to zero
-void AC_PosControl::set_posvelaccel_offset_target_xy_cm(const Vector2p& pos_offset_target_xy_cm, const Vector2f& vel_offset_target_xy_cms, const Vector2f& accel_offset_target_xy_cmss)
+void AC_PosControl::set_posvelaccel_offset_target_NE_cm(const Vector2p& pos_offset_target_ne_cm, const Vector2f& vel_offset_target_ne_cms, const Vector2f& accel_offset_target_ne_cmss)
 {
     // set position offset target
-    _pos_offset_target.xy() = pos_offset_target_xy_cm;
+    _pos_offset_target_neu_cm.xy() = pos_offset_target_ne_cm;
 
     // set velocity offset target
-    _vel_offset_target.xy() = vel_offset_target_xy_cms;
+    _vel_offset_target_neu_cms.xy() = vel_offset_target_ne_cms;
 
     // set acceleration offset target
-    _accel_offset_target.xy() = accel_offset_target_xy_cmss;
+    _accel_offset_target_neu_cmss.xy() = accel_offset_target_ne_cmss;
 
     // record time of update so we can detect timeouts
-    _posvelaccel_offset_target_xy_ms = AP_HAL::millis();
+    _posvelaccel_offset_target_ne_ms = AP_HAL::millis();
 }
 
 /// set the vertical position, velocity and acceleration offset targets in cm, cms and cm/s/s from EKF origin in NE frame
 /// these must be set every 3 seconds (or less) or they will timeout and return to zero
-void AC_PosControl::set_posvelaccel_offset_target_z_cm(float pos_offset_target_z_cm, float vel_offset_target_z_cms, const float accel_offset_target_z_cmss)
+void AC_PosControl::set_posvelaccel_offset_target_U_cm(float pos_offset_target_u_cm, float vel_offset_target_u_cms, const float accel_offset_target_u_cmss)
 {
     // set position offset target
-    _pos_offset_target.z = pos_offset_target_z_cm;
+    _pos_offset_target_neu_cm.z = pos_offset_target_u_cm;
 
     // set velocity offset target
-    _vel_offset_target.z = vel_offset_target_z_cms;
+    _vel_offset_target_neu_cms.z = vel_offset_target_u_cms;
 
     // set acceleration offset target
-    _accel_offset_target.z = accel_offset_target_z_cmss;
+    _accel_offset_target_neu_cmss.z = accel_offset_target_u_cmss;
 
     // record time of update so we can detect timeouts
-    _posvelaccel_offset_target_z_ms = AP_HAL::millis();
+    _posvelaccel_offset_target_u_ms = AP_HAL::millis();
 }
 
 // returns the NED target acceleration vector for attitude control
 Vector3f AC_PosControl::get_thrust_vector() const
 {
-    Vector3f accel_target = get_accel_target_cmss();
-    accel_target.z = -GRAVITY_MSS * 100.0f;
-    return accel_target;
+    Vector3f accel_target_neu_cmss = get_accel_target_NEU_cmss();
+    accel_target_neu_cmss.z = -GRAVITY_MSS * 100.0f;
+    return accel_target_neu_cmss;
 }
 
-/// get_stopping_point_xy_cm - calculates stopping point in NEU cm based on current position, velocity, vehicle acceleration
+/// get_stopping_point_NE_cm - calculates stopping point in NEU cm based on current position, velocity, vehicle acceleration
 ///    function does not change the z axis
-void AC_PosControl::get_stopping_point_xy_cm(Vector2p &stopping_point) const
+void AC_PosControl::get_stopping_point_NE_cm(Vector2p &stopping_point_neu_cm) const
 {
     // todo: we should use the current target position and velocity if we are currently running the position controller
-    stopping_point = _inav.get_position_xy_cm().topostype();
-    stopping_point -= _pos_offset.xy();
+    stopping_point_neu_cm = _inav.get_position_xy_cm().topostype();
+    stopping_point_neu_cm -= _pos_offset_neu_cm.xy();
 
     Vector2f curr_vel = _inav.get_velocity_xy_cms();
-    curr_vel -= _vel_offset.xy();
+    curr_vel -= _vel_offset_neu_cms.xy();
 
     // calculate current velocity
     float vel_total = curr_vel.length();
@@ -1289,39 +1290,40 @@ void AC_PosControl::get_stopping_point_xy_cm(Vector2p &stopping_point) const
         return;
     }
     
-    float kP = _p_pos_xy.kP();
-    const float stopping_dist = stopping_distance(constrain_float(vel_total, 0.0, _vel_max_xy_cms), kP, _accel_max_xy_cmss);
+    float kP = _p_pos_ne.kP();
+    const float stopping_dist = stopping_distance(constrain_float(vel_total, 0.0, _vel_max_ne_cms), kP, _accel_max_ne_cmss);
     if (!is_positive(stopping_dist)) {
         return;
     }
 
     // convert the stopping distance into a stopping point using velocity vector
+    // todo: convert velocity to a unit vector instead.
     const float t = stopping_dist / vel_total;
-    stopping_point += (curr_vel * t).topostype();
+    stopping_point_neu_cm += (curr_vel * t).topostype();
 }
 
-/// get_stopping_point_z_cm - calculates stopping point in NEU cm based on current position, velocity, vehicle acceleration
-void AC_PosControl::get_stopping_point_z_cm(postype_t &stopping_point) const
+/// get_stopping_point_U_cm - calculates stopping point in NEU cm based on current position, velocity, vehicle acceleration
+void AC_PosControl::get_stopping_point_U_cm(postype_t &stopping_point_u_cm) const
 {
-    float curr_pos_z = _inav.get_position_z_up_cm();
-    curr_pos_z -= _pos_offset.z;
+    float curr_pos_u_cm = _inav.get_position_z_up_cm();
+    curr_pos_u_cm -= _pos_offset_neu_cm.z;
 
-    float curr_vel_z = _inav.get_velocity_z_up_cms();
-    curr_vel_z -= _vel_offset.z;
+    float curr_vel_u_cms = _inav.get_velocity_z_up_cms();
+    curr_vel_u_cms -= _vel_offset_neu_cms.z;
 
     // avoid divide by zero by using current position if kP is very low or acceleration is zero
-    if (!is_positive(_p_pos_z.kP()) || !is_positive(_accel_max_z_cmss)) {
-        stopping_point = curr_pos_z;
+    if (!is_positive(_p_pos_u.kP()) || !is_positive(_accel_max_u_cmss)) {
+        stopping_point_u_cm = curr_pos_u_cm;
         return;
     }
 
-    stopping_point = curr_pos_z + constrain_float(stopping_distance(curr_vel_z, _p_pos_z.kP(), _accel_max_z_cmss), - POSCONTROL_STOPPING_DIST_DOWN_MAX, POSCONTROL_STOPPING_DIST_UP_MAX);
+    stopping_point_u_cm = curr_pos_u_cm + constrain_float(stopping_distance(curr_vel_u_cms, _p_pos_u.kP(), _accel_max_u_cmss), - POSCONTROL_STOPPING_DIST_DOWN_MAX, POSCONTROL_STOPPING_DIST_UP_MAX);
 }
 
 /// get_bearing_to_target_cd - get bearing to target position in centi-degrees
 int32_t AC_PosControl::get_bearing_to_target_cd() const
 {
-    return get_bearing_cd(_inav.get_position_xy_cm(), _pos_target.tofloat().xy());
+    return get_bearing_cd(_inav.get_position_xy_cm(), _pos_target_neu_cm.tofloat().xy());
 }
 
 
@@ -1332,66 +1334,66 @@ int32_t AC_PosControl::get_bearing_to_target_cd() const
 // get throttle using vibration-resistant calculation (uses feed forward with manually calculated gain)
 float AC_PosControl::get_throttle_with_vibration_override()
 {
-    const float thr_per_accelz_cmss = _motors.get_throttle_hover() / (GRAVITY_MSS * 100.0f);
+    const float thr_per_accel_u_cmss = _motors.get_throttle_hover() / (GRAVITY_MSS * 100.0f);
     // during vibration compensation use feed forward with manually calculated gain
     // ToDo: clear pid_info P, I and D terms for logging
-    if (!(_motors.limit.throttle_lower || _motors.limit.throttle_upper) || ((is_positive(_pid_accel_z.get_i()) && is_negative(_pid_vel_z.get_error())) || (is_negative(_pid_accel_z.get_i()) && is_positive(_pid_vel_z.get_error())))) {
-        _pid_accel_z.set_integrator(_pid_accel_z.get_i() + _dt * thr_per_accelz_cmss * 1000.0f * _pid_vel_z.get_error() * _pid_vel_z.kP() * POSCONTROL_VIBE_COMP_I_GAIN);
+    if (!(_motors.limit.throttle_lower || _motors.limit.throttle_upper) || ((is_positive(_pid_accel_u.get_i()) && is_negative(_pid_vel_u.get_error())) || (is_negative(_pid_accel_u.get_i()) && is_positive(_pid_vel_u.get_error())))) {
+        _pid_accel_u.set_integrator(_pid_accel_u.get_i() + _dt * thr_per_accel_u_cmss * 1000.0f * _pid_vel_u.get_error() * _pid_vel_u.kP() * POSCONTROL_VIBE_COMP_I_GAIN);
     }
-    return POSCONTROL_VIBE_COMP_P_GAIN * thr_per_accelz_cmss * _accel_target.z + _pid_accel_z.get_i() * 0.001f;
+    return POSCONTROL_VIBE_COMP_P_GAIN * thr_per_accel_u_cmss * _accel_target_neu_cmss.z + _pid_accel_u.get_i() * 0.001f;
 }
 
-/// standby_xyz_reset - resets I terms and removes position error
+/// standby_NEU_reset - resets I terms and removes position error
 ///     This function will let Loiter and Alt Hold continue to operate
 ///     in the event that the flight controller is in control of the
 ///     aircraft when in standby.
-void AC_PosControl::standby_xyz_reset()
+void AC_PosControl::standby_NEU_reset()
 {
-    // Set _pid_accel_z integrator to zero.
-    _pid_accel_z.set_integrator(0.0f);
+    // Set _pid_accel_u integrator to zero.
+    _pid_accel_u.set_integrator(0.0f);
 
     // Set the target position to the current pos.
-    _pos_target = _inav.get_position_neu_cm().topostype();
+    _pos_target_neu_cm = _inav.get_position_neu_cm().topostype();
 
-    // Set _pid_vel_xy integrator and derivative to zero.
-    _pid_vel_xy.reset_filter();
+    // Set _pid_vel_ne integrator and derivative to zero.
+    _pid_vel_ne.reset_filter();
 
     // initialise ekf xy reset handler
-    init_ekf_xy_reset();
+    init_ekf_NE_reset();
 }
 
 #if HAL_LOGGING_ENABLED
 // write PSC and/or PSCZ logs
 void AC_PosControl::write_log()
 {
-    if (is_active_xy()) {
-        float accel_x, accel_y;
-        lean_angles_to_accel_xy(accel_x, accel_y);
-        Write_PSCN(_pos_desired.x, _pos_target.x, _inav.get_position_neu_cm().x,
-                   _vel_desired.x, _vel_target.x, _inav.get_velocity_neu_cms().x,
-                   _accel_desired.x, _accel_target.x, accel_x);
-        Write_PSCE(_pos_desired.y, _pos_target.y, _inav.get_position_neu_cm().y,
-                   _vel_desired.y, _vel_target.y, _inav.get_velocity_neu_cms().y,
-                   _accel_desired.y, _accel_target.y, accel_y);
+    if (is_active_NE()) {
+        float accel_n_cmss, accel_e_cmss;
+        lean_angles_to_accel_NE_cmss(accel_n_cmss, accel_e_cmss);
+        Write_PSCN(_pos_desired_neu_cm.x, _pos_target_neu_cm.x, _inav.get_position_neu_cm().x,
+                   _vel_desired_neu_cms.x, _vel_target_neu_cms.x, _inav.get_velocity_neu_cms().x,
+                   _accel_desired_neu_cmss.x, _accel_target_neu_cmss.x, accel_n_cmss);
+        Write_PSCE(_pos_desired_neu_cm.y, _pos_target_neu_cm.y, _inav.get_position_neu_cm().y,
+                   _vel_desired_neu_cms.y, _vel_target_neu_cms.y, _inav.get_velocity_neu_cms().y,
+                   _accel_desired_neu_cmss.y, _accel_target_neu_cmss.y, accel_e_cmss);
 
         // log offsets if they are being used
-        if (!_pos_offset.xy().is_zero()) {
-            Write_PSON(_pos_offset_target.x, _pos_offset.x, _vel_offset_target.x, _vel_offset.x, _accel_offset_target.x, _accel_offset.x);
-            Write_PSOE(_pos_offset_target.y, _pos_offset.y, _vel_offset_target.y, _vel_offset.y, _accel_offset_target.y, _accel_offset.y);
+        if (!_pos_offset_neu_cm.xy().is_zero()) {
+            Write_PSON(_pos_offset_target_neu_cm.x, _pos_offset_neu_cm.x, _vel_offset_target_neu_cms.x, _vel_offset_neu_cms.x, _accel_offset_target_neu_cmss.x, _accel_offset_neu_cmss.x);
+            Write_PSOE(_pos_offset_target_neu_cm.y, _pos_offset_neu_cm.y, _vel_offset_target_neu_cms.y, _vel_offset_neu_cms.y, _accel_offset_target_neu_cmss.y, _accel_offset_neu_cmss.y);
         }
     }
 
-    if (is_active_z()) {
-        Write_PSCD(-_pos_desired.z, -_pos_target.z, -_inav.get_position_z_up_cm(),
-                   -_vel_desired.z, -_vel_target.z, -_inav.get_velocity_z_up_cms(),
-                   -_accel_desired.z, -_accel_target.z, -get_z_accel_cmss());
+    if (is_active_U()) {
+        Write_PSCD(-_pos_desired_neu_cm.z, -_pos_target_neu_cm.z, -_inav.get_position_z_up_cm(),
+                   -_vel_desired_neu_cms.z, -_vel_target_neu_cms.z, -_inav.get_velocity_z_up_cms(),
+                   -_accel_desired_neu_cmss.z, -_accel_target_neu_cmss.z, -get_measured_accel_U_cmss());
 
         // log down and terrain offsets if they are being used
-        if (!is_zero(_pos_offset.z)) {
-            Write_PSOD(-_pos_offset_target.z, -_pos_offset.z, -_vel_offset_target.z, -_vel_offset.z, -_accel_offset_target.z, -_accel_offset.z);
+        if (!is_zero(_pos_offset_neu_cm.z)) {
+            Write_PSOD(-_pos_offset_target_neu_cm.z, -_pos_offset_neu_cm.z, -_vel_offset_target_neu_cms.z, -_vel_offset_neu_cms.z, -_accel_offset_target_neu_cmss.z, -_accel_offset_neu_cmss.z);
         }
-        if (!is_zero(_pos_terrain)) {
-            Write_PSOT(-_pos_terrain_target, -_pos_terrain, 0, -_vel_terrain, 0, -_accel_terrain);
+        if (!is_zero(_pos_terrain_u_cm)) {
+            Write_PSOT(-_pos_terrain_target_u_cm, -_pos_terrain_u_cm, 0, -_vel_terrain_u_cms, 0, -_accel_terrain_u_cmss);
         }
     }
 }
@@ -1400,13 +1402,13 @@ void AC_PosControl::write_log()
 /// crosstrack_error - returns horizontal error to the closest point to the current track
 float AC_PosControl::crosstrack_error() const
 {
-    const Vector2f pos_error = _inav.get_position_xy_cm() - (_pos_target.xy()).tofloat();
-    if (is_zero(_vel_desired.xy().length_squared())) {
+    const Vector2f pos_error = _inav.get_position_xy_cm() - (_pos_target_neu_cm.xy()).tofloat();
+    if (is_zero(_vel_desired_neu_cms.xy().length_squared())) {
         // crosstrack is the horizontal distance to target when stationary
         return pos_error.length();
     } else {
         // crosstrack is the horizontal distance to the closest point to the current track
-        const Vector2f vel_unit = _vel_desired.xy().normalized();
+        const Vector2f vel_unit = _vel_desired_neu_cms.xy().normalized();
         const float dot_error = pos_error * vel_unit;
 
         // todo: remove MAX of zero when safe_sqrt fixed
@@ -1426,8 +1428,9 @@ bool AC_PosControl::get_fwd_pitch_is_limited() const
     // Check for pitch limiting in the forward direction
     const float accel_fwd_unlimited = _limit_vector.x * _ahrs.cos_yaw() + _limit_vector.y * _ahrs.sin_yaw();
     const float pitch_target_unlimited = accel_to_angle(- MIN(accel_fwd_unlimited, accel_max) * 0.01f) * 100;
-    const float accel_fwd_limited = _accel_target.x * _ahrs.cos_yaw() + _accel_target.y * _ahrs.sin_yaw();
+    const float accel_fwd_limited = _accel_target_neu_cmss.x * _ahrs.cos_yaw() + _accel_target_neu_cmss.y * _ahrs.sin_yaw();
     const float pitch_target_limited = accel_to_angle(- accel_fwd_limited * 0.01f) * 100;
+
     return is_negative(pitch_target_unlimited) && pitch_target_unlimited < pitch_target_limited;
 }
 #endif // APM_BUILD_TYPE(APM_BUILD_ArduPlane)
@@ -1441,141 +1444,141 @@ bool AC_PosControl::get_fwd_pitch_is_limited() const
 /// update_z_offsets - updates the vertical offsets used by terrain following
 void AC_PosControl::update_terrain()
 {
-    // update position, velocity, accel offsets for this iteration
-    postype_t pos_terrain = _pos_terrain;
-    update_pos_vel_accel(pos_terrain, _vel_terrain, _accel_terrain, _dt, MIN(_limit_vector.z, 0.0f), _p_pos_z.get_error(), _pid_vel_z.get_error());
-    _pos_terrain = pos_terrain;
+    // update position, velocity, acceleration offsets for this iteration
+    postype_t pos_terrain_u_cm = _pos_terrain_u_cm;
+    update_pos_vel_accel(pos_terrain_u_cm, _vel_terrain_u_cms, _accel_terrain_u_cmss, _dt, MIN(_limit_vector.z, 0.0f), _p_pos_u.get_error(), _pid_vel_u.get_error());
+    _pos_terrain_u_cm = pos_terrain_u_cm;
 
     // input shape horizontal position, velocity and acceleration offsets
-    shape_pos_vel_accel(_pos_terrain_target, 0.0, 0.0,
-        _pos_terrain, _vel_terrain, _accel_terrain,
+    shape_pos_vel_accel(_pos_terrain_target_u_cm, 0.0, 0.0,
+        _pos_terrain_u_cm, _vel_terrain_u_cms, _accel_terrain_u_cmss,
         get_max_speed_down_cms(), get_max_speed_up_cms(),
-        -get_max_accel_z_cmss(), get_max_accel_z_cmss(),
-        _jerk_max_z_cmsss, _dt, false);
+        -get_max_accel_U_cmss(), get_max_accel_U_cmss(),
+        _jerk_max_u_cmsss, _dt, false);
 
-    // we do not have to update _pos_terrain_target because we assume the target velocity and acceleration are zero
-    // if we know how fast the terain altitude is changing we would add update_pos_vel_accel for _pos_terrain_target here
+    // we do not have to update _pos_terrain_target_u_cm because we assume the target velocity and acceleration are zero
+    // if we know how fast the terain altitude is changing we would add update_pos_vel_accel for _pos_terrain_target_u_cm here
 }
 
-// get_lean_angles_to_accel - convert roll, pitch lean angles to NE frame accelerations in cm/s/s
-void AC_PosControl::accel_to_lean_angles(float accel_x_cmss, float accel_y_cmss, float& roll_target, float& pitch_target) const
+// get_lean_angles_to_accel - convert NE frame accelerations in cm/s/s to roll, pitch lean angles in centi-degrees
+void AC_PosControl::accel_NE_cmss_to_lean_angles(float accel_n_cmss, float accel_e_cmss, float& roll_target_cd, float& pitch_target_cd) const
 {
     // rotate accelerations into body forward-right frame
-    const float accel_forward = accel_x_cmss * _ahrs.cos_yaw() + accel_y_cmss * _ahrs.sin_yaw();
-    const float accel_right = -accel_x_cmss * _ahrs.sin_yaw() + accel_y_cmss * _ahrs.cos_yaw();
+    const float accel_forward = accel_n_cmss * _ahrs.cos_yaw() + accel_e_cmss * _ahrs.sin_yaw();
+    const float accel_right = -accel_n_cmss * _ahrs.sin_yaw() + accel_e_cmss * _ahrs.cos_yaw();
 
     // update angle targets that will be passed to stabilize controller
-    pitch_target = accel_to_angle(-accel_forward * 0.01) * 100;
-    float cos_pitch_target = cosf(pitch_target * M_PI / 18000.0f);
-    roll_target = accel_to_angle((accel_right * cos_pitch_target)*0.01) * 100;
+    pitch_target_cd = accel_to_angle(-accel_forward * 0.01) * 100;
+    float cos_pitch_target = cosf(pitch_target_cd * M_PI / 18000.0f);
+    roll_target_cd = accel_to_angle((accel_right * cos_pitch_target)*0.01) * 100;
 }
 
-// lean_angles_to_accel_xy - convert roll, pitch lean target angles to NE frame accelerations in cm/s/s
+// lean_angles_to_accel_NE_cmss - convert roll, pitch lean target angles to NE frame accelerations in cm/s/s
 // todo: this should be based on thrust vector attitude control
-void AC_PosControl::lean_angles_to_accel_xy(float& accel_x_cmss, float& accel_y_cmss) const
+void AC_PosControl::lean_angles_to_accel_NE_cmss(float& accel_n_cmss, float& accel_e_cmss) const
 {
     // rotate our roll, pitch angles into lat/lon frame
     Vector3f att_target_euler = _attitude_control.get_att_target_euler_rad();
     att_target_euler.z = _ahrs.yaw;
-    Vector3f accel_cmss = lean_angles_to_accel(att_target_euler);
+    Vector3f accel_ne_cmss = lean_angles_to_accel(att_target_euler);
 
-    accel_x_cmss = accel_cmss.x;
-    accel_y_cmss = accel_cmss.y;
+    accel_n_cmss = accel_ne_cmss.x;
+    accel_e_cmss = accel_ne_cmss.y;
 }
 
 // calculate_yaw_and_rate_yaw - update the calculated the vehicle yaw and rate of yaw.
 void AC_PosControl::calculate_yaw_and_rate_yaw()
 {
     // Calculate the turn rate
-    float turn_rate = 0.0f;
-    const float vel_desired_xy_len = _vel_desired.xy().length();
-    if (is_positive(vel_desired_xy_len)) {
-        const float accel_forward = (_accel_desired.x * _vel_desired.x + _accel_desired.y * _vel_desired.y) / vel_desired_xy_len;
-        const Vector2f accel_turn = _accel_desired.xy() - _vel_desired.xy() * accel_forward / vel_desired_xy_len;
-        const float accel_turn_xy_len = accel_turn.length();
-        turn_rate = accel_turn_xy_len / vel_desired_xy_len;
-        if ((accel_turn.y * _vel_desired.x - accel_turn.x * _vel_desired.y) < 0.0) {
-            turn_rate = -turn_rate;
+    float turn_rate_rads = 0.0f;
+    const float vel_desired_length_ne_cms = _vel_desired_neu_cms.xy().length();
+    if (is_positive(vel_desired_length_ne_cms)) {
+        const float accel_forward = (_accel_desired_neu_cmss.x * _vel_desired_neu_cms.x + _accel_desired_neu_cmss.y * _vel_desired_neu_cms.y) / vel_desired_length_ne_cms;
+        const Vector2f accel_turn_ne_cmss = _accel_desired_neu_cmss.xy() - _vel_desired_neu_cms.xy() * accel_forward / vel_desired_length_ne_cms;
+        const float accel_turn_length_ne_cmss = accel_turn_ne_cmss.length();
+        turn_rate_rads = accel_turn_length_ne_cmss / vel_desired_length_ne_cms;
+        if ((accel_turn_ne_cmss.y * _vel_desired_neu_cms.x - accel_turn_ne_cmss.x * _vel_desired_neu_cms.y) < 0.0) {
+            turn_rate_rads = -turn_rate_rads;
         }
     }
 
-    // update the target yaw if velocity is greater than 5% _vel_max_xy_cms
-    if (vel_desired_xy_len > _vel_max_xy_cms * 0.05f) {
-        _yaw_target = degrees(_vel_desired.xy().angle()) * 100.0f;
-        _yaw_rate_target = turn_rate * degrees(100.0f);
+    // update the target yaw if velocity is greater than 5% _vel_max_ne_cms
+    if (vel_desired_length_ne_cms > _vel_max_ne_cms * 0.05f) {
+        _yaw_target_cd = degrees(_vel_desired_neu_cms.xy().angle()) * 100.0f;
+        _yaw_rate_target_cds = turn_rate_rads * degrees(100.0f);
         return;
     }
 
     // use the current attitude controller yaw target
-    _yaw_target = _attitude_control.get_att_target_euler_cd().z;
-    _yaw_rate_target = 0;
+    _yaw_target_cd = _attitude_control.get_att_target_euler_cd().z;
+    _yaw_rate_target_cds = 0;
 }
 
 // calculate_overspeed_gain - calculated increased maximum acceleration and jerk if over speed condition is detected
 float AC_PosControl::calculate_overspeed_gain()
 {
-    if (_vel_desired.z < _vel_max_down_cms && !is_zero(_vel_max_down_cms)) {
-        return POSCONTROL_OVERSPEED_GAIN_Z * _vel_desired.z / _vel_max_down_cms;
+    if (_vel_desired_neu_cms.z < _vel_max_down_cms && !is_zero(_vel_max_down_cms)) {
+        return POSCONTROL_OVERSPEED_GAIN_U * _vel_desired_neu_cms.z / _vel_max_down_cms;
     }
-    if (_vel_desired.z > _vel_max_up_cms && !is_zero(_vel_max_up_cms)) {
-        return POSCONTROL_OVERSPEED_GAIN_Z * _vel_desired.z / _vel_max_up_cms;
+    if (_vel_desired_neu_cms.z > _vel_max_up_cms && !is_zero(_vel_max_up_cms)) {
+        return POSCONTROL_OVERSPEED_GAIN_U * _vel_desired_neu_cms.z / _vel_max_up_cms;
     }
     return 1.0;
 }
 
 /// initialise ekf xy position reset check
-void AC_PosControl::init_ekf_xy_reset()
+void AC_PosControl::init_ekf_NE_reset()
 {
     Vector2f pos_shift;
-    _ekf_xy_reset_ms = _ahrs.getLastPosNorthEastReset(pos_shift);
+    _ekf_ne_reset_ms = _ahrs.getLastPosNorthEastReset(pos_shift);
 }
 
-/// handle_ekf_xy_reset - check for ekf position reset and adjust loiter or brake target position
-void AC_PosControl::handle_ekf_xy_reset()
+/// handle_ekf_NE_reset - check for ekf position reset and adjust loiter or brake target position
+void AC_PosControl::handle_ekf_NE_reset()
 {
     // check for position shift
     Vector2f pos_shift;
     uint32_t reset_ms = _ahrs.getLastPosNorthEastReset(pos_shift);
-    if (reset_ms != _ekf_xy_reset_ms) {
+    if (reset_ms != _ekf_ne_reset_ms) {
 
         // ToDo: move EKF steps into the offsets for modes setting absolute position and velocity
         // for this we need some sort of switch to select what type of EKF handling we want to use
 
         // To zero real position shift during relative position modes like Loiter, PosHold, Guided velocity and accleration control.
-        _pos_target.xy() = (_inav.get_position_xy_cm() + _p_pos_xy.get_error()).topostype();
-        _pos_desired.xy() = _pos_target.xy() - _pos_offset.xy();
-        _vel_target.xy() = _inav.get_velocity_xy_cms() + _pid_vel_xy.get_error();
-        _vel_desired.xy() = _vel_target.xy() - _vel_offset.xy();
+        _pos_target_neu_cm.xy() = (_inav.get_position_xy_cm() + _p_pos_ne.get_error()).topostype();
+        _pos_desired_neu_cm.xy() = _pos_target_neu_cm.xy() - _pos_offset_neu_cm.xy();
+        _vel_target_neu_cms.xy() = _inav.get_velocity_xy_cms() + _pid_vel_ne.get_error();
+        _vel_desired_neu_cms.xy() = _vel_target_neu_cms.xy() - _vel_offset_neu_cms.xy();
 
-        _ekf_xy_reset_ms = reset_ms;
+        _ekf_ne_reset_ms = reset_ms;
     }
 }
 
 /// initialise ekf z axis reset check
-void AC_PosControl::init_ekf_z_reset()
+void AC_PosControl::init_ekf_U_reset()
 {
-    float alt_shift;
-    _ekf_z_reset_ms = _ahrs.getLastPosDownReset(alt_shift);
+    float alt_shift_d_m;
+    _ekf_u_reset_ms = _ahrs.getLastPosDownReset(alt_shift_d_m);
 }
 
-/// handle_ekf_z_reset - check for ekf position reset and adjust loiter or brake target position
-void AC_PosControl::handle_ekf_z_reset()
+/// handle_ekf_U_reset - check for ekf position reset and adjust loiter or brake target position
+void AC_PosControl::handle_ekf_U_reset()
 {
     // check for position shift
-    float alt_shift;
-    uint32_t reset_ms = _ahrs.getLastPosDownReset(alt_shift);
-    if (reset_ms != 0 && reset_ms != _ekf_z_reset_ms) {
+    float alt_shift_d_m;
+    uint32_t reset_ms = _ahrs.getLastPosDownReset(alt_shift_d_m);
+    if (reset_ms != 0 && reset_ms != _ekf_u_reset_ms) {
 
         // ToDo: move EKF steps into the offsets for modes setting absolute position and velocity
         // for this we need some sort of switch to select what type of EKF handling we want to use
 
         // To zero real position shift during relative position modes like Loiter, PosHold, Guided velocity and accleration control.
-        _pos_target.z = _inav.get_position_z_up_cm() + _p_pos_z.get_error();
-        _pos_desired.z = _pos_target.z - (_pos_offset.z + _pos_terrain);
-        _vel_target.z = _inav.get_velocity_z_up_cms() + _pid_vel_z.get_error();
-        _vel_desired.z = _vel_target.z - (_vel_offset.z + _vel_terrain);
+        _pos_target_neu_cm.z = _inav.get_position_z_up_cm() + _p_pos_u.get_error();
+        _pos_desired_neu_cm.z = _pos_target_neu_cm.z - (_pos_offset_neu_cm.z + _pos_terrain_u_cm);
+        _vel_target_neu_cms.z = _inav.get_velocity_z_up_cms() + _pid_vel_u.get_error();
+        _vel_desired_neu_cms.z = _vel_target_neu_cms.z - (_vel_offset_neu_cms.z + _vel_terrain_u_cms);
 
-        _ekf_z_reset_ms = reset_ms;
+        _ekf_u_reset_ms = reset_ms;
     }
 }
 
@@ -1583,23 +1586,23 @@ bool AC_PosControl::pre_arm_checks(const char *param_prefix,
                                    char *failure_msg,
                                    const uint8_t failure_msg_len)
 {
-    if (!is_positive(get_pos_xy_p().kP())) {
+    if (!is_positive(get_pos_NE_p().kP())) {
         hal.util->snprintf(failure_msg, failure_msg_len, "%s_POSXY_P must be > 0", param_prefix);
         return false;
     }
-    if (!is_positive(get_pos_z_p().kP())) {
+    if (!is_positive(get_pos_U_p().kP())) {
         hal.util->snprintf(failure_msg, failure_msg_len, "%s_POSZ_P must be > 0", param_prefix);
         return false;
     }
-    if (!is_positive(get_vel_z_pid().kP())) {
+    if (!is_positive(get_vel_U_pid().kP())) {
         hal.util->snprintf(failure_msg, failure_msg_len, "%s_VELZ_P must be > 0", param_prefix);
         return false;
     }
-    if (!is_positive(get_accel_z_pid().kP())) {
+    if (!is_positive(get_accel_U_pid().kP())) {
         hal.util->snprintf(failure_msg, failure_msg_len, "%s_ACCZ_P must be > 0", param_prefix);
         return false;
     }
-    if (!is_positive(get_accel_z_pid().kI())) {
+    if (!is_positive(get_accel_U_pid().kI())) {
         hal.util->snprintf(failure_msg, failure_msg_len, "%s_ACCZ_I must be > 0", param_prefix);
         return false;
     }

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -17,8 +17,8 @@
 #include <AP_Logger/LogStructure.h>
 
 // position controller default definitions
-#define POSCONTROL_ACCEL_XY                     100.0f  // default horizontal acceleration in cm/s/s.  This is overwritten by waypoint and loiter controllers
-#define POSCONTROL_JERK_XY                      5.0f    // default horizontal jerk m/s/s/s
+#define POSCONTROL_ACCEL_NE                     100.0f  // default horizontal acceleration in cm/s/s.  This is overwritten by waypoint and loiter controllers
+#define POSCONTROL_JERK_NE                      5.0f    // default horizontal jerk m/s/s/s
 
 #define POSCONTROL_STOPPING_DIST_UP_MAX         300.0f  // max stopping distance (in cm) vertically while climbing
 #define POSCONTROL_STOPPING_DIST_DOWN_MAX       200.0f  // max stopping distance (in cm) vertically while descending
@@ -27,12 +27,12 @@
 #define POSCONTROL_SPEED_DOWN                  -150.0f  // default descent rate in cm/s
 #define POSCONTROL_SPEED_UP                     250.0f  // default climb rate in cm/s
 
-#define POSCONTROL_ACCEL_Z                      250.0f  // default vertical acceleration in cm/s/s.
-#define POSCONTROL_JERK_Z                       5.0f    // default vertical jerk m/s/s/s
+#define POSCONTROL_ACCEL_U                      250.0f  // default vertical acceleration in cm/s/s.
+#define POSCONTROL_JERK_U                       5.0f    // default vertical jerk m/s/s/s
 
 #define POSCONTROL_THROTTLE_CUTOFF_FREQ_HZ      2.0f    // low-pass filter on acceleration error (unit: Hz)
 
-#define POSCONTROL_OVERSPEED_GAIN_Z             2.0f    // gain controlling rate at which z-axis speed is brought back within SPEED_UP and SPEED_DOWN range
+#define POSCONTROL_OVERSPEED_GAIN_U             2.0f    // gain controlling rate at which z-axis speed is brought back within SPEED_UP and SPEED_DOWN range
 
 #define POSCONTROL_RELAX_TC                     0.16f   // This is used to decay the I term to 5% in half a second.
 
@@ -47,133 +47,134 @@ public:
     // do not allow copying
     CLASS_NO_COPY(AC_PosControl);
 
-    /// set_dt / get_dt - dt is the time since the last time the position controllers were updated
+    /// set_dt / get_dt - dt is the time in seconds since the last time the position controllers were updated
     ///   _dt should be set based on the time of the last IMU read used by these controllers
     ///   the position controller should run updates for active controllers on each loop to ensure normal operation
     void set_dt(float dt) { _dt = dt; }
     float get_dt() const { return _dt; }
 
-    /// get_shaping_jerk_xy_cmsss - gets the jerk limit of the xy kinematic path generation in cm/s/s/s
-    float get_shaping_jerk_xy_cmsss() const { return _shaping_jerk_xy * 100.0; }
+    /// get_shaping_jerk_NE_cmsss - gets the jerk limit of the ne kinematic path generation in cm/s/s/s
+    float get_shaping_jerk_NE_cmsss() const { return _shaping_jerk_ne_msss * 100.0; }
 
 
     ///
     /// 3D position shaper
     ///
 
-    /// input_pos_xyz - calculate a jerk limited path from the current position, velocity and acceleration to an input position.
-    ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
-    ///     The kinematic path is constrained by the maximum acceleration and jerk set using the function set_max_speed_accel_xy.
-    void input_pos_xyz(const Vector3p& pos, float pos_terrain_target, float terrain_buffer);
+    /// input_pos_NEU_cm - computes a jerk-limited trajectory from the current NEU position, velocity, and acceleration to a new position input (in cm).
+    /// This function updates the desired acceleration using a smooth kinematic path constrained by acceleration and jerk limits.
+    void input_pos_NEU_cm(const Vector3p& pos_neu_cm, float pos_terrain_target_alt_cm, float terrain_buffer_cm);
 
-    /// pos_offset_z_scaler - calculates a multiplier used to reduce the horizontal velocity to allow the z position controller to stay within the provided buffer range
-    float pos_offset_z_scaler(float pos_offset_z, float pos_offset_z_buffer) const;
+    /// pos_terrain_U_scaler - computes a scaling factor applied to horizontal velocity limits to ensure the vertical position controller remains within its terrain buffer.
+    float pos_terrain_U_scaler(float pos_terrain_u_cm, float pos_terrain_u_buffer_cm) const;
 
     ///
     /// Lateral position controller
     ///
 
-    /// set_max_speed_accel_xy - set the maximum horizontal speed in cm/s and acceleration in cm/s/s
+    /// set_max_speed_accel_NE_cm - set the maximum horizontal speed in cm/s and acceleration in cm/s/s
     ///     This function only needs to be called if using the kinematic shaping.
     ///     This can be done at any time as changes in these parameters are handled smoothly
     ///     by the kinematic shaping.
-    void set_max_speed_accel_xy(float speed_cms, float accel_cmss);
+    void set_max_speed_accel_NE_cm(float speed_cms, float accel_cmss);
 
-    /// set_max_speed_accel_xy - set the position controller correction velocity and acceleration limit
+    /// set_correction_speed_accel_NE_cm - set the position controller correction velocity and acceleration limit
     ///     This should be done only during initialisation to avoid discontinuities
-    void set_correction_speed_accel_xy(float speed_cms, float accel_cmss);
+    void set_correction_speed_accel_NE_cm(float speed_cms, float accel_cmss);
 
-    /// get_max_speed_xy_cms - get the maximum horizontal speed in cm/s
-    float get_max_speed_xy_cms() const { return _vel_max_xy_cms; }
+    /// get_max_speed_NE_cms - get the maximum horizontal speed in cm/s
+    float get_max_speed_NE_cms() const { return _vel_max_ne_cms; }
 
-    /// get_max_accel_xy_cmss - get the maximum horizontal acceleration in cm/s/s
-    float get_max_accel_xy_cmss() const { return _accel_max_xy_cmss; }
+    /// get_max_accel_NE_cmss - get the maximum horizontal acceleration in cm/s/s
+    float get_max_accel_NE_cmss() const { return _accel_max_ne_cmss; }
 
-    // set the maximum horizontal position error that will be allowed in the horizontal plane
-    void set_pos_error_max_xy_cm(float error_max) { _p_pos_xy.set_error_max(error_max); }
-    float get_pos_error_max_xy_cm() { return _p_pos_xy.get_error_max(); }
+    // set_pos_error_max_NE_cm - set the maximum horizontal position error that will be allowed in the horizontal plane
+    void set_pos_error_max_NE_cm(float error_max_cm) { _p_pos_ne.set_error_max(error_max_cm); }
 
-    /// init_xy_controller_stopping_point - initialise the position controller to the stopping point with zero velocity and acceleration.
+    // get_pos_error_max_NE_cm - return the maximum horizontal position error that will be allowed in the horizontal plane
+    float get_pos_error_max_NE_cm() { return _p_pos_ne.get_error_max(); }
+
+    /// init_NE_controller_stopping_point - initialise the position controller to the stopping point with zero velocity and acceleration.
     ///     This function should be used when the expected kinematic path assumes a stationary initial condition but does not specify a specific starting position.
-    ///     The starting position can be retrieved by getting the position target using get_pos_target_cm() after calling this function.
-    void init_xy_controller_stopping_point();
+    ///     The starting position can be retrieved by getting the position target using get_pos_target_NEU_cm() after calling this function.
+    void init_NE_controller_stopping_point();
 
-    // relax_velocity_controller_xy - initialise the position controller to the current position and velocity with decaying acceleration.
-    ///     This function decays the output acceleration by 95% every half second to achieve a smooth transition to zero requested acceleration.
-    void relax_velocity_controller_xy();
+    // relax_velocity_controller_NE - initialise the position controller to the current position and velocity with decaying acceleration.
+    ///     This function exponentially decays the acceleration output by ~95% over 0.5 seconds to achieve a smooth transition to zero requested acceleration.
+    void relax_velocity_controller_NE();
 
-    /// reduce response for landing
-    void soften_for_landing_xy();
+    /// Reduces controller response for landing by decaying position error and preventing I-term windup.
+    void soften_for_landing_NE();
 
-    // init_xy_controller - initialise the position controller to the current position, velocity, acceleration and attitude.
+    // init_NE_controller - initialise the position controller to the current position, velocity, acceleration and attitude.
     ///     This function is the default initialisation for any position control that provides position, velocity and acceleration.
-    ///     This function is private and contains all the shared xy axis initialisation functions
-    void init_xy_controller();
+    ///     This function is private and contains all the shared ne axis initialisation functions
+    void init_NE_controller();
 
-    /// input_accel_xy - calculate a jerk limited path from the current position, velocity and acceleration to an input acceleration.
+    /// input_accel_NE_cm - computes a jerk-limited trajectory to smoothly reach the specified acceleration in the NE plane from the current position, velocity, and acceleration.
     ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
-    ///     The kinematic path is constrained by the maximum acceleration and jerk set using the function set_max_speed_accel_xy.
+    ///     The kinematic path is constrained by the maximum acceleration and jerk set using the function set_max_speed_accel_ne.
     ///     The jerk limit defines the acceleration error decay in the kinematic path as the system approaches constant acceleration.
     ///     The jerk limit also defines the time taken to achieve the maximum acceleration.
-    void input_accel_xy(const Vector3f& accel);
+    void input_accel_NE_cm(const Vector3f& accel_neu_cmsss);
 
-    /// input_vel_accel_xy - calculate a jerk limited path from the current position, velocity and acceleration to an input velocity and acceleration.
+    /// input_vel_accel_NE_cm - calculate a jerk limited path from the current position, velocity and acceleration to an input velocity and acceleration.
     ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
-    ///     The kinematic path is constrained by the maximum acceleration and jerk set using the function set_max_speed_accel_xy.
-    ///     The function alters the vel to be the kinematic path based on accel
+    ///     The kinematic path is constrained by the maximum acceleration and jerk set using the function set_max_speed_accel_ne.
+    ///     The function modifies vel_ne_cms to follow the kinematic trajectory toward accel_cmss.
     ///     The parameter limit_output specifies if the velocity and acceleration limits are applied to the sum of commanded and correction values or just correction.
-    void input_vel_accel_xy(Vector2f& vel, const Vector2f& accel, bool limit_output = true);
+    void input_vel_accel_NE_cm(Vector2f& vel_ne_cms, const Vector2f& accel_ne_cmss, bool limit_output = true);
 
-    /// input_pos_vel_accel_xy - calculate a jerk limited path from the current position, velocity and acceleration to an input position velocity and acceleration.
+    /// input_pos_vel_accel_NE_cm - calculate a jerk limited path from the current position, velocity and acceleration to an input position velocity and acceleration.
     ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
-    ///     The kinematic path is constrained by the maximum acceleration and jerk set using the function set_max_speed_accel_xy.
-    ///     The function alters the pos and vel to be the kinematic path based on accel
+    ///     The kinematic path is constrained by the maximum acceleration and jerk set using the function set_max_speed_accel_ne.
+    ///     The function modifies pos_ne_cm and vel_ne_cms to follow the jerk-limited trajectory defined by accel_ne_cmss.
     ///     The parameter limit_output specifies if the velocity and acceleration limits are applied to the sum of commanded and correction values or just correction.
-    void input_pos_vel_accel_xy(Vector2p& pos, Vector2f& vel, const Vector2f& accel, bool limit_output = true);
+    void input_pos_vel_accel_NE_cm(Vector2p& pos_ne_cm, Vector2f& vel_ne_cms, const Vector2f& accel_ne_cmss, bool limit_output = true);
 
-    // is_active_xy - returns true if the xy position controller has been run in the previous 5 loop times
-    bool is_active_xy() const;
+    // is_active_NE - returns true if the ne position controller has been run in the previous 5 loop times
+    bool is_active_NE() const;
 
-    /// stop_pos_xy_stabilisation - sets the target to the current position to remove any position corrections from the system
-    void stop_pos_xy_stabilisation();
+    /// stop_pos_NE_stabilisation - sets the target to the current position to remove any position corrections from the system
+    void stop_pos_NE_stabilisation();
 
-    /// stop_vel_xy_stabilisation - sets the target to the current position and velocity to the current velocity to remove any position and velocity corrections from the system
-    void stop_vel_xy_stabilisation();
+    /// stop_vel_NE_stabilisation - sets the target to the current position and velocity to the current velocity to remove any position and velocity corrections from the system
+    void stop_vel_NE_stabilisation();
 
-    /// set a single loop XY control scale factor. Set to zero to disable
-    void set_xy_control_scale_factor(float xy_scale_factor) {
-        _xy_control_scale_factor = xy_scale_factor;
+    /// set a single loop ne control scale factor. Set to zero to disable
+    void set_NE_control_scale_factor(float ne_control_scale_factor) {
+        _ne_control_scale_factor = ne_control_scale_factor;
     }
 
-    /// update_xy_controller - runs the horizontal position controller correcting position, velocity and acceleration errors.
+    /// update_NE_controller - runs the horizontal position controller correcting position, velocity and acceleration errors.
     ///     Position and velocity errors are converted to velocity and acceleration targets using PID objects
     ///     Desired velocity and accelerations are added to these corrections as they are calculated
     ///     Kinematically consistent target position and desired velocity and accelerations should be provided before calling this function
-    void update_xy_controller();
+    void update_NE_controller();
 
     ///
     /// Vertical position controller
     ///
 
-    /// set_max_speed_accel_z - set the maximum vertical speed in cm/s and acceleration in cm/s/s
-    ///     speed_down can be positive or negative but will always be interpreted as a descent speed
+    /// set_max_speed_accel_U_cmss - set the maximum vertical speed in cm/s and acceleration in cm/s/s
+    ///     speed_down_cms may be positive or negative, but it is always interpreted as a descent rate.
     ///     This can be done at any time as changes in these parameters are handled smoothly
     ///     by the kinematic shaping.
-    void set_max_speed_accel_z(float speed_down, float speed_up, float accel_cmss);
+    void set_max_speed_accel_U_cm(float speed_down_cms, float speed_up_cms, float accel_cmss);
 
-    /// set_correction_speed_accel_z - set the position controller correction velocity and acceleration limit
-    ///     speed_down can be positive or negative but will always be interpreted as a descent speed
+    /// set_correction_speed_accel_U_cmss - set the position controller correction velocity and acceleration limit
+    ///     speed_down_cms may be positive or negative, but it is always interpreted as a descent rate.
     ///     This should be done only during initialisation to avoid discontinuities
-    void set_correction_speed_accel_z(float speed_down, float speed_up, float accel_cmss);
+    void set_correction_speed_accel_U_cmss(float speed_down_cms, float speed_up_cms, float accel_cmss);
 
-    /// get_max_accel_z_cmss - get the maximum vertical acceleration in cm/s/s
-    float get_max_accel_z_cmss() const { return _accel_max_z_cmss; }
+    /// get_max_accel_U_cmss - get the maximum vertical acceleration in cm/s/s
+    float get_max_accel_U_cmss() const { return _accel_max_u_cmss; }
 
-    // get_pos_error_z_up_cm - get the maximum vertical position error up that will be allowed
-    float get_pos_error_z_up_cm() { return _p_pos_z.get_error_max(); }
+    // get_pos_error_up_cm - get the allowed upper bound of vertical position error (positive direction)
+    float get_pos_error_up_cm() { return _p_pos_u.get_error_max(); }
 
-    // get_pos_error_z_down_cm - get the maximum vertical position error down that will be allowed
-    float get_pos_error_z_down_cm() { return _p_pos_z.get_error_min(); }
+    // get_pos_error_down_cm - get the allowed lower bound of vertical position error (negative direction)
+    float get_pos_error_down_cm() { return _p_pos_u.get_error_min(); }
 
     /// get_max_speed_up_cms - accessors for current maximum up speed in cm/s
     float get_max_speed_up_cms() const { return _vel_max_up_cms; }
@@ -181,65 +182,65 @@ public:
     /// get_max_speed_down_cms - accessors for current maximum down speed in cm/s.  Will be a negative number
     float get_max_speed_down_cms() const { return _vel_max_down_cms; }
 
-    /// init_z_controller_no_descent - initialise the position controller to the current position, velocity, acceleration and attitude.
+    /// init_U_controller_no_descent - initialise the position controller to the current position, velocity, acceleration and attitude.
     ///     This function is the default initialisation for any position control that provides position, velocity and acceleration.
     ///     This function does not allow any negative velocity or acceleration
-    void init_z_controller_no_descent();
+    void init_U_controller_no_descent();
 
-    /// init_z_controller_stopping_point - initialise the position controller to the stopping point with zero velocity and acceleration.
+    /// init_U_controller_stopping_point - initialise the position controller to the stopping point with zero velocity and acceleration.
     ///     This function should be used when the expected kinematic path assumes a stationary initial condition but does not specify a specific starting position.
-    ///     The starting position can be retrieved by getting the position target using get_pos_target_cm() after calling this function.
-    void init_z_controller_stopping_point();
+    ///     The starting position can be retrieved by getting the position target using get_pos_target_NEU_cm() after calling this function.
+    void init_U_controller_stopping_point();
 
-    // relax_z_controller - initialise the position controller to the current position and velocity with decaying acceleration.
+    // relax_U_controller - initialise the position controller to the current position and velocity with decaying acceleration.
     ///     This function decays the output acceleration by 95% every half second to achieve a smooth transition to zero requested acceleration.
-    void relax_z_controller(float throttle_setting);
+    void relax_U_controller(float throttle_setting);
 
-    // init_z_controller - initialise the position controller to the current position, velocity, acceleration and attitude.
+    // init_U_controller - initialise the position controller to the current position, velocity, acceleration and attitude.
     ///     This function is the default initialisation for any position control that provides position, velocity and acceleration.
     ///     This function is private and contains all the shared z axis initialisation functions
-    void init_z_controller();
+    void init_U_controller();
 
-    /// input_accel_z - calculate a jerk limited path from the current position, velocity and acceleration to an input acceleration.
+    /// input_accel_U_cm - calculate a jerk limited path from the current position, velocity and acceleration to an input acceleration.
     ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
     ///     The kinematic path is constrained by the maximum acceleration and jerk set using the function set_max_speed_accel_z.
-    virtual void input_accel_z(float accel);
+    virtual void input_accel_U_cm(float accel_u_cmss);
 
-    /// input_vel_accel_z - calculate a jerk limited path from the current position, velocity and acceleration to an input velocity and acceleration.
+    /// input_vel_accel_U_cm - calculate a jerk limited path from the current position, velocity and acceleration to an input velocity and acceleration.
     ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
     ///     The kinematic path is constrained by the maximum acceleration and jerk set using the function set_max_speed_accel_z.
-    ///     The function alters the vel to be the kinematic path based on accel
+    ///     The function modifies vel_u_cms to follow the jerk-limited trajectory defined by accel_u_cmss.
     ///     The parameter limit_output specifies if the velocity and acceleration limits are applied to the sum of commanded and correction values or just correction.
-    virtual void input_vel_accel_z(float &vel, float accel, bool limit_output = true);
+    virtual void input_vel_accel_U_cm(float &vel_u_cms, float accel_u_cmss, bool limit_output = true);
 
-    /// set_pos_target_z_from_climb_rate_cm - adjusts target up or down using a commanded climb rate in cm/s
-    ///     using the default position control kinematic path.
-    ///     The zero target altitude is varied to follow pos_offset_z
-    void set_pos_target_z_from_climb_rate_cm(float vel);
+    /// set_pos_target_U_from_climb_rate_cm - adjusts target up or down using a commanded climb rate in cm/s
+    ///     using the default jerk-limited kinematic shaping method.
+    ///     The zero target altitude is varied to follow pos_offset_u
+    void set_pos_target_U_from_climb_rate_cm(float vel_u_cms);
 
     /// land_at_climb_rate_cm - adjusts target up or down using a commanded climb rate in cm/s
-    ///     using the default position control kinematic path.
+    ///     using the default jerk-limited kinematic shaping method.
     ///     ignore_descent_limit turns off output saturation handling to aid in landing detection. ignore_descent_limit should be true unless landing.
-    void land_at_climb_rate_cm(float vel, bool ignore_descent_limit);
+    void land_at_climb_rate_cm(float vel_u_cms, bool ignore_descent_limit);
 
-    /// input_pos_vel_accel_z - calculate a jerk limited path from the current position, velocity and acceleration to an input position velocity and acceleration.
+    /// input_pos_vel_accel_U_cm - calculate a jerk limited path from the current position, velocity and acceleration to an input position velocity and acceleration.
     ///     The function takes the current position, velocity, and acceleration and calculates the required jerk limited adjustment to the acceleration for the next time dt.
-    ///     The function alters the pos and vel to be the kinematic path based on accel
+    ///     The function alters the pos_u_cm and vel_u_cms to be the kinematic path based on accel_u_cmss
     ///     The parameter limit_output specifies if the velocity and acceleration limits are applied to the sum of commanded and correction values or just correction.
-    void input_pos_vel_accel_z(float &pos, float &vel, float accel, bool limit_output = true);
+    void input_pos_vel_accel_U_cm(float &pos_u_cm, float &vel_u_cms, float accel_u_cmss, bool limit_output = true);
 
-    /// set_alt_target_with_slew - adjusts target up or down using a commanded altitude in cm
-    ///     using the default position control kinematic path.
-    void set_alt_target_with_slew(float pos);
+    /// set_alt_target_with_slew_cm - adjusts target up or down using a commanded altitude in cm
+    ///     using the default jerk-limited kinematic shaping method.
+    void set_alt_target_with_slew_cm(float pos_u_cm);
 
-    // is_active_z - returns true if the z position controller has been run in the previous 5 loop times
-    bool is_active_z() const;
+    // is_active_U - returns true if the z position controller has been run in the previous 5 loop times
+    bool is_active_U() const;
 
-    /// update_z_controller - runs the vertical position controller correcting position, velocity and acceleration errors.
+    /// update_U_controller - runs the vertical position controller correcting position, velocity and acceleration errors.
     ///     Position and velocity errors are converted to velocity and acceleration targets using PID objects
     ///     Desired velocity and accelerations are added to these corrections as they are calculated
     ///     Kinematically consistent target position and desired velocity and accelerations should be provided before calling this function
-    void update_z_controller();
+    void update_U_controller();
 
 
 
@@ -248,92 +249,92 @@ public:
     ///
 
     /// set commanded position (cm), velocity (cm/s) and acceleration (cm/s/s) inputs when the path is created externally.
-    void set_pos_vel_accel(const Vector3p& pos, const Vector3f& vel, const Vector3f& accel);
-    void set_pos_vel_accel_xy(const Vector2p& pos, const Vector2f& vel, const Vector2f& accel);
+    void set_pos_vel_accel_NEU_cm(const Vector3p& pos_neu_cm, const Vector3f& vel_neu_cms, const Vector3f& accel_neu_cmss);
+    void set_pos_vel_accel_NE_cm(const Vector2p& pos_ne_cm, const Vector2f& vel_ne_cms, const Vector2f& accel_ne_cmss);
 
 
     /// Position
 
-    /// get_pos_target_cm - returns the position target, frame NEU in cm relative to the EKF origin
-    const Vector3p& get_pos_target_cm() const { return _pos_target; }
+    /// get_pos_target_NEU_cm - returns the position target, frame NEU in cm relative to the EKF origin
+    const Vector3p& get_pos_target_NEU_cm() const { return _pos_target_neu_cm; }
 
-    /// set_pos_desired_xy_cm - sets the position target, frame NEU in cm relative to the EKF origin
-    void set_pos_desired_xy_cm(const Vector2f& pos) { _pos_desired.xy() = pos.topostype(); }
+    /// set_pos_desired_NE_cm - sets the position target, frame NEU in cm relative to the EKF origin
+    void set_pos_desired_NE_cm(const Vector2f& pos_desired_ne_cm) { _pos_desired_neu_cm.xy() = pos_desired_ne_cm.topostype(); }
 
-    /// get_pos_desired_cm - returns the position desired, frame NEU in cm relative to the EKF origin
-    const Vector3p& get_pos_desired_cm() const { return _pos_desired; }
+    /// get_pos_desired_NEU_cm - returns the position desired, frame NEU in cm relative to the EKF origin
+    const Vector3p& get_pos_desired_NEU_cm() const { return _pos_desired_neu_cm; }
 
-    /// get_pos_target_z_cm - get target altitude (in cm above the EKF origin)
-    float get_pos_target_z_cm() const { return _pos_target.z; }
+    /// get_pos_target_U_cm - get target altitude (in cm above the EKF origin)
+    float get_pos_target_U_cm() const { return _pos_target_neu_cm.z; }
 
-    /// set_pos_desired_z_cm - set altitude target in cm above the EKF origin
-    void set_pos_desired_z_cm(float pos_z) { _pos_desired.z = pos_z; }
+    /// set_pos_desired_U_cm - set altitude target in cm above the EKF origin
+    void set_pos_desired_U_cm(float pos_desired_u_cm) { _pos_desired_neu_cm.z = pos_desired_u_cm; }
 
-    /// get_pos_desired_z_cm - get target altitude (in cm above the EKF origin)
-    float get_pos_desired_z_cm() const { return _pos_desired.z; }
+    /// get_pos_desired_U_cm - get target altitude (in cm above the EKF origin)
+    float get_pos_desired_U_cm() const { return _pos_desired_neu_cm.z; }
 
 
     /// Stopping Point
 
-    /// get_stopping_point_xy_cm - calculates stopping point in NEU cm based on current position, velocity, vehicle acceleration
-    void get_stopping_point_xy_cm(Vector2p &stopping_point) const;
+    /// get_stopping_point_NE_cm - calculates stopping point in NEU cm based on current position, velocity, vehicle acceleration
+    void get_stopping_point_NE_cm(Vector2p &stopping_point_neu_cm) const;
 
-    /// get_stopping_point_z_cm - calculates stopping point in NEU cm based on current position, velocity, vehicle acceleration
-    void get_stopping_point_z_cm(postype_t &stopping_point) const;
+    /// get_stopping_point_U_cm - calculates stopping point in NEU cm based on current position, velocity, vehicle acceleration
+    void get_stopping_point_U_cm(postype_t &stopping_point_u_cm) const;
 
 
     /// Position Error
 
-    /// get_pos_error_cm - get position error vector between the current and target position
-    const Vector3f get_pos_error_cm() const { return Vector3f(_p_pos_xy.get_error().x, _p_pos_xy.get_error().y, _p_pos_z.get_error()); }
+    /// get_pos_error_NEU_cm - returns the 3D position error vector between the current and target NEU positions.
+    const Vector3f get_pos_error_NEU_cm() const { return Vector3f(_p_pos_ne.get_error().x, _p_pos_ne.get_error().y, _p_pos_u.get_error()); }
 
-    /// get_pos_error_xy_cm - get the length of the position error vector in the xy plane
-    float get_pos_error_xy_cm() const { return _p_pos_xy.get_error().length(); }
+    /// get_pos_error_NE_cm - get the length of the position error vector in the ne plane
+    float get_pos_error_NE_cm() const { return _p_pos_ne.get_error().length(); }
 
-    /// get_pos_error_z_cm - returns altitude error in cm
-    float get_pos_error_z_cm() const { return _p_pos_z.get_error(); }
+    /// get_pos_error_U_cm - returns altitude error in cm
+    float get_pos_error_U_cm() const { return _p_pos_u.get_error(); }
 
 
     /// Velocity
 
-    /// set_vel_desired_cms - sets desired velocity in NEU cm/s
-    void set_vel_desired_cms(const Vector3f &des_vel) { _vel_desired = des_vel; }
+    /// set_vel_desired_NEU_cms - sets desired velocity in NEU cm/s
+    void set_vel_desired_NEU_cms(const Vector3f &vel_desired_neu_cms) { _vel_desired_neu_cms = vel_desired_neu_cms; }
 
-    /// set_vel_desired_xy_cms - sets horizontal desired velocity in NEU cm/s
-    void set_vel_desired_xy_cms(const Vector2f &vel) {_vel_desired.xy() = vel; }
+    /// set_vel_desired_NE_cms - sets the desired horizontal velocity (NE only) in cm/s.
+    void set_vel_desired_NE_cms(const Vector2f &vel_desired_ne_cms) {_vel_desired_neu_cms.xy() = vel_desired_ne_cms; }
 
-    /// get_vel_desired_cms - returns desired velocity in cm/s in NEU
-    const Vector3f& get_vel_desired_cms() { return _vel_desired; }
+    /// get_vel_desired_NEU_cms - returns desired velocity in cm/s in NEU
+    const Vector3f& get_vel_desired_NEU_cms() { return _vel_desired_neu_cms; }
 
-    // get_vel_target_cms - returns the target velocity in NEU cm/s
-    const Vector3f& get_vel_target_cms() const { return _vel_target; }
+    // get_vel_target_NEU_cms - returns the target velocity in NEU cm/s
+    const Vector3f& get_vel_target_NEU_cms() const { return _vel_target_neu_cms; }
 
-    /// set_vel_desired_z_cms - sets desired velocity in cm/s in z axis
-    void set_vel_desired_z_cms(float vel_z_cms) {_vel_desired.z = vel_z_cms;}
+    /// set_vel_desired_U_cms - sets desired velocity in cm/s in z axis
+    void set_vel_desired_U_cms(float vel_desired_u_cms) {_vel_desired_neu_cms.z = vel_desired_u_cms;}
 
-    /// get_vel_target_z_cms - returns target vertical speed in cm/s
-    float get_vel_target_z_cms() const { return _vel_target.z; }
+    /// get_vel_target_U_cms - returns target vertical speed in cm/s
+    float get_vel_target_U_cms() const { return _vel_target_neu_cms.z; }
 
 
     /// Acceleration
 
-    // set_accel_desired_xy_cmss - set desired acceleration in cm/s in xy axis
-    void set_accel_desired_xy_cmss(const Vector2f &accel_cms) { _accel_desired.xy() = accel_cms; }
+    // set_accel_desired_NE_cmss - set desired acceleration in cm/s in ne axis
+    void set_accel_desired_NE_cmss(const Vector2f &accel_desired_neu_cmss) { _accel_desired_neu_cmss.xy() = accel_desired_neu_cmss; }
 
-    // get_accel_target_cmss - returns the target acceleration in NEU cm/s/s
-    const Vector3f& get_accel_target_cmss() const { return _accel_target; }
+    // get_accel_target_NEU_cmss - returns the target acceleration in NEU cm/s/s
+    const Vector3f& get_accel_target_NEU_cmss() const { return _accel_target_neu_cmss; }
 
 
     /// Terrain
 
-    // set_pos_terrain_target_cm - set target terrain altitude in cm
-    void set_pos_terrain_target_cm(float pos_terrain_target) {_pos_terrain_target = pos_terrain_target;}
+    // set_pos_terrain_target_U_cm - set target terrain altitude in cm
+    void set_pos_terrain_target_U_cm(float pos_terrain_target_u_cm) {_pos_terrain_target_u_cm = pos_terrain_target_u_cm;}
 
-    // init_pos_terrain_cm - initialises the current terrain altitude and target altitude to pos_offset_terrain_cm
-    void init_pos_terrain_cm(float pos_offset_terrain_cm);
+    // init_pos_terrain_U_cm - initialises the current terrain altitude and target altitude to pos_offset_terrain_cm
+    void init_pos_terrain_U_cm(float pos_terrain_u_cm);
 
-    // get_pos_terrain_cm - returns the current terrain altitude in cm
-    float get_pos_terrain_cm() { return _pos_terrain; }
+    // get_pos_terrain_U_cm - returns the current terrain altitude in cm
+    float get_pos_terrain_U_cm() { return _pos_terrain_u_cm; }
 
 
     /// Offset
@@ -352,39 +353,39 @@ public:
     bool get_accel_target(Vector3f &accel_target_NED);
 #endif
 
-    /// set the horizontal position, velocity and acceleration offset targets in cm, cms and cm/s/s from EKF origin in NE frame
-    /// these must be set every 3 seconds (or less) or they will timeout and return to zero
-    void set_posvelaccel_offset_target_xy_cm(const Vector2p& pos_offset_target_xy_cm, const Vector2f& vel_offset_target_xy_cms, const Vector2f& accel_offset_target_xy_cmss);
-    void set_posvelaccel_offset_target_z_cm(float pos_offset_target_z_cm, float vel_offset_target_z_cms, float accel_offset_target_z_cmss);
+    /// set the horizontal position, velocity and acceleration offset targets in cm, cms and cm/s/s from EKF origin in NE frame.
+    /// These offsets must be updated at least every 3 seconds or they will timeout and revert to zero.
+    void set_posvelaccel_offset_target_NE_cm(const Vector2p& pos_offset_target_ne_cm, const Vector2f& vel_offset_target_ne_cms, const Vector2f& accel_offset_target_ne_cmss);
+    void set_posvelaccel_offset_target_U_cm(float pos_offset_target_u_cm, float vel_offset_target_u_cms, float accel_offset_target_u_cmss);
 
     /// get the position, velocity or acceleration offets in cm from EKF origin in NEU frame
-    const Vector3p& get_pos_offset_cm() const { return _pos_offset; }
-    const Vector3f& get_vel_offset_cms() const { return _vel_offset; }
-    const Vector3f& get_accel_offset_cmss() const { return _accel_offset; }
+    const Vector3p& get_pos_offset_NEU_cm() const { return _pos_offset_neu_cm; }
+    const Vector3f& get_vel_offset_NEU_cms() const { return _vel_offset_neu_cms; }
+    const Vector3f& get_accel_offset_NEU_cmss() const { return _accel_offset_neu_cmss; }
 
-    /// set_pos_offset_z_cm - set altitude offset in cm above the EKF origin
-    void set_pos_offset_z_cm(float pos_offset_z) { _pos_offset.z = pos_offset_z; }
+    /// set_pos_offset_U_cm - set altitude offset in cm above the EKF origin
+    void set_pos_offset_U_cm(float pos_offset_u) { _pos_offset_neu_cm.z = pos_offset_u; }
 
-    /// get_pos_offset_z_cm - returns altitude offset in cm above the EKF origin
-    float get_pos_offset_z_cm() const { return _pos_offset.z; }
+    /// get_pos_offset_U_cm - returns altitude offset in cm above the EKF origin
+    float get_pos_offset_U_cm() const { return _pos_offset_neu_cm.z; }
 
-    /// get_vel_offset_z_cm - returns current vertical offset speed in cm/s
-    float get_vel_offset_z_cms() const { return _vel_offset.z; }
+    /// get_vel_offset_U_cms - returns current vertical offset speed in cm/s
+    float get_vel_offset_U_cms() const { return _vel_offset_neu_cms.z; }
 
-    /// get_accel_offset_z_cm - returns current vertical offset acceleration in cm/s/s
-    float get_accel_offset_z_cmss() const { return _accel_offset.z; }
+    /// get_accel_offset_U_cmss - returns current vertical offset acceleration in cm/s/s
+    float get_accel_offset_U_cmss() const { return _accel_offset_neu_cmss.z; }
 
     /// Outputs
 
     /// get desired roll and pitch to be passed to the attitude controller
-    float get_roll_cd() const { return _roll_target; }
-    float get_pitch_cd() const { return _pitch_target; }
+    float get_roll_cd() const { return _roll_target_cd; }
+    float get_pitch_cd() const { return _pitch_target_cd; }
 
     /// get desired yaw to be passed to the attitude controller
-    float get_yaw_cd() const { return _yaw_target; }
+    float get_yaw_cd() const { return _yaw_target_cd; }
 
     /// get desired yaw rate to be passed to the attitude controller
-    float get_yaw_rate_cds() const { return _yaw_rate_target; }
+    float get_yaw_rate_cds() const { return _yaw_rate_target_cds; }
 
     /// get desired roll and pitch to be passed to the attitude controller
     Vector3f get_thrust_vector() const;
@@ -397,7 +398,7 @@ public:
 
     /*
       set_lean_angle_max_cd - set the maximum lean angle. A value of zero means to use the ANGLE_MAX parameter.
-      This is reset to zero on init_xy_controller()
+      This is reset to zero on init_NE_controller()
     */
     void set_lean_angle_max_cd(float angle_max_cd) { _angle_max_override_cd = angle_max_cd; }
     
@@ -405,15 +406,15 @@ public:
     /// Other
 
     /// get pid controllers
-    AC_P_2D& get_pos_xy_p() { return _p_pos_xy; }
-    AC_P_1D& get_pos_z_p() { return _p_pos_z; }
-    AC_PID_2D& get_vel_xy_pid() { return _pid_vel_xy; }
-    AC_PID_Basic& get_vel_z_pid() { return _pid_vel_z; }
-    AC_PID& get_accel_z_pid() { return _pid_accel_z; }
+    AC_P_2D& get_pos_NE_p() { return _p_pos_ne; }
+    AC_P_1D& get_pos_U_p() { return _p_pos_u; }
+    AC_PID_2D& get_vel_NE_pid() { return _pid_vel_ne; }
+    AC_PID_Basic& get_vel_U_pid() { return _pid_vel_u; }
+    AC_PID& get_accel_U_pid() { return _pid_accel_u; }
 
-    /// set_limit_accel_xy - mark that accel has been limited
-    ///     this prevents integrator buildup
-    void set_externally_limited_xy() { _limit_vector.x = _accel_target.x; _limit_vector.y = _accel_target.y; }
+    /// set_externally_limited_NE - mark that accel has been limited
+    ///     this prevents integrator windup during external acceleration saturation
+    void set_externally_limited_NE() { _limit_vector.x = _accel_target_neu_cmss.x; _limit_vector.y = _accel_target_neu_cmss.y; }
 
     // lean_angles_to_accel - convert roll, pitch lean angles to lat/lon frame accelerations in cm/s/s
     Vector3f lean_angles_to_accel(const Vector3f& att_target_euler) const;
@@ -429,35 +430,35 @@ public:
     // enable or disable high vibration compensation
     void set_vibe_comp(bool on_off) { _vibe_comp_enabled = on_off; }
 
-    /// get_vel_z_error_ratio - returns the proportion of error relative to the maximum request
-    float get_vel_z_control_ratio() const { return constrain_float(_vel_z_control_ratio, 0.0f, 1.0f); }
+    /// get_vel_U_control_ratio - returns the proportion of control authority used on the vertical axis (0 to 1)
+    float get_vel_U_control_ratio() const { return constrain_float(_vel_u_control_ratio, 0.0f, 1.0f); }
 
     /// crosstrack_error - returns horizontal error to the closest point to the current track
     float crosstrack_error() const;
 
-    /// standby_xyz_reset - resets I terms and removes position error
+    /// standby_NEU_reset - resets I terms and removes position error
     ///     This function will let Loiter and Alt Hold continue to operate
     ///     in the event that the flight controller is in control of the
     ///     aircraft when in standby.
-    void standby_xyz_reset();
+    void standby_NEU_reset();
 
-    // get earth-frame Z-axis acceleration with gravity removed in cm/s/s with +ve being up
-    float get_z_accel_cmss() const { return -(_ahrs.get_accel_ef().z + GRAVITY_MSS) * 100.0f; }
+    // get_measured_accel_U_cmss - returns the vertical (Up) acceleration in the earth frame, gravity-compensated, in cm/s/s (+ve = upward)
+    float get_measured_accel_U_cmss() const { return -(_ahrs.get_accel_ef().z + GRAVITY_MSS) * 100.0f; }
 
     /// returns true when the forward pitch demand is limited by the maximum allowed tilt
     bool get_fwd_pitch_is_limited() const;
     
-    // set disturbance north
-    void set_disturb_pos_cm(Vector2f disturb_pos) {_disturb_pos = disturb_pos;}
+    // set_disturb_pos_NE_cm - set the position disturbance in the north east plane
+    void set_disturb_pos_NE_cm(Vector2f disturb_pos) {_disturb_pos_ne_cm = disturb_pos;}
 
-    // set disturbance north
-    void set_disturb_vel_cms(Vector2f disturb_vel) {_disturb_vel = disturb_vel;}
+    // set_disturb_vel_NE_cms - set the velocity disturbance in the north east plane
+    void set_disturb_vel_NE_cms(Vector2f disturb_vel) {_disturb_vel_ne_cms = disturb_vel;}
 
     static const struct AP_Param::GroupInfo var_info[];
 
-    static void Write_PSCN(float pos_desired, float pos_target, float pos, float vel_desired, float vel_target, float vel, float accel_desired, float accel_target, float accel);
-    static void Write_PSCE(float pos_desired, float pos_target, float pos, float vel_desired, float vel_target, float vel, float accel_desired, float accel_target, float accel);
-    static void Write_PSCD(float pos_desired, float pos_target, float pos, float vel_desired, float vel_target, float vel, float accel_desired, float accel_target, float accel);
+    static void Write_PSCN(float pos_desired_cm, float pos_target_cm, float pos_cm, float vel_desired_cms, float vel_target_cms, float vel_cms, float accel_desired_cmss, float accel_target_cmss, float accel_cmss);
+    static void Write_PSCE(float pos_desired_cm, float pos_target_cm, float pos_cm, float vel_desired_cms, float vel_target_cms, float vel_cms, float accel_desired_cmss, float accel_target_cmss, float accel_cmss);
+    static void Write_PSCD(float pos_desired_cm, float pos_target_cm, float pos_cm, float vel_desired_cms, float vel_target_cms, float vel_cms, float accel_desired_cmss, float accel_target_cmss, float accel_cmss);
     static void Write_PSON(float pos_target_offset_cm, float pos_offset_cm, float vel_target_offset_cms, float vel_offset_cms, float accel_target_offset_cmss, float accel_offset_cmss);
     static void Write_PSOE(float pos_target_offset_cm, float pos_offset_cm, float vel_target_offset_cms, float vel_offset_cms, float accel_target_offset_cmss, float accel_offset_cmss);
     static void Write_PSOD(float pos_target_offset_cm, float pos_offset_cm, float vel_target_offset_cms, float vel_offset_cms, float accel_target_offset_cmss, float accel_offset_cmss);
@@ -472,10 +473,10 @@ protected:
     float get_throttle_with_vibration_override();
 
     // lean_angles_to_accel - convert roll, pitch lean angles to lat/lon frame accelerations in cm/s/s
-    void accel_to_lean_angles(float accel_x_cmss, float accel_y_cmss, float& roll_target, float& pitch_target) const;
+    void accel_NE_cmss_to_lean_angles(float accel_n_cmss, float accel_e_cmss, float& roll_target_cd, float& pitch_target_cd) const;
 
     // lean_angles_to_accel - convert roll, pitch lean angles to lat/lon frame accelerations in cm/s/s
-    void lean_angles_to_accel_xy(float& accel_x_cmss, float& accel_y_cmss) const;
+    void lean_angles_to_accel_NE_cmss(float& accel_n_cmss, float& accel_e_cmss) const;
 
     // calculate_yaw_and_rate_yaw - calculate the vehicle yaw and rate of yaw.
     void calculate_yaw_and_rate_yaw();
@@ -492,7 +493,7 @@ protected:
     void init_terrain();
 
     /// update_terrain - updates the terrain position, velocity and acceleration estimation
-    /// this moves the estimated terrain position _pos_terrain towards the target _pos_terrain_target
+    /// this moves the estimated terrain position _pos_terrain_u_cm towards the target _pos_terrain_target_u_cm
     void update_terrain();
 
 
@@ -501,19 +502,19 @@ protected:
     /// init_offsets - set the position, velocity and acceleration offsets in cm, cms and cm/s/s from EKF origin in NE frame
     /// this is used to initiate the offsets when initialise the position controller or do an offset reset
     /// note that this sets the actual offsets, not the offset targets
-    void init_offsets_xy();
-    void init_offsets_z();
+    void init_offsets_NE();
+    void init_offsets_U();
 
     /// update_offsets - update the position and velocity offsets
-    /// this moves the offsets (e.g _pos_offset, _vel_offset, _accel_offset) towards the targets (e.g. _pos_offset_target or _vel_offset_target)
-    void update_offsets_xy();
-    void update_offsets_z();
+    /// this moves the offsets (e.g _pos_offset_neu_cm, _vel_offset_neu_cms, _accel_offset_neu_cmss) towards the targets (e.g. _pos_offset_target_neu_cm or _vel_offset_target_neu_cms)
+    void update_offsets_NE();
+    void update_offsets_U();
 
     /// initialise and check for ekf position resets
-    void init_ekf_xy_reset();
-    void handle_ekf_xy_reset();
-    void init_ekf_z_reset();
-    void handle_ekf_z_reset();
+    void init_ekf_NE_reset();
+    void handle_ekf_NE_reset();
+    void init_ekf_U_reset();
+    void handle_ekf_U_reset();
 
     // references to inertial nav and ahrs libraries
     AP_AHRS_View&           _ahrs;
@@ -522,65 +523,65 @@ protected:
     AC_AttitudeControl&     _attitude_control;
 
     // parameters
-    AP_Float        _lean_angle_max;    // Maximum autopilot commanded angle (in degrees). Set to zero for Angle Max
-    AP_Float        _shaping_jerk_xy;   // Jerk limit of the xy kinematic path generation in m/s^3 used to determine how quickly the aircraft varies the acceleration target
-    AP_Float        _shaping_jerk_z;    // Jerk limit of the z kinematic path generation in m/s^3 used to determine how quickly the aircraft varies the acceleration target
-    AC_P_2D         _p_pos_xy;          // XY axis position controller to convert distance error to desired velocity
-    AC_P_1D         _p_pos_z;           // Z axis position controller to convert altitude error to desired climb rate
-    AC_PID_2D       _pid_vel_xy;        // XY axis velocity controller to convert velocity error to desired acceleration
-    AC_PID_Basic    _pid_vel_z;         // Z axis velocity controller to convert climb rate error to desired acceleration
-    AC_PID          _pid_accel_z;       // Z axis acceleration controller to convert desired acceleration to throttle output
+    AP_Float        _lean_angle_max_deg;    // Maximum autopilot commanded angle (in degrees). Set to zero for Angle Max
+    AP_Float        _shaping_jerk_ne_msss;  // Jerk limit of the ne kinematic path generation in m/s^3 used to determine how quickly the aircraft varies the acceleration target
+    AP_Float        _shaping_jerk_u_msss;   // Jerk limit of the u kinematic path generation in m/s^3 used to determine how quickly the aircraft varies the acceleration target
+    AC_P_2D         _p_pos_ne;              // XY axis position controller to convert distance error to desired velocity
+    AC_P_1D         _p_pos_u;               // Z axis position controller to convert altitude error to desired climb rate
+    AC_PID_2D       _pid_vel_ne;            // XY axis velocity controller to convert velocity error to desired acceleration
+    AC_PID_Basic    _pid_vel_u;             // Z axis velocity controller to convert climb rate error to desired acceleration
+    AC_PID          _pid_accel_u;           // Z axis acceleration controller to convert desired acceleration to throttle output
 
     // internal variables
-    float       _dt;                    // time difference (in seconds) since the last loop time
-    uint32_t    _last_update_xy_ticks;  // ticks of last last update_xy_controller call
-    uint32_t    _last_update_z_ticks;   // ticks of last update_z_controller call
-    float       _vel_max_xy_cms;        // max horizontal speed in cm/s used for kinematic shaping
-    float       _vel_max_up_cms;        // max climb rate in cm/s used for kinematic shaping
-    float       _vel_max_down_cms;      // max descent rate in cm/s used for kinematic shaping
-    float       _accel_max_xy_cmss;     // max horizontal acceleration in cm/s/s used for kinematic shaping
-    float       _accel_max_z_cmss;      // max vertical acceleration in cm/s/s used for kinematic shaping
-    float       _jerk_max_xy_cmsss;       // Jerk limit of the xy kinematic path generation in cm/s^3 used to determine how quickly the aircraft varies the acceleration target
-    float       _jerk_max_z_cmsss;        // Jerk limit of the z kinematic path generation in cm/s^3 used to determine how quickly the aircraft varies the acceleration target
-    float       _vel_z_control_ratio = 2.0f;    // confidence that we have control in the vertical axis
-    Vector2f    _disturb_pos;           // position disturbance generated by system ID mode
-    Vector2f    _disturb_vel;           // velocity disturbance generated by system ID mode
-    float       _xy_control_scale_factor = 1.0; // single loop scale factor for XY control
+    float       _dt;                        // time difference (in seconds) since the last loop time
+    uint32_t    _last_update_ne_ticks;      // ticks of last last update_NE_controller call
+    uint32_t    _last_update_u_ticks;       // ticks of last update_z_controller call
+    float       _vel_max_ne_cms;            // max horizontal speed in cm/s used for kinematic shaping
+    float       _vel_max_up_cms;            // max climb rate in cm/s used for kinematic shaping
+    float       _vel_max_down_cms;          // max descent rate in cm/s used for kinematic shaping
+    float       _accel_max_ne_cmss;         // max horizontal acceleration in cm/s/s used for kinematic shaping
+    float       _accel_max_u_cmss;          // max vertical acceleration in cm/s/s used for kinematic shaping
+    float       _jerk_max_ne_cmsss;         // Jerk limit of the ne kinematic path generation in cm/s^3 used to determine how quickly the aircraft varies the acceleration target
+    float       _jerk_max_u_cmsss;          // Jerk limit of the z kinematic path generation in cm/s^3 used to determine how quickly the aircraft varies the acceleration target
+    float       _vel_u_control_ratio = 2.0f;    // confidence that we have control in the vertical axis
+    Vector2f    _disturb_pos_ne_cm;         // position disturbance generated by system ID mode
+    Vector2f    _disturb_vel_ne_cms;        // velocity disturbance generated by system ID mode
+    float       _ne_control_scale_factor = 1.0; // single loop scale factor for XY control
 
     // output from controller
-    float       _roll_target;           // desired roll angle in centi-degrees calculated by position controller
-    float       _pitch_target;          // desired roll pitch in centi-degrees calculated by position controller
-    float       _yaw_target;            // desired yaw in centi-degrees calculated by position controller
-    float       _yaw_rate_target;       // desired yaw rate in centi-degrees per second calculated by position controller
+    float       _roll_target_cd;            // desired roll angle in centi-degrees calculated by position controller
+    float       _pitch_target_cd;           // desired roll pitch in centi-degrees calculated by position controller
+    float       _yaw_target_cd;             // desired yaw in centi-degrees calculated by position controller
+    float       _yaw_rate_target_cds;       // desired yaw rate in centi-degrees per second calculated by position controller
 
     // position controller internal variables
-    Vector3p    _pos_desired;           // desired location, frame NEU in cm relative to the EKF origin.  This is equal to the _pos_target minus offsets
-    Vector3p    _pos_target;            // target location, frame NEU in cm relative to the EKF origin.  This is equal to the _pos_desired plus offsets
-    Vector3f    _vel_desired;           // desired velocity in NEU cm/s
-    Vector3f    _vel_target;            // velocity target in NEU cm/s calculated by pos_to_rate step
-    Vector3f    _accel_desired;         // desired acceleration in NEU cm/s/s (feed forward)
-    Vector3f    _accel_target;          // acceleration target in NEU cm/s/s
-    Vector3f    _limit_vector;          // the direction that the position controller is limited, zero when not limited
+    Vector3p    _pos_desired_neu_cm;        // desired location, frame NEU in cm relative to the EKF origin.  This is equal to the _pos_target minus offsets
+    Vector3p    _pos_target_neu_cm;         // target location, frame NEU in cm relative to the EKF origin.  This is equal to the _pos_desired_neu_cm plus offsets
+    Vector3f    _vel_desired_neu_cms;       // desired velocity in NEU cm/s
+    Vector3f    _vel_target_neu_cms;        // velocity target in NEU cm/s calculated by pos_to_rate step
+    Vector3f    _accel_desired_neu_cmss;    // desired acceleration in NEU cm/s/s (feed forward)
+    Vector3f    _accel_target_neu_cmss;     // acceleration target in NEU cm/s/s
+    Vector3f    _limit_vector;              // the direction that the position controller is limited, zero when not limited
 
     // terrain handling variables
-    float    _pos_terrain_target;       // position terrain target in cm relative to the EKF origin in NEU frame
-    float    _pos_terrain;              // position terrain in cm from the EKF origin in NEU frame.  this terrain moves towards _pos_terrain_target
-    float    _vel_terrain;              // velocity terrain in NEU cm/s calculated by pos_to_rate step.  this terrain moves towards _vel_terrain_target
-    float    _accel_terrain;            // acceleration terrain in NEU cm/s/s
+    float    _pos_terrain_target_u_cm;    // position terrain target in cm relative to the EKF origin in NEU frame
+    float    _pos_terrain_u_cm;           // position terrain in cm from the EKF origin in NEU frame.  this terrain moves towards _pos_terrain_target_u_cm
+    float    _vel_terrain_u_cms;          // velocity terrain in NEU cm/s calculated by pos_to_rate step.  this terrain moves towards _vel_terrain_target
+    float    _accel_terrain_u_cmss;       // acceleration terrain in NEU cm/s/s
 
     // offset handling variables
-    Vector3p    _pos_offset_target;     // position offset target in cm relative to the EKF origin in NEU frame
-    Vector3p    _pos_offset;            // position offset in cm from the EKF origin in NEU frame.  this offset moves towards _pos_offset_target
-    Vector3f    _vel_offset_target;     // velocity offset target in cm/s in NEU frame
-    Vector3f    _vel_offset;            // velocity offset in NEU cm/s calculated by pos_to_rate step.  this offset moves towards _vel_offset_target
-    Vector3f    _accel_offset_target;   // acceleration offset target in cm/s/s in NEU frame
-    Vector3f    _accel_offset;          // acceleration offset in NEU cm/s/s
-    uint32_t    _posvelaccel_offset_target_xy_ms;   // system time that pos, vel, accel targets were set (used to implement timeouts)
-    uint32_t    _posvelaccel_offset_target_z_ms;    // system time that pos, vel, accel targets were set (used to implement timeouts)
+    Vector3p    _pos_offset_target_neu_cm;      // position offset target in cm relative to the EKF origin in NEU frame
+    Vector3p    _pos_offset_neu_cm;             // position offset in cm from the EKF origin in NEU frame.  this offset moves towards _pos_offset_target_neu_cm
+    Vector3f    _vel_offset_target_neu_cms;     // velocity offset target in cm/s in NEU frame
+    Vector3f    _vel_offset_neu_cms;            // velocity offset in NEU cm/s calculated by pos_to_rate step.  this offset moves towards _vel_offset_target_neu_cms
+    Vector3f    _accel_offset_target_neu_cmss;  // acceleration offset target in cm/s/s in NEU frame
+    Vector3f    _accel_offset_neu_cmss;         // acceleration offset in NEU cm/s/s
+    uint32_t    _posvelaccel_offset_target_ne_ms;   // system time that pos, vel, accel targets were set (used to implement timeouts)
+    uint32_t    _posvelaccel_offset_target_u_ms;    // system time that pos, vel, accel targets were set (used to implement timeouts)
 
     // ekf reset handling
-    uint32_t    _ekf_xy_reset_ms;       // system time of last recorded ekf xy position reset
-    uint32_t    _ekf_z_reset_ms;        // system time of last recorded ekf altitude reset
+    uint32_t    _ekf_ne_reset_ms;       // system time of last recorded ekf ne position reset
+    uint32_t    _ekf_u_reset_ms;        // system time of last recorded ekf altitude reset
 
     // high vibration handling
     bool        _vibe_comp_enabled;     // true when high vibration compensation is on
@@ -592,14 +593,15 @@ protected:
     bool has_good_timing(void) const;
 
 private:
-    // convenience method for writing out the identical PSCE, PSCN, PSCD - and
-    // to save bytes
-    static void Write_PSCx(LogMessages ID, float pos_desired, float pos_target, float pos, float vel_desired, float vel_target, float vel, float accel_desired, float accel_target, float accel);
+    // convenience method for writing PSCE, PSCN, and PSCD logs, to reduce code duplication
+    static void Write_PSCx(LogMessages ID, float pos_desired_cm, float pos_target_cm, float pos_cm, 
+                            float vel_desired_cms, float vel_target_cms, float vel_cms, 
+                            float accel_desired_cmss, float accel_target_cmss, float accel_cmss);
 
     // a convenience function for writing out the position controller offsets
     static void Write_PSOx(LogMessages id, float pos_target_offset_cm, float pos_offset_cm,
-                           float vel_target_offset_cms, float vel_offset_cms,
-                           float accel_target_offset_cmss, float accel_offset_cmss);
+                            float vel_target_offset_cms, float vel_offset_cms,
+                            float accel_target_offset_cmss, float accel_offset_cmss);
 
     // singleton
     static AC_PosControl *_singleton;

--- a/libraries/AC_AttitudeControl/AC_PosControl_Logging.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl_Logging.cpp
@@ -8,37 +8,37 @@
 #include "LogStructure.h"
 
 // a convenience function for writing out the position controller PIDs
-void AC_PosControl::Write_PSCx(LogMessages id, float pos_desired, float pos_target, float pos, float vel_desired, float vel_target, float vel, float accel_desired, float accel_target, float accel)
+void AC_PosControl::Write_PSCx(LogMessages id, float pos_desired_cm, float pos_target_cm, float pos_cm, float vel_desired_cms, float vel_target_cms, float vel_cms, float accel_desired_cmss, float accel_target_cmss, float accel_cmss)
 {
     const struct log_PSCx pkt{
         LOG_PACKET_HEADER_INIT(id),
             time_us         : AP_HAL::micros64(),
-            pos_desired   : pos_desired * 0.01f,
-            pos_target    : pos_target * 0.01f,
-            pos           : pos * 0.01f,
-            vel_desired   : vel_desired * 0.01f,
-            vel_target    : vel_target * 0.01f,
-            vel           : vel * 0.01f,
-            accel_desired : accel_desired * 0.01f,
-            accel_target  : accel_target * 0.01f,
-            accel         : accel * 0.01f
+            pos_desired   : pos_desired_cm * 0.01f,
+            pos_target    : pos_target_cm * 0.01f,
+            pos           : pos_cm * 0.01f,
+            vel_desired   : vel_desired_cms * 0.01f,
+            vel_target    : vel_target_cms * 0.01f,
+            vel           : vel_cms * 0.01f,
+            accel_desired : accel_desired_cmss * 0.01f,
+            accel_target  : accel_target_cmss * 0.01f,
+            accel         : accel_cmss * 0.01f
     };
     AP::logger().WriteBlock(&pkt, sizeof(pkt));
 }
 
-void AC_PosControl::Write_PSCN(float pos_desired, float pos_target, float pos, float vel_desired, float vel_target, float vel, float accel_desired, float accel_target, float accel)
+void AC_PosControl::Write_PSCN(float pos_desired_cm, float pos_target_cm, float pos_cm, float vel_desired_cms, float vel_target_cms, float vel_cms, float accel_desired_cmss, float accel_target_cmss, float accel_cmss)
 {
-    Write_PSCx(LOG_PSCN_MSG, pos_desired, pos_target, pos, vel_desired, vel_target, vel, accel_desired, accel_target, accel);
+    Write_PSCx(LOG_PSCN_MSG, pos_desired_cm, pos_target_cm, pos_cm, vel_desired_cms, vel_target_cms, vel_cms, accel_desired_cmss, accel_target_cmss, accel_cmss);
 }
 
-void AC_PosControl::Write_PSCE(float pos_desired, float pos_target, float pos, float vel_desired, float vel_target, float vel, float accel_desired, float accel_target, float accel)
+void AC_PosControl::Write_PSCE(float pos_desired_cm, float pos_target_cm, float pos_cm, float vel_desired_cms, float vel_target_cms, float vel_cms, float accel_desired_cmss, float accel_target_cmss, float accel_cmss)
 {
-    Write_PSCx(LOG_PSCE_MSG, pos_desired, pos_target, pos, vel_desired, vel_target, vel, accel_desired, accel_target, accel);
+    Write_PSCx(LOG_PSCE_MSG, pos_desired_cm, pos_target_cm, pos_cm, vel_desired_cms, vel_target_cms, vel_cms, accel_desired_cmss, accel_target_cmss, accel_cmss);
 }
 
-void AC_PosControl::Write_PSCD(float pos_desired, float pos_target, float pos, float vel_desired, float vel_target, float vel, float accel_desired, float accel_target, float accel)
+void AC_PosControl::Write_PSCD(float pos_desired_cm, float pos_target_cm, float pos_cm, float vel_desired_cms, float vel_target_cms, float vel_cms, float accel_desired_cmss, float accel_target_cmss, float accel_cmss)
 {
-    Write_PSCx(LOG_PSCD_MSG, pos_desired, pos_target, pos, vel_desired, vel_target, vel, accel_desired, accel_target, accel);
+    Write_PSCx(LOG_PSCD_MSG, pos_desired_cm, pos_target_cm, pos_cm, vel_desired_cms, vel_target_cms, vel_cms, accel_desired_cmss, accel_target_cmss, accel_cmss);
 }
 
 // a convenience function for writing out the position controller offsets

--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -161,7 +161,7 @@ bool AC_AutoTune::init_position_controller(void)
     init_z_limits();
 
     // initialise the vertical position controller
-    pos_control->init_z_controller();
+    pos_control->init_U_controller();
 
     return true;
 }
@@ -244,7 +244,7 @@ void AC_AutoTune::run()
     if (!motors->armed() || !motors->get_interlock()) {
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
         attitude_control->set_throttle_out(0.0f, true, 0.0f);
-        pos_control->relax_z_controller(0.0f);
+        pos_control->relax_U_controller(0.0f);
         return;
     }
 
@@ -310,8 +310,8 @@ void AC_AutoTune::run()
     }
 
     // call position controller
-    pos_control->set_pos_target_z_from_climb_rate_cm(target_climb_rate_cms);
-    pos_control->update_z_controller();
+    pos_control->set_pos_target_U_from_climb_rate_cm(target_climb_rate_cms);
+    pos_control->update_U_controller();
 
 }
 

--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -62,8 +62,8 @@ void AC_Circle::init(const Vector3p& center, bool terrain_alt, float rate_deg_pe
     _rate = rate_deg_per_sec;
 
     // initialise position controller (sets target roll angle, pitch angle and I terms based on vehicle current lean angles)
-    _pos_control.init_xy_controller_stopping_point();
-    _pos_control.init_z_controller_stopping_point();
+    _pos_control.init_NE_controller_stopping_point();
+    _pos_control.init_U_controller_stopping_point();
 
     // calculate velocities
     calc_velocities(true);
@@ -82,11 +82,11 @@ void AC_Circle::init()
     _rate = _rate_parm;
 
     // initialise position controller (sets target roll angle, pitch angle and I terms based on vehicle current lean angles)
-    _pos_control.init_xy_controller_stopping_point();
-    _pos_control.init_z_controller_stopping_point();
+    _pos_control.init_NE_controller_stopping_point();
+    _pos_control.init_U_controller_stopping_point();
 
     // get stopping point
-    const Vector3p& stopping_point = _pos_control.get_pos_desired_cm();
+    const Vector3p& stopping_point = _pos_control.get_pos_desired_NEU_cm();
 
     // set circle center to circle_radius ahead of stopping point
     _center = stopping_point;
@@ -185,7 +185,7 @@ bool AC_Circle::update(float climb_rate_cms)
     if (_terrain_alt) {
         target_z_cm = _center.z + terr_offset;
     } else {
-        target_z_cm = _pos_control.get_pos_desired_z_cm();
+        target_z_cm = _pos_control.get_pos_desired_U_cm();
     }
 
     // if the circle_radius is zero we are doing panorama so no need to update loiter target
@@ -200,7 +200,7 @@ bool AC_Circle::update(float climb_rate_cms)
         target.y += - _radius * sinf(-_angle);
 
         // heading is from vehicle to center of circle
-        _yaw = get_bearing_cd(_pos_control.get_pos_desired_cm().xy().tofloat(), _center.tofloat().xy());
+        _yaw = get_bearing_cd(_pos_control.get_pos_desired_NEU_cm().xy().tofloat(), _center.tofloat().xy());
 
         if ((_options.get() & CircleOptions::FACE_DIRECTION_OF_TRAVEL) != 0) {
             _yaw += is_positive(_rate)?-9000.0f:9000.0f;
@@ -214,17 +214,17 @@ bool AC_Circle::update(float climb_rate_cms)
 
     // update position controller target
     Vector2f zero;
-    _pos_control.input_pos_vel_accel_xy(target.xy(), zero, zero);
+    _pos_control.input_pos_vel_accel_NE_cm(target.xy(), zero, zero);
     if (_terrain_alt) {
         float zero2 = 0;
         float target_zf = target.z;
-        _pos_control.input_pos_vel_accel_z(target_zf, zero2, 0);
+        _pos_control.input_pos_vel_accel_U_cm(target_zf, zero2, 0);
     } else {
-        _pos_control.set_pos_target_z_from_climb_rate_cm(climb_rate_cms);
+        _pos_control.set_pos_target_U_from_climb_rate_cm(climb_rate_cms);
     }
 
     // update position controller
-    _pos_control.update_xy_controller();
+    _pos_control.update_NE_controller();
 
     // set update time
     _last_update_ms = AP_HAL::millis();
@@ -241,8 +241,8 @@ void AC_Circle::get_closest_point_on_circle(Vector3f& result, float& dist_cm) co
 {
     // get current position
     Vector3p stopping_point;
-    _pos_control.get_stopping_point_xy_cm(stopping_point.xy());
-    _pos_control.get_stopping_point_z_cm(stopping_point.z);
+    _pos_control.get_stopping_point_NE_cm(stopping_point.xy());
+    _pos_control.get_stopping_point_U_cm(stopping_point.z);
 
     // calc vector from stopping point to circle center
     Vector3f vec = (stopping_point - _center).tofloat();
@@ -279,14 +279,14 @@ void AC_Circle::calc_velocities(bool init_velocity)
         _angular_accel = MAX(fabsf(_angular_vel_max),ToRad(AC_CIRCLE_ANGULAR_ACCEL_MIN));  // reach maximum yaw velocity in 1 second
     }else{
         // calculate max velocity based on waypoint speed ensuring we do not use more than half our max acceleration for accelerating towards the center of the circle
-        float velocity_max = MIN(_pos_control.get_max_speed_xy_cms(), safe_sqrt(0.5f*_pos_control.get_max_accel_xy_cmss()*_radius));
+        float velocity_max = MIN(_pos_control.get_max_speed_NE_cms(), safe_sqrt(0.5f*_pos_control.get_max_accel_NE_cmss()*_radius));
 
         // angular_velocity in radians per second
         _angular_vel_max = velocity_max/_radius;
         _angular_vel_max = constrain_float(ToRad(_rate),-_angular_vel_max,_angular_vel_max);
 
         // angular_velocity in radians per second
-        _angular_accel = MAX(_pos_control.get_max_accel_xy_cmss()/_radius, ToRad(AC_CIRCLE_ANGULAR_ACCEL_MIN));
+        _angular_accel = MAX(_pos_control.get_max_accel_NE_cmss()/_radius, ToRad(AC_CIRCLE_ANGULAR_ACCEL_MIN));
     }
 
     // initialise angular velocity
@@ -315,7 +315,7 @@ void AC_Circle::init_start_angle(bool use_heading)
     } else {
         // if we are exactly at the center of the circle, init angle to directly behind vehicle (so vehicle will backup but not change heading)
         // curr_pos_desired is the position before we add offsets and terrain
-        const Vector3f &curr_pos_desired= _pos_control.get_pos_desired_cm().tofloat();
+        const Vector3f &curr_pos_desired= _pos_control.get_pos_desired_NEU_cm().tofloat();
         if (is_equal(curr_pos_desired.x,float(_center.x)) && is_equal(curr_pos_desired.y,float(_center.y))) {
             _angle = wrap_PI(_ahrs.yaw-M_PI);
         } else {

--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -81,7 +81,7 @@ public:
     void get_closest_point_on_circle(Vector3f& result, float& dist_cm) const;
 
     /// get horizontal distance to loiter target in cm
-    float get_distance_to_target() const { return _pos_control.get_pos_error_xy_cm(); }
+    float get_distance_to_target() const { return _pos_control.get_pos_error_NE_cm(); }
 
     /// get bearing to target in centi-degrees
     int32_t get_bearing_to_target() const { return _pos_control.get_bearing_to_target_cd(); }

--- a/libraries/AC_WPNav/AC_Loiter.h
+++ b/libraries/AC_WPNav/AC_Loiter.h
@@ -41,7 +41,7 @@ public:
     void get_stopping_point_xy(Vector2f& stopping_point) const;
 
     /// get horizontal distance to loiter target in cm
-    float get_distance_to_target() const { return _pos_control.get_pos_error_xy_cm(); }
+    float get_distance_to_target() const { return _pos_control.get_pos_error_NE_cm(); }
 
     /// get bearing to target in centi-degrees
     int32_t get_bearing_to_target() const { return _pos_control.get_bearing_to_target_cd(); }

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -162,8 +162,8 @@ void AC_WPNav::wp_and_spline_init(float speed_cms, Vector3f stopping_point)
     _wp_speed_cms.set_and_save_ifchanged(MAX(_wp_speed_cms, WPNAV_WP_SPEED_MIN));
 
     // initialise position controller
-    _pos_control.init_z_controller_stopping_point();
-    _pos_control.init_xy_controller_stopping_point();
+    _pos_control.init_U_controller_stopping_point();
+    _pos_control.init_NE_controller_stopping_point();
 
     // initialize the desired wp speed
     _check_wp_speed_change = !is_positive(speed_cms);
@@ -171,10 +171,10 @@ void AC_WPNav::wp_and_spline_init(float speed_cms, Vector3f stopping_point)
     _wp_desired_speed_xy_cms = MAX(_wp_desired_speed_xy_cms, WPNAV_WP_SPEED_MIN);
 
     // initialise position controller speed and acceleration
-    _pos_control.set_max_speed_accel_xy(_wp_desired_speed_xy_cms, get_wp_acceleration());
-    _pos_control.set_correction_speed_accel_xy(_wp_desired_speed_xy_cms, get_wp_acceleration());
-    _pos_control.set_max_speed_accel_z(-get_default_speed_down(), _wp_speed_up_cms, _wp_accel_z_cmss);
-    _pos_control.set_correction_speed_accel_z(-get_default_speed_down(), _wp_speed_up_cms, _wp_accel_z_cmss);
+    _pos_control.set_max_speed_accel_NE_cm(_wp_desired_speed_xy_cms, get_wp_acceleration());
+    _pos_control.set_correction_speed_accel_NE_cm(_wp_desired_speed_xy_cms, get_wp_acceleration());
+    _pos_control.set_max_speed_accel_U_cm(-get_default_speed_down(), _wp_speed_up_cms, _wp_accel_z_cmss);
+    _pos_control.set_correction_speed_accel_U_cmss(-get_default_speed_down(), _wp_speed_up_cms, _wp_accel_z_cmss);
 
     // calculate scurve jerk and jerk time
     if (!is_positive(_wp_jerk)) {
@@ -219,8 +219,8 @@ void AC_WPNav::set_speed_xy(float speed_cms)
         _wp_desired_speed_xy_cms = speed_cms;
 
         // update position controller speed and acceleration
-        _pos_control.set_max_speed_accel_xy(_wp_desired_speed_xy_cms, get_wp_acceleration());
-        _pos_control.set_correction_speed_accel_xy(_wp_desired_speed_xy_cms, get_wp_acceleration());
+        _pos_control.set_max_speed_accel_NE_cm(_wp_desired_speed_xy_cms, get_wp_acceleration());
+        _pos_control.set_correction_speed_accel_NE_cm(_wp_desired_speed_xy_cms, get_wp_acceleration());
 
         // change track speed
         update_track_with_speed_accel_limits();
@@ -230,14 +230,14 @@ void AC_WPNav::set_speed_xy(float speed_cms)
 /// set current target climb rate during wp navigation
 void AC_WPNav::set_speed_up(float speed_up_cms)
 {
-    _pos_control.set_max_speed_accel_z(_pos_control.get_max_speed_down_cms(), speed_up_cms, _pos_control.get_max_accel_z_cmss());
+    _pos_control.set_max_speed_accel_U_cm(_pos_control.get_max_speed_down_cms(), speed_up_cms, _pos_control.get_max_accel_U_cmss());
     update_track_with_speed_accel_limits();
 }
 
 /// set current target descent rate during wp navigation
 void AC_WPNav::set_speed_down(float speed_down_cms)
 {
-    _pos_control.set_max_speed_accel_z(speed_down_cms, _pos_control.get_max_speed_up_cms(), _pos_control.get_max_accel_z_cmss());
+    _pos_control.set_max_speed_accel_U_cm(speed_down_cms, _pos_control.get_max_speed_up_cms(), _pos_control.get_max_accel_U_cmss());
     update_track_with_speed_accel_limits();
 }
 
@@ -304,8 +304,8 @@ bool AC_WPNav::set_wp_destination(const Vector3f& destination, bool terrain_alt)
     if (terrain_alt == _terrain_alt) {
         if (_this_leg_is_spline) {
             // if previous leg was a spline we can use current target velocity vector for origin velocity vector
-            Vector3f curr_target_vel = _pos_control.get_vel_desired_cms();
-            curr_target_vel.z -= _pos_control.get_vel_offset_z_cms();
+            Vector3f curr_target_vel = _pos_control.get_vel_desired_NEU_cms();
+            curr_target_vel.z -= _pos_control.get_vel_offset_U_cms();
             origin_speed = curr_target_vel.length();
         } else {
             // store previous leg
@@ -323,11 +323,11 @@ bool AC_WPNav::set_wp_destination(const Vector3f& destination, bool terrain_alt)
         if (terrain_alt) {
             // new destination is alt-above-terrain, previous destination was alt-above-ekf-origin
             _origin.z -= origin_terr_offset;
-            _pos_control.init_pos_terrain_cm(origin_terr_offset);
+            _pos_control.init_pos_terrain_U_cm(origin_terr_offset);
         } else {
             // new destination is alt-above-ekf-origin, previous destination was alt-above-terrain
             _origin.z += origin_terr_offset;
-            _pos_control.init_pos_terrain_cm(0.0);
+            _pos_control.init_pos_terrain_U_cm(0.0);
         }
     }
 
@@ -339,7 +339,7 @@ bool AC_WPNav::set_wp_destination(const Vector3f& destination, bool terrain_alt)
         _scurve_this_leg = _scurve_next_leg;
     } else {
         _scurve_this_leg.calculate_track(_origin, _destination,
-                                         _pos_control.get_max_speed_xy_cms(), _pos_control.get_max_speed_up_cms(), _pos_control.get_max_speed_down_cms(),
+                                         _pos_control.get_max_speed_NE_cms(), _pos_control.get_max_speed_up_cms(), _pos_control.get_max_speed_down_cms(),
                                          get_wp_acceleration(), _wp_accel_z_cmss,
                                          _scurve_snap * 100.0f, _scurve_jerk * 100.0f);
         if (!is_zero(origin_speed)) {
@@ -368,7 +368,7 @@ bool AC_WPNav::set_wp_destination_next(const Vector3f& destination, bool terrain
     }
 
     _scurve_next_leg.calculate_track(_destination, destination,
-                                     _pos_control.get_max_speed_xy_cms(), _pos_control.get_max_speed_up_cms(), _pos_control.get_max_speed_down_cms(),
+                                     _pos_control.get_max_speed_NE_cms(), _pos_control.get_max_speed_up_cms(), _pos_control.get_max_speed_down_cms(),
                                      get_wp_acceleration(), _wp_accel_z_cmss,
                                      _scurve_snap * 100.0f, _scurve_jerk * 100.0);
     if (_this_leg_is_spline) {
@@ -407,7 +407,7 @@ bool AC_WPNav::set_wp_destination_next_NED(const Vector3f& destination_NED)
 void AC_WPNav::shift_wp_origin_and_destination_to_current_pos_xy()
 {
     // Reset position controller to current location
-    _pos_control.init_xy_controller();
+    _pos_control.init_NE_controller();
 
     // get current and target locations
     const Vector2f& curr_pos = _inav.get_position_xy_cm();
@@ -424,7 +424,7 @@ void AC_WPNav::shift_wp_origin_and_destination_to_stopping_point_xy()
 {
     // relax position control in xy axis
     // removing velocity error also impacts stopping point calculation
-    _pos_control.relax_velocity_controller_xy();
+    _pos_control.relax_velocity_controller_NE();
 
     // get current and target locations
     Vector2f stopping_point;
@@ -435,14 +435,14 @@ void AC_WPNav::shift_wp_origin_and_destination_to_stopping_point_xy()
     _destination.xy() = stopping_point;
 
     // move pos controller target horizontally
-    _pos_control.set_pos_desired_xy_cm(stopping_point);
+    _pos_control.set_pos_desired_NE_cm(stopping_point);
 }
 
 /// get_wp_stopping_point_xy - returns vector to stopping point based on a horizontal position and velocity
 void AC_WPNav::get_wp_stopping_point_xy(Vector2f& stopping_point) const
 {
     Vector2p stop;
-    _pos_control.get_stopping_point_xy_cm(stop);
+    _pos_control.get_stopping_point_NE_cm(stop);
     stopping_point = stop.tofloat();
 }
 
@@ -450,8 +450,8 @@ void AC_WPNav::get_wp_stopping_point_xy(Vector2f& stopping_point) const
 void AC_WPNav::get_wp_stopping_point(Vector3f& stopping_point) const
 {
     Vector3p stop;
-    _pos_control.get_stopping_point_xy_cm(stop.xy());
-    _pos_control.get_stopping_point_z_cm(stop.z);
+    _pos_control.get_stopping_point_NE_cm(stop.xy());
+    _pos_control.get_stopping_point_U_cm(stop.z);
     stopping_point = stop.tofloat();
 }
 
@@ -463,19 +463,19 @@ bool AC_WPNav::advance_wp_target_along_track(float dt)
     if (_terrain_alt && !get_terrain_offset(terr_offset)) {
         return false;
     }
-    const float offset_z_scaler = _pos_control.pos_offset_z_scaler(terr_offset, get_terrain_margin() * 100.0);
+    const float offset_z_scaler = _pos_control.pos_terrain_U_scaler(terr_offset, get_terrain_margin() * 100.0);
 
     // input shape the terrain offset
-    _pos_control.set_pos_terrain_target_cm(terr_offset);
+    _pos_control.set_pos_terrain_target_U_cm(terr_offset);
 
     // get position controller's position offset (post input shaping) so it can be used in position error calculation
-    const Vector3p& psc_pos_offset = _pos_control.get_pos_offset_cm();
+    const Vector3p& psc_pos_offset = _pos_control.get_pos_offset_NEU_cm();
 
     // get current position and adjust altitude to origin and destination's frame (i.e. _frame)
     Vector3f curr_pos = _inav.get_position_neu_cm() - psc_pos_offset.tofloat();
     curr_pos.z -= terr_offset;
-    Vector3f curr_target_vel = _pos_control.get_vel_desired_cms();
-    curr_target_vel.z -= _pos_control.get_vel_offset_z_cms();
+    Vector3f curr_target_vel = _pos_control.get_vel_desired_NEU_cms();
+    curr_target_vel.z -= _pos_control.get_vel_offset_U_cms();
 
     // Use _track_scalar_dt to slow down progression of the position target moving too far in front of aircraft
     // _track_scalar_dt does not scale the velocity or acceleration
@@ -483,10 +483,10 @@ bool AC_WPNav::advance_wp_target_along_track(float dt)
     // check target velocity is non-zero
     if (is_positive(curr_target_vel.length_squared())) {
         Vector3f track_direction = curr_target_vel.normalized();
-        const float track_error = _pos_control.get_pos_error_cm().dot(track_direction);
+        const float track_error = _pos_control.get_pos_error_NEU_cm().dot(track_direction);
         const float track_velocity = _inav.get_velocity_neu_cms().dot(track_direction);
         // set time scaler to be consistent with the achievable aircraft speed with a 5% buffer for short term variation.
-        track_scaler_dt = constrain_float(0.05f + (track_velocity - _pos_control.get_pos_xy_p().kP() * track_error) / curr_target_vel.length(), 0.0f, 1.0f);
+        track_scaler_dt = constrain_float(0.05f + (track_velocity - _pos_control.get_pos_NE_p().kP() * track_error) / curr_target_vel.length(), 0.0f, 1.0f);
     }
 
     // Use vel_scaler_dt to slow down the trajectory time
@@ -496,7 +496,7 @@ bool AC_WPNav::advance_wp_target_along_track(float dt)
         update_vel_accel(_offset_vel, _offset_accel, dt, 0.0, 0.0);
         const float vel_input = !_paused ? _wp_desired_speed_xy_cms * offset_z_scaler : 0.0;
         shape_vel_accel(vel_input, 0.0, _offset_vel, _offset_accel, -get_wp_acceleration(), get_wp_acceleration(),
-                        _pos_control.get_shaping_jerk_xy_cmsss(), dt, true);
+                        _pos_control.get_shaping_jerk_NE_cmsss(), dt, true);
         vel_scaler_dt = _offset_vel / _wp_desired_speed_xy_cms;
     }
 
@@ -533,7 +533,7 @@ bool AC_WPNav::advance_wp_target_along_track(float dt)
     target_accel += accel_offset;
 
     // pass new target to the position controller
-    _pos_control.set_pos_vel_accel(target_pos.topostype(), target_vel, target_accel);
+    _pos_control.set_pos_vel_accel_NEU_cm(target_pos.topostype(), target_vel, target_accel);
 
     // check if we've reached the waypoint
     if (!_flags.reached_destination) {
@@ -560,18 +560,18 @@ void AC_WPNav::update_track_with_speed_accel_limits()
 {
     // update this leg
     if (_this_leg_is_spline) {
-        _spline_this_leg.set_speed_accel(_pos_control.get_max_speed_xy_cms(), _pos_control.get_max_speed_up_cms(), _pos_control.get_max_speed_down_cms(),
+        _spline_this_leg.set_speed_accel(_pos_control.get_max_speed_NE_cms(), _pos_control.get_max_speed_up_cms(), _pos_control.get_max_speed_down_cms(),
                                          get_wp_acceleration(), _wp_accel_z_cmss);
     } else {
-        _scurve_this_leg.set_speed_max(_pos_control.get_max_speed_xy_cms(), _pos_control.get_max_speed_up_cms(), _pos_control.get_max_speed_down_cms());
+        _scurve_this_leg.set_speed_max(_pos_control.get_max_speed_NE_cms(), _pos_control.get_max_speed_up_cms(), _pos_control.get_max_speed_down_cms());
     }
 
     // update next leg
     if (_next_leg_is_spline) {
-        _spline_next_leg.set_speed_accel(_pos_control.get_max_speed_xy_cms(), _pos_control.get_max_speed_up_cms(), _pos_control.get_max_speed_down_cms(),
+        _spline_next_leg.set_speed_accel(_pos_control.get_max_speed_NE_cms(), _pos_control.get_max_speed_up_cms(), _pos_control.get_max_speed_down_cms(),
                                          get_wp_acceleration(), _wp_accel_z_cmss);
     } else {
-        _scurve_next_leg.set_speed_max(_pos_control.get_max_speed_xy_cms(), _pos_control.get_max_speed_up_cms(), _pos_control.get_max_speed_down_cms());
+        _scurve_next_leg.set_speed_max(_pos_control.get_max_speed_NE_cms(), _pos_control.get_max_speed_up_cms(), _pos_control.get_max_speed_down_cms());
     }
 }
 
@@ -613,7 +613,7 @@ bool AC_WPNav::update_wpnav()
         ret = false;
     }
 
-    _pos_control.update_xy_controller();
+    _pos_control.update_NE_controller();
 
     _wp_last_update = AP_HAL::millis();
 
@@ -743,8 +743,8 @@ bool AC_WPNav::set_spline_destination(const Vector3f& destination, bool terrain_
     }
 
     // update spline calculators speeds and accelerations
-    _spline_this_leg.set_speed_accel(_pos_control.get_max_speed_xy_cms(), _pos_control.get_max_speed_up_cms(), _pos_control.get_max_speed_down_cms(),
-                                     _pos_control.get_max_accel_xy_cmss(), _pos_control.get_max_accel_z_cmss());
+    _spline_this_leg.set_speed_accel(_pos_control.get_max_speed_NE_cms(), _pos_control.get_max_speed_up_cms(), _pos_control.get_max_speed_down_cms(),
+                                     _pos_control.get_max_accel_NE_cmss(), _pos_control.get_max_accel_U_cmss());
 
     // calculate origin and origin velocity vector
     Vector3f origin_vector;
@@ -777,11 +777,11 @@ bool AC_WPNav::set_spline_destination(const Vector3f& destination, bool terrain_
         if (terrain_alt) {
             // new destination is alt-above-terrain, previous destination was alt-above-ekf-origin
             _origin.z -= origin_terr_offset;
-            _pos_control.init_pos_terrain_cm(origin_terr_offset);
+            _pos_control.init_pos_terrain_U_cm(origin_terr_offset);
         } else {
             // new destination is alt-above-ekf-origin, previous destination was alt-above-terrain
             _origin.z += origin_terr_offset;
-            _pos_control.init_pos_terrain_cm(0.0);
+            _pos_control.init_pos_terrain_U_cm(0.0);
         }
     }
 
@@ -845,8 +845,8 @@ bool AC_WPNav::set_spline_destination_next(const Vector3f& next_destination, boo
     }
 
     // update spline calculators speeds and accelerations
-    _spline_next_leg.set_speed_accel(_pos_control.get_max_speed_xy_cms(), _pos_control.get_max_speed_up_cms(), _pos_control.get_max_speed_down_cms(),
-                                     _pos_control.get_max_accel_xy_cmss(), _pos_control.get_max_accel_z_cmss());
+    _spline_next_leg.set_speed_accel(_pos_control.get_max_speed_NE_cms(), _pos_control.get_max_speed_up_cms(), _pos_control.get_max_speed_down_cms(),
+                                     _pos_control.get_max_accel_NE_cmss(), _pos_control.get_max_accel_U_cmss());
 
     // setup next spline leg.  Note this could be made local
     _spline_next_leg.set_origin_and_destination(_destination, next_destination, origin_vector, destination_vector);

--- a/libraries/AC_WPNav/AC_WPNav_OA.cpp
+++ b/libraries/AC_WPNav/AC_WPNav_OA.cpp
@@ -215,10 +215,10 @@ bool AC_WPNav_OA::update_wpnav()
                 Vector3p dest_NEU{dest_NE.x, dest_NE.y, (float)target_alt_loc.alt};
 
                 // pass the desired position directly to the position controller
-                _pos_control.input_pos_xyz(dest_NEU, terr_offset, 1000.0);
+                _pos_control.input_pos_NEU_cm(dest_NEU, terr_offset, 1000.0);
 
                 // update horizontal position controller (vertical is updated in vehicle code)
-                _pos_control.update_xy_controller();
+                _pos_control.update_NE_controller();
 
                 // return success without calling parent AC_WPNav
                 return true;
@@ -238,10 +238,10 @@ bool AC_WPNav_OA::update_wpnav()
 
                 // pass the desired position directly to the position controller as an offset from EKF origin in NEU
                 Vector3p dest_NEU_p{dest_NEU.x, dest_NEU.y, dest_NEU.z};
-                _pos_control.input_pos_xyz(dest_NEU_p, 0, 1000.0);
+                _pos_control.input_pos_NEU_cm(dest_NEU_p, 0, 1000.0);
 
                 // update horizontal position controller (vertical is updated in vehicle code)
-                _pos_control.update_xy_controller();
+                _pos_control.update_NE_controller();
 
                 // return success without calling parent AC_WPNav
                 return true;


### PR DESCRIPTION
This is my first step towards updating the position controller and variables to standard units and NED frame.

I have attempted to add frame and units to every variable and function call.

I have also updated the comments and tryed to improve the clarity and readability.

I don't know why I get slightly different results shown here:

```
SCB: Running (rsync -ap build/ /tmp/tmpaer1vc0h/out-branch-CubeOrange) in (.)
Board,blimp,bootloader,copter,heli,plane,rover,sub
CubeOrange,*,*,0,0,0,*,0
```