### PR TITLE
AP_Math: tests: include <signal.h> on macOS for sigemptyset()

### DIFF
--- a/libraries/AP_Math/tests/test_control.cpp
+++ b/libraries/AP_Math/tests/test_control.cpp
@@ -6,6 +6,7 @@
 #include <AP_Math/control.h>
 
 #include <fenv.h>
+#include <signal.h>
 #include <setjmp.h>
 
 TEST(Control, test_control)


### PR DESCRIPTION
I had an error on Mac wile trying to build tests.
Compiling libraries/AP_Math/tests/test_math_double.cpp ../../libraries/AP_Math/tests/test_control.cpp:492:5: fatal error: use of undeclared identifier 'sigemptyset'
Probably it is common for Mac so I added signal.h

PR recreated because I failed with git in previous one.