### PR TITLE
AP_WheelEncoder: add support for single pin pulse encoders

### DIFF
--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -194,27 +194,6 @@ bool Rover::set_target_velocity_NED(const Vector3f& vel_ned)
     return true;
 }
 
-// set steering and throttle (-1 to +1) (for use by scripting)
-bool Rover::set_steering_and_throttle(float steering, float throttle)
-{
-    // exit if vehicle is not in Guided mode or Auto-Guided mode
-    if (!control_mode->in_guided_mode()) {
-        return false;
-    }
-
-    // set steering and throttle
-    mode_guided.set_steering_and_throttle(steering, throttle);
-    return true;
-}
-
-// get steering and throttle (-1 to +1) (for use by scripting)
-bool Rover::get_steering_and_throttle(float& steering, float& throttle)
-{
-    steering = g2.motors.get_steering() / 4500.0;
-    throttle = g2.motors.get_throttle() * 0.01;
-    return true;
-}
-
 // set desired turn rate (degrees/sec) and speed (m/s). Used for scripting
 bool Rover::set_desired_turn_rate_and_speed(float turn_rate, float speed)
 {
@@ -295,6 +274,27 @@ void Rover::nav_script_time_done(uint16_t id)
     return mode_auto.nav_script_time_done(id);
 }
 #endif // AP_SCRIPTING_ENABLED
+
+// set steering and throttle (-1 to +1) (for use by scripting)
+bool Rover::set_steering_and_throttle(float steering, float throttle)
+{
+    // exit if vehicle is not in Guided mode or Auto-Guided mode
+    if (!control_mode->in_guided_mode()) {
+        return false;
+    }
+
+    // set steering and throttle
+    mode_guided.set_steering_and_throttle(steering, throttle);
+    return true;
+}
+
+// get steering and throttle (-1 to +1) (for use by scripting)
+bool Rover::get_steering_and_throttle(float& steering, float& throttle)
+{
+    steering = g2.motors.get_steering() / 4500.0;
+    throttle = g2.motors.get_throttle() * 0.01;
+    return true;
+}
 
 // update AHRS system
 void Rover::ahrs_update()

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -277,8 +277,6 @@ private:
 
 #if AP_SCRIPTING_ENABLED
     bool set_target_velocity_NED(const Vector3f& vel_ned) override;
-    bool set_steering_and_throttle(float steering, float throttle) override;
-    bool get_steering_and_throttle(float& steering, float& throttle) override;
     // set desired turn rate (degrees/sec) and speed (m/s). Used for scripting
     bool set_desired_turn_rate_and_speed(float turn_rate, float speed) override;
     bool set_desired_speed(float speed) override;
@@ -287,6 +285,8 @@ private:
     bool nav_script_time(uint16_t &id, uint8_t &cmd, float &arg1, float &arg2, int16_t &arg3, int16_t &arg4) override;
     void nav_script_time_done(uint16_t id) override;
 #endif // AP_SCRIPTING_ENABLED
+    bool set_steering_and_throttle(float steering, float throttle) override;
+    bool get_steering_and_throttle(float& steering, float& throttle) override;
     void ahrs_update();
     void gcs_failsafe_check(void);
     void update_logging1(void);

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -203,10 +203,6 @@ public:
     virtual bool get_circle_radius(float &radius_m) { return false; }
     virtual bool set_circle_rate(float rate_dps) { return false; }
 
-    // get or set steering and throttle (-1 to +1) (for use by scripting with Rover)
-    virtual bool set_steering_and_throttle(float steering, float throttle) { return false; }
-    virtual bool get_steering_and_throttle(float& steering, float& throttle) { return false; }
-
     // set turn rate in deg/sec and speed in meters/sec (for use by scripting with Rover)
     virtual bool set_desired_turn_rate_and_speed(float turn_rate, float speed) { return false; }
 
@@ -254,6 +250,10 @@ public:
     virtual custom_mode_state* register_custom_mode(const uint8_t number, const char* full_name, const char* short_name) { return nullptr; }
 
 #endif // AP_SCRIPTING_ENABLED
+
+    // get or set steering and throttle (-1 to +1) (for use by scripting with Rover)
+    virtual bool set_steering_and_throttle(float steering, float throttle) { return false; }
+    virtual bool get_steering_and_throttle(float& steering, float& throttle) { return false; }
 
     // returns true if vehicle is in the process of landing
     virtual bool is_landing() const { return false; }

--- a/libraries/AP_WheelEncoder/AP_WheelEncoder.cpp
+++ b/libraries/AP_WheelEncoder/AP_WheelEncoder.cpp
@@ -16,6 +16,7 @@
 #include "AP_WheelEncoder.h"
 #include "WheelEncoder_Quadrature.h"
 #include "WheelEncoder_SITL_Quadrature.h"
+#include "WheelEncoder_Pulse.h"
 #include <AP_Logger/AP_Logger.h>
 
 extern const AP_HAL::HAL& hal;
