### PR TITLE
Plane: support individual vtail and elevon mixing parameter

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1269,6 +1269,10 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Path: systemid.cpp
     AP_SUBGROUPINFO(systemid, "SID", 38, ParametersG2, AP_SystemID),
 #endif
+
+    // @Group: MIX_
+    // @Path: mixing.cpp
+    AP_SUBGROUPINFO(mixing, "MIX_", 39, ParametersG2, AP_Mixing),
     
     AP_GROUPEND
 };
@@ -1281,6 +1285,7 @@ ParametersG2::ParametersG2(void) :
 #if HAL_SOARING_ENABLED
     ,soaring_controller(plane.TECS_controller, plane.aparm)
 #endif
+    ,mixing()
 {
     AP_Param::setup_object_defaults(this, var_info);
 }

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -592,6 +592,9 @@ public:
 #if AP_PLANE_SYSTEMID_ENABLED
     AP_SystemID systemid;
 #endif
+
+    // MIXING group
+    AP_Mixing mixing;
 };
 
 extern const AP_Param::Info var_info[];

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1179,7 +1179,8 @@ private:
     bool suppress_throttle(void);
     void update_throttle_hover();
     void channel_function_mixer(SRV_Channel::Function func1_in, SRV_Channel::Function func2_in,
-                                SRV_Channel::Function func1_out, SRV_Channel::Function func2_out) const;
+                                SRV_Channel::Function func1_out, SRV_Channel::Function func2_out,
+                                float mixing_gain, int16_t mixing_offset) const;
     void flaperon_update();
     void indicate_waiting_for_rud_neutral_to_takeoff(void);
 

--- a/ArduPlane/mixing.cpp
+++ b/ArduPlane/mixing.cpp
@@ -1,0 +1,46 @@
+#include "mixing.h"
+
+// table of user settable parameters
+const AP_Param::GroupInfo AP_Mixing::var_info[] = {
+    // @Param: INDV_EN
+    // @DisplayName: Individual mix enable
+    // @Description: Enable individual mixing parameters for VTAIL and ELEVON
+    // @Values: 0:Disable, 1:Enable
+    // @User: Advanced
+    AP_GROUPINFO_FLAGS("INDV_EN", 1, AP_Mixing, individual_mix_enable, 0, AP_PARAM_FLAG_ENABLE),
+
+    // @Param: VT_GAIN
+    // @DisplayName: V-tail mixing gain
+    // @Description: Gain applied to V-tail mixing output
+    // @Range: 0.0 1.0
+    // @User: Advanced
+    AP_GROUPINFO("VT_GAIN", 2, AP_Mixing, vtail_mgain, 0.5f),
+
+    // @Param: VT_OFFSET
+    // @DisplayName: V-tail mixing offset
+    // @Description: Offset applied to V-tail mixing output
+    // @Range: -1000 1000
+    // @User: Advanced
+    AP_GROUPINFO("VT_OFFSET", 3, AP_Mixing, vtail_moffset, 0),
+
+    // @Param: EL_GAIN
+    // @DisplayName: Elevon mixing gain
+    // @Description: Gain applied to elevon mixing output
+    // @Range: 0.0 1.0
+    // @User: Advanced
+    AP_GROUPINFO("EL_GAIN", 4, AP_Mixing, elevon_mgain, 0.5f),
+
+    // @Param: EL_OFFSET
+    // @DisplayName: Elevon mixing offset
+    // @Description: Offset applied to elevon mixing output
+    // @Range: -1000 1000
+    // @User: Advanced
+    AP_GROUPINFO("EL_OFFSET", 5, AP_Mixing, elevon_moffset, 0),
+
+    AP_GROUPEND
+};
+
+AP_Mixing::AP_Mixing(void)
+{
+    AP_Param::setup_object_defaults(this, var_info);
+} 

--- a/ArduPlane/mixing.h
+++ b/ArduPlane/mixing.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <AP_Param/AP_Param.h>
+
+class AP_Mixing {
+public:
+    AP_Mixing(void);
+
+    // var_info for holding Parameter information
+    static const struct AP_Param::GroupInfo var_info[];
+
+    // Individual mix enable parameter
+    AP_Int8 individual_mix_enable;
+    
+    // V-tail mixing parameters
+    AP_Float vtail_mgain;
+    AP_Int16 vtail_moffset;
+    
+    // Elevon mixing parameters  
+    AP_Float elevon_mgain;
+    AP_Int16 elevon_moffset;
+}; 

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -12,6 +12,7 @@
 #include "config.h"
 #include "pullup.h"
 #include "systemid.h"
+#include "mixing.h"
 
 #ifndef AP_QUICKTUNE_ENABLED
 #define AP_QUICKTUNE_ENABLED HAL_QUADPLANE_ENABLED


### PR DESCRIPTION
## Summary
This PR introduces support for individual mixing parameters for V-tail and elevon configurations in ArduPlane, providing more granular control over mixing behavior compared to the existing global mixing parameters.

- **Individual Mixing Control**: Added `MIX_INDV_EN` parameter to enable/disable individual mixing parameters
- **V-tail Specific Parameters**:
  - `MIX_VT_GAIN` - Individual gain control for V-tail mixing (Range: 0.0-1.0, Default: 0.5)
  - `MIX_VT_OFFSET` - Individual offset control for V-tail mixing (Range: -1000-1000, Default: 0)
- **Elevon Specific Parameters**:
  - `MIX_EL_GAIN` - Individual gain control for elevon mixing (Range: 0.0-1.0, Default: 0.5)
  - `MIX_EL_OFFSET` - Individual offset control for elevon mixing (Range: -1000-1000, Default: 0)

### Backward Compatibility
- When `MIX_INDV_EN` is disabled (default), the system uses existing global `MIXING_GAIN` and `MIXING_OFFSET` parameters
- When enabled, V-tail and elevon mixing use their respective individual parameters
- No breaking changes to existing configurations