### PR TITLE
ardupilotwaf: speed up ChibiOS build preparation

### DIFF
--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -58,7 +58,6 @@ def ch_dynamic_env(self):
 
     if not _dynamic_env_data:
         _load_dynamic_env_data(self.bld)
-    self.use += ' ch'
     self.env.append_value('INCLUDES', _dynamic_env_data['include_dirs'])
 
 


### PR DESCRIPTION
Doing `self.use += ' ch'` actually adds the elements ` `, `c`, and `h` since `self.use` is a list and strings are iterable. Adding these elements doesn't accomplish anything since none are the name of a task generator, which is what `self.use` specifies.

However, the function `ch_dynamic_env` is run (roughly) every AP library, so the elements get added hundreds of times. Dealing with searching for the missing generators, the generated internal errors, and the ever-growing list length wastes considerable time in waf's guts.

Deleting the pointless assignment therefore gives a nice speedup.

Timings of CubeOrange copter build:

```
  before, fresh repo: 2m14s
  after,  fresh repo: 1m58s

  before, built repo: 10s
  after,  built repo: 3.6s
```

SITL is only 2.5s on a built repo so there may be more performance to gain.

Confirmed no compiler output change.