### PR TITLE
Prevent airspeed ratio autocal when throttle is active with ARSPD_USE=2

### DIFF
--- a/ArduPlane/Plane.cpp
+++ b/ArduPlane/Plane.cpp
@@ -410,6 +410,17 @@ void Plane::three_hz_loop()
  */
 void Plane::airspeed_ratio_update(void)
 {
+    // check if any airspeed sensor has ARSPD_USE set to 2 (UseWhenZeroThrottle)
+    for (uint8_t i = 0; i < AIRSPEED_MAX_SENSORS; i++) {
+        if (airspeed.get_param(i)->use == 2) {
+            // if ARSPD_USE is 2, check if throttle is active
+            if (!is_zero(SRV_Channels::get_output_scaled(SRV_Channel::k_throttle))) {
+                // Throttle is active, so we must not calibrate.
+                return;
+            }
+        }
+    }
+
     if (!hal.util->get_soft_armed() ||
         !ahrs.get_fly_forward() ||
         !is_flying() ||


### PR DESCRIPTION
Currently, the airspeed ratio autocalibration runs even when the throttle is active. This corrupts the ARSPD_RATIO for users with ARSPD_USE=2 (e.g., front-motor gliders), as the calibration is fed invalid data from the propeller's wash. This fix adds a check to skip the autocalibration cycle if ARSPD_USE is set to 2 and the throttle is active. This change aligns the behavior of the autocalibration with the user's intent, making the feature reliable for these common configurations without affecting other users. This should resolve the issue described in #30749.