### PR TITLE
AP_Motors: Tidy Setting of Motor Limits

### DIFF
--- a/libraries/AP_Motors/AP_Motors6DOF.cpp
+++ b/libraries/AP_Motors/AP_Motors6DOF.cpp
@@ -215,11 +215,8 @@ void AP_Motors6DOF::output_min()
     int8_t i;
 
     // set limits flags
-    limit.roll = true;
-    limit.pitch = true;
-    limit.yaw = true;
-    limit.throttle_lower = false;
-    limit.throttle_upper = false;
+    limit.set_rpy(true);
+    limit.set_throttle(false);
 
     // fill the motor_out[] array for HIL use and send minimum value to each motor
     // ToDo find a field to store the minimum pwm instead of hard coding 1500
@@ -315,11 +312,7 @@ void AP_Motors6DOF::output_armed_stabilizing()
         float linear_out[AP_MOTORS_MAX_NUM_MOTORS]; // 3 linear DOF mix for each motor
 
         // initialize limits flags
-        limit.roll = false;
-        limit.pitch = false;
-        limit.yaw = false;
-        limit.throttle_lower = false;
-        limit.throttle_upper = false;
+        limit.set_all(false);
 
         // sanity check throttle is above zero and below current limited throttle
         if (throttle_thrust <= -_throttle_thrust_max) {
@@ -421,11 +414,7 @@ void AP_Motors6DOF::output_armed_stabilizing_vectored()
     float linear_out[AP_MOTORS_MAX_NUM_MOTORS]; // 3 linear DOF mix for each motor
 
     // initialize limits flags
-    limit.roll= false;
-    limit.pitch = false;
-    limit.yaw = false;
-    limit.throttle_lower = false;
-    limit.throttle_upper = false;
+    limit.set_all(false);
 
     // sanity check throttle is above zero and below current limited throttle
     if (throttle_thrust <= -_throttle_thrust_max) {
@@ -508,11 +497,7 @@ void AP_Motors6DOF::output_armed_stabilizing_vectored_6dof()
     float yfl_max;
 
     // initialize limits flags
-    limit.roll = false;
-    limit.pitch = false;
-    limit.yaw = false;
-    limit.throttle_lower = false;
-    limit.throttle_upper = false;
+    limit.set_all(false);
 
     // sanity check throttle is above zero and below current limited throttle
     if (throttle_thrust <= -_throttle_thrust_max) {

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -199,7 +199,7 @@ void AP_MotorsHeli::output_min()
     update_motor_control(AP_MotorsHeli_RSC::RotorControlState::STOP);
 
     // override limits flags
-    set_limit_flag_pitch_roll_yaw(true);
+    limit.set_rpy(true);
     limit.throttle_lower = true;
     limit.throttle_upper = false;
 }
@@ -326,6 +326,9 @@ void AP_MotorsHeli::output_logic()
         _spool_state = SpoolState::SHUT_DOWN;
     }
 
+    // Always reset the collective limit flags, they get set in move_actuators() if collective reaches a limit
+    limit.set_throttle(false);
+
     switch (_spool_state) {
         case SpoolState::SHUT_DOWN:
             // Motors should be stationary.
@@ -333,9 +336,9 @@ void AP_MotorsHeli::output_logic()
 
             // set limits flags
             if (!using_leaky_integrator()) {
-                set_limit_flag_pitch_roll_yaw(true);
+                limit.set_rpy(true);
             } else {
-                set_limit_flag_pitch_roll_yaw(false);
+                limit.set_rpy(false);
             }
 
             // make sure the motors are spooling in the correct direction
@@ -350,9 +353,9 @@ void AP_MotorsHeli::output_logic()
             // Motors should be stationary or at ground idle.
             // set limits flags
             if (_heliflags.land_complete && !using_leaky_integrator()) {
-                set_limit_flag_pitch_roll_yaw(true);
+                limit.set_rpy(true);
             } else {
-                set_limit_flag_pitch_roll_yaw(false);
+                limit.set_rpy(false);
             }
 
             // Servos should be moving to correct the current attitude.
@@ -372,9 +375,9 @@ void AP_MotorsHeli::output_logic()
 
             // set limits flags
             if (_heliflags.land_complete && !using_leaky_integrator()) {
-                set_limit_flag_pitch_roll_yaw(true);
+                limit.set_rpy(true);
             } else {
-                set_limit_flag_pitch_roll_yaw(false);
+                limit.set_rpy(false);
             }
 
             // make sure the motors are spooling in the correct direction
@@ -394,9 +397,9 @@ void AP_MotorsHeli::output_logic()
 
             // set limits flags
             if (_heliflags.land_complete && !using_leaky_integrator()) {
-                set_limit_flag_pitch_roll_yaw(true);
+                limit.set_rpy(true);
             } else {
-                set_limit_flag_pitch_roll_yaw(false);
+                limit.set_rpy(false);
             }
 
             // make sure the motors are spooling in the correct direction
@@ -414,9 +417,9 @@ void AP_MotorsHeli::output_logic()
 
             // set limits flags
             if (_heliflags.land_complete && !using_leaky_integrator()) {
-                set_limit_flag_pitch_roll_yaw(true);
+                limit.set_rpy(true);
             } else {
-                set_limit_flag_pitch_roll_yaw(false);
+                limit.set_rpy(false);
             }
 
             // make sure the motors are spooling in the correct direction

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -382,10 +382,6 @@ void AP_MotorsHeli_Dual::update_motor_control(AP_MotorsHeli_RSC::RotorControlSta
 //
 void AP_MotorsHeli_Dual::move_actuators(float roll_out, float pitch_out, float collective_in, float yaw_out)
 {
-    // initialize limits flag
-    limit.throttle_lower = false;
-    limit.throttle_upper = false;
-
     if (_dual_mode == AP_MOTORS_HELI_DUAL_MODE_TRANSVERSE || _dual_mode == AP_MOTORS_HELI_DUAL_MODE_INTERMESHING) {
         if (pitch_out < -_cyclic_max/4500.0f) {
             pitch_out = -_cyclic_max/4500.0f;

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -167,10 +167,6 @@ void AP_MotorsHeli_Quad::update_motor_control(AP_MotorsHeli_RSC::RotorControlSta
 //
 void AP_MotorsHeli_Quad::move_actuators(float roll_out, float pitch_out, float collective_in, float yaw_out)
 {
-    // initialize limits flag
-    limit.throttle_lower = false;
-    limit.throttle_upper = false;
-
     // constrain collective input
     float collective_out = collective_in;
     if (collective_out <= 0.0f) {

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -358,10 +358,6 @@ void AP_MotorsHeli_Single::update_motor_control(AP_MotorsHeli_RSC::RotorControlS
 //
 void AP_MotorsHeli_Single::move_actuators(float roll_out, float pitch_out, float coll_in, float yaw_out)
 {
-    // initialize limits flag
-    limit.throttle_lower = false;
-    limit.throttle_upper = false;
-
     // rescale roll_out and pitch_out into the min and max ranges to provide linear motion
     // across the input range instead of stopping when the input hits the constrain value
     // these calculations are based on an assumption of the user specified cyclic_max

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -372,9 +372,7 @@ void AP_MotorsMatrix::output_armed_stabilizing()
     float thr_adj = throttle_thrust - throttle_thrust_best_rpy;
     if (rpy_scale < 1.0f) {
         // Full range is being used by roll, pitch, and yaw.
-        limit.roll = true;
-        limit.pitch = true;
-        limit.yaw = true;
+        limit.set_rpy(true);
         if (thr_adj > 0.0f) {
             limit.throttle_upper = true;
         }

--- a/libraries/AP_Motors/AP_MotorsMatrix_6DoF_Scripting.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix_6DoF_Scripting.cpp
@@ -161,9 +161,7 @@ void AP_MotorsMatrix_6DoF_Scripting::output_armed_stabilizing()
 
     // set limit flags if output is being scaled
     if (rpy_ratio < 1) {
-        limit.roll = true;
-        limit.pitch = true;
-        limit.yaw = true;
+        limit.set_rpy(true);
     }
 
     // scale back rotations evenly so it will all fit

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -537,11 +537,7 @@ void AP_MotorsMulticopter::output_logic()
         // Servos set to their trim values or in a test condition.
 
         // set limits flags
-        limit.roll = true;
-        limit.pitch = true;
-        limit.yaw = true;
-        limit.throttle_lower = true;
-        limit.throttle_upper = true;
+        limit.set_all(true);
 
         // make sure the motors are spooling in the correct direction
         if (_spool_desired != DesiredSpoolState::SHUT_DOWN && _disarm_safe_timer >= _safe_time.get()) {
@@ -563,11 +559,7 @@ void AP_MotorsMulticopter::output_logic()
         // Servos should be moving to correct the current attitude.
 
         // set limits flags
-        limit.roll = true;
-        limit.pitch = true;
-        limit.yaw = true;
-        limit.throttle_lower = true;
-        limit.throttle_upper = true;
+        limit.set_all(true);
 
         // set and increment ramp variables
         switch (_spool_desired) {
@@ -621,11 +613,7 @@ void AP_MotorsMulticopter::output_logic()
         // Servos should exhibit normal flight behavior.
 
         // initialize limits flags
-        limit.roll = false;
-        limit.pitch = false;
-        limit.yaw = false;
-        limit.throttle_lower = false;
-        limit.throttle_upper = false;
+        limit.set_all(false);
 
         // make sure the motors are spooling in the correct direction
         if (_spool_desired != DesiredSpoolState::THROTTLE_UNLIMITED) {
@@ -657,11 +645,7 @@ void AP_MotorsMulticopter::output_logic()
         // Servos should exhibit normal flight behavior.
 
         // initialize limits flags
-        limit.roll = false;
-        limit.pitch = false;
-        limit.yaw = false;
-        limit.throttle_lower = false;
-        limit.throttle_upper = false;
+        limit.set_all(false);
 
         // make sure the motors are spooling in the correct direction
         if (_spool_desired != DesiredSpoolState::THROTTLE_UNLIMITED) {
@@ -686,11 +670,7 @@ void AP_MotorsMulticopter::output_logic()
         // Servos should exhibit normal flight behavior.
 
         // initialize limits flags
-        limit.roll = false;
-        limit.pitch = false;
-        limit.yaw = false;
-        limit.throttle_lower = false;
-        limit.throttle_upper = false;
+        limit.set_all(false);
 
         // make sure the motors are spooling in the correct direction
         if (_spool_desired == DesiredSpoolState::THROTTLE_UNLIMITED) {

--- a/libraries/AP_Motors/AP_MotorsSingle.cpp
+++ b/libraries/AP_Motors/AP_MotorsSingle.cpp
@@ -198,9 +198,7 @@ void AP_MotorsSingle::output_armed_stabilizing()
     _throttle_out = _thrust_out / compensation_gain;
 
     if (is_zero(_thrust_out)) {
-        limit.roll = true;
-        limit.pitch = true;
-        limit.yaw = true;
+        limit.set_rpy(true);
     }
 
     // limit thrust out for calculation of actuator gains
@@ -215,9 +213,7 @@ void AP_MotorsSingle::output_armed_stabilizing()
     if (actuator_max > thrust_out_actuator && !is_zero(actuator_max)) {
         // roll, pitch and yaw request can not be achieved at full servo defection
         // reduce roll, pitch and yaw to reduce the requested defection to maximum
-        limit.roll = true;
-        limit.pitch = true;
-        limit.yaw = true;
+        limit.set_rpy(true);
         rp_scale = thrust_out_actuator / actuator_max;
     } else {
         rp_scale = 1.0f;

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -48,11 +48,7 @@ AP_Motors::AP_Motors(uint16_t speed_hz) :
     _throttle_slew.reset();
 
     // init limit flags
-    limit.roll = true;
-    limit.pitch = true;
-    limit.yaw = true;
-    limit.throttle_lower = true;
-    limit.throttle_upper = true;
+    limit.set_all(true);
     _thrust_boost = false;
     _thrust_balanced = true;
 };
@@ -229,14 +225,6 @@ void AP_Motors::add_motor_num(int8_t motor_num)
     }
 }
 
-    // set limit flag for pitch, roll and yaw
-void AP_Motors::set_limit_flag_pitch_roll_yaw(bool flag)
-{
-    limit.roll = flag;
-    limit.pitch = flag;
-    limit.yaw = flag;
-}
-
 #if AP_SCRIPTING_ENABLED
 void AP_Motors::set_external_limits(bool roll, bool pitch, bool yaw, bool throttle_lower, bool throttle_upper)
 {
@@ -323,6 +311,28 @@ bool AP_Motors::motor_test_checks(size_t buflen, char *buffer) const
     // Do not run frame specific arming checks as motor test is less strict
     // For example not all the outputs have to be assigned
     return AP_Motors::arming_checks(buflen, buffer);
+}
+
+// set all limits
+void AP_Motors::AP_Motors_limit::set_all(bool flag)
+{
+    set_rpy(flag);
+    set_throttle(flag);
+}
+
+// set limits for roll pitch yaw
+void AP_Motors::AP_Motors_limit::set_rpy(bool flag)
+{
+    roll = flag;
+    pitch = flag;
+    yaw = flag;
+}
+
+// set limits for throttle upper and lower
+void AP_Motors::AP_Motors_limit::set_throttle(bool flag)
+{
+    throttle_lower = flag;
+    throttle_upper = flag;
 }
 
 namespace AP {

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -195,15 +195,15 @@ public:
 
     // structure for holding motor limit flags
     struct AP_Motors_limit {
-        bool roll;           // we have reached roll or pitch limit
-        bool pitch;          // we have reached roll or pitch limit
-        bool yaw;            // we have reached yaw limit
-        bool throttle_lower; // we have reached throttle's lower limit
-        bool throttle_upper; // we have reached throttle's upper limit
+        bool roll;                    // we have reached roll or pitch limit
+        bool pitch;                   // we have reached roll or pitch limit
+        bool yaw;                     // we have reached yaw limit
+        bool throttle_lower;          // we have reached throttle's lower limit
+        bool throttle_upper;          // we have reached throttle's upper limit
+        void set_all(bool flag);      // set all limits
+        void set_rpy(bool flag);      // set limits for roll pitch yaw
+        void set_throttle(bool flag); // set limits for throttle upper and lower
     } limit;
-
-    // set limit flag for pitch, roll and yaw
-    void set_limit_flag_pitch_roll_yaw(bool flag);
 
 #if AP_SCRIPTING_ENABLED
     // set limit flag for pitch, roll and yaw


### PR DESCRIPTION
I got a bit confused by the way we are setting the motor limits in heli motors.  This PR is the resulting tidy up I did whilst poking at the code.  Opening this PR to promote some discussion.  There is every chance I am just missing something here.

There should be no change multi-copters outputs, that is just a tidy up.

This PR does the following:
- Attempts to tidy the setting of limit flags with some new methods added to the limit struct.
- Trying to bring heli more in line with multicopter by moving the setting of the throttle limits out of move_actuators() and into the spool logic.
-  Unwraps the leaky I from the from the motors limiting logic (I don't think this is needed).

**Comments About the Change to Leaky I**

The logic currently in master sort of suggests that we are okay with letting I term build if we are using leaky I and in either ground idle, spool up, or spool down.  Whilst most of the time the leaky I will mean that we don't suffer I-term wind up when in these states, I also do not understand why we wouldn't just set the limit flags regardless of whether we use leaky I.

To be in any of the states: ground idle, spool up, or spool down the rotor speed controller has to be below below critical unless we are in an autorotation.  If our head speed is below critical then the vehicle is not running a head speed that it is tuned for, so I think we should simply not let I terms build.

It is work noting that the in_autorotation() state is set false by copter when land_complete or land_complete_maybe are true.


**EDIT: Reduced Scope of This PR**

I have reduced the scope of this PR such that there is now no functional change.  I am just doing two things:
- Adding common methods for setting limits.
- Heli: Moving the resetting of the throttle limits out of move actuators and into the spool state function.  This brings heli a little closer in line with multi.

