### PR TITLE
autotest: Split Loweheizer tests into auto and manual starter configuration

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -9328,12 +9328,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.wait_disarmed()
         self.set_rc(3, 1000)  # Restore the throttle stick since takeoff raised it.
 
-    def Loweheiser(self):
-        '''Ensure the Loweheiser device sends in GENERATOR_STATUS and EFI_STATUS messages'''
+    def LoweheiserAuto(self):
+        '''Ensure the Loweheiser generator works as expected in auto-starter mode.'''
 
         gen_ctrl_ch = 9
-        loweheiser_man_throt_ch = 10
-        loweheiser_man_start_ch = 11
 
         self.set_parameters({
             "SERIAL5_PROTOCOL": 2,    # mavlink
@@ -9350,8 +9348,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.set_rc_from_map({
             gen_ctrl_ch: 1000,   # remember this is a switch position - stop
-            loweheiser_man_throt_ch: 1000,
-            loweheiser_man_start_ch: 1000,
         })
 
         self.customise_SITL_commandline(["--serial5=sim:loweheiser"])
@@ -9369,13 +9365,16 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.delay_sim_time(10)  # so we can actually receive messages...
 
-        self.start_subtest("Checking GENERATOR_STATUS")
+        #######################################################################
+        # Generator OFF subtest.
+        #######################################################################
+        self.start_subtest("Checking GENERATOR_STATUS while OFF.")
         self.set_message_rate_hz("GENERATOR_STATUS", 10)
         self.delay_sim_time(1)
 
         self.wait_generator_speed_and_state(0, 0, mavutil.mavlink.MAV_GENERATOR_STATUS_FLAG_OFF)
 
-        self.start_subtest("Checking EFI_STATUS")
+        self.start_subtest("Checking EFI_STATUS while OFF.")
         self.set_message_rate_hz("EFI_STATUS", 10)
         self.delay_sim_time(1)
         self.assert_received_message_field_values('EFI_STATUS', {
@@ -9417,7 +9416,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # check prearms - should bounce due to generator not in correct state
         self.try_arm(result=False, expect_msg="requested state is not RUN")
 
-        self.start_subtest("Generator to idle")
+        #######################################################################
+        # Generator IDLE subtest.
+        #######################################################################
+        self.start_subtest("Setting generator to IDLE state.")
         self.set_rc(gen_ctrl_ch, 1500) # remember this is a switch position - idle
         self.wait_statustext("Generator MIDDLE", check_context=True)
         self.delay_sim_time(2)
@@ -9449,7 +9451,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         })
         self.wait_generator_speed_and_state(2000, 3000, mavutil.mavlink.MAV_GENERATOR_STATUS_FLAG_IDLE)
 
-        self.start_subtest("Move generator to run")
+        #######################################################################
+        # Generator RUN subtest.
+        #######################################################################
+        self.start_subtest("Setting generator to RUN state.")
         self.set_rc(gen_ctrl_ch, 2000) # remember this is a switch position - run
         self.wait_statustext("Generator HIGH", check_context=True)
 
@@ -9535,7 +9540,9 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.set_parameter("LOG_DISARMED", 0)
         if not self.current_onboard_log_contains_message("LOEG"):
-            raise NotAchievedException("Did not find expected GEN message")
+            raise NotAchievedException("Did not find expected LOEG message in .bin log")
+        if not self.current_onboard_log_contains_message("LOEC"):
+            raise NotAchievedException("Did not find expected LOEC message in .bin log")
 
         self.set_parameter("LOG_DISARMED", 1)  # Re-start logging, to help with debugging.
         self.progress("Stopping generator")
@@ -9545,11 +9552,93 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.wait_generator_speed_and_state(0, 0, mavutil.mavlink.MAV_GENERATOR_STATUS_FLAG_OFF)
 
-        self.end_subtest("Move generator to run")
+        #######################################################################
+        # E-stop subtest.
+        #######################################################################
+        self.start_subtest("Checking safety switch estop")
+        self.set_rc(gen_ctrl_ch, 2000)
+        self.wait_generator_speed_and_state(8000, 30000, mavutil.mavlink.MAV_GENERATOR_STATUS_FLAG_GENERATING)
 
-        self.start_subtest("LoweHeiser manual control")
+        self.set_safetyswitch_on()
+        self.wait_generator_speed_and_state(0, 0, mavutil.mavlink.MAV_GENERATOR_STATUS_FLAG_OFF)
+        self.wait_message_field_values('EFI_STATUS', {
+            # note that percent isn't honouring dead-zones...
+            "throttle_position": 0,
+            "rpm": 0,
+        })
+
+        self.set_safetyswitch_off()
+
+        self.wait_message_field_values('EFI_STATUS', {
+            # note that percent isn't honouring dead-zones...
+            "throttle_position": 80,  # Throttle set by governor.
+            "rpm": 8000,  # RPM for 50% throttle
+        }, timeout=20)
+
+        # stop generator:
+        self.set_rc(gen_ctrl_ch, 1000)
+        self.wait_generator_speed_and_state(0, 0, mavutil.mavlink.MAV_GENERATOR_STATUS_FLAG_OFF)
+
+        #######################################################################
+        # Battery failsafe subtest.
+        #######################################################################
+        self.start_subtest("Battery Failsafes")
         self.context_push()
+        batt3_capacity = 500
+        batt3_low_mah = 100
+        batt3_low_consumed_mah = batt3_capacity - batt3_low_mah
         self.set_parameters({
+            "BATT3_CAPACITY": batt3_capacity,
+            "BATT3_LOW_MAH": batt3_low_mah,
+            "BATT3_CRT_MAH": 50,
+            "BATT3_FS_LOW_ACT": 2, # RTL
+            "BATT3_FS_CRT_ACT": 1, # LAND
+            "BATT3_LOW_VOLT": 0,
+        })
+        self.reboot_sitl()
+        self.set_rc(gen_ctrl_ch, 2000)
+        self.takeoff(10, mode='GUIDED')
+
+        first_efi_status = self.assert_receive_message('EFI_STATUS', verbose=True)
+        if first_efi_status.fuel_consumed < 100:  # takes about this much to get going
+            raise NotAchievedException("Unexpected fuel consumed value after takeoff (%f)" % first_efi_status.fuel_consumed)
+
+        self.fly_guided_move_local(100, 100, 20)
+
+        self.wait_mode('RTL', timeout=300)
+
+        second_efi_status = self.assert_receive_message('EFI_STATUS', verbose=True)
+
+        if second_efi_status.fuel_consumed < batt3_low_consumed_mah:
+            raise NotAchievedException("Unexpected fuel consumed value after failsafe (%f)" % second_efi_status.fuel_consumed)
+
+        self.wait_mode('LAND', timeout=300)
+        self.wait_disarmed()
+
+        self.context_pop()
+        self.reboot_sitl()
+
+        self.set_message_rate_hz("EFI_STATUS", -1)
+        self.set_message_rate_hz("GENERATOR_STATUS", -1)
+
+    def LoweheiserManual(self):
+        '''Ensure the Loweheiser generator works as expected in manual starter mode.'''
+
+        gen_ctrl_ch = 9
+        loweheiser_man_throt_ch = 10
+        loweheiser_man_start_ch = 11
+
+        self.set_parameters({
+            "SERIAL5_PROTOCOL": 2,    # mavlink
+            "MAV3_OPTIONS": 2,        # private
+            "GEN_TYPE": 4,            # loweheiser
+            "EFI_TYPE": 4,            # loweheiser
+            "SIM_EFI_TYPE": 2,        # loweheiser sim
+            "BATT2_MONITOR": 17,  # generator (elec)
+            "BATT3_MONITOR": 18,  # generator (fuel-level)
+            "BATT3_CAPACITY": 10000,  # generator (fuel) in mL
+            f"RC{gen_ctrl_ch}_OPTION": 85,  # generator control
+            "LOG_DISARMED": 1,
             "RC%u_OPTION" % loweheiser_man_throt_ch: 218,  # loweheiser manual throttle control
             "RC%u_DZ" % loweheiser_man_throt_ch: 20,
             "RC%u_TRIM" % loweheiser_man_throt_ch: 1000,
@@ -9557,27 +9646,73 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "RC%u_MAX" % loweheiser_man_throt_ch: 2000,
             "RC%u_OPTION" % loweheiser_man_start_ch: 111, # loweheiser starter channel
         })
-        self.set_rc(loweheiser_man_throt_ch, 1000)  # zero throttle
-        self.set_rc(loweheiser_man_start_ch, 1000)  # zero starter channel
 
-        # check generator doesn't auto-start - except in "run"
-        for pwm in 1000, 1500:  # off, idle
-            self.set_rc(gen_ctrl_ch, pwm)
-            self.delay_sim_time(5)
-            self.wait_generator_speed_and_state(0, 0, mavutil.mavlink.MAV_GENERATOR_STATUS_FLAG_OFF)
+        self.set_rc_from_map({
+            gen_ctrl_ch: 1000,   # remember this is a switch position - stop
+            loweheiser_man_throt_ch: 1000,  # zero throttle
+            loweheiser_man_start_ch: 1000,  # the starter is off
+        })
 
-            self.assert_received_message_field_values('EFI_STATUS', {
-                "throttle_out": 0,
-                "rpm": 0,
-            })
+        self.customise_SITL_commandline(["--serial5=sim:loweheiser"])
 
-        self.set_rc(gen_ctrl_ch, 2000)
-        self.delay_sim_time(5)
-        self.wait_generator_speed_and_state(8000, 30000, mavutil.mavlink.MAV_GENERATOR_STATUS_FLAG_GENERATING)
+        self.set_parameters({
+            "GEN_IDLE_TH": 25,
+            "GEN_IDLE_TH_H": 40,
+            "GEN_RUN_TEMP": 60,
+            "GEN_IDLE_TEMP": 80,
+        })
 
-        self.progress("Stopping generator again")
-        self.set_rc(gen_ctrl_ch, 1000)
+        self.reboot_sitl()
+
+        self.assert_parameter_value("GEN_IDLE_TH", 25)
+
+        self.delay_sim_time(10)  # so we can actually receive messages...
+
+        #######################################################################
+        # Generator OFF subtest.
+        #######################################################################
+        self.start_subtest("Checking GENERATOR_STATUS while OFF.")
+        self.set_message_rate_hz("GENERATOR_STATUS", 10)
+        self.delay_sim_time(1)
+
         self.wait_generator_speed_and_state(0, 0, mavutil.mavlink.MAV_GENERATOR_STATUS_FLAG_OFF)
+
+        self.start_subtest("Checking EFI_STATUS while OFF.")
+        self.set_message_rate_hz("EFI_STATUS", 10)
+        self.delay_sim_time(1)
+        self.assert_received_message_field_values('EFI_STATUS', {
+            "health": 1,
+            "ecu_index": 1.0,
+            "rpm": 0.0,
+            "fuel_consumed": 0,
+            "fuel_flow": float("nan"),
+            "engine_load": 0.0,
+            "throttle_position": 0.0,
+            "spark_dwell_time": 0.0,
+            "barometric_pressure": 0.0,
+            "intake_manifold_pressure": float("nan"),
+            "intake_manifold_temperature": float("nan"),
+            "cylinder_head_temperature": float("nan"),
+            "ignition_timing": 0.0,
+            "injection_time": float("nan"),
+            "exhaust_gas_temperature": float("nan"),
+            "throttle_out": 0.0,
+            "pt_compensation": 0.0,
+            "ignition_voltage": 0,  # As per the spec, 0 means "Unknown".
+        }, epsilon=1.0)
+        self.assert_received_message_field_values('GENERATOR_STATUS', {
+            "status": 1,
+            "generator_speed": 0,
+            "battery_current": -0.30000001192092896,
+            "load_current": 10.119999885559082,
+            "power_generated": 521.0,
+            "bus_voltage": 50,
+            "rectifier_temperature": 32767,
+            "bat_current_setpoint": float("nan"),
+            "generator_temperature": 32767,
+            "runtime": 0,
+            "time_until_maintenance": 300*60*60,
+        })
 
         rc_dz = self.get_parameter('RC%u_DZ' % loweheiser_man_throt_ch)
         rc_trim = int(self.get_parameter('RC%u_TRIM' % loweheiser_man_throt_ch))
@@ -9594,37 +9729,187 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 "rpm": 0,
             })
 
