### PR TITLE
RC_Channel: remove AUX_FUNC entries based on feature defines

### DIFF
--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -11,6 +11,22 @@
 #include <AP_Math/AP_Math.h>
 #include <AP_Common/Bitmask.h>
 
+#include <AC_Sprayer/AC_Sprayer_config.h>
+#include <AP_Airspeed/AP_Airspeed_config.h>
+#include <AP_Camera/AP_Camera_config.h>
+#include <AP_Compass/AP_Compass_config.h>
+#include <AP_Gripper/AP_Gripper_config.h>
+#include <AP_OpticalFlow/AP_OpticalFlow_config.h>
+#include <AP_Parachute/AP_Parachute_config.h>
+#include <AP_RangeFinder/AP_RangeFinder_config.h>
+#include <AP_ServoRelayEvents/AP_ServoRelayEvents_config.h>
+#include <AP_Torqeedo/AP_Torqeedo_config.h>
+#include <AP_VisualOdom/AP_VisualOdom_config.h>
+#include <AP_Winch/AP_Winch_config.h>
+#include <AP_VideoTX/AP_VideoTX_config.h>
+#include <AP_Arming/AP_Arming_config.h>
+#include <AP_BattMonitor/AP_BattMonitor_config.h>
+
 #define NUM_RC_CHANNELS 16
 
 /// @class	RC_Channel
@@ -116,34 +132,57 @@ public:
         SIMPLE_MODE =          3, // change to simple mode
         RTL =                  4, // change to RTL flight mode
         SAVE_TRIM =            5, // save current position as level
+#if AP_MISSION_ENABLED
         SAVE_WP =              7, // save mission waypoint or RTL if in auto mode
+#endif  // AP_MISSION_ENABLED
+#if AP_CAMERA_ENABLED
         CAMERA_TRIGGER =       9, // trigger camera servo or relay
+#endif  // AP_CAMERA_ENABLED
+#if AP_RANGEFINDER_ENABLED
         RANGEFINDER =         10, // allow enabling or disabling rangefinder in flight which helps avoid surface tracking when you are far above the ground
+#endif  // AP_RANGEFINDER_ENABLED
+#if AP_FENCE_ENABLED
         FENCE =               11, // allow enabling or disabling fence in flight
+#endif  // AP_FENCE_ENABLED
         RESETTOARMEDYAW =     12, // UNUSED
         SUPERSIMPLE_MODE =    13, // change to simple mode in middle, super simple at top
         ACRO_TRAINER =        14, // low = disabled, middle = leveled, high = leveled and limited
+#if HAL_SPRAYER_ENABLED
         SPRAYER =             15, // enable/disable the crop sprayer
+#endif  // HAL_SPRAYER_ENABLED
         AUTO =                16, // change to auto flight mode
         AUTOTUNE_MODE =       17, // auto tune
         LAND =                18, // change to LAND flight mode
+#if AP_GRIPPER_ENABLED
         GRIPPER =             19, // Operate cargo grippers low=off, middle=neutral, high=on
+#endif  // AP_GRIPPER_ENABLED
+#if HAL_PARACHUTE_ENABLED
         PARACHUTE_ENABLE  =   21, // Parachute enable/disable
         PARACHUTE_RELEASE =   22, // Parachute release
         PARACHUTE_3POS =      23, // Parachute disable, enable, release with 3 position switch
+#endif  // HAL_PARACHUTE_ENABLED
+#if AP_MISSION_ENABLED
         MISSION_RESET =       24, // Reset auto mission to start from first command
+#endif  // AP_MISSION_ENABLED
         ATTCON_FEEDFWD =      25, // enable/disable the roll and pitch rate feed forward
         ATTCON_ACCEL_LIM =    26, // enable/disable the roll, pitch and yaw accel limiting
+#if HAL_MOUNT_ENABLED
         RETRACT_MOUNT1 =      27, // Retract Mount1
+#endif  // HAL_MOUNT_ENABLED
+#if AP_SERVORELAYEVENTS_ENABLED && AP_RELAY_ENABLED
+
         RELAY =               28, // Relay pin on/off (only supports first relay)
+#endif  // AP_SERVORELAYEVENTS_ENABLED && AP_RELAY_ENABLED
         LANDING_GEAR =        29, // Landing gear controller
         LOST_VEHICLE_SOUND =  30, // Play lost vehicle sound
         MOTOR_ESTOP =         31, // Emergency Stop Switch
         MOTOR_INTERLOCK =     32, // Motor On/Off switch
         BRAKE =               33, // Brake flight mode
