### PR TITLE
AP_Mount: use update_mnt_target in SToRM32s, XFRobot and CADDx

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -925,6 +925,10 @@ void AP_Mount_Backend::update_mnt_target()
     // change to RC_TARGETING mode if RC input has changed
     set_rctargeting_on_rcinput_change();
 
+    // note that not all backends currently use "fresh".  We should
+    // change this to have all backends use this or none use it.
+    mnt_target.fresh = false;
+
     switch (get_mode()) {
     case MAV_MOUNT_MODE_RETRACT: {
         // move mount to a "retracted" position.  To-Do: remove support and replace with a relaxed mode?
@@ -945,17 +949,20 @@ void AP_Mount_Backend::update_mnt_target()
     case MAV_MOUNT_MODE_MAVLINK_TARGETING:
         // point to the angles given by a mavlink message
         // mavlink targets are stored while handling the incoming message
+        mnt_target.fresh = true;
         return;
 
     case MAV_MOUNT_MODE_RC_TARGETING:
         // RC radio manual angle control, but with stabilization from the AHRS
         update_mnt_target_from_rc_target();
+        mnt_target.fresh = true;
         return;
 
     case MAV_MOUNT_MODE_GPS_POINT:
         // point mount to a GPS point given by the mission planner
         if (get_angle_target_to_roi(mnt_target.angle_rad)) {
             mnt_target.target_type = MountTargetType::ANGLE;
+            mnt_target.fresh = true;
         }
         return;
 
@@ -963,6 +970,7 @@ void AP_Mount_Backend::update_mnt_target()
         // point mount to Home location
         if (get_angle_target_to_home(mnt_target.angle_rad)) {
             mnt_target.target_type = MountTargetType::ANGLE;
+            mnt_target.fresh = true;
         }
         return;
 
@@ -970,6 +978,7 @@ void AP_Mount_Backend::update_mnt_target()
         // point mount to another vehicle
         if (get_angle_target_to_sysid(mnt_target.angle_rad)) {
             mnt_target.target_type = MountTargetType::ANGLE;
+            mnt_target.fresh = true;
         }
         return;
     case MAV_MOUNT_MODE_ENUM_END:

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -322,6 +322,11 @@ protected:
         MountTarget angle_rad;      // angle target in radians
         MountTarget rate_rads;      // rate target in rad/s
         uint32_t last_rate_request_ms;
+
+        // 'fresh' indicates that the MountTarget data in this
+        // structure has been updated in this loop; some backends use
+        // this to gate whether to send data to the device or not.
+        bool fresh;
     } mnt_target;
     
     // RP earth frame locks accessible by backend

--- a/libraries/AP_Mount/AP_Mount_CADDX.cpp
+++ b/libraries/AP_Mount/AP_Mount_CADDX.cpp
@@ -22,72 +22,7 @@ void AP_Mount_CADDX::update()
         return;
     }
 
-    // change to RC_TARGETING mode if RC input has changed
-    set_rctargeting_on_rcinput_change();
-
-    // flag to trigger sending target angles to gimbal
-    bool resend_now = false;
-
-    // update based on mount mode
-    switch (get_mode()) {
-        // move mount to a "retracted" position.  To-Do: remove support and replace with a relaxed mode?
-        case MAV_MOUNT_MODE_RETRACT: {
-            const Vector3f &target = _params.retract_angles.get();
-            mnt_target.angle_rad.set(target*DEG_TO_RAD, false);
-            mnt_target.target_type = MountTargetType::ANGLE;
-            break;
-        }
-
-        // move mount to a neutral position, typically pointing forward
-        case MAV_MOUNT_MODE_NEUTRAL: {
-            const Vector3f &target = _params.neutral_angles.get();
-            mnt_target.angle_rad.set(target*DEG_TO_RAD, false);
-            mnt_target.target_type = MountTargetType::ANGLE;
-            break;
-        }
-
-        // point to the angles given by a mavlink message
-        case MAV_MOUNT_MODE_MAVLINK_TARGETING:
-            // mnt_target should have already been filled in by set_angle_target() or set_rate_target()
-            resend_now = true;
-            break;
-
-        // RC radio manual angle control, but with stabilization from the AHRS
-        case MAV_MOUNT_MODE_RC_TARGETING: {
-            // update targets using pilot's RC inputs
-            update_mnt_target_from_rc_target();
-            resend_now = true;
-            break;
-        }
-
-        // point mount to a GPS point given by the mission planner
-        case MAV_MOUNT_MODE_GPS_POINT:
-            if (get_angle_target_to_roi(mnt_target.angle_rad)) {
-                mnt_target.target_type = MountTargetType::ANGLE;
-                resend_now = true;
-            }
-            break;
-
-        // point mount to Home location
-        case MAV_MOUNT_MODE_HOME_LOCATION:
-            if (get_angle_target_to_home(mnt_target.angle_rad)) {
-                mnt_target.target_type = MountTargetType::ANGLE;
-                resend_now = true;
-            }
-            break;
-
-        // point mount to another vehicle
-        case MAV_MOUNT_MODE_SYSID_TARGET:
-            if (get_angle_target_to_sysid(mnt_target.angle_rad)) {
-                mnt_target.target_type = MountTargetType::ANGLE;
-                resend_now = true;
-            }
-            break;
-
-        default:
-            // we do not know this mode so do nothing
-            break;
-    }
+    AP_Mount_Backend::update_mnt_target();
 
     // update angle targets from angle rates
     if (mnt_target.target_type == MountTargetType::RATE) {
@@ -95,8 +30,7 @@ void AP_Mount_CADDX::update()
     }
 
     // resend target angles at least once per second
