### PR TITLE
Tools: Use `del x.attr` instead of `delattr(x, 'attr')`

### DIFF
--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -487,7 +487,7 @@ def clean_param(param):
         param.Values = ",".join(new_valueList)
 
     if hasattr(param, "Vector3Parameter"):
-        delattr(param, "Vector3Parameter")
+        del param.Vector3Parameter
 
 
 def do_copy_values(vehicle_params, libraries, param):
@@ -680,7 +680,7 @@ for library in libraries:
             param.path = param.path.rsplit('/')[-1].rsplit('.')[0]
         else:
             # not a duplicate, so delete attribute.
-            delattr(param, "path")
+            del param.path
 
 for library in libraries:
     for param in library.params:


### PR DESCRIPTION
Discovered by:
* #30574

https://pypi.org/project/flake8-bugbear rule B043
>  __B043__: Do not call `delattr(x, 'attr')`, instead use `del x.attr`. There is no additional safety in using `delattr` if you know the attribute name ahead of time.