### PR TITLE
autotest: add ScriptingFlyVelocity autotest

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -13705,7 +13705,7 @@ RTL_ALT 111
         self.install_example_script_context('set-target-velocity.lua')
         self.reboot_sitl()
 
-        # Should be alowd to enter from alt hold
+        # Should be allowed to enter from alt hold
         self.change_mode("ALT_HOLD")
         self.wait_ready_to_arm()
         self.arm_vehicle()


### PR DESCRIPTION
~~This demonstrates a problem with set_target_velocity_NED() where request in m/s are showing up as 100x in the log~~
this is an issue with GCS display, but the test is still a good one as there are no autotests currently for these scripting functions.