### PR TITLE
Plane:prevent using STAB_PITCH_DOWN during landings

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -624,7 +624,9 @@ void Plane::calc_nav_roll()
 void Plane::adjust_nav_pitch_throttle(void)
 {
     int8_t throttle = throttle_percentage();
-    if (throttle >= 0 && throttle < aparm.throttle_cruise && flight_stage != AP_FixedWing::FlightStage::VTOL) {
+    uint16_t mission_id = mission.get_current_nav_cmd().id;
+    if (throttle >= 0 && throttle < aparm.throttle_cruise && flight_stage != AP_FixedWing::FlightStage::VTOL && 
+        !(is_landing() || is_land_command(mission_id))) {
         float p = (aparm.throttle_cruise - throttle) / (float)aparm.throttle_cruise;
         nav_pitch_cd -= g.stab_pitch_down * 100.0f * p;
     }


### PR DESCRIPTION
Obviously an error IMO....when TECS cuts throttle in flare, if you have a high (>5deg) STAB_PITCH_DOWN the nose is instantly forced down....for agile frames this crashes the vehicle almost immediately....STAB_PITCH_DOWN is supposed to be used in FBWA/STABILIZE/ACRO modes to prevent stalls in hands-off glides, not in flares..and is typically small, but my stubby wing needs 6 deg to prevent stalls while gliding...

 noticed this on my small penguin twin when I started doing autolands......especially without Rangefinder...new commits for autolands with rangefinders patches over this somewhat  as it fixed another issue, but not enough to prevent short landings, just the semicrashes

will test this week with and without RF 