### PR TITLE
Rover: Better pivot turns through steering deceleration parameter

### DIFF
--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -154,6 +154,7 @@ private:
     AP_Int8  _brake_enable;         // speed control brake enable/disable. if set to 1 a reversed output to the motors to slow the vehicle.
     AP_Float _stop_speed;           // speed control stop speed.  Motor outputs to zero once vehicle speed falls below this value
     AP_Float _steer_accel_max;      // steering angle acceleration max in deg/s/s
+    AP_Float _steer_decel_max;      // steering angle deceleration max in deg/s/s
     AP_Float _steer_rate_max;       // steering rate control maximum rate in deg/s
     AP_Float _turn_lateral_G_max;   // sterring maximum lateral acceleration limit in 'G'
 


### PR DESCRIPTION
This PR adds a new parameter ``ATC_STR_DEC_MAX``, the maximum steering deceleration (deg/sec/sec).

This allows for much more accurate pivot turns, as many skid-steering vehicles have a much lower deceleration (vs acceleration) rate for steering.

It also fixes the odd "veering" behaviour seen just after a pivot turn.

Before:
![Rover_Navigation_Yaw_Tracking_before](https://github.com/user-attachments/assets/3caf5102-7fda-4465-aefd-db4fcdb61ce9)
The pivot turn overshoot (red) is quite obvious, as the vehicle is unable to decelerate it's turn from 180deg/sec to 0deg/sec by time it reaches the desired yaw angle (green)

After:
![Rover_Navigation_Yaw_Tracking_after](https://github.com/user-attachments/assets/ac2ec52d-dd20-49ba-a02f-216fddefd0ec)
The pivot turn overshoot (red) is gone.

In general, I found that ``ATC_STR_DEC_MAX`` should be about half of ``ATC_STR_ACC_MAX``.