### PR TITLE
Tool: Fix Docker build on macOS Apple Silicon by handling GID conflicts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,12 @@ ARG SKIP_AP_COV_ENV=1
 ARG SKIP_AP_GIT_CHECK=1
 ARG DO_AP_STM_ENV=1
 
-RUN groupadd ${USER_NAME} --gid ${USER_GID}\
+RUN if ! getent group ${USER_GID} > /dev/null 2>&1; then \
+        groupadd ${USER_NAME} --gid ${USER_GID}; \
+    else \
+        groupadd ${USER_NAME}; \
+        USER_GID=$(getent group ${USER_NAME} | cut -d: -f3); \
+    fi \
     && useradd -l -m ${USER_NAME} -u ${USER_UID} -g ${USER_GID} -s /bin/bash
 
 RUN apt-get update && apt-get install --no-install-recommends -y \


### PR DESCRIPTION
## Problem
Docker builds fail on macOS 15.5 due to group ID conflicts. The original Dockerfile assumes the specified GID (1000) is available, but on macOS systems, this GID may already be assigned to existing system groups, causing the `groupadd` command to fail.

## Solution
This PR adds conditional logic to handle GID conflicts gracefully