### PR TITLE
AP_Logger: Deprecate logging without units/scalars

### DIFF
--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -287,10 +287,13 @@ public:
     void Write_SRTL(bool active, uint16_t num_points, uint16_t max_points, uint8_t action, const Vector3f& point);
     void Write_Winch(bool healthy, bool thread_end, bool moving, bool clutch, uint8_t mode, float desired_length, float length, float desired_rate, uint16_t tension, float voltage, int8_t temp);
 
+    //! @deprecated Use the other signature with units and mults
     void Write(const char *name, const char *labels, const char *fmt, ...);
     void Write(const char *name, const char *labels, const char *units, const char *mults, const char *fmt, ...);
+    //! @deprecated Use the other signature with units and mults
     void WriteStreaming(const char *name, const char *labels, const char *fmt, ...);
     void WriteStreaming(const char *name, const char *labels, const char *units, const char *mults, const char *fmt, ...);
+    //! @deprecated Use the other signature with units and mults
     void WriteCritical(const char *name, const char *labels, const char *fmt, ...);
     void WriteCritical(const char *name, const char *labels, const char *units, const char *mults, const char *fmt, ...);
     void WriteV(const char *name, const char *labels, const char *units, const char *mults, const char *fmt, va_list arg_list, bool is_critical=false, bool is_streaming=false);


### PR DESCRIPTION
* This is an editor-friendly deprecation, we aren't going to add a compile time [[deprecated]] warning yet


Example shown in VSCode
<img width="1256" height="536" alt="Screenshot from 2025-11-10 23-46-34" src="https://github.com/user-attachments/assets/5668b26e-353c-48e3-8d1b-71ed7c9e4a2c" />

I wasn't aware we should be using one over the other, inspried from https://github.com/ArduPilot/ardupilot/pull/30232#discussion_r2512083911
