### PR TITLE
Tools: Upgrade pyenv v2.6.7 and Python v3.10.18

### DIFF
--- a/Tools/environment_install/install-prereqs-mac.sh
+++ b/Tools/environment_install/install-prereqs-mac.sh
@@ -120,7 +120,7 @@ if maybe_prompt_user "Install python using pyenv [N/y]?" ; then
 
         pushd $HOME/.pyenv
         git fetch --tags
-        git checkout v2.3.12
+        git checkout v2.6.7
         popd
         exportline="export PYENV_ROOT=\$HOME/.pyenv"
         echo $exportline >> ~/$SHELL_LOGIN
@@ -134,10 +134,10 @@ if maybe_prompt_user "Install python using pyenv [N/y]?" ; then
     }
     echo "pyenv installed"
     {
-        $(pyenv global 3.10.4)
+        $(pyenv global 3.10.18)
     } || {
-        env PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 3.10.4
-        pyenv global 3.10.4
+        env PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 3.10.18
+        pyenv global 3.10.18
     }
 fi
 


### PR DESCRIPTION
Let's fix the broken GitHub Action workflow macos_build that is failing consistently.

* https://github.com/ArduPilot/ardupilot/actions/workflows/macos_build.yml

Upgrade pyenv and Python 3.10 in Tools/environment_install/install-prereqs-mac.sh

Questions:
* Why install and configure pyenv by hand instead of doing `brew install pyenv`?
* Why specify the micro version Python 3.10.4 instead of 3.10?
* Why not use `brew install uv && uv python install 3.10` instead of pyenv?