### PR TITLE
RC_Channel: Set RC calibration values from a file

### DIFF
--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -665,6 +665,7 @@ private:
     AP_Int32  _options;
     AP_Int32  _protocols;
     AP_Float _fs_timeout;
+    AP_Int8   _propo_type;
 
     // set to true if we see overrides or other RC input
     bool _has_ever_seen_rc_input;

--- a/libraries/RC_Channel/RC_Channels_VarInfo.h
+++ b/libraries/RC_Channel/RC_Channels_VarInfo.h
@@ -112,6 +112,13 @@ const AP_Param::GroupInfo RC_Channels::var_info[] = {
     // @Units: s
     AP_GROUPINFO_FRAME("_FS_TIMEOUT", 35, RC_CHANNELS_SUBCLASS, _fs_timeout, 1.0, AP_PARAM_FRAME_COPTER),
 
+    // @Param: _PROPO_TYPE
+    // @DisplayName: RC Propo Type
+    // @Description: The PWM signals vary depending on the type of transmitter. By specifying the transmitter type, we can set the calibration values as parameters in ArduPilot. This configuration eliminates the need for manual radio calibration.
+    // @User: Advanced
+    // @Values: 0:RC Calibration,1:Futaba 14SG,2:Skydroid H12,3:Futaba WSC-1
+    AP_GROUPINFO("_PROPO_TYPE", 36, RC_CHANNELS_SUBCLASS, _propo_type, 0),
+
     AP_GROUPEND
 };
 


### PR DESCRIPTION
The PWM values differ depending on the type of transmitter.
For example, the SKYDROID H12 allows manual input of the minimum and maximum PWM values for each radio channel.
With such transmitters, it becomes possible to configure these values through a file.
I plan to add a parameter, and based on the value of this parameter, a Lua script will determine the appropriate minimum, maximum, trim, and reverse values for the transmitter.
By configuring these values through a file, it helps prevent incorrect maximum, minimum, trim, or reverse settings caused by improper RC calibration procedures.

