### PR TITLE
APM_Control: link example against AP_Avoidance

### DIFF
--- a/libraries/APM_Control/examples/AP_FW_Controller_test/wscript
+++ b/libraries/APM_Control/examples/AP_FW_Controller_test/wscript
@@ -10,7 +10,10 @@ def build(bld):
         name='AP_FW_Controller_test_libs',
         ap_vehicle='UNKNOWN',
         ap_libraries=bld.ap_common_vehicle_libraries() + [
-            'SITL', 'APM_Control', 'AP_AdvancedFailsafe',
+            'SITL',
+            'APM_Control',
+            'AP_AdvancedFailsafe',
+            'AP_Avoidance',
         ],
     )
 


### PR DESCRIPTION
Fixes:
```
/usr/bin/ld: lib/libAP_FW_Controller_test_libs.a(RC_Channel.cpp.1.o): in function `RC_Channel::do_aux_function_avoid_adsb(RC_Channel::AuxSwitchPos)': RC_Channel.cpp:(.text._ZN10RC_Channel26do_aux_function_avoid_adsbENS_12AuxSwitchPosE+0xd): undefined reference to `AP::ap_avoidance()' collect2: error: ld returned 1 exit status
```

several other tools (eg. Replay) do the same thing to link correctly