### PR TITLE
Correct embedding of bootloader in hex using USE_BOOTLOADER_FROM_BOARD

### DIFF
--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -434,7 +434,10 @@ def chibios_firmware(self):
     cleanup_task = self.create_task('build_normalized_bins', src=bin_target)
     cleanup_task.set_run_after(generate_apj_task)
 
-    bootloader_bin = self.bld.srcnode.make_node("Tools/bootloaders/%s_bl.bin" % self.env.BOARD)
+    bootloader_board = self.env.BOARD
+    if self.bld.env.USE_BOOTLOADER_FROM_BOARD:
+        bootloader_board = self.bld.env.USE_BOOTLOADER_FROM_BOARD
+    bootloader_bin = self.bld.srcnode.make_node("Tools/bootloaders/%s_bl.bin" % bootloader_board)
     if self.bld.env.HAVE_INTEL_HEX:
         if os.path.exists(bootloader_bin.abspath()):
             if int(self.bld.env.FLASH_RESERVE_START_KB) > 0:

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -3117,6 +3117,12 @@ Please run: Tools/scripts/build_bootloaders.py %s
         self.mcu_type = self.get_config('MCU', 1)
         self.progress("Setup for MCU %s" % self.mcu_type)
 
+        # put USE_BOOTLOADER_FROM_BOARD into the environment so the
+        # build process can use it when generating hex files:
+        use_bootloader_from_board = self.get_config('USE_BOOTLOADER_FROM_BOARD', default=None, required=False)
+        if use_bootloader_from_board is not None:
+            self.env_vars['USE_BOOTLOADER_FROM_BOARD'] = use_bootloader_from_board
+
         # build a list for peripherals for DMA resolver
         self.periph_list = self.build_peripheral_list()
 


### PR DESCRIPTION
New:

```
expanding uavcan.protocol.param.ExecuteOpcode
expanding uavcan.protocol.dynamic_node_id.server.AppendEntries

No target_list file found, creating
Generating compile_commands.json
Build commands will be stored in build/CUAV-Pixhack-v3/compile_commands.json
Generating compile_commands.json
```

```
pbarker@crun:~/rc/ardupilot(pr/correct-bootloader-embedding-hexes)$ ls -la /home/pbarker/rc/ardupilot/build/CUAV-Pixhack-v3/bin/antennatracker_with_bl.hex 
-rw-rw-r-- 1 pbarker pbarker 3093352 Jun 17 21:40 /home/pbarker/rc/ardupilot/build/CUAV-Pixhack-v3/bin/antennatracker_with_bl.hex
pbarker@crun:~/rc/ardupilot(pr/correct-bootloader-embedding-hexes)$ 
```


master:
```
expanding uavcan.protocol.enumeration.Indication
expanding uavcan.protocol.dynamic_node_id.server.AppendEntries

Not embedding bootloader; /home/pbarker/rc/ardupilot/Tools/bootloaders/CUAV-Pixhack-v3_bl.bin does not exist
No target_list file found, creating
Generating compile_commands.json
Build commands will be stored in build/CUAV-Pixhack-v3/compile_commands.json
```

```
pbarker@crun:~/rc/ardupilot(master)$ ls -la /home/pbarker/rc/ardupilot/build/CUAV-Pixhack-v3/bin/antennatracker_with_bl.hex 
ls: cannot access '/home/pbarker/rc/ardupilot/build/CUAV-Pixhack-v3/bin/antennatracker_with_bl.hex': No such file or directory
pbarker@crun:~/rc/ardupilot(master)$ 
```