FUTABA 14SG
![Screenshot from 2025-06-20 06-53-11](https://github.com/user-attachments/assets/c6987bfb-48c5-4572-9064-cee77854051e)

SKYDROID H12
![Screenshot from 2025-06-20 06-56-40](https://github.com/user-attachments/assets/948cd3a1-bf46-4537-980d-5f66dfd815a5)


SKYDROID H12 (LUA Script)

local MAV_SEVERITY = {
    EMERGENCY = 0,
    ALERT = 1,
    CRITICAL = 2,
    ERROR = 3,
    WARNING = 4,
    NOTICE = 5,
    INFO = 6,
    DEBUG = 7
}

function update()
  gcs:send_text(MAV_SEVERITY.NOTICE, 'LUA: Skydroid H12-RC param script enabled')

  -- RCx_DZ parameters are used to set the deadzone for each RC channels
  param:set_and_save('RC1_DZ', 20)
  param:set_and_save('RC2_DZ', 20)
  param:set_and_save('RC3_DZ', 30)
  param:set_and_save('RC4_DZ', 20)
  param:set_and_save('RC5_DZ', 0)
  param:set_and_save('RC6_DZ', 0)
  param:set_and_save('RC7_DZ', 0)
  param:set_and_save('RC8_DZ', 0)
  param:set_and_save('RC9_DZ', 0)
  param:set_and_save('RC10_DZ', 0)
  param:set_and_save('RC11_DZ', 0)
  param:set_and_save('RC12_DZ', 0)
  param:set_and_save('RC13_DZ', 0)
  param:set_and_save('RC14_DZ', 0)
  param:set_and_save('RC15_DZ', 0)
  param:set_and_save('RC16_DZ', 0)

  -- RCx_MIN parameters are used to set the minimum value for each RC channels
  param:set_and_save('RC1_MIN', 1050)
  param:set_and_save('RC2_MIN', 1050)
  param:set_and_save('RC3_MIN', 1050)
  param:set_and_save('RC4_MIN', 1050)
  param:set_and_save('RC5_MIN', 1050)
  param:set_and_save('RC6_MIN', 1050)
  param:set_and_save('RC7_MIN', 1050)
  param:set_and_save('RC8_MIN', 1050)
  param:set_and_save('RC9_MIN', 1050)
  param:set_and_save('RC10_MIN', 1050)
  param:set_and_save('RC11_MIN', 1050)
  param:set_and_save('RC12_MIN', 1050)
  param:set_and_save('RC13_MIN', 1050)
  param:set_and_save('RC14_MIN', 1050)
  param:set_and_save('RC15_MIN', 1050)
  param:set_and_save('RC16_MIN', 1050)

  -- RCx_MAX parameters are used to set the maximum value for each RC channels
  param:set_and_save('RC1_MAX', 1950)
  param:set_and_save('RC2_MAX', 1950)
  param:set_and_save('RC3_MAX', 1950)
  param:set_and_save('RC4_MAX', 1950)
  param:set_and_save('RC5_MAX', 1950)
  param:set_and_save('RC6_MAX', 1950)
  param:set_and_save('RC7_MAX', 1950)
  param:set_and_save('RC8_MAX', 1950)
  param:set_and_save('RC9_MAX', 1950)
  param:set_and_save('RC10_MAX', 1950)
  param:set_and_save('RC11_MAX', 1950)
  param:set_and_save('RC12_MAX', 1950)
  param:set_and_save('RC13_MAX', 1950)
  param:set_and_save('RC14_MAX', 1950)
  param:set_and_save('RC15_MAX', 1950)
  param:set_and_save('RC16_MAX', 1950)

  -- RCx_TRIM parameters are used to set the trim value for each RC channels
  param:set_and_save('RC1_TRIM', 1500)
  param:set_and_save('RC2_TRIM', 1500)
  param:set_and_save('RC3_TRIM', 1500)
  param:set_and_save('RC4_TRIM', 1500)
  param:set_and_save('RC5_TRIM', 1500)
  param:set_and_save('RC6_TRIM', 1500)
  param:set_and_save('RC7_TRIM', 1500)
  param:set_and_save('RC8_TRIM', 1500)
  param:set_and_save('RC9_TRIM', 1500)
  param:set_and_save('RC10_TRIM', 1500)
  param:set_and_save('RC11_TRIM', 1500)
  param:set_and_save('RC12_TRIM', 1500)
  param:set_and_save('RC13_TRIM', 1500)
  param:set_and_save('RC14_TRIM', 1500)
  param:set_and_save('RC15_TRIM', 1500)
  param:set_and_save('RC16_TRIM', 1500)

  -- RCx__REVERSED parameters are used to set the reversed value for each RC channels
  param:set_and_save('RC1_REVERSED', 0)
  param:set_and_save('RC2_REVERSED', 0)
  param:set_and_save('RC3_REVERSED', 0)
  param:set_and_save('RC4_REVERSED', 0)
  param:set_and_save('RC5_REVERSED', 0)
  param:set_and_save('RC6_REVERSED', 0)
  param:set_and_save('RC7_REVERSED', 0)
  param:set_and_save('RC8_REVERSED', 0)
  param:set_and_save('RC9_REVERSED', 0)
  param:set_and_save('RC10_REVERSED', 0)
  param:set_and_save('RC11_REVERSED', 0)
  param:set_and_save('RC12_REVERSED', 0)
  param:set_and_save('RC13_REVERSED', 0)
  param:set_and_save('RC14_REVERSED', 0)
  param:set_and_save('RC15_REVERSED', 0)
  param:set_and_save('RC16_REVERSED', 0)
end

local value = param:get('RC_PROPO_TYPE')
if value ~= 2 then
  return
end

return update()
