### PR TITLE
Rover: Change to GCS_SEND_TEXT

### DIFF
--- a/Rover/RC_Channel_Rover.cpp
+++ b/Rover/RC_Channel_Rover.cpp
@@ -148,7 +148,7 @@ bool RC_Channel_Rover::do_aux_function(const AuxFuncTrigger &trigger)
             // if disarmed clear mission and set home to current location
             if (!rover.arming.is_armed()) {
                 rover.mode_auto.mission.clear();
-                gcs().send_text(MAV_SEVERITY_NOTICE, "SaveWP: Mission cleared!");
+                GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "SaveWP: Mission cleared!");
                 if (!rover.set_home_to_current_location(false)) {
                     // ignored
                 }
@@ -243,7 +243,7 @@ bool RC_Channel_Rover::do_aux_function(const AuxFuncTrigger &trigger)
             (rover.control_mode != &rover.mode_loiter)
             && (rover.control_mode != &rover.mode_hold) && ch_flag == AuxSwitchPos::HIGH) {
             SRV_Channels::set_trim_to_servo_out_for(SRV_Channel::k_steering);
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "Steering trim saved!");
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Steering trim saved!");
         }
         break;
 

--- a/Rover/commands.cpp
+++ b/Rover/commands.cpp
@@ -30,7 +30,7 @@ bool Rover::set_home(const Location& loc, bool lock)
     }
 
     // send text of home position to ground stations
-    gcs().send_text(MAV_SEVERITY_INFO, "Set HOME to %.6f %.6f at %.2fm",
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Set HOME to %.6f %.6f at %.2fm",
             static_cast<double>(loc.lat * 1.0e-7f),
             static_cast<double>(loc.lng * 1.0e-7f),
             static_cast<double>(loc.alt * 0.01f));

--- a/Rover/crash_check.cpp
+++ b/Rover/crash_check.cpp
@@ -50,11 +50,11 @@ void Rover::crash_check()
 
         if (is_balancebot()) {
             // send message to gcs
-            gcs().send_text(MAV_SEVERITY_EMERGENCY, "Crash: Disarming");
+            GCS_SEND_TEXT(MAV_SEVERITY_EMERGENCY, "Crash: Disarming");
             arming.disarm(AP_Arming::Method::CRASH);
         } else {
             // send message to gcs
-            gcs().send_text(MAV_SEVERITY_EMERGENCY, "Crash: Going to HOLD");
+            GCS_SEND_TEXT(MAV_SEVERITY_EMERGENCY, "Crash: Going to HOLD");
             // change mode to hold and disarm
             set_mode(mode_hold, ModeReason::CRASH_FAILSAFE);
             if (g.fs_crash_check == FS_CRASH_HOLD_AND_DISARM) {

--- a/Rover/cruise_learn.cpp
+++ b/Rover/cruise_learn.cpp
@@ -7,7 +7,7 @@ void Rover::cruise_learn_start()
     float speed;
     if (!arming.is_armed() || !g2.attitude_control.get_forward_speed(speed)) {
         cruise_learn.learn_start_ms = 0;
-        gcs().send_text(MAV_SEVERITY_CRITICAL, "Cruise Learning NOT started");
+        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Cruise Learning NOT started");
         return;
     }
     // start learning
@@ -18,7 +18,7 @@ void Rover::cruise_learn_start()
 #if HAL_LOGGING_ENABLED
     log_write_cruise_learn();
 #endif
-    gcs().send_text(MAV_SEVERITY_CRITICAL, "Cruise Learning started");
+    GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Cruise Learning started");
 }
 
 // update cruise learning with latest speed and throttle
@@ -55,9 +55,9 @@ void Rover::cruise_learn_complete()
         if (thr >= 10.0f && thr <= 100.0f && is_positive(speed)) {
             g.throttle_cruise.set_and_save(thr);
             g.speed_cruise.set_and_save(speed);
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "Cruise Learned: Thr:%d Speed:%3.1f", (int)g.throttle_cruise, (double)g.speed_cruise);
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Cruise Learned: Thr:%d Speed:%3.1f", (int)g.throttle_cruise, (double)g.speed_cruise);
         } else {
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "Cruise Learning failed");
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Cruise Learning failed");
         }
         cruise_learn.learn_start_ms = 0;
 #if HAL_LOGGING_ENABLED

