### PR TITLE
Remove unicode superscripts

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -436,7 +436,7 @@ float AC_PosControl::pos_terrain_U_scaler_m(float pos_terrain_u_m, float pos_ter
 /// Lateral position controller
 ///
 
-// Sets maximum horizontal speed (cm/s) and acceleration (cm/s²) for NE-axis shaping.
+// Sets maximum horizontal speed (cm/s) and acceleration (cm/s/s) for NE-axis shaping.
 // Can be called anytime; transitions are handled smoothly.
 // See set_max_speed_accel_NE_m() for full details.
 void AC_PosControl::set_max_speed_accel_NE_cm(float speed_ne_cms, float accel_ne_cmss)
@@ -444,7 +444,7 @@ void AC_PosControl::set_max_speed_accel_NE_cm(float speed_ne_cms, float accel_ne
     set_max_speed_accel_NE_m(speed_ne_cms * 0.01, accel_ne_cmss * 0.01);
 }
 
-// Sets maximum horizontal speed (m/s) and acceleration (m/s²) for NE-axis shaping.
+// Sets maximum horizontal speed (m/s) and acceleration (m/s/s) for NE-axis shaping.
 // These values constrain the kinematic trajectory used by the lateral controller.
 void AC_PosControl::set_max_speed_accel_NE_m(float speed_ne_ms, float accel_ne_mss)
 {
@@ -469,7 +469,7 @@ void AC_PosControl::set_max_speed_accel_NE_m(float speed_ne_ms, float accel_ne_m
     }
 }
 
-// Sets horizontal correction limits for velocity (cm/s) and acceleration (cm/s²).
+// Sets horizontal correction limits for velocity (cm/s) and acceleration (cm/s/s).
 // Should be called only during initialization to avoid control discontinuities.
 // See set_correction_speed_accel_NE_m() for full details.
 void AC_PosControl::set_correction_speed_accel_NE_cm(float speed_ne_cms, float accel_ne_cmss)
@@ -477,7 +477,7 @@ void AC_PosControl::set_correction_speed_accel_NE_cm(float speed_ne_cms, float a
     set_correction_speed_accel_NE_m(speed_ne_cms * 0.01, accel_ne_cmss * 0.01);
 }
 
-// Sets horizontal correction limits for velocity (m/s) and acceleration (m/s²).
+// Sets horizontal correction limits for velocity (m/s) and acceleration (m/s/s).
 // These values constrain the PID correction path, not the desired trajectory.
 void AC_PosControl::set_correction_speed_accel_NE_m(float speed_ne_ms, float accel_ne_mss)
 {
@@ -573,14 +573,14 @@ void AC_PosControl::init_NE_controller()
     _last_update_ne_ticks = AP::scheduler().ticks32();
 }
 
-// Sets the desired NE-plane acceleration in cm/s² using jerk-limited shaping.
+// Sets the desired NE-plane acceleration in cm/s/s using jerk-limited shaping.
 // See input_accel_NE_m() for full details.
 void AC_PosControl::input_accel_NE_cm(const Vector3f& accel_neu_cmss)
 {
     input_accel_NE_m(accel_neu_cmss * 0.01);
 }
 
-// Sets the desired NE-plane acceleration in m/s² using jerk-limited shaping.
+// Sets the desired NE-plane acceleration in m/s/s using jerk-limited shaping.
 // Smoothly transitions to the specified acceleration from current kinematic state.
 // Constraints: max acceleration and jerk set via set_max_speed_accel_NE_m().
 void AC_PosControl::input_accel_NE_m(const Vector3f& accel_neu_mss)
@@ -589,7 +589,7 @@ void AC_PosControl::input_accel_NE_m(const Vector3f& accel_neu_mss)
     shape_accel_xy(accel_neu_mss.xy(), _accel_desired_neu_mss.xy(), _jerk_max_ne_msss, _dt_s);
 }
 
