### PR TITLE
AP_DroneCAN: stop reversing ARDUPILOT_INDICATION_NOTIFYSTATE_VEHICLE_…

### DIFF
--- a/libraries/AP_DroneCAN/AP_DroneCAN.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.cpp
@@ -1065,6 +1065,9 @@ void AP_DroneCAN::notify_state_send()
     }
 #endif // HAL_BUILD_AP_PERIPH
 
+    // beware that
+    // ARDUPILOT_INDICATION_NOTIFYSTATE_VEHICLE_YAW_EARTH_CENTIDEGREES
+    // is strange; it's number of degrees *counter-clockwise* from North.
     msg.aux_data_type = ARDUPILOT_INDICATION_NOTIFYSTATE_VEHICLE_YAW_EARTH_CENTIDEGREES;
     uint16_t yaw_cd = (uint16_t)(360.0f - AP::ahrs().get_yaw_deg())*100.0f;
     const uint8_t *data = (uint8_t *)&yaw_cd;


### PR DESCRIPTION
…YAW_EARTH_CENTIDEGREES

this number is already wrapped.  This reverses the yaw direction so if the vehicle was pointing 15 degrees East then this would change it to be 15 degrees West...

I believe this was created so a HereGPS could use its blinkenlights to indicate where the vehicle thought North might be.

There are currently no in-tree users of the LUA binding which was probably used to get the effect.

Can we change this?
