### PR TITLE
AP_HAL_SITL: Blimp: stop initialising pwm_output to 1000

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -300,7 +300,7 @@ void SITL_State::_simulator_servos(struct sitl_input &input)
      * to change */
 
     if (last_update_usec == 0 || !output_ready) {
-        if (_vehicle == ArduPlane || _vehicle == Blimp) {
+        if (_vehicle == ArduPlane) {
             for (uint8_t i=0; i<SITL_NUM_CHANNELS; i++) {
                 pwm_output[i] = 1000;
             }


### PR DESCRIPTION
the simulator specifically handles the zero case.  Probably not correctly (it zeroes the servo angle), but it is handled.