### PR TITLE
AP_Scripting: fix cast-local-type in Rockblock and MAVLinkHL

### DIFF
--- a/libraries/AP_Scripting/applets/RockBlock.lua
+++ b/libraries/AP_Scripting/applets/RockBlock.lua
@@ -760,8 +760,7 @@ function HLSatcom()
     --- check if GCS telemetry has been lost for RCK_TIMEOUT sec (if param enabled)
     if RCK_FORCEHL:get() == 2 then
         -- link lost time = boot time - GCS last seen time
-        ---@diagnostic disable-next-line cast-local-type
-        link_lost_for = millis():toint() - gcs:last_seen()
+        link_lost_for = (millis()- gcs:last_seen()):toint()
         -- gcs:last_seen() is set to millis() during boot (on plane). 0 on rover/copter
         -- So if it's less than 10000 assume no GCS packet received since boot
         if link_lost_for > (RCK_TIMEOUT:get() * 1000) and not gcs:get_high_latency_status() and gcs:last_seen() > 10000 then

--- a/libraries/AP_Scripting/examples/MAVLinkHL.lua
+++ b/libraries/AP_Scripting/examples/MAVLinkHL.lua
@@ -415,8 +415,7 @@ function HLSatcom()
     -- if mode 1 and there's been no mavlink traffic for 5000 ms, enable high latency
     if hl_mode == 1 then
         -- link lost time = boot time - GCS last seen time
-        ---@diagnostic disable-next-line cast-local-type
-        link_lost_for = millis():toint() - gcs:last_seen()
+        link_lost_for = (millis()- gcs:last_seen()):toint()
         -- gcs:last_seen() is set to millis() during boot (on plane). 0 on rover/copter
         -- So if it's less than 10000 assume no GCS packet received since boot
         if link_lost_for > 5000 and not gcs:get_high_latency_status() and gcs:last_seen() > 10000 then


### PR DESCRIPTION
Following on from the discussion in #29889, this PR fixes up a Lua ``cast-local-type`` issue.