@@ -25,7 +26,7 @@ const AP_Param::GroupInfo AP_WheelEncoder::var_info[] = {
     // @Param: _TYPE
     // @DisplayName: WheelEncoder type
     // @Description: What type of WheelEncoder is connected
-    // @Values: 0:None,1:Quadrature,10:SITL Quadrature
+    // @Values: 0:None,1:Quadrature,2:Pulsed,10:SITL Quadrature
     // @User: Standard
     AP_GROUPINFO_FLAGS("_TYPE", 0, AP_WheelEncoder, _type[0], 0, AP_PARAM_FLAG_ENABLE),
 
@@ -87,7 +88,7 @@ const AP_Param::GroupInfo AP_WheelEncoder::var_info[] = {
     // @Param: 2_TYPE
     // @DisplayName: Second WheelEncoder type
     // @Description: What type of WheelEncoder sensor is connected
-    // @Values: 0:None,1:Quadrature,10:SITL Quadrature
+    // @Values: 0:None,1:Quadrature,2:Pulsed,10:SITL Quadrature
     // @User: Standard
     AP_GROUPINFO("2_TYPE",   6, AP_WheelEncoder, _type[1], 0),
 
@@ -167,7 +168,7 @@ void AP_WheelEncoder::init(void)
         switch ((WheelEncoder_Type)_type[i].get()) {
 
         case WheelEncoder_TYPE_QUADRATURE:
-#if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
+#if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS || CONFIG_HAL_BOARD == HAL_BOARD_LINUX
             drivers[i] = NEW_NOTHROW AP_WheelEncoder_Quadrature(*this, i, state[i]);
 #endif
             break;
@@ -177,7 +178,13 @@ void AP_WheelEncoder::init(void)
             drivers[i] = NEW_NOTHROW AP_WheelEncoder_SITL_Quadrature(*this, i, state[i]);
 #endif
             break;
-            
+
+        case WheelEncoder_TYPE_PULSE:
+#if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS || CONFIG_HAL_BOARD == HAL_BOARD_LINUX
+            drivers[i] = NEW_NOTHROW AP_WheelEncoder_Pulse(*this, i, state[i]);
+#endif
+            break;
+
         case WheelEncoder_TYPE_NONE:
             break;
         }

--- a/libraries/AP_WheelEncoder/AP_WheelEncoder.h
+++ b/libraries/AP_WheelEncoder/AP_WheelEncoder.h
@@ -46,6 +46,7 @@ public:
     enum WheelEncoder_Type : uint8_t {
         WheelEncoder_TYPE_NONE             =   0,
         WheelEncoder_TYPE_QUADRATURE       =   1,
+        WheelEncoder_TYPE_PULSE            =   2,
         WheelEncoder_TYPE_SITL_QUADRATURE  =  10,
     };
 

--- a/libraries/AP_WheelEncoder/WheelEncoder_Pulse.cpp
+++ b/libraries/AP_WheelEncoder/WheelEncoder_Pulse.cpp
@@ -1,0 +1,160 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <AP_AHRS/AP_AHRS.h>
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Vehicle/AP_Vehicle.h>
+
+#include "WheelEncoder_Pulse.h"
+
+#include <GCS_MAVLink/GCS.h>
+
+extern const AP_HAL::HAL& hal;
+
+// threshold above noise-level where we'll respect velocity for direction determination
+#define VELOCITY_THRESHOLD 0.005
+
+
+// check if pin has changed and initialise gpio event callback
+void AP_WheelEncoder_Pulse::update_pin(uint8_t &pin,
+                                            uint8_t new_pin,
+                                            uint8_t &pin_value)
+{
+    if (new_pin == pin) {
+        // no change
+        return;
+    }
+
+    // remove old gpio event callback if present
+    if (pin != (uint8_t)-1 &&
+        !hal.gpio->detach_interrupt(pin)) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "WEnc: Failed to detach from pin %u", pin);
+        // ignore this failure or the user may be stuck
+    }
+
+    pin = new_pin;
+
+    // install interrupt handler on rising or falling edge of gpio for pin a
+    if (new_pin != (uint8_t)-1) {
+        hal.gpio->pinMode(pin, HAL_GPIO_INPUT);
+        if (!hal.gpio->attach_interrupt(
+                pin,
+                FUNCTOR_BIND_MEMBER(&AP_WheelEncoder_Pulse::irq_handler,
+                                    void,
+                                    uint8_t,
+                                    bool,
+                                    uint32_t),
+                AP_HAL::GPIO::INTERRUPT_BOTH)) {
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "WEnc: Failed to attach to pin %u", pin);
+        }
+        pin_value = hal.gpio->read(pin);
+    }
+}
+
+void AP_WheelEncoder_Pulse::update(void)
+{
+    /* check if pin changed */
+    update_pin(last_pin_a, get_pin_a(), last_pin_a_value);
+
+    // disable interrupts to prevent race with irq_handler
+    void *irqstate = hal.scheduler->disable_interrupts_save();
+
+    // copy distance and error count so it is accessible to front end
+    copy_state_to_frontend(irq_state.distance_count,
+                           irq_state.total_count,
+                           irq_state.error_count,
+                           irq_state.last_reading_ms);
+
+    // restore interrupts
+    hal.scheduler->restore_interrupts(irqstate);
+}
+
+void AP_WheelEncoder_Pulse::irq_handler(uint8_t pin,
+                                             bool pin_value,
+                                             uint32_t timestamp)
+{
+    // sanity check
+    if (last_pin_a == 0) {
+        return;
+    }
+
+    // record update time
+    irq_state.last_reading_ms = timestamp * 1e-3f;
+
+    // value didn't change - we missed an interrupt?
+    if(last_pin_a_value == pin_value) {
+        irq_state.error_count++;
+        return;
+    }
+
+    // remember last value
+    last_pin_a_value = pin_value;
+
+    // count reading
+    irq_state.total_count++;
+
+    // +1 for forward movement, -1 for backwards. Let's decide...
+    int32_t increment = 0;
+
+    // // get velocity from AHRS
+    // Vector3f velocity;
+    // if (!AP::ahrs().get_velocity_NED(velocity)) {
+    //     // treat unknown velocity as zero
+    //     velocity.zero();
+    // }
+
+    // // get forward direction (X-axis of the vehicle body frame, in NED)
+    // Matrix3f rot = AP::ahrs().get_rotation_body_to_ned();
+    // Vector3f forward_dir = rot.colx();  // body X-axis in NED
+    // forward_dir.z = 0;                  // only horizontal
+    // forward_dir.normalize();           // ensure unit vector
+
+    // // project velocity onto forward direction to get signed ground speed
+    // float signed_speed = velocity.dot(forward_dir) * 100.0f; // cm/s
+
+    // get current throttle
+    float steering = 0, throttle = 0;
+    if(!AP::vehicle()->get_steering_and_throttle(steering, throttle)) {
+        irq_state.error_count++;
+        return;
+    }
+
+    // // throttle contradicting ground_speed?
+    // if((throttle < 0 && ground_speed > 0) || (throttle > 0 && ground_speed < 0)) {
+    //     // are we getting pushed or pulled?
+    //     hal.console->printf(
+    //         "AP_WheelEncoder_Pulse: IMU (%f) & throttle (%f) direction mismatch!\n",
+    //         ground_speed, throttle
+    //     );
+    //     irq_state.error_count++;
+    //     return;
+    // }
+
+    // use throttle to determine direction by default
+    increment = throttle < 0 ? -1 : 1;
+
+    // // use speed to override throttle direction?
+    // if(ground_speed != 0) {
+    //     increment = ground_speed < 0 ? -1: 1;
+    // }
+
+    // hal.console->printf(
+    //    "AP_WheelEncoder_Pulse: instance: %d, spd: %f, thr: %f, inc: %d, dist: %d err: %d\n", 
+    //    _state.instance, signed_speed, throttle, increment, irq_state.distance_count, irq_state.error_count
+    // );
+
+    // register movement
+    irq_state.distance_count += increment;
+}

