### PR TITLE
AP_Serial: Provide bindings for parity and stop bits

### DIFF
--- a/libraries/AP_Scripting/AP_Scripting_SerialAccess.cpp
+++ b/libraries/AP_Scripting/AP_Scripting_SerialAccess.cpp
@@ -24,6 +24,18 @@ void AP_Scripting_SerialAccess::begin(uint32_t baud)
     }
 }
 
+void AP_Scripting_SerialAccess::configure_parity(uint8_t parity) {
+    if (!check_is_device_port()) {
+        stream->configure_parity(parity);
+    }
+}
+
+void AP_Scripting_SerialAccess::set_stop_bits(uint8_t stop_bits) {
+    if (!check_is_device_port()) {
+        stream->set_stop_bits(stop_bits);
+    }
+}
+
 size_t AP_Scripting_SerialAccess::write(uint8_t c)
 {
     return write(&c, 1);

--- a/libraries/AP_Scripting/AP_Scripting_SerialAccess.h
+++ b/libraries/AP_Scripting/AP_Scripting_SerialAccess.h
@@ -14,6 +14,9 @@ public:
 
     void begin(uint32_t baud);
 
+    void configure_parity(uint8_t parity);
+    void set_stop_bits(uint8_t stop_bits);
+
     size_t write(uint8_t c);
     size_t write(const uint8_t *buffer, size_t size);
 

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1288,6 +1288,14 @@ local AP_Scripting_SerialAccess_ud = {}
 ---@param baud_rate uint32_t_ud|integer|number
 function AP_Scripting_SerialAccess_ud:begin(baud_rate) end
 
+-- Set UART parity (no effect for device ports)
+---@param parity integer 0=None, 1=Odd, 2=Even
+function AP_Scripting_SerialAccess_ud:configure_parity(parity) end
+
+-- Set UART stop bits (no effect for device ports)
+---@param stop_bits integer 1 or 2
+function AP_Scripting_SerialAccess_ud:set_stop_bits(stop_bits) end
+
 -- Writes a single byte
 ---@param value integer -- byte to write
 ---@return uint32_t_ud -- 1 if success else 0

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -430,6 +430,8 @@ include AP_Scripting/AP_Scripting_SerialAccess.h
 -- don't let user create access objects
 userdata AP_Scripting_SerialAccess creation null -1
 userdata AP_Scripting_SerialAccess method begin void uint32_t 1U UINT32_MAX
+userdata AP_Scripting_SerialAccess method configure_parity void uint8_t 0 2
+userdata AP_Scripting_SerialAccess method set_stop_bits void uint8_t 1 2
 userdata AP_Scripting_SerialAccess method write uint32_t uint8_t'skip_check
 userdata AP_Scripting_SerialAccess manual writestring lua_serial_writestring 1 1
 userdata AP_Scripting_SerialAccess method read int16_t


### PR DESCRIPTION
Adds Lua scripting support to configure UART parity and stop bits through the AP_Scripting_SerialAccess interface.

Changes
Added configure_parity(uint8_t) and set_stop_bits(uint8_t) methods to AP_Scripting_SerialAccess

Updated bindings.desc with proper type validation and range limits

Updated docs.lua for Lua API documentation

Needs further testing. If someone can test on my behalf I would be very grateful, as I am on vacation now.