### PR TITLE
Sub: github: move to actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/cygwin_build.yml
+++ b/.github/workflows/cygwin_build.yml
@@ -215,7 +215,7 @@ jobs:
           fail: true
 
       - name: Archive build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: binaries
           path: artifacts

--- a/.github/workflows/esp32_build.yml
+++ b/.github/workflows/esp32_build.yml
@@ -256,7 +256,7 @@ jobs:
           ls bootloader* partition* Ardu*.elf Ardu*.bin >> $GITHUB_STEP_SUMMARY
 
       - name: Archive artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
            name: esp32-binaries -${{matrix.config}}
            path: |

--- a/.github/workflows/test_dds.yml
+++ b/.github/workflows/test_dds.yml
@@ -180,7 +180,7 @@ jobs:
           Tools/scripts/build_ci.sh
 
       - name: Archive buildlog artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
            name: fail-${{matrix.config}}

--- a/.github/workflows/test_replay.yml
+++ b/.github/workflows/test_replay.yml
@@ -193,7 +193,7 @@ jobs:
           Tools/scripts/build_ci.sh
 
       - name: Archive buildlog artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
            name: fail-${{ matrix.toolchain }}-${{matrix.config}}

--- a/.github/workflows/test_sitl_blimp.yml
+++ b/.github/workflows/test_sitl_blimp.yml
@@ -248,7 +248,7 @@ jobs:
           Tools/scripts/build_ci.sh
 
       - name: Archive buildlog artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
            name: fail-${{matrix.config}}
@@ -262,7 +262,7 @@ jobs:
            retention-days: 14
 
       - name: Archive .bin artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
            name: BIN-${{matrix.config}}
            path: /__w/ardupilot/ardupilot/logs

--- a/.github/workflows/test_sitl_copter.yml
+++ b/.github/workflows/test_sitl_copter.yml
@@ -252,7 +252,7 @@ jobs:
           Tools/scripts/build_ci.sh
 
       - name: Archive buildlog artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
            name: fail-${{matrix.config}}
@@ -266,7 +266,7 @@ jobs:
            retention-days: 14
 
       - name: Archive .bin artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
            name: BIN-${{matrix.config}}
            path: /__w/ardupilot/ardupilot/logs
@@ -348,7 +348,7 @@ jobs:
           Tools/scripts/build_ci.sh
 
       - name: Archive buildlog artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
            name: fail-${{matrix.config}}
@@ -362,7 +362,7 @@ jobs:
            retention-days: 14
 
       - name: Archive .bin artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
            name: BIN-${{matrix.config}}
            path: /__w/ardupilot/ardupilot/logs

--- a/.github/workflows/test_sitl_plane.yml
+++ b/.github/workflows/test_sitl_plane.yml
@@ -248,7 +248,7 @@ jobs:
           Tools/scripts/build_ci.sh
 
       - name: Archive buildlog artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
            name: fail-${{matrix.config}}
@@ -262,7 +262,7 @@ jobs:
            retention-days: 14
 
       - name: Archive .bin artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
            name: BIN-${{matrix.config}}
            path: /__w/ardupilot/ardupilot/logs

--- a/.github/workflows/test_sitl_rover.yml
+++ b/.github/workflows/test_sitl_rover.yml
@@ -250,7 +250,7 @@ jobs:
           Tools/scripts/build_ci.sh
 
       - name: Archive buildlog artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
            name: fail-${{matrix.config}}
@@ -264,7 +264,7 @@ jobs:
            retention-days: 14
 
       - name: Archive .bin artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
            name: BIN-${{matrix.config}}
            path: /__w/ardupilot/ardupilot/logs

--- a/.github/workflows/test_sitl_sub.yml
+++ b/.github/workflows/test_sitl_sub.yml
@@ -249,7 +249,7 @@ jobs:
           Tools/scripts/build_ci.sh
 
       - name: Archive buildlog artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
            name: fail-${{matrix.config}}
@@ -263,7 +263,7 @@ jobs:
            retention-days: 14
 
       - name: Archive .bin artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
            name: BIN-${{matrix.config}}
            path: /__w/ardupilot/ardupilot/logs

--- a/.github/workflows/test_sitl_tracker.yml
+++ b/.github/workflows/test_sitl_tracker.yml
@@ -249,7 +249,7 @@ jobs:
           Tools/scripts/build_ci.sh
 
       - name: Archive buildlog artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
            name: fail-${{matrix.config}}
@@ -263,7 +263,7 @@ jobs:
            retention-days: 14
 
       - name: Archive .bin artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
            name: BIN-${{matrix.config}}
            path: /__w/ardupilot/ardupilot/logs

--- a/.github/workflows/test_unit_tests.yml
+++ b/.github/workflows/test_unit_tests.yml
@@ -149,7 +149,7 @@ jobs:
           Tools/scripts/build_ci.sh
 
       - name: Archive buildlog artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
            name: fail-${{ matrix.toolchain }}-${{matrix.config}}


### PR DESCRIPTION
v3 has been deprecated, which is breaking a bunch of CI tests for [other backports](https://github.com/ArduPilot/ardupilot/pull/31564), so I'm backporting this gift-wrapped fix from @peterbarker (#28261) to allow those tests to run :-)