### PR TITLE
autotest: loosen constrain on DO_CHANGE_SPEED

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -1001,7 +1001,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             )
             self.wait_message_field_values('VFR_HUD', {
                 "throttle": expected_throttle,
-            }, minimum_duration=5, epsilon=2)
+            }, minimum_duration=5, epsilon=5)
 
         self.fly_home_land_and_disarm(timeout=240)
 


### PR DESCRIPTION
we're really only after gross changes here, and that's taken care of by the three cases which are tested.

CI is getting values of 82 or 83 vs what I get on my machine here.  Vagaries of race conditions getting into this state, I believe.

May stop Plane-tests1a flapping.
