### PR TITLE
AP_BattMonitor: handle_scripting nullptr check

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -1304,6 +1304,9 @@ bool AP_BattMonitor::handle_scripting(uint8_t idx, const BattMonitorScript_State
     if (idx >= _num_instances) {
         return false;
     }
+    if (drivers[idx] == nullptr) {
+        return false;
+    }
     return drivers[idx]->handle_scripting(_state);
 }
 #endif


### PR DESCRIPTION
Don't want a bug in a lua script to cause a hard fault.