### PR TITLE
global: correct shebang lines to refernce python3

### DIFF
--- a/AntennaTracker/wscript
+++ b/AntennaTracker/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     vehicle = bld.path.name

--- a/ArduCopter/wscript
+++ b/ArduCopter/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     vehicle = bld.path.name

--- a/ArduPlane/wscript
+++ b/ArduPlane/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     vehicle = bld.path.name

--- a/ArduSub/wscript
+++ b/ArduSub/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     vehicle = bld.path.name

--- a/Blimp/wscript
+++ b/Blimp/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     vehicle = bld.path.name

--- a/Rover/wscript
+++ b/Rover/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     vehicle = bld.path.name

--- a/Tools/FilterTestTool/BiquadFilter.py
+++ b/Tools/FilterTestTool/BiquadFilter.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 
 """ ArduPilot BiquadFilter
 

--- a/Tools/FilterTestTool/run_filter_test.py
+++ b/Tools/FilterTestTool/run_filter_test.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/Tools/PrintVersion.py
+++ b/Tools/PrintVersion.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Extract version information for the various vehicle types, print it

--- a/Tools/Replay/CheckLogs.py
+++ b/Tools/Replay/CheckLogs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/Tools/Replay/check_replay.py
+++ b/Tools/Replay/check_replay.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/Tools/Replay/check_replay_branch.py
+++ b/Tools/Replay/check_replay_branch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/Tools/Replay/examples/rewrite-RFND-values-to-floats.py
+++ b/Tools/Replay/examples/rewrite-RFND-values-to-floats.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
 '''In ArduPilot 4.7 the distance values were moved to float to
 facilitate supporting rangefinders with more than 327m of range.
 

--- a/Tools/ardupilotwaf/embed.py
+++ b/Tools/ardupilotwaf/embed.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/Tools/autotest/check_autotest_speedup.py
+++ b/Tools/autotest/check_autotest_speedup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 Run autotest repeatedly at different speedups to help find best default speedup

--- a/Tools/autotest/fakepos.py
+++ b/Tools/autotest/fakepos.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import errno
 import socket

--- a/Tools/autotest/logger_metadata/enum_parse.py
+++ b/Tools/autotest/logger_metadata/enum_parse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 AP_FLAKE8_CLEAN

--- a/Tools/autotest/logger_metadata/parse.py
+++ b/Tools/autotest/logger_metadata/parse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 AP_FLAKE8_CLEAN

--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''Generates parameter metadata files suitable for consumption by
   ground control stations and various web services

--- a/Tools/autotest/param_metadata/rstemit.py
+++ b/Tools/autotest/param_metadata/rstemit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/Tools/autotest/pysim/fg_display.py
+++ b/Tools/autotest/pysim/fg_display.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import errno
 import socket

--- a/Tools/autotest/validate_board_list.py
+++ b/Tools/autotest/validate_board_list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 Check Tools/bootloader/board_types.txt for problems

--- a/Tools/debug/crash_debugger.py
+++ b/Tools/debug/crash_debugger.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/Tools/gittools/pre-commit.py
+++ b/Tools/gittools/pre-commit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 A script suitable for use as a git pre-commit hook to ensure your

--- a/Tools/scripts/battery_fit.py
+++ b/Tools/scripts/battery_fit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/Tools/scripts/build_bootloaders.py
+++ b/Tools/scripts/build_bootloaders.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/Tools/scripts/build_examples.py
+++ b/Tools/scripts/build_examples.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # useful script to test the build of all example code
 # This helps when doing large merges

--- a/Tools/scripts/build_peripherals.py
+++ b/Tools/scripts/build_peripherals.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/Tools/scripts/build_tests/pretty_diff_size.py
+++ b/Tools/scripts/build_tests/pretty_diff_size.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 This script intend to provide a pretty size diff between two binaries.

--- a/Tools/scripts/check_firmware_version.py
+++ b/Tools/scripts/check_firmware_version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/Tools/scripts/configure_all.py
+++ b/Tools/scripts/configure_all.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/Tools/scripts/convert_plane_PID.py
+++ b/Tools/scripts/convert_plane_PID.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/Tools/scripts/crc32.py
+++ b/Tools/scripts/crc32.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/Tools/scripts/create_OEM_board.py
+++ b/Tools/scripts/create_OEM_board.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 script to automatically create a copy of a board for an OEM setup

--- a/Tools/scripts/decode_ICSR.py
+++ b/Tools/scripts/decode_ICSR.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 decode an stm32 ICSR register value
 

--- a/Tools/scripts/decode_devid.py
+++ b/Tools/scripts/decode_devid.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/Tools/scripts/decode_watchdog.py
+++ b/Tools/scripts/decode_watchdog.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
 '''
 decode an watchdog message
 

--- a/Tools/scripts/du32_change.py
+++ b/Tools/scripts/du32_change.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Parses a log file and shows how Copter's du32 changes over time

--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 script to determine what features have been built into an ArduPilot binary

--- a/Tools/scripts/frame_sizes.py
+++ b/Tools/scripts/frame_sizes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/Tools/scripts/gen_stable.py
+++ b/Tools/scripts/gen_stable.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/Tools/scripts/generate_manifest.py
+++ b/Tools/scripts/generate_manifest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 AP_FLAKE8_CLEAN

--- a/Tools/scripts/logic_decode_channels.py
+++ b/Tools/scripts/logic_decode_channels.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/Tools/scripts/mavlink_parse.py
+++ b/Tools/scripts/mavlink_parse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/Tools/scripts/param_check.py
+++ b/Tools/scripts/param_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Parameter File Validation Script

--- a/Tools/scripts/playback_log_fg.py
+++ b/Tools/scripts/playback_log_fg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 play back an onboard log as a FlightGear FG NET stream

--- a/Tools/scripts/powr_change.py
+++ b/Tools/scripts/powr_change.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Parses a log file and shows how the power flags changed over time

--- a/Tools/scripts/rcda_decode.py
+++ b/Tools/scripts/rcda_decode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/Tools/scripts/run_flake8.py
+++ b/Tools/scripts/run_flake8.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Runs flake8 over Python files which contain a marker indicating

--- a/Tools/scripts/runcoptertest.py
+++ b/Tools/scripts/runcoptertest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/Tools/scripts/runfliptest.py
+++ b/Tools/scripts/runfliptest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/Tools/scripts/sensor_status_change.py
+++ b/Tools/scripts/sensor_status_change.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Parses a log file and shows how the SENSOR_STATUS flags changed over time

--- a/Tools/scripts/solution_status_change.py
+++ b/Tools/scripts/solution_status_change.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Parses a log file and shows how the solution status changed over time

--- a/Tools/scripts/tempcal_IMU.py
+++ b/Tools/scripts/tempcal_IMU.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/Tools/scripts/uploader.py
+++ b/Tools/scripts/uploader.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
 ############################################################################
 #
 #   Copyright (c) 2012-2017 PX4 Development Team. All rights reserved.

--- a/libraries/AC_PID/examples/AC_PID_test/wscript
+++ b/libraries/AC_PID/examples/AC_PID_test/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/APM_Control/examples/AP_FW_Controller_test/wscript
+++ b/libraries/APM_Control/examples/AP_FW_Controller_test/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
 

--- a/libraries/AP_ADSB/tests/wscript
+++ b/libraries/AP_ADSB/tests/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_find_tests(

--- a/libraries/AP_AHRS/examples/AHRS_Test/wscript
+++ b/libraries/AP_AHRS/examples/AHRS_Test/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_Airspeed/examples/Airspeed/wscript
+++ b/libraries/AP_Airspeed/examples/Airspeed/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_Baro/examples/BARO_generic/wscript
+++ b/libraries/AP_Baro/examples/BARO_generic/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_Baro/examples/ICM20789/wscript
+++ b/libraries/AP_Baro/examples/ICM20789/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_Baro/tests/wscript
+++ b/libraries/AP_Baro/tests/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_find_tests(

--- a/libraries/AP_BattMonitor/tests/wscript
+++ b/libraries/AP_BattMonitor/tests/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_find_tests(

--- a/libraries/AP_Beacon/examples/AP_Marvelmind_test/wscript
+++ b/libraries/AP_Beacon/examples/AP_Marvelmind_test/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_CSVReader/tests/wscript
+++ b/libraries/AP_CSVReader/tests/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_find_tests(

--- a/libraries/AP_Common/examples/AP_Common/wscript
+++ b/libraries/AP_Common/examples/AP_Common/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_Common/tests/wscript
+++ b/libraries/AP_Common/tests/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_find_tests(

--- a/libraries/AP_Compass/examples/AP_Compass_test/wscript
+++ b/libraries/AP_Compass/examples/AP_Compass_test/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_Compass/examples/CompassCalibrator_index_test/wscript
+++ b/libraries/AP_Compass/examples/CompassCalibrator_index_test/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_DAL/examples/AP_DAL_Standalone/wscript
+++ b/libraries/AP_DAL/examples/AP_DAL_Standalone/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_stlib(

--- a/libraries/AP_Declination/examples/AP_Declination_test/wscript
+++ b/libraries/AP_Declination/examples/AP_Declination_test/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_Declination/tests/wscript
+++ b/libraries/AP_Declination/tests/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_find_tests(

--- a/libraries/AP_DroneCAN/examples/DroneCAN_sniffer/wscript
+++ b/libraries/AP_DroneCAN/examples/DroneCAN_sniffer/wscript
@@ -1,5 +1,5 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
+
 # flake8: noqa
 from waflib.TaskGen import after_method, before_method, feature
 

--- a/libraries/AP_Filesystem/examples/File_IO/wscript
+++ b/libraries/AP_Filesystem/examples/File_IO/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_FlashIface/examples/jedec_test/wscript
+++ b/libraries/AP_FlashIface/examples/jedec_test/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_FlashIface/examples/jedec_test_bl/wscript
+++ b/libraries/AP_FlashIface/examples/jedec_test_bl/wscript
@@ -1,5 +1,5 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
+
 # flake8: noqa
 def build(bld):
     if bld.env.BOOTLOADER:

--- a/libraries/AP_FlashStorage/examples/FlashTest/wscript
+++ b/libraries/AP_FlashStorage/examples/FlashTest/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_GPS/examples/GPS_AUTO_test/wscript
+++ b/libraries/AP_GPS/examples/GPS_AUTO_test/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_GPS/examples/GPS_UBLOX_passthrough/wscript
+++ b/libraries/AP_GPS/examples/GPS_UBLOX_passthrough/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_GPS/tests/wscript
+++ b/libraries/AP_GPS/tests/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_find_tests(

--- a/libraries/AP_Generator/scripts/test-loweheiser.py
+++ b/libraries/AP_Generator/scripts/test-loweheiser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Script designed to provide a simple console-based program to

--- a/libraries/AP_GyroFFT/examples/ReplayGyroFFT/wscript
+++ b/libraries/AP_GyroFFT/examples/ReplayGyroFFT/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_GyroFFT/tests/wscript
+++ b/libraries/AP_GyroFFT/tests/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_find_tests(

--- a/libraries/AP_HAL/examples/AnalogIn/wscript
+++ b/libraries/AP_HAL/examples/AnalogIn/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_HAL/examples/BinarySem/wscript
+++ b/libraries/AP_HAL/examples/BinarySem/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_HAL/examples/DSP_test/gyro_isb_reader.py
+++ b/libraries/AP_HAL/examples/DSP_test/gyro_isb_reader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/libraries/AP_HAL/examples/DSP_test/wscript
+++ b/libraries/AP_HAL/examples/DSP_test/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_HAL/examples/Printf/wscript
+++ b/libraries/AP_HAL/examples/Printf/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_HAL/examples/RCInput/wscript
+++ b/libraries/AP_HAL/examples/RCInput/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_HAL/examples/RCInputToRCOutput/wscript
+++ b/libraries/AP_HAL/examples/RCInputToRCOutput/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_HAL/examples/RCOutput/wscript
+++ b/libraries/AP_HAL/examples/RCOutput/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_HAL/examples/RCOutput2/wscript
+++ b/libraries/AP_HAL/examples/RCOutput2/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_HAL/examples/RNG_test/wscript
+++ b/libraries/AP_HAL/examples/RNG_test/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_HAL/examples/RingBuffer/wscript
+++ b/libraries/AP_HAL/examples/RingBuffer/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_HAL/examples/Storage/wscript
+++ b/libraries/AP_HAL/examples/Storage/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_HAL/examples/UART_chargen/wscript
+++ b/libraries/AP_HAL/examples/UART_chargen/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_HAL/examples/UART_test/wscript
+++ b/libraries/AP_HAL/examples/UART_test/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_HAL/tests/wscript
+++ b/libraries/AP_HAL/tests/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_find_tests(

--- a/libraries/AP_HAL/utility/tests/wscript
+++ b/libraries/AP_HAL/utility/tests/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_find_tests(

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/CKS32F407xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/CKS32F407xx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F100xB.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F100xB.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F103xB.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F103xB.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F105xC.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F105xC.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F303xC.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F303xC.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F405xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F405xx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F407xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F407xx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F412Rx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F412Rx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F413xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F413xx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F427xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F427xx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F469xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F469xx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F732xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F732xx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F745xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F745xx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F767xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F767xx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F777xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32F777xx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32G431xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32G431xx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32G441xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32G441xx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32G474xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32G474xx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32G491xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32G491xx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H723xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H723xx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H730xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H730xx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H743xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H743xx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H750xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H750xx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H755xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H755xx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H757xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H757xx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H7A3xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32H7A3xx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32L431xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32L431xx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32L476xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32L476xx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32L496xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32L496xx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32L4R5xx.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/STM32L4R5xx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/addfunc_parse.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/addfunc_parse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/af_parse.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/af_parse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/bdshot_encoder.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/bdshot_encoder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 setup board.h for chibios
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/convert_betaflight_unified.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/convert_betaflight_unified.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/dma_parse.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/dma_parse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/dma_resolver.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/dma_resolver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/libraries/AP_HAL_Linux/benchmarks/wscript
+++ b/libraries/AP_HAL_Linux/benchmarks/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_find_benchmarks(

--- a/libraries/AP_HAL_Linux/examples/BusTest/wscript
+++ b/libraries/AP_HAL_Linux/examples/BusTest/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_HAL_Linux/examples/GPIOTest/wscript
+++ b/libraries/AP_HAL_Linux/examples/GPIOTest/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_HAL_Linux/hwdef/scripts/linux_hwdef.py
+++ b/libraries/AP_HAL_Linux/hwdef/scripts/linux_hwdef.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 setup board.h for Linux
 

--- a/libraries/AP_HAL_Linux/tests/wscript
+++ b/libraries/AP_HAL_Linux/tests/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_find_tests(

--- a/libraries/AP_IOMCU/iofirmware/wscript
+++ b/libraries/AP_IOMCU/iofirmware/wscript
@@ -1,5 +1,5 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
+
 # flake8: noqa
 
 def build(bld):

--- a/libraries/AP_InertialSensor/examples/INS_generic/wscript
+++ b/libraries/AP_InertialSensor/examples/INS_generic/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_InertialSensor/examples/coning.py
+++ b/libraries/AP_InertialSensor/examples/coning.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/libraries/AP_JSButton/tests/wscript
+++ b/libraries/AP_JSButton/tests/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_find_tests(

--- a/libraries/AP_JSON/examples/XPlane/wscript
+++ b/libraries/AP_JSON/examples/XPlane/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_Logger/examples/AP_Logger_AllTypes/wscript
+++ b/libraries/AP_Logger/examples/AP_Logger_AllTypes/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_Logger/examples/AP_Logger_test/wscript
+++ b/libraries/AP_Logger/examples/AP_Logger_test/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_MSP/Tools/msposd.py
+++ b/libraries/AP_MSP/Tools/msposd.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
+
 # flake8: noqa
 '''
 A tool to view MSP telemetry, simulating a DJI FPV display

--- a/libraries/AP_MSP/Tools/pymsp.py
+++ b/libraries/AP_MSP/Tools/pymsp.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
+
 # flake8: noqa
 
 """

