### PR TITLE
Build: Allow DDS to be enabled in hwdef

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -40,6 +40,7 @@ COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'AP_GSOF',
     'AP_HAL',
     'AP_HAL_Empty',
+    'AP_DDS',
     'AP_InertialSensor',
     'AP_Math',
     'AP_Mission',
@@ -166,7 +167,6 @@ def set_double_precision_flags(flags):
 IGNORED_AP_LIBRARIES = [
     'doc',
     'AP_Scripting', # this gets explicitly included when it is needed and should otherwise never be globbed in
-    'AP_DDS',
 ]
 
 

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -408,7 +408,7 @@ def do_build(opts, frame_options):
         cmd_configure.append("--define=%s" % nv)
 
     if opts.enable_dds:
-        cmd_configure.append("--enable-dds")
+        cmd_configure.append("--enable-DDS")
 
     if opts.disable_networking:
         cmd_configure.append("--disable-networking")

--- a/Tools/ros2/ardupilot_sitl/CMakeLists.txt
+++ b/Tools/ros2/ardupilot_sitl/CMakeLists.txt
@@ -35,7 +35,7 @@ set(WAF_CONFIG $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:"--debug">)
 set(WAF_DISABLE_NETWORKING $<$<BOOL:${ARDUPILOT_DISABLE_NETWORKING}>:"--disable-networking">)
 set(WAF_DISABLE_SCRIPTING $<$<BOOL:${ARDUPILOT_DISABLE_SCRIPTING}>:"--disable-scripting">)
 set(WAF_DISABLE_WATCHDOG $<$<BOOL:${ARDUPILOT_DISABLE_WATCHDOG}>:"--disable-watchdog">)
-set(WAF_ENABLE_DDS $<$<BOOL:${ARDUPILOT_ENABLE_DDS}>:"--enable-dds">)
+set(WAF_ENABLE_DDS $<$<BOOL:${ARDUPILOT_ENABLE_DDS}>:"--enable-DDS">)
 set(WAF_ENABLE_NETWORKING_TESTS $<$<BOOL:${ARDUPILOT_ENABLE_NETWORKING_TESTS}>:"--enable-networking-tests">)
 set(WAF_ENABLE_PPP $<$<BOOL:${ARDUPILOT_ENABLE_PPP}>:"--enable-PPP">)
 
@@ -53,7 +53,7 @@ add_custom_target(ardupilot_configure ALL
 )
 
 add_custom_target(ardupilot_build ALL
-  ${WAF_COMMAND} build --enable-dds ${WAF_CONFIG} ${ARDUPILOT_WAF_BUILD_ARGS}
+  ${WAF_COMMAND} build --enable-DDS ${WAF_CONFIG} ${ARDUPILOT_WAF_BUILD_ARGS}
   WORKING_DIRECTORY ${ARDUPILOT_ROOT}
 )
 add_dependencies(ardupilot_build ardupilot_configure)

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -404,7 +404,7 @@ for t in $CI_BUILD_TARGET; do
     
     if [ "$t" == "dds-stm32h7" ]; then
         echo "Building with DDS support on a STM32H7"
-        $waf configure --board Durandal --enable-dds
+        $waf configure --board Durandal --enable-DDS
         $waf clean
         $waf copter
         $waf plane
@@ -413,7 +413,7 @@ for t in $CI_BUILD_TARGET; do
 
     if [ "$t" == "dds-sitl" ]; then
         echo "Building with DDS support on SITL"
-        $waf configure --board sitl --enable-dds
+        $waf configure --board sitl --enable-DDS
         $waf clean
         $waf copter
         $waf plane

--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -456,6 +456,9 @@ BUILD_OPTIONS = [
 
     Feature('CAN', 'DroneCAN', 'HAL_ENABLE_DRONECAN_DRIVERS', 'Enable DroneCAN support', 0, None),
     Feature('CAN', 'CAN Logging', 'AP_CAN_LOGGING_ENABLED', 'Enable CAN logging support', 0, 'Logging'),
+
+    Feature('DDS', 'DDS', 'AP_DDS_ENABLED', 'Enable MicroXRCE DDS support for ROS 2', 0, None),
+
 ]
 
 BUILD_OPTIONS.sort(key=lambda x: (x.category + x.label))

--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -297,6 +297,7 @@ class ExtractFeatures(object):
             ('AP_FILTER_ENABLED', r'AP_Filters::update'),
             ('AP_CAN_LOGGING_ENABLED', r'AP_CANManager::can_logging_callback'),
             ('AP_PLANE_SYSTEMID_ENABLED', r'AP_SystemID::start'),
+            ('AP_DDS_ENABLED', r'AP_DDS_Client::start'),
         ]
 
     def progress(self, msg):

--- a/libraries/AP_DDS/AP_DDS_Serial.cpp
+++ b/libraries/AP_DDS/AP_DDS_Serial.cpp
@@ -1,5 +1,7 @@
 #include "AP_DDS_Client.h"
 
+#if AP_DDS_ENABLED
+
 #include <AP_SerialManager/AP_SerialManager.h>
 
 #include <errno.h>
