### PR TITLE
Avoid duplicate temperature compensation in EAHRS

### DIFF
--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS.h
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS.h
@@ -89,6 +89,13 @@ public:
     // get serial port number, -1 for not enabled
     int8_t get_port(AvailableSensor sensor) const;
 
+    enum class TempCal {
+        DoesntProvideTemp,
+        IsNotTempCalibrated,
+        IsTempCalibrated
+    };
+
+
     struct state_t {
         HAL_Semaphore sem;
 
@@ -163,6 +170,7 @@ public:
         Vector3f accel;
         Vector3f gyro;
         float temperature;
+        TempCal TempCalibration = TempCal::IsNotTempCalibrated;
     } ins_data_message_t;
 
     typedef struct {

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_MicroStrain5.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_MicroStrain5.cpp
@@ -124,11 +124,10 @@ void AP_ExternalAHRS_MicroStrain5::post_imu() const
     }
 
     {
-        AP_ExternalAHRS::ins_data_message_t ins {
-            accel: imu_data.accel,
-            gyro: imu_data.gyro,
-            temperature: -300
-        };
+        AP_ExternalAHRS::ins_data_message_t ins;
+        ins.accel = imu_data.accel;
+        ins.gyro = imu_data.gyro;
+        ins.temperature= -300;
         AP::ins().handle_external(ins);
     }
 

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_MicroStrain7.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_MicroStrain7.cpp
@@ -152,13 +152,11 @@ void AP_ExternalAHRS_MicroStrain7::post_imu() const
     }
 
     {
-        // *INDENT-OFF*
-        AP_ExternalAHRS::ins_data_message_t ins {
-            accel: imu_data.accel,
-            gyro: imu_data.gyro,
-            temperature: -300
-        };
-        // *INDENT-ON*
+        AP_ExternalAHRS::ins_data_message_t ins;
+        ins.accel = imu_data.accel;
+        ins.gyro = imu_data.gyro;
+        ins.temperature= -300;
+        ins.TempCalibration = AP_ExternalAHRS::TempCal::IsTempCalibrated;
         AP::ins().handle_external(ins);
     }
 

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_SBG.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_SBG.cpp
@@ -631,6 +631,7 @@ void AP_ExternalAHRS_SBG::handle_msg(const sbgMessage &msg)
     if (updated_ins) {
         cached.sensors.ins_data.accel = state.accel;
         cached.sensors.ins_data.gyro = state.gyro;
+        cached.sensors.ins_data.TempCalibration = AP_ExternalAHRS::TempCal::IsTempCalibrated;
         cached.sensors.ins_ms = now_ms;
         AP::ins().handle_external(cached.sensors.ins_data);
     }

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -2795,6 +2795,9 @@ void AP_InertialSensor::send_uart_data(void)
 void AP_InertialSensor::handle_external(const AP_ExternalAHRS::ins_data_message_t &pkt)
 {
     for (uint8_t i = 0; i < _backend_count; i++) {
+        if(pkt.TempCalibration == AP_ExternalAHRS::TempCal::IsTempCalibrated){
+            tcal(i).enable.set_and_save_ifchanged(int8_t(AP_InertialSensor_TCal::Enable::Disabled));
+        }
         _backends[i]->handle_external(pkt);
     }
 }


### PR DESCRIPTION
As explained in issue #25792, there is an issue where EAHRS performs duplicate temperature compensation for certain sensors.

The enum `TempCalibration` of the type `TempCal` is adjusted to see if the sensors is of the MicroStrain7 type (as mentioned in the issue) and set the enum as `IsTempCalibrated`. Else the enum is set as `IsNotTempCalibrated`.

In the inertial sensor section, this enum, which was sent by the message `ins_data_message_t`, is checked, and if there is temperature compensation, a new bool `IsTempCalibrated` is set to `true`. This bool then checked at places where temperature compensation due to `HAL_INS_TEMPERATURE_CAL_ENABLE` occurs and the code inside is executed if the bool is `false`.