### PR TITLE
board_types.txt : add board ID for AP_HW_NarinX3.

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -315,7 +315,7 @@ AP_HW_SEQUREH743                     1195
 AP_HW_SPEDIXH743                     1196
 AP_HW_SPEDIXF405                     1197
 AP_HW_AEDROXH7                       1198
-
+AP_HW_NarinX3                        1199
 AP_HW_JFB200                         1200
 AP_HW_SKYSTARSF405V2                 1201
 


### PR DESCRIPTION
board_types.txt : add board ID for AP_HW_NarinX3.