### PR TITLE
Fixes for testing for identical Linux builds

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -529,6 +529,11 @@ class Board:
             # if symbols are renamed we don't want them to affect the output:
             env.CXXFLAGS += ['-fno-rtti']
             env.CFLAGS += ['-fno-rtti']
+            # stop including a unique ID in the headers.  More useful
+            # when trying to find binary differences as the build-id
+            # appears to be a hash of the output products
+            # (ie. identical for identical compiler output):
+            env.LDFLAGS += ['-Wl,--build-id=bob']
             # squash all line numbers to be the number 17
             env.CXXFLAGS += [
                 "-D__AP_LINE__=17",

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -526,6 +526,9 @@ class Board:
             env.CXXFLAGS += ['-DHAL_WITH_EKF_DOUBLE=0']
 
         if cfg.options.consistent_builds:
+            # if symbols are renamed we don't want them to affect the output:
+            env.CXXFLAGS += ['-fno-rtti']
+            env.CFLAGS += ['-fno-rtti']
             # squash all line numbers to be the number 17
             env.CXXFLAGS += [
                 "-D__AP_LINE__=17",


### PR DESCRIPTION
Symbol renames create identical output binaries on stm32 targets, but elf outputs (eg. for Linux builds) contain symbol names in default builds.

These patches strip run-time-type-information (rtti) information from the builds; not sure why the linker is deciding we need that in our Linux binaries, but removing it from these special builds seems reasonable.

The symbol differences also mean the build ID is different, so canonicalise that in our consistent-builds too.

Finally, have size_compare_branches.py understand that stripping symbols might be required before determining if an elf file should be considered identical to another elf file.
