### PR TITLE
allow AvoidADSB to be compiled out of the ArduCopter codebase

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -232,7 +232,7 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
 #if AP_TEMPCALIBRATION_ENABLED
     SCHED_TASK_CLASS(AP_TempCalibration,   &copter.g2.temp_calibration, update,          10, 100, 135),
 #endif
-#if HAL_ADSB_ENABLED
+#if AP_COPTER_MODE_AVOIDADSB_ENABLED || HAL_ADSB_ENABLED
     SCHED_TASK(avoidance_adsb_update, 10,    100, 138),
 #endif
 #if AP_COPTER_ADVANCED_FAILSAFE_ENABLED

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -545,10 +545,12 @@ private:
 
 #if HAL_ADSB_ENABLED
     AP_ADSB adsb;
+#endif  // HAL_ADSB_ENABLED
 
+#if AP_COPTER_MODE_AVOIDADSB_ENABLED
     // avoidance of adsb enabled vehicles (normally manned vehicles)
     AP_Avoidance_Copter avoidance_adsb{adsb};
-#endif
+#endif  // AP_COPTER_MODE_AVOIDADSB_ENABLED
 
     // last valid RC input time
     uint32_t last_radio_update_ms;
@@ -760,10 +762,10 @@ private:
     // avoidance.cpp
     void low_alt_avoidance();
 
-#if HAL_ADSB_ENABLED
+#if AP_COPTER_MODE_AVOIDADSB_ENABLED || HAL_ADSB_ENABLED
     // avoidance_adsb.cpp
     void avoidance_adsb_update(void);
-#endif
+#endif  // AP_COPTER_MODE_AVOIDADSB_ENABLED
 
     // baro_ground_effect.cpp
     void update_ground_effect_detector(void);
@@ -1078,9 +1080,9 @@ private:
 #if MODE_SYSTEMID_ENABLED
     ModeSystemId mode_systemid;
 #endif
-#if HAL_ADSB_ENABLED
+#if AP_COPTER_MODE_AVOIDADSB_ENABLED
     ModeAvoidADSB mode_avoid_adsb;
-#endif
+#endif  // AP_COPTER_MODE_AVOIDADSB_ENABLED
 #if MODE_THROW_ENABLED
     ModeThrow mode_throw;
 #endif

--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -384,12 +384,13 @@ void GCS_MAVLINK_Copter::packetReceived(const mavlink_status_t &status,
                                         const mavlink_message_t &msg)
 {
     // we handle these messages here to avoid them being blocked by mavlink routing code
-#if HAL_ADSB_ENABLED
+#if AP_COPTER_MODE_AVOIDADSB_ENABLED
     if (copter.g2.dev_options.get() & DevOptionADSBMAVLink) {
         // optional handling of GLOBAL_POSITION_INT as a MAVLink based avoidance source
         copter.avoidance_adsb.handle_msg(msg);
     }
-#endif
+#endif  // AP_COPTER_MODE_AVOIDADSB_ENABLED
+
     GCS_MAVLINK::packetReceived(status, msg);
 }
 
@@ -1461,9 +1462,9 @@ uint8_t GCS_MAVLINK_Copter::send_available_mode(uint8_t index) const
 #if MODE_THROW_ENABLED
         &copter.mode_throw,
 #endif
-#if HAL_ADSB_ENABLED
+#if AP_COPTER_MODE_AVOIDADSB_ENABLED
         &copter.mode_avoid_adsb,
