### PR TITLE
Avoid compiler warnings raised by clang++

### DIFF
--- a/Blimp/AP_Arming_Blimp.cpp
+++ b/Blimp/AP_Arming_Blimp.cpp
@@ -29,6 +29,8 @@ bool AP_Arming_Blimp::run_pre_arm_checks(bool display_failure)
         return mandatory_checks(display_failure);
     }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wbitwise-instead-of-logical"
     return parameter_checks(display_failure)
 #if AP_FENCE_ENABLED
            & fence_checks(display_failure)
@@ -37,6 +39,7 @@ bool AP_Arming_Blimp::run_pre_arm_checks(bool display_failure)
            & gcs_failsafe_check(display_failure)
            & alt_checks(display_failure)
            & AP_Arming::pre_arm_checks(display_failure);
+#pragma clang diagnostic pop
 }
 
 bool AP_Arming_Blimp::barometer_checks(bool display_failure)

--- a/Rover/AP_Arming_Rover.cpp
+++ b/Rover/AP_Arming_Rover.cpp
@@ -88,6 +88,8 @@ bool AP_Arming_Rover::pre_arm_checks(bool report)
         return false;
     }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wbitwise-instead-of-logical"
     return (AP_Arming::pre_arm_checks(report)
             & motor_checks(report)
 #if AP_OAPATHPLANNER_ENABLED
@@ -95,6 +97,7 @@ bool AP_Arming_Rover::pre_arm_checks(bool report)
 #endif
             & parameter_checks(report)
             & mode_checks(report));
+#pragma clang diagnostic pop
 }
 
 bool AP_Arming_Rover::arm_checks(AP_Arming::Method method)

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3515,7 +3515,9 @@ MAV_RESULT GCS_MAVLINK::handle_preflight_reboot(const mavlink_command_int_t &pac
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
+#if !defined(__clang__)  // avoid -Wunknown-warning-option
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
             *foo = 0xab;
 #pragma GCC diagnostic pop
 
@@ -3533,7 +3535,9 @@ MAV_RESULT GCS_MAVLINK::handle_preflight_reboot(const mavlink_command_int_t &pac
             // String is kept short for space reasons.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
+#if !defined(__clang__)  // avoid -Wunknown-warning-option
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
             send_text(MAV_SEVERITY_INFO, "x: %u", (unsigned)*foo);
 #pragma GCSS diagnostic pop
 

--- a/libraries/GCS_MAVLink/GCS_MAVLink_Parameters.cpp
+++ b/libraries/GCS_MAVLink/GCS_MAVLink_Parameters.cpp
@@ -96,7 +96,7 @@ static const uint8_t default_rates[] {
     AP_MAV_DEFAULT_STREAM_RATE_PARAMS,
     AP_MAV_DEFAULT_STREAM_RATE_ADSB,
 };
-static_assert(ARRAY_SIZE(default_rates) == GCS_MAVLINK::NUM_STREAMS);
+static_assert(ARRAY_SIZE(default_rates) == GCS_MAVLINK::NUM_STREAMS, "enough default rates for all streams");
 
 #define DRATE(x) (float(default_rates[x]))
 


### PR DESCRIPTION
btiwise-op stuff; we intentionally use & to avoid short-circuiting.

Also fixes for `-Wunknown-warning-option`
