### PR TITLE
AP_HAL_ESP32: allow SPI buses and devices to come from hwdef.dat files

### DIFF
--- a/Tools/scripts/size_compare_branches.py
+++ b/Tools/scripts/size_compare_branches.py
@@ -812,7 +812,6 @@ class SizeCompareBranches(object):
 
             result.vehicle[vehicle] = {}
             v = result.vehicle[vehicle]
-            v["bin_filename"] = self.vehicle_map[vehicle] + '.bin'
 
             elf_dirname = "bin"
             if vehicle == 'bootloader':
@@ -826,10 +825,19 @@ class SizeCompareBranches(object):
                     self.progress("Have source trees")
                 except FileNotFoundError:
                     pass
-            v["bin_dir"] = os.path.join(elf_basedir, task.board, "bin")
-            elf_dir = os.path.join(elf_basedir, task.board, elf_dirname)
-            v["elf_dir"] = elf_dir
-            v["elf_filename"] = self.vehicle_map[vehicle]
+            bin_dirname = "bin"
+            bin_filename = self.vehicle_map[vehicle] + '.bin'
+            elf_filename = self.vehicle_map[vehicle]
+            esp32_elf_dirname = "esp-idf_build"
+            if os.path.exists(os.path.join(elf_basedir, task.board, esp32_elf_dirname)):
+                bin_filename = "ardupilot.bin"
+                elf_dirname = esp32_elf_dirname
+                bin_dirname = elf_dirname
+                elf_filename = "ardupilot.elf"
+            v["bin_dir"] = os.path.join(elf_basedir, task.board, bin_dirname)
+            v["bin_filename"] = bin_filename
+            v["elf_dir"] = os.path.join(elf_basedir, task.board, elf_dirname)
+            v["elf_filename"] = elf_filename
 
         return result
 

--- a/libraries/AP_HAL_ESP32/boards/esp32s3m5stampfly.h
+++ b/libraries/AP_HAL_ESP32/boards/esp32s3m5stampfly.h
@@ -87,18 +87,8 @@
 // r-up, l-down, l-up, r-down (quad X order)
 #define HAL_ESP32_RCOUT { GPIO_NUM_42, GPIO_NUM_10, GPIO_NUM_5, GPIO_NUM_41 }
 
-// SPI BUS setup, including gpio, dma, etc
-#define HAL_ESP32_SPI_BUSES \
-    {.host=SPI2_HOST, .dma_ch=SPI_DMA_CH_AUTO, .mosi=GPIO_NUM_14, .miso=GPIO_NUM_43, .sclk=GPIO_NUM_44}
-// SPI2 was used in original firmware
-
-// SPI per-device setup, including speeds, etc.
-// the optical flow sensor (pixartflow) is on the same bus as the main IMU so
-// a) we have to list it here so its CS gets deasserted and the IMU can talk, but
-// b) we name it something the driver won't find because it's too slow and ties up the bus
-#define HAL_ESP32_SPI_DEVICES \
-    {.name= "bmi270", .bus=0, .device=0, .cs=GPIO_NUM_46, .mode=3, .lspeed=10*MHZ, .hspeed=10*MHZ}, \
-    {.name="pixartflow_disabled", .bus=0, .device=1, .cs=GPIO_NUM_12, .mode=3, .lspeed=2*MHZ, .hspeed=2*MHZ},
+// SPI BUS setup, including gpio, dma, etc is in the hwdef.dat
+// SPI per-device setup, including speeds, etc. is in the hwdef.dat
 
 //I2C bus list. bus 0 is internal, bus 1 is the red grove connector
 #define HAL_ESP32_I2C_BUSES \

--- a/libraries/AP_HAL_ESP32/hwdef/esp32s3m5stampfly/hwdef.dat
+++ b/libraries/AP_HAL_ESP32/hwdef/esp32s3m5stampfly/hwdef.dat
@@ -1,3 +1,17 @@
+
+# SPI Buses; see PlatformIO infrastructure for available values
+#            Host      DMA Channel     MOSI        MISO        SCLK
+ESP32_SPIBUS SPI2_HOST SPI_DMA_CH_AUTO GPIO_NUM_14 GPIO_NUM_43 GPIO_NUM_44
+
+# the optical flow sensor (pixartflow) is on the same bus as the main IMU so
+# a) we have to list it here so its CS gets deasserted and the IMU can talk, but
+# b) we name it something the driver won't find because it's too slow and ties up the bus
+
+# SPI Devices - see PlatformIO infrastructure for available values
+#            Name                Bus   Device  ChipSel      Mode LoSpeed HiSpeed
+ESP32_SPIDEV bmi270              0     0       GPIO_NUM_46  3    10*MHZ  10*MHZ
+ESP32_SPIDEV pixartflow_disabled 0     1       GPIO_NUM_12  3     2*MHZ   2*MHZ
+
 # the stampfly does not have an Airspeed sensor:
 define AP_AIRSPEED_ENABLED 0
 

