### PR TITLE
AP_Networking: cache port type in init

### DIFF
--- a/libraries/AP_Networking/AP_Networking.h
+++ b/libraries/AP_Networking/AP_Networking.h
@@ -240,7 +240,8 @@ private:
         Port() {}
 
         static const struct AP_Param::GroupInfo var_info[];
-        AP_Enum<NetworkPortType> type;
+        AP_Enum<NetworkPortType> type_param;
+        NetworkPortType type;
         AP_Networking_IPV4 ip {"0.0.0.0"};
         AP_Int32 port;
         SocketAPM *sock;

--- a/libraries/AP_Networking/AP_Networking_port.cpp
+++ b/libraries/AP_Networking/AP_Networking_port.cpp
@@ -36,7 +36,7 @@ const AP_Param::GroupInfo AP_Networking::Port::var_info[] = {
     // @Values: 0:Disabled, 1:UDP client, 2:UDP server, 3:TCP client, 4:TCP server
     // @RebootRequired: True
     // @User: Advanced
-    AP_GROUPINFO_FLAGS("TYPE", 1,  AP_Networking::Port, type, 0, AP_PARAM_FLAG_ENABLE),
+    AP_GROUPINFO_FLAGS("TYPE", 1,  AP_Networking::Port, type_param, 0, AP_PARAM_FLAG_ENABLE),
 
     // @Param: PROTOCOL
     // @DisplayName: Protocol
@@ -69,9 +69,9 @@ void AP_Networking::ports_init(void)
 {
     for (uint8_t i=0; i<ARRAY_SIZE(ports); i++) {
         auto &p = ports[i];
-        NetworkPortType ptype = (NetworkPortType)p.type;
+        p.type = (NetworkPortType)p.type_param;
         p.state.idx = AP_SERIALMANAGER_NET_PORT_1 + i;
-        switch (ptype) {
+        switch (p.type) {
         case NetworkPortType::NONE:
             break;
         case NetworkPortType::UDP_CLIENT:


### PR DESCRIPTION
AP_Networking: cache port type in init. Without this you can change the Network port type at runtime and that could potentially be very bad.