-        # at 50 percent throttle
+        self.context_collect('STATUSTEXT')
+        # check prearms - should bounce due to generator not in correct state
+        self.try_arm(result=False, expect_msg="requested state is not RUN")
+
+        #######################################################################
+        # Generator IDLE subtest.
+        #######################################################################
+        self.start_subtest("Setting generator to IDLE state.")
+        self.set_rc(gen_ctrl_ch, 1500) # remember this is a switch position - idle
+        self.wait_statustext("Generator MIDDLE", check_context=True)
+        self.delay_sim_time(5)
+
+        # Ensure the generator has not auto-started.
+        self.assert_received_message_field_values('EFI_STATUS', {
+            "throttle_out": 0,
+            "rpm": 0,
+        })
+
+        # at 50 percent throttle should not start until user triggers starter
         pwm_for_fifty_percent_throttle = int(rc_min + rc_dz + int((rc_max-rc_min-rc_dz)/2))
         self.progress("Using PWM of %u for 50 percent throttle" % pwm_for_fifty_percent_throttle)
         self.set_rc(loweheiser_man_throt_ch, pwm_for_fifty_percent_throttle)
-
-        self.progress("Turning EFI on (setting IDLE)")
-        self.set_rc(gen_ctrl_ch, 1500)
-
-        # should not start until user triggers starter
         self.wait_message_field_values('EFI_STATUS', {
             # note that percent isn't honouring dead-zones...
             "throttle_position": 51,  # magic fixed throttle value from AP_Generator_Loweheiser.cpp
             "rpm": 0,
         }, timeout=20)
 
