### PR TITLE
autotest: improve `test.Plane.CompassLearnInFlight` robustness

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -6737,6 +6737,9 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.wait_ready_to_arm()
         self.takeoff(30, mode='TAKEOFF')
         self.assert_parameter_value("COMPASS_OFS_X", 20, epsilon=30)
+        # fly straight and level for a bit to let GSF converge for accurate learning
+        self.change_mode("FBWB") # not "CRUISE" to avoid heading track with bad compass
+        self.wait_distance(200, accuracy=20)
         old_compass_ofs_x = self.get_parameter('COMPASS_OFS_X')
         self.set_parameters({
             "COMPASS_OFS_X": 1100,


### PR DESCRIPTION
The test has always learned a marginal compass value (25-30, with failure at 35) and since commit `a52f911b` it has usually failed on my machine with a value of 40-45 presumably due to a small change in the flight path. It also occasionally fails in CI with similar values; presumably different machine speeds select a different part of the flight during which learning occurs.

Fix the issue by flying a straight level path to allow time for the GSF to converge, as that is used as the reference for learning according to the code. This results in a learned value of 5-10 which is much closer to the target and hopefully less sensitive to the particular machine.