### PR TITLE
autotest: PeriphMultiUARTTunnel: allow more time for heartbeats to arrrive

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -14129,23 +14129,25 @@ RTL_ALT 111
         # self.delay_sim_time(100000)
 
         self.progress("Connect to the serial port on the peripheral, which should be talking mavlink")
+        self.drain_mav()
         mav2 = mavutil.mavlink_connection(
             "tcp:localhost:5772",
             robust_parsing=True,
             source_system=9,
             source_component=9,
         )
-        self.assert_receive_message("HEARTBEAT", mav=mav2, very_verbose=True)
+        self.assert_receive_message("HEARTBEAT", mav=mav2, very_verbose=True, timeout=5)
         self.drain_mav()
 
         self.progress("Connect to the other serial port on the peripheral, which should also be talking mavlink")
+        self.drain_mav()
         mav3 = mavutil.mavlink_connection(
             "tcp:localhost:5773",
             robust_parsing=True,
             source_system=10,
             source_component=10,
         )
-        self.assert_receive_message("HEARTBEAT", mav=mav3, very_verbose=True)
+        self.assert_receive_message("HEARTBEAT", mav=mav3, very_verbose=True, timeout=5)
         self.drain_mav()
 
         # make sure we continue to get heartbeats:


### PR DESCRIPTION
we only emit the hearbeats at 1Hz, so reasonably easy to see that vagaries of scheduling might mean you won't see it on a 1s timeout!

2025-06-22T13:44:02.4408668Z AT-1949.5: Connect to the other serial port on the peripheral, which should also be talking mavlink 2025-06-22T13:44:03.4206967Z AT-1950.5: Exception caught: Did not get HEARTBEAT after 1.0033669471740723 seconds 2025-06-22T13:44:03.4207939Z Traceback (most recent call last):
2025-06-22T13:44:03.4209915Z   File "/__w/Leonard_ardupilot/Leonard_ardupilot/Tools/autotest/vehicle_test_suite.py", line 9028, in run_one_test_attempt
2025-06-22T13:44:03.4211111Z     test_function(**test_kwargs)
2025-06-22T13:44:03.4214559Z   File "/__w/Leonard_ardupilot/Leonard_ardupilot/Tools/autotest/arducopter.py", line 14148, in PeriphMultiUARTTunnel
2025-06-22T13:44:03.4216238Z     self.assert_receive_message("HEARTBEAT", mav=mav3, very_verbose=True)
2025-06-22T13:44:03.4218057Z   File "/__w/Leonard_ardupilot/Leonard_ardupilot/Tools/autotest/vehicle_test_suite.py", line 5234, in assert_receive_message
2025-06-22T13:44:03.4219636Z     raise NotAchievedException("Did not get %s after %s seconds" %
2025-06-22T13:44:03.4233228Z ##[error]vehicle_test_suite.NotAchievedException: Did not get HEARTBEAT after 1.0033669471740723 seconds