### PR TITLE
Tools: ros2: Reduce test code duplication with fixture reuse

### DIFF
--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/launch_fixtures.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/launch_fixtures.py
@@ -1,0 +1,45 @@
+# Copyright 2025 ArduPilot.org.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import launch_pytest
+from launch import LaunchDescription
+
+
+@launch_pytest.fixture
+def launch_sitl_copter_dds_serial(sitl_copter_dds_serial):
+    """Launch SITL Copter with DDS over serial."""
+    sitl_ld, sitl_actions = sitl_copter_dds_serial
+    yield LaunchDescription([sitl_ld, launch_pytest.actions.ReadyToTest()]), sitl_actions
+
+
+@launch_pytest.fixture
+def launch_sitl_copter_dds_udp(sitl_copter_dds_udp):
+    """Launch SITL Copter with DDS over UDP."""
+    sitl_ld, sitl_actions = sitl_copter_dds_udp
+    yield LaunchDescription([sitl_ld, launch_pytest.actions.ReadyToTest()]), sitl_actions
+
+
+@launch_pytest.fixture
+def launch_sitl_plane_dds_serial(sitl_plane_dds_serial):
+    """Launch SITL Plane with DDS over serial."""
+    sitl_ld, sitl_actions = sitl_plane_dds_serial
+    yield LaunchDescription([sitl_ld, launch_pytest.actions.ReadyToTest()]), sitl_actions
+
+
+@launch_pytest.fixture
+def launch_sitl_plane_dds_udp(sitl_plane_dds_udp):
+    """Launch SITL Plane with DDS over UDP."""
+    sitl_ld, sitl_actions = sitl_plane_dds_udp
+    yield LaunchDescription([sitl_ld, launch_pytest.actions.ReadyToTest()]), sitl_actions

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_battery_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_battery_msg_received.py
@@ -24,13 +24,10 @@ colcon test --packages-select ardupilot_dds_tests \
 
 """
 
-import launch_pytest
 import pytest
 import rclpy
 import rclpy.node
 import threading
-
-from launch import LaunchDescription
 
 from launch_pytest.tools import process as process_tools
 
@@ -39,6 +36,11 @@ from rclpy.qos import QoSReliabilityPolicy
 from rclpy.qos import QoSHistoryPolicy
 
 from sensor_msgs.msg import BatteryState
+
+from launch_fixtures import (
+    launch_sitl_copter_dds_serial,
+    launch_sitl_copter_dds_udp,
+)
 
 TOPIC = "ap/battery"
 
@@ -82,36 +84,6 @@ class BatteryListener(rclpy.node.Node):
 
         if msg.header.frame_id == '1':
             self.frame_id_incorrect_object.set()
-
-
-@launch_pytest.fixture
-def launch_sitl_copter_dds_serial(sitl_copter_dds_serial):
-    """Fixture to create the launch description."""
-    sitl_ld, sitl_actions = sitl_copter_dds_serial
-
-    ld = LaunchDescription(
-        [
-            sitl_ld,
-            launch_pytest.actions.ReadyToTest(),
-        ]
-    )
-    actions = sitl_actions
-    yield ld, actions
-
-
-@launch_pytest.fixture
-def launch_sitl_copter_dds_udp(sitl_copter_dds_udp):
-    """Fixture to create the launch description."""
-    sitl_ld, sitl_actions = sitl_copter_dds_udp
-
-    ld = LaunchDescription(
-        [
-            sitl_ld,
-            launch_pytest.actions.ReadyToTest(),
-        ]
-    )
-    actions = sitl_actions
-    yield ld, actions
 
 
 @pytest.mark.launch(fixture=launch_sitl_copter_dds_serial)

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_geopose_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_geopose_msg_received.py
@@ -21,15 +21,12 @@ colcon test --packages-select ardupilot_dds_tests \
 
 """
 
-import launch_pytest
 import math
 import pytest
 import rclpy
 import rclpy.node
 from scipy.spatial.transform import Rotation as R
 import threading