--- a/Rover/ekf_check.cpp
+++ b/Rover/ekf_check.cpp
@@ -57,7 +57,7 @@ void Rover::ekf_check()
                                          LogErrorCode::EKFCHECK_BAD_VARIANCE);
                 // send message to gcs
                 if ((AP_HAL::millis() - ekf_check_state.last_warn_time) > EKF_CHECK_WARNING_TIME) {
-                    gcs().send_text(MAV_SEVERITY_CRITICAL,"EKF variance");
+                    GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"EKF variance");
                     ekf_check_state.last_warn_time = AP_HAL::millis();
                 }
                 failsafe_ekf_event();
@@ -177,7 +177,7 @@ void Rover::failsafe_ekf_event()
             break;
     }
 
-    gcs().send_text(MAV_SEVERITY_CRITICAL,"EKF failsafe");
+    GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"EKF failsafe");
 }
 
 // failsafe_ekf_off_event - actions to take when EKF failsafe is cleared
@@ -191,5 +191,5 @@ void Rover::failsafe_ekf_off_event(void)
     failsafe.ekf = false;
     LOGGER_WRITE_ERROR(LogErrorSubsystem::FAILSAFE_EKFINAV,
                              LogErrorCode::FAILSAFE_RESOLVED);
-    gcs().send_text(MAV_SEVERITY_CRITICAL,"EKF failsafe cleared");
+    GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"EKF failsafe cleared");
 }

--- a/Rover/failsafe.cpp
+++ b/Rover/failsafe.cpp
@@ -58,7 +58,7 @@ void Rover::failsafe_trigger(uint8_t failsafe_type, const char* type_str, bool o
     }
     if (failsafe.triggered != 0 && failsafe.bits == 0) {
         // a failsafe event has ended
-        gcs().send_text(MAV_SEVERITY_INFO, "%s Failsafe Cleared", type_str);
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s Failsafe Cleared", type_str);
     }
 
     failsafe.triggered &= failsafe.bits;
@@ -69,7 +69,7 @@ void Rover::failsafe_trigger(uint8_t failsafe_type, const char* type_str, bool o
         (control_mode != &mode_rtl) &&
         ((control_mode != &mode_hold || (g2.fs_options & (uint32_t)Failsafe_Options::Failsafe_Option_Active_In_Hold)))) {
         failsafe.triggered = failsafe.bits;
-        gcs().send_text(MAV_SEVERITY_WARNING, "%s Failsafe", type_str);
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "%s Failsafe", type_str);
 
         // clear rc overrides
         RC_Channels::clear_overrides();
@@ -78,7 +78,7 @@ void Rover::failsafe_trigger(uint8_t failsafe_type, const char* type_str, bool o
             ((failsafe_type == FAILSAFE_EVENT_THROTTLE && g.fs_throttle_enabled == FS_THR_ENABLED_CONTINUE_MISSION) ||
              (failsafe_type == FAILSAFE_EVENT_GCS && g.fs_gcs_enabled == FS_GCS_ENABLED_CONTINUE_MISSION))) {
             // continue with mission in auto mode
-            gcs().send_text(MAV_SEVERITY_WARNING, "Failsafe - Continuing Auto Mode");
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Failsafe - Continuing Auto Mode");
         } else {
             switch ((FailsafeAction)g.fs_action.get()) {
             case FailsafeAction::None:

--- a/Rover/mode_auto.cpp
+++ b/Rover/mode_auto.cpp
@@ -6,7 +6,7 @@ bool ModeAuto::_enter()
 {
     // fail to enter auto if no mission commands
     if (!mission.present()) {
-        gcs().send_text(MAV_SEVERITY_NOTICE, "No Mission. Can't set AUTO.");
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "No Mission. Can't set AUTO.");
         return false;
     }
 
@@ -68,10 +68,10 @@ void ModeAuto::update()
             // if mission is running restart the current command if it is a waypoint command
             if ((mission.state() == AP_Mission::MISSION_RUNNING) && (_submode == SubMode::WP)) {
                 if (mission.restart_current_nav_cmd()) {
-                    gcs().send_text(MAV_SEVERITY_CRITICAL, "Auto mission changed, restarted command");
+                    GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Auto mission changed, restarted command");
                 } else {
                     // failed to restart mission for some reason
-                    gcs().send_text(MAV_SEVERITY_CRITICAL, "Auto mission changed but failed to restart command");
+                    GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Auto mission changed but failed to restart command");
                 }
             }
         }
@@ -411,7 +411,7 @@ bool ModeAuto::check_trigger(void)
 {
     // check for user pressing the auto trigger to off
     if (auto_triggered && g.auto_trigger_pin != -1 && rover.check_digital_pin(g.auto_trigger_pin) == 1) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "AUTO triggered off");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "AUTO triggered off");
         auto_triggered = false;
         return false;
     }
