### PR TITLE
AP_Scripting: Added Lua bindings for AC_Sprayer

### DIFF
--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -4106,6 +4106,35 @@ function networking:get_ip_active() end
 ---@return boolean
 function networking:add_route(backend_idx, iface_idx, dest_ip, mask_len) end
 
+
+-- Manages a crop sprayer with a spinner and pump; both controlled by pwm
+---@class sprayer
+sprayer = {}
+
+-- Allow (true) or disallow (false) spraying to occur
+---@param param1 boolean
+function sprayer:run(param1) end
+
+-- Returns true if spraying is currently permitted
+---@return boolean
+function sprayer:running() end
+
+-- Returns true if spraying is actually happening
+---@return boolean
+function sprayer:spraying() end
+
+-- If set to true, turns on pump as if traveling at 1 m/s (as a test)
+---@param param1 boolean
+function sprayer:test_pump(param1) end
+
+-- Sets desired quantity of spray when traveling at 1 m/s as a percentage of maximum pump rate
+---@param param1 number
+function sprayer:set_pump_rate(param1) end
+
+-- Adjusts servo positions based on speed an requested quantity
+function sprayer:update() end
+
+
 -- visual odometry object
 visual_odom = {}
 

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -829,6 +829,16 @@ singleton AC_PosControl method get_posvelaccel_offset boolean Vector3f'Null Vect
 singleton AC_PosControl method get_vel_target boolean Vector3f'Null
 singleton AC_PosControl method get_accel_target boolean Vector3f'Null
 
+include AC_Sprayer/AC_Sprayer.h depends APM_BUILD_TYPE(APM_BUILD_ArduCopter) || APM_BUILD_TYPE(APM_BUILD_Rover)
+singleton AC_Sprayer depends APM_BUILD_TYPE(APM_BUILD_ArduCopter) || APM_BUILD_TYPE(APM_BUILD_Rover)
+singleton AC_Sprayer rename sprayer
+singleton AC_Sprayer method run void boolean
+singleton AC_Sprayer method running boolean
+singleton AC_Sprayer method spraying boolean
+singleton AC_Sprayer method test_pump void boolean
+singleton AC_Sprayer method set_pump_rate void float 0 100
+singleton AC_Sprayer method update void
+
 include APM_Control/AR_AttitudeControl.h depends APM_BUILD_TYPE(APM_BUILD_Rover)
 singleton AR_AttitudeControl depends APM_BUILD_TYPE(APM_BUILD_Rover)
 singleton AR_AttitudeControl method get_srate void float'Ref float'Ref


### PR DESCRIPTION
Added bindings for public methods of AC_Sprayer.

Expected behavior: Sprayer pump can be controlled from Lua like it can from RC channels.
Tested on CubeOrange+ with HobbyWing XRotor 5L pump
Pump responded to Lua code.