### PR TITLE
Fix RangeFinderDrivers test when running locally

### DIFF
--- a/libraries/SITL/SIM_RF_NoopLoop.cpp
+++ b/libraries/SITL/SIM_RF_NoopLoop.cpp
@@ -22,6 +22,12 @@ using namespace SITL;
 
 uint32_t RF_Nooploop::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
 {
+    // the NoopLoop driver considers a value of zero invalid and won't
+    // consider it a reading, so you end up with no readings at all
+    // from the driver.  Fudge it here:
+    if (alt_cm == 0) {
+        alt_cm = 1;
+    }
 
     int32_t alt_scaled = 2560*alt_cm;
     buffer[0] = 0x57;

--- a/libraries/SITL/SIM_RF_Wasp.cpp
+++ b/libraries/SITL/SIM_RF_Wasp.cpp
@@ -113,5 +113,11 @@ void RF_Wasp::update(float range)
 
 uint32_t RF_Wasp::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
 {
+    // the Wasp driver does not consider 0 a valid reading, so you end
+    // up getting 0 samples back if you send exactly zero all the
+    // time.  So munge it a little bit:
+    if (alt_cm == 0) {
+        alt_cm = 1;
+    }
     return snprintf((char*)buffer, buflen, "%f\n", alt_cm*0.01f);
 }


### PR DESCRIPTION
Vagaries of timing and the terrain database mean that it's not a good idea to run with SIM_TERRAIN on for this test.

Also changes two simulators to not return zero for their distance, ever, as the drivers don't consider 0 a valid reading.

I'm not sure if those drivers *should* accept zero as a valid distance - perhaps @rishabsingh3003 has a datasheet for the NoopLoop.

```
 - improve diagnostics
 - split tests up to ensure clean state for mavlink and sitl tests
 - make arming more reliable in mavlink test
 - make use of new infrastructure
 - stop using simulated terrain in RangeFinderDrivers test
  - we're not actually moving the vehicle, so we really don't need simulated terrain, and because the terrain db isn't always ready to go we get inconsistent results
```
