### PR TITLE
Tools/environment_install: add Debian Trixie

### DIFF
--- a/.github/workflows/test_environment.yml
+++ b/.github/workflows/test_environment.yml
@@ -37,6 +37,8 @@ jobs:
           - os: archlinux
             name: latest
           - os: debian
+            name: trixie
+          - os: debian
             name: bookworm
           - os: debian
             name: bullseye
@@ -53,7 +55,6 @@ jobs:
           apt-get update && apt-get install --no-install-recommends -qy \
           lsb-release \
           sudo \
-          git \
           software-properties-common
           add-apt-repository ppa:git-core/ppa -y
           apt-get update && apt-get install --no-install-recommends -qy git
@@ -63,7 +64,7 @@ jobs:
           lsb-release \
           sudo \
           git \
-          software-properties-common
+          ca-certificates
           ;;
           *"archlinux"*)
           pacman -Syu --noconfirm --needed git sudo
@@ -104,7 +105,7 @@ jobs:
             ;;
           esac
 
-      - name: test build STIL ${{matrix.os}}.${{matrix.name}}
+      - name: test build SITL ${{matrix.os}}.${{matrix.name}}
         env:
           DISABLE_MAVNATIVE: True
           DEBIAN_FRONTEND: noninteractive
@@ -164,7 +165,7 @@ jobs:
         run: |
           PATH="/github/home/.local/bin:$PATH"
           Tools/environment_install/install-prereqs-alpine.sh
-      - name: test build STIL alpine
+      - name: test build SITL alpine
         env:
           DISABLE_MAVNATIVE: True
           TZ: Europe/Paris

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -101,6 +101,11 @@ if [ ${RELEASE_CODENAME} == 'bionic' ] ||
       [ ${RELEASE_CODENAME} == 'buster' ]; then
     echo "ArduPilot no longer supports developing on this operating system that has reached end of standard support."
     exit 1
+elif [ ${RELEASE_CODENAME} == 'trixie' ]; then
+    SITLFML_VERSION="2.6"
+    SITLCFML_VERSION="2.6"
+    PYTHON_V="python3"
+    PIP=pip3
 elif [ ${RELEASE_CODENAME} == 'bookworm' ]; then
     SITLFML_VERSION="2.5"
     SITLCFML_VERSION="2.5"
@@ -194,7 +199,8 @@ fi
 ARM_LINUX_PKGS="g++-arm-linux-gnueabihf $INSTALL_PKG_CONFIG"
 # python-wxgtk packages are added to SITL_PKGS below
 
-if [ ${RELEASE_CODENAME} == 'bookworm' ] ||
+if [ ${RELEASE_CODENAME} == 'trixie' ] ||
+   [ ${RELEASE_CODENAME} == 'bookworm' ] ||
    [ ${RELEASE_CODENAME} == 'lunar' ] ||
    [ ${RELEASE_CODENAME} == 'mantic' ] ||
    [ ${RELEASE_CODENAME} == 'noble' ] ||
@@ -210,7 +216,8 @@ fi
 
 # add some packages required for commonly-used MAVProxy modules:
 if [[ $SKIP_AP_GRAPHIC_ENV -ne 1 ]]; then
-    if [ ${RELEASE_CODENAME} == 'bookworm' ] ||
+    if [ ${RELEASE_CODENAME} == 'trixie' ] ||
+       [ ${RELEASE_CODENAME} == 'bookworm' ] ||
        [ ${RELEASE_CODENAME} == 'lunar' ] ||
        [ ${RELEASE_CODENAME} == 'mantic' ] ||
        [ ${RELEASE_CODENAME} == 'noble' ] ||
@@ -303,6 +310,8 @@ elif [ ${RELEASE_CODENAME} == 'groovy' ] ||
          [ ${RELEASE_CODENAME} == 'jammy' ]; then
     BASE_PKGS+=" python-is-python3"
     SITL_PKGS+=" libpython3-stdlib" # for argparse
