### PR TITLE
autotest: fix multi-vehicle default param path

### DIFF
--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -784,10 +784,10 @@ def start_vehicle(binary, opts, stuff, spawns=None):
             if not os.path.isfile(x):
                 print("The parameter file (%s) does not exist" % (x,))
                 sys.exit(1)
-        path = ",".join(paths)
         if cmd_opts.count > 1 or opts.auto_sysid:
             # we are in a subdirectory when using -n
-            path = os.path.join("..", path)
+            paths = [os.path.join("..", x) for x in paths]
+        path = ",".join(paths)
         progress("Using defaults from (%s)" % (path,))
     if opts.flash_storage:
         cmd.append("--set-storage-flash-enabled 1")


### PR DESCRIPTION
Set the correct path for multiple parameter files when running SITL for more than one vehicle. 

## Detail

If SITL is run using the arguments `--count 3 --auto-sysid `, and the frame type requires more than one default parameter file (such as `rover-skid` which requires `autotest/default_params/rover.parm` and `autotest/default_params/rover-skid.parm`), the incorrect path is set for the second and subsequent parameter files and SITL crashes.

Example

```bash
sim_vehicle.py --debug -v Rover -f rover-skid --count 3 --auto-sysid --location CMAC --auto-offset-line 90,5 --console --map
```

The modification to the path in `sim_vehicle.py` that prefixes `../` is only applied to the first parameter file. This PR applies the modification to all default param files. 

## Tasks

- [ ] Fix case when `--count 1`  