### PR TITLE
replace ALLOW_DOUBLE_MATH_FUNCTIONS with AP_MATH_ALLOW_DOUBLE_FUNCTIONS

### DIFF
--- a/Tools/CPUInfo/CPUInfo.cpp
+++ b/Tools/CPUInfo/CPUInfo.cpp
@@ -3,7 +3,7 @@
   Andrew Tridgell September 2011
 */
 
-#define ALLOW_DOUBLE_MATH_FUNCTIONS
+#define AP_MATH_ALLOW_DOUBLE_FUNCTIONS 1
 
 #include <cmath>
 

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -162,7 +162,7 @@ def set_double_precision_flags(flags):
                 flags.remove(opt)
             except ValueError:
                 break
-    flags.append("-DALLOW_DOUBLE_MATH_FUNCTIONS")
+    flags.append("-DAP_MATH_ALLOW_DOUBLE_FUNCTIONS=1")
 
     return flags
 

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_MicroStrain5.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_MicroStrain5.cpp
@@ -14,7 +14,7 @@
   support for MicroStrain CX5/GX5-45 serially connected AHRS Systems
  */
 
-#define ALLOW_DOUBLE_MATH_FUNCTIONS
+#define AP_MATH_ALLOW_DOUBLE_FUNCTIONS 1
 
 #include "AP_ExternalAHRS_config.h"
 

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_MicroStrain7.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_MicroStrain7.cpp
@@ -28,7 +28,7 @@
     ./Tools/autotest/sim_vehicle.py -v Plane -A "--serial3=sim:MicroStrain7" --console --map -DG
  */
 
-#define ALLOW_DOUBLE_MATH_FUNCTIONS
+#define AP_MATH_ALLOW_DOUBLE_FUNCTIONS 1
 
 #include "AP_ExternalAHRS_config.h"
 

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.cpp
@@ -16,7 +16,7 @@
   support for serial connected AHRS systems
  */
 
-#define ALLOW_DOUBLE_MATH_FUNCTIONS
+#define AP_MATH_ALLOW_DOUBLE_FUNCTIONS 1
 
 #include "AP_ExternalAHRS_config.h"
 

--- a/libraries/AP_ExternalAHRS/MicroStrain_common.cpp
+++ b/libraries/AP_ExternalAHRS/MicroStrain_common.cpp
@@ -14,7 +14,7 @@
   support for MicroStrain MIP parsing
  */
 
-#define ALLOW_DOUBLE_MATH_FUNCTIONS
+#define AP_MATH_ALLOW_DOUBLE_FUNCTIONS 1
 
 #include "AP_ExternalAHRS_config.h"
 

--- a/libraries/AP_GPS/AP_GPS_GSOF.cpp
+++ b/libraries/AP_GPS/AP_GPS_GSOF.cpp
@@ -38,7 +38,7 @@
 //    param set GPS1_TYPE 11 // GSOF
 //    param set SERIAL3_PROTOCOL 5 // GPS
 
-#define ALLOW_DOUBLE_MATH_FUNCTIONS
+#define AP_MATH_ALLOW_DOUBLE_FUNCTIONS 1
 
 #include "AP_GPS.h"
 #include "AP_GPS_GSOF.h"

--- a/libraries/AP_GSOF/AP_GSOF.cpp
+++ b/libraries/AP_GSOF/AP_GSOF.cpp
@@ -1,11 +1,9 @@
-#define ALLOW_DOUBLE_MATH_FUNCTIONS
+#define AP_MATH_ALLOW_DOUBLE_FUNCTIONS 1
 
 #include "AP_GSOF_config.h"
 #include "AP_GSOF.h"
 
 #if AP_GSOF_ENABLED
-
-
 
 #include <AP_Logger/AP_Logger.h>
 #include <AP_HAL/utility/sparse-endian.h>

--- a/libraries/AP_HAL/AP_HAL_Macros.h
+++ b/libraries/AP_HAL/AP_HAL_Macros.h
@@ -6,19 +6,17 @@
   macros to allow code to build on multiple platforms more easily
  */
 
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL || CONFIG_HAL_BOARD == HAL_BOARD_LINUX || HAL_WITH_EKF_DOUBLE || AP_SIM_ENABLED
+#ifndef AP_MATH_ALLOW_DOUBLE_FUNCTIONS
 /*
   allow double maths on Linux and SITL to avoid problems with system headers
  */
-  #if !defined(ALLOW_DOUBLE_MATH_FUNCTIONS)
-    #define ALLOW_DOUBLE_MATH_FUNCTIONS
-  #endif
-#endif
+#define AP_MATH_ALLOW_DOUBLE_FUNCTIONS (CONFIG_HAL_BOARD == HAL_BOARD_SITL || CONFIG_HAL_BOARD == HAL_BOARD_LINUX || HAL_WITH_EKF_DOUBLE || AP_SIM_ENABLED)
+#endif  // AP_MATH_ALLOW_DOUBLE_FUNCTIONS
 
 // we need to include math.h here for newer compilers (eg. g++ 7.3.1 for stm32)
 #include <math.h>
 
