### PR TITLE
CI: revert "build CubeRed-EKF2 not CubeOrange-EKF2 in CI"

### DIFF
--- a/.github/workflows/test_chibios.yml
+++ b/.github/workflows/test_chibios.yml
@@ -156,7 +156,7 @@ jobs:
             build-options-defaults-test,
             signing,
             CubeOrange-PPP,
-            CubeRed-EKF2,
+            CubeOrange-EKF2,
             SOHW,
             Pixhawk6X-PPPGW,
             new-check,

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -341,9 +341,9 @@ for t in $CI_BUILD_TARGET; do
         continue
     fi
 
-    if [ "$t" == "CubeRed-EKF2" ]; then
-        echo "Building CubeRed with EKF2 enabled"
-        $waf configure --board CubeRedPrimary --enable-EKF2
+    if [ "$t" == "CubeOrange-EKF2" ]; then
+        echo "Building CubeOrange with EKF2 enabled"
+        $waf configure --board CubeOrange --enable-EKF2
         $waf clean
         $waf copter
         continue


### PR DESCRIPTION
Reverts ArduPilot/ardupilot#28128 now that CubeRed is out of flash and CubeOrange has loads free.