### PR TITLE
Adjust Ainstein LR-D1 driver to handle new packet format

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -9937,7 +9937,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             simname='ainsteinlrd1',
             maxalt=100,
             sqalt=95,
-            sq_at_sqalt=100,
+            sq_at_sqalt=39,
         )
 
     def RangeFinderDriversLongRange(self):

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -9877,26 +9877,38 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             self.reboot_sitl()
             self.fly_rangefinder_drivers_fly([x.name for x in do_drivers])
 
-    def RangeFinderDriversMaxAlt(self):
+    def RangeFinderDriversMaxAlt_FlyDriver(self,
+                                           name : str,
+                                           rngfnd_type : int,
+                                           simname : str,
+                                           maxalt : float,
+                                           sqalt : float = None,
+                                           sq_at_sqalt : float = None,
+                                           ):
         '''test max-height behaviour'''
         # lightwareserial goes to 130m when out of range
+        self.progress(f"Flying {name}")
         self.set_parameters({
             "SERIAL4_PROTOCOL": 9,
-            "RNGFND1_TYPE": 8,
+            "RNGFND1_TYPE": rngfnd_type,
             "WPNAV_SPEED_UP": 1000,  # cm/s
         })
         self.customise_SITL_commandline([
-            "--serial4=sim:lightwareserial",
+            f"--serial4=sim:{simname}",
         ])
-        self.takeoff(95, mode='GUIDED', timeout=240, max_err=0.5)
-        self.assert_rangefinder_distance_between(90, 100)
+        takeoff_alt = sqalt
+        if sqalt is None:
+            takeoff_alt = maxalt
+        self.takeoff(takeoff_alt, mode='GUIDED', timeout=240, max_err=0.5)
+        self.assert_rangefinder_distance_between(takeoff_alt-5, takeoff_alt+5)
 
-        self.wait_rangefinder_distance(90, 100)
+        self.wait_rangefinder_distance(takeoff_alt-5, takeoff_alt+5)
 
         rf_bit = mavutil.mavlink.MAV_SYS_STATUS_SENSOR_LASER_POSITION
 
         self.assert_sensor_state(rf_bit, present=True, enabled=True, healthy=True)
-        self.assert_distance_sensor_quality(100)
+        if sq_at_sqalt is not None:
+            self.assert_distance_sensor_quality(sq_at_sqalt)
 
         self.progress("Moving higher to be out of max rangefinder range")
         self.fly_guided_move_local(0, 0, 150)
@@ -9906,7 +9918,19 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.assert_distance_sensor_quality(1)
 
-        self.do_RTL()
+        # life's too short for soft landings:
+        self.disarm_vehicle(force=True)
+
+    def RangeFinderDriversMaxAlt(self) -> None:
+        '''test max-height behaviour'''
+        self.RangeFinderDriversMaxAlt_FlyDriver(
+            name="LightwareSerial",
+            rngfnd_type=8,
+            simname='lightwareserial',
+            maxalt=100,
+            sqalt=95,
+            sq_at_sqalt=100,
+        )
 
     def RangeFinderDriversLongRange(self):
         '''test rangefinder above 327m'''

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -9931,6 +9931,14 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             sqalt=95,
             sq_at_sqalt=100,
         )
