### PR TITLE
AP_Scripting: mavlink: avoid crash on reinit with bigger size

### DIFF
--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -70,6 +70,10 @@ int lua_mavlink_init(lua_State *L) {
         }
         if (data.accept_msg_ids == nullptr) {
             data.accept_msg_ids = NEW_NOTHROW uint32_t[num_msgs];
+            if (data.accept_msg_ids != nullptr) {
+                data.accept_msg_ids_size = num_msgs;
+                memset(data.accept_msg_ids, UINT32_MAX, sizeof(int) * num_msgs);
+            }
         }
         if ((data.rx_buffer == nullptr) || (data.accept_msg_ids == nullptr)) {
             delete data.rx_buffer;
@@ -78,9 +82,6 @@ int lua_mavlink_init(lua_State *L) {
             data.accept_msg_ids = nullptr;
             data.accept_msg_ids_size = 0;
             failed = true;
-        } else {
-            data.accept_msg_ids_size = num_msgs;
-            memset(data.accept_msg_ids, UINT32_MAX, sizeof(int) * num_msgs);
         }
     } // release semaphore here as luaL_error will NOT do that!
 


### PR DESCRIPTION
The different size won't cause the `accept_msg_ids` array to be reallocated, but it will still be zeroed up to its new size. If that's bigger than the old one, then the heap gets corrupted, and mayhem and destruction ensues.

Fix by only initializing the related data immediately on successful allocation.

Introduced by myself (oops) in https://github.com/ArduPilot/ardupilot/pull/29257 . Tested that I can't fault my CubeOrange now.