### PR TITLE
Blimp: remove inertialnav instantiation

### DIFF
--- a/Blimp/Blimp.cpp
+++ b/Blimp/Blimp.cpp
@@ -290,7 +290,6 @@ Blimp::Blimp(void)
     :
       control_mode(Mode::Number::MANUAL),
       rc_throttle_control_in_filter(1.0f),
-      inertial_nav(ahrs),
       param_loader(var_info),
       flightmode(&mode_manual)
 {

--- a/Blimp/Blimp.h
+++ b/Blimp/Blimp.h
@@ -41,7 +41,6 @@
 #include <AP_AHRS/AP_AHRS.h>
 #include <Filter/Filter.h>             // Filter library
 #include <AP_Vehicle/AP_Vehicle.h>         // needed for AHRS build
-#include <AP_InertialNav/AP_InertialNav.h>     // inertial navigation library
 #include <AP_RCMapper/AP_RCMapper.h>        // RC input mapping library
 #include <AP_BattMonitor/AP_BattMonitor.h>     // Battery monitor library
 #include <AP_Arming/AP_Arming.h>
@@ -163,9 +162,6 @@ private:
 
     RCMapper rcmap;
 
-    // inertial nav alt when we armed
-    float arming_altitude_m;
-
     // Failsafe
     struct {
         int8_t radio_counter;            // number of iterations with throttle below throttle_fs_value
@@ -213,9 +209,6 @@ private:
     NotchFilterVector2f vel_xy_filter;
     NotchFilterFloat vel_z_filter;
     NotchFilterFloat vel_yaw_filter;
-
-    // Inertial Navigation
-    AP_InertialNav inertial_nav;
 
     // Vel & pos PIDs
     AC_PID_2D pid_vel_xy{3, 0.2, 0, 0, 0.2, 3, 3}; //These are the defaults - P I D FF IMAX FiltHz FiltDHz DT

--- a/Blimp/inertia.cpp
+++ b/Blimp/inertia.cpp
@@ -3,9 +3,6 @@
 // read_inertia - read inertia in from accelerometers
 void Blimp::read_inertia()
 {
-    // inertial altitude estimates. Use barometer climb rate during high vibrations
-    inertial_nav.update(vibration_check.high_vibes);
-
     // pull position from ahrs
     Location loc;
     // AHRS provides a best-guess in case of failure
@@ -14,12 +11,13 @@ void Blimp::read_inertia()
     current_loc.lng = loc.lng;
 
     // exit immediately if we do not have an altitude estimate
-    if (!ahrs.has_status(AP_AHRS::Status::VERT_POS)) {
+    float pos_d_m;
+    if (!AP::ahrs().get_relative_position_D_origin_float(pos_d_m)) {
         return;
     }
 
-    // current_loc.alt is alt-above-home, converted from inertial nav's alt-above-ekf-origin
-    const int32_t alt_above_origin_cm = inertial_nav.get_position_z_up_cm();
+    // current_loc.alt is alt-above-home, converted from AHRS's alt-above-ekf-origin
+    const int32_t alt_above_origin_cm = -pos_d_m * 100.0;
     current_loc.set_alt_cm(alt_above_origin_cm, Location::AltFrame::ABOVE_ORIGIN);
     if (!ahrs.home_is_set() || !current_loc.change_alt_frame(Location::AltFrame::ABOVE_HOME)) {
         // if home has not been set yet we treat alt-above-origin as alt-above-home

--- a/Blimp/mode.cpp
+++ b/Blimp/mode.cpp
@@ -11,7 +11,6 @@
 Mode::Mode(void) :
     g(blimp.g),
     g2(blimp.g2),
-    inertial_nav(blimp.inertial_nav),
     ahrs(blimp.ahrs),
     motors(blimp.motors),
     loiter(blimp.loiter),

--- a/Blimp/mode.h
+++ b/Blimp/mode.h
@@ -106,7 +106,6 @@ protected:
     // convenience references to avoid code churn in conversion:
     Parameters &g;
     ParametersG2 &g2;
-    AP_InertialNav &inertial_nav;
     AP_AHRS &ahrs;
     Fins *&motors;
     Loiter *&loiter;

--- a/Blimp/wscript
+++ b/Blimp/wscript
@@ -7,7 +7,6 @@ def build(bld):
         ap_vehicle=vehicle,
         ap_libraries=bld.ap_common_vehicle_libraries() + [
             'AC_InputManager',
-            'AP_InertialNav',
             'AP_Avoidance',
             'AP_LTM_Telem',
             'AP_Devo_Telem',


### PR DESCRIPTION
no longer required

took this for a quick spin in SITL, but mostly relying on autotests
