### PR TITLE
AP_Scripting: Add bindings to allow updating servo telem

### DIFF
--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -4222,56 +4222,105 @@ servo_telem = {}
 
 -- get servo telem for the given servo number
 ---@param servo_index integer -- 0 indexed servo number
----@return AP_Servo_Telem_Data_ud|nil
+---@return ServoTelemetryData_ud|nil
 function servo_telem:get_telem(servo_index) end
 
+-- update telemetry data for an servo instance
+---@param instance integer -- servo instance, 0 indexed
+---@param telemdata ServoTelemetryData_ud -- Data to update
+function servo_telem:update_telem_data(instance, telemdata) end
+
 -- Servo telemetry userdata object
----@class AP_Servo_Telem_Data_ud
-local AP_Servo_Telem_Data_ud = {}
+---@class ServoTelemetryData_ud
+local ServoTelemetryData_ud = {}
+
+-- Create new instance of ServoTelemetryData userdata object
+---@return ServoTelemetryData_ud
+function ServoTelemetryData() end
 
 -- Get timestamp of last telem update
 ---@return uint32_t_ud -- milliseconds since boot
-function AP_Servo_Telem_Data_ud:last_update_ms() end
+function ServoTelemetryData_ud:last_update_ms() end
 
 -- Get type spesfic status flags
 ---@return integer|nil -- flags or nil if not available
-function AP_Servo_Telem_Data_ud:status_flags() end
+function ServoTelemetryData_ud:status_flags() end
+
+-- Set type spesfic status flags
+---@param value integer
+function ServoTelemetryData_ud:status_flags(value) end
 
 -- Get pcb temperature in centidegrees
 ---@return integer|nil -- temperature in centidegrees or nil if not available
-function AP_Servo_Telem_Data_ud:pcb_temperature_cdeg() end
+function ServoTelemetryData_ud:pcb_temperature_cdeg() end
+
+-- Set pcb temperature in centidegrees
+---@param value integer -- temperature in centidegrees
+function ServoTelemetryData_ud:pcb_temperature_cdeg(value) end
 
 -- Get motor temperature in centidegrees
 ---@return integer|nil -- temperature in centidegrees or nil if not available
-function AP_Servo_Telem_Data_ud:motor_temperature_cdeg() end
+function ServoTelemetryData_ud:motor_temperature_cdeg() end
+
+-- Set motor temperature in centidegrees
+---@param value integer -- temperature in centidegrees
+function ServoTelemetryData_ud:motor_temperature_cdeg(value) end
 
 -- Get duty cycle
 ---@return integer|nil -- duty cycle 0% to 100% or nil if not available
-function AP_Servo_Telem_Data_ud:duty_cycle() end
+function ServoTelemetryData_ud:duty_cycle() end
+
+-- Set duty cycle
+---@param value integer -- duty cycle 0% to 100%
+function ServoTelemetryData_ud:duty_cycle(value) end
 
 -- get current
 ---@return number|nil -- current in amps or nil if not available
-function AP_Servo_Telem_Data_ud:current() end
+function ServoTelemetryData_ud:current() end
+
+-- Set current
+---@param value number -- current in amps
+function ServoTelemetryData_ud:current(value) end
 
 -- get voltage
 ---@return number|nil -- voltage in volts or nil if not available
-function AP_Servo_Telem_Data_ud:voltage() end
+function ServoTelemetryData_ud:voltage() end
+
+-- Set voltage
+---@param value number -- voltage in volts
+function ServoTelemetryData_ud:voltage(value) end
 
 -- get speed
 ---@return number|nil -- speed in degrees per second or nil if not available
-function AP_Servo_Telem_Data_ud:speed() end
+function ServoTelemetryData_ud:speed() end
+
+-- Set speed
+---@param value number -- speed in degrees per second
+function ServoTelemetryData_ud:speed(value) end
 
 -- get force
 ---@return number|nil -- force in newton meters or nil if not available
-function AP_Servo_Telem_Data_ud:force() end
+function ServoTelemetryData_ud:force() end
+
+-- Set force
+---@param value number -- force in newton meters
+function ServoTelemetryData_ud:force(value) end
 
 -- get measured position
 ---@return number|nil -- measured position in degrees or nil if not available
-function AP_Servo_Telem_Data_ud:measured_position() end
+function ServoTelemetryData_ud:measured_position() end
+
+-- Set measured position
+---@param value number -- measured position in degrees
+function ServoTelemetryData_ud:measured_position(value) end
 
 -- get commanded position
 ---@return number|nil -- comanded position in degrees or nil if not available
