### PR TITLE
Copter: Remove most of the remaining _cd() functions

### DIFF
--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -56,8 +56,8 @@ void Copter::update_throttle_hover()
     float throttle = motors->get_throttle();
 
     // calc average throttle if we are in a level hover.  accounts for heli hover roll trim
-    if (throttle > 0.0f && fabsf(vel_d_ms) < 0.6 &&
-        fabsf(ahrs.roll_sensor-attitude_control->get_roll_trim_cd()) < 500 && labs(ahrs.pitch_sensor) < 500) {
+    if ((throttle > 0.0f) && (fabsf(vel_d_ms) < 0.6) &&
+        (fabsf(ahrs.get_roll_rad() - attitude_control->get_roll_trim_rad()) < radians(5)) && (labs(ahrs.get_pitch_rad()) < radians(5))) {
         // Can we set the time constant automatically
         motors->update_throttle_hover(0.01f);
 #if HAL_GYROFFT_ENABLED

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -938,7 +938,7 @@ bool Copter::get_wp_distance_m(float &distance) const
 bool Copter::get_wp_bearing_deg(float &bearing) const
 {
     // see GCS_MAVLINK_Copter::send_nav_controller_output()
-    bearing = flightmode->wp_bearing() * 0.01;
+    bearing = flightmode->wp_bearing_deg();
     return true;
 }
 

--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -208,14 +208,14 @@ void GCS_MAVLINK_Copter::send_nav_controller_output() const
     if (!copter.ap.initialised) {
         return;
     }
-    const Vector3f &targets = copter.attitude_control->get_att_target_euler_cd();
+    const Vector3f &targets_rad = copter.attitude_control->get_att_target_euler_rad();
     const Mode *flightmode = copter.flightmode;
     mavlink_msg_nav_controller_output_send(
         chan,
-        targets.x * 1.0e-2f,
-        targets.y * 1.0e-2f,
-        targets.z * 1.0e-2f,
-        flightmode->wp_bearing() * 1.0e-2f,
+        degrees(targets_rad.x),
+        degrees(targets_rad.y),
+        degrees(targets_rad.z),
+        flightmode->wp_bearing_deg(),
         MIN(flightmode->wp_distance_m(), UINT16_MAX),
         copter.pos_control->get_pos_error_U_cm() * 1.0e-2f,
         0,
@@ -1362,8 +1362,8 @@ uint8_t GCS_MAVLINK_Copter::high_latency_tgt_heading() const
     if (copter.ap.initialised) {
         // return units are deg/2
         const Mode *flightmode = copter.flightmode;
-        // need to convert -18000->18000 to 0->360/2
-        return wrap_360_cd(flightmode->wp_bearing()) / 200;
+        // need to convert -180->180 to 0->360/2
+        return wrap_360(flightmode->wp_bearing_deg()) / 2;
     }
     return 0;     
 }

--- a/ArduCopter/RC_Channel_Copter.cpp
+++ b/ArduCopter/RC_Channel_Copter.cpp
@@ -793,13 +793,13 @@ void RC_Channels_Copter::auto_trim_run()
             return;
         }
         // calculate roll trim adjustment, divisor set subjectively to give same "feel" as previous RC input method
-        float roll_trim_adjustment = radians(copter.attitude_control->get_att_target_euler_cd().x / 2000.0f);
+        float roll_trim_adjustment_rad = copter.attitude_control->get_att_target_euler_rad().x / 20.0f;
 
         // calculate pitch trim adjustment, divisor set subjectively to give same "feel" as previous RC input method
-        float pitch_trim_adjustment = radians(copter.attitude_control->get_att_target_euler_cd().y / 2000.0f);
+        float pitch_trim_adjustment_rad = copter.attitude_control->get_att_target_euler_rad().y / 20.0f;
 
         // add trim to ahrs object, but do not save to permanent storage:
-        AP::ahrs().add_trim(roll_trim_adjustment, pitch_trim_adjustment, false);
+        AP::ahrs().add_trim(roll_trim_adjustment_rad, pitch_trim_adjustment_rad, false);
 }
 
 #endif  // AP_COPTER_AHRS_AUTO_TRIM_ENABLED

