### PR TITLE
AC_Autorotation: correct logging of reason into AROT

### DIFF
--- a/libraries/AC_Autorotation/AC_Autorotation.cpp
+++ b/libraries/AC_Autorotation/AC_Autorotation.cpp
@@ -447,7 +447,7 @@ void AC_Autorotation::log_write_autorotation(void) const
                                 "F-",
                                 "QB",
                                 AP_HAL::micros64(),
-                                _landed_reason);
+                                reason);
 }
 #endif  // HAL_LOGGING_ENABLED
 


### PR DESCRIPTION
it's a lot of trouble to go to to create a variable to then not use it!