### PR TITLE
SITL: correct safety switch behaviour in SITL for Rover

### DIFF
--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6861,6 +6861,30 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.context_pop()
         self.reboot_sitl()
 
+    def SafetySwitch(self):
+        '''check safety switch works'''
+        self.start_subtest("Make sure we don't start moving when safety switch enabled")
+        self.wait_ready_to_arm()
+        self.set_rc(1, 2000)
+        self.wait_armed()
+        self.set_rc(1, 1500)
+        self.set_safetyswitch_on()
+        self.wait_groundspeed(0, 0.1, minimum_duration=2)
+        self.set_safetyswitch_off()
+        self.disarm_vehicle()
+
+        self.start_subtest("Make sure we stop moving when safety switch enabled")
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        self.set_rc(3, 1700)
+        self.wait_groundspeed(5, 100, minimum_duration=2)
+        self.set_safetyswitch_on()
+        self.wait_groundspeed(0, 0.1, minimum_duration=2)
+        self.set_safetyswitch_off()
+        self.wait_groundspeed(5, 100, minimum_duration=2)
+        self.set_rc(3, 1500)
+        self.disarm_vehicle()
+
     def GetMessageInterval(self):
         '''check that the two methods for requesting a MESSAGE_INTERVAL message are equivalent'''
         target_msg = mavutil.mavlink.MAVLINK_MSG_ID_HOME_POSITION
@@ -6988,6 +7012,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             self.BatteryInvalid,
             self.REQUIRE_LOCATION_FOR_ARMING,
             self.GetMessageInterval,
+            self.SafetySwitch,
             self.ThrottleFailsafe,
         ])
         return ret

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -445,9 +445,13 @@ void SITL_State::_simulator_servos(struct sitl_input &input)
             throttle = hover_throttle;
         }
     } else if (_vehicle == Rover) {
-        input.servos[2] = static_cast<uint16_t>(constrain_int16(input.servos[2], 1000, 2000));
+        if (input.servos[2] != 0) {
+            input.servos[2] = static_cast<uint16_t>(constrain_int16(input.servos[2], 1000, 2000));
+            throttle = fabsf((input.servos[2] - 1500) / 500.0f);
+        } else {
+            throttle = 0;
+        }
         input.servos[0] = static_cast<uint16_t>(constrain_int16(input.servos[0], 1000, 2000));
-        throttle = fabsf((input.servos[2] - 1500) / 500.0f);
     } else {
         // run checks on each motor
         uint8_t running_motors = 0;

--- a/libraries/SITL/SIM_Rover.cpp
+++ b/libraries/SITL/SIM_Rover.cpp
@@ -148,12 +148,24 @@ void SimRover::update_ackermann_or_skid(const struct sitl_input &input, float de
     // if in skid steering mode the steering and throttle values are used for motor1 and motor2
     if (skid_steering) {
         float motor1 = 2*((input.servos[0]-1000)/1000.0f - 0.5f);
+        if (input.servos[0] == 0) {
+            // eg. safety switch in "safe" mode
+            motor1 = 0;
+        }
         float motor2 = 2*((input.servos[2]-1000)/1000.0f - 0.5f);
+        if (input.servos[2] == 0) {
+            // eg. safety switch in "safe" mode
+            motor2 = 0;
+        }
         steering = motor1 - motor2;
         throttle = 0.5*(motor1 + motor2);
     } else {
         steering = 2*((input.servos[0]-1000)/1000.0f - 0.5f);
         throttle = 2*((input.servos[2]-1000)/1000.0f - 0.5f);
+        if (input.servos[2] == 0) {
+            // eg. safety switch in "safe" mode
+            throttle = 0;
+        }
 
         // vectored thrust conversion
         if (vectored_thrust) {


### PR DESCRIPTION
It isn't hard to replicate this in SITL; `arm throttle` followed by `arm safetyon` is sufficient.  The vehicle starts going in circles really, really fast.
