### PR TITLE
Plane: added BBX messages for blackbox logging

### DIFF
--- a/ArduPlane/Plane.cpp
+++ b/ArduPlane/Plane.cpp
@@ -316,6 +316,10 @@ void Plane::update_logging25(void)
 
     if (should_log(MASK_LOG_IMU))
         AP::ins().Write_Vibration();
+
+#if AP_PLANE_BLACKBOX_LOGGING
+    Log_Write_Blackbox();
+#endif
 }
 #endif  // HAL_LOGGING_ENABLED
 

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -959,6 +959,10 @@ private:
     void Log_Write_RC(void);
     void Log_Write_Vehicle_Startup_Messages();
     void Log_Write_AETR();
+
+#if AP_PLANE_BLACKBOX_LOGGING
+    void Log_Write_Blackbox(void);
+#endif
 #endif
 
     // Parameters.cpp


### PR DESCRIPTION
this was requested by the developers of FlightCoach to improve the display of the ribbon by ensuring that all the data they use is time aligned.