### PR TITLE
Copter: Units and Name - No compiler change

### DIFF
--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -609,7 +609,7 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_mount(const mavlink_command_int_t 
             !copter.camera_mount.has_pan_control()) {
             // Per the handler in AP_Mount, DO_MOUNT_CONTROL yaw angle is in body frame, which is
             // equivalent to an offset to the current yaw demand.
-            copter.flightmode->auto_yaw.set_yaw_angle_offset(packet.param3);
+            copter.flightmode->auto_yaw.set_yaw_offset_deg(packet.param3);
         }
         break;
     default:
@@ -883,7 +883,7 @@ void GCS_MAVLINK_Copter::handle_mount_message(const mavlink_message_t &msg)
             // Per the handler in AP_Mount, MOUNT_CONTROL yaw angle is in body frame, which is
             // equivalent to an offset to the current yaw demand.
             const float yaw_offset_d = mavlink_msg_mount_control_get_input_c(&msg) * 0.01f;
-            copter.flightmode->auto_yaw.set_yaw_angle_offset(yaw_offset_d);
+            copter.flightmode->auto_yaw.set_yaw_offset_deg(yaw_offset_d);
             break;
         }
     }

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1086,7 +1086,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Increment: 0.01
     // @Values: 0.5:Very Soft, 0.2:Soft, 0.15:Medium, 0.1:Crisp, 0.05:Very Crisp
     // @User: Standard
-    AP_SUBGROUPINFO(command_model_pilot, "PILOT_Y_", 56, ParametersG2, AC_CommandModel),
+    AP_SUBGROUPINFO(command_model_pilot_y, "PILOT_Y_", 56, ParametersG2, AC_CommandModel),
 
     // @Param: TKOFF_SLEW_TIME
     // @DisplayName: Slew time of throttle during take-off
@@ -1263,7 +1263,7 @@ ParametersG2::ParametersG2(void) :
     ,command_model_acro_y(ACRO_Y_RATE_DEFAULT, ACRO_Y_EXPO_DEFAULT, 0.0f)
 #endif
 
-    ,command_model_pilot(PILOT_Y_RATE_DEFAULT, PILOT_Y_EXPO_DEFAULT, 0.0f)
+    ,command_model_pilot_y(PILOT_Y_RATE_DEFAULT, PILOT_Y_EXPO_DEFAULT, 0.0f)
 
 #if WEATHERVANE_ENABLED
     ,weathervane()

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -632,7 +632,7 @@ public:
     AC_CommandModel command_model_acro_y;
 #endif
 
