### PR TITLE
SRV_Channel: ensure pwm from set_output_norm is in correct range

### DIFF
--- a/libraries/SRV_Channel/SRV_Channel.cpp
+++ b/libraries/SRV_Channel/SRV_Channel.cpp
@@ -256,7 +256,7 @@ void SRV_Channel::set_output_pwm(uint16_t pwm, bool force)
 void SRV_Channel::set_output_norm(float value)
 {
     // convert normalised value to pwm
-    set_output_pwm(pwm_from_scaled_value(value * high_out));
+    set_output_pwm(pwm_from_scaled_value(0.5 * (1.0 + value) * high_out));
 }
 
 // set angular range of scaled output


### PR DESCRIPTION
`set_output_norm` seems to be missing a scaling to ensure that `value = 0` results in `pwm = 1500`. This function is not really used anywhere except an example rover Lua script and in `AP_Periph/rc_out.cpp`.

Came across while testing heli autorotation in simulation.