### PR TITLE
Tools/AP_Bootloader: save flash

### DIFF
--- a/Tools/AP_Bootloader/bl_protocol.cpp
+++ b/Tools/AP_Bootloader/bl_protocol.cpp
@@ -354,7 +354,7 @@ exit:
 static void
 sync_response(void)
 {
-    uint8_t data[] = {
+    static const uint8_t data[] = {
         PROTO_INSYNC,	// "in sync"
         PROTO_OK	// "OK"
     };
@@ -365,7 +365,7 @@ sync_response(void)
 static void
 invalid_response(void)
 {
-    uint8_t data[] = {
+    static const uint8_t data[] = {
         PROTO_INSYNC,	// "in sync"
         PROTO_INVALID	// "invalid command"
     };
@@ -376,7 +376,7 @@ invalid_response(void)
 static void
 failure_response(void)
 {
-    uint8_t data[] = {
+    static const uint8_t data[] = {
         PROTO_INSYNC,	// "in sync"
         PROTO_FAILED	// "command failed"
     };

--- a/Tools/AP_Bootloader/bl_protocol.cpp
+++ b/Tools/AP_Bootloader/bl_protocol.cpp
@@ -399,7 +399,7 @@ wait_for_eoc(unsigned timeout)
 static void
 cout_word(uint32_t val)
 {
-    cout((uint8_t *)&val, 4);
+    cout((uint8_t *)&val, sizeof(uint32_t));
 }
 
 #define TEST_FLASH 0
@@ -573,34 +573,31 @@ bootloader(unsigned timeout)
 
             switch (arg) {
             case PROTO_DEVICE_BL_REV: {
-                uint32_t bl_proto_rev = BL_PROTOCOL_VERSION;
-                cout((uint8_t *)&bl_proto_rev, sizeof(bl_proto_rev));
+                cout_word(BL_PROTOCOL_VERSION);
                 break;
             }
 
             case PROTO_DEVICE_BOARD_ID:
-                cout((uint8_t *)&board_info.board_type, sizeof(board_info.board_type));
+                cout_word(board_info.board_type);
                 break;
 
             case PROTO_DEVICE_BOARD_REV:
-                cout((uint8_t *)&board_info.board_rev, sizeof(board_info.board_rev));
+                cout_word(board_info.board_rev);
                 break;
 
             case PROTO_DEVICE_FW_SIZE:
-                cout((uint8_t *)&board_info.fw_size, sizeof(board_info.fw_size));
+                cout_word(board_info.fw_size);
                 break;
 
             case PROTO_DEVICE_VEC_AREA:
                 for (unsigned p = 7; p <= 10; p++) {
-                    uint32_t bytes = flash_func_read_word(p * 4);
-
-                    cout((uint8_t *)&bytes, sizeof(bytes));
+                    cout_word(flash_func_read_word(p * 4));
                 }
 
                 break;
 
             case PROTO_DEVICE_EXTF_SIZE:
-                cout((uint8_t *)&board_info.extf_size, sizeof(board_info.extf_size));
+                cout_word(board_info.extf_size);
                 break;
 
             default:

--- a/Tools/AP_Bootloader/bl_protocol.cpp
+++ b/Tools/AP_Bootloader/bl_protocol.cpp
@@ -494,7 +494,7 @@ bootloader(unsigned timeout)
     }
 
     while (true) {
-        volatile int c;
+        int c;
         int arg;
         static union {
             uint8_t		c[256];

--- a/Tools/AP_Bootloader/bl_protocol.cpp
+++ b/Tools/AP_Bootloader/bl_protocol.cpp
@@ -55,8 +55,6 @@
 #endif
 #include <AP_CheckFirmware/AP_CheckFirmware.h>
 
-// #pragma GCC optimize("O0")
-
 
 // bootloader flash update protocol.
 //

--- a/Tools/AP_Bootloader/support.cpp
+++ b/Tools/AP_Bootloader/support.cpp
@@ -38,8 +38,6 @@ static uint8_t last_uart;
 #define BOOTLOADER_BAUDRATE 115200
 #endif
 
-// #pragma GCC optimize("O0")
-
 static bool cin_data(uint8_t *data, uint8_t len, unsigned timeout_ms)
 {
     for (uint8_t i=0; i<ARRAY_SIZE(uarts); i++) {

--- a/Tools/AP_Bootloader/support.cpp
+++ b/Tools/AP_Bootloader/support.cpp
@@ -72,7 +72,7 @@ int cin_word(uint32_t *wp, unsigned timeout_ms)
 }
 
 
-void cout(uint8_t *data, uint32_t len)
+void cout(const uint8_t *data, uint32_t len)
 {
     chnWriteTimeout(uarts[last_uart], data, len, chTimeMS2I(100));
 }

--- a/Tools/AP_Bootloader/support.h
+++ b/Tools/AP_Bootloader/support.h
@@ -22,7 +22,7 @@ extern struct boardinfo board_info;
 void init_uarts(void);
 int16_t cin(unsigned timeout_ms);
 int cin_word(uint32_t *wp, unsigned timeout_ms);
-void cout(uint8_t *data, uint32_t len);
+void cout(const uint8_t *data, uint32_t len);
 void port_setbaud(uint32_t baudrate);
 #if defined(BOOTLOADER_FORWARD_OTG2_SERIAL)
 bool update_otg2_serial_forward(void);

--- a/libraries/AP_HAL_ChibiOS/GPIO.cpp
+++ b/libraries/AP_HAL_ChibiOS/GPIO.cpp
@@ -77,9 +77,6 @@ static struct gpio_entry *gpio_by_pin_num(uint8_t pin_num, bool check_enabled=tr
     return NULL;
 }
 
-static void pal_interrupt_cb(void *arg);
-static void pal_interrupt_cb_functor(void *arg);
-
 GPIO::GPIO()
 {}
 
@@ -300,6 +297,11 @@ AP_HAL::DigitalSource* GPIO::channel(uint16_t pin)
 
 extern const AP_HAL::HAL& hal;
 
+#if PAL_USE_CALLBACKS == TRUE // then ChibiOS PAL event funcs/types are declared
+
+static void pal_interrupt_cb(void *arg);
+static void pal_interrupt_cb_functor(void *arg);
+
 /*
    Attach an interrupt handler to a GPIO pin number. The pin number
    must be one specified with a GPIO() marker in hwdef.dat
@@ -391,6 +393,8 @@ bool GPIO::_attach_interrupt(ioline_t line, palcallback_t cb, void *p, uint8_t m
     return ret;
 }
 
+#endif // PAL_USE_CALLBACKS == TRUE
+
 bool GPIO::usb_connected(void)
 {
     return _usb_connected;
@@ -436,6 +440,8 @@ void IOMCU_DigitalSource::toggle()
 }
 #endif // HAL_WITH_IO_MCU
 
+#if PAL_USE_CALLBACKS == TRUE // then ChibiOS PAL event funcs/types are declared
+
 static void pal_interrupt_cb(void *arg)
 {
     if (arg != nullptr) {
@@ -472,6 +478,8 @@ static void pal_interrupt_cb_functor(void *arg)
     }
     (g->fn)(g->pin_num, palReadLine(g->pal_line), now);
 }
+
+#endif // PAL_USE_CALLBACKS == TRUE
 
 /*
   handle interrupt from pin change for wait_pin()

--- a/libraries/AP_HAL_ChibiOS/GPIO.h
+++ b/libraries/AP_HAL_ChibiOS/GPIO.h
@@ -42,6 +42,8 @@ public:
     /* Alternative interface: */
     AP_HAL::DigitalSource* channel(uint16_t n) override;
 
+    // only override and implement if necessary ChibiOS declarations are available
+#if PAL_USE_CALLBACKS == TRUE
     /* Interrupt interface - fast, for RCOutput and SPI radios */
     bool    attach_interrupt(uint8_t interrupt_num,
                              AP_HAL::Proc p,
@@ -51,6 +53,7 @@ public:
     bool    attach_interrupt(uint8_t pin,
                              irq_handler_fn_t fn,
                              INTERRUPT_TRIGGER_TYPE mode) override;
+#endif // PAL_USE_CALLBACKS == TRUE
 
     /* return true if USB cable is connected */
     bool    usb_connected(void) override;

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -1234,6 +1234,9 @@ class ChibiOSHWDef(hwdef.HWDef):
 #define CH_CFG_USE_DYNAMIC FALSE
 #endif
 #define STM32_FLASH_DISABLE_ISR 0
+#ifndef PAL_USE_CALLBACKS
+#define PAL_USE_CALLBACKS FALSE
+#endif
 ''')
             # get bootloader flash space, if larger than 128k we can enable Heap
             flash_size = self.get_config('FLASH_USE_MAX_KB', type=int, default=0)


### PR DESCRIPTION
Saves ~500 bytes mostly by removing unused GPIO interrupt support. Please see commits for details.

Tested on CubeOrange that this boots and can accept a USB flash.