### PR TITLE
Tools: Fix pytest DeprecationWarning: 'maxsplit' is passed as positional

### DIFF
--- a/Tools/scripts/param_check.py
+++ b/Tools/scripts/param_check.py
@@ -335,7 +335,7 @@ def load_params(file, skip=SkippedChecks(), depth=0):
             continue
 
         # Split on , or any whitespace
-        parts = re.split(r'[,=\s]+', processed_line, 1)
+        parts = re.split(r'[,=\s]+', processed_line, maxsplit=1)
 
         # Check for redefinition
         if parts[0] in seen_params and not skip.no_redefinition:


### PR DESCRIPTION
… argument

```diff
- parts = re.split(r'[,=\s]+', processed_line, 1)
+ parts = re.split(r'[,=\s]+', processed_line, maxsplit=1)
```

Pytest: `DeprecationWarning: 'maxsplit' is passed as positional argument`
* https://docs.python.org/3/library/re.html#re.split
> Deprecated since version 3.13: Passing maxsplit and flags as positional arguments is deprecated. In future Python versions they will be [keyword-only parameters](https://docs.python.org/3/glossary.html#keyword-only-parameter).

### How was this tested?
Localhost testing...
% `python -m pytest --ignore=Tools/ros2`
```
========================================== test session starts ==========================================
platform darwin -- Python 3.13.5, pytest-8.4.1, pluggy-1.6.0
rootdir: /Users/cclauss/Python/ardupilot
configfile: pyproject.toml
collected 53 items

Tools/autotest/unittest/annotate_params_test.py ........................                                                                                                                                                         [ 45%]
Tools/autotest/unittest/extract_param_defaults_test.py ..................                                                                                                                                                        [ 79%]
Tools/scripts/param_check_test.py ...........                                                                                                                                                                                    [100%]

========================================== warnings summary ==========================================
Tools/scripts/param_check_test.py: 118 warnings
  /Users/cclauss/Python/ardupilot/Tools/scripts/param_check.py:338: DeprecationWarning: 'maxsplit' is passed as positional argument
    parts = re.split(r'[,=\s]+', processed_line, 1)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================== 53 passed, 118 warnings in 2.74s ==========================================
```

After this change:
% `python -m pytest --ignore=Tools/ros2`
```
========================================== test session starts ==========================================
platform darwin -- Python 3.13.5, pytest-8.4.1, pluggy-1.6.0
rootdir: /Users/cclauss/Python/ardupilot
configfile: pyproject.toml
collected 53 items

Tools/autotest/unittest/annotate_params_test.py ........................                                                                                                                                                         [ 45%]
Tools/autotest/unittest/extract_param_defaults_test.py ..................                                                                                                                                                        [ 79%]
Tools/scripts/param_check_test.py ...........                                                                                                                                                                                    [100%]

========================================== 53 passed in 2.55s ==========================================
```

Also failed with `ruff check --select=B034` and passed after the proposed change.

https://docs.astral.sh/ruff/rules/re-sub-positional-args