### PR TITLE
pre-commit: Remove the flake8 Tools-only restriction

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,8 +55,7 @@ repos:
       rev: 7.3.0
       hooks:
       -   id: flake8
-          args:
-            - Tools
+
 # # Use to sort python imports by name and put system import first.
 #   -   repo: https://github.com/pycqa/isort
 #       rev: 5.12.0


### PR DESCRIPTION
Locks in the changes made in:
* #30340

Completes step 2 of:
* https://github.com/ArduPilot/ardupilot/pull/30288#discussion_r2136752562