### PR TITLE
AP_Stat: Add STAT_DISTANCE parameter

### DIFF
--- a/libraries/AP_Stats/AP_Stats.cpp
+++ b/libraries/AP_Stats/AP_Stats.cpp
@@ -2,6 +2,7 @@
 
 #include <AP_Math/AP_Math.h>
 #include <AP_RTC/AP_RTC.h>
+#include <AP_AHRS/AP_AHRS.h>
 
 const extern AP_HAL::HAL& hal;
 
@@ -46,6 +47,14 @@ const AP_Param::GroupInfo AP_Stats::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("_FLTCNT",    4, AP_Stats, params.fltcount, 0),
 
+    // @Param: _DISTM
+    // @DisplayName: Total Distance Flown
+    // @Description: Estimate of total distance flown since statistics reset
+    // @Units: m
+    // @ReadOnly: True
+    // @User: Standard
+    AP_GROUPINFO("_DISTANCE",    5, AP_Stats, params.distance_m, 0),
+
     AP_GROUPEND
 };
 
@@ -65,6 +74,7 @@ void AP_Stats::copy_variables_from_parameters()
     reset = params.reset;
     flttime_boot = flttime;
     fltcount = params.fltcount;
+    distance_m = params.distance_m;
 }
 
 void AP_Stats::init()
@@ -75,12 +85,12 @@ void AP_Stats::init()
     copy_variables_from_parameters();
 }
 
-
 void AP_Stats::flush()
 {
     params.flttime.set_and_save_ifchanged(flttime);
     params.runtime.set_and_save_ifchanged(runtime);
     params.fltcount.set_and_save_ifchanged(fltcount);
+    params.distance_m.set_and_save_ifchanged(distance_m);
     last_flush_ms = AP_HAL::millis();
 }
 
@@ -107,6 +117,7 @@ void AP_Stats::update()
 {
     WITH_SEMAPHORE(sem);
     const uint32_t now_ms = AP_HAL::millis();
+    update_distance();
     if (now_ms -  last_flush_ms > flush_interval_ms) {
         update_flighttime();
         update_runtime();
@@ -123,6 +134,7 @@ void AP_Stats::update()
         params.flttime.set_and_save_ifchanged(0);
         params.runtime.set_and_save_ifchanged(0);
         params.fltcount.set_and_save_ifchanged(0);
+        params.distance_m.set_and_save_ifchanged(0);
         uint32_t system_clock = 0; // in seconds
 #if AP_RTC_ENABLED
         uint64_t rtc_clock_us;
@@ -135,8 +147,9 @@ void AP_Stats::update()
 #endif
         params.reset.set_and_save_ifchanged(system_clock);
         copy_variables_from_parameters();
+        // Reset distance tracking state
+        _last_position_valid = false;
     }
-
 }
 
 void AP_Stats::set_flying(const bool is_flying)
@@ -150,10 +163,60 @@ void AP_Stats::set_flying(const bool is_flying)
         if (_flying_ms) {
             update_flighttime();
             update_runtime();
+            update_distance();
             flush();
         }
         _flying_ms = 0;
     }
+}
+
+void AP_Stats::update_distance()
+{
+    if (!_flying_ms) {
+        // Dont count unless flying
+        _last_position_valid = false;
+        return;
+    }
+
+    // Run at 1Hz to reduce how much GPS variance is counted as distance
+    const uint32_t now_ms = AP_HAL::millis();
+    if (now_ms - _last_distance_update_ms < 1000) {
+        return;
+    }
+    _last_distance_update_ms = now_ms;
+
+    AP_AHRS &ahrs = AP::ahrs();
+    if (!ahrs.healthy()) {
+        _last_position_valid = false;
+        return;
+    }
+
+    Location current_loc;
+    if (!ahrs.get_location(current_loc)) {
+        _last_position_valid = false;
+        return;
+    }
+
+    if (_last_position_valid) {
+        float horiz_dist_m = _last_position.get_distance(current_loc);
+        float alt_diff_m = (current_loc.alt - _last_position.alt) * 0.01f;
+
+        // get_distance only calculates 2D distance, so account for altitude differences
+        float delta_m = sqrtf(sq(horiz_dist_m) + sq(alt_diff_m));
+
+        // Avoid counting small distances that are probably error
+        if (delta_m >= 0.5) {
+            // Dont blindly add large distances that are likely just gross error / spoofing
+            // Assumes vehicle traveling below mach ~0.9
+            if (delta_m > 300.0f) {
+                delta_m = 300.0f;
+            }
+            distance_m += delta_m;
+        }
+    }
+
+    _last_position = current_loc;
+    _last_position_valid = true;
 }
 
 /*

--- a/libraries/AP_Stats/AP_Stats.h
+++ b/libraries/AP_Stats/AP_Stats.h
@@ -5,6 +5,8 @@
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
+#include <AP_AHRS/AP_AHRS.h>
+#include <AP_Common/Location.h>
 
 class AP_Stats
 {
@@ -20,6 +22,7 @@ public:
     uint32_t reset;   // last time AP_Stats parameters were reset (in seconds since AP_Stats Jan 1st 2016)
     uint32_t flttime_boot; // seconds in flight (or driving), at boot
     uint32_t fltcount; // total number of takeoffs
+    float distance_m; // total distance flown in meters
     
     void init();
 
@@ -57,6 +60,7 @@ private:
         AP_Int32 runtime;
         AP_Int32 reset;
         AP_Int32 fltcount;
+        AP_Float distance_m;
     } params;
 
     void copy_variables_from_parameters();
@@ -67,8 +71,13 @@ private:
     uint64_t _flying_ms;
     uint64_t _last_runtime_ms;
 
+    Location _last_position;
+    bool _last_position_valid;
+    uint32_t _last_distance_update_ms;
+
     void update_flighttime();
     void update_runtime();
+    void update_distance();
     HAL_Semaphore sem;
 };
 


### PR DESCRIPTION
This PR adds a new statistics parameter STAT_DISTANCE that tracks the cumulative distance flown by the vehicle, similar to an odometer.

Implementation notes:
- Accumulates distance by differentiating 3D position from AHRS at 1Hz
- Basic sanity checks to avoid one instance of error tainting the odometer forever: minimum 0.5m threshold to filter GPS noise, maximum 300m per update to reject huge errors

### Testing:
Tested in SITL:
- Armed and flew multiple waypoints in GUIDED mode
- Verified `STAT_DISTANCE` increments correctly with commanded distance traveled
- Confirmed persistence across reboots
- Confirmed distance resets if `STAT_RESET = 0` sent