### PR TITLE
Tools: ros2: satisfy formatter

### DIFF
--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_virtual_ports.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_virtual_ports.py
@@ -23,6 +23,7 @@ from launch_pytest.tools import process as process_tools
 
 WAIT_FOR_START_TIMEOUT = 5.0
 
+
 @launch_pytest.fixture
 def launch_description(virtual_ports):
     """Launch description fixture."""


### PR DESCRIPTION
https://github.com/ArduPilot/ardupilot/pull/30396 includes a change with invalid `black` formatting. Was not reported in CI but is being picked up by precommit hook.

Further discussion here: 
- https://github.com/ArduPilot/ardupilot/pull/30427#discussion_r2160420068
- https://discord.com/channels/674039678562861068/850924523610963988/1386408054823719165 