### PR TITLE
Tools: scripts: configure all: --build: fix periph detection

### DIFF
--- a/Tools/scripts/configure_all.py
+++ b/Tools/scripts/configure_all.py
@@ -70,7 +70,7 @@ if args.start is not None:
 
 def is_ap_periph(board):
     hwdef = os.path.join('libraries/AP_HAL_ChibiOS/hwdef/%s/hwdef.dat' % board)
-    ch = chibios_hwdef.ChibiOSHWDef(hwdef)
+    ch = chibios_hwdef.ChibiOSHWDef(hwdef=[hwdef], quiet=True)
     ch.process_hwdefs()
     return ch.is_periph_fw()
 


### PR DESCRIPTION
The `ChibiOSHWDef` takes named values, seems to have been broken for ages, maybe by https://github.com/ArduPilot/ardupilot/pull/23732

Without this detection no hwdef is ever passed so nothing is detected as periph. That means configure all trys to build vehicles on periph boards and fails. 