### PR TITLE
SITL: update rangefinder API to use metres for packet_for_alt

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -10184,7 +10184,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.assert_sensor_state(rf_bit, present=True, enabled=True, healthy=True)
         m = self.assert_receive_message('DISTANCE_SENSOR', verbose=True)
         if abs(m.current_distance * 0.01 - alt) > 1:
-            raise NotAchievedException(f"Expected {alt}m range")
+            raise NotAchievedException(f"Expected {alt}m range got range={m.current_distance * 0.01}")
         self.assert_parameter_value("RNGFND1_MAX", m.max_distance * 0.01, epsilon=0.00001)
         self.assert_parameter_value("RNGFND1_MIN", m.min_distance * 0.01, epsilon=0.00001)
 

--- a/libraries/SITL/SIM_RF_Ainstein_LR_D1.cpp
+++ b/libraries/SITL/SIM_RF_Ainstein_LR_D1.cpp
@@ -20,7 +20,7 @@
 
 using namespace SITL;
 
-uint32_t RF_Ainstein_LR_D1::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
+uint32_t RF_Ainstein_LR_D1::packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen)
 {
     const uint8_t PACKET_LEN = 32;
 
@@ -29,6 +29,8 @@ uint32_t RF_Ainstein_LR_D1::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uin
     }
 
     uint8_t malfunction_alert = 0;
+
+    const uint16_t alt_cm = alt_m * 100;
 
     const uint8_t snr = (alt_cm == 0xFFFF) ? 0 : 100;
 

--- a/libraries/SITL/SIM_RF_Ainstein_LR_D1.h
+++ b/libraries/SITL/SIM_RF_Ainstein_LR_D1.h
@@ -46,7 +46,7 @@ public:
 
     static SerialRangeFinder *create() { return NEW_NOTHROW RF_Ainstein_LR_D1(); }
 
-    uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
+    uint32_t packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen) override;
 
     uint16_t reading_interval_ms() const override { return 100; }
 

--- a/libraries/SITL/SIM_RF_BLping.cpp
+++ b/libraries/SITL/SIM_RF_BLping.cpp
@@ -24,7 +24,7 @@
 
 using namespace SITL;
 
-uint32_t RF_BLping::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
+uint32_t RF_BLping::packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen)
 {
 #define BLPING_MSGID_ACK                    1
 #define BLPING_MSGID_NACK                   2
@@ -33,7 +33,7 @@ uint32_t RF_BLping::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buf
 #define BLDPIN_MSGID_DISTANCE_SIMPLE        1211
 #define BLPING_MSGID_CONTINUOUS_START       1400
 
-    const uint32_t alt_mm = uint32_t(alt_cm * 10);
+    const uint32_t alt_mm = uint32_t(alt_m * 1000);
     const uint8_t payload[] = {
         uint8_t(alt_mm & 0xff),
         uint8_t((alt_mm >> 8) & 0xff),

--- a/libraries/SITL/SIM_RF_BLping.h
+++ b/libraries/SITL/SIM_RF_BLping.h
@@ -38,7 +38,7 @@ public:
 
     static SerialRangeFinder *create() { return NEW_NOTHROW RF_BLping(); }
 
-    uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
+    uint32_t packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen) override;
 
 };
 

--- a/libraries/SITL/SIM_RF_Benewake.cpp
+++ b/libraries/SITL/SIM_RF_Benewake.cpp
@@ -20,8 +20,10 @@
 
 using namespace SITL;
 
