### PR TITLE
Copter: avoid updating simple-mode values when RC input is invalid

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -853,6 +853,11 @@ void Copter::update_simple_mode(void)
     // mark radio frame as consumed
     ap.new_radio_frame = false;
 
+    // avoid processing bind-time RC values:
+    if (!rc().has_valid_input()) {
+        return;
+    }
+
     if (simple_mode == SimpleMode::SIMPLE) {
         // rotate roll, pitch input by -initial simple heading (i.e. north facing)
         rollx = channel_roll->get_control_in()*simple_cos_yaw - channel_pitch->get_control_in()*simple_sin_yaw;


### PR DESCRIPTION
if we are at bind-time values then we still get new radio frames, they're just not something we should use

Tested in SITL by setting a breakpoint within the new clause.  When we're in there having set SIM_RC_FAIL to 2 the channels are definitely using bind-time values.
