### PR TITLE
[WIP] support MAV_FRAME_BODY_FRD in set_position_target_local_ned

### DIFF
--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -1042,7 +1042,8 @@ void GCS_MAVLINK_Copter::handle_message_set_position_target_local_ned(const mavl
     if (packet.coordinate_frame != MAV_FRAME_LOCAL_NED &&
         packet.coordinate_frame != MAV_FRAME_LOCAL_OFFSET_NED &&
         packet.coordinate_frame != MAV_FRAME_BODY_NED &&
-        packet.coordinate_frame != MAV_FRAME_BODY_OFFSET_NED) {
+        packet.coordinate_frame != MAV_FRAME_BODY_OFFSET_NED &&
+        packet.coordinate_frame != MAV_FRAME_BODY_FRD) {
         // input is not valid so stop
         copter.mode_guided.init(true);
         return;
@@ -1099,6 +1100,10 @@ void GCS_MAVLINK_Copter::handle_message_set_position_target_local_ned(const mavl
         // rotate to body-frame if necessary
         if (packet.coordinate_frame == MAV_FRAME_BODY_NED || packet.coordinate_frame == MAV_FRAME_BODY_OFFSET_NED) {
             vel_neu_ms.xy() = copter.ahrs.body_to_earth2D(vel_neu_ms.xy());
+        } else if (packet.coordinate_frame == MAV_FRAME_BODY_FRD) {
+            vel_neu_ms.z = -vel_neu_ms.z;
+            vel_neu_ms = AP::ahrs().get_rotation_body_to_ned() * vel_neu_ms;
+            vel_neu_ms.z = -vel_neu_ms.z;
         }
     }
 


### PR DESCRIPTION
test code and videos https://discuss.ardupilot.org/t/fast-3d-obstacles-avoidance/140037?u=chobitsfan

The purpose of this PR is to support fast obstacles avoidance. Because the stereo camera is usually fixed to the drone body, the safe direction returned by the obstacles avoidance algorithm is expressed in the body-fixed frame. Currently, ArduPilot treats the forward axis of MAV_FRAME_BODY_OFFSET_NED and MAV_FRAME_BODY_NED as aligned with the front of the vehicle in the horizontal plane. At higher speeds, a quadcopter tilts more significantly, making these differences non-negligible. While it is possible to request ArduPilot to send the current attitude and perform the coordinate system translation on the companion computer, this approach requires the current attitude to be sent at a high frequency.

WIP, only velocity is implemented and tested