### PR TITLE
Ensure atomic access to turtle mode state from rate thread

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -3,6 +3,7 @@
 #include "Copter.h"
 #include <AP_Math/chirp.h>
 #include <AP_ExternalControl/AP_ExternalControl_config.h> // TODO why is this needed if Copter.h includes this
+#include <AP_HAL/Semaphores.h>
 
 #if AP_COPTER_ADVANCED_FAILSAFE_ENABLED
 #include "afs_copter.h"
@@ -1857,6 +1858,10 @@ private:
     float motors_output;
     Vector2f motors_input;
     uint32_t last_throttle_warning_output_ms;
+
+    // Semaphore to protect the motors from the arming state
+    HAL_Semaphore msem;
+    bool shutdown;
 };
 #endif
 

--- a/ArduCopter/mode_turtle.cpp
+++ b/ArduCopter/mode_turtle.cpp
@@ -8,6 +8,8 @@
 
 bool ModeTurtle::init(bool ignore_checks)
 {
+    WITH_SEMAPHORE(msem);
+
     // do not enter the mode when already armed or when flying
     if (motors->armed() || SRV_Channels::get_dshot_esc_type() == 0) {
         return false;
@@ -26,14 +28,15 @@ bool ModeTurtle::init(bool ignore_checks)
         return false;
     }
 
-    // turn on notify leds
-    AP_Notify::flags.esc_calibration = true;
+    shutdown = false;
 
     return true;
 }
 
 void ModeTurtle::arm_motors()
 {
+    WITH_SEMAPHORE(msem);
+
     if (hal.util->get_soft_armed()) {
         return;
     }
@@ -45,11 +48,14 @@ void ModeTurtle::arm_motors()
     hal.rcout->disable_channel_mask_updates();
     change_motor_direction(true);
 
-    // disable throttle and gps failsafe
+    // disable throttle and gcs failsafe
     g.failsafe_throttle.set(FS_THR_DISABLED);
     g.failsafe_gcs.set(FS_GCS_DISABLED);
     g.fs_ekf_action.set(FS_EKF_ACTION_REPORT_ONLY);
 
+    // ensure the arming library is aware of our meddling
+    // even if it fails we don't want to prevent people getting into turtle mode
+    AP::arming().AP_Arming::arm(AP_Arming::Method::TURTLE_MODE, false);
     // arm
     motors->armed(true);
     hal.util->set_soft_armed(true);
@@ -62,6 +68,8 @@ bool ModeTurtle::allows_arming(AP_Arming::Method method) const
 
 void ModeTurtle::exit()
 {
+    shutdown = true;
+
     disarm_motors();
 
     // turn off notify leds
@@ -70,13 +78,17 @@ void ModeTurtle::exit()
 
 void ModeTurtle::disarm_motors()
 {
+    WITH_SEMAPHORE(msem);
+
     if (!hal.util->get_soft_armed()) {
         return;
     }
 
+    // ensure the arming library is aware of our meddling
+    AP::arming().AP_Arming::disarm(AP_Arming::Method::TURTLE_MODE, false);
+
     // disarm
     motors->armed(false);
-    hal.util->set_soft_armed(false);
 
     // un-reverse the motors
     change_motor_direction(false);
@@ -86,6 +98,8 @@ void ModeTurtle::disarm_motors()
     g.failsafe_throttle.load();
     g.failsafe_gcs.load();
     g.fs_ekf_action.load();
+
+    hal.util->set_soft_armed(false);
 }
 
 void ModeTurtle::change_motor_direction(bool reverse)
@@ -169,6 +183,14 @@ void ModeTurtle::run()
 // actually write values to the motors
 void ModeTurtle::output_to_motors()
 {
+    if (shutdown) {
+        disarm_motors();
+
+        // turn off notify leds
+        AP_Notify::flags.esc_calibration = false;
+        return;
+    }
+
     // throttle needs to be raised
     if (is_zero(channel_throttle->norm_input_dz())) {
         const uint32_t now = AP_HAL::millis();
@@ -180,6 +202,9 @@ void ModeTurtle::output_to_motors()
         disarm_motors();
         return;
     }
+
+    // turn on notify leds
+    AP_Notify::flags.esc_calibration = true;
 
     arm_motors();
 

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -2073,6 +2073,7 @@ void AP_Arming::check_forced_logging(const AP_Arming::Method method)
         case Method::LANDING:
         case Method::DDS:
         case Method::AUTO_ARM_ONCE:
+        case Method::TURTLE_MODE:
         case Method::UNKNOWN:
             AP::logger().set_long_log_persist(false);
             return;

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -83,6 +83,7 @@ public:
         BLACKBOX = 34,
         DDS = 35,
         AUTO_ARM_ONCE = 36,
+        TURTLE_MODE = 37,
         UNKNOWN = 100,
     };
 


### PR DESCRIPTION
This is similar in nature to the bug fix required for motor test in the fast rate loop (FYI @rmackay9). Races between the threads can cause uncontrolled motor output when switching modes.

There is still a bug with arming on a switch that I need to debug