### PR TITLE
AP_AHRS: remove duplicate dependency

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -33,7 +33,6 @@
 #include "AP_AHRS_DCM.h"
 #include "AP_AHRS_SIM.h"
 #include "AP_AHRS_External.h"
-#include <AP_NavEKF/AP_Nav_Common.h>
 
 // forward declare view class
 class AP_AHRS_View;


### PR DESCRIPTION
This removes an extra dependency from the AP_AHRS.h file.  AP_NavCommon.h was being included twice within a few lines of each other