### PR TITLE
AP_Arming: Show detailed failure information

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -390,12 +390,13 @@ bool AP_Arming::airspeed_checks(bool report)
 bool AP_Arming::logging_checks(bool report)
 {
     if (check_enabled(Check::LOGGING)) {
+        int8_t ret = 0;
         if (!AP::logger().logging_present()) {
             // Logging is disabled, so nothing to check.
             return true;
         }
-        if (AP::logger().logging_failed()) {
-            check_failed(Check::LOGGING, report, "Logging failed");
+        if ((ret = AP::logger().logging_failed())) {
+            check_failed(Check::LOGGING, report, "Logging failed %d", ret);
             return false;
         }
         if (!AP::logger().CardInserted()) {

--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -599,18 +599,18 @@ bool AP_Logger::logging_enabled() const
     }
     return false;
 }
-bool AP_Logger::logging_failed() const
+int8_t AP_Logger::logging_failed() const
 {
     if (_next_backend < 1) {
         // we should not have been called!
-        return true;
+        return 1;
     }
     for (uint8_t i=0; i<_next_backend; i++) {
         if (backends[i]->logging_failed()) {
-            return true;
+            return 2;
         }
     }
-    return false;
+    return 0;
 }
 
 void AP_Logger::Write_MessageF(const char *fmt, ...)

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -360,7 +360,7 @@ public:
     // typically AP_Logger_File.
     bool logging_present() const;
     bool logging_enabled() const;
-    bool logging_failed() const;
+    int8_t logging_failed() const;
 
     // notify logging subsystem of an arming failure. This triggers
     // logging for HAL_LOGGER_ARM_PERSIST seconds


### PR DESCRIPTION
This anomaly notification has two causes.
By clarifying these causes, the root issue can be identified.

This image shows that the notification is triggered periodically if the system remains powered on after disarming.
![515157938_24355985754026016_7921214884530593521_n](https://github.com/user-attachments/assets/f4beca3b-55f2-4eef-8f74-f250b91a4791)




