### PR TITLE
AP_Airspeed: convert get_temperature() to const to match other accessors

### DIFF
--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -485,7 +485,7 @@ void AP_Airspeed::allocate()
 }
 
 // get a temperature reading if possible
-bool AP_Airspeed::get_temperature(uint8_t i, float &temperature)
+bool AP_Airspeed::get_temperature(uint8_t i, float &temperature) const
 {
     if (!enabled(i)) {
         return false;
@@ -995,7 +995,7 @@ bool AP_Airspeed::arming_checks(size_t buflen, char *buffer) const
 const AP_Param::GroupInfo AP_Airspeed::var_info[] = { AP_GROUPEND };
 
 void AP_Airspeed::update() {};
-bool AP_Airspeed::get_temperature(uint8_t i, float &temperature) { return false; }
+bool AP_Airspeed::get_temperature(uint8_t i, float &temperature) const { return false; }
 void AP_Airspeed::calibrate(bool in_startup) {}
 AP_Airspeed::CalibrationState AP_Airspeed::get_calibration_state() const { return CalibrationState::NOT_STARTED; }
 bool AP_Airspeed::use(uint8_t i) const { return false; }

--- a/libraries/AP_Airspeed/AP_Airspeed.h
+++ b/libraries/AP_Airspeed/AP_Airspeed.h
@@ -125,8 +125,8 @@ public:
     float get_airspeed_ratio(void) const { return get_airspeed_ratio(primary); }
 
     // get temperature if available
-    bool get_temperature(uint8_t i, float &temperature);
-    bool get_temperature(float &temperature) { return get_temperature(primary, temperature); }
+    bool get_temperature(uint8_t i, float &temperature) const;
+    bool get_temperature(float &temperature) const { return get_temperature(primary, temperature); }
 
     // set the airspeed ratio (dimensionless)
 #ifndef HAL_BUILD_AP_PERIPH


### PR DESCRIPTION
AP_Airspeed: convert get_temperature() to const to match other accessors. This was the only public accessor that wasn't a const already. 