### PR TITLE
Tools: use --gap-fill 0xFF in objcopy for consistent flash content

### DIFF
--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -172,7 +172,10 @@ class generate_bin(Task.Task):
                 return ret
             return ret
         else:
-            cmd = [self.env.get_flat('OBJCOPY'), '-O', 'binary', self.inputs[0].relpath(),  self.outputs[0].relpath()]
+            # use --gap-fill 0xFF so gaps match erased flash, avoiding CRC
+            # mismatch when loading via GDB vs bootloader/DroneCAN
+            cmd = [self.env.get_flat('OBJCOPY'), '-O', 'binary', '--gap-fill', '0xFF',
+                   self.inputs[0].relpath(), self.outputs[0].relpath()]
             self.exec_command(cmd)
 
     '''list sections and split into two binaries based on section's location in internal, external or in ram'''
@@ -218,8 +221,10 @@ class generate_bin(Task.Task):
         else:
             Logs.error("Couldn't find .text section")
         # create intf binary
+        # use --gap-fill 0xFF so gaps match erased flash, avoiding CRC
+        # mismatch when loading via GDB vs bootloader/DroneCAN
         if len(intf_sections):
-            cmd = "'{}' {} -O binary {} {}".format(self.env.get_flat('OBJCOPY'),
+            cmd = "'{}' {} --gap-fill 0xFF -O binary {} {}".format(self.env.get_flat('OBJCOPY'),
                                                 ' '.join(intf_sections), self.inputs[0].relpath(), self.outputs[0].relpath())
         else:
             cmd = "cp /dev/null {}".format(self.outputs[0].relpath())
@@ -227,7 +232,7 @@ class generate_bin(Task.Task):
         if (ret < 0):
             return ret
         # create extf binary
-        cmd = "'{}' {} -O binary {} {}".format(self.env.get_flat('OBJCOPY'),
+        cmd = "'{}' {} --gap-fill 0xFF -O binary {} {}".format(self.env.get_flat('OBJCOPY'),
                                                 ' '.join(extf_sections), self.inputs[0].relpath(), self.outputs[1].relpath())
         return self.exec_command(cmd)
 


### PR DESCRIPTION
Fill gaps between sections with 0xFF instead of 0x00 when generating binary files. This ensures the .bin file content matches erased flash state, so firmware loaded via GDB produces identical flash content to firmware loaded via bootloader/DroneCAN.

Previously, gaps were filled with 0x00 by objcopy default, but GDB leaves gaps at 0xFF (erased flash). This caused CRC mismatches when the bootloader verified firmware loaded via GDB.

Fixes issue where AP_Periph firmware CRC check fails after GDB load.

alternative to https://github.com/ArduPilot/ardupilot/pull/31594
@Huibean please test

I've tested with and without this change and looked at the changes to the bin file, looks correct
```
  | Location      | Bytes | Without Fix  | With Fix     | Description                             |
  |---------------|-------|--------------|--------------|-----------------------------------------|
  | 517-528       | 12    | 00 00 00...  | FF FF FF...  | Gap padding after vectors               |
  | 537-544       | 8     | CRC 5c40f38f | CRC 14a9b7e8 | App descriptor (changed due to content) |
  | 213709-213712 | 4     | 00 00 00 00  | FF FF FF FF  | Gap padding near end                    |
```
