### PR TITLE
Tools:  gdb_crashdump.sh: quote filenames to fix problems with spaces…

### DIFF
--- a/Tools/debug/gdb_crashdump.sh
+++ b/Tools/debug/gdb_crashdump.sh
@@ -7,7 +7,7 @@
     exit 1
 }
 
-ELF_FILE=$1
-CRASH_DUMP=$2
+ELF_FILE="$1"
+CRASH_DUMP="$2"
 
-arm-none-eabi-gdb -nx "$ELF_FILE" -ex "set target-charset ASCII" -ex "target remote | modules/CrashDebug/bins/lin64/CrashDebug --elf $ELF_FILE --dump $CRASH_DUMP"
+arm-none-eabi-gdb -nx "$ELF_FILE" -ex "set target-charset ASCII" -ex "target remote | modules/CrashDebug/bins/lin64/CrashDebug --elf "$ELF_FILE" --dump \"$CRASH_DUMP\""


### PR DESCRIPTION
…-in-filenames