### PR TITLE
AP_OpticalFlow: add type param desc for SITL

### DIFF
--- a/libraries/AP_OpticalFlow/AP_OpticalFlow.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow.cpp
@@ -27,7 +27,7 @@ const AP_Param::GroupInfo AP_OpticalFlow::var_info[] = {
     // @DisplayName: Optical flow sensor type
     // @Description: Optical flow sensor type
     // @SortValues: AlphabeticalZeroAtTop
-    // @Values: 0:None, 1:PX4Flow, 2:Pixart, 3:Bebop, 4:CXOF, 5:MAVLink, 6:DroneCAN, 7:MSP, 8:UPFLOW
+    // @Values: 0:None, 1:PX4Flow, 2:Pixart, 3:Bebop, 4:CXOF, 5:MAVLink, 6:DroneCAN, 7:MSP, 8:UPFLOW, 10:SITL
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO_FLAGS("_TYPE", 0,  AP_OpticalFlow,    _type,   (float)OPTICAL_FLOW_TYPE_DEFAULT, AP_PARAM_FLAG_ENABLE),


### PR DESCRIPTION
I noticed while looking at a user issue (https://github.com/ArduPilot/ardupilot/issues/30257) that the FLOW_TYPE = 10 didn't have a description so this adds it.

I've not tested this by generating and param docs but surely it's fine