### PR TITLE
AP_Compass: Fix BMM350 temperature calculation

### DIFF
--- a/libraries/AP_Compass/AP_Compass_BMM350.cpp
+++ b/libraries/AP_Compass/AP_Compass_BMM350.cpp
@@ -452,13 +452,7 @@ void AP_Compass_BMM350::timer()
     float magx = (float)magx_raw * BMM350_XY_SCALE;
     float magy = (float)magy_raw * BMM350_XY_SCALE;
     float magz = (float)magz_raw * BMM350_Z_SCALE;
-    float temp = (float)temp_raw * BMM350_TEMP_SCALE;
-
-    if (temp > 0.0f) {
-        temp -= 25.49f;
-    } else if (temp < 0.0f) {
-        temp += 25.49f;
-    }
+    float temp = ((float)temp_raw * BMM350_TEMP_SCALE) - 25.49f;
 
     // Apply compensation
     temp = ((1 + _mag_comp.sensit_coef.temp) * temp) + _mag_comp.offset_coef.temp;


### PR DESCRIPTION
This fixed BMM350 mag value offset at low temperatures [problem](https://discuss.ardupilot.org/t/bmm350-offset-at-low-temperatures/138110).

Datasheet has no particular help about this. But bosch has confirmed this issue [here](https://community.bosch-sensortec.com/member/DOi03WF57Z).