### PR TITLE
AP_GPS: Add support for NAVIC constellation in UBLOX driver

### DIFF
--- a/libraries/AP_GPS/AP_GPS_Params.cpp
+++ b/libraries/AP_GPS/AP_GPS_Params.cpp
@@ -33,7 +33,7 @@ const AP_Param::GroupInfo AP_GPS::Params::var_info[] = {
     // @Param: GNSS_MODE
     // @DisplayName: GNSS system configuration
     // @Description: Bitmask for what GNSS system to use (all unchecked or zero to leave GPS as configured)
-    // @Bitmask: 0:GPS,1:SBAS,2:Galileo,3:Beidou,4:IMES,5:QZSS,6:GLONASS
+    // @Bitmask: 0:GPS,1:SBAS,2:Galileo,3:Beidou,4:IMES,5:QZSS,6:GLONASS,7:NAVIC
     // @User: Advanced
     AP_GROUPINFO("GNSS_MODE", 2, AP_GPS::Params, gnss_mode, 0),
 

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -2384,6 +2384,10 @@ uint8_t AP_GPS_UBLOX::populate_F9_gnss(void)
                     config_GNSS[cfg_count++] = { ConfigKey::CFG_SIGNAL_GLO_L2_ENA, ena };
                 }
                 break;
+            case GNSS_NAVIC:
+                config_GNSS[cfg_count++] = { ConfigKey::CFG_SIGNAL_NAVIC_ENA, ena };
+                config_GNSS[cfg_count++] = { ConfigKey::CFG_SIGNAL_NAVIC_L5_ENA, ena };
+                break;
             // not supported or leave alone
             case GNSS_IMES:
             case GNSS_QZSS:

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -695,7 +695,8 @@ private:
         GNSS_BEIDOU  = 0x03,
         GNSS_IMES    = 0x04,
         GNSS_QZSS    = 0x05,
-        GNSS_GLONASS = 0x06
+        GNSS_GLONASS = 0x06,
+        GNSS_NAVIC   = 0x07,
     };
     enum ubs_nav_fix_type {
         FIX_NONE = 0,


### PR DESCRIPTION
Added support for Navigation with Indian Constellation (NAVIC) to the u-blox GPS driver:
- Added NAVIC as GNSS identifier with value 0x07
- Added ConfigKey values for NAVIC signal enable and L5 band
- Updated GNSS mode parameter description to include NAVIC (bit 7)
- Added NAVIC configuration in F9 GNSS configuration