### PR TITLE
Scripted Arming Checks

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -5863,19 +5863,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             quiet=True,
         )
 
-    def setup_servo_mount(self, roll_servo=5, pitch_servo=6, yaw_servo=7):
-        '''configure a rpy servo mount; caller responsible for required rebooting'''
-        self.progress("Setting up servo mount")
-        self.set_parameters({
-            "MNT1_TYPE": 1,
-            "MNT1_PITCH_MIN": -45,
-            "MNT1_PITCH_MAX": 45,
-            "RC6_OPTION": 213,  # MOUNT1_PITCH
-            "SERVO%u_FUNCTION" % roll_servo: 8, # roll
-            "SERVO%u_FUNCTION" % pitch_servo: 7, # pitch
-            "SERVO%u_FUNCTION" % yaw_servo: 6, # yaw
-        })
-
     def get_mount_roll_pitch_yaw_deg(self):
         '''return mount (aka gimbal) roll, pitch and yaw angles in degrees'''
         # wait for gimbal attitude message

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -7502,6 +7502,214 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.set_rc(2, 1500)
         self.fly_home_land_and_disarm()
 
+    def ScriptedArmingChecksApplet(self):
+        """ Applet for Arming Checks will prevent a vehicle from arming based on scripted checks
+            """
+        self.start_subtest("Scripted Arming Checks Applet validation")
+        self.context_collect("STATUSTEXT")
+
+        """Initialize the FC"""
+        self.set_parameter("SCR_ENABLE", 1)
+        self.install_applet_script_context("arming-checks.lua")
+        self.reboot_sitl()
+        self.wait_ekf_happy()
+        self.wait_text("ArduPilot Ready", check_context=True)
+        self.wait_text("Arming Checks .* loaded", timeout=30, check_context=True, regex=True)
+
+        self.start_subsubtest("ArmCk: MAV_SYSID not set")
+        self.progress("Currently SYSID is %f" % self.get_parameter('MAV_SYSID'))
+        self.wait_text("ArmCk: warn: MAV_SYSID not set", timeout=30, check_context=True, regex=True)
+        """ disable the SYSID check, since autotest doesn't like changing the sysid"""
+        self.set_parameter("ARM_SYSID", -1)
+
+        ''' This check comes first since its part of the standard parameters - an invalid scaling speed'''
+        self.start_subsubtest("ArmCk: SCALING_SPEED close to AIRSPEED_CRUISE")
+        self.assert_prearm_failure("fail: Scaling spd", other_prearm_failures_fatal=False)
+        self.set_parameter("SCALING_SPEED", 22)
+        self.wait_text("clear: Scaling spd", check_context=True)
+
+        self.start_subsubtest("ArmCk: FOLL_SYSID must be set if FOLL_ENABLE = 1")
+        self.set_parameter("FOLL_ENABLE", 1)
+        self.set_parameter("FOLL_OFS_X", 10)
+        self.assert_prearm_failure("FOLL_SYSID not set", other_prearm_failures_fatal=False)
+        self.set_parameter("FOLL_SYSID", 3)
+        self.wait_text("clear: FOLL_SYSID not set", check_context=True)
+        self.set_parameter("FOLL_SYSID", -1)
+
+        self.start_subsubtest("ArmCk: FOLL_OFS_[XYZ] must be set if FOLL_ENABLE = 1")
+        self.set_parameter("FOLL_OFS_X", 0)
+        self.assert_prearm_failure("FOLL_OFS_[XYZ] = 0", other_prearm_failures_fatal=False)
+        self.set_parameter("FOLL_OFS_X", 10)
+        self.wait_text("clear: FOLL_OFS_[XYZ] = 0", check_context=True)
+        self.set_parameter("FOLL_OFS_X", 0)
+        self.assert_prearm_failure("FOLL_OFS_[XYZ] = 0", other_prearm_failures_fatal=False)
+        self.set_parameter("FOLL_OFS_Y", 10)
+        self.wait_text("clear: FOLL_OFS_[XYZ] = 0", check_context=True)
+        self.set_parameter("FOLL_OFS_Y", 0)
+        self.assert_prearm_failure("FOLL_OFS_[XYZ] = 0", other_prearm_failures_fatal=False)
+        self.set_parameter("FOLL_OFS_Z", 10)
+        self.wait_text("clear: FOLL_OFS_[XYZ] = 0", check_context=True)
+        """ clear these checks to make the context cleaner for subsequent tests """
+        self.set_parameters({
+            "ARM_SYSID": -1,
+            "ARM_FOLL_SYSID": -1,
+            "ARM_FOLL_SYSID_X": -1,
+            "ARM_FOLL_OFS_DEF": -1,
+        })
+
+        self.start_subsubtest("ArmCk: RTL_ALTITUDE must be legal")
+        self.progress("Currently ARM_P_RTL_ALT is %f" % self.get_parameter('ARM_P_RTL_ALT'))
+        self.set_parameter("RTL_ALTITUDE", 150)
+        self.assert_prearm_failure("ArmCk: fail: RTL_ALTITUDE too high", other_prearm_failures_fatal=False)
+        self.set_parameter("RTL_ALTITUDE", 120)
+        self.wait_text("clear: RTL_ALT", check_context=True)
+
+        self.start_subsubtest("ArmCk: RTL_CLIMB_MIN must be legal")
+        self.set_parameter("RTL_CLIMB_MIN", 150)
+        self.wait_text("ArmCk: warn: RTL_CLIMB_MIN too high", check_context=True)
+        self.set_parameter("RTL_CLIMB_MIN", 120)
+        self.wait_text("clear: RTL_CLIMB_MIN too high", check_context=True)
+
+        self.start_subsubtest("ArmCk: AIRSPEED stall < min < cruise < max")
+        ''' Airspeed parameter start out as
+        AIRSPEED_STALL = 0
+        AIRSPEED_MIN = 10
+        AIRSPEED_CRUISE = 22
+        AIRSPEED_MAX = 30
+        '''
+        self.start_subsubtest("ArmCk: AIRSPEED max < others")
+        self.set_parameter("AIRSPEED_MAX", 5)
+        self.assert_prearm_failure("ArmCk: fail: stall < min", other_prearm_failures_fatal=False)
+        self.set_parameter("AIRSPEED_MAX", 30)
+        self.wait_text("clear: stall < min", check_context=True)
+        self.start_subsubtest("ArmCk: AIRSPEED cruise < min")
+        self.set_parameter("AIRSPEED_MIN", 25)
+        self.assert_prearm_failure("ArmCk: fail: stall < min", other_prearm_failures_fatal=False)
+        self.set_parameter("AIRSPEED_MIN", 10)
+        self.wait_text("clear: stall < min", check_context=True)
+        self.start_subsubtest("ArmCk: AIRSPEED cruise > max")
+        self.set_parameter("AIRSPEED_CRUISE", 40)
+        self.set_parameter("SCALING_SPEED", 40)
+        self.assert_prearm_failure("ArmCk: fail: stall < min", other_prearm_failures_fatal=False)
+        self.set_parameter("AIRSPEED_CRUISE", 22)
+        self.set_parameter("SCALING_SPEED", 22)
+        self.wait_text("clear: stall < min", check_context=True)
+
+        self.start_subsubtest("ArmCk: AIRSPEED_MIN must be > AIRSPEED_STALL")
+        ''' only applies if AIRSPEED_STALL is non zero'''
+        self.set_parameter("AIRSPEED_STALL", 2)
+        self.wait_text("ArmCk: info: Min Speed not", check_context=True)
+        self.set_parameter("AIRSPEED_STALL", 8)
+
+        self.start_subsubtest("ArmCk: Mount SYSID must not match FOLL_SYSID")
+        self.set_parameter("ARM_SYSID", -1)
+        ''' to fail the check MNTx_SYSID_DFLT must be non zero but not= FOLL_SYSID'''
+        self.set_parameter("MNT1_SYSID_DFLT", 1)
+        ''' Need a healthy camera mount defined for this to work '''
+        self.setup_servo_mount()
+        self.progress("rebooting to enable MNT1")
+        self.reboot_sitl() # to handle MNT_TYPE changing
+        self.wait_ekf_happy()
+        self.wait_text("ArduPilot Ready", check_context=True)
+        self.wait_text("Arming Checks .* loaded", timeout=30, check_context=True, regex=True)
+        self.progress("Currently FOLL_SYSID is %f" % self.get_parameter('FOLL_SYSID'))
+        self.progress("Currently MNT1_SYSID_DFLT is %f" % self.get_parameter('MNT1_SYSID_DFLT'))
+        self.set_parameter("ARM_SYSID", -1)
+        self.progress("Currently FOLL_SYSID is %f" % self.get_parameter('FOLL_SYSID'))
+        self.progress("Currently MNT1_SYSID_DFLT is %f" % self.get_parameter('MNT1_SYSID_DFLT'))
+        self.wait_text("warn: MNTx_SYSID != FOLL", check_context=True)
+
+        self.start_subsubtest("ArmCk: Fence must be enabled or autoenabled (warning)")
+        self.reboot_sitl()
+        self.wait_ekf_happy()
+        self.wait_text("ArduPilot Ready", check_context=True)
+        self.wait_text("Arming Checks .* loaded", timeout=30, check_context=True, regex=True)
+        self.load_fence("CMAC-fence.txt")
+        self.wait_statustext("warn: Fence not enabled", check_context=True)
+        self.set_parameter("FENCE_ENABLE", 1)
+        self.wait_statustext("clear: Fence not enabled", check_context=True)
+        self.set_parameter("FENCE_ENABLE", 0)
+        self.wait_statustext("warn: Fence not enabled", check_context=True)
+        self.set_parameter("FENCE_AUTOENABLE", 1)
+        self.wait_text("clear: Fence not enabled", check_context=True)
+        self.set_parameter("FENCE_AUTOENABLE", 0)
+        self.wait_text("warn: Fence not enabled", check_context=True)
+
+    def ScriptedArmingChecksAppletEStop(self):
+        """ Applet for Arming Checks will prevent a vehicle from arming based on scripted checks
+            """
+        self.start_subtest("Scripted Arming Checks Applet validation")
+        self.context_collect("STATUSTEXT")
+
+        """Initialize the FC"""
+        self.set_parameter("SCR_ENABLE", 1)
+        self.install_applet_script_context("arming-checks.lua")
+        self.reboot_sitl()
+        self.wait_ekf_happy()
+        self.wait_text("ArduPilot Ready", check_context=True)
+        self.wait_text("Arming Checks .* loaded", timeout=30, check_context=True, regex=True)
+        self.set_parameters({
+            "ARM_SYSID": -1,
+            "ARM_FOLL_SYSID": -1,
+            "ARM_FOLL_SYSID_X": -1,
+            "ARM_FOLL_OFS_DEF": -1,
+            "ARM_P_SCALING": -1,
+        })
+
+        self.start_subsubtest("ArmCk: Cannot arm while motors estopped")
+        self.set_parameter("RC6_OPTION", 165)
+        self.progress("rebooting to enable RC channel")
+        self.reboot_sitl() # to handle RC option changing
+        self.wait_ekf_happy()
+        self.wait_text("ArduPilot Ready", check_context=True)
+        self.wait_text("Arming Checks .* loaded", timeout=30, check_context=True, regex=True)
+        self.set_parameters({
+            "ARM_SYSID": -1,
+            "ARM_FOLL_SYSID": -1,
+            "ARM_FOLL_SYSID_X": -1,
+            "ARM_FOLL_OFS_DEF": -1,
+            "ARM_P_SCALING": -1,
+        })
+        self.set_rc(6, 1000)
+        self.assert_prearm_failure("ArmCk: fail: Motors EStopped", other_prearm_failures_fatal=False)
+        self.set_rc(6, 2000)
+        self.wait_text("clear: Motors EStopped", timeout=30, check_context=True, regex=True)
+        self.wait_ready_to_arm()
+
+    def ScriptedArmingChecksAppletRally(self):
+        """ Applet for Arming Checks will prevent a vehicle from arming based on scripted checks
+            """
+        self.start_subtest("Scripted Arming Checks Applet validation")
+        self.context_collect("STATUSTEXT")
+
+        """Initialize the FC"""
+        self.set_parameter("SCR_ENABLE", 1)
+        self.install_applet_script_context("arming-checks.lua")
+        self.reboot_sitl()
+        self.wait_ekf_happy()
+        self.wait_text("ArduPilot Ready", check_context=True)
+        self.wait_text("Arming Checks .* loaded", timeout=30, check_context=True, regex=True)
+
+        self.start_subsubtest("ArmCk: MAV_SYSID not set")
+        self.progress("Currently SYSID is %f" % self.get_parameter('MAV_SYSID'))
+        self.wait_text("ArmCk: warn: MAV_SYSID not set", timeout=30, check_context=True, regex=True)
+        """ disable the SYSID check, since autotest doesn't like changing the sysid"""
+        self.set_parameters({
+            "ARM_SYSID": -1,
+            "ARM_FOLL_SYSID": -1,
+            "ARM_FOLL_SYSID_X": -1,
+            "ARM_FOLL_OFS_DEF": -1,
+            "ARM_P_SCALING": -1,
+        })
+
+        self.start_subsubtest("ArmCk: Rally Point must be < ARM_V_RALLY_MAX meters away")
+        self.progress("Currently RALLY_LIMIT_KM is %f" % self.get_parameter('RALLY_LIMIT_KM'))
+        loc = self.home_relative_loc_ne(6500, -50)
+        self.upload_rally_points_from_locations([loc])
+        self.wait_text("warn: Rally too far", check_context=True)
+        self.set_parameter("RALLY_LIMIT_KM", 7)
+        self.wait_text("clear: Rally too far", check_context=True)
+
     def tests(self):
         '''return list of all tests'''
         ret = []
