### PR TITLE
AP_Param: fix spelling of sentinel

### DIFF
--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -45,7 +45,7 @@
 
 extern const AP_HAL::HAL &hal;
 
-uint16_t AP_Param::sentinal_offset;
+uint16_t AP_Param::sentinel_offset;
 
 // singleton instance
 AP_Param *AP_Param::_singleton;
@@ -161,19 +161,19 @@ void AP_Param::eeprom_write_check(const void *ptr, uint16_t ofs, uint8_t size)
 
 bool AP_Param::_hide_disabled_groups = true;
 
-// write a sentinal value at the given offset
-void AP_Param::write_sentinal(uint16_t ofs)
+// write a sentinel value at the given offset
+void AP_Param::write_sentinel(uint16_t ofs)
 {
     struct Param_header phdr;
-    phdr.type = _sentinal_type;
-    set_key(phdr, _sentinal_key);
-    phdr.group_element = _sentinal_group;
+    phdr.type = _sentinel_type;
+    set_key(phdr, _sentinel_key);
+    phdr.group_element = _sentinel_group;
     eeprom_write_check(&phdr, ofs, sizeof(phdr));
-    sentinal_offset = ofs;
+    sentinel_offset = ofs;
 }
 
 // erase all EEPROM variables by re-writing the header and adding
-// a sentinal
+// a sentinel
 void AP_Param::erase_all(void)
 {
     struct EEPROM_header hdr;
@@ -185,8 +185,8 @@ void AP_Param::erase_all(void)
     hdr.spare    = 0;
     eeprom_write_check(&hdr, 0, sizeof(hdr));
 
-    // add a sentinal directly after the header
-    write_sentinal(sizeof(struct EEPROM_header));
+    // add a sentinel directly after the header
+    write_sentinel(sizeof(struct EEPROM_header));
 }
 
 /* the 'group_id' of a element of a group is the 18 bit identifier
@@ -383,7 +383,7 @@ bool AP_Param::setup(void)
         }
 #endif // AP_PARAM_STORAGE_BAK_ENABLED
         // header doesn't match. We can't recover any variables. Wipe
-        // the header and setup the sentinal directly after the header
+        // the header and setup the sentinel directly after the header
         Debug("bad header in setup - erasing");
         erase_all();
     }
@@ -734,15 +734,15 @@ void AP_Param::set_key(Param_header &phdr, uint16_t key)
 }
 
 /*
-  return true if a header is the end of eeprom sentinal
+  return true if a header is the end of eeprom sentinel
  */