+#if AP_SERVORELAYEVENTS_ENABLED && AP_RELAY_ENABLED
         RELAY2 =              34, // Relay2 pin on/off
         RELAY3 =              35, // Relay3 pin on/off
         RELAY4 =              36, // Relay4 pin on/off
+#endif  // AP_SERVORELAYEVENTS_ENABLED && AP_RELAY_ENABLED
         THROW =               37, // change to THROW flight mode
         AVOID_ADSB =          38, // enable AP_Avoidance library
         PRECISION_LOITER =    39, // enable precision loiter
@@ -151,8 +190,10 @@ public:
         ARMDISARM_UNUSED =    41, // UNUSED
         SMART_RTL =           42, // change to SmartRTL flight mode
         INVERTED  =           43, // enable inverted flight
+#if AP_WINCH_ENABLED
         WINCH_ENABLE =        44, // winch enable/disable
         WINCH_CONTROL =       45, // winch control
+#endif  // AP_WINCH_ENABLED
         RC_OVERRIDE_ENABLE =  46, // enable RC Override
         USER_FUNC1 =          47, // user function #1
         USER_FUNC2 =          48, // user function #2
@@ -165,16 +206,22 @@ public:
         GUIDED       =        55, // guided mode
         LOITER       =        56, // loiter mode
         FOLLOW       =        57, // follow mode
+#if AP_MISSION_ENABLED
         CLEAR_WP     =        58, // clear waypoints
+#endif  // AP_MISSION_ENABLED
         SIMPLE       =        59, // simple mode
         ZIGZAG       =        60, // zigzag mode
         ZIGZAG_SaveWP =       61, // zigzag save waypoint
         COMPASS_LEARN =       62, // learn compass offsets
         SAILBOAT_TACK =       63, // rover sailboat tack
         REVERSE_THROTTLE =    64, // reverse throttle input
+#if AP_GPS_ENABLED
         GPS_DISABLE  =        65, // disable GPS for testing
+#endif  // AP_GPS_ENABLED
+#if AP_SERVORELAYEVENTS_ENABLED && AP_RELAY_ENABLED
         RELAY5 =              66, // Relay5 pin on/off
         RELAY6 =              67, // Relay6 pin on/off
+#endif  // AP_SERVORELAYEVENTS_ENABLED && AP_RELAY_ENABLED
         STABILIZE =           68, // stabilize mode
         POSHOLD   =           69, // poshold mode
         ALTHOLD   =           70, // althold mode
@@ -185,45 +232,77 @@ public:
         SURFACE_TRACKING =    75, // Surface tracking upwards or downwards
         STANDBY  =            76, // Standby mode
         TAKEOFF   =           77, // takeoff
+#if AP_CAMERA_RUNCAM_ENABLED
         RUNCAM_CONTROL =      78, // control RunCam device
         RUNCAM_OSD_CONTROL =  79, // control RunCam OSD
+#endif  // AP_CAMERA_RUNCAM_ENABLED
+#if HAL_VISUALODOM_ENABLED
         VISODOM_ALIGN =       80, // align visual odometry camera's attitude to AHRS
+#endif  // HAL_VISUALODOM_ENABLED
         DISARM =              81, // disarm vehicle
         Q_ASSIST =            82, // disable, enable and force Q assist
         ZIGZAG_Auto =         83, // zigzag auto switch
         AIRMODE =             84, // enable / disable airmode for copter
+#if HAL_GENERATOR_ENABLED
         GENERATOR   =         85, // generator control
+#endif  // HAL_GENERATOR_ENABLED
         TER_DISABLE =         86, // disable terrain following in CRUISE/FBWB modes
         CROW_SELECT =         87, // select CROW mode for diff spoilers;high disables,mid forces progressive
         SOARING =             88, // three-position switch to set soaring mode
         LANDING_FLARE =       89, // force flare, throttle forced idle, pitch to LAND_PITCH_DEG, tilts up
         EKF_SOURCE_SET =      90, // change EKF data source set between primary, secondary and tertiary
+#if AP_AIRSPEED_AUTOCAL_ENABLE
         ARSPD_CALIBRATE=      91, // calibrate airspeed ratio 
+#endif  // AP_AIRSPEED_AUTOCAL_ENABLE
         FBWA =                92, // Fly-By-Wire-A
+#if AP_MISSION_ENABLED
         RELOCATE_MISSION =    93, // used in separate branch MISSION_RELATIVE
+#endif  // AP_MISSION_ENABLED
+#if AP_VIDEOTX_ENABLED
         VTX_POWER =           94, // VTX power level
