### PR TITLE
Remove INAV from Copter

### DIFF
--- a/ArduCopter/AP_Arming_Copter.cpp
+++ b/ArduCopter/AP_Arming_Copter.cpp
@@ -138,8 +138,10 @@ bool AP_Arming_Copter::barometer_checks(bool display_failure)
         // that may differ from the baro height due to baro drift.
         const auto &ahrs = AP::ahrs();
         const bool using_baro_ref = !ahrs.has_status(AP_AHRS::Status::PRED_HORIZ_POS_REL) && ahrs.has_status(AP_AHRS::Status::PRED_HORIZ_POS_ABS);
+        float pos_d_m = 0;
+        UNUSED_RESULT(AP::ahrs().get_relative_position_D_origin_float(pos_d_m));
         if (using_baro_ref) {
-            if (fabsf(copter.inertial_nav.get_position_z_up_cm() - copter.baro_alt) > PREARM_MAX_ALT_DISPARITY_CM) {
+            if (fabsf(-pos_d_m * 100.0 - copter.baro_alt) > PREARM_MAX_ALT_DISPARITY_CM) {
                 check_failed(Check::BARO, display_failure, "Altitude disparity");
                 ret = false;
             }
@@ -732,8 +734,10 @@ bool AP_Arming_Copter::arm(const AP_Arming::Method method, const bool do_arming_
             // ignore failure
         }
 
-        // remember the height when we armed
-        copter.arming_altitude_m = copter.inertial_nav.get_position_z_up_cm() * 0.01;
+        // remember the height when we armed (ignore failures)
+        float pos_d_m = 0;
+        UNUSED_RESULT(AP::ahrs().get_relative_position_D_origin_float(pos_d_m));
+        copter.arming_altitude_m = -pos_d_m;
     }
     copter.update_super_simple_bearing(false);
 

--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -46,11 +46,17 @@ void Copter::update_throttle_hover()
         return;
     }
 
+    // do not update if no vertical velocity estimate
+    float vel_d_ms;
+    if (!AP::ahrs().get_velocity_D(vel_d_ms, vibration_check.high_vibes)) {
+        return;
+    }
+
     // get throttle output
     float throttle = motors->get_throttle();
 
     // calc average throttle if we are in a level hover.  accounts for heli hover roll trim