--- a/libraries/AP_WheelEncoder/WheelEncoder_Pulse.h
+++ b/libraries/AP_WheelEncoder/WheelEncoder_Pulse.h
@@ -1,0 +1,50 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "AP_WheelEncoder.h"
+#include "WheelEncoder_Backend.h"
+#include <Filter/Filter.h>
+#include <AP_Math/AP_Math.h>
+
+class AP_WheelEncoder_Pulse : public AP_WheelEncoder_Backend
+{
+public:
+    // constructor
+    using AP_WheelEncoder_Backend::AP_WheelEncoder_Backend;
+
+    // update state
+    void update(void) override;
+
+private:
+
+    // check if pin has changed and initialise gpio event callback
+    void update_pin(uint8_t &pin, uint8_t new_pin, uint8_t &pin_value);
+
+    // gpio interrupt handlers
+    void irq_handler(uint8_t pin, bool pin_value, uint32_t timestamp);  // combined irq handler
+
+
+    struct IrqState {
+        int32_t  distance_count;    // distance measured by cumulative steps forward or backwards since last update
+        uint32_t total_count;       // total number of successful readings from sensor (used for sensor quality calcs)
+        uint32_t error_count;       // total number of errors reading from sensor (used for sensor quality calcs)
+        uint32_t last_reading_ms;   // system time of last update from encoder
+    } irq_state;
+
+    // private members
+    uint8_t last_pin_a = -1;
+    uint8_t last_pin_a_value;
+};


### PR DESCRIPTION
This PR enables use of single pin pulse encoders. Direction is determined by the sign of thrust.
(Works for me™ but barely tested)