### PR TITLE
Sub: place Home at surface when setting it inflight

### DIFF
--- a/ArduSub/Sub.cpp
+++ b/ArduSub/Sub.cpp
@@ -431,13 +431,7 @@ float Sub::get_alt_rel() const
 
     // get relative position
     float posD;
-    if (ahrs.get_relative_position_D_origin_float(posD)) {
-        if (ahrs.home_is_set()) {
-            // adjust to the home position
-            auto home = ahrs.get_home();
-            posD -= static_cast<float>(home.alt) * 0.01f;
-        }
-    } else {
+    if (!ahrs.get_relative_position_D_origin_float(posD)) {
         // fall back to the barometer reading
         posD = -AP::baro().get_altitude();
     }

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -459,6 +459,7 @@ private:
     enum class Option {
         JammingExpected     = (1<<0),
         ManualLaneSwitch   = (1<<1),
+        ForceZeroAltOrigin = (1<<2),
     };
     bool option_is_enabled(Option option) const {
         return (_options & (uint32_t)option) != 0;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -689,6 +689,9 @@ void NavEKF3_core::readGpsData()
         if (inFlight) {
             gpsloc_fieldelevation.alt += (int32_t)(100.0f * stateStruct.position.z);
         }
+        if (frontend->option_is_enabled(NavEKF3::Option::ForceZeroAltOrigin)) {
+            gpsloc_fieldelevation.alt = 0;
+        }
 
         if (!setOrigin(gpsloc_fieldelevation)) {
             // set an error as an attempt was made to set the origin more than once

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -1311,7 +1311,7 @@ void NavEKF3_core::selectHeightForFusion()
     // If we are not using GPS as the primary height sensor, correct EKF origin height so that
     // combined local NED position height and origin height remains consistent with the GPS altitude
     // This also enables the GPS height to be used as a backup height source
-    if (gpsDataToFuse &&
+    if (gpsDataToFuse && !frontend->option_is_enabled(NavEKF3::Option::ForceZeroAltOrigin) &&
             (((frontend->_originHgtMode & (1 << 0)) && (activeHgtSource == AP_NavEKF_Source::SourceZ::BARO)) ||
             ((frontend->_originHgtMode & (1 << 1)) && (activeHgtSource == AP_NavEKF_Source::SourceZ::RANGEFINDER)))
             ) {


### PR DESCRIPTION
Fixes an issue where the home would be set to the ekf origin, which uses the GPS altitude, which is far, far more imprecise than our baros, and doesn't take tides into account.

Fixes the issue of "my rov got a gps lock at the surface and now thinks it is 8m underwater because the GPS is ~drunk~ innacurate on vertical position"