### PR TITLE
Tools: get Linux and ESP32 board names dynamically for bootloader blacklist

### DIFF
--- a/Tools/scripts/board_list.py
+++ b/Tools/scripts/board_list.py
@@ -17,6 +17,7 @@ class Board(object):
         self.name = name
         self.is_ap_periph = False
         self.toolchain = 'arm-none-eabi'  # FIXME: try to remove this?
+        self.hal = None  # filled in below
         self.autobuild_targets = [
             'Tracker',
             'Blimp',
@@ -82,6 +83,8 @@ class BoardList(object):
             Board("SITL_x86_64_linux_gnu"),
             Board("SITL_arm_linux_gnueabihf"),
         ]
+        for b in self.boards:
+            b.hal = "AP_HAL_SITL"
 
         for hwdef_dir in self.hwdef_dir:
             self.add_hwdefs_from_hwdef_dir(hwdef_dir)
@@ -140,7 +143,16 @@ class BoardList(object):
                 elif "ESP32" in hwdef_dir:
                     board.toolchain = 'xtensa-esp32-elf'
                 else:
-                    raise ValueError(f"Unable to determine toolchain for {adir}")
+                    raise ValueError(f"Unable to determine toolchain for {hwdef_dir}")
+
+            if "Linux" in hwdef_dir:
+                board.hal = "Linux"
+            elif "ChibiOS" in hwdef_dir:
+                board.hal = "ChibiOS"
+            elif "ESP32" in hwdef_dir:
+                board.hal = "ESP32"
+            else:
+                raise ValueError(f"Unable to determine HAL for {hwdef_dir}")
 
     def read_hwdef(self, filepath):
         fh = open(filepath)

--- a/Tools/scripts/size_compare_branches.py
+++ b/Tools/scripts/size_compare_branches.py
@@ -179,6 +179,7 @@ class SizeCompareBranches(object):
             'Pixhawk1-1M-bdshot',
             'Pixhawk1-bdshot',
             'SITL_arm_linux_gnueabihf',
+            'SITL_x86_64_linux_gnu',
             'RADIX2HD',
             'canzero',
             't3-gem-o1',
@@ -209,57 +210,10 @@ class SizeCompareBranches(object):
             'MatekL431-Serial',  # uses USE_BOOTLOADER_FROM_BOARD
         ])
 
-        # blacklist all linux boards for bootloader build:
-        self.bootloader_blacklist.update(self.linux_board_names())
-        # ... and esp32 boards:
-        self.bootloader_blacklist.update(self.esp32_board_names())
-
-    def linux_board_names(self):
-        '''return a list of all Linux board names; FIXME: get this dynamically'''
-        # grep 'class.*[(]linux' Tools/ardupilotwaf/boards.py  | perl -pe "s/class (.*)\(linux\).*/            '\\1',/"
-        return [
-            'navigator',
-            'navigator64',
-            'erleboard',
-            'navio',
-            'navio2',
-            'edge',
-            'zynq',
-            'ocpoc_zynq',
-            'bbbmini',
-            'blue',
-            'pocket',
-            'pocket2',
-            'pxf',
-            'bebop',
-            'vnav',
-            'disco',
-            'erlebrain2',
-            'bhat',
-            'dark',
-            'pxfmini',
-            'aero',
-            'rst_zynq',
-            'obal',
-            'SITL_x86_64_linux_gnu',
-            'canzero',
-            't3-gem-o1',
-            'linux',
-            'pilotpi',
-        ]
-
-    def esp32_board_names(self):
-        return [
-            'esp32buzz',
-            'esp32empty',
-            'esp32tomte76',
-            'esp32nick',
-            'esp32s3devkit',
-            'esp32s3empty',
-            'esp32s3m5stampfly',
-            'esp32icarous',
-            'esp32diy',
-        ]
+        for board_name in self.board:
+            board = self.boards_by_name[board_name]
+            if board.hal in ["Linux", "ESP32"]:
+                self.bootloader_blacklist.add(board.name)
 
     def find_bin_dir(self, toolchain_prefix="arm-none-eabi-"):
         '''attempt to find where the arm-none-eabi tools are'''


### PR DESCRIPTION
I'm not entirely happy with the way this is plumbed at the moment, but it is certainly better than the static lists which we forget to update all the time!
