### PR TITLE
Copter: Add and fix variable units

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -427,7 +427,7 @@ public:
     bool is_autopilot() const override { return false; }
     bool init(bool ignore_checks) override;
     void exit() override;
-    // whether an air-mode aux switch has been toggled
+    // Called when air mode is enabled via AUX switch; prevents automatic reset to default air_mode state
     void air_mode_aux_changed();
     bool allows_save_trim() const override { return true; }
     bool allows_flip() const override { return true; }
@@ -438,9 +438,9 @@ protected:
     const char *name() const override { return "ACRO"; }
     const char *name4() const override { return "ACRO"; }
 
-    // get_pilot_desired_angle_rates - transform pilot's normalised roll pitch and yaw input into a desired lean angle rates
+    // get_pilot_desired_rates_cds - transform pilot's normalised roll pitch and yaw input into a desired lean angle rates
     // inputs are -1 to 1 and the function returns desired angle rates in centi-degrees-per-second
-    void get_pilot_desired_angle_rates(float roll_in, float pitch_in, float yaw_in, float &roll_out, float &pitch_out, float &yaw_out);
+    void get_pilot_desired_rates_cds(float roll_in_norm, float pitch_in_norm, float yaw_in_norm, float &roll_out_cds, float &pitch_out_cds, float &yaw_out_cds);
 
     float throttle_hover() const override;
 
@@ -1016,7 +1016,7 @@ private:
     void update_height_estimate(void);
 
     // minimum assumed height
-    const float height_min = 0.1f;
+    const float height_min_m = 0.1f;
 
     // maximum scaling height
     const float height_max = 3.0f;
@@ -1034,16 +1034,16 @@ private:
     Vector2f xy_I;
 
     // accumulated INS delta velocity in north-east form since last flow update
-    Vector2f delta_velocity_ne;
+    Vector2f delta_velocity_ne_ms;
 
     // last flow rate in radians/sec in north-east axis
-    Vector2f last_flow_rate_rps;
+    Vector2f last_flow_rate_rads;
 
     // timestamp of last flow data
     uint32_t last_flow_ms;
 
-    float last_ins_height;
-    float height_offset;
+    float last_ins_height_m;
+    float height_offset_m;
 
     // are we braking after pilot input?
     bool braking;

