### PR TITLE
AP_Camera: avoid using cd when sending camera feedback message

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -1143,6 +1143,18 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             raise NotAchievedException("Bad relalt (want=%f vs got=%f)" % (takeoff_alt, x.alt_rel))
         if abs(x.alt_msl - (original_alt+30)) > 10:
             raise NotAchievedException("Bad absalt (want=%f vs got=%f)" % (original_alt+30, x.alt_msl))
+
+        self.change_mode('LOITER')
+        self.delay_sim_time(10)
+
+        self.context_collect('CAMERA_FEEDBACK')
+        self.set_rc(12, 2000)
+        self.delay_sim_time(1)
+        self.set_rc(12, 1000)
+        self.assert_received_message_field_values('CAMERA_FEEDBACK', {
+            "roll": math.degrees(self.assert_receive_message('ATTITUDE').roll),
+        }, check_context=True, epsilon=5.0)
+
         self.fly_home_land_and_disarm()
 
     def ThrottleFailsafe(self):

--- a/libraries/AP_Camera/AP_Camera_Backend.cpp
+++ b/libraries/AP_Camera/AP_Camera_Backend.cpp
@@ -212,9 +212,9 @@ void AP_Camera_Backend::send_camera_feedback(mavlink_channel_t chan)
         camera_feedback.location.lng,       // longitude
         altitude*1e-2f,                     // alt MSL
         altitude_rel*1e-2f,                 // alt relative to home
-        camera_feedback.roll_sensor*1e-2f,  // roll angle (deg)
-        camera_feedback.pitch_sensor*1e-2f, // pitch angle (deg)
-        camera_feedback.yaw_sensor*1e-2f,   // yaw angle (deg)
+        camera_feedback.roll_deg,           // roll angle (deg)
+        camera_feedback.pitch_deg,          // pitch angle (deg)
+        camera_feedback.yaw_deg,            // yaw angle (deg)
         0.0f,                               // focal length
         CAMERA_FEEDBACK_PHOTO,              // flags
         camera_feedback.feedback_trigger_logged_count); // completed image captures
@@ -436,9 +436,9 @@ void AP_Camera_Backend::prep_mavlink_msg_camera_feedback(uint64_t timestamp_us)
         // completely ignore this failure!  AHRS will provide its best guess.
     }
     camera_feedback.timestamp_us = timestamp_us;
-    camera_feedback.roll_sensor = ahrs.roll_sensor;
-    camera_feedback.pitch_sensor = ahrs.pitch_sensor;
-    camera_feedback.yaw_sensor = ahrs.yaw_sensor;
+    camera_feedback.roll_deg = ahrs.get_roll_deg();
+    camera_feedback.pitch_deg = ahrs.get_pitch_deg();
+    camera_feedback.yaw_deg = ahrs.get_yaw_deg();
     camera_feedback.feedback_trigger_logged_count = feedback_trigger_logged_count;
 
     GCS_SEND_MESSAGE(MSG_CAMERA_FEEDBACK);

--- a/libraries/AP_Camera/AP_Camera_Backend.h
+++ b/libraries/AP_Camera/AP_Camera_Backend.h
@@ -167,9 +167,9 @@ protected:
     struct {
         uint64_t timestamp_us;      // system time of most recent image
         Location location;          // location where most recent image was taken
-        int32_t roll_sensor;        // vehicle roll in centi-degrees
-        int32_t pitch_sensor;       // vehicle pitch in centi-degrees
-        int32_t yaw_sensor;         // vehicle yaw in centi-degrees
+        float roll_deg;             // vehicle roll in degrees
+        float pitch_deg;            // vehicle pitch in degrees
+        float yaw_deg;              // vehicle yaw in degrees
         uint32_t feedback_trigger_logged_count; // ID sequence number
     } camera_feedback;
 


### PR DESCRIPTION
Added an autotest to make sure this comes through

We really should be adjusting the values returned into this message if we know the camera's orientation (eg. it is on a mount)
