### PR TITLE
Tools: Add Linux Mint “zara” codename translation to install-prereqs-ubuntu.sh

### DIFF
--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -72,7 +72,7 @@ case ${RELEASE_DISTRIBUTOR} in
     linuxmint)
         # translate Mint-codenames to Ubuntu-codenames based on https://www.linuxmint.com/download_all.php
         case ${RELEASE_CODENAME} in
-            wilma | xia)
+            wilma | xia | zara)
                 RELEASE_CODENAME='noble'
                 ;;
             vanessa | vera | victoria | virginia)


### PR DESCRIPTION
This PR adds support for the Linux Mint codename **`zara`** to the prerequisites installation script.
Linux Mint “zara” (Mint 22.2) is based on **Ubuntu 24.04 LTS (noble)**, but the installer currently does not include this codename in the Mint → Ubuntu translation table. This causes the script to stop early with:

```
Unable to map zara to an Ubuntu release.
```

## **What this PR does**

* Adds `"zara"` to the existing Linux Mint → Ubuntu mapping block.
* Maps Mint `"zara"` to the correct Ubuntu base release: **`noble`**.
* Tested locally on Mint 22.2 (“zara”): installation proceeds normally after the fix.

## **Why this is needed**

Without this translation, the installer cannot detect the correct Ubuntu base codename and exits prematurely. Supporting Mint codenames in this script is consistent with past contributions (e.g., additions for `xia`, `vera`, `victoria`, `virginia` merged in April 2024).

## **Reference**

Linux Mint → Ubuntu base mapping verified from Mint’s official release information:
[https://www.linuxmint.com/download_all.php](https://www.linuxmint.com/download_all.php)

## **Testing**

* Verified on Linux Mint 22.2 “zara”
* Full install process runs successfully after applying this patch.

## **Notes**

* No other behavior is changed.
* Follows the same pattern as previous Mint translation patches.
* Happy to update the mapping or add additional Mint variants if needed.
