### PR TITLE
Refactor AC_PID comments and internal naming for clarity and consistency

### DIFF
--- a/libraries/AC_PID/AC_P.cpp
+++ b/libraries/AC_PID/AC_P.cpp
@@ -1,12 +1,12 @@
 /// @file	AC_P.cpp
-/// @brief	Generic P algorithm
+/// @brief	Single-axis P controller with EEPROM-backed gain storage.
 
 #include <AP_Math/AP_Math.h>
 #include "AC_P.h"
 
 const AP_Param::GroupInfo AC_P::var_info[] = {
     // @Param: P
-    // @DisplayName: PI Proportional Gain
+    // @DisplayName: P Proportional Gain
     // @Description: P Gain which produces an output value that is proportional to the current error value
     AP_GROUPINFO_FLAGS_DEFAULT_POINTER("P",    0, AC_P, _kp, default_kp),
     AP_GROUPEND
@@ -17,11 +17,13 @@ float AC_P::get_p(float error) const
     return (float)error * _kp;
 }
 
+// Loads controller configuration from EEPROM, including gains and filter frequencies. (not used)
 void AC_P::load_gains()
 {
     _kp.load();
 }
 
+// Saves controller configuration from EEPROM. Used by autotune to save gains before tuning.
 void AC_P::save_gains()
 {
     _kp.save();

--- a/libraries/AC_PID/AC_P.h
+++ b/libraries/AC_PID/AC_P.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /// @file	AC_PD.h
-/// @brief	Generic P controller with EEPROM-backed storage of constants.
+/// @brief	Single-axis P controller with EEPROM-backed gain storage.
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
@@ -13,7 +13,8 @@
 class AC_P {
 public:
 
-    /// Constructor for P that saves its settings to EEPROM
+    /// Constructor for P controller with EEPROM-backed gain.
+    /// Parameters are initialized from defaults or EEPROM at runtime.
     ///
     /// @note	PIs must be named to avoid either multiple parameters with the
     ///			same name, or an overly complex constructor.
@@ -33,21 +34,14 @@ public:
     /// Positive error produces positive output.
     ///
     /// @param error	The measured error value
-    /// @param dt		The time delta in milliseconds (note
-    ///					that update interval cannot be more
-    ///					than 65.535 seconds due to limited range
-    ///					of the data type).
-    ///
     /// @returns		The updated control output.
     ///
     float       get_p(float error) const;
 
-    /// Load gain properties
-    ///
+    // Loads controller configuration from EEPROM, including gains and filter frequencies. (not used)
     void        load_gains();
 
-    /// Save gain properties
-    ///
+    // Saves controller configuration from EEPROM. Used by autotune to save gains before tuning.
     void        save_gains();
 
     /// @name	parameter accessors

--- a/libraries/AC_PID/AC_PID_2D.cpp
+++ b/libraries/AC_PID/AC_PID_2D.cpp
@@ -1,5 +1,5 @@
 /// @file	AC_PID_2D.cpp
-/// @brief	Generic PID algorithm
+/// @brief	2D PID controller with vector support, input filtering, integrator clamping, and EEPROM-backed gain storage.
 
 #include <AP_Math/AP_Math.h>
 #include "AC_PID_2D.h"
@@ -23,8 +23,8 @@ const AP_Param::GroupInfo AC_PID_2D::var_info[] = {
     AP_GROUPINFO_FLAGS_DEFAULT_POINTER("IMAX", 2, AC_PID_2D, _kimax, default_kimax),
 
     // @Param: FLTE
-    // @DisplayName: PID Input filter frequency in Hz
-    // @Description: Input filter frequency in Hz
+    // @DisplayName: PID Error filter frequency in Hz
+    // @Description: Low-pass filter frequency applied to the error (Hz)
     // @Units: Hz
     AP_GROUPINFO_FLAGS_DEFAULT_POINTER("FLTE", 3, AC_PID_2D, _filt_E_hz, default_filt_E_hz),
 
@@ -35,8 +35,8 @@ const AP_Param::GroupInfo AC_PID_2D::var_info[] = {
 
     // @Param: FLTD
     // @DisplayName: D term filter frequency in Hz
-    // @Description: D term filter frequency in Hz
-    // @Units: Hz
+    // @Description: Low-pass filter frequency applied to the derivative (Hz)
+    // @Units: Hzs
     AP_GROUPINFO_FLAGS_DEFAULT_POINTER("FLTD", 5, AC_PID_2D, _filt_D_hz, default_filt_D_hz),
 
     // @Param: FF
@@ -64,13 +64,12 @@ AC_PID_2D::AC_PID_2D(float initial_kP, float initial_kI, float initial_kD, float
     _reset_filter = true;
 }
 
-//  update_all - set target and measured inputs to PID controller and calculate outputs
-//  target and error are filtered
-//  the derivative is then calculated and filtered
-//  the integral is then updated if it does not increase in the direction of the limit vector
+// Computes the 2D PID output from target and measurement vectors.
+// Applies filtering to error and derivative terms.
+// Integrator is updated only if it does not grow in the direction of the specified limit vector.
 Vector2f AC_PID_2D::update_all(const Vector2f &target, const Vector2f &measurement, float dt, const Vector2f &limit)
 {
-    // don't process inf or NaN
+    // Return zero if any component is NaN or infinite
     if (target.is_nan() || target.is_inf() ||
         measurement.is_nan() || measurement.is_inf()) {
         return Vector2f{};
@@ -80,14 +79,17 @@ Vector2f AC_PID_2D::update_all(const Vector2f &target, const Vector2f &measureme
 
     // reset input filter to value received
     if (_reset_filter) {
+        // Reset filters to match the current inputs
         _reset_filter = false;
         _error = _target - measurement;
+        // Reset the derivative to avoid transients
         _derivative.zero();
     } else {
         Vector2f error_last{_error};
+        // Apply first-order low-pass filter to error
         _error += ((_target - measurement) - _error) * get_filt_E_alpha(dt);
 
-        // calculate and filter derivative
+        // Compute and low-pass filter the derivative
         if (is_positive(dt)) {
             const Vector2f derivative{(_error - error_last) / dt};
             _derivative += (derivative - _derivative) * get_filt_D_alpha(dt);
@@ -113,6 +115,7 @@ Vector2f AC_PID_2D::update_all(const Vector2f &target, const Vector2f &measureme
     _pid_info_y.D = _derivative.y * _kd;
     _pid_info_y.FF = _target.y * _kff;
 
+    // Return total control output: P + I + D + FF terms
     return _error * _kp + _integrator + _derivative * _kd + _target * _kff;
 }
 
@@ -121,8 +124,8 @@ Vector2f AC_PID_2D::update_all(const Vector3f &target, const Vector3f &measureme
     return update_all(Vector2f{target.x, target.y}, Vector2f{measurement.x, measurement.y}, dt, Vector2f{limit.x, limit.y});
 }
 
-//  update_i - update the integral
-//  If the limit is set the integral is only allowed to reduce in the direction of the limit
+// Updates the 2D integrator using the filtered error.
+// The integrator is only allowed to grow if it does not push further in the direction of the limit vector.
 void AC_PID_2D::update_i(float dt, const Vector2f &limit)
 {
     _pid_info_x.limit = false;
@@ -131,12 +134,13 @@ void AC_PID_2D::update_i(float dt, const Vector2f &limit)
     Vector2f delta_integrator = (_error * _ki) * dt;
     float integrator_length = _integrator.length();
     _integrator += delta_integrator;
-    // do not let integrator increase in length if delta_integrator is in the direction of limit
+    // Compute integrator delta and apply anti-windup by limiting growth in the direction of the limit vector
     if (is_positive(delta_integrator * limit) && _integrator.limit_length(integrator_length)) {
         _pid_info_x.limit = true;
         _pid_info_y.limit = true;
     }
 
+    // Clamp integrator to maximum length (IMAX)
     _integrator.limit_length(_kimax);
 }
 
@@ -155,6 +159,7 @@ Vector2f AC_PID_2D::get_d() const
     return _derivative * _kd;
 }
 
+// Update FF terms in PID logs and return feedforward vector
 Vector2f AC_PID_2D::get_ff()
 {
     _pid_info_x.FF = _target.x * _kff;
@@ -167,7 +172,7 @@ void AC_PID_2D::reset_I()
     _integrator.zero(); 
 }
 
-// save_gains - save gains to eeprom
+// Saves controller configuration from EEPROM, including gains and filter frequencies. (not used)
 void AC_PID_2D::save_gains()
 {
     _kp.save();
@@ -179,28 +184,31 @@ void AC_PID_2D::save_gains()
     _filt_D_hz.save();
 }
 
-// get the target filter alpha
+// Returns alpha value for the error low-pass filter (based on filter frequency and dt)
 float AC_PID_2D::get_filt_E_alpha(float dt) const
 {
     return calc_lowpass_alpha_dt(dt, _filt_E_hz);
 }
 
-// get the derivative filter alpha
+// Returns alpha value for the derivative low-pass filter (based on filter frequency and dt)
 float AC_PID_2D::get_filt_D_alpha(float dt) const
 {
     return calc_lowpass_alpha_dt(dt, _filt_D_hz);
 }
 
+// Compute error from target and measurement, then set integrator
 void AC_PID_2D::set_integrator(const Vector2f& target, const Vector2f& measurement, const Vector2f& i)
 {
     set_integrator(target - measurement, i);
 }
 
+// Convert from desired total output and error to integrator value
 void AC_PID_2D::set_integrator(const Vector2f& error, const Vector2f& i)
 {
     set_integrator(i - error * _kp);
 }
 
+// Set integrator directly and clamp to IMAX
 void AC_PID_2D::set_integrator(const Vector2f& i)
 {
     _integrator = i;

--- a/libraries/AC_PID/AC_PI_2D.cpp
+++ b/libraries/AC_PID/AC_PI_2D.cpp
@@ -130,6 +130,7 @@ void AC_PI_2D::reset_I()
     _integrator.zero();
 }
 
+// Loads controller configuration from EEPROM, including gains and filter frequencies. (not used)
 void AC_PI_2D::load_gains()
 {
     _kp.load();
@@ -142,7 +143,7 @@ void AC_PI_2D::load_gains()
     calc_filt_alpha();
 }
 
-// save_gains - save gains to eeprom
+// Saves controller configuration from EEPROM, including gains and filter frequencies. (not used)
 void AC_PI_2D::save_gains()
 {
     _kp.save();

--- a/libraries/AC_PID/AC_PI_2D.h
+++ b/libraries/AC_PID/AC_PI_2D.h
@@ -41,10 +41,10 @@ public:
     // reset_filter - input filter will be reset to the next value provided to set_input()
     void reset_filter();
 
-    // load gain from eeprom
+    // Loads controller configuration from EEPROM, including gains and filter frequencies. (not used)
     void load_gains();
 
-    // save gain to eeprom
+    // Saves controller configuration from EEPROM, including gains and filter frequencies. (not used)
     void save_gains();
 
     // get accessors

--- a/libraries/AC_PID/AC_P_1D.cpp
+++ b/libraries/AC_PID/AC_P_1D.cpp
@@ -1,5 +1,5 @@
 /// @file	AC_P_1D.cpp
-/// @brief	Generic P algorithm
+/// @brief	Position-based P controller with optional limits on output and its first derivative.
 
 #include <AP_Math/AP_Math.h>
 #include "AC_P_1D.h"
@@ -20,13 +20,15 @@ AC_P_1D::AC_P_1D(float initial_p) :
     AP_Param::setup_object_defaults(this, var_info);
 }
 
-// update_all - set target and measured inputs to P controller and calculate outputs
-// target and measurement are filtered
+// Computes the P controller output given a target and measurement.
+// Applies position error clamping based on configured limits.
+// Optionally constrains output slope using the sqrt_controller.
 float AC_P_1D::update_all(float &target, float measurement)
 {
-    // calculate distance _error
+    // Compute position error between target and measurement
     _error = target - measurement;
 
+    // Clamp error to configured min/max bounds
     if (is_negative(_error_min) && (_error < _error_min)) {
         _error = _error_min;
         target = measurement + _error;
@@ -35,40 +37,44 @@ float AC_P_1D::update_all(float &target, float measurement)
         target = measurement + _error;
     }
 
-    // MIN(_Dxy_max, _D2xy_max / _kxy_P) limits the max accel to the point where max jerk is exceeded
+    // Use sqrt_controller to limit output and/or its derivative
     return sqrt_controller(_error, _kp, _D1_max, 0.0);
 }
 
-// set_limits - sets the maximum error to limit output and first and second derivative of output
-// when using for a position controller, lim_err will be position error, lim_out will be correction velocity, lim_D will be acceleration, lim_D2 will be jerk
+// Sets limits on output, output slope (D1), and output acceleration (D2).
+// For position controllers: output = velocity, D1 = acceleration, D2 = jerk.
 void AC_P_1D::set_limits(float output_min, float output_max, float D_Out_max, float D2_Out_max)
 {
+    // Reset all limits to zero before applying new ones
     _D1_max = 0.0f;
     _error_min = 0.0f;
     _error_max = 0.0f;
 
+    // Set first derivative (acceleration) limit if specified
     if (is_positive(D_Out_max)) {
         _D1_max = D_Out_max;
     }
 
+    // If second derivative (jerk) limit is specified, constrain velocity limit accordingly
     if (is_positive(D2_Out_max) && is_positive(_kp)) {
         // limit the first derivative so as not to exceed the second derivative
         _D1_max = MIN(_D1_max, D2_Out_max / _kp);
     }
 
+    // Compute min/max allowable error from output limits
     if (is_negative(output_min) && is_positive(_kp)) {
         _error_min = inv_sqrt_controller(output_min, _kp, _D1_max);
     }
-
     if (is_positive(output_max) && is_positive(_kp)) {
         _error_max = inv_sqrt_controller(output_max, _kp, _D1_max);
     }
 }
 
-// set_error_limits - reduce maximum error to error_max
-// to be called after setting limits
+// Reduces error limits to user-specified bounds, respecting previously computed limits.
+// Intended to be called after `set_limits()`.
 void AC_P_1D::set_error_limits(float error_min, float error_max)
 {
+    // Update _error_min if it's non-zero and the new value is more conservative
     if (is_negative(error_min)) {
         if (!is_zero(_error_min)) {
             _error_min = MAX(_error_min, error_min);
@@ -77,6 +83,7 @@ void AC_P_1D::set_error_limits(float error_min, float error_max)
         }
     }
 
+    // Update _error_max if it's non-zero and the new value is more conservative
     if (is_positive(error_max)) {
         if (!is_zero(_error_max)) {
             _error_max = MIN(_error_max, error_max);

--- a/libraries/AC_PID/AC_P_1D.h
+++ b/libraries/AC_PID/AC_P_1D.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /// @file	AC_P_1D.h
-/// @brief	Generic P controller, with EEPROM-backed storage of constants.
+/// @brief	Position-based P controller with optional limits on output and its first derivative.
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
@@ -11,29 +11,31 @@
 class AC_P_1D {
 public:
 
-    // constructor
+    /// Constructor for 1D P controller with initial gain.
     AC_P_1D(float initial_p);
 
     CLASS_NO_COPY(AC_P_1D);
 
-    // update_all - set target and measured inputs to P controller and calculate outputs
-    // target and measurement are filtered
+    // Computes the P controller output given a target and measurement.
+    // Applies position error clamping based on configured limits.
+    // Optionally constrains output slope using the sqrt_controller.
     float update_all(float &target, float measurement) WARN_IF_UNUSED;
 
-    // set_limits - sets the maximum error to limit output and first and second derivative of output
+    // Sets limits on output, output slope (D1), and output acceleration (D2).
+    // For position controllers: output = velocity, D1 = acceleration, D2 = jerk.
     void set_limits(float output_min, float output_max, float D_Out_max = 0.0f, float D2_Out_max = 0.0f);
 
-    // set_error_limits - reduce maximum position error to error_max
-    // to be called after setting limits
+    // Reduces error limits to user-specified bounds, respecting previously computed limits.
+    // Intended to be called after `set_limits()`.
     void set_error_limits(float error_min, float error_max);
 
-    // get_error_min - return minimum position error
+    // Returns the current minimum error clamp, in controller units.
     float get_error_min() const { return _error_min; }
 
-    // get_error_max - return maximum position error
+    // Returns the current maximum error clamp, in controller units.
     float get_error_max() const { return _error_max; }
 
-    // save gain to eeprom
+    // Saves controller configuration from EEPROM. (not used)
     void save_gains() { _kp.save(); }
 
     // accessors

--- a/libraries/AC_PID/AC_P_2D.cpp
+++ b/libraries/AC_PID/AC_P_2D.cpp
@@ -1,5 +1,5 @@
 /// @file   AC_P_2D.cpp
-/// @brief  2-axis P controller
+/// @brief  2D P controller with output limiting, derivative constraint, and EEPROM-backed gain storage.
 
 #include <AP_Math/AP_Math.h>
 #include "AC_P_2D.h"
@@ -7,7 +7,7 @@
 const AP_Param::GroupInfo AC_P_2D::var_info[] = {
     // @Param: P
     // @DisplayName: Proportional Gain
-    // @Description: P Gain which produces an output value that is proportional to the current error value
+    // @Description: Proportional gain that generates output based on the current error value
     AP_GROUPINFO_FLAGS_DEFAULT_POINTER("P",    0, AC_P_2D, _kp, default_kp),
     AP_GROUPEND
 };
@@ -20,47 +20,53 @@ AC_P_2D::AC_P_2D(float initial_p) :
     AP_Param::setup_object_defaults(this, var_info);
 }
 
-// update_all - set target and measured inputs to P controller and calculate outputs
+// Computes the P controller output given a target and measurement.
+// Applies position error clamping based on configured limits.
+// Optionally constrains output slope using the sqrt_controller.
 Vector2f AC_P_2D::update_all(Vector2p &target, const Vector2p &measurement)
 {
-    // calculate distance _error
+    // Compute vector error between target and measurement (NED frame)
     _error = (target - measurement).tofloat();
 
-    // Constrain _error and target position
-    // Constrain the maximum length of _vel_target to the maximum position correction velocity
+    // Limit error vector length to prevent exceeding output constraints
     if (is_positive(_error_max) && _error.limit_length(_error_max)) {
         target = measurement + _error.topostype();
     }
 
-    // MIN(_Dmax, _D2max / _kp) limits the max accel to the point where max jerk is exceeded
+    // Use sqrt_controller to limit output and/or its derivative
     return sqrt_controller(_error, _kp, _D1_max, 0.0);
 }
 
-// set_limits - sets the maximum error to limit output and first and second derivative of output
-// when using for a position controller, lim_err will be position error, lim_out will be correction velocity, lim_D will be acceleration, lim_D2 will be jerk
+// Sets limits on output, output slope (D1), and output acceleration (D2).
+// For position controllers: output = velocity, D1 = acceleration, D2 = jerk.
 void AC_P_2D::set_limits(float output_max, float D_Out_max, float D2_Out_max)
 {
+    // Reset all limits to zero before applying new ones
     _D1_max = 0.0f;
     _error_max = 0.0f;
 
+    // Set first derivative (acceleration) limit if specified
     if (is_positive(D_Out_max)) {
         _D1_max = D_Out_max;
     }
 
+    // If second derivative (jerk) limit is specified, constrain velocity limit accordingly
     if (is_positive(D2_Out_max) && is_positive(_kp)) {
         // limit the first derivative so as not to exceed the second derivative
         _D1_max = MIN(_D1_max, D2_Out_max / _kp);
     }
 
+    // Compute min/max allowable error from output limits
     if (is_positive(output_max) && is_positive(_kp)) {
         _error_max = inv_sqrt_controller(output_max, _kp, _D1_max);
     }
 }
 
-// set_error_max - reduce maximum position error to error_max
-// to be called after setting limits
+// Reduces the maximum allowable error after limit initialization.
+// Intended to be called after set_limits().
 void AC_P_2D::set_error_max(float error_max)
 {
+    // Update _error_min if it's non-zero and the new value is more conservative
     if (is_positive(error_max)) {
         if (!is_zero(_error_max) ) {
             _error_max = MIN(_error_max, error_max);

--- a/libraries/AC_PID/AC_P_2D.h
+++ b/libraries/AC_PID/AC_P_2D.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /// @file   AC_P_2D.h
-/// @brief  2-axis P controller with EEPROM-backed storage of constants.
+/// @brief  2D P controller with output limiting, derivative constraint, and EEPROM-backed gain storage.
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
@@ -11,25 +11,28 @@
 class AC_P_2D {
 public:
 
-    // constructor
+    /// Constructor for 2D P controller with initial gain.
     AC_P_2D(float initial_p);
 
     CLASS_NO_COPY(AC_P_2D);
 
-    // set target and measured inputs to P controller and calculate outputs
+    // Computes the P controller output given a target and measurement.
+    // Applies position error clamping based on configured limits.
+    // Optionally constrains output slope using the sqrt_controller.
     Vector2f update_all(Vector2p &target, const Vector2p &measurement) WARN_IF_UNUSED;
 
-    // set_limits - sets the maximum error to limit output and first and second derivative of output
+    // Sets limits on output, output slope (D1), and output acceleration (D2).
+    // For position controllers: output = velocity, D1 = acceleration, D2 = jerk.
     void set_limits(float output_max, float D_Out_max = 0.0f, float D2_Out_max = 0.0f);
 
-    // set_error_max - reduce maximum position error to error_max
-    // to be called after setting limits
+    // Reduces the maximum allowable error after limit initialization.
+    // Intended to be called after set_limits().
     void set_error_max(float error_max);
 
-    // get_error_max - return maximum position error
+    // Returns the current error clamp limit in controller units.
     float get_error_max() { return _error_max; }
 
-    // save gain to eeprom
+    // Saves controller configuration from EEPROM. (not used)
     void save_gains() { _kp.save(); }
 
     // get accessors


### PR DESCRIPTION
I wanted to change the "boost" input variable name to "pd_scale" for better clarity and thought I should do the job properly while I was there. 

- Improved function and inline comments for AC_PID, aligning with ArduPilot PID controller conventions
- Clarified filter reset, derivative calculation, and integrator behavior
- Renamed internal PD_scale to pd_limit_scale to avoid confusion with pd_scale input parameter
- Minor comment corrections and typo fixes across .h and .cpp

No functional changes. Improves readability and maintainability.

```
Board,blimp,bootloader,copter,heli,plane,rover,sub
CubeOrange,*,*,*,*,*,*,*
```