### PR TITLE
Convert Copter to meters (8): Remove unused functions

### DIFF
--- a/ArduCopter/mode_loiter.cpp
+++ b/ArduCopter/mode_loiter.cpp
@@ -192,7 +192,7 @@ void ModeLoiter::run()
 
 float ModeLoiter::wp_distance_m() const
 {
-    return loiter_nav->get_distance_to_target_cm() * 0.01f;
+    return loiter_nav->get_distance_to_target_m();
 }
 
 float ModeLoiter::wp_bearing_deg() const

--- a/ArduCopter/tuning.cpp
+++ b/ArduCopter/tuning.cpp
@@ -219,7 +219,7 @@ void Copter::tuning(const RC_Channel *tuning_ch, int8_t tuning_param, float tuni
         break;
 
     case TUNING_LOITER_MAX_XY_SPEED:
-        loiter_nav->set_speed_max_NE_cms(tuning_value);
+        loiter_nav->set_speed_max_NE_ms(tuning_value * 0.01);
         break;
     }
 }

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -475,18 +475,6 @@ void AC_AttitudeControl::input_euler_angle_roll_pitch_yaw_rad(float euler_roll_a
     attitude_controller_run_quat();
 }
 
-// Sets desired roll, pitch, and yaw angular rates (in centidegrees/s).
-// See input_euler_rate_roll_pitch_yaw_rads() for full details.
-void AC_AttitudeControl::input_euler_rate_roll_pitch_yaw_cds(float euler_roll_rate_cds, float euler_pitch_rate_cds, float euler_yaw_rate_cds)
-{
-    // Convert from centidegrees on public interface to radians
-    const float euler_roll_rate_rads = cd_to_rad(euler_roll_rate_cds);
-    const float euler_pitch_rate_rads = cd_to_rad(euler_pitch_rate_cds);
-    const float euler_yaw_rate_rads = cd_to_rad(euler_yaw_rate_cds);
-
-    input_euler_rate_roll_pitch_yaw_rads(euler_roll_rate_rads, euler_pitch_rate_rads, euler_yaw_rate_rads);
-}
-
 // Sets desired roll, pitch, and yaw angular rates (in radians/s).
 // This command is used to apply angular rate targets in the earth frame.
 // The inputs are shaped using acceleration limits and time constants.
@@ -757,16 +745,6 @@ void AC_AttitudeControl::input_rate_step_bf_roll_pitch_yaw_rads(float roll_rate_
     _ang_vel_body_rads = Vector3f{roll_rate_step_bf_rads, pitch_rate_step_bf_rads, yaw_rate_step_bf_rads};
 }
 
-// Sets desired thrust vector and heading rate (in centidegrees/s).
-// See input_thrust_vector_rate_heading_rads() for full details.
-void AC_AttitudeControl::input_thrust_vector_rate_heading_cds(const Vector3f& thrust_vector, float heading_rate_cds, bool slew_yaw)
-{
-    // Convert from centidegrees on public interface to radians
-    const float heading_rate_rads = cd_to_rad(heading_rate_cds);
-
-    input_thrust_vector_rate_heading_rads(thrust_vector, heading_rate_rads, slew_yaw);
-}
-
 // Sets desired thrust vector and heading rate (in radians/s).
 // Used for tilt-based navigation with independent yaw control.
 // The thrust vector defines the desired orientation (e.g., pointing direction for vertical thrust),
@@ -822,17 +800,6 @@ void AC_AttitudeControl::input_thrust_vector_rate_heading_rads(const Vector3f& t
 
     // Call quaternion attitude controller
     attitude_controller_run_quat();
-}
-
-// Sets desired thrust vector and heading (in centidegrees) with heading rate (in centidegrees/s).
-// See input_thrust_vector_heading_rad() for full details.
-void AC_AttitudeControl::input_thrust_vector_heading_cd(const Vector3f& thrust_vector, float heading_angle_cd, float heading_rate_cds)
-{
-    // Convert from centidegrees on public interface to radians
-    const float heading_rate_rads = cd_to_rad(heading_rate_cds);
-    const float heading_angle_rad = cd_to_rad(heading_angle_cd);
-
-    input_thrust_vector_heading_rad(thrust_vector, heading_angle_rad, heading_rate_rads);
 }
 
 // Sets desired thrust vector and heading (in radians) with heading rate (in radians/s).

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -217,10 +217,6 @@ public:
     // Outputs are passed to the rate controller via shaped angular velocity targets.
     virtual void input_euler_angle_roll_pitch_yaw_rad(float euler_roll_angle_rad, float euler_pitch_angle_rad, float euler_yaw_angle_rad, bool slew_yaw);
 
-    // Sets desired roll, pitch, and yaw angular rates (in centidegrees/s).
-    // See input_euler_rate_roll_pitch_yaw_rads() for full details.
-    void input_euler_rate_roll_pitch_yaw_cds(float euler_roll_rate_cds, float euler_pitch_rate_cds, float euler_yaw_rate_cds);
-
     // Sets desired roll, pitch, and yaw angular rates (in radians/s).
     // This command is used to apply angular rate targets in the earth frame.
     // The inputs are shaped using acceleration limits and time constants.
@@ -274,19 +270,11 @@ public:
     // Used to apply discrete disturbances or step inputs for system identification.
     virtual void input_rate_step_bf_roll_pitch_yaw_rads(float roll_rate_step_bf_rads, float pitch_rate_step_bf_rads, float yaw_rate_step_bf_rads);
 
-    // Sets desired thrust vector and heading rate (in centidegrees/s).
-    // See input_thrust_vector_rate_heading_rads() for full details.
-    void input_thrust_vector_rate_heading_cds(const Vector3f& thrust_vector, float heading_rate_cds, bool slew_yaw = true);
-
     // Sets desired thrust vector and heading rate (in radians/s).
     // Used for tilt-based navigation with independent yaw control.
     // The thrust vector defines the desired orientation (e.g., pointing direction for vertical thrust),
     // while the heading rate adjusts yaw. The input is shaped by acceleration and slew limits.
     virtual void input_thrust_vector_rate_heading_rads(const Vector3f& thrust_vector, float heading_rate_rads, bool slew_yaw = true);
