### PR TITLE
Tools: autotest: vehicle_test_suite: change from `SIGSTOP` to `SIGTSTP`

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -3331,7 +3331,16 @@ class TestSuite(ABC):
         '''temporarily stop the SITL process from running.  Note that
         simulation time will not move forward!'''
         # self.progress("Pausing SITL")
-        self.sitl.kill(signal.SIGSTOP)
+        if sys.platform == 'cygwin':
+            # Maintain original behaviour under cygwin as SIGTSTP has not been tested
+            self.sitl.kill(signal.SIGSTOP)
+
+        else:
+            # SIGTSTP can be ignored by GDB allowing easier debugging rather than having GDB break at every pause
+            # EG add:
+            # handle SIGTSTP nostop noprint pass
+            # handle SIGCONT nostop noprint pass
+            self.sitl.kill(signal.SIGTSTP)
 
     def unpause_SITL(self):
         # self.progress("Unpausing SITL")


### PR DESCRIPTION
For me GDB using VSCode was breaking on every `SIGSTOP` sent by autotest. This makes it almost impossible to use. `SIGSTOP` cant be ignored, if we swap to `SIGTSTP` I can then get GDB to ignore it by adding:
```
{
    "description": "Don't break on SIGTSTP",
    "text": "handle SIGTSTP nostop noprint pass"
},
{
    "description": "Don't break on SIGCONT",
    "text": "handle SIGCONT nostop noprint pass"
}
```

To the `setupCommands` in `launch.json`

I will caveat this by saying that I'm no expert in GDB it took some googling and asking ChatGPT to get this working. There may well be a better way to do this.