### PR TITLE
AP_Scripting: add CMUX to LTE modem driver

### DIFF
--- a/libraries/AP_Scripting/drivers/LTE_modem.lua
+++ b/libraries/AP_Scripting/drivers/LTE_modem.lua
@@ -96,11 +96,11 @@ local LTE_SERVER_PORT = bind_add_param('SERVER_PORT',  8, 0)
 --[[
     // @Param: LTE_BAUD
     // @DisplayName: Serial Baud Rate
-    // @Description: Baud rate for the serial port to the LTE modem. If using something other than 115200 you need to connect to the modem and use AT+IPREX=BAUD to set the baud rate and save with AT&W. The fastest supported baudrate is 3686400.
+    // @Description: Baud rate for the serial port to the LTE modem when connected. Initial power on baudrate is in LTE_IBAUD
     // @Values: 19200:19200,38400:38400,57600:57600,115200:115200,230400:230400,460800:460800,921600:921600,3686400:3686400
     // @User: Standard
 --]]
-local LTE_BAUD        = bind_add_param('BAUD',  9, 115200)
+local LTE_BAUD        = bind_add_param('BAUD',  9, 921600)
 
 --[[
     // @Param: LTE_TIMEOUT
@@ -124,13 +124,30 @@ local LTE_PROTOCOL     = bind_add_param('PROTOCOL', 11, 48)
 --[[
     // @Param: LTE_OPTIONS
     // @DisplayName: LTE options
-    // @Description: Options to control the LTE modem driver
-    // @Bitmask: 0:LogAllData
+    // @Description: Options to control the LTE modem driver. If VerboseSignalInfoGCS is set then additional NAMED_VALUE_FLOAT values are sent with verbose signal information
+    // @Bitmask: 0:LogAllData,1:VerboseSignalInfoGCS
     // @User: Standard
 --]]
 local LTE_OPTIONS     = bind_add_param('OPTIONS', 12, 0)
 
+--[[
+    // @Param: LTE_IBAUD
+    // @DisplayName: LTE initial baudrate
+    // @Description: This is the initial baud rate on power on for the modem. This is set in the modem with the AT+IREX=baud command
+    // @Values: 19200:19200,38400:38400,57600:57600,115200:115200,230400:230400,460800:460800,921600:921600,3686400:3686400
+    // @User: Standard
+--]]
+local LTE_IBAUD       = bind_add_param('IBAUD', 13, 115200)
+
 local LTE_OPTIONS_LOGALL = (1<<0)
+local LTE_OPTIONS_SIGNALS = (1<<1)
+
+--[[
+    return true if an option is enabled
+--]]
+local function option_enabled(option)
+    return (LTE_OPTIONS:get() & option) ~= 0
+end
 
 if LTE_ENABLE:get() == 0 then
     -- disabled
@@ -151,7 +168,9 @@ end
 
 local step = "ATI"
 
-uart:begin(LTE_BAUD:get())
+local stats = { bytes_in = 0, bytes_out = 0 }
+
+uart:begin(LTE_IBAUD:get())
 
 --[[
     Open a log file to log the output from the modem
@@ -177,6 +196,7 @@ end
 local function uart_read()
     local s = uart:readstring(512)
     log_data(s, '<<<')
+    stats.bytes_in = stats.bytes_in + #s
     return s
 end
 
@@ -186,7 +206,105 @@ end
 local function uart_write(s)
     uart:writestring(s)
     log_data(s, '>>>')
-    return s
+    stats.bytes_out = stats.bytes_out + #s
+    return #s
+end
+
+-- Constants for GSM 07.10 CMUX framing
+local FLAG = 0xF9
+local UIH = 0xEF
+local SABM = 0x2F
+--local UA = 0x63
+local EA = 0x01
+local CR_SEND = 0x02
+
+-- CMUX buffer state
+local cmux = {}
+cmux.buffers = {[1] = "", [2] = ""} -- DLC1=AT, DLC2=DATA(PPP or TCP)
+
+--[[
+    FCS lookup table for polynomial x^8 + x^2 + x^1 + 1 (0x07)
+    This is the reverse of the standard CRC-8 table
+--]]
+local fcs_table = {
+    0x00, 0x91, 0xe3, 0x72, 0x07, 0x96, 0xe4, 0x75,
+    0x0e, 0x9f, 0xed, 0x7c, 0x09, 0x98, 0xea, 0x7b,
+    0x1c, 0x8d, 0xff, 0x6e, 0x1b, 0x8a, 0xf8, 0x69,
+    0x12, 0x83, 0xf1, 0x60, 0x15, 0x84, 0xf6, 0x67,
+    0x38, 0xa9, 0xdb, 0x4a, 0x3f, 0xae, 0xdc, 0x4d,
+    0x36, 0xa7, 0xd5, 0x44, 0x31, 0xa0, 0xd2, 0x43,
+    0x24, 0xb5, 0xc7, 0x56, 0x23, 0xb2, 0xc0, 0x51,
+    0x2a, 0xbb, 0xc9, 0x58, 0x2d, 0xbc, 0xce, 0x5f,
+    0x70, 0xe1, 0x93, 0x02, 0x77, 0xe6, 0x94, 0x05,
+    0x7e, 0xef, 0x9d, 0x0c, 0x79, 0xe8, 0x9a, 0x0b,
+    0x6c, 0xfd, 0x8f, 0x1e, 0x6b, 0xfa, 0x88, 0x19,
+    0x62, 0xf3, 0x81, 0x10, 0x65, 0xf4, 0x86, 0x17,
+    0x48, 0xd9, 0xab, 0x3a, 0x4f, 0xde, 0xac, 0x3d,
+    0x46, 0xd7, 0xa5, 0x34, 0x41, 0xd0, 0xa2, 0x33,
+    0x54, 0xc5, 0xb7, 0x26, 0x53, 0xc2, 0xb0, 0x21,
+    0x5a, 0xcb, 0xb9, 0x28, 0x5d, 0xcc, 0xbe, 0x2f,
+    0xe0, 0x71, 0x03, 0x92, 0xe7, 0x76, 0x04, 0x95,
+    0xee, 0x7f, 0x0d, 0x9c, 0xe9, 0x78, 0x0a, 0x9b,
+    0xfc, 0x6d, 0x1f, 0x8e, 0xfb, 0x6a, 0x18, 0x89,
+    0xf2, 0x63, 0x11, 0x80, 0xf5, 0x64, 0x16, 0x87,
+    0xd8, 0x49, 0x3b, 0xaa, 0xdf, 0x4e, 0x3c, 0xad,
+    0xd6, 0x47, 0x35, 0xa4, 0xd1, 0x40, 0x32, 0xa3,
+    0xc4, 0x55, 0x27, 0xb6, 0xc3, 0x52, 0x20, 0xb1,
+    0xca, 0x5b, 0x29, 0xb8, 0xcd, 0x5c, 0x2e, 0xbf,
+    0x90, 0x01, 0x73, 0xe2, 0x97, 0x06, 0x74, 0xe5,
+    0x9e, 0x0f, 0x7d, 0xec, 0x99, 0x08, 0x7a, 0xeb,
+    0x8c, 0x1d, 0x6f, 0xfe, 0x8b, 0x1a, 0x68, 0xf9,
+    0x82, 0x13, 0x61, 0xf0, 0x85, 0x14, 0x66, 0xf7,
+    0xa8, 0x39, 0x4b, 0xda, 0xaf, 0x3e, 0x4c, 0xdd,
+    0xa6, 0x37, 0x45, 0xd4, 0xa1, 0x30, 0x42, 0xd3,
+    0xb4, 0x25, 0x57, 0xc6, 0xb3, 0x22, 0x50, 0xc1,
+    0xba, 0x2b, 0x59, 0xc8, 0xbd, 0x2c, 0x5e, 0xcf
+}
+
+--[[
+    Calculate FCS for a byte array
+    data: table of bytes (numbers 0-255) or string
+    Returns: FCS value (0-255)
+--]]
+local function fcs_calc(data)
+    local fcs = 0xff  -- Initial value
+    
+    for i = 1, #data do
+        local byte = string.byte(data, i)
+        fcs = fcs_table[((fcs ~ byte) & 0xff) + 1] ~ (fcs >> 8)
+    end
+
+    return (~fcs) & 0xff
+end
+
+-- Construct a CMUX frame for a given DLC, data type and data
+function cmux.encode_cmux_frame(dlc, dtype, data)
+    local addr = string.char((dlc << 2) | EA | CR_SEND)
+    local ctrl = string.char(dtype | 0x10)
+    local len = #data
+    local len_byte = string.char((len << 1) | EA)
+    local header = addr .. ctrl .. len_byte
+    local fcs = string.char(fcs_calc(header))
+    return string.char(FLAG) .. header .. data .. fcs .. string.char(FLAG)
+end
+
+--[[
+    send an AT command string with CMUX framing
+--]]
+local function cmux_AT_send(atcmd)
+    local s = cmux.encode_cmux_frame(1, UIH, atcmd)
+    return uart_write(s) == #s
+end
+
+--[[
+    send an appropriate data reset for the protocol
+--]]
+local function send_data_reset()
+    if LTE_PROTOCOL:get() == PPP then
+        cmux_AT_send('ATH\r\n')
+    else
+        cmux_AT_send('AT+CRESET\r\n')
+    end
 end
 
 --[[
@@ -197,34 +315,174 @@ end
 local function handle_error(s)
     if s and s:find('\nERROR\r\n') then
         gcs:send_text(MAV_SEVERITY.ERROR, 'LTE_modem: error response from modem')
-        uart_write('ATH\r\nAT+CRESET;\r\n')
+        send_data_reset()
         step = "ATI"
         return true
     end
     return false
 end
 
+-- Send SABM (Set Asynchronous Balanced Mode) for all DLCs
+function cmux.send_sabm()
+    uart_write(cmux.encode_cmux_frame(0, SABM, ""))
+    uart_write(cmux.encode_cmux_frame(1, SABM, ""))
+    uart_write(cmux.encode_cmux_frame(2, SABM, ""))
+end
+
+--[[
+ Parses a single CMUX frame from a byte buffer.
+ Returns: DLC number, extracted payload, and remaining buffer (or nils on failure)
+--]]
+function cmux.parse_cmux_frame(buf)
+    local start_idx = buf:find(string.char(FLAG))
+    if not start_idx then
+        --gcs:send_text(MAV_SEVERITY.INFO, "no start idx")
+        return nil, nil, nil
+    end
+    local end_idx = buf:find(string.char(FLAG), start_idx + 1)
+    if not end_idx then
+        --gcs:send_text(MAV_SEVERITY.INFO, "no end idx")
+        return nil, nil, nil, "short"
+    end
+
+    local frame = buf:sub(start_idx + 1, end_idx - 1)
+    if #frame < 4 then
+        --gcs:send_text(MAV_SEVERITY.INFO, "too short")
+        return nil, nil, nil
+    end
+
+    local addr = frame:byte(1)
+    local ctrl = frame:byte(2)
+
+    --gcs:send_text(MAV_SEVERITY.INFO, string.format("addr=0x%02x ctrl=0x%02x", addr, ctrl))
+
+    if ctrl == SABM then
+        return nil, nil, buf:sub(end_idx + 1)
+    end
+
+    if (ctrl & 0xef) ~= UIH then
+        return nil, nil, nil
+    end
+
+    local len_byte = frame:byte(3)
+    if (len_byte & EA) == 0 then
+        gcs:send_text(MAV_SEVERITY.INFO, "mux multibyte")
+        return nil, nil, nil -- we don't handle multi-byte length yet
+    end
+    local len = len_byte >> 1
+    if #frame < 3 + len + 1 then return nil, nil, nil end
+
+    local data = frame:sub(4, 3 + len)
+    local fcs_field = frame:byte(3 + len + 1)
+    local header = frame:sub(1, 3)
+    local calc_fcs = fcs_calc(header)
+    if calc_fcs ~= fcs_field then
+        gcs:send_text(MAV_SEVERITY.INFO, "FCS mismatch")
+        return nil, nil, nil -- FCS mismatch
+    end
+
+    local dlc = (addr >> 2) & 0x3F
+    local remainder = buf:sub(end_idx + 1)
+    --gcs:send_text(MAV_SEVERITY.INFO, string.format("CMUX got: dlc=%d ldata=%d lrem=%d", dlc, #data, #remainder))
+    return dlc, data, remainder
+end
+
+-- Feeds raw UART data into CMUX frame parser and routes payloads to DLC buffers
+function cmux.feed_uart_in(raw)
+    while #raw > 0 do
+        local dlc, data, rest, err = cmux.parse_cmux_frame(raw)
+        if not dlc or not data or not rest then
+            if err == "short" then
+                return raw
+            end
+            -- discard
+            return ""
+        end
+        if cmux.buffers[dlc] then
+            cmux.buffers[dlc] = cmux.buffers[dlc] .. data
+        end
+        raw = rest
+    end
+    return raw
+end
+
+--[[
+    send data with CMUX framing
+--]]
+local function cmux_data_send(data)
+    local s = cmux.encode_cmux_frame(2, UIH, data)
+    return uart_write(s) == #s
+end
+
+--[[
+    send data with CMUX framing when connected (logging only if data
+    logging enabled)
+--]]
+local function cmux_data_send_connected(data)
+    local s = cmux.encode_cmux_frame(2, UIH, data)
+    if option_enabled(LTE_OPTIONS_LOGALL) then
+        log_data(s, '>>>')
+    end
+    local n = uart:writestring(s)
+    stats.bytes_out = stats.bytes_out + n
+    return n == #s
+end
+
 local ati_sequence = 0
 
 --[[
     Function to confirm the connection to the modem
-    it uses AIT command to get the modem info, and +++ if needed
-    to break out of transparent mode
+    it uses AIT command to get the modem info
+
+    when we enter the ATI step the modem could be in one of several states:
+
+    - in AT command mode
+    - in muxed mode
+    - in muxed mode at higher baudrate
 --]]
 local function step_ATI()
     local s = uart_read()
     if s and s:find('IMEI: ') then
         gcs:send_text(MAV_SEVERITY.INFO, 'LTE_modem: found modem')
-        step = "CREG"
+        if cmux.parse_cmux_frame(s) then
+            -- already in CMUX mode
+            cmux.send_sabm()
+            send_data_reset()
+            step = "BAUD"
+        else
+            step = "CMUX"
+        end
         return
     end
-    if ati_sequence == 1 then
+    if s and #s >= 4 and s:byte(1) == FLAG and s:byte(-1) == FLAG then
+        -- already in mux mode
+        send_data_reset()
+        cmux_AT_send('ATI\r\n')
+        return
+    end
+    if ati_sequence % 2 == 1 then
         uart_write('+++')
-        ati_sequence = 0
     else
         uart_write('\r\nATI\r\n')
-        ati_sequence = 1
     end
+    if ati_sequence % 10 == 5 then
+        uart:begin(LTE_BAUD:get())
+    end
+    if ati_sequence % 10 == 9 then
+        uart:begin(LTE_IBAUD:get())
+    end
+    ati_sequence = ati_sequence + 1
+end
+
+local change_baud = nil
+
+--[[
+    change baud rate
+--]]
+local function step_BAUD()
+    cmux_AT_send(string.format('AT+IPR=%u\r\n', LTE_BAUD:get()))
+    step = "CREG"
+    change_baud = LTE_BAUD:get()
 end
 
 --[[
@@ -244,27 +502,7 @@ local function step_CREG()
         end
         return
     end
-    uart_write('AT+CREG?\r\n')
-end
-
---[[
-    setup automatic signal reporting
---]]
-local function step_AUTOCSQ()
-    local s = uart_read()
-    if handle_error(s) then
-        return
-    end
-    if s and s:find('AUTOCSQ=1,1\r\r\nOK\r') then
-        gcs:send_text(MAV_SEVERITY.INFO, 'LTE_modem: AUTOCSQ OK')
-        if LTE_PROTOCOL:get() == PPP then
-            step = "PPPOPEN"
-        else
-            step = "CIPMODE"
-        end
-        return
-    end
-    uart_write('AT+AUTOCSQ=1,1\r\n')
+    cmux_AT_send('AT+CREG?\r\n')
 end
 
 --[[
@@ -275,12 +513,31 @@ local function step_CIPMODE()
     if handle_error(s) then
         return
     end
-    if s and s:find('CIPMODE=1\r\r\nOK\r') then
+    if s and s:find('CIPMODE=1\r') and s:find('\r\r\nOK\r') then
         gcs:send_text(MAV_SEVERITY.INFO, 'LTE_modem: transparent mode set')
         step = "NETOPEN"
         return
     end
-    uart_write('AT+CIPMODE=1\r\n')
+    cmux_data_send('AT+CIPMODE=1\r\n')
+end
+
+--[[
+    setup CMUX multiplexing mode
+--]]
+local function step_CMUX()
+    local s = uart_read()
+    if handle_error(s) then
+        return
+    end
+    if s and s:find('CMUX=0\r\r\nOK\r') then
+        gcs:send_text(MAV_SEVERITY.INFO, 'LTE_modem: CMUX mode set')
+        -- send SABM frames to establish the DLCs
+        send_data_reset()
+        cmux.send_sabm()
+        step = "BAUD"
+        return
+    end
+    uart_write('AT+CMUX=0\r\n')
 end
 
 --[[
@@ -292,17 +549,18 @@ local function step_NETOPEN()
     if handle_error(s) then
         return
     end
-    if s and s:find('NETOPEN\r\r\nOK\r\n') then
+    if s and s:find('NETOPEN\r') and s:find('\r\r\nOK\r\n') then
         gcs:send_text(MAV_SEVERITY.INFO, 'LTE_modem: network opened')
         step = "CIPOPEN"
         return
     end
-    uart_write('AT+NETOPEN\r\n')
+    cmux_data_send('AT+NETOPEN\r\n')
 end
 
 local last_data_ms = millis()
 local pending_to_modem = ""
 local pending_to_fc = ""
+local pending_to_parse = ""
 
 --[[
     open PPP mode
@@ -318,10 +576,11 @@ local function step_PPPOPEN()
         last_data_ms = millis()
         pending_to_modem = ""
         pending_to_fc = ""
+        pending_to_parse = ""
         step = "CONNECTED"
         return
     end
-    uart_write('AT+CGDATA="PPP",1\r\n')
+    cmux_data_send('AT+CGDATA="PPP",1\r\n')
 end
 
 --[[
@@ -339,6 +598,7 @@ local function step_CIPOPEN()
         last_data_ms = millis()
         pending_to_modem = ""
         pending_to_fc = ""
+        pending_to_parse = ""
         step = "CONNECTED"
         return
     end
@@ -346,17 +606,75 @@ local function step_CIPOPEN()
         gcs:send_text(MAV_SEVERITY.ERROR, "Must set LTE_SERVER_PORT")
         return
     end
-    uart_write(string.format('AT+CIPOPEN=0,"TCP","%d.%d.%d.%d",%d\r\n',
-                                   LTE_SERVER_IP0:get(), LTE_SERVER_IP1:get(), LTE_SERVER_IP2:get(), LTE_SERVER_IP3:get(),
-                                   LTE_SERVER_PORT:get()))
+    cmux_data_send(string.format('AT+CIPOPEN=0,"TCP","%d.%d.%d.%d",%d\r\n',
+                                 LTE_SERVER_IP0:get(), LTE_SERVER_IP1:get(), LTE_SERVER_IP2:get(), LTE_SERVER_IP3:get(),
+                                 LTE_SERVER_PORT:get()))
 end
+
+--[[
+    handle AT replies in CMUX mode
+--]]
+local function handle_AT_reply(s)
+    -- check for CSQ reply
+    local rssi_raw, ber_raw = s:match("%+CSQ:%s*(%d+),(%d+)")
+    if rssi_raw then
+        gcs:send_named_float('LTE_RSSI', rssi_raw)
+        logger:write("LTE",'RSSI,BER,Bin,Bout','iiII',
+                     rssi_raw,
+                     ber_raw,
+                     stats.bytes_in,
+                     stats.bytes_out)
+        -- gcs:send_text(MAV_SEVERITY.INFO, string.format("RSSI:%d BER:%d", rssi_raw, ber_raw))
+        return
+    end
+    -- check for CSPI reply
+    -- example: +CPSI: LTE,Online,505-02,0xCBE8,36519691,101,EUTRAN-BAND3,1800,5,5,-147,-1143,-764,11
+    local system_mode, operation_mode, mcc_mnc, tac_str, scell_id_str, pcid_str, earfcn_band, ul_freq_str, dl_freq_str, tdd_cfg_str, rsrp_str, rsrq_str, rssi_str, sinr_str =
+    s:match("%+CPSI:%s*([^,]+),([^,]+),([^,]+),([^,]+),([^,]+),([^,]+),([^,]+),([^,]+),([^,]+),([^,]+),([%-]?%d+),([%-]?%d+),([%-]?%d+),([%-]?%d+)")
+
+    if system_mode then
+        -- Convert strings to numbers
+        local tac = tonumber(tac_str:match("0x(%w+)"), 16) or tonumber(tac_str) or 0
+        local scell_id = tonumber(scell_id_str) or 0
+        local pcid = tonumber(pcid_str) or 0
+        local ul_freq = tonumber(ul_freq_str) or 0
+        local dl_freq = tonumber(dl_freq_str) or 0
+        local tdd_cfg = tonumber(tdd_cfg_str) or 0
+        local rsrp = tonumber(rsrp_str) or 0
+        local rsrq = tonumber(rsrq_str) or 0
+        local rssi = tonumber(rssi_str) or 0
+        local sinr = tonumber(sinr_str) or 0
+        local band = earfcn_band:match("[^%d]+(%d+)") or -1
+        logger:write("LTES",'Md,Op,MCC,TAC,CID,PID,BND,F,DF,TDD,RP,RQ,RS,SR','nNNIIINHhhhhhh',
+                     system_mode, operation_mode, mcc_mnc, tac, scell_id, pcid, earfcn_band,
+                     ul_freq, dl_freq, tdd_cfg, rsrp, rsrq, rssi, sinr)
+        if option_enabled(LTE_OPTIONS_SIGNALS) then
+            gcs:send_named_float('LTE_RSRP', rsrp)
+            gcs:send_named_float('LTE_RSRQ', rsrq)
+            gcs:send_named_float('LTE_SINR', sinr)
+            gcs:send_named_float('LTE_BAND', band)
+            gcs:send_named_float('LTE_FREQ', ul_freq)
+            gcs:send_named_float('LTE_CID', scell_id)
+        end
+        return
+    end
+
+    if s:find("PPPD: DISCONNECTED") then
+        step = "PPPOPEN"
+    end
+end
+
+local last_CSQ_ms = millis()
+local last_CSQ_reply_ms = uint32_t(0)
+local last_parse_ms = uint32_t(0)
 
 --[[
     handle data while connected
 --]]
 local function step_CONNECTED()
     local s = uart:readstring(512)
-    if LTE_OPTIONS:get() & LTE_OPTIONS_LOGALL then
+    stats.bytes_in = stats.bytes_in + #s
+    if option_enabled(LTE_OPTIONS_LOGALL) then
         log_data(s, '<<<')
     end
     if s and s:find('\r\nCLOSED\r\n') then
@@ -364,19 +682,37 @@ local function step_CONNECTED()
         step = "CIPOPEN"
         return
     end
+    if s and s:find('PPPD: DISCONNECTED\r\n') then
+        gcs:send_text(MAV_SEVERITY.INFO, 'LTE_modem: PPP closed, reconnecting')
+        step = "PPPOPEN"
+        return
+    end
     local now_ms = millis()
     if s and #s > 0 then
-        last_data_ms = now_ms
-        pending_to_fc = pending_to_fc .. s
+        pending_to_parse = pending_to_parse .. s
+        pending_to_parse = cmux.feed_uart_in(pending_to_parse)
+        if now_ms - last_parse_ms > 1000 then
+            pending_to_parse = ""
+        end
+        if #cmux.buffers[1] > 0 then
+            last_parse_ms = now_ms
+            --gcs:send_text(MAV_SEVERITY.INFO, string.format("AT reply %d", #cmux.buffers[1]))
+            handle_AT_reply(cmux.buffers[1])
+            cmux.buffers[1] = ""
+        end
+        if #cmux.buffers[2] > 0 then
+            last_data_ms = now_ms
+            -- gcs:send_text(MAV_SEVERITY.INFO, string.format("data input %d", #cmux.buffers[2]))
+            last_parse_ms = now_ms
+            pending_to_fc = pending_to_fc .. cmux.buffers[2]
+            cmux.buffers[2] = ""
+        end
     elseif now_ms - last_data_ms > uint32_t(LTE_TIMEOUT:get() * 1000) then
         gcs:send_text(MAV_SEVERITY.ERROR, 'LTE_modem: timeout')
         step = "ATI"
         return
     end
     s = ser_device:readstring(512)
-    if LTE_OPTIONS:get() & LTE_OPTIONS_LOGALL then
-        log_data(s, '>>>')
-    end
     if s then
         pending_to_modem = pending_to_modem .. s
     end
@@ -393,11 +729,16 @@ local function step_CONNECTED()
         pending_to_fc = ""
     end
     
-    if #pending_to_modem > 0 then
-        local nwritten = uart:writestring(pending_to_modem)
-        if nwritten > 0 then
-            pending_to_modem = pending_to_modem:sub(nwritten + 1)
+    while #pending_to_modem > 0 do
+        local n = #pending_to_modem
+        if n > 127 then
+            n = 127
         end
+        -- gcs:send_text(MAV_SEVERITY.INFO, string.format("data output %d", n))
+        if not cmux_data_send_connected(pending_to_modem:sub(1, n)) then
+            break
+        end
+        pending_to_modem = pending_to_modem:sub(n + 1)
     end
     if #pending_to_fc > 0 then
         local nwritten = ser_device:writestring(pending_to_fc)
@@ -405,18 +746,49 @@ local function step_CONNECTED()
             pending_to_fc = pending_to_fc:sub(nwritten + 1)
         end
     end
+    -- request CSQ signal strength at 1Hz
+    if now_ms - last_CSQ_ms > 1000 then
+        last_CSQ_ms = now_ms
+        cmux_AT_send("AT+CSQ\r\n")
+        cmux_AT_send("AT+CPSI?\r\n")
+    end
+    if now_ms - last_CSQ_reply_ms > 5000 then
+        last_CSQ_reply_ms = now_ms
+        gcs:send_named_float('LTE_RSSI', -1)
+    end
 end
+
+local step_count = 0
+local last_step = nil
 
 local function update()
     if LTE_ENABLE:get() == 0 then
         return update, 500
     end
 
+    if change_baud then
+        uart:begin(change_baud)
+        change_baud = nil
+    end
+
     if step == "CONNECTED" then
         -- run the connected step at 200Hz
         step_CONNECTED()
+        step_count = 0
         return update, 5
     end
+
+    -- prevent getting stuck
+    if step == last_step and step ~= "ATI" then
+        step_count = step_count + 1
+        if step_count > 50 then
+            gcs:send_text(MAV_SEVERITY.INFO, "LTE_modem: step reset")
+            step = "ATI"
+        end
+    else
+        step_count = 0
+    end
+    last_step = step
 
     gcs:send_text(MAV_SEVERITY.INFO, string.format('LTE_modem: step %s', step))
 
@@ -425,34 +797,39 @@ local function update()
         return update, 1100
     end
 
-    if step == "CREG" then
-        step_CREG()
-        return update, 500
+    if step == "BAUD" then
+        step_BAUD()
+        return update, 200
     end
 
-    if step == "AUTOCSQ" then
-        step_AUTOCSQ()
+    if step == "CREG" then
+        step_CREG()
         return update, 500
     end
     
     if step == "CIPMODE" then
         step_CIPMODE()
-        return update, 500
+        return update, 200
     end
 
     if step == "NETOPEN" then
         step_NETOPEN()
-        return update, 500
+        return update, 200
+    end
+
+    if step == "CMUX" then
+        step_CMUX()
+        return update, 200
     end
 
     if step == "PPPOPEN" then
         step_PPPOPEN()
-        return update, 500
+        return update, 200
     end
     
     if step == "CIPOPEN" then
         step_CIPOPEN()
-        return update, 500
+        return update, 200
     end
 
     gcs:send_text(MAV_SEVERITY.ERROR, string.format("LTE_modem: bad step %s", step))

--- a/libraries/AP_Scripting/drivers/LTE_modem.md
+++ b/libraries/AP_Scripting/drivers/LTE_modem.md
@@ -83,22 +83,24 @@ Range: 1-65525. This is not used with PPP.
 
 ## LTE_BAUD
 
-This sets the baud rate for the serial port to the LTE modem. Common
-values are 9600, 57600, or 115200. The modem must be configured to use
-the same baud rate. Range: 9600-3686400. Default: 115200.
+This sets the baud rate for the serial port to the LTE modem to use
+for data transfer. Common values are 115200 or 921600. Default:
+115200.
 
-If using something other than 115200 you need to connect to the modem
-with a terminal program and use AT+IPREX=BAUD to set the baud rate and
-then save with AT&W. If the modem is wired to a flight controller then
-you can use the SERIAL_PASS parameters to give temporary control of
-the modem to a USB port so you can use a terminal protocol to
-configure the modem.
+## LTE_IBAUD
+
+The initial baud rate when the modem is powered on. This is normally
+115200 but can be changed in the modem using the AT+IREX terminal command.
 
 ## LTE_TIMEOUT
 
 This sets the timeout in seconds for the LTE connection. If no data is
 received for this time, the connection will be reset and the driver
 will attempt to reconnect. Range: 1-60 seconds. Default: 10 seconds.
+
+## LTE_OPTIONS
+
+This sets options for debugging and data display
 
 # Operation
 
@@ -131,7 +133,6 @@ port 20001. It assumes you have the modem on Telem1 (SERIAL1)
  - SCR_SDEV1_PROTO 48
  - SERIAL1_PROTOCOL 28
  - LTE_PROTOCOL 48
- - LTE_BAUD 115200
  - NET_ENABLE 1
  - NET_P1_TYPE 3
  - NET_P1_IP0 157
@@ -148,7 +149,6 @@ the support server is used and modem is attached on SERAL1 (no PPP used)
  - SCR_SDEV1_PROTO 2
  - SERIAL1_PROTOCOL 28
  - LTE_PROTOCOL 2
- - LTE_BAUD 115200
  - LTE_SERVER_IP0 157
  - LTE_SERVER_IP1 245
  - LTE_SERVER_IP2 83
@@ -194,3 +194,11 @@ Common issues:
 
 If the connection fails or is lost, the driver will automatically attempt
 to reconnect by restarting the connection sequence.
+
+# Logging
+
+A LTE log message is saved in the onboard log. That has signal
+strength information and data transfer statistics.
+
+A NAMED_VALUE_FLOAT MAVLink message "LTE_RSSI" is sent with the RSSI
+signal strength.

--- a/libraries/AP_Scripting/drivers/LTE_modem.md
+++ b/libraries/AP_Scripting/drivers/LTE_modem.md
@@ -1,9 +1,10 @@
-# SIM7600 LTE Modem Driver
+# LTE Modem Driver
 
-This driver implements support for SIM7600 LTE modems for establishing
+This driver implements support for LTE modems for establishing
 cellular data connections. It provides either PPP or a transparent TCP
 connectivity to a remote server through the LTE modem, allowing
-network communication over LTE networks without using a companion computer.
+network communication over LTE networks without using a companion
+computer.
 
 The driver best paired with with the ArduPilot remote support server
 https://support.ardupilot.org, but can also be used for any other
@@ -11,6 +12,11 @@ network service.
 
 If you don't have access to the ArduPilot support server you can
 install your own using https://github.com/ArduPilot/UDPProxy
+
+# Supported Hardware
+
+Currently the only modem that is supported is the SIM76xx series of
+modems from SimCom.
 
 # Parameters
 
@@ -154,28 +160,28 @@ the support server is used and modem is attached on SERAL1 (no PPP used)
 The driver provides status messages through the GCS indicating the current
 connection state:
 
-- "SIM7600: starting" - Driver initialization
-- "SIM7600: found modem" - Modem detected and responding
-- "SIM7600: CREG OK" - Network registration successful
-- "SIM7600: transparent mode set" - Modem configured for transparent operation
-- "SIM7600: network opened" - Network stack ready
-- "SIM7600: connected" - TCP connection established
-- "SIM7600: connection closed, reconnecting" - Connection lost, attempting reconnection
-- "SIM7600: timeout" - No data received within timeout period
-- "SIM7600: error response from modem" - Modem returned an error
+- "LTE_modem: starting" - Driver initialization
+- "LTE_modem: found modem" - Modem detected and responding
+- "LTE_modem: CREG OK" - Network registration successful
+- "LTE_modem: transparent mode set" - Modem configured for transparent operation
+- "LTE_modem: network opened" - Network stack ready
+- "LTE_modem: connected" - TCP connection established
+- "LTE_modem: connection closed, reconnecting" - Connection lost, attempting reconnection
+- "LTE_modem: timeout" - No data received within timeout period
+- "LTE_modem: error response from modem" - Modem returned an error
 
 # Physical Connections
 
-The SIM7600 modem should be connected to a flight controller serial
+The modem should be connected to a flight controller serial
 port. You may also want to use a serial port with hardware flow
 control support and set BRD_SERn_RTSCRS to 1 for that port.
 
-Note that the SIM7600 can be quite sensitive to power supply
+Note that the modems can be quite sensitive to power supply
 issues. The power from the serial port will likely not be sufficient.
 
 # Troubleshooting
 
-The driver creates a log file "SIM7600.log" on the SD card that contains
+The driver creates a log file "LTE_modem.log" on the SD card that contains
 all communication with the modem. This log can be useful for debugging
 connection issues.
 


### PR DESCRIPTION
This adds GSM 07.10 muxing to the LTE modem driver, allowing it to maintain separate AT command streams and data streams for PPP or transparent TCP
This allows us to query the signal strength and other information about the link while running PPP.
It also allows for auto-baudrate changing, so the user can set LTE_BAUD to a higher baud rate without having to pre-configure the modem.