@@ -431,7 +431,7 @@ bool ModeAuto::check_trigger(void)
 
     // check if trigger pin has been pushed
     if (g.auto_trigger_pin != -1 && rover.check_digital_pin(g.auto_trigger_pin) == 0) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Triggered AUTO with pin");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Triggered AUTO with pin");
         auto_triggered = true;
         return true;
     }
@@ -440,7 +440,7 @@ bool ModeAuto::check_trigger(void)
     if (!is_zero(g.auto_kickstart)) {
         const float xaccel = rover.ins.get_accel().x;
         if (xaccel >= g.auto_kickstart) {
-            gcs().send_text(MAV_SEVERITY_WARNING, "Triggered AUTO xaccel=%.1f", static_cast<double>(xaccel));
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Triggered AUTO xaccel=%.1f", static_cast<double>(xaccel));
             auto_triggered = true;
             return true;
         }
@@ -608,7 +608,7 @@ void ModeAuto::exit_mission()
     // play a tone
     AP_Notify::events.mission_complete = 1;
     // send message
-    gcs().send_text(MAV_SEVERITY_NOTICE, "Mission Complete");
+    GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Mission Complete");
 
     switch ((DoneBehaviour)g2.mis_done_behave) {
     case DoneBehaviour::HOLD:
@@ -709,7 +709,7 @@ bool ModeAuto::verify_command(const AP_Mission::Mission_Command& cmd)
 
     default:
         // error message
-        gcs().send_text(MAV_SEVERITY_WARNING, "Skipping invalid cmd #%i", cmd.id);
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Skipping invalid cmd #%i", cmd.id);
         // return true if we do not recognize the command so that we move on to the next command
         return true;
     }
@@ -785,7 +785,7 @@ void ModeAuto::do_nav_delay(const AP_Mission::Mission_Command& cmd)
         nav_delay_time_max_ms = 0;
 #endif
     }
-    gcs().send_text(MAV_SEVERITY_INFO, "Delaying %u sec", (unsigned)(nav_delay_time_max_ms/1000));
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Delaying %u sec", (unsigned)(nav_delay_time_max_ms/1000));
 }
 
 // start guided within auto to allow external navigation system to control vehicle
@@ -835,14 +835,14 @@ bool ModeAuto::verify_nav_wp(const AP_Mission::Mission_Command& cmd)
         // check if we are loitering at this waypoint - the message sent to the GCS is different
         if (loiter_duration > 0) {
             // send message including loiter time
-            gcs().send_text(MAV_SEVERITY_INFO, "Reached waypoint #%u. Loiter for %u seconds",
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Reached waypoint #%u. Loiter for %u seconds",
                             (unsigned int)cmd.index,
                             (unsigned int)loiter_duration);
             // record the current time i.e. start timer
             loiter_start_time = millis();
         } else {
             // send simpler message to GCS
-            gcs().send_text(MAV_SEVERITY_INFO, "Reached waypoint #%u", (unsigned int)cmd.index);
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Reached waypoint #%u", (unsigned int)cmd.index);
         }
     }
 
@@ -881,7 +881,7 @@ bool ModeAuto::verify_loiter_time(const AP_Mission::Mission_Command& cmd)
 {
     const bool result = verify_nav_wp(cmd);
     if (result) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Finished active loiter");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Finished active loiter");
     }
     return result;
 }
@@ -991,7 +991,7 @@ void ModeAuto::do_change_speed(const AP_Mission::Mission_Command& cmd)
 {
     // set speed for active mode
     if (set_desired_speed(cmd.content.speed.target_ms)) {
-        gcs().send_text(MAV_SEVERITY_INFO, "speed: %.1f m/s", static_cast<double>(cmd.content.speed.target_ms));
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "speed: %.1f m/s", static_cast<double>(cmd.content.speed.target_ms));
     }
 }
 

