### PR TITLE
waf: correct compilation when DDS not in build_options.BUILD_OPTIONS

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -103,7 +103,7 @@ class Board:
                 if "#define AP_DDS_ENABLED 1" in file.read():
                     # Enable DDS if the hwdef file has it enabled
                     cfg.env.OPTIONS['enable_DDS'] = True
-                elif cfg.env.OPTIONS['enable_DDS']:
+                elif cfg.env.OPTIONS.get('enable_DDS', False):
                     # Add the define enabled if the hwdef file does not have it and the commandline option is set
                     env.DEFINES.update(
                         AP_DDS_ENABLED=1,

--- a/libraries/AP_DDS/wscript
+++ b/libraries/AP_DDS/wscript
@@ -5,7 +5,7 @@ import pathlib
 
 
 def configure(cfg):
-    if cfg.env.OPTIONS['enable_DDS'] is False:
+    if cfg.env.OPTIONS.get('enable_DDS', False) is False:
         return
 
     # check for microxrceddsgen
@@ -44,7 +44,7 @@ def configure(cfg):
 
 
 def build(bld):
-    if bld.env.OPTIONS['enable_DDS'] is False:
+    if bld.env.OPTIONS.get('enable_DDS', False) is False:
         return
 
     config_h_in = [


### PR DESCRIPTION
Problem occurs if you cut down `BOARD_LIST` to not include DDS - gives a KeyError exception