### PR TITLE
.github: Report colcon test result Junit results

### DIFF
--- a/.github/workflows/colcon.yml
+++ b/.github/workflows/colcon.yml
@@ -136,6 +136,9 @@ concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  checks: write
+
 jobs:
   build-test:
     runs-on: ubuntu-22.04
@@ -199,7 +202,14 @@ jobs:
         run: |
           source install/setup.bash
           colcon test --executor sequential --parallel-workers 0 --base-paths src/ardupilot --event-handlers=console_cohesion+
-      - name: Report colcon test results
+      - name: Display colcon test results
         run: |
           colcon test-result --all --verbose
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v5
+        if: success() || failure() # always run even if the previous step fails
+        with:
+          report_paths: |
+            build/**/pytest.xml
+            build/**/Testing/**/Test.xml
 


### PR DESCRIPTION
Use [junit-report](https://github.com/mikepenz/action-junit-report) to add junit output for colcon tests.
This should allow us to more quickly drill into the colcon test results rather than immediately looking at logs.
