### PR TITLE
Fix non-Periph Network Bootloodaer

### DIFF
--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -488,7 +488,7 @@ def setup_canmgr_build(cfg):
         ]
     env.CFLAGS += ['-DHAL_CAN_IFACES=2']
 
-    if not env.AP_PERIPH:
+    if not env.AP_PERIPH and not cfg.options.bootloader:
         env.DEFINES += [
             'DRONECAN_CXX_WRAPPERS=1',
             'USE_USER_HELPERS=1',

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -669,7 +669,7 @@ class ChibiOSHWDef(hwdef.HWDef):
     def get_ram_reserve_start(self):
         '''get amount of memory to reserve for bootloader comms and the address if non-zero'''
         ram_reserve_start = self.get_config('RAM_RESERVE_START', default=0, type=int)
-        if ram_reserve_start == 0 and self.is_periph_fw():
+        if ram_reserve_start == 0:
             ram_reserve_start = 256
         ram_map_bootloader = self.get_ram_map(use_bootloader=True)
         ram0_start_address = ram_map_bootloader[0][0]


### PR DESCRIPTION
Fix non-Periph Network Bootlooder

Build fails on any FMU bootloader with networking

problems that this PR fixes:
- RAM_RESERVE_START is not defined
- CANARD_ENABLE_DEADLINE is set to 1 which is not implemented in the bootloader
- CANARD_MULTI_IFACE is set to 1 which is not implemented in the bootloader