### PR TITLE
AP_RagneFinder: add signal quality of JRE Serial

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_JRE_Serial.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_JRE_Serial.h
@@ -84,7 +84,7 @@ protected:
 
     int8_t get_signal_quality_pct() const override
     {
-        return no_signal ? RangeFinder::SIGNAL_QUALITY_MIN : RangeFinder::SIGNAL_QUALITY_MAX;
+        return no_signal ? RangeFinder::SIGNAL_QUALITY_MIN : signal_quality_pct;
     }
 
 private:
@@ -98,5 +98,7 @@ private:
     uint8_t data_buff_ofs;      // index where next item will be added in data_buff
 
     bool no_signal;     // true if the latest read attempt found no valid distances
+
+    int8_t signal_quality_pct;
 };
 #endif  // AP_RANGEFINDER_JRE_SERIAL_ENABLED


### PR DESCRIPTION
This adds support for signal quality data of the JAE-30 radar.

I tested this and confirmed that the signal quality changes depending on the detected object's material and distance.