### PR TITLE
Motortest error rate

### DIFF
--- a/ArduCopter/motor_test.cpp
+++ b/ArduCopter/motor_test.cpp
@@ -10,6 +10,9 @@
 
 static uint32_t motor_test_start_ms;        // system time the motor test began
 static uint32_t motor_test_timeout_ms;      // test will timeout this many milliseconds after the motor_test_start_ms
+#if HAL_WITH_ESC_TELEM
+static uint32_t last_motor_message_ms;      // last time we output a message about poor error rates
+#endif
 static uint8_t motor_test_seq;              // motor sequence number of motor being tested
 static uint8_t motor_test_count;            // number of motors to test
 static uint8_t motor_test_throttle_type;    // motor throttle type (0=throttle percentage, 1=PWM, 2=pilot throttle channel pass-through)
@@ -92,6 +95,15 @@ void Copter::motor_test_output()
             gcs().send_text(MAV_SEVERITY_INFO, "Motor Test: cancelled");
             motor_test_stop();
         }
+#if HAL_WITH_ESC_TELEM
+        float rpm, error_rate;
+        if (AP::esc_telem().get_raw_rpm_and_error_rate(motor_test_seq, rpm, error_rate)
+            && error_rate > 1.0f
+            && now - last_motor_message_ms > 1000) {
+            gcs().send_text(MAV_SEVERITY_WARNING,"Motor Test: error rate %f for motor %u at %f rpm", error_rate, motor_test_seq, rpm);
+            last_motor_message_ms = now;
+        }
+#endif
     }
 }
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -2010,6 +2010,30 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.context_pop()
         self.reboot_sitl()
 
+    def test_takeoff_check_mode(self, mode, user_takeoff=False):
+        # stabilize check
+        self.progress("Motor takeoff check in %s" % mode)
+        self.change_mode(mode)
+        self.zero_throttle()
+        self.wait_ready_to_arm()
+        self.context_push()
+        self.context_collect('STATUSTEXT')
+        self.arm_vehicle()
+        if user_takeoff:
+            self.run_cmd(
+                mavutil.mavlink.MAV_CMD_NAV_TAKEOFF,
+                p7=10,
+            )
+        else:
+            self.set_rc(3, 1700)
+        # we may never see ourselves as armed in a heartbeat
+        self.wait_statustext("Takeoff blocked: ESC RPM or errors out of range", check_context=True)
+        self.context_pop()
+        self.zero_throttle()
+        self.disarm_vehicle()
+        self.wait_disarmed()
+
+
     # Tests the motor failsafe
     def TakeoffCheck(self):
         '''Test takeoff check'''

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp
@@ -145,7 +145,7 @@ uint8_t AP_ESC_Telem::get_num_active_escs() const {
 }
 
 // return the whether all the motors in servo_channel_mask are running
-bool AP_ESC_Telem::are_motors_running(uint32_t servo_channel_mask, float min_rpm, float max_rpm) const
+bool AP_ESC_Telem::are_motors_running(uint32_t servo_channel_mask, float min_rpm, float max_rpm, float max_error_rate) const
 {
 
     for (uint8_t i = 0; i < ESC_TELEM_MAX_ESCS; i++) {
@@ -159,6 +159,9 @@ bool AP_ESC_Telem::are_motors_running(uint32_t servo_channel_mask, float min_rpm
                 return false;
             }
             if ((max_rpm > 0) && (rpmdata.rpm > max_rpm)) {
+                return false;
+            }
+            if (!is_zero(min_rpm) && !is_zero(max_error_rate) && rpmdata.error_rate > max_error_rate) {
                 return false;
             }
         }
@@ -224,6 +227,7 @@ bool AP_ESC_Telem::get_raw_rpm_and_error_rate(uint8_t esc_index, float& rpm, flo
 
     rpm = rpmdata.rpm;
     error_rate = rpmdata.error_rate;
+
     return true;
 }
 

--- a/libraries/AP_ESC_Telem/AP_ESC_Telem.h
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem.h
@@ -46,7 +46,7 @@ public:
     float get_average_motor_rpm() const { return get_average_motor_rpm(0xFFFFFFFF); }
 
     // determine whether all the motors in servo_channel_mask are running
-    bool are_motors_running(uint32_t servo_channel_mask, float min_rpm, float max_rpm) const;
+    bool are_motors_running(uint32_t servo_channel_mask, float min_rpm, float max_rpm, float max_error_rate) const;
 
     // get an individual ESC's temperature in centi-degrees if available, returns true on success
     bool get_temperature(uint8_t esc_index, int16_t& temp) const;

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -1188,7 +1188,7 @@ bool AP_Vehicle::motors_takeoff_check(float rpm_min, float rpm_max)
     // check ESCs are sending RPM at expected level
     uint32_t motor_mask = motors->get_motor_mask();
     const bool telem_active = AP::esc_telem().is_telemetry_active(motor_mask);
-    const bool rpm_adequate = AP::esc_telem().are_motors_running(motor_mask, rpm_min, rpm_max);
+    const bool rpm_adequate = AP::esc_telem().are_motors_running(motor_mask, rpm_min, rpm_max, 1.0f);
 
     // if RPM is at the expected level clear block
     if (telem_active && rpm_adequate) {
@@ -1202,7 +1202,7 @@ bool AP_Vehicle::motors_takeoff_check(float rpm_min, float rpm_max)
         if (!telem_active) {
             gcs().send_text(MAV_SEVERITY_CRITICAL, "%s waiting for ESC RPM", prefix_str);
         } else if (!rpm_adequate) {
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "%s ESC RPM out of range", prefix_str);
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "%s ESC RPM or errors out of range", prefix_str);
         }
     }
     return false;


### PR DESCRIPTION
Prints out a GCS warning if the error rate is too high in a motor test.

Checks the motor error rate in the takeoff check if TKOFF_RPM_MIN is set

I have seen two cases now where having this would have helped - high error rate is indicative of impending motor failure + desyncs so quite an important safety feature