### PR TITLE
AP_Scripting: loiter to autoland altitude

### DIFF
--- a/libraries/AP_Scripting/applets/UniversalAutoLand.md
+++ b/libraries/AP_Scripting/applets/UniversalAutoLand.md
@@ -1,6 +1,6 @@
 This script is intended to allow easy, unpre-planned operation at any location with the protection of a do-land-start autoland sequence for failsafes that accounts for takeoff direction (ie wind direction). Final approach objects must be considered before you launch.
 
-If enabled by AUTOLAND_ENABLE =1, setups up an autotakeoff waypoint as first waypoint and upon Arming , adds mission items consisting of:  DO_LAND_START,Final Approach WP opposite bearing from HOME of heading used during takeoff, to AUTOLAND_WP_ALT above home,  and at AUTOLAND_WP_DIST distancee, and a LAND waypoint at HOME and stops until next disarm/boot. Warnings are given if the AUTOLAND parameters are not set.
+If enabled by AUTOLAND_ENABLE =1, setups up an autotakeoff waypoint as first waypoint and upon Arming , adds mission items consisting of:  DO_LAND_START, clockwise to final approach altitude, Final Approach WP opposite bearing from HOME of heading used during takeoff, to AUTOLAND_WP_ALT above home,  and at AUTOLAND_WP_DIST distancee, and a LAND waypoint at HOME and stops until next disarm/boot. Warnings are given if the AUTOLAND parameters are not set.
 
 In use you just arm and switch to AUTO, and then switch to other flight modes after takeoff is completed to fly around.....relatively assured that a failsafe (assuming defaults for Failsafe) will result in an autolanding in the correct direction. You can also just switch back to AUTO or RTL to do an autoland. 
 


### PR DESCRIPTION
Based on similar functionality in AUTOLAND mode with some Lua limitations. Meant to be used with stable 4.6 builds (can't do a PR versus that branch because the script history appeared in 4.7). 

Verified with 4.6.0 SITL, seems to work alright, with some differences:
- Since the mission is pre-generated at takeoff, there is no way of telling if we are left or right of the approach path, defaulting to right/cw loiter.
- Apparently no Lua binding for L1's `loiter_radius()` method so we aren't exiting at the final approach WP exactly, just close to it.

![image](https://github.com/user-attachments/assets/6f7fea3e-e879-404c-97a5-9099fc840370)
