### PR TITLE
Tools: size_compare_branches.py: don't build bootloader for pilotpi/A…

### DIFF
--- a/Tools/scripts/size_compare_branches.py
+++ b/Tools/scripts/size_compare_branches.py
@@ -163,6 +163,7 @@ class SizeCompareBranches(object):
             'TBS-L431-BattMon',  # uses USE_BOOTLOADER_FROM_BOARD
             'TBS-L431-CurrMon',  # uses USE_BOOTLOADER_FROM_BOARD
             'TBS-L431-PWM',  # uses USE_BOOTLOADER_FROM_BOARD
+            'ARKV6X-bdshot',  # uses USE_BOOTLOADER_FROM_BOARD
         ])
 
         # blacklist all linux boards for bootloader build:
@@ -199,6 +200,7 @@ class SizeCompareBranches(object):
             'SITL_x86_64_linux_gnu',
             'canzero',
             'linux',
+            'pilotpi',
         ]
 
     def esp32_board_names(self):


### PR DESCRIPTION
…RKV6X-bdshot

We don't build bootloaders for Linux boards, so don't try for pilotpi

ARKV6X-bdshot uses the bootloader from ARKV6X


I do have branches to do this better.  Soon, hopefully...
