### PR TITLE
AP_InertialSensor: track primary gyro with the in-flight FFT

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -161,9 +161,9 @@ public:
 
     // FFT support access
 #if HAL_GYROFFT_ENABLED
-    const Vector3f& get_gyro_for_fft(void) const { return _gyro_for_fft[_first_usable_gyro]; }
+    const Vector3f& get_gyro_for_fft(void) const { return _gyro_for_fft[_primary]; }
     FloatBuffer&  get_raw_gyro_window(uint8_t instance, uint8_t axis) { return _gyro_window[instance][axis]; }
-    FloatBuffer&  get_raw_gyro_window(uint8_t axis) { return get_raw_gyro_window(_first_usable_gyro, axis); }
+    FloatBuffer&  get_raw_gyro_window(uint8_t axis) { return get_raw_gyro_window(_primary, axis); }
 #if AP_INERTIALSENSOR_HARMONICNOTCH_ENABLED
     bool has_fft_notch() const;
 #endif


### PR DESCRIPTION
This is quite a subtle issue but I observed this in a log:

<img width="1700" height="712" alt="image" src="https://github.com/user-attachments/assets/1f517f06-c9a9-4757-b994-7ed2c6865513" />

I am using post-filter FFT and the increase in noise is congruent with a lane switch. It turns out when we have a lane switch we were not switching the gyro the FFT was looking at. This PR resolves the issue.