-
-    // Sets desired thrust vector and heading (in centidegrees) with heading rate (in centidegrees/s).
-    // See input_thrust_vector_heading_rad() for full details.
-    void input_thrust_vector_heading_cd(const Vector3f& thrust_vector, float heading_angle_cd, float heading_rate_cds);
 
     // Sets desired thrust vector and heading (in radians) with heading rate (in radians/s).
     // Used for advanced attitude control where thrust direction is separated from yaw orientation.

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -57,10 +57,6 @@ public:
     // When high_vibes is true, forces use of vertical fallback for velocity.
     void update_estimates(bool high_vibes = false);
 
-    // Returns the jerk limit for horizontal path shaping in cm/s³.
-    // See get_shaping_jerk_NE_msss() for full details.
-    float get_shaping_jerk_NE_cmsss() const { return get_shaping_jerk_NE_msss() * 100.0; }
-
     // Returns the jerk limit for horizontal path shaping in m/s³.
     // Used to constrain acceleration changes in trajectory generation.
     float get_shaping_jerk_NE_msss() const { return _shaping_jerk_ne_msss; }
@@ -70,20 +66,11 @@ public:
     /// 3D position shaper
     ///
 
-    // Sets a new NEU position target in centimeters and computes a jerk-limited trajectory.
-    // Also updates vertical buffer logic using terrain altitude target.
-    // See input_pos_NEU_m() for full details.
-    void input_pos_NEU_cm(const Vector3p& pos_neu_cm, float pos_terrain_target_alt_cm, float terrain_buffer_cm);
-
     // Sets a new NEU position target in meters and computes a jerk-limited trajectory.
     // Updates internal acceleration commands using a smooth kinematic path constrained
     // by configured acceleration and jerk limits. Terrain margin is used to constrain
     // horizontal velocity to avoid vertical buffer violation.
     void input_pos_NEU_m(const Vector3p& pos_neu_m, float pos_terrain_target_alt_m, float terrain_buffer_m);
-
-    // Returns a scaling factor for horizontal velocity in cm/s to respect vertical terrain buffer.
-    // See pos_terrain_U_scaler_m() for full details.
-    float pos_terrain_U_scaler_cm(float pos_terrain_u_cm, float pos_terrain_u_buffer_cm) const;
 
     // Returns a scaling factor for horizontal velocity in m/s to ensure
     // the vertical controller maintains a safe distance above terrain.
@@ -118,24 +105,12 @@ public:
     // Returns maximum horizontal speed in m/s used for shaping the trajectory.
     float get_max_speed_NE_ms() const { return _vel_max_ne_ms; }
 
-    // Returns maximum horizontal acceleration in cm/s².
-    // See get_max_accel_NE_mss() for full details.
-    float get_max_accel_NE_cmss() const { return get_max_accel_NE_mss() * 100.0; }
-
     // Returns maximum horizontal acceleration in m/s² used for trajectory shaping.
     float get_max_accel_NE_mss() const { return _accel_max_ne_mss; }
-
-    // Sets maximum allowed horizontal position error in cm.
-    // See set_pos_error_max_NE_m() for full details.
-    void set_pos_error_max_NE_cm(float error_max_cm) { set_pos_error_max_NE_m(error_max_cm * 0.01); }
 
     // Sets maximum allowed horizontal position error in meters.
     // Used to constrain the output of the horizontal position P controller.
     void set_pos_error_max_NE_m(float error_max_m) { _p_pos_ne_m.set_error_max(error_max_m); }
-
-    // Returns maximum allowed horizontal position error in cm.
-    // See get_pos_error_max_NE_m() for full details.
-    float get_pos_error_max_NE_cm() const { return get_pos_error_max_NE_m() * 100.0; }
 
     // Returns maximum allowed horizontal position error in meters.
     float get_pos_error_max_NE_m() const { return _p_pos_ne_m.get_error_max(); }
@@ -157,10 +132,6 @@ public:
     // Intended for normal startup when the full state is known.
     // Private function shared by other NE initializers.
     void init_NE_controller();
-
-    // Sets the desired NE-plane acceleration in cm/s² using jerk-limited shaping.
-    // See input_accel_NE_m() for full details.
-    void input_accel_NE_cm(const Vector3f& accel_neu_cmsss);
 
     // Sets the desired NE-plane acceleration in m/s² using jerk-limited shaping.
     // Smoothly transitions to the specified acceleration from current kinematic state.
@@ -229,23 +200,11 @@ public:
     // These values constrain the correction output of the PID controller.
     void set_correction_speed_accel_U_m(float speed_down_ms, float speed_up_ms, float accel_mss);
 
-    // Returns maximum vertical acceleration in cm/s².
-    // See get_max_accel_U_mss() for full details.
-    float get_max_accel_U_cmss() const { return get_max_accel_U_mss() * 100.0; }
-
     // Returns maximum vertical acceleration in m/s² used for shaping the climb/descent trajectory.
     float get_max_accel_U_mss() const { return _accel_max_u_mss; }
 
-    // Returns maximum allowed positive (upward) position error in cm.
-    // See get_pos_error_up_m() for full details.
-    float get_pos_error_up_cm() const { return get_pos_error_up_m() * 100.0; }
-
     // Returns maximum allowed positive (upward) position error in meters.
     float get_pos_error_up_m() const { return _p_pos_u_m.get_error_max(); }
-
-    // Returns maximum allowed negative (downward) position error in cm.
-    // See get_pos_error_down_m() for full details.
-    float get_pos_error_down_cm() const { return get_pos_error_down_m() * 100.0; }
 
     // Returns maximum allowed negative (downward) position error in meters.
     float get_pos_error_down_m() const { return _p_pos_u_m.get_error_min(); }
@@ -256,10 +215,6 @@ public:
 
     // Returns maximum climb rate in m/s used for shaping the vertical trajectory.
     float get_max_speed_up_ms() const { return _vel_max_up_ms; }
-
-    // Returns maximum descent rate in cm/s (typically negative).
-    // See get_max_speed_down_ms() for full details.
-    float get_max_speed_down_cms() const { return get_max_speed_down_ms() * 100.0; }
 
     /// Returns maximum descent rate in m/s (typically negative).
     float get_max_speed_down_ms() const { return _vel_max_down_ms; }
