### PR TITLE
AP_AIS: Populate OADatabase for avoidance

### DIFF
--- a/libraries/AC_Avoidance/AP_OADatabase.cpp
+++ b/libraries/AC_Avoidance/AP_OADatabase.cpp
@@ -54,7 +54,7 @@ const AP_Param::GroupInfo AP_OADatabase::var_info[] = {
     // @DisplayName: OADatabase item timeout
     // @Description: OADatabase item timeout. The time an item will linger without any updates before it expires. Zero means never expires which is useful for a sent-once static environment but terrible for dynamic ones.
     // @Units: s
-    // @Range: 0 127
+    // @Range: 0 500
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("EXPIRE", 2, AP_OADatabase, _database_expiry_seconds, AP_OADATABASE_TIMEOUT_SECONDS_DEFAULT),
@@ -122,6 +122,9 @@ AP_OADatabase::AP_OADatabase()
 
 void AP_OADatabase::init()
 {
+    // PARAMETER_CONVERSION - Added: JUN-2025
+    _database_expiry_seconds.convert_parameter_width(AP_PARAM_INT8);
+
     init_database();
     init_queue();
 

--- a/libraries/AC_Avoidance/AP_OADatabase.h
+++ b/libraries/AC_Avoidance/AP_OADatabase.h
@@ -66,7 +66,7 @@ private:
 
     // database item management
     void database_item_add(const OA_DbItem &item);
-    void database_item_refresh(const uint16_t index, const uint32_t timestamp_ms, const float radius);
+    void database_item_refresh(const uint16_t index, const OA_DbItem &item);
     void database_item_remove(const uint16_t index);
     void database_items_remove_all_expired();
 

--- a/libraries/AC_Avoidance/AP_OADatabase.h
+++ b/libraries/AC_Avoidance/AP_OADatabase.h
@@ -38,8 +38,9 @@ public:
     void init();
     void update();
 
-    // push an object into the database.  Pos is the offset in meters from the EKF origin, angle is in degrees, distance in meters
-    void queue_push(const Vector3f &pos, uint32_t timestamp_ms, float distance);
+    // Push an object into the database. Pos is the offset in meters from the EKF origin, measurement timestamp in ms, distance in meters, optional radius in meters
+    void queue_push(const Vector3f &pos, const uint32_t timestamp_ms, const float distance, float radius);
+    void queue_push(const Vector3f &pos, const uint32_t timestamp_ms, const float distance);
 
     // returns true if database is healthy
     bool healthy() const { return (_queue.items != nullptr) && (_database.items != nullptr); }

--- a/libraries/AC_Avoidance/AP_OADatabase.h
+++ b/libraries/AC_Avoidance/AP_OADatabase.h
@@ -88,7 +88,7 @@ private:
     // parameters
     AP_Int16        _queue_size_param;                      // queue size
     AP_Int16        _database_size_param;                   // db size
-    AP_Int8         _database_expiry_seconds;               // objects expire after this timeout
+    AP_Int16        _database_expiry_seconds;               // objects expire after this timeout
     AP_Enum<OutputLevel> _output_level;                     // controls which items should be sent to GCS
     AP_Float        _beam_width;                            // beam width used when converting lidar readings to object radius
     AP_Float        _radius_min;                            // objects minimum radius (in meters)

--- a/libraries/AC_Avoidance/AP_OADatabase.h
+++ b/libraries/AC_Avoidance/AP_OADatabase.h
@@ -21,7 +21,7 @@ public:
         return _singleton;
     }
 
-    enum OA_DbItemImportance {
+    enum OA_DbItemImportance : uint8_t {
         Low,
         Normal,
         High,
@@ -39,7 +39,7 @@ public:
         OA_DbItemImportance importance;
 
         // Source of item, refresh treats sources differently
-        enum class Source {
+        enum class Source : uint8_t {
             proximity,
             AIS
         } source;

--- a/libraries/AP_AIS/AP_AIS.cpp
+++ b/libraries/AP_AIS/AP_AIS.cpp
@@ -306,7 +306,7 @@ void AP_AIS::send_to_object_avoidance_database(const struct ais_vehicle_t &vesse
 
     if ((vessel.info.flags & AIS_FLAGS_VALID_DIMENSIONS) == 0) {
         // No dimensions, let the database calculate from the configured beam width
-        oaDb->queue_push(pos, vessel.last_update_ms, distance);
+        oaDb->queue_push(pos, vessel.last_update_ms, distance, AP_OADatabase::OA_DbItem::Source::AIS, vessel.info.MMSI);
         return;
     }
 
@@ -322,7 +322,7 @@ void AP_AIS::send_to_object_avoidance_database(const struct ais_vehicle_t &vesse
         radius = MAX(radius, vessel.info.dimension_stern);
         radius = MAX(radius, vessel.info.dimension_port);
         radius = MAX(radius, vessel.info.dimension_starboard);
-        oaDb->queue_push(pos, vessel.last_update_ms, distance, radius);
+        oaDb->queue_push(pos, vessel.last_update_ms, distance, radius, AP_OADatabase::OA_DbItem::Source::AIS, vessel.info.MMSI);
         return;
     }
 
@@ -343,7 +343,7 @@ void AP_AIS::send_to_object_avoidance_database(const struct ais_vehicle_t &vesse
         (vessel.info.dimension_starboard + vessel.info.dimension_port) * 0.5
     );
 
-    oaDb->queue_push(pos, vessel.last_update_ms, distance, radius);
+    oaDb->queue_push(pos, vessel.last_update_ms, distance, radius, AP_OADatabase::OA_DbItem::Source::AIS, vessel.info.MMSI);
 }
 #endif
 

--- a/libraries/AP_AIS/AP_AIS.h
+++ b/libraries/AP_AIS/AP_AIS.h
@@ -110,6 +110,9 @@ private:
     // decode the payload
     bool payload_decode(const char *payload) WARN_IF_UNUSED;
 
+    // Apply scale to lat lon felids, avoiding integer overflow
+    int32_t scale_lat_lon(const int32_t val) const;
+
     // decode specific message types
     bool decode_position_report(const char *payload, uint8_t type) WARN_IF_UNUSED;
     bool decode_base_station_report(const char *payload) WARN_IF_UNUSED;

--- a/libraries/AP_AIS/AP_AIS.h
+++ b/libraries/AP_AIS/AP_AIS.h
@@ -94,10 +94,16 @@ private:
 
     uint16_t _send_index; // index of the last vessel send over mavlink
 
+    // Send a AIS vessel to the object avoidance data base if its postion is valid
+    void send_to_object_avoidance_database(const struct ais_vehicle_t &vessel);
+
+    // Return true if location is valid
+    bool check_location(int32_t lat, int32_t lng) const;
+
     // removed the given index from the AIVDM buffer shift following elements
     void buffer_shift(uint8_t i);
 
-    // find vessel in existing list, if not then return NEW_NOTHROW index if possible
+    // find vessel index in existing list, if not then return new index if possible, returns true if index is valid
     bool get_vessel_index(uint32_t mmsi, uint16_t &index, uint32_t lat = 0, uint32_t lon = 0) WARN_IF_UNUSED;
     void clear_list_item(uint16_t index);
 

--- a/libraries/AP_HAL_SITL/SITL_State_common.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State_common.cpp
@@ -250,11 +250,17 @@ SITL::SerialDevice *SITL_State_Common::create_serial_sim(const char *name, const
 
 #if HAL_SIM_AIS_ENABLED
     } else if (streq(name, "AIS")) {
-        if (ais != nullptr) {
+        if ((ais != nullptr) || (ais_replay != nullptr)) {
             AP_HAL::panic("Only one AIS at a time");
         }
         ais = NEW_NOTHROW SITL::AIS();
         return ais;
+    } else if (streq(name, "AISReplay")) {
+        if ((ais != nullptr) || (ais_replay != nullptr)) {
+            AP_HAL::panic("Only one AIS at a time");
+        }
+        ais_replay = NEW_NOTHROW SITL::AIS_Replay();
+        return ais_replay;
 #endif
     } else if (strncmp(name, "gps", 3) == 0) {
         uint8_t x = atoi(arg);
@@ -379,7 +385,10 @@ void SITL_State_Common::sim_update(void)
 
 #if HAL_SIM_AIS_ENABLED
     if (ais != nullptr) {
-        ais->update();
+        ais->update(*sitl_model);
+    }
+    if (ais_replay != nullptr) {
+        ais_replay->update();
     }
 #endif
     for (uint8_t i=0; i<ARRAY_SIZE(gps); i++) {

--- a/libraries/AP_HAL_SITL/SITL_State_common.h
+++ b/libraries/AP_HAL_SITL/SITL_State_common.h
@@ -166,6 +166,7 @@ public:
 #if HAL_SIM_AIS_ENABLED
     // simulated AIS stream
     SITL::AIS *ais;
+    SITL::AIS_Replay *ais_replay;
 #endif
 
     // simulated EFI MegaSquirt device:

--- a/libraries/AP_Proximity/AP_Proximity_Backend.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.cpp
@@ -141,7 +141,7 @@ void AP_Proximity_Backend::database_push(float angle, float pitch, float distanc
     //Convert the vector to a NEU frame from NED
     temp_pos.z = temp_pos.z * -1.0f;
 
-    oaDb->queue_push(temp_pos, timestamp_ms, distance);
+    oaDb->queue_push(temp_pos, timestamp_ms, distance, AP_OADatabase::OA_DbItem::Source::proximity);
 #endif  // AP_OADATABASE_ENABLED
 }
 

--- a/libraries/SITL/SIM_AIS.cpp
+++ b/libraries/SITL/SIM_AIS.cpp
@@ -13,8 +13,17 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 /*
+    Simulate virtual vessels
+    ./Tools/autotest/sim_vehicle.py -v Rover -A --serial5=sim:AIS --map
+
+    param set SERIAL5_PROTOCOL 40
+    param set AIS_TYPE 1
+    param set SIM_AIS_COUNT 10
+    reboot
+    module load ais
+
     Dump logged AIS data to the serial port
-    ./Tools/autotest/sim_vehicle.py -v Rover -A --serial5=sim:AIS --custom-location 51.58689798356386,-3.9044570193067965,0,0 --map
+    ./Tools/autotest/sim_vehicle.py -v Rover -A --serial5=sim:AISReplay --custom-location 51.58689798356386,-3.9044570193067965,0,0 --map
 
     param set SERIAL5_PROTOCOL 40
     param set AIS_TYPE 1
@@ -31,12 +40,15 @@
 #define FORCE_VERSION_H_INCLUDE
 #include "ap_version.h"
 
+#include "SIM_Aircraft.h"
+#include <AP_Common/NMEA.h>
+
 extern const AP_HAL::HAL& hal;
 
 using namespace SITL;
 
 
-AIS::AIS() : SerialDevice::SerialDevice()
+AIS_Replay::AIS_Replay() : SerialDevice::SerialDevice()
 {
     char* file_path;
     IGNORE_RETURN(asprintf(&file_path, AP_BUILD_ROOT "/libraries/SITL/SIM_AIS_data.txt"));
@@ -52,7 +64,7 @@ AIS::AIS() : SerialDevice::SerialDevice()
     IGNORE_RETURN(fgets(line, sizeof(line), file));
 }
 
-void AIS::update()
+void AIS_Replay::update()
 {
     if (file == nullptr) {
         AP_HAL::panic("AIS lost data file");
@@ -79,6 +91,454 @@ void AIS::update()
     //hal.console->printf("%s",line);
     write_to_autopilot(line, strlen(line));
 
+}
+
+void AIS::update(const class Aircraft &aircraft)
+{
+    const SIM *sitl = AP::sitl();
+    if (sitl == nullptr) {
+        return;
+    }
+    const int8_t count = sitl->ais_vessel_count.get();
+    const float radius = sitl->ais_radius_m.get();
+
+    // Disabled
+    if (count <= 0) {
+        return;
+    }
+
+    // Calculate the time step to take
+    const uint32_t now_ms = AP_HAL::millis();
+    const float dt = (now_ms - last_sim_update_ms) * 0.001;
+    last_sim_update_ms = now_ms;
+
+    // Get current location to remove any vessel that is too far away
+    const Location &aircraft_loc = aircraft.get_location();
+
+    // Update all vessels, marking any that move too far from the aircraft as in-active
+    for (uint8_t i=0; i<ARRAY_SIZE(vessels); i++) {
+        update_simulated_vessel(vessels[i], dt, aircraft_loc, radius, now_ms);
+    }
+
+    // Add new vessels until we have the correct number
+    for (uint8_t i=0; i<ARRAY_SIZE(vessels); i++) {
+        // Disable any extra vessels over the set count
+        if (i >= count) {
+            vessels[i].active = false;
+            continue;
+        }
+
+        // Vessel is already active
+        if (vessels[i].active) {
+            continue;
+        }
+
+        // Generate new vessel
+        init_vessel(vessels[i], aircraft_loc, radius);
+    }
+
+}
+
+// Update a active vessel position and heading
+void AIS::update_simulated_vessel(ais_vessel &vessel, const float dt, const Location &vehicle_loc, const float radius, const uint32_t now_ms)
+{
+    // Check if this vessel is active
+    if (!vessel.active) {
+        return;
+    }
+
+    // Update heading from turn rate, both turn rate and heading are in cdeg
+    vessel.info.heading += vessel.info.turn_rate * dt;
+
+    // Extract location
+    Location loc { vessel.info.lat, vessel.info.lon, 0, Location::AltFrame::ABOVE_ORIGIN };
+
+    // Update location from heading and velocity
+    loc.offset_bearing(vessel.info.heading * 0.01, vessel.info.velocity * 0.01 * dt);
+
+    // Repopulate location
+    vessel.info.lat = loc.lat;
+    vessel.info.lon = loc.lng;
+
+    // Check if location is still valid
+    if (vehicle_loc.get_distance(loc) > radius) {
+        vessel.active = false;
+        return;
+    }
+
+    // Report, update rate depends on speed
+    uint32_t postion_interval;
+
+    // Convert speed over ground from 0.1 knots to cm/s
+    if (vessel.info.velocity > 23.0 * 0.1 * KNOTS_TO_M_PER_SEC * 100.0) {
+        postion_interval = 2000; // every 2 seconds if faster than 23 knots
+
+    } else if (vessel.info.velocity > 14.0 * 0.1 * KNOTS_TO_M_PER_SEC * 100.0) {
+        postion_interval = 6000; // every 6 seconds if faster than 14 knots
+
+    } else if (vessel.info.velocity > 0.0) {
+        postion_interval = 10000; // every 10 seconds if moving
+
+    } else {
+        postion_interval = 3 * 60 * 1000; // every 3 mins if anchored or moored and moving at less than 3 knots
+
+    }
+
+    // Send position report at internal
+    if ((vessel.last_position_report_ms == 0) || (now_ms - vessel.last_position_report_ms > postion_interval)) {
+        send_position_report(vessel.info);
+        vessel.last_position_report_ms = now_ms;
+    }
+
+    // Send static and voyage at internal
+    const uint32_t static_and_voyage_interval = 6 * 60 * 1000; // every 6 mins
+    if ((vessel.last_static_and_voyage_ms == 0) || (now_ms - vessel.last_static_and_voyage_ms > static_and_voyage_interval)) {
+        send_static_and_voyage(vessel.info);
+        vessel.last_static_and_voyage_ms = now_ms;
+    }
+
+}
+
+// Generate a new vessel
+void AIS::init_vessel(ais_vessel &vessel, const Location &vehicle_loc, const float radius)
+{
+    // Clear any existing data
+    memset(&vessel, 0, sizeof(vessel));
+
+    // Set flags for valid data
+    vessel.info.flags |= AIS_FLAGS_VALID_VELOCITY | AIS_FLAGS_VALID_TURN_RATE;
+
+    // Generate random data for static info, mask to 30 bit
+    vessel.info.MMSI = rand() & 0x3FFFFFFF;
+
+    // Set nav status and type
+    vessel.info.navigational_status = UNDER_WAY;
+    vessel.info.type = AIS_TYPE_CARGO;
+
+    // 90% chance of having valid dimensions
+    if (rand() > RAND_MAX * 0.1) {
+        vessel.info.flags |= AIS_FLAGS_VALID_DIMENSIONS;
+
+        // Generate each dimension
+        vessel.info.dimension_bow = abs(Aircraft::rand_normal(0, 300.0));
+        if (vessel.info.dimension_bow > 511) {
+            vessel.info.dimension_bow = 511;
+            vessel.info.flags |= AIS_FLAGS_LARGE_BOW_DIMENSION;
+        }
+
+        vessel.info.dimension_stern = abs(Aircraft::rand_normal(0, 300.0));
+        if (vessel.info.dimension_stern > 511) {
+            vessel.info.dimension_stern = 511;
+            vessel.info.flags |= AIS_FLAGS_LARGE_STERN_DIMENSION;
+        }
+
+        vessel.info.dimension_port = abs(Aircraft::rand_normal(0, 30.0));
+        if (vessel.info.dimension_port > 63) {
+            vessel.info.dimension_port = 63;
+            vessel.info.flags |= AIS_FLAGS_LARGE_PORT_DIMENSION;
+        }
+
+        vessel.info.dimension_starboard = abs(Aircraft::rand_normal(0, 30.0));
+        if (vessel.info.dimension_starboard > 63) {
+            vessel.info.dimension_starboard = 63;
+            vessel.info.flags |= AIS_FLAGS_LARGE_STARBOARD_DIMENSION;
+        }
+    }
+
+    // 25% chance of turning
+    if (rand() > RAND_MAX * 0.75) {
+        vessel.info.turn_rate = Aircraft::rand_normal(0, 100.0);
+    }
+
+    // 95% chance of moving
+    if (rand() > RAND_MAX * 0.05) {
+        vessel.info.velocity = abs(Aircraft::rand_normal(0, 500.0));
+
+        // Speed threshold for high velocity flag
+        // Convert speed over ground from 0.1 knots to cm/s
+        const uint16_t high_velocity = 1022 * 0.1 * KNOTS_TO_M_PER_SEC * 100.0;
+
+        if (vessel.info.velocity >= high_velocity) {
+            vessel.info.velocity = high_velocity;
+            vessel.info.flags |= AIS_FLAGS_HIGH_VELOCITY;
+        }
+    }
+
+    // Generate a heading
+    vessel.info.heading = wrap_360_cd(rand());
+
+    // Generate a random location
+    Location loc = vehicle_loc;
+    loc.offset( Vector3p {
+        Aircraft::rand_normal(0, radius),
+        Aircraft::rand_normal(0, radius),
+        0
+    });
+    vessel.info.lat = loc.lat;
+    vessel.info.lon = loc.lng;
+
+    // mark active
+    vessel.active = true;
+}
+
+/*
+  formatted print of NMEA message, with checksum appended
+ */
+void AIS::nmea_printf(const char *fmt, ...)
+{
+    va_list ap;
+
+    va_start(ap, fmt);
+    char *s = nmea_vaprintf(fmt, ap);
+    va_end(ap);
+    if (s != nullptr) {
+        write_to_autopilot((const char*)s, strlen(s));
+        free(s);
+    }
+}
+
+
+// Convert to NMEA char
+uint8_t AIS::encode_char(uint8_t payload) const
+{
+    if (payload + 8 > 40) {
+        return payload + 8 + 48;
+    }
+    return payload + 48;
+}
+
+uint8_t AIS::get_bits(uint32_t value, const uint8_t start, const uint8_t len) const
+{
+    value = value >> start;
+    const uint8_t mask = 0b111111 >> (6 - len);
+    return value & mask;
+}
+
+// set the specified bits in the payload with 6 bit chars
+void AIS::set_bits(uint8_t *payload, const uint16_t low, const uint16_t high, uint32_t value)
+{
+    // Bits are inclusive, so add one
+    const uint8_t bit_len = high - low + 1;
+    const uint32_t value_mask = 0xFFFFFFFF >> (32 - bit_len);
+
+    if ((value & ~value_mask) != 0) {
+        AP_HAL::panic("AIS value passed too big to fit (%u > %u bits)", value, bit_len);
+    }
+
+    const uint8_t char_low = low / 6;
+    const uint8_t bit_low = low % 6;
+
+    const uint8_t char_high = high / 6;
+    const uint8_t bit_high = (high % 6) + 1;
+
+    const uint8_t char_range = char_high - char_low;
+    uint8_t bits = bit_len;
+    for (uint8_t index = 0; index <= char_range; index++) {
+        if (bits == 0) {
+            AP_HAL::panic("AIS packing fail A");
+        }
+        if (index == char_range) {
+            // last char uses high bit
+            const uint8_t bits_needed = MIN(bit_high, bit_len);
+            bits -= bits_needed;
+            payload[char_low + index] |= get_bits(value, bits, bits_needed) << (6 - bit_high);
+
+        } else if (index == 0) {
+            // First char uses low bit
+            const uint8_t bits_needed = MIN(6 - bit_low, bit_len);
+            bits -= bits_needed;
+            payload[char_low + index] |= get_bits(value, bits, bits_needed);
+
+        } else {
+            // Others need full length
+            bits -= 6;
+            payload[char_low + index] |= get_bits(value, bits, 6);
+
+        }
+    }
+
+    if (bits != 0) {
+        AP_HAL::panic("AIS packing fail B");
+    }
+
+}
+
+void AIS::set_bits_signed(uint8_t *payload, const uint16_t low, const uint16_t high, int32_t value)
+{
+    if (value >= 0) {
+        // Positive number is the same as unsigned
+        set_bits(payload, low, high, value);
+        return;
+    }
+
+    // Convert to unsigned
+    uint32_t val = value;
+
+    // Mask to correct length
+    const uint8_t bit_len = high - low + 1;
+    val &= 0xFFFFFFFF >> (32 - bit_len);
+
+    // Set sign bit
+    val |= 1 << (bit_len - 1);
+
+    set_bits(payload, low, high, val);
+}
+
+void AIS::send_position_report(const mavlink_ais_vessel_t &info) {
+
+    // Turn rate, default to not available
+    int8_t rot = -128;
+    if ((info.flags & AIS_FLAGS_VALID_TURN_RATE) != 0) {
+        if ((info.flags & AIS_FLAGS_TURN_RATE_SIGN_ONLY) != 0) {
+            // Only sign available
+            rot = info.turn_rate >= 0 ? 127 : -127;
+
+        } else {
+            // cdeg/s to deg/min, take abs to allow sqrt
+            const float turn_rate_deg_per_min = fabsf(info.turn_rate) * 60.0 * 0.01;
+
+            // Apply scaling, recovering sign
+            rot = 4.733 * sqrtf(turn_rate_deg_per_min) * info.turn_rate >= 0 ? 1.0 : -1.0;
+        }
+    }
+
+    // Corse over ground, default to not available
+    uint16_t cog = 3600;
+    if ((info.flags & AIS_FLAGS_VALID_COG) != 0) {
+        // cdeg to 0.1 deg
+        cog = info.COG * 0.1;
+    }
+
+    // Accuracy bit from flag
+    const bool accuracy = (info.flags & AIS_FLAGS_POSITION_ACCURACY) != 0;
+
+    // Speed over ground, default to not available
+    uint16_t sog = 1023;
+    if ((info.flags & AIS_FLAGS_VALID_VELOCITY) != 0) {
+        if ((info.flags & AIS_FLAGS_HIGH_VELOCITY) != 0) {
+            sog = 1022;
+        } else {
+            sog = MIN((float(info.velocity) * 0.01 * M_PER_SEC_TO_KNOTS * 10), 1022);
+        }
+    }
+
+    // storage for payload
+    uint8_t payload[28] {};
+    set_bits(payload, 0,  5,  1); // type: Position Report Class A
+    set_bits(payload, 6,  7,  3); // repeat: Do not repeat
+    set_bits(payload, 8,  37, info.MMSI); // mmsi
+    set_bits(payload, 38, 41, info.navigational_status); // status
+    set_bits_signed(payload, 42, 49, rot); // rate of turn
+    set_bits(payload, 50, 59, sog); // speed
+    set_bits(payload, 60, 60, accuracy); // accuracy
+    set_bits_signed(payload, 61, 88, int32_t(double(info.lon) * 0.06)); // lon
+    set_bits_signed(payload, 89, 115, int32_t(double(info.lat) * 0.06)); // lat
+    set_bits(payload, 116, 127, cog); // course over ground
+    set_bits(payload, 128, 136, uint32_t(info.heading * 0.01)); // heading convert from deg to centi-deg
+    set_bits(payload, 137, 142, 60); // second: not available
+    set_bits(payload, 143, 144, 0); // maneuver: not available
+    // 145 - 147: spare
+    set_bits(payload, 148, 148, 0); // raim not used
+    set_bits(payload, 149, 167, 0); // Radio status
+
+    // Convert to chars
+    uint8_t encoded[sizeof(payload) + 1] {};
+    for (uint8_t i = 0; i < sizeof(payload); i++) {
+        encoded[i] = encode_char(payload[i]);
+    }
+
+    const uint8_t total_fragments = 1;
+    const uint8_t fragment = 1;
+    // sequence ID is not used for a single fragment message
+    const char channel_code = 'A';
+    const uint8_t fill_bits = 0;
+
+    // Send
+    nmea_printf("!AIVDM,%u,%u,,%c,%s,%u", total_fragments, fragment, channel_code, encoded, fill_bits);
+
+}
+
+void AIS::send_static_and_voyage(const mavlink_ais_vessel_t &info) {
+
+    // Fill in dimensions if valid
+    uint16_t bow_dim = 0;
+    uint16_t stern_dim = 0;
+    uint8_t port_dim = 0;
+    uint8_t star_dim = 0;
+
+    if ((info.flags & AIS_FLAGS_VALID_DIMENSIONS) != 0) {
+        if ((info.flags & AIS_FLAGS_LARGE_BOW_DIMENSION) != 0) {
+            bow_dim = 511;
+        } else {
+            bow_dim = MIN(info.dimension_bow, 511);
+        }
+        if ((info.flags & AIS_FLAGS_LARGE_STERN_DIMENSION) != 0) {
+            stern_dim = 511;
+        } else {
+            stern_dim = MIN(info.dimension_stern, 511);
+        }
+        if ((info.flags & AIS_FLAGS_LARGE_PORT_DIMENSION) != 0) {
+            port_dim = 63;
+        } else {
+            port_dim = MIN(info.dimension_port, 63);
+        }
+        if ((info.flags & AIS_FLAGS_LARGE_STARBOARD_DIMENSION) != 0) {
+            star_dim = 63;
+        } else {
+            star_dim = MIN(info.dimension_starboard, 63);
+        }
+    }
+
+    // storage for payload
+    uint8_t payload[71] {};
+    set_bits(payload, 0,  5,  5); // type: Static and Voyage Related Data
+    set_bits(payload, 6,  7,  3); // repeat: Do not repeat
+    set_bits(payload, 8,  37, info.MMSI); // mmsi
+    set_bits(payload, 38, 39, 1); // AIS version
+    set_bits(payload, 40, 69, 0); // imo number
+    set_bits(payload, 70, 111, '@'); // call_sign: empty
+    set_bits(payload, 112, 231, '@'); // name: empty
+    set_bits(payload, 232, 239, info.type);
+    set_bits(payload, 240, 248, bow_dim); // bow_dim
+    set_bits(payload, 249, 257, stern_dim); // stern_dim
+    set_bits(payload, 258, 263, port_dim); // port_dim
+    set_bits(payload, 264, 269, star_dim); // star_dim
+    set_bits(payload, 270, 273, 1); // fix: GPS
+    set_bits(payload, 274, 277, 0); // ETA month: not available
+    set_bits(payload, 278, 282, 0); // ETA day: not available
+    set_bits(payload, 283, 287, 0); // ETA hour: not available
+    set_bits(payload, 288, 293, 0); // ETA minute: not available
+    set_bits(payload, 294, 301, 0); // draught: 0 decimeters
+    set_bits(payload, 302, 421, '@'); // destination: empty
+    set_bits(payload, 422, 422, 1); // dte: Data terminal not ready
+    // 423: not used
+
+    // Split and encode
+    const uint8_t msg1_len = 50;
+    const uint8_t msg2_len = sizeof(payload) - msg1_len;
+
+    uint8_t msg1_encoded[msg1_len + 1] {};
+    for (uint8_t i = 0; i < msg1_len; i++) {
+        msg1_encoded[i] = encode_char(payload[i]);
+    }
+
+    uint8_t msg2_encoded[msg2_len + 1] {};
+    for (uint8_t i = 0; i < msg2_len; i++) {
+        msg2_encoded[i] = encode_char(payload[msg1_len + i]);
+    }
+
+    const uint8_t total_fragments = 2;
+    uint8_t fragment = 1;
+    const char channel_code = 'A';
+    const uint8_t fill_bits = 0;
+
+    // Send
+    nmea_printf("!AIVDM,%u,%u,%u,%c,%s,%u", total_fragments, fragment, sequence_ID, channel_code, msg1_encoded, fill_bits);
+    fragment++;
+
+    nmea_printf("!AIVDM,%u,%u,%u,%c,%s,%u", total_fragments, fragment, sequence_ID, channel_code, msg2_encoded, fill_bits);
+
+    sequence_ID++;
 }
 
 #endif  // HAL_SIM_AIS_ENABLED

--- a/libraries/SITL/SIM_AIS.h
+++ b/libraries/SITL/SIM_AIS.h
@@ -55,10 +55,16 @@ private:
 // Generate virtual vessels
 class AIS : public SerialDevice {
 public:
-    AIS() {};
+    AIS();
+
     void update(const class Aircraft &aircraft);
 
+    static const struct AP_Param::GroupInfo var_info[];
+
 private:
+
+    AP_Int8 vessel_count;
+    AP_Float radius_m;
 
     struct ais_vessel {
         mavlink_ais_vessel_t info; // Info about the vessel

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -1258,17 +1258,6 @@ const AP_Param::GroupInfo SIM::var_ins[] = {
     // @Description: If non-zero the vehicle will be clamped in position until the value on this servo channel passes 1800PWM
     AP_GROUPINFO("CLAMP_CH",     49, SIM, clamp_ch, 0),
 
-    // @Param: AIS_COUNT
-    // @DisplayName: Number of AIS vessels
-    // @Description: Total number of AIS simulated vessels
-    AP_GROUPINFO("AIS_COUNT", 50, SIM,  ais_vessel_count, -1),
-
-    // @Param: AIS_RADIUS
-    // @DisplayName: AIS radius stddev of vessels
-    // @Description: Simulated standard deviation of radius in AIS of a vessel
-    // @Units: m
-    AP_GROUPINFO("AIS_RADIUS", 51, SIM,  ais_radius_m, 10000),
-
     // the IMUT parameters must be last due to the enable parameters
 #if HAL_INS_TEMPERATURE_CAL_ENABLE
     AP_SUBGROUPINFO(imu_tcal[0], "IMUT1_", 61, SIM, AP_InertialSensor_TCal),
@@ -1326,9 +1315,15 @@ const AP_Param::GroupInfo SIM::ModelParm::var_info[] = {
     AP_SUBGROUPINFO(tether_sim, "TETH_", 6, SIM::ModelParm, TetherSim),
 #endif
 
+#if HAL_SIM_AIS_ENABLED
+    // @Group: AIS_
+    // @Path: ./SIM_AIS.cpp
+    AP_SUBGROUPPTR(ais_ptr, "AIS_", 7, SIM::ModelParm, AIS),
+#endif
+
     AP_GROUPEND
 };
-    
+
 const Location post_origin {
     518752066,
     146487830,

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -1258,6 +1258,17 @@ const AP_Param::GroupInfo SIM::var_ins[] = {
     // @Description: If non-zero the vehicle will be clamped in position until the value on this servo channel passes 1800PWM
     AP_GROUPINFO("CLAMP_CH",     49, SIM, clamp_ch, 0),
 
+    // @Param: AIS_COUNT
+    // @DisplayName: Number of AIS vessels
+    // @Description: Total number of AIS simulated vessels
+    AP_GROUPINFO("AIS_COUNT", 50, SIM,  ais_vessel_count, -1),
+
+    // @Param: AIS_RADIUS
+    // @DisplayName: AIS radius stddev of vessels
+    // @Description: Simulated standard deviation of radius in AIS of a vessel
+    // @Units: m
+    AP_GROUPINFO("AIS_RADIUS", 51, SIM,  ais_radius_m, 10000),
+
     // the IMUT parameters must be last due to the enable parameters
 #if HAL_INS_TEMPERATURE_CAL_ENABLE
     AP_SUBGROUPINFO(imu_tcal[0], "IMUT1_", 61, SIM, AP_InertialSensor_TCal),

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -33,6 +33,7 @@
 #include "SIM_DroneCANDevice.h"
 #include "SIM_ADSB_Sagetech_MXS.h"
 #include "SIM_Volz.h"
+#include "SIM_AIS.h"
 
 namespace SITL {
 
@@ -368,6 +369,9 @@ public:
 #if AP_SIM_FLIGHTAXIS_ENABLED
         FlightAxis *flightaxis_ptr;
 #endif
+#if HAL_SIM_AIS_ENABLED
+        class AIS *ais_ptr;
+#endif
     };
     ModelParm models;
     
@@ -598,10 +602,6 @@ public:
 
     // clamp simulation - servo channel starting at offset 1 (usually ailerons)
     AP_Int8 clamp_ch;
-
-    // AIS vessel simulation
-    AP_Int8 ais_vessel_count;
-    AP_Float ais_radius_m;
 
 #if AP_SIM_INS_FILE_ENABLED
     enum INSFileMode {

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -599,6 +599,10 @@ public:
     // clamp simulation - servo channel starting at offset 1 (usually ailerons)
     AP_Int8 clamp_ch;
 
+    // AIS vessel simulation
+    AP_Int8 ais_vessel_count;
+    AP_Float ais_radius_m;
+
 #if AP_SIM_INS_FILE_ENABLED
     enum INSFileMode {
         INS_FILE_NONE = 0,


### PR DESCRIPTION
This adds support for AIS vessels as a source for avoidance data. This allows a vehicle to navigate around them. It also does some minor fix-ups to both AIS and the OADatabase.

![image](https://github.com/user-attachments/assets/ea06439e-46a7-4e62-ad0b-82c5dc5e1403)

Features: 

- This converts the timeout parameter from a int8 to a int16, this allows longer timeouts. AIS messages can be quite low update-rates, anchored vessels are only required to update every 3 mins. So the timeout must be longer than 180 seconds, 127 was the maximum with the int8. A timeout of 10 minutes (600 seconds) might be a good value for AIS avoidance.
- The item refresh code now updates position, the current behavior is to just change the timeout, but not the position. This means the avoidance item will not update position until it is has changed by one radius, which here could be >100m.
- It is now possible for the data source to provide a radius for the item. In the case of AIS we can get the vessel dimensions so can provide the exact size.
- The max distance threshold now applies to the closest point not the center of the item, this means we don't ignore items with large radius.

Some shortcomings: 

- AIS is only supported in "path planning" avoidance. It is not included in simple avoidance. The other avoidance methods, proximity sensor and fences, are supported by both simple and "path planning" avoidance. We could add AIS to simple avoidance in the future.
- There is no way to ignore AIS from "path planning" but still use proximity. We could fix this by adding a sources bitmask to the OADatabase.
- The defaults don't work that well, everything is on a much larger scale. For example I set `OA_BR_LOOKAHEAD` to 500 (the default is 15) `OA_DB_RADIUS_MIN` to 10 (default of 0.01). This means would probably make it hard to find a set of params that would work well for AIS avoidance at sea and proximity avoidance in a harbor. 
- I'm not sure how well the avoidance would get on with large fast moving obstacles, we could plausibly have a 3m boat traveling at 3 knots trying to avoid a 300m vessel traveling at 30 knots. Such vessels won't change direction quickly, so some sort of look ahead or velocity projection could be used.  