-        self.progress("Running starter")
-        self.set_rc(loweheiser_man_start_ch, 2000)
+        self.set_rc(loweheiser_man_start_ch, 2000)  # Run the starter for a few seconds.
+
+        self.drain_mav()
+        self.assert_received_message_field_values('EFI_STATUS', {
+            "intake_manifold_pressure": 94,
+            "exhaust_gas_temperature": float("nan"),
+            "ignition_voltage": 12,
+        }, epsilon=1.0)
+
+        self.wait_message_field_values('EFI_STATUS', {
+            "cylinder_head_temperature": 20,
+        }, epsilon=5.0, timeout=10)
+
+        self.set_rc(loweheiser_man_start_ch, 1000)
+
+        self.assert_received_message_field_values('GENERATOR_STATUS', {
+            # Commenting out "status" argument.
+            # For some reason the test suite can't accept an integer value. Says it's not part of the FLAG.
+            # "status": mavutil.mavlink.MAV_GENERATOR_STATUS_FLAG_IDLE,
+            "battery_current": -0.30000001192092896,
+            "load_current": 10.119999885559082,
+            "power_generated": 521.0,
+            "bus_voltage": 50,
+            "rectifier_temperature": 32767,
+            "bat_current_setpoint": float("nan"),
+            "generator_temperature": 32767,
+            "runtime": 2,
+            "time_until_maintenance": 300*60*60 - 2,
+        })
 
         self.progress("Generator at idle should not run governor and use throttle input")
