### PR TITLE
waf: stop setting CXX flags based on C compiler version

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -294,14 +294,6 @@ class Board:
                 '-Wno-format-contains-nul',
                 '-fsingle-precision-constant', # force const vals to be float , not double. so 100.0 means 100.0f
             ]
-            if self.cc_version_gte(cfg, 7, 4):
-                env.CXXFLAGS += [
-                    '-Werror=implicit-fallthrough',
-                ]
-            env.CXXFLAGS += [
-                '-fsingle-precision-constant',
-                '-Wno-psabi',
-            ]
 
         if cfg.env.DEBUG:
             env.CFLAGS += [
@@ -428,7 +420,9 @@ class Board:
         else:
             env.CXXFLAGS += [
                 '-Wno-format-contains-nul',
-                '-Werror=unused-but-set-variable'
+                '-Werror=unused-but-set-variable',
+                '-fsingle-precision-constant',
+                '-Wno-psabi',
             ]
             if self.cc_version_gte(cfg, 5, 2):
                 env.CXXFLAGS += [


### PR DESCRIPTION
If you expand up you can see we're setting these CXX flags based on `if 'clang' in cfg.env.COMPILER_CC:`  - but that's the C compiler, not the C++ compiler version.

We have a block for adding CXX flags based on C++ compiler version, so use that for these CXX flags!
