### PR TITLE
ArduSub: add EMERGENCY surface mode to Sub

### DIFF
--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -118,6 +118,7 @@ public:
     friend class ModeAuto;
     friend class ModeCircle;
     friend class ModeSurface;
+    friend class ModeEmergency;
     friend class ModeMotordetect;
 
     Sub(void);
@@ -620,6 +621,7 @@ private:
     ModePoshold mode_poshold;
     ModeCircle mode_circle;
     ModeSurface mode_surface;
+    ModeEmergency mode_emergency;
     ModeMotordetect mode_motordetect;
     ModeSurftrak mode_surftrak;
 

--- a/ArduSub/defines.h
+++ b/ArduSub/defines.h
@@ -102,6 +102,7 @@ enum LoggingParameters {
 #define FS_GCS_DISARM       2 // Disarm
 #define FS_GCS_HOLD         3 // Switch depth hold mode or poshold mode if available
 #define FS_GCS_SURFACE      4 // Switch to surface mode
+#define FS_GCS_EMERGENCY    5 // Swith to emergency mode
 
 // Leak failsafe definitions (FS_LEAK_ENABLE parameter)
 #define FS_LEAK_DISABLED    0 // Disabled
@@ -142,6 +143,7 @@ enum LoggingParameters {
 #define FS_THR_DISABLED                            0
 #define FS_THR_WARN                                1
 #define FS_THR_SURFACE                             2
+#define FS_THR_EMERGENCY		           3
 
 // Amount of time to attempt recovery of valid rangefinder data before
 // initiating terrain failsafe action

--- a/ArduSub/failsafe.cpp
+++ b/ArduSub/failsafe.cpp
@@ -360,6 +360,8 @@ void Sub::failsafe_gcs_check()
         if (!set_mode(Mode::Number::SURFACE, ModeReason::GCS_FAILSAFE)) {
             arming.disarm(AP_Arming::Method::GCS_FAILSAFE_SURFACEFAILED);
         }
+    } else if (g.failsafe_gcs == FS_GCS_EMERGENCY && motors.armed()) {
+        set_mode(Mode::Number::EMERGENCY, ModeReason::GCS_FAILSAFE);
     }
 }
 
@@ -535,6 +537,9 @@ void Sub::failsafe_radio_on_event()
         switch(g.failsafe_throttle) {
         case FS_THR_SURFACE:
             set_mode(Mode::Number::SURFACE, ModeReason::RADIO_FAILSAFE);
+            break;
+        case FS_THR_EMERGENCY:
+            set_mode(Mode::Number::EMERGENCY, ModeReason:: RADIO_FAILSAFE);
             break;
         case FS_THR_WARN:
         case FS_THR_DISABLED:

--- a/ArduSub/mode.cpp
+++ b/ArduSub/mode.cpp
@@ -59,6 +59,9 @@ Mode *Sub::mode_from_mode_num(const Mode::Number mode)
     case Mode::Number::MOTOR_DETECT:
         ret = &mode_motordetect;
         break;
+    case Mode::Number::EMERGENCY:
+        ret = &mode_emergency;
+        break;
     default:
         break;
     }

--- a/ArduSub/mode.h
+++ b/ArduSub/mode.h
@@ -50,7 +50,8 @@ public:
         POSHOLD =      16,  // automatic position hold with manual override, with automatic throttle
         MANUAL =       19,  // Pass-through input with no stabilization
         MOTOR_DETECT = 20,  // Automatically detect motors orientation
-        SURFTRAK =     21   // Track distance above seafloor (hold range)
+        SURFTRAK =     21,   // Track distance above seafloor (hold range)
+        EMERGENCY =    22   // emergency surface not requiring position or depth
         // Mode number 30 reserved for "offboard" for external/lua control.
     };
 
@@ -503,3 +504,30 @@ protected:
     const char *name4() const override { return "DETE"; }
     Mode::Number number() const override { return Mode::Number::MOTOR_DETECT; }
 };
+
+class ModeEmergency : public Mode
+{
+
+public:
+    // inherit constructor
+    using Mode::Mode;
+
+    virtual void run() override;
+
+    bool init(bool ignore_checks) override;
+    bool requires_GPS() const override { return false; }
+    bool has_manual_throttle() const override { return false; }
+    bool allows_arming(bool from_gcs) const override { return true; }
+    bool is_autopilot() const override { return true; }
+
+protected:
+
+    const char *name() const override { return "EMERGENCY"; }
+    const char *name4() const override { return "EMER"; }
+    Mode::Number number() const override { return Mode::Number::EMERGENCY; }
+
+private:
+    bool has_surfaced;
+};
+
+

--- a/ArduSub/mode_emergency.cpp
+++ b/ArduSub/mode_emergency.cpp
@@ -1,0 +1,55 @@
+#include "Sub.h"
+
+
+bool ModeEmergency::init(bool ignore_checks)
+{
+    has_surfaced = false;
+    // initialize vertical speeds and acceleration
+    position_control->set_max_speed_accel_U_cm(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    position_control->set_correction_speed_accel_U_cmss(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+
+    // initialise position and desired velocity
+    position_control->init_U_controller();
+    GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"Emergencey surface!");
+    return true;
+    
+    has_surfaced = false;
+
+}
+
+void ModeEmergency::run()
+{
+    // if not armed set throttle to zero and exit immediately
+    if (!motors.armed()) {
+        motors.output_min();
+        motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
+        attitude_control->set_throttle_out(.5,true,g.throttle_filt);
+        attitude_control->relax_attitude_controllers();
+        position_control->init_U_controller();
+        return;
+    }
+
+    // Already at surface, hold depth at surface
+    if (sub.ap.at_surface || has_surfaced) {
+        if (!has_surfaced) {
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING,"At Surface");
+            has_surfaced = true;
+        }
+        motors.set_throttle(.55);  //hold at surface
+        return;
+    }
+
+
+    // call attitude controller
+    attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(0,0,0);
+
+    // set target climb rate
+    float cmb_rate_cms = constrain_float(fabsf(sub.wp_nav.get_default_speed_up_cms()), 1, position_control->get_max_speed_up_cms());
+
+    // update altitude target and call position controller
+    position_control->set_pos_target_U_from_climb_rate_cm(cmb_rate_cms);
+    position_control->update_U_controller();
+
+    // maximum climb to surface
+    motors.set_throttle(1.1); //over 1 to clear current throttle limit on surface detection
+}


### PR DESCRIPTION
allows recovery without position or depth sensor

considered making it part of SURFACE, but Sub mode base module has so many checks for position and depth sensor before even switching modes to SURFACE that making an independent mode was cleaner, and easier to understand and clearly does not affect other modes or operation. Also allows easy hiding from user as normal mode.

This has NOT been added to the MAVLink available modes message, and we do not intend to add as XML or to pymavlink as a user mode...this is for failsafe use primarily....SITL and MAVLink users can still command it by mode number if desired...