### PR TITLE
AP_ADSB: add simulated HW Ping200X

### DIFF
--- a/libraries/AP_ADSB/AP_ADSB_uAvionix_UCP.h
+++ b/libraries/AP_ADSB/AP_ADSB_uAvionix_UCP.h
@@ -53,6 +53,10 @@ private:
     uint16_t gdl90Transmit(GDL90_TX_MESSAGE &message, const uint16_t length);
     static bool parseByte(const uint8_t data, GDL90_RX_MESSAGE &msg, GDL90_RX_STATUS &status);
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    uint32_t set_IdentActive_ms;
+#endif
+
     struct {
         uint32_t last_msg_ms;
         GDL90_RX_MESSAGE msg;


### PR DESCRIPTION
add simulated HW Ping200X by locally creating the packets the HW would normally generate and feed them in locally. This doesn't implement a whole external serial-parsing monster SITL driver, just a smaller one locally within the uAvionix_UCP driver