-#endif
+#endif  // AP_COPTER_MODE_AVOIDADSB_ENABLED
 #if MODE_GUIDED_NOGPS_ENABLED
         &copter.mode_guided_nogps,
 #endif

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -617,11 +617,13 @@ const AP_Param::Info Copter::var_info[] = {
     // @Group: ADSB_
     // @Path: ../libraries/AP_ADSB/AP_ADSB.cpp
     GOBJECT(adsb,                "ADSB_", AP_ADSB),
+#endif  // HAL_ADSB_ENABLED
 
+#if AP_COPTER_MODE_AVOIDADSB_ENABLED
     // @Group: AVD_
     // @Path: ../libraries/AP_Avoidance/AP_Avoidance.cpp
     GOBJECT(avoidance_adsb, "AVD_", AP_Avoidance_Copter),
-#endif
+#endif  // AP_COPTER_MODE_AVOIDADSB_ENABLED
 
     // @Group: NTF_
     // @Path: ../libraries/AP_Notify/AP_Notify.cpp

--- a/ArduCopter/avoidance_adsb.cpp
+++ b/ArduCopter/avoidance_adsb.cpp
@@ -1,12 +1,19 @@
 #include "Copter.h"
 #include <AP_Notify/AP_Notify.h>
 
-#if HAL_ADSB_ENABLED
+#if AP_COPTER_MODE_AVOIDADSB_ENABLED || HAL_ADSB_ENABLED
 void Copter::avoidance_adsb_update(void)
 {
+#if HAL_ADSB_ENABLED
     adsb.update();
+#endif  // HAL_ADSB_ENABLED
+#if AP_COPTER_MODE_AVOIDADSB_ENABLED
     avoidance_adsb.update();
+#endif  // AP_COPTER_MODE_AVOIDADSB_ENABLED
 }
+#endif // AP_COPTER_MODE_AVOIDADSB_ENABLED || HAL_ADSB_ENABLED
+
+#if AP_COPTER_MODE_AVOIDADSB_ENABLED
 
 #include <stdio.h>
 
@@ -263,4 +270,5 @@ bool AP_Avoidance_Copter::handle_avoidance_perpendicular(const AP_Avoidance::Obs
     // if we got this far we failed to set the new target
     return false;
 }
-#endif
+
+#endif  // AP_COPTER_MODE_AVOIDADSB_ENABLED

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -139,6 +139,12 @@
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
+// AvoidADSB - set maneuvers to avoid an encounter with another vehicle
+#ifndef AP_COPTER_MODE_AVOIDADSB_ENABLED
+# define AP_COPTER_MODE_AVOIDADSB_ENABLED HAL_ADSB_ENABLED
+#endif
+
+//////////////////////////////////////////////////////////////////////////////
 // Brake mode - bring vehicle to stop
 #ifndef MODE_BRAKE_ENABLED
 # define MODE_BRAKE_ENABLED 1

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -107,10 +107,10 @@ Mode *Copter::mode_from_mode_num(const Mode::Number mode)
             return &mode_throw;
 #endif
 
-#if HAL_ADSB_ENABLED
+#if AP_COPTER_MODE_AVOIDADSB_ENABLED
         case Mode::Number::AVOID_ADSB:
             return &mode_avoid_adsb;
-#endif
+#endif  // AP_COPTER_MODE_AVOIDADSB_ENABLED
 
 #if MODE_GUIDED_NOGPS_ENABLED
         case Mode::Number::GUIDED_NOGPS:

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1867,6 +1867,7 @@ private:
 
 // modes below rely on Guided mode so must be declared at the end (instead of in alphabetical order)
 
+#if AP_COPTER_MODE_AVOIDADSB_ENABLED
 class ModeAvoidADSB : public ModeGuided {
 
 public:
@@ -1892,6 +1893,7 @@ protected:
 private:
 
 };
+#endif  // AP_COPTER_MODE_AVOIDADSB_ENABLED
 
 #if MODE_FOLLOW_ENABLED
 class ModeFollow : public ModeGuided {

--- a/ArduCopter/mode_avoid_adsb.cpp
+++ b/ArduCopter/mode_avoid_adsb.cpp
@@ -1,5 +1,6 @@
 #include "Copter.h"
 
+#if AP_COPTER_MODE_AVOIDADSB_ENABLED
 /*
  * control_avoid.cpp - init and run calls for AP_Avoidance's AVOID flight mode
  *
@@ -36,3 +37,5 @@ void ModeAvoidADSB::run()
     //       position and velocity requests will be ignored while the vehicle is not in guided mode
     ModeGuided::run();
 }
+
+#endif  // AP_COPTER_MODE_AVOIDADSB_ENABLED

--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -151,6 +151,7 @@ BUILD_OPTIONS = [
 
     Feature('Camera', 'RUNCAM', 'AP_CAMERA_RUNCAM_ENABLED', 'Enable RunCam control', 0, 'Camera'),
 
+    Feature('Copter', 'COPTER_MODE_AVOIDADSB', 'AP_COPTER_MODE_AVOIDADSB_ENABLED', 'Enable AvoidADSB', 0, 'ADSB'),
     Feature('Copter', 'MODE_ZIGZAG', 'MODE_ZIGZAG_ENABLED', 'Enable Mode ZigZag', 0, None),
     Feature('Copter', 'MODE_SYSTEMID', 'MODE_SYSTEMID_ENABLED', 'Enable Mode SystemID', 0, 'Logging'),
     Feature('Copter', 'MODE_SPORT', 'MODE_SPORT_ENABLED', 'Enable Mode Sport', 0, None),

--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -291,6 +291,7 @@ class ExtractFeatures(object):
             ('AP_ROVER_AUTO_ARM_ONCE_ENABLED', r'Rover::handle_auto_arm_once'),
             ('AP_COPTER_ADVANCED_FAILSAFE_ENABLED', r'Copter::afs_fs_check'),
             ('AP_COPTER_AHRS_AUTO_TRIM_ENABLED', r'RC_Channels_Copter::auto_trim_run'),
+            ('AP_COPTER_MODE_AVOIDADSB_ENABLED', r'ModeAvoidADSB::init'),
 
             ('AP_PLANE_OFFBOARD_GUIDED_SLEW_ENABLED', r'GCS_MAVLINK_Plane::handle_command_int_guided_slew_commands'),
             ('AP_SERIALMANAGER_REGISTER_ENABLED', r'AP_SerialManager::register_port'),


### PR DESCRIPTION
See https://github.com/ardupilot/ardupilot/issues/28210

Note that this is a bit confusing as there's a *flightmode* which is responsible for navigation, but there's a bunch more code in `ArduCopter/avoidance_adsb.cpp` which I've gated with the same define.  Can only stomach so many different defines...

```
###### Enabling COPTER_MODE_AVOIDADSB(AP_COPTER_MODE_AVOIDADSB_ENABLED) on copter costs -4376 bytes
```

```
###### Enabling ADSB(HAL_ADSB_ENABLED) on copter costs -23680 bytes
```
