### PR TITLE
SITL: support SimNet simulator

### DIFF
--- a/libraries/SITL/SIM_JSON.cpp
+++ b/libraries/SITL/SIM_JSON.cpp
@@ -30,8 +30,11 @@
 #include <AP_Logger/AP_Logger.h>
 #include <AP_HAL/utility/replace.h>
 #include <SRV_Channel/SRV_Channel.h>
+#include <AP_Filesystem/AP_Filesystem.h>
 
 #define UDP_TIMEOUT_MS 100
+
+#define SITL_JSON_DEBUG 0
 
 extern const AP_HAL::HAL& hal;
 
@@ -147,6 +150,22 @@ uint32_t JSON::parse_sensors(const char *json)
 {
     uint32_t received_bitmask = 0;
 
+#if SITL_JSON_DEBUG && AP_FILESYSTEM_FILE_WRITING_ENABLED
+    // it is useful in some environments to be able to get a copy of the raw
+    // JSON data
+    const uint32_t now_ms = AP_HAL::millis();
+    if (now_ms - last_debug_ms >= 1000) {
+        // dump received JSON at 1Hz for easy debugging
+        last_debug_ms = now_ms;
+        auto &fs = AP::FS();
+        int fd = fs.open("json_debug.txt", O_WRONLY|O_CREAT|O_TRUNC);
+        if (fd != -1) {
+            fs.write(fd, json, strlen(json));
+            fs.close(fd);
+        }
+    }
+#endif
+
     //printf("%s\n", json);
     for (uint16_t i=0; i<ARRAY_SIZE(keytable); i++) {
         struct keytable &key = keytable[i];
@@ -222,11 +241,18 @@ uint32_t JSON::parse_sensors(const char *json)
                 break;
             }
 
-            case BOOLEAN:
-                *((bool *)key.ptr) = strtoull(p, nullptr, 10) != 0;
+            case BOOLEAN: {
+                bool *b = (bool *)key.ptr;
+                if (strncasecmp(p, "true", 4) == 0) {
+                    *b = true;
+                } else if (strncasecmp(p, "false", 5) == 0) {
+                    *b = false;
+                } else {
+                    *b = strtoull(p, nullptr, 10) != 0;
+                }
                 //printf("%s/%s = %i\n", key.section, key.key, *((unit8_t *)key.ptr));
                 break;
-
+            }
         }
     }
 
@@ -309,7 +335,18 @@ void JSON::recv_fdm(const struct sitl_input &input)
     velocity_ef = state.velocity;
     position = state.position;
     position.xy() += origin.get_distance_NE_double(home);
-    use_time_sync = !state.no_time_sync;
+
+    if (received_bitmask & TIME_SYNC) {
+        if (use_time_sync != !state.no_time_sync) {
+            use_time_sync = !state.no_time_sync;
+            printf("Forcing use_time_sync=%d\n", int(use_time_sync));
+            if (!use_time_sync) {
+                // if not using time sync then default EKF type to 10, as
+                // otherwise EKF is likely to diverge
+                AP_Param::set_default_by_name("AHRS_EKF_TYPE", 10);
+            }
+        }
+    }
 
     // deal with euler or quaternion attitude
     if ((received_bitmask & QUAT_ATT) != 0) {
@@ -339,6 +376,10 @@ void JSON::recv_fdm(const struct sitl_input &input)
         update_eas_airspeed();
     }
 
+    if ((received_bitmask & WIND_VEL) != 0) {
+        wind_ef = state.velocity_wind;
+    }
+
     // Convert from a meters from origin physics to a lat long alt
     update_position();
 
@@ -356,6 +397,25 @@ void JSON::recv_fdm(const struct sitl_input &input)
     }
     if ((received_bitmask & WIND_SPD) != 0) {
         wind_vane_apparent.speed = state.wind_vane_apparent.speed;
+    }
+
+    // update RC input
+    static_assert(ARRAY_SIZE(state.rc) <= ARRAY_SIZE(rcin), "JSON rc in size mismatch");
+    uint8_t rc_chan_count = 0;
+    for (uint8_t i=0; i<ARRAY_SIZE(state.rc); i++) {
+        if ((received_bitmask & (RC_1 << i)) != 0) {
+            rcin[i] = (state.rc[i] - 1000.0f) / 1000.0f;
+            rc_chan_count = i+1;
+        }
+    }
+    rcin_chan_count = rc_chan_count;
+
+    // update battery state
+    if ((received_bitmask & BAT_VOLT) != 0) {
+        battery_voltage = state.bat_volt; 
+    }
+    if ((received_bitmask & BAT_AMP) != 0) {
+        battery_current = state.bat_amp; 
     }
 
     double deltat;
