### PR TITLE
Tools: fix parameter sorting in alphanumeric parameter names

### DIFF
--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -439,8 +439,16 @@ for library in libraries:
 
     debug("Processed %u documented parameters" % len(library.params))
 
+
+def natural_sort_key(libname):
+    """Natural sort key used for sorting alphanumeric strings"""
+    # splitting string into parts (numeric , non-numeric)
+    parts = re.split(r'(\d+)', libname)
+    return tuple((int(p) if p.isdigit() else p) for p in parts)
+
+
 # sort libraries by name
-alllibs = sorted(alllibs, key=lambda x: x.name)
+alllibs = sorted(alllibs, key=lambda x: natural_sort_key(x.name))
 
 libraries = alllibs
 


### PR DESCRIPTION
In complete parameters list in docs the parameters were sorted in lexographical order causing weird ordering of some params ( SERVO10_ appears before SERVO2_ ) and for all parameter groups , this PR should fixes the param_parser.py script responsible of generating the .rst files used to generate docs

After the fix :
<img width="1920" height="1080" alt="parameters_list_sv" src="https://github.com/user-attachments/assets/9dfb6d0e-2fd5-45a6-9082-7136972adf2c" />

<img width="1920" height="1080" alt="parameters_list_mav" src="https://github.com/user-attachments/assets/df47b1c5-80ce-417a-875e-eae0e097a82f" />

*These screenshots were taken by replacing the original parameters.rst file by the file generted by [this](https://github.com/ArduPilot/ardupilot/blob/master/Tools/scripts/build_parameters.sh) script*


Should fix #29155