### PR TITLE
GCS_MAVLink: protect control sensor flag bitmasks with a semaphore

### DIFF
--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -131,6 +131,8 @@ void GCS::get_sensor_status_flags(uint32_t &present,
 ASSERT_STORAGE_SIZE(GCS::statustext_t, 58);
 #endif
 
+    WITH_SEMAPHORE(control_sensors_sem);
+
     update_sensor_status_flags();
 
     present = control_sensors_present;
@@ -267,6 +269,9 @@ bool GCS::install_alternative_protocol(mavlink_channel_t c, GCS_MAVLINK::protoco
     return true;
 }
 
+// note that control_sensors_present and friends are protected by
+// control_sensors_sem.  There is currently only one caller to this
+// method, and it does the protection for us.
 void GCS::update_sensor_status_flags()
 {
     control_sensors_present = 0;

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -1323,6 +1323,7 @@ protected:
 
     virtual GCS_MAVLINK *new_gcs_mavlink_backend(AP_HAL::UARTDriver &uart) = 0;
 
+    HAL_Semaphore control_sensors_sem; // protects the three bitmasks
     uint32_t control_sensors_present;
     uint32_t control_sensors_enabled;
     uint32_t control_sensors_health;


### PR DESCRIPTION
nothing says get_sensor_status_flags can't be called from multiple threads.

If it is called from multiple threads then there's a reasonably obvious race where the mask can be cleared while some other process is already updating the flags.  That can cause a caller to report something as unhealthy when it isn't.