@@ -462,7 +522,9 @@ void JSON::update(const struct sitl_input &input)
     update_mag_field_bf();
 
     // allow for changes in physics step
-    adjust_frame_time(constrain_float(sitl->loop_rate_hz, rate_hz-1, rate_hz+1));
+    if (use_time_sync) {
+        adjust_frame_time(constrain_float(sitl->loop_rate_hz, rate_hz-1, rate_hz+1));
+    }
 
 #if 0
     // report frame rate

--- a/libraries/SITL/SIM_JSON.h
+++ b/libraries/SITL/SIM_JSON.h
@@ -94,7 +94,11 @@ private:
         Vector3f attitude;
         Quaternion quaternion;
         Vector3f velocity;
+        Vector3f velocity_wind;
         float rng[6];
+        float rc[12];
+        float bat_volt;
+        float bat_amp;
         struct {
             float direction;
             float speed;
@@ -110,7 +114,7 @@ private:
         void *ptr;
         enum data_type type;
         bool required;
-    } keytable[17] = {
+    } keytable[32] {
         { "", "timestamp", &state.timestamp_s, DATA_DOUBLE, true },
         { "imu", "gyro",    &state.imu.gyro, DATA_VECTOR3F, true },
         { "imu", "accel_body", &state.imu.accel_body, DATA_VECTOR3F, true },
@@ -124,10 +128,25 @@ private:
         { "", "rng_4", &state.rng[3], DATA_FLOAT, false },
         { "", "rng_5", &state.rng[4], DATA_FLOAT, false },
         { "", "rng_6", &state.rng[5], DATA_FLOAT, false },
+        {"","velocity_wind", &state.velocity_wind, DATA_VECTOR3F, false},
         {"windvane","direction", &state.wind_vane_apparent.direction, DATA_FLOAT, false},
         {"windvane","speed", &state.wind_vane_apparent.speed, DATA_FLOAT, false},
         {"", "airspeed", &state.airspeed, DATA_FLOAT, false},
         {"", "no_time_sync", &state.no_time_sync, BOOLEAN, false},
+        { "rc", "rc_1", &state.rc[0], DATA_FLOAT, false },
+        { "rc", "rc_2", &state.rc[1], DATA_FLOAT, false },
+        { "rc", "rc_3", &state.rc[2], DATA_FLOAT, false },
+        { "rc", "rc_4", &state.rc[3], DATA_FLOAT, false },
+        { "rc", "rc_5", &state.rc[4], DATA_FLOAT, false },
+        { "rc", "rc_6", &state.rc[5], DATA_FLOAT, false },
+        { "rc", "rc_7", &state.rc[6], DATA_FLOAT, false },
+        { "rc", "rc_8", &state.rc[7], DATA_FLOAT, false },
+        { "rc", "rc_9", &state.rc[8], DATA_FLOAT, false },
+        { "rc", "rc_10", &state.rc[9], DATA_FLOAT, false },
+        { "rc", "rc_11", &state.rc[10], DATA_FLOAT, false },
+        { "rc", "rc_12", &state.rc[11], DATA_FLOAT, false },
+        { "battery", "voltage", &state.bat_volt, DATA_FLOAT, false },
+        { "battery", "current", &state.bat_amp, DATA_FLOAT, false },
     };
 
     // Enum coresponding to the ordering of keys in the keytable.
@@ -145,12 +164,29 @@ private:
         RNG_4       = 1U << 10,
         RNG_5       = 1U << 11,
         RNG_6       = 1U << 12,