+#endif  // AP_VIDEOTX_ENABLED
         FBWA_TAILDRAGGER =    95, // enables FBWA taildragger takeoff mode. Once this feature is enabled it will stay enabled until the aircraft goes above TKOFF_TDRAG_SPD1 airspeed, changes mode, or the pitch goes above the initial pitch when this is engaged or goes below 0 pitch. When enabled the elevator will be forced to TKOFF_TDRAG_ELEV. This option allows for easier takeoffs on taildraggers in FBWA mode, and also makes it easier to test auto-takeoff steering handling in FBWA.
         MODE_SWITCH_RESET =   96, // trigger re-reading of mode switch
         WIND_VANE_DIR_OFSSET= 97, // flag for windvane direction offset input, used with windvane type 2
         TRAINING            = 98, // mode training
+#if AP_MISSION_ENABLED
         AUTO_RTL =            99, // AUTO RTL via DO_LAND_START
+#endif  // AP_MISSION_ENABLED
 
+#if AP_INERTIALSENSOR_KILL_IMU_ENABLED
         // entries from 100-150  are expected to be developer
         // options used for testing
         KILL_IMU1 =          100, // disable first IMU (for IMU failure testing)
         KILL_IMU2 =          101, // disable second IMU (for IMU failure testing)
+#endif  // AP_INERTIALSENSOR_KILL_IMU_ENABLED
+#if AP_CAMERA_ENABLED
         CAM_MODE_TOGGLE =    102, // Momentary switch to cycle camera modes
+#endif  // AP_CAMERA_ENABLED
+#if AP_AHRS_ENABLED
         EKF_LANE_SWITCH =    103, // trigger lane switch attempt
         EKF_YAW_RESET =      104, // trigger yaw reset attempt
+#endif  // AP_AHRS_ENABLED
+#if AP_GPS_ENABLED
         GPS_DISABLE_YAW =    105, // disable GPS yaw for testing
+#endif  // AP_GPS_ENABLED
+#if AP_AIRSPEED_ENABLED
         DISABLE_AIRSPEED_USE = 106, // equivalent to AIRSPEED_USE 0
+#endif  // AP_AIRSPEED_ENABLED
         FW_AUTOTUNE =          107, // fixed wing auto tune
         QRTL =               108, // QRTL mode
         CUSTOM_CONTROLLER =  109,  // use Custom Controller
+#if AP_INERTIALSENSOR_KILL_IMU_ENABLED
         KILL_IMU3 =          110, // disable third IMU (for IMU failure testing)
+#endif  // AP_INERTIALSENSOR_KILL_IMU_ENABLED
+#if HAL_GENERATOR_ENABLED
         LOWEHEISER_STARTER = 111,  // allows for manually running starter
+#endif  // HAL_GENERATOR_ENABLED
+#if AP_AHRS_ENABLED
         AHRS_TYPE =          112, // change AHRS_EKF_TYPE
+#endif  // AP_AHRS_ENABLED
+#if HAL_MOUNT_ENABLED
         RETRACT_MOUNT2 =     113, // Retract Mount2
+#endif  // HAL_MOUNT_ENABLED
 
         // if you add something here, make sure to update the documentation of the parameter in RC_Channel.cpp!
         // also, if you add an option >255, you will need to fix duplicate_options_exist
@@ -232,31 +311,51 @@ public:
         CRUISE =             150,  // CRUISE mode
         TURTLE =             151,  // Turtle mode - flip over after crash
         SIMPLE_HEADING_RESET = 152, // reset simple mode reference heading to current
+#if AP_ARMING_ENABLED
         ARMDISARM =          153, // arm or disarm vehicle
         ARMDISARM_AIRMODE =  154, // arm or disarm vehicle enabling airmode
+#endif  // AP_ARMING_ENABLED
         TRIM_TO_CURRENT_SERVO_RC = 155, // trim to current servo and RC
+#if HAL_TORQEEDO_ENABLED
         TORQEEDO_CLEAR_ERR = 156, // clear torqeedo error
+#endif  // HAL_TORQEEDO_ENABLED
         EMERGENCY_LANDING_EN = 157, //Force long FS action to FBWA for landing out of range
+#if AP_OPTICALFLOW_ENABLED
         OPTFLOW_CAL =        158, // optical flow calibration
+#endif  // AP_OPTICALFLOW_ENABLED
         FORCEFLYING =        159, // enable or disable land detection for GPS based manual modes preventing land detection and maintainting set_throttle_mix_max
         WEATHER_VANE_ENABLE = 160, // enable/disable weathervaning
         TURBINE_START =      161, // initialize turbine start sequence
         FFT_NOTCH_TUNE =     162, // FFT notch tuning function
