### PR TITLE
AP_GPS: SBF: move state machine forward if we choose not to adjust co…

### DIFF
--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -149,8 +149,10 @@ AP_GPS_SBF::read(void)
                                                             (params.gnss_mode&(1U<<6))!=0 ? ((params.gnss_mode&0x2F)==0  ? "GLONASS" : "+GLONASS") : "") == -1) {
                                         config_string=nullptr;
                                     }
+                                    break;
                                 }
-                                break;
+                                config_step = Config_State::Blob;
+                                FALLTHROUGH;
                             case Config_State::Blob:
                                 if (asprintf(&config_string, "%s\n", _initialisation_blob[_init_blob_index]) == -1) {
                                     config_string = nullptr;
@@ -388,6 +390,11 @@ AP_GPS_SBF::parse(uint8_t temp)
                                     config_step = Config_State::Constellation;
                                     break;
                                 case Config_State::Constellation:
+                                    // we can also move to
+                                    // Config_State::Blob if we choose
+                                    // not to update the GPS's
+                                    // constellation configuration
+                                    // (above).
                                     config_step = Config_State::Blob;
                                     break;
                                 case Config_State::Blob:


### PR DESCRIPTION
…nstellations

we move state machines forward based on responses; if we don't send a message then we won't get one and won't leave this state.  This happens with the default configuration of "leave it alone"