### PR TITLE
AP_RangeFinder: correct the reported types for CAN range finders

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend_CAN.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend_CAN.h
@@ -36,10 +36,6 @@ protected:
     // maximum time between readings before we change state to NoData:
     virtual uint32_t read_timeout_ms() const { return 200; }
 
-    virtual MAV_DISTANCE_SENSOR _get_mav_distance_sensor_type() const override {
-        return MAV_DISTANCE_SENSOR_RADAR;
-    }
-
     // return true if the CAN ID is correct
     bool is_correct_id(uint32_t can_id) const;
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_CAN.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_CAN.h
@@ -15,6 +15,12 @@ public:
     // handler for incoming frames. Return true if consumed
     bool handle_frame(AP_HAL::CANFrame &frame) override;
     bool handle_frame_H30(AP_HAL::CANFrame &frame);
+
+protected:
+
+    MAV_DISTANCE_SENSOR _get_mav_distance_sensor_type() const override {
+        return MAV_DISTANCE_SENSOR_LASER;
+    }
 };
 
 #endif  // AP_RANGEFINDER_BENEWAKE_CAN_ENABLED

--- a/libraries/AP_RangeFinder/AP_RangeFinder_NRA24_CAN.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_NRA24_CAN.h
@@ -18,6 +18,12 @@ public:
 
     static const struct AP_Param::GroupInfo var_info[];
 
+protected:
+
+    MAV_DISTANCE_SENSOR _get_mav_distance_sensor_type() const override {
+        return MAV_DISTANCE_SENSOR_RADAR;
+    }
+
 private:
 
     uint32_t get_radar_id(uint32_t id) const { return ((id & 0xF0U) >> 4U); }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_TOFSenseP_CAN.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_TOFSenseP_CAN.h
@@ -16,6 +16,12 @@ public:
     bool handle_frame(AP_HAL::CANFrame &frame) override;
 
     static const struct AP_Param::GroupInfo var_info[];
+    
+protected:
+
+    MAV_DISTANCE_SENSOR _get_mav_distance_sensor_type() const override {
+        return MAV_DISTANCE_SENSOR_LASER;
+    }
 };
 
 #endif  // AP_RANGEFINDER_USD1_CAN_ENABLED

--- a/libraries/AP_RangeFinder/AP_RangeFinder_USD1_CAN.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_USD1_CAN.h
@@ -16,6 +16,12 @@ public:
     bool handle_frame(AP_HAL::CANFrame &frame) override;
 
     static const struct AP_Param::GroupInfo var_info[];
+
+protected:
+
+    MAV_DISTANCE_SENSOR _get_mav_distance_sensor_type() const override {
+        return MAV_DISTANCE_SENSOR_RADAR;
+    }
 };
 
 #endif  // AP_RANGEFINDER_USD1_CAN_ENABLED


### PR DESCRIPTION
I found all of the CAN based range finders were being reported as Radar's. The CAN backend is providing the distance sensor type, rather than each device driver.

I've removed this from the backend and think I corrected the types of all the devices.