### PR TITLE
Add unit extensions for variables in  PosHold and ZigZag units

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1379,12 +1379,12 @@ protected:
 
 private:
 
-    void update_pilot_lean_angle(float &lean_angle_filtered, float &lean_angle_raw);
+    void update_pilot_lean_angle_cd(float &lean_angle_filtered, float &lean_angle_raw);
     float mix_controls(float mix_ratio, float first_control, float second_control);
-    void update_brake_angle_from_velocity(float &brake_angle, float velocity);
+    void update_brake_angle_from_velocity(float &brake_angle_cd, float velocity_cms);
     void init_wind_comp_estimate();
     void update_wind_comp_estimate();
-    void get_wind_comp_lean_angles(float &roll_angle, float &pitch_angle);
+    void get_wind_comp_lean_angles(float &roll_angle_cd, float &pitch_angle_cd);
     void roll_controller_to_pilot_override();
     void pitch_controller_to_pilot_override();
 
@@ -1401,8 +1401,8 @@ private:
     RPMode pitch_mode;
 
     // pilot input related variables
-    float pilot_roll;                         // pilot requested roll angle (filtered to slow returns to zero)
-    float pilot_pitch;                        // pilot requested roll angle (filtered to slow returns to zero)
+    float pilot_roll_cd;                    // pilot requested roll angle (filtered to slow returns to zero)
+    float pilot_pitch_cd;                   // pilot requested roll angle (filtered to slow returns to zero)
 
     // braking related variables
     struct {
@@ -1410,31 +1410,31 @@ private:
         uint8_t time_updated_pitch  : 1;    // true once we have re-estimated the braking time.  This is done once as the vehicle begins to flatten out after braking
 
         float gain;                         // gain used during conversion of vehicle's velocity to lean angle during braking (calculated from rate)
-        float roll;                         // target roll angle during braking periods
-        float pitch;                        // target pitch angle during braking periods
+        float roll_cd;                      // target roll angle during braking periods
+        float pitch_cd;                     // target pitch angle during braking periods
         int16_t timeout_roll;               // number of cycles allowed for the braking to complete, this timeout will be updated at half-braking
         int16_t timeout_pitch;              // number of cycles allowed for the braking to complete, this timeout will be updated at half-braking
-        float angle_max_roll;               // maximum lean angle achieved during braking.  Used to determine when the vehicle has begun to flatten out so that we can re-estimate the braking time
-        float angle_max_pitch;              // maximum lean angle achieved during braking  Used to determine when the vehicle has begun to flatten out so that we can re-estimate the braking time
+        float angle_max_roll_cd;            // maximum lean angle achieved during braking. Used to determine when the vehicle has begun to flatten out so that we can re-estimate the braking time
+        float angle_max_pitch_cd;           // maximum lean angle achieved during braking. Used to determine when the vehicle has begun to flatten out so that we can re-estimate the braking time
         int16_t to_loiter_timer;            // cycles to mix brake and loiter controls in POSHOLD_TO_LOITER
     } brake;
 
     // loiter related variables
     int16_t controller_to_pilot_timer_roll;     // cycles to mix controller and pilot controls in POSHOLD_CONTROLLER_TO_PILOT
     int16_t controller_to_pilot_timer_pitch;    // cycles to mix controller and pilot controls in POSHOLD_CONTROLLER_TO_PILOT
-    float controller_final_roll;                // final roll angle from controller as we exit brake or loiter mode (used for mixing with pilot input)
-    float controller_final_pitch;               // final pitch angle from controller as we exit brake or loiter mode (used for mixing with pilot input)
+    float controller_final_roll_cd;             // final roll angle from controller as we exit brake or loiter mode (used for mixing with pilot input)
+    float controller_final_pitch_cd;            // final pitch angle from controller as we exit brake or loiter mode (used for mixing with pilot input)
 
     // wind compensation related variables
     Vector2f wind_comp_ef;                      // wind compensation in earth frame, filtered lean angles from position controller
