### PR TITLE
EAHRS  gps heading

### DIFF
--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS.h
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS.h
@@ -154,6 +154,10 @@ public:
         float  ned_vel_north;
         float  ned_vel_east;
         float  ned_vel_down;
+        float heading;
+        bool have_heading;
+        float heading_accuracy;
+        bool have_heading_acc;
     } gps_data_message_t;
 
     typedef struct {

--- a/libraries/AP_GPS/AP_GPS_ExternalAHRS.cpp
+++ b/libraries/AP_GPS/AP_GPS_ExternalAHRS.cpp
@@ -82,6 +82,17 @@ void AP_GPS_ExternalAHRS::handle_external(const AP_ExternalAHRS::gps_data_messag
 
     state.last_gps_time_ms = AP_HAL::millis();
 
+    if (pkt.have_heading) {
+        state.gps_yaw = pkt.heading;
+        state.gps_yaw_time_ms = state.last_gps_time_ms;
+        state.gps_yaw_configured = true;
+
+        if (pkt.have_heading_acc) {
+            state.have_gps_yaw_accuracy = true;
+            state.gps_yaw_accuracy = pkt.heading_accuracy;
+        }
+    }
+
     new_data = true;
 }
 


### PR DESCRIPTION
# Purpose

Allow an EAHRS GPS to provide a heading to the AP_GPS subsystem. Useful on systems such as the PX-1 that have a single antenna and highly accurate heading solution.

# Testing Performed

None yet, needs SITL testing or flight testing 