### PR TITLE
AP_Common: disable weak symbols on cygwin

### DIFF
--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -28,8 +28,19 @@
 // used to pack structures
 #define PACKED __attribute__((__packed__))
 
+#if !defined(CYGWIN_BUILD)
 // used to weaken symbols
 #define WEAK __attribute__((__weak__))
+#else
+// cygwin cannot properly support weak symbols allegedly due to Windows
+// executable format limitations
+// (see https://www.cygwin.com/faq.html#faq.programming.linker ). fortunately
+// we only use weak symbols for tests and some HAL stuff which SITL and
+// therefore cygwin does not need to override. in the event that overriding is
+// attempted the link will fail with a symbol redefinition error hopefully
+// suggesting that an alternate approach is needed.
+#define WEAK
+#endif
 
 // used to mark a function that may be unused in some builds
 #define UNUSED_FUNCTION __attribute__((unused))

--- a/libraries/AP_HAL/system.cpp
+++ b/libraries/AP_HAL/system.cpp
@@ -14,12 +14,3 @@ uint16_t WEAK AP_HAL::micros16()
 {
     return micros() & 0xFFFF;
 }
-
-void WEAK AP_HAL::dump_stack_trace()
-{
-    // stack dump not available on this platform
-}
-void WEAK AP_HAL::dump_core_file()
-{
-    // core dump not available on this platform
-}

--- a/libraries/AP_HAL/system.h
+++ b/libraries/AP_HAL/system.h
@@ -19,6 +19,7 @@ uint16_t millis16();
 uint64_t micros64();
 uint64_t millis64();
 
+// only defined and used on SITL, but declared here for historical reasons
 void dump_stack_trace();
 void dump_core_file();
 

--- a/libraries/AP_HAL_SITL/system.cpp
+++ b/libraries/AP_HAL_SITL/system.cpp
@@ -33,11 +33,7 @@ void init()
     state.start_time_ns = ts_to_nsec(ts);
 }
 
-#if defined(__CYGWIN__) || defined(__CYGWIN64__) || defined(CYGWIN_BUILD)
-void panic(const char *errormsg, ...)
-#else
 void WEAK panic(const char *errormsg, ...)
-#endif
 {
     va_list ap;
 
@@ -172,14 +168,6 @@ uint32_t micros()
 uint32_t millis()
 {
     return millis64() & 0xFFFFFFFF;
-}
-
-/*
-  we define a millis16() here to avoid an issue with sitl builds in cygwin
- */
-uint16_t millis16()
-{
-    return millis64() & 0xFFFF;
 }
     
 uint64_t micros64()


### PR DESCRIPTION
Cygwin cannot properly support weak symbols. If a weak symbol is weakly referenced, the linker never patches up the call, leaving a garbage call instruction that jumps into unmapped memory and immediately segfaults.
    
This apparently has never worked, as various weak symbols (including `panic` and `millis16`) had hacks added to address this over the years. The recent introduction of `mem_realloc` in PR #30572 completely broke ArduPilot SITL builds for cygwin as this function is called during arming through ExpandingString preparing information for logging. Therefore, arming always crashed.
    
Fix this problem for good by never making a weak symbol on cygwin. Fortunately this is rare in ArduPilot so symbol conflicts are easily fixed.

Fixes #31017 