### PR TITLE
Tools: ros2: improve stability of DDS CI tests

### DIFF
--- a/.github/workflows/colcon.yml
+++ b/.github/workflows/colcon.yml
@@ -206,7 +206,7 @@ jobs:
         shell: 'bash'
         run: |
           source install/setup.bash
-          colcon test --executor sequential --parallel-workers 0 --base-paths src/ardupilot --event-handlers=console_cohesion+
+          colcon test --python-testing "pytest" --pytest-args " --verbose" " --stepwise" --executor sequential --parallel-workers 0 --base-paths src/ardupilot --event-handlers=console_cohesion+
       - name: Report colcon test results
         run: |
           colcon test-result --all --verbose

--- a/Tools/ros2/ardupilot_dds_tests/setup.py
+++ b/Tools/ros2/ardupilot_dds_tests/setup.py
@@ -21,7 +21,11 @@ setup(
     maintainer_email='maintainer@ardupilot.org',
     description='Tests for the ArduPilot AP_DDS library',
     license='GPL-3.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test' : [
+            'pytest'
+        ]
+    },
     entry_points={
         'console_scripts': [
             "time_listener = ardupilot_dds_tests.time_listener:main",

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/conftest.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/conftest.py
@@ -33,7 +33,7 @@ from ardupilot_sitl.launch import MAVProxyLaunch
 from ardupilot_sitl.launch import SITLLaunch
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def device_dir(tmp_path_factory):
     """Fixture to create a temporary directory for devices."""
     path = tmp_path_factory.mktemp("devices")
@@ -44,7 +44,7 @@ def device_dir(tmp_path_factory):
     yield path
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def virtual_ports(device_dir):
     """Fixture to create virtual ports."""
     tty0 = Path(device_dir, "dev", "tty0").resolve()
@@ -62,7 +62,7 @@ def virtual_ports(device_dir):
     yield ld, vp_actions
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def micro_ros_agent_serial(device_dir):
     """Fixture to create a micro_ros_agent node."""
     tty0 = Path(device_dir, "dev", "tty0").resolve()
@@ -80,7 +80,7 @@ def micro_ros_agent_serial(device_dir):
     yield ld, mra_actions
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def micro_ros_agent_udp():
     """Fixture to create a micro_ros_agent node."""
     mra_ld, mra_actions = MicroRosAgentLaunch.generate_launch_description_with_actions()
@@ -94,7 +94,7 @@ def micro_ros_agent_udp():
     yield ld, mra_actions
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def mavproxy():
     """Fixture to bring up MAVProxy."""
     mp_ld, mp_actions = MAVProxyLaunch.generate_launch_description_with_actions()
@@ -109,7 +109,7 @@ def mavproxy():
     yield ld, mp_actions
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def sitl_copter_dds_serial(device_dir, virtual_ports, micro_ros_agent_serial, mavproxy):
     """Fixture to bring up ArduPilot SITL DDS."""
     tty1 = Path(device_dir, "dev", "tty1").resolve()
@@ -167,7 +167,7 @@ def sitl_copter_dds_serial(device_dir, virtual_ports, micro_ros_agent_serial, ma
     yield ld, actions
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def sitl_copter_dds_udp(micro_ros_agent_udp, mavproxy):
     """Fixture to bring up ArduPilot SITL DDS."""
     mra_ld, mra_actions = micro_ros_agent_udp
@@ -219,7 +219,7 @@ def sitl_copter_dds_udp(micro_ros_agent_udp, mavproxy):
     yield ld, actions
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def sitl_plane_dds_serial(device_dir, virtual_ports, micro_ros_agent_serial, mavproxy):
     """Fixture to bring up ArduPilot SITL DDS."""
     tty1 = Path(device_dir, "dev", "tty1").resolve()
@@ -277,7 +277,7 @@ def sitl_plane_dds_serial(device_dir, virtual_ports, micro_ros_agent_serial, mav
     yield ld, actions
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def sitl_plane_dds_udp(device_dir, virtual_ports, micro_ros_agent_udp, mavproxy):
     """Fixture to bring up ArduPilot SITL DDS."""
     tty1 = Path(device_dir, "dev", "tty1").resolve()

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/launch_fixtures.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/launch_fixtures.py
@@ -17,28 +17,28 @@ import launch_pytest
 from launch import LaunchDescription
 
 
-@launch_pytest.fixture
+@launch_pytest.fixture(scope="function")
 def launch_sitl_copter_dds_serial(sitl_copter_dds_serial):
     """Launch SITL Copter with DDS over serial."""
     sitl_ld, sitl_actions = sitl_copter_dds_serial
     yield LaunchDescription([sitl_ld, launch_pytest.actions.ReadyToTest()]), sitl_actions
 
 
-@launch_pytest.fixture
+@launch_pytest.fixture(scope="function")
 def launch_sitl_copter_dds_udp(sitl_copter_dds_udp):
     """Launch SITL Copter with DDS over UDP."""
     sitl_ld, sitl_actions = sitl_copter_dds_udp
     yield LaunchDescription([sitl_ld, launch_pytest.actions.ReadyToTest()]), sitl_actions
 
 
-@launch_pytest.fixture
+@launch_pytest.fixture(scope="function")
 def launch_sitl_plane_dds_serial(sitl_plane_dds_serial):
     """Launch SITL Plane with DDS over serial."""
     sitl_ld, sitl_actions = sitl_plane_dds_serial
     yield LaunchDescription([sitl_ld, launch_pytest.actions.ReadyToTest()]), sitl_actions
 
 
-@launch_pytest.fixture
+@launch_pytest.fixture(scope="function")
 def launch_sitl_plane_dds_udp(sitl_plane_dds_udp):
     """Launch SITL Plane with DDS over UDP."""
     sitl_ld, sitl_actions = sitl_plane_dds_udp

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_battery_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_battery_msg_received.py
@@ -45,6 +45,7 @@ from launch_fixtures import (
 )
 
 TOPIC = "ap/battery"
+WAIT_FOR_START_TIMEOUT = 5.0
 
 
 class BatteryListener(rclpy.node.Node):
@@ -98,10 +99,10 @@ def test_dds_serial_battery_msg_recv(launch_context, launch_sitl_copter_dds_seri
     sitl = actions["sitl"].action
 
     # Wait for process to start.
-    process_tools.wait_for_start_sync(launch_context, virtual_ports, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, sitl, timeout=2)
+    process_tools.wait_for_start_sync(launch_context, virtual_ports, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
     rclpy.init()
     try:
@@ -127,9 +128,9 @@ def test_dds_udp_battery_msg_recv(launch_context, launch_sitl_copter_dds_udp):
     sitl = actions["sitl"].action
 
     # Wait for process to start.
-    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, sitl, timeout=2)
+    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
     rclpy.init()
     try:

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_battery_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_battery_msg_received.py
@@ -78,8 +78,6 @@ class BatteryListener(rclpy.node.Node):
 
     def subscriber_callback(self, msg):
         """Process a BatteryState message."""
-        self.msg_event_object.set()
-
         self.get_logger().info("From AP : ID {} Voltage {}".format(msg.header.frame_id, msg.voltage))
 
         if msg.header.frame_id == '0':
@@ -87,6 +85,9 @@ class BatteryListener(rclpy.node.Node):
 
         if msg.header.frame_id == '1':
             self.frame_id_incorrect_object.set()
+
+        # set event last
+        self.msg_event_object.set()
 
 
 @pytest.mark.launch(fixture=launch_sitl_copter_dds_serial)

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_geopose_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_geopose_msg_received.py
@@ -44,6 +44,7 @@ from launch_fixtures import (
 )
 
 TOPIC = "ap/geopose/filtered"
+WAIT_FOR_START_TIMEOUT = 5.0
 # Copied from locations.txt
 CMAC_LAT = -35.363261
 CMAC_LON = 149.165230
@@ -146,10 +147,10 @@ def test_dds_serial_geopose_msg_recv(launch_context, launch_sitl_copter_dds_seri
     sitl = actions["sitl"].action
 
     # Wait for process to start.
-    process_tools.wait_for_start_sync(launch_context, virtual_ports, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, sitl, timeout=2)
+    process_tools.wait_for_start_sync(launch_context, virtual_ports, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
     rclpy.init()
     try:
@@ -175,9 +176,9 @@ def test_dds_udp_geopose_msg_recv(launch_context, launch_sitl_copter_dds_udp):
     sitl = actions["sitl"].action
 
     # Wait for process to start.
-    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, sitl, timeout=2)
+    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
     rclpy.init()
     try:

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_geopose_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_geopose_msg_received.py
@@ -124,8 +124,6 @@ class GeoPoseListener(rclpy.node.Node):
 
     def subscriber_callback(self, msg):
         """Process a GeoPoseStamped message."""
-        self.msg_event_object.set()
-
         position = msg.pose.position
 
         self.get_logger().info("From AP : Position [lat:{}, lon: {}]".format(position.latitude, position.longitude))
@@ -135,6 +133,9 @@ class GeoPoseListener(rclpy.node.Node):
 
         if validate_heading_cmac(msg.pose.orientation):
             self.orientation_event_object.set()
+
+        # set event last
+        self.msg_event_object.set()
 
 
 @pytest.mark.launch(fixture=launch_sitl_copter_dds_serial)

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_joy_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_joy_msg_received.py
@@ -42,6 +42,8 @@ import threading
 
 from launch_fixtures import launch_sitl_copter_dds_udp
 
+WAIT_FOR_START_TIMEOUT = 5.0
+
 GUIDED = 4
 LOITER = 5
 
@@ -191,9 +193,9 @@ def test_dds_udp_joy_msg_recv(launch_context, launch_sitl_copter_dds_udp):
     sitl = actions["sitl"].action
 
     # Wait for process to start.
-    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, sitl, timeout=2)
+    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
     rclpy.init()
     try:

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_navsat_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_navsat_msg_received.py
@@ -30,6 +30,7 @@ from rclpy.qos import QoSHistoryPolicy
 from sensor_msgs.msg import NavSatFix
 
 TOPIC = "ap/navsat"
+WAIT_FOR_START_TIMEOUT = 5.0
 
 from launch_fixtures import (
     launch_sitl_copter_dds_serial,
@@ -83,10 +84,10 @@ def test_dds_serial_navsat_msg_recv(launch_context, launch_sitl_copter_dds_seria
     sitl = actions["sitl"].action
 
     # Wait for process to start.
-    process_tools.wait_for_start_sync(launch_context, virtual_ports, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, sitl, timeout=2)
+    process_tools.wait_for_start_sync(launch_context, virtual_ports, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
     rclpy.init()
     try:
@@ -108,9 +109,9 @@ def test_dds_udp_navsat_msg_recv(launch_context, launch_sitl_copter_dds_udp):
     sitl = actions["sitl"].action
 
     # Wait for process to start.
-    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, sitl, timeout=2)
+    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
     rclpy.init()
     try:

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_navsat_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_navsat_msg_received.py
@@ -66,12 +66,13 @@ class NavSatFixListener(rclpy.node.Node):
 
     def subscriber_callback(self, msg):
         """Process a NavSatFix message."""
-        self.msg_event_object.set()
-
         if msg.latitude:
             self.get_logger().info("From AP : True [lat:{}, lon: {}]".format(msg.latitude, msg.longitude))
         else:
             self.get_logger().info("From AP : False")
+
+        # set event last
+        self.msg_event_object.set()
 
 
 @pytest.mark.launch(fixture=launch_sitl_copter_dds_serial)

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_parameter_service.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_parameter_service.py
@@ -44,6 +44,8 @@ from rcl_interfaces.srv import GetParameters
 from rcl_interfaces.srv import SetParameters
 from rcl_interfaces.msg import Parameter
 
+WAIT_FOR_START_TIMEOUT = 5.0
+
 # Enums for parameter type
 PARAMETER_NOT_SET = 0
 PARAMETER_INTEGER = 2
@@ -173,9 +175,9 @@ def test_dds_udp_parameter_services(launch_context, launch_sitl_copter_dds_udp):
     sitl = actions["sitl"].action
 
     # Wait for process to start.
-    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, sitl, timeout=2)
+    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
     rclpy.init()
     try:

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_plane_airspeed.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_plane_airspeed.py
@@ -39,6 +39,7 @@ from rclpy.qos import QoSHistoryPolicy
 from ardupilot_msgs.msg import Airspeed
 
 TOPIC = "/ap/airspeed"
+WAIT_FOR_START_TIMEOUT = 5.0
 AIRSPEED_RECV_TIMEOUT = 20.0
 
 
@@ -141,10 +142,10 @@ def test_dds_serial_airspeed_msg_recv_copter(launch_context, launch_sitl_copter_
     sitl = actions["sitl"].action
 
     # Wait for process to start.
-    process_tools.wait_for_start_sync(launch_context, virtual_ports, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, sitl, timeout=2)
+    process_tools.wait_for_start_sync(launch_context, virtual_ports, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
     rclpy.init()
     try:
@@ -166,9 +167,9 @@ def test_dds_udp_airspeed_msg_recv_copter(launch_context, launch_sitl_copter_dds
     sitl = actions["sitl"].action
 
     # Wait for process to start.
-    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, sitl, timeout=2)
+    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
     rclpy.init()
     try:
@@ -192,10 +193,10 @@ def test_dds_serial_airspeed_msg_recv_plane(launch_context, launch_sitl_plane_dd
     sitl = actions["sitl"].action
 
     # Wait for process to start.
-    process_tools.wait_for_start_sync(launch_context, virtual_ports, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, sitl, timeout=2)
+    process_tools.wait_for_start_sync(launch_context, virtual_ports, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
     rclpy.init()
     try:
@@ -217,9 +218,9 @@ def test_dds_udp_airspeed_msg_recv_plane(launch_context, launch_sitl_plane_dds_u
     sitl = actions["sitl"].action
 
     # Wait for process to start.
-    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, sitl, timeout=2)
+    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
     rclpy.init()
     try:

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_plane_airspeed.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_plane_airspeed.py
@@ -67,9 +67,10 @@ class AirspeedTester(rclpy.node.Node):
 
     def airspeed_data_callback(self, msg):
         """Process a airspeed message from the autopilot."""
-        self.msg_event_object.set()
-
         self.get_logger().info(f"From AP : airspeed {msg}")
+
+        # set event last
+        self.msg_event_object.set()
 
 
 @launch_pytest.fixture

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_prearm_service.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_prearm_service.py
@@ -39,6 +39,7 @@ from launch_fixtures import (
 )
 
 SERVICE = "/ap/prearm_check"
+WAIT_FOR_START_TIMEOUT = 5.0
 
 
 class PreamService(rclpy.node.Node):
@@ -95,10 +96,10 @@ def test_dds_serial_prearm_service_call(launch_context, launch_sitl_copter_dds_s
     sitl = actions["sitl"].action
 
     # Wait for process to start.
-    process_tools.wait_for_start_sync(launch_context, virtual_ports, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, sitl, timeout=2)
+    process_tools.wait_for_start_sync(launch_context, virtual_ports, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
     rclpy.init()
     try:
@@ -121,9 +122,9 @@ def test_dds_udp_prearm_service_call(launch_context, launch_sitl_copter_dds_udp)
     sitl = actions["sitl"].action
 
     # Wait for process to start.
-    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, sitl, timeout=2)
+    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
     rclpy.init()
     try:

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_rc_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_rc_msg_received.py
@@ -45,6 +45,7 @@ from launch_fixtures import (
 )
 
 TOPIC = "ap/rc"
+WAIT_FOR_START_TIMEOUT = 5.0
 
 
 class RcListener(rclpy.node.Node):
@@ -88,10 +89,10 @@ def test_dds_serial_rc_msg_recv(launch_context, launch_sitl_copter_dds_serial):
     sitl = actions["sitl"].action
 
     # Wait for process to start.
-    process_tools.wait_for_start_sync(launch_context, virtual_ports, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, sitl, timeout=2)
+    process_tools.wait_for_start_sync(launch_context, virtual_ports, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
     rclpy.init()
     try:
@@ -113,9 +114,9 @@ def test_dds_udp_rc_msg_recv(launch_context, launch_sitl_copter_dds_udp):
     sitl = actions["sitl"].action
 
     # Wait for process to start.
-    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, sitl, timeout=2)
+    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
     rclpy.init()
     try:

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_rc_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_rc_msg_received.py
@@ -76,6 +76,7 @@ class RcListener(rclpy.node.Node):
 
     def subscriber_callback(self, msg):
         """Process a Rc message."""
+        # set event last
         self.msg_event_object.set()
 
 

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_time_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_time_msg_received.py
@@ -54,12 +54,13 @@ class TimeListener(rclpy.node.Node):
 
     def subscriber_callback(self, msg):
         """Process a Time message."""
-        self.msg_event_object.set()
-
         if msg.sec:
             self.get_logger().info("From AP : True [sec:{}, nsec: {}]".format(msg.sec, msg.nanosec))
         else:
             self.get_logger().info("From AP : False")
+
+        # set event last
+        self.msg_event_object.set()
 
 
 @pytest.mark.launch(fixture=launch_sitl_copter_dds_serial)

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_time_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_time_msg_received.py
@@ -29,6 +29,7 @@ from launch_fixtures import (
 )
 
 TOPIC = "ap/time"
+WAIT_FOR_START_TIMEOUT = 5.0
 
 
 class TimeListener(rclpy.node.Node):
@@ -71,10 +72,10 @@ def test_dds_serial_time_msg_recv(launch_context, launch_sitl_copter_dds_serial)
     sitl = actions["sitl"].action
 
     # Wait for process to start.
-    process_tools.wait_for_start_sync(launch_context, virtual_ports, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, sitl, timeout=2)
+    process_tools.wait_for_start_sync(launch_context, virtual_ports, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
     rclpy.init()
     try:
@@ -96,9 +97,9 @@ def test_dds_udp_time_msg_recv(launch_context, launch_sitl_copter_dds_udp):
     sitl = actions["sitl"].action
 
     # Wait for process to start.
-    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=2)
-    process_tools.wait_for_start_sync(launch_context, sitl, timeout=2)
+    process_tools.wait_for_start_sync(launch_context, micro_ros_agent, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
+    process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
     rclpy.init()
     try:

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_virtual_ports.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_virtual_ports.py
@@ -21,6 +21,7 @@ from launch import LaunchDescription
 
 from launch_pytest.tools import process as process_tools
 
+WAIT_FOR_START_TIMEOUT = 5.0
 
 @launch_pytest.fixture
 def launch_description(virtual_ports):
@@ -44,7 +45,7 @@ def test_virtual_ports(launch_context, launch_description):
     virtual_ports = actions["virtual_ports"].action
 
     # Wait for process to start.
-    process_tools.wait_for_start_sync(launch_context, virtual_ports, timeout=2)
+    process_tools.wait_for_start_sync(launch_context, virtual_ports, timeout=WAIT_FOR_START_TIMEOUT)
 
     # Assert contents of output to stderr.
     def validate_output(output):


### PR DESCRIPTION
Ongoing attempt to improve stability in the DDS `colcon` CI tests.

- The tests that run the `micro_ros_agent` with `serial` transport require a temporary directory for the virtual devices `tty0` and `tty1` managed by `socat`. This changes the fixture that creates the temp `dev` folder to have `function` rather than `module` scope. This ensures that the directory is torn down after every test.

- Other fixtures use `function` scope by default, this makes that explicit.

- Use `extras_require` in `setup.py` as `tests_require` is removed from newer versions of setuptools. See discussion and suggestions in: https://github.com/ros2/ros2_documentation/issues/4727

- Increase `pytest` verbosity and run stepwise.

- Increase the timeout while waiting for processes to start and synchronise

- Ensure that the `msg_event_object` in the test node callbacks is set last. The callback runs asynchronously and once the event is set the main fixture can proceed to check the event state and any additional flags, and then shutdown rclpy. Suspect this can result in an invalid context for the logger, and this exception may lead the fixture to not shut down cleanly, or misreport the state.

## Motivation

Example from: https://github.com/ArduPilot/ardupilot/actions/runs/15767553194/job/44448010803?pr=30409

The test fails when a SIGINT is sent to the SITL process:

```bash
[mavproxy.py -33] AP: EKF3 IMU1 is using GPS
[INFO] [dds_udp.parm --synthetic-clock -34]: sending signal 'SIGINT' to process[dds_udp.parm --synthetic-clock -34]
[INFO] [mavproxy.py -33]: sending signal 'SIGINT' to process[mavproxy.py -33]
```

At this point it's not clear whether the ROS 2 node `AirspeedTester` has been started (need to add further logging), however it appears that the test framework is attempting to kill the SITL process before the message checks have been run. 


Full log below

<details>

```bash
=================================== FAILURES ===================================
____________________ test_dds_udp_airspeed_msg_recv_copter _____________________
/opt/ros/humble/lib/python3.10/site-packages/launch_pytest/plugin.py:438: in inner
    on_shutdown()
/opt/ros/humble/lib/python3.10/site-packages/launch_pytest/fixture.py:36: in finalize_launch_service
    assert rc == 0, f"{eprefix} launch service failed when finishing, return code '{rc}'"
E   AssertionError: When running test test_dds_udp_airspeed_msg_recv_copter launch service failed when finishing, return code '1'
---------------------------- Captured stdout setup -----------------------------
[INFO] [launch]: All log files can be found below /github/home/.ros/log/2025-06-19-23-53-13-184889-471bc6b89970-14929
[INFO] [launch]: Default logging verbosity is set to INFO
namespace:        
transport:        udp4
middleware:       dds
verbose:          4
discovery:        7400
port:             2019
command:          mavproxy.py
master:           tcp:127.0.0.1:5760
sitl:             127.0.0.1:5501
out:              127.0.0.1:14550
console:          False
map:              False
command:          arducopter
model:            quad
speedup:          10
slave:            0
sim_address:      127.0.0.1
instance:         0
defaults:         /__w/ardupilot/ardupilot/install/ardupilot_sitl/share/ardupilot_sitl/config/default_params/copter.parm,/__w/ardupilot/ardupilot/install/ardupilot_sitl/share/ardupilot_sitl/config/default_params/dds_udp.parm
synthetic_clock:  True
----------------------------- Captured stdout call -----------------------------
[INFO] [micro_ros_agent-32]: process started with pid [15514]
[INFO] [mavproxy.py -33]: process started with pid [15516]
[INFO] [dds_udp.parm --synthetic-clock -34]: process started with pid [15518]
[dds_udp.parm --synthetic-clock -34] Setting SIM_SPEEDUP=10.000000
[dds_udp.parm --synthetic-clock -34] Ignoring stale command-line parameter '-S'Suggested EK3_DRAG_BCOEF_* = 17.209, EK3_DRAG_MCOEF = 0.209
[dds_udp.parm --synthetic-clock -34] Starting sketch 'ArduCopter'
[dds_udp.parm --synthetic-clock -34] Starting SITL input
[dds_udp.parm --synthetic-clock -34] Using Irlock at port : 9005
[micro_ros_agent-32] [1750377303.597766] info     | ProxyClient.cpp    | create_topic             | topic created          | client_key: 0xAAAABBBB, topic_id: 0x00B(2), participant_id: 0x001(1)
[micro_ros_agent-32] [1750377303.597809] info     | ProxyClient.cpp    | create_publisher         | publisher created      | client_key: 0xAAAABBBB, publisher_id: 0x00B(3), participant_id: 0x001(1)
[mavproxy.py -33] AP: DDS: Topic/Pub/Writer session pass for index '4'
[micro_ros_agent-32] [1750377303.598325] info     | ProxyClient.cpp    | create_datawriter        | datawriter created     | client_key: 0xAAAABBBB, datawriter_id: 0x00B(5), publisher_id: 0x00B(3)
[mavproxy.py -33] AP: DDS: Topic/Pub/Writer session pass for index '5'
[mavproxy.py -33] AP: DDS: Topic/Pub/Writer session pass for index '6'
[mavproxy.py -33] AP: DDS: Topic/Pub/Writer session pass for index '7'
[mavproxy.py -33] AP: DDS: Topic/Pub/Writer session pass for index '8'
[micro_ros_agent-32] [1750377303.599281] info     | ProxyClient.cpp    | create_topic             | topic created          | client_key: 0xAAAABBBB, topic_id: 0x00C(2), participant_id: 0x001(1)
[micro_ros_agent-32] [1750377303.599390] info     | ProxyClient.cpp    | create_publisher         | publisher created      | client_key: 0xAAAABBBB, publisher_id: 0x00C(3), participant_id: 0x001(1)
[mavproxy.py -33] AP: DDS: Topic/Pub/Writer session pass for index '9'
[mavproxy.py -33] AP: DDS: Topic/Pub/Writer session pass for index '10'
[mavproxy.py -33] AP: DDS: Topic/Pub/Writer session pass for index '11'
[micro_ros_agent-32] [1750377303.600414] info     | ProxyClient.cpp    | create_datawriter        | datawriter created     | client_key: 0xAAAABBBB, datawriter_id: 0x00C(5), publisher_id: 0x00C(3)
[micro_ros_agent-32] [1750377303.600622] info     | ProxyClient.cpp    | create_topic             | topic created          | client_key: 0xAAAABBBB, topic_id: 0x00D(2), participant_id: 0x001(1)
[micro_ros_agent-32] [1750377303.600658] info     | ProxyClient.cpp    | create_publisher         | publisher created      | client_key: 0xAAAABBBB, publisher_id: 0x00D(3), participant_id: 0x001(1)
[micro_ros_agent-32] [1750377303.601100] info     | ProxyClient.cpp    | create_datawriter        | datawriter created     | client_key: 0xAAAABBBB, datawriter_id: 0x00D(5), publisher_id: 0x00D(3)
[micro_ros_agent-32] [1750377303.601367] info     | ProxyClient.cpp    | create_topic             | topic created          | client_key: 0xAAAABBBB, topic_id: 0x00E(2), participant_id: 0x001(1)
[micro_ros_agent-32] [1750377303.601419] info     | ProxyClient.cpp    | create_subscriber        | subscriber created     | client_key: 0xAAAABBBB, subscriber_id: 0x00E(4), participant_id: 0x001(1)
[micro_ros_agent-32] [1750377303.601737] info     | ProxyClient.cpp    | create_datareader        | datareader created     | client_key: 0xAAAABBBB, datareader_id: 0x00E(6), subscriber_id: 0x00E(4)
[micro_ros_agent-32] [1750377303.602053] info     | ProxyClient.cpp    | create_topic             | topic created          | client_key: 0xAAAABBBB, topic_id: 0x00F(2), participant_id: 0x001(1)
[micro_ros_agent-32] [1750377303.602083] info     | ProxyClient.cpp    | create_subscriber        | subscriber created     | client_key: 0xAAAABBBB, subscriber_id: 0x00F(4), participant_id: 0x001(1)
[micro_ros_agent-32] [1750377303.602411] info     | ProxyClient.cpp    | create_datareader        | datareader created     | client_key: 0xAAAABBBB, datareader_id: 0x00F(6), subscriber_id: 0x00F(4)
[micro_ros_agent-32] [1750377303.602667] info     | ProxyClient.cpp    | create_topic             | topic created          | client_key: 0xAAAABBBB, topic_id: 0x010(2), participant_id: 0x001(1)
[micro_ros_agent-32] [1750377303.602697] info     | ProxyClient.cpp    | create_subscriber        | subscriber created     | client_key: 0xAAAABBBB, subscriber_id: 0x010(4), participant_id: 0x001(1)
[micro_ros_agent-32] [1750377303.602981] info     | ProxyClient.cpp    | create_datareader        | datareader created     | client_key: 0xAAAABBBB, datareader_id: 0x010(6), subscriber_id: 0x010(4)
[micro_ros_agent-32] [1750377303.603216] info     | ProxyClient.cpp    | create_topic             | topic created          | client_key: 0xAAAABBBB, topic_id: 0x011(2), participant_id: 0x001(1)
[micro_ros_agent-32] [1750377303.603264] info     | ProxyClient.cpp    | create_subscriber        | subscriber created     | client_key: 0xAAAABBBB, subscriber_id: 0x011(4), participant_id: 0x001(1)
[micro_ros_agent-32] [1750377303.603581] info     | ProxyClient.cpp    | create_datareader        | datareader created     | client_key: 0xAAAABBBB, datareader_id: 0x011(6), subscriber_id: 0x011(4)
[micro_ros_agent-32] [1750377303.604427] info     | ProxyClient.cpp    | create_replier           | replier created        | client_key: 0xAAAABBBB, requester_id: 0x000(7), participant_id: 0x001(1)
[mavproxy.py -33] AP: DDS: Topic/Pub/Writer session pass for index '12'
[micro_ros_agent-32] [1750377303.605764] info     | ProxyClient.cpp    | create_replier           | replier created        | client_key: 0xAAAABBBB, requester_id: 0x001(7), participant_id: 0x001(1)
[mavproxy.py -33] AP: DDS: Topic/Pub/Writer session pass for index '13'
[mavproxy.py -33] AP: DDS: Topic/Sub/Reader session pass for index '14'
[mavproxy.py -33] AP: DDS: Topic/Sub/Reader session pass for index '15'
[micro_ros_agent-32] [1750377303.606894] info     | ProxyClient.cpp    | create_replier           | replier created        | client_key: 0xAAAABBBB, requester_id: 0x002(7), participant_id: 0x001(1)
[mavproxy.py -33] AP: DDS: Topic/Sub/Reader session pass for index '16'
[mavproxy.py -33] AP: DDS: Topic/Sub/Reader session pass for index '17'
[mavproxy.py -33] AP: DDS: Service/Replier session pass for index '0'
[mavproxy.py -33] AP: DDS: Service/Replier session pass for index '1'
[mavproxy.py -33] AP: DDS: Service/Replier session pass for index '2'
[micro_ros_agent-32] [1750377303.608837] info     | ProxyClient.cpp    | create_replier           | replier created        | client_key: 0xAAAABBBB, requester_id: 0x003(7), participant_id: 0x001(1)
[micro_ros_agent-32] [1750377303.609662] info     | ProxyClient.cpp    | create_replier           | replier created        | client_key: 0xAAAABBBB, requester_id: 0x004(7), participant_id: 0x001(1)
[micro_ros_agent-32] [1750377303.610823] info     | ProxyClient.cpp    | create_replier           | replier created        | client_key: 0xAAAABBBB, requester_id: 0x005(7), participant_id: 0x001(1)
[mavproxy.py -33] AP: DDS: Service/Replier session pass for index '3'
[mavproxy.py -33] AP: DDS: Service/Replier session pass for index '4'
[mavproxy.py -33] AP: DDS: Service/Replier session pass for index '5'
[mavproxy.py -33] AP: DDS: Initialization passed
[mavproxy.py -33] AP: GPS 1: probing for u-blox at 230400 baud
[mavproxy.py -33] AP: GPS 1: detected u-blox
[mavproxy.py -33] AP: ArduCopter V4.7.0-dev (fd2478e5)
[mavproxy.py -33] AP: 9e8b6703f27540529def73cf40a4a22e
[mavproxy.py -33] AP: Frame: QUAD/PLUS
[mavproxy.py -33] Received [1363](https://github.com/ArduPilot/ardupilot/actions/runs/15759290242/job/44430221635?pr=30396#step:13:1364) parameters (ftp)
[mavproxy.py -33] Saved 1363 parameters to mav.parm
[mavproxy.py -33] Flight battery 100 percent
[mavproxy.py -33] AP: EKF3 IMU1 origin set
[mavproxy.py -33] AP: Field Elevation Set: 584m
[mavproxy.py -33] AP: EKF3 IMU0 origin set
[mavproxy.py -33] AP: EKF3 IMU0 is using GPS
[mavproxy.py -33] AP: EKF3 IMU1 is using GPS
[INFO] [dds_udp.parm --synthetic-clock -34]: sending signal 'SIGINT' to process[dds_udp.parm --synthetic-clock -34]
[INFO] [mavproxy.py -33]: sending signal 'SIGINT' to process[mavproxy.py -33]
[INFO] [micro_ros_agent-32]: sending signal 'SIGINT' to process[micro_ros_agent-32]
Error:  [micro_ros_agent-32]: process has died [pid 15514, exit code -2, cmd '/__w/ardupilot/ardupilot/install/micro_ros_agent/lib/micro_ros_agent/micro_ros_agent udp4 --middleware dds --verbose 4 --port 2019 --ros-args -r __node:=micro_ros_agent -r __ns:=/'].
[mavproxy.py -33] AP: DDS: No ping response, disconnecting
Error:  [dds_udp.parm --synthetic-clock -34]: process[dds_udp.parm --synthetic-clock -34] failed to terminate '5' seconds after receiving 'SIGINT', escalating to 'SIGTERM'
Error:  [mavproxy.py -33]: process[mavproxy.py -33] failed to terminate '5' seconds after receiving 'SIGINT', escalating to 'SIGTERM'
[INFO] [dds_udp.parm --synthetic-clock -34]: sending signal 'SIGTERM' to process[dds_udp.parm --synthetic-clock -34]
[INFO] [mavproxy.py -33]: sending signal 'SIGTERM' to process[mavproxy.py -33]
Error:  [dds_udp.parm --synthetic-clock -34]: process has died [pid 15518, exit code -15, cmd 'arducopter --model quad --speedup 10 --slave 0 --sim-address=127.0.0.1 --instance 0 --defaults /__w/ardupilot/ardupilot/install/ardupilot_sitl/share/ardupilot_sitl/config/default_params/copter.parm,/__w/ardupilot/ardupilot/install/ardupilot_sitl/share/ardupilot_sitl/config/default_params/dds_udp.parm --synthetic-clock '].
Error:  [mavproxy.py -33]: process has died [pid 15516, exit code -15, cmd 'mavproxy.py  --out 127.0.0.1:14550  --out  127.0.0.1:14551  --master tcp:127.0.0.1:5760  --sitl 127.0.0.1:5501  --non-interactive '].
Error:  [launch]: Caught exception in launch (see debug for traceback): '_io.StringIO' object has no attribute 'info'
----------------------------- Captured stderr call -----------------------------
[INFO] [1750377307.152202955] [airspeed_listener]: From AP : airspeed ardupilot_msgs.msg.Airspeed(header=std_msgs.msg.Header(stamp=builtin_interfaces.msg.Time(sec=1750377343, nanosec=468609000), frame_id='base_link'), true_airspeed=geometry_msgs.msg.Vector3(x=-0.00014248021761886775, y=-0.00012262031668797135, z=-0.0006289896555244923), eas_2_tas=1.028623104095459)
Failed to publish log message to rosout: publisher's context is invalid, at ./src/rcl/publisher.c:389
- generated xml file: /__w/ardupilot/ardupilot/build/ardupilot_dds_tests/pytest.xml -
=========================== short test summary info ============================
FAILED test/ardupilot_dds_tests/test_plane_airspeed.py::test_dds_udp_airspeed_msg_recv_copter
=================== 1 failed, 20 passed in 198.89s (0:03:18) ===================
```

</details>

The only place this message is generated in ROS 2 is in the `launch/actions/execute_local.py` module:

https://github.com/ros2/launch/blob/6854fae626f2948139e1734e68d712cc1e0def1b/launch/launch/actions/execute_local.py#L311-L341

```python
    def __on_signal_process_event(
        self,
        context: LaunchContext
    ) -> Optional[LaunchDescription]:
        typed_event = cast(SignalProcess, context.locals.event)
        if not typed_event.process_matcher(self):
            # this event was not intended for this process
            return None
        if self.process_details is None:
            raise RuntimeError('Signal event received before execution.')
        if self._subprocess_transport is None:
            raise RuntimeError('Signal event received before subprocess transport available.')
        if self._subprocess_protocol.complete.done():
            # the process is done or is cleaning up, no need to signal
            self.__logger.debug(
                "signal '{}' not set to '{}' because it is already closing".format(
                    typed_event.signal_name, self.process_details['name']),
            )
            return None
        if platform.system() == 'Windows' and typed_event.signal_name == 'SIGINT':
            # TODO(wjwwood): remove this when/if SIGINT is fixed on Windows
            self.__logger.warning(
                "'SIGINT' sent to process[{}] not supported on Windows, escalating to 'SIGTERM'"
                .format(self.process_details['name']),
            )
            typed_event = SignalProcess(
                signal_number=signal.SIGTERM,
                process_matcher=lambda process: True)
        self.__logger.info("sending signal '{}' to process[{}]".format(
            typed_event.signal_name, self.process_details['name']
        ))
```