@@ -283,18 +238,10 @@ public:
     // Private function shared by other vertical initializers.
     void init_U_controller();
 
-    // Sets the desired vertical acceleration in cm/s² using jerk-limited shaping.
-    // See input_accel_U_m() for full details.
-    virtual void input_accel_U_cm(float accel_u_cmss);
-
     // Sets the desired vertical acceleration in m/s² using jerk-limited shaping.
     // Smoothly transitions to the target acceleration from current kinematic state.
     // Constraints: max acceleration and jerk set via set_max_speed_accel_U_m().
     void input_accel_U_m(float accel_u_mss);
-
-    // Sets desired vertical velocity and acceleration (cm/s, cm/s²) using jerk-limited shaping.
-    // See input_vel_accel_U_m() for full details.
-    void input_vel_accel_U_cm(float &vel_u_cms, float accel_u_cmss, bool limit_output = true);
 
     // Sets desired vertical velocity and acceleration (m/s, m/s²) using jerk-limited shaping.
     // Calculates required acceleration using current vertical kinematics.
@@ -350,17 +297,9 @@ public:
     /// Accessors
     ///
 
-    // Sets externally computed NEU position, velocity, and acceleration in centimeters, cm/s, and cm/s².
-    // See set_pos_vel_accel_NEU_m() for full details.
-    void set_pos_vel_accel_NEU_cm(const Vector3p& pos_neu_cm, const Vector3f& vel_neu_cms, const Vector3f& accel_neu_cmss);
-
     // Sets externally computed NEU position, velocity, and acceleration in meters, m/s, and m/s².
     // Use when path planning or shaping is done outside this controller.
     void set_pos_vel_accel_NEU_m(const Vector3p& pos_neu_m, const Vector3f& vel_neu_ms, const Vector3f& accel_neu_mss);
-
-    // Sets externally computed NE position, velocity, and acceleration in centimeters, cm/s, and cm/s².
-    // See set_pos_vel_accel_NE_m() for full details.
-    void set_pos_vel_accel_NE_cm(const Vector2p& pos_ne_cm, const Vector2f& vel_ne_cms, const Vector2f& accel_ne_cmss);
 
     // Sets externally computed NE position, velocity, and acceleration in meters, m/s, and m/s².
     // Use when path planning or shaping is done outside this controller.
@@ -369,30 +308,14 @@ public:
 
     /// Position
 
-    // Returns the estimated position in NEU frame, in centimeters relative to EKF origin.
-    // See get_pos_estimate_NEU_m() for full details.
-    const Vector3p get_pos_estimate_NEU_cm() const { return get_pos_estimate_NEU_m() * 100.0; }
-
     // Returns the estimated position in NEU frame, in meters relative to EKF origin.
     const Vector3p& get_pos_estimate_NEU_m() const { return _pos_estimate_neu_m; }
-
-    // Returns the target position in NEU frame, in centimeters relative to EKF origin.
-    // See get_pos_target_NEU_m() for full details.
-    const Vector3p get_pos_target_NEU_cm() const { return get_pos_target_NEU_m() * 100.0; }
 
     // Returns the target position in NEU frame, in meters relative to EKF origin.
     const Vector3p& get_pos_target_NEU_m() const { return _pos_target_neu_m; }
 
-    // Sets the desired NE position in centimeters relative to EKF origin.
-    // See set_pos_desired_NE_m() for full details.
-    void set_pos_desired_NE_cm(const Vector2f& pos_desired_ne_cm) { set_pos_desired_NE_m(pos_desired_ne_cm.topostype() * 0.01); }
-
     // Sets the desired NE position in meters relative to EKF origin.
     void set_pos_desired_NE_m(const Vector2p& pos_desired_ne_m) { _pos_desired_neu_m.xy() = pos_desired_ne_m; }
-
-    // Returns the desired position in NEU frame, in centimeters relative to EKF origin.
-    // See get_pos_desired_NEU_m() for full details.
-    const Vector3p get_pos_desired_NEU_cm() const { return get_pos_desired_NEU_m() * 100.0; }
 
     // Returns the desired position in NEU frame, in meters relative to EKF origin.
     const Vector3p& get_pos_desired_NEU_m() const { return _pos_desired_neu_m; }
@@ -421,16 +344,8 @@ public:
 
     /// Stopping Point
 
-    // Computes NE stopping point in centimeters based on current position, velocity, and acceleration.
-    // See get_stopping_point_NE_m() for full details.
-    void get_stopping_point_NE_cm(Vector2p &stopping_point_neu_cm) const;
-
     // Computes NE stopping point in meters based on current position, velocity, and acceleration.
     void get_stopping_point_NE_m(Vector2p &stopping_point_neu_m) const;
-
-    // Computes vertical stopping point in centimeters based on current velocity and acceleration.
-    // See get_stopping_point_U_m() for full details.
-    void get_stopping_point_U_cm(postype_t &stopping_point_u_cm) const;
 
     // Computes vertical stopping point in meters based on current velocity and acceleration.
     void get_stopping_point_U_m(postype_t &stopping_point_u_m) const;
@@ -438,16 +353,8 @@ public:
 
     /// Position Error
 
-    // Returns NEU position error vector in centimeters.
-    // See get_pos_error_NEU_m() for full details.
-    const Vector3f get_pos_error_NEU_cm() const { return get_pos_error_NEU_m() * 100.0; }
-
     // Returns NEU position error vector in meters between current and target positions.
     const Vector3f get_pos_error_NEU_m() const { return Vector3f{_p_pos_ne_m.get_error().x, _p_pos_ne_m.get_error().y, _p_pos_u_m.get_error()}; }
-
-    // Returns total NE-plane position error magnitude in centimeters.
-    // See get_pos_error_NE_m() for full details.
-    float get_pos_error_NE_cm() const { return get_pos_error_NE_m() * 100.0; }
 
     // Returns total NE-plane position error magnitude in meters.
     float get_pos_error_NE_m() const { return _p_pos_ne_m.get_error().length(); }
@@ -462,10 +369,6 @@ public:
 
     /// Velocity
 
