### PR TITLE
AP_HAL_ESP32: Change the GPIO pin description for SERIAL3

### DIFF
--- a/libraries/AP_HAL_ESP32/hwdef/esp32s3m5stampfly/hwdef.dat
+++ b/libraries/AP_HAL_ESP32/hwdef/esp32s3m5stampfly/hwdef.dat
@@ -15,7 +15,7 @@
 #
 # Grove Black (SERIAL3)
 # 1 (toward rear) : GPIO_NUM_1, RX
-# 2               : GPIO_NUM_3, TX
+# 2               : GPIO_NUM_2, TX
 # 3               : +V (+5V if plugged into USB, else +Vbat)
 # 4 (toward front): GND
 


### PR DESCRIPTION
The GPIO in the description of SERIAL3 is different from the one defined.
I will update the description to match the definition.

https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ESP32/hwdef/esp32s3m5stampfly/hwdef.dat#L51