### PR TITLE
RC_Channel: Change the minimum timeout value

### DIFF
--- a/libraries/RC_Channel/RC_Channels_VarInfo.h
+++ b/libraries/RC_Channel/RC_Channels_VarInfo.h
@@ -108,7 +108,7 @@ const AP_Param::GroupInfo RC_Channels::var_info[] = {
     // @DisplayName: RC Failsafe timeout
     // @Description: RC failsafe will trigger this many seconds after loss of RC
     // @User: Standard
-    // @Range: 0.5 10.0
+    // @Range: 0.1 10.0
     // @Units: s
     AP_GROUPINFO_FRAME("_FS_TIMEOUT", 35, RC_CHANNELS_SUBCLASS, _fs_timeout, 1.0, AP_PARAM_FRAME_COPTER),
 


### PR DESCRIPTION
In the following line, the minimum value is set to 100 milliseconds.
I will change it to 100 milliseconds.

https://github.com/ArduPilot/ardupilot/blob/master/libraries/RC_Channel/RC_Channel.h#L750