### PR TITLE
AP_Compass: add a MSP probe method which can fail

### DIFF
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -1406,7 +1406,11 @@ void Compass::_detect_backends(void)
 #if AP_COMPASS_MSP_ENABLED
     for (uint8_t i=0; i<8; i++) {
         if (msp_instance_mask & (1U<<i)) {
-            ADD_BACKEND(DRIVER_MSP, NEW_NOTHROW AP_Compass_MSP(i));
+            auto *backend = AP_Compass_MSP::probe(i);
+            if (backend == nullptr) {
+                continue;
+            }
+            ADD_BACKEND(DRIVER_MSP, backend);
         }
     }
 #endif

--- a/libraries/AP_Compass/AP_Compass_MSP.h
+++ b/libraries/AP_Compass/AP_Compass_MSP.h
@@ -11,11 +11,17 @@
 class AP_Compass_MSP : public AP_Compass_Backend
 {
 public:
-    AP_Compass_MSP(uint8_t msp_instance);
+
+    static AP_Compass_Backend *probe(uint8_t _msp_instance);
 
     void read(void) override;
 
 private:
+    AP_Compass_MSP(uint8_t _msp_instance) :
+        msp_instance{_msp_instance} { }
+
+    bool init();
+
     void handle_msp(const MSP::msp_compass_data_message_t &pkt) override;
     uint8_t msp_instance;
     uint8_t instance;


### PR DESCRIPTION
currently registering an MSP backend can't fail, so if we fail to register (e.g. out of slots) then we can end up overwriting other's data.

Add a probe method which can return nullptr on failure