### PR TITLE
AP_Mount: SToRM32 search continues while disarmed

### DIFF
--- a/libraries/AP_Mount/AP_Mount_SToRM32.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.cpp
@@ -110,8 +110,8 @@ void AP_Mount_SToRM32::find_gimbal()
         return;
     }
 
-    // return if search time has has passed
-    if (AP_HAL::millis() > AP_MOUNT_STORM32_SEARCH_MS) {
+    // search for gimbal for 60 seconds or until armed
+    if ((AP_HAL::millis() > AP_MOUNT_STORM32_SEARCH_MS) && hal.util->get_soft_armed()) {
         return;
     }
 


### PR DESCRIPTION
This relaxes the SToRM32 mavlink gimbal driver's "find_gimbal" check so that instead of giving up after 60 seconds, it continues searching until the vehicle is armed.  This is consistent with the similar Gremsy mavlink gimbal ([see gremsy code here](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Mount/AP_Mount_Gremsy.cpp#L139))

This has not been tested because I do not have one of the gimbals myself.  Still, from inspection I'm fairly confident that it must be correct.

This was requested by one of the AP Partner companies