### PR TITLE
AP_Landing: add abstract deep-stall input bypassing elevator channel

### DIFF
--- a/libraries/AP_Landing/AP_Landing_Deepstall.h
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.h
@@ -60,6 +60,8 @@ private:
     AP_Float time_constant;
     AP_Float min_abort_alt;
     AP_Float aileron_scalar;
+    AP_Int8 ds_elev_src; // elevator source (0=legacy, 1=channel invariant)
+    AP_Float elevator_norm; // normalized channel invariant value for the elevator at full deflection in deepstall
     int32_t loiter_sum_cd;         // used for tracking the progress on loitering
     DEEPSTALL_STAGE stage;
     Location landing_point;
@@ -71,6 +73,7 @@ private:
     float target_heading_deg;      // target heading for the deepstall in degrees
     uint32_t stall_entry_time;     // time when the aircrafted enter the stall (in millis)
     uint16_t initial_elevator_pwm; // PWM to start slewing the elevator up from
+    int16_t initial_elevator_scaled; // scaled value to start slewing the elevator up from
     uint32_t last_time;            // last time the controller ran
     float L1_xtrack_i;             // L1 integrator for navigation
     PID ds_PID;


### PR DESCRIPTION
Introduce dual-mode deep stall control:
- legacy mode: use elevator PWM only (as before)
- abstract mode: accept normalized input in range [-1..1], so behavior is invariant to elevator channel

This was motivated by my own use case, and I noticed this need echoed in a 2021 forum thread: “Deep stall landing” (discuss.ardupilot.org/t/deep-stall-landing/75962), where others observed limitations in configurations without dedicated elevator control.

Tested via SITL. Verified that behavior under legacy mode matches previous behavior, and that abstract mode properly handles cases without elevator input.