### PR TITLE
Plane: optional limit to flaperon percentage

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -210,6 +210,15 @@ const AP_Param::Info Plane::var_info[] = {
     // @User: Advanced
     GSCALAR(takeoff_flap_percent,     "TKOFF_FLAP_PCNT", 0),
 
+    // @Param: FLAPERON_LIMIT
+    // @DisplayName: Flaperon percentage limit
+    // @Description: The maximum amount of flaps (as a percentage) mixed into flaperons
+    // @Range: 0 100
+    // @Units: %
+    // @Increment: 1
+    // @User: Advanced
+    GSCALAR(flaperon_limit,     "FLAPERON_LIMIT", 100),
+
     // @Param: LEVEL_ROLL_LIMIT
     // @DisplayName: Level flight roll limit
     // @Description: This controls the maximum bank angle in degrees during flight modes where level flight is desired, such as in the final stages of landing, and during auto takeoff. This should be a small angle (such as 5 degrees) to prevent a wing hitting the runway during takeoff or landing. Setting this to zero will completely disable heading hold on auto takeoff while below 5 meters and during the flare portion of a final landing approach.

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -370,6 +370,7 @@ public:
         k_param_quicktune,
         k_param_mode_autoland,
         k_param__gcs,
+        k_param_flaperon_limit,
 
     };
 
@@ -452,7 +453,8 @@ public:
     AP_Int8 flap_1_speed;
     AP_Int8 flap_2_percent;
     AP_Int8 flap_2_speed;
-    AP_Int8 takeoff_flap_percent;  
+    AP_Int8 takeoff_flap_percent;
+    AP_Int8 flaperon_limit;
     AP_Enum<StickMixing> stick_mixing;
     AP_Float takeoff_throttle_min_speed;
     AP_Float takeoff_throttle_min_accel;

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -208,6 +208,7 @@ void Plane::flaperon_update()
      */
     float aileron = SRV_Channels::get_output_scaled(SRV_Channel::k_aileron);
     float flap_percent = SRV_Channels::get_slew_limited_output_scaled(SRV_Channel::k_flap_auto);
+    flap_percent = fmin(flap_percent, g.flaperon_limit);
     float flaperon_left  = constrain_float(aileron + flap_percent * 45, -4500, 4500);
     float flaperon_right = constrain_float(aileron - flap_percent * 45, -4500, 4500);
     SRV_Channels::set_output_scaled(SRV_Channel::k_flaperon_left, flaperon_left);


### PR DESCRIPTION
On my model full [manual] flaperon extension seems to be very badly affecting the roll behavior. Of course this can be remedied with trick settings on the RC range and/or transmitter, but it seems hacky and would interfere with RC calibration. This PR creates a new parameter which can be used to limit the flaperon mixing amount so that if the RC remote commands 100% flap it can be limited to somewhere sane (as we can't do that with servo throw since that would also be affecting the aileron function). 

This also allows a wing with both flaps and aileron to be configured with a shallow flaperon limit not to interfere with the aileron too much, but still have some flap functionality. From my theorycrafting sofa this could be useful to delay wingtip stalls while not going for full flaperon setup.

SITL-tested will report from an actual aircraft.