### PR TITLE
Global: Clarify the floating point value

### DIFF
--- a/ArduCopter/mode_drift.cpp
+++ b/ArduCopter/mode_drift.cpp
@@ -59,7 +59,7 @@ void ModeDrift::run()
     roll_vel = constrain_float(roll_vel, -DRIFT_SPEEDLIMIT, DRIFT_SPEEDLIMIT);
     pitch_vel = constrain_float(pitch_vel, -DRIFT_SPEEDLIMIT, DRIFT_SPEEDLIMIT);
 
-    roll_input = roll_input * .96f + (float)channel_yaw->get_control_in() * .04f;
+    roll_input = roll_input * 0.96f + (float)channel_yaw->get_control_in() * 0.04f;
 
     // convert user input into desired roll velocity
     float roll_vel_error = roll_vel - (roll_input / DRIFT_SPEEDGAIN);
@@ -70,8 +70,8 @@ void ModeDrift::run()
 
     // If we let go of sticks, bring us to a stop
     if (is_zero(target_pitch)) {
-        // .14/ (.03 * 100) = 4.6 seconds till full braking
-        braker += .03f;
+        // 0.14/ (0.03 * 100) = 4.6 seconds till full braking
+        braker += 0.03f;
         braker = MIN(braker, DRIFT_SPEEDGAIN);
         target_pitch = pitch_vel * braker;
     } else {

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3709,7 +3709,7 @@ float QuadPlane::forward_throttle_pct()
             float fwd_thr = rc_fwd_thr_ch->percent_input();
 
             // set forward throttle to fwd_thr_max * (manual input + mix): range [0,100]
-            fwd_thr *= .01f * constrain_float(fwd_thr_max, 0, 100);
+            fwd_thr *= 0.01f * constrain_float(fwd_thr_max, 0, 100);
             return fwd_thr;
         }
     }

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -557,7 +557,7 @@ bool Tailsitter::transition_vtol_complete(void) const
         return true;
     }
     // for vectored tailsitters at zero pilot throttle
