### PR TITLE
ardupilotwaf: drop unused dynamic_env functions

### DIFF
--- a/Tools/ardupilotwaf/esp32.py
+++ b/Tools/ardupilotwaf/esp32.py
@@ -25,12 +25,6 @@ import hal_common
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../libraries/AP_HAL_ESP32/hwdef/scripts'))
 import esp32_hwdef  # noqa:501
 
-@feature('esp32_ap_library', 'esp32_ap_program')
-@before_method('process_source')
-def esp32_dynamic_env(self):
-    hal_common.common_dynamic_env(self)
-
-
 def configure(cfg):
     mcu_esp32s3 = True if (cfg.variant[0:7] == "esp32s3") else False
     target = "esp32s3" if mcu_esp32s3 else "esp32"

--- a/Tools/ardupilotwaf/hal_common.py
+++ b/Tools/ardupilotwaf/hal_common.py
@@ -4,8 +4,6 @@ Waf tool for functions common to the esp32, Linux and ChibiOS builds.
 AP_FLAKE8_CLEAN
 """
 
-import sys
-
 
 def load_env_vars(env, hwdef_env, kv_handler=None):
     '''load environment variables from the hwdef generator'''
@@ -33,17 +31,6 @@ def load_env_vars_handle_kv_pair(env, kv_pair):
     else:
         env[k] = v
         print("env set %s=%s" % (k, v))
-
-
-def common_dynamic_env(self):
-    # The generated files from configuration possibly don't exist if it's just
-    # a list command (TODO: figure out a better way to address that).
-    if self.bld.cmd == 'list':
-        return
-
-    def exec_command(self, cmd, **kw):
-        kw['stdout'] = sys.stdout
-        return super(exec_command, self).exec_command(cmd, **kw)
 
 
 def handle_hwdef_files(cfg, hwdef_files):

--- a/Tools/ardupilotwaf/linux.py
+++ b/Tools/ardupilotwaf/linux.py
@@ -6,7 +6,7 @@ Waf tool for Linux build
 AP_FLAKE8_CLEAN
 """
 
-from waflib.TaskGen import after_method, before_method, feature
+from waflib.TaskGen import after_method, feature
 
 import os
 import sys
@@ -16,12 +16,6 @@ import hal_common
 
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../libraries/AP_HAL_Linux/hwdef/scripts'))
 import linux_hwdef  # noqa:501
-
-
-@feature('linux_ap_library', 'linux_ap_program')
-@before_method('process_source')
-def linux_dynamic_env(self):
-    hal_common.common_dynamic_env(self)
 
 
 @feature('linux_ap_program')


### PR DESCRIPTION
These are called automatically by waf, but the only thing they do is define a function which would probably crash if called (`super` being used on a function instead of a class), then (fortunately) not call it. No need to keep that sort of stuff around.

Confirmed no compiler output change for an arbitrary linux and esp32 board.