### PR TITLE
Copter: modes: get_alt_above_ground_cm to const

### DIFF
--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -600,7 +600,7 @@ void Mode::make_safe_ground_handling(bool force_throttle_unlimited)
 /*
   get a height above ground estimate for landing
  */
-int32_t Mode::get_alt_above_ground_cm(void)
+int32_t Mode::get_alt_above_ground_cm(void) const
 {
     int32_t alt_above_ground_cm;
     if (copter.get_rangefinder_height_interpolated_cm(alt_above_ground_cm)) {

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -173,7 +173,7 @@ public:
     virtual bool set_speed_up(float speed_xy_cms) {return false;}
     virtual bool set_speed_down(float speed_xy_cms) {return false;}
 
-    virtual int32_t get_alt_above_ground_cm(void);
+    virtual int32_t get_alt_above_ground_cm(void) const;
 
     // pilot input processing
     void get_pilot_desired_lean_angles(float &roll_out_cd, float &pitch_out_cd, float angle_max_cd, float angle_limit_cd) const;
@@ -607,7 +607,7 @@ public:
 #endif
 
     // Get height above ground, uses landing height if available
-    int32_t get_alt_above_ground_cm() override;
+    int32_t get_alt_above_ground_cm() const override;
 
 protected:
 

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -2370,7 +2370,7 @@ bool ModeAuto::paused() const
 /*
   get a height above ground estimate for landing
  */
-int32_t ModeAuto::get_alt_above_ground_cm()
+int32_t ModeAuto::get_alt_above_ground_cm() const
 {
     // Only override if in landing submode
     if (_mode == SubMode::LAND) {


### PR DESCRIPTION
Minor follow up to https://github.com/ArduPilot/ardupilot/pull/30195, the method can be const. 