### PR TITLE
Add option to ignore parameter sets / LUA applet to handle parameter sets

### DIFF
--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -1464,6 +1464,13 @@ bool AP_Param::allow_set_via_mavlink(uint16_t flags) const
         }
     }
 
+#if HAL_GCS_ENABLED
+    // check the MAVLink library is OK with the concept:
+    if (!gcs().get_allow_param_set()) {
+        return false;
+    }
+#endif  // HAL_GCS_ENABLED
+
     return true;
 }
 

--- a/libraries/AP_Scripting/applets/param-set.lua
+++ b/libraries/AP_Scripting/applets/param-set.lua
@@ -1,0 +1,171 @@
+-- Inspect parameter sets received via MAVLink, determine action based
+-- on whitelist.
+
+-- When this script runs and ENABLE is true ArduPilot will stop
+--   processing parameter-sets via the GCS library.  Instead, this
+--   script becomes responsible for setting parameters, and it will
+--   only set parameters which are whitelisted.  Setting ENABLE to
+--   false will allow ArduPilot to set parameters normally.
+
+-- Setting SCR_ENABLE to false while this script is running in the
+--   ENABLE state is... not advised.
+
+-- How To Use
+-- 1. copy this script to the autopilot's "scripts" directory
+-- 2. set SCR_ENABLE to 1
+
+-- global definitions
+local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
+local UPDATE_INTERVAL_MS = 10           -- update at about 100hz
+
+-- get a reference to MAV_SYSID parameter so we can filter messages to
+--   just those parameter-sets aimed at this vehicle:
+MAV_SYSID = Parameter("MAV_SYSID")
+
+-- prefix for all text messages:
+local TEXT_PREFIX_STR = "param-set"
+
+--
+-- parameter setup
+--
+local PARAM_TABLE_KEY = 92
+local PARAM_TABLE_PREFIX = "PARAM_SET_"
+assert(param:add_table(PARAM_TABLE_KEY, PARAM_TABLE_PREFIX, 7), 'could not add param table')
+
+-- add a parameter and bind it to a variable
+function bind_add_param(name, idx, default_value)
+    assert(param:add_param(PARAM_TABLE_KEY, idx, name, default_value), string.format('could not add param %s', PARAM_TABLE_PREFIX .. name))
+    return Parameter(PARAM_TABLE_PREFIX .. name)
+end
+
+--[[
+  // @Param: PARAM_SET_ENABLE
+  // @DisplayName: Param Set enable
+  // @Description: Param Set enable
+  // @Values: 0:Disabled,1:Enabled
+  // @User: Standard
+--]]
+local PARAM_SET_ENABLE = bind_add_param("ENABLE", 1, 1)
+
+-- initialize MAVLink rx with buffer depth and number of rx message IDs to register
+mavlink:init(5, 1)
+
+-- register message id to receive
+local PARAM_SET_ID = 23
+mavlink:register_rx_msgid(PARAM_SET_ID)
+
+-- handle PARAM_SET message
+local parameters_which_can_be_set = {}
+parameters_which_can_be_set["MAV_OPTIONS"] = true
+parameters_which_can_be_set["PARAM_SET_ENABLE"] = true
+parameters_which_can_be_set["BATT_ARM_MAH"] = true
+parameters_which_can_be_set["BATT_ARM_VOLT"] = true
+parameters_which_can_be_set["BATT_CAPACITY"] = true
+parameters_which_can_be_set["BATT_CRT_MAH"] = true
+parameters_which_can_be_set["BATT_CRT_VOLT"] = true
+parameters_which_can_be_set["BATT_FS_CRT_ACT"] = true
+parameters_which_can_be_set["BATT_FS_LOW_ACT"] = true
+parameters_which_can_be_set["BATT_LOW_MAH"] = true
+parameters_which_can_be_set["BATT_LOW_VOLT"] = true
+parameters_which_can_be_set["BRD_OPTIONS"] = true
+parameters_which_can_be_set["COMPASS_USE3"] = true
+parameters_which_can_be_set["FENCE_ACTION"] = true
+parameters_which_can_be_set["FENCE_ALT_MAX"] = true
+parameters_which_can_be_set["FENCE_ENABLE"] = true
+parameters_which_can_be_set["FENCE_RADIUS"] = true
+parameters_which_can_be_set["FENCE_TYPE"] = true
+parameters_which_can_be_set["LIGHTS_ON"] = true
+parameters_which_can_be_set["LOG_BITMASK"] = true
+parameters_which_can_be_set["LOG_DISARMED"] = true
+parameters_which_can_be_set["LOG_FILE_DSRMROT"] = true
+parameters_which_can_be_set["RTL_ALT"] = true
+parameters_which_can_be_set["RTL_LOIT_TIME"] = true
+parameters_which_can_be_set["RTL_SPEED"] = true
+
+local function should_set_parameter_id(param_id)
+    if parameters_which_can_be_set[param_id] == nil then
+        return false
+    end
+    return parameters_which_can_be_set[param_id]
+end
+
+local function handle_param_set(name, value)
+    -- we will not receive packets in here for the wrong system ID /
+    --   component ID; this is handled by ArduPilot's MAVLink routing
+    --   code
+
+    -- check for this specific ID:
+    if not should_set_parameter_id(name) then
+        gcs:send_text(MAV_SEVERITY.WARNING, string.format("%s: param set denied (%s)", TEXT_PREFIX_STR, name))
+        return
+    end
+
+    param:set_and_save(name, value)
+    gcs:send_text(MAV_SEVERITY.WARNING, string.format("%s: param set applied", TEXT_PREFIX_STR))
+end
+
+-- display welcome message
+gcs:send_text(MAV_SEVERITY.INFO, "param-set script loaded")
+
+-- initialise our knowledge of the GCS's allow-set-parameters state.
+--   We do not want to fight over setting this GCS state via other
+--   mechanisms (eg. an auxiliary function), so we keep this state
+--   around to track what we last set:
+local gcs_allow_set = gcs:get_allow_param_set()
+
+-- update function to receive param_set messages and perhaps act on them
+local function update()
+    -- return immediately if not enabled
+    if (PARAM_SET_ENABLE:get() <= 0) then
+        -- this script is disabled, set allow-via-GCS (once):
+        if not gcs_allow_set then
+          gcs:set_allow_param_set(true)
+          gcs_allow_set = true
+        end
+        -- drain all mavlink messages to avoid processing them when enabled
+        while true do
+          local msg, _ = mavlink:receive_chan()
+          if msg == nil then
+            break
+          end
+        end
+        return
+    end
+
+    -- this script is enabled, disallow setting via normal means (once):
+    if gcs_allow_set then
+        gcs:set_allow_param_set(false)
+        gcs_allow_set = false
+    end
+
+    -- consume all available mavlink messages
+    while true do
+        local msg, _ = mavlink:receive_chan()
+        if msg == nil then
+            break
+        end
+
+        local param_value, _, _, param_id, _ = string.unpack("<fBBc16B", string.sub(msg, 13, 36))
+        param_id = string.gsub(param_id, string.char(0), "")
+
+        handle_param_set(param_id, param_value)
+    end
+end
+
+-- wrapper around update(). This calls update() with an interval of
+-- UPDATE_INTERVAL_MS, and if update faults then an error is
+-- displayed, but the script is not stopped
+
+function protected_wrapper()
+  local success, err = pcall(update)
+  if not success then
+     gcs:send_text(MAV_SEVERITY.EMERGENCY, "Internal Error: " .. err)
+     -- when we fault we run the update function again after 1s, slowing it
+     -- down a bit so we don't flood the console with errors
+     return protected_wrapper, 1000
+  end
+  return protected_wrapper, UPDATE_INTERVAL_MS
+end
+
+-- start running update loop
+return protected_wrapper()