-        WIND_DIR    = 1U << 13,
-        WIND_SPD    = 1U << 14,
-        AIRSPEED    = 1U << 15,
-        TIME_SYNC   = 1U << 16,
+        WIND_VEL    = 1U << 13,
+        WIND_DIR    = 1U << 14,
+        WIND_SPD    = 1U << 15,
+        AIRSPEED    = 1U << 16,
+        TIME_SYNC   = 1U << 17,
+        RC_1        = 1U << 18,
+        RC_2        = 1U << 19,
+        RC_3        = 1U << 20,
+        RC_4        = 1U << 21,
+        RC_5        = 1U << 22,
+        RC_6        = 1U << 23,
+        RC_7        = 1U << 24,
+        RC_8        = 1U << 25,
+        RC_9        = 1U << 26,
+        RC_10       = 1U << 27,
+        RC_11       = 1U << 28,
+        RC_12       = 1U << 29,
+        BAT_VOLT    = 1U << 30,
+        BAT_AMP     = 1U << 31,
     };
     uint32_t last_received_bitmask;
+
+    uint32_t last_debug_ms;
 };
 
 }

--- a/libraries/SITL/examples/JSON/pybullet/robot.py
+++ b/libraries/SITL/examples/JSON/pybullet/robot.py
@@ -1,203 +1,207 @@
 #!/usr/bin/env python3
-
-# flake8: noqa
-
 '''
-example rover for JSON backend using pybullet
-based on racecar example from pybullet
+example vehicles using pyBullet
 '''
 
-import os, inspect, sys
-
+import os
+import sys
+import time
+import math
 import socket
 import struct
 import json
-import math
+import argparse
 
-from pyrobolearn.simulators import Bullet
+import pybullet as p
 import pybullet_data
 
-# use pymavlink for ArduPilot convention transformations
-from pymavlink.rotmat import Vector3, Matrix3
+from pymavlink.rotmat import Vector3
 from pymavlink.quaternion import Quaternion
-from pyrobolearn.utils.transformation import get_rpy_from_quaternion
-import pyrobolearn as prl
 
-import time
-
-import argparse
-from math import degrees, radians
-
-parser = argparse.ArgumentParser(description="pybullet robot")
-parser.add_argument("--vehicle", required=True, choices=['quad', 'racecar', 'iris', 'opendog', 'all'], default='iris', help="vehicle type")
-parser.add_argument("--fps", type=float, default=1000.0, help="physics frame rate")
+# --- Argument parsing ---
+parser = argparse.ArgumentParser(description="pybullet robot (no pyrobolearn)")
+parser.add_argument("--vehicle", required=True, choices=['racecar', 'iris'], default='iris', help="vehicle type")
+parser.add_argument("--fps", type=float, default=1200.0, help="physics frame rate")
 parser.add_argument("--stadium", default=False, action='store_true', help="use stadium for world")
-
+parser.add_argument("--nogui", default=False, action='store_true', help="disable GUI")
 args = parser.parse_args()
 
+# --- Constants ---
 RATE_HZ = args.fps
 TIME_STEP = 1.0 / RATE_HZ
 GRAVITY_MSS = 9.80665
 
-# Create simulator
-sim = Bullet()
+# --- PyBullet initialization ---
+physicsClient = p.connect(p.DIRECT if args.nogui else p.GUI)
+p.setTimeStep(TIME_STEP)
+p.setGravity(0, 0, -GRAVITY_MSS)
+p.setRealTimeSimulation(0)
+p.setAdditionalSearchPath(pybullet_data.getDataPath())
 
-# create world
-from pyrobolearn.worlds import BasicWorld
-world = BasicWorld(sim)
-
+# --- Load environment ---
 if args.stadium:
