### PR TITLE
AP_Terrain: Add DisableDisk option flag

### DIFF
--- a/libraries/AP_Terrain/AP_Terrain.cpp
+++ b/libraries/AP_Terrain/AP_Terrain.cpp
@@ -58,7 +58,7 @@ const AP_Param::GroupInfo AP_Terrain::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: Terrain options
     // @Description: Options to change behaviour of terrain system
-    // @Bitmask: 0:Disable Download
+    // @Bitmask: 0:Disable Download,1:Disable Disk
     // @User: Advanced
     AP_GROUPINFO("OPTIONS",   2, AP_Terrain, options, 0),
 

--- a/libraries/AP_Terrain/AP_Terrain.h
+++ b/libraries/AP_Terrain/AP_Terrain.h
@@ -379,7 +379,12 @@ private:
 
     enum class Options {
         DisableDownload = (1U<<0),
+        DisableDisk = (1U<<1),
     };
+
+    inline bool diskless() const {
+        return (options.get() & uint16_t(Options::DisableDisk)) != 0;
+    }
 
     // cache of grids in memory, LRU
     uint8_t cache_size = 0;

--- a/libraries/AP_Terrain/TerrainGCS.cpp
+++ b/libraries/AP_Terrain/TerrainGCS.cpp
@@ -50,7 +50,7 @@ bool AP_Terrain::request_missing(mavlink_channel_t chan, struct grid_cache &gcac
     }
 
     // see if we are waiting for disk read
-    if (gcache.state == GRID_CACHE_DISKWAIT) {
+    if (gcache.state == GRID_CACHE_DISKWAIT && !diskless()) {
         // don't request data from the GCS till we know it's not on disk
         return false;
     }
@@ -294,7 +294,9 @@ void AP_Terrain::handle_terrain_data(const mavlink_message_t &msg)
     gcache.grid.bitmap |= ((uint64_t)1) << packet.gridbit;
     
     // mark dirty for disk IO
-    gcache.state = GRID_CACHE_DIRTY;
+    if (!diskless()) {
+        gcache.state = GRID_CACHE_DIRTY;
+    }
     
 #if TERRAIN_DEBUG
     hal.console->printf("Filled bit %u idx_x=%u idx_y=%u\n", 

--- a/libraries/AP_Terrain/TerrainIO.cpp
+++ b/libraries/AP_Terrain/TerrainIO.cpp
@@ -61,7 +61,7 @@ void AP_Terrain::check_disk_write(void)
  */
 void AP_Terrain::schedule_disk_io(void)
 {
-    if (enable == 0 || !allocate()) {
+    if (enable == 0 || !allocate() || diskless()) {
         return;
     }
 
@@ -135,6 +135,9 @@ All file operations are done by the IO thread.
  */
 void AP_Terrain::open_file(void)
 {
+    if (diskless()) {
+        return;
+    }
     struct grid_block &block = disk_block.block;
     if (fd != -1 && 
         block.lat_degrees == file_lat_degrees &&
@@ -257,7 +260,7 @@ void AP_Terrain::seek_offset(void)
 void AP_Terrain::write_block(void)
 {
     seek_offset();
-    if (io_failure) {
+    if (io_failure || diskless()) {
         return;
     }
 
@@ -290,7 +293,7 @@ void AP_Terrain::write_block(void)
 void AP_Terrain::read_block(void)
 {
     seek_offset();
-    if (io_failure) {
+    if (io_failure || diskless()) {
         return;
     }
     int32_t lat = disk_block.block.lat;


### PR DESCRIPTION
Add support for streaming terrain from the GCS when the vehicle doesnt have an SD card installed. 

Without this patch, flying with `TERRAIN_ENABLE=1` and no-sd card is not supported as `request_missing` would get stuck here: https://github.com/ArduPilot/ardupilot/blob/5d1ba8b7cda19eb8d5b375686b40ca187293b8db/libraries/AP_Terrain/TerrainGCS.cpp#L52-L56 waiting (forever) to confirm the tile isnt stored on the SD card before sending a request to the GCS

## Testing:
```
sim_vehicle.py -v ArduCopter --console --map
```
- Applied [this patch](https://github.com/ArduPilot/ardupilot/pull/30992) and set `SIM_SD_DISABLE=1` (to simulate lack of SD card)
- With bit 1 unset:
  - Past behavior observed:
  - GCS is not requested for terrain due to logic above waiting on SD card
  - `PreArm: waiting for terrain data` observed
- With bit 1 set:
  - GCS is requested for terrain
  - Terrain data uploaded (pending = 0 after a few seconds)
  - Pre arm passes
  - Able to takeoff and fly around
  - GCS is requested for more terrain as vehicle leaves cached area