### PR TITLE
.github: downgrade pydantic for ESP-IDF install

### DIFF
--- a/.github/workflows/esp32_build.yml
+++ b/.github/workflows/esp32_build.yml
@@ -179,26 +179,11 @@ jobs:
           python3 --version
           python3 -m pip install gevent
 
-          # we actualy want 3.11 .. but the above only gave us 3.10, not ok with esp32 builds.
-          sudo add-apt-repository ppa:deadsnakes/ppa
-          sudo apt-get update
-          sudo apt-get install python3.11 python3.11-venv python3.11-distutils  -y
-          sudo apt-get install python3 python3-pip python3-venv python3-setuptools python3-serial python3-cryptography python3-future python3-pyparsing python3-pyelftools
-          python3 -m pip install gevent
-          python3 --version
-          python3.11 --version
-          which python3.11
-
           git submodule update --init --recursive --depth=1
           ./Tools/scripts/esp32_get_idf.sh
 
           sudo ln -s /usr/bin/ninja /usr/bin/ninja-build
 
-          cd modules/esp_idf
-          echo "Installing ESP-IDF tools...."
-          ./install.sh esp32,esp32s3 
-          cd ../..
-          
           
       - name: build ${{matrix.config}}
         env:
@@ -209,8 +194,9 @@ jobs:
           PATH="/github/home/.local/bin:$PATH"
           echo $PATH
           echo "### Configure ${{matrix.config}} :rocket:" >> $GITHUB_STEP_SUMMARY
+          echo "Installing ESP-IDF tools...."
           cd modules/esp_idf
-          ./install.sh
+          ./install.sh esp32,esp32s3
           source ./export.sh
           cd ../..
           python3 -m pip install --progress-bar off future lxml pymavlink MAVProxy pexpect flake8 geocoder empy==3.3.4 dronecan "pydantic<2.12"

--- a/.github/workflows/esp32_build.yml
+++ b/.github/workflows/esp32_build.yml
@@ -213,7 +213,7 @@ jobs:
           ./install.sh
           source ./export.sh
           cd ../..
-          python3 -m pip install --progress-bar off future lxml pymavlink MAVProxy pexpect flake8 geocoder empy==3.3.4 dronecan
+          python3 -m pip install --progress-bar off future lxml pymavlink MAVProxy pexpect flake8 geocoder empy==3.3.4 dronecan "pydantic<2.12"
           which cmake
           ./waf configure --board ${{matrix.config}} 
           echo './waf configure --board ${{matrix.config}}' >> $GITHUB_STEP_SUMMARY  


### PR DESCRIPTION
A recent change has broken ESP-IDF. Downgrade until upstream fixes.

Also smooths the installation a little bit by removing redundant steps.