### PR TITLE
CI: fail fast on rover PPP install

### DIFF
--- a/.github/workflows/test_sitl_rover.yml
+++ b/.github/workflows/test_sitl_rover.yml
@@ -195,6 +195,7 @@ jobs:
         run: |
           sudo apt-get update || true
           sudo apt-get -y install ppp || true
+          pppd --help # fail with `command not found` if ppp install failed
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
           if [[ ${{ matrix.toolchain }} == "clang" ]]; then
             export CC=clang

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -188,6 +188,7 @@ for t in $CI_BUILD_TARGET; do
     if [ "$t" == "sitltest-rover" ]; then
         sudo apt-get update || /bin/true
         sudo apt-get install -y ppp || /bin/true
+        pppd --help # fail with `command not found` if ppp install failed
         run_autotest "Rover" "build.Rover" "test.Rover"
         continue
     fi


### PR DESCRIPTION
Avoids the tests failing after a while when pppd is not found.

Now the same as the install necessary for signing.