### PR TITLE
Tracker w/o GPS

### DIFF
--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -1,3 +1,4 @@
+#include "AP_Compass/AP_Compass.h"
 #include "Tracker.h"
 
 // mission storage
@@ -65,6 +66,12 @@ void Tracker::init_ardupilot()
     // see if EEPROM has a default location as well
     if (current_loc.lat == 0 && current_loc.lng == 0) {
         get_home_eeprom(current_loc);
+    }
+
+    // force compass declination update if starting coordinates are given
+    if (current_loc.lat != 0 || current_loc.lng != 0) {
+        AP::compass().set_initial_location((float)current_loc.lat / 10000000,
+                                           (float)current_loc.lng / 10000000);
     }
 
     hal.scheduler->delay(1000); // Why????
@@ -137,6 +144,9 @@ bool Tracker::set_home(const Location &temp, bool lock)
 
     current_loc = temp;
 
+    // update compass declination with the new location
+    AP::compass().set_initial_location((float)current_loc.lat / 10000000,
+                                       (float)current_loc.lng / 10000000);
     return true;
 }
 

--- a/AntennaTracker/tracking.cpp
+++ b/AntennaTracker/tracking.cpp
@@ -1,3 +1,4 @@
+#include "AP_Compass/AP_Compass.h"
 #include "Tracker.h"
 
 /**
@@ -35,6 +36,10 @@ void Tracker::update_tracker_position()
 
     // REVISIT: what if we lose lock during a mission and the antenna is moving?
     if (ahrs.get_location(temp_loc)) {
+        // If we were stationary before, reset the compass auto-declination logic
+        if (stationary) {
+            AP::compass().unset_initial_location();
+        }
         stationary = false;
         current_loc = temp_loc;
     }

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -671,10 +671,12 @@ bool AP_Arming::gps_checks(bool report)
             }
         }
 
+#if !APM_BUILD_TYPE(APM_BUILD_AntennaTracker)
         if (!AP::ahrs().home_is_set()) {
             check_failed(Check::GPS, report, "AHRS: waiting for home");
             return false;
         }
+#endif
 
         // check GPSs are within 50m of each other and that blending is healthy
         float distance_m;

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -1942,7 +1942,7 @@ Compass::save_motor_compensation()
     }
 }
 
-void Compass::try_set_initial_location()
+void Compass::set_initial_location(float latitude, float longitude)
 {
     if (!_auto_declination) {
         return;
@@ -1951,19 +1951,23 @@ void Compass::try_set_initial_location()
         return;
     }
 
+    _initial_location_set = true;
+
+    _declination.set(radians(AP_Declination::get_declination(latitude, longitude)));
+}
+
+void Compass::try_set_initial_location()
+{
     Location loc;
     if (!AP::ahrs().get_location(loc)) {
         return;
     }
-    _initial_location_set = true;
 
     // if automatic declination is configured, then compute
     // the declination based on the initial GPS fix
     // Set the declination based on the lat/lng from GPS
-    _declination.set(radians(
-                         AP_Declination::get_declination(
-                             (float)loc.lat / 10000000,
-                             (float)loc.lng / 10000000)));
+    set_initial_location((float)loc.lat / 10000000,
+                         (float)loc.lng / 10000000);
 }
 
 /// return true if the compass should be used for yaw calculations

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -361,6 +361,16 @@ public:
     // get the first compass marked for use by COMPASSx_USE
     uint8_t get_first_usable(void) const { return _first_usable; }
 
+    /// Directly sets the initial location used to get declination
+    ///
+    /// @param  latitude             GPS Latitude.
+    /// @param  longitude            GPS Longitude.
+    ///
+    void set_initial_location(float latitude, float longitude);
+
+    /// Invalidate the initial location setup flag to auto-set the declination
+    void unset_initial_location() { _initial_location_set = false; }
+
 private:
     static Compass *_singleton;
 
@@ -651,11 +661,7 @@ private:
     CompassLearn *learn;
     bool learn_allocated;
 
-    /// Sets the initial location used to get declination
-    ///
-    /// @param  latitude             GPS Latitude.
-    /// @param  longitude            GPS Longitude.
-    ///
+    /// Sets the initial location used to get declination if not already set
     void try_set_initial_location();
     bool _initial_location_set;
 


### PR DESCRIPTION
The documentation implies that Tracker can work without a GPS unit installed by picking its location from paramters/EEPROM/home. When the tracker is actually set up like this, the `COMPASS_AUTODEC` code is never reached and `AP_Arming` spams the console with the complaints about home not being set.

This PR introduces the following:
1. Compass initial position can now be set explicitly and the flag indicating if it's set or not can be cleared from other code.
2. If Tracker has a start-up location (parameters/EEPROM) it calls set the aforementioned method which sets the declination off that location (provided `COMPASS_AUTODEC` is set etc).
3. Subsequent changes to the Tracker location while it's not using the GPS call the same method again to refresh the declination.
4. If the Tracker receives a real GPS update, it invalidates the previously set initial location flag which should restore the previous compass code path on the next update.
5. As a quality of life, we no longer complain about AHRS home in Tracker. Note that the Tracker does not have an accessible `ARMING_CHECK` parameter so it wasn't possible for the user to silence this message by just unsetting the corresponding flag.