### PR TITLE
AP_FlashStorage: Fix failing test and update some comments

### DIFF
--- a/libraries/AP_FlashStorage/AP_FlashStorage.h
+++ b/libraries/AP_FlashStorage/AP_FlashStorage.h
@@ -40,7 +40,7 @@
 #include <AP_HAL/AP_HAL.h>
 
 /*
-  we support 3 different types of flash which have different restrictions
+  we support 4 different types of flash which have different restrictions
  */
 #define AP_FLASHSTORAGE_TYPE_F1  1 // F1 and F3
 #define AP_FLASHSTORAGE_TYPE_F4  2 // F4 and F7
@@ -66,7 +66,7 @@
 #define AP_FLASHSTORAGE_TYPE AP_FLASHSTORAGE_TYPE_G4
 #else // F4, F7
 /*
-  STM32HF4 and STM32H7 can update bits from 1 to 0
+  STM32F4 and STM32F7 can update bits from 1 to 0
  */
 #define AP_FLASHSTORAGE_TYPE AP_FLASHSTORAGE_TYPE_F4
 #endif

--- a/libraries/AP_FlashStorage/examples/FlashTest/FlashTest.cpp
+++ b/libraries/AP_FlashStorage/examples/FlashTest/FlashTest.cpp
@@ -72,7 +72,7 @@ bool FlashTest::flash_write(uint8_t sector, uint32_t offset, const uint8_t *data
                           b[i],
                           data[i]);
         }
-#ifndef AP_FLASHSTORAGE_MULTI_WRITE
+#if AP_FLASHSTORAGE_TYPE != AP_FLASHSTORAGE_TYPE_F4
         if (v != v2 && v != 0xFFFF && v2 != 0xFFFF) {
             AP_HAL::panic("FATAL: invalid write16 at %u:%u 0x%04x 0x%04x",
                           (unsigned)sector,


### PR DESCRIPTION
AP_FLASHSTORAGE_MULTI_WRITE is not defined anywhere so the FlashStorage test with multiwrite will always fail even for F4,F7 (linux builds also) which support multwrite.

On building for linux the FlashTest should have passed but it was failing :
```bash
./waf configure --debug --board=linux && ./waf build --target=examples/FlashTest && ./build/linux/examples/FlashTest
```

Fix some comments :
- flash type count : 3 -> 4
- STM32HF4  -> STM32F4 and STM32H7 -> STM32F7 ( since these two supports multiwrite and belong to F4 type)

Fixes #14168