### PR TITLE
ardupilotwaf: kill `env.py`

### DIFF
--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -17,6 +17,7 @@ import pickle
 import struct
 import base64
 import subprocess
+import traceback
 
 import hal_common
 
@@ -602,6 +603,7 @@ def configure(cfg):
     try:
         hwdef_env = generate_hwdef_h(env)
     except Exception:
+        traceback.print_exc()
         cfg.fatal("Failed to process hwdef.dat")
     load_env_vars(cfg.env, hwdef_env)
     if env.HAL_NUM_CAN_IFACES and not env.AP_PERIPH:

--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -620,16 +620,16 @@ def generate_hwdef_h(env):
         else:
             # update to using hwdef-bl.dat
             env.HWDEF = env.HWDEF.replace('hwdef.dat', 'hwdef-bl.dat')
-        env.BOOTLOADER_OPTION="--bootloader"
+        bootloader_option="--bootloader"
     else:
         if len(env.HWDEF) == 0:
             env.HWDEF = os.path.join(env.SRCROOT, 'libraries/AP_HAL_ChibiOS/hwdef/%s/hwdef.dat' % env.BOARD)
-        env.BOOTLOADER_OPTION=""
+        bootloader_option=""
 
     if env.AP_SIGNED_FIRMWARE:
-        print(env.BOOTLOADER_OPTION)
-        env.BOOTLOADER_OPTION += " --signed-fw"
-        print(env.BOOTLOADER_OPTION)
+        print(bootloader_option)
+        bootloader_option += " --signed-fw"
+        print(bootloader_option)
     hwdef_script = os.path.join(env.SRCROOT, 'libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py')
     hwdef_out = env.BUILDROOT
     if not os.path.exists(hwdef_out):
@@ -638,8 +638,8 @@ def generate_hwdef_h(env):
     cmd = "{0} '{1}' -D '{2}' --params '{3}' '{4}'".format(python, hwdef_script, hwdef_out, env.DEFAULT_PARAMETERS, env.HWDEF)
     if env.HWDEF_EXTRA:
         cmd += " '{0}'".format(env.HWDEF_EXTRA)
-    if env.BOOTLOADER_OPTION:
-        cmd += " " + env.BOOTLOADER_OPTION
+    if bootloader_option:
+        cmd += " " + bootloader_option
     return subprocess.call(cmd, shell=True)
 
 def pre_build(bld):
@@ -663,26 +663,6 @@ def build(bld):
 
     # make ccache effective on ChibiOS builds
     os.environ['CCACHE_IGNOREOPTIONS'] = '--specs=nano.specs --specs=nosys.specs'