-    if ((quadplane.get_pilot_throttle() < .05f) && _is_vectored) {
+    if ((quadplane.get_pilot_throttle() < 0.05f) && _is_vectored) {
         // if we are not moving (hence on the ground?) or don't know
         // transition immediately to tilt motors up and prevent prop strikes
         if (quadplane.ahrs.groundspeed() < 1.0f) {

--- a/ArduPlane/tiltrotor.cpp
+++ b/ArduPlane/tiltrotor.cpp
@@ -311,7 +311,7 @@ void Tiltrotor::continuous_update(void)
             slew(0);
         } else {
             // manual control of forward throttle up to max VTOL angle
-            float settilt = .01f * quadplane.forward_throttle_pct();
+            float settilt = 0.01f * quadplane.forward_throttle_pct();
             slew(MIN(settilt * max_angle_deg * (1/90.0), get_forward_flight_tilt())); 
         }
         return;

--- a/libraries/AP_BattMonitor/AP_BattMonitor_DroneCAN.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_DroneCAN.cpp
@@ -22,7 +22,7 @@ const AP_Param::GroupInfo AP_BattMonitor_DroneCAN::var_info[] = {
     // @Param: CURR_MULT
     // @DisplayName: Scales reported power monitor current
     // @Description: Multiplier applied to all current related reports to allow for adjustment if no UAVCAN param access or current splitting applications
-    // @Range: .1 10
+    // @Range: 0.1 10
     // @User: Advanced
     AP_GROUPINFO("CURR_MULT", 30, AP_BattMonitor_DroneCAN, _curr_mult, 1.0),
 

--- a/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.cpp
@@ -665,7 +665,7 @@ uint32_t AP_Frsky_SPort_Passthrough::calc_velandyaw(void)
     }
     // horizontal velocity in dm/s
     velandyaw |= prep_number(roundf(hspeed_m * 10), 2, 1)<<VELANDYAW_XYVEL_OFFSET;
-    // yaw from [0;36000] centidegrees to .2 degree increments [0;1800] (just in case, limit to 2047 (0x7FF) since the value is stored on 11 bits)
+    // yaw from [0;36000] centidegrees to 0.2 degree increments [0;1800] (just in case, limit to 2047 (0x7FF) since the value is stored on 11 bits)
     velandyaw |= ((uint16_t)roundf(_ahrs.yaw_sensor * 0.05f) & VELANDYAW_YAW_LIMIT)<<VELANDYAW_YAW_OFFSET;
     // flag the airspeed bit if required
     if (airspeed_estimate_true && option_airspeed_enabled && _passthrough.send_airspeed) {
@@ -689,9 +689,9 @@ uint32_t AP_Frsky_SPort_Passthrough::calc_attiandrng(void)
     float roll;
     float pitch;
     AP::vehicle()->get_osd_roll_pitch_rad(roll,pitch);
-    // roll from [-18000;18000] centidegrees to unsigned .2 degree increments [0;1800] (just in case, limit to 2047 (0x7FF) since the value is stored on 11 bits)
+    // roll from [-18000;18000] centidegrees to unsigned 0.2 degree increments [0;1800] (just in case, limit to 2047 (0x7FF) since the value is stored on 11 bits)
     uint32_t attiandrng = ((uint16_t)roundf((roll * RAD_TO_DEG * 100 + 18000) * 0.05f) & ATTIANDRNG_ROLL_LIMIT);
-    // pitch from [-9000;9000] centidegrees to unsigned .2 degree increments [0;900] (just in case, limit to 1023 (0x3FF) since the value is stored on 10 bits)
+    // pitch from [-9000;9000] centidegrees to unsigned 0.2 degree increments [0;900] (just in case, limit to 1023 (0x3FF) since the value is stored on 10 bits)
     attiandrng |= ((uint16_t)roundf((pitch * RAD_TO_DEG * 100 + 9000) * 0.05f) & ATTIANDRNG_PITCH_LIMIT)<<ATTIANDRNG_PITCH_OFFSET;
     // rangefinder measurement in cm
 #if AP_RANGEFINDER_ENABLED

--- a/libraries/AP_HAL/utility/st24.cpp
+++ b/libraries/AP_HAL/utility/st24.cpp
@@ -277,13 +277,13 @@ int st24_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 						channels[chan_index] = ((uint16_t)d->channel[i] << 4);
 						channels[chan_index] |= ((uint16_t)(0xF0 & d->channel[i + 1]) >> 4);
 						/* convert values to 1000-2000 ppm encoding in a not too sloppy fashion */
-						channels[chan_index] = (uint16_t)(channels[chan_index] * ST24_SCALE_FACTOR + .5f) + ST24_SCALE_OFFSET;
+						channels[chan_index] = (uint16_t)(channels[chan_index] * ST24_SCALE_FACTOR + 0.5f) + ST24_SCALE_OFFSET;
 						chan_index++;
 
 						channels[chan_index] = ((uint16_t)d->channel[i + 2]);
 						channels[chan_index] |= (((uint16_t)(0x0F & d->channel[i + 1])) << 8);
 						/* convert values to 1000-2000 ppm encoding in a not too sloppy fashion */
-						channels[chan_index] = (uint16_t)(channels[chan_index] * ST24_SCALE_FACTOR + .5f) + ST24_SCALE_OFFSET;
+						channels[chan_index] = (uint16_t)(channels[chan_index] * ST24_SCALE_FACTOR + 0.5f) + ST24_SCALE_OFFSET;
 						chan_index++;
 					}
 				}
@@ -305,13 +305,13 @@ int st24_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 						channels[chan_index] = ((uint16_t)d->channel[i] << 4);
 						channels[chan_index] |= ((uint16_t)(0xF0 & d->channel[i + 1]) >> 4);
 						/* convert values to 1000-2000 ppm encoding in a not too sloppy fashion */
-						channels[chan_index] = (uint16_t)(channels[chan_index] * ST24_SCALE_FACTOR + .5f) + ST24_SCALE_OFFSET;
+						channels[chan_index] = (uint16_t)(channels[chan_index] * ST24_SCALE_FACTOR + 0.5f) + ST24_SCALE_OFFSET;
 						chan_index++;
 
 						channels[chan_index] = ((uint16_t)d->channel[i + 2]);
 						channels[chan_index] |= (((uint16_t)(0x0F & d->channel[i + 1])) << 8);
 						/* convert values to 1000-2000 ppm encoding in a not too sloppy fashion */
-						channels[chan_index] = (uint16_t)(channels[chan_index] * ST24_SCALE_FACTOR + .5f) + ST24_SCALE_OFFSET;
+						channels[chan_index] = (uint16_t)(channels[chan_index] * ST24_SCALE_FACTOR + 0.5f) + ST24_SCALE_OFFSET;
 						chan_index++;
 					}
 				}

