### PR TITLE
Rover: add 'Loiter or Hold' as a failsafe action

### DIFF
--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -91,7 +91,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: FS_ACTION
     // @DisplayName: Failsafe Action
     // @Description: What to do on a failsafe event
-    // @Values: 0:Nothing,1:RTL,2:Hold,3:SmartRTL or RTL,4:SmartRTL or Hold,5:Terminate
+    // @Values: 0:Nothing,1:RTL,2:Hold,3:SmartRTL or RTL,4:SmartRTL or Hold,5:Terminate,6:Loiter or Hold
     // @User: Standard
     GSCALAR(fs_action,    "FS_ACTION",     (int8_t)FailsafeAction::Hold),
 

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -416,7 +416,8 @@ private:
         Hold          = 2,
         SmartRTL      = 3,
         SmartRTL_Hold = 4,
-        Terminate     = 5
+        Terminate     = 5,
+        Loiter_Hold   = 6,
     };
 
     enum class Failsafe_Options : uint32_t {

--- a/Rover/failsafe.cpp
+++ b/Rover/failsafe.cpp
@@ -101,6 +101,11 @@ void Rover::failsafe_trigger(uint8_t failsafe_type, const char* type_str, bool o
                     set_mode(mode_hold, ModeReason::FAILSAFE);
                 }
                 break;
+            case FailsafeAction::Loiter_Hold:
+                if (!set_mode(mode_loiter, ModeReason::FAILSAFE)) {
+                    set_mode(mode_hold, ModeReason::FAILSAFE);
+                }
+                break;
             case FailsafeAction::Terminate:
                 arming.disarm(AP_Arming::Method::FAILSAFE_ACTION_TERMINATE);
                 break;
@@ -126,6 +131,11 @@ void Rover::handle_battery_failsafe(const char* type_str, const int8_t action)
                 FALLTHROUGH;
             case FailsafeAction::Hold:
                 set_mode(mode_hold, ModeReason::BATTERY_FAILSAFE);
+                break;
+            case FailsafeAction::Loiter_Hold:
+                if (!set_mode(mode_loiter, ModeReason::BATTERY_FAILSAFE)) {
+                    set_mode(mode_hold, ModeReason::BATTERY_FAILSAFE);
+                }
                 break;
             case FailsafeAction::SmartRTL_Hold:
                 if (!set_mode(mode_smartrtl, ModeReason::BATTERY_FAILSAFE)) {

--- a/Rover/fence.cpp
+++ b/Rover/fence.cpp
@@ -67,6 +67,11 @@ void Rover::fence_check()
                         set_mode(mode_hold, ModeReason::FENCE_BREACHED);
                     }
                     break;
+                case FailsafeAction::Loiter_Hold:
+                    if (!set_mode(mode_loiter, ModeReason::FENCE_BREACHED)) {
+                        set_mode(mode_hold, ModeReason::FENCE_BREACHED);
+                    }
+                    break;
                 case FailsafeAction::Terminate:
                     arming.disarm(AP_Arming::Method::FENCEBREACH);
                     break;

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -67,7 +67,7 @@ const AP_Param::GroupInfo AC_Fence::var_info[] = {
     // @DisplayName: Fence Action
     // @Description: What action should be taken when fence is breached
     // @Values{Copter}: 0:Report Only,1:RTL or Land,2:Always Land,3:SmartRTL or RTL or Land,4:Brake or Land,5:SmartRTL or Land
-    // @Values{Rover}: 0:Report Only,1:RTL or Hold,2:Hold,3:SmartRTL or RTL or Hold,4:SmartRTL or Hold
+    // @Values{Rover}: 0:Report Only,1:RTL or Hold,2:Hold,3:SmartRTL or RTL or Hold,4:SmartRTL or Hold,5:Terminate,6:Loiter or Hold
     // @Values{Plane}: 0:Report Only,1:RTL,6:Guided,7:GuidedThrottlePass,8:AUTOLAND if possible else RTL
     // @Values: 0:Report Only,1:RTL or Land
     // @User: Standard

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
@@ -115,7 +115,7 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
     // @Values{Copter}: 0:None,1:Land,2:RTL,3:SmartRTL or RTL,4:SmartRTL or Land,5:Terminate,6:Auto DO_LAND_START/DO_RETURN_PATH_START or RTL,7:Brake or Land
     // @Values{Plane}: 0:None,1:RTL,2:Land,3:Terminate,4:QLand,5:Parachute release,6:Loiter to QLand,7:AUTOLAND or RTL
     // @Values{Sub}: 0:None,2:Disarm,3:Enter surface mode
-    // @Values{Rover}: 0:None,1:RTL,2:Hold,3:SmartRTL,4:SmartRTL or Hold,5:Terminate
+    // @Values{Rover}: 0:None,1:RTL,2:Hold,3:SmartRTL,4:SmartRTL or Hold,5:Terminate,6:Loiter or Hold
     // @Values{Tracker}: 0:None
     // @Values{Blimp}: 0:None,1:Land
     // @User: Standard
@@ -127,7 +127,7 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
     // @Values{Copter}: 0:None,1:Land,2:RTL,3:SmartRTL or RTL,4:SmartRTL or Land,5:Terminate,6:Auto DO_LAND_START/DO_RETURN_PATH_START or RTL,7:Brake or Land
     // @Values{Plane}: 0:None,1:RTL,2:Land,3:Terminate,4:QLand,5:Parachute,6:Loiter to QLand,7:AUTOLAND or RTL
     // @Values{Sub}: 0:None,2:Disarm,3:Enter surface mode
-    // @Values{Rover}: 0:None,1:RTL,2:Hold,3:SmartRTL,4:SmartRTL or Hold,5:Terminate
+    // @Values{Rover}: 0:None,1:RTL,2:Hold,3:SmartRTL,4:SmartRTL or Hold,5:Terminate,6:Loiter or Hold
     // @Values{Tracker}: 0:None
     // @Values{Blimp}: 0:None,1:Land
     // @User: Standard


### PR DESCRIPTION
This is especially useful for boats, as we usually don't want it to drift away with the current once if failsafes