### PR TITLE
Convert WP_Nav (5): WPNav Object Avoidance library from centimetres to meters with backward-compatible cm interfaces

### DIFF
--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -5,14 +5,14 @@
 
 extern const AP_HAL::HAL& hal;
 
-#define LOITER_SPEED_DEFAULT                1250.0f // default loiter speed in cm/s
-#define LOITER_SPEED_MIN                    20.0f   // minimum loiter speed in cm/s
-#define LOITER_ACCEL_MAX_DEFAULT            500.0f  // default acceleration in loiter mode
-#define LOITER_BRAKE_ACCEL_DEFAULT          250.0f  // minimum acceleration in loiter mode
-#define LOITER_BRAKE_JERK_DEFAULT           500.0f  // maximum jerk in cm/s/s/s in loiter mode
-#define LOITER_BRAKE_START_DELAY_DEFAULT    1.0f    // delay (in seconds) before loiter braking begins after sticks are released
-#define LOITER_VEL_CORRECTION_MAX           200.0f  // max speed used to correct position errors in loiter
-#define LOITER_POS_CORRECTION_MAX           200.0f  // max position error in loiter
+#define LOITER_SPEED_DEFAULT_CM             1250.0  // default loiter speed in cm/s
+#define LOITER_SPEED_MIN_CMS                20.0    // minimum loiter speed in cm/s
+#define LOITER_ACCEL_MAX_DEFAULT_CMSS       500.0   // default acceleration in loiter mode
+#define LOITER_BRAKE_ACCEL_DEFAULT_CMSS     250.0   // minimum acceleration in loiter mode
+#define LOITER_BRAKE_JERK_DEFAULT_CMSSS     500.0   // maximum jerk in cm/s/s/s in loiter mode
+#define LOITER_BRAKE_START_DELAY_DEFAULT_S  1.0     // delay (in seconds) before loiter braking begins after sticks are released
+#define LOITER_VEL_CORRECTION_MAX_CMS       200.0   // max speed used to correct position errors in loiter
+#define LOITER_POS_CORRECTION_MAX_CM        200.0   // max position error in loiter
 #define LOITER_ACTIVE_TIMEOUT_MS            200     // loiter controller is considered active if it has been called within the past 200ms (0.2 seconds)
 
 const AP_Param::GroupInfo AC_Loiter::var_info[] = {
@@ -34,7 +34,7 @@ const AP_Param::GroupInfo AC_Loiter::var_info[] = {
     // @Range: 20 3500
     // @Increment: 50
     // @User: Standard
-    AP_GROUPINFO("SPEED", 2, AC_Loiter, _speed_max_ne_cms, LOITER_SPEED_DEFAULT),
+    AP_GROUPINFO("SPEED", 2, AC_Loiter, _speed_max_ne_cms, LOITER_SPEED_DEFAULT_CM),
 
     // @Param: ACC_MAX
     // @DisplayName: Loiter maximum correction acceleration
@@ -43,7 +43,7 @@ const AP_Param::GroupInfo AC_Loiter::var_info[] = {
     // @Range: 100 981
     // @Increment: 1
     // @User: Advanced
-    AP_GROUPINFO("ACC_MAX", 3, AC_Loiter, _accel_max_ne_cmss, LOITER_ACCEL_MAX_DEFAULT),
+    AP_GROUPINFO("ACC_MAX", 3, AC_Loiter, _accel_max_ne_cmss, LOITER_ACCEL_MAX_DEFAULT_CMSS),
 
     // @Param: BRK_ACCEL
     // @DisplayName: Loiter braking acceleration
@@ -52,7 +52,7 @@ const AP_Param::GroupInfo AC_Loiter::var_info[] = {
     // @Range: 25 250
     // @Increment: 1
     // @User: Advanced
-    AP_GROUPINFO("BRK_ACCEL", 4, AC_Loiter, _brake_accel_max_cmss, LOITER_BRAKE_ACCEL_DEFAULT),
+    AP_GROUPINFO("BRK_ACCEL", 4, AC_Loiter, _brake_accel_max_cmss, LOITER_BRAKE_ACCEL_DEFAULT_CMSS),
 
     // @Param: BRK_JERK
     // @DisplayName: Loiter braking jerk
@@ -61,7 +61,7 @@ const AP_Param::GroupInfo AC_Loiter::var_info[] = {
     // @Range: 500 5000
     // @Increment: 1
     // @User: Advanced
-    AP_GROUPINFO("BRK_JERK", 5, AC_Loiter, _brake_jerk_max_cmsss, LOITER_BRAKE_JERK_DEFAULT),
+    AP_GROUPINFO("BRK_JERK", 5, AC_Loiter, _brake_jerk_max_cmsss, LOITER_BRAKE_JERK_DEFAULT_CMSSS),
 
     // @Param: BRK_DELAY
     // @DisplayName: Loiter brake start delay (in seconds)
@@ -70,7 +70,7 @@ const AP_Param::GroupInfo AC_Loiter::var_info[] = {
     // @Range: 0 2
     // @Increment: 0.1
     // @User: Advanced
-    AP_GROUPINFO("BRK_DELAY",  6, AC_Loiter, _brake_delay_s, LOITER_BRAKE_START_DELAY_DEFAULT),
+    AP_GROUPINFO("BRK_DELAY",  6, AC_Loiter, _brake_delay_s, LOITER_BRAKE_START_DELAY_DEFAULT_S),
 
     AP_GROUPEND
 };
@@ -93,8 +93,8 @@ void AC_Loiter::init_target_cm(const Vector2f& position_ne_cm)
     sanity_check_params();
 
     // initialise position controller speed and acceleration
-    _pos_control.set_correction_speed_accel_NE_cm(LOITER_VEL_CORRECTION_MAX, _accel_max_ne_cmss);
-    _pos_control.set_pos_error_max_NE_cm(LOITER_POS_CORRECTION_MAX);
+    _pos_control.set_correction_speed_accel_NE_cm(LOITER_VEL_CORRECTION_MAX_CMS, _accel_max_ne_cmss);
+    _pos_control.set_pos_error_max_NE_cm(LOITER_VEL_CORRECTION_MAX_CMS);
 
     // initialise position controller
     _pos_control.init_NE_controller_stopping_point();
@@ -115,8 +115,8 @@ void AC_Loiter::init_target()
     sanity_check_params();
 
     // initialise position controller speed and acceleration
-    _pos_control.set_correction_speed_accel_NE_cm(LOITER_VEL_CORRECTION_MAX, _accel_max_ne_cmss);
-    _pos_control.set_pos_error_max_NE_cm(LOITER_POS_CORRECTION_MAX);
+    _pos_control.set_correction_speed_accel_NE_cm(LOITER_VEL_CORRECTION_MAX_CMS, _accel_max_ne_cmss);
+    _pos_control.set_pos_error_max_NE_cm(LOITER_POS_CORRECTION_MAX_CM);
 
     // initialise position controller and move target accelerations smoothly towards zero
     _pos_control.relax_velocity_controller_NE();
@@ -141,33 +141,33 @@ void AC_Loiter::set_pilot_desired_acceleration_cd(float euler_roll_angle_cd, flo
 }
 
 /// set pilot desired acceleration in radians
-//   dt should be the time (in seconds) since the last call to this function
+//   dt_s should be the time (in seconds) since the last call to this function
 void AC_Loiter::set_pilot_desired_acceleration_rad(float euler_roll_angle_rad, float euler_pitch_angle_rad)
 {
-    const float dt = _attitude_control.get_dt_s();
+    const float dt_s = _attitude_control.get_dt_s();
 
     // convert our desired attitude to an acceleration vector assuming we are not accelerating vertically
     const Vector3f desired_euler_rad {euler_roll_angle_rad, euler_pitch_angle_rad, _ahrs.yaw};
-    const Vector3f desired_accel_NEU_cmss = _pos_control.lean_angles_rad_to_accel_NEU_cmss(desired_euler_rad);
+    const Vector3f desired_accel_neu_cmss = _pos_control.lean_angles_rad_to_accel_NEU_cmss(desired_euler_rad);
 
-    _desired_accel_ne_cmss.x = desired_accel_NEU_cmss.x;
-    _desired_accel_ne_cmss.y = desired_accel_NEU_cmss.y;
+    _desired_accel_ne_cmss.x = desired_accel_neu_cmss.x;
+    _desired_accel_ne_cmss.y = desired_accel_neu_cmss.y;
 
     // difference between where we think we should be and where we want to be
-    Vector2f angle_error(wrap_PI(euler_roll_angle_rad - _predicted_euler_angle_rad.x), wrap_PI(euler_pitch_angle_rad - _predicted_euler_angle_rad.y));
+    Vector2f angle_error_euler_rad(wrap_PI(euler_roll_angle_rad - _predicted_euler_angle_rad.x), wrap_PI(euler_pitch_angle_rad - _predicted_euler_angle_rad.y));
 
     // calculate the angular velocity that we would expect given our desired and predicted attitude
-    _attitude_control.input_shaping_rate_predictor(angle_error, _predicted_euler_rate, dt);
+    _attitude_control.input_shaping_rate_predictor(angle_error_euler_rad, _predicted_euler_rate, dt_s);
 
     // update our predicted attitude based on our predicted angular velocity
-    _predicted_euler_angle_rad += _predicted_euler_rate * dt;
+    _predicted_euler_angle_rad += _predicted_euler_rate * dt_s;
 
     // convert our predicted attitude to an acceleration vector assuming we are not accelerating vertically
     const Vector3f predicted_euler_rad {_predicted_euler_angle_rad.x, _predicted_euler_angle_rad.y, _ahrs.yaw};
-    const Vector3f predicted_accel = _pos_control.lean_angles_rad_to_accel_NEU_cmss(predicted_euler_rad);
+    const Vector3f predicted_accel_neu_cm = _pos_control.lean_angles_rad_to_accel_NEU_cmss(predicted_euler_rad);
 
-    _predicted_accel_ne_cmss.x = predicted_accel.x;
-    _predicted_accel_ne_cmss.y = predicted_accel.y;
+    _predicted_accel_ne_cmss.x = predicted_accel_neu_cm.x;
+    _predicted_accel_ne_cmss.y = predicted_accel_neu_cm.y;
 }
 
 /// get vector to stopping point based on a horizontal position and velocity
@@ -201,13 +201,13 @@ void AC_Loiter::update(bool avoidance_on)
 //set maximum horizontal speed
 void AC_Loiter::set_speed_max_NE_cms(float speed_max_ne_cms)
 {
-    _speed_max_ne_cms.set(MAX(speed_max_ne_cms, LOITER_SPEED_MIN));
+    _speed_max_ne_cms.set(MAX(speed_max_ne_cms, LOITER_SPEED_MIN_CMS));
 }
 
 // sanity check parameters
 void AC_Loiter::sanity_check_params()
 {
-    _speed_max_ne_cms.set(MAX(_speed_max_ne_cms, LOITER_SPEED_MIN));
+    _speed_max_ne_cms.set(MAX(_speed_max_ne_cms, LOITER_SPEED_MIN_CMS));
     _accel_max_ne_cmss.set(MIN(_accel_max_ne_cmss, GRAVITY_MSS * 100.0f * tanf(_attitude_control.lean_angle_max_rad())));
 }
 
@@ -215,63 +215,63 @@ void AC_Loiter::sanity_check_params()
 ///		updated velocity sent directly to position controller
 void AC_Loiter::calc_desired_velocity(bool avoidance_on)
 {
-    float ekfGndSpdLimit, ahrsControlScaleXY;
-    AP::ahrs().getControlLimits(ekfGndSpdLimit, ahrsControlScaleXY);
+    float ekfGndSpdLimit_ms, ahrsControlScaleXY;
+    AP::ahrs().getControlLimits(ekfGndSpdLimit_ms, ahrsControlScaleXY);
 
-    const float dt = _pos_control.get_dt_s();
+    const float dt_s = _pos_control.get_dt_s();
 
     // calculate a loiter speed limit which is the minimum of the value set by the LOITER_SPEED
     // parameter and the value set by the EKF to observe optical flow limits
-    float gnd_speed_limit_cms = MIN(_speed_max_ne_cms, ekfGndSpdLimit * 100.0f);
-    gnd_speed_limit_cms = MAX(gnd_speed_limit_cms, LOITER_SPEED_MIN);
+    float gnd_speed_limit_cms = MIN(_speed_max_ne_cms, ekfGndSpdLimit_ms * 100.0f);
+    gnd_speed_limit_cms = MAX(gnd_speed_limit_cms, LOITER_SPEED_MIN_CMS);
 
-    float pilot_acceleration_max = angle_rad_to_accel_mss(get_angle_max_rad()) * 100;
+    float pilot_acceleration_max_cmss = angle_rad_to_accel_mss(get_angle_max_rad()) * 100;
 
-    // range check dt
-    if (is_negative(dt)) {
+    // range check dt_s
+    if (is_negative(dt_s)) {
         return;
     }
 
     // get loiters desired velocity from the position controller where it is being stored.
-    Vector2f desired_vel = _pos_control.get_vel_desired_NEU_cms().xy();
+    Vector2f desired_vel_ne_cms = _pos_control.get_vel_desired_NEU_cms().xy();
 
     // update the desired velocity using our predicted acceleration
-    desired_vel += _predicted_accel_ne_cmss * dt;
+    desired_vel_ne_cms += _predicted_accel_ne_cmss * dt_s;
 
-    Vector2f loiter_accel_brake;
-    float desired_speed = desired_vel.length();
-    if (!is_zero(desired_speed)) {
-        Vector2f desired_vel_norm = desired_vel / desired_speed;
+    Vector2f loiter_accel_brake_cmss;
+    float desired_speed_cms = desired_vel_ne_cms.length();
+    if (!is_zero(desired_speed_cms)) {
+        Vector2f desired_vel_norm = desired_vel_ne_cms / desired_speed_cms;
 
         // calculate a drag acceleration based on the desired speed.
-        float drag_decel = pilot_acceleration_max * desired_speed / gnd_speed_limit_cms;
+        float drag_decel_cmss = pilot_acceleration_max_cmss * desired_speed_cms / gnd_speed_limit_cms;
 
         // calculate a braking acceleration if sticks are at zero
-        float loiter_brake_accel = 0.0f;
+        float loiter_brake_accel_cmss = 0.0f;
         if (_desired_accel_ne_cmss.is_zero()) {
             if ((AP_HAL::millis() - _brake_timer_ms) > _brake_delay_s * 1000.0f) {
                 float brake_gain = _pos_control.get_vel_NE_pid().kP() * 0.5f;
-                loiter_brake_accel = constrain_float(sqrt_controller(desired_speed, brake_gain, _brake_jerk_max_cmsss, dt), 0.0f, _brake_accel_max_cmss);
+                loiter_brake_accel_cmss = constrain_float(sqrt_controller(desired_speed_cms, brake_gain, _brake_jerk_max_cmsss, dt_s), 0.0f, _brake_accel_max_cmss);
             }
         } else {
-            loiter_brake_accel = 0.0f;
+            loiter_brake_accel_cmss = 0.0f;
             _brake_timer_ms = AP_HAL::millis();
         }
-        _brake_accel_cmss += constrain_float(loiter_brake_accel - _brake_accel_cmss, -_brake_jerk_max_cmsss * dt, _brake_jerk_max_cmsss * dt);
-        loiter_accel_brake = desired_vel_norm * _brake_accel_cmss;
+        _brake_accel_cmss += constrain_float(loiter_brake_accel_cmss - _brake_accel_cmss, -_brake_jerk_max_cmsss * dt_s, _brake_jerk_max_cmsss * dt_s);
+        loiter_accel_brake_cmss = desired_vel_norm * _brake_accel_cmss;
 
         // update the desired velocity using the drag and braking accelerations
-        desired_speed = MAX(desired_speed - (drag_decel + _brake_accel_cmss) * dt, 0.0f);
-        desired_vel = desired_vel_norm * desired_speed;
+        desired_speed_cms = MAX(desired_speed_cms - (drag_decel_cmss + _brake_accel_cmss) * dt_s, 0.0f);
+        desired_vel_ne_cms = desired_vel_norm * desired_speed_cms;
     }
 
     // add braking to the desired acceleration
-    _desired_accel_ne_cmss -= loiter_accel_brake;
+    _desired_accel_ne_cmss -= loiter_accel_brake_cmss;
 
     // Apply EKF limit to desired velocity -  this limit is calculated by the EKF and adjusted as required to ensure certain sensor limits are respected (eg optical flow sensing)
-    float horizSpdDem = desired_vel.length();
+    float horizSpdDem = desired_vel_ne_cms.length();
     if (horizSpdDem > gnd_speed_limit_cms) {
-        desired_vel = desired_vel * gnd_speed_limit_cms / horizSpdDem;
+        desired_vel_ne_cms = desired_vel_ne_cms * gnd_speed_limit_cms / horizSpdDem;
     }
 
 #if AP_AVOIDANCE_ENABLED && !APM_BUILD_TYPE(APM_BUILD_ArduPlane)
@@ -280,19 +280,19 @@ void AC_Loiter::calc_desired_velocity(bool avoidance_on)
         // TODO: We need to also limit the _desired_accel_ne_cmss
         AC_Avoid *_avoid = AP::ac_avoid();
         if (_avoid != nullptr) {
-            Vector3f avoidance_vel_3d{desired_vel.x, desired_vel.y, 0.0f};
-            _avoid->adjust_velocity(avoidance_vel_3d, _pos_control.get_pos_NE_p().kP(), _accel_max_ne_cmss, _pos_control.get_pos_U_p().kP(), _pos_control.get_max_accel_U_cmss(), dt);
-            desired_vel = Vector2f{avoidance_vel_3d.x, avoidance_vel_3d.y};
+            Vector3f avoidance_vel_neu_cms{desired_vel_ne_cms.x, desired_vel_ne_cms.y, 0.0f};
+            _avoid->adjust_velocity(avoidance_vel_neu_cms, _pos_control.get_pos_NE_p().kP(), _accel_max_ne_cmss, _pos_control.get_pos_U_p().kP(), _pos_control.get_max_accel_U_cmss(), dt_s);
+            desired_vel_ne_cms = Vector2f{avoidance_vel_neu_cms.x, avoidance_vel_neu_cms.y};
         }
     }
 #endif // !APM_BUILD_ArduPlane
 
     // get loiters desired velocity from the position controller where it is being stored.
-    Vector2p desired_pos = _pos_control.get_pos_desired_NEU_cm().xy();
+    Vector2p desired_pos_neu_cm = _pos_control.get_pos_desired_NEU_cm().xy();
 
     // update the desired position using our desired velocity and acceleration
-    desired_pos += (desired_vel * dt).topostype();
+    desired_pos_neu_cm += (desired_vel_ne_cms * dt_s).topostype();
 
     // send adjusted feed forward acceleration and velocity back to the Position Controller
-    _pos_control.set_pos_vel_accel_NE_cm(desired_pos, desired_vel, _desired_accel_ne_cmss);
+    _pos_control.set_pos_vel_accel_NE_cm(desired_pos_neu_cm, desired_vel_ne_cms, _desired_accel_ne_cmss);
 }

--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -87,13 +87,16 @@ AC_Loiter::AC_Loiter(const AP_AHRS_View& ahrs, AC_PosControl& pos_control, const
     AP_Param::setup_object_defaults(this, var_info);
 }
 
-/// initialise loiter target to a position in cm from ekf origin
+// Sets the initial loiter target position in centimeters from the EKF origin.
+// See init_target_m() for full details.
 void AC_Loiter::init_target_cm(const Vector2f& position_ne_cm)
 {
     init_target_m(position_ne_cm * 0.01);
 }
 
-/// initialise loiter target to a position in m from ekf origin
+// Sets the initial loiter target position in meters from the EKF origin.
+// - position_neu_m: horizontal position in the NE frame, in meters.
+// - Initializes internal control state including acceleration targets and feed-forward planning.
 void AC_Loiter::init_target_m(const Vector2f& position_ne_m)
 {
     sanity_check_params();
@@ -114,7 +117,8 @@ void AC_Loiter::init_target_m(const Vector2f& position_ne_m)
     _pos_control.set_pos_desired_NE_m(position_ne_m);
 }
 
-/// initialize's position and feed-forward velocity from current pos and velocity
+// Initializes the loiter controller using the current position and velocity.
+// Updates feed-forward velocity, predicted acceleration, and resets control state.
 void AC_Loiter::init_target()
 {
     sanity_check_params();
@@ -133,20 +137,24 @@ void AC_Loiter::init_target()
     _brake_accel_mss = 0.0f;
 }
 
-/// reduce response for landing
+// Reduces loiter responsiveness for smoother descent during landing.
+// Internally softens horizontal control gains.
 void AC_Loiter::soften_for_landing()
 {
     _pos_control.soften_for_landing_NE();
 }
 
-/// set pilot desired acceleration in centidegrees
+// Sets pilot desired acceleration using Euler angles in centidegrees.
+// See set_pilot_desired_acceleration_rad() for full details.
 void AC_Loiter::set_pilot_desired_acceleration_cd(float euler_roll_angle_cd, float euler_pitch_angle_cd)
 {
     set_pilot_desired_acceleration_rad(cd_to_rad(euler_roll_angle_cd), cd_to_rad(euler_pitch_angle_cd));
 }
 
-/// set pilot desired acceleration in radians
-//   dt_s should be the time (in seconds) since the last call to this function
+// Sets pilot desired acceleration using Euler angles in radians.
+// - Internally computes a smoothed acceleration vector based on predictive rate shaping.
+// - Inputs: `euler_roll_angle_rad`, `euler_pitch_angle_rad` in radians.
+// - Applies internal shaping using the current attitude controller dt.
 void AC_Loiter::set_pilot_desired_acceleration_rad(float euler_roll_angle_rad, float euler_pitch_angle_rad)
 {
     const float dt_s = _attitude_control.get_dt_s();
@@ -175,7 +183,9 @@ void AC_Loiter::set_pilot_desired_acceleration_rad(float euler_roll_angle_rad, f
     _predicted_accel_ne_mss.y = predicted_accel_neu_m.y;
 }
 
-/// get vector to stopping point based on a horizontal position and velocity
+// Calculates the expected stopping point based on current velocity and position in the NE frame.
+// Result is returned in centimeters.
+// See get_stopping_point_NE_m() for full details.
 void AC_Loiter::get_stopping_point_NE_cm(Vector2f& stopping_point_ne_cm) const
 {
     Vector2f stop_ne_m;
@@ -183,7 +193,9 @@ void AC_Loiter::get_stopping_point_NE_cm(Vector2f& stopping_point_ne_cm) const
     stopping_point_ne_cm = stop_ne_m * 100.0;
 }
 
-/// get vector to stopping point based on a horizontal position and velocity
+// Calculates the expected stopping point based on current velocity and position in the NE frame.
+// Result is returned in meters.
+// Uses the position controller’s deceleration model.
 void AC_Loiter::get_stopping_point_NE_m(Vector2f& stopping_point_ne_m) const
 {
     Vector2p stop_ne_m;
@@ -191,7 +203,16 @@ void AC_Loiter::get_stopping_point_NE_m(Vector2f& stopping_point_ne_m) const
     stopping_point_ne_m = stop_ne_m.tofloat();
 }
 
-/// get maximum lean angle when using loiter
+// Returns the maximum pilot-commanded lean angle in centidegrees.
+// See get_angle_max_rad() for full details.
+float AC_Loiter::get_angle_max_cd() const
+{
+    return rad_to_cd(get_angle_max_rad());
+}
+
+// Returns the maximum pilot-commanded lean angle in radians.
+// - If `_angle_max_deg` is zero, this returns 2/3 of the limiting PSC angle.
+// - Otherwise, returns the minimum of `_angle_max_deg` and PSC’s configured angle limit.
 float AC_Loiter::get_angle_max_rad() const
 {
     if (!is_positive(_angle_max_deg)) {
@@ -199,37 +220,41 @@ float AC_Loiter::get_angle_max_rad() const
     }
     return MIN(radians(_angle_max_deg), _pos_control.get_lean_angle_max_rad());
 }
-float AC_Loiter::get_angle_max_cd() const
-{
-    return rad_to_cd(get_angle_max_rad());
-}
 
-/// run the loiter controller
+// Runs the loiter control loop, computing desired acceleration and updating position control.
+// If `avoidance_on` is true, velocity is adjusted using avoidance logic before being applied.
 void AC_Loiter::update(bool avoidance_on)
 {
     calc_desired_velocity(avoidance_on);
     _pos_control.update_NE_controller();
 }
 
-//set maximum horizontal speed
+// Sets the maximum allowed horizontal loiter speed in cm/s.
+// See set_speed_max_NE_ms() for full details.
 void AC_Loiter::set_speed_max_NE_cms(float speed_max_ne_cms)
 {
     set_speed_max_NE_ms(speed_max_ne_cms * 0.01);
 }
+
+// Sets the maximum allowed horizontal loiter speed in m/s.
+// Internally converts to cm/s and clamps to a minimum of LOITER_SPEED_MIN_CMS.
 void AC_Loiter::set_speed_max_NE_ms(float speed_max_ne_ms)
 {
     _speed_max_ne_cms.set(MAX(speed_max_ne_ms * 100.0, LOITER_SPEED_MIN_CMS));
 }
 
-// sanity check parameters
+// Ensures internal parameters are within valid safety limits.
+// Applies min/max constraints on speed and acceleration settings.
 void AC_Loiter::sanity_check_params()
 {
     _speed_max_ne_cms.set(MAX(_speed_max_ne_cms, LOITER_SPEED_MIN_CMS));
     _accel_max_ne_cmss.set(MIN(_accel_max_ne_cmss, GRAVITY_MSS * 100.0f * tanf(_attitude_control.lean_angle_max_rad())));
 }
 
-/// calc_desired_velocity - updates desired velocity (i.e. feed forward) with pilot requested acceleration and fake wind resistance
-///		updated velocity sent directly to position controller
+// Updates feed-forward velocity using pilot-requested acceleration and braking logic.
+// - Applies drag and braking forces when sticks are released.
+// - Velocity is adjusted for fence/avoidance if enabled.
+// - Resulting velocity and acceleration are sent to the position controller.
 void AC_Loiter::calc_desired_velocity(bool avoidance_on)
 {
     float ekfGndSpdLimit_ms, ahrsControlScaleXY;

--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -5,15 +5,15 @@
 
 extern const AP_HAL::HAL& hal;
 
-#define LOITER_SPEED_DEFAULT_CM             1250.0  // default loiter speed in cm/s
-#define LOITER_SPEED_MIN_CMS                20.0    // minimum loiter speed in cm/s
-#define LOITER_ACCEL_MAX_DEFAULT_CMSS       500.0   // default acceleration in loiter mode
-#define LOITER_BRAKE_ACCEL_DEFAULT_CMSS     250.0   // minimum acceleration in loiter mode
-#define LOITER_BRAKE_JERK_DEFAULT_CMSSS     500.0   // maximum jerk in cm/s/s/s in loiter mode
-#define LOITER_BRAKE_START_DELAY_DEFAULT_S  1.0     // delay (in seconds) before loiter braking begins after sticks are released
-#define LOITER_VEL_CORRECTION_MAX_MS        2.0     // max speed in m/s used to correct position errors in loiter
-#define LOITER_POS_CORRECTION_MAX_M         2.0     // max position error in loiter
-#define LOITER_ACTIVE_TIMEOUT_MS            200     // loiter controller is considered active if it has been called within the past 200ms (0.2 seconds)
+#define LOITER_SPEED_DEFAULT_CM             1250.0  // Default horizontal loiter speed in cm/s.
+#define LOITER_SPEED_MIN_CMS                20.0    // Minimum allowed horizontal loiter speed in cm/s.
+#define LOITER_ACCEL_MAX_DEFAULT_CMSS       500.0   // Default maximum horizontal acceleration in loiter mode (cm/s²).
+#define LOITER_BRAKE_ACCEL_DEFAULT_CMSS     250.0   // Default maximum braking acceleration when sticks are released (cm/s²).
+#define LOITER_BRAKE_JERK_DEFAULT_CMSSS     500.0   // Default maximum jerk applied during braking transitions (cm/s³).
+#define LOITER_BRAKE_START_DELAY_DEFAULT_S  1.0     // Delay (in seconds) before braking begins after sticks are released.
+#define LOITER_VEL_CORRECTION_MAX_MS        2.0     // Maximum speed (in m/s) used for correcting position errors in loiter.
+#define LOITER_POS_CORRECTION_MAX_M         2.0     // Maximum horizontal position error allowed before correction (m).
+#define LOITER_ACTIVE_TIMEOUT_MS            200     // Loiter is considered active if updated within the past 200 ms.
 
 const AP_Param::GroupInfo AC_Loiter::var_info[] = {
 

--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -78,7 +78,6 @@ const AP_Param::GroupInfo AC_Loiter::var_info[] = {
 // Default constructor.
 // Note that the Vector/Matrix constructors already implicitly zero
 // their values.
-//
 AC_Loiter::AC_Loiter(const AP_AHRS_View& ahrs, AC_PosControl& pos_control, const AC_AttitudeControl& attitude_control) :
     _ahrs(ahrs),
     _pos_control(pos_control),
@@ -101,19 +100,20 @@ void AC_Loiter::init_target_m(const Vector2f& position_ne_m)
 {
     sanity_check_params();
 
+    // Configure speed/accel limits in meters using internal parameter (_accel_max_ne_cmss)
     _pos_control.set_correction_speed_accel_NE_m(LOITER_VEL_CORRECTION_MAX_MS, _accel_max_ne_cmss * 0.01);
     _pos_control.set_pos_error_max_NE_m(LOITER_POS_CORRECTION_MAX_M);
 
-    // initialise position controller
+    // Reset controller state for stationary loiter
     _pos_control.init_NE_controller_stopping_point();
 
-    // initialise desired acceleration and angles to zero to remain on station
+    // Zero out desired and predicted accelerations and angles
     _predicted_accel_ne_mss.zero();
     _desired_accel_ne_mss.zero();
     _predicted_euler_angle_rad.zero();
     _brake_accel_mss = 0.0f;
 
-    // set target position
+    // Set position target for stationary loiter
     _pos_control.set_pos_desired_NE_m(position_ne_m);
 }
 
@@ -123,14 +123,14 @@ void AC_Loiter::init_target()
 {
     sanity_check_params();
 
-    // initialise position controller speed and acceleration
+    // Configure correction speed and acceleration limits (in m/s and m/s²)
     _pos_control.set_correction_speed_accel_NE_m(LOITER_VEL_CORRECTION_MAX_MS, _accel_max_ne_cmss * 0.01);
     _pos_control.set_pos_error_max_NE_m(LOITER_POS_CORRECTION_MAX_M);
 
-    // initialise position controller and move target accelerations smoothly towards zero
+    // Apply velocity smoothing: softly transitions target acceleration to zero
     _pos_control.relax_velocity_controller_NE();
 
-    // initialise predicted acceleration and angles from the position controller
+    // Initialize prediction state using current acceleration and lean angles
     _predicted_accel_ne_mss = _pos_control.get_accel_target_NEU_mss().xy();
     _predicted_euler_angle_rad.x = _pos_control.get_roll_rad();
     _predicted_euler_angle_rad.y = _pos_control.get_pitch_rad();
@@ -166,16 +166,16 @@ void AC_Loiter::set_pilot_desired_acceleration_rad(float euler_roll_angle_rad, f
     _desired_accel_ne_mss.x = desired_accel_neu_mss.x;
     _desired_accel_ne_mss.y = desired_accel_neu_mss.y;
 
-    // difference between where we think we should be and where we want to be
+    // Compute attitude error between desired and predicted lean angles
     Vector2f angle_error_euler_rad(wrap_PI(euler_roll_angle_rad - _predicted_euler_angle_rad.x), wrap_PI(euler_pitch_angle_rad - _predicted_euler_angle_rad.y));
 
-    // calculate the angular velocity that we would expect given our desired and predicted attitude
+    // Predict roll/pitch rate required to achieve target attitude
     _attitude_control.input_shaping_rate_predictor(angle_error_euler_rad, _predicted_euler_rate, dt_s);
 
-    // update our predicted attitude based on our predicted angular velocity
+    // Update internal attitude estimate for next iteration
     _predicted_euler_angle_rad += _predicted_euler_rate * dt_s;
 
-    // convert our predicted attitude to an acceleration vector assuming we are not accelerating vertically
+    // Convert predicted angles into an acceleration vector for braking/shaping
     const Vector3f predicted_euler_rad {_predicted_euler_angle_rad.x, _predicted_euler_angle_rad.y, _ahrs.yaw};
     const Vector3f predicted_accel_neu_m = _pos_control.lean_angles_rad_to_accel_NEU_mss(predicted_euler_rad);
 
@@ -189,7 +189,9 @@ void AC_Loiter::set_pilot_desired_acceleration_rad(float euler_roll_angle_rad, f
 void AC_Loiter::get_stopping_point_NE_cm(Vector2f& stopping_point_ne_cm) const
 {
     Vector2f stop_ne_m;
+    // Retrieve stopping point in meters
     get_stopping_point_NE_m(stop_ne_m);
+    // Convert to centimeters
     stopping_point_ne_cm = stop_ne_m * 100.0;
 }
 
@@ -199,7 +201,10 @@ void AC_Loiter::get_stopping_point_NE_cm(Vector2f& stopping_point_ne_cm) const
 void AC_Loiter::get_stopping_point_NE_m(Vector2f& stopping_point_ne_m) const
 {
     Vector2p stop_ne_m;
+    // Query stopping point from position controller in postype (float or double)
     _pos_control.get_stopping_point_NE_m(stop_ne_m);
+
+    // Convert from postype to float (Vector2f)
     stopping_point_ne_m = stop_ne_m.tofloat();
 }
 
@@ -207,6 +212,7 @@ void AC_Loiter::get_stopping_point_NE_m(Vector2f& stopping_point_ne_m) const
 // See get_angle_max_rad() for full details.
 float AC_Loiter::get_angle_max_cd() const
 {
+    // Convert radians to centidegrees
     return rad_to_cd(get_angle_max_rad());
 }
 
@@ -216,8 +222,10 @@ float AC_Loiter::get_angle_max_cd() const
 float AC_Loiter::get_angle_max_rad() const
 {
     if (!is_positive(_angle_max_deg)) {
+        // Use 2/3 of the smallest system-wide max lean angle
         return MIN(_attitude_control.lean_angle_max_rad(), _pos_control.get_lean_angle_max_rad()) * (2.0f / 3.0f);
     }
+    // Use configured parameter (in degrees), constrained to PSC limit
     return MIN(radians(_angle_max_deg), _pos_control.get_lean_angle_max_rad());
 }
 
@@ -225,7 +233,10 @@ float AC_Loiter::get_angle_max_rad() const
 // If `avoidance_on` is true, velocity is adjusted using avoidance logic before being applied.
 void AC_Loiter::update(bool avoidance_on)
 {
+    // Calculate desired velocity using pilot inputs, braking, and drag
     calc_desired_velocity(avoidance_on);
+
+    // Run position controller to compute desired attitude and thrust
     _pos_control.update_NE_controller();
 }
 
@@ -240,6 +251,7 @@ void AC_Loiter::set_speed_max_NE_cms(float speed_max_ne_cms)
 // Internally converts to cm/s and clamps to a minimum of LOITER_SPEED_MIN_CMS.
 void AC_Loiter::set_speed_max_NE_ms(float speed_max_ne_ms)
 {
+    // Convert to cm/s and apply minimum clamp
     _speed_max_ne_cms.set(MAX(speed_max_ne_ms * 100.0, LOITER_SPEED_MIN_CMS));
 }
 
@@ -247,7 +259,10 @@ void AC_Loiter::set_speed_max_NE_ms(float speed_max_ne_ms)
 // Applies min/max constraints on speed and acceleration settings.
 void AC_Loiter::sanity_check_params()
 {
+    // Enforce minimum loiter speed
     _speed_max_ne_cms.set(MAX(_speed_max_ne_cms, LOITER_SPEED_MIN_CMS));
+
+    // Clamp horizontal accel to lean-angle-limited max (converted to cm/s²)
     _accel_max_ne_cmss.set(MIN(_accel_max_ne_cmss, GRAVITY_MSS * 100.0f * tanf(_attitude_control.lean_angle_max_rad())));
 }
 
@@ -258,23 +273,24 @@ void AC_Loiter::sanity_check_params()
 void AC_Loiter::calc_desired_velocity(bool avoidance_on)
 {
     float ekfGndSpdLimit_ms, ahrsControlScaleXY;
+    // Query EKF-imposed horizontal ground speed limit (e.g. for optical flow)
     AP::ahrs().getControlLimits(ekfGndSpdLimit_ms, ahrsControlScaleXY);
 
     const float dt_s = _pos_control.get_dt_s();
 
-    // calculate a loiter speed limit which is the minimum of the value set by the LOITER_SPEED
-    // parameter and the value set by the EKF to observe optical flow limits
+    // Apply speed limit from LOITER_SPEED and EKF constraint
     float gnd_speed_limit_ms = MIN(_speed_max_ne_cms * 0.01, ekfGndSpdLimit_ms);
     gnd_speed_limit_ms = MAX(gnd_speed_limit_ms, LOITER_SPEED_MIN_CMS * 0.01);
 
+    // Determine acceleration limit based on maximum allowed lean angle
     float pilot_acceleration_max_mss = angle_rad_to_accel_mss(get_angle_max_rad());
 
-    // range check dt_s
+    // Check for invalid dt
     if (is_negative(dt_s)) {
         return;
     }
 
-    // get loiters desired velocity from the position controller where it is being stored.
+    // Integrate predicted acceleration
     Vector2f desired_vel_ne_ms = _pos_control.get_vel_desired_NEU_ms().xy();
 
     // update the desired velocity using our predicted acceleration
@@ -285,10 +301,10 @@ void AC_Loiter::calc_desired_velocity(bool avoidance_on)
     if (!is_zero(desired_speed_ms)) {
         Vector2f desired_vel_norm = desired_vel_ne_ms / desired_speed_ms;
 
-        // calculate a drag acceleration based on the desired speed.
+        // Apply drag: deceleration proportional to current velocity
         float drag_decel_mss = pilot_acceleration_max_mss * desired_speed_ms / gnd_speed_limit_ms;
 
-        // calculate a braking acceleration if sticks are at zero
+        // Determine braking acceleration based on stick release and delay timer
         float loiter_brake_accel_mss = 0.0f;
         if (_desired_accel_ne_mss.is_zero()) {
             if ((AP_HAL::millis() - _brake_timer_ms) > _brake_delay_s * 1000.0) {
@@ -299,18 +315,20 @@ void AC_Loiter::calc_desired_velocity(bool avoidance_on)
             loiter_brake_accel_mss = 0.0f;
             _brake_timer_ms = AP_HAL::millis();
         }
+
+        // Integrate jerk-limited brake acceleration
         _brake_accel_mss += constrain_float(loiter_brake_accel_mss - _brake_accel_mss, -_brake_jerk_max_cmsss * 0.01 * dt_s, _brake_jerk_max_cmsss * 0.01 * dt_s);
         loiter_accel_brake_mss = desired_vel_norm * _brake_accel_mss;
 
-        // update the desired velocity using the drag and braking accelerations
+        // Update desired speed based on braking and drag
         desired_speed_ms = MAX(desired_speed_ms - (drag_decel_mss + _brake_accel_mss) * dt_s, 0.0f);
         desired_vel_ne_ms = desired_vel_norm * desired_speed_ms;
     }
 
-    // add braking to the desired acceleration
+    // Apply braking acceleration to overall feed-forward acceleration
     _desired_accel_ne_mss -= loiter_accel_brake_mss;
 
-    // Apply EKF limit to desired velocity -  this limit is calculated by the EKF and adjusted as required to ensure certain sensor limits are respected (eg optical flow sensing)
+    // Apply final velocity magnitude constraint
     float desired_vel_ms = desired_vel_ne_ms.length();
     if (desired_vel_ms > gnd_speed_limit_ms) {
         desired_vel_ne_ms = desired_vel_ne_ms * gnd_speed_limit_ms / desired_vel_ms;
@@ -318,7 +336,7 @@ void AC_Loiter::calc_desired_velocity(bool avoidance_on)
 
 #if AP_AVOIDANCE_ENABLED && !APM_BUILD_TYPE(APM_BUILD_ArduPlane)
     if (avoidance_on) {
-        // Limit the velocity to prevent fence violations
+        // Apply fence/obstacle avoidance adjustments (velocity only)
         // TODO: We need to also limit the _desired_accel_ne_mss
         AC_Avoid *_avoid = AP::ac_avoid();
         if (_avoid != nullptr) {
@@ -329,12 +347,12 @@ void AC_Loiter::calc_desired_velocity(bool avoidance_on)
     }
 #endif // !APM_BUILD_ArduPlane
 
-    // get loiters desired velocity from the position controller where it is being stored.
+    // Retrieve current desired position
     Vector2p desired_pos_neu_m = _pos_control.get_pos_desired_NEU_m().xy();
 
-    // update the desired position using our desired velocity and acceleration
+    // Integrate velocity to update desired position
     desired_pos_neu_m += (desired_vel_ne_ms * dt_s).topostype();
 
-    // send adjusted feed forward acceleration and velocity back to the Position Controller
+    // Send updated position, velocity, and acceleration to the position controller
     _pos_control.set_pos_vel_accel_NE_m(desired_pos_neu_m, desired_vel_ne_ms, _desired_accel_ne_mss);
 }

--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -11,8 +11,8 @@ extern const AP_HAL::HAL& hal;
 #define LOITER_BRAKE_ACCEL_DEFAULT_CMSS     250.0   // minimum acceleration in loiter mode
 #define LOITER_BRAKE_JERK_DEFAULT_CMSSS     500.0   // maximum jerk in cm/s/s/s in loiter mode
 #define LOITER_BRAKE_START_DELAY_DEFAULT_S  1.0     // delay (in seconds) before loiter braking begins after sticks are released
-#define LOITER_VEL_CORRECTION_MAX_CMS       200.0   // max speed used to correct position errors in loiter
-#define LOITER_POS_CORRECTION_MAX_CM        200.0   // max position error in loiter
+#define LOITER_VEL_CORRECTION_MAX_MS        2.0     // max speed in m/s used to correct position errors in loiter
+#define LOITER_POS_CORRECTION_MAX_M         2.0     // max position error in loiter
 #define LOITER_ACTIVE_TIMEOUT_MS            200     // loiter controller is considered active if it has been called within the past 200ms (0.2 seconds)
 
 const AP_Param::GroupInfo AC_Loiter::var_info[] = {
@@ -90,23 +90,28 @@ AC_Loiter::AC_Loiter(const AP_AHRS_View& ahrs, AC_PosControl& pos_control, const
 /// initialise loiter target to a position in cm from ekf origin
 void AC_Loiter::init_target_cm(const Vector2f& position_ne_cm)
 {
+    init_target_m(position_ne_cm * 0.01);
+}
+
+/// initialise loiter target to a position in m from ekf origin
+void AC_Loiter::init_target_m(const Vector2f& position_ne_m)
+{
     sanity_check_params();
 
-    // initialise position controller speed and acceleration
-    _pos_control.set_correction_speed_accel_NE_cm(LOITER_VEL_CORRECTION_MAX_CMS, _accel_max_ne_cmss);
-    _pos_control.set_pos_error_max_NE_cm(LOITER_VEL_CORRECTION_MAX_CMS);
+    _pos_control.set_correction_speed_accel_NE_m(LOITER_VEL_CORRECTION_MAX_MS, _accel_max_ne_cmss * 0.01);
+    _pos_control.set_pos_error_max_NE_m(LOITER_POS_CORRECTION_MAX_M);
 
     // initialise position controller
     _pos_control.init_NE_controller_stopping_point();
 
     // initialise desired acceleration and angles to zero to remain on station
-    _predicted_accel_ne_cmss.zero();
-    _desired_accel_ne_cmss.zero();
+    _predicted_accel_ne_mss.zero();
+    _desired_accel_ne_mss.zero();
     _predicted_euler_angle_rad.zero();
-    _brake_accel_cmss = 0.0f;
+    _brake_accel_mss = 0.0f;
 
     // set target position
-    _pos_control.set_pos_desired_NE_cm(position_ne_cm);
+    _pos_control.set_pos_desired_NE_m(position_ne_m);
 }
 
 /// initialize's position and feed-forward velocity from current pos and velocity
@@ -115,17 +120,17 @@ void AC_Loiter::init_target()
     sanity_check_params();
 
     // initialise position controller speed and acceleration
-    _pos_control.set_correction_speed_accel_NE_cm(LOITER_VEL_CORRECTION_MAX_CMS, _accel_max_ne_cmss);
-    _pos_control.set_pos_error_max_NE_cm(LOITER_POS_CORRECTION_MAX_CM);
+    _pos_control.set_correction_speed_accel_NE_m(LOITER_VEL_CORRECTION_MAX_MS, _accel_max_ne_cmss * 0.01);
+    _pos_control.set_pos_error_max_NE_m(LOITER_POS_CORRECTION_MAX_M);
 
     // initialise position controller and move target accelerations smoothly towards zero
     _pos_control.relax_velocity_controller_NE();
 
     // initialise predicted acceleration and angles from the position controller
-    _predicted_accel_ne_cmss = _pos_control.get_accel_target_NEU_cmss().xy();
+    _predicted_accel_ne_mss = _pos_control.get_accel_target_NEU_mss().xy();
     _predicted_euler_angle_rad.x = _pos_control.get_roll_rad();
     _predicted_euler_angle_rad.y = _pos_control.get_pitch_rad();
-    _brake_accel_cmss = 0.0f;
+    _brake_accel_mss = 0.0f;
 }
 
 /// reduce response for landing
@@ -148,10 +153,10 @@ void AC_Loiter::set_pilot_desired_acceleration_rad(float euler_roll_angle_rad, f
 
     // convert our desired attitude to an acceleration vector assuming we are not accelerating vertically
     const Vector3f desired_euler_rad {euler_roll_angle_rad, euler_pitch_angle_rad, _ahrs.yaw};
-    const Vector3f desired_accel_neu_cmss = _pos_control.lean_angles_rad_to_accel_NEU_cmss(desired_euler_rad);
+    const Vector3f desired_accel_neu_mss = _pos_control.lean_angles_rad_to_accel_NEU_mss(desired_euler_rad);
 
-    _desired_accel_ne_cmss.x = desired_accel_neu_cmss.x;
-    _desired_accel_ne_cmss.y = desired_accel_neu_cmss.y;
+    _desired_accel_ne_mss.x = desired_accel_neu_mss.x;
+    _desired_accel_ne_mss.y = desired_accel_neu_mss.y;
 
     // difference between where we think we should be and where we want to be
     Vector2f angle_error_euler_rad(wrap_PI(euler_roll_angle_rad - _predicted_euler_angle_rad.x), wrap_PI(euler_pitch_angle_rad - _predicted_euler_angle_rad.y));
@@ -164,18 +169,26 @@ void AC_Loiter::set_pilot_desired_acceleration_rad(float euler_roll_angle_rad, f
 
     // convert our predicted attitude to an acceleration vector assuming we are not accelerating vertically
     const Vector3f predicted_euler_rad {_predicted_euler_angle_rad.x, _predicted_euler_angle_rad.y, _ahrs.yaw};
-    const Vector3f predicted_accel_neu_cm = _pos_control.lean_angles_rad_to_accel_NEU_cmss(predicted_euler_rad);
+    const Vector3f predicted_accel_neu_m = _pos_control.lean_angles_rad_to_accel_NEU_mss(predicted_euler_rad);
 
-    _predicted_accel_ne_cmss.x = predicted_accel_neu_cm.x;
-    _predicted_accel_ne_cmss.y = predicted_accel_neu_cm.y;
+    _predicted_accel_ne_mss.x = predicted_accel_neu_m.x;
+    _predicted_accel_ne_mss.y = predicted_accel_neu_m.y;
 }
 
 /// get vector to stopping point based on a horizontal position and velocity
 void AC_Loiter::get_stopping_point_NE_cm(Vector2f& stopping_point_ne_cm) const
 {
-    Vector2p stop_ne_cm;
-    _pos_control.get_stopping_point_NE_cm(stop_ne_cm);
-    stopping_point_ne_cm = stop_ne_cm.tofloat();
+    Vector2f stop_ne_m;
+    get_stopping_point_NE_m(stop_ne_m);
+    stopping_point_ne_cm = stop_ne_m * 100.0;
+}
+
+/// get vector to stopping point based on a horizontal position and velocity
+void AC_Loiter::get_stopping_point_NE_m(Vector2f& stopping_point_ne_m) const
+{
+    Vector2p stop_ne_m;
+    _pos_control.get_stopping_point_NE_m(stop_ne_m);
+    stopping_point_ne_m = stop_ne_m.tofloat();
 }
 
 /// get maximum lean angle when using loiter
@@ -201,7 +214,11 @@ void AC_Loiter::update(bool avoidance_on)
 //set maximum horizontal speed
 void AC_Loiter::set_speed_max_NE_cms(float speed_max_ne_cms)
 {
-    _speed_max_ne_cms.set(MAX(speed_max_ne_cms, LOITER_SPEED_MIN_CMS));
+    set_speed_max_NE_ms(speed_max_ne_cms * 0.01);
+}
+void AC_Loiter::set_speed_max_NE_ms(float speed_max_ne_ms)
+{
+    _speed_max_ne_cms.set(MAX(speed_max_ne_ms * 100.0, LOITER_SPEED_MIN_CMS));
 }
 
 // sanity check parameters
@@ -222,10 +239,10 @@ void AC_Loiter::calc_desired_velocity(bool avoidance_on)
 
     // calculate a loiter speed limit which is the minimum of the value set by the LOITER_SPEED
     // parameter and the value set by the EKF to observe optical flow limits
-    float gnd_speed_limit_cms = MIN(_speed_max_ne_cms, ekfGndSpdLimit_ms * 100.0f);
-    gnd_speed_limit_cms = MAX(gnd_speed_limit_cms, LOITER_SPEED_MIN_CMS);
+    float gnd_speed_limit_ms = MIN(_speed_max_ne_cms * 0.01, ekfGndSpdLimit_ms);
+    gnd_speed_limit_ms = MAX(gnd_speed_limit_ms, LOITER_SPEED_MIN_CMS * 0.01);
 
-    float pilot_acceleration_max_cmss = angle_rad_to_accel_mss(get_angle_max_rad()) * 100;
+    float pilot_acceleration_max_mss = angle_rad_to_accel_mss(get_angle_max_rad());
 
     // range check dt_s
     if (is_negative(dt_s)) {
@@ -233,66 +250,66 @@ void AC_Loiter::calc_desired_velocity(bool avoidance_on)
     }
 
     // get loiters desired velocity from the position controller where it is being stored.
-    Vector2f desired_vel_ne_cms = _pos_control.get_vel_desired_NEU_cms().xy();
+    Vector2f desired_vel_ne_ms = _pos_control.get_vel_desired_NEU_ms().xy();
 
     // update the desired velocity using our predicted acceleration
-    desired_vel_ne_cms += _predicted_accel_ne_cmss * dt_s;
+    desired_vel_ne_ms += _predicted_accel_ne_mss * dt_s;
 
-    Vector2f loiter_accel_brake_cmss;
-    float desired_speed_cms = desired_vel_ne_cms.length();
-    if (!is_zero(desired_speed_cms)) {
-        Vector2f desired_vel_norm = desired_vel_ne_cms / desired_speed_cms;
+    Vector2f loiter_accel_brake_mss;
+    float desired_speed_ms = desired_vel_ne_ms.length();
+    if (!is_zero(desired_speed_ms)) {
+        Vector2f desired_vel_norm = desired_vel_ne_ms / desired_speed_ms;
 
         // calculate a drag acceleration based on the desired speed.
-        float drag_decel_cmss = pilot_acceleration_max_cmss * desired_speed_cms / gnd_speed_limit_cms;
+        float drag_decel_mss = pilot_acceleration_max_mss * desired_speed_ms / gnd_speed_limit_ms;
 
         // calculate a braking acceleration if sticks are at zero
-        float loiter_brake_accel_cmss = 0.0f;
-        if (_desired_accel_ne_cmss.is_zero()) {
-            if ((AP_HAL::millis() - _brake_timer_ms) > _brake_delay_s * 1000.0f) {
+        float loiter_brake_accel_mss = 0.0f;
+        if (_desired_accel_ne_mss.is_zero()) {
+            if ((AP_HAL::millis() - _brake_timer_ms) > _brake_delay_s * 1000.0) {
                 float brake_gain = _pos_control.get_vel_NE_pid().kP() * 0.5f;
-                loiter_brake_accel_cmss = constrain_float(sqrt_controller(desired_speed_cms, brake_gain, _brake_jerk_max_cmsss, dt_s), 0.0f, _brake_accel_max_cmss);
+                loiter_brake_accel_mss = constrain_float(sqrt_controller(desired_speed_ms, brake_gain, _brake_jerk_max_cmsss * 0.01, dt_s), 0.0f, _brake_accel_max_cmss * 0.01);
             }
         } else {
-            loiter_brake_accel_cmss = 0.0f;
+            loiter_brake_accel_mss = 0.0f;
             _brake_timer_ms = AP_HAL::millis();
         }
-        _brake_accel_cmss += constrain_float(loiter_brake_accel_cmss - _brake_accel_cmss, -_brake_jerk_max_cmsss * dt_s, _brake_jerk_max_cmsss * dt_s);
-        loiter_accel_brake_cmss = desired_vel_norm * _brake_accel_cmss;
+        _brake_accel_mss += constrain_float(loiter_brake_accel_mss - _brake_accel_mss, -_brake_jerk_max_cmsss * 0.01 * dt_s, _brake_jerk_max_cmsss * 0.01 * dt_s);
+        loiter_accel_brake_mss = desired_vel_norm * _brake_accel_mss;
 
         // update the desired velocity using the drag and braking accelerations
-        desired_speed_cms = MAX(desired_speed_cms - (drag_decel_cmss + _brake_accel_cmss) * dt_s, 0.0f);
-        desired_vel_ne_cms = desired_vel_norm * desired_speed_cms;
+        desired_speed_ms = MAX(desired_speed_ms - (drag_decel_mss + _brake_accel_mss) * dt_s, 0.0f);
+        desired_vel_ne_ms = desired_vel_norm * desired_speed_ms;
     }
 
     // add braking to the desired acceleration
-    _desired_accel_ne_cmss -= loiter_accel_brake_cmss;
+    _desired_accel_ne_mss -= loiter_accel_brake_mss;
 
     // Apply EKF limit to desired velocity -  this limit is calculated by the EKF and adjusted as required to ensure certain sensor limits are respected (eg optical flow sensing)
-    float horizSpdDem = desired_vel_ne_cms.length();
-    if (horizSpdDem > gnd_speed_limit_cms) {
-        desired_vel_ne_cms = desired_vel_ne_cms * gnd_speed_limit_cms / horizSpdDem;
+    float desired_vel_ms = desired_vel_ne_ms.length();
+    if (desired_vel_ms > gnd_speed_limit_ms) {
+        desired_vel_ne_ms = desired_vel_ne_ms * gnd_speed_limit_ms / desired_vel_ms;
     }
 
 #if AP_AVOIDANCE_ENABLED && !APM_BUILD_TYPE(APM_BUILD_ArduPlane)
     if (avoidance_on) {
         // Limit the velocity to prevent fence violations
-        // TODO: We need to also limit the _desired_accel_ne_cmss
+        // TODO: We need to also limit the _desired_accel_ne_mss
         AC_Avoid *_avoid = AP::ac_avoid();
         if (_avoid != nullptr) {
-            Vector3f avoidance_vel_neu_cms{desired_vel_ne_cms.x, desired_vel_ne_cms.y, 0.0f};
+            Vector3f avoidance_vel_neu_cms{desired_vel_ne_ms.x * 100.0, desired_vel_ne_ms.y * 100.0, 0.0f};
             _avoid->adjust_velocity(avoidance_vel_neu_cms, _pos_control.get_pos_NE_p().kP(), _accel_max_ne_cmss, _pos_control.get_pos_U_p().kP(), _pos_control.get_max_accel_U_cmss(), dt_s);
-            desired_vel_ne_cms = Vector2f{avoidance_vel_neu_cms.x, avoidance_vel_neu_cms.y};
+            desired_vel_ne_ms = avoidance_vel_neu_cms.xy() * 0.01;
         }
     }
 #endif // !APM_BUILD_ArduPlane
 
     // get loiters desired velocity from the position controller where it is being stored.
-    Vector2p desired_pos_neu_cm = _pos_control.get_pos_desired_NEU_cm().xy();
+    Vector2p desired_pos_neu_m = _pos_control.get_pos_desired_NEU_m().xy();
 
     // update the desired position using our desired velocity and acceleration
-    desired_pos_neu_cm += (desired_vel_ne_cms * dt_s).topostype();
+    desired_pos_neu_m += (desired_vel_ne_ms * dt_s).topostype();
 
     // send adjusted feed forward acceleration and velocity back to the Position Controller
-    _pos_control.set_pos_vel_accel_NE_cm(desired_pos_neu_cm, desired_vel_ne_cms, _desired_accel_ne_cmss);
+    _pos_control.set_pos_vel_accel_NE_m(desired_pos_neu_m, desired_vel_ne_ms, _desired_accel_ne_mss);
 }

--- a/libraries/AC_WPNav/AC_Loiter.h
+++ b/libraries/AC_WPNav/AC_Loiter.h
@@ -87,18 +87,18 @@ protected:
     const AC_AttitudeControl& _attitude_control;
 
     // parameters
-    AP_Float    _angle_max_deg;         // maximum pilot commanded angle in degrees. Set to zero for 2/3 Angle Max
-    AP_Float    _speed_max_ne_cms;      // maximum horizontal speed in cm/s while in loiter
-    AP_Float    _accel_max_ne_cmss;     // loiter's max acceleration in cm/s/s
-    AP_Float    _brake_accel_max_cmss;  // loiter's maximum acceleration during braking in cm/s/s
-    AP_Float    _brake_jerk_max_cmsss;  // loiter's maximum jerk during braking in cm/s/s
-    AP_Float    _brake_delay_s;         // delay (in seconds) before loiter braking begins after sticks are released
+    AP_Float    _angle_max_deg;         // Maximum pilot-commanded lean angle in degrees. Set to zero to default to 2/3 of PSC_ANGLE_MAX (or Q_ANGLE_MAX for QuadPlane).
+    AP_Float    _speed_max_ne_cms;      // Maximum horizontal speed in cm/s while in loiter mode. Used to limit both user and internal trajectory velocities.
+    AP_Float    _accel_max_ne_cmss;     // Maximum horizontal acceleration (in cm/s²) applied during normal loiter corrections.
+    AP_Float    _brake_accel_max_cmss;  // Maximum braking acceleration (in cm/s²) applied when pilot sticks are released.
+    AP_Float    _brake_jerk_max_cmsss;  // Maximum braking jerk (in cm/s³) applied during braking transitions after pilot release.
+    AP_Float    _brake_delay_s;         // Delay in seconds before braking begins after sticks are centered. Prevents premature deceleration during brief pauses.
 
     // loiter controller internal variables
-    Vector2f    _desired_accel_ne_mss;     // slewed pilot's desired acceleration in lat/lon frame
-    Vector2f    _predicted_accel_ne_mss;   // predicted acceleration in lat/lon frame based on pilot's desired acceleration
-    Vector2f    _predicted_euler_angle_rad; // predicted roll/pitch angles in radians based on pilot's desired acceleration
-    Vector2f    _predicted_euler_rate;      // predicted roll/pitch rates in radians/sec based on pilot's desired acceleration
-    uint32_t    _brake_timer_ms;            // system time that brake was initiated
-    float       _brake_accel_mss;          // acceleration due to braking from previous iteration (used for jerk limiting)
+    Vector2f    _desired_accel_ne_mss;      // Pilot-requested horizontal acceleration in m/s² (after smoothing), in the NE (horizontal) frame.
+    Vector2f    _predicted_accel_ne_mss;    // Predicted acceleration in m/s² based on internal rate shaping of pilot input.
+    Vector2f    _predicted_euler_angle_rad; // Predicted roll/pitch angles (in radians) used for rate shaping of pilot input.
+    Vector2f    _predicted_euler_rate;      // Predicted roll/pitch angular rates (in rad/s) for pilot acceleration shaping.
+    uint32_t    _brake_timer_ms;            // Timestamp (in ms) when braking logic was last triggered (sticks released).
+    float       _brake_accel_mss;           // Current braking acceleration in m/s², updated using jerk limits over time.
 };

--- a/libraries/AC_WPNav/AC_Loiter.h
+++ b/libraries/AC_WPNav/AC_Loiter.h
@@ -40,7 +40,7 @@ public:
     }
 
     /// get vector to stopping point based on a horizontal position and velocity
-    void get_stopping_point_NE_cm(Vector2f& stopping_point) const;
+    void get_stopping_point_NE_cm(Vector2f& stopping_point_ne_cm) const;
 
     /// get horizontal distance to loiter target in cm
     float get_distance_to_target_cm() const { return _pos_control.get_pos_error_NE_cm(); }

--- a/libraries/AC_WPNav/AC_Loiter.h
+++ b/libraries/AC_WPNav/AC_Loiter.h
@@ -17,6 +17,7 @@ public:
 
     /// initialise loiter target to a position in cm from ekf origin
     void init_target_cm(const Vector2f& position_neu_cm);
+    void init_target_m(const Vector2f& position_neu_m);
 
     /// initialize's position and feed-forward velocity from current pos and velocity
     void init_target();
@@ -32,7 +33,8 @@ public:
     void set_pilot_desired_acceleration_cd(float euler_roll_angle_cd, float euler_pitch_angle_cd);
 
     /// gets pilot desired acceleration in the earth frame
-    Vector2f get_pilot_desired_acceleration_NE_cmss() const { return Vector2f{_desired_accel_ne_cmss.x, _desired_accel_ne_cmss.y}; }
+    Vector2f get_pilot_desired_acceleration_NE_cmss() const { return get_pilot_desired_acceleration_NE_mss() * 100.0; }
+    const Vector2f& get_pilot_desired_acceleration_NE_mss() const { return _desired_accel_ne_mss; }
 
     /// clear pilot desired acceleration
     void clear_pilot_desired_acceleration() {
@@ -41,9 +43,11 @@ public:
 
     /// get vector to stopping point based on a horizontal position and velocity
     void get_stopping_point_NE_cm(Vector2f& stopping_point_ne_cm) const;
+    void get_stopping_point_NE_m(Vector2f& stopping_point_ne_m) const;
 
     /// get horizontal distance to loiter target in cm
-    float get_distance_to_target_cm() const { return _pos_control.get_pos_error_NE_cm(); }
+    float get_distance_to_target_cm() const { return get_distance_to_target_m() * 100.0; }
+    float get_distance_to_target_m() const { return _pos_control.get_pos_error_NE_m(); }
 
     /// get bearing to target in centi-degrees
     float get_bearing_to_target_rad() const { return _pos_control.get_bearing_to_target_rad(); }
@@ -57,6 +61,7 @@ public:
 
     //set maximum horizontal speed
     void set_speed_max_NE_cms(float speed_max_NE_cms);
+    void set_speed_max_NE_ms(float speed_max_NE_ms);
 
     /// get desired roll, pitch which should be fed into stabilize controllers
     float get_roll_rad() const { return _pos_control.get_roll_rad(); }
@@ -90,10 +95,10 @@ protected:
     AP_Float    _brake_delay_s;         // delay (in seconds) before loiter braking begins after sticks are released
 
     // loiter controller internal variables
-    Vector2f    _desired_accel_ne_cmss;     // slewed pilot's desired acceleration in lat/lon frame
-    Vector2f    _predicted_accel_ne_cmss;   // predicted acceleration in lat/lon frame based on pilot's desired acceleration
+    Vector2f    _desired_accel_ne_mss;     // slewed pilot's desired acceleration in lat/lon frame
+    Vector2f    _predicted_accel_ne_mss;   // predicted acceleration in lat/lon frame based on pilot's desired acceleration
     Vector2f    _predicted_euler_angle_rad; // predicted roll/pitch angles in radians based on pilot's desired acceleration
     Vector2f    _predicted_euler_rate;      // predicted roll/pitch rates in radians/sec based on pilot's desired acceleration
     uint32_t    _brake_timer_ms;            // system time that brake was initiated
-    float       _brake_accel_cmss;          // acceleration due to braking from previous iteration (used for jerk limiting)
+    float       _brake_accel_mss;          // acceleration due to braking from previous iteration (used for jerk limiting)
 };

--- a/libraries/AC_WPNav/AC_Loiter.h
+++ b/libraries/AC_WPNav/AC_Loiter.h
@@ -15,70 +15,115 @@ public:
     /// Constructor
     AC_Loiter(const AP_AHRS_View& ahrs, AC_PosControl& pos_control, const AC_AttitudeControl& attitude_control);
 
-    /// initialise loiter target to a position in cm from ekf origin
+    // Sets the initial loiter target position in centimeters from the EKF origin.
+    // See init_target_m() for full details.
     void init_target_cm(const Vector2f& position_neu_cm);
+
+    // Sets the initial loiter target position in meters from the EKF origin.
+    // - position_neu_m: horizontal position in the NE frame, in meters.
+    // - Initializes internal control state including acceleration targets and feed-forward planning.
     void init_target_m(const Vector2f& position_neu_m);
 
-    /// initialize's position and feed-forward velocity from current pos and velocity
+    // Initializes the loiter controller using the current position and velocity.
+    // Updates feed-forward velocity, predicted acceleration, and resets control state.
     void init_target();
 
-    /// reduce response for landing
+    // Reduces loiter responsiveness for smoother descent during landing.
+    // Internally softens horizontal control gains.
     void soften_for_landing();
 
-    /// set pilot desired acceleration in radians
-    //   dt should be the time (in seconds) since the last call to this function
-    void set_pilot_desired_acceleration_rad(float euler_roll_angle_rad, float euler_pitch_angle_rad);
-
-    /// set pilot desired acceleration in centidegrees
+    // Sets pilot desired acceleration using Euler angles in centidegrees.
+    // See set_pilot_desired_acceleration_rad() for full details.
     void set_pilot_desired_acceleration_cd(float euler_roll_angle_cd, float euler_pitch_angle_cd);
 
-    /// gets pilot desired acceleration in the earth frame
+    // Sets pilot desired acceleration using Euler angles in radians.
+    // - Internally computes a smoothed acceleration vector based on predictive rate shaping.
+    // - Inputs: `euler_roll_angle_rad`, `euler_pitch_angle_rad` in radians.
+    // - Applies internal shaping using the current attitude controller dt.
+    void set_pilot_desired_acceleration_rad(float euler_roll_angle_rad, float euler_pitch_angle_rad);
+
+    // Returns pilot-requested horizontal acceleration in the NE frame in cm/s².
+    // See get_pilot_desired_acceleration_NE_mss() for full details.
     Vector2f get_pilot_desired_acceleration_NE_cmss() const { return get_pilot_desired_acceleration_NE_mss() * 100.0; }
+
+    // Returns pilot-requested horizontal acceleration in the NE frame in m/s².
+    // This is the internally computed and smoothed acceleration vector applied by the loiter controller.
     const Vector2f& get_pilot_desired_acceleration_NE_mss() const { return _desired_accel_ne_mss; }
 
-    /// clear pilot desired acceleration
-    void clear_pilot_desired_acceleration() {
-        set_pilot_desired_acceleration_rad(0.0, 0.0);
-    }
+    // Clears any pilot-requested acceleration by setting roll and pitch inputs to zero.
+    void clear_pilot_desired_acceleration() { set_pilot_desired_acceleration_rad(0.0, 0.0); }
 
-    /// get vector to stopping point based on a horizontal position and velocity
+    // Calculates the expected stopping point based on current velocity and position in the NE frame.
+    // Result is returned in centimeters.
+    // See get_stopping_point_NE_m() for full details.
     void get_stopping_point_NE_cm(Vector2f& stopping_point_ne_cm) const;
+
+    // Calculates the expected stopping point based on current velocity and position in the NE frame.
+    // Result is returned in meters.
+    // Uses the position controller’s deceleration model.
     void get_stopping_point_NE_m(Vector2f& stopping_point_ne_m) const;
 
-    /// get horizontal distance to loiter target in cm
+    // Returns the horizontal distance to the loiter target in centimeters.
+    // See get_distance_to_target_m() for full details.
     float get_distance_to_target_cm() const { return get_distance_to_target_m() * 100.0; }
+
+    // Returns the horizontal distance to the loiter target in meters.
+    // Computed using the NE position error from the position controller.
     float get_distance_to_target_m() const { return _pos_control.get_pos_error_NE_m(); }
 
-    /// get bearing to target in centi-degrees
+    // Returns the bearing from current position to the loiter target in radians.
+    // Bearing is relative to true north, using the NE frame.
     float get_bearing_to_target_rad() const { return _pos_control.get_bearing_to_target_rad(); }
 
-    /// get maximum lean angle when using loiter
-    float get_angle_max_rad() const;
+    // Returns the maximum pilot-commanded lean angle in centidegrees.
+    // See get_angle_max_rad() for full details.
     float get_angle_max_cd() const;
 
-    /// run the loiter controller
+    // Returns the maximum pilot-commanded lean angle in radians.
+    // - If `_angle_max_deg` is zero, this returns 2/3 of the limiting PSC angle.
+    // - Otherwise, returns the minimum of `_angle_max_deg` and PSC’s configured angle limit.
+    float get_angle_max_rad() const;
+
+    // Runs the loiter control loop, computing desired acceleration and updating position control.
+    // If `avoidance_on` is true, velocity is adjusted using avoidance logic before being applied.
     void update(bool avoidance_on = true);
 
-    //set maximum horizontal speed
+    // Sets the maximum allowed horizontal loiter speed in cm/s.
+    // See set_speed_max_NE_ms() for full details.
     void set_speed_max_NE_cms(float speed_max_NE_cms);
+
+    // Sets the maximum allowed horizontal loiter speed in m/s.
+    // Internally converts to cm/s and clamps to a minimum of LOITER_SPEED_MIN_CMS.
     void set_speed_max_NE_ms(float speed_max_NE_ms);
 
-    /// get desired roll, pitch which should be fed into stabilize controllers
-    float get_roll_rad() const { return _pos_control.get_roll_rad(); }
-    float get_pitch_rad() const { return _pos_control.get_pitch_rad(); }
+    // Returns the desired roll angle in centidegrees from the loiter controller.
     float get_roll_cd() const { return _pos_control.get_roll_cd(); }
+
+    // Returns the desired pitch angle in centidegrees from the loiter controller.
     float get_pitch_cd() const { return _pos_control.get_pitch_cd(); }
+
+    // Returns the desired roll angle in radians from the loiter controller.
+    float get_roll_rad() const { return _pos_control.get_roll_rad(); }
+
+    // Returns the desired pitch angle in radians from the loiter controller.
+    float get_pitch_rad() const { return _pos_control.get_pitch_rad(); }
+
+    // Returns the desired 3D thrust vector from the loiter controller for attitude control.
+    // Directional only; magnitude is handled by the attitude controller.
     Vector3f get_thrust_vector() const { return _pos_control.get_thrust_vector(); }
 
     static const struct AP_Param::GroupInfo var_info[];
 
 protected:
 
-    // sanity check parameters
+    // Ensures internal parameters are within valid safety limits.
+    // Applies min/max constraints on speed and acceleration settings.
     void sanity_check_params();
 
-    /// updates desired velocity (i.e. feed forward) with pilot requested acceleration and fake wind resistance
-    ///		updated velocity sent directly to position controller
+    // Updates feed-forward velocity using pilot-requested acceleration and braking logic.
+    // - Applies drag and braking forces when sticks are released.
+    // - Velocity is adjusted for fence/avoidance if enabled.
+    // - Resulting velocity and acceleration are sent to the position controller.
     void calc_desired_velocity(bool avoidance_on = true);
 
     // references and pointers to external libraries

--- a/libraries/AC_WPNav/AC_WPNav_OA.cpp
+++ b/libraries/AC_WPNav/AC_WPNav_OA.cpp
@@ -30,7 +30,12 @@ bool AC_WPNav_OA::get_oa_wp_destination(Location& destination) const
 ///     returns false on failure (likely caused by missing terrain data)
 bool AC_WPNav_OA::set_wp_destination_NEU_cm(const Vector3f& destination_neu_cm, bool is_terrain_alt)
 {
-    const bool ret = AC_WPNav::set_wp_destination_NEU_cm(destination_neu_cm, is_terrain_alt);
+    return set_wp_destination_NEU_m(destination_neu_cm * 0.01, is_terrain_alt);
+}
+
+bool AC_WPNav_OA::set_wp_destination_NEU_m(const Vector3f& destination_neu_m, bool is_terrain_alt)
+{
+    const bool ret = AC_WPNav::set_wp_destination_NEU_m(destination_neu_m, is_terrain_alt);
 
     if (ret) {
         // reset object avoidance state
@@ -44,22 +49,22 @@ bool AC_WPNav_OA::set_wp_destination_NEU_cm(const Vector3f& destination_neu_cm, 
 /// always returns distance to final destination (i.e. does not use oa adjusted destination)
 float AC_WPNav_OA::get_wp_distance_to_destination_cm() const
 {
+    return get_wp_distance_to_destination_m() * 100.0;
+}
+float AC_WPNav_OA::get_wp_distance_to_destination_m() const
+{
     if (_oa_state == AP_OAPathPlanner::OA_NOT_REQUIRED) {
-        return AC_WPNav::get_wp_distance_to_destination_cm();
+        return AC_WPNav::get_wp_distance_to_destination_m();
     }
 
-    return get_horizontal_distance(_pos_control.get_pos_estimate_NEU_cm().xy().tofloat(), _destination_oabak_neu_cm.xy());
+    return get_horizontal_distance(_pos_control.get_pos_estimate_NEU_m().xy().tofloat(), _destination_oabak_neu_m.xy());
 }
 
 /// get_wp_bearing_to_destination - get bearing to next waypoint in centi-degrees
 /// always returns bearing to final destination (i.e. does not use oa adjusted destination)
 int32_t AC_WPNav_OA::get_wp_bearing_to_destination_cd() const
 {
-    if (_oa_state == AP_OAPathPlanner::OA_NOT_REQUIRED) {
-        return AC_WPNav::get_wp_bearing_to_destination_cd();
-    }
-
-    return get_bearing_cd(_pos_control.get_pos_estimate_NEU_cm().xy().tofloat(), _destination_oabak_neu_cm.xy());
+    return rad_to_cd(get_wp_bearing_to_destination_rad());
 }
 
 /// get_wp_bearing_to_destination_cd - get bearing to next waypoint in centi-degrees
@@ -69,7 +74,7 @@ float AC_WPNav_OA::get_wp_bearing_to_destination_rad() const
         return AC_WPNav::get_wp_bearing_to_destination_rad();
     }
 
-    return get_bearing_rad(_pos_control.get_pos_estimate_NEU_cm().xy().tofloat(), _destination_oabak_neu_cm.xy());
+    return get_bearing_rad(_pos_control.get_pos_estimate_NEU_m().xy().tofloat(), _destination_oabak_neu_m.xy());
 }
 
 /// true when we have come within RADIUS cm of the waypoint
@@ -88,16 +93,16 @@ bool AC_WPNav_OA::update_wpnav()
 
         // backup _origin and _destination_neu_m when not doing oa
         if (_oa_state == AP_OAPathPlanner::OA_NOT_REQUIRED) {
-            _origin_oabak_neu_cm = _origin_neu_m * 100.0;
-            _destination_oabak_neu_cm = _destination_neu_m * 100.0;
+            _origin_oabak_neu_m = _origin_neu_m;
+            _destination_oabak_neu_m = _destination_neu_m;
             _is_terrain_alt_oabak = _is_terrain_alt;
-            _next_destination_oabak_neu_cm = _next_destination_neu_m * 100.0;
+            _next_destination_oabak_neu_m = _next_destination_neu_m;
         }
 
         // convert origin, destination and next_destination to Locations and pass into oa
-        const Location origin_loc(_origin_oabak_neu_cm, _is_terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
-        const Location destination_loc(_destination_oabak_neu_cm, _is_terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
-        const Location next_destination_loc(_next_destination_oabak_neu_cm, _is_terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
+        const Location origin_loc(_origin_oabak_neu_m * 100.0, _is_terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
+        const Location destination_loc(_destination_oabak_neu_m * 100.0, _is_terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
+        const Location next_destination_loc(_next_destination_oabak_neu_m * 100.0, _is_terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
         Location oa_origin_new, oa_destination_new, oa_next_destination_new;
         bool dest_to_next_dest_clear = true;
         AP_OAPathPlanner::OAPathPlannerUsed path_planner_used = AP_OAPathPlanner::OAPathPlannerUsed::None;
@@ -116,7 +121,7 @@ bool AC_WPNav_OA::update_wpnav()
         case AP_OAPathPlanner::OA_NOT_REQUIRED:
             if (_oa_state != oa_retstate) {
                 // object avoidance has become inactive so reset target to original destination
-                if (!set_wp_destination_NEU_cm(_destination_oabak_neu_cm, _is_terrain_alt_oabak)) {
+                if (!set_wp_destination_NEU_m(_destination_oabak_neu_m, _is_terrain_alt_oabak)) {
                     // trigger terrain failsafe
                     return false;
                 }
@@ -124,8 +129,8 @@ bool AC_WPNav_OA::update_wpnav()
                 // if path from destination to next_destination is clear
                 if (dest_to_next_dest_clear && (oa_ptr->get_options() & AP_OAPathPlanner::OA_OPTION_FAST_WAYPOINTS)) {
                     // set next destination if non-zero
-                    if (!_next_destination_oabak_neu_cm.is_zero()) {
-                        set_wp_destination_next_NEU_cm(_next_destination_oabak_neu_cm);
+                    if (!_next_destination_oabak_neu_m.is_zero()) {
+                        set_wp_destination_next_NEU_m(_next_destination_oabak_neu_m);
                     }
                 }
                 _oa_state = oa_retstate;
@@ -150,11 +155,11 @@ bool AC_WPNav_OA::update_wpnav()
             // by setting the oa_destination to a stopping point
             if ((_oa_state != AP_OAPathPlanner::OA_PROCESSING) && (_oa_state != AP_OAPathPlanner::OA_ERROR)) {
                 // calculate stopping point
-                Vector3f stopping_point_neu_cm;
-                get_wp_stopping_point_NEU_cm(stopping_point_neu_cm);
-                _oa_destination = Location(stopping_point_neu_cm, Location::AltFrame::ABOVE_ORIGIN);
+                Vector3f stopping_point_neu_m;
+                get_wp_stopping_point_NEU_m(stopping_point_neu_m);
+                _oa_destination = Location(stopping_point_neu_m * 100.0, Location::AltFrame::ABOVE_ORIGIN);
                 _oa_next_destination.zero();
-                if (set_wp_destination_NEU_cm(stopping_point_neu_cm, false)) {
+                if (set_wp_destination_NEU_m(stopping_point_neu_m, false)) {
                     _oa_state = oa_retstate;
                 }
             }
@@ -173,8 +178,8 @@ bool AC_WPNav_OA::update_wpnav()
             case AP_OAPathPlanner::OAPathPlannerUsed::Dijkstras:
                 // Dijkstra's.  Action is only needed if path planner has just became active or the target destination's lat or lon has changed
                 if ((_oa_state != AP_OAPathPlanner::OA_SUCCESS) || !oa_destination_new.same_latlon_as(_oa_destination)) {
-                    Location origin_oabak_loc(_origin_oabak_neu_cm, _is_terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
-                    Location destination_oabak_loc(_destination_oabak_neu_cm, _is_terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
+                    Location origin_oabak_loc(_origin_oabak_neu_m * 100.0, _is_terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
+                    Location destination_oabak_loc(_destination_oabak_neu_m * 100, _is_terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
                     oa_destination_new.linearly_interpolate_alt(origin_oabak_loc, destination_oabak_loc);
 
                     // set new OA adjusted destination
@@ -190,7 +195,7 @@ bool AC_WPNav_OA::update_wpnav()
                     if ((oa_ptr->get_options() & AP_OAPathPlanner::OA_OPTION_FAST_WAYPOINTS) && !oa_next_destination_new.is_zero()) {
                         // calculate oa_next_destination_new's altitude using linear interpolation between original origin and destination
                         // this "next destination" is still an intermediate point between the origin and destination
-                        Location next_destination_oabak_loc(_next_destination_oabak_neu_cm, _is_terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
+                        Location next_destination_oabak_loc(_next_destination_oabak_neu_m * 100.0, _is_terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
                         oa_next_destination_new.linearly_interpolate_alt(origin_oabak_loc, destination_oabak_loc);
                         if (set_wp_destination_next_loc(oa_next_destination_new)) {
                             _oa_next_destination = oa_next_destination_new;
@@ -208,26 +213,26 @@ bool AC_WPNav_OA::update_wpnav()
                 target_alt_loc.linearly_interpolate_alt(origin_loc, destination_loc);
 
                 // correct target_alt_loc's alt-above-ekf-origin if using terrain altitudes
-                // positive terr_offset_cm means terrain below vehicle is above ekf origin's altitude
-                float terr_offset_cm = 0;
-                if (_is_terrain_alt_oabak && !get_terrain_offset_cm(terr_offset_cm)) {
+                // positive terr_offset_m means terrain below vehicle is above ekf origin's altitude
+                float terr_offset_m = 0;
+                if (_is_terrain_alt_oabak && !get_terrain_offset_m(terr_offset_m)) {
                     // trigger terrain failsafe
                     return false;
                 }
 
                 // calculate final destination as an offset from EKF origin in NEU
-                Vector2f destination_ne_cm;
-                if (!_oa_destination.get_vector_xy_from_origin_NE_cm(destination_ne_cm)) {
+                Vector2f destination_ne_m;
+                if (!_oa_destination.get_vector_xy_from_origin_NE_m(destination_ne_m)) {
                     // this should never happen because we can only get here if we have an EKF origin
                     INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
                     return false;
                 }
-                int32_t target_alt_loc_alt_cm = 0;
-                UNUSED_RESULT(target_alt_loc.get_alt_cm(target_alt_loc.get_alt_frame(), target_alt_loc_alt_cm));
-                Vector3p desination_neu_cm{destination_ne_cm.x, destination_ne_cm.y, (float)target_alt_loc_alt_cm};
+                float target_alt_loc_alt_m = 0;
+                UNUSED_RESULT(target_alt_loc.get_alt_m(target_alt_loc.get_alt_frame(), target_alt_loc_alt_m));
+                Vector3p destination_neu_m{destination_ne_m.x, destination_ne_m.y, target_alt_loc_alt_m};
 
                 // pass the desired position directly to the position controller
-                _pos_control.input_pos_NEU_cm(desination_neu_cm, terr_offset_cm, 1000.0);
+                _pos_control.input_pos_NEU_m(destination_neu_m, terr_offset_m, 10.0);
 
                 // update horizontal position controller (vertical is updated in vehicle code)
                 _pos_control.update_NE_controller();
@@ -241,16 +246,16 @@ bool AC_WPNav_OA::update_wpnav()
                 _oa_destination = oa_destination_new;
 
                 // calculate final destination as an offset from EKF origin in NEU
-                Vector3f desination_neu_cm;
-                if (!_oa_destination.get_vector_from_origin_NEU_cm(desination_neu_cm)) {
+                Vector3f destination_neu_m;
+                if (!_oa_destination.get_vector_from_origin_NEU_m(destination_neu_m)) {
                     // this should never happen because we can only get here if we have an EKF origin
                     INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
                     return false;
                 }
 
                 // pass the desired position directly to the position controller as an offset from EKF origin in NEU
-                Vector3p desination_neu_cm_p{desination_neu_cm.x, desination_neu_cm.y, desination_neu_cm.z};
-                _pos_control.input_pos_NEU_cm(desination_neu_cm_p, 0, 1000.0);
+                Vector3p destination_neu_m_p{destination_neu_m.x, destination_neu_m.y, destination_neu_m.z};
+                _pos_control.input_pos_NEU_m(destination_neu_m_p, 0, 10.0);
 
                 // update horizontal position controller (vertical is updated in vehicle code)
                 _pos_control.update_NE_controller();

--- a/libraries/AC_WPNav/AC_WPNav_OA.cpp
+++ b/libraries/AC_WPNav/AC_WPNav_OA.cpp
@@ -15,12 +15,12 @@ AC_WPNav_OA::AC_WPNav_OA(const AP_AHRS_View& ahrs, AC_PosControl& pos_control, c
 // Falls back to original destination if OA is not active.
 bool AC_WPNav_OA::get_oa_wp_destination(Location& destination) const
 {
-    // if oa inactive return unadjusted location
+    // Return unmodified global destination if OA is not active
     if (_oa_state == AP_OAPathPlanner::OA_NOT_REQUIRED) {
         return get_wp_destination_loc(destination);
     }
 
-    // return latest destination provided by oa path planner
+    // OA is active — return path-planner-adjusted intermediate destination
     destination = _oa_destination;
     return true;
 }
@@ -29,6 +29,7 @@ bool AC_WPNav_OA::get_oa_wp_destination(Location& destination) const
 // See set_wp_destination_NEU_m() for full details.
 bool AC_WPNav_OA::set_wp_destination_NEU_cm(const Vector3f& destination_neu_cm, bool is_terrain_alt)
 {
+    // Convert input from centimeters to meters and delegate to meter version
     return set_wp_destination_NEU_m(destination_neu_cm * 0.01, is_terrain_alt);
 }
 
@@ -38,8 +39,10 @@ bool AC_WPNav_OA::set_wp_destination_NEU_cm(const Vector3f& destination_neu_cm, 
 // - Resets OA state on success.
 bool AC_WPNav_OA::set_wp_destination_NEU_m(const Vector3f& destination_neu_m, bool is_terrain_alt)
 {
+    // Call base implementation to set destination and terrain-altitude flag
     const bool ret = AC_WPNav::set_wp_destination_NEU_m(destination_neu_m, is_terrain_alt);
 
+    // If destination set successfully, reset OA state to inactive
     if (ret) {
         // reset object avoidance state
         _oa_state = AP_OAPathPlanner::OA_NOT_REQUIRED;
@@ -52,6 +55,7 @@ bool AC_WPNav_OA::set_wp_destination_NEU_m(const Vector3f& destination_neu_m, bo
 // See get_wp_distance_to_destination_m() for full details.
 float AC_WPNav_OA::get_wp_distance_to_destination_cm() const
 {
+    // Convert horizontal distance from meters to centimeters
     return get_wp_distance_to_destination_m() * 100.0;
 }
 
@@ -59,10 +63,12 @@ float AC_WPNav_OA::get_wp_distance_to_destination_cm() const
 // Ignores OA-adjusted targets and always measures to the original final destination.
 float AC_WPNav_OA::get_wp_distance_to_destination_m() const
 {
+    // Return horizontal distance to final destination (ignoring OA intermediate goals)
     if (_oa_state == AP_OAPathPlanner::OA_NOT_REQUIRED) {
         return AC_WPNav::get_wp_distance_to_destination_m();
     }
 
+    // Compute distance to original destination using backed-up NEU position
     return get_horizontal_distance(_pos_control.get_pos_estimate_NEU_m().xy().tofloat(), _destination_oabak_neu_m.xy());
 }
 
@@ -70,6 +76,7 @@ float AC_WPNav_OA::get_wp_distance_to_destination_m() const
 // See get_wp_bearing_to_destination_rad() for full details.
 int32_t AC_WPNav_OA::get_wp_bearing_to_destination_cd() const
 {
+    // Convert bearing to destination (in radians) to centidegrees
     return rad_to_cd(get_wp_bearing_to_destination_rad());
 }
 
@@ -77,10 +84,12 @@ int32_t AC_WPNav_OA::get_wp_bearing_to_destination_cd() const
 // Ignores OA-adjusted targets and always calculates from original final destination.
 float AC_WPNav_OA::get_wp_bearing_to_destination_rad() const
 {
+    // Use base class method if object avoidance is inactive
     if (_oa_state == AP_OAPathPlanner::OA_NOT_REQUIRED) {
         return AC_WPNav::get_wp_bearing_to_destination_rad();
     }
 
+    // Return bearing to the original destination, not the OA-adjusted one
     return get_bearing_rad(_pos_control.get_pos_estimate_NEU_m().xy().tofloat(), _destination_oabak_neu_m.xy());
 }
 
@@ -88,6 +97,7 @@ float AC_WPNav_OA::get_wp_bearing_to_destination_rad() const
 // Ignores OA-adjusted intermediate destinations.
 bool AC_WPNav_OA::reached_wp_destination() const
 {
+    // Only consider the waypoint reached if OA is inactive and base class condition is met
     return (_oa_state == AP_OAPathPlanner::OA_NOT_REQUIRED) && AC_WPNav::reached_wp_destination();
 }
 
@@ -95,12 +105,12 @@ bool AC_WPNav_OA::reached_wp_destination() const
 // Delegates to parent class if OA is not active or not required.
 bool AC_WPNav_OA::update_wpnav()
 {
-    // run path planning around obstacles
+    // Run path planning logic using the active OA planner
     AP_OAPathPlanner *oa_ptr = AP_OAPathPlanner::get_singleton();
     Location current_loc;
     if ((oa_ptr != nullptr) && AP::ahrs().get_location(current_loc)) {
 
-        // backup _origin and _destination_neu_m when not doing oa
+        // Backup current path state before OA modifies it
         if (_oa_state == AP_OAPathPlanner::OA_NOT_REQUIRED) {
             _origin_oabak_neu_m = _origin_neu_m;
             _destination_oabak_neu_m = _destination_neu_m;
@@ -108,13 +118,15 @@ bool AC_WPNav_OA::update_wpnav()
             _next_destination_oabak_neu_m = _next_destination_neu_m;
         }
 
-        // convert origin, destination and next_destination to Locations and pass into oa
+        // Convert backup path state to global Location objects for planner input
         const Location origin_loc(_origin_oabak_neu_m * 100.0, _is_terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
         const Location destination_loc(_destination_oabak_neu_m * 100.0, _is_terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
         const Location next_destination_loc(_next_destination_oabak_neu_m * 100.0, _is_terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
         Location oa_origin_new, oa_destination_new, oa_next_destination_new;
         bool dest_to_next_dest_clear = true;
         AP_OAPathPlanner::OAPathPlannerUsed path_planner_used = AP_OAPathPlanner::OAPathPlannerUsed::None;
+
+        // Request obstacle-avoidance-adjusted path from planner
         const AP_OAPathPlanner::OA_RetState oa_retstate = oa_ptr->mission_avoidance(current_loc,
                                                                                     origin_loc,
                                                                                     destination_loc,
@@ -128,6 +140,7 @@ bool AC_WPNav_OA::update_wpnav()
         switch (oa_retstate) {
 
         case AP_OAPathPlanner::OA_NOT_REQUIRED:
+            // OA is no longer needed — restore original destination and optionally set next
             if (_oa_state != oa_retstate) {
                 // object avoidance has become inactive so reset target to original destination
                 if (!set_wp_destination_NEU_m(_destination_oabak_neu_m, _is_terrain_alt_oabak)) {
@@ -145,7 +158,7 @@ bool AC_WPNav_OA::update_wpnav()
                 _oa_state = oa_retstate;
             }
 
-            // ensure we stop at next waypoint
+            // Prevent transitioning past this waypoint if path to next is unclear
             // Note that this check is run on every iteration even if the path planner is not active
             if (!dest_to_next_dest_clear) {
                 force_stop_at_next_wp();
@@ -153,6 +166,7 @@ bool AC_WPNav_OA::update_wpnav()
             break;
 
         case AP_OAPathPlanner::OA_PROCESSING:
+            // Allow continued movement while OA path is processing if fast-waypointing is enabled
             if (oa_ptr->get_options() & AP_OAPathPlanner::OA_OPTION_FAST_WAYPOINTS) {
                 // if fast waypoint option is set, proceed during processing
                 break;
@@ -160,8 +174,7 @@ bool AC_WPNav_OA::update_wpnav()
             FALLTHROUGH;
 
         case AP_OAPathPlanner::OA_ERROR:
-            // during processing or in case of error stop the vehicle
-            // by setting the oa_destination to a stopping point
+            // OA temporarily failing — stop vehicle at current position
             if ((_oa_state != AP_OAPathPlanner::OA_PROCESSING) && (_oa_state != AP_OAPathPlanner::OA_ERROR)) {
                 // calculate stopping point
                 Vector3f stopping_point_neu_m;
@@ -176,7 +189,7 @@ bool AC_WPNav_OA::update_wpnav()
 
         case AP_OAPathPlanner::OA_SUCCESS:
 
-            // handling of returned destination depends upon path planner used
+            // Handle result differently depending on which OA planner was used
             switch (path_planner_used) {
 
             case AP_OAPathPlanner::OAPathPlannerUsed::None:
@@ -186,6 +199,7 @@ bool AC_WPNav_OA::update_wpnav()
 
             case AP_OAPathPlanner::OAPathPlannerUsed::Dijkstras:
                 // Dijkstra's.  Action is only needed if path planner has just became active or the target destination's lat or lon has changed
+                // Interpolate altitude and set new target if different or first OA success
                 if ((_oa_state != AP_OAPathPlanner::OA_SUCCESS) || !oa_destination_new.same_latlon_as(_oa_destination)) {
                     Location origin_oabak_loc(_origin_oabak_neu_m * 100.0, _is_terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
                     Location destination_oabak_loc(_destination_oabak_neu_m * 100, _is_terrain_alt_oabak ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
@@ -200,7 +214,7 @@ bool AC_WPNav_OA::update_wpnav()
                     _oa_state = oa_retstate;
                     _oa_destination = oa_destination_new;
 
-                    // if a next destination was provided then use it
+                    // Set next destination if provided
                     if ((oa_ptr->get_options() & AP_OAPathPlanner::OA_OPTION_FAST_WAYPOINTS) && !oa_next_destination_new.is_zero()) {
                         // calculate oa_next_destination_new's altitude using linear interpolation between original origin and destination
                         // this "next destination" is still an intermediate point between the origin and destination
@@ -217,19 +231,18 @@ bool AC_WPNav_OA::update_wpnav()
                 _oa_state = oa_retstate;
                 _oa_destination = oa_destination_new;
 
-                // altitude target interpolated from current_loc's distance along the original path
+                // Adjust altitude based on current progress along the path
                 Location target_alt_loc = current_loc;
                 target_alt_loc.linearly_interpolate_alt(origin_loc, destination_loc);
 
-                // correct target_alt_loc's alt-above-ekf-origin if using terrain altitudes
-                // positive terr_offset_m means terrain below vehicle is above ekf origin's altitude
+                // Get terrain offset if needed
                 float terr_offset_m = 0;
                 if (_is_terrain_alt_oabak && !get_terrain_offset_m(terr_offset_m)) {
                     // trigger terrain failsafe
                     return false;
                 }
 
-                // calculate final destination as an offset from EKF origin in NEU
+                // Convert global destination to NEU vector and pass directly to position controller
                 Vector2f destination_ne_m;
                 if (!_oa_destination.get_vector_xy_from_origin_NE_m(destination_ne_m)) {
                     // this should never happen because we can only get here if we have an EKF origin
@@ -254,7 +267,7 @@ bool AC_WPNav_OA::update_wpnav()
                 _oa_state = oa_retstate;
                 _oa_destination = oa_destination_new;
 
-                // calculate final destination as an offset from EKF origin in NEU
+                // Convert final destination to NEU offset and push to position controller
                 Vector3f destination_neu_m;
                 if (!_oa_destination.get_vector_from_origin_NEU_m(destination_neu_m)) {
                     // this should never happen because we can only get here if we have an EKF origin
@@ -277,7 +290,7 @@ bool AC_WPNav_OA::update_wpnav()
         }
     }
 
-    // run the non-OA update
+    // Run standard waypoint update if OA was not active or handled above
     return AC_WPNav::update_wpnav();
 }
 

--- a/libraries/AC_WPNav/AC_WPNav_OA.h
+++ b/libraries/AC_WPNav/AC_WPNav_OA.h
@@ -22,7 +22,7 @@ public:
     /// set_wp_destination waypoint using position vector (distance from ekf origin in cm)
     ///     is_terrain_alt should be true if destination.z is a desired altitude above terrain
     ///     returns false on failure (likely caused by missing terrain data)
-    bool set_wp_destination_NEU_cm(const Vector3f& destination, bool is_terrain_alt = false) override;
+    bool set_wp_destination_NEU_cm(const Vector3f& destination_neu_cm, bool is_terrain_alt = false) override;
 
     /// get horizontal distance to destination in cm
     /// always returns distance to final destination (i.e. does not use oa adjusted destination)

--- a/libraries/AC_WPNav/AC_WPNav_OA.h
+++ b/libraries/AC_WPNav/AC_WPNav_OA.h
@@ -23,10 +23,12 @@ public:
     ///     is_terrain_alt should be true if destination.z is a desired altitude above terrain
     ///     returns false on failure (likely caused by missing terrain data)
     bool set_wp_destination_NEU_cm(const Vector3f& destination_neu_cm, bool is_terrain_alt = false) override;
+    bool set_wp_destination_NEU_m(const Vector3f& destination_neu_m, bool is_terrain_alt = false) override;
 
     /// get horizontal distance to destination in cm
     /// always returns distance to final destination (i.e. does not use oa adjusted destination)
     float get_wp_distance_to_destination_cm() const override;
+    float get_wp_distance_to_destination_m() const override;
 
     /// get bearing to next waypoint in centi-degrees
     /// always returns bearing to final destination (i.e. does not use oa adjusted destination)
@@ -45,9 +47,9 @@ protected:
 
     // oa path planning variables
     AP_OAPathPlanner::OA_RetState _oa_state;    // state of object avoidance, if OA_SUCCESS we use _oa_destination to avoid obstacles
-    Vector3f    _origin_oabak_neu_cm;           // backup of _origin_neu_m so it can be restored when oa completes
-    Vector3f    _destination_oabak_neu_cm;      // backup of _destination_neu_m so it can be restored when oa completes
-    Vector3f    _next_destination_oabak_neu_cm; // backup of _next_destination_neu_m so it can be restored when oa completes
+    Vector3f    _origin_oabak_neu_m;            // backup of _origin_neu_m so it can be restored when oa completes
+    Vector3f    _destination_oabak_neu_m;       // backup of _destination_neu_m so it can be restored when oa completes
+    Vector3f    _next_destination_oabak_neu_m;  // backup of _next_destination_neu_m so it can be restored when oa completes
     bool        _is_terrain_alt_oabak;  // true if backup origin and destination z-axis are terrain altitudes
     Location    _oa_destination;        // intermediate destination during avoidance
     Location    _oa_next_destination;   // intermediate next destination during avoidance

--- a/libraries/AC_WPNav/AC_WPNav_OA.h
+++ b/libraries/AC_WPNav/AC_WPNav_OA.h
@@ -15,32 +15,42 @@ public:
     /// Constructor
     AC_WPNav_OA(const AP_AHRS_View& ahrs, AC_PosControl& pos_control, const AC_AttitudeControl& attitude_control);
 
-    // returns object avoidance adjusted wp location using location class
-    // returns false if unable to convert from target vector to global coordinates
+    // Returns the object-avoidance-adjusted waypoint location (in global coordinates).
+    // Falls back to original destination if OA is not active.
     bool get_oa_wp_destination(Location& destination) const override;
 
-    /// set_wp_destination waypoint using position vector (distance from ekf origin in cm)
-    ///     is_terrain_alt should be true if destination.z is a desired altitude above terrain
-    ///     returns false on failure (likely caused by missing terrain data)
+    // Sets the waypoint destination using NEU coordinates in centimeters.
+    // See set_wp_destination_NEU_m() for full details.
     bool set_wp_destination_NEU_cm(const Vector3f& destination_neu_cm, bool is_terrain_alt = false) override;
+
+    // Sets the waypoint destination using NEU coordinates in meters.
+    // - destination_neu_m: NEU offset from EKF origin in meters.
+    // - is_terrain_alt: true if the Z component represents altitude above terrain.
+    // - Resets OA state on success.
     bool set_wp_destination_NEU_m(const Vector3f& destination_neu_m, bool is_terrain_alt = false) override;
 
-    /// get horizontal distance to destination in cm
-    /// always returns distance to final destination (i.e. does not use oa adjusted destination)
+    // Returns the horizontal distance to the final destination in centimeters.
+    // See get_wp_distance_to_destination_m() for full details.
     float get_wp_distance_to_destination_cm() const override;
+
+    // Returns the horizontal distance to the final destination in meters.
+    // Ignores OA-adjusted targets and always measures to the original final destination.
     float get_wp_distance_to_destination_m() const override;
 
-    /// get bearing to next waypoint in centi-degrees
-    /// always returns bearing to final destination (i.e. does not use oa adjusted destination)
+    // Returns the bearing to the final destination in centidegrees.
+    // See get_wp_bearing_to_destination_rad() for full details.
     int32_t get_wp_bearing_to_destination_cd() const override;
 
-    /// get_bearing_to_destination - get bearing to next waypoint in radians
+    // Returns the bearing to the final destination in radians.
+    // Ignores OA-adjusted targets and always calculates from original final destination.
     virtual float get_wp_bearing_to_destination_rad() const override;
 
-    /// true when we have come within RADIUS cm of the final destination
+    // Returns true if the vehicle has reached the final destination within radius threshold.
+    // Ignores OA-adjusted intermediate destinations.
     bool reached_wp_destination() const override;
 
-    /// run the wp controller
+    // Runs the waypoint navigation update loop, including OA path planning logic.
+    // Delegates to parent class if OA is not active or not required.
     bool update_wpnav() override;
 
 protected:


### PR DESCRIPTION
```
Board,blimp,bootloader,copter,heli,plane,rover,sub
CubeOrange,*,0,40,40,-264,*,-208
```