### PR TITLE
UltraMotion fixups

### DIFF
--- a/libraries/AP_Scripting/drivers/UltraMotion.lua
+++ b/libraries/AP_Scripting/drivers/UltraMotion.lua
@@ -132,10 +132,9 @@ end
    send outputs to all servos
 --]]
 local function send_outputs()
-   local noutputs = #actuators
-   for i = 1, noutputs do
-      local pwm = SRV_Channels:get_output_pwm_chan(actuators[i].unitID-1)
-      local msg = actuators[i].msg
+   for _, actuator in pairs(actuators) do
+      local pwm = SRV_Channels:get_output_pwm_chan(actuator.unitID-1)
+      local msg = actuator.msg
 
       put_uint16(msg, 0, pwm)
 
@@ -197,6 +196,11 @@ function update()
    return update, 1000/UM_RATE_HZ:get()
 end
 
-gcs:send_text(MAV_SEVERITY.INFO, string.format("Loaded UltraMotion with %u actuators", #actuators))
+-- Build an array of IDs to print out
+local ids = {}
+for _, actuator in pairs(actuators) do
+   table.insert(ids, actuator.unitID)
+end
+gcs:send_text(MAV_SEVERITY.INFO, string.format("Loaded UltraMotion with %u actuators: %s", #ids, table.concat(ids, ",")))
 
 return update, 100

--- a/libraries/AP_Scripting/drivers/UltraMotion.md
+++ b/libraries/AP_Scripting/drivers/UltraMotion.md
@@ -18,8 +18,9 @@ the 2nd scripting CAN driver set this to 2 and set CAN_Dx_PROTOCOL=12.
 
 ## UM_RATE_HZ
 
-This sets the update rate of the script in Hz (how often it checks for
-new data from the ECU). A value of 200 is reasonable.
+This sets the update rate of the script in Hz (how often it sends
+commands and checks for new data from the actuator). A value of 200 is
+reasonable.
 
 ## UM_OPTIONS
 
@@ -43,8 +44,26 @@ to ensure the script gets sufficient priority.
 then the flight controller should rebooted and parameters should be
 refreshed.
 
-# Telemetry Support
+# UltraMotion Settings
+The following settings need to be changed using the CLI or CONFIG.TXT
+  - unitID should be set to the servo number (1-indexed)
+  - pMin to 1000
+  - pMax to 2000
 
-To use telemetry you need to setup the servos with a specific txData
-format. The code currently assumes txData is pABCDEFS
+If using telemetry (remember to set UM_OPTIONS bit 2), the following 
+should also be set:
+  - txID should be set to match unitID
+  - txData should be set to ABCGHEFY
+  - txIvl should be set according to your desired telemetry rate
+    (e.g., 100 milliseconds for 10Hz)
 
+Commands, assuming you are setting up servo 7, and a telemetry rate of
+10Hz
+```
+id 7
+pn 1000
+px 2000
+ni 7
+dt ABCGHEFY
+it 100
+```


### PR DESCRIPTION
- UM_SERVO_MASK was broken; it only worked if you were using only the first N servos, starting from servo 1
- "pABCDEFS" was not the right txData setting
- I expanded upon the necessary UltraMotion setting prerequisites.
- Minor copy-paste leftover from an ECU markdown