### PR TITLE
AP_Baro: avoid use of ownptr in AP_Baro 

### DIFF
--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -331,6 +331,18 @@ private:
     bool _have_i2c_driver(uint8_t bus_num, uint8_t address) const;
     bool _add_backend(AP_Baro_Backend *backend);
     void _probe_i2c_barometers(void);
+
+    bool probe_i2c_dev(AP_Baro_Backend* (*probefn)(AP_Baro&, AP_HAL::Device&), uint8_t bus, uint8_t addr);
+    bool probe_spi_dev(AP_Baro_Backend* (*probefn)(AP_Baro&, AP_HAL::Device&), const char *name);
+    bool probe_dev(AP_Baro_Backend* (*probefn)(AP_Baro&, AP_HAL::Device&), AP_HAL::Device *dev);
+#if AP_BARO_ICM20789_ENABLED
+    bool probe_icm20789(uint8_t bus, uint8_t addr, const char *mpu_name);
+    bool probe_icm20789(uint8_t bus, uint8_t addr, uint8_t mpu_bus, uint8_t mpu_addr);
+    // convenience underlying method for other probe functions;
+    // will. delete the passed-in devices if a backend is not found
+    bool _probe_icm20789(AP_HAL::I2CDevice *i2c_dev, AP_HAL::Device *mpu_dev);
+#endif  // AP_BARO_ICM20789_ENABLED
+
     AP_Int8                            _filter_range;  // valid value range from mean value
     AP_Int32                           _baro_probe_ext;
 
@@ -365,6 +377,7 @@ private:
 
     float get_altitude_difference_simple(float base_pressure, float pressure) const;
     float get_EAS2TAS_simple(float altitude, float pressure) const;
