### PR TITLE
SITL: prevent movement in simulation startup for rovers

### DIFF
--- a/libraries/SITL/SIM_Rover.cpp
+++ b/libraries/SITL/SIM_Rover.cpp
@@ -109,6 +109,13 @@ void SimRover::update(const struct sitl_input &input)
         update_ackermann_or_skid(input, delta_time);
     }
 
+    if (!input.initialised()) {
+        // outputs are not yet initialised, prevent unintended
+        // movement
+        accel_body.zero();
+        velocity_ef.zero();
+    }
+
     // common to all rovers
 
     // now in earth frame

--- a/libraries/SITL/SIM_Sailboat.cpp
+++ b/libraries/SITL/SIM_Sailboat.cpp
@@ -291,6 +291,12 @@ void Sailboat::update(const struct sitl_input &input)
     // add in accel due to direction change
     accel_body.y += radians(yaw_rate) * speed;
 
+    if (!input.initialised()) {
+        // outputs are not yet initialised, prevent unintended
+        // movement
+        accel_body.zero();
+    }
+
     // now in earth frame
     // remove roll and pitch effects from waves
     float r, p, y;

--- a/libraries/SITL/SITL_Input.h
+++ b/libraries/SITL/SITL_Input.h
@@ -14,5 +14,15 @@ struct sitl_input {
         float turbulence;
         float dir_z;	  //degrees -90..90
     } wind;
+
+    // see if the servos have been initialised
+    bool initialised(void) const {
+        for (uint8_t i=0; i<ARRAY_SIZE(servos); i++) {
+            if (servos[i] != 0) {
+                return true;
+            }
+        }
+        return false;
+    }
 };
 


### PR DESCRIPTION
this provides an easy mechanism to prevent simulated vehicles from moving before the actuators are initialised. In this case it is being applied to rovers, which fixes a real issue with the motorboat simulation which makes it move backwards on startup