### PR TITLE
AP_DroneCAN: ESC bitmask description clarification

### DIFF
--- a/libraries/AP_DroneCAN/AP_DroneCAN.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.cpp
@@ -143,7 +143,7 @@ const AP_Param::GroupInfo AP_DroneCAN::var_info[] = {
 
     // @Param: ESC_OF
     // @DisplayName: ESC Output channels offset
-    // @Description: Offset for ESC numbering in DroneCAN ESC RawCommand messages. This allows for more efficient packing of ESC command messages. If your ESCs are on servo functions 5 to 8 and you set this parameter to 4 then the ESC RawCommand will be sent with the first 4 slots filled. This can be used for more efficient usage of CAN bandwidth
+    // @Description: Offset for ESC numbering in DroneCAN ESC RawCommand messages. This allows for more efficient packing of ESC command messages. If your ESCs are on servo outputs 5 to 8 and you set this parameter to 4 then the ESC RawCommand will be sent with the first 4 slots filled. This can be used for more efficient usage of CAN bandwidth
     // @Range: 0 18
     // @User: Advanced
     AP_GROUPINFO("ESC_OF", 7, AP_DroneCAN, _esc_offset, 0),


### PR DESCRIPTION
The way the description is phrased is a little confusing since need to map servo outputs and not functions. E.g. for this setup:
```
SERVO1_FUNCTION  19.000000 # Elevator
SERVO2_FUNCTION  0.000000 # Disabled
SERVO3_FUNCTION  0.000000 # Disabled
SERVO4_FUNCTION  0.000000 # Disabled
SERVO5_FUNCTION  4.000000 # Aileron
SERVO6_FUNCTION  4.000000 # Aileron
SERVO7_FUNCTION  0.000000 # Disabled
SERVO8_FUNCTION  0.000000 # Disabled
SERVO9_FUNCTION  33.000000 # Motor1
SERVO10_FUNCTION 34.000000 # Motor2
SERVO11_FUNCTION 35.000000 # Motor3
SERVO12_FUNCTION 36.000000 # Motor4
SERVO13_FUNCTION 70.000000 # Throttle
SERVO14_FUNCTION 0.000000 # Disabled
SERVO15_FUNCTION 0.000000 # Disabled
SERVO16_FUNCTION 0.000000 # Disabled
```

I expect the following:
```
CAN_D1_UC_ESC_BM 3840.000000 #  ESC 9| ESC 10| ESC 11| ESC 12
```

If anything motor 1 is function 33 and I don't think we need to set the 33th bit? This setup does work nice and clean, but the parameter description introduces unnecessary doubts.

In case I am correct in interpretation, I'd love the text be clarified for the next person.