### PR TITLE
hwdef: SkystarsHD: remove pin defaults which are inherited

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/SkystarsH7HDv2/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SkystarsH7HDv2/hwdef.dat
@@ -30,6 +30,5 @@ define DEFAULT_SERIAL3_PROTOCOL SerialProtocol_ESCTelemetry
 define DEFAULT_SERIAL5_PROTOCOL SerialProtocol_SmartAudio
 define DEFAULT_SERIAL6_PROTOCOL SerialProtocol_MSP_DisplayPort
 
-define RELAY2_PIN_DEFAULT 81
-define RELAY3_PIN_DEFAULT 82
+# other pin defaults come from hwdefs this one includes
 define RELAY4_PIN_DEFAULT 83


### PR DESCRIPTION
already present from files this one includes

```
Board,blimp,bootloader,copter,heli,plane,rover,sub
SkystarsH7HD,*,*,*,*,*,*,*
SkystarsH7HD-bdshot,*,*,*,*,*,*,*
SkystarsH7HDv2,0,*,0,-8,-8,-8,-8
```
bytes saved from romfs.  No compiler output if the hwdef is left out
