### PR TITLE
Tools: extract_features.py: correct extraction symbol for AP_Vehicle …

### DIFF
--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -327,7 +327,7 @@ class ExtractFeatures(object):
             ('AP_PERIPH_RPM_ENABLED', r'AP_Periph_FW::rpm_sensor_send'),
             ('AP_PERIPH_AIRSPEED_ENABLED', r'AP_Periph_FW::can_airspeed_update'),
 
-            ('AP_SCRIPTING_BINDING_VEHICLE_ENABLED', 'AP__vehicle___index'),
+            ('AP_SCRIPTING_BINDING_VEHICLE_ENABLED', 'AP_Vehicle_index'),
             ('AP_SCRIPTING_BINDING_MOTORS_ENABLED', 'AP__motors___index'),
         ]
 


### PR DESCRIPTION
…Lua bindings

custom build server showed this as not set on CubeOrange when the feature is in there.
