### PR TITLE
AP_GyroFFT: prevent buffer overwrite when FFT is not possible

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -7977,6 +7977,20 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.wait_text("clear: Motors EStopped", timeout=30, check_context=True, regex=True)
         self.wait_ready_to_arm()
 
+    def FFTPrearms(self):
+        '''check FFT prearms work'''
+        self.set_parameters({
+            "FFT_ENABLE": 1,
+            "FFT_MAXHZ": 1,
+            "FFT_MINHZ": 200,
+        })
+        self.reboot_sitl()
+        self.assert_prearm_failure(
+            "FFT config invalid",
+            other_prearm_failures_fatal=False,
+            timeout=120,
+        )
+
     def ScriptedArmingChecksAppletRally(self):
         """ Applet for Arming Checks will prevent a vehicle from arming based on scripted checks
             """
@@ -8130,6 +8144,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.TerrainMissionInterrupt,
             self.UniversalAutoLandScript,
             self.Replay,
+            self.FFTPrearms,
         ])
         return ret
 

--- a/libraries/AP_GyroFFT/AP_GyroFFT.cpp
+++ b/libraries/AP_GyroFFT/AP_GyroFFT.cpp
@@ -432,6 +432,10 @@ void AP_GyroFFT::update()
 // called from FFT thread
 uint16_t AP_GyroFFT::run_cycle()
 {
+    if (!_config.valid) {
+        return 0;
+    }
+
     if (!analysis_enabled()) {
         return 0;
     }
@@ -553,10 +557,21 @@ void AP_GyroFFT::update_parameters(bool force)
     }
 #endif
 
+    if (_fft_min_hz >= _fft_max_hz) {
+        // the parameters were just configured badly
+        return;
+    }
+
+    const float nyquist_limit_hz = _fft_sampling_rate_hz * 0.48;
+    if (_fft_min_hz >= nyquist_limit_hz) {
+        // we don't get data fast enough to run an FFT above the
+        // minimum configured frequency
+        return;
+    }
+
     WITH_SEMAPHORE(_sem);
 
-    // don't allow MAXHZ to go to Nyquist
-    _fft_max_hz.set(MIN(_fft_max_hz, _fft_sampling_rate_hz * 0.48));
+    _fft_max_hz.set(MIN(_fft_max_hz, nyquist_limit_hz));
     _config._snr_threshold_db = _snr_threshold_db;
     _config._fft_min_hz = _fft_min_hz;
     _config._fft_max_hz = _fft_max_hz;
@@ -566,6 +581,7 @@ void AP_GyroFFT::update_parameters(bool force)
     _config._fft_end_bin = MIN(ceilf(_fft_max_hz.get() / _state->_bin_resolution), _state->_bin_count);
     // actual attenuation from the db value
     _config._attenuation_cutoff = powf(10.0f, -_attenuation_power_db * 0.1f);
+    _config.valid = true;
 }
 
 // thread for processing gyro data via FFT
@@ -620,6 +636,17 @@ bool AP_GyroFFT::pre_arm_check(char *failure_msg, const uint8_t failure_msg_len)
         return true;
     }
 
+    // make sure the frequency maximum is below Nyquist
+    if (_fft_max_hz > _fft_sampling_rate_hz * 0.5f) {
+        hal.util->snprintf(failure_msg, failure_msg_len, "FFT config MAXHZ %dHz > %dHz", _fft_max_hz.get(), _fft_sampling_rate_hz / 2);
+        return false;
+    }
+
+    if (!_config.valid) {
+        hal.util->snprintf(failure_msg, failure_msg_len, "FFT config invalid");
+        return false;
+    }
+
     // analysis is started in the main thread, don't trample on in-flight analysis
     if (_global_state._analysis_started) {
         hal.util->snprintf(failure_msg, failure_msg_len, "FFT still analyzing");
@@ -629,12 +656,6 @@ bool AP_GyroFFT::pre_arm_check(char *failure_msg, const uint8_t failure_msg_len)
     // still calibrating noise so not ready
     if (_global_state._noise_needs_calibration) {
         hal.util->snprintf(failure_msg, failure_msg_len, "FFT calibrating noise");
-        return false;
-    }
-
-    // make sure the frequency maximum is below Nyquist
-    if (_fft_max_hz > _fft_sampling_rate_hz * 0.5f) {
-        hal.util->snprintf(failure_msg, failure_msg_len, "FFT config MAXHZ %dHz > %dHz", _fft_max_hz.get(), _fft_sampling_rate_hz / 2);
         return false;
     }
 

--- a/libraries/AP_GyroFFT/AP_GyroFFT.h
+++ b/libraries/AP_GyroFFT/AP_GyroFFT.h
@@ -139,6 +139,8 @@ private:
         float _attenuation_cutoff;
         // SNR Threshold
         float _snr_threshold_db;
+        // indicates whether anything in this structure is valid:
+        bool valid;
     } _config;
 
     // smoothing filter that first takes the median from a sliding window and then


### PR DESCRIPTION
## Summary

Stops the autopilot boot-looping if someone fat-fingers a filter parameter.

Throws a pre-arm check if a filter is configured incorrectly.

## Description

max-Hz was being set to a value below min-Hz because of the constraint of max-Hz to be below the Nyquist limit.  This was causing start and endpoints to be reversed, leading to integer underflow leading to indexing of arrays with Vrey Large Numbers.

~4.6 version is here: https://github.com/ArduPilot/ardupilot/pull/31156~
