### PR TITLE
autotest: Fix QAUTOTUNE test

### DIFF
--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -365,6 +365,8 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
 
         # adjust tune so QAUTOTUNE can cope
         self.set_parameters({
+            "Q_AUTOTUNE_AGGR": 0.1,
+            "Q_AUTOTUNE_MIN_D": 0.0004,
             "Q_A_RAT_RLL_P" : 0.15,
             "Q_A_RAT_RLL_I" : 0.25,
             "Q_A_RAT_RLL_D" : 0.002,


### PR DESCRIPTION
Does what it says on the packet.

The problem was the tune was hitting the minimum D value. Since this check was written we have:

- Decreased the default AGGR to 0.1
- Made Autotune fail if we hit minimum D
- Add a Backoff parameter that further softens the tune.

It was already very close before the addition of the autotune back off. This PR reduces the minimum D and increases the AGGR back to the value of 0.1 that was the default when this test was created. Either one of these changes fixes the problem. An Autotune failure will still hit the minimum D.