### PR TITLE
autotest: do not move failed-test logs if not running on autotest server

### DIFF
--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -521,6 +521,8 @@ def run_step(step):
     if opts.speedup is not None:
         fly_opts["speedup"] = opts.speedup
 
+    fly_opts["move_logs_on_test_failure"] = opts.move_logs_on_test_failure
+
     # handle "test.Copter" etc:
     if step in tester_class_map:
         # create an instance of the tester class:
@@ -845,6 +847,10 @@ if __name__ == "__main__":
                       action='store_true',
                       default=False,
                       help='Run in autotest-server mode; dangerous!')
+    parser.add_option("--move-logs-on-test-failure",
+                      action='store_true',
+                      default=None,
+                      help='Move logs to ../buildlogs if a test fails')
     parser.add_option("--skip",
                       type='string',
                       default='',
@@ -1055,6 +1061,17 @@ if __name__ == "__main__":
             opts.timeout *= 10
         elif opts.gdb:
             opts.timeout = None
+
+    # default to moving logs when running in autotest-server mode:
+    if opts.move_logs_on_test_failure is None:
+        opts.move_logs_on_test_failure = opts.autotest_server
+
+        # temporarily default it to the old behaviour, but allow a
+        # user to test it by setting an environment variable:
+        if os.getenv("AP_AUTOTEST_MOVE_LOGS_ON_FAILURE") is not None:
+            opts.move_logs_on_test_failure = os.getenv("AP_AUTOTEST_MOVE_LOGS_ON_FAILURE") == "1"
+        else:
+            opts.move_logs_on_test_failure = True
 
     steps = [
         'prerequisites',

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -1937,8 +1937,10 @@ class TestSuite(ABC):
                  num_aux_imus=0,
                  dronecan_tests=False,
                  generate_junit=False,
+                 build_opts={},
                  enable_fgview=False,
-                 build_opts={}):
+                 move_logs_on_test_failure : bool = False,
+                 ):
 
         self.start_time = time.time()
 
@@ -1966,6 +1968,7 @@ class TestSuite(ABC):
         self.ubsan = ubsan
         self.ubsan_abort = ubsan_abort
         self.build_opts = build_opts
+        self.move_logs_on_test_failure = move_logs_on_test_failure
         self.num_aux_imus = num_aux_imus
         self.generate_junit = generate_junit
         if generate_junit:
@@ -8976,6 +8979,8 @@ Also, ignores heartbeats not from our target system'''
     def check_logs(self, name):
         '''called to move relevant log files from our working directory to the
         buildlogs directory'''
+        if not self.move_logs_on_test_failure:
+            return
         to_dir = self.logs_dir
         # move telemetry log files
         for log in glob.glob("autotest-*.tlog"):


### PR DESCRIPTION
This is disabled unless you

```
export AP_AUTOTEST_MOVE_LOGS_ON_FAILURE=0
```

... until it's been tested a bit.
