### PR TITLE
Networking: support capturing all packets to a pcap file

### DIFF
--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -479,6 +479,7 @@ BUILD_OPTIONS = [
     Feature('Networking', 'Networking', 'AP_NETWORKING_ENABLED', 'Enable networking', 0, None),
     Feature('Networking', 'PPP', 'AP_NETWORKING_BACKEND_PPP', 'Enable PPP networking', 0, "Networking"),
     Feature('Networking', 'CAN_MCAST', 'AP_NETWORKING_CAN_MCAST_ENABLED', 'Enable CAN multicast bridge', 0, "Networking,DroneCAN"), # noqa
+    Feature('Networking', 'NetworkCapture', 'AP_NETWORKING_CAPTURE_ENABLED', 'Enable network capture', 0, "Networking"),
 
     Feature('CAN', 'DroneCAN', 'HAL_ENABLE_DRONECAN_DRIVERS', 'Enable DroneCAN support', 0, None),
     Feature('CAN', 'CAN Logging', 'AP_CAN_LOGGING_ENABLED', 'Enable CAN logging support', 0, 'Logging'),

--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -276,6 +276,8 @@ class ExtractFeatures(object):
             ('AP_NETWORKING_ENABLED', 'AP_Networking::init'),
             ('AP_NETWORKING_BACKEND_PPP', 'AP_Networking_PPP::init'),
             ('AP_NETWORKING_CAN_MCAST_ENABLED', 'AP_Networking_CAN::start'),
+            ('AP_NETWORKING_CAPTURE_ENABLED', 'AP_Networking_Backend::capture_pbuf'),
+
             ('FORCE_APJ_DEFAULT_PARAMETERS', 'AP_Param::param_defaults_data'),
             ('HAL_BUTTON_ENABLED', 'AP_Button::update'),
             ('HAL_LOGGING_ENABLED', 'AP_Logger::init'),

--- a/libraries/AP_Networking/AP_Networking.cpp
+++ b/libraries/AP_Networking/AP_Networking.cpp
@@ -90,7 +90,7 @@ const AP_Param::GroupInfo AP_Networking::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: Networking options
     // @Description: Networking options
-    // @Bitmask: 0:EnablePPP Ethernet gateway, 1:Enable CAN1 multicast endpoint, 2:Enable CAN2 multicast endpoint, 3:Enable CAN1 multicast bridged, 4:Enable CAN2 multicast bridged, 5:DisablePPPTimeout, 6:DisablePPPEchoLimit
+    // @Bitmask: 0:EnablePPP Ethernet gateway, 1:Enable CAN1 multicast endpoint, 2:Enable CAN2 multicast endpoint, 3:Enable CAN1 multicast bridged, 4:Enable CAN2 multicast bridged, 5:DisablePPPTimeout, 6:DisablePPPEchoLimit, 7:Capture to file
     // @RebootRequired: True
     // @User: Advanced
     AP_GROUPINFO("OPTIONS", 9,  AP_Networking,    param.options, 0),

--- a/libraries/AP_Networking/AP_Networking.h
+++ b/libraries/AP_Networking/AP_Networking.h
@@ -173,6 +173,9 @@ public:
 #endif
         PPP_TIMEOUT_DISABLE=(1U<<5),
         PPP_ECHO_LIMIT_DISABLE=(1U<<6),
+#if AP_NETWORKING_CAPTURE_ENABLED
+        CAPTURE_PACKETS=(1U<<7),
+#endif
     };
     bool option_is_set(OPTION option) const {
         return (param.options.get() & int32_t(option)) != 0;

--- a/libraries/AP_Networking/AP_Networking_Backend.cpp
+++ b/libraries/AP_Networking/AP_Networking_Backend.cpp
@@ -2,6 +2,12 @@
 
 #if AP_NETWORKING_ENABLED
 
+#if AP_NETWORKING_CAPTURE_ENABLED
+#include <AP_RTC/AP_RTC.h>
+#include <AP_Filesystem/AP_Filesystem.h>
+#include <lwip/tcpip.h>
+#endif
+
 // add a new route for an interface
 // Returns true if the route is added or the route already exists
 bool AP_Networking_Backend::add_route(uint8_t iface_idx, uint32_t dest_ip, uint8_t mask_len)
@@ -23,5 +29,40 @@ bool AP_Networking_Backend::add_route(uint8_t iface_idx, uint32_t dest_ip, uint8
     }
     return false;
 }
+
+#if AP_NETWORKING_CAPTURE_ENABLED
+
+/*
+  write a header for the start of a new capture packet
+  capture.sem should be taken before the header is output
+  and held for the whole packet
+  note that len should include the direction byte for PPP data
+
+  caller must have checked that capture.fd != -1
+*/
+void AP_Networking_Backend::capture_header(int fd, uint32_t len)
+{
+    uint64_t utc_usec = 0;
+#if AP_RTC_ENABLED
+    AP::rtc().get_utc_usec(utc_usec);
+#endif
+    if (utc_usec == 0) {
+        utc_usec = AP_HAL::micros64();
+    }
+    const struct pcaprec_hdr {
+        uint32_t ts_sec;
+        uint32_t ts_usec;
+        uint32_t incl_len;
+        uint32_t orig_len;
+    } rec {
+        .ts_sec = uint32_t(utc_usec / 1000000ULL),
+        .ts_usec = uint32_t(utc_usec % 1000000ULL),
+        .incl_len = len,
+        .orig_len = len
+    };
+
+    AP::FS().write(fd, (const void *)&rec, sizeof(rec));
+}
+#endif // AP_NETWORKING_CAPTURE_ENABLED
 
 #endif // AP_NETWORKING_ENABLED

