### PR TITLE
Copter: make three GuidedMode variables non-static class members

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1208,12 +1208,13 @@ private:
     void set_yaw_state_rad(bool use_yaw, float yaw_rad, bool use_yaw_rate, float yaw_rate_rads, bool relative_angle);
 
     // controls which controller is run (pos or vel):
-    static SubMode guided_mode;
-    static bool send_notification;     // used to send one time notification to ground station
+    SubMode guided_mode;
+     // used to send one time notification to ground station:
+    bool send_notification;
     static bool takeoff_complete;      // true once takeoff has completed (used to trigger retracting of landing gear)
 
     // guided mode is paused or not
-    static bool _paused;
+    bool _paused;
 };
 
 #if AP_SCRIPTING_ENABLED

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -30,13 +30,7 @@ struct Guided_Limit {
     Vector3f start_pos_neu_cm;  // start position as a distance from home in cm.  used for checking horiz_max limit
 } static guided_limit;
 
-// controls which controller is run (pos or vel):
-ModeGuided::SubMode ModeGuided::guided_mode = SubMode::TakeOff;
-bool ModeGuided::send_notification;     // used to send one time notification to ground station
 bool ModeGuided::takeoff_complete;      // true once takeoff has completed (used to trigger retracting of landing gear)
-
-// guided mode is paused or not
-bool ModeGuided::_paused;
 
 // init - initialise guided controller
 bool ModeGuided::init(bool ignore_checks)


### PR DESCRIPTION
Each of these three variables is initialised in the "init" function - two directly and one in the method `velaccel_control_start`.

Notionally this makes the values in these variables unshared between guided mode and any of its subclasses, so we can make them normal instance variables (but see below).

Use of static member variables like these is very rare in ArduPilot.  In this case this PR will increase RAM usage in ArduPilot - each of the subclasses of ModeGuided will have their own copy of these variables.  That's not a lot of resources, but there are similar larger data structures in mode_guided.cpp which we could do the same thing to (but which would require a bit more inspection to make sure their values are entirely unshared between ModeGuided-based objects).

This PR didn't take from @muramura 's https://github.com/ArduPilot/ardupilot/pull/28317 but it is the same concept and some of the patches will be the same.

This saves an inordinate amount of flash for what it's doing:
```
Board,copter
CubeOrange,-144
```

While testing this I found that neither `ModeFollow` nor `ModeGuidedNoGPS` call the parent-class init method.  That means they will currently leave stale data in the parent class in (_paused` and `send_notification`).  This is probably a hint that we want an abstract base class for ModeGuided as those variables are not relevant for the its direct descendants anyway.
