### PR TITLE
Tools: fix type hints in param_check

### DIFF
--- a/Tools/scripts/param_check.py
+++ b/Tools/scripts/param_check.py
@@ -29,6 +29,7 @@ AP_FLAKE8_CLEAN
 
 """
 
+from __future__ import annotations
 import os
 import json
 import re
@@ -80,7 +81,7 @@ def parse_arguments():
     return args
 
 
-def check_file(file, metadata, skip : SkippedChecks = None):
+def check_file(file, metadata, skip: SkippedChecks | None = None):
     """Checks a single parameter file against the metadata.
 
     Loads the parameters from the specified file and validates each parameter
@@ -129,7 +130,7 @@ def check_file(file, metadata, skip : SkippedChecks = None):
     return msgs
 
 
-def check_param(name, value, metadata, skip : SkippedChecks = None):
+def check_param(name, value, metadata, skip: SkippedChecks | None = None):
     """Checks a single parameter against its metadata definition.
 
     Validates the specified parameter. If the metadata contains multiple types
@@ -264,7 +265,7 @@ def check_values(name, value, metadata):
     return None
 
 
-def load_params(file, skip : SkippedChecks = None, depth=0):
+def load_params(file, skip: SkippedChecks | None = None, depth=0):
     """Loads a parameter file and returns parameters and errors.
 
     Reads the specified parameter file, stripping out comments. It checks the
@@ -484,7 +485,7 @@ def main():
     metadata = get_metadata(args.vehicle.split(','))
 
     # Dictionary to store error messages for each file
-    messages = {} # {filename: [error messages]}
+    messages = {}  # {filename: [error messages]}
 
     # Check each file, and store any error messages
     for file in args.files:
@@ -507,4 +508,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main() # pragma: no cover
+    main()  # pragma: no cover

--- a/Tools/scripts/param_check_all.py
+++ b/Tools/scripts/param_check_all.py
@@ -6,6 +6,7 @@ Check all default parameter files for all hwdef boards and sitl targets.
 AP_FLAKE8_CLEAN
 '''
 
+from __future__ import annotations
 import os
 import sys
 import glob
@@ -13,17 +14,17 @@ from board_list import BoardList
 from param_check import get_metadata, check_file, SkippedChecks
 
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../Tools', 'autotest'))
-from pysim.vehicleinfo import VehicleInfo # noqa: E402
+from pysim.vehicleinfo import VehicleInfo  # noqa: E402
 
 
-periph_hwdefs_to_skip = set([ # Most of these fail due to NET_ params
+periph_hwdefs_to_skip = set([  # Most of these fail due to NET_ params
     'BotBloxDroneNet',
     'CubeNode-ETH',
     'CubeRedPrimary-PPPGW',
-    'MatekG474-Periph', # Fails for RC_PORT
+    'MatekG474-Periph',  # Fails for RC_PORT
     'Pixhawk6X-PPPGW',
     'kha_eth',
-    'sw-boom-f407', # Fails for ESC_NUM_POLES*
+    'sw-boom-f407',  # Fails for ESC_NUM_POLES*
 ])
 
 sitl_params_to_skip = set([
@@ -75,7 +76,7 @@ PERIPH_BOARDS = BoardList().find_ap_periph_boards(skip=periph_hwdefs_to_skip)
 ALL_VEHICLE_FIRMWARES = ['Sub', 'Plane', 'Blimp', 'Copter', 'Tracker', 'Rover']
 
 
-def check_boards(boards, firmwares, skip : SkippedChecks = None):
+def check_boards(boards, firmwares, skip: SkippedChecks | None = None):
     '''Check parameter files for ChibiOS hwdef boards.'''
     if skip is None:
         skip = SkippedChecks()
@@ -97,7 +98,7 @@ def check_boards(boards, firmwares, skip : SkippedChecks = None):
     return check_files(param_files, firmwares, skip=skip)
 
 
-def check_sitl(skip : SkippedChecks = None):
+def check_sitl(skip: SkippedChecks | None = None):
     '''Check every parameter file that shows up in vehicleinfo.py
 
     Because this also provides us information about the intended firmware, we
@@ -150,7 +151,7 @@ def check_sitl(skip : SkippedChecks = None):
     return success
 
 
-def check_frame_params(skip : SkippedChecks = None):
+def check_frame_params(skip: SkippedChecks | None = None):
     '''Check all files within Tools/Frame_params
 
     These don't contain any information about firmware (e.g. Copter, Plane,
@@ -177,7 +178,7 @@ def check_frame_params(skip : SkippedChecks = None):
     return check_files(param_files, ALL_VEHICLE_FIRMWARES, skip=skip)
 
 
-def check_files(files, firmwares, skip : SkippedChecks = None):
+def check_files(files, firmwares, skip: SkippedChecks | None = None):
     '''Check a list of parameter files against the metadata'''
     if skip is None:
         skip = SkippedChecks()

--- a/Tools/scripts/param_check_unittests.py
+++ b/Tools/scripts/param_check_unittests.py
@@ -6,6 +6,7 @@ Parameter File Checker Unit Tests
 AP_FLAKE8_CLEAN
 """
 
+from __future__ import annotations
 import os
 import time
 import unittest
@@ -236,7 +237,7 @@ class TestParamCheck(unittest.TestCase):
 
         # Test Bitmask
         del metadata['ReadOnly']  # Remove ReadOnly to test the next priority
-        self.assertIsNone(check_param('PARAM', 256.0, metadata, skip)) # 256 would fail the other checks, but pass bitmask
+        self.assertIsNone(check_param('PARAM', 256.0, metadata, skip))  # 256 would fail the other checks, but pass bitmask
         self.assertEqual(check_param('PARAM', 1.5, metadata, skip), 'PARAM: 1.5 is not an integer')
         self.assertEqual(check_param('PARAM', -1, metadata, skip), 'PARAM: -1 is negative')
         self.assertEqual(
@@ -249,7 +250,7 @@ class TestParamCheck(unittest.TestCase):
 
         # Test Range
         del metadata['Bitmask']  # Remove Bitmask to test the next priority
-        self.assertIsNone(check_param('PARAM', 50, metadata, skip)) # 50 will fail the values check, but pass the range check
+        self.assertIsNone(check_param('PARAM', 50, metadata, skip))  # 50 will fail the values check, but pass the range check
         self.assertEqual(check_param('PARAM', 101, metadata, skip), 'PARAM: 101 is above maximum value 100.0')
         self.assertEqual(check_param('PARAM', -1, metadata, skip), 'PARAM: -1 is below minimum value 0.0')
         skip.no_range = True
@@ -264,7 +265,7 @@ class TestParamCheck(unittest.TestCase):
 
         # Test parameter with no range, bitmask, or value restrictions
         del metadata['Values']
-        self.assertIsNone(check_param('PARAM', 0, metadata, skip)) # Should pass no matter what
+        self.assertIsNone(check_param('PARAM', 0, metadata, skip))  # Should pass no matter what
 
     @patch('param_check.check_param')
     def test_check_file(self, mock_check_param):


### PR DESCRIPTION
Tiny nitpick that I should have caught in an earlier PR. We changed the default to None, but forgot to update the type hints. Not a big deal, and our CI doesn't currently check for that, but figured I'd fix it.