### PR TITLE
Use gimbal_device_id in DO_SET_ROI_LOCATION and DO_SET_ROI_NONE

### DIFF
--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -444,12 +444,12 @@ MAV_RESULT GCS_MAVLINK_Copter::_handle_command_preflight_calibration(const mavli
 }
 
 
-MAV_RESULT GCS_MAVLINK_Copter::handle_command_do_set_roi(const Location &roi_loc)
+MAV_RESULT GCS_MAVLINK_Copter::handle_command_do_set_roi(uint8_t instance, const Location &roi_loc)
 {
     if (!roi_loc.check_latlng()) {
         return MAV_RESULT_FAILED;
     }
-    copter.flightmode->auto_yaw.set_roi(roi_loc);
+    copter.flightmode->auto_yaw.set_roi(instance, roi_loc);
     return MAV_RESULT_ACCEPTED;
 }
 

--- a/ArduCopter/GCS_MAVLink_Copter.h
+++ b/ArduCopter/GCS_MAVLink_Copter.h
@@ -28,7 +28,7 @@ protected:
     void send_position_target_global_int() override;
     void send_position_target_local_ned() override;
 
-    MAV_RESULT handle_command_do_set_roi(const Location &roi_loc) override;
+    MAV_RESULT handle_command_do_set_roi(uint8_t instance, const Location &roi_loc) override;
     MAV_RESULT handle_preflight_reboot(const mavlink_command_int_t &packet, const mavlink_message_t &msg) override;
 #if HAL_MOUNT_ENABLED
     MAV_RESULT handle_command_mount(const mavlink_command_int_t &packet, const mavlink_message_t &msg) override;

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -333,6 +333,7 @@ public:
 
         // set_roi(...): set a "look at" location:
         void set_roi(const Location &roi_location);
+        void set_roi(uint8_t instance, const Location &roi_location);
 
         void set_fixed_yaw_rad(float angle_rad,
                                float turn_rate_rads,

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1981,7 +1981,7 @@ void ModeAuto::do_set_home(const AP_Mission::Mission_Command& cmd)
 // TO-DO: add support for other features of MAV_CMD_DO_SET_ROI including pointing at a given waypoint
 void ModeAuto::do_roi(const AP_Mission::Mission_Command& cmd)
 {
-    auto_yaw.set_roi(cmd.content.location);
+    auto_yaw.set_roi(cmd.p1, cmd.content.location);
 }
 
 #if HAL_MOUNT_ENABLED

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -161,12 +161,12 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
     case MAV_CMD_DO_SET_ROI:
         if (cmd.content.location.alt == 0 && cmd.content.location.lat == 0 && cmd.content.location.lng == 0) {
             // switch off the camera tracking if enabled
-            if (camera_mount.get_mode() == MAV_MOUNT_MODE_GPS_POINT) {
-                camera_mount.set_mode_to_default();
+            if (camera_mount.get_mode(cmd.p1) == MAV_MOUNT_MODE_GPS_POINT) {
+                camera_mount.set_mode_to_default(cmd.p1);
             }
         } else {
             // set mount's target location
-            camera_mount.set_roi_target(cmd.content.location);
+            camera_mount.set_roi_target(cmd.p1,cmd.content.location);
         }
         break;
 

--- a/ArduSub/GCS_MAVLink_Sub.cpp
+++ b/ArduSub/GCS_MAVLink_Sub.cpp
@@ -296,12 +296,12 @@ MAV_RESULT GCS_MAVLINK_Sub::_handle_command_preflight_calibration(const mavlink_
     return GCS_MAVLINK::_handle_command_preflight_calibration(packet, msg);
 }
 
-MAV_RESULT GCS_MAVLINK_Sub::handle_command_do_set_roi(const Location &roi_loc)
+MAV_RESULT GCS_MAVLINK_Sub::handle_command_do_set_roi(uint8_t instance, const Location &roi_loc)
 {
     if (!roi_loc.check_latlng()) {
         return MAV_RESULT_FAILED;
     }
-    sub.mode_auto.set_auto_yaw_roi(roi_loc);
+    sub.mode_auto.set_auto_yaw_roi(instance, roi_loc);
     return MAV_RESULT_ACCEPTED;
 }
 

--- a/ArduSub/GCS_MAVLink_Sub.h
+++ b/ArduSub/GCS_MAVLink_Sub.h
@@ -12,7 +12,7 @@ protected:
 
     MAV_RESULT handle_flight_termination(const mavlink_command_int_t &packet) override;
 
-    MAV_RESULT handle_command_do_set_roi(const Location &roi_loc) override;
+    MAV_RESULT handle_command_do_set_roi(uint8_t instance, const Location &roi_loc) override;
     MAV_RESULT _handle_command_preflight_calibration_baro(const mavlink_message_t &msg) override;
     MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_int_t &packet, const mavlink_message_t &msg) override;
 

--- a/ArduSub/commands_logic.cpp
+++ b/ArduSub/commands_logic.cpp
@@ -689,7 +689,7 @@ void Sub::do_set_home(const AP_Mission::Mission_Command& cmd)
 //  TO-DO: add support for other features of MAV_CMD_DO_SET_ROI including pointing at a given waypoint
 void Sub::do_roi(const AP_Mission::Mission_Command& cmd)
 {
-    sub.mode_auto.set_auto_yaw_roi(cmd.content.location);
+    sub.mode_auto.set_auto_yaw_roi(cmd.p1, cmd.content.location);
 }
 
 // point the camera to a specified angle

--- a/ArduSub/mode.h
+++ b/ArduSub/mode.h
@@ -321,7 +321,7 @@ public:
     void auto_circle_movetoedge_start(const Location &circle_center, float radius_m, bool ccw_turn);
     void auto_circle_start();
     void auto_nav_guided_start();
-    void set_auto_yaw_roi(const Location &roi_location);
+    void set_auto_yaw_roi(uint8_t instance, const Location &roi_location);
     void set_auto_yaw_look_at_heading(float angle_deg, float turn_rate_dps, int8_t direction, uint8_t relative_angle);
     void set_yaw_rate(float turn_rate_dps);
     bool auto_terrain_recover_start();

--- a/ArduSub/mode_auto.cpp
+++ b/ArduSub/mode_auto.cpp
@@ -387,7 +387,7 @@ void ModeAuto::set_yaw_rate(float turn_rate_dps)
 }
 
 // set_auto_yaw_roi - sets the yaw to look at roi for auto mode
