### PR TITLE
Sub:correct operation of pilot input and rc failsafes

### DIFF
--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -99,8 +99,8 @@ const AP_Param::Info Sub::var_info[] = {
 #if AP_SUB_RC_ENABLED        
     // @Param: FS_THR_ENABLE
     // @DisplayName: Throttle Failsafe Enable
-    // @Description: The throttle failsafe allows you to configure a software failsafe activated by a setting on the throttle input channel
-    // @Values:  0:Disabled,1: Warn only but prevent arming,2:Surface on throttle failsafe 
+    // @Description: The throttle failsafe allows you to configure a software RC failsafe activated by a setting on the throttle input channel. It also enables RC failsafe on absence of RC signals being recieved.
+    // @Values:  0:Disabled,1: Force effective control inputs to trim positions and prevent arming,2:Surface and hold on surface on failsafe 
     // @User: Standard
     GSCALAR(failsafe_throttle,  "FS_THR_ENABLE",   0),
 

--- a/ArduSub/failsafe.cpp
+++ b/ArduSub/failsafe.cpp
@@ -536,6 +536,8 @@ void Sub::failsafe_radio_on_event()
             set_mode(Mode::Number::SURFACE, ModeReason::RADIO_FAILSAFE);
             break;
         case FS_THR_WARN:
+            set_neutral_controls();
+            break;
         case FS_THR_DISABLED:
             break;
     }    

--- a/ArduSub/joystick.cpp
+++ b/ArduSub/joystick.cpp
@@ -814,11 +814,12 @@ void Sub::default_js_buttons()
 
 void Sub::set_neutral_controls()
 {
-    uint32_t tnow = AP_HAL::millis();
-
-    for (uint8_t i = 0; i < 6; i++) {
-        RC_Channels::set_override(i, 1500, tnow);
-    }
+    channel_roll->set_radio_in(channel_roll->get_radio_trim());
+    channel_pitch->set_radio_in(channel_pitch->get_radio_trim());
+    channel_yaw->set_radio_in(channel_yaw->get_radio_trim());
+    channel_throttle->set_radio_in(channel_throttle->get_radio_trim());
+    channel_forward->set_radio_in(channel_forward->get_radio_trim());
+    channel_lateral->set_radio_in(channel_lateral->get_radio_trim());
 
     // Clear pitch/roll trim settings
     pitchTrim = 0;


### PR DESCRIPTION
Pilot input failsafes historically forced RC overrides, which clears itself and leads to repeated re-entries. (BUG)

With the addition of RC failsafe,if  Pilot input failsafe(no rc, no manual control or rc override MAVLink messages) is also enabled, this leads to cycling RC failsafe clears and enters (in addition to the repeating Pilot input failsafe) .

The main issue was that pilot input failsafe sets RC overrides (clearing the pilot input failsafe) instead of just setting the channel RC values to trim like other vehicles do in RC failsafe. This PR fixes the **set_neutral_controls** function to not use rc overrides, but directly set the channel value to the trim value (this also allows unidirectional motors to be used)

the WARN ONLY RC failsafe action was slightly modified to not only warn and prevent arming, but also force the channels values to trim when RC fails to prevent last RC values from continuing to be used after loss of RC(swim aways)....

tested in SITL...behave much more rationally now and RC failsafe + Pilot Input failsafe now works so you could use RC AND joystick reasonably.