### PR TITLE
AP_Scripting: revert the reduction of MAXVARS and MAXUPVAL

### DIFF
--- a/libraries/AP_Scripting/lua/src/lfunc.h
+++ b/libraries/AP_Scripting/lua/src/lfunc.h
@@ -26,7 +26,7 @@
 ** maximum number of upvalues in a closure (both C and Lua). (Value
 ** must fit in a VM register.)
 */
-#define MAXUPVAL	127
+#define MAXUPVAL	255
 
 
 /*

--- a/libraries/AP_Scripting/lua/src/lparser.c
+++ b/libraries/AP_Scripting/lua/src/lparser.c
@@ -31,7 +31,7 @@
 
 /* maximum number of local variables per function (must be smaller
    than 250, due to the bytecode format) */
-#define MAXVARS		100
+#define MAXVARS		200
 
 
 #define hasmultret(k)		((k) == VCALL || (k) == VVARARG)


### PR DESCRIPTION
### Summary

I have a large script with lots of local variables. Even though I scope them minimally (inside blocks and functions), it seems that this is a total limit, not a local limit. Proposing to increase it, with Thomas' help we've come up with this:

This reverts commit https://github.com/ArduPilot/ardupilot/commit/6e7367b86fabe173f26f38f0cc1490ed5bc289ec.

This was apparently originally done to fix stack corruption on Linux, but @tpwrules says "i think now it was faulty back then but we've fixed so many memory corruption bugs in lua, so i figure it's probably fixed enough".

These reductions reduce the usage of the Lua stack, which is stored in the heap. This reverts back to the stock Lua values; some complex scripts may desire extra locals. There is some increased risk of memory fragmentation and so forth but presumably such scripts are prepared.

The actual C stack depth can be limited by `LUAI_MAXCCALLS`.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

Full CI matrix green on the current head (`f80873c`) — 101/101 checks passing, confirming this pure constant change builds clean across every board/vehicle target with no side effects.

### Description

`6e7367b` halved `MAXVARS` (200→100) and `MAXUPVAL` (255→127) under the assumption that this reduces C-stack usage. 

**Claude analysis:**
Tracing the actual mechanism: both constants only bound `dyd->actvar.arr` and `dyd->upvalues`, dynamically-grown parser vectors living on the heap (`luaM_growvector`, `lparser.c`/`lfunc.h`), not fixed-size C-stack frames. The real hard ceiling for a function's locals is the shared 255-register bytecode budget (`MAXREGS`, `lcode.c`), which fails safely with a clean compile-time error ("function or expression needs too many registers") rather than a crash — and the actual C-stack recursion depth is governed independently by `LUAI_MAXCCALLS`, unaffected by this change.

Rather than pick a new number, this reverts cleanly to the values that shipped and flew for years before `6e7367b`, restoring known-good headroom rather than asking for something unproven. Per the revert commit's own message: this does trade off a somewhat higher heap-fragmentation/growth risk for scripts that actually use the extra locals — accepted here as a reasonable cost for scripts that need it, with no effect on any script that doesn't.