### PR TITLE
AC_Fence: always record margin breaches for poly fences

### DIFF
--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -685,8 +685,7 @@ bool AC_Fence::check_fence_polygon()
             return true;
         }
         return false;
-    } else if (option_enabled(OPTIONS::NOTIFY_MARGIN_BREACH)
-               && _polygon_breach_distance < 0 && fabsf(_polygon_breach_distance) < _margin) {
+    } else if (_polygon_breach_distance < 0 && fabsf(_polygon_breach_distance) < _margin) {
         record_margin_breach(AC_FENCE_TYPE_POLYGON);
     } else {
         clear_margin_breach(AC_FENCE_TYPE_POLYGON);


### PR DESCRIPTION
We incorrectly were only doing this if you had notification on, but scripting can use these methods without notifications