-    resend_now = resend_now || ((AP_HAL::millis() - _last_send_ms) > AP_MOUNT_CADDX_RESEND_MS);
-    if (resend_now) {
+    if (mnt_target.fresh || ((AP_HAL::millis() - _last_send_ms) > AP_MOUNT_CADDX_RESEND_MS)) {
         send_target_angles(mnt_target.angle_rad);
     }
 }

--- a/libraries/AP_Mount/AP_Mount_SToRM32.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.cpp
@@ -23,70 +23,7 @@ void AP_Mount_SToRM32::update()
         return;
     }
 
-    // change to RC_TARGETING mode if RC input has changed
-    set_rctargeting_on_rcinput_change();
-
-    // flag to trigger sending target angles to gimbal
-    bool resend_now = false;
-
-    // update based on mount mode
-    switch(get_mode()) {
-        // move mount to a "retracted" position.  To-Do: remove support and replace with a relaxed mode?
-        case MAV_MOUNT_MODE_RETRACT: {
-            const Vector3f &target = _params.retract_angles.get();
-            mnt_target.angle_rad.set(target*DEG_TO_RAD, false);
-            mnt_target.target_type = MountTargetType::ANGLE;
-            break;
-        }
-
-        // move mount to a neutral position, typically pointing forward
-        case MAV_MOUNT_MODE_NEUTRAL: {
-            const Vector3f &target = _params.neutral_angles.get();
-            mnt_target.angle_rad.set(target*DEG_TO_RAD, false);
-            mnt_target.target_type = MountTargetType::ANGLE;
-            break;
-        }
-
-        // point to the angles given by a mavlink message
-        case MAV_MOUNT_MODE_MAVLINK_TARGETING:
-            // mnt_target should have already been populated by set_angle_target() or set_rate_target(). Update target angle from rate if necessary
-            resend_now = true;
-            break;
-
-        // RC radio manual angle control, but with stabilization from the AHRS
-        case MAV_MOUNT_MODE_RC_TARGETING:
-            update_mnt_target_from_rc_target();
-            resend_now = true;
-            break;
-
-        // point mount to a GPS point given by the mission planner
-        case MAV_MOUNT_MODE_GPS_POINT:
-            if (get_angle_target_to_roi(mnt_target.angle_rad)) {
-                mnt_target.target_type = MountTargetType::ANGLE;
-                resend_now = true;
-            }
-            break;
-
-        // point mount to Home location
-        case MAV_MOUNT_MODE_HOME_LOCATION:
-            if (get_angle_target_to_home(mnt_target.angle_rad)) {
-                mnt_target.target_type = MountTargetType::ANGLE;
-                resend_now = true;
-            }
-            break;
-
-        // point mount to another vehicle
-        case MAV_MOUNT_MODE_SYSID_TARGET:
-            if (get_angle_target_to_sysid(mnt_target.angle_rad)) {
-                mnt_target.target_type = MountTargetType::ANGLE;
-                resend_now = true;
-            }
-            break;
-
-        default:
-            // we do not know this mode so do nothing
-            break;
-    }
+    AP_Mount_Backend::update_mnt_target();
 
     // update angle targets from angle rates
     if (mnt_target.target_type == MountTargetType::RATE) {
@@ -94,7 +31,7 @@ void AP_Mount_SToRM32::update()
     }
 
     // resend target angles at least once per second
