### PR TITLE
AP_AdvancedFailsafe: option to not go back to the loss comm mission item if we are already in the return path

### DIFF
--- a/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.h
+++ b/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.h
@@ -82,6 +82,9 @@ public:
     // during sensor calibration
     void heartbeat(void);
 
+    //return true if we should jump to _wp_comms_hold
+    bool should_use_comms_hold(void);
+
     // return true if we are terminating (deliberately crashing the vehicle)
     bool should_crash_vehicle(void);
 
@@ -138,7 +141,7 @@ protected:
     bool _heartbeat_pin_value;
 
     // saved waypoint for resuming mission
-    uint8_t _saved_wp;
+    uint16_t _saved_wp;
     
     // number of times we've lost GPS
     uint8_t _gps_loss_count;
@@ -171,6 +174,7 @@ private:
     enum class Option {
         CONTINUE_AFTER_RECOVERED = (1U<<0),
         GCS_FS_ALL_AUTONOMOUS_MODES = (1U<<1),
+        CONTINUE_IF_ALREADY_IN_RETURN_PATH = (1U<<2),
     };
     bool option_is_set(Option option) const {
         return (options.get() & int16_t(option)) != 0;


### PR DESCRIPTION
Currently, if there is a loss comm., the aircraft will always fly to the mission item specified with AFS_WP_COMMS.

I added an option so that if we have already passed AFS_WP_COMMS and got a loss. We should not go back to AFS_WP_COMMS. 

This is useful, for example, if the aircraft is already in the landing sequence. If there is a loss during a landing attempt, it should just land instead of starting the landing sequence again. 

I tested the change with Gazebo SITL.