### PR TITLE
Rover: Set Loiter Destination Directly When Entering from Auto or Guided

### DIFF
--- a/Rover/mode.h
+++ b/Rover/mode.h
@@ -38,7 +38,7 @@ public:
     CLASS_NO_COPY(Mode);
 
     // enter this mode, returns false if we failed to enter
-    bool enter();
+    virtual bool enter();
 
     // perform any cleanups required:
     void exit();
@@ -654,6 +654,12 @@ public:
 
     // return distance (in meters) to destination
     float get_distance_to_destination() const override { return _distance_to_destination; }
+
+    // overriding the base class enter() method so that we can enter loiter without a destination being provided
+    bool enter() override;
+
+    // Enter mode and set destination location
+    bool enter(const Location &destintation);
 
 protected:
 

--- a/Rover/mode_auto.cpp
+++ b/Rover/mode_auto.cpp
@@ -451,7 +451,7 @@ bool ModeAuto::check_trigger(void)
 
 bool ModeAuto::start_loiter()
 {
-    if (rover.mode_loiter.enter()) {
+    if (rover.mode_loiter.enter(g2.wp_nav.get_destination())) {
         _submode = SubMode::Loiter;
         return true;
     }

--- a/Rover/mode_guided.cpp
+++ b/Rover/mode_guided.cpp
@@ -386,13 +386,17 @@ void ModeGuided::set_steering_and_throttle(float steering, float throttle)
 
 bool ModeGuided::start_loiter()
 {
-    if (rover.mode_loiter.enter()) {
+    if (_guided_mode == SubMode::WP && rover.mode_loiter.enter(g2.wp_nav.get_destination())) {
+        // in SubMode::WP we have a destination location so we can pass it directly to the loiter controller
+        _guided_mode = SubMode::Loiter;
+        return true;
+    } else if (rover.mode_loiter.enter()) {
+        // all other sub modes enter loiter using the stopping distance calculation
         _guided_mode = SubMode::Loiter;
         return true;
     }
     return false;
 }
-
 
 // start stopping vehicle as quickly as possible
 void ModeGuided::start_stop()

--- a/Rover/mode_loiter.cpp
+++ b/Rover/mode_loiter.cpp
@@ -2,11 +2,6 @@
 
 bool ModeLoiter::_enter()
 {
-    // set _destination to reasonable stopping point
-    if (!g2.wp_nav.get_stopping_location(_destination)) {
-        return false;
-    }
-
     // initialise desired speed to current speed
     if (!attitude_control.get_forward_speed(_desired_speed)) {
         _desired_speed = 0.0f;
@@ -15,6 +10,36 @@ bool ModeLoiter::_enter()
     // initialise heading to current heading
     _desired_yaw_cd = ahrs.yaw_sensor;
 
+    return true;
+}
+
+// Enter mode and calculate a destination location
+bool ModeLoiter::enter(void)
+{
+    // Call the normal mode enter function from the base class
+    // which in turn will call the _enter() function above.
+    if (!Mode::enter()) {
+        return false;
+    }
+
+    // set _destination to reasonable stopping point
+    if (!g2.wp_nav.get_stopping_location(_destination)) {
+        return false;
+    }
+
+    return true;
+}
+
+// Enter mode and set destination location directly
+bool ModeLoiter::enter(const Location &destination)
+{
+    // Call the normal mode enter function from the base class
+    // which in turn will call the _enter() function above.
+    if (!Mode::enter()) {
+        return false;
+    }
+
+    _destination = destination;
     return true;
 }
 


### PR DESCRIPTION
In Rover, when we enter into loiter, we always use the get_stopping_location() method ([See here](
https://github.com/ArduPilot/ardupilot/blob/73a62004e4c8ca96db42fde36aa8ddaf2ff973d9/Rover/mode_loiter.cpp#L3-L8)) to calculate the destination location.

When entering loiter as a sub mode from auto or guided, this can lead to a difference in the destination set by the users and destination that rover calculates to loiter around.  For 95% of the rovers out there, this doesn't make a noticeable difference as the calculated stopping point is always very close to a WP if we are invoking loiter from auto or guided position.  However, motor boats in the presence of tide or wind are an example where there can be some difference observed in the calculated loiter destination and the WP destination.

This patch simply allows for the loiter destination to be overwritten on init, when calling from auto or guided-position.  So that the vehicle does loiter about the destination set by the user in the mission/guided command.

Tested in SITL only.