@@ -7674,6 +7882,9 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.RudderArmingWithArmingChecksZero,
             self.TerrainLoiterToCircle,
             self.FenceDoubleBreach,
+            self.ScriptedArmingChecksApplet,
+            self.ScriptedArmingChecksAppletEStop,
+            self.ScriptedArmingChecksAppletRally,
         ]
 
     def disabled_tests(self):

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -15106,3 +15106,16 @@ SERIAL5_BAUD 128
                 "SIM_SPEEDUP": 4,
                 "FS_GCS_ENABLE": paramValue,
             })
+
+    def setup_servo_mount(self, roll_servo=5, pitch_servo=6, yaw_servo=7):
+        '''configure a rpy servo mount; caller responsible for required rebooting'''
+        self.progress("Setting up servo mount")
+        self.set_parameters({
+            "MNT1_TYPE": 1,
+            "MNT1_PITCH_MIN": -45,
+            "MNT1_PITCH_MAX": 45,
+            "RC6_OPTION": 213,  # MOUNT1_PITCH
+            "SERVO%u_FUNCTION" % roll_servo: 8, # roll
+            "SERVO%u_FUNCTION" % pitch_servo: 7, # pitch
+            "SERVO%u_FUNCTION" % yaw_servo: 6, # yaw
+        })

