### PR TITLE
Sub: allow SURFACE mode to work with no altitude data

### DIFF
--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -775,6 +775,14 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("ORIGIN_ALT", 21, ParametersG2, backup_origin_alt, 0),
 
+    // @Param: SFC_NOBARO_THST
+    // @DisplayName: Surface mode throttle output when no barometer is available
+    // @Description: Surface mode throttle output when no borometer is available. 100% is full throttle. -100% is maximum throttle downwards
+    // @Units: %
+    // @User: Standard
+    // @Range: -100 100
+    AP_GROUPINFO("SFC_NOBARO_THST", 22, ParametersG2, surface_nobaro_thrust, 10),
+
     AP_GROUPEND
 };
 

--- a/ArduSub/Parameters.h
+++ b/ArduSub/Parameters.h
@@ -209,7 +209,7 @@ public:
         k_param_cam_tilt_center, // deprecated
         k_param_frame_configuration,
         k_param_surface_max_throttle,
-
+        k_param_surface_nobaro_thrust,
         // 200: flight modes
         k_param_flight_mode1 = 200,
         k_param_flight_mode2,
@@ -404,6 +404,7 @@ public:
     AP_Float backup_origin_lat;
     AP_Float backup_origin_lon;
     AP_Float backup_origin_alt;
+    AP_Float surface_nobaro_thrust;
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduSub/Sub.cpp
+++ b/ArduSub/Sub.cpp
@@ -246,7 +246,7 @@ void Sub::ten_hz_logging_loop()
     if (should_log(MASK_LOG_RCOUT)) {
         logger.Write_RCOUT();
     }