-        self.delay_sim_time(30)
-        self.set_rc(loweheiser_man_throt_ch, pwm_for_fifty_percent_throttle)
         self.wait_message_field_values('EFI_STATUS', {
             # note that percent isn't honouring dead-zones...
             "throttle_position": 51,  # magic fixed throttle value from AP_Generator_Loweheiser.cpp
             "rpm": 4080,  # RPM for 50% throttle
         }, timeout=20)
 
-        self.assert_current_onboard_log_contains_message('LOEG')
-        self.assert_current_onboard_log_contains_message('LOEC')
+        #######################################################################
+        # Generator RUN subtest.
+        #######################################################################
+        self.start_subtest("Setting generator to RUN state.")
+        self.set_rc(gen_ctrl_ch, 2000) # remember this is a switch position - run
+        self.wait_statustext("Generator HIGH", check_context=True)
 
+        # check prearms - should bounce due to generator too cold
+        self.try_arm(result=False, expect_msg="Generator warming up")
+
+        self.set_rc(gen_ctrl_ch, 1000) # remember this is a switch position - stop
+        self.wait_statustext("requested state is not RUN", timeout=200)
+
+        self.set_rc(gen_ctrl_ch, 1500) # remember this is a switch position - idle
+        self.set_rc(loweheiser_man_start_ch, 2000)
+        self.wait_generator_speed_and_state(2000, 3000, mavutil.mavlink.MAV_GENERATOR_STATUS_FLAG_IDLE)
+        self.set_rc(loweheiser_man_start_ch, 1000)
+
+        self.set_rc(gen_ctrl_ch, 2000) # remember this is a switch position - run
+
+        self.wait_generator_speed_and_state(8000, 30000, mavutil.mavlink.MAV_GENERATOR_STATUS_FLAG_GENERATING)
+
+        bs = self.assert_receive_message(
+            "BATTERY_STATUS",
+            condition="BATTERY_STATUS.id==1",  # id is zero-indexed
+            timeout=1,
+            very_verbose=True,
+        )
+        if bs is None:
+            raise NotAchievedException("Did not receive BATTERY_STATUS")
+        self.progress("Received battery status: %s" % str(bs))
+        want_bs_volt = 50000
+        if bs.voltages[0] != want_bs_volt:
+            raise NotAchievedException("Battery voltage not as expected (want=%f) got=(%f)" % (want_bs_volt, bs.voltages[0],))
+
+        self.progress("Checking battery remaining")
+        bs = self.assert_receive_message(
+            "BATTERY_STATUS",
+            condition="BATTERY_STATUS.id==2",  # id is zero-indexed
+            timeout=1,
+            very_verbose=True,
+        )
+        self.progress("Waiting for some fuel to be consumed...")
+        self.wait_message_field_values("BATTERY_STATUS", {
+            "id": 2,
+            "battery_remaining": bs.battery_remaining-1,
+        }, timeout=100)
+
+        bs2 = self.assert_receive_message(
+            "BATTERY_STATUS",
+            condition="BATTERY_STATUS.id==2",  # id is zero-indexed
+            timeout=1,
+            very_verbose=True,
+        )
+        if bs2.battery_remaining >= bs.battery_remaining:
+            raise NotAchievedException("Expected battery remaining to drop")
+        if bs2.current_consumed <= bs.current_consumed:
+            raise NotAchievedException("Expected energy consumed to rise")
+
+        self.progress("Checking battery reset")
+        batt_reset_values = [(25, 24),
+                             (50, 49),
+                             (63, 62),
+                             (87, 86),
+                             (100, 99)]
+
+        for (reset_val, return_val) in batt_reset_values:
+            self.run_cmd(mavutil.mavlink.MAV_CMD_BATTERY_RESET,
+                         (1 << 2), # param1 - bitmask of batteries to reset
+                         reset_val, # level to reset to
+                         0, # param3
+                         0, # param4
+                         0, # param5
+                         0, # param6
+                         0 # param7
+                         )
+            self.wait_message_field_values("BATTERY_STATUS", {
+                "id": 2,
+                "battery_remaining": return_val,
+            }, timeout=5)
+
+        self.progress("Moving *back* to idle")
+        self.set_rc(gen_ctrl_ch, 1500) # remember this is a switch position - idle
+        self.wait_generator_speed_and_state(3000, 10000, mavutil.mavlink.MAV_GENERATOR_STATUS_FLAG_IDLE)
+
+        self.progress("Moving *back* to run")
+        self.set_rc(gen_ctrl_ch, 2000) # remember this is a switch position - run
+        self.wait_generator_speed_and_state(8000, 30000, mavutil.mavlink.MAV_GENERATOR_STATUS_FLAG_GENERATING)
+
+        self.set_parameter("LOG_DISARMED", 0)
+        if not self.current_onboard_log_contains_message("LOEG"):
+            raise NotAchievedException("Did not find expected LOEG message in .bin log")
+        if not self.current_onboard_log_contains_message("LOEC"):
+            raise NotAchievedException("Did not find expected LOEC message in .bin log")
+
+        self.set_parameter("LOG_DISARMED", 1)  # Re-start logging, to help with debugging.
+        self.progress("Stopping generator")
+        self.set_rc(gen_ctrl_ch, 1000)
+
+        self.wait_statustext("Cooling down")
+
+        self.wait_generator_speed_and_state(0, 0, mavutil.mavlink.MAV_GENERATOR_STATUS_FLAG_OFF)
+
+        #######################################################################
+        # E-stop subtest.
+        #######################################################################
         self.start_subtest("Checking safety switch estop")
