### PR TITLE
AP_AIS: get_vessel_index lat/lng should use int32

### DIFF
--- a/libraries/AP_AIS/AP_AIS.cpp
+++ b/libraries/AP_AIS/AP_AIS.cpp
@@ -378,7 +378,7 @@ void AP_AIS::buffer_shift(uint8_t i)
 // Functions related to the vessel list
 
 // find vessel index in existing list, if not then return new index if possible, returns true if index is valid
-bool AP_AIS::get_vessel_index(uint32_t mmsi, uint16_t &index, uint32_t lat, uint32_t lon)
+bool AP_AIS::get_vessel_index(uint32_t mmsi, uint16_t &index, int32_t lat, int32_t lon)
 {
     const uint16_t list_size = _list.max_items();
 

--- a/libraries/AP_AIS/AP_AIS.h
+++ b/libraries/AP_AIS/AP_AIS.h
@@ -104,7 +104,7 @@ private:
     void buffer_shift(uint8_t i);
 
     // find vessel index in existing list, if not then return new index if possible, returns true if index is valid
-    bool get_vessel_index(uint32_t mmsi, uint16_t &index, uint32_t lat = 0, uint32_t lon = 0) WARN_IF_UNUSED;
+    bool get_vessel_index(uint32_t mmsi, uint16_t &index, int32_t lat = 0, int32_t lon = 0) WARN_IF_UNUSED;
     void clear_list_item(uint16_t index);
 
     // decode the payload


### PR DESCRIPTION
AP_AIS: get_vessel_index lat/lng should use int32