### PR TITLE
ArduPilot 4.6.1-beta1 release

### DIFF
--- a/AntennaTracker/ReleaseNotes.txt
+++ b/AntennaTracker/ReleaseNotes.txt
@@ -1,4 +1,13 @@
-Antenna Tracker Release Notes:
+ArduPilot Antenna Tracker Release Notes:
+------------------------------------------------------------------
+Release 4.6.1-beta1 14-Jun-2025
+
+Changes from 4.6.0
+
+1) Bug Fixes
+
+- Prevent firmware erasure on boards using flash for parameter storage
+- bootloaders rebuilt for H7 boards using flash for parameter storage
 ------------------------------------------------------------------
 Release 4.6.0 21-May-2025
 

--- a/AntennaTracker/version.h
+++ b/AntennaTracker/version.h
@@ -6,15 +6,15 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "AntennaTracker V4.6.0"
+#define THISFIRMWARE "AntennaTracker V4.6.1-beta1"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,6,0,FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FIRMWARE_VERSION 4,6,1,FIRMWARE_VERSION_TYPE_BETA
 
 #define FW_MAJOR 4
 #define FW_MINOR 6
-#define FW_PATCH 0
-#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FW_PATCH 1
+#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
 
 #include <AP_Common/AP_FWVersionDefine.h>
 #include <AP_CheckFirmware/AP_CheckFirmwareDefine.h>

--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,5 +1,14 @@
 ArduPilot Copter Release Notes:
 ------------------------------------------------------------------
+Release 4.6.1-beta1 14-Jun-2025
+
+Changes from 4.6.0
+
+1) Bug Fixes
+
+- Prevent firmware erasure on boards using flash for parameter storage
+- bootloaders rebuilt for H7 boards using flash for parameter storage
+------------------------------------------------------------------
 Release 4.6.0 21-May-2025
 
 Changes from 4.6.0-beta6

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,15 +6,15 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.6.0"
+#define THISFIRMWARE "ArduCopter V4.6.1-beta1"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,6,0,FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FIRMWARE_VERSION 4,6,1,FIRMWARE_VERSION_TYPE_BETA
 
 #define FW_MAJOR 4
 #define FW_MINOR 6
-#define FW_PATCH 0
-#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FW_PATCH 1
+#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
 
 #include <AP_Common/AP_FWVersionDefine.h>
 #include <AP_CheckFirmware/AP_CheckFirmwareDefine.h>

--- a/ArduPlane/ReleaseNotes.txt
+++ b/ArduPlane/ReleaseNotes.txt
@@ -1,5 +1,14 @@
 ArduPilot Plane Release Notes:
 ------------------------------------------------------------------
+Release 4.6.1-beta1 14-Jun-2025
+
+Changes from 4.6.0
+
+1) Bug Fixes
+
+- Prevent firmware erasure on boards using flash for parameter storage
+- bootloaders rebuilt for H7 boards using flash for parameter storage
+------------------------------------------------------------------
 Release 4.6.0 21-May-2025
 
 Changes from 4.6.0-beta6

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,15 +6,15 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduPlane V4.6.0"
+#define THISFIRMWARE "ArduPlane V4.6.1-beta1"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,6,0,FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FIRMWARE_VERSION 4,6,1,FIRMWARE_VERSION_TYPE_BETA
 
 #define FW_MAJOR 4
 #define FW_MINOR 6
-#define FW_PATCH 0
-#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FW_PATCH 1
+#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
 
 #include <AP_Common/AP_FWVersionDefine.h>
 #include <AP_CheckFirmware/AP_CheckFirmwareDefine.h>

--- a/Rover/ReleaseNotes.txt
+++ b/Rover/ReleaseNotes.txt
@@ -1,4 +1,13 @@
-Rover Release Notes:
+ArduPilot Rover Release Notes:
+------------------------------------------------------------------
+Release 4.6.1-beta1 14-Jun-2025
+
+Changes from 4.6.0
+
+1) Bug Fixes
+
+- Prevent firmware erasure on boards using flash for parameter storage
+- bootloaders rebuilt for H7 boards using flash for parameter storage
 ------------------------------------------------------------------
 Release 4.6.0 21-May-2025
 

--- a/Rover/version.h
+++ b/Rover/version.h
@@ -6,15 +6,15 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduRover V4.6.0"
+#define THISFIRMWARE "ArduRover V4.6.1-beta1"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,6,0,FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FIRMWARE_VERSION 4,6,1,FIRMWARE_VERSION_TYPE_BETA
 
 #define FW_MAJOR 4
 #define FW_MINOR 6
-#define FW_PATCH 0
-#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FW_PATCH 1
+#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
 
 #include <AP_Common/AP_FWVersionDefine.h>
 #include <AP_CheckFirmware/AP_CheckFirmwareDefine.h>


### PR DESCRIPTION
This is the 4.6.1-beta1 release PR.

This beta release includes only a single change to allow for a short beta period and speed release to avoid the firmware-erase-on-restart issue that has affected some boards that store parameters in flash

- https://github.com/ArduPilot/ardupilot/pull/30310

All feedback is very welcome!