-
-    hwdef_rule="%s '%s/hwdef/scripts/chibios_hwdef.py' -D '%s' --params '%s' '%s'" % (
-            bld.env.get_flat('PYTHON'),
-            bld.env.AP_HAL_ROOT,
-            bld.env.BUILDROOT,
-            bld.env.default_parameters,
-            bld.env.HWDEF)
-    if bld.env.HWDEF_EXTRA:
-        hwdef_rule += " " + bld.env.HWDEF_EXTRA
-    if bld.env.BOOTLOADER_OPTION:
-        hwdef_rule += " " + bld.env.BOOTLOADER_OPTION
-    bld(
-        # build hwdef.h from hwdef.dat. This is needed after a waf clean
-        source=bld.path.ant_glob(bld.env.HWDEF),
-        rule=hwdef_rule,
-        group='dynamic_sources',
-        target=[bld.bldnode.find_or_declare('hwdef.h'),
-                bld.bldnode.find_or_declare('ldscript.ld'),
-                bld.bldnode.find_or_declare('hw.dat')]
-    )
     
     bld(
         # create the file modules/ChibiOS/include_dirs

--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -644,7 +644,6 @@ def generate_hwdef_h(env):
 
 def pre_build(bld):
     '''pre-build hook to change dynamic sources'''
-    load_env_vars(bld.env)
     if bld.env.HAL_NUM_CAN_IFACES:
         bld.get_board().with_can = True
     if bld.env.WITH_LITTLEFS:

--- a/Tools/ardupilotwaf/esp32.py
+++ b/Tools/ardupilotwaf/esp32.py
@@ -166,7 +166,6 @@ def pre_build(self):
     self.add_to_group(tsk)
 
     # hwdef pre-build:
-    load_env_vars(self.env)
 #    if bld.env.HAL_NUM_CAN_IFACES:
 #        bld.get_board().with_can = True
     hwdef_h = os.path.join(self.env.BUILDROOT, 'hwdef.h')

--- a/Tools/ardupilotwaf/esp32.py
+++ b/Tools/ardupilotwaf/esp32.py
@@ -31,11 +31,6 @@ def esp32_dynamic_env(self):
     hal_common.common_dynamic_env(self)
 
 
-def load_env_vars(env):
-    '''optionally load extra environment variables from env.py in the build directory'''
-    hal_common.load_env_vars(env)
-
-
 def configure(cfg):
     mcu_esp32s3 = True if (cfg.variant[0:7] == "esp32s3") else False
     target = "esp32s3" if mcu_esp32s3 else "esp32"
@@ -69,11 +64,11 @@ def configure(cfg):
     print("USING EXPRESSIF IDF:"+str(env.IDF))
 
     try:
-        generate_hwdef_h(env)
+        hwdef_env = generate_hwdef_h(env)
     except Exception as e:
         print(get_exception_stacktrace(e))
         cfg.fatal("Failed to generate hwdef")
-    load_env_vars(cfg.env)
+    hal_common.load_env_vars(cfg.env, hwdef_env)
 
 def get_exception_stacktrace(e):
     ret = "%s\n" % e
@@ -100,6 +95,7 @@ def generate_hwdef_h(env):
         quiet=False,
     )
     eh.run()
+    return eh.env_vars
 
 # delete the output sdkconfig file when the input defaults changes. we take the
 # stamp as the output so we can compute the path to the sdkconfig, yet it
@@ -173,6 +169,7 @@ def pre_build(self):
         print("Generating hwdef.h")
         try:
             generate_hwdef_h(self.env)
+            # TRAP: env vars are not reloaded!
         except Exception:
             self.fatal(f"Failed to process hwdef.dat {hwdef_h}")
 

--- a/Tools/ardupilotwaf/esp32.py
+++ b/Tools/ardupilotwaf/esp32.py
@@ -176,17 +176,6 @@ def pre_build(self):
         except Exception:
             self.fatal(f"Failed to process hwdef.dat {hwdef_h}")
 
-def build(bld):
-    bld(
-        # build hwdef.h from hwdef.dat. This is needed after a waf clean
-        source=bld.path.ant_glob(bld.env.HWDEF),
-        rule="",
-        group='dynamic_sources',
-        target=[
-            bld.bldnode.find_or_declare('hwdef.h'),
-        ]
-    )
-
 @feature('esp32_ap_program')
 @after_method('process_source')
 def esp32_firmware(self):

--- a/Tools/ardupilotwaf/esp32.py
+++ b/Tools/ardupilotwaf/esp32.py
@@ -65,17 +65,10 @@ def configure(cfg):
 
     try:
         hwdef_env = generate_hwdef_h(env)
-    except Exception as e:
-        print(get_exception_stacktrace(e))
+    except Exception:
+        traceback.print_exc()
         cfg.fatal("Failed to generate hwdef")
     hal_common.load_env_vars(cfg.env, hwdef_env)
-
-def get_exception_stacktrace(e):
-    ret = "%s\n" % e
-    ret += ''.join(traceback.format_exception(type(e),
-                                              e,
-                                              tb=e.__traceback__))
-    return ret
 
 def generate_hwdef_h(env):
     '''run esp32_hwdef.py'''

