### PR TITLE
AP_HAL: correct interpretation of probe_ICM20948 arguments

### DIFF
--- a/libraries/AP_HAL/hwdef/scripts/hwdef.py
+++ b/libraries/AP_HAL/hwdef/scripts/hwdef.py
@@ -440,7 +440,9 @@ class HWDef:
                 probe = a[1]
 
             expected_device_count = 1
-            if driver == 'AK09916' and probe != 'probe':
+            if driver == 'AK09916' and probe == 'probe_ICM20948':
+                expected_device_count = 1
+            elif driver == 'AK09916' and probe != 'probe':
                 expected_device_count = 0
             elif driver == 'AK8963' and probe == 'probe_mpu9250':
                 expected_device_count = 1
@@ -455,7 +457,9 @@ class HWDef:
                     devlist.append(self.spi_dev_to_object(d))
                 elif d.startswith("I2C:"):
                     devlist.append(self.i2c_dev_to_object(d))
-                elif driver == 'AK8963' and probe == 'probe_mpu9250' and d.isdigit():
+                elif ((driver == 'AK8963' and probe == 'probe_mpu9250') or
+                      (driver == 'AK09916' and probe == 'probe_ICM20948') and
+                      d.isdigit()):
                     devlist.append(d)
                 else:
                     raise ValueError(f"Unknown device ({d=}) ({orig_a=})")


### PR DESCRIPTION
was being intepreted as external flag rather than instance number

This is a no-compiler-output change, it's just clearing up the confusion in the Python a little

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
3DRControlZeroG                     *      *           *       *                 *      *      *
CubeBlack                           *      *           *       *                 *      *      *
CubeOrange                          *      *           *       *                 *      *      *
CubeOrange-periph-heavy  *                 *                                                   
CubePurple                          *      *           *       *                 *      *      *
CubeSolo                                   *           *                                       
CubeYellow                          *      *           *       *                 *      *      *
Durandal                            *      *           *       *                 *      *      *
Hitec-Airspeed           *                 *                                                   
KakuteH7-bdshot                     *      *           *       *                 *      *      *
MatekF405                           *      *           *       *                 *      *      *
NucleoH755                                 *                                                   
PixSurveyA1                         *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *                  *       *                 *      *      *
f103-QiotekPeriph        *                 *                                                   
f303-Universal           *                 *                                                   
iomcu                                                                *                         
mRoControlZeroClassic               *      *           *       *                 *      *      *
mRoControlZeroF7                    *      *           *       *                 *      *      *
mRoControlZeroH7                    *      *           *       *                 *      *      *
mRoControlZeroOEMH7                 *      *           *       *                 *      *      *
mRoPixracerPro                      *      *           *       *                 *      *      *
pocket2                             *                  *       *                 *      *      *
revo-mini                           *      *           *       *                 *      *      *
skyviper-v2450                                         *                                       
t3-gem-o1                           *                  *       *                 *      *      *
```
