### PR TITLE
AP_TECS: Initialize flare sink demand with current demand

### DIFF
--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -620,7 +620,7 @@ void AP_TECS::_update_height_demand(void)
             _flare_hgt_dem_adj = _hgt_dem;
             _flare_hgt_dem_ideal = _height;
             _hgt_at_start_of_flare = _hgt_afe;
-            _hgt_rate_at_flare_entry = _climb_rate;
+            _hgt_rate_dem_at_flare_entry = _hgt_rate_dem;
             _flare_initialised = true;
         }
 
@@ -634,7 +634,7 @@ void AP_TECS::_update_height_demand(void)
         } else {
             p = 1.0f;
         }
-        _hgt_rate_dem = _hgt_rate_at_flare_entry * (1.0f - p) - land_sink_rate_adj * p;
+        _hgt_rate_dem = _hgt_rate_dem_at_flare_entry * (1.0f - p) - land_sink_rate_adj * p;
 
         _flare_hgt_dem_ideal += _DT * _hgt_rate_dem; // the ideal height profile to follow
         _flare_hgt_dem_adj   += _DT * _hgt_rate_dem; // the demanded height profile that includes the pre-flare height tracking offset
@@ -1189,7 +1189,7 @@ void AP_TECS::_initialise_states(float hgt_afe)
 
         // misc variables used for alternative precision landing pitch control
         _hgt_at_start_of_flare    = 0.0f;
-        _hgt_rate_at_flare_entry  = 0.0f;
+        _hgt_rate_dem_at_flare_entry  = 0.0f;
         _hgt_afe                  = 0.0f;
         _pitch_min_at_flare_entry = 0.0f;
 

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -401,7 +401,7 @@ private:
 
     // variables used for precision landing pitch control
     float _hgt_at_start_of_flare;
-    float _hgt_rate_at_flare_entry;
+    float _hgt_rate_dem_at_flare_entry;
     float _hgt_afe;
     float _pitch_min_at_flare_entry;
 


### PR DESCRIPTION
# Summary

This PR modifies the flare landing stage and the climb rate control, to initialize the climb rate demand not from the current climb (sink) rate, but from the current climb rate **demand**.

# Details

I noticed in a [log posted in the forum](https://discuss.ardupilot.org/t/plane-4-6-release/134619/30?u=georacer) that when the flare starts, we snap the demanded climb rate to the current climb rate.

The original idea is to progressively fade in the flare climb rate, which is usually 0.
But what actually can happen is that if the current sink rate is different to the sink rate demand, it can result in abrupt pitch up or down demand. It can also lead to unintended loss of altitude at a very critical state of the landing.

A couple of examples from that log:
<img width="724" height="925" alt="Screenshot from 2025-11-27 13-21-25" src="https://github.com/user-attachments/assets/29d3468f-f457-483b-84e5-f37673e1cc86" />
<img width="724" height="925" alt="image" src="https://github.com/user-attachments/assets/125d3303-6138-4039-93bc-98cc6e403531" />

I think it's a better idea to initialize with the similar quantity of the climb rate demand instead.

# Testing

Tested in SITL, using the `MAV_CMD_DO_LAND_START` autotest.

Before:
<img width="724" height="925" alt="Screenshot from 2025-11-27 13-58-40" src="https://github.com/user-attachments/assets/85ef6d1a-41a5-4928-b0c2-607e92e62ba6" />

After:
<img width="724" height="925" alt="image" src="https://github.com/user-attachments/assets/6c005123-27b6-4bb4-bd4f-71443bbe3928" />


# Potential improvements

It would be better perhaps if we were holding on to `_hgt_rate_dem_prev`, but there's no such quantity yet.