### PR TITLE
Follow kinematic shaping

### DIFF
--- a/ArduCopter/mode_follow.cpp
+++ b/ArduCopter/mode_follow.cpp
@@ -47,6 +47,10 @@ void ModeFollow::run()
         return;
     }
 
+    // set offsets to current relative position if not already set
+    // this is done here to prevent the vehicle coliding with the target vehicle
+    g2.follow.init_offsets_if_required();
+
     // set motors to full range
     motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -1,17 +1,27 @@
 /*
-   This program is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License for more details.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-   You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+//==============================================================================
+// AP_Follow Library
+// Target Following Logic for ArduPilot Vehicles
+//==============================================================================
+
+
+//==============================================================================
+// Includes
+//==============================================================================
 
 #include "AP_Follow_config.h"
 
@@ -26,10 +36,16 @@
 #include <AP_Logger/AP_Logger.h>
 #include <GCS_MAVLink/GCS.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
+#include <AP_Scheduler/AP_Scheduler.h>
 
 extern const AP_HAL::HAL& hal;
 
-#define AP_FOLLOW_TIMEOUT_MS    3000    // position estimate timeout after 1 second
+
+//==============================================================================
+// Constants and Definitions
+//==============================================================================
+
+#define AP_FOLLOW_TIMEOUT_MS    3000    // position estimate timeout
 #define AP_FOLLOW_SYSID_TIMEOUT_MS 10000 // forget sysid we are following if we have not heard from them in 10 seconds
 
 #define AP_FOLLOW_OFFSET_TYPE_NED       0   // offsets are in north-east-down frame
@@ -40,10 +56,17 @@ extern const AP_HAL::HAL& hal;
 #define AP_FOLLOW_POS_P_DEFAULT 0.1f    // position error gain default
 
 #if APM_BUILD_TYPE(APM_BUILD_ArduPlane)
-#define AP_FOLLOW_ALT_TYPE_DEFAULT 0
+ #define AP_FOLLOW_ALT_TYPE_DEFAULT 0
+ #define AP_FOLLOW_DIST_MAX_DEFAULT 0
 #else
-#define AP_FOLLOW_ALT_TYPE_DEFAULT AP_FOLLOW_ALTITUDE_TYPE_RELATIVE
+ #define AP_FOLLOW_ALT_TYPE_DEFAULT AP_FOLLOW_ALTITUDE_TYPE_RELATIVE
+ #define AP_FOLLOW_DIST_MAX_DEFAULT 100
 #endif
+
+
+//==============================================================================
+// Constructor
+//==============================================================================
 
 AP_Follow *AP_Follow::_singleton;
 
@@ -70,11 +93,11 @@ const AP_Param::GroupInfo AP_Follow::var_info[] = {
 
     // @Param: _DIST_MAX
     // @DisplayName: Follow distance maximum
-    // @Description: Follow distance maximum.  targets further than this will be ignored
+    // @Description: Follow distance maximum. If exceeded, the follow estimate will be considered invalid.
     // @Units: m
     // @Range: 1 1000
     // @User: Standard
-    AP_GROUPINFO("_DIST_MAX", 5, AP_Follow, _dist_max_m, 100),
+    AP_GROUPINFO("_DIST_MAX", 5, AP_Follow, _dist_max_m, AP_FOLLOW_DIST_MAX_DEFAULT),
 
     // @Param: _OFS_TYPE
     // @DisplayName: Follow offset type
@@ -85,7 +108,7 @@ const AP_Param::GroupInfo AP_Follow::var_info[] = {
 
     // @Param: _OFS_X
     // @DisplayName: Follow offsets in meters north/forward
-    // @Description: Follow offsets in meters north/forward.  If positive, this vehicle fly ahead or north of lead vehicle.  Depends on FOLL_OFS_TYPE
+    // @Description: Follow offsets in meters north/forward. If positive, this vehicle fly ahead or north of lead vehicle.  Depends on FOLL_OFS_TYPE
     // @Range: -100 100
     // @Units: m
     // @Increment: 1
@@ -93,7 +116,7 @@ const AP_Param::GroupInfo AP_Follow::var_info[] = {
 
     // @Param: _OFS_Y
     // @DisplayName: Follow offsets in meters east/right
-    // @Description: Follow offsets in meters east/right.  If positive, this vehicle will fly to the right or east of lead vehicle.  Depends on FOLL_OFS_TYPE
+    // @Description: Follow offsets in meters east/right. If positive, this vehicle will fly to the right or east of lead vehicle.  Depends on FOLL_OFS_TYPE
     // @Range: -100 100
     // @Units: m
     // @Increment: 1
@@ -101,12 +124,12 @@ const AP_Param::GroupInfo AP_Follow::var_info[] = {
 
     // @Param: _OFS_Z
     // @DisplayName: Follow offsets in meters down
-    // @Description: Follow offsets in meters down.  If positive, this vehicle will fly below the lead vehicle
+    // @Description: Follow offsets in meters down. If positive, this vehicle will fly below the lead vehicle
     // @Range: -100 100
     // @Units: m
     // @Increment: 1
     // @User: Standard
-    AP_GROUPINFO("_OFS", 7, AP_Follow, _offset_ned_m, 0),
+    AP_GROUPINFO("_OFS", 7, AP_Follow, _offset_m, 0),
 
 #if !(APM_BUILD_TYPE(APM_BUILD_Rover))
     // @Param: _YAW_BEHAVE
@@ -119,7 +142,7 @@ const AP_Param::GroupInfo AP_Follow::var_info[] = {
 
     // @Param: _POS_P
     // @DisplayName: Follow position error P gain
-    // @Description: Follow position error P gain.  Converts the difference between desired vertical speed and actual speed into a desired acceleration that is passed to the throttle acceleration controller
+    // @Description: Follow position error P gain. Converts the difference between desired vertical speed and actual speed into a desired acceleration that is passed to the throttle acceleration controller
     // @Range: 0.01 1.00
     // @Increment: 0.01
     // @User: Standard
@@ -141,42 +164,258 @@ const AP_Param::GroupInfo AP_Follow::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("_OPTIONS", 11, AP_Follow, _options, 0),
 
+    // @Param: _ACCEL_NE
+    // @DisplayName: Acceleration limit for the horizontal kinematic input shaping
+    // @Description: Acceleration limit of the horizontal kinematic path generation used to determine how quickly the estimate varies in velocity
+    // @Range: 0 5
+    // @Units: m/s/s
+    // @User: Advanced
+    AP_GROUPINFO("_ACCEL_NE", 12, AP_Follow, _accel_max_ne_mss, 2.5),
+
+    // @Param: _JERK_NE
+    // @DisplayName: Jerk limit for the horizontal kinematic input shaping
+    // @Description: Jerk limit of the horizontal kinematic path generation used to determine how quickly the estimate varies in acceleration
+    // @Range: 0 20
+    // @Units: m/s/s/s
+    // @User: Advanced
+    AP_GROUPINFO("_JERK_NE", 13, AP_Follow, _jerk_max_ne_msss, 5.0),
+
+    // @Param: _ACCEL_D
+    // @DisplayName: Acceleration limit for the vertical kinematic input shaping
+    // @Description: Acceleration limit of the vertical kinematic path generation used to determine how quickly the estimate varies in velocity
+    // @Range: 0 2.5
+    // @Units: m/s/s
+    // @User: Advanced
+    AP_GROUPINFO("_ACCEL_D", 14, AP_Follow, _accel_max_d_mss, 2.5),
+
+    // @Param: _JERK_D
+    // @DisplayName: Jerk limit for the vertical kinematic input shaping
+    // @Description: Jerk limit of the vertical kinematic path generation used to determine how quickly the estimate varies in acceleration
+    // @Range: 0 5
+    // @Units: m/s/s/s
+    // @User: Advanced
+    AP_GROUPINFO("_JERK_D", 15, AP_Follow, _jerk_max_d_msss, 5.0),
+
+    // @Param: _ACCEL_H
+    // @DisplayName: Angular acceleration limit for the heading kinematic input shaping
+    // @Description: Angular acceleration limit of the heading kinematic path generation used to determine how quickly the estimate varies in angular velocity
+    // @Range: 0 90
+    // @Units: deg/s/s
+    // @User: Advanced
+    AP_GROUPINFO("_ACCEL_H", 16, AP_Follow, _accel_max_h_degss, 90.0),
+
+    // @Param: _JERK_H
+    // @DisplayName: Angular jerk limit for the heading kinematic input shaping
+    // @Description: Angular jerk limit of the heading kinematic path generation used to determine how quickly the estimate varies in angular acceleration
+    // @Range: 0 360
+    // @Units: deg/s/s/s
+    // @User: Advanced
+    AP_GROUPINFO("_JERK_H", 17, AP_Follow, _jerk_max_h_degsss, 360.0),
+
+
     AP_GROUPEND
 };
 
-/* 
-   The constructor also initialises the proximity sensor. Note that this
-   constructor is not called until detect() returns true, so we
-   already know that we should setup the proximity sensor
-*/
+// Constructor for AP_Follow. Initializes the position P-controller and sets up parameter defaults.
 AP_Follow::AP_Follow() :
-        _p_pos(AP_FOLLOW_POS_P_DEFAULT)
+    _p_pos(AP_FOLLOW_POS_P_DEFAULT)
 {
     _singleton = this;
     AP_Param::setup_object_defaults(this, var_info);
 }
 