+#if HAL_MOUNT_ENABLED
         MOUNT_LOCK =         163, // Mount yaw lock vs follow
+#endif  // HAL_MOUNT_ENABLED
+#if HAL_LOGGING_ENABLED
         LOG_PAUSE =          164, // Pauses logging if under logging rate control
+#endif  // HAL_LOGGING_ENABLED
         ARM_EMERGENCY_STOP = 165, // ARM on high, MOTOR_ESTOP on low
+#if AP_CAMERA_ENABLED
         CAMERA_REC_VIDEO =   166, // start recording on high, stop recording on low
         CAMERA_ZOOM =        167, // camera zoom high = zoom in, middle = hold, low = zoom out
         CAMERA_MANUAL_FOCUS = 168,// camera manual focus.  high = long shot, middle = stop focus, low = close shot
         CAMERA_AUTO_FOCUS =  169, // camera auto focus
+#endif  // AP_CAMERA_ENABLED
         QSTABILIZE =         170, // QuadPlane QStabilize mode
+#if COMPASS_CAL_ENABLED
         MAG_CAL =            171, // Calibrate compasses (disarmed only)
+#endif  // COMPASS_CAL_ENABLED
+#if AP_BATTERY_ENABLED
         BATTERY_MPPT_ENABLE = 172,// Battery MPPT Power enable. high = ON, mid = auto (controlled by mppt/batt driver), low = OFF. This effects all MPPTs.
+#endif  // AP_BATTERY_ENABLED
         PLANE_AUTO_LANDING_ABORT = 173, // Abort Glide-slope or VTOL landing during payload place or do_land type mission items
+#if AP_CAMERA_ENABLED
         CAMERA_IMAGE_TRACKING = 174, // camera image tracking
         CAMERA_LENS =        175, // camera lens selection
+#endif  // AP_CAMERA_ENABLED
         VFWD_THR_OVERRIDE =  176, // force enabled VTOL forward throttle method
+#if HAL_MOUNT_ENABLED
         MOUNT_LRF_ENABLE =   177,  // mount LRF enable/disable
+#endif  // HAL_MOUNT_ENABLED
         FLIGHTMODE_PAUSE =   178,  // e.g. pause movement towards waypoint
         ICE_START_STOP =     179, // AP_ICEngine start stop
         AUTOTUNE_TEST_GAINS = 180, // auto tune tuning switch to test or revert gains
@@ -275,18 +374,23 @@ public:
         FWD_THR =            209, // VTOL manual forward throttle
         AIRBRAKE =           210, // manual airbrake control
         WALKING_HEIGHT =     211, // walking robot height input
+#if HAL_MOUNT_ENABLED
         MOUNT1_ROLL =        212, // mount1 roll input
         MOUNT1_PITCH =       213, // mount1 pitch input
         MOUNT1_YAW =         214, // mount1 yaw input
         MOUNT2_ROLL =        215, // mount2 roll input
         MOUNT2_PITCH =       216, // mount3 pitch input
         MOUNT2_YAW =         217, // mount4 yaw input
+#endif  // HAL_MOUNT_ENABLED
+#if HAL_GENERATOR_ENABLED
         LOWEHEISER_THROTTLE= 218, // allows for throttle on slider
+#endif  // HAL_GENERATOR_ENABLED
         TRANSMITTER_TUNING = 219, // use a transmitter knob or slider for in-flight tuning
 
         // inputs 248-249 are reserved for the Skybrush fork at
         // https://github.com/skybrush-io/ardupilot
 
+#if AP_SCRIPTING_ENABLED
         // inputs for the use of onboard lua scripting
         SCRIPTING_1 =        300,
         SCRIPTING_2 =        301,
@@ -304,6 +408,7 @@ public:
         SCRIPTING_14 =       313,
         SCRIPTING_15 =       314,
         SCRIPTING_16 =       315,
+#endif  // AP_SCRIPTING_ENABLED
 
         // this must be higher than any aux function above
         AUX_FUNCTION_MAX =   316,


### PR DESCRIPTION
This is a no-compiler-output change PR.

This patch was previously used to catch cases where there was dead code still included in the compiled output which would never actually be used because the feature it relied on was not compiled in.

I think it makes for a good pattern for us to follow in here - in fact there may be more savings lurking (eg. `RC_Channel::do_aux_function_avoid_proximity`)

```
Board,plane
CubeOrange,*
MatekF405-Wing,*
```