-    world.sim.remove_body(world.floor_id)
-    world.floor_id = world.sim.load_sdf(os.path.join(pybullet_data.getDataPath(), "stadium.sdf"), position=[0,0,0])
-
-# setup keyboard interface
-interface = prl.tools.interfaces.MouseKeyboardInterface()
-
-def control_quad(pwm):
-    '''control quadcopter'''
-    motor_dir = [ 1, 1, -1, -1 ]
-    motor_order = [ 0, 1, 2, 3 ]
-
-    motors = pwm[0:4]
-    motor_speed = [ 0 ] * 4
-    for m in range(len(motors)):
-        motor_speed[motor_order[m]] = constrain(motors[m] - 1000.0, 0, 1000) * motor_dir[motor_order[m]]
-
-    robot.set_propeller_velocities(motor_speed)
-
-def control_racecar(pwm):
-    '''control racecar'''
-    steer_max = 45.0
-    throttle_max = 200.0
-    steering = constrain((pwm[0] - 1500.0)/500.0, -1, 1) * math.radians(steer_max) * -1
-    throttle = constrain((pwm[2] - 1500.0)/500.0, -1, 1) * throttle_max
-
-    robot.steer(steering)
-    robot.drive(throttle)
-
-last_angles = [0.0] * 12
-
-def control_joints(pwm):
-    '''control a joint based bot'''
-    global last_angles
-    max_angle = radians(90)
-    joint_speed = radians(30)
-    pwm = pwm[0:len(robot.joints)]
-    angles = [ constrain((v-1500.0)/500.0, -1, 1) * max_angle for v in pwm ]
-    current = last_angles
-    max_change = joint_speed * TIME_STEP
-    for i in range(len(angles)):
-        angles[i] = constrain(angles[i], current[i]-max_change, current[i]+max_change)
-    robot.set_joint_positions(angles, robot.joints)
-    last_angles = angles
-
-
-if args.vehicle == 'iris':
-    from pyrobolearn.robots import Quadcopter
-    robot = Quadcopter(sim, urdf="models/iris/iris.urdf")
-    control_pwm = control_quad
-elif args.vehicle == 'racecar':
-    from pyrobolearn.robots import F10Racecar
-    robot = F10Racecar(sim)
-    control_pwm = control_racecar
-elif args.vehicle == 'opendog':
-    from pyrobolearn.robots import OpenDog
-    robot = OpenDog(sim, urdf="models/opendog/opendog.urdf")
-    control_pwm = control_joints
-elif args.vehicle == 'all':
-    from pyrobolearn.robots import OpenDog, Aibo, Ant, ANYmal, HyQ, HyQ2Max, Laikago, LittleDog, Minitaur, Pleurobot, Crab, Morphex, Rhex, SEAHexapod
-    bots = [Crab, Morphex, Rhex, SEAHexapod, Aibo, Ant, ANYmal, HyQ, HyQ2Max, Laikago, LittleDog, Minitaur, Pleurobot ]
-    for i in range(len(bots)):
-        r = bots[i](sim)
-        r.position = [0, i*2, 2]
-    control_pwm = control_joints
-    robot = OpenDog(sim, urdf="models/opendog/opendog.urdf")
+    p.loadSDF("stadium.sdf")
 else:
-    raise Exception("Bad vehicle")
+    p.loadURDF("plane.urdf")
 
+script_dir = os.path.dirname(os.path.abspath(__file__))
 
-sim.set_time_step(TIME_STEP)
-
-time_now = 0
+# --- State ---
+time_now = 0.0
 last_velocity = None
+vehicle = None
+robot_id = None
 