-// restore offsets to zero if necessary, should be called when vehicle exits follow mode
-void AP_Follow::clear_offsets_if_required()
+
+//==============================================================================
+// Target Estimation Update Functions
+//==============================================================================
+
+// Projects and updates the estimated target position, velocity, and heading based on last known data and configured input shaping.
+bool AP_Follow::update_estimate()
 {
-    if (_offsets_were_zero) {
-        _offset_ned_m.set(Vector3f());
-        _offsets_were_zero = false;
+    // check for target: if no valid target, invalidate estimate
+    if (!have_target()) {
+        clear_dist_and_bearing_to_target();
+        _estimate_valid = false;
+        return _estimate_valid;
     }
+
+    // skip if update has already been processed this scheduler tick
+    if (_estimate_valid && (AP::scheduler().ticks32() - _last_update_ticks == 0)) {
+        return _estimate_valid;
+    }
+    _last_update_ticks = AP::scheduler().ticks32();
+
+    // if sysid changed, reset the estimation state
+    if (_sysid != _sysid_used) {
+        _sysid_used = _sysid;
+        _estimate_valid = false;
+    }
+
+    const uint32_t now = AP_HAL::millis();
+
+    // calculate time since last location update in seconds
+    const float dt = (now - _last_location_update_ms) * 0.001f;
+
+    // project target's position and velocity forward using simple kinematics
+    Vector3f delta_pos_m = _target_vel_ned_ms * dt + _target_accel_ned_mss * 0.5f * sq(dt);
+    Vector3f delta_vel_ms = _target_accel_ned_mss * dt;
+    float delta_heading_rad = radians(_target_heading_rate_degs) * dt;
+
+    // calculate time since last estimation update
+    const float e_dt = (now - _last_estimation_update_ms) * 0.001f;
+
+    const bool valid_kinematic_params = (_accel_max_ne_mss > 0.0f) && (_jerk_max_ne_msss > 0.0f) &&
+                                (_accel_max_d_mss > 0.0f) && (_jerk_max_d_msss > 0.0f) &&
+                                (_accel_max_h_degss > 0.0f) && (_jerk_max_h_degsss > 0.0f);
+    
+    if (_estimate_valid && valid_kinematic_params) {
+        // update X/Y position, velocity, acceleration with shaping
+        update_pos_vel_accel_xy(_estimate_pos_ned_m.xy(), _estimate_vel_ned_ms.xy(), _estimate_accel_ned_mss.xy(), e_dt, Vector2f(), Vector2f(), Vector2f());
+
+        // update Z axis position, velocity, acceleration without shaping (direct update)
+        update_pos_vel_accel(_estimate_pos_ned_m.z, _estimate_vel_ned_ms.z, _estimate_accel_ned_mss.z, e_dt, 0.0, 0.0, 0.0);
+
+        // apply horizontal shaping to refine estimate toward projected target state
+        shape_pos_vel_accel_xy(_target_pos_ned_m.xy() + delta_pos_m.xy().topostype(), _target_vel_ned_ms.xy() + delta_vel_ms.xy(), _target_accel_ned_mss.xy(),
+                               _estimate_pos_ned_m.xy(), _estimate_vel_ned_ms.xy(), _estimate_accel_ned_mss.xy(),
+                               0.0, _accel_max_ne_mss, _jerk_max_ne_msss, e_dt, false);
+
+        // apply angular shaping for heading estimate
+        shape_angle_vel_accel(radians(_target_heading_deg) + delta_heading_rad, radians(_target_heading_rate_degs), 0.0,
+                              _estimate_heading_rad, _estimate_heading_rate_rads, _estimate_heading_accel_radss,
+                              0.0, radians(_accel_max_h_degss),
+                              radians(_jerk_max_h_degsss), e_dt, false);
+
+        // update heading angle separately to maintain proper wrapping [-PI, PI]
+        postype_t estimate_heading_rad = _estimate_heading_rad;
+        update_pos_vel_accel(estimate_heading_rad, _estimate_heading_rate_rads, _estimate_heading_accel_radss, e_dt, 0.0, 0.0, 0.0);
+        _estimate_heading_rad = wrap_PI(estimate_heading_rad);
+    } else {
+        // no valid estimate yet: initialise from latest target position
+        _estimate_pos_ned_m = _target_pos_ned_m + delta_pos_m.topostype();
+        _estimate_vel_ned_ms = _target_vel_ned_ms + delta_vel_ms;
+        _estimate_accel_ned_mss = _target_accel_ned_mss;
+        _estimate_heading_rad = radians(_target_heading_deg) + delta_heading_rad;  
+        _estimate_heading_rate_rads = radians(_target_heading_rate_degs);  
+        _estimate_valid = true;
+    }
+
+    Vector3f offset_m = _offset_m.get();
+
+    // calculate estimated position and velocity with offsets applied
+    if (offset_m.is_zero() || (_offset_type == AP_FOLLOW_OFFSET_TYPE_NED)) {
+        // offsets are in NED frame: simple addition
+        _ofs_estimate_pos_ned_m = _estimate_pos_ned_m + offset_m.topostype();
+        _ofs_estimate_vel_ned_ms = _estimate_vel_ned_ms;
+        _ofs_estimate_accel_ned_mss = _estimate_accel_ned_mss;
+    } else {
+        // offsets are in FRD frame: rotate by heading
+        offset_m.xy().rotate(_estimate_heading_rad);
+        Vector3f offset_cross = offset_m.cross(Vector3f{0.0, 0.0, 1.0});
+        float offset_length_m = offset_m.length();
+        _ofs_estimate_pos_ned_m = _estimate_pos_ned_m + offset_m.topostype();
+        _ofs_estimate_vel_ned_ms = _estimate_vel_ned_ms + offset_cross * offset_length_m * _estimate_heading_rate_rads;
+        _ofs_estimate_accel_ned_mss = _estimate_accel_ned_mss + offset_cross * offset_length_m * _estimate_heading_accel_radss;
+    }
+
+    // update the distance and bearing to the target
+    update_dist_and_bearing_to_target();
+
+    _last_estimation_update_ms = now;
+
+    // Check if the target is within the maximum distance
+    Vector3f current_position_ned_m;
+    if (!AP::ahrs().get_relative_position_NED_origin(current_position_ned_m)) {
+        return false;
+    }
+    const Vector3p dist_vec_ned_m = _target_pos_ned_m - current_position_ned_m.topostype();
+    
+    // If _dist_max_m is not positive, we don't check the distance
+    if (is_positive(_dist_max_m.get()) && (dist_vec_ned_m.length() > _dist_max_m)) {
+        return false;
+    }
+    
+    return true;
 }
 
-// get target's estimated location
-bool AP_Follow::get_target_location_and_velocity(Location &loc, Vector3f &vel_ned_ms) const
+
+//==============================================================================
+// Target Information Retrieval Functions
+//==============================================================================
+
+// Retrieves the estimated target position, velocity, and acceleration in the NED frame (relative to origin).
+bool AP_Follow::get_target_pos_vel_accel_NED_m(Vector3p &pos_ned_m, Vector3f &vel_ned_ms, Vector3f &accel_ned_mss)
 {
-    Vector3p pos_ned_m;
-    Vector3f local_vel_ned_m;  // so we either change both return parameters or neither
-    if (!get_target_position_and_velocity_NED_m(pos_ned_m, local_vel_ned_m)) {
+    if (!update_estimate()) {
         return false;
     }
-    if (!AP::ahrs().get_location_from_origin_offset_NED(loc, pos_ned_m)) {
+
+    pos_ned_m = _estimate_pos_ned_m;
+    vel_ned_ms = _estimate_vel_ned_ms;
+    accel_ned_mss = _estimate_accel_ned_mss;
+
+    return true;
+}
+
+// Retrieves the estimated target position, velocity, and acceleration in the NED frame, including configured offsets.
+bool AP_Follow::get_ofs_pos_vel_accel_NED_m(Vector3p &pos_ofs_ned_m, Vector3f &vel_ofs_ned_ms, Vector3f &accel_ofs_ned_mss)
+{
+    if (!update_estimate()) {
         return false;
     }
-    vel_ned_ms = local_vel_ned_m;
+
+    pos_ofs_ned_m = _ofs_estimate_pos_ned_m;
+    vel_ofs_ned_ms = _ofs_estimate_vel_ned_ms;
+    accel_ofs_ned_mss = _ofs_estimate_accel_ned_mss;
+
+    return true;
+}
+
+// Retrieves distance vectors (with and without configured offsets) and the target’s velocity, all in the NED frame.
+bool AP_Follow::get_target_dist_and_vel_NED_m(Vector3f &dist_ned, Vector3f &dist_with_offs, Vector3f &vel_ned)
+{
+    if (!update_estimate()) {
+        return false;
+    }
+
+    Vector3f current_position_ned_m;
+    if (!AP::ahrs().get_relative_position_NED_origin(current_position_ned_m)) {
+        return false;
+    }
+
+    const Vector3p dist_vec_ned_m = _estimate_pos_ned_m - current_position_ned_m.topostype();
+    const Vector3p ofs_dist_vec = _ofs_estimate_pos_ned_m - current_position_ned_m.topostype();
+    dist_ned = dist_vec_ned_m.tofloat();
+    dist_with_offs = ofs_dist_vec.tofloat();
+    vel_ned = _ofs_estimate_vel_ned_ms;
+
+    return true;
+}
+
+// Retrieves the estimated target heading and heading rate in radians.
+bool AP_Follow::get_heading_heading_rate_rad(float &heading_rad, float &heading_rate_rads)
+{
+    if (!update_estimate()) {
+        return false;
+    }
+
+    // return latest heading estimate
+    heading_rad = _estimate_heading_rad;
+    heading_rate_rads = _estimate_heading_rate_rads;
+    return true;
+}
+
+// Retrieves the target's estimated global location and velocity, adjusting altitude frame if relative mode is set (for LUA bindings).
+bool AP_Follow::get_target_location_and_velocity(Location &loc, Vector3f &vel_ned)
+{
+    if (!update_estimate()) {
+        return false;
+    }
+
+    if (!AP::ahrs().get_location_from_origin_offset_NED(loc, _estimate_pos_ned_m)) {
+        return false;
+    }
+    vel_ned = _estimate_vel_ned_ms;
 
     if (_alt_type == AP_FOLLOW_ALTITUDE_TYPE_RELATIVE) {
         loc.change_alt_frame(Location::AltFrame::ABOVE_HOME);
@@ -185,108 +424,90 @@ bool AP_Follow::get_target_location_and_velocity(Location &loc, Vector3f &vel_ne
     return true;
 }
 
-// get target's estimated location and velocity, both NED SI from origin
-bool AP_Follow::get_target_position_and_velocity_NED_m(Vector3p &pos_ned_m, Vector3f &vel_ned_ms) const
+// Retrieves the target's estimated global location and velocity, including configured offsets, for LUA bindings.
+bool AP_Follow::get_target_location_and_velocity_ofs(Location &loc, Vector3f &vel_ned)
 {
-    // exit immediately if not enabled
-    if (!_enabled) {
+    if (!update_estimate()) {
         return false;
     }
-
-    // check for timeout
-    if ((_last_location_update_ms == 0) || (AP_HAL::millis() - _last_location_update_ms > AP_FOLLOW_TIMEOUT_MS)) {
+    if (!AP::ahrs().get_location_from_origin_offset_NED(loc, _ofs_estimate_pos_ned_m)) {
         return false;
     }
-
-    // calculate time since last actual position update
-    const float dt = (AP_HAL::millis() - _last_location_update_ms) * 0.001f;
-
-    // get velocity estimate
-    if (!get_velocity_NED_ms(vel_ned_ms, dt)) {
-        return false;
+    if (_alt_type == AP_FOLLOW_ALTITUDE_TYPE_RELATIVE) {
+        loc.change_alt_frame(Location::AltFrame::ABOVE_HOME);
     }
 
-    // project the vehicle position
-    const Vector3p vel_ned_p { vel_ned_ms.x, vel_ned_ms.y, vel_ned_ms.z };
-    pos_ned_m = _target_position_ned_m + vel_ned_p * dt;
-
+    vel_ned = _ofs_estimate_vel_ned_ms;
     return true;
 }
 
-// get distance vector to target (in meters) and target's velocity all in NED frame
-bool AP_Follow::get_target_dist_and_vel_NED_m(Vector3f &dist_ned_m, Vector3f &dist_with_offs_m, Vector3f &vel_ned_ms)
+// Retrieves the estimated target heading in degrees (0° = North, 90° = East) for LUA bindings.
+bool AP_Follow::get_target_heading_deg(float &heading)
 {
-    Vector3f current_position_NED;
-    if (!AP::ahrs().get_relative_position_NED_origin(current_position_NED)) {
-        clear_dist_and_bearing_to_target();
-        return false;
-    }
-    Vector3p target_position_ned_m;
-    Vector3f veh_vel_ned_ms;  // NED
-    if (!get_target_position_and_velocity_NED_m(target_position_ned_m, veh_vel_ned_ms)) {
-        clear_dist_and_bearing_to_target();
+    if (!update_estimate()) {
         return false;
     }
 
-    // convert from Vector3p to Vector3f as they can't be subtracted:
-    Vector3f target_position_NED_f;
-    target_position_NED_f.x = target_position_ned_m.x;
-    target_position_NED_f.y = target_position_ned_m.y;
-    target_position_NED_f.z = target_position_ned_m.z;
-
-    const Vector3f dist_vec_ned_m = target_position_NED_f - current_position_NED;
-
-    // fail if too far
-    if (is_positive(_dist_max_m.get()) && (dist_vec_ned_m.length() > _dist_max_m)) {
-        clear_dist_and_bearing_to_target();
-        return false;
-    }
-
-    // initialise offsets_ned_m from distance vector if required
-    init_offsets_if_required(dist_vec_ned_m);
-
-    // get offsets_ned_m
-    Vector3f offsets_ned_m;
-    if (!get_offsets_NED_m(offsets_ned_m)) {
-        clear_dist_and_bearing_to_target();
-        return false;
-    }
-
-    // calculate results
-    dist_ned_m = dist_vec_ned_m;
-    dist_with_offs_m = dist_vec_ned_m + offsets_ned_m;
-    vel_ned_ms = veh_vel_ned_ms;
-
-    // record distance and heading_deg for reporting purposes
-    if (is_zero(dist_with_offs_m.x) && is_zero(dist_with_offs_m.y)) {
-        clear_dist_and_bearing_to_target();
-    } else {
-        _dist_to_target_m = safe_sqrt(sq(dist_with_offs_m.x) + sq(dist_with_offs_m.y));
-        _bearing_to_target_deg = degrees(atan2f(dist_with_offs_m.y, dist_with_offs_m.x));
-    }
-
+    // return latest heading estimate
+    heading = degrees(_estimate_heading_rad);
     return true;
 }
 
-// get target's heading_deg in degrees (0 = north, 90 = east)
-bool AP_Follow::get_target_heading_deg(float &heading_deg) const
+
+//==============================================================================
+// MAVLink Message Handling
+//==============================================================================
+
+// Handles incoming MAVLink messages to update the target's position, velocity, and heading.
+void AP_Follow::handle_msg(const mavlink_message_t &msg)
 {
-    // exit immediately if not enabled
-    if (!_enabled) {
-        return false;
+    // Invalidate the estimate if no position update has been received within the timeout period.
+    // If using automatic sysid tracking, clear the sysid and reset tracking state.
+    if ((_last_location_update_ms == 0) ||
+        (AP_HAL::millis() - _last_location_update_ms > AP_FOLLOW_SYSID_TIMEOUT_MS)) {
+        if (_automatic_sysid) {
+            _sysid.set(0);         // clear target system ID
+            _sysid_used = 0;       // reset used sysid tracking
+        }
+        _estimate_valid = false;   // mark estimate as invalid
+        _using_follow_target = false; // reset follow-target usage flag
     }
 
-    // check for timeout
-    if ((_last_heading_update_ms == 0) || (AP_HAL::millis() - _last_heading_update_ms > AP_FOLLOW_TIMEOUT_MS)) {
-        return false;
+    if (!should_handle_message(msg)) {
+        // ignore message if filtering rules reject it (e.g., wrong sysid)
+        return;
     }
 
-    // return latest heading_deg estimate
-    heading_deg = _target_heading_deg;
-    return true;
+    // decode MAVLink message
+    bool updated = false;
+
+    switch (msg.msgid) {
+    case MAVLINK_MSG_ID_GLOBAL_POSITION_INT: {
+        // handle standard global position messages
+        updated = handle_global_position_int_message(msg);
+        break;
+    }
+    case MAVLINK_MSG_ID_FOLLOW_TARGET: {
+        // handle follow-target specific messages
+        updated = handle_follow_target_message(msg);
+        break;
+    }
+    }
+
+    if (updated) {
+        // Check if estimate needs reset based on position and velocity errors
+        if (estimate_error_too_large()) {
+            _estimate_valid = false;
+        }
+
+#if HAL_LOGGING_ENABLED
+        // log current follow diagnostic data
+        Log_Write_FOLL();
+#endif
+    }
 }
 
-// returns true if we should extract information from msg
+// Returns true if the incoming MAVLink message should be processed for target updates.
 bool AP_Follow::should_handle_message(const mavlink_message_t &msg) const
 {
     // exit immediately if not enabled
@@ -307,246 +528,264 @@ bool AP_Follow::should_handle_message(const mavlink_message_t &msg) const
     return true;
 }
 
-// handle mavlink DISTANCE_SENSOR messages
-void AP_Follow::handle_msg(const mavlink_message_t &msg)
+// Checks whether the current estimate should be reset based on position and velocity errors.
+bool AP_Follow::estimate_error_too_large() const
 {
-    // this method should be called from an "update()" method:
-    if (_automatic_sysid) {
-        // maybe timeout who we were following...
-        if ((_last_location_update_ms == 0) ||
-            (AP_HAL::millis() - _last_location_update_ms > AP_FOLLOW_SYSID_TIMEOUT_MS)) {
-            _sysid.set(0);
-        }
-    }
+    const float timeout_sec = AP_FOLLOW_TIMEOUT_MS * 0.001f;
 
-    if (!should_handle_message(msg)) {
-        return;
-    }
+    // Calculate position thresholds based on maximum acceleration then deceleration for the timeout duration
+    const float pos_thresh_horiz_m = _accel_max_ne_mss.get() * sq(timeout_sec * 0.5);
+    const float pos_thresh_vert_m  = _accel_max_d_mss.get()  * sq(timeout_sec * 0.5);
 
-    // decode global-position-int message
-    bool updated = false;
+    // Calculate velocity thresholds using the new helper function
+    const float vel_thresh_horiz_ms = calc_max_velocity_change(_accel_max_ne_mss.get(), _jerk_max_ne_msss.get(), timeout_sec);
+    const float vel_thresh_vert_ms  = calc_max_velocity_change(_accel_max_d_mss.get(), _jerk_max_d_msss.get(), timeout_sec);
 
-    switch (msg.msgid) {
-    case MAVLINK_MSG_ID_GLOBAL_POSITION_INT: {
-        updated = handle_global_position_int_message(msg);
-        break;
-    }
-    case MAVLINK_MSG_ID_FOLLOW_TARGET: {
-        updated = handle_follow_target_message(msg);
-        break;
-    }
-    }
+    // Calculate current position and velocity errors
+    const Vector3f pos_error = _estimate_pos_ned_m.tofloat() - _target_pos_ned_m.tofloat();
+    const Vector3f vel_error = _estimate_vel_ned_ms - _target_vel_ned_ms;
 
-    if (updated) {
-#if HAL_LOGGING_ENABLED
-        Log_Write_FOLL();
-#endif
+    const Vector2f pos_error_xy = pos_error.xy();
+    const float pos_error_z = pos_error.z;
+    const Vector2f vel_error_xy = vel_error.xy();
+    const float vel_error_z = vel_error.z;
+
+    // Check horizontal and vertical separately
+    const bool pos_horiz_bad = pos_error_xy.length() > pos_thresh_horiz_m;
+    const bool vel_horiz_bad = vel_error_xy.length() > vel_thresh_horiz_ms;
+    const bool pos_vert_bad = fabsf(pos_error_z) > pos_thresh_vert_m;
+    const bool vel_vert_bad = fabsf(vel_error_z) > vel_thresh_vert_ms;
+
+    return pos_horiz_bad || vel_horiz_bad || pos_vert_bad || vel_vert_bad;
+}
+
+// Calculates max velocity change under trapezoidal or triangular acceleration profile (jerk-limited).
+float AP_Follow::calc_max_velocity_change(float accel_max, float jerk_max, float timeout_sec) const
+{
+    const float t_jerk = accel_max / jerk_max;
+    const float t_total_jerk = 2.0f * t_jerk;
+
+    if (timeout_sec >= t_total_jerk) {
+        // time to ramp up, constant accel phase, and ramp down
+        const float t_const = timeout_sec - t_total_jerk;
+        const float delta_v_jerk = 0.5f * accel_max * t_jerk;
+        const float delta_v_const = accel_max * t_const;
+        return 2.0f * delta_v_jerk + delta_v_const;
+    } else {
+        // timeout too short: pure triangle profile
+        const float t_half = timeout_sec * 0.5f;
+        return 0.5f * jerk_max * sq(t_half);
     }
 }
 
+// Decodes a GLOBAL_POSITION_INT MAVLink message to update the target’s position, velocity, and heading.
 bool AP_Follow::handle_global_position_int_message(const mavlink_message_t &msg)
 {
-        // decode message
-        mavlink_global_position_int_t packet;
-        mavlink_msg_global_position_int_decode(&msg, &packet);
+    // decode GLOBAL_POSITION_INT message into packet struct
+    mavlink_global_position_int_t packet;
+    mavlink_msg_global_position_int_decode(&msg, &packet);
 
-        // ignore message if lat and lon are (exactly) zero
-        if ((packet.lat == 0 && packet.lon == 0)) {
-            return false;
-        }
+    // ignore message if latitude and longitude are exactly zero (invalid GPS fix)
+    if ((packet.lat == 0 && packet.lon == 0)) {
+        return false;
+    }
 
-        Location _target_location;
-        _target_location.lat = packet.lat;
-        _target_location.lng = packet.lon;
+    if (_using_follow_target) {
+        // if we are using follow_target, ignore global_position_int messages
+        return false;
+    }
 
-        // select altitude source based on FOLL_ALT_TYPE param 
-        if (_alt_type == AP_FOLLOW_ALTITUDE_TYPE_RELATIVE) {
-            // above home alt
-            _target_location.set_alt_cm(packet.relative_alt / 10, Location::AltFrame::ABOVE_HOME);
-        } else {
-            // absolute altitude
-            _target_location.set_alt_cm(packet.alt / 10, Location::AltFrame::ABSOLUTE);
-        }
-        if (!_target_location.get_vector_from_origin_NEU(_target_position_ned_m)) {
-            return false;
-        }
-        _target_position_ned_m.z = -_target_position_ned_m.z; // NEU->NED
-        _target_position_ned_m *= 0.01;  // cm -> m
+    Location _target_location;
+    _target_location.lat = packet.lat;
+    _target_location.lng = packet.lon;
 
-        _target_velocity_ned_ms.x = packet.vx * 0.01f; // velocity north
-        _target_velocity_ned_ms.y = packet.vy * 0.01f; // velocity east
-        _target_velocity_ned_ms.z = packet.vz * 0.01f; // velocity down
+    // set target altitude based on configured altitude type
+    if (_alt_type == AP_FOLLOW_ALTITUDE_TYPE_RELATIVE) {
+        // use relative altitude above home
+        _target_location.set_alt_cm(packet.relative_alt / 10, Location::AltFrame::ABOVE_HOME);
+    } else {
+        // use absolute altitude
+        _target_location.set_alt_cm(packet.alt / 10, Location::AltFrame::ABSOLUTE);
+    }
 
-        // get a local timestamp with correction for transport jitter
-        _last_location_update_ms = _jitter.correct_offboard_timestamp_msec(packet.time_boot_ms, AP_HAL::millis());
-        if (packet.hdg <= 36000) {                  // heading_deg (UINT16_MAX if unknown)
-            _target_heading_deg = packet.hdg * 0.01f;   // convert centi-degrees to degrees
-            _last_heading_update_ms = _last_location_update_ms;
-        }
-        // initialise _sysid if zero to sender's id
-        if (_sysid == 0) {
-            _sysid.set(msg.sysid);
-            _automatic_sysid = true;
-        }
-        return true;
-}
+    // convert global location to local NED frame position
+    if (!_target_location.get_vector_from_origin_NEU(_target_pos_ned_m)) {
+        return false;
+    }
+    _target_pos_ned_m.z = -_target_pos_ned_m.z; // convert NEU -> NED
+    _target_pos_ned_m *= 0.01;  // convert from cm to meters
 
-bool AP_Follow::handle_follow_target_message(const mavlink_message_t &msg)
-{
-        // decode message
-        mavlink_follow_target_t packet;
-        mavlink_msg_follow_target_decode(&msg, &packet);
+    // decode target velocity components (in m/s)
+    _target_vel_ned_ms.x = packet.vx * 0.01f; // velocity north
+    _target_vel_ned_ms.y = packet.vy * 0.01f; // velocity east
+    _target_vel_ned_ms.z = packet.vz * 0.01f; // velocity down
 
-        // ignore message if lat and lon are (exactly) zero
-        if ((packet.lat == 0 && packet.lon == 0)) {
-            return false;
-        }
-        // require at least position
-        if ((packet.est_capabilities & (1<<0)) == 0) {
-            return false;
-        }
+    // target acceleration not available in GLOBAL_POSITION_INT
+    _target_accel_ned_mss.zero();
 
-        const Location new_loc {
-            packet.lat,
-            packet.lon,
-            int32_t(packet.alt * 100),  // m -> cm
-            Location::AltFrame::ABSOLUTE
-        };
+    if (packet.hdg <= 36000) {
+        // valid heading field available (in centi-degrees)
+        _target_heading_deg = packet.hdg * 0.01f;
+    } else if (_offset_type == AP_FOLLOW_OFFSET_TYPE_RELATIVE) {
+        // heading missing but relative offset mode requires heading -> reject
+        return false;
+    } else {
+        // no heading available: set heading rate to zero
+        _target_heading_rate_degs = 0.0f;
+    }
 
-        if (!new_loc.get_vector_from_origin_NEU(_target_position_ned_m)) {
-            return false;
-        }
-        _target_position_ned_m.z = -_target_position_ned_m.z; // NEU->NED
-        _target_position_ned_m *= 0.01;  // cm -> m
+    // apply jitter-corrected timestamp to this update
+    _last_location_update_ms = _jitter.correct_offboard_timestamp_msec(packet.time_boot_ms, AP_HAL::millis());
 
-        if (packet.est_capabilities & (1<<1)) {
-            _target_velocity_ned_ms.x = packet.vel[0]; // velocity north
-            _target_velocity_ned_ms.y = packet.vel[1]; // velocity east
-            _target_velocity_ned_ms.z = packet.vel[2]; // velocity down
-        } else {
-            _target_velocity_ned_ms.zero();
-        }
+    // if sysid not yet set, adopt sender’s sysid and enable automatic sysid tracking
+    if (_sysid == 0) {
+        _sysid.set(msg.sysid);
+        _sysid_used = 0;
+        _estimate_valid = false;
+        _automatic_sysid = true;
+    }
 
-        // get a local timestamp with correction for transport jitter
-        _last_location_update_ms = _jitter.correct_offboard_timestamp_msec(packet.timestamp, AP_HAL::millis());
-
-        if (packet.est_capabilities & (1<<3)) {
-            Quaternion q{packet.attitude_q[0], packet.attitude_q[1], packet.attitude_q[2], packet.attitude_q[3]};
-            float r, p, y;
-            q.to_euler(r,p,y);
-            _target_heading_deg = degrees(y);
-            _last_heading_update_ms = _last_location_update_ms;
-        }
-
-        // initialise _sysid if zero to sender's id
-        if (_sysid == 0) {
-            _sysid.set(msg.sysid);
-            _automatic_sysid = true;
-        }
-
-        return true;
-}
-
-// write out an onboard-log message to help diagnose follow problems:
-#if HAL_LOGGING_ENABLED
-void AP_Follow::Log_Write_FOLL()
-{
-        // get estimated location and velocity
-        Location loc_estimate{};
-        Vector3f vel_estimate_ned_ms;
-        UNUSED_RESULT(get_target_location_and_velocity(loc_estimate, vel_estimate_ned_ms));
-
-        Location _target_location;
-        UNUSED_RESULT(AP::ahrs().get_location_from_origin_offset_NED(_target_location, _target_position_ned_m * 0.01));
-        if (_alt_type == AP_FOLLOW_ALTITUDE_TYPE_RELATIVE) {
-            _target_location.change_alt_frame(Location::AltFrame::ABOVE_HOME);
-        }
-
-        // log lead's estimated vs reported position
-// @LoggerMessage: FOLL
-// @Description: Follow library diagnostic data
-// @Field: TimeUS: Time since system startup
-// @Field: Lat: Target latitude
-// @Field: Lon: Target longitude
-// @Field: Alt: Target absolute altitude
-// @Field: VelN: Target earth-frame velocity, North
-// @Field: VelE: Target earth-frame velocity, East
-// @Field: VelD: Target earth-frame velocity, Down
-// @Field: LatE: Vehicle latitude
-// @Field: LonE: Vehicle longitude
-// @Field: AltE: Vehicle absolute altitude
-        AP::logger().WriteStreaming("FOLL",
-                                               "TimeUS,Lat,Lon,Alt,VelN,VelE,VelD,LatE,LonE,AltE",  // labels
-                                               "sDUmnnnDUm",    // units
-                                               "F--B000--B",    // mults
-                                               "QLLifffLLi",    // fmt
-                                               AP_HAL::micros64(),
-                                               _target_location.lat,
-                                               _target_location.lng,
-                                               _target_location.alt,
-                                               (double)_target_velocity_ned_ms.x,
-                                               (double)_target_velocity_ned_ms.y,
-                                               (double)_target_velocity_ned_ms.z,
-                                               loc_estimate.lat,
-                                               loc_estimate.lng,
-                                               loc_estimate.alt
-                                               );
-}
-#endif  // HAL_LOGGING_ENABLED
-
-// get velocity estimate in m/s in NED frame using dt since last update
-bool AP_Follow::get_velocity_NED_ms(Vector3f &vel_ned_ms, float dt) const
-{
-    vel_ned_ms = _target_velocity_ned_ms + (_target_accel_ned_mss * dt);
     return true;
 }
 
-// initialise offsets_ned_m to provided distance vector to other vehicle (in meters in NED frame) if required
-void AP_Follow::init_offsets_if_required(const Vector3f &dist_vec_ned)
+// Decodes a FOLLOW_TARGET MAVLink message to update the target’s position, velocity, acceleration, and orientation.
+bool AP_Follow::handle_follow_target_message(const mavlink_message_t &msg)
 {
-    // return immediately if offsets_ned_m have already been set
-    if (!_offset_ned_m.get().is_zero()) {
+    // decode FOLLOW_TARGET message into packet struct
+    mavlink_follow_target_t packet;
+    mavlink_msg_follow_target_decode(&msg, &packet);
+
+    // ignore message if latitude and longitude are exactly zero (invalid GPS fix)
+    if ((packet.lat == 0 && packet.lon == 0)) {
+        return false;
+    }
+
+    // require that at least position is estimated (bit 0 of est_capabilities)
+    if ((packet.est_capabilities & (1<<0)) == 0) {
+        return false;
+    }
+
+    // build Location object from latitude, longitude, and altitude (alt in meters)
+    const Location _target_location {
+        packet.lat,
+        packet.lon,
+        int32_t(packet.alt * 100),  // convert meters to centimeters
+        Location::AltFrame::ABSOLUTE
+    };
+
+    // convert global location to local NED frame position
+    if (!_target_location.get_vector_from_origin_NEU(_target_pos_ned_m)) {
+        return false;
+    }
+    _target_pos_ned_m *= 0.01; // convert from cm to meters
+
+    // adjust Z coordinate to NED frame (NEU altitude -> NED)
+    Location origin;
+    if (!AP::ahrs().get_origin(origin)) {
+        return false;
+    }
+    _target_pos_ned_m.z = -packet.alt + origin.alt * 0.01;
+
+    // decode velocity if available (bit 1 of est_capabilities)
+    if (packet.est_capabilities & (1<<1)) {
+        _target_vel_ned_ms.x = packet.vel[0]; // velocity north
+        _target_vel_ned_ms.y = packet.vel[1]; // velocity east
+        _target_vel_ned_ms.z = packet.vel[2]; // velocity down
+    } else {
+        _target_vel_ned_ms.zero();
+    }
+
+    // decode acceleration if available (bit 2 of est_capabilities)
+    if (packet.est_capabilities & (1 << 2)) {
+        _target_accel_ned_mss.x = packet.acc[0]; // acceleration north
+        _target_accel_ned_mss.y = packet.acc[1]; // acceleration east
+        _target_accel_ned_mss.z = packet.acc[2]; // acceleration down
+    } else {
+        _target_accel_ned_mss.zero();
+    }
+
+    // decode attitude if available (bit 3 of est_capabilities)
+    if (packet.est_capabilities & (1 << 3)) {
+        // reconstruct quaternion from packet
+        Quaternion q{packet.attitude_q[0], packet.attitude_q[1], packet.attitude_q[2], packet.attitude_q[3]};
+        float roll, pitch, yaw;
+        q.to_euler(roll, pitch, yaw);
+
+        // store heading in degrees, wrapped 0–360
+        _target_heading_deg = wrap_360(degrees(yaw));
+
+        // transform body rates (roll, pitch, yaw) to earth frame rates
+        Matrix3f R;
+        q.rotation_matrix(R);
+        Vector3f omega_body = Vector3f{packet.rates[0], packet.rates[1], packet.rates[2]};
+        Vector3f omega_world = R * omega_body; // rotate rates into earth frame
+
+        // store heading rate (yaw rate in world frame) in degrees/sec
+        _target_heading_rate_degs = degrees(omega_world.z);
+    } else if (_offset_type == AP_FOLLOW_OFFSET_TYPE_RELATIVE) {
+        // if attitude unavailable and using relative frame, cannot compute — abort
+        return false;
+    } else {
+        // otherwise, default heading rate to zero
+        _target_heading_rate_degs = 0.0f;
+    }
+
+    // apply jitter-corrected timestamp to this update
+    _last_location_update_ms = _jitter.correct_offboard_timestamp_msec(packet.timestamp, AP_HAL::millis());
+
+    // if sysid not yet assigned, adopt sender's sysid and enable automatic sysid tracking
+    if (_sysid == 0) {
+        _sysid.set(msg.sysid);
+        _automatic_sysid = true;
+    }
+
+    // we are using follow_target: set sysid to sender's sysid
+    _using_follow_target = true;
+
+    return true;
+}
+
+
+//==============================================================================
+// Offset Initialization and Adjustment Functions
+//==============================================================================
+
+// Initializes the positional offsets from the target vehicle if not already set.
+void AP_Follow::init_offsets_if_required()
+{
+    // return immediately if offsets have already been set
+    if (!_offset_m.get().is_zero()) {
         return;
     }
     _offsets_were_zero = true;
 
+    if (!update_estimate()) {
+        return;
+    }
+
+    // Check if the target is within the maximum distance
+    Vector3f current_position_ned_m;
+    if (!AP::ahrs().get_relative_position_NED_origin(current_position_ned_m)) {
+        return;
+    }
+    const Vector3f dist_vec_ned_m = (_target_pos_ned_m - current_position_ned_m.topostype()).tofloat();
+
     float target_heading_deg;
     if ((_offset_type == AP_FOLLOW_OFFSET_TYPE_RELATIVE) && get_target_heading_deg(target_heading_deg)) {
-        // rotate offsets_ned_m from north facing to vehicle's perspective
-        _offset_ned_m.set(rotate_vector(-dist_vec_ned, -target_heading_deg));
+        // rotate offset into vehicle-relative frame based on heading
+        _offset_m.set(rotate_vector(-dist_vec_ned_m, -target_heading_deg));
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Relative follow offset loaded");
     } else {
-        // initialise offset in NED frame
-        _offset_ned_m.set(-dist_vec_ned);
-        // ensure offset_type used matches frame of offsets_ned_m saved
+        // initialize offset in NED frame (no heading rotation)
+        _offset_m.set(-dist_vec_ned_m);
+
+        // ensure offset type is set to NED frame if initialized this way
         _offset_type.set(AP_FOLLOW_OFFSET_TYPE_NED);
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "N-E-D follow offset loaded");
     }
 }
 
-// get offsets_ned_m in meters in NED frame
-bool AP_Follow::get_offsets_NED_m(Vector3f &offset) const
-{
-    const Vector3f &off = _offset_ned_m.get();
-
-    // if offsets_ned_m are zero or type is NED, simply return offset vector
-    if (off.is_zero() || (_offset_type == AP_FOLLOW_OFFSET_TYPE_NED)) {
-        offset = off;
-        return true;
-    }
-
-    // offset type is relative, exit if we cannot get vehicle's heading_deg
-    float target_heading_deg;
-    if (!get_target_heading_deg(target_heading_deg)) {
-        return false;
-    }
-
-    // rotate offsets_ned_m from vehicle's perspective to NED
-    offset = rotate_vector(off, target_heading_deg);
-    return true;
-}
-
-// rotate 3D vector clockwise by specified angle (in degrees)
+// Rotates a 3D vector clockwise by the specified angle (degrees).
 Vector3f AP_Follow::rotate_vector(const Vector3f &vec, float angle_deg) const
 {
     // rotate roll, pitch input from north facing to vehicle's perspective
@@ -556,50 +795,111 @@ Vector3f AP_Follow::rotate_vector(const Vector3f &vec, float angle_deg) const
     return ret;
 }
 
-// set recorded distance and bearing to target to zero
+// Resets follow mode offsets to zero if they were automatically initialized.
+void AP_Follow::clear_offsets_if_required()
+{
+    if (_offsets_were_zero) {
+        _offset_m.set(Vector3f());
+        _offsets_were_zero = false;
+    }
+}
+
+
+//==============================================================================
+// Distance and Bearing Management
+//==============================================================================
+
+// Resets the recorded distance and bearing to the target to zero.
 void AP_Follow::clear_dist_and_bearing_to_target()
 {
     _dist_to_target_m = 0.0f;
     _bearing_to_target_deg = 0.0f;
 }
 
-// get target's estimated origin-relative-position and velocity (both in SI NED), with offsets_ned_m added
-bool AP_Follow::get_target_position_and_velocity_ofs_NED_m(Vector3p &pos_ned_m, Vector3f &vel_ned_ms) const
+// Updates the recorded distance and bearing to the target to zero.
+void AP_Follow::update_dist_and_bearing_to_target()
 {
-    Vector3f ofs_ned;
-    if (!get_offsets_NED_m(ofs_ned)) {
-        return false;
+    Vector3f current_position_ned_m;
+    if (!AP::ahrs().get_relative_position_NED_origin(current_position_ned_m)) {
+        // if unable to retrieve local position, clear distance/bearing info
+        clear_dist_and_bearing_to_target();
+    } else {
+        // convert vehicle position to NED meters (NEU -> NED and cm -> m)
+        current_position_ned_m.z = -current_position_ned_m.z; // NEU to NED
+        current_position_ned_m *= 0.01;  // convert cm to m
+
+        // calculate distance vectors to target, both with and without offsets
+        const Vector3p ofs_dist_vec = _ofs_estimate_pos_ned_m - current_position_ned_m.topostype();
+
+        // record distance and bearing to target for reporting/logging
+        if (ofs_dist_vec.xy().is_zero()) {
+            clear_dist_and_bearing_to_target();
+        } else {
+            _dist_to_target_m = ofs_dist_vec.xy().length();
+            _bearing_to_target_deg = degrees(ofs_dist_vec.xy().angle());
+        }
     }
-    if (!get_target_position_and_velocity_NED_m(pos_ned_m, vel_ned_ms)) {
-        return false;
-    }
-    // can't add Vector3p and Vector3f directly:
-    pos_ned_m.x += ofs_ned.x;
-    pos_ned_m.y += ofs_ned.y;
-    pos_ned_m.z += ofs_ned.z;
-    return true;
 }
 
-// get target's estimated location and velocity (in NED), with offsets_ned_m added
-bool AP_Follow::get_target_location_and_velocity_ofs(Location &loc, Vector3f &vel_ned_ms) const
+
+//==============================================================================
+// Logging
+//==============================================================================
+
+// Writes a diagnostic onboard log message containing target and vehicle tracking data for Follow mode.
+#if HAL_LOGGING_ENABLED
+void AP_Follow::Log_Write_FOLL()
 {
-    Vector3p pos_ned_m;
-    Vector3f local_vel_ned_m;  // so we either change both return parameters or neither
-    if (!get_target_position_and_velocity_ofs_NED_m(pos_ned_m, local_vel_ned_m)) {
-        return false;
-    }
-    if (!AP::ahrs().get_location_from_origin_offset_NED(loc, pos_ned_m)) {
-        return false;
-    }
+    // retrieve latest estimated location and velocity
+    Location loc_estimate{};
+    Vector3f vel_estimate;
+    UNUSED_RESULT(get_target_location_and_velocity(loc_estimate, vel_estimate));
+
+    Location _target_location;
+    UNUSED_RESULT(AP::ahrs().get_location_from_origin_offset_NED(_target_location, _target_pos_ned_m));
+
     if (_alt_type == AP_FOLLOW_ALTITUDE_TYPE_RELATIVE) {
-        loc.change_alt_frame(Location::AltFrame::ABOVE_HOME);
+        _target_location.change_alt_frame(Location::AltFrame::ABOVE_HOME);
     }
 
-    vel_ned_ms = local_vel_ned_m;
-    return true;
+    // log the lead target's reported position and vehicle's estimated position
+    // @LoggerMessage: FOLL
+    // @Description: Follow library diagnostic data
+    // @Field: TimeUS: Time since system startup (microseconds)
+    // @Field: Lat: Target latitude (degrees * 1E7)
+    // @Field: Lon: Target longitude (degrees * 1E7)
+    // @Field: Alt: Target absolute altitude (centimeters)
+    // @Field: VelN: Target velocity, North (m/s)
+    // @Field: VelE: Target velocity, East (m/s)
+    // @Field: VelD: Target velocity, Down (m/s)
+    // @Field: LatE: Vehicle estimated latitude (degrees * 1E7)
+    // @Field: LonE: Vehicle estimated longitude (degrees * 1E7)
+    // @Field: AltE: Vehicle estimated absolute altitude (centimeters)
+    AP::logger().WriteStreaming("FOLL",
+                                "TimeUS,Lat,Lon,Alt,VelN,VelE,VelD,LatE,LonE,AltE",  // labels
+                                "sDUmnnnDUm",    // units
+                                "F--B000--B",    // mults
+                                "QLLifffLLi",    // fmt
+                                AP_HAL::micros64(),
+                                _target_location.lat,
+                                _target_location.lng,
+                                _target_location.alt,
+                                (double)_target_vel_ned_ms.x,
+                                (double)_target_vel_ned_ms.y,
+                                (double)_target_vel_ned_ms.z,
+                                loc_estimate.lat,
+                                loc_estimate.lng,
+                                loc_estimate.alt
+                                );
 }
+#endif  // HAL_LOGGING_ENABLED
 
-// return true if we have a target
+
+//==============================================================================
+// Accessors and Helpers
+//==============================================================================
+
+// Returns true if following is enabled and a recent target update has been received.
 bool AP_Follow::have_target(void) const
 {
     if (!_enabled) {
@@ -613,13 +913,16 @@ bool AP_Follow::have_target(void) const
     return true;
 }
 
+//==============================================================================
+// AP_Follow Accessor
+//==============================================================================
+
+// Accessor for the AP_Follow singleton instance.
 namespace AP {
-
-AP_Follow &follow()
-{
-    return *AP_Follow::get_singleton();
-}
-
+    AP_Follow &follow()
+    {
+        return *AP_Follow::get_singleton();
+    }
 }
 
 #endif  // AP_FOLLOW_ENABLED

--- a/libraries/AP_Follow/AP_Follow.h
+++ b/libraries/AP_Follow/AP_Follow.h
@@ -177,7 +177,7 @@ private:
     bool _offsets_were_zero;        // true if offsets were originally zero and then initialised to the offset from lead vehicle
 
     // setup jitter correction with max transport lag of 3s
-    JitterCorrection _jitter{3000};
+    JitterCorrection _jitter{500};
 };
 
 namespace AP {

--- a/libraries/AP_Follow/AP_Follow.h
+++ b/libraries/AP_Follow/AP_Follow.h
@@ -26,10 +26,18 @@
 #include <AC_PID/AC_P.h>
 #include <AP_RTC/JitterCorrection.h>
 
+//==============================================================================
+// AP_Follow Class
+// Target Following Logic for ArduPilot Vehicles
+//==============================================================================
+
 class AP_Follow
 {
 
 public:
+    //==========================================================================
+    // Public Enums
+    //==========================================================================
 
     // enum for FOLLOW_OPTIONS parameter
     enum class Option {
@@ -43,6 +51,10 @@ public:
         YAW_BEHAVE_SAME_AS_LEAD_VEHICLE = 2,
         YAW_BEHAVE_DIR_OF_FLIGHT = 3
     };
+
+    //==========================================================================
+    // Constructor and Singleton Access
+    //==========================================================================
 
     // constructor
     AP_Follow();
@@ -58,34 +70,47 @@ public:
     // set which target to follow
     void set_target_sysid(uint8_t sysid) { _sysid.set(sysid); }
 
-    // restore offsets to zero if necessary, should be called when vehicle exits follow mode
+    // Resets the follow mode offsets to zero if they were automatically initialized. Should be called when exiting Follow mode.
     void clear_offsets_if_required();
 
-    //
-    // position tracking related methods
-    //
+    //==========================================================================
+    // Target Estimation and Tracking Methods
+    //==========================================================================
 
-    // true if we have a valid target location estimate
+    // Returns true if following is enabled and a recent target location update has been received.
     bool have_target() const;
 
-    // get target's estimated position (NED-from-origin) and velocity (in NED)
-    // from position-from-origin.  metres and metres/second
-    bool get_target_position_and_velocity_NED_m(Vector3p &pos_ned_m, Vector3f &vel_ned_ms) const;
+    // Projects the target’s position, velocity, and heading forward using the latest updates, smoothing with input shaping if necessary 
+    bool update_estimate();
 
-    // get target's estimated position (NED-from-origin) and velocity (in NED)
-    // from position-from-origin with offsets added.  metres and metres/second
-    bool get_target_position_and_velocity_ofs_NED_m(Vector3p &pos_ned, Vector3f &vel_ned) const;
+    // Retrieves the estimated target position, velocity, and acceleration in the NED frame relative to the origin (units: meters and meters/second).
+    bool get_target_pos_vel_accel_NED_m(Vector3p &pos_ned_m, Vector3f &vel_ned_ms, Vector3f &accel_ned_mss);
 
-    // get target's estimated location and velocity (in NED).  Derived
-    // from position-from-origin.
-    bool get_target_location_and_velocity(Location &loc, Vector3f &vel_ned) const;
+    // Retrieves the estimated target position, velocity, and acceleration in the NED frame, including configured positional offsets.
+    bool get_ofs_pos_vel_accel_NED_m(Vector3p &pos_ofs_ned_m, Vector3f &vel_ofs_ned_ms, Vector3f &accel_ofs_ned_mss);
 
-    // get target's estimated location and velocity (in NED), with
-    // offsets added.  Derived from position-from-origin.
-    bool get_target_location_and_velocity_ofs(Location &loc, Vector3f &vel_ned) const;
-    
-    // get distance vector to target (in meters), target plus offsets, and target's velocity all in NED frame
+    // Retrieves the estimated target heading and heading rate in radians.
+    bool get_heading_heading_rate_rad(float &heading_rad, float &heading_rate_rads);
+
+    //==========================================================================
+    // Global Location and Velocity Retrieval (LUA Bindings)
+    //==========================================================================
+
+    // Retrieves the estimated global location and velocity of the target. Adjusts altitude frame to relative if configured (for LUA bindings).
+    bool get_target_location_and_velocity(Location &loc, Vector3f &vel_ned);
+
+    // Retrieves the estimated global location and velocity of the target, including configured positional offsets (for LUA bindings).
+    bool get_target_location_and_velocity_ofs(Location &loc, Vector3f &vel_ned);
+
+    // Retrieves the estimated target heading in degrees (0° = North, 90° = East) for LUA bindings.
+    bool get_target_heading_deg(float &heading);
+
+    // Retrieves the distance vector to the target, the distance vector including configured offsets, and the target’s velocity in the NED frame (units: meters).
     bool get_target_dist_and_vel_NED_m(Vector3f &dist_ned, Vector3f &dist_with_ofs, Vector3f &vel_ned);
+
+    //==========================================================================
+    // Accessor Methods
+    //==========================================================================
 
     // get target sysid
     uint8_t get_target_sysid() const { return _sysid.get(); }
@@ -93,22 +118,22 @@ public:
     // get position controller.  this controller is not used within this library but it is convenient to hold it here
     const AC_P& get_pos_p() const { return _p_pos; }
 
-    //
-    // yaw/heading related methods
-    //
-
     // get user defined yaw behaviour
     YawBehave get_yaw_behave() const { return (YawBehave)_yaw_behave.get(); }
 
-    // get target's heading in degrees (0 = north, 90 = east)
-    bool get_target_heading_deg(float &heading) const;
+    // initialise offsets to provided distance vector to other vehicle (in meters in NED frame) if required
+    void init_offsets_if_required();
+
+    //==========================================================================
+    // MAVLink Message Handling
+    //==========================================================================
 
     // parse mavlink messages which may hold target's position, velocity and attitude
     void handle_msg(const mavlink_message_t &msg);
 
-    //
-    // GCS reporting functions
-    //
+    //==========================================================================
+    // GCS Reporting Methods
+    //==========================================================================
 
     // get horizontal distance to target (including offset) in meters (for reporting purposes)
     float get_distance_to_target_m() const { return _dist_to_target_m; }
@@ -117,34 +142,42 @@ public:
     float get_bearing_to_target_deg() const { return _bearing_to_target_deg; }
 
     // get system time of last position update
+    // LUA bindings
     uint32_t get_last_update_ms() const { return _last_location_update_ms; }
 
     // returns true if a follow option enabled
     bool option_is_enabled(Option option) const { return (_options.get() & (uint16_t)option) != 0; }
 
+    //==========================================================================
+    // Parameter Group Info
+    //==========================================================================
+
     // parameter list
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
+    //==========================================================================
+    // Private Helper Functions and Singleton
+    //==========================================================================
+
+    // Singleton instance of the AP_Follow class.
     static AP_Follow *_singleton;
 
     // returns true if we should extract information from msg
     bool should_handle_message(const mavlink_message_t &msg) const;
 
-    // get velocity estimate in m/s in NED frame using dt since last update
-    bool get_velocity_NED_ms(Vector3f &vel_ned, float dt) const;
+    // Checks whether the current estimate should be reset based on position and velocity errors.
+    bool estimate_error_too_large() const;
+    
+    // Calculates max velocity change under trapezoidal or triangular acceleration profile (jerk-limited).
+    float calc_max_velocity_change(float accel_max, float jerk_max, float timeout_sec) const;
 
-    // initialise offsets to provided distance vector to other vehicle (in meters in NED frame) if required
-    void init_offsets_if_required(const Vector3f &dist_vec_ned);
-
-    // get offsets in meters in NED frame
-    bool get_offsets_NED_m(Vector3f &offsets) const;
-
-    // rotate 3D vector clockwise by specified angle (in degrees)
+    // Rotates a 3D vector clockwise by the specified angle in degrees.
     Vector3f rotate_vector(const Vector3f &vec, float angle_deg) const;
 
-    // set recorded distance and bearing to target to zero
+    // Resets the recorded distance and bearing to the target to zero.
     void clear_dist_and_bearing_to_target();
+    void update_dist_and_bearing_to_target();
 
     // handle various mavlink messages supplying position:
     bool handle_global_position_int_message(const mavlink_message_t &msg);
@@ -153,32 +186,71 @@ private:
     // write out an onboard-log message to help diagnose follow problems:
     void Log_Write_FOLL();
 
-    // parameters
-    AP_Int8     _enabled;           // 1 if this subsystem is enabled
-    AP_Int16    _sysid;             // target's mavlink system id (0 to use first sysid seen)
-    AP_Float    _dist_max_m;          // maximum distance to target.  targets further than this will be ignored
-    AP_Int8     _offset_type;       // offset frame type (0:North-East-Down, 1:RelativeToLeadVehicleHeading)
-    AP_Vector3f _offset_ned_m;            // offset from lead vehicle in meters
-    AP_Int8     _yaw_behave;        // following vehicle's yaw/heading behaviour (see YAW_BEHAVE enum)
-    AP_Int8     _alt_type;          // altitude source for follow mode
-    AC_P        _p_pos;             // position error P controller
-    AP_Int16    _options;           // options for mount behaviour follow mode
+    //==========================================================================
+    // Parameters
+    //==========================================================================
 
-    // local variables
-    uint32_t _last_location_update_ms;  // system time of last position update
-    Vector3p _target_position_ned_m;  // last known position of target
-    Vector3f _target_velocity_ned_ms;  // last known velocity of target in NED frame in m/s
-    Vector3f _target_accel_ned_mss;     // last known acceleration of target in NED frame in m/s/s
-    uint32_t _last_heading_update_ms;   // system time of last heading update
-    float _target_heading_deg;          // heading in degrees
-    bool _automatic_sysid;          // did we lock onto a sysid automatically?
-    float _dist_to_target_m;          // latest distance to target in meters (for reporting purposes)
-    float _bearing_to_target_deg;       // latest bearing to target in degrees (for reporting purposes)
-    bool _offsets_were_zero;        // true if offsets were originally zero and then initialised to the offset from lead vehicle
+    AP_Int8     _enabled;           // 1 = Follow mode is enabled; 0 = disabled
+    AP_Int16    _sysid;             // MAVLink system ID of the target (0 = auto-select first sender)
+    AP_Float    _dist_max_m;        // Maximum allowed distance to target in meters; if exceeded, estimation is rejected
+    AP_Int8     _offset_type;       // Offset frame type: 0 = NED, 1 = relative to lead vehicle heading
+    AP_Vector3f _offset_m;          // Offset from lead vehicle (meters), in NED or FRD frame depending on _offset_type
+    AP_Int8     _yaw_behave;        // Yaw behavior mode (see YawBehave enum)
+    AP_Int8     _alt_type;          // Altitude reference: 0 = absolute, 1 = relative to home
+    AC_P        _p_pos;             // Position error P-controller for optional altitude following
+    AP_Int16    _options;           // Bitmask of follow behavior options (e.g., mount follow, etc.)
 
-    // setup jitter correction with max transport lag of 3s
+    AP_Float    _accel_max_ne_mss;  // Max horizontal acceleration for kinematic shaping (m/s²)
+    AP_Float    _jerk_max_ne_msss;  // Max horizontal jerk for kinematic shaping (m/s³)
+    AP_Float    _accel_max_d_mss;   // Max vertical acceleration for kinematic shaping (m/s²)
+    AP_Float    _jerk_max_d_msss;   // Max vertical jerk for kinematic shaping (m/s³)
+    AP_Float    _accel_max_h_degss; // Max angular acceleration for heading shaping (deg/s²)
+    AP_Float    _jerk_max_h_degsss; // Max angular jerk for heading shaping (deg/s³)
+
+    //==========================================================================
+    // Internal State Variables
+    //==========================================================================
+
+    uint32_t    _last_location_update_ms;       // Time of last target position update (ms)
+    uint32_t    _last_estimation_update_ms;     // Time of last estimate update (ms)
+    uint32_t    _last_update_ticks;             // Scheduler tick count at last estimate update
+
+    Vector3p    _target_pos_ned_m;              // Latest received target position (NED frame, meters)
+    Vector3f    _target_vel_ned_ms;             // Latest received target velocity (NED frame, m/s)
+    Vector3f    _target_accel_ned_mss;          // Latest received target acceleration (NED frame, m/s²)
+    float       _target_heading_deg;            // Latest received target heading (degrees, 0 = North)
+    float       _target_heading_rate_degs;      // Latest received target yaw rate (deg/s)
+
+    bool        _estimate_valid;                // True if internal estimate is valid and in sync with updates
+    Vector3p    _estimate_pos_ned_m;            // Estimated target position (NED frame, meters)
+    Vector3f    _estimate_vel_ned_ms;           // Estimated target velocity (NED frame, m/s)
+    Vector3f    _estimate_accel_ned_mss;        // Estimated target acceleration (NED frame, m/s²)
+    float       _estimate_heading_rad;          // Estimated heading (radians, range -PI to PI)
+    float       _estimate_heading_rate_rads;    // Estimated heading rate (rad/s)
+    float       _estimate_heading_accel_radss;  // Estimated heading acceleration (rad/s²)
+
+    Vector3p    _ofs_estimate_pos_ned_m;        // Estimated position with offsets applied (NED frame)
+    Vector3f    _ofs_estimate_vel_ned_ms;       // Estimated velocity with offsets applied (NED frame)
+    Vector3f    _ofs_estimate_accel_ned_mss;    // Estimated acceleration with offsets applied (NED frame)
+
+    bool        _automatic_sysid;               // True if target sysid was automatically selected
+    int16_t     _sysid_used;                    // Currently active sysid used for updates
+    float       _dist_to_target_m;              // Horizontal distance to target, for reporting (meters)
+    float       _bearing_to_target_deg;         // Bearing to target from vehicle (degrees, 0 = North)
+    bool        _offsets_were_zero;             // True if initial offset was zero before being initialized
+    bool        _using_follow_target;           // True if FOLLOW_TARGET messages are being used instead of GLOBAL_POSITION_INT
+
+    //==========================================================================
+    // Utilities
+    //==========================================================================
+
+    // Jitter correction helper for smoothing offboard timestamps.
     JitterCorrection _jitter{500};
 };
+
+//==============================================================================
+// AP_Follow Accessor
+//==============================================================================
 
 namespace AP {
     AP_Follow &follow();

--- a/libraries/AP_Math/control.cpp
+++ b/libraries/AP_Math/control.cpp
@@ -391,10 +391,8 @@ void shape_angle_vel_accel(float angle_input, float angle_vel_input, float angle
     // The negative acceleration limit is used here because the square root controller
     // manages the approach to the setpoint. Therefore the acceleration is in the opposite
     // direction to the position error.
-    float angle_accel_tc_max;
-    float KPv;
-    angle_accel_tc_max = 0.5 * angle_accel_max;
-    KPv = 0.5 * angle_jerk_max / angle_accel_max;
+    const float angle_accel_tc_max = 0.5 * angle_accel_max;
+    const float KPv = 0.5 * angle_jerk_max / angle_accel_max;
 
     // velocity to correct position
     float angle_vel_target = sqrt_controller(angle_error, KPv, angle_accel_tc_max, dt);

--- a/libraries/AP_Math/control.cpp
+++ b/libraries/AP_Math/control.cpp
@@ -197,7 +197,7 @@ void shape_vel_accel(float vel_input, float accel_input,
     // velocity correction with input velocity
     accel_target += accel_input;
 
-    // constrain total acceleration from accel_min to accel_max
+    // Constrain total acceleration if limiting is enabled
     if (limit_total_accel) {
         accel_target = constrain_float(accel_target, accel_min, accel_max);
     }
@@ -252,7 +252,7 @@ void shape_vel_accel_xy(const Vector2f& vel_input, const Vector2f& accel_input,
 
     accel_target += accel_input;
 
-    // limit total acceleration to accel_max
+    // Constrain total acceleration if limiting is enabled 
     if (limit_total_accel) {
         accel_target.limit_length(accel_max);
     }
@@ -312,8 +312,8 @@ void shape_pos_vel_accel(postype_t pos_input, float vel_input, float accel_input
     // velocity correction with input velocity
     vel_target += vel_input;
 
-    // limit velocity between vel_min and vel_max
-    if (limit_total) {
+    // Constrain total velocity if limiting is enabled and the velocity range is valid (non-zero and min < max)
+    if (limit_total && (vel_max > vel_min)) {
         vel_target = constrain_float(vel_target, vel_min, vel_max);
     }
 
@@ -351,8 +351,8 @@ void shape_pos_vel_accel_xy(const Vector2p& pos_input, const Vector2f& vel_input
     // velocity correction with input velocity
     vel_target = vel_target + vel_input;
     
-    // limit velocity to vel_max
-    if (limit_total) {
+    // Constrain total velocity if limiting is enabled and vel_max is positive 
+    if (limit_total && is_positive(vel_max)) {
         vel_target.limit_length(vel_max);
     }
 
@@ -407,7 +407,7 @@ void shape_angle_vel_accel(float angle_input, float angle_vel_input, float angle
     // velocity correction with input velocity
     angle_vel_target += angle_vel_input;
 
-    // limit velocity to vel_max
+    // Constrain total velocity if limiting is enabled and angle_vel_max is positive 
     if (limit_total && is_positive(angle_vel_max)){
         angle_vel_target = constrain_float(angle_vel_target, -angle_vel_max, angle_vel_max);
     }

--- a/libraries/AP_Math/control.h
+++ b/libraries/AP_Math/control.h
@@ -103,6 +103,21 @@ void shape_pos_vel_accel_xy(const Vector2p& pos_input, const Vector2f& vel_input
                             float vel_max, float accel_max,
                             float jerk_max, float dt, bool limit_total);
 
+/* shape_angle_vel_accel calculate a jerk limited path from the current angle, angular velocity and angular acceleration to an input angle, angular velocity and angular acceleration.           
+ The function takes the current angle, angular velocity, and angular acceleration and calculates the required jerk limited adjustment to the angular acceleration for the next time dt.
+ The kinematic path is constrained by :
+    maximum angular velocity - angle_vel_max,
+    maximum angular acceleration - angle_accel_max,
+    maximum angular jerk - angle_jerk_max.
+ The function alters the variable accel to follow a jerk limited kinematic path to angle_input, angle_vel_input and angle_accel_input.
+ The angle_vel_max limit can be removed by setting the desired limit to zero.
+ The correction angular velocity is limited to angle_vel_max. If limit_total is true the total angular velocity is limited to angle_vel_max.
+ The correction angular acceleration can is limited to angle_accel_max. If limit_total is true the total angular acceleration is limited to angle_accel_max.
+*/            
+void shape_angle_vel_accel(float angle_input, float angle_vel_input, float angle_accel_input,
+                         float angle, float angle_vel, float& angle_accel,
+                         float angle_vel_max, float angle_accel_max,
+                         float angle_jerk_max, float dt, bool limit_total);
 
 /* limit_accel_xy limits the acceleration to prioritise acceleration perpendicular to the provided velocity vector.
  Input parameters are:


### PR DESCRIPTION
This pr provides a kinematic estimate of the target location and heading.

I have added time out's and resets based on the kinematic limits and errors.

We need to decide on how we choose between the different data message sources. Ideally I would like to change the name and extend the _ALT_TYPE parameter to be 0: GPI absolute, 1: GPI relative, 2: Follow Target (GPI = global position int).

We also need to decide what the options and default settings should be. We can leave the kinematic interpolation off by default, we may choose not to process acceleration to reduce noise.