### PR TITLE
Don't erase flash with single ECC errors and only erase checked flash

### DIFF
--- a/Tools/AP_Bootloader/support.h
+++ b/Tools/AP_Bootloader/support.h
@@ -6,7 +6,7 @@
 #define LED_BOOTLOADER	2
 
 #ifndef AP_FLASH_ECC_CHECK_ENABLED
-#define AP_FLASH_ECC_CHECK_ENABLED defined(STM32H7) && CH_CFG_USE_HEAP && !defined(STORAGE_FLASH_START_PAGE)
+#define AP_FLASH_ECC_CHECK_ENABLED defined(STM32H7) && CH_CFG_USE_HEAP
 #endif
 
 /* board info forwarded from board-specific code to booloader */

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/flash.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/flash.c
@@ -455,9 +455,11 @@ static uint32_t last_erase_ms;
 #if defined(STM32H7)
 
 /*
-    corrupt a flash to trigger ECC fault
+    Corrupt flash to trigger ECC fault.
+    If double_bit is false, generate a single-bit error (correctable).
+    If double_bit is true, generate a double-bit error (uncorrectable).
 */
-void stm32_flash_corrupt(uint32_t addr)
+void stm32_flash_corrupt(uint32_t addr, bool double_bit)
 {
     stm32_flash_unlock();
 
@@ -476,11 +478,12 @@ void stm32_flash_corrupt(uint32_t addr)
     *CCR = ~0;
     *CR |= FLASH_CR_PG;
 
-    for (uint32_t i=0; i<2; i++) {
-        while (*SR & (FLASH_SR_BSY|FLASH_SR_QW)) ;
-        putreg32(0xAAAA5555, addr);
+    const uint32_t pattern1 = double_bit? 0xAAAAAAAA : 0xAAAA5555;
+    const uint32_t pattern2 = double_bit? 0xAAAAAAA9 : 0x5555AAAA;
+    for (uint32_t i = 0; i < 2; i++) {
+        while (*SR & (FLASH_SR_BSY | FLASH_SR_QW)) ;
+        putreg32(pattern1, addr);
         if (*SR & FLASH_SR_INCERR) {
-            // clear the error
             *SR &= ~FLASH_SR_INCERR;
         }
         addr += 4;
@@ -489,11 +492,10 @@ void stm32_flash_corrupt(uint32_t addr)
     *CR |= FLASH_CR_FW;  // force write
     stm32_flash_wait_idle();
 
-    for (uint32_t i=0; i<2; i++) {
-        while (*SR & (FLASH_SR_BSY|FLASH_SR_QW)) ;
-        putreg32(0x5555AAAA, addr);
+    for (uint32_t i = 0; i < 2; i++) {
+        while (*SR & (FLASH_SR_BSY | FLASH_SR_QW)) ;
+        putreg32(pattern2, addr);  // overwrite previous location
         if (*SR & FLASH_SR_INCERR) {
-            // clear the error
             *SR &= ~FLASH_SR_INCERR;
         }
         addr += 4;
@@ -509,7 +511,7 @@ void stm32_flash_corrupt(uint32_t addr)
 
     stm32_flash_lock();
 }
-#endif
+#endif // STM32H7
 
 /*
   erase a page

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/flash.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/flash.h
@@ -31,7 +31,7 @@ void stm32_flash_protect_flash(bool bootloader, bool protect);
 void stm32_flash_unprotect_flash(void);
 void stm32_flash_set_NRST_MODE(uint8_t nrst_mode);
 #if defined(STM32H7)
-void stm32_flash_corrupt(uint32_t addr);
+void stm32_flash_corrupt(uint32_t addr, bool double_bit);
 #endif
 #ifndef HAL_BOOTLOADER_BUILD
 bool stm32_flash_recent_erase(void);


### PR DESCRIPTION
Two different bugs here:
- Single ECC errors are not fatal and can occur fairly frequently. There is no need to erase the flash.
- We were checking the *whole* of flash but then only erasing the flash image if there was a problem, so if you had a problem in parameter storage the cure was worse than the disease.