### PR TITLE
Rover: fix accel limit and limit throttle ouput

### DIFF
--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -1041,9 +1041,8 @@ float AR_AttitudeControl::get_desired_speed() const
 // get acceleration limited desired speed
 float AR_AttitudeControl::get_desired_speed_accel_limited(float desired_speed, float dt) const
 {
-    // return input value if no recent calls to speed controller
     // apply no limiting when ATC_ACCEL_MAX is set to zero
-    if (!speed_control_active() || !is_positive(_throttle_accel_max)) {
+    if (!is_positive(_throttle_accel_max)) {
         return desired_speed;
     }
 

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -819,7 +819,7 @@ float AR_AttitudeControl::get_throttle_out_speed(float desired_speed, bool motor
     }
 
     // final output throttle in range -1 to 1
-    return throttle_out;
+    return constrain_float(throttle_out, -1.0f, 1.0f);
 }
 
 // return a throttle output from -1 to +1 to perform a controlled stop.  returns true once the vehicle has stopped


### PR DESCRIPTION
While working on the rover speed controller diagram [#7059](https://github.com/ArduPilot/ardupilot_wiki/pull/7059), I found two potential minor improvements. Below are the proposed changes:

1. Accel limit: Currently, the code never reaches the second `!speed_control_active()` condition. With the suggested change, we retain the enhancement introduced in [#8428](https://github.com/ArduPilot/ardupilot/pull/8428).

2. Speed-throttle controller: Add a constraint to the throttle output in the speed controller to align with the related comment.