### PR TITLE
.github: fix test size workflow to ignore abin files

### DIFF
--- a/.github/workflows/test_size.yml
+++ b/.github/workflows/test_size.yml
@@ -312,12 +312,12 @@ jobs:
             echo "No differences found." >> $GITHUB_STEP_SUMMARY
           fi
 
-      - name: Checksum compare with ${{ github.event.pull_request.base.ref }}
+      - name: Binary compare with ${{ github.event.pull_request.base.ref }}
         shell: bash
         run: |
-          diff -r $GITHUB_WORKSPACE/base_branch_bin_no_versions $GITHUB_WORKSPACE/pr_bin_no_versions --exclude=*.elf --exclude=*.apj || true
-          diff_output=$(diff -r $GITHUB_WORKSPACE/base_branch_bin_no_versions $GITHUB_WORKSPACE/pr_bin_no_versions --exclude=*.elf --exclude=*.apj || true || true)
-          echo "### Checksum Diff Output" >> $GITHUB_STEP_SUMMARY
+          diff -r $GITHUB_WORKSPACE/base_branch_bin_no_versions $GITHUB_WORKSPACE/pr_bin_no_versions --exclude=*.abin --exclude=*.apj || true
+          diff_output=$(diff -r $GITHUB_WORKSPACE/base_branch_bin_no_versions $GITHUB_WORKSPACE/pr_bin_no_versions --exclude=*.abin --exclude=*.apj || true)
+          echo "### Binary Diff Output" >> $GITHUB_STEP_SUMMARY
           if [ -n "$diff_output" ]; then
             echo '```diff' >> $GITHUB_STEP_SUMMARY
             echo "$diff_output" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
`*.elf` files don't exist (the built ELF files instead have no extension). `*.apj` and `*.abin` files both have git hashes inside so they will always differ. Correctly ignore them and compare only ELF and `*.bin`.

Also rename the action as it compares the full file, not a checksum.

Avoids always claiming that MatekH743-bdshot has a difference.