### PR TITLE
AP_HAL: hwdef.py: remove unused variable initialisation

### DIFF
--- a/libraries/AP_HAL/hwdef/scripts/hwdef.py
+++ b/libraries/AP_HAL/hwdef/scripts/hwdef.py
@@ -579,11 +579,7 @@ class HWDef:
             driver = baro.driver
             probe = baro.probe
 
-            args = ['*this']
-
             n = len(devlist)+1
-
-            args = []
 
             if driver == "DPS280":
                 # special handling for DPS280; use a probe method of


### PR DESCRIPTION
this is introduced and initialised further down in the method where it is used