### PR TITLE
AP_Logger: error on calculating length of over-long packets

### DIFF
--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -1370,8 +1370,8 @@ bool AP_Logger::fill_logstructure(struct LogStructure &logstruct, const uint8_t 
  * Tools/Replay/MsgHandler.cpp */
 int16_t AP_Logger::Write_calc_msg_len(const char *fmt) const
 {
-    uint8_t len =  LOG_PACKET_HEADER_LEN;
-    for (uint8_t i=0; i<strlen(fmt); i++) {
+    size_t len = LOG_PACKET_HEADER_LEN;
+    for (size_t i=0; i<strlen(fmt); i++) {
         switch(fmt[i]) {
         case 'a' : len += sizeof(int16_t[32]); break;
         case 'b' : len += sizeof(int8_t); break;
@@ -1401,7 +1401,10 @@ int16_t AP_Logger::Write_calc_msg_len(const char *fmt) const
             return -1;
         }
     }
-    return len;
+    if (len > LOG_PACKET_MAX_LEN) {
+        return -1;
+    }
+    return (int16_t)len;
 }
 
 /*

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -387,7 +387,7 @@ public:
     bool msg_type_in_use(uint8_t msg_type) const;
 
     // calculate the length of a message using fields specified in
-    // fmt; includes the message header
+    // fmt; includes the message header. returns -1 on on error.
     int16_t Write_calc_msg_len(const char *fmt) const;
 
     // this structure looks much like struct LogStructure in

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -117,6 +117,8 @@ const struct MultiplierStructure log_Multipliers[] = {
 #define LOG_PACKET_HEADER	       uint8_t head1, head2, msgid;
 #define LOG_PACKET_HEADER_INIT(id) head1 : HEAD_BYTE1, head2 : HEAD_BYTE2, msgid : id
 #define LOG_PACKET_HEADER_LEN 3 // bytes required for LOG_PACKET_HEADER
+// bytes required for a max-length packet, including header; stored in uint8_t
+#define LOG_PACKET_MAX_LEN (UINT8_MAX)
 
 // once the logging code is all converted we will remove these from
 // this header


### PR DESCRIPTION
The length is stored in `uint8_t` in a bunch of places, including this function. Something like `ZZZZZZZZZZZZZZZZ` is 16*64=1024 bytes long and would overflow. Previously a bogus length would be returned, leading to memory corruption. Passing such a format and corrupting memory was achievable from scripting.