### PR TITLE
AP_Bootloader: Add YARI_GNSS Board ID

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -331,6 +331,7 @@ AP_HW_MUPilot                        1222
 
 # IDs 1231-1240 reserved for YARI Robotics
 AP_HW_YARIV6X                        1234
+AP_HW_YARI_GNSS                      1235
 
 AP_HW_CBUnmanned-CM405-FC            1301
 


### PR DESCRIPTION
Reserving board_id for YARI_GNSS board