### PR TITLE
SITL: Fix SIM_SPEEDUP -1

### DIFF
--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -1057,7 +1057,7 @@ bool AP_Logger_File::io_thread_alive() const
     // disk.  Unfortunately these hardware devices do not obey our
     // SITL speedup options, so we allow for it here.
     SITL::SIM *sitl = AP::sitl();
-    if (sitl != nullptr) {
+    if (sitl != nullptr && sitl->speedup > 0) {
         timeout_ms *= sitl->speedup;
     }
 #endif

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -228,7 +228,7 @@ const AP_Param::GroupInfo SIM::var_info[] = {
     // @Description: Runs the simulation at multiples of normal speed. Do not use if realtime physics, like RealFlight, is being used
     // @Range: 1 10
     // @User: Advanced
-    AP_GROUPINFO("SPEEDUP",       52, SIM,  speedup, -1),
+    AP_GROUPINFO("SPEEDUP",       52, SIM,  speedup, 1),
     // @Param: IMU_POS
     // @DisplayName: IMU Offsets
     // @Description: XYZ position of the IMU accelerometer relative to the body frame origin


### PR DESCRIPTION
If you start a sim without setting param SIM_SPEEDUP then it will default to -1. That can't be good. Luckily, what's actually used in the SITL code is target_speedup that can be fetched via get_speedup() within the Airplane class and that set_speedup() at boot does a sanity check on the param. However, AP_Logger looks directly at the param value and sets a timeout depending on that. 

When it's negative it hangs the logio thread.

This PR does two things:
change SIM_SPEEDUP default from -1 to +1
sanity check sitl->speedup in logger. It's the only place in the code that uses it