### PR TITLE
autotest: run_mission.py: set mavlink20 in environment

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -5981,7 +5981,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.binary,
             'plane',
             self.generic_mission_filepath_for_filename("flaps.txt"),
-        ])
+        ], checkfail=True)
         self.start_SITL()
 
     def MAV_CMD_GUIDED_CHANGE_ALTITUDE(self):

--- a/Tools/autotest/run_mission.py
+++ b/Tools/autotest/run_mission.py
@@ -6,12 +6,14 @@ Run a mission in SITL
 AP_FLAKE8_CLEAN
 '''
 
-import vehicle_test_suite
 import os
-import sys
-import argparse
 
-from pysim import util
+os.environ['MAVLINK20'] = '1'
+
+import vehicle_test_suite  # noqa:E402
+import sys  # noqa:E402
+import argparse  # noqa:E402
+from pysim import util  # noqa:E402
 
 
 class RunMission(vehicle_test_suite.TestSuite):


### PR DESCRIPTION
    ... otherwise we fail to read mission files correctly as we try to construct mission items with too many parameters
