### PR TITLE
Tools: legacy-param options for param_parse.py

### DIFF
--- a/Tools/autotest/param_metadata/ednemit.py
+++ b/Tools/autotest/param_metadata/ednemit.py
@@ -34,6 +34,8 @@ class EDNEmit(Emit):
 
     def emit(self, g):
         for param in g.params:
+            if not self.should_emit_param(param):
+                continue
             output_dict = dict()
             # lowercase all keywords
             for key in param.__dict__.keys():

--- a/Tools/autotest/param_metadata/emit.py
+++ b/Tools/autotest/param_metadata/emit.py
@@ -10,6 +10,7 @@ class Emit:
         pass
 
     prog_values_field = re.compile(r"-?\d*\.?\d+: ?[\w ]+,?")
+    emit_legacy_params = True
 
     def close(self):
         pass
@@ -19,6 +20,11 @@ class Emit:
 
     def emit(self, g):
         pass
+
+    def should_emit_param(self, param):
+        if not self.emit_legacy_params and getattr(param, 'Legacy', False):
+            return False
+        return True
 
     def should_emit_field(self, param, field):
         return field not in ['Legacy']

--- a/Tools/autotest/param_metadata/htmlemit.py
+++ b/Tools/autotest/param_metadata/htmlemit.py
@@ -56,6 +56,8 @@ DO NOT EDIT
         t = '\n\n<h1>%s</h1>\n' % tag
 
         for param in g.params:
+            if not self.should_emit_param(param):
+                continue
             if not hasattr(param, 'DisplayName') or not hasattr(param, 'Description'):
                 continue
             d = param.__dict__

--- a/Tools/autotest/param_metadata/jsonemit.py
+++ b/Tools/autotest/param_metadata/jsonemit.py
@@ -36,6 +36,8 @@ class JSONEmit(Emit):
 
         # Check all params available
         for param in g.params:
+            if not self.should_emit_param(param):
+                continue
             param_json = {}
 
             # Get display name

--- a/Tools/autotest/param_metadata/mdemit.py
+++ b/Tools/autotest/param_metadata/mdemit.py
@@ -79,6 +79,8 @@ class MDEmit(Emit):
         t = '\n\n# %s' % tag
         
         for param in g.params:
+            if not self.should_emit_param(param):
+                continue
             if not hasattr(param, 'DisplayName') or not hasattr(param, 'Description'):
                 continue
             d = param.__dict__

--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -30,6 +30,16 @@ parser.add_argument("--no-emit",
                     action='store_false',
                     default=True,
                     help="don't emit parameter documentation, just validate")
+parser.add_argument("--legacy-params",
+                    dest='emit_legacy_params',
+                    action='store_true',
+                    default=None,
+                    help="include legacy parameters in output (default depends on format)")
+parser.add_argument("--no-legacy-params",
+                    dest='emit_legacy_params',
+                    action='store_false',
+                    default=None,
+                    help="don't include legacy parameters in output (default depends on format)")
 parser.add_argument("--format",
                     dest='output_format',
                     action='store',
@@ -712,6 +722,14 @@ for emitter_name in all_emitters.keys():
 # actually invoke each emitter:
 for emitter_name in emitters_to_use:
     emit = all_emitters[emitter_name]()
+
+    emit.emit_legacy_params = args.emit_legacy_params
+    if emit.emit_legacy_params is None:
+        if emitter_name in ('rst', 'rstlatexpdf'):
+            # do not emit legacy parameters to the Wiki
+            emit.emit_legacy_params = False
+        else:
+            emit.emit_legacy_params = True
 
     emit.emit(vehicle)
 

--- a/Tools/autotest/param_metadata/rstemit.py
+++ b/Tools/autotest/param_metadata/rstemit.py
@@ -227,8 +227,7 @@ This list is automatically generated from the latest ardupilot source code, and 
            reference=reference)
 
         for param in g.params:
-            if getattr(param, "Legacy", False):
-                # do not emit legacy parameters to the Wiki
+            if not self.should_emit_param(param):
                 continue
             if not hasattr(param, 'DisplayName') or not hasattr(param, 'Description'):
                 continue

--- a/Tools/autotest/param_metadata/xmlemit.py
+++ b/Tools/autotest/param_metadata/xmlemit.py
@@ -84,6 +84,8 @@ class XmlEmit(Emit):
         xml_parameters = etree.SubElement(self.current_element, 'parameters', name=g.reference)  # i.e. ArduPlane
 
         for param in g.params:
+            if not self.should_emit_param(param):
+                continue
             # Begin our parameter node
             if hasattr(param, 'DisplayName'):
                 xml_param = etree.SubElement(xml_parameters, 'param', humanName=param.DisplayName, name=param.name)  # i.e. ArduPlane (ArduPlane:FOOPARM)


### PR DESCRIPTION
On its own, this is a non-functional change. `build_parameters.sh` generates identical output before and after (the only diff being the gzip files, but those are because we don't pass `-n` when we call gzip)

This adds the option for a caller to explicitly decide if they want the legacy parameters included in the output.