### PR TITLE
AP_Landing: fixed assumption of AMSL WPs

### DIFF
--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -209,4 +209,7 @@ private:
     bool type_slope_is_on_approach(void) const;
     bool type_slope_is_expecting_impact(void) const;
     bool type_slope_is_throttle_suppressed(void) const;
+
+    // return a location alt in cm as AMSL
+    int32_t loc_alt_AMSL_cm(const Location &loc) const;
 };


### PR DESCRIPTION
the AP_Landing library assumed AMSL waypoints for both prev_WP_loc and next_WP_loc. This led to an incorrect glide slope for a NAV_LAND fixed wing landing when the landing WP is terrain relative.

This change fixes the code to handle either an AGL or AMSL location, which are the only two location types used in plane

fixes an issue in 4.6.0-beta reported here: https://discuss.ardupilot.org/t/plane-4-6-0-beta/126358/183

tested in SITL