### PR TITLE
Plane: use parameterised trim_throttle in place of constant value of TRIM_THROTTLE

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -42,7 +42,11 @@ float Plane::calc_speed_scaler(void)
     } else if (arming.is_armed_and_safety_off()) {
         // scale assumed surface movement using throttle output
         float throttle_out = MAX(SRV_Channels::get_output_scaled(SRV_Channel::k_throttle), 1);
-        speed_scaler = sqrtf(THROTTLE_CRUISE / throttle_out);
+        // we use a fixed value here as changing the trim throttle
+        // value is often done at runtime - and changing that
+        // shouldn't change the speed scaler here (it will change the
+        // effective PID values)
+        speed_scaler = sqrtf(AP_PLANE_TRIM_THROTTLE_DEFAULT / throttle_out);
         // This case is constrained tighter as we don't have real speed info
         speed_scaler = constrain_float(speed_scaler, 0.6f, 1.67f);
     } else {

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -426,7 +426,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Range: 0 100
     // @Increment: 1
     // @User: Standard
-    ASCALAR(throttle_cruise,        "TRIM_THROTTLE",  THROTTLE_CRUISE),
+    ASCALAR(throttle_cruise,        "TRIM_THROTTLE",  AP_PLANE_TRIM_THROTTLE_DEFAULT),
 
     // @Param: THROTTLE_NUDGE
     // @DisplayName: Throttle nudge enable

--- a/ArduPlane/config.h
+++ b/ArduPlane/config.h
@@ -138,8 +138,11 @@
 #ifndef THROTTLE_MIN
  # define THROTTLE_MIN                   0 // percent
 #endif
-#ifndef THROTTLE_CRUISE
- # define THROTTLE_CRUISE                45
+#ifdef THROTTLE_CRUISE
+#error THROTTLE_CRUISE was renamed to AP_PLANE_TRIM_THROTTLE_DEFAULT
+#endif
+#ifndef AP_PLANE_TRIM_THROTTLE_DEFAULT
+ # define AP_PLANE_TRIM_THROTTLE_DEFAULT                45
 #endif
 #ifndef THROTTLE_MAX
  # define THROTTLE_MAX                   100


### PR DESCRIPTION
I can't help but think maybe I'm missing something here.....

Two of my Planes run non-standard defaults.  One at 60% and the other at 30% vs the 45% default...

