### PR TITLE
ArduCopter: terrain failsafe fix confusing message

### DIFF
--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -281,7 +281,18 @@ void Copter::failsafe_terrain_set_status(bool data_ok)
 void Copter::failsafe_terrain_on_event()
 {
     failsafe.terrain = true;
-    gcs().send_text(MAV_SEVERITY_CRITICAL,"Failsafe: Terrain data missing");
+    switch (wp_nav->get_terrain_source()) {
+    case AC_WPNav::TerrainSource::TERRAIN_FROM_TERRAINDATABASE:
+        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"Failsafe: Terrain %s", "data missing");
+        break;
+    case AC_WPNav::TerrainSource::TERRAIN_FROM_RANGEFINDER:
+        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"Failsafe: Terrain %s", "Rangefinder Unhealthy");
+        break;
+    case AC_WPNav::TerrainSource::TERRAIN_UNAVAILABLE:
+        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL,"Failsafe: Terrain %s", "Unavailable");
+        break;
+    }
+
     LOGGER_WRITE_ERROR(LogErrorSubsystem::FAILSAFE_TERRAIN, LogErrorCode::FAILSAFE_OCCURRED);
 
     if (should_disarm_on_failsafe()) {

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1562,7 +1562,7 @@ void ModeAuto::do_nav_wp(const AP_Mission::Mission_Command& cmd)
     const Location target_loc = loc_from_cmd(cmd, default_loc);
 
     if (!wp_start(target_loc)) {
-        // failure to set next destination can only be because of missing terrain data
+        // failure to set next destination can be because of missing terrain data or unhealthy rangefinder
         copter.failsafe_terrain_on_event();
         return;
     }


### PR DESCRIPTION
When using terrain altitudes if ArduCopter can't get the terrain, it always reports "terrain data missing", but if a rangefinder is being used for terrain, if the rangefinder is unhealthy it still reports "terrain data missing".

This displays "Terrain rangefinder unhealthy" if the failure to get a terrain height is due to the rangefinder rather than the terrain data.