### PR TITLE
Mode Rate Acro

### DIFF
--- a/ArduCopter/APM_Config.h
+++ b/ArduCopter/APM_Config.h
@@ -22,6 +22,7 @@
 //#define MODE_SYSTEMID_ENABLED 0            // disable system ID mode support
 //#define MODE_THROW_ENABLED    0            // disable throw mode support
 //#define MODE_ZIGZAG_ENABLED   0            // disable zigzag mode support
+//#define MODE_RATE_ACRO_ENABLED 0           // disable acrobatic rate mode support
 //#define OSD_ENABLED           0            // disable on-screen-display support
 
 // features below are disabled by default on all boards

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -202,6 +202,7 @@ public:
 
     friend class Mode;
     friend class ModeAcro;
+    friend class ModeRateAcro;
     friend class ModeAcro_Heli;
     friend class ModeAltHold;
     friend class ModeAuto;
@@ -1030,6 +1031,9 @@ private:
 #else
     ModeAcro mode_acro;
 #endif
+#endif
+#if MODE_RATE_ACRO_ENABLED
+    ModeRateAcro mode_rate_acro;
 #endif
     ModeAltHold mode_althold;
 #if MODE_AUTO_ENABLED

--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -1425,6 +1425,9 @@ uint8_t GCS_MAVLINK_Copter::send_available_mode(uint8_t index) const
 #if MODE_ACRO_ENABLED
         &copter.mode_acro,
 #endif
+#if MODE_RATE_ACRO_ENABLED
+        &copter.mode_rate_acro,
+#endif
         &copter.mode_stabilize,
         &copter.mode_althold,
 #if MODE_CIRCLE_ENABLED

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -393,7 +393,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @User: Advanced
     GSCALAR(rc_speed, "RC_SPEED",              RC_FAST_SPEED),
 
-#if MODE_ACRO_ENABLED || MODE_SPORT_ENABLED
+#if MODE_ACRO_ENABLED || MODE_SPORT_ENABLED || MODE_RATE_ACRO_ENABLED
     // @Param: ACRO_BAL_ROLL
     // @DisplayName: Acro Balance Roll
     // @Description: rate at which roll angle returns to level in acro and sport mode.  A higher value causes the vehicle to return to level faster. For helicopter sets the decay rate of the virtual flybar in the roll axis. A higher value causes faster decay of desired to actual attitude.
