### PR TITLE
RC_Channel: Modify parameter parsing implementation to support "All-Vehicles" value.

### DIFF
--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -241,6 +241,8 @@ libraries = list(libraries)
 
 alllibs = libraries[:]
 
+def all_vehicles(vehicle_list:list) -> bool:
+    return len(vehicle_list) and vehicle_list[0].lower() == "all-vehicles"
 
 def process_library(vehicle, library, pathprefix=None):
     '''process one library'''
@@ -275,7 +277,8 @@ def process_library(vehicle, library, pathprefix=None):
                 for only_vehicle in only_vehicles_list:
                     if only_vehicle not in valid_truenames:
                         raise ValueError("Invalid only_vehicle %s" % only_vehicle)
-                if vehicle.name not in only_vehicles_list:
+                if (vehicle.name not in only_vehicles_list
+                    and not all_vehicles(only_vehicles_list)):
                     continue
             p = Parameter(library.name+param_name, current_file)
             debug(p.name + ' ')
@@ -317,22 +320,25 @@ def process_library(vehicle, library, pathprefix=None):
                                                                 field[2].strip())
                 only_for_vehicles = only_for_vehicles.split(",")
                 only_for_vehicles = [some_vehicle.strip() for some_vehicle in only_for_vehicles]
-                delta = set(only_for_vehicles) - set(truename_map.values())
-                if len(delta):
-                    error("Unknown vehicles (%s)" % delta)
+                if not all_vehicles(only_for_vehicles):
+                    delta = set(only_for_vehicles) - set(truename_map.values())
+                    if len(delta):
+                        error("Unknown vehicles (%s)" % delta)
                 debug("field_name=%s vehicle=%s field[1]=%s only_for_vehicles=%s\n" %
                       (field_name, vehicle.name, field[1], str(only_for_vehicles)))
                 if field_name not in known_param_fields:
                     error(f"tagged param: unknown parameter metadata field '{field_name}'")
                     continue
-                if vehicle.name not in only_for_vehicles:
+                if (vehicle.name not in only_for_vehicles
+                    and not all_vehicles(only_for_vehicles)):
                     if len(only_for_vehicles) and field_name in documentation_tags_which_are_comma_separated_nv_pairs:
                         seen_values_or_bitmask_for_other_vehicle = True
                     continue
 
                 append_value = False
                 if field_name in documentation_tags_which_are_comma_separated_nv_pairs:
-                    if vehicle.name in only_for_vehicles:
+                    if (vehicle.name in only_for_vehicles
+                        or all_vehicles(only_for_vehicles)):
                         if seen_values_or_bitmask_for_this_vehicle:
                             append_value = hasattr(p, field_name)
                         seen_values_or_bitmask_for_this_vehicle = True

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -260,8 +260,8 @@ const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Values{Copter, Rover, Plane, Sub}: 212:Mount1 Roll, 213:Mount1 Pitch, 214:Mount1 Yaw, 215:Mount2 Roll, 216:Mount2 Pitch, 217:Mount2 Yaw
     // @Values{Copter, Rover, Plane, Blimp, Sub}:  218:Loweheiser throttle
     // @Values{Copter}: 219:Transmitter Tuning
-    // @Values: 300:Scripting1, 301:Scripting2, 302:Scripting3, 303:Scripting4, 304:Scripting5, 305:Scripting6, 306:Scripting7, 307:Scripting8, 308:Scripting9, 309:Scripting10, 310:Scripting11, 311:Scripting12, 312:Scripting13, 313:Scripting14, 314:Scripting15, 315:Scripting16
-    // @Values: 316:Stop-Restart Scripting
+    // @Values{All-Vehicles}: 300:Scripting1, 301:Scripting2, 302:Scripting3, 303:Scripting4, 304:Scripting5, 305:Scripting6, 306:Scripting7, 307:Scripting8, 308:Scripting9, 309:Scripting10, 310:Scripting11, 311:Scripting12, 312:Scripting13, 313:Scripting14, 314:Scripting15, 315:Scripting16
+    // @Values{All-Vehicles}: 316:Stop-Restart Scripting
     // @User: Standard
     AP_GROUPINFO("OPTION",  6, RC_Channel, option, 0),
 


### PR DESCRIPTION
Changes to resolve [issue 30759](https://github.com/ArduPilot/ardupilot/issues/30759)

Tested the changes using the following method:

1. Executed Tools/scripts/build_parameters.sh from master branch against a version of RC_Channel.cpp that named the following vehicles, Copter, Rover, Plane, Sub, Tracker and Blimp, in the Values list of the OPTION param. Captured all output files generated from this run of the shell script.
2. Executed Tools/scripts/build_parameters.sh against a branch with the code changes in this PR. Captured all output files generated from this run of the shell script.
3. Executed a git diff against the output files from the two shell script runs, reviewed git diff results, and confirmed that the git diff results match expected results (Expected Results: No difference in any of the textual output files from the two runs).

The git diff results are in the attached file: [diff - Add support for All-Vehicles.txt](https://github.com/user-attachments/files/21515681/diff.-.Add.support.for.All-Vehicles.txt)