### PR TITLE
AP_Proximity: PROXIMITY is optional, so the number of devices can be specified

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -87,7 +87,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     // @Path: AP_Proximity_MR72_CAN.cpp
     AP_SUBGROUPVARPTR(drivers[0], "1_",  26, AP_Proximity, backend_var_info[0]),
 
-#if PROXIMITY_MAX_INSTANCES > 1
+#if AP_PROXIMITY_MAX_INSTANCES > 1
     // @Group: 2
     // @Path: AP_Proximity_Params.cpp
     AP_SUBGROUPINFO(params[1], "2", 22, AP_Proximity, AP_Proximity_Params),
@@ -97,7 +97,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     AP_SUBGROUPVARPTR(drivers[1], "2_",  27, AP_Proximity, backend_var_info[1]),
 #endif
 
-#if PROXIMITY_MAX_INSTANCES > 2
+#if AP_PROXIMITY_MAX_INSTANCES > 2
     // @Group: 3
     // @Path: AP_Proximity_Params.cpp
     AP_SUBGROUPINFO(params[2], "3", 23, AP_Proximity, AP_Proximity_Params),
@@ -107,7 +107,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     AP_SUBGROUPVARPTR(drivers[2], "3_",  28, AP_Proximity, backend_var_info[2]),
 #endif
 
-#if PROXIMITY_MAX_INSTANCES > 3
+#if AP_PROXIMITY_MAX_INSTANCES > 3
     // @Group: 4
     // @Path: AP_Proximity_Params.cpp
     AP_SUBGROUPINFO(params[3], "4", 24, AP_Proximity, AP_Proximity_Params),
@@ -117,7 +117,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     AP_SUBGROUPVARPTR(drivers[3], "4_",  29, AP_Proximity, backend_var_info[3]),
 #endif
 
-#if PROXIMITY_MAX_INSTANCES > 4
+#if AP_PROXIMITY_MAX_INSTANCES > 4
     // @Group: 5
     // @Path: AP_Proximity_Params.cpp
     AP_SUBGROUPINFO(params[4], "5", 30, AP_Proximity, AP_Proximity_Params),
@@ -130,7 +130,7 @@ const AP_Param::GroupInfo AP_Proximity::var_info[] = {
     AP_GROUPEND
 };
 
