### PR TITLE
AP_BattMonitor: alphabetise MONITOR param values

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.cpp
@@ -21,6 +21,7 @@ const AP_Param::GroupInfo AP_BattMonitor_Params::var_info[] = {
     // @Param: MONITOR
     // @DisplayName: Battery monitoring
     // @Description: Controls enabling monitoring of the battery's voltage and current
+    // @SortValues: AlphabeticalZeroAtTop
     // @Values: 0:Disabled
     // @Values: 3:Analog Voltage Only
     // @Values: 4:Analog Voltage and Current


### PR DESCRIPTION
This slightly improves usability by alphabetising the BATTx_MONITOR parameter description values.  I've posted below what it looks like afterwards so others can be the judge of whether it's an improvement or not.  I'd say AD7091R5 appearing near the top is slightly less than perfect but overall I thinks it's probably an improvement.  Potentially we could rename, "AD7091R5" to "TI-AD7091R5" or "TexasInstruments-AD7091R5" to move it lower on the list and make it less cryptic.

This is similar to PR https://github.com/ArduPilot/ardupilot/pull/29075

This change has been tested by running, "./Tools/autotest/autotest.py build.Copter test.Copter.Parameters" and reviewing the output of the "buildlogs/apm.pdef.xml" file.

      <param humanName="Battery monitoring" name="BATT_MONITOR" documentation="Controls enabling monitoring of the battery's voltage and current" user="Standard">
        <values>
          <value code="0">Disabled</value>
          <value code="28">AD7091R5</value>
          <value code="31">Analog Current Only</value>
          <value code="3">Analog Voltage Only</value>
          <value code="4">Analog Voltage and Current</value>
          <value code="6">Bebop</value>
          <value code="8">DroneCAN-BatteryInfo</value>
          <value code="27">EFI</value>
          <value code="9">ESC</value>
          <value code="11">FuelFlow</value>
          <value code="24">FuelLevelAnalog</value>
          <value code="12">FuelLevelPWM</value>
          <value code="17">Generator-Elec</value>
          <value code="18">Generator-Fuel</value>
          <value code="26">INA239_SPI</value>
          <value code="21">INA2XX (INA226 INA228 INA238 INA231 INA260)</value>
          <value code="30">INA3221</value>
          <value code="22">LTC2946</value>
          <value code="20">MPPT</value>
          <value code="15">NeoDesign</value>
          <value code="19">Rotoye</value>
          <value code="13">SMBUS-SUI3</value>
          <value code="14">SMBUS-SUI6</value>
          <value code="7">SMBus-Generic</value>
          <value code="16">SMBus-Maxell</value>
          <value code="29">Scripting</value>
          <value code="5">Solo</value>
          <value code="10">Sum Of Selected Monitors</value>
          <value code="25">Synthetic Current and Analog Voltage</value>
          <value code="23">Torqeedo</value>
        </values>
        <field name="RebootRequired">True</field>
      </param>