### PR TITLE
AP_Compass: remove internal probing of MMC5XX3 compass

### DIFF
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -1371,13 +1371,6 @@ void Compass::_probe_external_i2c_compasses(void)
                     true, ROTATION_NONE));
         RETURN_IF_NO_SPACE;
     }
-#if AP_COMPASS_INTERNAL_BUS_PROBING_ENABLED
-    FOREACH_I2C_INTERNAL(i) {
-        add_backend(DRIVER_MMC5XX3, AP_Compass_MMC5XX3::probe(GET_I2C_DEVICE(i, HAL_COMPASS_MMC5xx3_I2C_ADDR),
-                    all_external, ROTATION_NONE));
-        RETURN_IF_NO_SPACE;
-    }
-#endif
 #endif  // AP_COMPASS_MMC5XX3_ENABLED (MMC5983MA)
 
 #if AP_COMPASS_RM3100_ENABLED


### PR DESCRIPTION
these should really only ever be in the hwdef if they are internal; we don't need generic probing of these!

In https://github.com/ArduPilot/ardupilot/pull/29722 we added probing for this MMC compass.

@tpwrules pointed out a spurious error message introduced by that PR on CubeBlack, so we're removing that message elsewhere.

Both Thomas and I realised we should not have added probing for this compass on the internal bus - the probe information should be present in any hwdef for a board which requires it.
