### PR TITLE
hwdef: remove unused USB_HW_ENABLE_HS define

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CUAV-Nora/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CUAV-Nora/hwdef.dat
@@ -27,7 +27,6 @@ PA12 OTG_FS_DP OTG1
 
 # Port switching for USB HS and FS,high = USB_FS , LOW = USB_HS
 PH15 USB_HS_ENABLE OUTPUT HIGH
-define USB_HW_ENABLE_HS 0
 
 # these are the pins for SWD debugging with a STlinkv2 or black-magic probe
 PA13 JTMS-SWDIO SWD

--- a/libraries/AP_HAL_ChibiOS/hwdef/CUAV-X7/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CUAV-X7/hwdef.dat
@@ -27,7 +27,6 @@ PA12 OTG_FS_DP OTG1
 
 # Port switching for USB HS and FS,high = USB_FS , LOW = USB_HS
 PH15 USB_HS_ENABLE OUTPUT HIGH
-define USB_HW_ENABLE_HS 0
 
 # these are the pins for SWD debugging with a STlinkv2 or black-magic probe
 PA13 JTMS-SWDIO SWD

--- a/libraries/AP_HAL_ChibiOS/hwdef/MFT-SEMA100/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MFT-SEMA100/hwdef.dat
@@ -29,7 +29,6 @@ PA12 OTG_FS_DP OTG1
 
 # Port switching for USB HS and FS,high = USB_FS , LOW = USB_HS
 PH15 USB_HS_ENABLE OUTPUT HIGH
-define USB_HW_ENABLE_HS 0
 
 # these are the pins for SWD debugging with a STlinkv2 or black-magic probe
 PA13 JTMS-SWDIO SWD

--- a/libraries/AP_HAL_ChibiOS/hwdef/NarinFC-H7/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/NarinFC-H7/hwdef.dat
@@ -46,7 +46,6 @@ PA12 OTG_FS_DP OTG1
 
 # Port switching for USB HS and FS,high = USB_FS , LOW = USB_HS
 PH15 USB_HS_ENABLE OUTPUT HIGH
-define USB_HW_ENABLE_HS 0
 
 # these are the pins for SWD debugging with a STlinkv2 or black-magic probe
 PA13 JTMS-SWDIO SWD


### PR DESCRIPTION
```
Board        blimp  bootloader  copter  heli  plane  rover  sub
CUAV-Nora    *      *           *       *     *      *      *
CUAV-X7      *      *           *       *     *      *      *
MFT-SEMA100  *      *           *       *     *      *      *
NarinFC-H7   *      *           *       *     *      *      *
```
