### PR TITLE
Use cygpath to get working directory for cygwin build job

### DIFF
--- a/.github/workflows/cygwin_build.yml
+++ b/.github/workflows/cygwin_build.yml
@@ -168,11 +168,12 @@ jobs:
           PATH: /usr/bin:$(cygpath ${SYSTEMROOT})/system32
         shell: C:\cygwin\bin\bash.exe -eo pipefail '{0}'
         run: >-
-          mkdir -p /cygdrive/d/a/ardupilot/ardupilot/ccache &&
+          CYGPATH_GITHUB_WORKSPACE=$(cygpath -u "$GITHUB_WORKSPACE") &&
+          mkdir -p "${CYGPATH_GITHUB_WORKSPACE}/ccache" &&
           mkdir -p /usr/local/etc &&
           echo "export CCACHE_SLOPPINESS=file_stat_matches" >> ~/ccache.conf &&
-          echo "export CCACHE_DIR=/cygdrive/d/a/ardupilot/ardupilot/ccache" >> ~/ccache.conf &&
-          echo "export CCACHE_BASEDIR=/cygdrive/d/a/ardupilot/ardupilot" >> ~/ccache.conf &&
+          echo "export CCACHE_DIR=${CYGPATH_GITHUB_WORKSPACE}/ccache" >> ~/ccache.conf &&
+          echo "export CCACHE_BASEDIR=${CYGPATH_GITHUB_WORKSPACE}" >> ~/ccache.conf &&
           echo "export CCACHE_COMPRESS=1" >> ~/ccache.conf &&
           echo "export CCACHE_COMPRESSLEVEL=6" >> ~/ccache.conf &&
           echo "export CCACHE_MAXSIZE=400M" >> ~/ccache.conf &&
@@ -202,7 +203,9 @@ jobs:
           PATH: /usr/bin:$(cygpath ${SYSTEMROOT})/system32
         shell: C:\cygwin\bin\bash.exe -eo pipefail '{0}'
         run: >-
-          git config --global --add safe.directory /cygdrive/d/a/${GITHUB_REPOSITORY#$GITHUB_REPOSITORY_OWNER/}/${GITHUB_REPOSITORY#$GITHUB_REPOSITORY_OWNER/} &&
+          echo "GITHUB_WORKSPACE=${GITHUB_WORKSPACE}" &&
+          CYGPATH_GITHUB_WORKSPACE=$(cygpath -u "$GITHUB_WORKSPACE") &&
+          git config --global --add safe.directory "${CYGPATH_GITHUB_WORKSPACE}" &&
           export PATH=/usr/local/bin:/usr/bin:$(cygpath ${SYSTEMROOT})/system32 &&
           source ~/ccache.conf &&
           Tools/scripts/cygwin_build.sh &&

--- a/Tools/ardupilotwaf/git_submodule.py
+++ b/Tools/ardupilotwaf/git_submodule.py
@@ -31,7 +31,7 @@ post_mode should be set to POST_LAZY. Example::
         ...
 """
 
-from waflib import Context, Logs, Task, Utils
+from waflib import Context, Logs, Task, Utils, Errors
 from waflib.Configure import conf
 from waflib.TaskGen import before_method, feature, taskgen_method
 
@@ -161,7 +161,12 @@ def _git_head_hash(ctx, path, short=False):
     if short:
         cmd.append('--short=8')
     cmd.append('HEAD')
-    out = ctx.cmd_and_log(cmd, quiet=Context.BOTH, cwd=path)
+    try:
+        out = ctx.cmd_and_log(cmd, quiet=Context.BOTH, cwd=path)
+    except Errors.WafError as e:
+        print(e.stdout, e.stderr)
+        raise e
+
     return out.strip()
 
 @conf


### PR DESCRIPTION
Apparently this can move around, so assume /c/d isn't great

Extracted from: https://github.com/ArduPilot/ardupilot/pull/30250/commits
