### PR TITLE
Tools: Fix for failing preq ubuntu script due to whitespace in directory

### DIFF
--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -509,7 +509,7 @@ fi
 
 heading "Adding ArduPilot Tools to environment"
 
-SCRIPT_DIR=$(dirname $(realpath ${BASH_SOURCE[0]}))
+SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 ARDUPILOT_ROOT=$(realpath "$SCRIPT_DIR/../../")
 
 if [[ $DO_AP_STM_ENV -eq 1 ]]; then


### PR DESCRIPTION
Fixes issue #30477 

```diff
- SCRIPT_DIR=$(dirname $(realpath ${BASH_SOURCE[0]}))
+ SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"