### PR TITLE
AP_HAL_ESP32: fix compilation issue for esp32s3devkit

### DIFF
--- a/libraries/AP_HAL_ESP32/i2c_sw.c
+++ b/libraries/AP_HAL_ESP32/i2c_sw.c
@@ -52,7 +52,7 @@
 #include "malloc.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
-#include "freertos/xtensa_api.h"
+#include "xtensa_api.h"
 #include "freertos/task.h"
 #include "freertos/ringbuf.h"
 #include "soc/dport_reg.h"
@@ -61,7 +61,7 @@
 //#include "hal/i2c_hal.h"
 #include "soc/i2c_periph.h"
 #include "driver/i2c.h"
-#include "driver/periph_ctrl.h"
+//#include "driver/periph_ctrl.h"
 #include "lwip/netdb.h"
 #include "i2c_sw.h"
 


### PR DESCRIPTION
when compiling esp32s3devkit:
```
./waf configure --board esp32s3devkit
./waf copter
```
error is due to "freertos/xtensa_api.h" shall be "xtensa_api.h" since it is deprecated 

compilation error that this file is not found at all : 
`#include "driver/periph_ctrl.h"`


compiler is from docker esp latest : 

```
esp32ulp-elf-ar --version
GNU ar (GNU Binutils) 2.38_20240113
Copyright (C) 2022 Free Software Foundation, Inc.
This program is free software; you may redistribute it under the terms of
the GNU General Public License version 3 or (at your option) any later version.
This program has absolutely no warranty.
```