### PR TITLE
Fix AP_DDS init on ChibiOS with GPS lock

### DIFF
--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -720,18 +720,18 @@ bool AP_DDS_Client::update_topic(ardupilot_msgs_msg_Status& msg)
     uint8_t fs_iter = 0;
     msg.failsafe_size = 0;
     if (rc().in_rc_failsafe()) {
-        msg.failsafe[fs_iter++] = FS_RADIO;
+        msg.failsafe[fs_iter++] = ardupilot_msgs_msg_Status_FS_RADIO;
     }
     if (battery.has_failsafed()) {
-        msg.failsafe[fs_iter++] = FS_BATTERY;
+        msg.failsafe[fs_iter++] = ardupilot_msgs_msg_Status_FS_BATTERY;
     }
     // TODO: replace flag with function.
     if (AP_Notify::flags.failsafe_gcs) {
-        msg.failsafe[fs_iter++] = FS_GCS;
+        msg.failsafe[fs_iter++] = ardupilot_msgs_msg_Status_FS_GCS;
     }
     // TODO: replace flag with function.
     if (AP_Notify::flags.failsafe_ekf) {
-        msg.failsafe[fs_iter++] = FS_EKF;
+        msg.failsafe[fs_iter++] = ardupilot_msgs_msg_Status_FS_EKF;
     }
     msg.failsafe_size = fs_iter;
 
@@ -1051,13 +1051,13 @@ void AP_DDS_Client::on_request(uxrSession* uxr_session, uxrObjectId object_id, u
             bool param_isinf = true;
             float param_value = 0.0f;
             switch (param.value.type) {
-            case PARAMETER_INTEGER: {
+            case rcl_interfaces_msg_ParameterType_PARAMETER_INTEGER: {
                 param_isnan = isnan(param.value.integer_value);
                 param_isinf = isinf(param.value.integer_value);
                 param_value = float(param.value.integer_value);
                 break;
             }
-            case PARAMETER_DOUBLE: {
+            case rcl_interfaces_msg_ParameterType_PARAMETER_DOUBLE: {
                 param_isnan = isnan(param.value.double_value);
                 param_isinf = isinf(param.value.double_value);
                 param_value = float(param.value.double_value);
@@ -1151,38 +1151,38 @@ void AP_DDS_Client::on_request(uxrSession* uxr_session, uxrObjectId object_id, u
 
             vp = AP_Param::find(param_key, &var_type);
             if (vp == nullptr) {
-                get_parameters_response.values[i].type = PARAMETER_NOT_SET;
+                get_parameters_response.values[i].type = rcl_interfaces_msg_ParameterType_PARAMETER_NOT_SET;
                 successful_read &= false;
                 continue;
             }
 
             switch (var_type) {
             case AP_PARAM_INT8: {
-                get_parameters_response.values[i].type = PARAMETER_INTEGER;
+                get_parameters_response.values[i].type = rcl_interfaces_msg_ParameterType_PARAMETER_INTEGER;
                 get_parameters_response.values[i].integer_value = ((AP_Int8 *)vp)->get();
                 successful_read &= true;
                 break;
             }
             case AP_PARAM_INT16: {
-                get_parameters_response.values[i].type = PARAMETER_INTEGER;
+                get_parameters_response.values[i].type = rcl_interfaces_msg_ParameterType_PARAMETER_INTEGER;
                 get_parameters_response.values[i].integer_value = ((AP_Int16 *)vp)->get();
                 successful_read &= true;
                 break;
             }
             case AP_PARAM_INT32: {
-                get_parameters_response.values[i].type = PARAMETER_INTEGER;
+                get_parameters_response.values[i].type = rcl_interfaces_msg_ParameterType_PARAMETER_INTEGER;
                 get_parameters_response.values[i].integer_value = ((AP_Int32 *)vp)->get();
                 successful_read &= true;
                 break;
             }
             case AP_PARAM_FLOAT: {
-                get_parameters_response.values[i].type = PARAMETER_DOUBLE;
+                get_parameters_response.values[i].type = rcl_interfaces_msg_ParameterType_PARAMETER_DOUBLE;
                 get_parameters_response.values[i].double_value = vp->cast_to_float(var_type);
                 successful_read &= true;
                 break;
             }
             default: {
-                get_parameters_response.values[i].type = PARAMETER_NOT_SET;
+                get_parameters_response.values[i].type = rcl_interfaces_msg_ParameterType_PARAMETER_NOT_SET;
                 successful_read &= false;
                 break;
             }
@@ -1220,6 +1220,12 @@ void AP_DDS_Client::on_request(uxrSession* uxr_session, uxrObjectId object_id, u
 void AP_DDS_Client::main_loop(void)
 {
     GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s initializing...", msg_prefix);
+
+    while (AP::rtc().get_source_type() == AP_RTC::SOURCE_NONE) {
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s Waiting 1s for RTC...", msg_prefix);
+        hal.scheduler->delay(1000);
+    }
+
     if (!init_transport()) {
         return;
     }

--- a/libraries/AP_RTC/AP_RTC.h
+++ b/libraries/AP_RTC/AP_RTC.h
@@ -65,6 +65,10 @@ public:
     bool clock_s_to_date_fields(const uint32_t utc_sec32, uint16_t& year, uint8_t& month, uint8_t& day, uint8_t &hour, uint8_t &min, uint8_t &sec, uint8_t &wday) const;
     uint32_t date_fields_to_clock_s(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t min, uint8_t sec) const;
 
+    source_type get_source_type() const {
+        return rtc_source_type;
+    }
+
 private:
 
     static AP_RTC *_singleton;


### PR DESCRIPTION
If the RTC doesn't have a source, AP_DDS initialization will currently fail. This patch blocks AP_DDS from starting till the RTC has a source.

A longer term improvement would be to lock AP_DDS onto an RTC source once it starts and never switch. If the RTC is expected to never have a source, AP_DDS will just use the millis() for the entire duration.

This is easily tested in SITL. Start sitl with AP_DDS, 
```
param set SIM_GPS1_ENABLE 0
reboot
```

Wait   a while, observe AP_DDS blocked from initialization, and then set SIM_GPS1_ENABLE  to 1 to observe it boot.

Tested this RTC patch on a vehicle running 4.5.

Closes #25535

Needs backport


Sponsored by AeroVironment, Inc.