-    if (throttle > 0.0f && fabsf(inertial_nav.get_velocity_z_up_cms()) < 60 &&
+    if (throttle > 0.0f && fabsf(vel_d_ms) < 0.6 &&
         fabsf(ahrs.roll_sensor-attitude_control->get_roll_trim_cd()) < 500 && labs(ahrs.pitch_sensor) < 500) {
         // Can we set the time constant automatically
         motors->update_throttle_hover(0.01f);

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -975,7 +975,6 @@ Copter::Copter(void)
     super_simple_cos_yaw(1.0),
     land_accel_ef_filter(LAND_DETECTOR_ACCEL_LPF_CUTOFF),
     rc_throttle_control_in_filter(1.0f),
-    inertial_nav(ahrs),
     param_loader(var_info)
 {
 }

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -49,7 +49,6 @@
 #include <AP_Motors/AP_Motors.h>            // AP Motors library
 #include <Filter/Filter.h>                  // Filter library
 #include <AP_Vehicle/AP_Vehicle.h>          // needed for AHRS build
-#include <AP_InertialNav/AP_InertialNav.h>  // inertial navigation library
 #include <AC_WPNav/AC_WPNav.h>              // ArduCopter waypoint navigation library
 #include <AC_WPNav/AC_Loiter.h>             // ArduCopter Loiter Mode Library
 #include <AC_WPNav/AC_Circle.h>             // circle navigation library
@@ -256,8 +255,8 @@ private:
     AP_Int8 *flight_modes;
     const uint8_t num_flight_modes = 6;
 
-    AP_SurfaceDistance rangefinder_state {ROTATION_PITCH_270, inertial_nav, 0U};
-    AP_SurfaceDistance rangefinder_up_state {ROTATION_PITCH_90, inertial_nav, 1U};
+    AP_SurfaceDistance rangefinder_state {ROTATION_PITCH_270, 0U};
+    AP_SurfaceDistance rangefinder_up_state {ROTATION_PITCH_90, 1U};
 
     // helper function to get inertially interpolated rangefinder height.
     bool get_rangefinder_height_interpolated_cm(int32_t& ret) const;
@@ -471,9 +470,6 @@ private:
     // 3D Location vectors
     // Current location of the vehicle (altitude is relative to home)
     Location current_loc;
-
-    // Inertial Navigation
-    AP_InertialNav inertial_nav;
 
     // Attitude, Position and Waypoint navigation objects
     // To-Do: move inertial nav up or other navigation variables down here

--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -948,291 +948,296 @@ bool GCS_MAVLINK_Copter::sane_vel_or_acc_vector(const Vector3f &vec) const
 #if MODE_GUIDED_ENABLED
 void GCS_MAVLINK_Copter::handle_message_set_attitude_target(const mavlink_message_t &msg)
 {
-        // decode packet
-        mavlink_set_attitude_target_t packet;
-        mavlink_msg_set_attitude_target_decode(&msg, &packet);
+    // decode packet
+    mavlink_set_attitude_target_t packet;
+    mavlink_msg_set_attitude_target_decode(&msg, &packet);
 
-        // exit if vehicle is not in Guided mode or Auto-Guided mode
-        if (!copter.flightmode->in_guided_mode()) {
-            return;
-        }
+    // exit if vehicle is not in Guided mode or Auto-Guided mode
+    if (!copter.flightmode->in_guided_mode()) {
+        return;
+    }
 
-        const bool roll_rate_ignore   = packet.type_mask & ATTITUDE_TARGET_TYPEMASK_BODY_ROLL_RATE_IGNORE;
-        const bool pitch_rate_ignore  = packet.type_mask & ATTITUDE_TARGET_TYPEMASK_BODY_PITCH_RATE_IGNORE;
-        const bool yaw_rate_ignore    = packet.type_mask & ATTITUDE_TARGET_TYPEMASK_BODY_YAW_RATE_IGNORE;
-        const bool throttle_ignore    = packet.type_mask & ATTITUDE_TARGET_TYPEMASK_THROTTLE_IGNORE;
-        const bool attitude_ignore    = packet.type_mask & ATTITUDE_TARGET_TYPEMASK_ATTITUDE_IGNORE;
+    const bool roll_rate_ignore   = packet.type_mask & ATTITUDE_TARGET_TYPEMASK_BODY_ROLL_RATE_IGNORE;
+    const bool pitch_rate_ignore  = packet.type_mask & ATTITUDE_TARGET_TYPEMASK_BODY_PITCH_RATE_IGNORE;
+    const bool yaw_rate_ignore    = packet.type_mask & ATTITUDE_TARGET_TYPEMASK_BODY_YAW_RATE_IGNORE;
+    const bool throttle_ignore    = packet.type_mask & ATTITUDE_TARGET_TYPEMASK_THROTTLE_IGNORE;
+    const bool attitude_ignore    = packet.type_mask & ATTITUDE_TARGET_TYPEMASK_ATTITUDE_IGNORE;
 
-        // ensure thrust field is not ignored
-        if (throttle_ignore) {
-            // The throttle input is not defined
-            return;
-        }
+    // ensure thrust field is not ignored
+    if (throttle_ignore) {
+        // The throttle input is not defined
+        copter.mode_guided.init(true);
+        return;
+    }
 
-        Quaternion attitude_quat;
-        if (attitude_ignore) {
-            attitude_quat.zero();
-        } else {
-            attitude_quat = Quaternion(packet.q[0],packet.q[1],packet.q[2],packet.q[3]);
+    Quaternion attitude_quat;
+    if (attitude_ignore) {
+        attitude_quat.zero();
+    } else {
+        attitude_quat = Quaternion(packet.q[0],packet.q[1],packet.q[2],packet.q[3]);
 
-            // Do not accept the attitude_quaternion
-            // if its magnitude is not close to unit length +/- 1E-3
-            // this limit is somewhat greater than sqrt(FLT_EPSL)
-            if (!attitude_quat.is_unit_length()) {
-                // The attitude quaternion is ill-defined
-                return;
-            }
-        }
-
-        Vector3f ang_vel_body;
-        if (!roll_rate_ignore && !pitch_rate_ignore && !yaw_rate_ignore) {
-            ang_vel_body.x = packet.body_roll_rate;
-            ang_vel_body.y = packet.body_pitch_rate;
-            ang_vel_body.z = packet.body_yaw_rate;
-        } else if (!(roll_rate_ignore && pitch_rate_ignore && yaw_rate_ignore)) {
-            // The body rates are ill-defined
-            // input is not valid so stop
+        // Do not accept the attitude_quaternion
+        // if its magnitude is not close to unit length +/- 1E-3
+        // this limit is somewhat greater than sqrt(FLT_EPSL)
+        if (!attitude_quat.is_unit_length()) {
+            // The attitude quaternion is ill-defined
             copter.mode_guided.init(true);
             return;
         }
+    }
 
-        // check if the message's thrust field should be interpreted as a climb rate or as thrust
-        const bool use_thrust = copter.mode_guided.set_attitude_target_provides_thrust();
+    Vector3f ang_vel_body;
+    if (!roll_rate_ignore && !pitch_rate_ignore && !yaw_rate_ignore) {
+        ang_vel_body.x = packet.body_roll_rate;
+        ang_vel_body.y = packet.body_pitch_rate;
+        ang_vel_body.z = packet.body_yaw_rate;
+    } else if (!(roll_rate_ignore && pitch_rate_ignore && yaw_rate_ignore)) {
+        // The body rates are ill-defined
+        // input is not valid so stop
+        copter.mode_guided.init(true);
+        return;
+    }
 
-        float climb_rate_or_thrust;
-        if (use_thrust) {
-            // interpret thrust as thrust
-            climb_rate_or_thrust = constrain_float(packet.thrust, -1.0f, 1.0f);
+    // check if the message's thrust field should be interpreted as a climb rate or as thrust
+    const bool use_thrust = copter.mode_guided.set_attitude_target_provides_thrust();
+
+    float climb_rate_or_thrust;
+    if (use_thrust) {
+        // interpret thrust as thrust
+        climb_rate_or_thrust = constrain_float(packet.thrust, -1.0f, 1.0f);
+    } else {
+        // convert thrust to climb rate
+        packet.thrust = constrain_float(packet.thrust, 0.0f, 1.0f);
+        if (is_equal(packet.thrust, 0.5f)) {
+            climb_rate_or_thrust = 0.0f;
+        } else if (packet.thrust > 0.5f) {
+            // climb at up to WPNAV_SPEED_UP
+            climb_rate_or_thrust = (packet.thrust - 0.5f) * 2.0f * copter.wp_nav->get_default_speed_up_cms();
         } else {
-            // convert thrust to climb rate
-            packet.thrust = constrain_float(packet.thrust, 0.0f, 1.0f);
-            if (is_equal(packet.thrust, 0.5f)) {
-                climb_rate_or_thrust = 0.0f;
-            } else if (packet.thrust > 0.5f) {
-                // climb at up to WPNAV_SPEED_UP
-                climb_rate_or_thrust = (packet.thrust - 0.5f) * 2.0f * copter.wp_nav->get_default_speed_up_cms();
-            } else {
-                // descend at up to WPNAV_SPEED_DN
-                climb_rate_or_thrust = (0.5f - packet.thrust) * 2.0f * -copter.wp_nav->get_default_speed_down_cms();
-            }
+            // descend at up to WPNAV_SPEED_DN
+            climb_rate_or_thrust = (0.5f - packet.thrust) * 2.0f * -copter.wp_nav->get_default_speed_down_cms();
         }
+    }
 
-        copter.mode_guided.set_angle(attitude_quat, ang_vel_body,
-                climb_rate_or_thrust, use_thrust);
+    copter.mode_guided.set_angle(attitude_quat, ang_vel_body,
+            climb_rate_or_thrust, use_thrust);
 }
 
 void GCS_MAVLINK_Copter::handle_message_set_position_target_local_ned(const mavlink_message_t &msg)
 {
-        // decode packet
-        mavlink_set_position_target_local_ned_t packet;
-        mavlink_msg_set_position_target_local_ned_decode(&msg, &packet);
+    // decode packet
+    mavlink_set_position_target_local_ned_t packet;
+    mavlink_msg_set_position_target_local_ned_decode(&msg, &packet);
 
-        // exit if vehicle is not in Guided mode or Auto-Guided mode
-        if (!copter.flightmode->in_guided_mode()) {
-            return;
+    // exit if vehicle is not in Guided mode or Auto-Guided mode
+    if (!copter.flightmode->in_guided_mode()) {
+        return;
+    }
+
+    // check for supported coordinate frames
+    if (packet.coordinate_frame != MAV_FRAME_LOCAL_NED &&
+        packet.coordinate_frame != MAV_FRAME_LOCAL_OFFSET_NED &&
+        packet.coordinate_frame != MAV_FRAME_BODY_NED &&
+        packet.coordinate_frame != MAV_FRAME_BODY_OFFSET_NED) {
+        // input is not valid so stop
+        copter.mode_guided.init(true);
+        return;
+    }
+
+    bool pos_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_POS_IGNORE;
+    bool vel_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_VEL_IGNORE;
+    bool acc_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_ACC_IGNORE;
+    bool yaw_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_YAW_IGNORE;
+    bool yaw_rate_ignore = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_YAW_RATE_IGNORE;
+    bool force_set       = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_FORCE_SET;
+
+    // Force inputs are not supported
+    // Do not accept command if force_set is true and acc_ignore is false
+    if (force_set && !acc_ignore) {
+        copter.mode_guided.init(true);
+        return;
+    }
+
+    // prepare position
+    Vector3f pos_vector;
+    if (!pos_ignore) {
+        // convert to cm
+        pos_vector = Vector3f(packet.x * 100.0f, packet.y * 100.0f, -packet.z * 100.0f);
+        // rotate to body-frame if necessary
+        if (packet.coordinate_frame == MAV_FRAME_BODY_NED ||
+            packet.coordinate_frame == MAV_FRAME_BODY_OFFSET_NED) {
+            copter.rotate_body_frame_to_NE(pos_vector.x, pos_vector.y);
         }
-
-        // check for supported coordinate frames
-        if (packet.coordinate_frame != MAV_FRAME_LOCAL_NED &&
-            packet.coordinate_frame != MAV_FRAME_LOCAL_OFFSET_NED &&
-            packet.coordinate_frame != MAV_FRAME_BODY_NED &&
-            packet.coordinate_frame != MAV_FRAME_BODY_OFFSET_NED) {
-            // input is not valid so stop
-            copter.mode_guided.init(true);
-            return;
-        }
-
-        bool pos_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_POS_IGNORE;
-        bool vel_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_VEL_IGNORE;
-        bool acc_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_ACC_IGNORE;
-        bool yaw_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_YAW_IGNORE;
-        bool yaw_rate_ignore = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_YAW_RATE_IGNORE;
-        bool force_set       = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_FORCE_SET;
-
-        // Force inputs are not supported
-        // Do not accept command if force_set is true and acc_ignore is false
-        if (force_set && !acc_ignore) {
-            return;
-        }
-
-        // prepare position
-        Vector3f pos_vector;
-        if (!pos_ignore) {
-            // convert to cm
-            pos_vector = Vector3f(packet.x * 100.0f, packet.y * 100.0f, -packet.z * 100.0f);
-            // rotate to body-frame if necessary
-            if (packet.coordinate_frame == MAV_FRAME_BODY_NED ||
-                packet.coordinate_frame == MAV_FRAME_BODY_OFFSET_NED) {
-                copter.rotate_body_frame_to_NE(pos_vector.x, pos_vector.y);
-            }
-            // add body offset if necessary
-            if (packet.coordinate_frame == MAV_FRAME_LOCAL_OFFSET_NED ||
-                packet.coordinate_frame == MAV_FRAME_BODY_NED ||
-                packet.coordinate_frame == MAV_FRAME_BODY_OFFSET_NED) {
-                Vector3f pos_ned_m;
-                if (!AP::ahrs().get_relative_position_NED_origin_float(pos_ned_m)) {
-                    // need position estimate to calculate target position
-                    return;
-                }
-                pos_vector.xy() += pos_ned_m.xy() * 100.0;
-                pos_vector.z -= pos_ned_m.z * 100.0;
-            }
-        }
-
-        // prepare velocity
-        Vector3f vel_vector;
-        if (!vel_ignore) {
-            vel_vector = Vector3f{packet.vx, packet.vy, -packet.vz};
-            if (!sane_vel_or_acc_vector(vel_vector)) {
-                // input is not valid so stop
+        // add body offset if necessary
+        if (packet.coordinate_frame == MAV_FRAME_LOCAL_OFFSET_NED ||
+            packet.coordinate_frame == MAV_FRAME_BODY_NED ||
+            packet.coordinate_frame == MAV_FRAME_BODY_OFFSET_NED) {
+            Vector3f pos_ned_m;
+            if (!AP::ahrs().get_relative_position_NED_origin_float(pos_ned_m)) {
+                // need position estimate to calculate target position
                 copter.mode_guided.init(true);
                 return;
             }
-            vel_vector *= 100;  // m/s -> cm/s
-            // rotate to body-frame if necessary
-            if (packet.coordinate_frame == MAV_FRAME_BODY_NED || packet.coordinate_frame == MAV_FRAME_BODY_OFFSET_NED) {
-                copter.rotate_body_frame_to_NE(vel_vector.x, vel_vector.y);
-            }
+            pos_vector.xy() += pos_ned_m.xy() * 100.0;
+            pos_vector.z -= pos_ned_m.z * 100.0;
         }
+    }
 
-        // prepare acceleration
-        Vector3f accel_vector;
-        if (!acc_ignore) {
-            // convert to cm
-            accel_vector = Vector3f(packet.afx * 100.0f, packet.afy * 100.0f, -packet.afz * 100.0f);
-            // rotate to body-frame if necessary
-            if (packet.coordinate_frame == MAV_FRAME_BODY_NED || packet.coordinate_frame == MAV_FRAME_BODY_OFFSET_NED) {
-                copter.rotate_body_frame_to_NE(accel_vector.x, accel_vector.y);
-            }
-        }
-
-        // prepare yaw
-        float yaw_cd = 0.0f;
-        bool yaw_relative = false;
-        float yaw_rate_cds = 0.0f;
-        if (!yaw_ignore) {
-            yaw_cd = degrees(packet.yaw) * 100.0f;
-            yaw_relative = packet.coordinate_frame == MAV_FRAME_BODY_NED || packet.coordinate_frame == MAV_FRAME_BODY_OFFSET_NED;
-        }
-        if (!yaw_rate_ignore) {
-            yaw_rate_cds = degrees(packet.yaw_rate) * 100.0f;
-        }
-
-        // send request
-        if (!pos_ignore && !vel_ignore) {
-            copter.mode_guided.set_destination_posvelaccel(pos_vector, vel_vector, accel_vector, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds, yaw_relative);
-        } else if (pos_ignore && !vel_ignore) {
-            copter.mode_guided.set_velaccel(vel_vector, accel_vector, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds, yaw_relative);
-        } else if (pos_ignore && vel_ignore && !acc_ignore) {
-            copter.mode_guided.set_accel(accel_vector, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds, yaw_relative);
-        } else if (!pos_ignore && vel_ignore && acc_ignore) {
-            copter.mode_guided.set_destination(pos_vector, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds, yaw_relative, false);
-        } else {
+    // prepare velocity
+    Vector3f vel_vector;
+    if (!vel_ignore) {
+        vel_vector = Vector3f{packet.vx, packet.vy, -packet.vz};
+        if (!sane_vel_or_acc_vector(vel_vector)) {
             // input is not valid so stop
             copter.mode_guided.init(true);
+            return;
         }
+        vel_vector *= 100;  // m/s -> cm/s
+        // rotate to body-frame if necessary
+        if (packet.coordinate_frame == MAV_FRAME_BODY_NED || packet.coordinate_frame == MAV_FRAME_BODY_OFFSET_NED) {
+            copter.rotate_body_frame_to_NE(vel_vector.x, vel_vector.y);
+        }
+    }
+
+    // prepare acceleration
+    Vector3f accel_vector;
+    if (!acc_ignore) {
+        // convert to cm
+        accel_vector = Vector3f(packet.afx * 100.0f, packet.afy * 100.0f, -packet.afz * 100.0f);
+        // rotate to body-frame if necessary
+        if (packet.coordinate_frame == MAV_FRAME_BODY_NED || packet.coordinate_frame == MAV_FRAME_BODY_OFFSET_NED) {
+            copter.rotate_body_frame_to_NE(accel_vector.x, accel_vector.y);
+        }
+    }
+
+    // prepare yaw
+    float yaw_cd = 0.0f;
+    bool yaw_relative = false;
+    float yaw_rate_cds = 0.0f;
+    if (!yaw_ignore) {
+        yaw_cd = degrees(packet.yaw) * 100.0f;
+        yaw_relative = packet.coordinate_frame == MAV_FRAME_BODY_NED || packet.coordinate_frame == MAV_FRAME_BODY_OFFSET_NED;
+    }
+    if (!yaw_rate_ignore) {
+        yaw_rate_cds = degrees(packet.yaw_rate) * 100.0f;
+    }
+
+    // send request
+    if (!pos_ignore && !vel_ignore) {
+        copter.mode_guided.set_destination_posvelaccel(pos_vector, vel_vector, accel_vector, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds, yaw_relative);
+    } else if (pos_ignore && !vel_ignore) {
+        copter.mode_guided.set_velaccel(vel_vector, accel_vector, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds, yaw_relative);
+    } else if (pos_ignore && vel_ignore && !acc_ignore) {
+        copter.mode_guided.set_accel(accel_vector, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds, yaw_relative);
+    } else if (!pos_ignore && vel_ignore && acc_ignore) {
+        copter.mode_guided.set_destination(pos_vector, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds, yaw_relative, false);
+    } else {
+        // input is not valid so stop
+        copter.mode_guided.init(true);
+    }
 }
 
 void GCS_MAVLINK_Copter::handle_message_set_position_target_global_int(const mavlink_message_t &msg)
 {
-        // decode packet
-        mavlink_set_position_target_global_int_t packet;
-        mavlink_msg_set_position_target_global_int_decode(&msg, &packet);
+    // decode packet
+    mavlink_set_position_target_global_int_t packet;
+    mavlink_msg_set_position_target_global_int_decode(&msg, &packet);
 
-        // exit if vehicle is not in Guided mode or Auto-Guided mode
-        if (!copter.flightmode->in_guided_mode()) {
-            return;
-        }
+    // exit if vehicle is not in Guided mode or Auto-Guided mode
+    if (!copter.flightmode->in_guided_mode()) {
+        return;
+    }
 
-        // todo: do we need to check for supported coordinate frames
+    // todo: do we need to check for supported coordinate frames
 
-        bool pos_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_POS_IGNORE;
-        bool vel_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_VEL_IGNORE;
-        bool acc_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_ACC_IGNORE;
-        bool yaw_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_YAW_IGNORE;
-        bool yaw_rate_ignore = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_YAW_RATE_IGNORE;
-        bool force_set       = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_FORCE_SET;
+    bool pos_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_POS_IGNORE;
+    bool vel_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_VEL_IGNORE;
+    bool acc_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_ACC_IGNORE;
+    bool yaw_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_YAW_IGNORE;
+    bool yaw_rate_ignore = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_YAW_RATE_IGNORE;
+    bool force_set       = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_FORCE_SET;
 
-        // Force inputs are not supported
-        // Do not accept command if force_set is true and acc_ignore is false
-        if (force_set && !acc_ignore) {
-            return;
-        }
+    // Force inputs are not supported
+    // Do not accept command if force_set is true and acc_ignore is false
+    if (force_set && !acc_ignore) {
+        copter.mode_guided.init(true);
+        return;
+    }
 
-        // extract location from message
-        Location loc;
-        if (!pos_ignore) {
-            // sanity check location
-            if (!check_latlng(packet.lat_int, packet.lon_int)) {
-                // input is not valid so stop
-                copter.mode_guided.init(true);
-                return;
-            }
-            Location::AltFrame frame;
-            if (!mavlink_coordinate_frame_to_location_alt_frame((MAV_FRAME)packet.coordinate_frame, frame)) {
-                // unknown coordinate frame
-                // input is not valid so stop
-                copter.mode_guided.init(true);
-                return;
-            }
-            loc = {packet.lat_int, packet.lon_int, int32_t(packet.alt*100), frame};
-        }
-
-        // prepare velocity
-        Vector3f vel_vector;
-        if (!vel_ignore) {
-            vel_vector = Vector3f{packet.vx, packet.vy, -packet.vz};
-            if (!sane_vel_or_acc_vector(vel_vector)) {
-                // input is not valid so stop
-                copter.mode_guided.init(true);
-                return;
-            }
-            vel_vector *= 100;  // m/s -> cm/s
-        }
-
-        // prepare acceleration
-        Vector3f accel_vector;
-        if (!acc_ignore) {
-            // convert to cm
-            accel_vector = Vector3f(packet.afx * 100.0f, packet.afy * 100.0f, -packet.afz * 100.0f);
-        }
-
-        // prepare yaw
-        float yaw_cd = 0.0f;
-        float yaw_rate_cds = 0.0f;
-        if (!yaw_ignore) {
-            yaw_cd = degrees(packet.yaw) * 100.0f;
-        }
-        if (!yaw_rate_ignore) {
-            yaw_rate_cds = degrees(packet.yaw_rate) * 100.0f;
-        }
-
-        // send targets to the appropriate guided mode controller
-        if (!pos_ignore && !vel_ignore) {
-            // convert Location to vector from ekf origin for posvel controller
-            if (loc.get_alt_frame() == Location::AltFrame::ABOVE_TERRAIN) {
-                // posvel controller does not support alt-above-terrain
-                // input is not valid so stop
-                copter.mode_guided.init(true);
-                return;
-            }
-            Vector3f pos_neu_cm;
-            if (!loc.get_vector_from_origin_NEU_cm(pos_neu_cm)) {
-                // input is not valid so stop
-                copter.mode_guided.init(true);
-                return;
-            }
-            copter.mode_guided.set_destination_posvel(pos_neu_cm, vel_vector, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds);
-        } else if (pos_ignore && !vel_ignore) {
-            copter.mode_guided.set_velaccel(vel_vector, accel_vector, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds);
-        } else if (pos_ignore && vel_ignore && !acc_ignore) {
-            copter.mode_guided.set_accel(accel_vector, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds);
-        } else if (!pos_ignore && vel_ignore && acc_ignore) {
-            copter.mode_guided.set_destination(loc, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds);
-        } else {
+    // extract location from message
+    Location loc;
+    if (!pos_ignore) {
+        // sanity check location
+        if (!check_latlng(packet.lat_int, packet.lon_int)) {
             // input is not valid so stop
             copter.mode_guided.init(true);
+            return;
         }
+        Location::AltFrame frame;
+        if (!mavlink_coordinate_frame_to_location_alt_frame((MAV_FRAME)packet.coordinate_frame, frame)) {
+            // unknown coordinate frame
+            // input is not valid so stop
+            copter.mode_guided.init(true);
+            return;
+        }
+        loc = {packet.lat_int, packet.lon_int, int32_t(packet.alt*100), frame};
+    }
+
+    // prepare velocity
+    Vector3f vel_vector;
+    if (!vel_ignore) {
+        vel_vector = Vector3f{packet.vx, packet.vy, -packet.vz};
+        if (!sane_vel_or_acc_vector(vel_vector)) {
+            // input is not valid so stop
+            copter.mode_guided.init(true);
+            return;
+        }
+        vel_vector *= 100;  // m/s -> cm/s
+    }
+
+    // prepare acceleration
+    Vector3f accel_vector;
+    if (!acc_ignore) {
+        // convert to cm
+        accel_vector = Vector3f(packet.afx * 100.0f, packet.afy * 100.0f, -packet.afz * 100.0f);
+    }
+
+    // prepare yaw
+    float yaw_cd = 0.0f;
+    float yaw_rate_cds = 0.0f;
+    if (!yaw_ignore) {
+        yaw_cd = degrees(packet.yaw) * 100.0f;
+    }
+    if (!yaw_rate_ignore) {
+        yaw_rate_cds = degrees(packet.yaw_rate) * 100.0f;
+    }
+
+    // send targets to the appropriate guided mode controller
+    if (!pos_ignore && !vel_ignore) {
+        // convert Location to vector from ekf origin for posvel controller
+        if (loc.get_alt_frame() == Location::AltFrame::ABOVE_TERRAIN) {
+            // posvel controller does not support alt-above-terrain
+            // input is not valid so stop
+            copter.mode_guided.init(true);
+            return;
+        }
+        Vector3f pos_neu_cm;
+        if (!loc.get_vector_from_origin_NEU_cm(pos_neu_cm)) {
+            // input is not valid so stop
+            copter.mode_guided.init(true);
+            return;
+        }
+        copter.mode_guided.set_destination_posvel(pos_neu_cm, vel_vector, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds);
+    } else if (pos_ignore && !vel_ignore) {
+        copter.mode_guided.set_velaccel(vel_vector, accel_vector, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds);
+    } else if (pos_ignore && vel_ignore && !acc_ignore) {
+        copter.mode_guided.set_accel(accel_vector, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds);
+    } else if (!pos_ignore && vel_ignore && acc_ignore) {
+        copter.mode_guided.set_destination(loc, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds);
+    } else {
+        // input is not valid so stop
+        copter.mode_guided.init(true);
+    }
 }
 #endif  // MODE_GUIDED_ENABLED
 

--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -1069,7 +1069,13 @@ void GCS_MAVLINK_Copter::handle_message_set_position_target_local_ned(const mavl
             if (packet.coordinate_frame == MAV_FRAME_LOCAL_OFFSET_NED ||
                 packet.coordinate_frame == MAV_FRAME_BODY_NED ||
                 packet.coordinate_frame == MAV_FRAME_BODY_OFFSET_NED) {
-                pos_vector += copter.inertial_nav.get_position_neu_cm();
+                Vector3f pos_ned_m;
+                if (!AP::ahrs().get_relative_position_NED_origin_float(pos_ned_m)) {
+                    // need position estimate to calculate target position
+                    return;
+                }
+                pos_vector.xy() += pos_ned_m.xy() * 100.0;
+                pos_vector.z -= pos_ned_m.z * 100.0;
             }
         }
 

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -58,7 +58,7 @@ void Copter::Log_Write_Control_Tuning()
         throttle_out        : motors->get_throttle(),
         throttle_hover      : motors->get_throttle_hover(),
         desired_alt         : des_alt_m,
-        inav_alt            : inertial_nav.get_position_z_up_cm() * 0.01f,
+        inav_alt            : float(pos_control->get_pos_estimate_NEU_cm().z) * 0.01,
         baro_alt            : baro_alt,
         desired_rangefinder_alt : desired_rangefinder_alt,
 #if AP_RANGEFINDER_ENABLED
@@ -68,7 +68,7 @@ void Copter::Log_Write_Control_Tuning()
 #endif
         terr_alt            : terr_alt,
         target_climb_rate   : target_climb_rate_cms,
-        climb_rate          : int16_t(inertial_nav.get_velocity_z_up_cms()) // float -> int16_t
+        climb_rate          : int16_t(pos_control->get_vel_estimate_NEU_cms().z) // float -> int16_t
     };
     logger.WriteBlock(&pkt, sizeof(pkt));
 }

--- a/ArduCopter/baro_ground_effect.cpp
+++ b/ArduCopter/baro_ground_effect.cpp
@@ -14,19 +14,12 @@ void Copter::update_ground_effect_detector(void)
     // variable initialization
     uint32_t tnow_ms = millis();
     float xy_des_speed_cms = 0.0f;
-    float xy_speed_cms = 0.0f;
     float des_climb_rate_cms = pos_control->get_vel_desired_NEU_cms().z;
 
     if (pos_control->is_active_NE()) {
         Vector3f vel_target = pos_control->get_vel_target_NEU_cms();
         vel_target.z = 0.0f;
         xy_des_speed_cms = vel_target.length();
-    }
-
-    if (position_ok() || ekf_has_relative_position()) {
-        Vector3f vel = inertial_nav.get_velocity_neu_cms();
-        vel.z = 0.0f;
-        xy_speed_cms = vel.length();
     }
 
     // takeoff logic
@@ -39,29 +32,34 @@ void Copter::update_ground_effect_detector(void)
         gndeffect_state.takeoff_expected = true;
     }
 
+    // get altitude estimate
+    float pos_d_m = 0;
+    UNUSED_RESULT(AP::ahrs().get_relative_position_D_origin_float(pos_d_m));
+
     // if we aren't taking off yet, reset the takeoff timer, altitude and complete flag
     const bool throttle_up = flightmode->has_manual_throttle() && channel_throttle->get_control_in() > 0;
     if (!throttle_up && ap.land_complete) {
         gndeffect_state.takeoff_time_ms = tnow_ms;
-        gndeffect_state.takeoff_alt_cm = inertial_nav.get_position_z_up_cm();
+        gndeffect_state.takeoff_alt_cm = -pos_d_m * 100.0;
     }
 
     // if we are in takeoff_expected and we meet the conditions for having taken off
     // end the takeoff_expected state
-    if (gndeffect_state.takeoff_expected && (tnow_ms-gndeffect_state.takeoff_time_ms > 5000 || inertial_nav.get_position_z_up_cm()-gndeffect_state.takeoff_alt_cm > 50.0f)) {
+    if (gndeffect_state.takeoff_expected && (tnow_ms-gndeffect_state.takeoff_time_ms > 5000 || (-pos_d_m * 100.0 - gndeffect_state.takeoff_alt_cm) > 50.0f)) {
         gndeffect_state.takeoff_expected = false;
     }
 
     // landing logic
     Vector3f angle_target_rad = attitude_control->get_att_target_euler_rad();
     bool small_angle_request = cosf(angle_target_rad.x)*cosf(angle_target_rad.y) > cosf(radians(7.5f));
-    bool xy_speed_low = (position_ok() || ekf_has_relative_position()) && xy_speed_cms <= 125.0f;
+    Vector3f vel_ned_ms;
+    bool xy_speed_low = AP::ahrs().get_velocity_NED(vel_ned_ms) && (vel_ned_ms.xy().length() < 1.25);
     bool xy_speed_demand_low = pos_control->is_active_NE() && xy_des_speed_cms <= 125.0f;
     bool slow_horizontal = xy_speed_demand_low || (xy_speed_low && !pos_control->is_active_NE()) || (flightmode->mode_number() == Mode::Number::ALT_HOLD && small_angle_request);
 
     bool descent_demanded = pos_control->is_active_U() && des_climb_rate_cms < 0.0f;
     bool slow_descent_demanded = descent_demanded && des_climb_rate_cms >= -100.0f;
-    bool z_speed_low = fabsf(inertial_nav.get_velocity_z_up_cms()) <= 60.0f;
+    bool z_speed_low = AP::ahrs().get_velocity_D(vel_ned_ms.z, vibration_check.high_vibes) && fabsf(vel_ned_ms.z) <= 0.6f;
     bool slow_descent = (slow_descent_demanded || (z_speed_low && descent_demanded));
 
     gndeffect_state.touchdown_expected = slow_horizontal && slow_descent;

--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -143,7 +143,9 @@ void Copter::thrust_loss_check()
     }
 
     // check for descent
-    if (!is_negative(inertial_nav.get_velocity_z_up_cms())) {
+    float vel_d_ms = 0;
+    if (!AP::ahrs().get_velocity_D(vel_d_ms, vibration_check.high_vibes) || !is_positive(vel_d_ms)) {
+        // we have no vertical velocity estimate and/or we are not descending
         thrust_loss_counter = 0;
         return;
     }
@@ -252,7 +254,9 @@ void Copter::parachute_check()
     parachute.set_is_flying(!ap.land_complete);
 
     // pass sink rate to parachute library
-    parachute.set_sink_rate(-inertial_nav.get_velocity_z_up_cms() * 0.01f);
+    float vel_d_ms = 0;
+    UNUSED_RESULT(AP::ahrs().get_velocity_D(vel_d_ms, vibration_check.high_vibes));
+    parachute.set_sink_rate(vel_d_ms);
 
     // exit immediately if in standby
     if (standby_active) {

--- a/ArduCopter/heli.cpp
+++ b/ArduCopter/heli.cpp
@@ -33,10 +33,10 @@ void Copter::check_dynamic_flight(void)
     bool moving = false;
 
     // with GPS lock use inertial nav to determine if we are moving
-    if (position_ok()) {
+    Vector3f vel_ned_ms;
+    if (AP::ahrs().get_velocity_NED(vel_ned_ms)) {
         // get horizontal speed
-        const float speed = inertial_nav.get_speed_xy_cms();
-        moving = (speed >= HELI_DYNAMIC_FLIGHT_SPEED_MIN);
+        moving = (vel_ned_ms.xy().length() * 100.0 >= HELI_DYNAMIC_FLIGHT_SPEED_MIN);
     } else {
         // with no GPS lock base it on throttle and forward lean angle
         moving = (motors->get_throttle() > 0.8f || ahrs.pitch_sensor < -1500);

--- a/ArduCopter/inertia.cpp
+++ b/ArduCopter/inertia.cpp
@@ -4,7 +4,6 @@
 void Copter::read_inertia()
 {
     // inertial altitude estimates. Use barometer climb rate during high vibrations
-    inertial_nav.update(vibration_check.high_vibes);
     pos_control->update_estimates(vibration_check.high_vibes);
 #if MODE_FOLLOW_ENABLED
     g2.follow.update_estimates();
@@ -17,12 +16,13 @@ void Copter::read_inertia()
     current_loc.lng = loc.lng;
 
     // exit immediately if we do not have an altitude estimate
-    if (!ahrs.has_status(AP_AHRS::Status::VERT_POS)) {
+    float pos_d_m;
+    if (!AP::ahrs().get_relative_position_D_origin_float(pos_d_m)) {
         return;
     }
 
-    // current_loc.alt is alt-above-home, converted from inertial nav's alt-above-ekf-origin
-    const int32_t alt_above_origin_cm = inertial_nav.get_position_z_up_cm();
+    // current_loc.alt is alt-above-home, converted from AHRS's alt-above-ekf-origin
+    const int32_t alt_above_origin_cm = -pos_d_m * 100.0;
     current_loc.set_alt_cm(alt_above_origin_cm, Location::AltFrame::ABOVE_ORIGIN);
     if (!ahrs.home_is_set() || !current_loc.change_alt_frame(Location::AltFrame::ABOVE_HOME)) {
         // if home has not been set yet we treat alt-above-origin as alt-above-home

--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -125,7 +125,9 @@ void Copter::update_land_detector()
         SET_LOG_FLAG(accel_stationary, LandDetectorLoggingFlag::ACCEL_STATIONARY);
 
         // check that vertical speed is within 1m/s of zero
-        bool descent_rate_low = fabsf(inertial_nav.get_velocity_z_up_cms()) < 100.0 * LAND_DETECTOR_VEL_Z_MAX * land_detector_scalar;
+        float vel_d_ms = 0;
+        UNUSED_RESULT(AP::ahrs().get_velocity_D(vel_d_ms, copter.vibration_check.high_vibes));
+        const bool descent_rate_low = fabsf(vel_d_ms) < LAND_DETECTOR_VEL_Z_MAX * land_detector_scalar;
         SET_LOG_FLAG(descent_rate_low, LandDetectorLoggingFlag::DESCENT_RATE_LOW);
 
         // if we have a healthy rangefinder only allow landing detection below 2 meters

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -14,7 +14,6 @@ Mode::Mode(void) :
     wp_nav(copter.wp_nav),
     loiter_nav(copter.loiter_nav),
     pos_control(copter.pos_control),
-    inertial_nav(copter.inertial_nav),
     ahrs(copter.ahrs),
     attitude_control(copter.attitude_control),
     motors(copter.motors),

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -259,7 +259,6 @@ protected:
     AC_WPNav *&wp_nav;
     AC_Loiter *&loiter_nav;
     AC_PosControl *&pos_control;
-    AP_InertialNav &inertial_nav;
     AP_AHRS &ahrs;
     AC_AttitudeControl *&attitude_control;
     MOTOR_CLASS *&motors;

--- a/ArduCopter/wscript
+++ b/ArduCopter/wscript
@@ -15,7 +15,6 @@ def build(bld):
             'AC_WPNav',
             'AP_Camera',
             'AP_IRLock',
-            'AP_InertialNav',
             'AP_Motors',
             'AP_Avoidance',
             'AP_AdvancedFailsafe',

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -10,7 +10,6 @@
 #include <AC_PID/AC_PI_2D.h>        // PI library (2-axis)
 #include <AC_PID/AC_PID_Basic.h>    // PID library (1-axis)
 #include <AC_PID/AC_PID_2D.h>       // PID library (2-axis)
-#include <AP_InertialNav/AP_InertialNav.h>  // Inertial Navigation library
 #include <AP_Scripting/AP_Scripting_config.h>
 #include "AC_AttitudeControl.h"     // Attitude control library
 

--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -3,7 +3,6 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
-#include <AP_InertialNav/AP_InertialNav.h>     // Inertial Navigation library
 #include <AC_AttitudeControl/AC_PosControl.h>      // Position control library
 
 // loiter maximum velocities and accelerations

--- a/libraries/AC_WPNav/AC_Loiter.h
+++ b/libraries/AC_WPNav/AC_Loiter.h
@@ -4,7 +4,6 @@
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_Common/Location.h>
-#include <AP_InertialNav/AP_InertialNav.h>
 #include <AC_AttitudeControl/AC_PosControl.h>
 #include <AC_AttitudeControl/AC_AttitudeControl.h>
 #include <AC_Avoidance/AC_Avoid.h>

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -6,7 +6,6 @@
 #include <AP_Math/SCurve.h>
 #include <AP_Math/SplineCurve.h>
 #include <AP_Common/Location.h>
-#include <AP_InertialNav/AP_InertialNav.h>     // Inertial Navigation library
 #include <AC_AttitudeControl/AC_PosControl.h>      // Position control library
 #include <AC_AttitudeControl/AC_AttitudeControl.h> // Attitude control library
 #include <AP_Terrain/AP_Terrain.h>

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -1654,6 +1654,18 @@ bool AP_AHRS::get_mag_field_correction(Vector3f &vec) const
     return false;
 }
 
+// get velocity down in m/s.  This returns get_velocity_NED.z() if available, otherwise falls back to get_vert_pos_rate_D()
+// if high_vibes is true then this is equivalent to get_vert_pos_rate_D
+bool AP_AHRS::get_velocity_D(float &velD, bool high_vibes) const
+{
+    Vector3f velNED;
+    if (!high_vibes && get_velocity_NED(velNED)) {
+        velD = velNED.z;
+        return true;
+    }
+    return get_vert_pos_rate_D(velD);
+}
+
 // Get a derivative of the vertical position which is kinematically consistent with the vertical position is required by some control loops.
 // This is different to the vertical velocity from the EKF which is not always consistent with the vertical position due to the various errors that are being corrected for.
 bool AP_AHRS::get_vert_pos_rate_D(float &velocity) const

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -299,6 +299,10 @@ public:
     bool get_location_from_origin_offset_NED(Location &loc, const Vector3p &offset_ned) const WARN_IF_UNUSED;
     bool get_location_from_home_offset_NED(Location &loc, const Vector3p &offset_ned) const WARN_IF_UNUSED;
 
+    // get velocity down in m/s.  This returns get_velocity_NED.z() if available, otherwise falls back to get_vert_pos_rate_D()
+    // if high_vibes is true then this is equivalent to get_vert_pos_rate_D
+    bool get_velocity_D(float &velD, bool high_vibes = false) const WARN_IF_UNUSED;
+
     // Get a derivative of the vertical position in m/s which is kinematically consistent with the vertical position is required by some control loops.
     // This is different to the vertical velocity from the EKF which is not always consistent with the vertical position due to the various errors that are being corrected for.
     bool get_vert_pos_rate_D(float &velocity) const;

--- a/libraries/AP_SurfaceDistance/AP_SurfaceDistance.h
+++ b/libraries/AP_SurfaceDistance/AP_SurfaceDistance.h
@@ -2,14 +2,12 @@
 
 #include <AP_Math/AP_Math.h>
 #include <Filter/LowPassFilter.h>
-#include <AP_InertialNav/AP_InertialNav.h>
 #include <AP_HAL/Semaphores.h>
 
 class AP_SurfaceDistance {
 public:
-    AP_SurfaceDistance(Rotation rot, const AP_InertialNav& inav, uint8_t i) :
+    AP_SurfaceDistance(Rotation rot, uint8_t i) :
         instance(i),
-        inertial_nav(inav),
         rotation(rot)
     {};
 
@@ -46,6 +44,5 @@ private:
     uint8_t status;
     uint32_t last_healthy_ms;
 
-    const AP_InertialNav& inertial_nav;
     const Rotation rotation;
 };


### PR DESCRIPTION
This is the final PR to remove INAV from Copter completly.

Board,blimp,bootloader,copter,heli,plane,rover,sub
CubeOrange,0,*,32,56,*,*,0