### PR TITLE
Pass toolchain through to tools using board_config.py

### DIFF
--- a/libraries/AP_HAL_Linux/hwdef/linux/hwdef.dat
+++ b/libraries/AP_HAL_Linux/hwdef/linux/hwdef.dat
@@ -1,5 +1,7 @@
 # hwdef for generic Linux configuration option, eg. running on your laptop
 
+env TOOLCHAIN native
+
 define HAL_BOARD_LOG_DIRECTORY "logs"
 define HAL_BOARD_TERRAIN_DIRECTORY "terrain"
 define HAL_BOARD_STORAGE_DIRECTORY "."


### PR DESCRIPTION
This allows for correct stripping of Linux binaries when determining binary-identicalness.

Also removes hack for making elf-diff work.

Create a Result object to handle a compilation result as a gradual-improvement thing
