### PR TITLE
Copter: add FS_EKF_ACTION report only and notify in all cases

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -364,7 +364,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: FS_EKF_ACTION
     // @DisplayName: EKF Failsafe Action
     // @Description: Controls the action that will be taken when an EKF failsafe is invoked
-    // @Values: 1:Land, 2:AltHold, 3:Land even in Stabilize
+    // @Values: 0:Report only, 1:Switch to Land mode if current mode requires postion, 2:Switch to AltHold mode if current mode requires postion, 3:Switch to Land mode from all modes
     // @User: Advanced
     GSCALAR(fs_ekf_action, "FS_EKF_ACTION",    FS_EKF_ACTION_DEFAULT),
 

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -136,6 +136,7 @@ enum LoggingParameters {
 #define FS_GCS_ENABLED_BRAKE_OR_LAND           7
 
 // EKF failsafe definitions (FS_EKF_ACTION parameter)
+#define FS_EKF_ACTION_REPORT_ONLY           0
 #define FS_EKF_ACTION_LAND                  1       // switch to LAND mode on EKF failsafe
 #define FS_EKF_ACTION_ALTHOLD               2       // switch to ALTHOLD mode on EKF failsafe
 #define FS_EKF_ACTION_LAND_EVEN_STABILIZE   3       // switch to Land mode on EKF failsafe even if in a manual flight mode like stabilize

--- a/ArduCopter/mode_turtle.cpp
+++ b/ArduCopter/mode_turtle.cpp
@@ -48,7 +48,7 @@ void ModeTurtle::arm_motors()
     // disable throttle and gps failsafe
     g.failsafe_throttle.set(FS_THR_DISABLED);
     g.failsafe_gcs.set(FS_GCS_DISABLED);
-    g.fs_ekf_action.set(0);
+    g.fs_ekf_action.set(FS_EKF_ACTION_REPORT_ONLY);
 
     // arm
     motors->armed(true);

--- a/ArduCopter/motor_test.cpp
+++ b/ArduCopter/motor_test.cpp
@@ -178,7 +178,7 @@ MAV_RESULT Copter::mavlink_motor_test_start(const GCS_MAVLINK &gcs_chan, uint8_t
             // disable throttle and gps failsafe
             g.failsafe_throttle.set(FS_THR_DISABLED);
             g.failsafe_gcs.set(FS_GCS_DISABLED);
-            g.fs_ekf_action.set(0);
+            g.fs_ekf_action.set(FS_EKF_ACTION_REPORT_ONLY);
 
             // turn on notify leds
             AP_Notify::flags.esc_calibration = true;


### PR DESCRIPTION
This changes to always trigger the notify library and send a message in EKF fail-safes if armed, this should make it clear to the user that there is a issue. For example if flying in stabilize currently it would not be clear to the pilot that the vehicle is in a EKF failsafe, they would just find they can't switch to position control for some reason.

One disadvantage of this is that EKF failsafes will get more annoying which might lead to complaints.

It also adds a report only option for that will only trigger the notify state and a send text. In such a case the the pilot can decide what the best course of action is. The default value of the parameter is Land from position control modes.