### PR TITLE
hwdef: remove HAL_CHIBIOS_ARCH_F405 defines

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/DroneerF405/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/DroneerF405/hwdef.dat
@@ -6,8 +6,6 @@
 # MCU class and specific type.
 MCU STM32F4xx STM32F405xx
 
-HAL_CHIBIOS_ARCH_F405 1
-
 # board ID. See Tools/AP_Bootloader/board_types.txt
 APJ_BOARD_ID AP_HW_DroneerF405
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/FoxeerF405v2/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/FoxeerF405v2/hwdef.dat
@@ -6,8 +6,6 @@
 # MCU class and specific type
 MCU STM32F4xx STM32F405xx
 
-HAL_CHIBIOS_ARCH_F405 1
-
 # board ID. See Tools/AP_Bootloader/board_types.txt
 APJ_BOARD_ID AP_HW_FOXEERF405_V2
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MambaF405v2/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MambaF405v2/hwdef.dat
@@ -7,8 +7,6 @@
 # MCU class and specific type.
 MCU STM32F4xx STM32F405xx
 
-HAL_CHIBIOS_ARCH_F405 1
-
 # board ID. See Tools/AP_Bootloader/board_types.txt
 APJ_BOARD_ID AP_HW_MAMBA405
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SuccexF4/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SuccexF4/hwdef.dat
@@ -3,8 +3,6 @@
 
 MCU STM32F4xx STM32F405xx
 
-HAL_CHIBIOS_ARCH_F405 1
-
 # board ID. See Tools/AP_Bootloader/board_types.txt
 APJ_BOARD_ID AP_HW_SUCCEXF4
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/airbotf4/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/airbotf4/hwdef.dat
@@ -4,8 +4,6 @@
 
 MCU STM32F4xx STM32F405xx
 
-HAL_CHIBIOS_ARCH_F405 1
-
 # board ID. See Tools/AP_Bootloader/board_types.txt
 APJ_BOARD_ID AP_HW_AIRBOTF4
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/omnibusf4pro/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/omnibusf4pro/hwdef.dat
@@ -4,8 +4,6 @@
 
 MCU STM32F4xx STM32F405xx
 
-HAL_CHIBIOS_ARCH_F405 1
-
 # board ID. See Tools/AP_Bootloader/board_types.txt
 APJ_BOARD_ID AP_HW_OMNIBUSF4PRO
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/skyviper-f412-rev1/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/skyviper-f412-rev1/hwdef.dat
@@ -102,8 +102,6 @@ SPIDEV icm20789   SPI2 DEVID4 MPU_CS   MODE3 1*MHZ 8*MHZ
 # reserve 16k for bootloader and 32k for storage
 FLASH_RESERVE_START_KB 48
 
-define HAL_CHIBIOS_ARCH_F412 1
-
 IMU Invensense SPI:icm20789 ROTATION_NONE
 
 # radio IRQ is on GPIO(100)

--- a/libraries/AP_HAL_ChibiOS/hwdef/skyviper-journey/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/skyviper-journey/hwdef.dat
@@ -92,8 +92,6 @@ SPIDEV pixartflow SPI2 DEVID2 FLOW_CS  MODE3 2*MHZ 2*MHZ
 # reserve 16k for bootloader and 32k for storage
 FLASH_RESERVE_START_KB 48
 
-define HAL_CHIBIOS_ARCH_F412 1
-
 IMU Invensense I2C:1:0x68 ROTATION_NONE
 
 # radio IRQ is on GPIO(100)


### PR DESCRIPTION
this was never a Thing.  I'm sure we could track a lineage back to a single board and see them all copied from that....

this string doesn't exist in the codebase past this PR.

edit: now removes `HAL_CHIBIOS_ARCH_F412` too