### PR TITLE
AP_Networking: fixed LWIP to produce a consistent build with --out

### DIFF
--- a/libraries/AP_Networking/AP_Networking.cpp
+++ b/libraries/AP_Networking/AP_Networking.cpp
@@ -470,9 +470,9 @@ const char *AP_Networking::address_to_str(uint32_t addr)
 }
 
 #ifdef LWIP_PLATFORM_ASSERT
-void ap_networking_platform_assert(const char *msg, int line, const char *file)
+void ap_networking_platform_assert(const char *msg, int line)
 {
-    AP_HAL::panic("LWIP: %s: %s:%u", msg, file, line);
+    AP_HAL::panic("LWIP: %s: %u", msg, line);
 }
 #endif
 

--- a/libraries/AP_Networking/config/lwipopts.h
+++ b/libraries/AP_Networking/config/lwipopts.h
@@ -400,8 +400,8 @@ void sys_check_core_locking(void);
 
 #ifndef LWIP_PLATFORM_ASSERT
 /* Define LWIP_PLATFORM_ASSERT to something to catch missing stdio.h includes */
-void ap_networking_platform_assert(const char *msg, int line, const char *file);
-#define LWIP_PLATFORM_ASSERT(x) ap_networking_platform_assert(x, __LINE__, __FILE__)
+void ap_networking_platform_assert(const char *msg, int line);
+#define LWIP_PLATFORM_ASSERT(x) ap_networking_platform_assert(x, __LINE__)
 #endif
 
 /*


### PR DESCRIPTION
don't give __FILE__, just rely on __LINE__ for these very rare debug events