### PR TITLE
AP_TemperatureSensor: Support Servo_Telem sources

### DIFF
--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Backend.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Backend.cpp
@@ -20,6 +20,7 @@
 
 #include <AP_Logger/AP_Logger.h>
 #include <AP_BattMonitor/AP_BattMonitor.h>
+#include <AP_Servo_Telem/AP_Servo_Telem.h>
 
 /*
   All backends use the same parameter table and set of indices. Therefore, two
@@ -85,6 +86,10 @@ void AP_TemperatureSensor_Backend::update_external_libraries(const float tempera
 #if HAL_WITH_ESC_TELEM
     AP_ESC_Telem_Backend::TelemetryData t;
 #endif
+#if AP_SERVO_TELEM_ENABLED
+    AP_Servo_Telem *servo_telem;
+    AP_Servo_Telem::TelemetryData servo_telem_data;
+#endif
 
     switch ((AP_TemperatureSensor_Params::Source)_params.source.get()) {
 #if HAL_WITH_ESC_TELEM
@@ -110,6 +115,28 @@ void AP_TemperatureSensor_Backend::update_external_libraries(const float tempera
         case AP_TemperatureSensor_Params::Source::DroneCAN:
             // Label only, used by AP_Periph
             break;
+
+#if AP_SERVO_TELEM_ENABLED
+        case AP_TemperatureSensor_Params::Source::Servo_Motor:
+            servo_telem = AP_Servo_Telem::get_singleton();
+            if (servo_telem == nullptr) {
+                break;
+            }
+            servo_telem_data.motor_temperature_cdeg = temperature * 100;
+            servo_telem_data.present_types = AP_Servo_Telem::TelemetryData::Types::MOTOR_TEMP;
+            servo_telem->update_telem_data(_params.source_id-1, servo_telem_data);
+            break;
+
+        case AP_TemperatureSensor_Params::Source::Servo_PCB:
+            servo_telem = AP_Servo_Telem::get_singleton();
+            if (servo_telem == nullptr) {
+                break;
+            }
+            servo_telem_data.pcb_temperature_cdeg = temperature * 100;
+            servo_telem_data.present_types = AP_Servo_Telem::TelemetryData::Types::PCB_TEMP;
+            servo_telem->update_telem_data(_params.source_id-1, servo_telem_data);
+            break;
+#endif // AP_SERVO_TELEM_ENABLED
 
         case AP_TemperatureSensor_Params::Source::None:
         case AP_TemperatureSensor_Params::Source::Pitot_tube:

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Params.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Params.cpp
@@ -58,7 +58,7 @@ const AP_Param::GroupInfo AP_TemperatureSensor_Params::var_info[] = {
     // @Param: SRC
     // @DisplayName: Sensor Source
     // @Description: Sensor Source is used to designate which device's temperature report will be replaced by this temperature sensor's data. If 0 (None) then the data is only available via log. In the future a new Motor temperature report will be created for returning data directly.
-    // @Values: 0: None, 1:ESC, 2:Motor, 3:Battery Index, 4:Battery ID/SerialNumber, 5:CAN based Pitot tube, 6:DroneCAN-out on AP_Periph
+    // @Values: 0: None, 1:ESC, 2:Motor, 3:Battery Index, 4:Battery ID/SerialNumber, 5:CAN based Pitot tube, 6:DroneCAN-out on AP_Periph, 7:Servo motor, 8:Servo PCB
     // @User: Standard
     AP_GROUPINFO("SRC", 4, AP_TemperatureSensor_Params, source, (float)Source::None),
 

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Params.h
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Params.h
@@ -48,6 +48,8 @@ public:
         Battery_ID_SerialNumber     = 4,
         Pitot_tube                  = 5,
         DroneCAN                    = 6,
+        Servo_Motor                 = 7,
+        Servo_PCB                   = 8,
     };
 
     AP_Enum<Type> type;             // 0=disabled, others see frontend enum TYPE


### PR DESCRIPTION
Add support for updating motor and PCB temperatures in `Servo_Telem` from `AP_TemperatureSensor` backends.

Supports integrating temperature reports from DroneCAN servos using `ActuatorStatus`, as that message does not include a temperature field.

### Testing

`Tools/scripts/build_all.sh` completes successfully.

Tested by sending `uavcan.equipment.device.Temperature` messages from DroneCAN GUI's interactive console to SITL initially configured with:
- LOG_DISARMED: 1
- TEMP1_TYPE: 6 (DroneCAN)
- TEMP1_MSG_ID: 5
- TEMP1_SRC_ID: 1
- TEMP1_SRC: 3 (Battery_Index)

DroneCAN temperature messages were sent with a temperature of approximately 23 C and were recorded as battery temperature (BAT[0].Temp) in the log.

TEMP1_SRC was then modified to a value of 7 (ServoMotor), added in this PR. Temperature messages were sent with a value of approximately 100 C and were recorded as servo motor temperature (CSRV[0].MotT) in the log.

Finally, TEMP1_SRC was then modified to a value of 8 (ServoPCB), also added in this PR. Temperature messages were sent with a value of approximately -100 C and were recorded as servo PCB temperature (CSRV[0].PCBT) in the log.

Graph of the log from MissionPlanner:

<img width="1470" height="568" alt="image" src="https://github.com/user-attachments/assets/8b91fc2c-f914-4e79-81c1-d21340d9c087" />

### Queries

1. I'm not sure about the placement of `AP_Servo_Telem::get_singleton`. Running that for every report feels like a waste. This could be done in the switch case.
2. Is there a reason the current code initialises variables outside of the switch? It feels cleaner to have:
```cpp
switch ((AP_TemperatureSensor_Params::Source)_params.source.get()) {
    //...
    case AP_TemperatureSensor_Params::Source::ServoMotor: {
        AP_Servo_Telem *servo_telem = AP_Servo_Telem::get_singleton();
        if (servo_telem == nullptr) {
            break;
        }
        AP_Servo_Telem::TelemetryData servo_telem_data;
        servo_telem_data.motor_temperature_cdeg = temperature * 100;
        servo_telem_data.present_types = AP_Servo_Telem::TelemetryData::Types::MOTOR_TEMP;
        servo_telem->update_telem_data(_params.source_id-1, servo_telem_data);
        break;        
    }
    //...
}
```