-    if (resend_now || ((AP_HAL::millis() - _last_send) > AP_MOUNT_STORM32_RESEND_MS)) {
+    if (mnt_target.fresh || ((AP_HAL::millis() - _last_send) > AP_MOUNT_STORM32_RESEND_MS)) {
         send_do_mount_control(mnt_target.angle_rad);
     }
 }

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
@@ -20,70 +20,7 @@ void AP_Mount_SToRM32_serial::update()
 
     read_incoming(); // read the incoming messages from the gimbal
 
-    // change to RC_TARGETING mode if RC input has changed
-    set_rctargeting_on_rcinput_change();
-
-    // flag to trigger sending target angles to gimbal
-    bool resend_now = false;
-
-    // update based on mount mode
-    switch(get_mode()) {
-        // move mount to a "retracted" position.  To-Do: remove support and replace with a relaxed mode?
-        case MAV_MOUNT_MODE_RETRACT: {
-            const Vector3f &target = _params.retract_angles.get();
-            mnt_target.angle_rad.set(target*DEG_TO_RAD, false);
-            mnt_target.target_type = MountTargetType::ANGLE;
-            break;
-        }
-
-        // move mount to a neutral position, typically pointing forward
-        case MAV_MOUNT_MODE_NEUTRAL: {
-            const Vector3f &target = _params.neutral_angles.get();
-            mnt_target.angle_rad.set(target*DEG_TO_RAD, false);
-            mnt_target.target_type = MountTargetType::ANGLE;
-            break;
-        }
-
-        // point to the angles given by a mavlink message
-        case MAV_MOUNT_MODE_MAVLINK_TARGETING:
-            // mnt_target should have already been filled in by set_angle_target() or set_rate_target()
-            resend_now = true;
-            break;
-
-        // RC radio manual angle control, but with stabilization from the AHRS
-        case MAV_MOUNT_MODE_RC_TARGETING:
-            update_mnt_target_from_rc_target();
-            resend_now = true;
-            break;
-
-        // point mount to a GPS point given by the mission planner
-        case MAV_MOUNT_MODE_GPS_POINT:
-            if (get_angle_target_to_roi(mnt_target.angle_rad)) {
-                mnt_target.target_type = MountTargetType::ANGLE;
-                resend_now = true;
-            }
-            break;
-
-        // point mount to Home location
-        case MAV_MOUNT_MODE_HOME_LOCATION:
-            if (get_angle_target_to_home(mnt_target.angle_rad)) {
-                mnt_target.target_type = MountTargetType::ANGLE;
-                resend_now = true;
-            }
-            break;
-
-        // point mount to another vehicle
-        case MAV_MOUNT_MODE_SYSID_TARGET:
-            if (get_angle_target_to_sysid(mnt_target.angle_rad)) {
-                mnt_target.target_type = MountTargetType::ANGLE;
-                resend_now = true;
-            }
-            break;
-
-        default:
-            // we do not know this mode so do nothing
-            break;
-    }
+    AP_Mount_Backend::update_mnt_target();
 
     // update angle targets from angle rates
     if (mnt_target.target_type == MountTargetType::RATE) {
@@ -91,7 +28,7 @@ void AP_Mount_SToRM32_serial::update()
     }
 
     // resend target angles at least once per second
