### PR TITLE
add yaw and yaw rate logging for MAVLink_SET_POSITION_TARGET_LOCAL_NED

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -911,7 +911,7 @@ private:
     void Log_Write_Data(LogDataID id, float value);
     void Log_Write_PTUN(uint8_t param, float tuning_val, float tune_min, float tune_max, float norm_in);
     void Log_Video_Stabilisation();
-    void Log_Write_Guided_Position_Target(ModeGuided::SubMode submode, const Vector3p& pos_target_m, bool is_terrain_alt, const Vector3f& vel_target_ms, const Vector3f& accel_target_mss);
+    void Log_Write_Guided_Position_Target(ModeGuided::SubMode submode, const Vector3p& pos_target_m, bool is_terrain_alt, const Vector3f& vel_target_ms, const Vector3f& accel_target_mss, const float yaw_rad, const float yaw_rate_rads);
     void Log_Write_Guided_Attitude_Target(ModeGuided::SubMode submode, float roll, float pitch, float yaw, const Vector3f &ang_vel, float thrust, float climb_rate);
     void Log_Write_SysID_Setup(uint8_t systemID_axis, float waveform_magnitude, float frequency_start, float frequency_stop, float time_fade_in, float time_const_freq, float time_record, float time_fade_out);
     void Log_Write_SysID_Data(float waveform_time, float waveform_sample, float waveform_freq, float angle_x, float angle_y, float angle_z, float accel_x, float accel_y, float accel_z);

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -920,7 +920,7 @@ private:
     void Log_Write_Data(LogDataID id, float value);
     void Log_Write_PTUN(uint8_t param, float tuning_val, float tune_min, float tune_max, float norm_in);
     void Log_Video_Stabilisation();
-    void Log_Write_Guided_Position_Target(ModeGuided::SubMode submode, const Vector3p& pos_target_ned_m, bool is_terrain_alt, const Vector3f& vel_target_ms, const Vector3f& accel_target_mss);
+    void Log_Write_Guided_Position_Target(ModeGuided::SubMode submode, const Vector3p& pos_target_ned_m, bool is_terrain_alt, const Vector3f& vel_target_ms, const Vector3f& accel_target_mss, const float yaw_rad, const float yaw_rate_rads);
     void Log_Write_Guided_Attitude_Target(ModeGuided::SubMode submode, float roll_rad, float pitch_rad, float yaw_rad, const Vector3f &ang_vel_rads, float thrust, float climb_rate_ms);
     void Log_Write_SysID_Setup(uint8_t systemID_axis, float waveform_magnitude, float frequency_start, float frequency_stop, float time_fade_in, float time_const_freq, float time_record, float time_fade_out);
     void Log_Write_SysID_Data(float waveform_time, float waveform_sample, float waveform_freq_hz, float angle_x_degs, float angle_y_degs, float angle_z_degs, float accel_x_mss, float accel_y_mss, float accel_z_mss);

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -329,6 +329,8 @@ struct PACKED log_Guided_Position_Target {
     float accel_target_x;
     float accel_target_y;
     float accel_target_z;
+    float yaw_target;
+    float yaw_rate_target;
 };
 
 // guided attitude target logging
