### PR TITLE
AP_HAL_SITL: check loop time more rapidly in threads

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -14896,7 +14896,7 @@ return update, 1000
             self.GPSBlendingLog,
             self.GPSBlendingAffinity,
             self.DataFlash,
-            Test(self.DataFlashErase, attempts=8),
+            self.DataFlashErase,
             self.Callisto,
             self.PerfInfo,
             self.ModeAllowsEntryWhenNoPilotInput,

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -3887,13 +3887,13 @@ class TestSuite(abc.ABC):
         if ex is not None:
             raise ex
 
-    def download_full_log_list(self, print_logs=True):
+    def download_full_log_list(self, print_logs=True, LOG_ENTRY_sanity_check=True):
         tstart = self.get_sim_time()
         self.mav.mav.log_request_list_send(self.sysid_thismav(),
                                            1, # target component
                                            0,
                                            0xffff)
-        logs = {}
+        logs : dict[int : mavutil.MAVLink.MAVLink_log_entry_message] = {}
         last_id = None
         num_logs = None
         while True:
@@ -3929,7 +3929,8 @@ class TestSuite(abc.ABC):
                 break
 
         # ensure we don't get any extras:
-        self.assert_not_receiving_message('LOG_ENTRY', timeout=2)
+        if LOG_ENTRY_sanity_check:
+            self.assert_not_receiving_message('LOG_ENTRY', timeout=2)
 
         return logs
 
@@ -10648,6 +10649,19 @@ Also, ignores heartbeats not from our target system'''
 
         if herrors > header_errors:
             raise NotAchievedException("Error parsing log file %s, %d header errors" % (logname, herrors))
+
+    def assert_current_log_filesizes(self, sizes):
+        file_list = self.download_full_log_list(LOG_ENTRY_sanity_check=False)
+        self.progress(f"List: {file_list}")
+        for file_id, minmax in sizes.items():
+            (minsize, maxsize) = minmax
+            if file_id not in file_list:
+                raise NotAchievedException(f"{file_id} not in downloaded log info")
+            m = file_list[file_id]
+            if m.size < minsize:
+                raise NotAchievedException(f"{file_id} too small; got={m.size} want>{minsize}")
+            if m.size > maxsize:
+                raise NotAchievedException(f"{file_id} too large; got={m.size} want<{minsize}")
 
     def DataFlashErase(self):
         """Test that erasing the dataflash chip and creating a new log is error free"""

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -3929,12 +3929,7 @@ class TestSuite(abc.ABC):
                 break
 
         # ensure we don't get any extras:
-        m = self.mav.recv_match(type='LOG_ENTRY',
-                                blocking=True,
-                                timeout=2)
-        if m is not None:
-            raise NotAchievedException("Received extra LOG_ENTRY?!")
-        # should be: m = self.assert_not_receive_message('LOG_ENTRY', timeout=2)
+        self.assert_not_receiving_message('LOG_ENTRY', timeout=2)
 
         return logs
 

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -10671,59 +10671,62 @@ Also, ignores heartbeats not from our target system'''
         self.context_push()
         try:
             self.set_parameters({
+                "LOG_DISARMED": 0,
                 "LOG_BACKEND_TYPE": 4,
-                "SIM_SPEEDUP": 20,
+                "SIM_SPEEDUP": 10,
             })
             self.reboot_sitl()
             mavproxy.send("module load log\n")
             mavproxy.send("log erase\n")
             mavproxy.expect("Chip erase complete")
-            self.set_parameter("LOG_DISARMED", 1)
+
+            self.set_autodisarm_delay(0)
+
+            self.progress("Creating a very short log")
+            self.wait_ready_to_arm()
+            self.arm_vehicle()
             self.delay_sim_time(3)
-            self.set_parameter("LOG_DISARMED", 0)
+            self.disarm_vehicle()
             mavproxy.send("log download 1 logs/dataflash-log-erase.BIN\n")
             mavproxy.expect("Finished downloading", timeout=120)
             # read the downloaded log - it must parse without error
             self.validate_log_file("logs/dataflash-log-erase.BIN")
             self.assert_current_log_filesizes({
-                1: (10*1024, 50*1024),  # got=30246
+                1: (500*1024, 600*1024),
             })
 
             self.start_subtest("Test file wrapping results in a valid file")
             self.set_parameter("LOG_FILE_DSRMROT", 1)
             self.set_parameter("LOG_BITMASK", 131071)
             self.wait_ready_to_arm()
