### PR TITLE
AP_Scheduler: cleanup after  #31138  (remove redundant checks, clarify comments)

### DIFF
--- a/ArduPlane/Plane.cpp
+++ b/ArduPlane/Plane.cpp
@@ -383,13 +383,6 @@ void Plane::one_second_loop()
             landing.alt_offset = 0;
     }
 
-    // this ensures G_Dt is correct, catching startup issues with constructors
-    // calling the scheduler methods
-    if (!is_equal(1.0f/scheduler.get_loop_rate_hz(), scheduler.get_loop_period_s()) ||
-        !is_equal(G_Dt, scheduler.get_loop_period_s())) {
-        INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
-    }
-
     const float loop_rate = AP::scheduler().get_filtered_loop_rate_hz();
 #if HAL_QUADPLANE_ENABLED
     if (quadplane.available()) {

--- a/libraries/AP_Scheduler/AP_Scheduler.cpp
+++ b/libraries/AP_Scheduler/AP_Scheduler.cpp
@@ -113,8 +113,9 @@ void AP_Scheduler::init(const AP_Scheduler::Task *tasks, uint8_t num_tasks, uint
         _loop_rate_hz.set(2000);
     }
     _last_loop_time_s = 1.0 / _loop_rate_hz;
-    // at least on SITL the lazy initialization of these gets called early
-    // make sure they reflect the current values of _loop_rate_hz
+
+    // These variables are initialized only here in scheduler::init()
+    // These are also defensively initialized in the getter functions to catch initialization order issues.
     _loop_period_us = 1000000UL / _loop_rate_hz;
     _loop_period_s = 1.0f / _loop_rate_hz;
     _active_loop_rate_hz = _loop_rate_hz;

--- a/libraries/AP_Scheduler/AP_Scheduler.h
+++ b/libraries/AP_Scheduler/AP_Scheduler.h
@@ -29,6 +29,7 @@
 #include <AP_HAL/Util.h>
 #include <AP_Math/AP_Math.h>
 #include "PerfInfo.h"       // loop perf monitoring
+#include <AP_InternalError/AP_InternalError.h>
 
 #if AP_SCHEDULER_EXTENDED_TASKINFO_ENABLED
 #define AP_SCHEDULER_NAME_INITIALIZER(_clazz,_name) .name = #_clazz "::" #_name,
@@ -142,6 +143,7 @@ public:
     // get the active main loop rate
     uint16_t get_loop_rate_hz(void) {
         if (_active_loop_rate_hz == 0) {
+            INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
             _active_loop_rate_hz = _loop_rate_hz;
         }
         return _active_loop_rate_hz;
@@ -149,6 +151,7 @@ public:
     // get the time-allowed-per-loop in microseconds
     uint32_t get_loop_period_us() {
         if (_loop_period_us == 0) {
+            INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
             _loop_period_us = 1000000UL / _loop_rate_hz;
         }
         return _loop_period_us;
@@ -156,6 +159,7 @@ public:
     // get the time-allowed-per-loop in seconds
     float get_loop_period_s() {
         if (is_zero(_loop_period_s)) {
+            INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
             _loop_period_s = 1.0f / _loop_rate_hz;
         }
         return _loop_period_s;
@@ -203,7 +207,7 @@ private:
     AP_Int16 _loop_rate_hz;
 
     // loop rate in Hz as set at startup
-    AP_Int16 _active_loop_rate_hz;
+    uint16_t _active_loop_rate_hz;
 
     // scheduler options
     AP_Int8 _options;


### PR DESCRIPTION
This PR follows up on #31138 and #30305 and should close #30234 

**Changes:**
- Simplify `get_loop_rate_hz`, `get_loop_period_us`, `get_loop_period_s` getters
  - Removed lazy initialization logic
  - Marked as `const`
 - Updated comment to clarify initialization occurs only in `init()`
 - Changed `_active_loop_rate_hz` type from `AP_Int16` to `uint16_t`
- Removed redundant scheduler validation in `ArduPlane`

These changes are only cleanup / style improvements, no functional behavior is changed.

**Tests**
- Build succesfully for sitl 
<img width="1585" height="465" alt="copter_build_test" src="https://github.com/user-attachments/assets/a495f22a-1f2c-4f86-8e89-6f2917e1d911" />

<img width="1625" height="467" alt="plane_build_test" src="https://github.com/user-attachments/assets/89fcf369-0839-4908-9728-22b7dc180d45" />
