### PR TITLE
SITL: Add disable sdcard parameter

### DIFF
--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -547,6 +547,13 @@ const AP_Param::GroupInfo SIM::var_info3[] = {
     // @Description: Number of simulated IMUs to create
     AP_GROUPINFO("IMU_COUNT",    23, SIM,  imu_count,  2),
 
+    // @Param: SD_DISABLE
+    // @DisplayName: Disable SD card in SITL
+    // @Description: When set to 1, the SITL filesystem backend simulates an absent SD card
+    // @Values: 0:Enabled (default),1:Disabled (simulate no SD)
+    // @User: Advanced
+    AP_GROUPINFO("SD_DISABLE", 24, SIM, sdcard_disable, 0),
+
     // @Group: FTOWESC_
     // @Path: ./SIM_FETtecOneWireESC.cpp
     AP_SUBGROUPINFO(fetteconewireesc_sim, "FTOWESC_", 30, SIM, FETtecOneWireESC),

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -456,6 +456,9 @@ public:
     // minimum throttle for addition of ins noise
     AP_Float ins_noise_throttle_min;
 
+    // 0 = normal FS, 1 = simulate "no SD card"
+    AP_Int8 sdcard_disable;
+
     struct {
         AP_Float x;
         AP_Float y;


### PR DESCRIPTION
Add sim parameter to simulate lack of SD card

## Testing:
```
sim_vehicle.py -v ArduCopter --console --map
```
- Non-sdcard files can still be opened (e.g: `Tools/autotest/default_params/copter.parm`)
- With `LOG_BACKEND_TYPE = 1` (sdcard) Pre arm shows logging failed
- With `LOG_BACKEND_TYPE = 2` (mavlink) pre arm passes, able to takeoff and fly around