--- a/Rover/mode_circle.cpp
+++ b/Rover/mode_circle.cpp
@@ -305,7 +305,7 @@ void ModeCircle::check_config_speed()
 
     if (config.speed > speed_max) {
         config.speed = speed_max;
-        gcs().send_text(MAV_SEVERITY_WARNING, "Circle: max speed is %4.1f", (double)config.speed);
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Circle: max speed is %4.1f", (double)config.speed);
     }
 }
 
@@ -317,6 +317,6 @@ void ModeCircle::check_config_radius()
     // ensure radius is at least as large as vehicle's turn radius
     if (config.radius < g2.turn_radius) {
         config.radius = g2.turn_radius;
-        gcs().send_text(MAV_SEVERITY_WARNING, "Circle: radius increased to TURN_RADIUS (%4.1f)", (double)g2.turn_radius);
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Circle: radius increased to TURN_RADIUS (%4.1f)", (double)g2.turn_radius);
     }
 }

--- a/Rover/mode_dock.cpp
+++ b/Rover/mode_dock.cpp
@@ -60,13 +60,13 @@ bool ModeDock::_enter()
 {
     // refuse to enter the mode if dock is not in sight
     if (!rover.precland.enabled() || !rover.precland.target_acquired()) {
-        gcs().send_text(MAV_SEVERITY_NOTICE, "Dock: target not acquired");
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Dock: target not acquired");
         return false;
     }
 
     if (hdg_corr_enable && is_negative(desired_dir)) {
         // DOCK_DIR is required for heading correction
-        gcs().send_text(MAV_SEVERITY_NOTICE, "Dock: Set DOCK_DIR or disable heading correction");
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Dock: Set DOCK_DIR or disable heading correction");
         return false;
     }
 
@@ -132,7 +132,7 @@ void ModeDock::update()
         _docking_complete = true;
 
         // send a one time notification to GCS
-        gcs().send_text(MAV_SEVERITY_INFO, "Dock: Docking complete");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Dock: Docking complete");
 
         // initialise mode loiter if it is a boat
         if (rover.is_boat()) {

--- a/Rover/mode_guided.cpp
+++ b/Rover/mode_guided.cpp
@@ -53,7 +53,7 @@ void ModeGuided::update()
         {
             // stop vehicle if target not updated within 3 seconds
             if (have_attitude_target && (millis() - _des_att_time_ms) > 3000) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "target not received last 3secs, stopping");
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "target not received last 3secs, stopping");
                 have_attitude_target = false;
             }
             if (have_attitude_target) {
@@ -77,7 +77,7 @@ void ModeGuided::update()
         {
             // stop vehicle if target not updated within 3 seconds
             if (have_attitude_target && (millis() - _des_att_time_ms) > 3000) {
-                gcs().send_text(MAV_SEVERITY_WARNING, "target not received last 3secs, stopping");
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "target not received last 3secs, stopping");
                 have_attitude_target = false;
             }
             if (have_attitude_target) {
@@ -112,7 +112,7 @@ void ModeGuided::update()
             // handle timeout
             if (_have_strthr && (AP_HAL::millis() - _strthr_time_ms) > 3000) {
                 _have_strthr = false;
-                gcs().send_text(MAV_SEVERITY_WARNING, "target not received last 3secs, stopping");
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "target not received last 3secs, stopping");
             }
             if (_have_strthr) {
                 // pass latest steering and throttle directly to motors library
@@ -136,7 +136,7 @@ void ModeGuided::update()
             break;
 
         default:
-            gcs().send_text(MAV_SEVERITY_WARNING, "Unknown GUIDED mode");
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Unknown GUIDED mode");
             break;
     }
 }

--- a/Rover/mode_rtl.cpp
+++ b/Rover/mode_rtl.cpp
@@ -37,7 +37,7 @@ void ModeRTL::update()
         // send notification
         if (send_notification) {
             send_notification = false;
-            gcs().send_text(MAV_SEVERITY_INFO, "Reached destination");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Reached destination");
         }
 
         // we have reached the destination

