### PR TITLE
AP_TempratureSensor: Comment param table indexes to avoid future clashes

### DIFF
--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Analog.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Analog.cpp
@@ -61,7 +61,7 @@ const AP_Param::GroupInfo AP_TemperatureSensor_Analog::var_info[] = {
     // @Description: a5 in polynomial of form temperature in deg = a0 + a1*voltage + a2*voltage^2 + a3*voltage^3 + a4*voltage^4 + a5*voltage^5
     AP_GROUPINFO("A5", 7, AP_TemperatureSensor_Analog, _a[5], 0),
 
-    // This param table is shared between backends, check for index clashes before adding more params!
+    // CHECK/UPDATE INDEX TABLE IN AP_TemperatureSensor_Backend.cpp WHEN CHANGING OR ADDING PARAMETERS
 
     AP_GROUPEND
 };

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Backend.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Backend.cpp
@@ -22,6 +22,18 @@
 #include <AP_BattMonitor/AP_BattMonitor.h>
 
 /*
+  All backends use the same parameter table and set of indices. Therefore, two
+  backends must not use the same index. The list of used indices and
+  corresponding backends is below.
+
+    1:   AP_TemperatureSensor_DroneCAN.cpp, note there is a clash with analog, but due to different param types we get away with it
+    1-7: AP_TemperatureSensor_Analog.cpp
+    8-9: AP_TemperatureSensor_MAX31865.cpp
+
+  Usage does not need to be contiguous. The maximum possible index is 63.
+*/
+
+/*
     base class constructor.
     This incorporates initialisation as well.
 */

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_DroneCAN.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_DroneCAN.cpp
@@ -35,7 +35,7 @@ const AP_Param::GroupInfo AP_TemperatureSensor_DroneCAN::var_info[] = {
     // @Range: 0 65535
     AP_GROUPINFO("MSG_ID", 1, AP_TemperatureSensor_DroneCAN, _ID, 0),
 
-    // This param table is shared between backends, check for index clashes before adding more params!
+    // CHECK/UPDATE INDEX TABLE IN AP_TemperatureSensor_Backend.cpp WHEN CHANGING OR ADDING PARAMETERS
     // MSG_ID here clashes with pin in the analog backed,
     // but because there different types (AP_Int8 vs AP_Int32) we get away with it.
 

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_MAX31865.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_MAX31865.cpp
@@ -74,7 +74,7 @@ const AP_Param::GroupInfo AP_TemperatureSensor_MAX31865::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("RTD_REF", 9, AP_TemperatureSensor_MAX31865, reference_resistance, 400),
 
-    // This param table is shared between backends, check for index clashes before adding more params!
+    // CHECK/UPDATE INDEX TABLE IN AP_TemperatureSensor_Backend.cpp WHEN CHANGING OR ADDING PARAMETERS
 
     AP_GROUPEND
 


### PR DESCRIPTION
Follow up to https://github.com/ArduPilot/ardupilot/pull/30406, adds better documentation of indexes in the same style as battery monitor. 