### PR TITLE
Convert AC_WPNav library from centimeters to meters with backward-compatible cm interfaces

### DIFF
--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -1026,8 +1026,8 @@ uint16_t Mode::get_pilot_speed_dn()
 // Return stopping point as a location with above origin alt frame
 Location Mode::get_stopping_point() const
 {
-    Vector3p stopping_point_NEU;
-    copter.pos_control->get_stopping_point_NE_cm(stopping_point_NEU.xy());
-    copter.pos_control->get_stopping_point_U_cm(stopping_point_NEU.z);
-    return Location { stopping_point_NEU.tofloat(), Location::AltFrame::ABOVE_ORIGIN };
+    Vector3p stopping_point_neu_cm;
+    copter.pos_control->get_stopping_point_NE_cm(stopping_point_neu_cm.xy());
+    copter.pos_control->get_stopping_point_U_cm(stopping_point_neu_cm.z);
+    return Location { stopping_point_neu_cm.tofloat(), Location::AltFrame::ABOVE_ORIGIN };
 }

--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -39,7 +39,6 @@ const AP_Param::GroupInfo AC_Circle::var_info[] = {
 // Default constructor.
 // Note that the Vector/Matrix constructors already implicitly zero
 // their values.
-//
 AC_Circle::AC_Circle(const AP_AHRS_View& ahrs, AC_PosControl& pos_control) :
     _ahrs(ahrs),
     _pos_control(pos_control)
@@ -233,10 +232,10 @@ bool AC_Circle::update_cms(float climb_rate_cms)
 }
 
 // get_closest_point_on_circle_NEU_cm - returns closest point on the circle
-//  circle's center should already have been set
-//  closest point on the circle will be placed in result_NEU_cm, dist_cm will be updated with the 3D distance to the center
-//  result_NEU_cm's altitude (i.e. z) will be set to the circle_center's altitude
-//  if vehicle is at the center of the circle, the edge directly behind vehicle will be returned
+//      circle's center should already have been set
+//      closest point on the circle will be placed in result_NEU_cm, dist_cm will be updated with the 3D distance to the center
+//      result_NEU_cm's altitude (i.e. z) will be set to the circle_center's altitude
+//      if vehicle is at the center of the circle, the edge directly behind vehicle will be returned
 void AC_Circle::get_closest_point_on_circle_NEU_cm(Vector3f& result_NEU_cm, float& dist_cm) const
 {
     // get current position
@@ -296,8 +295,8 @@ void AC_Circle::calc_velocities(bool init_velocity)
 }
 
 // init_start_angle - sets the starting angle around the circle and initialises the angle_total
-//  if use_heading is true the vehicle's heading will be used to init the angle causing minimum yaw movement
-//  if use_heading is false the vehicle's position from the center will be used to initialise the angle
+//      if use_heading is true the vehicle's heading will be used to init the angle causing minimum yaw movement
+//      if use_heading is false the vehicle's position from the center will be used to initialise the angle
 void AC_Circle::init_start_angle(bool use_heading)
 {
     // initialise angle total

--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -74,10 +74,10 @@ public:
     bool is_active() const;
 
     // get_closest_point_on_circle_NEU_cm - returns closest point on the circle
-    //  circle's center should already have been set
-    //  closest point on the circle will be placed in result, dist_cm will be updated with the distance to the center
-    //  result's altitude (i.e. z) will be set to the circle_center's altitude
-    //  if vehicle is at the center of the circle, the edge directly behind vehicle will be returned
+    //      circle's center should already have been set
+    //      closest point on the circle will be placed in result, dist_cm will be updated with the distance to the center
+    //      result's altitude (i.e. z) will be set to the circle_center's altitude
+    //      if vehicle is at the center of the circle, the edge directly behind vehicle will be returned
     void get_closest_point_on_circle_NEU_cm(Vector3f& result_NEU_cm, float& dist_cm) const;
 
     /// get horizontal distance to loiter target in cm
@@ -110,8 +110,8 @@ private:
     void calc_velocities(bool init_velocity);
 
     // init_start_angle - sets the starting angle around the circle and initialises the angle_total
-    //  if use_heading is true the vehicle's heading will be used to init the angle causing minimum yaw movement
-    //  if use_heading is false the vehicle's position from the center will be used to initialise the angle
+    //      if use_heading is true the vehicle's heading will be used to init the angle causing minimum yaw movement
+    //      if use_heading is false the vehicle's position from the center will be used to initialise the angle
     void init_start_angle(bool use_heading);
 
     // get expected source of terrain data
@@ -142,26 +142,26 @@ private:
     };
 
     // parameters
-    AP_Float    _radius_parm_cm;   // radius of circle in cm loaded from params
-    AP_Float    _rate_parm_degs;     // rotation speed in deg/sec
-    AP_Int16    _options;       // stick control enable/disable
+    AP_Float    _radius_parm_cm;    // radius of circle in cm loaded from params
+    AP_Float    _rate_parm_degs;    // rotation speed in deg/sec
+    AP_Int16    _options;           // stick control enable/disable
 
     // internal variables
-    Vector3p    _center_neu_cm;        // center of circle in cm from home
-    float       _radius_cm;        // radius of circle in cm
-    float       _rate_degs;          // rotation speed of circle in deg/sec. +ve for cw turn
-    float       _yaw_cd;           // yaw heading (normally towards circle center)
-    float       _angle_rad;         // current angular position around circle in radians (0=directly north of the center of the circle)
-    float       _angle_total_rad;   // total angle traveled in radians
-    float       _angular_vel_rads;   // angular velocity in radians/sec
-    float       _angular_vel_max_rads;   // maximum velocity in radians/sec
-    float       _angular_accel_radss; // angular acceleration in radians/sec/sec
-    uint32_t    _last_update_ms;    // system time of last update
-    float       _last_radius_param; // last value of radius param, used to update radius on param change
+    Vector3p    _center_neu_cm;         // center of circle in cm from home
+    float       _radius_cm;             // radius of circle in cm
+    float       _rate_degs;             // rotation speed of circle in deg/sec. +ve for cw turn
+    float       _yaw_cd;                // yaw heading (normally towards circle center)
+    float       _angle_rad;             // current angular position around circle in radians (0=directly north of the center of the circle)
+    float       _angle_total_rad;       // total angle traveled in radians
+    float       _angular_vel_rads;      // angular velocity in radians/sec
+    float       _angular_vel_max_rads;  // maximum velocity in radians/sec
+    float       _angular_accel_radss;   // angular acceleration in radians/sec/sec
+    uint32_t    _last_update_ms;        // system time of last update
+    float       _last_radius_param;     // last value of radius param, used to update radius on param change
 
     // terrain following variables
-    bool        _is_terrain_alt;           // true if _center_neu_cm.z is alt-above-terrain, false if alt-above-ekf-origin
-    bool        _rangefinder_available; // true if range finder could be used
-    bool        _rangefinder_healthy;   // true if range finder is healthy
+    bool        _is_terrain_alt;                // true if _center_neu_cm.z is alt-above-terrain, false if alt-above-ekf-origin
+    bool        _rangefinder_available;         // true if range finder could be used
+    bool        _rangefinder_healthy;           // true if range finder is healthy
     float       _rangefinder_terrain_offset_cm; // latest rangefinder based terrain offset (e.g. terrain's height above EKF origin)
 };

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -3,14 +3,14 @@
 
 extern const AP_HAL::HAL& hal;
 
-// maximum velocities and accelerations
-#define WPNAV_WP_SPEED_CMS             1000.0f      // default horizontal speed between waypoints in cm/s
-#define WPNAV_WP_SPEED_MIN_MS            0.01f      // minimum horizontal speed between waypoints in cm/s
-#define WPNAV_WP_RADIUS_CM              200.0f      // default waypoint radius in cm
-#define WPNAV_WP_RADIUS_MIN_CM            5.0f      // minimum waypoint radius in cm
-#define WPNAV_WP_SPEED_UP_CMS           250.0f      // default maximum climb velocity
-#define WPNAV_WP_SPEED_DOWN_CMS         150.0f      // default maximum descent velocity
-#define WPNAV_WP_ACCEL_Z_DEFAULT_CMSS   100.0f      // default vertical acceleration between waypoints in cm/s/s
+// Default waypoint navigation constraints
+#define WPNAV_WP_SPEED_CMS             1000.0f     // default horizontal speed between waypoints (cm/s)
+#define WPNAV_WP_SPEED_MIN_MS             0.01f    // minimum horizontal speed allowed (m/s)
+#define WPNAV_WP_RADIUS_CM              200.0f     // default radius within which a waypoint is considered reached (cm)
+#define WPNAV_WP_RADIUS_MIN_CM            5.0f     // minimum allowable waypoint radius (cm)
+#define WPNAV_WP_SPEED_UP_CMS           250.0f     // default maximum climb speed (cm/s)
+#define WPNAV_WP_SPEED_DOWN_CMS         150.0f     // default maximum descent speed (cm/s)
+#define WPNAV_WP_ACCEL_Z_DEFAULT_CMSS   100.0f     // default vertical acceleration limit (cm/s²)
 
 const AP_Param::GroupInfo AC_WPNav::var_info[] = {
     // index 0 was used for the old orientation matrix

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -400,40 +400,6 @@ bool AC_WPNav::set_wp_destination_next_NED_m(const Vector3f& destination_NED_m)
     return set_wp_destination_next_NEU_cm(Vector3f(destination_NED_m.x * 100.0f, destination_NED_m.y * 100.0f, -destination_NED_m.z * 100.0f), false);
 }
 