-    float wind_comp_roll;                       // roll angle to compensate for wind
-    float wind_comp_pitch;                      // pitch angle to compensate for wind
+    float wind_comp_roll_cd;                    // roll angle to compensate for wind
+    float wind_comp_pitch_cd;                   // pitch angle to compensate for wind
     uint16_t wind_comp_start_timer;             // counter to delay start of wind compensation for a short time after loiter is engaged
     int8_t  wind_comp_timer;                    // counter to reduce wind comp roll/pitch lean angle calcs to 10hz
 
     // final output
-    float roll;   // final roll angle sent to attitude controller
-    float pitch;  // final pitch angle sent to attitude controller
+    float roll_cd;   // final roll angle sent to attitude controller
+    float pitch_cd;  // final pitch angle sent to attitude controller
 
 };
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1982,8 +1982,8 @@ private:
     bool calculate_side_dest(Vector3f& next_dest, bool& terrain_alt) const;
     void move_to_side();
 
-    Vector2f dest_A;    // in NEU frame in cm relative to ekf origin
-    Vector2f dest_B;    // in NEU frame in cm relative to ekf origin
+    Vector2f dest_A_ne_cm;    // in NEU frame in cm relative to ekf origin
+    Vector2f dest_B_ne_cm;    // in NEU frame in cm relative to ekf origin
     Vector3f current_dest; // current target destination (use for resume after suspending)
     bool current_terr_alt;
 
@@ -1992,8 +1992,8 @@ private:
 #if HAL_SPRAYER_ENABLED
     AP_Int8  _spray_enabled;   // auto spray enable/disable
 #endif
