### PR TITLE
Convert Copter to meters (0-Static): No Compiler name, axis and units

### DIFF
--- a/ArduCopter/AP_ExternalControl_Copter.cpp
+++ b/ArduCopter/AP_ExternalControl_Copter.cpp
@@ -25,7 +25,7 @@ bool AP_ExternalControl_Copter::set_linear_velocity_and_yaw_rate(const Vector3f 
         linear_velocity.y,
         -linear_velocity.z };
     Vector3f velocity_up_cms = velocity_NEU_ms * 100;
-    copter.mode_guided.set_velocity(velocity_up_cms, false, 0, !isnan(yaw_rate_rads), checked_yaw_rate_rad);
+    copter.mode_guided.set_vel_neu_cms(velocity_up_cms, false, 0, !isnan(yaw_rate_rads), checked_yaw_rate_rad);
     return true;
 }
 

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -318,7 +318,7 @@ bool Copter::set_target_pos_NED(const Vector3f& target_pos, bool use_yaw, float 
 
     const Vector3f pos_neu_cm(target_pos.x * 100.0f, target_pos.y * 100.0f, -target_pos.z * 100.0f);
 
-    return mode_guided.set_destination(pos_neu_cm, use_yaw, radians(yaw_deg), use_yaw_rate, radians(yaw_rate_degs), yaw_relative, terrain_alt);
+    return mode_guided.set_pos_neu_cm(pos_neu_cm, use_yaw, radians(yaw_deg), use_yaw_rate, radians(yaw_rate_degs), yaw_relative, terrain_alt);
 }
 
 // set target position and velocity (for use by scripting)
@@ -332,7 +332,7 @@ bool Copter::set_target_posvel_NED(const Vector3f& target_pos, const Vector3f& t
     const Vector3f pos_neu_cm(target_pos.x * 100.0f, target_pos.y * 100.0f, -target_pos.z * 100.0f);
     const Vector3f vel_neu_cms(target_vel.x * 100.0f, target_vel.y * 100.0f, -target_vel.z * 100.0f);
 
-    return mode_guided.set_destination_posvelaccel(pos_neu_cm, vel_neu_cms, Vector3f());
+    return mode_guided.set_pos_vel_accel_neu_cm(pos_neu_cm, vel_neu_cms, Vector3f());
 }
 
 // set target position, velocity and acceleration (for use by scripting)
@@ -347,7 +347,7 @@ bool Copter::set_target_posvelaccel_NED(const Vector3f& target_pos, const Vector
     const Vector3f vel_neu_cms(target_vel.x * 100.0f, target_vel.y * 100.0f, -target_vel.z * 100.0f);
     const Vector3f accel_neu_cms(target_accel.x * 100.0f, target_accel.y * 100.0f, -target_accel.z * 100.0f);
 
-    return mode_guided.set_destination_posvelaccel(pos_neu_cm, vel_neu_cms, accel_neu_cms, use_yaw, radians(yaw_deg), use_yaw_rate, radians(yaw_rate_degs), yaw_relative);
+    return mode_guided.set_pos_vel_accel_neu_cm(pos_neu_cm, vel_neu_cms, accel_neu_cms, use_yaw, radians(yaw_deg), use_yaw_rate, radians(yaw_rate_degs), yaw_relative);
 }
 
 bool Copter::set_target_velocity_NED(const Vector3f& vel_ned)
@@ -359,7 +359,7 @@ bool Copter::set_target_velocity_NED(const Vector3f& vel_ned)
 
     // convert vector to neu in cm
     const Vector3f vel_neu_cms(vel_ned.x * 100.0f, vel_ned.y * 100.0f, -vel_ned.z * 100.0f);
-    mode_guided.set_velocity(vel_neu_cms);
+    mode_guided.set_vel_neu_cms(vel_neu_cms);
     return true;
 }
 
@@ -375,7 +375,7 @@ bool Copter::set_target_velaccel_NED(const Vector3f& target_vel, const Vector3f&
     const Vector3f vel_neu_cms(target_vel.x * 100.0f, target_vel.y * 100.0f, -target_vel.z * 100.0f);
     const Vector3f accel_neu_cms(target_accel.x * 100.0f, target_accel.y * 100.0f, -target_accel.z * 100.0f);
 
-    mode_guided.set_velaccel(vel_neu_cms, accel_neu_cms, use_yaw, radians(yaw_deg), use_yaw_rate, radians(yaw_rate_degs), relative_yaw);
+    mode_guided.set_vel_accel_neu_cm(vel_neu_cms, accel_neu_cms, use_yaw, radians(yaw_deg), use_yaw_rate, radians(yaw_rate_degs), relative_yaw);
     return true;
 }
 

--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -631,9 +631,9 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_MAV_CMD_NAV_TAKEOFF(const mavlink_command_
         // param6 : longitude   (not supported)
         // param7 : altitude [metres]
 
-        float takeoff_alt = packet.z * 100;      // Convert m to cm
+        float takeoff_alt_cm = packet.z * 100;      // Convert m to cm
 
-        if (!copter.flightmode->do_user_takeoff(takeoff_alt, is_zero(packet.param3))) {
+        if (!copter.flightmode->do_user_takeoff(takeoff_alt_cm, is_zero(packet.param3))) {
             return MAV_RESULT_FAILED;
         }
         return MAV_RESULT_ACCEPTED;

--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -147,9 +147,9 @@ void GCS_MAVLINK_Copter::send_position_target_local_ned()
     }
 
     const ModeGuided::SubMode guided_mode = copter.mode_guided.submode();
-    Vector3f target_pos;
-    Vector3f target_vel;
-    Vector3f target_accel;
+    Vector3f target_pos_neu_m;
+    Vector3f target_vel_neu_ms;
+    Vector3f target_accel_neu_mss;
     uint16_t type_mask = 0;
 
     switch (guided_mode) {
@@ -162,25 +162,25 @@ void GCS_MAVLINK_Copter::send_position_target_local_ned()
         type_mask = POSITION_TARGET_TYPEMASK_VX_IGNORE | POSITION_TARGET_TYPEMASK_VY_IGNORE | POSITION_TARGET_TYPEMASK_VZ_IGNORE |
                     POSITION_TARGET_TYPEMASK_AX_IGNORE | POSITION_TARGET_TYPEMASK_AY_IGNORE | POSITION_TARGET_TYPEMASK_AZ_IGNORE |
                     POSITION_TARGET_TYPEMASK_YAW_IGNORE| POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE; // ignore everything except position
-        target_pos = copter.mode_guided.get_target_pos().tofloat() * 0.01; // convert to metres
+        target_pos_neu_m = copter.mode_guided.get_target_pos().tofloat() * 0.01; // convert to metres
         break;
     case ModeGuided::SubMode::PosVelAccel:
         type_mask = POSITION_TARGET_TYPEMASK_YAW_IGNORE| POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE; // ignore everything except position, velocity & acceleration
-        target_pos = copter.mode_guided.get_target_pos().tofloat() * 0.01; // convert to metres
-        target_vel = copter.mode_guided.get_target_vel() * 0.01f; // convert to metres/s
-        target_accel = copter.mode_guided.get_target_accel() * 0.01f; // convert to metres/s/s
+        target_pos_neu_m = copter.mode_guided.get_target_pos().tofloat() * 0.01; // convert to metres
+        target_vel_neu_ms = copter.mode_guided.get_target_vel() * 0.01f; // convert to metres/s
+        target_accel_neu_mss = copter.mode_guided.get_target_accel() * 0.01f; // convert to metres/s/s
         break;
     case ModeGuided::SubMode::VelAccel:
         type_mask = POSITION_TARGET_TYPEMASK_X_IGNORE | POSITION_TARGET_TYPEMASK_Y_IGNORE | POSITION_TARGET_TYPEMASK_Z_IGNORE |
                     POSITION_TARGET_TYPEMASK_YAW_IGNORE| POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE; // ignore everything except velocity & acceleration
-        target_vel = copter.mode_guided.get_target_vel() * 0.01f; // convert to metres/s
-        target_accel = copter.mode_guided.get_target_accel() * 0.01f; // convert to metres/s/s
+        target_vel_neu_ms = copter.mode_guided.get_target_vel() * 0.01f; // convert to metres/s
+        target_accel_neu_mss = copter.mode_guided.get_target_accel() * 0.01f; // convert to metres/s/s
         break;
     case ModeGuided::SubMode::Accel:
         type_mask = POSITION_TARGET_TYPEMASK_X_IGNORE | POSITION_TARGET_TYPEMASK_Y_IGNORE | POSITION_TARGET_TYPEMASK_Z_IGNORE |
                     POSITION_TARGET_TYPEMASK_VX_IGNORE | POSITION_TARGET_TYPEMASK_VY_IGNORE | POSITION_TARGET_TYPEMASK_VZ_IGNORE |
                     POSITION_TARGET_TYPEMASK_YAW_IGNORE| POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE; // ignore everything except velocity & acceleration
-        target_accel = copter.mode_guided.get_target_accel() * 0.01f; // convert to metres/s/s
+        target_accel_neu_mss = copter.mode_guided.get_target_accel() * 0.01f; // convert to metres/s/s
         break;
     }
 
@@ -189,15 +189,15 @@ void GCS_MAVLINK_Copter::send_position_target_local_ned()
         AP_HAL::millis(), // time boot ms
         MAV_FRAME_LOCAL_NED, 
         type_mask,
-        target_pos.x,   // x in metres
-        target_pos.y,   // y in metres
-        -target_pos.z,  // z in metres NED frame
-        target_vel.x,   // vx in m/s
-        target_vel.y,   // vy in m/s
-        -target_vel.z,  // vz in m/s NED frame
-        target_accel.x, // afx in m/s/s
-        target_accel.y, // afy in m/s/s
-        -target_accel.z,// afz in m/s/s NED frame
+        target_pos_neu_m.x,   // x in metres
+        target_pos_neu_m.y,   // y in metres
+        -target_pos_neu_m.z,  // z in metres NED frame
+        target_vel_neu_ms.x,   // vx in m/s
+        target_vel_neu_ms.y,   // vy in m/s
+        -target_vel_neu_ms.z,  // vz in m/s NED frame
+        target_accel_neu_mss.x, // afx in m/s/s
+        target_accel_neu_mss.y, // afy in m/s/s
+        -target_accel_neu_mss.z,// afz in m/s/s NED frame
         0.0f, // yaw
         0.0f); // yaw_rate
 #endif
@@ -1063,14 +1063,14 @@ void GCS_MAVLINK_Copter::handle_message_set_position_target_local_ned(const mavl
     }
 
     // prepare position
-    Vector3f pos_vector;
+    Vector3f pos_neu_cm;
     if (!pos_ignore) {
         // convert to cm
-        pos_vector = Vector3f(packet.x * 100.0f, packet.y * 100.0f, -packet.z * 100.0f);
+        pos_neu_cm = Vector3f(packet.x * 100.0f, packet.y * 100.0f, -packet.z * 100.0f);
         // rotate to body-frame if necessary
         if (packet.coordinate_frame == MAV_FRAME_BODY_NED ||
             packet.coordinate_frame == MAV_FRAME_BODY_OFFSET_NED) {
-            copter.rotate_body_frame_to_NE(pos_vector.x, pos_vector.y);
+            copter.rotate_body_frame_to_NE(pos_neu_cm.x, pos_neu_cm.y);
         }
         // add body offset if necessary
         if (packet.coordinate_frame == MAV_FRAME_LOCAL_OFFSET_NED ||
@@ -1082,35 +1082,35 @@ void GCS_MAVLINK_Copter::handle_message_set_position_target_local_ned(const mavl
                 copter.mode_guided.init(true);
                 return;
             }
-            pos_vector.xy() += pos_ned_m.xy() * 100.0;
-            pos_vector.z -= pos_ned_m.z * 100.0;
+            pos_neu_cm.xy() += pos_ned_m.xy() * 100.0;
+            pos_neu_cm.z -= pos_ned_m.z * 100.0;
         }
     }
 
     // prepare velocity
