### PR TITLE
AP_ExternalAHRS: Prevent EAHR logging when EAHRS_TYPE is set to None

### DIFF
--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS.cpp
@@ -401,7 +401,7 @@ void AP_ExternalAHRS::update(void)
     WITH_SEMAPHORE(state.sem);
 #if HAL_LOGGING_ENABLED
     const uint32_t now_ms = AP_HAL::millis();
-    if (log_rate.get() > 0 && now_ms - last_log_ms >= uint32_t(1000U/log_rate.get())) {
+    if (enabled() && log_rate.get() > 0 && now_ms - last_log_ms >= uint32_t(1000U/log_rate.get())) {
         last_log_ms = now_ms;
 
         // @LoggerMessage: EAHR


### PR DESCRIPTION
When EAHRS_TYPE is set to None, the system was still generating EAHR and EAHV log messages even though no external AHRS device was active.

This patch adds an enabled() condition to AP_ExternalAHRS::update(), ensuring that external AHRS logs are only written when a valid backend is active and EAHRS_TYPE is not None.

This prevents meaningless log entries and reduces unnecessary log size.

<img width="1850" height="1053" alt="Screenshot from 2025-11-10 06-13-13" src="https://github.com/user-attachments/assets/174f6ec5-c2f3-4cf9-819f-ebb7291fe3f0" />
