### PR TITLE
Improve accuracy of TECS airspeed  derivative estimate 

### DIFF
--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -400,7 +400,7 @@ void AP_TECS::_update_speed(float DT)
             // take 5 point moving average
             _vel_dot = _vdot_filter.apply(temp);
         } else {
-            // In no wind relative velocity data is availablem use less ccurate method
+            // If no wind relative velocity data is available use less accurate method
             // that uses acceleration along X axis and is subject to pitch coupling
             const Matrix3f &rotMat = _ahrs.get_rotation_body_to_ned();
             // Calculate speed rate of change


### PR DESCRIPTION
This change uses a more accurate calculation of the TAS rate of change if vehicle and wind velocity estimates are available. This prevents the issue of the bias in the TAS rate of change estimate that is introduced when the X body axis is not aligned with the wind relative velocity vector.

The change has been tested in SITL by performing a short flight in TAKEOFF mode. The TECS speed derivative estimate was compared with speed first order difference.

The following results are for 0 wind

Before - note the small offset
<img width="2050" height="1082" alt="image" src="https://github.com/user-attachments/assets/5b421ddd-8b92-49e9-bfbe-926d00771acc" />

After - the small offset is eliminated
<img width="1028" height="540" alt="Screenshot 2025-10-01 at 6 42 43 PM" src="https://github.com/user-attachments/assets/65bd397d-d261-4ce0-8f97-57888156ba31" />

The following results are with 7 m/s of wind from 090 with the sim continued for long enough to allow a complete orbit as shown

<img width="602" height="580" alt="Screenshot 2025-10-01 at 6 49 51 PM" src="https://github.com/user-attachments/assets/889de7a5-c845-44e7-80af-d17439845284" />

Before - there is more offset during the orbit
<img width="999" height="531" alt="Screenshot 2025-10-01 at 6 49 09 PM" src="https://github.com/user-attachments/assets/496bafb5-5cf0-4263-a1e1-a44867c10bca" />

After - offset during the orbit is reduced, but there is more initially.
<img width="1009" height="529" alt="Screenshot 2025-10-01 at 6 49 28 PM" src="https://github.com/user-attachments/assets/3af47464-1e08-4b4a-befb-121559f9d5c7" />

The first part of takeoff is performed with full throttle and auto-throttle is not engaged until a completion height is achieved, so airspeed derivative accuracy before then is less important.
Wind drift will take longer to learn if there is no airspeed sensor, but those vehicles are using a simple pitch to throttle map and do not use the airspeed derivative.

For reference, this is the wind estimate from the SITL test showing the rate of convergence
<img width="1036" height="547" alt="Screenshot 2025-10-01 at 7 05 01 PM" src="https://github.com/user-attachments/assets/6ce2a3c7-e678-47ee-a912-f6a7131900de" />
