### PR TITLE
AC_Autotune: Fix gain load problem when mode set to FAILED

### DIFF
--- a/libraries/AC_AutoTune/AC_AutoTune.h
+++ b/libraries/AC_AutoTune/AC_AutoTune.h
@@ -207,7 +207,8 @@ protected:
         WAITING_FOR_LEVEL = 0,    // autotune is waiting for vehicle to return to level before beginning the next twitch
         TESTING           = 1,    // autotune has begun a test and is watching the resulting vehicle movement
         UPDATE_GAINS      = 2,    // autotune has completed a test and is updating the gains based on the results
-        ABORT             = 3     // load normal gains and return to WAITING_FOR_LEVEL
+        ABORT             = 3,    // load normal gains and return to WAITING_FOR_LEVEL
+        COMPLETE          = 4,    // load original gains
     };
 
     // mini steps performed while in Tuning mode, Testing step

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
@@ -286,6 +286,8 @@ void AC_AutoTune_Heli::test_run(AxisType test_axis, const float dir_sign)
             mode = FAILED;
             LOGGER_WRITE_EVENT(LogEvent::AUTOTUNE_FAILED);
             update_gcs(AUTOTUNE_MESSAGE_FAILED);
+            // Load Original Gains
+            step = COMPLETE;
         } else if ((tune_type == MAX_GAINS || tune_type == RP_UP || tune_type == RD_UP || tune_type == SP_UP) && exceeded_freq_range(start_freq)){
             GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: Exceeded frequency range");
             mode = FAILED;

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -581,14 +581,16 @@ void AC_AutoTune_Multi::twitching_abort_rate(float angle, float rate, float angl
             // reduce the maximum target rate
             if (step_scaler > 0.2f) {
                 step_scaler *= 0.9f;
+                // ignore result and start test again
+                step = ABORT;
             } else {
                 LOGGER_WRITE_EVENT(LogEvent::AUTOTUNE_REACHED_LIMIT);
                 GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "AutoTune: Twitch Size Determination Failed");
                 mode = FAILED;
                 LOGGER_WRITE_EVENT(LogEvent::AUTOTUNE_FAILED);
+                // Load Original Gains
+                step = COMPLETE;
             }
-            // ignore result and start test again
-            step = ABORT;
         } else {
             step = UPDATE_GAINS;
         }
@@ -960,6 +962,8 @@ void AC_AutoTune_Multi::updating_rate_p_up_d_down(float &tune_d, float tune_d_mi
                 GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "AutoTune: Rate D Gain Determination Failed");
                 mode = FAILED;
                 LOGGER_WRITE_EVENT(LogEvent::AUTOTUNE_FAILED);
+                // Load Original Gains
+                step = COMPLETE;
             }
         }
         // decrease P gain to match D gain reduction
@@ -970,6 +974,8 @@ void AC_AutoTune_Multi::updating_rate_p_up_d_down(float &tune_d, float tune_d_mi
             GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "AutoTune: Rate P Gain Determination Failed");
             mode = FAILED;
             LOGGER_WRITE_EVENT(LogEvent::AUTOTUNE_FAILED);
+            // Load Original Gains
+            step = COMPLETE;
         }
     } else {
         if (ignore_next == false) {
@@ -1019,6 +1025,8 @@ void AC_AutoTune_Multi::updating_angle_p_down(float &tune_p, float tune_p_min, f
             GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "AutoTune: Angle P Gain Determination Failed");
             mode = FAILED;
             LOGGER_WRITE_EVENT(LogEvent::AUTOTUNE_FAILED);
+            // Load Original Gains
+            step = COMPLETE;
        }
     }
 }

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -7,6 +7,7 @@
 #include <AP_Logger/AP_Logger.h>
 #include <AP_Scheduler/AP_Scheduler.h>
 #include <GCS_MAVLink/GCS.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 
 /*
  * autotune support for multicopters
@@ -58,7 +59,13 @@
 #define AUTOTUNE_FLTE_MIN                  2.5     // minimum Rate Yaw error filter value
 #define AUTOTUNE_RP_MIN                   0.01     // minimum Rate P value
 #define AUTOTUNE_RP_MAX                    2.0     // maximum Rate P value
-#define AUTOTUNE_SP_MAX                   40.0     // maximum Stab P value
+
+#if APM_BUILD_TYPE(APM_BUILD_ArduPlane)
+ #define AUTOTUNE_SP_MAX                   10.0     // maximum Stab P value
+#else
+ #define AUTOTUNE_SP_MAX                   40.0     // maximum Stab P value
+#endif
+
 #define AUTOTUNE_SP_MIN                    0.5     // maximum Stab P value
 #define AUTOTUNE_RP_ACCEL_MIN            4000.0    // Minimum acceleration for Roll and Pitch
 #define AUTOTUNE_Y_ACCEL_MIN             1000.0    // Minimum acceleration for Yaw


### PR DESCRIPTION
This PR fixes a serious bug in the Multirotor Autotune where we break the primary rule "Gains are only changed from default (I excepted) during the twitch".

The code is set up such that when a test `step = ABORT;` is changed the gains are not changed immediately but instead on the next loop. When we also set `mode = FAILED;` we don't run the next loop.

This is where we set mode to FAILED:
https://github.com/ArduPilot/ardupilot/blob/d229c8c74655e2e9b9d42b95b212a0c286c8066a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp#L580

This is why the loop doesn't run again:
https://github.com/ArduPilot/ardupilot/blob/d229c8c74655e2e9b9d42b95b212a0c286c8066a/libraries/AC_AutoTune/AC_AutoTune.cpp#L303

