### PR TITLE
AP_HAL_ChibiOS: stop defining HAL_USE_EXT and HAL_NO_CCM

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -1189,9 +1189,7 @@ class ChibiOSHWDef(hwdef.HWDef):
             f.write('''
 #define HAL_BOOTLOADER_BUILD TRUE
 #define HAL_USE_ADC FALSE
-#define HAL_USE_EXT FALSE
 #define HAL_NO_PRINTF
-#define HAL_NO_CCM
 #define HAL_USE_I2C FALSE
 #define HAL_USE_PWM FALSE
 #define CH_DBG_ENABLE_STACK_CHECK FALSE


### PR DESCRIPTION
these aren't used anywhere in the codebase