### PR TITLE
Use compass helper functions for hwdef-defined compass probes

### DIFF
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -1564,6 +1564,17 @@ void Compass::probe_ak8963_via_mpu9250(uint8_t imu_instance, Rotation rotation)
     auto *backend = AP_Compass_AK8963::probe_mpu9250(imu_instance, rotation);
     add_backend(DRIVER_AK8963, backend);  // add_backend does nullptr check
 }
+void Compass::probe_ak8963_via_mpu9250(uint8_t i2c_bus, uint8_t ak8963_addr, Rotation rotation)
+{
+    if (!_driver_enabled(DRIVER_AK8963)) {
+        return;
+    }
+    auto *backend = AP_Compass_AK8963::probe_mpu9250(
+        GET_I2C_DEVICE(i2c_bus, ak8963_addr),
+        rotation
+    );
+    add_backend(DRIVER_AK8963, backend);  // add_backend does nullptr check
+}
 #endif  // AP_COMPASS_AK8963_ENABLED
 
 #if AP_COMPASS_AK09916_ENABLED && AP_COMPASS_ICM20948_ENABLED
@@ -1609,6 +1620,18 @@ void Compass::probe_i2c_dev(DriverType driver_type, probe_i2c_dev_probefn_t prob
     add_backend(driver_type, backend);  // add_backend does nullptr check
 }
 
