### PR TITLE
AP_GPS: only send GPS raw if GPS is enabled

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1372,6 +1372,11 @@ uint16_t AP_GPS::gps_yaw_cdeg(uint8_t instance) const
 #if AP_GPS_GPS_RAW_INT_SENDING_ENABLED
 void AP_GPS::send_mavlink_gps_raw(mavlink_channel_t chan)
 {
+    // Only send if enabled
+    if (get_type(0) == GPS_TYPE_NONE) {
+        return;
+    }
+
     const Location &loc = location(0);
     float hacc = 0.0f;
     float vacc = 0.0f;


### PR DESCRIPTION
Currently we will send the GPS RAW message even if GPS 1 is set to none.