### PR TITLE
Tools: size_compare_branches.py: make --all-vehicles include tracker

### DIFF
--- a/Tools/scripts/size_compare_branches.py
+++ b/Tools/scripts/size_compare_branches.py
@@ -290,7 +290,12 @@ class SizeCompareBranches(BuildScriptBase):
             else:
                 if board_info.is_ap_periph:
                     continue
-                if vehicle.lower() not in [x.lower() for x in board_info.autobuild_targets]:
+                # Map vehicle name to autobuild target name
+                # antennatracker (waf target) -> Tracker (autobuild target)
+                vehicle_for_autobuild = vehicle
+                if vehicle.lower() == 'antennatracker':
+                    vehicle_for_autobuild = 'tracker'
+                if vehicle_for_autobuild.lower() not in [x.lower() for x in board_info.autobuild_targets]:
                     continue
             vehicles_to_build.append(vehicle)
 


### PR DESCRIPTION
better fix would be to call it tracker throughout ArduPilot, but a rather larger and more disruptive fix

After:
```
Board,antennatracker,blimp,bootloader,copter,heli,plane,rover,sub
MatekF405-Wing,*,*,*,*,*,*,*,*
```

... before doesn't include `antennatracker`
