### PR TITLE
AP_Mount:add warning for missing location data

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -53,6 +53,23 @@ void AP_Mount_Backend::update()
         mnt_target.rate_rads.pitch = 0;
         mnt_target.rate_rads.yaw = 0;
     }
+    // location exists for mode
+    Location current_loc;
+    switch (_mode) {
+    case MAV_MOUNT_MODE_RETRACT:
+    case MAV_MOUNT_MODE_NEUTRAL:
+    case MAV_MOUNT_MODE_MAVLINK_TARGETING:
+    case MAV_MOUNT_MODE_RC_TARGETING:
+    case MAV_MOUNT_MODE_ENUM_END:
+        break;
+    case MAV_MOUNT_MODE_GPS_POINT:
+    case MAV_MOUNT_MODE_SYSID_TARGET:
+    case MAV_MOUNT_MODE_HOME_LOCATION:
+         if (!AP::ahrs().get_location(current_loc)) {
+             send_warning_to_GCS("not targeting, no location");
+         }
+    }
+ 
 }
 
 // return true if this mount accepts roll targets


### PR DESCRIPTION
This provides a warning if there is no GPS attached for mount modes that need location. Its really applicable to bench testers, since they may not have a GPS attached or locked when testing and location-requiring gimbal modes will fail silently. Of course, if a GPS breaks after boot, then DCM location is usually supplied and these checks are skipped anyway.

addresses #31494