### PR TITLE
Copter: has_valid_input is only  true if we have ever seen RC input

### DIFF
--- a/ArduCopter/RC_Channel_Copter.cpp
+++ b/ArduCopter/RC_Channel_Copter.cpp
@@ -50,6 +50,9 @@ bool RC_Channels_Copter::has_valid_input() const
     if (copter.failsafe.radio_counter != 0) {
         return false;
     }
+    if (!rc().has_ever_seen_rc_input()) {
+        return false;
+    }
     return true;
 }
 


### PR DESCRIPTION
This is a Copter-only version of PR https://github.com/ArduPilot/ardupilot/pull/31351

Let's focus on the full change (linked above) until we find it can't be merged in a timely manner