+        # Start the engine.
+        self.set_rc(gen_ctrl_ch, 1500)
+        self.set_rc(loweheiser_man_start_ch, 2000)
+        self.wait_message_field_values('EFI_STATUS', {
+            # note that percent isn't honouring dead-zones...
+            "rpm": 4000,  # RPM for 50% throttle
+        }, timeout=20)
+        self.set_rc(loweheiser_man_start_ch, 1000)
+
         self.set_safetyswitch_on()
         self.wait_generator_speed_and_state(0, 0, mavutil.mavlink.MAV_GENERATOR_STATUS_FLAG_OFF)
         self.wait_message_field_values('EFI_STATUS', {
@@ -9635,18 +9920,22 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.set_safetyswitch_off()
 
+        self.set_rc(gen_ctrl_ch, 1500)
+        self.set_rc(loweheiser_man_start_ch, 2000)
         self.wait_message_field_values('EFI_STATUS', {
             # note that percent isn't honouring dead-zones...
             "throttle_position": 51,  # magic fixed throttle value from AP_Generator_Loweheiser.cpp
             "rpm": 4000,  # RPM for 50% throttle
         }, timeout=20)
+        self.set_rc(loweheiser_man_start_ch, 1000)
 
         # stop generator:
         self.set_rc(gen_ctrl_ch, 1000)
         self.wait_generator_speed_and_state(0, 0, mavutil.mavlink.MAV_GENERATOR_STATUS_FLAG_OFF)
 
-        self.context_pop()
-
+        #######################################################################
+        # Battery failsafe subtest.
+        #######################################################################
         self.start_subtest("Battery Failsafes")
         self.context_push()
         batt3_capacity = 500
@@ -9661,7 +9950,14 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "BATT3_LOW_VOLT": 0,
         })
         self.reboot_sitl()
