### PR TITLE
AP_InertialSensor: remove unused rotation member

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.h
@@ -50,7 +50,5 @@ private:
     // Low Pass filters for gyro and accel 
     LowPassFilter2pVector3f _accel_filter;
     LowPassFilter2pVector3f _gyro_filter;
-
-    enum Rotation _rotation; 
 };
 #endif // __AP_INERTIAL_SENSOR_L3G4200D2_H__


### PR DESCRIPTION
It's private and doesn't appear in the C++
