### PR TITLE
fix enum format

### DIFF
--- a/libraries/AP_HAL_Linux/RCInput_RPI.cpp
+++ b/libraries/AP_HAL_Linux/RCInput_RPI.cpp
@@ -290,7 +290,7 @@ void RCInput_RPI::set_physical_addresses()
         clk_base = RCIN_RPI_RPI4_CLK_BASE;
         pcm_base = RCIN_RPI_RPI4_PCM_BASE;
     } else {
-        fprintf(stderr,"Unknown Linux Board version!\n");
+        fprintf(stderr,"Unknown Linux Board version: %i\n", int(_version));
         exit(-1);
     }
 }


### PR DESCRIPTION
The `fprintf` for the `LINUX_BOARD_TYPE` fails due to the format specifier that is incompatible with enums:
```
../../libraries/AP_HAL_Linux/RCInput_RPI.cpp: In member function ‘void Linux::RCInput_RPI::set_physical_addresses()’:
../../libraries/AP_HAL_Linux/RCInput_RPI.cpp:293:56: error: format ‘%i’ expects argument of type ‘int’, but argument 3 has type ‘Linux::LINUX_BOARD_TYPE’ [-Werror=format=]
  293 |         fprintf(stderr,"Unknown Linux Board version!: %i\n", _version);
      |                                                       ~^     ~~~~~~~~
      |                                                        |     |
      |                                                        int   Linux::LINUX_BOARD_TYPE
compilation terminated due to -Wfatal-errors.
cc1plus: some warnings being treated as errors
```

This PR fixes the issue with an explicit cast.