-
-from launch import LaunchDescription
 
 from launch_pytest.tools import process as process_tools
 
@@ -38,6 +35,11 @@ from rclpy.qos import QoSReliabilityPolicy
 from rclpy.qos import QoSHistoryPolicy
 
 from geographic_msgs.msg import GeoPoseStamped
+
+from launch_fixtures import (
+    launch_sitl_copter_dds_serial,
+    launch_sitl_copter_dds_udp,
+)
 
 TOPIC = "ap/geopose/filtered"
 # Copied from locations.txt
@@ -63,6 +65,7 @@ def validate_position_cmac(position):
         and math.isclose(position.altitude, CMAC_ABS_ALT, abs_tol=1.0)
     )
 
+
 def wrap_360(angle):
     if angle > 360:
         angle -= 360.0
@@ -71,6 +74,7 @@ def wrap_360(angle):
         angle += 360.0
         return wrap_360(angle)
     return angle
+
 
 def validate_heading_cmac(orientation):
     """
@@ -128,36 +132,6 @@ class GeoPoseListener(rclpy.node.Node):
 
         if validate_heading_cmac(msg.pose.orientation):
             self.orientation_event_object.set()
-
-
-@launch_pytest.fixture
-def launch_sitl_copter_dds_serial(sitl_copter_dds_serial):
-    """Fixture to create the launch description."""
-    sitl_ld, sitl_actions = sitl_copter_dds_serial
-
-    ld = LaunchDescription(
-        [
-            sitl_ld,
-            launch_pytest.actions.ReadyToTest(),
-        ]
-    )
-    actions = sitl_actions
-    yield ld, actions
-
-
-@launch_pytest.fixture
-def launch_sitl_copter_dds_udp(sitl_copter_dds_udp):
-    """Fixture to create the launch description."""
-    sitl_ld, sitl_actions = sitl_copter_dds_udp
-
-    ld = LaunchDescription(
-        [
-            sitl_ld,
-            launch_pytest.actions.ReadyToTest(),
-        ]
-    )
-    actions = sitl_actions
-    yield ld, actions
 
 
 @pytest.mark.launch(fixture=launch_sitl_copter_dds_serial)

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_joy_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_joy_msg_received.py
@@ -25,7 +25,6 @@ colcon test --packages-select ardupilot_dds_tests \
 
 import rclpy
 import time
-import launch_pytest
 from rclpy.node import Node
 from builtin_interfaces.msg import Time
 from geographic_msgs.msg import GeoPoseStamped
@@ -37,8 +36,9 @@ from sensor_msgs.msg import Joy
 from scipy.spatial.transform import Rotation as R
 import pytest
 from launch_pytest.tools import process as process_tools
-from launch import LaunchDescription
 import threading
+
+from launch_fixtures import launch_sitl_copter_dds_udp
 
 GUIDED = 4
 LOITER = 5
@@ -65,30 +65,32 @@ class PlaneFbwbJoyControl(Node):
         self._client_arm = self.create_client(ArmMotors, "/ap/arm_motors")
 
         self._client_mode_switch = self.create_client(ModeSwitch, "/ap/mode_switch")
-            
-        self._joy_pub = self.create_publisher(Joy, "/ap/joy", 1)          
+
+        self._joy_pub = self.create_publisher(Joy, "/ap/joy", 1)
 
         # Create subscriptions after services are up
         qos = rclpy.qos.QoSProfile(
             reliability=rclpy.qos.ReliabilityPolicy.BEST_EFFORT, durability=rclpy.qos.DurabilityPolicy.VOLATILE, depth=1
         )
-        self._subscription_geopose = self.create_subscription(GeoPoseStamped, "/ap/geopose/filtered", self.geopose_cb, qos)
+        self._subscription_geopose = self.create_subscription(
+            GeoPoseStamped, "/ap/geopose/filtered", self.geopose_cb, qos
+        )
         self._cur_geopose = GeoPoseStamped()
-        
+
         self._subscription_twist = self.create_subscription(TwistStamped, "/ap/twist/filtered", self.twist_cb, qos)
         self._climb_rate = 0.0
 
         # Add a spin thread.
         self.ros_spin_thread = threading.Thread(target=lambda node: rclpy.spin(node), args=(self,))
         self.ros_spin_thread.start()
-        
+
     def geopose_cb(self, msg: GeoPoseStamped):
         """Process a GeoPose message."""
         stamp = msg.header.stamp
         if stamp.sec:
             # Store current state
             self._cur_geopose = msg
-            
+
     def twist_cb(self, msg: TwistStamped):
         """Process a Twist message."""
         linear = msg.twist.linear
@@ -121,7 +123,7 @@ class PlaneFbwbJoyControl(Node):
         try:
             return future.result().status and future.result().curr_mode == mode
         except:
-            return False        
+            return False
 
     def switch_mode_with_timeout(self, desired_mode: int, timeout: rclpy.duration.Duration):
         """Try to switch mode. Returns true on success, or false if mode switch fails or times out."""
@@ -136,75 +138,48 @@ class PlaneFbwbJoyControl(Node):
     def get_cur_geopose(self):
         """Return latest geopose."""
         return self._cur_geopose
-        
+
     def send_joy_value(self, joy_val):
         self._joy_pub.publish(joy_val)
-        
-    #-------------- PROCESSES -----------------
+
+    # -------------- PROCESSES -----------------
     def process_arm(self):
         if self.arm_with_timeout(rclpy.duration.Duration(seconds=30)):
             self.arming_event_object.set()
-        
+
     def start_arm(self):
         self.arm_thread = threading.Thread(target=self.process_arm)
         self.arm_thread.start()
-        
+
     def process_climb(self):
         joy_msg = Joy()
         joy_msg.axes.append(0.0)
         joy_msg.axes.append(0.0)
-        joy_msg.axes.append(0.8) #- straight up
-        joy_msg.axes.append(0.0)        
+        joy_msg.axes.append(0.8)  # - straight up
+        joy_msg.axes.append(0.0)
 
         while True:
             self.send_joy_value(joy_msg)
-            self.arm() #- Keep the system armed (sometimes it disarms and the test fails)
+            self.arm()  # - Keep the system armed (sometimes it disarms and the test fails)
             time.sleep(0.1)
             self.get_logger().info("From AP : Climb rate {}".format(self._climb_rate))
             if self._climb_rate > 0.5:
                 self.climbing_event_object.set()
-                return      
-            
+                return
+
     def climb(self):
         self.climb_thread = threading.Thread(target=self.process_climb)
         self.climb_thread.start()
-        
+
     def arm_and_takeoff_process(self):
         self.process_arm()
         self.climb()
-        
+
     def arm_and_takeoff(self):
         self.climb_thread = threading.Thread(target=self.arm_and_takeoff_process)
-        self.climb_thread.start()        
+        self.climb_thread.start()
 
-@launch_pytest.fixture
-def launch_sitl_copter_dds_serial(sitl_copter_dds_serial):
-    """Fixture to create the launch description."""
-    sitl_ld, sitl_actions = sitl_copter_dds_serial
 
-    ld = LaunchDescription(
-        [
-            sitl_ld,
-            launch_pytest.actions.ReadyToTest(),
-        ]
-    )
-    actions = sitl_actions
-    yield ld, actions
-
-@launch_pytest.fixture
-def launch_sitl_copter_dds_udp(sitl_copter_dds_udp):
-    """Fixture to create the launch description."""
-    sitl_ld, sitl_actions = sitl_copter_dds_udp
-
-    ld = LaunchDescription(
-        [
-            sitl_ld,
-            launch_pytest.actions.ReadyToTest(),
-        ]
-    )
-    actions = sitl_actions
-    yield ld, actions
-    
 @pytest.mark.launch(fixture=launch_sitl_copter_dds_udp)
 def test_dds_udp_joy_msg_recv(launch_context, launch_sitl_copter_dds_udp):
     """Test joy messages are published by AP_DDS."""

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_navsat_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_navsat_msg_received.py
@@ -14,13 +14,10 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 """Bring up ArduPilot SITL and check the NavSat message is being published."""
-import launch_pytest
 import pytest
 import rclpy
 import rclpy.node
 import threading
-
-from launch import LaunchDescription
 
 from launch_pytest.tools import process as process_tools
 
@@ -31,6 +28,11 @@ from rclpy.qos import QoSHistoryPolicy
 from sensor_msgs.msg import NavSatFix
 
 TOPIC = "ap/navsat"
+
+from launch_fixtures import (
+    launch_sitl_copter_dds_serial,
+    launch_sitl_copter_dds_udp,
+)
 
 
 class NavSatFixListener(rclpy.node.Node):
@@ -67,36 +69,6 @@ class NavSatFixListener(rclpy.node.Node):
             self.get_logger().info("From AP : True [lat:{}, lon: {}]".format(msg.latitude, msg.longitude))
         else:
             self.get_logger().info("From AP : False")
-
-
-@launch_pytest.fixture
-def launch_sitl_copter_dds_serial(sitl_copter_dds_serial):
-    """Fixture to create the launch description."""
-    sitl_ld, sitl_actions = sitl_copter_dds_serial
-
-    ld = LaunchDescription(
-        [
-            sitl_ld,
-            launch_pytest.actions.ReadyToTest(),
-        ]
-    )
-    actions = sitl_actions
-    yield ld, actions
-
-
-@launch_pytest.fixture
-def launch_sitl_copter_dds_udp(sitl_copter_dds_udp):
-    """Fixture to create the launch description."""
-    sitl_ld, sitl_actions = sitl_copter_dds_udp
-
-    ld = LaunchDescription(
-        [
-            sitl_ld,
-            launch_pytest.actions.ReadyToTest(),
-        ]
-    )
-    actions = sitl_actions
-    yield ld, actions
 
 
 @pytest.mark.launch(fixture=launch_sitl_copter_dds_serial)

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_prearm_service.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_prearm_service.py
@@ -22,18 +22,19 @@ colcon test --executor sequential --parallel-workers 0 --base-paths src/ardupilo
 
 """
 