--- a/libraries/AP_HAL_ESP32/hwdef/esp32s3m5stampfly/hwdef.dat
+++ b/libraries/AP_HAL_ESP32/hwdef/esp32s3m5stampfly/hwdef.dat
@@ -1,5 +1,5 @@
 
-# SPI Buses; see PlatformIO infrastructure for available values
+# SPI Buses; https://docs.espressif.com/projects/esp-idf/en/v5.3.4/esp32/api-reference/peripherals/spi_master.html
 #            Host      DMA Channel     MOSI        MISO        SCLK
 ESP32_SPIBUS SPI2_HOST SPI_DMA_CH_AUTO GPIO_NUM_14 GPIO_NUM_43 GPIO_NUM_44
 
@@ -7,7 +7,7 @@ ESP32_SPIBUS SPI2_HOST SPI_DMA_CH_AUTO GPIO_NUM_14 GPIO_NUM_43 GPIO_NUM_44
 # a) we have to list it here so its CS gets deasserted and the IMU can talk, but
 # b) we name it something the driver won't find because it's too slow and ties up the bus
 
-# SPI Devices - see PlatformIO infrastructure for available values
+# SPI Devices
 #            Name                Bus   Device  ChipSel      Mode LoSpeed HiSpeed
 ESP32_SPIDEV bmi270              0     0       GPIO_NUM_46  3    10*MHZ  10*MHZ
 ESP32_SPIDEV pixartflow_disabled 0     1       GPIO_NUM_12  3     2*MHZ   2*MHZ

