### PR TITLE
Document DAL RFRN message

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -3154,7 +3154,7 @@ class TestSuite(ABC):
         # effectively binary blobs for replay
         # Documenting these is still useful! -pb
         REPLAY_MSGS = ['RFRH', 'RFRF', 'REV2', 'RSO2', 'RWA2', 'REV3', 'RSO3', 'RWA3', 'RMGI',
-                       'REY3', 'RFRN', 'RISH', 'RISI', 'RISJ', 'RBRH', 'RBRI', 'RRNH', 'RRNI',
+                       'REY3', 'RISH', 'RISI', 'RISJ', 'RBRH', 'RBRI', 'RRNH', 'RRNI',
                        'RGPH', 'RGPI', 'RGPJ', 'RASH', 'RASI', 'RBCH', 'RBCI', 'RVOH', 'RMGH',
                        'ROFH', 'REPH', 'REVH', 'RWOH', 'RBOH', 'RSLL']
 

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -2998,7 +2998,7 @@ class TestSuite(ABC):
             print("message_info: %s" % str(message_info))
             for define in defines:
                 message_info = re.sub(define, defines[define], message_info)
-            m = re.match(r'\s*LOG_\w+\s*,\s*sizeof\([^)]+\)\s*,\s*"(\w+)"\s*,\s*"(\w+)"\s*,\s*"([\w,]+)"\s*,\s*"([^"]+)"\s*,\s*"([^"]+)"\s*(,\s*(true|false))?\s*$', message_info)  # noqa
+            m = re.match(r'\s*LOG_\w+\s*,\s*(?:sizeof|RLOG_SIZE)\([^)]+\)\s*,\s*"(\w+)"\s*,\s*"(\w+)"\s*,\s*"([\w,]+)"\s*,\s*"([^"]+)"\s*,\s*"([^"]+)"\s*(,\s*(true|false))?\s*$', message_info)  # noqa
             if m is None:
                 print("NO MATCH")
                 continue
@@ -3272,8 +3272,18 @@ class TestSuite(ABC):
                                                (name, label))
                 seen_labels[label] = True
                 if label not in docco_ids[name]["labels"]:
-                    raise NotAchievedException("%s.%s not in documented fields (have (%s))" %
-                                               (name, label, ",".join(docco_ids[name]["labels"])))
+                    msg = ("%s.%s not in documented fields (have (%s))" %
+                           (name, label, ",".join(docco_ids[name]["labels"])))
+                    if name in whitelist:
+                        self.progress(msg)
+                        # a lot of our Replay messages have names but
+                        # nothing more
+                        try:
+                            overdocumented.remove(name)
+                        except KeyError:
+                            pass
+                        continue
+                    raise NotAchievedException(msg)
 
         if len(undocumented):
             for name in sorted(undocumented):

--- a/libraries/AP_DAL/AP_DAL.h
+++ b/libraries/AP_DAL/AP_DAL.h
@@ -87,8 +87,15 @@ public:
     void log_writeDefaultAirSpeed3(const float aspeed, const float uncertainty);
     void log_writeEulerYawAngle(float yawAngle, float yawAngleErr, uint32_t timeStamp_ms, uint8_t type);
 
-    enum class StateMask {
+    enum class RFRNFlags {
         ARMED = (1U<<0),
+        UNUSED = (1U<<1),
+        FLY_FORWARD = (1U<<2),
+        AHRS_AIRSPEED_SENSOR_ENABLED = (1U<<3),
+        OPTICALFLOW_ENABLED = (1U<<4),
+        WHEELENCODER_ENABLED = (1U<<5),
+        TAKEOFF_EXPECTED = (1U<<6),
+        TOUCHDOWN_EXPECTED = (1U<<7),
     };
 
     // EKF ID for timing checks

--- a/libraries/AP_DAL/LogStructure.h
+++ b/libraries/AP_DAL/LogStructure.h
@@ -58,6 +58,19 @@ struct log_RFRF {
 
 // @LoggerMessage: RFRN
 // @Description: Replay FRame - aNother frame header
+// @Field: HLat: home latitude
+// @Field: HLon: home latitude
+// @Field: HAlt: home altitude AMSL
+// @Field: E2T: EAS to TAS factor
+// @Field: AM: available memory
+// @Field: TX: AHRS trim X
+// @Field: TY: AHRS trim Y
+// @Field: TZ: AHRS trim Z
+// @Field: VC: AHRS Vehicle Class
+// @Field: EKT: configured EKF type
+// @FieldValueEnum: EKT: AP_DAL::EKFType
+// @Field: Flags: bitmask of boolean state
+// @FieldBitmaskEnum: Flags: AP_DAL::RFRNFlags
 struct log_RFRN {
     int32_t lat;
     int32_t lng;
@@ -392,7 +405,7 @@ struct log_RBOH {
     { LOG_RFRF_MSG, RLOG_SIZE(RFRF),                          \
       "RFRF", "BB", "FTypes,Slow", "--", "--" }, \
     { LOG_RFRN_MSG, RLOG_SIZE(RFRN),                            \
-      "RFRN", "IIIfIfffBBB", "HLat,HLon,HAlt,E2T,AM,TX,TY,TZ,VC,EKT,Flags", "DUm????????", "GGB--------" }, \
+      "RFRN", "IIIfIfffBBB", "HLat,HLon,HAlt,E2T,AM,TX,TY,TZ,VC,EKT,Flags", "DUm-bddd---", "GGB--------" }, \
     { LOG_REV2_MSG, RLOG_SIZE(REV2),                                   \
       "REV2", "B", "Event", "-", "-" }, \
     { LOG_RSO2_MSG, RLOG_SIZE(RSO2),                         \


### PR DESCRIPTION
I found this very useful when working on replay beacon stuff.

The Flags enumeration values are based off the RFRN log structure:
```
struct log_RFRN {
    int32_t lat;
    int32_t lng;
    int32_t alt;
    float EAS2TAS;
    uint32_t available_memory;
    Vector3f ahrs_trim;
    uint8_t vehicle_class;
    uint8_t ekf_type;
    uint8_t armed:1;
    uint8_t unused:1;  // was get_compass_is_null
    uint8_t fly_forward:1;
    uint8_t ahrs_airspeed_sensor_enabled:1;
    uint8_t opticalflow_enabled:1;
    uint8_t wheelencoder_enabled:1;
    uint8_t takeoff_expected:1;
    uint8_t touchdown_expected:1;
    uint8_t _end;
};
```