### PR TITLE
AP_RangeFinder: ensure that too low and too far states are propagated in DroneCAN

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
@@ -66,6 +66,7 @@ public:
     bool has_data() const;
 
     // returns count of consecutive good readings
+    // note that this method returning zero does not mean that the device is unhealthy:
     uint8_t range_valid_count() const { return state.range_valid_count; }
 
     // return a 3D vector defining the position offset of the sensor

--- a/libraries/AP_RangeFinder/AP_RangeFinder_DroneCAN.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_DroneCAN.h
@@ -28,6 +28,7 @@ protected:
     }
 private:
     uint8_t _instance;
+    // _status is the state received from the peripheral - or "NoData" in case of timeout
     RangeFinder::Status _status;
     float _distance_m;
     uint32_t _last_reading_ms;


### PR DESCRIPTION
The current code means that you will always get "No Data" (which is fatal) rather than too low (which happens when you are sitting on the ground).