### PR TITLE
Plane: fix yaw calculation during POS1 overshoot

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2605,14 +2605,18 @@ void QuadPlane::vtol_position_controller(void)
                                                   2*position2_dist_threshold_m + stopping_distance_m(rel_groundspeed_sq));
 
                 target_speed_ne_ms = diff_wp_norm * approach_speed_ms;
-                have_target_yaw = true;
-
-                // adjust target yaw angle for wind. We calculate yaw based on the target speed
-                // we want assuming no speed scaling due to direction
+                
+                // adjust target yaw angle into the apparent wind
                 const Vector2f wind_ms = plane.ahrs.wind_estimate().xy();
-                const float gnd_speed_ms = plane.ahrs.groundspeed();
-                Vector2f target_speed_xy = landing_velocity_ne_ms + diff_wp_norm * gnd_speed_ms - wind_ms;
-                target_yaw_deg = degrees(target_speed_xy.angle());
+                const Vector2f airspeed_ne_ms = plane.ahrs.groundspeed_vector() - wind_ms;
+                if (airspeed_ne_ms.length_squared() < 1) {
+                    // Don't cause unpredictable yaw swings if the airspeed vector
+                    // is very small; let the weathervane logic handle it instead.
+                    have_target_yaw = false;
+                } else {
+                    have_target_yaw = true;
+                    target_yaw_deg = degrees(airspeed_ne_ms.angle());
+                }
             }
         }
         const float target_speed_ms = target_speed_ne_ms.length();


### PR DESCRIPTION
This PR fixes the issue @timtuxworth encountered recently: [logs](https://www.dropbox.com/scl/fi/nl3yrk05md41ndbuzez2s/log_52_2025-10-20-14-24-50.bin?rlkey=kb8nppl9kn2rvus6ih2et0htl&st=qz7rq1ad&dl=0) and [video](https://youtu.be/E8bJBzEQbvM). It's something I've also encountered a few times over the years (and it's terrifying) but never looked into fixing it and just did everything possible to prevent overshoot from ever occurring.

During an overshoot, the aircraft should yaw to keep its nose into the _current_ apparent wind, not the future apparent wind when the target ground speed is eventually reached. This fix causes the aircraft to yaw gently as intended as it slows and corrects course during POS1 overshoot.

This leads to significantly less yaw output, and overall better/safer control. The ground track itself is the same between the two, so this shouldn't negatively impact anything.

Tested in RealFlight on the Cobra. 3m/s crosswind with a mission designed to cause a QRTL overshoot:
- [logs.zip](https://github.com/user-attachments/files/23201368/logs.zip)
- [mission](https://github.com/user-attachments/files/23201416/cmac_too_close.txt)

<img width="602" height="676" alt="image" src="https://github.com/user-attachments/assets/7a480b7d-3080-41a7-aa8d-7385ca487ca7" />

Current Behavior:
<img width="1529" height="477" alt="Current Behavior" src="https://github.com/user-attachments/assets/aabd21f2-9e92-4369-a537-a8069beee6f3" />

This Fix:
<img width="1529" height="477" alt="This Fix)" src="https://github.com/user-attachments/assets/41e8dcb7-6c49-444c-9e22-15c5dfcb81dc" />