### PR TITLE
AP_HAL_ChibiOS: improve H7 low memory zero check

### DIFF
--- a/libraries/AP_HAL_ChibiOS/Scheduler.cpp
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.cpp
@@ -603,25 +603,15 @@ void Scheduler::_io_thread(void* arg)
  */
 void Scheduler::check_low_memory_is_zero()
 {
-    const uint32_t *lowmem = nullptr;
-    // we start at address 0x1 as reading address zero causes a fault
-    for (uint16_t i=1; i<256; i++) {
-        if (lowmem[i] != 0) {
+    for (int addr=0; addr<1024; addr+=4) {
+        uint32_t val;
+        // read using assembly so we don't invoke UB dereferencing nullptr
+        __asm__("\tldr %0, [%1]\n\t" : "=r"(val) : "r"(addr));
+        if (val != 0) {
             // re-use memory guard internal error
             AP_memory_guard_error(1023);
             break;
         }
-    }
-    // we can't do address 0, but can check next 3 bytes
-    const uint8_t *addr0 = (const uint8_t *)0;
-    for (uint8_t i=1; i<4; i++) {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Warray-bounds"
-        if (addr0[i] != 0) {
-            AP_memory_guard_error(1023);
-            break;
-        }
-#pragma GCC diagnostic pop
     }
 }
 #endif // MEMCHECK_ENABLED

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/malloc.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/malloc.c
@@ -81,18 +81,13 @@ void malloc_init(void)
 #endif
 
 #if defined(STM32H7)
-    // zero first 1k of ITCM. We leave 1k free to avoid addresses
-    // close to nullptr being valid. Zeroing it here means we can
-    // check for changes which indicate a write to an uninitialised
-    // object.  We start at address 0x1 as writing the first byte
-    // causes a fault
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Warray-bounds"
-#if defined(__GNUC__) &&  __GNUC__ >= 10
-#pragma GCC diagnostic ignored "-Wstringop-overflow"
-#endif
-    memset((void*)0x00000001, 0, 1023);
-#pragma GCC diagnostic pop
+    // zero first 1k of ITCM. We leave 1k free to avoid addresses close to
+    // nullptr being valid. Zeroing it here means we can check for changes
+    // which indicate a write to an uninitialised object.
+    for (int addr=0; addr<1024; addr+=4) {
+        // write using assembly so we don't invoke UB dereferencing nullptr
+        __asm__("\tstr %0, [%1]\n\t" : : "r"(0), "r"(addr));
+    }
 #endif
 
     uint8_t i;


### PR DESCRIPTION
The hardware can read and write address zero just fine, but doing it through a C null pointer will invoke undefined behavior and may cause the compiler to emit faulting instructions.

Switch to using an assembly instruction to do the actual access, thereby avoiding UB by not having an actual null pointer anywhere. Simplifies the code and reduces flash usage while improving safety 0.1%!

Tested on KakuteH7Mini that using the "nullptr write" mavlink evil command triggers an internal error. And of course that the board still boots otherwise.