### PR TITLE
autotest: add support for adding prefix while launching tmux new-window

### DIFF
--- a/Tools/autotest/run_in_terminal_window.sh
+++ b/Tools/autotest/run_in_terminal_window.sh
@@ -29,7 +29,7 @@ if [ -n "$SITL_RITW_TERMINAL" ]; then
   chmod +x "$FILEPATH"
   $SITL_RITW_TERMINAL "$FILEPATH" &
 elif [ -n "$TMUX" ]; then
-  tmux new-window -dn "$name" "$*"
+  tmux new-window -dn "$name" "$TMUX_PREFIX $*"
 elif [ -n "$DISPLAY" -a -n "$(which osascript)" ]; then
   osascript -e 'tell application "Terminal" to do script "'"cd $(pwd) && clear && $* "'"'
 elif [ -n "$DISPLAY" -a -n "$(which xterm)" ]; then


### PR DESCRIPTION
This allows a method to launch gdbserver from vscode extension 