-def quaternion_to_AP(quaternion):
-    '''convert pybullet quaternion to ArduPilot quaternion'''
-    return Quaternion([quaternion[3], quaternion[0], -quaternion[1], -quaternion[2]])
+
+def constrain(v, min_v, max_v):
+    '''constrain a value to a range'''
+    return max(min_v, min(v, max_v))
+
+
+class Iris(object):
+    '''Iris quadcopter'''
+    def __init__(self):
+        global robot_id
+        iris_path = os.path.join(script_dir, "models/iris/iris.urdf")
+        robot_id = p.loadURDF(iris_path, [0, 0, 0.2])
+
+        self.motor_indices = [1, 2, 3, 4]
+        self.motor_dir = [1, 1, -1, -1]
+        self.motor_speed = 5 # visual speed
+        self.thrust_scale = 0.01
+
+        # positive for CCW, negative for CW (quad-X layout)
+        self.rotor_torque_dirs = [1, 1, -1, -1]
+        self.torque_coef = 0.001  # Nm per unit thrust (tunable)
+
+        # physical layout
+        L = 0.2  # arm length
+        self.rotor_positions = [
+            [L, -L, 0],   # motor 1, Front-Right
+            [-L, L, 0],   # motor 2, Rear-Left
+            [L, L, 0],   # motor 3, Front-Left
+            [-L, L, 0],   # motor 4, Rear-Right
+        ]
+        self.reset()
+        print("Created Iris vehicle")
+
+    def update(self, pwm):
+        '''update Iris simulation'''
+        num_motors = 4
+        motors = pwm[:num_motors]
+
+        # scale PWM to thrust (N) and torque (Nm)
+        thrusts = [constrain(p - 1000, 0, 1000) * self.thrust_scale for p in motors]
+
+        total_yaw_torque = 0.0
+
+        for i in range(num_motors):
+            force = [0, 0, thrusts[i]]
+            p.applyExternalForce(
+                objectUniqueId=robot_id,
+                linkIndex=self.motor_indices[i],
+                forceObj=force,
+                posObj=[0, 0, 0],
+                flags=p.LINK_FRAME
+                )
+
+            # accumulate torque (about Z axis)
+            total_yaw_torque += self.rotor_torque_dirs[i] * thrusts[i] * self.torque_coef
+
+        # Apply yaw torque to body
+        p.applyExternalTorque(
+            objectUniqueId=robot_id,
+            linkIndex=-1,
+            torqueObj=[0, 0, -total_yaw_torque],
+            flags=p.LINK_FRAME
+        )
+
+        # animate motor spinning
+        for i in range(num_motors):
+            speed = constrain(motors[i] - 1000.0, 0, 1000) * self.motor_dir[i] * self.motor_speed
+            p.setJointMotorControl2(robot_id, self.motor_indices[i], p.VELOCITY_CONTROL, targetVelocity=speed)
+
+    def reset(self):
+        '''reset time and location'''
+        p.resetBasePositionAndOrientation(robot_id, [0, 0, 0.2], [0, 0, 0, 1])
+
+
+class RaceCar(object):
+    '''racing car'''
+    def __init__(self):
+        global robot_id
+        robot_id = p.loadURDF("racecar/racecar.urdf", [0, 0, 0.2])
+
+        self.steering_joints = [4, 6]
+        self.wheel_joints = [2, 3, 5, 7]
+        self.steer_max = 45.0
+        self.throttle_max = 200.0
+
+        self.reset()
+
+        print("Created RaceCar vehicle")
+
+    def update(self, pwm):
+        '''update RaceCar simulation'''
+        steering = constrain((pwm[0] - 1500.0)/500.0, -1, 1) * math.radians(self.steer_max) * -1
+        throttle = constrain((pwm[2] - 1500.0)/500.0, -1, 1) * self.throttle_max
+
+        for joint in self.wheel_joints:
+            p.setJointMotorControl2(robot_id, joint,
+                                    p.VELOCITY_CONTROL,
+                                    targetVelocity=throttle)
+        for joint in self.steering_joints:
+            p.setJointMotorControl2(robot_id, joint,
+                                    p.POSITION_CONTROL,
+                                    targetPosition=steering)
+
+    def reset(self):
+        '''reset time and location'''
+        p.resetBasePositionAndOrientation(robot_id, [0, 0, 0.2], [0, 0, 0, 1])
+
 
 def vector_to_AP(vec):
-    '''convert pybullet vector tuple to ArduPilot Vector3'''
     return Vector3(vec[0], -vec[1], -vec[2])
 
-def quaternion_from_AP(q):
-    '''convert ArduPilot quaternion to pybullet quaternion'''
-    return [q.q[1], -q.q[2], -q.q[3], q.q[0]]
 
-def to_tuple(vec3):
-    '''convert a Vector3 to a tuple'''
-    return (vec3.x, vec3.y, vec3.z)
+def to_tuple(v3):
+    return (v3.x, v3.y, v3.z)
 
-def init():
-  global time_now
-  time_now = 0
-  robot.position = [0,0,0]
-  robot.orientation = [0,0,0,1]
 
-def constrain(v,min_v,max_v):
-    '''constrain a value'''
-    if v < min_v:
-        v = min_v
-    if v > max_v:
-        v = max_v
-    return v
+def quaternion_to_AP(q):
+    '''convert pybullet quaternion to ArduPilot quaternion'''
+    return Quaternion([q[3], q[0], -q[1], -q[2]])
 
-#robot.position = [ 0, 0, 2]
-#robot.orientation = quaternion_from_AP(Quaternion([math.radians(0), math.radians(0), math.radians(50)]))
 
 def physics_step(pwm_in):
+    global time_now, last_velocity
+    vehicle.update(pwm_in)
+    p.stepSimulation()
+    time_now += TIME_STEP
 
-  control_pwm(pwm_in)
+    pos, orn = p.getBasePositionAndOrientation(robot_id)
+    lin_vel, ang_vel = p.getBaseVelocity(robot_id)
 
