### PR TITLE
Correct LUA parameter registration for out-of-order indexes

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -6456,6 +6456,25 @@ class TestSuite(ABC):
 
         self.progress("%s: (%f) check passed %f%% error less than %f%%" % (name, value, error_percent, max_error_percent))
 
+    def fetch_all_parameters(self):
+        self.mav.mav.param_request_list_send(self.sysid_thismav(), 1)
+        tstart = self.get_sim_time_cached()
+        ret = {}
+        param_count = 0
+        while True:
+            if param_count > 100 and len(ret) == param_count:
+                break
+            if self.get_sim_time_cached() - tstart > 5:
+                raise NotAchievedException("Did not get all params")
+            m = self.mav.recv_match(type='PARAM_VALUE', blocking=True, timeout=0.1)
+            if m is None:
+                continue
+            if param_count is None or m.param_count > param_count:
+                param_count = m.param_count
+            ret[m.param_id] = m.param_value
+
+        return ret
+
     def get_parameter(self, *args, **kwargs):
         return self.get_parameter_direct(*args, **kwargs)
 

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -11,6 +11,7 @@ import errno
 import glob
 import math
 import os
+import pathlib
 import re
 import shutil
 import signal
@@ -5061,6 +5062,13 @@ class TestSuite(ABC):
         if isinstance(hook, TestSuite.MessageHook):
             hook.hook_removed()
 
+    def install_script_content_context(self, scriptname, content):
+        '''installs an example script with content which will be
+        removed when the context goes away
+        '''
+        self.install_script_content(scriptname, content)
+        self.context_get().installed_scripts.append(scriptname)
+
     def install_example_script_context(self, scriptname):
         '''installs an example script which will be removed when the context goes
         away'''
@@ -8806,6 +8814,14 @@ Also, ignores heartbeats not from our target system'''
                                          "message_definitions", "v1.0", "ardupilotmega.xml")
         mavgen.mavgen(mavgen.Opts(output=dest, wire_protocol='2.0', language='Lua'), [ardupilotmega_xml])
         self.progress("Installed mavlink module")
+
+    def install_script_content(self, scriptname, content):
+        dest = self.installed_script_path(scriptname)
+        destdir = os.path.dirname(dest)
+        if not os.path.exists(destdir):
+            os.mkdir(destdir)
+        destPath = pathlib.Path(dest)
+        destPath.write_text(content)
 
     def install_example_script(self, scriptname):
         source = self.script_example_source_path(scriptname)

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -3134,22 +3134,23 @@ bool AP_Param::add_table(uint8_t _key, const char *prefix, uint8_t num_params)
             info.name = _empty_string;
             return false;
         }
-        // fill in footer for all entries
-        for (uint8_t gi=1; gi<num_params+2; gi++) {
-            auto &ginfo = const_cast<GroupInfo*>(info.group_info)[gi];
-            ginfo.name = _empty_string;
-            ginfo.idx = 0xff;
-        }
-        // hidden first parameter containing AP_Int32 crc
-        auto &hinfo = const_cast<GroupInfo*>(info.group_info)[0];
-        hinfo.flags = AP_PARAM_FLAG_HIDDEN;
-        hinfo.name = _empty_string;
-        hinfo.idx = 0;
-        hinfo.offset = 0;
-        hinfo.type = AP_PARAM_INT32;
-        // fill in default value with the CRC. Relies on sizeof crc == sizeof float
-        memcpy((uint8_t *)&hinfo.def_value, (const uint8_t *)&crc, sizeof(crc));
     }
+    // fill in footer for all entries
+    for (uint8_t gi=1; gi<num_params+2; gi++) {
+        auto &ginfo = const_cast<GroupInfo*>(info.group_info)[gi];
+        ginfo.name = _empty_string;
+        ginfo.idx = 0xff;
+        ginfo.flags = AP_PARAM_FLAG_HIDDEN;
+    }
+    // hidden first parameter containing AP_Int32 crc
+    auto &hinfo = const_cast<GroupInfo*>(info.group_info)[0];
+    hinfo.flags = AP_PARAM_FLAG_HIDDEN;
+    hinfo.name = _empty_string;
+    hinfo.idx = 0;
+    hinfo.offset = 0;
+    hinfo.type = AP_PARAM_INT32;
+    // fill in default value with the CRC. Relies on sizeof crc == sizeof float
+    memcpy((uint8_t *)&hinfo.def_value, (const uint8_t *)&crc, sizeof(crc));
 
     // remember the table size
     if (_dynamic_table_sizes[i] == 0) {

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -3285,6 +3285,7 @@ bool AP_Param::add_param(uint8_t _key, uint8_t param_num, const char *pname, flo
     }
     ginfo.offset = param_num*sizeof(float);
     ginfo.idx = param_num;
+    ginfo.flags = 0;  // clear the hidden flag if set
     float *def_value = const_cast<float *>(&ginfo.def_value);
     *def_value = default_value;
     ginfo.type = AP_PARAM_FLOAT;

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -177,12 +177,12 @@
 
 enum ap_var_type {
     AP_PARAM_NONE    = 0,
-    AP_PARAM_INT8,
-    AP_PARAM_INT16,
-    AP_PARAM_INT32,
-    AP_PARAM_FLOAT,
-    AP_PARAM_VECTOR3F,
-    AP_PARAM_GROUP
+    AP_PARAM_INT8    = 1,
+    AP_PARAM_INT16   = 2,
+    AP_PARAM_INT32   = 3,
+    AP_PARAM_FLOAT   = 4,
+    AP_PARAM_VECTOR3F= 5,
+    AP_PARAM_GROUP   = 6,
 };
 
 


### PR DESCRIPTION
Gaps have their entries marked as "hidden" - but we don't unset that flag when we register a parameter in that gap.

New test fails before and passes afterwards.

This work sponsored by Freespace Solutions.
