### PR TITLE
AP_Param: check for duplicate names when adding scripting params

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -5625,9 +5625,9 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.reboot_sitl()
         self.wait_text("Loaded UniversalAutoLand.lua", check_context=True)
         self.set_parameters({
-             "AUTOLAND_ENABLE" : 1,
-             "AUTOLAND_WP_ALT" : 55,
-             "AUTOLAND_WP_DIST" : 400
+             "ALAND_ENABLE" : 1,
+             "ALAND_WP_ALT" : 55,
+             "ALAND_WP_DIST" : 400
             })
         self.wait_ready_to_arm()
         self.scripting_restart()

--- a/libraries/AP_Scripting/applets/UniversalAutoLand.lua
+++ b/libraries/AP_Scripting/applets/UniversalAutoLand.lua
@@ -3,7 +3,7 @@
 local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
 
 local PARAM_TABLE_KEY = 80
-local PARAM_TABLE_PREFIX = "AUTOLAND_"
+local PARAM_TABLE_PREFIX = "ALAND_"
 assert(param:add_table(PARAM_TABLE_KEY, PARAM_TABLE_PREFIX, 4), 'could not add param table')
 
 -- add a parameter and bind it to a variable
@@ -13,9 +13,9 @@ function bind_add_param(name, idx, default_value)
 end
 
 --[[
-  // @Param: AUTOLAND_ENABLE
-  // @DisplayName: AUTOLAND ENABLE
-  // @Description: enable AUTOLAND script action
+  // @Param: ALAND_ENABLE
+  // @DisplayName: Auto land enable
+  // @Description: enable Auto land script action
   // @Values: 0:Disabled,1:Enabled
   // @User: Standard
 --]]
@@ -23,7 +23,7 @@ local AULND_ENABLE = bind_add_param('ENABLE', 1, 1)
 local enable = AULND_ENABLE:get()
 
 --[[
-  // @Param: AUTOLAND_WP_ALT
+  // @Param: ALAND_WP_ALT
   // @DisplayName: Final approach waypoint alt
   // @Description: Altitude of final approach waypoint created by script
   // @Range: 1 100
@@ -33,9 +33,9 @@ local enable = AULND_ENABLE:get()
 local AULND_ALT = bind_add_param('WP_ALT', 2, 0)
 local final_wp_alt = AULND_ALT:get()
 --[[
-  // @Param: AUTOLAND_WP_DIST
+  // @Param: ALAND_WP_DIST
   // @DisplayName: Final approach waypoint distance
-  // @Description: Distance from landng point (HOME) to final approach waypoint created by script in the opposite direction of initial takeoff
+  // @Description: Distance from landing point (HOME) to final approach waypoint created by script in the opposite direction of initial takeoff
   // @Range: 0 1000
   // @Units: m
   // @User: Standard


### PR DESCRIPTION
This adds a check for adding duplicated param names from scripting. Duplicate param names confuse GCS's. This checks against all existing params, so you cannot add a param that conflicts with a C++ one, you also cannot add a param that would conflict with another param added by a script either in the same script or in another script. Scripting restarts still work.

This is loading plane aerobatics on master (CubeOrangePlus):
![image](https://github.com/user-attachments/assets/d7120273-0b95-419c-97ad-80585045fed3)
811853us is 0.81 seconds.

On this branch:
![image](https://github.com/user-attachments/assets/2b8399b8-c9b7-472b-8144-2a1dd0b06715)
824554us is 0.82 seconds

Plane aerobatics loads on the order of 40 params, it seems to be in the noise of the measurement. The script already does a fetch by name when adding the parameter to get the object into the script, we now do another one per param. This script does lots of other setup stuff in its first call, I'm sure we could write a script where this had a much more dramatic effect compared to the current setup.