### PR TITLE
GCS_MAVLink: Check altitude sent in SET_GPS_GLOBAL_ORIGIN

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3923,6 +3923,11 @@ void GCS_MAVLINK::handle_set_gps_global_origin(const mavlink_message_t &msg)
         // silently drop the request
         return;
     }
+    // sanity check altitude in mm, note that abs can't handle INT32_MIN correctly
+    if (packet.altitude < -LOCATION_ALT_MAX_M * 1000 || packet.altitude > LOCATION_ALT_MAX_M * 1000) {
+        // silently drop the request
+        return;
+    }
 
     const Location ekf_origin {
         packet.latitude,


### PR DESCRIPTION
This prevents a floating point exception crash if a very negative value is accepted by EKF3. 

If a `qNaN` float is cast to `int32_t` in the message, it produces 0x80000000 (`INT32_MIN`) which goes through all stages correctly, but causes an error later. Unfortunately I can't get the stack trace, so only fix I could find was to check the magnitude when receiving the message, like the MAV_CMD_DO_SET_GLOBAL_ORIGIN does.

While a GCS shouldn't send invalid values, I feel like ArduPilot shouldn't crash because of them either.

<details><summary>SITL process output</summary>
<pre><code>Setting SIM_SPEEDUP=1.000000
Home: 52.226028 20.929549 alt=115.000000m hdg=253.000000
Starting sketch 'ArduPlane'
Starting SITL input
Using Irlock at port : 9005
bind port 5760 for SERIAL0
SERIAL0 on TCP port 5760
Waiting for connection ....
Connection on serial port 5760
Loaded defaults from ../Tools/autotest/models/plane.parm
bind port 5762 for SERIAL1
SERIAL1 on TCP port 5762
bind port 5763 for SERIAL2
SERIAL2 on TCP port 5763
Smoothing reset at 0.001
validate_structures:528: Validating structures
Waiting for internal clock bits to be set (current=0x00)
Loaded defaults from ../Tools/autotest/models/plane.parm
ERROR: Floating point exception - aborting
Running: sh ../Tools/scripts/dumpstack.sh 24023 >dumpstack.sh_arduplane.24023.out 2>&1
dumpstack.sh has been run.  Output was:
-------------- begin dumpstack.sh output ----------------
Could not attach to process.  If your uid matches the uid of the target
process, check the setting of /proc/sys/kernel/yama/ptrace_scope, or try
again as the root user.  For more details, see /etc/sysctl.d/10-ptrace.conf
ptrace: Inappropriate ioctl for device.
/tmp/gdb.24036:2: Error in sourced command file:
No stack.
-------------- end dumpstack.sh output ----------------
Running: sh ../Tools/scripts/dumpcore.sh 24023 >dumpcore.sh_arduplane.24023.out 2>&1
dumpcore.sh has been run.  Output was:
-------------- begin dumpcore.sh output ----------------
Could not attach to process.  If your uid matches the uid of the target
process, check the setting of /proc/sys/kernel/yama/ptrace_scope, or try
again as the root user.  For more details, see /etc/sysctl.d/10-ptrace.conf
ptrace: Inappropriate ioctl for device.
/tmp/gdb.24074:2: Error in sourced command file:
You can't do that without a process to debug.
-------------- end dumpcore.sh output ----------------
</code></pre>
</details> 

---

It seems to me that definition of `LOCATION_ALT_MAX_M` makes sense for a 24 bit value, but currently the type used is `int32_t`. Maybe a change to a narrower, geographically meaningful range would help catch more spurious data? For example, instead of ±83km, check between -11km and 100km.

---

*(Contribution on behalf of @FlyfocusUAV)*