### PR TITLE
Plane: improve POSITION1 velocity control

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2634,6 +2634,8 @@ void QuadPlane::vtol_position_controller(void)
 
         // use input shaping and abide by accel and jerk limits
         pos_control->input_vel_accel_NE_m(target_speed_ne_ms, target_accel_ne_mss);
+        // During POS1, we only want to control velocity and acceleration
+        pos_control->stop_pos_NE_stabilisation();
 
         // run horizontal velocity controller
         run_xy_controller(MAX(approach_accel_mss, transition_decel_mss)*1.5);


### PR DESCRIPTION
For a while, I've noticed an annoying behavior during POS1. The aircraft initially can't decelerate fast enough, but then as it gets slower, it massively undershoots QPOS.TSpd. This can be seen by the aircraft pitching up to max and then suddenly pitching back down below 0 right after. I can reproduce this in RealFlight using the Titan Cobra, but I've encountered this in real life on Volanti and Ottano.

![backtransition_before](https://github.com/user-attachments/assets/276ae60f-18ea-477a-8a6e-cc2e2c4bc1b4)

The POS1 controller target velocity is shown in purple. The actual velocity, in orange, is doing a terrible job following it. We can see that the undershoot is actually commanded by the underlying position controller's target velocity in brown (multiple brown lines, I know). The position controller's target velocity goes lower because we start winding up a position error (blue/brown lines). The pitch angle (green/brown) goes from 27 degrees pitched up to 4 degrees pitched down back-to-back.

Essentially what the controller is saying is "I'm at the right speed to reach the point X meters away, but I got here too early and I should slow down even more to get my position-vs-time curve to match up with expectations". It does a great job of getting the actual position to come back and follow that curve, but that's entirely unnecessary.

Instead, we should clear the position error when we're in POS1. The outer controller just wants the inner controller to handle velocity and acceleration.

Here's the same plot after this PR. I think this is much nicer. Now the actual velocity follows QPOS.TSpd quite well. And our attitude commands are much more reasonable. We only hit 17 degrees pitch up, and after, we relax to 3 degrees pitch up, and we don't drop the nose until we switch to POS2 (I could try to knock that out too, but I'm fine with that).

![backtransition_after](https://github.com/user-attachments/assets/0f7e1111-fefd-4174-8de2-02c2dd592f9d)
