### PR TITLE
AP_Param: ensure flags is filled in for find()

### DIFF
--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -934,6 +934,8 @@ AP_Param::find(const char *name, enum ap_var_type *ptype, uint16_t *flags)
                     ap->find_var_info(&group_element, ginfo, group_nesting, &idx);
                     if (ginfo != nullptr) {
                         *flags = ginfo->flags;
+                    } else {
+                        *flags = 0;
                     }
                 }
                 return ap;
@@ -946,6 +948,9 @@ AP_Param::find(const char *name, enum ap_var_type *ptype, uint16_t *flags)
             ptrdiff_t base;
             if (!get_base(info, base)) {
                 return nullptr;
+            }
+            if (flags != nullptr) {
+                *flags = 0;
             }
             return (AP_Param *)base;
         }


### PR DESCRIPTION
top level parameters don't have flags, but we need to fill in the flags return field as otherwise we can refuse to set a parameter based on it being internal and the allow_set_via_mavlink() check
backported from https://github.com/ArduPilot/ardupilot/pull/30628
