### PR TITLE
Tools: Add All-Vehicles Values option to param_parse.py

### DIFF
--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -242,6 +242,14 @@ libraries = list(libraries)
 alllibs = libraries[:]
 
 
+def all_vehicles(vehicle_list: list) -> bool:
+    return len(vehicle_list) and vehicle_list[0].lower() == "all-vehicles"
+
+
+def applicable_to_vehicle(vehicle: str, vehicle_list: list) -> bool:
+    return vehicle in vehicle_list or all_vehicles(vehicle_list)
+
+
 def process_library(vehicle, library, pathprefix=None):
     '''process one library'''
     paths = library.Path.split(',')
@@ -275,7 +283,7 @@ def process_library(vehicle, library, pathprefix=None):
                 for only_vehicle in only_vehicles_list:
                     if only_vehicle not in valid_truenames:
                         raise ValueError("Invalid only_vehicle %s" % only_vehicle)
-                if vehicle.name not in only_vehicles_list:
+                if not applicable_to_vehicle(vehicle.name, only_vehicles_list):
                     continue
             p = Parameter(library.name+param_name, current_file)
             debug(p.name + ' ')
@@ -317,22 +325,23 @@ def process_library(vehicle, library, pathprefix=None):
                                                                 field[2].strip())
                 only_for_vehicles = only_for_vehicles.split(",")
                 only_for_vehicles = [some_vehicle.strip() for some_vehicle in only_for_vehicles]
-                delta = set(only_for_vehicles) - set(truename_map.values())
-                if len(delta):
-                    error("Unknown vehicles (%s)" % delta)
+                if not all_vehicles(only_for_vehicles):
+                    delta = set(only_for_vehicles) - set(truename_map.values())
+                    if len(delta):
+                        error("Unknown vehicles (%s)" % delta)
                 debug("field_name=%s vehicle=%s field[1]=%s only_for_vehicles=%s\n" %
                       (field_name, vehicle.name, field[1], str(only_for_vehicles)))
                 if field_name not in known_param_fields:
                     error(f"tagged param: unknown parameter metadata field '{field_name}'")
                     continue
-                if vehicle.name not in only_for_vehicles:
+                if not applicable_to_vehicle(vehicle.name, only_for_vehicles):
                     if len(only_for_vehicles) and field_name in documentation_tags_which_are_comma_separated_nv_pairs:
                         seen_values_or_bitmask_for_other_vehicle = True
                     continue
 
                 append_value = False
                 if field_name in documentation_tags_which_are_comma_separated_nv_pairs:
-                    if vehicle.name in only_for_vehicles:
+                    if applicable_to_vehicle(vehicle.name, only_for_vehicles):
                         if seen_values_or_bitmask_for_this_vehicle:
                             append_value = hasattr(p, field_name)
                         seen_values_or_bitmask_for_this_vehicle = True


### PR DESCRIPTION
Changes to resolve [issue 30759](https://github.com/ArduPilot/ardupilot/issues/30759)

Tested the changes using the following method:

1. Executed Tools/scripts/build_parameters.sh from master branch against a version of RC_Channel.cpp that named the following vehicles, Copter, Rover, Plane, Sub, Tracker and Blimp, in the Scripting Values list of the OPTION param. Captured all output files generated from this run of the shell script.
2. Executed Tools/scripts/build_parameters.sh against a branch with the code changes in this PR along with a version of RC_Channel.cpp that named "All-Vehicles" in the Scripting Values list of the OPTION param. Captured all output files generated from this run of the shell script.
3. Executed a git diff against the output files from the two shell script runs, reviewed git diff results, and confirmed that the git diff results match expected results (Expected Results: No difference in any of the textual output files from the two runs).

The git diff results are in the attached file: [diff - Add support for All-Vehicles.txt](https://github.com/user-attachments/files/21531935/diff.-.Add.support.for.All-Vehicles.txt)