### PR TITLE
Fix #12996, fixed auto_state.checked_for_autoland from being reset at mode change

### DIFF
--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -40,9 +40,6 @@ bool Mode::enter()
     // don't cross-track when starting a mission
     plane.auto_state.next_wp_crosstrack = false;
 
-    // reset landing check
-    plane.auto_state.checked_for_autoland = false;
-
     // zero locked course
     plane.steer_state.locked_course_err = 0;
     plane.steer_state.locked_course = false;


### PR DESCRIPTION
Removed **checked_for_autoland** from **bool Mode::enter()**: This fixes #12996, as each time the mode changes it wont return to false, only during arming.

If **checked_for_autoland** is set true, it will now persist throughout.