-// Sets desired NE-plane velocity and acceleration (cm/s, cm/s²) using jerk-limited shaping.
+// Sets desired NE-plane velocity and acceleration (cm/s, cm/s/s) using jerk-limited shaping.
 // See input_vel_accel_NE_m() for full details.
 void AC_PosControl::input_vel_accel_NE_cm(Vector2f& vel_ne_cms, const Vector2f& accel_ne_cmss, bool limit_output)
 {
@@ -598,7 +598,7 @@ void AC_PosControl::input_vel_accel_NE_cm(Vector2f& vel_ne_cms, const Vector2f& 
     vel_ne_cms = vel_ne_ms * 100.0;
 }
 
-// Sets desired NE-plane velocity and acceleration (m/s, m/s²) using jerk-limited shaping.
+// Sets desired NE-plane velocity and acceleration (m/s, m/s/s) using jerk-limited shaping.
 // Calculates target acceleration using current kinematics constrained by acceleration and jerk limits.
 // If `limit_output` is true, applies limits to total command (desired + correction).
 void AC_PosControl::input_vel_accel_NE_m(Vector2f& vel_ne_ms, const Vector2f& accel_ne_mss, bool limit_output)
@@ -611,7 +611,7 @@ void AC_PosControl::input_vel_accel_NE_m(Vector2f& vel_ne_ms, const Vector2f& ac
     update_vel_accel_xy(vel_ne_ms, accel_ne_mss, _dt_s, Vector2f(), Vector2f());
 }
 
-// Sets desired NE position, velocity, and acceleration (cm, cm/s, cm/s²) with jerk-limited shaping.
+// Sets desired NE position, velocity, and acceleration (cm, cm/s, cm/s/s) with jerk-limited shaping.
 // See input_pos_vel_accel_NE_m() for full details.
 void AC_PosControl::input_pos_vel_accel_NE_cm(Vector2p& pos_ne_cm, Vector2f& vel_ne_cms, const Vector2f& accel_ne_cmss, bool limit_output)
 {
@@ -622,7 +622,7 @@ void AC_PosControl::input_pos_vel_accel_NE_cm(Vector2p& pos_ne_cm, Vector2f& vel
     vel_ne_cms = vel_ne_ms * 100.0;
 }
 
-// Sets desired NE position, velocity, and acceleration (m, m/s, m/s²) with jerk-limited shaping.
+// Sets desired NE position, velocity, and acceleration (m, m/s, m/s/s) with jerk-limited shaping.
 // Calculates acceleration trajectory based on current kinematics and constraints.
 // If `limit_output` is true, limits apply to full command (desired + correction).
 void AC_PosControl::input_pos_vel_accel_NE_m(Vector2p& pos_ne_m, Vector2f& vel_ne_ms, const Vector2f& accel_ne_mss, bool limit_output)
@@ -780,7 +780,7 @@ void AC_PosControl::update_NE_controller()
 /// Vertical position controller
 ///
 
-// Sets maximum climb/descent rate (cm/s) and vertical acceleration (cm/s²) for the U-axis.
+// Sets maximum climb/descent rate (cm/s) and vertical acceleration (cm/s/s) for the U-axis.
 // Descent rate may be positive or negative and is always interpreted as a descent.
 // See set_max_speed_accel_U_m() for full details.
 void AC_PosControl::set_max_speed_accel_U_cm(float speed_down_cms, float speed_up_cms, float accel_cmss)
@@ -788,7 +788,7 @@ void AC_PosControl::set_max_speed_accel_U_cm(float speed_down_cms, float speed_u
     set_max_speed_accel_U_m(speed_down_cms * 0.01, speed_up_cms * 0.01, accel_cmss * 0.01);
 }
 
-// Sets maximum climb/descent rate (m/s) and vertical acceleration (m/s²) for the U-axis.
+// Sets maximum climb/descent rate (m/s) and vertical acceleration (m/s/s) for the U-axis.
 // These values are used for jerk-limited kinematic shaping of the vertical trajectory.
 void AC_PosControl::set_max_speed_accel_U_m(float speed_down_ms, float speed_up_ms, float accel_mss)
 {
@@ -816,7 +816,7 @@ void AC_PosControl::set_max_speed_accel_U_m(float speed_down_ms, float speed_up_
     }
 }
 
-// Sets vertical correction velocity and acceleration limits (cm/s, cm/s²).
+// Sets vertical correction velocity and acceleration limits (cm/s, cm/s/s).
 // Should only be called during initialization to avoid discontinuities.
 // See set_correction_speed_accel_U_mss() for full details.
 void AC_PosControl::set_correction_speed_accel_U_cmss(float speed_down_cms, float speed_up_cms, float accel_cmss)
@@ -824,7 +824,7 @@ void AC_PosControl::set_correction_speed_accel_U_cmss(float speed_down_cms, floa
     set_correction_speed_accel_U_mss(speed_down_cms * 0.01, speed_up_cms * 0.01, accel_cmss * 0.01);
 }
 
-// Sets vertical correction velocity and acceleration limits (m/s, m/s²).
+// Sets vertical correction velocity and acceleration limits (m/s, m/s/s).
 // These values constrain the correction output of the PID controller.
 void AC_PosControl::set_correction_speed_accel_U_mss(float speed_down_ms, float speed_up_ms, float accel_mss)
 {
@@ -916,14 +916,14 @@ void AC_PosControl::init_U_controller()
     _last_update_u_ticks = AP::scheduler().ticks32();
 }
 
-// Sets the desired vertical acceleration in cm/s² using jerk-limited shaping.
+// Sets the desired vertical acceleration in cm/s/s using jerk-limited shaping.
 // See input_accel_U_m() for full details.
 void AC_PosControl::input_accel_U_cm(float accel_cmss)
 {
     input_accel_U_m(accel_cmss * 0.01);
 }
 
-// Sets the desired vertical acceleration in m/s² using jerk-limited shaping.
+// Sets the desired vertical acceleration in m/s/s using jerk-limited shaping.
 // Smoothly transitions to the target acceleration from current kinematic state.
 // Constraints: max acceleration and jerk set via set_max_speed_accel_U_m().
 void AC_PosControl::input_accel_U_m(float accel_mss)
@@ -937,7 +937,7 @@ void AC_PosControl::input_accel_U_m(float accel_mss)
     shape_accel(accel_mss, _accel_desired_neu_mss.z, jerk_max_u_msss, _dt_s);
 }
 
-// Sets desired vertical velocity and acceleration (cm/s, cm/s²) using jerk-limited shaping.
+// Sets desired vertical velocity and acceleration (cm/s, cm/s/s) using jerk-limited shaping.
 // See input_vel_accel_U_m() for full details.
 void AC_PosControl::input_vel_accel_U_cm(float &vel_u_cms, float accel_cmss, bool limit_output)
 {
@@ -946,7 +946,7 @@ void AC_PosControl::input_vel_accel_U_cm(float &vel_u_cms, float accel_cmss, boo
     vel_u_cms = vel_u_ms * 100.0;
 }
 
-// Sets desired vertical velocity and acceleration (m/s, m/s²) using jerk-limited shaping.
+// Sets desired vertical velocity and acceleration (m/s, m/s/s) using jerk-limited shaping.
 // Calculates required acceleration using current vertical kinematics.
 // If `limit_output` is true, limits apply to the combined (desired + correction) command.
 void AC_PosControl::input_vel_accel_U_m(float &vel_u_ms, float accel_mss, bool limit_output)
@@ -1198,14 +1198,14 @@ float AC_PosControl::get_lean_angle_max_rad() const
     return radians(_lean_angle_max_deg);
 }
 
-// Sets externally computed NEU position, velocity, and acceleration in centimeters, cm/s, and cm/s².
+// Sets externally computed NEU position, velocity, and acceleration in centimeters, cm/s, and cm/s/s.
 // See set_pos_vel_accel_NEU_m() for full details.
 void AC_PosControl::set_pos_vel_accel_NEU_cm(const Vector3p& pos_neu_cm, const Vector3f& vel_neu_cms, const Vector3f& accel_neu_cmss)
 {
     set_pos_vel_accel_NEU_m(pos_neu_cm * 0.01, vel_neu_cms * 0.01, accel_neu_cmss * 0.01);
 }
 
-// Sets externally computed NEU position, velocity, and acceleration in meters, m/s, and m/s².
+// Sets externally computed NEU position, velocity, and acceleration in meters, m/s, and m/s/s.
 // Use when path planning or shaping is done outside this controller.
 void AC_PosControl::set_pos_vel_accel_NEU_m(const Vector3p& pos_neu_m, const Vector3f& vel_neu_ms, const Vector3f& accel_neu_mss)
 {
@@ -1214,14 +1214,14 @@ void AC_PosControl::set_pos_vel_accel_NEU_m(const Vector3p& pos_neu_m, const Vec
     _accel_desired_neu_mss = accel_neu_mss;
 }
 
-// Sets externally computed NE position, velocity, and acceleration in centimeters, cm/s, and cm/s².
+// Sets externally computed NE position, velocity, and acceleration in centimeters, cm/s, and cm/s/s.
 // See set_pos_vel_accel_NE_m() for full details.
 void AC_PosControl::set_pos_vel_accel_NE_cm(const Vector2p& pos_ne_cm, const Vector2f& vel_ne_cms, const Vector2f& accel_ne_cmss)
 {
     set_pos_vel_accel_NE_m(pos_ne_cm * 0.01, vel_ne_cms * 0.01, accel_ne_cmss * 0.01);
 }
 
-// Sets externally computed NE position, velocity, and acceleration in meters, m/s, and m/s².
+// Sets externally computed NE position, velocity, and acceleration in meters, m/s, and m/s/s.
 // Use when path planning or shaping is done outside this controller.
 void AC_PosControl::set_pos_vel_accel_NE_m(const Vector2p& pos_ne_m, const Vector2f& vel_ne_ms, const Vector2f& accel_ne_mss)
 {
@@ -1230,14 +1230,14 @@ void AC_PosControl::set_pos_vel_accel_NE_m(const Vector2p& pos_ne_m, const Vecto
     _accel_desired_neu_mss.xy() = accel_ne_mss;
 }
 
-// Converts lean angles (rad) to NEU acceleration in cm/s².
+// Converts lean angles (rad) to NEU acceleration in cm/s/s.
 // See lean_angles_rad_to_accel_NEU_mss() for full details.
 Vector3f AC_PosControl::lean_angles_rad_to_accel_NEU_cmss(const Vector3f& att_target_euler_rad) const
 {
     return lean_angles_rad_to_accel_NEU_mss(att_target_euler_rad) * 100.0;
 }
 
-// Converts lean angles (rad) to NEU acceleration in m/s².
+// Converts lean angles (rad) to NEU acceleration in m/s/s.
 Vector3f AC_PosControl::lean_angles_rad_to_accel_NEU_mss(const Vector3f& att_target_euler_rad) const
 {
     // rotate our roll, pitch angles into lat/lon frame
@@ -1373,7 +1373,7 @@ bool AC_PosControl::get_vel_target(Vector3f &vel_target_NED_ms)
     return true;
 }
 
-// Retrieves current target acceleration (NED frame, m/s²) including any scripted offset.
+// Retrieves current target acceleration (NED frame, m/s/s) including any scripted offset.
 // Used in LUA
 bool AC_PosControl::get_accel_target(Vector3f &accel_target_NED_mss)
 {
@@ -1388,7 +1388,7 @@ bool AC_PosControl::get_accel_target(Vector3f &accel_target_NED_mss)
 }
 #endif
 
-// Sets NE offset targets (position [cm], velocity [cm/s], acceleration [cm/s²]) from EKF origin.
+// Sets NE offset targets (position [cm], velocity [cm/s], acceleration [cm/s/s]) from EKF origin.
 // Offsets must be refreshed at least every 3 seconds to remain active.
 // See set_posvelaccel_offset_target_NE_m() for full details.
 void AC_PosControl::set_posvelaccel_offset_target_NE_cm(const Vector2p& pos_offset_target_ne_cm, const Vector2f& vel_offset_target_ne_cms, const Vector2f& accel_offset_target_ne_cmss)
@@ -1396,7 +1396,7 @@ void AC_PosControl::set_posvelaccel_offset_target_NE_cm(const Vector2p& pos_offs
     set_posvelaccel_offset_target_NE_m(pos_offset_target_ne_cm * 0.01, vel_offset_target_ne_cms * 0.01, accel_offset_target_ne_cmss * 0.01);
 }
 
-// Sets NE offset targets in meters, m/s, and m/s².
+// Sets NE offset targets in meters, m/s, and m/s/s.
 void AC_PosControl::set_posvelaccel_offset_target_NE_m(const Vector2p& pos_offset_target_ne_m, const Vector2f& vel_offset_target_ne_ms, const Vector2f& accel_offset_target_ne_mss)
 {
     // set position offset target
@@ -1412,14 +1412,14 @@ void AC_PosControl::set_posvelaccel_offset_target_NE_m(const Vector2p& pos_offse
     _posvelaccel_offset_target_ne_ms = AP_HAL::millis();
 }
 
-// Sets vertical offset targets (cm, cm/s, cm/s²) from EKF origin.
+// Sets vertical offset targets (cm, cm/s, cm/s/s) from EKF origin.
 // See set_posvelaccel_offset_target_U_m() for full details.
 void AC_PosControl::set_posvelaccel_offset_target_U_cm(float pos_offset_target_u_cm, float vel_offset_target_u_cms, const float accel_offset_target_u_cmss)
 {
     set_posvelaccel_offset_target_U_m(pos_offset_target_u_cm * 0.01, vel_offset_target_u_cms * 0.01, accel_offset_target_u_cmss * 0.01);
 }
 
-// Sets vertical offset targets (m, m/s, m/s²) from EKF origin.
+// Sets vertical offset targets (m, m/s, m/s/s) from EKF origin.
 void AC_PosControl::set_posvelaccel_offset_target_U_m(float pos_offset_target_u_m, float vel_offset_target_u_ms, const float accel_offset_target_u_mss)
 {
     // set position offset target
@@ -1696,7 +1696,7 @@ void AC_PosControl::update_terrain()
     // if we know how fast the terain altitude is changing we would add update_pos_vel_accel for _pos_terrain_target_u_m here
 }
 
-    // Converts horizontal acceleration (m/s²) to roll/pitch lean angles in radians.
+    // Converts horizontal acceleration (m/s/s) to roll/pitch lean angles in radians.
 void AC_PosControl::accel_NE_mss_to_lean_angles_rad(float accel_n_mss, float accel_e_mss, float& roll_target_rad, float& pitch_target_rad) const
 {
     // rotate accelerations into body forward-right frame
@@ -1709,7 +1709,7 @@ void AC_PosControl::accel_NE_mss_to_lean_angles_rad(float accel_n_mss, float acc
     roll_target_rad = accel_mss_to_angle_rad(accel_right_mss * cos_pitch_target);
 }
 
-// Converts current target lean angles to NE acceleration in m/s².
+// Converts current target lean angles to NE acceleration in m/s/s.
 void AC_PosControl::lean_angles_to_accel_NE_mss(float& accel_n_mss, float& accel_e_mss) const
 {
     // rotate our roll, pitch angles into lat/lon frame

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -16,8 +16,8 @@
 #include <AP_Logger/LogStructure.h>
 
 // position controller default definitions
-#define POSCONTROL_ACCEL_NE_MSS                 1.0f    // default horizontal acceleration in m/s². This is overwritten by waypoint and loiter controllers
-#define POSCONTROL_JERK_NE_MSSS                 5.0f    // default horizontal jerk m/s³
+#define POSCONTROL_ACCEL_NE_MSS                 1.0f    // default horizontal acceleration in m/s/s. This is overwritten by waypoint and loiter controllers
+#define POSCONTROL_JERK_NE_MSSS                 5.0f    // default horizontal jerk m/s/s/s
 
 #define POSCONTROL_STOPPING_DIST_UP_MAX_M       3.0f    // max stopping distance (in m) vertically while climbing
 #define POSCONTROL_STOPPING_DIST_DOWN_MAX_M     2.0f    // max stopping distance (in m) vertically while descending
@@ -26,8 +26,8 @@
 #define POSCONTROL_SPEED_DOWN_MS                -1.5f   // default descent rate in m/s
 #define POSCONTROL_SPEED_UP_MS                  2.5f    // default climb rate in m/s
 
-#define POSCONTROL_ACCEL_U_MSS                  2.5f    // default vertical acceleration in m/s²
-#define POSCONTROL_JERK_U_MSSS                  5.0f    // default vertical jerk m/s³
+#define POSCONTROL_ACCEL_U_MSS                  2.5f    // default vertical acceleration in m/s/s
+#define POSCONTROL_JERK_U_MSSS                  5.0f    // default vertical jerk m/s/s/s
 
 #define POSCONTROL_THROTTLE_CUTOFF_FREQ_HZ      2.0f    // low-pass filter on acceleration error (unit: Hz)
 
@@ -862,13 +862,13 @@ protected:
 
     // parameters
     AP_Float        _lean_angle_max_deg;    // Maximum autopilot commanded angle (in degrees). Set to zero for Angle Max
-    AP_Float        _shaping_jerk_ne_msss;  // Jerk limit of the ne kinematic path generation in m/s³ used to determine how quickly the aircraft varies the acceleration target
-    AP_Float        _shaping_jerk_u_msss;   // Jerk limit of the u kinematic path generation in m/s³ used to determine how quickly the aircraft varies the acceleration target
+    AP_Float        _shaping_jerk_ne_msss;  // Jerk limit of the ne kinematic path generation in m/s/s/s used to determine how quickly the aircraft varies the acceleration target
+    AP_Float        _shaping_jerk_u_msss;   // Jerk limit of the u kinematic path generation in m/s/s/s used to determine how quickly the aircraft varies the acceleration target
     AC_P_2D         _p_pos_ne_m;            // XY axis position controller to convert target distance (cm) to target velocity (cm/s)
     AC_P_1D         _p_pos_u_m;             // Z axis position controller to convert target altitude (cm) to target climb rate (cm/s)
-    AC_PID_2D       _pid_vel_ne_cm;         // XY axis velocity controller to convert target velocity (cm/s) to target acceleration (cm/s²)
-    AC_PID_Basic    _pid_vel_u_cm;          // Z axis velocity controller to convert target climb rate (cm/s) to target acceleration (cm/s²)
-    AC_PID          _pid_accel_u_cm_to_kt;  // Z axis acceleration controller to convert target acceleration (cm/s²) to throttle output (0 to 1000)
+    AC_PID_2D       _pid_vel_ne_cm;         // XY axis velocity controller to convert target velocity (cm/s) to target acceleration (cm/s/s)
+    AC_PID_Basic    _pid_vel_u_cm;          // Z axis velocity controller to convert target climb rate (cm/s) to target acceleration (cm/s/s)
+    AC_PID          _pid_accel_u_cm_to_kt;  // Z axis acceleration controller to convert target acceleration (cm/s/s) to throttle output (0 to 1000)
 
     // internal variables
     float       _dt_s;                     // time difference (in seconds) since the last loop time
@@ -877,10 +877,10 @@ protected:
     float       _vel_max_ne_ms;            // max horizontal speed in m/s used for kinematic shaping
     float       _vel_max_up_ms;            // max climb rate in m/s used for kinematic shaping
     float       _vel_max_down_ms;          // max descent rate in m/s used for kinematic shaping
-    float       _accel_max_ne_mss;         // max horizontal acceleration in m/s² used for kinematic shaping
-    float       _accel_max_u_mss;          // max vertical acceleration in m/s² used for kinematic shaping
-    float       _jerk_max_ne_msss;         // Jerk limit of the ne kinematic path generation in m/s³ used to determine how quickly the aircraft varies the acceleration target
-    float       _jerk_max_u_msss;          // Jerk limit of the z kinematic path generation in m/s³ used to determine how quickly the aircraft varies the acceleration target
+    float       _accel_max_ne_mss;         // max horizontal acceleration in m/s/s used for kinematic shaping
+    float       _accel_max_u_mss;          // max vertical acceleration in m/s/s used for kinematic shaping
+    float       _jerk_max_ne_msss;         // Jerk limit of the ne kinematic path generation in m/s/s/s used to determine how quickly the aircraft varies the acceleration target
+    float       _jerk_max_u_msss;          // Jerk limit of the z kinematic path generation in m/s/s/s used to determine how quickly the aircraft varies the acceleration target
     float       _vel_u_control_ratio = 2.0f;    // confidence that we have control in the vertical axis
     Vector2f    _disturb_pos_ne_m;         // position disturbance generated by system ID mode
     Vector2f    _disturb_vel_ne_ms;        // velocity disturbance generated by system ID mode
@@ -899,8 +899,8 @@ protected:
     Vector3f    _vel_estimate_neu_ms;
     Vector3f    _vel_desired_neu_ms;       // desired velocity in NEU m/s
     Vector3f    _vel_target_neu_ms;        // velocity target in NEU m/s calculated by pos_to_rate step
-    Vector3f    _accel_desired_neu_mss;    // desired acceleration in NEU m/s² (feed forward)
-    Vector3f    _accel_target_neu_mss;     // acceleration target in NEU m/s²
+    Vector3f    _accel_desired_neu_mss;    // desired acceleration in NEU m/s/s (feed forward)
+    Vector3f    _accel_target_neu_mss;     // acceleration target in NEU m/s/s
     // todo: seperate the limit vector into ne and u. ne is based on acceleration while u is set +-1 based on throttle saturation. Together they don't form a direction vector because the units are different.
     Vector3f    _limit_vector_neu;         // the direction that the position controller is limited, zero when not limited
 
@@ -908,15 +908,15 @@ protected:
     float    _pos_terrain_target_u_m;    // position terrain target in m relative to the EKF origin in NEU frame
     float    _pos_terrain_u_m;           // position terrain in m from the EKF origin in NEU frame. This terrain moves towards _pos_terrain_target_u_m
     float    _vel_terrain_u_ms;          // velocity terrain in NEU m/s calculated by pos_to_rate step. This terrain moves towards _vel_terrain_target
-    float    _accel_terrain_u_mss;       // acceleration terrain in NEU m/s²
+    float    _accel_terrain_u_mss;       // acceleration terrain in NEU m/s/s
 
     // offset handling variables
     Vector3p    _pos_offset_target_neu_m;      // position offset target in m relative to the EKF origin in NEU frame
     Vector3p    _pos_offset_neu_m;             // position offset in m from the EKF origin in NEU frame. This offset moves towards _pos_offset_target_neu_m
     Vector3f    _vel_offset_target_neu_ms;     // velocity offset target in m/s in NEU frame
     Vector3f    _vel_offset_neu_ms;            // velocity offset in NEU m/s calculated by pos_to_rate step. This offset moves towards _vel_offset_target_neu_ms
-    Vector3f    _accel_offset_target_neu_mss;  // acceleration offset target in m/s² in NEU frame
-    Vector3f    _accel_offset_neu_mss;         // acceleration offset in NEU m/s²
+    Vector3f    _accel_offset_target_neu_mss;  // acceleration offset target in m/s/s in NEU frame
+    Vector3f    _accel_offset_neu_mss;         // acceleration offset in NEU m/s/s
     uint32_t    _posvelaccel_offset_target_ne_ms;   // system time that pos, vel, accel targets were set (used to implement timeouts)
     uint32_t    _posvelaccel_offset_target_u_ms;    // system time that pos, vel, accel targets were set (used to implement timeouts)
 

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -57,11 +57,11 @@ public:
     // When high_vibes is true, forces use of vertical fallback for velocity.
     void update_estimates(bool high_vibes = false);
 
-    // Returns the jerk limit for horizontal path shaping in cm/s³.
+    // Returns the jerk limit for horizontal path shaping in cm/s/s/s.
     // See get_shaping_jerk_NE_msss() for full details.
     float get_shaping_jerk_NE_cmsss() const { return get_shaping_jerk_NE_msss() * 100.0; }
 
-    // Returns the jerk limit for horizontal path shaping in m/s³.
+    // Returns the jerk limit for horizontal path shaping in m/s/s/s.
     // Used to constrain acceleration changes in trajectory generation.
     float get_shaping_jerk_NE_msss() const { return _shaping_jerk_ne_msss; }
 
@@ -93,21 +93,21 @@ public:
     /// Lateral position controller
     ///
 
-    // Sets maximum horizontal speed (cm/s) and acceleration (cm/s²) for NE-axis shaping.
+    // Sets maximum horizontal speed (cm/s) and acceleration (cm/s/s) for NE-axis shaping.
     // Can be called anytime; transitions are handled smoothly.
     // See set_max_speed_accel_NE_m() for full details.
     void set_max_speed_accel_NE_cm(float speed_cms, float accel_cmss);
 
-    // Sets maximum horizontal speed (m/s) and acceleration (m/s²) for NE-axis shaping.
+    // Sets maximum horizontal speed (m/s) and acceleration (m/s/s) for NE-axis shaping.
     // These values constrain the kinematic trajectory used by the lateral controller.
     void set_max_speed_accel_NE_m(float speed_ms, float accel_mss);
 
-    // Sets horizontal correction limits for velocity (cm/s) and acceleration (cm/s²).
+    // Sets horizontal correction limits for velocity (cm/s) and acceleration (cm/s/s).
     // Should be called only during initialization to avoid control discontinuities.
     // See set_correction_speed_accel_NE_m() for full details.
     void set_correction_speed_accel_NE_cm(float speed_cms, float accel_cmss);
 
-    // Sets horizontal correction limits for velocity (m/s) and acceleration (m/s²).
+    // Sets horizontal correction limits for velocity (m/s) and acceleration (m/s/s).
     // These values constrain the PID correction path, not the desired trajectory.
     void set_correction_speed_accel_NE_m(float speed_ms, float accel_mss);
 
@@ -118,11 +118,11 @@ public:
     // Returns maximum horizontal speed in m/s used for shaping the trajectory.
     float get_max_speed_NE_ms() const { return _vel_max_ne_ms; }
 
-    // Returns maximum horizontal acceleration in cm/s².
+    // Returns maximum horizontal acceleration in cm/s/s.
     // See get_max_accel_NE_mss() for full details.
     float get_max_accel_NE_cmss() const { return get_max_accel_NE_mss() * 100.0; }
 
-    // Returns maximum horizontal acceleration in m/s² used for trajectory shaping.
+    // Returns maximum horizontal acceleration in m/s/s used for trajectory shaping.
     float get_max_accel_NE_mss() const { return _accel_max_ne_mss; }
 
     // Sets maximum allowed horizontal position error in cm.
@@ -158,29 +158,29 @@ public:
     // Private function shared by other NE initializers.
     void init_NE_controller();
 
-    // Sets the desired NE-plane acceleration in cm/s² using jerk-limited shaping.
+    // Sets the desired NE-plane acceleration in cm/s/s using jerk-limited shaping.
     // See input_accel_NE_m() for full details.
     void input_accel_NE_cm(const Vector3f& accel_neu_cmsss);
 
-    // Sets the desired NE-plane acceleration in m/s² using jerk-limited shaping.
+    // Sets the desired NE-plane acceleration in m/s/s using jerk-limited shaping.
     // Smoothly transitions to the specified acceleration from current kinematic state.
     // Constraints: max acceleration and jerk set via set_max_speed_accel_NE_m().
     void input_accel_NE_m(const Vector3f& accel_neu_msss);
 
-    // Sets desired NE-plane velocity and acceleration (cm/s, cm/s²) using jerk-limited shaping.
+    // Sets desired NE-plane velocity and acceleration (cm/s, cm/s/s) using jerk-limited shaping.
     // See input_vel_accel_NE_m() for full details.
     void input_vel_accel_NE_cm(Vector2f& vel_ne_cms, const Vector2f& accel_ne_cmss, bool limit_output = true);
 
-    // Sets desired NE-plane velocity and acceleration (m/s, m/s²) using jerk-limited shaping.
+    // Sets desired NE-plane velocity and acceleration (m/s, m/s/s) using jerk-limited shaping.
     // Calculates target acceleration using current kinematics constrained by acceleration and jerk limits.
     // If `limit_output` is true, applies limits to total command (desired + correction).
     void input_vel_accel_NE_m(Vector2f& vel_ne_ms, const Vector2f& accel_ne_mss, bool limit_output = true);
 
-    // Sets desired NE position, velocity, and acceleration (cm, cm/s, cm/s²) with jerk-limited shaping.
+    // Sets desired NE position, velocity, and acceleration (cm, cm/s, cm/s/s) with jerk-limited shaping.
     // See input_pos_vel_accel_NE_m() for full details.
     void input_pos_vel_accel_NE_cm(Vector2p& pos_ne_cm, Vector2f& vel_ne_cms, const Vector2f& accel_ne_cmss, bool limit_output = true);
 
-    // Sets desired NE position, velocity, and acceleration (m, m/s, m/s²) with jerk-limited shaping.
+    // Sets desired NE position, velocity, and acceleration (m, m/s, m/s/s) with jerk-limited shaping.
     // Calculates acceleration trajectory based on current kinematics and constraints.
     // If `limit_output` is true, limits apply to full command (desired + correction).
     void input_pos_vel_accel_NE_m(Vector2p& pos_ne_m, Vector2f& vel_ne_ms, const Vector2f& accel_ne_mss, bool limit_output = true);
@@ -211,29 +211,29 @@ public:
     /// Vertical position controller
     ///
 
-    // Sets maximum climb/descent rate (cm/s) and vertical acceleration (cm/s²) for the U-axis.
+    // Sets maximum climb/descent rate (cm/s) and vertical acceleration (cm/s/s) for the U-axis.
     // Descent rate may be positive or negative and is always interpreted as a descent.
     // See set_max_speed_accel_U_m() for full details.
     void set_max_speed_accel_U_cm(float speed_down_cms, float speed_up_cms, float accel_cmss);
 
-    // Sets maximum climb/descent rate (m/s) and vertical acceleration (m/s²) for the U-axis.
+    // Sets maximum climb/descent rate (m/s) and vertical acceleration (m/s/s) for the U-axis.
     // These values are used for jerk-limited kinematic shaping of the vertical trajectory.
     void set_max_speed_accel_U_m(float speed_down_ms, float speed_up_ms, float accel_mss);
 
-    // Sets vertical correction velocity and acceleration limits (cm/s, cm/s²).
+    // Sets vertical correction velocity and acceleration limits (cm/s, cm/s/s).
     // Should only be called during initialization to avoid discontinuities.
     // See set_correction_speed_accel_U_mss() for full details.
     void set_correction_speed_accel_U_cmss(float speed_down_cms, float speed_up_cms, float accel_cmss);
 
-    // Sets vertical correction velocity and acceleration limits (m/s, m/s²).
+    // Sets vertical correction velocity and acceleration limits (m/s, m/s/s).
     // These values constrain the correction output of the PID controller.
     void set_correction_speed_accel_U_mss(float speed_down_ms, float speed_up_ms, float accel_mss);
 
-    // Returns maximum vertical acceleration in cm/s².
+    // Returns maximum vertical acceleration in cm/s/s.
     // See get_max_accel_U_mss() for full details.
     float get_max_accel_U_cmss() const { return get_max_accel_U_mss() * 100.0; }
 
-    // Returns maximum vertical acceleration in m/s² used for shaping the climb/descent trajectory.
+    // Returns maximum vertical acceleration in m/s/s used for shaping the climb/descent trajectory.
     float get_max_accel_U_mss() const { return _accel_max_u_mss; }
 
     // Returns maximum allowed positive (upward) position error in cm.
@@ -283,20 +283,20 @@ public:
     // Private function shared by other vertical initializers.
     void init_U_controller();
 
-    // Sets the desired vertical acceleration in cm/s² using jerk-limited shaping.
+    // Sets the desired vertical acceleration in cm/s/s using jerk-limited shaping.
     // See input_accel_U_m() for full details.
     virtual void input_accel_U_cm(float accel_u_cmss);
 
-    // Sets the desired vertical acceleration in m/s² using jerk-limited shaping.
+    // Sets the desired vertical acceleration in m/s/s using jerk-limited shaping.
     // Smoothly transitions to the target acceleration from current kinematic state.
     // Constraints: max acceleration and jerk set via set_max_speed_accel_U_m().
     void input_accel_U_m(float accel_u_mss);
 
-    // Sets desired vertical velocity and acceleration (cm/s, cm/s²) using jerk-limited shaping.
+    // Sets desired vertical velocity and acceleration (cm/s, cm/s/s) using jerk-limited shaping.
     // See input_vel_accel_U_m() for full details.
     void input_vel_accel_U_cm(float &vel_u_cms, float accel_u_cmss, bool limit_output = true);
 
-    // Sets desired vertical velocity and acceleration (m/s, m/s²) using jerk-limited shaping.
+    // Sets desired vertical velocity and acceleration (m/s, m/s/s) using jerk-limited shaping.
     // Calculates required acceleration using current vertical kinematics.
     // If `limit_output` is true, limits apply to the combined (desired + correction) command.
     void input_vel_accel_U_m(float &vel_u_ms, float accel_u_mss, bool limit_output = true);
@@ -350,19 +350,19 @@ public:
     /// Accessors
     ///
 
-    // Sets externally computed NEU position, velocity, and acceleration in centimeters, cm/s, and cm/s².
+    // Sets externally computed NEU position, velocity, and acceleration in centimeters, cm/s, and cm/s/s.
     // See set_pos_vel_accel_NEU_m() for full details.
     void set_pos_vel_accel_NEU_cm(const Vector3p& pos_neu_cm, const Vector3f& vel_neu_cms, const Vector3f& accel_neu_cmss);
 
-    // Sets externally computed NEU position, velocity, and acceleration in meters, m/s, and m/s².
+    // Sets externally computed NEU position, velocity, and acceleration in meters, m/s, and m/s/s.
     // Use when path planning or shaping is done outside this controller.
     void set_pos_vel_accel_NEU_m(const Vector3p& pos_neu_m, const Vector3f& vel_neu_ms, const Vector3f& accel_neu_mss);
 
-    // Sets externally computed NE position, velocity, and acceleration in centimeters, cm/s, and cm/s².
+    // Sets externally computed NE position, velocity, and acceleration in centimeters, cm/s, and cm/s/s.
     // See set_pos_vel_accel_NE_m() for full details.
     void set_pos_vel_accel_NE_cm(const Vector2p& pos_ne_cm, const Vector2f& vel_ne_cms, const Vector2f& accel_ne_cmss);
 
-    // Sets externally computed NE position, velocity, and acceleration in meters, m/s, and m/s².
+    // Sets externally computed NE position, velocity, and acceleration in meters, m/s, and m/s/s.
     // Use when path planning or shaping is done outside this controller.
     void set_pos_vel_accel_NE_m(const Vector2p& pos_ne_m, const Vector2f& vel_ne_ms, const Vector2f& accel_ne_mss);
 
@@ -514,18 +514,18 @@ public:
 
     /// Acceleration
 
-    // Sets desired horizontal acceleration in cm/s².
+    // Sets desired horizontal acceleration in cm/s/s.
     // See set_accel_desired_NE_mss() for full details.
     void set_accel_desired_NE_cmss(const Vector2f &accel_desired_neu_cmss) { set_accel_desired_NE_mss(accel_desired_neu_cmss * 0.01); }
 
-    // Sets desired horizontal acceleration in m/s².
+    // Sets desired horizontal acceleration in m/s/s.
     void set_accel_desired_NE_mss(const Vector2f &accel_desired_neu_mss) { _accel_desired_neu_mss.xy() = accel_desired_neu_mss; }
 
-    // Returns target NEU acceleration in cm/s².
+    // Returns target NEU acceleration in cm/s/s.
     // See get_accel_target_NEU_mss() for full details.
     const Vector3f get_accel_target_NEU_cmss() const { return get_accel_target_NEU_mss() * 100.0; }
 
-    // Returns target NEU acceleration in m/s².
+    // Returns target NEU acceleration in m/s/s.
     const Vector3f& get_accel_target_NEU_mss() const { return _accel_target_neu_mss; }
 
 
@@ -570,24 +570,24 @@ public:
     // Used in LUA
     bool get_vel_target(Vector3f &vel_target_NED_ms);
 
-    // Retrieves current target acceleration (NED frame, m/s²) including any scripted offset.
+    // Retrieves current target acceleration (NED frame, m/s/s) including any scripted offset.
     // Used in LUA
     bool get_accel_target(Vector3f &accel_target_NED_mss);
 #endif
 
-    // Sets NE offset targets (position [cm], velocity [cm/s], acceleration [cm/s²]) from EKF origin.
+    // Sets NE offset targets (position [cm], velocity [cm/s], acceleration [cm/s/s]) from EKF origin.
     // Offsets must be refreshed at least every 3 seconds to remain active.
     // See set_posvelaccel_offset_target_NE_m() for full details.
     void set_posvelaccel_offset_target_NE_cm(const Vector2p& pos_offset_target_ne_cm, const Vector2f& vel_offset_target_ne_cms, const Vector2f& accel_offset_target_ne_cmss);
 
-    // Sets NE offset targets in meters, m/s, and m/s².
+    // Sets NE offset targets in meters, m/s, and m/s/s.
     void set_posvelaccel_offset_target_NE_m(const Vector2p& pos_offset_target_ne_m, const Vector2f& vel_offset_target_ne_ms, const Vector2f& accel_offset_target_ne_mss);
 
-    // Sets vertical offset targets (cm, cm/s, cm/s²) from EKF origin.
+    // Sets vertical offset targets (cm, cm/s, cm/s/s) from EKF origin.
     // See set_posvelaccel_offset_target_U_m() for full details.
     void set_posvelaccel_offset_target_U_cm(float pos_offset_target_u_cm, float vel_offset_target_u_cms, float accel_offset_target_u_cmss);
 
-    // Sets vertical offset targets (m, m/s, m/s²) from EKF origin.
+    // Sets vertical offset targets (m, m/s, m/s/s) from EKF origin.
     void set_posvelaccel_offset_target_U_m(float pos_offset_target_u_m, float vel_offset_target_u_ms, float accel_offset_target_u_mss);
 
     // Returns current NEU position offset in cm.
@@ -604,11 +604,11 @@ public:
     // Returns current NEU velocity offset in m/s.
     const Vector3f& get_vel_offset_NEU_ms() const { return _vel_offset_neu_ms; }
 
-    // Returns current NEU acceleration offset in cm/s².
+    // Returns current NEU acceleration offset in cm/s/s.
     // See get_accel_offset_NEU_mss() for full details.
     const Vector3f get_accel_offset_NEU_cmss() const { return get_accel_offset_NEU_mss() * 100.0; }
 
-    // Returns current NEU acceleration offset in m/s².
+    // Returns current NEU acceleration offset in m/s/s.
     const Vector3f& get_accel_offset_NEU_mss() const { return _accel_offset_neu_mss; }
 
     // Sets vertical position offset in meters above EKF origin.
@@ -628,11 +628,11 @@ public:
     // Returns vertical velocity offset in m/s.
     float get_vel_offset_U_ms() const { return _vel_offset_neu_ms.z; }
 
-    // Returns vertical acceleration offset in cm/s².
+    // Returns vertical acceleration offset in cm/s/s.
     // See get_accel_offset_U_mss() for full details.
     float get_accel_offset_U_cmss() const { return get_accel_offset_U_mss() * 100.0; }
 
-    // Returns vertical acceleration offset in m/s².
+    // Returns vertical acceleration offset in m/s/s.
     float get_accel_offset_U_mss() const { return _accel_offset_neu_mss.z; }
 
     /// Outputs
@@ -708,11 +708,11 @@ public:
     // Prevents I-term windup by storing the current target direction.
     void set_externally_limited_NE() { _limit_vector_neu.x = _accel_target_neu_mss.x; _limit_vector_neu.y = _accel_target_neu_mss.y; }
 
-    // Converts lean angles (rad) to NEU acceleration in cm/s².
+    // Converts lean angles (rad) to NEU acceleration in cm/s/s.
     // See lean_angles_rad_to_accel_NEU_mss() for full details.
     Vector3f lean_angles_rad_to_accel_NEU_cmss(const Vector3f& att_target_euler_rad) const;
 
-    // Converts lean angles (rad) to NEU acceleration in m/s².
+    // Converts lean angles (rad) to NEU acceleration in m/s/s.
     Vector3f lean_angles_rad_to_accel_NEU_mss(const Vector3f& att_target_euler_rad) const;
 
     // Writes position controller diagnostic logs (PSCN, PSCE, etc).
@@ -740,11 +740,11 @@ public:
     // Zeros I-terms and aligns targets to current position.
     void standby_NEU_reset();
 
-    // Returns measured vertical (Up) acceleration in cm/s² (Earth frame, gravity-compensated).
+    // Returns measured vertical (Up) acceleration in cm/s/s (Earth frame, gravity-compensated).
     // See get_measured_accel_U_mss() for full details.
     float get_measured_accel_U_cmss() const { return get_measured_accel_U_mss() * 100.0; }
 
-    // Returns measured vertical (Up) acceleration in m/s² (Earth frame, gravity-compensated).
+    // Returns measured vertical (Up) acceleration in m/s/s (Earth frame, gravity-compensated).
     // Positive = upward acceleration.
     float get_measured_accel_U_mss() const { return -(_ahrs.get_accel_ef().z + GRAVITY_MSS); }
 
@@ -768,31 +768,31 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
     // Logs position controller state along the North axis to PSCN..
-    // Logs desired, target, and actual position [m], velocity [m/s], and acceleration [m/s²].
+    // Logs desired, target, and actual position [m], velocity [m/s], and acceleration [m/s/s].
     static void Write_PSCN(float pos_desired_m, float pos_target_m, float pos_m, float vel_desired_ms, float vel_target_ms, float vel_ms, float accel_desired_mss, float accel_target_mss, float accel_mss);
 
     // Logs position controller state along the East axis to PSCE.
-    // Logs desired, target, and actual values for position [m], velocity [m/s], and acceleration [m/s²].
+    // Logs desired, target, and actual values for position [m], velocity [m/s], and acceleration [m/s/s].
     static void Write_PSCE(float pos_desired_m, float pos_target_m, float pos_m, float vel_desired_ms, float vel_target_ms, float vel_ms, float accel_desired_mss, float accel_target_mss, float accel_mss);
 
     // Logs position controller state along the Down (vertical) axis to PSCD.
-    // Logs desired, target, and actual values for position [m], velocity [m/s], and acceleration [m/s²].
+    // Logs desired, target, and actual values for position [m], velocity [m/s], and acceleration [m/s/s].
     static void Write_PSCD(float pos_desired_m, float pos_target_m, float pos_m, float vel_desired_ms, float vel_target_ms, float vel_ms, float accel_desired_mss, float accel_target_mss, float accel_mss);
 
     // Logs offset tracking along the North axis to PSON.
-    // Logs target and actual offset for position [m], velocity [m/s], and acceleration [m/s²].
+    // Logs target and actual offset for position [m], velocity [m/s], and acceleration [m/s/s].
     static void Write_PSON(float pos_target_offset_m, float pos_offset_m, float vel_target_offset_ms, float vel_offset_ms, float accel_target_offset_mss, float accel_offset_mss);
 
     // Logs offset tracking along the East axis to PSOE.
-    // Logs target and actual offset for position [m], velocity [m/s], and acceleration [m/s²].
+    // Logs target and actual offset for position [m], velocity [m/s], and acceleration [m/s/s].
     static void Write_PSOE(float pos_target_offset_m, float pos_offset_m, float vel_target_offset_ms, float vel_offset_ms, float accel_target_offset_mss, float accel_offset_mss);
 
     // Logs offset tracking along the Down axis to PSOD.
-    // Logs target and actual offset for position [m], velocity [m/s], and acceleration [m/s²].
+    // Logs target and actual offset for position [m], velocity [m/s], and acceleration [m/s/s].
     static void Write_PSOD(float pos_target_offset_m, float pos_offset_m, float vel_target_offset_ms, float vel_offset_ms, float accel_target_offset_mss, float accel_offset_mss);
 
     // Logs terrain-following offset tracking along the Down axis to PSOT.
-    // Logs target and actual offset for position [m], velocity [m/s], and acceleration [m/s²].
+    // Logs target and actual offset for position [m], velocity [m/s], and acceleration [m/s/s].
     static void Write_PSOT(float pos_target_offset_m, float pos_offset_m, float vel_target_offset_ms, float vel_offset_ms, float accel_target_offset_mss, float accel_offset_mss);
 
 
@@ -806,10 +806,10 @@ protected:
     // Integrator is adjusted using velocity error when PID is being overridden.
     float get_throttle_with_vibration_override();
 
-    // Converts horizontal acceleration (m/s²) to roll/pitch lean angles in radians.
+    // Converts horizontal acceleration (m/s/s) to roll/pitch lean angles in radians.
     void accel_NE_mss_to_lean_angles_rad(float accel_n_mss, float accel_e_mss, float& roll_target_rad, float& pitch_target_rad) const;
 
-    // Converts current target lean angles to NE acceleration in m/s².
+    // Converts current target lean angles to NE acceleration in m/s/s.
     void lean_angles_to_accel_NE_mss(float& accel_n_mss, float& accel_e_mss) const;
 
     // Computes desired yaw and yaw rate based on the NE acceleration and velocity vectors.

--- a/libraries/AC_AttitudeControl/AC_PosControl_Logging.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl_Logging.cpp
@@ -29,21 +29,21 @@ void AC_PosControl::Write_PSCx(LogMessages id, float pos_desired_m, float pos_ta
 }
 
 // Logs position controller state along the North axis to PSCN..
-// Logs desired, target, and actual position [m], velocity [m/s], and acceleration [m/s²].
+// Logs desired, target, and actual position [m], velocity [m/s], and acceleration [m/s/s].
 void AC_PosControl::Write_PSCN(float pos_desired_m, float pos_target_m, float pos_m, float vel_desired_ms, float vel_target_ms, float vel_ms, float accel_desired_mss, float accel_target_mss, float accel_mss)
 {
     Write_PSCx(LOG_PSCN_MSG, pos_desired_m, pos_target_m, pos_m, vel_desired_ms, vel_target_ms, vel_ms, accel_desired_mss, accel_target_mss, accel_mss);
 }
 
 // Logs position controller state along the East axis to PSCE.
-// Logs desired, target, and actual values for position [m], velocity [m/s], and acceleration [m/s²].
+// Logs desired, target, and actual values for position [m], velocity [m/s], and acceleration [m/s/s].
 void AC_PosControl::Write_PSCE(float pos_desired_m, float pos_target_m, float pos_m, float vel_desired_ms, float vel_target_ms, float vel_ms, float accel_desired_mss, float accel_target_mss, float accel_mss)
 {
     Write_PSCx(LOG_PSCE_MSG, pos_desired_m, pos_target_m, pos_m, vel_desired_ms, vel_target_ms, vel_ms, accel_desired_mss, accel_target_mss, accel_mss);
 }
 
 // Logs position controller state along the Down (vertical) axis to PSCD.
-// Logs desired, target, and actual values for position [m], velocity [m/s], and acceleration [m/s²].
+// Logs desired, target, and actual values for position [m], velocity [m/s], and acceleration [m/s/s].
 void AC_PosControl::Write_PSCD(float pos_desired_m, float pos_target_m, float pos_m, float vel_desired_ms, float vel_target_ms, float vel_ms, float accel_desired_mss, float accel_target_mss, float accel_mss)
 {
     Write_PSCx(LOG_PSCD_MSG, pos_desired_m, pos_target_m, pos_m, vel_desired_ms, vel_target_ms, vel_ms, accel_desired_mss, accel_target_mss, accel_mss);
@@ -70,7 +70,7 @@ void AC_PosControl::Write_PSOx(LogMessages id, float pos_target_offset_m, float 
 }
 
 // Logs offset tracking along the North axis to PSON.
-// Logs target and actual offset for position [m], velocity [m/s], and acceleration [m/s²].
+// Logs target and actual offset for position [m], velocity [m/s], and acceleration [m/s/s].
 void AC_PosControl::Write_PSON(float pos_target_offset_m, float pos_offset_m,
                                float vel_target_offset_ms, float vel_offset_ms,
                                float accel_target_offset_mss, float accel_offset_mss)
@@ -79,7 +79,7 @@ void AC_PosControl::Write_PSON(float pos_target_offset_m, float pos_offset_m,
 }
 
 // Logs offset tracking along the East axis to PSOE.
-// Logs target and actual offset for position [m], velocity [m/s], and acceleration [m/s²].
+// Logs target and actual offset for position [m], velocity [m/s], and acceleration [m/s/s].
 void AC_PosControl::Write_PSOE(float pos_target_offset_m, float pos_offset_m,
                                float vel_target_offset_ms, float vel_offset_ms,
                                float accel_target_offset_mss, float accel_offset_mss)
@@ -88,7 +88,7 @@ void AC_PosControl::Write_PSOE(float pos_target_offset_m, float pos_offset_m,
 }
 
 // Logs offset tracking along the Down axis to PSOD.
-// Logs target and actual offset for position [m], velocity [m/s], and acceleration [m/s²].
+// Logs target and actual offset for position [m], velocity [m/s], and acceleration [m/s/s].
 void AC_PosControl::Write_PSOD(float pos_target_offset_m, float pos_offset_m,
                                float vel_target_offset_ms, float vel_offset_ms,
                                float accel_target_offset_mss, float accel_offset_mss)
@@ -97,7 +97,7 @@ void AC_PosControl::Write_PSOD(float pos_target_offset_m, float pos_offset_m,
 }
 
 // Logs terrain-following offset tracking along the Down axis to PSOT.
-// Logs target and actual offset for position [m], velocity [m/s], and acceleration [m/s²].
+// Logs target and actual offset for position [m], velocity [m/s], and acceleration [m/s/s].
 void AC_PosControl::Write_PSOT(float pos_target_offset_m, float pos_offset_m,
                                float vel_target_offset_ms, float vel_offset_ms,
                                float accel_target_offset_mss, float accel_offset_mss)

--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -227,7 +227,7 @@ private:
     float    _angle_total_rad;          // Accumulated angle travelled in radians (used for full rotations).
     float    _angular_vel_rads;         // Current angular velocity in rad/s.
     float    _angular_vel_max_rads;     // Maximum allowed angular velocity in rad/s.
-    float    _angular_accel_radss;      // Angular acceleration limit in rad/s².
+    float    _angular_accel_radss;      // Angular acceleration limit in rad/s/s.
     uint32_t _last_update_ms;           // Timestamp (in milliseconds) of the last update() call.
     float    _last_radius_param_cm;     // Cached copy of radius parameter (cm) to detect parameter changes.
 

--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -8,7 +8,7 @@
 // Circle mode default and limit constants
 #define AC_CIRCLE_RADIUS_DEFAULT     1000.0f   // Default circle radius in cm (10 meters).
 #define AC_CIRCLE_RATE_DEFAULT       20.0f     // Default circle turn rate in degrees per second. Positive = clockwise, negative = counter-clockwise.
-#define AC_CIRCLE_ANGULAR_ACCEL_MIN  2.0f      // Minimum angular acceleration in deg/s² (used to avoid sluggish yaw transitions).
+#define AC_CIRCLE_ANGULAR_ACCEL_MIN  2.0f      // Minimum angular acceleration in deg/s/s (used to avoid sluggish yaw transitions).
 #define AC_CIRCLE_RADIUS_MAX_M       2000.0    // Maximum allowed circle radius in meters (2000 m = 2 km).
 
 class AC_Circle

--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -123,7 +123,7 @@ void AC_Loiter::init_target()
 {
     sanity_check_params();
 
-    // Configure correction speed and acceleration limits (in m/s and m/s²)
+    // Configure correction speed and acceleration limits (in m/s and m/s/s)
     _pos_control.set_correction_speed_accel_NE_m(LOITER_VEL_CORRECTION_MAX_MS, _accel_max_ne_cmss * 0.01);
     _pos_control.set_pos_error_max_NE_m(LOITER_POS_CORRECTION_MAX_M);
 
@@ -262,7 +262,7 @@ void AC_Loiter::sanity_check_params()
     // Enforce minimum loiter speed
     _speed_max_ne_cms.set(MAX(_speed_max_ne_cms, LOITER_SPEED_MIN_CMS));
 
-    // Clamp horizontal accel to lean-angle-limited max (converted to cm/s²)
+    // Clamp horizontal accel to lean-angle-limited max (converted to cm/s/s)
     _accel_max_ne_cmss.set(MIN(_accel_max_ne_cmss, GRAVITY_MSS * 100.0f * tanf(_attitude_control.lean_angle_max_rad())));
 }
 

--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -7,9 +7,9 @@ extern const AP_HAL::HAL& hal;
 
 #define LOITER_SPEED_DEFAULT_CM             1250.0  // Default horizontal loiter speed in cm/s.
 #define LOITER_SPEED_MIN_CMS                20.0    // Minimum allowed horizontal loiter speed in cm/s.
-#define LOITER_ACCEL_MAX_DEFAULT_CMSS       500.0   // Default maximum horizontal acceleration in loiter mode (cm/s²).
-#define LOITER_BRAKE_ACCEL_DEFAULT_CMSS     250.0   // Default maximum braking acceleration when sticks are released (cm/s²).
-#define LOITER_BRAKE_JERK_DEFAULT_CMSSS     500.0   // Default maximum jerk applied during braking transitions (cm/s³).
+#define LOITER_ACCEL_MAX_DEFAULT_CMSS       500.0   // Default maximum horizontal acceleration in loiter mode (cm/s/s).
+#define LOITER_BRAKE_ACCEL_DEFAULT_CMSS     250.0   // Default maximum braking acceleration when sticks are released (cm/s/s).
+#define LOITER_BRAKE_JERK_DEFAULT_CMSSS     500.0   // Default maximum jerk applied during braking transitions (cm/s/s/s).
 #define LOITER_BRAKE_START_DELAY_DEFAULT_S  1.0     // Delay (in seconds) before braking begins after sticks are released.
 #define LOITER_VEL_CORRECTION_MAX_MS        2.0     // Maximum speed (in m/s) used for correcting position errors in loiter.
 #define LOITER_POS_CORRECTION_MAX_M         2.0     // Maximum horizontal position error allowed before correction (m).

--- a/libraries/AC_WPNav/AC_Loiter.h
+++ b/libraries/AC_WPNav/AC_Loiter.h
@@ -134,16 +134,16 @@ protected:
     // parameters
     AP_Float    _angle_max_deg;         // Maximum pilot-commanded lean angle in degrees. Set to zero to default to 2/3 of PSC_ANGLE_MAX (or Q_ANGLE_MAX for QuadPlane).
     AP_Float    _speed_max_ne_cms;      // Maximum horizontal speed in cm/s while in loiter mode. Used to limit both user and internal trajectory velocities.
-    AP_Float    _accel_max_ne_cmss;     // Maximum horizontal acceleration (in cm/s²) applied during normal loiter corrections.
-    AP_Float    _brake_accel_max_cmss;  // Maximum braking acceleration (in cm/s²) applied when pilot sticks are released.
-    AP_Float    _brake_jerk_max_cmsss;  // Maximum braking jerk (in cm/s³) applied during braking transitions after pilot release.
+    AP_Float    _accel_max_ne_cmss;     // Maximum horizontal acceleration (in cm/s/s) applied during normal loiter corrections.
+    AP_Float    _brake_accel_max_cmss;  // Maximum braking acceleration (in cm/s/s) applied when pilot sticks are released.
+    AP_Float    _brake_jerk_max_cmsss;  // Maximum braking jerk (in cm/s/s/s) applied during braking transitions after pilot release.
     AP_Float    _brake_delay_s;         // Delay in seconds before braking begins after sticks are centered. Prevents premature deceleration during brief pauses.
 
     // loiter controller internal variables
-    Vector2f    _desired_accel_ne_mss;      // Pilot-requested horizontal acceleration in m/s² (after smoothing), in the NE (horizontal) frame.
-    Vector2f    _predicted_accel_ne_mss;    // Predicted acceleration in m/s² based on internal rate shaping of pilot input.
+    Vector2f    _desired_accel_ne_mss;      // Pilot-requested horizontal acceleration in m/s/s (after smoothing), in the NE (horizontal) frame.
+    Vector2f    _predicted_accel_ne_mss;    // Predicted acceleration in m/s/s based on internal rate shaping of pilot input.
     Vector2f    _predicted_euler_angle_rad; // Predicted roll/pitch angles (in radians) used for rate shaping of pilot input.
     Vector2f    _predicted_euler_rate;      // Predicted roll/pitch angular rates (in rad/s) for pilot acceleration shaping.
     uint32_t    _brake_timer_ms;            // Timestamp (in ms) when braking logic was last triggered (sticks released).
-    float       _brake_accel_mss;           // Current braking acceleration in m/s², updated using jerk limits over time.
+    float       _brake_accel_mss;           // Current braking acceleration in m/s/s, updated using jerk limits over time.
 };

--- a/libraries/AC_WPNav/AC_Loiter.h
+++ b/libraries/AC_WPNav/AC_Loiter.h
@@ -42,11 +42,11 @@ public:
     // - Applies internal shaping using the current attitude controller dt.
     void set_pilot_desired_acceleration_rad(float euler_roll_angle_rad, float euler_pitch_angle_rad);
 
-    // Returns pilot-requested horizontal acceleration in the NE frame in cm/s².
+    // Returns pilot-requested horizontal acceleration in the NE frame in cm/s/s.
     // See get_pilot_desired_acceleration_NE_mss() for full details.
     Vector2f get_pilot_desired_acceleration_NE_cmss() const { return get_pilot_desired_acceleration_NE_mss() * 100.0; }
 
-    // Returns pilot-requested horizontal acceleration in the NE frame in m/s².
+    // Returns pilot-requested horizontal acceleration in the NE frame in m/s/s.
     // This is the internally computed and smoothed acceleration vector applied by the loiter controller.
     const Vector2f& get_pilot_desired_acceleration_NE_mss() const { return _desired_accel_ne_mss; }
 

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -10,7 +10,7 @@ extern const AP_HAL::HAL& hal;
 #define WPNAV_WP_RADIUS_MIN_CM            5.0f     // minimum allowable waypoint radius (cm)
 #define WPNAV_WP_SPEED_UP_CMS           250.0f     // default maximum climb speed (cm/s)
 #define WPNAV_WP_SPEED_DOWN_CMS         150.0f     // default maximum descent speed (cm/s)
-#define WPNAV_WP_ACCEL_Z_DEFAULT_CMSS   100.0f     // default vertical acceleration limit (cm/s²)
+#define WPNAV_WP_ACCEL_Z_DEFAULT_CMSS   100.0f     // default vertical acceleration limit (cm/s/s)
 
 const AP_Param::GroupInfo AC_WPNav::var_info[] = {
     // index 0 was used for the old orientation matrix

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -12,7 +12,7 @@
 #include <AC_Avoidance/AC_Avoid.h>                 // Stop at fence library
 
 // maximum velocities and accelerations
-#define WPNAV_ACCELERATION_MS           2.5        // default horizontal acceleration limit for waypoint navigation (m/s²)
+#define WPNAV_ACCELERATION_MS           2.5        // default horizontal acceleration limit for waypoint navigation (m/s/s)
 
 class AC_WPNav
 {
@@ -393,10 +393,10 @@ protected:
     AP_Float    _wp_speed_up_cms;    // default climb rate in cm/s for waypoint navigation
     AP_Float    _wp_speed_down_cms;  // default descent rate in cm/s for waypoint navigation
     AP_Float    _wp_radius_cm;       // waypoint radius in cm; waypoint is considered reached when within this distance
-    AP_Float    _wp_accel_cmss;      // maximum horizontal acceleration in cm/s² used during waypoint tracking
-    AP_Float    _wp_accel_c_cmss;    // maximum acceleration in cm/s² for turns; defaults to 2x horizontal accel if unset
-    AP_Float    _wp_accel_z_cmss;    // maximum vertical acceleration in cm/s² used during climb or descent
-    AP_Float    _wp_jerk_msss;       // maximum jerk in m/s³ used for s-curve trajectory shaping
+    AP_Float    _wp_accel_cmss;      // maximum horizontal acceleration in cm/s/s used during waypoint tracking
+    AP_Float    _wp_accel_c_cmss;    // maximum acceleration in cm/s/s for turns; defaults to 2x horizontal accel if unset
+    AP_Float    _wp_accel_z_cmss;    // maximum vertical acceleration in cm/s/s used during climb or descent
+    AP_Float    _wp_jerk_msss;       // maximum jerk in m/s/s/s used for s-curve trajectory shaping
     AP_Float    _terrain_margin_m;   // minimum altitude margin in meters when terrain following is active
 
     // WPNAV_SPEED param change checker
@@ -409,7 +409,7 @@ protected:
     SCurve _scurve_prev_leg;         // s-curve for the previous waypoint leg, used for smoothing transitions
     SCurve _scurve_this_leg;         // s-curve for the current active waypoint leg
     SCurve _scurve_next_leg;         // s-curve for the next waypoint leg, used for lookahead blending
-    float _scurve_jerk_max_msss;     // computed maximum jerk in m/s³ used for trajectory shaping
+    float _scurve_jerk_max_msss;     // computed maximum jerk in m/s/s/s used for trajectory shaping
     float _scurve_snap_max_mssss;    // computed maximum snap in m/s⁴ derived from controller responsiveness
 
     // spline curves

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -136,23 +136,23 @@ public:
     // Derived from the WPNAV_SPEED_DN parameter. Always positive.
     float get_default_speed_down_ms() const { return fabsf(_wp_speed_down_cms * 0.01); }
 
-    // Returns the vertical acceleration in cm/s² used during waypoint navigation.
+    // Returns the vertical acceleration in cm/s/s used during waypoint navigation.
     // Always positive. See get_accel_U_mss() for full details.
     float get_accel_U_cmss() const { return get_accel_U_mss() * 100.0; }
 
-    // Returns the vertical acceleration in m/s² used during waypoint navigation.
+    // Returns the vertical acceleration in m/s/s used during waypoint navigation.
     // Derived from the WPNAV_ACCEL_Z parameter. Always positive.
     float get_accel_U_mss() const { return _wp_accel_z_cmss * 0.01; }
 
-    // Returns the horizontal acceleration in cm/s² used during waypoint navigation.
+    // Returns the horizontal acceleration in cm/s/s used during waypoint navigation.
     // See get_wp_acceleration_mss() for full details.
     float get_wp_acceleration_cmss() const { return get_wp_acceleration_mss() * 100.0; }
 
-    // Returns the horizontal acceleration in m/s² used during waypoint navigation.
+    // Returns the horizontal acceleration in m/s/s used during waypoint navigation.
     // Derived from the WPNAV_ACCEL parameter. Falls back to a default if unset.
     float get_wp_acceleration_mss() const { return (is_positive(_wp_accel_cmss)) ? _wp_accel_cmss * 0.01 : WPNAV_ACCELERATION_MS; }
 
-    // Returns the maximum lateral acceleration in m/s² used during waypoint cornering.
+    // Returns the maximum lateral acceleration in m/s/s used during waypoint cornering.
     // Derived from WPNAV_ACCEL_C or defaults to 2x WPNAV_ACCEL if unset.
     float get_corner_acceleration_mss() const { return (is_positive(_wp_accel_c_cmss)) ? _wp_accel_c_cmss * 0.01 : 2.0 * get_wp_acceleration_mss(); }
 

--- a/libraries/AP_Follow/AP_Follow.h
+++ b/libraries/AP_Follow/AP_Follow.h
@@ -203,12 +203,12 @@ private:
     AC_P        _p_pos;             // Position error P-controller for optional altitude following
     AP_Int16    _options;           // Bitmask of follow behavior options (e.g., mount follow, etc.)
 
-    AP_Float    _accel_max_ne_mss;  // Max horizontal acceleration for kinematic shaping (m/s²)
-    AP_Float    _jerk_max_ne_msss;  // Max horizontal jerk for kinematic shaping (m/s³)
-    AP_Float    _accel_max_d_mss;   // Max vertical acceleration for kinematic shaping (m/s²)
-    AP_Float    _jerk_max_d_msss;   // Max vertical jerk for kinematic shaping (m/s³)
-    AP_Float    _accel_max_h_degss; // Max angular acceleration for heading shaping (deg/s²)
-    AP_Float    _jerk_max_h_degsss; // Max angular jerk for heading shaping (deg/s³)
+    AP_Float    _accel_max_ne_mss;  // Max horizontal acceleration for kinematic shaping (m/s/s)
+    AP_Float    _jerk_max_ne_msss;  // Max horizontal jerk for kinematic shaping (m/s/s/s)
+    AP_Float    _accel_max_d_mss;   // Max vertical acceleration for kinematic shaping (m/s/s)
+    AP_Float    _jerk_max_d_msss;   // Max vertical jerk for kinematic shaping (m/s/s/s)
+    AP_Float    _accel_max_h_degss; // Max angular acceleration for heading shaping (deg/s/s)
+    AP_Float    _jerk_max_h_degsss; // Max angular jerk for heading shaping (deg/s/s/s)
 
     //==========================================================================
     // Internal State Variables
@@ -219,17 +219,17 @@ private:
 
     Vector3p    _target_pos_ned_m;              // Latest received target position (NED frame, meters)
     Vector3f    _target_vel_ned_ms;             // Latest received target velocity (NED frame, m/s)
-    Vector3f    _target_accel_ned_mss;          // Latest received target acceleration (NED frame, m/s²)
+    Vector3f    _target_accel_ned_mss;          // Latest received target acceleration (NED frame, m/s/s)
     float       _target_heading_deg;            // Latest received target heading (degrees, 0 = North)
     float       _target_heading_rate_degs;      // Latest received target yaw rate (deg/s)
 
     bool        _estimate_valid;                // True if internal estimate is valid and in sync with updates
     Vector3p    _estimate_pos_ned_m;            // Estimated target position (NED frame, meters)
     Vector3f    _estimate_vel_ned_ms;           // Estimated target velocity (NED frame, m/s)
-    Vector3f    _estimate_accel_ned_mss;        // Estimated target acceleration (NED frame, m/s²)
+    Vector3f    _estimate_accel_ned_mss;        // Estimated target acceleration (NED frame, m/s/s)
     float       _estimate_heading_rad;          // Estimated heading (radians, range -PI to PI)
     float       _estimate_heading_rate_rads;    // Estimated heading rate (rad/s)
-    float       _estimate_heading_accel_radss;  // Estimated heading acceleration (rad/s²)
+    float       _estimate_heading_accel_radss;  // Estimated heading acceleration (rad/s/s)
 
     Vector3p    _ofs_estimate_pos_ned_m;        // Estimated position with offsets applied (NED frame)
     Vector3f    _ofs_estimate_vel_ned_ms;       // Estimated velocity with offsets applied (NED frame)

--- a/libraries/AP_Math/control.cpp
+++ b/libraries/AP_Math/control.cpp
@@ -626,7 +626,7 @@ float input_expo(float input, float expo)
     return input;
 }
 
-// Converts a lean angle (radians) to horizontal acceleration in m/s².
+// Converts a lean angle (radians) to horizontal acceleration in m/s/s.
 // Assumes flat Earth and small angle approximation: a = g * tan(θ)
 float angle_rad_to_accel_mss(float angle_rad)
 {
@@ -634,14 +634,14 @@ float angle_rad_to_accel_mss(float angle_rad)
     return GRAVITY_MSS * tanf(angle_rad);
 }
 
-// Converts a lean angle (degrees) to horizontal acceleration in m/s².
+// Converts a lean angle (degrees) to horizontal acceleration in m/s/s.
 float angle_deg_to_accel_mss(float angle_deg)
 {
     // Convert degrees to radians, then to acceleration
     return angle_rad_to_accel_mss(radians(angle_deg));
 }
 
-// Converts a horizontal acceleration (m/s²) to lean angle in radians.
+// Converts a horizontal acceleration (m/s/s) to lean angle in radians.
 // Assumes: angle = atan(a / g)
 float accel_mss_to_angle_rad(float accel_mss)
 {
@@ -649,7 +649,7 @@ float accel_mss_to_angle_rad(float accel_mss)
     return atanf(accel_mss/GRAVITY_MSS);
 }
 
-// Converts a horizontal acceleration (m/s²) to lean angle in degrees.
+// Converts a horizontal acceleration (m/s/s) to lean angle in degrees.
 float accel_mss_to_angle_deg(float accel_mss)
 {
     // Convert result of radian-based conversion to degrees

--- a/libraries/AP_Math/control.h
+++ b/libraries/AP_Math/control.h
@@ -170,18 +170,18 @@ float kinematic_limit(Vector3f direction, float max_xy, float max_z_pos, float m
 // - Clipped to `expo < 0.95` to avoid divide-by-zero or extreme scaling.
 float input_expo(float input, float expo);
 
-// Converts a lean angle (radians) to horizontal acceleration in m/s².
+// Converts a lean angle (radians) to horizontal acceleration in m/s/s.
 // Assumes flat Earth and small angle approximation: a = g * tan(θ)
 float angle_rad_to_accel_mss(float angle_rad);
 
-// Converts a lean angle (degrees) to horizontal acceleration in m/s².
+// Converts a lean angle (degrees) to horizontal acceleration in m/s/s.
 float angle_deg_to_accel_mss(float angle_deg);
 
-// Converts a horizontal acceleration (m/s²) to lean angle in radians.
+// Converts a horizontal acceleration (m/s/s) to lean angle in radians.
 // Assumes: angle = atan(a / g)
 float accel_mss_to_angle_rad(float accel_mss);
 
-// Converts a horizontal acceleration (m/s²) to lean angle in degrees.
+// Converts a horizontal acceleration (m/s/s) to lean angle in degrees.
 float accel_mss_to_angle_deg(float accel_mss);
 
 // Converts pilot’s normalized roll/pitch input into target roll and pitch angles (radians).


### PR DESCRIPTION
I would like to discuss the possibility of still using it for comments in the code as it is much easier to read. This has been used in the EKF and Sub to great effect.