### PR TITLE
Quick Fix for Autotune in Copter 4.6

### DIFF
--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -324,6 +324,7 @@ bool AC_AutoTune::currently_level()
         GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "AutoTune: Failed to level, please tune manually");
         mode = FAILED;
         LOGGER_WRITE_EVENT(LogEvent::AUTOTUNE_FAILED);
+        load_gains(GAIN_ORIGINAL);
     }
 
     // slew threshold to ensure sufficient settling time for aircraft unable to obtain small thresholds

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
@@ -286,11 +286,13 @@ void AC_AutoTune_Heli::test_run(AxisType test_axis, const float dir_sign)
             mode = FAILED;
             LOGGER_WRITE_EVENT(LogEvent::AUTOTUNE_FAILED);
             update_gcs(AUTOTUNE_MESSAGE_FAILED);
+            load_gains(GAIN_ORIGINAL);
         } else if ((tune_type == MAX_GAINS || tune_type == RP_UP || tune_type == RD_UP || tune_type == SP_UP) && exceeded_freq_range(start_freq)){
             GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AutoTune: Exceeded frequency range");
             mode = FAILED;
             LOGGER_WRITE_EVENT(LogEvent::AUTOTUNE_FAILED);
             update_gcs(AUTOTUNE_MESSAGE_FAILED);
+            load_gains(GAIN_ORIGINAL);
         } else if (tune_type == TUNE_COMPLETE) {
             counter = AUTOTUNE_SUCCESS_COUNT;
             step = UPDATE_GAINS;

--- a/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Multi.cpp
@@ -579,6 +579,7 @@ void AC_AutoTune_Multi::twitching_abort_rate(float angle, float rate, float angl
                 GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "AutoTune: Twitch Size Determination Failed");
                 mode = FAILED;
                 LOGGER_WRITE_EVENT(LogEvent::AUTOTUNE_FAILED);
+                load_gains(GAIN_ORIGINAL);
             }
             // ignore result and start test again
             step = ABORT;
@@ -953,6 +954,7 @@ void AC_AutoTune_Multi::updating_rate_p_up_d_down(float &tune_d, float tune_d_mi
                 GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "AutoTune: Rate D Gain Determination Failed");
                 mode = FAILED;
                 LOGGER_WRITE_EVENT(LogEvent::AUTOTUNE_FAILED);
+                load_gains(GAIN_ORIGINAL);
             }
         }
         // decrease P gain to match D gain reduction
@@ -963,6 +965,7 @@ void AC_AutoTune_Multi::updating_rate_p_up_d_down(float &tune_d, float tune_d_mi
             GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "AutoTune: Rate P Gain Determination Failed");
             mode = FAILED;
             LOGGER_WRITE_EVENT(LogEvent::AUTOTUNE_FAILED);
+            load_gains(GAIN_ORIGINAL);
         }
     } else {
         if (ignore_next == false) {
@@ -1012,6 +1015,7 @@ void AC_AutoTune_Multi::updating_angle_p_down(float &tune_p, float tune_p_min, f
             GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "AutoTune: Angle P Gain Determination Failed");
             mode = FAILED;
             LOGGER_WRITE_EVENT(LogEvent::AUTOTUNE_FAILED);
+            load_gains(GAIN_ORIGINAL);
        }
     }
 }


### PR DESCRIPTION
I have added an autotest that doesn't do the check but creates the abort. I have added events in the load sections so you can see which set of parameters are being used in the log.

The last commit should be removed before merging.
