### PR TITLE
Tools: fix flake8 B008 errors, methods-in-function-definitions

### DIFF
--- a/Tools/scripts/param_check.py
+++ b/Tools/scripts/param_check.py
@@ -80,7 +80,7 @@ def parse_arguments():
     return args
 
 
-def check_file(file, metadata, skip=SkippedChecks()):
+def check_file(file, metadata, skip : SkippedChecks = None):
     """Checks a single parameter file against the metadata.
 
     Loads the parameters from the specified file and validates each parameter
@@ -96,6 +96,9 @@ def check_file(file, metadata, skip=SkippedChecks()):
     Returns:
         list: A list of error messages if any parameters are invalid.
     """
+    if skip is None:
+        skip = SkippedChecks()
+
     params, msgs = load_params(file, skip)
 
     for param in params:
@@ -126,7 +129,7 @@ def check_file(file, metadata, skip=SkippedChecks()):
     return msgs
 
 
-def check_param(name, value, metadata, skip=SkippedChecks()):
+def check_param(name, value, metadata, skip : SkippedChecks = None):
     """Checks a single parameter against its metadata definition.
 
     Validates the specified parameter. If the metadata contains multiple types
@@ -143,6 +146,8 @@ def check_param(name, value, metadata, skip=SkippedChecks()):
         str: An error message if the parameter is invalid, or None otherwise.
     """
     # List of checks with their corresponding skip flags and check functions
+    if skip is None:
+        skip = SkippedChecks()
     checks = [
         (
             'ReadOnly',
@@ -259,7 +264,7 @@ def check_values(name, value, metadata):
     return None
 
 
-def load_params(file, skip=SkippedChecks(), depth=0):
+def load_params(file, skip : SkippedChecks = None, depth=0):
     """Loads a parameter file and returns parameters and errors.
 
     Reads the specified parameter file, stripping out comments. It checks the
@@ -283,6 +288,9 @@ def load_params(file, skip=SkippedChecks(), depth=0):
             - errors (list): A list of error messages encountered during
               parsing.
     """
+    if skip is None:
+        skip = SkippedChecks()
+
     if depth > 10:
         raise ValueError("Too many levels of @include")
 

--- a/Tools/scripts/param_check_all.py
+++ b/Tools/scripts/param_check_all.py
@@ -75,8 +75,11 @@ PERIPH_BOARDS = BoardList().find_ap_periph_boards(skip=periph_hwdefs_to_skip)
 ALL_VEHICLE_FIRMWARES = ['Sub', 'Plane', 'Blimp', 'Copter', 'Tracker', 'Rover']
 
 
-def check_boards(boards, firmwares, skip=SkippedChecks()):
+def check_boards(boards, firmwares, skip : SkippedChecks = None):
     '''Check parameter files for ChibiOS hwdef boards.'''
+    if skip is None:
+        skip = SkippedChecks()
+
     hwdef_dir = os.path.join(
         os.path.dirname(os.path.realpath(__file__)),
         '..', '..', 'libraries', 'AP_HAL_ChibiOS', 'hwdef'
@@ -94,13 +97,15 @@ def check_boards(boards, firmwares, skip=SkippedChecks()):
     return check_files(param_files, firmwares, skip=skip)
 
 
-def check_sitl(skip=SkippedChecks()):
+def check_sitl(skip : SkippedChecks = None):
     '''Check every parameter file that shows up in vehicleinfo.py
 
     Because this also provides us information about the intended firmware, we
     can check it strictly against the parameter metadata for that specific
     firmware, unlike the non-periph hwdef boards.
     '''
+    if skip is None:
+        skip = SkippedChecks()
     vinfo = VehicleInfo()
     vehicle_name = {
         'ArduCopter': 'Copter',
@@ -145,13 +150,15 @@ def check_sitl(skip=SkippedChecks()):
     return success
 
 
-def check_frame_params(skip=SkippedChecks()):
+def check_frame_params(skip : SkippedChecks = None):
     '''Check all files within Tools/Frame_params
 
     These don't contain any information about firmware (e.g. Copter, Plane,
     etc.), so we check them against all vehicles, but it would be a good idea
     to strictly check them against the intended firmware in the future.
     '''
+    if skip is None:
+        skip = SkippedChecks()
     frame_params_dir = os.path.join(
         os.path.dirname(os.path.realpath(__file__)),
         '..', '..', 'Tools', 'Frame_params'
@@ -170,8 +177,11 @@ def check_frame_params(skip=SkippedChecks()):
     return check_files(param_files, ALL_VEHICLE_FIRMWARES, skip=skip)
 
 
-def check_files(files, firmwares, skip=SkippedChecks()):
+def check_files(files, firmwares, skip : SkippedChecks = None):
     '''Check a list of parameter files against the metadata'''
+    if skip is None:
+        skip = SkippedChecks()
+
     metadata = get_metadata(firmwares)
     success = True
     for file in files:


### PR DESCRIPTION
e.g.

./Tools/scripts/param_check_all.py:180:40: B008 Do not perform function calls in argument defaults.  The call is performed only once at function definition time. All calls to your function will reuse the result of that definition-time function call.  If this is intended, assign the function call to a module-level variable and use that variable as a default value.

As suggested by @cclauss in https://github.com/ArduPilot/ardupilot/pull/30574
