### PR TITLE
Add option to disable timestamp correction, let companion computer handle timesync

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -525,6 +525,7 @@ protected:
         // first bit is reserved for: MAVLINK2_SIGNING_DISABLED = (1U << 0),
         NO_FORWARD                = (1U << 1),  // don't forward MAVLink data to or from this device
         NOSTREAMOVERRIDE          = (1U << 2),  // ignore REQUEST_DATA_STREAM messages (eg. from GCSs)
+        NO_TS_CORRECT             = (1U << 3),  // no offboard timestamp correction, companion computer will take responsibility for timesync
     };
     bool option_enabled(Option option) const {
         return options & static_cast<uint16_t>(option);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4036,7 +4036,12 @@ void GCS_MAVLINK::handle_common_vision_position_estimate_data(const uint64_t use
     float posErr = 0;
     float angErr = 0;
     // correct offboard timestamp to be in local ms since boot
-    uint32_t timestamp_ms = correct_offboard_timestamp_usec_to_ms(usec, payload_size);
+    uint32_t timestamp_ms;
+    if (option_enabled(Option::NO_TS_CORRECT)) {
+        timestamp_ms = usec / 1000U;
+    } else {
+        timestamp_ms = correct_offboard_timestamp_usec_to_ms(usec, payload_size);
+    }
 
     AP_VisualOdom *visual_odom = AP::visualodom();
     if (visual_odom == nullptr) {
@@ -4056,8 +4061,13 @@ void GCS_MAVLINK::handle_att_pos_mocap(const mavlink_message_t &msg)
     mavlink_att_pos_mocap_t m;
     mavlink_msg_att_pos_mocap_decode(&msg, &m);
 
-    // correct offboard timestamp to be in local ms since boot
-    uint32_t timestamp_ms = correct_offboard_timestamp_usec_to_ms(m.time_usec, PAYLOAD_SIZE(chan, ATT_POS_MOCAP));
+    uint32_t timestamp_ms;
+    if (option_enabled(Option::NO_TS_CORRECT)) {
+        timestamp_ms = m.time_usec / 1000U;
+    } else {
+        // correct offboard timestamp to be in local ms since boot
+        timestamp_ms = correct_offboard_timestamp_usec_to_ms(m.time_usec, PAYLOAD_SIZE(chan, ATT_POS_MOCAP));
+    }
    
     AP_VisualOdom *visual_odom = AP::visualodom();
     if (visual_odom == nullptr) {
@@ -4076,7 +4086,12 @@ void GCS_MAVLINK::handle_vision_speed_estimate(const mavlink_message_t &msg)
     mavlink_vision_speed_estimate_t m;
     mavlink_msg_vision_speed_estimate_decode(&msg, &m);
     const Vector3f vel = {m.x, m.y, m.z};
-    uint32_t timestamp_ms = correct_offboard_timestamp_usec_to_ms(m.usec, PAYLOAD_SIZE(chan, VISION_SPEED_ESTIMATE));
+    uint32_t timestamp_ms;
+    if (option_enabled(Option::NO_TS_CORRECT)) {
+        timestamp_ms = m.usec / 1000U;
+    } else {
+        timestamp_ms = correct_offboard_timestamp_usec_to_ms(m.usec, PAYLOAD_SIZE(chan, VISION_SPEED_ESTIMATE));
+    }
     visual_odom->handle_vision_speed_estimate(m.usec, timestamp_ms, vel, m.reset_counter, 0);
 }
 #endif  // HAL_VISUALODOM_ENABLED


### PR DESCRIPTION
Currently, we correct the timestamps of visual odometry messages (e.g., ATT_POS_MOCAP, VISION_SPEED_ESTIMATE, etc.) to match the flight controller's (FC) local time. This correction assumes that the message timestamps represent the moment the companion computer sends the messages. Users must set VISO_DELAY_MS to account for the vision system's processing delay. However, due to the nature of computer vision, this processing time can vary significantly, potentially affecting flight performance.

This PR introduces an option to disable timestamp correction. In this mode, the companion computer must synchronize its clock with the FC using the TIMESYNC message. Once synchronized, the companion can send visual odometry messages with timestamps corresponding to the time the image was taken and set VISO_DELAY_MS to 0.

Attached flight log is tested with a raspberry pi 5 running vins-fusion and its processing time varies from 40ms to 70ms
[2 2025-7-12 下午 02-21-23.zip](https://github.com/user-attachments/files/21194564/2.2025-7-12.02-21-23.zip)
