### PR TITLE
AC_WPNav: Coordinated_Turn_Loiter

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -5058,6 +5058,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         '''test zigzag mode'''
         # set channel 8 for zigzag savewp and recentre it
         self.set_parameter("RC8_OPTION", 61)
+        self.set_parameter("LOIT_OPTIONS", 0)
 
         self.takeoff(alt_min=5, mode='LOITER')
 

--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -14,6 +14,7 @@ extern const AP_HAL::HAL& hal;
 #define LOITER_VEL_CORRECTION_MAX_MS        2.0     // Maximum speed (in m/s) used for correcting position errors in loiter.
 #define LOITER_POS_CORRECTION_MAX_M         2.0     // Maximum horizontal position error allowed before correction (m).
 #define LOITER_ACTIVE_TIMEOUT_MS            200     // Loiter is considered active if updated within the past 200 ms.
+#define LOITER_DEFAULT_OPTIONS              1       // Enable Coordinated Turn by default.
 
 const AP_Param::GroupInfo AC_Loiter::var_info[] = {
 
@@ -71,6 +72,13 @@ const AP_Param::GroupInfo AC_Loiter::var_info[] = {
     // @Increment: 0.1
     // @User: Advanced
     AP_GROUPINFO("BRK_DELAY",  6, AC_Loiter, _brake_delay_s, LOITER_BRAKE_START_DELAY_DEFAULT_S),
+
+    // @Param: OPTIONS
+    // @DisplayName: Loiter mode options
+    // @Description: Enables optional Loiter mode behaviors
+    // @Bitmask: 0: Enable Coordinated turns
+    // @User: Standard
+    AP_GROUPINFO("OPTIONS", 7, AC_Loiter, _options, LOITER_DEFAULT_OPTIONS),
 
     AP_GROUPEND
 };
@@ -179,8 +187,15 @@ void AC_Loiter::set_pilot_desired_acceleration_rad(float euler_roll_angle_rad, f
     const Vector3f predicted_euler_rad {_predicted_euler_angle_rad.x, _predicted_euler_angle_rad.y, _ahrs.yaw};
     const Vector3f predicted_accel_neu_m = _pos_control.lean_angles_rad_to_accel_NEU_mss(predicted_euler_rad);
 
-    _predicted_accel_ne_mss.x = predicted_accel_neu_m.x;
-    _predicted_accel_ne_mss.y = predicted_accel_neu_m.y;
+    _predicted_accel_ne_mss = predicted_accel_neu_m.xy();
+
+    if (loiter_option_is_set(LoiterOption::COORDINATED_TURN_ENABLED)) {
+        Vector3f target_ang_vel_rads = _attitude_control.get_attitude_target_ang_vel();
+        Vector3f desired_velocity_ms = _pos_control.get_vel_desired_NEU_ms();
+        Vector2f turn_accel_ne_mss = Vector2f(-desired_velocity_ms.y * target_ang_vel_rads.z, desired_velocity_ms.x * target_ang_vel_rads.z);
+        _desired_accel_ne_mss += turn_accel_ne_mss;
+        _predicted_accel_ne_mss += turn_accel_ne_mss;
+    }
 }
 
 // Calculates the expected stopping point based on current velocity and position in the NE frame.
@@ -264,6 +279,10 @@ void AC_Loiter::sanity_check_params()
 
     // Clamp horizontal accel to lean-angle-limited max (converted to cm/s²)
     _accel_max_ne_cmss.set(MIN(_accel_max_ne_cmss, GRAVITY_MSS * 100.0f * tanf(_attitude_control.lean_angle_max_rad())));
+}
+
+bool AC_Loiter::loiter_option_is_set(LoiterOption option) const {
+    return (_options & int8_t(option)) != 0;
 }
 
 // Updates feed-forward velocity using pilot-requested acceleration and braking logic.

--- a/libraries/AC_WPNav/AC_Loiter.h
+++ b/libraries/AC_WPNav/AC_Loiter.h
@@ -138,6 +138,13 @@ protected:
     AP_Float    _brake_accel_max_cmss;  // Maximum braking acceleration (in cm/s²) applied when pilot sticks are released.
     AP_Float    _brake_jerk_max_cmsss;  // Maximum braking jerk (in cm/s³) applied during braking transitions after pilot release.
     AP_Float    _brake_delay_s;         // Delay in seconds before braking begins after sticks are centered. Prevents premature deceleration during brief pauses.
+    AP_Int8     _options;               // Loiter options bit mask
+
+    // Bitfields of LOITER_OPTIONS
+    enum class LoiterOption {
+        COORDINATED_TURN_ENABLED    = (1U << 0),    // Enable Coordinated Turn
+    };
+    bool loiter_option_is_set(LoiterOption option) const;
 
     // loiter controller internal variables
     Vector2f    _desired_accel_ne_mss;      // Pilot-requested horizontal acceleration in m/s² (after smoothing), in the NE (horizontal) frame.


### PR DESCRIPTION
This provides automated coordinated turns to loiter.

WIKI TEXT:

Loiter Parameters
LOIT_OPTIONS: Loiter mode options
  This parameter enables additional Loiter mode behaviours through a bit-mask.
  Bit 0 – Enable Coordinated Turns:
  When set, Loiter mode will automatically include coordinated turn logic. This adjusts the requested roll and pitch accelerations so that the vehicle’s motion matches both the horizontal velocity vector and the commanded yaw rate. The effect is that during turns in Loiter mode, the aircraft will naturally bank and pitch into the turn in a way that maintains coordinated flight, rather than skidding or sliding outward.

Coordinated Turns in Loiter
  When Coordinated Turns are enabled (via the LOIT_OPTIONS parameter, Bit 0), the aircraft modifies its commanded accelerations in Loiter mode to take into account the requested yaw rate and current horizontal velocity.
  This produces turns that feel more natural and “aircraft-like,” as the drone banks into the turn to match the trajectory.
  Without this option, Loiter turns are controlled purely by position and velocity demands, which can result in a flat, sliding turn.
  The feature is optional and can be enabled or disabled depending on pilot preference.