### PR TITLE
AP_GPS: fix SBF undulation usage

### DIFF
--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -440,11 +440,8 @@ AP_GPS_SBF::parse(uint8_t temp)
 
 static bool is_DNU(double value)
 {
-    constexpr double DNU = -2e-10f;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wfloat-equal" // suppress -Wfloat-equal as it's false positive when testing for DNU values
-    return value != DNU;
-#pragma GCC diagnostic pop
+    constexpr double DNU = -2e10;
+    return is_equal(value, DNU);
 }
 
 bool


### PR DESCRIPTION
Correct handling of ellipsoid and AMSL altitudes from SBF receivers. Previously, undulation was not applied properly, causing altitude values to be reported as elipsoid only.

Bug was introduced in [!27859](https://github.com/ArduPilot/ardupilot/pull/27859)

Before fix altidude above elipsoid is not reported:
<img width="1348" height="765" alt="image" src="https://github.com/user-attachments/assets/736b0e11-3c22-4328-827f-fcc25818dede" />

After fix correct altitude above elipsoid is reported:
<img width="1505" height="710" alt="image" src="https://github.com/user-attachments/assets/e488b1ab-8d19-40f4-83b6-ee6a42a98c73" />