--- a/libraries/AP_Scripting/applets/param-set.md
+++ b/libraries/AP_Scripting/applets/param-set.md
@@ -1,0 +1,77 @@
+# Parameter Set Filter Script
+
+## Description
+
+This Lua script adds a safty-focused layer to MAVLink parameter setting. When enabled, it intercepts all incoming `PARAM_SET` messages and only allows modification of a predefined whitelist of parameters.
+
+This is especially useful in scenarios where parameter integrity is critical (e.g., automated testing, payload-hosted GCS systems, or shared telemetry environments).
+
+When enabled, the script disables ArduPilot's default GCS handling for parameter writes and takes over that responsibility with additional filtering.
+
+## How It Works
+
+- Intercepts MAVLink `PARAM_SET` messages targeted at the vehicle.
+- Validates that the parameter ID is in the whitelist.
+- Only whitelisted parameters will be updated.
+- Dynamically toggles ArduPilot’s `gcs:set_allow_param_set()` based on enable state.
+
+## Requirements
+
+- ArduPilot 4.7 or later with Lua scripting enabled (`SCR_ENABLE = 1`)
+- copy the script to the vehicle autopilot's "scripts" directory
+- The script must be placed in appropriate directories:
+
+## Parameters
+
+This script introduces a new parameter table named `PARAM_SET_`. It includes:
+
+| Name              | Type   | Default | Description                            |
+|-------------------|--------|---------|----------------------------------------|
+| `ENABLE`          | `int`  | `1`     | Enables (1) or disables (0) the script |
+
+You can disable the script by setting `PARAM_SET_ENABLE = 0`. **Note:** disabling `SCR_ENABLE` while this script is actively blocking parameter sets is not recommended.
+
+## Whitelisted Parameters
+
+Only the following parameters are allowed to be set when the script is enabled:
+
+- `MAV_OPTIONS`
+- `PARAM_SET_ENABLE`
+- Battery parameters (e.g., `BATT_ARM_MAH`, `BATT_FS_CRT_ACT`, etc.)
+- `BRD_OPTIONS`
+- `COMPASS_USE3`
+- Geofence and RTL parameters (e.g., `FENCE_TYPE`, `RTL_ALT`)
+- `LOG_*`, `LIGHTS_ON`
+
+(See the full script for the complete whitelist.)
+
+## Usage
+
+1. Copy the script into the SD card's scripts directory.
+2. Ensure `SCR_ENABLE` and `PARAM_SET_ENABLE` are both set to `1`.
+3. Reboot the autopilot or reload the script if necessary.
+
+## Logging & Debugging
+
+The script sends diagnostic messages to the GCS:
+
+- Allowed parameter updates show a `param set received` message.
+- Blocked updates show a `param set denied` message with the offending parameter name.
+
+Example output:
+
+[param-set] param set received
+[param-set] param set denied (LOG_BACKEND_TYPE)
+
+
+## Limitations
+
+- Only handles `PARAM_SET` messages (not `PARAM_REQUEST_*`).
+- The parameter whitelist is hardcoded; changes require script edits.
+- ArduPilot must support the `gcs:set_allow_param_set()` interface.
+- parameter upload via FTP is denied when this script is running
+
+## Author
+
+[Contributed via PR #29989](https://github.com/ArduPilot/ardupilot/pull/29989)  
+May 2025

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -2985,6 +2985,14 @@ function gcs:send_text(severity, text) end
 ---@return uint32_t_ud -- system time in milliseconds
 function gcs:last_seen() end
 
+-- Return whether the GCS library is currently allowed to set parameters
+---@return boolean
+function gcs:get_allow_param_set() end
+
+-- set whether the GCS library is currently allowed to set parameters
+---@param new_allow_value boolean
+function gcs:set_allow_param_set(new_allow_value) end
+
 -- call a MAVLink MAV_CMD_xxx command via command_int interface
 ---@param command integer -- MAV_CMD_xxx
 ---@param params table -- parameters of p1, p2, p3, p4, x, y and z and frame. Any not specified taken as zero

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -316,6 +316,11 @@ singleton GCS method enable_high_latency_connections void boolean
 singleton GCS method enable_high_latency_connections depends HAL_HIGH_LATENCY2_ENABLED == 1
 singleton GCS manual run_command_int lua_GCS_command_int 2 1
 
+-- GCS methods to enable/disable setting of parameters via the GCS
+--   PARAM_SET handling and the MAVFTP param-file-upload method:
+singleton GCS method get_allow_param_set boolean
+singleton GCS method set_allow_param_set void boolean
+
 include AP_ONVIF/AP_ONVIF.h depends ENABLE_ONVIF == 1
 singleton AP_ONVIF depends ENABLE_ONVIF == 1
 singleton AP_ONVIF rename onvif

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -34,6 +34,10 @@
 
 #define GCS_DEBUG_SEND_MESSAGE_TIMINGS 0
 
+#ifndef HAL_GCS_ALLOW_PARAM_SET_DEFAULT
+#define HAL_GCS_ALLOW_PARAM_SET_DEFAULT 1
+#endif  // HAL_GCS_IGNORE_PARAM_SET_DEFAULT
+
 // macros used to determine if a message will fit in the space available.
 
 void gcs_out_of_space_to_send(mavlink_channel_t chan);
@@ -1241,6 +1245,17 @@ public:
         return (mav_options & (uint16_t)option) != 0;
     }
 
