### PR TITLE
Add and use a write_device_table method for hwdef.py's to use

### DIFF
--- a/libraries/AP_HAL/hwdef/scripts/hwdef.py
+++ b/libraries/AP_HAL/hwdef/scripts/hwdef.py
@@ -392,6 +392,18 @@ class HWDef:
         if len(devlist) > 0:
             f.write('#define HAL_BARO_PROBE_LIST %s\n\n' % ';'.join(devlist))
 
+    def write_device_table(self, f, description, define_name, devlist):
+        '''writes out a #define which can be used as the body of a C
+        structure to populate object constructor arguments'''
+        if len(devlist) == 0:
+            f.write(f'\n// No {description}\n')
+            return
+
+        f.write(f'\n// {description} table\n')
+        f.write(f'#define {define_name} \\\n')
+        f.write(',\\\n'.join([f"   {x}" for x in devlist]))
+        f.write("\n")
+
     def write_env_py(self, filename):
         '''write out env.py for environment variables to control the build process'''
         pickle.dump(self.env_vars, open(filename, "wb"))

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -1486,7 +1486,7 @@ INCLUDE common.ld
                 % (devidx, name, self.spi_list.index(bus), int(devid[5:]), pal_line,
                    mode, lowspeed, highspeed))
             devlist.append('HAL_SPI_DEVICE%u' % devidx)
-        f.write('#define HAL_SPI_DEVICE_LIST %s\n\n' % ','.join(devlist))
+        self.write_device_table(f, 'spi devices', 'HAL_SPI_DEVICE_LIST', devlist)
         for dev in self.spidev:
             f.write("#define HAL_WITH_SPI_%s 1\n" % dev[0].upper().replace("-", "_"))
         f.write("\n")
@@ -1539,7 +1539,7 @@ INCLUDE common.ld
                 '#define HAL_WSPI_DEVICE%-2u WSPIDesc(%-17s, %2u, WSPIDEV_%s, %7s, %2u, %2u)\n'
                 % (devidx, name, self.wspi_list.index(bus), mode, speed, int(size_pow2), int(ncs_clk_delay)))
             devlist.append('HAL_WSPI_DEVICE%u' % devidx)
-        f.write('#define HAL_WSPI_DEVICE_LIST %s\n\n' % ','.join(devlist))
+        self.write_device_table(f, "wspi devices", "HAL_WSPI_DEVICE_LIST", devlist)
         for dev in self.wspidev:
             f.write("#define HAL_HAS_WSPI_%s 1\n" % dev[0].upper().replace("-", "_"))
             if dev[1].startswith('QUADSPI'):
@@ -1879,7 +1879,7 @@ INCLUDE common.ld
 #endif
 ''' % (OTG2_index, OTG2_index))
 
-        f.write('#define HAL_SERIAL_DEVICE_LIST %s\n\n' % ','.join(devlist))
+        self.write_device_table(f, "serial devices", "HAL_SERIAL_DEVICE_LIST", devlist)
         if not need_uart_driver and not self.is_bootloader_fw():
             f.write('''
 #ifndef HAL_USE_SERIAL
