### PR TITLE
AP_Periph: add servo command timeout

### DIFF
--- a/Tools/AP_Periph/AP_Periph.h
+++ b/Tools/AP_Periph/AP_Periph.h
@@ -364,6 +364,13 @@ public:
     uint32_t last_esc_raw_command_ms;
     uint8_t  last_esc_num_channels;
 
+    // Track channels that have been output to by actuator commands
+    // Note there is a single timeout, channels are not tracked individually
+    struct {
+        uint32_t last_command_ms;
+        uint32_t mask;
+    } actuator;
+
     void rcout_init();
     void rcout_init_1Hz();
     void rcout_esc(int16_t *rc, uint8_t num_channels);

--- a/Tools/AP_Periph/Parameters.cpp
+++ b/Tools/AP_Periph/Parameters.cpp
@@ -748,6 +748,16 @@ const AP_Param::Info AP_Periph_FW::var_info[] = {
     GOBJECT(_gcs,           "MAV",  GCS),
 #endif
 
+#if AP_PERIPH_RC_OUT_ENABLED
+    // @Param: SRV_CMD_TIME_OUT
+    // @DisplayName: Servo Command Timeout
+    // @Description: This is the duration (ms) with which to hold the last driven servo command before timing out and zeroing the servo outputs. To disable zeroing of outputs in event of CAN loss, use 0. Use values greater than the expected duration between two CAN frames to ensure Periph is not starved of ESC Raw Commands.
+    // @Range: 0 10000
+    // @Units: ms
+    // @User: Advanced
+    GSCALAR(servo_command_timeout_ms, "SRV_CMD_TIME_OUT", 200),
+#endif
+
     AP_VAREND
 };
 

--- a/Tools/AP_Periph/Parameters.h
+++ b/Tools/AP_Periph/Parameters.h
@@ -102,6 +102,7 @@ public:
         k_param_dac,
         k_param__gcs,
         k_param_battery_tag,
+        k_param_servo_command_timeout_ms,
     };
 
     AP_Int16 format_version;
@@ -193,6 +194,7 @@ public:
     AP_Int16 esc_extended_telem_rate;
 #endif
 #endif
+    AP_Int16 servo_command_timeout_ms;
 #endif
 
     AP_Int8 debug;

--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -675,16 +675,23 @@ void AP_Periph_FW::handle_act_command(CanardInstance* canard_instance, CanardRxT
         return;
     }
 
+    bool valid_output = false;
     for (uint8_t i=0; i < cmd.commands.len; i++) {
         const auto &c = cmd.commands.data[i];
         switch (c.command_type) {
         case UAVCAN_EQUIPMENT_ACTUATOR_COMMAND_COMMAND_TYPE_UNITLESS:
             rcout_srv_unitless(c.actuator_id, c.command_value);
+            valid_output = true;
             break;
         case UAVCAN_EQUIPMENT_ACTUATOR_COMMAND_COMMAND_TYPE_PWM:
             rcout_srv_PWM(c.actuator_id, c.command_value);
+            valid_output = true;
             break;
         }
+    }
+
+    if (valid_output) {
+        actuator.last_command_ms = AP_HAL::millis();
     }
 }
 #endif // AP_PERIPH_RC_OUT_ENABLED


### PR DESCRIPTION
fixes #30345 

This adds a servo command timeout to match the existing ESC one. If no commands are received for longer than the timeout 0 PWM is output, this should stops ESCs and relax servos (depending on brand). 

This PR results from a real incident on a heli where CAN communication was lost due to a bad connection, but the periph device remained powered (lucky on the ground).  The RSC output for the head held at the last value and it stayed at full head speed. Independent of what the main flight controller did. The only way to stop the head was to wait for the battery to run out or to disconnect the power to the periph device or motor.

The existing ESC commands only really make scene for things which use the motor 1 to motor 32 servo functions. Although you theoretically could use them for other output types the hard-coded endpoints and armed check makes that impractical.

This means other "motor" functions such as plane throttle and heli RSC tend to be sent via the servo commands. However, the servo commands currently do not timeout as the ESC command do. If communication is lost periph will just hold the last value. This adds the same protection to servo commands.

It would be nice to do this in a little bit of a cleverer way, only zeroing "motor" type output but holding on control surfaces, but periph doesn't have enough information to know what is what. We could add a mask parameter, but that is the sort of thing users only find after the first crash.

Tested on an MatekL431-DShot using a Salease to check PWM outputs.

