### PR TITLE
AP_Periph: allow servo output to be disabled via SRV_ENABLED

### DIFF
--- a/Tools/AP_Periph/Parameters.cpp
+++ b/Tools/AP_Periph/Parameters.cpp
@@ -73,6 +73,10 @@ extern const AP_HAL::HAL &hal;
 #define AP_PERIPH_PROBE_CONTINUOUS 0
 #endif
 
+#ifndef AP_PERIPH_SERVO_ENABLED_DEFAULT
+#define AP_PERIPH_SERVO_ENABLED_DEFAULT 1
+#endif
+
 /*
  *  AP_Periph parameter definitions
  *
@@ -431,6 +435,13 @@ const AP_Param::Info AP_Periph_FW::var_info[] = {
     // @Units: ms
     // @User: Advanced
     GSCALAR(esc_command_timeout_ms, "ESC_CMD_TIMO",     200),
+
+    // @Param: SRV_ENABLED
+    // @DisplayName: Servos and ESCs enabled
+    // @Description: This allows the servo and ESC outputs to be disabled
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+    GSCALAR(servo_enabled, "SRV_ENABLED", AP_PERIPH_SERVO_ENABLED_DEFAULT),
 
 #if HAL_WITH_ESC_TELEM && !HAL_GCS_ENABLED
     // @Param: ESC_TELEM_PORT

--- a/Tools/AP_Periph/Parameters.h
+++ b/Tools/AP_Periph/Parameters.h
@@ -103,6 +103,7 @@ public:
         k_param__gcs,
         k_param_battery_tag,
         k_param_servo_command_timeout_ms,
+        k_param_servo_enabled,
     };
 
     AP_Int16 format_version;
@@ -185,6 +186,8 @@ public:
     AP_Int16 esc_rate;
     AP_Int8 esc_pwm_type;
     AP_Int16 esc_command_timeout_ms;
+    AP_Int8 servo_enabled;
+
 #if HAL_WITH_ESC_TELEM && !HAL_GCS_ENABLED
     AP_Int8 esc_telem_port;
 #endif

--- a/Tools/AP_Periph/rc_out.cpp
+++ b/Tools/AP_Periph/rc_out.cpp
@@ -154,6 +154,10 @@ void AP_Periph_FW::rcout_handle_safety_state(uint8_t safety_state)
 
 void AP_Periph_FW::rcout_update()
 {
+    if (!g.servo_enabled) {
+        return;
+    }
+
     uint32_t now_ms = AP_HAL::millis();
 
     // Timeout for ESC commands


### PR DESCRIPTION
If rcout support is compiled in (as is on a lot of sensors) they thread is busy doing a lot of stuff even if none of the outputs are used. This allows all the busy work to be bypassed via a parameter.