-import launch_pytest
 import time
 import pytest
 import rclpy
 import rclpy.node
 import threading
 
-from launch import LaunchDescription
-
 from launch_pytest.tools import process as process_tools
 from std_srvs.srv import Trigger
 
+from launch_fixtures import (
+    launch_sitl_copter_dds_serial,
+    launch_sitl_copter_dds_udp,
+)
 
 SERVICE = "/ap/prearm_check"
 
@@ -80,36 +81,6 @@ class PreamService(rclpy.node.Node):
             print("start_prearm not started yet")
         self.prearm_thread = threading.Thread(target=self.process_prearm)
         self.prearm_thread.start()
-
-
-@launch_pytest.fixture
-def launch_sitl_copter_dds_serial(sitl_copter_dds_serial):
-    """Fixture to create the launch description."""
-    sitl_ld, sitl_actions = sitl_copter_dds_serial
-
-    ld = LaunchDescription(
-        [
-            sitl_ld,
-            launch_pytest.actions.ReadyToTest(),
-        ]
-    )
-    actions = sitl_actions
-    yield ld, actions
-
-
-@launch_pytest.fixture
-def launch_sitl_copter_dds_udp(sitl_copter_dds_udp):
-    """Fixture to create the launch description."""
-    sitl_ld, sitl_actions = sitl_copter_dds_udp
-
-    ld = LaunchDescription(
-        [
-            sitl_ld,
-            launch_pytest.actions.ReadyToTest(),
-        ]
-    )
-    actions = sitl_actions
-    yield ld, actions
 
 
 @pytest.mark.launch(fixture=launch_sitl_copter_dds_serial)

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_rc_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_rc_msg_received.py
@@ -24,13 +24,10 @@ colcon test --packages-select ardupilot_dds_tests \
 
 """
 
-import launch_pytest
 import pytest
 import rclpy
 import rclpy.node
 import threading
-
-from launch import LaunchDescription
 
 from launch_pytest.tools import process as process_tools
 
@@ -39,6 +36,11 @@ from rclpy.qos import QoSReliabilityPolicy
 from rclpy.qos import QoSHistoryPolicy
 
 from ardupilot_msgs.msg import Rc
+
+from launch_fixtures import (
+    launch_sitl_copter_dds_serial,
+    launch_sitl_copter_dds_udp,
+)
 
 TOPIC = "ap/rc"
 
@@ -72,36 +74,6 @@ class RcListener(rclpy.node.Node):
     def subscriber_callback(self, msg):
         """Process a Rc message."""
         self.msg_event_object.set()
-
-
-@launch_pytest.fixture
-def launch_sitl_copter_dds_serial(sitl_copter_dds_serial):
-    """Fixture to create the launch description."""
-    sitl_ld, sitl_actions = sitl_copter_dds_serial
-
-    ld = LaunchDescription(
-        [
-            sitl_ld,
-            launch_pytest.actions.ReadyToTest(),
-        ]
-    )
-    actions = sitl_actions
-    yield ld, actions
-
-
-@launch_pytest.fixture
-def launch_sitl_copter_dds_udp(sitl_copter_dds_udp):
-    """Fixture to create the launch description."""
-    sitl_ld, sitl_actions = sitl_copter_dds_udp
-
-    ld = LaunchDescription(
-        [
-            sitl_ld,
-            launch_pytest.actions.ReadyToTest(),
-        ]
-    )
-    actions = sitl_actions
-    yield ld, actions
 
 
 @pytest.mark.launch(fixture=launch_sitl_copter_dds_serial)
@@ -153,4 +125,3 @@ def test_dds_udp_rc_msg_recv(launch_context, launch_sitl_copter_dds_udp):
     finally:
         rclpy.shutdown()
     yield
-    

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_time_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_time_msg_received.py
@@ -14,17 +14,19 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 """Bring up ArduPilot SITL check the Time message is being published."""
-import launch_pytest
 import pytest
 import rclpy
 import rclpy.node
 import threading
 
-from launch import LaunchDescription
-
 from launch_pytest.tools import process as process_tools
 
 from builtin_interfaces.msg import Time
+
+from launch_fixtures import (
+    launch_sitl_copter_dds_serial,
+    launch_sitl_copter_dds_udp,
+)
 
 TOPIC = "ap/time"
 
@@ -57,36 +59,6 @@ class TimeListener(rclpy.node.Node):
             self.get_logger().info("From AP : True [sec:{}, nsec: {}]".format(msg.sec, msg.nanosec))
         else:
             self.get_logger().info("From AP : False")
-
-
-@launch_pytest.fixture
-def launch_sitl_copter_dds_serial(sitl_copter_dds_serial):
-    """Fixture to create the launch description."""
-    sitl_ld, sitl_actions = sitl_copter_dds_serial
-
-    ld = LaunchDescription(
-        [
-            sitl_ld,
-            launch_pytest.actions.ReadyToTest(),
-        ]
-    )
-    actions = sitl_actions
-    yield ld, actions
-
-
-@launch_pytest.fixture
-def launch_sitl_copter_dds_udp(sitl_copter_dds_udp):
-    """Fixture to create the launch description."""
-    sitl_ld, sitl_actions = sitl_copter_dds_udp
-
-    ld = LaunchDescription(
-        [
-            sitl_ld,
-            launch_pytest.actions.ReadyToTest(),
-        ]
-    )
-    actions = sitl_actions
-    yield ld, actions
 
 
 @pytest.mark.launch(fixture=launch_sitl_copter_dds_serial)


### PR DESCRIPTION
* Normally these go in conftest and are auto-imported by pytest, but LaunchPytest requires any fixtures to be statically visible at import time and imported directly
* By moving these fixtures into a common file, we reduce the amount of code duplication for our tests