### PR TITLE
AP_Vehicle: init msp after CAN manager

### DIFF
--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -391,11 +391,6 @@ void AP_Vehicle::setup()
     hal.scheduler->register_delay_callback(scheduler_delay_callback, 5);
 #endif
 
-#if HAL_MSP_ENABLED
-    // call MSP init before init_ardupilot to allow for MSP sensors
-    msp.init();
-#endif
-
 #if AP_EXTERNAL_AHRS_ENABLED
     // call externalAHRS init before init_ardupilot to allow for external sensors
     externalAHRS.init();
@@ -414,6 +409,11 @@ void AP_Vehicle::setup()
 
 #if HAL_CANMANAGER_ENABLED
     can_mgr.init();
+#endif
+
+#if HAL_MSP_ENABLED
+    // call MSP init before init_ardupilot to allow for MSP sensors
+    msp.init();
 #endif
 
 #if HAL_LOGGING_ENABLED


### PR DESCRIPTION
This moves msp init down to after CAN manager. This means it now comes after:

- External AHRS
- Generator
- Stats
- Board config
- CAN manager

The result is that MSP serial protocols work over DroneCAN. Currently the serial port is not found because its not registered until DroneCAN init is done from CAN manager init.

Prior to this I was getting:
```
MSP DisplayPort uart not available
```
After this fix display port OSD works over a DroneCAN serial port.

