### PR TITLE
AP_Radio: Add the definitions of transmitter modes 3 and 4

### DIFF
--- a/libraries/AP_Radio/AP_Radio.cpp
+++ b/libraries/AP_Radio/AP_Radio.cpp
@@ -82,7 +82,7 @@ const AP_Param::GroupInfo AP_Radio::var_info[] = {
     // @Param: _STKMD
     // @DisplayName: Stick input mode
     // @Description: This selects between different stick input modes. The default is mode2, which has throttle on the left stick and pitch on the right stick. You can instead set mode1, which has throttle on the right stick and pitch on the left stick.
-    // @Values: 1:Mode1,2:Mode2
+    // @Values: 1:Mode1,2:Mode2,3:Mode3,4:Mode4
     // @User: Advanced
     AP_GROUPINFO("_STKMD", 10, AP_Radio, stick_mode, 2),
 


### PR DESCRIPTION
In Japan, there are people who are accustomed to using game controllers to operate drones.
These people choose Mode 3.
I found that Modes 3 and 4 are not included in the parameter descriptions.
I will add them to the parameter descriptions.

ex:
https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Radio/AP_Radio_bk2425.cpp#L606