### PR TITLE
autotest: tweak qassist test servo output to more closely match scenario

### DIFF
--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -923,13 +923,17 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.set_rc(3, 2000)
         self.delay_sim_time(5)
         self.change_mode('MANUAL')
-        self.set_rc(2, 1700)
-        self.wait_pitch(lim_pitch_up_deg+15, accuracy=5)
+        self.context_push()
+        self.set_parameter("SIM_SPEEDUP", 1)
+        self.set_rc(2, 1550)
+        self.wait_pitch(lim_pitch_up_deg+5, accuracy=5)
+        self.context_pop()
         self.progress("Killing elevator servo output to force qassist to help")
+        servo2_out = self.get_servo_channel_value(2)
         self.set_parameters({
-            "SERVO2_MIN": 1480,
-            "SERVO2_MAX": 1480,
-            "SERVO2_TRIM": 1480,
+            "SERVO2_MIN": servo2_out,
+            "SERVO2_MAX": servo2_out,
+            "SERVO2_TRIM": servo2_out,
         })
         self.change_mode('FBWA')
         self.progress("Trying to pitch down hard")


### PR DESCRIPTION
lock the servo in the pitched condition rather than bringing back to neutral

New:
<img width="2046" height="949" alt="image" src="https://github.com/user-attachments/assets/6d640acd-9ad7-495c-ae9f-bbe70171cc60" />

master:
<img width="2046" height="949" alt="image" src="https://github.com/user-attachments/assets/565ed9c2-8a60-4854-a4e2-8800ef384a49" />
