### PR TITLE
Fix: use _timestamp instead of TimeUS*1.0e-6 for Tools/scripts/playback_log_fg.py

### DIFF
--- a/Tools/scripts/playback_log_fg.py
+++ b/Tools/scripts/playback_log_fg.py
@@ -42,7 +42,7 @@ class Playback(object):
         self.msg = self.next_msg()
         if self.msg is None:
             sys.exit(1)
-        self.last_timestamp = self.msg.TimeUS*1.0e-6
+        self.last_timestamp = self.msg._timestamp
 
         while True:
             self.next_message()
@@ -64,7 +64,7 @@ class Playback(object):
         if msg is None:
             return
 
-        timestamp = msg.TimeUS*1.0e-6
+        timestamp = msg._timestamp
 
         dt = timestamp - self.last_timestamp
         dt = max(dt, 0)


### PR DESCRIPTION
This PR fixes a crash in playback_log_fg.py when processing log messages that do not contain a TimeUS field. The script now uses the _timestamp attribute, which is always present, instead of directly accessing TimeUS.