### PR TITLE
Rover/Parameters.cpp: update FRAME_TYPE description

### DIFF
--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -464,7 +464,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: FRAME_TYPE
     // @DisplayName: Frame Type
     // @Description: Frame Type
-    // @Values: 0:Undefined,1:Omni3,2:OmniX,3:OmniPlus,4:Omni3Mecanum
+    // @Values: 0:Default,1:Omni3,2:OmniX,3:OmniPlus,4:Omni3Mecanum
     // @User: Standard
     // @RebootRequired: True
     AP_GROUPINFO("FRAME_TYPE", 24, ParametersG2, frame_type, 0),


### PR DESCRIPTION
While "Undefined" as the 0-index FRAME_TYPE makes sense to those of us who understand the inner workings of Rover firmware, displaying "Undefined" in GCS parameter lists can appear like an error to users. Suggest "Default" as a more intuitive descriptor for users.