### PR TITLE
Copter: Brake mode is a autopilot mode as there is no pilot input

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -128,7 +128,7 @@ public:
     virtual bool requires_GPS() const = 0;
     virtual bool has_manual_throttle() const = 0;
     virtual bool allows_arming(AP_Arming::Method method) const = 0;
-    virtual bool is_autopilot() const { return false; }
+    virtual bool is_autopilot() const = 0;
     virtual bool has_user_takeoff(bool must_navigate) const { return false; }
     virtual bool in_guided_mode() const { return false; }
     virtual bool logs_attitude() const { return false; }
@@ -854,7 +854,7 @@ public:
     bool requires_GPS() const override { return true; }
     bool has_manual_throttle() const override { return false; }
     bool allows_arming(AP_Arming::Method method) const override { return false; };
-    bool is_autopilot() const override { return false; }
+    bool is_autopilot() const override { return true; }
 
     void timeout_to_loiter_ms(uint32_t timeout_ms);
 


### PR DESCRIPTION
This does depend a little on how you define `is_autopilot` of course. The thinking here is that there is no pilot input possible in brake mode, so it must be a autopilot mode.

This is only used in two places. One for notify:
https://github.com/ArduPilot/ardupilot/blob/46b1b35d59c453830611cd8105f19584e8821db0/ArduCopter/mode.cpp#L461-L466

The other for GCS failsafe:
https://github.com/ArduPilot/ardupilot/blob/46b1b35d59c453830611cd8105f19584e8821db0/ArduCopter/events.cpp#L223-L224

This is a change in behavior. Currently a GCS failsafe in Brake mode will result in no action if the failsafe bit is set (which it is by defualt). After this change it will take the specified action. The bit is described as:
"Continue if in pilot controlled modes on GCS failsafe"

I don't think anyone would expect Brake mode to be included as a "pilot controlled mode". Maybe for clarity we should invert `is_autopilot` to be `is_pilot_controlled`.

This also changes the method in the base mode class to be a pure virtual, all the modes are overriding it anyway so there is no error. 


