### PR TITLE
AP_Scripting: docs_check.py: flake8 correctness

### DIFF
--- a/libraries/AP_Scripting/tests/docs_check.py
+++ b/libraries/AP_Scripting/tests/docs_check.py
@@ -5,12 +5,15 @@
 '''
 Reads two lua docs files and checks for differences
 
-python ./libraries/AP_Scripting/tests/docs_check.py "./libraries/AP_Scripting/docs/docs expected.lua" "./libraries/AP_Scripting/docs/docs.lua"
+python ./libraries/AP_Scripting/tests/docs_check.py "./libraries/AP_Scripting/docs/docs expected.lua" "./libraries/AP_Scripting/docs/docs.lua"  # noqa:E501
 
 AP_FLAKE8_CLEAN
 '''
 
-import optparse, sys, re
+import optparse
+import sys
+import re
+
 
 class method(object):
     def __init__(self, global_name, local_name, num_args, full_line, returns, params):
@@ -36,22 +39,22 @@ class method(object):
             ret_str += "\tFunction: %s\n" % (self.local_name)
         else:
             ret_str += "\tGlobal: %s\n" % (self.global_name)
-        ret_str +=  "\tNum Args: %s\n" % (self.num_args)
+        ret_str += "\tNum Args: %s\n" % (self.num_args)
 
-        ret_str +=  "\tParams:\n"
+        ret_str += "\tParams:\n"
         for param_type in self.params:
             ret_str += "\t\t%s\n" % param_type
 
-        ret_str +=  "\tReturns:\n"
+        ret_str += "\tReturns:\n"
         for return_type in self.returns:
             ret_str += "\t\t%s\n" % return_type
 
-        ret_str +="\n"
+        ret_str += "\n"
         return ret_str
 
     def type_compare(self, A, B):
         if (((len(A) == 1) and (A[0] == 'UNKNOWN')) or
-            ((len(B) == 1) and (B[0] == 'UNKNOWN'))):
+                ((len(B) == 1) and (B[0] == 'UNKNOWN'))):
             # UNKNOWN is a special case used for manual bindings
             return True
 
@@ -73,7 +76,7 @@ class method(object):
                 return False
 
         return True
-    
+
     def check_types(self, other):
         if not self.types_compare(self.returns, other.returns):
             return False
@@ -84,33 +87,41 @@ class method(object):
         return True
 
     def __eq__(self, other):
-        return (self.global_name == other.global_name) and (self.local_name == other.local_name) and (self.num_args == other.num_args)
+        return (
+            self.global_name == other.global_name and
+            self.local_name == other.local_name and
+            self.num_args == other.num_args
+        )
 
     def is_overload(self, other):
         # this allows multiple function definitions with different params
         white_list = [
-            "Parameter" 
+            "Parameter"
         ]
         allow_override = other.manual or (self.global_name in white_list)
-        return allow_override and (self.global_name == other.global_name) and (self.local_name == other.local_name) and (self.num_args != other.num_args)
+        return (
+            allow_override and
+            self.global_name == other.global_name and
+            self.local_name == other.local_name and
+            self.num_args != other.num_args
+        )
+
 
 def get_return_type(line):
-    try:
-        match = re.findall(r"^---@return (\w+(\|(\w+))*)", line)
-        all_types = match[0][0]
-        return all_types.split("|")
+    m = re.findall(r"^---@return (\w+(\|(\w+))*)", line)
+    if m is None or len(m) == 0 or len(m[0]) == 0:
+        raise ValueError(f"Could not get return type in: {line}")
+    all_types = m[0][0]
+    return all_types.split("|")
 
-    except:
-        raise Exception("Could not get return type in: %s" % line)
 
 def get_param_type(line):
-    try:
-        match = re.findall(r"^---@param (?:\w+\??|...) (\w+(\|(\w+))*)", line)
-        all_types = match[0][0]
-        return all_types.split("|")
+    m = re.findall(r"^---@param (?:\w+\??|...) (\w+(\|(\w+))*)", line)
+    if m is None or len(m) == 0 or len(m[0]) == 0:
+        raise ValueError(f"Could not get return type in: {line}")
+    all_types = m[0][0]
+    return all_types.split("|")
 
-    except:
-        raise Exception("Could not get param type in: %s" % line)
 
 def parse_file(file_name):
     methods = []
@@ -149,7 +160,7 @@ def parse_file(file_name):
             function_line = function_line.replace(" ", "")
 
             # get arguments
-            function_name, args = function_line.split("(",1)
+            function_name, args = function_line.split("(", 1)
             args = args[0:args.find(")")]
 
             if len(args) == 0:
@@ -163,7 +174,7 @@ def parse_file(file_name):
             # get global/class name and function name
             local_name = ""
             if function_name.count(":") == 1:
-                global_name, local_name = function_name.split(":",1)
+                global_name, local_name = function_name.split(":", 1)
             else:
                 global_name = function_name
 
@@ -172,6 +183,7 @@ def parse_file(file_name):
             params = []
 
     return methods
+
 
 def compare(expected_file_name, got_file_name):
 
@@ -206,10 +218,11 @@ def compare(expected_file_name, got_file_name):
             print(meth)
             pass_check = False
 
-
     # White list of classes that are allowed unexpected definitions
     white_list = [
-        # "virtual" class to bypass need for nil check when getting a parameter value, Parameter_ud is used internally, Parameter_ud_const exists only in the docs.
+        # "virtual" class to bypass need for nil check when getting a
+        # parameter value, Parameter_ud is used internally,
+        # Parameter_ud_const exists only in the docs.
         "Parameter_ud_const"
     ]
 
@@ -234,6 +247,7 @@ def compare(expected_file_name, got_file_name):
     else:
         print("Docs check passed")
 
+
 if __name__ == '__main__':
 
     parser = optparse.OptionParser(__file__)
@@ -245,5 +259,3 @@ if __name__ == '__main__':
         sys.exit(0)
 
     compare(args[0], args[1])
-
-


### PR DESCRIPTION
... also avoid catching bare exception, handle the case where the regex isn't matching

```
pbarker@crun:~/rc/ardupilot(pr/docs-check-flake8)$ flake8 libraries/AP_Scripting/tests/docs_check.py
pbarker@crun:~/rc/ardupilot(pr/docs-check-flake8)$ 
```

Extracted from https://github.com/ArduPilot/ardupilot/pull/30272/files