--- a/libraries/AP_Math/benchmarks/wscript
+++ b/libraries/AP_Math/benchmarks/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_find_benchmarks(

--- a/libraries/AP_Math/examples/eulers/wscript
+++ b/libraries/AP_Math/examples/eulers/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_Math/examples/location/wscript
+++ b/libraries/AP_Math/examples/location/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_Math/examples/matrix_alg/wscript
+++ b/libraries/AP_Math/examples/matrix_alg/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_Math/examples/polygon/wscript
+++ b/libraries/AP_Math/examples/polygon/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_Math/examples/rotations/wscript
+++ b/libraries/AP_Math/examples/rotations/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_Math/tests/wscript
+++ b/libraries/AP_Math/tests/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_find_tests(

--- a/libraries/AP_Math/tools/geodesic_grid/geodesic_grid.py
+++ b/libraries/AP_Math/tools/geodesic_grid/geodesic_grid.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (C) 2016  Intel Corporation. All rights reserved.
 #

--- a/libraries/AP_Mission/examples/AP_Mission_test/wscript
+++ b/libraries/AP_Mission/examples/AP_Mission_test/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_Module/examples/ModuleTest/wscript
+++ b/libraries/AP_Module/examples/ModuleTest/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_Motors/examples/AP_Motors_test/wscript
+++ b/libraries/AP_Motors/examples/AP_Motors_test/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_Motors/examples/expo_inverse_test/wscript
+++ b/libraries/AP_Motors/examples/expo_inverse_test/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_MultiHeap/tests/wscript
+++ b/libraries/AP_MultiHeap/tests/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_find_tests(

--- a/libraries/AP_NMEA_Output/examples/NMEA_Output/wscript
+++ b/libraries/AP_NMEA_Output/examples/NMEA_Output/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_NavEKF/tests/wscript
+++ b/libraries/AP_NavEKF/tests/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_find_tests(

--- a/libraries/AP_Notify/examples/AP_Notify_test/wscript
+++ b/libraries/AP_Notify/examples/AP_Notify_test/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_Notify/examples/ToshibaLED_test/wscript
+++ b/libraries/AP_Notify/examples/ToshibaLED_test/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_OLC/tests/wscript
+++ b/libraries/AP_OLC/tests/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_find_tests(

--- a/libraries/AP_ONVIF/examples/onvif_test/wscript
+++ b/libraries/AP_ONVIF/examples/onvif_test/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_ONVIF/wscript
+++ b/libraries/AP_ONVIF/wscript
@@ -1,5 +1,5 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
+
 # flake8: noqa
 '''
 build generated bindings from bindings.desc for AP_Scripting

--- a/libraries/AP_OSD/fonts/mcm2bin.py
+++ b/libraries/AP_OSD/fonts/mcm2bin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 import sys

--- a/libraries/AP_OSD/fonts/mcm_all.py
+++ b/libraries/AP_OSD/fonts/mcm_all.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/libraries/AP_OpticalFlow/examples/AP_OpticalFlow_test/wscript
+++ b/libraries/AP_OpticalFlow/examples/AP_OpticalFlow_test/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_Parachute/examples/AP_Parachute_test/wscript
+++ b/libraries/AP_Parachute/examples/AP_Parachute_test/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_RCProtocol/examples/RCProtocolDecoder/wscript
+++ b/libraries/AP_RCProtocol/examples/RCProtocolDecoder/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_RCProtocol/examples/RCProtocolTest/wscript
+++ b/libraries/AP_RCProtocol/examples/RCProtocolTest/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_RCProtocol/tests/wscript
+++ b/libraries/AP_RCProtocol/tests/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_find_tests(

--- a/libraries/AP_RPM/examples/RPM_generic/wscript
+++ b/libraries/AP_RPM/examples/RPM_generic/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_RTC/examples/RTC_test/wscript
+++ b/libraries/AP_RTC/examples/RTC_test/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_RangeFinder/examples/RFIND_test/wscript
+++ b/libraries/AP_RangeFinder/examples/RFIND_test/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_Scheduler/examples/Scheduler_test/wscript
+++ b/libraries/AP_Scheduler/examples/Scheduler_test/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_Scripting/applets/Aerobatics/FixedWing/dual_log.py
+++ b/libraries/AP_Scripting/applets/Aerobatics/FixedWing/dual_log.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 

--- a/libraries/AP_Scripting/wscript
+++ b/libraries/AP_Scripting/wscript
@@ -1,5 +1,5 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
+
 # flake8: noqa
 '''
 build generated bindings from bindings.desc for AP_Scripting

--- a/libraries/AP_SmartRTL/examples/SmartRTL_test/wscript
+++ b/libraries/AP_SmartRTL/examples/SmartRTL_test/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/AP_Terrain/tools/create_terrain.py
+++ b/libraries/AP_Terrain/tools/create_terrain.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # flake8: noqa
 '''

--- a/libraries/Filter/examples/Derivative/wscript
+++ b/libraries/Filter/examples/Derivative/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/Filter/examples/Filter/wscript
+++ b/libraries/Filter/examples/Filter/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/Filter/examples/LowPassFilter/wscript
+++ b/libraries/Filter/examples/LowPassFilter/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/Filter/examples/LowPassFilter2p/wscript
+++ b/libraries/Filter/examples/LowPassFilter2p/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/Filter/examples/SlewLimiter/wscript
+++ b/libraries/Filter/examples/SlewLimiter/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/Filter/examples/TransferFunctionCheck/wscript
+++ b/libraries/Filter/examples/TransferFunctionCheck/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/Filter/tests/wscript
+++ b/libraries/Filter/tests/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_find_tests(

--- a/libraries/GCS_MAVLink/examples/routing/wscript
+++ b/libraries/GCS_MAVLink/examples/routing/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/RC_Channel/examples/RC_Channel/wscript
+++ b/libraries/RC_Channel/examples/RC_Channel/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/RC_Channel/examples/RC_UART/wscript
+++ b/libraries/RC_Channel/examples/RC_UART/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(

--- a/libraries/SITL/examples/EvaluateBatteryModel/wscript
+++ b/libraries/SITL/examples/EvaluateBatteryModel/wscript
@@ -1,5 +1,5 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
+
 # flake8: noqa
 
 def build(bld):

--- a/libraries/SITL/examples/EvaluateMotorModel/wscript
+++ b/libraries/SITL/examples/EvaluateMotorModel/wscript
@@ -1,5 +1,5 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
+
 # flake8: noqa
 
 def build(bld):

--- a/libraries/SITL/tests/wscript
+++ b/libraries/SITL/tests/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
 

--- a/libraries/StorageManager/examples/StorageTest/wscript
+++ b/libraries/StorageManager/examples/StorageTest/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+#!/usr/bin/env python3
 
 def build(bld):
     bld.ap_example(


### PR DESCRIPTION
also remove the odd encoding line which is not required in Py3

single commit covering many, many directories
