### PR TITLE
AP_TECS: Fix off-by-one error in TECS_HDEM_TCONST docs

### DIFF
--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -284,7 +284,7 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
 
     // @Param: HDEM_TCONST
     // @DisplayName: Height Demand Time Constant
-    // @Description: This sets the time constant of the low pass filter that is applied to the height demand input when bit 1 of TECS_OPTIONS is not selected.
+    // @Description: This sets the time constant of the low pass filter that is applied to the height demand input when bit 0 of TECS_OPTIONS is not selected.
     // @Range: 1.0 5.0
     // @Units: s
     // @Increment: 0.2


### PR DESCRIPTION
* This is useful when you are NOT a glider, which is bit 0, not bit 1.

![image](https://github.com/user-attachments/assets/f59a797f-c152-42e3-a4f0-ecd1439d606c)