--- a/Tools/ardupilotwaf/hal_common.py
+++ b/Tools/ardupilotwaf/hal_common.py
@@ -4,19 +4,12 @@ Waf tool for functions common to the esp32, Linux and ChibiOS builds.
 AP_FLAKE8_CLEAN
 """
 
-import os
-import pickle
 import sys
 
 
-def load_env_vars(env, kv_handler=None):
-    '''optionally load extra environment variables from env.py in the build directory'''
-    env_py = os.path.join(env.BUILDROOT, 'env.py')
-    if not os.path.exists(env_py):
-        print("No env.py found")
-        return
-    e = pickle.load(open(env_py, 'rb'))
-    for kv in e.items():
+def load_env_vars(env, hwdef_env, kv_handler=None):
+    '''load environment variables from the hwdef generator'''
+    for kv in hwdef_env.items():
         if kv_handler is not None:
             kv_handler(env, kv)
             continue
@@ -24,7 +17,7 @@ def load_env_vars(env, kv_handler=None):
 
 
 def load_env_vars_handle_kv_pair(env, kv_pair):
-    '''handle a key/value pair out of the pickled environment dictionary'''
+    '''handle a key/value pair out of the hwdef generator'''
     (k, v) = kv_pair
     if k in env:
         if isinstance(env[k], dict):

--- a/Tools/ardupilotwaf/linux.py
+++ b/Tools/ardupilotwaf/linux.py
@@ -93,7 +93,6 @@ def generate_hwdef_h(env):
 
 def pre_build(bld):
     '''pre-build hook to change dynamic sources'''
-    load_env_vars(bld.env)
     if bld.env.HAL_NUM_CAN_IFACES:
         bld.get_board().with_can = True
     if bld.env.WITH_LITTLEFS:

--- a/Tools/ardupilotwaf/linux.py
+++ b/Tools/ardupilotwaf/linux.py
@@ -104,15 +104,3 @@ def pre_build(bld):
             generate_hwdef_h(bld.env)
         except Exception:
             bld.fatal(f"Failed to process hwdef.dat {hwdef_h}")
-
-
-def build(bld):
-    bld(
-        # build hwdef.h from hwdef.dat. This is needed after a waf clean
-        source=bld.path.ant_glob(bld.env.HWDEF),
-        rule="",
-        group='dynamic_sources',
-        target=[
-            bld.bldnode.find_or_declare('hwdef.h'),
-        ]
-    )

--- a/Tools/ardupilotwaf/linux.py
+++ b/Tools/ardupilotwaf/linux.py
@@ -52,18 +52,10 @@ def configure(cfg):
 
     try:
         hwdef_env = generate_hwdef_h(env)
-    except Exception as e:
-        print(get_exception_stacktrace(e))
+    except Exception:
+        traceback.print_exc()
         cfg.fatal("Failed to generate hwdef")
     hal_common.load_env_vars(cfg.env, hwdef_env)
-
-
-def get_exception_stacktrace(e):
-    ret = "%s\n" % e
-    ret += ''.join(traceback.format_exception(type(e),
-                                              e,
-                                              tb=e.__traceback__))
-    return ret
 
 
 def generate_hwdef_h(env):

--- a/Tools/ardupilotwaf/linux.py
+++ b/Tools/ardupilotwaf/linux.py
@@ -30,11 +30,6 @@ def linux_firmware(self):
     pass
 
 
-def load_env_vars(env):
-    '''optionally load extra environment variables from env.py in the build directory'''
-    hal_common.load_env_vars(env)
-
-
 def configure(cfg):
 
     def srcpath(path):
@@ -56,11 +51,11 @@ def configure(cfg):
     env.AP_PROGRAM_FEATURES += ['linux_ap_program']
 
     try:
-        generate_hwdef_h(env)
+        hwdef_env = generate_hwdef_h(env)
     except Exception as e:
         print(get_exception_stacktrace(e))
         cfg.fatal("Failed to generate hwdef")
-    load_env_vars(cfg.env)
+    hal_common.load_env_vars(cfg.env, hwdef_env)
 
 
 def get_exception_stacktrace(e):
@@ -89,6 +84,7 @@ def generate_hwdef_h(env):
         quiet=False,
     )
     lh.run()
+    return lh.env_vars
 
 
 def pre_build(bld):
@@ -102,5 +98,6 @@ def pre_build(bld):
         print("Generating hwdef.h")
         try:
             generate_hwdef_h(bld.env)
+            # TRAP: env vars are not reloaded!
         except Exception:
             bld.fatal(f"Failed to process hwdef.dat {hwdef_h}")

--- a/Tools/scripts/run_flake8.py
+++ b/Tools/scripts/run_flake8.py
@@ -41,10 +41,6 @@ class Flake8Checker(object):
             for filename in filenames:
                 if os.path.splitext(filename)[1] != ".py":
                     continue
-                if filename == 'env.py':
-                    # we are generating content into these files which
-                    # is not actually Python...
-                    continue
                 filepath = os.path.join(dirpath, filename)
                 content = pathlib.Path(filepath).read_text()
                 if "AP_FLAKE8_CLEAN" not in content:

--- a/libraries/AP_HAL/hwdef/scripts/hwdef.py
+++ b/libraries/AP_HAL/hwdef/scripts/hwdef.py
@@ -6,7 +6,6 @@ AP_FLAKE8_CLEAN
 
 import filecmp
 import os
-import pickle
 import re
 import shlex
 import sys
@@ -403,7 +402,3 @@ class HWDef:
         f.write(f'#define {define_name} \\\n')
         f.write(',\\\n'.join([f"   {x}" for x in devlist]))
         f.write("\n")
-
-    def write_env_py(self, filename):
-        '''write out env.py for environment variables to control the build process'''
-        pickle.dump(self.env_vars, open(filename, "wb"))

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -3131,7 +3131,6 @@ Please run: Tools/scripts/build_bootloaders.py %s
 
         # CHIBIOS_BUILD_FLAGS is passed to the ChibiOS makefile
         self.env_vars['CHIBIOS_BUILD_FLAGS'] = ' '.join(self.build_flags)
-        self.write_env_py(os.path.join(self.outdir, "env.py"))
 
 
 if __name__ == '__main__':

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -2729,7 +2729,7 @@ Please run: Tools/scripts/build_bootloaders.py %s
     def write_processed_defaults_file(self, filepath):
         # see if board has a defaults.parm file or a --default-parameters file was specified
         defaults_filename = os.path.join(os.path.dirname(self.hwdef[0]), 'defaults.parm')
-        defaults_path = os.path.join(os.path.dirname(self.hwdef[0]), args.params)
+        defaults_path = os.path.join(os.path.dirname(self.hwdef[0]), self.default_params_filepath)
 
         defaults_abspath = None
         if os.path.exists(defaults_path):

--- a/libraries/AP_HAL_ESP32/hwdef/scripts/esp32_hwdef.py
+++ b/libraries/AP_HAL_ESP32/hwdef/scripts/esp32_hwdef.py
@@ -46,8 +46,6 @@ class ESP32HWDef(hwdef.HWDef):
         self.write_SERIAL_config(f)
         self.write_RCOUT_config(f)
 
-        self.write_env_py(os.path.join(self.outdir, "env.py"))
-
     def process_line(self, line, depth):
         '''process one line of pin definition file'''
         # keep all config lines for later use

--- a/libraries/AP_HAL_Linux/hwdef/scripts/linux_hwdef.py
+++ b/libraries/AP_HAL_Linux/hwdef/scripts/linux_hwdef.py
@@ -32,8 +32,6 @@ class LinuxHWDef(hwdef.HWDef):
         self.write_MAG_config(f)
         self.write_BARO_config(f)
 
-        self.write_env_py(os.path.join(self.outdir, "env.py"))
-
     def process_line(self, line, depth):
         '''process one line of pin definition file'''
         # keep all config lines for later use


### PR DESCRIPTION
This removes a wart in the build system where environment variables from the hwdef generator were written to a Python Pickle file (not a Python source file as the name suggests) then read back in. This cleans that up to just pass the data directly. Unlike the implication in the source code, it was never really possible to use this file to add custom environment variables as it is unconditionally overwritten every compile. Please see the commits for details.

It also uncovers some more warts (for which fixes will be PRed later)
* The whole `load_env_vars` thing needs rethinking, it was not optional for a long time and can probably be cleaned up
* There should be no need to rerun the hwdef generator at build time, waf has mechanisms to preserve files

Tested that there is no compiler output change for an arbitrary board for each of ChibiOS, ESP32, and Linux.