### PR TITLE
ArduPilot-4.6: fix copter's version (was beta, now official)

### DIFF
--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -14,7 +14,7 @@
 #define FW_MAJOR 4
 #define FW_MINOR 6
 #define FW_PATCH 3
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>
 #include <AP_CheckFirmware/AP_CheckFirmwareDefine.h>


### PR DESCRIPTION
This corrects a mistake made during the ArduPilot-4.6.3 release that has left Copter appearing to still be in beta.

While this corrects the mistake, it's not clear to me whether we should just update the Copter/Heli stable release tags or whether we should re-release with a new version number (e.g. 4.6.4)