--- a/libraries/AP_HAL_SITL/SITL_State_common.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State_common.cpp
@@ -434,8 +434,8 @@ void SITL_State_Common::update_voltage_current(struct sitl_input &input, float t
     voltage_pin_voltage = (voltage / 10.1f);
     current_pin_voltage = current/17.0f;
     // fake battery2 as just a 25% gain on the first one
-    voltage2_pin_voltage = voltage_pin_voltage * .25f;
-    current2_pin_voltage = current_pin_voltage * .25f;
+    voltage2_pin_voltage = voltage_pin_voltage * 0.25f;
+    current2_pin_voltage = current_pin_voltage * 0.25f;
 }
 
 #endif // HAL_BOARD_SITL

--- a/libraries/AP_Math/tests/test_geodesic_grid.cpp
+++ b/libraries/AP_Math/tests/test_geodesic_grid.cpp
@@ -222,13 +222,13 @@ INSTANTIATE_TEST_CASE_P(GeneralVectors,
  */
 static TestParam hardcoded_vectors[] = {
     /* a + 2 * m_a + .5 * m_c for T_4 */
-    {{.25f * M_GOLDEN, -.25f * (13.0f * M_GOLDEN + 1.0f), - 1.25f}, 17},
+    {{0.25f * M_GOLDEN, -0.25f * (13.0f * M_GOLDEN + 1.0f), - 1.25f}, 17},
     /* 3 * m_a + 2 * m_b 0 * m_c for T_4 */
     {{M_GOLDEN, -4.0f * M_GOLDEN -1.0f, 1.0f}, -1, {16, 18, -1}},
     /* 2 * m_c + (1 / 3) * m_b + .1 * c for T_13 */
-    {{-.2667f, .1667f * M_GOLDEN, 2.2667f * M_GOLDEN + .1667f}, 55},
+    {{-0.2667f, 0.1667f * M_GOLDEN, 2.2667f * M_GOLDEN + 0.1667f}, 55},
     /* .25 * m_a + 5 * b + 2 * m_b for T_8 */
-    {{-.875f, 6.125f * M_GOLDEN, -1.125f * M_GOLDEN - 6.125f}, 34},
+    {{-0.875f, 6.125f * M_GOLDEN, -1.125f * M_GOLDEN - 6.125f}, 34},
 };
 INSTANTIATE_TEST_CASE_P(HardcodedVectors,
                         GeodesicGridTest,

--- a/libraries/AP_Math/tests/test_rc_in_to_roll_pitch.cpp
+++ b/libraries/AP_Math/tests/test_rc_in_to_roll_pitch.cpp
@@ -21,8 +21,8 @@ TEST(RC2RPTest, Corners) {
     for (uint i=0; i<ARRAY_SIZE(roll_val_deg); i++) {
         rc_input_to_roll_pitch(roll_in[i], pitch_in[i], angle_max_deg, angle_limit_deg, roll_out_deg, pitch_out_deg);
 
-        EXPECT_TRUE(fabsf(roll_out_deg  - roll_val_deg[i])  < .0005f);
-        EXPECT_TRUE(fabsf(pitch_out_deg - pitch_val_deg[i]) < .0005f);
+        EXPECT_TRUE(fabsf(roll_out_deg  - roll_val_deg[i])  < 0.0005f);
+        EXPECT_TRUE(fabsf(pitch_out_deg - pitch_val_deg[i]) < 0.0005f);
     }
 }
 
@@ -48,8 +48,8 @@ TEST(RC2RPTest, Axes) {
     for (uint i=0; i<ARRAY_SIZE(roll_val_deg); i++) {
         rc_input_to_roll_pitch(roll_in[i], pitch_in[i], angle_max_deg, angle_limit_deg, roll_out_deg, pitch_out_deg);
 
-        EXPECT_TRUE(fabsf(roll_out_deg  - roll_val_deg[i])  < .00005f);
-        EXPECT_TRUE(fabsf(pitch_out_deg - pitch_val_deg[i]) < .00005f);
+        EXPECT_TRUE(fabsf(roll_out_deg  - roll_val_deg[i])  < 0.00005f);
+        EXPECT_TRUE(fabsf(pitch_out_deg - pitch_val_deg[i]) < 0.00005f);
     }
 
 }
@@ -82,8 +82,8 @@ TEST(RC2RPTest, Circle) {
         float pitch_in = xy_rp[row][1];
         rc_input_to_roll_pitch(roll_in, pitch_in, angle_max_deg, angle_limit_deg, roll_out_deg, pitch_out_deg);
 
-        EXPECT_TRUE(fabsf(roll_out_deg  - xy_rp[row][2]) < .02f);
-        EXPECT_TRUE(fabsf(pitch_out_deg - xy_rp[row][3]) < .02f);
+        EXPECT_TRUE(fabsf(roll_out_deg  - xy_rp[row][2]) < 0.02f);
+        EXPECT_TRUE(fabsf(pitch_out_deg - xy_rp[row][3]) < 0.02f);
     }
 }
 

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -191,7 +191,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @Param: SLEW_UP_TIME
     // @DisplayName: Output slew time for increasing throttle
     // @Description: Time in seconds to slew output from zero to full. This is used to limit the rate at which output can change. Range is constrained between 0 and 0.5.
-    // @Range: 0 .5
+    // @Range: 0 0.5
     // @Units: s
     // @Increment: 0.001
     // @User: Advanced
@@ -200,7 +200,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @Param: SLEW_DN_TIME
     // @DisplayName: Output slew time for decreasing throttle
     // @Description: Time in seconds to slew output from full to zero. This is used to limit the rate at which output can change.  Range is constrained between 0 and 0.5.
-    // @Range: 0 .5
+    // @Range: 0 0.5
     // @Units: s
     // @Increment: 0.001
     // @User: Advanced

--- a/libraries/AP_RCProtocol/AP_RCProtocol_ST24.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_ST24.cpp
@@ -168,13 +168,13 @@ void AP_RCProtocol_ST24::_process_byte(uint8_t byte)
                     values[chan_index] = ((uint16_t)d->channel[i] << 4);
                     values[chan_index] |= ((uint16_t)(0xF0 & d->channel[i + 1]) >> 4);
                     /* convert values to 1000-2000 ppm encoding in a not too sloppy fashion */
-                    values[chan_index] = (uint16_t)(values[chan_index] * ST24_SCALE_FACTOR + .5f) + ST24_SCALE_OFFSET;
+                    values[chan_index] = (uint16_t)(values[chan_index] * ST24_SCALE_FACTOR + 0.5f) + ST24_SCALE_OFFSET;
                     chan_index++;
 
                     values[chan_index] = ((uint16_t)d->channel[i + 2]);
                     values[chan_index] |= (((uint16_t)(0x0F & d->channel[i + 1])) << 8);
                     /* convert values to 1000-2000 ppm encoding in a not too sloppy fashion */
-                    values[chan_index] = (uint16_t)(values[chan_index] * ST24_SCALE_FACTOR + .5f) + ST24_SCALE_OFFSET;
+                    values[chan_index] = (uint16_t)(values[chan_index] * ST24_SCALE_FACTOR + 0.5f) + ST24_SCALE_OFFSET;
                     chan_index++;
                 }
                 add_input(num_values, values, false);//AP_RCProtocol: Fix the issue of ST24 receiver not working
