### PR TITLE
AP_RCProtocol: remove pointless initialisation of member variables

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol_Backend.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_Backend.cpp
@@ -35,10 +35,7 @@
 
 
 AP_RCProtocol_Backend::AP_RCProtocol_Backend(AP_RCProtocol &_frontend) :
-    frontend(_frontend),
-    rc_input_count(0),
-    last_rc_input_count(0),
-    _num_channels(0)
+    frontend(_frontend)
 {}
 
 bool AP_RCProtocol_Backend::new_input()


### PR DESCRIPTION
implicitly zero