### PR TITLE
Rename AP::ahrs().get_roll() to AP::ahrs().get_roll_rad() etc.

### DIFF
--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -82,7 +82,7 @@ void Copter::update_land_detector()
         // check if landing
         const bool landing = flightmode->is_landing();
         SET_LOG_FLAG(landing, LandDetectorLoggingFlag::LANDING);
-        bool motor_at_lower_limit = (flightmode->has_manual_throttle() && (motors->get_below_land_min_coll() || heli_flags.coll_stk_low) && fabsf(ahrs.get_roll()) < M_PI/2.0f)
+        bool motor_at_lower_limit = (flightmode->has_manual_throttle() && (motors->get_below_land_min_coll() || heli_flags.coll_stk_low) && fabsf(ahrs.get_roll_rad()) < M_PI/2.0f)
 #if MODE_AUTOROTATE_ENABLED
                                     || (flightmode->mode_number() == Mode::Number::AUTOROTATE && motors->get_below_land_min_coll())
 #endif

--- a/ArduPlane/GCS_MAVLink_Plane.cpp
+++ b/ArduPlane/GCS_MAVLink_Plane.cpp
@@ -132,9 +132,9 @@ void GCS_MAVLINK_Plane::send_attitude() const
 {
     const AP_AHRS &ahrs = AP::ahrs();
 
-    float r = ahrs.get_roll();
-    float p = ahrs.get_pitch();
-    float y = ahrs.get_yaw();
+    float r = ahrs.get_roll_rad();
+    float p = ahrs.get_pitch_rad();
+    float y = ahrs.get_yaw_rad();
 
     if (!(plane.flight_option_enabled(FlightOptions::GCS_REMOVE_TRIM_PITCH))) {
         p -= radians(plane.g.pitch_trim);

--- a/ArduPlane/Plane.cpp
+++ b/ArduPlane/Plane.cpp
@@ -1031,8 +1031,8 @@ void Plane::get_osd_roll_pitch_rad(float &roll, float &pitch) const
         return;
     }
 #endif
-    pitch = ahrs.get_pitch();
-    roll = ahrs.get_roll();
+    pitch = ahrs.get_pitch_rad();
+    roll = ahrs.get_roll_rad();
     if (!(flight_option_enabled(FlightOptions::OSD_REMOVE_TRIM_PITCH))) {  // correct for PTCH_TRIM_DEG
         pitch -= g.pitch_trim * DEG_TO_RAD;
     }

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -1097,7 +1097,7 @@ bool Plane::verify_landing_vtol_approach(const AP_Mission::Mission_Command &cmd)
                 const float breakout_direction_rad = radians(vtol_approach_s.approach_direction_deg + (direction > 0 ? 270 : 90));
 
                 // breakout when within 5 degrees of the opposite direction
-                if (fabsF(wrap_PI(ahrs.get_yaw() - breakout_direction_rad)) < radians(5.0f)) {
+                if (fabsF(wrap_PI(ahrs.get_yaw_rad() - breakout_direction_rad)) < radians(5.0f)) {
                     gcs().send_text(MAV_SEVERITY_INFO, "Starting VTOL land approach path");
                     vtol_approach_s.approach_stage = VTOLApproach::Stage::APPROACH_LINE;
                     set_next_WP(cmd.content.location);

--- a/ArduPlane/mode_cruise.cpp
+++ b/ArduPlane/mode_cruise.cpp
@@ -61,7 +61,7 @@ void ModeCruise::navigate()
 
     // check if we are moving in the direction of the front of the vehicle
     const int32_t ground_course_cd = plane.gps.ground_course_cd();
-    const bool moving_forwards = fabsf(wrap_PI(cd_to_rad(ground_course_cd) - plane.ahrs.get_yaw())) < M_PI_2;
+    const bool moving_forwards = fabsf(wrap_PI(cd_to_rad(ground_course_cd) - plane.ahrs.get_yaw_rad())) < M_PI_2;
 
     if (!locked_heading &&
         plane.channel_roll->get_control_in() == 0 &&

--- a/ArduPlane/mode_guided.cpp
+++ b/ArduPlane/mode_guided.cpp
@@ -52,7 +52,7 @@ void ModeGuided::update()
 
         float error = 0.0f;
         if (plane.guided_state.target_heading_type == GUIDED_HEADING_HEADING) {
-            error = wrap_PI(plane.guided_state.target_heading - AP::ahrs().get_yaw());
+            error = wrap_PI(plane.guided_state.target_heading - AP::ahrs().get_yaw_rad());
         } else {
             Vector2f groundspeed = AP::ahrs().groundspeed_vector();
             error = wrap_PI(plane.guided_state.target_heading - atan2f(-groundspeed.y, -groundspeed.x) + M_PI);

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2586,7 +2586,7 @@ void QuadPlane::vtol_position_controller(void)
             target_speed_xy_cms = diff_wp_norm * target_speed * 100;
             target_accel_cms = diff_wp_norm * (-target_accel*100);
             target_yaw_deg = degrees(diff_wp_norm.angle());
-            const float yaw_err_deg = wrap_180(target_yaw_deg - degrees(plane.ahrs.get_yaw()));
+            const float yaw_err_deg = wrap_180(target_yaw_deg - degrees(plane.ahrs.get_yaw_rad()));
             bool overshoot = (closing_groundspeed < 0 || fabsf(yaw_err_deg) > 60);
             if (overshoot && !poscontrol.overshoot) {
                 gcs().send_text(MAV_SEVERITY_INFO,"VTOL Overshoot d=%.1f cs=%.1f yerr=%.1f",
@@ -3045,7 +3045,7 @@ void QuadPlane::assign_tilt_to_fwd_thr(void)
 */
 float QuadPlane::get_scaled_wp_speed(float target_bearing_deg) const
 {
-    const float yaw_difference = fabsf(wrap_180(degrees(plane.ahrs.get_yaw()) - target_bearing_deg));
+    const float yaw_difference = fabsf(wrap_180(degrees(plane.ahrs.get_yaw_rad()) - target_bearing_deg));
     const float wp_speed = wp_nav->get_default_speed_NE_cms() * 0.01;
     if (yaw_difference > 20) {
         // this gives a factor of 2x reduction in max speed when

--- a/ArduSub/mode_guided.cpp
+++ b/ArduSub/mode_guided.cpp
@@ -389,7 +389,7 @@ void ModeGuided::guided_set_angle(const Quaternion &q, float climb_rate_cms)
 // helper function to set yaw state and targets
 void ModeGuided::guided_set_yaw_state(bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_angle)
 {    
-    float current_yaw = wrap_2PI(AP::ahrs().get_yaw());
+    float current_yaw = wrap_2PI(AP::ahrs().get_yaw_rad());
     float euler_yaw_angle;
     float yaw_error;
 

--- a/ArduSub/turn_counter.cpp
+++ b/ArduSub/turn_counter.cpp
@@ -8,11 +8,11 @@ void Sub::update_turn_counter()
     // Determine state
     // 0: 0-90 deg, 1: 90-180 deg, 2: -180--90 deg, 3: -90--0 deg
     uint8_t turn_state;
-    if (ahrs.get_yaw() >= 0.0f && ahrs.get_yaw() < radians(90)) {
+    if (ahrs.get_yaw_rad() >= 0.0f && ahrs.get_yaw_rad() < radians(90)) {
         turn_state = 0;
-    } else if (ahrs.get_yaw() > radians(90)) {
+    } else if (ahrs.get_yaw_rad() > radians(90)) {
         turn_state = 1;
-    } else if (ahrs.get_yaw() < -radians(90)) {
+    } else if (ahrs.get_yaw_rad() < -radians(90)) {
         turn_state = 2;
     } else {
         turn_state = 3;

--- a/Blimp/Blimp.cpp
+++ b/Blimp/Blimp.cpp
@@ -244,7 +244,7 @@ void Blimp::read_AHRS(void)
                                 pos_ned.x,
                                 pos_ned.y,
                                 pos_ned.z,
-                                blimp.ahrs.get_yaw());
+                                blimp.ahrs.get_yaw_rad());
 #endif
 }
 

--- a/Blimp/Loiter.cpp
+++ b/Blimp/Loiter.cpp
@@ -34,7 +34,7 @@ void Loiter::run(Vector3f& target_pos, float& target_yaw, Vector4b axes_disabled
                                 scaler_xz, scaler_yyaw, scaler_xz_n, scaler_yyaw_n);
 #endif
 
-    float yaw_ef = blimp.ahrs.get_yaw();
+    float yaw_ef = blimp.ahrs.get_yaw_rad();
     Vector3f err_xyz = target_pos - blimp.pos_ned;
     float err_yaw = wrap_PI(target_yaw - yaw_ef);
 
@@ -96,7 +96,7 @@ void Loiter::run(Vector3f& target_pos, float& target_yaw, Vector4b axes_disabled
         blimp.pid_vel_z.set_integrator(0);
         blimp.pid_vel_yaw.set_integrator(0);
         target_pos = blimp.pos_ned;
-        target_yaw = blimp.ahrs.get_yaw();
+        target_yaw = blimp.ahrs.get_yaw_rad();
     }
 
     if (zero.x) {

--- a/Blimp/mode_loiter.cpp
+++ b/Blimp/mode_loiter.cpp
@@ -9,7 +9,7 @@
 bool ModeLoiter::init(bool ignore_checks)
 {
     target_pos = blimp.pos_ned;
-    target_yaw = blimp.ahrs.get_yaw();
+    target_yaw = blimp.ahrs.get_yaw_rad();
 
     return true;
 }
@@ -41,7 +41,7 @@ void ModeLoiter::run()
     if (fabsf(target_pos.z-blimp.pos_ned.z) < (g.max_pos_z*POS_LAG)) {
         target_pos.z += pilot.z;
     }
-    if (fabsf(wrap_PI(target_yaw-ahrs.get_yaw())) < (g.max_pos_yaw*POS_LAG)) {
+    if (fabsf(wrap_PI(target_yaw-ahrs.get_yaw_rad())) < (g.max_pos_yaw*POS_LAG)) {
         target_yaw = wrap_PI(target_yaw + pilot_yaw);
     }
 

--- a/Rover/GCS_MAVLink_Rover.cpp
+++ b/Rover/GCS_MAVLink_Rover.cpp
@@ -244,9 +244,9 @@ void GCS_MAVLINK_Rover::send_water_depth()
             loc.lat,            // latitude of vehicle
             loc.lng,            // longitude of vehicle
             loc.alt * 0.01f,    // altitude of vehicle (MSL)
-            ahrs.get_roll(),    // roll in radians
-            ahrs.get_pitch(),   // pitch in radians
-            ahrs.get_yaw(),     // yaw in radians
+            ahrs.get_roll_rad(),    // roll in radians
+            ahrs.get_pitch_rad(),   // pitch in radians
+            ahrs.get_yaw_rad(),     // yaw in radians
             s->distance(),    // distance in meters
             temp_C);            // temperature in degC
 

--- a/Rover/crash_check.cpp
+++ b/Rover/crash_check.cpp
@@ -20,7 +20,7 @@ void Rover::crash_check()
     }
 
     // Crashed if pitch/roll > crash_angle
-    if ((g2.crash_angle != 0) && ((fabsf(ahrs.get_pitch()) > radians(g2.crash_angle)) || (fabsf(ahrs.get_roll()) > radians(g2.crash_angle)))) {
+    if ((g2.crash_angle != 0) && ((fabsf(ahrs.get_pitch_rad()) > radians(g2.crash_angle)) || (fabsf(ahrs.get_roll_rad()) > radians(g2.crash_angle)))) {
         crashed = true;
     }
 

--- a/Rover/mode.cpp
+++ b/Rover/mode.cpp
@@ -292,7 +292,7 @@ void Mode::calc_throttle(float target_speed, bool avoidance_enabled)
 #if AP_AVOIDANCE_ENABLED
     // apply object avoidance to desired speed using half vehicle's maximum deceleration
     if (avoidance_enabled) {
-        g2.avoid.adjust_speed(0.0f, 0.5f * attitude_control.get_decel_max(), ahrs.get_yaw(), target_speed, rover.G_Dt);
+        g2.avoid.adjust_speed(0.0f, 0.5f * attitude_control.get_decel_max(), ahrs.get_yaw_rad(), target_speed, rover.G_Dt);
         if (g2.sailboat.tack_enabled() && g2.avoid.limits_active()) {
             // we are a sailboat trying to avoid fence, try a tack
             if (rover.control_mode != &rover.mode_acro) {

--- a/Rover/mode_circle.cpp
+++ b/Rover/mode_circle.cpp
@@ -90,7 +90,7 @@ bool ModeCircle::_enter()
 
     config.dir = (direction == 1) ? Direction::CCW : Direction::CW;
     config.speed = is_positive(speed) ? speed : g2.wp_nav.get_default_speed();
-    target.yaw_rad = AP::ahrs().get_yaw();
+    target.yaw_rad = AP::ahrs().get_yaw_rad();
     target.speed = 0;
 
     // record center as location (only used for reporting)
@@ -130,7 +130,7 @@ void ModeCircle::init_target_yaw_rad()
     // if no position estimate use vehicle yaw
     Vector2f curr_pos_NE;
     if (!AP::ahrs().get_relative_position_NE_origin_float(curr_pos_NE)) {
-        target.yaw_rad = AP::ahrs().get_yaw();
+        target.yaw_rad = AP::ahrs().get_yaw_rad();
         return;
     }
 
@@ -140,7 +140,7 @@ void ModeCircle::init_target_yaw_rad()
 
     // if current position is exactly at the center of the circle return vehicle yaw
     if (is_zero(dist_m)) {
-        target.yaw_rad = AP::ahrs().get_yaw();
+        target.yaw_rad = AP::ahrs().get_yaw_rad();
     } else {
         target.yaw_rad = center_to_veh.angle();
     }

--- a/Rover/sailboat.cpp
+++ b/Rover/sailboat.cpp
@@ -317,7 +317,7 @@ float Sailboat::get_VMG() const
         return speed;
     }
 
-    return (speed * cosf(wrap_PI(radians(rover.g2.wp_nav.wp_bearing_cd() * 0.01f) - rover.ahrs.get_yaw())));
+    return (speed * cosf(wrap_PI(radians(rover.g2.wp_nav.wp_bearing_cd() * 0.01f) - rover.ahrs.get_yaw_rad())));
 }
 
 // handle user initiated tack while in acro mode
@@ -328,7 +328,7 @@ void Sailboat::handle_tack_request_acro()
     }
     // set tacking heading target to the current angle relative to the true wind but on the new tack
     currently_tacking = true;
-    tack_heading_rad = wrap_2PI(rover.ahrs.get_yaw() + 2.0f * wrap_PI((rover.g2.windvane.get_true_wind_direction_rad() - rover.ahrs.get_yaw())));
+    tack_heading_rad = wrap_2PI(rover.ahrs.get_yaw_rad() + 2.0f * wrap_PI((rover.g2.windvane.get_true_wind_direction_rad() - rover.ahrs.get_yaw_rad())));
 
     tack_request_ms = AP_HAL::millis();
 }
@@ -336,7 +336,7 @@ void Sailboat::handle_tack_request_acro()
 // return target heading in radians when tacking (only used in acro)
 float Sailboat::get_tack_heading_rad()
 {
-    if (fabsf(wrap_PI(tack_heading_rad - rover.ahrs.get_yaw())) < radians(SAILBOAT_TACKING_ACCURACY_DEG) ||
+    if (fabsf(wrap_PI(tack_heading_rad - rover.ahrs.get_yaw_rad())) < radians(SAILBOAT_TACKING_ACCURACY_DEG) ||
        ((AP_HAL::millis() - tack_request_ms) > SAILBOAT_AUTO_TACKING_TIMEOUT_MS)) {
         clear_tack();
     }
@@ -482,7 +482,7 @@ float Sailboat::calc_heading(float desired_heading_cd)
     // if we are tacking we maintain the target heading until the tack completes or times out
     if (currently_tacking) {
         // check if we have reached target
-        if (fabsf(wrap_PI(tack_heading_rad - rover.ahrs.get_yaw())) <= radians(SAILBOAT_TACKING_ACCURACY_DEG)) {
+        if (fabsf(wrap_PI(tack_heading_rad - rover.ahrs.get_yaw_rad())) <= radians(SAILBOAT_TACKING_ACCURACY_DEG)) {
             clear_tack();
         } else if ((now - auto_tack_start_ms) > SAILBOAT_AUTO_TACKING_TIMEOUT_MS) {
             // tack has taken too long

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi_6DoF.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi_6DoF.cpp
@@ -20,10 +20,10 @@ void AC_AttitudeControl_Multi_6DoF::rate_controller_run() {
     // if 6DoF control, always point directly up
     // this stops horizontal drift due to error between target and true attitude
     if (lateral_enable) {
-        roll_deg = degrees(AP::ahrs().get_roll());
+        roll_deg = degrees(AP::ahrs().get_roll_rad());
     }
     if (forward_enable) {
-        pitch_deg = degrees(AP::ahrs().get_pitch());
+        pitch_deg = degrees(AP::ahrs().get_pitch_rad());
     }
     _motors.set_roll_pitch(roll_deg,pitch_deg);
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.cpp
@@ -457,7 +457,7 @@ void AC_AttitudeControl_Sub::input_euler_angle_roll_pitch_slew_yaw(float euler_r
     // Convert from centidegrees on public interface to radians
     const float euler_yaw_angle = wrap_PI(cd_to_rad(euler_yaw_angle_cd));
 
-    const float current_yaw = AP::ahrs().get_yaw();
+    const float current_yaw = AP::ahrs().get_yaw_rad();
 
     // Compute angle error
     const float yaw_error = wrap_PI(euler_yaw_angle - current_yaw);

--- a/libraries/APM_Control/AP_PitchController.cpp
+++ b/libraries/APM_Control/AP_PitchController.cpp
@@ -209,7 +209,7 @@ bool AP_PitchController::is_underspeed(const float aspeed) const
 float AP_PitchController::_get_coordination_rate_offset(const float &aspeed, bool &inverted) const
 {
     float rate_offset;
-    float bank_angle = AP::ahrs().get_roll();
+    float bank_angle = AP::ahrs().get_roll_rad();
 
     // limit bank angle between +- 80 deg if right way up
     if (fabsf(bank_angle) < radians(90))	{
@@ -228,7 +228,7 @@ float AP_PitchController::_get_coordination_rate_offset(const float &aspeed, boo
         // don't do turn coordination handling when at very high pitch angles
         rate_offset = 0;
     } else {
-        rate_offset = cosf(_ahrs.get_pitch())*fabsf(degrees((GRAVITY_MSS / MAX((aspeed * _ahrs.get_EAS2TAS()), MAX(aparm.airspeed_min, 1))) * tanf(bank_angle) * sinf(bank_angle))) * _roll_ff;
+        rate_offset = cosf(_ahrs.get_pitch_rad())*fabsf(degrees((GRAVITY_MSS / MAX((aspeed * _ahrs.get_EAS2TAS()), MAX(aparm.airspeed_min, 1))) * tanf(bank_angle) * sinf(bank_angle))) * _roll_ff;
     }
     if (inverted) {
         rate_offset = -rate_offset;

--- a/libraries/APM_Control/AP_YawController.cpp
+++ b/libraries/APM_Control/AP_YawController.cpp
@@ -206,7 +206,7 @@ int32_t AP_YawController::get_servo_out(float scaler, bool disable_integrator)
     // Calculate yaw rate required to keep up with a constant height coordinated turn
     float aspeed;
     float rate_offset;
-    float bank_angle = AP::ahrs().get_roll();
+    float bank_angle = AP::ahrs().get_roll_rad();
     // limit bank angle between +- 80 deg if right way up
     if (fabsf(bank_angle) < 1.5707964f)	{
         bank_angle = constrain_float(bank_angle,-1.3962634f,1.3962634f);

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -613,7 +613,7 @@ float AR_AttitudeControl::get_steering_out_heading(float heading_rad, float rate
 // return a desired turn-rate given a desired heading in radians
 float AR_AttitudeControl::get_turn_rate_from_heading(float heading_rad, float rate_max_rads) const
 {
-    const float yaw_error = wrap_PI(heading_rad - AP::ahrs().get_yaw());
+    const float yaw_error = wrap_PI(heading_rad - AP::ahrs().get_yaw_rad());
 
     // Calculate the desired turn rate (in radians) from the angle error (also in radians)
     float desired_rate = _steer_angle_p.get_p(yaw_error);
@@ -884,7 +884,7 @@ float AR_AttitudeControl::get_throttle_out_from_pitch(float desired_pitch, float
     }
 
     // initialise output to feed forward from current pitch angle
-    const float pitch_rad = AP::ahrs().get_pitch();
+    const float pitch_rad = AP::ahrs().get_pitch_rad();
     float output = sinf(pitch_rad) * _pitch_to_throttle_ff;
 
     // add regular PID control
@@ -940,7 +940,7 @@ float AR_AttitudeControl::get_sail_out_from_heel(float desired_heel, float dt)
     }
     _heel_controller_last_ms = now;
 
-    _sailboat_heel_pid.update_all(desired_heel, fabsf(AP::ahrs().get_roll()), dt);
+    _sailboat_heel_pid.update_all(desired_heel, fabsf(AP::ahrs().get_roll_rad()), dt);
 
     // get feed-forward
     const float ff = _sailboat_heel_pid.get_ff();

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -573,9 +573,9 @@ public:
      */
 
     // roll/pitch/yaw euler angles, all in radians
-    float get_roll() const { return roll; }
-    float get_pitch() const { return pitch; }
-    float get_yaw() const { return yaw; }
+    float get_roll_rad() const { return roll; }
+    float get_pitch_rad() const { return pitch; }
+    float get_yaw_rad() const { return yaw; }
 
     // roll/pitch/yaw euler angles, all in degrees
     float get_roll_deg() const { return rpy_deg[0]; }

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -572,6 +572,14 @@ public:
      * Attitude-related public methods and attributes:
      */
 
+#if AP_SCRIPTING_ENABLED
+    // deprecated functions for accessing rpy.  Do not use, these will
+    // be removed.
+    float get_roll() const { return roll; }
+    float get_pitch() const { return pitch; }
+    float get_yaw() const { return yaw; }
+#endif  // AP_SCRIPTING_ENABLED
+
     // roll/pitch/yaw euler angles, all in radians
     float get_roll_rad() const { return roll; }
     float get_pitch_rad() const { return pitch; }

--- a/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.cpp
+++ b/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.cpp
@@ -92,9 +92,9 @@ void loop(void)
         hal.console->printf(
                 "r:%4.1f  p:%4.1f y:%4.1f "
                     "drift=(%5.1f %5.1f %5.1f) hdg=%.1f rate=%.1f\n",
-                (double)degrees(ahrs.get_roll()),
-                (double)degrees(ahrs.get_pitch()),
-                (double)degrees(ahrs.get_yaw()),
+                (double)ahrs.get_roll_deg(),
+                (double)ahrs.get_pitch_deg(),
+                (double)ahrs.get_yaw_deg(),
                 (double)degrees(drift.x),
                 (double)degrees(drift.y),
                 (double)degrees(drift.z),

--- a/libraries/AP_Camera/AP_Camera_Backend.cpp
+++ b/libraries/AP_Camera/AP_Camera_Backend.cpp
@@ -316,7 +316,7 @@ void AP_Camera_Backend::send_camera_fov_status(mavlink_channel_t chan) const
 
     // calculate attitude quaternion in earth frame using AHRS yaw
     Quaternion quat_ef;
-    quat_ef.from_euler(0, 0, AP::ahrs().get_yaw());
+    quat_ef.from_euler(0, 0, AP::ahrs().get_yaw_rad());
     quat_ef *= quat;
 
     // send camera fov status message only if the last calculated values aren't stale

--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -538,7 +538,7 @@ bool Compass::mag_cal_fixed_yaw(float yaw_deg, uint8_t compass_mask,
     field = R * field;
 
     Matrix3f dcm;
-    dcm.from_euler(AP::ahrs().get_roll(), AP::ahrs().get_pitch(), radians(yaw_deg));
+    dcm.from_euler(AP::ahrs().get_roll_rad(), AP::ahrs().get_pitch_rad(), radians(yaw_deg));
 
     // Rotate into body frame using provided yaw
     field = dcm.transposed() * field;

--- a/libraries/AP_Compass/Compass_learn.cpp
+++ b/libraries/AP_Compass/Compass_learn.cpp
@@ -43,7 +43,7 @@ void CompassLearn::update(void)
         // no GSF available
         return;
     }
-    if (degrees(fabsf(ahrs.get_pitch())) > 50) {
+    if (degrees(fabsf(ahrs.get_pitch_rad())) > 50) {
         // we don't want to be too close to nose up, or yaw gets
         // problematic. Tailsitters need to wait till they are in
         // forward flight

--- a/libraries/AP_DroneCAN/AP_DroneCAN.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.cpp
@@ -1060,7 +1060,7 @@ void AP_DroneCAN::notify_state_send()
 #endif // HAL_BUILD_AP_PERIPH
 
     msg.aux_data_type = ARDUPILOT_INDICATION_NOTIFYSTATE_VEHICLE_YAW_EARTH_CENTIDEGREES;
-    uint16_t yaw_cd = (uint16_t)(360.0f - degrees(AP::ahrs().get_yaw()))*100.0f;
+    uint16_t yaw_cd = (uint16_t)(360.0f - degrees(AP::ahrs().get_yaw_rad()))*100.0f;
     const uint8_t *data = (uint8_t *)&yaw_cd;
     for (uint8_t i=0; i<2; i++) {
         msg.aux_data.data[i] = data[i];

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1375,7 +1375,7 @@ bool AP_InertialSensor::_calculate_trim(const Vector3f &accel_sample, Vector3f &
     if (view != nullptr) {
         // Use pitch to guess which axis the user is trying to trim
         // 5 deg buffer to favor normal AHRS and avoid floating point funny business
-        if (fabsf(view->pitch) < (fabsf(AP::ahrs().get_pitch())+radians(5)) ) {
+        if (fabsf(view->pitch) < (fabsf(AP::ahrs().get_pitch_rad())+radians(5)) ) {
             // user is trying to calibrate view
             rotation = view->get_rotation();
             if (!is_zero(view->get_pitch_trim())) {

--- a/libraries/AP_L1_Control/AP_L1_Control.cpp
+++ b/libraries/AP_L1_Control/AP_L1_Control.cpp
@@ -56,9 +56,9 @@ const AP_Param::GroupInfo AP_L1_Control::var_info[] = {
 float AP_L1_Control::get_yaw() const
 {
     if (_reverse) {
-        return wrap_PI(M_PI + _ahrs.get_yaw());
+        return wrap_PI(M_PI + _ahrs.get_yaw_rad());
     }
-    return _ahrs.get_yaw();
+    return _ahrs.get_yaw_rad();
 }
 
 /*
@@ -88,7 +88,7 @@ int32_t AP_L1_Control::nav_roll_cd(void) const
 		Made changes to avoid zero division as proposed by Andrew Tridgell: https://github.com/ArduPilot/ardupilot/pull/24331#discussion_r1267798397		 
 	*/
 	float pitchLimL1 = radians(60); // Suggestion: constraint may be modified to pitch limits if their absolute values are less than 90 degree and more than 60 degrees.
-	float pitchL1 = constrain_float(_ahrs.get_pitch(),-pitchLimL1,pitchLimL1);
+	float pitchL1 = constrain_float(_ahrs.get_pitch_rad(),-pitchLimL1,pitchLimL1);
     ret = degrees(atanf(_latAccDem * (1.0f/(GRAVITY_MSS * cosf(pitchL1))))) * 100.0f;
     ret = constrain_float(ret, -9000, 9000);
     return ret;
@@ -399,7 +399,7 @@ void AP_L1_Control::update_loiter(const Location &center_WP, float radius, int8_
         A_air_unit = A_air.normalized();
     } else {
         if (_groundspeed_vector.length() < 0.1f) {
-            A_air_unit = Vector2f(cosf(_ahrs.get_yaw()), sinf(_ahrs.get_yaw()));
+            A_air_unit = Vector2f(cosf(_ahrs.get_yaw_rad()), sinf(_ahrs.get_yaw_rad()));
         } else {
             A_air_unit = _groundspeed_vector.normalized();
         }
@@ -533,7 +533,7 @@ void AP_L1_Control::update_level_flight(void)
 {
     // copy to _target_bearing_cd and _nav_bearing
     _target_bearing_cd = _ahrs.yaw_sensor;
-    _nav_bearing = _ahrs.get_yaw();
+    _nav_bearing = _ahrs.get_yaw_rad();
     _bearing_error = 0;
     _crosstrack_error = 0;
 

--- a/libraries/AP_Landing/AP_Landing_Deepstall.cpp
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.cpp
@@ -646,7 +646,7 @@ float AP_Landing_Deepstall::update_steering()
             L1_xtrack_i = constrain_float(L1_xtrack_i, -0.5f, 0.5f);
             nu1 += L1_xtrack_i;
         }
-        desired_change = wrap_PI(radians(target_heading_deg) + nu1 - landing.ahrs.get_yaw()) / time_constant;
+        desired_change = wrap_PI(radians(target_heading_deg) + nu1 - landing.ahrs.get_yaw_rad()) / time_constant;
     }
 
     float yaw_rate = landing.ahrs.get_gyro().z;

--- a/libraries/AP_Module/AP_Module.cpp
+++ b/libraries/AP_Module/AP_Module.cpp
@@ -167,9 +167,9 @@ void AP_Module::call_hook_AHRS_update(const AP_AHRS &ahrs)
     state.quat[2] = q[2];
     state.quat[3] = q[3];
 
-    state.eulers[0] = ahrs.get_roll();
-    state.eulers[1] = ahrs.get_pitch();
-    state.eulers[2] = ahrs.get_yaw();
+    state.eulers[0] = ahrs.get_roll_rad();
+    state.eulers[1] = ahrs.get_pitch_rad();
+    state.eulers[2] = ahrs.get_yaw_rad();
 
     Location loc;
     if (ahrs.get_origin(loc)) {

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -416,7 +416,7 @@ bool AP_Mount_Backend::handle_global_position_int(uint8_t msg_sysid, const mavli
 void AP_Mount_Backend::write_log(uint64_t timestamp_us)
 {
     // return immediately if no yaw estimate
-    float ahrs_yaw = AP::ahrs().get_yaw();
+    float ahrs_yaw = AP::ahrs().get_yaw_rad();
     if (isnan(ahrs_yaw)) {
         return;
     }
@@ -535,7 +535,7 @@ void AP_Mount_Backend::calculate_poi()
         // iteratively move test_loc forward until its alt-above-sea-level is below terrain-alt-above-sea-level
         const float dist_increment_m = MAX(terrain->get_grid_spacing(), 10);
         const float mount_pitch_deg = degrees(quat.get_euler_pitch());
-        const float mount_yaw_ef_deg = wrap_180(degrees(quat.get_euler_yaw()) + degrees(ahrs.get_yaw()));
+        const float mount_yaw_ef_deg = wrap_180(degrees(quat.get_euler_yaw()) + degrees(ahrs.get_yaw_rad()));
         float total_dist_m = 0;
         bool get_terrain_alt_success = true;
         float prev_terrain_amsl_m = terrain_amsl_m;
@@ -745,7 +745,7 @@ float AP_Mount_Backend::MountTarget::get_bf_yaw() const
 {
     if (yaw_is_ef) {
         // convert to body-frame
-        return wrap_PI(yaw - AP::ahrs().get_yaw());
+        return wrap_PI(yaw - AP::ahrs().get_yaw_rad());
     }
 
     // target is already body-frame
@@ -761,7 +761,7 @@ float AP_Mount_Backend::MountTarget::get_ef_yaw() const
     }
 
     // convert to earth-frame
-    return wrap_PI(yaw + AP::ahrs().get_yaw());
+    return wrap_PI(yaw + AP::ahrs().get_yaw_rad());
 }
 
 // sets roll, pitch, yaw and yaw_is_ef

--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -173,7 +173,7 @@ void AP_Mount_Servo::update_angle_outputs(const MountTarget& angle_rad)
     }
 
     // retrieve lean angles from ahrs
-    Vector2f ahrs_angle_rad = {ahrs.get_roll(), ahrs.get_pitch()};
+    Vector2f ahrs_angle_rad = {ahrs.get_roll_rad(), ahrs.get_pitch_rad()};
 
     // rotate ahrs roll and pitch angles to gimbal yaw
     if (has_pan_control()) {
@@ -187,7 +187,7 @@ void AP_Mount_Servo::update_angle_outputs(const MountTarget& angle_rad)
     // lead filter
     const Vector3f &gyro = ahrs.get_gyro();
 
-    if (!is_zero(_params.roll_stb_lead) && fabsf(ahrs.get_pitch()) < M_PI/3.0f) {
+    if (!is_zero(_params.roll_stb_lead) && fabsf(ahrs.get_pitch_rad()) < M_PI/3.0f) {
         // Compute rate of change of euler roll angle
         float roll_rate = gyro.x + (ahrs.sin_pitch() / ahrs.cos_pitch()) * (gyro.y * ahrs.sin_roll() + gyro.z * ahrs.cos_roll());
         _angle_bf_output_rad.x -= roll_rate * _params.roll_stb_lead;

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -719,7 +719,7 @@ void AP_Mount_Siyi::send_target_angles(float pitch_rad, float yaw_rad, bool yaw_
     const float pitch_rate_scalar = constrain_float(100.0 * pitch_err_rad * AP_MOUNT_SIYI_PITCH_P / AP_MOUNT_SIYI_RATE_MAX_RADS, -100, 100);
 
     // convert yaw angle to body-frame
-    float yaw_bf_rad = yaw_is_ef ? wrap_PI(yaw_rad - AP::ahrs().get_yaw()) : yaw_rad;
+    float yaw_bf_rad = yaw_is_ef ? wrap_PI(yaw_rad - AP::ahrs().get_yaw_rad()) : yaw_rad;
 
     // enforce body-frame yaw angle limits.  If beyond limits always use body-frame control
     const float yaw_bf_min = radians(_params.yaw_angle_min);
@@ -1270,9 +1270,9 @@ void AP_Mount_Siyi::send_attitude_position(void)
     const uint32_t now_ms = AP_HAL::millis();
 
     attitude.time_boot_ms = now_ms;
-    attitude.roll = ahrs.get_roll();
-    attitude.pitch = ahrs.get_pitch();
-    attitude.yaw = ahrs.get_yaw();
+    attitude.roll = ahrs.get_roll_rad();
+    attitude.pitch = ahrs.get_pitch_rad();
+    attitude.yaw = ahrs.get_yaw_rad();
     attitude.rollspeed = gyro.x;
     attitude.pitchspeed = gyro.y;
     attitude.yawspeed = gyro.z;

--- a/libraries/AP_Mount/AP_Mount_Topotek.cpp
+++ b/libraries/AP_Mount/AP_Mount_Topotek.cpp
@@ -941,7 +941,7 @@ bool AP_Mount_Topotek::send_location_info()
 
     // prepare and send vehicle yaw
     // sample command: #tpUD5wAZI359.9, similar format to $GPRMC
-    const float veh_yaw_deg = wrap_360(degrees(AP::ahrs().get_yaw()));
+    const float veh_yaw_deg = wrap_360(degrees(AP::ahrs().get_yaw_rad()));
     uint8_t databuff_azimuth[6];
     hal.util->snprintf((char*)databuff_azimuth, ARRAY_SIZE(databuff_azimuth), "%05.1f", veh_yaw_deg);
     if (!send_variablelen_packet(HeaderType::VARIABLE_LEN, AddressByte::SYSTEM_AND_IMAGE, AP_MOUNT_TOPOTEK_ID3CHAR_SET_AZIMUTH, true, (uint8_t*)databuff_azimuth, ARRAY_SIZE(databuff_azimuth)-1)) {

--- a/libraries/AP_Mount/AP_Mount_Viewpro.cpp
+++ b/libraries/AP_Mount/AP_Mount_Viewpro.cpp
@@ -533,7 +533,7 @@ bool AP_Mount_Viewpro::send_target_angles(float pitch_rad, float yaw_rad, bool y
     }
 
     // convert yaw angle to body-frame
-    float yaw_bf_rad = yaw_is_ef ? wrap_PI(yaw_rad - AP::ahrs().get_yaw()) : yaw_rad;
+    float yaw_bf_rad = yaw_is_ef ? wrap_PI(yaw_rad - AP::ahrs().get_yaw_rad()) : yaw_rad;
 
     // enforce body-frame yaw angle limits.  If beyond limits always use body-frame control
     const float yaw_bf_min = radians(_params.yaw_angle_min);
@@ -684,7 +684,7 @@ bool AP_Mount_Viewpro::send_m_ahrs()
     uint16_t gps_vdop = AP::gps().get_vdop();
 
     // get vehicle yaw in the range 0 to 360
-    const uint16_t veh_yaw_deg = wrap_360(degrees(AP::ahrs().get_yaw()));
+    const uint16_t veh_yaw_deg = wrap_360(degrees(AP::ahrs().get_yaw_rad()));
 
     // fill in packet
     const M_AHRSPacket mahrs_packet {
@@ -692,8 +692,8 @@ bool AP_Mount_Viewpro::send_m_ahrs()
             frame_id: FrameId::M_AHRS,
             data_type: 0x07,                        // Bit0: Attitude, Bit1: GPS, Bit2 Gyro
             unused2to8 : {0, 0, 0, 0, 0, 0, 0},
-            roll_be: htobe16(degrees(AP::ahrs().get_roll()) * AP_MOUNT_VIEWPRO_DEG_TO_OUTPUT),      // vehicle roll angle.  1bit=360deg/65536
-            pitch_be: htobe16(-degrees(AP::ahrs().get_pitch()) * AP_MOUNT_VIEWPRO_DEG_TO_OUTPUT),   // vehicle pitch angle.  1bit=360deg/65536
+            roll_be: htobe16(degrees(AP::ahrs().get_roll_rad()) * AP_MOUNT_VIEWPRO_DEG_TO_OUTPUT),      // vehicle roll angle.  1bit=360deg/65536
+            pitch_be: htobe16(-degrees(AP::ahrs().get_pitch_rad()) * AP_MOUNT_VIEWPRO_DEG_TO_OUTPUT),   // vehicle pitch angle.  1bit=360deg/65536
             yaw_be: htobe16(veh_yaw_deg * AP_MOUNT_VIEWPRO_DEG_TO_OUTPUT),                          // vehicle yaw angle.  1bit=360deg/65536
             date_be: htobe16(date),                 // bit0~6:year, bit7~10:month, bit11~15:day
             seconds_utc: {uint8_t((second_hundredths & 0xFF0000ULL) >> 16), // seconds * 100 MSB.  1bit = 0.01sec

--- a/libraries/AP_Mount/AP_Mount_XFRobot.cpp
+++ b/libraries/AP_Mount/AP_Mount_XFRobot.cpp
@@ -455,9 +455,9 @@ void AP_Mount_XFRobot::send_target_angles(const MountTarget& angle_target_rad)
     // byte 12~13: absolute roll angle of vehicle (int16, -18000 ~ +18000)
     // byte 14~15: absolute pitch angle of vehicle (int16, -9000 ~ +9000)
     // byte 16~17: absolute yaw angle of vehicle (uint16, 0 ~ 36000)
-    set_attitude_packet.content.main.roll_abs = htole16(constrain_int16(degrees(AP::ahrs().get_roll()) * 100, -18000, 18000));
-    set_attitude_packet.content.main.pitch_abs = htole16(constrain_int16(degrees(AP::ahrs().get_pitch()) * 100, -9000, 9000));
-    set_attitude_packet.content.main.yaw_abs = htole16(constrain_int16(degrees(wrap_PI(AP::ahrs().get_yaw())) * 100, -18000, 18000));
+    set_attitude_packet.content.main.roll_abs = htole16(constrain_int16(degrees(AP::ahrs().get_roll_rad()) * 100, -18000, 18000));
+    set_attitude_packet.content.main.pitch_abs = htole16(constrain_int16(degrees(AP::ahrs().get_pitch_rad()) * 100, -9000, 9000));
+    set_attitude_packet.content.main.yaw_abs = htole16(constrain_int16(degrees(wrap_PI(AP::ahrs().get_yaw_rad())) * 100, -18000, 18000));
 
     // byte 18~19: North acceleration of vehicle (int16, cm/s/s)
     // byte 20~21: East acceleration of vehicle (int16, cm/s/s)

--- a/libraries/AP_Mount/AP_Mount_Xacti.cpp
+++ b/libraries/AP_Mount/AP_Mount_Xacti.cpp
@@ -409,7 +409,7 @@ void AP_Mount_Xacti::send_target_rates(float pitch_rads, float yaw_rads, bool ya
 void AP_Mount_Xacti::send_target_angles(float pitch_rad, float yaw_rad, bool yaw_is_ef)
 {
     // convert yaw to body frame
-    const float yaw_bf_rad = yaw_is_ef ? wrap_PI(yaw_rad - AP::ahrs().get_yaw()) : yaw_rad;
+    const float yaw_bf_rad = yaw_is_ef ? wrap_PI(yaw_rad - AP::ahrs().get_yaw_rad()) : yaw_rad;
 
     // send angle target to gimbal
     send_gimbal_control(2, degrees(pitch_rad) * 100, degrees(yaw_bf_rad) * 100);

--- a/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp
+++ b/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp
@@ -251,9 +251,9 @@ void AP_NMEA_Output::update()
 #if AP_AHRS_ENABLED
     if ((_message_enable_bitmask.get() & static_cast<int16_t>(Enabled_Messages::PASHR)) != 0) {
         // get roll, pitch, yaw
-        const float roll_deg = wrap_180(degrees(ahrs.get_roll()));
-        const float pitch_deg = wrap_180(degrees(ahrs.get_pitch()));
-        const float yaw_deg = wrap_360(degrees(ahrs.get_yaw()));
+        const float roll_deg = wrap_180(degrees(ahrs.get_roll_rad()));
+        const float pitch_deg = wrap_180(degrees(ahrs.get_pitch_rad()));
+        const float yaw_deg = wrap_360(degrees(ahrs.get_yaw_rad()));
         const float heave_m = 0; // instantaneous heave in meters
         const float roll_deg_accuracy = 0; // stddev of roll_deg;
         const float pitch_deg_accuracy = 0; // stddev of pitch_deg;

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -1692,7 +1692,7 @@ void AP_OSD_Screen::draw_gspeed(uint8_t x, uint8_t y)
     float angle = 0;
     const float length = v.length();
     if (length > 1.0f) {
-        angle = atan2f(v.y, v.x) - ahrs.get_yaw();
+        angle = atan2f(v.y, v.x) - ahrs.get_yaw_rad();
     }
     draw_speed(x + 1, y, angle, length);
 }
@@ -1947,7 +1947,7 @@ void AP_OSD_Screen::draw_wind(uint8_t x, uint8_t y)
         if (check_option(AP_OSD::OPTION_INVERTED_WIND)) {
             angle = M_PI;
         }
-        angle = angle + atan2f(v.y, v.x) - ahrs.get_yaw();
+        angle = angle + atan2f(v.y, v.x) - ahrs.get_yaw_rad();
     } 
     draw_speed(x + 1, y, angle, length);
 

--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
@@ -1033,9 +1033,9 @@ void AP_CRSF_Telem::calc_attitude()
 
     const int16_t INT_PI = 31415;
     // units are radians * 10000
-    _telem.bcast.attitude.roll_angle = htobe16(constrain_int16(roundf(wrap_PI(_ahrs.get_roll()) * 10000.0f), -INT_PI, INT_PI));
-    _telem.bcast.attitude.pitch_angle = htobe16(constrain_int16(roundf(wrap_PI(_ahrs.get_pitch()) * 10000.0f), -INT_PI, INT_PI));
-    _telem.bcast.attitude.yaw_angle = htobe16(constrain_int16(roundf(wrap_PI(_ahrs.get_yaw()) * 10000.0f), -INT_PI, INT_PI));
+    _telem.bcast.attitude.roll_angle = htobe16(constrain_int16(roundf(wrap_PI(_ahrs.get_roll_rad()) * 10000.0f), -INT_PI, INT_PI));
+    _telem.bcast.attitude.pitch_angle = htobe16(constrain_int16(roundf(wrap_PI(_ahrs.get_pitch_rad()) * 10000.0f), -INT_PI, INT_PI));
+    _telem.bcast.attitude.yaw_angle = htobe16(constrain_int16(roundf(wrap_PI(_ahrs.get_yaw_rad()) * 10000.0f), -INT_PI, INT_PI));
 
     _telem_size = sizeof(AP_CRSF_Telem::AttitudeFrame);
     _telem_type = AP_RCProtocol_CRSF::CRSF_FRAMETYPE_ATTITUDE;

--- a/libraries/AP_Scripting/applets/Aerobatics/FixedWing/plane_aerobatics.lua
+++ b/libraries/AP_Scripting/applets/Aerobatics/FixedWing/plane_aerobatics.lua
@@ -1703,7 +1703,7 @@ function rudder_over(direction, min_speed)
 
       -- use user set throttle for achieving the stall
       local throttle = AEROM_STALL_THR:get()
-      local pitch_deg = math.deg(ahrs:get_pitch())
+      local pitch_deg = math.deg(ahrs:get_pitch_rad())
       if reached_speed and not kick_started and math.abs(math.deg(ahrs_gyro:z())) > ACRO_YAW_RATE:get()/3 then
          kick_started = true
       end
@@ -1824,7 +1824,7 @@ function takeoff_controller(distance, thr_slew)
    local start_time = 0
    local start_pos = nil
    local all_done = false
-   local initial_yaw_deg = math.deg(ahrs:get_yaw())
+   local initial_yaw_deg = math.deg(ahrs:get_yaw_rad())
    local yaw_correction_tconst = 1.0
    gcs:send_text(MAV_SEVERITY.INFO,string.format("Takeoff init"))
 
@@ -1845,7 +1845,7 @@ function takeoff_controller(distance, thr_slew)
       end
       local throttle = constrain(thr_slew * (now - start_time), 0, 100)
 
-      local yaw_deg = math.deg(ahrs:get_yaw())
+      local yaw_deg = math.deg(ahrs:get_yaw_rad())
       local yaw_err_deg = wrap_180(yaw_deg - initial_yaw_deg)
       local targ_yaw_rate = -yaw_err_deg / yaw_correction_tconst
 

--- a/libraries/AP_Scripting/applets/RockBlock.lua
+++ b/libraries/AP_Scripting/applets/RockBlock.lua
@@ -825,7 +825,7 @@ function HLSatcom()
             hl2.failure_flags = hl2.failure_flags + 256 -- HL_FAILURE_FLAG_RC_RECEIVER
         end
 
-        hl2.heading = math.floor(wrap_360(math.deg(ahrs:get_yaw())) / 2)
+        hl2.heading = math.floor(wrap_360(math.deg(ahrs:get_yaw_rad())) / 2)
         hl2.throttle = math.floor(gcs:get_hud_throttle())
         if ahrs:airspeed_estimate() ~= nil then
             hl2.airspeed = math.abs(math.floor(ahrs:airspeed_estimate() * 5))

--- a/libraries/AP_Scripting/applets/WebExamples/test.shtml
+++ b/libraries/AP_Scripting/applets/WebExamples/test.shtml
@@ -7,9 +7,9 @@
     <table>
       <tr><th>Roll</th><th>Pitch</th><th>Yaw</th></tr>
       <tr>
-      <td><?lua return tostring(math.deg(ahrs:get_roll()))?></td>
-      <td><?lstr math.deg(ahrs:get_pitch())?></td>
-      <td><?lstr math.deg(ahrs:get_yaw())?></td>
+      <td><?lua return tostring(math.deg(ahrs:get_roll_rad()))?></td>
+      <td><?lstr math.deg(ahrs:get_pitch_rad())?></td>
+      <td><?lstr math.deg(ahrs:get_yaw_rad())?></td>
       </tr>
     </table>
   </body>

--- a/libraries/AP_Scripting/applets/copter-deadreckon-home.lua
+++ b/libraries/AP_Scripting/applets/copter-deadreckon-home.lua
@@ -317,7 +317,7 @@ function update()
       -- change to Guided_NoGPS and initialise stage2
       if (vehicle:set_mode(copter_guided_nogps_mode)) then
         flight_stage = 2
-        target_yaw = math.deg(ahrs:get_yaw())
+        target_yaw = math.deg(ahrs:get_yaw_rad())
         stage2_start_time_ms = now_ms
       else
         -- warn user of unexpected failure

--- a/libraries/AP_Scripting/applets/mount-poi.lua
+++ b/libraries/AP_Scripting/applets/mount-poi.lua
@@ -215,7 +215,7 @@ function update()
 
   -- get gimbal mount's pitch and yaw
   local mount_pitch_deg = pitch_deg
-  local mount_yaw_ef_deg = wrap_180(yaw_bf_deg + math.deg(ahrs:get_yaw()))
+  local mount_yaw_ef_deg = wrap_180(yaw_bf_deg + math.deg(ahrs:get_yaw_rad()))
   local dist_increment_m = TERRAIN_SPACING:get()
 
   -- initialise total distance test_loc has moved

--- a/libraries/AP_Scripting/applets/net_webserver.md
+++ b/libraries/AP_Scripting/applets/net_webserver.md
@@ -49,9 +49,9 @@ files for files with a filename of *.shtml. Here is an example:
     <table>
       <tr><th>Roll</th><th>Pitch</th><th>Yaw</th></tr>
       <tr>
-      <td><?lua return tostring(math.deg(ahrs:get_roll()))?></td>
-      <td><?lstr math.deg(ahrs:get_pitch())?></td>
-      <td><?lstr math.deg(ahrs:get_yaw())?></td>
+      <td><?lua return tostring(math.deg(ahrs:get_roll_rad()))?></td>
+      <td><?lstr math.deg(ahrs:get_pitch_rad())?></td>
+      <td><?lstr math.deg(ahrs:get_yaw_rad())?></td>
       </tr>
     </table>
   </body>

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -3785,15 +3785,30 @@ function ahrs:get_position() end
 
 -- Returns the current vehicle euler yaw angle in radians.
 ---@return number -- yaw angle in radians.
+---@deprecated -- get_yaw_rad
 function ahrs:get_yaw() end
 
 -- Returns the current vehicle euler pitch angle in radians.
 ---@return number -- pitch angle in radians.
+---@deprecated -- get_pitch_rad
 function ahrs:get_pitch() end
 
 -- Returns the current vehicle euler roll angle in radians.
 ---@return number -- roll angle in radians
+---@deprecated -- get_roll_rad
 function ahrs:get_roll() end
+
+-- Returns the current vehicle euler yaw angle in radians.
+---@return number -- yaw angle in radians (0 to 2*Pi).
+function ahrs:get_yaw_rad() end
+
+-- Returns the current vehicle euler pitch angle in radians.
+---@return number -- pitch angle in radians.
+function ahrs:get_pitch_rad() end
+
+-- Returns the current vehicle euler roll angle in radians.
+---@return number -- roll angle in radians
+function ahrs:get_roll_rad() end
 
 -- desc
 AC_AttitudeControl = {}

--- a/libraries/AP_Scripting/drivers/mount-djirs2-driver.lua
+++ b/libraries/AP_Scripting/drivers/mount-djirs2-driver.lua
@@ -746,7 +746,7 @@ function update()
     if roll_deg and pitch_deg and yaw_deg then
       if yaw_is_ef then
         -- convert to body-frame
-        yaw_deg = wrap_180(yaw_deg - math.deg(ahrs:get_yaw()))
+        yaw_deg = wrap_180(yaw_deg - math.deg(ahrs:get_yaw_rad()))
       end
       send_target_angles(roll_deg, pitch_deg, yaw_deg, 1)
       return update, UPDATE_INTERVAL_MS

--- a/libraries/AP_Scripting/drivers/mount-viewpro-driver.lua
+++ b/libraries/AP_Scripting/drivers/mount-viewpro-driver.lua
@@ -817,7 +817,7 @@ function update()
     local roll_deg, pitch_deg, yaw_deg, yaw_is_ef = mount:get_angle_target(MOUNT_INSTANCE)
     if roll_deg and pitch_deg and yaw_deg then
       if yaw_is_ef then
-        yaw_deg = wrap_180(yaw_deg - math.deg(ahrs:get_yaw()))
+        yaw_deg = wrap_180(yaw_deg - math.deg(ahrs:get_yaw_rad()))
       end
       send_target_angles(pitch_deg, yaw_deg)
       return update, UPDATE_INTERVAL_MS

--- a/libraries/AP_Scripting/examples/6DoF_roll_pitch.lua
+++ b/libraries/AP_Scripting/examples/6DoF_roll_pitch.lua
@@ -31,8 +31,8 @@ function update() -- this is the loop which periodically runs
   if not motors_spinning and current_motors_spinning then
     -- Just armed or removed E-stop
     -- set offsets to current attitude
-    local roll = math.deg(ahrs:get_roll())
-    local pitch = math.deg(ahrs:get_pitch())
+    local roll = math.deg(ahrs:get_roll_rad())
+    local pitch = math.deg(ahrs:get_pitch_rad())
     attitude_control:set_offset_roll_pitch(roll,pitch)
     gcs:send_text(0, string.format("Set Offsets Roll: %0.1f, Pitch: %0.1f",roll,pitch))
 

--- a/libraries/AP_Scripting/examples/Flip_Mode.lua
+++ b/libraries/AP_Scripting/examples/Flip_Mode.lua
@@ -119,9 +119,9 @@ local function init()
     end
 
     -- Record start attitude to be used in recovery stage
-    start_attitude.roll = math.deg(ahrs:get_roll())
-    start_attitude.pitch = math.deg(ahrs:get_pitch())
-    start_attitude.yaw = math.deg(ahrs:get_yaw())
+    start_attitude.roll = math.deg(ahrs:get_roll_rad())
+    start_attitude.pitch = math.deg(ahrs:get_pitch_rad())
+    start_attitude.yaw = math.deg(ahrs:get_yaw_rad())
 
 end
 
@@ -139,8 +139,8 @@ local function run()
         return
     end
 
-    local roll_deg = math.deg(ahrs:get_roll())
-    local pitch_deg = math.deg(ahrs:get_pitch())
+    local roll_deg = math.deg(ahrs:get_roll_rad())
+    local pitch_deg = math.deg(ahrs:get_pitch_rad())
 
     if state == FLIP_STATE.RECOVER then
         -- Target original attitude with 0 climb rate

--- a/libraries/AP_Scripting/examples/LED_matrix_text.lua
+++ b/libraries/AP_Scripting/examples/LED_matrix_text.lua
@@ -242,7 +242,7 @@ function update_LEDs()
     -- start with the stuff off the right edge of the display
     offset = 8
 
-    text_string = tostring(math.floor(math.deg(ahrs:get_yaw())))
+    text_string = tostring(math.floor(math.deg(ahrs:get_yaw_rad())))
   end
 
   return update_LEDs, 100

--- a/libraries/AP_Scripting/examples/LED_roll.lua
+++ b/libraries/AP_Scripting/examples/LED_roll.lua
@@ -72,7 +72,7 @@ end
 We will set the colour of the LEDs based on roll of the aircraft
 --]]
 function update_LEDs()
-  local roll = constrain(ahrs:get_roll(), math.rad(-60), math.rad(60))
+  local roll = constrain(ahrs:get_roll_rad(), math.rad(-60), math.rad(60))
 
   for led = 0, num_leds-1 do
     local v  = constrain(0.5 + 0.5 * math.sin(roll * (led - num_leds/2) / (num_leds/2)), 0, 1)

--- a/libraries/AP_Scripting/examples/MAVLinkHL.lua
+++ b/libraries/AP_Scripting/examples/MAVLinkHL.lua
@@ -480,7 +480,7 @@ function HLSatcom()
             hl2.failure_flags = hl2.failure_flags + 256 -- HL_FAILURE_FLAG_RC_RECEIVER
         end
 
-        hl2.heading = math.floor(wrap_360(math.deg(ahrs:get_yaw())) / 2)
+        hl2.heading = math.floor(wrap_360(math.deg(ahrs:get_yaw_rad())) / 2)
         hl2.throttle = math.floor(gcs:get_hud_throttle())
         if ahrs:airspeed_estimate() ~= nil then
             hl2.airspeed = math.abs(math.floor(ahrs:airspeed_estimate() * 5))

--- a/libraries/AP_Scripting/examples/ahrs-print-angle-and-rates.lua
+++ b/libraries/AP_Scripting/examples/ahrs-print-angle-and-rates.lua
@@ -1,9 +1,9 @@
 -- This script displays the vehicle lean angles and rotation rates at 1hz
 
 function update() -- this is the loop which periodically runs
-  roll = math.deg(ahrs:get_roll())
-  pitch = math.deg(ahrs:get_pitch())
-  yaw = math.deg(ahrs:get_yaw())
+  roll = math.deg(ahrs:get_roll_rad())
+  pitch = math.deg(ahrs:get_pitch_rad())
+  yaw = math.deg(ahrs:get_yaw_rad())
   rates = ahrs:get_gyro()
   if rates then
     roll_rate = math.deg(rates:x())

--- a/libraries/AP_Scripting/examples/copter-fast-descent.lua
+++ b/libraries/AP_Scripting/examples/copter-fast-descent.lua
@@ -106,15 +106,15 @@ function update()
       circle_radius = 0           -- reset circle radius to zero
       if yaw_behave:get() == 0 then
         -- yaw does not move so reset starting angle to current heading
-        circle_angle_rad = ahrs:get_yaw()
+        circle_angle_rad = ahrs:get_yaw_rad()
       else
         -- yaw points towards center so start 180deg behind vehicle
-        circle_angle_rad = ahrs:get_yaw() + math.pi
+        circle_angle_rad = ahrs:get_yaw_rad() + math.pi
         if (circle_angle_rad >= (math.pi * 2)) then
           circle_angle_rad = circle_angle_rad - (math.pi * 2)
         end
       end
-      target_yaw_deg = math.deg(ahrs:get_yaw()) -- target heading will be kept at original heading
+      target_yaw_deg = math.deg(ahrs:get_yaw_rad()) -- target heading will be kept at original heading
       target_alt_D = circle_center_pos:z() -- initialise target alt using current position (Note: down is positive)
       speed_xy = 0
       speed_z = 0

--- a/libraries/AP_Scripting/examples/copter-fly-vertical-circle.lua
+++ b/libraries/AP_Scripting/examples/copter-fly-vertical-circle.lua
@@ -27,7 +27,7 @@ function update()
     if pwm6 and pwm6 > 1800 then    -- check if RC6 input has moved high
       if (stage == 0) then          -- change to guided mode
         if (vehicle:set_mode(copter_guided_mode_num)) then  -- change to Guided mode
-          local yaw_rad = ahrs:get_yaw()
+          local yaw_rad = ahrs:get_yaw_rad()
           yaw_cos = math.cos(yaw_rad)
           yaw_sin = math.sin(yaw_rad)
           stage = stage + 1

--- a/libraries/AP_Scripting/examples/copter-wall-climber.lua
+++ b/libraries/AP_Scripting/examples/copter-wall-climber.lua
@@ -221,7 +221,7 @@ function update()
   pitch_speed = math.max(pitch_speed_target, pitch_speed - roll_pitch_speed_chg_max, -roll_pitch_speed_max)
 
   -- convert targets from body to earth frame and send to guided mode velocity controller
-  local yaw_rad = ahrs:get_yaw()
+  local yaw_rad = ahrs:get_yaw_rad()
   yaw_cos = math.cos(yaw_rad)
   yaw_sin = math.sin(yaw_rad)
   local target_vel_ned = Vector3f()

--- a/libraries/AP_Scripting/examples/glide_into_wind.lua
+++ b/libraries/AP_Scripting/examples/glide_into_wind.lua
@@ -240,7 +240,7 @@ function update()
   -- State TRIGGERED actions
   if fs_state == "TRIGGERED" then
     -- Get the heading angle
-    hdg = math.floor(math.deg(ahrs:get_yaw()))
+    hdg = math.floor(math.deg(ahrs:get_yaw_rad()))
 
     -- Get wind direction. Function wind_estimate returns x and y for direction wind blows in, add pi to get true wind dir
     wind = ahrs:wind_estimate()

--- a/libraries/AP_Scripting/examples/hello_world_display.lua
+++ b/libraries/AP_Scripting/examples/hello_world_display.lua
@@ -26,8 +26,8 @@ local function update()
     else
         -- Generate the smiley
         local width = (displayWidth / 2)
-        local roll = math.floor(width + (ahrs:get_roll() * width)) - 4
-        local pitch = math.floor(ahrs:get_pitch() * 6) + 2;
+        local roll = math.floor(width + (ahrs:get_roll_rad() * width)) - 4
+        local pitch = math.floor(ahrs:get_pitch_rad() * 6) + 2;
         local sub = 5 - roll
         if sub < 0 then
             sub = 0

--- a/libraries/AP_Scripting/examples/jump_tags_calibrate_agl.lua
+++ b/libraries/AP_Scripting/examples/jump_tags_calibrate_agl.lua
@@ -64,7 +64,7 @@ function sample_rangefinder_to_get_AGL()
     local distance_raw_m = rangefinder:distance_orient(ROTATION_PITCH_270)
 
     -- correct the range for attitude (multiply by DCM.c.z, which is cos(roll)*cos(pitch))
-    local ahrs_get_rotation_body_to_ned_c_z = math.cos(ahrs:get_roll())*math.cos(ahrs:get_pitch())
+    local ahrs_get_rotation_body_to_ned_c_z = math.cos(ahrs:get_roll_rad())*math.cos(ahrs:get_pitch_rad())
     local agl_corrected_for_attitude_m = distance_raw_m * ahrs_get_rotation_body_to_ned_c_z
 
     if (agl_samples_count <= 0) then

--- a/libraries/AP_Scripting/examples/land_hagl.lua
+++ b/libraries/AP_Scripting/examples/land_hagl.lua
@@ -34,7 +34,7 @@ local function send_HAGL()
       return
    end
    local rangefinder_dist = rangefinder:distance_orient(RANGEFINDER_ORIENT)
-   local correction = math.cos(ahrs:get_roll())*math.cos(ahrs:get_pitch())
+   local correction = math.cos(ahrs:get_roll_rad())*math.cos(ahrs:get_pitch_rad())
    local rangefinder_corrected = rangefinder_dist * correction
    if RANGEFINDER_ORIENT == ROTATION_PITCH_90 then
       rangefinder_corrected = -rangefinder_corrected

--- a/libraries/AP_Scripting/examples/logging.lua
+++ b/libraries/AP_Scripting/examples/logging.lua
@@ -40,9 +40,9 @@ end
 function update()
 
   -- get some interesting data
-  interesting_data[roll] = math.deg(ahrs:get_roll())
-  interesting_data[pitch] = math.deg(ahrs:get_pitch())
-  interesting_data[yaw] = math.deg(ahrs:get_yaw())
+  interesting_data[roll] = math.deg(ahrs:get_roll_rad())
+  interesting_data[pitch] = math.deg(ahrs:get_pitch_rad())
+  interesting_data[yaw] = math.deg(ahrs:get_yaw_rad())
 
   -- write to then new file the SD card
   write_to_file()

--- a/libraries/AP_Scripting/examples/mag_heading.lua
+++ b/libraries/AP_Scripting/examples/mag_heading.lua
@@ -22,7 +22,7 @@ function wrap_360(angle)
 end
 
 function update()
-   local yaw_deg = wrap_360(math.deg(ahrs:get_yaw() - COMPASS_DEC:get()))
+   local yaw_deg = wrap_360(math.deg(ahrs:get_yaw_rad() - COMPASS_DEC:get()))
    local gspd = ahrs:groundspeed_vector()
    local gcrs_deg = wrap_360(math.deg(math.atan(gspd:y(), gspd:x()) - COMPASS_DEC:get()))
    gcs:send_named_float("MAG_HEAD", yaw_deg)

--- a/libraries/AP_Scripting/examples/plane-wind-fs.lua
+++ b/libraries/AP_Scripting/examples/plane-wind-fs.lua
@@ -135,7 +135,7 @@ local function time_to_home()
     local effective_speed = home_airspeed + tail_wind
 
     -- Estimate the extra distance required to turn
-    local yaw = ahrs:get_yaw()
+    local yaw = ahrs:get_yaw_rad()
     -- this is the estimated angle we have to turn to be at the home bearing and crab angle
     local turn_angle_rad = bearing - crab_angle - yaw 
     -- wrap to +- PI

--- a/libraries/AP_Scripting/examples/rover-SaveTurns.lua
+++ b/libraries/AP_Scripting/examples/rover-SaveTurns.lua
@@ -109,7 +109,7 @@ function collect_breadcrumbs()
     if not ahrs:healthy() then return collect_breadcrumbs, RUN_INTERVAL_MS end
 
     local cur_pos = ahrs:get_location()
-    local cur_yaw = ahrs:get_yaw() * 180.0 / math.pi
+    local cur_yaw = ahrs:get_yaw_rad() * 180.0 / math.pi
 
     if cur_pos:get_distance(last_wp) < MIN_DIST then
         last_yaw = cur_yaw

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -34,11 +34,14 @@ singleton AP_AHRS rename ahrs
 singleton AP_AHRS depends AP_AHRS_ENABLED
 singleton AP_AHRS semaphore
 singleton AP_AHRS method get_roll_rad float
-singleton AP_AHRS method get_roll_rad alias get_roll
+singleton AP_AHRS method get_roll float
+singleton AP_AHRS method get_roll deprecate Use get_roll_rad
 singleton AP_AHRS method get_pitch_rad float
-singleton AP_AHRS method get_pitch_rad alias get_pitch
+singleton AP_AHRS method get_pitch float
+singleton AP_AHRS method get_pitch deprecate Use get_pitch_rad
 singleton AP_AHRS method get_yaw_rad float
-singleton AP_AHRS method get_yaw_rad alias get_yaw
+singleton AP_AHRS method get_yaw float
+singleton AP_AHRS method get_yaw deprecate Use get_yaw_rad
 singleton AP_AHRS method get_location boolean Location'Null
 singleton AP_AHRS method get_location alias get_position
 singleton AP_AHRS method get_home Location

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -33,9 +33,12 @@ include AP_AHRS/AP_AHRS.h
 singleton AP_AHRS rename ahrs
 singleton AP_AHRS depends AP_AHRS_ENABLED
 singleton AP_AHRS semaphore
-singleton AP_AHRS method get_roll float
-singleton AP_AHRS method get_pitch float
-singleton AP_AHRS method get_yaw float
+singleton AP_AHRS method get_roll_rad float
+singleton AP_AHRS method get_roll_rad alias get_roll
+singleton AP_AHRS method get_pitch_rad float
+singleton AP_AHRS method get_pitch_rad alias get_pitch
+singleton AP_AHRS method get_yaw_rad float
+singleton AP_AHRS method get_yaw_rad alias get_yaw
 singleton AP_AHRS method get_location boolean Location'Null
 singleton AP_AHRS method get_location alias get_position
 singleton AP_AHRS method get_home Location

--- a/libraries/AP_Soaring/AP_Soaring.cpp
+++ b/libraries/AP_Soaring/AP_Soaring.cpp
@@ -285,8 +285,8 @@ void SoaringController::init_thermalling()
     // New state vector filter will be reset. Thermal location is placed in front of a/c
     const float init_xr[4] = {_vario.get_trigger_value(),
                               INITIAL_THERMAL_RADIUS,
-                              position.x + thermal_distance_ahead * cosf(_ahrs.get_yaw()),
-                              position.y + thermal_distance_ahead * sinf(_ahrs.get_yaw())};
+                              position.x + thermal_distance_ahead * cosf(_ahrs.get_yaw_rad()),
+                              position.y + thermal_distance_ahead * sinf(_ahrs.get_yaw_rad())};
 
     const VectorN<float,4> xr{init_xr};
 

--- a/libraries/AP_Soaring/Variometer.cpp
+++ b/libraries/AP_Soaring/Variometer.cpp
@@ -63,7 +63,7 @@ void Variometer::update(const float thermal_bank)
     float smoothed_climb_rate = _climb_filter.apply(raw_climb_rate, dt);
 
     // Compute still-air sinkrate
-    float roll = _ahrs.get_roll();
+    float roll = _ahrs.get_roll_rad();
     float sinkrate = calculate_aircraft_sinkrate(roll);
 
     reading = raw_climb_rate + dsp_cor*_aspd_filt_constrained/GRAVITY_MSS + sinkrate;

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -926,7 +926,7 @@ void AP_TECS::_update_throttle_without_airspeed(int16_t throttle_nudge, float pi
     // so that the throttle mapping adjusts for the effect of pitch control errors
     _pitch_demand_lpf.apply(_pitch_dem, _DT);
     const float pitch_demand_hpf = _pitch_dem - _pitch_demand_lpf.get();
-    _pitch_measured_lpf.apply(_ahrs.get_pitch(), _DT);
+    _pitch_measured_lpf.apply(_ahrs.get_pitch_rad(), _DT);
     const float pitch_corrected_lpf = _pitch_measured_lpf.get() - radians(pitch_trim_deg);
     const float pitch_blended = pitch_demand_hpf + pitch_corrected_lpf;
 
@@ -1170,7 +1170,7 @@ void AP_TECS::_initialise_states(float hgt_afe)
         _integSEBdot          = 0.0f;
         _integKE              = 0.0f;
         _last_throttle_dem    = aparm.throttle_cruise * 0.01f;
-        _last_pitch_dem       = _ahrs.get_pitch();
+        _last_pitch_dem       = _ahrs.get_pitch_rad();
         _hgt_dem_in_prev      = hgt_afe;
         _hgt_dem_lpf          = hgt_afe;
         _hgt_dem_rate_ltd     = hgt_afe;
@@ -1199,8 +1199,8 @@ void AP_TECS::_initialise_states(float hgt_afe)
         const float fc = 1.0f / (M_2PI * _timeConst);
         _pitch_demand_lpf.set_cutoff_frequency(fc);
         _pitch_measured_lpf.set_cutoff_frequency(fc);
-        _pitch_demand_lpf.reset(_ahrs.get_pitch());
-        _pitch_measured_lpf.reset(_ahrs.get_pitch());
+        _pitch_demand_lpf.reset(_ahrs.get_pitch_rad());
+        _pitch_measured_lpf.reset(_ahrs.get_pitch_rad());
 
     } else if (_flight_stage == AP_FixedWing::FlightStage::TAKEOFF || _flight_stage == AP_FixedWing::FlightStage::ABORT_LANDING) {
         
@@ -1225,8 +1225,8 @@ void AP_TECS::_initialise_states(float hgt_afe)
         _TAS_dem_adj = _TAS_dem;
         _max_climb_scaler = 1.0f;
         _max_sink_scaler = 1.0f;
-        _pitch_demand_lpf.reset(_ahrs.get_pitch());
-        _pitch_measured_lpf.reset(_ahrs.get_pitch());
+        _pitch_demand_lpf.reset(_ahrs.get_pitch_rad());
+        _pitch_measured_lpf.reset(_ahrs.get_pitch_rad());
         
 
         if (!_flag_have_reset_after_takeoff) {

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -995,8 +995,8 @@ void AP_Vehicle::publish_osd_info()
 void AP_Vehicle::get_osd_roll_pitch_rad(float &roll, float &pitch) const
 {
 #if AP_AHRS_ENABLED
-    roll = ahrs.get_roll();
-    pitch = ahrs.get_pitch();
+    roll = ahrs.get_roll_rad();
+    pitch = ahrs.get_pitch_rad();
 #else
     roll = 0.0;
     pitch = 0.0;

--- a/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.cpp
+++ b/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.cpp
@@ -163,7 +163,7 @@ bool AP_VisualOdom_IntelT265::align_yaw_to_ahrs(const Vector3f &position, const 
         return false;
     }
 
-    align_yaw(position, attitude, AP::ahrs().get_yaw());
+    align_yaw(position, attitude, AP::ahrs().get_yaw_rad());
     return true;
 }
 

--- a/libraries/AP_WindVane/AP_WindVane.cpp
+++ b/libraries/AP_WindVane/AP_WindVane.cpp
@@ -321,7 +321,7 @@ void AP_WindVane::update()
         }
     } else {
         // only have direction, can't do true wind calcs, set true direction to apparent + heading
-        _direction_true_raw = wrap_PI(_direction_apparent_raw + AP::ahrs().get_yaw());
+        _direction_true_raw = wrap_PI(_direction_apparent_raw + AP::ahrs().get_yaw_rad());
         _speed_true_raw = 0.0f;
     }
 
@@ -397,7 +397,7 @@ void AP_WindVane::update()
 
 void AP_WindVane::record_home_heading()
 {
-    _home_heading = AP::ahrs().get_yaw();
+    _home_heading = AP::ahrs().get_yaw_rad();
 }
 
 // to start direction calibration from mavlink or other
@@ -456,7 +456,7 @@ void AP_WindVane::update_true_wind_speed_and_direction()
     }
 
     // convert apparent wind speed and direction to 2D vector in same frame as vehicle velocity
-    const float wind_dir_180 = _direction_apparent_raw + AP::ahrs().get_yaw() + radians(180);
+    const float wind_dir_180 = _direction_apparent_raw + AP::ahrs().get_yaw_rad() + radians(180);
     const Vector2f wind_apparent_vec(cosf(wind_dir_180) * _speed_apparent, sinf(wind_dir_180) * _speed_apparent);
 
     // add vehicle velocity
@@ -484,7 +484,7 @@ void AP_WindVane::update_apparent_wind_dir_from_true()
     Vector2f wind_apparent_vec = Vector2f(wind_true_vec.x - veh_velocity.x, wind_true_vec.y - veh_velocity.y);
 
     // calculate apartment speed and direction
-    _direction_apparent_raw = wrap_PI(atan2f(wind_apparent_vec.y, wind_apparent_vec.x) - radians(180) - AP::ahrs().get_yaw());
+    _direction_apparent_raw = wrap_PI(atan2f(wind_apparent_vec.y, wind_apparent_vec.x) - radians(180) - AP::ahrs().get_yaw_rad());
     _speed_apparent_raw = wind_apparent_vec.length();
 }
 

--- a/libraries/AP_WindVane/AP_WindVane_Home.cpp
+++ b/libraries/AP_WindVane/AP_WindVane_Home.cpp
@@ -32,7 +32,7 @@ void AP_WindVane_Home::update_direction()
         }
     }
 
-    _frontend._direction_apparent_raw = wrap_PI(direction_apparent_ef - AP::ahrs().get_yaw());
+    _frontend._direction_apparent_raw = wrap_PI(direction_apparent_ef - AP::ahrs().get_yaw_rad());
 }
 
 #endif  // AP_WINDVANE_HOME_ENABLED

--- a/libraries/AP_WindVane/AP_WindVane_SITL.cpp
+++ b/libraries/AP_WindVane/AP_WindVane_SITL.cpp
@@ -41,7 +41,7 @@ void AP_WindVane_SITL::update_direction()
         wind_vector_ef.x += AP::sitl()->state.speedN;
         wind_vector_ef.y += AP::sitl()->state.speedE;
 
-        _frontend._direction_apparent_raw =  wrap_PI(atan2f(wind_vector_ef.y, wind_vector_ef.x) - AP::ahrs().get_yaw());
+        _frontend._direction_apparent_raw =  wrap_PI(atan2f(wind_vector_ef.y, wind_vector_ef.x) - AP::ahrs().get_yaw_rad());
 
     } else { // WINDVANE_SITL_APARRENT
         // directly read the body frame apparent wind set by physics backend

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -5988,9 +5988,9 @@ void GCS_MAVLINK::send_attitude() const
     mavlink_msg_attitude_send(
         chan,
         AP_HAL::millis(),
-        ahrs.get_roll(),
-        ahrs.get_pitch(),
-        ahrs.get_yaw(),
+        ahrs.get_roll_rad(),
+        ahrs.get_pitch_rad(),
+        ahrs.get_yaw_rad(),
         omega.x,
         omega.y,
         omega.z);


### PR DESCRIPTION
Costs more bytes on boards with scripting because of the extra bindings
```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                 *                                                   
CubeRedPrimary                      416    *           408     416               408    416    416
Durandal                            416    *           408     416               408    416    408
Hitec-Airspeed           *                 *                                                   
KakuteH7-bdshot                     408    *           416     408               416    408    408
MatekF405                           *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *                  *       *                 *      *      *
f103-QiotekPeriph        *                 *                                                   
f303-Universal           *                 *                                                   
iomcu                                                                *                         
revo-mini                           *      *           *       *                 *      *      *
skyviper-v2450                                         *                                       
```

Changes all the scripts to choose between renaming to use the new binding or use the *other* new binding introduced, `get_roll_deg` etc.  Most places change to use `_deg`

Deprecates the old `get_roll` etc bindings, so at some stage that space can be reclaimed.

If scripting is disabled then this is a no-compiler-output change.  To that end, reviews could probably focus on the LUA script changes.

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                 *
CubeRedPrimary                      *      *           *       *                 *      *      *
Durandal                            *      *           *       *                 *      *      *
Hitec-Airspeed           *                 *
KakuteH7-bdshot                     *      *           *       *                 *      *      *
MatekF405                           *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *                  *       *                 *      *      *
f103-QiotekPeriph        *                 *
f303-Universal           *                 *
iomcu                                                                *
revo-mini                           *      *           *       *                 *      *      *
skyviper-journey                                       *
skyviper-v2450                                         *
```
