### PR TITLE
Copter: `WP_NAVALT_MIN` only apply to takeoff

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -701,8 +701,8 @@ const AP_Param::Info Copter::var_info[] = {
 const AP_Param::GroupInfo ParametersG2::var_info[] = {
 
     // @Param: WP_NAVALT_MIN
-    // @DisplayName: Minimum navigation altitude
-    // @Description: This is the altitude in meters above which for navigation can begin. This applies in auto takeoff and auto landing.
+    // @DisplayName: Waypoint navigation altitude minimum
+    // @Description: Altitude in meters above which navigation will begin during auto takeoff
     // @Range: 0 5
     // @User: Standard
     AP_GROUPINFO("WP_NAVALT_MIN", 1, ParametersG2, wp_navalt_min, 0),

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -751,27 +751,6 @@ void Mode::land_run_horizontal_control()
     pos_control->update_NE_controller();
     Vector3f thrust_vector = pos_control->get_thrust_vector();
 
-    if (g2.wp_navalt_min > 0) {
-        // user has requested an altitude below which navigation
-        // attitude is limited. This is used to prevent commanded roll
-        // over on landing, which particularly affects helicopters if
-        // there is any position estimate drift after touchdown. We
-        // limit attitude to 7 degrees below this limit and linearly
-        // interpolate for 1m above that
-        const float attitude_limit_rad = linear_interpolate(radians(7), attitude_control->lean_angle_max_rad(), get_alt_above_ground_cm(),
-                                                     g2.wp_navalt_min*100U, (g2.wp_navalt_min+1)*100U);
-        const float thrust_vector_max = sinf(attitude_limit_rad) * GRAVITY_MSS * 100.0f;
-        const float thrust_vector_mag = thrust_vector.xy().length();
-        if (thrust_vector_mag > thrust_vector_max) {
-            float ratio = thrust_vector_max / thrust_vector_mag;
-            thrust_vector.x *= ratio;
-            thrust_vector.y *= ratio;
-
-            // tell position controller we are applying an external limit
-            pos_control->set_externally_limited_NE();
-        }
-    }
-
     // call attitude controller
     attitude_control->input_thrust_vector_heading(thrust_vector, auto_yaw.get_heading());
 


### PR DESCRIPTION
This stops applying  `WP_NAVALT_MIN` during landings. Incorrect ground altitude estimates can mean we stop navigating too high and end up drifting a long way. This is not a problem for takeoff because the altitude is measured relative to where the takeoff is started.

A alternate might be to add a flight option bit to enable this behavior (but I think it should be disabled by defualt).