### PR TITLE
Control ESC Logging

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -635,6 +635,12 @@ void Copter::loop_rate_logging()
         AP::ins().write_notch_log_messages();
     }
 #endif
+#if HAL_WITH_ESC_TELEM
+    // associate full rate ESC data with full rate notch data
+    if (should_log(MASK_LOG_MOTBATT) && should_log(MASK_LOG_FTN_FAST)) {
+        AP::esc_telem().write_log();
+    }
+#endif
     if (should_log(MASK_LOG_IMU_FAST)) {
         AP::ins().Write_IMU();
     }
@@ -718,6 +724,11 @@ void Copter::twentyfive_hz_logging()
 #if HAL_GYROFFT_ENABLED
     if (should_log(MASK_LOG_FTN_FAST)) {
         gyro_fft.write_log_messages();
+    }
+#endif
+#if HAL_WITH_ESC_TELEM
+    if (should_log(MASK_LOG_MOTBATT) && !should_log(MASK_LOG_FTN_FAST)) {
+        AP::esc_telem().write_log();
     }
 #endif
 }

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -70,6 +70,11 @@ void Plane::Log_Write_FullRate(void)
         AP::ins().write_notch_log_messages();
     }
 #endif
+#if HAL_WITH_ESC_TELEM
+    if (should_log(MASK_LOG_NOTCH_FULLRATE)) {
+        AP::esc_telem().write_log();
+    }
+#endif
 }
 
 

--- a/ArduPlane/Plane.cpp
+++ b/ArduPlane/Plane.cpp
@@ -301,6 +301,11 @@ void Plane::update_logging25(void)
             AP::ins().write_notch_log_messages();
         }
 #endif
+#if HAL_WITH_ESC_TELEM
+        if (!should_log(MASK_LOG_NOTCH_FULLRATE)) {
+            AP::esc_telem().write_log();
+        }
+#endif
 #if HAL_GYROFFT_ENABLED
         gyro_fft.write_log_messages();
 #endif

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -667,7 +667,7 @@ uint16_t AP_ESC_Telem::merge_edt2_stress(uint16_t old_stress, uint16_t new_stres
 
 #endif // AP_EXTENDED_DSHOT_TELEM_V2_ENABLED
 
-void AP_ESC_Telem::update()
+void AP_ESC_Telem::write_log()
 {
 #if HAL_LOGGING_ENABLED
     AP_Logger *logger = AP_Logger::get_singleton();
@@ -796,7 +796,10 @@ void AP_ESC_Telem::update()
         }
     }
 #endif  // HAL_LOGGING_ENABLED
+}
 
+void AP_ESC_Telem::update()
+{
     for (uint8_t i = 0; i < ESC_TELEM_MAX_ESCS; i++) {
         // copy the last_updated_us timestamp to avoid any race issues
         const uint32_t last_updated_us = _rpm_data[i].last_update_us;

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.h
@@ -111,8 +111,11 @@ public:
     // send telemetry data to mavlink
     void send_esc_telemetry_mavlink(uint8_t mav_chan);
 
-    // update at 10Hz to log telemetry
+    // update at 10Hz to handle invalidation
     void update();
+
+    // log ESC data
+    void write_log();
 
     // is rpm telemetry configured for the provided channel mask
     bool is_telemetry_active(uint32_t servo_channel_mask) const;


### PR DESCRIPTION
Currently ESC data is logged at a fixed 100Hz per motor, so on a Quad that's 400Hz logging. There is no way to turn it off or turn it down. This can then dominate log file sizes.

This PR defaults ESC logging to 25Hz controlled from the vehicle (so that it can be turned off). It also associates full rate logging with the full rate notch logging which is off by default.