### PR TITLE
QuadPlane: fix transition yaw suppression

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1569,7 +1569,7 @@ void SLT_Transition::update()
             // is needed to maintain good control in forward
             // transitions
             quadplane.attitude_control->reset_yaw_target_and_rate();
-            quadplane.attitude_control->rate_bf_yaw_target(0.0);
+            quadplane.attitude_control->rate_bf_yaw_target(rad_to_cd(quadplane.ahrs.get_gyro().z));
         }
         if (quadplane.tiltrotor.enabled() && !quadplane.tiltrotor.has_fw_motor()) {
             // tilt rotors without dedicated fw motors do not have forward throttle output in this stage
@@ -1645,7 +1645,7 @@ void SLT_Transition::update()
         // yaw control throughout the transition
         if (!quadplane.tiltrotor.is_vectored()) {
             quadplane.attitude_control->reset_yaw_target_and_rate();
-            quadplane.attitude_control->rate_bf_yaw_target(0.0);
+            quadplane.attitude_control->rate_bf_yaw_target(rad_to_cd(quadplane.ahrs.get_gyro().z));
         }
         break;
     }

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -288,6 +288,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Bitmask: 20: Force RTL mode-forces RTL mode on rc failsafe in VTOL modes overriding bit 5(USE_QRTL)
     // @Bitmask: 21: Tilt rotor-tilt motors up when disarmed in FW modes (except manual) to prevent ground strikes.
     // @Bitmask: 22: Scale FF by the ratio of VTOL to plane angle P gains in Position 1 phase of transition into VTOL flight as well as reducing VTOL angle P based on airspeed.
+    // @Bitmask: 23: Suppress VTOL yaw stabilization during transition (ignored on vectored-yaw tiltrotors)
     AP_GROUPINFO("OPTIONS", 58, QuadPlane, options, 0),
 
     AP_SUBGROUPEXTENSION("",59, QuadPlane, var_info2),
@@ -1561,7 +1562,7 @@ void SLT_Transition::update()
         }
         quadplane.hold_hover(climb_rate_cms);
 
-        if (!quadplane.tiltrotor.is_vectored()) {
+        if (!quadplane.tiltrotor.is_vectored() && quadplane.option_is_set(QuadPlane::OPTION::SUPPRESS_YAW_TRANSITION)) {
             // set desired yaw to current yaw in both desired angle
             // and rate request. This reduces wing twist in transition
             // due to multicopter yaw demands. This is disabled when
@@ -1643,7 +1644,7 @@ void SLT_Transition::update()
         // control surfaces at this stage.
         // We disable this for vectored yaw tilt rotors as they do need active
         // yaw control throughout the transition
-        if (!quadplane.tiltrotor.is_vectored()) {
+        if (!quadplane.tiltrotor.is_vectored() && quadplane.option_is_set(QuadPlane::OPTION::SUPPRESS_YAW_TRANSITION)) {
             quadplane.attitude_control->reset_yaw_target_and_rate();
             quadplane.attitude_control->rate_bf_yaw_target(rad_to_cd(quadplane.ahrs.get_gyro().z));
         }

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -608,6 +608,7 @@ private:
         FS_RTL=(1<<20),
         DISARMED_TILT_UP=(1<<21),
         SCALE_FF_ANGLE_P=(1<<22),
+        SUPPRESS_YAW_TRANSITION=(1<<23),
     };
     bool option_is_set(OPTION option) const {
         return (options.get() & int32_t(option)) != 0;


### PR DESCRIPTION
This PR will need careful testing, because it is changing a long-standing (bad) behavior. I'll be deploying this on the Carbonix birds immediately, and I've extensively tested in RealFlight, but we should get some others.

During transition the VTOL yaw controller is _intended_ to be suppressed (except for vectored tiltrotors). This is to avoid wing twist since on quadcopters yaw is achieved by lifting more from one diagonal pair or another. As implemented, the yaw controller tries to hold zero yaw rate, which is not what was intended. This was due to a radian/centidegree unit confusion when the line was first added. Later, in #22127, the unit confusion was cleared up, but to avoid risking a behavior change, it was decided to explicitly set the rate command to 0. This can and does lead to large yaw outputs, even in normal straight-line transitions.

The problem is even worse if you don't use level-transition and turn before transition is complete, especially if you have a good/tight yaw controller (this is the case with Ottano, which has great yaw control and a very long time to transition). Also, with the current behavior, during any QAssist, the VTOL controller actively fights against any coordinated turn. If a control surface fails, and you try to limp home on force QAssist, things might go very badly.

This PR lets you select between two behaviors:
- VTOL controller actively assists with turn coordination
- VTOL yaw controller is (properly) suppressed

Neither is exactly the same as the current behavior, but I'd say the former is closer to the current behavior, so I chose that as the default. In a straight-line transition, assisting with turn coordination is the same as holding 0 yaw rate. And in a turning transition, it leads to significantly smaller yaw outputs and better flight. One could argue the default should be to suppress yaw, since that's safer for quadplanes with poor stiffness, but they've been managing with the current worse behavior for years with apparently no issue. I can go either way on the default, I just need the option.

Next I'll post some logs and graphs from my RealFlight testing.