### PR TITLE
SITL: fix linker error in JSON C++ example

### DIFF
--- a/libraries/SITL/examples/JSON/C++/CMakeLists.txt
+++ b/libraries/SITL/examples/JSON/C++/CMakeLists.txt
@@ -5,9 +5,9 @@ project(minimal)
 set(CMAKE_CXX_STANDARD 11)
 
 add_executable(minimal
-  minimal.cpp
+  minimal.cpp SocketExample.cpp libAP_JSON.cpp
 )
 
 add_executable(simpleRover
-  simpleRover.cpp
+  simpleRover.cpp SocketExample.cpp libAP_JSON.cpp
 )

--- a/libraries/SITL/examples/JSON/C++/minimal.cpp
+++ b/libraries/SITL/examples/JSON/C++/minimal.cpp
@@ -20,7 +20,7 @@
 #include <chrono>
 #include <stdlib.h>
 
-#include "libAP_JSON.cpp"
+#include "libAP_JSON.h"
 
 uint16_t servo_out[16];
 

--- a/libraries/SITL/examples/JSON/C++/simpleRover.cpp
+++ b/libraries/SITL/examples/JSON/C++/simpleRover.cpp
@@ -21,7 +21,7 @@
 #include <chrono>
 #include <stdlib.h>
 
-#include "libAP_JSON.cpp"
+#include "libAP_JSON.h"
 #include "simpleRover.h"
 
 uint16_t servo_out[16];


### PR DESCRIPTION
Fixed a build error in `libraries/SITL/examples/JSON/C++/`.
Previously, attempting to build the `minimal` example resulted in linker errors because `SocketExample` methods were undefined.

**Error fixed:**
`undefined reference to SocketExample::set_blocking(bool) const`
`undefined reference to SocketExample::bind(char const*, unsigned short)`
...and others.

**Change:**
Updated the build configuration to correctly compile and link the `Socket` implementation.