### PR TITLE
AP_NavEKF3: rename EK3_MAX_FLOW to EK3_FLOW_MAX

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -302,14 +302,14 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
 
     // Optical flow measurement parameters
 
-    // @Param: MAX_FLOW
-    // @DisplayName: Maximum valid optical flow rate
-    // @Description: This sets the magnitude maximum optical flow rate in rad/sec that will be accepted by the filter
+    // @Param: FLOW_MAX
+    // @DisplayName: Optical flow rate maximum
+    // @Description: The maximum optical flow rate in rad/sec that will be accepted by the filter.  Flow rates above this value will not be fused.
     // @Range: 1.0 4.0
     // @Increment: 0.1
     // @User: Advanced
     // @Units: rad/s
-    AP_GROUPINFO("MAX_FLOW", 20, NavEKF3, _maxFlowRate, 2.5f),
+    AP_GROUPINFO("FLOW_MAX", 20, NavEKF3, _maxFlowRate, 2.5f),
 
     // @Param: FLOW_M_NSE
     // @DisplayName: Optical flow measurement noise (rad/s)


### PR DESCRIPTION
This renames the EK3_MAX_FLOW parameter to EK3_FLOW_MAX so that it appears with other EK3_FLOW_xxx parameters and improves "discoverability" by users.

**Before**
<img width="1189" height="1195" alt="image" src="https://github.com/user-attachments/assets/7542ca6e-db3f-4b67-8b56-76aa4abe782b" />

**After**
<img width="1190" height="478" alt="image" src="https://github.com/user-attachments/assets/8e93062e-a1ec-425b-a879-098de79d4d00" />

This is a very rarely used parameter and I don't see it in any of our parameter files so I don't think we need to worry too much about users being surprised by the name change.