@@ -199,13 +199,13 @@ void AP_RCProtocol_ST24::_process_byte(uint8_t byte)
                     values[chan_index] = ((uint16_t)d->channel[i] << 4);
                     values[chan_index] |= ((uint16_t)(0xF0 & d->channel[i + 1]) >> 4);
                     /* convert values to 1000-2000 ppm encoding in a not too sloppy fashion */
-                    values[chan_index] = (uint16_t)(values[chan_index] * ST24_SCALE_FACTOR + .5f) + ST24_SCALE_OFFSET;
+                    values[chan_index] = (uint16_t)(values[chan_index] * ST24_SCALE_FACTOR + 0.5f) + ST24_SCALE_OFFSET;
                     chan_index++;
 
                     values[chan_index] = ((uint16_t)d->channel[i + 2]);
                     values[chan_index] |= (((uint16_t)(0x0F & d->channel[i + 1])) << 8);
                     /* convert values to 1000-2000 ppm encoding in a not too sloppy fashion */
-                    values[chan_index] = (uint16_t)(values[chan_index] * ST24_SCALE_FACTOR + .5f) + ST24_SCALE_OFFSET;
+                    values[chan_index] = (uint16_t)(values[chan_index] * ST24_SCALE_FACTOR + 0.5f) + ST24_SCALE_OFFSET;
                     chan_index++;
                 }
                 add_input(num_values, values, false);//AP_RCProtocol: Fix the issue of ST24 receiver not working

