### PR TITLE
Make wind simulation code common between AP_HAL_SITL and SimOnHW

### DIFF
--- a/libraries/AP_DAL/examples/AP_DAL_Standalone/main.cpp
+++ b/libraries/AP_DAL/examples/AP_DAL_Standalone/main.cpp
@@ -51,6 +51,7 @@ public:
             nullptr,
             nullptr,
             nullptr,
+            nullptr,
             nullptr
             ) {}
     void run(int argc, char* const argv[], Callbacks* callbacks) const override {}

--- a/libraries/AP_HAL/HAL.h
+++ b/libraries/AP_HAL/HAL.h
@@ -43,7 +43,9 @@ public:
         AP_HAL::Util*       _util,
         AP_HAL::OpticalFlow*_opticalflow,
         AP_HAL::Flash*      _flash,
-#if AP_SIM_ENABLED && CONFIG_HAL_BOARD != HAL_BOARD_SITL
+#if AP_SIM_ENABLED
+        // note that not much of _simstate is used on AP_HAL_SITL, but
+        // more is being moved in!
         class AP_HAL::SIMState*   _simstate,
 #endif
 #if HAL_WITH_DSP
@@ -82,7 +84,7 @@ public:
             _serial7,
             _serial8,
             _serial9}
-#if AP_SIM_ENABLED && CONFIG_HAL_BOARD != HAL_BOARD_SITL
+#if AP_SIM_ENABLED
             ,simstate(_simstate)
 #endif
     {
@@ -148,7 +150,7 @@ private:
     AP_HAL::UARTDriver* serial_array[num_serial];
 
 public:
-#if AP_SIM_ENABLED && CONFIG_HAL_BOARD != HAL_BOARD_SITL
+#if AP_SIM_ENABLED
     AP_HAL::SIMState *simstate;
 #endif
 

--- a/libraries/AP_HAL/SIMState.cpp
+++ b/libraries/AP_HAL/SIMState.cpp
@@ -1,6 +1,6 @@
 #include "SIMState.h"
 
-#if AP_SIM_ENABLED && CONFIG_HAL_BOARD != HAL_BOARD_SITL
+#if AP_SIM_ENABLED
 
 /*
  *  This is a very-much-cut-down AP_HAL_SITL object.  We should make
@@ -25,6 +25,8 @@
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 
 #include <AP_Baro/AP_Baro.h>
+
+#include <AP_BoardConfig/AP_BoardConfig.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -73,6 +75,7 @@ using namespace AP_HAL;
 #endif
 
 
+#if CONFIG_HAL_BOARD != HAL_BOARD_SITL
 void SIMState::update()
 {
     static bool init_done;
@@ -424,4 +427,6 @@ void SIMState::set_height_agl(void)
     }
 }
 
-#endif  // AP_SIM_ENABLED && CONFIG_HAL_BOARD != HAL_BOARD_SITL
+#endif  // CONFIG_HAL_BOARD != HAL_BOARD_SITL
+
+#endif  // AP_SIM_ENABLED

--- a/libraries/AP_HAL/SIMState.cpp
+++ b/libraries/AP_HAL/SIMState.cpp
@@ -273,37 +273,43 @@ void SIMState::fdm_input_local(void)
 
     _update_count++;
 }
+#endif  // CONFIG_HAL_BOARD != HAL_BOARD_SITL
 
-/*
-  create sitl_input structure for sending to FDM
- */
-void SIMState::_simulator_servos(struct sitl_input &input)
+#if AP_SIM_WIND_SIMULATION_ENABLED
+void SIMState::update_simulated_wind(struct sitl_input &input)
 {
-    if (_sitl == nullptr) {
-        return;
-    }
-
-    // output at chosen framerate
-    uint32_t now = AP_HAL::micros();
-
-    // find the barometer object if it exists
-    const auto *_barometer = AP_Baro::get_singleton();
-
-    float altitude = _barometer?_barometer->get_altitude():0;
     float wind_speed = 0;
     float wind_direction = 0;
     float wind_dir_z = 0;
 
+    uint32_t now = AP_HAL::micros();
+
+    if (_sitl == nullptr)  {
+        _sitl = AP::sitl();
+    }
     // give 5 seconds to calibrate airspeed sensor at 0 wind speed
     if (wind_start_delay_micros == 0) {
         wind_start_delay_micros = now;
     } else if ((now - wind_start_delay_micros) > 5000000) {
         // The EKF does not like step inputs so this LPF keeps it happy.
-        wind_speed =     _sitl->wind_speed_active     = (0.95f*_sitl->wind_speed_active)     + (0.05f*_sitl->wind_speed);
-        wind_direction = _sitl->wind_direction_active = (0.95f*_sitl->wind_direction_active) + (0.05f*_sitl->wind_direction);
-        wind_dir_z =     _sitl->wind_dir_z_active     = (0.95f*_sitl->wind_dir_z_active)     + (0.05f*_sitl->wind_dir_z);
-        
+        uint32_t dt_us = now - last_wind_update_us;
+        if (dt_us > 1000) {
+            last_wind_update_us = now;
+            // slew wind based on the configured time constant
+            const float dt = dt_us * 1.0e-6;
+            const float tc = MAX(_sitl->wind_change_tc, 0.1);
+            const float alpha = calc_lowpass_alpha_dt(dt, 1.0/tc);
+            _sitl->wind_speed_active     += (_sitl->wind_speed - _sitl->wind_speed_active) * alpha;
+            _sitl->wind_direction_active += (wrap_180(_sitl->wind_direction - _sitl->wind_direction_active)) * alpha;
+            _sitl->wind_dir_z_active     += (_sitl->wind_dir_z - _sitl->wind_dir_z_active) * alpha;
+            _sitl->wind_direction_active = wrap_180(_sitl->wind_direction_active);
+        }
+        wind_speed =     _sitl->wind_speed_active;
+        wind_direction = _sitl->wind_direction_active;
+        wind_dir_z =     _sitl->wind_dir_z_active;
+
         // pass wind into simulators using different wind types via param SIM_WIND_T*.
+        const float altitude = _sitl->state.height_agl;
         switch (_sitl->wind_type) {
         case SITL::SIM::WIND_TYPE_SQRT:
             if (altitude < _sitl->wind_type_alt) {
@@ -328,6 +334,20 @@ void SIMState::_simulator_servos(struct sitl_input &input)
     input.wind.direction = wind_direction;
     input.wind.turbulence = _sitl->wind_turbulance;
     input.wind.dir_z = wind_dir_z;
+}
+#endif  // AP_SIM_WIND_SIMULATION_ENABLED
+
+#if CONFIG_HAL_BOARD != HAL_BOARD_SITL
+/*
+  create sitl_input structure for sending to FDM
+ */
+void SIMState::_simulator_servos(struct sitl_input &input)
+{
+    if (_sitl == nullptr) {
+        return;
+    }
+
+    update_simulated_wind(input);
 
     for (uint8_t i=0; i<ARRAY_SIZE(pwm_output); i++) {
         if (pwm_output[i] == 0xFFFF) {

--- a/libraries/AP_HAL/SIMState.h
+++ b/libraries/AP_HAL/SIMState.h
@@ -4,6 +4,11 @@
 
 #if AP_SIM_ENABLED
 
+// this might move elsewhere?
+#ifndef AP_SIM_WIND_SIMULATION_ENABLED
+#define AP_SIM_WIND_SIMULATION_ENABLED 1
+#endif
+
 #include <AP_HAL/AP_HAL.h>
 
 #include <SITL/SITL_Input.h>
@@ -70,7 +75,15 @@ public:
     uint16_t pwm_output[32];  // was SITL_NUM_CHANNELS
 #endif  // CONFIG_HAL_BOARD != HAL_BOARD_SITL
 
+#if AP_SIM_WIND_SIMULATION_ENABLED
+    uint32_t last_wind_update_us;
+    uint32_t wind_start_delay_micros;
+    void update_simulated_wind(struct sitl_input &input);
+#endif  // AP_SIM_WIND_SIMULATION_ENABLED
+
 private:
+    SITL::SIM *_sitl;
+
 #if CONFIG_HAL_BOARD != HAL_BOARD_SITL
     void _set_param_default(const char *parm);
     void _sitl_setup(const char *home_str);
@@ -96,7 +109,6 @@ private:
     pid_t _parent_pid;
     uint32_t _update_count;
 
-    SITL::SIM *_sitl;
     uint16_t _rcin_port;
     uint16_t _fg_view_port;
     uint16_t _irlock_port;
@@ -227,8 +239,6 @@ private:
     const char *defaults_path = HAL_PARAM_DEFAULTS_PATH;
 
     const char *_home_str;
-
-    uint32_t wind_start_delay_micros;
 
 #if AP_SIM_GPS_ENABLED
     // simulated GPS devices

--- a/libraries/AP_HAL/SIMState.h
+++ b/libraries/AP_HAL/SIMState.h
@@ -52,6 +52,7 @@
 class AP_HAL::SIMState {
 public:
 
+#if CONFIG_HAL_BOARD != HAL_BOARD_SITL
     // simulated airspeed, sonar and battery monitor
     uint16_t sonar_pin_value;    // pin 0
     uint16_t airspeed_pin_value[2]; // pin 1
@@ -67,8 +68,10 @@ public:
 #endif
 
     uint16_t pwm_output[32];  // was SITL_NUM_CHANNELS
+#endif  // CONFIG_HAL_BOARD != HAL_BOARD_SITL
 
 private:
+#if CONFIG_HAL_BOARD != HAL_BOARD_SITL
     void _set_param_default(const char *parm);
     void _sitl_setup(const char *home_str);
     void _setup_timer(void);
@@ -231,6 +234,8 @@ private:
     // simulated GPS devices
     SITL::GPS *gps[2];  // constrained by # of parameter sets
 #endif
+
+#endif  // CONFIG_HAL_BOARD != HAL_BOARD_SITL
 };
 
 #endif // AP_SIM_ENABLED

--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
@@ -33,6 +33,7 @@
 #include <AP_InternalError/AP_InternalError.h>
 #include <AP_Logger/AP_Logger.h>
 #include <AP_RCProtocol/AP_RCProtocol_config.h>
+#include <AP_HAL/SIMState.h>
 
 using namespace HALSITL;
 
@@ -49,6 +50,11 @@ static Empty::RCInput  sitlRCInput;
 static RCOutput sitlRCOutput(&sitlState);
 static GPIO sitlGPIO(&sitlState);
 static AnalogIn sitlAnalogIn(&sitlState);
+
+#if AP_SIM_ENABLED
+static AP_HAL::SIMState xsimstate;
+#endif
+
 #if HAL_WITH_DSP
 static DSP dspDriver;
 #endif
@@ -109,6 +115,9 @@ HAL_SITL::HAL_SITL() :
         &utilInstance,      /* util */
         &emptyOpticalFlow,  /* onboard optical flow */
         &emptyFlash,        /* flash driver */
+#if AP_SIM_ENABLED
+&xsimstate,
+#endif
 #if HAL_WITH_DSP
         &dspDriver,         /* dsp driver */
 #endif

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -25,6 +25,8 @@
 #include <SITL/SIM_JSBSim.h>
 #include <AP_HAL/utility/Socket_native.h>
 
+#include <AP_HAL/SIMState.h>
+
 extern const AP_HAL::HAL& hal;
 
 using namespace HALSITL;
@@ -314,57 +316,9 @@ void SITL_State::_simulator_servos(struct sitl_input &input)
     uint32_t now = AP_HAL::micros();
     last_update_usec = now;
 
-    float wind_speed = 0;
-    float wind_direction = 0;
-    float wind_dir_z = 0;
-
-    // give 5 seconds to calibrate airspeed sensor at 0 wind speed
-    if (wind_start_delay_micros == 0) {
-        wind_start_delay_micros = now;
-    } else if ((now - wind_start_delay_micros) > 5000000 ) {
-        // The EKF does not like step inputs so this LPF keeps it happy.
-        uint32_t dt_us = now - last_wind_update_us;
-        if (dt_us > 1000) {
-            last_wind_update_us = now;
-            // slew wind based on the configured time constant
-            const float dt = dt_us * 1.0e-6;
-            const float tc = MAX(_sitl->wind_change_tc, 0.1);
-            const float alpha = calc_lowpass_alpha_dt(dt, 1.0/tc);
-            _sitl->wind_speed_active     += (_sitl->wind_speed - _sitl->wind_speed_active) * alpha;
-            _sitl->wind_direction_active += (wrap_180(_sitl->wind_direction - _sitl->wind_direction_active)) * alpha;
-            _sitl->wind_dir_z_active     += (_sitl->wind_dir_z - _sitl->wind_dir_z_active) * alpha;
-            _sitl->wind_direction_active = wrap_180(_sitl->wind_direction_active);
-        }
-        wind_speed =     _sitl->wind_speed_active;
-        wind_direction = _sitl->wind_direction_active;
-        wind_dir_z =     _sitl->wind_dir_z_active;
-        
-        // pass wind into simulators using different wind types via param SIM_WIND_T*.
-        const float altitude = _sitl->state.height_agl;
-        switch (_sitl->wind_type) {
-        case SITL::SIM::WIND_TYPE_SQRT:
-            if (altitude < _sitl->wind_type_alt) {
-                wind_speed *= sqrtf(MAX(altitude / _sitl->wind_type_alt, 0));
-            }
-            break;
-
-        case SITL::SIM::WIND_TYPE_COEF:
-            wind_speed += (altitude - _sitl->wind_type_alt) * _sitl->wind_type_coef;
-            break;
-
-        case SITL::SIM::WIND_TYPE_NO_LIMIT:
-        default:
-            break;
-        }
-
-        // never allow negative wind velocity
-        wind_speed = MAX(wind_speed, 0);
-    }
-
-    input.wind.speed = wind_speed;
-    input.wind.direction = wind_direction;
-    input.wind.turbulence = _sitl->wind_turbulance;
-    input.wind.dir_z = wind_dir_z;
+#if AP_SIM_WIND_SIMULATION_ENABLED
+    hal.simstate->update_simulated_wind(input);
+#endif  // AP_SIM_WIND_SIMULATION_ENABLED
 
     for (uint8_t i=0; i<SITL_NUM_CHANNELS; i++) {
         if (pwm_output[i] == 0xFFFF) {

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -105,8 +105,6 @@ private:
     VectorN<readings_wind,wind_buffer_length> buffer_wind;
     uint32_t time_delta_wind;
     uint32_t delayed_time_wind;
-    uint32_t wind_start_delay_micros;
-    uint32_t last_wind_update_us;
 
     // returns a voltage between 0V to 5V which should appear as the
     // voltage from the sensor


### PR DESCRIPTION
The implementations had drifted a little bit here; the stuff we use in SITL had been improved in a couple of ways which the SIMState stuff lacked.
