### PR TITLE
AP_OpenDroneID: rename EnforceArming to EnforcePreArmChecks (NFC)

### DIFF
--- a/libraries/AP_OpenDroneID/AP_OpenDroneID.cpp
+++ b/libraries/AP_OpenDroneID/AP_OpenDroneID.cpp
@@ -68,7 +68,7 @@ const AP_Param::GroupInfo AP_OpenDroneID::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: OpenDroneID options
     // @Description: Options for OpenDroneID subsystem
-    // @Bitmask: 0:EnforceArming, 1:AllowNonGPSPosition, 2:LockUASIDOnFirstBasicIDRx
+    // @Bitmask: 0:EnforcePreArmChecks, 1:AllowNonGPSPosition, 2:LockUASIDOnFirstBasicIDRx
     AP_GROUPINFO("OPTIONS", 4, AP_OpenDroneID, _options, 0),
 
     // @Param: BARO_ACC
@@ -162,7 +162,7 @@ bool AP_OpenDroneID::pre_arm_check(char* failmsg, uint8_t failmsg_len)
 {
     WITH_SEMAPHORE(_sem);
 
-    if (!option_enabled(Options::EnforceArming)) {
+    if (!option_enabled(Options::EnforcePreArmChecks)) {
         return true;
     }
 

--- a/libraries/AP_OpenDroneID/AP_OpenDroneID.h
+++ b/libraries/AP_OpenDroneID/AP_OpenDroneID.h
@@ -113,7 +113,7 @@ private:
     char id_str[21];
     bool bootloader_flashed;
     enum Options : int16_t {
-        EnforceArming     = (1U << 0U),
+        EnforcePreArmChecks = (1U << 0U),
         AllowNonGPSPosition = (1U << 1U),
         LockUASIDOnFirstBasicIDRx = (1U << 2U),
     };


### PR DESCRIPTION
This patch renames the Options bit 0 from `EnforceArming` to ~`EnablePreArmCheck`~ `EnforcePreArmChecks` to better reflect what the flag actually does (enable ODID-related pre-arm checks).
The previous name might be misread as “force arming” (bypass checks), which is the opposite of the implemented behavior.