-    // Returns current velocity estimate in NEU frame in cm/s.
-    // See get_vel_estimate_NEU_ms() for full details.
-    const Vector3f get_vel_estimate_NEU_cms() const { return get_vel_estimate_NEU_ms() * 100.0; }
-
     // Returns current velocity estimate in NEU frame in m/s.
     const Vector3f& get_vel_estimate_NEU_ms() const { return _vel_estimate_neu_ms; }
 
@@ -475,10 +378,6 @@ public:
 
     // Sets desired velocity in NEU frame in m/s.
     void set_vel_desired_NEU_ms(const Vector3f &vel_desired_neu_ms) { _vel_desired_neu_ms = vel_desired_neu_ms; }
-
-    // Sets desired horizontal (NE) velocity in cm/s.
-    // See set_vel_desired_NE_ms() for full details.
-    void set_vel_desired_NE_cms(const Vector2f &vel_desired_ne_cms) { set_vel_desired_NE_ms(vel_desired_ne_cms * 0.01); }
 
     // Sets desired horizontal (NE) velocity in m/s.
     void set_vel_desired_NE_ms(const Vector2f &vel_desired_ne_ms) { _vel_desired_neu_ms.xy() = vel_desired_ne_ms; }
@@ -497,10 +396,6 @@ public:
     // Returns velocity target in NEU frame in m/s.
     const Vector3f& get_vel_target_NEU_ms() const { return _vel_target_neu_ms; }
 
-    // Sets desired vertical velocity (Up) in cm/s.
-    // See set_vel_desired_U_ms() for full details.
-    void set_vel_desired_U_cms(float vel_desired_u_cms) { set_vel_desired_U_ms(vel_desired_u_cms * 0.01); }
-
     // Sets desired vertical velocity (Up) in m/s.
     void set_vel_desired_U_ms(float vel_desired_u_ms) { _vel_desired_neu_ms.z = vel_desired_u_ms; }
 
@@ -514,16 +409,8 @@ public:
 
     /// Acceleration
 
-    // Sets desired horizontal acceleration in cm/s².
-    // See set_accel_desired_NE_mss() for full details.
-    void set_accel_desired_NE_cmss(const Vector2f &accel_desired_neu_cmss) { set_accel_desired_NE_mss(accel_desired_neu_cmss * 0.01); }
-
     // Sets desired horizontal acceleration in m/s².
     void set_accel_desired_NE_mss(const Vector2f &accel_desired_neu_mss) { _accel_desired_neu_mss.xy() = accel_desired_neu_mss; }
-
-    // Returns target NEU acceleration in cm/s².
-    // See get_accel_target_NEU_mss() for full details.
-    const Vector3f get_accel_target_NEU_cmss() const { return get_accel_target_NEU_mss() * 100.0; }
 
     // Returns target NEU acceleration in m/s².
     const Vector3f& get_accel_target_NEU_mss() const { return _accel_target_neu_mss; }
@@ -544,10 +431,6 @@ public:
 
     // Initializes terrain altitude and terrain target to the same value (in meters).
     void init_pos_terrain_U_m(float pos_terrain_u_m);
-
-    // Returns current terrain altitude in centimeters above EKF origin.
-    // See get_pos_terrain_U_m() for full details.
-    float get_pos_terrain_U_cm() const { return get_pos_terrain_U_m() * 100.0; }
 
     // Returns current terrain altitude in meters above EKF origin.
     float get_pos_terrain_U_m() const { return _pos_terrain_u_m; }
@@ -575,38 +458,17 @@ public:
     bool get_accel_target(Vector3f &accel_target_NED_mss);
 #endif
 
-    // Sets NE offset targets (position [cm], velocity [cm/s], acceleration [cm/s²]) from EKF origin.
-    // Offsets must be refreshed at least every 3 seconds to remain active.
-    // See set_posvelaccel_offset_target_NE_m() for full details.
-    void set_posvelaccel_offset_target_NE_cm(const Vector2p& pos_offset_target_ne_cm, const Vector2f& vel_offset_target_ne_cms, const Vector2f& accel_offset_target_ne_cmss);
-
     // Sets NE offset targets in meters, m/s, and m/s².
     void set_posvelaccel_offset_target_NE_m(const Vector2p& pos_offset_target_ne_m, const Vector2f& vel_offset_target_ne_ms, const Vector2f& accel_offset_target_ne_mss);
-
-    // Sets vertical offset targets (cm, cm/s, cm/s²) from EKF origin.
-    // See set_posvelaccel_offset_target_U_m() for full details.
-    void set_posvelaccel_offset_target_U_cm(float pos_offset_target_u_cm, float vel_offset_target_u_cms, float accel_offset_target_u_cmss);
 
     // Sets vertical offset targets (m, m/s, m/s²) from EKF origin.
     void set_posvelaccel_offset_target_U_m(float pos_offset_target_u_m, float vel_offset_target_u_ms, float accel_offset_target_u_mss);
 
-    // Returns current NEU position offset in cm.
-    // See get_pos_offset_NEU_m() for full details.
-    const Vector3p get_pos_offset_NEU_cm() const { return get_pos_offset_NEU_m() * 100.0; }
-
     // Returns current NEU position offset in meters.
     const Vector3p& get_pos_offset_NEU_m() const { return _pos_offset_neu_m; }
 
-    // Returns current NEU velocity offset in cm/s.
-    // See get_vel_offset_NEU_ms() for full details.
-    const Vector3f get_vel_offset_NEU_cms() const { return get_vel_offset_NEU_ms() * 100.0; }
-
     // Returns current NEU velocity offset in m/s.
     const Vector3f& get_vel_offset_NEU_ms() const { return _vel_offset_neu_ms; }
-
-    // Returns current NEU acceleration offset in cm/s².
-    // See get_accel_offset_NEU_mss() for full details.
-    const Vector3f get_accel_offset_NEU_cmss() const { return get_accel_offset_NEU_mss() * 100.0; }
 
     // Returns current NEU acceleration offset in m/s².
     const Vector3f& get_accel_offset_NEU_mss() const { return _accel_offset_neu_mss; }
@@ -614,23 +476,11 @@ public:
     // Sets vertical position offset in meters above EKF origin.
     void set_pos_offset_U_m(float pos_offset_u_m) { _pos_offset_neu_m.z = pos_offset_u_m; }
 
