### PR TITLE
.github: Keep Actions up to date with GitHub's Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Keep GitHub Actions up to date with GitHub's Dependabot...
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    commit-message:
+      prefix: .github
+    directory: /
+    groups:
+      github-actions:
+        patterns:
+          - "*"  # Group all Actions updates into a single larger pull request
+    schedule:
+      interval: weekly


### PR DESCRIPTION
* ArduPilot/pymavlink#1065
    * —> ArduPilot/pymavlink#1077 
* [Keeping your software supply chain secure with Dependabot](https://docs.github.com/en/code-security/dependabot)
* [Keeping your actions up to date with Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot)
* [Configuration options for the  file - package-ecosystem](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem)

GitHub Actions are only used at CI test-time, while most other dependencies are also used at runtime.  This means that if the CI tests pass, maintainers have more confidence that the proposed changes will not break runtime.  

GitHub Actions have very infrequent major version changes .  `setup-python`, the most frequent, has had only four major upgrades in its lifetime.

When GitHub Actions are upgraded, it often happens in batches.  The `pattern: *` proposed in this PR will consolidate all GHA updates into a single pull request to further reduce chattiness.  Please see the example output provided below.

There is a tradeoff between supply chain security and chattiness.  Given that we have a few GHAs that are updated rarely and usually in batches, and we are using `pattern: *` to ensure that ___there will only ever be a single GHA upgrade PR at a time___. 

% `git grep "uses: " .github/workflows | awk '{print $NF}' | sort | uniq`