### PR TITLE
GCS_MAVLink: stop compiling support for sending HWSTATUS message

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -729,7 +729,9 @@ protected:
 
     // message sending functions:
     bool try_send_mission_message(enum ap_message id);
+#if AP_MAVLINK_MSG_HWSTATUS_ENABLED
     void send_hwstatus();
+#endif  // AP_MAVLINK_MSG_HWSTATUS_ENABLED
     void handle_data_packet(const mavlink_message_t &msg);
 
     // these two methods are called after current_loc is updated:

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1103,7 +1103,9 @@ ap_message GCS_MAVLINK::mavlink_id_to_ap_message_id(const uint32_t mavlink_id) c
 #endif  // AP_AHRS_ENABLED
         { MAVLINK_MSG_ID_VFR_HUD,               MSG_VFR_HUD},
 #endif
+#if AP_MAVLINK_MSG_HWSTATUS_ENABLED
         { MAVLINK_MSG_ID_HWSTATUS,              MSG_HWSTATUS},
+#endif  // AP_MAVLINK_MSG_HWSTATUS_ENABLED
 #if AP_MAVLINK_MSG_WIND_ENABLED
         { MAVLINK_MSG_ID_WIND,                  MSG_WIND},
 #endif  // AP_MAVLINK_MSG_WIND_ENABLED
@@ -5892,6 +5894,7 @@ bool GCS_MAVLINK::try_send_mission_message(const enum ap_message id)
     return true;
 }
 
+#if AP_MAVLINK_MSG_HWSTATUS_ENABLED
 void GCS_MAVLINK::send_hwstatus()
 {
     mavlink_msg_hwstatus_send(
@@ -5899,6 +5902,7 @@ void GCS_MAVLINK::send_hwstatus()
         hal.analogin->board_voltage()*1000,
         0);
 }
+#endif  // AP_MAVLINK_MSG_HWSTATUS_ENABLED
 
 #if AP_RPM_ENABLED
 void GCS_MAVLINK::send_rpm() const
@@ -6363,10 +6367,12 @@ bool GCS_MAVLINK::try_send_message(const enum ap_message id)
         send_heartbeat();
         break;
 
+#if AP_MAVLINK_MSG_HWSTATUS_ENABLED
     case MSG_HWSTATUS:
         CHECK_PAYLOAD_SIZE(HWSTATUS);
         send_hwstatus();
         break;
+#endif  // AP_MAVLINK_MSG_HWSTATUS_ENABLED
 
 #if AP_AHRS_ENABLED
     case MSG_LOCATION:

--- a/libraries/GCS_MAVLink/GCS_config.h
+++ b/libraries/GCS_MAVLink/GCS_config.h
@@ -124,6 +124,13 @@
 #define AP_MAVLINK_MSG_HIGHRES_IMU_ENABLED (HAL_PROGRAM_SIZE_LIMIT_KB > 1024) && AP_INERTIALSENSOR_ENABLED
 #endif
 
+// ArduPilot 4.4 stopped sending this message by default
+// ArduPilot 4.7 stops compiling support into the firmware
+// ArduPilot 4.8 removes the code
+#ifndef AP_MAVLINK_MSG_HWSTATUS_ENABLED
+#define AP_MAVLINK_MSG_HWSTATUS_ENABLED 0
+#endif
+
 #ifndef AP_MAVLINK_MAV_CMD_SET_HAGL_ENABLED
 #define AP_MAVLINK_MAV_CMD_SET_HAGL_ENABLED (HAL_PROGRAM_SIZE_LIMIT_KB > 1024)
 #endif

--- a/libraries/GCS_MAVLink/ap_message.h
+++ b/libraries/GCS_MAVLink/ap_message.h
@@ -49,7 +49,9 @@ enum ap_message : uint8_t {
     MSG_FENCE_STATUS                   =  32,
     MSG_SIMSTATE                       =  33,
     MSG_SIM_STATE                      =  34,
+#if AP_MAVLINK_MSG_HWSTATUS_ENABLED
     MSG_HWSTATUS                       =  35,
+#endif  // AP_MAVLINK_MSG_HWSTATUS_ENABLED
     MSG_WIND                           =  36,
 #if AP_MAVLINK_MSG_RANGEFINDER_SENDING_ENABLED
     MSG_RANGEFINDER                    =  37,


### PR DESCRIPTION
still leaving the code in in case someone is desperate, but slated it for removal

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  -104              *
Durandal                            -104   *           -104    -104              -104   -104   -104
Hitec-Airspeed           *                 *
KakuteH7-bdshot                     -104   *           -104    -104              -104   -104   -104
MatekF405                           -96    *           -104    -104              -96    -96    -104
Pixhawk1-1M-bdshot                  -104               -104    -104              -104   -104   -104
SITL_x86_64_linux_gnu               0                  0       0                 0      0      0
f103-QiotekPeriph        *                 *
f303-Universal           *                 *
iomcu                                                                *
revo-mini                           -96    *           -96     -96               -104   -104   -96
skyviper-v2450                                         -104
```