-    // Returns vertical position offset in cm above EKF origin.
-    // See get_pos_offset_U_m() for full details.
-    float get_pos_offset_U_cm() const { return get_pos_offset_U_m() * 100.0; }
-
     // Returns vertical position offset in meters above EKF origin.
     float get_pos_offset_U_m() const { return _pos_offset_neu_m.z; }
 
-    // Returns vertical velocity offset in cm/s.
-    // See get_vel_offset_U_ms() for full details.
-    float get_vel_offset_U_cms() const { return get_vel_offset_U_ms() * 100.0; }
-
     // Returns vertical velocity offset in m/s.
     float get_vel_offset_U_ms() const { return _vel_offset_neu_ms.z; }
-
-    // Returns vertical acceleration offset in cm/s².
-    // See get_accel_offset_U_mss() for full details.
-    float get_accel_offset_U_cmss() const { return get_accel_offset_U_mss() * 100.0; }
 
     // Returns vertical acceleration offset in m/s².
     float get_accel_offset_U_mss() const { return _accel_offset_neu_mss.z; }
@@ -656,14 +506,6 @@ public:
     // Returns desired pitch angle in centidegrees for the attitude controller.
     // See get_pitch_rad() for full details.
     float get_pitch_cd() const { return rad_to_cd(_pitch_target_rad); }
-
-    // Returns desired yaw angle in centidegrees for the attitude controller.
-    // See get_yaw_rad() for full details.
-    float get_yaw_cd() const { return rad_to_cd(_yaw_target_rad); }
-
-    // Returns desired yaw rate in centidegrees/second for the attitude controller.
-    // See get_yaw_rate_rads() for full details.
-    float get_yaw_rate_cds() const { return rad_to_cd(_yaw_rate_target_rads); }
 
     // Returns desired thrust direction as a unit vector in the body frame.
     Vector3f get_thrust_vector() const;
@@ -708,10 +550,6 @@ public:
     // Prevents I-term windup by storing the current target direction.
     void set_externally_limited_NE() { _limit_vector_neu.x = _accel_target_neu_mss.x; _limit_vector_neu.y = _accel_target_neu_mss.y; }
 
-    // Converts lean angles (rad) to NEU acceleration in cm/s².
-    // See lean_angles_rad_to_accel_NEU_mss() for full details.
-    Vector3f lean_angles_rad_to_accel_NEU_cmss(const Vector3f& att_target_euler_rad) const;
-
     // Converts lean angles (rad) to NEU acceleration in m/s².
     Vector3f lean_angles_rad_to_accel_NEU_mss(const Vector3f& att_target_euler_rad) const;
 
@@ -740,27 +578,15 @@ public:
     // Zeros I-terms and aligns targets to current position.
     void standby_NEU_reset();
 
-    // Returns measured vertical (Up) acceleration in cm/s² (Earth frame, gravity-compensated).
-    // See get_measured_accel_U_mss() for full details.
-    float get_measured_accel_U_cmss() const { return get_measured_accel_U_mss() * 100.0; }
-
     // Returns measured vertical (Up) acceleration in m/s² (Earth frame, gravity-compensated).
     // Positive = upward acceleration.
     float get_measured_accel_U_mss() const { return -(_ahrs.get_accel_ef().z + GRAVITY_MSS); }
 
     // Returns true if the requested forward pitch is limited by the configured tilt constraint.
     bool get_fwd_pitch_is_limited() const;
-    
-    // Sets artificial NE position disturbance in centimeters.
-    // See set_disturb_pos_NE_m() for full details.
-    void set_disturb_pos_NE_cm(const Vector2f& disturb_pos_cm) { set_disturb_pos_NE_m(disturb_pos_cm * 0.01); }
 
     // Sets artificial NE position disturbance in meters.
     void set_disturb_pos_NE_m(const Vector2f& disturb_pos_m) { _disturb_pos_ne_m = disturb_pos_m; }
-
-    // Sets artificial NE velocity disturbance in cm/s.
-    // See set_disturb_vel_NE_ms() for full details.
-    void set_disturb_vel_NE_cms(const Vector2f& disturb_vel_cms) { set_disturb_vel_NE_ms(disturb_vel_cms * 0.01); }
 
     // Sets artificial NE velocity disturbance in m/s.
     void set_disturb_vel_NE_ms(const Vector2f& disturb_vel_ms) { _disturb_vel_ne_ms = disturb_vel_ms; }

--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -410,19 +410,6 @@ AC_Circle::TerrainSource AC_Circle::get_terrain_source() const
 #endif
 }
 
-// Returns terrain offset in centimeters above the EKF origin at the current position.
-// See get_terrain_offset_m() for full details.
-bool AC_Circle::get_terrain_offset_cm(float& offset_cm)
-{
-    // Convert input value to meters for internal processing
-    float offset_m = offset_cm * 0.01;
-    // Retrieve terrain offset in meters
-    bool terrain_valid = get_terrain_offset_m(offset_m);
-    // Convert result back to centimeters
-    offset_cm = offset_m * 100.0;
-    return terrain_valid;
-}
-
 // Returns terrain offset in meters above the EKF origin at the current position.
 // Positive values indicate terrain is above the EKF origin altitude.
 // Terrain source may be rangefinder or terrain database.

--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -40,10 +40,6 @@ public:
     // If conversion fails, defaults to current position and logs a navigation error.
     void set_center(const Location& center);
 
-    // Sets the circle center using a NEU position vector in centimeters from the EKF origin.
-    // See set_center_NEU_m() for full details.
-    void set_center_NEU_cm(const Vector3f& center_neu_cm, bool is_terrain_alt) { _center_neu_m = center_neu_cm.topostype() * 0.01; _is_terrain_alt = is_terrain_alt; }
-
     // Sets the circle center using a NEU position vector in meters from the EKF origin.
     // If `is_terrain_alt` is true, the Z component is treated as altitude above terrain; otherwise, above EKF origin.
     void set_center_NEU_m(const Vector3p& center_neu_m, bool is_terrain_alt) { _center_neu_m = center_neu_m; _is_terrain_alt = is_terrain_alt; }
@@ -100,11 +96,11 @@ public:
 
     // Returns the desired roll angle in centidegrees from the position controller.
     // Should be passed to the attitude controller as a stabilization input.
