### PR TITLE
treewide: remove isolated bitfields

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -568,7 +568,7 @@ private:
 #if FRAME_CONFIG == HELI_FRAME
     // Tradheli flags
     typedef struct {
-        uint8_t dynamic_flight          : 1;    // 0   // true if we are moving at a significant speed (used to turn on/off leaky I terms)
+        bool dynamic_flight                ;    // 0   // true if we are moving at a significant speed (used to turn on/off leaky I terms)
         bool coll_stk_low                  ;    // 1   // true when collective stick is on lower limit
     } heli_flags_t;
     heli_flags_t heli_flags;

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -518,7 +518,7 @@ private:
         Vector3p target_neu_m;
         Vector2f correction_ne_m;
         Vector3f target_vel_ms;
-        bool slow_descent:1;
+        bool slow_descent;
         bool pilot_correction_active;
         bool pilot_correction_done;
         uint32_t thrust_loss_start_ms;

--- a/ArduPlane/tiltrotor.h
+++ b/ArduPlane/tiltrotor.h
@@ -89,7 +89,7 @@ public:
 
     float current_tilt;
     float current_throttle;
-    bool _motors_active:1;
+    bool _motors_active;
     float transition_yaw_cd;
     uint32_t transition_yaw_set_ms;
     bool _is_vectored;

--- a/libraries/AC_InputManager/AC_InputManager_Heli.h
+++ b/libraries/AC_InputManager/AC_InputManager_Heli.h
@@ -43,7 +43,7 @@ public:
 
 private:
     struct InputManagerHeliFlags {
-        uint8_t use_stab_col        :   1;  // 1 if we should use Stabilise mode collective range, 0 for Acro range
+        bool use_stab_col; // 1 if we should use Stabilise mode collective range, 0 for Acro range
     } _im_flags_heli;
 
     //  factor used to smoothly ramp collective from Acro value to Stab-Col value

--- a/libraries/AC_PID/AC_PI_2D.h
+++ b/libraries/AC_PID/AC_PI_2D.h
@@ -80,7 +80,7 @@ private:
 
     // flags
     struct ac_pid_flags {
-        bool _reset_filter : 1;    // true when input filter should be reset during next call to set_input
+        bool _reset_filter;    // true when input filter should be reset during next call to set_input
     } _flags;
 
     // internal variables

--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -45,8 +45,6 @@ AC_Circle::AC_Circle(const AP_AHRS_View& ahrs, AC_PosControl& pos_control) :
 {
     AP_Param::setup_object_defaults(this, var_info);
 
-    // init flags
-    _flags.panorama = false;
     _rotation_rate_max_rads = radians(_rate_parm_degs);
 }
 

--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -197,11 +197,6 @@ private:
     // Terrain source may be rangefinder or terrain database.
     bool get_terrain_offset_m(float& offset_m);
 
-    // flags structure
-    struct circle_flags {
-        uint8_t panorama    : 1;    // true if we are doing a panorama
-    } _flags;
-
     // references to inertial nav and ahrs libraries
     const AP_AHRS_View&         _ahrs;
     AC_PosControl&              _pos_control;

--- a/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.h
+++ b/libraries/AP_AdvancedFailsafe/AP_AdvancedFailsafe.h
@@ -153,7 +153,7 @@ protected:
     uint32_t _last_gps_loss_ms;
 
     // have the failsafe values been setup?
-    bool _failsafe_setup:1;
+    bool _failsafe_setup;
 
     Location _first_location;
     bool _have_first_location;

--- a/libraries/AP_Button/AP_Button.h
+++ b/libraries/AP_Button/AP_Button.h
@@ -116,7 +116,7 @@ private:
     uint32_t last_report_ms;
 
     // has the timer been installed?
-    bool initialised:1;
+    bool initialised;
     
     // called by timer thread
     void timer_update(void);

--- a/libraries/AP_Compass/AP_Compass_QMC5883L.h
+++ b/libraries/AP_Compass/AP_Compass_QMC5883L.h
@@ -68,7 +68,7 @@ private:
 
     enum Rotation _rotation;
     uint8_t _instance;
-    bool _force_external:1;
+    bool _force_external;
 };
 
 #endif  // AP_COMPASS_QMC5883L_ENABLED

--- a/libraries/AP_Compass/AP_Compass_QMC5883P.h
+++ b/libraries/AP_Compass/AP_Compass_QMC5883P.h
@@ -67,7 +67,7 @@ private:
 
     enum Rotation _rotation;
     uint8_t _instance;
-    bool _force_external:1;
+    bool _force_external;
 };
 
 #endif  // AP_COMPASS_QMC5883P_ENABLED

--- a/libraries/AP_GyroFFT/AP_GyroFFT.cpp
+++ b/libraries/AP_GyroFFT/AP_GyroFFT.cpp
@@ -257,7 +257,7 @@ __INITFUNC__ void AP_GyroFFT::init(uint16_t loop_rate_hz)
             }
         }
     }
