### PR TITLE
autotest: Fix DeprecationWarning: 'count' is passed as positional arg

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -5126,9 +5126,8 @@ class TestSuite(ABC):
 
         if not match_comments:
             # strip comments from all lines
-            lines1 = [re.sub(r"\s*#.*", "", x, re.DOTALL) for x in lines1]
-            lines2 = [re.sub(r"\s*#.*", "", x, re.DOTALL) for x in lines2]
-            # FIXME: because DOTALL doesn't seem to work as expected:
+            lines1 = [re.sub(r"\s*#.*", "", x) for x in lines1]
+            lines2 = [re.sub(r"\s*#.*", "", x) for x in lines2]
             lines1 = [x.rstrip() for x in lines1]
             lines2 = [x.rstrip() for x in lines2]
             # remove now-empty lines:


### PR DESCRIPTION
Like:
* #30563
```diff
-            lines1 = [re.sub(r"\s*#.*", "", x, re.DOTALL) for x in lines1]
-            lines2 = [re.sub(r"\s*#.*", "", x, re.DOTALL) for x in lines2]
+            lines1 = [re.sub(r"\s*#.*", "", x, count=re.DOTALL) for x in lines1]
+            lines2 = [re.sub(r"\s*#.*", "", x, count=re.DOTALL) for x in lines2]
```
https://docs.python.org/3/library/re.html#re.sub
> ___Deprecated since version 3.13___: Passing count and flags as positional arguments is deprecated. In future Python versions they will be keyword-only parameters.