### PR TITLE
Blimp: remove pointless set of CH_6 RC deadzone

### DIFF
--- a/Blimp/radio.cpp
+++ b/Blimp/radio.cpp
@@ -10,7 +10,6 @@ void Blimp::default_dead_zones()
     channel_front->set_default_dead_zone(20);
     channel_up->set_default_dead_zone(30);
     channel_yaw->set_default_dead_zone(20);
-    rc().channel(CH_6)->set_default_dead_zone(0);
 }
 
 void Blimp::init_rc_in()


### PR DESCRIPTION
this was for Copter's transmitter-based-tuning code, which wasn't brought over in Blimp.