### PR TITLE
AP_Scripting: Fix ‘buff’ may be used uninitialized

### DIFF
--- a/libraries/AP_Scripting/lua/src/loslib.c
+++ b/libraries/AP_Scripting/lua/src/loslib.c
@@ -177,7 +177,7 @@ static int os_rename (lua_State *L) {
 
 
 static int os_tmpname (lua_State *L) {
-  char buff[LUA_TMPNAMBUFSIZE];
+  char buff[LUA_TMPNAMBUFSIZE] = {0};
   int err;
   lua_tmpnam(buff, err);
   if (err)


### PR DESCRIPTION
Fixes: #30623
* #30623

Initialized the `buff` to remove a frequent warning in our GitHub Actions.
```diff
-  char buff[LUA_TMPNAMBUFSIZE];
+  char buff[LUA_TMPNAMBUFSIZE] = {0};
```
