### PR TITLE
AP_RCTelemetry, CRSF ground speed incorrect by some 20%

### DIFF
--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
@@ -1014,7 +1014,7 @@ void AP_CRSF_Telem::calc_gps()
 
     _telem.bcast.gps.latitude = htobe32(loc.lat);
     _telem.bcast.gps.longitude = htobe32(loc.lng);
-    _telem.bcast.gps.groundspeed = htobe16(roundf(AP::gps().ground_speed() * 100000 / 3600));
+    _telem.bcast.gps.groundspeed = htobe16(roundf(AP::gps().ground_speed() * 36.0f));
     _telem.bcast.gps.altitude = htobe16(constrain_int16(loc.alt / 100, 0, 5000) + 1000);
     _telem.bcast.gps.gps_heading = htobe16(roundf(AP::gps().ground_course() * 100.0f));
     _telem.bcast.gps.satellites = AP::gps().num_sats();


### PR DESCRIPTION
It is believed (see below) that the conversion is wrong and needs to be changed from 100000/3600 = 100/3.6 to 36 = 10*3.6.

(note: 100/3.6 = 28 is quite a bit different from 36 but maybe not enough to be immediately noticed)

The PR also grabs the oportunity to write the factor in floats, like it is done two lines below for the other gps() data.

### Details

This came out of a bug report of a mLRS user, https://github.com/olliw42/mLRS/issues/271, where the user observed a signifcant difference for the ground speed reported as FCRSF GSpd telemetry sensor and in MissionPlanner, even though both data items are derived from the same MAVLink message. It was traced back to a bug in the conversion from the mavlink data into crsf data in mLRS.

The same code is used also in ArduPilot howver (actually, it's likely the opposite, that mLRS has followed AP's conversion).

The situation is a little further blurred by that there seems to be an icorrect statement in the TBS docs for this sad sensor.

So, the situation is:
- the conversion MUST be wrong, as it is easily seen from the fact that it needs to convert from m/s (the units returned by AP::gps().ground_speed()) into km/h (the unitsdesired by GPsd), so it must be of the type *3.6 and not /3.6 ! (the code uses /3.6)
- by some brute force testing for mLRS it was determined that the GSpd representation is in units of 0.1 km/h and not 0.01 km/h as suggested by TBS docs.
- that the TBS docs are incorrect is suggested also that the suggested conversion change indices a change by only 23%, not anywhere near to a factor of 10.

Ergo, the conversion is changed from 100000/3600 = 100/3.6 to 36 = 10*3.6.

