### PR TITLE
AP_Stats: correct compilation when AP_AHRS is not enabled

### DIFF
--- a/libraries/AP_Stats/AP_Stats.cpp
+++ b/libraries/AP_Stats/AP_Stats.cpp
@@ -117,7 +117,9 @@ void AP_Stats::update()
 {
     WITH_SEMAPHORE(sem);
     const uint32_t now_ms = AP_HAL::millis();
+#if AP_AHRS_ENABLED
     update_distance_flown();
+#endif  // AP_AHRS_ENABLED
     if (now_ms -  last_flush_ms > flush_interval_ms) {
         update_flighttime();
         update_runtime();
@@ -170,6 +172,7 @@ void AP_Stats::set_flying(const bool is_flying)
     }
 }
 
+#if AP_AHRS_ENABLED
 void AP_Stats::update_distance_flown()
 {
     if (!_flying_ms) {
@@ -214,6 +217,7 @@ void AP_Stats::update_distance_flown()
     _last_position = current_loc;
     _last_position_valid = true;
 }
+#endif  // AP_AHRS_ENABLED
 
 /*
   get time in flight since boot


### PR DESCRIPTION
CarbonixF405 peripheral uses this library but not AP_AHRS


```
/home/pbarker/gcc/gcc-arm-none-eabi-10-2020-q4-major/bin/../lib/gcc/arm-none-eabi/10.2.1/../../../../arm-none-eabi/bin/ld: lib/libAP_Periph_libs.a(AP_Stats.cpp.0.o): in function `AP_Stats::update_distance_flown()':
AP_Stats.cpp:(.text._ZN8AP_Stats21update_distance_flownEv+0x28): undefined reference to `AP::ahrs()'
/home/pbarker/gcc/gcc-arm-none-eabi-10-2020-q4-major/bin/../lib/gcc/arm-none-eabi/10.2.1/../../../../arm-none-eabi/bin/ld: AP_Stats.cpp:(.text._ZN8AP_Stats21update_distance_flownEv+0x2e): undefined reference to `AP_AHRS::healthy() const'
/home/pbarker/gcc/gcc-arm-none-eabi-10-2020-q4-major/bin/../lib/gcc/arm-none-eabi/10.2.1/../../../../arm-none-eabi/bin/ld: AP_Stats.cpp:(.text._ZN8AP_Stats21update_distance_flownEv+0x42): undefined reference to `AP_AHRS::get_location(Location&) const'
collect2: error: ld returned 1 exit status
```
