### PR TITLE
hwdef:revert osd type change

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743-AIO/defaults.parm
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743-AIO/defaults.parm
@@ -1,2 +1,0 @@
-#Enable DisplayPort OSD
-OSD_TYPE2 5

--- a/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743-AIO/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743-AIO/hwdef.dat
@@ -154,7 +154,7 @@ define DEFAULT_SERIAL6_PROTOCOL SerialProtocol_ESCTelemetry
 
 # setup for OSD
 define OSD_ENABLED 1
-define HAL_OSD_TYPE_DEFAULT 1
+define HAL_OSD_TYPE_DEFAULT 5
 
 # setup for BF migration
 define HAL_FRAME_TYPE_DEFAULT 12


### PR DESCRIPTION
this autopilot does not have an onboard OSD chip and should not have had the correction