-    float get_roll_cd() const { return _pos_control.get_roll_cd(); }
+    float get_roll_cd() const { return rad_to_cd(_pos_control.get_roll_rad()); }
 
     // Returns the desired pitch angle in centidegrees from the position controller.
     // Should be passed to the attitude controller as a stabilization input.
-    float get_pitch_cd() const { return _pos_control.get_pitch_cd(); }
+    float get_pitch_cd() const { return rad_to_cd(_pos_control.get_pitch_rad()); }
 
     // Returns the desired yaw angle in centidegrees computed by the circle controller.
     // May be oriented toward the circle center or along the path depending on configuration.
@@ -132,10 +128,6 @@ public:
     // dist_m is updated with the horizontal distance to the circle center.
     // If the vehicle is at the center, the point directly behind the vehicle (based on yaw) is returned.
     void get_closest_point_on_circle_NEU_m(Vector3p& result_NEU_m, float& dist_m) const;
-
-    // Returns the horizontal distance to the circle target in centimeters.
-    // See get_distance_to_target_m() for full details.
-    float get_distance_to_target_cm() const { return get_distance_to_target_m() * 100.0; }
 
     // Returns the horizontal distance to the circle target in meters.
     // Calculated using the position controller’s NE position error norm.
@@ -187,10 +179,6 @@ private:
         TERRAIN_FROM_TERRAINDATABASE,
     };
     AC_Circle::TerrainSource get_terrain_source() const;
-
-    // Returns terrain offset in centimeters above the EKF origin at the current position.
-    // See get_terrain_offset_m() for full details.
-    bool get_terrain_offset_cm(float& offset_cm);
 
     // Returns terrain offset in meters above the EKF origin at the current position.
     // Positive values indicate terrain is above the EKF origin altitude.

--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -94,13 +94,6 @@ AC_Loiter::AC_Loiter(const AP_AHRS_View& ahrs, AC_PosControl& pos_control, const
     AP_Param::setup_object_defaults(this, var_info);
 }
 
-// Sets the initial loiter target position in centimeters from the EKF origin.
-// See init_target_m() for full details.
-void AC_Loiter::init_target_cm(const Vector2f& position_ne_cm)
-{
-    init_target_m(position_ne_cm.topostype() * 0.01);
-}
-
 // Sets the initial loiter target position in meters from the EKF origin.
 // - position_neu_m: horizontal position in the NE frame, in meters.
 // - Initializes internal control state including acceleration targets and feed-forward planning.
@@ -199,18 +192,6 @@ void AC_Loiter::set_pilot_desired_acceleration_rad(float euler_roll_angle_rad, f
 }
 
 // Calculates the expected stopping point based on current velocity and position in the NE frame.
-// Result is returned in centimeters.
-// See get_stopping_point_NE_m() for full details.
-void AC_Loiter::get_stopping_point_NE_cm(Vector2f& stopping_point_ne_cm) const
-{
-    Vector2f stop_ne_m;
-    // Retrieve stopping point in meters
-    get_stopping_point_NE_m(stop_ne_m);
-    // Convert to centimeters
-    stopping_point_ne_cm = stop_ne_m * 100.0;
-}
-
-// Calculates the expected stopping point based on current velocity and position in the NE frame.
 // Result is returned in meters.
 // Uses the position controller’s deceleration model.
 void AC_Loiter::get_stopping_point_NE_m(Vector2f& stopping_point_ne_m) const
@@ -253,13 +234,6 @@ void AC_Loiter::update(bool avoidance_on)
 
     // Run position controller to compute desired attitude and thrust
     _pos_control.update_NE_controller();
-}
-
-// Sets the maximum allowed horizontal loiter speed in cm/s.
-// See set_speed_max_NE_ms() for full details.
-void AC_Loiter::set_speed_max_NE_cms(float speed_max_ne_cms)
-{
-    set_speed_max_NE_ms(speed_max_ne_cms * 0.01);
 }
 
 // Sets the maximum allowed horizontal loiter speed in m/s.

--- a/libraries/AC_WPNav/AC_Loiter.h
+++ b/libraries/AC_WPNav/AC_Loiter.h
@@ -15,10 +15,6 @@ public:
     /// Constructor
     AC_Loiter(const AP_AHRS_View& ahrs, AC_PosControl& pos_control, const AC_AttitudeControl& attitude_control);
 
-    // Sets the initial loiter target position in centimeters from the EKF origin.
-    // See init_target_m() for full details.
-    void init_target_cm(const Vector2f& position_neu_cm);
-
     // Sets the initial loiter target position in meters from the EKF origin.
     // - position_neu_m: horizontal position in the NE frame, in meters.
     // - Initializes internal control state including acceleration targets and feed-forward planning.
@@ -42,10 +38,6 @@ public:
     // - Applies internal shaping using the current attitude controller dt.
     void set_pilot_desired_acceleration_rad(float euler_roll_angle_rad, float euler_pitch_angle_rad);
 
-    // Returns pilot-requested horizontal acceleration in the NE frame in cm/s².
-    // See get_pilot_desired_acceleration_NE_mss() for full details.
-    Vector2f get_pilot_desired_acceleration_NE_cmss() const { return get_pilot_desired_acceleration_NE_mss() * 100.0; }
-
     // Returns pilot-requested horizontal acceleration in the NE frame in m/s².
     // This is the internally computed and smoothed acceleration vector applied by the loiter controller.
     const Vector2f& get_pilot_desired_acceleration_NE_mss() const { return _desired_accel_ne_mss; }
@@ -54,18 +46,9 @@ public:
     void clear_pilot_desired_acceleration() { set_pilot_desired_acceleration_rad(0.0, 0.0); }
 
     // Calculates the expected stopping point based on current velocity and position in the NE frame.
-    // Result is returned in centimeters.
-    // See get_stopping_point_NE_m() for full details.
-    void get_stopping_point_NE_cm(Vector2f& stopping_point_ne_cm) const;
-
-    // Calculates the expected stopping point based on current velocity and position in the NE frame.
     // Result is returned in meters.
     // Uses the position controller’s deceleration model.
     void get_stopping_point_NE_m(Vector2f& stopping_point_ne_m) const;