-/// shifts the origin and destination horizontally to the current position
-///     used to reset the track when taking off without horizontal position control
-///     relies on set_wp_destination_NEU_cm or set_wp_origin_and_destination having been called first
-void AC_WPNav::shift_wp_origin_and_destination_to_current_pos_NE()
-{
-    // Reset position controller to current location
-    _pos_control.init_NE_controller();
-
-    // shift origin and destination horizontally
-    _origin_neu_cm.xy() = _pos_control.get_pos_estimate_NEU_cm().xy().tofloat();
-    _destination_neu_cm.xy() = _pos_control.get_pos_estimate_NEU_cm().xy().tofloat();
-}
-
-/// shifts the origin and destination horizontally to the achievable stopping point
-///     used to reset the track when horizontal navigation is enabled after having been disabled (see Copter's wp_navalt_min)
-///     relies on set_wp_destination_NEU_cm or set_wp_origin_and_destination having been called first
-void AC_WPNav::shift_wp_origin_and_destination_to_stopping_point_NE()
-{
-    // relax position control in xy axis
-    // removing velocity error also impacts stopping point calculation
-    _pos_control.relax_velocity_controller_NE();
-
-    // get current and target locations
-    Vector2f stopping_point_ne_cm;
-    get_wp_stopping_point_NE_cm(stopping_point_ne_cm);
-
-    // shift origin and destination horizontally
-    _origin_neu_cm.xy() = stopping_point_ne_cm;
-    _destination_neu_cm.xy() = stopping_point_ne_cm;
-
-    // move pos controller target horizontally
-    _pos_control.set_pos_desired_NE_cm(stopping_point_ne_cm);
-}
-
 /// get_wp_stopping_point_NE_cm - returns vector to stopping point based on a horizontal position and velocity
 void AC_WPNav::get_wp_stopping_point_NE_cm(Vector2f& stopping_point_ne_cm) const
 {

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -105,9 +105,7 @@ const AP_Param::GroupInfo AC_WPNav::var_info[] = {
 };
 
 // Default constructor.
-// Note that the Vector/Matrix constructors already implicitly zero
-// their values.
-//
+// Note that the Vector/Matrix constructors already implicitly zero their values.
 AC_WPNav::AC_WPNav(const AP_AHRS_View& ahrs, AC_PosControl& pos_control, const AC_AttitudeControl& attitude_control) :
     _ahrs(ahrs),
     _pos_control(pos_control),
@@ -125,7 +123,8 @@ AC_WPNav::AC_WPNav(const AP_AHRS_View& ahrs, AC_PosControl& pos_control, const A
     _last_wp_speed_down_cms = get_default_speed_down_cms();
 }
 
-// get expected source of terrain data if alt-above-terrain command is executed (used by Copter's ModeRTL)
+// Returns the expected source of terrain data when using alt-above-terrain commands.
+// Used by systems like ModeRTL to determine which terrain provider is active.
 AC_WPNav::TerrainSource AC_WPNav::get_terrain_source() const
 {
     // use range finder if connected
@@ -148,15 +147,16 @@ AC_WPNav::TerrainSource AC_WPNav::get_terrain_source() const
 /// waypoint navigation
 ///
 
-/// wp_and_spline_init_cm - initialise straight line and spline waypoint controllers
-///     speed_cms should be a positive value or left at zero to use the default speed
-///     stopping_point_ne_cm should be the vehicle's stopping point (equal to the starting point of the next segment) if know or left as zero
-///     should be called once before the waypoint controller is used but does not need to be called before subsequent updates to destination
+// Initializes waypoint and spline controllers using inputs in cm.
+// See wp_and_spline_init_m() for full details.
 void AC_WPNav::wp_and_spline_init_cm(float speed_cms, Vector3f stopping_point_neu_cm)
 {    
     wp_and_spline_init_m(speed_cms * 0.01, stopping_point_neu_cm * 0.01);
 }
 
+// Initializes waypoint and spline navigation using inputs in meters.
+// Sets speed and acceleration limits, calculates jerk constraints,
+// and initializes spline or S-curve leg with a defined starting point.
 void AC_WPNav::wp_and_spline_init_m(float speed_ms, Vector3f stopping_point_neu_m)
 {    
     // check _wp_radius_cm is reasonable
@@ -211,13 +211,15 @@ void AC_WPNav::wp_and_spline_init_m(float speed_ms, Vector3f stopping_point_neu_
     _wp_last_update_ms = AP_HAL::millis();
 }
 
-/// set_speed_NE_cms - allows main code to pass target horizontal velocity for wp navigation
+// Sets the target horizontal speed in cm/s during waypoint navigation.
+// See set_speed_NE_ms() for full details.
 void AC_WPNav::set_speed_NE_cms(float speed_cms)
 {
     set_speed_NE_ms(speed_cms * 0.01);
 }
 
-/// set_speed_NE_cms - allows main code to pass target horizontal velocity for wp navigation
+// Sets the target horizontal speed in m/s during waypoint navigation.
+// Also updates internal velocity offsets and path shaping limits.
 void AC_WPNav::set_speed_NE_ms(float speed_ms)
 {
     // range check target speed and protect against divide by zero
@@ -237,34 +239,39 @@ void AC_WPNav::set_speed_NE_ms(float speed_ms)
     }
 }
 
-/// set current target climb rate during wp navigation
+// Sets the climb speed for waypoint navigation in cm/s.
+// See set_speed_up_ms() for full details.
 void AC_WPNav::set_speed_up_cms(float speed_up_cms)
 {
     set_speed_up_ms(speed_up_cms * 0.01);
 }
 
-/// set current target climb rate during wp navigation
+// Sets the climb speed for waypoint navigation in m/s.
+// Updates the vertical controller with the new ascent rate limit.
 void AC_WPNav::set_speed_up_ms(float speed_up_ms)
 {
     _pos_control.set_max_speed_accel_U_m(_pos_control.get_max_speed_down_ms(), speed_up_ms, _pos_control.get_max_accel_U_mss());
     update_track_with_speed_accel_limits();
 }
 
-/// set current target descent rate during wp navigation
+// Sets the descent speed for waypoint navigation in cm/s.
+// See set_speed_down_ms() for full details.
 void AC_WPNav::set_speed_down_cms(float speed_down_cms)
 {
     set_speed_down_ms(speed_down_cms * 0.01);
 }
 
-/// set current target descent rate during wp navigation
+// Sets the descent speed for waypoint navigation in m/s.
+// Updates the vertical controller with the new descent rate limit.
 void AC_WPNav::set_speed_down_ms(float speed_down_ms)
 {
     _pos_control.set_max_speed_accel_U_m(speed_down_ms, _pos_control.get_max_speed_up_ms(), _pos_control.get_max_accel_U_mss());
     update_track_with_speed_accel_limits();
 }
 
-/// set_wp_destination_NEU_cm waypoint using location class
-///     returns false if conversion from location to vector from ekf origin cannot be calculated
+// Sets the current waypoint destination using a Location object.
+// Converts global coordinates to NEU position and sets destination.
+// Returns false if conversion fails (e.g. missing terrain data).
 bool AC_WPNav::set_wp_destination_loc(const Location& destination)
 {
     bool is_terrain_alt;
@@ -279,8 +286,9 @@ bool AC_WPNav::set_wp_destination_loc(const Location& destination)
     return set_wp_destination_NEU_m(dest_neu_m, is_terrain_alt);
 }
 
-/// set next destination using location class
-///     returns false if conversion from location to vector from ekf origin cannot be calculated
+// Sets the next waypoint destination using a Location object.
+// Converts global coordinates to NEU position and preloads the trajectory.
+// Returns false if conversion fails or terrain data is unavailable.
 bool AC_WPNav::set_wp_destination_next_loc(const Location& destination)
 {
     bool is_terrain_alt;
@@ -295,8 +303,9 @@ bool AC_WPNav::set_wp_destination_next_loc(const Location& destination)
     return set_wp_destination_next_NEU_m(dest_neu_m, is_terrain_alt);
 }
 
-// get destination as a location. Altitude frame will be above origin or above terrain
-// returns false if unable to return a destination (for example if origin has not yet been set)
+// Gets the current waypoint destination as a Location object.
+// Altitude frame will be ABOVE_TERRAIN or ABOVE_ORIGIN depending on path configuration.
+// Returns false if origin is not set or coordinate conversion fails.
 bool AC_WPNav::get_wp_destination_loc(Location& destination) const
 {
     if (!AP::ahrs().get_origin(destination)) {
@@ -307,17 +316,17 @@ bool AC_WPNav::get_wp_destination_loc(Location& destination) const
     return true;
 }
 
-/// set_wp_destination_NEU_cm - set destination waypoints using position vectors (distance from ekf origin in cm)
-///     is_terrain_alt should be true if destination_neu_cm.z is an altitude above terrain (false if alt-above-ekf-origin)
-///     returns false on failure (likely caused by missing terrain data)
+// Sets waypoint destination using NEU position vector in centimeters from EKF origin.
+// See set_wp_destination_NEU_m() for full details.
 bool AC_WPNav::set_wp_destination_NEU_cm(const Vector3f& destination_neu_cm, bool is_terrain_alt)
 {
     return set_wp_destination_NEU_m(destination_neu_cm * 0.01, is_terrain_alt);
 }
 
-/// set_wp_destination_NEU_cm - set destination waypoints using position vectors (distance from ekf origin in cm)
-///     terrain_alt should be true if destination_neu_m.z is an altitude above terrain (false if alt-above-ekf-origin)
-///     returns false on failure (likely caused by missing terrain data)
+// Sets waypoint destination using NEU position vector in meters from EKF origin.
+// If `is_terrain_alt` is true, altitude is interpreted as height above terrain.
+// Reinitializes the current leg if interrupted, updates origin, and computes trajectory.
+// Returns false if terrain offset cannot be determined when required.
 bool AC_WPNav::set_wp_destination_NEU_m(const Vector3f& destination_neu_m, bool is_terrain_alt)
 {
     // re-initialise if previous destination has been interrupted
@@ -387,17 +396,17 @@ bool AC_WPNav::set_wp_destination_NEU_m(const Vector3f& destination_neu_m, bool 
     return true;
 }
 
-/// set next destination using position vector (distance from ekf origin in cm)
-///     is_terrain_alt should be true if destination_neu_cm.z is a desired altitude above terrain
-///     provide next_destination_neu_cm
+// Sets the next waypoint destination using a NEU position vector in centimeters.
+// See set_wp_destination_next_NEU_m() for full details.
 bool AC_WPNav::set_wp_destination_next_NEU_cm(const Vector3f& destination_neu_cm, bool is_terrain_alt)
 {
     return set_wp_destination_next_NEU_m(destination_neu_cm * 0.01, is_terrain_alt);
 }
 
-/// set next destination_neu_m using position vector (distance from ekf origin in m)
-///     terrain_alt should be true if destination_neu_m.z is a desired altitude above terrain
-///     provide next_destination_neu_m
+// Sets the next waypoint destination using a NEU position vector in meters.
+// Only updates if terrain frame matches current leg.
+// Calculates trajectory preview for smoother transition into next segment.
+// Updates velocity handoff if previous leg is a spline.
 bool AC_WPNav::set_wp_destination_next_NEU_m(const Vector3f& destination_neu_m, bool is_terrain_alt)
 {
     // do not add next point if alt types don't match
@@ -425,21 +434,24 @@ bool AC_WPNav::set_wp_destination_next_NEU_m(const Vector3f& destination_neu_m, 
     return true;
 }
 
-/// set waypoint destination using NED position vector from ekf origin in meters
+// Sets waypoint destination using a NED position vector in meters from EKF origin.
+// Converts internally to NEU. Terrain following is not used.
 bool AC_WPNav::set_wp_destination_NED_m(const Vector3f& destination_NED_m)
 {
     // convert NED to NEU and do not use terrain following
     return set_wp_destination_NEU_m(Vector3f(destination_NED_m.x, destination_NED_m.y, -destination_NED_m.z), false);
 }
 
-/// set waypoint destination using NED position vector from ekf origin in meters
+// Sets the next waypoint destination using a NED position vector in meters from EKF origin.
+// Converts to NEU internally. Terrain following is not applied.
 bool AC_WPNav::set_wp_destination_next_NED_m(const Vector3f& destination_NED_m)
 {
     // convert NED to NEU and do not use terrain following
     return set_wp_destination_next_NEU_m(Vector3f(destination_NED_m.x, destination_NED_m.y, -destination_NED_m.z), false);
 }
 
-/// get_wp_stopping_point_NE_cm - returns vector to stopping point based on a horizontal position and velocity
+// Computes the horizontal stopping point in NE frame, returned in centimeters.
+// See get_wp_stopping_point_NE_m() for full details.
 void AC_WPNav::get_wp_stopping_point_NE_cm(Vector2f& stopping_point_ne_cm) const
 {
     Vector2f stopping_point_ne_m = stopping_point_ne_cm * 0.01;
@@ -447,7 +459,8 @@ void AC_WPNav::get_wp_stopping_point_NE_cm(Vector2f& stopping_point_ne_cm) const
     stopping_point_ne_cm = stopping_point_ne_m * 100.0;
 }
 
-/// get_wp_stopping_point_NE_m - returns vector to stopping point based on a horizontal position and velocity
+// Computes the horizontal stopping point in NE frame, in meters, based on current velocity and configured acceleration.
+// This is the point where the vehicle would come to a stop if decelerated using the configured limits.
 void AC_WPNav::get_wp_stopping_point_NE_m(Vector2f& stopping_point_ne_m) const
 {
     Vector2p stop_ne_m;
@@ -455,7 +468,8 @@ void AC_WPNav::get_wp_stopping_point_NE_m(Vector2f& stopping_point_ne_m) const
     stopping_point_ne_m = stop_ne_m.tofloat();
 }
 
-/// get_wp_stopping_point_NE_cm - returns vector to stopping point based on a horizontal position and velocity
+// Computes the full 3D NEU stopping point vector in centimeters based on current kinematics.
+// See get_wp_stopping_point_NEU_m() for full details.
 void AC_WPNav::get_wp_stopping_point_NEU_cm(Vector3f& stopping_point_neu_cm) const
 {
     Vector3f stopping_point_neu_m = stopping_point_neu_cm * 0.01;
@@ -463,7 +477,8 @@ void AC_WPNav::get_wp_stopping_point_NEU_cm(Vector3f& stopping_point_neu_cm) con
     stopping_point_neu_cm = stopping_point_neu_m * 100.0;
 }
 
-/// get_wp_stopping_point_NEU_m - returns vector to stopping point based on 3D position and velocity
+// Computes the full 3D NEU stopping point in meters based on current velocity and configured acceleration in all axes.
+// Represents where the vehicle will stop if decelerated from current velocity using configured limits.
 void AC_WPNav::get_wp_stopping_point_NEU_m(Vector3f& stopping_point_neu_m) const
 {
     Vector3p stop_neu_m;
@@ -472,7 +487,9 @@ void AC_WPNav::get_wp_stopping_point_NEU_m(Vector3f& stopping_point_neu_m) const
     stopping_point_neu_m = stop_neu_m.tofloat();
 }
 
-/// advance_wp_target_along_track - move target location along track from origin to destination
+// Advances the target location along the current path segment.
+// Updates target position, velocity, and acceleration based on jerk-limited profile (or spline).
+// Returns true if the update succeeded (e.g., terrain data was available).
 bool AC_WPNav::advance_wp_target_along_track(float dt)
 {
     // calculate terrain adjustments
@@ -572,7 +589,8 @@ bool AC_WPNav::advance_wp_target_along_track(float dt)
     return true;
 }
 
-/// recalculate path with update speed and/or acceleration limits
+// Updates the current and next path segment to reflect new speed and acceleration limits.
+// Should be called after modifying NE/U controller limits or vehicle configuration.
 void AC_WPNav::update_track_with_speed_accel_limits()
 {
     // update this leg
@@ -592,31 +610,36 @@ void AC_WPNav::update_track_with_speed_accel_limits()
     }
 }
 
-/// get_wp_distance_to_destination - get horizontal distance to destination in cm
+// Returns the horizontal distance to the destination waypoint in centimeters.
+// See get_wp_distance_to_destination_m() for full details.
 float AC_WPNav::get_wp_distance_to_destination_cm() const
 {
     return get_wp_distance_to_destination_m() * 100.0;
 }
 
-/// get_wp_distance_to_destination - get horizontal distance to destination in m
+// Returns the horizontal distance in meters between the current position and the destination waypoint.
 float AC_WPNav::get_wp_distance_to_destination_m() const
 {
     return get_horizontal_distance(_pos_control.get_pos_estimate_NEU_m().xy().tofloat(), _destination_neu_m.xy());
 }
 
-/// get_wp_bearing_to_destination_cd - get bearing to next waypoint in centi-degrees
+// Returns the bearing to the current waypoint destination in centidegrees.
+// See get_wp_bearing_to_destination_rad() for full details.
 int32_t AC_WPNav::get_wp_bearing_to_destination_cd() const
 {
     return get_bearing_cd(_pos_control.get_pos_estimate_NEU_m().xy().tofloat(), _destination_neu_m.xy());
 }
 
-/// get_wp_bearing_to_destination_cd - get bearing to next waypoint in centi-degrees
+// Returns the bearing to the current waypoint destination in radians.
+// The bearing is measured clockwise from North, with 0 = North.
 float AC_WPNav::get_wp_bearing_to_destination_rad() const
 {
     return get_bearing_rad(_pos_control.get_pos_estimate_NEU_m().xy().tofloat(), _destination_neu_m.xy());
 }
 
-/// update_wpnav - run the wp controller - should be called at 100hz or higher
+// Runs the waypoint navigation controller.
+// Advances the target position and updates the position controller.
+// Should be called at 100 Hz or higher for accurate tracking.
 bool AC_WPNav::update_wpnav()
 {
     // check for changes in speed parameter values
@@ -649,15 +672,17 @@ bool AC_WPNav::update_wpnav()
     return ret;
 }
 
-// returns true if update_wpnav has been run very recently
+// Returns true if update_wpnav() has been called within the last 200 ms.
+// Used to check if waypoint navigation is currently active.
 bool AC_WPNav::is_active() const
 {
     return (AP_HAL::millis() - _wp_last_update_ms) < 200;
 }
 
-// force stopping at next waypoint.  Used by Dijkstra's object avoidance when path from destination to next destination is not clear
-// only affects regular (e.g. non-spline) waypoints
-// returns true if this had any affect on the path
+// Forces a stop at the next waypoint instead of continuing to the subsequent one.
+// Used by Dijkstra’s object avoidance when the future path is obstructed.
+// Only affects regular (non-spline) waypoints.
+// Returns true if the stop behavior was newly enforced.
 bool AC_WPNav::force_stop_at_next_wp()
 {
     // exit immediately if vehicle was going to stop anyway
@@ -678,7 +703,8 @@ bool AC_WPNav::force_stop_at_next_wp()
     return true;
 }
 
-// get terrain's altitude (in cm above the ekf origin) at the current position (+ve means terrain below vehicle is above ekf origin's altitude)
+// Returns terrain offset in cm above the EKF origin at the current position.
+// See get_terrain_offset_m() for full details.
 bool AC_WPNav::get_terrain_offset_cm(float& offset_cm)
 {
     // call meter-version and convert to centimeters
@@ -688,7 +714,9 @@ bool AC_WPNav::get_terrain_offset_cm(float& offset_cm)
     return ret;
 }
 
-// get terrain's altitude (in cm above the ekf origin) at the current position (+ve means terrain below vehicle is above ekf origin's altitude)
+// Returns terrain offset in meters above the EKF origin at the current position.
+// Positive values mean terrain lies above the EKF origin altitude.
+// Source may be rangefinder or terrain database depending on availability.
 bool AC_WPNav::get_terrain_offset_m(float& offset_m)
 {
     // calculate offset based on source (rangefinder or terrain database)
@@ -722,10 +750,9 @@ bool AC_WPNav::get_terrain_offset_m(float& offset_m)
 /// spline methods
 ///
 
-/// set_spline_destination_NEU_cm waypoint using location class
-///     returns false if conversion from location to vector from ekf origin cannot be calculated
-///     next_destination should be the next segment's destination
-///     next_is_spline should be true if path to next_destination should be a spline
+// Sets the current spline waypoint using global coordinates.
+// Converts `destination` and `next_destination` to NEU position vectors and sets up a spline between them.
+// Returns false if conversion from location to vector fails.
 bool AC_WPNav::set_spline_destination_loc(const Location& destination, const Location& next_destination, bool next_is_spline)
 {
     // convert destination location to vector
@@ -746,9 +773,9 @@ bool AC_WPNav::set_spline_destination_loc(const Location& destination, const Loc
     return set_spline_destination_NEU_m(dest_neu_m, dest_is_terrain_alt, next_dest_neu_m, next_dest_is_terrain_alt, next_is_spline);
 }
 
-/// set next destination (e.g. the one after the current destination) as a spline segment specified as a location
-///     returns false if conversion from location to vector from ekf origin cannot be calculated
-///     next_next_destination should be the next segment's destination
+// Sets the next spline segment using global coordinates.
+// Converts the next and next-next destinations to NEU position vectors and initializes the spline transition.
+// Returns false if any conversion from location to vector fails.
 bool AC_WPNav::set_spline_destination_next_loc(const Location& next_destination, const Location& next_next_destination, bool next_next_is_spline)
 {
     // convert next_destination location to vector
@@ -769,11 +796,10 @@ bool AC_WPNav::set_spline_destination_next_loc(const Location& next_destination,
     return set_spline_destination_next_NEU_m(next_dest_neu_m, next_dest_is_terrain_alt, next_next_dest_neu_m, next_next_dest_is_terr_alt, next_next_is_spline);
 }
 
-/// set_spline_destination_NEU_m waypoint using position vector (distance from ekf origin in m)
-///     is_terrain_alt should be true if destination_neu_m.z is a desired altitude above terrain (false if its desired altitudes above ekf origin)
-///     next_destination_neu_m should be set to the next segment's destination
-///     next_is_terrain_alt should be true if next_destination_neu_m.z is a desired altitude above terrain (false if its desired altitudes above ekf origin)
-///     next_destination_neu_m.z  must be in the same "frame" as destination_neu_m.z (i.e. if destination is a alt-above-terrain, next_destination should be too)
+// Sets the current spline waypoint using NEU position vectors in meters.
+// Initializes a spline path from `destination_neu_m` to `next_destination_neu_m`, respecting terrain altitude framing.
+// Both waypoints must use the same altitude frame (either above terrain or above origin).
+// Returns false if terrain altitude cannot be determined when required.
 bool AC_WPNav::set_spline_destination_NEU_m(const Vector3f& destination_neu_m, bool is_terrain_alt, const Vector3f& next_destination_neu_m, bool next_is_terrain_alt, bool next_is_spline)
 {
     // re-initialise if previous destination has been interrupted
@@ -849,11 +875,10 @@ bool AC_WPNav::set_spline_destination_NEU_m(const Vector3f& destination_neu_m, b
     return true;
 }
 
-/// set next destination (e.g. the one after the current destination) as an offset (in m, NEU frame) from the EKF origin
-///     next_is_terrain_alt should be true if next_destination_neu_m.z is a desired altitude above terrain (false if its desired altitudes above ekf origin)
-///     next_next_destination_neu_m should be set to the next segment's destination_neu_m
-///     next_next_is_terrain_alt should be true if next_next_destination_neu_m.z is a desired altitude above terrain (false if it is desired altitude above ekf origin)
-///     next_next_destination_neu_m.z  must be in the same "frame" as destination_neu_m.z (i.e. if next_destination is a alt-above-terrain, next_next_destination should be too)
+// Sets the next spline segment using NEU position vectors in meters.
+// Creates a spline path from the current destination to `next_destination_neu_m`, and prepares transition toward `next_next_destination_neu_m`.
+// All waypoints must use the same altitude frame (above terrain or origin).
+// Returns false if terrain data is missing and required.
 bool AC_WPNav::set_spline_destination_next_NEU_m(const Vector3f& next_destination_neu_m, bool next_is_terrain_alt, const Vector3f& next_next_destination_neu_m, bool next_next_is_terrain_alt, bool next_next_is_spline)
 {
     // do not add next point if alt types don't match
@@ -904,8 +929,8 @@ bool AC_WPNav::set_spline_destination_next_NEU_m(const Vector3f& next_destinatio
     return true;
 }
 
-// convert location to vector from ekf origin.  is_terrain_alt is set to true if resulting vector's z-axis should be treated as alt-above-terrain
-//      returns false if conversion failed (likely because terrain data was not available)
+// Converts a Location to a NEU position vector in cm from the EKF origin.
+// See get_vector_NEU_m() for full details.
 bool AC_WPNav::get_vector_NEU_cm(const Location &loc, Vector3f &pos_from_origin_neu_cm, bool &is_terrain_alt)
 {
     Vector3f pos_from_origin_neu_m = pos_from_origin_neu_cm * 0.01;
@@ -915,8 +940,9 @@ bool AC_WPNav::get_vector_NEU_cm(const Location &loc, Vector3f &pos_from_origin_
     return ret;
 }
 
-// convert location to vector from ekf origin.  is_terrain_alt is set to true if resulting vector's z-axis should be treated as alt-above-terrain
-//      returns false if conversion failed (likely because terrain data was not available)
+// Converts a Location to a NEU position vector in meters from the EKF origin.
+// Sets `is_terrain_alt` to true if the resulting Z position is relative to terrain.
+// Returns false if terrain data is unavailable or conversion fails.
 bool AC_WPNav::get_vector_NEU_m(const Location &loc, Vector3f &pos_from_origin_neu_m, bool &is_terrain_alt)
 {
     // convert location to NE vector2f
@@ -950,8 +976,8 @@ bool AC_WPNav::get_vector_NEU_m(const Location &loc, Vector3f &pos_from_origin_n
     return true;
 }
 
-// helper function to calculate scurve jerk and jerk_time values
-// updates _scurve_jerk_max_msss and _scurve_snap_max_mssss
+// Calculates s-curve jerk and snap limits based on attitude controller capabilities.
+// Updates _scurve_jerk_max_msss and _scurve_snap_max_mssss with constrained values.
 void AC_WPNav::calc_scurve_jerk_and_snap()
 {
     // calculate jerk

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -128,17 +128,20 @@ AC_WPNav::AC_WPNav(const AP_AHRS_View& ahrs, AC_PosControl& pos_control, const A
 AC_WPNav::TerrainSource AC_WPNav::get_terrain_source() const
 {
     // use range finder if connected
+    // prioritise rangefinder when enabled and available
     if (_rangefinder_available && _rangefinder_use) {
         return AC_WPNav::TerrainSource::TERRAIN_FROM_RANGEFINDER;
     }
 #if AP_TERRAIN_AVAILABLE
     const AP_Terrain *terrain = AP::terrain();
+    // use terrain database if enabled
     if (terrain != nullptr && terrain->enabled()) {
         return AC_WPNav::TerrainSource::TERRAIN_FROM_TERRAINDATABASE;
     } else {
         return AC_WPNav::TerrainSource::TERRAIN_UNAVAILABLE;
     }
 #else
+    // fallback if no terrain support is compiled in
     return AC_WPNav::TerrainSource::TERRAIN_UNAVAILABLE;
 #endif
 }
@@ -150,7 +153,8 @@ AC_WPNav::TerrainSource AC_WPNav::get_terrain_source() const
 // Initializes waypoint and spline controllers using inputs in cm.
 // See wp_and_spline_init_m() for full details.
 void AC_WPNav::wp_and_spline_init_cm(float speed_cms, Vector3f stopping_point_neu_cm)
-{    
+{
+    // convert inputs from centimeters to meters and call the main initializer
     wp_and_spline_init_m(speed_cms * 0.01, stopping_point_neu_cm * 0.01);
 }
 
@@ -159,17 +163,17 @@ void AC_WPNav::wp_and_spline_init_cm(float speed_cms, Vector3f stopping_point_ne
 // and initializes spline or S-curve leg with a defined starting point.
 void AC_WPNav::wp_and_spline_init_m(float speed_ms, Vector3f stopping_point_neu_m)
 {    
-    // check _wp_radius_cm is reasonable
+    // ensure waypoint radius is not below minimum allowed value
     _wp_radius_cm.set_and_save_ifchanged(MAX(_wp_radius_cm, WPNAV_WP_RADIUS_MIN_CM));
 
-    // check _wp_speed
+    // ensure waypoint speed is not below minimum allowed value
     _wp_speed_cms.set_and_save_ifchanged(MAX(_wp_speed_cms, WPNAV_WP_SPEED_MIN_MS * 100.0));
 
     // initialise position controller
     _pos_control.init_U_controller_stopping_point();
     _pos_control.init_NE_controller_stopping_point();
 
-    // initialize the desired wp speed
+    // determine desired waypoint speed; fallback to default if not provided
     _check_wp_speed_change = !is_positive(speed_ms);
     _wp_desired_speed_ne_ms = is_positive(speed_ms) ? speed_ms : get_default_speed_NE_ms();
     _wp_desired_speed_ne_ms = MAX(_wp_desired_speed_ne_ms, WPNAV_WP_SPEED_MIN_MS);
@@ -180,7 +184,7 @@ void AC_WPNav::wp_and_spline_init_m(float speed_ms, Vector3f stopping_point_neu_
     _pos_control.set_max_speed_accel_U_m(-get_default_speed_down_ms(), get_default_speed_up_ms(), get_accel_U_mss());
     _pos_control.set_correction_speed_accel_U_mss(-get_default_speed_down_ms(), get_default_speed_up_ms(), get_accel_U_mss());
 
-    // calculate scurve jerk and jerk time
+    // calculate jerk limit if not explicitly set by parameter
     if (!is_positive(_wp_jerk_msss)) {
         _wp_jerk_msss.set(get_wp_acceleration_mss() * 100.0);
     }
@@ -194,7 +198,7 @@ void AC_WPNav::wp_and_spline_init_m(float speed_ms, Vector3f stopping_point_neu_
     _flags.reached_destination = true;
     _flags.fast_waypoint = false;
 
-    // initialise origin and destination to stopping point
+    // determine initial origin and destination; fallback to current stopping point if not provided
     if (stopping_point_neu_m.is_zero()) {
         get_wp_stopping_point_NEU_m(stopping_point_neu_m);
     }
@@ -202,7 +206,7 @@ void AC_WPNav::wp_and_spline_init_m(float speed_ms, Vector3f stopping_point_neu_
     _is_terrain_alt = false;
     _this_leg_is_spline = false;
 
-    // initialise the terrain velocity to the current maximum velocity
+    // initialise velocity profile for terrain margin shaping
     _offset_vel_ms = _wp_desired_speed_ne_ms;
     _offset_accel_mss = 0.0;
     _paused = false;
@@ -222,19 +226,19 @@ void AC_WPNav::set_speed_NE_cms(float speed_cms)
 // Also updates internal velocity offsets and path shaping limits.
 void AC_WPNav::set_speed_NE_ms(float speed_ms)
 {
-    // range check target speed and protect against divide by zero
+    // validate input: speed must be above minimum and current desired speed must be non-zero
     if (speed_ms >= WPNAV_WP_SPEED_MIN_MS && is_positive(_wp_desired_speed_ne_ms)) {
-        // update horizontal velocity speed offset scalar
+        // adjust internal velocity offset to preserve relative motion scaling
         _offset_vel_ms = speed_ms * _offset_vel_ms / _wp_desired_speed_ne_ms;
 
-        // initialize the desired wp speed
+        // set new desired horizontal speed for waypoint controller
         _wp_desired_speed_ne_ms = speed_ms;
 
-        // update position controller speed and acceleration
+        // update horizontal shaping and correction constraints
         _pos_control.set_max_speed_accel_NE_m(_wp_desired_speed_ne_ms, get_wp_acceleration_mss());
         _pos_control.set_correction_speed_accel_NE_m(_wp_desired_speed_ne_ms, get_wp_acceleration_mss());
 
-        // change track speed
+        // update internal trajectory with new limits
         update_track_with_speed_accel_limits();
     }
 }
@@ -250,7 +254,10 @@ void AC_WPNav::set_speed_up_cms(float speed_up_cms)
 // Updates the vertical controller with the new ascent rate limit.
 void AC_WPNav::set_speed_up_ms(float speed_up_ms)
 {
+    // update vertical controller's max speed and accel limits (U axis)
     _pos_control.set_max_speed_accel_U_m(_pos_control.get_max_speed_down_ms(), speed_up_ms, _pos_control.get_max_accel_U_mss());
+
+    // recompute the trajectory using updated limits
     update_track_with_speed_accel_limits();
 }
 
@@ -258,6 +265,7 @@ void AC_WPNav::set_speed_up_ms(float speed_up_ms)
 // See set_speed_down_ms() for full details.
 void AC_WPNav::set_speed_down_cms(float speed_down_cms)
 {
+    // convert cm/s to m/s and apply to descent limit
     set_speed_down_ms(speed_down_cms * 0.01);
 }
 
@@ -265,7 +273,10 @@ void AC_WPNav::set_speed_down_cms(float speed_down_cms)
 // Updates the vertical controller with the new descent rate limit.
 void AC_WPNav::set_speed_down_ms(float speed_down_ms)
 {
+    // update vertical controller descent speed
     _pos_control.set_max_speed_accel_U_m(speed_down_ms, _pos_control.get_max_speed_up_ms(), _pos_control.get_max_accel_U_mss());
+
+    // recompute the trajectory using updated limits
     update_track_with_speed_accel_limits();
 }
 
@@ -277,12 +288,12 @@ bool AC_WPNav::set_wp_destination_loc(const Location& destination)
     bool is_terrain_alt;
     Vector3f dest_neu_m;
 
-    // convert destination location to vector
+    // convert Location to NEU position vector in meters and determine altitude reference frame
     if (!get_vector_NEU_m(destination, dest_neu_m, is_terrain_alt)) {
         return false;
     }
 
-    // set target as vector from EKF origin
+    // apply destination as the active waypoint leg
     return set_wp_destination_NEU_m(dest_neu_m, is_terrain_alt);
 }
 
@@ -294,12 +305,12 @@ bool AC_WPNav::set_wp_destination_next_loc(const Location& destination)
     bool is_terrain_alt;
     Vector3f dest_neu_m;
 
-    // convert destination location to vector
+    // convert Location to NEU position vector in meters and determine altitude reference frame
     if (!get_vector_NEU_m(destination, dest_neu_m, is_terrain_alt)) {
         return false;
     }
 
-    // set target as vector from EKF origin
+    // apply destination as the next waypoint leg
     return set_wp_destination_next_NEU_m(dest_neu_m, is_terrain_alt);
 }
 
@@ -308,10 +319,12 @@ bool AC_WPNav::set_wp_destination_next_loc(const Location& destination)
 // Returns false if origin is not set or coordinate conversion fails.
 bool AC_WPNav::get_wp_destination_loc(Location& destination) const
 {
+    // retrieve global origin for coordinate conversion
     if (!AP::ahrs().get_origin(destination)) {
         return false;
     }
 
+    // convert NEU waypoint to global Location format with appropriate altitude frame
     destination = Location{get_wp_destination_NEU_m() * 100.0, _is_terrain_alt ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN};
     return true;
 }
@@ -342,17 +355,16 @@ bool AC_WPNav::set_wp_destination_NEU_m(const Vector3f& destination_neu_m, bool 
 
     if (is_terrain_alt == _is_terrain_alt) {
         if (_this_leg_is_spline) {
-            // if previous leg was a spline we can use current target velocity vector for origin velocity vector
+            // Use velocity from end of spline leg to seed new S-curve origin speed
             Vector3f curr_target_vel_neu_ms = _pos_control.get_vel_desired_NEU_ms();
             curr_target_vel_neu_ms.z -= _pos_control.get_vel_offset_U_ms();
             origin_speed_m = curr_target_vel_neu_ms.length();
         } else {
-            // store previous leg
+            // Preserve current leg profile to enable blending with new leg
             _scurve_prev_leg = _scurve_this_leg;
         }
     } else {
-
-        // get current alt above terrain
+        // Handle transition between terrain-relative and origin-relative altitude frames
         float origin_terr_offset_u_m;
         if (!get_terrain_offset_m(origin_terr_offset_u_m)) {
             return false;
@@ -360,11 +372,11 @@ bool AC_WPNav::set_wp_destination_NEU_m(const Vector3f& destination_neu_m, bool 
 
         // convert origin to alt-above-terrain if necessary
         if (is_terrain_alt) {
-            // new destination is alt-above-terrain, previous destination was alt-above-ekf-origin
+            // Convert origin.z to terrain-relative altitude
             _origin_neu_m.z -= origin_terr_offset_u_m;
             _pos_control.init_pos_terrain_U_m(origin_terr_offset_u_m);
         } else {
-            // new destination is alt-above-ekf-origin, previous destination was alt-above-terrain
+            // Convert origin.z to origin-relative altitude
             _origin_neu_m.z += origin_terr_offset_u_m;
             _pos_control.init_pos_terrain_U_m(0.0);
         }
@@ -375,14 +387,16 @@ bool AC_WPNav::set_wp_destination_NEU_m(const Vector3f& destination_neu_m, bool 
     _is_terrain_alt = is_terrain_alt;
 
     if (_flags.fast_waypoint && !_this_leg_is_spline && !_next_leg_is_spline && !_scurve_next_leg.finished()) {
+        // Reuse preloaded next leg if valid to avoid unnecessary recalculation
         _scurve_this_leg = _scurve_next_leg;
     } else {
+        // Generate a new S-curve segment to the new destination
         _scurve_this_leg.calculate_track(_origin_neu_m, _destination_neu_m,
                                          _pos_control.get_max_speed_NE_ms(), _pos_control.get_max_speed_up_ms(), _pos_control.get_max_speed_down_ms(),
                                          get_wp_acceleration_mss(), get_accel_U_mss(),
                                          _scurve_snap_max_mssss, _scurve_jerk_max_msss);
         if (!is_zero(origin_speed_m)) {
-            // rebuild start of scurve if we have a non-zero origin speed
+            // If we have a valid starting speed, seed it into the S-curve
             _scurve_this_leg.set_origin_speed_max(origin_speed_m);
         }
     }
@@ -414,21 +428,23 @@ bool AC_WPNav::set_wp_destination_next_NEU_m(const Vector3f& destination_neu_m, 
         return true;
     }
 
+    // Preload next S-curve leg with current speed and acceleration constraints
     _scurve_next_leg.calculate_track(_destination_neu_m, destination_neu_m,
                                      _pos_control.get_max_speed_NE_ms(), _pos_control.get_max_speed_up_ms(), _pos_control.get_max_speed_down_ms(),
                                      get_wp_acceleration_mss(), get_accel_U_mss(),
                                      _scurve_snap_max_mssss, _scurve_jerk_max_msss);
     if (_this_leg_is_spline) {
         const float this_leg_dest_speed_max_ms = _spline_this_leg.get_destination_speed_max();
+        // Pass velocity forward to allow continuous spline-scurve transition
         const float next_leg_origin_speed_max_ms = _scurve_next_leg.set_origin_speed_max(this_leg_dest_speed_max_ms);
         _spline_this_leg.set_destination_speed_max(next_leg_origin_speed_max_ms);
     }
     _next_leg_is_spline = false;
 
-    // next destination provided so fast waypoint
+    // Enable fast waypoint transition since next leg is known
     _flags.fast_waypoint = true;
 
-    // record next destination
+    // Store the upcoming destination for reference
     _next_destination_neu_m = destination_neu_m;
 
     return true;
@@ -438,7 +454,8 @@ bool AC_WPNav::set_wp_destination_next_NEU_m(const Vector3f& destination_neu_m, 
 // Converts internally to NEU. Terrain following is not used.
 bool AC_WPNav::set_wp_destination_NED_m(const Vector3f& destination_NED_m)
 {
-    // convert NED to NEU and do not use terrain following
+    // convert NED to NEU by inverting the Z axis
+    // terrain following is not used (altitude is relative to EKF origin)
     return set_wp_destination_NEU_m(Vector3f(destination_NED_m.x, destination_NED_m.y, -destination_NED_m.z), false);
 }
 
@@ -446,7 +463,8 @@ bool AC_WPNav::set_wp_destination_NED_m(const Vector3f& destination_NED_m)
 // Converts to NEU internally. Terrain following is not applied.
 bool AC_WPNav::set_wp_destination_next_NED_m(const Vector3f& destination_NED_m)
 {
-    // convert NED to NEU and do not use terrain following
+    // convert NED to NEU by inverting the Z axis
+    // terrain following is not used (altitude is relative to EKF origin)
     return set_wp_destination_next_NEU_m(Vector3f(destination_NED_m.x, destination_NED_m.y, -destination_NED_m.z), false);
 }
 
@@ -454,6 +472,7 @@ bool AC_WPNav::set_wp_destination_next_NED_m(const Vector3f& destination_NED_m)
 // See get_wp_stopping_point_NE_m() for full details.
 void AC_WPNav::get_wp_stopping_point_NE_cm(Vector2f& stopping_point_ne_cm) const
 {
+    // convert input/output to meters to match internal representation
     Vector2f stopping_point_ne_m = stopping_point_ne_cm * 0.01;
     get_wp_stopping_point_NE_m(stopping_point_ne_m);
     stopping_point_ne_cm = stopping_point_ne_m * 100.0;
@@ -463,8 +482,10 @@ void AC_WPNav::get_wp_stopping_point_NE_cm(Vector2f& stopping_point_ne_cm) const
 // This is the point where the vehicle would come to a stop if decelerated using the configured limits.
 void AC_WPNav::get_wp_stopping_point_NE_m(Vector2f& stopping_point_ne_m) const
 {
+    // request stopping point from the position controller
     Vector2p stop_ne_m;
     _pos_control.get_stopping_point_NE_m(stop_ne_m);
+    // convert from postype_t to Vector2f for external use
     stopping_point_ne_m = stop_ne_m.tofloat();
 }
 
@@ -472,8 +493,11 @@ void AC_WPNav::get_wp_stopping_point_NE_m(Vector2f& stopping_point_ne_m) const
 // See get_wp_stopping_point_NEU_m() for full details.
 void AC_WPNav::get_wp_stopping_point_NEU_cm(Vector3f& stopping_point_neu_cm) const
 {
+    // convert input from cm to m for internal calculation
     Vector3f stopping_point_neu_m = stopping_point_neu_cm * 0.01;
+    // compute stopping point using meters
     get_wp_stopping_point_NEU_m(stopping_point_neu_m);
+    // convert result back to centimeters
     stopping_point_neu_cm = stopping_point_neu_m * 100.0;
 }
 
@@ -482,7 +506,9 @@ void AC_WPNav::get_wp_stopping_point_NEU_cm(Vector3f& stopping_point_neu_cm) con
 void AC_WPNav::get_wp_stopping_point_NEU_m(Vector3f& stopping_point_neu_m) const
 {
     Vector3p stop_neu_m;
+    // get horizontal stopping point (North and East)
     _pos_control.get_stopping_point_NE_m(stop_neu_m.xy());
+    // get vertical stopping point (Up)
     _pos_control.get_stopping_point_U_m(stop_neu_m.z);
     stopping_point_neu_m = stop_neu_m.tofloat();
 }
@@ -492,39 +518,40 @@ void AC_WPNav::get_wp_stopping_point_NEU_m(Vector3f& stopping_point_neu_m) const
 // Returns true if the update succeeded (e.g., terrain data was available).
 bool AC_WPNav::advance_wp_target_along_track(float dt)
 {
-    // calculate terrain adjustments
+    // calculate terrain offset if using alt-above-terrain frame
     float terr_offset_u_m = 0.0f;
     if (_is_terrain_alt && !get_terrain_offset_m(terr_offset_u_m)) {
         return false;
     }
+
+    // calculate terrain-based velocity scaling factor
     const float offset_u_scalar = _pos_control.pos_terrain_U_scaler_m(terr_offset_u_m, get_terrain_margin_m());
 
     // input shape the terrain offset
     _pos_control.set_pos_terrain_target_U_m(terr_offset_u_m);
 
-    // get position controller's position offset (post input shaping) so it can be used in position error calculation
+    // get position controller's post-shaped position offset for use in position error computation
     const Vector3p& psc_pos_offset_neu_m = _pos_control.get_pos_offset_NEU_m();
 
-    // get current position and adjust altitude to origin and destination_neu_m's frame (i.e. _frame)
+    // compute current position in NEU frame, adjusted to destination frame (e.g., terrain-relative if needed)
     Vector3f curr_pos_neu_m = _pos_control.get_pos_estimate_NEU_m().tofloat() - psc_pos_offset_neu_m.tofloat();
     curr_pos_neu_m.z -= terr_offset_u_m;
+
+    // get desired velocity and remove offset
     Vector3f curr_target_vel_neu_ms = _pos_control.get_vel_desired_NEU_ms();
     curr_target_vel_neu_ms.z -= _pos_control.get_vel_offset_U_ms();
 
-    // Use _track_dt_scalar to slow down progression of the position target moving too far in front of aircraft
-    // _track_dt_scalar does not scale the velocity or acceleration
+    // scale progression time (track_dt_scalar) based on aircraft’s speed alignment with desired path
     float track_dt_scalar = 1.0f;
-    // check target velocity is non-zero
     if (is_positive(curr_target_vel_neu_ms.length_squared())) {
         Vector3f track_direction_neu = curr_target_vel_neu_ms.normalized();
         const float track_error_neu_m = _pos_control.get_pos_error_NEU_m().dot(track_direction_neu);
         const float track_velocity_neu_ms = _pos_control.get_vel_estimate_NEU_ms().dot(track_direction_neu);
-        // set time scalar to be consistent with the achievable aircraft speed with a 5% buffer for short term variation.
+        // limit time step scalar to [0,1], with 5% buffer
         track_dt_scalar = constrain_float(0.05f + (track_velocity_neu_ms - _pos_control.get_pos_NE_p().kP() * track_error_neu_m) / curr_target_vel_neu_ms.length(), 0.0f, 1.0f);
     }
 
-    // Use vel_dt_scalar to slow down the trajectory time
-    // vel_dt_scalar scales the velocity and acceleration to be kinematically consistent
+    // compute velocity scaling (vel_dt_scalar) and apply jerk-limited velocity shaping
     float vel_dt_scalar = 1.0;
     if (is_positive(_wp_desired_speed_ne_ms)) {
         update_vel_accel(_offset_vel_ms, _offset_accel_mss, dt, 0.0, 0.0);
@@ -534,16 +561,15 @@ bool AC_WPNav::advance_wp_target_along_track(float dt)
         vel_dt_scalar = _offset_vel_ms / _wp_desired_speed_ne_ms;
     }
 
-    // change s-curve time speed with a time constant of maximum acceleration / maximum jerk
+    // apply exponential filter to track_dt_scalar using jerk-based time constant
     float track_dt_scalar_tc = 1.0f;
     if (!is_zero(_wp_jerk_msss)) {
         track_dt_scalar_tc = get_wp_acceleration_mss()/_wp_jerk_msss;
     }
     _track_dt_scalar += (track_dt_scalar - _track_dt_scalar) * (dt / track_dt_scalar_tc);
 
-    // target position, velocity and acceleration from straight line or spline calculators
+    // select path generator (S-curve or spline) and compute target state
     Vector3f target_pos_neu_m, target_vel_neu_ms, target_accel_neu_mss;
-
     bool s_finished;
     if (!_this_leg_is_spline) {
         // update target position, velocity and acceleration
@@ -556,6 +582,7 @@ bool AC_WPNav::advance_wp_target_along_track(float dt)
         s_finished = _spline_this_leg.reached_destination();
     }
 
+    // apply scaled acceleration offset along current direction of travel
     Vector3f accel_offset_neu_mss;
     if (is_positive(target_vel_neu_ms.length_squared())) {
         Vector3f track_direction_neu = target_vel_neu_ms.normalized();
@@ -566,10 +593,10 @@ bool AC_WPNav::advance_wp_target_along_track(float dt)
     target_accel_neu_mss *= sq(vel_dt_scalar);
     target_accel_neu_mss += accel_offset_neu_mss;
 
-    // pass new target to the position controller
+    // send updated position, velocity, and acceleration targets to position controller
     _pos_control.set_pos_vel_accel_NEU_m(target_pos_neu_m.topostype(), target_vel_neu_ms, target_accel_neu_mss);
 
-    // check if we've reached the waypoint
+    // check if waypoint has been reached based on mode and radius
     if (!_flags.reached_destination) {
         if (s_finished) {
             // "fast" waypoints are complete once the intermediate point reaches the destination
@@ -593,7 +620,7 @@ bool AC_WPNav::advance_wp_target_along_track(float dt)
 // Should be called after modifying NE/U controller limits or vehicle configuration.
 void AC_WPNav::update_track_with_speed_accel_limits()
 {
-    // update this leg
+    // update speed and acceleration limits for the current segment
     if (_this_leg_is_spline) {
         _spline_this_leg.set_speed_accel(_pos_control.get_max_speed_NE_ms(), _pos_control.get_max_speed_up_ms(), _pos_control.get_max_speed_down_ms(),
                                          get_wp_acceleration_mss(), get_accel_U_mss());
@@ -601,7 +628,7 @@ void AC_WPNav::update_track_with_speed_accel_limits()
         _scurve_this_leg.set_speed_max(_pos_control.get_max_speed_NE_ms(), _pos_control.get_max_speed_up_ms(), _pos_control.get_max_speed_down_ms());
     }
 
-    // update next leg
+    // update speed and acceleration limits for the next segment
     if (_next_leg_is_spline) {
         _spline_next_leg.set_speed_accel(_pos_control.get_max_speed_NE_ms(), _pos_control.get_max_speed_up_ms(), _pos_control.get_max_speed_down_ms(),
                                          get_wp_acceleration_mss(), get_accel_U_mss());
@@ -614,12 +641,14 @@ void AC_WPNav::update_track_with_speed_accel_limits()
 // See get_wp_distance_to_destination_m() for full details.
 float AC_WPNav::get_wp_distance_to_destination_cm() const
 {
+    // convert distance from meters to centimeters
     return get_wp_distance_to_destination_m() * 100.0;
 }
 
 // Returns the horizontal distance in meters between the current position and the destination waypoint.
 float AC_WPNav::get_wp_distance_to_destination_m() const
 {
+    // calculate 2D ground distance between current position and destination in NE frame
     return get_horizontal_distance(_pos_control.get_pos_estimate_NEU_m().xy().tofloat(), _destination_neu_m.xy());
 }
 
@@ -627,6 +656,7 @@ float AC_WPNav::get_wp_distance_to_destination_m() const
 // See get_wp_bearing_to_destination_rad() for full details.
 int32_t AC_WPNav::get_wp_bearing_to_destination_cd() const
 {
+    // compute heading from current position to destination in centidegrees
     return get_bearing_cd(_pos_control.get_pos_estimate_NEU_m().xy().tofloat(), _destination_neu_m.xy());
 }
 
@@ -634,6 +664,7 @@ int32_t AC_WPNav::get_wp_bearing_to_destination_cd() const
 // The bearing is measured clockwise from North, with 0 = North.
 float AC_WPNav::get_wp_bearing_to_destination_rad() const
 {
+    // compute heading from current position to destination in radians
     return get_bearing_rad(_pos_control.get_pos_estimate_NEU_m().xy().tofloat(), _destination_neu_m.xy());
 }
 
@@ -642,13 +673,15 @@ float AC_WPNav::get_wp_bearing_to_destination_rad() const
 // Should be called at 100 Hz or higher for accurate tracking.
 bool AC_WPNav::update_wpnav()
 {
-    // check for changes in speed parameter values
+    // check for changes in WPNAV_SPEED parameter (horizontal speed target)
     if (_check_wp_speed_change) {
         if (!is_equal(_wp_speed_cms.get(), _last_wp_speed_cms)) {
+            // apply new WPNAV_SPEED value
             set_speed_NE_ms(get_default_speed_NE_ms());
             _last_wp_speed_cms = _wp_speed_cms;
         }
     }
+    // check for climb and descent speed updates
     if (!is_equal(_wp_speed_up_cms.get(), _last_wp_speed_up_cms)) {
         set_speed_up_ms(get_default_speed_up_ms());
         _last_wp_speed_up_cms = _wp_speed_up_cms;
@@ -658,15 +691,17 @@ bool AC_WPNav::update_wpnav()
         _last_wp_speed_down_cms = _wp_speed_down_cms;
     }
 
-    // advance the target if necessary
+    // advance the waypoint target based on current position and timing
     bool ret = true;
     if (!advance_wp_target_along_track(_pos_control.get_dt_s())) {
         // To-Do: handle inability to advance along track (probably because of missing terrain data)
         ret = false;
     }
 
+    // run the horizontal position controller
     _pos_control.update_NE_controller();
 
+    // record update time for is_active()
     _wp_last_update_ms = AP_HAL::millis();
 
     return ret;
@@ -676,6 +711,7 @@ bool AC_WPNav::update_wpnav()
 // Used to check if waypoint navigation is currently active.
 bool AC_WPNav::is_active() const
 {
+    // consider WPNAV active if last update was within 200 milliseconds
     return (AP_HAL::millis() - _wp_last_update_ms) < 200;
 }
 
@@ -685,14 +721,14 @@ bool AC_WPNav::is_active() const
 // Returns true if the stop behavior was newly enforced.
 bool AC_WPNav::force_stop_at_next_wp()
 {
-    // exit immediately if vehicle was going to stop anyway
+    // skip if vehicle was already going to stop at the next waypoint
     if (!_flags.fast_waypoint) {
         return false;
     }
 
     _flags.fast_waypoint = false;
 
-    // update this_leg's final velocity and next leg's initial velocity to zero
+    // override final velocity for current leg and reset preview for next leg
     if (!_this_leg_is_spline) {
         _scurve_this_leg.set_destination_speed_max(0);
     }
@@ -719,22 +755,26 @@ bool AC_WPNav::get_terrain_offset_cm(float& offset_cm)
 // Source may be rangefinder or terrain database depending on availability.
 bool AC_WPNav::get_terrain_offset_m(float& offset_m)
 {
-    // calculate offset based on source (rangefinder or terrain database)
+    // determine terrain data source and compute offset accordingly
     switch (get_terrain_source()) {
     case AC_WPNav::TerrainSource::TERRAIN_UNAVAILABLE:
         return false;
+
     case AC_WPNav::TerrainSource::TERRAIN_FROM_RANGEFINDER:
         if (_rangefinder_healthy) {
+            // return previously saved offset based on rangefinder
             offset_m = _rangefinder_terrain_offset_m;
             return true;
         }
         return false;
+
     case AC_WPNav::TerrainSource::TERRAIN_FROM_TERRAINDATABASE:
 #if AP_TERRAIN_AVAILABLE
         float terrain_alt_m = 0.0f;
         AP_Terrain *terrain = AP::terrain();
         if (terrain != nullptr &&
             terrain->height_above_terrain(terrain_alt_m, true)) {
+            // compute offset as difference between current altitude and terrain height
             offset_m = _pos_control.get_pos_estimate_NEU_m().z - terrain_alt_m;
             return true;
         }
@@ -742,7 +782,7 @@ bool AC_WPNav::get_terrain_offset_m(float& offset_m)
         return false;
     }
 
-    // we should never get here
+    // unreachable fallback path
     return false;
 }
 
@@ -755,21 +795,21 @@ bool AC_WPNav::get_terrain_offset_m(float& offset_m)
 // Returns false if conversion from location to vector fails.
 bool AC_WPNav::set_spline_destination_loc(const Location& destination, const Location& next_destination, bool next_is_spline)
 {
-    // convert destination location to vector
+    // convert destination location to NEU vector and altitude frame
     Vector3f dest_neu_m;
     bool dest_is_terrain_alt;
     if (!get_vector_NEU_m(destination, dest_neu_m, dest_is_terrain_alt)) {
         return false;
     }
 
-    // convert next destination to vector
+    // convert next destination location to NEU vector and altitude frame
     Vector3f next_dest_neu_m;
     bool next_dest_is_terrain_alt;
     if (!get_vector_NEU_m(next_destination, next_dest_neu_m, next_dest_is_terrain_alt)) {
         return false;
     }
 
-    // set target as vector from EKF origin
+    // initialize spline path between converted destination and next_destination
     return set_spline_destination_NEU_m(dest_neu_m, dest_is_terrain_alt, next_dest_neu_m, next_dest_is_terrain_alt, next_is_spline);
 }
 
@@ -778,21 +818,21 @@ bool AC_WPNav::set_spline_destination_loc(const Location& destination, const Loc
 // Returns false if any conversion from location to vector fails.
 bool AC_WPNav::set_spline_destination_next_loc(const Location& next_destination, const Location& next_next_destination, bool next_next_is_spline)
 {
-    // convert next_destination location to vector
+    // convert next_destination location to NEU vector and determine if it uses terrain-relative altitude
     Vector3f next_dest_neu_m;
     bool next_dest_is_terrain_alt;
     if (!get_vector_NEU_m(next_destination, next_dest_neu_m, next_dest_is_terrain_alt)) {
         return false;
     }
 
-    // convert next_next_destination to vector
+    // convert next_next_destination location to NEU vector and determine if it uses terrain-relative altitude
     Vector3f next_next_dest_neu_m;
     bool next_next_dest_is_terr_alt;
     if (!get_vector_NEU_m(next_next_destination, next_next_dest_neu_m, next_next_dest_is_terr_alt)) {
         return false;
     }
 
-    // set target as vector from EKF origin
+    // initialize next spline segment using converted waypoints
     return set_spline_destination_next_NEU_m(next_dest_neu_m, next_dest_is_terrain_alt, next_next_dest_neu_m, next_next_dest_is_terr_alt, next_next_is_spline);
 }
 
@@ -802,7 +842,7 @@ bool AC_WPNav::set_spline_destination_next_loc(const Location& next_destination,
 // Returns false if terrain altitude cannot be determined when required.
 bool AC_WPNav::set_spline_destination_NEU_m(const Vector3f& destination_neu_m, bool is_terrain_alt, const Vector3f& next_destination_neu_m, bool next_is_terrain_alt, bool next_is_spline)
 {
-    // re-initialise if previous destination has been interrupted
+    // re-initialise path state if previous destination was not completed or controller inactive
     if (!is_active() || !_flags.reached_destination) {
         wp_and_spline_init_m(_wp_desired_speed_ne_ms);
     }
@@ -817,10 +857,10 @@ bool AC_WPNav::set_spline_destination_NEU_m(const Vector3f& destination_neu_m, b
         if (_flags.fast_waypoint) {
             // calculate origin vector
             if (_this_leg_is_spline) {
-                // if previous leg was a spline we can use destination velocity vector for origin velocity vector
+                // use velocity vector from end of previous spline segment
                 origin_vector_neu_m = _spline_this_leg.get_destination_vel();
             } else {
-                // use direction of the previous straight line segment
+                // use direction vector from previous straight-line segment
                 origin_vector_neu_m = _destination_neu_m - _origin_neu_m;
             }
         }
@@ -858,16 +898,16 @@ bool AC_WPNav::set_spline_destination_NEU_m(const Vector3f& destination_neu_m, b
     Vector3f destination_vector_neu_m;
     if (is_terrain_alt == next_is_terrain_alt) {
         if (next_is_spline) {
-            // leave this segment moving parallel to vector from origin to next destination
+            // aim to leave segment in direction of full arc (origin to next)
             destination_vector_neu_m = next_destination_neu_m - _origin_neu_m;
         } else {
-            // leave this segment moving parallel to next segment
+            // aim to leave segment in direction of following leg
             destination_vector_neu_m = next_destination_neu_m - _destination_neu_m;
         }
     }
     _flags.fast_waypoint = !destination_vector_neu_m.is_zero();
 
-    // setup spline leg
+    // setup spline leg using origin and destination vectors
     _spline_this_leg.set_origin_and_destination(_origin_neu_m, _destination_neu_m, origin_vector_neu_m, destination_vector_neu_m);
     _this_leg_is_spline = true;
     _flags.reached_destination = false;
@@ -889,10 +929,10 @@ bool AC_WPNav::set_spline_destination_next_NEU_m(const Vector3f& next_destinatio
     // calculate origin and origin velocity vector
     Vector3f origin_vector_neu_m;
     if (_this_leg_is_spline) {
-        // if previous leg was a spline we can use destination velocity vector for origin velocity vector
+        // use final velocity vector from current spline segment
         origin_vector_neu_m = _spline_this_leg.get_destination_vel();
     } else {
-        // use the direction of the previous straight line segment
+        // use vector from previous origin to current destination
         origin_vector_neu_m = _destination_neu_m - _origin_neu_m;
     }
 
@@ -900,10 +940,10 @@ bool AC_WPNav::set_spline_destination_next_NEU_m(const Vector3f& next_destinatio
     Vector3f destination_vector_neu_m;
     if (next_is_terrain_alt == next_next_is_terrain_alt) {
         if (next_next_is_spline) {
-            // leave this segment moving parallel to vector from this leg's origin (i.e. prev leg's destination) to next next destination
+            // aim to leave segment in direction of the arc from current to next-next
             destination_vector_neu_m = next_next_destination_neu_m - _destination_neu_m;
         } else {
-            // leave this segment moving parallel to next segment
+            // aim to leave segment in direction of the upcoming straight leg
             destination_vector_neu_m = next_next_destination_neu_m - next_destination_neu_m;
         }
     }
@@ -933,6 +973,7 @@ bool AC_WPNav::set_spline_destination_next_NEU_m(const Vector3f& next_destinatio
 // See get_vector_NEU_m() for full details.
 bool AC_WPNav::get_vector_NEU_cm(const Location &loc, Vector3f &pos_from_origin_neu_cm, bool &is_terrain_alt)
 {
+    // convert input to meters for processing
     Vector3f pos_from_origin_neu_m = pos_from_origin_neu_cm * 0.01;
     // perform vector conversion using meters interface
     const bool ret = get_vector_NEU_m(loc, pos_from_origin_neu_m, is_terrain_alt);
@@ -945,7 +986,7 @@ bool AC_WPNav::get_vector_NEU_cm(const Location &loc, Vector3f &pos_from_origin_
 // Returns false if terrain data is unavailable or conversion fails.
 bool AC_WPNav::get_vector_NEU_m(const Location &loc, Vector3f &pos_from_origin_neu_m, bool &is_terrain_alt)
 {
-    // convert location to NE vector2f
+    // convert horizontal position (latitude/longitude) to NE vector from EKF origin
     Vector2f loc_pos_from_origin_neu_m;
     if (!loc.get_vector_xy_from_origin_NE_m(loc_pos_from_origin_neu_m)) {
         return false;
@@ -969,7 +1010,7 @@ bool AC_WPNav::get_vector_NEU_m(const Location &loc, Vector3f &pos_from_origin_n
         is_terrain_alt = false;
     }
 
-    // copy xy (we do this to ensure we do not adjust vector unless the overall conversion is successful
+    // set horizontal components (x/y) of NEU vector after successful conversion
     pos_from_origin_neu_m.x = loc_pos_from_origin_neu_m.x;
     pos_from_origin_neu_m.y = loc_pos_from_origin_neu_m.y;
 
@@ -980,7 +1021,7 @@ bool AC_WPNav::get_vector_NEU_m(const Location &loc, Vector3f &pos_from_origin_n
 // Updates _scurve_jerk_max_msss and _scurve_snap_max_mssss with constrained values.
 void AC_WPNav::calc_scurve_jerk_and_snap()
 {
-    // calculate jerk
+    // calculate max horizontal jerk based on roll/pitch angular velocity limits
     _scurve_jerk_max_msss = MIN(_attitude_control.get_ang_vel_roll_max_rads() * GRAVITY_MSS, _attitude_control.get_ang_vel_pitch_max_rads() * GRAVITY_MSS);
     if (is_zero(_scurve_jerk_max_msss)) {
         _scurve_jerk_max_msss = _wp_jerk_msss;
@@ -988,14 +1029,16 @@ void AC_WPNav::calc_scurve_jerk_and_snap()
         _scurve_jerk_max_msss = MIN(_scurve_jerk_max_msss, _wp_jerk_msss);
     }
 
-    // calculate maximum snap
-    // Snap (the rate of change of jerk) uses the attitude control input time constant because multicopters
-    // lean to accelerate. This means the change in angle is equivalent to the change in acceleration
+    // calculate maximum snap (rate of change of jerk)
+    // uses input time constant as proxy for lean angle actuation latency
     _scurve_snap_max_mssss = (_scurve_jerk_max_msss * M_PI) / (2.0 * MAX(_attitude_control.get_input_tc(), 0.1f));
+
+    // constrain snap based on roll/pitch angular acceleration capability
     const float snap = MIN(_attitude_control.get_accel_roll_max_radss(), _attitude_control.get_accel_pitch_max_radss()) * GRAVITY_MSS;
     if (is_positive(snap)) {
         _scurve_snap_max_mssss = MIN(_scurve_snap_max_mssss, snap);
     }
-    // reduce maximum snap by a factor of two from what the aircraft is capable of
+
+    // apply safety margin: reduce snap to 50% of calculated maximum
     _scurve_snap_max_mssss *= 0.5;
 }

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -186,7 +186,7 @@ void AC_WPNav::wp_and_spline_init_m(float speed_ms, Vector3f stopping_point_neu_
 
     // calculate jerk limit if not explicitly set by parameter
     if (!is_positive(_wp_jerk_msss)) {
-        _wp_jerk_msss.set(get_wp_acceleration_mss() * 100.0);
+        _wp_jerk_msss.set(get_wp_acceleration_mss());
     }
     calc_scurve_jerk_and_snap();
 

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -5,7 +5,7 @@ extern const AP_HAL::HAL& hal;
 
 // maximum velocities and accelerations
 #define WPNAV_WP_SPEED_CMS             1000.0f      // default horizontal speed between waypoints in cm/s
-#define WPNAV_WP_SPEED_MIN_CMS           10.0f      // minimum horizontal speed between waypoints in cm/s
+#define WPNAV_WP_SPEED_MIN_MS            0.01f      // minimum horizontal speed between waypoints in cm/s
 #define WPNAV_WP_RADIUS_CM              200.0f      // default waypoint radius in cm
 #define WPNAV_WP_RADIUS_MIN_CM            5.0f      // minimum waypoint radius in cm
 #define WPNAV_WP_SPEED_UP_CMS           250.0f      // default maximum climb velocity
@@ -58,7 +58,7 @@ const AP_Param::GroupInfo AC_WPNav::var_info[] = {
     // @Range: 50 500
     // @Increment: 10
     // @User: Standard
-    AP_GROUPINFO("ACCEL",       5, AC_WPNav, _wp_accel_cmss, WPNAV_ACCELERATION),
+    AP_GROUPINFO("ACCEL",       5, AC_WPNav, _wp_accel_cmss, WPNAV_ACCELERATION_MS * 100.0),
 
     // @Param: ACCEL_Z
     // @DisplayName: Waypoint Vertical Acceleration
@@ -152,32 +152,37 @@ AC_WPNav::TerrainSource AC_WPNav::get_terrain_source() const
 ///     speed_cms should be a positive value or left at zero to use the default speed
 ///     stopping_point_ne_cm should be the vehicle's stopping point (equal to the starting point of the next segment) if know or left as zero
 ///     should be called once before the waypoint controller is used but does not need to be called before subsequent updates to destination
-void AC_WPNav::wp_and_spline_init_cm(float speed_cms, Vector3f stopping_point_ne_cm)
+void AC_WPNav::wp_and_spline_init_cm(float speed_cms, Vector3f stopping_point_neu_cm)
+{    
+    wp_and_spline_init_m(speed_cms * 0.01, stopping_point_neu_cm * 0.01);
+}
+
+void AC_WPNav::wp_and_spline_init_m(float speed_ms, Vector3f stopping_point_neu_m)
 {    
     // check _wp_radius_cm is reasonable
     _wp_radius_cm.set_and_save_ifchanged(MAX(_wp_radius_cm, WPNAV_WP_RADIUS_MIN_CM));
 
     // check _wp_speed
-    _wp_speed_cms.set_and_save_ifchanged(MAX(_wp_speed_cms, WPNAV_WP_SPEED_MIN_CMS));
+    _wp_speed_cms.set_and_save_ifchanged(MAX(_wp_speed_cms, WPNAV_WP_SPEED_MIN_MS * 100.0));
 
     // initialise position controller
     _pos_control.init_U_controller_stopping_point();
     _pos_control.init_NE_controller_stopping_point();
 
     // initialize the desired wp speed
-    _check_wp_speed_change = !is_positive(speed_cms);
-    _wp_desired_speed_ne_cms = is_positive(speed_cms) ? speed_cms : _wp_speed_cms;
-    _wp_desired_speed_ne_cms = MAX(_wp_desired_speed_ne_cms, WPNAV_WP_SPEED_MIN_CMS);
+    _check_wp_speed_change = !is_positive(speed_ms);
+    _wp_desired_speed_ne_ms = is_positive(speed_ms) ? speed_ms : get_default_speed_NE_ms();
+    _wp_desired_speed_ne_ms = MAX(_wp_desired_speed_ne_ms, WPNAV_WP_SPEED_MIN_MS);
 
     // initialise position controller speed and acceleration
-    _pos_control.set_max_speed_accel_NE_cm(_wp_desired_speed_ne_cms, get_wp_acceleration_cmss());
-    _pos_control.set_correction_speed_accel_NE_cm(_wp_desired_speed_ne_cms, get_wp_acceleration_cmss());
-    _pos_control.set_max_speed_accel_U_cm(-get_default_speed_down_cms(), _wp_speed_up_cms, _wp_accel_z_cmss);
-    _pos_control.set_correction_speed_accel_U_cmss(-get_default_speed_down_cms(), _wp_speed_up_cms, _wp_accel_z_cmss);
+    _pos_control.set_max_speed_accel_NE_m(_wp_desired_speed_ne_ms, get_wp_acceleration_mss());
+    _pos_control.set_correction_speed_accel_NE_m(_wp_desired_speed_ne_ms, get_wp_acceleration_mss());
+    _pos_control.set_max_speed_accel_U_m(-get_default_speed_down_ms(), get_default_speed_up_ms(), get_accel_U_mss());
+    _pos_control.set_correction_speed_accel_U_mss(-get_default_speed_down_ms(), get_default_speed_up_ms(), get_accel_U_mss());
 
     // calculate scurve jerk and jerk time
     if (!is_positive(_wp_jerk_msss)) {
-        _wp_jerk_msss.set(get_wp_acceleration_cmss());
+        _wp_jerk_msss.set(get_wp_acceleration_mss() * 100.0);
     }
     calc_scurve_jerk_and_snap();
 
@@ -190,16 +195,16 @@ void AC_WPNav::wp_and_spline_init_cm(float speed_cms, Vector3f stopping_point_ne
     _flags.fast_waypoint = false;
 
     // initialise origin and destination to stopping point
-    if (stopping_point_ne_cm.is_zero()) {
-        get_wp_stopping_point_NEU_cm(stopping_point_ne_cm);
+    if (stopping_point_neu_m.is_zero()) {
+        get_wp_stopping_point_NEU_m(stopping_point_neu_m);
     }
-    _origin_neu_cm = _destination_neu_cm = stopping_point_ne_cm;
+    _origin_neu_m = _destination_neu_m = stopping_point_neu_m;
     _is_terrain_alt = false;
     _this_leg_is_spline = false;
 
     // initialise the terrain velocity to the current maximum velocity
-    _offset_vel_cms = _wp_desired_speed_ne_cms;
-    _offset_accel_cmss = 0.0;
+    _offset_vel_ms = _wp_desired_speed_ne_ms;
+    _offset_accel_mss = 0.0;
     _paused = false;
 
     // mark as active
@@ -209,17 +214,23 @@ void AC_WPNav::wp_and_spline_init_cm(float speed_cms, Vector3f stopping_point_ne
 /// set_speed_NE_cms - allows main code to pass target horizontal velocity for wp navigation
 void AC_WPNav::set_speed_NE_cms(float speed_cms)
 {
+    set_speed_NE_ms(speed_cms * 0.01);
+}
+
+/// set_speed_NE_cms - allows main code to pass target horizontal velocity for wp navigation
+void AC_WPNav::set_speed_NE_ms(float speed_ms)
+{
     // range check target speed and protect against divide by zero
-    if (speed_cms >= WPNAV_WP_SPEED_MIN_CMS && is_positive(_wp_desired_speed_ne_cms)) {
+    if (speed_ms >= WPNAV_WP_SPEED_MIN_MS && is_positive(_wp_desired_speed_ne_ms)) {
         // update horizontal velocity speed offset scalar
-        _offset_vel_cms = speed_cms * _offset_vel_cms / _wp_desired_speed_ne_cms;
+        _offset_vel_ms = speed_ms * _offset_vel_ms / _wp_desired_speed_ne_ms;
 
         // initialize the desired wp speed
-        _wp_desired_speed_ne_cms = speed_cms;
+        _wp_desired_speed_ne_ms = speed_ms;
 
         // update position controller speed and acceleration
-        _pos_control.set_max_speed_accel_NE_cm(_wp_desired_speed_ne_cms, get_wp_acceleration_cmss());
-        _pos_control.set_correction_speed_accel_NE_cm(_wp_desired_speed_ne_cms, get_wp_acceleration_cmss());
+        _pos_control.set_max_speed_accel_NE_m(_wp_desired_speed_ne_ms, get_wp_acceleration_mss());
+        _pos_control.set_correction_speed_accel_NE_m(_wp_desired_speed_ne_ms, get_wp_acceleration_mss());
 
         // change track speed
         update_track_with_speed_accel_limits();
@@ -229,14 +240,26 @@ void AC_WPNav::set_speed_NE_cms(float speed_cms)
 /// set current target climb rate during wp navigation
 void AC_WPNav::set_speed_up_cms(float speed_up_cms)
 {
-    _pos_control.set_max_speed_accel_U_cm(_pos_control.get_max_speed_down_cms(), speed_up_cms, _pos_control.get_max_accel_U_cmss());
+    set_speed_up_ms(speed_up_cms * 0.01);
+}
+
+/// set current target climb rate during wp navigation
+void AC_WPNav::set_speed_up_ms(float speed_up_ms)
+{
+    _pos_control.set_max_speed_accel_U_m(_pos_control.get_max_speed_down_ms(), speed_up_ms, _pos_control.get_max_accel_U_mss());
     update_track_with_speed_accel_limits();
 }
 
 /// set current target descent rate during wp navigation
 void AC_WPNav::set_speed_down_cms(float speed_down_cms)
 {
-    _pos_control.set_max_speed_accel_U_cm(speed_down_cms, _pos_control.get_max_speed_up_cms(), _pos_control.get_max_accel_U_cmss());
+    set_speed_down_ms(speed_down_cms * 0.01);
+}
+
+/// set current target descent rate during wp navigation
+void AC_WPNav::set_speed_down_ms(float speed_down_ms)
+{
+    _pos_control.set_max_speed_accel_U_m(speed_down_ms, _pos_control.get_max_speed_up_ms(), _pos_control.get_max_accel_U_mss());
     update_track_with_speed_accel_limits();
 }
 
@@ -245,15 +268,15 @@ void AC_WPNav::set_speed_down_cms(float speed_down_cms)
 bool AC_WPNav::set_wp_destination_loc(const Location& destination)
 {
     bool is_terrain_alt;
-    Vector3f dest_neu_cm;
+    Vector3f dest_neu_m;
 
     // convert destination location to vector
-    if (!get_vector_NEU_cm(destination, dest_neu_cm, is_terrain_alt)) {
+    if (!get_vector_NEU_m(destination, dest_neu_m, is_terrain_alt)) {
         return false;
     }
 
     // set target as vector from EKF origin
-    return set_wp_destination_NEU_cm(dest_neu_cm, is_terrain_alt);
+    return set_wp_destination_NEU_m(dest_neu_m, is_terrain_alt);
 }
 
 /// set next destination using location class
@@ -261,15 +284,15 @@ bool AC_WPNav::set_wp_destination_loc(const Location& destination)
 bool AC_WPNav::set_wp_destination_next_loc(const Location& destination)
 {
     bool is_terrain_alt;
-    Vector3f dest_neu_cm;
+    Vector3f dest_neu_m;
 
     // convert destination location to vector
-    if (!get_vector_NEU_cm(destination, dest_neu_cm, is_terrain_alt)) {
+    if (!get_vector_NEU_m(destination, dest_neu_m, is_terrain_alt)) {
         return false;
     }
 
     // set target as vector from EKF origin
-    return set_wp_destination_next_NEU_cm(dest_neu_cm, is_terrain_alt);
+    return set_wp_destination_next_NEU_m(dest_neu_m, is_terrain_alt);
 }
 
 // get destination as a location. Altitude frame will be above origin or above terrain
@@ -280,7 +303,7 @@ bool AC_WPNav::get_wp_destination_loc(Location& destination) const
         return false;
     }
 
-    destination = Location{get_wp_destination_NEU_cm(), _is_terrain_alt ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN};
+    destination = Location{get_wp_destination_NEU_m() * 100.0, _is_terrain_alt ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN};
     return true;
 }
 
@@ -289,23 +312,31 @@ bool AC_WPNav::get_wp_destination_loc(Location& destination) const
 ///     returns false on failure (likely caused by missing terrain data)
 bool AC_WPNav::set_wp_destination_NEU_cm(const Vector3f& destination_neu_cm, bool is_terrain_alt)
 {
+    return set_wp_destination_NEU_m(destination_neu_cm * 0.01, is_terrain_alt);
+}
+
+/// set_wp_destination_NEU_cm - set destination waypoints using position vectors (distance from ekf origin in cm)
+///     terrain_alt should be true if destination_neu_m.z is an altitude above terrain (false if alt-above-ekf-origin)
+///     returns false on failure (likely caused by missing terrain data)
+bool AC_WPNav::set_wp_destination_NEU_m(const Vector3f& destination_neu_m, bool is_terrain_alt)
+{
     // re-initialise if previous destination has been interrupted
     if (!is_active() || !_flags.reached_destination) {
-        wp_and_spline_init_cm(_wp_desired_speed_ne_cms);
+        wp_and_spline_init_m(_wp_desired_speed_ne_ms);
     }
 
     _scurve_prev_leg.init();
-    float origin_speed_cms = 0.0f;
+    float origin_speed_m = 0.0f;
 
     // use previous destination as origin
-    _origin_neu_cm = _destination_neu_cm;
+    _origin_neu_m = _destination_neu_m;
 
     if (is_terrain_alt == _is_terrain_alt) {
         if (_this_leg_is_spline) {
             // if previous leg was a spline we can use current target velocity vector for origin velocity vector
-            Vector3f curr_target_vel_neu_cms = _pos_control.get_vel_desired_NEU_cms();
-            curr_target_vel_neu_cms.z -= _pos_control.get_vel_offset_U_cms();
-            origin_speed_cms = curr_target_vel_neu_cms.length();
+            Vector3f curr_target_vel_neu_ms = _pos_control.get_vel_desired_NEU_ms();
+            curr_target_vel_neu_ms.z -= _pos_control.get_vel_offset_U_ms();
+            origin_speed_m = curr_target_vel_neu_ms.length();
         } else {
             // store previous leg
             _scurve_prev_leg = _scurve_this_leg;
@@ -313,44 +344,44 @@ bool AC_WPNav::set_wp_destination_NEU_cm(const Vector3f& destination_neu_cm, boo
     } else {
 
         // get current alt above terrain
-        float origin_terr_offset_u_cm;
-        if (!get_terrain_offset_cm(origin_terr_offset_u_cm)) {
+        float origin_terr_offset_u_m;
+        if (!get_terrain_offset_m(origin_terr_offset_u_m)) {
             return false;
         }
 
         // convert origin to alt-above-terrain if necessary
         if (is_terrain_alt) {
             // new destination is alt-above-terrain, previous destination was alt-above-ekf-origin
-            _origin_neu_cm.z -= origin_terr_offset_u_cm;
-            _pos_control.init_pos_terrain_U_cm(origin_terr_offset_u_cm);
+            _origin_neu_m.z -= origin_terr_offset_u_m;
+            _pos_control.init_pos_terrain_U_m(origin_terr_offset_u_m);
         } else {
             // new destination is alt-above-ekf-origin, previous destination was alt-above-terrain
-            _origin_neu_cm.z += origin_terr_offset_u_cm;
-            _pos_control.init_pos_terrain_U_cm(0.0);
+            _origin_neu_m.z += origin_terr_offset_u_m;
+            _pos_control.init_pos_terrain_U_m(0.0);
         }
     }
 
     // update destination
-    _destination_neu_cm = destination_neu_cm;
+    _destination_neu_m = destination_neu_m;
     _is_terrain_alt = is_terrain_alt;
 
     if (_flags.fast_waypoint && !_this_leg_is_spline && !_next_leg_is_spline && !_scurve_next_leg.finished()) {
         _scurve_this_leg = _scurve_next_leg;
     } else {
-        _scurve_this_leg.calculate_track(_origin_neu_cm, _destination_neu_cm,
-                                         _pos_control.get_max_speed_NE_cms(), _pos_control.get_max_speed_up_cms(), _pos_control.get_max_speed_down_cms(),
-                                         get_wp_acceleration_cmss(), _wp_accel_z_cmss,
-                                         _scurve_snap_max_mssss * 100.0f, _scurve_jerk_max_msss * 100.0f);
-        if (!is_zero(origin_speed_cms)) {
+        _scurve_this_leg.calculate_track(_origin_neu_m, _destination_neu_m,
+                                         _pos_control.get_max_speed_NE_ms(), _pos_control.get_max_speed_up_ms(), _pos_control.get_max_speed_down_ms(),
+                                         get_wp_acceleration_mss(), get_accel_U_mss(),
+                                         _scurve_snap_max_mssss, _scurve_jerk_max_msss);
+        if (!is_zero(origin_speed_m)) {
             // rebuild start of scurve if we have a non-zero origin speed
-            _scurve_this_leg.set_origin_speed_max(origin_speed_cms);
+            _scurve_this_leg.set_origin_speed_max(origin_speed_m);
         }
     }
 
     _this_leg_is_spline = false;
     _scurve_next_leg.init();
-    _next_destination_neu_cm.zero();    // clear next destination_neu_cm
-    _flags.fast_waypoint = false;       // default waypoint back to slow
+    _next_destination_neu_m.zero(); // clear next destination_neu_m
+    _flags.fast_waypoint = false;   // default waypoint back to slow
     _flags.reached_destination = false;
 
     return true;
@@ -361,19 +392,27 @@ bool AC_WPNav::set_wp_destination_NEU_cm(const Vector3f& destination_neu_cm, boo
 ///     provide next_destination_neu_cm
 bool AC_WPNav::set_wp_destination_next_NEU_cm(const Vector3f& destination_neu_cm, bool is_terrain_alt)
 {
+    return set_wp_destination_next_NEU_m(destination_neu_cm * 0.01, is_terrain_alt);
+}
+
+/// set next destination_neu_m using position vector (distance from ekf origin in m)
+///     terrain_alt should be true if destination_neu_m.z is a desired altitude above terrain
+///     provide next_destination_neu_m
+bool AC_WPNav::set_wp_destination_next_NEU_m(const Vector3f& destination_neu_m, bool is_terrain_alt)
+{
     // do not add next point if alt types don't match
     if (is_terrain_alt != _is_terrain_alt) {
         return true;
     }
 
-    _scurve_next_leg.calculate_track(_destination_neu_cm, destination_neu_cm,
-                                     _pos_control.get_max_speed_NE_cms(), _pos_control.get_max_speed_up_cms(), _pos_control.get_max_speed_down_cms(),
-                                     get_wp_acceleration_cmss(), _wp_accel_z_cmss,
-                                     _scurve_snap_max_mssss * 100.0f, _scurve_jerk_max_msss * 100.0);
+    _scurve_next_leg.calculate_track(_destination_neu_m, destination_neu_m,
+                                     _pos_control.get_max_speed_NE_ms(), _pos_control.get_max_speed_up_ms(), _pos_control.get_max_speed_down_ms(),
+                                     get_wp_acceleration_mss(), get_accel_U_mss(),
+                                     _scurve_snap_max_mssss, _scurve_jerk_max_msss);
     if (_this_leg_is_spline) {
-        const float this_leg_dest_speed_max = _spline_this_leg.get_destination_speed_max();
-        const float next_leg_origin_speed_max = _scurve_next_leg.set_origin_speed_max(this_leg_dest_speed_max);
-        _spline_this_leg.set_destination_speed_max(next_leg_origin_speed_max);
+        const float this_leg_dest_speed_max_ms = _spline_this_leg.get_destination_speed_max();
+        const float next_leg_origin_speed_max_ms = _scurve_next_leg.set_origin_speed_max(this_leg_dest_speed_max_ms);
+        _spline_this_leg.set_destination_speed_max(next_leg_origin_speed_max_ms);
     }
     _next_leg_is_spline = false;
 
@@ -381,7 +420,7 @@ bool AC_WPNav::set_wp_destination_next_NEU_cm(const Vector3f& destination_neu_cm
     _flags.fast_waypoint = true;
 
     // record next destination
-    _next_destination_neu_cm = destination_neu_cm;
+    _next_destination_neu_m = destination_neu_m;
 
     return true;
 }
@@ -390,112 +429,128 @@ bool AC_WPNav::set_wp_destination_next_NEU_cm(const Vector3f& destination_neu_cm
 bool AC_WPNav::set_wp_destination_NED_m(const Vector3f& destination_NED_m)
 {
     // convert NED to NEU and do not use terrain following
-    return set_wp_destination_NEU_cm(Vector3f(destination_NED_m.x * 100.0f, destination_NED_m.y * 100.0f, -destination_NED_m.z * 100.0f), false);
+    return set_wp_destination_NEU_m(Vector3f(destination_NED_m.x, destination_NED_m.y, -destination_NED_m.z), false);
 }
 
 /// set waypoint destination using NED position vector from ekf origin in meters
 bool AC_WPNav::set_wp_destination_next_NED_m(const Vector3f& destination_NED_m)
 {
     // convert NED to NEU and do not use terrain following
-    return set_wp_destination_next_NEU_cm(Vector3f(destination_NED_m.x * 100.0f, destination_NED_m.y * 100.0f, -destination_NED_m.z * 100.0f), false);
+    return set_wp_destination_next_NEU_m(Vector3f(destination_NED_m.x, destination_NED_m.y, -destination_NED_m.z), false);
 }
 
 /// get_wp_stopping_point_NE_cm - returns vector to stopping point based on a horizontal position and velocity
 void AC_WPNav::get_wp_stopping_point_NE_cm(Vector2f& stopping_point_ne_cm) const
 {
-    Vector2p stop_ne_cm;
-    _pos_control.get_stopping_point_NE_cm(stop_ne_cm);
-    stopping_point_ne_cm = stop_ne_cm.tofloat();
+    Vector2f stopping_point_ne_m = stopping_point_ne_cm * 0.01;
+    get_wp_stopping_point_NE_m(stopping_point_ne_m);
+    stopping_point_ne_cm = stopping_point_ne_m * 100.0;
 }
 
-/// get_wp_stopping_point_NEU_cm - returns vector to stopping point based on 3D position and velocity
+/// get_wp_stopping_point_NE_m - returns vector to stopping point based on a horizontal position and velocity
+void AC_WPNav::get_wp_stopping_point_NE_m(Vector2f& stopping_point_ne_m) const
+{
+    Vector2p stop_ne_m;
+    _pos_control.get_stopping_point_NE_m(stop_ne_m);
+    stopping_point_ne_m = stop_ne_m.tofloat();
+}
+
+/// get_wp_stopping_point_NE_cm - returns vector to stopping point based on a horizontal position and velocity
 void AC_WPNav::get_wp_stopping_point_NEU_cm(Vector3f& stopping_point_neu_cm) const
 {
-    Vector3p stop_neu_cm;
-    _pos_control.get_stopping_point_NE_cm(stop_neu_cm.xy());
-    _pos_control.get_stopping_point_U_cm(stop_neu_cm.z);
-    stopping_point_neu_cm = stop_neu_cm.tofloat();
+    Vector3f stopping_point_neu_m = stopping_point_neu_cm * 0.01;
+    get_wp_stopping_point_NEU_m(stopping_point_neu_m);
+    stopping_point_neu_cm = stopping_point_neu_m * 100.0;
+}
+
+/// get_wp_stopping_point_NEU_m - returns vector to stopping point based on 3D position and velocity
+void AC_WPNav::get_wp_stopping_point_NEU_m(Vector3f& stopping_point_neu_m) const
+{
+    Vector3p stop_neu_m;
+    _pos_control.get_stopping_point_NE_m(stop_neu_m.xy());
+    _pos_control.get_stopping_point_U_m(stop_neu_m.z);
+    stopping_point_neu_m = stop_neu_m.tofloat();
 }
 
 /// advance_wp_target_along_track - move target location along track from origin to destination
 bool AC_WPNav::advance_wp_target_along_track(float dt)
 {
     // calculate terrain adjustments
-    float terr_offset_u_cm = 0.0f;
-    if (_is_terrain_alt && !get_terrain_offset_cm(terr_offset_u_cm)) {
+    float terr_offset_u_m = 0.0f;
+    if (_is_terrain_alt && !get_terrain_offset_m(terr_offset_u_m)) {
         return false;
     }
-    const float offset_u_scalar = _pos_control.pos_terrain_U_scaler_cm(terr_offset_u_cm, get_terrain_margin_m() * 100.0);
+    const float offset_u_scalar = _pos_control.pos_terrain_U_scaler_m(terr_offset_u_m, get_terrain_margin_m());
 
     // input shape the terrain offset
-    _pos_control.set_pos_terrain_target_U_cm(terr_offset_u_cm);
+    _pos_control.set_pos_terrain_target_U_m(terr_offset_u_m);
 
     // get position controller's position offset (post input shaping) so it can be used in position error calculation
-    const Vector3p& psc_pos_offset_neu_cm = _pos_control.get_pos_offset_NEU_cm();
+    const Vector3p& psc_pos_offset_neu_m = _pos_control.get_pos_offset_NEU_m();
 
-    // get current position and adjust altitude to origin and destination's frame (i.e. _frame)
-    Vector3f curr_pos_neu_cm = _pos_control.get_pos_estimate_NEU_cm().tofloat() - psc_pos_offset_neu_cm.tofloat();
-    curr_pos_neu_cm.z -= terr_offset_u_cm;
-    Vector3f curr_target_vel_neu_cms = _pos_control.get_vel_desired_NEU_cms();
-    curr_target_vel_neu_cms.z -= _pos_control.get_vel_offset_U_cms();
+    // get current position and adjust altitude to origin and destination_neu_m's frame (i.e. _frame)
+    Vector3f curr_pos_neu_m = _pos_control.get_pos_estimate_NEU_m().tofloat() - psc_pos_offset_neu_m.tofloat();
+    curr_pos_neu_m.z -= terr_offset_u_m;
+    Vector3f curr_target_vel_neu_ms = _pos_control.get_vel_desired_NEU_ms();
+    curr_target_vel_neu_ms.z -= _pos_control.get_vel_offset_U_ms();
 
     // Use _track_dt_scalar to slow down progression of the position target moving too far in front of aircraft
     // _track_dt_scalar does not scale the velocity or acceleration
     float track_dt_scalar = 1.0f;
     // check target velocity is non-zero
-    if (is_positive(curr_target_vel_neu_cms.length_squared())) {
-        Vector3f track_direction_neu = curr_target_vel_neu_cms.normalized();
-        const float track_error_neu_cm = _pos_control.get_pos_error_NEU_cm().dot(track_direction_neu);
-        const float track_velocity_neu_cms = _pos_control.get_vel_estimate_NEU_cms().dot(track_direction_neu);
+    if (is_positive(curr_target_vel_neu_ms.length_squared())) {
+        Vector3f track_direction_neu = curr_target_vel_neu_ms.normalized();
+        const float track_error_neu_m = _pos_control.get_pos_error_NEU_m().dot(track_direction_neu);
+        const float track_velocity_neu_ms = _pos_control.get_vel_estimate_NEU_ms().dot(track_direction_neu);
         // set time scalar to be consistent with the achievable aircraft speed with a 5% buffer for short term variation.
-        track_dt_scalar = constrain_float(0.05f + (track_velocity_neu_cms - _pos_control.get_pos_NE_p().kP() * track_error_neu_cm) / curr_target_vel_neu_cms.length(), 0.0f, 1.0f);
+        track_dt_scalar = constrain_float(0.05f + (track_velocity_neu_ms - _pos_control.get_pos_NE_p().kP() * track_error_neu_m) / curr_target_vel_neu_ms.length(), 0.0f, 1.0f);
     }
 
     // Use vel_dt_scalar to slow down the trajectory time
     // vel_dt_scalar scales the velocity and acceleration to be kinematically consistent
     float vel_dt_scalar = 1.0;
-    if (is_positive(_wp_desired_speed_ne_cms)) {
-        update_vel_accel(_offset_vel_cms, _offset_accel_cmss, dt, 0.0, 0.0);
-        const float vel_input_cms = !_paused ? _wp_desired_speed_ne_cms * offset_u_scalar : 0.0;
-        shape_vel_accel(vel_input_cms, 0.0, _offset_vel_cms, _offset_accel_cmss, -get_wp_acceleration_cmss(), get_wp_acceleration_cmss(),
-                        _pos_control.get_shaping_jerk_NE_cmsss(), dt, true);
-        vel_dt_scalar = _offset_vel_cms / _wp_desired_speed_ne_cms;
+    if (is_positive(_wp_desired_speed_ne_ms)) {
+        update_vel_accel(_offset_vel_ms, _offset_accel_mss, dt, 0.0, 0.0);
+        const float vel_input_ms = !_paused ? _wp_desired_speed_ne_ms * offset_u_scalar : 0.0;
+        shape_vel_accel(vel_input_ms, 0.0, _offset_vel_ms, _offset_accel_mss, -get_wp_acceleration_mss(), get_wp_acceleration_mss(),
+                        _pos_control.get_shaping_jerk_NE_msss(), dt, true);
+        vel_dt_scalar = _offset_vel_ms / _wp_desired_speed_ne_ms;
     }
 
     // change s-curve time speed with a time constant of maximum acceleration / maximum jerk
     float track_dt_scalar_tc = 1.0f;
     if (!is_zero(_wp_jerk_msss)) {
-        track_dt_scalar_tc = 0.01f * get_wp_acceleration_cmss()/_wp_jerk_msss;
+        track_dt_scalar_tc = get_wp_acceleration_mss()/_wp_jerk_msss;
     }
     _track_dt_scalar += (track_dt_scalar - _track_dt_scalar) * (dt / track_dt_scalar_tc);
 
     // target position, velocity and acceleration from straight line or spline calculators
-    Vector3f target_pos_neu_cm, target_vel_neu_cms, target_accel_neu_cmss;
+    Vector3f target_pos_neu_m, target_vel_neu_ms, target_accel_neu_mss;
 
     bool s_finished;
     if (!_this_leg_is_spline) {
         // update target position, velocity and acceleration
-        target_pos_neu_cm = _origin_neu_cm;
-        s_finished = _scurve_this_leg.advance_target_along_track(_scurve_prev_leg, _scurve_next_leg, _wp_radius_cm, get_corner_acceleration_cmss(), _flags.fast_waypoint, _track_dt_scalar * vel_dt_scalar * dt, target_pos_neu_cm, target_vel_neu_cms, target_accel_neu_cmss);
+        target_pos_neu_m = _origin_neu_m;
+        s_finished = _scurve_this_leg.advance_target_along_track(_scurve_prev_leg, _scurve_next_leg, _wp_radius_cm * 0.01, get_corner_acceleration_mss(), _flags.fast_waypoint, _track_dt_scalar * vel_dt_scalar * dt, target_pos_neu_m, target_vel_neu_ms, target_accel_neu_mss);
     } else {
         // splinetarget_vel
-        target_vel_neu_cms = curr_target_vel_neu_cms;
-        _spline_this_leg.advance_target_along_track(_track_dt_scalar * vel_dt_scalar * dt, target_pos_neu_cm, target_vel_neu_cms);
+        target_vel_neu_ms = curr_target_vel_neu_ms;
+        _spline_this_leg.advance_target_along_track(_track_dt_scalar * vel_dt_scalar * dt, target_pos_neu_m, target_vel_neu_ms);
         s_finished = _spline_this_leg.reached_destination();
     }
 
-    Vector3f accel_offset_neu_cmss;
-    if (is_positive(target_vel_neu_cms.length_squared())) {
-        Vector3f track_direction_neu = target_vel_neu_cms.normalized();
-        accel_offset_neu_cmss = track_direction_neu * _offset_accel_cmss * target_vel_neu_cms.length() / _wp_desired_speed_ne_cms;
+    Vector3f accel_offset_neu_mss;
+    if (is_positive(target_vel_neu_ms.length_squared())) {
+        Vector3f track_direction_neu = target_vel_neu_ms.normalized();
+        accel_offset_neu_mss = track_direction_neu * _offset_accel_mss * target_vel_neu_ms.length() / _wp_desired_speed_ne_ms;
     }
 
-    target_vel_neu_cms *= vel_dt_scalar;
-    target_accel_neu_cmss *= sq(vel_dt_scalar);
-    target_accel_neu_cmss += accel_offset_neu_cmss;
+    target_vel_neu_ms *= vel_dt_scalar;
+    target_accel_neu_mss *= sq(vel_dt_scalar);
+    target_accel_neu_mss += accel_offset_neu_mss;
 
     // pass new target to the position controller
-    _pos_control.set_pos_vel_accel_NEU_cm(target_pos_neu_cm.topostype(), target_vel_neu_cms, target_accel_neu_cmss);
+    _pos_control.set_pos_vel_accel_NEU_m(target_pos_neu_m.topostype(), target_vel_neu_ms, target_accel_neu_mss);
 
     // check if we've reached the waypoint
     if (!_flags.reached_destination) {
@@ -505,8 +560,8 @@ bool AC_WPNav::advance_wp_target_along_track(float dt)
                 _flags.reached_destination = true;
             } else {
                 // regular waypoints also require the copter to be within the waypoint radius
-                const Vector3f dist_to_dest_cm = curr_pos_neu_cm - _destination_neu_cm;
-                if (dist_to_dest_cm.length_squared() <= sq(_wp_radius_cm)) {
+                const Vector3f dist_to_dest_m = curr_pos_neu_m - _destination_neu_m;
+                if (dist_to_dest_m.length_squared() <= sq(_wp_radius_cm * 0.01)) {
                     _flags.reached_destination = true;
                 }
             }
@@ -522,37 +577,43 @@ void AC_WPNav::update_track_with_speed_accel_limits()
 {
     // update this leg
     if (_this_leg_is_spline) {
-        _spline_this_leg.set_speed_accel(_pos_control.get_max_speed_NE_cms(), _pos_control.get_max_speed_up_cms(), _pos_control.get_max_speed_down_cms(),
-                                         get_wp_acceleration_cmss(), _wp_accel_z_cmss);
+        _spline_this_leg.set_speed_accel(_pos_control.get_max_speed_NE_ms(), _pos_control.get_max_speed_up_ms(), _pos_control.get_max_speed_down_ms(),
+                                         get_wp_acceleration_mss(), get_accel_U_mss());
     } else {
-        _scurve_this_leg.set_speed_max(_pos_control.get_max_speed_NE_cms(), _pos_control.get_max_speed_up_cms(), _pos_control.get_max_speed_down_cms());
+        _scurve_this_leg.set_speed_max(_pos_control.get_max_speed_NE_ms(), _pos_control.get_max_speed_up_ms(), _pos_control.get_max_speed_down_ms());
     }
 
     // update next leg
     if (_next_leg_is_spline) {
-        _spline_next_leg.set_speed_accel(_pos_control.get_max_speed_NE_cms(), _pos_control.get_max_speed_up_cms(), _pos_control.get_max_speed_down_cms(),
-                                         get_wp_acceleration_cmss(), _wp_accel_z_cmss);
+        _spline_next_leg.set_speed_accel(_pos_control.get_max_speed_NE_ms(), _pos_control.get_max_speed_up_ms(), _pos_control.get_max_speed_down_ms(),
+                                         get_wp_acceleration_mss(), get_accel_U_mss());
     } else {
-        _scurve_next_leg.set_speed_max(_pos_control.get_max_speed_NE_cms(), _pos_control.get_max_speed_up_cms(), _pos_control.get_max_speed_down_cms());
+        _scurve_next_leg.set_speed_max(_pos_control.get_max_speed_NE_ms(), _pos_control.get_max_speed_up_ms(), _pos_control.get_max_speed_down_ms());
     }
 }
 
 /// get_wp_distance_to_destination - get horizontal distance to destination in cm
 float AC_WPNav::get_wp_distance_to_destination_cm() const
 {
-    return get_horizontal_distance(_pos_control.get_pos_estimate_NEU_cm().xy().tofloat(), _destination_neu_cm.xy());
+    return get_wp_distance_to_destination_m() * 100.0;
+}
+
+/// get_wp_distance_to_destination - get horizontal distance to destination in m
+float AC_WPNav::get_wp_distance_to_destination_m() const
+{
+    return get_horizontal_distance(_pos_control.get_pos_estimate_NEU_m().xy().tofloat(), _destination_neu_m.xy());
 }
 
 /// get_wp_bearing_to_destination_cd - get bearing to next waypoint in centi-degrees
 int32_t AC_WPNav::get_wp_bearing_to_destination_cd() const
 {
-    return get_bearing_cd(_pos_control.get_pos_estimate_NEU_cm().xy().tofloat(), _destination_neu_cm.xy());
+    return get_bearing_cd(_pos_control.get_pos_estimate_NEU_m().xy().tofloat(), _destination_neu_m.xy());
 }
 
 /// get_wp_bearing_to_destination_cd - get bearing to next waypoint in centi-degrees
 float AC_WPNav::get_wp_bearing_to_destination_rad() const
 {
-    return get_bearing_rad(_pos_control.get_pos_estimate_NEU_cm().xy().tofloat(), _destination_neu_cm.xy());
+    return get_bearing_rad(_pos_control.get_pos_estimate_NEU_m().xy().tofloat(), _destination_neu_m.xy());
 }
 
 /// update_wpnav - run the wp controller - should be called at 100hz or higher
@@ -561,16 +622,16 @@ bool AC_WPNav::update_wpnav()
     // check for changes in speed parameter values
     if (_check_wp_speed_change) {
         if (!is_equal(_wp_speed_cms.get(), _last_wp_speed_cms)) {
-            set_speed_NE_cms(_wp_speed_cms);
+            set_speed_NE_ms(get_default_speed_NE_ms());
             _last_wp_speed_cms = _wp_speed_cms;
         }
     }
     if (!is_equal(_wp_speed_up_cms.get(), _last_wp_speed_up_cms)) {
-        set_speed_up_cms(_wp_speed_up_cms);
+        set_speed_up_ms(get_default_speed_up_ms());
         _last_wp_speed_up_cms = _wp_speed_up_cms;
     }
     if (!is_equal(_wp_speed_down_cms.get(), _last_wp_speed_down_cms)) {
-        set_speed_down_cms(_wp_speed_down_cms);
+        set_speed_down_ms(get_default_speed_down_ms());
         _last_wp_speed_down_cms = _wp_speed_down_cms;
     }
 
@@ -620,13 +681,23 @@ bool AC_WPNav::force_stop_at_next_wp()
 // get terrain's altitude (in cm above the ekf origin) at the current position (+ve means terrain below vehicle is above ekf origin's altitude)
 bool AC_WPNav::get_terrain_offset_cm(float& offset_cm)
 {
+    // call meter-version and convert to centimeters
+    float offset_m = offset_cm;
+    const bool ret = get_terrain_offset_m(offset_m);
+    offset_cm = offset_m * 100.0;
+    return ret;
+}
+
+// get terrain's altitude (in cm above the ekf origin) at the current position (+ve means terrain below vehicle is above ekf origin's altitude)
+bool AC_WPNav::get_terrain_offset_m(float& offset_m)
+{
     // calculate offset based on source (rangefinder or terrain database)
     switch (get_terrain_source()) {
     case AC_WPNav::TerrainSource::TERRAIN_UNAVAILABLE:
         return false;
     case AC_WPNav::TerrainSource::TERRAIN_FROM_RANGEFINDER:
         if (_rangefinder_healthy) {
-            offset_cm = _rangefinder_terrain_offset_cm;
+            offset_m = _rangefinder_terrain_offset_m;
             return true;
         }
         return false;
@@ -636,7 +707,7 @@ bool AC_WPNav::get_terrain_offset_cm(float& offset_cm)
         AP_Terrain *terrain = AP::terrain();
         if (terrain != nullptr &&
             terrain->height_above_terrain(terrain_alt_m, true)) {
-            offset_cm = _pos_control.get_pos_estimate_NEU_cm().z - (terrain_alt_m * 100.0);
+            offset_m = _pos_control.get_pos_estimate_NEU_m().z - terrain_alt_m;
             return true;
         }
 #endif
@@ -658,21 +729,21 @@ bool AC_WPNav::get_terrain_offset_cm(float& offset_cm)
 bool AC_WPNav::set_spline_destination_loc(const Location& destination, const Location& next_destination, bool next_is_spline)
 {
     // convert destination location to vector
-    Vector3f dest_neu;
+    Vector3f dest_neu_m;
     bool dest_is_terrain_alt;
-    if (!get_vector_NEU_cm(destination, dest_neu, dest_is_terrain_alt)) {
+    if (!get_vector_NEU_m(destination, dest_neu_m, dest_is_terrain_alt)) {
         return false;
     }
 
     // convert next destination to vector
-    Vector3f next_dest_neu_cm;
+    Vector3f next_dest_neu_m;
     bool next_dest_is_terrain_alt;
-    if (!get_vector_NEU_cm(next_destination, next_dest_neu_cm, next_dest_is_terrain_alt)) {
+    if (!get_vector_NEU_m(next_destination, next_dest_neu_m, next_dest_is_terrain_alt)) {
         return false;
     }
 
     // set target as vector from EKF origin
-    return set_spline_destination_NEU_cm(dest_neu, dest_is_terrain_alt, next_dest_neu_cm, next_dest_is_terrain_alt, next_is_spline);
+    return set_spline_destination_NEU_m(dest_neu_m, dest_is_terrain_alt, next_dest_neu_m, next_dest_is_terrain_alt, next_is_spline);
 }
 
 /// set next destination (e.g. the one after the current destination) as a spline segment specified as a location
@@ -681,109 +752,109 @@ bool AC_WPNav::set_spline_destination_loc(const Location& destination, const Loc
 bool AC_WPNav::set_spline_destination_next_loc(const Location& next_destination, const Location& next_next_destination, bool next_next_is_spline)
 {
     // convert next_destination location to vector
-    Vector3f next_dest_neu_cm;
+    Vector3f next_dest_neu_m;
     bool next_dest_is_terrain_alt;
-    if (!get_vector_NEU_cm(next_destination, next_dest_neu_cm, next_dest_is_terrain_alt)) {
+    if (!get_vector_NEU_m(next_destination, next_dest_neu_m, next_dest_is_terrain_alt)) {
         return false;
     }
 
     // convert next_next_destination to vector
-    Vector3f next_next_dest_neu;
-    bool next_next_dest_is_terrain_alt;
-    if (!get_vector_NEU_cm(next_next_destination, next_next_dest_neu, next_next_dest_is_terrain_alt)) {
+    Vector3f next_next_dest_neu_m;
+    bool next_next_dest_is_terr_alt;
+    if (!get_vector_NEU_m(next_next_destination, next_next_dest_neu_m, next_next_dest_is_terr_alt)) {
         return false;
     }
 
     // set target as vector from EKF origin
-    return set_spline_destination_next_NEU_cm(next_dest_neu_cm, next_dest_is_terrain_alt, next_next_dest_neu, next_next_dest_is_terrain_alt, next_next_is_spline);
+    return set_spline_destination_next_NEU_m(next_dest_neu_m, next_dest_is_terrain_alt, next_next_dest_neu_m, next_next_dest_is_terr_alt, next_next_is_spline);
 }
 
-/// set_spline_destination_NEU_cm waypoint using position vector (distance from ekf origin in cm)
-///     is_terrain_alt should be true if destination_neu_cm.z is a desired altitude above terrain (false if its desired altitudes above ekf origin)
-///     next_destination_neu_cm should be set to the next segment's destination
-///     next_is_terrain_alt should be true if next_destination_neu_cm.z is a desired altitude above terrain (false if its desired altitudes above ekf origin)
-///     next_destination_neu_cm.z  must be in the same "frame" as destination_neu_cm.z (i.e. if destination is a alt-above-terrain, next_destination should be too)
-bool AC_WPNav::set_spline_destination_NEU_cm(const Vector3f& destination_neu_cm, bool is_terrain_alt, const Vector3f& next_destination_neu_cm, bool next_is_terrain_alt, bool next_is_spline)
+/// set_spline_destination_NEU_m waypoint using position vector (distance from ekf origin in m)
+///     is_terrain_alt should be true if destination_neu_m.z is a desired altitude above terrain (false if its desired altitudes above ekf origin)
+///     next_destination_neu_m should be set to the next segment's destination
+///     next_is_terrain_alt should be true if next_destination_neu_m.z is a desired altitude above terrain (false if its desired altitudes above ekf origin)
+///     next_destination_neu_m.z  must be in the same "frame" as destination_neu_m.z (i.e. if destination is a alt-above-terrain, next_destination should be too)
+bool AC_WPNav::set_spline_destination_NEU_m(const Vector3f& destination_neu_m, bool is_terrain_alt, const Vector3f& next_destination_neu_m, bool next_is_terrain_alt, bool next_is_spline)
 {
     // re-initialise if previous destination has been interrupted
     if (!is_active() || !_flags.reached_destination) {
-        wp_and_spline_init_cm(_wp_desired_speed_ne_cms);
+        wp_and_spline_init_m(_wp_desired_speed_ne_ms);
     }
 
     // update spline calculators speeds and accelerations
-    _spline_this_leg.set_speed_accel(_pos_control.get_max_speed_NE_cms(), _pos_control.get_max_speed_up_cms(), _pos_control.get_max_speed_down_cms(),
-                                     _pos_control.get_max_accel_NE_cmss(), _pos_control.get_max_accel_U_cmss());
+    _spline_this_leg.set_speed_accel(_pos_control.get_max_speed_NE_ms(), _pos_control.get_max_speed_up_ms(), _pos_control.get_max_speed_down_ms(),
+                                     _pos_control.get_max_accel_NE_mss(), _pos_control.get_max_accel_U_mss());
 
     // calculate origin and origin velocity vector
-    Vector3f origin_vector_neu_cm;
+    Vector3f origin_vector_neu_m;
     if (is_terrain_alt == _is_terrain_alt) {
         if (_flags.fast_waypoint) {
             // calculate origin vector
             if (_this_leg_is_spline) {
                 // if previous leg was a spline we can use destination velocity vector for origin velocity vector
-                origin_vector_neu_cm = _spline_this_leg.get_destination_vel();
+                origin_vector_neu_m = _spline_this_leg.get_destination_vel();
             } else {
                 // use direction of the previous straight line segment
-                origin_vector_neu_cm = _destination_neu_cm - _origin_neu_cm;
+                origin_vector_neu_m = _destination_neu_m - _origin_neu_m;
             }
         }
 
         // use previous destination as origin
-        _origin_neu_cm = _destination_neu_cm;
+        _origin_neu_m = _destination_neu_m;
     } else {
 
         // use previous destination as origin
-        _origin_neu_cm = _destination_neu_cm;
+        _origin_neu_m = _destination_neu_m;
 
         // get current alt above terrain
-        float origin_terr_offset_u_cm;
-        if (!get_terrain_offset_cm(origin_terr_offset_u_cm)) {
+        float origin_terr_offset_u_m;
+        if (!get_terrain_offset_m(origin_terr_offset_u_m)) {
             return false;
         }
 
         // convert origin to alt-above-terrain if necessary
         if (is_terrain_alt) {
             // new destination is alt-above-terrain, previous destination was alt-above-ekf-origin
-            _origin_neu_cm.z -= origin_terr_offset_u_cm;
-            _pos_control.init_pos_terrain_U_cm(origin_terr_offset_u_cm);
+            _origin_neu_m.z -= origin_terr_offset_u_m;
+            _pos_control.init_pos_terrain_U_m(origin_terr_offset_u_m);
         } else {
             // new destination is alt-above-ekf-origin, previous destination was alt-above-terrain
-            _origin_neu_cm.z += origin_terr_offset_u_cm;
-            _pos_control.init_pos_terrain_U_cm(0.0);
+            _origin_neu_m.z += origin_terr_offset_u_m;
+            _pos_control.init_pos_terrain_U_m(0.0);
         }
     }
 
     // store destination location
-    _destination_neu_cm = destination_neu_cm;
+    _destination_neu_m = destination_neu_m;
     _is_terrain_alt = is_terrain_alt;
 
     // calculate destination velocity vector
-    Vector3f destination_vector_neu_cm;
+    Vector3f destination_vector_neu_m;
     if (is_terrain_alt == next_is_terrain_alt) {
         if (next_is_spline) {
             // leave this segment moving parallel to vector from origin to next destination
-            destination_vector_neu_cm = next_destination_neu_cm - _origin_neu_cm;
+            destination_vector_neu_m = next_destination_neu_m - _origin_neu_m;
         } else {
             // leave this segment moving parallel to next segment
-            destination_vector_neu_cm = next_destination_neu_cm - _destination_neu_cm;
+            destination_vector_neu_m = next_destination_neu_m - _destination_neu_m;
         }
     }
-    _flags.fast_waypoint = !destination_vector_neu_cm.is_zero();
+    _flags.fast_waypoint = !destination_vector_neu_m.is_zero();
 
     // setup spline leg
-    _spline_this_leg.set_origin_and_destination(_origin_neu_cm, _destination_neu_cm, origin_vector_neu_cm, destination_vector_neu_cm);
+    _spline_this_leg.set_origin_and_destination(_origin_neu_m, _destination_neu_m, origin_vector_neu_m, destination_vector_neu_m);
     _this_leg_is_spline = true;
     _flags.reached_destination = false;
 
     return true;
 }
 
-/// set next destination (e.g. the one after the current destination) as an offset (in cm, NEU frame) from the EKF origin
-///     next_is_terrain_alt should be true if next_destination_neu_cm.z is a desired altitude above terrain (false if its desired altitudes above ekf origin)
-///     next_next_destination_neu_cm should be set to the next segment's destination_neu_cm
-///     next_next_is_terrain_alt should be true if next_next_destination_neu_cm.z is a desired altitude above terrain (false if it is desired altitude above ekf origin)
-///     next_next_destination_neu_cm.z  must be in the same "frame" as destination_neu_cm.z (i.e. if next_destination is a alt-above-terrain, next_next_destination should be too)
-bool AC_WPNav::set_spline_destination_next_NEU_cm(const Vector3f& next_destination_neu_cm, bool next_is_terrain_alt, const Vector3f& next_next_destination_neu_cm, bool next_next_is_terrain_alt, bool next_next_is_spline)
+/// set next destination (e.g. the one after the current destination) as an offset (in m, NEU frame) from the EKF origin
+///     next_is_terrain_alt should be true if next_destination_neu_m.z is a desired altitude above terrain (false if its desired altitudes above ekf origin)
+///     next_next_destination_neu_m should be set to the next segment's destination_neu_m
+///     next_next_is_terrain_alt should be true if next_next_destination_neu_m.z is a desired altitude above terrain (false if it is desired altitude above ekf origin)
+///     next_next_destination_neu_m.z  must be in the same "frame" as destination_neu_m.z (i.e. if next_destination is a alt-above-terrain, next_next_destination should be too)
+bool AC_WPNav::set_spline_destination_next_NEU_m(const Vector3f& next_destination_neu_m, bool next_is_terrain_alt, const Vector3f& next_next_destination_neu_m, bool next_next_is_terrain_alt, bool next_next_is_spline)
 {
     // do not add next point if alt types don't match
     if (next_is_terrain_alt != _is_terrain_alt) {
@@ -791,33 +862,33 @@ bool AC_WPNav::set_spline_destination_next_NEU_cm(const Vector3f& next_destinati
     }
 
     // calculate origin and origin velocity vector
-    Vector3f origin_vector_neu_cm;
+    Vector3f origin_vector_neu_m;
     if (_this_leg_is_spline) {
         // if previous leg was a spline we can use destination velocity vector for origin velocity vector
-        origin_vector_neu_cm = _spline_this_leg.get_destination_vel();
+        origin_vector_neu_m = _spline_this_leg.get_destination_vel();
     } else {
         // use the direction of the previous straight line segment
-        origin_vector_neu_cm = _destination_neu_cm - _origin_neu_cm;
+        origin_vector_neu_m = _destination_neu_m - _origin_neu_m;
     }
 
     // calculate destination velocity vector
-    Vector3f destination_vector_neu_cm;
+    Vector3f destination_vector_neu_m;
     if (next_is_terrain_alt == next_next_is_terrain_alt) {
         if (next_next_is_spline) {
             // leave this segment moving parallel to vector from this leg's origin (i.e. prev leg's destination) to next next destination
-            destination_vector_neu_cm = next_next_destination_neu_cm - _destination_neu_cm;
+            destination_vector_neu_m = next_next_destination_neu_m - _destination_neu_m;
         } else {
             // leave this segment moving parallel to next segment
-            destination_vector_neu_cm = next_next_destination_neu_cm - next_destination_neu_cm;
+            destination_vector_neu_m = next_next_destination_neu_m - next_destination_neu_m;
         }
     }
 
     // update spline calculators speeds and accelerations
-    _spline_next_leg.set_speed_accel(_pos_control.get_max_speed_NE_cms(), _pos_control.get_max_speed_up_cms(), _pos_control.get_max_speed_down_cms(),
-                                     _pos_control.get_max_accel_NE_cmss(), _pos_control.get_max_accel_U_cmss());
+    _spline_next_leg.set_speed_accel(_pos_control.get_max_speed_NE_ms(), _pos_control.get_max_speed_up_ms(), _pos_control.get_max_speed_down_ms(),
+                                     _pos_control.get_max_accel_NE_mss(), _pos_control.get_max_accel_U_mss());
 
     // setup next spline leg.  Note this could be made local
-    _spline_next_leg.set_origin_and_destination(_destination_neu_cm, next_destination_neu_cm, origin_vector_neu_cm, destination_vector_neu_cm);
+    _spline_next_leg.set_origin_and_destination(_destination_neu_m, next_destination_neu_m, origin_vector_neu_m, destination_vector_neu_m);
     _next_leg_is_spline = true;
 
     // next destination provided so fast waypoint
@@ -837,33 +908,44 @@ bool AC_WPNav::set_spline_destination_next_NEU_cm(const Vector3f& next_destinati
 //      returns false if conversion failed (likely because terrain data was not available)
 bool AC_WPNav::get_vector_NEU_cm(const Location &loc, Vector3f &pos_from_origin_neu_cm, bool &is_terrain_alt)
 {
+    Vector3f pos_from_origin_neu_m = pos_from_origin_neu_cm * 0.01;
+    // perform vector conversion using meters interface
+    const bool ret = get_vector_NEU_m(loc, pos_from_origin_neu_m, is_terrain_alt);
+    pos_from_origin_neu_cm = pos_from_origin_neu_m * 100.0;
+    return ret;
+}
+
+// convert location to vector from ekf origin.  is_terrain_alt is set to true if resulting vector's z-axis should be treated as alt-above-terrain
+//      returns false if conversion failed (likely because terrain data was not available)
+bool AC_WPNav::get_vector_NEU_m(const Location &loc, Vector3f &pos_from_origin_neu_m, bool &is_terrain_alt)
+{
     // convert location to NE vector2f
-    Vector2f loc_pos_from_origin_neu_cm;
-    if (!loc.get_vector_xy_from_origin_NE_cm(loc_pos_from_origin_neu_cm)) {
+    Vector2f loc_pos_from_origin_neu_m;
+    if (!loc.get_vector_xy_from_origin_NE_m(loc_pos_from_origin_neu_m)) {
         return false;
     }
 
     // convert altitude
     if (loc.get_alt_frame() == Location::AltFrame::ABOVE_TERRAIN) {
-        int32_t terrain_alt_cm;
-        if (!loc.get_alt_cm(Location::AltFrame::ABOVE_TERRAIN, terrain_alt_cm)) {
+        float terrain_alt_m;
+        if (!loc.get_alt_m(Location::AltFrame::ABOVE_TERRAIN, terrain_alt_m)) {
             return false;
         }
-        pos_from_origin_neu_cm.z = terrain_alt_cm;
+        pos_from_origin_neu_m.z = terrain_alt_m;
         is_terrain_alt = true;
     } else {
         is_terrain_alt = false;
-        int32_t origin_alt_cm;
-        if (!loc.get_alt_cm(Location::AltFrame::ABOVE_ORIGIN, origin_alt_cm)) {
+        float origin_alt_m;
+        if (!loc.get_alt_m(Location::AltFrame::ABOVE_ORIGIN, origin_alt_m)) {
             return false;
         }
-        pos_from_origin_neu_cm.z = origin_alt_cm;
+        pos_from_origin_neu_m.z = origin_alt_m;
         is_terrain_alt = false;
     }
 
     // copy xy (we do this to ensure we do not adjust vector unless the overall conversion is successful
-    pos_from_origin_neu_cm.x = loc_pos_from_origin_neu_cm.x;
-    pos_from_origin_neu_cm.y = loc_pos_from_origin_neu_cm.y;
+    pos_from_origin_neu_m.x = loc_pos_from_origin_neu_m.x;
+    pos_from_origin_neu_m.y = loc_pos_from_origin_neu_m.y;
 
     return true;
 }

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -91,7 +91,7 @@ public:
 
     /// get_wp_destination_NEU_cm waypoint using position vector
     /// x,y are distance from ekf origin in cm
-    /// z may be cm above ekf origin or terrain (see origin_and_destination_are_terrain_alt method)
+    /// z may be cm above ekf origin or terrain (see origin_and_destination_are_is_terrain_alt method)
     const Vector3f &get_wp_destination_NEU_cm() const { return _destination_neu_cm; }
 
     /// get origin using position vector (distance from ekf origin in cm)

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -124,16 +124,6 @@ public:
     bool set_wp_destination_NED_m(const Vector3f& destination_NED_m);
     bool set_wp_destination_next_NED_m(const Vector3f& destination_NED_m);
 
-    /// shifts the origin and destination horizontally to the current position
-    ///     used to reset the track when taking off without horizontal position control
-    ///     relies on set_wp_destination_NEU_cm or set_wp_origin_and_destination having been called first
-    void shift_wp_origin_and_destination_to_current_pos_NE(); // todo: Not used
-
-    /// shifts the origin and destination horizontally to the achievable stopping point
-    ///     used to reset the track when horizontal navigation is enabled after having been disabled (see Copter's wp_navalt_min)
-    ///     relies on set_wp_destination_NEU_cm or set_wp_origin_and_destination having been called first
-    void shift_wp_origin_and_destination_to_stopping_point_NE(); // todo: Not used
-
     /// get_wp_stopping_point_cm - calculates stopping point based on current position, velocity, waypoint acceleration
     ///		results placed in stopping_position vector
     void get_wp_stopping_point_NE_cm(Vector2f& stopping_point_NE_cm) const;

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -12,7 +12,7 @@
 #include <AC_Avoidance/AC_Avoid.h>                 // Stop at fence library
 
 // maximum velocities and accelerations
-#define WPNAV_ACCELERATION_MS           2.5        // maximum horizontal acceleration in cm/s/s that wp navigation will request
+#define WPNAV_ACCELERATION_MS           2.5        // default horizontal acceleration limit for waypoint navigation (m/s²)
 
 class AC_WPNav
 {
@@ -21,16 +21,22 @@ public:
     /// Constructor
     AC_WPNav(const AP_AHRS_View& ahrs, AC_PosControl& pos_control, const AC_AttitudeControl& attitude_control);
 
-    /// provide rangefinder based terrain offset
-    /// terrain offset is the terrain's height above the EKF origin
+    // Sets terrain offset in cm from EKF origin using rangefinder.
+    // See set_rangefinder_terrain_offset_m() for full details.
     void set_rangefinder_terrain_offset_cm(bool use, bool healthy, float terrain_offset_cm) { _rangefinder_available = use; _rangefinder_healthy = healthy; _rangefinder_terrain_offset_m = terrain_offset_cm * 0.01;}
+
+    // Sets terrain offset in meters from EKF origin using rangefinder data.
+    // This value is used to determine alt-above-terrain for terrain following.
     void set_rangefinder_terrain_offset_m(bool use, bool healthy, float terrain_offset_m) { _rangefinder_available = use; _rangefinder_healthy = healthy; _rangefinder_terrain_offset_m = terrain_offset_m;}
 
-    // return true if range finder may be used for terrain following
+    // Returns true if rangefinder is enabled and may be used for terrain following.
     bool rangefinder_used() const { return _rangefinder_use; }
+
+    // Returns true if rangefinder is enabled and currently healthy.
     bool rangefinder_used_and_healthy() const { return _rangefinder_use && _rangefinder_healthy; }
 
-    // get expected source of terrain data if alt-above-terrain command is executed (used by Copter's ModeRTL)
+    // Returns the expected source of terrain data when using alt-above-terrain commands.
+    // Used by systems like ModeRTL to determine which terrain provider is active.
     enum class TerrainSource {
         TERRAIN_UNAVAILABLE,
         TERRAIN_FROM_RANGEFINDER,
@@ -38,214 +44,328 @@ public:
     };
     AC_WPNav::TerrainSource get_terrain_source() const;
 
-    // get terrain's altitude (in cm above the ekf origin) at the current position (+ve means terrain below vehicle is above ekf origin's altitude)
+    // Returns terrain offset in cm above the EKF origin at the current position.
+    // See get_terrain_offset_m() for full details.
     bool get_terrain_offset_cm(float& offset_cm);
+
+    // Returns terrain offset in meters above the EKF origin at the current position.
+    // Positive values mean terrain lies above the EKF origin altitude.
+    // Source may be rangefinder or terrain database depending on availability.
     bool get_terrain_offset_m(float& offset_m);
 
-    // return terrain following altitude margin.  vehicle will stop if distance from target altitude is larger than this margin
+    // Returns the terrain following altitude margin in meters.
+    // Vehicle will stop if distance from target altitude exceeds this margin.
     float get_terrain_margin_m() const { return MAX(_terrain_margin_m, 0.1); }
 
-    // convert location to vector from ekf origin.  is_terrain_alt is set to true if resulting vector's z-axis should be treated as alt-above-terrain
-    //      returns false if conversion failed (likely because terrain data was not available)
+    // Converts a Location to a NEU position vector in cm from the EKF origin.
+    // See get_vector_NEU_m() for full details.
     bool get_vector_NEU_cm(const Location &loc, Vector3f &pos_from_origin_NEU_cm, bool &is_terrain_alt);
+
+    // Converts a Location to a NEU position vector in meters from the EKF origin.
+    // Sets `is_terrain_alt` to true if the resulting Z position is relative to terrain.
+    // Returns false if terrain data is unavailable or conversion fails.
     bool get_vector_NEU_m(const Location &loc, Vector3f &pos_from_origin_NEU_m, bool &is_terrain_alt);
 
     ///
     /// waypoint controller
     ///
 
-    /// wp_and_spline_init_cm - initialise straight line and spline waypoint controllers
-    ///     speed_cms is the desired max speed to travel between waypoints.  should be a positive value or omitted to use the default speed
-    ///     updates target roll, pitch targets and I terms based on vehicle lean angles
-    ///     should be called once before the waypoint controller is used but does not need to be called before subsequent updates to destination
+    // Initializes waypoint and spline controllers using inputs in cm.
+    // See wp_and_spline_init_m() for full details.
     void wp_and_spline_init_cm(float speed_cms = 0.0f, Vector3f stopping_point_neu_cm = Vector3f{});
+
+    // Initializes waypoint and spline navigation using inputs in meters.
+    // Sets speed and acceleration limits, calculates jerk constraints,
+    // and initializes spline or S-curve leg with a defined starting point.
     void wp_and_spline_init_m(float speed_ms = 0.0f, Vector3f stopping_point_neu_m = Vector3f{});
 
-    /// set current target horizontal speed during wp navigation
+    // Sets the target horizontal speed in cm/s during waypoint navigation.
+    // See set_speed_NE_ms() for full details.
     void set_speed_NE_cms(float speed_cms);
+
+    // Sets the target horizontal speed in m/s during waypoint navigation.
+    // Also updates internal velocity offsets and path shaping limits.
     void set_speed_NE_ms(float speed_ms);
 
-    /// set pause or resume during wp navigation
+    // Pauses progression along the waypoint track.
     void set_pause() { _paused = true; }
+
+    // Resumes waypoint navigation after a pause. Track advancement continues from the current position.
     void set_resume() { _paused = false; }
 
-    /// get paused status
+    // Returns true if waypoint navigation is currently paused via set_pause().
     bool paused() { return _paused; }
 
-    /// set current target climb or descent rate during wp navigation
+    // Sets the climb speed for waypoint navigation in cm/s.
+    // See set_speed_up_ms() for full details.
     void set_speed_up_cms(float speed_up_cms);
+
+    // Sets the climb speed for waypoint navigation in m/s.
+    // Updates the vertical controller with the new ascent rate limit.
     void set_speed_up_ms(float speed_up_ms);
+
+    // Sets the descent speed for waypoint navigation in cm/s.
+    // See set_speed_down_ms() for full details.
     void set_speed_down_cms(float speed_down_cms);
+
+    // Sets the descent speed for waypoint navigation in m/s.
+    // Updates the vertical controller with the new descent rate limit.
     void set_speed_down_ms(float speed_down_ms);
 
-    /// get default target horizontal velocity during wp navigation
+    // Returns the default horizontal speed in cm/s used during waypoint navigation.
+    // See get_default_speed_NE_ms() for full details.
     float get_default_speed_NE_cms() const { return get_default_speed_NE_ms() * 100.0; }
+
+    // Returns the default horizontal speed in m/s used during waypoint navigation.
+    // Derived from the WPNAV_SPEED parameter.
     float get_default_speed_NE_ms() const { return _wp_speed_cms * 0.01; }
 
-    /// get default target climb speed in cm/s during missions
+    // Returns the default climb speed in cm/s used during waypoint navigation.
+    // See get_default_speed_up_ms() for full details.
     float get_default_speed_up_cms() const { return get_default_speed_up_ms() * 100.0; }
+
+    // Returns the default climb speed in m/s used during waypoint navigation.
+    // Derived from the WPNAV_SPEED_UP parameter.
     float get_default_speed_up_ms() const { return _wp_speed_up_cms * 0.01; }
 
-    /// get default target descent rate in cm/s during missions.  Note: always positive
+    // Returns the default descent rate in cm/s used during waypoint navigation.
+    // Always positive. See get_default_speed_down_ms() for full details.
     float get_default_speed_down_cms() const { return get_default_speed_down_ms() * 100.0; }
+
+    // Returns the default descent rate in m/s used during waypoint navigation.
+    // Derived from the WPNAV_SPEED_DN parameter. Always positive.
     float get_default_speed_down_ms() const { return fabsf(_wp_speed_down_cms * 0.01); }
 
-    /// get_accel_U_cmss - returns vertical acceleration in cm/s/s during missions.  Note: always positive
+    // Returns the vertical acceleration in cm/s² used during waypoint navigation.
+    // Always positive. See get_accel_U_mss() for full details.
     float get_accel_U_cmss() const { return get_accel_U_mss() * 100.0; }
+
+    // Returns the vertical acceleration in m/s² used during waypoint navigation.
+    // Derived from the WPNAV_ACCEL_Z parameter. Always positive.
     float get_accel_U_mss() const { return _wp_accel_z_cmss * 0.01; }
 
-    /// get_wp_acceleration - returns acceleration in cm/s/s during missions
+    // Returns the horizontal acceleration in cm/s² used during waypoint navigation.
+    // See get_wp_acceleration_mss() for full details.
     float get_wp_acceleration_cmss() const { return get_wp_acceleration_mss() * 100.0; }
+
+    // Returns the horizontal acceleration in m/s² used during waypoint navigation.
+    // Derived from the WPNAV_ACCEL parameter. Falls back to a default if unset.
     float get_wp_acceleration_mss() const { return (is_positive(_wp_accel_cmss)) ? _wp_accel_cmss * 0.01 : WPNAV_ACCELERATION_MS; }
 
-    /// get_corner_acceleration_mss - returns maximum acceleration in m/s/s used during cornering in missions
+    // Returns the maximum lateral acceleration in m/s² used during waypoint cornering.
+    // Derived from WPNAV_ACCEL_C or defaults to 2x WPNAV_ACCEL if unset.
     float get_corner_acceleration_mss() const { return (is_positive(_wp_accel_c_cmss)) ? _wp_accel_c_cmss * 0.01 : 2.0 * get_wp_acceleration_mss(); }
 
-    /// get_wp_destination_NEU_cm waypoint using position vector
-    /// x,y are distance from ekf origin in cm
-    /// z may be cm above ekf origin or terrain (see origin_and_destination_are_is_terrain_alt method)
+    // Returns the destination waypoint vector in NEU frame, in centimeters from EKF origin.
+    // See get_wp_destination_NEU_m() for full details.
     const Vector3f get_wp_destination_NEU_cm() const { return get_wp_destination_NEU_m() * 100.0; }
+
+    // Returns the destination waypoint vector in NEU frame, in meters from EKF origin.
+    // Z is relative to terrain or EKF origin, depending on _is_terrain_alt.
     const Vector3f &get_wp_destination_NEU_m() const { return _destination_neu_m; }
 
-    /// get origin using position vector (distance from ekf origin in cm)
+    // Returns the origin waypoint vector in NEU frame, in centimeters from EKF origin.
+    // See get_wp_origin_NEU_m() for full details.
     const Vector3f get_wp_origin_NEU_cm() const { return get_wp_origin_NEU_m() * 100.0; }
+
+    // Returns the origin waypoint vector in NEU frame, in meters from EKF origin.
+    // This marks the start of the current waypoint leg.
     const Vector3f &get_wp_origin_NEU_m() const { return _origin_neu_m; }
 
-    /// true if origin.z and destination.z are alt-above-terrain, false if alt-above-ekf-origin
+    // Returns true if origin.z and destination.z are specified as altitudes above terrain.
+    // Returns false if altitudes are relative to the EKF origin.
     bool origin_and_destination_are_terrain_alt() const { return _is_terrain_alt; }
 
-    /// set_wp_destination_NEU_cm waypoint using location class
-    ///     provide the next_destination if known
-    ///     returns false if conversion from location to vector from ekf origin cannot be calculated
+    // Sets the current waypoint destination using a Location object.
+    // Converts global coordinates to NEU position and sets destination.
+    // Returns false if conversion fails (e.g. missing terrain data).
     bool set_wp_destination_loc(const Location& destination);
+
+    // Sets the next waypoint destination using a Location object.
+    // Converts global coordinates to NEU position and preloads the trajectory.
+    // Returns false if conversion fails or terrain data is unavailable.
     bool set_wp_destination_next_loc(const Location& destination);
 
-    // get destination as a location.  Altitude frame will be absolute (AMSL) or above terrain
-    // returns false if unable to return a destination (for example if origin has not yet been set)
+    // Gets the current waypoint destination as a Location object.
+    // Altitude frame will be ABOVE_TERRAIN or ABOVE_ORIGIN depending on path configuration.
+    // Returns false if origin is not set or coordinate conversion fails.
     bool get_wp_destination_loc(Location& destination) const;
 
-    // returns object avoidance adjusted destination which is always the same as get_wp_destination_NEU_cm
-    // having this function unifies the AC_WPNav_OA and AC_WPNav interfaces making vehicle code simpler
+    // Returns the waypoint destination adjusted for object avoidance.
+    // In the base class this is identical to get_wp_destination_loc().
+    // Used to unify the AC_WPNav and AC_WPNav_OA interfaces.
     virtual bool get_oa_wp_destination(Location& destination) const { return get_wp_destination_loc(destination); }
 
-    /// set_wp_destination_NEU_cm waypoint using position vector (distance from ekf origin in cm)
-    ///     is_terrain_alt should be true if destination.z is a desired altitude above terrain
+    // Sets waypoint destination using NEU position vector in centimeters from EKF origin.
+    // See set_wp_destination_NEU_m() for full details.
     virtual bool set_wp_destination_NEU_cm(const Vector3f& destination_neu_cm, bool is_terrain_alt = false);
+
+    // Sets waypoint destination using NEU position vector in meters from EKF origin.
+    // If `is_terrain_alt` is true, altitude is interpreted as height above terrain.
+    // Reinitializes the current leg if interrupted, updates origin, and computes trajectory.
+    // Returns false if terrain offset cannot be determined when required.
     virtual bool set_wp_destination_NEU_m(const Vector3f& destination_neu_m, bool is_terrain_alt = false);
+
+    // Sets the next waypoint destination using a NEU position vector in centimeters.
+    // See set_wp_destination_next_NEU_m() for full details.
     bool set_wp_destination_next_NEU_cm(const Vector3f& destination_neu_cm, bool is_terrain_alt = false);
+
+    // Sets the next waypoint destination using a NEU position vector in meters.
+    // Only updates if terrain frame matches current leg.
+    // Calculates trajectory preview for smoother transition into next segment.
+    // Updates velocity handoff if previous leg is a spline.
     bool set_wp_destination_next_NEU_m(const Vector3f& destination_neu_m, bool is_terrain_alt = false);
 
-    /// set waypoint destination using NED position vector from ekf origin in meters
-    ///     provide next_destination_NED if known
+    // Sets waypoint destination using a NED position vector in meters from EKF origin.
+    // Converts internally to NEU. Terrain following is not used.
     bool set_wp_destination_NED_m(const Vector3f& destination_NED_m);
+
+    // Sets the next waypoint destination using a NED position vector in meters from EKF origin.
+    // Converts to NEU internally. Terrain following is not applied.
     bool set_wp_destination_next_NED_m(const Vector3f& destination_NED_m);
 
-    /// get_wp_stopping_point_cm - calculates stopping point based on current position, velocity, waypoint acceleration
-    ///		results placed in stopping_position vector
+    // Computes the horizontal stopping point in NE frame, returned in centimeters.
+    // See get_wp_stopping_point_NE_m() for full details.
     void get_wp_stopping_point_NE_cm(Vector2f& stopping_point_ne_cm) const;
+
+    // Computes the horizontal stopping point in NE frame, in meters, based on current velocity and configured acceleration.
+    // This is the point where the vehicle would come to a stop if decelerated using the configured limits.
     void get_wp_stopping_point_NE_m(Vector2f& stopping_point_ne_m) const;
+
+    // Computes the full 3D NEU stopping point vector in centimeters based on current kinematics.
+    // See get_wp_stopping_point_NEU_m() for full details.
     void get_wp_stopping_point_NEU_cm(Vector3f& stopping_point_neu_cm) const;
+
+    // Computes the full 3D NEU stopping point in meters based on current velocity and configured acceleration in all axes.
+    // Represents where the vehicle will stop if decelerated from current velocity using configured limits.
     void get_wp_stopping_point_NEU_m(Vector3f& stopping_point_neu_m) const;
 
-    /// get_wp_distance_to_destination - get horizontal distance to destination in cm
+    // Returns the horizontal distance to the destination waypoint in centimeters.
+    // See get_wp_distance_to_destination_m() for full details.
     virtual float get_wp_distance_to_destination_cm() const;
+
+    // Returns the horizontal distance in meters between the current position and the destination waypoint.
     virtual float get_wp_distance_to_destination_m() const;
 
-    /// get_bearing_to_destination - get bearing to next waypoint in centi-degrees
+    // Returns the bearing to the current waypoint destination in centidegrees.
+    // See get_wp_bearing_to_destination_rad() for full details.
     virtual int32_t get_wp_bearing_to_destination_cd() const;
 
-    /// get_bearing_to_destination - get bearing to next waypoint in radians
+    // Returns the bearing to the current waypoint destination in radians.
+    // The bearing is measured clockwise from North, with 0 = North.
     virtual float get_wp_bearing_to_destination_rad() const;
 
-    /// reached_destination - true when we have come within RADIUS cm of the waypoint
+    // Returns true if the vehicle has reached the waypoint destination.
+    // A waypoint is considered reached when the vehicle comes within the defined radius threshold.
     virtual bool reached_wp_destination() const { return _flags.reached_destination; }
 
-    // reached_wp_destination_NE - true if within RADIUS_CM of waypoint in x/y
+    // Returns true if the vehicle's horizontal (NE) distance to the waypoint is less than the waypoint radius.
+    // Uses the waypoint radius in meters for comparison.
     bool reached_wp_destination_NE() const {
         return get_wp_distance_to_destination_m() < _wp_radius_cm * 0.01;
     }
 
-    // get wp_radius parameter value in cm
+    // Returns the waypoint acceptance radius in centimeters.
+    // See get_wp_radius_m() for full details.
     float get_wp_radius_cm() const { return get_wp_radius_m() * 100.0; }
+
+    // Returns the waypoint acceptance radius in meters.
+    // This radius defines the distance from the target waypoint within which the vehicle is considered to have arrived.
     float get_wp_radius_m() const { return _wp_radius_cm * 0.01; }
 
-    /// update_wpnav - run the wp controller - should be called at 100hz or higher
+    // Runs the waypoint navigation controller.
+    // Advances the target position and updates the position controller.
+    // Should be called at 100 Hz or higher for accurate tracking.
     virtual bool update_wpnav();
 
-    // returns true if update_wpnav has been run very recently
+    // Returns true if update_wpnav() has been called within the last 200 ms.
+    // Used to check if waypoint navigation is currently active.
     bool is_active() const;
 
-    // force stopping at next waypoint.  Used by Dijkstra's object avoidance when path from destination to next destination is not clear
-    // only affects regular (e.g. non-spline) waypoints
-    // returns true if this had any affect on the path
+    // Forces a stop at the next waypoint instead of continuing to the subsequent one.
+    // Used by Dijkstra’s object avoidance when the future path is obstructed.
+    // Only affects regular (non-spline) waypoints.
+    // Returns true if the stop behavior was newly enforced.
     bool force_stop_at_next_wp();
 
     ///
     /// spline methods
     ///
 
-    /// set_spline_destination_NEU_cm waypoint using location class
-    ///     returns false if conversion from location to vector from ekf origin cannot be calculated
-    ///     next_destination should be the next segment's destination
-    ///     next_is_spline should be true if next_destination is a spline segment
+    // Sets the current spline waypoint using global coordinates.
+    // Converts `destination` and `next_destination` to NEU position vectors and sets up a spline between them.
+    // Returns false if conversion from location to vector fails.
     bool set_spline_destination_loc(const Location& destination, const Location& next_destination, bool next_is_spline);
 
-    /// set next destination (e.g. the one after the current destination) as a spline segment specified as a location
-    ///     returns false if conversion from location to vector from ekf origin cannot be calculated
-    ///     next_next_destination should be the next segment's destination
-    ///     next_next_is_spline should be true if next_next_destination is a spline segment
+    // Sets the next spline segment using global coordinates.
+    // Converts the next and next-next destinations to NEU position vectors and initializes the spline transition.
+    // Returns false if any conversion from location to vector fails.
     bool set_spline_destination_next_loc(const Location& next_destination, const Location& next_next_destination, bool next_next_is_spline);
 
-    /// set_spline_destination_NEU_cm waypoint using position vector (distance from ekf origin in cm)
-    ///     is_terrain_alt should be true if destination.z is a desired altitude above terrain (false if its desired altitudes above ekf origin)
-    ///     next_destination is the next segment's destination
-    ///     next_is_terrain_alt should be true if next_destination.z is a desired altitude above terrain (false if its desired altitudes above ekf origin)
-    ///     next_destination.z must be in the same "frame" as destination.z (i.e. if destination is a alt-above-terrain, next_destination must be too)
-    ///     next_is_spline should be true if next_destination is a spline segment
+    // Sets the current spline segment using position vectors in centimeters.
+    // See set_spline_destination_NEU_m() for full details.
     bool set_spline_destination_NEU_cm(const Vector3f& destination_neu_cm, bool is_terrain_alt, const Vector3f& next_destination_neu_cm, bool next_terrain_alt, bool next_is_spline);
+
+    // Sets the current spline waypoint using NEU position vectors in meters.
+    // Initializes a spline path from `destination_neu_m` to `next_destination_neu_m`, respecting terrain altitude framing.
+    // Both waypoints must use the same altitude frame (either above terrain or above origin).
+    // Returns false if terrain altitude cannot be determined when required.
     bool set_spline_destination_NEU_m(const Vector3f& destination_neu_m, bool is_terrain_alt, const Vector3f& next_destination_neu_m, bool next_terrain_alt, bool next_is_spline);
 
-    /// set next destination (e.g. the one after the current destination) as an offset (in cm, NEU frame) from the EKF origin
-    ///     next_is_terrain_alt should be true if next_destination.z is a desired altitude above terrain (false if its desired altitudes above ekf origin)
-    ///     next_next_destination is the next segment's destination
-    ///     next_next_is_terrain_alt should be true if next_next_destination.z is a desired altitude above terrain (false if it is desired altitude above ekf origin)
-    ///     next_next_destination.z must be in the same "frame" as destination.z (i.e. if next_destination is a alt-above-terrain, next_next_destination must be too)
-    ///     next_next_is_spline should be true if next_next_destination is a spline segment
+    // Sets the next spline segment using NEU position vectors in centimeters.
+    // See set_spline_destination_next_NEU_m() for full details.
     bool set_spline_destination_next_NEU_cm(const Vector3f& next_destination_neu_cm, bool next_is_terrain_alt, const Vector3f& next_next_destination_neu_cm, bool next_next_is_terrain_alt, bool next_next_is_spline);
+
+    // Sets the next spline segment using NEU position vectors in meters.
+    // Creates a spline path from the current destination to `next_destination_neu_m`, and prepares transition toward `next_next_destination_neu_m`.
+    // All waypoints must use the same altitude frame (above terrain or origin).
+    // Returns false if terrain data is missing and required.
     bool set_spline_destination_next_NEU_m(const Vector3f& next_destination_neu_m, bool next_is_terrain_alt, const Vector3f& next_next_destination_neu_m, bool next_next_is_terrain_alt, bool next_next_is_spline);
 
     ///
     /// shared methods
     ///
 
-    /// Returns the desired roll angle in radians from the position controller.
+    // Returns the desired roll angle in radians from the position controller.
+    // This value is passed to the attitude controller to achieve lateral motion.
     float get_roll_rad() const { return _pos_control.get_roll_rad(); }
 
-    /// Returns the desired pitch angle in radians from the position controller.
+    // Returns the desired pitch angle in radians from the position controller.
+    // This angle controls forward or backward acceleration.
     float get_pitch_rad() const { return _pos_control.get_pitch_rad(); }
 
-    /// Returns the desired yaw target in radians from the position controller.
+    // Returns the desired yaw angle in radians from the position controller.
+    // Used to align the vehicle heading with track direction or command input.
     float get_yaw_rad() const { return _pos_control.get_yaw_rad(); }
 
-    /// Returns the desired thrust direction vector for tilt control from the position controller.
+    // Returns the desired 3D unit vector representing the commanded thrust direction.
+    // Used to calculate tilt angles for the attitude controller.
     Vector3f get_thrust_vector() const { return _pos_control.get_thrust_vector(); }
 
-    /// Returns the desired roll angle in centidegrees from the position controller.
+    // Returns the desired roll angle in centidegrees from the position controller.
+    // See get_roll_rad() for full details.
     float get_roll() const { return _pos_control.get_roll_cd(); }
 
-    /// Returns the desired pitch angle in centidegrees from the position controller.
+    // Returns the desired pitch angle in centidegrees from the position controller.
+    // See get_pitch_rad() for full details.
     float get_pitch() const { return _pos_control.get_pitch_cd(); }
 
-    /// Returns the desired yaw target in centidegrees from the position controller.
+    // Returns the desired yaw angle in centidegrees from the position controller.
+    // See get_yaw_rad() for full details.
     float get_yaw() const { return _pos_control.get_yaw_cd(); }
 
-    /// advance_wp_target_along_track - move target location along track from origin to destination
+    // Advances the target location along the current path segment.
+    // Updates target position, velocity, and acceleration based on jerk-limited profile (or spline).
+    // Returns true if the update succeeded (e.g., terrain data was available).
     bool advance_wp_target_along_track(float dt);
 
-    /// recalculate path with update speed and/or acceleration limits
+    // Updates the current and next path segment to reflect new speed and acceleration limits.
+    // Should be called after modifying NE/U controller limits or vehicle configuration.
     void update_track_with_speed_accel_limits();
 
-    /// return the crosstrack_error - horizontal error of the actual position vs the desired position
+    // Returns lateral (cross-track) position error in meters.
+    // Computed as the perpendicular distance between current position and the planned path.
+    // Used to assess horizontal deviation from the trajectory.
     float crosstrack_error() const { return _pos_control.crosstrack_error();}
 
     static const struct AP_Param::GroupInfo var_info[];
@@ -259,11 +379,11 @@ protected:
         uint8_t wp_yaw_set              : 1;    // true if yaw target has been set
     } _flags;
 
-    // helper function to calculate scurve jerk and jerk_time values
-    // updates _scurve_jerk_max_msss and _scurve_snap_max_mssss
+    // Calculates s-curve jerk and snap limits based on attitude controller capabilities.
+    // Updates _scurve_jerk_max_msss and _scurve_snap_max_mssss with constrained values.
     void calc_scurve_jerk_and_snap();
 
-    // references and pointers to external libraries
+    // References to shared sensor fusion, position, and attitude control subsystems.
     const AP_AHRS_View&     _ahrs;
     AC_PosControl&          _pos_control;
     const AC_AttitudeControl& _attitude_control;

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -12,7 +12,7 @@
 #include <AC_Avoidance/AC_Avoid.h>                 // Stop at fence library
 
 // maximum velocities and accelerations
-#define WPNAV_ACCELERATION              250.0f      // maximum horizontal acceleration in cm/s/s that wp navigation will request
+#define WPNAV_ACCELERATION_MS           2.5        // maximum horizontal acceleration in cm/s/s that wp navigation will request
 
 class AC_WPNav
 {
@@ -23,7 +23,8 @@ public:
 
     /// provide rangefinder based terrain offset
     /// terrain offset is the terrain's height above the EKF origin
-    void set_rangefinder_terrain_offset_cm(bool use, bool healthy, float terrain_offset_cm) { _rangefinder_available = use; _rangefinder_healthy = healthy; _rangefinder_terrain_offset_cm = terrain_offset_cm;}
+    void set_rangefinder_terrain_offset_cm(bool use, bool healthy, float terrain_offset_cm) { _rangefinder_available = use; _rangefinder_healthy = healthy; _rangefinder_terrain_offset_m = terrain_offset_cm * 0.01;}
+    void set_rangefinder_terrain_offset_m(bool use, bool healthy, float terrain_offset_m) { _rangefinder_available = use; _rangefinder_healthy = healthy; _rangefinder_terrain_offset_m = terrain_offset_m;}
 
     // return true if range finder may be used for terrain following
     bool rangefinder_used() const { return _rangefinder_use; }
@@ -39,6 +40,7 @@ public:
 
     // get terrain's altitude (in cm above the ekf origin) at the current position (+ve means terrain below vehicle is above ekf origin's altitude)
     bool get_terrain_offset_cm(float& offset_cm);
+    bool get_terrain_offset_m(float& offset_m);
 
     // return terrain following altitude margin.  vehicle will stop if distance from target altitude is larger than this margin
     float get_terrain_margin_m() const { return MAX(_terrain_margin_m, 0.1); }
@@ -46,6 +48,7 @@ public:
     // convert location to vector from ekf origin.  is_terrain_alt is set to true if resulting vector's z-axis should be treated as alt-above-terrain
     //      returns false if conversion failed (likely because terrain data was not available)
     bool get_vector_NEU_cm(const Location &loc, Vector3f &pos_from_origin_NEU_cm, bool &is_terrain_alt);
+    bool get_vector_NEU_m(const Location &loc, Vector3f &pos_from_origin_NEU_m, bool &is_terrain_alt);
 
     ///
     /// waypoint controller
@@ -55,10 +58,12 @@ public:
     ///     speed_cms is the desired max speed to travel between waypoints.  should be a positive value or omitted to use the default speed
     ///     updates target roll, pitch targets and I terms based on vehicle lean angles
     ///     should be called once before the waypoint controller is used but does not need to be called before subsequent updates to destination
-    void wp_and_spline_init_cm(float speed_cms = 0.0f, Vector3f stopping_point = Vector3f{});
+    void wp_and_spline_init_cm(float speed_cms = 0.0f, Vector3f stopping_point_neu_cm = Vector3f{});
+    void wp_and_spline_init_m(float speed_ms = 0.0f, Vector3f stopping_point_neu_m = Vector3f{});
 
     /// set current target horizontal speed during wp navigation
     void set_speed_NE_cms(float speed_cms);
+    void set_speed_NE_ms(float speed_ms);
 
     /// set pause or resume during wp navigation
     void set_pause() { _paused = true; }
@@ -69,33 +74,42 @@ public:
 
     /// set current target climb or descent rate during wp navigation
     void set_speed_up_cms(float speed_up_cms);
+    void set_speed_up_ms(float speed_up_ms);
     void set_speed_down_cms(float speed_down_cms);
+    void set_speed_down_ms(float speed_down_ms);
 
     /// get default target horizontal velocity during wp navigation
-    float get_default_speed_NE_cms() const { return _wp_speed_cms; }
+    float get_default_speed_NE_cms() const { return get_default_speed_NE_ms() * 100.0; }
+    float get_default_speed_NE_ms() const { return _wp_speed_cms * 0.01; }
 
     /// get default target climb speed in cm/s during missions
-    float get_default_speed_up_cms() const { return _wp_speed_up_cms; }
+    float get_default_speed_up_cms() const { return get_default_speed_up_ms() * 100.0; }
+    float get_default_speed_up_ms() const { return _wp_speed_up_cms * 0.01; }
 
     /// get default target descent rate in cm/s during missions.  Note: always positive
-    float get_default_speed_down_cms() const { return fabsf(_wp_speed_down_cms); }
+    float get_default_speed_down_cms() const { return get_default_speed_down_ms() * 100.0; }
+    float get_default_speed_down_ms() const { return fabsf(_wp_speed_down_cms * 0.01); }
 
     /// get_accel_U_cmss - returns vertical acceleration in cm/s/s during missions.  Note: always positive
-    float get_accel_U_cmss() const { return _wp_accel_z_cmss; }
+    float get_accel_U_cmss() const { return get_accel_U_mss() * 100.0; }
+    float get_accel_U_mss() const { return _wp_accel_z_cmss * 0.01; }
 
     /// get_wp_acceleration - returns acceleration in cm/s/s during missions
-    float get_wp_acceleration_cmss() const { return (is_positive(_wp_accel_cmss)) ? _wp_accel_cmss : WPNAV_ACCELERATION; }
+    float get_wp_acceleration_cmss() const { return get_wp_acceleration_mss() * 100.0; }
+    float get_wp_acceleration_mss() const { return (is_positive(_wp_accel_cmss)) ? _wp_accel_cmss * 0.01 : WPNAV_ACCELERATION_MS; }
 
-    /// get_corner_acceleration_cmss - returns maximum acceleration in cm/s/s used during cornering in missions
-    float get_corner_acceleration_cmss() const { return (is_positive(_wp_accel_c_cmss)) ? _wp_accel_c_cmss : 2.0 * get_wp_acceleration_cmss(); }
+    /// get_corner_acceleration_mss - returns maximum acceleration in m/s/s used during cornering in missions
+    float get_corner_acceleration_mss() const { return (is_positive(_wp_accel_c_cmss)) ? _wp_accel_c_cmss * 0.01 : 2.0 * get_wp_acceleration_mss(); }
 
     /// get_wp_destination_NEU_cm waypoint using position vector
     /// x,y are distance from ekf origin in cm
     /// z may be cm above ekf origin or terrain (see origin_and_destination_are_is_terrain_alt method)
-    const Vector3f &get_wp_destination_NEU_cm() const { return _destination_neu_cm; }
+    const Vector3f get_wp_destination_NEU_cm() const { return get_wp_destination_NEU_m() * 100.0; }
+    const Vector3f &get_wp_destination_NEU_m() const { return _destination_neu_m; }
 
     /// get origin using position vector (distance from ekf origin in cm)
-    const Vector3f &get_wp_origin_NEU_cm() const { return _origin_neu_cm; }
+    const Vector3f get_wp_origin_NEU_cm() const { return get_wp_origin_NEU_m() * 100.0; }
+    const Vector3f &get_wp_origin_NEU_m() const { return _origin_neu_m; }
 
     /// true if origin.z and destination.z are alt-above-terrain, false if alt-above-ekf-origin
     bool origin_and_destination_are_terrain_alt() const { return _is_terrain_alt; }
@@ -117,7 +131,9 @@ public:
     /// set_wp_destination_NEU_cm waypoint using position vector (distance from ekf origin in cm)
     ///     is_terrain_alt should be true if destination.z is a desired altitude above terrain
     virtual bool set_wp_destination_NEU_cm(const Vector3f& destination_neu_cm, bool is_terrain_alt = false);
+    virtual bool set_wp_destination_NEU_m(const Vector3f& destination_neu_m, bool is_terrain_alt = false);
     bool set_wp_destination_next_NEU_cm(const Vector3f& destination_neu_cm, bool is_terrain_alt = false);
+    bool set_wp_destination_next_NEU_m(const Vector3f& destination_neu_m, bool is_terrain_alt = false);
 
     /// set waypoint destination using NED position vector from ekf origin in meters
     ///     provide next_destination_NED if known
@@ -126,11 +142,14 @@ public:
 
     /// get_wp_stopping_point_cm - calculates stopping point based on current position, velocity, waypoint acceleration
     ///		results placed in stopping_position vector
-    void get_wp_stopping_point_NE_cm(Vector2f& stopping_point_NE_cm) const;
-    void get_wp_stopping_point_NEU_cm(Vector3f& stopping_point) const;
+    void get_wp_stopping_point_NE_cm(Vector2f& stopping_point_ne_cm) const;
+    void get_wp_stopping_point_NE_m(Vector2f& stopping_point_ne_m) const;
+    void get_wp_stopping_point_NEU_cm(Vector3f& stopping_point_neu_cm) const;
+    void get_wp_stopping_point_NEU_m(Vector3f& stopping_point_neu_m) const;
 
     /// get_wp_distance_to_destination - get horizontal distance to destination in cm
     virtual float get_wp_distance_to_destination_cm() const;
+    virtual float get_wp_distance_to_destination_m() const;
 
     /// get_bearing_to_destination - get bearing to next waypoint in centi-degrees
     virtual int32_t get_wp_bearing_to_destination_cd() const;
@@ -143,11 +162,12 @@ public:
 
     // reached_wp_destination_NE - true if within RADIUS_CM of waypoint in x/y
     bool reached_wp_destination_NE() const {
-        return get_wp_distance_to_destination_cm() < _wp_radius_cm;
+        return get_wp_distance_to_destination_m() < _wp_radius_cm * 0.01;
     }
 
     // get wp_radius parameter value in cm
-    float get_wp_radius_cm() const { return _wp_radius_cm; }
+    float get_wp_radius_cm() const { return get_wp_radius_m() * 100.0; }
+    float get_wp_radius_m() const { return _wp_radius_cm * 0.01; }
 
     /// update_wpnav - run the wp controller - should be called at 100hz or higher
     virtual bool update_wpnav();
@@ -182,7 +202,8 @@ public:
     ///     next_is_terrain_alt should be true if next_destination.z is a desired altitude above terrain (false if its desired altitudes above ekf origin)
     ///     next_destination.z must be in the same "frame" as destination.z (i.e. if destination is a alt-above-terrain, next_destination must be too)
     ///     next_is_spline should be true if next_destination is a spline segment
-    bool set_spline_destination_NEU_cm(const Vector3f& destination_neu_cm, bool is_terrain_alt, const Vector3f& next_destination_neu_cm, bool next_is_terrain_alt, bool next_is_spline);
+    bool set_spline_destination_NEU_cm(const Vector3f& destination_neu_cm, bool is_terrain_alt, const Vector3f& next_destination_neu_cm, bool next_terrain_alt, bool next_is_spline);
+    bool set_spline_destination_NEU_m(const Vector3f& destination_neu_m, bool is_terrain_alt, const Vector3f& next_destination_neu_m, bool next_terrain_alt, bool next_is_spline);
 
     /// set next destination (e.g. the one after the current destination) as an offset (in cm, NEU frame) from the EKF origin
     ///     next_is_terrain_alt should be true if next_destination.z is a desired altitude above terrain (false if its desired altitudes above ekf origin)
@@ -191,6 +212,7 @@ public:
     ///     next_next_destination.z must be in the same "frame" as destination.z (i.e. if next_destination is a alt-above-terrain, next_next_destination must be too)
     ///     next_next_is_spline should be true if next_next_destination is a spline segment
     bool set_spline_destination_next_NEU_cm(const Vector3f& next_destination_neu_cm, bool next_is_terrain_alt, const Vector3f& next_next_destination_neu_cm, bool next_next_is_terrain_alt, bool next_next_is_spline);
+    bool set_spline_destination_next_NEU_m(const Vector3f& next_destination_neu_m, bool next_is_terrain_alt, const Vector3f& next_next_destination_neu_m, bool next_next_is_terrain_alt, bool next_next_is_spline);
 
     ///
     /// shared methods
@@ -280,13 +302,13 @@ protected:
 
     // waypoint controller internal variables
     uint32_t    _wp_last_update_ms;         // time of last update_wpnav call (in ms)
-    float       _wp_desired_speed_ne_cms;   // desired wp speed in cm/sec
-    Vector3f    _origin_neu_cm;             // starting point of trip to next waypoint in cm from ekf origin
-    Vector3f    _destination_neu_cm;        // target destination in cm from ekf origin
-    Vector3f    _next_destination_neu_cm;   // next target destination in cm from ekf origin
+    float       _wp_desired_speed_ne_ms;    // desired wp speed in m/sec
+    Vector3f    _origin_neu_m;              // starting point of trip to next waypoint in m from ekf origin
+    Vector3f    _destination_neu_m;         // target destination in m from ekf origin
+    Vector3f    _next_destination_neu_m;    // next target destination in cm from ekf origin
     float       _track_dt_scalar;           // time compression multiplier to slow the progress along the track
-    float       _offset_vel_cms;            // horizontal velocity reference used to slow the aircraft for pause and to ensure the aircraft can maintain height above terrain
-    float       _offset_accel_cmss;         // horizontal acceleration reference used to slow the aircraft for pause and to ensure the aircraft can maintain height above terrain
+    float       _offset_vel_ms;             // horizontal velocity reference used to slow the aircraft for pause and to ensure the aircraft can maintain height above terrain
+    float       _offset_accel_mss;          // horizontal acceleration reference used to slow the aircraft for pause and to ensure the aircraft can maintain height above terrain
     bool        _paused;                    // flag for pausing waypoint controller
 
     // terrain following variables
@@ -294,5 +316,5 @@ protected:
     bool        _rangefinder_available;         // true if rangefinder is enabled (user switch can turn this true/false)
     AP_Int8     _rangefinder_use;               // parameter that specifies if the range finder should be used for terrain following commands
     bool        _rangefinder_healthy;           // true if rangefinder distance is healthy (i.e. between min and maximum)
-    float       _rangefinder_terrain_offset_cm; // latest rangefinder based terrain offset (e.g. terrain's height above EKF origin)
+    float       _rangefinder_terrain_offset_m;  // latest rangefinder based terrain offset (e.g. terrain's height above EKF origin)
 };

--- a/libraries/AC_WPNav/AC_WPNav_OA.cpp
+++ b/libraries/AC_WPNav/AC_WPNav_OA.cpp
@@ -86,12 +86,12 @@ bool AC_WPNav_OA::update_wpnav()
     Location current_loc;
     if ((oa_ptr != nullptr) && AP::ahrs().get_location(current_loc)) {
 
-        // backup _origin and _destination_neu_cm when not doing oa
+        // backup _origin and _destination_neu_m when not doing oa
         if (_oa_state == AP_OAPathPlanner::OA_NOT_REQUIRED) {
-            _origin_oabak_neu_cm = _origin_neu_cm;
-            _destination_oabak_neu_cm = _destination_neu_cm;
+            _origin_oabak_neu_cm = _origin_neu_m * 100.0;
+            _destination_oabak_neu_cm = _destination_neu_m * 100.0;
             _is_terrain_alt_oabak = _is_terrain_alt;
-            _next_destination_oabak_neu_cm = _next_destination_neu_cm;
+            _next_destination_oabak_neu_cm = _next_destination_neu_m * 100.0;
         }
 
         // convert origin, destination and next_destination to Locations and pass into oa

--- a/libraries/AC_WPNav/AC_WPNav_OA.h
+++ b/libraries/AC_WPNav/AC_WPNav_OA.h
@@ -45,10 +45,10 @@ protected:
 
     // oa path planning variables
     AP_OAPathPlanner::OA_RetState _oa_state;    // state of object avoidance, if OA_SUCCESS we use _oa_destination to avoid obstacles
-    Vector3f    _origin_oabak_neu_cm;          // backup of _origin_neu_cm so it can be restored when oa completes
-    Vector3f    _destination_oabak_neu_cm;     // backup of _destination_neu_cm so it can be restored when oa completes
-    Vector3f    _next_destination_oabak_neu_cm;// backup of _next_destination_neu_cm so it can be restored when oa completes
-    bool        _is_terrain_alt_oabak;     // true if backup origin and destination z-axis are terrain altitudes
+    Vector3f    _origin_oabak_neu_cm;           // backup of _origin_neu_m so it can be restored when oa completes
+    Vector3f    _destination_oabak_neu_cm;      // backup of _destination_neu_m so it can be restored when oa completes
+    Vector3f    _next_destination_oabak_neu_cm; // backup of _next_destination_neu_m so it can be restored when oa completes
+    bool        _is_terrain_alt_oabak;  // true if backup origin and destination z-axis are terrain altitudes
     Location    _oa_destination;        // intermediate destination during avoidance
     Location    _oa_next_destination;   // intermediate next destination during avoidance
 };


### PR DESCRIPTION
This PR refactors the AC_WPNav library to use meters as the internal unit for all waypoint navigation calculations, aligning it with the rest of the position control stack. The existing centimeter-based functions have been preserved as wrappers for compatibility but marked clearly with *_cm suffixes and updated comments.

Key changes:

- All internal NEU vectors and related calculations now operate in meters
- Added parallel *_m versions of all public cm-based methods
- Updated all function comments:
- cm-version comments now reference the meter version and list units only
- m-version comments provide the full behavioral description
- Parameter and macro comments reviewed and corrected for clarity and unit consistency
- Internal comments updated throughout AC_WPNav.cpp for improved maintainability
- No functional change to external behavior; all existing parameters remain in centimeters

This refactor is a precursor to updating the rest of the flight code to use the meter-based interfaces, after which the cm functions can be safely removed.

```
Board,antennatracker,blimp,bootloader,copter,heli,plane,rover,sub
CubeOrange,*,*,*,1176,1136,-8,*,520
```