### PR TITLE
AP_Notify: stop SSD1306 using ownptr

### DIFF
--- a/libraries/AP_Notify/Display.cpp
+++ b/libraries/AP_Notify/Display.cpp
@@ -338,7 +338,14 @@ bool Display::init(void)
     FOREACH_I2C(i) {
         switch (pNotify->_display_type) {
         case DISPLAY_SSD1306: {
-            _driver = Display_SSD1306_I2C::probe(std::move(hal.i2c_mgr->get_device(i, NOTIFY_DISPLAY_I2C_ADDR)));
+            const auto dev_ptr = hal.i2c_mgr->get_device_ptr(i, NOTIFY_DISPLAY_I2C_ADDR);
+            if (dev_ptr == nullptr) {
+                break;
+            }
+            _driver = Display_SSD1306_I2C::probe(*dev_ptr);
+            if (_driver == nullptr) {
+                delete dev_ptr;
+            }
             break;
         }
         case DISPLAY_SH1106: {

--- a/libraries/AP_Notify/Display_SSD1306_I2C.h
+++ b/libraries/AP_Notify/Display_SSD1306_I2C.h
@@ -2,17 +2,20 @@
 
 #include "Display.h"
 #include "Display_Backend.h"
-#include <AP_HAL/I2CDevice.h>
 
 #define SSD1306_COLUMNS 128		// display columns
 #define SSD1306_ROWS 64		    // display rows
 #define SSD1306_ROWS_PER_PAGE 8
 
+namespace AP_HAL {
+    class Device;
+};
+
 class Display_SSD1306_I2C: public Display_Backend {
 
 public:
 
-    static Display_SSD1306_I2C *probe(AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    static Display_SSD1306_I2C *probe(AP_HAL::Device &_dev);
 
     void hw_update() override;
     void set_pixel(uint16_t x, uint16_t y) override;
@@ -21,7 +24,7 @@ public:
 
 protected:
 
-    Display_SSD1306_I2C(AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    Display_SSD1306_I2C(AP_HAL::Device &dev);
     ~Display_SSD1306_I2C() override;
 
 private:
@@ -30,7 +33,7 @@ private:
 
     void _timer();
 
-    AP_HAL::OwnPtr<AP_HAL::Device> _dev;
+    AP_HAL::Device &dev;
     uint8_t _displaybuffer[SSD1306_COLUMNS * SSD1306_ROWS_PER_PAGE];
     bool _need_hw_update;
 };


### PR DESCRIPTION
Eliminates use of ownptr which we're trying to get rid of

Saves a few bytes
```
Board,plane
CUAVv5,-72
```

Also moves to storing a device reference rather than using a pointer throughout, and WITH_SEMAPHORE (because I needed to modify the lines anyway)

Tested on fresh-out-of-the-packet SSD1306

