### PR TITLE
AP_HAL_ChibiOS: fix NeoPixel support for MatekL431-Periph

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekL431-Periph/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekL431-Periph/hwdef.dat
@@ -80,6 +80,7 @@ PB1 BATT2_CURRENT_SENS ADC1 SCALE(1)
 # -------------------- Buzzer+NeoPixels --------------d------
 define AP_PERIPH_RC_OUT_ENABLED 1
 define AP_PERIPH_NOTIFY_ENABLED 1
+define AP_SERIALLED_ENABLED 1
 
 
 define HAL_SERIAL_ESC_COMM_ENABLED 1


### PR DESCRIPTION
Matek's website says L431-Periph support NeoPixel, but since commit [e736d5ecb78bb6a5eb9bec4732a69bbbdf2336de](https://github.com/villivateur/ardupilot/commit/e736d5ecb78bb6a5eb9bec4732a69bbbdf2336de) , NeoPixel is not supported by default.