-#if !defined(ALLOW_DOUBLE_MATH_FUNCTIONS)
+#if !AP_MATH_ALLOW_DOUBLE_FUNCTIONS
 /* give warnings if we use double precision maths functions without
    specifying ALLOW_DOUBLE_TRIG_FUNCTIONS. Code should use the
    equivalent f function instead (eg. use cosf() instead of

--- a/libraries/AP_HAL/AP_HAL_Macros.h
+++ b/libraries/AP_HAL/AP_HAL_Macros.h
@@ -6,6 +6,10 @@
   macros to allow code to build on multiple platforms more easily
  */
 
+#ifdef ALLOW_DOUBLE_MATH_FUNCTIONS
+#error ALLOW_DOUBLE_MATH_FUNCTIONS has been replaced with AP_MATH_ALLOW_DOUBLE_FUNCTIONS (which must be defined).  So replace "define ALLOW_DOUBLE_MATH_FUNCTIONS" with "define AP_MATH_ALLOW_DOUBLE_FUNCTIONS 1"
+#endif  // ALLOW_DOUBLE_MATH_FUNCTIONS
+
 #ifndef AP_MATH_ALLOW_DOUBLE_FUNCTIONS
 /*
   allow double maths on Linux and SITL to avoid problems with system headers

--- a/libraries/AP_HAL/utility/sparse-endian.h
+++ b/libraries/AP_HAL/utility/sparse-endian.h
@@ -107,10 +107,10 @@ static inline uint64_t be64toh_ptr(const uint8_t *p) { return (uint64_t) p[7] | 
 
 static inline float be32tofloat_ptr(const uint8_t *p) { return int32_to_float_le(be32toh_ptr(p)); }
 static inline float be32tofloat_ptr(const uint8_t *p, const uint8_t offset) { return be32tofloat_ptr(&p[offset]); }
-#ifdef ALLOW_DOUBLE_MATH_FUNCTIONS
+#if AP_MATH_ALLOW_DOUBLE_FUNCTIONS
 static inline double be64todouble_ptr(const uint8_t *p) { return uint64_to_double_le(be64toh_ptr(p)); }
 static inline double be64todouble_ptr(const uint8_t *p, const uint8_t offset) { return be64todouble_ptr(&p[offset]); }
-#endif
+#endif  // AP_MATH_ALLOW_DOUBLE_FUNCTIONS
 
 static inline void put_le16_ptr(uint8_t *p, uint16_t v) { p[0] = (v&0xFF); p[1] = (v>>8); }
 static inline void put_le24_ptr(uint8_t *p, uint32_t v) { p[0] = (v&0xFF); p[1] = (v>>8)&0xFF; p[2] = (v>>16)&0xFF; }

--- a/libraries/AP_JSON/AP_JSON.cpp
+++ b/libraries/AP_JSON/AP_JSON.cpp
@@ -34,7 +34,7 @@
 
 #pragma GCC optimize("Os")
 
-#define ALLOW_DOUBLE_MATH_FUNCTIONS
+#define AP_MATH_ALLOW_DOUBLE_FUNCTIONS 1
 
 #include "AP_JSON.h"
 #include <AP_Filesystem/AP_Filesystem.h>

--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -25,7 +25,7 @@ template <typename Arithmetic1, typename Arithmetic2>
 typename std::enable_if<std::is_floating_point<typename std::common_type<Arithmetic1, Arithmetic2>::type>::value, bool>::type
 is_equal(const Arithmetic1 v_1, const Arithmetic2 v_2)
 {
-#ifdef ALLOW_DOUBLE_MATH_FUNCTIONS
+#if AP_MATH_ALLOW_DOUBLE_FUNCTIONS
     typedef typename std::common_type<Arithmetic1, Arithmetic2>::type common_type;
     typedef typename std::remove_cv<common_type>::type common_type_nonconst;
     if (std::is_same<double, common_type_nonconst>::value) {
@@ -169,7 +169,7 @@ T wrap_180_cd(const T angle)
 template int wrap_180<int>(const int angle);
 template short wrap_180<short>(const short angle);
 template float wrap_180<float>(const float angle);
-#ifdef ALLOW_DOUBLE_MATH_FUNCTIONS
+#if AP_MATH_ALLOW_DOUBLE_FUNCTIONS
 template double wrap_180<double>(const double angle);
 #endif
 
@@ -177,7 +177,7 @@ template int wrap_180_cd<int>(const int angle);
 template long wrap_180_cd<long>(const long angle);
 template short wrap_180_cd<short>(const short angle);
 template float wrap_180_cd<float>(const float angle);
-#ifdef ALLOW_DOUBLE_MATH_FUNCTIONS
+#if AP_MATH_ALLOW_DOUBLE_FUNCTIONS
 template double wrap_180_cd<double>(const double angle);
 #endif
 
@@ -190,7 +190,7 @@ float wrap_360(const float angle)
     return res;
 }
 
-#ifdef ALLOW_DOUBLE_MATH_FUNCTIONS
+#if AP_MATH_ALLOW_DOUBLE_FUNCTIONS
 double wrap_360(const double angle)
 {
     double res = fmod(angle, 360.0);
@@ -219,7 +219,7 @@ float wrap_360_cd(const float angle)
     return res;
 }
 
-#ifdef ALLOW_DOUBLE_MATH_FUNCTIONS
+#if AP_MATH_ALLOW_DOUBLE_FUNCTIONS
 double wrap_360_cd(const double angle)
 {
     double res = fmod(angle, 36000.0);

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -141,7 +141,7 @@ T wrap_180_cd(const T angle);
  * 100 == centi.
  */
 float wrap_360(const float angle);
