### PR TITLE
AP_Follow: stop adjusting frame of return location based on parameter

### DIFF
--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -408,7 +408,7 @@ bool AP_Follow::get_heading_heading_rate_rad(float &heading_rad, float &heading_
     return true;
 }
 
-// Retrieves the target's estimated global location and velocity, adjusting altitude frame if relative mode is set (for LUA bindings).
+// Retrieves the target's estimated global location and velocity
 bool AP_Follow::get_target_location_and_velocity(Location &loc, Vector3f &vel_ned)
 {
     WITH_SEMAPHORE(_follow_sem);
@@ -421,10 +421,6 @@ bool AP_Follow::get_target_location_and_velocity(Location &loc, Vector3f &vel_ne
         return false;
     }
     vel_ned = _estimate_vel_ned_ms;
-
-    if (_alt_type == AP_FOLLOW_ALTITUDE_TYPE_RELATIVE) {
-        loc.change_alt_frame(Location::AltFrame::ABOVE_HOME);
-    }
 
     return true;
 }
@@ -439,9 +435,6 @@ bool AP_Follow::get_target_location_and_velocity_ofs(Location &loc, Vector3f &ve
     }
     if (!AP::ahrs().get_location_from_origin_offset_NED(loc, _ofs_estimate_pos_ned_m)) {
         return false;
-    }
-    if (_alt_type == AP_FOLLOW_ALTITUDE_TYPE_RELATIVE) {
-        loc.change_alt_frame(Location::AltFrame::ABOVE_HOME);
     }
 
     vel_ned = _ofs_estimate_vel_ned_ms;
@@ -879,10 +872,6 @@ void AP_Follow::Log_Write_FOLL()
 
     Location _target_location;
     UNUSED_RESULT(AP::ahrs().get_location_from_origin_offset_NED(_target_location, _target_pos_ned_m));
-
-    if (_alt_type == AP_FOLLOW_ALTITUDE_TYPE_RELATIVE) {
-        _target_location.change_alt_frame(Location::AltFrame::ABOVE_HOME);
-    }
 
     // log the lead target's reported position and vehicle's estimated position
     // @LoggerMessage: FOLL

--- a/libraries/AP_Follow/AP_Follow.h
+++ b/libraries/AP_Follow/AP_Follow.h
@@ -96,7 +96,7 @@ public:
     // Global Location and Velocity Retrieval (LUA Bindings)
     //==========================================================================
 
-    // Retrieves the estimated global location and velocity of the target. Adjusts altitude frame to relative if configured (for LUA bindings).
+    // Retrieves the estimated global location and velocity of the target
     bool get_target_location_and_velocity(Location &loc, Vector3f &vel_ned);
 
     // Retrieves the estimated global location and velocity of the target, including configured positional offsets (for LUA bindings).


### PR DESCRIPTION
this removes the dual-use of the _alt_type parameter.

This parameter was changing both which input we accepted from the other vehicle (eg. GLOBAL_POSITION_INT.alt vs GLOBAL_POSITION_INT.relative_alt, but it was also specifying the return frame for the Location object returned from various methods.  This was somewhat confusing and unnecessary.


 - all lua scripts in-tree canonicalise this to absolute altitude
 - there are only two callers to these.  One is logging, meaning we will always now log in relative-to-origin numbers.  The secon is mavlink-reporting which canonicalises the altitude.  Many other `get_wp()` methods can return absolute-altitude locations.