-    AP_Int8  _wp_delay;        // delay for zigzag waypoint
-    AP_Float _side_dist;       // sideways distance
+    AP_Int8  _wp_delay_s;      // delay for zigzag waypoint
+    AP_Float _side_dist_m;     // sideways distance
     AP_Int8  _direction;       // sideways direction
     AP_Int16 _line_num;        // total number of lines
 

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -32,7 +32,7 @@ const AP_Param::GroupInfo ModeZigZag::var_info[] = {
     // @Units: s
     // @Range: 0 127
     // @User: Advanced
-    AP_GROUPINFO("WP_DELAY", 3, ModeZigZag, _wp_delay, 0),
+    AP_GROUPINFO("WP_DELAY", 3, ModeZigZag, _wp_delay_s, 0),
 
     // @Param: SIDE_DIST
     // @DisplayName: Sideways distance in ZigZag auto
@@ -40,7 +40,7 @@ const AP_Param::GroupInfo ModeZigZag::var_info[] = {
     // @Units: m
     // @Range: 0.1 100
     // @User: Advanced
-    AP_GROUPINFO("SIDE_DIST", 4, ModeZigZag, _side_dist, 4),
+    AP_GROUPINFO("SIDE_DIST", 4, ModeZigZag, _side_dist_m, 4),
 
     // @Param: DIRECTION
     // @DisplayName: Sideways direction in ZigZag auto
@@ -71,11 +71,11 @@ bool ModeZigZag::init(bool ignore_checks)
     update_simple_mode();
 
     // convert pilot input to lean angles
-    float target_roll, target_pitch;
-    get_pilot_desired_lean_angles(target_roll, target_pitch, loiter_nav->get_angle_max_cd(), attitude_control->get_althold_lean_angle_max_cd());
+    float target_roll_cd, target_pitch_cd;
+    get_pilot_desired_lean_angles(target_roll_cd, target_pitch_cd, loiter_nav->get_angle_max_cd(), attitude_control->get_althold_lean_angle_max_cd());
 
     // process pilot's roll and pitch input
-    loiter_nav->set_pilot_desired_acceleration_cd(target_roll, target_pitch);
+    loiter_nav->set_pilot_desired_acceleration_cd(target_roll_cd, target_pitch_cd);
 
     loiter_nav->init_target();
 
@@ -90,8 +90,8 @@ bool ModeZigZag::init(bool ignore_checks)
 
     // initialise waypoint state
     stage = STORING_POINTS;
-    dest_A.zero();
-    dest_B.zero();
+    dest_A_ne_cm.zero();
+    dest_B_ne_cm.zero();
 
     // initialize zigzag auto
     init_auto();
@@ -157,7 +157,7 @@ void ModeZigZag::run()
 void ModeZigZag::save_or_move_to_destination(Destination ab_dest)
 {
     // get current position as an offset from EKF origin
-    const Vector2f curr_pos = pos_control->get_pos_desired_NEU_cm().xy().tofloat();
+    const Vector2f curr_pos_neu_cm = pos_control->get_pos_desired_NEU_cm().xy().tofloat();
 
     // handle state machine changes
     switch (stage) {
@@ -165,20 +165,20 @@ void ModeZigZag::save_or_move_to_destination(Destination ab_dest)
         case STORING_POINTS:
             if (ab_dest == Destination::A) {
                 // store point A
-                dest_A = curr_pos;
+                dest_A_ne_cm = curr_pos_neu_cm;
                 gcs().send_text(MAV_SEVERITY_INFO, "%s: point A stored", name());
                 LOGGER_WRITE_EVENT(LogEvent::ZIGZAG_STORE_A);
             } else {
                 // store point B
-                dest_B = curr_pos;
+                dest_B_ne_cm = curr_pos_neu_cm;
                 gcs().send_text(MAV_SEVERITY_INFO, "%s: point B stored", name());
                 LOGGER_WRITE_EVENT(LogEvent::ZIGZAG_STORE_B);
             }
             // if both A and B have been stored advance state
-            if (!dest_A.is_zero() && !dest_B.is_zero() && !is_zero((dest_B - dest_A).length_squared())) {
+            if (!dest_A_ne_cm.is_zero() && !dest_B_ne_cm.is_zero() && !is_zero((dest_B_ne_cm - dest_A_ne_cm).length_squared())) {
                 stage = MANUAL_REGAIN;
                 spray(false);
-            } else if (!dest_A.is_zero() || !dest_B.is_zero()) {
+            } else if (!dest_A_ne_cm.is_zero() || !dest_B_ne_cm.is_zero()) {
                 // if only A or B have been stored, spray on
                 spray(true);
             }
@@ -188,10 +188,10 @@ void ModeZigZag::save_or_move_to_destination(Destination ab_dest)
         case MANUAL_REGAIN:
             // A and B have been defined, move vehicle to destination A or B
             Vector3f next_dest;
-            bool terr_alt;
-            if (calculate_next_dest(ab_dest, stage == AUTO, next_dest, terr_alt)) {
+            bool terr_alt_cm;
+            if (calculate_next_dest(ab_dest, stage == AUTO, next_dest, terr_alt_cm)) {
                 wp_nav->wp_and_spline_init_cm();
-                if (wp_nav->set_wp_destination_NEU_cm(next_dest, terr_alt)) {
+                if (wp_nav->set_wp_destination_NEU_cm(next_dest, terr_alt_cm)) {
                     stage = AUTO;
                     auto_stage = AutoState::AB_MOVING;
                     ab_dest_stored = ab_dest;
@@ -212,7 +212,7 @@ void ModeZigZag::save_or_move_to_destination(Destination ab_dest)
 
 void ModeZigZag::move_to_side()
 {
-    if (!dest_A.is_zero() && !dest_B.is_zero() && !is_zero((dest_B - dest_A).length_squared())) {
+    if (!dest_A_ne_cm.is_zero() && !dest_B_ne_cm.is_zero() && !is_zero((dest_B_ne_cm - dest_A_ne_cm).length_squared())) {
         Vector3f next_dest;
         bool terr_alt;
         if (calculate_side_dest(next_dest, terr_alt)) {
@@ -253,11 +253,11 @@ void ModeZigZag::return_to_manual_control(bool maintain_target)
     }
 }
 
-// fly the vehicle to closest point on line perpendicular to dest_A or dest_B
+// fly the vehicle to closest point on line perpendicular to dest_A_ne_cm or dest_B_ne_cm
 void ModeZigZag::auto_control()
 {
     // process pilot's yaw input
-    const float target_yaw_rate = get_pilot_desired_yaw_rate();
+    const float target_yaw_rate_cds = get_pilot_desired_yaw_rate();
 
     // set motors to full range
     motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
@@ -271,7 +271,7 @@ void ModeZigZag::auto_control()
 
     // call attitude controller
     // roll & pitch from waypoint controller, yaw rate from pilot
-    attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(wp_nav->get_roll(), wp_nav->get_pitch(), target_yaw_rate);
+    attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(wp_nav->get_roll(), wp_nav->get_pitch(), target_yaw_rate_cds);
 
     // if wpnav failed (because of lack of terrain data) switch back to pilot control for next iteration
     if (!wpnav_ok) {
@@ -282,28 +282,28 @@ void ModeZigZag::auto_control()
 // manual_control - process manual control
 void ModeZigZag::manual_control()
 {
-    float target_yaw_rate = 0.0f;
-    float target_climb_rate = 0.0f;
+    float target_yaw_rate_cds = 0.0f;
+    float target_climb_rate_cd = 0.0f;
 
     // process pilot inputs unless we are in radio failsafe
-    float target_roll, target_pitch;
+    float target_roll_cd, target_pitch_cd;
 
     // apply SIMPLE mode transform to pilot inputs
     update_simple_mode();
 
     // convert pilot input to lean angles
-    get_pilot_desired_lean_angles(target_roll, target_pitch, loiter_nav->get_angle_max_cd(), attitude_control->get_althold_lean_angle_max_cd());
+    get_pilot_desired_lean_angles(target_roll_cd, target_pitch_cd, loiter_nav->get_angle_max_cd(), attitude_control->get_althold_lean_angle_max_cd());
 
     // process pilot's roll and pitch input
-    loiter_nav->set_pilot_desired_acceleration_cd(target_roll, target_pitch);
+    loiter_nav->set_pilot_desired_acceleration_cd(target_roll_cd, target_pitch_cd);
 
     // get pilot's desired yaw rate
-    target_yaw_rate = get_pilot_desired_yaw_rate();
+    target_yaw_rate_cds = get_pilot_desired_yaw_rate();
 
     // get pilot desired climb rate
-    target_climb_rate = get_pilot_desired_climb_rate();
+    target_climb_rate_cd = get_pilot_desired_climb_rate();
     // make sure the climb rate is in the given range, prevent floating point errors
-    target_climb_rate = constrain_float(target_climb_rate, -get_pilot_speed_dn(), g.pilot_speed_up);
+    target_climb_rate_cd = constrain_float(target_climb_rate_cd, -get_pilot_speed_dn(), g.pilot_speed_up);
 
     // relax loiter target if we might be landed
     if (copter.ap.land_complete_maybe) {
@@ -311,7 +311,7 @@ void ModeZigZag::manual_control()
     }
 
     // Loiter State Machine Determination
-    AltHoldModeState althold_state = get_alt_hold_state(target_climb_rate);
+    AltHoldModeState althold_state = get_alt_hold_state(target_climb_rate_cd);
 
     // althold state machine
     switch (althold_state) {
@@ -321,7 +321,7 @@ void ModeZigZag::manual_control()
         attitude_control->reset_yaw_target_and_rate();
         pos_control->relax_U_controller(0.0f);   // forces throttle output to decay to zero
         loiter_nav->init_target();
-        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(loiter_nav->get_roll_cd(), loiter_nav->get_pitch_cd(), target_yaw_rate);
+        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(loiter_nav->get_roll_cd(), loiter_nav->get_pitch_cd(), target_yaw_rate_cds);
         break;
 
     case AltHoldModeState::Takeoff:
@@ -331,16 +331,16 @@ void ModeZigZag::manual_control()
         }
 
         // get avoidance adjusted climb rate
-        target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);
+        target_climb_rate_cd = get_avoidance_adjusted_climbrate(target_climb_rate_cd);
 
         // run loiter controller
         loiter_nav->update();
 
         // call attitude controller
-        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(loiter_nav->get_roll_cd(), loiter_nav->get_pitch_cd(), target_yaw_rate);
+        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(loiter_nav->get_roll_cd(), loiter_nav->get_pitch_cd(), target_yaw_rate_cds);
 
         // set position controller targets adjusted for pilot input
-        takeoff.do_pilot_takeoff(target_climb_rate);
+        takeoff.do_pilot_takeoff(target_climb_rate_cd);
         break;
 
     case AltHoldModeState::Landed_Ground_Idle:
@@ -350,7 +350,7 @@ void ModeZigZag::manual_control()
     case AltHoldModeState::Landed_Pre_Takeoff:
         attitude_control->reset_rate_controller_I_terms_smoothly();
         loiter_nav->init_target();
-        attitude_control->input_thrust_vector_rate_heading_cds(loiter_nav->get_thrust_vector(), target_yaw_rate);
+        attitude_control->input_thrust_vector_rate_heading_cds(loiter_nav->get_thrust_vector(), target_yaw_rate_cds);
         pos_control->relax_U_controller(0.0f);   // forces throttle output to decay to zero
         break;
 
@@ -362,10 +362,10 @@ void ModeZigZag::manual_control()
         loiter_nav->update();
 
         // call attitude controller
-        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(loiter_nav->get_roll_cd(), loiter_nav->get_pitch_cd(), target_yaw_rate);
+        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(loiter_nav->get_roll_cd(), loiter_nav->get_pitch_cd(), target_yaw_rate_cds);
 
         // get avoidance adjusted climb rate
-        target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);
+        target_climb_rate_cd = get_avoidance_adjusted_climbrate(target_climb_rate_cd);
 
 #if AP_RANGEFINDER_ENABLED
         // update the vertical offset based on the surface measurement
@@ -373,7 +373,7 @@ void ModeZigZag::manual_control()
 #endif
 
         // Send the commanded climb rate to the position controller
-        pos_control->set_pos_target_U_from_climb_rate_cm(target_climb_rate);
+        pos_control->set_pos_target_U_from_climb_rate_cm(target_climb_rate_cd);
         break;
     }
 
@@ -399,54 +399,54 @@ bool ModeZigZag::reached_destination()
     if (reach_wp_time_ms == 0) {
         reach_wp_time_ms = now;
     }
-    return ((now - reach_wp_time_ms) >= (uint16_t)constrain_int16(_wp_delay, 0, 127) * 1000);
+    return ((now - reach_wp_time_ms) >= (uint16_t)constrain_int16(_wp_delay_s, 0, 127) * 1000);
 }
 
 // calculate next destination according to vector A-B and current position
 // use_wpnav_alt should be true if waypoint controller's altitude target should be used, false for position control or current altitude target
 // terrain_alt is returned as true if the next_dest should be considered a terrain alt
-bool ModeZigZag::calculate_next_dest(Destination ab_dest, bool use_wpnav_alt, Vector3f& next_dest, bool& terrain_alt) const
+bool ModeZigZag::calculate_next_dest(Destination ab_dest, bool use_wpnav_alt, Vector3f& next_dest_neu_cm, bool& terrain_alt) const
 {
-    // define start_pos as either destination A or B
-    Vector2f start_pos = (ab_dest == Destination::A) ? dest_A : dest_B;
+    // define start_pos_ne_cm as either destination A or B
+    Vector2f start_pos_ne_cm = (ab_dest == Destination::A) ? dest_A_ne_cm : dest_B_ne_cm;
 
     // calculate vector from A to B
-    Vector2f AB_diff = dest_B - dest_A;
+    Vector2f AB_diff_ne_cm = dest_B_ne_cm - dest_A_ne_cm;
 
     // check distance between A and B
-    if (is_zero(AB_diff.length_squared())) {
+    if (is_zero(AB_diff_ne_cm.length_squared())) {
         return false;
     }
 
-    // get distance from vehicle to start_pos
-    const Vector2f curr_pos2d = pos_control->get_pos_desired_NEU_cm().xy().tofloat();
-    Vector2f veh_to_start_pos = curr_pos2d - start_pos;
+    // get distance from vehicle to start_pos_ne_cm
+    const Vector2f curr_pos_ne_cm = pos_control->get_pos_desired_NEU_cm().xy().tofloat();
+    Vector2f veh_to_start_pos = curr_pos_ne_cm - start_pos_ne_cm;
 
-    // lengthen AB_diff so that it is at least as long as vehicle is from start point
+    // lengthen AB_diff_ne_cm so that it is at least as long as vehicle is from start point
     // we need to ensure that the lines perpendicular to AB are long enough to reach the vehicle
     float scalar = 1.0f;
-    if (veh_to_start_pos.length_squared() > AB_diff.length_squared()) {
-        scalar = veh_to_start_pos.length() / AB_diff.length();
+    if (veh_to_start_pos.length_squared() > AB_diff_ne_cm.length_squared()) {
+        scalar = veh_to_start_pos.length() / AB_diff_ne_cm.length();
     }
 
-    // create a line perpendicular to AB but originating at start_pos
-    Vector2f perp1 = start_pos + Vector2f(-AB_diff[1] * scalar, AB_diff[0] * scalar);
-    Vector2f perp2 = start_pos + Vector2f(AB_diff[1] * scalar, -AB_diff[0] * scalar);
+    // create a line perpendicular to AB but originating at start_pos_ne_cm
+    Vector2f perp1 = start_pos_ne_cm + Vector2f(-AB_diff_ne_cm[1] * scalar, AB_diff_ne_cm[0] * scalar);
+    Vector2f perp2 = start_pos_ne_cm + Vector2f(AB_diff_ne_cm[1] * scalar, -AB_diff_ne_cm[0] * scalar);
 
     // find the closest point on the perpendicular line
-    const Vector2f closest2d = Vector2f::closest_point(curr_pos2d, perp1, perp2);
-    next_dest.x = closest2d.x;
-    next_dest.y = closest2d.y;
+    const Vector2f closest2d = Vector2f::closest_point(curr_pos_ne_cm, perp1, perp2);
+    next_dest_neu_cm.x = closest2d.x;
+    next_dest_neu_cm.y = closest2d.y;
 
     if (use_wpnav_alt) {
         // get altitude target from waypoint controller
         terrain_alt = wp_nav->origin_and_destination_are_terrain_alt();
-        next_dest.z = wp_nav->get_wp_destination_NEU_cm().z;
+        next_dest_neu_cm.z = wp_nav->get_wp_destination_NEU_cm().z;
     } else {
         terrain_alt = copter.rangefinder_alt_ok() && wp_nav->rangefinder_used_and_healthy();
-        next_dest.z = pos_control->get_pos_desired_U_cm();
+        next_dest_neu_cm.z = pos_control->get_pos_desired_U_cm();
         if (!terrain_alt) {
-            next_dest.z += pos_control->get_pos_terrain_U_cm();
+            next_dest_neu_cm.z += pos_control->get_pos_terrain_U_cm();
         }
     }
 
@@ -455,44 +455,44 @@ bool ModeZigZag::calculate_next_dest(Destination ab_dest, bool use_wpnav_alt, Ve
 
 // calculate side destination according to vertical vector A-B and current position
 // terrain_alt is returned as true if the next_dest should be considered a terrain alt
-bool ModeZigZag::calculate_side_dest(Vector3f& next_dest, bool& terrain_alt) const
+bool ModeZigZag::calculate_side_dest(Vector3f& next_dest_neu_cm, bool& terrain_alt) const
 {
     // calculate vector from A to B
-    Vector2f AB_diff = dest_B - dest_A;
+    Vector2f AB_diff_ne_cm = dest_B_ne_cm - dest_A_ne_cm;
 
     // calculate a vertical right or left vector for AB from the current yaw direction
-    Vector2f AB_side;
+    Vector2f AB_side_ne_cm;
     if (zigzag_direction == Direction::RIGHT || zigzag_direction == Direction::LEFT) {
-        float yaw_ab_sign = (-ahrs.sin_yaw() * AB_diff[1]) + (ahrs.cos_yaw() * -AB_diff[0]);
+        float yaw_ab_sign = (-ahrs.sin_yaw() * AB_diff_ne_cm[1]) + (ahrs.cos_yaw() * -AB_diff_ne_cm[0]);
         if (is_positive(yaw_ab_sign * (zigzag_direction == Direction::RIGHT ? 1 : -1))) {
-            AB_side = Vector2f(AB_diff[1], -AB_diff[0]);
+            AB_side_ne_cm = Vector2f(AB_diff_ne_cm[1], -AB_diff_ne_cm[0]);
         } else {
-            AB_side = Vector2f(-AB_diff[1], AB_diff[0]);
+            AB_side_ne_cm = Vector2f(-AB_diff_ne_cm[1], AB_diff_ne_cm[0]);
         }
     } else {
-        float yaw_ab_sign = (ahrs.cos_yaw() * AB_diff[1]) + (ahrs.sin_yaw() * -AB_diff[0]);
+        float yaw_ab_sign = (ahrs.cos_yaw() * AB_diff_ne_cm[1]) + (ahrs.sin_yaw() * -AB_diff_ne_cm[0]);
         if (is_positive(yaw_ab_sign * (zigzag_direction == Direction::FORWARD ? 1 : -1))) {
-            AB_side = Vector2f(AB_diff[1], -AB_diff[0]);
+            AB_side_ne_cm = Vector2f(AB_diff_ne_cm[1], -AB_diff_ne_cm[0]);
         } else {
-            AB_side = Vector2f(-AB_diff[1], AB_diff[0]);
+            AB_side_ne_cm = Vector2f(-AB_diff_ne_cm[1], AB_diff_ne_cm[0]);
         }
     }
 
     // check distance the vertical vector between A and B
-    if (is_zero(AB_side.length_squared())) {
+    if (is_zero(AB_side_ne_cm.length_squared())) {
         return false;
     }
 
-    // adjust AB_side length to zigzag_side_dist
-    float scalar = constrain_float(_side_dist, 0.1f, 100.0f) * 100 / safe_sqrt(AB_side.length_squared());
+    // adjust AB_side_ne_cm length to zigzag_side_dist
+    float scalar = constrain_float(_side_dist_m, 0.1f, 100.0f) * 100 / safe_sqrt(AB_side_ne_cm.length_squared());
 
-    // get distance from vehicle to start_pos
-    const Vector2f curr_pos2d = pos_control->get_pos_desired_NEU_cm().xy().tofloat();
-    next_dest.xy() = curr_pos2d + (AB_side * scalar);
+    // get distance from vehicle to start_pos_ne_cm
+    const Vector2f curr_pos_ne_cm = pos_control->get_pos_desired_NEU_cm().xy().tofloat();
+    next_dest_neu_cm.xy() = curr_pos_ne_cm + (AB_side_ne_cm * scalar);
 
     // if we have a downward facing range finder then use terrain altitude targets
     terrain_alt = copter.rangefinder_alt_ok() && wp_nav->rangefinder_used_and_healthy();
-    next_dest.z = pos_control->get_pos_desired_U_cm();
+    next_dest_neu_cm.z = pos_control->get_pos_desired_U_cm();
 
     return true;
 }


### PR DESCRIPTION
This is a zero compiler change:

```
Board,blimp,bootloader,copter,heli,plane,rover,sub
CubeOrange,*,*,*,*,*,*,*
```