### PR TITLE
Make fence action enum class

### DIFF
--- a/ArduCopter/fence.cpp
+++ b/ArduCopter/fence.cpp
@@ -58,8 +58,8 @@ void Copter::fence_check()
         }
 
         // if the user wants some kind of response and motors are armed
-        uint8_t fence_act = fence.get_action();
-        if (fence_act != AC_FENCE_ACTION_REPORT_ONLY ) {
+        const auto fence_act = fence.get_action();
+        if (fence_act != AC_Fence::Action::REPORT_ONLY ) {
 
             // disarm immediately if we think we are on the ground or in a manual flight mode with zero throttle
             // don't disarm if the high-altitude fence has been broken because it's likely the user has pulled their throttle to zero to bring it down
@@ -73,18 +73,18 @@ void Copter::fence_check()
                     set_mode(Mode::Number::LAND, ModeReason::FENCE_BREACHED);
                 } else {
                     switch (fence_act) {
-                    case AC_FENCE_ACTION_RTL_AND_LAND:
+                    case AC_Fence::Action::RTL_AND_LAND:
                     default:
                         // switch to RTL, if that fails then Land
                         if (!set_mode(Mode::Number::RTL, ModeReason::FENCE_BREACHED)) {
                             set_mode(Mode::Number::LAND, ModeReason::FENCE_BREACHED);
                         }
                         break;
-                    case AC_FENCE_ACTION_ALWAYS_LAND:
+                    case AC_Fence::Action::ALWAYS_LAND:
                         // if always land option mode is specified, land
                         set_mode(Mode::Number::LAND, ModeReason::FENCE_BREACHED);
                         break;
-                    case AC_FENCE_ACTION_SMART_RTL:
+                    case AC_Fence::Action::SMART_RTL:
                         // Try SmartRTL, if that fails, RTL, if that fails Land
                         if (!set_mode(Mode::Number::SMART_RTL, ModeReason::FENCE_BREACHED)) {
                             if (!set_mode(Mode::Number::RTL, ModeReason::FENCE_BREACHED)) {
@@ -92,13 +92,13 @@ void Copter::fence_check()
                             }
                         }
                         break;
-                    case AC_FENCE_ACTION_BRAKE:
+                    case AC_Fence::Action::BRAKE:
                         // Try Brake, if that fails Land
                         if (!set_mode(Mode::Number::BRAKE, ModeReason::FENCE_BREACHED)) {
                             set_mode(Mode::Number::LAND, ModeReason::FENCE_BREACHED);
                         }
                         break;
-                    case AC_FENCE_ACTION_SMART_RTL_OR_LAND:
+                    case AC_Fence::Action::SMART_RTL_OR_LAND:
                         // Try SmartRTL, if that fails, Land
                         if (!set_mode(Mode::Number::SMART_RTL, ModeReason::FENCE_BREACHED)) {
                             set_mode(Mode::Number::LAND, ModeReason::FENCE_BREACHED);

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -354,7 +354,7 @@ bool Copter::set_mode(Mode::Number mode, ModeReason reason)
 #endif
 
 #if AP_FENCE_ENABLED
-    if (fence.get_action() != AC_FENCE_ACTION_REPORT_ONLY) {
+    if (fence.get_action() != AC_Fence::Action::REPORT_ONLY) {
         // pilot requested flight mode change during a fence breach indicates pilot is attempting to manually recover
         // this flight mode change could be automatic (i.e. fence, battery, GPS or GCS failsafe)
         // but it should be harmless to disable the fence temporarily in these situations as well

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1363,6 +1363,8 @@ void Plane::load_parameters(void)
         }
     }
 
+
+// PARAMETER_CONVERSION - Added: March 2021 for ArduPlane-4.1
 #if AP_FENCE_ENABLED
     enum ap_var_type ptype_fence_type;
     AP_Int8 *fence_type_new = (AP_Int8*)AP_Param::find("FENCE_TYPE", &ptype_fence_type);

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1410,22 +1410,22 @@ void Plane::load_parameters(void)
     if (AP_Param::find_old_parameter(&fence_action_info_old, &fence_action_old)) {
         enum ap_var_type ptype;
         AP_Int8 *fence_action_new = (AP_Int8*)AP_Param::find(&fence_action_info_old.new_name[0], &ptype);
-        uint8_t fence_action_new_val;
+        AC_Fence::Action fence_action_new_val;
         if (fence_action_new && !fence_action_new->configured()) {
             switch(fence_action_old.get()) {
                 case 0: // FENCE_ACTION_NONE
                 case 2: // FENCE_ACTION_REPORT_ONLY
                 default:
-                    fence_action_new_val = AC_FENCE_ACTION_REPORT_ONLY;
+                    fence_action_new_val = AC_Fence::Action::REPORT_ONLY;
                     break;
                 case 1: // FENCE_ACTION_GUIDED
-                    fence_action_new_val = AC_FENCE_ACTION_GUIDED;
+                    fence_action_new_val = AC_Fence::Action::GUIDED;
                     break;
                 case 3: // FENCE_ACTION_GUIDED_THR_PASS
-                    fence_action_new_val = AC_FENCE_ACTION_GUIDED_THROTTLE_PASS;
+                    fence_action_new_val = AC_Fence::Action::GUIDED_THROTTLE_PASS;
                     break;
                 case 4: // FENCE_ACTION_RTL
-                    fence_action_new_val = AC_FENCE_ACTION_RTL_AND_LAND;
+                    fence_action_new_val = AC_Fence::Action::RTL_AND_LAND;
                     break;
             }
             fence_action_new->set_and_save((int8_t)fence_action_new_val);

--- a/ArduPlane/fence.cpp
+++ b/ArduPlane/fence.cpp
@@ -60,10 +60,10 @@ void Plane::fence_check()
         // Switch back to the chosen control mode if still in
         // GUIDED to the return point
         switch(fence.get_action()) {
-            case AC_FENCE_ACTION_GUIDED:
-            case AC_FENCE_ACTION_GUIDED_THROTTLE_PASS:
-            case AC_FENCE_ACTION_RTL_AND_LAND:
-            case AC_FENCE_ACTION_AUTOLAND_OR_RTL:
+            case AC_Fence::Action::GUIDED:
+            case AC_Fence::Action::GUIDED_THROTTLE_PASS:
+            case AC_Fence::Action::RTL_AND_LAND:
+            case AC_Fence::Action::AUTOLAND_OR_RTL:
                 if (plane.control_mode_reason == ModeReason::FENCE_BREACHED &&
                     control_mode->is_guided_mode()) {
                     set_mode(*previous_mode, ModeReason::FENCE_RETURN_PREVIOUS_MODE);
@@ -108,13 +108,20 @@ void Plane::fence_check()
         fence.print_fence_message("breached", fence_breaches.new_breaches);
 
         // if the user wants some kind of response and motors are armed
-        const uint8_t fence_act = fence.get_action();
+        const auto fence_act = fence.get_action();
         switch (fence_act) {
-        case AC_FENCE_ACTION_REPORT_ONLY:
+        case AC_Fence::Action::REPORT_ONLY:
             break;
 
-        case AC_FENCE_ACTION_AUTOLAND_OR_RTL:
-        case AC_FENCE_ACTION_RTL_AND_LAND:
+        case AC_Fence::Action::ALWAYS_LAND:
+        case AC_Fence::Action::SMART_RTL:
+        case AC_Fence::Action::SMART_RTL_OR_LAND:
+        case AC_Fence::Action::BRAKE:
+            // invalid enumeration value for Plane
+            break;
+
+        case AC_Fence::Action::AUTOLAND_OR_RTL:
+        case AC_Fence::Action::RTL_AND_LAND:
             if (control_mode == &mode_auto &&
                 mission.get_in_landing_sequence_flag() &&
                 (g.rtl_autoland == RtlAutoland::RTL_THEN_DO_LAND_START ||
@@ -127,15 +134,15 @@ void Plane::fence_check()
                 // Already landing
                 return;
             }
-            if ((fence_act == AC_FENCE_ACTION_AUTOLAND_OR_RTL) && set_mode(mode_autoland, ModeReason::FENCE_BREACHED)) {
+            if ((fence_act == AC_Fence::Action::AUTOLAND_OR_RTL) && set_mode(mode_autoland, ModeReason::FENCE_BREACHED)) {
                 break;
             }
 #endif
             set_mode(mode_rtl, ModeReason::FENCE_BREACHED);
             break;
 
-        case AC_FENCE_ACTION_GUIDED:
-        case AC_FENCE_ACTION_GUIDED_THROTTLE_PASS:
+        case AC_Fence::Action::GUIDED:
+        case AC_Fence::Action::GUIDED_THROTTLE_PASS:
             set_mode(mode_guided, ModeReason::FENCE_BREACHED);
 
             Location loc;
@@ -174,7 +181,7 @@ void Plane::fence_check()
             setup_terrain_target_alt(loc);
             set_guided_WP(loc);
 
-            if (fence.get_action() == AC_FENCE_ACTION_GUIDED_THROTTLE_PASS) {
+            if (fence.get_action() == AC_Fence::Action::GUIDED_THROTTLE_PASS) {
                 guided_throttle_passthru = true;
             }
             break;

--- a/ArduSub/fence.cpp
+++ b/ArduSub/fence.cpp
@@ -25,7 +25,7 @@ void Sub::fence_checks_async()
 
     // if the user wants some kind of response and motors are armed
     if (new_breaches) {
-        if (fence.get_action() != AC_FENCE_ACTION_REPORT_ONLY) {
+        if (fence.get_action() != AC_Fence::Action::REPORT_ONLY) {
             //
             //            // disarm immediately if we think we are on the ground or in a manual flight mode with zero throttle
             //            // don't disarm if the high-altitude fence has been broken because it's likely the user has pulled their throttle to zero to bring it down

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -71,7 +71,7 @@ const AP_Param::GroupInfo AC_Fence::var_info[] = {
     // @Values{Plane}: 0:Report Only,1:RTL,6:Guided,7:GuidedThrottlePass,8:AUTOLAND if possible else RTL
     // @Values: 0:Report Only,1:RTL or Land
     // @User: Standard
-    AP_GROUPINFO("ACTION",      2,  AC_Fence,   _action,        AC_FENCE_ACTION_RTL_AND_LAND),
+    AP_GROUPINFO("ACTION",      2,  AC_Fence,   _action,        float(Action::RTL_AND_LAND)),
 
     // @Param{Copter, Plane, Sub}: ALT_MAX
     // @DisplayName: Fence Maximum Altitude
@@ -1013,7 +1013,7 @@ bool AC_Fence::sys_status_enabled() const
     if (!sys_status_present()) {
         return false;
     }
-    if (_action == AC_FENCE_ACTION_REPORT_ONLY) {
+    if (_action == Action::REPORT_ONLY) {
         return false;
     }
     // Fence is only enabled when the flag is enabled

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -19,17 +19,6 @@
 #define AC_FENCE_ARMING_FENCES  (AC_FENCE_TYPE_ALT_MAX | AC_FENCE_TYPE_CIRCLE | AC_FENCE_TYPE_POLYGON)
 #define AC_FENCE_ALL_FENCES (AC_FENCE_ARMING_FENCES | AC_FENCE_TYPE_ALT_MIN)
 
-// valid actions should a fence be breached
-#define AC_FENCE_ACTION_REPORT_ONLY                 0       // report to GCS that boundary has been breached but take no further action
-#define AC_FENCE_ACTION_RTL_AND_LAND                1       // return to launch and, if that fails, land
-#define AC_FENCE_ACTION_ALWAYS_LAND                 2       // always land
-#define AC_FENCE_ACTION_SMART_RTL                   3       // smartRTL, if that fails, RTL, it that still fails, land
-#define AC_FENCE_ACTION_BRAKE                       4       // brake, if that fails, land
-#define AC_FENCE_ACTION_SMART_RTL_OR_LAND           5       // SmartRTL, if that fails, Land
-#define AC_FENCE_ACTION_GUIDED                      6       // guided mode, with target waypoint as fence return point
-#define AC_FENCE_ACTION_GUIDED_THROTTLE_PASS        7       // guided mode, but pilot retains manual throttle control
-#define AC_FENCE_ACTION_AUTOLAND_OR_RTL             8       // fixed wing autoland,if enabled, or RTL
-
 // give up distance
 #define AC_FENCE_GIVE_UP_DISTANCE                   100.0f  // distance outside the fence at which we should give up and just land.  Note: this is not used by library directly but is intended to be used by the main code
 
@@ -37,6 +26,19 @@ class AC_Fence
 {
 public:
     friend class AC_PolyFence_loader;
+
+// valid actions should a fence be breached
+    enum class Action {
+        REPORT_ONLY          = 0, // report to GCS that boundary has been breached but take no further action
+        RTL_AND_LAND         = 1, // return to launch and, if that fails, land
+        ALWAYS_LAND          = 2, // always land
+        SMART_RTL            = 3, // smartRTL, if that fails, RTL, and if that still fails, land
+        BRAKE                = 4, // brake, if that fails, land
+        SMART_RTL_OR_LAND    = 5, // SmartRTL, if that fails, Land
+        GUIDED               = 6, // guided mode, with target waypoint as fence return point
+        GUIDED_THROTTLE_PASS = 7, // guided mode, but pilot retains manual throttle control
+        AUTOLAND_OR_RTL      = 8, // fixed wing autoland,if enabled, or RTL
+    };
 
     enum class AutoEnable : uint8_t
     {
@@ -142,7 +144,7 @@ public:
     float get_breach_distance(uint8_t fence_type) const;
 
     /// get_action - getter for user requested action on limit breach
-    uint8_t get_action() const { return _action.get(); }
+    Action get_action() const { return _action; }
 
     /// get_safe_alt - returns maximum safe altitude (i.e. alt_max - margin)
     float get_safe_alt_max() const { return _alt_max - _margin; }
@@ -242,7 +244,7 @@ private:
     AP_Int8         _auto_enabled;          // top level flag for auto enabling fence
     uint8_t         _last_auto_enabled;     // value of auto_enabled last time we checked
     AP_Int8         _configured_fences;     // bit mask holding which fences are enabled
-    AP_Int8         _action;                // recovery action specified by user
+    AP_Enum<Action> _action;                // recovery action specified by user
     AP_Float        _alt_max;               // altitude upper limit in meters
     AP_Float        _alt_min;               // altitude lower limit in meters
     AP_Float        _circle_radius;         // circle fence radius in meters


### PR DESCRIPTION
```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                 *
CubeRedPrimary                      *      *           *       *                 0      *      *
Durandal                            *      *           *       *                 0      *      *
Hitec-Airspeed           *                 *
KakuteH7-bdshot                     *      *           *       *                 0      *      *
MatekF405                           *      *           *       *                 0      *      *
Pixhawk1-1M-bdshot                  *                  *       *                 0      *      *
f103-QiotekPeriph        *                 *
f303-Universal           *                 *
iomcu                                                                *
revo-mini                           *      *           *       *                 0      *      *
skyviper-journey                                       *
skyviper-v2450                                         *
```

Plane has a few more options in its fence handling code to avoid adding `default:`
