### PR TITLE
Tools: SITL toolchain names

### DIFF
--- a/Tools/scripts/board_list.py
+++ b/Tools/scripts/board_list.py
@@ -16,7 +16,7 @@ class Board(object):
     def __init__(self, name):
         self.name = name
         self.is_ap_periph = False
-        self.toolchain = 'arm-eabi-none'  # FIXME: try to remove this?
+        self.toolchain = 'arm-none-eabi'  # FIXME: try to remove this?
         self.autobuild_targets = [
             'Tracker',
             'Blimp',
@@ -26,6 +26,12 @@ class Board(object):
             'Rover',
             'Sub',
         ]
+        SITL_toolchain = {
+            "SITL_x86_64_linux_gnu": "x86_64-linux-gnu",
+            "SITL_arm_linux_gnueabihf": "arm-linux-gnueabihf",
+        }
+        if name in SITL_toolchain:
+            self.toolchain = SITL_toolchain[name]
 
 
 def in_boardlist(boards : Collection[str], board : str) -> bool:


### PR DESCRIPTION
stops SITL arm builds from being stripped for comparison

reinstates testing of sizes for SITL builds via `size_compare_branches.py`.

Before:
```
Board,blimp,bootloader,copter,heli,plane,rover,sub
CubeOrange,*,*,*,*,*,*,*



```

After:
```
CubeOrange,*,*,*,*,*,*,*
SITL_arm_linux_gnueabihf,0,,0,0,0,0,0
SITL_x86_64_linux_gnu,0,,0,0,0,0,0
```