--- a/Rover/mode_smart_rtl.cpp
+++ b/Rover/mode_smart_rtl.cpp
@@ -47,7 +47,7 @@ void ModeSmartRTL::update()
                 Vector3f dest_NED;
                 if (!g2.smart_rtl.pop_point(dest_NED)) {
                     // if not more points, we have reached home
-                    gcs().send_text(MAV_SEVERITY_INFO, "Reached destination");
+                    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Reached destination");
                     smart_rtl_state = SmartRTLState::StopAtHome;
                     break;
                 } else {
@@ -56,7 +56,7 @@ void ModeSmartRTL::update()
                     if (g2.smart_rtl.peek_point(next_dest_NED)) {
                         if (!g2.wp_nav.set_desired_location_NED(dest_NED, next_dest_NED)) {
                             // this should never happen because the EKF origin should already be set
-                            gcs().send_text(MAV_SEVERITY_INFO, "SmartRTL: failed to set destination");
+                            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SmartRTL: failed to set destination");
                             smart_rtl_state = SmartRTLState::Failure;
                             INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
                         }
@@ -64,7 +64,7 @@ void ModeSmartRTL::update()
                         // no next point so add only immediate point
                         if (!g2.wp_nav.set_desired_location_NED(dest_NED)) {
                             // this should never happen because the EKF origin should already be set
-                            gcs().send_text(MAV_SEVERITY_INFO, "SmartRTL: failed to set destination");
+                            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SmartRTL: failed to set destination");
                             smart_rtl_state = SmartRTLState::Failure;
                             INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
                         }

--- a/Rover/sailboat.cpp
+++ b/Rover/sailboat.cpp
@@ -465,7 +465,7 @@ float Sailboat::calc_heading(float desired_heading_cd)
 
     // if tack triggered, calculate target heading
     if (should_tack && (now - tack_clear_ms) > TACK_RETRY_TIME_MS) {
-        gcs().send_text(MAV_SEVERITY_INFO, "Sailboat: Tacking");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Sailboat: Tacking");
         // calculate target heading for the new tack
         switch (current_tack) {
             case AP_WindVane::Sailboat_Tack::TACK_PORT:
@@ -490,7 +490,7 @@ float Sailboat::calc_heading(float desired_heading_cd)
                 // if we have throttle available use it for another two time periods to get the tack done
                 tack_assist = true;
             } else {
-                gcs().send_text(MAV_SEVERITY_INFO, "Sailboat: Tacking timed out");
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Sailboat: Tacking timed out");
                 clear_tack();
             }
         }
@@ -521,7 +521,7 @@ void Sailboat::set_motor_state(UseMotor state, bool report_failure)
         rover.get_frame_type() != rover.g2.motors.frame_type::FRAME_TYPE_UNDEFINED) {
         motor_state = state;
     } else if (report_failure) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "Sailboat: failed to enable motor");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Sailboat: failed to enable motor");
     }
 }
 

--- a/Rover/system.cpp
+++ b/Rover/system.cpp
@@ -221,7 +221,7 @@ bool Rover::set_mode(Mode &new_mode, ModeReason reason)
 
     // Check if GCS mode change is disabled via parameter
     if ((reason == ModeReason::GCS_COMMAND) && !gcs_mode_enabled((Mode::Number)new_mode.mode_number())) {
-        gcs().send_text(MAV_SEVERITY_NOTICE,"Mode change to %s denied, GCS entry disabled (FLTMODE_GCSBLOCK)", new_mode.name4());
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE,"Mode change to %s denied, GCS entry disabled (FLTMODE_GCSBLOCK)", new_mode.name4());
         return false;
     }
 
@@ -230,7 +230,7 @@ bool Rover::set_mode(Mode &new_mode, ModeReason reason)
         // Log error that we failed to enter desired flight mode
         LOGGER_WRITE_ERROR(LogErrorSubsystem::FLIGHT_MODE,
                            LogErrorCode(new_mode.mode_number()));
-        gcs().send_text(MAV_SEVERITY_WARNING, "Flight mode change failed");
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Flight mode change failed");
         return false;
     }
 
@@ -277,7 +277,7 @@ bool Rover::set_mode(Mode::Number new_mode, ModeReason reason)
 
 void Rover::startup_INS(void)
 {
-    gcs().send_text(MAV_SEVERITY_INFO, "Beginning INS calibration. Do not move vehicle");
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Beginning INS calibration. Do not move vehicle");
     hal.scheduler->delay(100);
 
     ahrs.init();


### PR DESCRIPTION
Both GCS().SEND_TEXT and GCS_SEND_TEXT are being used.
I think it would be better to standardize the notation.