### PR TITLE
autotest: tweak QAssist takeoff alt higher

### DIFF
--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -820,7 +820,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
 
     def QAssist(self):
         '''QuadPlane Assist tests'''
-        self.takeoff(50, mode="QHOVER", timeout=120)
+        self.takeoff(100, mode="QHOVER", timeout=120)
         self.set_rc(3, 1800)
         self.change_mode("FBWA")
 


### PR DESCRIPTION
found a test where the vehicle hit the ground and started a transition instead of having qassist kick in