### PR TITLE
Rover: Convert a literal value into a defined value

### DIFF
--- a/Rover/GCS_MAVLink_Rover.cpp
+++ b/Rover/GCS_MAVLink_Rover.cpp
@@ -145,7 +145,7 @@ void GCS_MAVLINK_Rover::send_servo_out()
 #if AP_RSSI_ENABLED
         receiver_rssi()
 #else
-        255
+        UINT8_MAX
 #endif
         );
 }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -7377,11 +7377,11 @@ uint8_t GCS_MAVLINK::receiver_rssi() const
 {
     AP_RSSI *aprssi = AP::rssi();
     if (aprssi == nullptr) {
-        return 255;
+        return UINT8_MAX;
     }
 
     if (!aprssi->enabled()) {
-        return 255;
+        return UINT8_MAX;
     }
 
     // scale across the full valid range


### PR DESCRIPTION
In the MAVLINK message RC_CHANNELS_SCALED, the RSSI is represented as UINT8_MAX. I changed 255 to UINT8_MAX.

https://mavlink.io/en/messages/common.html#RC_CHANNELS_SCALED