### PR TITLE
AP_Compass: remove probing failure message on MMC5XX3 compass

### DIFF
--- a/libraries/AP_Compass/AP_Compass_MMC5xx3.cpp
+++ b/libraries/AP_Compass/AP_Compass_MMC5xx3.cpp
@@ -90,7 +90,7 @@ bool AP_Compass_MMC5XX3::init()
     }
 
     if (whoami != MMC5983_ID) {
-        printf("MMC5983 got unexpected product id: %d, expected: %d\n", whoami, MMC5983_ID);
+        // printf("MMC5983 got unexpected product id: %d, expected: %d\n", whoami, MMC5983_ID);
         // not a MMC5983
         return false;
     }


### PR DESCRIPTION
Avoids a meaningless print on every board which does not have one of these compasses now that we probe them. Several other drivers have similar lines commented out and they may be useful to keep around for debugging instead of just deleting them completely.

Been a thing since the merge of #29722 . A future PR might uncomment it but put it behind a debug define, and similar for probe success and failure messages in all the other drivers. Dumping them on the mavlink bus is the wrong thing to do. But this PR at least restores previous behavior.

Tested that there are no more `MMC5983 got unexpected product id: 0, expected: 48` messages on Cube Orange.