### PR TITLE
AP_VideoTX: force maximum power output at maximum level

### DIFF
--- a/libraries/AP_VideoTX/AP_VideoTX.cpp
+++ b/libraries/AP_VideoTX/AP_VideoTX.cpp
@@ -530,6 +530,11 @@ void AP_VideoTX::change_power(int8_t position)
         }
     }
 
+    if (position == 5 && power < _max_power_mw) {
+        power = _max_power_mw;
+        debug("selected power %dmw", power);
+    }
+
     if (power == 0) {
         if (!hal.util->get_soft_armed()) {    // don't allow pitmode to be entered if already armed
             set_configured_options(get_configured_options() | uint8_t(VideoOptions::VTX_PITMODE));


### PR DESCRIPTION
The current logic means that if you set maximum power on a pot or switch (RC function 94) you don't necessarily get maximum power (or at least not what you have configured as maximum power). This PR forces the power to the value of VTX_MAX_POWER if you select function 94 and its fully high.