### PR TITLE
Tidy Copter AutoTune tests

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -2944,6 +2944,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "ATC_RAT_RLL_D",
             "ATC_RAT_RLL_I",
             "ATC_RAT_RLL_P",
+            "ATC_RAT_YAW_D",
         ]
         ogains = self.get_parameters(gain_names)
         # set these parameters so they get reverted at the end of the test:

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -2940,9 +2940,15 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
     def AutoTuneYawD(self):
         """Test autotune mode"""
 
-        rlld = self.get_parameter("ATC_RAT_RLL_D")
-        rlli = self.get_parameter("ATC_RAT_RLL_I")
-        rllp = self.get_parameter("ATC_RAT_RLL_P")
+        gain_names = [
+            "ATC_RAT_RLL_D",
+            "ATC_RAT_RLL_I",
+            "ATC_RAT_RLL_P",
+        ]
+        ogains = self.get_parameters(gain_names)
+        # set these parameters so they get reverted at the end of the test:
+        self.set_parameters(ogains)
+
         self.set_parameter("ATC_RAT_RLL_SMAX", 1)
         self.set_parameter("AUTOTUNE_AXES", 15)
         self.takeoff(10)
@@ -2967,10 +2973,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 self.change_mode('LAND')
                 self.wait_landed_and_disarmed()
                 # check the original gains have been re-instated
-                if (rlld != self.get_parameter("ATC_RAT_RLL_D") or
-                        rlli != self.get_parameter("ATC_RAT_RLL_I") or
-                        rllp != self.get_parameter("ATC_RAT_RLL_P")):
-                    raise NotAchievedException("AUTOTUNE gains still present")
+                ngains = self.get_parameters(gain_names)
+                for g in ngains.keys():
+                    if ogains[g] != ngains[g]:
+                        raise NotAchievedException(f"AUTOTUNE gains still present {ogains=} {ngains=}")
                 return
 
         raise NotAchievedException("AUTOTUNE failed (%u seconds)" %

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -2902,40 +2902,36 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
     def AutoTune(self):
         """Test autotune mode"""
 
-        rlld = self.get_parameter("ATC_RAT_RLL_D")
-        rlli = self.get_parameter("ATC_RAT_RLL_I")
-        rllp = self.get_parameter("ATC_RAT_RLL_P")
+        gain_names = [
+            "ATC_RAT_RLL_D",
+            "ATC_RAT_RLL_I",
+            "ATC_RAT_RLL_P",
+        ]
+
+        ogains = self.get_parameters(gain_names)
+        # set these parameters so they get reverted at the end of the test:
+        self.set_parameters(ogains)
+
         self.set_parameter("ATC_RAT_RLL_SMAX", 1)
         self.takeoff(10)
 
-        # hold position in loiter
+        tstart = self.get_sim_time()
+
         self.change_mode('AUTOTUNE')
 
-        tstart = self.get_sim_time()
-        sim_time_expected = 5000
-        deadline = tstart + sim_time_expected
-        while self.get_sim_time_cached() < deadline:
-            now = self.get_sim_time_cached()
-            m = self.mav.recv_match(type='STATUSTEXT',
-                                    blocking=True,
-                                    timeout=1)
-            if m is None:
-                continue
-            self.progress("STATUSTEXT (%u<%u): %s" % (now, deadline, m.text))
-            if "AutoTune: Success" in m.text:
-                self.progress("AUTOTUNE OK (%u seconds)" % (now - tstart))
-                # near enough for now:
-                self.change_mode('LAND')
-                self.wait_landed_and_disarmed()
-                # check the original gains have been re-instated
-                if (rlld != self.get_parameter("ATC_RAT_RLL_D") or
-                        rlli != self.get_parameter("ATC_RAT_RLL_I") or
-                        rllp != self.get_parameter("ATC_RAT_RLL_P")):
-                    raise NotAchievedException("AUTOTUNE gains still present")
-                return
+        self.wait_statustext("AutoTune: Success", timeout=5000)
+        now = self.get_sim_time()
+        self.progress("AUTOTUNE OK (%u seconds)" % (now - tstart))
 
-        raise NotAchievedException("AUTOTUNE failed (%u seconds)" %
-                                   (self.get_sim_time() - tstart))
+        # near enough for now:
+        self.change_mode('LAND')
+        self.wait_landed_and_disarmed()
+
+        self.progress("checking the original gains have been re-instated")
+        ngains = self.get_parameters(gain_names)
+        for g in ngains.keys():
+            if ogains[g] != ngains[g]:
+                raise NotAchievedException(f"AUTOTUNE gains not discarded {ogains=} {ngains=}")
 
     def AutoTuneYawD(self):
         """Test autotune mode"""


### PR DESCRIPTION
Tidies both AutoTune and AutoTuneYawD, which are essentially identical at the moment.

Corrects AutoTuneYawD to verify that the yaw D gain hasn't changed at the end of the test.

I tested that the final assertions still work by modifying the test to landing in autotune mode.  The gains get saved and the test fails.

Added some code that allows the test suite to revert the parameter values.  Given the current working of these AutoTune tests it isn't strictly necessary (they assert these values haven't changed, and we reset parameters in the suite on failure), but I don't want weird tuning values to creep into subsequent tests because someone forgets this code in future tests!

I did consider factoring these two tests but decided against it.  There should be more test clauses in these tests to make sure the tuning *did* change values, and I'm not sure if that would fit well with any factorisation.
