### PR TITLE
AP_Mount: move mount_open servo control to dedicated function

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -38,12 +38,19 @@ void AP_Mount_Backend::set_dev_id(uint32_t id)
     _params.dev_id.set_and_save(int32_t(id));
 }
 
+// update_mount_open_servo - should be called periodically to control the mount open/close servo
+void AP_Mount_Backend::update_mount_open_servo()
+{
+    // move mount to a "retracted position" into the fuselage or out of it
+    const bool mount_open = (_mode != MAV_MOUNT_MODE_RETRACT);
+    SRV_Channels::move_servo(_open_idx, mount_open, 0, 1);
+}
+
 // base implementation should be called from derived classes for common functionality
 void AP_Mount_Backend::update()
 {
-    // move mount to a "retracted position" into the fuselage or out of it
-    const bool mount_open = (_mode == MAV_MOUNT_MODE_RETRACT);
-    SRV_Channels::move_servo(_open_idx, mount_open, 0, 1);
+    // update mount open/close servo
+    update_mount_open_servo();
 
     // set target rate to zero if we have not received rate command for a while
     if ((get_mode() == MAV_MOUNT_MODE_MAVLINK_TARGETING) &&

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -54,6 +54,9 @@ public:
     // used for gimbals that need to read INS data at full rate
     virtual void update_fast() {}
 
+    // update_mount_open_servo - should be called periodically to control the mount open/close servo
+    void update_mount_open_servo();
+
     // return true if healthy
     virtual bool healthy() const { return true; }
 


### PR DESCRIPTION
Refactored mount open/close servo control into dedicated `update_mount_open_servo()` function in `AP_Mount_Backend`. Previously embedded inline in `update()`, now explicit and maintainable. All 14 mount backends automatically inherit functionality.

**Testing:**
- Built and tested in SITL for copter and plane
- All vehicle builds pass (copter, plane, rover, sub, tracker, blimp)
- No behavioral changes, fully backward compatible

Fixes #26892 