--- a/ArduCopter/mode_acro.cpp
+++ b/ArduCopter/mode_acro.cpp
@@ -10,8 +10,8 @@
 void ModeAcro::run()
 {
     // convert the input to the desired body frame rate
-    float target_roll, target_pitch, target_yaw;
-    get_pilot_desired_angle_rates(channel_roll->norm_input_dz(), channel_pitch->norm_input_dz(), channel_yaw->norm_input_dz(), target_roll, target_pitch, target_yaw);
+    float target_roll_cds, target_pitch_cds, target_yaw_cds;
+    get_pilot_desired_rates_cds(channel_roll->norm_input_dz(), channel_pitch->norm_input_dz(), channel_yaw->norm_input_dz(), target_roll_cds, target_pitch_cds, target_yaw_cds);
 
     if (!motors->armed()) {
         // Motors should be Stopped
@@ -60,9 +60,11 @@ void ModeAcro::run()
 
     // run attitude controller
     if (g2.acro_options.get() & uint8_t(AcroOptions::RATE_LOOP_ONLY)) {
-        attitude_control->input_rate_bf_roll_pitch_yaw_2_cds(target_roll, target_pitch, target_yaw);
+        // send rate commands to attitude controller (RATE_LOOP_ONLY bypasses full attitude stabilization)
+        attitude_control->input_rate_bf_roll_pitch_yaw_2_cds(target_roll_cds, target_pitch_cds, target_yaw_cds);
     } else {
-        attitude_control->input_rate_bf_roll_pitch_yaw_cds(target_roll, target_pitch, target_yaw);
+        // send rate commands to attitude controller with attitude stabilization
+        attitude_control->input_rate_bf_roll_pitch_yaw_cds(target_roll_cds, target_pitch_cds, target_yaw_cds);
     }
 
     // output pilot's throttle without angle boost
@@ -100,101 +102,100 @@ float ModeAcro::throttle_hover() const
     return Mode::throttle_hover();
 }
 
-// get_pilot_desired_angle_rates - transform pilot's normalised roll pitch and yaw input into a desired lean angle rates
-// inputs are -1 to 1 and the function returns desired angle rates in centi-degrees-per-second
-void ModeAcro::get_pilot_desired_angle_rates(float roll_in, float pitch_in, float yaw_in, float &roll_out, float &pitch_out, float &yaw_out)
+// Transform normalized pilot inputs (-1 to 1) into desired angular rates (centidegrees/second)
+void ModeAcro::get_pilot_desired_rates_cds(float roll_in_norm, float pitch_in_norm, float yaw_in_norm, float &roll_out_cds, float &pitch_out_cds, float &yaw_out_cds)
 {
-    float rate_limit;
-    Vector3f rate_ef_level_cd, rate_bf_level_cd, rate_bf_request_cd;
+    float rate_delta_max_cds;
+    Vector3f rate_ef_level_cds, rate_bf_level_cds, rate_bf_request_cds;
 
     // apply circular limit to pitch and roll inputs
-    float total_in = norm(pitch_in, roll_in);
+    float norm_in_length = norm(pitch_in_norm, roll_in_norm);
 
-    if (total_in > 1.0) {
-        float ratio = 1.0 / total_in;
-        roll_in *= ratio;
-        pitch_in *= ratio;
+    if (norm_in_length > 1.0) {
+        float ratio = 1.0 / norm_in_length;
+        roll_in_norm *= ratio;
+        pitch_in_norm *= ratio;
     }
 
     // calculate roll, pitch rate requests
     
-    // roll expo
-    rate_bf_request_cd.x = g2.command_model_acro_rp.get_rate() * 100.0 * input_expo(roll_in, g2.command_model_acro_rp.get_expo());
+    // roll rate request with input expo applied
+    rate_bf_request_cds.x = g2.command_model_acro_rp.get_rate() * 100.0 * input_expo(roll_in_norm, g2.command_model_acro_rp.get_expo());
 
-    // pitch expo
-    rate_bf_request_cd.y = g2.command_model_acro_rp.get_rate() * 100.0 * input_expo(pitch_in, g2.command_model_acro_rp.get_expo());
+    // pitch rate request with input expo applied
+    rate_bf_request_cds.y = g2.command_model_acro_rp.get_rate() * 100.0 * input_expo(pitch_in_norm, g2.command_model_acro_rp.get_expo());
 
-    // yaw expo
-    rate_bf_request_cd.z = g2.command_model_acro_y.get_rate() * 100.0 * input_expo(yaw_in, g2.command_model_acro_y.get_expo());
+    // yaw rate request with input expo applied
+    rate_bf_request_cds.z = g2.command_model_acro_y.get_rate() * 100.0 * input_expo(yaw_in_norm, g2.command_model_acro_y.get_expo());
 
     // calculate earth frame rate corrections to pull the copter back to level while in ACRO mode
 
     if (g.acro_trainer != (uint8_t)Trainer::OFF) {
 
         // get attitude targets
-        const Vector3f att_target = attitude_control->get_att_target_euler_cd();
+        const Vector3f att_target_euler_cd = attitude_control->get_att_target_euler_cd();
 
         // Calculate trainer mode earth frame rate command for roll
-        int32_t roll_angle = wrap_180_cd(att_target.x);
-        rate_ef_level_cd.x = -constrain_int32(roll_angle, -ACRO_LEVEL_MAX_ANGLE, ACRO_LEVEL_MAX_ANGLE) * g.acro_balance_roll;
+        int32_t roll_angle_cd = wrap_180_cd(att_target_euler_cd.x);
+        rate_ef_level_cds.x = -constrain_int32(roll_angle_cd, -ACRO_LEVEL_MAX_ANGLE, ACRO_LEVEL_MAX_ANGLE) * g.acro_balance_roll;
 
         // Calculate trainer mode earth frame rate command for pitch
-        int32_t pitch_angle = wrap_180_cd(att_target.y);
-        rate_ef_level_cd.y = -constrain_int32(pitch_angle, -ACRO_LEVEL_MAX_ANGLE, ACRO_LEVEL_MAX_ANGLE) * g.acro_balance_pitch;
+        int32_t pitch_angle_cd = wrap_180_cd(att_target_euler_cd.y);
+        rate_ef_level_cds.y = -constrain_int32(pitch_angle_cd, -ACRO_LEVEL_MAX_ANGLE, ACRO_LEVEL_MAX_ANGLE) * g.acro_balance_pitch;
 
         // Calculate trainer mode earth frame rate command for yaw
-        rate_ef_level_cd.z = 0;
+        rate_ef_level_cds.z = 0;
 
         // Calculate angle limiting earth frame rate commands
         if (g.acro_trainer == (uint8_t)Trainer::LIMITED) {
-            const float angle_max = copter.aparm.angle_max;
-            if (roll_angle > angle_max){
-                rate_ef_level_cd.x += sqrt_controller(angle_max - roll_angle, g2.command_model_acro_rp.get_rate() * 100.0 / ACRO_LEVEL_MAX_OVERSHOOT, attitude_control->get_accel_roll_max_cdss(), G_Dt);
-            }else if (roll_angle < -angle_max) {
-                rate_ef_level_cd.x += sqrt_controller(-angle_max - roll_angle, g2.command_model_acro_rp.get_rate() * 100.0 / ACRO_LEVEL_MAX_OVERSHOOT, attitude_control->get_accel_roll_max_cdss(), G_Dt);
+            const float angle_max_cd = copter.aparm.angle_max;
+            if (roll_angle_cd > angle_max_cd){
+                rate_ef_level_cds.x += sqrt_controller(angle_max_cd - roll_angle_cd, g2.command_model_acro_rp.get_rate() * 100.0 / ACRO_LEVEL_MAX_OVERSHOOT, attitude_control->get_accel_roll_max_cdss(), G_Dt);
+            }else if (roll_angle_cd < -angle_max_cd) {
+                rate_ef_level_cds.x += sqrt_controller(-angle_max_cd - roll_angle_cd, g2.command_model_acro_rp.get_rate() * 100.0 / ACRO_LEVEL_MAX_OVERSHOOT, attitude_control->get_accel_roll_max_cdss(), G_Dt);
             }
 
-            if (pitch_angle > angle_max){
-                rate_ef_level_cd.y += sqrt_controller(angle_max - pitch_angle, g2.command_model_acro_rp.get_rate() * 100.0 / ACRO_LEVEL_MAX_OVERSHOOT, attitude_control->get_accel_pitch_max_cdss(), G_Dt);
-            }else if (pitch_angle < -angle_max) {
-                rate_ef_level_cd.y += sqrt_controller(-angle_max - pitch_angle, g2.command_model_acro_rp.get_rate() * 100.0 / ACRO_LEVEL_MAX_OVERSHOOT, attitude_control->get_accel_pitch_max_cdss(), G_Dt);
+            if (pitch_angle_cd > angle_max_cd){
+                rate_ef_level_cds.y += sqrt_controller(angle_max_cd - pitch_angle_cd, g2.command_model_acro_rp.get_rate() * 100.0 / ACRO_LEVEL_MAX_OVERSHOOT, attitude_control->get_accel_pitch_max_cdss(), G_Dt);
+            }else if (pitch_angle_cd < -angle_max_cd) {
+                rate_ef_level_cds.y += sqrt_controller(-angle_max_cd - pitch_angle_cd, g2.command_model_acro_rp.get_rate() * 100.0 / ACRO_LEVEL_MAX_OVERSHOOT, attitude_control->get_accel_pitch_max_cdss(), G_Dt);
             }
         }
 
         // convert earth-frame level rates to body-frame level rates
-        attitude_control->euler_rate_to_ang_vel(attitude_control->get_attitude_target_quat(), rate_ef_level_cd, rate_bf_level_cd);
+        attitude_control->euler_rate_to_ang_vel(attitude_control->get_attitude_target_quat(), rate_ef_level_cds, rate_bf_level_cds);
 
         // combine earth frame rate corrections with rate requests
         if (g.acro_trainer == (uint8_t)Trainer::LIMITED) {
-            rate_bf_request_cd.x += rate_bf_level_cd.x;
-            rate_bf_request_cd.y += rate_bf_level_cd.y;
-            rate_bf_request_cd.z += rate_bf_level_cd.z;
+            rate_bf_request_cds.x += rate_bf_level_cds.x;
+            rate_bf_request_cds.y += rate_bf_level_cds.y;
+            rate_bf_request_cds.z += rate_bf_level_cds.z;
         }else{
-            float acro_level_mix = constrain_float(1-float(MAX(MAX(abs(roll_in), abs(pitch_in)), abs(yaw_in))/4500.0), 0, 1)*ahrs.cos_pitch();
+            float acro_level_mix = constrain_float(1-float(MAX(MAX(abs(roll_in_norm), abs(pitch_in_norm)), abs(yaw_in_norm))/4500.0), 0, 1) * ahrs.cos_pitch();
 
             // Scale levelling rates by stick input
-            rate_bf_level_cd = rate_bf_level_cd * acro_level_mix;
+            rate_bf_level_cds = rate_bf_level_cds * acro_level_mix;
 
-            // Calculate rate limit to prevent change of rate through inverted
-            rate_limit = fabsf(fabsf(rate_bf_request_cd.x)-fabsf(rate_bf_level_cd.x));
-            rate_bf_request_cd.x += rate_bf_level_cd.x;
-            rate_bf_request_cd.x = constrain_float(rate_bf_request_cd.x, -rate_limit, rate_limit);
+            // Calculate the maximum allowed change in rate to prevent reversal through inverted
+            rate_delta_max_cds = fabsf(fabsf(rate_bf_request_cds.x)-fabsf(rate_bf_level_cds.x));
+            rate_bf_request_cds.x += rate_bf_level_cds.x;
+            rate_bf_request_cds.x = constrain_float(rate_bf_request_cds.x, -rate_delta_max_cds, rate_delta_max_cds);
 
-            // Calculate rate limit to prevent change of rate through inverted
-            rate_limit = fabsf(fabsf(rate_bf_request_cd.y)-fabsf(rate_bf_level_cd.y));
-            rate_bf_request_cd.y += rate_bf_level_cd.y;
-            rate_bf_request_cd.y = constrain_float(rate_bf_request_cd.y, -rate_limit, rate_limit);
+            // Calculate the maximum allowed change in rate to prevent reversal through inverted
+            rate_delta_max_cds = fabsf(fabsf(rate_bf_request_cds.y)-fabsf(rate_bf_level_cds.y));
+            rate_bf_request_cds.y += rate_bf_level_cds.y;
+            rate_bf_request_cds.y = constrain_float(rate_bf_request_cds.y, -rate_delta_max_cds, rate_delta_max_cds);
 
-            // Calculate rate limit to prevent change of rate through inverted
-            rate_limit = fabsf(fabsf(rate_bf_request_cd.z)-fabsf(rate_bf_level_cd.z));
-            rate_bf_request_cd.z += rate_bf_level_cd.z;
-            rate_bf_request_cd.z = constrain_float(rate_bf_request_cd.z, -rate_limit, rate_limit);
+            // Calculate the maximum allowed change in rate to prevent reversal through inverted
+            rate_delta_max_cds = fabsf(fabsf(rate_bf_request_cds.z)-fabsf(rate_bf_level_cds.z));
+            rate_bf_request_cds.z += rate_bf_level_cds.z;
+            rate_bf_request_cds.z = constrain_float(rate_bf_request_cds.z, -rate_delta_max_cds, rate_delta_max_cds);
         }
     }
 
     // hand back rate request
-    roll_out = rate_bf_request_cd.x;
-    pitch_out = rate_bf_request_cd.y;
-    yaw_out = rate_bf_request_cd.z;
+    roll_out_cds = rate_bf_request_cds.x;
+    pitch_out_cds = rate_bf_request_cds.y;
+    yaw_out_cds = rate_bf_request_cds.z;
 }
 #endif

--- a/ArduCopter/mode_acro_heli.cpp
+++ b/ArduCopter/mode_acro_heli.cpp
@@ -69,7 +69,7 @@ void ModeAcro_Heli::run()
 
     if (!motors->has_flybar()){
         // convert the input to the desired body frame rate
-        get_pilot_desired_angle_rates(channel_roll->norm_input_dz(), channel_pitch->norm_input_dz(), channel_yaw->norm_input_dz(), target_roll_cds, target_pitch_cds, target_yaw_cds);
+        get_pilot_desired_rates_cds(channel_roll->norm_input_dz(), channel_pitch->norm_input_dz(), channel_yaw->norm_input_dz(), target_roll_cds, target_pitch_cds, target_yaw_cds);
         // only mimic flybar response when trainer mode is disabled
         if ((Trainer)g.acro_trainer.get() == Trainer::OFF) {
             // while landed always leak off target attitude to current attitude
@@ -127,29 +127,29 @@ void ModeAcro_Heli::run()
 
 
 // virtual_flybar - acts like a flybar by leaking target atttitude back to current attitude
-void ModeAcro_Heli::virtual_flybar( float &roll_out, float &pitch_out, float &yaw_out, float pitch_leak, float roll_leak)
+void ModeAcro_Heli::virtual_flybar( float &roll_out_cds, float &pitch_out_cds, float &yaw_out_cds, float pitch_leak, float roll_leak)
 {
-    Vector3f rate_ef_level, rate_bf_level;
+    Vector3f rate_ef_level_cds, rate_bf_level_cds;
 
     // get attitude targets
-    const Vector3f att_target = attitude_control->get_att_target_euler_cd();
+    const Vector3f att_target_cd = attitude_control->get_att_target_euler_cd();
 
     // Calculate earth frame rate command for roll leak to current attitude
-    rate_ef_level.x = -wrap_180_cd(att_target.x - ahrs.roll_sensor) * roll_leak;
+    rate_ef_level_cds.x = -wrap_180_cd(att_target_cd.x - ahrs.roll_sensor) * roll_leak;
 
     // Calculate earth frame rate command for pitch leak to current attitude
-    rate_ef_level.y = -wrap_180_cd(att_target.y - ahrs.pitch_sensor) * pitch_leak;
+    rate_ef_level_cds.y = -wrap_180_cd(att_target_cd.y - ahrs.pitch_sensor) * pitch_leak;
 
     // Calculate earth frame rate command for yaw
-    rate_ef_level.z = 0;
+    rate_ef_level_cds.z = 0;
 
     // convert earth-frame leak rates to body-frame leak rates
-    attitude_control->euler_rate_to_ang_vel(attitude_control->get_attitude_target_quat(), rate_ef_level, rate_bf_level);
+    attitude_control->euler_rate_to_ang_vel(attitude_control->get_attitude_target_quat(), rate_ef_level_cds, rate_bf_level_cds);
 
     // combine earth frame rate corrections with rate requests
-    roll_out += rate_bf_level.x;
-    pitch_out += rate_bf_level.y;
-    yaw_out += rate_bf_level.z;
+    roll_out_cds += rate_bf_level_cds.x;
+    pitch_out_cds += rate_bf_level_cds.y;
+    yaw_out_cds += rate_bf_level_cds.z;
 
 }
 #endif  //HELI_FRAME

--- a/ArduCopter/mode_drift.cpp
+++ b/ArduCopter/mode_drift.cpp
@@ -12,6 +12,9 @@
 #ifndef DRIFT_SPEEDLIMIT
  # define DRIFT_SPEEDLIMIT 560.0f
 #endif
+#ifndef DRIFT_VEL_FORWARD_MIN
+ # define DRIFT_VEL_FORWARD_MIN 2000.0f
+#endif
 
 #ifndef DRIFT_THR_ASSIST_GAIN
  # define DRIFT_THR_ASSIST_GAIN 0.0018f    // gain controlling amount of throttle assistance
@@ -39,41 +42,41 @@ bool ModeDrift::init(bool ignore_checks)
 void ModeDrift::run()
 {
     static float braker = 0.0f;
-    static float roll_input = 0.0f;
+    static float roll_input_cd = 0.0f;
 
     // convert pilot input to lean angles
-    float target_roll, target_pitch;
-    get_pilot_desired_lean_angles(target_roll, target_pitch, copter.aparm.angle_max, copter.aparm.angle_max);
+    float target_roll_cd, target_pitch_cd;
+    get_pilot_desired_lean_angles(target_roll_cd, target_pitch_cd, copter.aparm.angle_max, copter.aparm.angle_max);
 
     // Grab inertial velocity
-    const Vector3f& vel = pos_control->get_vel_estimate_NEU_cms();
+    const Vector3f& vel_NEU_cms = pos_control->get_vel_estimate_NEU_cms();
 
     // rotate roll, pitch input from north facing to vehicle's perspective
-    float roll_vel =  vel.y * ahrs.cos_yaw() - vel.x * ahrs.sin_yaw(); // body roll vel
-    float pitch_vel = vel.y * ahrs.sin_yaw() + vel.x * ahrs.cos_yaw(); // body pitch vel
+    float vel_right_cms =  vel_NEU_cms.y * ahrs.cos_yaw() - vel_NEU_cms.x * ahrs.sin_yaw(); // body roll vel_NEU_cms
+    float vel_forward_cms = vel_NEU_cms.y * ahrs.sin_yaw() + vel_NEU_cms.x * ahrs.cos_yaw(); // body pitch vel_NEU_cms
 
     // gain scheduling for yaw
-    float pitch_vel2 = MIN(fabsf(pitch_vel), 2000);
-    float target_yaw_rate = target_roll * (1.0f - (pitch_vel2 / 5000.0f)) * g2.command_model_acro_y.get_rate() / 45.0;
+    float vel_forward_2_cms = MIN(fabsf(vel_forward_cms), DRIFT_VEL_FORWARD_MIN);
+    float target_yaw_rate_cds = target_roll_cd * (1.0f - (vel_forward_2_cms / 5000.0f)) * g2.command_model_acro_y.get_rate() / 45.0;
 
-    roll_vel = constrain_float(roll_vel, -DRIFT_SPEEDLIMIT, DRIFT_SPEEDLIMIT);
-    pitch_vel = constrain_float(pitch_vel, -DRIFT_SPEEDLIMIT, DRIFT_SPEEDLIMIT);
+    vel_right_cms = constrain_float(vel_right_cms, -DRIFT_SPEEDLIMIT, DRIFT_SPEEDLIMIT);
+    vel_forward_cms = constrain_float(vel_forward_cms, -DRIFT_SPEEDLIMIT, DRIFT_SPEEDLIMIT);
 
-    roll_input = roll_input * 0.96f + (float)channel_yaw->get_control_in() * 0.04f;
+    roll_input_cd = roll_input_cd * 0.96f + (float)channel_yaw->get_control_in() * 0.04f;
 
     // convert user input into desired roll velocity
-    float roll_vel_error = roll_vel - (roll_input / DRIFT_SPEEDGAIN);
+    float roll_vel_error = vel_right_cms - (roll_input_cd / DRIFT_SPEEDGAIN);
 
     // roll velocity is feed into roll acceleration to minimize slip
-    target_roll = roll_vel_error * -DRIFT_SPEEDGAIN;
-    target_roll = constrain_float(target_roll, -4500.0f, 4500.0f);
+    target_roll_cd = roll_vel_error * -DRIFT_SPEEDGAIN;
+    target_roll_cd = constrain_float(target_roll_cd, -4500.0f, 4500.0f);
 
     // If we let go of sticks, bring us to a stop
-    if (is_zero(target_pitch)) {
+    if (is_zero(target_pitch_cd)) {
         // 0.14/ (0.03 * 100) = 4.6 seconds till full braking
         braker += 0.03f;
         braker = MIN(braker, DRIFT_SPEEDGAIN);
-        target_pitch = pitch_vel * braker;
+        target_pitch_cd = vel_forward_cms * braker;
     } else {
         braker = 0.0f;
     }
@@ -115,10 +118,10 @@ void ModeDrift::run()
     }
 
     // call attitude controller
-    attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(target_roll, target_pitch, target_yaw_rate);
+    attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(target_roll_cd, target_pitch_cd, target_yaw_rate_cds);
 
     // output pilot's throttle with angle boost
-    const float assisted_throttle = get_throttle_assist(vel.z, get_pilot_desired_throttle());
+    const float assisted_throttle = get_throttle_assist(vel_NEU_cms.z, get_pilot_desired_throttle());
     attitude_control->set_throttle_out(assisted_throttle, true, g.throttle_filt);
 }
 

--- a/ArduCopter/mode_flowhold.cpp
+++ b/ArduCopter/mode_flowhold.cpp
@@ -106,8 +106,8 @@ bool ModeFlowHold::init(bool ignore_checks)
     flow_pi_xy.set_dt(1.0/copter.scheduler.get_loop_rate_hz());
 
     // start with INS height
-    last_ins_height = pos_control->get_pos_estimate_NEU_cm().z * 0.01;
-    height_offset = 0;
+    last_ins_height_m = pos_control->get_pos_estimate_NEU_cm().z * 0.01;
+    height_offset_m = 0;
 
     return true;
 }
@@ -115,7 +115,7 @@ bool ModeFlowHold::init(bool ignore_checks)
 /*
   calculate desired attitude from flow sensor. Called when flow sensor is healthy
  */
-void ModeFlowHold::flowhold_flow_to_angle(Vector2f &bf_angles, bool stick_input)
+void ModeFlowHold::flowhold_flow_to_angle(Vector2f &bf_angles_cd, bool stick_input)
 {
     uint32_t now = AP_HAL::millis();
 
@@ -129,12 +129,12 @@ void ModeFlowHold::flowhold_flow_to_angle(Vector2f &bf_angles, bool stick_input)
     // filter the flow rate
     Vector2f sensor_flow = flow_filter.apply(raw_flow);
 
-    // scale by height estimate, limiting it to height_min to height_max
-    float ins_height = pos_control->get_pos_estimate_NEU_cm().z * 0.01;
-    float height_estimate = ins_height + height_offset;
+    // scale by height estimate, limiting it to height_min_m to height_max
+    float ins_height_m = pos_control->get_pos_estimate_NEU_cm().z * 0.01;
+    float height_estimate_m = ins_height_m + height_offset_m;
 
     // compensate for height, this converts to (approx) m/s
-    sensor_flow *= constrain_float(height_estimate, height_min, height_max);
+    sensor_flow *= constrain_float(height_estimate_m, height_min_m, height_max);
 
     // rotate controller input to earth frame
     Vector2f input_ef = copter.ahrs.body_to_earth2D(sensor_flow);
@@ -184,7 +184,7 @@ void ModeFlowHold::flowhold_flow_to_angle(Vector2f &bf_angles, bool stick_input)
             if (velocity < 0) {
                 lean_angle_cd = -lean_angle_cd;
             }
-            bf_angles[i] = lean_angle_cd;
+            bf_angles_cd[i] = lean_angle_cd;
         }
         ef_output.zero();
     }
@@ -193,14 +193,14 @@ void ModeFlowHold::flowhold_flow_to_angle(Vector2f &bf_angles, bool stick_input)
     ef_output *= copter.aparm.angle_max;
 
     // convert to body frame
-    bf_angles += copter.ahrs.earth_to_body2D(ef_output);
+    bf_angles_cd += copter.ahrs.earth_to_body2D(ef_output);
 
     // set limited flag to prevent integrator windup
-    limited = fabsf(bf_angles.x) > copter.aparm.angle_max || fabsf(bf_angles.y) > copter.aparm.angle_max;
+    limited = fabsf(bf_angles_cd.x) > copter.aparm.angle_max || fabsf(bf_angles_cd.y) > copter.aparm.angle_max;
 
     // constrain to angle limit
-    bf_angles.x = constrain_float(bf_angles.x, -copter.aparm.angle_max, copter.aparm.angle_max);
-    bf_angles.y = constrain_float(bf_angles.y, -copter.aparm.angle_max, copter.aparm.angle_max);
+    bf_angles_cd.x = constrain_float(bf_angles_cd.x, -copter.aparm.angle_max, copter.aparm.angle_max);
+    bf_angles_cd.y = constrain_float(bf_angles_cd.y, -copter.aparm.angle_max, copter.aparm.angle_max);
 
 #if HAL_LOGGING_ENABLED
 // @LoggerMessage: FHLD
@@ -219,7 +219,7 @@ void ModeFlowHold::flowhold_flow_to_angle(Vector2f &bf_angles, bool stick_input)
         AP::logger().WriteStreaming("FHLD", "TimeUS,SFx,SFy,Ax,Ay,Qual,Ix,Iy", "Qfffffff",
                                                AP_HAL::micros64(),
                                                (double)sensor_flow.x, (double)sensor_flow.y,
-                                               (double)bf_angles.x, (double)bf_angles.y,
+                                               (double)bf_angles_cd.x, (double)bf_angles_cd.y,
                                                (double)quality_filtered,
                                                (double)xy_I.x, (double)xy_I.y);
     }
@@ -244,14 +244,14 @@ void ModeFlowHold::run()
     }
 
     // get pilot desired climb rate
-    float target_climb_rate = copter.get_pilot_desired_climb_rate();
-    target_climb_rate = constrain_float(target_climb_rate, -get_pilot_speed_dn(), copter.g.pilot_speed_up);
+    float target_climb_rate_cms = copter.get_pilot_desired_climb_rate();
+    target_climb_rate_cms = constrain_float(target_climb_rate_cms, -get_pilot_speed_dn(), copter.g.pilot_speed_up);
 
     // get pilot's desired yaw rate
-    float target_yaw_rate = get_pilot_desired_yaw_rate();
+    float target_yaw_rate_cds = get_pilot_desired_yaw_rate();
 
     // Flow Hold State Machine Determination
-    AltHoldModeState flowhold_state = get_alt_hold_state(target_climb_rate);
+    AltHoldModeState flowhold_state = get_alt_hold_state(target_climb_rate_cms);
 
     if (copter.optflow.healthy()) {
         const float filter_constant = 0.95;
@@ -281,10 +281,10 @@ void ModeFlowHold::run()
         }
 
         // get avoidance adjusted climb rate
-        target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);
+        target_climb_rate_cms = get_avoidance_adjusted_climbrate(target_climb_rate_cms);
 
         // set position controller targets adjusted for pilot input
-        takeoff.do_pilot_takeoff(target_climb_rate);
+        takeoff.do_pilot_takeoff(target_climb_rate_cms);
         break;
 
     case AltHoldModeState::Landed_Ground_Idle:
@@ -300,7 +300,7 @@ void ModeFlowHold::run()
         copter.motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
         // get avoidance adjusted climb rate
-        target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);
+        target_climb_rate_cms = get_avoidance_adjusted_climbrate(target_climb_rate_cms);
 
 #if AP_RANGEFINDER_ENABLED
         // update the vertical offset based on the surface measurement
