### PR TITLE
AP_Scripting: Sync 2MB flash limit with docs

### DIFF
--- a/libraries/AP_Scripting/README.md
+++ b/libraries/AP_Scripting/README.md
@@ -2,7 +2,7 @@
 
 ## Enabling Scripting Support in Builds
 
-Scripting is automatically enabled on all boards with at least 1MB of flash space.
+Scripting is automatically enabled on all boards with more than 1MB of flash space.
 The following example enables scripting, builds the ArduPlane firmware for the Cube, and uploads it.
 
 ```


### PR DESCRIPTION
https://ardupilot.org/copter/docs/common-lua-scripts.html

The docs reference 2MB limit, discord discussion suggested 2MB is the real limit.