--- a/ArduCopter/autoyaw.cpp
+++ b/ArduCopter/autoyaw.cpp
@@ -2,14 +2,14 @@
 
 Mode::AutoYaw Mode::auto_yaw;
 
-// roi_yaw - returns heading towards location held in roi
-float Mode::AutoYaw::roi_yaw() const
+// roi_yaw_rad - returns heading towards location held in roi
+float Mode::AutoYaw::roi_yaw_rad() const
 {
     Vector2f pos_ne_m;
     if (AP::ahrs().get_relative_position_NE_origin_float(pos_ne_m)){
-        return get_bearing_cd(pos_ne_m * 100.0, roi.xy());
+        return get_bearing_rad(pos_ne_m * 100.0, roi.xy());
     }
-    return copter.attitude_control->get_att_target_euler_cd().z;
+    return copter.attitude_control->get_att_target_euler_rad().z;
 }
 
 // Returns the yaw angle (in radians) representing the direction of horizontal motion.
@@ -236,7 +236,7 @@ float Mode::AutoYaw::yaw_rad()
 
     case Mode::ROI:
         // point towards a location held in roi
-        _yaw_angle_rad = cd_to_rad(roi_yaw());
+        _yaw_angle_rad = roi_yaw_rad();
         break;
 
     case Mode::FIXED: {
@@ -264,7 +264,7 @@ float Mode::AutoYaw::yaw_rad()
     case Mode::CIRCLE:
 #if MODE_CIRCLE_ENABLED
         if (copter.circle_nav->is_active()) {
-            _yaw_angle_rad = cd_to_rad(copter.circle_nav->get_yaw_cd());
+            _yaw_angle_rad = copter.circle_nav->get_yaw_rad();
         }
 #endif
         break;
@@ -286,7 +286,7 @@ float Mode::AutoYaw::yaw_rad()
     case Mode::LOOK_AT_NEXT_WP:
     default:
         // point towards next waypoint.
-        // we don't use wp_bearing because we don't want the copter to turn too much during flight
+        // we don't use wp_bearing_deg because we don't want the copter to turn too much during flight
         _yaw_angle_rad = copter.pos_control->get_yaw_rad();
     break;
     }

--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -124,8 +124,8 @@ void Copter::thrust_loss_check()
 
     // check for desired angle over 15 degrees
     // todo: add thrust angle to AC_AttitudeControl