-  world.step(sleep_dt=0)
+    q_ap = quaternion_to_AP(orn)
+    roll, pitch, yaw = q_ap.euler
+    velocity = vector_to_AP(lin_vel)
+    position = vector_to_AP(pos)
 
-  global time_now
-  time_now += TIME_STEP
+    dcm = q_ap.dcm
+    gyro = dcm.transposed() * vector_to_AP(ang_vel)
 
-  # get the position orientation and velocity
-  quaternion = quaternion_to_AP(robot.orientation)
-  roll, pitch, yaw = quaternion.euler
-  velocity = vector_to_AP(robot.linear_velocity)
-  position = vector_to_AP(robot.position)
+    if last_velocity is None:
+        last_velocity = velocity
 
-  # get ArduPilot DCM matrix (rotation matrix)
-  dcm = quaternion.dcm
+    accel = (velocity - last_velocity) * (1.0 / TIME_STEP)
+    last_velocity = velocity
+    accel.z -= GRAVITY_MSS
+    accel = dcm.transposed() * accel
 
-  # get gyro vector in body frame
-  gyro = dcm.transposed() * vector_to_AP(robot.angular_velocity)
-  
-  # calculate acceleration
-  global last_velocity
-  if last_velocity is None:
-      last_velocity = velocity
+    return time_now, to_tuple(gyro), to_tuple(accel), to_tuple(position), (roll, pitch, yaw), to_tuple(velocity)
 
-  accel = (velocity - last_velocity) * (1.0 / TIME_STEP)
-  last_velocity = velocity
 
-  # add in gravity in earth frame
-  accel.z -= GRAVITY_MSS
-
-  # convert accel to body frame
-  accel = dcm.transposed() * accel
-
-  # convert to tuples
-  accel = to_tuple(accel)
-  gyro = to_tuple(gyro)
-  position = to_tuple(position)
-  velocity = to_tuple(velocity)
-  euler = (roll, pitch, yaw)
-
-  return time_now,gyro,accel,position,euler,velocity
-
+# --- UDP communication setup ---
 sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 sock.bind(('', 9002))
 sock.settimeout(0.1)
@@ -208,126 +212,84 @@ frame_count = 0
 frame_time = time.time()
 print_frame_count = 1000
 
-move_accel = 0.0
-last_move = time.time()
+vehicles = {
+    "iris" : Iris,
+    "racecar" : RaceCar
+}
 
-def move_view(keys):
-    '''move camera target based on arrow keys'''
-    global last_move, move_accel
-    now = time.time()
-    if now - last_move < 0.1:
-        return
-    last_move = now
-    KEY_LEFT = 65295
-    KEY_RIGHT = 65296
-    KEY_UP = 65297
-    KEY_DOWN = 65298
-    global move_accel
-    angle = None
-    if KEY_LEFT in keys:
-        angle = 90
-    elif KEY_RIGHT in keys:
-        angle = -90
-    elif KEY_UP in keys:
-        angle = 180
-    elif KEY_DOWN in keys:
-        angle = 0
-    else:
-        move_accel = 0
-        return
+if args.vehicle not in vehicles:
+    print(f"Unknown vehicle {args.vehicle}")
+    sys.exit(1)
+vehicle = vehicles[args.vehicle]()
 
-    caminfo = list(sim.sim.getDebugVisualizerCamera())
-    target = caminfo[-1]
-    dist = caminfo[-2]
-    pitch = caminfo[-3]
-    yaw = caminfo[-4]
-    look = 90.0-yaw
-    step = 0.3 + move_accel
-    move_accel += 0.1
-    move_accel = min(move_accel, 5)
-    target = (target[0] + step*math.cos(radians(look+angle)),
-              target[1] - step*math.sin(radians(look+angle)),
-              target[2])
-    sim.reset_debug_visualizer(dist, radians(yaw), radians(pitch), target)
+# show the joints
+print("Vehicle joints:")
+number_of_joints = p.getNumJoints(robot_id)
+for joint_number in range(number_of_joints):
+    info = p.getJointInfo(robot_id, joint_number)
+    print(" %s : %s" % (info[0], info[1]))
 
+# --- Main loop ---
 while True:
+    try:
+        data, address = sock.recvfrom(100)
+    except Exception:
+        time.sleep(0.01)
+        continue
 
