### PR TITLE
GCS_MAVLink: Check whether the number of bytes read is zero before proceeding

### DIFF
--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -519,14 +519,14 @@ void GCS_MAVLINK::ftp_worker(void) {
                                 break;
                             }
 
-                            if (read_bytes != sizeof(reply.data)) {
-                                // don't send any old data
-                                memset(reply.data + read_bytes, 0, sizeof(reply.data) - read_bytes);
-                            }
-
                             if (read_bytes == 0) {
                                 ftp_error(reply, FTP_ERROR::EndOfFile);
                                 break;
+                            }
+                            
+                            if (read_bytes != sizeof(reply.data)) {
+                                // don't send any old data
+                                memset(reply.data + read_bytes, 0, sizeof(reply.data) - read_bytes);
                             }
 
                             reply.opcode = FTP_OP::Ack;


### PR DESCRIPTION
Check whether the file is empty first.
By doing this beforehand, the memory clear process will not be executed.