### PR TITLE
AP_GPS: Fix undulation sign across codebase

### DIFF
--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -460,7 +460,7 @@ void AP_GPS_Backend::set_alt_amsl_cm(AP_GPS::GPS_State &_state, int32_t alt_amsl
     if (option_set(AP_GPS::HeightEllipsoid) && _state.have_undulation) {
         // user has asked ArduPilot to use ellipsoid height in the
         // canonical height for mission and navigation
-        _state.location.alt = alt_amsl_cm - _state.undulation*100;
+        _state.location.alt = alt_amsl_cm + _state.undulation*100;
     } else {
         _state.location.alt = alt_amsl_cm;
     }


### PR DESCRIPTION
The correct form of the equation is `ellipsoidal_m = msl_m + undulation_m​`. We forgot this place in the code in this rarely used option bit code block, and all of AP's internal undulation was still incorrect.

FYI @tizianofiorenzani 