### PR TITLE
hwdef: add board type AP_HW_HWH7 with ID 1223

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -332,6 +332,8 @@ AP_HW_CSKY-PMU                       1212
 
 AP_HW_MUPilot                        1222
 
+AP_HW_HWH7                           1223
+
 # IDs 1231-1240 reserved for YARI Robotics
 AP_HW_YARIV6X                        1234
 AP_HW_YARI_GNSS                      1235


### PR DESCRIPTION
Reserve board id 1223 for AP_HW_HWH7, a custom STM32H743-based flight controller.

This PR only updates board_types.txt to allocate the ID.
Full board support (hwdef, bootloader, README) will be submitted in a later PR.