### PR TITLE
GCS_MAVLink: check airspeed is enabled before trying to calibrate

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4776,7 +4776,7 @@ MAV_RESULT GCS_MAVLINK::_handle_command_preflight_calibration_baro(const mavlink
 #if AP_AIRSPEED_ENABLED
 
     AP_Airspeed *airspeed = AP_Airspeed::get_singleton();
-    if (airspeed != nullptr) {
+    if (airspeed != nullptr && airspeed->enabled()) {
         GCS_MAVLINK_InProgress *task = GCS_MAVLINK_InProgress::get_task(MAV_CMD_PREFLIGHT_CALIBRATION, GCS_MAVLINK_InProgress::Type::AIRSPEED_CAL, msg.sysid, msg.compid, chan);
         if (task == nullptr) {
             return MAV_RESULT_TEMPORARILY_REJECTED;


### PR DESCRIPTION
Without this patch, ArduPilot replies with 'MAV_RESULT_IN_PROGRESS' instead of 'MAV_RESULT_ACCEPTED' for a barometer calibration with no airspeed sensor.
Copter 4.3 responded with 'MAV_RESULT_ACCEPTED' when a barometer cal was requested. 