### PR TITLE
Copter: create and use handle_new_breaches

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -836,6 +836,7 @@ private:
 #if AP_FENCE_ENABLED
     void fence_check();
     void fence_checks_async() override;
+    void fence_handle_new_breaches();
 #endif
 
     // heli.cpp


### PR DESCRIPTION
... because the indenting was getting excessive

best viewed without whitespace changes