### PR TITLE
AP_RangeFinder: remove unused <utility> include

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.cpp
@@ -25,8 +25,6 @@
 
 #if AP_RANGEFINDER_MAXSONARI2CXL_ENABLED
 
-#include <utility>
-
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/utility/sparse-endian.h>
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PulsedLightLRF.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PulsedLightLRF.cpp
@@ -16,7 +16,6 @@
 
 #if AP_RANGEFINDER_PULSEDLIGHTLRF_ENABLED
 
-#include <utility>
 #include <stdio.h>
 
 #include <AP_HAL/AP_HAL.h>

--- a/libraries/AP_RangeFinder/AP_RangeFinder_TeraRangerI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_TeraRangerI2C.cpp
@@ -19,7 +19,6 @@
 
 #if AP_RANGEFINDER_TRI2C_ENABLED
 
-#include <utility>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/crc.h>
 


### PR DESCRIPTION
this was for std::move - no longer used in these drivers