### PR TITLE
AP_Motors: add governor engage condition to rotor runup complete check

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -457,7 +457,7 @@ void AP_MotorsHeli_RSC::update_rotor_runup(float dt)
     }
 
     // if rotor ramp and runup are both at full speed, then run-up has been completed
-    if (!_runup_complete && (_rotor_ramp_output >= 1.0f) && (_rotor_runup_output >= 1.0f)) {
+    if (!_runup_complete && (_rotor_ramp_output >= 1.0f) && (_rotor_runup_output >= 1.0f) && (_control_mode == ROTOR_CONTROL_MODE_AUTOTHROTTLE ? _governor_engage : true)) {
         _runup_complete = true;
     }
     // if rotor speed is less than critical speed, then run-up is not complete


### PR DESCRIPTION
This PR adds a safety barrier before declaring run-up complete if RSC mode 4 is used.
Currently the code would only look at the timer run-up to be completed, not considering the governor status. This would allow a take-off in Auto even if the governor has not succesfully engaged.