@@ -93,3 +95,4 @@ bool AP_DDS_Client::ddsSerialInit()
     comm = &serial.transport.comm;
     return true;
 }
+#endif // AP_DDS_ENABLED

--- a/libraries/AP_DDS/README.md
+++ b/libraries/AP_DDS/README.md
@@ -318,7 +318,7 @@ mkdir -p libraries/AP_DDS/Idl/builtin_interfaces/msg/
 # Copy the IDL
 cp /opt/ros/humble/share/builtin_interfaces/msg/Time.idl libraries/AP_DDS/Idl/builtin_interfaces/msg/
 
-# Build the code again with the `--enable-dds` flag as described above
+# Build the code again with the `--enable-DDS` flag as described above
 ```
 
 If the message is custom for ardupilot, first create the ROS message in `Tools/ros2/ardupilot_msgs/msg/GlobalPosition.msg`.
@@ -406,7 +406,7 @@ SERIAL_ORDER OTG1 UART7 UART5 USART1 UART8 USART2 UART4 USART3 OTG2
 
 For example, build, flash, and set up OTG2 for DDS
 ```bash
-./waf configure --board Pixhawk6X --enable-dds
+./waf configure --board Pixhawk6X --enable-DDS
 ./waf plane --upload
 mavproxy.py --console
 param set DDS_ENABLE 1

--- a/libraries/AP_DDS/gen_config_h.py
+++ b/libraries/AP_DDS/gen_config_h.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 '''
- process a *.h.in file to produce a *.h file
+ process config.h.in file to produce a <uxr/client/config.h> file
 '''
 
 # TODO move to AP_DDS_Client/tools

--- a/libraries/AP_DDS/wscript
+++ b/libraries/AP_DDS/wscript
@@ -5,6 +5,12 @@ import pathlib
 
 
 def configure(cfg):
+    if cfg.env.OPTIONS['enable_DDS'] is False:
+        return
+    
+    # check for microxrceddsgen
+    cfg.find_program('microxrceddsgen', mandatory=True)
+
     extra_src = [
         'modules/Micro-XRCE-DDS-Client/src/c/core/session/stream/*.c',
         'modules/Micro-XRCE-DDS-Client/src/c/core/session/*.c',
@@ -38,6 +44,9 @@ def configure(cfg):
 
 
 def build(bld):
+    if bld.env.OPTIONS['enable_DDS'] is False:
+        return
+
     config_h_in = [
         'modules/Micro-XRCE-DDS-Client/include/uxr/client/config.h.in',
         'modules/Micro-CDR/include/ucdr/config.h.in',
@@ -55,9 +64,9 @@ def build(bld):
         bld.env.INCLUDES += [bld.bldnode.find_or_declare(inc).abspath()]
 
     for i in range(len(config_h_nodes)):
-        print(f"building {config_h_nodes[i].abspath()}")
+        print(f"Building {config_h_nodes[i].abspath()}")
         bld(
-            # build config.h file
+            # Generate config.h file
             source=config_h_in_nodes[i],
             target=config_h_nodes[i],
             rule="%s %s/%s %s %s"
@@ -95,5 +104,4 @@ def build(bld):
             rule=gen_cmd,
             group='dynamic_sources',
         )
-
         bld.env.AP_LIB_EXTRA_SOURCES['AP_DDS'] += [str(gen[1])]

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -71,6 +71,7 @@
 #include <AP_KDECAN/AP_KDECAN.h>
 #include <Filter/AP_Filter.h>
 #include <AP_Stats/AP_Stats.h>              // statistics library
+#include <AP_DDS/AP_DDS_config.h>
 #if AP_SCRIPTING_ENABLED
 #include <AP_Scripting/AP_Scripting.h>
 #endif

--- a/wscript
+++ b/wscript
@@ -329,9 +329,6 @@ submodules at specific revisions.
     g.add_option('--enable-gps-logging', action='store_true',
                  default=False,
                  help="Enables GPS logging")
-    
-    g.add_option('--enable-dds', action='store_true',
-                 help="Enable the dds client to connect with ROS2/DDS.")
 
     g.add_option('--disable-networking', action='store_true',
                  help="Disable the networking API code")
@@ -639,6 +636,7 @@ def configure(cfg):
     cfg.recurse('libraries/SITL')
 
     cfg.recurse('libraries/AP_Networking')
+    cfg.recurse('libraries/AP_DDS')
 
     cfg.start_msg('Scripting runtime checks')
     if cfg.options.scripting_checks:
@@ -825,8 +823,7 @@ def _build_dynamic_sources(bld):
             ]
         )
 
-    if bld.env.ENABLE_DDS:
-        bld.recurse("libraries/AP_DDS")
+    bld.recurse("libraries/AP_DDS")
 
     def write_version_header(tsk):
         bld = tsk.generator.bld


### PR DESCRIPTION
A continuation of @Ryanf55's attempt in #28440.

This allows the DDS (ROS2) feature to be enabled via hwdef. Currently only enabled for the CubeRedPrimary - happy to take advice on which other boards to enable for.

Tested in SITL and on a CubeRed.