### PR TITLE
 AP_HAL_ChibiOS: use TX FIFO on bxCAN

### DIFF
--- a/libraries/AP_HAL_ChibiOS/CANIface.h
+++ b/libraries/AP_HAL_ChibiOS/CANIface.h
@@ -120,7 +120,7 @@ class ChibiOS::CANIface : public AP_HAL::CANIface
 
     void discardTimedOutTxMailboxes(uint64_t current_time);
 
-    bool canAcceptNewTxFrame(const AP_HAL::CANFrame& frame) const;
+    bool canAcceptNewTxFrame() const;
 
     bool isRxBufferEmpty() const;
 

--- a/libraries/AP_HAL_ChibiOS/CanIface.cpp
+++ b/libraries/AP_HAL_ChibiOS/CanIface.cpp
@@ -294,22 +294,6 @@ int16_t CANIface::send(const AP_HAL::CANFrame& frame, uint64_t tx_deadline,
     }
     PERF_STATS(stats.tx_requests);
 
-    /*
-     * Normally we should perform the same check as in @ref canAcceptNewTxFrame(), because
-     * it is possible that the highest-priority frame between select() and send() could have been
-     * replaced with a lower priority one due to TX timeout. But we don't do this check because:
-     *
-     *  - It is a highly unlikely scenario.
-     *
-     *  - Frames do not timeout on a properly functioning bus. Since frames do not timeout, the new
-     *    frame can only have higher priority, which doesn't break the logic.
-     *
-     *  - If high-priority frames are timing out in the TX queue, there's probably a lot of other
-     *    issues to take care of before this one becomes relevant.
-     *
-     *  - It takes CPU time. Not just CPU time, but critical section time, which is expensive.
-     */
-
     {
         CriticalSectionLocker lock;
 
@@ -579,35 +563,20 @@ void CANIface::pollErrorFlags()
     pollErrorFlagsFromISR();
 }
 
-bool CANIface::canAcceptNewTxFrame(const AP_HAL::CANFrame& frame) const
+bool CANIface::canAcceptNewTxFrame() const
 {
     /*
-     * We can accept more frames only if the following conditions are satisfied:
-     *  - There is at least one TX mailbox free (obvious enough);
-     *  - The priority of the new frame is higher than priority of all TX mailboxes.
+     * We accept more frames only if there is a mailbox free. In an ideal world,
+     * we would take into account the frame's priority but:
+     *  - That's overhead and it reduces message throughput by using fewer mailboxes
+     *  - That never worked properly on AP_Periph (as it's never called this function)
+     *  - That was never implemented in the FDCAN driver so we must be okay without it
      */
-    {
-        static const uint32_t TME = bxcan::TSR_TME0 | bxcan::TSR_TME1 | bxcan::TSR_TME2;
-        const uint32_t tme = can_->TSR & TME;
+    static const uint32_t TME = bxcan::TSR_TME0 | bxcan::TSR_TME1 | bxcan::TSR_TME2;
+    const uint32_t tme = can_->TSR & TME;
 
-        if (tme == TME) {   // All TX mailboxes are free (as in freedom).
-            return true;
-        }
-
-        if (tme == 0) {     // All TX mailboxes are busy transmitting.
-            return false;
-        }
-    }
-
-    /*
-     * The second condition requires a critical section.
-     */
-    CriticalSectionLocker lock;
-
-    for (int mbx = 0; mbx < NumTxMailboxes; mbx++) {
-        if (!(pending_tx_[mbx].pushed || pending_tx_[mbx].aborted) && !frame.priorityHigherThan(pending_tx_[mbx].frame)) {
-            return false;       // There's a mailbox whose priority is higher or equal the priority of the new frame.
-        }
+    if (tme == 0) {     // All TX mailboxes are busy transmitting.
+        return false;
     }
 
     return true;                // This new frame will be added to a free TX mailbox in the next @ref send().
@@ -646,7 +615,7 @@ void CANIface::checkAvailable(bool& read, bool& write, const AP_HAL::CANFrame* p
     read = !isRxBufferEmpty();
 
     if (pending_tx != nullptr) {
-        write = canAcceptNewTxFrame(*pending_tx);
+        write = canAcceptNewTxFrame();
     }
 }
 


### PR DESCRIPTION
FDCAN (H7 and G4) uses FIFO mode in the CAN hardware, where messages queued in the hardware are transmitted in order of being queued instead of in order of priority. This is necessary for multi-part DroneCAN messages (which is most of them) to be transmitted in the correct order. Each part is the same priority, so in priority mode the hardware transmits in slot order, which may not equal queue order, causing messages to be mis-ordered and corrupted.

In all cases before and after this PR, priority is maintained in libcanard so only the highest priority frames are dequeued for transmission by the hardware anyway. But if a high priority message is enqueued in the hardware, it will not be transmitted until lower priority messages in the hardware are sent first. This is against CAN priority semantics, where higher priority messages should be transmitted first. Fortunately, it has worked well in practice. (Though there was still the possibility for a higher priority message to be dequeued and not have space in the hardware even in priority mode).

By contrast, bxCAN (F4 and F7) did not use FIFO mode and had logic in the CAN driver to avoid enqueuing multiple messages of the same priority in the hardware. However, due to an oversight in design, AP_Periph has never used this logic, causing it to be vulnerable to mis-ordered messages, which is easily observable using a bus monitor. For whatever reason, older versions of AP_Periph appear to mis-order messages less often.

This PR fixes the AP_Periph issue by simply switching bxCAN to use FIFO mode like FDCAN and removing the priority maintenance logic from the driver. Using FIFO mode (vs. fixing priority mode) enables higher transmit throughput as all hardware slots can be used simultaneously.

This changes the behavior for bxCAN-based flight controllers which previously did correctly use priority. But these are less-used now and empirically the priority is not necessary. The concept of ignoring priority in the hardware may be reconsidered in the future, and improvements brought to both bxCAN and FDCAN.

Tested on Cube Black and MatekL431-Periph hosting a GPS and battery. Before there were several corrupted messages per minute, now there are one per hour (which is probably in the MAVCAN code, none were observed on Cube Orange).

Original PR: #31393 