### PR TITLE
AP_Scripting: add example which prints checksum of @SYS/flash.bin

### DIFF
--- a/libraries/AP_Scripting/examples/checksum_firmware.lua
+++ b/libraries/AP_Scripting/examples/checksum_firmware.lua
@@ -1,0 +1,27 @@
+--[[
+   This script reads the firmware, calculates a checksum and emits a text message.
+
+   It does this 10 seconds after boot.  And any time millis() wraps.
+--]]
+
+local flash_file_path = "@SYS/flash.bin"
+
+function update()
+   -- wait until we've been booted 10 seconds before sending:
+   local now = millis()
+   if now < 10000 then
+      -- not time yet
+      return update, 100
+   end
+
+   local result = fs:crc32(flash_file_path)
+   if result == nil then
+      gcs:send_text(3, string.format("checksum_firmware error: checksumming failed"))
+   else
+      gcs:send_text(3, string.format("checksum_firmware: 0x%x", result:toint()))
+   end
+
+   return  -- this script is one-shot 
+end
+
+return update()


### PR DESCRIPTION
Simply emits the CRC for the running firmware 10 seconds after boot.

```
AP: RCOut: PWM:1-14
AP: checksum_firmware: 0x7C7954E6

MANUAL> 
MANUAL> ftp crc @SYS/flash.bin
MANUAL> Getting CRC for @SYS/flash.bin
crc: @SYS/flash.bin 0x7c7954e6 in 0.1s
AP: PreArm: Hardware safety switch
```