@@ -360,7 +362,7 @@ struct PACKED log_Rate_Thread_Dt {
 // pos_target_m is lat, lon, alt OR offset from ekf origin in m
 // terrain should be 0 if pos_target_m.z is alt-above-ekf-origin, 1 if alt-above-terrain
 // vel_target_ms is m/s
-void Copter::Log_Write_Guided_Position_Target(ModeGuided::SubMode submode, const Vector3p& pos_target_m, bool is_terrain_alt, const Vector3f& vel_target_ms, const Vector3f& accel_target_mss)
+void Copter::Log_Write_Guided_Position_Target(ModeGuided::SubMode submode, const Vector3p& pos_target_m, bool is_terrain_alt, const Vector3f& vel_target_ms, const Vector3f& accel_target_mss, const float yaw_target_rad, const float yaw_rate_target_rads)
 {
     const log_Guided_Position_Target pkt {
         LOG_PACKET_HEADER_INIT(LOG_GUIDED_POSITION_TARGET_MSG),
@@ -375,7 +377,9 @@ void Copter::Log_Write_Guided_Position_Target(ModeGuided::SubMode submode, const
         vel_target_z    : vel_target_ms.z,
         accel_target_x  : accel_target_mss.x,
         accel_target_y  : accel_target_mss.y,
-        accel_target_z  : accel_target_mss.z
+        accel_target_z  : accel_target_mss.z,
+        yaw_target      : wrap_360(degrees(yaw_target_rad)),
+        yaw_rate_target  : yaw_rate_target_rads,
     };
     logger.WriteBlock(&pkt, sizeof(pkt));
 }
@@ -543,7 +547,7 @@ const struct LogStructure Copter::log_structure[] = {
 // @Field: aZ: Target acceleration, Z-Axis
 
     { LOG_GUIDED_POSITION_TARGET_MSG, sizeof(log_Guided_Position_Target),
-      "GUIP",  "QBfffbffffff",    "TimeUS,Type,pX,pY,pZ,Terrain,vX,vY,vZ,aX,aY,aZ", "s-mmm-nnnooo", "F-000-000000" , true },
+      "GUIP",  "QBfffbffffffff",    "TimeUS,Type,pX,pY,pZ,Terrain,vX,vY,vZ,aX,aY,aZ,y,yR", "s-mmm-nnnooodE", "F-000-00000000" , true },
 
 // @LoggerMessage: GUIA
 // @Description: Guided mode attitude target information

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -329,6 +329,8 @@ struct PACKED log_Guided_Position_Target {
     float accel_target_x;
     float accel_target_y;
     float accel_target_z;
+    float yaw_target_deg;
+    float yaw_rate_target_degs;
 };
 
 // guided attitude target logging
@@ -360,22 +362,24 @@ struct PACKED log_Rate_Thread_Dt {
 // pos_target_ned_m is lat, lon, alt OR offset from ekf origin in m
 // terrain should be 0 if pos_target_ned_m.z is alt-above-ekf-origin, 1 if alt-above-terrain
 // vel_target_ms is m/s
-void Copter::Log_Write_Guided_Position_Target(ModeGuided::SubMode submode, const Vector3p& pos_target_ned_m, bool is_terrain_alt, const Vector3f& vel_target_ms, const Vector3f& accel_target_mss)
+void Copter::Log_Write_Guided_Position_Target(ModeGuided::SubMode submode, const Vector3p& pos_target_ned_m, bool is_terrain_alt, const Vector3f& vel_target_ms, const Vector3f& accel_target_mss, const float yaw_target_rad, const float yaw_rate_target_rads)
 {
     const log_Guided_Position_Target pkt {
         LOG_PACKET_HEADER_INIT(LOG_GUIDED_POSITION_TARGET_MSG),
-        time_us         : AP_HAL::micros64(),
-        type            : (uint8_t)submode,
-        pos_target_x    : (float)pos_target_ned_m.x,
-        pos_target_y    : (float)pos_target_ned_m.y,
-        pos_target_z    : (float)pos_target_ned_m.z,
-        terrain         : is_terrain_alt,
-        vel_target_x    : vel_target_ms.x,
-        vel_target_y    : vel_target_ms.y,
-        vel_target_z    : vel_target_ms.z,
-        accel_target_x  : accel_target_mss.x,
-        accel_target_y  : accel_target_mss.y,
-        accel_target_z  : accel_target_mss.z
+        time_us              : AP_HAL::micros64(),
+        type                 : (uint8_t)submode,
+        pos_target_x         : (float)pos_target_ned_m.x,
+        pos_target_y         : (float)pos_target_ned_m.y,
+        pos_target_z         : (float)pos_target_ned_m.z,
+        terrain              : is_terrain_alt,
+        vel_target_x         : vel_target_ms.x,
+        vel_target_y         : vel_target_ms.y,
+        vel_target_z         : vel_target_ms.z,
+        accel_target_x       : accel_target_mss.x,
+        accel_target_y       : accel_target_mss.y,
+        accel_target_z       : accel_target_mss.z,
+        yaw_target_deg      : wrap_360(degrees(yaw_target_rad)),
+        yaw_rate_target_degs : degrees(yaw_rate_target_rads),
     };
     logger.WriteBlock(&pkt, sizeof(pkt));
 }
@@ -543,7 +547,7 @@ const struct LogStructure Copter::log_structure[] = {
 // @Field: aZ: Target acceleration, Z-Axis
 
     { LOG_GUIDED_POSITION_TARGET_MSG, sizeof(log_Guided_Position_Target),
-      "GUIP",  "QBfffbffffff",    "TimeUS,Type,pX,pY,pZ,Terrain,vX,vY,vZ,aX,aY,aZ", "s-mmm-nnnooo", "F-000-000000" , true },
+      "GUIP",  "QBfffbffffffff",    "TimeUS,Type,pX,pY,pZ,Terrain,vX,vY,vZ,aX,aY,aZ,y,yR", "s-mmm-nnnooodE", "F-000-00000000" , true },
 
 // @LoggerMessage: GUIA
 // @Description: Guided mode attitude target information

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -363,7 +363,8 @@ bool ModeGuided::set_pos_NEU_m(const Vector3p& pos_neu_m, bool use_yaw, float ya
 
 #if HAL_LOGGING_ENABLED
         // log target
-        copter.Log_Write_Guided_Position_Target(guided_mode, pos_neu_m, is_terrain_alt, Vector3f(), Vector3f());
+        AC_AttitudeControl::HeadingCommand yaw_command = auto_yaw.get_heading();
+        copter.Log_Write_Guided_Position_Target(guided_mode, pos_neu_m, is_terrain_alt, Vector3f(), Vector3f(), yaw_command.yaw_angle_rad, yaw_command.yaw_rate_rads);
 #endif
         send_notification = true;
         return true;
@@ -405,7 +406,8 @@ bool ModeGuided::set_pos_NEU_m(const Vector3p& pos_neu_m, bool use_yaw, float ya
 
 #if HAL_LOGGING_ENABLED
     // log target
-    copter.Log_Write_Guided_Position_Target(guided_mode, guided_pos_target_neu_m, guided_is_terrain_alt, guided_vel_target_neu_ms, guided_accel_target_neu_mss);
+    AC_AttitudeControl::HeadingCommand yaw_command = auto_yaw.get_heading();
+    copter.Log_Write_Guided_Position_Target(guided_mode, guided_pos_target_neu_m, guided_is_terrain_alt, guided_vel_target_neu_ms, guided_accel_target_neu_mss, yaw_command.yaw_angle_rad, yaw_command.yaw_rate_rads);
 #endif
 
     send_notification = true;
@@ -465,7 +467,8 @@ bool ModeGuided::set_destination(const Location& dest_loc, bool use_yaw, float y
 
 #if HAL_LOGGING_ENABLED
         // log target
-        copter.Log_Write_Guided_Position_Target(guided_mode, Vector3p(dest_loc.lat, dest_loc.lng, dest_loc.alt), (dest_loc.get_alt_frame() == Location::AltFrame::ABOVE_TERRAIN), Vector3f(), Vector3f());
+        AC_AttitudeControl::HeadingCommand yaw_command = auto_yaw.get_heading();
+        copter.Log_Write_Guided_Position_Target(guided_mode, Vector3p(dest_loc.lat, dest_loc.lng, dest_loc.alt), (dest_loc.get_alt_frame() == Location::AltFrame::ABOVE_TERRAIN), Vector3f(), Vector3f(), yaw_command.yaw_angle_rad, yaw_command.yaw_rate_rads);
 #endif
 
         send_notification = true;
@@ -512,9 +515,10 @@ bool ModeGuided::set_destination(const Location& dest_loc, bool use_yaw, float y
     guided_accel_target_neu_mss.zero();
     update_time_ms = millis();
 
-    // log target
 #if HAL_LOGGING_ENABLED
-    copter.Log_Write_Guided_Position_Target(guided_mode, Vector3p(dest_loc.lat, dest_loc.lng, dest_loc.alt), guided_is_terrain_alt, guided_vel_target_neu_ms, guided_accel_target_neu_mss);
+    // log target
+    AC_AttitudeControl::HeadingCommand yaw_command = auto_yaw.get_heading();
+    copter.Log_Write_Guided_Position_Target(guided_mode, Vector3p(dest_loc.lat, dest_loc.lng, dest_loc.alt), guided_is_terrain_alt, guided_vel_target_neu_ms, guided_accel_target_neu_mss, yaw_command.yaw_angle_rad, yaw_command.yaw_rate_rads);
 #endif
 
     send_notification = true;
@@ -543,7 +547,8 @@ void ModeGuided::set_accel_NEU_mss(const Vector3f& accel_neu_mss, bool use_yaw, 
 #if HAL_LOGGING_ENABLED
     // log target
     if (log_request) {
-        copter.Log_Write_Guided_Position_Target(guided_mode, guided_pos_target_neu_m, guided_is_terrain_alt, guided_vel_target_neu_ms, guided_accel_target_neu_mss);
+        AC_AttitudeControl::HeadingCommand yaw_command = auto_yaw.get_heading();
+        copter.Log_Write_Guided_Position_Target(guided_mode, guided_pos_target_neu_m, guided_is_terrain_alt, guided_vel_target_neu_ms, guided_accel_target_neu_mss, yaw_command.yaw_angle_rad, yaw_command.yaw_rate_rads);
     }
 #endif
 }
@@ -575,7 +580,8 @@ void ModeGuided::set_vel_accel_NEU_m(const Vector3f& vel_neu_ms, const Vector3f&
 #if HAL_LOGGING_ENABLED
     // log target
     if (log_request) {
-        copter.Log_Write_Guided_Position_Target(guided_mode, guided_pos_target_neu_m, guided_is_terrain_alt, guided_vel_target_neu_ms, guided_accel_target_neu_mss);
+        AC_AttitudeControl::HeadingCommand yaw_command = auto_yaw.get_heading();
+        copter.Log_Write_Guided_Position_Target(guided_mode, guided_pos_target_neu_m, guided_is_terrain_alt, guided_vel_target_neu_ms, guided_accel_target_neu_mss, yaw_command.yaw_angle_rad, yaw_command.yaw_rate_rads);
     }
 #endif
 }
@@ -615,7 +621,8 @@ bool ModeGuided::set_pos_vel_accel_NEU_m(const Vector3p& pos_neu_m, const Vector
 
 #if HAL_LOGGING_ENABLED
     // log target
-    copter.Log_Write_Guided_Position_Target(guided_mode, guided_pos_target_neu_m, guided_is_terrain_alt, guided_vel_target_neu_ms, guided_accel_target_neu_mss);
+    AC_AttitudeControl::HeadingCommand yaw_command = auto_yaw.get_heading();
+    copter.Log_Write_Guided_Position_Target(guided_mode, guided_pos_target_neu_m, guided_is_terrain_alt, guided_vel_target_neu_ms, guided_accel_target_neu_mss, yaw_command.yaw_angle_rad, yaw_command.yaw_rate_rads);
 #endif
     return true;
 }

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -391,7 +391,8 @@ bool ModeGuided::set_pos_NED_m(const Vector3p& pos_ned_m, bool use_yaw, float ya
 
 #if HAL_LOGGING_ENABLED
         // log target
-        copter.Log_Write_Guided_Position_Target(guided_mode, pos_ned_m, is_terrain_alt, Vector3f(), Vector3f());
+        AC_AttitudeControl::HeadingCommand yaw_command = auto_yaw.get_heading();
+        copter.Log_Write_Guided_Position_Target(guided_mode, pos_ned_m, is_terrain_alt, Vector3f(), Vector3f(), yaw_command.yaw_angle_rad, yaw_command.yaw_rate_rads);
 #endif
         send_notification = true;
         return true;
@@ -433,7 +434,8 @@ bool ModeGuided::set_pos_NED_m(const Vector3p& pos_ned_m, bool use_yaw, float ya
 
 #if HAL_LOGGING_ENABLED
     // log target
-    copter.Log_Write_Guided_Position_Target(guided_mode, guided_pos_target_ned_m, guided_is_terrain_alt, guided_vel_target_ned_ms, guided_accel_target_ned_mss);
+    AC_AttitudeControl::HeadingCommand yaw_command = auto_yaw.get_heading();
+    copter.Log_Write_Guided_Position_Target(guided_mode, guided_pos_target_ned_m, guided_is_terrain_alt, guided_vel_target_ned_ms, guided_accel_target_ned_mss, yaw_command.yaw_angle_rad, yaw_command.yaw_rate_rads);
 #endif
 
     send_notification = true;
@@ -493,7 +495,8 @@ bool ModeGuided::set_destination(const Location& dest_loc, bool use_yaw, float y
 
 #if HAL_LOGGING_ENABLED
         // log target
-        copter.Log_Write_Guided_Position_Target(guided_mode, Vector3p(dest_loc.lat, dest_loc.lng, dest_loc.alt), (dest_loc.get_alt_frame() == Location::AltFrame::ABOVE_TERRAIN), Vector3f(), Vector3f());
+        AC_AttitudeControl::HeadingCommand yaw_command = auto_yaw.get_heading();
+        copter.Log_Write_Guided_Position_Target(guided_mode, Vector3p(dest_loc.lat, dest_loc.lng, dest_loc.alt), (dest_loc.get_alt_frame() == Location::AltFrame::ABOVE_TERRAIN), Vector3f(), Vector3f(), yaw_command.yaw_angle_rad, yaw_command.yaw_rate_rads);
 #endif
 
         send_notification = true;
@@ -540,9 +543,10 @@ bool ModeGuided::set_destination(const Location& dest_loc, bool use_yaw, float y
     guided_accel_target_ned_mss.zero();
     update_time_ms = millis();
 
-    // log target
 #if HAL_LOGGING_ENABLED
-    copter.Log_Write_Guided_Position_Target(guided_mode, Vector3p(dest_loc.lat, dest_loc.lng, dest_loc.alt), guided_is_terrain_alt, guided_vel_target_ned_ms, guided_accel_target_ned_mss);
+    // log target
+    AC_AttitudeControl::HeadingCommand yaw_command = auto_yaw.get_heading();
+    copter.Log_Write_Guided_Position_Target(guided_mode, Vector3p(dest_loc.lat, dest_loc.lng, dest_loc.alt), guided_is_terrain_alt, guided_vel_target_ned_ms, guided_accel_target_ned_mss, yaw_command.yaw_angle_rad, yaw_command.yaw_rate_rads);
 #endif
 
     send_notification = true;
@@ -571,7 +575,8 @@ void ModeGuided::set_accel_NED_mss(const Vector3f& accel_ned_mss, bool use_yaw, 
 #if HAL_LOGGING_ENABLED
     // log target
     if (log_request) {
-        copter.Log_Write_Guided_Position_Target(guided_mode, guided_pos_target_ned_m, guided_is_terrain_alt, guided_vel_target_ned_ms, guided_accel_target_ned_mss);
+        AC_AttitudeControl::HeadingCommand yaw_command = auto_yaw.get_heading();
+        copter.Log_Write_Guided_Position_Target(guided_mode, guided_pos_target_ned_m, guided_is_terrain_alt, guided_vel_target_ned_ms, guided_accel_target_ned_mss, yaw_command.yaw_angle_rad, yaw_command.yaw_rate_rads);
     }
 #endif
 }
@@ -603,7 +608,8 @@ void ModeGuided::set_vel_accel_NED_m(const Vector3f& vel_ned_ms, const Vector3f&
 #if HAL_LOGGING_ENABLED
     // log target
     if (log_request) {
-        copter.Log_Write_Guided_Position_Target(guided_mode, guided_pos_target_ned_m, guided_is_terrain_alt, guided_vel_target_ned_ms, guided_accel_target_ned_mss);
+        AC_AttitudeControl::HeadingCommand yaw_command = auto_yaw.get_heading();
+        copter.Log_Write_Guided_Position_Target(guided_mode, guided_pos_target_ned_m, guided_is_terrain_alt, guided_vel_target_ned_ms, guided_accel_target_ned_mss, yaw_command.yaw_angle_rad, yaw_command.yaw_rate_rads);
     }
 #endif
 }
@@ -643,7 +649,8 @@ bool ModeGuided::set_pos_vel_accel_NED_m(const Vector3p& pos_ned_m, const Vector
 
 #if HAL_LOGGING_ENABLED
     // log target
-    copter.Log_Write_Guided_Position_Target(guided_mode, guided_pos_target_ned_m, guided_is_terrain_alt, guided_vel_target_ned_ms, guided_accel_target_ned_mss);
+    AC_AttitudeControl::HeadingCommand yaw_command = auto_yaw.get_heading();
+    copter.Log_Write_Guided_Position_Target(guided_mode, guided_pos_target_ned_m, guided_is_terrain_alt, guided_vel_target_ned_ms, guided_accel_target_ned_mss, yaw_command.yaw_angle_rad, yaw_command.yaw_rate_rads);
 #endif
     return true;
 }


### PR DESCRIPTION
Adds support for logging commanded yaw and yaw rates from the guided setpoint target.
The implementation uses `get_heading()` method of the AutoYaw object to get the yaw and yaw rate target.
I have tested the branch in SITL.
Please let me know your thoughts on the implementation.
@peterbarker , @rmackay9 
