### PR TITLE
Copter: toymode: correct check for wifi reset

### DIFF
--- a/ArduCopter/toy_mode.cpp
+++ b/ArduCopter/toy_mode.cpp
@@ -291,7 +291,7 @@ void ToyMode::update()
     }
 
     bool reset_combination = left_action_button && right_action_button;
-    if (reset_combination && abs(copter.ahrs.roll_sensor) > 160) {
+    if (reset_combination && fabsf(copter.ahrs.get_roll_deg()) > 160) {
         /*
           if both shoulder buttons are pressed at the same time for 5
           seconds while the vehicle is inverted then we send a


### PR DESCRIPTION
centidegree vs degree mixup

This is by inspection only.  But 160 cd can't be right, and the description says "inverted".

Net effect of this is that any holding down of the two buttons at the same time is likely to reset the wifi information.