-    const Vector3f angle_target = attitude_control->get_att_target_euler_cd();
-    if (sq(angle_target.x) + sq(angle_target.y) > sq(THRUST_LOSS_CHECK_ANGLE_DEVIATION_CD)) {
+    const Vector3f& angle_target_rad = attitude_control->get_att_target_euler_rad();
+    if (angle_target_rad.xy().length_squared() > sq(cd_to_rad(THRUST_LOSS_CHECK_ANGLE_DEVIATION_CD))) {
         thrust_loss_counter = 0;
         return;
     }

--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -111,8 +111,8 @@ void Copter::update_land_detector()
 #endif
 
         // check for aggressive flight requests - requested roll or pitch angle below 15 degrees
-        const Vector3f angle_target = attitude_control->get_att_target_euler_cd();
-        bool large_angle_request = angle_target.xy().length() > LAND_CHECK_LARGE_ANGLE_CD;
+        const Vector3f& angle_target_rad = attitude_control->get_att_target_euler_rad();
+        bool large_angle_request = angle_target_rad.xy().length() > cd_to_rad(LAND_CHECK_LARGE_ANGLE_CD);
         SET_LOG_FLAG(large_angle_request, LandDetectorLoggingFlag::LARGE_ANGLE_REQUEST);
 
         // check for large external disturbance - angle error over 30 degrees
@@ -298,8 +298,8 @@ void Copter::update_throttle_mix()
         // autopilot controlled throttle
 
         // check for aggressive flight requests - requested roll or pitch angle below 15 degrees
-        const Vector3f angle_target = attitude_control->get_att_target_euler_cd();
-        bool large_angle_request = angle_target.xy().length() > LAND_CHECK_LARGE_ANGLE_CD;
+        const Vector3f& angle_target_rad = attitude_control->get_att_target_euler_rad();
+        bool large_angle_request = angle_target_rad.xy().length() > cd_to_rad(LAND_CHECK_LARGE_ANGLE_CD);
 
         // check for large external disturbance - angle error over 30 degrees
         const float angle_error = attitude_control->get_att_error_angle_deg();

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -165,7 +165,7 @@ public:
 
     // functions for reporting to GCS
     virtual bool get_wp(Location &loc) const { return false; };
-    virtual int32_t wp_bearing() const { return 0; }
+    virtual float wp_bearing_deg() const { return 0; }
     virtual float wp_distance_m() const { return 0.0f; }
     virtual float crosstrack_error() const { return 0.0f;}
 
@@ -359,7 +359,7 @@ public:
         // Returns the yaw angle (in radians) representing the direction of horizontal motion.
         float look_ahead_yaw_rad();
 
-        float roi_yaw() const;
+        float roi_yaw_rad() const;
 
         // auto flight mode's yaw mode
         Mode _mode = Mode::LOOK_AT_NEXT_WP;
@@ -616,7 +616,7 @@ protected:
     const char *name4() const override { return auto_RTL? "ARTL" : "AUTO"; }
 
     float wp_distance_m() const override;
-    int32_t wp_bearing() const override;
+    float wp_bearing_deg() const override;
     float crosstrack_error() const override { return wp_nav->crosstrack_error();}
     bool get_wp(Location &loc) const override;
 
@@ -888,7 +888,7 @@ protected:
     const char *name4() const override { return "CIRC"; }
 
     float wp_distance_m() const override;
-    int32_t wp_bearing() const override;
+    float wp_bearing_deg() const override;
 
 private:
 
@@ -1165,7 +1165,7 @@ protected:
     const char *name4() const override { return "GUID"; }
 
     float wp_distance_m() const override;
-    int32_t wp_bearing() const override;
+    float wp_bearing_deg() const override;
     float crosstrack_error() const override;
 
 private:
@@ -1337,7 +1337,7 @@ protected:
     const char *name4() const override { return "LOIT"; }
 
     float wp_distance_m() const override;
-    int32_t wp_bearing() const override;
+    float wp_bearing_deg() const override;
     float crosstrack_error() const override { return pos_control->crosstrack_error();}
 
 #if AC_PRECLAND_ENABLED
@@ -1506,7 +1506,7 @@ protected:
 
     // for reporting to GCS
     float wp_distance_m() const override;
-    int32_t wp_bearing() const override;
+    float wp_bearing_deg() const override;
     float crosstrack_error() const override { return wp_nav->crosstrack_error();}
 
     void descent_start();
@@ -1597,7 +1597,7 @@ protected:
     // for reporting to GCS
     bool get_wp(Location &loc) const override;
     float wp_distance_m() const override;
-    int32_t wp_bearing() const override;
+    float wp_bearing_deg() const override;
     float crosstrack_error() const override { return wp_nav->crosstrack_error();}
 
 private:
@@ -1921,7 +1921,7 @@ protected:
     // for reporting to GCS
     bool get_wp(Location &loc) const override;
     float  wp_distance_m() const override;
-    int32_t wp_bearing() const override;
+    float wp_bearing_deg() const override;
 
     uint32_t last_log_ms;   // system time of last time desired velocity was logging
 };
@@ -1976,7 +1976,7 @@ protected:
     const char *name() const override { return "ZIGZAG"; }
     const char *name4() const override { return "ZIGZ"; }
     float wp_distance_m() const override;