--- a/libraries/AP_Networking/AP_Networking_Backend.h
+++ b/libraries/AP_Networking/AP_Networking_Backend.h
@@ -31,7 +31,16 @@ public:
 
     // hook for custom routes
     virtual struct netif *routing_hook(uint32_t dest) { return nullptr; }
-    
+
+#if AP_NETWORKING_CAPTURE_ENABLED
+    /*
+      write a header for the start of a new capture packet
+      a capture semaphore should be taken before the header is output
+      and held for the whole packet
+     */
+    void capture_header(int fd, uint32_t len);
+#endif
+
 protected:
     AP_Networking &frontend;
 

--- a/libraries/AP_Networking/AP_Networking_ChibiOS.h
+++ b/libraries/AP_Networking/AP_Networking_ChibiOS.h
@@ -25,6 +25,15 @@ private:
     static int8_t ethernetif_init(struct netif *netif);
     static int8_t low_level_output(struct netif *netif, struct pbuf *p);
     static bool low_level_input(struct netif *netif, struct pbuf **pbuf);
+#if AP_NETWORKING_CAPTURE_ENABLED
+    void start_capture(void);
+    void stop_capture(void);
+    static void capture_pbuf(struct pbuf *p);
+    struct {
+        HAL_Semaphore sem;
+        int fd = -1;
+    } capture;
+#endif
 
     struct lwipthread_opts *lwip_options;
     uint8_t macaddr[6];

--- a/libraries/AP_Networking/AP_Networking_Config.h
+++ b/libraries/AP_Networking/AP_Networking_Config.h
@@ -1,5 +1,6 @@
 #include <AP_HAL/AP_HAL_Boards.h>
 #include <AP_SerialManager/AP_SerialManager_config.h>
+#include <AP_Filesystem/AP_Filesystem_config.h>
 
 #if defined(AP_NETWORKING_BACKEND_PPP) && !defined(AP_NETWORKING_ENABLED)
 // allow --enable-PPP to enable networking
@@ -144,4 +145,9 @@
 
 #ifndef AP_NETWORKING_REGISTER_PORT_ENABLED
 #define AP_NETWORKING_REGISTER_PORT_ENABLED AP_NETWORKING_ENABLED && AP_SERIALMANAGER_REGISTER_ENABLED
+#endif
+
+// SITL only network capture, use custom build server to enable on real boards
+#ifndef AP_NETWORKING_CAPTURE_ENABLED
+#define AP_NETWORKING_CAPTURE_ENABLED (AP_NETWORKING_NEED_LWIP && AP_FILESYSTEM_FILE_WRITING_ENABLED && CONFIG_HAL_BOARD == HAL_BOARD_SITL)
 #endif

--- a/libraries/AP_Networking/AP_Networking_PPP.h
+++ b/libraries/AP_Networking/AP_Networking_PPP.h
@@ -21,7 +21,12 @@ public:
 
     // hook for custom routes
     struct netif *routing_hook(uint32_t dest) override;
-    
+
+#if AP_NETWORKING_CAPTURE_ENABLED
+    // hook for PPP capture
+    static void capture_hook(const struct ppp_pcb_s *pcb, const struct pbuf *pb);
+#endif
+
 private:
     void ppp_loop(void);
 
@@ -33,10 +38,22 @@ private:
         struct ppp_pcb_s *ppp;
         bool need_restart;
         uint32_t last_read_ms;
+#if AP_NETWORKING_CAPTURE_ENABLED
+        struct {
+            HAL_Semaphore sem;
+            int fd = -1;
+        } capture;
+        void capture_data(const uint8_t *ptr, uint32_t len);
+        void capture_hook(const struct pbuf *pb);
+#endif
     } iface[AP_NETWORKING_PPP_NUM_INTERFACES];
 
     void restart_instance(const uint8_t idx);
     bool update_instance(const uint8_t idx);
+#if AP_NETWORKING_CAPTURE_ENABLED
+    void start_capture(void);
+    void stop_capture(void);
+#endif
 
     static void ppp_status_callback(struct ppp_pcb_s *pcb, int code, void *ctx);
     static uint32_t ppp_output_cb(struct ppp_pcb_s *pcb, const void *data, uint32_t len, void *ctx);

--- a/libraries/AP_Networking/config/lwipopts.h
+++ b/libraries/AP_Networking/config/lwipopts.h
@@ -360,6 +360,12 @@ struct netif *ap_networking_routing_hook(const struct ip4_addr *dest);
 
 #if PPP_SUPPORT
 
+// support PPP network capture
+struct pbuf;
+struct ppp_pcb_s;
+void ap_ppp_capture_hook(const struct ppp_pcb_s *pcb, const struct pbuf *pb);
+#define LWIP_PPP_CAPTURE_HOOK ap_ppp_capture_hook
+
 #define NUM_PPP                 1      /* Max PPP sessions. */
 
 


### PR DESCRIPTION
This allows capturing of all packets (ethernet or PPP) to a pcap file which can be read by wireshark

this is very useful for debugging tricky networking issues

tested on CubeOrange with BotbloxDroneNet and on Pixhawk6X

depends on: https://github.com/ArduPilot/lwip/pull/4

this also includes a new set of buffered write operations for logging in AP_Filesystem, based on stdio-like API calls
