### PR TITLE
autotest: make error on quadplane ship landing larger

### DIFF
--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -1702,7 +1702,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
 
         distance = self.get_distance_int(vehicle_gpi, ship_gpi)
         self.progress(f"{distance=}")
-        max_distance = 1
+        max_distance = 1.2
         if distance > max_distance:
             raise NotAchievedException(f"Did not land within {max_distance}m of ship {distance=}")
 


### PR DESCRIPTION
the tune on the aircraft causes sinusoidal oscilation which means we miss