-    int32_t wp_bearing() const override;
+    float wp_bearing_deg() const override;
     float crosstrack_error() const override;
 
 private:

--- a/ArduCopter/mode_acro.cpp
+++ b/ArduCopter/mode_acro.cpp
@@ -148,7 +148,7 @@ void ModeAcro::get_pilot_desired_rates_rads(float roll_in_norm, float pitch_in_n
 
         // Calculate angle limiting earth frame rate commands
         if (g.acro_trainer == (uint8_t)Trainer::LIMITED) {
-            const float angle_max_rad = cd_to_rad(copter.aparm.angle_max);
+            const float angle_max_rad = attitude_control->lean_angle_max_rad();
             if (roll_angle_rad > angle_max_rad) {
                 rate_ef_level_rads.x += sqrt_controller(angle_max_rad - roll_angle_rad, radians(g2.command_model_acro_rp.get_rate()) / cd_to_rad(ACRO_LEVEL_MAX_OVERSHOOT), attitude_control->get_accel_roll_max_radss(), G_Dt);
             } else if (roll_angle_rad < -angle_max_rad) {

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -865,15 +865,15 @@ float ModeAuto::wp_distance_m() const
     }
 }
 
-int32_t ModeAuto::wp_bearing() const
+float ModeAuto::wp_bearing_deg() const
 {
     switch (_mode) {
     case SubMode::CIRCLE:
-        return copter.circle_nav->get_bearing_to_target_cd();
+        return degrees(copter.circle_nav->get_bearing_to_target_rad());
     case SubMode::WP:
     case SubMode::CIRCLE_MOVE_TO_EDGE:
     default:
-        return wp_nav->get_wp_bearing_to_destination_cd();
+        return degrees(wp_nav->get_wp_bearing_to_destination_rad());
     }
 }
 

--- a/ArduCopter/mode_circle.cpp
+++ b/ArduCopter/mode_circle.cpp
@@ -131,9 +131,9 @@ float ModeCircle::wp_distance_m() const
     return copter.circle_nav->get_distance_to_target_cm() * 0.01f;
 }
 
-int32_t ModeCircle::wp_bearing() const
+float ModeCircle::wp_bearing_deg() const
 {
-    return copter.circle_nav->get_bearing_to_target_cd();
+    return degrees(copter.circle_nav->get_bearing_to_target_rad());
 }
 
 #endif

--- a/ArduCopter/mode_follow.cpp
+++ b/ArduCopter/mode_follow.cpp
@@ -149,7 +149,7 @@ float ModeFollow::wp_distance_m() const
     return g2.follow.get_distance_to_target_m();
 }
 
-int32_t ModeFollow::wp_bearing() const
+float ModeFollow::wp_bearing_deg() const
 {
     return g2.follow.get_bearing_to_target_deg() * 100;
 }

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -1128,15 +1128,15 @@ float ModeGuided::wp_distance_m() const
     }
 }
 
-int32_t ModeGuided::wp_bearing() const
+float ModeGuided::wp_bearing_deg() const
 {
     switch(guided_mode) {
     case SubMode::WP:
-        return wp_nav->get_wp_bearing_to_destination_cd();
+        return degrees(wp_nav->get_wp_bearing_to_destination_rad());
     case SubMode::Pos:
-        return get_bearing_cd(pos_control->get_pos_estimate_NEU_cm().xy().tofloat(), guided_pos_target_cm.xy().tofloat());
+        return degrees(get_bearing_rad(pos_control->get_pos_estimate_NEU_cm().xy().tofloat(), guided_pos_target_cm.xy().tofloat()));
     case SubMode::PosVelAccel:
-        return pos_control->get_bearing_to_target_cd();
+        return degrees(pos_control->get_bearing_to_target_rad());
     case SubMode::TakeOff:
     case SubMode::Accel:
     case SubMode::VelAccel:

--- a/ArduCopter/mode_loiter.cpp
+++ b/ArduCopter/mode_loiter.cpp
@@ -195,9 +195,9 @@ float ModeLoiter::wp_distance_m() const
     return loiter_nav->get_distance_to_target_cm() * 0.01f;
 }
 
-int32_t ModeLoiter::wp_bearing() const
+float ModeLoiter::wp_bearing_deg() const
 {
-    return loiter_nav->get_bearing_to_target_cd();
+    return degrees(loiter_nav->get_bearing_to_target_rad());
 }
 
 #endif

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -536,9 +536,9 @@ float ModeRTL::wp_distance_m() const
     return wp_nav->get_wp_distance_to_destination_cm() * 0.01f;
 }
 
