### PR TITLE
waf: accept entirely lower case values for BUILD_OPTIONS options

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -191,10 +191,12 @@ class Board:
         for opt in build_options.BUILD_OPTIONS:
             enable_option = opt.config_option().replace("-","_")
             disable_option = "disable_" + enable_option[len("enable-"):]
-            if getattr(cfg.options, enable_option, False):
+            lower_disable_option = disable_option.lower().replace("_", "-")
+            lower_enable_option = enable_option.lower().replace("_", "-")
+            if getattr(cfg.options, enable_option, False) or getattr(cfg.options, lower_enable_option, False):
                 env.CXXFLAGS += ['-D%s=1' % opt.define]
                 cfg.msg("Enabled %s" % opt.label, 'yes', color='GREEN')
-            elif getattr(cfg.options, disable_option, False):
+            elif getattr(cfg.options, disable_option, False) or getattr(cfg.options, lower_disable_option, False):
                 env.CXXFLAGS += ['-D%s=0' % opt.define]
                 cfg.msg("Enabled %s" % opt.label, 'no', color='YELLOW')
 

--- a/wscript
+++ b/wscript
@@ -2,6 +2,7 @@
 # encoding: utf-8
 # flake8: noqa
 
+import optparse
 import os.path
 import os
 import sys
@@ -118,13 +119,13 @@ def add_build_options(g):
             g.add_option(lower_enable_option,
                          action='store_true',
                          default=False,
-                         help=enable_description)
+                         help=optparse.SUPPRESS_HELP)
         lower_disable_option = disable_option.lower().replace("_", "-")
         if lower_disable_option != disable_option:
             g.add_option(lower_disable_option,
                          action='store_true',
                          default=False,
-                         help=disable_description)
+                         help=optparse.SUPPRESS_HELP)
 
 def add_script_options(g):
     '''add any drivers or applets from libraries/AP_Scripting'''

--- a/wscript
+++ b/wscript
@@ -111,6 +111,21 @@ def add_build_options(g):
                      default=False,
                      help=disable_description)
 
+        # also add entirely-lower-case equivalents with underscores
+        # replaced with dashes::
+        lower_enable_option = enable_option.lower().replace("_", "-")
+        if lower_enable_option != enable_option:
+            g.add_option(lower_enable_option,
+                         action='store_true',
+                         default=False,
+                         help=enable_description)
+        lower_disable_option = disable_option.lower().replace("_", "-")
+        if lower_disable_option != disable_option:
+            g.add_option(lower_disable_option,
+                         action='store_true',
+                         default=False,
+                         help=disable_description)
+
 def add_script_options(g):
     '''add any drivers or applets from libraries/AP_Scripting'''
     driver_list = glob.glob(os.path.join(Context.run_dir, "libraries/AP_Scripting/drivers/*.lua"))


### PR DESCRIPTION
This makes `./waf configure --board=MatekF405 --enable-volz` and `./waf configure --board=MatekF405 --enable-Volz` behave the same.

edit: now also replaces underscores with dashes, so
```
./waf configure --board=MatekF405 --enable-nmea-unicore`
```
works
