### PR TITLE
AP_Mount: make Servo backend use update_mnt_target

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -30,63 +30,7 @@ void AP_Mount_Servo::update()
 {
     AP_Mount_Backend::update();
 
-    // change to RC_TARGETING mode if RC input has changed
-    set_rctargeting_on_rcinput_change();
-
-    auto mount_mode = get_mode();
-    switch (mount_mode) {
-        // move mount to a "retracted position" or to a position where a fourth servo can retract the entire mount into the fuselage
-        case MAV_MOUNT_MODE_RETRACT: {
-            _angle_bf_output_rad = _params.retract_angles.get() * DEG_TO_RAD;
-            mnt_target.angle_rad.set(_angle_bf_output_rad, false);
-            mnt_target.target_type = MountTargetType::ANGLE;
-            break;
-        }
-
-        // move mount to a neutral position, typically pointing forward
-        case MAV_MOUNT_MODE_NEUTRAL: {
-            _angle_bf_output_rad = _params.neutral_angles.get() * DEG_TO_RAD;
-            mnt_target.angle_rad.set(_angle_bf_output_rad, false);
-            mnt_target.target_type = MountTargetType::ANGLE;
-            break;
-        }
-
-        // point to the angles given by a mavlink message
-        case MAV_MOUNT_MODE_MAVLINK_TARGETING: {
-            // mavlink targets are stored while handling the incoming message and considered valid
-            break;
-        }
-
-        // RC radio manual angle control, but with stabilization from the AHRS
-        case MAV_MOUNT_MODE_RC_TARGETING:
-            update_mnt_target_from_rc_target();
-            break;
-
-        // point mount to a GPS point given by the mission planner
-        case MAV_MOUNT_MODE_GPS_POINT:
-            if (get_angle_target_to_roi(mnt_target.angle_rad)) {
-                mnt_target.target_type = MountTargetType::ANGLE;
-            }
-            break;
-
-        // point mount to Home location
-        case MAV_MOUNT_MODE_HOME_LOCATION:
-            if (get_angle_target_to_home(mnt_target.angle_rad)) {
-                mnt_target.target_type = MountTargetType::ANGLE;
-            }
-            break;
-
-        // point mount to another vehicle
-        case MAV_MOUNT_MODE_SYSID_TARGET:
-            if (get_angle_target_to_sysid(mnt_target.angle_rad)) {
-                mnt_target.target_type = MountTargetType::ANGLE;
-            }
-            break;
-
-        default:
-            //do nothing
-            break;
-    }
+    update_mnt_target();
 
     // send target angles or rates depending on the target type
     switch (mnt_target.target_type) {
@@ -95,9 +39,7 @@ void AP_Mount_Servo::update()
             FALLTHROUGH;
         case MountTargetType::ANGLE:
             // update _angle_bf_output_rad based on angle target
-            if ((mount_mode != MAV_MOUNT_MODE_RETRACT) && (mount_mode != MAV_MOUNT_MODE_NEUTRAL)) {
-                update_angle_outputs(mnt_target.angle_rad);
-            }
+            update_angle_outputs(mnt_target.angle_rad);
             break;
     }
 
@@ -162,6 +104,15 @@ void AP_Mount_Servo::update_angle_outputs(const MountTarget& angle_rad)
     _angle_bf_output_rad.x = angle_rad.roll;
     _angle_bf_output_rad.y = angle_rad.pitch;
     _angle_bf_output_rad.z = yaw_bf_rad;
+
+    // do no stabilization in retract or neutral:
+    switch (get_mode()) {
+    case MAV_MOUNT_MODE_RETRACT:
+    case MAV_MOUNT_MODE_NEUTRAL:
+        return;
+    case MAV_MOUNT_MODE_MAVLINK_TARGETING...MAV_MOUNT_MODE_ENUM_END:
+        break;
+    }
 
     // this is sufficient for self-stabilising brushless gimbals
     if (!requires_stabilization) {


### PR DESCRIPTION
This has been tested on a 3-axis servo mount here, including retract/neutral working as expected