@@ -308,18 +308,18 @@ void ModeFlowHold::run()
 #endif
 
         // Send the commanded climb rate to the position controller
-        pos_control->set_pos_target_U_from_climb_rate_cm(target_climb_rate);
+        pos_control->set_pos_target_U_from_climb_rate_cm(target_climb_rate_cms);
         break;
     }
 
     // flowhold attitude target calculations
-    Vector2f bf_angles;
+    Vector2f bf_angles_cd;
 
     // calculate alt-hold angles
     int16_t roll_in = copter.channel_roll->get_control_in();
     int16_t pitch_in = copter.channel_pitch->get_control_in();
-    float angle_max = copter.aparm.angle_max;
-    get_pilot_desired_lean_angles(bf_angles.x, bf_angles.y, angle_max, attitude_control->get_althold_lean_angle_max_cd());
+    float angle_max_cd = copter.aparm.angle_max;
+    get_pilot_desired_lean_angles(bf_angles_cd.x, bf_angles_cd.y, angle_max_cd, attitude_control->get_althold_lean_angle_max_cd());
 
     if (quality_filtered >= flow_min_quality &&
         AP_HAL::millis() - copter.arm_time_ms > 3000) {
@@ -327,20 +327,20 @@ void ModeFlowHold::run()
         Vector2f flow_angles;
 
         flowhold_flow_to_angle(flow_angles, (roll_in != 0) || (pitch_in != 0));
-        flow_angles.x = constrain_float(flow_angles.x, -angle_max/2, angle_max/2);
-        flow_angles.y = constrain_float(flow_angles.y, -angle_max/2, angle_max/2);
-        bf_angles += flow_angles;
+        flow_angles.x = constrain_float(flow_angles.x, -angle_max_cd/2, angle_max_cd/2);
+        flow_angles.y = constrain_float(flow_angles.y, -angle_max_cd/2, angle_max_cd/2);
+        bf_angles_cd += flow_angles;
     }
