### PR TITLE
AP_Relay: clarify internal function names

### DIFF
--- a/libraries/AP_Relay/AP_Relay.cpp
+++ b/libraries/AP_Relay/AP_Relay.cpp
@@ -344,12 +344,11 @@ void AP_Relay::init()
             if ((default_state == AP_Relay_Params::DefaultState::OFF) ||
                 (default_state == AP_Relay_Params::DefaultState::ON)) {
 
-                set_pin_by_instance(instance, (bool)default_state);
+                set_instance_state(instance, (bool)default_state);
             }
         } else {
             // all functions are supposed to be off by default
-            // this will need revisiting when we support inversion
-            set_pin_by_instance(instance, false);
+            set_instance_state(instance, false);
         }
 
         // Make sure any DroneCAN pin is enabled for streaming
@@ -371,13 +370,13 @@ void AP_Relay::set(const AP_Relay_Params::FUNCTION function, const bool value) {
             continue;
         }
 
-        set_pin_by_instance(instance, value);
+        set_instance_state(instance, value);
     }
 }
 
 // set a pins output state by instance and log if required
 // this is an internal helper, instance must have already been validated to be in range
-void AP_Relay::set_pin_by_instance(uint8_t instance, bool value)
+void AP_Relay::set_instance_state(uint8_t instance, bool value)
 {
     const int16_t pin = _params[instance].pin;
     if (pin == -1) {
@@ -391,14 +390,14 @@ void AP_Relay::set_pin_by_instance(uint8_t instance, bool value)
     }
 #endif
 
-    const bool initial_value = get_pin(pin);
+    const bool initial_value = get_pin_state(pin);
 
     if (_params[instance].inverted > 0) {
         value = !value;
     }
 
     if (initial_value != value) {
-        set_pin(pin, value);
+        set_pin_state(pin, value);
 #if HAL_LOGGING_ENABLED
 // @LoggerMessage: RELY
 // @Description: Relay state
@@ -428,7 +427,7 @@ void AP_Relay::set(const uint8_t instance, const bool value)
         return;
     }
 
-    set_pin_by_instance(instance, value);
+    set_instance_state(instance, value);
 }
 
 void AP_Relay::toggle(uint8_t instance)
@@ -496,14 +495,14 @@ bool AP_Relay::get(uint8_t instance) const
     }
 
     if (_params[instance].inverted > 0) {
-        return !get_pin(_params[instance].pin.get());
+        return !get_pin_state(_params[instance].pin.get());
     }
 
-    return get_pin(_params[instance].pin.get());
+    return get_pin_state(_params[instance].pin.get());
 }
 
 // Get relay state from pin number
-bool AP_Relay::get_pin(const int16_t pin) const
+bool AP_Relay::get_pin_state(const int16_t pin) const
 {
     if (pin < 0) {
         // invalid pin
@@ -513,7 +512,7 @@ bool AP_Relay::get_pin(const int16_t pin) const
 #if AP_RELAY_DRONECAN_ENABLED
     if (dronecan.valid_pin(pin)) {
         // Virtual DroneCAN pin
-        return dronecan.get_pin(pin);
+        return dronecan.get_pin_state(pin);
     }
 #endif
 
@@ -523,7 +522,7 @@ bool AP_Relay::get_pin(const int16_t pin) const
 }
 
 // Set relay state from pin number
-void AP_Relay::set_pin(const int16_t pin, const bool value)
+void AP_Relay::set_pin_state(const int16_t pin, const bool value)
 {
     if (pin < 0) {
         // invalid pin
@@ -533,7 +532,7 @@ void AP_Relay::set_pin(const int16_t pin, const bool value)
 #if AP_RELAY_DRONECAN_ENABLED
     if (dronecan.valid_pin(pin)) {
         // Virtual DroneCAN pin
-        dronecan.set_pin(pin, value);
+        dronecan.set_pin_state(pin, value);
         return;
     }
 #endif
@@ -600,7 +599,7 @@ uint8_t AP_Relay::DroneCAN::hardpoint_index(const int16_t pin) const
 }
 
 // Set DroneCAN relay state from pin number
-void AP_Relay::DroneCAN::set_pin(const int16_t pin, const bool value)
+void AP_Relay::DroneCAN::set_pin_state(const int16_t pin, const bool value)
 {
     const uint8_t index = hardpoint_index(pin);
 
@@ -626,7 +625,7 @@ void AP_Relay::DroneCAN::set_pin(const int16_t pin, const bool value)
 }
 
 // Get relay state from pin number, this relies on a cached value, assume remote pin is in sync
-bool AP_Relay::DroneCAN::get_pin(const int16_t pin) const
+bool AP_Relay::DroneCAN::get_pin_state(const int16_t pin) const
 {
     const uint8_t index = hardpoint_index(pin);
     return state[index].value;

--- a/libraries/AP_Relay/AP_Relay.h
+++ b/libraries/AP_Relay/AP_Relay.h
@@ -68,11 +68,13 @@ public:
 
     bool send_relay_status(const class GCS_MAVLINK &link) const;
 
+    // Set the state of all relays that are configured as the specified function type
     void set(AP_Relay_Params::FUNCTION function, bool value);
 
     // see if the relay is enabled
     bool enabled(AP_Relay_Params::FUNCTION function) const;
 
+    // Get the pin number of the instance (if assigned to a pin)
     bool get_pin_by_instance(uint8_t instance, uint8_t &pin) const;
 
 private:
@@ -80,21 +82,23 @@ private:
 
     AP_Relay_Params _params[AP_RELAY_NUM_RELAYS];
 
-    // Return true is function is valid
+    // Return true if function is valid
     bool function_valid(AP_Relay_Params::FUNCTION function) const;
 
+    // Set the state of the specified instance, if it is a valid relay
     void set(uint8_t instance, bool value);
 
     void set_defaults();
     void convert_params();
 
-    void set_pin_by_instance(uint8_t instance, bool value);
+    // Internal helper: set the instance state, accounting for configured inversion
+    void set_instance_state(uint8_t instance, bool value);
 
-    // Set relay state from pin number
-    void set_pin(const int16_t pin, const bool value);
+    // Internal helper: directly set the state of the specified pin
+    void set_pin_state(const int16_t pin, const bool value);
 
-    // Get relay state from pin number
-    bool get_pin(const int16_t pin) const;
+    // Get the state of the specified pin
+    bool get_pin_state(const int16_t pin) const;
 
 #if AP_RELAY_DRONECAN_ENABLED
     // Virtual DroneCAN pins
@@ -110,10 +114,10 @@ private:
         bool populate_next_command(uint8_t &index, uavcan_equipment_hardpoint_Command &msg) const;
 
         // Set DroneCAN relay state from pin number
-        void set_pin(const int16_t pin, const bool value);
+        void set_pin_state(const int16_t pin, const bool value);
 
         // Get relay state from pin number
-        bool get_pin(const int16_t pin) const;
+        bool get_pin_state(const int16_t pin) const;
 
     private:
 


### PR DESCRIPTION
Code cleanup.

The `get_pin`, `set_pin`, and `set_pin_by_instance` function names are confusing, especially given similar names are used elsewhere in the codebase to relate pins to a given functionality (whereas these functions relate to pin and instance states).