### PR TITLE
AP_HAL_SITL:MAC OS add custom serial baud support

### DIFF
--- a/libraries/AP_HAL_SITL/UART_utils.cpp
+++ b/libraries/AP_HAL_SITL/UART_utils.cpp
@@ -25,6 +25,9 @@
 
 #ifdef USE_TERMIOS
 #include <termios.h>
+#if defined(__APPLE__)
+#include <IOKit/serial/ioss.h>
+#endif
 #else
 #include <asm/ioctls.h>
 #include <asm/termbits.h>
@@ -41,10 +44,16 @@ bool HALSITL::UARTDriver::set_speed(int speed) const
         return false;
     }
 #ifdef USE_TERMIOS
+#if defined(__APPLE__)
+    if (ioctl(_fd, IOSSIOSPEED, &speed) == -1) {
+        return false;
+    }
+#else
     struct termios t;
     tcgetattr(_fd, &t);
     cfsetspeed(&t, speed);
     tcsetattr(_fd, TCSANOW, &t);
+#endif
 #else
     struct termios2 tc;
     memset(&tc, 0, sizeof(tc));


### PR DESCRIPTION
mac does not support full TERMIOS features, use IOKit to support custom serial baud
Tested on CP2102
Noticed some FTDI chip not support custom baud