### PR TITLE
AP_Scripting: fix and polish logger:write

### DIFF
--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -450,11 +450,7 @@ int AP_Logger_Write(lua_State *L) {
                 break;
             }
             case 'Q': { // uint64_t
-                void * ud = luaL_testudata(L, arg_index, "uint64_t");
-                if (ud == nullptr) {
-                    return luaL_argerror(L, arg_index, "argument out of range");
-                }
-                uint64_t tmp = *static_cast<uint64_t *>(ud);
+                uint64_t tmp = coerce_to_uint64_t(L, arg_index);
                 memcpy(&buffer[offset], &tmp, sizeof(uint64_t));
                 offset += sizeof(uint64_t);
                 break;


### PR DESCRIPTION
The main change is to a stack-allocated buffer. We did not leak the heap buffer, but we did not tell Lua its size upon freeing it, thereby screwing up internal accounting and creating the impression of a leak. We don't use the problematic `luaM_free` anywhere else.

While I was in there I also did some other nice things to make it more efficient. Saves a couple hundred bytes on Cube Orange. Tested that the calls in our little logging example still work and the dataflash log contains the right values.

Supersedes #31652 (who reported the original possible leak)