### PR TITLE
AP_Param: fixed data race in param creation

### DIFF
--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -3291,17 +3291,21 @@ bool AP_Param::add_param(uint8_t _key, uint8_t param_num, const char *pname, flo
     }
     ginfo.offset = param_num*sizeof(float);
     ginfo.idx = param_num;
-    ginfo.flags = 0;  // clear the hidden flag if set
     float *def_value = const_cast<float *>(&ginfo.def_value);
     *def_value = default_value;
     ginfo.type = AP_PARAM_FLOAT;
 
-    invalidate_count();
-
-    // load from storage if available
+    // load from storage if available, the param is hidden during this
+    // load so the param is not visible to MAVLink until after it is
+    // loaded
     p.set_default(default_value);
     p.load();
 
+    // clear the hidden flag if set and invalidate the count
+    // so we recount the parameters
+    ginfo.flags = 0;
+    invalidate_count();
+    
     return true;
 }
 #endif


### PR DESCRIPTION
this should properly fix the issue Peter raises in this PR:

https://github.com/ArduPilot/ardupilot/pull/30897

note that I'm avoiding a mutex as the load() is expensive