--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
@@ -980,7 +980,7 @@ int8_t AP_CRSF_Telem::get_vertical_speed_packed()
     float vspeed = get_vspeed_ms();
     float vertical_speed_cm_s = vspeed * 100.0f;
     const int16_t Kl = 100; // linearity constant;
-    const float Kr = .026f; // range constant;
+    const float Kr = 0.026f; // range constant;
     int8_t vspeed_packed = int8_t(logf(fabsf(vertical_speed_cm_s)/Kl + 1)/Kr);
     return vspeed_packed * (is_negative(vertical_speed_cm_s) ? -1 : 1);
 }

--- a/libraries/SITL/SIM_Calibration.cpp
+++ b/libraries/SITL/SIM_Calibration.cpp
@@ -97,7 +97,7 @@ void SITL::Calibration::_attitude_set(float desired_roll, float desired_pitch, f
 
     Vector3f desired_angvel = angle_differential * (1 / dt);
     /* Provide a somewhat "smooth" transition */
-    desired_angvel *= .005f;
+    desired_angvel *= 0.005f;
 
     Vector3f error = desired_angvel - gyro;
     rot_accel = error * (1.0f / dt);
@@ -121,7 +121,7 @@ void SITL::Calibration::_angular_velocity_control(const struct sitl_input &in,
 
     rot_accel = error * (1.0f / dt);
     /* Provide a somewhat "smooth" transition */
-    rot_accel *= .05f;
+    rot_accel *= 0.05f;
 }
 
 /*


### PR DESCRIPTION
I don't think there is any benefit to omitting the integer part in a floating-point value.
By adding a zero before the decimal point, we can clearly indicate that it is a floating-point value.