### PR TITLE
hwdef: skyviper-v2450: disable TRI motor backend

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/skyviper-v2450/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/skyviper-v2450/hwdef.dat
@@ -123,6 +123,9 @@ define AP_GPS_MAV_ENABLED 1
 define GPS_MOVING_BASELINE 0
 define GPS_MAX_RECEIVERS 1  # removes blended support
 
+# disable the Tri Motors class backend:
+define AP_MOTORS_TRI_ENABLED 0
+
 # enable only the QUAD frame
 define AP_MOTORS_FRAME_DEFAULT_ENABLED 0
 define AP_MOTORS_FRAME_QUAD_ENABLED 1


### PR DESCRIPTION
Simply removes the TriCopter motors backend from the SkyViper-v2450 build.  SkyVipers barely fly with 4 rotors, let alone 3....

```
Board,copter
skyviper-v2450,-1848
```
