### PR TITLE
Tools: autotest: param_metadata: check values and increments are numbers

### DIFF
--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -579,8 +579,15 @@ def validate(param, is_library=False):
         for i in valueList:
             i = i.replace(" ", "")
             values.append(i.partition(":")[0])
+
+        # Make sure all values are numbers
+        for value in values:
+            if not is_number(value):
+                error("Value not number: \"%s\"" % value)
+
         if (len(values) != len(set(values))):
             error("Duplicate values found" + str({x for x in values if values.count(x) > 1}))
+
     # Validate units
     if (hasattr(param, "Units")):
         if (param.__dict__["Units"] != "") and (param.__dict__["Units"] not in known_units):
@@ -590,6 +597,7 @@ def validate(param, is_library=False):
         if param.User.strip() not in ["Standard", "Advanced"]:
             error("unknown user (%s)" % param.User.strip())
 
+    # Validate description
     if (hasattr(param, "Description")):
         if not param.Description or not param.Description.strip():
             error("Empty Description (%s)" % param)
@@ -612,6 +620,11 @@ def validate(param, is_library=False):
             error("Range of %f to %f and value of: %f" % (minRange, maxRange, minValue))
         if maxValue > maxRange:
             error("Range of %f to %f and value of: %f" % (minRange, maxRange, maxValue))
+
+    # Validate increment
+    if (hasattr(param, "Increment")):
+        if not is_number(param.Increment):
+            error("Increment not number: \"%s\"" % param.Increment)
 
     required_fields = required_param_fields
     if is_library:


### PR DESCRIPTION
This would have caught the original error that https://github.com/ArduPilot/ardupilot/pull/31334 fixes. That PR will need to be merged first as master currently fails.

This is the output:
```
Error in ../libraries/AP_Scripting/drivers/LTE_modem.lua
At param LTE_MCCMNC
Value not number: "AU-Telstra"
Error in ../libraries/AP_Scripting/drivers/LTE_modem.lua
At param LTE_MCCMNC
Value not number: "AU-Optus"
Error in ../libraries/AP_Scripting/drivers/LTE_modem.lua
At param LTE_MCCMNC
Value not number: "AU-Vodaphone"
```