-uint32_t RF_Benewake::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
+uint32_t RF_Benewake::packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen)
 {
+    const uint16_t alt_cm = alt_m * 100;
+
     buffer[0] = 0x59;
     buffer[1] = 0x59;
     buffer[3] = alt_cm >> 8;

--- a/libraries/SITL/SIM_RF_Benewake.h
+++ b/libraries/SITL/SIM_RF_Benewake.h
@@ -25,7 +25,7 @@ namespace SITL {
 class RF_Benewake : public SerialRangeFinder {
 public:
 
-    uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
+    uint32_t packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen) override;
 
 private:
 

--- a/libraries/SITL/SIM_RF_GYUS42v2.cpp
+++ b/libraries/SITL/SIM_RF_GYUS42v2.cpp
@@ -23,8 +23,10 @@
 
 using namespace SITL;
 
-uint32_t RF_GYUS42v2::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
+uint32_t RF_GYUS42v2::packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen)
 {
+    const uint16_t alt_cm = alt_m * 100;
+
     if (buflen < 7) {
         return 0;
     }

--- a/libraries/SITL/SIM_RF_GYUS42v2.h
+++ b/libraries/SITL/SIM_RF_GYUS42v2.h
@@ -38,7 +38,7 @@ public:
 
     static SerialRangeFinder *create() { return NEW_NOTHROW RF_GYUS42v2(); }
 
-    uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
+    uint32_t packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen) override;
 
     // TODO: work this out
     uint16_t reading_interval_ms() const override { return 100; }

--- a/libraries/SITL/SIM_RF_JRE.cpp
+++ b/libraries/SITL/SIM_RF_JRE.cpp
@@ -20,12 +20,14 @@
 
 using namespace SITL;
 
-uint32_t RF_JRE::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
+uint32_t RF_JRE::packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen)
 {
     uint16_t status = 0;
-    if (alt_cm > 50000) {
+    if (alt_m > 500) {
         status |= 0x2;  // NTRK, whatever that means...
     }
+
+    const uint16_t alt_cm = alt_m * 100;
 
     buffer[0] = 'R';
     buffer[1] = 'A';

--- a/libraries/SITL/SIM_RF_JRE.h
+++ b/libraries/SITL/SIM_RF_JRE.h
@@ -39,7 +39,7 @@ public:
 
     static SerialRangeFinder *create() { return NEW_NOTHROW RF_JRE(); }
 
-    uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
+    uint32_t packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen) override;
 
 private:
     uint8_t frame_count;  // sequence number

--- a/libraries/SITL/SIM_RF_Lanbao.cpp
+++ b/libraries/SITL/SIM_RF_Lanbao.cpp
@@ -24,12 +24,14 @@
 
 using namespace SITL;
 
-uint32_t RF_Lanbao::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
+uint32_t RF_Lanbao::packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen)
 {
+    const uint16_t alt_mm = alt_m * 1000;
+
     buffer[0] = 0xA5;
     buffer[1] = 0x5A;
-    buffer[2] = (alt_cm * 10) >> 8;
-    buffer[3] = (alt_cm * 10) & 0xff;
+    buffer[2] = alt_mm >> 8;
+    buffer[3] = alt_mm & 0xff;
 
     const uint16_t crc = calc_crc_modbus(buffer, 4);
     buffer[4] = crc & 0xff;

--- a/libraries/SITL/SIM_RF_Lanbao.h
+++ b/libraries/SITL/SIM_RF_Lanbao.h
@@ -38,7 +38,7 @@ public:
 
     static SerialRangeFinder *create() { return NEW_NOTHROW RF_Lanbao(); }
 
-    uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
+    uint32_t packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen) override;
 
 };
 

--- a/libraries/SITL/SIM_RF_LeddarOne.cpp
+++ b/libraries/SITL/SIM_RF_LeddarOne.cpp
@@ -23,16 +23,16 @@
 
 using namespace SITL;
 
-uint32_t RF_LeddarOne::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
+uint32_t RF_LeddarOne::packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen)
 {
     const uint8_t response_size = 25;
     const uint16_t internal_temperature = 1245;
     const uint16_t num_detections = 1;
-    const uint16_t first_distance = alt_cm * 10;
+    const uint16_t first_distance = alt_m * 1000;
     const uint16_t first_amplitude = 37;
-    const uint16_t second_distance = alt_cm * 10;
+    const uint16_t second_distance = alt_m * 1000;
     const uint16_t second_amplitude = 37;
-    const uint16_t third_distance = alt_cm * 10;
+    const uint16_t third_distance = alt_m * 1000;
     const uint16_t third_amplitude = 37;
     const uint32_t now = AP_HAL::millis();
 

--- a/libraries/SITL/SIM_RF_LeddarOne.h
+++ b/libraries/SITL/SIM_RF_LeddarOne.h
@@ -38,7 +38,7 @@ public:
 
     static SerialRangeFinder *create() { return NEW_NOTHROW RF_LeddarOne(); }
 
-    uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
+    uint32_t packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen) override;
 
 };
 

