### PR TITLE
.github: hack ros2 launch library to not hide exceptions

### DIFF
--- a/.github/workflows/colcon.yml
+++ b/.github/workflows/colcon.yml
@@ -203,6 +203,9 @@ jobs:
       - name: Test with colcon
         shell: 'bash'
         run: |
+          # force on debugging so we can see ros2 launch internal errors
+          sed -i'' "s|debug: bool = False|debug: bool = True|g" /opt/ros/humble/lib/python3.10/site-packages/launch/launch_service.py
+
           source install/setup.bash
           colcon test --python-testing "pytest" --pytest-args " --verbose" " --stepwise" --executor sequential --parallel-workers 0 --base-paths src/ardupilot --event-handlers=console_cohesion+
       - name: Report colcon test results


### PR DESCRIPTION
Reveal the true cause for most of our colcon failures by no longer redirecting the exception to `/dev/null`.

The test harness tolerates failures in our processes during shutdown (which cause most of the printed error messages), but can throw internal errors which cause `AssertionError: When running test <x> launch service failed when finishing, return code '1'` in `finalize_launch_service`.

By default it just discards the actual exception with the helpful message `Error: [launch]: Caught exception in launch (see debug for traceback)`. Edit the source code to default debug mode to on so the exception is printed and we can see what is actually going on. Sadly, there appears to be no more sensible approach.

This shows that we need https://github.com/ros2/launch/commit/801d7cda05a87a74d59cb3d4752307d001956584 which we should get if we update the Docker images.

There are still some failures due to startup errors on ArduPilot's side but this cause appears to be the majority of them. And if there are other sources of this exception the traceback will enable us to see them.