### PR TITLE
autotest: correct EK3AccelBias test race condition

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1324,11 +1324,13 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.context_push()
 
         self.start_test("Test zero bias")
+        self.delay_sim_time(2)
         dfreader_tstart = self.assert_dataflash_message_field_level_at(
             "XKF2",
             "AZ",
             0.0,
             condition="XKF2.C==1",
+            maintain=1,
         )
 
         # Add 2m/s/s bias to the second IMU


### PR DESCRIPTION
this first test wants 1 second of the bias remaining at zero - but the autopilot may not have logged that much data when we check.  So delay 2 seconds and ensure that we only check 1 second of data.