### PR TITLE
Add autotest for peripheral passthrough

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -1089,7 +1089,19 @@ class sitl_periph_battery_tag(sitl_periph):
             AP_PERIPH_RTC_ENABLED = 1,
             AP_PERIPH_RTC_GLOBALTIME_ENABLED = 1,
         )
-        
+
+class sitl_periph_can_to_serial(sitl_periph):
+    def configure_env(self, cfg, env):
+        cfg.env.AP_PERIPH = 1
+        super().configure_env(cfg, env)
+        env.DEFINES.update(
+            HAL_BUILD_AP_PERIPH = 1,
+            PERIPH_FW = 1,
+            CAN_APP_NODE_NAME = '"org.ardupilot.serial_passthrough"',
+            APJ_BOARD_ID = 101,
+
+        )
+
 class esp32(Board):
     abstract = True
     toolchain = 'xtensa-esp32-elf'

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -11,6 +11,7 @@ import shutil
 import tempfile
 import time
 import numpy
+import pathlib
 
 from pymavlink import quaternion
 from pymavlink import mavutil
@@ -14024,6 +14025,90 @@ RTL_ALT 111
         self.change_mode('LAND')
         self.wait_disarmed()
 
+    def PeriphMultiUARTTunnel(self):
+        '''test peripheral multi-uart tunneling'''
+
+        speedup = 1
+
+        self.progress("Building Periph")
+        periph_board = 'sitl_periph_can_to_serial'
+        periph_builddir = util.reltopdir('build-periph')
+        util.build_SITL(
+            'bin/AP_Periph',
+            board=periph_board,
+            clean=False,
+            configure=True,
+            debug=True,
+            extra_configure_args=[
+                '--out', periph_builddir,
+            ],
+            # extra_defines={
+            # },
+        )
+
+        binary_path = ""
+
+        self.progress("Starting Periph simulation")
+        binary_path = pathlib.Path(periph_builddir, periph_board, 'bin', 'AP_Periph')
+        periph_rundir = util.reltopdir('run-periph')
+        if not os.path.exists(periph_rundir):
+            os.mkdir(periph_rundir)
+        periph_exp = util.start_SITL(
+            binary_path,
+            cwd=periph_rundir,
+            stdout_prefix="periph",
+            gdb=True,
+            valgrind=self.valgrind,
+            customisations=[
+                '-I', str(1),
+                '--serial0', 'mcast:',
+            ],
+            param_defaults={
+                "SIM_SPEEDUP": speedup,
+            },
+        )
+        self.expect_list_add(periph_exp)
+
+        self.progress("Reconfiguring for multicast")
+        self.customise_SITL_commandline([
+            "--serial5=mcast:",
+        ],
+            model="octa-quad:@ROMFS/models/Callisto.json",
+            defaults_filepath=self.model_defaults_filepath('Callisto'),
+            wipe=True,
+        )
+
+        self.set_parameters({
+            'SERIAL5_PROTOCOL': 2,
+            "CAN_P1_DRIVER": 1,  # needed for multicast state!
+        })
+        self.reboot_sitl()
+        self.set_parameters({
+            "CAN_D1_UC_SER_EN": 1, # enable serial
+            "CAN_D1_UC_S1_IDX": 1,  # serial port number on CAN device
+            "CAN_D1_UC_S1_NOD": 125,  # FIXME: set this explicitly
+            "CAN_D1_UC_S1_PRO": 2,  # protocol to set on remote node
+        })
+
+        self.reboot_sitl()
+
+        # must be done after the reboot:
+        self.set_parameters({
+            'SIM_SPEEDUP': speedup,
+        })
+
+        # uncomment this if you just want the test scenario set up for you:
+        # self.delay_sim_time(100000)
+
+        self.progress("Connect to the serial port on the peripheral, which should be talking mavlink")
+        mav2 = mavutil.mavlink_connection(
+            "tcp:localhost:5772",
+            robust_parsing=True,
+            source_system=9,
+            source_component=9,
+        )
+        self.assert_receive_message("HEARTBEAT", mav=mav2, very_verbose=True)
+
     def tests2b(self):  # this block currently around 9.5mins here
         '''return list of all tests'''
         ret = ([
@@ -14146,7 +14231,8 @@ RTL_ALT 111
             self.Ch6TuningLoitMaxXYSpeed,
             self.TestEKF3CompassFailover,
             self.test_EKF3_option_disable_lane_switch,
-            self.PLDNoParameters
+            self.PLDNoParameters,
+            self.PeriphMultiUARTTunnel,
         ])
         return ret
 

--- a/Tools/autotest/pysim/util.py
+++ b/Tools/autotest/pysim/util.py
@@ -427,7 +427,8 @@ def start_SITL(binary,
                lldb=False,
                enable_fgview=False,
                supplementary=False,
-               stdout_prefix=None):
+               stdout_prefix=None,
+               ):
 
     """Launch a SITL instance."""
     cmd = []

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -14932,8 +14932,12 @@ SERIAL5_BAUD 128
 
         return psd
 
-    def model_defaults_filepath(self, model):
-        vehicle = self.vehicleinfo_key()
+    def model_defaults_filepath(self, model, vehicleinfo_key=None):
+        if vehicleinfo_key is None:
+            vehicle = self.vehicleinfo_key()
+        else:
+            vehicle = vehicleinfo_key
+
         vinfo = vehicleinfo.VehicleInfo()
         defaults_filepath = vinfo.options[vehicle]["frames"][model]["default_params_filename"]
         if isinstance(defaults_filepath, str):

--- a/libraries/AP_HAL_SITL/SITL_Periph_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_Periph_State.cpp
@@ -40,6 +40,9 @@ using namespace HALSITL;
     };
 
 void SITL_State::init(int argc, char * const argv[]) {
+    const int BASE_PORT = 5760;
+    _base_port = BASE_PORT;
+
     int opt;
     const struct GetOptLong::option options[] = {
         {"help",            false,  0, 'h'},
@@ -69,6 +72,9 @@ void SITL_State::init(int argc, char * const argv[]) {
         switch (opt) {
         case 'I':
             _instance = atoi(gopt.optarg);
+            if (_base_port == BASE_PORT) {
+                _base_port += _instance * 10;
+            }
             break;
         case 'M':
             printf("Running in Maintenance Mode\n");


### PR DESCRIPTION
Adds a test which makes sure serial passthrough on CAN (via the targetted-Tunnel DroneCAN message) works.  This is in preparation for expanding the function's capabilities.

This is a different approach to testing peripheral behaviour and interaction with the main ArduPilot process.

The current means of testing CAN is based on "supplemental" binaries and is supported somewhat in the framework.  The test suite lists binaries to run and adds steps to build them.  Someone running the test must run both build steps simultaneously to make the suite work (see `sitltest-can` in `build_ci.sh`) https://github.com/ArduPilot/ardupilot/pull/27233 is a fair example of what's required to add a test using this mechanism - it's essentially another test suite.


The approach taken in this PR is to compile and run binaries as required.  It's rather raw and has one major drawback - it rebuilds the peripheral every time the test runs.  OTOH it is quite self-contained and extremely flexible.

I've used this approach twice before and it's worked quite well.  You can set up reasonably complicated scenarios of multiple vehicles quite easily.

This work sponsored by Freespace Solutions.
