### PR TITLE
Tools: First argument of a method should be named 'self'

### DIFF
--- a/Tools/Replay/examples/rewrite-RFND-values-to-floats.py
+++ b/Tools/Replay/examples/rewrite-RFND-values-to-floats.py
@@ -27,10 +27,11 @@ class Rewrite():
         self.rewrite_fmtu = rewrite_fmtu
         self.rewrite_instance = rewrite_instance
 
+    @staticmethod
     def format_to_struct(fmt):
         ret = bytes("<", 'ascii')
         for c in fmt:
-            (s, mul, type) = DFReader.FORMAT_TO_STRUCT[c]
+            (s, _mul, _type) = DFReader.FORMAT_TO_STRUCT[c]
             ret += bytes(s, 'ascii')
         return bytes(ret)
 


### PR DESCRIPTION
% `uvx --with=pep8-naming flake8 --disable-noqa --select=N805 .`

https://pypi.org/project/pep8-naming:
> N805 first argument of a method should be named ‘self’

Should this be a standalone function or a @staticmethod because it does not attempt to access to `self`?
* https://docs.python.org/3/library/functions.html#staticmethod
* https://docs.astral.sh/ruff/rules/invalid-first-argument-name-for-method