### PR TITLE
AP_Scripting: fix binding generator spelling mistakes

### DIFF
--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -2732,7 +2732,7 @@ void emit_argcheck_helper(void) {
   fprintf(source, "    }\n");
 
   // Print generic warning
-  fprintf(source, "    lua_scripts::set_and_print_new_error_message(MAV_SEVERITY_WARNING, \"Warning: userdate creation does not take arguments, will be fatal in future\");\n");
+  fprintf(source, "    lua_scripts::set_and_print_new_error_message(MAV_SEVERITY_WARNING, \"Warning: userdata creation does not take arguments, will be fatal in future\");\n");
 
   fprintf(source, "    return true;\n");
   fprintf(source, "}\n\n");


### PR DESCRIPTION
There is one mistake that ends up in the binary, so this does change one byte. Now is the time to do this when we are close to a release and it won't create backport problems.