### PR TITLE
AP_Scripting: Fix param controller timing out and comma delimited lists

### DIFF
--- a/libraries/AP_Scripting/applets/Param_Controller.lua
+++ b/libraries/AP_Scripting/applets/Param_Controller.lua
@@ -111,12 +111,8 @@ function param_load_batch()
 
       -- skip empty lines and comments
       if line ~= "" and not string.match(line, "^%s*#") then
-         -- Try comma-separated format first (PARAM,value)
-         local _, _, parm, value = string.find(line, "^([%w_]+),([%d.-]+)")
-         if not parm then
-            -- Fall back to space-separated format (PARAM value)
-            _, _, parm, value = string.find(line, "^([%w_]+)%s+([%d.-]+)")
-         end
+         -- Parse parameter using unified pattern for both comma and space delimited formats
+         local _, _, parm, value = string.find(line, "^([%w_]+)[, ] *([%d.-]+)")
 
          if parm and value then
             local num_value = tonumber(value)


### PR DESCRIPTION
# AP_Scripting: Param Controller improvements for comma delimited files and timeout handling

This PR enhances the Param_Controller script with two improvements for handling parameter files.

## Changes Made

**Comma delimiter support** ([d11acc5](https://github.com/ArduPilot/ardupilot/pull/30475/commits/d11acc519c7748c5bc9faccd9a28238c5ddbcb67))
- Added support for both comma-separated (`PARAM,value`) and space-separated (`PARAM value`) parameter file formats
- Tries comma format first, then falls back to space format 

**Chunked processing for timeout prevention** ([2456e2a](https://github.com/ArduPilot/ardupilot/pull/30475/commits/2456e2af5862ad2b5103414eaeed6bf79be6e78c))
- Chunked file reading and parameter processing to handle large parameter files without script timeouts


The original script had two limitations:
1. Only supported space-delimited parameter files, which wasn't compatible with comma-separated formats such as Mission Planner param export
2. Large parameter files would cause script timeouts

## Testing

Verified with both small and large parameter files using comma and space delimited formats on a Cube Orange. Takes ~2 seconds for param read and write so roughly ~1s for param write. The script used to timeout for flashing parameter lists of >850 params. 
