### PR TITLE
Tools: pytest Tools/ros2 do not assume the working directory

### DIFF
--- a/Tools/ros2/ardupilot_dds_tests/test/test_copyright.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/test_copyright.py
@@ -13,13 +13,18 @@
 # limitations under the License.
 
 """Test files include a copyright notice."""
-from ament_copyright.main import main
+from pathlib import Path
+
 import pytest
+from ament_copyright.main import main
 
 
 @pytest.mark.copyright
 @pytest.mark.linter
 def test_copyright():
     """Copyright test case."""
-    rc = main(argv=[".", "test"])
+    ros2_dir = Path(__file__).parent.parent.parent
+    assert ros2_dir.name == "ros2", "This test must be run from the ROS 2 directory"
+    assert ros2_dir.parent.name == "Tools", "This test must be run in the Tools/ros2"
+    rc = main(argv=[str(ros2_dir), "test"])
     assert rc == 0, "Found errors"

--- a/Tools/ros2/ardupilot_dds_tests/test/test_pep257.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/test_pep257.py
@@ -13,13 +13,18 @@
 # limitations under the License.
 
 """Test Python files satisfy PEP257."""
-from ament_pep257.main import main
+from pathlib import Path
+
 import pytest
+from ament_pep257.main import main
 
 
 @pytest.mark.linter
 @pytest.mark.pep257
 def test_pep257():
     """PEP257 test case."""
-    rc = main(argv=[".", "test"])
+    ros2_dir = Path(__file__).parent.parent.parent
+    assert ros2_dir.name == "ros2", "This test must be run from the ROS 2 directory"
+    assert ros2_dir.parent.name == "Tools", "This test must be run in the Tools/ros2"
+    rc = main(argv=[str(ros2_dir), "test"])
     assert rc == 0, "Found code style errors / warnings"


### PR DESCRIPTION
In `test_copyright.py` and `test_pep257.py`, do not assume that the current working directory is `Tools/ros2` but use a relative path instead.  This enables us to run pytest from any directory as long as the [`ament`](https://github.com/ament) modules are installed.

An alternative to:
*  #30449

### How is this tested?
% `uvx --with=ament-lint-pep257 pytest Tools/ros2/ardupilot_dds_tests/test/test_pep257.py`
```
1 passed, 1 warning in 0.20s
```
Edit `Tools/ros2/ardupilot_sitl/src/ardupilot_sitl/utilities.py` and add a leading or trailing space inside the docstring, and save the file.

% `uvx --with=ament-lint-pep257 pytest Tools/ros2/ardupilot_dds_tests/test/test_pep257.py`
```
1 failed, 1 warning in 0.23s
```