### PR TITLE
Sub: remove parameter default which is the base default anyway

### DIFF
--- a/ArduSub/Parameters.h
+++ b/ArduSub/Parameters.h
@@ -449,9 +449,6 @@ static const struct AP_Param::defaults_table_struct defaults_table[] = {
     { "RC_PROTOCOLS",        0},
 #endif
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIGATOR
-#if AP_BARO_PROBE_EXT_PARAMETER_ENABLED
-    { "BARO_PROBE_EXT",      0},
-#endif
     { "BATT_MONITOR",        4},
     { "BATT_CAPACITY",       0},
     { "LEAK1_PIN",           27},


### PR DESCRIPTION
0 is just the base value set in AP_Baro.cpp

See `HAL_BARO_PROBE_EXT_DEFAULT`

Hopefully we can move these defaults into a defaults.parm next to the navigator hwdef at some stage.