-int32_t ModeRTL::wp_bearing() const
+float ModeRTL::wp_bearing_deg() const
 {
-    return wp_nav->get_wp_bearing_to_destination_cd();
+    return degrees(wp_nav->get_wp_bearing_to_destination_rad());
 }
 
 // returns true if pilot's yaw input should be used to adjust vehicle's heading

--- a/ArduCopter/mode_smart_rtl.cpp
+++ b/ArduCopter/mode_smart_rtl.cpp
@@ -201,9 +201,9 @@ float ModeSmartRTL::wp_distance_m() const
     return wp_nav->get_wp_distance_to_destination_cm() * 0.01f;
 }
 
-int32_t ModeSmartRTL::wp_bearing() const
+float ModeSmartRTL::wp_bearing_deg() const
 {
-    return wp_nav->get_wp_bearing_to_destination_cd();
+    return degrees(wp_nav->get_wp_bearing_to_destination_rad());
 }
 
 bool ModeSmartRTL::use_pilot_yaw() const

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -568,9 +568,9 @@ float ModeZigZag::wp_distance_m() const
 {
     return is_auto ? wp_nav->get_wp_distance_to_destination_cm() * 0.01f : 0.0f;
 }
-int32_t ModeZigZag::wp_bearing() const
+float ModeZigZag::wp_bearing_deg() const
 {
-    return is_auto ? wp_nav->get_wp_bearing_to_destination_cd() : 0;
+    return is_auto ? degrees(wp_nav->get_wp_bearing_to_destination_rad()) : 0;
 }
 float ModeZigZag::crosstrack_error() const
 {

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -507,6 +507,10 @@ public:
     // tail rotor thrust in hover. Overloaded by AC_Attitude_Heli to return angle.
     virtual float get_roll_trim_cd() { return 0;}
 
+    // Return angle in radians to be added to roll angle. Used by heli to counteract
+    // tail rotor thrust in hover. Overloaded by AC_Attitude_Heli to return angle.
+    float get_roll_trim_rad() { return cd_to_rad(get_roll_trim_cd()); }
+
     // passthrough_bf_roll_pitch_rate_yaw - roll and pitch are passed through directly, body-frame rate target for yaw
     // this assumes a maximum deflection rate of 45 degrees per second or pi/4 rad/s.
     void passthrough_bf_roll_pitch_rate_yaw_cds(float roll_passthrough_cds, float pitch_passthrough_cds, float yaw_rate_bf_cds);
@@ -566,10 +570,6 @@ protected:
 
     // Update rate_target_ang_vel using attitude_error_rot_vec_rad
     Vector3f update_ang_vel_target_from_att_error(const Vector3f &attitude_error_rot_vec_rad);
-
-    // Return angle in radians to be added to roll angle. Used by heli to counteract
-    // tail rotor thrust in hover. Overloaded by AC_Attitude_Heli to return angle.
-    virtual float get_roll_trim_rad() { return 0;}
 
     // Returns the most recent angular velocity reading (rad/s) for the rate controller.
     // Ensures minimum latency when rate control is run before or after attitude control.

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.h
@@ -146,9 +146,6 @@ private:
     // pass through for yaw if tail_passthrough is set
     float _passthrough_yaw_cds;
 
-    // get_roll_trim - angle in centi-degrees to be added to roll angle. Used by helicopter to counter tail rotor thrust in hover
-    float get_roll_trim_rad() override { return cd_to_rad(get_roll_trim_cd()); }
-
     // internal variables
     float _hover_roll_trim_scalar = 0;              // scalar used to suppress Hover Roll Trim
 

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -1318,9 +1318,9 @@ void AC_PosControl::get_stopping_point_U_cm(postype_t &stopping_point_u_cm) cons
 }
 
 /// get_bearing_to_target_cd - get bearing to target position in centi-degrees