-
-    // Returns the horizontal distance to the loiter target in centimeters.
-    // See get_distance_to_target_m() for full details.
-    float get_distance_to_target_cm() const { return get_distance_to_target_m() * 100.0; }
 
     // Returns the horizontal distance to the loiter target in meters.
     // Computed using the NE position error from the position controller.
@@ -88,19 +71,15 @@ public:
     // If `avoidance_on` is true, velocity is adjusted using avoidance logic before being applied.
     void update(bool avoidance_on = true);
 
-    // Sets the maximum allowed horizontal loiter speed in cm/s.
-    // See set_speed_max_NE_ms() for full details.
-    void set_speed_max_NE_cms(float speed_max_NE_cms);
-
     // Sets the maximum allowed horizontal loiter speed in m/s.
     // Internally converts to cm/s and clamps to a minimum of LOITER_SPEED_MIN_CMS.
     void set_speed_max_NE_ms(float speed_max_NE_ms);
 
     // Returns the desired roll angle in centidegrees from the loiter controller.
-    float get_roll_cd() const { return _pos_control.get_roll_cd(); }
+    float get_roll_cd() const { return rad_to_cd(get_roll_rad()); }
 
     // Returns the desired pitch angle in centidegrees from the loiter controller.
-    float get_pitch_cd() const { return _pos_control.get_pitch_cd(); }
+    float get_pitch_cd() const { return rad_to_cd(get_pitch_rad()); }
 
     // Returns the desired roll angle in radians from the loiter controller.
     float get_roll_rad() const { return _pos_control.get_roll_rad(); }

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -150,14 +150,6 @@ AC_WPNav::TerrainSource AC_WPNav::get_terrain_source() const
 /// waypoint navigation
 ///
 
-// Initializes waypoint and spline controllers using inputs in cm.
-// See wp_and_spline_init_m() for full details.
-void AC_WPNav::wp_and_spline_init_cm(float speed_cms, Vector3f stopping_point_neu_cm)
-{
-    // convert inputs from centimeters to meters and call the main initializer
-    wp_and_spline_init_m(speed_cms * 0.01, stopping_point_neu_cm.topostype() * 0.01);
-}
-
 // Initializes waypoint and spline navigation using inputs in meters.
 // Sets speed and acceleration limits, calculates jerk constraints,
 // and initializes spline or S-curve leg with a defined starting point.
@@ -243,13 +235,6 @@ void AC_WPNav::set_speed_NE_ms(float speed_ms)
     }
 }
 
-// Sets the climb speed for waypoint navigation in cm/s.
-// See set_speed_up_ms() for full details.
-void AC_WPNav::set_speed_up_cms(float speed_up_cms)
-{
-    set_speed_up_ms(speed_up_cms * 0.01);
-}
-
 // Sets the climb speed for waypoint navigation in m/s.
 // Updates the vertical controller with the new ascent rate limit.
 void AC_WPNav::set_speed_up_ms(float speed_up_ms)
@@ -259,14 +244,6 @@ void AC_WPNav::set_speed_up_ms(float speed_up_ms)
 
     // recompute the trajectory using updated limits
     update_track_with_speed_accel_limits();
-}
-
-// Sets the descent speed for waypoint navigation in cm/s.
-// See set_speed_down_ms() for full details.
-void AC_WPNav::set_speed_down_cms(float speed_down_cms)
-{
-    // convert cm/s to m/s and apply to descent limit
-    set_speed_down_ms(speed_down_cms * 0.01);
 }
 
 // Sets the descent speed for waypoint navigation in m/s.
@@ -408,13 +385,6 @@ bool AC_WPNav::set_wp_destination_NEU_m(const Vector3p& destination_neu_m, bool 
     _flags.reached_destination = false;
 
     return true;
-}
-
-// Sets the next waypoint destination using a NEU position vector in centimeters.
-// See set_wp_destination_next_NEU_m() for full details.
-bool AC_WPNav::set_wp_destination_next_NEU_cm(const Vector3f& destination_neu_cm, bool is_terrain_alt)
-{
-    return set_wp_destination_next_NEU_m(destination_neu_cm.topostype() * 0.01, is_terrain_alt);
 }
 
 // Sets the next waypoint destination using a NEU position vector in meters.
@@ -735,17 +705,6 @@ bool AC_WPNav::force_stop_at_next_wp()
     return true;
 }
 
-// Returns terrain offset in cm above the EKF origin at the current position.
-// See get_terrain_offset_m() for full details.
-bool AC_WPNav::get_terrain_offset_cm(float& offset_cm)
-{
-    // call meter-version and convert to centimeters
-    float offset_m = offset_cm;
-    const bool ret = get_terrain_offset_m(offset_m);
-    offset_cm = offset_m * 100.0;
-    return ret;
-}
-
 // Returns terrain offset in meters above the EKF origin at the current position.
 // Positive values mean terrain lies above the EKF origin altitude.
 // Source may be rangefinder or terrain database depending on availability.
@@ -963,18 +922,6 @@ bool AC_WPNav::set_spline_destination_next_NEU_m(const Vector3p& next_destinatio
     }
 
     return true;
-}
-
-// Converts a Location to a NEU position vector in cm from the EKF origin.
-// See get_vector_NEU_m() for full details.
-bool AC_WPNav::get_vector_NEU_cm(const Location &loc, Vector3f &pos_from_origin_neu_cm, bool &is_terrain_alt)
-{
-    // convert input to meters for processing
-    Vector3p pos_from_origin_neu_m = pos_from_origin_neu_cm.topostype() * 0.01;
-    // perform vector conversion using meters interface
-    const bool ret = get_vector_NEU_m(loc, pos_from_origin_neu_m, is_terrain_alt);
-    pos_from_origin_neu_cm = pos_from_origin_neu_m.tofloat() * 100.0;
-    return ret;
 }
 
 // Converts a Location to a NEU position vector in meters from the EKF origin.

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -44,10 +44,6 @@ public:
     };
     AC_WPNav::TerrainSource get_terrain_source() const;
 