-    bf_angles.x = constrain_float(bf_angles.x, -angle_max, angle_max);
-    bf_angles.y = constrain_float(bf_angles.y, -angle_max, angle_max);
+    bf_angles_cd.x = constrain_float(bf_angles_cd.x, -angle_max_cd, angle_max_cd);
+    bf_angles_cd.y = constrain_float(bf_angles_cd.y, -angle_max_cd, angle_max_cd);
 
 #if AP_AVOIDANCE_ENABLED
     // apply avoidance
-    copter.avoid.adjust_roll_pitch(bf_angles.x, bf_angles.y, copter.aparm.angle_max);
+    copter.avoid.adjust_roll_pitch(bf_angles_cd.x, bf_angles_cd.y, copter.aparm.angle_max);
 #endif
 
     // call attitude controller
-    copter.attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(bf_angles.x, bf_angles.y, target_yaw_rate);
+    copter.attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(bf_angles_cd.x, bf_angles_cd.y, target_yaw_rate_cds);
 
     // run the vertical position controller and set output throttle
     pos_control->update_U_controller();
@@ -351,44 +351,44 @@ void ModeFlowHold::run()
  */
 void ModeFlowHold::update_height_estimate(void)
 {
-    float ins_height = copter.pos_control->get_pos_estimate_NEU_cm().z * 0.01;
+    float ins_height_m = copter.pos_control->get_pos_estimate_NEU_cm().z * 0.01;
 
 #if 1
     // assume on ground when disarmed, or if we have only just started spooling the motors up
     if (!hal.util->get_soft_armed() ||
         copter.motors->get_desired_spool_state() != AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED ||
         AP_HAL::millis() - copter.arm_time_ms < 1500) {
-        height_offset = -ins_height;
-        last_ins_height = ins_height;
+        height_offset_m = -ins_height_m;
+        last_ins_height_m = ins_height_m;
         return;
     }
 #endif
 
     // get delta velocity in body frame
-    Vector3f delta_vel;
+    Vector3f delta_vel_ms;
     float delta_vel_dt;
-    if (!copter.ins.get_delta_velocity(delta_vel, delta_vel_dt)) {
+    if (!copter.ins.get_delta_velocity(delta_vel_ms, delta_vel_dt)) {
         return;
     }
 
     // integrate delta velocity in earth frame
     const Matrix3f &rotMat = copter.ahrs.get_rotation_body_to_ned();
-    delta_vel = rotMat * delta_vel;
-    delta_velocity_ne.x += delta_vel.x;
-    delta_velocity_ne.y += delta_vel.y;
+    delta_vel_ms = rotMat * delta_vel_ms;
+    delta_velocity_ne_ms.x += delta_vel_ms.x;
+    delta_velocity_ne_ms.y += delta_vel_ms.y;
 
     if (!copter.optflow.healthy()) {
         // can't update height model with no flow sensor
         last_flow_ms = AP_HAL::millis();
-        delta_velocity_ne.zero();
+        delta_velocity_ne_ms.zero();
         return;
     }
 
     if (last_flow_ms == 0) {
         // just starting up
         last_flow_ms = copter.optflow.last_update();
-        delta_velocity_ne.zero();
-        height_offset = 0;
+        delta_velocity_ne_ms.zero();
+        height_offset_m = 0;
         return;
     }
 
@@ -398,89 +398,89 @@ void ModeFlowHold::update_height_estimate(void)
     }
 
     // convert delta velocity back to body frame to match the flow sensor
-    Vector2f delta_vel_bf = copter.ahrs.earth_to_body2D(delta_velocity_ne);
+    Vector2f delta_vel_bf_ms = copter.ahrs.earth_to_body2D(delta_velocity_ne_ms);
 
     // and convert to an rate equivalent, to be comparable to flow
-    Vector2f delta_vel_rate(-delta_vel_bf.y, delta_vel_bf.x);
+    Vector2f delta_vel_rate_ms(-delta_vel_bf_ms.y, delta_vel_bf_ms.x);
 
     // get body flow rate in radians per second
-    Vector2f flow_rate_rps = copter.optflow.flowRate() - copter.optflow.bodyRate();
+    Vector2f flow_rate_rads = copter.optflow.flowRate() - copter.optflow.bodyRate();
 
     uint32_t dt_ms = copter.optflow.last_update() - last_flow_ms;
     if (dt_ms > 500) {
         // too long between updates, ignore
         last_flow_ms = copter.optflow.last_update();
-        delta_velocity_ne.zero();
-        last_flow_rate_rps = flow_rate_rps;
-        last_ins_height = ins_height;
-        height_offset = 0;
+        delta_velocity_ne_ms.zero();
+        last_flow_rate_rads = flow_rate_rads;
+        last_ins_height_m = ins_height_m;
+        height_offset_m = 0;
         return;        
     }
 
     /*
       basic equation is:
-      height_m = delta_velocity_mps / delta_flowrate_rps;
+      height_m = delta_velocity_ms / delta_flowrate_rads;
      */
 
     // get delta_flowrate_rps
-    Vector2f delta_flowrate = flow_rate_rps - last_flow_rate_rps;
-    last_flow_rate_rps = flow_rate_rps;
+    Vector2f delta_flowrate_rads = flow_rate_rads - last_flow_rate_rads;
+    last_flow_rate_rads = flow_rate_rads;
     last_flow_ms = copter.optflow.last_update();
 
     /*
       update height estimate
      */
-    const float min_velocity_change = 0.04;
+    const float min_velocity_change_ms = 0.04;
     const float min_flow_change = 0.04;
-    const float height_delta_max = 0.25;
+    const float height_delta_max_m = 0.25;
 
     /*
       for each axis update the height estimate
      */
-    float delta_height = 0;
+    float delta_height_m = 0;
     uint8_t total_weight = 0;
-    float height_estimate = ins_height + height_offset;
+    float height_estimate_m = ins_height_m + height_offset_m;
 
     for (uint8_t i=0; i<2; i++) {
         // only use height estimates when we have significant delta-velocity and significant delta-flow
-        float abs_flow = fabsf(delta_flowrate[i]);
+        float abs_flow = fabsf(delta_flowrate_rads[i]);
         if (abs_flow < min_flow_change ||
-            fabsf(delta_vel_rate[i]) < min_velocity_change) {
+            fabsf(delta_vel_rate_ms[i]) < min_velocity_change_ms) {
             continue;
         }
         // get instantaneous height estimate
-        float height = delta_vel_rate[i] / delta_flowrate[i];
-        if (height <= 0) {
+        float height_m = delta_vel_rate_ms[i] / delta_flowrate_rads[i];
+        if (height_m <= 0) {
             // discard negative heights
             continue;
         }
-        delta_height += (height - height_estimate) * abs_flow;
+        delta_height_m += (height_m - height_estimate_m) * abs_flow;
         total_weight += abs_flow;
     }
     if (total_weight > 0) {
-        delta_height /= total_weight;
+        delta_height_m /= total_weight;
     }
 
-    if (delta_height < 0) {
+    if (delta_height_m < 0) {
         // bias towards lower heights, as we'd rather have too low
         // gain than have oscillation. This also compensates a bit for
         // the discard of negative heights above
-        delta_height *= 2;
+        delta_height_m *= 2;
     }
 
-    // don't update height by more than height_delta_max, this is a simple way of rejecting noise
-    float new_offset = height_offset + constrain_float(delta_height, -height_delta_max, height_delta_max);
+    // don't update height by more than height_delta_max_m, this is a simple way of rejecting noise
+    float new_offset_m = height_offset_m + constrain_float(delta_height_m, -height_delta_max_m, height_delta_max_m);
 
     // apply a simple filter
-    height_offset = 0.8 * height_offset + 0.2 * new_offset;
+    height_offset_m = 0.8 * height_offset_m + 0.2 * new_offset_m;
 
-    if (ins_height + height_offset < height_min) {
+    if (ins_height_m + height_offset_m < height_min_m) {
         // height estimate is never allowed below the minimum
-        height_offset = height_min - ins_height;
+        height_offset_m = height_min_m - ins_height_m;
     }
 
     // new height estimate for logging
-    height_estimate = ins_height + height_offset;
+    height_estimate_m = ins_height_m + height_offset_m;
 
 #if HAL_LOGGING_ENABLED
 // @LoggerMessage: FHXY
@@ -499,21 +499,21 @@ void ModeFlowHold::update_height_estimate(void)
 
     AP::logger().WriteStreaming("FHXY", "TimeUS,DFx,DFy,DVx,DVy,Hest,DH,Hofs,InsH,LastInsH,DTms", "QfffffffffI",
                                            AP_HAL::micros64(),
-                                           (double)delta_flowrate.x,
-                                           (double)delta_flowrate.y,
-                                           (double)delta_vel_rate.x,
-                                           (double)delta_vel_rate.y,
-                                           (double)height_estimate,
-                                           (double)delta_height,
-                                           (double)height_offset,
-                                           (double)ins_height,
-                                           (double)last_ins_height,
+                                           (double)delta_flowrate_rads.x,
+                                           (double)delta_flowrate_rads.y,
+                                           (double)delta_vel_rate_ms.x,
+                                           (double)delta_vel_rate_ms.y,
+                                           (double)height_estimate_m,
+                                           (double)delta_height_m,
+                                           (double)height_offset_m,
+                                           (double)ins_height_m,
+                                           (double)last_ins_height_m,
                                            dt_ms);
 #endif
 
-    gcs().send_named_float("HEST", height_estimate);
-    delta_velocity_ne.zero();
-    last_ins_height = ins_height;
+    gcs().send_named_float("HEST", height_estimate_m);
+    delta_velocity_ne_ms.zero();
+    last_ins_height_m = ins_height_m;
 }
 
 #endif // MODE_FLOWHOLD_ENABLED

--- a/ArduCopter/mode_sport.cpp
+++ b/ArduCopter/mode_sport.cpp
@@ -34,42 +34,42 @@ void ModeSport::run()
     // get pilot's desired roll and pitch rates
 
     // calculate rate requests
-    float target_roll_rate = channel_roll->get_control_in() * g2.command_model_acro_rp.get_rate() * 100.0 / ROLL_PITCH_YAW_INPUT_MAX;
-    float target_pitch_rate = channel_pitch->get_control_in() * g2.command_model_acro_rp.get_rate() * 100.0 / ROLL_PITCH_YAW_INPUT_MAX;
+    float target_roll_rate_cds = channel_roll->get_control_in() * g2.command_model_acro_rp.get_rate() * 100.0 / ROLL_PITCH_YAW_INPUT_MAX;
+    float target_pitch_rate_cds = channel_pitch->get_control_in() * g2.command_model_acro_rp.get_rate() * 100.0 / ROLL_PITCH_YAW_INPUT_MAX;
 
     // get attitude targets
-    const Vector3f att_target = attitude_control->get_att_target_euler_cd();
+    const Vector3f att_target_cd = attitude_control->get_att_target_euler_cd();
 
     // Calculate trainer mode earth frame rate command for roll
-    int32_t roll_angle = wrap_180_cd(att_target.x);
-    target_roll_rate -= constrain_int32(roll_angle, -ACRO_LEVEL_MAX_ANGLE, ACRO_LEVEL_MAX_ANGLE) * g.acro_balance_roll;
+    int32_t roll_angle = wrap_180_cd(att_target_cd.x);
+    target_roll_rate_cds -= constrain_int32(roll_angle, -ACRO_LEVEL_MAX_ANGLE, ACRO_LEVEL_MAX_ANGLE) * g.acro_balance_roll;
 
     // Calculate trainer mode earth frame rate command for pitch
-    int32_t pitch_angle = wrap_180_cd(att_target.y);
-    target_pitch_rate -= constrain_int32(pitch_angle, -ACRO_LEVEL_MAX_ANGLE, ACRO_LEVEL_MAX_ANGLE) * g.acro_balance_pitch;
+    int32_t pitch_angle = wrap_180_cd(att_target_cd.y);
+    target_pitch_rate_cds -= constrain_int32(pitch_angle, -ACRO_LEVEL_MAX_ANGLE, ACRO_LEVEL_MAX_ANGLE) * g.acro_balance_pitch;
 
     const float angle_max = copter.aparm.angle_max;
     if (roll_angle > angle_max){
-        target_roll_rate +=  sqrt_controller(angle_max - roll_angle, g2.command_model_acro_rp.get_rate() * 100.0 / ACRO_LEVEL_MAX_OVERSHOOT, attitude_control->get_accel_roll_max_cdss(), G_Dt);
+        target_roll_rate_cds +=  sqrt_controller(angle_max - roll_angle, g2.command_model_acro_rp.get_rate() * 100.0 / ACRO_LEVEL_MAX_OVERSHOOT, attitude_control->get_accel_roll_max_cdss(), G_Dt);
     }else if (roll_angle < -angle_max) {
-        target_roll_rate +=  sqrt_controller(-angle_max - roll_angle, g2.command_model_acro_rp.get_rate() * 100.0 / ACRO_LEVEL_MAX_OVERSHOOT, attitude_control->get_accel_roll_max_cdss(), G_Dt);
+        target_roll_rate_cds +=  sqrt_controller(-angle_max - roll_angle, g2.command_model_acro_rp.get_rate() * 100.0 / ACRO_LEVEL_MAX_OVERSHOOT, attitude_control->get_accel_roll_max_cdss(), G_Dt);
     }
 
     if (pitch_angle > angle_max){
-        target_pitch_rate +=  sqrt_controller(angle_max - pitch_angle, g2.command_model_acro_rp.get_rate() * 100.0 / ACRO_LEVEL_MAX_OVERSHOOT, attitude_control->get_accel_pitch_max_cdss(), G_Dt);
+        target_pitch_rate_cds +=  sqrt_controller(angle_max - pitch_angle, g2.command_model_acro_rp.get_rate() * 100.0 / ACRO_LEVEL_MAX_OVERSHOOT, attitude_control->get_accel_pitch_max_cdss(), G_Dt);
     }else if (pitch_angle < -angle_max) {
-        target_pitch_rate +=  sqrt_controller(-angle_max - pitch_angle, g2.command_model_acro_rp.get_rate() * 100.0 / ACRO_LEVEL_MAX_OVERSHOOT, attitude_control->get_accel_pitch_max_cdss(), G_Dt);
+        target_pitch_rate_cds +=  sqrt_controller(-angle_max - pitch_angle, g2.command_model_acro_rp.get_rate() * 100.0 / ACRO_LEVEL_MAX_OVERSHOOT, attitude_control->get_accel_pitch_max_cdss(), G_Dt);
     }
 
     // get pilot's desired yaw rate
-    float target_yaw_rate = get_pilot_desired_yaw_rate();
+    float target_yaw_rate_cds = get_pilot_desired_yaw_rate();
 
     // get pilot desired climb rate
-    float target_climb_rate = get_pilot_desired_climb_rate();
-    target_climb_rate = constrain_float(target_climb_rate, -get_pilot_speed_dn(), g.pilot_speed_up);
+    float target_climb_rate_cms = get_pilot_desired_climb_rate();
+    target_climb_rate_cms = constrain_float(target_climb_rate_cms, -get_pilot_speed_dn(), g.pilot_speed_up);
 
     // Sport State Machine Determination
-    AltHoldModeState sport_state = get_alt_hold_state(target_climb_rate);
+    AltHoldModeState sport_state = get_alt_hold_state(target_climb_rate_cms);
 
     // State Machine
     switch (sport_state) {
@@ -96,17 +96,17 @@ void ModeSport::run()
         }
 
         // get avoidance adjusted climb rate
-        target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);
+        target_climb_rate_cms = get_avoidance_adjusted_climbrate(target_climb_rate_cms);
 
         // set position controller targets adjusted for pilot input
-        takeoff.do_pilot_takeoff(target_climb_rate);
+        takeoff.do_pilot_takeoff(target_climb_rate_cms);
         break;
 
     case AltHoldModeState::Flying:
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
         // get avoidance adjusted climb rate
-        target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);
+        target_climb_rate_cms = get_avoidance_adjusted_climbrate(target_climb_rate_cms);
 
 #if AP_RANGEFINDER_ENABLED
         // update the vertical offset based on the surface measurement
@@ -114,12 +114,12 @@ void ModeSport::run()
 #endif
 
         // Send the commanded climb rate to the position controller
-        pos_control->set_pos_target_U_from_climb_rate_cm(target_climb_rate);
+        pos_control->set_pos_target_U_from_climb_rate_cm(target_climb_rate_cms);
         break;
     }
 
     // call attitude controller
