### PR TITLE
AP_Arming: added option to disable IMU check with ICE running

### DIFF
--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -155,6 +155,7 @@ public:
     enum class Option : int32_t {
         DISABLE_PREARM_DISPLAY             = (1U << 0),
         DISABLE_STATUSTEXT_ON_STATE_CHANGE = (1U << 1),
+        SKIP_IMU_CONSISTENCY_ICE_RUNNING   = (1U << 2),
     };
     bool option_enabled(Option option) const {
         return (_arming_options & uint32_t(option)) != 0;


### PR DESCRIPTION
when ICE motors are running (and they are commonly started before arming) the IMU noise can overwhelm the IMU consistency checks, preventing arming. This gives the user a way to disable that check

alternative to #25905 