### PR TITLE
fix: `sim_vehicle.py`'s `under_vagrant` util doesn't appropriately check whether the script is run in a Vagrant VM

### DIFF
--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -191,7 +191,7 @@ def under_macos():
 
 
 def under_vagrant():
-    return os.path.isfile("/ardupilot.vagrant")
+    return os.path.isdir("/vagrant")
 
 
 def under_wsl2():


### PR DESCRIPTION
Within the spun up Vagrant VM, in a Python REPL, the current implementation evals to False
```
vagrant@ubuntu-jammy:~$ python
Python 3.10.12 (main, Aug 15 2025, 14:32:43) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> print(os.path.isfile("/ardupilot.vagrant"))
False
```
... with the suggested change
```
>>> os.path.isdir("/vagrant")
True
```