@@ -1955,7 +1955,8 @@ INCLUDE common.ld
 #endif
 '''
                     % (n, n, n, n, n, n, n, scl_line, sda_line, n, n, n, scl_line, sda_line))
-        f.write('\n#define HAL_I2C_DEVICE_LIST %s\n\n' % ','.join(devlist))
+        f.write('\n')
+        self.write_device_table(f, "i2c devices", "HAL_I2C_DEVICE_LIST", devlist)
 
     def parse_timer(self, str):
         '''parse timer channel string, i.e TIM8_CH2N'''

--- a/libraries/AP_HAL_ESP32/hwdef/scripts/esp32_hwdef.py
+++ b/libraries/AP_HAL_ESP32/hwdef/scripts/esp32_hwdef.py
@@ -61,31 +61,20 @@ class ESP32HWDef(hwdef.HWDef):
 
     def write_SPI_bus_table(self, f):
         '''write SPI bus table'''
-        if len(self.esp32_spibus) == 0:
-            f.write('\n// No SPI buses\n')
-            return
-
-        f.write('\n// SPI bus table\n')
         buslist = []
         for bus in self.esp32_spibus:
             if len(bus) != 5:
                 self.error(f"Badly formed ESP32_SPIBUS line {bus} {len(bus)=}")
             (host, dma_ch, mosi, miso, sclk) = bus
             buslist.append(f"{{ .host={host}, .dma_ch={dma_ch}, .mosi={mosi}, .miso={miso}, .sclk={sclk} }},")
-        f.write('#define HAL_ESP32_SPI_BUSES \\\n')
-        f.write(',\\\n'.join([f"   {x}" for x in buslist]))
-        f.write("\n")
+
+        self.write_device_table(f, "SPI buses", "HAL_ESP32_SPI_BUSES", buslist)
 
     def process_line_esp32_spidev(self, line, depth, a):
         self.esp32_spidev.append(a[1:])
 
     def write_SPI_device_table(self, f):
         '''write SPI device table'''
-        if len(self.esp32_spidev) == 0:
-            f.write('\n// No SPI devices\n')
-            return
-
-        f.write('\n// SPI device table\n')
         devlist = []
         for dev in self.esp32_spidev:
             if len(dev) != 7:
@@ -105,9 +94,8 @@ class ESP32HWDef(hwdef.HWDef):
                 self.error("Bad highspeed value %s in ESP32_SPIDEV line %s" %
                            (highspeed, dev))
             devlist.append(f"{{.name= \"{name}\", .bus={bus}, .device={device}, .cs={cs}, .mode={mode}, .lspeed={lowspeed}, .hspeed={highspeed}}}")  # noqa:E501
-        f.write('#define HAL_ESP32_SPI_DEVICES \\\n')
-        f.write(',\\\n'.join([f"   {x}" for x in devlist]))
-        f.write("\n")
+
+        self.write_device_table(f, 'SPI devices', 'HAL_ESP32_SPI_DEVICES', devlist)
 
     def write_SPI_config(self, f):
         '''write SPI config defines'''

--- a/libraries/AP_HAL_Linux/hwdef/scripts/linux_hwdef.py
+++ b/libraries/AP_HAL_Linux/hwdef/scripts/linux_hwdef.py
@@ -57,23 +57,9 @@ class LinuxHWDef(hwdef.HWDef):
     def process_line_linux_spidev(self, line, depth, a):
         self.linux_spidev.append(a[1:])
 
-    def write_SPI_config_define_line_for_dev(self, define_name, dev, n):
-        '''return a #define line for a SPI config line used in a SPI device table'''
-        (name, bus, subdev, mode, bits_per_word, cs_pin, lowspeed, highspeed) = dev
-
-#        return f'#define {define_name} SPIDesc("name")\n'
-
-        # sck_pin = self.bylabel['SPI%s_SCK' % n]
-        # sck_line = 'PAL_LINE(GPIO%s,%uU)' % (sck_pin.port, sck_pin.pin)
-        # return f'#define {define_name} {{ &SPID{n}, {n}, STM32_SPI_SPI{n}_DMA_STREAMS, {sck_line} }}\n'
-
     def write_SPI_device_table(self, f):
         '''write SPI device table'''
-        if len(self.linux_spidev) == 0:
-            # until all are converted
-            return
 
-        f.write('\n// SPI device table\n')
         devlist = []
         for dev in self.linux_spidev:
             if len(dev) != 8:
@@ -92,14 +78,11 @@ class LinuxHWDef(hwdef.HWDef):
                 f'#define HAL_SPI_DEVICE{len(devlist)+1} SPIDesc({name:12s}, {bus}, {subdev}, {mode}, {bits_per_word}, {cs_pin}, {lowspeed:6s}, {highspeed:6s})\n'  # noqa
             )
             devlist.append('HAL_SPI_DEVICE%u' % (len(devlist)+1))
-        f.write('#define HAL_SPI_DEVICE_LIST %s\n\n' % ','.join(devlist))
-        f.write("\n")
+
+        self.write_device_table(f, "spi devices", "HAL_SPI_DEVICE_LIST", devlist)
 
     def write_SPI_config(self, f):
         '''write SPI config defines'''
-
-        if len(self.linux_spidev) == 0:
-            return
 
         self.write_SPI_device_table(f)
 


### PR DESCRIPTION
No compiler output change

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                 *                                                   
Durandal                            *      *           *       *                 *      *      *
Hitec-Airspeed           *                 *                                                   
KakuteH7-bdshot                     *      *           *       *                 *      *      *
MatekF405                           *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *                  *       *                 *      *      *
SITL_x86_64_linux_gnu               0                  0       0                 0      0      0
f103-QiotekPeriph        *                 *                                                   
f303-Universal           *                 *                                                   
iomcu                                                                *                         
revo-mini                           *      *           *       *                 *      *      *
skyviper-v2450                                         *                                       
```

~~(esp32 results to come)~~ esp32 targets also no compiler output change

