### PR TITLE
AP_NavEKF: Remove FuseAllVelocities default from EK3_SRC_OPTIONS

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.cpp
@@ -138,7 +138,7 @@ const AP_Param::GroupInfo AP_NavEKF_Source::var_info[] = {
     // @Description: EKF Source Options. Bit 0: Fuse all velocity sources present in EK3_SRCx_VEL_. Bit 1: Align external navigation position when using optical flow. Bit 3: Use SRC per core. By default, EKF source selection is controlled via the EK3_SRC parameters, allowing only one source to be active at a time across all cores (switchable via MAVLink, Lua, or RC). Enabling this bit maps EKF core 1 to SRC1, core 2 to SRC2, etc., allowing each core to run independently with a dedicated source.
     // @Bitmask: 0:FuseAllVelocities, 1:AlignExtNavPosWhenUsingOptFlow, 3: UsePerCoreEKFSources
     // @User: Advanced
-    AP_GROUPINFO("_OPTIONS", 16, AP_NavEKF_Source, _options, (int16_t)SourceOptions::FUSE_ALL_VELOCITIES),
+    AP_GROUPINFO("_OPTIONS", 16, AP_NavEKF_Source, _options, 0),
 
     AP_GROUPEND
 };


### PR DESCRIPTION
I think it is a safer default not to have "FuseAllVelocities" set. People who are running GPS and optical flow sensors together, and who are not aware that this feature is enabled by default, can get into some dangerous situations: 

1. Vehicle not flying properly because of a bad optical flow sensor, even if the user thinks that they are currently flying with GPS
2. The vehicle was flying better than expected because of good GPS velocity was being used, and the user thought they were flying on Optical Flow 