### PR TITLE
Plane: fix short failsafe

### DIFF
--- a/ArduPlane/AP_Arming_Plane.cpp
+++ b/ArduPlane/AP_Arming_Plane.cpp
@@ -75,11 +75,6 @@ bool AP_Arming_Plane::pre_arm_checks(bool display_failure)
     ret &= AP_Arming::airspeed_checks(display_failure);
 #endif
 
-    if (plane.g.fs_timeout_long < plane.g.fs_timeout_short && plane.g.fs_action_short != FS_ACTION_SHORT_DISABLED) {
-        check_failed(display_failure, "FS_LONG_TIMEOUT < FS_SHORT_TIMEOUT");
-        ret = false;
-    }
-
     if (plane.aparm.roll_limit < 3) {
         check_failed(display_failure, "ROLL_LIMIT_DEG too small (%.1f)", plane.aparm.roll_limit.get());
         ret = false;

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -437,19 +437,10 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Param: FS_SHORT_ACTN
     // @DisplayName: Short failsafe action
-    // @Description: The action to take on a short (FS_SHORT_TIMEOUT) failsafe event. A short failsafe event can be triggered either by loss of RC control (see THR_FS_VALUE) or by loss of GCS control (see FS_GCS_ENABL). If in CIRCLE or RTL mode this parameter is ignored. A short failsafe event in stabilization and manual modes will cause a change to CIRCLE mode if FS_SHORT_ACTN is 0 or 1, a change to FBWA mode with zero throttle if FS_SHORT_ACTN is 2, and a change to FBWB mode if FS_SHORT_ACTN is 4. In all other modes (AUTO, GUIDED and LOITER) a short failsafe event will cause no mode change if FS_SHORT_ACTN is set to 0, will cause a change to CIRCLE mode if set to 1, will change to FBWA mode with zero throttle if set to 2, or will change to FBWB if set to 4. Please see the documentation for FS_LONG_ACTN for the behaviour after FS_LONG_TIMEOUT seconds of failsafe. This parameter only applies to failsafes during fixed wing modes. Quadplane modes will switch to QLAND unless Q_OPTIONS bit 5(QRTL) or 20(RTL) are set.
+    // @Description: The action to take on a short failsafe event. A short failsafe event can be triggered instantly by loss of RC control or by throttle value (see THR_FS_VALUE). If in CIRCLE or RTL mode this parameter is ignored. A short failsafe event in stabilization and manual modes will cause a change to CIRCLE mode if FS_SHORT_ACTN is 0 or 1, a change to FBWA mode with zero throttle if FS_SHORT_ACTN is 2, and a change to FBWB mode if FS_SHORT_ACTN is 4. In all other modes (AUTO, GUIDED and LOITER) a short failsafe event will cause no mode change if FS_SHORT_ACTN is set to 0, will cause a change to CIRCLE mode if set to 1, will change to FBWA mode with zero throttle if set to 2, or will change to FBWB if set to 4. Please see the documentation for FS_LONG_ACTN for the behaviour after FS_LONG_TIMEOUT seconds of failsafe. This parameter only applies to failsafes during fixed wing modes. Quadplane modes will switch to QLAND unless Q_OPTIONS bit 5(QRTL) or 20(RTL) are set.
     // @Values: 0:CIRCLE/no change(if already in AUTO|GUIDED|LOITER),1:CIRCLE,2:FBWA at zero throttle,3:Disable,4:FBWB
     // @User: Standard
     GSCALAR(fs_action_short,        "FS_SHORT_ACTN",  FS_ACTION_SHORT_BESTGUESS),
-
-    // @Param: FS_SHORT_TIMEOUT
-    // @DisplayName: Short failsafe timeout
-    // @Description: The time in seconds that a failsafe condition has to persist before a short failsafe event will occur. This defaults to 1.5 seconds
-    // @Units: s
-    // @Range: 1 100
-    // @Increment: 0.5
-    // @User: Standard
-    GSCALAR(fs_timeout_short,        "FS_SHORT_TIMEOUT", 1.5f),
 
     // @Param: FS_LONG_ACTN
     // @DisplayName: Long failsafe action

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -275,7 +275,7 @@ public:
         k_param_rc_12_old,
         k_param_fs_batt_voltage, // unused - moved to AP_BattMonitor
         k_param_fs_batt_mah,     // unused - moved to AP_BattMonitor
-        k_param_fs_timeout_short,
+        k_param_fs_timeout_short_unused, // unused
         k_param_fs_timeout_long,
         k_param_rc_13_old,
         k_param_rc_14_old,
@@ -414,7 +414,6 @@ public:
     // Failsafe
     AP_Int8 fs_action_short;
     AP_Int8 fs_action_long;
-    AP_Float fs_timeout_short;
     AP_Float fs_timeout_long;
     AP_Int8 gcs_heartbeat_fs_enabled;
 

--- a/ArduPlane/Plane.cpp
+++ b/ArduPlane/Plane.cpp
@@ -66,7 +66,7 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
     FAST_TASK(stabilize),
     FAST_TASK(set_servos),
     SCHED_TASK(read_radio,             50,    100,   6),
-    SCHED_TASK(check_short_failsafe,   50,    100,   9),
+    SCHED_TASK(check_short_rc_failsafe,   50,    100,   9),
     SCHED_TASK(update_speed_height,    50,    200,  12),
     SCHED_TASK(update_throttle_hover, 100,     90,  24),
     SCHED_TASK_CLASS(RC_Channels,     (RC_Channels*)&plane.g2.rc_channels, read_mode_switch,           7,    100, 27),

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -373,9 +373,6 @@ private:
         // number of low throttle values
         uint8_t throttle_counter;
 
-        // A timer used to track how long we have been in a "short failsafe" condition due to loss of RC signal
-        uint32_t short_timer_ms;
-
         uint32_t last_valid_rc_ms;
 
         //keeps track of the last valid rc as it relates to the AFS system
@@ -1055,9 +1052,9 @@ private:
     bool autotuning;
 
     // events.cpp
-    void failsafe_short_on_event(enum failsafe_state fstype, ModeReason reason);
+    void rc_failsafe_short_on_event();
     void failsafe_long_on_event(enum failsafe_state fstype, ModeReason reason);
-    void failsafe_short_off_event(ModeReason reason);
+    void rc_failsafe_short_off_event();
     void failsafe_long_off_event(ModeReason reason);
     void handle_battery_failsafe(const char* type_str, const int8_t action);
     bool failsafe_in_landing_sequence() const;  // returns true if the vehicle is in landing sequence.  Intended only for use in failsafe code.
@@ -1138,7 +1135,7 @@ private:
     bool set_mode(const uint8_t mode, const ModeReason reason) override;
     bool set_mode_by_number(const Mode::Number new_mode_number, const ModeReason reason);
     void check_long_failsafe();
-    void check_short_failsafe();
+    void check_short_rc_failsafe();
     void startup_INS(void);
     bool should_log(uint32_t mask);
     int8_t throttle_percentage(void);

--- a/ArduPlane/events.cpp
+++ b/ArduPlane/events.cpp
@@ -18,11 +18,10 @@ bool Plane::failsafe_in_landing_sequence() const
     return false;
 }
 
