### PR TITLE
GCS_MAVLink: fix FTP burst complete indicator

### DIFF
--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -525,7 +525,7 @@ void GCS_MAVLINK::ftp_worker(void) {
 
                             reply.opcode = FTP_OP::Ack;
                             reply.offset = request.offset + i * max_read;
-                            reply.burst_complete = (i == (transfer_size - 1));
+                            reply.burst_complete = ((read_bytes < max_read) || (i == (transfer_size - 1)));
                             reply.size = (uint8_t)read_bytes;
 
                             ftp_push_replies(reply);


### PR DESCRIPTION
https://mavlink.io/en/services/ftp.html#reading-a-file-burstreadfile

Per the docs, `burst_complete` should be set to `1` on the last burst packet.
Currently, it's only being set on the 500th (hard-coded server-limit) packet. 
This change adjusts it so it's also set on the final burst packet if there are less than 500 response packets.

Note that an EOF NAK will still be sent afterwards, which isn't specified in the docs. This can be prevented by adding a `break;` to the check on line 533. However, I was hesitant to propose that in fear of breaking existing systems for detecting the end of a burst file read.