### PR TITLE
Copter: stop passing RC channel inputs to get_pilot_desired_rates_rads

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -444,8 +444,8 @@ protected:
     const char *name4() const override { return "ACRO"; }
 
     // get_pilot_desired_rates_rads - transform pilot's normalised roll pitch and yaw input into a desired lean angle rates
-    // inputs are -1 to 1 and the function returns desired angle rates in centi-degrees-per-second
-    void get_pilot_desired_rates_rads(float roll_in_norm, float pitch_in_norm, float yaw_in_norm, float &roll_out_rads, float &pitch_out_rads, float &yaw_out_rads);
+    // the function returns desired angle rates in radians-per-second
+    void get_pilot_desired_rates_rads(float &roll_out_rads, float &pitch_out_rads, float &yaw_out_rads);
 
     float throttle_hover() const override;
 

--- a/ArduCopter/mode_acro.cpp
+++ b/ArduCopter/mode_acro.cpp
@@ -11,7 +11,7 @@ void ModeAcro::run()
 {
     // convert the input to the desired body frame rate
     float target_roll_rads, target_pitch_rads, target_yaw_rads;
-    get_pilot_desired_rates_rads(channel_roll->norm_input_dz(), channel_pitch->norm_input_dz(), channel_yaw->norm_input_dz(), target_roll_rads, target_pitch_rads, target_yaw_rads);
+    get_pilot_desired_rates_rads(target_roll_rads, target_pitch_rads, target_yaw_rads);
 
     if (!motors->armed()) {
         // Motors should be Stopped
@@ -102,11 +102,15 @@ float ModeAcro::throttle_hover() const
     return Mode::throttle_hover();
 }
 
-// Transform normalized pilot inputs (-1 to 1) into desired angular rates (centidegrees/second)
-void ModeAcro::get_pilot_desired_rates_rads(float roll_in_norm, float pitch_in_norm, float yaw_in_norm, float &roll_out_rads, float &pitch_out_rads, float &yaw_out_rads)
+// return desired angular rates (radians/second) created from pilot inputs
+void ModeAcro::get_pilot_desired_rates_rads(float &roll_out_rads, float &pitch_out_rads, float &yaw_out_rads)
 {
     float rate_delta_max_rads;
     Vector3f rate_ef_level_rads, rate_bf_level_rads, rate_bf_request_rads;
+
+    float roll_in_norm = channel_roll->norm_input_dz();
+    float pitch_in_norm = channel_pitch->norm_input_dz();
+    const float yaw_in_norm = channel_yaw->norm_input_dz();
 
     // apply circular limit to pitch and roll inputs
     float norm_in_length = norm(pitch_in_norm, roll_in_norm);

--- a/ArduCopter/mode_acro_heli.cpp
+++ b/ArduCopter/mode_acro_heli.cpp
@@ -69,7 +69,7 @@ void ModeAcro_Heli::run()
 
     if (!motors->has_flybar()){
         // convert the input to the desired body frame rate
-        get_pilot_desired_rates_rads(channel_roll->norm_input_dz(), channel_pitch->norm_input_dz(), channel_yaw->norm_input_dz(), target_roll_rads, target_pitch_rads, target_yaw_rads);
+        get_pilot_desired_rates_rads(target_roll_rads, target_pitch_rads, target_yaw_rads);
         // only mimic flybar response when trainer mode is disabled
         if ((Trainer)g.acro_trainer.get() == Trainer::OFF) {
             // while landed always leak off target attitude to current attitude


### PR DESCRIPTION
same parameters each time, and makes this function look like other get_pilot_desired_* methods

also correct units in comments.


Tested briefly in SITL.
