### PR TITLE
Tried to remove mav link enum dependecy from libraries/AP_DAL_GPS.h

### DIFF
--- a/libraries/AP_DAL/AP_DAL_GPS.cpp
+++ b/libraries/AP_DAL/AP_DAL_GPS.cpp
@@ -3,6 +3,17 @@
 #include <AP_Logger/AP_Logger.h>
 #include "AP_DAL.h"
 
+#if HAL_MAVLINK_BINDINGS_ENABLED
+// ensuring GPS_STATUS enumweration is 1:1 with mavlink when bindings are available
+static_assert((uint32_t)AP_DAL_GPS::GPS_Status::NO_GPS == (uint32_t)GPS_FIX_TYPE_NO_GPS, "NO_GPS incorrect");
+static_assert((uint32_t)AP_DAL_GPS::GPS_Status::NO_FIX == (uint32_t)GPS_FIX_TYPE_NO_FIX, "NO_FIX incorrect");
+static_assert((uint32_t)AP_DAL_GPS::GPS_Status::GPS_OK_FIX_2D == (uint32_t)GPS_FIX_TYPE_2D_FIX, "FIX_2D incorrect");
+static_assert((uint32_t)AP_DAL_GPS::GPS_Status::GPS_OK_FIX_3D == (uint32_t)GPS_FIX_TYPE_3D_FIX, "FIX_3D incorrect");
+static_assert((uint32_t)AP_DAL_GPS::GPS_Status::GPS_OK_FIX_3D_DGPS == (uint32_t)GPS_FIX_TYPE_DGPS, "FIX_DGPS incorrect");
+static_assert((uint32_t)AP_DAL_GPS::GPS_Status::GPS_OK_FIX_3D_RTK_FLOAT == (uint32_t)GPS_FIX_TYPE_RTK_FLOAT, "FIX_RTK_FLOAT incorrect");
+static_assert((uint32_t)AP_DAL_GPS::GPS_Status::GPS_OK_FIX_3D_RTK_FIXED == (uint32_t)GPS_FIX_TYPE_RTK_FIXED, "FIX_RTK_FIXED incorrect");
+#endif // HAL_MAVLINK_BINDINGS_ENABLED
+
 AP_DAL_GPS::AP_DAL_GPS()
 {
     for (uint8_t i=0; i<ARRAY_SIZE(_RGPI); i++) {

--- a/libraries/AP_DAL/AP_DAL_GPS.h
+++ b/libraries/AP_DAL/AP_DAL_GPS.h
@@ -9,13 +9,13 @@ public:
 
     /// GPS status codes
     enum GPS_Status : uint8_t {
-        NO_GPS = GPS_FIX_TYPE_NO_GPS,                     ///< No GPS connected/detected
-        NO_FIX = GPS_FIX_TYPE_NO_FIX,                     ///< Receiving valid GPS messages but no lock
-        GPS_OK_FIX_2D = GPS_FIX_TYPE_2D_FIX,              ///< Receiving valid messages and 2D lock
-        GPS_OK_FIX_3D = GPS_FIX_TYPE_3D_FIX,              ///< Receiving valid messages and 3D lock
-        GPS_OK_FIX_3D_DGPS = GPS_FIX_TYPE_DGPS,           ///< Receiving valid messages and 3D lock with differential improvements
-        GPS_OK_FIX_3D_RTK_FLOAT = GPS_FIX_TYPE_RTK_FLOAT, ///< Receiving valid messages and 3D RTK Float
-        GPS_OK_FIX_3D_RTK_FIXED = GPS_FIX_TYPE_RTK_FIXED, ///< Receiving valid messages and 3D RTK Fixed
+        NO_GPS = 0,                     ///< No GPS connected/detected
+        NO_FIX = 1,                     ///< Receiving valid GPS messages but no lock
+        GPS_OK_FIX_2D = 2,              ///< Receiving valid messages and 2D lock
+        GPS_OK_FIX_3D = 3,              ///< Receiving valid messages and 3D lock
+        GPS_OK_FIX_3D_DGPS = 4,           ///< Receiving valid messages and 3D lock with differential improvements
+        GPS_OK_FIX_3D_RTK_FLOAT = 5, ///< Receiving valid messages and 3D RTK Float
+        GPS_OK_FIX_3D_RTK_FIXED = 6, ///< Receiving valid messages and 3D RTK Fixed
     };
 
     AP_DAL_GPS();


### PR DESCRIPTION
Tried to replicate the changes made in PR(#23229) for  libraries/AP_DAL_GPS.h
Still think mavlink enum dependecy is there as it includes from header file 

possible solution i thought of
is to add a different macro to check whther we need mavlink enum or not 
but would require a senior contributor help and guidance to continue to work on this issue (#23320). 
