### PR TITLE
SITL test to show accel failure does not trigger landing detector

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -13181,6 +13181,21 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.wait_disarmed()
 
+    def AccelHealthFailureDisarmTest(self):
+        '''test the effect of Accel Failure on landing detector'''
+        self.start_subtest("Test to show land detector does not trigger when only Accel is unhealthy")
+        self.takeoff(10, mode='GUIDED')
+        self.set_rc(3, 1500)
+        self.set_parameters({
+            "SIM_ACC_HEALTH": 1,  # mark accel unhealthy
+            "SIM_ACCEL1_FAIL": 1,  # fail accel1
+        })
+        self.change_mode('LOITER')
+        self.set_rc(3, 1300)
+
+        self.wait_disarmed()
+
+
     def CameraLogMessages(self):
         '''ensure Camera log messages are good'''
         self.set_parameter("RC12_OPTION", 9) # CameraTrigger
@@ -14626,6 +14641,7 @@ return update, 1000
             self.PLDNoParameters,
             self.PeriphMultiUARTTunnel,
             self.EKF3SRCPerCore,
+            self.AccelHealthFailureDisarmTest,
         ])
         return ret
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
@@ -177,6 +177,10 @@ void AP_InertialSensor_SITL::generate_accel()
 
         if (fabsf(sitl->accel_fail[accel_instance]) > 1.0e-6f) {
             accel.x = accel.y = accel.z = sitl->accel_fail[accel_instance];
+            if (sitl->accel_health_mask & (1 << accel_instance)) {
+                // also increase error count for triggering health flag
+                _inc_accel_error_count(accel_instance);
+            }
         }
 
 #if HAL_INS_TEMPERATURE_CAL_ENABLE

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -1260,6 +1260,13 @@ const AP_Param::GroupInfo SIM::var_ins[] = {
     // @Description: If non-zero the vehicle will be clamped in position until the value on this servo channel passes 1800PWM
     AP_GROUPINFO("CLAMP_CH",     49, SIM, clamp_ch, 0),
 
+    // @Param: ACC_HEALTH
+    // @DisplayName: Accelerometer Health Flag Mask
+    // @Description: Determines if the accelerometer is marked unhealthy when an IMU failure is simulated by ACCELx_FAIL params
+    // @Values: 0:Disabled, 1:Mark unhealthy
+    // @User: Advanced
+    AP_GROUPINFO("ACC_HEALTH", 50, SIM, accel_health_mask,  0),
+
     // the IMUT parameters must be last due to the enable parameters
 #if HAL_INS_TEMPERATURE_CAL_ENABLE
     AP_SUBGROUPINFO(imu_tcal[0], "IMUT1_", 61, SIM, AP_InertialSensor_TCal),

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -595,6 +595,7 @@ public:
     // gyro and accel fail masks
     AP_Int8 gyro_fail_mask;
     AP_Int8 accel_fail_mask;
+    AP_Int8 accel_health_mask;
 
     // Sailboat sim only
     AP_Int8 sail_type;


### PR DESCRIPTION
This is a test to reproduce the issue that a partner reported in a log. 

When an accel is marked unhealthy, EKF will use the "first best accel" and continue to be healthy. However, certain parts of the vehicle code, including the landing detector, will continue to use the bad accel readings.