-const AP_Param::GroupInfo *AP_Proximity::backend_var_info[PROXIMITY_MAX_INSTANCES];
+const AP_Param::GroupInfo *AP_Proximity::backend_var_info[AP_PROXIMITY_MAX_INSTANCES];
 
 AP_Proximity::AP_Proximity()
 {
@@ -155,7 +155,7 @@ void AP_Proximity::init()
     // instantiate backends
     uint8_t serial_instance = 0;
     (void)serial_instance;  // in case no serial backends are compiled in
-    for (uint8_t instance=0; instance<PROXIMITY_MAX_INSTANCES; instance++) {
+    for (uint8_t instance=0; instance<AP_PROXIMITY_MAX_INSTANCES; instance++) {
         switch (get_type(instance)) {
         case Type::None:
             break;
@@ -306,7 +306,7 @@ void AP_Proximity::update()
 
 AP_Proximity::Type AP_Proximity::get_type(uint8_t instance) const
 {
-    if (instance < PROXIMITY_MAX_INSTANCES) {
+    if (instance < AP_PROXIMITY_MAX_INSTANCES) {
         return (Type)((uint8_t)params[instance].type);
     }
     return Type::None;
@@ -576,7 +576,7 @@ void AP_Proximity::log()
 // return true if the given instance exists
 bool AP_Proximity::valid_instance(uint8_t i) const
 {
-    if (i >= PROXIMITY_MAX_INSTANCES) {
+    if (i >= AP_PROXIMITY_MAX_INSTANCES) {
         return false;
     }
 

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -28,7 +28,9 @@
 
 #include <AP_HAL/Semaphores.h>
 
-#define PROXIMITY_MAX_INSTANCES             5   // Maximum number of proximity sensor instances available on this platform
+#ifndef AP_PROXIMITY_MAX_INSTANCES 
+  #define AP_PROXIMITY_MAX_INSTANCES             5   // Maximum number of proximity sensor instances available on this platform
+#endif
 #define PROXIMITY_SENSOR_ID_START 10
 
 class AP_Proximity_Backend;
@@ -191,7 +193,7 @@ public:
         const struct AP_Param::GroupInfo *var_info; // stores extra parameter information for the sensor (if it exists)
     };
 
-    static const struct AP_Param::GroupInfo *backend_var_info[PROXIMITY_MAX_INSTANCES];
+    static const struct AP_Param::GroupInfo *backend_var_info[AP_PROXIMITY_MAX_INSTANCES];
 
     // parameter list
     static const struct AP_Param::GroupInfo var_info[];
@@ -209,18 +211,18 @@ public:
 
     // get proximity address (for AP_Periph CAN)
     uint8_t get_address(uint8_t id) const {
-        return id >= PROXIMITY_MAX_INSTANCES? 0 : uint8_t(params[id].address.get());
+        return id >= AP_PROXIMITY_MAX_INSTANCES? 0 : uint8_t(params[id].address.get());
     }
 
 protected:
 
     // parameters for backends
-    AP_Proximity_Params params[PROXIMITY_MAX_INSTANCES];
+    AP_Proximity_Params params[AP_PROXIMITY_MAX_INSTANCES];
 
 private:
     static AP_Proximity *_singleton;
-    Proximity_State state[PROXIMITY_MAX_INSTANCES];
-    AP_Proximity_Backend *drivers[PROXIMITY_MAX_INSTANCES];
+    Proximity_State state[AP_PROXIMITY_MAX_INSTANCES];
+    AP_Proximity_Backend *drivers[AP_PROXIMITY_MAX_INSTANCES];
     uint8_t num_instances;
 
     // return true if the given instance exists

--- a/libraries/AP_Proximity/AP_Proximity_DroneCAN.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_DroneCAN.cpp
@@ -53,7 +53,7 @@ AP_Proximity_DroneCAN* AP_Proximity_DroneCAN::get_dronecan_backend(AP_DroneCAN* 
 
     AP_Proximity_DroneCAN* driver = nullptr;
     //Scan through the proximity type params to find DroneCAN with matching address.
-    for (uint8_t i = 0; i < PROXIMITY_MAX_INSTANCES; i++) {
+    for (uint8_t i = 0; i < AP_PROXIMITY_MAX_INSTANCES; i++) {
         if ((AP_Proximity::Type)prx->params[i].type.get() == AP_Proximity::Type::DroneCAN &&
             prx->params[i].address == address) {
             driver = (AP_Proximity_DroneCAN*)prx->drivers[i];
@@ -72,7 +72,7 @@ AP_Proximity_DroneCAN* AP_Proximity_DroneCAN::get_dronecan_backend(AP_DroneCAN* 
     }
 
     if (create_new) {
-        for (uint8_t i = 0; i < PROXIMITY_MAX_INSTANCES; i++) {
+        for (uint8_t i = 0; i < AP_PROXIMITY_MAX_INSTANCES; i++) {
             if ((AP_Proximity::Type)prx->params[i].type.get() == AP_Proximity::Type::DroneCAN &&
                 prx->params[i].address == address) {
                 WITH_SEMAPHORE(prx->detect_sem);


### PR DESCRIPTION
PROXIMITY devices are optional. 
Recently, the number of devices increased from 4 to 5. 
Therefore, the number of devices will be configurable.

AFTER
![Screenshot from 2025-04-24 02-19-03](https://github.com/user-attachments/assets/521015c8-fa4d-4aa7-8b57-48f1c4917299)

BEFORE
![Screenshot from 2025-04-24 02-08-05](https://github.com/user-attachments/assets/b0dc00e3-8e81-4836-a016-a7fea9cb56b8)