### PR TITLE
AP_HAL_ChibiOS: Correct GPIO defaults on LUCID H7

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7/README.md
@@ -112,7 +112,7 @@ The TBS LUCID H7 does not have a builtin compass, but you can attach an external
 
 ## VTX power control
 
-GPIO 81 controls the VSW pins which can be set to output either VBAT or 5V via a board jumper. Setting this GPIO high removes voltage supply to pins. RELAY2 is configured by default to control this GPIO and is low by default.
+GPIO 81 controls the VSW pins which can be set to output either VBAT or 5V via a board jumper. Setting this GPIO low removes voltage supply to pins. RELAY2 is configured by default to control this GPIO and is low by default.
 
 GPIO 83 controls the VTX BEC output to pins marked "9V" and is included on the HD VTX connector. Setting this GPIO low removes voltage supply to this pin/pad.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7/defaults.parm
+++ b/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7/defaults.parm
@@ -1,4 +1,10 @@
 # setup for LEDs on chan13
 SERVO13_FUNCTION 120
+# Default to CAM1
+RELAY3_DEFAULT 1
 # Default VTX power to on
 RELAY4_DEFAULT 1
+# Default VSW power to on
+RELAY2_DEFAULT 1
+# Support HD VTX as well
+OSD_TYPE2 5


### PR DESCRIPTION
Discovered in testing