### PR TITLE
AP_HAL_ChibiOS: don't unmount sdcard if its not running

### DIFF
--- a/libraries/AP_HAL_ChibiOS/sdcard.cpp
+++ b/libraries/AP_HAL_ChibiOS/sdcard.cpp
@@ -179,8 +179,10 @@ bool sdcard_init()
 void sdcard_stop(void)
 {
 #if HAL_USE_FATFS
-    // unmount
-    f_mount(nullptr, "/", 1);
+    if (sdcard_running) {
+        // unmount
+        f_mount(nullptr, "/", 1);
+    }
 #endif
 #if HAL_USE_SDC
 #if STM32_SDC_USE_SDMMC2 == TRUE


### PR DESCRIPTION
Pretty sure this was the cause of a deadlock that I saw:

```
Critical failure 0x8000 sysid=1 compid=1
AP: CRITICAL Deadlock 612 io 0x3000E810
AP: Internal Errors 0x8000
```
