### PR TITLE
HAL_ChibiOS: enable flow control for USB

### DIFF
--- a/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
+++ b/libraries/AP_HAL_ChibiOS/UARTDriver.cpp
@@ -387,6 +387,8 @@ void UARTDriver::_begin(uint32_t b, uint16_t rxS, uint16_t txS)
             }
             _device_initialised = true;
         }
+        // USB has flow control
+        _flow_control = FLOW_CONTROL_ENABLE;
 #endif
     } else {
 #if HAL_USE_SERIAL == TRUE


### PR DESCRIPTION
this greatly speeds up MAVFtp on USB connections.

Downloading a log file without this change on a CubeOrange gets around 16 kbyte/s. With this change I get over 480 kbyte/s, a factor of 30x speedup