### PR TITLE
ChibiOS: UARTDriver: init dma buffer

### DIFF
--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -107,6 +107,9 @@ _baudrate(57600)
 {
     osalDbgAssert(serial_num < UART_MAX_DRIVERS, "too many SERIALn drivers");
     serial_drivers[serial_num] = this;
+    rx_bounce_buf[0] = nullptr;
+    rx_bounce_buf[1] = nullptr;
+    tx_bounce_buf = nullptr;
 }
 
 /*
@@ -331,6 +334,12 @@ void UARTDriver::_begin(uint32_t b, uint16_t rxS, uint16_t txS)
     } else {
         rx_dma_enabled = rx_bounce_buf[0] != nullptr && rx_bounce_buf[1] != nullptr;
         tx_dma_enabled = tx_bounce_buf != nullptr;
+    }
+    if (_last_options & OPTION_NODMA_RX) {
+        rx_dma_enabled = false;
+    }
+    if (_last_options & OPTION_NODMA_TX) {
+        tx_dma_enabled = false;
     }
     if (contention_counter > 1000 && _baudrate <= CONTENTION_BAUD_THRESHOLD) {
         // we've previously disabled TX DMA due to contention, don't


### PR DESCRIPTION
this change initializes the UART DMA buffers properly and also respects the OPTION_NODMA_RX and OPTION_NODMA_TX options.