-#ifdef ALLOW_DOUBLE_MATH_FUNCTIONS
+#if AP_MATH_ALLOW_DOUBLE_FUNCTIONS
 double wrap_360(const double angle);
 #endif
 int wrap_360(const int angle);
@@ -149,7 +149,7 @@ int wrap_360(const int angle);
 int wrap_360_cd(const int angle);
 long wrap_360_cd(const long angle);
 float wrap_360_cd(const float angle);
-#ifdef ALLOW_DOUBLE_MATH_FUNCTIONS
+#if AP_MATH_ALLOW_DOUBLE_FUNCTIONS
 double wrap_360_cd(const double angle);
 #endif
 

--- a/libraries/AP_Math/definitions.h
+++ b/libraries/AP_Math/definitions.h
@@ -3,6 +3,7 @@
 #include <cmath>
 
 #include <AP_HAL/AP_HAL_Boards.h>
+#include <AP_HAL/AP_HAL_Macros.h>  // sets AP_MATH_ALLOW_DOUBLE_FUNCTIONS
 
 #ifdef M_PI
 # undef M_PI
@@ -35,7 +36,7 @@
 // GPS Specific double precision conversions
 // The precision here does matter when using the wsg* functions for converting
 // between LLH and ECEF coordinates.
-#ifdef ALLOW_DOUBLE_MATH_FUNCTIONS
+#if AP_MATH_ALLOW_DOUBLE_FUNCTIONS
 static const double DEG_TO_RAD_DOUBLE = asin(1) / 90;
 static const double RAD_TO_DEG_DOUBLE = 1 / DEG_TO_RAD_DOUBLE;
 #endif
@@ -65,7 +66,7 @@ static const double WGS84_F = ((double)1.0 / WGS84_IF);
 static const double WGS84_B = (WGS84_A * (1 - WGS84_F));
 
 // Eccentricity of the Earth
-#ifdef ALLOW_DOUBLE_MATH_FUNCTIONS
+#if AP_MATH_ALLOW_DOUBLE_FUNCTIONS
 static const double WGS84_E = (sqrt(2 * WGS84_F - WGS84_F * WGS84_F));
 #endif
 

--- a/libraries/AP_Math/examples/location/location.cpp
+++ b/libraries/AP_Math/examples/location/location.cpp
@@ -2,7 +2,7 @@
 // Unit tests for the AP_Math polygon code
 //
 
-#define ALLOW_DOUBLE_MATH_FUNCTIONS
+#define AP_MATH_ALLOW_DOUBLE_FUNCTIONS 1
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>

--- a/libraries/AP_Math/ftype.h
+++ b/libraries/AP_Math/ftype.h
@@ -68,7 +68,7 @@ inline bool is_zero(const float x) {
  * @brief: Check whether a double is zero
  */
 inline bool is_zero(const double x) {
-#ifdef ALLOW_DOUBLE_MATH_FUNCTIONS
+#if AP_MATH_ALLOW_DOUBLE_FUNCTIONS
   return fabs(x) < FLT_EPSILON;
 #else
   return fabsf(static_cast<float>(x)) < FLT_EPSILON;

--- a/libraries/AP_Math/location_double.cpp
+++ b/libraries/AP_Math/location_double.cpp
@@ -19,7 +19,7 @@
   this is for double precision functions related to the location structure
  */
 
-#define ALLOW_DOUBLE_MATH_FUNCTIONS
+#define AP_MATH_ALLOW_DOUBLE_FUNCTIONS 1
 
 #include <AP_HAL/AP_HAL.h>
 #include <stdlib.h>

--- a/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp
+++ b/libraries/AP_NMEA_Output/AP_NMEA_Output.cpp
@@ -17,7 +17,7 @@
 
  */
 
-#define ALLOW_DOUBLE_MATH_FUNCTIONS
+#define AP_MATH_ALLOW_DOUBLE_FUNCTIONS 1
 
 #include "AP_NMEA_Output.h"
 


### PR DESCRIPTION
```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                 *                                                   
Durandal                            *      *           *       *                 *      *      *
Hitec-Airspeed           *                 *                                                   
KakuteH7-bdshot                     *      *           *       *                 *      *      *
MatekF405                           *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *                  *       *                 *      *      *
f103-QiotekPeriph        *                 *                                                   
f303-Universal           *                 *                                                   
iomcu                                                                *                         
revo-mini                           *      *           *       *                 *      *      *
skyviper-v2450                                         *                                       
```

```
Board,copter
fmuv3,*
```
