### PR TITLE
AP_RPM: move to vehicle and run at 50hz

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -225,9 +225,6 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
 #if HAL_LOGGING_ENABLED
     SCHED_TASK_CLASS(AP_Scheduler,         &copter.scheduler,           update_logging, 0.1,  75, 126),
 #endif
-#if AP_RPM_ENABLED
-    SCHED_TASK_CLASS(AP_RPM,               &copter.rpm_sensor,          update,          40, 200, 129),
-#endif
 #if AP_TEMPCALIBRATION_ENABLED
     SCHED_TASK_CLASS(AP_TempCalibration,   &copter.g2.temp_calibration, update,          10, 100, 135),
 #endif

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -302,10 +302,6 @@ private:
     } surface_tracking;
 #endif
 
-#if AP_RPM_ENABLED
-    AP_RPM rpm_sensor;
-#endif
-
     // Inertial Navigation EKF - different viewpoint
     AP_AHRS_View *ahrs_view;
 

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -607,12 +607,6 @@ const AP_Param::Info Copter::var_info[] = {
     GOBJECT(precland, "PLND_", AC_PrecLand),
 #endif
 
-#if AP_RPM_ENABLED
-    // @Group: RPM
-    // @Path: ../libraries/AP_RPM/AP_RPM.cpp
-    GOBJECT(rpm_sensor, "RPM", AP_RPM),
-#endif
-
 #if HAL_ADSB_ENABLED
     // @Group: ADSB_
     // @Path: ../libraries/AP_ADSB/AP_ADSB.cpp
@@ -1287,6 +1281,11 @@ void Copter::load_parameters(void)
     // PARAMETER_CONVERSION - Added: Mar-2022
 #if AP_FENCE_ENABLED
     AP_Param::convert_class(g.k_param_fence_old, &fence, fence.var_info, 0, true);
+#endif
+
+    // PARAMETER_CONVERSION - Added: July-2025 for ArduPilot-4.7
+#if AP_RPM_ENABLED
+    AP_Param::convert_class(g.k_param_rpm_sensor_old, &rpm_sensor, rpm_sensor.var_info, 0, true, true);
 #endif
 
     static const AP_Param::G2ObjectConversion g2_conversions[] {

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -371,7 +371,7 @@ public:
         k_param_pi_vel_xy,              // remove
         k_param_fs_ekf_action,
         k_param_rtl_climb_min,
-        k_param_rpm_sensor,
+        k_param_rpm_sensor_old, // remove
         k_param_autotune_min_d, // remove
         k_param_arming, // 252  - AP_Arming
         k_param_logger = 253, // 253 - Logging Group

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -152,11 +152,6 @@ void Copter::init_ardupilot()
     g2.beacon.init();
 #endif
 
-#if AP_RPM_ENABLED
-    // initialise AP_RPM library
-    rpm_sensor.init();
-#endif
-
 #if MODE_AUTO_ENABLED
     // initialise mission library
     mode_auto.mission.init();

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -940,12 +940,6 @@ const AP_Param::Info Plane::var_info[] = {
     GOBJECTN(ahrs.EKF3, NavEKF3, "EK3_", NavEKF3),
 #endif
 
-#if AP_RPM_ENABLED
-    // @Group: RPM
-    // @Path: ../libraries/AP_RPM/AP_RPM.cpp
-    GOBJECT(rpm_sensor, "RPM", AP_RPM),
-#endif
-
 #if AP_RSSI_ENABLED
     // @Group: RSSI_
     // @Path: ../libraries/AP_RSSI/AP_RSSI.cpp
@@ -1491,7 +1485,12 @@ void Plane::load_parameters(void)
 #if AP_FENCE_ENABLED
     AP_Param::convert_class(g.k_param_fence, &fence, fence.var_info, 0, true);
 #endif
-  
+
+    // PARAMETER_CONVERSION - Added: July-2025 for ArduPilot-4.7
+#if AP_RPM_ENABLED
+    AP_Param::convert_class(g.k_param_rpm_sensor_old, &rpm_sensor, rpm_sensor.var_info, 0, true, true);
+#endif
+
     // PARAMETER_CONVERSION - Added: Dec 2023
     // Convert _CM (centimeter) parameters to meters and _CD (centidegrees) parameters to meters
     g.pitch_trim.convert_centi_parameter(AP_PARAM_INT16);

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -146,7 +146,7 @@ public:
         k_param_crash_detection_enable,
         k_param_land_abort_throttle_enable, // unused - moved to AP_Landing
         k_param_rssi = 97,
-        k_param_rpm_sensor,
+        k_param_rpm_sensor_old, // unused - moved to vehicle
         k_param_parachute,
         k_param_arming = 100,
         k_param_parachute_channel, // unused - moved to RC option

--- a/ArduPlane/Plane.cpp
+++ b/ArduPlane/Plane.cpp
@@ -99,9 +99,6 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
     SCHED_TASK(one_second_loop,         1,    400,  90),
     SCHED_TASK(three_hz_loop,           3,     75,  93),
     SCHED_TASK(check_long_failsafe,     3,    400,  96),
-#if AP_RPM_ENABLED
-    SCHED_TASK_CLASS(AP_RPM,           &plane.rpm_sensor,     update,     10, 100,  99),
-#endif
 #if AP_AIRSPEED_AUTOCAL_ENABLE
     SCHED_TASK(airspeed_ratio_update,   1,    100,  102),
 #endif // AP_AIRSPEED_AUTOCAL_ENABLE

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -242,11 +242,6 @@ private:
 
     float get_landing_height(bool &using_rangefinder);
 
-
-#if AP_RPM_ENABLED
-    AP_RPM rpm_sensor;
-#endif
-
     AP_TECS TECS_controller{ahrs, aparm, landing, MASK_LOG_TECS};
     AP_L1_Control L1_controller{ahrs, &TECS_controller};
 

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -50,10 +50,6 @@ void Plane::init_ardupilot()
     rssi.init();
 #endif
 
-#if AP_RPM_ENABLED
-    rpm_sensor.init();
-#endif
-
     // setup telem slots with serial ports
     gcs().setup_uarts();
 

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -708,12 +708,6 @@ const AP_Param::Info Sub::var_info[] = {
     GOBJECT(osd, "OSD", AP_OSD),
 #endif
 
-#if AP_RPM_ENABLED
-    // @Group: RPM
-    // @Path: ../libraries/AP_RPM/AP_RPM.cpp
-    GOBJECT(rpm_sensor, "RPM", AP_RPM),
-#endif
-
 #if AP_RSSI_ENABLED
     // @Group: RSSI_
     // @Path: ../libraries/AP_RSSI/AP_RSSI.cpp
@@ -834,6 +828,11 @@ void Sub::load_parameters()
     // PARAMETER_CONVERSION - Added: Mar-2022
 #if AP_FENCE_ENABLED
     AP_Param::convert_class(g.k_param_fence_old, &fence, fence.var_info, 0, true);
+#endif
+
+    // PARAMETER_CONVERSION - Added: July-2025 for ArduPilot-4.7
+#if AP_RPM_ENABLED
+    AP_Param::convert_class(g.k_param_rpm_sensor_old, &rpm_sensor, rpm_sensor.var_info, 0, true, true);
 #endif
 
     static const AP_Param::G2ObjectConversion g2_conversions[] {

--- a/ArduSub/Parameters.h
+++ b/ArduSub/Parameters.h
@@ -233,7 +233,7 @@ public:
         k_param_acro_balance_pitch,
 
         // RPM Sensor
-        k_param_rpm_sensor = 232, // Disabled
+        k_param_rpm_sensor_old = 232, // unused - moved to vehicle
 
         // RC_Mapper Library
         k_param_rcmap, // Disabled

--- a/ArduSub/Sub.cpp
+++ b/ArduSub/Sub.cpp
@@ -140,9 +140,6 @@ const AP_Scheduler::Task Sub::scheduler_tasks[] = {
 #if HAL_LOGGING_ENABLED
     SCHED_TASK_CLASS(AP_Scheduler,        &sub.scheduler,    update_logging,     0.1,  75,  63),
 #endif
-#if AP_RPM_ENABLED
-    SCHED_TASK_CLASS(AP_RPM,              &sub.rpm_sensor,   update,              10, 200,  66),
-#endif
     SCHED_TASK(terrain_update,        10,    100,  72),
 #if AP_STATS_ENABLED
     SCHED_TASK(stats_update,           1,    200,  76),

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -165,10 +165,6 @@ private:
         LowPassFilterFloat alt_filt;         // altitude filter
     } rangefinder_state = { false, false, 0, 0, 0, 0, 0, 0 };
 
-#if AP_RPM_ENABLED
-    AP_RPM rpm_sensor;
-#endif
-
     // Mission library
     AP_Mission mission{
             FUNCTOR_BIND_MEMBER(&Sub::start_command, bool, const AP_Mission::Mission_Command &),

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -137,11 +137,6 @@ void Sub::init_ardupilot()
     init_rangefinder();
 #endif
 
-    // initialise AP_RPM library
-#if AP_RPM_ENABLED
-    rpm_sensor.init();
-#endif
-
     // initialise mission library
     mission.init();
 #if HAL_LOGGING_ENABLED

--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -292,12 +292,6 @@ const AP_Param::Info Rover::var_info[] = {
     GOBJECTN(ahrs.EKF3, NavEKF3, "EK3_", NavEKF3),
 #endif
 
-#if AP_RPM_ENABLED
-    // @Group: RPM
-    // @Path: ../libraries/AP_RPM/AP_RPM.cpp
-    GOBJECT(rpm_sensor, "RPM", AP_RPM),
-#endif
-
     // @Group: MIS_
     // @Path: ../libraries/AP_Mission/AP_Mission.cpp
     GOBJECTN(mode_auto.mission, mission, "MIS_", AP_Mission),
@@ -865,6 +859,11 @@ void Rover::load_parameters(void)
     // PARAMETER_CONVERSION - Added: Feb-2024 for Rover-4.6
 #if HAL_LOGGING_ENABLED
     AP_Param::convert_class(g.k_param_logger, &logger, logger.var_info, 0, true);
+#endif
+
+    // PARAMETER_CONVERSION - Added: July-2025 for ArduPilot-4.7
+#if AP_RPM_ENABLED
+    AP_Param::convert_class(g.k_param_rpm_sensor_old, &rpm_sensor, rpm_sensor.var_info, 0, true, true);
 #endif
 
     static const AP_Param::TopLevelObjectConversion toplevel_conversions[] {

--- a/Rover/Parameters.h
+++ b/Rover/Parameters.h
@@ -71,8 +71,8 @@ public:
 
         // 97: RSSI
         k_param_rssi = 97,
-        k_param_rpm_sensor,     // rpm sensor 98
-        
+        k_param_rpm_sensor_old, // unused - moved to vehicle
+
         // 100: Arming parameters
         k_param_arming = 100,
 

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -104,9 +104,6 @@ const AP_Scheduler::Task Rover::scheduler_tasks[] = {
 #if AC_PRECLAND_ENABLED
     SCHED_TASK(update_precland,      400,     50,  70),
 #endif
-#if AP_RPM_ENABLED
-    SCHED_TASK_CLASS(AP_RPM,              &rover.rpm_sensor,       update,         10,  100,  72),
-#endif
 #if HAL_MOUNT_ENABLED
     SCHED_TASK_CLASS(AP_Mount,            &rover.camera_mount,     update,         50,  200,  75),
 #endif

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -140,11 +140,6 @@ private:
     AP_Int8 *modes;
     const uint8_t num_modes = 6;
 
-#if AP_RPM_ENABLED
-    // AP_RPM Module
-    AP_RPM rpm_sensor;
-#endif
-
     // Arming/Disarming management class
     AP_Arming_Rover arming;
 

--- a/Rover/system.cpp
+++ b/Rover/system.cpp
@@ -13,11 +13,6 @@ void Rover::init_ardupilot()
 
     battery.init();
 
-#if AP_RPM_ENABLED
-    // Initialise RPM sensor
-    rpm_sensor.init();
-#endif
-
 #if AP_RSSI_ENABLED
     rssi.init();
 #endif

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -2067,7 +2067,7 @@ void AP_Param::convert_old_parameters_scaled(const struct ConversionInfo *conver
 // is_top_level: Is true if the class had its own top level key, param_key. It is false if the class was a subgroup
 void AP_Param::convert_class(uint16_t param_key, void *object_pointer,
                                     const struct AP_Param::GroupInfo *group_info,
-                                    uint16_t old_index, bool is_top_level)
+                                    uint16_t old_index, bool is_top_level, bool recurse_sub_groups)
 {
     const uint8_t group_shift = is_top_level ? 0 : 6;
 
@@ -2081,6 +2081,15 @@ void AP_Param::convert_class(uint16_t param_key, void *object_pointer,
         if (group_shift != 0 && idx == 0) {
             // Note: Index 0 is treated as 63 for group bit shifting purposes. See group_id()
             idx = 63;
+        }
+
+        if (info.type == AP_PARAM_GROUP) {
+            // Convert subgroups if enabled
+            if (recurse_sub_groups) {
+                // Only recurse once
+                convert_class(param_key, (uint8_t *)object_pointer + group_info[i].offset, get_group_info(group_info[i]), idx, false, false);
+            }
+            continue;
         }
 
         info.old_group_element = (idx << group_shift) + old_index;

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -522,7 +522,7 @@ public:
     // is_top_level: Is true if the class had its own top level key, param_key. It is false if the class was a subgroup
     static void         convert_class(uint16_t param_key, void *object_pointer,
                                         const struct AP_Param::GroupInfo *group_info,
-                                        uint16_t old_index, bool is_top_level);
+                                        uint16_t old_index, bool is_top_level, bool recurse_sub_groups = false);
 
     /*
       fetch a parameter value based on the index within a group. This

--- a/libraries/AP_RPM/AP_RPM.h
+++ b/libraries/AP_RPM/AP_RPM.h
@@ -113,8 +113,6 @@ public:
 #endif
 
 private:
-    void convert_params(void);
-
     static AP_RPM *_singleton;
 
     RPM_State state[RPM_MAX_INSTANCES];

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -12,7 +12,6 @@
 #include <AP_Logger/AP_Logger.h>
 #include <AP_Mission/AP_Mission.h>
 #include <AP_OSD/AP_OSD.h>
-#include <AP_RPM/AP_RPM.h>
 #include <SRV_Channel/SRV_Channel.h>
 #include <AP_Motors/AP_Motors.h>
 #include <AR_Motors/AP_MotorsUGV.h>
@@ -284,6 +283,12 @@ const AP_Param::GroupInfo AP_Vehicle::var_info[] = {
     AP_SUBGROUPINFO(serial_manager, "SERIAL", 31, AP_Vehicle, AP_SerialManager),
 #endif
 
+#if AP_RPM_ENABLED
+    // @Group: RPM
+    // @Path: ../AP_RPM/AP_RPM.cpp
+    AP_SUBGROUPINFO(rpm_sensor, "RPM", 32, AP_Vehicle, AP_RPM),
+#endif
+
     AP_GROUPEND
 };
 
@@ -522,6 +527,10 @@ void AP_Vehicle::setup()
     }
 #endif
 
+#if AP_RPM_ENABLED
+    rpm_sensor.init();
+#endif
+
     // invalidate count in case an enable parameter changed during
     // initialisation
     AP_Param::invalidate_count();
@@ -645,6 +654,9 @@ const AP_Scheduler::Task AP_Vehicle::scheduler_tasks[] = {
 #endif
 #if AP_NETWORKING_ENABLED
     SCHED_TASK_CLASS(AP_Networking, &vehicle.networking,    update,                   10,  50, 238),
+#endif
+#if AP_RPM_ENABLED
+    SCHED_TASK_CLASS(AP_RPM, &vehicle.rpm_sensor, update,                             50, 100, 239),
 #endif
 #if OSD_ENABLED
     SCHED_TASK(publish_osd_info, 1, 10, 240),
@@ -844,10 +856,9 @@ void AP_Vehicle::update_dynamic_notch(AP_InertialSensor::HarmonicNotch &notch)
 #if AP_RPM_ENABLED
         case HarmonicNotchDynamicMode::UpdateRPM: // rpm sensor based tracking
         case HarmonicNotchDynamicMode::UpdateRPM2: {
-            const auto *rpm_sensor = AP::rpm();
             uint8_t sensor = (notch.params.tracking_mode()==HarmonicNotchDynamicMode::UpdateRPM?0:1);
             float rpm;
-            if (rpm_sensor != nullptr && rpm_sensor->get_rpm(sensor, rpm)) {
+            if (rpm_sensor.get_rpm(sensor, rpm)) {
                 // set the harmonic notch filter frequency from the main rotor rpm
                 notch.update_freq_hz(rpm * ref * (1.0/60));
             } else {

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -81,6 +81,11 @@
 #include <AP_Gripper/AP_Gripper.h>
 #endif
 
+#include <AP_RPM/AP_RPM_config.h>
+#if AP_RPM_ENABLED
+#include <AP_RPM/AP_RPM.h>
+#endif
+
 #include <AP_IBus_Telem/AP_IBus_Telem.h>
 
 class AP_DDS_Client;
@@ -490,6 +495,10 @@ protected:
 
 #if AP_SCRIPTING_ENABLED
     AP_Scripting scripting;
+#endif
+
+#if AP_RPM_ENABLED
+    AP_RPM rpm_sensor;
 #endif
 
     static const struct AP_Param::GroupInfo var_info[];


### PR DESCRIPTION
This moves AP_RPM out of copter, plane, rover and sub to AP_Vehicle and runs at 50Hz. Copter was running at 40Hz, other vehicles were running at 10Hz. RPM can be a source for notch tracking, fast updates are important.

Tested param conversion with:
```
./Tools/autotest/test_param_upgrade.py --vehicle=arduplane --vehicle=arducopter --vehicle=rover --vehicle=ardusub --param "RPM1_TYPE=1" --param "RPM1_SCALING=2" --param "RPM1_MAX=3" --param "RPM1_MIN=4" --param "RPM1_MIN_QUAL=5" --param "RPM1_PIN=6" --param "RPM1_ESC_MASK=7" --param "RPM2_TYPE=8" --param "RPM2_SCALING=9" --param "RPM2_MAX=10" --param "RPM2_MIN=11" --param "RPM2_MIN_QUAL=12" --param "RPM2_PIN=13" --param "RPM2_ESC_MASK=14"
```
