### PR TITLE
Tracker: separate desired angle from target angle

### DIFF
--- a/AntennaTracker/GCS_MAVLink_Tracker.cpp
+++ b/AntennaTracker/GCS_MAVLink_Tracker.cpp
@@ -72,7 +72,7 @@ void GCS_MAVLINK_Tracker::send_nav_controller_output() const
         0,
         tracker.nav_status.pitch,
         tracker.nav_status.bearing,
-        tracker.nav_status.bearing,
+        tracker.nav_status.bearing_to_target,
         MIN(tracker.nav_status.distance, UINT16_MAX),
         alt_diff,
         0,

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -118,9 +118,11 @@ private:
 
     // Navigation controller state
     struct NavStatus {
-        float bearing;                  // bearing to vehicle in centi-degrees
+        float bearing;                  // desired bearing in degrees
+        float bearing_to_target;        // bearing to vehicle in degrees
         float distance;                 // distance to vehicle in meters
-        float pitch;                    // pitch to vehicle in degrees (positive means vehicle is above tracker, negative means below)
+        float pitch;                    // desired pitch in degrees (positive means vehicle is above tracker, negative means below)
+        float pitch_to_target;          // pitch to vehicle in degrees (positive means vehicle is above tracker, negative means below)
         float angle_error_pitch;        // angle error between target and current pitch in centi-degrees
         float angle_error_yaw;          // angle error between target and current yaw in centi-degrees
         float alt_difference_baro;      // altitude difference between tracker and vehicle in meters according to the barometer.  positive value means vehicle is above tracker

--- a/AntennaTracker/mode.cpp
+++ b/AntennaTracker/mode.cpp
@@ -20,8 +20,11 @@ void Mode::update_auto(void)
     convert_ef_to_bf(pitch, yaw, bf_pitch, bf_yaw);
 
     // only move servos if target is at least distance_min away if we  have a target
-    if ((g.distance_min <= 0) || (nav_status.distance >= g.distance_min) || !tracker.vehicle.location_valid) {
+    const bool should_move = (g.distance_min <= 0) || (nav_status.distance >= g.distance_min) || !tracker.vehicle.location_valid;
+    if (should_move || tracker.nav_status.manual_control_pitch) {
         tracker.update_pitch_servo(bf_pitch);
+    }
+    if (should_move || tracker.nav_status.manual_control_yaw) {
         tracker.update_yaw_servo(bf_yaw);
     }
 }

--- a/AntennaTracker/mode_auto.cpp
+++ b/AntennaTracker/mode_auto.cpp
@@ -5,6 +5,12 @@
 void ModeAuto::update()
 {
     if (tracker.vehicle.location_valid) {
+        if (!tracker.nav_status.manual_control_yaw) {
+            tracker.nav_status.bearing = tracker.nav_status.bearing_to_target;
+        }
+        if (!tracker.nav_status.manual_control_pitch) {
+            tracker.nav_status.pitch = tracker.nav_status.pitch_to_target;
+        }
         update_auto();
     } else if (tracker.target_set || (tracker.g.auto_opts.get() & (1 << 0)) != 0) {
         update_scan();

--- a/AntennaTracker/mode_guided.cpp
+++ b/AntennaTracker/mode_guided.cpp
@@ -5,15 +5,20 @@
 
 void ModeGuided::update()
 {
+    struct Tracker::NavStatus &nav_status = tracker.nav_status;
+
     static uint32_t last_debug;
     const uint32_t now = AP_HAL::millis();
     float target_roll, target_pitch, target_yaw;
     _target_att.to_euler(target_roll, target_pitch, target_yaw);
+    nav_status.bearing = degrees(target_yaw);
+    nav_status.pitch = degrees(target_pitch);
+    // TODO: we probably don't need this STATUS_TEXT anymore
     if (now - last_debug > 5000) {
         last_debug = now;
-        gcs().send_text(MAV_SEVERITY_INFO, "target_yaw=%f target_pitch=%f", degrees(target_yaw), degrees(target_pitch));
+        gcs().send_text(MAV_SEVERITY_INFO, "target_yaw=%f target_pitch=%f", nav_status.bearing, nav_status.pitch);
     }
-    calc_angle_error(degrees(target_pitch)*100, degrees(target_yaw)*100, false);
+    calc_angle_error(nav_status.pitch*100, nav_status.bearing*100, false);
     float bf_pitch;
     float bf_yaw;
     convert_ef_to_bf(target_pitch, target_yaw, bf_pitch, bf_yaw);

--- a/AntennaTracker/tracking.cpp
+++ b/AntennaTracker/tracking.cpp
@@ -52,11 +52,7 @@ void Tracker::update_bearing_and_distance()
     }
 
     // calculate bearing to vehicle
-    // To-Do: remove need for check of control_mode
-    if (mode != &mode_scan && !nav_status.manual_control_yaw) {
-        nav_status.bearing  = current_loc.get_bearing_to(vehicle.location_estimate) * 0.01f;
-    }
-
+    nav_status.bearing_to_target  = current_loc.get_bearing_to(vehicle.location_estimate) * 0.01f;
     // calculate distance to vehicle
     nav_status.distance = current_loc.get_distance(vehicle.location_estimate);
 
@@ -69,13 +65,10 @@ void Tracker::update_bearing_and_distance()
     }
 
     // calculate pitch to vehicle
-    // To-Do: remove need for check of control_mode
-    if (mode->number() != Mode::Number::SCAN && !nav_status.manual_control_pitch) {
-    	if (g.alt_source == ALT_SOURCE_BARO) {
-    	    nav_status.pitch = degrees(atan2f(nav_status.alt_difference_baro, nav_status.distance));
-    	} else {
-            nav_status.pitch = degrees(atan2f(nav_status.alt_difference_gps, nav_status.distance));
-    	}
+    if (g.alt_source == ALT_SOURCE_BARO) {
+        nav_status.pitch_to_target = degrees(atan2f(nav_status.alt_difference_baro, nav_status.distance));
+    } else {
+        nav_status.pitch_to_target = degrees(atan2f(nav_status.alt_difference_gps, nav_status.distance));
     }
 }
 
@@ -187,7 +180,6 @@ void Tracker::tracking_manual_control(const mavlink_manual_control_t &msg)
 {
     nav_status.bearing = msg.x;
     nav_status.pitch   = msg.y;
-    nav_status.distance = 0.0;
     nav_status.manual_control_yaw   = (msg.x != 0x7FFF);
     nav_status.manual_control_pitch = (msg.y != 0x7FFF);
     // z, r and buttons are not used


### PR DESCRIPTION
This is my first time experimenting with Tracker.

This came about as I was reviewing: 
https://github.com/ArduPilot/ardupilot/pull/30083

You can test using:
```
./Tools/autotest/sim_vehicle.py -v ArduPlane -f quadplane --tracker

[wait for load]

arm throttle
mode guided
takeoff 50
[fly to here on map]

[watch the tracker's pitch, nav_pitch, yaw, nav_yaw; I did this using Mission Planner to connect to the tracker's second TCP serial port on 5772]

tracker mode guided
[see nav_bearing and nav_pitch go to 0]

tracker mode auto
tracker position 10 20
[see nav_bearing go to 10 and nav_pitch go to 20]

tracker position 32767 32767
[this is the only way to release the tracker from manual control. This took me forever to figure out; we should make a MAVProxy PR to add a more inuitive way to release control]

tracker mode scan
[see the nav_bearing and nav_pitch follow what scan is telling it to do]
```