-        self.set_rc(gen_ctrl_ch, 2000)  # start generator
+
+        # Start the generator anew.
+        self.set_rc(gen_ctrl_ch, 1500)
+        self.set_rc(loweheiser_man_start_ch, 2000)
+        self.delay_sim_time(5)
+        self.set_rc(loweheiser_man_start_ch, 1000)
+        self.set_rc(gen_ctrl_ch, 2000)
+        self.wait_generator_speed_and_state(8000, 30000, mavutil.mavlink.MAV_GENERATOR_STATUS_FLAG_GENERATING)
         self.takeoff(10, mode='GUIDED')
 
         first_efi_status = self.assert_receive_message('EFI_STATUS', verbose=True)
@@ -12641,7 +12937,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.PAUSE_CONTINUE_GUIDED,
              self.RichenPower,
              self.IE24,
-             self.Loweheiser,
+             self.LoweheiserAuto,
+             self.LoweheiserManual,
              self.MAVLandedStateTakeoff,
              self.Weathervane,
              self.MAV_CMD_AIRFRAME_CONFIGURATION,


### PR DESCRIPTION
This is a preparatory PR.

I plan to disable the auto-starter functionality for Loweheiser generators, as according to the manufacturer the feature isn't polished enough for end-users yet.

In this PR, the Loweheiser autotests are split into two. One with auto-starter enabled, and one where the manual starter is enabled. The rest of the tested functionality is identical.

Once the auto-starter has been deleted, I plan to delete the corresponding autotest as well.

The Auto and Manual tests differ in the following places:

Initially the Manual test has the manual throttle and starter channels declared.
```
    def LoweheiserAuto(self):				      |	    def LoweheiserManual(self):
        '''Ensure the Loweheiser generator works as expected  |	        '''Ensure the Loweheiser generator works as expected 
							      >	        loweheiser_man_throt_ch = 10
							      >	        loweheiser_man_start_ch = 11
            "LOG_DISARMED": 1				      |	            "LOG_DISARMED": 1,
							      >	            "RC%u_OPTION" % loweheiser_man_throt_ch: 218,  # 
							      >	            "RC%u_DZ" % loweheiser_man_throt_ch: 20,
							      >	            "RC%u_TRIM" % loweheiser_man_throt_ch: 1000,
							      >	            "RC%u_MIN" % loweheiser_man_throt_ch: 1000,
							      >	            "RC%u_MAX" % loweheiser_man_throt_ch: 2000,
							      >	            "RC%u_OPTION" % loweheiser_man_start_ch: 111, # l
							      >	            loweheiser_man_throt_ch: 1000,  # zero throttle
							      >	            loweheiser_man_start_ch: 1000,  # the starter is 
```

