### PR TITLE
Tools: ros2: set event once in test fixture callbacks

### DIFF
--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_battery_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_battery_msg_received.py
@@ -78,6 +78,9 @@ class BatteryListener(rclpy.node.Node):
 
     def subscriber_callback(self, msg):
         """Process a BatteryState message."""
+        if self.msg_event_object.set():
+            return
+
         self.get_logger().info("From AP : ID {} Voltage {}".format(msg.header.frame_id, msg.voltage))
 
         if msg.header.frame_id == '0':

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_geopose_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_geopose_msg_received.py
@@ -124,6 +124,9 @@ class GeoPoseListener(rclpy.node.Node):
 
     def subscriber_callback(self, msg):
         """Process a GeoPoseStamped message."""
+        if self.msg_event_object.set():
+            return
+
         position = msg.pose.position
 
         self.get_logger().info("From AP : Position [lat:{}, lon: {}]".format(position.latitude, position.longitude))

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_navsat_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_navsat_msg_received.py
@@ -66,6 +66,9 @@ class NavSatFixListener(rclpy.node.Node):
 
     def subscriber_callback(self, msg):
         """Process a NavSatFix message."""
+        if self.msg_event_object.set():
+            return
+
         if msg.latitude:
             self.get_logger().info("From AP : True [lat:{}, lon: {}]".format(msg.latitude, msg.longitude))
         else:

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_plane_airspeed.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_plane_airspeed.py
@@ -67,6 +67,9 @@ class AirspeedTester(rclpy.node.Node):
 
     def airspeed_data_callback(self, msg):
         """Process a airspeed message from the autopilot."""
+        if self.msg_event_object.set():
+            return
+
         self.get_logger().info(f"From AP : airspeed {msg}")
 
         # set event last

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_rc_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_rc_msg_received.py
@@ -76,6 +76,9 @@ class RcListener(rclpy.node.Node):
 
     def subscriber_callback(self, msg):
         """Process a Rc message."""
+        if self.msg_event_object.set():
+            return
+
         # set event last
         self.msg_event_object.set()
 

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_time_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_time_msg_received.py
@@ -54,6 +54,9 @@ class TimeListener(rclpy.node.Node):
 
     def subscriber_callback(self, msg):
         """Process a Time message."""
+        if self.msg_event_object.set():
+            return
+
         if msg.sec:
             self.get_logger().info("From AP : True [sec:{}, nsec: {}]".format(msg.sec, msg.nanosec))
         else:


### PR DESCRIPTION
The event used to verify a message is received only needs to be set once in the test fixture subscriber callback.

- [x] Requires https://github.com/ArduPilot/ardupilot/pull/30396
