### PR TITLE
AP_Scripting: fix non-string-induced null pointer dereferences

### DIFF
--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -813,7 +813,7 @@ int lua_serial_writestring(lua_State *L)
 
     // get the bytes the user wants to write, along with their length
     size_t req_bytes;
-    const char *data = lua_tolstring(L, 2, &req_bytes);
+    const char *data = luaL_checklstring(L, 2, &req_bytes);
 
     // write up to that number of bytes
     const uint32_t written_bytes = port->write((const uint8_t*)data, req_bytes);

--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -40,6 +40,15 @@ uint32_t lua_scripts::loaded_checksum;
 uint32_t lua_scripts::running_checksum;
 HAL_Semaphore lua_scripts::crc_sem;
 
+// return string error message for error object at top of stack
+static const char *get_error_object_message(lua_State *L) {
+    const char *m = lua_tostring(L, -1);
+    if (!m) { // error object is not stringifiable
+        return "<error>";
+    }
+    return m;
+}
+
 lua_scripts::lua_scripts(const AP_Int32 &vm_steps, const AP_Int32 &heap_size, AP_Int8 &debug_options)
     : _vm_steps(vm_steps),
       _debug_options(debug_options)
@@ -122,7 +131,7 @@ void lua_scripts::set_and_print_new_error_message(MAV_SEVERITY severity, const c
 }
 
 int lua_scripts::atpanic(lua_State *L) {
-    set_and_print_new_error_message(MAV_SEVERITY_CRITICAL, "Panic: %s", lua_tostring(L, -1));
+    set_and_print_new_error_message(MAV_SEVERITY_CRITICAL, "Panic: %s", get_error_object_message(L));
     longjmp(panic_jmp, 1);
     return 0;
 }
@@ -161,7 +170,7 @@ lua_scripts::script_info *lua_scripts::load_script(lua_State *L, char *filename)
     if (int error = luaL_loadfile(L, filename)) {
         switch (error) {
             case LUA_ERRSYNTAX:
-                set_and_print_new_error_message(MAV_SEVERITY_CRITICAL, "Error: %s", lua_tostring(L, -1));
+                set_and_print_new_error_message(MAV_SEVERITY_CRITICAL, "Error: %s", get_error_object_message(L));
                 lua_pop(L, lua_gettop(L));
                 return nullptr;
             case LUA_ERRMEM:
@@ -169,7 +178,7 @@ lua_scripts::script_info *lua_scripts::load_script(lua_State *L, char *filename)
                 lua_pop(L, lua_gettop(L));
                 return nullptr;
             case LUA_ERRFILE:
-                set_and_print_new_error_message(MAV_SEVERITY_CRITICAL, "Unable to load the file: %s", lua_tostring(L, -1));
+                set_and_print_new_error_message(MAV_SEVERITY_CRITICAL, "Unable to load the file: %s", get_error_object_message(L));
                 lua_pop(L, lua_gettop(L));
                 return nullptr;
             default:
@@ -340,7 +349,7 @@ void lua_scripts::run_next_script(lua_State *L) {
             // script has consumed an excessive amount of CPU time
             set_and_print_new_error_message(MAV_SEVERITY_CRITICAL, "%s exceeded time limit", script->name);
         } else {
-            set_and_print_new_error_message(MAV_SEVERITY_CRITICAL, "%s", lua_tostring(L, -1));
+            set_and_print_new_error_message(MAV_SEVERITY_CRITICAL, "%s", get_error_object_message(L));
         }
         remove_script(L, script);
         lua_pop(L, 1);


### PR DESCRIPTION
Incorrect use of the Lua string conversion functions could cause null pointer dereferences and possible autopilot faults. The simplest example is `error()`, which is guaranteed to cause a dereference if it occurs at the top level of a script, but there are some bindings susceptible to problems too. 

This is just the patches for 4.6 for easy backporting. The `error()` issue is also in 4.5 and probably earlier; that commit could be straightforwardly backported on its own. (The affected bindings are not in 4.5)

Tested on CubeOrange that the affected functions don't dereference null pointers anymore and appropriate errors are given.