### PR TITLE
AP_NavEKF3: expand EK3_FLOW_DELAY to support up to 250ms

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1822,6 +1822,8 @@ void NavEKF3::convert_parameters()
     if (dal.opticalflow_enabled() && (!found_gps_type || (gps_type_old.get() <= 2))) {
         AP_Param::set_and_save_by_name("EK3_SRC2_VELXY", (int8_t)AP_NavEKF_Source::SourceXY::OPTFLOW);
     }
+    // convert FLOW_DELAY from Int8 to Int16
+    _flowDelay_ms.convert_parameter_width(AP_PARAM_INT8);
 }
 
 // Set to true if the terrain underneath is stable enough to be used as a height reference

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -418,7 +418,7 @@ private:
     AP_Int8 _gpsGlitchRadiusMax;    // Maximum allowed discrepancy between inertial and GPS Horizontal position before GPS glitch is declared : m
     AP_Float _flowNoise;            // optical flow rate measurement noise
     AP_Int16  _flowInnovGate;       // Percentage number of standard deviations applied to optical flow innovation consistency check
-    AP_Int8  _flowDelay_ms;         // effective average delay of optical flow measurements rel to IMU (msec)
+    AP_Int16  _flowDelay_ms;         // effective average delay of optical flow measurements rel to IMU (msec)
     AP_Int16  _rngInnovGate;        // Percentage number of standard deviations applied to range finder innovation consistency check
     AP_Float _maxFlowRate;          // Maximum flow rate magnitude that will be accepted by the filter
     AP_Float _rngNoise;             // Range finder noise : m


### PR DESCRIPTION
Fixes #30947
Expands the `EK3_FLOW_DELAY` parameter from `AP_Int8` to `AP_Int16` to support delay values up to 250ms instead of the previous 127ms limit.
## Changes
- Modified `AP_NavEKF3.h`: Changed `_flowDelay_ms` from `AP_Int8` to `AP_Int16`
- Added parameter conversion in `ArduCopter/Parameters.cpp` to preserve existing parameter values when users upgrade firmware
## Testing
- Parameter conversion follows existing patterns in ArduCopter