-void Plane::failsafe_short_on_event(enum failsafe_state fstype, ModeReason reason)
+void Plane::rc_failsafe_short_on_event()
 {
     // This is how to handle a short loss of control signal failsafe.
-    failsafe.state = fstype;
-    failsafe.short_timer_ms = millis();
+    failsafe.state = FAILSAFE_SHORT;
     failsafe.saved_mode_number = control_mode->mode_number();
     switch (control_mode->mode_number())
     {
@@ -35,15 +34,15 @@ void Plane::failsafe_short_on_event(enum failsafe_state fstype, ModeReason reaso
     case Mode::Number::CRUISE:
     case Mode::Number::TRAINING:  
         if(plane.emergency_landing) {
-            set_mode(mode_fbwa, reason); // emergency landing switch overrides normal action to allow out of range landing
+            set_mode(mode_fbwa, ModeReason::RADIO_FAILSAFE); // emergency landing switch overrides normal action to allow out of range landing
             break;
         }
         if(g.fs_action_short == FS_ACTION_SHORT_FBWA) {
-            set_mode(mode_fbwa, reason);
+            set_mode(mode_fbwa, ModeReason::RADIO_FAILSAFE);
         } else if (g.fs_action_short == FS_ACTION_SHORT_FBWB) {
-            set_mode(mode_fbwb, reason);
+            set_mode(mode_fbwb, ModeReason::RADIO_FAILSAFE);
         } else {
-            set_mode(mode_circle, reason); // circle if action = 0 or 1 
+            set_mode(mode_circle, ModeReason::RADIO_FAILSAFE); // circle if action = 0 or 1 
         }
         break;
 
@@ -56,11 +55,11 @@ void Plane::failsafe_short_on_event(enum failsafe_state fstype, ModeReason reaso
 #endif
     case Mode::Number::QACRO:
         if (quadplane.option_is_set(QuadPlane::Option::FS_RTL)) {
-            set_mode(mode_rtl, reason);
+            set_mode(mode_rtl, ModeReason::RADIO_FAILSAFE);
         } else if (quadplane.option_is_set(QuadPlane::Option::FS_QRTL)) {
-            set_mode(mode_qrtl, reason);
+            set_mode(mode_qrtl, ModeReason::RADIO_FAILSAFE);
         } else {
-            set_mode(mode_qland, reason);
+            set_mode(mode_qland, ModeReason::RADIO_FAILSAFE);
         }
         break;
 #endif // HAL_QUADPLANE_ENABLED
@@ -83,11 +82,11 @@ void Plane::failsafe_short_on_event(enum failsafe_state fstype, ModeReason reaso
         if (g.fs_action_short != FS_ACTION_SHORT_BESTGUESS) { // if acton = 0(BESTGUESS) this group of modes take no action
             failsafe.saved_mode_number = control_mode->mode_number();
             if (g.fs_action_short == FS_ACTION_SHORT_FBWA) {
-                set_mode(mode_fbwa, reason);
+                set_mode(mode_fbwa, ModeReason::RADIO_FAILSAFE);
             } else if (g.fs_action_short == FS_ACTION_SHORT_FBWB) {
-                set_mode(mode_fbwb, reason);
+                set_mode(mode_fbwb, ModeReason::RADIO_FAILSAFE);
             } else {
-                set_mode(mode_circle, reason);
+                set_mode(mode_circle, ModeReason::RADIO_FAILSAFE);
             }
         }
          break;
@@ -113,7 +112,7 @@ void Plane::failsafe_long_on_event(enum failsafe_state fstype, ModeReason reason
 {
 
     // This is how to handle a long loss of control signal failsafe.
-    //  If the GCS is locked up we allow control to revert to RC
+    // If the GCS is locked up we allow control to revert to RC
     RC_Channels::clear_overrides();
     failsafe.state = fstype;
     switch (control_mode->mode_number())
@@ -234,13 +233,13 @@ void Plane::failsafe_long_on_event(enum failsafe_state fstype, ModeReason reason
 #endif
         break;
     }
-    gcs().send_text(MAV_SEVERITY_WARNING, "%s Failsafe On: %s", (reason == ModeReason:: GCS_FAILSAFE) ? "GCS" : "RC Long", control_mode->name());
+    gcs().send_text(MAV_SEVERITY_WARNING, "%s Failsafe On: switched to %s", (reason == ModeReason:: GCS_FAILSAFE) ? "GCS" : "RC Long", control_mode->name());
 }
 
-void Plane::failsafe_short_off_event(ModeReason reason)
+void Plane::rc_failsafe_short_off_event()
 {
     // We're back in radio contact
-    gcs().send_text(MAV_SEVERITY_WARNING, "Short Failsafe Cleared");
+    gcs().send_text(MAV_SEVERITY_WARNING, "RC Short Failsafe Cleared");
     failsafe.state = FAILSAFE_NONE;
     // restore entry mode if desired but check that our current mode is still due to failsafe
     if (control_mode_reason == ModeReason::RADIO_FAILSAFE) { 
@@ -254,7 +253,7 @@ void Plane::failsafe_long_off_event(ModeReason reason)
     long_failsafe_pending = false;
     // We're back in radio contact with RC or GCS
     if (reason == ModeReason:: GCS_FAILSAFE) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "GCS Failsafe Off");
+        gcs().send_text(MAV_SEVERITY_WARNING, "GCS Failsafe Cleared");
     }
     else {
         gcs().send_text(MAV_SEVERITY_WARNING, "RC Long Failsafe Cleared");

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -231,7 +231,7 @@ void Plane::control_failsafe()
     const bool has_had_input = rc().has_had_rc_receiver() || rc().has_had_rc_override();
     if ((g.throttle_fs_enabled != ThrFailsafe::Enabled && !failsafe.rc_failsafe) || (allow_failsafe_bypass && !has_had_input)) {
         // If throttle fs not enabled and not in failsafe, or 
-        // not flying and disarmed, don't trigger failsafe check until RC has been received for the fist time  
+        // not flying and disarmed, don't trigger failsafe check until RC has been received for the first time  
         return;
     }
 

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -349,17 +349,15 @@ bool Plane::set_mode_by_number(const Mode::Number new_mode_number, const ModeRea
 void Plane::check_long_failsafe()
 {
     const uint32_t gcs_last_seen_ms = gcs().sysid_mygcs_last_seen_time_ms();
+    const uint32_t rc_last_seen_ms = failsafe.last_valid_rc_ms;
     const uint32_t tnow = millis();
     // only act on changes
     // -------------------
-    if (failsafe.state != FAILSAFE_LONG && failsafe.state != FAILSAFE_GCS && flight_stage != AP_FixedWing::FlightStage::LAND) {
-        uint32_t radio_timeout_ms = failsafe.last_valid_rc_ms;
-        if (failsafe.state == FAILSAFE_SHORT) {
-            // time is relative to when short failsafe enabled
-            radio_timeout_ms = failsafe.short_timer_ms;
-        }
+    if (failsafe.state != FAILSAFE_LONG &&
+        failsafe.state != FAILSAFE_GCS &&
+        flight_stage != AP_FixedWing::FlightStage::LAND) {
         if (failsafe.rc_failsafe &&
-            (tnow - radio_timeout_ms) > g.fs_timeout_long*1000) {
+            (tnow - rc_last_seen_ms) > g.fs_timeout_long*1000) {
             failsafe_long_on_event(FAILSAFE_LONG, ModeReason::RADIO_FAILSAFE);
         } else if (g.gcs_heartbeat_fs_enabled == GCS_FAILSAFE_HB_AUTO && control_mode == &mode_auto &&
                    gcs_last_seen_ms != 0 &&
@@ -378,11 +376,6 @@ void Plane::check_long_failsafe()
         }
     } else {
         float timeout_seconds = g.fs_timeout_long;
-        if (g.fs_action_short != FS_ACTION_SHORT_DISABLED) {
-            // avoid dropping back into short timeout
-            timeout_seconds = g.fs_timeout_short;
-        }
-        // We do not change state but allow for user to change mode
         if (failsafe.state == FAILSAFE_GCS && 
             (tnow - gcs_last_seen_ms) < timeout_seconds*1000) {
             failsafe_long_off_event(ModeReason::GCS_FAILSAFE);
@@ -393,22 +386,20 @@ void Plane::check_long_failsafe()
     }
 }
 
-void Plane::check_short_failsafe()
+void Plane::check_short_rc_failsafe()
 {
-    // only act on changes
-    // -------------------
     if (g.fs_action_short != FS_ACTION_SHORT_DISABLED &&
-       failsafe.state == FAILSAFE_NONE &&
-       flight_stage != AP_FixedWing::FlightStage::LAND) {
+        failsafe.state == FAILSAFE_NONE &&
+        flight_stage != AP_FixedWing::FlightStage::LAND) {
         // The condition is checked and the flag rc_failsafe is set in radio.cpp
-        if(failsafe.rc_failsafe) {
-            failsafe_short_on_event(FAILSAFE_SHORT, ModeReason::RADIO_FAILSAFE);
+        if (failsafe.rc_failsafe) {
+            rc_failsafe_short_on_event();
         }
     }
 
     if(failsafe.state == FAILSAFE_SHORT) {
         if(!failsafe.rc_failsafe || g.fs_action_short == FS_ACTION_SHORT_DISABLED) {
-            failsafe_short_off_event(ModeReason::RADIO_FAILSAFE);
+            rc_failsafe_short_off_event();
         }
     }
 }


### PR DESCRIPTION
Hi,
I tested the short failsafe feature, but found that it is currently not working as expected. It appears that others have encountered the same issue - short failsafe triggered immediately without `FS_SHORT_TIMEOUT`:
https://discuss.ardupilot.org/t/fs-short-timeout-not-changing-rc-failsafe-timeout/119625

This PR fixes the `FS_SHORT_TIMEOUT` handling logic to ensure that the failsafe trigger responds correctly.
It just uses the same mechanism that long failsafe did. And since [arm check](https://github.com/ArduPilot/ardupilot/blob/966588f7142919482efc342cceebf0927366e65c/ArduPlane/AP_Arming_Plane.cpp#L78) will ask `FS_SHORT_TIMEOUT` < `FS_LONG_TIMEOUT`, they are not treated as relatively timeout usage anymore. (We don't need to know when short failsafe happened for long failsafe)
In addition, I also cleaned up some minor terminology inconsistencies across related functions.
I’ve tested this in SITL and confirmed that the failsafe now behaves as intended.

Hope this helps!