+    // returns true if attempts to set parameters via PARAM_SET or via
+    // file upload in mavftp should be honoured:
+    bool get_allow_param_set() const {
+        return allow_param_set;
+    }
+    // can be used to force sets via PARAM_SET or via mavftp file
+    // upload to be ignored by the GCS library:
+    void set_allow_param_set(bool new_allowed) {
+        allow_param_set = new_allowed;
+    }
+
     bool out_of_time() const;
 
 #if AP_FRSKY_TELEM_ENABLED
@@ -1349,6 +1364,11 @@ private:
 #else
     static const uint8_t _status_capacity = 30;
 #endif
+
+    // ephemeral state indicating whether the GCS (including via
+    // PARAM_SET and upload of param values via FTP) should be allowed
+    // to change parameter values:
+    bool allow_param_set = HAL_GCS_ALLOW_PARAM_SET_DEFAULT;
 
     // queue of outgoing statustext messages.  Each entry consumes 58
     // bytes of RAM on stm32

--- a/libraries/GCS_MAVLink/GCS_Param.cpp
+++ b/libraries/GCS_MAVLink/GCS_Param.cpp
@@ -282,7 +282,13 @@ void GCS_MAVLINK::handle_param_set(const mavlink_message_t &msg)
     float old_value = vp->cast_to_float(var_type);
 
     if (!vp->allow_set_via_mavlink(parameter_flags)) {
-        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Param write denied (%s)", key);
+        // don't warn the user about this failure if we are dropping
+        // messages here.  This is on the assumption that scripting is
+        // currently responsible for setting parameters and may set
+        // the value instead of us.
+        if (gcs().get_allow_param_set()) {
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Param write denied (%s)", key);
+        }
         // send the readonly value
         send_parameter_value(key, var_type, old_value);
         return;


### PR DESCRIPTION
~~Add `MAV_OPTION` bit to ignore setting of parameters via MAVLink.~~

State is now ephemeral.

Add a LUA script which will honours `PARAM_SET` - based on a a whitelist of parameter names.

```
STABILIZE> Lua: State memory usage: 4824 + 10598
AP: Scripting: restarted
AP: param-set-filter script loaded
STABILIZE> 
STABILIZE> param set DISARM_DELAY 5
STABILIZE> AP: param-set-filter: param set denied (DISARM_DELAY)
Flight battery 100 percent
AP: param-set-filter: param set denied (DISARM_DELAY)
Failed to set DISARM_DELAY to 5 (invalid returned value 3.0)

STABILIZE> 
```

This work sponsored by Freespace Solutions