-    if (should_log(MASK_LOG_NTUN) && (sub.flightmode->requires_GPS() || !sub.flightmode->has_manual_throttle())) {
+    if (should_log(MASK_LOG_NTUN) && (sub.flightmode->requires_GPS() || sub.flightmode->requires_altitude())) {
         pos_control.write_log();
     }
     if (should_log(MASK_LOG_IMU) || should_log(MASK_LOG_IMU_FAST) || should_log(MASK_LOG_IMU_RAW)) {

--- a/ArduSub/mode.cpp
+++ b/ArduSub/mode.cpp
@@ -95,8 +95,8 @@ bool Sub::set_mode(Mode::Number mode, ModeReason reason)
 
     // check for valid altitude if old mode did not require it but new one does
     // we only want to stop changing modes if it could make things worse
-    if (flightmode->has_manual_throttle() &&
-        !new_flightmode->has_manual_throttle() &&
+    if (!flightmode->requires_altitude() &&
+        new_flightmode->requires_altitude() &&
         !sub.control_check_barometer()) { // maybe use ekf_alt_ok() instead?
         gcs().send_text(MAV_SEVERITY_WARNING, "Mode change failed: %s need alt estimate", new_flightmode->name());
         LOGGER_WRITE_ERROR(LogErrorSubsystem::FLIGHT_MODE, LogErrorCode(mode));

--- a/ArduSub/mode.h
+++ b/ArduSub/mode.h
@@ -469,16 +469,16 @@ public:
     virtual void run() override;
 
     bool init(bool ignore_checks) override;
-    bool requires_GPS() const override { return true; }
+    bool requires_GPS() const override { return false; }
     bool has_manual_throttle() const override { return false; }
     bool allows_arming(bool from_gcs) const override { return true; }
     bool is_autopilot() const override { return true; }
 
 protected:
-
     const char *name() const override { return "SURFACE"; }
     const char *name4() const override { return "SURF"; }
     Mode::Number number() const override { return Mode::Number::SURFACE; }
+    bool sensorless_mode;
 };
 
 

--- a/ArduSub/mode.h
+++ b/ArduSub/mode.h
@@ -64,7 +64,7 @@ public:
     virtual bool init(bool ignore_checks) { return true; }
     virtual void run() = 0;
     virtual bool requires_GPS() const = 0;
-    virtual bool has_manual_throttle() const = 0;
+    virtual bool requires_altitude() const = 0;
     virtual bool allows_arming(bool from_gcs) const = 0;
     virtual bool is_autopilot() const { return false; }
     virtual bool in_guided_mode() const { return false; }
@@ -198,7 +198,7 @@ public:
     virtual void run() override;
     bool init(bool ignore_checks) override;
     bool requires_GPS() const override { return false; }
-    bool has_manual_throttle() const override { return true; }
+    bool requires_altitude() const override { return false; }
     bool allows_arming(bool from_gcs) const override { return true; }
     bool is_autopilot() const override { return false; }
 
@@ -221,7 +221,7 @@ public:
 
     bool init(bool ignore_checks) override;
     bool requires_GPS() const override { return false; }
-    bool has_manual_throttle() const override { return true; }
+    bool requires_altitude() const override { return false; }
     bool allows_arming(bool from_gcs) const override { return true; }
     bool is_autopilot() const override { return false; }
 
@@ -244,7 +244,7 @@ public:
 
     bool init(bool ignore_checks) override;
     bool requires_GPS() const override { return false; }
-    bool has_manual_throttle() const override { return true; }
+    bool requires_altitude() const override { return false; }
     bool allows_arming(bool from_gcs) const override { return true; }
     bool is_autopilot() const override { return false; }
 
@@ -267,7 +267,7 @@ public:
 
     bool init(bool ignore_checks) override;
     bool requires_GPS() const override { return false; }
-    bool has_manual_throttle() const override { return false; }
+    bool requires_altitude() const override { return true; }
     bool allows_arming(bool from_gcs) const override { return true; }
     bool is_autopilot() const override { return false; }
     void control_depth();
@@ -326,7 +326,7 @@ public:
 
     bool init(bool ignore_checks) override;
     bool requires_GPS() const override { return true; }
-    bool has_manual_throttle() const override { return false; }
+    bool requires_altitude() const override { return true; }
     bool allows_arming(bool from_gcs) const override { return true; }
     bool is_autopilot() const override { return true; }
     bool in_guided_mode() const override { return true; }
@@ -380,7 +380,7 @@ public:
 
     bool init(bool ignore_checks) override;
     bool requires_GPS() const override { return true; }
-    bool has_manual_throttle() const override { return false; }
+    bool requires_altitude() const override { return true; }
     bool allows_arming(bool from_gcs) const override { return true; }
     bool is_autopilot() const override { return true; }
     bool auto_loiter_start();
@@ -421,7 +421,7 @@ public:
     bool init(bool ignore_checks) override;
 
     bool requires_GPS() const override { return true; }
-    bool has_manual_throttle() const override { return false; }
+    bool requires_altitude() const override { return true; }
     bool allows_arming(bool from_gcs) const override { return true; }
     bool is_autopilot() const override { return true; }
 
@@ -448,7 +448,7 @@ public:
 
     bool init(bool ignore_checks) override;
     bool requires_GPS() const override { return true; }
-    bool has_manual_throttle() const override { return false; }
+    bool requires_altitude() const override { return true; }
     bool allows_arming(bool from_gcs) const override { return true; }
     bool is_autopilot() const override { return true; }
 
@@ -470,7 +470,7 @@ public:
 
     bool init(bool ignore_checks) override;
     bool requires_GPS() const override { return false; }
-    bool has_manual_throttle() const override { return false; }
+    bool requires_altitude() const override { return false; }
     bool allows_arming(bool from_gcs) const override { return true; }
     bool is_autopilot() const override { return true; }
 
@@ -478,7 +478,7 @@ protected:
     const char *name() const override { return "SURFACE"; }
     const char *name4() const override { return "SURF"; }
     Mode::Number number() const override { return Mode::Number::SURFACE; }
-    bool sensorless_mode;
+    bool nobaro_mode;
 };
 
 
@@ -493,7 +493,7 @@ public:
 
     bool init(bool ignore_checks) override;
     bool requires_GPS() const override { return false; }
-    bool has_manual_throttle() const override { return false; }
+    bool requires_altitude() const override { return false; }
     bool allows_arming(bool from_gcs) const override { return true; }
     bool is_autopilot() const override { return true; }
 

--- a/ArduSub/mode_surface.cpp
+++ b/ArduSub/mode_surface.cpp
@@ -3,7 +3,7 @@
 
 bool ModeSurface::init(bool ignore_checks)
 {
-    sensorless_mode = !sub.control_check_barometer();
+    nobaro_mode = !sub.control_check_barometer();
 
     // initialize vertical speeds and acceleration
     position_control->set_max_speed_accel_U_cm(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
@@ -30,8 +30,9 @@ void ModeSurface::run()
         return;
     }
 
-    if (sensorless_mode) {
-        float thrust_output = 0.5f + g2.surface_sensorless_thrust * 0.005f; // map -100, 100 to 0, 1
+    // If no barometer is available, use the surface_nobaro_thrust parameter to set the throttle output
+    if (nobaro_mode) {
+        float thrust_output = 0.5f + g2.surface_nobaro_thrust * 0.005f; // map -100, 100 to 0, 1
         attitude_control->set_throttle_out(thrust_output, true, g.throttle_filt);
     } else {
         // Already at surface, hold depth at surface

--- a/ArduSub/mode_surface.cpp
+++ b/ArduSub/mode_surface.cpp
@@ -3,9 +3,7 @@
 
 bool ModeSurface::init(bool ignore_checks)
 {
-    if(!sub.control_check_barometer()) {
-        return false;
-    }
+    sensorless_mode = !sub.control_check_barometer();
 
     // initialize vertical speeds and acceleration
     position_control->set_max_speed_accel_U_cm(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
@@ -32,28 +30,32 @@ void ModeSurface::run()
         return;
     }
 
-    // Already at surface, hold depth at surface
-    if (sub.ap.at_surface) {
-        set_mode(Mode::Number::ALT_HOLD, ModeReason::SURFACE_COMPLETE);
+    if (sensorless_mode) {
+        float thrust_output = 0.5f + g2.surface_sensorless_thrust * 0.005f; // map -100, 100 to 0, 1
+        attitude_control->set_throttle_out(thrust_output, true, g.throttle_filt);
+    } else {
+        // Already at surface, hold depth at surface
+        if (sub.ap.at_surface) {
+            set_mode(Mode::Number::ALT_HOLD, ModeReason::SURFACE_COMPLETE);
+        }
+
+        // convert pilot input to lean angles
+        // To-Do: convert sub.get_pilot_desired_lean_angles to return angles as floats
+        sub.get_pilot_desired_lean_angles(channel_roll->get_control_in(), channel_pitch->get_control_in(), target_roll, target_pitch, sub.aparm.angle_max);
+
+        // get pilot's desired yaw rate
+        float target_yaw_rate = sub.get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
+
+        // call attitude controller
+        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(target_roll, target_pitch, target_yaw_rate);
+
+        // set target climb rate
+        float cmb_rate_cms = constrain_float(fabsf(sub.wp_nav.get_default_speed_up_cms()), 1, position_control->get_max_speed_up_cms());
+
+        // update altitude target and call position controller
+        position_control->set_pos_target_U_from_climb_rate_cm(cmb_rate_cms);
+        position_control->update_U_controller();
     }
-
-    // convert pilot input to lean angles
-    // To-Do: convert sub.get_pilot_desired_lean_angles to return angles as floats
-    sub.get_pilot_desired_lean_angles(channel_roll->get_control_in(), channel_pitch->get_control_in(), target_roll, target_pitch, sub.aparm.angle_max);
-
-    // get pilot's desired yaw rate
-    float target_yaw_rate = sub.get_pilot_desired_yaw_rate(channel_yaw->get_control_in());
-
-    // call attitude controller
-    attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(target_roll, target_pitch, target_yaw_rate);
-
-    // set target climb rate
-    float cmb_rate_cms = constrain_float(fabsf(sub.wp_nav.get_default_speed_up_cms()), 1, position_control->get_max_speed_up_cms());
-
-    // update altitude target and call position controller
-    position_control->set_pos_target_U_from_climb_rate_cm(cmb_rate_cms);
-    position_control->update_U_controller();
-
     // pilot has control for repositioning
     motors.set_forward(channel_forward->norm_input());
     motors.set_lateral(channel_lateral->norm_input());


### PR DESCRIPTION
This fixes an issue where SURFACE mode doesn't work on vehicles with no baros for altitude sensor.