### PR TITLE
AP_HAL_ChibiOS: Enable tx FIFO for multiframe bxcan messages

### DIFF
--- a/libraries/AP_HAL_ChibiOS/CanIface.cpp
+++ b/libraries/AP_HAL_ChibiOS/CanIface.cpp
@@ -921,7 +921,7 @@ bool CANIface::init(const uint32_t bitrate, const CANIface::OperatingMode mode)
     /*
      * Hardware initialization (the hardware has already confirmed initialization mode, see above)
      */
-    can_->MCR = bxcan::MCR_ABOM | bxcan::MCR_AWUM | bxcan::MCR_INRQ;  // RM page 648
+    can_->MCR = bxcan::MCR_ABOM | bxcan::MCR_AWUM | bxcan::MCR_INRQ | bxcan::MCR_TXFP;  // RM page 648
 
     can_->BTR = ((timings.sjw & 3U)  << 24) |
                 ((timings.bs1 & 15U) << 16) |


### PR DESCRIPTION
Multi-frame DroneCAN messages with a periph in the loop is experiencing CRC and wrong toggle errors. I believe this is related to https://github.com/ArduPilot/ardupilot/issues/28545. According to DroneCAN and STM32 documentation we should be enabling tx FIFO to maintain the correct order of multi-frame messages. 

I can see in the [bootloader](https://github.com/ArduPilot/ardupilot/blob/4864398a30489999fafba47ee6030181a9b834da/Tools/AP_Bootloader/can.cpp#L47) the FIFO flag is being set. The equivalent is also being set for [CANFD](https://github.com/ArduPilot/ardupilot/blob/4864398a30489999fafba47ee6030181a9b834da/libraries/AP_HAL_ChibiOS/CANFDIface.cpp#L827). FIFO is not being set though for standard CAN, in my case with an STM32F4xx periph.

From the DroneCAN documentation:

https://dronecan.github.io/Specification/4.1_CAN_bus_transport_layer/

> Multi-frame transfers use identical CAN ID for all frames of the transfer, and DroneCAN requires that all frames of a multi-frame transfer should be transmitted in order. Therefore, the CAN controller driver software must ensure that CAN frames with identical CAN ID must be transmitted in their order of appearance in the TX queue. Some hardware will not meet this requirement by default, so the designer must take special care to ensure correct behavior, and apply workarounds if necessary.

[stm32f4xx](https://www.st.com/resource/en/reference_manual/rm0430-stm32f413423-advanced-armbased-32bit-mcus-stmicroelectronics.pdf) 34.7.1 docs:

> Transmit priority
> • By identifier
> When more than one transmit mailbox is pending, the transmission order is given
> by the identifier of the message stored in the mailbox. The message with the
> lowest identifier value has the highest priority according to the arbitration of the
> CAN protocol. If the identifier values are equal, the lower mailbox number is
> scheduled first.
> 
> • By transmit request order
> The transmit mailboxes can be configured as a transmit FIFO by setting the TXFP
> bit in the CAN_MCR register. In this mode, the priority order is given by the
> transmit request order. This mode is very useful for segmented transmission.

So we must set the TXFP flag to transmit by request order.

In my testing watching the stats panel in DroneCAN GUI I can see a drop in "Rx Error Wrong Toggle" and "RX Error Bad CRC" on the Autopilot Node when I've applied this patch.