### PR TITLE
GCS_MAVLink: set message interval fail msg only sent on SITL

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3135,7 +3135,9 @@ MAV_RESULT GCS_MAVLINK::set_message_interval(uint32_t msg_id, int32_t interval_u
 {
     const ap_message id = mavlink_id_to_ap_message_id(msg_id);
     if (id == MSG_LAST) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "No ap_message for mavlink id (%u)", (unsigned int)msg_id);
+#endif  // CONFIG_HAL_BOARD == HAL_BOARD_SITL
         return MAV_RESULT_DENIED;
     }
 


### PR DESCRIPTION
This follow-up to https://github.com/ArduPilot/ardupilot/pull/29783 stops another "No ap_message for mavlink id (xxx)" status text message from being sent when a set-message-interval request fails except for on SITL where we continue to send it.

Thanks to @Hwurzburg for finding this

This has been tested in SITL and on real hardware to ensure that the message appears before the change but does not appear afterwards.  For that testing I used Mission Planner's Ctrl-F screen to pull up the "Message Interval" screen and then chose an unsupported message (e.g. ACTUATOR_CONTROL_TARGET) and set the interval to 3hz
![image](https://github.com/user-attachments/assets/b56fd8b5-9fdb-4cef-b65e-0249cdb91205)

Before this change we see the message appear, after the change it does not
![image](https://github.com/user-attachments/assets/640d2785-56d1-4f78-915d-ea7764b5a065)
