### PR TITLE
Tools: add -Wno-format-security to littlefs waf build flags

### DIFF
--- a/Tools/ardupilotwaf/littlefs.py
+++ b/Tools/ardupilotwaf/littlefs.py
@@ -20,6 +20,6 @@ def littlefs(bld, **kw):
         source=['modules/littlefs/lfs.c', 'modules/littlefs/lfs_util.c', 'modules/littlefs/bd/lfs_filebd.c'],
         target='littlefs',
         defines=['LFS_NO_DEBUG', 'LFS_NO_WARN', 'LFS_NO_ERROR', 'LFS_NO_ASSERT'],
-        cflags=['-Wno-format', '-Wno-format-extra-args', '-Wno-shadow', '-Wno-unused-function', '-Wno-missing-declarations']
+        cflags=['-Wno-format-security', '-Wno-format', '-Wno-format-extra-args', '-Wno-shadow', '-Wno-unused-function', '-Wno-missing-declarations']
     )
     return bld.stlib(**kw)


### PR DESCRIPTION
The littlefs module failed to build with some compilers as the -Wformat-security flag, which is enabled globally, requires the -Wformat flag, which was disabled specifically for this module.
