### PR TITLE
CI: validate parameter files

### DIFF
--- a/.github/workflows/test_scripts.yml
+++ b/.github/workflows/test_scripts.yml
@@ -20,6 +20,7 @@ jobs:
             astyle-cleanliness,
             validate_board_list,
             logger_metadata,
+            param-file-validation,
        ]
     steps:
       # git checkout the PR

--- a/Tools/scripts/board_list.py
+++ b/Tools/scripts/board_list.py
@@ -3,6 +3,7 @@
 import os
 import re
 import fnmatch
+from collections.abc import Collection
 
 '''
 list of boards for build_binaries.py and custom build server
@@ -27,10 +28,10 @@ class Board(object):
         ]
 
 
-def in_blacklist(blacklist, b):
-    '''return true if board b is in the blacklist, including wildcards'''
-    for bl in blacklist:
-        if fnmatch.fnmatch(b, bl):
+def in_boardlist(boards : Collection[str], board : str) -> bool:
+    '''return true if board is in a collection of wildcard patterns'''
+    for pattern in boards:
+        if fnmatch.fnmatch(board, pattern):
             return True
     return False
 
@@ -145,7 +146,7 @@ class BoardList(object):
                 ret += [line]
         return ret
 
-    def find_autobuild_boards(self, build_target=None):
+    def find_autobuild_boards(self, build_target=None, skip : Collection[str] = None):
         ret = []
         for board in self.boards:
             if board.is_ap_periph:
@@ -156,33 +157,34 @@ class BoardList(object):
         # Omitting them for backwards-compatability here - but we
         # should probably have a line in the hwdef indicating they
         # shouldn't be auto-built...
-        blacklist = [
-            # IOMCU:
-            "iomcu",
-            'iomcu_f103_8MHz',
+        if skip is None:
+            skip = [
+                # IOMCU:
+                "iomcu",
+                'iomcu_f103_8MHz',
 
-            # bdshot
-            "fmuv3-bdshot",
+                # bdshot
+                "fmuv3-bdshot",
 
-            # renamed to KakuteH7Mini-Nand
-            "KakuteH7Miniv2",
+                # renamed to KakuteH7Mini-Nand
+                "KakuteH7Miniv2",
 
-            # renamed to AtomRCF405NAVI
-            "AtomRCF405"
+                # renamed to AtomRCF405NAVI
+                "AtomRCF405"
 
-            # other
-            "crazyflie2",
-            "CubeOrange-joey",
-            "luminousbee4",
-            "MazzyStarDrone",
-            "omnibusf4pro-one",
-            "skyviper-f412-rev1",
-            "SkystarsH7HD",
-            "*-ODID",
-            "*-ODID-heli",
-        ]
+                # other
+                "crazyflie2",
+                "CubeOrange-joey",
+                "luminousbee4",
+                "MazzyStarDrone",
+                "omnibusf4pro-one",
+                "skyviper-f412-rev1",
+                "SkystarsH7HD",
+                "*-ODID",
+                "*-ODID-heli",
+            ]
 
-        ret = filter(lambda x : not in_blacklist(blacklist, x), ret)
+        ret = filter(lambda x : not in_boardlist(skip, x), ret)
 
         # if the caller has supplied a vehicle to limit to then we do that here:
         if build_target is not None:
@@ -199,18 +201,19 @@ class BoardList(object):
 
         return sorted(list(ret))
 
-    def find_ap_periph_boards(self):
-        blacklist = [
-            "CubeOrange-periph-heavy",
-            "f103-HWESC",
-            "f103-Trigger",
-            "G4-ESC",
-        ]
+    def find_ap_periph_boards(self, skip : Collection[str] = None):
+        if skip is None:
+            skip = [
+                "CubeOrange-periph-heavy",
+                "f103-HWESC",
+                "f103-Trigger",
+                "G4-ESC",
+            ]
         ret = []
         for x in self.boards:
             if not x.is_ap_periph:
                 continue
-            if x.name in blacklist:
+            if in_boardlist(skip, x.name):
                 continue
             ret.append(x.name)
         return sorted(list(ret))

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -513,6 +513,14 @@ for t in $CI_BUILD_TARGET; do
         continue
     fi
 
+    if [ "$t" == "param-file-validation" ]; then
+        echo "Testing param check script"
+        ./Tools/scripts/param_check_unittests.py
+        echo "Validating parameter files"
+        ./Tools/scripts/param_check_all.py
+        continue
+    fi
+
     if [ "$t" == "configure-all" ]; then
         echo "Checking configure of all boards"
         ./Tools/scripts/configure_all.py

--- a/Tools/scripts/param_check.py
+++ b/Tools/scripts/param_check.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python
+
+"""
+Parameter File Validation Script
+
+This script validates a set of parameter files against the generated metadata
+for a specific firmware type (e.g. Plane, AP_Periph). The following checks are
+performed on each parameter in the files:
+
+- Ensure that the parameter exists in the metadata.
+- Validate that the parameter's value falls within a specified range.
+- Confirm that the parameter's value matches one a defined value.
+- Check bitmask parameters to ensure all set bits are valid.
+
+Usage:
+    python param_check.py --vehicle <vehicle_type> <parameter_files>
+
+Where:
+    - `<vehicle_type>` is the type of vehicle (or comma-separated list of
+      vehicles) for which to generate metadata. Valid values are: Sub, Plane,
+      Blimp, Copter, Tracker, Rover, AP_Periph.
+    - `<parameter_files>` is a list of parameter file paths to validate,
+       supporting wildcard patterns.
+
+Example:
+    python Tools/scripts/param_check.py --vehicle Plane Tools/autotest/default_params/*plane.parm
+
+AP_FLAKE8_CLEAN
+
+"""
+
+import os
+import json
+import re
+import glob
+import subprocess
+from argparse import ArgumentParser
+
+
+class SkippedChecks:
+    """A class to hold the skipped checks flags."""
+    def __init__(self, **kwargs):
+        self.no_missing = kwargs.get('no_missing', False)
+        self.no_redefinition = kwargs.get('no_redefinition', False)
+        self.no_readonly = kwargs.get('no_readonly', False)
+        self.no_bitmask = kwargs.get('no_bitmask', False)
+        self.no_range = kwargs.get('no_range', False)
+        self.no_values = kwargs.get('no_values', False)
+
+
+def parse_arguments():
+    """Parses command-line arguments, and expands any wildcard patterns."""
+    parser = ArgumentParser(description='Validate parameter files')
+    parser.add_argument('files', nargs='+', help='Parameter files to validate')
+    parser.add_argument(
+        '--vehicle', help='Vehicle type for which to generate metadata (default: all vehicles)',
+    )
+    parser.add_argument('--quiet-success', action='store_true', help='Only print errors, not successes')
+
+    # flags for disabling checks
+    parser.add_argument('--no-missing', action='store_true', help='Disable missing check')
+    parser.add_argument('--no-redefinition', action='store_true', help='Disable redefinition check')
+    parser.add_argument('--no-readonly', action='store_true', help='Disable read-only check')
+    parser.add_argument('--no-bitmask', action='store_true', help='Disable bitmask check')
+    parser.add_argument('--no-range', action='store_true', help='Disable range check')
+    parser.add_argument('--no-values', action='store_true', help='Disable values check')
+
+    args = parser.parse_args()
+
+    # Expand any wildcards in the list of files
+    files = []
+    for pattern in args.files:
+        files += glob.glob(pattern, recursive=True)
+    args.files = files
+
+    # If no vehicle is specified, default to all
+    if not args.vehicle:
+        args.vehicle = 'Sub,Plane,Blimp,Copter,Tracker,Rover,AP_Periph'
+
+    return args
+
+
+def check_file(file, metadata, skip=SkippedChecks()):
+    """Checks a single parameter file against the metadata.
+
+    Loads the parameters from the specified file and validates each parameter
+    against the provided metadata dictionary. It returns a list of error
+    messages for any invalid parameters found, or an empty list if all
+    parameters are valid.
+
+    Args:
+        file (str): The path to the parameter file to be checked.
+        metadata (dict): A dictionary containing the parameter metadata.
+        skip (SkippedChecks): Determines which checks to skip.
+
+    Returns:
+        list: A list of error messages if any parameters are invalid.
+    """
+    params, msgs = load_params(file, skip)
+
+    for param in params:
+        if param not in metadata:
+            if not skip.no_missing:
+                msgs.append(f'{param} not found in metadata')
+        else:
+            value, checks_disabled = params[param]
+            # If checks are disabled in a comment, then we enable all checks
+            # regardless of args (by passing None). We want to enforce that
+            # the DISABLE_CHECKS in the comment is necessary.
+            msg = check_param(
+                param,
+                value,
+                metadata[param],
+                skip if not checks_disabled else None,
+            )
+            # Assert that the DISABLE_CHECKS flag is necessary
+            if checks_disabled:
+                msg = (
+                    f'{param} does not need DISABLE_CHECKS'
+                    if msg is None
+                    else None
+                )
+            if msg:
+                msgs.append(msg)
+
+    return msgs
+
+
+def check_param(name, value, metadata, skip=SkippedChecks()):
+    """Checks a single parameter against its metadata definition.
+
+    Validates the specified parameter. If the metadata contains multiple types
+    of validity fields (e.g. Range and Values), only the first one encountered
+    will be checked in this priority order: ReadOnly, Bitmask, Range, Values.
+
+    Args:
+        name (str): The name of the parameter to be checked.
+        value (float): The value of the parameter as a float.
+        metadata (dict): A dictionary containing metadata for the parameter.
+        skip (SkippedChecks): Determines which checks to skip.
+
+    Returns:
+        str: An error message if the parameter is invalid, or None otherwise.
+    """
+    # List of checks with their corresponding skip flags and check functions
+    checks = [
+        (
+            'ReadOnly',
+            skip.no_readonly,
+            lambda: f'{name} is read only' if metadata['ReadOnly'] else None,
+        ),
+        (
+            'Bitmask',
+            skip.no_bitmask,
+            lambda: check_bitmask(name, value, metadata['Bitmask']),
+        ),
+        (
+            'Range',
+            skip.no_range,
+            lambda: check_range(name, value, metadata['Range']),
+        ),
+        (
+            'Values',
+            skip.no_values,
+            lambda: check_values(name, value, metadata['Values']),
+        ),
+    ]
+
+    for key, skip_flag, check_func in checks:
+        if key in metadata:
+            return check_func() if not skip_flag else None
+
+    # If none of the above, it's automatically valid
+    return None
+
+
+def check_bitmask(name, value, metadata):
+    """Validates a parameter against its bitmask metadata.
+
+    Checks if the parameter value is a positive integer and if each bit set in
+    the value corresponds to a valid bit in the metadata. It returns an error
+    message if any invalid bits are set.
+
+    Args:
+        name (str): The name of the parameter being checked.
+        value (float): The value of the parameter as a float.
+        metadata (dict): A dictionary containing bitmask definitions.
+
+    Returns:
+        str: An error message if the parameter is invalid, or None otherwise.
+    """
+    if not float(value).is_integer():
+        return f'{name}: {value:g} is not an integer'
+
+    value = int(float(value))
+
+    # Maximum number of expected bits
+    N = 64
+
+    if value < 0:
+        return f'{name}: {value} is negative'
+
+    if value >= (1 << N):
+        return f'{name}: {value} is larger than {N} bits'
+
+    # Loop through the set bits and confirm all correspond to something
+    for i in range(64):
+        # Break if we've checked the highest set bit
+        if value < (1 << i):
+            break
+        # Check if the bit is set, and if so, if it's described in the metadata
+        if value & (1 << i) and str(i) not in metadata:
+            return f'{name}: bit {i} is not valid'
+
+    return None
+
+
+def check_range(name, value, metadata):
+    """Validates a parameter against its range metadata.
+
+    Checks if the parameter value falls within the defined minimum and maximum
+    range in the metadata. It returns an error message if the value is out of
+    range.
+
+    Args:
+        name (str): The name of the parameter being checked.
+        value (float): The value of the parameter as a float.
+        metadata (dict): A dictionary containing the 'low' and 'high' range.
+
+    Returns:
+        str: An error message if the parameter is invalid, or None otherwise.
+    """
+
+    if value < float(metadata['low']):
+        return f'{name}: {value:g} is below minimum value {metadata["low"]}'
+    if value > float(metadata['high']):
+        return f'{name}: {value:g} is above maximum value {metadata["high"]}'
+
+    return None
+
+
+def check_values(name, value, metadata):
+    """Validates a parameter against its list of valid values.
+
+    Checks if the parameter value is one of the valid values listed in the
+    metadata. It returns an error message if the value is not in the list.
+
+    Args:
+        name (str): The name of the parameter being checked.
+        value (float): The value of the parameter as a float.
+        metadata (dict): A dictionary containing valid values for the parameter.
+
+    Returns:
+        str: An error message if the parameter is invalid, or None otherwise.
+    """
+    if f'{float(value):g}' not in metadata:
+        return f'{name}: {value:g} is not a valid value'
+
+    return None
+
+
+def load_params(file, skip=SkippedChecks(), depth=0):
+    """Loads a parameter file and returns parameters and errors.
+
+    Reads the specified parameter file, stripping out comments. It checks the
+    comments for a DISABLE_CHECKS flag. It builds a dictionary of parameters
+    and their values/disabled checks, and returns it along with any errors
+    encountered.
+
+    It will also check for redefinition of parameters within a single file (not
+    counting params from @include files) unless args.no_redefinition is set.
+
+    Args:
+        file (str): The path to the parameter file to be loaded.
+        skip (SkippedChecks): Determines which checks to skip.
+        depth (int): The depth of the recursive call to prevent infinite loops.
+
+    Returns:
+        tuple: (params, errors)
+            - params (dict): A dictionary where the keys are parameter names
+              and the values are tuples containing the parameter value as a
+              float and a boolean indicating if checks are disabled.
+            - errors (list): A list of error messages encountered during
+              parsing.
+    """
+    if depth > 10:
+        raise ValueError("Too many levels of @include")
+
+    params = {}
+    errors = []
+
+    with open(file, 'r') as file_object:
+        lines = file_object.readlines()
+
+    seen_params = set()
+    for i, line in enumerate(lines):
+        # Strip whitespace
+        processed_line = line.strip()
+
+        # Handle @include directives
+        if processed_line.startswith('@include'):
+            rel_path = line.split(maxsplit=1)[1].strip()
+            path = os.path.join(os.path.dirname(file), rel_path)
+            params2, errors2 = load_params(path, skip, depth + 1)
+            params.update(params2)
+            errors.extend(errors2)
+            continue  # Skip to next line
+
+        # Strip out stuff like the @READONLY tag
+        processed_line = re.sub(r'@\S*', '', processed_line)
+
+        # Handle comments
+        comment = ''
+        if '#' in processed_line:
+            i = processed_line.index('#')
+            comment = processed_line[i + 1:].strip()
+            processed_line = processed_line[:i].strip()
+
+        # Check for DISABLE_CHECKS flag
+        checks_disabled = 'DISABLE_CHECKS' in comment
+
+        # Check that a valid reason is provided if checks are disabled
+        explanation = ''.join(comment.split('DISABLE_CHECKS')).strip()
+        if checks_disabled and len(explanation) < 5:
+            errors.append(
+                f'Explanation required for disabled checks: `{line.strip()}`'
+            )
+            continue  # Skip to next line after logging the error
+
+        # Strip whitespace again
+        processed_line = processed_line.strip()
+
+        # Skip any empty lines
+        if not processed_line:
+            continue
+
+        # Split on , or any whitespace
+        parts = re.split(r'[,=\s]+', processed_line, 1)
+
+        # Check for redefinition
+        if parts[0] in seen_params and not skip.no_redefinition:
+            errors.append(f'{parts[0]} redefined')
+        seen_params.add(parts[0])
+
+        # Try to convert the value string to a float
+        try:
+            value = parts[1]
+            if '.' in value:
+                value = float(value)  # Convert hex to float
+            else:
+                # int(x, 0) will handle 0x and 0b prefixes
+                value = float(int(value, 0))  # Convert hex to float
+            # Store the parameter in the dictionary
+            params[parts[0]] = (value, checks_disabled)
+        except (IndexError, ValueError):
+            errors.append(f'Error parsing line: `{line.strip()}`')
+
+    return params, errors
+
+
+def generate_metadata(vehicle):
+    """Generates and returns metadata for a specific vehicle.
+
+    Runs an external script to generate the metadata for the specified vehicle.
+    Returns a dictionary with parameter names as keys and a metadata dictionary
+    for that parameter as values. The metadata includes information such as
+    whether the parameter is read-only, its valid range, and valid values.
+
+    Args:
+        vehicle (str): The type of vehicle for which to generate metadata.
+
+    Returns:
+        dict: A dictionary with parameter names as keys and metadata dicts for
+        each parameter as values.
+
+    Raises:
+        RuntimeError: If there is an error generating the metadata or if the
+        metadata file is not created or not updated.
+    """
+    metadata_script = os.path.join(
+        os.path.dirname(__file__), '../autotest/param_metadata/param_parse.py'
+    )
+    metadata_script = os.path.abspath(metadata_script)
+    metadata_file = 'apm.pdef.json'
+    # If the metadata file already exists, store the modification time so we
+    # can check if it gets updated
+    previous_mtime = (
+        os.path.getmtime(metadata_file) if os.path.exists(metadata_file) else 0
+    )
+
+    try:
+        subprocess.run(
+            ['python3', metadata_script, f'--vehicle={vehicle}', '--format=json'],
+            check=True,
+            capture_output=True,
+            text=True
+        )
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(
+            f'Error generating metadata for vehicle {vehicle}: {e.stderr.strip()}'
+        ) from e
+
+    if not os.path.exists(metadata_file):
+        raise RuntimeError(
+            f'Error: Metadata file "{metadata_file}" was not created.'
+        )
+
+    current_mtime = os.path.getmtime(metadata_file)
+    if current_mtime <= previous_mtime:
+        raise RuntimeError(
+            f'Error: Metadata file "{metadata_file}" was not updated.'
+        )
+
+    with open(metadata_file, 'r') as file:
+        json_file = json.load(file)
+
+    # Delete the metadata file, as we don't need it anymore
+    os.remove(metadata_file)
+
+    # Flatten the json file to remove the parameter groups
+    metadata = {}
+    for group in json_file:
+        if group == 'json':
+            # There is an  extra group with the json version. Skip it.
+            continue
+        metadata.update(json_file[group])
+
+    return metadata
+
+
+def get_metadata(vehicles):
+    """Generates merged metadata for multiple vehicles.
+
+    Generates metadata for each vehicle in the provided list and merges them
+    into a single dictionary. This is useful for validating parameters across
+    multiple vehicle types.
+    Args:
+        vehicles (list): A list of vehicle types to load metadata for.
+    Returns:
+        dict: A dictionary containing the merged metadata for all specified
+        vehicles. See generate_metadata for details.
+    """
+    metadata = {}
+    for vehicle in vehicles:
+        meta2 = generate_metadata(vehicle)
+        for param, meta in meta2.items():
+            if param not in metadata:
+                metadata[param] = meta
+            else:
+                for key, value in meta.items():
+                    if key not in metadata[param]:
+                        metadata[param][key] = value
+                    elif isinstance(metadata[param][key], dict):
+                        # Merge dictionaries
+                        metadata[param][key].update(value)
+    return metadata
+
+
+def main():
+    """Main function for the script."""
+    args = parse_arguments()
+
+    if not args.files:
+        print('Error: No parameter files specified.')
+        exit(1)
+
+    skip = SkippedChecks(
+        no_missing=args.no_missing,
+        no_redefinition=args.no_redefinition,
+        no_readonly=args.no_readonly,
+        no_bitmask=args.no_bitmask,
+        no_range=args.no_range,
+        no_values=args.no_values,
+    )
+
+    metadata = get_metadata(args.vehicle.split(','))
+
+    # Dictionary to store error messages for each file
+    messages = {} # {filename: [error messages]}
+
+    # Check each file, and store any error messages
+    for file in args.files:
+        msgs = check_file(file, metadata, skip)
+        messages[os.path.relpath(file)] = msgs
+
+    # Print the success/failure for each file
+    for file in messages:
+        if not messages[file]:
+            if not args.quiet_success:
+                print(f'{file}: Passed')
+        else:
+            print(f'{file}: Failed')
+            for msg in messages[file]:
+                print(f'  {msg}')
+
+    # Check if any files failed (i.e. have error messages)
+    if any(messages[file] for file in messages):
+        exit(1)
+
+
+if __name__ == '__main__':
+    main() # pragma: no cover

--- a/Tools/scripts/param_check_all.py
+++ b/Tools/scripts/param_check_all.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+
+'''
+Check all default parameter files for all hwdef boards and sitl targets.
+
+AP_FLAKE8_CLEAN
+'''
+
+import os
+import sys
+import glob
+from board_list import BoardList
+from param_check import get_metadata, check_file, SkippedChecks
+
+sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../Tools', 'autotest'))
+from pysim.vehicleinfo import VehicleInfo # noqa: E402
+
+
+vehicle_hwdefs_to_skip = set([
+    'CubeGreen-solo',
+    'CubeSolo',
+    'KakuteF4Mini',
+    'SPRacingH7RF',
+    'SkystarsH7HD',
+    'Swan-K1',
+    'luminousbee5',
+    'skyviper-journey',
+    'skyviper-v2450',
+])
+
+periph_hwdefs_to_skip = set([ # Most of these fail due to NET_ params
+    'BotBloxDroneNet',
+    'CubeNode-ETH',
+    'CubeRedPrimary-PPPGW',
+    'MatekG474-Periph', # Fails for RC_PORT
+    'Pixhawk6X-PPPGW',
+    'kha_eth',
+    'sw-boom-f407', # Fails for ESC_NUM_POLES*
+])
+
+sitl_params_to_skip = set([
+    'default_params/blimp.parm',
+    'default_params/stratoblimp.parm',
+    'default_params/motorboat.parm',
+    'default_params/sub.parm',
+    'default_params/sub-6dof.parm',
+])
+
+frame_params_to_skip = set([
+    'QuadPlanes/XPlane-Alia.parm',
+    'SkyWalkerX8.param',
+    'TradHeli_Copter36_Upgrade-MP.param',
+    'SkyWalkerX8_ReverseThrust.param',
+    'Solo_Copter-3.5_GreenCube.param',
+    'eLAB_LAB470_AC35.param',
+    'ArduRoller-balancebot.param',
+    'eLAB_VEK_AI_Rover.param',
+    'AION_R1_Rover.param',
+    'HK-HydroProInception-Rover350.param',
+    'Holybro-kospi1.param',
+    'intel-aero-rtf.param',
+    'EFlight_Convergence.param',
+    'WLToys_V383_HeliQuad.param',
+    'ThunderTiger-ToyotaHilux-Rover.param',
+    'deset-mapping-boat.param',
+    'TradHeli_Copter36_Setup-MP.param',
+    'eLAB_LAB445_AC34.param',
+    'boogie-board-boat.param',
+    '3DR_Iris+_AC34.param',
+    'intel-aero-rtf-cb.param',
+    'eLAB_EX700_AC34.param',
+    'HK-hydrotek-Rover331.param',
+    'DJI_AGRAS_MG-1_AC413.param',
+    'eLAB_EX1050_AC34.param',
+    'Solo_Copter-3.6_GreenCube.param',
+    'Parrot_Disco/Parrot_Disco.param',
+    'QuadPlanes/Mugin_EV350.param',
+    'QuadPlanes/Aerofox_AYK320.param',
+    'QuadPlanes/Foxtech_GreatShark.param',
+])
+
+
+VEHICLE_BOARDS = BoardList().find_autobuild_boards(skip=vehicle_hwdefs_to_skip)
+PERIPH_BOARDS = BoardList().find_ap_periph_boards(skip=periph_hwdefs_to_skip)
+
+# List of all firmware that isn't AP_Periph
+ALL_VEHICLE_FIRMWARES = ['Sub', 'Plane', 'Blimp', 'Copter', 'Tracker', 'Rover']
+
+
+def check_boards(boards, firmwares, skip=SkippedChecks()):
+    '''Check parameter files for ChibiOS hwdef boards.'''
+    hwdef_dir = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        '..', '..', 'libraries', 'AP_HAL_ChibiOS', 'hwdef'
+    )
+    hwdef_dir = os.path.abspath(hwdef_dir)
+    param_files = [
+        os.path.join(hwdef_dir, board, '**', f'*.{ext}')
+        for board in boards
+        for ext in ['parm', 'param']
+    ]
+
+    # Find all parameter files
+    param_files = [f for pattern in param_files for f in glob.glob(pattern, recursive=True)]
+
+    return check_files(param_files, firmwares, skip=skip)
+
+
+def check_sitl(skip=SkippedChecks()):
+    '''Check every parameter file that shows up in vehicleinfo.py
+
+    Because this also provides us information about the intended firmware, we
+    can check it strictly against the parameter metadata for that specific
+    firmware, unlike the non-periph hwdef boards.
+    '''
+    vinfo = VehicleInfo()
+    vehicle_name = {
+        'ArduCopter': 'Copter',
+        'Helicopter': 'Copter',
+        'Blimp': 'Blimp',
+        'ArduPlane': 'Plane',
+        'Rover': 'Rover',
+        'ArduSub': 'Sub',
+        'AntennaTracker': 'Tracker',
+        'sitl_periph_universal': 'AP_Periph'
+    }
+    directory = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        '..', '..', 'Tools', 'autotest'
+    )
+    success = True
+    for key, opts in vinfo.options.items():
+        print(f"Checking {key} SITL boards...")
+        vehicle = vehicle_name[key]
+        files = []
+        for frame_opts in opts['frames'].values():
+            if not frame_opts.get('default_params_filename'):
+                continue
+            defaults = frame_opts['default_params_filename']
+            # defaults is a string or a list of strings
+            if isinstance(defaults, str):
+                defaults = [defaults]
+            for default in defaults:
+                if default in files:
+                    continue
+                if default in sitl_params_to_skip:
+                    continue
+                default = os.path.relpath(os.path.join(directory, default))
+                if not os.path.exists(default):
+                    raise FileNotFoundError(f"Default parameter file {default} does not exist")
+                files.append(default)
+        if not files:
+            print(f"No SITL default files for {vehicle}")
+            continue
+        success &= check_files(files, [vehicle], skip=skip)
+
+    return success
+
+
+def check_frame_params(skip=SkippedChecks()):
+    '''Check all files within Tools/Frame_params
+
+    These don't contain any information about firmware (e.g. Copter, Plane,
+    etc.), so we check them against all vehicles, but it would be a good idea
+    to strictly check them against the intended firmware in the future.
+    '''
+    frame_params_dir = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        '..', '..', 'Tools', 'Frame_params'
+    )
+    frame_params_dir = os.path.abspath(frame_params_dir)
+    param_files_raw = glob.glob(os.path.join(frame_params_dir, '**', '*.parm'), recursive=True)
+    param_files_raw += glob.glob(os.path.join(frame_params_dir, '**', '*.param'), recursive=True)
+
+    # Filter out files that are in the skiplist
+    param_files = []
+    for file in param_files_raw:
+        if os.path.relpath(file, frame_params_dir) in frame_params_to_skip:
+            continue
+        param_files.append(file)
+
+    return check_files(param_files, ALL_VEHICLE_FIRMWARES, skip=skip)
+
+
+def check_files(files, firmwares, skip=SkippedChecks()):
+    '''Check a list of parameter files against the metadata'''
+    metadata = get_metadata(firmwares)
+    success = True
+    for file in files:
+        msgs = check_file(file, metadata, skip=skip)
+        if msgs:
+            success = False
+            print(f"Errors in {file}:")
+            for msg in msgs:
+                print(f"  {msg}")
+    return success
+
+
+def main():
+    skip = SkippedChecks(
+        no_range=True,
+        no_values=True,
+        no_bitmask=True,
+    )
+    success = True
+    print("Checking peripheral boards...")
+    success &= check_boards(PERIPH_BOARDS, ['AP_Periph'], skip=skip)
+    print("Checking vehicle boards...")
+    success &= check_boards(VEHICLE_BOARDS, ALL_VEHICLE_FIRMWARES, skip=skip)
+    print("Checking SITL...")
+    success &= check_sitl(skip=skip)
+    print("Checking frame parameters...")
+    success &= check_frame_params(skip=skip)
+    if not success:
+        print("Parameter checks failed!")
+        sys.exit(1)
+    print("All parameter checks passed!")
+
+
+if __name__ == '__main__':
+    main()

--- a/Tools/scripts/param_check_unittests.py
+++ b/Tools/scripts/param_check_unittests.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+
+"""
+Parameter File Checker Unit Tests
+
+AP_FLAKE8_CLEAN
+"""
+
+import os
+import time
+import unittest
+import subprocess
+from unittest.mock import MagicMock, patch, mock_open
+from param_check import (
+    SkippedChecks,
+    load_params,
+    check_param,
+    check_range,
+    check_values,
+    check_bitmask,
+    generate_metadata,
+    get_metadata,
+    check_file,
+    parse_arguments,
+    main
+)
+
+
+class TestParamCheck(unittest.TestCase):
+
+    def test_load_params(self):
+        # Mock parameter file content
+        base_mock_content = '''
+        PARAM1, 1
+        PARAM2\t0x10 @READONLY # Comment
+        # Comment
+        @tag
+        @include filename.parm
+        PARAM3   42.5#comment
+        PARAM4, 0x0F #DISABLE_CHECKS for some reason
+        '''
+        mock_file_content = base_mock_content
+        mock_included_content = '''
+        INCLUDED1, 123
+        INCLUDED2, 456
+        '''
+
+        def file_side_effect(file, *args, **kwargs):
+            if file == 'fake_file.parm':
+                return mock_open(read_data=mock_file_content)()
+            if file == 'filename.parm':
+                return mock_open(read_data=mock_included_content)()
+
+        with patch('builtins.open', side_effect=file_side_effect):
+            params, msgs = load_params('fake_file.parm')
+
+        # Test the correct parsing of parameters and DISABLE_CHECKS flag
+        self.assertEqual(params['PARAM1'], (1.0, False))
+        self.assertEqual(params['PARAM2'], (16.0, False))
+        self.assertEqual(params['PARAM3'], (42.5, False))
+        self.assertEqual(params['PARAM4'], (15.0, True))
+        self.assertEqual(msgs, [])
+
+        # Bad parameter lines that should fail to parse and exit the program
+        bad_lines = [
+            'PARAM5 1 2\n',
+            'PARAM5\n',
+            'P#ARAM5 1\n',
+            'PARAM5, 0x10.0\n',
+        ]
+        for line in bad_lines:
+            mock_file_content = base_mock_content + line
+            with patch('builtins.open', side_effect=file_side_effect):
+                _, msgs = load_params('fake_file.parm')
+            self.assertEqual(msgs, [f'Error parsing line: `{line.strip()}`'])
+
+        # Test that the program exits when DISABLE_CHECKS does not have a reason
+        mock_file_content = base_mock_content + 'PARAM4, 0x10 #DISABLE_CHECKS: \n'
+        with patch('builtins.open', side_effect=file_side_effect):
+            _, msgs = load_params('fake_file.parm')
+        self.assertEqual(msgs, ['Explanation required for disabled checks: `PARAM4, 0x10 #DISABLE_CHECKS:`'])
+
+        # Test that self-includes raise an error for infinite recursion
+        mock_file_content = base_mock_content + '@include fake_file.parm\n'
+        with patch('builtins.open', side_effect=file_side_effect):
+            with self.assertRaises(ValueError) as cm:
+                load_params('fake_file.parm')
+            self.assertEqual(str(cm.exception), 'Too many levels of @include')
+
+    def test_check_range(self):
+        # Mock metadata and parameters
+        metadata = {'low': 0.0, 'high': 100.0}
+        self.assertIsNone(check_range('PARAM', 50.0, metadata))
+        self.assertEqual(check_range('PARAM', -1.0, metadata), 'PARAM: -1 is below minimum value 0.0')
+        self.assertEqual(check_range('PARAM', 101.0, metadata), 'PARAM: 101 is above maximum value 100.0')
+
+    def test_check_values(self):
+        # Mock metadata and parameters
+        metadata = {'0': 'Off', '1': 'On'}
+        self.assertIsNone(check_values('PARAM', 0, metadata))
+        self.assertEqual(check_values('PARAM', 2, metadata), 'PARAM: 2 is not a valid value')
+
+    def test_check_bitmask(self):
+        # Mock metadata and parameters
+        metadata = {'0': 'Bit0', '1': 'Bit1'}
+        self.assertIsNone(check_bitmask('PARAM', 3.0, metadata))
+        self.assertEqual(check_bitmask('PARAM', 4.0, metadata), 'PARAM: bit 2 is not valid')
+        self.assertEqual(check_bitmask('PARAM', 1.5, metadata), 'PARAM: 1.5 is not an integer')
+
+    @patch('subprocess.run')
+    @patch('os.remove')
+    @patch('os.path.getmtime')
+    @patch('os.path.exists', return_value=True)
+    @patch('builtins.open', new_callable=mock_open, read_data='{}')
+    @patch('json.load', return_value={'GROUP1': {'PARAM1': {}}, 'GROUP2': {'PARAM2': {}}, 'json': {'version': 0}})
+    @patch('builtins.print')
+    def test_generate_metadata(self, mock_print, mock_json, mock_open, mock_exists, mock_getmtime, mock_remove, mock_run):
+        # When the function calls getmtime, it will return the current time
+        mock_getmtime.side_effect = lambda path: time.time()
+
+        # Call the function
+        metadata = generate_metadata('Plane')
+
+        # Test subprocess was called correctly
+        metadata_script = os.path.join(
+            os.path.dirname(__file__), '../autotest/param_metadata/param_parse.py'
+        )
+        metadata_script = os.path.abspath(metadata_script)
+        mock_run.assert_called_once_with(
+            ['python3', metadata_script, '--vehicle=Plane', '--format=json'],
+            check=True,
+            capture_output=True,
+            text=True
+        )
+
+        # Test that the metadata was loaded and that the json was flattened
+        # (and that the json version was stripped out)
+        self.assertEqual(metadata, {'PARAM1': {}, 'PARAM2': {}})
+
+        # Test that we raise a runtime error if the metadata file exists but is
+        # not updated
+        now = time.time()
+        mock_getmtime.side_effect = lambda path: now
+        with self.assertRaises(RuntimeError) as cm:
+            generate_metadata('Plane')
+        self.assertEqual('Error: Metadata file "apm.pdef.json" was not updated.', str(cm.exception))
+
+        # Test that we raise a runtime error if the metadata file does not
+        # exist after generation
+        mock_exists.return_value = False
+        with self.assertRaises(RuntimeError) as cm:
+            generate_metadata('Plane')
+        self.assertEqual('Error: Metadata file "apm.pdef.json" was not created.', str(cm.exception))
+
+        # Test that we raise a runtime error if CalledProcessError is raised
+        mock_run.side_effect = subprocess.CalledProcessError(
+            returncode=1,
+            cmd='python3',
+            output='Error running script',
+            stderr='Error details'
+        )
+        with self.assertRaises(RuntimeError) as cm:
+            generate_metadata('Plane')
+
+        self.assertIn('Error generating metadata for vehicle Plane', str(cm.exception))
+
+    @patch('param_check.generate_metadata')
+    def test_get_metadata_merges(self, mock_generate_metadata):
+        mock_generate_metadata.side_effect = [
+            {
+                'PARAM1': {
+                    'Description': 'plane PARAM1',
+                    'Bitmask': {'0': 'bit0', '1': 'bit1'},
+                },
+                'PARAM2': {
+                    'Description': 'plane PARAM3',
+                    'Range': {'low': '-1', 'high': '200'},
+                    'Values': {'0': 'Off', '1': 'On'},
+                },
+                'PARAM3': {'Description': 'plane PARAM2'},
+            },
+            {
+                'PARAM1': {
+                    'Description': 'copter PARAM1',
+                    'Bitmask': {'0': 'bit0copter', '2': 'bit2'},
+                },
+                'PARAM2': {
+                    'desc': 'copter3',
+                    'Range': {'low': '-100', 'high': '10'},
+                    'Values': {'0': 'Off', '1': 'On', '50': 'SoTotallyOn'},
+                },
+                'PARAM4': {'Description': 'copter PARAM4'},
+            },
+        ]
+        vehicles = ['Plane', 'Copter']
+        merged = get_metadata(vehicles)
+
+        # Matching field content gets overwritten by the last vehicle's
+        # metadata, but extra fields get added (we need to make sure values and
+        # bitmasks cover all valid values for all vehicles; we don't actually
+        # care about the content)
+
+        # Check that all keys are present in PARAM1's bitmask
+        self.assertIn('0', merged['PARAM1']['Bitmask'])
+        self.assertIn('1', merged['PARAM1']['Bitmask'])
+        self.assertIn('2', merged['PARAM1']['Bitmask'])
+
+        # Check that all keys are present in PARAM2's values
+        self.assertIn('0', merged['PARAM2']['Values'])
+        self.assertIn('1', merged['PARAM2']['Values'])
+        self.assertIn('50', merged['PARAM2']['Values'])
+
+        # Check that PARAM3 and PARAM4 are present
+        self.assertIn('PARAM3', merged)
+        self.assertIn('PARAM4', merged)
+
+        # Check that all params still have a non-empty description
+        # (just to ensure we're not dropping other fields somehow)
+        for param in ['PARAM1', 'PARAM2', 'PARAM3', 'PARAM4']:
+            self.assertTrue(merged[param]['Description'])
+
+    def test_check_param(self):
+        metadata = {
+            'Description': 'This is a test parameter',
+            'ReadOnly': True,
+            'Bitmask': {'0': 'Bit0', '1': 'Bit1', '8': 'Bit8'},
+            'Range': {'low': '0.0', 'high': '100.0'},
+            'Values': {'0': 'Off', '1': 'On'}
+        }
+        skip = SkippedChecks()
+
+        # Test ReadOnly
+        self.assertEqual(check_param('PARAM', 0, metadata, skip), 'PARAM is read only')
+        skip.no_readonly = True
+        self.assertIsNone(check_param('PARAM', 0, metadata, skip))
+
+        # Test Bitmask
+        del metadata['ReadOnly']  # Remove ReadOnly to test the next priority
+        self.assertIsNone(check_param('PARAM', 256.0, metadata, skip)) # 256 would fail the other checks, but pass bitmask
+        self.assertEqual(check_param('PARAM', 1.5, metadata, skip), 'PARAM: 1.5 is not an integer')
+        self.assertEqual(check_param('PARAM', -1, metadata, skip), 'PARAM: -1 is negative')
+        self.assertEqual(
+            check_param('PARAM', 18446744073709551616, metadata, skip),
+            'PARAM: 18446744073709551616 is larger than 64 bits'
+        )
+        self.assertEqual(check_param('PARAM', 4, metadata, skip), 'PARAM: bit 2 is not valid')
+        skip.no_bitmask = True
+        self.assertIsNone(check_param('PARAM', 4, metadata, skip))
+
+        # Test Range
+        del metadata['Bitmask']  # Remove Bitmask to test the next priority
+        self.assertIsNone(check_param('PARAM', 50, metadata, skip)) # 50 will fail the values check, but pass the range check
+        self.assertEqual(check_param('PARAM', 101, metadata, skip), 'PARAM: 101 is above maximum value 100.0')
+        self.assertEqual(check_param('PARAM', -1, metadata, skip), 'PARAM: -1 is below minimum value 0.0')
+        skip.no_range = True
+        self.assertIsNone(check_param('PARAM', -1, metadata, skip))
+
+        # Test Values
+        del metadata['Range']  # Remove Range to test the next priority
+        self.assertIsNone(check_param('PARAM', 0, metadata, skip))
+        self.assertEqual(check_param('PARAM', 2, metadata, skip), 'PARAM: 2 is not a valid value')
+        skip.no_values = True
+        self.assertIsNone(check_param('PARAM', 2, metadata, skip))
+
+        # Test parameter with no range, bitmask, or value restrictions
+        del metadata['Values']
+        self.assertIsNone(check_param('PARAM', 0, metadata, skip)) # Should pass no matter what
+
+    @patch('param_check.check_param')
+    def test_check_file(self, mock_check_param):
+        mock_skip = SkippedChecks()
+
+        # Case 1: All parameters pass their checks
+        mock_file_content = "PARAM1, 10\nPARAM2, 20\n"
+        mock_metadata = {'PARAM1': {}, 'PARAM2': {}}
+        # Mock check_param to return None for all params, indicating they pass validation
+        mock_check_param.side_effect = lambda name, value, metadata, skip: None
+        with patch('builtins.open', mock_open(read_data=mock_file_content)):
+            msgs = check_file('fake_file.parm', mock_metadata, mock_skip)
+        # Check that no error messages were returned
+        self.assertEqual(msgs, [])
+        # Check that check_param was called for each parameter
+        self.assertEqual(mock_check_param.call_count, 2)
+
+        # Case 2: Missing parameter (PARAM3 not in metadata)
+        mock_file_content += "PARAM3, 30\n"
+        with patch('builtins.open', mock_open(read_data=mock_file_content)):
+            msgs = check_file('fake_file.parm', mock_metadata, mock_skip)
+        # Check that a missing parameter error is reported
+        self.assertEqual(msgs, ['PARAM3 not found in metadata'])
+
+        # Case 3: Missing parameter but with no-missing flag
+        mock_skip.no_missing = True
+        with patch('builtins.open', mock_open(read_data=mock_file_content)):
+            msgs = check_file('fake_file.parm', mock_metadata, mock_skip)
+        # Check that no error messages are returned when no-missing is enabled
+        self.assertEqual(msgs, [])
+
+        # Case 4: Valid parameter with DISABLE_CHECKS flag, and invalid parameter
+        # (should report both errors)
+        mock_file_content = "PARAM1, 50.0 # DISABLE_CHECKS: reason\nPARAM2, 0\n"
+        # Mock check_param so PARAM1 is valid, but not PARAM2
+        mock_check_param.side_effect = lambda name, value, metadata, skip: (
+            None if name in ['PARAM1'] else f'{name}: Error'
+        )
+        with patch('builtins.open', mock_open(read_data=mock_file_content)):
+            msgs = check_file('fake_file.parm', mock_metadata, mock_skip)
+        self.assertEqual(
+            msgs,
+            [
+                'PARAM1 does not need DISABLE_CHECKS',
+                'PARAM2: Error',
+            ],
+        )
+
+        # Case 5: Invalid parameter but with DISABLE_CHECKS (should pass)
+        mock_file_content = "PARAM1, 150.0\nPARAM2, 200.0 # DISABLE_CHECKS: reason\n"
+        with patch('builtins.open', mock_open(read_data=mock_file_content)):
+            msgs = check_file('fake_file.parm', mock_metadata, mock_skip)
+        # Check that no error messages are returned because DISABLE_CHECKS is valid
+        self.assertEqual(msgs, [])
+
+        # Case 6: Redefined parameter
+        mock_file_content = "PARAM1, 10\nPARAM1, 20\n"
+        with patch('builtins.open', mock_open(read_data=mock_file_content)):
+            msgs = check_file('fake_file.parm', mock_metadata, mock_skip)
+        # Check that a redefined parameter error is reported
+        self.assertEqual(msgs, ['PARAM1 redefined'])
+
+        # Case 7: Redefined parameter but with no-redefinition flag
+        mock_skip.no_redefinition = True
+        with patch('builtins.open', mock_open(read_data=mock_file_content)):
+            msgs = check_file('fake_file.parm', mock_metadata, mock_skip)
+        # Check that no error messages are returned when no-redefinition is enabled
+        self.assertEqual(msgs, [])
+
+    @patch('param_check.glob.glob')
+    @patch('sys.argv', ['param_check.py', 'file1.parm', 'file2.parm'])
+    def test_parse_arguments_defaults(self, mock_glob):
+        # Simulate glob returning the same file names
+        mock_glob.side_effect = lambda pattern, recursive=True: [pattern]
+        args = parse_arguments()
+        self.assertEqual(args.files, ['file1.parm', 'file2.parm'])
+        # Should default to all vehicles
+        self.assertEqual(args.vehicle, 'Sub,Plane,Blimp,Copter,Tracker,Rover,AP_Periph')
+        self.assertFalse(args.quiet_success)
+
+    @patch('param_check.glob.glob')
+    @patch(
+        'sys.argv',
+        [
+            'param_check.py', 'file*.parm',
+            '--vehicle=Plane,Copter',
+            '--quiet-success', '--no-missing', '--no-redefinition', '--no-readonly',
+            '--no-bitmask', '--no-range', '--no-values',
+        ],
+    )
+    def test_parse_arguments_all_flags(self, mock_glob):
+        # Simulate glob expanding file*.parm to two files
+        mock_glob.side_effect = lambda pattern, recursive=True: ['file1.parm', 'file2.parm'] if pattern == 'file*.parm' else []
+        args = parse_arguments()
+        self.assertEqual(args.files, ['file1.parm', 'file2.parm'])
+        self.assertEqual(args.vehicle, 'Plane,Copter')
+        self.assertTrue(args.quiet_success)
+        self.assertTrue(args.no_missing)
+        self.assertTrue(args.no_redefinition)
+        self.assertTrue(args.no_readonly)
+        self.assertTrue(args.no_bitmask)
+        self.assertTrue(args.no_range)
+        self.assertTrue(args.no_values)
+
+    @patch('param_check.parse_arguments')
+    @patch('param_check.generate_metadata')
+    @patch('param_check.check_file')
+    @patch('builtins.print')
+    def test_main(self, mock_print, mock_check_file, mock_generate_metadata, mock_parse_arguments):
+
+        # Setup mock for parse_arguments
+        mock_args = MagicMock()
+        mock_args.vehicle = 'Plane'
+        mock_args.files = ['file1.parm', 'file2.parm']
+        mock_args.quiet_success = False
+        mock_parse_arguments.return_value = mock_args
+
+        # Setup mock for generate_metadata
+        mock_generate_metadata.return_value = {'PARAM1': {}, 'PARAM2': {}}
+
+        # Setup mock for check_file
+        mock_check_file.side_effect = lambda file, metadata, args: [] if file == 'file1.parm' else ['Error']
+
+        # Call main function
+        with patch('sys.argv', ['param_check.py']):
+            with self.assertRaises(SystemExit):
+                main()
+
+        # Check that generate_metadata was called correctly
+        mock_generate_metadata.assert_called_once_with('Plane')
+
+        # Check that check_file was called for each expanded file
+        self.assertEqual(mock_check_file.call_count, 2)
+        mock_check_file.assert_any_call('file1.parm', {'PARAM1': {}, 'PARAM2': {}}, unittest.mock.ANY)
+        mock_check_file.assert_any_call('file2.parm', {'PARAM1': {}, 'PARAM2': {}}, unittest.mock.ANY)
+
+        # Check that print was called correctly
+        mock_print.assert_any_call('file1.parm: Passed')
+        mock_print.assert_any_call('file2.parm: Failed')
+        mock_print.assert_any_call('  Error')
+
+        # Test that the program exits when no files are provided
+        mock_print.reset_mock()
+        mock_args.files = []
+        mock_parse_arguments.return_value = mock_args
+        with patch('sys.argv', ['param_check.py']):
+            with self.assertRaises(SystemExit):
+                main()
+
+        mock_print.assert_called_once_with('Error: No parameter files specified.')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
We don't automatically check our parameter files for correctness (name typos, param renames/removals, etc.). This adds the following, bare minimum checks (links take you to existing failures in the repo):
- [Every line in the parameter file has valid syntax](https://github.com/ArduPilot/ardupilot/blob/8fe927c1d3eb6be9da8544ac48f7ec210abf5789/Tools/autotest/default_params/motorboat.parm#L2)
- [Every parameter actually exists](https://github.com/ArduPilot/ardupilot/blob/8fe927c1d3eb6be9da8544ac48f7ec210abf5789/libraries/AP_HAL_ChibiOS/hwdef/SkystarsH7HD/defaults.parm#L7)
- [Every parameter appears in a file only once](https://github.com/ArduPilot/ardupilot/blob/8fe927c1d3eb6be9da8544ac48f7ec210abf5789/Tools/autotest/default_params/sub.parm#L5) (helps find copy/paste errors)
- [We don't try to set parameters that are ReadOnly](https://github.com/ArduPilot/ardupilot/blob/8fe927c1d3eb6be9da8544ac48f7ec210abf5789/libraries/AP_HAL_ChibiOS/hwdef/skyviper-v2450/defaults.parm#L181).

In Peter Barker style, I'm adding this test with a long whitelist for all the param files that are failing, and I'll chip away at fixing those files over the next few weeks as individual PRs.