### PR TITLE
GCS_FTP: return error code from close() calls when terminating a session

### DIFF
--- a/libraries/GCS_MAVLink/GCS_FTP.h
+++ b/libraries/GCS_MAVLink/GCS_FTP.h
@@ -95,7 +95,7 @@ private:
         void push_reply(Transaction &reply);
         bool handle_request(Transaction &request, Transaction &reply);
 
-        void close(void);
+        int close(void);
     };
     Session sessions[AP_MAVLINK_FTP_MAX_SESSIONS];
 


### PR DESCRIPTION
This PR updates the MAVFTP `TerminateSession` opcode handler to return the error code from an underlying `AP::FS().close()` call with a NAK instead of an ACK.

The modification is needed to allow errors to propagate when trying to upload a malformed packed parameter bundle to the virtual `@PARAM/param.pck` file path. In the current `master` version, the error code returned by the code in `AP_Filesystem_Param` class never propagates back to the GCS.

This is the first PR in a sequence of PRs that attempt to improve the validation of uploaded parameter bundles. Another PR will follow that validates the parameter names in the bundle when this PR is merged.