### PR TITLE
AP_HAL: fix up `ftoa_engine` to avoid wrong results and hangs

### DIFF
--- a/libraries/AP_HAL/utility/ftoa_engine.cpp
+++ b/libraries/AP_HAL/utility/ftoa_engine.cpp
@@ -146,6 +146,12 @@ int16_t ftoa_engine(float val, char *buf, uint8_t precision, uint8_t maxDecimals
 
     do {
         char digit = '0';
+        if(decimal == 0) {
+            // Abnormal case, can't ever add enough digits to exit the loop,
+            // bail out. This will happen for subnormals with frac <= 7 and
+            // precision == 7.
+            break;
+        }
         while(1) {// find the first nonzero digit or any of the next digits.
             while ((prod -= decimal) >= 0)
                 digit++;

--- a/libraries/AP_HAL/utility/ftoa_engine.cpp
+++ b/libraries/AP_HAL/utility/ftoa_engine.cpp
@@ -103,24 +103,25 @@ int16_t ftoa_engine(float val, char *buf, uint8_t precision, uint8_t maxDecimals
     // Read the sign, shift the exponent in place and delete it from frac.
     if (valbits[3] & (1<<7)) flags = FTOA_MINUS; else flags = 0;
     uint8_t exp = valbits[3]<<1;
-    if(valbits[2] & (1<<7)) exp++;    // TODO possible but in case of subnormal
+    if(valbits[2] & (1<<7)) exp++;
 
-    // Test for easy cases, zero and NaN
-    if(exp==0 && frac==0) {
-        buf[0] = flags | FTOA_ZERO;
-        uint8_t i;
-        for(i=0; i<=precision; i++) {
-            buf[i+1] = '0';
+    // Test for easy cases
+    if(exp==0) { // Zero or subnormal
+        if(frac == 0) { // Zero
+            buf[0] = flags | FTOA_ZERO;
+            uint8_t i;
+            for(i=0; i<=precision; i++) {
+                buf[i+1] = '0';
+            }
+            return 0;
+        } else { // Subnormal
+            exp = 1; // Subnormal mantissa has same significance as exp=1
         }
-        return 0;
+    } else if(exp==0xff) { // Infinity or NaN
+        if(frac==0) flags |= FTOA_INF; else flags |= FTOA_NAN;
+    } else { // Normal number
+        frac |= (1UL<<23); // The implicit leading 1 is made explicit
     }
-
-    if(exp == 0xff) {
-        if(frac == 0) flags |= FTOA_INF; else flags |= FTOA_NAN;
-    }
-
-    // The implicit leading 1 is made explicit, except if value subnormal.
-    if (exp != 0) frac |= (1UL<<23);
 
     uint8_t idx = exp>>3;
     int8_t exp10 = exponentTable[idx];


### PR DESCRIPTION
Alternative to #30754 to close #30722 . I have been severely nerd-sniped but here goes... Please see the commit messages for further detail.

This applies to anything that uses `%f` with `hal.util->snprintf` or the things we use linker wraps (augh) to point to that.

Resolves two problems. Out of the ~4.2 billion floats:
* Subnormal numbers are printed as half their true value. e.g. `0.<sufficient zeros>2` was printed as `0.<same zeros>1`. This affects the ~16.7 million non-zero values `fabsf(v) < 1.175494e-38f` (FLT_MIN).
* The 26 smallest non-zero floats (`fabsf(v) <= 2e-44f`) will get stuck in an infinite loop if formatted, causing a watchdog reboot even in flight if executed on the main thread!

Notices and does not resolve two additional problems:
* The requested number of digits is not always produced, the tests request 99 and get fewer depending on the magnitude of the number.
* The precision isn't enough to distinguish every float.

This study of `%f` problems is not exhaustive. I did dig out an OG Genuino Arduino Uno R3 and avr-gcc 7.3.0 to test the (nominally) original assembly this function was ported from and it has none of these problems. Fixing the latter two concerns me slightly for overflows, and none of these problems have been obvious for a decade or more.

We should perhaps consider modernizing our implementation (or digging deeper into the corresponding assembly to fix the other port problems) but this is a surprisingly rich and subtle field. We are also unfortunately not fully consistent in using this implementation.