-function AP_Servo_Telem_Data_ud:command_position() end
+function ServoTelemetryData_ud:command_position() end
+
+-- Set commanded position
+---@param value number -- comanded position in degrees
+function ServoTelemetryData_ud:command_position(value) end
 
 -- simulator specific bindings
 sim = {}

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -1131,19 +1131,20 @@ include AP_Servo_Telem/AP_Servo_Telem_config.h
 singleton AP_Servo_Telem depends AP_SERVO_TELEM_ENABLED
 singleton AP_Servo_Telem rename servo_telem
 singleton AP_Servo_Telem method get_telem boolean uint8_t'skip_check AP_Servo_Telem::TelemetryData'Null
+singleton AP_Servo_Telem method update_telem_data void uint8_t'skip_check AP_Servo_Telem::TelemetryData
 
 userdata AP_Servo_Telem::TelemetryData depends AP_SERVO_TELEM_ENABLED
-userdata AP_Servo_Telem::TelemetryData rename AP_Servo_Telem_Data
-userdata AP_Servo_Telem::TelemetryData field command_position float'skip_check read valid_mask present_types AP_Servo_Telem::TelemetryData::Types::COMMANDED_POSITION
-userdata AP_Servo_Telem::TelemetryData field measured_position float'skip_check read valid_mask present_types AP_Servo_Telem::TelemetryData::Types::MEASURED_POSITION
-userdata AP_Servo_Telem::TelemetryData field force float'skip_check read valid_mask present_types AP_Servo_Telem::TelemetryData::Types::FORCE
-userdata AP_Servo_Telem::TelemetryData field speed float'skip_check read valid_mask present_types AP_Servo_Telem::TelemetryData::Types::SPEED
-userdata AP_Servo_Telem::TelemetryData field voltage float'skip_check read valid_mask present_types AP_Servo_Telem::TelemetryData::Types::VOLTAGE
-userdata AP_Servo_Telem::TelemetryData field current float'skip_check read valid_mask present_types AP_Servo_Telem::TelemetryData::Types::CURRENT
-userdata AP_Servo_Telem::TelemetryData field duty_cycle uint8_t'skip_check read valid_mask present_types AP_Servo_Telem::TelemetryData::Types::DUTY_CYCLE
-userdata AP_Servo_Telem::TelemetryData field motor_temperature_cdeg int16_t'skip_check read valid_mask present_types AP_Servo_Telem::TelemetryData::Types::MOTOR_TEMP
-userdata AP_Servo_Telem::TelemetryData field pcb_temperature_cdeg int16_t'skip_check read valid_mask present_types AP_Servo_Telem::TelemetryData::Types::PCB_TEMP
-userdata AP_Servo_Telem::TelemetryData field status_flags uint8_t'skip_check read valid_mask present_types AP_Servo_Telem::TelemetryData::Types::STATUS
+userdata AP_Servo_Telem::TelemetryData rename ServoTelemetryData
+userdata AP_Servo_Telem::TelemetryData field command_position float'skip_check read write valid_mask present_types AP_Servo_Telem::TelemetryData::Types::COMMANDED_POSITION
+userdata AP_Servo_Telem::TelemetryData field measured_position float'skip_check read write valid_mask present_types AP_Servo_Telem::TelemetryData::Types::MEASURED_POSITION
+userdata AP_Servo_Telem::TelemetryData field force float'skip_check read write valid_mask present_types AP_Servo_Telem::TelemetryData::Types::FORCE
+userdata AP_Servo_Telem::TelemetryData field speed float'skip_check read write valid_mask present_types AP_Servo_Telem::TelemetryData::Types::SPEED
+userdata AP_Servo_Telem::TelemetryData field voltage float'skip_check read write valid_mask present_types AP_Servo_Telem::TelemetryData::Types::VOLTAGE
+userdata AP_Servo_Telem::TelemetryData field current float'skip_check read write valid_mask present_types AP_Servo_Telem::TelemetryData::Types::CURRENT
+userdata AP_Servo_Telem::TelemetryData field duty_cycle uint8_t'skip_check read write valid_mask present_types AP_Servo_Telem::TelemetryData::Types::DUTY_CYCLE
+userdata AP_Servo_Telem::TelemetryData field motor_temperature_cdeg int16_t'skip_check read write valid_mask present_types AP_Servo_Telem::TelemetryData::Types::MOTOR_TEMP
+userdata AP_Servo_Telem::TelemetryData field pcb_temperature_cdeg int16_t'skip_check read write valid_mask present_types AP_Servo_Telem::TelemetryData::Types::PCB_TEMP
+userdata AP_Servo_Telem::TelemetryData field status_flags uint8_t'skip_check read write valid_mask present_types AP_Servo_Telem::TelemetryData::Types::STATUS
 userdata AP_Servo_Telem::TelemetryData field last_update_ms uint32_t'skip_check read
 
 -- simulator only bindings


### PR DESCRIPTION
This allows a script to provide servo telem data in the same way we already can for ESC telem. 