### PR TITLE
Tools: remove absolute path reference to `rm` command

### DIFF
--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -404,7 +404,7 @@ def run_specific_test(step, *args, **kwargs):
 def run_step(step):
     """Run one step."""
     # remove old logs
-    util.run_cmd('/bin/rm -f logs/*.BIN logs/LASTLOG.TXT')
+    util.run_cmd('rm -f logs/*.BIN logs/LASTLOG.TXT')
 
     if step == "prerequisites":
         return test_prerequisites()

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -8989,11 +8989,11 @@ Also, ignores heartbeats not from our target system'''
         return glob.glob("logs/*.BIN")
 
     def remove_bin_logs(self):
-        util.run_cmd('/bin/rm -f logs/*.BIN logs/LASTLOG.TXT')
+        util.run_cmd('rm -f logs/*.BIN logs/LASTLOG.TXT')
 
     def remove_ardupilot_terrain_cache(self):
         '''removes the terrain files ArduPilot keeps in its onboiard storage'''
-        util.run_cmd('/bin/rm -f %s' % util.reltopdir("terrain/*.DAT"))
+        util.run_cmd('rm -f %s' % util.reltopdir("terrain/*.DAT"))
 
     def check_logs(self, name):
         '''called to move relevant log files from our working directory to the

--- a/Tools/scripts/build_autotest.sh
+++ b/Tools/scripts/build_autotest.sh
@@ -36,7 +36,7 @@ lock_file() {
 	    }
             return 1
         fi
-        /bin/rm -f "$lck"
+        rm -f "$lck"
         echo "$$" > "$lck"
         return 0
 }

--- a/Tools/scripts/dumpcore.sh
+++ b/Tools/scripts/dumpcore.sh
@@ -14,4 +14,4 @@ generate-core-file $COREFILE
 quit
 EOF
 gdb -n -batch -x $TMPFILE --pid $PID < /dev/null 2>&1
-/bin/rm -f $TMPFILE
+rm -f $TMPFILE

--- a/Tools/scripts/dumpstack.sh
+++ b/Tools/scripts/dumpstack.sh
@@ -12,4 +12,4 @@ thread apply all bt full
 quit
 EOF
 gdb -n -batch -x $TMPFILE --pid $PID < /dev/null 2>&1
-/bin/rm -f $TMPFILE
+rm -f $TMPFILE


### PR DESCRIPTION
On some systems (e.g. NixOS) it's not there.