### PR TITLE
AP_Scripting: param-set.lua: trim out unused MAV_SYSID parameter reference

### DIFF
--- a/libraries/AP_Scripting/applets/param-set.lua
+++ b/libraries/AP_Scripting/applets/param-set.lua
@@ -18,10 +18,6 @@
 local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
 local UPDATE_INTERVAL_MS = 10           -- update at about 100hz
 
--- get a reference to MAV_SYSID parameter so we can filter messages to
---   just those parameter-sets aimed at this vehicle:
-MAV_SYSID = Parameter("MAV_SYSID")
-
 -- prefix for all text messages:
 local TEXT_PREFIX_STR = "param-set"
 


### PR DESCRIPTION
We discovered we didn't need to filter to messages just to this system ID, the bindings do that