+elif [ ${RELEASE_CODENAME} == 'trixie' ]; then
+    SITL_PKGS+=" libpython3-stdlib" # for argparse
 elif [ ${RELEASE_CODENAME} == 'bookworm' ]; then
     SITL_PKGS+=" libpython3-stdlib" # for argparse
 elif [ ${RELEASE_CODENAME} == 'lunar' ]; then
@@ -326,6 +335,8 @@ if [[ $SKIP_AP_GRAPHIC_ENV -ne 1 ]]; then
   elif [ ${RELEASE_CODENAME} == 'groovy' ] ||
            [ ${RELEASE_CODENAME} == 'focal' ]; then
     SITL_PKGS+=" libjpeg8-dev"
+  elif [ ${RELEASE_CODENAME} == 'trixie' ]; then
+    SITL_PKGS+=" libgtk-3-dev libwxgtk3.2-dev "
   elif [ ${RELEASE_CODENAME} == 'bookworm' ]; then
     SITL_PKGS+=" libgtk-3-dev libwxgtk3.2-dev "
   elif [ ${RELEASE_CODENAME} == 'lunar' ]; then
@@ -353,7 +364,11 @@ if [[ $SKIP_AP_GRAPHIC_ENV -ne 1 ]]; then
       SITL_PKGS+=" fonts-freefont-ttf libfreetype6-dev libjpeg8-dev libpng12-0 libportmidi-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev"  # for pygame
   fi
 
-  if [ ${RELEASE_CODENAME} == 'bookworm' ]; then
+  if [ ${RELEASE_CODENAME} == 'trixie' ]; then
+      PYTHON_PKGS+=" opencv-python"
+      SITL_PKGS+=" python3-wxgtk4.0"
+      SITL_PKGS+=" fonts-freefont-ttf libfreetype6-dev libpng16-16 libportmidi-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev"  # for pygame
+  elif [ ${RELEASE_CODENAME} == 'bookworm' ]; then
       PYTHON_PKGS+=" opencv-python"
       SITL_PKGS+=" python3-wxgtk4.0"
       SITL_PKGS+=" fonts-freefont-ttf libfreetype6-dev libpng16-16 libportmidi-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev"  # for pygame
@@ -430,7 +445,8 @@ elif [ ${RELEASE_CODENAME} == 'noble' ]; then
     PYTHON_VENV_PACKAGE=python3.12-venv
 elif [ ${RELEASE_CODENAME} == 'oracular' ]; then
     PYTHON_VENV_PACKAGE=python3.12-venv
-elif [ ${RELEASE_CODENAME} == 'plucky' ]; then
+elif [ ${RELEASE_CODENAME} == 'trixie' ] ||
+     [ ${RELEASE_CODENAME} == 'plucky' ]; then
     PYTHON_VENV_PACKAGE=python3-venv
 fi
 
@@ -482,7 +498,8 @@ if [ "$GITHUB_ACTIONS" == "true" ]; then
     PIP_USER_ARGUMENT+=" --progress-bar off"
 fi
 
-if [ ${RELEASE_CODENAME} == 'bookworm' ] ||
+if [ ${RELEASE_CODENAME} == 'trixie' ] ||
+   [ ${RELEASE_CODENAME} == 'bookworm' ] ||
    [ ${RELEASE_CODENAME} == 'lunar' ] ||
    [ ${RELEASE_CODENAME} == 'mantic' ] ||
    [ ${RELEASE_CODENAME} == 'noble' ] ||


### PR DESCRIPTION
Adds Debian 13 (Trixie) support to install script.

- Increments SFML libs to v2.6 for Trixie. `./waf configure --enable-sfml --enable-sfml-audio` builds succeed.
- Replaces `software-properties-common` with `ca-certificates` in Debian CI workflow.
- Fixes redundant install of git in Ubuntu CI workflow.
- Fixes cosmetic typos in CI workflow  ("SITL" was spelled, "STIL").