### PR TITLE
AP_HAL_ChibiOS:fix padding issue that cause gdb load crc fail

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/common.ld
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/common.ld
@@ -107,6 +107,8 @@ SECTIONS
     .textalign : ONLY_IF_RO
     {
         . = ALIGN(8);
+        /* Fix alignment padding issue */
+        LONG(0);
     } > flash
 
     /* Legacy symbol, not used anywhere.*/


### PR DESCRIPTION
fix 0xFF 0x00 padding issue that casue AP_Periph gdb loading firmware not pass bootloader crc check