### PR TITLE
Tools: Additional fix for ubuntu prereq script $PATH whitespace bug

### DIFF
--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -308,7 +308,7 @@ elif [ ${RELEASE_CODENAME} == 'bookworm' ]; then
 elif [ ${RELEASE_CODENAME} == 'lunar' ]; then
     SITL_PKGS+=" libpython3-stdlib" # for argparse
 elif [ ${RELEASE_CODENAME} != 'mantic' ] &&
-     [ ${RELEASE_CODENAME} != 'noble' ] && 
+     [ ${RELEASE_CODENAME} != 'noble' ] &&
      [ ${RELEASE_CODENAME} != 'oracular' ] &&
      [ ${RELEASE_CODENAME} != 'plucky' ] &&
      true; then
@@ -516,30 +516,30 @@ if [[ $DO_AP_STM_ENV -eq 1 ]]; then
 exportline="export PATH=$OPT/$ARM_ROOT/bin:\$PATH";
 grep -Fxq "$exportline" ~/$SHELL_LOGIN 2>/dev/null || {
     if maybe_prompt_user "Add $OPT/$ARM_ROOT/bin to your PATH [N/y]?" ; then
-        echo $exportline >> ~/$SHELL_LOGIN
-        eval $exportline
+        echo "$exportline" >> ~/$SHELL_LOGIN
+        eval "$exportline"
     else
         echo "Skipping adding $OPT/$ARM_ROOT/bin to PATH."
     fi
 }
 fi
 
-exportline2="export PATH=$ARDUPILOT_ROOT/$ARDUPILOT_TOOLS:\$PATH";
+exportline2="export PATH=\"$ARDUPILOT_ROOT/$ARDUPILOT_TOOLS:\"\$PATH";
 grep -Fxq "$exportline2" ~/$SHELL_LOGIN 2>/dev/null || {
     if maybe_prompt_user "Add $ARDUPILOT_ROOT/$ARDUPILOT_TOOLS to your PATH [N/y]?" ; then
-        echo $exportline2 >> ~/$SHELL_LOGIN
-        eval $exportline2
+        echo "$exportline2" >> ~/$SHELL_LOGIN
+        eval "$exportline2"
     else
         echo "Skipping adding $ARDUPILOT_ROOT/$ARDUPILOT_TOOLS to PATH."
     fi
 }
 
 if [[ $SKIP_AP_COMPLETION_ENV -ne 1 ]]; then
-exportline3="source $ARDUPILOT_ROOT/Tools/completion/completion.bash";
+exportline3="source \"$ARDUPILOT_ROOT/Tools/completion/completion.bash\"";
 grep -Fxq "$exportline3" ~/$SHELL_LOGIN 2>/dev/null || {
     if maybe_prompt_user "Add ArduPilot Bash Completion to your bash shell [N/y]?" ; then
-        echo $exportline3 >> ~/.bashrc
-        eval $exportline3
+        echo "$exportline3" >> ~/.bashrc
+        eval "$exportline3"
     else
         echo "Skipping adding ArduPilot Bash Completion."
     fi
@@ -549,8 +549,8 @@ fi
 exportline4="export PATH=/usr/lib/ccache:\$PATH";
 grep -Fxq "$exportline4" ~/$SHELL_LOGIN 2>/dev/null || {
     if maybe_prompt_user "Append CCache to your PATH [N/y]?" ; then
-        echo $exportline4 >> ~/$SHELL_LOGIN
-        eval $exportline4
+        echo "$exportline4" >> ~/$SHELL_LOGIN
+        eval "$exportline4"
     else
         echo "Skipping appending CCache to PATH."
     fi
@@ -560,7 +560,7 @@ echo "Done!"
 if [[ $SKIP_AP_GIT_CHECK -ne 1 ]]; then
   if [ -d ".git" ]; then
     heading "Update git submodules"
-    cd $ARDUPILOT_ROOT
+    cd "$ARDUPILOT_ROOT"
     git submodule update --init --recursive
     echo "Done!"
   fi


### PR DESCRIPTION
Update for initial fix #30582 for bug #30477. Initial fix partially handled whitespace except during optional tool installs, wherein bug would still cause malformed $PATH to break Ubuntu PAM login.  