-int32_t AC_PosControl::get_bearing_to_target_cd() const
+float AC_PosControl::get_bearing_to_target_rad() const
 {
-    return get_bearing_cd(Vector2f{0.0, 0.0}, (_pos_target_neu_cm.xy() - _pos_estimate_neu_cm.xy()).tofloat());
+    return get_bearing_rad(Vector2f{0.0, 0.0}, (_pos_target_neu_cm.xy() - _pos_estimate_neu_cm.xy()).tofloat());
 }
 
 

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -414,7 +414,7 @@ public:
     Vector3f get_thrust_vector() const;
 
     /// Returns the bearing to the position target in centidegrees (0 = North, CW positive).
-    int32_t get_bearing_to_target_cd() const;
+    float get_bearing_to_target_rad() const;
 
     /// Returns the maximum allowed lean angle in radians (roll/pitch) for the attitude controller.
     float get_lean_angle_max_rad() const;

--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -67,6 +67,7 @@ public:
     float get_pitch_cd() const { return _pos_control.get_pitch_cd(); }
     Vector3f get_thrust_vector() const { return _pos_control.get_thrust_vector(); }
     float get_yaw_cd() const { return _yaw_cd; }
+    float get_yaw_rad() const { return cd_to_rad(_yaw_cd); }
 
     /// returns true if update has been run recently
     /// used by vehicle code to determine if get_yaw() is valid
@@ -82,8 +83,8 @@ public:
     /// get horizontal distance to loiter target in cm
     float get_distance_to_target_cm() const { return _pos_control.get_pos_error_NE_cm(); }
 
-    /// get bearing to target in centi-degrees
-    int32_t get_bearing_to_target_cd() const { return _pos_control.get_bearing_to_target_cd(); }
+    /// get bearing to target in degrees
+    float get_bearing_to_target_rad() const { return _pos_control.get_bearing_to_target_rad(); }
 
     /// true if pilot control of radius and turn rate is enabled
     bool pilot_control_enabled() const { return (_options.get() & CircleOptions::MANUAL_CONTROL) != 0; }

--- a/libraries/AC_WPNav/AC_Loiter.h
+++ b/libraries/AC_WPNav/AC_Loiter.h
@@ -46,7 +46,7 @@ public:
     float get_distance_to_target_cm() const { return _pos_control.get_pos_error_NE_cm(); }
 
     /// get bearing to target in centi-degrees
-    int32_t get_bearing_to_target_cd() const { return _pos_control.get_bearing_to_target_cd(); }
+    float get_bearing_to_target_rad() const { return _pos_control.get_bearing_to_target_rad(); }
 
     /// get maximum lean angle when using loiter
     float get_angle_max_rad() const;

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -583,6 +583,12 @@ int32_t AC_WPNav::get_wp_bearing_to_destination_cd() const
     return get_bearing_cd(_pos_control.get_pos_estimate_NEU_cm().xy().tofloat(), _destination_neu_cm.xy());
 }
 