During the state OFF subests, the manual throttle is set and its values are tested.
```
        self.context_collect('STATUSTEXT')		      |	        rc_dz = self.get_parameter('RC%u_DZ' % loweheiser_man
							      >	        rc_trim = int(self.get_parameter('RC%u_TRIM' % lowehe
							      >	        rc_min = self.get_parameter('RC%u_MIN' % loweheiser_m
							      >	        rc_max = int(self.get_parameter('RC%u_MAX' % loweheis
							      >
							      >	        self.progress("Ensuring 1000 and rc_trim all leave th
							      >	        for i in 1000, rc_trim:
							      >	            self.progress("Checking %u pwm" % i)
							      >	            self.set_rc(loweheiser_man_throt_ch, i)
							      >	            self.delay_sim_time(1)
							      >	            self.assert_received_message_field_values('EFI_ST
							      >	                "throttle_position": 0,
							      >	                "rpm": 0,
							      >	            })
							      >
							      >	        self.context_collect('STATUSTEXT')
        self.delay_sim_time(2)				      |	        self.delay_sim_time(5)
							      >
```

During the state IDLE testing, operate the manual throttle and starter.
```
							      >	        # Ensure the generator has not auto-started.
							      >	        self.assert_received_message_field_values('EFI_STATUS
							      >	            "throttle_out": 0,
							      >	            "rpm": 0,
							      >	        })
							      >
							      >	        # at 50 percent throttle should not start until user 
							      >	        pwm_for_fifty_percent_throttle = int(rc_min + rc_dz +
							      >	        self.progress("Using PWM of %u for 50 percent throttl
							      >	        self.set_rc(loweheiser_man_throt_ch, pwm_for_fifty_pe
							      >	        self.wait_message_field_values('EFI_STATUS', {
							      >	            # note that percent isn't honouring dead-zones...
							      >	            "throttle_position": 51,  # magic fixed throttle 
							      >	            "rpm": 0,
							      >	        }, timeout=20)
							      >
							      >	        self.set_rc(loweheiser_man_start_ch, 2000)  # Run the
							      >
            "throttle_position": 40,			      <
							      >	        self.set_rc(loweheiser_man_start_ch, 1000)
							      >
        self.wait_generator_speed_and_state(2000, 3000, mavut |
							      >	        self.progress("Generator at idle should not run gover
							      >	        self.wait_message_field_values('EFI_STATUS', {
							      >	            # note that percent isn't honouring dead-zones...
							      >	            "throttle_position": 51,  # magic fixed throttle 
							      >	            "rpm": 4080,  # RPM for 50% throttle
							      >	        }, timeout=20)
							      >
```

During the E-Stop test, operate the manual starter.
```
							      >	        self.set_rc(loweheiser_man_start_ch, 2000)
							      >	        self.set_rc(loweheiser_man_start_ch, 1000)
        self.set_rc(gen_ctrl_ch, 2000)			      <
        self.wait_generator_speed_and_state(8000, 30000, mavu <
							      <
							      >	        self.set_rc(gen_ctrl_ch, 1500)
							      >	        self.set_rc(loweheiser_man_start_ch, 2000)
            "throttle_position": 80,  # Throttle set by gover |	            "throttle_position": 51,  # magic fixed throttle 
            "rpm": 8000,  # RPM for 50% throttle	      |	            "rpm": 4000,  # RPM for 50% throttle
							      >	        self.set_rc(loweheiser_man_start_ch, 1000)
```

During the battery failsafe section, in the Manual case the starter is operated manually.
							      >
							      >	        # Start the generator anew.
							      >	        self.set_rc(gen_ctrl_ch, 1500)
							      >	        self.set_rc(loweheiser_man_start_ch, 2000)
							      >	        self.delay_sim_time(5)
							      >	        self.set_rc(loweheiser_man_start_ch, 1000)
							      >	        self.wait_generator_speed_and_state(8000, 30000, mavu
```