### PR TITLE
Global:: Change centimeters per second to cms

### DIFF
--- a/ArduSub/mode_althold.cpp
+++ b/ArduSub/mode_althold.cpp
@@ -110,12 +110,12 @@ void ModeAlthold::control_depth() {
     distance_to_surface = constrain_float(distance_to_surface, 0.0f, 1.0f);
     motors.set_max_throttle(g.surface_max_throttle + (1.0f - g.surface_max_throttle) * distance_to_surface);
 
-    float target_climb_rate_cm_s = sub.get_pilot_desired_climb_rate(channel_throttle->get_control_in());
-    target_climb_rate_cm_s = constrain_float(target_climb_rate_cm_s, -sub.get_pilot_speed_dn(), g.pilot_speed_up);
+    float target_climb_rate_cms = sub.get_pilot_desired_climb_rate(channel_throttle->get_control_in());
+    target_climb_rate_cms = constrain_float(target_climb_rate_cms, -sub.get_pilot_speed_dn(), g.pilot_speed_up);
 
     // desired_climb_rate returns 0 when within the deadzone.
     //we allow full control to the pilot, but as soon as there's no input, we handle being at surface/bottom
-    if (fabsf(target_climb_rate_cm_s) < 0.05f)  {
+    if (fabsf(target_climb_rate_cms) < 0.05f)  {
         if (sub.ap.at_surface) {
             position_control->set_pos_desired_U_cm(MIN(position_control->get_pos_desired_U_cm(), g.surface_depth)); // set target to 5 cm below surface level
         } else if (sub.ap.at_bottom) {
@@ -123,6 +123,6 @@ void ModeAlthold::control_depth() {
         }
     }
 
-    position_control->set_pos_target_U_from_climb_rate_cm(target_climb_rate_cm_s);
+    position_control->set_pos_target_U_from_climb_rate_cm(target_climb_rate_cms);
     position_control->update_U_controller();
 }

--- a/ArduSub/mode_poshold.cpp
+++ b/ArduSub/mode_poshold.cpp
@@ -101,7 +101,7 @@ void ModePoshold::control_horizontal() {
     float forward_out = 0;
 
     // get desired rates in the body frame
-    Vector2f body_rates_cm_s = {
+    Vector2f body_rates_cms = {
         sub.get_pilot_desired_horizontal_rate(channel_forward),
         sub.get_pilot_desired_horizontal_rate(channel_lateral)
     };
@@ -113,8 +113,8 @@ void ModePoshold::control_horizontal() {
         }
 
         // convert to the earth frame and set target rates
-        auto earth_rates_cm_s = ahrs.body_to_earth2D(body_rates_cm_s);
-        position_control->input_vel_accel_NE_cm(earth_rates_cm_s, {0, 0});
+        auto earth_rates_cms = ahrs.body_to_earth2D(body_rates_cms);
+        position_control->input_vel_accel_NE_cm(earth_rates_cms, {0, 0});
 
         // convert pos control roll and pitch angles back to lateral and forward efforts
         sub.translate_pos_control_rp(lateral_out, forward_out);
@@ -123,8 +123,8 @@ void ModePoshold::control_horizontal() {
         position_control->update_NE_controller();
     } else if (g.pilot_speed > 0) {
         // allow the pilot to reposition manually
-        forward_out = body_rates_cm_s.x / (float)g.pilot_speed;
-        lateral_out = body_rates_cm_s.y / (float)g.pilot_speed;
+        forward_out = body_rates_cms.x / (float)g.pilot_speed;
+        lateral_out = body_rates_cms.y / (float)g.pilot_speed;
     }
 
     motors.set_forward(forward_out);

--- a/ArduSub/mode_surftrak.cpp
+++ b/ArduSub/mode_surftrak.cpp
@@ -103,11 +103,11 @@ void ModeSurftrak::reset()
  * Main controller, call at 100hz+
  */
 void ModeSurftrak::control_range() {
-    float target_climb_rate_cm_s = sub.get_pilot_desired_climb_rate(channel_throttle->get_control_in());
-    target_climb_rate_cm_s = constrain_float(target_climb_rate_cm_s, -sub.get_pilot_speed_dn(), g.pilot_speed_up);
+    float target_climb_rate_cms = sub.get_pilot_desired_climb_rate(channel_throttle->get_control_in());
+    target_climb_rate_cms = constrain_float(target_climb_rate_cms, -sub.get_pilot_speed_dn(), g.pilot_speed_up);
 
     // Desired_climb_rate returns 0 when within the deadzone
-    if (fabsf(target_climb_rate_cm_s) < 0.05f)  {
+    if (fabsf(target_climb_rate_cms) < 0.05f)  {
         if (pilot_in_control) {
             // Pilot has released control; apply the delta to the rangefinder target
             set_rangefinder_target_cm(rangefinder_target_cm + inertial_nav.get_position_z_up_cm() - pilot_control_start_z_cm);
@@ -132,7 +132,7 @@ void ModeSurftrak::control_range() {
     }
 
     // Set the target altitude from the climb rate and the terrain offset
-    position_control->set_pos_target_U_from_climb_rate_cm(target_climb_rate_cm_s);
+    position_control->set_pos_target_U_from_climb_rate_cm(target_climb_rate_cms);
 
     // Run the PID controllers
     position_control->update_U_controller();

--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
@@ -978,11 +978,11 @@ uint16_t AP_CRSF_Telem::get_altitude_packed()
 int8_t AP_CRSF_Telem::get_vertical_speed_packed()
 {
     float vspeed = get_vspeed_ms();
-    float vertical_speed_cm_s = vspeed * 100.0f;
+    float vertical_speed_cms = vspeed * 100.0f;
     const int16_t Kl = 100; // linearity constant;
     const float Kr = 0.026f; // range constant;
-    int8_t vspeed_packed = int8_t(logf(fabsf(vertical_speed_cm_s)/Kl + 1)/Kr);
-    return vspeed_packed * (is_negative(vertical_speed_cm_s) ? -1 : 1);
+    int8_t vspeed_packed = int8_t(logf(fabsf(vertical_speed_cms)/Kl + 1)/Kr);
+    return vspeed_packed * (is_negative(vertical_speed_cms) ? -1 : 1);
 }
 
 // prepare vario data


### PR DESCRIPTION
Many use "cms" for centimeters per second.
I will change it to the more common "cms".