### PR TITLE
autotest: correct diagnostic output

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -5399,8 +5399,8 @@ class TestSuite(ABC):
             target_system=target_system,
             target_component=target_component
         )
-        itemstype = mavutil.mavlink.enums["MAV_MISSION_TYPE"][wploader.mav_mission_type()]
-        self.progress(f"Loading {itemstype} ({os.path.basename(filepath)}")
+        itemstype = mavutil.mavlink.enums["MAV_MISSION_TYPE"][wploader.mav_mission_type()].name
+        self.progress(f"Loading {itemstype} ({os.path.basename(filepath)})")
         wploader.load(filepath)
         return [self.wp_to_mission_item_int(x, wploader.mav_mission_type()) for x in wploader.wpoints]  # noqa:502
 


### PR DESCRIPTION
old:
```
AT-0000.1: Loading <pymavlink.dialects.v20.all.EnumEntry object at 0x7fa5b3300c50> (flaps.txt
```
new:
```
AT-0000.1: Loading MAV_MISSION_TYPE_MISSION (flaps.txt)
```
