### PR TITLE
Make bootloader builds repeatable again

### DIFF
--- a/.github/workflows/test_size.yml
+++ b/.github/workflows/test_size.yml
@@ -161,6 +161,7 @@ jobs:
           # export some environment variables designed to get
           #            repeatable builds from the same source:
           export CHIBIOS_GIT_VERSION="12345678"
+          export GIT_VERSION_EXTENDED="0123456789abcdef"
           export GIT_VERSION="abcdef"
           export GIT_VERSION_INT="15"
 
@@ -237,6 +238,7 @@ jobs:
           # export some environment variables designed to get
           #            repeatable builds from the same source:
           export CHIBIOS_GIT_VERSION="12345678"
+          export GIT_VERSION_EXTENDED="0123456789abcdef"
           export GIT_VERSION="abcdef"
           export GIT_VERSION_INT="15"
 

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -25,6 +25,7 @@ cxx_compiler=${CXX:-g++}
 export BUILDROOT=/tmp/ci.build
 rm -rf $BUILDROOT
 export GIT_VERSION="abcdef"
+export GIT_VERSION_EXTENDED="0123456789abcdef"
 export GIT_VERSION_INT="15"
 export CHIBIOS_GIT_VERSION="12345667"
 export CCACHE_SLOPPINESS="include_file_ctime,include_file_mtime"

--- a/Tools/scripts/size_compare_branches.py
+++ b/Tools/scripts/size_compare_branches.py
@@ -324,6 +324,7 @@ class SizeCompareBranches(object):
         consistent_build_envs = {
             "CHIBIOS_GIT_VERSION": "12345678",
             "GIT_VERSION": "abcdef",
+            "GIT_VERSION_EXTENDED": "0123456789abcdef",
             "GIT_VERSION_INT": "15",
         }
         for (n, v) in consistent_build_envs.items():


### PR DESCRIPTION
5f76ae9e331c9cbd2e363e0c107dc68eafffc7a9 allowed us to retrieve the bootloader version at runtime.

Unfortunately the new `GIT_VERSION_EXTENDED` define was unique to every git commit, so we'd always end up with changes reported by `size_compare_branches.py`.

This PR just adds in another dummy variable value as we do for several others just like it

bootloader builds are repeatable again after this:
```
Board,bootloader
CubeOrange,*
```