-    _current_sample_mode = _sample_mode;
+    _current_sample_mode = _sample_mode & 0x07; // mask matches previous 3 bit storage and param range
 
     _ref_energy = NEW_NOTHROW Vector3f[_window_size];
     if (_ref_energy == nullptr) {

--- a/libraries/AP_GyroFFT/AP_GyroFFT.h
+++ b/libraries/AP_GyroFFT/AP_GyroFFT.h
@@ -258,7 +258,7 @@ private:
         // filtered detected peak width
         Vector3f _center_bandwidth_hz_filtered[FrequencyPeak::MAX_TRACKED_PEAKS];
         // axes that still require noise calibration
-        uint8_t _noise_needs_calibration : 3;
+        uint8_t _noise_needs_calibration;
         // whether the analyzer is mid-cycle
         bool _analysis_started;
     };
@@ -292,7 +292,7 @@ private:
     // number of cycles over which to generate noise ensemble averages
     uint16_t _noise_calibration_cycles[XYZ_AXIS_COUNT];
     // current _sample_mode
-    uint8_t _current_sample_mode : 3;
+    uint8_t _current_sample_mode;
     // harmonic multiplier for two highest peaks
     float _harmonic_multiplier;
     // number of tracked peaks

--- a/libraries/AP_HAL/Scheduler.h
+++ b/libraries/AP_HAL/Scheduler.h
@@ -129,7 +129,7 @@ public:
 private:
 
     AP_HAL::Proc _delay_cb;
-    bool _in_delay_callback : 1;
+    bool _in_delay_callback;
 
 };
 

--- a/libraries/AP_ICEngine/AP_ICEngine.h
+++ b/libraries/AP_ICEngine/AP_ICEngine.h
@@ -153,7 +153,7 @@ private:
     float height_required;
 
     // we are waiting for valid height data
-    bool height_pending:1;
+    bool height_pending;
 
     bool allow_single_start_while_disarmed;
 

--- a/libraries/AP_IRLock/AP_IRLock.h
+++ b/libraries/AP_IRLock/AP_IRLock.h
@@ -53,7 +53,7 @@ public:
 
 protected:
     struct AP_IRLock_Flags {
-        uint8_t healthy : 1; // true if sensor is healthy
+        bool healthy; // true if sensor is healthy
     } _flags;
 
     // internals

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -223,7 +223,7 @@ private:
     } _buffer,_current_parameters;
 
     AP_HAL::UARTDriver *_port;
-    bool _initialised : 1;
+    bool _initialised;
 
     // result of the get_boardinfo
     uint8_t _board_version;
@@ -236,7 +236,7 @@ private:
     Vector3f _current_angle;
 
     // CMD_READ_PARAMS has been called once
-    bool _param_read_once : 1;
+    bool _param_read_once;
 
     // Serial Protocol Variables
     uint8_t _checksum;
@@ -246,6 +246,6 @@ private:
     uint8_t _payload_counter;
 
     // confirmed that last command was ok
-    bool _last_command_confirmed : 1;
+    bool _last_command_confirmed;
 };
 #endif // HAL_MOUNT_ALEXMOS_ENABLED

--- a/libraries/AP_Notify/ToneAlarm.h
+++ b/libraries/AP_Notify/ToneAlarm.h
@@ -64,7 +64,7 @@ private:
         uint16_t powering_off          : 1;    // 1 if smart battery is powering off
         uint16_t temp_cal_running      : 1;    // 1 if temperature calibration is running
     } flags;
-    bool _have_played_ready_tone : 1;
+    bool _have_played_ready_tone;
 
     int8_t _cont_tone_playing;
     int8_t _tone_playing;

--- a/libraries/AP_Notify/ToneAlarm.h
+++ b/libraries/AP_Notify/ToneAlarm.h
@@ -72,7 +72,7 @@ private:
 
     struct Tone {
         const char *str;
-        const uint8_t continuous : 1;
+        const bool continuous;
     };
 
     const static Tone _tones[];

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow.h
@@ -134,7 +134,7 @@ private:
     OpticalFlow_backend *backend;
 
     struct AP_OpticalFlow_Flags {
-        uint8_t healthy     : 1;    // true if sensor is healthy
+        bool healthy;               // true if sensor is healthy
     } _flags;
 
     // parameters

--- a/libraries/AP_Tuning/AP_Tuning.h
+++ b/libraries/AP_Tuning/AP_Tuning.h
@@ -79,7 +79,7 @@ private:
     uint8_t current_set;
 
     // true if tune has changed
-    bool changed:1;
+    bool changed;
 
     // mask of params in set that need reverting
     uint32_t need_revert;

--- a/libraries/SITL/SIM_ICEngine.h
+++ b/libraries/SITL/SIM_ICEngine.h
@@ -54,7 +54,7 @@ private:
         };
         uint8_t value;
     } state, last_state;
-    bool overheat:1;
+    bool overheat;
     bool throttle_reversed;
 };
 }


### PR DESCRIPTION
These save no memory yet require extra instructions. Some were completely unused and were removed. Others were changed to `bool` to better align their semantics.

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange               -80        *      -176        -224    -248  -144        -128
CubeOrange-periph-heavy  -40        *
Durandal                 -88        *      -168        -232    -240  -144        -128
Hitec-Airspeed           -16        *
KakuteH7-bdshot          -88        *      -176        -224    -248  -144        -136
MatekF405                -32        *      -48         -88     -128  -32         -40
Pixhawk1-1M-bdshot       -32        -72    -120        -160    -64   -64
f103-QiotekPeriph        -24        *
f303-Universal           -24        *
iomcu                    -16
revo-mini                -24        *      -32         -80     -112  -24         -32
skyviper-v2450           -64

```