### PR TITLE
AP_Mount: retract servo(s) operation for all backends

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -73,6 +73,8 @@ void AP_Mount_Alexmos::init()
 // update mount position - should be called periodically
 void AP_Mount_Alexmos::update()
 {
+    AP_Mount_Backend::update();
+
     if (!_initialised) {
         return;
     }

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -38,6 +38,14 @@ void AP_Mount_Backend::set_dev_id(uint32_t id)
     _params.dev_id.set_and_save(int32_t(id));
 }
 
+// base implementation should be called from derived classes for common functionality
+void AP_Mount_Backend::update()
+{
+    // move mount to a "retracted position" into the fuselage or out of it
+    const bool mount_open = (_mode == MAV_MOUNT_MODE_RETRACT);
+    SRV_Channels::move_servo(_open_idx, mount_open, 0, 1);
+}
+
 // return true if this mount accepts roll targets
 bool AP_Mount_Backend::has_roll_control() const
 {

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -28,6 +28,7 @@
 #include <AP_Common/Location.h>
 #include <RC_Channel/RC_Channel.h>
 #include <AP_Camera/AP_Camera_shareddefs.h>
+#include <SRV_Channel/SRV_Channel.h>
 #include "AP_Mount.h"
 
 class AP_Mount_Backend
@@ -37,7 +38,8 @@ public:
     AP_Mount_Backend(class AP_Mount &frontend, class AP_Mount_Params &params, uint8_t instance) :
         _frontend(frontend),
         _params(params),
-        _instance(instance)
+        _instance(instance),
+        _open_idx(_instance == 0? SRV_Channel::k_mount_open : SRV_Channel::k_mount2_open)
     {}
 
     // init - performs any required initialisation for this instance
@@ -47,7 +49,7 @@ public:
     void set_dev_id(uint32_t id);
 
     // update mount position - should be called periodically
-    virtual void update() = 0;
+    virtual void update();
 
     // used for gimbals that need to read INS data at full rate
     virtual void update_fast() {}
@@ -359,6 +361,9 @@ private:
         bool operator==(const mavlink_control_id_t &rhs) const { return (sysid == rhs.sysid && compid == rhs.compid); }
         bool operator!=(const mavlink_control_id_t &rhs) const { return !(*this == rhs); }
     } mavlink_control_id;
+
+    // SRV_Channel mount open function index
+    SRV_Channel::Function    _open_idx;
 };
 
 #endif // HAL_MOUNT_ENABLED