-            if not self.is_copter() or self.is_plane():
-                raise ValueError("No valid except on Plane or Copter")
 
-            self.progress("Appending to create ~270kB log")
-            self.set_autodisarm_delay(30)
+            self.progress("Appending to create larger log")
             self.arm_vehicle()
-            self.wait_disarmed()
+            self.delay_sim_time(10)
+            self.disarm_vehicle()
             self.assert_current_log_filesizes({
-                1: (300*1024, 320*1024),  # got=314496
+                1: (1900*1024, 2200*1024),
             })
             self.progress("Creating a second 200kB log")
-            self.set_autodisarm_delay(30)
             self.arm_vehicle()
-            self.wait_disarmed()
+            self.delay_sim_time(10)
+            self.disarm_vehicle()
             self.assert_current_log_filesizes({
-                1: (300*1024, 320*1024),  # got=314496
-                2: (215*1024, 255*1024),  # got=235496
+                1: (1900*1024, 2200*1024),
+                2: (1000*1024, 1700*1024),
             })
 
-            self.progress("Creating a third 500kB log")
-            self.set_autodisarm_delay(50)
+            self.progress("Creating a very large log which wipes the other ones out")
+            self.context_collect('STATUSTEXT')
             self.arm_vehicle()
-            self.wait_disarmed()
+            self.wait_statustext('Chip full, logging stopped', check_context=True, timeout=60)
+            self.disarm_vehicle()
 
             # make sure we have finished logging
             self.delay_sim_time(15)
 
             self.assert_current_log_filesizes({
-                1: (300*1024, 320*1024),  # got=314496
-                2: (215*1024, 255*1024),  # got=235496
-                3: (480*1024, 520*1024),  # got=500746
+                1: (3809996, 4109996),
             })
 
             mavproxy.send("log list\n")
@@ -10735,16 +10738,12 @@ Also, ignores heartbeats not from our target system'''
                 else:
                     self.progress("SITL is NOT running")
                 raise NotAchievedException("Received %s" % str(e))
-            if int(mavproxy.match.group(2)) != 3:
-                raise NotAchievedException("Expected 3 logs got %s" % (mavproxy.match.group(2)))
+            if int(mavproxy.match.group(2)) != 1:
+                raise NotAchievedException("Expected 1 log got %s" % (mavproxy.match.group(2)))
 
             mavproxy.send("log download 1 logs/dataflash-log-erase2.BIN\n")
             mavproxy.expect("Finished downloading", timeout=120)
-            self.validate_log_file("logs/dataflash-log-erase2.BIN", 1)
-
-            mavproxy.send("log download latest logs/dataflash-log-erase3.BIN\n")
-            mavproxy.expect("Finished downloading", timeout=120)
-            self.validate_log_file("logs/dataflash-log-erase3.BIN", 1)
+            self.validate_log_file("logs/dataflash-log-erase2.BIN", header_errors=1)
 
             # clean up
             mavproxy.send("log erase\n")

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -176,7 +176,7 @@ void SITL_State::wait_clock(uint64_t wait_time_usec)
                 }
             }
 #endif
-            usleep(1000);
+            usleep(10);
         }
     }
     // check the outbound TCP queue size.  If it is too long then


### PR DESCRIPTION
sleeping for 1ms limits the rate at which the logging thread (a real pthread in SITL!) can log.  If it only wakes up at 1kHz and only sends 1 4kB block each time it runs then that limits the logging rate to 4MB/second.  When we are running at over 40x speedup that means ArduPilot can only log at ~100kB/simulatedsecond - which is very close to our actual rate.  If an autotest tries to log faster (e.g test.Copter.FAST_ATTITUDE) then we start dropping log messages.

master:
<img width="2069" height="913" alt="image" src="https://github.com/user-attachments/assets/82c192e7-3d4c-4928-bee2-e80d1584b191" />

This:
<img width="2069" height="913" alt="image" src="https://github.com/user-attachments/assets/77e1e755-b75a-4d37-8b5f-c8e51d559d0c" />
