### PR TITLE
Copter: fix compassmot so that it works with the rate thread

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -777,6 +777,7 @@ private:
 
     // compassmot.cpp
     MAV_RESULT mavlink_compassmot(const GCS_MAVLINK &gcs_chan);
+    void compassmot_output();
 
     // crash_check.cpp
     void crash_check();

--- a/ArduCopter/compassmot.cpp
+++ b/ArduCopter/compassmot.cpp
@@ -268,10 +268,12 @@ MAV_RESULT Copter::mavlink_compassmot(const GCS_MAVLINK &gcs_chan)
 
 void Copter::compassmot_output()
 {
+#if FRAME_CONFIG != HELI_FRAME
     // exit immediately if the motor test is not running
     if (!ap.compass_mot) {
         return;
     }
     // pass through throttle to motors
     motors->set_throttle_passthrough_for_esc_calibration(channel_throttle->get_control_in() * 0.001f);
+#endif
 }

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -101,6 +101,8 @@ void Copter::motors_output(bool full_push)
     if (ap.motor_test) {
         // check if we are performing the motor test
         motor_test_output();
+    } else if (ap.compass_mot) {
+        compassmot_output();
     } else {
         // send output signals to motors
         flightmode->output_to_motors();


### PR DESCRIPTION
The compassmot code is not rate thread aware and does not work at all currently. The solution is to implement the updates in the same way as is done for motortest