### PR TITLE
CAN: fixed race in SITL and Linux HALs

### DIFF
--- a/libraries/AP_HAL_Linux/CANSocketIface.cpp
+++ b/libraries/AP_HAL_Linux/CANSocketIface.cpp
@@ -270,6 +270,9 @@ void CANIface::_pollWrite()
 {
     while (_hasReadyTx()) {
         WITH_SEMAPHORE(sem);
+        if (!_hasReadyTx()) {
+            break;
+        }
         const CanTxItem tx = _tx_queue.top();
         uint64_t curr_time = AP_HAL::micros64();
         if (tx.deadline >= curr_time) {

--- a/libraries/AP_HAL_SITL/CANSocketIface.cpp
+++ b/libraries/AP_HAL_SITL/CANSocketIface.cpp
@@ -140,11 +140,13 @@ void CANIface::_pollWrite()
     }
     while (_hasReadyTx()) {
         WITH_SEMAPHORE(sem);
-        const CanTxItem tx = *_tx_queue[0];
+        const CanTxItem *tx = _tx_queue[0];
+        if (tx == nullptr) {
+            break;
+        }
         const uint64_t curr_time = AP_HAL::micros64();
-        if (tx.deadline >= curr_time) {
-            // hal.console->printf("%x TDEAD: %lu CURRT: %lu DEL: %lu\n",tx.frame.id,  tx.deadline, curr_time, tx.deadline-curr_time);
-            bool ok = transport->send(tx.frame);
+        if (tx->deadline >= curr_time) {
+            bool ok = transport->send(tx->frame);
             if (ok) {
                 stats.tx_success++;
                 stats.last_transmit_us = curr_time;


### PR DESCRIPTION
With multiple threads sending CAN messages we can get a race with the send mutex. This issue was found in SITL with quadplane-can frame.
