### PR TITLE
AP_VisualOdom: Allow disabling health pre-arm check

### DIFF
--- a/libraries/AP_VisualOdom/AP_VisualOdom.cpp
+++ b/libraries/AP_VisualOdom/AP_VisualOdom.cpp
@@ -114,6 +114,13 @@ const AP_Param::GroupInfo AP_VisualOdom::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("_QUAL_MIN", 8, AP_VisualOdom, _quality_min, 0),
 
+    // @Param: _OPTIONS
+    // @DisplayName: Visual odometry options
+    // @Description: Visual odometry options
+    // @Bitmask: 0:Allow arming even if VO is not healthy
+    // @User: Advanced
+    AP_GROUPINFO("_OPTIONS", 9, AP_VisualOdom, _options, 0),
+
     AP_GROUPEND
 };
 
@@ -288,7 +295,7 @@ bool AP_VisualOdom::pre_arm_check(char *failure_msg, uint8_t failure_msg_len) co
     }
 
     // check healthy
-    if (!healthy()) {
+    if (!healthy() && !option_enabled(ViconOptionsMask::ALLOW_ARMING_IF_UNHEALTHY)) {
         hal.util->snprintf(failure_msg, failure_msg_len, "not healthy");
         return false;
     }

--- a/libraries/AP_VisualOdom/AP_VisualOdom.h
+++ b/libraries/AP_VisualOdom/AP_VisualOdom.h
@@ -122,6 +122,14 @@ public:
         return _type;
     }
 
+    enum class ViconOptionsMask : uint8_t {
+        ALLOW_ARMING_IF_UNHEALTHY = (1 << 0), // allow arming even if VO is not healthy
+    };
+
+    bool option_enabled(ViconOptionsMask option) const {
+        return (_options.get() & (uint8_t)option) != 0;
+    }
+
 private:
 
     static AP_VisualOdom *_singleton;
@@ -136,6 +144,7 @@ private:
     AP_Float _pos_noise;        // position measurement noise in meters
     AP_Float _yaw_noise;        // yaw measurement noise in radians
     AP_Int8 _quality_min;       // positions and velocities will only be sent to EKF if over this value.  if 0 all values sent to EKF
+    AP_Int8 _options;           // visual odometry options, see ViconOptionsMask
 
     // reference to backends
     AP_VisualOdom_Backend *_driver;


### PR DESCRIPTION
There are valid use cases where a user might want to take off with no visual odometry available (take off manually, switch to visual odom when in the air)
Also needed for: https://github.com/ArduPilot/ardupilot/pull/30701