### PR TITLE
Allow AP_MotorsTri to be compiled out of firmware

### DIFF
--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -381,11 +381,13 @@ void Copter::allocate_motors(void)
             motors = NEW_NOTHROW AP_MotorsMatrix(copter.scheduler.get_loop_rate_hz());
             motors_var_info = AP_MotorsMatrix::var_info;
             break;
+#if AP_MOTORS_TRI_ENABLED
         case AP_Motors::MOTOR_FRAME_TRI:
             motors = NEW_NOTHROW AP_MotorsTri(copter.scheduler.get_loop_rate_hz());
             motors_var_info = AP_MotorsTri::var_info;
             AP_Param::set_frame_type_flags(AP_PARAM_FRAME_TRICOPTER);
             break;
+#endif  // AP_MOTORS_TRI_ENABLED
         case AP_Motors::MOTOR_FRAME_SINGLE:
             motors = NEW_NOTHROW AP_MotorsSingle(copter.scheduler.get_loop_rate_hz());
             motors_var_info = AP_MotorsSingle::var_info;

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -712,10 +712,12 @@ bool QuadPlane::setup(void)
     }
 
     switch ((AP_Motors::motor_frame_class)frame_class) {
+#if AP_MOTORS_TRI_ENABLED
     case AP_Motors::MOTOR_FRAME_TRI:
         motors = NEW_NOTHROW AP_MotorsTri(rc_speed);
         motors_var_info = AP_MotorsTri::var_info;
         break;
+#endif  // AP_MOTORS_TRI_ENABLED
     case AP_Motors::MOTOR_FRAME_TAILSITTER:
         // this is a duo-motor tailsitter
         tailsitter.tailsitter_motors = NEW_NOTHROW AP_MotorsTailsitter(rc_speed);

--- a/Tools/autotest/test_build_options.py
+++ b/Tools/autotest/test_build_options.py
@@ -334,6 +334,7 @@ class TestBuildOptions(object):
             # only Plane and Copter instantiate Parachute
             feature_define_whitelist.add('HAL_PARACHUTE_ENABLED')
             # only Plane and Copter have AP_Motors:
+            feature_define_whitelist.add(r'AP_MOTORS_TRI_ENABLED')
 
         if target.lower() not in ["rover", "copter"]:
             # only Plane and Copter instantiate Beacon

--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -207,6 +207,7 @@ BUILD_OPTIONS = [
     Feature('Gimbal', 'XFROBOT', 'HAL_MOUNT_XFROBOT_ENABLED', 'Enable XFRobot gimbal', 0, "MOUNT"),
     Feature('Gimbal', 'VIEWPRO', 'HAL_MOUNT_VIEWPRO_ENABLED', 'Enable Viewpro gimbal', 0, "MOUNT"),
 
+    Feature('VTOL Type', 'TRI', 'AP_MOTORS_TRI_ENABLED', 'TriCopters', 0, None),
     Feature('VTOL Frame', 'QUAD', 'AP_MOTORS_FRAME_QUAD_ENABLED', 'QUADS(BI,TRI also)', 1, None),
     Feature('VTOL Frame', 'HEXA', 'AP_MOTORS_FRAME_HEXA_ENABLED', 'HEXA', 0, None),
     Feature('VTOL Frame', 'OCTA', 'AP_MOTORS_FRAME_OCTA_ENABLED', 'OCTA', 0, None),

--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -98,6 +98,7 @@ class ExtractFeatures(object):
 
             ('AP_BARO_{type}_ENABLED', r'AP_Baro_(?P<type>.*)::(_calculate|update)\b',),
 
+            ('AP_MOTORS_TRI_ENABLED', 'AP_MotorsTri::set_frame_class_and_type'),
             ('AP_MOTORS_FRAME_{type}_ENABLED', r'AP_MotorsMatrix::setup_(?P<type>.*)_matrix\b',),
 
             ('HAL_MSP_ENABLED', r'AP_MSP::init\b',),

--- a/libraries/AP_Motors/AP_Motors.h
+++ b/libraries/AP_Motors/AP_Motors.h
@@ -1,9 +1,13 @@
 #pragma once
 
+#include "AP_Motors_config.h"
+
 #include "AP_Motors_Class.h"
 #include "AP_MotorsMulticopter.h"
 #include "AP_MotorsMatrix.h"
+#if AP_MOTORS_TRI_ENABLED
 #include "AP_MotorsTri.h"
+#endif  // AP_MOTORS_TRI_ENABLED
 #include "AP_MotorsHeli_Single.h"
 #include "AP_MotorsHeli_Dual.h"
 #include "AP_MotorsHeli_Quad.h"

--- a/libraries/AP_Motors/AP_MotorsTri.cpp
+++ b/libraries/AP_Motors/AP_MotorsTri.cpp
@@ -13,6 +13,10 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "AP_Motors_config.h"
+
+#if AP_MOTORS_TRI_ENABLED
+
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 
@@ -451,3 +455,5 @@ uint8_t AP_MotorsTri::get_motor_test_order(uint8_t i)
     }
 }
 #endif // APM_BUILD_TYPE(APM_BUILD_UNKNOWN)
+
+#endif  // AP_MOTORS_TRI_ENABLED

--- a/libraries/AP_Motors/AP_MotorsTri.h
+++ b/libraries/AP_Motors/AP_MotorsTri.h
@@ -2,6 +2,10 @@
 /// @brief	Motor control class for Tricopters
 #pragma once
 
+#include "AP_Motors_config.h"
+
+#if AP_MOTORS_TRI_ENABLED
+
 #include <AP_Common/AP_Common.h>
 #include <AP_Math/AP_Math.h>        // ArduPilot Mega Vector/Matrix math Library
 #include "AP_MotorsMulticopter.h"
@@ -83,3 +87,5 @@ protected:
     bool _pitch_reversed;
     bool _have_tail_servo;
 };
+
+#endif  // AP_MOTORS_TRI_ENABLED

--- a/libraries/AP_Motors/AP_Motors_config.h
+++ b/libraries/AP_Motors/AP_Motors_config.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <AP_HAL/AP_HAL_Boards.h>
+
+#ifndef AP_MOTORS_TRI_ENABLED
+#define AP_MOTORS_TRI_ENABLED 1
+#endif  // AP_MOTORS_TRI_ENABLED


### PR DESCRIPTION
```
###### Enabling TRI(AP_MOTORS_TRI_ENABLED) on copter costs -1760 bytes
###### Enabling TRI(AP_MOTORS_TRI_ENABLED) on plane costs -1704 bytes
###### Enabling TRI(AP_MOTORS_TRI_ENABLED) on rover costs 0 bytes
###### Enabling TRI(AP_MOTORS_TRI_ENABLED) on antennatracker costs 0 bytes
###### Enabling TRI(AP_MOTORS_TRI_ENABLED) on sub costs 8 bytes
###### Enabling TRI(AP_MOTORS_TRI_ENABLED) on blimp costs 0 bytes
```

No compiler output change unless the option is used:
```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                 *                                                   
Durandal                            *      *           *       *                 *      *      *
Hitec-Airspeed           *                 *                                                   
KakuteH7-bdshot                     *      *           *       *                 *      *      *
MatekF405                           *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *                  *       *                 *      *      *
f103-QiotekPeriph        *                 *                                                   
f303-Universal           *                 *                                                   
iomcu                                                                *                         
revo-mini                           *      *           *       *                 *      *      *
skyviper-v2450                                         *                                       
```