-void ModeAuto::set_auto_yaw_roi(const Location &roi_location)
+void ModeAuto::set_auto_yaw_roi(uint8_t instance, const Location &roi_location)
 {
     // if location is zero lat, lon and altitude turn off ROI
     if (roi_location.alt == 0 && roi_location.lat == 0 && roi_location.lng == 0) {
@@ -395,18 +395,18 @@ void ModeAuto::set_auto_yaw_roi(const Location &roi_location)
         set_auto_yaw_mode(get_default_auto_yaw_mode(false));
 #if HAL_MOUNT_ENABLED
         // switch off the camera tracking if enabled
-        sub.camera_mount.clear_roi_target();
+        sub.camera_mount.clear_roi_target(instance);
 #endif  // HAL_MOUNT_ENABLED
     } else {
 #if HAL_MOUNT_ENABLED
         // check if mount type requires us to rotate the sub
-        if (!sub.camera_mount.has_pan_control()) {
+        if (!sub.camera_mount.has_pan_control(instance)) {
             if (roi_location.get_vector_from_origin_NEU_cm(sub.roi_WP)) {
                 set_auto_yaw_mode(AUTO_YAW_ROI);
             }
         }
         // send the command to the camera mount
-        sub.camera_mount.set_roi_target(roi_location);
+        sub.camera_mount.set_roi_target(instance, roi_location);
 
         // TO-DO: expand handling of the do_nav_roi to support all modes of the MAVLink.  Currently we only handle mode 4 (see below)
         //      0: do nothing

--- a/Blimp/GCS_MAVLink_Blimp.cpp
+++ b/Blimp/GCS_MAVLink_Blimp.cpp
@@ -227,7 +227,7 @@ MAV_RESULT GCS_MAVLINK_Blimp::_handle_command_preflight_calibration(const mavlin
 }
 
 
-MAV_RESULT GCS_MAVLINK_Blimp::handle_command_do_set_roi(const Location &roi_loc)
+MAV_RESULT GCS_MAVLINK_Blimp::handle_command_do_set_roi(uint8_t instance, const Location &roi_loc)
 {
     if (!roi_loc.check_latlng()) {
         return MAV_RESULT_FAILED;

--- a/Blimp/GCS_MAVLink_Blimp.h
+++ b/Blimp/GCS_MAVLink_Blimp.h
@@ -22,7 +22,7 @@ protected:
 
     void send_position_target_global_int() override;
 
-    MAV_RESULT handle_command_do_set_roi(const Location &roi_loc) override;
+    MAV_RESULT handle_command_do_set_roi(uint8_t instance, const Location &roi_loc) override;
     MAV_RESULT handle_command_int_packet(const mavlink_command_int_t &packet, const mavlink_message_t &msg) override;
     MAV_RESULT handle_command_int_do_reposition(const mavlink_command_int_t &packet);
 

--- a/Rover/mode_auto.cpp
+++ b/Rover/mode_auto.cpp
@@ -575,12 +575,12 @@ bool ModeAuto::start_command(const AP_Mission::Mission_Command& cmd)
     case MAV_CMD_DO_SET_ROI:
         if (cmd.content.location.alt == 0 && cmd.content.location.lat == 0 && cmd.content.location.lng == 0) {
             // switch off the camera tracking if enabled
-            if (rover.camera_mount.get_mode() == MAV_MOUNT_MODE_GPS_POINT) {
-                rover.camera_mount.set_mode_to_default();
+            if (rover.camera_mount.get_mode(cmd.p1) == MAV_MOUNT_MODE_GPS_POINT) {
+                rover.camera_mount.set_mode_to_default(cmd.p1);
             }
         } else {
             // send the command to the camera mount
-            rover.camera_mount.set_roi_target(cmd.content.location);
+            rover.camera_mount.set_roi_target(cmd.p1, cmd.content.location);
         }
         break;
 #endif

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -147,6 +147,9 @@ public:
     Type get_mount_type() const { return get_mount_type(_primary); }
     Type get_mount_type(uint8_t instance) const;
 
+    // get_backend - gets backend based on instance number
+    AP_Mount_Backend* get_backend(uint8_t instance) const;
+
     // has_pan_control - returns true if the mount has yaw control (required for copters)
     bool has_pan_control() const { return has_pan_control(_primary); }
     bool has_pan_control(uint8_t instance) const;
@@ -183,11 +186,11 @@ public:
 
     // set_roi_target - sets target location that mount should attempt to point towards
     void set_roi_target(const Location &target_loc) { set_roi_target(_primary,target_loc); }
-    void set_roi_target(uint8_t instance, const Location &target_loc);
+    bool set_roi_target(uint8_t instance, const Location &target_loc);
 
     // clear_roi_target - clears target location that mount should attempt to point towards
     void clear_roi_target() { clear_roi_target(_primary); }
-    void clear_roi_target(uint8_t instance);
+    bool clear_roi_target(uint8_t instance);
 
     // point at system ID sysid
     void set_target_sysid(uint8_t sysid) { set_target_sysid(_primary, sysid); }

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -693,7 +693,7 @@ protected:
 
     MAV_RESULT handle_command_camera(const mavlink_command_int_t &packet);
     MAV_RESULT handle_command_do_set_roi(const mavlink_command_int_t &packet);
-    virtual MAV_RESULT handle_command_do_set_roi(const Location &roi_loc);
+    virtual MAV_RESULT handle_command_do_set_roi(uint8_t instance, const Location &roi_loc);
     MAV_RESULT handle_command_do_gripper(const mavlink_command_int_t &packet);
     MAV_RESULT handle_command_do_sprayer(const mavlink_command_int_t &packet);
     MAV_RESULT handle_command_do_set_mode(const mavlink_command_int_t &packet);


### PR DESCRIPTION
Copter, Rover, Plane, Sub, AP_MOUNT, GCS_MAVLink, Blimp: Consuming parameter 1 as "gimbal device id" for DO_SET_ROI_LOCATION and DO_SET_ROI_NONE #29566

Using instance functions when using DO_SET_ROI_LOCATION and DO_SET_ROI_NONE in different modules.

Unifying the way of getting the backend using the instance in AP_Mount.

Tested for plane and Quad missions. 

The change for Blimb is small for consistency. 
The change for the Rover is small too.

[plane.zip](https://github.com/user-attachments/files/21297781/plane.zip)
[quad.zip](https://github.com/user-attachments/files/21297782/quad.zip)
