### PR TITLE
Copter: AC_WPNav: No compiler change to fix naming conventions

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -535,7 +535,7 @@ void ModeAuto::circle_movetoedge_start(const Location &circle_center, float radi
         }
 
         // if we are outside the circle, point at the edge, otherwise hold yaw
-        const float dist_to_center = get_horizontal_distance_cm(pos_control->get_pos_estimate_NEU_cm().xy().tofloat(), copter.circle_nav->get_center_NEU_cm().xy().tofloat());
+        const float dist_to_center = get_horizontal_distance(pos_control->get_pos_estimate_NEU_cm().xy().tofloat(), copter.circle_nav->get_center_NEU_cm().xy().tofloat());
         // initialise yaw
         // To-Do: reset the yaw only when the previous navigation command is not a WP.  this would allow removing the special check for ROI
         if (auto_yaw.mode() != AutoYaw::Mode::ROI) {

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -1085,7 +1085,7 @@ bool ModeGuided::limit_check()
 
     // check if we have gone beyond horizontal limit
     if (guided_limit.horiz_max_cm > 0.0f) {
-        const float horiz_move = get_horizontal_distance_cm(guided_limit.start_pos.xy(), curr_pos.xy());
+        const float horiz_move = get_horizontal_distance(guided_limit.start_pos.xy(), curr_pos.xy());
         if (horiz_move > guided_limit.horiz_max_cm) {
             return true;
         }
@@ -1116,7 +1116,7 @@ float ModeGuided::wp_distance_m() const
     case SubMode::WP:
         return wp_nav->get_wp_distance_to_destination_cm() * 0.01f;
     case SubMode::Pos:
-        return get_horizontal_distance_cm(pos_control->get_pos_estimate_NEU_cm().xy().tofloat(), guided_pos_target_cm.xy().tofloat()) * 0.01f;
+        return get_horizontal_distance(pos_control->get_pos_estimate_NEU_cm().xy().tofloat(), guided_pos_target_cm.xy().tofloat()) * 0.01f;
     case SubMode::PosVelAccel:
         return pos_control->get_pos_error_NE_cm() * 0.01f;
     default:

--- a/ArduCopter/mode_smart_rtl.cpp
+++ b/ArduCopter/mode_smart_rtl.cpp
@@ -106,21 +106,21 @@ void ModeSmartRTL::path_follow_run()
                 // this is the very last point, add 2m to the target alt and move to pre-land state
                 dest_NED.z -= 2.0f;
                 smart_rtl_state = SubMode::PRELAND_POSITION;
-                wp_nav->set_wp_destination_NED_cm(dest_NED);
+                wp_nav->set_wp_destination_NED_m(dest_NED);
             } else {
                 // peek at the next point.  this can fail if the IO task currently has the path semaphore
                 Vector3f next_dest_NED;
                 if (g2.smart_rtl.peek_point(next_dest_NED)) {
-                    wp_nav->set_wp_destination_NED_cm(dest_NED);
+                    wp_nav->set_wp_destination_NED_m(dest_NED);
                     if (g2.smart_rtl.get_num_points() == 1) {
                         // this is the very last point, add 2m to the target alt
                         next_dest_NED.z -= 2.0f;
                     }
-                    wp_nav->set_wp_destination_next_NED_cm(next_dest_NED);
+                    wp_nav->set_wp_destination_next_NED_m(next_dest_NED);
                 } else {
                     // this can only happen if peek failed to take the semaphore
                     // send next point anyway which will cause the vehicle to slow at the next point
-                    wp_nav->set_wp_destination_NED_cm(dest_NED);
+                    wp_nav->set_wp_destination_NED_m(dest_NED);
                     INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
                 }
             }

--- a/ArduSub/mode_auto.cpp
+++ b/ArduSub/mode_auto.cpp
@@ -208,7 +208,7 @@ void ModeAuto::auto_circle_movetoedge_start(const Location &circle_center, float
         }
 
         // if we are outside the circle, point at the edge, otherwise hold yaw
-        float dist_to_center = get_horizontal_distance_cm(inertial_nav.get_position_xy_cm().topostype(), sub.circle_nav.get_center_NEU_cm().xy());
+        float dist_to_center = get_horizontal_distance(inertial_nav.get_position_xy_cm().topostype(), sub.circle_nav.get_center_NEU_cm().xy());
         if (dist_to_center > sub.circle_nav.get_radius_cm() && dist_to_center > 500) {
             set_auto_yaw_mode(get_default_auto_yaw_mode(false));
         } else {

--- a/ArduSub/mode_guided.cpp
+++ b/ArduSub/mode_guided.cpp
@@ -874,7 +874,7 @@ bool ModeGuided::guided_limit_check()
 
     // check if we have gone beyond horizontal limit
     if (guided_limit.horiz_max_cm > 0.0f) {
-        const float horiz_move = get_horizontal_distance_cm(guided_limit.start_pos.xy(), curr_pos.xy());
+        const float horiz_move = get_horizontal_distance(guided_limit.start_pos.xy(), curr_pos.xy());
         if (horiz_move > guided_limit.horiz_max_cm) {
             return true;
         }

--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -19,9 +19,9 @@ public:
     AC_Circle(const AP_AHRS_View& ahrs, AC_PosControl& pos_control);
 
     /// init - initialise circle controller setting center specifically
-    ///     set terrain_alt to true if center_neu_cm.z should be interpreted as an alt-above-terrain. Rate should be +ve in deg/sec for cw turn
+    ///     set is_terrain_alt to true if center_neu_cm.z should be interpreted as an alt-above-terrain. Rate should be +ve in deg/sec for cw turn
     ///     caller should set the position controller's x,y and z speeds and accelerations before calling this
-    void init_NEU_cm(const Vector3p& center_neu_cm, bool terrain_alt, float rate_degs);
+    void init_NEU_cm(const Vector3p& center_neu_cm, bool is_terrain_alt, float rate_degs);
 
     /// init - initialise circle controller setting center using stopping point and projecting out based on the copter's heading
     ///     caller should set the position controller's x,y and z speeds and accelerations before calling this
@@ -31,14 +31,14 @@ public:
     void set_center(const Location& center);
 
     /// set_circle_center as a vector from ekf origin
-    ///     terrain_alt should be true if center.z is alt is above terrain
-    void set_center_NEU_cm(const Vector3f& center_neu_cm, bool terrain_alt) { _center_neu_cm = center_neu_cm.topostype(); _terrain_alt = terrain_alt; }
+    ///     is_terrain_alt should be true if center.z is alt is above terrain
+    void set_center_NEU_cm(const Vector3f& center_neu_cm, bool is_terrain_alt) { _center_neu_cm = center_neu_cm.topostype(); _is_terrain_alt = is_terrain_alt; }
 
     /// get_circle_center in cm from home
     const Vector3p& get_center_NEU_cm() const { return _center_neu_cm; }
 
     /// returns true if using terrain altitudes
-    bool center_is_terrain_alt() const { return _terrain_alt; }
+    bool center_is_terrain_alt() const { return _is_terrain_alt; }
 
     /// get_radius - returns radius of circle in cm
     float get_radius_cm() const { return is_positive(_radius_cm)?_radius_cm:_radius_parm_cm; }
@@ -160,7 +160,7 @@ private:
     float       _last_radius_param; // last value of radius param, used to update radius on param change
 
     // terrain following variables
-    bool        _terrain_alt;           // true if _center_neu_cm.z is alt-above-terrain, false if alt-above-ekf-origin
+    bool        _is_terrain_alt;           // true if _center_neu_cm.z is alt-above-terrain, false if alt-above-ekf-origin
     bool        _rangefinder_available; // true if range finder could be used
     bool        _rangefinder_healthy;   // true if range finder is healthy
     float       _rangefinder_terrain_offset_cm; // latest rangefinder based terrain offset (e.g. terrain's height above EKF origin)

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -574,7 +574,7 @@ void AC_WPNav::update_track_with_speed_accel_limits()
 /// get_wp_distance_to_destination - get horizontal distance to destination_neu_cm in cm
 float AC_WPNav::get_wp_distance_to_destination_cm() const
 {
-    return get_horizontal_distance_cm(_pos_control.get_pos_estimate_NEU_cm().xy().tofloat(), _destination_neu_cm.xy());
+    return get_horizontal_distance(_pos_control.get_pos_estimate_NEU_cm().xy().tofloat(), _destination_neu_cm.xy());
 }
 
 /// get_wp_bearing_to_destination_cd - get bearing to next waypoint in centi-degrees

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -387,17 +387,17 @@ bool AC_WPNav::set_wp_destination_next_NEU_cm(const Vector3f& destination_neu_cm
 }
 
 /// set waypoint destination using NED position vector from ekf origin in meters
-bool AC_WPNav::set_wp_destination_NED_cm(const Vector3f& destination_NED_cm)
+bool AC_WPNav::set_wp_destination_NED_m(const Vector3f& destination_NED_m)
 {
     // convert NED to NEU and do not use terrain following
-    return set_wp_destination_NEU_cm(Vector3f(destination_NED_cm.x * 100.0f, destination_NED_cm.y * 100.0f, -destination_NED_cm.z * 100.0f), false);
+    return set_wp_destination_NEU_cm(Vector3f(destination_NED_m.x * 100.0f, destination_NED_m.y * 100.0f, -destination_NED_m.z * 100.0f), false);
 }
 
 /// set waypoint destination using NED position vector from ekf origin in meters
-bool AC_WPNav::set_wp_destination_next_NED_cm(const Vector3f& destination_NED_cm)
+bool AC_WPNav::set_wp_destination_next_NED_m(const Vector3f& destination_NED_m)
 {
     // convert NED to NEU and do not use terrain following
-    return set_wp_destination_next_NEU_cm(Vector3f(destination_NED_cm.x * 100.0f, destination_NED_cm.y * 100.0f, -destination_NED_cm.z * 100.0f), false);
+    return set_wp_destination_next_NEU_cm(Vector3f(destination_NED_m.x * 100.0f, destination_NED_m.y * 100.0f, -destination_NED_m.z * 100.0f), false);
 }
 
 /// shifts the origin and destination horizontally to the current position

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -121,8 +121,8 @@ public:
 
     /// set waypoint destination using NED position vector from ekf origin in meters
     ///     provide next_destination_NED if known
-    bool set_wp_destination_NED_cm(const Vector3f& destination_NED_cm);
-    bool set_wp_destination_next_NED_cm(const Vector3f& destination_NED_cm);
+    bool set_wp_destination_NED_m(const Vector3f& destination_NED_m);
+    bool set_wp_destination_next_NED_m(const Vector3f& destination_NED_m);
 
     /// shifts the origin and destination horizontally to the current position
     ///     used to reset the track when taking off without horizontal position control

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -43,9 +43,9 @@ public:
     // return terrain following altitude margin.  vehicle will stop if distance from target altitude is larger than this margin
     float get_terrain_margin_m() const { return MAX(_terrain_margin_m, 0.1); }
 
-    // convert location to vector from ekf origin.  terrain_alt is set to true if resulting vector's z-axis should be treated as alt-above-terrain
+    // convert location to vector from ekf origin.  is_terrain_alt is set to true if resulting vector's z-axis should be treated as alt-above-terrain
     //      returns false if conversion failed (likely because terrain data was not available)
-    bool get_vector_NEU_cm(const Location &loc, Vector3f &pos_from_origin_NEU_cm, bool &terrain_alt);
+    bool get_vector_NEU_cm(const Location &loc, Vector3f &pos_from_origin_NEU_cm, bool &is_terrain_alt);
 
     ///
     /// waypoint controller
@@ -98,7 +98,7 @@ public:
     const Vector3f &get_wp_origin_NEU_cm() const { return _origin_neu_cm; }
 
     /// true if origin.z and destination.z are alt-above-terrain, false if alt-above-ekf-origin
-    bool origin_and_destination_are_terrain_alt() const { return _terrain_alt; }
+    bool origin_and_destination_are_terrain_alt() const { return _is_terrain_alt; }
 
     /// set_wp_destination_NEU_cm waypoint using location class
     ///     provide the next_destination if known
@@ -115,9 +115,9 @@ public:
     virtual bool get_oa_wp_destination(Location& destination) const { return get_wp_destination_loc(destination); }
 
     /// set_wp_destination_NEU_cm waypoint using position vector (distance from ekf origin in cm)
-    ///     terrain_alt should be true if destination.z is a desired altitude above terrain
-    virtual bool set_wp_destination_NEU_cm(const Vector3f& destination_neu_cm, bool terrain_alt = false);
-    bool set_wp_destination_next_NEU_cm(const Vector3f& destination_neu_cm, bool terrain_alt = false);
+    ///     is_terrain_alt should be true if destination.z is a desired altitude above terrain
+    virtual bool set_wp_destination_NEU_cm(const Vector3f& destination_neu_cm, bool is_terrain_alt = false);
+    bool set_wp_destination_next_NEU_cm(const Vector3f& destination_neu_cm, bool is_terrain_alt = false);
 
     /// set waypoint destination using NED position vector from ekf origin in meters
     ///     provide next_destination_NED if known
@@ -187,20 +187,20 @@ public:
     bool set_spline_destination_next_loc(const Location& next_destination, const Location& next_next_destination, bool next_next_is_spline);
 
     /// set_spline_destination_NEU_cm waypoint using position vector (distance from ekf origin in cm)
-    ///     terrain_alt should be true if destination.z is a desired altitude above terrain (false if its desired altitudes above ekf origin)
+    ///     is_terrain_alt should be true if destination.z is a desired altitude above terrain (false if its desired altitudes above ekf origin)
     ///     next_destination is the next segment's destination
-    ///     next_terrain_alt should be true if next_destination.z is a desired altitude above terrain (false if its desired altitudes above ekf origin)
+    ///     next_is_terrain_alt should be true if next_destination.z is a desired altitude above terrain (false if its desired altitudes above ekf origin)
     ///     next_destination.z must be in the same "frame" as destination.z (i.e. if destination is a alt-above-terrain, next_destination must be too)
     ///     next_is_spline should be true if next_destination is a spline segment
-    bool set_spline_destination_NEU_cm(const Vector3f& destination_neu_cm, bool terrain_alt, const Vector3f& next_destination_neu_cm, bool next_terrain_alt, bool next_is_spline);
+    bool set_spline_destination_NEU_cm(const Vector3f& destination_neu_cm, bool is_terrain_alt, const Vector3f& next_destination_neu_cm, bool next_is_terrain_alt, bool next_is_spline);
 
     /// set next destination (e.g. the one after the current destination) as an offset (in cm, NEU frame) from the EKF origin
-    ///     next_terrain_alt should be true if next_destination.z is a desired altitude above terrain (false if its desired altitudes above ekf origin)
+    ///     next_is_terrain_alt should be true if next_destination.z is a desired altitude above terrain (false if its desired altitudes above ekf origin)
     ///     next_next_destination is the next segment's destination
-    ///     next_next_terrain_alt should be true if next_next_destination.z is a desired altitude above terrain (false if it is desired altitude above ekf origin)
+    ///     next_next_is_terrain_alt should be true if next_next_destination.z is a desired altitude above terrain (false if it is desired altitude above ekf origin)
     ///     next_next_destination.z must be in the same "frame" as destination.z (i.e. if next_destination is a alt-above-terrain, next_next_destination must be too)
     ///     next_next_is_spline should be true if next_next_destination is a spline segment
-    bool set_spline_destination_next_NEU_cm(const Vector3f& next_destination_neu_cm, bool next_terrain_alt, const Vector3f& next_next_destination_neu_cm, bool next_next_terrain_alt, bool next_next_is_spline);
+    bool set_spline_destination_next_NEU_cm(const Vector3f& next_destination_neu_cm, bool next_is_terrain_alt, const Vector3f& next_next_destination_neu_cm, bool next_next_is_terrain_alt, bool next_next_is_spline);
 
     ///
     /// shared methods
@@ -300,7 +300,7 @@ protected:
     bool        _paused;                    // flag for pausing waypoint controller
 
     // terrain following variables
-    bool        _terrain_alt;                   // true if origin and destination.z are alt-above-terrain, false if alt-above-ekf-origin
+    bool        _is_terrain_alt;                // true if origin and destination.z are alt-above-terrain, false if alt-above-ekf-origin
     bool        _rangefinder_available;         // true if rangefinder is enabled (user switch can turn this true/false)
     AP_Int8     _rangefinder_use;               // parameter that specifies if the range finder should be used for terrain following commands
     bool        _rangefinder_healthy;           // true if rangefinder distance is healthy (i.e. between min and maximum)

--- a/libraries/AC_WPNav/AC_WPNav_OA.cpp
+++ b/libraries/AC_WPNav/AC_WPNav_OA.cpp
@@ -48,7 +48,7 @@ float AC_WPNav_OA::get_wp_distance_to_destination_cm() const
         return AC_WPNav::get_wp_distance_to_destination_cm();
     }
 
-    return get_horizontal_distance_cm(_pos_control.get_pos_estimate_NEU_cm().xy().tofloat(), _destination_oabak_neu_cm.xy());
+    return get_horizontal_distance(_pos_control.get_pos_estimate_NEU_cm().xy().tofloat(), _destination_oabak_neu_cm.xy());
 }
 
 /// get_wp_bearing_to_destination - get bearing to next waypoint in centi-degrees

--- a/libraries/AC_WPNav/AC_WPNav_OA.h
+++ b/libraries/AC_WPNav/AC_WPNav_OA.h
@@ -20,9 +20,9 @@ public:
     bool get_oa_wp_destination(Location& destination) const override;
 
     /// set_wp_destination waypoint using position vector (distance from ekf origin in cm)
-    ///     terrain_alt should be true if destination.z is a desired altitude above terrain
+    ///     is_terrain_alt should be true if destination.z is a desired altitude above terrain
     ///     returns false on failure (likely caused by missing terrain data)
-    bool set_wp_destination_NEU_cm(const Vector3f& destination, bool terrain_alt = false) override;
+    bool set_wp_destination_NEU_cm(const Vector3f& destination, bool is_terrain_alt = false) override;
 
     /// get horizontal distance to destination in cm
     /// always returns distance to final destination (i.e. does not use oa adjusted destination)
@@ -48,7 +48,7 @@ protected:
     Vector3f    _origin_oabak_neu_cm;          // backup of _origin_neu_cm so it can be restored when oa completes
     Vector3f    _destination_oabak_neu_cm;     // backup of _destination_neu_cm so it can be restored when oa completes
     Vector3f    _next_destination_oabak_neu_cm;// backup of _next_destination_neu_cm so it can be restored when oa completes
-    bool        _terrain_alt_oabak;     // true if backup origin and destination z-axis are terrain altitudes
+    bool        _is_terrain_alt_oabak;     // true if backup origin and destination z-axis are terrain altitudes
     Location    _oa_destination;        // intermediate destination during avoidance
     Location    _oa_next_destination;   // intermediate next destination during avoidance
 };

--- a/libraries/AP_Math/location.h
+++ b/libraries/AP_Math/location.h
@@ -9,9 +9,10 @@
  * LOCATION
  */
 
-// return horizontal distance between two positions in cm
+// Computes straight-line distance in the horizontal plane between two positions.
+// Input units (e.g., meters, centimeters) must match; no unit conversion is performed.
 template <typename T>
-float get_horizontal_distance_cm(const Vector2<T> &origin, const Vector2<T> &destination)
+float get_horizontal_distance(const Vector2<T> &origin, const Vector2<T> &destination)
 {
     return (destination - origin).length();
 }


### PR DESCRIPTION
```
Board,blimp,bootloader,copter,heli,plane,rover,sub
CubeOrange,*,*,*,*,*,*,*
```