### PR TITLE
Correct handling of DO_JUMP_TAG

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -5449,6 +5449,47 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                      timeout=1,
                      want_result=mavutil.mavlink.MAV_RESULT_DENIED)
 
+    def ValidJumpTags(self):
+        '''Check jump tag behaviour when waypoints follow jump tag.'''
+        ofs_wp1 = (50, 0)
+        ofs_wp3 = (50, 50)
+        ofs_wp4 = (100, 50)
+        ofs_wp6 = (100, 100)
+        ofs_wp7 = (150, 150)
+        self.upload_simple_relhome_mission([
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, ofs_wp1[0], ofs_wp1[1], 20),
+            self.mission_jump_tag(1),
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, ofs_wp3[0], ofs_wp3[1], 20),
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, ofs_wp4[0], ofs_wp4[1], 20),
+            self.mission_do_jump_tag(1, 2),
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, ofs_wp6[0], ofs_wp6[1], 20),
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, ofs_wp7[0], ofs_wp7[1], 20),
+        ])
+
+        self.wait_ready_to_arm()
+        here = self.mav.location()
+        loc_wp1 = self.offset_location_ne(here, ofs_wp1[0], ofs_wp1[1])
+        loc_wp3 = self.offset_location_ne(here, ofs_wp3[0], ofs_wp3[1])
+        loc_wp4 = self.offset_location_ne(here, ofs_wp4[0], ofs_wp4[1])
+        loc_wp6 = self.offset_location_ne(here, ofs_wp6[0], ofs_wp6[1])
+        loc_wp7 = self.offset_location_ne(here, ofs_wp7[0], ofs_wp7[1])
+
+        self.takeoff(mode='LOITER')
+        self.change_mode('AUTO')
+        self.wait_location(loc_wp1)
+
+        self.wait_location(loc_wp3)
+        self.wait_location(loc_wp4)
+        self.wait_location(loc_wp3)
+        self.wait_location(loc_wp4)
+        self.wait_location(loc_wp3)
+        self.wait_location(loc_wp4)
+
+        self.wait_location(loc_wp6)
+        self.wait_location(loc_wp7)
+
+        self.do_RTL()
+
     def GPSViconSwitching(self):
         """Fly GPS and Vicon switching test"""
         """Setup parameters including switching to EKF3"""
@@ -18991,6 +19032,7 @@ return update, 1000
             self.FlyMissionTwiceWithReset,
             self.MissionIndexValidity,
             self.InvalidJumpTags,
+            self.ValidJumpTags,
             self.IMUConsistency,
             self.AHRSTrimLand,
             self.IBus,

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -6454,44 +6454,6 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             0, # altitude
             mavutil.mavlink.MAV_MISSION_TYPE_MISSION)
 
-    def mission_jump_tag(self, tag, target_system=1, target_component=1):
-        '''create a jump tag mission item'''
-        return self.mav.mav.mission_item_int_encode(
-            target_system,
-            target_component,
-            0, # seq
-            mavutil.mavlink.MAV_FRAME_GLOBAL,
-            mavutil.mavlink.MAV_CMD_JUMP_TAG,
-            0, # current
-            0, # autocontinue
-            tag, # p1
-            0, # p2
-            0, # p3
-            0, # p4
-            0, # latitude
-            0, # longitude
-            0, # altitude
-            mavutil.mavlink.MAV_MISSION_TYPE_MISSION)
-
-    def mission_do_jump_tag(self, tag, target_system=1, target_component=1):
-        '''create a jump tag mission item'''
-        return self.mav.mav.mission_item_int_encode(
-            target_system,
-            target_component,
-            0, # seq
-            mavutil.mavlink.MAV_FRAME_GLOBAL,
-            mavutil.mavlink.MAV_CMD_DO_JUMP_TAG,
-            0, # current
-            0, # autocontinue
-            tag, # p1
-            0, # p2
-            0, # p3
-            0, # p4
-            0, # latitude
-            0, # longitude
-            0, # altitude
-            mavutil.mavlink.MAV_MISSION_TYPE_MISSION)
-
     def mission_anonymous_waypoint(self, target_system=1, target_component=1):
         '''just a boring waypoint'''
         return self.mav.mav.mission_item_int_encode(

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -6474,6 +6474,8 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             mavutil.mavlink.MAV_MISSION_TYPE_MISSION)
 
     def MissionJumpTags_missing_jump_target(self, target_system=1, target_component=1):
