### PR TITLE
Tools: scripts: decode devid: add latest airspeed and baro devices

### DIFF
--- a/Tools/scripts/decode_devid.py
+++ b/Tools/scripts/decode_devid.py
@@ -134,6 +134,7 @@ baro_types = {
     0x14 : "DEVTYPE_BARO_BMP390",
     0x15 : "DEVTYPE_BARO_BMP581",
     0x16 : "DEVTYPE_BARO_SPA06",
+    0x17 : "DEVTYPE_BARO_AUAV",
 }
 
 airspeed_types = {
@@ -147,8 +148,9 @@ airspeed_types = {
     0x08 : "DEVTYPE_AIRSPEED_ANALOG",
     0x09 : "DEVTYPE_AIRSPEED_NMEA",
     0x0A : "DEVTYPE_AIRSPEED_ASP5033",
+    0x0B : "DEVTYPE_AIRSPEED_AUAV",
 }
-    
+
 decoded_devname = ""
 
 if opts.compass:


### PR DESCRIPTION
This adds the AUAV baro and speed sensor to the decode devid script.

https://github.com/ArduPilot/ardupilot/blob/589708df48bb76302d9a725ae2b0f7e36f69475b/libraries/AP_Baro/AP_Baro_Backend.h#L58

https://github.com/ArduPilot/ardupilot/blob/589708df48bb76302d9a725ae2b0f7e36f69475b/libraries/AP_Airspeed/AP_Airspeed_Backend.h#L119

https://github.com/ArduPilot/WebTools/pull/255