### PR TITLE
Copter: Enable the disarm operation until the disarm is completed

### DIFF
--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -58,7 +58,7 @@ void Copter::arm_motors_check()
         }
 
         // increase the counter to a maximum of 1 beyond the disarm delay
-        if (arming_counter <= DISARM_DELAY) {
+        if (arming_counter < DISARM_DELAY) {
             arming_counter++;
         }
 


### PR DESCRIPTION
The processing is different when the operation is continued for both arm and disarm operations. 
The disarm operation will remain active until the disarm is completed.