### PR TITLE
Copter: Handle the case where the arming delay time is set to 0 seconds

### DIFF
--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -42,7 +42,7 @@
 #endif
 
 #ifndef ARMING_DELAY_SEC
-    # define ARMING_DELAY_SEC 2.0f
+    # define ARMING_DELAY_SEC 2
 #endif
 
 //////////////////////////////////////////////////////////////////////////////

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -140,7 +140,13 @@ void Copter::motors_output(bool full_push)
 #endif
 
     // Update arming delay state
-    if (ap.in_arming_delay && (!motors->armed() || millis()-arm_time_ms > ARMING_DELAY_SEC*1.0e3f || flightmode->mode_number() == Mode::Number::THROW)) {
+    if (ap.in_arming_delay && (!motors->armed() ||
+#if ARMING_DELAY_SEC != 0
+        millis()-arm_time_ms > ARMING_DELAY_SEC*1.0e3f ||
+#else
+        millis() ||
+#endif
+        flightmode->mode_number() == Mode::Number::THROW)) {
         ap.in_arming_delay = false;
     }
 


### PR DESCRIPTION
The arming delay time can be set to 0 seconds.
I handle the case of 0 seconds using the preprocessor.

![Screenshot from 2025-05-04 21-52-07](https://github.com/user-attachments/assets/a2aab8a4-0d89-458a-a378-9287cae9019b)