### PR TITLE
AP_Notify: add port flash and starboard flash pattern to RGBLed

### DIFF
--- a/libraries/AP_Notify/RGBLed.cpp
+++ b/libraries/AP_Notify/RGBLed.cpp
@@ -202,6 +202,22 @@ uint32_t RGBLed::get_colour_sequence_traffic_light(void) const
     return DEFINE_COLOUR_SEQUENCE_SLOW(GREEN);
 }
 
+uint32_t RGBLed::get_colour_sequence_port_flash(void) const
+{
+    if (AP_Notify::flags.armed) {
+        return DEFINE_COLOUR_SEQUENCE(RED,RED,RED,RED,RED,RED,RED,WHITE,RED,WHITE);
+    }
+    return DEFINE_COLOUR_SEQUENCE_SOLID(RED);
+}
+
+uint32_t RGBLed::get_colour_sequence_starboard_flash(void) const
+{
+    if (AP_Notify::flags.armed) {
+        return DEFINE_COLOUR_SEQUENCE(GREEN,GREEN,GREEN,GREEN,GREEN,GREEN,GREEN,WHITE,GREEN,WHITE);
+    }
+    return DEFINE_COLOUR_SEQUENCE_SOLID(GREEN);
+}
+
 // update - updates led according to timed_updated.  Should be called
 // at 50Hz
 void RGBLed::update()
@@ -220,6 +236,12 @@ void RGBLed::update()
         break;
     case Source::traffic_light:
         current_colour_sequence = get_colour_sequence_traffic_light();
+        break;
+    case Source::port_flash:
+        current_colour_sequence = get_colour_sequence_port_flash();
+        break;
+    case Source::starboard_flash:
+        current_colour_sequence = get_colour_sequence_starboard_flash();
         break;
     }
 

--- a/libraries/AP_Notify/RGBLed.h
+++ b/libraries/AP_Notify/RGBLed.h
@@ -68,6 +68,8 @@ private:
     uint32_t get_colour_sequence() const;
     uint32_t get_colour_sequence_obc() const;
     uint32_t get_colour_sequence_traffic_light() const;
+    uint32_t get_colour_sequence_port_flash() const;
+    uint32_t get_colour_sequence_starboard_flash() const;
 
     uint8_t get_brightness(void) const;
 
@@ -110,6 +112,8 @@ private:
         mavlink = 1,
         obc = 2,
         traffic_light = 3,
+        port_flash = 4,
+        starboard_flash = 5,
     };
     Source rgb_source() const;
 


### PR DESCRIPTION
Add new Notify LED Pattern to RDGLed:

4 = solid RED, when armed flashing white twice in between
5 = solid GREEN, when armed flashing white twice in between

it will be used i.e. for my https://github.com/ArduPilot/ardupilot/pull/30542 that can be used as left and right position lights