### PR TITLE
AP_Scripting: Correct INF EFI temperatures

### DIFF
--- a/libraries/AP_Scripting/drivers/INF_Inject.lua
+++ b/libraries/AP_Scripting/drivers/INF_Inject.lua
@@ -291,14 +291,14 @@ local function update_EFI()
    local cylinder_state = Cylinder_Status()
    local efi_state = EFI_State()
 
-   cylinder_state:cylinder_head_temperature(state.tmp0)
-   cylinder_state:exhaust_gas_temperature(state.tmp1)
+   cylinder_state:cylinder_head_temperature(state.tmp0+273.15)
+   cylinder_state:exhaust_gas_temperature(state.tmp1+273.15)
    cylinder_state:injection_time_ms(state.inj1_ms)
 
    efi_state:engine_speed_rpm(state.rpm_out)
 
    efi_state:atmospheric_pressure_kpa(state.pre_gas*0.01)
-   efi_state:intake_manifold_temperature(state.tmp2)
+   efi_state:intake_manifold_temperature(state.tmp2+273.15)
    efi_state:throttle_position_percent(math.floor(state.bus_thr*0.1))
    efi_state:ignition_voltage(state.vol_power)
 


### PR DESCRIPTION
They were being reported as C, while the driver expects them to be in Kelvin. This causes it to get sent to the GCS as the wrong unit. Correcting the named value float pairs is not required as they are not a part of a standard, so we can safely leave them in degrees C.