### PR TITLE
Rover: CONDITION_YAW command to skid-steering Rover

### DIFF
--- a/Rover/GCS_MAVLink_Rover.cpp
+++ b/Rover/GCS_MAVLink_Rover.cpp
@@ -506,6 +506,9 @@ MAV_RESULT GCS_MAVLINK_Rover::handle_command_int_packet(const mavlink_command_in
 {
     switch (packet.command) {
 
+    case MAV_CMD_CONDITION_YAW:
+        return handle_command_condition_yaw(packet);
+
     case MAV_CMD_DO_CHANGE_SPEED:
         // param1 : type
         // param2 : new speed in m/s
@@ -593,6 +596,43 @@ MAV_RESULT GCS_MAVLINK_Rover::handle_command_nav_set_yaw_speed(const mavlink_com
         return MAV_RESULT_ACCEPTED;
 }
 #endif
+
+MAV_RESULT GCS_MAVLINK_Rover::handle_command_condition_yaw(const mavlink_command_int_t &packet)
+{
+    // param1 : target angle [0-360]
+    // param2 : speed during change [deg per second]
+    // param3 : direction (-1:ccw, +1:cw, 0:quickest direction to target heading)
+    // param4 : relative offset (1) or absolute angle (0)
+
+    if (!rover.g2.motors.have_skid_steering()) {
+        // not yet implemented for other vehicle types
+        return MAV_RESULT_UNSUPPORTED;
+    }
+
+    // exit if vehicle is not in Guided mode
+    if (!rover.control_mode->in_guided_mode()) {
+        return MAV_RESULT_FAILED;
+    }
+
+    // Check valid direction parameter
+    const int8_t direction = static_cast<int8_t>(packet.param3);
+    if (abs(direction) > 1) {  // only 0, -1 and 1 are valid direction values
+        return MAV_RESULT_DENIED;
+    }
+
+    // get final angle, 1 = Relative, 0 = Absolute
+    switch ((int) packet.param4) {
+    case 0: // absolute angle
+        rover.mode_guided.set_desired_turn_rate_and_heading(packet.param1 * 100.0f, packet.param2 * 100.0f, direction);
+        break;
+    case 1: // relative angle
+        rover.mode_guided.set_desired_turn_rate_and_heading_delta(packet.param1 * 100.0f, packet.param2 * 100.0f, direction);
+        break;
+    default:
+        return MAV_RESULT_DENIED;
+    }
+    return MAV_RESULT_ACCEPTED;
+}
 
 MAV_RESULT GCS_MAVLINK_Rover::handle_command_int_do_reposition(const mavlink_command_int_t &packet)
 {

--- a/Rover/GCS_MAVLink_Rover.h
+++ b/Rover/GCS_MAVLink_Rover.h
@@ -19,6 +19,7 @@ protected:
 
     MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_int_t &packet, const mavlink_message_t &msg) override;
     MAV_RESULT handle_command_int_packet(const mavlink_command_int_t &packet, const mavlink_message_t &msg) override;
+    MAV_RESULT handle_command_condition_yaw(const mavlink_command_int_t &packet);
     MAV_RESULT handle_command_int_do_reposition(const mavlink_command_int_t &packet);
     MAV_RESULT handle_command_nav_set_yaw_speed(const mavlink_command_int_t &packet, const mavlink_message_t &msg);
 

--- a/Rover/mode.cpp
+++ b/Rover/mode.cpp
@@ -504,6 +504,19 @@ void Mode::calc_steering_to_heading(float desired_heading_cd, float rate_max_deg
     set_steering(steering_out * 4500.0f);
 }
 
+// calculate steering output to drive towards desired heading
+// rate_max is a maximum turn rate in deg/s.  set to zero to use default turn rate limits
+void Mode::calc_directional_steering_to_heading(float desired_heading_cd, float rate_max_degs)
+{
+    // call heading controller
+    const float steering_out = attitude_control.get_directional_steering_out_heading(radians(desired_heading_cd*0.01f),
+                                                                         radians(rate_max_degs),
+                                                                         g2.motors.limit.steer_left,
+                                                                         g2.motors.limit.steer_right,
+                                                                         rover.G_Dt);
+    set_steering(steering_out * 4500.0f);
+}
+
 void Mode::set_steering(float steering_value)
 {
     if (allows_stick_mixing() && g2.stick_mixing > 0) {

--- a/Rover/mode.h
+++ b/Rover/mode.h
@@ -175,6 +175,10 @@ protected:
     // rate_max is a maximum turn rate in deg/s.  set to zero to use default turn rate limits
     void calc_steering_to_heading(float desired_heading_cd, float rate_max_degs = 0.0f);
 
+    // calculate steering output to drive towards desired heading
+    // rate_max is a maximum turn rate in deg/s.  set to zero to use default turn rate limits
+    void calc_directional_steering_to_heading(float desired_heading_cd, float rate_max_degs = 0.0f);
+
     // calculates the amount of throttle that should be output based
     // on things like proximity to corners and current speed
     virtual void calc_throttle(float target_speed, bool avoidance_enabled);
@@ -551,6 +555,10 @@ public:
     void set_desired_heading_delta_and_speed(float yaw_delta_cd, float target_speed);
     void set_desired_turn_rate_and_speed(float turn_rate_cds, float target_speed);
 
+    // set desired turn rate and heading
+    void set_desired_turn_rate_and_heading(float yaw_angle_cd, float turn_rate_cds, int8_t direction);
+    void set_desired_turn_rate_and_heading_delta(float yaw_delta_cd, float turn_rate_cds, int8_t direction);
+
     // set steering and throttle (-1 to +1).  Only called from scripts
     void set_steering_and_throttle(float steering, float throttle);
 
@@ -574,6 +582,7 @@ protected:
         TurnRateAndSpeed,
         Loiter,
         SteeringAndThrottle,
+        TurnRateAndHeading,
         Stop
     };
 

--- a/Rover/mode_guided.cpp
+++ b/Rover/mode_guided.cpp
@@ -101,6 +101,30 @@ void ModeGuided::update()
             break;
         }
 
+        case SubMode::TurnRateAndHeading:
+        {
+            // stop vehicle if target not updated within 3 seconds
+            if (have_attitude_target && (millis() - _des_att_time_ms) > 3000) {
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "target not received last 3secs, stopping");
+                have_attitude_target = false;
+                break;
+            }
+            if (have_attitude_target) {
+                // run steering and throttle controllers
+                calc_directional_steering_to_heading(_desired_yaw_cd, _desired_yaw_rate_cds * 0.01f);
+                break;
+            }
+            // we have reached the destination so stay here
+            if (rover.is_boat()) {
+                if (!start_loiter()) {
+                    stop_vehicle();
+                }
+                break;
+            }
+            stop_vehicle();
+            break;
+        }
+
         case SubMode::Loiter:
         {
             rover.mode_loiter.update();
@@ -149,6 +173,7 @@ float ModeGuided::wp_bearing() const
         return g2.wp_nav.wp_bearing_cd() * 0.01f;
     case SubMode::HeadingAndSpeed:
     case SubMode::TurnRateAndSpeed:
+    case SubMode::TurnRateAndHeading:
         return 0.0f;
     case SubMode::Loiter:
         return rover.mode_loiter.wp_bearing();
@@ -169,6 +194,8 @@ float ModeGuided::nav_bearing() const
     case SubMode::HeadingAndSpeed:
     case SubMode::TurnRateAndSpeed:
         return 0.0f;
+    case SubMode::TurnRateAndHeading:
+        return _desired_yaw_cd * 0.01f;
     case SubMode::Loiter:
         return rover.mode_loiter.nav_bearing();
     case SubMode::SteeringAndThrottle:
@@ -187,6 +214,7 @@ float ModeGuided::crosstrack_error() const
         return g2.wp_nav.crosstrack_error();
     case SubMode::HeadingAndSpeed:
     case SubMode::TurnRateAndSpeed:
+    case SubMode::TurnRateAndHeading:
         return 0.0f;
     case SubMode::Loiter:
         return rover.mode_loiter.crosstrack_error();
@@ -206,6 +234,7 @@ float ModeGuided::get_desired_lat_accel() const
         return g2.wp_nav.get_lat_accel();
     case SubMode::HeadingAndSpeed:
     case SubMode::TurnRateAndSpeed:
+    case SubMode::TurnRateAndHeading:
         return 0.0f;
     case SubMode::Loiter:
         return rover.mode_loiter.get_desired_lat_accel();
@@ -226,6 +255,7 @@ float ModeGuided::get_distance_to_destination() const
         return _distance_to_destination;
     case SubMode::HeadingAndSpeed:
     case SubMode::TurnRateAndSpeed:
+    case SubMode::TurnRateAndHeading:
         return 0.0f;
     case SubMode::Loiter:
         return rover.mode_loiter.get_distance_to_destination();
@@ -246,6 +276,7 @@ bool ModeGuided::reached_destination() const
         return g2.wp_nav.reached_destination();
     case SubMode::HeadingAndSpeed:
     case SubMode::TurnRateAndSpeed:
+    case SubMode::TurnRateAndHeading:
     case SubMode::Loiter:
     case SubMode::SteeringAndThrottle:
     case SubMode::Stop:
@@ -269,6 +300,7 @@ bool ModeGuided::set_desired_speed(float speed)
     case SubMode::Loiter:
         return rover.mode_loiter.set_desired_speed(speed);
     case SubMode::SteeringAndThrottle:
+    case SubMode::TurnRateAndHeading:
     case SubMode::Stop:
         // no speed control
         return false;
@@ -288,6 +320,7 @@ bool ModeGuided::get_desired_location(Location& destination) const
         return false;
     case SubMode::HeadingAndSpeed:
     case SubMode::TurnRateAndSpeed:
+    case SubMode::TurnRateAndHeading:
         // not supported in these submodes
         return false;
     case SubMode::Loiter:
@@ -372,6 +405,36 @@ void ModeGuided::set_desired_turn_rate_and_speed(float turn_rate_cds, float targ
     // log new target
     rover.Log_Write_GuidedTarget((uint8_t)_guided_mode, Vector3f(_desired_yaw_rate_cds, 0.0f, 0.0f), Vector3f(_desired_speed, 0.0f, 0.0f));
 #endif
+}
+
+// set desired attitude
+void ModeGuided::set_desired_turn_rate_and_heading(float yaw_angle_cd, float turn_rate_cds, int8_t direction)
+{
+    // initialisation and logging
+    _guided_mode = SubMode::TurnRateAndHeading;
+    _des_att_time_ms = AP_HAL::millis();
+
+    // record targets
+    have_attitude_target = true;
+    _desired_yaw_rate_cds = turn_rate_cds; 
+    _desired_yaw_cd = wrap_180_cd(yaw_angle_cd);
+
+    // force clockwise or counter-clockwise movement according to direction
+    if (direction == -1 && is_positive(_desired_yaw_cd)) {
+        _desired_yaw_cd -= 36000.0;
+    } else if (direction == 1 && is_negative(_desired_yaw_cd)) {
+        _desired_yaw_cd += 36000.0;
+    }
+}
+
+// set desired attitude
+void ModeGuided::set_desired_turn_rate_and_heading_delta(float yaw_delta_cd, float turn_rate_cds, int8_t direction)
+{
+    /// handle initialisation
+    _guided_mode = SubMode::TurnRateAndHeading;
+    float current_yaw_cd = ahrs.yaw_sensor;
+
+    set_desired_turn_rate_and_heading(current_yaw_cd + yaw_delta_cd, turn_rate_cds, direction);
 }
 
 // set steering and throttle (both in the range -1 to +1)

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6361,6 +6361,60 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.wait_distance_to_home(0, 5, timeout=30)
         self.disarm_vehicle()
 
+    def MAV_CMD_CONDITION_YAW_ABSOLUTE(self):
+        '''simple test for CONDITION_YAW command with absolute angles'''
+        model = "rover-skid"
+        self.customise_SITL_commandline([],
+                                        model=model,
+                                        defaults_filepath=self.model_defaults_filepath(model))
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        self.change_mode('GUIDED')
+
+        for (heading, intermediate_heading, direction) in (170, 90, 1), (300, 90, -1), (200, 250, 0), (300, 250, 0):
+
+            def send_cmd(x, y):
+                self.run_cmd(
+                    mavutil.mavlink.MAV_CMD_CONDITION_YAW,
+                    p1=heading,     # target angle
+                    p2=10,          # degrees/second
+                    p3=direction,   # -1 is counter-clockwise, 1 clockwise
+                    p4=0,           # 1 for relative, 0 for absolute
+                )
+            """check if rotating in correct direction"""
+            self.wait_heading(intermediate_heading, 5, called_function=send_cmd)
+            """target angle"""
+            self.wait_heading(heading, 5, called_function=send_cmd)
+            self.wait_yaw_speed(0, 0.05, called_function=send_cmd)
+
+        self.disarm_vehicle()
+
+    def MAV_CMD_CONDITION_YAW_RELATIVE(self):
+        '''simple test for CONDITION_YAW command with relative angles'''
+        model = "rover-skid"
+        self.customise_SITL_commandline([],
+                                        model=model,
+                                        defaults_filepath=self.model_defaults_filepath(model))
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        self.change_mode('GUIDED')
+
+        """initial rover heading is 247"""
+        for (relative_heading, direction, target_heading) in (13, 1, 260), (-30, -1, 230), (20, 0, 250), (-30, 0, 220):
+
+            self.run_cmd(
+                mavutil.mavlink.MAV_CMD_CONDITION_YAW,
+                p1=relative_heading,     # target angle
+                p2=10,                   # degrees/second
+                p3=direction,            # -1 is counter-clockwise, 1 clockwise
+                p4=1,                    # 1 for relative, 0 for absolute
+            )
+            """target angle"""
+            self.wait_heading(target_heading, 5)
+            self.wait_yaw_speed(0, 0.05)
+
+        self.disarm_vehicle()
+
     def MAV_CMD_MISSION_START(self):
         '''simple test for starting missing using this command'''
         # home and 1 waypoint a long way away:
@@ -7183,6 +7237,8 @@ return update()
             self.SET_POSITION_TARGET_LOCAL_NED,
             self.MAV_CMD_DO_SET_MISSION_CURRENT,
             self.MAV_CMD_DO_CHANGE_SPEED,
+            self.MAV_CMD_CONDITION_YAW_ABSOLUTE,
+            self.MAV_CMD_CONDITION_YAW_RELATIVE,
             self.MAV_CMD_MISSION_START,
             self.MAV_CMD_NAV_SET_YAW_SPEED,
             self.Button,

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -620,6 +620,17 @@ float AR_AttitudeControl::get_steering_out_heading(float heading_rad, float rate
     return get_steering_out_rate(desired_rate, motor_limit_left, motor_limit_right, dt);
 }
 
+// return a steering servo output from -1 to +1 given a heading in radians
+// set rate_max_rads to a non-zero number to apply a limit on the desired turn rate
+// return value is normally in range -1.0 to +1.0 but can be higher or lower
+float AR_AttitudeControl::get_directional_steering_out_heading(float heading_rad, float rate_max_rads, bool motor_limit_left, bool motor_limit_right, float dt)
+{
+    // calculate the desired turn rate (in radians) from the angle error (also in radians)
+    float desired_rate = get_directional_turn_rate_from_heading(heading_rad, rate_max_rads);
+
+    return get_steering_out_rate(desired_rate, motor_limit_left, motor_limit_right, dt);
+}
+
 // return a desired turn-rate given a desired heading in radians
 float AR_AttitudeControl::get_turn_rate_from_heading(float heading_rad, float rate_max_rads) const
 {
@@ -639,6 +650,28 @@ float AR_AttitudeControl::get_turn_rate_from_heading(float heading_rad, float ra
         desired_rate = constrain_float(desired_rate, -steer_decel_rate_max_rads, steer_decel_rate_max_rads);
     } else if (is_positive(_steer_accel_max)) {
         // if no deceleration limit, use acceleration limit
+        const float steer_accel_rate_max_rads = safe_sqrt(2.0 * fabsf(yaw_error) * radians(_steer_accel_max));
+        desired_rate = constrain_float(desired_rate, -steer_accel_rate_max_rads, steer_accel_rate_max_rads);
+    }
+
+    return desired_rate;
+}
+
+// return a desired turn-rate given a desired heading in radians
+float AR_AttitudeControl::get_directional_turn_rate_from_heading(float heading_rad, float rate_max_rads) const
+{
+    const float yaw_error = wrap_neg2PI_2PI(heading_rad - AP::ahrs().get_yaw_rad());
+
+    // Calculate the desired turn rate (in radians) from the angle error (also in radians)
+    float desired_rate = _steer_angle_p.get_p(yaw_error);
+
+    // limit desired_rate if a custom pivot turn rate is selected, otherwise use ATC_STR_RAT_MAX
+    if (is_positive(rate_max_rads)) {
+        desired_rate = constrain_float(desired_rate, -rate_max_rads, rate_max_rads);
+    }
+
+    // if acceleration limit is provided, ensure rate can be slowed to zero in time to stop at heading_rad (i.e. avoid overshoot)
+    if (is_positive(_steer_accel_max)) {
         const float steer_accel_rate_max_rads = safe_sqrt(2.0 * fabsf(yaw_error) * radians(_steer_accel_max));
         desired_rate = constrain_float(desired_rate, -steer_accel_rate_max_rads, steer_accel_rate_max_rads);
     }

--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -29,9 +29,18 @@ public:
     // return value is normally in range -1.0 to +1.0 but can be higher or lower
     float get_steering_out_heading(float heading_rad, float rate_max_rads, bool motor_limit_left, bool motor_limit_right, float dt);
 
+    // return a steering servo output given a heading in radians
+    // set rate_max_rads to a non-zero number to apply a limit on the desired turn rate
+    // return value is normally in range -1.0 to +1.0 but can be higher or lower
+    float get_directional_steering_out_heading(float heading_rad, float rate_max_rads, bool motor_limit_left, bool motor_limit_right, float dt);
+
     // return a desired turn-rate given a desired heading in radians
     // normally the results are later passed into get_steering_out_rate
     float get_turn_rate_from_heading(float heading_rad, float rate_max_rads) const;
+
+    // return a desired turn-rate given a desired heading in radians
+    // normally the results are later passed into get_steering_out_rate
+    float get_directional_turn_rate_from_heading(float heading_rad, float rate_max_rads) const;
 
     // return a steering servo output given a desired yaw rate in radians/sec.
     // positive yaw is to the right

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -165,6 +165,14 @@ ftype wrap_PI(const ftype radian);
 ftype wrap_2PI(const ftype radian);
 
 /*
+ * wrap an angle in radians to -2PI..2PI
+ */
+inline ftype wrap_neg2PI_2PI(const ftype radian) 
+{
+    return fmodF(radian, M_2PI);
+}
+
+/*
  * Constrain a value to be within the range: low and high
  */
 template <typename T>

--- a/libraries/AP_Math/tests/test_math.cpp
+++ b/libraries/AP_Math/tests/test_math.cpp
@@ -551,6 +551,25 @@ TEST(MathWrapTest, Angle2PI)
     EXPECT_NEAR(1,    wrap_2PI((short)1), accuracy);
 }
 
+TEST(MathWrapTest, AngleNeg2PI_2PI)
+{
+    const float accuracy = 1.0e-5;
+
+    EXPECT_NEAR(1.f,    wrap_neg2PI_2PI(1.f), accuracy);
+    EXPECT_NEAR(-4.f,   wrap_neg2PI_2PI(-4.f), accuracy);
+    EXPECT_NEAR(M_PI,   wrap_neg2PI_2PI(M_PI), accuracy);
+    EXPECT_NEAR(-M_PI,  wrap_neg2PI_2PI(-M_PI), accuracy);
+    EXPECT_NEAR(0.f,    wrap_neg2PI_2PI(M_2PI), accuracy);
+    EXPECT_NEAR(0.f,    wrap_neg2PI_2PI(-M_2PI), accuracy);
+    EXPECT_NEAR(0.f,    wrap_neg2PI_2PI(M_2PI * 5), accuracy);
+    EXPECT_NEAR(0.f,    wrap_neg2PI_2PI(-M_2PI * 5), accuracy);
+    EXPECT_NEAR(1.f,    wrap_neg2PI_2PI(M_2PI + 1.f), accuracy);
+    EXPECT_NEAR(-1.f,   wrap_neg2PI_2PI(-M_2PI - 1.f), accuracy);
+    EXPECT_NEAR(1.f,    wrap_neg2PI_2PI(M_2PI * 4 + 1.f), accuracy);
+    EXPECT_NEAR(-1.f,   wrap_neg2PI_2PI(-M_2PI * 4 - 1.f), accuracy);
+    EXPECT_NEAR(1.f,    wrap_neg2PI_2PI((short)1), accuracy);
+}
+
 TEST(MathTest, ASin)
 {
     const float accuracy = 1.0e-5;


### PR DESCRIPTION
Related to #29416
Added initial handling logic for the CONDITION_YAW command. An associated autotest was created to validate the new functionality. However, the test currently fails, indicating that further debugging and refinement of the yaw control logic are needed.