### PR TITLE
AP_HAL_Linux: Correcting soc filename size in file detection.

### DIFF
--- a/libraries/AP_HAL_Linux/Util_RPI.cpp
+++ b/libraries/AP_HAL_Linux/Util_RPI.cpp
@@ -59,7 +59,7 @@ void UtilRPI::_get_board_type_using_peripheral_base()
         char ranges_path[256] {};
 
         while ((entry = readdir(dir)) != nullptr) {
-            if (strncmp(entry->d_name, "soc", 4) == 0) {
+            if (strncmp(entry->d_name, "soc", 3) == 0) {
                 snprintf(ranges_path, sizeof(ranges_path), "%s/%s/ranges", base_path, entry->d_name);
                 break;
             }


### PR DESCRIPTION
```soc``` filename size for comparison has changed from ```4``` to ```3```. Without this change, you might be getting a "ranges" file not found error.