### PR TITLE
AP_Mount: fix accels sent to XFRobot camera gimbal

### DIFF
--- a/libraries/AP_Mount/AP_Mount_XFRobot.cpp
+++ b/libraries/AP_Mount/AP_Mount_XFRobot.cpp
@@ -465,7 +465,7 @@ void AP_Mount_XFRobot::send_target_angles(const MountTarget& angle_target_rad)
     const Vector3f &accel_ef = AP::ahrs().get_accel_ef();
     set_attitude_packet.content.main.accel_north = htole16(constrain_int16(accel_ef.x * 100, -INT16_MAX, INT16_MAX));
     set_attitude_packet.content.main.accel_east = htole16(constrain_int16(accel_ef.y * 100, -INT16_MAX, INT16_MAX));
-    set_attitude_packet.content.main.accel_up = htole16(constrain_int16(accel_ef.z * 100, -INT16_MAX, INT16_MAX));
+    set_attitude_packet.content.main.accel_up = htole16(constrain_int16(-(accel_ef.z + GRAVITY_MSS) * 100, -INT16_MAX, INT16_MAX));
 
     // byte 24~25: North speed of vehicle (int16, decimeter/s)
     // byte 26~27: East speed of vehicle (int16, decimeter/s)


### PR DESCRIPTION
This resolves an issue with the XFRobot Z-1 mini camera gimbal's pitch drifting if it is pointed straight down for more than about 30 seconds.  The cause of the problem is we were sending the earth-frame Z-axis acceleration incorrectly.  Not only was the direction wrong but we also need to subtract gravity.

<img width="655" height="924" alt="image" src="https://github.com/user-attachments/assets/4eb8100a-0c97-4d31-b54a-703d58c5a743" />

This has been tested on real hardware