### PR TITLE
board_types.txt : add board ID for AP_HW_MicoAir743-Lite

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -318,6 +318,7 @@ AP_HW_AEDROXH7                       1198
 AP_HW_NarinX3                        1199
 AP_HW_JFB200                         1200
 AP_HW_SKYSTARSF405V2                 1201
+AP_HW_MicoAir743-Lite                1202
 
 AP_HW_ESP32_PERIPH                   1205
 AP_HW_ESP32S3_PERIPH                 1206


### PR DESCRIPTION
Dear ardupilot developers,

We are [MicoAir Tech.](micoair.com). And this PR reserves an ID for the upcoming MicoAir743-Lite.

Best Regard!
Minderring, MicoAir Tech.