-bool AP_Param::is_sentinal(const Param_header &phdr)
+bool AP_Param::is_sentinel(const Param_header &phdr)
 {
     // note that this is an ||, not an && on the key and group, as
     // this makes us more robust to power off while adding a variable
     // to EEPROM
-    if (phdr.type == _sentinal_type ||
-        get_key(phdr) == _sentinal_key) {
+    if (phdr.type == _sentinel_type ||
+        get_key(phdr) == _sentinel_key) {
         return true;
     }
     // also check for 0xFFFFFFFF and 0x00000000, which are the fill
@@ -758,8 +758,8 @@ bool AP_Param::is_sentinal(const Param_header &phdr)
 // scan the EEPROM looking for a given variable by header content
 // return true if found, along with the offset in the EEPROM where
 // the variable is stored
-// if not found return the offset of the sentinal
-// if the sentinal isn't found either, the offset is set to 0xFFFF
+// if not found return the offset of the sentinel
+// if the sentinel isn't found either, the offset is set to 0xFFFF
 bool AP_Param::scan(const AP_Param::Param_header *target, uint16_t *pofs)
 {
     struct Param_header phdr;
@@ -773,10 +773,10 @@ bool AP_Param::scan(const AP_Param::Param_header *target, uint16_t *pofs)
             *pofs = ofs;
             return true;
         }
-        if (is_sentinal(phdr)) {
-            // we've reached the sentinal
+        if (is_sentinel(phdr)) {
+            // we've reached the sentinel
             *pofs = ofs;
-            sentinal_offset = ofs;
+            sentinel_offset = ofs;
             return false;
         }
         ofs += type_size((enum ap_var_type)phdr.type) + sizeof(phdr);
@@ -1232,8 +1232,8 @@ void AP_Param::save_sync(bool force_save, bool send_to_gcs)
         return;
     }
 
-    // write a new sentinal, then the data, then the header
-    write_sentinal(ofs + sizeof(phdr) + type_size((enum ap_var_type)phdr.type));
+    // write a new sentinel, then the data, then the header
+    write_sentinel(ofs + sizeof(phdr) + type_size((enum ap_var_type)phdr.type));
     eeprom_write_check(ap, ofs+sizeof(phdr), type_size((enum ap_var_type)phdr.type));
     eeprom_write_check(&phdr, ofs, sizeof(phdr));
 
@@ -1569,9 +1569,9 @@ bool AP_Param::load_all()
     
     while (ofs < _storage.size()) {
         _storage.read_block(&phdr, ofs, sizeof(phdr));
-        if (is_sentinal(phdr)) {
-            // we've reached the sentinal
-            sentinal_offset = ofs;
+        if (is_sentinel(phdr)) {
+            // we've reached the sentinel
+            sentinel_offset = ofs;
             return true;
         }
 
@@ -1586,8 +1586,8 @@ bool AP_Param::load_all()
         ofs += type_size((enum ap_var_type)phdr.type) + sizeof(phdr);
     }
 
-    // we didn't find the sentinal
-    Debug("no sentinal in load_all");
+    // we didn't find the sentinel
+    Debug("no sentinel in load_all");
     return false;
 }
 
@@ -1698,9 +1698,9 @@ void AP_Param::load_object_from_eeprom(const void *object_pointer, const struct 
             _storage.read_block(&phdr, ofs, sizeof(phdr));
             // note that this is an || not an && for robustness
             // against power off while adding a variable
-            if (is_sentinal(phdr)) {
-                // we've reached the sentinal
-                sentinal_offset = ofs;
+            if (is_sentinel(phdr)) {
+                // we've reached the sentinel
+                sentinel_offset = ofs;
                 break;
             }
             if (get_key(phdr) == key) {

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -428,7 +428,7 @@ public:
     }
 
     // returns storage space used:
-    static uint16_t storage_used() { return sentinal_offset; }
+    static uint16_t storage_used() { return sentinel_offset; }
 
     // returns storage space :
     static uint16_t storage_size() { return _storage.size(); }
@@ -630,7 +630,7 @@ private:
     };
     static_assert(sizeof(struct EEPROM_header) == 4, "Bad EEPROM_header size!");
 
-    static uint16_t sentinal_offset;
+    static uint16_t sentinel_offset;
 
 /* This header is prepended to a variable stored in EEPROM.
  *  The meaning is as follows:
@@ -657,9 +657,9 @@ private:
     static const uint8_t        _group_level_shift = 6;
     static const uint8_t        _group_bits  = 18;
 
-    static const uint16_t       _sentinal_key   = 0x1FF;
-    static const uint8_t        _sentinal_type  = 0x1F;
-    static const uint8_t        _sentinal_group = 0xFF;
+    static const uint16_t       _sentinel_key   = 0x1FF;
+    static const uint8_t        _sentinel_type  = 0x1F;
+    static const uint8_t        _sentinel_group = 0xFF;
 
     static uint16_t             _frame_type_flags;
 
@@ -736,10 +736,10 @@ private:
                                     ptrdiff_t group_offset,
                                     const struct GroupInfo *group_info,
                                     enum ap_var_type *ptype);
-    static void                 write_sentinal(uint16_t ofs);
+    static void                 write_sentinel(uint16_t ofs);
     static uint16_t             get_key(const Param_header &phdr);
     static void                 set_key(Param_header &phdr, uint16_t key);
-    static bool                 is_sentinal(const Param_header &phrd);
+    static bool                 is_sentinel(const Param_header &phrd);
     static bool                 scan(
                                     const struct Param_header *phdr,
                                     uint16_t *pofs);

--- a/libraries/AP_Param/tools/eedump_apparam.c
+++ b/libraries/AP_Param/tools/eedump_apparam.c
@@ -50,9 +50,9 @@ struct Param_header {
     uint32_t group_element : 18;
 };
 
-static const uint16_t       _sentinal_key   = 0x1FF;
-static const uint8_t        _sentinal_type  = 0x1F;
-static const uint8_t        _sentinal_group = 0xFF;
+static const uint16_t       _sentinel_key   = 0x1FF;
+static const uint8_t        _sentinel_type  = 0x1F;
+static const uint8_t        _sentinel_group = 0xFF;
 
 static uint8_t type_size(enum ap_var_type type)
 {
@@ -121,8 +121,8 @@ main(int argc, char *argv[])
         uint8_t size;
         var = (struct Param_header *)&eeprom[index];
         const uint16_t key = ((uint16_t)var->key_high)<<8 | var->key_low;
-        if (key == _sentinal_key ||
-            var->type == _sentinal_type) {
+        if (key == _sentinel_key ||
+            var->type == _sentinel_type) {
             printf("end sentinel at %u\n", index);
             break;
         }


### PR DESCRIPTION
The correct spelling was used in some status messages. No compiler-output change, this is all variable renames. The incorrect spelling is also purely internal to this library.

Now, just before the next big release, is the time for this, as the likelihood of it confounding a backport is low.