### PR TITLE
Automatic serial baudrate in Lua scripts

### DIFF
--- a/libraries/AP_Scripting/AP_Scripting_SerialAccess.cpp
+++ b/libraries/AP_Scripting/AP_Scripting_SerialAccess.cpp
@@ -24,6 +24,13 @@ void AP_Scripting_SerialAccess::begin(uint32_t baud)
     }
 }
 
+void AP_Scripting_SerialAccess::begin()
+{
+    if (!check_is_device_port()) {
+        stream->begin(stream->get_baud_rate());
+    }
+}
+
 void AP_Scripting_SerialAccess::configure_parity(uint8_t parity) {
     if (!check_is_device_port()) {
         stream->configure_parity(parity);

--- a/libraries/AP_Scripting/AP_Scripting_SerialAccess.h
+++ b/libraries/AP_Scripting/AP_Scripting_SerialAccess.h
@@ -13,6 +13,7 @@ public:
     AP_Scripting_SerialAccess() {}
 
     void begin(uint32_t baud);
+    void begin();
 
     void configure_parity(uint8_t parity);
     void set_stop_bits(uint8_t stop_bits);

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1303,7 +1303,7 @@ local AP_Scripting_SerialAccess_ud = {}
 function AP_Scripting_SerialAccess_ud:set_unbuffered_writes(on) end
 
 -- Start serial port with the given baud rate (no effect for device ports)
----@param baud_rate uint32_t_ud|integer|number
+---@param baud_rate? uint32_t_ud|integer|number|nil baud rate, parameter-derived value used if nil or omitted
 function AP_Scripting_SerialAccess_ud:begin(baud_rate) end
 
 -- Set UART parity (no effect for device ports)

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -438,7 +438,7 @@ singleton RC_Channels method get_aux_cached boolean RC_Channel::AUX_FUNC'enum 0 
 include AP_Scripting/AP_Scripting_SerialAccess.h
 -- don't let user create access objects
 userdata AP_Scripting_SerialAccess creation null -1
-userdata AP_Scripting_SerialAccess method begin void uint32_t 1U UINT32_MAX
+userdata AP_Scripting_SerialAccess manual begin lua_serial_begin 1 0
 userdata AP_Scripting_SerialAccess method configure_parity void uint8_t 0 2
 userdata AP_Scripting_SerialAccess method set_stop_bits void uint8_t 1 2
 userdata AP_Scripting_SerialAccess method write uint32_t uint8_t'skip_check

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -853,6 +853,25 @@ int lua_serial_readstring(lua_State *L) {
     return 1;
 }
 
+int lua_serial_begin(lua_State *L) {
+    const int args = lua_gettop(L);
+    if (args > 2) {
+        return luaL_argerror(L, args, "too many arguments");
+    } else if (args < 1) {
+        return luaL_argerror(L, args, "too few arguments");
+    }
+    AP_Scripting_SerialAccess * port = check_AP_Scripting_SerialAccess(L, 1);
+
+    // nil or absent argument treated as automatic baud
+    if (!lua_isnoneornil(L, 2)) {
+        port->begin(get_uint32(L, 2, 1, UINT32_MAX));
+    } else {
+        port->begin();
+    }
+
+    return 0;
+}
+
 /*
   directory listing, return table of files in a directory
  */

--- a/libraries/AP_Scripting/lua_bindings.h
+++ b/libraries/AP_Scripting/lua_bindings.h
@@ -15,6 +15,7 @@ int lua_serial_find_serial(lua_State *L);
 int lua_serial_find_simulated_device(lua_State *L);
 int lua_serial_writestring(lua_State *L);
 int lua_serial_readstring(lua_State *L);
+int lua_serial_begin(lua_State *L);
 int lua_dirlist(lua_State *L);
 int lua_removefile(lua_State *L);
 int SRV_Channels_get_safety_state(lua_State *L);


### PR DESCRIPTION
Allows the scripts to work with serial ports without hardcoding the baudrate as in:
```
local port = serial:find_serial(0)
port:begin()
```

The actual baud rate comes from the HAL which in turn would return what the parameters say for the port or whichever value the particular derived `UARTDriver` class deems necessary.

~~The generator changes allow `binding_argcheck` to do a variable number of parameter checks e.g. "from 1 to 3".~~

~~The REPL change is to illustrate how it works.~~ I initially wanted to add some plumbing for the scripts to be able to infer what serial instance they are given (e.g. for printing the banner the way REPL does), but it's turned out to be a huge can of worms with all the "registered" networking serial drivers as well as the virtual scripting ones. If the reviewer seems merit in this I can still add something like this, but we'll probably need a short discusson on how to name/enumerate networking ports.
