### PR TITLE
AP_HAL_ChibiOS: correctly verify flash on H7

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/flash.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/flash.c
@@ -685,9 +685,8 @@ static bool stm32_flash_write_h7(uint32_t addr, const void *buf, uint32_t count)
     bool success = true;
 
     while (count >= 32) {
-        const uint8_t *b2 = (const uint8_t *)addr;
         // if the bytes already match then skip this chunk
-        if (memcmp(b, b2, 32) != 0) {
+        if (memcmp((void*)addr, b, 32) != 0) {
             // check for erasure
             if (!stm32h7_check_all_ones(addr, 8)) {
                 return false;
@@ -707,7 +706,8 @@ static bool stm32_flash_write_h7(uint32_t addr, const void *buf, uint32_t count)
                 success = false;
                 goto failed;
             }
-            // check contents
+            // check contents after invalidating so we see what actually got written
+            SCB_InvalidateDCache_by_Addr((void*)addr, 32);
             if (memcmp((void*)addr, b, 32) != 0) {
                 success = false;
                 goto failed;


### PR DESCRIPTION
Previously, the routine only read the data back from the data cache, which was guaranteed correct as the cache would be allocated by the test before programming then filled with the correct data during programming.

Invalidate the data cache area containing the just-programmed data to ensure that it is actually read back from the flash memory and the verification does something.

This is not trivial to check, but it can be done. To an unprogrammed (all 1s) 256-bit flash word, program the byte sequence `CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC1CCCCCCCC` followed by (and without erasing) the sequence
`CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC0CCCCCCCC`. This will cause the flash memory (on the tested H743 revision at least) to read `CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCDCCCCCCCCCCCCCCCCCCCCCCCC0CCCCCCCC` (and signal a one bit ECC error) and the verification check to fail.

Before this patch, the above sequence would always claim programming success despire the read data not matching the programmed data.

Also clean up the pre-flash check for already flashed data. It should not need a cache clear before the check as the flash normally operates coherently with the data cache.

Tested on KakuteH7Mini that the bootloader and parameter storage both still work. Not thought about other supported microcontroller families and if their caches might be incorrectly managed.