### PR TITLE
AP_Baro: Modify the GCC static analysis warning

### DIFF
--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -651,7 +651,7 @@ void AP_Baro::init(void)
     case AP_BoardConfig::PX4_BOARD_PCNC1:
 #if AP_BARO_ICM20789_ENABLED
         ADD_BACKEND(AP_Baro_ICM20789::probe(*this,
-                                            std::move(GET_I2C_DEVICE(1, 0x63)),
+                                            GET_I2C_DEVICE(1, 0x63),
                                             std::move(hal.spi->get_device(HAL_INS_MPU60x0_NAME))));
 #endif
         break;


### PR DESCRIPTION
I received a warning from GCC.
I modified the warning.

[ 879/1232] Compiling libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
../../libraries/AP_Baro/AP_Baro.cpp: In member function 'void AP_Baro::init()':
../../libraries/AP_Baro/AP_Baro.cpp:654:54: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
  654 |                                             std::move(GET_I2C_DEVICE(1, 0x63)),
      |                                             ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
../../libraries/AP_Baro/AP_Baro.cpp:521:23: note: in definition of macro 'ADD_BACKEND'
  521 |     do { _add_backend(backend);     \
      |                       ^~~~~~~
../../libraries/AP_Baro/AP_Baro.cpp:654:54: note: remove 'std::move' call
  654 |                                             std::move(GET_I2C_DEVICE(1, 0x63)),
      |                                             ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
../../libraries/AP_Baro/AP_Baro.cpp:521:23: note: in definition of macro 'ADD_BACKEND'
  521 |     do { _add_backend(backend);     \
      |                       ^~~~~~~

