### PR TITLE
AP_Mount: inline get_rc_target

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -339,10 +339,6 @@ private:
     // get pilot input (in the range -1 to +1) received through RC
     void get_rc_input(float& roll_in, float& pitch_in, float& yaw_in) const;
 
-    // get angle or rate targets from pilot RC
-    // target_type will be either ANGLE or RATE, rpy will be the target angle in deg or rate in deg/s
-    void get_rc_target(MountTargetType& target_type, MountTarget& rpy) const;
-
     // get angle targets (in radians) to a Location
     // returns true on success, false on failure
     bool get_angle_target_to_location(const Location &loc, MountTarget& angle_rad) const WARN_IF_UNUSED;


### PR DESCRIPTION
this doesn't really buy us anything, we can just update the mount target directly

I've tested this on a servo gimbal connected to a CUAVv5 using MAVProxy `rc 5 1300` etc etc to provide all of roll, pitch and yaw input.  Both angle and rate were tested.

This isn't about saving size, it's just getting rid of an unnecessary indirection with a weird interface.  It only exists because of progressive factorisation over the years and waiting for backends to all come into line (which they have).

```
Board                    AP_Periph  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                 *                                                   
Durandal                            *      *           -56     -56               -64    -64    -56
Hitec-Airspeed           *                 *                                                   
KakuteH7-bdshot                     *      *           -64     -64               -64    -64    -64
MatekF405                           *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *                  *       *                 *      *      *
SITL_x86_64_linux_gnu               *                  0       0                 0      0      0
f103-QiotekPeriph        *                 *                                                   
f303-MatekGPS            *                 *                                                   
f303-Universal           *                 *                                                   
iomcu                                                                *                         
revo-mini                           *      *           *       *                 *      *      *
skyviper-v2450                                         *                                       
speedybeef4                         *      *           *       *                 *      *      *
```
