### PR TITLE
AP_Beacon: disable feature due to flash space constraints

### DIFF
--- a/libraries/AP_Beacon/AP_Beacon_config.h
+++ b/libraries/AP_Beacon/AP_Beacon_config.h
@@ -3,7 +3,7 @@
 #include <AP_HAL/AP_HAL_Boards.h>
 
 #ifndef AP_BEACON_ENABLED
-#define AP_BEACON_ENABLED 1
+#define AP_BEACON_ENABLED HAL_PROGRAM_SIZE_LIMIT_KB > 2048
 #endif
 
 #ifndef AP_BEACON_MAX_BEACONS


### PR DESCRIPTION
ArduPilot doesn't have room for every feature it can have, and hasn't for some time.