### PR TITLE
AP_Periph: fix notify vehicle_state bit-length bug

### DIFF
--- a/Tools/AP_Periph/AP_Periph.h
+++ b/Tools/AP_Periph/AP_Periph.h
@@ -417,15 +417,15 @@ public:
     AP_Notify notify;
     uint64_t vehicle_state = 1; // default to initialisation
     float yaw_earth;
-    uint32_t last_vehicle_state;
+    uint32_t last_vehicle_state_ms;
 
     // Handled under LUA script to control LEDs
     float get_yaw_earth() { return yaw_earth; }
-    uint32_t get_vehicle_state() { return vehicle_state; }
+    uint64_t get_vehicle_state() { return vehicle_state; }
 #elif defined(AP_SCRIPTING_ENABLED)
     // create dummy methods for the case when the user doesn't want to use the notify object
     float get_yaw_earth() { return 0.0; }
-    uint32_t get_vehicle_state() { return 0.0; }
+    uint64_t get_vehicle_state() { return 0; }
 #endif
 
 #if AP_SCRIPTING_ENABLED

--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -709,7 +709,7 @@ void AP_Periph_FW::handle_notify_state(CanardInstance* canard_instance, CanardRx
         yaw_earth = radians((float)tmp * 0.01f);
     }
     vehicle_state = msg.vehicle_state;
-    last_vehicle_state = AP_HAL::millis();
+    last_vehicle_state_ms = AP_HAL::millis();
 }
 #endif // AP_PERIPH_NOTIFY_ENABLED
 

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1898,7 +1898,7 @@ function FWVersion:string() end
 periph = {}
 
 -- desc
----@return uint32_t_ud
+---@return uint64_t_ud
 function periph:get_vehicle_state() end
 
 -- desc

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -763,7 +763,7 @@ include ../Tools/AP_Periph/AP_Periph.h depends defined(HAL_BUILD_AP_PERIPH)
 singleton AP_Periph_FW depends defined(HAL_BUILD_AP_PERIPH)
 singleton AP_Periph_FW rename periph
 singleton AP_Periph_FW method get_yaw_earth float
-singleton AP_Periph_FW method get_vehicle_state uint32_t
+singleton AP_Periph_FW method get_vehicle_state uint64_t
 singleton AP_Periph_FW method can_printf void "%s"'literal string
 singleton AP_Periph_FW method reboot void boolean
 


### PR DESCRIPTION
AP_Periph: fix notify vehicle_state bit-length bug

The CAN notify message value is a uint64 value which the main `vehicle_state` variable is so thats correct but the accessors for it is uint32. Whoops! While I was tripped up on that I also thought the `last_vehicle_state` was a backup to check for change but it was a ms timer and so the uint32 was correct so I renamed it to `last_vehicle_state_ms` for clarity.