### PR TITLE
hwdef: rename BATT_CURR_SCALE to BATT_AMP_PERVLT in board READMEs

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/3DRControlZeroG/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/3DRControlZeroG/README.md
@@ -113,7 +113,7 @@ This board has a built-in voltage and current sensors. The following settings ne
 - BATT_VOLT_PIN 14
 - BATT_CURR_PIN 15
 - BATT_VOLT_SCALE 15.3
-- BATT_CURR_SCALE 50.0
+- BATT_AMP_PERVLT 50.0
 
 *Other Power Module needs to be adjusted accordingly*
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ACNS-CM4Pilot/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ACNS-CM4Pilot/README.md
@@ -75,7 +75,7 @@ The correct battery setting parameters are set by default and are:
  - BATT_VOLT_PIN 11
  - BATT_CURR_PIN 12
  - BATT_VOLT_SCALE 10.1
- - BATT_CURR_SCALE 17.0
+ - BATT_AMP_PERVLT 17.0
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ACNS-F405AIO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ACNS-F405AIO/README.md
@@ -61,7 +61,7 @@ The correct battery setting parameters are set by default and are:
  - BATT_VOLT_PIN 11
  - BATT_CURR_PIN 12
  - BATT_VOLT_SCALE 9.2
- - BATT_CURR_SCALE 50.0
+ - BATT_AMP_PERVLT 50.0
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/AET-H743-Basic/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/AET-H743-Basic/README.md
@@ -110,7 +110,7 @@ The first voltage/current sensor is enabled by default and the pin inputs for th
 * BATT_VOLT_PIN 10
 * BATT_CURR_PIN 11
 * BATT_VOLT_MULT 11
-* BATT_CURR_SCALE 40
+* BATT_AMP_PERVLT 40
 * BATT2_VOLT_PIN 18
 * BATT2_CURR_PIN 7
 * BATT2_VOLT_MULT 11

--- a/libraries/AP_HAL_ChibiOS/hwdef/ARK_FPV/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ARK_FPV/README.md
@@ -193,7 +193,7 @@ The default battery parameters are:
 - BATT_VOLT_PIN 9
 - BATT_CURR_PIN 12
 - BATT_VOLT_SCALE 21
-- BATT_CURR_SCALE 120
+- BATT_AMP_PERVLT 120
 
 ## Compass
 This autopilot has a built-in compass. The compass is the IIS2MDC

--- a/libraries/AP_HAL_ChibiOS/hwdef/BROTHERHOBBYF405v3/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BROTHERHOBBYF405v3/README.md
@@ -81,7 +81,7 @@ The default battery parameters are:
  - :ref:BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog> = 10
  - :ref:BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog> = 11
  - :ref:BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog> = 11
- - :ref:BATT_CURR_SCALE<BATT_CURR_SCALE__AP_BattMonitor_Analog> = 25.9 (will need to be adjusted for whichever current sensor is attached)
+ - :ref:BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog> = 25.9 (will need to be adjusted for whichever current sensor is attached)
 
 ## RSSI
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/GEPRCF745BTHD/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/GEPRCF745BTHD/README.md
@@ -81,7 +81,7 @@ The default battery parameters are:
  - BATT_VOLT_PIN 13
  - BATT_VOLT_SCALE 11.0
  - BATT_CURR_PIN 12
- - BATT_CURR_SCALE 28.5
+ - BATT_AMP_PERVLT 28.5
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/GEPRC_TAKER_H743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/GEPRC_TAKER_H743/README.md
@@ -81,7 +81,7 @@ The default battery parameters are:
  - BATT_VOLT_PIN 13
  - BATT_VOLT_SCALE 11.1
  - BATT_CURR_PIN 12
- - BATT_CURR_SCALE 28.5
+ - BATT_AMP_PERVLT 28.5
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MFT-SEMA100/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MFT-SEMA100/README.md
@@ -90,7 +90,7 @@ The default battery parameters are:
  - BATT_VOLT_PIN 19
  - BATT_CURR_PIN 8
  - BATT_VOLT_MULT 10
- - BATT_CURR_SCALE 10
+ - BATT_AMP_PERVLT 10
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MicoAir405Mini/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MicoAir405Mini/README.md
@@ -72,7 +72,7 @@ The default battery parameters are:
  - BATT_VOLT_PIN 10
  - BATT_CURR_PIN 11
  - BATT_VOLT_MULT 21.2
- - BATT_CURR_SCALE 40.2
+ - BATT_AMP_PERVLT 40.2
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MicoAir405v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MicoAir405v2/README.md
@@ -69,7 +69,7 @@ The default battery parameters are:
  - BATT_VOLT_PIN 10
  - BATT_CURR_PIN 11
  - BATT_VOLT_MULT 21.2
- - BATT_CURR_SCALE 40.2
+ - BATT_AMP_PERVLT 40.2
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743-AIO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743-AIO/README.md
@@ -67,7 +67,7 @@ The default battery parameters are:
  - BATT_VOLT_PIN 10
  - BATT_CURR_PIN 11
  - BATT_VOLT_MULT 21.2
- - BATT_CURR_SCALE 14.14
+ - BATT_AMP_PERVLT 14.14
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743/README.md
@@ -75,7 +75,7 @@ The default battery parameters are:
  - BATT_VOLT_PIN 10
  - BATT_CURR_PIN 11
  - BATT_VOLT_MULT 21.2
- - BATT_CURR_SCALE 40.2
+ - BATT_AMP_PERVLT 40.2
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743v2/README.md
@@ -89,7 +89,7 @@ The default battery parameters are:
  - BATT_VOLT_PIN 10
  - BATT_CURR_PIN 11
  - BATT_VOLT_MULT 21.12
- - BATT_CURR_SCALE 40.2
+ - BATT_AMP_PERVLT 40.2
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/NxtPX4v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/NxtPX4v2/README.md
@@ -57,7 +57,7 @@ The default battery parameters are:
  - BATT_VOLT_PIN 4
  - BATT_CURR_PIN 8
  - BATT_VOLT_MULT 10.2
- - BATT_CURR_SCALE 20.4
+ - BATT_AMP_PERVLT 20.4
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/X-MAV-AP-H743v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/X-MAV-AP-H743v2/README.md
@@ -77,7 +77,7 @@ The default battery parameters are:
  - BATT_VOLT_PIN 4
  - BATT_CURR_PIN 8
  - BATT_VOLT_MULT 10.2
- - BATT_CURR_SCALE 20.4
+ - BATT_AMP_PERVLT 20.4
 
 ## Compass
 


### PR DESCRIPTION
the hwdef define and param name are not the same (probably should be), so coders assume its the param name in the readmes...