### PR TITLE
Tools/environment_install: drop pymavlink from cygwin

### DIFF
--- a/Tools/environment_install/install-prereqs-windows-andAPMSource.ps1
+++ b/Tools/environment_install/install-prereqs-windows-andAPMSource.ps1
@@ -17,7 +17,7 @@ Write-Output "Installing Cygwin x64 (4/8)"
 Start-Process -wait -FilePath $PSScriptRoot\setup-x86_64.exe -ArgumentList "--root=C:\cygwin64 --no-startmenu --local-package-dir=$env:USERPROFILE\Downloads --site=http://cygwin.mirror.constant.com --packages autoconf,automake,ccache,cygwin32-gcc-g++,gcc-g++=7.4.0-1,libgcc1=7.4.0.1,gcc-core=7.4.0-1,git,libtool,make,gawk,libexpat-devel,libxml2-devel,python39,python39-future,python39-lxml,python39-pip,libxslt-devel,python39-devel,procps-ng,zip,gdb,ddd --quiet-mode"
 
 Write-Output "Downloading extra Python packages (5/8)"
-Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'python3.9 -m pip install empy==3.3.4 pyserial pymavlink intelhex dronecan pexpect'"
+Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'python3.9 -m pip install empy==3.3.4 pyserial intelhex dronecan pexpect'"
 
 Write-Output "Downloading APM source (6/8)"
 Copy-Item "APM_install.sh" -Destination "C:\cygwin64\home"

--- a/Tools/environment_install/install-prereqs-windows.ps1
+++ b/Tools/environment_install/install-prereqs-windows.ps1
@@ -17,7 +17,7 @@ Write-Output "Installing Cygwin x64 (4/7)"
 Start-Process -wait -FilePath $PSScriptRoot\setup-x86_64.exe -ArgumentList "--root=C:\cygwin64 --no-startmenu --local-package-dir=$env:USERPROFILE\Downloads --site=http://cygwin.mirror.constant.com --packages autoconf,automake,ccache,cygwin32-gcc-g++,gcc-g++=7.4.0-1,libgcc1=7.4.0.1,gcc-core=7.4.0-1,git,libtool,make,gawk,libexpat-devel,libxml2-devel,python39,python39-future,python39-lxml,python39-pip,libxslt-devel,python39-devel,procps-ng,zip,gdb,ddd,xterm --quiet-mode"
 
 Write-Output "Downloading extra Python packages (5/7)"
-Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'python3.9 -m pip install empy==3.3.4 pyserial pymavlink intelhex dronecan pexpect'"
+Start-Process -wait -FilePath "C:\cygwin64\bin\bash" -ArgumentList "--login -i -c 'python3.9 -m pip install empy==3.3.4 pyserial intelhex dronecan pexpect'"
 
 Write-Output "Installing ARM GCC Compiler 10-2020-Q4-Major (6/7)"
 & $PSScriptRoot\gcc-arm-none-eabi-10-2020-q4-major-win32.exe /S /P /R


### PR DESCRIPTION
It is impossible to install due to the dependency on fastcrc, which requires Rust, which cannot be built in Cygwin.

Fortunately, waf sets up its own local copy and a slower alternative is used if fastcrc is not available, so we can simply avoid trying to install it.

This setup script otherwise works and properly installs an environment which can at least build and run SITL.