### PR TITLE
Avoid infinite loop in ftoa_engine

### DIFF
--- a/libraries/AP_HAL/tests/test_vsnprintf.cpp
+++ b/libraries/AP_HAL/tests/test_vsnprintf.cpp
@@ -62,4 +62,13 @@ TEST(vsnprintf_Test, Basic)
     }
 }
 
+TEST(vsnprintf_Test, LargeNegativeExponent)
+{
+    char output[256];
+    const float x{1e-44};
+    hal.util->snprintf(output, ARRAY_SIZE(output), "%.99f", x);
+    EXPECT_STREQ("0.000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", output);
+}
+
+
 AP_GTEST_MAIN()

--- a/libraries/AP_HAL/utility/ftoa_engine.cpp
+++ b/libraries/AP_HAL/utility/ftoa_engine.cpp
@@ -146,6 +146,11 @@ int16_t ftoa_engine(float val, char *buf, uint8_t precision, uint8_t maxDecimals
     do {
         char digit = '0';
         while(1) {// find the first nonzero digit or any of the next digits.
+            if (decimal == 0) {
+                // we don't do anything nice if this happens, but at
+                // least we don't loop infinitely:
+                break;
+            }
             while ((prod -= decimal) >= 0)
                 digit++;
             // Now we got too low. Fix it by adding again, once.

--- a/libraries/AP_HAL/utility/print_vprintf.cpp
+++ b/libraries/AP_HAL/utility/print_vprintf.cpp
@@ -43,6 +43,7 @@
 #include <string.h>
 
 #include <AP_HAL/AP_HAL.h>
+#include <AP_Math/AP_Math.h>
 
 #include "ftoa_engine.h"
 #include "xtoa_fast.h"
@@ -205,6 +206,11 @@ flt_oper:
                     ndigs = 0;
                 }
                 memset(buf, 0, sizeof(buf));
+                // ftoa_engine has had problems with very small
+                // numbers; clamp the input to ftoa_engine:
+                if (fabsf(value) < FLT_MIN) {
+                    value = 0.0f;
+                }
                 exp = ftoa_engine(value, (char *)buf, vtype, ndigs);
                 vtype = buf[0];
 

--- a/libraries/AP_HAL/utility/tests/test_ftoa.cpp
+++ b/libraries/AP_HAL/utility/tests/test_ftoa.cpp
@@ -1,0 +1,13 @@
+#include <AP_gtest.h>
+
+#include <AP_HAL/utility/ftoa_engine.h>
+
+TEST(FTOAEngine, LargeNegativeExponent)
+{
+    char buf[255] {};
+    ftoa_engine(1e-44f, buf, 7, 7);
+
+    EXPECT_STREQ(buf, "");  // but at least it doesn't loop infinitely
+}
+
+AP_GTEST_MAIN()


### PR DESCRIPTION
Closes https://github.com/ardupilot/ardupilot/issues/30722

~~I am not satisfied with this at the moment as I was unable to replicate the problem as described in the issue.~~  @tpwrules helped make this reproduce the problem; the snprintf test infinitely loops before the fix and doesn't afterwards.

The issue states that we can cross this codepath in ftoa_engine via send_text, but my test for print_vprintf in here does not replicate the problem before or after the clamping patch!

This is a belts-and-bracers patch, with a bad/minimal patch inside ftoa_engine to avoid the infinite loop and a better clamping patch inside the sole caller to ftoa_engine.
