### PR TITLE
Plane: Unsuppress throttle for GPS movement or altitude relative to home only if flying

### DIFF
--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -131,28 +131,30 @@ bool Plane::suppress_throttle(void)
         // keep throttle suppressed
         return true;
     }
-    
-    if (fabsf(relative_altitude) >= 10.0f) {
-        // we're more than 10m from the home altitude
-        throttle_suppressed = false;
-        return false;
-    }
 
-    if (gps_movement) {
-        // if we have an airspeed sensor, then check it too, and
-        // require 5m/s. This prevents throttle up due to spiky GPS
-        // groundspeed with bad GPS reception
-#if AP_AIRSPEED_ENABLED
-        if ((!ahrs.using_airspeed_sensor()) || airspeed.get_airspeed() >= 5) {
-            // we're moving at more than 5 m/s
+    if (is_flying()) {
+        if (fabsf(relative_altitude) >= 10.0f) {
+            // we're more than 10m from the home altitude
             throttle_suppressed = false;
-            return false;        
+            return false;
         }
-#else
-        // no airspeed sensor, so we trust that the GPS's movement is truthful
-        throttle_suppressed = false;
-        return false;
-#endif
+
+        if (gps_movement) {
+            // if we have an airspeed sensor, then check it too, and
+            // require 5m/s. This prevents throttle up due to spiky GPS
+            // groundspeed with bad GPS reception
+    #if AP_AIRSPEED_ENABLED
+            if ((!ahrs.using_airspeed_sensor()) || airspeed.get_airspeed() >= 5) {
+                // we're moving at more than 5 m/s
+                throttle_suppressed = false;
+                return false;        
+            }
+    #else
+            // no airspeed sensor, so we trust that the GPS's movement is truthful
+            throttle_suppressed = false;
+            return false;
+    #endif
+        }
     }
 
 #if HAL_QUADPLANE_ENABLED


### PR DESCRIPTION
Instances of unexpected prop starts have happened as a result of GPS altitude reading drift or GPS groundspeed exceeding 5 m/s even when on the ground. This only happens while armed, so a mitigating action is to not spend too much time armed and not flying. Nevertheless, the checks are arbitrary and only make sense if the aircraft is already flying, anyways.

See log snippet of unexpected throttle-up after GPS altitude value drifted to just beyond 10 meters from home altitude.
<img width="1536" height="911" alt="image" src="https://github.com/user-attachments/assets/22af3a8c-855c-4047-8c2c-0977882c4895" />

This is ultimately a safety issue and to prevent damage to the prop or launching mechanism if armed and sitting on the launcher.