### PR TITLE
add dvl-gps integration tests

### DIFF
--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -1444,7 +1444,137 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
 
                 if alt_error > max_error:
                     max_error = alt_error
+        self.disarm_vehicle()
 
+    def IgnoreGPSDrift(self):
+        """ Test GPS-DVL integration. DVL (VISO) should be able to filter the GPS noise.
+        this tests switching over to VISO, running for a bit with no sensors, re-enabling viso,
+        and finally surfacing, where we expect the GPS position will be used to fix the drift
+        resulting of running with no positioning sensors."""
+
+        self.customise_SITL_commandline(["--serial5=sim:vicon:"])
+
+        # configure EKF to use external nav instead of GPS
+        self.set_parameters({
+            "EK3_SRC1_POSXY": 3,
+            "EK3_SRC1_VELXY": 6,
+            "EK3_SRC1_POSZ": 1,
+            "EK3_SRC1_VELZ": 0,
+
+            "VISO_TYPE": 1,
+            "SERIAL5_PROTOCOL": 1,
+            "SIM_VICON_TMASK": 8,  # send VISION_POSITION_DELTA
+            # "SIM_VICON_TMASK": 2,  # send VISION_SPEED_ESTIMATE
+            # "SIM_VICON_TMASK": 10,  # send VISION_SPEED_ESTIMATE AND VISION_POSITION_DELTA
+            # "EK3_VELNE_M_NSE": 0.001,
+
+            "GPS1_TYPE": 1,
+            "SIM_GPS1_DRFTALT": 3,
+            "SIM_GPS1_ACC": 0.3,
+            "SIM_GPS1_ENABLE": 1,
+            "SIM_GPS1_TYPE": 1,
+
+            "GPS2_TYPE": 0,
+
+            "EK3_POSNE_M_NSE": 100,
+        })
+        self.reboot_sitl()
+
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        self.progress("Ensuring that VISO manages to filter the GPS noise")
+        self.change_mode('POSHOLD')
+        self.set_parameter("SIM_GPS1_HNSE", 2)
+        self.wait_location(
+            self.sim_location(),
+            location_source="SIMSTATE",
+            minimum_duration=10,
+            height_accuracy=10.0,
+            accuracy=1.0,
+            timeout=60.0,
+        )
+
+        self.progress("Diving to 10m")
+        self.set_rc(Joystick.Throttle, 1300)
+        self.wait_altitude(altitude_min=-10, altitude_max=-9, relative=False, timeout=60)
+        self.set_rc(Joystick.Throttle, 1500)
+
+        self.progress("Disabling GPS")
+        self.set_parameters({
+            "SIM_GPS1_ENABLE": 0,
+        })
+
+        self.progress("Driving GPS-less for 10m using VISO")
+        self.set_rc(Joystick.Forward, 1900)
+        self.wait_distance(10, timeout=60, location_source="SIMSTATE")
+        self.set_rc(Joystick.Forward, 1500)
+
+        self.progress("Surfacing")
+        self.set_rc(Joystick.Throttle, 1900)
+        self.wait_altitude(altitude_min=-0.5, altitude_max=1, relative=False, timeout=60)
+        self.set_rc(Joystick.Throttle, 1500)
+
+        self.progress("Re-enabling GPS, expecting position to converge within 2m")
+        self.set_parameters({
+            "SIM_GPS1_ENABLE": 1,
+        })
+        self.wait_location(self.mav.location(), minimum_duration=5, accuracy=2, timeout=60.0)
+
+        self.progress("Driving forward 10m with GPS+VISO")
+        self.set_rc(Joystick.Forward, 1900)
+        self.wait_distance(10, timeout=60, location_source="SIMSTATE")
+        self.set_rc(Joystick.Forward, 1500)
+
+        self.progress("Disabling GPS and diving to 10m for no-GPS+no-VISO test")
+        self.set_parameters({
+            "SIM_GPS1_ENABLE": 0,
+        })
+        self.set_rc(Joystick.Throttle, 1300)
+        self.wait_altitude(altitude_min=-10, altitude_max=-9, relative=False, timeout=60)
+        self.set_rc(Joystick.Throttle, 1500)
+
+        self.progress("Driving 10m on VISO only, verifying EKF has relative position")
+        self.set_rc(Joystick.Forward, 1900)
+        self.wait_distance(10, timeout=60, location_source="SIMSTATE")
+        self.wait_ekf_flags(
+            mavutil.mavlink.ESTIMATOR_POS_HORIZ_REL,
+            0,
+            timeout=15,
+        )
+
+        self.progress("Disabling VISO and waiting for EKF to lose position")
+        self.set_parameters({
+            "SIM_VICON_TMASK": 0,
+        })
+        self.wait_ekf_flags(
+            0,
+            mavutil.mavlink.ESTIMATOR_POS_HORIZ_REL | mavutil.mavlink.ESTIMATOR_POS_HORIZ_ABS,
+            timeout=15,
+        )
+
+        self.progress("Stopping to build position error while EKF has no aiding")
+        self.set_rc(Joystick.Forward, 1500)
+        self.delay_sim_time(10, reason="build position error while EKF has no aiding")
+
+        self.progress("Re-enabling VISO and driving forward")
+        self.set_rc(Joystick.Forward, 1900)
+        self.delay_sim_time(5, reason="drive forward with no aiding")
+        self.set_parameters({
+            "SIM_VICON_TMASK": 10,
+        })
+        self.delay_sim_time(10, reason="drive forward with VISO aiding")
+        self.set_rc(Joystick.Forward, 1500)
+
+        self.progress("Surfacing to simulate re-acquiring GPS")
+        self.set_rc(Joystick.Throttle, 1900)
+        self.wait_altitude(altitude_min=-0.5, altitude_max=1, relative=False, timeout=60)
+        self.set_rc(Joystick.Throttle, 1500)
+
+        self.progress("Re-enabling GPS, expecting position correction")
+        self.set_parameters({
+            "SIM_GPS1_ENABLE": 1,
+        })
+        self.wait_distance(10, accuracy=5, timeout=60)
         self.disarm_vehicle()
 
     def AutoTerrainRecover(self):