+        self.RangeFinderDriversMaxAlt_FlyDriver(
+            name="Ainstein-LR-D1",
+            rngfnd_type=42,
+            simname='ainsteinlrd1',
+            maxalt=100,
+            sqalt=95,
+            sq_at_sqalt=100,
+        )
 
     def RangeFinderDriversLongRange(self):
         '''test rangefinder above 327m'''

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.cpp
@@ -82,7 +82,6 @@ bool AP_RangeFinder_Ainstein_LR_D1::get_reading(float &reading_m)
     if (u.packet.header_lsb != PACKET_HEADER_LSB ||
         u.packet.device_id != 0x00 ||
         u.packet.length != 28 ||
-        u.packet.objects_number != 1 ||
         u.calculate_checksum() != u.packet.checksum) {
         // sanity checks failed - discard and try again next time we're called:
         move_signature_in_buffer(1);

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.cpp
@@ -123,7 +123,11 @@ bool AP_RangeFinder_Ainstein_LR_D1::get_reading(float &reading_m)
             The altitude measurements should not in any circumstances be used as true
             measurements independently of the corresponding SNR values. 
         */
-        signal_quality_pct = (snr <= 13 || malfunction_alert != 0) ? RangeFinder::SIGNAL_QUALITY_MIN : RangeFinder::SIGNAL_QUALITY_MAX;
+    signal_quality_pct = linear_interpolate(
+        RangeFinder::SIGNAL_QUALITY_MIN, RangeFinder::SIGNAL_QUALITY_MAX,
+        snr,
+        0, 255
+    );
 
         if (snr <= 13) {
             if (snr == 0) {

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.cpp
@@ -24,61 +24,84 @@
 #include "AP_RangeFinder_Ainstein_LR_D1.h"
 #include <GCS_MAVLink/GCS.h>
 
+#include <AP_HAL/utility/sparse-endian.h>
+
+static const uint8_t PACKET_HEADER_MSB = 0xEB;
+static const uint8_t PACKET_HEADER_LSB = 0x90;
+
+// make sure we know what size the packet object is:
+// assert_storage_size<AP_RangeFinder_Ainstein_LR_D1::LRD1Union::LRD1Packet, 32> _assert_storage_lrd1_packet;
+
+// ensures that there is a packet starting at offset 0 in the buffer.
+// If that's not the case this returns false.  Search starts at offset
+// start in the buffer - if a packet header is found at a non-zero
+// offset then the data is moved to the start of the buffer.
+bool AP_RangeFinder_Ainstein_LR_D1::move_signature_in_buffer(uint8_t start)
+{
+    for (uint8_t i=start; i<buffer_used; i++) {
+        if (u.buffer[i] == PACKET_HEADER_MSB) {
+            memmove(&u.buffer[0], &u.buffer[i], buffer_used-i);
+            buffer_used -= i;
+            return true;
+        }
+    }
+    // header byte not in buffer
+    buffer_used = 0;
+    return false;
+}
+
+uint8_t AP_RangeFinder_Ainstein_LR_D1::LRD1Union::calculate_checksum() const
+{
+    // the -4 here is 3 bytes of header and 1 byte of checksum
+    return crc_sum_of_bytes(&buffer[3], sizeof(u.packet)-4);
+}
+
 // get_reading - read a value from the sensor
 bool AP_RangeFinder_Ainstein_LR_D1::get_reading(float &reading_m)
 {
-    if (uart == nullptr || uart->available() == 0) {
+    if (uart == nullptr) {
         return false;
     }
 
-    bool has_data = false;
+    const uint8_t num_read = uart->read(&u.buffer[buffer_used], ARRAY_SIZE(u.buffer)-buffer_used);
+    buffer_used += num_read;
 
-    uint32_t available = MAX(uart->available(), static_cast<unsigned int>(PACKET_SIZE*4));
-    while (available >= PACKET_SIZE) {
-        // ---------------
-        // Sync up with the header
-        const uint8_t header[] = {
-            0xEB,   // Header MSB
-            0x90,   // Header LSB
-            0x00   // Device ID
-        };
-        for (uint8_t i = 0; i<ARRAY_SIZE(header); i++) {
-            available--;
-            if (uart->read() != header[i]) {
-                continue;
-            }
-        }
+    if (buffer_used == 0) {
+        return false;
+    }
 
-        const uint8_t rest_of_packet_size = (PACKET_SIZE - ARRAY_SIZE(header));
-        if (available < rest_of_packet_size) {  
-            return false;
-        }
+    if (!move_signature_in_buffer(0)) {
+        return false;
+    }
 
-        // ---------------
-        // header is aligned!
-        // ---------------
+    if (buffer_used < sizeof(u.packet)) {
+        return false;
+    }
 
-        uint8_t buffer[rest_of_packet_size];
-        available -= uart->read(buffer, ARRAY_SIZE(buffer));
+    // sanity checks; see data sheet on these fixed values.
+    if (u.packet.header_lsb != PACKET_HEADER_LSB ||
+        u.packet.device_id != 0x00 ||
+        u.packet.length != 28 ||
+        u.packet.objects_number != 1 ||
+        u.calculate_checksum() != u.packet.checksum) {
+        // sanity checks failed - discard and try again next time we're called:
+        move_signature_in_buffer(1);
+        return false;
+    }
 
-        const uint8_t checksum = buffer[ARRAY_SIZE(buffer)-1]; // last byte is a checksum
-        if (crc_sum_of_bytes(buffer, ARRAY_SIZE(buffer)-1) != checksum) {
-            // bad Checksum
-            continue;
-        }
-
-        const uint8_t malfunction_alert = buffer[1];
-        reading_m = UINT16_VALUE(buffer[3], buffer[4]) * 0.01;
-        const uint8_t snr = buffer[5];
+    reading_m = be16toh(u.packet.object1_alt) * 0.01;
 
 #if AP_RANGEFINDER_AINSTEIN_LR_D1_SHOW_MALFUNCTIONS
         const uint32_t now_ms = AP_HAL::millis();
+        const uint8_t malfunction_alert = u.packet.malfunction_alert;
         if (malfunction_alert_prev != malfunction_alert && now_ms - malfunction_alert_last_send_ms >= 1000) {
             report_malfunction(malfunction_alert, malfunction_alert_prev);
             malfunction_alert_prev = malfunction_alert;
             malfunction_alert_last_send_ms = now_ms;
         }
 #endif
+
+    const uint8_t snr = u.packet.object1_snr;
 
         /* From datasheet:
             Altitude measurements associated with a SNR value 
@@ -90,6 +113,8 @@ bool AP_RangeFinder_Ainstein_LR_D1::get_reading(float &reading_m)
             measurements independently of the corresponding SNR values. 
         */
         signal_quality_pct = (snr <= 13 || malfunction_alert != 0) ? RangeFinder::SIGNAL_QUALITY_MIN : RangeFinder::SIGNAL_QUALITY_MAX;
+
+    bool has_data = false;
 
         if (snr <= 13) {            
             has_data = false;           
@@ -104,7 +129,9 @@ bool AP_RangeFinder_Ainstein_LR_D1::get_reading(float &reading_m)
             has_data = true;
             state.status = RangeFinder::Status::Good;
         }
-    }
+
+    // consume this packet:
+    move_signature_in_buffer(sizeof(u.packet));
 
     return has_data;
 }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.cpp
@@ -114,6 +114,32 @@ bool AP_RangeFinder_Ainstein_LR_D1::get_reading(float &reading_m)
 
     const uint8_t snr = u.packet.object1_snr;
 
+    signal_quality_pct = linear_interpolate(
+        RangeFinder::SIGNAL_QUALITY_MIN, RangeFinder::SIGNAL_QUALITY_MAX,
+        snr,
+        0, 255
+    );
+
+    if (is_v19000) {
+        abort();
+
+        // the device explicitly tells us if it is out-of-range:
+        switch (u.packet_v19000.out_of_range_indication) {
+        default: // invalid value / malformed packet
+        case 0:  // "undefined altitude"
+            return false;
+        case 1:  // "Valid Altitude"
+            break;
+        case 2:  // "Altitude is too close"
+            reading_m = min_distance() - 1;
+            break;
+        case 3:  // "Altitude is too far"
+            reading_m = max_distance() + 1;
+            break;
+        }
+    } else {  // not a v19.0.0.0 packet; we try to infer out-of-range
+              // from the SNR field:
+
         /* From datasheet:
             Altitude measurements associated with a SNR value 
             of 13dB or lower are considered erroneous. 
@@ -123,11 +149,6 @@ bool AP_RangeFinder_Ainstein_LR_D1::get_reading(float &reading_m)
             The altitude measurements should not in any circumstances be used as true
             measurements independently of the corresponding SNR values. 
         */
-    signal_quality_pct = linear_interpolate(
-        RangeFinder::SIGNAL_QUALITY_MIN, RangeFinder::SIGNAL_QUALITY_MAX,
-        snr,
-        0, 255
-    );
 
         if (snr <= 13) {
             if (snr == 0) {
@@ -135,6 +156,7 @@ bool AP_RangeFinder_Ainstein_LR_D1::get_reading(float &reading_m)
                 reading_m = max_distance() + 1;
             }
         }
+    }
 
     // consume this packet:
     move_signature_in_buffer(sizeof(u.packet));

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.cpp
@@ -108,7 +108,7 @@ bool AP_RangeFinder_Ainstein_LR_D1::get_one_reading(float &reading_m)
 
     // distinguish between old and new packet format by inspecting
     // "byte 12" (offset 11); in the old format this will always be
-    // 0xff.
+    // 0xff.  This was offset count, now is error flags.
     const bool is_v19000 = (u.packet_v19000.out_of_range_indication != 0xff);
 
     // same for both packet formats:

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.cpp
@@ -56,8 +56,26 @@ uint8_t AP_RangeFinder_Ainstein_LR_D1::LRD1Union::calculate_checksum() const
     return crc_sum_of_bytes(&buffer[3], sizeof(u.packet)-4);
 }
 
-// get_reading - read a value from the sensor
+// get_reading - read all samples, return last.  The device sends at
+// 40Hz, so there should only ever be one sample available.  Assuming
+// that something's gone wrong with scheduling, we will simply return
+// the last.
 bool AP_RangeFinder_Ainstein_LR_D1::get_reading(float &reading_m)
+{
+    bool ret = false;
+    for (uint8_t i=0; i<10; i++) {
+        float tmp_reading = 0;
+        if (!get_one_reading(tmp_reading)) {
+            break;
+        }
+        ret = true;
+        reading_m = tmp_reading;
+    }
+    return ret;
+}
+
+// get_one_reading - read a value from the sensor
+bool AP_RangeFinder_Ainstein_LR_D1::get_one_reading(float &reading_m)
 {
     if (uart == nullptr) {
         return false;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.cpp
@@ -175,7 +175,7 @@ void AP_RangeFinder_Ainstein_LR_D1::report_malfunction(const uint8_t _malfunctio
         { MalfunctionAlert::Temperature, "Temperature" },
         { MalfunctionAlert::Voltage, "Voltage" },
         { MalfunctionAlert::IFSignalSaturation, "IF signal saturation" },
-        { MalfunctionAlert::AltitudeReading, "Attitude reading overflow" },
+        { MalfunctionAlert::AltitudeReading, "Altitude reading overflow" },
     };
 
     for (const auto &alert : alerts) {

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.cpp
@@ -96,6 +96,7 @@ bool AP_RangeFinder_Ainstein_LR_D1::get_reading(float &reading_m)
             if (snr == 0) {
                 state.status = RangeFinder::Status::OutOfRangeHigh;
                 reading_m = MAX(656, max_distance() + 1);
+                has_data = true;
             } else {
                 state.status = RangeFinder::Status::NoData;
             }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.cpp
@@ -111,6 +111,12 @@ bool AP_RangeFinder_Ainstein_LR_D1::get_one_reading(float &reading_m)
     // 0xff.  This was offset count, now is error flags.
     const bool is_v19000 = (u.packet_v19000.out_of_range_indication != 0xff);
 
+    static uint8_t last_out_of_range_indication = -1;
+    if (u.packet_v19000.out_of_range_indication != last_out_of_range_indication) {
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "out_of_range_field = %u", u.packet_v19000.out_of_range_indication);
+        last_out_of_range_indication = u.packet_v19000.out_of_range_indication;
+    }
+
     // same for both packet formats:
     reading_m = be16toh(u.packet.object1_alt) * 0.01;
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.cpp
@@ -120,14 +120,15 @@ bool AP_RangeFinder_Ainstein_LR_D1::get_reading(float &reading_m)
         0, 255
     );
 
-    if (is_v19000) {
-        abort();
+    bool have_reading = true;
 
+    if (is_v19000) {
         // the device explicitly tells us if it is out-of-range:
         switch (u.packet_v19000.out_of_range_indication) {
         default: // invalid value / malformed packet
         case 0:  // "undefined altitude"
-            return false;
+            have_reading = false;
+            break;
         case 1:  // "Valid Altitude"
             break;
         case 2:  // "Altitude is too close"
@@ -161,7 +162,7 @@ bool AP_RangeFinder_Ainstein_LR_D1::get_reading(float &reading_m)
     // consume this packet:
     move_signature_in_buffer(sizeof(u.packet));
 
-    return true;
+    return have_reading;
 }
 
 #if AP_RANGEFINDER_AINSTEIN_LR_D1_SHOW_MALFUNCTIONS

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.cpp
@@ -125,26 +125,17 @@ bool AP_RangeFinder_Ainstein_LR_D1::get_reading(float &reading_m)
         */
         signal_quality_pct = (snr <= 13 || malfunction_alert != 0) ? RangeFinder::SIGNAL_QUALITY_MIN : RangeFinder::SIGNAL_QUALITY_MAX;
 
-    bool has_data = false;
-
-        if (snr <= 13) {            
-            has_data = false;           
+        if (snr <= 13) {
             if (snr == 0) {
-                state.status = RangeFinder::Status::OutOfRangeHigh;
-                reading_m = MAX(656, max_distance() + 1);
-                has_data = true;
-            } else {
-                state.status = RangeFinder::Status::NoData;
+                // out-of-range high:
+                reading_m = max_distance() + 1;
             }
-        } else {
-            has_data = true;
-            state.status = RangeFinder::Status::Good;
         }
 
     // consume this packet:
     move_signature_in_buffer(sizeof(u.packet));
 
-    return has_data;
+    return true;
 }
 
 #if AP_RANGEFINDER_AINSTEIN_LR_D1_SHOW_MALFUNCTIONS

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.cpp
@@ -88,11 +88,23 @@ bool AP_RangeFinder_Ainstein_LR_D1::get_reading(float &reading_m)
         return false;
     }
 
+    // distinguish between old and new packet format by inspecting
+    // "byte 12" (offset 11); in the old format this will always be
+    // 0xff.
+    const bool is_v19000 = (u.packet_v19000.out_of_range_indication != 0xff);
+
+    // same for both packet formats:
     reading_m = be16toh(u.packet.object1_alt) * 0.01;
 
 #if AP_RANGEFINDER_AINSTEIN_LR_D1_SHOW_MALFUNCTIONS
         const uint32_t now_ms = AP_HAL::millis();
-        const uint8_t malfunction_alert = u.packet.malfunction_alert;
+        uint16_t malfunction_alert;
+        if (is_v19000) {
+            // new packet format allows for 16 bits:
+            malfunction_alert = be16toh(u.packet_v19000.malfunction_alert);
+        } else {
+            malfunction_alert = u.packet.malfunction_alert;
+        }
         if (malfunction_alert_prev != malfunction_alert && now_ms - malfunction_alert_last_send_ms >= 1000) {
             report_malfunction(malfunction_alert, malfunction_alert_prev);
             malfunction_alert_prev = malfunction_alert;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.h
@@ -35,6 +35,14 @@ protected:
         return 115200;
     }
 
+    // make sure readings go out-of-range when necessary
+    float max_distance() const override  {
+        return MIN(AP_RangeFinder_Backend::max_distance(), 500);
+    }
+    float min_distance() const override {
+        return MAX(AP_RangeFinder_Backend::min_distance(), 0.7);
+    }
+
 private:
 
     using AP_RangeFinder_Backend_Serial::AP_RangeFinder_Backend_Serial;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.h
@@ -55,9 +55,37 @@ private:
         AltitudeReading   = (1U << 7),  // 0x80
     };
 
-    static constexpr uint8_t PACKET_SIZE = 32;
+    union LRD1Union {
+        struct PACKED LRD1Packet {
+            uint8_t header_msb;
+            uint8_t header_lsb;
+            uint8_t device_id;
+            uint8_t length;  // "fixed as 28 bytes"
+            uint8_t malfunction_alert;
+            uint8_t objects_number;  // "fixed as 1"
+            uint16_t object1_alt;
+            uint8_t object1_snr;
+            uint16_t object1_velocity;
+            uint8_t unused[20];
+            uint8_t checksum;  // (data4+data5+…+data29+data31) bitwise-AND with 0xFF
+        } packet;
+        uint8_t buffer[64];  // each packet is 30 bytes long
+
+        // return checksum calculated from data in buffer
+        uint8_t calculate_checksum() const;
+    } u;
+    uint8_t buffer_used;
+
     uint8_t malfunction_alert_prev;
     uint32_t malfunction_alert_last_send_ms;
+
     int8_t signal_quality_pct = RangeFinder::SIGNAL_QUALITY_UNKNOWN;    
+
+    // ensures that there is a packet starting at offset 0 in the
+    // buffer.  If that's not the case this returns false.  Search
+    // starts at offset start in the buffer - if a packet header is
+    // found at a non-zero offset then the data is moved to the start
+    // of the buffer.
+    bool move_signature_in_buffer(uint8_t start);
 };
 #endif

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.h
@@ -55,6 +55,16 @@ private:
         AltitudeReading   = (1U << 7),  // 0x80
     };
 
+    // Ainstein LR-D1 firmware emits a single message with the same
+    // header bytes, size, device_id and length, but different
+    // meanings for some of the fields!  We differentiate between the
+    // "original" packet and the new-style packet by looking at the
+    // "byte 12" (at offset 11).  If it is not 0xff then we consider
+    // the packet to be of the "v19.0.0" format.  In this new format
+    // there is no objectt count, there are 16 malfunction alert bits,
+    // "byte 12" contains the unit's self-assessed height-valid
+    // information a lot of fields move from "other object readings"
+    // to "reserved"
     union LRD1Union {
         struct PACKED LRD1Packet {
             uint8_t header_msb;
@@ -69,14 +79,27 @@ private:
             uint8_t unused[20];
             uint8_t checksum;  // (data4+data5+…+data29+data31) bitwise-AND with 0xFF
         } packet;
-        uint8_t buffer[64];  // each packet is 30 bytes long
+        struct PACKED LRD1Packet_v19000 {
+            uint8_t header_msb;
+            uint8_t header_lsb;
+            uint8_t device_id;
+            uint8_t length;  // "fixed as 28 bytes"
+            uint16_t malfunction_alert;
+            uint16_t object1_alt;
+            uint8_t object1_snr;
+            uint16_t object1_velocity;
+            uint8_t out_of_range_indication;
+            uint8_t reserved[19];
+            uint8_t checksum;  // (data4+data5+…+data29+data31) bitwise-AND with 0xFF
+        } packet_v19000;
+        uint8_t buffer[64];  // each packet is 32 bytes long
 
         // return checksum calculated from data in buffer
         uint8_t calculate_checksum() const;
     } u;
     uint8_t buffer_used;
 
-    uint8_t malfunction_alert_prev;
+    uint16_t malfunction_alert_prev;
     uint32_t malfunction_alert_last_send_ms;
 
     int8_t signal_quality_pct = RangeFinder::SIGNAL_QUALITY_UNKNOWN;    

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.h
@@ -75,7 +75,7 @@ private:
     // "original" packet and the new-style packet by looking at the
     // "byte 12" (at offset 11).  If it is not 0xff then we consider
     // the packet to be of the "v19.0.0" format.  In this new format
-    // there is no objectt count, there are 16 malfunction alert bits,
+    // there is no object count, there are 16 malfunction alert bits,
     // "byte 12" contains the unit's self-assessed height-valid
     // information a lot of fields move from "other object readings"
     // to "reserved"

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.h
@@ -47,8 +47,14 @@ private:
 
     using AP_RangeFinder_Backend_Serial::AP_RangeFinder_Backend_Serial;
 
-    // get a reading
+    // get_reading - read all samples, return last.  The device sends at
+    // 40Hz, so there should only ever be one sample available.  Assuming
+    // that something's gone wrong with scheduling, we will simply return
+    // the last.
     bool get_reading(float &reading_m) override;
+
+    // get a reading
+    bool get_one_reading(float &reading_m);
 
     // 0 is no return value, 100 is perfect.  false means signal
     // quality is not available

--- a/libraries/SITL/SIM_RF_Ainstein_LR_D1.cpp
+++ b/libraries/SITL/SIM_RF_Ainstein_LR_D1.cpp
@@ -30,7 +30,12 @@ uint32_t RF_Ainstein_LR_D1::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uin
 
     uint8_t malfunction_alert = 0;
 
-    const uint8_t snr = (alt_cm == 0xFFFF) ? 0 : 100;
+    uint8_t snr = 100;
+    if (alt_cm > 10000) {
+        // out of range @100m
+        snr = 0;
+        alt_cm = 146;  // bogus flag value
+    }
 
     buffer[0] = 0xEB;  // packet header msb
     buffer[1] = 0x90;  // packet header lsb


### PR DESCRIPTION
More information to come here, but a new protocol format allows the rangefinder to directly return its ranging status.
