### PR TITLE
AP_ExternalAHRS: Don't throw origin pre-arm error unless using ExtNav as primary AHRS

### DIFF
--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS.cpp
@@ -287,10 +287,13 @@ bool AP_ExternalAHRS::pre_arm_check(char *failure_msg, uint8_t failure_msg_len) 
             return false;
         }
     }
-
-    if (!state.have_origin) {
-        hal.util->snprintf(failure_msg, failure_msg_len, "ExternalAHRS: No origin");
-	    return false;
+    AP_AHRS &ahrs = AP::ahrs();
+    if (ahrs.get_ekf_type() == static_cast<int8_t>(AP_AHRS::EKFType::EXTERNAL)) {
+        // when using EAHRS as the EKF source, we must have a valid position origin
+        if (!state.have_origin) {
+            hal.util->snprintf(failure_msg, failure_msg_len, "ExternalAHRS: No origin");
+            return false;
+        }
     }
     return true;
 }


### PR DESCRIPTION
I am sure there is a reason for this pre-arm check (which I don't understand); however, having it in place means we cannot use any "external AHRS" sensor that doesn't have a GPS. We already supported the VectorNAV VN-100 as an external AHRS sensor, which does not have a GPS. My guess is that users trying to arm with just the VN-100 sensor would also trip up on this check. 

This PR is a placeholder for discussion for a proper solution. 


EDIT: Turns out the plane can arm without an origin if this check is removed. So I have modified the PR to only check in the case of AHRS_EKF_TYPE=11