+/// get_wp_bearing_to_destination_cd - get bearing to next waypoint in centi-degrees
+float AC_WPNav::get_wp_bearing_to_destination_rad() const
+{
+    return get_bearing_rad(_pos_control.get_pos_estimate_NEU_cm().xy().tofloat(), _destination_neu_cm.xy());
+}
+
 /// update_wpnav - run the wp controller - should be called at 100hz or higher
 bool AC_WPNav::update_wpnav()
 {

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -145,6 +145,9 @@ public:
     /// get_bearing_to_destination - get bearing to next waypoint in centi-degrees
     virtual int32_t get_wp_bearing_to_destination_cd() const;
 
+    /// get_bearing_to_destination - get bearing to next waypoint in radians
+    virtual float get_wp_bearing_to_destination_rad() const;
+
     /// reached_destination - true when we have come within RADIUS cm of the waypoint
     virtual bool reached_wp_destination() const { return _flags.reached_destination; }
 

--- a/libraries/AC_WPNav/AC_WPNav_OA.cpp
+++ b/libraries/AC_WPNav/AC_WPNav_OA.cpp
@@ -62,6 +62,16 @@ int32_t AC_WPNav_OA::get_wp_bearing_to_destination_cd() const
     return get_bearing_cd(_pos_control.get_pos_estimate_NEU_cm().xy().tofloat(), _destination_oabak_neu_cm.xy());
 }
 
+/// get_wp_bearing_to_destination_cd - get bearing to next waypoint in centi-degrees
+float AC_WPNav_OA::get_wp_bearing_to_destination_rad() const
+{
+    if (_oa_state == AP_OAPathPlanner::OA_NOT_REQUIRED) {
+        return AC_WPNav::get_wp_bearing_to_destination_rad();
+    }
+
+    return get_bearing_rad(_pos_control.get_pos_estimate_NEU_cm().xy().tofloat(), _destination_oabak_neu_cm.xy());
+}
+
 /// true when we have come within RADIUS cm of the waypoint
 bool AC_WPNav_OA::reached_wp_destination() const
 {

--- a/libraries/AC_WPNav/AC_WPNav_OA.h
+++ b/libraries/AC_WPNav/AC_WPNav_OA.h
@@ -32,6 +32,9 @@ public:
     /// always returns bearing to final destination (i.e. does not use oa adjusted destination)
     int32_t get_wp_bearing_to_destination_cd() const override;
 
+    /// get_bearing_to_destination - get bearing to next waypoint in radians
+    virtual float get_wp_bearing_to_destination_rad() const override;
+
     /// true when we have come within RADIUS cm of the final destination
     bool reached_wp_destination() const override;
 

--- a/libraries/AP_Math/location.cpp
+++ b/libraries/AP_Math/location.cpp
@@ -23,14 +23,16 @@
 #include "AP_Math.h"
 #include "location.h"
 
-// return bearing in centi-degrees between two positions
+// return bearing_rad in radians between two positions
+float get_bearing_rad(const Vector2f &origin, const Vector2f &destination)
+{
+    return wrap_2PI(atan2f(destination.y-origin.y, destination.x-origin.x));
+}
+
+// return bearing_cd in centi-degrees between two positions
 float get_bearing_cd(const Vector2f &origin, const Vector2f &destination)
 {
-    float bearing = rad_to_cd(atan2f(destination.y-origin.y, destination.x-origin.x));
-    if (bearing < 0) {
-        bearing += 36000.0f;
-    }
-    return bearing;
+    return rad_to_cd(get_bearing_rad(origin, destination));
 }
 
 // return true when lat and lng are within range

--- a/libraries/AP_Math/location.h
+++ b/libraries/AP_Math/location.h
@@ -16,6 +16,9 @@ float get_horizontal_distance_cm(const Vector2<T> &origin, const Vector2<T> &des
     return (destination - origin).length();
 }
 
+// return bearing in radians between two positions
+float        get_bearing_rad(const Vector2f &origin, const Vector2f &destination);
+
 // return bearing in centi-degrees between two positions
 float        get_bearing_cd(const Vector2f &origin, const Vector2f &destination);
 


### PR DESCRIPTION
To follow #30412

```
Board,blimp,bootloader,copter,heli,plane,rover,sub
CubeOrange,*,*,-16,16,40,*,40
```