### PR TITLE
AP_GPS: NOVA: fix undulation

### DIFF
--- a/libraries/AP_GPS/AP_GPS_NOVA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NOVA.cpp
@@ -211,7 +211,7 @@ AP_GPS_NOVA::process_message(void)
         state.location.lat = (int32_t) (bestposu.lat * (double)1e7);
         state.location.lng = (int32_t) (bestposu.lng * (double)1e7);
         state.have_undulation = true;
-        state.undulation = bestposu.undulation;
+        state.undulation = -bestposu.undulation;
         set_alt_amsl_cm(state, bestposu.hgt * 100);
 
         state.num_sats = bestposu.svsused;


### PR DESCRIPTION
Required for the ellipsoid height to be broadcast correctly over e.g. MAVLink. Tested on a NovAtel OEM719.

[Geoid information](https://www.unavco.org/software/geodetic-utilities/geoid-height-calculator/geoid-height-calculator.html) using EGM96 from my (approximate) back yard showing an ellipsoid height of 63.364m, an undulation of -28.35m, and a mean sea level height of 91.71m: 

![Screenshot from 2025-04-23 20-45-19](https://github.com/user-attachments/assets/adee4102-03f5-426d-b174-b4e9e0be4430)

Before this PR, the GPS shows a mean sea level height of 91.664m (correct), but an ellipsoid height of 119.964m (incorrect):
![Screenshot from 2025-04-23 20-45-35](https://github.com/user-attachments/assets/addd55c6-2665-4b3c-ba7c-a38593e877d1)

After this PR, the GPS shows a mean sea level height of 86.039m (correct, slightly different day and location), and an ellipsoid height of 57.739m (correct):
![Screenshot from 2025-04-25 20-59-38](https://github.com/user-attachments/assets/6dddedd0-d20a-4b6e-a65f-60254aad2306)
