### PR TITLE
Tools: siyi image download supports 9999 files

### DIFF
--- a/Tools/cameras_gimbals/siyi-download/siyi-download.py
+++ b/Tools/cameras_gimbals/siyi-download/siyi-download.py
@@ -45,7 +45,7 @@ def get_filelist_url(ip_address, media_type, dir_path):
         'media_type': str(media_type),
         'path': dir_path,
         'start': 0,
-        'count': 999
+        'count': 9999
     }
     return f"http://{ip_address}:82/cgi-bin/media.cgi/api/v1/getmedialist?" + urlencode(params)
 


### PR DESCRIPTION
This increases the maximum number of images that the Siyi download python script can download to 9999 (was 999).  The maximum number is a bit arbitrary and I found during preps for the Japan Innovation Challenge that 999 files is not quite enough for very long flights.

This has been tested on a real vehicle