### PR TITLE
RC_Channel: support big-endian GHST VTXFrame

### DIFF
--- a/libraries/AP_RCTelemetry/AP_GHST_Telem.h
+++ b/libraries/AP_RCTelemetry/AP_GHST_Telem.h
@@ -60,14 +60,18 @@ public:
     };
 
     struct PACKED VTXFrame {
-#if __BYTE_ORDER != __LITTLE_ENDIAN
-#error "Only supported on little-endian architectures"
-#endif
         uint8_t flags;
         uint16_t frequency;         // frequency in Mhz
         uint16_t power;              // power in mw, 0 == off
+#if __BYTE_ORDER == __LITTLE_ENDIAN
         uint8_t band : 4;               // A, B, E, AirWave, Race
         uint8_t channel : 4;            // 1x-8x
+#elif __BYTE_ORDER == __BIG_ENDIAN
+        uint8_t channel : 4;            // 1x-8x
+        uint8_t band : 4;               // A, B, E, AirWave, Race
+#else
+#error "Unsupported-endian architecture"
+#endif
         uint8_t spare[3];
     };
 


### PR DESCRIPTION
Part of a series of small patches to support compiling for big-endian controllers . This was tested by walking a bit through a VTXFrame and decoding the structure on the following platforms, then diffing the results.

* gcc 14.2.0 for ppc64
* gcc-12 (Debian 12.4.0-5) 12.4.0 for amd64