### PR TITLE
AP_OADijkstra: Fix missing Wrap

### DIFF
--- a/libraries/AC_Avoidance/AP_OADijkstra.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra.cpp
@@ -384,7 +384,7 @@ bool AP_OADijkstra::create_inclusion_polygon_with_margin(float margin_cm, AP_OAD
             }
 
             // don't add points in corners
-            if (fabsf(intermediate_pt.angle() - before_pt.angle()) < M_PI_2) {
+            if (fabsf(wrap_PI(intermediate_pt.angle() - before_pt.angle()) < M_PI_2)) {
                 continue;
             }
 
@@ -485,7 +485,7 @@ bool AP_OADijkstra::create_exclusion_polygon_with_margin(float margin_cm, AP_OAD
             }
 
             // don't add points in corners
-            if (fabsf(intermediate_pt.angle() - before_pt.angle()) < M_PI_2) {
+            if (fabsf(wrap_PI(intermediate_pt.angle() - before_pt.angle())) < M_PI_2) {
                 continue;
             }
 


### PR DESCRIPTION
While checking for places #30454 output range change could mess things up I found that we were missing a wrap in Dijkstra.

This will mean that when either side of -90 degrees before #30454, and 180 degrees after #30454. we could miss detecting a corner.