### PR TITLE
AP_GPS: AP_GPS_DroneCAN: limit rate of base-message warnings

### DIFF
--- a/libraries/AP_GPS/AP_GPS_DroneCAN.cpp
+++ b/libraries/AP_GPS/AP_GPS_DroneCAN.cpp
@@ -549,7 +549,11 @@ void AP_GPS_DroneCAN::handle_moving_baseline_msg(const ardupilot_gnss_MovingBase
 {
     WITH_SEMAPHORE(sem);
     if (role != AP_GPS::GPS_ROLE_MB_BASE) {
-        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Incorrect Role set for DroneCAN GPS, %d should be Base", node_id);
+        const uint32_t now_ms = AP_HAL::millis();
+        if (now_ms - last_base_warning_ms > 5000) {
+            GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Incorrect Role set for DroneCAN GPS, %d should be Base", node_id);
+            last_base_warning_ms = now_ms;
+        }
         return;
     }
 

--- a/libraries/AP_GPS/AP_GPS_DroneCAN.h
+++ b/libraries/AP_GPS/AP_GPS_DroneCAN.h
@@ -132,6 +132,7 @@ private:
 #if GPS_MOVING_BASELINE
     // RTCM3 parser for when in moving baseline base mode
     RTCM3_Parser *rtcm3_parser;
+    uint32_t last_base_warning_ms;
 #endif
     // the role set from GPS_TYPE
     AP_GPS::GPS_Role role;


### PR DESCRIPTION
This statustext coming out at the same rate as you get a mb message can easily kill your telemetry link...
