### PR TITLE
AP_Arming: assume gyros are consistent at boot

### DIFF
--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -332,6 +332,9 @@ private:
     bool last_prearm_checks_result; // result of last prearm check
     bool report_immediately; // set to true when check goes from true to false, to trigger immediate report
 
+    // true if once-only AP_Arming library initialisation has been done:
+    bool init_done;
+
     void update_arm_gpio();
 
 #if !AP_GPS_BLENDED_ENABLED


### PR DESCRIPTION
This PR changes the pre-arm checks for gyro consistency to assume the gyros are consistent and *then* checking them to see if they are.

This should remove the delay a lot of people have at boot.  It does mean that on a vehicle where the gyros *grow* in inconsistency over that first 10 seconds that a user may be able to arm when previously they would have gotten a prearm check.

Alternatively we could potentially try to make the existing warning less scary.

Closes https://github.com/ardupilot/ardupilot/issues/28092

@amilcarlucas 