### PR TITLE
AP_OpticalFlow: MAVLink backend accepts rad/s and supports roll/pitch stabilised sensor

### DIFF
--- a/libraries/AP_OpticalFlow/AP_OpticalFlow.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow.cpp
@@ -98,6 +98,13 @@ const AP_Param::GroupInfo AP_OpticalFlow::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO_FRAME("_HGT_OVR", 6,  AP_OpticalFlow, _height_override,   0.0f, AP_PARAM_FRAME_ROVER),
 
+    // @Param: _OPTIONS
+    // @DisplayName: Optical flow options
+    // @Description: Optical flow options. Bit 0 should be set if the sensor is stabilised (e.g. mounted on a gimbal)
+    // @Bitmask: 0:Roll/Pitch stabilised
+    // @User: Standard
+    AP_GROUPINFO("_OPTIONS", 7,  AP_OpticalFlow, _options,   0),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow.h
@@ -145,6 +145,7 @@ private:
     AP_Vector3f _pos_offset;        // position offset of the flow sensor in the body frame
     AP_Int8  _address;              // address on the bus (allows selecting between 8 possible I2C addresses for px4flow)
     AP_Float  _height_override;              // height of the sensor above the ground. Only used in rover
+    AP_Int16 _options;              // options parameter
 
     // method called by backend to update frontend state:
     void update_state(const OpticalFlow_state &state);

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Backend.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Backend.h
@@ -65,7 +65,17 @@ protected:
 
     // get ADDR parameter value
     uint8_t get_address(void) const { return frontend._address; }
-    
+
+    // options parameter values
+    enum class Option : uint16_t {
+        Stabilised = (1 << 0U)      // sensor is stabilised (e.g. mounted on a gimbal)
+    };
+
+    // returns true if an option is enabled
+    bool option_is_enabled(Option option) const {
+        return ((uint8_t)frontend._options.get() & (uint16_t)option) != 0;
+    }
+
     // semaphore for access to shared frontend data
     HAL_Semaphore _sem;
 };

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_MAV.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_MAV.cpp
@@ -61,9 +61,11 @@ void AP_OpticalFlow_MAV::update(void)
         const float flow_scale_factor_x = 1.0f + 0.001f * _flowScaler().x;
         const float flow_scale_factor_y = 1.0f + 0.001f * _flowScaler().y;
 
-        // copy flow rates to state structure
-        state.flowRate = { ((float)flow_sum.x / count) * flow_scale_factor_x * dt,
-                           ((float)flow_sum.y / count) * flow_scale_factor_y * dt };
+        // scale and copy flow rates to state structure
+        // if using flow_rates these are in rad/s (as opposed to pixels) and do not need to be multiplied by dt
+        const float dt_used = flow_sum_is_rads ? 1.0f : dt;
+        state.flowRate = { ((float)flow_sum.x / count) * flow_scale_factor_x * dt_used,
+                           ((float)flow_sum.y / count) * flow_scale_factor_y * dt_used };
 
         // copy average body rate to state structure
         state.bodyRate = { gyro_sum.x / gyro_sum_count, gyro_sum.y / gyro_sum_count };
@@ -98,9 +100,24 @@ void AP_OpticalFlow_MAV::handle_msg(const mavlink_message_t &msg)
     // ToDo: add jitter correction
     latest_frame_us = AP_HAL::micros64();
 
+    // use flow_rate_x/y fields if non-zero values are ever provided
+    if (!flow_sum_is_rads && (!is_zero(packet.flow_rate_x) || !is_zero(packet.flow_rate_y))) {
+        flow_sum_is_rads = true;
+        flow_sum.zero();
+        quality_sum = 0;
+        count = 0;
+    }
+
     // add sensor values to sum
-    flow_sum.x += packet.flow_x;
-    flow_sum.y += packet.flow_y;
+    if (flow_sum_is_rads) {
+        // higher precision flow_rate_x/y fields are used
+        flow_sum.x += packet.flow_rate_x;
+        flow_sum.y += packet.flow_rate_y;
+    } else {
+        // lower precision flow_x/y fields are used
+        flow_sum.x += packet.flow_x;
+        flow_sum.y += packet.flow_y;
+    }
     quality_sum += packet.quality;
     count++;
 

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_MAV.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_MAV.cpp
@@ -67,8 +67,14 @@ void AP_OpticalFlow_MAV::update(void)
         state.flowRate = { ((float)flow_sum.x / count) * flow_scale_factor_x * dt_used,
                            ((float)flow_sum.y / count) * flow_scale_factor_y * dt_used };
 
-        // copy average body rate to state structure
-        state.bodyRate = { gyro_sum.x / gyro_sum_count, gyro_sum.y / gyro_sum_count };
+        // copy body-rates from gyro or set to zero
+        if (option_is_enabled(Option::Stabilised)) {
+            // if the sensor is stabilised then body rates are always zero
+            state.bodyRate.zero();
+        } else {
+            // copy average body rate to state structure
+            state.bodyRate = { gyro_sum.x / gyro_sum_count, gyro_sum.y / gyro_sum_count };   
+        }
 
         // we only apply yaw to flowRate as body rate comes from AHRS
         _applyYaw(state.flowRate);

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_MAV.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_MAV.h
@@ -29,7 +29,8 @@ private:
 
     uint64_t prev_frame_us;             // system time of last message when update was last called
     uint64_t latest_frame_us;           // system time of most recent messages processed
-    Vector2l flow_sum;                  // sum of sensor's flow_x and flow_y values since last call to update
+    Vector2f flow_sum;                  // sum of sensor's flow_x and flow_y values since last call to update
+    bool flow_sum_is_rads;              // true if flow_sum holds values in rad/s, if false flow_sum holds dpi
     uint16_t quality_sum;               // sum of sensor's quality values since last call to update
     uint16_t count;                     // number of sensor readings since last call to update
     uint8_t sensor_id;                  // sensor_id received in latest mavlink message


### PR DESCRIPTION
This is a simplified version of https://github.com/ArduPilot/ardupilot/pull/29355 and adds the following features:

1. MAVLink backend consumes the [OPTICAL_FLOW message's](https://mavlink.io/en/messages/common.html#OPTICAL_FLOW) flow_rates_x and flow_rates_y fields if they are ever non-zero.  I considered adding an options bit to allow the user to specify this to reduce the chance of a false positive but I think this will work
2. FLOW_OPTIONS parameter added with a single bit defined as "Stabilised" to allow users to specify their flow sensor is mounted on a gimbal.  For now this is only implemented for the MAVLink backend but it could potentially be extended to other backends.  BTW, sensors with built-in IMUs (like the Hereflow) do not need this bit set even if they are mounted on a gimbal.

These changes have been successfully tested on a real vehicle.  I could add an autotest if people like.
Test flight video: https://www.youtube.com/watch?v=dKGyn1GjZnI

FYI @snktshrma 