### PR TITLE
DroneCAN: opt to ignore ESC_OF on receive

### DIFF
--- a/libraries/AP_DroneCAN/AP_DroneCAN.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.cpp
@@ -129,7 +129,16 @@ const AP_Param::GroupInfo AP_DroneCAN::var_info[] = {
     // @Param: OPTION
     // @DisplayName: DroneCAN options
     // @Description: Option flags
-    // @Bitmask: 0:ClearDNADatabase,1:IgnoreDNANodeConflicts,2:EnableCanfd,3:IgnoreDNANodeUnhealthy,4:SendServoAsPWM,5:SendGNSS,6:UseHimarkServo,7:HobbyWingESC,8:EnableStats,9:EnableFlexDebug
+    // @Bitmask: 0: Clear dynamic node allocation database
+    // @Bitmask: 1: Ignore dynamic node allocation conflicts
+    // @Bitmask: 2: Enable CANFD support
+    // @Bitmask: 3: Ignore unhealthy nodes in dynamic node allocation
+    // @Bitmask: 4: Send servo commands as PWM
+    // @Bitmask: 5: Send GNSS packets onto the bus
+    // @Bitmask: 6: Use Himark servo protocol
+    // @Bitmask: 7: Use HobbyWing ESC protocol
+    // @Bitmask: 8: Enable DroneCAN statistics
+    // @Bitmask: 9: Enable DroneCAN FlexDebug messages
     // @User: Advanced
     AP_GROUPINFO("OPTION", 5, AP_DroneCAN, _options, 0),
     

--- a/libraries/AP_DroneCAN/AP_DroneCAN.h
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.h
@@ -151,6 +151,7 @@ public:
         USE_HOBBYWING_ESC         = (1U<<7),
         ENABLE_STATS              = (1U<<8),
         ENABLE_FLEX_DEBUG         = (1U<<9),
+        IGNORE_ESC_OFFSET_RECEIVE = (1U<<10),
     };
 
     // check if a option is set


### PR DESCRIPTION
This is useful if you want ESC numbering in logs/MAVLink to be independent of servo numbering. For example, if your ESCs are on servos 17-24, but you want their telemetry to be reported to the GCS as ESCs 1-8, this allows you to do that. Tested (a 4.5 backport of this) on my OctoQuad VTOL.

If you are using two different busses, with different ESCs on each bus, and have your ESC_OF value set differently on each bus, this feature will result in clashes. Don't do that.

The more versitile way to handle this would be to add a separate receive offset for each bus (which defaults to -1, causing it to just match the transmit offset), but I abandoned this for two reasons:
1. Extra params most people don't need
2. Naming those new params is borderline impossible; I only get two characters left over to name this: "ESC_??"