### PR TITLE
Update feedforward scaling for plane controllers

### DIFF
--- a/libraries/AC_PID/AC_PID.cpp
+++ b/libraries/AC_PID/AC_PID.cpp
@@ -369,6 +369,16 @@ float AC_PID::get_ff() const
     return  _pid_info.FF + _pid_info.DFF;
 }
 
+float AC_PID::get_ff_component() const
+{
+    return  _pid_info.FF;
+}
+
+float AC_PID::get_dff_component() const
+{
+    return  _pid_info.DFF;
+}
+
 // Used to fully zero the I term between mode changes or initialization
 void AC_PID::reset_I()
 {

--- a/libraries/AC_PID/AC_PID.h
+++ b/libraries/AC_PID/AC_PID.h
@@ -75,6 +75,8 @@ public:
     float get_i() const;
     float get_d() const;
     float get_ff() const;
+    float get_ff_component() const;
+    float get_dff_component() const;
 
     // Used to fully zero the I term between mode changes or initialization
     void reset_I();

--- a/libraries/APM_Control/AP_YawController.cpp
+++ b/libraries/APM_Control/AP_YawController.cpp
@@ -314,8 +314,8 @@ float AP_YawController::get_rate_out(float desired_rate, float scaler, bool disa
         limit_I = true;
     }
 
-    // the P and I elements are scaled by sq(scaler). To use an
-    // unmodified AC_PID object we scale the inputs and calculate FF separately
+    // the PID elements are scaled by sq(scaler). To use an
+    // unmodified AC_PID object we scale the inputs (target and measurement)
     //
     // note that we run AC_PID in radians so that the normal scaling
     // range for IMAX in AC_PID applies (usually an IMAX value less than 1.0)
@@ -326,10 +326,11 @@ float AP_YawController::get_rate_out(float desired_rate, float scaler, bool disa
         rate_pid.set_integrator(old_I);
     }
 
-    // FF should be scaled by scaler/eas2tas, but since we have scaled
+    // FF and DFF should be scaled by scaler/eas2tas, but since we have scaled
     // the AC_PID target above by scaler*scaler we need to instead
     // divide by scaler*eas2tas to get the right scaling
-    const float ff = degrees(rate_pid.get_ff() / (scaler * eas2tas));
+    const float ff = degrees(rate_pid.get_ff_component() / (scaler * eas2tas));
+    const float dff = degrees(rate_pid.get_dff_component() / (scaler * eas2tas));
 
     if (disable_integrator) {
         rate_pid.reset_I();
@@ -344,7 +345,7 @@ float AP_YawController::get_rate_out(float desired_rate, float scaler, bool disa
     pinfo.P *= deg_scale;
     pinfo.I *= deg_scale;
     pinfo.D *= deg_scale;
-    pinfo.DFF *= deg_scale;
+    pinfo.DFF = dff;
     pinfo.limit = limit_I;
 
     // fix the logged target and actual values to not have the scalers applied


### PR DESCRIPTION
Based on our discussion about the ArduPlane PID diagram with @IamPete1, it was noticed that there might be an issue with the feedforward scaling. 

Currently, the FF scaling takes into account FF+DFF, but it only updates the FF. This results in: 

1. DFF component is "unscaled"
2. FF component is "scaled" and updated with the contribution of the DFF term (i.e., FF+DFF)
3. The step 2 affects the logging info of the FF component

This aims to update the FF and DFF components by scaling them separately.