--- a/libraries/AP_Mount/AP_Mount_CADDX.cpp
+++ b/libraries/AP_Mount/AP_Mount_CADDX.cpp
@@ -15,6 +15,8 @@
 // update mount position - should be called periodically
 void AP_Mount_CADDX::update()
 {
+    AP_Mount_Backend::update();
+
     // exit immediately if not initialised
     if (!_initialised) {
         return;

--- a/libraries/AP_Mount/AP_Mount_Gremsy.cpp
+++ b/libraries/AP_Mount/AP_Mount_Gremsy.cpp
@@ -16,6 +16,8 @@ extern const AP_HAL::HAL& hal;
 // update mount position
 void AP_Mount_Gremsy::update()
 {
+    AP_Mount_Backend::update();
+
     // exit immediately if not initialised
     if (!_initialised) {
         find_gimbal();

--- a/libraries/AP_Mount/AP_Mount_SToRM32.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.cpp
@@ -15,6 +15,8 @@ extern const AP_HAL::HAL& hal;
 // update mount position - should be called periodically
 void AP_Mount_SToRM32::update()
 {
+    AP_Mount_Backend::update();
+
     // exit immediately if not initialised
     if (!_initialised) {
         find_gimbal();

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
@@ -11,6 +11,8 @@
 // update mount position - should be called periodically
 void AP_Mount_SToRM32_serial::update()
 {
+    AP_Mount_Backend::update();
+
     // exit immediately if not initialised
     if (!_initialised) {
         return;

--- a/libraries/AP_Mount/AP_Mount_Scripting.cpp
+++ b/libraries/AP_Mount/AP_Mount_Scripting.cpp
@@ -18,6 +18,8 @@ extern const AP_HAL::HAL& hal;
 // update mount position - should be called periodically
 void AP_Mount_Scripting::update()
 {
+    AP_Mount_Backend::update();
+
     // change to RC_TARGETING mode if RC input has changed
     set_rctargeting_on_rcinput_change();
 

--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -16,13 +16,11 @@ void AP_Mount_Servo::init()
         _roll_idx = SRV_Channel::k_mount_roll;
         _tilt_idx = SRV_Channel::k_mount_tilt;
         _pan_idx  = SRV_Channel::k_mount_pan;
-        _open_idx = SRV_Channel::k_mount_open;
     } else {
         // this must be the 2nd mount
         _roll_idx = SRV_Channel::k_mount2_roll;
         _tilt_idx = SRV_Channel::k_mount2_tilt;
         _pan_idx  = SRV_Channel::k_mount2_pan;
-        _open_idx = SRV_Channel::k_mount2_open;
     }
     AP_Mount_Backend::init();
 }
@@ -30,6 +28,8 @@ void AP_Mount_Servo::init()
 // update mount position - should be called periodically
 void AP_Mount_Servo::update()
 {
+    AP_Mount_Backend::update();
+
     // change to RC_TARGETING mode if RC input has changed
     set_rctargeting_on_rcinput_change();
 
@@ -100,10 +100,6 @@ void AP_Mount_Servo::update()
             }
             break;
     }
-
-    // move mount to a "retracted position" into the fuselage with a fourth servo
-    const bool mount_open = (mount_mode == MAV_MOUNT_MODE_RETRACT) ? 0 : 1;
-    move_servo(_open_idx, mount_open, 0, 1);
 
     // write the results to the servos
     move_servo(_roll_idx, degrees(_angle_bf_output_rad.x)*10, _params.roll_angle_min*10, _params.roll_angle_max*10);

--- a/libraries/AP_Mount/AP_Mount_Servo.h
+++ b/libraries/AP_Mount/AP_Mount_Servo.h
@@ -11,7 +11,6 @@
 
 #include <AP_Math/AP_Math.h>
 #include <AP_Common/AP_Common.h>
-#include <SRV_Channel/SRV_Channel.h>
 
 class AP_Mount_Servo : public AP_Mount_Backend
 {
@@ -22,8 +21,7 @@ public:
         requires_stabilization(requires_stab),
         _roll_idx(SRV_Channel::k_none),
         _tilt_idx(SRV_Channel::k_none),
-        _pan_idx(SRV_Channel::k_none),
-        _open_idx(SRV_Channel::k_none)
+        _pan_idx(SRV_Channel::k_none)
     {
     }
 
@@ -62,7 +60,6 @@ private:
     SRV_Channel::Function    _roll_idx;  // SRV_Channel mount roll function index
     SRV_Channel::Function    _tilt_idx;  // SRV_Channel mount tilt function index
     SRV_Channel::Function    _pan_idx;   // SRV_Channel mount pan  function index
-    SRV_Channel::Function    _open_idx;  // SRV_Channel mount open function index
 
     Vector3f _angle_bf_output_rad;  // final body frame output angle in radians
 };

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -39,6 +39,8 @@ const AP_Mount_Siyi::HWInfo AP_Mount_Siyi::hardware_lookup_table[] {
 // update mount position - should be called periodically
 void AP_Mount_Siyi::update()
 {
+    AP_Mount_Backend::update();
+
     // exit immediately if not initialised
     if (!_initialised) {
         return;

--- a/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
+++ b/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
@@ -29,6 +29,8 @@ void AP_Mount_SoloGimbal::update_fast()
 // update mount position - should be called periodically
 void AP_Mount_SoloGimbal::update()
 {
+    AP_Mount_Backend::update();
+
     // exit immediately if not initialised
     if (!_initialised) {
         return;

--- a/libraries/AP_Mount/AP_Mount_Topotek.cpp
+++ b/libraries/AP_Mount/AP_Mount_Topotek.cpp
@@ -57,6 +57,8 @@ const char* AP_Mount_Topotek::send_message_prefix = "Mount: Topotek";
 // update mount position - should be called periodically
 void AP_Mount_Topotek::update()
 {
+    AP_Mount_Backend::update();
+
     // exit immediately if not initialised
     if (!_initialised) {
         return;

--- a/libraries/AP_Mount/AP_Mount_Viewpro.cpp
+++ b/libraries/AP_Mount/AP_Mount_Viewpro.cpp
@@ -34,6 +34,8 @@ const char* AP_Mount_Viewpro::send_text_prefix = "Viewpro:";
 // update mount position - should be called periodically
 void AP_Mount_Viewpro::update()
 {
+    AP_Mount_Backend::update();
+
     // exit immediately if not initialised
     if (!_initialised) {
         return;


### PR DESCRIPTION
Spiritual successor to #26944. This allows the mount retraction servo to be used regardless of the mount backend. Useful for e.g. a Storm32 gimbal that is itself being pulled into the fuselage by a servo.

I wanted to fix the branch first, but I realized the implementation can be much more compact. Unlike the other PR, this makes sure that **all** the corresponding servos are activated which allows for multi-servo setup. Only saps time at the mount mode changes so will not introduce any overhead (and if the servo function isn't configured the servo move method immediately quits anyway).

<img width="730" height="501" alt="image" src="https://github.com/user-attachments/assets/fbb21f63-387a-42a9-98c2-5ec3675c090b" />

SITL-tested, will backport to a stable commit and test in a real aircraft in a couple of days.