### PR TITLE
GCS_MAVLink: Set the invalid value of UINT16 to the maximum value of the unsigned type

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -5904,7 +5904,7 @@ void GCS_MAVLINK::send_sys_status()
 #if HAL_LOGGING_ENABLED
     const uint16_t dropped_logmessage_count = AP::logger().num_dropped();
 #else
-    const uint16_t dropped_logmessage_count = -1;
+    const uint16_t dropped_logmessage_count = UINT16_MAX;
 #endif  // HAL_LOGGING_ENABLED
 
     mavlink_msg_sys_status_send(


### PR DESCRIPTION
The invalid value for UINT16_T is 65535.
-1 is a value that ignores the type.

SYS_STATUS
https://mavlink.io/en/messages/common.html#SYS_STATUS