### PR TITLE
AP_BattMonitor: remove param conversion to dynamic tables required for update from 4.1 to 4.2

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -731,66 +731,7 @@ AP_BattMonitor::init()
             // there will be a gap, but as we always check for drivers[instances] being nullptr
             // this is safe
             _num_instances = instance + 1;
-
-            // Convert the old analog & Bus parameters to the new dynamic parameter groups
-            convert_dynamic_param_groups(instance);
         }
-    }
-}
-
-void AP_BattMonitor::convert_dynamic_param_groups(uint8_t instance)
-{
-    AP_Param::ConversionInfo info;
-    if (!AP_Param::find_top_level_key_by_pointer(this, info.old_key)) {
-        return;
-    }
-
-    char param_prefix[6] {};
-    char param_name[17] {};
-    info.new_name = param_name;
-
-    const uint8_t param_instance = instance + 1;
-    // first battmonitor does not have '1' in the param name
-    if(param_instance == 1) {
-        hal.util->snprintf(param_prefix, sizeof(param_prefix), "BATT");
-    } else {
-        hal.util->snprintf(param_prefix, sizeof(param_prefix), "BATT%X", param_instance);
-    }
-    param_prefix[sizeof(param_prefix)-1] = '\0';
-
-    hal.util->snprintf(param_name, sizeof(param_name), "%s_%s", param_prefix, "MONITOR");
-    param_name[sizeof(param_name)-1] = '\0';
-
-    // Find the index of the BATTn_MONITOR which is not moving to index the moving parameters off from
-    AP_Param::ParamToken token = AP_Param::ParamToken {};
-    ap_var_type type;
-    AP_Param* param = AP_Param::find_by_name(param_name, &type, &token);
-    const uint8_t battmonitor_index = 1;
-    if( param == nullptr) {
-        // BATTn_MONITOR not found
-        return;
-    }
-
-    const struct convert_table {
-        uint32_t old_group_element;
-        ap_var_type type;
-        const char* new_name;
-    }  conversion_table[] = {
-        // PARAMETER_CONVERSION - Added: Aug-2021
-            { 2,  AP_PARAM_INT8,  "VOLT_PIN"  },
-            { 3,  AP_PARAM_INT8,  "CURR_PIN"  },
-            { 4,  AP_PARAM_FLOAT, "VOLT_MULT" },
-            { 5,  AP_PARAM_FLOAT, "AMP_PERVLT"},
-            { 6,  AP_PARAM_FLOAT, "AMP_OFFSET"},
-            { 20, AP_PARAM_INT8,  "I2C_BUS"   },
-        };
-
-    for (const auto & elem : conversion_table) {
-        info.old_group_element = token.group_element + ((elem.old_group_element - battmonitor_index) * 64);
-        info.type = elem.type;
-
-        hal.util->snprintf(param_name, sizeof(param_name), "%s_%s", param_prefix, elem.new_name);
-        AP_Param::convert_old_parameter(&info, 1.0f, 0);
     }
 }
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -276,8 +276,6 @@ private:
     uint32_t    _log_battery_bit;
     uint8_t     _num_instances;                                     /// number of monitors
 
-    void convert_dynamic_param_groups(uint8_t instance);
-
     /// returns the failsafe state of the battery
     Failsafe check_failsafe(const uint8_t instance);
     void check_failsafes(void); // checks all batteries failsafes


### PR DESCRIPTION
This removes a user of `AP_Param::find_by_name`.