### PR TITLE
DDS: Add odometry topic

### DIFF
--- a/libraries/AP_DDS/AP_DDS_Client.h
+++ b/libraries/AP_DDS/AP_DDS_Client.h
@@ -54,6 +54,9 @@
 #include "rosgraph_msgs/msg/Clock.h"
 #endif // AP_DDS_CLOCK_PUB_ENABLED
 #if AP_DDS_PARAMETER_SERVER_ENABLED
+#if AP_DDS_ODOM_PUB_ENABLED
+#include "nav_msgs/msg/Odometry.h"
+#endif // AP_DDS_ODOM_PUB_ENABLED
 #include "rcl_interfaces/srv/SetParameters.h"
 #include "rcl_interfaces/msg/Parameter.h"
 #include "rcl_interfaces/msg/SetParametersResult.h"
@@ -228,6 +231,15 @@ private:
     void write_static_transforms();
     static void populate_static_transforms(tf2_msgs_msg_TFMessage& msg);
 #endif // AP_DDS_STATIC_TF_PUB_ENABLED
+
+#if AP_DDS_ODOM_PUB_ENABLED
+    nav_msgs_msg_Odometry odom_topic;
+    // The last ms timestamp AP_DDS wrote an Odometry message
+    uint64_t last_odom_time_ms;
+    bool update_topic(nav_msgs_msg_Odometry& msg);
+    //! @brief Serialize the current Odometry data and publish to the IO stream(s)
+    void write_odom_topic();
+#endif // AP_DDS_ODOM_PUB_ENABLED
 
 #if AP_DDS_JOY_SUB_ENABLED
     // incoming joystick data

--- a/libraries/AP_DDS/AP_DDS_Frames.h
+++ b/libraries/AP_DDS/AP_DDS_Frames.h
@@ -6,3 +6,5 @@ static constexpr char BASE_LINK_FRAME_ID[] = "base_link";
 static constexpr char BASE_LINK_NED_FRAME_ID[] = "base_link_ned";
 // https://www.ros.org/reps/rep-0105.html#map
 static constexpr char MAP_FRAME[] = "map";
+// https://www.ros.org/reps/rep-0105.html#odom
+static constexpr char ODOM_FRAME[] = "odom";

--- a/libraries/AP_DDS/AP_DDS_Topic_Table.h
+++ b/libraries/AP_DDS/AP_DDS_Topic_Table.h
@@ -69,6 +69,9 @@ enum class TopicIndex: uint8_t {
 #if AP_DDS_GLOBAL_POS_CTRL_ENABLED
     GLOBAL_POSITION_SUB,
 #endif // AP_DDS_GLOBAL_POS_CTRL_ENABLED
+#if AP_DDS_ODOM_PUB_ENABLED
+    ODOM_PUB,
+#endif // AP_DDS_ODOM_PUB_ENABLED
 };
 
 static inline constexpr uint8_t to_underlying(const TopicIndex index)
@@ -403,4 +406,22 @@ constexpr struct AP_DDS_Client::Topic_table AP_DDS_Client::topics[] = {
         },
     },
 #endif // AP_DDS_GLOBAL_POS_CTRL_ENABLED
+#if AP_DDS_ODOM_PUB_ENABLED
+    {
+        .topic_id = to_underlying(TopicIndex::ODOM_PUB),
+        .pub_id = to_underlying(TopicIndex::ODOM_PUB),
+        .sub_id = to_underlying(TopicIndex::ODOM_PUB),
+        .dw_id = uxrObjectId{.id=to_underlying(TopicIndex::ODOM_PUB), .type=UXR_DATAWRITER_ID},
+        .dr_id = uxrObjectId{.id=to_underlying(TopicIndex::ODOM_PUB), .type=UXR_DATAREADER_ID},
+        .topic_rw = Topic_rw::DataWriter,
+        .topic_name = "rt/ap/odometry",
+        .type_name = "nav_msgs::msg::dds_::Odometry_",
+        .qos = {
+            .durability = UXR_DURABILITY_VOLATILE,
+            .reliability = UXR_RELIABILITY_BEST_EFFORT,
+            .history = UXR_HISTORY_KEEP_LAST,
+            .depth = 5,
+        },
+    },
+#endif // AP_DDS_ODOM_PUB_ENABLED
 };

--- a/libraries/AP_DDS/AP_DDS_config.h
+++ b/libraries/AP_DDS/AP_DDS_config.h
@@ -165,6 +165,14 @@
 #define AP_DDS_ARM_CHECK_SERVER_ENABLED 1
 #endif
 
+#ifndef AP_DDS_ODOM_PUB_ENABLED
+#define AP_DDS_ODOM_PUB_ENABLED 1
+#endif
+
+#ifndef AP_DDS_DELAY_ODOM_TOPIC_MS
+#define AP_DDS_DELAY_ODOM_TOPIC_MS 33
+#endif
+
 // Whether to include Twist support
 #define AP_DDS_NEEDS_TWIST AP_DDS_VEL_CTRL_ENABLED || AP_DDS_LOCAL_VEL_PUB_ENABLED
 

