### PR TITLE
Revert "Tools: add and use ability to get HWDef for board out of Boar…

### DIFF
--- a/Tools/scripts/build_binaries.py
+++ b/Tools/scripts/build_binaries.py
@@ -615,7 +615,7 @@ is bob we will attempt to checkout bob-AVR'''
         '''build Tracker binaries'''
         self.build_vehicle(tag,
                            "AntennaTracker",
-                           self.board_list.find_autobuild_boards('AntennaTracker')[:],
+                           self.board_list.find_autobuild_boards('Tracker')[:],
                            "AntennaTracker",
                            "antennatracker")
 


### PR DESCRIPTION
…dList"

This reverts commit 721ed65003a8eb64c258c8b1518965f8edfa0637.

This commit causes issues on the 4.6 branch as hwdef.py doesn't exist.

We copy board_list.py back as part of build_binaries.py but not all of the hwdef.py files, so the script doesn't start.

It is unclear to me why we copy board_list.py back, it doesn't seem necessary or correct, rather build_binaries.py should adapt to whatever is on the branch it is trying to build.