@@ -413,7 +413,7 @@ const AP_Param::Info Copter::var_info[] = {
 
     // ACRO_RP_EXPO moved to Command Model class
 
-#if MODE_ACRO_ENABLED
+#if MODE_ACRO_ENABLED || MODE_RATE_ACRO_ENABLED
     // @Param: ACRO_TRAINER
     // @DisplayName: Acro Trainer
     // @Description: Type of trainer used in acro mode
@@ -760,7 +760,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
 
     // ACRO_Y_EXPO (9) moved to Command Model Class
 
-#if MODE_ACRO_ENABLED
+#if MODE_ACRO_ENABLED || MODE_RATE_ACRO_ENABLED
     // @Param: ACRO_THR_MID
     // @DisplayName: Acro Thr Mid
     // @Description: Acro Throttle Mid
@@ -1013,7 +1013,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("FS_DR_TIMEOUT", 53, ParametersG2, failsafe_dr_timeout, 30),
 
-#if MODE_ACRO_ENABLED || MODE_SPORT_ENABLED
+#if MODE_ACRO_ENABLED || MODE_SPORT_ENABLED || MODE_RATE_ACRO_ENABLED
     // @Param: ACRO_RP_RATE
     // @DisplayName: Acro Roll and Pitch Rate
     // @Description: Acro mode maximum roll and pitch rate.  Higher values mean faster rate of rotation
@@ -1039,7 +1039,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     AP_SUBGROUPINFO(command_model_acro_rp, "ACRO_RP_", 54, ParametersG2, AC_CommandModel),
 #endif
 
-#if MODE_ACRO_ENABLED || MODE_DRIFT_ENABLED
+#if MODE_ACRO_ENABLED || MODE_DRIFT_ENABLED || MODE_RATE_ACRO_ENABLED
     // @Param: ACRO_Y_RATE
     // @DisplayName: Acro Yaw Rate
     // @Description: Acro mode maximum yaw rate.  Higher value means faster rate of rotation
@@ -1276,11 +1276,11 @@ ParametersG2::ParametersG2(void) :
 #if MODE_ZIGZAG_ENABLED
     ,mode_zigzag_ptr(&copter.mode_zigzag)
 #endif
-#if MODE_ACRO_ENABLED || MODE_SPORT_ENABLED
+#if MODE_ACRO_ENABLED || MODE_SPORT_ENABLED || MODE_RATE_ACRO_ENABLED
     ,command_model_acro_rp(ACRO_RP_RATE_DEFAULT, ACRO_RP_EXPO_DEFAULT, 0.0f)
 #endif
 
-#if MODE_ACRO_ENABLED || MODE_DRIFT_ENABLED
+#if MODE_ACRO_ENABLED || MODE_DRIFT_ENABLED || MODE_RATE_ACRO_ENABLED
     ,command_model_acro_y(ACRO_Y_RATE_DEFAULT, ACRO_Y_EXPO_DEFAULT, 0.0f)
 #endif
 

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -469,13 +469,13 @@ public:
 
     AP_Int16                rc_speed; // speed of fast RC Channels in Hz
 
-#if MODE_ACRO_ENABLED || MODE_SPORT_ENABLED
+#if MODE_ACRO_ENABLED || MODE_SPORT_ENABLED || MODE_RATE_ACRO_ENABLED
     // Acro parameters
     AP_Float                acro_balance_roll;
     AP_Float                acro_balance_pitch;
 #endif
 
-#if MODE_ACRO_ENABLED
+#if MODE_ACRO_ENABLED || MODE_RATE_ACRO_ENABLED
     // Acro parameters
     AP_Int8                 acro_trainer;
 #endif
@@ -543,7 +543,7 @@ public:
     // developer options
     AP_Int32 dev_options;
 
-#if MODE_ACRO_ENABLED
+#if MODE_ACRO_ENABLED || MODE_RATE_ACRO_ENABLED
     AP_Float acro_thr_mid;
 #endif
 
@@ -628,11 +628,11 @@ public:
 #endif
 
     // command model parameters
-#if MODE_ACRO_ENABLED || MODE_SPORT_ENABLED
+#if MODE_ACRO_ENABLED || MODE_SPORT_ENABLED || MODE_RATE_ACRO_ENABLED
     AC_CommandModel command_model_acro_rp;
 #endif
 
-#if MODE_ACRO_ENABLED || MODE_DRIFT_ENABLED
+#if MODE_ACRO_ENABLED || MODE_DRIFT_ENABLED || MODE_RATE_ACRO_ENABLED
     AC_CommandModel command_model_acro_y;
 #endif
 

--- a/ArduCopter/RC_Channel_Copter.cpp
+++ b/ArduCopter/RC_Channel_Copter.cpp
@@ -291,7 +291,7 @@ bool RC_Channel_Copter::do_aux_function(const AuxFuncTrigger &trigger)
             break;
 #endif // AP_RANGEFINDER_ENABLED
 
-#if MODE_ACRO_ENABLED
+#if MODE_ACRO_ENABLED || MODE_RATE_ACRO_ENABLED
         case AUX_FUNC::ACRO_TRAINER:
             switch(ch_flag) {
                 case AuxSwitchPos::LOW:
@@ -534,6 +534,12 @@ bool RC_Channel_Copter::do_aux_function(const AuxFuncTrigger &trigger)
             break;
 #endif
 
+#if MODE_RATE_ACRO_ENABLED
+        case AUX_FUNC::RATE_ACRO:
+            do_aux_function_change_mode(Mode::Number::RATE_ACRO, ch_flag);
+            break;
+#endif
+
 #if MODE_FLOWHOLD_ENABLED
         case AUX_FUNC::FLOWHOLD:
             do_aux_function_change_mode(Mode::Number::FLOWHOLD, ch_flag);
@@ -616,7 +622,7 @@ bool RC_Channel_Copter::do_aux_function(const AuxFuncTrigger &trigger)
 
         case AUX_FUNC::AIRMODE:
             do_aux_function_change_air_mode(ch_flag);
-#if MODE_ACRO_ENABLED && FRAME_CONFIG != HELI_FRAME
+#if (MODE_ACRO_ENABLED || MODE_RATE_ACRO_ENABLED) && FRAME_CONFIG != HELI_FRAME
             copter.mode_acro.air_mode_aux_changed();
 #endif
             break;

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -133,6 +133,12 @@
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
+// Acro - fly vehicle in rate acrobatic mode
+#ifndef MODE_RATE_ACRO_ENABLED
+# define MODE_RATE_ACRO_ENABLED MODE_ACRO_ENABLED && (FRAME_CONFIG != HELI_FRAME)
+#endif
+
+//////////////////////////////////////////////////////////////////////////////
 // Auto mode - allows vehicle to trace waypoints and perform automated actions
 #ifndef MODE_AUTO_ENABLED
 # define MODE_AUTO_ENABLED 1

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -101,6 +101,7 @@ public:
         AUTOROTATE =   26,  // Autonomous autorotation
         AUTO_RTL =     27,  // Auto RTL, this is not a true mode, AUTO will report as this mode if entered to perform a DO_LAND_START Landing sequence
         TURTLE =       28,  // Flip over after crash
+        RATE_ACRO =    29,  // Betaflight-style rate acro
 
         // Mode number 30 reserved for "offboard" for external/lua control.
 
@@ -448,11 +449,32 @@ protected:
     // get_pilot_desired_rates_rads - transform pilot's normalised roll pitch and yaw input into a desired lean angle rates
     // the function returns desired angle rates in radians-per-second
     void get_pilot_desired_rates_rads(float &roll_out_rads, float &pitch_out_rads, float &yaw_out_rads);
+    void get_desired_rates(float& target_roll_rads, float& target_pitch_rads, float& target_yaw_rads, float& pilot_desired_throttle);
 
     float throttle_hover() const override;
 
-private:
     bool disable_air_mode_reset;
+};
+#endif
+
+#if MODE_RATE_ACRO_ENABLED
+class ModeRateAcro : public ModeAcro {
+
+public:
+    // inherit constructor
+    using ModeAcro::ModeAcro;
+    Number mode_number() const override { return Number::RATE_ACRO; }
+
+    virtual void run() override;
+    bool init(bool ignore_checks) override;
+    void exit() override;
+    // Called when air mode is enabled via AUX switch; prevents automatic reset to default air_mode state
+    void air_mode_aux_changed();
+
+protected:
+
+    const char *name() const override { return "ACRR"; }
+    const char *name4() const override { return "RATE_ACRO"; }
 };
 #endif
 

--- a/ArduCopter/mode_acro.cpp
+++ b/ArduCopter/mode_acro.cpp
@@ -7,10 +7,9 @@
 /*
  * Init and run calls for acro flight mode
  */
-void ModeAcro::run()
+void ModeAcro::get_desired_rates(float& target_roll_rads, float& target_pitch_rads, float& target_yaw_rads, float& pilot_desired_throttle)
 {
     // convert the input to the desired body frame rate
-    float target_roll_rads, target_pitch_rads, target_yaw_rads;
     get_pilot_desired_rates_rads(target_roll_rads, target_pitch_rads, target_yaw_rads);
 
     if (!motors->armed()) {
@@ -28,7 +27,7 @@ void ModeAcro::run()
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
     }
 
-    float pilot_desired_throttle = get_pilot_desired_throttle();
+    pilot_desired_throttle = get_pilot_desired_throttle();
 
     switch (motors->get_spool_state()) {
     case AP_Motors::SpoolState::SHUT_DOWN:
@@ -57,6 +56,12 @@ void ModeAcro::run()
         // do nothing
         break;
     }
+}
+
+void ModeAcro::run()
+{
+    float target_roll_rads, target_pitch_rads, target_yaw_rads, pilot_desired_throttle;
+    get_desired_rates(target_roll_rads, target_pitch_rads, target_yaw_rads, pilot_desired_throttle);
 
     // run attitude controller
     if (g2.acro_options.get() & uint8_t(AcroOptions::RATE_LOOP_ONLY)) {
@@ -203,3 +208,42 @@ void ModeAcro::get_pilot_desired_rates_rads(float &roll_out_rads, float &pitch_o
     yaw_out_rads = rate_bf_request_rads.z;
 }
 #endif
+
+#if MODE_RATE_ACRO_ENABLED
+/*
+ * Init and run calls for rate acro flight mode
+ */
+void ModeRateAcro::run()
+{
+    float target_roll_rads, target_pitch_rads, target_yaw_rads, pilot_desired_throttle;
+
+    get_desired_rates(target_roll_rads, target_pitch_rads, target_yaw_rads, pilot_desired_throttle);
+
+    // scale I by the value of angle P to mimic betaflight tunes
+    attitude_control->scale_I_to_angle_P();
+
+    // send rate commands to attitude controller (RATE_LOOP_ONLY bypasses full attitude stabilization)
+    attitude_control->input_rate_bf_roll_pitch_yaw_2_cds(target_roll_rads, target_pitch_rads, target_yaw_rads);
+
+    // output pilot's throttle without angle boost
+    attitude_control->set_throttle_out(pilot_desired_throttle, false, copter.g.throttle_filt);
+}
+
+bool ModeRateAcro::init(bool ignore_checks)
+{
+    disable_air_mode_reset = false;
+    copter.air_mode = AirMode::AIRMODE_ENABLED;
+
+    return true;
+}
+
+void ModeRateAcro::exit()
+{
+    if (!disable_air_mode_reset) {
+        copter.air_mode = AirMode::AIRMODE_DISABLED;
+    }
+    disable_air_mode_reset = false;
+}
+
+#endif // MODE_RATE_ACRO_ENABLED
+

--- a/ArduCopter/toy_mode.cpp
+++ b/ArduCopter/toy_mode.cpp
@@ -497,6 +497,14 @@ void ToyMode::update()
 #endif
         break;
 
+    case ACTION_MODE_RATE_ACRO:
+#if MODE_RATE_ACRO_ENABLED
+        new_mode = Mode::Number::RATE_ACRO;
+#else
+        gcs().send_text(MAV_SEVERITY_ERROR, "Tmode: RATEACRO is disabled");
+#endif
+        break;
+
     case ACTION_MODE_ALTHOLD:
         new_mode = Mode::Number::ALT_HOLD;
         break;

--- a/ArduCopter/toy_mode.h
+++ b/ArduCopter/toy_mode.h
@@ -81,6 +81,7 @@ private:
         ACTION_TOGGLE_SSIMPLE = 22,
         ACTION_LOAD_TEST = 23,
         ACTION_MODE_FLOW = 24,
+        ACTION_MODE_RATE_ACRO    = 25,
     };
 
     enum toy_action last_action;

--- a/ArduCopter/tuning.cpp
+++ b/ArduCopter/tuning.cpp
@@ -128,14 +128,14 @@ void Copter::tuning(const RC_Channel *tuning_ch, int8_t tuning_param, float tuni
         wp_nav->set_speed_NE_cms(tuning_value);
         break;
 
-#if MODE_ACRO_ENABLED || MODE_SPORT_ENABLED
+#if MODE_ACRO_ENABLED || MODE_SPORT_ENABLED || MODE_RATE_ACRO_ENABLED
     // Acro roll pitch rates
     case TUNING_ACRO_RP_RATE:
         g2.command_model_acro_rp.set_rate(tuning_value);
         break;
 #endif
 
-#if MODE_ACRO_ENABLED || MODE_DRIFT_ENABLED
+#if MODE_ACRO_ENABLED || MODE_DRIFT_ENABLED || MODE_RATE_ACRO_ENABLED
     // Acro yaw rate
     case TUNING_ACRO_YAW_RATE:
         g2.command_model_acro_y.set_rate(tuning_value);

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -68,7 +68,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
     @staticmethod
     def get_normal_armable_modes_list():
-        return ["ACRO", "ALT_HOLD", "STABILIZE", "GUIDED_NOGPS"]
+        return ["ACRO", "RATE_ACRO", "ALT_HOLD", "STABILIZE", "GUIDED_NOGPS"]
 
     def log_name(self):
         return "ArduCopter"
@@ -1247,6 +1247,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.test_takeoff_check_mode("STABILIZE")
         self.test_takeoff_check_mode("ACRO")
+        # self.test_takeoff_check_mode("RATE_ACRO")
+        self.test_takeoff_check_mode(29)
         self.test_takeoff_check_mode("LOITER")
         self.test_takeoff_check_mode("ALT_HOLD")
         # self.test_takeoff_check_mode("FLOWHOLD")
@@ -1262,6 +1264,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         })
         self.test_takeoff_check_mode("STABILIZE")
         self.test_takeoff_check_mode("ACRO")
+        # self.test_takeoff_check_mode("RATE_ACRO")
+        self.test_takeoff_check_mode(29)
         self.test_takeoff_check_mode("LOITER")
         self.test_takeoff_check_mode("ALT_HOLD")
         # self.test_takeoff_check_mode("FLOWHOLD")
@@ -5810,6 +5814,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.wait_ready_to_arm()
         self.arm_vehicle()
         self.change_mode("ACRO")
+        self.change_mode(29)
+        # self.change_mode("RATE_ACRO")
         self.change_mode("STABILIZE")
         self.change_mode("GUIDED")
         self.set_rc(3, 1700)
@@ -5817,6 +5823,12 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.run_cmd_do_set_mode(
             "ACRO",
             want_result=mavutil.mavlink.MAV_RESULT_FAILED)
+        self.run_cmd_do_set_mode(
+            29,
+            want_result=mavutil.mavlink.MAV_RESULT_FAILED)
+        # self.run_cmd_do_set_mode(
+        #    "RATE_ACRO",
+        #    want_result=mavutil.mavlink.MAV_RESULT_FAILED)
         self.run_cmd_do_set_mode(
             "STABILIZE",
             want_result=mavutil.mavlink.MAV_RESULT_FAILED)

--- a/Tools/autotest/helicopter.py
+++ b/Tools/autotest/helicopter.py
@@ -52,6 +52,13 @@ class AutoTestHelicopter(AutoTestCopter):
         ret = filter(lambda x : x != "THROW", ret)
         return ret
 
+    @staticmethod
+    def get_normal_armable_modes_list():
+        '''filter RATE_ACRO mode out of armable modes list; Heli is special-cased'''
+        ret = AutoTestCopter.get_normal_armable_modes_list()
+        ret = filter(lambda x : x != "RATE_ACRO", ret)
+        return ret
+
     def loiter_requires_position(self):
         self.progress("Skipping loiter-requires-position for heli; rotor runup issues")
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -1114,6 +1114,15 @@ void AC_AttitudeControl::input_shaping_rate_predictor(const Vector2f &error_angl
     target_ang_vel_rads.y = ang_vel_rads.y;
 }
 
+// scale I to represent the current angle P
+void AC_AttitudeControl::scale_I_to_angle_P()
+{
+    Vector3f i_scale(_p_angle_roll.kP() * _angle_P_scale.x,
+                     _p_angle_pitch.kP() * _angle_P_scale.y,
+                     _p_angle_yaw.kP() * _angle_P_scale.y);
+    set_I_scale_mult(i_scale);
+}
+
 // limits angular velocity
 void AC_AttitudeControl::ang_vel_limit(Vector3f& euler_rad, float ang_vel_roll_max_rads, float ang_vel_pitch_max_rads, float ang_vel_yaw_max_rads) const
 {

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -533,6 +533,15 @@ public:
     // purposes
     void set_PD_scale_mult(const Vector3f &pd_scale) { _pd_scale *= pd_scale; }
 
+    // setup a one loop I scale multiplier, multiplying by any
+    // previously applied scale from this loop. This allows for more
+    // than one type of scale factor to be applied for different
+    // purposes
+    void set_I_scale_mult(const Vector3f &i_scale) { _i_scale *= i_scale; }
+
+    // scale I to represent the control given by angle P
+    void scale_I_to_angle_P();
+
     // write RATE message
     void Write_Rate(const AC_PosControl &pos_control) const;
 
@@ -681,7 +690,13 @@ protected:
     Vector3f            _pd_scale{1,1,1};
 
     // Proportional-Derivative gains this loop (for logging/debugging)
-    Vector3f            _pd_scale_used;
+     Vector3f            _pd_scale_used;
+
+    // Integrator gains applied dynamically per axis
+    Vector3f            _i_scale{1,1,1};
+
+    // Integrator gains this loop (for logging/debugging)
+    Vector3f            _i_scale_used;
 
     // Ratio of normal to reduced rate controller gain when landed to suppress ground resonance
     float               _landed_gain_ratio;

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Logging.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Logging.cpp
@@ -57,7 +57,10 @@ void AC_AttitudeControl::Write_Rate(const AC_PosControl &pos_control) const
      */
     const Vector3f &scale = get_last_angle_P_scale();
     const Vector3f &pd_scale = _pd_scale_used;
-    if (scale != AC_AttitudeControl::VECTORF_111 || pd_scale != AC_AttitudeControl::VECTORF_111) {
+    const Vector3f &i_scale = _i_scale_used;
+    if (scale != AC_AttitudeControl::VECTORF_111 
+        || pd_scale != AC_AttitudeControl::VECTORF_111
+        || i_scale != AC_AttitudeControl::VECTORF_111) {
         const struct log_ATSC pkt_ATSC {
             LOG_PACKET_HEADER_INIT(LOG_ATSC_MSG),
             time_us  : _rate_gyro_time_us,
@@ -67,6 +70,9 @@ void AC_AttitudeControl::Write_Rate(const AC_PosControl &pos_control) const
             scalePD_x : pd_scale.x,
             scalePD_y : pd_scale.y,
             scalePD_z : pd_scale.z,
+            scaleI_x : i_scale.x,
+            scaleI_y : i_scale.y,
+            scaleI_z : i_scale.z,
         };
         AP::logger().WriteBlock(&pkt_ATSC, sizeof(pkt_ATSC));
     }

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
@@ -455,16 +455,17 @@ void AC_AttitudeControl_Multi::rate_controller_run_dt(const Vector3f& gyro_rads,
     _rate_gyro_rads = gyro_rads;
     _rate_gyro_time_us = AP_HAL::micros64();
 
-    _motors.set_roll(get_rate_roll_pid().update_all(ang_vel_body.x, gyro_rads.x,  dt, _motors.limit.roll, _pd_scale.x) + _actuator_sysid.x);
+    _motors.set_roll(get_rate_roll_pid().update_all(ang_vel_body.x, gyro_rads.x,  dt, _motors.limit.roll, _pd_scale.x, _i_scale.x) + _actuator_sysid.x);
     _motors.set_roll_ff(get_rate_roll_pid().get_ff());
 
-    _motors.set_pitch(get_rate_pitch_pid().update_all(ang_vel_body.y, gyro_rads.y,  dt, _motors.limit.pitch, _pd_scale.y) + _actuator_sysid.y);
+    _motors.set_pitch(get_rate_pitch_pid().update_all(ang_vel_body.y, gyro_rads.y,  dt, _motors.limit.pitch, _pd_scale.y, _i_scale.y) + _actuator_sysid.y);
     _motors.set_pitch_ff(get_rate_pitch_pid().get_ff());
 
-    _motors.set_yaw(get_rate_yaw_pid().update_all(ang_vel_body.z, gyro_rads.z,  dt, _motors.limit.yaw, _pd_scale.z) + _actuator_sysid.z);
+    _motors.set_yaw(get_rate_yaw_pid().update_all(ang_vel_body.z, gyro_rads.z,  dt, _motors.limit.yaw, _pd_scale.z, _i_scale.z) + _actuator_sysid.z);
     _motors.set_yaw_ff(get_rate_yaw_pid().get_ff()*_feedforward_scalar);
 
     _pd_scale_used = _pd_scale;
+    _i_scale_used = _i_scale;
 }
 
 // reset the rate controller target loop updates
@@ -473,6 +474,7 @@ void AC_AttitudeControl_Multi::rate_controller_target_reset()
     _sysid_ang_vel_body_rads.zero();
     _actuator_sysid.zero();
     _pd_scale = VECTORF_111;
+    _i_scale = VECTORF_111;
 }
 
 // run the rate controller using the configured _dt and latest gyro_rads

--- a/libraries/AC_PID/AC_PID.cpp
+++ b/libraries/AC_PID/AC_PID.cpp
@@ -193,7 +193,7 @@ void AC_PID::set_notch_sample_rate(float sample_rate)
 // Computes the PID output using a target and measurement input.
 // Applies filters to the target and error, calculates the derivative and updates the integrator.
 // If `limit` is true, the integrator is allowed to shrink but not grow.
-float AC_PID::update_all(float target, float measurement, float dt, bool limit, float pd_scale)
+float AC_PID::update_all(float target, float measurement, float dt, bool limit, float pd_scale, float i_scale)
 {
     // Return zero if input is invalid (NaN or infinite)
     if (!isfinite(target) || !isfinite(measurement)) {
@@ -264,10 +264,11 @@ float AC_PID::update_all(float target, float measurement, float dt, bool limit, 
 
     // Integrate error (with wind-up protection if limit is active)
     // If limit is active, allow I-term to shrink but not grow
-    update_i(dt, limit);
+    update_i(dt, limit, i_scale);
 
     float P_out = (_error * _kp);
     float D_out = (_derivative * _kd);
+    float I_out = _integrator;
 
     // Calculate dynamic modifier to reduce P+D output based on slew rate limiter
     _pid_info.Dmod = _slew_limiter.modifier((_pid_info.P + _pid_info.D) * _slew_limit_scale, dt);
@@ -298,10 +299,15 @@ float AC_PID::update_all(float target, float measurement, float dt, bool limit, 
     _pid_info.error = _error;
     _pid_info.P = P_out;
     _pid_info.D = D_out;
+    _pid_info.I = I_out;
+    _pid_info.limit = limit;
+    // Set I set flag for logging and clear
+    _pid_info.I_term_set = _flags._I_set;
+    _flags._I_set = false;
     _pid_info.FF = _target * _kff;
     _pid_info.DFF = _target_derivative * _kdff;
 
-    return P_out + D_out + _integrator;
+    return P_out + D_out + I_out;
 }
 
 // Computes the PID output from an error input only (target assumed to be zero).
@@ -330,23 +336,17 @@ float AC_PID::update_error(float error, float dt, bool limit)
 
 // Updates the integrator based on current error and dt.
 // If `limit` is true, the integrator is only allowed to shrink to avoid wind-up.
-void AC_PID::update_i(float dt, bool limit)
+void AC_PID::update_i(float dt, bool limit, float i_scale)
 {
     if (!is_zero(_ki) && is_positive(dt)) {
         // Allow integrator growth only if not limited, or if error opposes the integrator direction
         if (!limit || ((is_positive(_integrator) && is_negative(_error)) || (is_negative(_integrator) && is_positive(_error)))) {
-            _integrator += ((float)_error * _ki) * dt;
+            _integrator += ((float)_error * _ki) * i_scale * dt;
             _integrator = constrain_float(_integrator, -_kimax, _kimax);
         }
     } else {
         _integrator = 0.0f;
     }
-    _pid_info.I = _integrator;
-    _pid_info.limit = limit;
-
-    // Set I set flag for logging and clear
-    _pid_info.I_term_set = _flags._I_set;
-    _flags._I_set = false;
 }
 
 float AC_PID::get_p() const

--- a/libraries/AC_PID/AC_PID.h
+++ b/libraries/AC_PID/AC_PID.h
@@ -62,7 +62,7 @@ public:
     // Computes the PID output using a target and measurement input.
     // Applies filters to the target and error, calculates the derivative and updates the integrator.
     // If `limit` is true, the integrator is allowed to shrink but not grow.
-    float update_all(float target, float measurement, float dt, bool limit = false, float pd_scale = 1.0f);
+    float update_all(float target, float measurement, float dt, bool limit = false, float pd_scale = 1.0f, float i_scale = 1.0f);
 
     // Computes the PID output from an error input only (target assumed to be zero).
     // Applies error filtering and updates the derivative and integrator.
@@ -159,7 +159,7 @@ protected:
 
     // Updates the integrator based on current error and dt.
     // If `limit` is true, the integrator is only allowed to shrink to avoid wind-up.
-    void update_i(float dt, bool limit);
+    void update_i(float dt, bool limit, float i_scale = 1.0f);
 
     // parameters
     AP_Float _kp;

--- a/libraries/AP_AHRS/LogStructure.h
+++ b/libraries/AP_AHRS/LogStructure.h
@@ -143,6 +143,9 @@ struct PACKED log_Video_Stabilisation {
 // @Field: PDScX: PD scale X
 // @Field: PDScY: PD scale Y
 // @Field: PDScZ: PD scale Z
+// @Field: IScX: I scale X
+// @Field: IScY: I scale Y
+// @Field: IScZ: I scale Z
 struct PACKED log_ATSC {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -152,6 +155,9 @@ struct PACKED log_ATSC {
     float scalePD_x;
     float scalePD_y;
     float scalePD_z;
+    float scaleI_x;
+    float scaleI_y;
+    float scaleI_z;
 };
 
 
@@ -167,7 +173,7 @@ struct PACKED log_ATSC {
     { LOG_POS_MSG, sizeof(log_POS), \
         "POS","QLLfff","TimeUS,Lat,Lng,Alt,RelHomeAlt,RelOriginAlt", "sDUmmm", "FGG000" , true }, \
     { LOG_ATSC_MSG, sizeof(log_ATSC), \
-        "ATSC", "Qffffff",  "TimeUS,AngPScX,AngPScY,AngPScZ,PDScX,PDScY,PDScZ", "s------", "F000000" , true }, \
+        "ATSC", "Qfffffffff",  "TimeUS,AngPScX,AngPScY,AngPScZ,PDScX,PDScY,PDScZ,IScX,IScY,IScZ", "s---------", "F000000000" , true }, \
     { LOG_VIDEO_STABILISATION_MSG, sizeof(log_Video_Stabilisation), \
         "VSTB", "Qffffffffff",  "TimeUS,GyrX,GyrY,GyrZ,AccX,AccY,AccZ,Q1,Q2,Q3,Q4", "sEEEooo----", "F0000000000" },
 

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -368,6 +368,7 @@ public:
         AHRS_AUTO_TRIM =     182,  // in-flight AHRS autotrim
         AUTOLAND =           183,  //Fixed Wing AUTOLAND Mode
         SYSTEMID =           184,  // system ID as an aux switch
+        RATE_ACRO =          185,  // rate acro mode
 
         // inputs from 200 will eventually used to replace RCMAP
         ROLL =               201, // roll input


### PR DESCRIPTION
This provides support rate-only aka "betaflight" acro as a mode. Betaflight acro does not have angle control but instead relies on much higher I terms to avoid drift. The relationship between angle P and the required I term is pretty simple - simply multiply the tuned I term by angle P to get the required I term for rate only acro. This PR achieves this transparently when switching into the mode.