### PR TITLE
AP_Scripting: correct use of pcall in examples and applets

### DIFF
--- a/libraries/AP_Scripting/applets/VTOL-quicktune.lua
+++ b/libraries/AP_Scripting/applets/VTOL-quicktune.lua
@@ -661,8 +661,7 @@ function protected_wrapper()
      gcs:send_text(MAV_SEVERITY_EMERGENCY, "Internal Error: " .. err)
      -- when we fault we run the update function again after 1s, slowing it
      -- down a bit so we don't flood the console with errors
-     --return protected_wrapper, 1000
-     return
+     return protected_wrapper, 1000
   end
   return protected_wrapper, 1000/UPDATE_RATE_HZ
 end

--- a/libraries/AP_Scripting/applets/revert_param.lua
+++ b/libraries/AP_Scripting/applets/revert_param.lua
@@ -175,8 +175,7 @@ function protected_wrapper()
      gcs:send_text(MAV_SEVERITY.EMERGENCY, "Internal Error: " .. err)
      -- when we fault we run the update function again after 1s, slowing it
      -- down a bit so we don't flood the console with errors
-     --return protected_wrapper, 1000
-     return
+     return protected_wrapper, 1000
   end
   return protected_wrapper, 1000/UPDATE_RATE_HZ
 end

--- a/libraries/AP_Scripting/applets/rover-quicktune.lua
+++ b/libraries/AP_Scripting/applets/rover-quicktune.lua
@@ -645,8 +645,7 @@ function protected_wrapper()
     gcs:send_text(MAV_SEVERITY.CRITICAL, "RTun: Internal Error: " .. err)
     -- when we fault we run the update function again after 1s, slowing it
     -- down a bit so we don't flood the console with errors
-    --return protected_wrapper, 1000
-    return
+    return protected_wrapper, 1000
   end
   return protected_wrapper, 1000/UPDATE_RATE_HZ
 end

--- a/libraries/AP_Scripting/examples/gen_control.lua
+++ b/libraries/AP_Scripting/examples/gen_control.lua
@@ -198,8 +198,7 @@ function protected_wrapper()
      gcs:send_text(MAV_SEVERITY_EMERGENCY, "Internal Error: " .. err)
      -- when we fault we run the update function again after 1s, slowing it
      -- down a bit so we don't flood the console with errors
-     --return protected_wrapper, 1000
-     return
+     return protected_wrapper, 1000
   end
   return protected_wrapper, 1000/UPDATE_RATE_HZ
 end


### PR DESCRIPTION
... tested in another script which uses the same block....