--- a/libraries/SITL/SIM_RF_LightWareSerial.cpp
+++ b/libraries/SITL/SIM_RF_LightWareSerial.cpp
@@ -48,8 +48,9 @@ void RF_LightWareSerial::update(float range)
     return SerialRangeFinder::update(range);
 }
 
-uint32_t RF_LightWareSerial::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
+uint32_t RF_LightWareSerial::packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen)
 {
+    uint16_t alt_cm = alt_m * 100;
     if (alt_cm > 10000) {
         // out-of-range-high
         alt_cm = 13000;  // from datasheet

--- a/libraries/SITL/SIM_RF_LightWareSerial.h
+++ b/libraries/SITL/SIM_RF_LightWareSerial.h
@@ -38,7 +38,7 @@ public:
 
     static SerialRangeFinder *create() { return NEW_NOTHROW RF_LightWareSerial(); }
 
-    uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
+    uint32_t packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen) override;
 
     void update(float range) override;
 

--- a/libraries/SITL/SIM_RF_LightWareSerialBinary.cpp
+++ b/libraries/SITL/SIM_RF_LightWareSerialBinary.cpp
@@ -24,8 +24,10 @@
 
 using namespace SITL;
 
-uint32_t RF_LightWareSerialBinary::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
+uint32_t RF_LightWareSerialBinary::packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen)
 {
+    const uint16_t alt_cm = alt_m * 100;
+
     // high byte is second 7 bits but high bit set
     buffer[0] = ((alt_cm >> 7) & 0x7f) | (1<<7);
     // low byte is just first 7 bits

--- a/libraries/SITL/SIM_RF_LightWareSerialBinary.h
+++ b/libraries/SITL/SIM_RF_LightWareSerialBinary.h
@@ -38,7 +38,7 @@ public:
 
     static SerialRangeFinder *create() { return NEW_NOTHROW RF_LightWareSerialBinary(); }
 
-    uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
+    uint32_t packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen) override;
 
 };
 

--- a/libraries/SITL/SIM_RF_MAVLink.cpp
+++ b/libraries/SITL/SIM_RF_MAVLink.cpp
@@ -25,11 +25,12 @@
 
 using namespace SITL;
 
-uint32_t RF_MAVLink::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
+uint32_t RF_MAVLink::packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen)
 {
     mavlink_message_t msg;
     const uint8_t system_id = 32;
     const uint8_t component_id = 32;
+    const uint16_t alt_cm = alt_m * 100;
     const mavlink_distance_sensor_t distance_sensor{
         .time_boot_ms = AP_HAL::millis(),
         .min_distance = 10, // cm

--- a/libraries/SITL/SIM_RF_MAVLink.h
+++ b/libraries/SITL/SIM_RF_MAVLink.h
@@ -38,7 +38,7 @@ public:
 
     static SerialRangeFinder *create() { return NEW_NOTHROW RF_MAVLink(); }
 
-    uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
+    uint32_t packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen) override;
 
 private:
     mavlink_status_t mav_status;

--- a/libraries/SITL/SIM_RF_MaxsonarSerialLV.cpp
+++ b/libraries/SITL/SIM_RF_MaxsonarSerialLV.cpp
@@ -23,8 +23,8 @@
 
 using namespace SITL;
 
-uint32_t RF_MaxsonarSerialLV::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
+uint32_t RF_MaxsonarSerialLV::packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen)
 {
-    const float inches = alt_cm / 2.54f;
+    const float inches = alt_m * 100 / 2.54f;
     return snprintf((char*)buffer, buflen, "%u\r", (unsigned)inches);
 }

--- a/libraries/SITL/SIM_RF_MaxsonarSerialLV.h
+++ b/libraries/SITL/SIM_RF_MaxsonarSerialLV.h
@@ -38,7 +38,7 @@ public:
 
     static SerialRangeFinder *create() { return NEW_NOTHROW RF_MaxsonarSerialLV(); }
 
-    uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
+    uint32_t packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen) override;
 
 };
 

--- a/libraries/SITL/SIM_RF_NMEA.cpp
+++ b/libraries/SITL/SIM_RF_NMEA.cpp
@@ -25,12 +25,12 @@
 
 using namespace SITL;
 