--- a/libraries/AP_Rally/AP_Rally.cpp
+++ b/libraries/AP_Rally/AP_Rally.cpp
@@ -81,6 +81,17 @@ bool AP_Rally::get_rally_point_with_index(uint8_t i, RallyLocation &ret) const
     return true; 
 }
 
+// Get rally point as a location
+bool AP_Rally::get_rally_location_with_index(uint8_t i, Location &ret) const
+{
+    RallyLocation rally_loc;
+    if (!get_rally_point_with_index(i, rally_loc)) {
+        return false;
+    }
+    ret = rally_location_to_location(rally_loc);
+    return true;
+}
+
 void AP_Rally::truncate(uint8_t num)
 {
     if (num > _rally_point_total_count) {

--- a/libraries/AP_Rally/AP_Rally.h
+++ b/libraries/AP_Rally/AP_Rally.h
@@ -53,6 +53,7 @@ public:
 
     // data handling
     bool get_rally_point_with_index(uint8_t i, RallyLocation &ret) const;
+    bool get_rally_location_with_index(uint8_t i, Location &ret) const;
     bool set_rally_point_with_index(uint8_t i, const RallyLocation &rallyLoc);
     uint8_t get_rally_total() const {
         return (uint8_t)_rally_point_total_count;

--- a/libraries/AP_Scripting/applets/arming-checks.lua
+++ b/libraries/AP_Scripting/applets/arming-checks.lua
@@ -1,0 +1,633 @@
+-- This script runs arming checks for validations that are important
+-- to some, but might need to behave differently depending on the vehicle or use case
+-- so we don't want to bake them into the firmware. 
+-- The severity of each check can be set by simply setting the value of parameters.
+-- from warnings, which still allow arming to to errors failsafe which prevent arming 
+-- Set the value of the matching parameter to the MAV_SEVERITY of the error level you want.
+--
+-- New checks can optionally be added, by adding a true/false function (false = fail)
+-- and adding a check to the arming_checks table. 
+--
+-- Thanks to @yuri_rage and Peter Barker for help with the Lua and Autotests
+
+SCRIPT_VERSION = "4.7.0-021"
+SCRIPT_NAME = "Arming Checks"
+SCRIPT_NAME_SHORT = "ArmCk"
+
+REFRESH_DELAY = 500      -- wait this many milliseconds between each update loop (while not armed)
+INITIAL_DELAY = 20000   -- wait 20 seconds for the AP to settle down before starting to show messages
+
+GLOBAL_PARAM_TABLE_BASE = 170
+VALUES_PARAM_TABLE_KEY = GLOBAL_PARAM_TABLE_BASE + 9
+VALUES_PARAM_TABLE_PREFIX = "ARM_V_"
+
+FIRMWARE = {GLOBAL = 0, ROVER = 1, COPTER = 2, PLANE = 3, ANTENNA = 4, SUB = 7, BLIMP = 12, HELI = 13 }
+VEHICLE = {
+    -- these table key comments are so that a grep on PARAM_TABLE_KEY will find all the keys used by this script
+    -- PARAM_TABLE_KEY = 170
+    [FIRMWARE.GLOBAL]   = {prefix = "ARM_", key = GLOBAL_PARAM_TABLE_BASE},
+    -- PARAM_TABLE_KEY = 171
+    [FIRMWARE.ROVER]    = {prefix = "ARM_R_", key = GLOBAL_PARAM_TABLE_BASE + 1},
+    -- PARAM_TABLE_KEY = 172
+    [FIRMWARE.COPTER]   = {prefix = "ARM_C_", key = GLOBAL_PARAM_TABLE_BASE + 2},
+    -- PARAM_TABLE_KEY = 173
+    [FIRMWARE.PLANE]    = {prefix = "ARM_P_", key = GLOBAL_PARAM_TABLE_BASE + 3},
+    -- PARAM_TABLE_KEY = 174
+    [FIRMWARE.ANTENNA]  = {prefix = "ARM_A_", key = GLOBAL_PARAM_TABLE_BASE + 4},
+    -- PARAM_TABLE_KEY = 175
+    [FIRMWARE.BLIMP]    = {prefix = "ARM_B_", key = GLOBAL_PARAM_TABLE_BASE + 5},
+    -- PARAM_TABLE_KEY = 176
+    [FIRMWARE.HELI]     = {prefix = "ARM_H_", key = GLOBAL_PARAM_TABLE_BASE + 6},
+}
+
+MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7, NONE=-1}
+
+MAV_SEVERITY_TEXT = {[MAV_SEVERITY.EMERGENCY]   = "emrg",
+                    [MAV_SEVERITY.ALERT]        = "alrt",
+                    [MAV_SEVERITY.CRITICAL]     = "crit",
+                    [MAV_SEVERITY.ERROR]        = "fail",
+                    [MAV_SEVERITY.WARNING]      = "warn",
+                    [MAV_SEVERITY.NOTICE]       = "note",
+                    [MAV_SEVERITY.INFO]         = "info",
+                    [MAV_SEVERITY.DEBUG]        = "debg",
+                }
+
+PLANE_MODE = { AUTO = 10, TAKEOFF = 13}
+
+-- create parameter table for general/global ARM_ parameters that will be created below. 
+assert(param:add_table(VEHICLE[FIRMWARE.GLOBAL].key, VEHICLE[FIRMWARE.GLOBAL].prefix, 20), string.format('could not add param table: (%d) %s ', VEHICLE[FIRMWARE.GLOBAL].key, VEHICLE[FIRMWARE.GLOBAL].prefix))
+-- create parameter table for ARM_C_ parameters for copter that will be created below. 
+assert(param:add_table(VEHICLE[FIRMWARE.COPTER].key, VEHICLE[FIRMWARE.COPTER].prefix, 10), string.format('could not add param table: (%d) %s ', VEHICLE[FIRMWARE.COPTER].key, VEHICLE[FIRMWARE.COPTER].prefix))
+-- create parameter table for ARM_P_ parameters for plane that will be created below. 
+assert(param:add_table(VEHICLE[FIRMWARE.PLANE].key, VEHICLE[FIRMWARE.PLANE].prefix, 10), string.format('could not add param table: (%d) %s ', VEHICLE[FIRMWARE.PLANE].key, VEHICLE[FIRMWARE.PLANE].prefix))
+
+-- create parameter table for ARM_V_ VALUE parameters which are "reference values" used by the parameter methods
+assert(param:add_table(VALUES_PARAM_TABLE_KEY, VALUES_PARAM_TABLE_PREFIX, 15),  string.format('could not add param table: (%d) %s ', VALUES_PARAM_TABLE_KEY, VALUES_PARAM_TABLE_PREFIX))
+
+local arm_auth_id = arming:get_aux_auth_id()
+if arm_auth_id == nil then
+    gcs:send_text(MAV_SEVERITY.ERROR, string.format("%s %s Failed", SCRIPT_NAME, SCRIPT_VERSION) )
+    gcs:send_text(MAV_SEVERITY.ERROR, string.format("%s: get_aux_auth_id failed", SCRIPT_NAME_SHORT))
+    error(SCRIPT_NAME_SHORT .. ": failed to get arm auth ID")
+    return -- don't execute the script if we can't get an auth_id
+end
+
+----  CLASS: Arming_Check  ----
+local Arming_Check = {}
+Arming_Check.__index = Arming_Check
+
+setmetatable(Arming_Check, {
+    __call = function(cls, firmware, index, func, param_name, text, severity, passed, changed) -- constructor
+        local self      = setmetatable({}, cls)
+        self.firmware   = firmware         -- which firmware type is this check for (0 for general/global)
+        self.index      = index            -- the index of the ardupilot parameter 
+        self.func       = func             -- func() is called to validate arming
+        self.param_name = param_name       -- the name of a ARM_ parameter overriding the severity
+        self.text       = text             -- the message on failure
+        self.severity   = severity         -- is failure a warning or hard stop?
+        self.passed     = passed or nil
+        self.changed    = changed or true
+        return self
+    end
+})
+
+function Arming_Check:state()
+    local passed_new = self.func()
+
+    if self.passed == passed_new then
+        self.changed = false
+    else
+        self.passed = passed_new
+        self.changed = true
+    end
+    return passed_new
+end
+
+-- parameters that store values used by the validation methods, rather than severities of the individual arming checks
+ARM_V_ALT_LEGAL = Parameter()
+local alt_legal_max = 120.0
+
+FENCE_TYPE = Parameter("FENCE_TYPE")
+FENCE_TOTAL = Parameter("FENCE_TOTAL")
+FENCE_ENABLE = Parameter("FENCE_ENABLE")
+FENCE_AUTOENABLE = Parameter("FENCE_AUTOENABLE")
+FOLL_ENABLE = Parameter("FOLL_ENABLE")
+FOLL_SYSID = Parameter("FOLL_SYSID")
+RALLY_LIMIT_KM = Parameter("RALLY_LIMIT_KM")
+
+if FWVersion:type() == FIRMWARE.COPTER then -- Copter specific paramters
+    RTL_ALT = Parameter("RTL_ALT")
+elseif FWVersion:type() == FIRMWARE.PLANE then -- Plane specific Parameters
+    RTL_ALTITUDE = Parameter("RTL_ALTITUDE")
+    RTL_CLIMB_MIN = Parameter("RTL_CLIMB_MIN")
+    Q_ENABLE = Parameter("Q_ENABLE")
+    AIRSPEED_STALL = Parameter("AIRSPEED_STALL")
+    AIRSPEED_MIN = Parameter("AIRSPEED_MIN")
+    AIRSPEED_CRUISE = Parameter("AIRSPEED_CRUISE")
+    AIRSPEED_MAX = Parameter("AIRSPEED_MAX")
+    SCALING_SPEED = Parameter("SCALING_SPEED")
+end
+
+-- this is the pre 4.7 name for the SYSID parameter
+---@diagnostic disable-next-line:lowercase-global
+function try_sysid_thismav()
+    MAV_SYSID = Parameter("SYSID_THISMAV")
+end
+if not pcall(try_sysid_thismav) then
+    MAV_SYSID = Parameter("MAV_SYSID")
+end
+
+local validate      -- forward definition of the validate() function
+
+-- check that the MAVLink SYSID has been set for this vehicle
+local function sysid_set()
+    local mav_sysid = MAV_SYSID:get()
+
+    if mav_sysid == nil or mav_sysid <= 1 then
+        return false
+    end
+    return true
+end
+
+-- check that if Follow is enabled, the FOLL_SYSID is set
+local function foll_sysid_set()
+    local foll_enable = FOLL_ENABLE:get()
+    if foll_enable ~= 1 then
+        return true
+    end
+    local foll_sysid = FOLL_SYSID:get()
+    if foll_sysid == 0 then
+        return false
+    end
+    return true
+end
+
+-- check that if the FOLL_SYSID is set it's not pointing to itself (the test returns true if "good" - hence the _not_)
+local function foll_sysid_not_thismav()
+    local foll_enable = FOLL_ENABLE:get()
+    if foll_enable ~= 1 then
+        return true
+    end
+    local mav_sysid = MAV_SYSID:get()
+    local foll_sysid = FOLL_SYSID:get()
+    if foll_sysid > 0 and mav_sysid == foll_sysid then
+        return false
+    end
+    return true
+end
+
+-- if FOLLOW is enabled make sure the XYZ offsets have been set
+local function foll_ofs_default()
+    local foll_enable = FOLL_ENABLE:get()
+    if foll_enable ~= 1 then
+        return true
+    end
+    local foll_ofs_x = Parameter("FOLL_OFS_X"):get()
+    local foll_ofs_y = Parameter("FOLL_OFS_Y"):get()
+    local foll_ofs_z = Parameter("FOLL_OFS_Z"):get()
+    if foll_ofs_x == 0 and foll_ofs_y == 0 and foll_ofs_z == 0 then
+        return false
+    end
+    return true
+end
+
+-- for many use cases if MNTx_SYSID_DEFLT is set is should match the FOLL_SYSID (remember set ARM_MNTX_SYSID severity to NONE to disable this check)
+local function mntx_sysid_match()
+    local foll_enable = FOLL_ENABLE:get()
+    local mnt1_enable = (Parameter("MNT1_TYPE"):get() ~= 0)
+    local mnt2_enable = (Parameter("MNT2_TYPE"):get() ~= 0)
+
+    if foll_enable ~= 1 then
+        return true
+    end
+    local foll_sysid = FOLL_SYSID:get()
+    if mnt1_enable then
+        local mnt1_sysid = Parameter("MNT1_SYSID_DFLT"):get()
+        if mnt1_sysid > 0 and foll_sysid ~= mnt1_sysid then
+            return false
+        end
+    end
+    if mnt2_enable then
+        local mnt2_sysid = Parameter("MNT2_SYSID_DFLT"):get()
+        if mnt2_sysid > 0 and foll_sysid ~= mnt2_sysid then
+            return false
+        end
+    end
+    return true
+end
+
+-- is the RTL altitude legal? This defaults to 120m (400') as set in ARM_ALT_LEGAL
+local function rtl_altitude_legal()
+    -- plane uses RTL_ALTITUDE in m
+    -- RTL_ALTITUDE will be correct for either plane or copter
+    if (RTL_ALTITUDE ~= nil and (RTL_ALTITUDE:get()) > alt_legal_max) then
+        return false
+    end
+    return true
+end
+
+-- is the Q RTL altitude (quadplane) legal? This defaults to 120m (400') as set in ARM_ALT_LEGAL
+local function q_rtl_alt_legal()
+    -- Plane specific Parameters
+    if Q_ENABLE:get() ~= 1 then
+        return true
+    end
+    -- QuadPlane specific Paraemters
+    local q_rtl_alt = Parameter("Q_RTL_ALT"):get()
+    if q_rtl_alt > alt_legal_max then
+        return false
+    end
+    return true
+end
+
+-- is the RTL climb minimum legal? This defaults to 120m (400')
+local function rtl_climb_legal()
+    if (RTL_CLIMB_MIN ~= nil) and (RTL_CLIMB_MIN:get() > alt_legal_max) then
+        return false
+    end
+    return true
+end
+
+-- Display a message as to whether failsafe will QLand or QRTL
+local function qland_warning()
+    if Q_ENABLE:get() ~= 1 then
+        return true
+    end
+    -- Only applies to QuadPlane
+    local q_options = Parameter("Q_OPTIONS"):get()
+    local q_land_option = ((q_options & (1 << 5)) > 0)
+    local q_RTL_option = ((q_options & (1 << 20)) > 0)
+
+    if (not q_land_option) and (not q_RTL_option) then
+        return false
+    end
+    return true -- always ok if not a QuadPlane
+end
+local function qrtl_warning()
+    if Q_ENABLE:get() ~= 1 then
+        return true -- always ok if not a QuadPlane
+    end
+    local q_options = Parameter("Q_OPTIONS"):get()
+    local q_land_option = ((q_options & (1 << 5)) > 0)
+    local q_RTL_option = ((q_options & (1 << 20)) > 0)
+    if q_land_option or q_RTL_option then
+        return false
+    end
+    return true
+end
+
+-- A single check to ensure AIRSPEED_STALL < AIRSPEED_MIN < AIRSPEED_CRUISE < AIRSPEED_MAX
+local function airspeed_check()
+    local airspeed_stall = AIRSPEED_STALL:get()
+    local airspeed_min = AIRSPEED_MIN:get()
+    local airspeed_cruise = AIRSPEED_CRUISE:get()
+    local airspeed_max = AIRSPEED_MAX:get()
+
+    if airspeed_stall > 0 then
+        if airspeed_min < airspeed_stall then
+            return false
+        end
+    end
+    if airspeed_cruise < airspeed_min then
+        return false
+    end
+    if airspeed_max < airspeed_cruise then
+        return false
+    end
+    return true
+end
+
+-- If AIRSPEED_STALL is set AIRSPEED_MIN should be at least 25% higher than AIRSPEED_STALL
+local function stallspeed_check()
+    local airspeed_stall = AIRSPEED_STALL:get()
+    local airspeed_min = AIRSPEED_MIN:get()
+
+    if airspeed_stall > 0 then
+        if airspeed_min > (airspeed_stall * 1.25) then
+            return false
+        end
+    end
+
+    return true
+end
+
+-- From the wiki: This is the center of the speed scaling range and should be set close to the normal cruising speed of the vehicle.
+local function scaling_speed_check()
+    local scaling_speed = SCALING_SPEED:get()
+    local airspeed_cruise = AIRSPEED_CRUISE:get()
+    if scaling_speed <= 0 or airspeed_cruise <= 0 then
+        return false
+    end
+    -- use a 20% range for "close"
+    if scaling_speed < (airspeed_cruise * 0.8) or scaling_speed > (airspeed_cruise * 1.2) then
+        return false
+    end
+    -- if either are not set then
+    return true
+end
+
+-- want to be notified if motors are emergency stopped or not
+local function motors_emergency_stopped()
+    return not SRV_Channels:get_emergency_stop()
+end
+
+-- Logic provided by Peter Barker 
+-- Fences present if 
+-- a. there are basic fences (assume this includes min(8)/max(1) and home circle(2) fences) or 
+-- b. there are polygon_fences (fence type bit 2 = 4) with at least one side 
+local function fence_present()
+    local enabled_fences = FENCE_TYPE:get()
+    local basic_fence = (enabled_fences & (8+2+1)) ~= 0
+    local polygon_fence = ((enabled_fences & 4) ~= 0) and FENCE_TOTAL:get() > 0
+    return basic_fence or polygon_fence
+end
+
+-- check if any rally point is too far away aka further than RALLY_LIMIT_KM away from home
+local function rally_ok()
+    if rally == nil then
+        return true -- rally library not loaded so we pass
+    end
+    local home_location = ahrs:get_home()
+    local rally_distance_max_m = RALLY_LIMIT_KM:get() * 1000.0
+    if rally_distance_max_m <= 0 then
+        return true
+    end
+
+    local i = 0
+    repeat
+        local rally_location = rally:get_rally_location(i)
+        if rally_location then
+            local rally_distance_m = home_location:get_distance(rally_location)
+            if rally_distance_m > rally_distance_max_m then
+                return false
+            end
+        end
+        i = i + 1
+    until rally_location == nil
+
+    return true
+end
+
+-- fail if there is a fence on the board, it must be enabled
+local function geofence_present_enabled()
+    if not fence_present() then
+        return true
+    end
+    if (FENCE_ENABLE:get() == 1) or (FENCE_AUTOENABLE:get() > 0) then
+        return true
+    end
+    return false
+end
+
+-- Arming checks can be deleted if not required, or set the parameter to MAV_SEVERITY.NONE to avoid changing the script
+-- or new arming checks added. The position/number of the check should not be changed. If you delete a check, do not renumber the rest.
+-- First add checks that can apply to all vehicles.
+local arming_checks = {}
+
+--[[
+    // @Param: ARM_SYSID
+    // @DisplayName: MAV_SYSID must be set
+    // @Description: Check that MAV_SYSID (or SYDID_THISMAV) has been set. 3 or less to prevent arming. -1 to disable.
+    // @Values: -1:Disabled,0:Emergency(PreArm),1:Alert(PreArm),2:Critical(PreArm),3:Error(PreArm),4:Warning,5:Notice,6:Info,7:Debug
+    // @User: Standard
+--]]
+    table.insert(arming_checks, Arming_Check(FIRMWARE.GLOBAL, 1,
+                    sysid_set, "SYSID", "MAV_SYSID not set", MAV_SEVERITY.WARNING, false, false))
+--[[
+    // @Param: ARM_FOLL_SYSID
+    // @DisplayName: FOLL_SYSID must be set 
+    // @Description: If FOLL_ENABLE = 1, check that FOLL_SYSID has been set. 3 or less to prevent arming. -1 to disable.
+    // @Values: -1:Disabled,0:Emergency(PreArm),1:Alert(PreArm),2:Critical(PreArm),3:Error(PreArm),4:Warning,5:Notice,6:Info,7:Debug
+    // @User: Standard
+--]]
+    table.insert(arming_checks, Arming_Check(FIRMWARE.GLOBAL, 2,
+                    foll_sysid_set, "FOLL_SYSID", "FOLL_SYSID not set", MAV_SEVERITY.ERROR, true, false ))
+--[[
+    // @Param: ARM_FOLL_SYSID_X
+    // @DisplayName: Vehicle should not follow itself
+    // @Description: If FOLL_ENABLE = 1, check that FOLL_SYSID is different to MAV_SYSID. 3 or less to prevent arming. -1 to disable.
+    // @Values: -1:Disabled,0:Emergency(PreArm),1:Alert(PreArm),2:Critical(PreArm),3:Error(PreArm),4:Warning,5:Notice,6:Info,7:Debug
+    // @User: Standard
+--]]
+    table.insert(arming_checks, Arming_Check(FIRMWARE.GLOBAL, 3,
+                    foll_sysid_not_thismav, "FOLL_SYSID_X", "FOLL_SYSID == MAV_SYSID", MAV_SEVERITY.ERROR, true, false))
+--[[
+    // @Param: ARM_FOLL_OFS_DEF
+    // @DisplayName: Follow Offsets defaulted
+    // @Description: Follow offsets should not be left as default (zero) if FOLL_ENABLE = 1. 3 or less to prevent arming. -1 to disable.
+    // @Values: -1:Disabled,0:Emergency(PreArm),1:Alert(PreArm),2:Critical(PreArm),3:Error(PreArm),4:Warning,5:Notice,6:Info,7:Debug
+    // @User: Standard
+--]]
+    table.insert(arming_checks, Arming_Check(FIRMWARE.GLOBAL, 4,
+                    foll_ofs_default, "FOLL_OFS_DEF", "FOLL_OFS_[XYZ] = 0", MAV_SEVERITY.ERROR, true, false))
+--[[
+    // @Param: ARM_MNTX_SYSID
+    // @DisplayName: Follow and Mount should follow the same vehicle
+    // @Description: If FOLL_ENABLE = 1 and MNTx_SYSID_DEFLT is set, check that FOLL_SYSID is equal MNTx. 3 or less to prevent arming. -1 to disable.
+    // @Values: -1:Disabled,0:Emergency(PreArm),1:Alert(PreArm),2:Critical(PreArm),3:Error(PreArm),4:Warning,5:Notice,6:Info,7:Debug
+    // @User: Standard
+--]]
+    table.insert(arming_checks, Arming_Check(FIRMWARE.GLOBAL, 5,
+                    mntx_sysid_match, "MNTX_SYSID", "MNTx_SYSID != FOLL", MAV_SEVERITY.WARNING, true, false))
+--[[
+    // @Param: ARM_RTL_CLIMB
+    // @DisplayName: RTL_CLIMB_MIN should be a valid value
+    // @Description: RTL_CLIMB_MIN should be < 120m (400ft). 3 or less to prevent arming. -1 to disable.
+    // @Values: -1:Disabled,0:Emergency(PreArm),1:Alert(PreArm),2:Critical(PreArm),3:Error(PreArm),4:Warning,5:Notice,6:Info,7:Debug
+    // @User: Standard
+--]]
+    table.insert(arming_checks, Arming_Check(FIRMWARE.GLOBAL, 6,
+                    rtl_climb_legal, "RTL_CLIMB", "RTL_CLIMB_MIN too high", MAV_SEVERITY.WARNING, true, false))
+--[[
+// @Param: ARM_ESTOP
+// @DisplayName: Motors EStopped
+// @Description: Emergency Stop disables arming. 3 or less to prevent arming. -1 to disable.
+// @Values: -1:Disabled,0:Emergency(PreArm),1:Alert(PreArm),2:Critical(PreArm),3:Error(PreArm),4:Warning,5:Notice,6:Info,7:Debug
+// @User: Standard
+--]]
+    table.insert(arming_checks, Arming_Check(FIRMWARE.GLOBAL, 7,
+                    motors_emergency_stopped, "ESTOP", "Motors EStopped", MAV_SEVERITY.ERROR, true, false))
+--[[
+// @Param: ARM_FENCE
+// @DisplayName: Fence not enabled
+// @Description: Fences loaded but no fence enabled. 3 or less to prevent arming. -1 to disable.
+// @Values: -1:Disabled,0:Emergency(PreArm),1:Alert(PreArm),2:Critical(PreArm),3:Error(PreArm),4:Warning,5:Notice,6:Info,7:Debug
+// @User: Standard
+--]]
+    table.insert(arming_checks, Arming_Check(FIRMWARE.GLOBAL, 8,
+                    geofence_present_enabled, "FENCE", "Fence not enabled", MAV_SEVERITY.WARNING, true, false))
+--[[
+// @Param: ARM_RALLY
+// @DisplayName: Rally too far
+// @Description: Rally Point more than RALLY_LIMIT_KM kilometers away. 3 or less to prevent arming. -1 to disable.
+// @Values: -1:Disabled,0:Emergency(PreArm),1:Alert(PreArm),2:Critical(PreArm),3:Error(PreArm),4:Warning,5:Notice,6:Info,7:Debug
+// @User: Standard
+--]]
+    table.insert(arming_checks, Arming_Check(FIRMWARE.GLOBAL, 9,
+                    rally_ok, "RALLY", "Rally too far", MAV_SEVERITY.WARNING, true, false))
+
+-- ArduCopter specific checks. Note that the index number starts from 1 for FIRMWARE.COPTER (ARM_C_ parameters)
+if FWVersion:type() == FIRMWARE.COPTER then -- add Copter specific Parameters
+--[[
+    // @Param: ARM_C_RTL_ALT
+    // @DisplayName: RTL_ALT should be a valid value
+    // @Description: RTL_ALT should be < 120m (400ft). 3 or less to prevent arming. -1 to disable.
+    // @Values: -1:Disabled,0:Emergency(PreArm),1:Alert(PreArm),2:Critical(PreArm),3:Error(PreArm),4:Warning,5:Notice,6:Info,7:Debug
+    // @User: Standard
+--]]
+    table.insert(arming_checks, Arming_Check(FIRMWARE.COPTER, 1,
+                    rtl_altitude_legal, "RTL_ALT", "RTL_AL too high", MAV_SEVERITY.ERROR, false, false))
+elseif FWVersion:type() == FIRMWARE.PLANE then -- add Plane specific Parameters
+-- ArduPlane specific checks. Note that the index number starts from 1 for FIRMWARE.PLANE (ARM_P_ parameters)
+--[[
+    // @Param: ARM_P_Q_FS_LAND
+    // @DisplayName: Warn if Q failsafe will land
+    // @Description: Notify the user that on failsafe a QuadPlan will land. 3 or less to prevent arming. -1 to disable.
+    // @Values: -1:Disabled,0:Emergency(PreArm),1:Alert(PreArm),2:Critical(PreArm),3:Error(PreArm),4:Warning,5:Notice,6:Info,7:Debug
+    // @User: Standard
+--]]
+    table.insert(arming_checks, Arming_Check(FIRMWARE.PLANE, 1,
+                    qland_warning, "Q_FS_LAND", "Q will land on failsafe", MAV_SEVERITY.NOTICE, true, false))
+--[[
+    // @Param: ARM_P_Q_FS_RTL
+    // @DisplayName: Warn if Q failsafe will QRTL
+    // @Description: Notify the user that on failsafe a QuadPlan will QRTL. 3 or less to prevent arming. -1 to disable.
+    // @Values: -1:Disabled,0:Emergency(PreArm),1:Alert(PreArm),2:Critical(PreArm),3:Error(PreArm),4:Warning,5:Notice,6:Info,7:Debug
+    // @User: Standard
+--]]
+    table.insert(arming_checks, Arming_Check(FIRMWARE.PLANE, 2,
+                    qrtl_warning, "Q_FS_RTL", "Q will RTL on failsafe", MAV_SEVERITY.NOTICE, true, false))
+--[[
+    // @Param: ARM_P_AIRSPEED
+    // @DisplayName: Check AIRSPEED_ parameters
+    // @Description: Validate that AIRSPEED_STALL(if set) < MIN < CRUISE < MAX d. 3 or less to prevent arming. -1 to disable.
+    // @Values: -1:Disabled,0:Emergency(PreArm),1:Alert(PreArm),2:Critical(PreArm),3:Error(PreArm),4:Warning,5:Notice,6:Info,7:Debug
+    // @User: Standard
+--]]
+    table.insert(arming_checks, Arming_Check(FIRMWARE.PLANE, 3,
+                    airspeed_check, "AIRSPEED", "stall < min < crs < max", MAV_SEVERITY.ERROR, true, false))
+--[[
+    // @Param: ARM_P_STALL
+    // @DisplayName: AIRSPEED_MIN should be 25% above STALL
+    // @Description: Validate that AIRSPEED_MIN is at least 25% above AIRSPEED_STALL(if set). 3 or less to prevent arming. -1 to disable.
+    // @Values: -1:Disabled,0:Emergency(PreArm),1:Alert(PreArm),2:Critical(PreArm),3:Error(PreArm),4:Warning,5:Notice,6:Info,7:Debug
+    // @User: Standard
+--]]
+    table.insert(arming_checks, Arming_Check(FIRMWARE.PLANE, 4,
+                    stallspeed_check, "STALL", "Min speed not 25% above stall", MAV_SEVERITY.INFO, true, false))
+--[[
+    // @Param: ARM_P_SCALING
+    // @DisplayName: SCALING_SPEED valid
+    // @Description: Validate that SCALING_SPEED is within 20% of AIRSPEED_CRUISE. If SCALING_SPEED changes the vehicle may need to be retuned. 3 or less to prevent arming. -1 to disable.
+    // @Values: -1:Disabled,0:Emergency(PreArm),1:Alert(PreArm),2:Critical(PreArm),3:Error(PreArm),4:Warning,5:Notice,6:Info,7:Debug
+    // @User: Standard
+--]]
+    table.insert(arming_checks, Arming_Check(FIRMWARE.PLANE, 5,
+                    scaling_speed_check, "SCALING", "Scaling spd >< 20% of CRUISE", MAV_SEVERITY.ERROR, true, false))
+--[[
+    // @Param: ARM_P_RTL_ALT
+    // @DisplayName: RTL_ALTITUDE should be a valid value
+    // @Description: RTL_ALTITITUDE should be < 120m (400ft). 3 or less to prevent arming. -1 to disable.
+    // @Values: -1:Disabled,0:Emergency(PreArm),1:Alert(PreArm),2:Critical(PreArm),3:Error(PreArm),4:Warning,5:Notice,6:Info,7:Debug
+    // @User: Standard
+--]]
+    table.insert(arming_checks, Arming_Check(FIRMWARE.PLANE, 6,
+                    rtl_altitude_legal, "RTL_ALT", "RTL_ALTITUDE too high", MAV_SEVERITY.ERROR, false, false))
+--[[
+    // @Param: ARM_P_QRTL_ALT
+    // @DisplayName: Q_RTL_ALT should be a valid value
+    // @Description: Q_RTL_ALT should be < 120m (400ft). 3 or less to prevent arming. -1 to disable.
+    // @Values: -1:Disabled,0:Emergency(PreArm),1:Alert(PreArm),2:Critical(PreArm),3:Error(PreArm),4:Warning,5:Notice,6:Info,7:Debug
+    // @User: Standard
+--]]
+    table.insert(arming_checks, Arming_Check(FIRMWARE.PLANE, 7,
+                    q_rtl_alt_legal, "QRTL_ALT", "Q_RTL_ALT too high", MAV_SEVERITY.ERROR, false, false))
+end
+
+-- No need to actively check while armed.
+local function idle_while_armed()
+    if not arming:is_armed() then return validate, REFRESH_DELAY end
+    return idle_while_armed, REFRESH_DELAY * 20
+end
+
+-- initialize all the parameters based on the data in the arming_checks table
+local function initialize()
+-- special case for the ARV_ALT_LEGAL parameter which ideally should be a "regular" parameter
+--[[
+    // @Param: ARM_V_ALT_LEGAL
+    // @DisplayName: Legal max altitude
+    // @Description: Legal max altitude for UAV/RPAS/drones in your jurisdiction
+    // @Units: m
+    // @User: Standard
+--]]
+    assert(param:add_param(VALUES_PARAM_TABLE_KEY, 1, "ALT_LEGAL", 120.0),
+                        string.format('could not add param %s', VALUES_PARAM_TABLE_PREFIX.."ALT_LEGAL"))
+    ARM_V_ALT_LEGAL:init("ARM_V_ALT_LEGAL")
+
+    for _, check in ipairs(arming_checks) do
+        local param_name = VEHICLE[check.firmware].prefix..check.param_name
+
+        assert(param:add_param(VEHICLE[check.firmware].key , check.index, check.param_name, check.severity),
+                        string.format('could not add param %s', param_name))
+    end
+end
+
+-- run an indivual check
+local function run_check(check, severity, validated)
+    local check_passed = check:state() -- sets check.passed and check.changed
+    local raise_prearm = not check_passed
+
+    if check.changed then
+        if check_passed then
+            -- it's passed now, but changed, so previously failed. Let the user know its all clear
+            gcs:send_text(MAV_SEVERITY.INFO, string.format('%s: clear: %s', SCRIPT_NAME_SHORT, check.text))
+        elseif severity > MAV_SEVERITY.ERROR then
+            -- deal with warning messages (MAV_SEVERITY > ERROR), we display a message but no prearm
+            gcs:send_text(severity, string.format('%s: %s: %s', SCRIPT_NAME_SHORT,
+                            MAV_SEVERITY_TEXT[severity], check.text))
+            -- display the message, but this should not block arming so is actually "passed"
+            raise_prearm = false
+        end
+    elseif not check_passed and severity > MAV_SEVERITY.ERROR then
+        -- if nothing changed we only want to fail on errors
+        raise_prearm = false
+    end
+    if raise_prearm then
+        validated = false
+        arming:set_aux_auth_failed(arm_auth_id, string.format('%s: %s: %s', SCRIPT_NAME_SHORT,
+                                    MAV_SEVERITY_TEXT[severity], check.text))
+    end
+    return validated
+end
+
+validate = function() -- this is the loop which periodically runs to do the validations
+
+    if arming:is_armed() then return idle_while_armed() end
+
+    alt_legal_max = ARM_V_ALT_LEGAL:get() or 120.0  -- used Parameter():init() to initialize this one.
+    local validated = true
+
+    for _, check in ipairs(arming_checks) do
+        local param_name = VEHICLE[check.firmware].prefix..check.param_name
+        local parameter = Parameter(param_name)
+        local param_severity  = parameter:get()
+        if param_severity ~= MAV_SEVERITY.NONE then -- ignore if NONE
+            validated = run_check(check, param_severity, validated)
+        end
+    end
+
+    if validated then
+        arming:set_aux_auth_passed(arm_auth_id)
+    end
+
+    return validate, REFRESH_DELAY
+end
+
+local function delayed_startup()
+    gcs:send_text(MAV_SEVERITY.INFO, string.format("%s %s loaded", SCRIPT_NAME, SCRIPT_VERSION) )
+    return validate, REFRESH_DELAY
+end
+
+initialize()
+-- start running update loop - waiting 20s for the AP to initialize so we don't spam the user with spurios notices
+return delayed_startup, INITIAL_DELAY

--- a/libraries/AP_Scripting/applets/arming-checks.md
+++ b/libraries/AP_Scripting/applets/arming-checks.md
@@ -1,0 +1,99 @@
+# arming-checks
+
+This script implements user defined pre-arm and arming checks. Checks
+can be warnings or errors. Warnings don't prevent arming but will display
+on the ground station, whereas errors will prevent arming.
+
+Additional arming checks can be added by adding a method that returns true/false (true = arming ok), and defining the check, including the parameter it uses in the method arming_checks().
+
+# Parameters
+
+There is a single parameter defined for each arming check. The error or warning level can be changed for each arming check by setting the MAV_SEVERITY of the arming check. An arming check can be disabled by setting the parameter value to MAV_SEVERITY.NONE or -1.
+
+All arming check parameters are prefixed with ARM_. Copter specific checks are prefexed with ARM_C_, Plane specific checks are prefixed with ARM_P_, Rover specific checks are prefixed with ARM_R_, Blimp specific checks are prefixed with ARM_B_, Antenna Tracker specific checks are prefixe with ARM_A_, TradHeli specific checks are prefixed with ARM_H_.
+
+# Generic checks
+
+These checks apply to all firmware types
+
+# ARM_SYSID
+
+If the SYSID_THISMAV parameter has not been changed from it's default value of 1, this arming check will prevent arming. This is intended to be used in large fleets, were SYSID_THISMAV should always be set. 
+
+# ARM_FOLL_SYSID_X
+
+If the FOLL_SYSID parameter has not been changed from it's default value of 0, this arming check will prevent arming. This is intended to be used in large fleets flying in swarms, were FOLL_SYSID should almost always be set. 
+# ARM_FOLL_OFS_DEF
+
+Follow offsets should not be left as the default (0). If using the Follow library, leaving the follow offsets at zero will 
+mean the follow vehicle will attempt to fly to where the target is, which would likely cause a crash. 
+
+# ARM_MNTX_SYSID
+
+If the MNTX_SYSID parameter does not match the FOLL_SYSID, this arming check will prevent arming. This is intended to be used in large fleets flying in swarms, were the camera mount should always be pointing to the vehicle being followed. 
+
+
+# ARM_RTL_CLIMB
+
+This check is to by default warn if the vehicle RTL_CLIMB has not been set. This is intended to be an example of how specific configuration checks could be added for specific requirements without having to change the firmware. 
+
+# ARM_ESTOP
+
+This check will fail if the motors are emergency stopped. The standard pre-arm will not prevent arming if the emergency stop
+has been set by a switch (set using RCx_OPTION = 165). This check will prevent arming regardless of the reason for the EStop. 
+
+# ARM_FENCE
+
+If fences are loaded but no fence is enabled this will prevent arming. 
+
+# ARM_RALLY
+
+If there is a rally point more than RALLY_LIMIT_KM kilometers from the home location, this will prevent arming..T
+
+# Copter specific checks
+
+The following checks only apply if the firmware is ArduCopter
+
+# ARM_C_RTL_ALT
+
+This check is to by default warn if the vehicle RTL_ALT has been set to a value > ARM_V_ALT_LEGAL. 
+
+# Plane specific checks
+
+The following checks only apply if the firmware is ArduPlane
+
+# ARM_P_RTL_ALT
+
+This check is to by default warn if RTL_ALTITUDE > ARM_V_ALT_LEGAL which defaults to 120m (400ft) which is the legal limit in many jurisdictions. This is intended to be an example of how specific configuration checks could be added for specific requirements without having to change the firmware.
+
+# ARM_P_QRTL_ALT
+
+This check is to by default warn if Q_RTL_ALT > ARM_V_ALT_LEGAL which defaults to 120m (400ft) which is the legal limit in many jurisdictions. This is intended to be an example of how specific configuration checks could be added for specific requirements without having to change the firmware.
+
+# ARM_P_Q_FS_LAND and ARM_P_Q_FS_RTL
+
+These two checks are to display important configuration information for a vehicle at boot time. One of these checks should be displayed. Neither is an error. This is to demonstrate how to notify the pilot of important configuration information at boot time without preventing flying.
+
+# ARM_P_AIRSPEED
+
+The values of AIRSPEED_STALL (optional) should be less than AIRSPEED_MIN which should be less than AIRSPEED_CRUISE
+which should be less than AIRSPEED_MAX. This validates that this rule has not been broken.
+
+# ARM_P_STALL
+
+AIRSPEED_STALL is a newly added and optional value, but if set, AIRSPEED_MIN should not be more than 25% higher 
+than AIRSPEED_STALL. When looked at the other way round, AIRSPEED_STALL should not be more than 20% lower than
+AIRSPEED_MIN. 
+
+# ARM_P_SCALING
+
+The SCALING_SPEED should be close to AIRSPEED_CRUISE. Its quite easy to remember to set AIRSPEED_CRUISE correctly
+when setting up an aircraft, but not to reset SCALING_SPEED. The aircraft should be retuned if SCALING_SPEED is changed. The airThis gives a warning if the values are very different.
+
+# Operation
+
+Copy this file to the APM/scripts folder on your SD card and make sure 
+
+SCR_ENABLE = 1
+
+Edit the arming_checks table if you want to change any of the checks from warnings to errors or errors to warnings or delete the row if you want to remove the check completely.

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -4007,6 +4007,18 @@ function fence:get_margin_breaches() end
 ---@return number -- distance
 function fence:get_breach_distance(fence_type) end
 
+-- Rally library
+rally = {}
+
+-- Returns the count of the number of Rally points
+---@return integer
+function rally:get_rally_total() end
+
+-- Returns a specfic rally by index as a Location (i.e NOT as a RallyLocation, a regular Location)
+---@param index integer
+---@return Location_ud|nil
+function rally:get_rally_location_with_index(index) end
+
 -- desc
 ---@class (exact) stat_t_ud
 local stat_t_ud = {}

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -4009,15 +4009,10 @@ function fence:get_breach_distance(fence_type) end
 
 -- Rally library
 rally = {}
-
--- Returns the count of the number of Rally points
----@return integer
-function rally:get_rally_total() end
-
--- Returns a specfic rally by index as a Location (i.e NOT as a RallyLocation, a regular Location)
----@param index integer
+-- Returns a specfic rally by index as a Location 
+---@param index integer -- 0 indexed
 ---@return Location_ud|nil
-function rally:get_rally_location_with_index(index) end
+function rally:get_rally_location(index) end
 
 -- desc
 ---@class (exact) stat_t_ud

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -1047,6 +1047,13 @@ singleton AC_Fence method get_margin_breaches uint8_t
 singleton AC_Fence method get_margin_breach_time uint32_t
 singleton AC_Fence method get_breach_distance float uint8_t'skip_check
 
+include AP_Rally/AP_Rally.h depends HAL_RALLY_ENABLED
+
+singleton AP_Rally depends HAL_RALLY_ENABLED
+singleton AP_Rally rename rally
+singleton AP_Rally method get_rally_location_with_index boolean uint8_t'skip_check Location'Null
+singleton AP_Rally method get_rally_location_with_index rename get_rally_location
+
 include AP_Filesystem/AP_Filesystem.h depends AP_FILESYSTEM_FILE_READING_ENABLED
 include AP_Filesystem/AP_Filesystem_config.h
 userdata AP_Filesystem::stat_t depends AP_FILESYSTEM_FILE_READING_ENABLED


### PR DESCRIPTION
This adds a Lua Applet for scripted arming checks. Each check can be set as mandatory (generates a prearm fail), warning (displays a message, but allows arming) or disabled by setting a parameter.

There is a set of standard checks that I find useful, of course new ones can be added. Any suggestions appreciated. I've just added a check for Rally Point further than RALLY_LIMIT_KM from the home location.

This is designed to get around the controversy that often arises about adding arming checks to c++. To some people particular checks are essential, while to others they are unnecessary or annoying. 

This works for plane, copter and rover for now, but as a base could easily be extended to other vehicles.