### PR TITLE
Plane: integrate AC_PosControl and AC_WPNav move to meters

### DIFF
--- a/ArduPlane/Plane.cpp
+++ b/ArduPlane/Plane.cpp
@@ -840,7 +840,7 @@ bool Plane::get_wp_distance_m(float &distance) const
     }
 #if HAL_QUADPLANE_ENABLED
     if (quadplane.in_vtol_mode()) {
-        distance = quadplane.using_wp_nav() ? quadplane.wp_nav->get_wp_distance_to_destination_cm() * 0.01 : 0;
+        distance = quadplane.using_wp_nav() ? quadplane.wp_nav->get_wp_distance_to_destination_m() : 0;
         return true;
     }
 #endif

--- a/ArduPlane/VTOL_Assist.cpp
+++ b/ArduPlane/VTOL_Assist.cpp
@@ -174,7 +174,7 @@ bool VTOL_Assist::check_VTOL_recovery(void)
             quadplane.force_fw_control_recovery = false;
             quadplane.attitude_control->reset_target_and_rate(false);
 
-            if (ahrs.groundspeed() > quadplane.wp_nav->get_default_speed_NE_cms()*0.01) {
+            if (ahrs.groundspeed() > quadplane.wp_nav->get_default_speed_NE_ms()) {
                 /* if moving at high speed also reset position
                    controller and height controller
 

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -1197,7 +1197,7 @@ float Plane::get_wp_radius() const
 {
 #if HAL_QUADPLANE_ENABLED
     if (plane.quadplane.in_vtol_mode()) {
-        return plane.quadplane.wp_nav->get_wp_radius_cm() * 0.01;
+        return plane.quadplane.wp_nav->get_wp_radius_m();
     }
 #endif
     return g.waypoint_radius;

--- a/ArduPlane/mode_qhover.cpp
+++ b/ArduPlane/mode_qhover.cpp
@@ -6,8 +6,8 @@
 bool ModeQHover::_enter()
 {
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_U_cm(-quadplane.get_pilot_velocity_z_max_dn_cm(), quadplane.pilot_speed_z_max_up_ms*100, quadplane.pilot_accel_z_mss*100);
-    pos_control->set_correction_speed_accel_U_cmss(-quadplane.get_pilot_velocity_z_max_dn_cm(), quadplane.pilot_speed_z_max_up_ms*100, quadplane.pilot_accel_z_mss*100);
+    pos_control->set_max_speed_accel_U_cm(-quadplane.get_pilot_velocity_z_max_dn_m() * 100, quadplane.pilot_speed_z_max_up_ms * 100, quadplane.pilot_accel_z_mss * 100);
+    pos_control->set_correction_speed_accel_U_cmss(-quadplane.get_pilot_velocity_z_max_dn_m() * 100, quadplane.pilot_speed_z_max_up_ms * 100, quadplane.pilot_accel_z_mss * 100);
     quadplane.set_climb_rate_cms(0);
 
     quadplane.init_throttle_wait();

--- a/ArduPlane/mode_qhover.cpp
+++ b/ArduPlane/mode_qhover.cpp
@@ -6,8 +6,8 @@
 bool ModeQHover::_enter()
 {
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_U_cm(-quadplane.get_pilot_velocity_z_max_dn_m() * 100, quadplane.pilot_speed_z_max_up_ms * 100, quadplane.pilot_accel_z_mss * 100);
-    pos_control->set_correction_speed_accel_U_cmss(-quadplane.get_pilot_velocity_z_max_dn_m() * 100, quadplane.pilot_speed_z_max_up_ms * 100, quadplane.pilot_accel_z_mss * 100);
+    pos_control->set_max_speed_accel_U_m(-quadplane.get_pilot_velocity_z_max_dn_m(), quadplane.pilot_speed_z_max_up_ms, quadplane.pilot_accel_z_mss);
+    pos_control->set_correction_speed_accel_U_mss(-quadplane.get_pilot_velocity_z_max_dn_m(), quadplane.pilot_speed_z_max_up_ms, quadplane.pilot_accel_z_mss);
     quadplane.set_climb_rate_ms(0);
 
     quadplane.init_throttle_wait();

--- a/ArduPlane/mode_qhover.cpp
+++ b/ArduPlane/mode_qhover.cpp
@@ -8,7 +8,7 @@ bool ModeQHover::_enter()
     // set vertical speed and acceleration limits
     pos_control->set_max_speed_accel_U_cm(-quadplane.get_pilot_velocity_z_max_dn_m() * 100, quadplane.pilot_speed_z_max_up_ms * 100, quadplane.pilot_accel_z_mss * 100);
     pos_control->set_correction_speed_accel_U_cmss(-quadplane.get_pilot_velocity_z_max_dn_m() * 100, quadplane.pilot_speed_z_max_up_ms * 100, quadplane.pilot_accel_z_mss * 100);
-    quadplane.set_climb_rate_cms(0);
+    quadplane.set_climb_rate_ms(0);
 
     quadplane.init_throttle_wait();
     return true;

--- a/ArduPlane/mode_qloiter.cpp
+++ b/ArduPlane/mode_qloiter.cpp
@@ -55,7 +55,7 @@ void ModeQLoiter::run()
         // we have an active landing target override
         Vector2f rel_origin;
         if (plane.next_WP_loc.get_vector_xy_from_origin_NE_cm(rel_origin)) {
-            quadplane.pos_control->set_pos_desired_NE_cm(rel_origin);
+            quadplane.pos_control->set_pos_desired_NE_m(rel_origin * 0.01);
             last_target_loc_set_ms = 0;
         }
     }
@@ -64,8 +64,8 @@ void ModeQLoiter::run()
     if (last_vel_set_ms != 0 && now - last_vel_set_ms < precland_timeout_ms) {
         // we have an active landing velocity override
         Vector2f target_accel;
-        Vector2f target_speed_xy_cms{quadplane.poscontrol.velocity_match_ms.x*100, quadplane.poscontrol.velocity_match_ms.y*100};
-        quadplane.pos_control->input_vel_accel_NE_cm(target_speed_xy_cms, target_accel);
+        Vector2f target_speed_xy_ms{quadplane.poscontrol.velocity_match_ms.x, quadplane.poscontrol.velocity_match_ms.y};
+        quadplane.pos_control->input_vel_accel_NE_m(target_speed_xy_ms, target_accel);
         quadplane.poscontrol.last_velocity_match_ms = 0;
     }
 #endif // AC_PRECLAND_ENABLED
@@ -164,7 +164,7 @@ void ModeQLoiter::run()
             ahrs.set_touchdown_expected(true);
         }
 
-        pos_control->land_at_climb_rate_cm(-descent_rate_cms, descent_rate_cms>0);
+        pos_control->land_at_climb_rate_m(-descent_rate_cms * 0.01, descent_rate_cms>0);
         quadplane.check_land_complete();
     } else if (plane.control_mode == &plane.mode_guided && quadplane.guided_takeoff) {
         quadplane.set_climb_rate_ms(0);

--- a/ArduPlane/mode_qloiter.cpp
+++ b/ArduPlane/mode_qloiter.cpp
@@ -10,8 +10,8 @@ bool ModeQLoiter::_enter()
     loiter_nav->init_target();
 
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_U_cm(-quadplane.get_pilot_velocity_z_max_dn_cm(), quadplane.pilot_speed_z_max_up_ms*100, quadplane.pilot_accel_z_mss*100);
-    pos_control->set_correction_speed_accel_U_cmss(-quadplane.get_pilot_velocity_z_max_dn_cm(), quadplane.pilot_speed_z_max_up_ms*100, quadplane.pilot_accel_z_mss*100);
+    pos_control->set_max_speed_accel_U_cm(-quadplane.get_pilot_velocity_z_max_dn_m() * 100, quadplane.pilot_speed_z_max_up_ms * 100, quadplane.pilot_accel_z_mss * 100);
+    pos_control->set_correction_speed_accel_U_cmss(-quadplane.get_pilot_velocity_z_max_dn_m() * 100, quadplane.pilot_speed_z_max_up_ms * 100, quadplane.pilot_accel_z_mss * 100);
 
     quadplane.init_throttle_wait();
 
@@ -107,7 +107,7 @@ void ModeQLoiter::run()
     quadplane.set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_U_cm(-quadplane.get_pilot_velocity_z_max_dn_cm(), quadplane.pilot_speed_z_max_up_ms*100, quadplane.pilot_accel_z_mss*100);
+    pos_control->set_max_speed_accel_U_cm(-quadplane.get_pilot_velocity_z_max_dn_m() * 100, quadplane.pilot_speed_z_max_up_ms * 100, quadplane.pilot_accel_z_mss * 100);
 
     // process pilot's roll and pitch input
     float target_roll_cd, target_pitch_cd;

--- a/ArduPlane/mode_qloiter.cpp
+++ b/ArduPlane/mode_qloiter.cpp
@@ -167,10 +167,10 @@ void ModeQLoiter::run()
         pos_control->land_at_climb_rate_cm(-descent_rate_cms, descent_rate_cms>0);
         quadplane.check_land_complete();
     } else if (plane.control_mode == &plane.mode_guided && quadplane.guided_takeoff) {
-        quadplane.set_climb_rate_cms(0);
+        quadplane.set_climb_rate_ms(0);
     } else {
         // update altitude target and call position controller
-        quadplane.set_climb_rate_cms(quadplane.get_pilot_desired_climb_rate_cms());
+        quadplane.set_climb_rate_ms(quadplane.get_pilot_desired_climb_rate_cms() * 0.01);
     }
     quadplane.run_z_controller();
 

--- a/ArduPlane/mode_qloiter.cpp
+++ b/ArduPlane/mode_qloiter.cpp
@@ -158,13 +158,13 @@ void ModeQLoiter::run()
 #endif  // AP_ICENGINE_ENABLED
         }
         float height_above_ground = plane.relative_ground_altitude(RangeFinderUse::TAKEOFF_LANDING);
-        float descent_rate_cms = quadplane.landing_descent_rate_cms(height_above_ground);
+        float descent_rate_ms = quadplane.landing_descent_rate_ms(height_above_ground);
 
         if (poscontrol.get_state() == QuadPlane::QPOS_LAND_FINAL && !quadplane.option_is_set(QuadPlane::Option::DISABLE_GROUND_EFFECT_COMP)) {
             ahrs.set_touchdown_expected(true);
         }
 
-        pos_control->land_at_climb_rate_m(-descent_rate_cms * 0.01, descent_rate_cms>0);
+        pos_control->land_at_climb_rate_m(-descent_rate_ms, descent_rate_ms>0);
         quadplane.check_land_complete();
     } else if (plane.control_mode == &plane.mode_guided && quadplane.guided_takeoff) {
         quadplane.set_climb_rate_ms(0);

--- a/ArduPlane/mode_qloiter.cpp
+++ b/ArduPlane/mode_qloiter.cpp
@@ -10,8 +10,8 @@ bool ModeQLoiter::_enter()
     loiter_nav->init_target();
 
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_U_cm(-quadplane.get_pilot_velocity_z_max_dn_m() * 100, quadplane.pilot_speed_z_max_up_ms * 100, quadplane.pilot_accel_z_mss * 100);
-    pos_control->set_correction_speed_accel_U_cmss(-quadplane.get_pilot_velocity_z_max_dn_m() * 100, quadplane.pilot_speed_z_max_up_ms * 100, quadplane.pilot_accel_z_mss * 100);
+    pos_control->set_max_speed_accel_U_m(-quadplane.get_pilot_velocity_z_max_dn_m(), quadplane.pilot_speed_z_max_up_ms, quadplane.pilot_accel_z_mss);
+    pos_control->set_correction_speed_accel_U_mss(-quadplane.get_pilot_velocity_z_max_dn_m(), quadplane.pilot_speed_z_max_up_ms, quadplane.pilot_accel_z_mss);
 
     quadplane.init_throttle_wait();
 
@@ -107,7 +107,7 @@ void ModeQLoiter::run()
     quadplane.set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_U_cm(-quadplane.get_pilot_velocity_z_max_dn_m() * 100, quadplane.pilot_speed_z_max_up_ms * 100, quadplane.pilot_accel_z_mss * 100);
+    pos_control->set_max_speed_accel_U_m(-quadplane.get_pilot_velocity_z_max_dn_m(), quadplane.pilot_speed_z_max_up_ms, quadplane.pilot_accel_z_mss);
 
     // process pilot's roll and pitch input
     float target_roll_cd, target_pitch_cd;

--- a/ArduPlane/mode_qrtl.cpp
+++ b/ArduPlane/mode_qrtl.cpp
@@ -97,7 +97,7 @@ void ModeQRTL::run()
         case SubMode::climb: {
             // request zero velocity
             Vector2f vel, accel;
-            pos_control->input_vel_accel_NE_cm(vel, accel);
+            pos_control->input_vel_accel_NE_m(vel, accel);
             quadplane.run_xy_controller();
 
             // nav roll and pitch are controller by position controller
@@ -121,8 +121,8 @@ void ModeQRTL::run()
 
             // Climb done when stopping point reaches target altitude
             Vector3p stopping_point;
-            pos_control->get_stopping_point_U_cm(stopping_point.z);
-            Location stopping_loc = Location(stopping_point.tofloat(), Location::AltFrame::ABOVE_ORIGIN);
+            pos_control->get_stopping_point_U_m(stopping_point.z);
+            Location stopping_loc = Location(stopping_point.tofloat() * 100.0, Location::AltFrame::ABOVE_ORIGIN);
 
             ftype alt_diff;
             if (!stopping_loc.get_height_above(plane.next_WP_loc, alt_diff) || is_positive(alt_diff)) {

--- a/ArduPlane/mode_qrtl.cpp
+++ b/ArduPlane/mode_qrtl.cpp
@@ -116,7 +116,7 @@ void ModeQRTL::run()
                                                                           quadplane.get_weathervane_yaw_rate_cds());
 
             // climb at full WP nav speed
-            quadplane.set_climb_rate_ms(quadplane.wp_nav->get_default_speed_up_cms() * 0.01);
+            quadplane.set_climb_rate_ms(quadplane.wp_nav->get_default_speed_up_ms());
             quadplane.run_z_controller();
 
             // Climb done when stopping point reaches target altitude

--- a/ArduPlane/mode_qrtl.cpp
+++ b/ArduPlane/mode_qrtl.cpp
@@ -116,7 +116,7 @@ void ModeQRTL::run()
                                                                           quadplane.get_weathervane_yaw_rate_cds());
 
             // climb at full WP nav speed
-            quadplane.set_climb_rate_cms(quadplane.wp_nav->get_default_speed_up_cms());
+            quadplane.set_climb_rate_ms(quadplane.wp_nav->get_default_speed_up_cms() * 0.01);
             quadplane.run_z_controller();
 
             // Climb done when stopping point reaches target altitude

--- a/ArduPlane/qautotune.cpp
+++ b/ArduPlane/qautotune.cpp
@@ -41,10 +41,10 @@ void QAutoTune::get_pilot_desired_rp_yrate_rad(float &des_roll_rad, float &des_p
 void QAutoTune::init_z_limits()
 {
     // set vertical speed and acceleration limits
-    plane.quadplane.pos_control->set_max_speed_accel_U_cm(-plane.quadplane.get_pilot_velocity_z_max_dn_cm(),
+    plane.quadplane.pos_control->set_max_speed_accel_U_cm(-plane.quadplane.get_pilot_velocity_z_max_dn_m() * 100,
                                                        plane.quadplane.pilot_speed_z_max_up_ms * 100,
                                                        plane.quadplane.pilot_accel_z_mss * 100);
-    plane.quadplane.pos_control->set_correction_speed_accel_U_cmss(-plane.quadplane.get_pilot_velocity_z_max_dn_cm(),
+    plane.quadplane.pos_control->set_correction_speed_accel_U_cmss(-plane.quadplane.get_pilot_velocity_z_max_dn_m() * 100,
                                                               plane.quadplane.pilot_speed_z_max_up_ms * 100,
                                                               plane.quadplane.pilot_accel_z_mss * 100);
 }

--- a/ArduPlane/qautotune.cpp
+++ b/ArduPlane/qautotune.cpp
@@ -41,12 +41,12 @@ void QAutoTune::get_pilot_desired_rp_yrate_rad(float &des_roll_rad, float &des_p
 void QAutoTune::init_z_limits()
 {
     // set vertical speed and acceleration limits
-    plane.quadplane.pos_control->set_max_speed_accel_U_cm(-plane.quadplane.get_pilot_velocity_z_max_dn_m() * 100,
-                                                       plane.quadplane.pilot_speed_z_max_up_ms * 100,
-                                                       plane.quadplane.pilot_accel_z_mss * 100);
-    plane.quadplane.pos_control->set_correction_speed_accel_U_cmss(-plane.quadplane.get_pilot_velocity_z_max_dn_m() * 100,
-                                                              plane.quadplane.pilot_speed_z_max_up_ms * 100,
-                                                              plane.quadplane.pilot_accel_z_mss * 100);
+    plane.quadplane.pos_control->set_max_speed_accel_U_m(-plane.quadplane.get_pilot_velocity_z_max_dn_m(),
+                                                       plane.quadplane.pilot_speed_z_max_up_ms,
+                                                       plane.quadplane.pilot_accel_z_mss);
+    plane.quadplane.pos_control->set_correction_speed_accel_U_mss(-plane.quadplane.get_pilot_velocity_z_max_dn_m(),
+                                                              plane.quadplane.pilot_speed_z_max_up_ms,
+                                                              plane.quadplane.pilot_accel_z_mss);
 }
 
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1021,7 +1021,7 @@ void QuadPlane::run_z_controller(void)
     }
     if ((now - last_pidz_active_ms) > 20 || !pos_control->is_active_U()) {
         // set vertical speed and acceleration limits
-        pos_control->set_max_speed_accel_U_cm(-get_pilot_velocity_z_max_dn_m() * 100, pilot_speed_z_max_up_ms * 100, pilot_accel_z_mss * 100);
+        pos_control->set_max_speed_accel_U_m(-get_pilot_velocity_z_max_dn_m(), pilot_speed_z_max_up_ms, pilot_accel_z_mss);
 
         // initialise the vertical position controller
         if (!tailsitter.enabled()) {
@@ -1074,7 +1074,7 @@ void QuadPlane::hold_hover(float target_climb_rate_cms)
     set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_U_cm(-get_pilot_velocity_z_max_dn_m() * 100, pilot_speed_z_max_up_ms * 100, pilot_accel_z_mss * 100);
+    pos_control->set_max_speed_accel_U_m(-get_pilot_velocity_z_max_dn_m(), pilot_speed_z_max_up_ms, pilot_accel_z_mss);
 
     // call attitude controller
     multicopter_attitude_rate_update(get_desired_yaw_rate_cds(false));
@@ -2168,14 +2168,14 @@ void QuadPlane::update_land_positioning(void)
  */
 void QuadPlane::run_xy_controller(float accel_limit_mss)
 {
-    float accel_cmss = wp_nav->get_wp_acceleration_cmss();
+    float accel_mss = wp_nav->get_wp_acceleration_cmss() * 0.01;
     if (is_positive(accel_limit_mss)) {
         // allow for accel limit override
-        accel_cmss = MAX(accel_cmss, accel_limit_mss * 100);
+        accel_mss = MAX(accel_mss, accel_limit_mss);
     }
-    const float speed_cms = wp_nav->get_default_speed_NE_cms();
-    pos_control->set_max_speed_accel_NE_cm(speed_cms, accel_cmss);
-    pos_control->set_correction_speed_accel_NE_cm(speed_cms, accel_cmss);
+    const float speed_ms = wp_nav->get_default_speed_NE_cms() * 0.01;
+    pos_control->set_max_speed_accel_NE_m(speed_ms, accel_mss);
+    pos_control->set_correction_speed_accel_NE_m(speed_ms, accel_mss);
     if (!pos_control->is_active_NE()) {
         pos_control->init_NE_controller();
     }
@@ -3074,8 +3074,8 @@ void QuadPlane::setup_target_position(void)
     poscontrol.target_neu_cm.z = plane.next_WP_loc.alt - origin.alt;
 
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_U_cm(-get_pilot_velocity_z_max_dn_m() * 100, pilot_speed_z_max_up_ms * 100, pilot_accel_z_mss * 100);
-    pos_control->set_correction_speed_accel_U_cmss(-get_pilot_velocity_z_max_dn_m() * 100, pilot_speed_z_max_up_ms * 100, pilot_accel_z_mss * 100);
+    pos_control->set_max_speed_accel_U_m(-get_pilot_velocity_z_max_dn_m(), pilot_speed_z_max_up_ms, pilot_accel_z_mss);
+    pos_control->set_correction_speed_accel_U_mss(-get_pilot_velocity_z_max_dn_m(), pilot_speed_z_max_up_ms, pilot_accel_z_mss);
 }
 
 /*
@@ -3325,8 +3325,8 @@ bool QuadPlane::do_vtol_takeoff(const AP_Mission::Mission_Command& cmd)
     throttle_wait = false;
 
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_U_cm(-get_pilot_velocity_z_max_dn_m() * 100, pilot_speed_z_max_up_ms * 100, pilot_accel_z_mss * 100);
-    pos_control->set_correction_speed_accel_U_cmss(-get_pilot_velocity_z_max_dn_m() * 100, pilot_speed_z_max_up_ms * 100, pilot_accel_z_mss * 100);
+    pos_control->set_max_speed_accel_U_m(-get_pilot_velocity_z_max_dn_m(), pilot_speed_z_max_up_ms, pilot_accel_z_mss);
+    pos_control->set_correction_speed_accel_U_mss(-get_pilot_velocity_z_max_dn_m(), pilot_speed_z_max_up_ms, pilot_accel_z_mss);
 
     // initialise the vertical position controller
     pos_control->init_U_controller();

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2548,7 +2548,7 @@ void QuadPlane::vtol_position_controller(void)
 
         // maximum configured VTOL speed
         const float wp_speed_ms = MAX(1.0, wp_nav->get_default_speed_NE_ms());
-        const float scaled_wp_speed = get_scaled_wp_speed(degrees(wp_distance_ne_m.angle()));
+        const float scaled_wp_speed_ms = get_scaled_wp_speed(degrees(wp_distance_ne_m.angle()));
 
         // limit target speed to a the pos1 speed limit, which starts out at the initial speed
         // but is adjusted if we start putting our nose down. We always allow at least twice
@@ -2557,14 +2557,14 @@ void QuadPlane::vtol_position_controller(void)
 
         if (poscontrol.reached_wp_speed ||
             rel_groundspeed_sq < sq(wp_speed_ms) ||
-            wp_speed_ms > 1.35*scaled_wp_speed) {
+            wp_speed_ms > 1.35*scaled_wp_speed_ms) {
             // once we get below the Q_WP_SPEED then we don't want to
             // speed up again. At that point we should fly within the
             // limits of the configured VTOL controller we also apply
             // this limit when we are more than 45 degrees off the
             // target in yaw, which is when we start to become
             // unstable
-            approach_speed_ms = MIN(approach_speed_ms, scaled_wp_speed);
+            approach_speed_ms = MIN(approach_speed_ms, scaled_wp_speed_ms);
             poscontrol.reached_wp_speed = true;
         }
 
@@ -3773,7 +3773,7 @@ float QuadPlane::forward_throttle_pct()
         return 0;
     }
     // get component of velocity error in fwd body frame direction
-    Vector3f vel_error_body_ms = ahrs.get_rotation_body_to_ned().transposed() * ((desired_velocity_ned_ms) - vel_ned_ms);
+    Vector3f vel_error_body_ms = ahrs.get_rotation_body_to_ned().transposed() * (desired_velocity_ned_ms - vel_ned_ms);
 
     float fwd_vel_error_ms = vel_error_body_ms.x;
 
@@ -3783,7 +3783,7 @@ float QuadPlane::forward_throttle_pct()
     // add in a component from our current pitch demand. This tends to
     // move us to zero pitch. Assume that LIM_PITCH would give us the
     // WP nav speed.
-    fwd_vel_error_ms -= (wp_nav->get_default_speed_NE_ms()) * plane.nav_pitch_cd / (plane.aparm.pitch_limit_max * 100);
+    fwd_vel_error_ms -= wp_nav->get_default_speed_NE_ms() * plane.nav_pitch_cd / (plane.aparm.pitch_limit_max * 100);
 
     if (should_relax() && vel_ned_ms.length() < 1) {
         // we may be landed

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2693,10 +2693,10 @@ void QuadPlane::vtol_position_controller(void)
           for final land repositioning and descent we run the position controller
          */
         Vector2f zero;
-        Vector2f vel_ms = poscontrol.target_vel_cms.xy() * 0.01 + landing_velocity_ms;
-        Vector2p target_m = poscontrol.target_vel_cms.xy() * 0.01;
-        pos_control->input_pos_vel_accel_NE_m(target_m, vel_ms, zero);
-        poscontrol.target_vel_cms.xy() = target_m * 100.0;
+        Vector2f vel_ne_ms = poscontrol.target_vel_cms.xy() * 0.01 + landing_velocity_ne_ms;
+        Vector2p target_m = poscontrol.target_neu_cm.xy() * 0.01;
+        pos_control->input_pos_vel_accel_NE_m(target_m, vel_ne_ms, zero);
+        poscontrol.target_neu_cm.xy() = target_m * 100.0;
 
         // also run fixed wing navigation
         plane.nav_controller->update_waypoint(plane.current_loc, loc);

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3685,7 +3685,7 @@ void QuadPlane::Log_Write_QControl_Tuning()
         angle_boost         : attitude_control->angle_boost(),
         throttle_out        : motors->get_throttle(),
         throttle_hover      : motors->get_throttle_hover(),
-        desired_alt         : des_alt_m,
+        desired_alt         : des_alt_m * 100.0,
         inav_alt            : inertial_nav.get_position_z_up_cm() * 0.01f,
         baro_alt            : int32_t(plane.barometer.get_altitude() * 100),
         target_climb_rate   : int16_t(target_climb_rate_ms * 100.0),

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3685,7 +3685,7 @@ void QuadPlane::Log_Write_QControl_Tuning()
         angle_boost         : attitude_control->angle_boost(),
         throttle_out        : motors->get_throttle(),
         throttle_hover      : motors->get_throttle_hover(),
-        desired_alt         : des_alt_m * 100.0,
+        desired_alt         : des_alt_m,
         inav_alt            : inertial_nav.get_position_z_up_cm() * 0.01f,
         baro_alt            : int32_t(plane.barometer.get_altitude() * 100),
         target_climb_rate   : int16_t(target_climb_rate_ms * 100.0),

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3638,10 +3638,10 @@ bool QuadPlane::verify_vtol_land(void)
 void QuadPlane::Log_Write_QControl_Tuning()
 {
     float des_alt_m = 0.0f;
-    int16_t target_climb_rate_cms = 0;
+    float target_climb_rate_ms = 0;
     if (plane.control_mode != &plane.mode_qstabilize) {
-        des_alt_m = pos_control->get_pos_desired_U_cm() * 0.01f;
-        target_climb_rate_cms = pos_control->get_vel_target_U_cms();
+        des_alt_m = pos_control->get_pos_desired_U_m();
+        target_climb_rate_ms = pos_control->get_vel_target_U_ms();
     }
 
     // Assemble assistance bitmask, definition here is used to generate log documentation
@@ -3688,7 +3688,7 @@ void QuadPlane::Log_Write_QControl_Tuning()
         desired_alt         : des_alt_m,
         inav_alt            : inertial_nav.get_position_z_up_cm() * 0.01f,
         baro_alt            : int32_t(plane.barometer.get_altitude() * 100),
-        target_climb_rate   : target_climb_rate_cms,
+        target_climb_rate   : int16_t(target_climb_rate_ms * 100.0),
         climb_rate          : int16_t(inertial_nav.get_velocity_z_up_cms()),
         throttle_mix        : attitude_control->get_throttle_mix(),
         transition_state    : transition->get_log_transition_state(),

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1021,7 +1021,7 @@ void QuadPlane::run_z_controller(void)
     }
     if ((now - last_pidz_active_ms) > 20 || !pos_control->is_active_U()) {
         // set vertical speed and acceleration limits
-        pos_control->set_max_speed_accel_U_cm(-get_pilot_velocity_z_max_dn_cm(), pilot_speed_z_max_up_ms*100, pilot_accel_z_mss*100);
+        pos_control->set_max_speed_accel_U_cm(-get_pilot_velocity_z_max_dn_m() * 100, pilot_speed_z_max_up_ms * 100, pilot_accel_z_mss * 100);
 
         // initialise the vertical position controller
         if (!tailsitter.enabled()) {
@@ -1074,7 +1074,7 @@ void QuadPlane::hold_hover(float target_climb_rate_cms)
     set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_U_cm(-get_pilot_velocity_z_max_dn_cm(), pilot_speed_z_max_up_ms*100, pilot_accel_z_mss*100);
+    pos_control->set_max_speed_accel_U_cm(-get_pilot_velocity_z_max_dn_m() * 100, pilot_speed_z_max_up_ms * 100, pilot_accel_z_mss * 100);
 
     // call attitude controller
     multicopter_attitude_rate_update(get_desired_yaw_rate_cds(false));
@@ -1296,7 +1296,7 @@ float QuadPlane::get_pilot_input_yaw_rate_cds(void) const
         (!plane.control_mode->does_auto_throttle() || motors->limit.throttle_lower) &&
         plane.arming.get_rudder_arming_type() == AP_Arming::RudderArming::ARMDISARM &&
         rudder_in < 0 &&
-        fabsf(inertial_nav.get_velocity_z_up_cms()) < 0.5 * get_pilot_velocity_z_max_dn_cm()) {
+        fabsf(inertial_nav.get_velocity_z_up_cms()) < (0.5 * get_pilot_velocity_z_max_dn_m()) * 100) {
         // the user may be trying to disarm, disable pilot yaw control
         return 0;
     }
@@ -1360,7 +1360,7 @@ float QuadPlane::get_pilot_desired_climb_rate_cms(void) const
     uint16_t dead_zone = plane.channel_throttle->get_dead_zone();
     uint16_t trim = (plane.channel_throttle->get_radio_max() + plane.channel_throttle->get_radio_min()) / 2;
     const float throttle_request = plane.channel_throttle->pwm_to_angle_dz_trim(dead_zone, trim) * 0.01f;
-    return throttle_request * (throttle_request > 0.0f ? pilot_speed_z_max_up_ms*100 : get_pilot_velocity_z_max_dn_cm());
+    return throttle_request * (throttle_request > 0.0f ? pilot_speed_z_max_up_ms : get_pilot_velocity_z_max_dn_m()) * 100;
 }
 
 
@@ -3074,8 +3074,8 @@ void QuadPlane::setup_target_position(void)
     poscontrol.target_neu_cm.z = plane.next_WP_loc.alt - origin.alt;
 
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_U_cm(-get_pilot_velocity_z_max_dn_cm(), pilot_speed_z_max_up_ms*100, pilot_accel_z_mss*100);
-    pos_control->set_correction_speed_accel_U_cmss(-get_pilot_velocity_z_max_dn_cm(), pilot_speed_z_max_up_ms*100, pilot_accel_z_mss*100);
+    pos_control->set_max_speed_accel_U_cm(-get_pilot_velocity_z_max_dn_m() * 100, pilot_speed_z_max_up_ms * 100, pilot_accel_z_mss * 100);
+    pos_control->set_correction_speed_accel_U_cmss(-get_pilot_velocity_z_max_dn_m() * 100, pilot_speed_z_max_up_ms * 100, pilot_accel_z_mss * 100);
 }
 
 /*
@@ -3325,8 +3325,8 @@ bool QuadPlane::do_vtol_takeoff(const AP_Mission::Mission_Command& cmd)
     throttle_wait = false;
 
     // set vertical speed and acceleration limits
-    pos_control->set_max_speed_accel_U_cm(-get_pilot_velocity_z_max_dn_cm(), pilot_speed_z_max_up_ms * 100, pilot_accel_z_mss * 100);
-    pos_control->set_correction_speed_accel_U_cmss(-get_pilot_velocity_z_max_dn_cm(), pilot_speed_z_max_up_ms * 100, pilot_accel_z_mss * 100);
+    pos_control->set_max_speed_accel_U_cm(-get_pilot_velocity_z_max_dn_m() * 100, pilot_speed_z_max_up_ms * 100, pilot_accel_z_mss * 100);
+    pos_control->set_correction_speed_accel_U_cmss(-get_pilot_velocity_z_max_dn_m() * 100, pilot_speed_z_max_up_ms * 100, pilot_accel_z_mss * 100);
 
     // initialise the vertical position controller
     pos_control->init_U_controller();
@@ -4235,12 +4235,12 @@ bool SLT_Transition::show_vtol_view() const
   return the PILOT_VELZ_MAX_DN value if non zero, otherwise returns the PILOT_VELZ_MAX value.
   return is in cm/s
 */
-uint16_t QuadPlane::get_pilot_velocity_z_max_dn_cm() const
+uint16_t QuadPlane::get_pilot_velocity_z_max_dn_m() const
 {
     if (is_zero(pilot_speed_z_max_dn_ms)) {
-        return abs(pilot_speed_z_max_up_ms * 100);
+        return abs(pilot_speed_z_max_up_ms);
     }
-    return abs(pilot_speed_z_max_dn_ms * 100);
+    return abs(pilot_speed_z_max_dn_ms);
 }
 
 /*

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1060,9 +1060,9 @@ void QuadPlane::check_yaw_reset(void)
     }
 }
 
-void QuadPlane::set_climb_rate_cms(float target_climb_rate_cms)
+void QuadPlane::set_climb_rate_ms(float target_climb_rate_ms)
 {
-    pos_control->input_vel_accel_U_cm(target_climb_rate_cms, 0, false);
+    pos_control->input_vel_accel_U_m(target_climb_rate_ms, 0, false);
 }
 
 /*
@@ -1080,7 +1080,7 @@ void QuadPlane::hold_hover(float target_climb_rate_cms)
     multicopter_attitude_rate_update(get_desired_yaw_rate_cds(false));
 
     // call position controller
-    set_climb_rate_cms(target_climb_rate_cms);
+    set_climb_rate_ms(target_climb_rate_cms * 0.01);
 
     run_z_controller();
 }
@@ -2829,7 +2829,7 @@ void QuadPlane::vtol_position_controller(void)
             float zero = 0;
             pos_control->input_pos_vel_accel_U_cm(target_u_cm, zero, 0);
         } else {
-            set_climb_rate_cms(0);
+            set_climb_rate_ms(0);
         }
         break;
     }
@@ -2844,7 +2844,7 @@ void QuadPlane::vtol_position_controller(void)
             }
         }
         if (poscontrol.get_state() == QPOS_LAND_ABORT) {
-            set_climb_rate_cms(wp_nav->get_default_speed_up_cms());
+            set_climb_rate_ms(wp_nav->get_default_speed_up_cms() * 0.01);
             break;
         }
         const float descent_rate_cms = landing_descent_rate_cms(height_above_ground_m);
@@ -3166,7 +3166,7 @@ void QuadPlane::takeoff_controller(void)
                                                                   plane.nav_pitch_cd,
                                                                   get_pilot_input_yaw_rate_cds() + get_weathervane_yaw_rate_cds());
 
-    float vel_u_cm = wp_nav->get_default_speed_up_cms();
+    float vel_u_ms = wp_nav->get_default_speed_up_cms();
     if (plane.control_mode == &plane.mode_guided && guided_takeoff) {
         // for guided takeoff we aim for a specific height with zero
         // velocity at that height
@@ -3176,13 +3176,13 @@ void QuadPlane::takeoff_controller(void)
             // stage
             const int32_t margin_cm = 5;
             float pos_u_cm = margin_cm + plane.next_WP_loc.alt - origin.alt;
-            vel_u_cm = 0;
-            pos_control->input_pos_vel_accel_U_cm(pos_u_cm, vel_u_cm, 0);
+            vel_u_ms = 0;
+            pos_control->input_pos_vel_accel_U_cm(pos_u_cm, vel_u_ms, 0);
         } else {
-            set_climb_rate_cms(vel_u_cm);
+            set_climb_rate_ms(vel_u_ms);
         }
     } else {
-        set_climb_rate_cms(vel_u_cm);
+        set_climb_rate_ms(vel_u_ms);
     }
 
     run_z_controller();
@@ -3228,7 +3228,7 @@ void QuadPlane::waypoint_controller(void)
                                                        true);
 
     // climb based on altitude error
-    set_climb_rate_cms(assist_climb_rate_cms());
+    set_climb_rate_ms(assist_climb_rate_cms() * 0.01);
     run_z_controller();
 }
 

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -248,7 +248,7 @@ private:
     void hold_stabilize(float throttle_in);
 
     // set climb rate in position controller
-    void set_climb_rate_cms(float target_climb_rate_cms);
+    void set_climb_rate_ms(float target_climb_rate_ms);
 
     // get pilot desired yaw rate in cd/s
     float get_pilot_input_yaw_rate_cds(void) const;

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -149,7 +149,7 @@ public:
     // is throttle controlled landing descent active?
     bool thr_ctrl_land;
 
-    uint16_t get_pilot_velocity_z_max_dn_cm() const;
+    uint16_t get_pilot_velocity_z_max_dn_m() const;
     
     struct PACKED log_QControl_Tuning {
         LOG_PACKET_HEADER;

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -515,9 +515,9 @@ private:
         uint32_t time_since_state_start_ms() const {
             return AP_HAL::millis() - last_state_change_ms;
         }
-        Vector3p target_neu_cm;
+        Vector3p target_neu_m;
         Vector2f correction_ne_m;
-        Vector3f target_vel_cms;
+        Vector3f target_vel_ms;
         bool slow_descent:1;
         bool pilot_correction_active;
         bool pilot_correction_done;

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -288,7 +288,7 @@ private:
     void motors_output(bool run_rate_controller = true);
     void Log_Write_QControl_Tuning();
     void log_QPOS(void);
-    float landing_descent_rate_cms(float height_above_ground_m);
+    float landing_descent_rate_ms(float height_above_ground_m);
     
     // setup correct aux channels for frame class
     void setup_default_channels(uint8_t num_motors);


### PR DESCRIPTION
Reclaim lost space by moving all AC_PosControl  and AC_WPNav accessors to m. We should get a little more back as I restructure both to compile out any cm accessors in the .h file.

```
Board,blimp,bootloader,copter,heli,plane,rover,sub
CubeOrange,*,*,*,*,-1232,*,*
```