### PR TITLE
hwdef: StellarH7V2: reinstate HAL_BATT_CURR_SCALE to fix compilation

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/StellarH7V2/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/StellarH7V2/hwdef.dat
@@ -59,8 +59,10 @@ PA4 BATT2_VOLTAGE_SENS ADC1 SCALE(1)
 define HAL_BATT_MONITOR_DEFAULT 4
 define HAL_BATT_VOLT_PIN 10
 define HAL_BATT_CURR_PIN 11
-define HAL_BATT2_VOLT_PIN 18
+define HAL_BATT_CURR_SCALE 10.0
 define HAL_BATT_VOLT_SCALE 11.0 # Onboard voltage divider 10k and 1k
+
+define HAL_BATT2_VOLT_PIN 18
 define HAL_BATT2_VOLT_SCALE 21.0 # PDB voltage divider 20k and 1k
 
 # External PDB INA169 current sensor: Rs = 0.15 mOhm, Rl = 100 kOhm (defines gain), 1 V = 66.7 A, 15 mV per 1 A


### PR DESCRIPTION
cut/copy/paste error lead to failed compilation?

Compilation was broken by https://github.com/ArduPilot/ardupilot/pull/31263 - simply broken.

```
[ 154/1249] Compiling libraries/AP_CheckFirmware/AP_CheckFirmware_secure_command.cpp
In file included from ../../libraries/AP_CANManager/AP_CANManager.h:26,
                 from ../../libraries/AP_CANManager/AP_CANSensor.h:24,
                 from ../../libraries/AP_EFI/AP_EFI_config.h:4,
                 from ../../libraries/AP_BattMonitor/AP_BattMonitor_config.h:5,
                 from ../../libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp:1:
../../libraries/AP_BattMonitor/AP_BattMonitor_Analog.h:15:45: error: 'HAL_BATT_CURR_SCALE' was not declared in this scope; did you mean 'HAL_BATT_VOLT_SCALE'?
   15 |  # define AP_BATT_CURR_AMP_PERVOLT_DEFAULT  HAL_BATT_CURR_SCALE
      |                                             ^~~~~~~~~~~~~~~~~~~
../../libraries/AP_Param/AP_Param.h:133:118: note: in definition of macro 'AP_GROUPINFO_FLAGS'
  133 | #define AP_GROUPINFO_FLAGS(name, idx, clazz, element, def, flags) { name, AP_VAROFFSET(clazz, element), {def_value : def}, flags, idx, AP_CLASSTYPE(clazz, element)}
      |                                                                                                                      ^~~
../../libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp:45:5: note: in expansion of macro 'AP_GROUPINFO'
   45 |     AP_GROUPINFO("AMP_PERVLT", 4, AP_BattMonitor_Analog, _curr_amp_per_volt, AP_BATT_CURR_AMP_PERVOLT_DEFAULT),
      |     ^~~~~~~~~~~~
../../libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp:45:78: note: in expansion of macro 'AP_BATT_CURR_AMP_PERVOLT_DEFAULT'
   45 |     AP_GROUPINFO("AMP_PERVLT", 4, AP_BattMonitor_Analog, _curr_amp_per_volt, AP_BATT_CURR_AMP_PERVOLT_DEFAULT),
```

Since we're still using analogue for the first battery sensor, I think this is *probably* correct.

Ping @marchuks 
