### PR TITLE
AP_Mount: Siyi ZT6 min cam version is 0.1.9

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -1204,10 +1204,13 @@ void AP_Mount_Siyi::check_firmware_version() const
             minimum_ver.camera.patch = 1;
             break;
 
+        case HardwareModel::ZT6:
+            minimum_ver.camera = {.major = 0, .minor = 1, .patch = 9};
+            break;
+
         case HardwareModel::A2:
         case HardwareModel::ZR10:
         case HardwareModel::ZR30:
-        case HardwareModel::ZT6:
         case HardwareModel::ZT30:
             // TBD
             break;


### PR DESCRIPTION
This adds a check that the Siyi ZT6's camera firmware is at least version 0.1.9 which will encourage users to update the firmware on the camera gimbal and reduce issues like those reported in [this 4.6 beta testing thread](https://discuss.ardupilot.org/t/geotag-images-taken-by-siyi-gimbal-cameras/129664/11).

This has been lightly tested on real-hardware
![image](https://github.com/user-attachments/assets/25a51571-c3bc-41b4-b5de-c89bb4453e70)
