### PR TITLE
AP_Mount:Enhance YAW_LOCK to capture heading for target in lock for RC targetting

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -83,7 +83,7 @@ public:
 
     // set yaw_lock used in RC_TARGETING mode.  If true, the gimbal's yaw target is maintained in earth-frame meaning it will lock onto an earth-frame heading (e.g. North)
     // If false (aka "follow") the gimbal's yaw is maintained in body-frame meaning it will rotate with the vehicle
-    void set_yaw_lock(bool yaw_lock) { _yaw_lock = yaw_lock; }
+    void set_yaw_lock(bool yaw_lock);
 
     // set pitch_lock used in RC_TARGETING mode.  If true, the gimbal's tilt target is maintained in earth-frame meaning it will lock onto an earth-frame
     // If false (aka "follow") the gimbal's tilt is maintained in body-frame meaning it will tilt with the vehicle
@@ -389,6 +389,8 @@ private:
 #endif
 
     bool _yaw_lock;                 // yaw_lock used in RC_TARGETING mode. True if the gimbal's yaw target is maintained in earth-frame, if false (aka "follow") it is maintained in body-frame
+    
+    float _yaw_lock_heading_rad;            // mount earth frame direction captured upon calling set_yaw_lock
 
 #if AP_MOUNT_POI_TO_LATLONALT_ENABLED
     struct {

--- a/libraries/AP_Mount/AP_Mount_CADDX.cpp
+++ b/libraries/AP_Mount/AP_Mount_CADDX.cpp
@@ -61,7 +61,7 @@ void AP_Mount_CADDX::send_target_angles(const MountAngleTarget& angle_target_rad
     const uint16_t roll_target_cmd = constrain_uint16(wrap_2PI(angle_target_rad.roll) * scalar, AXIS_MIN, AXIS_MAX);
     const uint16_t pitch_target_cmd = constrain_uint16(wrap_2PI(angle_target_rad.pitch) * scalar, AXIS_MIN, AXIS_MAX);
     const uint16_t yaw_target_cmd = constrain_uint16(wrap_2PI(angle_target_rad.get_bf_yaw()) * scalar, AXIS_MIN, AXIS_MAX);
-
+    
     // prepare packet to send to gimbal
     uint8_t set_attitude_cmd_buf[SET_ATTITUDE_BUF_SIZE] {};
 


### PR DESCRIPTION
Adds a MOUNT_OPTION to change yaw_lock mount state which is used only in RC targeting and MAVLink from using North as the yaw target in RC targeting (MAVLINK provides the heading target) which captures heading on lock and uses it for the target instead of only pointing NORTH (which is useless). Now yaw will point in the same heading focussing on ROI as vehicle turns. Only affects yaw target.

Tested on CADDX