### PR TITLE
AP_Notify: stop using ownptr in LP5562 driver

### DIFF
--- a/libraries/AP_Notify/LP5562.h
+++ b/libraries/AP_Notify/LP5562.h
@@ -35,7 +35,10 @@ protected:
     bool hw_set_rgb(uint8_t r, uint8_t g, uint8_t b) override;
 
 private:
-    AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev;
+
+    bool configure_dev();
+
+    AP_HAL::I2CDevice *_dev;
     uint8_t _bus;
     uint8_t _addr;
 


### PR DESCRIPTION
More stop-using-ownptr stuff.

Saves 16 bytes.

Tested in SITL.

Broke out a `configure_dev()` so we can tidy the cleanup a little bit.
