### PR TITLE
autotest: Flake8 clean all logger metadata scripts

### DIFF
--- a/Tools/autotest/logger_metadata/emit_html.py
+++ b/Tools/autotest/logger_metadata/emit_html.py
@@ -1,4 +1,8 @@
+'''
+AP_FLAKE8_CLEAN
+'''
 import emitter
+
 
 class HTMLEmitter(emitter.Emitter):
     def preface(self):
@@ -18,6 +22,7 @@ DO NOT EDIT
 [toc exclude="Onboard Message Log Messages"]
 
 """
+
     def postface(self):
         return ""
 
@@ -42,7 +47,7 @@ DO NOT EDIT
                     fdesc = docco.fields[f]["description"]
                 else:
                     fdesc = ""
-                if "units" in docco.fields[f] and docco.fields[f]["units"]!="":
+                if "units" in docco.fields[f] and docco.fields[f]["units"] != "":
                     ftypeunits = docco.fields[f]["units"]
                 elif "fmt" in docco.fields[f] and "char" in docco.fields[f]["fmt"]:
                     ftypeunits = docco.fields[f]["fmt"]

--- a/Tools/autotest/logger_metadata/emit_md.py
+++ b/Tools/autotest/logger_metadata/emit_md.py
@@ -1,6 +1,11 @@
+'''
+AP_FLAKE8_CLEAN
+'''
+
 import os
 import time
 import emitter
+
 
 class MDEmitter(emitter.Emitter):
     def preface(self):
@@ -50,6 +55,7 @@ DO NOT EDIT
 [toc exclude="Onboard Message Log Messages"]
 
 """
+
     def postface(self):
         return ""
 
@@ -73,7 +79,7 @@ DO NOT EDIT
                     fdesc = docco.fields[f]["description"]
                 else:
                     fdesc = ""
-                if "units" in docco.fields[f] and docco.fields[f]["units"]!="":
+                if "units" in docco.fields[f] and docco.fields[f]["units"] != "":
                     ftypeunits = docco.fields[f]["units"]
                 elif "fmt" in docco.fields[f] and "char" in docco.fields[f]["fmt"]:
                     ftypeunits = docco.fields[f]["fmt"]

--- a/Tools/autotest/logger_metadata/emit_rst.py
+++ b/Tools/autotest/logger_metadata/emit_rst.py
@@ -1,4 +1,8 @@
+'''
+AP_FLAKE8_CLEAN
+'''
 import emitter
+
 
 class RSTEmitter(emitter.Emitter):
     def preface(self):
@@ -15,6 +19,7 @@ Onboard Message Log Messages
 This is a list of log messages which may be present in logs produced and stored onboard ArduPilot vehicles.
 
 """
+
     def postface(self):
         return ""
 
@@ -60,7 +65,7 @@ This is a list of log messages which may be present in logs produced and stored 
                     enumeration = enumerations[enum_name]
                     bitmaskrows = []
                     for enumentry in enumeration.entries:
-#                        print("enumentry: %s" % str(enumentry))
+                        # print("enumentry: %s" % str(enumentry))
                         comment = enumentry.comment
                         if comment is None:
                             comment = ""
@@ -83,7 +88,6 @@ This is a list of log messages which may be present in logs produced and stored 
     def stop(self):
         print(self.postface(), file=self.fh)
         self.fh.close()
-
 
     # tablify swiped from rstemit.py
 
@@ -205,4 +209,3 @@ This is a list of log messages which may be present in logs produced and stored 
             ret += bar + "\n"
 
         return ret
-

--- a/Tools/autotest/logger_metadata/emit_xml.py
+++ b/Tools/autotest/logger_metadata/emit_xml.py
@@ -1,5 +1,9 @@
+'''
+AP_FLAKE8_CLEAN
+'''
 from lxml import etree
 import emitter
+
 
 class XMLEmitter(emitter.Emitter):
     def preface(self):
@@ -56,7 +60,7 @@ class XMLEmitter(emitter.Emitter):
                     for entry in enum.entries:
                         xml_enum_entry = etree.SubElement(xml_enum, xmlentrytag, name=entry.name)
                         xml_enum_entry_value = etree.SubElement(xml_enum_entry, 'value')
-                        xml_enum_entry_value.text =  str(entry.value)
+                        xml_enum_entry_value.text = str(entry.value)
                         if entry.comment is not None:
                             xml_enum_entry_comment = etree.SubElement(xml_enum_entry, 'description')
                             xml_enum_entry_comment.text = entry.comment

--- a/Tools/autotest/logger_metadata/emitter.py
+++ b/Tools/autotest/logger_metadata/emitter.py
@@ -1,3 +1,7 @@
+'''
+AP_FLAKE8_CLEAN
+'''
+
+
 class Emitter(object):
     pass
-


### PR DESCRIPTION
This PR updates to the Logger metadata parser Python scripts in Tools/autotest/logger_metadata to be flake8 clean, including adding the "AP_FLAKE8_CLEAN" tag to them. Only minor whitespace changes were required.
Checked by running flake8 locally and also by Ardupilot CI.