### PR TITLE
Plane: added Q_FW_LND_ANGLE

### DIFF
--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -1141,7 +1141,7 @@ bool Plane::verify_landing_vtol_approach(const AP_Mission::Mission_Command &cmd)
                 if (ahrs.get_velocity_NED(vel_NED)) {
                     const Vector2f target_vec = current_loc.get_distance_NE(cmd.content.location);
                     const float angle_err = fabsf(wrap_180(degrees(vel_NED.xy().angle(target_vec))));
-                    lined_up = (angle_err < 30);
+                    lined_up = (angle_err < quadplane.fw_land_accept_angle);
                 }
 
                 if (past_finish_line && (lined_up || half_radius)) {

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -572,6 +572,15 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     AP_GROUPINFO("TKOFF_RPM_MAX", 41, QuadPlane, takeoff_rpm_max, 0),
 #endif
 
+    // @Param: FW_LND_ANGLE
+    // @DisplayName: Quadplane fixed wing landing acceptance angle
+    // @Description: This is the angle from a track towards the landing point at the center of the spiral landing circle that must be achieved to switch to QRTL for the final landing approach. Some vehicles may benefit from a smaller angle to ensure good line up with the center of the circle.
+    // @Units: deg
+    // @Range: 5 40
+    // @Increment: 1
+    // @User: Advanced
+    AP_GROUPINFO("FW_LND_ANGLE", 42, QuadPlane, fw_land_accept_angle, 30),
+    
     AP_GROUPEND
 };
 

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -337,6 +337,9 @@ private:
     // fw landing approach radius
     AP_Float fw_land_approach_radius_m;
 
+    // fw landing acceptance angle before QRTL
+    AP_Float fw_land_accept_angle;
+    
     AP_Int16 rc_speed;
 
     // VTOL assistance in a forward flight mode


### PR DESCRIPTION
this controls the acceptance angle of the track towards the center of the circle for a spiral descent VTOL landing. Reducing this value from the default of 30 may be useful in some vehicles to get a neater landing approach