### PR TITLE
AC_AttitudeControl: WeatherVane: emit active message for change of direction

### DIFF
--- a/libraries/AC_AttitudeControl/AC_WeatherVane.cpp
+++ b/libraries/AC_AttitudeControl/AC_WeatherVane.cpp
@@ -218,10 +218,10 @@ bool AC_WeatherVane::get_yaw_out(float &yaw_output, const int16_t pilot_yaw, con
             break;
     }
 
-    if (!active_msg_sent) {
+    if (active_msg_dir != dir) {
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Weathervane Active: %s", dir_string);
         (void)dir_string;  // in case GCS is disabled
-        active_msg_sent = true;
+        active_msg_dir = dir;
     }
 
     // Slew output and apply gain
@@ -234,7 +234,7 @@ bool AC_WeatherVane::get_yaw_out(float &yaw_output, const int16_t pilot_yaw, con
 void AC_WeatherVane::reset(void)
 {
     last_output = 0;
-    active_msg_sent = false;
+    active_msg_dir = Direction::OFF;
     first_activate_ms = 0;
     last_check_ms = AP_HAL::millis();
 }

--- a/libraries/AC_AttitudeControl/AC_WeatherVane.h
+++ b/libraries/AC_AttitudeControl/AC_WeatherVane.h
@@ -48,7 +48,7 @@ class AC_WeatherVane {
         AP_Int16 _options;
 
         float last_output;
-        bool active_msg_sent;
+        Direction active_msg_dir;
         uint32_t first_activate_ms;
         uint32_t last_check_ms;
 


### PR DESCRIPTION
Weathervaning can change direction while still active, for example when transitioning into or out of takeoff/landing. This changes to send a second GCS message with the new direction in that case. Currently only the start of the weathervaning would get a message. 

EG:
```
Weathervane Active: nose in
Weathervane Active: side in
```

This will also happen if you were to change the parameter value while weathervaning is active.