### PR TITLE
Constrain and check Acro Balance parameters

### DIFF
--- a/ArduCopter/AP_Arming_Copter.cpp
+++ b/ArduCopter/AP_Arming_Copter.cpp
@@ -226,7 +226,9 @@ bool AP_Arming_Copter::parameter_checks(bool display_failure)
 
         // acro balance parameter check
 #if MODE_ACRO_ENABLED || MODE_SPORT_ENABLED
-        if ((copter.g.acro_balance_roll > copter.attitude_control->get_angle_roll_p().kP()) || (copter.g.acro_balance_pitch > copter.attitude_control->get_angle_pitch_p().kP())) {
+        if (is_negative(copter.g.acro_balance_roll) || is_negative(copter.g.acro_balance_pitch) ||
+            (copter.g.acro_balance_roll > copter.attitude_control->get_angle_roll_p().kP()) || 
+            (copter.g.acro_balance_pitch > copter.attitude_control->get_angle_pitch_p().kP())) {
             check_failed(Check::PARAMETERS, display_failure, "Check ACRO_BAL_ROLL/PITCH");
             return false;
         }


### PR DESCRIPTION
This PR Fixed #30152.
Adds pre-arm check to make sure they are positive.
Pilot must input negative, out of range, parameters and turn off arming checks.

```
Board,blimp,bootloader,copter,heli,plane,rover,sub
CubeOrange,*,*,24,24,*,*,*
```