-    AC_CommandModel command_model_pilot;
+    AC_CommandModel command_model_pilot_y;
 
 #if MODE_ACRO_ENABLED
     AP_Int8 acro_options;

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -241,7 +241,7 @@ bool Copter::set_mode(Mode::Number mode, ModeReason reason)
         control_mode_reason = reason;
         // set yaw rate time constant during autopilot startup
         if (reason == ModeReason::INITIALISED && mode == Mode::Number::STABILIZE) {
-            attitude_control->set_yaw_rate_tc(g2.command_model_pilot.get_rate_tc());
+            attitude_control->set_yaw_rate_tc(g2.command_model_pilot_y.get_rate_tc());
         }
         // make happy noise
         if (copter.ap.initialised && (reason != last_reason)) {
@@ -369,7 +369,7 @@ bool Copter::set_mode(Mode::Number mode, ModeReason reason)
 #if MODE_ACRO_ENABLED || MODE_SPORT_ENABLED
     attitude_control->set_roll_pitch_rate_tc(g2.command_model_acro_rp.get_rate_tc());
 #endif
-    attitude_control->set_yaw_rate_tc(g2.command_model_pilot.get_rate_tc());
+    attitude_control->set_yaw_rate_tc(g2.command_model_pilot_y.get_rate_tc());
 #if MODE_ACRO_ENABLED || MODE_DRIFT_ENABLED
     if (mode== Mode::Number::ACRO || mode== Mode::Number::DRIFT) {
         attitude_control->set_yaw_rate_tc(g2.command_model_acro_y.get_rate_tc());
@@ -462,7 +462,7 @@ void Copter::notify_flight_mode() {
 
 // get_pilot_desired_angle - transform pilot's roll or pitch input into a desired lean angle
 // returns desired angle in centi-degrees
-void Mode::get_pilot_desired_lean_angles(float &roll_out_cd, float &pitch_out_cd, float angle_max_cd, float angle_limit_cd) const
+void Mode::get_pilot_desired_lean_angles_cd(float &roll_out_cd, float &pitch_out_cd, float angle_max_cd, float angle_limit_cd) const
 {
     if (!rc().has_valid_input()) {
         roll_out_cd = 0.0;
@@ -505,10 +505,10 @@ Vector2f Mode::get_pilot_desired_velocity(float vel_max) const
     copter.rotate_body_frame_to_NE(vel.x, vel.y);
 
     // Transform square input range to circular output
-    // vel_scaler is the vector to the edge of the +- 1.0 square in the direction of the current input
-    Vector2f vel_scaler = vel / MAX(fabsf(vel.x), fabsf(vel.y));
+    // vel_scalar is the vector to the edge of the +- 1.0 square in the direction of the current input
+    Vector2f vel_scalar = vel / MAX(fabsf(vel.x), fabsf(vel.y));
     // We scale the output by the ratio of the distance to the square to the unit circle and multiply by vel_max
-    vel *= vel_max / vel_scaler.length();
+    vel *= vel_max / vel_scalar.length();
     return vel;
 }
 
@@ -818,13 +818,13 @@ void Mode::precland_retry_position(const Vector3f &retry_pos)
         // allow user to take control during repositioning. Note: copied from land_run_horizontal_control()
         // To-Do: this code exists at several different places in slightly different forms and that should be fixed
         if (g.land_repositioning) {
-            float target_roll = 0.0f;
-            float target_pitch = 0.0f;
+            float target_roll_cd = 0.0f;
+            float target_pitch_cd = 0.0f;
             // convert pilot input to lean angles
-            get_pilot_desired_lean_angles(target_roll, target_pitch, loiter_nav->get_angle_max_cd(), attitude_control->get_althold_lean_angle_max_cd());
+            get_pilot_desired_lean_angles_cd(target_roll_cd, target_pitch_cd, loiter_nav->get_angle_max_cd(), attitude_control->get_althold_lean_angle_max_cd());
 
             // record if pilot has overridden roll or pitch
-            if (!is_zero(target_roll) || !is_zero(target_pitch)) {
+            if (!is_zero(target_roll_cd) || !is_zero(target_pitch_cd)) {
                 if (!copter.ap.land_repo_active) {
                     LOGGER_WRITE_EVENT(LogEvent::LAND_REPO_ACTIVE);
                 }
@@ -930,13 +930,13 @@ float Mode::get_pilot_desired_throttle() const
     return throttle_out;
 }
 
-float Mode::get_avoidance_adjusted_climbrate(float target_rate)
+float Mode::get_avoidance_adjusted_climbrate_cms(float target_rate_cms)
 {
 #if AP_AVOIDANCE_ENABLED
-    AP::ac_avoid()->adjust_velocity_z(pos_control->get_pos_U_p().kP(), pos_control->get_max_accel_U_cmss(), target_rate, G_Dt);
-    return target_rate;
+    AP::ac_avoid()->adjust_velocity_z(pos_control->get_pos_U_p().kP(), pos_control->get_max_accel_U_cmss(), target_rate_cms, G_Dt);
+    return target_rate_cms;
 #else
-    return target_rate;
+    return target_rate_cms;
 #endif
 }
 
@@ -1000,7 +1000,7 @@ Mode::AltHoldModeState Mode::get_alt_hold_state(float target_climb_rate_cms)
 
 // transform pilot's yaw input into a desired yaw rate
 // returns desired yaw rate in centi-degrees per second
-float Mode::get_pilot_desired_yaw_rate() const
+float Mode::get_pilot_desired_yaw_rate_cds() const
 {
     if (!rc().has_valid_input()) {
         return 0.0f;
@@ -1010,7 +1010,7 @@ float Mode::get_pilot_desired_yaw_rate() const
     const float yaw_in = channel_yaw->norm_input_dz();
 
     // convert pilot input to the desired yaw rate
-    return g2.command_model_pilot.get_rate() * 100.0 * input_expo(yaw_in, g2.command_model_pilot.get_expo());
+    return g2.command_model_pilot_y.get_rate() * 100.0 * input_expo(yaw_in, g2.command_model_pilot_y.get_expo());
 }
 
 // pass-through functions to reduce code churn on conversion;

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -177,14 +177,14 @@ public:
     virtual int32_t get_alt_above_ground_cm(void) const;
 
     // pilot input processing
-    void get_pilot_desired_lean_angles(float &roll_out_cd, float &pitch_out_cd, float angle_max_cd, float angle_limit_cd) const;
+    void get_pilot_desired_lean_angles_cd(float &roll_out_cd, float &pitch_out_cd, float angle_max_cd, float angle_limit_cd) const;
+    float get_pilot_desired_yaw_rate_cds() const;
     Vector2f get_pilot_desired_velocity(float vel_max) const;
-    float get_pilot_desired_yaw_rate() const;
     float get_pilot_desired_throttle() const;
 
     // returns climb target_rate reduced to avoid obstacles and
     // altitude fence
-    float get_avoidance_adjusted_climbrate(float target_rate);
+    float get_avoidance_adjusted_climbrate_cms(float target_rate_cms);
 
     // send output to the motors, can be overridden by subclasses
     virtual void output_to_motors();
@@ -312,7 +312,7 @@ public:
             ROI =              2,  // point towards a location held in roi (no pilot input accepted)
             FIXED =            3,  // point towards a particular angle (no pilot input accepted)
             LOOK_AHEAD =       4,  // point in the direction the copter is moving
-            RESETTOARMEDYAW =  5,  // point towards heading at time motors were armed
+            RESET_TO_ARMED_YAW =  5,  // point towards heading at time motors were armed
             ANGLE_RATE =       6,  // turn at a specified rate from a starting angle
             RATE =             7,  // turn at a specified rate (held in auto_yaw_rate)
             CIRCLE =           8,  // use AC_Circle's provided yaw (used during Loiter-Turns commands)
@@ -332,13 +332,13 @@ public:
         void set_roi(const Location &roi_location);
 
         void set_fixed_yaw(float angle_deg,
-                           float turn_rate_dps,
+                           float turn_rate_degs,
                            int8_t direction,
                            bool relative_angle);
 
-        void set_yaw_angle_rate(float yaw_angle_d, float yaw_rate_ds);
+        void set_yaw_angle_and_rate_deg(float yaw_angle_deg, float yaw_rate_degs);
 
-        void set_yaw_angle_offset(const float yaw_angle_offset_d);
+        void set_yaw_offset_deg(const float yaw_angle_offset_deg);
 
         bool reached_fixed_yaw_target();
 
@@ -357,7 +357,7 @@ public:
         float rate_cds();
 
         // returns a yaw in degrees, direction of vehicle travel:
-        float look_ahead_yaw();
+        float look_ahead_yaw_deg();
 
         float roi_yaw() const;
 
@@ -378,7 +378,7 @@ public:
         uint32_t _last_update_ms;
 
         // heading when in yaw_look_ahead_yaw
-        float _look_ahead_yaw;
+        float _look_ahead_yaw_deg;
 
         // turn rate (in cds) when auto_yaw_mode is set to AUTO_YAW_RATE
         float _yaw_angle_cd;
@@ -948,7 +948,7 @@ protected:
 private:
 
     // Flip
-    Vector3f orig_attitude;         // original vehicle attitude before flip
+    Vector3f orig_attitude_euler_cd;         // original vehicle attitude before flip
 
     enum class FlipState : uint8_t {
         Start,

--- a/ArduCopter/mode_acro.cpp
+++ b/ArduCopter/mode_acro.cpp
@@ -118,7 +118,7 @@ void ModeAcro::get_pilot_desired_rates_cds(float roll_in_norm, float pitch_in_no
     }
 
     // calculate roll, pitch rate requests
-    
+
     // roll rate request with input expo applied
     rate_bf_request_cds.x = g2.command_model_acro_rp.get_rate() * 100.0 * input_expo(roll_in_norm, g2.command_model_acro_rp.get_expo());
 
@@ -149,15 +149,15 @@ void ModeAcro::get_pilot_desired_rates_cds(float roll_in_norm, float pitch_in_no
         // Calculate angle limiting earth frame rate commands
         if (g.acro_trainer == (uint8_t)Trainer::LIMITED) {
             const float angle_max_cd = copter.aparm.angle_max;
-            if (roll_angle_cd > angle_max_cd){
+            if (roll_angle_cd > angle_max_cd) {
                 rate_ef_level_cds.x += sqrt_controller(angle_max_cd - roll_angle_cd, g2.command_model_acro_rp.get_rate() * 100.0 / ACRO_LEVEL_MAX_OVERSHOOT, attitude_control->get_accel_roll_max_cdss(), G_Dt);
-            }else if (roll_angle_cd < -angle_max_cd) {
+            } else if (roll_angle_cd < -angle_max_cd) {
                 rate_ef_level_cds.x += sqrt_controller(-angle_max_cd - roll_angle_cd, g2.command_model_acro_rp.get_rate() * 100.0 / ACRO_LEVEL_MAX_OVERSHOOT, attitude_control->get_accel_roll_max_cdss(), G_Dt);
             }
 
-            if (pitch_angle_cd > angle_max_cd){
+            if (pitch_angle_cd > angle_max_cd) {
                 rate_ef_level_cds.y += sqrt_controller(angle_max_cd - pitch_angle_cd, g2.command_model_acro_rp.get_rate() * 100.0 / ACRO_LEVEL_MAX_OVERSHOOT, attitude_control->get_accel_pitch_max_cdss(), G_Dt);
-            }else if (pitch_angle_cd < -angle_max_cd) {
+            } else if (pitch_angle_cd < -angle_max_cd) {
                 rate_ef_level_cds.y += sqrt_controller(-angle_max_cd - pitch_angle_cd, g2.command_model_acro_rp.get_rate() * 100.0 / ACRO_LEVEL_MAX_OVERSHOOT, attitude_control->get_accel_pitch_max_cdss(), G_Dt);
             }
         }
@@ -170,7 +170,7 @@ void ModeAcro::get_pilot_desired_rates_cds(float roll_in_norm, float pitch_in_no
             rate_bf_request_cds.x += rate_bf_level_cds.x;
             rate_bf_request_cds.y += rate_bf_level_cds.y;
             rate_bf_request_cds.z += rate_bf_level_cds.z;
-        }else{
+        } else {
             float acro_level_mix = constrain_float(1-float(MAX(MAX(abs(roll_in_norm), abs(pitch_in_norm)), abs(yaw_in_norm))), 0, 1) * ahrs.cos_pitch();
 
             // Scale levelling rates by stick input

--- a/ArduCopter/mode_acro_heli.cpp
+++ b/ArduCopter/mode_acro_heli.cpp
@@ -111,7 +111,7 @@ void ModeAcro_Heli::run()
             // if there is no external gyro then run the usual
             // ACRO_YAW_P gain on the input control, including
             // deadzone
-            yaw_in_cds = get_pilot_desired_yaw_rate();
+            yaw_in_cds = get_pilot_desired_yaw_rate_cds();
         }
 
         // run attitude controller

--- a/ArduCopter/mode_althold.cpp
+++ b/ArduCopter/mode_althold.cpp
@@ -32,11 +32,11 @@ void ModeAltHold::run()
     update_simple_mode();
 
     // get pilot desired lean angles
-    float target_roll, target_pitch;
-    get_pilot_desired_lean_angles(target_roll, target_pitch, copter.aparm.angle_max, attitude_control->get_althold_lean_angle_max_cd());
+    float target_roll_cd, target_pitch_cd;
+    get_pilot_desired_lean_angles_cd(target_roll_cd, target_pitch_cd, copter.aparm.angle_max, attitude_control->get_althold_lean_angle_max_cd());
 
     // get pilot's desired yaw rate
-    float target_yaw_rate = get_pilot_desired_yaw_rate();
+    float target_yaw_rate_cds = get_pilot_desired_yaw_rate_cds();
 
     // get pilot desired climb rate
     float target_climb_rate = get_pilot_desired_climb_rate();
@@ -70,7 +70,7 @@ void ModeAltHold::run()
         }
 
         // get avoidance adjusted climb rate
-        target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);
+        target_climb_rate = get_avoidance_adjusted_climbrate_cms(target_climb_rate);
 
         // set position controller targets adjusted for pilot input
         takeoff.do_pilot_takeoff(target_climb_rate);
@@ -81,11 +81,11 @@ void ModeAltHold::run()
 
 #if AP_AVOIDANCE_ENABLED
         // apply avoidance
-        copter.avoid.adjust_roll_pitch(target_roll, target_pitch, copter.aparm.angle_max);
+        copter.avoid.adjust_roll_pitch(target_roll_cd, target_pitch_cd, copter.aparm.angle_max);
 #endif
 
         // get avoidance adjusted climb rate
-        target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);
+        target_climb_rate = get_avoidance_adjusted_climbrate_cms(target_climb_rate);
 
 #if AP_RANGEFINDER_ENABLED
         // update the vertical offset based on the surface measurement
@@ -98,7 +98,7 @@ void ModeAltHold::run()
     }
 
     // call attitude controller
-    attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(target_roll, target_pitch, target_yaw_rate);
+    attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(target_roll_cd, target_pitch_cd, target_yaw_rate_cds);
 
     // run the vertical position controller and set output throttle
     pos_control->update_U_controller();

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1194,7 +1194,7 @@ void ModeAuto::loiter_to_alt_run()
     target_climb_rate = constrain_float(target_climb_rate, pos_control->get_max_speed_down_cms(), pos_control->get_max_speed_up_cms());
 
     // get avoidance adjusted climb rate
-    target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);
+    target_climb_rate = get_avoidance_adjusted_climbrate_cms(target_climb_rate);
 
 #if AP_RANGEFINDER_ENABLED
     // update the vertical offset based on the surface measurement
@@ -1220,7 +1220,7 @@ void ModeAuto::nav_attitude_time_run()
     float target_climb_rate_cms = constrain_float(nav_attitude_time.climb_rate * 100.0, pos_control->get_max_speed_down_cms(), pos_control->get_max_speed_up_cms());
 
     // get avoidance adjusted climb rate
-    target_climb_rate_cms = get_avoidance_adjusted_climbrate(target_climb_rate_cms);
+    target_climb_rate_cms = get_avoidance_adjusted_climbrate_cms(target_climb_rate_cms);
 
     // limit and scale lean angles
     const float angle_limit_cd = MAX(1000.0f, MIN(copter.aparm.angle_max, attitude_control->get_althold_lean_angle_max_cd()));
@@ -1992,7 +1992,7 @@ void ModeAuto::do_mount_control(const AP_Mission::Mission_Command& cmd)
         !copter.camera_mount.has_pan_control()) {
         // Per the handler in AP_Mount, DO_MOUNT_CONTROL yaw angle is in body frame, which is
         // equivalent to an offset to the current yaw demand.
-        auto_yaw.set_yaw_angle_offset(cmd.content.mount_control.yaw);
+        auto_yaw.set_yaw_offset_deg(cmd.content.mount_control.yaw);
     }
     // pass the target angles to the camera mount
     copter.camera_mount.set_angle_target(cmd.content.mount_control.roll, cmd.content.mount_control.pitch, cmd.content.mount_control.yaw, false);

--- a/ArduCopter/mode_autotune.cpp
+++ b/ArduCopter/mode_autotune.cpp
@@ -62,7 +62,7 @@ float AutoTune::get_pilot_desired_climb_rate_cms(void) const
     float target_climb_rate = copter.get_pilot_desired_climb_rate();
 
     // get avoidance adjusted climb rate
-    target_climb_rate = copter.mode_autotune.get_avoidance_adjusted_climbrate(target_climb_rate);
+    target_climb_rate = copter.mode_autotune.get_avoidance_adjusted_climbrate_cms(target_climb_rate);
 
     return target_climb_rate;
 }
@@ -72,9 +72,9 @@ float AutoTune::get_pilot_desired_climb_rate_cms(void) const
  */
 void AutoTune::get_pilot_desired_rp_yrate_cd(float &des_roll_cd, float &des_pitch_cd, float &yaw_rate_cds)
 {
-    copter.mode_autotune.get_pilot_desired_lean_angles(des_roll_cd, des_pitch_cd, copter.aparm.angle_max,
+    copter.mode_autotune.get_pilot_desired_lean_angles_cd(des_roll_cd, des_pitch_cd, copter.aparm.angle_max,
                                                        copter.attitude_control->get_althold_lean_angle_max_cd());
-    yaw_rate_cds = copter.mode_autotune.get_pilot_desired_yaw_rate();
+    yaw_rate_cds = copter.mode_autotune.get_pilot_desired_yaw_rate_cds();
 }
 
 /*

--- a/ArduCopter/mode_circle.cpp
+++ b/ArduCopter/mode_circle.cpp
@@ -103,7 +103,7 @@ void ModeCircle::run()
     float target_climb_rate = get_pilot_desired_climb_rate();
 
     // get avoidance adjusted climb rate
-    target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);
+    target_climb_rate = get_avoidance_adjusted_climbrate_cms(target_climb_rate);
 
     // if not armed set throttle to zero and exit immediately
     if (is_disarmed_or_landed()) {

--- a/ArduCopter/mode_drift.cpp
+++ b/ArduCopter/mode_drift.cpp
@@ -46,7 +46,7 @@ void ModeDrift::run()
 
     // convert pilot input to lean angles
     float target_roll_cd, target_pitch_cd;
-    get_pilot_desired_lean_angles(target_roll_cd, target_pitch_cd, copter.aparm.angle_max, copter.aparm.angle_max);
+    get_pilot_desired_lean_angles_cd(target_roll_cd, target_pitch_cd, copter.aparm.angle_max, copter.aparm.angle_max);
 
     // Grab inertial velocity
     const Vector3f& vel_NEU_cms = pos_control->get_vel_estimate_NEU_cms();

--- a/ArduCopter/mode_flip.cpp
+++ b/ArduCopter/mode_flip.cpp
@@ -20,11 +20,11 @@
  *          FlipState::Recover (while copter is between -90deg and original target angle) : use earth frame angle controller to return vehicle to original attitude
  */
 
-#define FLIP_THR_INC        0.20f   // throttle increase during FlipState::Start stage (under 45deg lean angle)
-#define FLIP_THR_DEC        0.24f   // throttle decrease during FlipState::Roll stage (between 45deg ~ -90deg roll)
-#define FLIP_ROTATION_RATE  40000   // rotation rate request in centi-degrees / sec (i.e. 400 deg/sec)
-#define FLIP_TIMEOUT_MS     2500    // timeout after 2.5sec.  Vehicle will switch back to original flight mode
-#define FLIP_RECOVERY_ANGLE 500     // consider successful recovery when roll is back within 5 degrees of original
+#define FLIP_THR_INC            0.20f   // throttle increase during FlipState::Start stage (under 45deg lean angle)
+#define FLIP_THR_DEC            0.24f   // throttle decrease during FlipState::Roll stage (between 45deg ~ -90deg roll)
+#define FLIP_ROTATION_RATE_CDS  40000   // rotation rate request in centi-degrees / sec (i.e. 400 deg/sec)
+#define FLIP_TIMEOUT_MS         2500    // timeout after 2.5sec.  Vehicle will switch back to original flight mode
+#define FLIP_RECOVERY_ANGLE_CD  500     // consider successful recovery when roll is back within 5 degrees of original
 
 #define FLIP_ROLL_RIGHT      1      // used to set flip_dir
 #define FLIP_ROLL_LEFT      -1      // used to set flip_dir
@@ -80,9 +80,9 @@ bool ModeFlip::init(bool ignore_checks)
 
     // capture current attitude which will be used during the FlipState::Recovery stage
     const float angle_max = copter.aparm.angle_max;
-    orig_attitude.x = constrain_float(ahrs.roll_sensor, -angle_max, angle_max);
-    orig_attitude.y = constrain_float(ahrs.pitch_sensor, -angle_max, angle_max);
-    orig_attitude.z = ahrs.yaw_sensor;
+    orig_attitude_euler_cd.x = constrain_float(ahrs.roll_sensor, -angle_max, angle_max);
+    orig_attitude_euler_cd.y = constrain_float(ahrs.pitch_sensor, -angle_max, angle_max);
+    orig_attitude_euler_cd.z = ahrs.yaw_sensor;
 
     return true;
 }
@@ -103,13 +103,13 @@ void ModeFlip::run()
     motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
     // get corrected angle based on direction and axis of rotation
-    // we flip the sign of flip_angle to minimize the code repetition
-    int32_t flip_angle;
+    // we flip the sign of flip_angle_cd to minimize the code repetition
+    int32_t flip_angle_cd;
 
     if (roll_dir != 0) {
-        flip_angle = ahrs.roll_sensor * roll_dir;
+        flip_angle_cd = ahrs.roll_sensor * roll_dir;
     } else {
-        flip_angle = ahrs.pitch_sensor * pitch_dir;
+        flip_angle_cd = ahrs.pitch_sensor * pitch_dir;
     }
 
     // state machine
@@ -117,13 +117,13 @@ void ModeFlip::run()
 
     case FlipState::Start:
         // under 45 degrees request 400deg/sec roll or pitch
-        attitude_control->input_rate_bf_roll_pitch_yaw_cds(FLIP_ROTATION_RATE * roll_dir, FLIP_ROTATION_RATE * pitch_dir, 0.0);
+        attitude_control->input_rate_bf_roll_pitch_yaw_cds(FLIP_ROTATION_RATE_CDS * roll_dir, FLIP_ROTATION_RATE_CDS * pitch_dir, 0.0);
 
         // increase throttle
         throttle_out += FLIP_THR_INC;
 
         // beyond 45deg lean angle move to next stage
-        if (flip_angle >= 4500) {
+        if (flip_angle_cd >= 4500) {
             if (roll_dir != 0) {
                 // we are rolling
             _state = FlipState::Roll;
@@ -136,58 +136,58 @@ void ModeFlip::run()
 
     case FlipState::Roll:
         // between 45deg ~ -90deg request 400deg/sec roll
-        attitude_control->input_rate_bf_roll_pitch_yaw_cds(FLIP_ROTATION_RATE * roll_dir, 0.0, 0.0);
+        attitude_control->input_rate_bf_roll_pitch_yaw_cds(FLIP_ROTATION_RATE_CDS * roll_dir, 0.0, 0.0);
         // decrease throttle
         throttle_out = MAX(throttle_out - FLIP_THR_DEC, 0.0f);
 
         // beyond -90deg move on to recovery
-        if ((flip_angle < 4500) && (flip_angle > -9000)) {
+        if ((flip_angle_cd < 4500) && (flip_angle_cd > -9000)) {
             _state = FlipState::Recover;
         }
         break;
 
     case FlipState::Pitch_A:
         // between 45deg ~ -90deg request 400deg/sec pitch
-        attitude_control->input_rate_bf_roll_pitch_yaw_cds(0.0f, FLIP_ROTATION_RATE * pitch_dir, 0.0);
+        attitude_control->input_rate_bf_roll_pitch_yaw_cds(0.0f, FLIP_ROTATION_RATE_CDS * pitch_dir, 0.0);
         // decrease throttle
         throttle_out = MAX(throttle_out - FLIP_THR_DEC, 0.0f);
 
         // check roll for inversion
-        if ((labs(ahrs.roll_sensor) > 9000) && (flip_angle > 4500)) {
+        if ((labs(ahrs.roll_sensor) > 9000) && (flip_angle_cd > 4500)) {
             _state = FlipState::Pitch_B;
         }
         break;
 
     case FlipState::Pitch_B:
         // between 45deg ~ -90deg request 400deg/sec pitch
-        attitude_control->input_rate_bf_roll_pitch_yaw_cds(0.0, FLIP_ROTATION_RATE * pitch_dir, 0.0);
+        attitude_control->input_rate_bf_roll_pitch_yaw_cds(0.0, FLIP_ROTATION_RATE_CDS * pitch_dir, 0.0);
         // decrease throttle
         throttle_out = MAX(throttle_out - FLIP_THR_DEC, 0.0f);
 
         // check roll for inversion
-        if ((labs(ahrs.roll_sensor) < 9000) && (flip_angle > -4500)) {
+        if ((labs(ahrs.roll_sensor) < 9000) && (flip_angle_cd > -4500)) {
             _state = FlipState::Recover;
         }
         break;
 
     case FlipState::Recover: {
         // use originally captured earth-frame angle targets to recover
-        attitude_control->input_euler_angle_roll_pitch_yaw_cd(orig_attitude.x, orig_attitude.y, orig_attitude.z, false);
+        attitude_control->input_euler_angle_roll_pitch_yaw_cd(orig_attitude_euler_cd.x, orig_attitude_euler_cd.y, orig_attitude_euler_cd.z, false);
 
         // increase throttle to gain any lost altitude
         throttle_out += FLIP_THR_INC;
 
-        float recovery_angle;
+        float recovery_angle_cd;
         if (roll_dir != 0) {
             // we are rolling
-            recovery_angle = fabsf(orig_attitude.x - (float)ahrs.roll_sensor);
+            recovery_angle_cd = fabsf(orig_attitude_euler_cd.x - (float)ahrs.roll_sensor);
         } else {
             // we are pitching
-            recovery_angle = fabsf(orig_attitude.y - (float)ahrs.pitch_sensor);
+            recovery_angle_cd = fabsf(orig_attitude_euler_cd.y - (float)ahrs.pitch_sensor);
         }
 
         // check for successful recovery
-        if (fabsf(recovery_angle) <= FLIP_RECOVERY_ANGLE) {
+        if (fabsf(recovery_angle_cd) <= FLIP_RECOVERY_ANGLE_CD) {
             // restore original flight mode
             if (!copter.set_mode(orig_control_mode, ModeReason::FLIP_COMPLETE)) {
                 // this should never happen but just in case

--- a/ArduCopter/mode_flowhold.cpp
+++ b/ArduCopter/mode_flowhold.cpp
@@ -248,7 +248,7 @@ void ModeFlowHold::run()
     target_climb_rate_cms = constrain_float(target_climb_rate_cms, -get_pilot_speed_dn(), copter.g.pilot_speed_up);
 
     // get pilot's desired yaw rate
-    float target_yaw_rate_cds = get_pilot_desired_yaw_rate();
+    float target_yaw_rate_cds = get_pilot_desired_yaw_rate_cds();
 
     // Flow Hold State Machine Determination
     AltHoldModeState flowhold_state = get_alt_hold_state(target_climb_rate_cms);
@@ -281,7 +281,7 @@ void ModeFlowHold::run()
         }
 
         // get avoidance adjusted climb rate
-        target_climb_rate_cms = get_avoidance_adjusted_climbrate(target_climb_rate_cms);
+        target_climb_rate_cms = get_avoidance_adjusted_climbrate_cms(target_climb_rate_cms);
 
         // set position controller targets adjusted for pilot input
         takeoff.do_pilot_takeoff(target_climb_rate_cms);
@@ -300,7 +300,7 @@ void ModeFlowHold::run()
         copter.motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
         // get avoidance adjusted climb rate
-        target_climb_rate_cms = get_avoidance_adjusted_climbrate(target_climb_rate_cms);
+        target_climb_rate_cms = get_avoidance_adjusted_climbrate_cms(target_climb_rate_cms);
 
 #if AP_RANGEFINDER_ENABLED
         // update the vertical offset based on the surface measurement
@@ -319,7 +319,7 @@ void ModeFlowHold::run()
     int16_t roll_in = copter.channel_roll->get_control_in();
     int16_t pitch_in = copter.channel_pitch->get_control_in();
     float angle_max_cd = copter.aparm.angle_max;
-    get_pilot_desired_lean_angles(bf_angles_cd.x, bf_angles_cd.y, angle_max_cd, attitude_control->get_althold_lean_angle_max_cd());
+    get_pilot_desired_lean_angles_cd(bf_angles_cd.x, bf_angles_cd.y, angle_max_cd, attitude_control->get_althold_lean_angle_max_cd());
 
     if (quality_filtered >= flow_min_quality &&
         AP_HAL::millis() - copter.arm_time_ms > 3000) {

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -952,7 +952,7 @@ void ModeGuided::angle_control_run()
         climb_rate_cms = constrain_float(guided_angle_state.climb_rate_cms, -wp_nav->get_default_speed_down_cms(), wp_nav->get_default_speed_up_cms());
 
         // get avoidance adjusted climb rate
-        climb_rate_cms = get_avoidance_adjusted_climbrate(climb_rate_cms);
+        climb_rate_cms = get_avoidance_adjusted_climbrate_cms(climb_rate_cms);
     }
 
     // check for timeout - set lean angles and climb rate to zero if no updates received for 3 seconds
@@ -1018,9 +1018,9 @@ void ModeGuided::set_yaw_state(bool use_yaw, float yaw_cd, bool use_yaw_rate, fl
     if (use_yaw && relative_angle) {
         auto_yaw.set_fixed_yaw(yaw_cd * 0.01f, 0.0f, 0, relative_angle);
     } else if (use_yaw && use_yaw_rate) {
-        auto_yaw.set_yaw_angle_rate(yaw_cd * 0.01f, yaw_rate_cds * 0.01f);
+        auto_yaw.set_yaw_angle_and_rate_deg(yaw_cd * 0.01f, yaw_rate_cds * 0.01f);
     } else if (use_yaw && !use_yaw_rate) {
-        auto_yaw.set_yaw_angle_rate(yaw_cd * 0.01f, 0.0f);
+        auto_yaw.set_yaw_angle_and_rate_deg(yaw_cd * 0.01f, 0.0f);
     } else if (use_yaw_rate) {
         auto_yaw.set_rate(yaw_rate_cds);
     } else {

--- a/ArduCopter/mode_land.cpp
+++ b/ArduCopter/mode_land.cpp
@@ -92,7 +92,7 @@ void ModeLand::gps_run()
 //      should be called at 100hz or more
 void ModeLand::nogps_run()
 {
-    float target_roll = 0.0f, target_pitch = 0.0f;
+    float target_roll_cd = 0.0f, target_pitch_cd = 0.0f;
 
     // process pilot inputs
     if (rc().has_valid_input()) {
@@ -107,7 +107,7 @@ void ModeLand::nogps_run()
             update_simple_mode();
 
             // get pilot desired lean angles
-            get_pilot_desired_lean_angles(target_roll, target_pitch, copter.aparm.angle_max, attitude_control->get_althold_lean_angle_max_cd());
+            get_pilot_desired_lean_angles_cd(target_roll_cd, target_pitch_cd, copter.aparm.angle_max, attitude_control->get_althold_lean_angle_max_cd());
         }
 
     }
@@ -133,7 +133,7 @@ void ModeLand::nogps_run()
     }
 
     // call attitude controller
-    attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(target_roll, target_pitch, auto_yaw.get_heading().yaw_rate_cds);
+    attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(target_roll_cd, target_pitch_cd, auto_yaw.get_heading().yaw_rate_cds);
 }
 
 // do_not_use_GPS - forces land-mode to not use the GPS but instead rely on pilot input for roll and pitch

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -83,10 +83,10 @@ void ModePosHold::run()
 
     // convert pilot input to lean angles
     float target_roll_cd, target_pitch_cd;
-    get_pilot_desired_lean_angles(target_roll_cd, target_pitch_cd, copter.aparm.angle_max, attitude_control->get_althold_lean_angle_max_cd());
+    get_pilot_desired_lean_angles_cd(target_roll_cd, target_pitch_cd, copter.aparm.angle_max, attitude_control->get_althold_lean_angle_max_cd());
 
     // get pilot's desired yaw rate
-    float target_yaw_rate_cds = get_pilot_desired_yaw_rate();
+    float target_yaw_rate_cds = get_pilot_desired_yaw_rate_cds();
 
     // get pilot desired climb rate (for alt-hold mode and take-off)
     float target_climb_rate_cms = get_pilot_desired_climb_rate();
@@ -141,7 +141,7 @@ void ModePosHold::run()
         }
 
         // get avoidance adjusted climb rate
-        target_climb_rate_cms = get_avoidance_adjusted_climbrate(target_climb_rate_cms);
+        target_climb_rate_cms = get_avoidance_adjusted_climbrate_cms(target_climb_rate_cms);
 
         // set position controller targets adjusted for pilot input
         takeoff.do_pilot_takeoff(target_climb_rate_cms);
@@ -159,7 +159,7 @@ void ModePosHold::run()
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
         // get avoidance adjusted climb rate
-        target_climb_rate_cms = get_avoidance_adjusted_climbrate(target_climb_rate_cms);
+        target_climb_rate_cms = get_avoidance_adjusted_climbrate_cms(target_climb_rate_cms);
 
 #if AP_RANGEFINDER_ENABLED
         // update the vertical offset based on the surface measurement

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -193,7 +193,7 @@ void ModeRTL::loiterathome_start()
 
     // yaw back to initial take-off heading yaw unless pilot has already overridden yaw
     if (auto_yaw.default_mode(true) != AutoYaw::Mode::HOLD) {
-        auto_yaw.set_mode(AutoYaw::Mode::RESETTOARMEDYAW);
+        auto_yaw.set_mode(AutoYaw::Mode::RESET_TO_ARMED_YAW);
     } else {
         auto_yaw.set_mode(AutoYaw::Mode::HOLD);
     }
@@ -224,7 +224,7 @@ void ModeRTL::loiterathome_run()
 
     // check if we've completed this stage of RTL
     if ((millis() - _loiter_start_time) >= (uint32_t)g.rtl_loiter_time.get()) {
-        if (auto_yaw.mode() == AutoYaw::Mode::RESETTOARMEDYAW) {
+        if (auto_yaw.mode() == AutoYaw::Mode::RESET_TO_ARMED_YAW) {
             // check if heading is within 2 degrees of heading when vehicle was armed
             if (abs(wrap_180_cd(ahrs.yaw_sensor-copter.initial_armed_bearing)) <= 200) {
                 _state_complete = true;

--- a/ArduCopter/mode_sport.cpp
+++ b/ArduCopter/mode_sport.cpp
@@ -62,7 +62,7 @@ void ModeSport::run()
     }
 
     // get pilot's desired yaw rate
-    float target_yaw_rate_cds = get_pilot_desired_yaw_rate();
+    float target_yaw_rate_cds = get_pilot_desired_yaw_rate_cds();
 
     // get pilot desired climb rate
     float target_climb_rate_cms = get_pilot_desired_climb_rate();
@@ -96,7 +96,7 @@ void ModeSport::run()
         }
 
         // get avoidance adjusted climb rate
-        target_climb_rate_cms = get_avoidance_adjusted_climbrate(target_climb_rate_cms);
+        target_climb_rate_cms = get_avoidance_adjusted_climbrate_cms(target_climb_rate_cms);
 
         // set position controller targets adjusted for pilot input
         takeoff.do_pilot_takeoff(target_climb_rate_cms);
@@ -106,7 +106,7 @@ void ModeSport::run()
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
         // get avoidance adjusted climb rate
-        target_climb_rate_cms = get_avoidance_adjusted_climbrate(target_climb_rate_cms);
+        target_climb_rate_cms = get_avoidance_adjusted_climbrate_cms(target_climb_rate_cms);
 
 #if AP_RANGEFINDER_ENABLED
         // update the vertical offset based on the surface measurement

--- a/ArduCopter/mode_stabilize.cpp
+++ b/ArduCopter/mode_stabilize.cpp
@@ -12,11 +12,11 @@ void ModeStabilize::run()
     update_simple_mode();
 
     // convert pilot input to lean angles
-    float target_roll, target_pitch;
-    get_pilot_desired_lean_angles(target_roll, target_pitch, copter.aparm.angle_max, copter.aparm.angle_max);
+    float target_roll_cd, target_pitch_cd;
+    get_pilot_desired_lean_angles_cd(target_roll_cd, target_pitch_cd, copter.aparm.angle_max, copter.aparm.angle_max);
 
     // get pilot's desired yaw rate
-    float target_yaw_rate = get_pilot_desired_yaw_rate();
+    float target_yaw_rate_cds = get_pilot_desired_yaw_rate_cds();
 
     if (!motors->armed()) {
         // Motors should be Stopped
@@ -63,7 +63,7 @@ void ModeStabilize::run()
     }
 
     // call attitude controller
-    attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(target_roll, target_pitch, target_yaw_rate);
+    attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(target_roll_cd, target_pitch_cd, target_yaw_rate_cds);
 
     // output pilot's throttle
     attitude_control->set_throttle_out(pilot_desired_throttle, true, g.throttle_filt);

--- a/ArduCopter/mode_stabilize_heli.cpp
+++ b/ArduCopter/mode_stabilize_heli.cpp
@@ -21,17 +21,17 @@ bool ModeStabilize_Heli::init(bool ignore_checks)
 // should be called at 100hz or more
 void ModeStabilize_Heli::run()
 {
-    float target_roll, target_pitch;
+    float target_roll_cd, target_pitch_cd;
     float pilot_throttle_scaled;
 
     // apply SIMPLE mode transform to pilot inputs
     update_simple_mode();
 
     // convert pilot input to lean angles
-    get_pilot_desired_lean_angles(target_roll, target_pitch, copter.aparm.angle_max, copter.aparm.angle_max);
+    get_pilot_desired_lean_angles_cd(target_roll_cd, target_pitch_cd, copter.aparm.angle_max, copter.aparm.angle_max);
 
     // get pilot's desired yaw rate
-    float target_yaw_rate = get_pilot_desired_yaw_rate();
+    float target_yaw_rate = get_pilot_desired_yaw_rate_cds();
 
     // get pilot's desired throttle
     pilot_throttle_scaled = copter.input_manager.get_pilot_desired_collective(channel_throttle->get_control_in());
@@ -75,7 +75,7 @@ void ModeStabilize_Heli::run()
     }
 
     // call attitude controller
-    attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(target_roll, target_pitch, target_yaw_rate);
+    attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(target_roll_cd, target_pitch_cd, target_yaw_rate);
 
     // output pilot's throttle
     attitude_control->set_throttle_out(pilot_throttle_scaled, true, g.throttle_filt);

--- a/ArduCopter/mode_systemid.cpp
+++ b/ArduCopter/mode_systemid.cpp
@@ -161,9 +161,9 @@ void ModeSystemId::exit()
 // should be called at 100hz or more
 void ModeSystemId::run()
 {
-    float target_roll = 0.0f;
-    float target_pitch = 0.0f;
-    float target_yaw_rate = 0.0f;
+    float target_roll_cd = 0.0f;
+    float target_pitch_cd = 0.0f;
+    float target_yaw_rate_cds = 0.0f;
     float pilot_throttle_scaled = 0.0f;
     float target_climb_rate = 0.0f;
     Vector2f input_vel;
@@ -174,10 +174,10 @@ void ModeSystemId::run()
         update_simple_mode();
 
         // convert pilot input to lean angles
-        get_pilot_desired_lean_angles(target_roll, target_pitch, copter.aparm.angle_max, copter.aparm.angle_max);
+        get_pilot_desired_lean_angles_cd(target_roll_cd, target_pitch_cd, copter.aparm.angle_max, copter.aparm.angle_max);
 
         // get pilot's desired yaw rate
-        target_yaw_rate = get_pilot_desired_yaw_rate();
+        target_yaw_rate_cds = get_pilot_desired_yaw_rate_cds();
 
         if (!motors->armed()) {
             // Motors should be Stopped
@@ -268,24 +268,24 @@ void ModeSystemId::run()
                     gcs().send_text(MAV_SEVERITY_INFO, "SystemID Stopped: axis = 0");
                     break;
                 case AxisType::INPUT_ROLL:
-                    target_roll += waveform_sample*100.0f;
+                    target_roll_cd += waveform_sample*100.0f;
                     break;
                 case AxisType::INPUT_PITCH:
-                    target_pitch += waveform_sample*100.0f;
+                    target_pitch_cd += waveform_sample*100.0f;
                     break;
                 case AxisType::INPUT_YAW:
-                    target_yaw_rate += waveform_sample*100.0f;
+                    target_yaw_rate_cds += waveform_sample*100.0f;
                     break;
                 case AxisType::RECOVER_ROLL:
-                    target_roll += waveform_sample*100.0f;
+                    target_roll_cd += waveform_sample*100.0f;
                     attitude_control->bf_feedforward(false);
                     break;
                 case AxisType::RECOVER_PITCH:
-                    target_pitch += waveform_sample*100.0f;
+                    target_pitch_cd += waveform_sample*100.0f;
                     attitude_control->bf_feedforward(false);
                     break;
                 case AxisType::RECOVER_YAW:
-                    target_yaw_rate += waveform_sample*100.0f;
+                    target_yaw_rate_cds += waveform_sample*100.0f;
                     attitude_control->bf_feedforward(false);
                     break;
                 case AxisType::RATE_ROLL:
@@ -350,7 +350,7 @@ void ModeSystemId::run()
     if (!is_poscontrol_axis_type()) {
 
         // call attitude controller
-        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(target_roll, target_pitch, target_yaw_rate);
+        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(target_roll_cd, target_pitch_cd, target_yaw_rate_cds);
 
         // output pilot's throttle
         attitude_control->set_throttle_out(pilot_throttle_scaled, !copter.is_tradheli(), g.throttle_filt);
@@ -374,7 +374,7 @@ void ModeSystemId::run()
         pos_control->update_NE_controller();
 
         // call attitude controller
-        attitude_control->input_thrust_vector_rate_heading_cds(pos_control->get_thrust_vector(), target_yaw_rate, false);
+        attitude_control->input_thrust_vector_rate_heading_cds(pos_control->get_thrust_vector(), target_yaw_rate_cds, false);
 
         // Send the commanded climb rate to the position controller
         pos_control->set_pos_target_U_from_climb_rate_cm(target_climb_rate);

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -72,7 +72,7 @@ bool ModeZigZag::init(bool ignore_checks)
 
     // convert pilot input to lean angles
     float target_roll_cd, target_pitch_cd;
-    get_pilot_desired_lean_angles(target_roll_cd, target_pitch_cd, loiter_nav->get_angle_max_cd(), attitude_control->get_althold_lean_angle_max_cd());
+    get_pilot_desired_lean_angles_cd(target_roll_cd, target_pitch_cd, loiter_nav->get_angle_max_cd(), attitude_control->get_althold_lean_angle_max_cd());
 
     // process pilot's roll and pitch input
     loiter_nav->set_pilot_desired_acceleration_cd(target_roll_cd, target_pitch_cd);
@@ -257,7 +257,7 @@ void ModeZigZag::return_to_manual_control(bool maintain_target)
 void ModeZigZag::auto_control()
 {
     // process pilot's yaw input
-    const float target_yaw_rate_cds = get_pilot_desired_yaw_rate();
+    const float target_yaw_rate_cds = get_pilot_desired_yaw_rate_cds();
 
     // set motors to full range
     motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
@@ -292,13 +292,13 @@ void ModeZigZag::manual_control()
     update_simple_mode();
 
     // convert pilot input to lean angles
-    get_pilot_desired_lean_angles(target_roll_cd, target_pitch_cd, loiter_nav->get_angle_max_cd(), attitude_control->get_althold_lean_angle_max_cd());
+    get_pilot_desired_lean_angles_cd(target_roll_cd, target_pitch_cd, loiter_nav->get_angle_max_cd(), attitude_control->get_althold_lean_angle_max_cd());
 
     // process pilot's roll and pitch input
     loiter_nav->set_pilot_desired_acceleration_cd(target_roll_cd, target_pitch_cd);
 
     // get pilot's desired yaw rate
-    target_yaw_rate_cds = get_pilot_desired_yaw_rate();
+    target_yaw_rate_cds = get_pilot_desired_yaw_rate_cds();
 
     // get pilot desired climb rate
     target_climb_rate_cd = get_pilot_desired_climb_rate();
@@ -331,7 +331,7 @@ void ModeZigZag::manual_control()
         }
 
         // get avoidance adjusted climb rate
-        target_climb_rate_cd = get_avoidance_adjusted_climbrate(target_climb_rate_cd);
+        target_climb_rate_cd = get_avoidance_adjusted_climbrate_cms(target_climb_rate_cd);
 
         // run loiter controller
         loiter_nav->update();
@@ -365,7 +365,7 @@ void ModeZigZag::manual_control()
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(loiter_nav->get_roll_cd(), loiter_nav->get_pitch_cd(), target_yaw_rate_cds);
 
         // get avoidance adjusted climb rate
-        target_climb_rate_cd = get_avoidance_adjusted_climbrate(target_climb_rate_cd);
+        target_climb_rate_cd = get_avoidance_adjusted_climbrate_cms(target_climb_rate_cd);
 
 #if AP_RANGEFINDER_ENABLED
         // update the vertical offset based on the surface measurement

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2184,7 +2184,7 @@ void QuadPlane::run_xy_controller(float accel_limit)
     if (!pos_control->is_active_NE()) {
         pos_control->init_NE_controller();
     }
-    pos_control->set_lean_angle_max_cd(MIN(4500, MAX(accel_to_angle(accel_limit)*100, aparm.angle_max)));
+    pos_control->set_lean_angle_max_cd(MIN(4500, MAX(accel_mss_to_angle_deg(accel_limit)*100, aparm.angle_max)));
     if (q_fwd_throttle > 0.95f) {
         // prevent wind up of the velocity controller I term due to a saturated forward throttle
         pos_control->set_externally_limited_NE();

--- a/ArduSub/mode.h
+++ b/ArduSub/mode.h
@@ -151,7 +151,7 @@ public:
         // rate_cds(): desired yaw rate in centidegrees/second:
         float rate_cds();
 
-        float look_ahead_yaw();
+        float look_ahead_yaw_deg();
         float roi_yaw();
 
         // auto flight mode's yaw mode
@@ -170,7 +170,7 @@ public:
         int16_t _fixed_yaw_slewrate;
 
         // heading when in yaw_look_ahead_yaw
-        float _look_ahead_yaw;
+        float _look_ahead_yaw_deg;
 
         // used to reduce update rate to 100hz:
         uint8_t roi_yaw_counter;

--- a/libraries/AC_Autorotation/AC_Autorotation.cpp
+++ b/libraries/AC_Autorotation/AC_Autorotation.cpp
@@ -42,7 +42,7 @@ const AP_Param::GroupInfo AC_Autorotation::var_info[] = {
     // @Range: 8 20
     // @Increment: 0.5
     // @User: Standard
-    AP_GROUPINFO("FWD_SP_TARG", 4, AC_Autorotation, _param_target_speed, 11),
+    AP_GROUPINFO("FWD_SP_TARG", 4, AC_Autorotation, _param_target_speed_ms, 11),
 
     // @Param: COL_FILT_E
     // @DisplayName: Entry Phase Collective Filter
@@ -69,7 +69,7 @@ const AP_Param::GroupInfo AC_Autorotation::var_info[] = {
     // @Range: 0.5 8.0
     // @Increment: 0.1
     // @User: Standard
-    AP_GROUPINFO("XY_ACC_MAX", 7, AC_Autorotation, _param_accel_max, 2.0),
+    AP_GROUPINFO("XY_ACC_MAX", 7, AC_Autorotation, _param_accel_max_mss, 2.0),
 
     // @Param: HS_SENSOR
     // @DisplayName: Main Rotor RPM Sensor 
@@ -178,8 +178,8 @@ void AC_Autorotation::init_entry(void)
     _motors_heli->set_throttle_filter_cutoff(2.0);
 
     // Set speed target to maintain the current speed whilst we enter the autorotation
-    _desired_vel = _param_target_speed.get();
-    _target_vel = get_speed_forward();
+    _desired_vel_ms = _param_target_speed_ms.get();
+    _target_vel_ms = get_speed_forward_ms();
 
     // Reset I term of velocity PID
     _fwd_speed_pid.reset_filter();
@@ -187,7 +187,7 @@ void AC_Autorotation::init_entry(void)
 }
 
 // The entry controller just a special case of the glide controller with head speed target slewing
-void AC_Autorotation::run_entry(float pilot_norm_accel)
+void AC_Autorotation::run_entry(float pilot_accel_norm)
 {
     // Slowly change the target head speed until the target head speed matches the parameter defined value
     float head_speed_norm;
@@ -201,7 +201,7 @@ void AC_Autorotation::run_entry(float pilot_norm_accel)
     const float max_change = _hs_accel * _dt;
     _target_head_speed = constrain_float(HEAD_SPEED_TARGET_RATIO, _target_head_speed - max_change, _target_head_speed + max_change);
 
-    run_glide(pilot_norm_accel);
+    run_glide(pilot_accel_norm);
 }
 
 // Functions and config that are only to be done once at the beginning of the glide
@@ -216,15 +216,15 @@ void AC_Autorotation::init_glide(void)
     _target_head_speed = HEAD_SPEED_TARGET_RATIO;
 
     // Ensure desired forward speed target is set to param value
-    _desired_vel = _param_target_speed.get();
+    _desired_vel_ms = _param_target_speed_ms.get();
 }
 
 // Maintain head speed and forward speed as we glide to the ground
-void AC_Autorotation::run_glide(float pilot_norm_accel)
+void AC_Autorotation::run_glide(float pilot_accel_norm)
 {
     update_headspeed_controller();
 
-    update_forward_speed_controller(pilot_norm_accel);
+    update_forward_speed_controller(pilot_accel_norm);
 }
 
 void AC_Autorotation::update_headspeed_controller(void)
@@ -307,34 +307,35 @@ bool AC_Autorotation::get_norm_head_speed(float& norm_rpm) const
 }
 
 // Update speed controller
-void AC_Autorotation::update_forward_speed_controller(float pilot_norm_accel)
+void AC_Autorotation::update_forward_speed_controller(float pilot_accel_norm)
 {
     // Limiting the desired velocity based on the max acceleration limit to get an update target
-    const float min_vel = _target_vel - get_accel_max() * _dt;
-    const float max_vel = _target_vel + get_accel_max() * _dt;
-    _target_vel = constrain_float(_desired_vel, min_vel, max_vel); // (m/s)
+    const float min_vel_ms = _target_vel_ms - get_accel_max_mss() * _dt;
+    const float max_vel_ms = _target_vel_ms + get_accel_max_mss() * _dt;
+    _target_vel_ms = constrain_float(_desired_vel_ms, min_vel_ms, max_vel_ms); // (m/s)
 
     // Calculate acceleration target
-    const float fwd_accel_target  = _fwd_speed_pid.update_all(_target_vel, get_speed_forward(), _dt, _limit_accel); // (m/s/s)
+    const float fwd_accel_target_mss  = _fwd_speed_pid.update_all(_target_vel_ms, get_speed_forward_ms(), _dt, _limit_accel); // (m/s/s)
 
     // Build the body frame XY accel vector.
     // Pilot can request as much as 1/2 of the max accel laterally to perform a turn.
     // We only allow up to half as we need to prioritize building/maintaining airspeed.
-    Vector2f bf_accel_target = {fwd_accel_target, pilot_norm_accel * get_accel_max() * 0.5};
+    Vector2f bf_accel_target_mss = {fwd_accel_target_mss, pilot_accel_norm * get_accel_max_mss() * 0.5};
 
     // Ensure we do not exceed the accel limit
-    _limit_accel = bf_accel_target.limit_length(get_accel_max());
+    _limit_accel = bf_accel_target_mss.limit_length(get_accel_max_mss());
 
     // Calculate roll and pitch targets from angles, negative accel for negative pitch (pitch forward)
-    Vector2f angle_target = { accel_to_angle(-bf_accel_target.x), // Pitch
-                              accel_to_angle(bf_accel_target.y)}; // Roll
+    Vector2f angle_target_deg = { accel_mss_to_angle_deg(-bf_accel_target_mss.x), // Pitch
+                              accel_mss_to_angle_deg(bf_accel_target_mss.y)}; // Roll
 
     // Ensure that the requested angles do not exceed angle max
-    _limit_accel |= angle_target.limit_length(_attitude_control->lean_angle_max_cd());
+    // todo: FIX BUG: degrees limited in centidegrees
+    _limit_accel |= angle_target_deg.limit_length(_attitude_control->lean_angle_max_cd());
 
     // we may have scaled the lateral accel in the angle limit scaling, so we need to
     // back calculate the resulting accel from this constrained angle for the yaw rate calc
-    const float bf_lat_accel_target = angle_to_accel(angle_target.y);
+    const float bf_lat_accel_target_mss = angle_deg_to_accel_mss(angle_target_deg.y);
 
     // Calc yaw rate from desired body-frame accels
     // this seems suspiciously simple, but it is correct
@@ -348,12 +349,12 @@ void AC_Autorotation::update_forward_speed_controller(float pilot_norm_accel)
     // accel = s * w
     // w = accel / s
     float yaw_rate_cds = 0.0;
-    if (!is_zero(_target_vel)) {
-        yaw_rate_cds = degrees(bf_lat_accel_target / _target_vel) * 100.0;
+    if (!is_zero(_target_vel_ms)) {
+        yaw_rate_cds = degrees(bf_lat_accel_target_mss / _target_vel_ms) * 100.0;
     }
 
     // Output to attitude controller
-    _attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(angle_target.y * 100.0, angle_target.x * 100.0, yaw_rate_cds);
+    _attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(angle_target_deg.y * 100.0, angle_target_deg.x * 100.0, yaw_rate_cds);
 
 #if HAL_LOGGING_ENABLED
     // @LoggerMessage: ARSC
@@ -378,7 +379,7 @@ void AC_Autorotation::update_forward_speed_controller(float pilot_norm_accel)
                                 "F0000000-00",
                                 "QfffffffBff",
                                 AP_HAL::micros64(),
-                                _desired_vel,
+                                _desired_vel_ms,
                                 pid_info.target,
                                 pid_info.actual,
                                 pid_info.P,
@@ -386,20 +387,20 @@ void AC_Autorotation::update_forward_speed_controller(float pilot_norm_accel)
                                 pid_info.D,
                                 pid_info.FF,
                                 uint8_t(_limit_accel),
-                                bf_accel_target.x,
-                                bf_accel_target.y);
+                                bf_accel_target_mss.x,
+                                bf_accel_target_mss.y);
 #endif
 }
 
 // smoothly zero velocity and accel
 void AC_Autorotation::run_landed(void)
 {
-    _desired_vel *= 0.95;
+    _desired_vel_ms *= 0.95;
     update_forward_speed_controller(0.0);
 }
 
 // Determine the body frame forward speed
-float AC_Autorotation::get_speed_forward(void) const
+float AC_Autorotation::get_speed_forward_ms(void) const
 {
     Vector3f vel_NED = {0,0,0};
     const AP_AHRS &ahrs = AP::ahrs();

--- a/libraries/AC_Autorotation/AC_Autorotation.h
+++ b/libraries/AC_Autorotation/AC_Autorotation.h
@@ -59,7 +59,7 @@ private:
     AC_AttitudeControl*& _attitude_control;
 
     // Calculates the forward ground speed in the horizontal plane
-    float get_speed_forward(void) const;
+    float get_speed_forward_ms(void) const;
 
     // (s) Time step, updated dynamically from vehicle
     float _dt; 
@@ -68,10 +68,10 @@ private:
     AP_Int8  _param_enable;
     AC_P _p_hs{1.0};
     AP_Float _param_head_speed_set_point;
-    AP_Float _param_target_speed;
+    AP_Float _param_target_speed_ms;
     AP_Float _param_col_entry_cutoff_freq;
     AP_Float _param_col_glide_cutoff_freq;
-    AP_Float _param_accel_max;
+    AP_Float _param_accel_max_mss;
     AP_Int8  _param_rpm_instance;
     AP_Float _param_fwd_k_ff;
 
@@ -79,8 +79,8 @@ private:
     void update_forward_speed_controller(float pilot_norm_accel);
     AC_PID_Basic _fwd_speed_pid{2.0, 2.0, 0.2, 0.1, 4.0, 0.0, 10.0};  // PID object for vel to accel controller, Default values for kp, ki, kd, kff, imax, filt E Hz, filt D Hz
     bool _limit_accel;            // flag used for limiting integrator wind up if vehicle is against an accel or angle limit
-    float _desired_vel;           // (m/s) This is the velocity that we want.  This is the variable that is set by the invoking function to request a certain speed
-    float _target_vel;            // (m/s) This is the acceleration constrained velocity that we are allowed
+    float _desired_vel_ms;           // (m/s) This is the velocity that we want.  This is the variable that is set by the invoking function to request a certain speed
+    float _target_vel_ms;            // (m/s) This is the acceleration constrained velocity that we are allowed
 
     // Head speed controller variables
     void update_headspeed_controller(void);  // Update controller used to drive head speed with collective
@@ -99,5 +99,5 @@ private:
     } _landed_reason;
 
     // Parameter accessors that provide value constraints
-    float get_accel_max(void) const { return MAX(_param_accel_max.get(), 0.5); }
+    float get_accel_max_mss(void) const { return MAX(_param_accel_max_mss.get(), 0.5); }
 };

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -73,7 +73,7 @@ public:
     // adjust roll-pitch to push vehicle away from objects
     // roll and pitch value are in centi-degrees
     // angle_max is the user defined maximum lean angle for the vehicle in centi-degrees
-    void adjust_roll_pitch(float &roll, float &pitch, float angle_max);
+    void adjust_roll_pitch(float &roll_cd, float &pitch_cd, float angle_max_cd);
 
     // enable/disable proximity based avoidance
     void proximity_avoidance_enable(bool on_off) { _proximity_enabled = on_off; }
@@ -194,10 +194,10 @@ private:
      */
 
     // convert distance (in meters) to a lean percentage (in 0~1 range) for use in manual flight modes
-    float distance_to_lean_pct(float dist_m);
+    float distance_to_lean_norm(float dist_m);
 
     // returns the maximum positive and negative roll and pitch percentages (in -1 ~ +1 range) based on the proximity sensor
-    void get_proximity_roll_pitch_pct(float &roll_positive, float &roll_negative, float &pitch_positive, float &pitch_negative);
+    void get_proximity_roll_pitch_norm(float &roll_positive, float &roll_negative, float &pitch_positive, float &pitch_negative);
 
     // Logging function
     void Write_SimpleAvoidance(const uint8_t state, const Vector3f& desired_vel, const Vector3f& modified_vel, const bool back_up) const;

--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -218,7 +218,7 @@ void AC_Loiter::calc_desired_velocity(bool avoidance_on)
     float gnd_speed_limit_cms = MIN(_speed_max_ne_cms, ekfGndSpdLimit * 100.0f);
     gnd_speed_limit_cms = MAX(gnd_speed_limit_cms, LOITER_SPEED_MIN);
 
-    float pilot_acceleration_max = angle_to_accel(get_angle_max_cd() * 0.01) * 100;
+    float pilot_acceleration_max = angle_deg_to_accel_mss(get_angle_max_cd() * 0.01) * 100;
 
     // range check dt
     if (is_negative(dt)) {
@@ -242,13 +242,13 @@ void AC_Loiter::calc_desired_velocity(bool avoidance_on)
         // calculate a braking acceleration if sticks are at zero
         float loiter_brake_accel = 0.0f;
         if (_desired_accel_ne_cmss.is_zero()) {
-            if ((AP_HAL::millis() - _brake_timer) > _brake_delay_s * 1000.0f) {
+            if ((AP_HAL::millis() - _brake_timer_ms) > _brake_delay_s * 1000.0f) {
                 float brake_gain = _pos_control.get_vel_NE_pid().kP() * 0.5f;
                 loiter_brake_accel = constrain_float(sqrt_controller(desired_speed, brake_gain, _brake_jerk_max_cmsss, dt), 0.0f, _brake_accel_max_cmss);
             }
         } else {
             loiter_brake_accel = 0.0f;
-            _brake_timer = AP_HAL::millis();
+            _brake_timer_ms = AP_HAL::millis();
         }
         _brake_accel_cmss += constrain_float(loiter_brake_accel - _brake_accel_cmss, -_brake_jerk_max_cmsss * dt, _brake_jerk_max_cmsss * dt);
         loiter_accel_brake = desired_vel_norm * _brake_accel_cmss;

--- a/libraries/AC_WPNav/AC_Loiter.h
+++ b/libraries/AC_WPNav/AC_Loiter.h
@@ -88,6 +88,6 @@ protected:
     Vector2f    _predicted_accel_ne_cmss;   // predicted acceleration in lat/lon frame based on pilot's desired acceleration
     Vector2f    _predicted_euler_angle_rad; // predicted roll/pitch angles in radians based on pilot's desired acceleration
     Vector2f    _predicted_euler_rate;      // predicted roll/pitch rates in radians/sec based on pilot's desired acceleration
-    uint32_t    _brake_timer;               // system time that brake was initiated
+    uint32_t    _brake_timer_ms;            // system time that brake was initiated
     float       _brake_accel_cmss;          // acceleration due to braking from previous iteration (used for jerk limiting)
 };

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -277,7 +277,7 @@ protected:
     Vector3f    _origin_neu_cm;             // starting point of trip to next waypoint in cm from ekf origin
     Vector3f    _destination_neu_cm;        // target destination in cm from ekf origin
     Vector3f    _next_destination_neu_cm;   // next target destination in cm from ekf origin
-    float       _track_scalar_dt;           // time compression multiplier to slow the progress along the track
+    float       _track_dt_scalar;           // time compression multiplier to slow the progress along the track
     float       _offset_vel_cms;            // horizontal velocity reference used to slow the aircraft for pause and to ensure the aircraft can maintain height above terrain
     float       _offset_accel_cmss;         // horizontal acceleration reference used to slow the aircraft for pause and to ensure the aircraft can maintain height above terrain
     bool        _paused;                    // flag for pausing waypoint controller

--- a/libraries/AP_Math/control.cpp
+++ b/libraries/AP_Math/control.cpp
@@ -582,14 +582,14 @@ float input_expo(float input, float expo)
     return input;
 }
 
-// angle_to_accel converts a maximum lean angle in degrees to an accel limit in m/s/s
-float angle_to_accel(float angle_deg)
+// angle_deg_to_accel_mss converts a maximum lean angle in degrees to an accel limit in m/s/s
+float angle_deg_to_accel_mss(float angle_deg)
 {
     return GRAVITY_MSS * tanf(radians(angle_deg));
 }
 
-// accel_to_angle converts a maximum accel in m/s/s to a lean angle in degrees
-float accel_to_angle(float accel)
+// accel_mss_to_angle_deg converts a maximum accel in m/s/s to a lean angle in degrees
+float accel_mss_to_angle_deg(float accel)
 {
     return degrees(atanf((accel/GRAVITY_MSS)));
 }

--- a/libraries/AP_Math/control.h
+++ b/libraries/AP_Math/control.h
@@ -150,11 +150,11 @@ float kinematic_limit(Vector3f direction, float max_xy, float max_z_pos, float m
 // The expo should be less than 1.0 but limited to be less than 0.95.
 float input_expo(float input, float expo);
 
-// angle_to_accel converts a maximum lean angle in degrees to an accel limit in m/s/s
-float angle_to_accel(float angle_deg);
+// angle_deg_to_accel_mss converts a maximum lean angle in degrees to an accel limit in m/s/s
+float angle_deg_to_accel_mss(float angle_deg);
 
-// accel_to_angle converts a maximum accel in m/s/s to a lean angle in degrees
-float accel_to_angle(float accel);
+// accel_mss_to_angle_deg converts a maximum accel in m/s/s to a lean angle in degrees
+float accel_mss_to_angle_deg(float accel);
 
 // rc_input_to_roll_pitch - transform pilot's normalised roll or pitch stick input into a roll and pitch euler angle command
 // roll_in_unit and pitch_in_unit - are normalised roll and pitch stick inputs


### PR DESCRIPTION
This should only be names and units. Nothing should change compiler output.

```
Board,blimp,bootloader,copter,heli,plane,rover,sub
CubeOrange,*,*,*,*,*,*,*
```