### PR TITLE
AP_BoardConfig: print value of unknown board type

### DIFF
--- a/libraries/AP_BoardConfig/board_drivers.cpp
+++ b/libraries/AP_BoardConfig/board_drivers.cpp
@@ -107,7 +107,7 @@ void AP_BoardConfig::board_setup_drivers(void)
     case FMUV6_BOARD_CUAV_6X:
         break;
     default:
-        config_error("Unknown board type");
+        config_error("Unknown board type %u", px4_configured_board);
         break;
     }
 }


### PR DESCRIPTION
```
STABILIZE> AP: Config Error: fix problem then reboot
Config Error: Unknown board type 127
AP: Config Error: Unknown board type 127
```
