### PR TITLE
AP_HAL_ESP32: Dynamic SPI Speed Switching Implementation

### DIFF
--- a/libraries/AP_HAL_ESP32/SPIDevice.h
+++ b/libraries/AP_HAL_ESP32/SPIDevice.h
@@ -81,10 +81,11 @@ private:
     SPIDeviceDesc &device_desc;
     Speed speed;
     char *pname;
-    spi_device_handle_t low_speed_dev_handle;
-    spi_device_handle_t high_speed_dev_handle;
+    spi_device_handle_t device_handle;  // Single reconfigurable handle
+    uint32_t current_speed_hz;  // Track currently configured speed
     spi_device_handle_t current_handle();
-    void acquire_bus(bool accuire);
+    void reconfigure_speed(uint32_t new_speed_hz);  // Reconfigure device handle speed
+    void acquire_bus(bool acquire);
 };
 
 class SPIDeviceManager : public AP_HAL::SPIDeviceManager


### PR DESCRIPTION
**Dynamic SPI Speed Switching Implementation**

Problem: Original ESP32 SPI implementation had a critical bug where identical low/high speeds (required by MPU9250) created GPIO conflicts.

Bug Analysis:

```
// ORIGINAL BUGGY CODE:
 if (_device_desc.hspeed != _device_desc.lspeed) {
     spi_bus_add_device(host, &cfg_high, &high_speed_dev_handle);  // Only if different
 }
 // PROBLEM: MPU9250 needs lspeed=7MHz, hspeed=7MHz (identical)
 // Result: high_speed_dev_handle = nullptr → ArduPilot crashes
```

Solution - Dynamic Device Handle Reconfiguration:

```
  // NEW IMPLEMENTATION:
  class SPIDevice {
      spi_device_handle_t device_handle;      // Single reconfigurable handle
      uint32_t current_speed_hz;              // Track current speed
      void reconfigure_speed(uint32_t new_speed_hz);  // Dynamic reconfiguration
  };

  void SPIDevice::reconfigure_speed(uint32_t new_speed_hz) {
      if (current_speed_hz == new_speed_hz) return;  // Skip if already correct

      spi_bus_remove_device(device_handle);          // Remove old handle
      // Create new handle with desired speed
      spi_device_interface_config_t cfg = { .clock_speed_hz = new_speed_hz };
      spi_bus_add_device(host, &cfg, &device_handle);
      current_speed_hz = new_speed_hz;
  }
```


Benefits:

- Supports both variable speeds (MPU9250: 2MHz/8MHz) and identical speeds (MPU9250: 7MHz/7MHz)
- True dynamic speed switching with minimal overhead
