### PR TITLE
autotest: lengthten timeout in SetHomeAlt test

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -6665,7 +6665,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             higher_home = copy.copy(home)
             higher_home.alt += 40
             self.set_home(higher_home)
-            self.wait_altitude(home.alt+target_alt-5, home.alt+target_alt+5, relative=False, minimum_duration=10, timeout=11)
+            self.wait_altitude(home.alt+target_alt-5, home.alt+target_alt+5, relative=False, minimum_duration=10, timeout=12)
             self.disarm_vehicle(force=True)
             self.reboot_sitl()
 


### PR DESCRIPTION
there's a race condition here around timing

2025-09-18T05:53:40.6428106Z AT-1055.7: Got mode CRUISE 2025-09-18T05:53:40.6428551Z AT-1055.7: Sending COMMAND_INT to (1,1) (MAV_CMD_DO_SET_HOME=179) (p1=0.000000 p2=0.000000 p3=0.000000 p4=0.000000 p5=-353629381 p6=1491650850  p7=625.100000 f=5) 2025-09-18T05:53:40.6429319Z AT-1055.7: ACK received: COMMAND_ACK {command : 179, result : 0, progress : 0, result_param2 : 0, target_system : 250, target_component : 250} (0.000000s) 2025-09-18T05:53:40.6429870Z AT-1055.7: Waiting for Altitude=605.10 with accuracy 5.00 2025-09-18T05:53:40.6430176Z AT-1055.7: Altitude=601.21 (got 605.100000 +- 5.000000) 2025-09-18T05:53:40.6430556Z AT-1055.8: Altitude=600.12 (got 605.100000 +- 5.000000) (maintain=1.1/10.0) 2025-09-18T05:53:40.6430940Z AT-1055.8: Altitude=600.18 (got 605.100000 +- 5.000000) (maintain=0.8/10.0) 2025-09-18T05:53:40.6431306Z AT-1055.8: Altitude=601.95 (got 605.100000 +- 5.000000) (maintain=1.9/10.0) 2025-09-18T05:53:40.6431747Z AT-1055.9: Altitude=602.73 (got 605.100000 +- 5.000000) (maintain=3.0/10.0) 2025-09-18T05:53:40.6432361Z AT-1055.9: Altitude=602.89 (got 605.100000 +- 5.000000) (maintain=4.1/10.0) 2025-09-18T05:53:40.6432809Z AT-1056.0: Altitude=602.82 (got 605.100000 +- 5.000000) (maintain=5.2/10.0) 2025-09-18T05:53:40.6433175Z AT-1056.0: Altitude=602.73 (got 605.100000 +- 5.000000) (maintain=6.3/10.0) 2025-09-18T05:53:40.6433528Z AT-1056.0: Altitude=602.68 (got 605.100000 +- 5.000000) (maintain=7.4/10.0) 2025-09-18T05:53:40.6433885Z AT-1056.1: Altitude=602.66 (got 605.100000 +- 5.000000) (maintain=8.5/10.0) 2025-09-18T05:53:40.6434242Z AT-1056.1: Altitude=602.66 (got 605.100000 +- 5.000000) (maintain=9.5/10.0) 2025-09-18T05:53:40.6434679Z AT-1056.1: Exception caught: Failed to attain Altitude want 605.1, reached 602.2793750000004 2025-09-18T05:53:40.6435071Z Traceback (most recent call last):