### PR TITLE
AP_Scripting: Add WheelEncoder bindings

### DIFF
--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1733,6 +1733,24 @@ function mavlink_video_stream_information_t_ud:encoding(value) end
 function camera:set_stream_information(instance, stream_info) end
 
 -- desc
+wheel_encoder = {}
+
+-- desc
+---@param instance integer
+---@return number
+function wheel_encoder:get_delta_angle(instance) end
+
+-- desc
+---@param instance integer
+---@return number
+function wheel_encoder:get_distance(instance) end
+
+-- desc
+---@param instance integer
+---@return number
+function wheel_encoder:get_rate(instance) end
+
+-- desc
 mount = {}
 
 -- desc
@@ -4340,4 +4358,3 @@ function DroneCAN_Handle_ud:request(target_node, payload) end
 ---@param payload string -- payload for message
 ---@return boolean -- true if send succeeded
 function DroneCAN_Handle_ud:broadcast(payload) end
-

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -839,6 +839,13 @@ include APM_Control/AR_AttitudeControl.h depends APM_BUILD_TYPE(APM_BUILD_Rover)
 singleton AR_AttitudeControl depends APM_BUILD_TYPE(APM_BUILD_Rover)
 singleton AR_AttitudeControl method get_srate void float'Ref float'Ref
 
+include AP_WheelEncoder/AP_WheelEncoder.h depends APM_BUILD_TYPE(APM_BUILD_Rover)
+singleton AP_WheelEncoder depends APM_BUILD_TYPE(APM_BUILD_Rover)
+singleton AP_WheelEncoder rename wheel_encoder
+singleton AP_WheelEncoder method get_delta_angle float uint8_t 0 WHEELENCODER_MAX_INSTANCES
+singleton AP_WheelEncoder method get_distance float uint8_t 0 WHEELENCODER_MAX_INSTANCES
+singleton AP_WheelEncoder method get_rate float uint8_t 0 WHEELENCODER_MAX_INSTANCES
+
 include AP_Mount/AP_Mount.h
 singleton AP_Mount depends HAL_MOUNT_ENABLED == 1
 singleton AP_Mount rename mount
@@ -1141,4 +1148,3 @@ userdata DroneCAN_Handle manual request DroneCAN_Handle::request 2 1
 userdata DroneCAN_Handle method subscribe boolean
 userdata DroneCAN_Handle manual check_message DroneCAN_Handle::check_message 0 4
 userdata DroneCAN_Handle manual_operator __gc DroneCAN_Handle::__gc
-


### PR DESCRIPTION
Add bindings for AP_WheelEncoder to the Lua bindings and docs.

These have been tested in the Rover SITL and using an mRoControlZero flight controller using [HEDS-5540](https://www.mouser.com/ProductDetail/630-HEDS-5540-C11) quadrature encoders.