### PR TITLE
Fix for #30477:Ubuntu Setup: Prereq script exits after path error

### DIFF
--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -509,7 +509,7 @@ fi
 
 heading "Adding ArduPilot Tools to environment"
 
-SCRIPT_DIR=$(dirname $(realpath ${BASH_SOURCE[0]}))
+SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 ARDUPILOT_ROOT=$(realpath "$SCRIPT_DIR/../../")
 
 if [[ $DO_AP_STM_ENV -eq 1 ]]; then


### PR DESCRIPTION
fix for  #30477 

```diff
- SCRIPT_DIR= $(dirname $(realpath ${BASH_SOURCE[0]}))
+ SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