-  py_time = time.time()
+    parse_format = 'HHI16H'
+    if len(data) != struct.calcsize(parse_format):
+        print(f"Bad packet size: {len(data)}")
+        continue
 
-  interface.step()
-  move_view(interface.key_down)
+    decoded = struct.unpack(parse_format, data)
+    magic = 18458
+    if decoded[0] != magic:
+        print(f"Incorrect magic: {decoded[0]}")
+        continue
 
-  try:
-      data,address = sock.recvfrom(100)
-  except Exception as ex:
-      time.sleep(0.01)
-      continue
+    frame_rate_hz = decoded[1]
+    frame_number = decoded[2]
+    pwm = decoded[3:]
 
-  parse_format = 'HHI16H'
-  magic = 18458
+    if frame_rate_hz != RATE_HZ:
+        RATE_HZ = frame_rate_hz
+        TIME_STEP = 1.0 / RATE_HZ
+        p.setTimeStep(TIME_STEP)
+        print(f"Updated rate to {RATE_HZ} Hz")
 
-  if len(data) != struct.calcsize(parse_format):
-    print("got packet of len %u, expected %u" % (len(data), struct.calcsize(parse_format)))
-    continue
+    if frame_number < last_SITL_frame:
+        vehicle.reset()
+        time_now = 0.0
+        print("Controller reset")
+    elif frame_number != last_SITL_frame + 1 and connected:
+        print(f"Missed {frame_number - last_SITL_frame - 1} frames")
 
+    last_SITL_frame = frame_number
 
-  decoded = struct.unpack(parse_format,data)
+    if not connected:
+        connected = True
+        print(f"Connected to {address}")
 
-  if magic != decoded[0]:
-      print("Incorrect protocol magic %u should be %u" % (decoded[0], magic))
-      continue
+    frame_count += 1
 
-  frame_rate_hz = decoded[1]
-  frame_count = decoded[2]
-  pwm = decoded[3:]
+    phys_time, gyro, accel, pos, euler, velo = physics_step(pwm)
 
-  if frame_rate_hz != RATE_HZ:
-      print("New frame rate %u" % frame_rate_hz)
-      RATE_HZ = frame_rate_hz
-      TIME_STEP = 1.0 / RATE_HZ
-      sim.set_time_step(TIME_STEP)
+    json_data = {
+        "timestamp": phys_time,
+        "imu": {
+            "gyro": gyro,
+            "accel_body": accel
+        },
+        "position": pos,
+        "attitude": euler,
+        "velocity": velo
+    }
 
-  # Check if the fame is in expected order
-  if frame_count < last_SITL_frame:
-    # Controller has reset, reset physics also
-    init()
-    print('Controller reset')
-  elif frame_count == last_SITL_frame:
-    # duplicate frame, skip
-    print('Duplicate input frame')
-    continue
-  elif frame_count != last_SITL_frame + 1 and connected:
-    print('Missed {0} input frames'.format(frame_count - last_SITL_frame - 1))
-  last_SITL_frame = frame_count
+    sock.sendto((json.dumps(json_data, separators=(',', ':')) + "\n").encode("ascii"), address)
 
-  if not connected:
-    connected = True
-    print('Connected to {0}'.format(str(address)))
-  frame_count += 1
-
-  # physics time step
-  phys_time,gyro,accel,pos,euler,velo = physics_step(pwm)
-
-  # build JSON format
-  IMU_fmt = {
-    "gyro" : gyro,
-    "accel_body" : accel
-  }
-  JSON_fmt = {
-    "timestamp" : phys_time,
-    "imu" : IMU_fmt,
-    "position" : pos,
-    "attitude" : euler,
-    "velocity" : velo
-  }
-  JSON_string = "\n" + json.dumps(JSON_fmt,separators=(',', ':')) + "\n"
-
-  # Send to AP
-  sock.sendto(bytes(JSON_string,"ascii"), address)
-
-  # Track frame rate
-  if frame_count % print_frame_count == 0:
-    now = time.time()
-    total_time = now - frame_time
-    print("%.2f fps T=%.3f dt=%.3f" % (print_frame_count/total_time, phys_time, total_time))
-    frame_time = now
+    if frame_count % print_frame_count == 0:
+        now = time.time()
+        total_time = now - frame_time
+        print(f"{print_frame_count/total_time:.2f} fps T={phys_time:.3f} dt={total_time:.3f}")
+        frame_time = now

