### PR TITLE
hwdef: remove LAND_START_ALT from skyviper hwdefs

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/skyviper-f412-rev1/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/skyviper-f412-rev1/hwdef.dat
@@ -122,7 +122,6 @@ define HAL_STORAGE_SIZE 15360
 # setup defines for ArduCopter config
 define TOY_MODE_ENABLED 1
 define ARMING_DELAY_SEC 0
-define LAND_START_ALT 700
 define LAND_DETECTOR_ACCEL_MAX 2.0f
 
 COMPASS BMM150 I2C:0:0x10 false ROTATION_NONE

--- a/libraries/AP_HAL_ChibiOS/hwdef/skyviper-journey/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/skyviper-journey/hwdef.dat
@@ -115,7 +115,6 @@ define HAL_STORAGE_SIZE 15360
 # setup defines for ArduCopter config
 define TOY_MODE_ENABLED 1
 define ARMING_DELAY_SEC 0
-define LAND_START_ALT 700
 define LAND_DETECTOR_ACCEL_MAX 2.0f
 define ALLOW_ARM_NO_COMPASS
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/skyviper-v2450/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/skyviper-v2450/hwdef.dat
@@ -48,7 +48,6 @@ define HAL_GPIO_RADIO_IRQ       100
 # setup defines for ArduCopter config
 define TOY_MODE_ENABLED 1
 define ARMING_DELAY_SEC 0
-define LAND_START_ALT 700
 define LAND_DETECTOR_ACCEL_MAX 2.0f
 
 # support cypress and cc2500 radios


### PR DESCRIPTION
Ineffective since January 2018, best to remove the stale define than fix problem 8 years on.

See: cfc69214e6eab9d4e69c2edb716e3c71ccaddfe5