### PR TITLE
AP_Param: Revert "check for duplicate names when adding scripting params"

### DIFF
--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -3189,7 +3189,7 @@ bool AP_Param::add_param(uint8_t _key, uint8_t param_num, const char *pname, flo
     }
 
     // check for valid values
-    if (param_num == 0 || param_num > 63 || strlen(pname) > AP_MAX_NAME_SIZE) {
+    if (param_num == 0 || param_num > 63 || strlen(pname) > 16) {
         return false;
     }
 
@@ -3224,30 +3224,6 @@ bool AP_Param::add_param(uint8_t _key, uint8_t param_num, const char *pname, flo
     if (load_int32(key, 0, current_crc) && current_crc != crc) {
         // crc mismatch, we have a conflict with an existing use of this key
         return false;
-    }
-
-    // Check length
-    char fullName[AP_MAX_NAME_SIZE+1] = {};
-    const int fullNameLength = hal.util->snprintf(fullName, sizeof(fullName), "%s%s", info.name, pname);
-    if ((fullNameLength < 0) || (fullNameLength > AP_MAX_NAME_SIZE)) {
-        // Param is too long with table prefix (or snprintf failed)
-        return false;
-    }
-
-    // Check for conflicting name
-    enum ap_var_type existingType;
-    ParamToken existingToken;
-    if (find_by_name(fullName, &existingType, &existingToken) != nullptr) {
-        // Param with this name already exists, check if it is the parameter were trying to add from a previous script run
-        if (existingToken.key != (_num_vars_base + i)) {
-            // Found param is not in this table, can't be this one
-            return false;
-        }
-        if (existingToken.group_element != param_num) {
-            // Index does not match, two params with the same name in the same table?
-            return false;
-        }
-        // Existing param is the same as this one, must be a scripting restart
     }
 
     // fill in idx of any gaps, leaving them hidden, this allows


### PR DESCRIPTION
This reverts commit a562b113ee20e1a79b5f1bbbccd9d06e0a75b672 from PR #30523 .

This has severe performance impacts on both SITL/autotest and real hardware. In SITL it increases the (virtual?) time required for the `plane_aerobatics.lua` script to load from <1ms to ~800ms, causing the AerobaticsScripting test to fail as the script is not always loaded by the time its parameters are referenced. On CubeOrange, it increases the time required from ~850ms to ~2000ms; the original test might have been flawed.

The culprit appears to be the `find_by_name` function call added for each parameter. Its operation is inscrutable to Peter Barker and I, and removing it fixes the time issue.

Experimentation reveals that the `find` function call used by the existing `Parameter` system is much faster. A custom version patched to return the required `i` and `group_element` values for the test increases script load time to ~900ms.

Considering the potential issues posed by `find_by_name` and our inability to immediately devote time to fixes, it seems prudent to revert to get CI back on its feet and try to get the feature in later after fixing the parameter system or re-designing the test to use the faster function.

Removing the parameter table setup infrastructure from the aerobatics script results in a load time of ~65ms on hardware, illustrating that there are still severe inefficiencies in the parameter setup, but this is a pre-existing issue.