### PR TITLE
RC_Channel: rename aux fn for gripper

### DIFF
--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -126,7 +126,7 @@ const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Values{Copter, Rover, Plane}: 16:AUTO Mode
     // @Values{Copter}: 17:AUTOTUNE Mode
     // @Values{Copter, Blimp}: 18:LAND Mode
-    // @Values{Copter, Rover}: 19:Gripper Release
+    // @Values{Copter, Rover}: 19:Gripper
     // @Values{Copter}: 21:Parachute Enable
     // @Values{Copter, Plane}: 22:Parachute Release
     // @Values{Copter}: 23:Parachute 3pos


### PR DESCRIPTION
The original RCx_OPTION parameter description, "Gripper Release" led some users (and me actually) to think that "high" would release the gripper but actually "high" is grab.  "low" is release.  I think simply renaming the option to "Gripper" will naturally lead users to expect "low" is release and "high" is grab.

I haven't specifically tested rebuilding the parameter descriptions but surely it's OK