### PR TITLE
Plane: remove the roll rate limit in fixed wing recovery

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -4272,6 +4272,11 @@ bool QuadPlane::use_fw_attitude_controllers(void) const
         }
     }
 
+    if (force_fw_control_recovery) {
+        // tell the roll controller not to apply roll rate limits
+        plane.rollController.set_in_recovery();
+    }
+
     return true;
 }
 

--- a/libraries/APM_Control/AP_RollController.cpp
+++ b/libraries/APM_Control/AP_RollController.cpp
@@ -220,12 +220,18 @@ float AP_RollController::get_servo_out(int32_t angle_err, float scaler, bool dis
         }
     }
 
-    // Limit the demanded roll rate
-    if (gains.rmax_pos && desired_rate < -gains.rmax_pos) {
-        desired_rate = - gains.rmax_pos;
-    } else if (gains.rmax_pos && desired_rate > gains.rmax_pos) {
-        desired_rate = gains.rmax_pos;
+    if (!in_recovery) {
+        // Limit the demanded roll rate. When we are in a VTOL
+        // recovery we don't apply the limit
+        if (gains.rmax_pos && desired_rate < -gains.rmax_pos) {
+            desired_rate = - gains.rmax_pos;
+        } else if (gains.rmax_pos && desired_rate > gains.rmax_pos) {
+            desired_rate = gains.rmax_pos;
+        }
     }
+
+    // the in_recovery flag is single loop only
+    in_recovery = false;
 
     return _get_rate_out(desired_rate, scaler, disable_integrator, get_airspeed(), ground_mode);
 }

--- a/libraries/APM_Control/AP_RollController.h
+++ b/libraries/APM_Control/AP_RollController.h
@@ -16,8 +16,18 @@ public:
 
     void convert_pid();
 
+    /*
+      set the in_recovery flag, which is used during a VTOL upset recovery
+      this flag only lasts one loop
+    */
+    void set_in_recovery(void) {
+        in_recovery = true;
+    }
+
 private:
     float get_airspeed() const override;
     bool is_underspeed(const float aspeed) const override;
     float get_measured_rate() const override;
+
+    bool in_recovery;
 };


### PR DESCRIPTION
When we are recovering a VTOL plane from an upset attitude we use the fixed wing attitude controller. The roll rate limit RLL2SRV_RMAX can severely limit the speed of recovery as it also applies to the VTOL rate controller rate demand.
After discussions with @priseborough we decided it is best to just remove the limit when in a recovery operation. Getting the aircraft back upright very quickly is critical, if we take too long then the aircraft can get into a state where recovery becomes impossible.
