### PR TITLE
copter: auto: provide alt above landing location if landing

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -173,7 +173,7 @@ public:
     virtual bool set_speed_up(float speed_xy_cms) {return false;}
     virtual bool set_speed_down(float speed_xy_cms) {return false;}
 
-    int32_t get_alt_above_ground_cm(void);
+    virtual int32_t get_alt_above_ground_cm(void);
 
     // pilot input processing
     void get_pilot_desired_lean_angles(float &roll_out_cd, float &pitch_out_cd, float angle_max_cd, float angle_limit_cd) const;
@@ -606,6 +606,9 @@ public:
 #if WEATHERVANE_ENABLED
     bool allows_weathervaning(void) const override;
 #endif
+
+    // Get height above ground, uses landing height if available
+    int32_t get_alt_above_ground_cm() override;
 
 protected:
 


### PR DESCRIPTION
This allows using the height above a landing waypoint if it is available. This is used only on land commands in auto. Rangefinder takes priority if available. 

This altitude is used for the transition to slow landing, landing gear deploy, min nav altitude.

This is a change in behavior with no rangefinder. Copter will currently use the height above terrain if available, if not the height above home.

The disadvantage is that currently the land altitude is never used, its quite easy when using mission planner to endup with the landing at the same altitude as the mission because of the default altitude functionality. 

The advantage is that you can set the landing altitude in whatever alt frame you like. This is especially important if landing away from home.

Quadplane already does this, however terrain takes priority. Maybe allowing terrain to take priority here too would mean its less likely to catch people out. However, that does mean we loose the ability to land at a altitude relative to terrain, for example on a building.


