### PR TITLE
Plane: make RNGFND_LANDING a bitmask (4.6 backport)

### DIFF
--- a/ArduPlane/GCS_Plane.cpp
+++ b/ArduPlane/GCS_Plane.cpp
@@ -118,7 +118,7 @@ void GCS_Plane::update_vehicle_sensor_status_flags(void)
     const RangeFinder *rangefinder = RangeFinder::get_singleton();
     if (rangefinder && rangefinder->has_orientation(plane.rangefinder_orientation())) {
         control_sensors_present |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
-        if (plane.g.rangefinder_landing) {
+        if (uint16_t(plane.g.rangefinder_landing.get()) != 0) {
             control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_LASER_POSITION;
         }
         if (rangefinder->has_data_orient(plane.rangefinder_orientation())) {

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -794,9 +794,9 @@ const AP_Param::Info Plane::var_info[] = {
     GOBJECT(rangefinder,            "RNGFND", RangeFinder),
 
     // @Param: RNGFND_LANDING
-    // @DisplayName: Enable rangefinder for landing
-    // @Description: This enables the use of a rangefinder for automatic landing. The rangefinder will be used both on the landing approach and for final flare
-    // @Values: 0:Disabled,1:Enabled
+    // @DisplayName: Enable use of rangefinder
+    // @Description: Sets the use of a rangefinder for automatic landing and other use cases. When enabled for landing and takeoff the rangefinder will be used both on the landing approach and for final flare as well as as VTOL landing and for takeoffs and throttle suppression when close to the ground. When enabled for assist the rangefinder will be used for VTOL assistance. When enabled for climb the rangefinder will be used for the initial climb in QRTL and AUTO. Set to 0 to disable use of the rangefinder.
+    // @Bitmask: 0:All, 1:TakeoffAndLanding, 2:Assist, 3:InitialClimb
     // @User: Standard
     GSCALAR(rangefinder_landing,    "RNGFND_LANDING",   0),
 #endif

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -219,6 +219,7 @@ private:
     Rotation rangefinder_orientation(void) const {
         return Rotation(g2.rangefinder_land_orient.get());
     }
+
 #endif
 
 #if AP_MAVLINK_MAV_CMD_SET_HAGL_ENABLED
@@ -892,8 +893,9 @@ private:
     void adjust_altitude_target();
     void setup_glide_slope(void);
     int32_t get_RTL_altitude_cm() const;
-    float relative_ground_altitude(bool use_rangefinder_if_available);
-    float relative_ground_altitude(bool use_rangefinder_if_available, bool use_terrain_if_available);
+    bool rangefinder_use(enum RangeFinderUse rangefinder_use) const;
+    float relative_ground_altitude(enum RangeFinderUse rangefinder_use);
+    float relative_ground_altitude(enum RangeFinderUse rangefinder_use, bool use_terrain_if_available);
     void set_target_altitude_current(void);
     void set_target_altitude_current_adjusted(void);
     void set_target_altitude_location(const Location &loc);

--- a/ArduPlane/VTOL_Assist.cpp
+++ b/ArduPlane/VTOL_Assist.cpp
@@ -106,7 +106,7 @@ bool VTOL_Assist::should_assist(float aspeed, bool have_airspeed)
         alt_error.reset();
 
     } else {
-        const float height_above_ground = plane.relative_ground_altitude(plane.g.rangefinder_landing);
+        const float height_above_ground = plane.relative_ground_altitude(RangeFinderUse::ASSIST);
         if (alt_error.update(height_above_ground < alt, now_ms, tigger_delay_ms, clear_delay_ms)) {
             gcs().send_text(MAV_SEVERITY_WARNING, "Alt assist %.1fm", height_above_ground);
         }

--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -113,7 +113,7 @@ int32_t Plane::get_RTL_altitude_cm() const
   return relative altitude in meters (relative to terrain, if available,
   or home otherwise)
  */
-float Plane::relative_ground_altitude(bool use_rangefinder_if_available, bool use_terrain_if_available)
+float Plane::relative_ground_altitude(enum RangeFinderUse use_rangefinder, bool use_terrain_if_available)
 {
 #if AP_MAVLINK_MAV_CMD_SET_HAGL_ENABLED
    float height_AGL;
@@ -124,13 +124,13 @@ float Plane::relative_ground_altitude(bool use_rangefinder_if_available, bool us
 #endif // AP_MAVLINK_MAV_CMD_SET_HAGL_ENABLED
 
 #if AP_RANGEFINDER_ENABLED
-   if (use_rangefinder_if_available && rangefinder_state.in_range) {
+   if (rangefinder_use(use_rangefinder) && rangefinder_state.in_range) {
         return rangefinder_state.height_estimate;
    }
 #endif
 
 #if HAL_QUADPLANE_ENABLED && AP_RANGEFINDER_ENABLED
-   if (use_rangefinder_if_available && quadplane.in_vtol_land_final() &&
+   if (rangefinder_use(use_rangefinder) && quadplane.in_vtol_land_final() &&
        rangefinder.status_orient(rangefinder_orientation()) == RangeFinder::Status::OutOfRangeLow) {
        // a special case for quadplane landing when rangefinder goes
        // below minimum. Consider our height above ground to be zero
@@ -161,13 +161,29 @@ float Plane::relative_ground_altitude(bool use_rangefinder_if_available, bool us
     return relative_altitude;
 }
 
+/*
+  return true if we should use the rangefinder for a specific use case
+ */
+bool Plane::rangefinder_use(enum RangeFinderUse use_rangefinder) const
+{
+    const uint8_t use = uint8_t(g.rangefinder_landing.get());
+    if (use == uint8_t(RangeFinderUse::NONE)) {
+        return false;
+    }
+    if (use & uint8_t(RangeFinderUse::ALL)) {
+        // if ALL bit is set then ignore other bits
+        return true;
+    }
+    return (use & uint8_t(use_rangefinder)) != 0;
+}
+
 // Helper for above method using terrain if the vehicle is currently terrain following
-float Plane::relative_ground_altitude(bool use_rangefinder_if_available)
+float Plane::relative_ground_altitude(enum RangeFinderUse use_rangefinder)
 {
 #if AP_TERRAIN_AVAILABLE
-    return relative_ground_altitude(use_rangefinder_if_available, target_altitude.terrain_following);
+    return relative_ground_altitude(use_rangefinder, target_altitude.terrain_following);
 #else
-    return relative_ground_altitude(use_rangefinder_if_available, false);
+    return relative_ground_altitude(use_rangefinder, false);
 #endif
 }
 
@@ -678,7 +694,7 @@ float Plane::rangefinder_correction(void)
     }
 
     // for now we only support the rangefinder for landing 
-    bool using_rangefinder = (g.rangefinder_landing && flight_stage == AP_FixedWing::FlightStage::LAND);
+    bool using_rangefinder = (rangefinder_use(RangeFinderUse::TAKEOFF_LANDING) && flight_stage == AP_FixedWing::FlightStage::LAND);
     if (!using_rangefinder) {
         return 0;
     }
@@ -693,7 +709,7 @@ float Plane::rangefinder_correction(void)
 void Plane::rangefinder_terrain_correction(float &height)
 {
 #if AP_TERRAIN_AVAILABLE
-    if (!g.rangefinder_landing ||
+    if (!rangefinder_use(RangeFinderUse::TAKEOFF_LANDING) ||
         flight_stage != AP_FixedWing::FlightStage::LAND ||
         !terrain_enabled_in_current_mode()) {
         return;
@@ -776,7 +792,7 @@ void Plane::rangefinder_height_update(void)
 #endif
             if (!rangefinder_state.in_use &&
                 flightstage_good_for_rangefinder_landing &&
-                g.rangefinder_landing) {
+                rangefinder_use(RangeFinderUse::TAKEOFF_LANDING)) {
                 rangefinder_state.in_use = true;
                 gcs().send_text(MAV_SEVERITY_INFO, "Rangefinder engaged at %.2fm", (double)rangefinder_state.height_estimate);
             }
@@ -806,7 +822,7 @@ void Plane::rangefinder_height_update(void)
         if (now - rangefinder_state.last_correction_time_ms > 5000) {
             rangefinder_state.correction = correction;
             rangefinder_state.initial_correction = correction;
-            if (g.rangefinder_landing) {
+            if (rangefinder_use(RangeFinderUse::TAKEOFF_LANDING)) {
                 landing.set_initial_slope();
             }
             rangefinder_state.last_correction_time_ms = now;
@@ -939,7 +955,7 @@ float Plane::get_landing_height(bool &rangefinder_active)
 #if AP_RANGEFINDER_ENABLED
     // possibly correct with rangefinder
     height -= rangefinder_correction();
-    rangefinder_active = g.rangefinder_landing && rangefinder_state.in_range;
+    rangefinder_active = rangefinder_use(RangeFinderUse::TAKEOFF_LANDING) && rangefinder_state.in_range;
 #endif
 
     return height;

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -197,3 +197,15 @@ enum class FenceAutoEnable : uint8_t {
     AutoDisableFloorOnly=2,
     WhenArmed=3
 };
+
+/*
+  bitmask of options for RGFND_LANDING
+ */
+enum class RangeFinderUse : uint8_t {
+    NONE    = 0U,
+    ALL     = (1U<<0),
+    TAKEOFF_LANDING = (1U<<1),
+    ASSIST  = (1U<<2),
+    CLIMB   = (1U<<3),
+};
+

--- a/ArduPlane/mode_qland.cpp
+++ b/ArduPlane/mode_qland.cpp
@@ -9,7 +9,7 @@ bool ModeQLand::_enter()
     quadplane.throttle_wait = false;
     quadplane.setup_target_position();
     poscontrol.set_state(QuadPlane::QPOS_LAND_DESCEND);
-    quadplane.last_land_final_agl = plane.relative_ground_altitude(plane.g.rangefinder_landing);
+    quadplane.last_land_final_agl = plane.relative_ground_altitude(RangeFinderUse::TAKEOFF_LANDING);
     quadplane.landing_detect.lower_limit_start_ms = 0;
     quadplane.landing_detect.land_start_ms = 0;
 #if AP_LANDINGGEAR_ENABLED

--- a/ArduPlane/mode_qloiter.cpp
+++ b/ArduPlane/mode_qloiter.cpp
@@ -149,7 +149,7 @@ void ModeQLoiter::run()
             }
 #endif  // AP_ICENGINE_ENABLED
         }
-        float height_above_ground = plane.relative_ground_altitude(plane.g.rangefinder_landing);
+        float height_above_ground = plane.relative_ground_altitude(RangeFinderUse::TAKEOFF_LANDING);
         float descent_rate_cms = quadplane.landing_descent_rate_cms(height_above_ground);
 
         if (poscontrol.get_state() == QuadPlane::QPOS_LAND_FINAL && !quadplane.option_is_set(QuadPlane::OPTION::DISABLE_GROUND_EFFECT_COMP)) {

--- a/ArduPlane/mode_qrtl.cpp
+++ b/ArduPlane/mode_qrtl.cpp
@@ -33,7 +33,7 @@ bool ModeQRTL::_enter()
         const bool use_terrain = false;
 #endif
 
-        const float dist_to_climb = target_alt - plane.relative_ground_altitude(plane.g.rangefinder_landing, use_terrain);
+        const float dist_to_climb = target_alt - plane.relative_ground_altitude(RangeFinderUse::CLIMB, use_terrain);
         if (is_positive(dist_to_climb)) {
             // climb before returning, only next waypoint altitude is used
             submode = SubMode::climb;

--- a/ArduPlane/mode_takeoff.cpp
+++ b/ArduPlane/mode_takeoff.cpp
@@ -82,7 +82,7 @@ void ModeTakeoff::update()
     const float dist = target_dist;
     if (!takeoff_mode_setup) {
         plane.auto_state.takeoff_altitude_rel_cm = alt * 100;
-        const uint16_t altitude = plane.relative_ground_altitude(false,true);
+        const uint16_t altitude = plane.relative_ground_altitude(RangeFinderUse::NONE,true);
         const Vector2f &groundspeed2d = ahrs.groundspeed_vector();
         const float direction = wrap_360(degrees(groundspeed2d.angle()));
         const float groundspeed = groundspeed2d.length();

--- a/ArduPlane/parachute.cpp
+++ b/ArduPlane/parachute.cpp
@@ -49,7 +49,7 @@ bool Plane::parachute_manual_release()
         return false;
     }
 
-    if (parachute.alt_min() > 0 && relative_ground_altitude(false) < parachute.alt_min() &&
+    if (parachute.alt_min() > 0 && relative_ground_altitude(RangeFinderUse::NONE) < parachute.alt_min() &&
             auto_state.last_flying_ms > 0) {
         // Allow manual ground tests by only checking if flying too low if we've taken off
         gcs().send_text(MAV_SEVERITY_WARNING, "Parachute: Too low");

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1861,7 +1861,7 @@ void QuadPlane::update_throttle_suppression(void)
     }
 
     // if we are more than 5m from home altitude then allow motors to run
-    if (plane.relative_ground_altitude(plane.g.rangefinder_landing) > 5) {
+    if (plane.relative_ground_altitude(RangeFinderUse::TAKEOFF_LANDING) > 5) {
         return;
     }
 
@@ -2206,7 +2206,7 @@ void QuadPlane::poscontrol_init_approach(void)
                                 plane.ahrs.groundspeed(),
                                 dist,
                                 stopping_distance(),
-                                plane.relative_ground_altitude(plane.g.rangefinder_landing));
+                                plane.relative_ground_altitude(RangeFinderUse::TAKEOFF_LANDING));
                 poscontrol.set_state(QPOS_AIRBRAKE);
             }
         } else {
@@ -2421,7 +2421,7 @@ void QuadPlane::vtol_position_controller(void)
                                 groundspeed,
                                 plane.auto_state.wp_distance,
                                 stop_distance,
-                                plane.relative_ground_altitude(plane.g.rangefinder_landing));
+                                plane.relative_ground_altitude(RangeFinderUse::TAKEOFF_LANDING));
                 poscontrol.set_state(QPOS_POSITION1);
                 transition->set_last_fw_pitch();
             } else {
@@ -2429,7 +2429,7 @@ void QuadPlane::vtol_position_controller(void)
                                 groundspeed,
                                 distance,
                                 stop_distance,
-                                plane.relative_ground_altitude(plane.g.rangefinder_landing));
+                                plane.relative_ground_altitude(RangeFinderUse::TAKEOFF_LANDING));
                 poscontrol.set_state(QPOS_AIRBRAKE);
             }
         }
@@ -2456,7 +2456,7 @@ void QuadPlane::vtol_position_controller(void)
             gcs().send_text(MAV_SEVERITY_INFO,"VTOL position1 v=%.1f d=%.1f h=%.1f dc=%.1f",
                             (double)groundspeed,
                             (double)plane.auto_state.wp_distance,
-                            plane.relative_ground_altitude(plane.g.rangefinder_landing),
+                            plane.relative_ground_altitude(RangeFinderUse::TAKEOFF_LANDING),
                             desired_closing_speed);
             poscontrol.set_state(QPOS_POSITION1);
             transition->set_last_fw_pitch();
@@ -2675,7 +2675,7 @@ void QuadPlane::vtol_position_controller(void)
             poscontrol.pilot_correction_done = false;
             gcs().send_text(MAV_SEVERITY_INFO,"VTOL position2 started v=%.1f d=%.1f h=%.1f",
                             (double)ahrs.groundspeed(), (double)plane.auto_state.wp_distance,
-                            plane.relative_ground_altitude(plane.g.rangefinder_landing));
+                            plane.relative_ground_altitude(RangeFinderUse::TAKEOFF_LANDING));
         }
         break;
     }
@@ -2832,7 +2832,7 @@ void QuadPlane::vtol_position_controller(void)
     case QPOS_LAND_DESCEND:
     case QPOS_LAND_ABORT:
     case QPOS_LAND_FINAL: {
-        float height_above_ground = plane.relative_ground_altitude(plane.g.rangefinder_landing);
+        float height_above_ground = plane.relative_ground_altitude(RangeFinderUse::TAKEOFF_LANDING);
         if (poscontrol.get_state() == QPOS_LAND_FINAL) {
             if (!option_is_set(QuadPlane::OPTION::DISABLE_GROUND_EFFECT_COMP)) {
                 ahrs.set_touchdown_expected(true);
@@ -2981,7 +2981,7 @@ void QuadPlane::assign_tilt_to_fwd_thr(void)
     if (!in_vtol_land_approach()) {
         // To prevent forward motor prop strike, reduce throttle to zero when close to ground.
         float alt_cutoff = MAX(0,vel_forward_alt_cutoff);
-        float height_above_ground = plane.relative_ground_altitude(plane.g.rangefinder_landing);
+        float height_above_ground = plane.relative_ground_altitude(RangeFinderUse::TAKEOFF_LANDING);
         fwd_thr_scaler = linear_interpolate(0.0f, 1.0f, height_above_ground, alt_cutoff, alt_cutoff+2);
     } else {
         // When we are doing horizontal positioning in a VTOL land we always allow the fwd motor
@@ -3508,7 +3508,7 @@ bool QuadPlane::check_land_complete(void)
  */
 bool QuadPlane::check_land_final(void)
 {
-    float height_above_ground = plane.relative_ground_altitude(plane.g.rangefinder_landing);
+    float height_above_ground = plane.relative_ground_altitude(RangeFinderUse::TAKEOFF_LANDING);
     // we require 2 readings at 10Hz to be within 5m of each other to
     // trigger the switch to land final. This prevents a short term
     // glitch at high altitude from triggering land final
@@ -3562,7 +3562,7 @@ bool QuadPlane::verify_vtol_land(void)
 #if AP_LANDINGGEAR_ENABLED
             plane.g2.landing_gear.deploy_for_landing();
 #endif
-            last_land_final_agl = plane.relative_ground_altitude(plane.g.rangefinder_landing);
+            last_land_final_agl = plane.relative_ground_altitude(RangeFinderUse::TAKEOFF_LANDING);
             gcs().send_text(MAV_SEVERITY_INFO,"Land descend started");
             if (plane.control_mode == &plane.mode_auto) {
                 // set height to mission height, so we can use the mission
@@ -3789,7 +3789,8 @@ float QuadPlane::forward_throttle_pct()
         vel_forward.last_pct = vel_forward.integrator;
     } else if ((in_vtol_land_final() && motors->limit.throttle_lower) ||
 #if AP_RANGEFINDER_ENABLED
-              (plane.g.rangefinder_landing && (plane.rangefinder.status_orient(plane.rangefinder_orientation()) == RangeFinder::Status::OutOfRangeLow))) {
+               (plane.rangefinder_use(RangeFinderUse::TAKEOFF_LANDING) &&
+                (plane.rangefinder.status_orient(plane.rangefinder_orientation()) == RangeFinder::Status::OutOfRangeLow))) {
 #else
               false) {
 #endif
@@ -3800,7 +3801,7 @@ float QuadPlane::forward_throttle_pct()
         // If we are below alt_cutoff then scale down the effect until
         // it turns off at alt_cutoff and decay the integrator
         float alt_cutoff = MAX(0,vel_forward_alt_cutoff);
-        float height_above_ground = plane.relative_ground_altitude(plane.g.rangefinder_landing);
+        float height_above_ground = plane.relative_ground_altitude(RangeFinderUse::TAKEOFF_LANDING);
 
         vel_forward.last_pct = linear_interpolate(0, vel_forward.integrator,
                                                   height_above_ground, alt_cutoff, alt_cutoff+2);
@@ -3841,7 +3842,7 @@ float QuadPlane::get_weathervane_yaw_rate_cds(void)
     float wv_output;
     if (weathervane->get_yaw_out(wv_output,
                                      plane.channel_rudder->get_control_in(),
-                                     plane.relative_ground_altitude(plane.g.rangefinder_landing),
+                                     plane.relative_ground_altitude(RangeFinderUse::TAKEOFF_LANDING),
                                      pos_control->get_roll_cd(),
                                      pos_control->get_pitch_cd(),
                                      is_takeoff,

--- a/ArduPlane/takeoff.cpp
+++ b/ArduPlane/takeoff.cpp
@@ -374,7 +374,7 @@ return_zero:
  */
 void Plane::landing_gear_update(void)
 {
-    g2.landing_gear.update(relative_ground_altitude(g.rangefinder_landing));
+    g2.landing_gear.update(relative_ground_altitude(RangeFinderUse::TAKEOFF_LANDING));
 }
 #endif
 


### PR DESCRIPTION
this gives greater control of when the rangefinder will be used. A particularly important one is the ability to disable it for VTOL assist as false positives can be quite common and drains the battery