### PR TITLE
Augment code to help track down uninitialised location

### DIFF
--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -22,6 +22,11 @@ set -ex
 c_compiler=${CC:-gcc}
 cxx_compiler=${CXX:-g++}
 
+# we want processes to exit in CI.  If we don't end up calling
+# alarm_handler and not getting the binaries in the failure archive on
+# github.
+export SITL_PANIC_EXIT=1
+
 export BUILDROOT=/tmp/ci.build
 rm -rf $BUILDROOT
 export GIT_VERSION="abcdef"

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -380,6 +380,11 @@ void AP_AHRS::update_state(void)
     state.secondary_attitude_ok = _get_secondary_attitude(state.secondary_attitude);
     state.secondary_quat_ok = _get_secondary_quaternion(state.secondary_quat);
     state.location_ok = _get_location(state.location);
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    if (state.location_ok && !state.location.initialised()) {
+        AP_HAL::panic("uninitialised location returned by _get_location");
+    }
+#endif  // CONFIG_HAL_BOARD == HAL_BOARD_SITL
     state.secondary_pos_ok = _get_secondary_position(state.secondary_pos);
     state.ground_speed_vec = _groundspeed_vector();
     state.ground_speed = _groundspeed();

--- a/libraries/AP_GPS/AP_GPS_Blended.cpp
+++ b/libraries/AP_GPS/AP_GPS_Blended.cpp
@@ -386,6 +386,13 @@ void AP_GPS_Blended::calc_state(void)
         gps.Write_GPS(GPS_BLENDED_INSTANCE);
     }
 #endif
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    // sanity checks
+    if (state.status > AP_GPS::NO_FIX && !state.location.initialised()) {
+        AP_HAL::panic("status is >NO_FIX but location is zero");
+    }
+#endif  // CONFIG_HAL_BOARD == HAL_BOARD_SITL
 }
 
 bool AP_GPS_Blended::get_lag(float &lag_sec) const

--- a/libraries/AP_HAL_SITL/system.cpp
+++ b/libraries/AP_HAL_SITL/system.cpp
@@ -54,6 +54,7 @@ void WEAK panic(const char *errormsg, ...)
     if (getenv("SITL_PANIC_EXIT")) {
         // this is used on the autotest server to prevent us waiting
         // 10 hours for a timeout
+        printf("panic and SITL_PANIC_EXIT set - exitting");
         exit(1);
     }
     for(;;);


### PR DESCRIPTION
A [recent run](https://productionresultssa6.blob.core.windows.net/actions-results/d17f283a-3a47-49e5-ac3d-a0d19e528986/workflow-job-run-01519dc1-d1ac-5473-9860-af6feca4bd0d/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-08-11T00%3A32%3A31Z&sig=%2FYPKc%2Fc8vf7ezhZ9DMWuTYjMRyNSxp9E4k8uMzdQ8Ho%3D&ske=2025-08-11T10%3A59%3A04Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-08-10T22%3A59%3A04Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-05-05&sp=r&spr=https&sr=b&st=2025-08-11T00%3A22%3A26Z&sv=2025-05-05) in CI showed ArduCopter panicking and exiting due to an uninitalised location.

That location is the current location.  The AHRS has it as all zeroes in its state cache, but it also has that location marked as good.

This PR:
 - ensures the process exits in SITL on panic so we get a copy of the binary (which I've been unable to reproduce here
 - adds some sanity checks to catch this problem earlier in SITL to help track it down
 - adds a little bit of diagnostics to clarify what SITL is up to when it has panicked.
- only changes the SITL binaries:
```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                 *                                                   
Durandal                            *      *           *       *                 *      *      *
Hitec-Airspeed           *                 *                                                   
KakuteH7-bdshot                     *      *           *       *                 *      *      *
MatekF405                           *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *                  *       *                 *      *      *
SITL_x86_64_linux_gnu               0                  0       0                 0      0      0
f103-QiotekPeriph        *                 *                                                   
f303-Universal           *                 *                                                   
iomcu                                                                *                         
revo-mini                           *      *           *       *                 *      *      *
skyviper-v2450                                         *                                       
```

I don't *know* blended is returning the invalid results (and an AHRS backend parroting that), but it seems likely.