@@ -1523,6 +1653,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
             self.UpsideDown,
             self.GuidedWP,
             self.AutoTerrainRecover,
+            self.IgnoreGPSDrift,
         ])
 
         return ret

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -8200,7 +8200,10 @@ class TestSuite(abc.ABC):
             lat = m.lat * 1e-7
             lon = m.lon * 1e-7
             alt_m = m.alt * 0.001
-
+        elif m_type == "SIMSTATE":
+            lat = m.lat * 1e-7
+            lon = m.lng * 1e-7
+            alt_m = 0  # not available in SIMSTATE
         if lat == 0 and lon == 0:
             raise ValueError(f"Bad lat/lng {lat=} {lon=}")
 

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -575,11 +575,12 @@ class WaitAndMaintain(object):
 
 
 class WaitAndMaintainLocation(WaitAndMaintain):
-    def __init__(self, test_suite, target, accuracy=5, height_accuracy=1, **kwargs):
+    def __init__(self, test_suite, target, accuracy=5, height_accuracy=1, location_source=None, **kwargs):
         super(WaitAndMaintainLocation, self).__init__(test_suite, **kwargs)
         self.target = target
         self.height_accuracy = height_accuracy
         self.accuracy = accuracy
+        self.location_source = location_source
 
     def announce_start_text(self):
         t = self.target
@@ -593,7 +594,9 @@ class WaitAndMaintainLocation(WaitAndMaintain):
         return self.loc
 
     def get_current_value(self):
-        return self.test_suite.mav.location()
+        if self.location_source is None:
+            return self.test_suite.mav.location()
+        return self.test_suite.get_mav_location(self.location_source)
 
     def horizontal_error(self, value):
         return self.test_suite.get_distance(value, self.target)

