### PR TITLE
AP_Compass: check return value of register_compass in AP_Compass_MSP

### DIFF
--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -376,7 +376,7 @@ private:
     /// @param  dev_id                   Dev ID of compass to register against
     ///
     /// @return instance number saved against the dev id or first available empty instance number
-    bool register_compass(int32_t dev_id, uint8_t& instance);
+    bool register_compass(int32_t dev_id, uint8_t& instance) WARN_IF_UNUSED;
 
     // load backend drivers
     bool _add_backend(AP_Compass_Backend *backend);

--- a/libraries/AP_Compass/AP_Compass_Backend.h
+++ b/libraries/AP_Compass/AP_Compass_Backend.h
@@ -112,7 +112,7 @@ protected:
     void drain_accumulated_samples(uint8_t instance, const Vector3f *scale = NULL);
 
     // register a new compass instance with the frontend
-    bool register_compass(int32_t dev_id, uint8_t& instance) const;
+    bool register_compass(int32_t dev_id, uint8_t& instance) const WARN_IF_UNUSED;
 
     // set dev_id for an instance
     void set_dev_id(uint8_t instance, uint32_t dev_id);

--- a/libraries/AP_Compass/AP_Compass_MSP.cpp
+++ b/libraries/AP_Compass/AP_Compass_MSP.cpp
@@ -24,7 +24,9 @@ AP_Compass_MSP::AP_Compass_MSP(uint8_t _msp_instance)
     msp_instance = _msp_instance;
 
     auto devid = AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_MSP, 0, _msp_instance, 0);
-    register_compass(devid, instance);
+    if (!register_compass(devid, instance)) {
+        return;
+    }
 
     set_dev_id(instance, devid);
     set_external(instance, true);


### PR DESCRIPTION
if we don't do this then we can end up overwriting someone else's data

... and make sure these bugs don't come back by using WARN_IF_UNUSED