### PR TITLE
AP_Scripting: avoid `DEV_PRINTF` for initial memory usage

### DIFF
--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -519,10 +519,11 @@ void lua_scripts::run(void) {
     lua_setmetatable(L, -2);  /* set table as metatable for strings */
     lua_pop(L, 1);  /* pop dummy string */
 
-#ifndef HAL_CONSOLE_DISABLED
-    const int loaded_mem = lua_gc(L, LUA_GCCOUNT, 0) * 1024 + lua_gc(L, LUA_GCCOUNTB, 0);
-    DEV_PRINTF("Lua: State memory usage: %i + %i\n", inital_mem, loaded_mem - inital_mem);
-#endif
+    if (option_is_set(AP_Scripting::DebugOption::RUNTIME_MSG)) {
+        const int loaded_mem = lua_gc(L, LUA_GCCOUNT, 0) * 1024 + lua_gc(L, LUA_GCCOUNTB, 0);
+        GCS_SEND_TEXT(MAV_SEVERITY_DEBUG, "Lua: State memory usage: %i + %i\n",
+            inital_mem, loaded_mem - inital_mem);
+    }
 
     // Scan the filesystem in an appropriate manner and autostart scripts
     // Skip those directores disabled with SCR_DIR_DISABLE param


### PR DESCRIPTION
This corrupts other MAVLink messages going out at the same time, particularly in CI, causing tests to fail because scripting restart and script initial startup messages are destroyed.

Instead use a MAVLink debug statustext, but only send it if the runtime measurement debug bit is on to avoid an obvious change in behavior and unnecessary appearance of a new message.

Tested on Cube Orange that the message appears at the right time. I don't love that it now requires an extra step and additional messages to see this but the CI fix is important. Closes #26478 .

We also still use `DEV_PRINTF` [here](https://github.com/ArduPilot/ardupilot/blob/a3041bd10f8b62e8157dbf68e55783577a8096c9/libraries/AP_Scripting/lua_scripts.cpp#L127) but that is probably less likely to cause a CI problem since we retransmit the message several times.