### PR TITLE
Plane: rework `allow_reverse_thrust` to allow reverse thrust in manual modes with `USE_REV_THRUST` 0

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -221,10 +221,10 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Param: USE_REV_THRUST
     // @DisplayName: Bitmask for when to allow negative reverse thrust
-    // @Description: This controls when to use reverse thrust. If set to zero then reverse thrust is never used. If set to a non-zero value then the bits correspond to flight stages where reverse thrust may be used. The most commonly used value for USE_REV_THRUST is 2, which means AUTO_LAND only. That enables reverse thrust in the landing stage of AUTO mode. Another common choice is 1, which means to use reverse thrust in all auto flight stages. Reverse thrust is always used in MANUAL mode if enabled with THR_MIN < 0. In non-autothrottle controlled modes, if reverse thrust is not used, then THR_MIN is effectively set to 0 for that mode.
+    // @Description: This controls when to use reverse thrust. If set to a non-zero value then the bits correspond to flight stages where reverse thrust may be used. The most commonly used value for USE_REV_THRUST is 2, which means AUTO_LAND only. That enables reverse thrust in the landing stage of AUTO mode. Another common choice is 1, which means to use reverse thrust in all auto flight stages. Reverse thrust is always used in MANUAL mode if enabled with THR_MIN < 0. In non-autothrottle controlled modes, if reverse thrust is not used, then THR_MIN is effectively set to 0 for that mode.
     // @Bitmask: 0:AUTO_ALWAYS,1:AUTO_LAND,2:AUTO_LOITER_TO_ALT,3:AUTO_LOITER_ALL,4:AUTO_WAYPOINTS,5:LOITER,6:RTL,7:CIRCLE,8:CRUISE,9:FBWB,10:GUIDED,11:AUTO_LANDING_PATTERN,12:FBWA,13:ACRO,14:STABILIZE,15:THERMAL
     // @User: Advanced
-    GSCALAR(use_reverse_thrust,     "USE_REV_THRUST",  USE_REVERSE_THRUST_AUTO_LAND_APPROACH),
+    GSCALAR(use_reverse_thrust,     "USE_REV_THRUST",  float(UseReverseThrust::AUTO_LAND_APPROACH)),
 
     // @Param: ALT_OFFSET
     // @DisplayName: Altitude offset

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1219,6 +1219,7 @@ private:
     bool have_reverse_thrust(void) const;
     float get_throttle_input(bool no_deadzone=false) const;
     float get_adjusted_throttle_input(bool no_deadzone=false) const;
+    bool reverse_thrust_enabled(UseReverseThrust use_reverse_thrust_option) const;
 
 #if AP_SCRIPTING_ENABLED
     // support for NAV_SCRIPT_TIME mission command

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -125,24 +125,23 @@ enum {
     // note: next enum will be (1<<1), then (1<<2), then (1<<3)
 };
 
-enum {
-    USE_REVERSE_THRUST_NEVER                    = 0,
-    USE_REVERSE_THRUST_AUTO_ALWAYS              = (1<<0),
-    USE_REVERSE_THRUST_AUTO_LAND_APPROACH       = (1<<1),
-    USE_REVERSE_THRUST_AUTO_LOITER_TO_ALT       = (1<<2),
-    USE_REVERSE_THRUST_AUTO_LOITER_ALL          = (1<<3),
-    USE_REVERSE_THRUST_AUTO_WAYPOINT            = (1<<4),
-    USE_REVERSE_THRUST_LOITER                   = (1<<5),
-    USE_REVERSE_THRUST_RTL                      = (1<<6),
-    USE_REVERSE_THRUST_CIRCLE                   = (1<<7),
-    USE_REVERSE_THRUST_CRUISE                   = (1<<8),
-    USE_REVERSE_THRUST_FBWB                     = (1<<9),
-    USE_REVERSE_THRUST_GUIDED                   = (1<<10),
-    USE_REVERSE_THRUST_AUTO_LANDING_PATTERN     = (1<<11),
-    USE_REVERSE_THRUST_FBWA                   = (1<<12),
-    USE_REVERSE_THRUST_ACRO                   = (1<<13),
-    USE_REVERSE_THRUST_STABILIZE            = (1<<14),
-    USE_REVERSE_THRUST_THERMAL             = (1<<15),
+enum class UseReverseThrust {
+    AUTO_ALWAYS          = (1<<0),
+    AUTO_LAND_APPROACH   = (1<<1),
+    AUTO_LOITER_TO_ALT   = (1<<2),
+    AUTO_LOITER_ALL      = (1<<3),
+    AUTO_WAYPOINT        = (1<<4),
+    LOITER               = (1<<5),
+    RTL                  = (1<<6),
+    CIRCLE               = (1<<7),
+    CRUISE               = (1<<8),
+    FBWB                 = (1<<9),
+    GUIDED               = (1<<10),
+    AUTO_LANDING_PATTERN = (1<<11),
+    FBWA                 = (1<<12),
+    ACRO                 = (1<<13),
+    STABILIZE            = (1<<14),
+    THERMAL              = (1<<15),
 };
 
 enum FlightOptions {


### PR DESCRIPTION
fixes https://github.com/ArduPilot/ardupilot/issues/30530

There was a early return for the `USE_REV_THRUST` 0 case which should not have been there. `USE_REV_THRUST` defaults to 2 so we have never noticed this before as the parameter is rarely changed.

This also updates the enum to a enum class and adds a helper.