### PR TITLE
Fix BLHeli_S passthrough

### DIFF
--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -58,6 +58,8 @@ extern const AP_HAL::HAL& hal;
 extern AP_IOMCU iomcu;
 #endif
 
+// to use this make sure you have a logic analyser on GPIO outputs 54 and 55
+// set the servo output for these channels as "GPIO", on a Pixhawk these would be FMU outputs 5/6
 #define RCOU_SERIAL_TIMING_DEBUG 0
 #define LED_THD_WA_SIZE 256
 #ifndef HAL_NO_LED_THREAD
@@ -1950,7 +1952,7 @@ void RCOutput::dma_cancel(pwm_group& group)
   until serial_end() has been called
 */
 #if HAL_SERIAL_ESC_COMM_ENABLED
-#define BYTE_BITS 10
+#define BYTE_BITS 10U
 
 bool RCOutput::serial_setup_output(uint8_t chan, uint32_t baudrate, uint32_t chanmask)
 {
@@ -2044,7 +2046,9 @@ void RCOutput::fill_DMA_buffer_byte(dmar_uint_t *buffer, uint8_t stride, uint8_t
     }
 }
 
-#define BYTE_TIME(bitus) (bitus *  (BYTE_BITS + 2))   // timeout should come well after the next start bit
+// timeout should come well after the next start bit, on BlueJay start to start is about 624us
+// timeout behaviour can be stressed by setting this to BYTE_BITS + 2
+#define BYTE_TIME(bitus) (bitus *  (BYTE_BITS + 3U))
 
 /*
   send one serial byte, blocking call, should be called with the DMA lock held
@@ -2139,6 +2143,8 @@ HAL_BinarySemaphore RCOutput::serial_sem;
  */
 void RCOutput::serial_bit_irq(void)
 {
+    chSysLockFromISR();
+
     uint16_t now = AP_HAL::micros16();
     uint8_t bit = palReadLine(irq.line);
     bool send_signal = false;
@@ -2146,8 +2152,6 @@ void RCOutput::serial_bit_irq(void)
 #if RCOU_SERIAL_TIMING_DEBUG
     palWriteLine(HAL_GPIO_LINE_GPIO55, bit);
 #endif
-
-    chSysLockFromISR();
 
     // value of completed byte (includes start and stop bits)
     uint16_t byteval = 0;
@@ -2198,6 +2202,7 @@ void RCOutput::serial_bit_irq(void)
         if ((byteval & 0x201) != 0x200) {
             // wrong start/stop bits
             byteval = BAD_BYTE;
+            chVTResetI(&irq.serial_timeout);
         } else {
             // seen the last bit so setup the timeout for the next byte
             chVTSetI(&irq.serial_timeout, chTimeUS2I(BYTE_TIME(irq.bit_time_tick)), serial_byte_timeout, irq.waiter);
@@ -2216,6 +2221,16 @@ void RCOutput::serial_bit_irq(void)
 void RCOutput::serial_byte_timeout(virtual_timer_t* vt, void *ctx)
 {
     chSysLockFromISR();
+
+    // avoid a ChibiOS race in timer signalling, if all is well it should not be armed at this point
+    if (chVTIsArmedI(vt)) {
+        chSysUnlockFromISR();
+        return;
+    }
+#if RCOU_SERIAL_TIMING_DEBUG
+    palToggleLine(HAL_GPIO_LINE_GPIO54);
+    palToggleLine(HAL_GPIO_LINE_GPIO54);
+#endif
     uint16_t byteval = irq.bitmask | (((1U<<BYTE_BITS)-1) & ~((1U<<irq.nbits)-1));
     // we can accept a byte with a timeout if the last bit was 1
     // and the start bit is set correctly
@@ -2225,6 +2240,11 @@ void RCOutput::serial_byte_timeout(virtual_timer_t* vt, void *ctx)
         // wrong start/stop bits
         byteval = BAD_BYTE;
     }
+
+    // we are assuming we read the byte so reset in case there is another read
+    irq.nbits = 0;
+    irq.bitmask = 0;
+    irq.last_bit = 0;
 
     serial_buffer.write((uint8_t*)&byteval, 2);
     chSysUnlockFromISR();
@@ -2240,7 +2260,7 @@ bool RCOutput::serial_read_byte(uint8_t &b, uint32_t timeout_us)
         // consumer/producer pattern
         if (serial_buffer.is_empty()) {
             if (!serial_sem.wait(timeout_us)) {
-                return false;  // no data after 2ms
+                return false;  // no data after timeout_us
             }
         }
 


### PR DESCRIPTION
https://github.com/ArduPilot/ardupilot/pull/29590 exposed timing issues on BLHeli_S and BlueJay. The byte timeout code on serial passthrough had a couple of bugs which also exposed a ChibiOS race. This fixes the race and the bugs using timeouts and also ensures that timeouts only occur when strictly necessary.

Tested with:

 - BlueJay 0.14, 0.21 on Pixhawk6X
 - BLHeli32 32.9 on MambaH743v4
 - AM32 2.19 on TBS Lucid H7