### PR TITLE
Plane: added an option to enable flaps by actual speed

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1087,6 +1087,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Bitmask: 12: Enable FBWB style loiter altitude control
     // @Bitmask: 13: Indicate takeoff waiting for neutral rudder with flight control surfaces
     // @Bitmask: 14: In AUTO - climb to next waypoint altitude immediately instead of linear climb
+    // @Bitmask: 15: Use minimum of target and actual speed for flap setting
     // @User: Advanced
     AP_GROUPINFO("FLIGHT_OPTIONS", 13, ParametersG2, flight_options, 0),
 

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -160,6 +160,7 @@ enum FlightOptions {
     ENABLE_LOITER_ALT_CONTROL = (1<<12),
     INDICATE_WAITING_FOR_RUDDER_NEUTRAL = (1<<13),
     IMMEDIATE_CLIMB_IN_AUTO = (1<<14),
+    FLAP_ACTUAL_SPEED = (1<<15),
 };
 
 enum CrowFlapOptions {

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -685,10 +685,23 @@ void Plane::set_servos_flaps(void)
         manual_flap_percent = channel_flap->percent_input();
     }
 
-    if (control_mode->does_auto_throttle()) {
+    const auto flap_actual_speed = flight_option_enabled(FlightOptions::FLAP_ACTUAL_SPEED);
+    const bool has_target_airspeed = control_mode->does_auto_throttle();
+    if (has_target_airspeed || flap_actual_speed) {
         int16_t flapSpeedSource = 0;
-        if (ahrs.using_airspeed_sensor()) {
+        float est_airspeed;
+        bool have_airspeed = ahrs.airspeed_estimate(est_airspeed);
+        if (has_target_airspeed && ahrs.using_airspeed_sensor()) {
             flapSpeedSource = target_airspeed_cm * 0.01f;
+            if (flap_actual_speed) {
+                // if we have a target and also want to use actual
+                // speed then use the minimum of the two so we bring
+                // flaps in early when deliberately slowing down
+                flapSpeedSource = MIN(flapSpeedSource, est_airspeed);
+            }
+        } else if (flap_actual_speed && have_airspeed) {
+            // use actual speed directly
+            flapSpeedSource = est_airspeed;
         } else {
             flapSpeedSource = aparm.throttle_cruise;
         }


### PR DESCRIPTION
When the new FLIGHT_OPTIONS bit is enabled:
 - In manual throttle modes actual airspeed (or estimate) is used for flaps
 - in auto-throttle modes the minimum of target airspeed and actual airspeed is used

this allows for auto flaps in manual throttle modes, and when speed drops in an uncommanded fashion in auto-throttle modes

this needs to be used with caution and carefully tested on an aircraft as it could result in an oscillation, as adding flaps can change the airspeed