--- a/libraries/AP_DDS/Idl/geometry_msgs/msg/PoseWithCovariance.idl
+++ b/libraries/AP_DDS/Idl/geometry_msgs/msg/PoseWithCovariance.idl
@@ -1,0 +1,23 @@
+// generated from rosidl_adapter/resource/msg.idl.em
+// with input from geometry_msgs/msg/PoseWithCovariance.msg
+// generated code does not contain a copyright notice
+
+#include "geometry_msgs/msg/Pose.idl"
+
+module geometry_msgs {
+  module msg {
+    typedef double double__36[36];
+    @verbatim (language="comment", text=
+      "This represents a pose in free space with uncertainty.")
+    struct PoseWithCovariance {
+      geometry_msgs::msg::Pose pose;
+
+      @verbatim (language="comment", text=
+        "Row-major representation of the 6x6 covariance matrix" "\n"
+        "The orientation parameters use a fixed-axis representation." "\n"
+        "In order, the parameters are:" "\n"
+        "(x, y, z, rotation about X axis, rotation about Y axis, rotation about Z axis)")
+      double__36 covariance;
+    };
+  };
+};

--- a/libraries/AP_DDS/Idl/geometry_msgs/msg/TwistWithCovariance.idl
+++ b/libraries/AP_DDS/Idl/geometry_msgs/msg/TwistWithCovariance.idl
@@ -1,0 +1,22 @@
+// generated from rosidl_adapter/resource/msg.idl.em
+// with input from geometry_msgs/msg/TwistWithCovariance.msg
+// generated code does not contain a copyright notice
+#include "geometry_msgs/msg/Twist.idl"
+
+module geometry_msgs {
+  module msg {
+    typedef double doubl__36[36];
+    @verbatim (language="comment", text=
+      "This expresses velocity in free space with uncertainty.")
+    struct TwistWithCovariance {
+      geometry_msgs::msg::Twist twist;
+
+      @verbatim (language="comment", text=
+        "Row-major representation of the 6x6 covariance matrix" "\n"
+        "The orientation parameters use a fixed-axis representation." "\n"
+        "In order, the parameters are:" "\n"
+        "(x, y, z, rotation about X axis, rotation about Y axis, rotation about Z axis)")
+      doubl__36 covariance;
+    };
+  };
+};

--- a/libraries/AP_DDS/Idl/nav_msgs/msg/Odometry.idl
+++ b/libraries/AP_DDS/Idl/nav_msgs/msg/Odometry.idl
@@ -1,0 +1,33 @@
+// generated from rosidl_adapter/resource/msg.idl.em
+// with input from nav_msgs/msg/Odometry.msg
+// generated code does not contain a copyright notice
+
+#include "geometry_msgs/msg/PoseWithCovariance.idl"
+#include "geometry_msgs/msg/TwistWithCovariance.idl"
+#include "std_msgs/msg/Header.idl"
+
+module nav_msgs {
+  module msg {
+    @verbatim (language="comment", text=
+      "This represents an estimate of a position and velocity in free space." "\n"
+      "The pose in this message should be specified in the coordinate frame given by header.frame_id" "\n"
+      "The twist in this message should be specified in the coordinate frame given by the child_frame_id")
+    struct Odometry {
+      @verbatim (language="comment", text=
+        "Includes the frame id of the pose parent.")
+      std_msgs::msg::Header header;
+
+      @verbatim (language="comment", text=
+        "Frame id the pose points to. The twist is in this coordinate frame.")
+      string child_frame_id;
+
+      @verbatim (language="comment", text=
+        "Estimated pose that is typically relative to a fixed world frame.")
+      geometry_msgs::msg::PoseWithCovariance pose;
+
+      @verbatim (language="comment", text=
+        "Estimated linear and angular velocity relative to child_frame_id.")
+      geometry_msgs::msg::TwistWithCovariance twist;
+    };
+  };
+};

--- a/libraries/AP_DDS/README.md
+++ b/libraries/AP_DDS/README.md
@@ -166,6 +166,7 @@ Published topics:
  * /ap/tf_static [tf2_msgs/msg/TFMessage] 1 publisher
  * /ap/time [builtin_interfaces/msg/Time] 1 publisher
  * /ap/twist/filtered [geometry_msgs/msg/TwistStamped] 1 publisher
+ * /ap/odometry [nav_msgs/msg/Odometry] 1 publisher
  * /parameter_events [rcl_interfaces/msg/ParameterEvent] 1 publisher
  * /rosout [rcl_interfaces/msg/Log] 1 publisher
 


### PR DESCRIPTION
This adds a ``/ap/odometry`` topic to the DDS interface. It is in the ``odom`` frame.

The odometry is relative to the EKF origin and is published at 30Hz. The odometry is not published until the AHRS is active.

I still need to figure out how to handle large EKF jumps, as other parts of ROS2 does not handle the jumps well (they assume no large jumps in the odometry).

Of particular note is the check for ``ahrs.initialised()`` to determine if we should send the odometry messages. This needs to be changed to the check that triggers the ``AP: AHRS: EKF3 active`` message (once I find it).