-uint32_t RF_NMEA::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
+uint32_t RF_NMEA::packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen)
 {
 // Format 2 DBT NMEA mode (e.g. $SMDBT,5.94,f,1.81,M,67)
 // Format 3 DPT NMEA mode (e.g. $SMDPT,1.81,0.066)
 
-    ssize_t ret = snprintf((char*)buffer, buflen, "$SMDPT,%f,%f", alt_cm*0.01f, 0.01f);
+    ssize_t ret = snprintf((char*)buffer, buflen, "$SMDPT,%f,%f", alt_m, 0.01f);
     uint8_t checksum = 0;
     for (uint8_t i=1; i<ret; i++) { // 1 because the initial $ is skipped
         checksum ^= buffer[i];

--- a/libraries/SITL/SIM_RF_NMEA.h
+++ b/libraries/SITL/SIM_RF_NMEA.h
@@ -41,7 +41,7 @@ public:
 
     uint32_t device_baud() const override { return 9600; }
 
-    uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
+    uint32_t packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen) override;
 
     bool has_temperature() const override { return true; }
     uint32_t packet_for_temperature(float temperature, uint8_t *buffer, uint8_t buflen) override;

--- a/libraries/SITL/SIM_RF_NoopLoop.cpp
+++ b/libraries/SITL/SIM_RF_NoopLoop.cpp
@@ -20,11 +20,12 @@
 
 using namespace SITL;
 
-uint32_t RF_Nooploop::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
+uint32_t RF_Nooploop::packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen)
 {
     // the NoopLoop driver considers a value of zero invalid and won't
     // consider it a reading, so you end up with no readings at all
     // from the driver.  Fudge it here:
+    uint16_t alt_cm = alt_m * 100;
     if (alt_cm == 0) {
         alt_cm = 1;
     }

--- a/libraries/SITL/SIM_RF_NoopLoop.h
+++ b/libraries/SITL/SIM_RF_NoopLoop.h
@@ -27,7 +27,7 @@ public:
 
     static SerialRangeFinder *create() { return NEW_NOTHROW RF_Nooploop(); }
 
-    uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
+    uint32_t packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen) override;
 
 };
 

--- a/libraries/SITL/SIM_RF_RDS02UF.cpp
+++ b/libraries/SITL/SIM_RF_RDS02UF.cpp
@@ -23,8 +23,10 @@
 
 using namespace SITL;
 
-uint32_t RF_RDS02UF::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
+uint32_t RF_RDS02UF::packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen)
 {
+    const uint16_t alt_cm = alt_m * 100;
+
     const uint16_t fc_code = 0x3ff;  // NFI what this means
     const uint16_t data_fc = 0x70c;  // NFI what this means
 

--- a/libraries/SITL/SIM_RF_RDS02UF.h
+++ b/libraries/SITL/SIM_RF_RDS02UF.h
@@ -39,7 +39,7 @@ public:
 
     static SerialRangeFinder *create() { return NEW_NOTHROW RF_RDS02UF(); }
 
-    uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
+    uint32_t packet_for_alt(float alt_cm, uint8_t *buffer, uint8_t buflen) override;
 
 };
 

--- a/libraries/SITL/SIM_RF_TeraRanger_Serial.cpp
+++ b/libraries/SITL/SIM_RF_TeraRanger_Serial.cpp
@@ -18,14 +18,14 @@
 
 using namespace SITL;
 
-uint32_t RF_TeraRanger_Serial::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
+uint32_t RF_TeraRanger_Serial::packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen)
 {
-    uint16_t alt_mm = alt_cm * 10;
+    const uint16_t alt_mm = alt_m * 1000;
     buffer[0] = 0x54; //header byte
     buffer[1] = alt_mm >> 8; //MSB mm
     buffer[2] = alt_mm & 0xff; //LSB mm
 
-    if (alt_cm > 3000) {
+    if (alt_m > 30) {
        buffer[3] = 0xC4; //full strength, out of range, no overtemp
     }
     else {

--- a/libraries/SITL/SIM_RF_TeraRanger_Serial.h
+++ b/libraries/SITL/SIM_RF_TeraRanger_Serial.h
@@ -33,7 +33,7 @@ public:
 
     static SerialRangeFinder *create() { return NEW_NOTHROW RF_TeraRanger_Serial(); }
 
-    uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
+    uint32_t packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen) override;
 
 
 };

--- a/libraries/SITL/SIM_RF_USD1_v0.cpp
+++ b/libraries/SITL/SIM_RF_USD1_v0.cpp
@@ -20,9 +20,9 @@
 
 using namespace SITL;
 
-uint32_t RF_USD1_v0::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
+uint32_t RF_USD1_v0::packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen)
 {
-    const uint16_t reading = alt_cm / 2.5f;
+    const uint16_t reading = alt_m * 100 / 2.5f;
     buffer[0] = 0x48;
     buffer[1] = reading & 0x7f;
     buffer[2] = (reading >> 7) & 0xff;

--- a/libraries/SITL/SIM_RF_USD1_v0.h
+++ b/libraries/SITL/SIM_RF_USD1_v0.h
@@ -38,7 +38,7 @@ public:
 
     static SerialRangeFinder *create() { return NEW_NOTHROW RF_USD1_v0(); }
 
-    uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
+    uint32_t packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen) override;
 
 };
 