-    Vector3f vel_vector;
+    Vector3f vel_neu_cms;
     if (!vel_ignore) {
-        vel_vector = Vector3f{packet.vx, packet.vy, -packet.vz};
-        if (!sane_vel_or_acc_vector(vel_vector)) {
+        vel_neu_cms = Vector3f{packet.vx, packet.vy, -packet.vz};
+        if (!sane_vel_or_acc_vector(vel_neu_cms)) {
             // input is not valid so stop
             copter.mode_guided.init(true);
             return;
         }
-        vel_vector *= 100;  // m/s -> cm/s
+        vel_neu_cms *= 100;  // m/s -> cm/s
         // rotate to body-frame if necessary
         if (packet.coordinate_frame == MAV_FRAME_BODY_NED || packet.coordinate_frame == MAV_FRAME_BODY_OFFSET_NED) {
-            copter.rotate_body_frame_to_NE(vel_vector.x, vel_vector.y);
+            copter.rotate_body_frame_to_NE(vel_neu_cms.x, vel_neu_cms.y);
         }
     }
 
     // prepare acceleration
-    Vector3f accel_vector;
+    Vector3f accel_neu_cmss;
     if (!acc_ignore) {
         // convert to cm
-        accel_vector = Vector3f(packet.afx * 100.0f, packet.afy * 100.0f, -packet.afz * 100.0f);
+        accel_neu_cmss = Vector3f(packet.afx * 100.0f, packet.afy * 100.0f, -packet.afz * 100.0f);
         // rotate to body-frame if necessary
         if (packet.coordinate_frame == MAV_FRAME_BODY_NED || packet.coordinate_frame == MAV_FRAME_BODY_OFFSET_NED) {
-            copter.rotate_body_frame_to_NE(accel_vector.x, accel_vector.y);
+            copter.rotate_body_frame_to_NE(accel_neu_cmss.x, accel_neu_cmss.y);
         }
     }
 
@@ -1128,13 +1128,13 @@ void GCS_MAVLINK_Copter::handle_message_set_position_target_local_ned(const mavl
 
     // send request
     if (!pos_ignore && !vel_ignore) {
-        copter.mode_guided.set_destination_posvelaccel(pos_vector, vel_vector, accel_vector, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads, yaw_relative);
+        copter.mode_guided.set_destination_posvelaccel(pos_neu_cm, vel_neu_cms, accel_neu_cmss, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads, yaw_relative);
     } else if (pos_ignore && !vel_ignore) {
-        copter.mode_guided.set_velaccel(vel_vector, accel_vector, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads, yaw_relative);
+        copter.mode_guided.set_velaccel(vel_neu_cms, accel_neu_cmss, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads, yaw_relative);
     } else if (pos_ignore && vel_ignore && !acc_ignore) {
-        copter.mode_guided.set_accel(accel_vector, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads, yaw_relative);
+        copter.mode_guided.set_accel(accel_neu_cmss, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads, yaw_relative);
     } else if (!pos_ignore && vel_ignore && acc_ignore) {
-        copter.mode_guided.set_destination(pos_vector, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads, yaw_relative, false);
+        copter.mode_guided.set_destination(pos_neu_cm, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads, yaw_relative, false);
     } else {
         // input is not valid so stop
         copter.mode_guided.init(true);
@@ -1188,22 +1188,22 @@ void GCS_MAVLINK_Copter::handle_message_set_position_target_global_int(const mav
     }
 
     // prepare velocity
-    Vector3f vel_vector;
+    Vector3f vel_neu_cms;
     if (!vel_ignore) {
-        vel_vector = Vector3f{packet.vx, packet.vy, -packet.vz};
-        if (!sane_vel_or_acc_vector(vel_vector)) {
+        vel_neu_cms = Vector3f{packet.vx, packet.vy, -packet.vz};
+        if (!sane_vel_or_acc_vector(vel_neu_cms)) {
             // input is not valid so stop
             copter.mode_guided.init(true);
             return;
         }
-        vel_vector *= 100;  // m/s -> cm/s
+        vel_neu_cms *= 100;  // m/s -> cm/s
     }
 
     // prepare acceleration
-    Vector3f accel_vector;
+    Vector3f accel_neu_cmss;
     if (!acc_ignore) {
         // convert to cm
-        accel_vector = Vector3f(packet.afx * 100.0f, packet.afy * 100.0f, -packet.afz * 100.0f);
+        accel_neu_cmss = Vector3f(packet.afx * 100.0f, packet.afy * 100.0f, -packet.afz * 100.0f);
     }
 
     // prepare yaw
@@ -1231,11 +1231,11 @@ void GCS_MAVLINK_Copter::handle_message_set_position_target_global_int(const mav
             copter.mode_guided.init(true);
             return;
         }
-        copter.mode_guided.set_destination_posvel(pos_neu_cm, vel_vector, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads);
+        copter.mode_guided.set_destination_posvel(pos_neu_cm, vel_neu_cms, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads);
     } else if (pos_ignore && !vel_ignore) {
-        copter.mode_guided.set_velaccel(vel_vector, accel_vector, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads);
+        copter.mode_guided.set_velaccel(vel_neu_cms, accel_neu_cmss, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads);
     } else if (pos_ignore && vel_ignore && !acc_ignore) {
-        copter.mode_guided.set_accel(accel_vector, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads);
+        copter.mode_guided.set_accel(accel_neu_cmss, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads);
     } else if (!pos_ignore && vel_ignore && acc_ignore) {
         copter.mode_guided.set_destination(loc, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads);
     } else {

--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -162,25 +162,25 @@ void GCS_MAVLINK_Copter::send_position_target_local_ned()
         type_mask = POSITION_TARGET_TYPEMASK_VX_IGNORE | POSITION_TARGET_TYPEMASK_VY_IGNORE | POSITION_TARGET_TYPEMASK_VZ_IGNORE |
                     POSITION_TARGET_TYPEMASK_AX_IGNORE | POSITION_TARGET_TYPEMASK_AY_IGNORE | POSITION_TARGET_TYPEMASK_AZ_IGNORE |
                     POSITION_TARGET_TYPEMASK_YAW_IGNORE| POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE; // ignore everything except position
-        target_pos_neu_m = copter.mode_guided.get_target_pos().tofloat() * 0.01; // convert to metres
+        target_pos_neu_m = copter.mode_guided.get_target_pos_neu_cm().tofloat() * 0.01; // convert to metres
         break;
     case ModeGuided::SubMode::PosVelAccel:
         type_mask = POSITION_TARGET_TYPEMASK_YAW_IGNORE| POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE; // ignore everything except position, velocity & acceleration
-        target_pos_neu_m = copter.mode_guided.get_target_pos().tofloat() * 0.01; // convert to metres
-        target_vel_neu_ms = copter.mode_guided.get_target_vel() * 0.01f; // convert to metres/s
-        target_accel_neu_mss = copter.mode_guided.get_target_accel() * 0.01f; // convert to metres/s/s
+        target_pos_neu_m = copter.mode_guided.get_target_pos_neu_cm().tofloat() * 0.01; // convert to metres
+        target_vel_neu_ms = copter.mode_guided.get_target_vel_neu_cms() * 0.01f; // convert to metres/s
+        target_accel_neu_mss = copter.mode_guided.get_target_accel_neu_cmss() * 0.01f; // convert to metres/s/s
         break;
     case ModeGuided::SubMode::VelAccel:
         type_mask = POSITION_TARGET_TYPEMASK_X_IGNORE | POSITION_TARGET_TYPEMASK_Y_IGNORE | POSITION_TARGET_TYPEMASK_Z_IGNORE |
                     POSITION_TARGET_TYPEMASK_YAW_IGNORE| POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE; // ignore everything except velocity & acceleration
-        target_vel_neu_ms = copter.mode_guided.get_target_vel() * 0.01f; // convert to metres/s
-        target_accel_neu_mss = copter.mode_guided.get_target_accel() * 0.01f; // convert to metres/s/s
+        target_vel_neu_ms = copter.mode_guided.get_target_vel_neu_cms() * 0.01f; // convert to metres/s
+        target_accel_neu_mss = copter.mode_guided.get_target_accel_neu_cmss() * 0.01f; // convert to metres/s/s
         break;
     case ModeGuided::SubMode::Accel:
         type_mask = POSITION_TARGET_TYPEMASK_X_IGNORE | POSITION_TARGET_TYPEMASK_Y_IGNORE | POSITION_TARGET_TYPEMASK_Z_IGNORE |
                     POSITION_TARGET_TYPEMASK_VX_IGNORE | POSITION_TARGET_TYPEMASK_VY_IGNORE | POSITION_TARGET_TYPEMASK_VZ_IGNORE |
                     POSITION_TARGET_TYPEMASK_YAW_IGNORE| POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE; // ignore everything except velocity & acceleration
-        target_accel_neu_mss = copter.mode_guided.get_target_accel() * 0.01f; // convert to metres/s/s
+        target_accel_neu_mss = copter.mode_guided.get_target_accel_neu_cmss() * 0.01f; // convert to metres/s/s
         break;
     }
 
@@ -1128,13 +1128,13 @@ void GCS_MAVLINK_Copter::handle_message_set_position_target_local_ned(const mavl
 
     // send request
     if (!pos_ignore && !vel_ignore) {
-        copter.mode_guided.set_destination_posvelaccel(pos_neu_cm, vel_neu_cms, accel_neu_cmss, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads, yaw_relative);
+        copter.mode_guided.set_pos_vel_accel_neu_cm(pos_neu_cm, vel_neu_cms, accel_neu_cmss, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads, yaw_relative);
     } else if (pos_ignore && !vel_ignore) {
-        copter.mode_guided.set_velaccel(vel_neu_cms, accel_neu_cmss, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads, yaw_relative);
+        copter.mode_guided.set_vel_accel_neu_cm(vel_neu_cms, accel_neu_cmss, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads, yaw_relative);
     } else if (pos_ignore && vel_ignore && !acc_ignore) {
-        copter.mode_guided.set_accel(accel_neu_cmss, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads, yaw_relative);
+        copter.mode_guided.set_accel_neu_cmss(accel_neu_cmss, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads, yaw_relative);
     } else if (!pos_ignore && vel_ignore && acc_ignore) {
-        copter.mode_guided.set_destination(pos_neu_cm, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads, yaw_relative, false);
+        copter.mode_guided.set_pos_neu_cm(pos_neu_cm, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads, yaw_relative, false);
     } else {
         // input is not valid so stop
         copter.mode_guided.init(true);
@@ -1231,11 +1231,11 @@ void GCS_MAVLINK_Copter::handle_message_set_position_target_global_int(const mav
             copter.mode_guided.init(true);
             return;
         }
-        copter.mode_guided.set_destination_posvel(pos_neu_cm, vel_neu_cms, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads);
+        copter.mode_guided.set_pos_vel_neu_cm(pos_neu_cm, vel_neu_cms, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads);
     } else if (pos_ignore && !vel_ignore) {
-        copter.mode_guided.set_velaccel(vel_neu_cms, accel_neu_cmss, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads);
+        copter.mode_guided.set_vel_accel_neu_cm(vel_neu_cms, accel_neu_cmss, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads);
     } else if (pos_ignore && vel_ignore && !acc_ignore) {
-        copter.mode_guided.set_accel(accel_neu_cmss, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads);
+        copter.mode_guided.set_accel_neu_cmss(accel_neu_cmss, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads);
     } else if (!pos_ignore && vel_ignore && acc_ignore) {
         copter.mode_guided.set_destination(loc, !yaw_ignore, yaw_rad, !yaw_rate_ignore, yaw_rate_rads);
     } else {

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -699,9 +699,10 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: WP_NAVALT_MIN
     // @DisplayName: Waypoint navigation altitude minimum
     // @Description: Altitude in meters above which navigation will begin during auto takeoff
+    // @Units: m
     // @Range: 0 5
     // @User: Standard
-    AP_GROUPINFO("WP_NAVALT_MIN", 1, ParametersG2, wp_navalt_min, 0),
+    AP_GROUPINFO("WP_NAVALT_MIN", 1, ParametersG2, wp_navalt_min_m, 0),
 
 #if HAL_BUTTON_ENABLED
     // @Group: BTN_

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -499,7 +499,7 @@ public:
     static const struct AP_Param::GroupInfo var_info2[];
 
     // altitude at which nav control can start in takeoff
-    AP_Float wp_navalt_min;
+    AP_Float wp_navalt_min_m;
 
     // unused_integer simply exists so that the constructor for
     // ParametersG2 can be created with a relatively easy syntax in

--- a/ArduCopter/avoidance_adsb.cpp
+++ b/ArduCopter/avoidance_adsb.cpp
@@ -193,19 +193,19 @@ bool AP_Avoidance_Copter::handle_avoidance_vertical(const AP_Avoidance::Obstacle
     }
 
     // get best vector away from obstacle
-    Vector3f velocity_neu;
+    Vector3f velocity_neu_cms;
     if (should_climb) {
-        velocity_neu.z = copter.wp_nav->get_default_speed_up_cms();
+        velocity_neu_cms.z = copter.wp_nav->get_default_speed_up_cms();
     } else {
-        velocity_neu.z = -copter.wp_nav->get_default_speed_down_cms();
+        velocity_neu_cms.z = -copter.wp_nav->get_default_speed_down_cms();
         // do not descend if below minimum altitude
         if (copter.current_loc.alt < get_altitude_minimum()) {
-            velocity_neu.z = 0.0f;
+            velocity_neu_cms.z = 0.0f;
         }
     }
 
     // send target velocity
-    copter.mode_avoid_adsb.set_velocity(velocity_neu);
+    copter.mode_avoid_adsb.set_velocity(velocity_neu_cms);
     return true;
 }
 
@@ -217,21 +217,21 @@ bool AP_Avoidance_Copter::handle_avoidance_horizontal(const AP_Avoidance::Obstac
     }
 
     // get best vector away from obstacle
-    Vector3f velocity_neu;
-    if (get_vector_perpendicular(obstacle, velocity_neu)) {
+    Vector3f velocity_neu_cms;
+    if (get_vector_perpendicular(obstacle, velocity_neu_cms)) {
         // remove vertical component
-        velocity_neu.z = 0.0f;
+        velocity_neu_cms.z = 0.0f;
         // check for divide by zero
-        if (is_zero(velocity_neu.x) && is_zero(velocity_neu.y)) {
+        if (is_zero(velocity_neu_cms.x) && is_zero(velocity_neu_cms.y)) {
             return false;
         }
         // re-normalise
-        velocity_neu.normalize();
+        velocity_neu_cms.normalize();
         // convert horizontal components to velocities
-        velocity_neu.x *= copter.wp_nav->get_default_speed_NE_cms();
-        velocity_neu.y *= copter.wp_nav->get_default_speed_NE_cms();
+        velocity_neu_cms.x *= copter.wp_nav->get_default_speed_NE_cms();
+        velocity_neu_cms.y *= copter.wp_nav->get_default_speed_NE_cms();
         // send target velocity
-        copter.mode_avoid_adsb.set_velocity(velocity_neu);
+        copter.mode_avoid_adsb.set_velocity(velocity_neu_cms);
         return true;
     }
 
@@ -247,23 +247,23 @@ bool AP_Avoidance_Copter::handle_avoidance_perpendicular(const AP_Avoidance::Obs
     }
 
     // get best vector away from obstacle
-    Vector3f velocity_neu;
-    if (get_vector_perpendicular(obstacle, velocity_neu)) {
+    Vector3f velocity_neu_cms;
+    if (get_vector_perpendicular(obstacle, velocity_neu_cms)) {
         // convert horizontal components to velocities
-        velocity_neu.x *= copter.wp_nav->get_default_speed_NE_cms();
-        velocity_neu.y *= copter.wp_nav->get_default_speed_NE_cms();
+        velocity_neu_cms.x *= copter.wp_nav->get_default_speed_NE_cms();
+        velocity_neu_cms.y *= copter.wp_nav->get_default_speed_NE_cms();
         // use up and down waypoint speeds
-        if (velocity_neu.z > 0.0f) {
-            velocity_neu.z *= copter.wp_nav->get_default_speed_up_cms();
+        if (velocity_neu_cms.z > 0.0f) {
+            velocity_neu_cms.z *= copter.wp_nav->get_default_speed_up_cms();
         } else {
-            velocity_neu.z *= copter.wp_nav->get_default_speed_down_cms();
+            velocity_neu_cms.z *= copter.wp_nav->get_default_speed_down_cms();
             // do not descend if below minimum altitude
             if (copter.current_loc.alt < get_altitude_minimum()) {
-                velocity_neu.z = 0.0f;
+                velocity_neu_cms.z = 0.0f;
             }
         }
         // send target velocity
-        copter.mode_avoid_adsb.set_velocity(velocity_neu);
+        copter.mode_avoid_adsb.set_velocity(velocity_neu_cms);
         return true;
     }
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -782,7 +782,7 @@ private:
         float xy;     // desired speed horizontally in m/s. 0 if unset
         float up;     // desired speed upwards in m/s. 0 if unset
         float down;   // desired speed downwards in m/s. 0 if unset
-    } desired_speed_override;
+    } desired_speed_override_ms;
 
     float circle_last_num_complete;
 };

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1991,9 +1991,9 @@ private:
     void auto_control();
     void manual_control();
     bool reached_destination();
-    bool calculate_next_dest(Destination ab_dest, bool use_wpnav_alt, Vector3f& next_dest, bool& terrain_alt) const;
+    bool calculate_next_dest(Destination ab_dest, bool use_wpnav_alt, Vector3f& next_dest, bool& is_terrain_alt) const;
     void spray(bool b);
-    bool calculate_side_dest(Vector3f& next_dest, bool& terrain_alt) const;
+    bool calculate_side_dest(Vector3f& next_dest, bool& is_terrain_alt) const;
     void move_to_side();
 
     Vector2f dest_A_ne_cm;    // in NEU frame in cm relative to ekf origin

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1100,19 +1100,19 @@ public:
     //             IF false: climb_rate_cms_or_thrust represents climb_rate (cm/s)
     void set_angle(const Quaternion &attitude_quat, const Vector3f &ang_vel, float climb_rate_cms_or_thrust, bool use_thrust);
 
-    bool set_destination(const Vector3f& destination, bool use_yaw = false, float yaw_rad = 0.0, bool use_yaw_rate = false, float yaw_rate_rads = 0.0, bool yaw_relative = false, bool terrain_alt = false);
+    bool set_pos_neu_cm(const Vector3f& pos_neu_cm, bool use_yaw = false, float yaw_rad = 0.0, bool use_yaw_rate = false, float yaw_rate_rads = 0.0, bool yaw_relative = false, bool is_terrain_alt = false);
     bool set_destination(const Location& dest_loc, bool use_yaw = false, float yaw_rad = 0.0, bool use_yaw_rate = false, float yaw_rate_rads = 0.0, bool yaw_relative = false);
     bool get_wp(Location &loc) const override;
-    void set_accel(const Vector3f& acceleration, bool use_yaw = false, float yaw_rad = 0.0, bool use_yaw_rate = false, float yaw_rate_rads = 0.0, bool yaw_relative = false, bool log_request = true);
-    void set_velocity(const Vector3f& velocity, bool use_yaw = false, float yaw_rad = 0.0, bool use_yaw_rate = false, float yaw_rate_rads = 0.0, bool yaw_relative = false, bool log_request = true);
-    void set_velaccel(const Vector3f& velocity, const Vector3f& acceleration, bool use_yaw = false, float yaw_rad = 0.0, bool use_yaw_rate = false, float yaw_rate_rads = 0.0, bool yaw_relative = false, bool log_request = true);
-    bool set_destination_posvel(const Vector3f& destination, const Vector3f& velocity, bool use_yaw = false, float yaw_rad = 0.0, bool use_yaw_rate = false, float yaw_rate_rads = 0.0, bool yaw_relative = false);
-    bool set_destination_posvelaccel(const Vector3f& destination, const Vector3f& velocity, const Vector3f& acceleration, bool use_yaw = false, float yaw_rad = 0.0, bool use_yaw_rate = false, float yaw_rate_rads = 0.0, bool yaw_relative = false);
+    void set_accel_neu_cmss(const Vector3f& accel_neu_cm, bool use_yaw = false, float yaw_rad = 0.0, bool use_yaw_rate = false, float yaw_rate_rads = 0.0, bool yaw_relative = false, bool log_request = true);
+    void set_vel_neu_cms(const Vector3f& vel_neu_cm, bool use_yaw = false, float yaw_rad = 0.0, bool use_yaw_rate = false, float yaw_rate_rads = 0.0, bool yaw_relative = false, bool log_request = true);
+    void set_vel_accel_neu_cm(const Vector3f& vel_neu_cm, const Vector3f& accel_neu_cm, bool use_yaw = false, float yaw_rad = 0.0, bool use_yaw_rate = false, float yaw_rate_rads = 0.0, bool yaw_relative = false, bool log_request = true);
+    bool set_pos_vel_neu_cm(const Vector3f& pos_neu_cm, const Vector3f& vel_neu_cm, bool use_yaw = false, float yaw_rad = 0.0, bool use_yaw_rate = false, float yaw_rate_rads = 0.0, bool yaw_relative = false);
+    bool set_pos_vel_accel_neu_cm(const Vector3f& pos_neu_cm, const Vector3f& vel_neu_cm, const Vector3f& accel_neu_cm, bool use_yaw = false, float yaw_rad = 0.0, bool use_yaw_rate = false, float yaw_rate_rads = 0.0, bool yaw_relative = false);
 
     // get position, velocity and acceleration targets
-    const Vector3p& get_target_pos() const;
-    const Vector3f& get_target_vel() const;
-    const Vector3f& get_target_accel() const;
+    const Vector3p& get_target_pos_neu_cm() const;
+    const Vector3f& get_target_vel_neu_cms() const;
+    const Vector3f& get_target_accel_neu_cmss() const;
 
     // returns true if GUIDED_OPTIONS param suggests SET_ATTITUDE_TARGET's "thrust" field should be interpreted as thrust instead of climb rate
     bool set_attitude_target_provides_thrust() const;

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -19,8 +19,8 @@ class GCS_Copter;
 class _AutoTakeoff {
 public:
     void run();
-    void start(float complete_alt_cm, bool terrain_alt);
-    bool get_completion_pos(Vector3p& pos_neu_cm);
+    void start(float complete_alt_cm, bool is_terrain_alt);
+    bool get_completion_pos_neu_cm(Vector3p& pos_neu_cm);
 
     bool complete;          // true when takeoff is complete
 
@@ -30,9 +30,9 @@ private:
     float no_nav_alt_cm;
 
     // auto takeoff variables
-    float complete_alt_cm;  // completion altitude expressed in cm above ekf origin or above terrain (depending upon auto_takeoff_terrain_alt)
-    bool terrain_alt;       // true if altitudes are above terrain
-    Vector3p complete_pos;  // target takeoff position as offset from ekf origin in cm
+    float complete_alt_cm;          // completion altitude expressed in cm above ekf origin or above terrain (depending upon auto_takeoff_terrain_alt)
+    bool is_terrain_alt;            // true if altitudes are above terrain
+    Vector3p complete_pos_neu_cm;   // target takeoff position as offset from ekf origin in cm
 };
 
 #if AC_PAYLOAD_PLACE_ENABLED
@@ -292,8 +292,8 @@ protected:
         bool running() const { return _running; }
     private:
         bool _running;
-        float take_off_start_alt;
-        float take_off_complete_alt;
+        float take_off_start_alt_cm;
+        float take_off_complete_alt_cm;
     };
 
     static _TakeOff takeoff;

--- a/ArduCopter/mode_althold.cpp
+++ b/ArduCopter/mode_althold.cpp
@@ -16,7 +16,7 @@ bool ModeAltHold::init(bool ignore_checks)
 
     // set vertical speed and acceleration limits
     pos_control->set_max_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
-    pos_control->set_correction_speed_accel_U_cmss(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_correction_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     return true;
 }

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -473,7 +473,7 @@ void ModeAuto::land_start()
 
     // set vertical speed and acceleration limits
     pos_control->set_max_speed_accel_U_cm(wp_nav->get_default_speed_down_cms(), wp_nav->get_default_speed_up_cms(), wp_nav->get_accel_U_cmss());
-    pos_control->set_correction_speed_accel_U_cmss(wp_nav->get_default_speed_down_cms(), wp_nav->get_default_speed_up_cms(), wp_nav->get_accel_U_cmss());
+    pos_control->set_correction_speed_accel_U_cm(wp_nav->get_default_speed_down_cms(), wp_nav->get_default_speed_up_cms(), wp_nav->get_accel_U_cmss());
 
     // initialise the vertical position controller
     if (!pos_control->is_active_U()) {
@@ -624,7 +624,7 @@ void PayloadPlace::start_descent()
 
     // set vertical speed and acceleration limits
     pos_control->set_max_speed_accel_U_cm(wp_nav->get_default_speed_down_cms(), wp_nav->get_default_speed_up_cms(), wp_nav->get_accel_U_cmss());
-    pos_control->set_correction_speed_accel_U_cmss(wp_nav->get_default_speed_down_cms(), wp_nav->get_default_speed_up_cms(), wp_nav->get_accel_U_cmss());
+    pos_control->set_correction_speed_accel_U_cm(wp_nav->get_default_speed_down_cms(), wp_nav->get_default_speed_up_cms(), wp_nav->get_accel_U_cmss());
 
     // initialise the vertical position controller
     if (!pos_control->is_active_U()) {
@@ -1766,7 +1766,7 @@ void ModeAuto::do_loiter_to_alt(const AP_Mission::Mission_Command& cmd)
 
     // set vertical speed and acceleration limits
     pos_control->set_max_speed_accel_U_cm(wp_nav->get_default_speed_down_cms(), wp_nav->get_default_speed_up_cms(), wp_nav->get_accel_U_cmss());
-    pos_control->set_correction_speed_accel_U_cmss(wp_nav->get_default_speed_down_cms(), wp_nav->get_default_speed_up_cms(), wp_nav->get_accel_U_cmss());
+    pos_control->set_correction_speed_accel_U_cm(wp_nav->get_default_speed_down_cms(), wp_nav->get_default_speed_up_cms(), wp_nav->get_accel_U_cmss());
 
     // set submode
     set_submode(SubMode::LOITER_TO_ALT);

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -427,7 +427,7 @@ bool ModeAuto::wp_start(const Location& dest_loc)
         Vector3f stopping_point_neu_cm;
         if (_mode == SubMode::TAKEOFF) {
             Vector3p takeoff_complete_pos_neu_cm;
-            if (auto_takeoff.get_completion_pos(takeoff_complete_pos_neu_cm)) {
+            if (auto_takeoff.get_completion_pos_neu_cm(takeoff_complete_pos_neu_cm)) {
                 stopping_point_neu_cm = takeoff_complete_pos_neu_cm.tofloat();
             }
         }

--- a/ArduCopter/mode_autotune.cpp
+++ b/ArduCopter/mode_autotune.cpp
@@ -83,7 +83,7 @@ void AutoTune::init_z_limits()
 {
     // set vertical speed and acceleration limits
     copter.pos_control->set_max_speed_accel_U_cm(-copter.get_pilot_speed_dn(), copter.g.pilot_speed_up, copter.g.pilot_accel_z);
-    copter.pos_control->set_correction_speed_accel_U_cmss(-copter.get_pilot_speed_dn(), copter.g.pilot_speed_up, copter.g.pilot_accel_z);
+    copter.pos_control->set_correction_speed_accel_U_cm(-copter.get_pilot_speed_dn(), copter.g.pilot_speed_up, copter.g.pilot_accel_z);
 }
 
 #if HAL_LOGGING_ENABLED

--- a/ArduCopter/mode_avoid_adsb.cpp
+++ b/ArduCopter/mode_avoid_adsb.cpp
@@ -26,7 +26,7 @@ bool ModeAvoidADSB::set_velocity(const Vector3f& velocity_neu)
     }
 
     // re-use guided mode's velocity controller
-    ModeGuided::set_velocity(velocity_neu);
+    ModeGuided::set_vel_neu_cms(velocity_neu);
     return true;
 }
 

--- a/ArduCopter/mode_brake.cpp
+++ b/ArduCopter/mode_brake.cpp
@@ -18,7 +18,7 @@ bool ModeBrake::init(bool ignore_checks)
 
     // set vertical speed and acceleration limits
     pos_control->set_max_speed_accel_U_cm(BRAKE_MODE_SPEED_Z, BRAKE_MODE_SPEED_Z, BRAKE_MODE_DECEL_RATE);
-    pos_control->set_correction_speed_accel_U_cmss(BRAKE_MODE_SPEED_Z, BRAKE_MODE_SPEED_Z, BRAKE_MODE_DECEL_RATE);
+    pos_control->set_correction_speed_accel_U_cm(BRAKE_MODE_SPEED_Z, BRAKE_MODE_SPEED_Z, BRAKE_MODE_DECEL_RATE);
 
     // initialise the vertical position controller
     if (!pos_control->is_active_U()) {

--- a/ArduCopter/mode_circle.cpp
+++ b/ArduCopter/mode_circle.cpp
@@ -16,7 +16,7 @@ bool ModeCircle::init(bool ignore_checks)
     pos_control->set_max_speed_accel_NE_cm(wp_nav->get_default_speed_NE_cms(), wp_nav->get_wp_acceleration_cmss());
     pos_control->set_correction_speed_accel_NE_cm(wp_nav->get_default_speed_NE_cms(), wp_nav->get_wp_acceleration_cmss());
     pos_control->set_max_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
-    pos_control->set_correction_speed_accel_U_cmss(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_correction_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // initialise circle controller including setting the circle center based on vehicle speed
     copter.circle_nav->init();

--- a/ArduCopter/mode_flowhold.cpp
+++ b/ArduCopter/mode_flowhold.cpp
@@ -90,7 +90,7 @@ bool ModeFlowHold::init(bool ignore_checks)
 
     // set vertical speed and acceleration limits
     pos_control->set_max_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
-    pos_control->set_correction_speed_accel_U_cmss(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_correction_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // initialise the vertical position controller
     if (!copter.pos_control->is_active_U()) {

--- a/ArduCopter/mode_follow.cpp
+++ b/ArduCopter/mode_follow.cpp
@@ -35,7 +35,7 @@ bool ModeFollow::init(const bool ignore_checks)
 
     // initialize vertical speeds and acceleration
     pos_control->set_max_speed_accel_U_cm(wp_nav->get_default_speed_down_cms(), wp_nav->get_default_speed_up_cms(), wp_nav->get_accel_U_cmss());
-    pos_control->set_correction_speed_accel_U_cmss(wp_nav->get_default_speed_down_cms(), wp_nav->get_default_speed_up_cms(), wp_nav->get_accel_U_cmss());
+    pos_control->set_correction_speed_accel_U_cm(wp_nav->get_default_speed_down_cms(), wp_nav->get_default_speed_up_cms(), wp_nav->get_accel_U_cmss());
 
     // initialise velocity controller
     pos_control->init_U_controller();

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -229,7 +229,7 @@ void ModeGuided::pva_control_start()
 
     // initialize vertical speeds and acceleration
     pos_control->set_max_speed_accel_U_cm(wp_nav->get_default_speed_down_cms(), wp_nav->get_default_speed_up_cms(), wp_nav->get_accel_U_cmss());
-    pos_control->set_correction_speed_accel_U_cmss(wp_nav->get_default_speed_down_cms(), wp_nav->get_default_speed_up_cms(), wp_nav->get_accel_U_cmss());
+    pos_control->set_correction_speed_accel_U_cm(wp_nav->get_default_speed_down_cms(), wp_nav->get_default_speed_up_cms(), wp_nav->get_accel_U_cmss());
 
     // initialise velocity controller
     pos_control->init_U_controller();
@@ -299,7 +299,7 @@ bool ModeGuided::set_speed_up_cms(float speed_up_cms)
 {
     // initialize vertical speeds and acceleration
     pos_control->set_max_speed_accel_U_cm(wp_nav->get_default_speed_down_cms(), speed_up_cms, wp_nav->get_accel_U_cmss());
-    pos_control->set_correction_speed_accel_U_cmss(wp_nav->get_default_speed_down_cms(), speed_up_cms, wp_nav->get_accel_U_cmss());
+    pos_control->set_correction_speed_accel_U_cm(wp_nav->get_default_speed_down_cms(), speed_up_cms, wp_nav->get_accel_U_cmss());
     return true;
 }
 
@@ -307,7 +307,7 @@ bool ModeGuided::set_speed_down_cms(float speed_down_cms)
 {
     // initialize vertical speeds and acceleration
     pos_control->set_max_speed_accel_U_cm(speed_down_cms, wp_nav->get_default_speed_up_cms(), wp_nav->get_accel_U_cmss());
-    pos_control->set_correction_speed_accel_U_cmss(speed_down_cms, wp_nav->get_default_speed_up_cms(), wp_nav->get_accel_U_cmss());
+    pos_control->set_correction_speed_accel_U_cm(speed_down_cms, wp_nav->get_default_speed_up_cms(), wp_nav->get_accel_U_cmss());
     return true;
 }
 
@@ -319,7 +319,7 @@ void ModeGuided::angle_control_start()
 
     // set vertical speed and acceleration limits
     pos_control->set_max_speed_accel_U_cm(wp_nav->get_default_speed_down_cms(), wp_nav->get_default_speed_up_cms(), wp_nav->get_accel_U_cmss());
-    pos_control->set_correction_speed_accel_U_cmss(wp_nav->get_default_speed_down_cms(), wp_nav->get_default_speed_up_cms(), wp_nav->get_accel_U_cmss());
+    pos_control->set_correction_speed_accel_U_cm(wp_nav->get_default_speed_down_cms(), wp_nav->get_default_speed_up_cms(), wp_nav->get_accel_U_cmss());
 
     // initialise the vertical position controller
     if (!pos_control->is_active_U()) {

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -6,11 +6,11 @@
  * Init and run calls for guided flight mode
  */
 
-static Vector3p guided_pos_target_cm;       // position target (used by posvel controller only)
-static bool guided_pos_terrain_alt;         // true if guided_pos_target_cm.z is an alt above terrain
-static Vector3f guided_vel_target_cms;      // velocity target (used by pos_vel_accel controller and vel_accel controller)
-static Vector3f guided_accel_target_cmss;   // acceleration target (used by pos_vel_accel controller vel_accel controller and accel controller)
-static uint32_t update_time_ms;             // system time of last target update to pos_vel_accel, vel_accel or accel controller
+static Vector3p guided_pos_target_neu_cm;       // position target (used by posvel controller only)
+static bool guided_is_terrain_alt;              // true if guided_pos_target_neu_cm.z is an alt above terrain
+static Vector3f guided_vel_target_neu_cms;      // velocity target (used by pos_vel_accel controller and vel_accel controller)
+static Vector3f guided_accel_target_neu_cmss;   // acceleration target (used by pos_vel_accel controller vel_accel controller and accel controller)
+static uint32_t update_time_ms;                 // system time of last target update to pos_vel_accel, vel_accel or accel controller
 
 struct {
     uint32_t update_time_ms;
@@ -43,8 +43,8 @@ bool ModeGuided::init(bool ignore_checks)
 {
     // start in velaccel control mode
     velaccel_control_start();
-    guided_vel_target_cms.zero();
-    guided_accel_target_cmss.zero();
+    guided_vel_target_neu_cms.zero();
+    guided_accel_target_neu_cmss.zero();
     send_notification = false;
 
     // clear pause state when entering guided mode
@@ -239,7 +239,7 @@ void ModeGuided::pva_control_start()
     auto_yaw.set_mode_to_default(false);
 
     // initialise terrain alt
-    guided_pos_terrain_alt = false;
+    guided_is_terrain_alt = false;
 }
 
 // initialise guided mode's position controller
@@ -385,7 +385,7 @@ bool ModeGuided::set_pos_neu_cm(const Vector3f& pos_neu_cm, bool use_yaw, float 
             return false;
         }
         // convert origin to alt-above-terrain if necessary
-        if (!guided_pos_terrain_alt) {
+        if (!guided_is_terrain_alt) {
             // new destination is alt-above-terrain, previous destination was alt-above-ekf-origin
             pos_control->init_pos_terrain_U_cm(origin_terr_offset_cm);
         }
@@ -397,15 +397,15 @@ bool ModeGuided::set_pos_neu_cm(const Vector3f& pos_neu_cm, bool use_yaw, float 
     set_yaw_state_rad(use_yaw, yaw_rad, use_yaw_rate, yaw_rate_rads, relative_yaw);
 
     // set position target and zero velocity and acceleration
-    guided_pos_target_cm = pos_neu_cm.topostype();
-    guided_pos_terrain_alt = is_terrain_alt;
-    guided_vel_target_cms.zero();
-    guided_accel_target_cmss.zero();
+    guided_pos_target_neu_cm = pos_neu_cm.topostype();
+    guided_is_terrain_alt = is_terrain_alt;
+    guided_vel_target_neu_cms.zero();
+    guided_accel_target_neu_cmss.zero();
     update_time_ms = millis();
 
 #if HAL_LOGGING_ENABLED
     // log target
-    copter.Log_Write_Guided_Position_Target(guided_mode, guided_pos_target_cm.tofloat(), guided_pos_terrain_alt, guided_vel_target_cms, guided_accel_target_cmss);
+    copter.Log_Write_Guided_Position_Target(guided_mode, guided_pos_target_neu_cm.tofloat(), guided_is_terrain_alt, guided_vel_target_neu_cms, guided_accel_target_neu_cmss);
 #endif
 
     send_notification = true;
@@ -419,7 +419,7 @@ bool ModeGuided::get_wp(Location& destination) const
     case SubMode::WP:
         return wp_nav->get_oa_wp_destination(destination);
     case SubMode::Pos:
-        destination = Location(guided_pos_target_cm.tofloat(), guided_pos_terrain_alt ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
+        destination = Location(guided_pos_target_neu_cm.tofloat(), guided_is_terrain_alt ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
         return true;
     case SubMode::Angle:
     case SubMode::TakeOff:
@@ -498,7 +498,7 @@ bool ModeGuided::set_destination(const Location& dest_loc, bool use_yaw, float y
             return false;
         }
         // convert origin to alt-above-terrain if necessary
-        if (!guided_pos_terrain_alt) {
+        if (!guided_is_terrain_alt) {
             // new destination is alt-above-terrain, previous destination was alt-above-ekf-origin
             pos_control->init_pos_terrain_U_cm(origin_terr_offset_cm);
         }
@@ -506,15 +506,15 @@ bool ModeGuided::set_destination(const Location& dest_loc, bool use_yaw, float y
         pos_control->init_pos_terrain_U_cm(0.0);
     }
 
-    guided_pos_target_cm = pos_target_neu_cm.topostype();
-    guided_pos_terrain_alt = is_terrain_alt;
-    guided_vel_target_cms.zero();
-    guided_accel_target_cmss.zero();
+    guided_pos_target_neu_cm = pos_target_neu_cm.topostype();
+    guided_is_terrain_alt = is_terrain_alt;
+    guided_vel_target_neu_cms.zero();
+    guided_accel_target_neu_cmss.zero();
     update_time_ms = millis();
 
     // log target
 #if HAL_LOGGING_ENABLED
-    copter.Log_Write_Guided_Position_Target(guided_mode, Vector3f(dest_loc.lat, dest_loc.lng, dest_loc.alt), guided_pos_terrain_alt, guided_vel_target_cms, guided_accel_target_cmss);
+    copter.Log_Write_Guided_Position_Target(guided_mode, Vector3f(dest_loc.lat, dest_loc.lng, dest_loc.alt), guided_is_terrain_alt, guided_vel_target_neu_cms, guided_accel_target_neu_cmss);
 #endif
 
     send_notification = true;
@@ -534,16 +534,16 @@ void ModeGuided::set_accel_neu_cmss(const Vector3f& accel_neu_cm, bool use_yaw, 
     set_yaw_state_rad(use_yaw, yaw_rad, use_yaw_rate, yaw_rate_rads, relative_yaw);
 
     // set velocity and acceleration targets and zero position
-    guided_pos_target_cm.zero();
-    guided_pos_terrain_alt = false;
-    guided_vel_target_cms.zero();
-    guided_accel_target_cmss = accel_neu_cm;
+    guided_pos_target_neu_cm.zero();
+    guided_is_terrain_alt = false;
+    guided_vel_target_neu_cms.zero();
+    guided_accel_target_neu_cmss = accel_neu_cm;
     update_time_ms = millis();
 
 #if HAL_LOGGING_ENABLED
     // log target
     if (log_request) {
-        copter.Log_Write_Guided_Position_Target(guided_mode, guided_pos_target_cm.tofloat(), guided_pos_terrain_alt, guided_vel_target_cms, guided_accel_target_cmss);
+        copter.Log_Write_Guided_Position_Target(guided_mode, guided_pos_target_neu_cm.tofloat(), guided_is_terrain_alt, guided_vel_target_neu_cms, guided_accel_target_neu_cmss);
     }
 #endif
 }
@@ -566,16 +566,16 @@ void ModeGuided::set_vel_accel_neu_cm(const Vector3f& vel_neu_cm, const Vector3f
     set_yaw_state_rad(use_yaw, yaw_rad, use_yaw_rate, yaw_rate_rads, relative_yaw);
 
     // set velocity and acceleration targets and zero position
-    guided_pos_target_cm.zero();
-    guided_pos_terrain_alt = false;
-    guided_vel_target_cms = vel_neu_cm;
-    guided_accel_target_cmss = accel_neu_cm;
+    guided_pos_target_neu_cm.zero();
+    guided_is_terrain_alt = false;
+    guided_vel_target_neu_cms = vel_neu_cm;
+    guided_accel_target_neu_cmss = accel_neu_cm;
     update_time_ms = millis();
 
 #if HAL_LOGGING_ENABLED
     // log target
     if (log_request) {
-        copter.Log_Write_Guided_Position_Target(guided_mode, guided_pos_target_cm.tofloat(), guided_pos_terrain_alt, guided_vel_target_cms, guided_accel_target_cmss);
+        copter.Log_Write_Guided_Position_Target(guided_mode, guided_pos_target_neu_cm.tofloat(), guided_is_terrain_alt, guided_vel_target_neu_cms, guided_accel_target_neu_cmss);
     }
 #endif
 }
@@ -608,14 +608,14 @@ bool ModeGuided::set_pos_vel_accel_neu_cm(const Vector3f& pos_neu_cm, const Vect
     set_yaw_state_rad(use_yaw, yaw_rad, use_yaw_rate, yaw_rate_rads, relative_yaw);
 
     update_time_ms = millis();
-    guided_pos_target_cm = pos_neu_cm.topostype();
-    guided_pos_terrain_alt = false;
-    guided_vel_target_cms = vel_neu_cm;
-    guided_accel_target_cmss = accel_neu_cm;
+    guided_pos_target_neu_cm = pos_neu_cm.topostype();
+    guided_is_terrain_alt = false;
+    guided_vel_target_neu_cms = vel_neu_cm;
+    guided_accel_target_neu_cmss = accel_neu_cm;
 
 #if HAL_LOGGING_ENABLED
     // log target
-    copter.Log_Write_Guided_Position_Target(guided_mode, guided_pos_target_cm.tofloat(), guided_pos_terrain_alt, guided_vel_target_cms, guided_accel_target_cmss);
+    copter.Log_Write_Guided_Position_Target(guided_mode, guided_pos_target_neu_cm.tofloat(), guided_is_terrain_alt, guided_vel_target_neu_cms, guided_accel_target_neu_cmss);
 #endif
     return true;
 }
@@ -715,7 +715,7 @@ void ModeGuided::pos_control_run()
 
     // calculate terrain adjustments
     float terr_offset_cm = 0.0f;
-    if (guided_pos_terrain_alt && !wp_nav->get_terrain_offset_cm(terr_offset_cm)) {
+    if (guided_is_terrain_alt && !wp_nav->get_terrain_offset_cm(terr_offset_cm)) {
         // failure to set destination can only be because of missing terrain data
         copter.failsafe_terrain_on_event();
         return;
@@ -725,8 +725,8 @@ void ModeGuided::pos_control_run()
     motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
 
     // send position and velocity targets to position controller
-    guided_accel_target_cmss.zero();
-    guided_vel_target_cms.zero();
+    guided_accel_target_neu_cmss.zero();
+    guided_vel_target_neu_cms.zero();
 
     // stop rotating if no updates received within timeout_ms
     if (millis() - update_time_ms > get_timeout_ms()) {
@@ -736,10 +736,10 @@ void ModeGuided::pos_control_run()
     }
 
     float pos_offset_z_buffer_cm = 0.0; // Vertical buffer size in m
-    if (guided_pos_terrain_alt) {
-        pos_offset_z_buffer_cm = MIN(copter.wp_nav->get_terrain_margin_m() * 100.0, 0.5 * fabsF(guided_pos_target_cm.z));
+    if (guided_is_terrain_alt) {
+        pos_offset_z_buffer_cm = MIN(copter.wp_nav->get_terrain_margin_m() * 100.0, 0.5 * fabsF(guided_pos_target_neu_cm.z));
     }
-    pos_control->input_pos_NEU_cm(guided_pos_target_cm, terr_offset_cm, pos_offset_z_buffer_cm);
+    pos_control->input_pos_NEU_cm(guided_pos_target_neu_cm, terr_offset_cm, pos_offset_z_buffer_cm);
 
     // run position controllers
     pos_control->update_NE_controller();
@@ -766,16 +766,16 @@ void ModeGuided::accel_control_run()
     // set velocity to zero and stop rotating if no updates received for 3 seconds
     uint32_t tnow = millis();
     if (tnow - update_time_ms > get_timeout_ms()) {
-        guided_vel_target_cms.zero();
-        guided_accel_target_cmss.zero();
+        guided_vel_target_neu_cms.zero();
+        guided_accel_target_neu_cmss.zero();
         if ((auto_yaw.mode() == AutoYaw::Mode::RATE) || (auto_yaw.mode() == AutoYaw::Mode::ANGLE_RATE)) {
             auto_yaw.set_mode(AutoYaw::Mode::HOLD);
         }
-        pos_control->input_vel_accel_NE_cm(guided_vel_target_cms.xy(), guided_accel_target_cmss.xy(), false);
-        pos_control->input_vel_accel_U_cm(guided_vel_target_cms.z, guided_accel_target_cmss.z, false);
+        pos_control->input_vel_accel_NE_cm(guided_vel_target_neu_cms.xy(), guided_accel_target_neu_cmss.xy(), false);
+        pos_control->input_vel_accel_U_cm(guided_vel_target_neu_cms.z, guided_accel_target_neu_cmss.z, false);
     } else {
         // update position controller with new target
-        pos_control->input_accel_NE_cm(guided_accel_target_cmss);
+        pos_control->input_accel_NE_cm(guided_accel_target_neu_cmss);
         if (!stabilizing_vel_xy()) {
             // set position and velocity errors to zero
             pos_control->stop_vel_NE_stabilisation();
@@ -783,7 +783,7 @@ void ModeGuided::accel_control_run()
             // set position errors to zero
             pos_control->stop_pos_NE_stabilisation();
         }
-        pos_control->input_accel_U_cm(guided_accel_target_cmss.z);
+        pos_control->input_accel_U_cm(guided_accel_target_neu_cmss.z);
     }
 
     // call velocity controller which includes z axis controller
@@ -811,8 +811,8 @@ void ModeGuided::velaccel_control_run()
     // set velocity to zero and stop rotating if no updates received for 3 seconds
     uint32_t tnow = millis();
     if (tnow - update_time_ms > get_timeout_ms()) {
-        guided_vel_target_cms.zero();
-        guided_accel_target_cmss.zero();
+        guided_vel_target_neu_cms.zero();
+        guided_accel_target_neu_cmss.zero();
         if ((auto_yaw.mode() == AutoYaw::Mode::RATE) || (auto_yaw.mode() == AutoYaw::Mode::ANGLE_RATE)) {
             auto_yaw.set_mode(AutoYaw::Mode::HOLD);
         }
@@ -821,7 +821,7 @@ void ModeGuided::velaccel_control_run()
     bool do_avoid = false;
 #if AP_AVOIDANCE_ENABLED
     // limit the velocity for obstacle/fence avoidance
-    copter.avoid.adjust_velocity(guided_vel_target_cms, pos_control->get_pos_NE_p().kP(), pos_control->get_max_accel_NE_cmss(), pos_control->get_pos_U_p().kP(), pos_control->get_max_accel_U_cmss(), G_Dt);
+    copter.avoid.adjust_velocity(guided_vel_target_neu_cms, pos_control->get_pos_NE_p().kP(), pos_control->get_max_accel_NE_cmss(), pos_control->get_pos_U_p().kP(), pos_control->get_max_accel_U_cmss(), G_Dt);
     do_avoid = copter.avoid.limits_active();
 #endif
 
@@ -829,9 +829,9 @@ void ModeGuided::velaccel_control_run()
 
     if (!stabilizing_vel_xy() && !do_avoid) {
         // set the current commanded xy vel to the desired vel
-        guided_vel_target_cms.xy() = pos_control->get_vel_desired_NEU_cms().xy();
+        guided_vel_target_neu_cms.xy() = pos_control->get_vel_desired_NEU_cms().xy();
     }
-    pos_control->input_vel_accel_NE_cm(guided_vel_target_cms.xy(), guided_accel_target_cmss.xy(), false);
+    pos_control->input_vel_accel_NE_cm(guided_vel_target_neu_cms.xy(), guided_accel_target_neu_cmss.xy(), false);
     if (!stabilizing_vel_xy() && !do_avoid) {
         // set position and velocity errors to zero
         pos_control->stop_vel_NE_stabilisation();
@@ -839,7 +839,7 @@ void ModeGuided::velaccel_control_run()
         // set position errors to zero
         pos_control->stop_pos_NE_stabilisation();
     }
-    pos_control->input_vel_accel_U_cm(guided_vel_target_cms.z, guided_accel_target_cmss.z, false);
+    pos_control->input_vel_accel_U_cm(guided_vel_target_neu_cms.z, guided_accel_target_neu_cmss.z, false);
 
     // call velocity controller which includes z axis controller
     pos_control->update_NE_controller();
@@ -896,8 +896,8 @@ void ModeGuided::posvelaccel_control_run()
     // set velocity to zero and stop rotating if no updates received for 3 seconds
     uint32_t tnow = millis();
     if (tnow - update_time_ms > get_timeout_ms()) {
-        guided_vel_target_cms.zero();
-        guided_accel_target_cmss.zero();
+        guided_vel_target_neu_cms.zero();
+        guided_accel_target_neu_cmss.zero();
         if ((auto_yaw.mode() == AutoYaw::Mode::RATE) || (auto_yaw.mode() == AutoYaw::Mode::ANGLE_RATE)) {
             auto_yaw.set_mode(AutoYaw::Mode::HOLD);
         }
@@ -906,13 +906,13 @@ void ModeGuided::posvelaccel_control_run()
     // send position and velocity targets to position controller
     if (!stabilizing_vel_xy()) {
         // set the current commanded xy pos to the target pos and xy vel to the desired vel
-        guided_pos_target_cm.xy() = pos_control->get_pos_desired_NEU_cm().xy();
-        guided_vel_target_cms.xy() = pos_control->get_vel_desired_NEU_cms().xy();
+        guided_pos_target_neu_cm.xy() = pos_control->get_pos_desired_NEU_cm().xy();
+        guided_vel_target_neu_cms.xy() = pos_control->get_vel_desired_NEU_cms().xy();
     } else if (!stabilizing_pos_xy()) {
         // set the current commanded xy pos to the target pos
-        guided_pos_target_cm.xy() = pos_control->get_pos_desired_NEU_cm().xy();
+        guided_pos_target_neu_cm.xy() = pos_control->get_pos_desired_NEU_cm().xy();
     }
-    pos_control->input_pos_vel_accel_NE_cm(guided_pos_target_cm.xy(), guided_vel_target_cms.xy(), guided_accel_target_cmss.xy(), false);
+    pos_control->input_pos_vel_accel_NE_cm(guided_pos_target_neu_cm.xy(), guided_vel_target_neu_cms.xy(), guided_accel_target_neu_cmss.xy(), false);
     if (!stabilizing_vel_xy()) {
         // set position and velocity errors to zero
         pos_control->stop_vel_NE_stabilisation();
@@ -922,13 +922,13 @@ void ModeGuided::posvelaccel_control_run()
     }
 
     // guided_pos_target z-axis should never be a terrain altitude
-    if (guided_pos_terrain_alt) {
+    if (guided_is_terrain_alt) {
         INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
     }
 
-    float pz = guided_pos_target_cm.z;
-    pos_control->input_pos_vel_accel_U_cm(pz, guided_vel_target_cms.z, guided_accel_target_cmss.z, false);
-    guided_pos_target_cm.z = pz;
+    float pz = guided_pos_target_neu_cm.z;
+    pos_control->input_pos_vel_accel_U_cm(pz, guided_vel_target_neu_cms.z, guided_accel_target_neu_cmss.z, false);
+    guided_pos_target_neu_cm.z = pz;
 
     // run position controllers
     pos_control->update_NE_controller();
@@ -1097,17 +1097,17 @@ bool ModeGuided::limit_check()
 
 const Vector3p &ModeGuided::get_target_pos_neu_cm() const
 {
-    return guided_pos_target_cm;
+    return guided_pos_target_neu_cm;
 }
 
 const Vector3f& ModeGuided::get_target_vel_neu_cms() const
 {
-    return guided_vel_target_cms;
+    return guided_vel_target_neu_cms;
 }
 
 const Vector3f& ModeGuided::get_target_accel_neu_cmss() const
 {
-    return guided_accel_target_cmss;
+    return guided_accel_target_neu_cmss;
 }
 
 float ModeGuided::wp_distance_m() const
@@ -1116,7 +1116,7 @@ float ModeGuided::wp_distance_m() const
     case SubMode::WP:
         return wp_nav->get_wp_distance_to_destination_cm() * 0.01f;
     case SubMode::Pos:
-        return get_horizontal_distance(pos_control->get_pos_estimate_NEU_cm().xy().tofloat(), guided_pos_target_cm.xy().tofloat()) * 0.01f;
+        return get_horizontal_distance(pos_control->get_pos_estimate_NEU_cm().xy().tofloat(), guided_pos_target_neu_cm.xy().tofloat()) * 0.01f;
     case SubMode::PosVelAccel:
         return pos_control->get_pos_error_NE_cm() * 0.01f;
     default:
@@ -1130,7 +1130,7 @@ float ModeGuided::wp_bearing_deg() const
     case SubMode::WP:
         return degrees(wp_nav->get_wp_bearing_to_destination_rad());
     case SubMode::Pos:
-        return degrees(get_bearing_rad(pos_control->get_pos_estimate_NEU_cm().xy().tofloat(), guided_pos_target_cm.xy().tofloat()));
+        return degrees(get_bearing_rad(pos_control->get_pos_estimate_NEU_cm().xy().tofloat(), guided_pos_target_neu_cm.xy().tofloat()));
     case SubMode::PosVelAccel:
         return degrees(pos_control->get_bearing_to_target_rad());
     case SubMode::TakeOff:

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -16,18 +16,18 @@ struct {
     uint32_t update_time_ms;
     Quaternion attitude_quat;
     Vector3f ang_vel_body;
-    float climb_rate_cms;   // climb rate in cms.  Used if use_thrust is false
-    float thrust;           // thrust from -1 to 1.  Used if use_thrust is true
+    float climb_rate_cms;       // climb rate in cms.  Used if use_thrust is false
+    float thrust_norm;          // thrust from -1 to 1.  Used if use_thrust is true
     bool use_thrust;
 } static guided_angle_state;
 
 struct Guided_Limit {
-    uint32_t timeout_ms;  // timeout (in seconds) from the time that guided is invoked
-    float alt_min_cm;   // lower altitude limit in cm above home (0 = no limit)
-    float alt_max_cm;   // upper altitude limit in cm above home (0 = no limit)
-    float horiz_max_cm; // horizontal position limit in cm from where guided mode was initiated (0 = no limit)
-    uint32_t start_time;// system time in milliseconds that control was handed to the external computer
-    Vector3f start_pos; // start position as a distance from home in cm.  used for checking horiz_max limit
+    uint32_t timeout_ms;        // timeout (in seconds) from the time that guided is invoked
+    float alt_min_cm;           // lower altitude limit in cm above home (0 = no limit)
+    float alt_max_cm;           // upper altitude limit in cm above home (0 = no limit)
+    float horiz_max_cm;         // horizontal position limit in cm from where guided mode was initiated (0 = no limit)
+    uint32_t start_time_ms;     // system time in milliseconds that control was handed to the external computer
+    Vector3f start_pos_neu_cm;  // start position as a distance from home in cm.  used for checking horiz_max limit
 } static guided_limit;
 
 // controls which controller is run (pos or vel):
@@ -333,14 +333,14 @@ void ModeGuided::angle_control_start()
     guided_angle_state.climb_rate_cms = 0.0f;
 }
 
-// set_destination - sets guided mode's target destination
+// set_pos_neu_cm - sets guided mode's target pos_neu_cm
 // Returns true if the fence is enabled and guided waypoint is within the fence
 // else return false if the waypoint is outside the fence
-bool ModeGuided::set_destination(const Vector3f& destination, bool use_yaw, float yaw_rad, bool use_yaw_rate, float yaw_rate_rads, bool relative_yaw, bool terrain_alt)
+bool ModeGuided::set_pos_neu_cm(const Vector3f& pos_neu_cm, bool use_yaw, float yaw_rad, bool use_yaw_rate, float yaw_rate_rads, bool relative_yaw, bool is_terrain_alt)
 {
 #if AP_FENCE_ENABLED
     // reject destination if outside the fence
-    const Location dest_loc(destination, terrain_alt ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
+    const Location dest_loc(pos_neu_cm, is_terrain_alt ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
     if (!copter.fence.check_destination_within_fence(dest_loc)) {
         LOGGER_WRITE_ERROR(LogErrorSubsystem::NAVIGATION, LogErrorCode::DEST_OUTSIDE_FENCE);
         // failure is propagated to GCS with NAK
@@ -359,11 +359,11 @@ bool ModeGuided::set_destination(const Vector3f& destination, bool use_yaw, floa
         set_yaw_state_rad(use_yaw, yaw_rad, use_yaw_rate, yaw_rate_rads, relative_yaw);
 
         // no need to check return status because terrain data is not used
-        wp_nav->set_wp_destination_NEU_cm(destination, terrain_alt);
+        wp_nav->set_wp_destination_NEU_cm(pos_neu_cm, is_terrain_alt);
 
 #if HAL_LOGGING_ENABLED
         // log target
-        copter.Log_Write_Guided_Position_Target(guided_mode, destination, terrain_alt, Vector3f(), Vector3f());
+        copter.Log_Write_Guided_Position_Target(guided_mode, pos_neu_cm, is_terrain_alt, Vector3f(), Vector3f());
 #endif
         send_notification = true;
         return true;
@@ -376,10 +376,10 @@ bool ModeGuided::set_destination(const Vector3f& destination, bool use_yaw, floa
     }
 
     // initialise terrain following if needed
-    if (terrain_alt) {
+    if (is_terrain_alt) {
         // get current alt above terrain
-        float origin_terr_offset;
-        if (!wp_nav->get_terrain_offset_cm(origin_terr_offset)) {
+        float origin_terr_offset_cm;
+        if (!wp_nav->get_terrain_offset_cm(origin_terr_offset_cm)) {
             // if we don't have terrain altitude then stop
             init(true);
             return false;
@@ -387,7 +387,7 @@ bool ModeGuided::set_destination(const Vector3f& destination, bool use_yaw, floa
         // convert origin to alt-above-terrain if necessary
         if (!guided_pos_terrain_alt) {
             // new destination is alt-above-terrain, previous destination was alt-above-ekf-origin
-            pos_control->init_pos_terrain_U_cm(origin_terr_offset);
+            pos_control->init_pos_terrain_U_cm(origin_terr_offset_cm);
         }
     } else {
         pos_control->init_pos_terrain_U_cm(0.0);
@@ -397,8 +397,8 @@ bool ModeGuided::set_destination(const Vector3f& destination, bool use_yaw, floa
     set_yaw_state_rad(use_yaw, yaw_rad, use_yaw_rate, yaw_rate_rads, relative_yaw);
 
     // set position target and zero velocity and acceleration
-    guided_pos_target_cm = destination.topostype();
-    guided_pos_terrain_alt = terrain_alt;
+    guided_pos_target_cm = pos_neu_cm.topostype();
+    guided_pos_terrain_alt = is_terrain_alt;
     guided_vel_target_cms.zero();
     guided_accel_target_cmss.zero();
     update_time_ms = millis();
@@ -473,9 +473,9 @@ bool ModeGuided::set_destination(const Location& dest_loc, bool use_yaw, float y
     }
 
     // set position target and zero velocity and acceleration
-    Vector3f pos_target_f;
-    bool terrain_alt;
-    if (!wp_nav->get_vector_NEU_cm(dest_loc, pos_target_f, terrain_alt)) {
+    Vector3f pos_target_neu_cm;
+    bool is_terrain_alt;
+    if (!wp_nav->get_vector_NEU_cm(dest_loc, pos_target_neu_cm, is_terrain_alt)) {
         return false;
     }
 
@@ -489,10 +489,10 @@ bool ModeGuided::set_destination(const Location& dest_loc, bool use_yaw, float y
     set_yaw_state_rad(use_yaw, yaw_rad, use_yaw_rate, yaw_rate_rads, relative_yaw);
 
     // initialise terrain following if needed
-    if (terrain_alt) {
+    if (is_terrain_alt) {
         // get current alt above terrain
-        float origin_terr_offset;
-        if (!wp_nav->get_terrain_offset_cm(origin_terr_offset)) {
+        float origin_terr_offset_cm;
+        if (!wp_nav->get_terrain_offset_cm(origin_terr_offset_cm)) {
             // if we don't have terrain altitude then stop
             init(true);
             return false;
@@ -500,14 +500,14 @@ bool ModeGuided::set_destination(const Location& dest_loc, bool use_yaw, float y
         // convert origin to alt-above-terrain if necessary
         if (!guided_pos_terrain_alt) {
             // new destination is alt-above-terrain, previous destination was alt-above-ekf-origin
-            pos_control->init_pos_terrain_U_cm(origin_terr_offset);
+            pos_control->init_pos_terrain_U_cm(origin_terr_offset_cm);
         }
     } else {
         pos_control->init_pos_terrain_U_cm(0.0);
     }
 
-    guided_pos_target_cm = pos_target_f.topostype();
-    guided_pos_terrain_alt = terrain_alt;
+    guided_pos_target_cm = pos_target_neu_cm.topostype();
+    guided_pos_terrain_alt = is_terrain_alt;
     guided_vel_target_cms.zero();
     guided_accel_target_cmss.zero();
     update_time_ms = millis();
@@ -522,8 +522,8 @@ bool ModeGuided::set_destination(const Location& dest_loc, bool use_yaw, float y
     return true;
 }
 
-// set_velaccel - sets guided mode's target velocity and acceleration
-void ModeGuided::set_accel(const Vector3f& acceleration, bool use_yaw, float yaw_rad, bool use_yaw_rate, float yaw_rate_rads, bool relative_yaw, bool log_request)
+// set_vel_accel_neu_cm - sets guided mode's target velocity and acceleration
+void ModeGuided::set_accel_neu_cmss(const Vector3f& accel_neu_cm, bool use_yaw, float yaw_rad, bool use_yaw_rate, float yaw_rate_rads, bool relative_yaw, bool log_request)
 {
     // check we are in acceleration control mode
     if (guided_mode != SubMode::Accel) {
@@ -537,7 +537,7 @@ void ModeGuided::set_accel(const Vector3f& acceleration, bool use_yaw, float yaw
     guided_pos_target_cm.zero();
     guided_pos_terrain_alt = false;
     guided_vel_target_cms.zero();
-    guided_accel_target_cmss = acceleration;
+    guided_accel_target_cmss = accel_neu_cm;
     update_time_ms = millis();
 
 #if HAL_LOGGING_ENABLED
@@ -548,14 +548,14 @@ void ModeGuided::set_accel(const Vector3f& acceleration, bool use_yaw, float yaw
 #endif
 }
 
-// set_velocity - sets guided mode's target velocity
-void ModeGuided::set_velocity(const Vector3f& velocity, bool use_yaw, float yaw_rad, bool use_yaw_rate, float yaw_rate_rads, bool relative_yaw, bool log_request)
+// set_vel_neu_cms - sets guided mode's target velocity
+void ModeGuided::set_vel_neu_cms(const Vector3f& vel_neu_cm, bool use_yaw, float yaw_rad, bool use_yaw_rate, float yaw_rate_rads, bool relative_yaw, bool log_request)
 {
-    set_velaccel(velocity, Vector3f(), use_yaw, yaw_rad, use_yaw_rate, yaw_rate_rads, relative_yaw, log_request);
+    set_vel_accel_neu_cm(vel_neu_cm, Vector3f(), use_yaw, yaw_rad, use_yaw_rate, yaw_rate_rads, relative_yaw, log_request);
 }
 
-// set_velaccel - sets guided mode's target velocity and acceleration
-void ModeGuided::set_velaccel(const Vector3f& velocity, const Vector3f& acceleration, bool use_yaw, float yaw_rad, bool use_yaw_rate, float yaw_rate_rads, bool relative_yaw, bool log_request)
+// set_vel_accel_neu_cm - sets guided mode's target velocity and acceleration
+void ModeGuided::set_vel_accel_neu_cm(const Vector3f& vel_neu_cm, const Vector3f& accel_neu_cm, bool use_yaw, float yaw_rad, bool use_yaw_rate, float yaw_rate_rads, bool relative_yaw, bool log_request)
 {
     // check we are in velocity and acceleration control mode
     if (guided_mode != SubMode::VelAccel) {
@@ -568,8 +568,8 @@ void ModeGuided::set_velaccel(const Vector3f& velocity, const Vector3f& accelera
     // set velocity and acceleration targets and zero position
     guided_pos_target_cm.zero();
     guided_pos_terrain_alt = false;
-    guided_vel_target_cms = velocity;
-    guided_accel_target_cmss = acceleration;
+    guided_vel_target_cms = vel_neu_cm;
+    guided_accel_target_cmss = accel_neu_cm;
     update_time_ms = millis();
 
 #if HAL_LOGGING_ENABLED
@@ -580,18 +580,18 @@ void ModeGuided::set_velaccel(const Vector3f& velocity, const Vector3f& accelera
 #endif
 }
 
-// set_destination_posvel - set guided mode position and velocity target
-bool ModeGuided::set_destination_posvel(const Vector3f& destination, const Vector3f& velocity, bool use_yaw, float yaw_rad, bool use_yaw_rate, float yaw_rate_rads, bool relative_yaw)
+// set_pos_vel_neu_cm - set guided mode position and velocity target
+bool ModeGuided::set_pos_vel_neu_cm(const Vector3f& pos_neu_cm, const Vector3f& vel_neu_cm, bool use_yaw, float yaw_rad, bool use_yaw_rate, float yaw_rate_rads, bool relative_yaw)
 {
-    return set_destination_posvelaccel(destination, velocity, Vector3f(), use_yaw, yaw_rad, use_yaw_rate, yaw_rate_rads, relative_yaw);
+    return set_pos_vel_accel_neu_cm(pos_neu_cm, vel_neu_cm, Vector3f(), use_yaw, yaw_rad, use_yaw_rate, yaw_rate_rads, relative_yaw);
 }
 
-// set_destination_posvelaccel - set guided mode position, velocity and acceleration target
-bool ModeGuided::set_destination_posvelaccel(const Vector3f& destination, const Vector3f& velocity, const Vector3f& acceleration, bool use_yaw, float yaw_rad, bool use_yaw_rate, float yaw_rate_rads, bool relative_yaw)
+// set_pos_vel_accel_neu_cm - set guided mode position, velocity and acceleration target
+bool ModeGuided::set_pos_vel_accel_neu_cm(const Vector3f& pos_neu_cm, const Vector3f& vel_neu_cm, const Vector3f& accel_neu_cm, bool use_yaw, float yaw_rad, bool use_yaw_rate, float yaw_rate_rads, bool relative_yaw)
 {
 #if AP_FENCE_ENABLED
     // reject destination if outside the fence
-    const Location dest_loc(destination, Location::AltFrame::ABOVE_ORIGIN);
+    const Location dest_loc(pos_neu_cm, Location::AltFrame::ABOVE_ORIGIN);
     if (!copter.fence.check_destination_within_fence(dest_loc)) {
         LOGGER_WRITE_ERROR(LogErrorSubsystem::NAVIGATION, LogErrorCode::DEST_OUTSIDE_FENCE);
         // failure is propagated to GCS with NAK
@@ -608,10 +608,10 @@ bool ModeGuided::set_destination_posvelaccel(const Vector3f& destination, const 
     set_yaw_state_rad(use_yaw, yaw_rad, use_yaw_rate, yaw_rate_rads, relative_yaw);
 
     update_time_ms = millis();
-    guided_pos_target_cm = destination.topostype();
+    guided_pos_target_cm = pos_neu_cm.topostype();
     guided_pos_terrain_alt = false;
-    guided_vel_target_cms = velocity;
-    guided_accel_target_cmss = acceleration;
+    guided_vel_target_cms = vel_neu_cm;
+    guided_accel_target_cmss = accel_neu_cm;
 
 #if HAL_LOGGING_ENABLED
     // log target
@@ -666,10 +666,10 @@ void ModeGuided::set_angle(const Quaternion &attitude_quat, const Vector3f &ang_
 
     guided_angle_state.use_thrust = use_thrust;
     if (use_thrust) {
-        guided_angle_state.thrust = climb_rate_cms_or_thrust;
+        guided_angle_state.thrust_norm = climb_rate_cms_or_thrust;
         guided_angle_state.climb_rate_cms = 0.0f;
     } else {
-        guided_angle_state.thrust = 0.0f;
+        guided_angle_state.thrust_norm = 0.0f;
         guided_angle_state.climb_rate_cms = climb_rate_cms_or_thrust;
     }
 
@@ -681,7 +681,7 @@ void ModeGuided::set_angle(const Quaternion &attitude_quat, const Vector3f &ang_
 
 #if HAL_LOGGING_ENABLED
     // log target
-    copter.Log_Write_Guided_Attitude_Target(guided_mode, roll_rad, pitch_rad, yaw_rad, ang_vel_body, guided_angle_state.thrust, guided_angle_state.climb_rate_cms * 0.01);
+    copter.Log_Write_Guided_Attitude_Target(guided_mode, roll_rad, pitch_rad, yaw_rad, ang_vel_body, guided_angle_state.thrust_norm, guided_angle_state.climb_rate_cms * 0.01);
 #endif
 }
 
@@ -714,8 +714,8 @@ void ModeGuided::pos_control_run()
     }
 
     // calculate terrain adjustments
-    float terr_offset = 0.0f;
-    if (guided_pos_terrain_alt && !wp_nav->get_terrain_offset_cm(terr_offset)) {
+    float terr_offset_cm = 0.0f;
+    if (guided_pos_terrain_alt && !wp_nav->get_terrain_offset_cm(terr_offset_cm)) {
         // failure to set destination can only be because of missing terrain data
         copter.failsafe_terrain_on_event();
         return;
@@ -735,11 +735,11 @@ void ModeGuided::pos_control_run()
         }
     }
 
-    float pos_offset_z_buffer = 0.0; // Vertical buffer size in m
+    float pos_offset_z_buffer_cm = 0.0; // Vertical buffer size in m
     if (guided_pos_terrain_alt) {
-        pos_offset_z_buffer = MIN(copter.wp_nav->get_terrain_margin_m() * 100.0, 0.5 * fabsF(guided_pos_target_cm.z));
+        pos_offset_z_buffer_cm = MIN(copter.wp_nav->get_terrain_margin_m() * 100.0, 0.5 * fabsF(guided_pos_target_cm.z));
     }
-    pos_control->input_pos_NEU_cm(guided_pos_target_cm, terr_offset, pos_offset_z_buffer);
+    pos_control->input_pos_NEU_cm(guided_pos_target_cm, terr_offset_cm, pos_offset_z_buffer_cm);
 
     // run position controllers
     pos_control->update_NE_controller();
@@ -965,7 +965,7 @@ void ModeGuided::angle_control_run()
     }
 
     // interpret positive climb rate or thrust as triggering take-off
-    const bool positive_thrust_or_climbrate = is_positive(guided_angle_state.use_thrust ? guided_angle_state.thrust : climb_rate_cms);
+    const bool positive_thrust_or_climbrate = is_positive(guided_angle_state.use_thrust ? guided_angle_state.thrust_norm : climb_rate_cms);
     if (motors->armed() && positive_thrust_or_climbrate) {
         copter.set_auto_armed(true);
     }
@@ -1001,7 +1001,7 @@ void ModeGuided::angle_control_run()
 
     // call position controller
     if (guided_angle_state.use_thrust) {
-        attitude_control->set_throttle_out(guided_angle_state.thrust, true, copter.g.throttle_filt);
+        attitude_control->set_throttle_out(guided_angle_state.thrust_norm, true, copter.g.throttle_filt);
     } else {
         pos_control->set_pos_target_U_from_climb_rate_cm(climb_rate_cms);
         pos_control->update_U_controller();
@@ -1055,10 +1055,10 @@ void ModeGuided::limit_set(uint32_t timeout_ms, float alt_min_cm, float alt_max_
 void ModeGuided::limit_init_time_and_pos()
 {
     // initialise start time
-    guided_limit.start_time = AP_HAL::millis();
+    guided_limit.start_time_ms = AP_HAL::millis();
 
     // initialise start position from current position
-    guided_limit.start_pos = pos_control->get_pos_estimate_NEU_cm().tofloat();
+    guided_limit.start_pos_neu_cm = pos_control->get_pos_estimate_NEU_cm().tofloat();
 }
 
 // limit_check - returns true if guided mode has breached a limit
@@ -1066,26 +1066,26 @@ void ModeGuided::limit_init_time_and_pos()
 bool ModeGuided::limit_check()
 {
     // check if we have passed the timeout
-    if ((guided_limit.timeout_ms > 0) && (millis() - guided_limit.start_time >= guided_limit.timeout_ms)) {
+    if ((guided_limit.timeout_ms > 0) && (millis() - guided_limit.start_time_ms >= guided_limit.timeout_ms)) {
         return true;
     }
 
     // get current location
-    const Vector3f& curr_pos = pos_control->get_pos_estimate_NEU_cm().tofloat();
+    const Vector3f& curr_pos_neu_cm = pos_control->get_pos_estimate_NEU_cm().tofloat();
 
     // check if we have gone below min alt
-    if (!is_zero(guided_limit.alt_min_cm) && (curr_pos.z < guided_limit.alt_min_cm)) {
+    if (!is_zero(guided_limit.alt_min_cm) && (curr_pos_neu_cm.z < guided_limit.alt_min_cm)) {
         return true;
     }
 
     // check if we have gone above max alt
-    if (!is_zero(guided_limit.alt_max_cm) && (curr_pos.z > guided_limit.alt_max_cm)) {
+    if (!is_zero(guided_limit.alt_max_cm) && (curr_pos_neu_cm.z > guided_limit.alt_max_cm)) {
         return true;
     }
 
     // check if we have gone beyond horizontal limit
     if (guided_limit.horiz_max_cm > 0.0f) {
-        const float horiz_move = get_horizontal_distance(guided_limit.start_pos.xy(), curr_pos.xy());
+        const float horiz_move = get_horizontal_distance(guided_limit.start_pos_neu_cm.xy(), curr_pos_neu_cm.xy());
         if (horiz_move > guided_limit.horiz_max_cm) {
             return true;
         }
@@ -1095,17 +1095,17 @@ bool ModeGuided::limit_check()
     return false;
 }
 
-const Vector3p &ModeGuided::get_target_pos() const
+const Vector3p &ModeGuided::get_target_pos_neu_cm() const
 {
     return guided_pos_target_cm;
 }
 
-const Vector3f& ModeGuided::get_target_vel() const
+const Vector3f& ModeGuided::get_target_vel_neu_cms() const
 {
     return guided_vel_target_cms;
 }
 
-const Vector3f& ModeGuided::get_target_accel() const
+const Vector3f& ModeGuided::get_target_accel_neu_cmss() const
 {
     return guided_accel_target_cmss;
 }

--- a/ArduCopter/mode_land.cpp
+++ b/ArduCopter/mode_land.cpp
@@ -17,7 +17,7 @@ bool ModeLand::init(bool ignore_checks)
 
     // set vertical speed and acceleration limits
     pos_control->set_max_speed_accel_U_cm(wp_nav->get_default_speed_down_cms(), wp_nav->get_default_speed_up_cms(), wp_nav->get_accel_U_cmss());
-    pos_control->set_correction_speed_accel_U_cmss(wp_nav->get_default_speed_down_cms(), wp_nav->get_default_speed_up_cms(), wp_nav->get_accel_U_cmss());
+    pos_control->set_correction_speed_accel_U_cm(wp_nav->get_default_speed_down_cms(), wp_nav->get_default_speed_up_cms(), wp_nav->get_accel_U_cmss());
 
     // initialise the vertical position controller
     if (!pos_control->is_active_U()) {

--- a/ArduCopter/mode_loiter.cpp
+++ b/ArduCopter/mode_loiter.cpp
@@ -28,7 +28,7 @@ bool ModeLoiter::init(bool ignore_checks)
 
     // set vertical speed and acceleration limits
     pos_control->set_max_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
-    pos_control->set_correction_speed_accel_U_cmss(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_correction_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
 #if AC_PRECLAND_ENABLED
     _precision_loiter_active = false;

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -26,7 +26,7 @@ bool ModePosHold::init(bool ignore_checks)
 {
     // set vertical speed and acceleration limits
     pos_control->set_max_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
-    pos_control->set_correction_speed_accel_U_cmss(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_correction_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // initialise the vertical position controller
     if (!pos_control->is_active_U()) {

--- a/ArduCopter/mode_sport.cpp
+++ b/ArduCopter/mode_sport.cpp
@@ -11,7 +11,7 @@ bool ModeSport::init(bool ignore_checks)
 {
     // set vertical speed and acceleration limits
     pos_control->set_max_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
-    pos_control->set_correction_speed_accel_U_cmss(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_correction_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // initialise the vertical position controller
     if (!pos_control->is_active_U()) {

--- a/ArduCopter/mode_systemid.cpp
+++ b/ArduCopter/mode_systemid.cpp
@@ -122,7 +122,7 @@ bool ModeSystemId::init(bool ignore_checks)
 
         // set vertical speed and acceleration limits
         pos_control->set_max_speed_accel_U_cm(wp_nav->get_default_speed_down_cms(), wp_nav->get_default_speed_up_cms(), wp_nav->get_accel_U_cmss());
-        pos_control->set_correction_speed_accel_U_cmss(wp_nav->get_default_speed_down_cms(), wp_nav->get_default_speed_up_cms(), wp_nav->get_accel_U_cmss());
+        pos_control->set_correction_speed_accel_U_cm(wp_nav->get_default_speed_down_cms(), wp_nav->get_default_speed_up_cms(), wp_nav->get_accel_U_cmss());
 
         // initialise the vertical position controller
         if (!pos_control->is_active_U()) {

--- a/ArduCopter/mode_throw.cpp
+++ b/ArduCopter/mode_throw.cpp
@@ -25,7 +25,7 @@ bool ModeThrow::init(bool ignore_checks)
 
     // set vertical speed and acceleration limits
     pos_control->set_max_speed_accel_U_cm(BRAKE_MODE_SPEED_Z, BRAKE_MODE_SPEED_Z, BRAKE_MODE_DECEL_RATE);
-    pos_control->set_correction_speed_accel_U_cmss(BRAKE_MODE_SPEED_Z, BRAKE_MODE_SPEED_Z, BRAKE_MODE_DECEL_RATE);
+    pos_control->set_correction_speed_accel_U_cm(BRAKE_MODE_SPEED_Z, BRAKE_MODE_SPEED_Z, BRAKE_MODE_DECEL_RATE);
 
     return true;
 }

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -404,8 +404,8 @@ bool ModeZigZag::reached_destination()
 
 // calculate next destination according to vector A-B and current position
 // use_wpnav_alt should be true if waypoint controller's altitude target should be used, false for position control or current altitude target
-// terrain_alt is returned as true if the next_dest should be considered a terrain alt
-bool ModeZigZag::calculate_next_dest(Destination ab_dest, bool use_wpnav_alt, Vector3f& next_dest_neu_cm, bool& terrain_alt) const
+// is_terrain_alt is returned as true if the next_dest should be considered a terrain alt
+bool ModeZigZag::calculate_next_dest(Destination ab_dest, bool use_wpnav_alt, Vector3f& next_dest_neu_cm, bool& is_terrain_alt) const
 {
     // define start_pos_ne_cm as either destination A or B
     Vector2f start_pos_ne_cm = (ab_dest == Destination::A) ? dest_A_ne_cm : dest_B_ne_cm;
@@ -440,12 +440,12 @@ bool ModeZigZag::calculate_next_dest(Destination ab_dest, bool use_wpnav_alt, Ve
 
     if (use_wpnav_alt) {
         // get altitude target from waypoint controller
-        terrain_alt = wp_nav->origin_and_destination_are_terrain_alt();
+        is_terrain_alt = wp_nav->origin_and_destination_are_terrain_alt();
         next_dest_neu_cm.z = wp_nav->get_wp_destination_NEU_cm().z;
     } else {
-        terrain_alt = copter.rangefinder_alt_ok() && wp_nav->rangefinder_used_and_healthy();
+        is_terrain_alt = copter.rangefinder_alt_ok() && wp_nav->rangefinder_used_and_healthy();
         next_dest_neu_cm.z = pos_control->get_pos_desired_U_cm();
-        if (!terrain_alt) {
+        if (!is_terrain_alt) {
             next_dest_neu_cm.z += pos_control->get_pos_terrain_U_cm();
         }
     }
@@ -454,8 +454,8 @@ bool ModeZigZag::calculate_next_dest(Destination ab_dest, bool use_wpnav_alt, Ve
 }
 
 // calculate side destination according to vertical vector A-B and current position
-// terrain_alt is returned as true if the next_dest should be considered a terrain alt
-bool ModeZigZag::calculate_side_dest(Vector3f& next_dest_neu_cm, bool& terrain_alt) const
+// is_terrain_alt is returned as true if the next_dest should be considered a terrain alt
+bool ModeZigZag::calculate_side_dest(Vector3f& next_dest_neu_cm, bool& is_terrain_alt) const
 {
     // calculate vector from A to B
     Vector2f AB_diff_ne_cm = dest_B_ne_cm - dest_A_ne_cm;
@@ -491,7 +491,7 @@ bool ModeZigZag::calculate_side_dest(Vector3f& next_dest_neu_cm, bool& terrain_a
     next_dest_neu_cm.xy() = curr_pos_ne_cm + (AB_side_ne_cm * scalar);
 
     // if we have a downward facing range finder then use terrain altitude targets
-    terrain_alt = copter.rangefinder_alt_ok() && wp_nav->rangefinder_used_and_healthy();
+    is_terrain_alt = copter.rangefinder_alt_ok() && wp_nav->rangefinder_used_and_healthy();
     next_dest_neu_cm.z = pos_control->get_pos_desired_U_cm();
 
     return true;

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -81,7 +81,7 @@ bool ModeZigZag::init(bool ignore_checks)
 
     // set vertical speed and acceleration limits
     pos_control->set_max_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
-    pos_control->set_correction_speed_accel_U_cmss(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    pos_control->set_correction_speed_accel_U_cm(-get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // initialise the vertical position controller
     if (!pos_control->is_active_U()) {

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -52,8 +52,8 @@ void Mode::_TakeOff::start(float alt_cm)
 {
     // initialise takeoff state
     _running = true;
-    take_off_start_alt = copter.pos_control->get_pos_desired_U_cm();
-    take_off_complete_alt  = take_off_start_alt + alt_cm;
+    take_off_start_alt_cm = copter.pos_control->get_pos_desired_U_cm();
+    take_off_complete_alt_cm  = take_off_start_alt_cm + alt_cm;
 }
 
 // stop takeoff
@@ -80,14 +80,14 @@ void Mode::_TakeOff::do_pilot_takeoff(float& pilot_climb_rate_cm)
 
     if (copter.ap.land_complete) {
         // send throttle to attitude controller with angle boost
-        float throttle = constrain_float(copter.attitude_control->get_throttle_in() + copter.G_Dt / copter.g2.takeoff_throttle_slew_time, 0.0, 1.0);
-        copter.attitude_control->set_throttle_out(throttle, true, 0.0);
+        float throttle_norm = constrain_float(copter.attitude_control->get_throttle_in() + copter.G_Dt / copter.g2.takeoff_throttle_slew_time, 0.0, 1.0);
+        copter.attitude_control->set_throttle_out(throttle_norm, true, 0.0);
         // tell position controller to reset alt target and reset I terms
         copter.pos_control->init_U_controller();
-        if (throttle >= MIN(copter.g2.takeoff_throttle_max, 0.9) || 
+        if (throttle_norm >= MIN(copter.g2.takeoff_throttle_max, 0.9) || 
             (copter.pos_control->get_measured_accel_U_cmss() >= 0.5 * copter.pos_control->get_max_accel_U_cmss()) ||
             (copter.pos_control->get_vel_desired_NEU_cms().z >= constrain_float(pilot_climb_rate_cm, copter.pos_control->get_max_speed_up_cms() * 0.1, copter.pos_control->get_max_speed_up_cms() * 0.5)) || 
-            (is_positive(take_off_complete_alt - take_off_start_alt) && copter.pos_control->get_pos_desired_U_cm() - take_off_start_alt > 0.5 * (take_off_complete_alt - take_off_start_alt))) {
+            (is_positive(take_off_complete_alt_cm - take_off_start_alt_cm) && copter.pos_control->get_pos_desired_U_cm() - take_off_start_alt_cm > 0.5 * (take_off_complete_alt_cm - take_off_start_alt_cm))) {
             // throttle > 90%
             // acceleration > 50% maximum acceleration
             // velocity > 10% maximum velocity && commanded climb rate
@@ -96,15 +96,15 @@ void Mode::_TakeOff::do_pilot_takeoff(float& pilot_climb_rate_cm)
             copter.set_land_complete(false);
         }
     } else {
-        float pos_z = take_off_complete_alt;
-        float vel_z = pilot_climb_rate_cm;
+        float pos_u_cm = take_off_complete_alt_cm;
+        float vel_u_cms = pilot_climb_rate_cm;
 
         // command the aircraft to the take off altitude and current pilot climb rate
-        copter.pos_control->input_pos_vel_accel_U_cm(pos_z, vel_z, 0);
+        copter.pos_control->input_pos_vel_accel_U_cm(pos_u_cm, vel_u_cms, 0);
 
         // stop take off early and return if negative climb rate is commanded or we are within 0.1% of our take off altitude
         if (is_negative(pilot_climb_rate_cm) ||
-            (take_off_complete_alt  - take_off_start_alt) * 0.999f < copter.pos_control->get_pos_desired_U_cm() - take_off_start_alt) {
+            (take_off_complete_alt_cm  - take_off_start_alt_cm) * 0.999f < copter.pos_control->get_pos_desired_U_cm() - take_off_start_alt_cm) {
             stop();
         }
     }
@@ -125,13 +125,13 @@ void _AutoTakeoff::run()
         // do not spool down tradheli when on the ground with motor interlock enabled
         copter.flightmode->make_safe_ground_handling(copter.is_tradheli() && motors->get_interlock());
         // update auto_takeoff_no_nav_alt_cm
-        no_nav_alt_cm = pos_control->get_pos_estimate_NEU_cm().z + g2.wp_navalt_min * 100;
+        no_nav_alt_cm = pos_control->get_pos_estimate_NEU_cm().z + g2.wp_navalt_min_m * 100;
         return;
     }
 
     // get terrain offset
-    float terr_offset = 0.0f;
-    if (terrain_alt && !wp_nav->get_terrain_offset_cm(terr_offset)) {
+    float terr_offset_cm = 0.0f;
+    if (is_terrain_alt && !wp_nav->get_terrain_offset_cm(terr_offset_cm)) {
         // trigger terrain failsafe
         copter.failsafe_terrain_on_event();
         return;
@@ -151,7 +151,7 @@ void _AutoTakeoff::run()
         attitude_control->reset_rate_controller_I_terms();
         attitude_control->input_thrust_vector_rate_heading_rads(pos_control->get_thrust_vector(), 0.0);
         // update auto_takeoff_no_nav_alt_cm
-        no_nav_alt_cm = pos_control->get_pos_estimate_NEU_cm().z + g2.wp_navalt_min * 100;
+        no_nav_alt_cm = pos_control->get_pos_estimate_NEU_cm().z + g2.wp_navalt_min_m * 100;
         return;
     }
     
@@ -187,16 +187,16 @@ void _AutoTakeoff::run()
         }
         pos_control->relax_velocity_controller_NE();
     } else {
-        Vector2f vel;
-        Vector2f accel;
-        pos_control->input_vel_accel_NE_cm(vel, accel);
+        Vector2f vel_zero;
+        Vector2f accel_zero;
+        pos_control->input_vel_accel_NE_cm(vel_zero, accel_zero);
     }
     pos_control->update_NE_controller();
 
     // command the aircraft to the take off altitude
-    float pos_z = complete_alt_cm + terr_offset;
-    float vel_z = 0.0;
-    copter.pos_control->input_pos_vel_accel_U_cm(pos_z, vel_z, 0.0);
+    float pos_u_cm = complete_alt_cm + terr_offset_cm;
+    float vel_zero = 0.0;
+    copter.pos_control->input_pos_vel_accel_U_cm(pos_u_cm, vel_zero, 0.0);
     
     // run the vertical position controller and set output throttle
     pos_control->update_U_controller();
@@ -208,29 +208,29 @@ void _AutoTakeoff::run()
     // and 10% our maximum climb rate
     const float vel_threshold_fraction = 0.1;
     // stopping distance from vel_threshold_fraction * max velocity
-    const float stop_distance = 0.5 * sq(vel_threshold_fraction * copter.pos_control->get_max_speed_up_cms()) / copter.pos_control->get_max_accel_U_cmss();
-    bool reached_altitude = copter.pos_control->get_pos_desired_U_cm() >= pos_z - stop_distance;
+    const float stop_distance_cm = 0.5 * sq(vel_threshold_fraction * copter.pos_control->get_max_speed_up_cms()) / copter.pos_control->get_max_accel_U_cmss();
+    bool reached_altitude = copter.pos_control->get_pos_desired_U_cm() >= pos_u_cm - stop_distance_cm;
     bool reached_climb_rate = copter.pos_control->get_vel_desired_NEU_cms().z < copter.pos_control->get_max_speed_up_cms() * vel_threshold_fraction;
     complete = reached_altitude && reached_climb_rate;
 
     // calculate completion for location in case it is needed for a smooth transition to wp_nav
     if (complete) {
-        const Vector3p& _complete_pos = copter.pos_control->get_pos_desired_NEU_cm();
-        complete_pos = Vector3p{_complete_pos.x, _complete_pos.y, pos_z};
+        const Vector3p& _complete_pos_neu_cm = copter.pos_control->get_pos_desired_NEU_cm();
+        complete_pos_neu_cm = Vector3p{_complete_pos_neu_cm.x, _complete_pos_neu_cm.y, pos_u_cm};
     }
 }
 
-void _AutoTakeoff::start(float _complete_alt_cm, bool _terrain_alt)
+void _AutoTakeoff::start(float _complete_alt_cm, bool _is_terrain_alt)
 {
     // auto_takeoff_complete_alt_cm is a problem if equal to auto_takeoff_start_alt_cm
     complete_alt_cm = _complete_alt_cm;
-    terrain_alt = _terrain_alt;
+    is_terrain_alt = _is_terrain_alt;
     complete = false;
     // initialise auto_takeoff_no_nav_alt_cm
     const auto &g2 = copter.g2;
-    no_nav_alt_cm = copter.pos_control->get_pos_estimate_NEU_cm().z + g2.wp_navalt_min * 100;
-    if ((g2.wp_navalt_min > 0) && (copter.flightmode->is_disarmed_or_landed() || !copter.motors->get_interlock())) {
-        // we are not flying, climb with no navigation to current alt-above-ekf-origin + wp_navalt_min
+    no_nav_alt_cm = copter.pos_control->get_pos_estimate_NEU_cm().z + g2.wp_navalt_min_m * 100;
+    if ((g2.wp_navalt_min_m > 0) && (copter.flightmode->is_disarmed_or_landed() || !copter.motors->get_interlock())) {
+        // we are not flying, climb with no navigation to current alt-above-ekf-origin + wp_navalt_min_m
         no_nav_active = true;
     } else {
         no_nav_active = false;
@@ -238,14 +238,14 @@ void _AutoTakeoff::start(float _complete_alt_cm, bool _terrain_alt)
 }
 
 // return takeoff final target position in cm from the EKF origin if takeoff has completed successfully
-bool _AutoTakeoff::get_completion_pos(Vector3p& pos_neu_cm)
+bool _AutoTakeoff::get_completion_pos_neu_cm(Vector3p& pos_neu_cm)
 {
     // only provide location if takeoff has completed
     if (!complete) {
         return false;
     }
 
-    pos_neu_cm = complete_pos;
+    pos_neu_cm = complete_pos_neu_cm;
     return true;
 }
 

--- a/ArduPlane/mode_qhover.cpp
+++ b/ArduPlane/mode_qhover.cpp
@@ -7,7 +7,7 @@ bool ModeQHover::_enter()
 {
     // set vertical speed and acceleration limits
     pos_control->set_max_speed_accel_U_m(-quadplane.get_pilot_velocity_z_max_dn_m(), quadplane.pilot_speed_z_max_up_ms, quadplane.pilot_accel_z_mss);
-    pos_control->set_correction_speed_accel_U_mss(-quadplane.get_pilot_velocity_z_max_dn_m(), quadplane.pilot_speed_z_max_up_ms, quadplane.pilot_accel_z_mss);
+    pos_control->set_correction_speed_accel_U_m(-quadplane.get_pilot_velocity_z_max_dn_m(), quadplane.pilot_speed_z_max_up_ms, quadplane.pilot_accel_z_mss);
     quadplane.set_climb_rate_ms(0);
 
     quadplane.init_throttle_wait();

--- a/ArduPlane/mode_qloiter.cpp
+++ b/ArduPlane/mode_qloiter.cpp
@@ -11,7 +11,7 @@ bool ModeQLoiter::_enter()
 
     // set vertical speed and acceleration limits
     pos_control->set_max_speed_accel_U_m(-quadplane.get_pilot_velocity_z_max_dn_m(), quadplane.pilot_speed_z_max_up_ms, quadplane.pilot_accel_z_mss);
-    pos_control->set_correction_speed_accel_U_mss(-quadplane.get_pilot_velocity_z_max_dn_m(), quadplane.pilot_speed_z_max_up_ms, quadplane.pilot_accel_z_mss);
+    pos_control->set_correction_speed_accel_U_m(-quadplane.get_pilot_velocity_z_max_dn_m(), quadplane.pilot_speed_z_max_up_ms, quadplane.pilot_accel_z_mss);
 
     quadplane.init_throttle_wait();
 

--- a/ArduPlane/qautotune.cpp
+++ b/ArduPlane/qautotune.cpp
@@ -44,7 +44,7 @@ void QAutoTune::init_z_limits()
     plane.quadplane.pos_control->set_max_speed_accel_U_m(-plane.quadplane.get_pilot_velocity_z_max_dn_m(),
                                                        plane.quadplane.pilot_speed_z_max_up_ms,
                                                        plane.quadplane.pilot_accel_z_mss);
-    plane.quadplane.pos_control->set_correction_speed_accel_U_mss(-plane.quadplane.get_pilot_velocity_z_max_dn_m(),
+    plane.quadplane.pos_control->set_correction_speed_accel_U_m(-plane.quadplane.get_pilot_velocity_z_max_dn_m(),
                                                               plane.quadplane.pilot_speed_z_max_up_ms,
                                                               plane.quadplane.pilot_accel_z_mss);
 }

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3075,7 +3075,7 @@ void QuadPlane::setup_target_position(void)
 
     // set vertical speed and acceleration limits
     pos_control->set_max_speed_accel_U_m(-get_pilot_velocity_z_max_dn_m(), pilot_speed_z_max_up_ms, pilot_accel_z_mss);
-    pos_control->set_correction_speed_accel_U_mss(-get_pilot_velocity_z_max_dn_m(), pilot_speed_z_max_up_ms, pilot_accel_z_mss);
+    pos_control->set_correction_speed_accel_U_m(-get_pilot_velocity_z_max_dn_m(), pilot_speed_z_max_up_ms, pilot_accel_z_mss);
 }
 
 /*
@@ -3326,7 +3326,7 @@ bool QuadPlane::do_vtol_takeoff(const AP_Mission::Mission_Command& cmd)
 
     // set vertical speed and acceleration limits
     pos_control->set_max_speed_accel_U_m(-get_pilot_velocity_z_max_dn_m(), pilot_speed_z_max_up_ms, pilot_accel_z_mss);
-    pos_control->set_correction_speed_accel_U_mss(-get_pilot_velocity_z_max_dn_m(), pilot_speed_z_max_up_ms, pilot_accel_z_mss);
+    pos_control->set_correction_speed_accel_U_m(-get_pilot_velocity_z_max_dn_m(), pilot_speed_z_max_up_ms, pilot_accel_z_mss);
 
     // initialise the vertical position controller
     pos_control->init_U_controller();

--- a/ArduSub/mode_althold.cpp
+++ b/ArduSub/mode_althold.cpp
@@ -9,7 +9,7 @@ bool ModeAlthold::init(bool ignore_checks) {
     // initialize vertical maximum speeds and acceleration
     // sets the maximum speed up and down returned by position controller
     position_control->set_max_speed_accel_U_cm(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
-    position_control->set_correction_speed_accel_U_cmss(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    position_control->set_correction_speed_accel_U_cm(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // initialise position and desired velocity
     position_control->init_U_controller();

--- a/ArduSub/mode_auto.cpp
+++ b/ArduSub/mode_auto.cpp
@@ -459,7 +459,7 @@ bool ModeAuto::auto_terrain_recover_start()
 
     // initialize vertical maximum speeds and acceleration
     position_control->set_max_speed_accel_U_cm(sub.wp_nav.get_default_speed_down_cms(), sub.wp_nav.get_default_speed_up_cms(), sub.wp_nav.get_accel_U_cmss());
-    position_control->set_correction_speed_accel_U_cmss(sub.wp_nav.get_default_speed_down_cms(), sub.wp_nav.get_default_speed_up_cms(), sub.wp_nav.get_accel_U_cmss());
+    position_control->set_correction_speed_accel_U_cm(sub.wp_nav.get_default_speed_down_cms(), sub.wp_nav.get_default_speed_up_cms(), sub.wp_nav.get_accel_U_cmss());
 
     gcs().send_text(MAV_SEVERITY_WARNING, "Attempting auto failsafe recovery");
     return true;

--- a/ArduSub/mode_circle.cpp
+++ b/ArduSub/mode_circle.cpp
@@ -17,7 +17,7 @@ bool ModeCircle::init(bool ignore_checks)
     position_control->set_max_speed_accel_NE_cm(sub.wp_nav.get_default_speed_NE_cms(), sub.wp_nav.get_wp_acceleration_cmss());
     position_control->set_correction_speed_accel_NE_cm(sub.wp_nav.get_default_speed_NE_cms(), sub.wp_nav.get_wp_acceleration_cmss());
     position_control->set_max_speed_accel_U_cm(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
-    position_control->set_correction_speed_accel_U_cmss(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    position_control->set_correction_speed_accel_U_cm(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // initialise circle controller including setting the circle center based on vehicle speed
     sub.circle_nav.init();

--- a/ArduSub/mode_guided.cpp
+++ b/ArduSub/mode_guided.cpp
@@ -105,7 +105,7 @@ void ModeGuided::guided_vel_control_start()
 
     // initialize vertical maximum speeds and acceleration
     position_control->set_max_speed_accel_U_cm(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
-    position_control->set_correction_speed_accel_U_cmss(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    position_control->set_correction_speed_accel_U_cm(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // initialise velocity controller
     position_control->init_U_controller();
@@ -124,7 +124,7 @@ void ModeGuided::guided_posvel_control_start()
 
     // set vertical speed and acceleration
     position_control->set_max_speed_accel_U_cm(sub.wp_nav.get_default_speed_down_cms(), sub.wp_nav.get_default_speed_up_cms(), sub.wp_nav.get_accel_U_cmss());
-    position_control->set_correction_speed_accel_U_cmss(sub.wp_nav.get_default_speed_down_cms(), sub.wp_nav.get_default_speed_up_cms(), sub.wp_nav.get_accel_U_cmss());
+    position_control->set_correction_speed_accel_U_cm(sub.wp_nav.get_default_speed_down_cms(), sub.wp_nav.get_default_speed_up_cms(), sub.wp_nav.get_accel_U_cmss());
 
     // initialise velocity controller
     position_control->init_U_controller();
@@ -143,7 +143,7 @@ void ModeGuided::guided_angle_control_start()
 
     // set vertical speed and acceleration
     position_control->set_max_speed_accel_U_cm(sub.wp_nav.get_default_speed_down_cms(), sub.wp_nav.get_default_speed_up_cms(), sub.wp_nav.get_accel_U_cmss());
-    position_control->set_correction_speed_accel_U_cmss(sub.wp_nav.get_default_speed_down_cms(), sub.wp_nav.get_default_speed_up_cms(), sub.wp_nav.get_accel_U_cmss());
+    position_control->set_correction_speed_accel_U_cm(sub.wp_nav.get_default_speed_down_cms(), sub.wp_nav.get_default_speed_up_cms(), sub.wp_nav.get_accel_U_cmss());
 
     // initialise velocity controller
     position_control->init_U_controller();

--- a/ArduSub/mode_guided.cpp
+++ b/ArduSub/mode_guided.cpp
@@ -24,8 +24,8 @@ struct Guided_Limit {
     float alt_min_cm;   // lower altitude limit in cm above home (0 = no limit)
     float alt_max_cm;   // upper altitude limit in cm above home (0 = no limit)
     float horiz_max_cm; // horizontal position limit in cm from where guided mode was initiated (0 = no limit)
-    uint32_t start_time;// system time in milliseconds that control was handed to the external computer
-    Vector3f start_pos; // start position as a distance from home in cm.  used for checking horiz_max limit
+    uint32_t start_time_ms;// system time in milliseconds that control was handed to the external computer
+    Vector3f start_pos_neu_cm; // start position as a distance from home in cm.  used for checking horiz_max limit
 } guided_limit;
 
 // guided_init - initialise guided controller
@@ -844,10 +844,10 @@ void ModeGuided::guided_limit_set(uint32_t timeout_ms, float alt_min_cm, float a
 void ModeGuided::guided_limit_init_time_and_pos()
 {
     // initialise start time
-    guided_limit.start_time = AP_HAL::millis();
+    guided_limit.start_time_ms = AP_HAL::millis();
 
     // initialise start position from current position
-    guided_limit.start_pos = inertial_nav.get_position_neu_cm();
+    guided_limit.start_pos_neu_cm = inertial_nav.get_position_neu_cm();
 }
 
 // guided_limit_check - returns true if guided mode has breached a limit
@@ -855,7 +855,7 @@ void ModeGuided::guided_limit_init_time_and_pos()
 bool ModeGuided::guided_limit_check()
 {
     // check if we have passed the timeout
-    if ((guided_limit.timeout_ms > 0) && (AP_HAL::millis() - guided_limit.start_time >= guided_limit.timeout_ms)) {
+    if ((guided_limit.timeout_ms > 0) && (AP_HAL::millis() - guided_limit.start_time_ms >= guided_limit.timeout_ms)) {
         return true;
     }
 
@@ -874,7 +874,7 @@ bool ModeGuided::guided_limit_check()
 
     // check if we have gone beyond horizontal limit
     if (guided_limit.horiz_max_cm > 0.0f) {
-        const float horiz_move = get_horizontal_distance(guided_limit.start_pos.xy(), curr_pos.xy());
+        const float horiz_move = get_horizontal_distance(guided_limit.start_pos_neu_cm.xy(), curr_pos.xy());
         if (horiz_move > guided_limit.horiz_max_cm) {
             return true;
         }

--- a/ArduSub/mode_poshold.cpp
+++ b/ArduSub/mode_poshold.cpp
@@ -18,7 +18,7 @@ bool ModePoshold::init(bool ignore_checks)
     position_control->set_max_speed_accel_NE_cm(g.pilot_speed, g.pilot_accel_z);
     position_control->set_correction_speed_accel_NE_cm(g.pilot_speed, g.pilot_accel_z);
     position_control->set_max_speed_accel_U_cm(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
-    position_control->set_correction_speed_accel_U_cmss(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    position_control->set_correction_speed_accel_U_cm(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // initialise position and desired velocity
     position_control->init_NE_controller_stopping_point();

--- a/ArduSub/mode_surface.cpp
+++ b/ArduSub/mode_surface.cpp
@@ -7,7 +7,7 @@ bool ModeSurface::init(bool ignore_checks)
 
     // initialize vertical speeds and acceleration
     position_control->set_max_speed_accel_U_cm(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
-    position_control->set_correction_speed_accel_U_cmss(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
+    position_control->set_correction_speed_accel_U_cm(-sub.get_pilot_speed_dn(), g.pilot_speed_up, g.pilot_accel_z);
 
     // initialise position and desired velocity
     position_control->init_U_controller();

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -818,15 +818,15 @@ void AC_PosControl::set_max_speed_accel_U_m(float speed_down_ms, float speed_up_
 
 // Sets vertical correction velocity and acceleration limits (cm/s, cm/s²).
 // Should only be called during initialization to avoid discontinuities.
-// See set_correction_speed_accel_U_mss() for full details.
-void AC_PosControl::set_correction_speed_accel_U_cmss(float speed_down_cms, float speed_up_cms, float accel_cmss)
+// See set_correction_speed_accel_U_m() for full details.
+void AC_PosControl::set_correction_speed_accel_U_cm(float speed_down_cms, float speed_up_cms, float accel_cmss)
 {
-    set_correction_speed_accel_U_mss(speed_down_cms * 0.01, speed_up_cms * 0.01, accel_cmss * 0.01);
+    set_correction_speed_accel_U_m(speed_down_cms * 0.01, speed_up_cms * 0.01, accel_cmss * 0.01);
 }
 
 // Sets vertical correction velocity and acceleration limits (m/s, m/s²).
 // These values constrain the correction output of the PID controller.
-void AC_PosControl::set_correction_speed_accel_U_mss(float speed_down_ms, float speed_up_ms, float accel_mss)
+void AC_PosControl::set_correction_speed_accel_U_m(float speed_down_ms, float speed_up_ms, float accel_mss)
 {
     // define maximum position error and maximum first and second differential limits
     _p_pos_u_m.set_limits(-fabsf(speed_down_ms), speed_up_ms, accel_mss, 0.0f);

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -222,12 +222,12 @@ public:
 
     // Sets vertical correction velocity and acceleration limits (cm/s, cm/s²).
     // Should only be called during initialization to avoid discontinuities.
-    // See set_correction_speed_accel_U_mss() for full details.
-    void set_correction_speed_accel_U_cmss(float speed_down_cms, float speed_up_cms, float accel_cmss);
+    // See set_correction_speed_accel_U_m() for full details.
+    void set_correction_speed_accel_U_cm(float speed_down_cms, float speed_up_cms, float accel_cmss);
 
     // Sets vertical correction velocity and acceleration limits (m/s, m/s²).
     // These values constrain the correction output of the PID controller.
-    void set_correction_speed_accel_U_mss(float speed_down_ms, float speed_up_ms, float accel_mss);
+    void set_correction_speed_accel_U_m(float speed_down_ms, float speed_up_ms, float accel_mss);
 
     // Returns maximum vertical acceleration in cm/s².
     // See get_max_accel_U_mss() for full details.

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -182,7 +182,7 @@ void AC_WPNav::wp_and_spline_init_m(float speed_ms, Vector3f stopping_point_neu_
     _pos_control.set_max_speed_accel_NE_m(_wp_desired_speed_ne_ms, get_wp_acceleration_mss());
     _pos_control.set_correction_speed_accel_NE_m(_wp_desired_speed_ne_ms, get_wp_acceleration_mss());
     _pos_control.set_max_speed_accel_U_m(-get_default_speed_down_ms(), get_default_speed_up_ms(), get_accel_U_mss());
-    _pos_control.set_correction_speed_accel_U_mss(-get_default_speed_down_ms(), get_default_speed_up_ms(), get_accel_U_mss());
+    _pos_control.set_correction_speed_accel_U_m(-get_default_speed_down_ms(), get_default_speed_up_ms(), get_accel_U_mss());
 
     // calculate jerk limit if not explicitly set by parameter
     if (!is_positive(_wp_jerk_msss)) {


### PR DESCRIPTION
This should be a no-compiler-change but when I change the static names we do see a change but no change to size.

```
Board,blimp,bootloader,copter,heli,plane,rover,sub
CubeOrange,*,0,0,0,*,*,*
```

blimp changed on the last PR for some reason.