### PR TITLE
autotest: Fix strip-with-multi-characters

### DIFF
--- a/Tools/autotest/antennatracker.py
+++ b/Tools/autotest/antennatracker.py
@@ -229,7 +229,7 @@ class AutoTestTracker(vehicle_test_suite.TestSuite):
             if m is None:
                 break
             self.progress(f"{m.Message=}")
-            msg = m.Message.lstrip("SRC=250/250:")
+            msg = m.Message.removeprefix("SRC=250/250:")
             if phase == "short":
                 if msg != short_message_text:
                     continue


### PR DESCRIPTION
~Blocked by #32526~
* ~#32526~

```diff
-            msg = m.Message.lstrip("SRC=250/250:")
+            msg = m.Message.removeprefix("SRC=250/250:")
```

[`str.lstrip()`](https://docs.python.org/3/library/stdtypes.html#str.lstrip) is an unintuitive footgun, so Python 3.9 has added [`str.removeprefix()`](https://docs.python.org/3/library/stdtypes.html#str.removeprefix) to do the intuitive thing.

% [`ruff rule B005`](https://docs.astral.sh/ruff/rules/strip-with-multi-characters/#strip-with-multi-characters-b005)

# strip-with-multi-characters (B005)

Derived from the **flake8-bugbear** linter.

## What it does
Checks for uses of multi-character strings in `.strip()`, `.lstrip()`, and
`.rstrip()` calls.

## Why is this bad?
All characters in the call to `.strip()`, `.lstrip()`, or `.rstrip()` are
removed from the leading and trailing ends of the string. If the string
contains multiple characters, the reader may be misled into thinking that
a prefix or suffix is being removed, rather than a set of characters.

In Python 3.9 and later, you can use `str.removeprefix` and
`str.removesuffix` to remove an exact prefix or suffix from a string,
respectively, which should be preferred when possible.

## Known problems
As a heuristic, this rule only flags multi-character strings that contain
duplicate characters. This allows usages like `.strip("xyz")`, which
removes all occurrences of the characters `x`, `y`, and `z` from the
leading and trailing ends of the string, but not `.strip("foo")`.

The use of unique, multi-character strings may be intentional and
consistent with the intent of `.strip()`, `.lstrip()`, or `.rstrip()`,
while the use of duplicate-character strings is very likely to be a
mistake.

## Example
```python
"text.txt".strip(".txt")  # "e"
```

Use instead:
```python
"text.txt".removesuffix(".txt")  # "text"
```

## References
- [Python documentation: `str.strip`](https://docs.python.org/3/library/stdtypes.html#str.strip)

---
Outdated comments.
---

Find 200+ instances of error-prone Python statements using [`flake8-blind-except`](https://pypi.org/project/flake8-blind-except) and [`flake8-bugbear`](https://pypi.org/project/flake8-bugbear).
```
36    B006 Do not use mutable data structures for argument defaults.  They are created during function
            definition time. All calls to the function reuse this one instance of that data structure,
            persisting changes between them.
8     B008 Do not perform function calls in argument defaults.  The call is performed only once at function
            definition time. All calls to your function will reuse the result of that definition-time
            function call.  If this is intended, assign the function call to a module-level variable and
            use that variable as a default value.
10    B901 blind except: statement
148   B902 blind except Exception: statement
```
* https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments
* https://peps.python.org/pep-0008/#programming-recommendations
> A bare except: clause will catch SystemExit and KeyboardInterrupt exceptions, making it harder to interrupt a program with Control-C, and can disguise other problems. If you want to catch all exceptions that signal program errors, use except Exception: (bare except is equivalent to except BaseException:).

> A good rule of thumb is to limit use of bare ‘except’ clauses to two cases:
> 1. If the exception handler will be printing out or logging the traceback; at least the user will be aware that an error has occurred.
> 2. If the code needs to do some cleanup work, but then lets the exception propagate upwards with raise. try...finally can be a better way to handle this case.