-    attitude_control->input_euler_rate_roll_pitch_yaw_cds(target_roll_rate, target_pitch_rate, target_yaw_rate);
+    attitude_control->input_euler_rate_roll_pitch_yaw_cds(target_roll_rate_cds, target_pitch_rate_cds, target_yaw_rate_cds);
 
     // run the vertical position controller and set output throttle
     pos_control->update_U_controller();

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.cpp
@@ -457,7 +457,7 @@ void AC_AttitudeControl_Sub::parameter_sanity_check()
 // Sets desired roll, pitch, and yaw angles (in centidegrees), with yaw slewing.
 // Slews toward target yaw at a fixed rate (in centidegrees/s) until the error is within 5 degrees.
 // Used to enforce consistent heading changes without large instantaneous yaw errors.
-void AC_AttitudeControl_Sub::input_euler_angle_roll_pitch_slew_yaw_cd(float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_angle_cd, float target_yaw_rate)
+void AC_AttitudeControl_Sub::input_euler_angle_roll_pitch_slew_yaw_cd(float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_angle_cd, float slew_yaw_rate_cds)
 {
     // Convert from centidegrees on public interface to radians
     const float euler_yaw_angle = wrap_PI(cd_to_rad(euler_yaw_angle_cd));
@@ -474,11 +474,11 @@ void AC_AttitudeControl_Sub::input_euler_angle_roll_pitch_slew_yaw_cd(float eule
         direction = 1;
     }
 
-    target_yaw_rate *= direction;
+    slew_yaw_rate_cds *= direction;
 
     if (fabsf(yaw_error) > MAX_YAW_ERROR) {
         // rotate the rov with desired yaw rate towards the target yaw
-        input_euler_angle_roll_pitch_euler_rate_yaw_cd(euler_roll_angle_cd, euler_pitch_angle_cd, target_yaw_rate);
+        input_euler_angle_roll_pitch_euler_rate_yaw_cd(euler_roll_angle_cd, euler_pitch_angle_cd, slew_yaw_rate_cds);
     } else {
         // holds the rov's angles
         input_euler_angle_roll_pitch_yaw_cd(euler_roll_angle_cd, euler_pitch_angle_cd, euler_yaw_angle_cd, true);

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.h
@@ -71,7 +71,7 @@ public:
     // Sets desired roll, pitch, and yaw angles (in centidegrees), with yaw slewing.
     // Slews toward target yaw at a fixed rate (in centidegrees/s) until the error is within 5 degrees.
     // Used to enforce consistent heading changes without large instantaneous yaw errors.
-    void input_euler_angle_roll_pitch_slew_yaw_cd(float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_angle_cd, float slew_yaw);
+    void input_euler_angle_roll_pitch_slew_yaw_cd(float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_angle_cd, float slew_yaw_rate_cds);
 
     // user settable parameters
     static const struct AP_Param::GroupInfo var_info[];

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_TS.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_TS.cpp
@@ -86,17 +86,17 @@ void AC_AttitudeControl_TS::input_euler_rate_yaw_euler_angle_pitch_bf_roll_rad(b
     error_quat.to_axis_angle(att_error);
 
     // update heading
-    float yaw_rate_rad = euler_yaw_rate_rads;
+    float yaw_rate_rads = euler_yaw_rate_rads;
     if (plane_controls) {
-        yaw_rate_rad = (euler_yaw_rate_rads * spitch) + (body_roll_rad * cpitch);
+        yaw_rate_rads = (euler_yaw_rate_rads * spitch) + (body_roll_rad * cpitch);
     }
     // limit yaw error
     float yaw_error = fabsf(att_error.z);
     float error_ratio = yaw_error / M_PI_2;
     if (error_ratio > 1) {
-        yaw_rate_rad /= (error_ratio * error_ratio);
+        yaw_rate_rads /= (error_ratio * error_ratio);
     }
-    _euler_angle_target_rad.z = wrap_PI(_euler_angle_target_rad.z + yaw_rate_rad * _dt);
+    _euler_angle_target_rad.z = wrap_PI(_euler_angle_target_rad.z + yaw_rate_rads * _dt);
 
     // init attitude target to desired euler yaw and pitch with zero roll
     _attitude_target.from_euler(0, euler_pitch_rad, _euler_angle_target_rad.z);


### PR DESCRIPTION
No compiler change fixing units and comments.

To go in after #30120

`
Board,blimp,bootloader,copter,heli,plane,rover,sub
CubeOrange,*,*,*,*,*,*,*
`