### PR TITLE
Ap_Scheduler: initialize _active_loop_rate_hz in loop() and remove check in get_loop_rate_hz()

### DIFF
--- a/libraries/AP_Scheduler/AP_Scheduler.cpp
+++ b/libraries/AP_Scheduler/AP_Scheduler.cpp
@@ -363,6 +363,10 @@ void AP_Scheduler::loop()
         _last_loop_time_s = (sample_time_us - _loop_timer_start_us) * 1.0e-6;
     }
 
+    if (_active_loop_rate_hz == 0) {
+       _active_loop_rate_hz = _loop_rate_hz;
+    }
+
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     {
         /*

--- a/libraries/AP_Scheduler/AP_Scheduler.h
+++ b/libraries/AP_Scheduler/AP_Scheduler.h
@@ -141,9 +141,6 @@ public:
 
     // get the active main loop rate
     uint16_t get_loop_rate_hz(void) {
-        if (_active_loop_rate_hz == 0) {
-            _active_loop_rate_hz = _loop_rate_hz;
-        }
         return _active_loop_rate_hz;
     }
     // get the time-allowed-per-loop in microseconds


### PR DESCRIPTION
- issue: #30234 
- an extra check was made on every call of get_loop_rate_hz() for _active_loop_rate_hz == 0
- remove extra check and initialize the value of _active_loop_rate_hz in AP_Scheduler::loop()

**Testing**
- succesfully build for sitl
![Screenshot from 2025-06-11 00-07-38](https://github.com/user-attachments/assets/d68c1628-32ff-4488-bea7-4eb8941de3c1)
- tested on sitl
![Screenshot from 2025-06-11 00-27-10](https://github.com/user-attachments/assets/ddbdb9cb-4a3b-4c65-bbf7-2e6188e33e62)

