### PR TITLE
SITL: trim bad trailing whitespace in parameter metadata

### DIFF
--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -227,7 +227,7 @@ const AP_Param::GroupInfo SIM::var_info[] = {
     // @DisplayName: Sim Speedup
     // @Description: Runs the simulation at multiples of normal speed. Do not use if realtime physics, like RealFlight, is being used
     // @Range: 1 10
-    // @User: Advanced    
+    // @User: Advanced
     AP_GROUPINFO("SPEEDUP",       52, SIM,  speedup, -1),
     // @Param: IMU_POS
     // @DisplayName: IMU Offsets


### PR DESCRIPTION
causes problems on QGC

(PRs welcome to CI-test for this...)
