### PR TITLE
Stop initialising Copter pwm output values in AP_HAL_SITL 

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -300,7 +300,7 @@ void SITL_State::_simulator_servos(struct sitl_input &input)
      * to change */
 
     if (last_update_usec == 0 || !output_ready) {
-        if (_vehicle == ArduPlane || _vehicle == ArduCopter || _vehicle == Blimp) {
+        if (_vehicle == ArduPlane || _vehicle == Blimp) {
             for (uint8_t i=0; i<SITL_NUM_CHANNELS; i++) {
                 pwm_output[i] = 1000;
             }

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -1063,7 +1063,9 @@ bool Aircraft::Clamp::clamped(Aircraft &aircraft, const struct sitl_input &input
     }
     const uint16_t servo_pos = input.servos[clamp_idx];
     bool new_clamped = currently_clamped;
-    if (servo_pos < 1200) {
+    if (servo_pos == 0) {
+        // invalid value, do nothing
+    } else if (servo_pos < 1200) {
         if (currently_clamped) {
             GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SITL: Clamp: released vehicle");
             new_clamped = false;


### PR DESCRIPTION
... and a minor fix for clamps while we're at it.
