### PR TITLE
Copter: stop passing control in value to get_pilot_desired_climb_rate

### DIFF
--- a/ArduCopter/AP_Arming_Copter.cpp
+++ b/ArduCopter/AP_Arming_Copter.cpp
@@ -621,7 +621,7 @@ bool AP_Arming_Copter::arm_checks(AP_Arming::Method method)
         // check throttle is not too high - skips checks if arming from GCS/scripting in Guided,Guided_NoGPS or Auto 
         if (!((AP_Arming::method_is_GCS(method) || method == AP_Arming::Method::SCRIPTING) && copter.flightmode->allows_GCS_or_SCR_arming_with_throttle_high())) {
             // above top of deadband is too always high
-            if (copter.get_pilot_desired_climb_rate(copter.channel_throttle->get_control_in()) > 0.0f) {
+            if (copter.get_pilot_desired_climb_rate() > 0.0f) {
                 check_failed(Check::RC, true, "%s too high", rc_item);
                 return false;
             }

--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -62,12 +62,14 @@ void Copter::update_throttle_hover()
 
 // get_pilot_desired_climb_rate - transform pilot's throttle input to climb rate in cm/s
 // without any deadzone at the bottom
-float Copter::get_pilot_desired_climb_rate(float throttle_control)
+float Copter::get_pilot_desired_climb_rate()
 {
     // throttle failsafe check
     if (failsafe.radio || !rc().has_ever_seen_rc_input()) {
         return 0.0f;
     }
+
+    float throttle_control = copter.channel_throttle->get_control_in();
 
 #if TOY_MODE_ENABLED
     if (g2.toy_mode.enabled()) {

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -732,7 +732,7 @@ private:
 
     // Attitude.cpp
     void update_throttle_hover();
-    float get_pilot_desired_climb_rate(float throttle_control);
+    float get_pilot_desired_climb_rate();
     float get_non_takeoff_throttle();
     void set_accel_throttle_I_from_pilot_throttle();
     void rotate_body_frame_to_NE(float &x, float &y);

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -1021,9 +1021,9 @@ float Mode::get_pilot_desired_yaw_rate() const
 // pass-through functions to reduce code churn on conversion;
 // these are candidates for moving into the Mode base
 // class.
-float Mode::get_pilot_desired_climb_rate(float throttle_control)
+float Mode::get_pilot_desired_climb_rate()
 {
-    return copter.get_pilot_desired_climb_rate(throttle_control);
+    return copter.get_pilot_desired_climb_rate();
 }
 
 float Mode::get_non_takeoff_throttle()

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -390,7 +390,7 @@ public:
     // pass-through functions to reduce code churn on conversion;
     // these are candidates for moving into the Mode base
     // class.
-    float get_pilot_desired_climb_rate(float throttle_control);
+    float get_pilot_desired_climb_rate();
     float get_non_takeoff_throttle(void);
     void update_simple_mode(void);
     bool set_mode(Mode::Number mode, ModeReason reason);

--- a/ArduCopter/mode_althold.cpp
+++ b/ArduCopter/mode_althold.cpp
@@ -39,7 +39,7 @@ void ModeAltHold::run()
     float target_yaw_rate = get_pilot_desired_yaw_rate();
 
     // get pilot desired climb rate
-    float target_climb_rate = get_pilot_desired_climb_rate(channel_throttle->get_control_in());
+    float target_climb_rate = get_pilot_desired_climb_rate();
     target_climb_rate = constrain_float(target_climb_rate, -get_pilot_speed_dn(), g.pilot_speed_up);
 
     // Alt Hold State Machine Determination

--- a/ArduCopter/mode_autotune.cpp
+++ b/ArduCopter/mode_autotune.cpp
@@ -60,7 +60,7 @@ void AutoTune::run()
  */
 float AutoTune::get_pilot_desired_climb_rate_cms(void) const
 {
-    float target_climb_rate = copter.get_pilot_desired_climb_rate(copter.channel_throttle->get_control_in());
+    float target_climb_rate = copter.get_pilot_desired_climb_rate();
 
     // get avoidance adjusted climb rate
     target_climb_rate = copter.mode_autotune.get_avoidance_adjusted_climbrate(target_climb_rate);

--- a/ArduCopter/mode_circle.cpp
+++ b/ArduCopter/mode_circle.cpp
@@ -100,7 +100,7 @@ void ModeCircle::run()
     }
 
     // get pilot desired climb rate (or zero if in radio failsafe)
-    float target_climb_rate = get_pilot_desired_climb_rate(channel_throttle->get_control_in());
+    float target_climb_rate = get_pilot_desired_climb_rate();
 
     // get avoidance adjusted climb rate
     target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);

--- a/ArduCopter/mode_flowhold.cpp
+++ b/ArduCopter/mode_flowhold.cpp
@@ -244,7 +244,7 @@ void ModeFlowHold::run()
     }
 
     // get pilot desired climb rate
-    float target_climb_rate = copter.get_pilot_desired_climb_rate(copter.channel_throttle->get_control_in());
+    float target_climb_rate = copter.get_pilot_desired_climb_rate();
     target_climb_rate = constrain_float(target_climb_rate, -get_pilot_speed_dn(), copter.g.pilot_speed_up);
 
     // get pilot's desired yaw rate

--- a/ArduCopter/mode_loiter.cpp
+++ b/ArduCopter/mode_loiter.cpp
@@ -105,7 +105,7 @@ void ModeLoiter::run()
         target_yaw_rate = get_pilot_desired_yaw_rate();
 
         // get pilot desired climb rate
-        target_climb_rate = get_pilot_desired_climb_rate(channel_throttle->get_control_in());
+        target_climb_rate = get_pilot_desired_climb_rate();
         target_climb_rate = constrain_float(target_climb_rate, -get_pilot_speed_dn(), g.pilot_speed_up);
     } else {
         // clear out pilot desired acceleration in case radio failsafe event occurs and we do not switch to RTL for some reason

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -86,7 +86,7 @@ void ModePosHold::run()
     float target_yaw_rate = get_pilot_desired_yaw_rate();
 
     // get pilot desired climb rate (for alt-hold mode and take-off)
-    float target_climb_rate = get_pilot_desired_climb_rate(channel_throttle->get_control_in());
+    float target_climb_rate = get_pilot_desired_climb_rate();
     target_climb_rate = constrain_float(target_climb_rate, -get_pilot_speed_dn(), g.pilot_speed_up);
 
     // relax loiter target if we might be landed

--- a/ArduCopter/mode_sport.cpp
+++ b/ArduCopter/mode_sport.cpp
@@ -65,7 +65,7 @@ void ModeSport::run()
     float target_yaw_rate = get_pilot_desired_yaw_rate();
 
     // get pilot desired climb rate
-    float target_climb_rate = get_pilot_desired_climb_rate(channel_throttle->get_control_in());
+    float target_climb_rate = get_pilot_desired_climb_rate();
     target_climb_rate = constrain_float(target_climb_rate, -get_pilot_speed_dn(), g.pilot_speed_up);
 
     // Sport State Machine Determination

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -308,7 +308,7 @@ void ModeZigZag::manual_control()
         target_yaw_rate = get_pilot_desired_yaw_rate();
 
         // get pilot desired climb rate
-        target_climb_rate = get_pilot_desired_climb_rate(channel_throttle->get_control_in());
+        target_climb_rate = get_pilot_desired_climb_rate();
         // make sure the climb rate is in the given range, prevent floating point errors
         target_climb_rate = constrain_float(target_climb_rate, -get_pilot_speed_dn(), g.pilot_speed_up);
     } else {


### PR DESCRIPTION
these are always the same value, so simplify things

Makes this method look like several other methods which consume data from rc() directly rather than having it passed in eg. `get_pilot_desired_lean_angles`
