### PR TITLE
AP_Arming: fix silent terrain arming failure

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1212,8 +1212,7 @@ bool AP_Arming::terrain_checks(bool report) const
 
     const AP_Terrain *terrain = AP_Terrain::get_singleton();
     if (terrain == nullptr) {
-        // this is also a system error, and it is already complaining
-        // about it.
+        check_failed(Check::PARAMETERS, report, "terrain disabled");
         return false;
     }
 


### PR DESCRIPTION
This adds an arming failure message if the terrain database is not enabled on Rover and the autopilot uses terrain altitudes.  Below is a picture from testing in SITL

<img width="800" height="383" alt="image" src="https://github.com/user-attachments/assets/faeef1ee-6f2b-4035-bcd2-2313c3e72d0f" />

I've also removed an out-of-date comment, "// this is also a system error, and it is already complaining about it." because the system checks are different and as far as I can tell, they don't overlap ([they can be seen here](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Arming/AP_Arming.cpp#L1113C1-L1119C7))

This resolves issue https://github.com/ArduPilot/ardupilot/issues/31364

I've created a related wiki page issue here for a nearby message that's not explained on the wiki https://github.com/ArduPilot/ardupilot_wiki/issues/7199