### PR TITLE
create and use AP_AHRS::has_status

### DIFF
--- a/ArduCopter/AP_Arming_Copter.cpp
+++ b/ArduCopter/AP_Arming_Copter.cpp
@@ -131,8 +131,8 @@ bool AP_Arming_Copter::barometer_checks(bool display_failure)
         // Check baro & inav alt are within 1m if EKF is operating in an absolute position mode.
         // Do not check if intending to operate in a ground relative height mode as EKF will output a ground relative height
         // that may differ from the baro height due to baro drift.
-        nav_filter_status filt_status = copter.inertial_nav.get_filter_status();
-        bool using_baro_ref = (!filt_status.flags.pred_horiz_pos_rel && filt_status.flags.pred_horiz_pos_abs);
+        const auto &ahrs = AP::ahrs();
+        bool using_baro_ref = !ahrs.has_status(AP_AHRS::Status::PRED_HORIZ_POS_REL) && ahrs.has_status(AP_AHRS::Status::PRED_HORIZ_POS_ABS);
         if (using_baro_ref) {
             if (fabsf(copter.inertial_nav.get_position_z_up_cm() - copter.baro_alt) > PREARM_MAX_ALT_DISPARITY_CM) {
                 check_failed(Check::BARO, display_failure, "Altitude disparity");
@@ -402,10 +402,7 @@ bool AP_Arming_Copter::gps_checks(bool display_failure)
 // check ekf attitude is acceptable
 bool AP_Arming_Copter::pre_arm_ekf_attitude_check()
 {
-    // get ekf filter status
-    nav_filter_status filt_status = copter.inertial_nav.get_filter_status();
-
-    return filt_status.flags.attitude;
+    return AP::ahrs().has_status(AP_AHRS::Status::ATTITUDE_VALID);
 }
 
 #if HAL_PROXIMITY_ENABLED

--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -298,9 +298,7 @@ void Copter::failsafe_terrain_on_event()
 // check for gps glitch failsafe
 void Copter::gpsglitch_check()
 {
-    // get filter status
-    nav_filter_status filt_status = inertial_nav.get_filter_status();
-    bool gps_glitching = filt_status.flags.gps_glitching;
+    const bool gps_glitching = AP::ahrs().has_status(AP_AHRS::Status::GPS_GLITCHING);
 
     // log start or stop of gps glitch.  AP_Notify update is handled from within AP_AHRS
     if (ap.gps_glitching != gps_glitching) {
@@ -322,7 +320,7 @@ void Copter::failsafe_deadreckon_check()
     const char* dr_prefix_str = "Dead Reckoning";
 
     // get EKF filter status
-    bool ekf_dead_reckoning = inertial_nav.get_filter_status().flags.dead_reckoning;
+    const bool ekf_dead_reckoning = AP::ahrs().has_status(AP_AHRS::Status::DEAD_RECKONING);
 
     // alert user to start or stop of dead reckoning
     const uint32_t now_ms = AP_HAL::millis();

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -374,6 +374,7 @@ void AP_AHRS::update_state(void)
     _getCorrectedDeltaVelocityNED(state.corrected_dv, state.corrected_dv_dt);
     state.origin_ok = _get_origin(state.origin);
     state.velocity_NED_ok = _get_velocity_NED(state.velocity_NED);
+    _get_filter_status(state.filter_status);
 }
 
 // update run at loop rate
@@ -2397,37 +2398,38 @@ bool AP_AHRS::initialised(void) const
 };
 
 // get_filter_status : returns filter status as a series of flags
-bool AP_AHRS::get_filter_status(nav_filter_status &status) const
+void AP_AHRS::_get_filter_status(nav_filter_status &status) const
 {
     switch (ekf_type()) {
 #if AP_AHRS_DCM_ENABLED
     case EKFType::DCM:
-        return dcm.get_filter_status(status);
+        dcm.get_filter_status(status);
+        return;
 #endif
 
 #if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         EKF2.getFilterStatus(status);
-        return true;
+        return;
 #endif
 
 #if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         EKF3.getFilterStatus(status);
-        return true;
+        return;
 #endif
 
 #if AP_AHRS_SIM_ENABLED
     case EKFType::SIM:
-        return sim.get_filter_status(status);
+        sim.get_filter_status(status);
+        return;
 #endif
 #if AP_AHRS_EXTERNAL_ENABLED
     case EKFType::EXTERNAL:
-        return external.get_filter_status(status);
+        external.get_filter_status(status);
+        return;
 #endif
     }
-
-    return false;
 }
 
 // write optical flow data to EKF

--- a/libraries/AP_NavEKF/AP_Nav_Common.h
+++ b/libraries/AP_NavEKF/AP_Nav_Common.h
@@ -21,30 +21,6 @@
 
 #define MAX_EKF_CORES     3 // maximum allowed EKF Cores to be instantiated
 
-// enumeration corresponding to buts within nav_filter_status union.
-// Only used for documentation purposes.
-enum class NavFilterStatusBit {
-    ATTITUDE           =      1, // attitude estimate valid
-    HORIZ_VEL          =      2, // horizontal velocity estimate valid
-    VERT_VEL           =      4, // vertical velocity estimate valid
-    HORIZ_POS_REL      =      8, // relative horizontal position estimate valid
-    HORIZ_POS_ABS      =     16, // absolute horizontal position estimate valid
-    VERT_POS           =     32, // vertical position estimate valid
-    TERRAIN_ALT        =     64, // terrain height estimate valid
-    CONST_POS_MODE     =    128, // in constant position mode
-    PRED_HORIZ_POS_REL =    256, // expected good relative horizontal position estimate - used before takeoff
-    PRED_HORIZ_POS_ABS =    512, // expected good absolute horizontal position estimate - used before takeoff
-    TAKEOFF_DETECTED   =   1024, // optical flow takeoff has been detected
-    TAKEOFF_EXPECTED   =   2048, // compensating for baro errors during takeoff
-    TOUCHDOWN_EXPECTED =   4096, // compensating for baro errors during touchdown
-    USING_GPS          =   8192, // using GPS position
-    GPS_GLITCHING      =  16384, // GPS glitching is affecting navigation accuracy
-    GPS_QUALITY_GOOD   =  32768, // can use GPS for navigation
-    INITALIZED         =  65536, // has ever been healthy
-    REJECTING_AIRSPEED = 131072, // rejecting airspeed data
-    DEAD_RECKONING     = 262144, // dead reckoning (e.g. no position or velocity source)
-};
-
 union nav_filter_status {
     struct {
         bool attitude           : 1; // 0 - true if attitude estimate is valid

--- a/libraries/AP_NavEKF3/LogStructure.h
+++ b/libraries/AP_NavEKF3/LogStructure.h
@@ -188,7 +188,7 @@ struct PACKED log_XKF3 {
 // @Field: FS: Filter fault status
 // @Field: TS: Filter timeout status bitmask (0:position measurement, 1:velocity measurement, 2:height measurement, 3:magnetometer measurement, 4:airspeed measurement, 5:drag measurement)
 // @Field: SS: Filter solution status
-// @FieldBitmaskEnum: SS: NavFilterStatusBit
+// @FieldBitmaskEnum: SS: AP_AHRS::Status
 // @Field: GPS: Filter GPS status
 // @Field: PI: Primary core index
 struct PACKED log_XKF4 {


### PR DESCRIPTION
Currently just the shape I am intending.

Not sure about the boolean return value on get-filter-status.  I think we just make the get_filter_status non-boolean and the backends must make a best-effort to fill in