--- a/libraries/SITL/SIM_RF_USD1_v1.cpp
+++ b/libraries/SITL/SIM_RF_USD1_v1.cpp
@@ -20,8 +20,10 @@
 
 using namespace SITL;
 
-uint32_t RF_USD1_v1::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
+uint32_t RF_USD1_v1::packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen)
 {
+    const uint16_t alt_cm = alt_m * 100;
+
     buffer[0] = 0xFE;
     buffer[1] = 0; // unused?
     buffer[2] = alt_cm & 0xff;

--- a/libraries/SITL/SIM_RF_USD1_v1.h
+++ b/libraries/SITL/SIM_RF_USD1_v1.h
@@ -38,7 +38,7 @@ public:
 
     static SerialRangeFinder *create() { return NEW_NOTHROW RF_USD1_v1(); }
 
-    uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
+    uint32_t packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen) override;
 
 };
 

--- a/libraries/SITL/SIM_RF_Wasp.cpp
+++ b/libraries/SITL/SIM_RF_Wasp.cpp
@@ -111,13 +111,13 @@ void RF_Wasp::update(float range)
 }
 
 
-uint32_t RF_Wasp::packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen)
+uint32_t RF_Wasp::packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen)
 {
     // the Wasp driver does not consider 0 a valid reading, so you end
     // up getting 0 samples back if you send exactly zero all the
     // time.  So munge it a little bit:
-    if (alt_cm == 0) {
-        alt_cm = 1;
+    if (alt_m < 0.01) {
+        alt_m = 0.01;
     }
-    return snprintf((char*)buffer, buflen, "%f\n", alt_cm*0.01f);
+    return snprintf((char*)buffer, buflen, "%f\n", alt_m);
 }

--- a/libraries/SITL/SIM_RF_Wasp.h
+++ b/libraries/SITL/SIM_RF_Wasp.h
@@ -40,7 +40,7 @@ public:
 
     void update(float range) override;
 
-    uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) override;
+    uint32_t packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen) override;
 
     // 20Hz; if Wasp driver doesn't get a reading each time its update
     // is called it goes NoData

--- a/libraries/SITL/SIM_SerialRangeFinder.cpp
+++ b/libraries/SITL/SIM_SerialRangeFinder.cpp
@@ -29,9 +29,8 @@ void SerialRangeFinder::update(float range)
     }
     last_sent_ms = now;
 
-    const uint16_t range_cm = uint16_t(range*100);
     uint8_t data[255];
-    const uint32_t packetlen = packet_for_alt(range_cm,
+    const uint32_t packetlen = packet_for_alt(range,
                                               data,
                                               ARRAY_SIZE(data));
 

--- a/libraries/SITL/SIM_SerialRangeFinder.h
+++ b/libraries/SITL/SIM_SerialRangeFinder.h
@@ -34,7 +34,7 @@ public:
     // update state
     virtual void update(float range);
 
-    virtual uint32_t packet_for_alt(uint16_t alt_cm, uint8_t *buffer, uint8_t buflen) = 0;
+    virtual uint32_t packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen) = 0;
 
     virtual uint16_t reading_interval_ms() const { return 200; } // 5Hz default
 


### PR DESCRIPTION
allows for better precision for mm-capable devices

allows for higher altitudes than 655.35 metres

This work sponsored by Ainstein
