### PR TITLE
Respect mavlink loiter radius in LOITER_TIME

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -973,7 +973,7 @@ private:
     void do_RTL(int32_t alt);
     bool verify_takeoff();
     bool verify_loiter_unlim(const AP_Mission::Mission_Command &cmd);
-    bool verify_loiter_time();
+    bool verify_loiter_time(const AP_Mission::Mission_Command &cmd);
     bool verify_loiter_turns(const AP_Mission::Mission_Command &cmd);
     bool verify_loiter_to_alt(const AP_Mission::Mission_Command &cmd);
     bool verify_continue_and_change_alt();

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -263,7 +263,7 @@ bool Plane::verify_command(const AP_Mission::Mission_Command& cmd)        // Ret
         return verify_loiter_turns(cmd);
 
     case MAV_CMD_NAV_LOITER_TIME:
-        return verify_loiter_time();
+        return verify_loiter_time(cmd);
 
     case MAV_CMD_NAV_LOITER_TO_ALT:
         return verify_loiter_to_alt(cmd);
@@ -481,7 +481,7 @@ void Plane::do_loiter_time(const AP_Mission::Mission_Command& cmd)
     loiter_set_direction_wp(cmd);
 
     // we set start_time_ms when we reach the waypoint
-    loiter.time_max_ms = cmd.p1 * (uint32_t)1000;     // convert sec to ms
+    loiter.time_max_ms = cmd.get_loiter_time_sec() * (uint32_t)1000;     // convert sec to ms
     condition_value = 1; // used to signify primary time goal not yet met
 }
 
@@ -703,11 +703,11 @@ bool Plane::verify_loiter_unlim(const AP_Mission::Mission_Command &cmd)
     return false;
 }
 
-bool Plane::verify_loiter_time()
+bool Plane::verify_loiter_time(const AP_Mission::Mission_Command &cmd)
 {
     bool result = false;
-    // mission radius is always aparm.loiter_radius
-    update_loiter(0);
+    // use radius from packed p1, or default to aparm.loiter_radius if 0
+    update_loiter(cmd.get_loiter_time_radius());
 
     if (loiter.start_time_ms == 0) {
         if (reached_loiter_target() && loiter.sum_cd > 1) {

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -435,6 +435,32 @@ public:
             }
             return turns;
         }
+
+        /*
+          return the loiter time in seconds for a LOITER_TIME command
+          this has special handling for times > 255 seconds from cmd.p1 and type_specific_bits
+         */
+        float get_loiter_time_sec(void) const {
+            float time_sec = LOWBYTE(p1);
+            if (type_specific_bits & (1U<<2)) {
+                // time was stored divided by 4
+                time_sec *= 4.0;
+            }
+            return time_sec;
+        }
+
+        /*
+          return the loiter radius for a LOITER_TIME command
+          this has special handling for radius > 255m from cmd.p1 and type_specific_bits
+         */
+        float get_loiter_time_radius(void) const {
+            float radius = HIGHBYTE(p1);
+            if (type_specific_bits & (1U<<0)) {
+                // radius was stored divided by 10
+                radius *= 10.0;
+            }
+            return radius;
+        }
     };
 
 


### PR DESCRIPTION
Previously, the default `WP_LOITER_RAD` param was used, and the radius provided in `MAV_CMD_NAV_LOITER_TIME` was ignored.

Fixes https://github.com/ArduPilot/ardupilot/issues/28451