### PR TITLE
GCS_MAVLink: send dropped message count in SYS_STATUS.errors_count3

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -5901,6 +5901,12 @@ void GCS_MAVLINK::send_sys_status()
     const uint16_t errors2 = (errors>>16) & 0xffff;
     const uint16_t errors4 = AP::internalerror().count() & 0xffff;
 
+#if HAL_LOGGING_ENABLED
+    const uint16_t dropped_logmessage_count = AP::logger().num_dropped();
+#else
+    const uint16_t dropped_logmessage_count = -1;
+#endif  // HAL_LOGGING_ENABLED
+
     mavlink_msg_sys_status_send(
         chan,
         control_sensors_present,
@@ -5924,7 +5930,7 @@ void GCS_MAVLINK::send_sys_status()
         0,  // comm drops in pkts,
         errors1,
         errors2,
-        0,  // errors3
+        dropped_logmessage_count,  // errors3
         errors4); // errors4
 }
 


### PR DESCRIPTION
for first backend instance

Useful for knowing if you are going to hav a good replay log / get all of the raw IMU data you want etc.

Tested using the following patch:
```
--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -454,6 +454,11 @@ bool AP_Logger_File::_WritePrioritisedBlock(const void *pBuffer, uint16_t size,
 
     uint32_t space = _writebuf.space();
 
+    if (rand() /float(RAND_MAX) < 0.01) {
+        _dropped++;
+        return false;
+    }
+
     if (_writing_startup_messages &&
         _startup_messagewriter->fmt_done()) {
         // the state machine has called us, and it has finished
```

![image](https://github.com/user-attachments/assets/1688820a-6d01-4abc-9d08-6cf6a0aaf52d)

