### PR TITLE
Fix invalid escape sequence in chibios.py

### DIFF
--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -102,7 +102,7 @@ class upload_fw(Task.Task):
         except subprocess.CalledProcessError:
             #if where.exe can't find the file it returns a non-zero result which throws this exception
             where_python = ""
-        if not where_python or "\Python\Python" not in where_python or "python.exe" not in where_python:
+        if not where_python or r"\Python\Python" not in where_python or "python.exe" not in where_python:
             print(self.get_full_wsl2_error_msg("Windows python.exe not found"))
             return False
         return True


### PR DESCRIPTION
- Error Message: `ardupilot/Tools/ardupilotwaf/chibios.py:105: SyntaxWarning: invalid escape sequence '\P' if not where_python or "\Python\Python" not in where_python or "python.exe" not in where_python:`

- Python version: 3.12

- Ardupilot: Plane 4.5.7

- OS: Windows 11 + WSL Ubuntu 24.04