### PR TITLE
SITL: add option to set pwm to zero while initialising

### DIFF
--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -607,6 +607,12 @@ const AP_Param::GroupInfo SIM::var_info3[] = {
     // @User: Advanced
     AP_GROUPINFO("UART_LOSS", 42, SIM,  uart_byte_loss_pct, 0),
 
+    // @Param: PWM_ZERO
+    // @DisplayName: PWM zero on initialise
+    // @Description: Sets PWM outputs to zero while initialising
+    // @User: Advanced
+    AP_GROUPINFO("PWM_ZERO", 43, SIM,  pwm_zero_on_init, 0),
+
     // @Group: ARSPD_
     // @Path: ./SITL_Airspeed.cpp
     AP_SUBGROUPINFO(airspeed[0], "ARSPD_", 50, SIM, AirspeedParm),

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -554,6 +554,9 @@ public:
     // RPM when motors are armed
     AP_Float esc_rpm_armed;
 
+    // PWM output 
+    AP_Int8 pwm_zero_on_init;
+
     struct {
         // LED state, for serial LED emulation
         struct {


### PR DESCRIPTION
Add a parameter `SIM_PWM_ZERO` that sets the `pwm_output` to zero while initialising. Default behaviour is unchanged.

### Motivation

The current behaviour causes issues for simulated vehicles in external physics simulations that have servo mappings different from the standard configurations handled in `SITL_State.cpp`. The problem is that since the values `pwm=1000` or `pwm=1500` are valid, an external simulation engine has no way to determine whether they are set to these values because they have been commanded, or because they are set while the `output_ready` flag is false.

If the vehicle requires additional channels, or maps servos differently to defaults, then the pwm values received during   initialisation may not correspond to the value required for a motor to be off, or a servo at its neutral position. This causes the vehicle to move during initialisation and IMU calibration.

For an example of how the changed behaviour is used in an external simulator see: https://github.com/ArduPilot/ardupilot_gazebo/pull/142