+// short-lived method which expects a probe function that doesn't
+// offer the ability to specify the compass as external:
+void Compass::probe_i2c_dev(DriverType driver_type, probe_i2c_dev_noexternal_probefn_t probefn, uint8_t i2c_bus, uint8_t i2c_addr, Rotation rotation)
+{
+    if (!_driver_enabled(driver_type)) {
+        return;
+    }
+    auto *backend = probefn(GET_I2C_DEVICE(i2c_bus, i2c_addr), rotation);
+
+    add_backend(driver_type, backend);  // add_backend does nullptr check
+}
+
 void Compass::probe_spi_dev(DriverType driver_type, probe_spi_dev_probefn_t probefn, const char *name, bool external, Rotation rotation)
 {
     if (!_driver_enabled(driver_type)) {
@@ -1619,7 +1642,7 @@ void Compass::probe_spi_dev(DriverType driver_type, probe_spi_dev_probefn_t prob
     add_backend(driver_type, backend);  // add_backend does nullptr check
 }
 
-// short-lived method which expectes a probe function that doesn't
+// short-lived method which expects a probe function that doesn't
 // offer the ability to specify an external rotation:
 void Compass::probe_spi_dev(DriverType driver_type, probe_spi_dev_noexternal_probefn_t probefn, const char *name, Rotation rotation)
 {

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -505,10 +505,16 @@ private:
     // helper probe functions
     void probe_ak09916_via_icm20948(uint8_t i2c_bus, uint8_t ak09916_addr, uint8_t icm20948_addr, bool external, Rotation rotation);
     void probe_ak09916_via_icm20948(uint8_t ins_instance, Rotation rotation);
+    void probe_ak8963_via_mpu9250(uint8_t i2c_bus, uint8_t ak8963_addr, Rotation rotation);
     void probe_ak8963_via_mpu9250(uint8_t imu_instance, Rotation rotation);
 
     using probe_i2c_dev_probefn_t = AP_Compass_Backend* (*)(AP_HAL::OwnPtr<AP_HAL::Device>, bool, Rotation);
     void probe_i2c_dev(DriverType driver_type, probe_i2c_dev_probefn_t probefn, uint8_t i2c_bus, uint8_t i2c_addr, bool external, Rotation rotation);
+
+    // short-lived method which expects a probe function that doesn't
+    // offer the ability to specify the compass as external:
+    using probe_i2c_dev_noexternal_probefn_t = AP_Compass_Backend* (*)(AP_HAL::OwnPtr<AP_HAL::Device>, Rotation);
+    void probe_i2c_dev(DriverType driver_type, probe_i2c_dev_noexternal_probefn_t, uint8_t i2c_bus, uint8_t i2c_addr, Rotation rotation);
 
     using probe_spi_dev_probefn_t = AP_Compass_Backend* (*)(AP_HAL::OwnPtr<AP_HAL::Device>, bool, Rotation);
     void probe_spi_dev(DriverType driver_type, probe_spi_dev_probefn_t probefn, const char *name, bool external, Rotation rotation);

--- a/libraries/AP_HAL/hwdef/scripts/hwdef.py
+++ b/libraries/AP_HAL/hwdef/scripts/hwdef.py
@@ -458,6 +458,10 @@ class HWDef:
             if len(a) > 1 and a[1].startswith('probe'):
                 probe = a[1]
 
+            # these two are aliases:
+            if probe == 'probe_ICM20948_SPI':
+                probe = 'probe_ICM20948'
+
             expected_device_count = 1
             if driver == 'AK09916' and probe == 'probe_ICM20948':
                 expected_device_count = 1
@@ -527,30 +531,65 @@ class HWDef:
             n = len(devlist)+1
             devlist.append('HAL_MAG_PROBE%u' % n)
 
-            args = []
-            for dev in compass.devlist:
-                if isinstance(dev, I2CDev):
-                    if dev.buses_to_probe == 'SINGLE':
-                        busnum = str(dev.busnum)
-                    elif dev.buses_to_probe in {'ALL', 'ALL_EXTERNAL', 'ALL_INTERNAL'}:
-                        busnum = 'b'
-                    else:
-                        raise ValueError("Unexpected {buses_to_probe=}")
-                    args.extend(["GET_I2C_DEVICE(%s,0x%02x)" % (busnum, dev.busaddr)])
-                elif isinstance(dev, SPIDev):
-                    args.extend([f'hal.spi->get_device("{dev.name}")'])
-                elif dev.isdigit():
-                    args.extend([str(dev)])
+            def i2c_dev_as_arguments_string(dev):
+                if dev.buses_to_probe == 'SINGLE':
+                    busnum = str(dev.busnum)
+                elif dev.buses_to_probe in {'ALL', 'ALL_EXTERNAL', 'ALL_INTERNAL'}:
+                    busnum = 'b'
                 else:
-                    raise ValueError("unexpected devbit {dev=}")
+                    raise ValueError("Unexpected {buses_to_probe=}")
+                return "%s, 0x%02x" % (busnum, dev.busaddr)
 
-            if compass.force_external is not None:
-                args.append(str(compass.force_external))
-            args.append(str(compass.rotation))
+            args = []
+            if probe == "probe":
+                for dev in compass.devlist:
+                    if isinstance(dev, I2CDev):
+                        compass_probe_method = 'probe_i2c_dev'
+                        args.append(f"DRIVER_{compass.driver}")
+                        args.append(f'AP_Compass_{compass.driver}::probe')
+                        args.append(i2c_dev_as_arguments_string(dev))
+                    elif isinstance(dev, SPIDev):
+                        compass_probe_method = 'probe_spi_dev'
+                        args.append(f"DRIVER_{compass.driver}")
+                        args.append(f'AP_Compass_{compass.driver}::probe')
+                        args.append(f'"{dev.name}"')
+                    elif dev.isdigit():
+                        args.append(str(dev))
+                    else:
+                        raise ValueError("unexpected devbit {dev=}")
 
-            f.write(
-                '#define HAL_MAG_PROBE%u %s {add_backend(DRIVER_%s, AP_Compass_%s::%s(%s));RETURN_IF_NO_SPACE;}\n'
-                % (n, wrapper, driver, driver, probe, ','.join(args)))
+                if compass.force_external is not None:
+                    args.append(str(compass.force_external))
+                args.append(str(compass.rotation))
+            elif probe == 'probe_ICM20948':
+                compass_probe_method = 'probe_ak09916_via_icm20948'
+                if len(compass.devlist) != 1:
+                    raise ValueError(f"Expected 0 arguments for {probe} ({compass.devlist=}")
+                if isinstance(compass.devlist[0], I2CDev):
+                    devstring = i2c_dev_as_arguments_string(compass.devlist[0])
+                else:
+                    devstring = compass.devlist[0]
+                args.append(devstring)
+                if compass.force_external is not None:
+                    args.append(str(compass.force_external))
+                args.append(str(compass.rotation))
+            elif probe == 'probe_mpu9250':
+                compass_probe_method = 'probe_ak8963_via_mpu9250'
+                if len(compass.devlist) != 1:
+                    raise ValueError(f"Expected 0 arguments for {probe} ({compass.devlist=}")
+                if isinstance(compass.devlist[0], I2CDev):
+                    devstring = i2c_dev_as_arguments_string(compass.devlist[0])
+                else:
+                    devstring = compass.devlist[0]
+                args.append(devstring)
+                if compass.force_external is not None:
+                    args.append(str(compass.force_external))
+                args.append(str(compass.rotation))
+            else:
+                raise ValueError(f"Unknown probe method {probe=}")
+
+            f.write(f'#define HAL_MAG_PROBE{n} {wrapper} {{{compass_probe_method}({", ".join(args)});RETURN_IF_NO_SPACE;}}\n')
+
             f.write(f"#undef AP_COMPASS_{driver}_ENABLED\n#define AP_COMPASS_{driver}_ENABLED 1\n")
         if len(devlist) > 0:
             f.write('#define HAL_MAG_PROBE_LIST %s\n\n' % ';'.join(devlist))


### PR DESCRIPTION
Well, Claude was happy.

```
● Based on my comprehensive analysis of the generated hwdef.h files, I don't see any problems with your changes. Here's what I found:

  Summary of Changes

  Your modifications correctly convert compass probe definitions from the old add_backend format to new wrapper functions:

  Old format:
  add_backend(DRIVER_XXX, AP_Compass_XXX::probe(GET_I2C_DEVICE(bus,addr), external, rotation))

  New format:
  probe_i2c_dev(DRIVER_XXX, AP_Compass_XXX::probe, bus, addr, external, rotation)

  Verification Results

  1. Correct handling of different probe signatures:
    - Standard compasses (HMC5843, IST8310, RM3100, etc.): Use 5-parameter probe_i2c_dev/probe_spi_dev with external flag
    - Special compasses (LSM303D, AK8963 direct): Correctly use 4-parameter "noexternal" variant
    - MPU/ICM auxiliary compasses (AK8963 via MPU9250, AK09916 via ICM20948): Use dedicated wrapper functions
  2. Syntax validation:
    - All 315 compass probe lines were converted (matched count)
    - All parentheses are balanced
    - All lines end with RETURN_IF_NO_SPACE;
    - No malformed syntax detected
  3. Wrapper function existence:
    - Verified all wrapper functions exist in libraries/AP_Compass/AP_Compass.cpp (lines 1613-1656)
    - Confirmed overloaded versions handle both standard and "noexternal" probe signatures
  4. Sample checks across board types:
    - Pixhawk variants: ✓
    - Cube variants: ✓
    - Peripheral boards: ✓
    - Various compass types (I2C, SPI, auxiliary): ✓

  The changes appear to be production-ready with no issues detected.
```

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  16                                *                                                   
Durandal                            -160            -160   *           -160    -160              -160   -160   -160
Hitec-Airspeed           *                                 *                                                   
KakuteH7-bdshot                     *               *      *           *       *                 *      *      *
MatekF405                           *               *      *           *       *                 *      *      *
MatekH7A3                           *               *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  120             120                128     120               128    120    128
SITL_x86_64_linux_gnu               *               *                  *       *                 *      *      *
YJUAV_A6SE                          -160            -160   *           -160    -160              -160   -160   -160
f103-QiotekPeriph        -344                              *                                                   
f303-MatekGPS            104                               *                                                   
f303-Universal           24                                *                                                   
iomcu                                                                                *                         
mindpx-v2                           -32             -32    *           -32     -32               -32    -32    -32
revo-mini                           72              72     *           72      72                72     72     72
skyviper-v2450                                                         80                                      
speedybeef4                         *               *      *           *       *                 *      *      *
```

A useful test is to use `./Tools/scripts/configure_all.py --copy-hwdef old-hwdefs --stop` on master and similarly on this branch and then `diff -ur` on the two directories to see the difference.

Will be testing on hardware.


pr/compass-ownptr is the next step (and saves flash on all boards tested)