--- a/libraries/AP_HAL_ESP32/hwdef/scripts/esp32_hwdef.py
+++ b/libraries/AP_HAL_ESP32/hwdef/scripts/esp32_hwdef.py
@@ -7,7 +7,8 @@ AP_FLAKE8_CLEAN
 '''
 
 import argparse
-# import shlex
+import shlex
+import re
 import sys
 import os
 
@@ -19,13 +20,16 @@ class ESP32HWDef(hwdef.HWDef):
 
     def __init__(self, quiet=False, outdir=None, hwdef=[]):
         super(ESP32HWDef, self).__init__(quiet=quiet, outdir=outdir, hwdef=hwdef)
+        # lists of ESP32_SPIDEV buses and devices
+        self.esp32_spibus = []
+        self.esp32_spidev = []
 
     def write_hwdef_header_content(self, f):
         for d in self.alllines:
             if d.startswith('define '):
                 f.write('#define %s\n' % d[7:])
 
-        # self.write_SPI_config(f)
+        self.write_SPI_config(f)
         self.write_IMU_config(f)
         self.write_MAG_config(f)
         self.write_BARO_config(f)
@@ -38,9 +42,81 @@ class ESP32HWDef(hwdef.HWDef):
         self.all_lines.append(line)
         self.alllines.append(line)
 
-        # a = shlex.split(line, posix=False)
+        a = shlex.split(line, posix=False)
+        if a[0] == 'ESP32_SPIBUS':
+            self.process_line_esp32_spibus(line, depth, a)
+        if a[0] == 'ESP32_SPIDEV':
+            self.process_line_esp32_spidev(line, depth, a)
 
         super(ESP32HWDef, self).process_line(line, depth)
+
+    # SPI_BUS support:
+    def process_line_esp32_spibus(self, line, depth, a):
+        self.esp32_spibus.append(a[1:])
+
+    def SPI_config_define_line_for_dev(self, define_name, dev, n):
+        '''return a #define line for a ESP32_SPIBUS config line'''
+        (host, dma_ch, mosi, miso, sclk) = dev
+        return "{{ .host={host}, .dma_ch={dma_ch}, .mosi={mosi}, .miso={miso}, .sclk={sclk} }},"
+
+    def write_SPI_bus_table(self, f):
+        '''write SPI bus table'''
+        if len(self.esp32_spibus) == 0:
+            f.write('\n// No SPI buses\n')
+            return
+
+        f.write('\n// SPI bus table\n')
+        buslist = []
+        for bus in self.esp32_spibus:
+            if len(bus) != 5:
+                self.error(f"Badly formed ESP32_SPIBUS line {bus} {len(bus)=}")
+            (host, dma_ch, mosi, miso, sclk) = bus
+            buslist.append(f"{{ .host={host}, .dma_ch={dma_ch}, .mosi={mosi}, .miso={miso}, .sclk={sclk} }},")
+        f.write('#define HAL_ESP32_SPI_BUSES \\\n')
+        f.write(',\\\n'.join([f"   {x}" for x in buslist]))
+        f.write("\n")
+
+    def process_line_esp32_spidev(self, line, depth, a):
+        self.esp32_spidev.append(a[1:])
+
+    def write_SPI_device_table(self, f):
+        '''write SPI device table'''
+        if len(self.esp32_spidev) == 0:
+            f.write('\n// No SPI devices\n')
+            return
+
+        f.write('\n// SPI device table\n')
+        devlist = []
+        for dev in self.esp32_spidev:
+            if len(dev) != 7:
+                self.error(f"Badly formed ESP32_SPIDEV line {dev} {len(dev)=}")
+            (name, bus, device, cs, mode, lowspeed, highspeed) = dev
+            if not re.match(r"^\d+$", bus):
+                raise ValueError(f"Bad ESP32_SPIDEV bus ({bus}) (must be digits)")
+            if not re.match(r"^\d+$", device):
+                raise ValueError(f"Bad ESP32_SPIDEV device ({device}) (must be digits)")
+            if not re.match(r"^\w+$", cs):
+                raise ValueError(f"Bad ESP32_SPIDEV cs ({cs}) (must be word characters)")
+            if not re.match(r"^\d+$", mode):
+                raise ValueError(f"Bad ESP32_SPIDEV mode ({mode}) (must be digits)")
+            if not lowspeed.endswith('*MHZ') and not lowspeed.endswith('*KHZ'):
+                self.error("Bad lowspeed value %s in ESP32_SPIDEV line %s" % (lowspeed, dev))
+            if not highspeed.endswith('*MHZ') and not highspeed.endswith('*KHZ'):
+                self.error("Bad highspeed value %s in ESP32_SPIDEV line %s" %
+                           (highspeed, dev))
+            devlist.append(f"{{.name= \"{name}\", .bus={bus}, .device={device}, .cs={cs}, .mode={mode}, .lspeed={lowspeed}, .hspeed={highspeed}}}")  # noqa:E501
+        f.write('#define HAL_ESP32_SPI_DEVICES \\\n')
+        f.write(',\\\n'.join([f"   {x}" for x in devlist]))
+        f.write("\n")
+
+    def write_SPI_config(self, f):
+        '''write SPI config defines'''
+
+        if len(self.esp32_spibus):
+            self.write_SPI_bus_table(f)
+
+        if len(self.esp32_spidev):
+            self.write_SPI_device_table(f)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I've only changed the stampfly over, but it does compile :-)

New generated table:
```
// SPI bus table
#define HAL_ESP32_SPI_BUSES \
   { .host=SPI2_HOST, .dma_ch=SPI_DMA_CH_AUTO, .mosi=GPIO_NUM_14, .miso=GPIO_NUM_43, .sclk=GPIO_NUM_44 },

// SPI device table
#define HAL_ESP32_SPI_DEVICES \
   {.name= "bmi270", .bus=0, .device=0, .cs=GPIO_NUM_46, .mode=3, .lspeed=10*MHZ, .hspeed=10*MHZ},\
   {.name= "no_pixart", .bus=0, .device=1, .cs=GPIO_NUM_12, .mode=3, .lspeed=2*MHZ, .hspeed=2*MHZ}

```

vs

```
-#define HAL_ESP32_SPI_BUSES \
-    {.host=SPI2_HOST, .dma_ch=SPI_DMA_CH_AUTO, .mosi=GPIO_NUM_14, .miso=GPIO_NUM_43, .sclk=GPIO_NUM_44}
```

and
```
-#define HAL_ESP32_SPI_DEVICES \
-    {.name= "bmi270", .bus=0, .device=0, .cs=GPIO_NUM_46, .mode=3, .lspeed=10*MHZ, .hspeed=10*MHZ}, \
-    {.name="pixartflow_disabled", .bus=0, .device=1, .cs=GPIO_NUM_12, .mode=3, .lspeed=2*MHZ, .hspeed=2*MHZ},
```