### PR TITLE
Sub: GCS_MAVLink: fix SCALED_PRESSURE3 for standard users

### DIFF
--- a/ArduSub/GCS_MAVLink_Sub.cpp
+++ b/ArduSub/GCS_MAVLink_Sub.cpp
@@ -107,6 +107,8 @@ void GCS_MAVLINK_Sub::send_scaled_pressure3()
 #if AP_TEMPERATURE_SENSOR_ENABLED
     float temperature;
     if (!sub.temperature_sensor.get_temperature(temperature)) {
+        // Fall back to original behaviour
+        GCS_MAVLINK::send_scaled_pressure3();
         return;
     }
     mavlink_msg_scaled_pressure3_send(
@@ -116,6 +118,9 @@ void GCS_MAVLINK_Sub::send_scaled_pressure3()
         0,
         temperature * 100,
         0); // TODO: use differential pressure temperature
+#else
+    // Fall back to standard behaviour
+    GCS_MAVLINK::send_scaled_pressure3();
 #endif
 }
 


### PR DESCRIPTION
Adds fallback behaviour so users with a third barometer can get their data, at least when it's not used in conjunction with the temperature sensor that the initial reallocation workaround was being used for.

---

The missing functionality was raised in [this forum thread](https://discuss.bluerobotics.com/t/3rd-pressure-sensor-data-not-included-in-mavlink/20922/10), where a Cube Black user (which has 2 internal baros) was trying to use their external baro (which is required for ArduSub depth estimation), and couldn't get temperature data from it.