### PR TITLE
AP_Mount: correct rate RC targetting for SToRM32 gimbals (both sorts)

### DIFF
--- a/libraries/AP_Mount/AP_Mount_SToRM32.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.cpp
@@ -50,9 +50,6 @@ void AP_Mount_SToRM32::update()
         // point to the angles given by a mavlink message
         case MAV_MOUNT_MODE_MAVLINK_TARGETING:
             // mnt_target should have already been populated by set_angle_target() or set_rate_target(). Update target angle from rate if necessary
-            if (mnt_target.target_type == MountTargetType::RATE) {
-                update_angle_target_from_rate(mnt_target.rate_rads, mnt_target.angle_rad);
-            }
             resend_now = true;
             break;
 
@@ -89,6 +86,11 @@ void AP_Mount_SToRM32::update()
         default:
             // we do not know this mode so do nothing
             break;
+    }
+
+    // update angle targets from angle rates
+    if (mnt_target.target_type == MountTargetType::RATE) {
+        update_angle_target_from_rate(mnt_target.rate_rads, mnt_target.angle_rad);
     }
 
     // resend target angles at least once per second

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
@@ -47,9 +47,6 @@ void AP_Mount_SToRM32_serial::update()
         // point to the angles given by a mavlink message
         case MAV_MOUNT_MODE_MAVLINK_TARGETING:
             // mnt_target should have already been filled in by set_angle_target() or set_rate_target()
-            if (mnt_target.target_type == MountTargetType::RATE) {
-                update_angle_target_from_rate(mnt_target.rate_rads, mnt_target.angle_rad);
-            }
             resend_now = true;
             break;
 
@@ -86,6 +83,11 @@ void AP_Mount_SToRM32_serial::update()
         default:
             // we do not know this mode so do nothing
             break;
+    }
+
+    // update angle targets from angle rates
+    if (mnt_target.target_type == MountTargetType::RATE) {
+        update_angle_target_from_rate(mnt_target.rate_rads, mnt_target.angle_rad);
     }
 
     // resend target angles at least once per second


### PR DESCRIPTION
update_mnt_target_from_rc_target can put the backend into rate mode if the parameters say that's how things should work.

The SToRM32 backends weren't adding that rate up to come up with an angle like the other backends (CADDx, XFRobot) do.

This makes the driver look like the other backends who need us to make up an angle for them.

This patch is simply by inspection, I don't have a working gimbal of either sort.

FWIW this commit killed it in 2023: fd6db1ef4501b5ede24035a0961cef528fc31601
<img width="1978" height="781" alt="image" src="https://github.com/user-attachments/assets/60f7759d-5d0b-49b9-a16d-64e5f6411a8e" />
