### PR TITLE
RC_Channel: Assign ARM to a non-latching button

### DIFF
--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -651,6 +651,7 @@ void RC_Channel::init_aux_function(const AUX_FUNC ch_option, const AuxSwitchPos 
     case AUX_FUNC::COMPASS_LEARN:
 #if AP_ARMING_ENABLED
     case AUX_FUNC::DISARM:
+    case AUX_FUNC::ARM:
 #endif
     case AUX_FUNC::DO_NOTHING:
 #if AP_LANDINGGEAR_ENABLED
@@ -1563,6 +1564,12 @@ bool RC_Channel::do_aux_function(const AuxFuncTrigger &trigger)
             AP::arming().disarm(AP_Arming::Method::AUXSWITCH);
         }
         break;
+
+    case AUX_FUNC::ARM:
+        if (ch_flag == AuxSwitchPos::HIGH) {
+            AP::arming().arm(AP_Arming::Method::AUXSWITCH);
+        }  
+        break;  
 #endif
 
     case AUX_FUNC::COMPASS_LEARN:

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -264,6 +264,7 @@ public:
         AHRS_AUTO_TRIM =     182,  // in-flight AHRS autotrim
         AUTOLAND =           183,  //Fixed Wing AUTOLAND Mode
         SYSTEMID =           184,  // system ID as an aux switch
+        ARM =                185,  // arm vehicle
 
         // inputs from 200 will eventually used to replace RCMAP
         ROLL =               201, // roll input


### PR DESCRIPTION
A game controller has non-latching buttons.
Assign the ARM function to a non-latching button.