### PR TITLE
board_types.txt : add board ID for AP_HW_TMOTOR-PACER-H743

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -308,7 +308,7 @@ AP_HW_NarinH5                        1188
 AP_HW_CORVON743V1                    1189
 AP_HW_DAKEFPVF405                    1190
 AP_HW_ORBITH743                      1191
-
+AP_HW_TMOTOR-PACER-H743              1192
 AP_HW_DAKEFPVH743                    1193
 AP_HW_DAKEFPVH743PRO                 1194
 AP_HW_SEQUREH743                     1195


### PR DESCRIPTION
Reserves ID for T-Motor Pacer H743, which is incompatible with the T-Motor H743 Target.