### PR TITLE
Plane: prevent bad climbs in auto mode

### DIFF
--- a/ArduPlane/commands.cpp
+++ b/ArduPlane/commands.cpp
@@ -41,7 +41,9 @@ void Plane::set_next_WP(const Location &loc)
 
     // convert relative alt to absolute alt
     if (!next_WP_loc.terrain_alt) {
-        next_WP_loc.change_alt_frame(Location::AltFrame::ABSOLUTE);
+        if (!next_WP_loc.change_alt_frame(Location::AltFrame::ABSOLUTE)) {
+            INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
+        }
     }
 
     // are we already past the waypoint? This happens when we jump

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -296,6 +296,8 @@ protected:
 
 private:
 
+    bool init_pending;
+
     // Delay the next navigation command
     struct {
         uint32_t time_max_ms;

--- a/ArduPlane/mode_auto.cpp
+++ b/ArduPlane/mode_auto.cpp
@@ -23,9 +23,6 @@ bool ModeAuto::_enter()
 #else
     plane.auto_state.vtol_mode = false;
 #endif
-    plane.next_WP_loc = plane.prev_WP_loc = plane.current_loc;
-    // start or resume the mission, based on MIS_AUTORESET
-    plane.mission.start_or_resume();
 
     if (hal.util->was_watchdog_armed()) {
         if (hal.util->persistent_data.waypoint_num != 0) {
@@ -38,6 +35,8 @@ bool ModeAuto::_enter()
 #if HAL_SOARING_ENABLED
     plane.g2.soaring_controller.init_cruising();
 #endif
+
+    init_pending = true;
 
     return true;
 }
@@ -62,6 +61,16 @@ void ModeAuto::_exit()
 
 void ModeAuto::update()
 {
+    if (init_pending) {
+        if (!AP::ahrs().home_is_set()) {
+            return;
+        }
+        init_pending = false;
+        plane.next_WP_loc = plane.prev_WP_loc = plane.current_loc;
+        // start or resume the mission, based on MIS_AUTORESET
+        plane.mission.start_or_resume();
+    }
+
     if (plane.mission.state() != AP_Mission::MISSION_RUNNING) {
         // this could happen if AP_Landing::restart_landing_sequence() returns false which would only happen if:
         // restart_landing_sequence() is called when not executing a NAV_LAND or there is no previous nav point
@@ -148,6 +157,11 @@ bool ModeAuto::does_auto_throttle() const
 // returns true if the vehicle can be armed in this mode
 bool ModeAuto::_pre_arm_checks(size_t buflen, char *buffer) const
 {
+    if (init_pending) {
+        hal.util->snprintf(buffer, buflen, "ModeAuto: waiting for home");
+        return false;
+    }
+
 #if HAL_QUADPLANE_ENABLED
     if (plane.quadplane.enabled()) {
         if (plane.quadplane.option_is_set(QuadPlane::Option::ONLY_ARM_IN_QMODE_OR_AUTO) &&

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -7517,6 +7517,32 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.set_rc(2, 1500)
         self.fly_home_land_and_disarm()
 
+    def PlaneAbsAltTakeoff(self):
+        '''try taking off to an absolute altitude'''
+        takeoff_alt = 650
+        self.upload_simple_relhome_mission([
+            self.create_MISSION_ITEM_INT(
+                mavutil.mavlink.MAV_CMD_NAV_TAKEOFF,
+                frame=mavutil.mavlink.MAV_FRAME_GLOBAL,
+                z=takeoff_alt,
+            ),
+            self.create_MISSION_ITEM_INT(
+                mavutil.mavlink.MAV_CMD_NAV_LOITER_UNLIM,
+                frame=mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT,
+            ),
+        ])
+
+        self.reboot_sitl()
+        self.change_mode('AUTO')
+        self.wait_ready_to_arm()
+        alt = self.get_altitude()
+        if takeoff_alt - alt > 100:
+            raise ValueError("Bad altitude assumption made")
+
+        self.arm_vehicle()
+        self.wait_altitude(takeoff_alt-10, takeoff_alt+10, timeout=60, minimum_duration=45)
+        self.fly_home_land_and_disarm()
+
     def ScriptedArmingChecksApplet(self):
         """ Applet for Arming Checks will prevent a vehicle from arming based on scripted checks
             """
@@ -7787,6 +7813,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.LOITER,
             self.MAV_CMD_NAV_LOITER_TURNS,
             self.MAV_CMD_NAV_LOITER_TO_ALT,
+            self.PlaneAbsAltTakeoff,
             self.DeepStall,
             self.WatchdogHome,
             self.LargeMissions,


### PR DESCRIPTION
if we entered auto mode before we get our home location then we can end up subtracting a 0m AMSL from a supplied absolute altitude, making the relative-takeoff-altitude a Very Big Number

Supplied autotest fails before and passes after.

From before the fix:
<img width="1933" height="919" alt="image" src="https://github.com/user-attachments/assets/c8cfc940-b621-48e1-85e0-6bf78d29a5f4" />

(I'm not even going to speculate on what's going on with that altitude at the end of the test, but you can see we climb to ~1000m AMSL rather than the mission-desired 650m)

After the fix:
<img width="1933" height="919" alt="image" src="https://github.com/user-attachments/assets/1c998fb6-1a3a-4644-bee8-ce6102b6da50" />

I'm labeling this for backport, but I'm dubious as this is probably a very long-standing bug.

The pre-arm check is probably overkill as Plane currently requires position for arming anyway and home will get set rapidly from that.  Might close a thin race.
