### PR TITLE
AP_Mount_Mavlink: fix GIMBAL_DEVICE_FLAGS_RETRACT being overwritten

### DIFF
--- a/libraries/AP_Mount/AP_Mount_MAVLink.cpp
+++ b/libraries/AP_Mount/AP_Mount_MAVLink.cpp
@@ -35,7 +35,7 @@ void AP_Mount_MAVLink::update()
             mnt_target.target_type = MountTargetType::ANGLE;
             mnt_target.angle_rad.set(Vector3f{0,0,0}, false);
             send_gimbal_device_retract();
-            break;
+            return;
 
         // move mount to a neutral position, typically pointing forward
         case MAV_MOUNT_MODE_NEUTRAL: {


### PR DESCRIPTION
The RETRACT mode in AP_Mount_MAVLink is not working correctly because in MAV_MOUNT_MODE_RETRACT, 
the GIMBAL_DEVICE_SET_ATTITUDE is sent with GIMBAL_DEVICE_FLAGS_RETRACT set but it was immediately 
cancelled by the generic send_gimbal_device_set_attitude() call at the end of update().

Fix by returning early after handling RETRACT ensuring the retract command is the only one sent.
This fix is tested on AVT gimbal.