### PR TITLE
Plane: Logged rangefinder state

### DIFF
--- a/ArduPlane/Plane.cpp
+++ b/ArduPlane/Plane.cpp
@@ -280,6 +280,14 @@ void Plane::update_logging10(void)
         camera_mount.write_log();
     }
 #endif
+#if AP_RANGEFINDER_ENABLED
+    if (should_log(MASK_LOG_NTUN)) {
+        if (rangefinder.has_orientation(rangefinder_orientation()) &&
+            (g.rangefinder_landing.get() > 0)) {
+            Log_Write_RFNS();
+        }
+    }
+#endif
 }
 
 /*

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -955,6 +955,9 @@ private:
     void Log_Write_OFG_Guided();
     void Log_Write_Guided(void);
     void Log_Write_Nav_Tuning();
+#if AP_RANGEFINDER_ENABLED
+    void Log_Write_RFNS();
+#endif
     void Log_Write_Status();
     void Log_Write_RC(void);
     void Log_Write_Vehicle_Startup_Messages();

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -96,6 +96,7 @@ enum log_messages {
     LOG_OFG_MSG,
     LOG_TSIT_MSG,
     LOG_TILT_MSG,
+    LOG_RFNS_MSG,
 };
 
 #define MASK_LOG_ATTITUDE_FAST          (1<<0)

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -2820,6 +2820,8 @@ class TestSuite(abc.ABC):
                         continue
                     if "#if AP_PLANE_OFFBOARD_GUIDED_SLEW_ENABLED" in line:
                         continue
+                    if "#if AP_RANGEFINDER_ENABLED" in line:
+                        continue
                     if "#end" in line:
                         continue
                     if "LOG_COMMON_STRUCTURES" in line:


### PR DESCRIPTION
I've recently tried to debug some landing logs and I've always stumbled guessing the rangefinder state information.

This PR adds logging of the whole structure.