### PR TITLE
Plane: postition control QPOS1 and QPOS2

### DIFF
--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -526,6 +526,7 @@ private:
         bool reached_wp_speed;
         uint32_t last_run_ms;
         float pos1_speed_limit_ms;
+        Location pos1_start_loc;
         bool done_accel_init;
         Vector2f velocity_match_ms;
         uint32_t last_velocity_match_ms;


### PR DESCRIPTION
Rebase of https://github.com/ArduPilot/ardupilot/pull/21620 to 4.7dev

This doesn't work like it should. In the old PR, the comment
```
       // It never trys to speed up or slow down due to position error (unless in overshoot)
```
is correct. But now after rebasing to 4.7, it's not quite working that way. Something with the input shaping has changed and now the target position is lagging significantly behind the actual position, causing the aircraft to pitch way back, then pitch forward again (4.7dev does this too, which I'm [trying to fix in another PR](https://github.com/ArduPilot/ardupilot/pull/30309), but if this PR can achieve the same result, it has other benefits).

<img width="1813" height="513" alt="newplot (30)" src="https://github.com/user-attachments/assets/0ed9853d-b63d-4b87-8cc6-0e35968d87db" />

[backtransition_21620_4.7dev.zip](https://github.com/user-attachments/files/23181218/backtransition_21620_4.7dev.zip)

I get the behavior I want if I use `set_pos_vel_accel_NE_m` instead of `input_pos_vel_accel_NE_m` on line 2603 but that's definitely not the right fix. Unfortunately, I don't understand the AC_PosControl library well enough. Hoping someone else sees something obvious here.