### PR TITLE
Apply various methods to avoid use of .alt in the Location object

### DIFF
--- a/AntennaTracker/tracking.cpp
+++ b/AntennaTracker/tracking.cpp
@@ -16,7 +16,7 @@ void Tracker::update_vehicle_pos_estimate()
         float north_offset = vehicle.vel.x * dt;
         float east_offset = vehicle.vel.y * dt;
         vehicle.location_estimate.offset(north_offset, east_offset);
-    	vehicle.location_estimate.alt += vehicle.vel.z * 100.0f * dt;
+    	vehicle.location_estimate.offset_up_m(vehicle.vel.z * dt);
         // set valid_location flag
         vehicle.location_valid = true;
     } else {

--- a/ArduCopter/autoyaw.cpp
+++ b/ArduCopter/autoyaw.cpp
@@ -172,7 +172,7 @@ void Mode::AutoYaw::set_yaw_angle_offset_deg(const float yaw_angle_offset_deg)
 void Mode::AutoYaw::set_roi(const Location &roi_location)
 {
     // if location is zero lat, lon and altitude turn off ROI
-    if (roi_location.alt == 0 && roi_location.lat == 0 && roi_location.lng == 0) {
+    if (!roi_location.initialised()) {
         // set auto yaw mode back to default assuming the active command is a waypoint command.  A more sophisticated method is required to ensure we return to the proper yaw control for the active command
         auto_yaw.set_mode_to_default(false);
 #if HAL_MOUNT_ENABLED

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -526,7 +526,7 @@ void ModeAuto::circle_movetoedge_start(const Location &circle_center, float radi
         Location circle_edge(circle_edge_neu, Location::AltFrame::ABOVE_ORIGIN);
 
         // convert altitude to same as command
-        circle_edge.set_alt_cm(circle_center.alt, circle_center.get_alt_frame());
+        circle_edge.copy_alt_from(circle_center);
 
         // initialise wpnav to move to edge of circle
         if (!wp_nav->set_wp_destination_loc(circle_edge)) {
@@ -1538,7 +1538,7 @@ Location ModeAuto::loc_from_cmd(const AP_Mission::Mission_Command& cmd, const Lo
             ret.set_alt_cm(default_alt, ret.get_alt_frame());
         } else {
             // default to default_loc's altitude and frame
-            ret.set_alt_cm(default_loc.alt, default_loc.get_alt_frame());
+            ret.copy_alt_from(default_loc);
         }
     }
     return ret;
@@ -1964,7 +1964,7 @@ void ModeAuto::do_change_speed(const AP_Mission::Mission_Command& cmd)
 
 void ModeAuto::do_set_home(const AP_Mission::Mission_Command& cmd)
 {
-    if (cmd.p1 == 1 || (cmd.content.location.lat == 0 && cmd.content.location.lng == 0 && cmd.content.location.alt == 0)) {
+    if (cmd.p1 == 1 || !cmd.content.location.initialised()) {
         if (!copter.set_home_to_current_location(false)) {
             // ignore failure
         }

--- a/ArduPlane/GCS_MAVLink_Plane.cpp
+++ b/ArduPlane/GCS_MAVLink_Plane.cpp
@@ -511,7 +511,7 @@ void GCS_MAVLINK_Plane::handle_change_alt_request(Location &location)
     plane.fix_terrain_WP(location, __LINE__);
 
     if (location.terrain_alt) {
-        plane.next_WP_loc.set_alt_cm(location.alt, Location::AltFrame::ABOVE_TERRAIN);
+        plane.next_WP_loc.copy_alt_from(location);
     } else {
         // convert to absolute alt
         float abs_alt_m;

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -284,7 +284,7 @@ void Plane::Log_Write_Guided(void)
         logger.Write_PID(LOG_PIDG_MSG, g2.guidedHeading.get_pid_info());
     }
 
-    if ( guided_state.target_location.alt != -1 || is_positive(guided_state.target_airspeed_cm) ) {
+    if (!guided_state.target_location_alt_is_minus_one() || is_positive(guided_state.target_airspeed_cm) ) {
         Log_Write_OFG_Guided();
     }
 #endif // AP_PLANE_OFFBOARD_GUIDED_SLEW_ENABLED

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -583,7 +583,7 @@ private:
     } nav_scripting;
 #endif
 
-    struct {
+    struct GuidedState {
         // roll pitch yaw commanded from external controller in centidegrees
         Vector3l forced_rpy_cd;
         // last time we heard from the external controller
@@ -601,6 +601,9 @@ private:
 
         // altitude adjustments
         Location target_location;
+        // target_location altitude is uses to hold some flag values:
+        bool target_location_alt_is_minus_one() const;
+
         float target_alt_rate;
         uint32_t target_alt_time_ms = 0;
         uint8_t target_mav_frame = -1;

--- a/ArduPlane/commands.cpp
+++ b/ArduPlane/commands.cpp
@@ -32,8 +32,8 @@ void Plane::set_next_WP(const Location &loc)
         next_WP_loc.lat = current_loc.lat;
         next_WP_loc.lng = current_loc.lng;
         // additionally treat zero altitude as current altitude
-        if (next_WP_loc.alt == 0) {
-            next_WP_loc.set_alt_cm(current_loc.alt, Location::AltFrame::ABSOLUTE);
+        if (next_WP_loc.alt_is_zero()) {
+            next_WP_loc.copy_alt_from(current_loc);
         }
     }
 

--- a/ArduPlane/mode_guided.cpp
+++ b/ArduPlane/mode_guided.cpp
@@ -158,11 +158,21 @@ void ModeGuided::set_radius_and_direction(const float radius, const bool directi
     plane.loiter.direction = direction_is_ccw ? -1 : 1;
 }
 
+#if AP_PLANE_OFFBOARD_GUIDED_SLEW_ENABLED
+bool Plane::GuidedState::target_location_alt_is_minus_one() const
+{
+    int32_t target_location_alt = 0;
+    UNUSED_RESULT(target_location.get_alt_cm(target_location.get_alt_frame(), target_location_alt));
+    return target_location_alt == -1;
+}
+#endif // AP_PLANE_OFFBOARD_GUIDED_SLEW_ENABLED
+
 void ModeGuided::update_target_altitude()
 {
 #if AP_PLANE_OFFBOARD_GUIDED_SLEW_ENABLED
     // target altitude can be negative (e.g. flying below home altitude from the top of a mountain)
-    if (((plane.guided_state.target_alt_time_ms != 0) || plane.guided_state.target_location.alt != -1 )) { // target_alt now defaults to -1, and _time_ms defaults to zero.
+    if ((plane.guided_state.target_alt_time_ms != 0) ||
+        !plane.guided_state.target_location_alt_is_minus_one()) { // target_alt now defaults to -1, and _time_ms defaults to zero.
         // offboard altitude demanded
         uint32_t now = AP_HAL::millis();
         float delta = 1e-3f * (now - plane.guided_state.target_alt_time_ms);

--- a/ArduPlane/mode_qrtl.cpp
+++ b/ArduPlane/mode_qrtl.cpp
@@ -160,7 +160,7 @@ void ModeQRTL::run()
             quadplane.vtol_position_controller();
             if (poscontrol.get_state() > QuadPlane::QPOS_POSITION2) {
                 // change target altitude to home alt
-                plane.next_WP_loc.set_alt_cm(plane.home.alt, Location::AltFrame::ABSOLUTE);
+                plane.next_WP_loc.copy_alt_from(plane.home);
             }
             if (poscontrol.get_state() >= QuadPlane::QPOS_POSITION2) {
                 // start landing logic
@@ -210,7 +210,7 @@ void ModeQRTL::update_target_altitude()
                                    dist,
                                    rad_min, MAX(rad_min, MIN(rad_max, rad_min+sink_dist)));
     Location loc = plane.next_WP_loc;
-    loc.alt += alt*100;
+    loc.offset_up_m(alt);
     plane.set_target_altitude_location(loc);
 }
 

--- a/ArduPlane/mode_takeoff.cpp
+++ b/ArduPlane/mode_takeoff.cpp
@@ -98,7 +98,7 @@ void ModeTakeoff::update()
                 gcs().send_text(MAV_SEVERITY_INFO, "Climbing to TKOFF alt then loitering");
                 start_loc = plane.current_loc;
                 plane.next_WP_loc = plane.current_loc;
-                plane.next_WP_loc.alt += ((alt - altitude) *100);
+                plane.next_WP_loc.offset_up_m(alt - altitude);
                 plane.next_WP_loc.offset_bearing(direction, dist);
                 takeoff_mode_setup = true;
                 plane.set_flight_stage(AP_FixedWing::FlightStage::TAKEOFF);
@@ -109,7 +109,7 @@ void ModeTakeoff::update()
             start_loc = plane.current_loc;
             plane.prev_WP_loc = plane.current_loc;
             plane.next_WP_loc = plane.current_loc;
-            plane.next_WP_loc.alt += alt*100.0;
+            plane.next_WP_loc.offset_up_m(alt);
             plane.next_WP_loc.offset_bearing(direction, dist);
 
             plane.crash_state.is_crashed = false;
@@ -155,7 +155,7 @@ void ModeTakeoff::update()
         const float direction = start_loc.get_bearing_to(plane.current_loc) * 0.01;
         plane.next_WP_loc = start_loc;
         plane.next_WP_loc.offset_bearing(direction, dist);
-        plane.next_WP_loc.alt += alt*100.0;
+        plane.next_WP_loc.offset_up_m(alt);
         plane.steer_state.hold_course_cd = wrap_360_cd(direction*100); // Necessary to allow Plane::takeoff_calc_roll() to function.
     }
         

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3370,8 +3370,7 @@ bool QuadPlane::do_vtol_land(const AP_Mission::Mission_Command& cmd)
 
     plane.set_next_WP(cmd.content.location);
     // initially aim for current altitude
-    plane.next_WP_loc.set_alt_cm(plane.current_loc.alt,
-                                 Location::AltFrame::ABSOLUTE);
+    plane.next_WP_loc.copy_alt_from(plane.current_loc);
 
     // initialise the position controller
     pos_control->init_NE_controller();
@@ -3591,8 +3590,7 @@ bool QuadPlane::verify_vtol_land(void)
                 plane.set_next_WP(plane.mission.get_current_nav_cmd().content.location);
             } else {
                 plane.set_next_WP(plane.next_WP_loc);
-                plane.next_WP_loc.set_alt_cm(ahrs.get_home().alt,
-                                             Location::AltFrame::ABSOLUTE);
+                plane.next_WP_loc.copy_alt_from(ahrs.get_home());
             }
         }
     }
@@ -3964,7 +3962,7 @@ bool QuadPlane::do_user_takeoff(float takeoff_altitude)
     plane.auto_state.vtol_loiter = true;
     plane.prev_WP_loc = plane.current_loc;
     plane.next_WP_loc = plane.current_loc;
-    plane.next_WP_loc.alt += takeoff_altitude*100;
+    plane.next_WP_loc.offset_up_m(takeoff_altitude);
     set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
     guided_start();
     guided_takeoff = true;

--- a/ArduSub/commands.cpp
+++ b/ArduSub/commands.cpp
@@ -26,7 +26,7 @@ void Sub::set_home_to_current_location_inflight()
     Location temp_loc;
     Location ekf_origin;
     if (ahrs.get_location(temp_loc) && ahrs.get_origin(ekf_origin)) {
-        temp_loc.alt = ekf_origin.alt;
+        temp_loc.copy_alt_from(ekf_origin);
         if (!set_home(temp_loc, false)) {
             // ignore this failure
         }
@@ -44,7 +44,7 @@ bool Sub::set_home_to_current_location(bool lock)
         // This allows disarming and arming again at depth.
         // This also ensures that mission items with relative altitude frame, are always
         // relative to the water's surface, whether in a high elevation lake, or at sea level.
-        temp_loc.alt -= barometer.get_altitude() * 100.0f;
+        temp_loc.offset_up_m(-barometer.get_altitude());
         return set_home(temp_loc, lock);
     }
     return false;

--- a/ArduSub/commands_logic.cpp
+++ b/ArduSub/commands_logic.cpp
@@ -238,7 +238,7 @@ void Sub::do_nav_wp(const AP_Mission::Mission_Command& cmd)
             target_loc.set_alt_cm(curr_alt, target_loc.get_alt_frame());
         } else {
             // default to current altitude as alt-above-home
-            target_loc.set_alt_cm(current_loc.alt, current_loc.get_alt_frame());
+            target_loc.copy_alt_from(current_loc);
         }
     }
 
@@ -323,7 +323,7 @@ void Sub::do_loiter_unlimited(const AP_Mission::Mission_Command& cmd)
             target_loc.set_alt_cm(curr_alt, target_loc.get_alt_frame());
         } else {
             // default to current altitude as alt-above-home
-            target_loc.set_alt_cm(current_loc.alt, current_loc.get_alt_frame());
+            target_loc.copy_alt_from(current_loc);
         }
     }
 
@@ -344,14 +344,14 @@ void Sub::do_circle(const AP_Mission::Mission_Command& cmd)
     }
 
     // default target altitude to current altitude if not provided
-    if (circle_center.alt == 0) {
+    if (circle_center.alt_is_zero()) {
         int32_t curr_alt;
         if (current_loc.get_alt_cm(circle_center.get_alt_frame(),curr_alt)) {
             // circle altitude uses frame from command
             circle_center.set_alt_cm(curr_alt,circle_center.get_alt_frame());
         } else {
             // default to current altitude above origin
-            circle_center.set_alt_cm(current_loc.alt, current_loc.get_alt_frame());
+            circle_center.copy_alt_from(current_loc);
             LOGGER_WRITE_ERROR(LogErrorSubsystem::TERRAIN, LogErrorCode::MISSING_TERRAIN_DATA);
         }
     }
@@ -672,7 +672,7 @@ void Sub::do_change_speed(const AP_Mission::Mission_Command& cmd)
 
 void Sub::do_set_home(const AP_Mission::Mission_Command& cmd)
 {
-    if (cmd.p1 == 1 || (cmd.content.location.lat == 0 && cmd.content.location.lng == 0 && cmd.content.location.alt == 0)) {
+    if (cmd.p1 == 1 || !cmd.content.location.initialised()) {
         if (!set_home_to_current_location(false)) {
             // silently ignore this failure
         }

--- a/ArduSub/mode_auto.cpp
+++ b/ArduSub/mode_auto.cpp
@@ -199,7 +199,7 @@ void ModeAuto::auto_circle_movetoedge_start(const Location &circle_center, float
         Location circle_edge(circle_edge_neu, Location::AltFrame::ABOVE_ORIGIN);
 
         // convert altitude to same as command
-        circle_edge.set_alt_cm(circle_center.alt, circle_center.get_alt_frame());
+        circle_edge.copy_alt_from(circle_center);
 
         // initialise wpnav to move to edge of circle
         if (!sub.wp_nav.set_wp_destination_loc(circle_edge)) {
@@ -390,7 +390,7 @@ void ModeAuto::set_yaw_rate(float turn_rate_dps)
 void ModeAuto::set_auto_yaw_roi(const Location &roi_location)
 {
     // if location is zero lat, lon and altitude turn off ROI
-    if (roi_location.alt == 0 && roi_location.lat == 0 && roi_location.lng == 0) {
+    if (!roi_location.initialised()) {
         // set auto yaw mode back to default assuming the active command is a waypoint command.  A more sophisticated method is required to ensure we return to the proper yaw control for the active command
         set_auto_yaw_mode(get_default_auto_yaw_mode(false));
 #if HAL_MOUNT_ENABLED

--- a/Blimp/commands.cpp
+++ b/Blimp/commands.cpp
@@ -26,7 +26,7 @@ void Blimp::set_home_to_current_location_inflight()
     Location temp_loc;
     Location ekf_origin;
     if (ahrs.get_location(temp_loc) && ahrs.get_origin(ekf_origin)) {
-        temp_loc.alt = ekf_origin.alt;
+        temp_loc.copy_alt_from(ekf_origin);
         if (!set_home(temp_loc, false)) {
             return;
         }

--- a/Rover/mode_auto.cpp
+++ b/Rover/mode_auto.cpp
@@ -573,7 +573,7 @@ bool ModeAuto::start_command(const AP_Mission::Mission_Command& cmd)
     case MAV_CMD_DO_SET_ROI_LOCATION:
     case MAV_CMD_DO_SET_ROI_NONE:
     case MAV_CMD_DO_SET_ROI:
-        if (cmd.content.location.alt == 0 && cmd.content.location.lat == 0 && cmd.content.location.lng == 0) {
+        if (!cmd.content.location.initialised()) {
             // switch off the camera tracking if enabled
             if (rover.camera_mount.get_mode() == MAV_MOUNT_MODE_GPS_POINT) {
                 rover.camera_mount.set_mode_to_default();

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -783,7 +783,7 @@ bool AC_PrecLand::get_target_location(Location &loc)
         return false;
     }
     loc.offset(_last_target_pos_rel_origin_NED.x, _last_target_pos_rel_origin_NED.y);
-    loc.alt -= _last_target_pos_rel_origin_NED.z*100;
+    loc.offset_up_m(-_last_target_pos_rel_origin_NED.z);
     return true;
 }
 

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -3018,7 +3018,7 @@ bool AP_AHRS::set_home(const Location &loc)
 {
     WITH_SEMAPHORE(_rsem);
     // check location is valid
-    if (loc.lat == 0 && loc.lng == 0 && loc.alt == 0) {
+    if (!loc.initialised()) {
         return false;
     }
     if (!loc.check_latlng()) {

--- a/libraries/AP_Common/Location.h
+++ b/libraries/AP_Common/Location.h
@@ -119,6 +119,12 @@ public:
     // extrapolate latitude/longitude given distances (in meters) north
     // and east. Note that this is metres, *even for the altitude*.
     void offset(const Vector3p &ofs_ned);
+    void offset_up_cm(int32_t alt_offset_cm) {
+        alt += alt_offset_cm;
+    }
+    void offset_up_m(float alt_offset_m) {
+        alt += alt_offset_m * 100;
+    }
 
     // extrapolate latitude/longitude given bearing and distance
     void offset_bearing(ftype bearing_deg, ftype distance);
@@ -184,6 +190,10 @@ public:
     void linearly_interpolate_alt(const Location &point1, const Location &point2);
 
     bool initialised() const { return (lat !=0 || lng != 0 || alt != 0); }
+    // return true if alt is *exactly* zero.  This is not intended to
+    // be used for anything except magically changing a 0-altitude
+    // passed via mavlink into the current vehicle's altitude
+    bool alt_is_zero() const { return alt == 0; }
 
     // wrap longitude at -180e7 to 180e7
     static int32_t wrap_longitude(int64_t lon);

--- a/libraries/AP_DAL/AP_DAL.h
+++ b/libraries/AP_DAL/AP_DAL.h
@@ -238,9 +238,12 @@ public:
     }
     void handle_message(const log_RFRN &msg) {
         _RFRN = msg;
-        _home.lat = msg.lat;
-        _home.lng = msg.lng;
-        _home.alt = msg.alt;
+        _home = {
+            msg.lat,
+            msg.lng,
+            msg.alt,
+            Location::AltFrame::ABSOLUTE
+        };
     }
     void handle_message(const log_RFRF &msg, NavEKF2 &ekf2, NavEKF3 &ekf3);
 

--- a/libraries/AP_DAL/AP_DAL_GPS.cpp
+++ b/libraries/AP_DAL/AP_DAL_GPS.cpp
@@ -50,8 +50,11 @@ void AP_DAL_GPS::start_frame()
         WRITE_REPLAY_BLOCK_IFCHANGED(RGPI, RGPI, old_RGPI);
         WRITE_REPLAY_BLOCK_IFCHANGED(RGPJ, RGPJ, old_RGPJ);
 
-        tmp_location[i].lat = RGPJ.lat;
-        tmp_location[i].lng = RGPJ.lng;
-        tmp_location[i].alt = RGPJ.alt;
+        tmp_location[i] = {
+            RGPJ.lat,
+            RGPJ.lng,
+            RGPJ.alt,
+            Location::AltFrame::ABSOLUTE
+        };
     }
 }

--- a/libraries/AP_GPS/AP_GPS_Blended.cpp
+++ b/libraries/AP_GPS/AP_GPS_Blended.cpp
@@ -327,7 +327,7 @@ void AP_GPS_Blended::calc_state(void)
 
     // Add the sum of weighted offsets to the reference location to obtain the blended location
     state.location.offset(blended_NE_offset_m.x, blended_NE_offset_m.y);
-    state.location.alt += (int)blended_alt_offset_cm;
+    state.location.offset_up_cm(blended_alt_offset_cm);
 
     // Calculate ground speed and course from blended velocity vector
     state.ground_speed = state.velocity.xy().length();

--- a/libraries/AP_Landing/AP_Landing_Deepstall.cpp
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.cpp
@@ -187,7 +187,7 @@ void AP_Landing_Deepstall::do_land(const AP_Mission::Mission_Command& cmd, const
 
     if (!landing_point.relative_alt && !landing_point.terrain_alt) {
         approach_alt_offset = cmd.p1;
-        landing_point.alt += approach_alt_offset * 100;
+        landing_point.offset_up_m(approach_alt_offset);
     } else {
         approach_alt_offset = 0.0f;
     }

--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -325,7 +325,7 @@ void AP_Landing::type_slope_setup_landing_glide_slope(const Location &prev_WP_lo
 
     // calculate point along that slope 500m ahead
     loc.offset_bearing(land_bearing_cd * 0.01f, land_projection);
-    loc.alt -= slope * land_projection * 100;
+    loc.offset_up_m(-slope * land_projection);
 
     // setup the offset_cm for set_target_altitude_proportion()
     target_altitude_offset_cm = loc.alt - loc_alt_AMSL_cm(prev_WP_loc);

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -3105,7 +3105,7 @@ bool AP_Mission::calc_rewind_pos(Mission_Command& rewind_cmd)
 
     // calculate the resume wp position
     rewind_cmd.content.location.offset(dist_vec.x * leg_percent, dist_vec.y * leg_percent);
-    rewind_cmd.content.location.alt -= dist_vec.z * leg_percent * 100; //(cm)
+    rewind_cmd.content.location.offset_up_m(-dist_vec.z * leg_percent);
 
     // The rewind_cmd.index has the index of the 'last passed wp' from the history array.  This ensures that the mission order
     // continues as planned without further intervention.  The resume wp is not written to memory so will not perminantely change the mission.

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -297,7 +297,7 @@ bool NavEKF2_core::resetHeightDatum(void)
             // altitude. This ensures the reported AMSL alt from
             // getLLH() is equal to GPS altitude, while also ensuring
             // that the relative alt is zero
-            EKF_origin.alt = dal.gps().location().alt;
+            EKF_origin.copy_alt_from(dal.gps().location());
         }
         ekfGpsRefHgt = (double)0.01 * (double)EKF_origin.alt;
     }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -390,7 +390,7 @@ bool NavEKF3_core::resetHeightDatum(void)
             // altitude. This ensures the reported AMSL alt from
             // getLLH() is equal to GPS altitude, while also ensuring
             // that the relative alt is zero
-            EKF_origin.alt = dal.gps().location().alt;
+            EKF_origin.copy_alt_from(dal.gps().location());
         }
         ekfGpsRefHgt = (double)0.01 * (double)EKF_origin.alt;
     }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -5373,7 +5373,7 @@ MAV_RESULT GCS_MAVLINK::handle_command_do_set_roi(const Location &roi_loc)
         return MAV_RESULT_FAILED;
     }
 
-    if (roi_loc.lat == 0 && roi_loc.lng == 0 && roi_loc.alt == 0) {
+    if (!roi_loc.initialised()) {
         mount->clear_roi_target();
     } else {
         mount->set_roi_target(roi_loc);


### PR DESCRIPTION
various changes to avoid use of the Location .alt field, which should be private.
    
Introduces several new helper functions on Location to help with this

Prevents access to `.alt` on some location objects, which should be private.
