### PR TITLE
Tools: add --configure-if-required command-line option

### DIFF
--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -414,6 +414,7 @@ def run_step(step):
         "debug": opts.debug,
         "clean": not opts.no_clean,
         "configure": not opts.no_configure,
+        "configure_if_required": opts.configure_if_required,
         "math_check_indexes": opts.math_check_indexes,
         "ekf_single": opts.ekf_single,
         "postype_single": opts.postype_single,
@@ -910,6 +911,11 @@ if __name__ == "__main__":
                            action='store_true',
                            help='do not configure before building',
                            dest="no_configure")
+    group_build.add_option("--configure-if-required",
+                           default=False,
+                           action='store_true',
+                           help='configure before building only if required',
+                           dest="configure_if_required")
     group_build.add_option("", "--waf-configure-args",
                            action="append",
                            dest="waf_configure_args",

--- a/Tools/autotest/pysim/util.py
+++ b/Tools/autotest/pysim/util.py
@@ -5,6 +5,7 @@ AP_FLAKE8_CLEAN
 import atexit
 import math
 import os
+import pathlib
 import re
 import shlex
 import signal
@@ -146,6 +147,7 @@ def build_SITL(
         board='sitl',
         clean=True,
         configure=True,
+        configure_if_required=False,
         coverage=False,
         debug=False,
         ekf_single=False,
@@ -162,6 +164,12 @@ def build_SITL(
 ):
 
     # first configure
+    if configure_if_required:
+        # we simply base this off whether the expected target directory exists
+        p = pathlib.Path(topdir(), "build", board)
+        if p.exists():
+            configure = False
+
     if configure:
         waf_configure(board,
                       j=j,


### PR DESCRIPTION
this adds an alternative to `--no-configure` to autotest.

Adding `--no-configure --no-clean` to autotest.py's command-line makes iteration *much* faster but means that if you blow away your simulation directory then you get a compilation failure when doing (e.g.) `build.Rover` as there's now no longer a build configured for the build step to execute on.

This PR adds a very rough implementation of `--configure-if-required` to the command-line which just checks for the presence of the configured-build-directory to work out whether to run the configure step or not.  If the directory doesn't exist it configures the build, if the directory does exist it doesn't configure the build meaning the build is *much* faster.
