### PR TITLE
Plane: Quadplane: coordinate turns in transition

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1561,16 +1561,6 @@ void SLT_Transition::update()
         }
         quadplane.hold_hover(climb_rate_cms);
 
-        if (!quadplane.tiltrotor.is_vectored()) {
-            // set desired yaw to current yaw in both desired angle
-            // and rate request. This reduces wing twist in transition
-            // due to multicopter yaw demands. This is disabled when
-            // using vectored yaw for tilt-rotors as the yaw control
-            // is needed to maintain good control in forward
-            // transitions
-            quadplane.attitude_control->reset_yaw_target_and_rate();
-            quadplane.attitude_control->rate_bf_yaw_target(0.0);
-        }
         if (quadplane.tiltrotor.enabled() && !quadplane.tiltrotor.has_fw_motor()) {
             // tilt rotors without dedicated fw motors do not have forward throttle output in this stage
             // prevent throttle I wind up
@@ -1637,16 +1627,6 @@ void SLT_Transition::update()
         quadplane.assisted_flight = true;
         quadplane.hold_stabilize(throttle_scaled);
 
-        // set desired yaw to current yaw in both desired angle and
-        // rate request while waiting for transition to
-        // complete. Navigation should be controlled by fixed wing
-        // control surfaces at this stage.
-        // We disable this for vectored yaw tilt rotors as they do need active
-        // yaw control throughout the transition
-        if (!quadplane.tiltrotor.is_vectored()) {
-            quadplane.attitude_control->reset_yaw_target_and_rate();
-            quadplane.attitude_control->rate_bf_yaw_target(0.0);
-        }
         break;
     }
 


### PR DESCRIPTION
`hold_hover` and `hold_stabilize` set the commanded yaw rate to that of a coordinated turn during assisted flight (calling   `multicopter_attitude_rate_update(get_desired_yaw_rate_cds(false))`) That command gets thrown away here, ostensibly to suppress yaw output in transition, but it actually causes far more (see my analysis in #30415).

This is actually a well-tested code-path, since this is what vectored tilt-rotors always do.

Split out from #30415. Both Tridge and Pete responded skeptically about very idea yaw suppression. If yaw suppression is bad, then both the intended behavior and actual behavior of these lines is bad, and they should just be deleted.

Tridge suggested a possible idea of phasing out yaw command through the transition, and I'll change #30415 to implement that, but in the meantime, I'm going to split out this bit.