### PR TITLE
Allow pytest discovery to find and run Python tests

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,3 +20,16 @@ jobs:
     - run: python3 -m pip install --upgrade pip
     - run: python3 -m pip install pytest
     - run: PYTHONPATH="." pytest tests/test_pre_commit_copyright.py
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        submodules: recursive
+    - uses: actions/setup-python@v6
+      with:
+        python-version: 3.x
+    - run: python3 -m pip install --upgrade pip
+    - run: python3 -m pip install MAVProxy mock numpy pexpect pytest requests
+    - run: python3 -m pip install --editable modules/mavlink/pymavlink
+    - run: pytest --config-file=tests/pytest-whole-repo.toml  # 59 passed in 2.83s

--- a/tests/pytest-whole-repo.toml
+++ b/tests/pytest-whole-repo.toml
@@ -1,0 +1,25 @@
+# This file is used by .github/workflows/pre-commit.yml to enable pytest to discover
+# and run tests across the entire codebase.  These settings should NOT be copied into
+# pytest.toml or pyproject.toml as they would negatively affect autotest and build/test.
+
+[tool.pytest.ini_options]
+addopts = [
+    "--ignore=modules",  # Ignore tests in git submodules.
+    "--ignore=Tools/FilterTestTool",  # Auto-runs and it contains no pytests.
+    "--ignore=Tools/ros2/ardupilot_dds_tests/test",  # Requires a special setup.
+]
+filterwarnings = [
+    "ignore:cannot collect test class.*test_build_options:pytest.PytestCollectionWarning",
+    "ignore:cannot collect test class.*test_param_upgrade:pytest.PytestCollectionWarning",
+]
+python_files = [
+    "test_*.py",
+    "*_test.py",
+    "*_unittest.py",
+    "*_unittests.py"
+]
+pythonpath = [
+    "..",
+    "../Tools/autotest",
+    "../Tools/scripts"
+]


### PR DESCRIPTION
* #30292 says that dependencies are being pinned to out-of-date versions.  Let's use pytest discover to see which Python tests will be found and see what dependencies they require, and if they will pass with the current versions of those dependencies.

https://docs.pytest.org/en/stable/explanation/goodpractices.html#conventions-for-python-test-discovery

Test results: https://github.com/ArduPilot/ardupilot/actions/runs/16271173917/job/45938928611?pr=30361

% `pytest --config-file=tests/pytest-whole-repo.toml`
```
============================= test session starts ==============================
platform linux -- Python 3.14.0, pytest-8.4.2, pluggy-1.6.0
rootdir: /home/runner/work/ardupilot/ardupilot/tests
configfile: pytest-whole-repo.toml
collected 59 items

tests/Tools/autotest/unittest/annotate_params_unittest.py .............. [ 23%]
..........                                                               [ 40%]
tests/Tools/autotest/unittest/extract_param_defaults_unittest.py ....... [ 52%]
...........                                                              [ 71%]
tests/Tools/scripts/param_check_unittests.py ...........                 [ 89%]
tests/test_pre_commit_copyright.py ......                                [100%]

============================== 59 passed in 2.83s ==============================
```