### PR TITLE
SITL: fixed motorboat-skid

### DIFF
--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6920,7 +6920,6 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         vinfo_options = vinfo.options[self.vehicleinfo_key()]
         known_broken_frames = {
             "balancebot": "needs special stay-upright code",
-            "motorboat-skid": "gets stuck between waypoints 2 and 3",
         }
         for frame in sorted(vinfo_options["frames"].keys()):
             self.start_subtest("Testing frame (%s)" % str(frame))

--- a/libraries/SITL/SIM_Sailboat.cpp
+++ b/libraries/SITL/SIM_Sailboat.cpp
@@ -100,19 +100,20 @@ float Sailboat::get_turn_circle(float steering) const
 // return yaw rate in deg/sec given a steering input (in the range -1 to +1) and speed in m/s
 float Sailboat::get_yaw_rate(float steering, float speed) const
 {
+    if (skid_steering) {
+        return steering * M_PI * 5;
+    }
+
     float rate = 0.0f;
-    if (is_zero(steering) || (!skid_steering && is_zero(speed))) {
+    if (is_zero(steering)) {
         return rate;
     } 
     
-    if (is_zero(speed) && skid_steering) {
-        rate = steering * M_PI * 5;
-    } else {
-        float d = get_turn_circle(steering);
-        float c = M_PI * d;
-        float t = c / speed;
-        rate = 360.0f / t;
-    }
+    float d = get_turn_circle(steering);
+    float c = M_PI * d;
+    float t = c / speed;
+    rate = 360.0f / t;
+
     return rate;
 }
 


### PR DESCRIPTION
is_zero doesn't work as boats always drift to non-zero
