### PR TITLE
Rover: disable pivot turns by default for 4.7

### DIFF
--- a/libraries/AR_WPNav/AR_PivotTurn.cpp
+++ b/libraries/AR_WPNav/AR_PivotTurn.cpp
@@ -25,7 +25,7 @@
 extern const AP_HAL::HAL& hal;
 
 #define AR_PIVOT_TIMEOUT_MS     100 // pivot controller timesout and reset target if not called within this many milliseconds
-#define AR_PIVOT_ANGLE_DEFAULT  60  // default PIVOT_ANGLE parameter value
+#define AR_PIVOT_ANGLE_DEFAULT  0   // default PIVOT_ANGLE parameter value (disabled by default)
 #define AR_PIVOT_ANGLE_ACCURACY 5   // vehicle will pivot to within this many degrees of destination
 #define AR_PIVOT_RATE_DEFAULT   60  // default PIVOT_RATE parameter value
 #define AR_PIVOT_DELAY_DEFAULT  0   // default PIVOT_DELAY parameter value


### PR DESCRIPTION
This PR is mostly to promote some discussion of whether we should disable Rover's Pivot Turns by default for 4.7

My feeling is that SCurve turns are already tight enough (especially at the low speeds that most rovers travel at) that most users will find they perform better than Pivot turns.

The issue with Pivot turns is they suffer from two key weaknesses:

1. pivots rely on a very good heading.  If the heading is off then then the vehicle will end up pointing slightly off from the direction of travel towards the next waypoint.  This means the vehicle tends to veer off the path at the beginning of each waypoint segment
2. pivots rely on the vehicle stopping precisely on the origin of the next waypoint segment.  If they stop too close or too far then again, the vehicle ends up correcting at the beginning of the segment

Here's a little video showing the difference in a near perfect setup
https://youtu.be/sT4IhKjE7Lw

I've created a [discussion here to get feedback from the wider community](https://discuss.ardupilot.org/t/should-we-disable-pivot-turns-by-default-in-4-7/140302) as well