### PR TITLE
AP_Scripting: remove utf8 assistance code

### DIFF
--- a/libraries/AP_Scripting/lua/src/linit.c
+++ b/libraries/AP_Scripting/lua/src/linit.c
@@ -48,7 +48,9 @@ static const luaL_Reg loadedlibs[] = {
 //  {LUA_OSLIBNAME, luaopen_os},
   {LUA_STRLIBNAME, luaopen_string},
   {LUA_MATHLIBNAME, luaopen_math},
+#if !defined(ARDUPILOT_BUILD)
   {LUA_UTF8LIBNAME, luaopen_utf8},
+#endif
 //  {LUA_DBLIBNAME, luaopen_debug},
 #if defined(LUA_COMPAT_BITLIB)
   {LUA_BITLIBNAME, luaopen_bit32},

--- a/libraries/AP_Scripting/lua/src/llex.c
+++ b/libraries/AP_Scripting/lua/src/llex.c
@@ -328,7 +328,7 @@ static int readhexaesc (LexState *ls) {
   return r;
 }
 
-
+#if !defined(ARDUPILOT_BUILD)
 static unsigned long readutf8esc (LexState *ls) {
   unsigned long r;
   int i = 4;  /* chars to be removed: '\', 'u', '{', and first digit */
@@ -353,7 +353,7 @@ static void utf8esc (LexState *ls) {
   for (; n > 0; n--)  /* add 'buff' to string */
     save(ls, buff[UTF8BUFFSZ - n]);
 }
-
+#endif
 
 static int readdecesc (LexState *ls) {
   int i;
@@ -391,7 +391,9 @@ static void read_string (LexState *ls, int del, SemInfo *seminfo) {
           case 't': c = '\t'; goto read_save;
           case 'v': c = '\v'; goto read_save;
           case 'x': c = readhexaesc(ls); goto read_save;
+#if !defined(ARDUPILOT_BUILD)
           case 'u': utf8esc(ls);  goto no_save;
+#endif
           case '\n': case '\r':
             inclinenumber(ls); c = '\n'; goto only_save;
           case '\\': case '\"': case '\'':

--- a/libraries/AP_Scripting/lua/src/lobject.c
+++ b/libraries/AP_Scripting/lua/src/lobject.c
@@ -440,12 +440,14 @@ const char *luaO_pushvfstring (lua_State *L, const char *fmt, va_list argp) {
         pushstr(L, buff, l);
         break;
       }
+#if !defined(ARDUPILOT_BUILD)
       case 'U': {  /* an 'int' as a UTF-8 sequence */
         char buff[UTF8BUFFSZ];
         int l = luaO_utf8esc(buff, cast(long, va_arg(argp, long)));
         pushstr(L, buff + UTF8BUFFSZ - l, l);
         break;
       }
+#endif
       case '%': {
         pushstr(L, "%", 1);
         break;

--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -251,9 +251,6 @@ void lua_scripts::create_sandbox(lua_State *L) {
     lua_pushstring(L, "io");
     luaopen_io(L);
     lua_settable(L, -3);
-    lua_pushstring(L, "utf8");
-    luaopen_utf8(L);
-    lua_settable(L, -3);
     lua_pushstring(L, "package");
     luaopen_package(L);
     lua_settable(L, -3);

--- a/libraries/AP_Scripting/tests/check.json
+++ b/libraries/AP_Scripting/tests/check.json
@@ -9,7 +9,8 @@
         "ffi": "disable",
         "jit": "disable",
         "table.clear": "disable",
-        "table.new": "disable"
+        "table.new": "disable",
+        "utf8": "disable"
       },
     "workspace": {
       // These lua scripts are not for running on AP


### PR DESCRIPTION
Removes the `utf8` library, the `\u{xxxx}` string escape, and the `%U` string formatting operator.

None of these are used by any of our examples and it's difficult to imagine a case where they would be used in the context of ArduPilot. They are also easy to substitute and implement in Lua itself. Removing them leaves error messages that directly say the operation is invalid so if there are any existing users they will get an obvious error and hopefully complain.

This doesn't change the ability to print or store utf8 sequences in any way (although the exact escape sequences used may need changing), so this shouldn't compromise existing or future language support, for example. The thing I can think that might be impaired is something that edits utf8 text, but I maintain the only applet that does that (the REPL) and think that it isn't worth the flash (and isn't supported now anyway).

Saves 1688 bytes of flash and a few hundred bytes of per-script RAM on Cube Orange. This leaves more room for future features.