-    // Returns terrain offset in cm above the EKF origin at the current position.
-    // See get_terrain_offset_m() for full details.
-    bool get_terrain_offset_cm(float& offset_cm);
-
     // Returns terrain offset in meters above the EKF origin at the current position.
     // Positive values mean terrain lies above the EKF origin altitude.
     // Source may be rangefinder or terrain database depending on availability.
@@ -57,10 +53,6 @@ public:
     // Vehicle will stop if distance from target altitude exceeds this margin.
     float get_terrain_margin_m() const { return MAX(_terrain_margin_m, 0.1); }
 
-    // Converts a Location to a NEU position vector in cm from the EKF origin.
-    // See get_vector_NEU_m() for full details.
-    bool get_vector_NEU_cm(const Location &loc, Vector3f &pos_from_origin_NEU_cm, bool &is_terrain_alt);
-
     // Converts a Location to a NEU position vector in meters from the EKF origin.
     // Sets `is_terrain_alt` to true if the resulting Z position is relative to terrain.
     // Returns false if terrain data is unavailable or conversion fails.
@@ -69,10 +61,6 @@ public:
     ///
     /// waypoint controller
     ///
-
-    // Initializes waypoint and spline controllers using inputs in cm.
-    // See wp_and_spline_init_m() for full details.
-    void wp_and_spline_init_cm(float speed_cms = 0.0f, Vector3f stopping_point_neu_cm = Vector3f{});
 
     // Initializes waypoint and spline navigation using inputs in meters.
     // Sets speed and acceleration limits, calculates jerk constraints,
@@ -96,17 +84,9 @@ public:
     // Returns true if waypoint navigation is currently paused via set_pause().
     bool paused() { return _paused; }
 
-    // Sets the climb speed for waypoint navigation in cm/s.
-    // See set_speed_up_ms() for full details.
-    void set_speed_up_cms(float speed_up_cms);
-
     // Sets the climb speed for waypoint navigation in m/s.
     // Updates the vertical controller with the new ascent rate limit.
     void set_speed_up_ms(float speed_up_ms);
-
-    // Sets the descent speed for waypoint navigation in cm/s.
-    // See set_speed_down_ms() for full details.
-    void set_speed_down_cms(float speed_down_cms);
 
     // Sets the descent speed for waypoint navigation in m/s.
     // Updates the vertical controller with the new descent rate limit.
@@ -206,10 +186,6 @@ public:
     // Returns false if terrain offset cannot be determined when required.
     virtual bool set_wp_destination_NEU_m(const Vector3p& destination_neu_m, bool is_terrain_alt = false);
 
-    // Sets the next waypoint destination using a NEU position vector in centimeters.
-    // See set_wp_destination_next_NEU_m() for full details.
-    bool set_wp_destination_next_NEU_cm(const Vector3f& destination_neu_cm, bool is_terrain_alt = false);
-
     // Sets the next waypoint destination using a NEU position vector in meters.
     // Only updates if terrain frame matches current leg.
     // Calculates trajectory preview for smoother transition into next segment.
@@ -265,10 +241,6 @@ public:
         return get_wp_distance_to_destination_m() < _wp_radius_cm * 0.01;
     }
 
-    // Returns the waypoint acceptance radius in centimeters.
-    // See get_wp_radius_m() for full details.
-    float get_wp_radius_cm() const { return get_wp_radius_m() * 100.0; }
-
     // Returns the waypoint acceptance radius in meters.
     // This radius defines the distance from the target waypoint within which the vehicle is considered to have arrived.
     float get_wp_radius_m() const { return _wp_radius_cm * 0.01; }
@@ -302,19 +274,11 @@ public:
     // Returns false if any conversion from location to vector fails.
     bool set_spline_destination_next_loc(const Location& next_destination, const Location& next_next_destination, bool next_next_is_spline);
 
-    // Sets the current spline segment using position vectors in centimeters.
-    // See set_spline_destination_NEU_m() for full details.
-    bool set_spline_destination_NEU_cm(const Vector3f& destination_neu_cm, bool is_terrain_alt, const Vector3f& next_destination_neu_cm, bool next_terrain_alt, bool next_is_spline);
-
     // Sets the current spline waypoint using NEU position vectors in meters.
     // Initializes a spline path from `destination_neu_m` to `next_destination_neu_m`, respecting terrain altitude framing.
     // Both waypoints must use the same altitude frame (either above terrain or above origin).
     // Returns false if terrain altitude cannot be determined when required.
     bool set_spline_destination_NEU_m(const Vector3p& destination_neu_m, bool is_terrain_alt, const Vector3p& next_destination_neu_m, bool next_terrain_alt, bool next_is_spline);
-
-    // Sets the next spline segment using NEU position vectors in centimeters.
-    // See set_spline_destination_next_NEU_m() for full details.
-    bool set_spline_destination_next_NEU_cm(const Vector3f& next_destination_neu_cm, bool next_is_terrain_alt, const Vector3f& next_next_destination_neu_cm, bool next_next_is_terrain_alt, bool next_next_is_spline);
 
     // Sets the next spline segment using NEU position vectors in meters.
     // Creates a spline path from the current destination to `next_destination_neu_m`, and prepares transition toward `next_next_destination_neu_m`.
@@ -344,15 +308,15 @@ public:
 
     // Returns the desired roll angle in centidegrees from the position controller.
     // See get_roll_rad() for full details.
-    float get_roll() const { return _pos_control.get_roll_cd(); }
+    float get_roll() const { return rad_to_cd(get_roll_rad()); }
 
     // Returns the desired pitch angle in centidegrees from the position controller.
     // See get_pitch_rad() for full details.
-    float get_pitch() const { return _pos_control.get_pitch_cd(); }
+    float get_pitch() const { return rad_to_cd(get_pitch_rad()); }
 
     // Returns the desired yaw angle in centidegrees from the position controller.
     // See get_yaw_rad() for full details.
-    float get_yaw() const { return _pos_control.get_yaw_cd(); }
+    float get_yaw() const { return rad_to_cd(get_yaw_rad()); }
 
     // Advances the target location along the current path segment.
     // Updates target position, velocity, and acceleration based on jerk-limited profile (or spline).


### PR DESCRIPTION
Just what the name suggests.

```
Board,blimp,bootloader,copter,heli,plane,rover,sub
CubeOrange,*,*,-64,-72,-120,*,-112
```