### PR TITLE
colcon: Use current flake8 in GitHub Action

### DIFF
--- a/.github/workflows/colcon.yml
+++ b/.github/workflows/colcon.yml
@@ -175,9 +175,7 @@ jobs:
         run: |
           apt update
           rosdep update
-          # Workaround for flake8 attribute error
-          # https://github.com/ArduPilot/ardupilot/pull/24277#issuecomment-1632833433
-          python3 -m pip install flake8==3.7.9
+          python3 -m pip install flake8
           source /opt/ros/humble/setup.bash
           rosdep install --from-paths src --ignore-src --default-yes
       - name: Install MAVProxy


### PR DESCRIPTION
This GitHub Action fails occasionally, so let's upgrade its flake8 to see if that provides more stable runs.

https://pypi.org/project/flake8 --> v7.2.0

flake8: Both the local issue and the flake8 issue it points to were closed 4 or 5 years ago, so let's test with current flake8.