--- a/libraries/SITL/SIM_GPS.cpp
+++ b/libraries/SITL/SIM_GPS.cpp
@@ -95,11 +95,11 @@ const AP_Param::GroupInfo SIM::GPSParms::var_info[] = {
     AP_GROUPINFO("POS",        9, GPSParms, pos_offset, 0),
 
     // @Param: NOISE
-    // @DisplayName: GPS Noise
-    // @Description: Amplitude of the GPS altitude error
+    // @DisplayName: GPS vertical noise
+    // @Description: Amplitude of the GPS vertical position error
     // @Units: m
     // @User: Advanced
-    AP_GROUPINFO("NOISE",     10, GPSParms, noise, 0),
+    AP_GROUPINFO("NOISE",     10, GPSParms, noise_vertical, 0),
 
     // @Param: LCKTIME
     // @DisplayName: GPS Lock Time
@@ -160,6 +160,13 @@ const AP_Param::GroupInfo SIM::GPSParms::var_info[] = {
     // @Values: 0:No GPS connected, 1:No Fix, 2:2D Fix, 3:3D Fix, 4:3D DGPS Fix, 5:3D RTK Float, 6:3D RTK Fixed
     // @User: Advanced
     AP_GROUPINFO("FIXTYPE", 19, GPSParms, fix_type, 6),
+
+    // @Param: HNSE
+    // @DisplayName: GPS horizontal noise
+    // @Description: Radius of the GPS horizontal position error in meters
+    // @Units: m
+    // @User: Advanced
+    AP_GROUPINFO("HNSE",       20, GPSParms, noise_horizontal, 0),
 
     AP_GROUPEND
 };
@@ -503,8 +510,9 @@ void GPS::update()
     d.roll_deg = _sitl->state.rollDeg;
     d.pitch_deg = _sitl->state.pitchDeg;
 
+    const float gps_wander_angle_rad = now_ms * 0.0005f;  // choosing T=12.6 sec arbitrarily
     // add an altitude error controlled by a slow sine wave
-    d.altitude = altitude + params.noise * sinf(now_ms * 0.0005f) + params.alt_offset;
+    d.altitude = altitude + params.noise_vertical * sinf(gps_wander_angle_rad) + params.alt_offset;
 
     // Add offset to c.g. velocity to get velocity at antenna and add simulated error
     Vector3f velErrorNED = params.vel_err;
@@ -564,8 +572,14 @@ void GPS::update()
     // Applying GPS glitch
     // Using first gps glitch
     Vector3f glitch_offsets = params.glitch;
-    d.latitude += glitch_offsets.x;
-    d.longitude += glitch_offsets.y;
+    // apply a slow circular horizontal wander of radius noise_horizontal (in metres)
+    const double earth_rad_inv = 1.0f/RADIUS_OF_EARTH;
+    const float lat_wander_m = params.noise_horizontal * sinf(gps_wander_angle_rad);
+    const float lon_wander_m = params.noise_horizontal * cosf(gps_wander_angle_rad);
+    const float highest_permissible_lat_deg = 89.0f;
+    const double cosine_of_lat = (fabsf(d.latitude) < highest_permissible_lat_deg) ? cos(radians(d.latitude)) : cos(radians(highest_permissible_lat_deg));
+    d.latitude += glitch_offsets.x + degrees(lat_wander_m * earth_rad_inv);
+    d.longitude += glitch_offsets.y + degrees(lon_wander_m * earth_rad_inv / cosine_of_lat);
     d.altitude += glitch_offsets.z;
 
     if (params.jam == 1) {

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -329,7 +329,7 @@ public:
         }
         static const struct AP_Param::GroupInfo var_info[];
 
-        AP_Float noise; // amplitude of the gps altitude error
+        AP_Float noise_vertical; // amplitude of the gps altitude error
         AP_Int16 lock_time; // delay in seconds before GPS gets lock
         AP_Int16 alt_offset; // gps alt error
         AP_Int8  enabled; // enable simulated GPS
@@ -348,6 +348,7 @@ public:
         AP_Float heading_offset; // heading offset in degrees
         AP_Int32 options; // GPS options bitmask
         AP_Int8 fix_type; // GPS fix type
+        AP_Float noise_horizontal; // horizontal noise radius in meters
     };
     GPSParms gps[AP_SIM_MAX_GPS_SENSORS];
 


### PR DESCRIPTION
This checks switching from VICON (which uses the same API as DVLs) and GPS, and multiple configurations of them.