### PR TITLE
Fixup lua language server CI

### DIFF
--- a/.github/problem-matchers/Lua.json
+++ b/.github/problem-matchers/Lua.json
@@ -15,16 +15,14 @@
         },
         {
             "owner": "Lua-language-server-problem-matcher",
+            "fileLocation": [ "relative", "${GITHUB_WORKSPACE}" ],
             "pattern": [
                 {
-                    "regexp": "^(.+.lua):(\\d+):(\\d+)",
+                    "regexp": "^(.+\\.lua):(\\d+):(\\d+)(.*)$",
                     "file": 1,
                     "line": 2,
-                    "column": 3
-                },
-                {
-                    "regexp": "^(.*)",
-                    "message": 1
+                    "column": 3,
+                    "message": 4
                 }
             ]
         }

--- a/.github/workflows/test_scripting.yml
+++ b/.github/workflows/test_scripting.yml
@@ -29,8 +29,10 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: Register lua problem matcher
-        run: echo "::add-matcher::.github/problem-matchers/Lua.json"
+      - name: Register lua check problem matcher
+        run: |
+          echo "::add-matcher::.github/problem-matchers/Lua.json"
+          echo "::remove-matcher owner=Lua-language-server-problem-matcher::"
 
       - name: Lua Linter
         shell: bash
@@ -39,11 +41,21 @@ jobs:
           sudo apt-get -y install lua-check
           ./Tools/scripts/run_luacheck.sh
 
+      - name: Register lua language server problem matcher
+        run: |
+          echo "::add-matcher::.github/problem-matchers/Lua.json"
+          echo "::remove-matcher owner=Luacheck-problem-matcher::"
+
       - name: Language server check
         shell: bash
         run: |
           python3 -m pip install github-release-downloader
           python3 ./Tools/scripts/run_lua_language_check.py
+
+      - name: Remove problem matchers
+        run: |
+          echo "::remove-matcher owner=Luacheck-problem-matcher::"
+          echo "::remove-matcher owner=Lua-language-server-problem-matcher::"
 
       - name: Generate docs md
         shell: bash

--- a/Tools/scripts/run_lua_language_check.py
+++ b/Tools/scripts/run_lua_language_check.py
@@ -12,38 +12,10 @@ import optparse
 import sys
 import os
 import pathlib
-import json
 import shutil
 import platform
-from urllib.parse import unquote
 import subprocess
 import re
-
-
-def print_failures(file_name, fails, original_name):
-    file_name = unquote(file_name)
-    file_path = pathlib.Path(file_name[5:])
-
-    if (original_name is not None) and (original_name.name == file_path.name):
-        file_path = original_name
-
-    for fail in fails:
-        start = fail['range']['start']
-
-        # These seem to be off by one, not sure why
-        line = start['line'] + 1
-        character = start['character'] + 1
-
-        print("%s:%i:%i" % (file_path, line, character))
-
-        print("\tCode: %s" % fail['code'])
-        message = fail['message'].split("\n")
-        for line in message:
-            print("\t%s" % line)
-
-    print()
-    return len(fails)
-
 
 if __name__ == '__main__':
 
@@ -145,6 +117,22 @@ if __name__ == '__main__':
             elif checked_files != count:
                 raise Exception("Checked files error expected: %i got: %i" % (checked_files, count))
 
+    # Grab the summary line to so we can error out for errors
+    summary = None
+    summary_re = re.compile(r"^Diagnosis (?:complete|completed), (\d+|no) problems found")
+    for line in result:
+        match = summary_re.search(line)
+        if match is not None:
+            summary = match
+
+    if summary is None:
+        raise Exception("Could not complete Diagnosis")
+
+    # Get number of errors
+    errors = 0
+    if summary.group(1) != "no":
+        errors = int(summary.group(1))
+
     if tmp_check_dir is not None:
         # Remove test directory
         shutil.rmtree(tmp_check_dir)
@@ -152,20 +140,6 @@ if __name__ == '__main__':
     elif docs_copy is not None:
         # remove copy of docs
         os.remove(docs_copy)
-
-    # Read output
-    errors = 0
-    result = (logs / "check.json").resolve()
-    if os.path.exists(result):
-        # File only created if there are errors
-        f = open((logs / "check.json").resolve())
-        data = json.load(f)
-        f.close()
-
-        if len(data) > 0:
-            # Print output if there are any errors
-            for key, value in data.items():
-                errors += print_failures(key, value, original_name)
 
     # Remove output
     shutil.rmtree(logs)

--- a/libraries/AP_Scripting/applets/RockBlock.lua
+++ b/libraries/AP_Scripting/applets/RockBlock.lua
@@ -760,6 +760,7 @@ function HLSatcom()
     --- check if GCS telemetry has been lost for RCK_TIMEOUT sec (if param enabled)
     if RCK_FORCEHL:get() == 2 then
         -- link lost time = boot time - GCS last seen time
+        ---@diagnostic disable-next-line cast-local-type
         link_lost_for = millis():toint() - gcs:last_seen()
         -- gcs:last_seen() is set to millis() during boot (on plane). 0 on rover/copter
         -- So if it's less than 10000 assume no GCS packet received since boot

--- a/libraries/AP_Scripting/examples/MAVLinkHL.lua
+++ b/libraries/AP_Scripting/examples/MAVLinkHL.lua
@@ -415,6 +415,7 @@ function HLSatcom()
     -- if mode 1 and there's been no mavlink traffic for 5000 ms, enable high latency
     if hl_mode == 1 then
         -- link lost time = boot time - GCS last seen time
+        ---@diagnostic disable-next-line cast-local-type
         link_lost_for = millis():toint() - gcs:last_seen()
         -- gcs:last_seen() is set to millis() during boot (on plane). 0 on rover/copter
         -- So if it's less than 10000 assume no GCS packet received since boot


### PR DESCRIPTION
Our lua language server CI has been incorrectly passing thanks to some recent changes to the language server. This updates so it correctly fails (and fixes the issues that crept in)

I can't get the problem matcher to work again, so no nice annotations, `fileLocation` seems to not work. It works fine for the luacheck problem matcher, so I have no idea.

A alternate fix would be to add `--check_format json` to the call to the language server. But the new native error printing is nicer than what I had done in python by parsing the json. Just we loose the problem match.