### PR TITLE
colcon: Use current MAVProxy in GitHub Action

### DIFF
--- a/.github/workflows/colcon.yml
+++ b/.github/workflows/colcon.yml
@@ -183,12 +183,12 @@ jobs:
       - name: Install MAVProxy
         run: |
           # Install this specific version just to prevent rolling updates.
-          # These are the latest available
-          python3 -m pip install MAVProxy==1.8.67
+          # See the latest available at https://pypi.org/project/MAVProxy
+          python3 -m pip install MAVProxy==1.8.71
       - name: Install local pymavlink
         working-directory: ./src/ardupilot/modules/mavlink/pymavlink
         run: |
-          python3 -m pip install . -U --user
+          python3 -m pip install . --upgrade --user
       # install Micro-XRCE-DDS-Gen from source until image is updated
       - name: install Micro-XRCE-DDS-Gen from source
         run: |
@@ -210,4 +210,3 @@ jobs:
       - name: Report colcon test results
         run: |
           colcon test-result --all --verbose
-


### PR DESCRIPTION
This GitHub Action fails occasionally, so let's upgrade its MAVProxy to see if that provides more stable runs.
* https://pypi.org/project/MAVProxy --> v1.8.71

Given the changes in MAVProxy, should we upgrade?
* https://github.com/ArduPilot/MAVProxy/releases
* https://github.com/ArduPilot/ardupilot/pull/30369#issuecomment-2975476125

---

`pip install -U` can be quite opaque to readers because `pip install` currently has six `--u*` options.

% `python3 -m pip install --help | grep "\-\-u"`
```
  --user                      Install to the Python user install directory for
  -U, --upgrade               Upgrade all specified packages to the newest
  --upgrade-strategy <upgrade_strategy>
  --use-pep517                Use PEP 517 for building source distributions
  --use-feature <feature>     Enable new functionality, that may be backward
  --use-deprecated <feature>  Enable deprecated functionality, that will be
```