+
 };
 
 namespace AP {

--- a/libraries/AP_Baro/AP_Baro_BMP085.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP085.cpp
@@ -36,19 +36,14 @@ extern const AP_HAL::HAL &hal;
 #define OVERSAMPLING BMP085_OVERSAMPLING_HIGHRES
 #endif
 
-AP_Baro_BMP085::AP_Baro_BMP085(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev)
+AP_Baro_BMP085::AP_Baro_BMP085(AP_Baro &baro, AP_HAL::Device &dev)
     : AP_Baro_Backend(baro)
-    , _dev(std::move(dev))
+    , _dev(&dev)
 { }
 
-AP_Baro_Backend * AP_Baro_BMP085::probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev)
+AP_Baro_Backend * AP_Baro_BMP085::probe(AP_Baro &baro, AP_HAL::Device &dev)
 {
-
-    if (!dev) {
-        return nullptr;
-    }
-
-    AP_Baro_BMP085 *sensor = NEW_NOTHROW AP_Baro_BMP085(baro, std::move(dev));
+    AP_Baro_BMP085 *sensor = NEW_NOTHROW AP_Baro_BMP085(baro, dev);
     if (!sensor || !sensor->_init()) {
         delete sensor;
         return nullptr;

--- a/libraries/AP_Baro/AP_Baro_BMP085.h
+++ b/libraries/AP_Baro/AP_Baro_BMP085.h
@@ -6,7 +6,6 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/I2CDevice.h>
-#include <AP_HAL/utility/OwnPtr.h>
 #include <Filter/Filter.h>
 
 #ifndef HAL_BARO_BMP085_I2C_ADDR
@@ -15,12 +14,12 @@
 
 class AP_Baro_BMP085 : public AP_Baro_Backend {
 public:
-    AP_Baro_BMP085(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    AP_Baro_BMP085(AP_Baro &baro, AP_HAL::Device &dev);
 
     /* AP_Baro public interface: */
     void update() override;
 
-    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::Device &dev);
 
 
 private:
@@ -39,7 +38,7 @@ private:
     bool     _read_prom(uint16_t *prom);
 
 
-    AP_HAL::OwnPtr<AP_HAL::Device> _dev;
+    AP_HAL::Device *_dev;
     AP_HAL::DigitalSource *_eoc;
 
     uint8_t _instance;

--- a/libraries/AP_Baro/AP_Baro_BMP280.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP280.cpp
@@ -47,20 +47,15 @@ extern const AP_HAL::HAL &hal;
 #define BMP280_REG_CONFIG    0xF5
 #define BMP280_REG_DATA      0xF7
 
-AP_Baro_BMP280::AP_Baro_BMP280(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev)
+AP_Baro_BMP280::AP_Baro_BMP280(AP_Baro &baro, AP_HAL::Device &dev)
     : AP_Baro_Backend(baro)
-    , _dev(std::move(dev))
+    , _dev(&dev)
 {
 }
 
-AP_Baro_Backend *AP_Baro_BMP280::probe(AP_Baro &baro,
-                                       AP_HAL::OwnPtr<AP_HAL::Device> dev)
+AP_Baro_Backend *AP_Baro_BMP280::probe(AP_Baro &baro, AP_HAL::Device &dev)
 {
-    if (!dev) {
-        return nullptr;
-    }
-
-    AP_Baro_BMP280 *sensor = NEW_NOTHROW AP_Baro_BMP280(baro, std::move(dev));
+    AP_Baro_BMP280 *sensor = NEW_NOTHROW AP_Baro_BMP280(baro, dev);
     if (!sensor || !sensor->_init()) {
         delete sensor;
         return nullptr;

--- a/libraries/AP_Baro/AP_Baro_BMP280.h
+++ b/libraries/AP_Baro/AP_Baro_BMP280.h
@@ -6,7 +6,6 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/Device.h>
-#include <AP_HAL/utility/OwnPtr.h>
 
 #ifndef HAL_BARO_BMP280_I2C_ADDR
  #define HAL_BARO_BMP280_I2C_ADDR  (0x76)
@@ -18,12 +17,12 @@
 class AP_Baro_BMP280 : public AP_Baro_Backend
 {
 public:
-    AP_Baro_BMP280(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    AP_Baro_BMP280(AP_Baro &baro, AP_HAL::Device &dev);
 
     /* AP_Baro public interface: */
     void update() override;
 
-    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::Device &dev);
 
 private:
 
@@ -32,7 +31,7 @@ private:
     void _update_temperature(int32_t);
     void _update_pressure(int32_t);
 
-    AP_HAL::OwnPtr<AP_HAL::Device> _dev;
+    AP_HAL::Device *_dev;
 
     uint8_t _instance;
     int32_t _t_fine;

--- a/libraries/AP_Baro/AP_Baro_BMP388.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP388.cpp
@@ -53,20 +53,15 @@ extern const AP_HAL::HAL &hal;
 #define BMP388_REG_CAL_P     0x36
 #define BMP388_REG_CAL_T     0x31
 
-AP_Baro_BMP388::AP_Baro_BMP388(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> _dev)
+AP_Baro_BMP388::AP_Baro_BMP388(AP_Baro &baro, AP_HAL::Device &_dev)
     : AP_Baro_Backend(baro)
-    , dev(std::move(_dev))
+    , dev(&_dev)
 {
 }
 
-AP_Baro_Backend *AP_Baro_BMP388::probe(AP_Baro &baro,
-                                       AP_HAL::OwnPtr<AP_HAL::Device> _dev)
+AP_Baro_Backend *AP_Baro_BMP388::probe(AP_Baro &baro, AP_HAL::Device &_dev)
 {
-    if (!_dev) {
-        return nullptr;
-    }
-
-    AP_Baro_BMP388 *sensor = NEW_NOTHROW AP_Baro_BMP388(baro, std::move(_dev));
+    AP_Baro_BMP388 *sensor = NEW_NOTHROW AP_Baro_BMP388(baro, _dev);
     if (!sensor || !sensor->init()) {
         delete sensor;
         return nullptr;

--- a/libraries/AP_Baro/AP_Baro_BMP388.h
+++ b/libraries/AP_Baro/AP_Baro_BMP388.h
@@ -6,7 +6,6 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/Device.h>
-#include <AP_HAL/utility/OwnPtr.h>
 
 #ifndef HAL_BARO_BMP388_I2C_ADDR
  #define HAL_BARO_BMP388_I2C_ADDR  (0x76)
@@ -18,12 +17,12 @@
 class AP_Baro_BMP388 : public AP_Baro_Backend
 {
 public:
-    AP_Baro_BMP388(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> _dev);
+    AP_Baro_BMP388(AP_Baro &baro, AP_HAL::Device &_dev);
 
     /* AP_Baro public interface: */
     void update() override;
 
-    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> _dev);
+    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::Device &_dev);
 
 private:
 
@@ -32,7 +31,7 @@ private:
     void update_temperature(uint32_t);
     void update_pressure(uint32_t);
 
-    AP_HAL::OwnPtr<AP_HAL::Device> dev;
+    AP_HAL::Device *dev;
 
     uint8_t instance;
     float pressure_sum;

--- a/libraries/AP_Baro/AP_Baro_BMP581.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP581.cpp
@@ -55,20 +55,15 @@ extern const AP_HAL::HAL &hal;
 #define BMP581_REG_OSR_EFF            0x38
 #define BMP581_REG_CMD                0x7E
 
-AP_Baro_BMP581::AP_Baro_BMP581(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev)
+AP_Baro_BMP581::AP_Baro_BMP581(AP_Baro &baro, AP_HAL::Device &dev)
     : AP_Baro_Backend(baro)
-    , _dev(std::move(dev))
+    , _dev(&dev)
 {
 }
 
-AP_Baro_Backend *AP_Baro_BMP581::probe(AP_Baro &baro,
-                                       AP_HAL::OwnPtr<AP_HAL::Device> dev)
+AP_Baro_Backend *AP_Baro_BMP581::probe(AP_Baro &baro, AP_HAL::Device &dev)
 {
-    if (!dev) {
-        return nullptr;
-    }
-
-    AP_Baro_BMP581 *sensor = NEW_NOTHROW AP_Baro_BMP581(baro, std::move(dev));
+    AP_Baro_BMP581 *sensor = NEW_NOTHROW AP_Baro_BMP581(baro, dev);
     if (!sensor || !sensor->init()) {
         delete sensor;
         return nullptr;

--- a/libraries/AP_Baro/AP_Baro_BMP581.h
+++ b/libraries/AP_Baro/AP_Baro_BMP581.h
@@ -6,7 +6,6 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/Device.h>
-#include <AP_HAL/utility/OwnPtr.h>
 
 #ifndef HAL_BARO_BMP581_I2C_ADDR
  #define HAL_BARO_BMP581_I2C_ADDR  (0x46)
@@ -18,19 +17,19 @@
 class AP_Baro_BMP581 : public AP_Baro_Backend
 {
 public:
-    AP_Baro_BMP581(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    AP_Baro_BMP581(AP_Baro &baro, AP_HAL::Device &dev);
 
     /* AP_Baro public interface: */
     void update() override;
 
-    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::Device &dev);
 
 private:
 
     bool init(void);
     void timer(void);
 
-    AP_HAL::OwnPtr<AP_HAL::Device> _dev;
+    AP_HAL::Device *_dev;
 
     uint8_t instance;
     float pressure_sum;

--- a/libraries/AP_Baro/AP_Baro_Backend.cpp
+++ b/libraries/AP_Baro/AP_Baro_Backend.cpp
@@ -11,6 +11,11 @@ AP_Baro_Backend::AP_Baro_Backend(AP_Baro &baro) :
 {
 }
 
+void AP_Baro_Backend::set_bus_id(uint8_t instance, uint32_t id)
+{
+    _frontend.sensors[instance].bus_id.set(int32_t(id));
+}
+
 void AP_Baro_Backend::update_healthy_flag(uint8_t instance)
 {
     if (instance >= _frontend._num_sensors) {

--- a/libraries/AP_Baro/AP_Baro_Backend.h
+++ b/libraries/AP_Baro/AP_Baro_Backend.h
@@ -5,7 +5,7 @@
 class AP_Baro_Backend
 {
 public:
-    AP_Baro_Backend(AP_Baro &baro);
+    AP_Baro_Backend(class AP_Baro &baro);
     virtual ~AP_Baro_Backend(void) {};
 
     // each driver must provide an update method to copy accumulated
@@ -74,7 +74,5 @@ protected:
     uint32_t _error_count;
 
     // set bus ID of this instance, for BARO_DEVID parameters
-    void set_bus_id(uint8_t instance, uint32_t id) {
-        _frontend.sensors[instance].bus_id.set(int32_t(id));
-    }
+    void set_bus_id(uint8_t instance, uint32_t id);
 };

--- a/libraries/AP_Baro/AP_Baro_DPS280.cpp
+++ b/libraries/AP_Baro/AP_Baro_DPS280.cpp
@@ -43,20 +43,17 @@ extern const AP_HAL::HAL &hal;
 
 #define TEMPERATURE_LIMIT_C 120
 
-AP_Baro_DPS280::AP_Baro_DPS280(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> _dev)
+AP_Baro_DPS280::AP_Baro_DPS280(AP_Baro &baro, AP_HAL::Device &_dev)
     : AP_Baro_Backend(baro)
-    , dev(std::move(_dev))
+    , dev(&_dev)
 {
 }
 
 AP_Baro_Backend *AP_Baro_DPS280::probe(AP_Baro &baro,
-                                       AP_HAL::OwnPtr<AP_HAL::Device> _dev, bool _is_dps310)
+                                       AP_HAL::Device &_dev,
+                                       bool _is_dps310)
 {
-    if (!_dev) {
-        return nullptr;
-    }
-
-    AP_Baro_DPS280 *sensor = NEW_NOTHROW AP_Baro_DPS280(baro, std::move(_dev));
+    AP_Baro_DPS280 *sensor = NEW_NOTHROW AP_Baro_DPS280(baro, _dev);
     if (sensor) {
         sensor->is_dps310 = _is_dps310;
     }
@@ -67,11 +64,10 @@ AP_Baro_Backend *AP_Baro_DPS280::probe(AP_Baro &baro,
     return sensor;
 }
 
-AP_Baro_Backend *AP_Baro_DPS310::probe(AP_Baro &baro,
-                                       AP_HAL::OwnPtr<AP_HAL::Device> _dev)
+AP_Baro_Backend *AP_Baro_DPS310::probe(AP_Baro &baro, AP_HAL::Device &_dev)
 {
     // same as DPS280 but with is_dps310 set for temperature fix
-    return AP_Baro_DPS280::probe(baro, std::move(_dev), true);
+    return AP_Baro_DPS280::probe(baro, _dev, true);
 }
 
 /*

--- a/libraries/AP_Baro/AP_Baro_DPS280.h
+++ b/libraries/AP_Baro/AP_Baro_DPS280.h
@@ -6,7 +6,6 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/Device.h>
-#include <AP_HAL/utility/OwnPtr.h>
 
 #ifndef HAL_BARO_DPS280_I2C_ADDR
  #define HAL_BARO_DPS280_I2C_ADDR  0x76
@@ -17,16 +16,16 @@
 
 class AP_Baro_DPS280 : public AP_Baro_Backend {
 public:
-    AP_Baro_DPS280(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    AP_Baro_DPS280(AP_Baro &baro, AP_HAL::Device &dev);
 
     /* AP_Baro public interface: */
     void update() override;
 
-    static AP_Baro_Backend *probe_280(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev) {
-        return probe(baro, std::move(dev), false);
+    static AP_Baro_Backend *probe_280(AP_Baro &baro, AP_HAL::Device &dev) {
+        return probe(baro, dev, false);
     }
 
-    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev, bool _is_dps310=false);
+    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::Device &dev, bool _is_dps310=false);
 
 protected:
     bool init(bool _is_dps310);
@@ -39,7 +38,7 @@ protected:
     void set_config_registers(void);
     void check_health();
 
-    AP_HAL::OwnPtr<AP_HAL::Device> dev;
+    AP_HAL::Device *dev;
 
     uint8_t instance;
 
@@ -69,7 +68,7 @@ class AP_Baro_DPS310 : public AP_Baro_DPS280 {
     // like DPS280 but workaround for temperature bug
 public:
     using AP_Baro_DPS280::AP_Baro_DPS280;
-    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::Device &dev);
 };
 
 

--- a/libraries/AP_Baro/AP_Baro_FBM320.cpp
+++ b/libraries/AP_Baro/AP_Baro_FBM320.cpp
@@ -35,20 +35,15 @@ extern const AP_HAL::HAL &hal;
 
 #define FBM320_WHOAMI 0x42
 
-AP_Baro_FBM320::AP_Baro_FBM320(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> _dev)
+AP_Baro_FBM320::AP_Baro_FBM320(AP_Baro &baro, AP_HAL::Device &_dev)
     : AP_Baro_Backend(baro)
-    , dev(std::move(_dev))
+    , dev(&_dev)
 {
 }
 
-AP_Baro_Backend *AP_Baro_FBM320::probe(AP_Baro &baro,
-                                       AP_HAL::OwnPtr<AP_HAL::Device> _dev)
+AP_Baro_Backend *AP_Baro_FBM320::probe(AP_Baro &baro, AP_HAL::Device &_dev)
 {
-    if (!_dev) {
-        return nullptr;
-    }
-
-    AP_Baro_FBM320 *sensor = NEW_NOTHROW AP_Baro_FBM320(baro, std::move(_dev));
+    AP_Baro_FBM320 *sensor = NEW_NOTHROW AP_Baro_FBM320(baro, _dev);
     if (!sensor || !sensor->init()) {
         delete sensor;
         return nullptr;

--- a/libraries/AP_Baro/AP_Baro_FBM320.h
+++ b/libraries/AP_Baro/AP_Baro_FBM320.h
@@ -6,7 +6,6 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/Device.h>
-#include <AP_HAL/utility/OwnPtr.h>
 
 #ifndef HAL_BARO_FBM320_I2C_ADDR
  #define HAL_BARO_FBM320_I2C_ADDR  0x6C
@@ -18,12 +17,12 @@
 
 class AP_Baro_FBM320 : public AP_Baro_Backend {
 public:
-    AP_Baro_FBM320(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    AP_Baro_FBM320(AP_Baro &baro, AP_HAL::Device &dev);
 
     /* AP_Baro public interface: */
     void update() override;
 
-    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::Device &dev);
 
 private:
     bool init(void);
@@ -31,7 +30,7 @@ private:
     void timer(void);
     void calculate_PT(int32_t UT, int32_t UP, int32_t &pressure, int32_t &temperature);
 
-    AP_HAL::OwnPtr<AP_HAL::Device> dev;
+    AP_HAL::Device *dev;
 
     uint8_t instance;
 

--- a/libraries/AP_Baro/AP_Baro_ICM20789.cpp
+++ b/libraries/AP_Baro/AP_Baro_ICM20789.cpp
@@ -65,22 +65,19 @@ extern const AP_HAL::HAL &hal;
 /*
   constructor
  */
-AP_Baro_ICM20789::AP_Baro_ICM20789(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev, AP_HAL::OwnPtr<AP_HAL::Device> _dev_imu)
+AP_Baro_ICM20789::AP_Baro_ICM20789(AP_Baro &baro, AP_HAL::I2CDevice &_dev, AP_HAL::Device &_dev_imu)
     : AP_Baro_Backend(baro)
-    , dev(std::move(_dev))
-    , dev_imu(std::move(_dev_imu))
+    , dev(&_dev)
+    , dev_imu(&_dev_imu)
 {
 }
 
 AP_Baro_Backend *AP_Baro_ICM20789::probe(AP_Baro &baro,
-                                         AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev,
-                                         AP_HAL::OwnPtr<AP_HAL::Device> dev_imu)
+                                         AP_HAL::I2CDevice &dev,
+                                         AP_HAL::Device &dev_imu)
 {
     debug("Probing for ICM20789 baro\n");
-    if (!dev || !dev_imu) {
-        return nullptr;
-    }
-    AP_Baro_ICM20789 *sensor = NEW_NOTHROW AP_Baro_ICM20789(baro, std::move(dev), std::move(dev_imu));
+    AP_Baro_ICM20789 *sensor = NEW_NOTHROW AP_Baro_ICM20789(baro, dev, dev_imu);
     if (!sensor || !sensor->init()) {
         delete sensor;
         return nullptr;
@@ -164,10 +161,6 @@ bool AP_Baro_ICM20789::imu_i2c_init(void)
 
 bool AP_Baro_ICM20789::init()
 {
-    if (!dev) {
-        return false;
-    }
-
     debug("Looking for 20789 baro\n");
 
     dev->get_semaphore()->take_blocking();

--- a/libraries/AP_Baro/AP_Baro_ICM20789.h
+++ b/libraries/AP_Baro/AP_Baro_ICM20789.h
@@ -19,10 +19,10 @@ class AP_Baro_ICM20789 : public AP_Baro_Backend
 public:
     void update() override;
 
-    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev, AP_HAL::OwnPtr<AP_HAL::Device> dev_imu);
-    
+    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::I2CDevice &dev, AP_HAL::Device &dev_imu);
+
 private:
-    AP_Baro_ICM20789(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev, AP_HAL::OwnPtr<AP_HAL::Device> dev_imu);
+    AP_Baro_ICM20789(AP_Baro &baro, AP_HAL::I2CDevice &dev, AP_HAL::Device &dev_imu);
 
     bool init();
     bool send_cmd16(uint16_t cmd);
@@ -45,8 +45,8 @@ private:
 
     uint8_t instance;
 
-    AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev;
-    AP_HAL::OwnPtr<AP_HAL::Device> dev_imu;
+    AP_HAL::I2CDevice *dev;
+    AP_HAL::Device *dev_imu;
 
     // time last read command was sent
     uint32_t last_measure_us;

--- a/libraries/AP_Baro/AP_Baro_ICP101XX.cpp
+++ b/libraries/AP_Baro/AP_Baro_ICP101XX.cpp
@@ -49,19 +49,15 @@ extern const AP_HAL::HAL &hal;
 /*
   constructor
  */
-AP_Baro_ICP101XX::AP_Baro_ICP101XX(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev)
+AP_Baro_ICP101XX::AP_Baro_ICP101XX(AP_Baro &baro, AP_HAL::I2CDevice &_dev)
     : AP_Baro_Backend(baro)
-    , dev(std::move(_dev))
+    , dev(&_dev)
 {
 }
 
-AP_Baro_Backend *AP_Baro_ICP101XX::probe(AP_Baro &baro,
-                                         AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)
+AP_Baro_Backend *AP_Baro_ICP101XX::probe(AP_Baro &baro, AP_HAL::I2CDevice &dev)
 {
-    if (!dev) {
-        return nullptr;
-    }
-    AP_Baro_ICP101XX *sensor = NEW_NOTHROW AP_Baro_ICP101XX(baro, std::move(dev));
+    AP_Baro_ICP101XX *sensor = NEW_NOTHROW AP_Baro_ICP101XX(baro, dev);
     if (!sensor || !sensor->init()) {
         delete sensor;
         return nullptr;

--- a/libraries/AP_Baro/AP_Baro_ICP101XX.h
+++ b/libraries/AP_Baro/AP_Baro_ICP101XX.h
@@ -13,10 +13,10 @@ class AP_Baro_ICP101XX : public AP_Baro_Backend
 public:
     void update() override;
 
-    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
+    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::I2CDevice &dev);
     
 private:
-    AP_Baro_ICP101XX(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
+    AP_Baro_ICP101XX(AP_Baro &baro, AP_HAL::I2CDevice &dev);
 
     bool init();
     bool send_cmd16(uint16_t cmd);
@@ -38,7 +38,7 @@ private:
 
     uint8_t instance;
 
-    AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev;
+    AP_HAL::I2CDevice *dev;
 
     // time last read command was sent
     uint32_t last_measure_us;

--- a/libraries/AP_Baro/AP_Baro_ICP201XX.cpp
+++ b/libraries/AP_Baro/AP_Baro_ICP201XX.cpp
@@ -75,19 +75,15 @@ extern const AP_HAL::HAL &hal;
 /*
   constructor
  */
-AP_Baro_ICP201XX::AP_Baro_ICP201XX(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev)
+AP_Baro_ICP201XX::AP_Baro_ICP201XX(AP_Baro &baro, AP_HAL::I2CDevice &_dev)
     : AP_Baro_Backend(baro)
-    , dev(std::move(_dev))
+    , dev(&_dev)
 {
 }
 
-AP_Baro_Backend *AP_Baro_ICP201XX::probe(AP_Baro &baro,
-                                         AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)
+AP_Baro_Backend *AP_Baro_ICP201XX::probe(AP_Baro &baro, AP_HAL::I2CDevice &dev)
 {
-    if (!dev) {
-        return nullptr;
-    }
-    AP_Baro_ICP201XX *sensor = NEW_NOTHROW AP_Baro_ICP201XX(baro, std::move(dev));
+    AP_Baro_ICP201XX *sensor = NEW_NOTHROW AP_Baro_ICP201XX(baro, dev);
     if (!sensor || !sensor->init()) {
         delete sensor;
         return nullptr;

--- a/libraries/AP_Baro/AP_Baro_ICP201XX.h
+++ b/libraries/AP_Baro/AP_Baro_ICP201XX.h
@@ -13,10 +13,10 @@ class AP_Baro_ICP201XX : public AP_Baro_Backend
 public:
     void update() override;
 
-    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
+    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::I2CDevice &dev);
 
 private:
-    AP_Baro_ICP201XX(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev);
+    AP_Baro_ICP201XX(AP_Baro &baro, AP_HAL::I2CDevice &dev);
 
     bool init();
     void dummy_reg();
@@ -35,7 +35,7 @@ private:
 
     uint8_t instance;
 
-    AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev;
+    AP_HAL::I2CDevice *dev;
 
     // accumulation structure, protected by _sem
     struct {

--- a/libraries/AP_Baro/AP_Baro_KellerLD.cpp
+++ b/libraries/AP_Baro/AP_Baro_KellerLD.cpp
@@ -43,19 +43,16 @@ static const uint8_t CMD_PRANGE_MAX_LSB = 0x16;
 // write to this address to start pressure measurement
 static const uint8_t CMD_REQUEST_MEASUREMENT = 0xAC;
 
-AP_Baro_KellerLD::AP_Baro_KellerLD(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev)
+AP_Baro_KellerLD::AP_Baro_KellerLD(AP_Baro &baro, AP_HAL::Device &dev)
     : AP_Baro_Backend(baro)
-    , _dev(std::move(dev))
+    , _dev(&dev)
 {
 }
 
 // Look for the device on the bus and see if it responds appropriately
-AP_Baro_Backend *AP_Baro_KellerLD::probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev)
+AP_Baro_Backend *AP_Baro_KellerLD::probe(AP_Baro &baro, AP_HAL::Device &dev)
 {
-    if (!dev) {
-        return nullptr;
-    }
-    AP_Baro_KellerLD *sensor = NEW_NOTHROW AP_Baro_KellerLD(baro, std::move(dev));
+    AP_Baro_KellerLD *sensor = NEW_NOTHROW AP_Baro_KellerLD(baro, dev);
     if (!sensor || !sensor->_init()) {
         delete sensor;
         return nullptr;

--- a/libraries/AP_Baro/AP_Baro_KellerLD.h
+++ b/libraries/AP_Baro/AP_Baro_KellerLD.h
@@ -42,10 +42,10 @@ class AP_Baro_KellerLD : public AP_Baro_Backend
 public:
     void update() override;
 
-    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::Device &dev);
 
 private:
-    AP_Baro_KellerLD(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    AP_Baro_KellerLD(AP_Baro &baro, AP_HAL::Device &dev);
 
     bool _init();
 
@@ -55,7 +55,7 @@ private:
 
     void _update_and_wrap_accumulator(uint16_t pressure, uint16_t temperature, uint8_t max_count);
 
-    AP_HAL::OwnPtr<AP_HAL::Device> _dev;
+    AP_HAL::Device *_dev;
 
     /* Shared values between thread sampling the HW and main thread */
     /* These are raw outputs, not calculated values */

--- a/libraries/AP_Baro/AP_Baro_LPS2XH.cpp
+++ b/libraries/AP_Baro/AP_Baro_LPS2XH.cpp
@@ -56,20 +56,15 @@ extern const AP_HAL::HAL &hal;
 
 //putting 1 in the MSB of those two registers turns on Auto increment for faster reading.
 
-AP_Baro_LPS2XH::AP_Baro_LPS2XH(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev)
+AP_Baro_LPS2XH::AP_Baro_LPS2XH(AP_Baro &baro, AP_HAL::Device &dev)
     : AP_Baro_Backend(baro)
-    , _dev(std::move(dev))
+    , _dev(&dev)
 {
 }
 
-AP_Baro_Backend *AP_Baro_LPS2XH::probe(AP_Baro &baro,
-                                       AP_HAL::OwnPtr<AP_HAL::Device> dev)
+AP_Baro_Backend *AP_Baro_LPS2XH::probe(AP_Baro &baro, AP_HAL::Device &dev)
 {
-    if (!dev) {
-        return nullptr;
-    }
-
-    AP_Baro_LPS2XH *sensor = NEW_NOTHROW AP_Baro_LPS2XH(baro, std::move(dev));
+    AP_Baro_LPS2XH *sensor = NEW_NOTHROW AP_Baro_LPS2XH(baro, dev);
     if (!sensor || !sensor->_init()) {
         delete sensor;
         return nullptr;
@@ -79,14 +74,10 @@ AP_Baro_Backend *AP_Baro_LPS2XH::probe(AP_Baro &baro,
 }
 
 AP_Baro_Backend *AP_Baro_LPS2XH::probe_InvensenseIMU(AP_Baro &baro,
-                                                     AP_HAL::OwnPtr<AP_HAL::Device> dev,
+                                                     AP_HAL::Device &dev,
                                                      uint8_t imu_address)
 {
-    if (!dev) {
-        return nullptr;
-    }
-
-    AP_Baro_LPS2XH *sensor = NEW_NOTHROW AP_Baro_LPS2XH(baro, std::move(dev));
+    AP_Baro_LPS2XH *sensor = NEW_NOTHROW AP_Baro_LPS2XH(baro, dev);
     if (sensor) {
         if (!sensor->_imu_i2c_init(imu_address)) {
             delete sensor;
@@ -138,9 +129,6 @@ bool AP_Baro_LPS2XH::_imu_i2c_init(uint8_t imu_address)
 
 bool AP_Baro_LPS2XH::_init()
 {
-    if (!_dev) {
-        return false;
-    }
     _dev->get_semaphore()->take_blocking();
 
     _dev->set_speed(AP_HAL::Device::SPEED_HIGH);

--- a/libraries/AP_Baro/AP_Baro_LPS2XH.h
+++ b/libraries/AP_Baro/AP_Baro_LPS2XH.h
@@ -6,7 +6,6 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/Device.h>
-#include <AP_HAL/utility/OwnPtr.h>
 #include <AP_Math/AP_Math.h>
 
 #define HAL_BARO_LPS25H_I2C_BUS 0
@@ -24,13 +23,13 @@ public:
         BARO_LPS25H = 1,
     };
 
-    AP_Baro_LPS2XH(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    AP_Baro_LPS2XH(AP_Baro &baro, AP_HAL::Device &dev);
 
     /* AP_Baro public interface: */
     void update() override;
 
-    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
-    static AP_Baro_Backend *probe_InvensenseIMU(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev, uint8_t imu_address);
+    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::Device &dev);
+    static AP_Baro_Backend *probe_InvensenseIMU(AP_Baro &baro, AP_HAL::Device &dev, uint8_t imu_address);
 
 private:
     virtual ~AP_Baro_LPS2XH(void) {};
@@ -43,7 +42,7 @@ private:
 
     bool _check_whoami(void);
 
-    AP_HAL::OwnPtr<AP_HAL::Device> _dev;
+    AP_HAL::Device *_dev;
 
     uint8_t _instance;
     float _pressure_sum;

--- a/libraries/AP_Baro/AP_Baro_MS5611.cpp
+++ b/libraries/AP_Baro/AP_Baro_MS5611.cpp
@@ -57,12 +57,14 @@ static const uint8_t ADDR_CMD_CONVERT_TEMPERATURE = ADDR_CMD_CONVERT_D2_OSR1024;
 /*
   constructor
  */
-AP_Baro_MS56XX::AP_Baro_MS56XX(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev)
+AP_Baro_MS56XX::AP_Baro_MS56XX(AP_Baro &baro, AP_HAL::Device &dev)
     : AP_Baro_Backend(baro)
-    , _dev(std::move(dev))
+    , _dev(&dev)
 {
 }
 
+// convenience methods for derivative classes to call.  Will free
+// sensor if it can't init it.
 AP_Baro_Backend *AP_Baro_MS56XX::_probe(AP_Baro &baro, AP_Baro_MS56XX *sensor)
 {
     if (!sensor || !sensor->_init()) {
@@ -73,43 +75,39 @@ AP_Baro_Backend *AP_Baro_MS56XX::_probe(AP_Baro &baro, AP_Baro_MS56XX *sensor)
 }
 
 #if AP_BARO_MS5611_ENABLED
-AP_Baro_Backend *AP_Baro_MS5611::probe(AP_Baro &baro,
-                                       AP_HAL::OwnPtr<AP_HAL::Device> dev)
+AP_Baro_Backend *AP_Baro_MS5611::probe(AP_Baro &baro, AP_HAL::Device &dev)
 {
 #if AP_BARO_MS5607_ENABLED
     /*
       cope with vendors substituting a MS5607 for a MS5611 on Pixhawk1 'clone' boards
      */
     if (AP::baro().option_enabled(AP_Baro::Options::TreatMS5611AsMS5607)) {
-        return _probe(baro, NEW_NOTHROW AP_Baro_MS5607(baro, std::move(dev)));
+        return _probe(baro, NEW_NOTHROW AP_Baro_MS5607(baro, dev));
     }
 #endif  // AP_BARO_MS5607_ENABLED
 
-    return _probe(baro, NEW_NOTHROW AP_Baro_MS5611(baro, std::move(dev)));
+    return _probe(baro, NEW_NOTHROW AP_Baro_MS5611(baro, dev));
 }
 #endif  // AP_BARO_MS5611_ENABLED
 
 #if AP_BARO_MS5607_ENABLED
-AP_Baro_Backend *AP_Baro_MS5607::probe(AP_Baro &baro,
-                                       AP_HAL::OwnPtr<AP_HAL::Device> dev)
+AP_Baro_Backend *AP_Baro_MS5607::probe(AP_Baro &baro, AP_HAL::Device &dev)
 {
-    return _probe(baro, NEW_NOTHROW AP_Baro_MS5607(baro, std::move(dev)));
+    return _probe(baro, NEW_NOTHROW AP_Baro_MS5607(baro, dev));
 }
 #endif  // AP_BARO_MS5607_ENABLED
 
 #if AP_BARO_MS5637_ENABLED
-AP_Baro_Backend *AP_Baro_MS5637::probe(AP_Baro &baro,
-                                       AP_HAL::OwnPtr<AP_HAL::Device> dev)
+AP_Baro_Backend *AP_Baro_MS5637::probe(AP_Baro &baro, AP_HAL::Device &dev)
 {
-    return _probe(baro, NEW_NOTHROW AP_Baro_MS5637(baro, std::move(dev)));
+    return _probe(baro, NEW_NOTHROW AP_Baro_MS5637(baro, dev));
 }
 #endif  // AP_BARO_MS5637_ENABLED
 
 #if AP_BARO_MS5837_ENABLED
-AP_Baro_Backend *AP_Baro_MS5837::probe(AP_Baro &baro,
-                                       AP_HAL::OwnPtr<AP_HAL::Device> dev)
+AP_Baro_Backend *AP_Baro_MS5837::probe(AP_Baro &baro, AP_HAL::Device &dev)
 {
-    return _probe(baro, NEW_NOTHROW AP_Baro_MS5837(baro, std::move(dev)));
+    return _probe(baro, NEW_NOTHROW AP_Baro_MS5837(baro, dev));
 }
 
 bool AP_Baro_MS5837::_init()
@@ -124,10 +122,6 @@ bool AP_Baro_MS5837::_init()
 
 bool AP_Baro_MS56XX::_init()
 {
-    if (!_dev) {
-        return false;
-    }
-
     _dev->get_semaphore()->take_blocking();
 
     // high retries for init

--- a/libraries/AP_Baro/AP_Baro_MS5611.h
+++ b/libraries/AP_Baro/AP_Baro_MS5611.h
@@ -33,11 +33,12 @@ class AP_Baro_MS56XX : public AP_Baro_Backend
 public:
     void update() override;
 
-    AP_Baro_MS56XX(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    AP_Baro_MS56XX(AP_Baro &baro, AP_HAL::Device &dev);
 
 protected:
 
-    // convenience methods for derivative classes to call:
+    // convenience methods for derivative classes to call.  Will free
+    // sensor if it can't init it.
     static AP_Baro_Backend *_probe(AP_Baro &baro, AP_Baro_MS56XX *sensor);
 
     virtual bool _init();
@@ -60,6 +61,8 @@ protected:
 
 private:
 
+    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::Device &dev);
+
     /*
      * Update @accum and @count with the new sample in @val, taking into
      * account a maximum number of samples given by @max_count; in case
@@ -73,7 +76,7 @@ private:
 
     void _timer();
 
-    AP_HAL::OwnPtr<AP_HAL::Device> _dev;
+    AP_HAL::Device *_dev;
 
     /* Shared values between thread sampling the HW and main thread */
     struct {
@@ -96,7 +99,7 @@ class AP_Baro_MS5607 : public AP_Baro_MS56XX
 {
 public:
     using AP_Baro_MS56XX::AP_Baro_MS56XX;
-    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::Device &dev);
 protected:
     const char *name() const override { return "MS5607"; }
     bool _read_prom(uint16_t *prom) override { return _read_prom_5611(prom); }
@@ -110,7 +113,7 @@ class AP_Baro_MS5611 : public AP_Baro_MS56XX
 {
 public:
     using AP_Baro_MS56XX::AP_Baro_MS56XX;
-    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::Device &dev);
 protected:
     const char *name() const override { return "MS5611"; }
     bool _read_prom(uint16_t *prom) override { return _read_prom_5611(prom); }
@@ -124,7 +127,7 @@ class AP_Baro_MS5637 : public AP_Baro_MS56XX
 {
 public:
     using AP_Baro_MS56XX::AP_Baro_MS56XX;
-    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::Device &dev);
 protected:
     const char *name() const override { return "MS5637"; }
     bool _read_prom(uint16_t *prom) override { return _read_prom_5637(prom); }
@@ -138,7 +141,7 @@ class AP_Baro_MS5837 : public AP_Baro_MS56XX
 {
 public:
     using AP_Baro_MS56XX::AP_Baro_MS56XX;
-    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::Device &dev);
 protected:
     const char *name() const override { return "MS5837"; }
     bool _read_prom(uint16_t *prom) override { return _read_prom_5637(prom); }

--- a/libraries/AP_Baro/AP_Baro_SPL06.cpp
+++ b/libraries/AP_Baro/AP_Baro_SPL06.cpp
@@ -82,24 +82,19 @@ extern const AP_HAL::HAL &hal;
 #define AP_BARO_SPL06_BACKGROUND_ENABLE 1
 #endif
 
-AP_Baro_SPL06::AP_Baro_SPL06(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev)
+AP_Baro_SPL06::AP_Baro_SPL06(AP_Baro &baro, AP_HAL::Device &dev)
     : AP_Baro_Backend(baro)
-    , _dev(std::move(dev))
+    , _dev(&dev)
 {
 }
 
-AP_Baro_Backend *AP_Baro_SPL06::probe(AP_Baro &baro,
-                                       AP_HAL::OwnPtr<AP_HAL::Device> dev)
+AP_Baro_Backend *AP_Baro_SPL06::probe(AP_Baro &baro, AP_HAL::Device &dev)
 {
-    if (!dev) {
-        return nullptr;
+    if (dev.bus_type() == AP_HAL::Device::BUS_TYPE_SPI) {
+        dev.set_read_flag(0x80);
     }
 
-    if (dev->bus_type() == AP_HAL::Device::BUS_TYPE_SPI) {
-        dev->set_read_flag(0x80);
-    }
-
-    AP_Baro_SPL06 *sensor = NEW_NOTHROW AP_Baro_SPL06(baro, std::move(dev));
+    AP_Baro_SPL06 *sensor = NEW_NOTHROW AP_Baro_SPL06(baro, dev);
     if (!sensor || !sensor->_init()) {
         delete sensor;
         return nullptr;
@@ -109,9 +104,6 @@ AP_Baro_Backend *AP_Baro_SPL06::probe(AP_Baro &baro,
 
 bool AP_Baro_SPL06::_init()
 {
-    if (!_dev) {
-        return false;
-    }
     WITH_SEMAPHORE(_dev->get_semaphore());
 
     _dev->set_speed(AP_HAL::Device::SPEED_HIGH);

--- a/libraries/AP_Baro/AP_Baro_SPL06.h
+++ b/libraries/AP_Baro/AP_Baro_SPL06.h
@@ -6,7 +6,6 @@
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/Device.h>
-#include <AP_HAL/utility/OwnPtr.h>
 
 #ifndef HAL_BARO_SPL06_I2C_ADDR
  #define HAL_BARO_SPL06_I2C_ADDR  (0x76)
@@ -23,12 +22,12 @@ public:
 		SPL06,
 		SPA06,
 	};
-    AP_Baro_SPL06(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    AP_Baro_SPL06(AP_Baro &baro, AP_HAL::Device &dev);
 
     /* AP_Baro public interface: */
     void update() override;
 
-    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    static AP_Baro_Backend *probe(AP_Baro &baro, AP_HAL::Device &dev);
 
 private:
 
@@ -39,7 +38,7 @@ private:
 
     int32_t raw_value_scale_factor(uint8_t);
 
-    AP_HAL::OwnPtr<AP_HAL::Device> _dev;
+    AP_HAL::Device *_dev;
 
     int8_t _timer_counter;
     uint8_t _instance;

--- a/libraries/AP_Baro/examples/ICM20789/ICM20789.cpp
+++ b/libraries/AP_Baro/examples/ICM20789/ICM20789.cpp
@@ -11,10 +11,6 @@
 
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
-static AP_HAL::OwnPtr<AP_HAL::Device> i2c_dev;
-static AP_HAL::OwnPtr<AP_HAL::Device> spi_dev;
-static AP_HAL::OwnPtr<AP_HAL::Device> dev;
-
 // SPI registers
 #define MPUREG_WHOAMI                           0x75
 #define MPUREG_USER_CTRL                        0x6A
@@ -268,12 +264,12 @@ void setup()
     hal.scheduler->delay(1000);
 
 #ifdef HAL_INS_MPU60x0_NAME
-    spi_dev = std::move(hal.spi->get_device(HAL_INS_MPU60x0_NAME));
+    spi_dev = hal.spi->get_device_ptr(HAL_INS_MPU60x0_NAME));
 
     spi_dev->get_semaphore()->take_blocking();
 
-    i2c_dev = std::move(hal.i2c_mgr->get_device(1, 0x63));
-    dev = std::move(hal.i2c_mgr->get_device(1, 0x29));
+    i2c_dev = hal.i2c_mgr->get_device_ptr(1, 0x63));
+    dev = hal.i2c_mgr->get_device_ptr(1, 0x29);
 
     while (true) {
         spi_init();


### PR DESCRIPTION
I've flashed this onto CubeOrangePlus and ZeroOneX6 and both still see their baros.

Everything that built still builds.

Things still seem to have all of the baro features they used to have.

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  -896              *                                                   
CubeRedPrimary                      -800   *           -800    -800              -800   -800   -912
Durandal                            -904   *           -904    -904              -896   -896   -1112
Hitec-Airspeed           *                 *                                                   
KakuteH7-bdshot                     -944   *           -952    -944              -952   -952   -1184
MatekF405                           -112   *           -112    -112              -112   -104   -104
Pixhawk1-1M-bdshot                  -128               -128    -120              -128   -120   -344
f103-QiotekPeriph        *                 *                                                   
f303-Universal           -896              *                                                   
iomcu                                                                *                         
revo-mini                           -160   *           -160    -160              -160   -160   -392
skyviper-journey                                       -952                                    
skyviper-v2450                                         -48                                     
```

Looking more closely at the Durandal changes:
![image](https://github.com/user-attachments/assets/79abcec4-d526-4ef3-bfae-8c98e1ef6e10)

And each of the probe functions gets smaller:
![image](https://github.com/user-attachments/assets/25e5454c-fc6f-48ad-9e51-66e748cf4345)
![image](https://github.com/user-attachments/assets/9e45ec7c-d78a-43f6-8142-88464a9bc368)

... and the compiler is optimising better in there, too.

There's a couple of obvious follow-up cleanups which will save more bytes.
 - holding reference-to-device rather than pointer-to-device
 - possible creation of AP_Baro_I2C or similar as common base class for I2C barometers (init and constructors can be shared)