--- a/libraries/SITL/examples/JSON/readme.md
+++ b/libraries/SITL/examples/JSON/readme.md
@@ -1,3 +1,5 @@
+# JSON Simulation Format
+
 The JSON SITL backend allows software to easily interface with ArduPilot using a standard JSON interface.
 
 To launch the JSON backend run SITL with ```--model JSON:127.0.0.1``` where 127.0.0.1 is replaced with the IP the physics backend is running at. For example: ```sim_vehicle.py -v ArduCopter -f octaquad --model JSON:127.0.0.1 --map --console```
@@ -5,7 +7,8 @@ To launch the JSON backend run SITL with ```--model JSON:127.0.0.1``` where 127.
 Connection to SITL is made via a UDP link. The physics backend should listen for incoming messages on port 9002 it should then reply to the IP and port the messages were received from. This removes the need to configure a target
 IP and port for SITL in the physics backend. SITL will send a output message every 10 seconds allowing the physics backend to auto detect.
 
-SITL output
+## SITL output
+
 Data is output from SITL in a binary format:
 ```
     uint16 magic = 18458
@@ -28,14 +31,14 @@ SERVO_32_ENABLE = 1. The SITL output packet is then
 
 and uses a magic value 29569.  
 
-
 The frame rate represents the time step the simulation should take, this can be changed with the SIM_RATE_HZ ArduPilot parameter. The physics backend is free to ignore this value, a maximum time step size would typically be set. The SIM_RATE_HZ should value be kept above the vehicle loop rate, by default this 400hz on copter and quadplanes and 50 hz on plane and rover.
 
 The frame_count will increment for each output frame sent by ArduPilot, this count can be used to detect lost or duplicate frames. This count will be reset when SITL is re-started allowing the physics backend to reset the vehicle. If not input data is received after 10 seconds ArduPilot will re-send the output frame without incrementing the counter. This allows the physics model to be restarted and re-connect. Note that this may fill up the input buffer of the physics backend after some time. 
 
 PWM is a array of 16 (or 32) servo values in micro seconds, typically in the 1000 to 2000 range as set by the servo output functions.
 
-SITL input
+## SITL input
+
 Data is received from the physics backend in a plain text JSON format. The data must contain the following fields:
 ```
     timestamp (s) physics time
@@ -72,19 +75,47 @@ rangefinder distances corresponding to driver instances:
     rng_6 (m)
 ```
 
-Apparent wind:
+## Apparent wind:
 ```
     windvane:
         direction (radians) clockwise relative to the front, i.e. 0 = head to wind
         speed (m/s)
 ```
-for example:```"windvane":{"direction":0,"speed":0}```
+for example:
+```
+ "windvane":{"direction":0,"speed":0}
+```
 
-Airspeed:
+## Wind Vector
+
+3D wind can be provided in m/s NED frame, for example:
+```
+"velocity_wind":[3.2,0.0,-0.7]
+```
+
+## Airspeed:
 
 ```
     airspeed (m/s)
 ```
+
+## RC Input
+
+The controller can optionally provide R/C input data, up to 12
+channels.
+```
+"rc":{"rc_1":1500,"rc_2":1500,"rc_3":1000,"rc_4":1500,"rc_5":1000,"rc_6":1000,"rc_7":1000,"rc_8":1500,rc_9":1500,"rc_10":1500}
+```
+
+## Battery
+
+The controller can provide battery voltage and current. Voltage in
+Volts, current in Amps:
+```
+"battery":{"voltage":50.39,"current":64.01}
+```
+
+## Debugging
 
 When first connecting you will see a message reporting what fields were successfully received. If any of the mandatory fields are missing SITL will stop, however it will run without the optional fields. This message can be used to double check SITL is receiving everything being sent by the physics backend.
 


### PR DESCRIPTION
extend with more data fields, and fixes for time sync control from JSON server. This avoids the need for a custom firmware for SimNet, allowing users to fly master/stable/beta etc.

Note: for this to work SimNet must be changed to send no_time_sync as true in the JSON.

This also fixes our pybullet example code to work with just pyBullet, removing the dependency on the defunct pyrobolearn package. It only supports the Iris and Racecar examples for now