### PR TITLE
Copter: Trust get-pilot-desired methods check RC input for validity

### DIFF
--- a/ArduCopter/mode_loiter.cpp
+++ b/ArduCopter/mode_loiter.cpp
@@ -9,20 +9,16 @@
 // loiter_init - initialise loiter controller
 bool ModeLoiter::init(bool ignore_checks)
 {
-    if (!copter.failsafe.radio) {
-        float target_roll, target_pitch;
-        // apply SIMPLE mode transform to pilot inputs
-        update_simple_mode();
+    float target_roll, target_pitch;
+    // apply SIMPLE mode transform to pilot inputs
+    update_simple_mode();
 
-        // convert pilot input to lean angles
-        get_pilot_desired_lean_angles(target_roll, target_pitch, loiter_nav->get_angle_max_cd(), attitude_control->get_althold_lean_angle_max_cd());
+    // convert pilot input to lean angles
+    get_pilot_desired_lean_angles(target_roll, target_pitch, loiter_nav->get_angle_max_cd(), attitude_control->get_althold_lean_angle_max_cd());
 
-        // process pilot's roll and pitch input
-        loiter_nav->set_pilot_desired_acceleration_cd(target_roll, target_pitch);
-    } else {
-        // clear out pilot desired acceleration in case radio failsafe event occurs and we do not switch to RTL for some reason
-        loiter_nav->clear_pilot_desired_acceleration();
-    }
+    // process pilot's roll and pitch input
+    loiter_nav->set_pilot_desired_acceleration_cd(target_roll, target_pitch);
+
     loiter_nav->init_target();
 
     // initialise the vertical position controller
@@ -90,27 +86,21 @@ void ModeLoiter::run()
     // set vertical speed and acceleration limits
     pos_control->set_max_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
-    // process pilot inputs unless we are in radio failsafe
-    if (!copter.failsafe.radio) {
-        // apply SIMPLE mode transform to pilot inputs
-        update_simple_mode();
+    // apply SIMPLE mode transform to pilot inputs
+    update_simple_mode();
 
-        // convert pilot input to lean angles
-        get_pilot_desired_lean_angles(target_roll, target_pitch, loiter_nav->get_angle_max_cd(), attitude_control->get_althold_lean_angle_max_cd());
+    // convert pilot input to lean angles
+    get_pilot_desired_lean_angles(target_roll, target_pitch, loiter_nav->get_angle_max_cd(), attitude_control->get_althold_lean_angle_max_cd());
 
-        // process pilot's roll and pitch input
-        loiter_nav->set_pilot_desired_acceleration_cd(target_roll, target_pitch);
+    // process pilot's roll and pitch input
+    loiter_nav->set_pilot_desired_acceleration_cd(target_roll, target_pitch);
 
-        // get pilot's desired yaw rate
-        target_yaw_rate = get_pilot_desired_yaw_rate();
+    // get pilot's desired yaw rate
+    target_yaw_rate = get_pilot_desired_yaw_rate();
 
-        // get pilot desired climb rate
-        target_climb_rate = get_pilot_desired_climb_rate();
-        target_climb_rate = constrain_float(target_climb_rate, -get_pilot_speed_dn(), g.pilot_speed_up);
-    } else {
-        // clear out pilot desired acceleration in case radio failsafe event occurs and we do not switch to RTL for some reason
-        loiter_nav->clear_pilot_desired_acceleration();
-    }
+    // get pilot desired climb rate
+    target_climb_rate = get_pilot_desired_climb_rate();
+    target_climb_rate = constrain_float(target_climb_rate, -get_pilot_speed_dn(), g.pilot_speed_up);
 
     // relax loiter target if we might be landed
     if (copter.ap.land_complete_maybe) {


### PR DESCRIPTION
.... which they do, for the most part.

This PR removes special-case logic in Loiter and ZigZag which check for radio failsafe before updating the loiter controller with values returned from them (etc.).

Those methods already check that RC input is good (improvements coming there, however!).  So rely on those methods returning sensible values when there's no RC present.  Several other modes already make the assumption that these methods do sensible things (eg. `ModeAltHold`!).

Note that `clear_pilot_desired_acceleration` just sets `(0, 0)`, and `get_pilot_desired_lean_angles` sets target-roll/target-pitch to zero if RC input is bad).


~There is a second fix in here where checks were insufficient when looking at RC values.  This is the `update_simple_mode` method matches.  We not only have to check that a new frame has been received, but that the values are generally good ie. not coming in at bind-mode values.  This is a minimal patch to allow for the first patch to go in - there's plenty else wrong in the radio codepath which will be fixed in a future PR (eg. incorporating bind-time values into the throttle filter, setting the throttle-zero flag).  This is also a bugfix for several methods which already transform the pilot inputs.~  - this was moved to a different PR

