### PR TITLE
Tools: remove -ftrapping-math as it cause SITL to crash

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -331,7 +331,6 @@ class Board:
                 '-Werror=implicit-fallthrough',
                 '-cl-single-precision-constant',
                 '-Wno-vla-extension',
-                '-ftrapping-math',  # prevent re-ordering of sanity checks
             ]
         else:
             env.CFLAGS += [
@@ -453,7 +452,6 @@ class Board:
                 '-Wno-gnu-variable-sized-type-not-at-end',
                 '-Werror=implicit-fallthrough',
                 '-cl-single-precision-constant',
-                '-ftrapping-math',  # prevent re-ordering of sanity checks
             ]
             if self.cc_version_gte(cfg, 10, 0):
                 use_prefix_map = True


### PR DESCRIPTION
adding -ftrapping-math causes SITL to crash on startup on my M1 Mac running Tahoe 26.1. and 26.2 Reverting #31346

The crash is an Abort Trap: 6 SIGABRT  throwing EXC_BAD_ACCESS at https://github.com/ArduPilot/ardupilot/blob/54f1b3dfd18132a2956524af5e5f26d96c747085/libraries/AP_Logger/AP_Logger.cpp#L1264 due to _num_types not being initialized.

which is called from here
https://github.com/ArduPilot/ardupilot/blob/86c8eb034b2a4216a0a6b24d8494fef90e338123/libraries/AP_Logger/AP_Logger_Backend.cpp#L388

where _front is null at the time it is called.

This is the dump of what happens when it runs 

```
+ /Users/tim/ardupilot/master/build/sitl/bin/arduplane --speedup 1 --instance 1 --home -35.36274643,149.16513199,585,353.8 --model plane --serial0 mcast: --defaults /Users/tim/ardupilot/master/Tools/autotest/models/plane.parm
Setting SIM_SPEEDUP=1.000000
Home: -35.362746 149.165132 alt=585.000000m hdg=353.799988
Starting sketch 'ArduPlane'
Starting SITL input
Using Irlock at port : 9015
UDP multicast connection 239.255.145.50:14550
Loaded defaults from /Users/tim/ardupilot/master/Tools/autotest/models/plane.parm
bind port 5772 for SERIAL1
SERIAL1 on TCP port 5772
bind port 5773 for SERIAL2
SERIAL2 on TCP port 5773
Smoothing reset at 0.001
validate_structures:538: Validating structures
ERROR: segmentation fault - aborting
Running: sh dumpstack.sh 41356 >dumpstack.sh_nknown.41356.out 2>&1
Failed
Running: sh dumpcore.sh 41356 >dumpcore.sh_nknown.41356.out 2>&1
Failed
/Users/tim/.local/bin/dual_plane1.sh: line 40: 41356 Abort trap: 6           $PLANE --speedup 1 --instance 1 --home $LOC1 --model plane --serial0 $SERIAL0 --defaults $PLANE_DEFAULTS
[2025-12-16-22:15 /Users/tim/ardupilot/master (scripted-oa)]$
```

This is what it looks like in VSCode

<img width="673" height="273" alt="Screenshot 2025-12-16 at 10 19 07 PM" src="https://github.com/user-attachments/assets/586890e1-b89b-4a02-971b-fcdd4c094efb" />
