### PR TITLE
AP_Mount: Adjust the version setting to match ZT6

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -1199,9 +1199,7 @@ void AP_Mount_Siyi::check_firmware_version() const
     FirmwareVersion minimum_ver {};
     switch (_hardware_model) {
         case HardwareModel::A8:
-            minimum_ver.camera.major = 0;
-            minimum_ver.camera.minor = 2;
-            minimum_ver.camera.patch = 1;
+        	minimum_ver.camera = {.major = 0, .minor = 2, .patch = 1};
             break;
 
         case HardwareModel::ZT6:


### PR DESCRIPTION
By setting the version to bdde2690 , it becomes a single line.
This makes the version easier to visualize.