### PR TITLE
ArduPlane: Fixed transition to forward flight mode when transitioning to VTOL

### DIFF
--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -872,7 +872,9 @@ void Tailsitter_Transition::update()
     }
 
     case TRANSITION_ANGLE_WAIT_VTOL:
-        // nothing to do, this is handled in the fixed wing attitude controller
+        // Switched to Forward flight mode while in transition to VTOL.
+        // Start transition back to forward flight.
+        restart();
         break;
 
     case TRANSITION_DONE:


### PR DESCRIPTION
For Arduplane Tailsitter.

This patch fixes a problem with the Tailsitter state machine, which remains stuck in VTOL mode if we command a forward flight mode while transitioning to VTOL.

I don't know if we send this state out in any message, I just found out through sending it through DDS. During transition to QRTL I commanded CRUISE mode. Vehicle correctly switched to CRUISE but the state machine kept reporting "VTOL"