-    resend_now = resend_now || ((AP_HAL::millis() - _last_send) > AP_MOUNT_STORM32_SERIAL_RESEND_MS);
+    const bool resend_now = mnt_target.fresh || ((AP_HAL::millis() - _last_send) > AP_MOUNT_STORM32_SERIAL_RESEND_MS);
 
     if ((AP_HAL::millis() - _last_send) > AP_MOUNT_STORM32_SERIAL_RESEND_MS*2) {
         _reply_type = ReplyType_UNKNOWN;

--- a/libraries/AP_Mount/AP_Mount_XFRobot.cpp
+++ b/libraries/AP_Mount/AP_Mount_XFRobot.cpp
@@ -129,72 +129,7 @@ void AP_Mount_XFRobot::update()
     // check for recording request timeout
     check_recording_timeout();
 
-    // change to RC_TARGETING mode if RC input has changed
-    set_rctargeting_on_rcinput_change();
-
-    // flag to trigger sending target angles to gimbal
-    bool resend_now = false;
-
-    // update based on mount mode
-    switch (get_mode()) {
-        // move mount to a "retracted" position
-        case MAV_MOUNT_MODE_RETRACT: {
-            const Vector3f &target = _params.retract_angles.get();
-            mnt_target.angle_rad.set(target*DEG_TO_RAD, false);
-            mnt_target.target_type = MountTargetType::ANGLE;
-            break;
-        }
-
-        // move mount to a neutral position, typically pointing forward
-        case MAV_MOUNT_MODE_NEUTRAL: {
-            const Vector3f &target = _params.neutral_angles.get();
-            mnt_target.angle_rad.set(target*DEG_TO_RAD, false);
-            mnt_target.target_type = MountTargetType::ANGLE;
-            break;
-        }
-
-        // point to the angles given by a mavlink message
-        case MAV_MOUNT_MODE_MAVLINK_TARGETING:
-            // mnt_target should have already been filled in by set_angle_target() or set_rate_target()
-            resend_now = true;
-            break;
-
-        // RC radio manual angle control, but with stabilization from the AHRS
-        case MAV_MOUNT_MODE_RC_TARGETING: {
-            // update targets using pilot's RC inputs
-            update_mnt_target_from_rc_target();
-            resend_now = true;
-            break;
-        }
-
-        // point mount to a GPS point given by the mission planner
-        case MAV_MOUNT_MODE_GPS_POINT:
-            if (get_angle_target_to_roi(mnt_target.angle_rad)) {
-                mnt_target.target_type = MountTargetType::ANGLE;
-                resend_now = true;
-            }
-            break;
-
-        // point mount to Home location
-        case MAV_MOUNT_MODE_HOME_LOCATION:
-            if (get_angle_target_to_home(mnt_target.angle_rad)) {
-                mnt_target.target_type = MountTargetType::ANGLE;
-                resend_now = true;
-            }
-            break;
-
-        // point mount to another vehicle
-        case MAV_MOUNT_MODE_SYSID_TARGET:
-            if (get_angle_target_to_sysid(mnt_target.angle_rad)) {
-                mnt_target.target_type = MountTargetType::ANGLE;
-                resend_now = true;
-            }
-            break;
-
-        default:
-            // we do not know this mode so do nothing
-            break;
-    }
+    AP_Mount_Backend::update_mnt_target();
 
     // update angle targets from angle rates
     if (mnt_target.target_type == MountTargetType::RATE) {
@@ -202,8 +137,7 @@ void AP_Mount_XFRobot::update()
     }
 
     // resend target angles at least once per second
-    resend_now = resend_now || ((AP_HAL::millis() - last_send_ms) > SEND_ATTITUDE_TARGET_MS);
-    if (resend_now) {
+    if (mnt_target.fresh || ((AP_HAL::millis() - last_send_ms) > SEND_ATTITUDE_TARGET_MS)) {
         send_target_angles(mnt_target.angle_rad);
     }
 }


### PR DESCRIPTION
the only difference between these and the method which was previously factored up was the setting of this boolean flag indicating there was changed data to send to the gimbal.

I took each of the backends modified in this PR and moved the block-to-be-removed into individual files and looked at the deltas between them.  There were none outside of extra-braces, variable renames and a few twiddled lines.  I then compared the Caddx to the Siyi block before it was moved up into the backend object and found they were near-enough to identical once the boolean was ignored.

This PR preserves the existing bug where there's up to a 1 second pause between retract mode being entered and the command being sent to the mount.

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                 *                                                   
Durandal                            0      *           -504    -504              -504   -504   -504
Hitec-Airspeed           *                 *                                                   
KakuteH7-bdshot                     0      *           -512    -504              -504   -504   -504
MatekF405                           *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *                  *       *                 *      *      *
f103-QiotekPeriph        *                 *                                                   
f303-Universal           *                 *                                                   
iomcu                                                                *                         
revo-mini                           *      *           *       *                 *      *      *
skyviper-v2450                                         *                                       
```

I've tested this on a SiyiA8 - not discernible difference, this vs master.  The only changes it sees are pointless setting of the fresh_data boolean which it does not use.
