### PR TITLE
AP_Networking: disable asserts for production builds

### DIFF
--- a/libraries/AP_Networking/AP_Networking.cpp
+++ b/libraries/AP_Networking/AP_Networking.cpp
@@ -470,10 +470,17 @@ const char *AP_Networking::address_to_str(uint32_t addr)
 }
 
 #ifdef LWIP_PLATFORM_ASSERT
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL || defined(HAL_DEBUG_BUILD)
 void ap_networking_platform_assert(const char *msg, int line)
 {
-    AP_HAL::panic("LWIP: %s: %u", msg, line);
+    AP_HAL::panic("LWIP:%u %s", line, msg);
 }
+#else
+void ap_networking_platform_assert(int line)
+{
+    AP_HAL::panic("LWIP:%u", line);
+}
+#endif
 #endif
 
 #ifdef LWIP_HOOK_IP4_ROUTE

--- a/libraries/AP_Networking/config/lwipopts.h
+++ b/libraries/AP_Networking/config/lwipopts.h
@@ -400,8 +400,13 @@ void sys_check_core_locking(void);
 
 #ifndef LWIP_PLATFORM_ASSERT
 /* Define LWIP_PLATFORM_ASSERT to something to catch missing stdio.h includes */
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL || defined(HAL_DEBUG_BUILD)
 void ap_networking_platform_assert(const char *msg, int line);
 #define LWIP_PLATFORM_ASSERT(x) ap_networking_platform_assert(x, __LINE__)
+#else
+void ap_networking_platform_assert(int line);
+#define LWIP_PLATFORM_ASSERT(x) ap_networking_platform_assert(__LINE__)
+#endif
 #endif
 
 /*


### PR DESCRIPTION
the AP::panic() isn't really very useful, and this costs us 15k of flash

tested on a Pixhawk6X and working