### PR TITLE
board_types.txt: reserve IDs for ZeroOneA3 and ZeroOneM9

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -503,6 +503,8 @@ AP_HW_MATEKH743SE                    5501
 AP_HW_ZeroOne_X6                     5600
 AP_HW_ZeroOne_PMU                    5601
 AP_HW_ZeroOne_GNSS                   5602
+AP_HW_ZeroOne_M9                     5610
+AP_HW_ZeroOne_A3                     5620
 
 #IDs 5700-5710 reserved for DroneBuild  
 AP_HW_DroneBuild_G1                  5700


### PR DESCRIPTION
Reserve IDs for the new A3 and M9 flight controllers, new boards designed by ZeroOne