### PR TITLE
AP_Networking: support multiple PPP interfaces

### DIFF
--- a/libraries/AP_Networking/AP_Networking.h
+++ b/libraries/AP_Networking/AP_Networking.h
@@ -147,6 +147,13 @@ public:
     static uint32_t convert_netmask_bitcount_to_ip(const uint32_t netmask_bitcount);
     static uint8_t convert_netmask_ip_to_bitcount(const uint32_t netmask_ip);
 
+    // add new routes for an interface.
+    // Returns true if the route is added or the route already exists
+    bool add_route(uint8_t backend_idx, uint8_t iface_idx, uint32_t dest_ip, uint8_t mask_len);
+
+    // hook for custom routes
+    struct netif *routing_hook(uint32_t dest);
+
     /*
       send contents of a file to a socket then close both socket and file
      */

--- a/libraries/AP_Networking/AP_Networking_Backend.cpp
+++ b/libraries/AP_Networking/AP_Networking_Backend.cpp
@@ -1,0 +1,27 @@
+#include "AP_Networking_Backend.h"
+
+#if AP_NETWORKING_ENABLED
+
+// add a new route for an interface
+// Returns true if the route is added or the route already exists
+bool AP_Networking_Backend::add_route(uint8_t iface_idx, uint32_t dest_ip, uint8_t mask_len)
+{
+    const uint32_t netmask = frontend.convert_netmask_bitcount_to_ip(mask_len);
+    for (uint8_t i=0; i<AP_NETWORKING_MAX_ROUTES; i++) {
+        auto &r = routes[i];
+        if (r.enabled && r.iface_idx == iface_idx && r.dest_ip == dest_ip && r.netmask == netmask) {
+            // already have it
+            return true;
+        }
+        if (!r.enabled) {
+            r.iface_idx = iface_idx;
+            r.dest_ip = dest_ip;
+            r.netmask = netmask;
+            r.enabled = true;
+            return true;
+        }
+    }
+    return false;
+}
+
+#endif // AP_NETWORKING_ENABLED

--- a/libraries/AP_Networking/AP_Networking_Backend.h
+++ b/libraries/AP_Networking/AP_Networking_Backend.h
@@ -8,6 +8,10 @@
 
 class AP_Networking;
 
+#ifndef AP_NETWORKING_MAX_ROUTES
+#define AP_NETWORKING_MAX_ROUTES 4
+#endif
+
 class AP_Networking_Backend
 {
 public:
@@ -21,6 +25,13 @@ public:
     virtual bool init() = 0;
     virtual void update() {};
 
+    // add a new route for an interface
+    // Returns true if the route is added or the route already exists
+    bool add_route(uint8_t iface_idx, uint32_t dest_ip, uint8_t mask_len);
+
+    // hook for custom routes
+    virtual struct netif *routing_hook(uint32_t dest) { return nullptr; }
+    
 protected:
     AP_Networking &frontend;
 
@@ -32,6 +43,13 @@ protected:
         uint8_t macaddr[6];
         uint32_t last_change_ms;
     } activeSettings;
+
+    struct {
+        bool enabled;
+        uint8_t iface_idx;
+        uint32_t dest_ip;
+        uint32_t netmask;
+    } routes[AP_NETWORKING_MAX_ROUTES];
 };
 
 #endif // AP_NETWORKING_ENABLED

--- a/libraries/AP_Networking/AP_Networking_PPP.h
+++ b/libraries/AP_Networking/AP_Networking_PPP.h
@@ -5,6 +5,10 @@
 #ifdef AP_NETWORKING_BACKEND_PPP
 #include "AP_Networking_Backend.h"
 
+#ifndef AP_NETWORKING_PPP_NUM_INTERFACES
+#define AP_NETWORKING_PPP_NUM_INTERFACES 3
+#endif
+
 class AP_Networking_PPP : public AP_Networking_Backend
 {
 public:
@@ -15,13 +19,24 @@ public:
 
     bool init() override;
 
+    // hook for custom routes
+    struct netif *routing_hook(uint32_t dest) override;
+    
 private:
     void ppp_loop(void);
 
-    AP_HAL::UARTDriver *uart;
-    struct netif *pppif;
-    struct ppp_pcb_s *ppp;
-    bool need_restart;
+    struct PPP_Instance {
+        uint8_t idx;
+        AP_Networking_PPP *backend;
+        AP_HAL::UARTDriver *uart;
+        struct netif *pppif;
+        struct ppp_pcb_s *ppp;
+        bool need_restart;
+        uint32_t last_read_ms;
+    } iface[AP_NETWORKING_PPP_NUM_INTERFACES];
+
+    void restart_instance(const uint8_t idx);
+    bool update_instance(const uint8_t idx);
 
     static void ppp_status_callback(struct ppp_pcb_s *pcb, int code, void *ctx);
     static uint32_t ppp_output_cb(struct ppp_pcb_s *pcb, const void *data, uint32_t len, void *ctx);

--- a/libraries/AP_Networking/config/lwipopts.h
+++ b/libraries/AP_Networking/config/lwipopts.h
@@ -347,6 +347,11 @@ a lot of data that needs to be copied, this should be set high. */
 /* ---------- NETBIOS options ---------- */
 #define LWIP_NETBIOS_RESPOND_NAME_QUERY 0
 
+/* routing hook */
+#define LWIP_HOOK_IP4_ROUTE ap_networking_routing_hook
+struct ip4_addr;
+struct netif *ap_networking_routing_hook(const struct ip4_addr *dest);
+
 /* ---------- PPP options ---------- */
 
 #ifndef PPP_SUPPORT

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -4098,6 +4098,14 @@ function networking:get_netmask_active() end
 ---@return uint32_t_ud
 function networking:get_ip_active() end
 
+-- add a custom ipv4 route
+---@param backend_idx integer -- backend index
+---@param iface_idx integer -- interface index
+---@param dest_ip uint32_t_ud|integer|number -- desttination IP address
+---@param mask_len integer -- network mask bit length
+---@return boolean
+function networking:add_route(backend_idx, iface_idx, dest_ip, mask_len) end
+
 -- visual odometry object
 visual_odom = {}
 

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -1080,6 +1080,7 @@ singleton AP_Networking method get_ip_active uint32_t
 singleton AP_Networking method get_netmask_active uint32_t
 singleton AP_Networking method get_gateway_active uint32_t
 singleton AP_Networking method address_to_str string uint32_t'skip_check
+singleton AP_Networking method add_route boolean uint8_t'skip_check uint8_t'skip_check uint32_t'skip_check uint8_t'skip_check
 
 include AP_VisualOdom/AP_VisualOdom.h
 singleton AP_VisualOdom depends HAL_VISUALODOM_ENABLED


### PR DESCRIPTION
This allows for up to 3 PPP interfaces, allowing for both a ethernet adapter (such as a BotBloxDroneNet) and a LTE modem.
It also adds support for custom routes, which is needed to control the routing for multiple PPP interfaces
