### PR TITLE
AC_AttitudeControl: Removed old reference to PSC_ACC_XY_FILT

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -82,13 +82,7 @@ AC_PosControl *AC_PosControl::_singleton;
 const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // 0 was used for HOVER
 
-    // @Param: _ACC_XY_FILT
-    // @DisplayName: XY Acceleration filter cutoff frequency
-    // @Description: Lower values will slow the response of the navigation controller and reduce twitchiness
-    // @Units: Hz
-    // @Range: 0.5 5
-    // @Increment: 0.1
-    // @User: Advanced
+    // POS_ACC_XY_FILT was here.
 
     // @Param: _POSZ_P
     // @DisplayName: Position (vertical) controller P gain


### PR DESCRIPTION
Addresses #31184.

This will have the side-effect that the parameter documentation will likely not be available to MP, when it connects to old firmwares who still have this parameter (pre 2022).