### PR TITLE
AP_Periph: allow continuous update to work with airspeed sensors

### DIFF
--- a/Tools/AP_Periph/airspeed.cpp
+++ b/Tools/AP_Periph/airspeed.cpp
@@ -12,6 +12,8 @@
 #define AP_PERIPH_PROBE_CONTINUOUS 0
 #endif
 
+extern const AP_HAL::HAL &hal;
+
 /*
   update CAN airspeed
  */


### PR DESCRIPTION
This fixes a compilation error if AP_PERIPH_PROBE_CONTINUOUS is defined