### PR TITLE
AP_Networking: make PPP much more robust

### DIFF
--- a/libraries/AP_Networking/config/lwipopts.h
+++ b/libraries/AP_Networking/config/lwipopts.h
@@ -118,6 +118,12 @@ extern "C"
 
 #define USE_PPP 1
 
+// generate a regular LCP echo to keep link up
+#define LCP_ECHOINTERVAL                1
+
+// on 5 failed echos terminate link
+#define LCP_MAXECHOFAILS                5
+
 #define LWIP_TIMEVAL_PRIVATE 0
 #define LWIP_FD_SET_PRIVATE 0
 


### PR DESCRIPTION
this fixes two key issues with PPP:

 - if we lost the link (eg. serial cable unplugged) then it did not properly restart the link when the cable is plugged back in

 - if using hardware flow control and the UART write buffer fills up then we would sleep with the TCPIP lock held, which means if the main thread tries to send an IPv4 packet then it would block on the TCPIP lock, and we would watchdog