### PR TITLE
AP_TempratureSensor: MAX31865: add params for nominal and refrence resistance

### DIFF
--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor.cpp
@@ -61,6 +61,10 @@ const AP_Param::GroupInfo AP_TemperatureSensor::var_info[] = {
 
     // @Group: 1_
     // @Path: AP_TemperatureSensor_Analog.cpp
+    // @Group: 1_
+    // @Path: AP_TemperatureSensor_DroneCAN.cpp
+    // @Group: 1_
+    // @Path: AP_TemperatureSensor_MAX31865.cpp
     AP_SUBGROUPVARPTR(drivers[0], "1_", 19, AP_TemperatureSensor, backend_var_info[0]),
 
 #if AP_TEMPERATURE_SENSOR_MAX_INSTANCES >= 2
@@ -70,6 +74,10 @@ const AP_Param::GroupInfo AP_TemperatureSensor::var_info[] = {
 
     // @Group: 2_
     // @Path: AP_TemperatureSensor_Analog.cpp
+    // @Group: 2_
+    // @Path: AP_TemperatureSensor_DroneCAN.cpp
+    // @Group: 2_
+    // @Path: AP_TemperatureSensor_MAX31865.cpp
     AP_SUBGROUPVARPTR(drivers[1], "2_", 20, AP_TemperatureSensor, backend_var_info[1]),
 #endif
 
@@ -80,6 +88,10 @@ const AP_Param::GroupInfo AP_TemperatureSensor::var_info[] = {
 
     // @Group: 3_
     // @Path: AP_TemperatureSensor_Analog.cpp
+    // @Group: 3_
+    // @Path: AP_TemperatureSensor_DroneCAN.cpp
+    // @Group: 3_
+    // @Path: AP_TemperatureSensor_MAX31865.cpp
     AP_SUBGROUPVARPTR(drivers[2], "3_", 21, AP_TemperatureSensor, backend_var_info[2]),
 #endif
 
@@ -90,6 +102,10 @@ const AP_Param::GroupInfo AP_TemperatureSensor::var_info[] = {
 
     // @Group: 4_
     // @Path: AP_TemperatureSensor_Analog.cpp
+    // @Group: 4_
+    // @Path: AP_TemperatureSensor_DroneCAN.cpp
+    // @Group: 4_
+    // @Path: AP_TemperatureSensor_MAX31865.cpp
     AP_SUBGROUPVARPTR(drivers[3], "4_", 22, AP_TemperatureSensor, backend_var_info[3]),
 #endif
 
@@ -100,6 +116,10 @@ const AP_Param::GroupInfo AP_TemperatureSensor::var_info[] = {
 
     // @Group: 5_
     // @Path: AP_TemperatureSensor_Analog.cpp
+    // @Group: 5_
+    // @Path: AP_TemperatureSensor_DroneCAN.cpp
+    // @Group: 5_
+    // @Path: AP_TemperatureSensor_MAX31865.cpp
     AP_SUBGROUPVARPTR(drivers[4], "5_", 23, AP_TemperatureSensor, backend_var_info[4]),
 #endif
 
@@ -110,6 +130,10 @@ const AP_Param::GroupInfo AP_TemperatureSensor::var_info[] = {
 
     // @Group: 6_
     // @Path: AP_TemperatureSensor_Analog.cpp
+    // @Group: 6_
+    // @Path: AP_TemperatureSensor_DroneCAN.cpp
+    // @Group: 6_
+    // @Path: AP_TemperatureSensor_MAX31865.cpp
     AP_SUBGROUPVARPTR(drivers[5], "6_", 24, AP_TemperatureSensor, backend_var_info[5]),
 #endif
 
@@ -120,6 +144,10 @@ const AP_Param::GroupInfo AP_TemperatureSensor::var_info[] = {
 
     // @Group: 7_
     // @Path: AP_TemperatureSensor_Analog.cpp
+    // @Group: 7_
+    // @Path: AP_TemperatureSensor_DroneCAN.cpp
+    // @Group: 7_
+    // @Path: AP_TemperatureSensor_MAX31865.cpp
     AP_SUBGROUPVARPTR(drivers[6], "7_", 25, AP_TemperatureSensor, backend_var_info[6]),
 #endif
 
@@ -130,6 +158,10 @@ const AP_Param::GroupInfo AP_TemperatureSensor::var_info[] = {
 
     // @Group: 8_
     // @Path: AP_TemperatureSensor_Analog.cpp
+    // @Group: 8_
+    // @Path: AP_TemperatureSensor_DroneCAN.cpp
+    // @Group: 8_
+    // @Path: AP_TemperatureSensor_MAX31865.cpp
     AP_SUBGROUPVARPTR(drivers[7], "8_", 26, AP_TemperatureSensor, backend_var_info[7]),
 #endif
 
@@ -140,6 +172,10 @@ const AP_Param::GroupInfo AP_TemperatureSensor::var_info[] = {
 
     // @Group: 9_
     // @Path: AP_TemperatureSensor_Analog.cpp
+    // @Group: 9_
+    // @Path: AP_TemperatureSensor_DroneCAN.cpp
+    // @Group: 9_
+    // @Path: AP_TemperatureSensor_MAX31865.cpp
     AP_SUBGROUPVARPTR(drivers[8], "9_", 27, AP_TemperatureSensor, backend_var_info[8]),
 #endif
 
@@ -189,7 +225,8 @@ void AP_TemperatureSensor::init()
                 break;
 #endif
 #if AP_TEMPERATURE_SENSOR_MAX31865_ENABLED
-            case AP_TemperatureSensor_Params::Type::MAX31865:
+            case AP_TemperatureSensor_Params::Type::MAX31865_2_or_4_wire:
+            case AP_TemperatureSensor_Params::Type::MAX31865_3_wire:
                 drivers[instance] = NEW_NOTHROW AP_TemperatureSensor_MAX31865(*this, _state[instance], _params[instance]);
                 break;
 #endif

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Analog.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Analog.cpp
@@ -61,6 +61,8 @@ const AP_Param::GroupInfo AP_TemperatureSensor_Analog::var_info[] = {
     // @Description: a5 in polynomial of form temperature in deg = a0 + a1*voltage + a2*voltage^2 + a3*voltage^3 + a4*voltage^4 + a5*voltage^5
     AP_GROUPINFO("A5", 7, AP_TemperatureSensor_Analog, _a[5], 0),
 
+    // This param table is shared between backends, check for index clashes before adding more params!
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_DroneCAN.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_DroneCAN.cpp
@@ -35,6 +35,10 @@ const AP_Param::GroupInfo AP_TemperatureSensor_DroneCAN::var_info[] = {
     // @Range: 0 65535
     AP_GROUPINFO("MSG_ID", 1, AP_TemperatureSensor_DroneCAN, _ID, 0),
 
+    // This param table is shared between backends, check for index clashes before adding more params!
+    // MSG_ID here clashes with pin in the analog backed,
+    // but because there different types (AP_Int8 vs AP_Int32) we get away with it.
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_MAX31865.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_MAX31865.cpp
@@ -43,12 +43,6 @@ extern const AP_HAL::HAL &hal;
 #define MAX31865_REG_FAULT_STATUS_READ      0x07
 #define MAX31865_REG_FAULT_STATUS_WRITE     (MAX31865_REG_FAULT_STATUS_READ | MAX31865_REG_WRITE_ADDR_OFFSET)
 
-
-// Vbias = ON (must be on for automatic mode)
-// Conversion mode: Auto
-// Fault Status: 1set 1 to Clear all latched faults
-#define MAX31865_CONFIG_VALUE               (0b11000010)
-
 #define MAX31865_DEBUGGING 0
 
 #if MAX31865_DEBUGGING
@@ -65,6 +59,35 @@ extern const AP_HAL::HAL &hal;
  # define Debug(fmt, args ...)
 #endif // MAX31865_DEBUGGING
 
+
+const AP_Param::GroupInfo AP_TemperatureSensor_MAX31865::var_info[] = {
+
+    // @Param: RTD_NOM
+    // @DisplayName: Nominal RTD resistance
+    // @Description: Nominal RTD resistance used to calculate temperature, typically 100 or 1000 ohms.
+    // @User: Standard
+    AP_GROUPINFO("RTD_NOM", 8, AP_TemperatureSensor_MAX31865, nominal_resistance, 100),
+
+    // @Param: RTD_REF
+    // @DisplayName: RTD reference resistance
+    // @Description: Reference resistance used to calculate temperature, in ohms
+    // @User: Standard
+    AP_GROUPINFO("RTD_REF", 9, AP_TemperatureSensor_MAX31865, reference_resistance, 400),
+
+    // This param table is shared between backends, check for index clashes before adding more params!
+
+    AP_GROUPEND
+
+};
+
+AP_TemperatureSensor_MAX31865::AP_TemperatureSensor_MAX31865(AP_TemperatureSensor &front,
+                                                         AP_TemperatureSensor::TemperatureSensor_State &state,
+                                                         AP_TemperatureSensor_Params &params) :
+    AP_TemperatureSensor_Backend(front, state, params)
+{
+    AP_Param::setup_object_defaults(this, var_info);
+    _state.var_info = var_info;
+}
 
 void AP_TemperatureSensor_MAX31865::init()
 {
@@ -85,11 +108,16 @@ void AP_TemperatureSensor_MAX31865::init()
         return;
     }
 
+    // Set 3 wire config bit
+    if (_params.type == AP_TemperatureSensor_Params::Type::MAX31865_3_wire) {
+        config_register |= 0b00010000;
+    }
+
     WITH_SEMAPHORE(_dev->get_semaphore());
 
     _dev->set_speed(AP_HAL::Device::SPEED_LOW);
 
-    _dev->write_register(MAX31865_REG_CONFIG_WRITE, MAX31865_CONFIG_VALUE);
+    _dev->write_register(MAX31865_REG_CONFIG_WRITE, config_register);
 
     _dev->set_speed(AP_HAL::Device::SPEED_HIGH);
 
@@ -98,15 +126,60 @@ void AP_TemperatureSensor_MAX31865::init()
                                      FUNCTOR_BIND_MEMBER(&AP_TemperatureSensor_MAX31865::thread_tick, void));
 }
 
+// Convert raw value in to temperature in deg celsius
+// https://www.analog.com/media/en/technical-documentation/application-notes/AN709_0.pdf
+float AP_TemperatureSensor_MAX31865::calculate_temperature(const uint16_t raw) const
+{
+    const float measured_resistance = (raw / 32768.0) * reference_resistance;
+
+    // direct mathmatical method, valid for positive temperature
+    const float A = 3.9083e-3;
+    const float B = -5.775e-7;
+
+    const float Z1 = -A;
+    const float Z2 = A*A - (4.0 * B);
+    const float Z3 = (4.0 * B) / nominal_resistance;
+    const float Z4 = 2.0 * B;
+
+    float temp = (Z1 + sqrtf(Z2 + (Z3 * measured_resistance))) / Z4;
+
+    if (is_positive(temp)) {
+        return temp;
+    }
+
+    // Polynomial for sub zero temperatures
+    // normalize to 100 ohm
+    const float norm_resistance = (measured_resistance / nominal_resistance) * 100.0;
+
+    float rpoly = norm_resistance;
+    temp = -242.02;
+    temp += 2.2228 * norm_resistance;
+    rpoly *= norm_resistance;
+    temp += 2.5859e-3 * norm_resistance;
+    rpoly *= norm_resistance;
+    temp -= 4.8260e-6 * norm_resistance;
+    rpoly *= norm_resistance;
+    temp -= 2.8183e-8 * norm_resistance;
+    rpoly *= norm_resistance;
+    temp += 1.5243e-10 * norm_resistance;
+
+    return temp;
+}
+
 void AP_TemperatureSensor_MAX31865::thread_tick()
 {
+    if (!is_positive(nominal_resistance) || !is_positive(reference_resistance)) {
+        // calculate_temperature function will fall over with bad reference values
+        return;
+    }
+
     uint16_t raw_data;
     if (!_dev->read_registers(MAX31865_REG_DATA_MSB, (uint8_t *)&raw_data, sizeof(raw_data))) {
         return;
     }
 
     // 16bit byte swap
-     const uint16_t data = htobe16(raw_data);
+    const uint16_t data = htobe16(raw_data);
 
     // fault is LSB bit, temperature data is upper 15 bits
     const bool is_fault = (data & 0x0001) != 0;
@@ -115,21 +188,21 @@ void AP_TemperatureSensor_MAX31865::thread_tick()
     if (is_fault) {
 #if MAX31865_DEBUGGING
         uint8_t data_fault = 0;
-        _dev->read_registers(MAX31865_REG_FAULT_STATUS_READ, (uint8_t *)&data_fault, 1);
-        Debug("%d MAX31865 fault: 0x02X", _state.instance, data_fault);
+        if (_dev->read_registers(MAX31865_REG_FAULT_STATUS_READ, (uint8_t *)&data_fault, 1)) {
+            Debug("%d MAX31865 fault: %u -> 0x%x", _state.instance, data, data_fault);
+        } else {
+            Debug("%d MAX31865 unkown fault: %u", data, _state.instance);
+        }
 #endif
         // clear the fault
-        _dev->write_register(MAX31865_REG_CONFIG_WRITE, MAX31865_CONFIG_VALUE);
+        _dev->write_register(MAX31865_REG_CONFIG_WRITE, config_register);
         return;
     }
 
-    // For a temperature range of -100 C to +100 C, a good approximation of
-    // temperature can be made with simple linearization. This equation gives
-    // 0 C error at 0C, -1.75 C error at -100 C, and -1.4 C error at +100 C
-    const float temperature = ((float)data_temperature/32.0f) - 256.0f;
+    const float temperature = calculate_temperature(data_temperature);
 
 #if MAX31865_DEBUGGING
-    Debug("%d MAX31865 %.2f C", _state.instance, temperature);
+    Debug("%d MAX31865 %u -> %.2f C", _state.instance, data_temperature, temperature);
 #endif
 
     set_temperature(temperature);

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_MAX31865.h
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_MAX31865.h
@@ -26,14 +26,28 @@
 #if AP_TEMPERATURE_SENSOR_MAX31865_ENABLED
 
 class AP_TemperatureSensor_MAX31865 : public AP_TemperatureSensor_Backend {
-    using AP_TemperatureSensor_Backend::AP_TemperatureSensor_Backend;
 public:
+    AP_TemperatureSensor_MAX31865(AP_TemperatureSensor &front, AP_TemperatureSensor::TemperatureSensor_State &state, AP_TemperatureSensor_Params &params);
 
     __INITFUNC__ void init(void) override;
 
     void update(void) override {};
 
+    static const struct AP_Param::GroupInfo var_info[];
+
 private:
+
+    // Vbias = ON (must be on for automatic mode)
+    // Conversion mode: Auto
+    // Fault Status: 1set 1 to Clear all latched faults
+    uint8_t config_register = 0b11000010;
+
+    AP_Float nominal_resistance;
+    AP_Float reference_resistance;
+
+    // Convert raw value in to temperature in deg celsius
+    float calculate_temperature(const uint16_t raw) const;
+
     void thread_tick(void);
 };
 

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Params.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Params.cpp
@@ -34,7 +34,7 @@ const AP_Param::GroupInfo AP_TemperatureSensor_Params::var_info[] = {
     // @Param: TYPE
     // @DisplayName: Temperature Sensor Type
     // @Description: Enables temperature sensors
-    // @Values: 0:Disabled, 1:TSYS01, 2:MCP9600, 3:MAX31865, 4:TSYS03, 5:Analog, 6:DroneCAN, 7:MLX90614, 8:SHT3x
+    // @Values: 0:Disabled, 1:TSYS01, 2:MCP9600, 3:MAX31865 2 or 4 wire, 4:TSYS03, 5:Analog, 6:DroneCAN, 7:MLX90614, 8:SHT3x, 3:MAX31865 3 wire
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO_FLAGS("TYPE", 1, AP_TemperatureSensor_Params, type, (float)Type::NONE, AP_PARAM_FLAG_ENABLE),

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Params.h
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Params.h
@@ -30,12 +30,13 @@ public:
         NONE                        = 0,
         TSYS01                      = 1,
         MCP9600                     = 2,
-        MAX31865                    = 3,
+        MAX31865_2_or_4_wire        = 3,
         TSYS03                      = 4,
         ANALOG                      = 5,
         DRONECAN                    = 6,
         MLX90614                    = 7,
         SHT3x                       = 8,
+        MAX31865_3_wire             = 9,
     };
 
     // option to map to another system component


### PR DESCRIPTION
This adds reference and nominal resistance parameter to the MAX31865 temperature sensor backed. It also adds a new 3 wire variant. The default values provide the same conversion as the current method:

https://www.geogebra.org/calculator/qq5wfb9m

The params are needed to get the correct temperature with common breakout boards such as this one: 

https://www.adafruit.com/product/3328?srsltid=AfmBOorc_ViZOA57qXZ_xJCoaMYtHglsLPddjIeM0JcRv5RsC_uzuGO7