### PR TITLE
AP_GPS: DroneCAN: only trust ellipsoid height if different from MSL

### DIFF
--- a/libraries/AP_GPS/AP_GPS_DroneCAN.h
+++ b/libraries/AP_GPS/AP_GPS_DroneCAN.h
@@ -111,6 +111,7 @@ private:
     bool seen_aux;
     bool seen_status;
     bool seen_relposheading;
+    bool seen_valid_height_ellipsoid;
 
     bool healthy;
     uint32_t status_flags;


### PR DESCRIPTION
AP_Periph sends `ellipsoid == MSL` if the underlying GPS driver can't retrieve an ellipsoid height for whatever reason. Older versions of AP_Periph (including all Here3+ firmwares at the time of writing) always send `MSL == ellipsoid` and never report a valid ellipsoid height.

To accommodate this, only use the ellipsoid height reported over DroneCAN to compute an undulation if we've ever seen it different from the MSL height. This ensures we accurately represent the equipment capability, at least if the GPS is not changed at runtime.

Future work will establish an "unknown" ellipsoid height value in the DroneCAN standard and always ignore it.

Tested on Cube Orange and MatekL431-Periph nodes (running various code versions) connected to a u-blox GPS.