### PR TITLE
AP_GPS: log altitude above ellipsoid instead of undulation

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1912,11 +1912,14 @@ void AP_GPS::Write_GPS(uint8_t i)
 
     /* write auxiliary accuracy information as well */
     float hacc = 0, vacc = 0, sacc = 0;
+    int32_t alt_ellipsoid = INT32_MIN;
     float undulation = 0;
     horizontal_accuracy(i, hacc);
     vertical_accuracy(i, vacc);
     speed_accuracy(i, sacc);
-    get_undulation(i, undulation);
+    if (get_undulation(i, undulation)) {
+        alt_ellipsoid = loc.alt - (undulation*100);
+    }
     struct log_GPA pkt2{
         LOG_PACKET_HEADER_INIT(LOG_GPA_MSG),
         time_us       : time_us,
@@ -1929,7 +1932,7 @@ void AP_GPS::Write_GPS(uint8_t i)
         have_vv       : (uint8_t)have_vertical_velocity(i),
         sample_ms     : last_message_time_ms(i),
         delta_ms      : last_message_delta_time_ms(i),
-        undulation    : undulation,
+        alt_ellipsoid : alt_ellipsoid,
         rtcm_fragments_used: rtcm_stats.fragments_used,
         rtcm_fragments_discarded: rtcm_stats.fragments_discarded
     };

--- a/libraries/AP_GPS/LogStructure.h
+++ b/libraries/AP_GPS/LogStructure.h
@@ -63,7 +63,7 @@ struct PACKED log_GPS {
 // @Field: VV: true if vertical velocity is available
 // @Field: SMS: time since system startup this sample was taken
 // @Field: Delta: system time delta between the last two reported positions
-// @Field: Und: Undulation
+// @Field: AEl: altitude above WGS-84 ellipsoid; INT32_MIN (-2147483648) if unknown
 // @Field: RTCMFU: RTCM fragments used
 // @Field: RTCMFD: RTCM fragments discarded
 struct PACKED log_GPA {
@@ -78,7 +78,7 @@ struct PACKED log_GPA {
     uint8_t  have_vv;
     uint32_t sample_ms;
     uint16_t delta_ms;
-    float undulation;
+    int32_t  alt_ellipsoid;
     uint16_t rtcm_fragments_used;
     uint16_t rtcm_fragments_discarded;
 };
@@ -207,7 +207,7 @@ struct PACKED log_GPS_RAWS {
     { LOG_GPS_MSG, sizeof(log_GPS), \
       "GPS",  "QBBIHBcLLeffffB", "TimeUS,I,Status,GMS,GWk,NSats,HDop,Lat,Lng,Alt,Spd,GCrs,VZ,Yaw,U", "s#-s-S-DUmnhnh-", "F--C-0BGGB000--" , true }, \
     { LOG_GPA_MSG,  sizeof(log_GPA), \
-      "GPA",  "QBCCCCfBIHfHH", "TimeUS,I,VDop,HAcc,VAcc,SAcc,YAcc,VV,SMS,Delta,Und,RTCMFU,RTCMFD", "s#-mmnd-ssm--", "F-BBBB0-CC0--" , true }, \
+      "GPA",  "QBCCCCfBIHeHH", "TimeUS,I,VDop,HAcc,VAcc,SAcc,YAcc,VV,SMS,Delta,AEl,RTCMFU,RTCMFD", "s#-mmnd-ssm--", "F-BBBB0-CCB--" , true }, \
     { LOG_GPS_UBX1_MSG, sizeof(log_Ubx1), \
       "UBX1", "QBHBBHI",  "TimeUS,Instance,noisePerMS,jamInd,aPower,agcCnt,config", "s#-----", "F------"  , true }, \
     { LOG_GPS_UBX2_MSG, sizeof(log_Ubx2), \


### PR DESCRIPTION
ArduPilot's internal definition of undulation is reversed in sign compared to the accepted convention and this creates confusion: https://github.com/ArduPilot/ardupilot/issues/29199 .

Instead of the internal definition, log the altitude above ellipsoid, which ArduPilot already consistently and correctly calculates and broadcasts over e.g. DroneCAN and MAVLink. Switching the quantity logged allows users to accommodate the problem in old logs (i.e. always flip GPA.Und sign to match the accepted convention) and reduces opportunity for future confusion.

Future work will clean up or replace the internal representation, but this should be a complete fix for the issue from a user perspective.

Tested using u-blox, u-blox over AP_Periph over DroneCAN, and NovAtel.

[Geoid information](https://www.unavco.org/software/geodetic-utilities/geoid-height-calculator/geoid-height-calculator.html) using EGM96 from my (approximate) back yard showing an ellipsoid height of 60.57m, an undulation of -28.35m, and a mean sea level height of 88.92m:
![Screenshot from 2025-04-26 15-43-09](https://github.com/user-attachments/assets/5f5dab21-ef9b-43a0-a125-dfcd3e1a7f4a)


Dataflash log from a u-blox NEO-M9N, values match well (receiver-calculated undulation is -30.07m):
![Screenshot from 2025-04-26 15-42-24](https://github.com/user-attachments/assets/9cc93bd6-38e9-4970-a4b1-d2b22254cbcf)


Corresponding telemetry log: 
![Screenshot from 2025-04-26 15-42-20](https://github.com/user-attachments/assets/cda28229-cca2-4021-aadb-77864d4af2b3)

