### PR TITLE
AP_Bootloader: Add new revisions of STM32F4xx CPUs

### DIFF
--- a/Tools/AP_Bootloader/mcu_f4.h
+++ b/Tools/AP_Bootloader/mcu_f4.h
@@ -7,11 +7,12 @@
 enum {
     MCU_REV_STM32F4_REV_A = 0x1000,
     MCU_REV_STM32F4_REV_Z = 0x1001,
-    MCU_REV_STM32F4_REV_Y = 0x1003,
-    MCU_REV_STM32F4_REV_1 = 0x1007,
-    MCU_REV_STM32F4_REV_3 = 0x2001
+    MCU_REV_STM32F4_REV_1 = 0x1003,
+    MCU_REV_STM32F4_REV_2 = 0x1007,
+    MCU_REV_STM32F4_REV_3 = 0x2001,
+    MCU_REV_STM32F4_REV_Y = 0x100F,
+    MCU_REV_STM32F4_REV_5 = 0x101F,
 };
-
 
 #define STM32_UNKNOWN	0
 #define STM32F40x_41x	0x413
@@ -29,11 +30,12 @@ const mcu_des_t mcu_descriptions[] = {
 
 const mcu_rev_t silicon_revs[] = {
     {MCU_REV_STM32F4_REV_3, '3'}, /* Revision 3 */
-
     {MCU_REV_STM32F4_REV_A, 'A'}, /* Revision A */
     {MCU_REV_STM32F4_REV_Z, 'Z'}, /* Revision Z */
     {MCU_REV_STM32F4_REV_Y, 'Y'}, /* Revision Y */
     {MCU_REV_STM32F4_REV_1, '1'}, /* Revision 1 */
+    {MCU_REV_STM32F4_REV_2, '2'}, /* Revision 2 */
+    {MCU_REV_STM32F4_REV_5, '5'}, /* Revision 5 */
 };
 
 #endif // STM32F4

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -342,6 +342,8 @@ class Board:
             env.CFLAGS += [
                 '-g',
                 '-O0',
+                '-ggdb3',
+                '-fno-omit-frame-pointer'
             ]
             env.DEFINES.update(
                 HAL_DEBUG_BUILD = 1,

--- a/Tools/scripts/uploader.py
+++ b/Tools/scripts/uploader.py
@@ -820,14 +820,18 @@ class uploader(object):
                 mcu = F4_IDS[family]
                 MCU_REV_STM32F4_REV_A = 0x1000
                 MCU_REV_STM32F4_REV_Z = 0x1001
-                MCU_REV_STM32F4_REV_Y = 0x1003
-                MCU_REV_STM32F4_REV_1 = 0x1007
+                MCU_REV_STM32F4_REV_1 = 0x1003
+                MCU_REV_STM32F4_REV_2 = 0x1007
+                MCU_REV_STM32F4_REV_Y = 0x100F
+                MCU_REV_STM32F4_REV_5 = 0x101F
                 MCU_REV_STM32F4_REV_3 = 0x2001
                 revs = {
                     MCU_REV_STM32F4_REV_A: ("A", True),
                     MCU_REV_STM32F4_REV_Z: ("Z", True),
                     MCU_REV_STM32F4_REV_Y: ("Y", True),
                     MCU_REV_STM32F4_REV_1: ("1", True),
+                    MCU_REV_STM32F4_REV_2: ("2", True),
+                    MCU_REV_STM32F4_REV_5: ("5", True),
                     MCU_REV_STM32F4_REV_3: ("3", False),
                 }
                 rev = (chip & 0xFFFF0000) >> 16


### PR DESCRIPTION
Use of latest STM32Fxx boards made bootloader stuck because of missing CPU revision versions list to check against. This makes new boards unusable until fixed.
Also, I've found mismatch of revision values vs version names.