### PR TITLE
Sub:stop spammin depth sensor messages

### DIFF
--- a/ArduSub/mode.cpp
+++ b/ArduSub/mode.cpp
@@ -95,9 +95,9 @@ bool Sub::set_mode(Mode::Number mode, ModeReason reason)
 
     // check for valid altitude if old mode did not require it but new one does
     // we only want to stop changing modes if it could make things worse
-    if (!sub.control_check_barometer() && // maybe use ekf_alt_ok() instead?
-        flightmode->has_manual_throttle() &&
-        !new_flightmode->has_manual_throttle()) {
+    if (flightmode->has_manual_throttle() &&
+        !new_flightmode->has_manual_throttle() &&
+        !sub.control_check_barometer()) { // maybe use ekf_alt_ok() instead?
         gcs().send_text(MAV_SEVERITY_WARNING, "Mode change failed: %s need alt estimate", new_flightmode->name());
         LOGGER_WRITE_ERROR(LogErrorSubsystem::FLIGHT_MODE, LogErrorCode(mode));
         return false;


### PR DESCRIPTION
all mode  changes spam when there is no depth sensor, even on mode changes not requiring one...this just changes the early return order to avoid this....no logic change to the IF statement per see

tested on CubeOrange