### PR TITLE
GCS_MAVLink: Match the number of channels to RC_CHANNELS_OVERRIDE

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4129,7 +4129,9 @@ void GCS_MAVLINK::handle_rc_channels_override(const mavlink_message_t &msg)
         packet.chan13_raw,
         packet.chan14_raw,
         packet.chan15_raw,
-        packet.chan16_raw
+        packet.chan16_raw,
+        packet.chan17_raw,
+        packet.chan18_raw
     };
 
     for (uint8_t i=0; i<8; i++) {


### PR DESCRIPTION
The number of channels in RC_CHANNELS_OVERRIDE is different from the number of elements in override_data.
I think it's better to add channels 17 and 18 to override_data.

RC_CHANNELS_OVERRIDE spec:
https://mavlink.io/en/messages/common.html#RC_CHANNELS_OVERRIDE