### PR TITLE
AP_Scripting: regenerate MAVLink message definitions

### DIFF
--- a/libraries/AP_Scripting/modules/MAVLink/Readme.md
+++ b/libraries/AP_Scripting/modules/MAVLink/Readme.md
@@ -2,7 +2,7 @@ These .lua definition for messages can be generated using pymavlink with the fol
 (change the last path accordingly to place the files where you need them)
 ```
 cd ardupilot/modules/mavlink
-python ./pymavlink/tools/mavgen.py --lang Lua ./message_definitions/v1.0/all.xml --out ./modules/MAVLink
+python ./pymavlink/tools/mavgen.py --lang Lua ./message_definitions/v1.0/all.xml --out ./modules/MAVLink --wire-protocol 2.0
 ```
 
 Add `--wire-protocol 2.0` to include extension fields in the generated code

--- a/libraries/AP_Scripting/modules/MAVLink/mavlink_msg_COMMAND_ACK.lua
+++ b/libraries/AP_Scripting/modules/MAVLink/mavlink_msg_COMMAND_ACK.lua
@@ -1,5 +1,6 @@
 local COMMAND_ACK = {}
 COMMAND_ACK.id = 77
+COMMAND_ACK.crc_extra = 143
 COMMAND_ACK.fields = {
              { "command", "<I2" },
              { "result", "<B" },

--- a/libraries/AP_Scripting/modules/MAVLink/mavlink_msg_FOLLOW_TARGET.lua
+++ b/libraries/AP_Scripting/modules/MAVLink/mavlink_msg_FOLLOW_TARGET.lua
@@ -1,5 +1,6 @@
 local FOLLOW_TARGET = {}
 FOLLOW_TARGET.id = 144
+FOLLOW_TARGET.crc_extra = 127
 FOLLOW_TARGET.fields = {
              { "timestamp", "<I8" },
              { "custom_state", "<I8" },

--- a/libraries/AP_Scripting/modules/MAVLink/mavlink_msg_GLOBAL_POSITION_INT.lua
+++ b/libraries/AP_Scripting/modules/MAVLink/mavlink_msg_GLOBAL_POSITION_INT.lua
@@ -1,5 +1,6 @@
 local GLOBAL_POSITION_INT = {}
 GLOBAL_POSITION_INT.id = 33
+GLOBAL_POSITION_INT.crc_extra = 104
 GLOBAL_POSITION_INT.fields = {
              { "time_boot_ms", "<I4" },
              { "lat", "<i4" },

--- a/libraries/AP_Scripting/modules/MAVLink/mavlink_msg_HEARTBEAT.lua
+++ b/libraries/AP_Scripting/modules/MAVLink/mavlink_msg_HEARTBEAT.lua
@@ -1,5 +1,6 @@
 local HEARTBEAT = {}
 HEARTBEAT.id = 0
+HEARTBEAT.crc_extra = 50
 HEARTBEAT.fields = {
              { "custom_mode", "<I4" },
              { "type", "<B" },

--- a/libraries/AP_Scripting/modules/MAVLink/mavlink_msg_SERIAL_CONTROL.lua
+++ b/libraries/AP_Scripting/modules/MAVLink/mavlink_msg_SERIAL_CONTROL.lua
@@ -1,5 +1,6 @@
 local SERIAL_CONTROL = {}
 SERIAL_CONTROL.id = 126
+SERIAL_CONTROL.crc_extra = 220
 SERIAL_CONTROL.fields = {
              { "baudrate", "<I4" },
              { "timeout", "<I2" },


### PR DESCRIPTION
fixes https://github.com/ArduPilot/ardupilot/issues/31267

In retrospect allowing messages which fail the CRC in https://github.com/ArduPilot/ardupilot/pull/28248 for those using existing scripts was a mistake. I'm not really sure what we can do about that now its been in tree for a year.

This updates our in-tree message definitions to include the CRC so the lua parser will check the CRC automatically. Note that this does mean the lua parser may return nil which the script using it will have to deal with correctly.