### PR TITLE
DDS: Fix initialisation on UDP transport

### DIFF
--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -1227,6 +1227,18 @@ void AP_DDS_Client::main_loop(void)
             GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s transport invalid, exiting", msg_prefix);
             return;
         }
+        // If using UDP, check if the network is active before proceeding
+        // not applicable for SITL, which doesn't use AP_Networking
+#if AP_DDS_UDP_ENABLED && !AP_NETWORKING_BACKEND_SITL
+        if (!is_using_serial) {
+            const auto &network = AP::network();
+            if (network.get_ip_active() == 0) {
+                hal.scheduler->delay(1000);
+                continue;
+            }
+
+        }
+#endif
 
         // check ping
         if (ping_max_retry == 0) {

--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -659,7 +659,6 @@ void AP_DDS_Client::update_topic(sensor_msgs_msg_Imu& msg)
     } else {
         initialize(msg.orientation);
     }
-    msg.orientation_covariance[0] = -1;
 
     uint8_t accel_index = ahrs.get_primary_accel_index();
     uint8_t gyro_index = ahrs.get_primary_gyro_index();
@@ -674,8 +673,6 @@ void AP_DDS_Client::update_topic(sensor_msgs_msg_Imu& msg)
     msg.angular_velocity.x = gyro_data.x;
     msg.angular_velocity.y = gyro_data.y;
     msg.angular_velocity.z = gyro_data.z;
-    msg.angular_velocity_covariance[0] = -1;
-    msg.linear_acceleration_covariance[0] = -1;
 }
 #endif // AP_DDS_IMU_PUB_ENABLED
 


### PR DESCRIPTION
This fixes a bug where the DDS initialisation silently fails if it's using UDP transport and the networking has not finished initialised.

This is noticeable on boards using PPP connections, where the PPP can take 5-10 seconds to come up. It was a bit tricky to track down, as it's sometimes networking would come up before DDS and vice versa.

Tested on CubeOrange with PPP connection to Raspberry Pi companion computer.

I also added in a commit for the IMU topic, changing the covariance for -1 to 0 (covariance unknown), which is more in line with ROS definition at https://docs.ros2.org/foxy/api/sensor_msgs/msg/Imu.html