### PR TITLE
Plane: quantise the airspeed target from MIN_GROUNDSPEED

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -437,6 +437,7 @@ private:
     // The amount current ground speed is below min ground speed.  Centimeters per second
     int32_t groundspeed_undershoot;
     bool groundspeed_undershoot_is_valid;
+    float last_groundspeed_undershoot_offset;
 
     // speed scaler for control surfaces, updated at 10Hz
     float surface_speed_scaler = 1.0;


### PR DESCRIPTION
TECS is very sensitive to oscillation when it has a changing airspeed target which results from triggering of MIN_GROUNDSPEED. To avoid this we quantise the target and apply a hysteresis. This greatly reduces the oscillation, although it isn't completely eliminated

Tested in SITL with high wind. Before the PR:
![image](https://github.com/user-attachments/assets/bdfea81b-d50d-4d3d-bd28-e30dfbb63e74)
after:
![image](https://github.com/user-attachments/assets/952dc27f-0c03-4fbc-9218-cda38fb19121)

SITL logs here:
https://uav.tridgell.net/tmp/MIN_GROUNDSPEED/

