### PR TITLE
Dds quadplane takeoff

### DIFF
--- a/ArduPlane/Plane.cpp
+++ b/ArduPlane/Plane.cpp
@@ -1009,6 +1009,14 @@ bool Plane::is_taking_off() const
     return control_mode->is_taking_off();
 }
 
+bool Plane::start_takeoff(const float alt) {
+#if HAL_QUADPLANE_ENABLED
+    return quadplane.do_user_takeoff(alt);
+#else
+    return false;
+#endif
+}
+
 // correct AHRS pitch for PTCH_TRIM_DEG in non-VTOL modes, and return VTOL view in VTOL
 void Plane::get_osd_roll_pitch_rad(float &roll, float &pitch) const
 {

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1003,6 +1003,8 @@ private:
     bool verify_nav_wp(const AP_Mission::Mission_Command& cmd);
 #if HAL_QUADPLANE_ENABLED
     bool verify_landing_vtol_approach(const AP_Mission::Mission_Command& cmd);
+    // vtol takeoff from AP_Vehicle for quadplane.
+    bool start_takeoff(const float alt) override;
 #endif
     void do_wait_delay(const AP_Mission::Mission_Command& cmd);
     void do_within_distance(const AP_Mission::Mission_Command& cmd);

--- a/Tools/ros2/ardupilot_msgs/srv/Takeoff.srv
+++ b/Tools/ros2/ardupilot_msgs/srv/Takeoff.srv
@@ -1,5 +1,5 @@
 
-# This service requests the vehicle to takeoff
+# This service requests the vehicle to takeoff (VTOL style for QuadPlane).
 
 # alt : Set the takeoff altitude above home or above terrain(in case of rangefinder)
 


### PR DESCRIPTION
# Purpose

Allow VTOL takeoff on quadplane using DDS

# Instructions
In ros workspace
```
ros2 launch ardupilot_sitl micro_ros_agent.launch.py
```
In ardupilot
```
./Tools/autotest/sim_vehicle.py -v plane -f quadplane --console --map --enable-dds -DG
```
In a CLI, switch to guided, arm, takeoff, and send a goal location showing switch to forward flight
```
ros2 service call /ap/mode_switch ardupilot_msgs/srv/ModeSwitch "{mode: 15}" # GUIDED
ros2 service call /ap/arm_motors ardupilot_msgs/srv/ArmMotors "{arm: true}"
ros2 service call /ap/experimental/takeoff ardupilot_msgs/srv/Takeoff "{alt: 20.0}"
ros2 topic pub /ap/cmd_gps_pose ardupilot_msgs/msg/GlobalPosition "{header: {frame_id: map}, latitude: -35.36078618, longitude: 149.16231842, altitude: 600.0, coordinate_frame: 5}"
```