### PR TITLE
AP_GPS: do not zero blended weights if no-fix from a GPS

### DIFF
--- a/libraries/AP_GPS/AP_GPS_Blended.cpp
+++ b/libraries/AP_GPS/AP_GPS_Blended.cpp
@@ -16,10 +16,6 @@
 */
 bool AP_GPS_Blended::_calc_weights(void)
 {
-    // zero the blend weights
-    memset(&_blend_weights, 0, sizeof(_blend_weights));
-
-
     static_assert(GPS_MAX_RECEIVERS == 2, "GPS blending only currently works with 2 receivers");
     // Note that the early quit below relies upon exactly 2 instances
     // The time delta calculations below also rely upon every instance being currently detected and being parsed


### PR DESCRIPTION
if a GPS loses fix then we do not necessarily become unhealthy - there's a health counter which updates and must pass a threshold to be unhealthy.

If we zero the blended weights when a GPS loses fix *and* the other has a fix then we will end up not only having a bad location but also having zero velocities and accuracies as we multiply by the weights to find a blended number.

Using stale eights would seem to be the only option if we want to have hysteresis on the blended health even when a GPS loses its fix