### PR TITLE
Plane: Use AP_Enum for throttle_fs_enabled

### DIFF
--- a/ArduPlane/AP_Arming_Plane.cpp
+++ b/ArduPlane/AP_Arming_Plane.cpp
@@ -97,7 +97,7 @@ bool AP_Arming_Plane::pre_arm_checks(bool display_failure)
     }
 
     if (plane.channel_throttle->get_reverse() && 
-        Plane::ThrFailsafe(plane.g.throttle_fs_enabled.get()) != Plane::ThrFailsafe::Disabled &&
+        plane.g.throttle_fs_enabled != Plane::ThrFailsafe::Disabled &&
         plane.g.throttle_fs_value < 
         plane.channel_throttle->get_radio_max()) {
         check_failed(display_failure, "Invalid THR_FS_VALUE for rev throttle");
@@ -486,7 +486,7 @@ bool AP_Arming_Plane::rc_received_if_enabled_check(bool display_failure)
     }
 
     // If RC failsafe is enabled we must receive RC before arming
-    if ((Plane::ThrFailsafe(plane.g.throttle_fs_enabled.get()) == Plane::ThrFailsafe::Enabled) && 
+    if ((plane.g.throttle_fs_enabled == Plane::ThrFailsafe::Enabled) &&
         !(rc().has_had_rc_receiver() || rc().has_had_rc_override())) {
         check_failed(display_failure, "Waiting for RC");
         return false;

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -36,6 +36,11 @@ public:
     static const uint16_t k_format_version = 13;
     //////////////////////////////////////////////////////////////////
 
+    enum class ThrFailsafe {
+        Disabled    = 0,
+        Enabled     = 1,
+        EnabledNoFS = 2
+    };
 
     enum {
         // Layout version number, always key zero.

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -406,7 +406,7 @@ public:
     //
     AP_Int8 throttle_suppress_manual;
     AP_Int8 throttle_passthru_stabilize;
-    AP_Int8 throttle_fs_enabled;
+    AP_Enum<ThrFailsafe> throttle_fs_enabled;
     AP_Int16 throttle_fs_value;
     AP_Int8 throttle_nudge;
     AP_Int32 use_reverse_thrust;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1269,11 +1269,7 @@ private:
         CROW_DISABLED,
     };
 
-    enum class ThrFailsafe {
-        Disabled    = 0,
-        Enabled     = 1,
-        EnabledNoFS = 2
-    };
+    using ThrFailsafe = Parameters::ThrFailsafe;
 
     CrowMode crow_mode = CrowMode::NORMAL;
 

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -285,7 +285,7 @@ void Plane::control_failsafe()
 
     const bool allow_failsafe_bypass = !arming.is_armed() && !is_flying() && (rc().enabled_protocols() != 0);
     const bool has_had_input = rc().has_had_rc_receiver() || rc().has_had_rc_override();
-    if ((ThrFailsafe(g.throttle_fs_enabled.get()) != ThrFailsafe::Enabled) || (allow_failsafe_bypass && !has_had_input)) {
+    if ((g.throttle_fs_enabled != ThrFailsafe::Enabled) || (allow_failsafe_bypass && !has_had_input)) {
         // If not flying and disarmed don't trigger failsafe until RC has been received for the fist time
         return;
     }
@@ -387,7 +387,7 @@ void Plane::trim_radio()
  */
 bool Plane::rc_throttle_value_ok(void) const
 {
-    if (ThrFailsafe(g.throttle_fs_enabled.get()) == ThrFailsafe::Disabled) {
+    if (g.throttle_fs_enabled == ThrFailsafe::Disabled) {
         return true;
     }
     if (channel_throttle->get_reverse()) {


### PR DESCRIPTION
No compiler output change.

Avoids a bunch of casting...

```
Board,plane
MatekF405-Wing,*
```