+        '''try to jump via mavlink command to a jump tag which doesn't exist'''
+        self.wait_ready_to_arm()
         self.start_subtest("Check missing-jump-tag behaviour")
         jump_target = 2
         mission = [
@@ -6500,6 +6502,8 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.assert_current_waypoint(4)
 
     def MissionJumpTags_do_jump_to_bad_tag(self, target_system=1, target_component=1):
+        '''try jumping to bad tag number with mission command'''
+        self.wait_ready_to_arm()
         mission = [
             self.mission_home_point(),
             self.mission_anonymous_waypoint(),
@@ -6515,6 +6519,8 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.disarm_vehicle()
 
     def MissionJumpTags_jump_tag_at_end_of_mission(self, target_system=1, target_component=1):
+        '''check behaviour when bad jump tag at end of mission'''
+        self.wait_ready_to_arm()
         mission = [
             self.mission_home_point(),
             self.mission_anonymous_waypoint(),
@@ -6537,13 +6543,6 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             want_result=mavutil.mavlink.MAV_RESULT_FAILED
         )
         self.disarm_vehicle()
-
-    def MissionJumpTags(self):
-        '''test MAV_CMD_JUMP_TAG'''
-        self.wait_ready_to_arm()
-        self.MissionJumpTags_missing_jump_target()
-        self.MissionJumpTags_do_jump_to_bad_tag()
-        self.MissionJumpTags_jump_tag_at_end_of_mission()
 
     def AltResetBadGPS(self):
         '''Tests the handling of poor GPS lock pre-arm alt resets'''
@@ -8794,7 +8793,9 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.AltResetBadGPS,
             self.AirspeedCal,
             self.AirspeedScripting,
-            self.MissionJumpTags,
+            self.MissionJumpTags_missing_jump_target,
+            self.MissionJumpTags_do_jump_to_bad_tag,
+            self.MissionJumpTags_jump_tag_at_end_of_mission,
             Test(self.GCSFailsafe, speedup=8),
             self.SDCardWPTest,
             self.NoArmWithoutMissionItems,

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -7136,6 +7136,44 @@ class TestSuite(abc.ABC):
                 mission_type
         )
 
+    def mission_jump_tag(self, tag, target_system=1, target_component=1):
+        '''create a jump tag mission item'''
+        return self.mav.mav.mission_item_int_encode(
+            target_system,
+            target_component,
+            0, # seq
+            mavutil.mavlink.MAV_FRAME_GLOBAL,
+            mavutil.mavlink.MAV_CMD_JUMP_TAG,
+            0, # current
+            0, # autocontinue
+            tag, # p1
+            0, # p2
+            0, # p3
+            0, # p4
+            0, # latitude
+            0, # longitude
+            0, # altitude
+            mavutil.mavlink.MAV_MISSION_TYPE_MISSION)
+
+    def mission_do_jump_tag(self, tag, repeats=0, target_system=1, target_component=1):
+        '''create a jump tag mission item'''
+        return self.mav.mav.mission_item_int_encode(
+            target_system,
+            target_component,
+            0, # seq
+            mavutil.mavlink.MAV_FRAME_GLOBAL,
+            mavutil.mavlink.MAV_CMD_DO_JUMP_TAG,
+            0, # current
+            0, # autocontinue
+            tag, # p1
+            repeats, # p2
+            0, # p3
+            0, # p4
+            0, # latitude
+            0, # longitude
+            0, # altitude
+            mavutil.mavlink.MAV_MISSION_TYPE_MISSION)
+
     def run_cmd_int(self,
                     command,
                     p1=0,

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -2236,7 +2236,7 @@ bool AP_Mission::get_next_cmd(uint16_t start_index, Mission_Command& cmd, bool i
         // check for do-jump-tag command and convert target tag to do-jump target index and do-jump to it
         if (temp_cmd.id == MAV_CMD_DO_JUMP_TAG) {
             // convert tmp_cmd target from a target tag to a target index
-            temp_cmd.content.jump.target = get_index_of_jump_tag(temp_cmd.content.jump.target);
+            temp_cmd.content.jump.target = get_index_of_jump_tag(temp_cmd.content.jump.target) + 1;
             temp_cmd.id = MAV_CMD_DO_JUMP;
         }
 


### PR DESCRIPTION
We have to point to the item *after* the jump tag.  Otherwise get_next_nav_cmd will skip forward to he next index in the linear sequence of commands, ignoring the sequence specified by the jump tag!

before/after autotest.

This is all *still* going to go wrong if the item directly after the jump tag is not a nav command!

But, then, I'm pretty sure a normal jump pointing to a DO is also going to do Bad Things.
