### PR TITLE
AC_PrecLand: Copter uses PLND_ORIENT

### DIFF
--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -181,13 +181,13 @@ const AP_Param::GroupInfo AC_PrecLand::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("OPTIONS", 17, AC_PrecLand, _options, 0),
 
-    // @Param{Rover}: ORIENT
+    // @Param{Rover,Copter}: ORIENT
     // @DisplayName: Camera Orientation
     // @Description: Orientation of camera/sensor on body
     // @Values: 0:Forward, 4:Back, 25:Down
     // @User: Advanced
     // @RebootRequired: True
-    AP_GROUPINFO_FRAME("ORIENT", 18, AC_PrecLand, _orient, AC_PRECLAND_ORIENT_DEFAULT, AP_PARAM_FRAME_ROVER),
+    AP_GROUPINFO_FRAME("ORIENT", 18, AC_PrecLand, _orient, AC_PRECLAND_ORIENT_DEFAULT, AP_PARAM_FRAME_ROVER | AP_PARAM_FRAME_COPTER | AP_PARAM_FRAME_TRICOPTER | AP_PARAM_FRAME_HELI), 
 
     AP_GROUPEND
 };


### PR DESCRIPTION
I believe this is an oversight from the review of PR #31474.

Coper:
https://ardupilot.org/copter/docs/precision-landing-and-loiter.html#quick-start


AFTER
<img width="1850" height="1053" alt="Screenshot from 2025-11-11 01-48-33" src="https://github.com/user-attachments/assets/4cbe358b-a606-4c88-afbb-089761703070" />

BEFORE
<img width="1407" height="807" alt="Screenshot from 2025-11-11 01-29-28" src="https://github.com/user-attachments/assets/5a2bada3-0990-4652-9969-ca67af742b62" />
