### PR TITLE
autotest: add timing margin to EKF deadreckoning state checks

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -2070,14 +2070,14 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
             self.set_parameter("AHRS_OPTIONS", 1)
             self.set_parameter("SIM_GPS1_JAM", 1)
-            self.delay_sim_time(10)
+            self.delay_sim_time(13)
             self.set_parameter("SIM_GPS1_JAM", 0)
             t_enabled = self.get_sim_time()
             # The EKF should wait for GPS checks to pass when we are still able to navigate using dead reckoning
             # to prevent bad GPS being used when coming back after loss of lock due to interence.
             # The EKF_STATUS_REPORT does not tell us when the good to align check passes, so the minimum time
             # value of 3.0 seconds is an arbitrary value set on inspection of dataflash logs from this test
-            self.wait_ekf_flags(mavutil.mavlink.ESTIMATOR_POS_HORIZ_ABS, 0, timeout=15)
+            self.wait_ekf_flags(mavutil.mavlink.ESTIMATOR_POS_HORIZ_ABS, 0, timeout=20)
             time_since_jamming_stopped = self.get_sim_time() - t_enabled
             if time_since_jamming_stopped < 3:
                 raise NotAchievedException("GPS use re-started %f sec after jamming stopped" % time_since_jamming_stopped)


### PR DESCRIPTION
The EKF takes almost exactly 10 (simulated) seconds to deassert flag 16 (POS_HORIZ_ABS) after jamming starts, then 15 to reassert it after it stops. The test timings leave basically no margin for error and recently the flag is sometimes asserted a few hundred milliseconds late according to the test suite.

Fix by increasing the allowed times arbitrarily by 30%, assuming there is no need for such exact timing. Though the deassertion has not been seen to fail yet, also give it some more margin to avoid a future failure. Checked that the 10 second deassertion and 15 second reassertion still hold. Confirmed also that the timings are the same in 4.6, suggesting an actual regression is unlikely.