### PR TITLE
autotest: allow time for param-set parameters to initialise

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -14312,6 +14312,7 @@ RTL_ALT 111
         self.assert_parameter_value('DISARM_DELAY', 111)
 
         # very bad things happen if we don't turn things off at the end..
+        self.delay_sim_time(1, "allow param-set parameter values to initialise")
         self.set_parameter("PARAM_SET_ENABLE", 0)
 
     def do_land(self):


### PR DESCRIPTION
otherwise we see a value of 0 for PARAM_SET_ENABLE so we don't try to set it.  Then the script initialises properly and this gets a value of 1 so we can't actually set any parameters and the test fails