### PR TITLE
AP_Mount: split MountTarget into MountAngleTarget and MountRateTarget

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -155,7 +155,7 @@ void AP_Mount_Alexmos::get_boardinfo()
 /*
   control_axis : send new angle target to the gimbal at a fixed speed of 30 deg/s
 */
-void AP_Mount_Alexmos::control_axis(const MountTarget& angle_target_rad)
+void AP_Mount_Alexmos::control_axis(const MountAngleTarget& angle_target_rad)
 {
     alexmos_parameters outgoing_buffer;
     outgoing_buffer.angle_speed.mode = AP_MOUNT_ALEXMOS_MODE_ANGLE;

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -45,7 +45,7 @@ private:
     void get_boardinfo();
 
     // send new angles to the gimbal at a fixed speed of 30 deg/s
-    void control_axis(const MountTarget& angle_target_rad);
+    void control_axis(const MountAngleTarget& angle_target_rad);
 
     // read_params - read current profile profile_id and global parameters from the gimbal settings
     void read_params(uint8_t profile_id);

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -719,7 +719,7 @@ void AP_Mount_Backend::get_rc_input(float& roll_in, float& pitch_in, float& yaw_
 
 // get angle targets (in radians) to a Location
 // returns true on success, false on failure
-bool AP_Mount_Backend::get_angle_target_to_location(const Location &loc, MountTarget& angle_rad) const
+bool AP_Mount_Backend::get_angle_target_to_location(const Location &loc, MountAngleTarget& angle_rad) const
 {
     // exit immediately if vehicle's location is unavailable
     Location current_loc;
@@ -758,7 +758,7 @@ bool AP_Mount_Backend::get_angle_target_to_location(const Location &loc, MountTa
 
 // get angle targets (in radians) to ROI location
 // returns true on success, false on failure
-bool AP_Mount_Backend::get_angle_target_to_roi(MountTarget& angle_rad) const
+bool AP_Mount_Backend::get_angle_target_to_roi(MountAngleTarget& angle_rad) const
 {
     if (!_roi_target.initialised()) {
         return false;
@@ -767,7 +767,7 @@ bool AP_Mount_Backend::get_angle_target_to_roi(MountTarget& angle_rad) const
 }
 
 // return body-frame yaw angle from a mount target
-float AP_Mount_Backend::MountTarget::get_bf_yaw() const
+float AP_Mount_Backend::MountAngleTarget::get_bf_yaw() const
 {
     if (yaw_is_ef) {
         // convert to body-frame
@@ -779,7 +779,7 @@ float AP_Mount_Backend::MountTarget::get_bf_yaw() const
 }
 
 // return earth-frame yaw angle from a mount target
-float AP_Mount_Backend::MountTarget::get_ef_yaw() const
+float AP_Mount_Backend::MountAngleTarget::get_ef_yaw() const
 {
     if (yaw_is_ef) {
         // target is already earth-frame
@@ -791,7 +791,7 @@ float AP_Mount_Backend::MountTarget::get_ef_yaw() const
 }
 
 // sets roll, pitch, yaw and yaw_is_ef
-void AP_Mount_Backend::MountTarget::set(const Vector3f& rpy, bool yaw_is_ef_in)
+void AP_Mount_Backend::MountAngleTarget::set(const Vector3f& rpy, bool yaw_is_ef_in)
 {
     roll  = rpy.x;
     pitch = rpy.y;
@@ -802,7 +802,7 @@ void AP_Mount_Backend::MountTarget::set(const Vector3f& rpy, bool yaw_is_ef_in)
 // update angle targets using a given rate target
 // the resulting angle_rad yaw frame will match the rate_rad yaw frame
 // assumes a 50hz update rate
-void AP_Mount_Backend::update_angle_target_from_rate(const MountTarget& rate_rad, MountTarget& angle_rad) const
+void AP_Mount_Backend::update_angle_target_from_rate(const MountRateTarget& rate_rad, MountAngleTarget& angle_rad) const
 {
     // update roll and pitch angles and apply limits
     angle_rad.roll = constrain_float(angle_rad.roll + rate_rad.roll * AP_MOUNT_UPDATE_DT, radians(_params.roll_angle_min), radians(_params.roll_angle_max));
@@ -876,7 +876,7 @@ uint16_t AP_Mount_Backend::get_gimbal_device_flags() const
 
 // get angle targets (in radians) to home location
 // returns true on success, false on failure
-bool AP_Mount_Backend::get_angle_target_to_home(MountTarget& angle_rad) const
+bool AP_Mount_Backend::get_angle_target_to_home(MountAngleTarget& angle_rad) const
 {
     // exit immediately if home is not set
     if (!AP::ahrs().home_is_set()) {
@@ -887,7 +887,7 @@ bool AP_Mount_Backend::get_angle_target_to_home(MountTarget& angle_rad) const
 
 // get angle targets (in radians) to a vehicle with sysid of  _target_sysid
 // returns true on success, false on failure
-bool AP_Mount_Backend::get_angle_target_to_sysid(MountTarget& angle_rad) const
+bool AP_Mount_Backend::get_angle_target_to_sysid(MountAngleTarget& angle_rad) const
 {
     // exit immediately if sysid is not set or no location available
     if (!_target_sysid_location.initialised()) {

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -233,7 +233,7 @@ protected:
     };
 
     // class for a single angle or rate target
-    class MountTarget {
+    class MountAngleTarget {
     public:
         float roll;
         float pitch;
@@ -250,6 +250,13 @@ protected:
 
         // set roll, pitch, yaw and yaw_is_ef from Vector3f
         void set(const Vector3f& rpy, bool yaw_is_ef_in);
+    };
+    class MountRateTarget {
+    public:
+        float roll;      // roll rate in radians/second
+        float pitch;     // roll rate in radians/second
+        float yaw;       // roll rate in radians/second
+        bool yaw_is_ef;  // if set then `yaw` is a rate in earth frame
     };
 
     // options parameter bitmask handling
@@ -289,20 +296,20 @@ protected:
 
     // get angle targets (in radians) to ROI location
     // returns true on success, false on failure
-    bool get_angle_target_to_roi(MountTarget& angle_rad) const WARN_IF_UNUSED;
+    bool get_angle_target_to_roi(MountAngleTarget& angle_rad) const WARN_IF_UNUSED;
 
     // get angle targets (in radians) to home location
     // returns true on success, false on failure
-    bool get_angle_target_to_home(MountTarget& angle_rad) const WARN_IF_UNUSED;
+    bool get_angle_target_to_home(MountAngleTarget& angle_rad) const WARN_IF_UNUSED;
 
     // get angle targets (in radians) to a vehicle with sysid of _target_sysid
     // returns true on success, false on failure
-    bool get_angle_target_to_sysid(MountTarget& angle_rad) const WARN_IF_UNUSED;
+    bool get_angle_target_to_sysid(MountAngleTarget& angle_rad) const WARN_IF_UNUSED;
 
     // update angle targets using a given rate target
     // the resulting angle_rad yaw frame will match the rate_rad yaw frame
     // assumes a 50hz update rate
-    void update_angle_target_from_rate(const MountTarget& rate_rad, MountTarget& angle_rad) const;
+    void update_angle_target_from_rate(const MountRateTarget& rate_rad, MountAngleTarget& angle_rad) const;
 
     // helper function to provide GIMBAL_DEVICE_FLAGS for use in GIMBAL_DEVICE_ATTITUDE_STATUS message
     uint16_t get_gimbal_device_flags() const;
@@ -319,8 +326,8 @@ protected:
     // structure for MAVLink Targeting angle and rate targets
     struct {
         MountTargetType target_type;// MAVLink targeting mode's current target type (e.g. angle or rate)
-        MountTarget angle_rad;      // angle target in radians
-        MountTarget rate_rads;      // rate target in rad/s
+        MountAngleTarget angle_rad; // angle target in radians
+        MountRateTarget rate_rads;  // rate target in rad/s
         uint32_t last_rate_request_ms;
 
         // 'fresh' indicates that the MountTarget data in this
@@ -341,7 +348,7 @@ private:
 
     // get angle targets (in radians) to a Location
     // returns true on success, false on failure
-    bool get_angle_target_to_location(const Location &loc, MountTarget& angle_rad) const WARN_IF_UNUSED;
+    bool get_angle_target_to_location(const Location &loc, MountAngleTarget& angle_rad) const WARN_IF_UNUSED;
 
 #if AP_MOUNT_POI_TO_LATLONALT_ENABLED
     // calculate the Location that the gimbal is pointing at

--- a/libraries/AP_Mount/AP_Mount_CADDX.cpp
+++ b/libraries/AP_Mount/AP_Mount_CADDX.cpp
@@ -44,7 +44,7 @@ bool AP_Mount_CADDX::get_attitude_quaternion(Quaternion& att_quat)
 }
 
 // send_target_angles
-void AP_Mount_CADDX::send_target_angles(const MountTarget& angle_target_rad)
+void AP_Mount_CADDX::send_target_angles(const MountAngleTarget& angle_target_rad)
 {
     // exit immediately if not initialised
     if (!_initialised) {

--- a/libraries/AP_Mount/AP_Mount_CADDX.h
+++ b/libraries/AP_Mount/AP_Mount_CADDX.h
@@ -44,7 +44,7 @@ private:
     };
 
     // send_target_angles
-    void send_target_angles(const MountTarget& angle_target_rad);
+    void send_target_angles(const MountAngleTarget& angle_target_rad);
 
     // internal variables
     uint32_t _last_send_ms;     // system time of last do_mount_control sent to gimbal

--- a/libraries/AP_Mount/AP_Mount_SToRM32.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.cpp
@@ -66,7 +66,7 @@ void AP_Mount_SToRM32::find_gimbal()
 }
 
 // send_do_mount_control - send a COMMAND_LONG containing a do_mount_control message
-void AP_Mount_SToRM32::send_do_mount_control(const MountTarget& angle_target_rad)
+void AP_Mount_SToRM32::send_do_mount_control(const MountAngleTarget& angle_target_rad)
 {
     // exit immediately if not initialised
     if (!_initialised) {

--- a/libraries/AP_Mount/AP_Mount_SToRM32.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.h
@@ -36,7 +36,7 @@ private:
     void find_gimbal();
 
     // send_do_mount_control with latest angle targets
-    void send_do_mount_control(const MountTarget& angle_target_rad);
+    void send_do_mount_control(const MountAngleTarget& angle_target_rad);
 
     // internal variables
     bool _initialised;              // true once the driver has been initialised

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
@@ -66,7 +66,7 @@ bool AP_Mount_SToRM32_serial::can_send(bool with_control) {
 
 
 // send_target_angles
-void AP_Mount_SToRM32_serial::send_target_angles(const MountTarget& angle_target_rad)
+void AP_Mount_SToRM32_serial::send_target_angles(const MountAngleTarget& angle_target_rad)
 {
 
     static cmd_set_angles_struct cmd_set_angles_data = {

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
@@ -36,7 +36,7 @@ protected:
 private:
 
     // send_target_angles
-    void send_target_angles(const MountTarget& angle_target_rad);
+    void send_target_angles(const MountAngleTarget& angle_target_rad);
 
     // send read data request
     void get_angles();

--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -93,7 +93,7 @@ bool AP_Mount_Servo::get_attitude_quaternion(Quaternion& att_quat)
 // private methods
 
 // update body-frame angle outputs from earth-frame angle targets
-void AP_Mount_Servo::update_angle_outputs(const MountTarget& angle_rad)
+void AP_Mount_Servo::update_angle_outputs(const MountAngleTarget& angle_rad)
 {
     const AP_AHRS &ahrs = AP::ahrs();
 

--- a/libraries/AP_Mount/AP_Mount_Servo.h
+++ b/libraries/AP_Mount/AP_Mount_Servo.h
@@ -48,7 +48,7 @@ protected:
 private:
 
     // update body-frame angle outputs from earth-frame targets
-    void update_angle_outputs(const MountTarget& angle_rad);
+    void update_angle_outputs(const MountAngleTarget& angle_rad);
 
     ///  moves servo with the given function id to the specified angle.  all angles are in body-frame and degrees * 10
     void move_servo(uint8_t rc, int16_t angle, int16_t angle_min, int16_t angle_max);

--- a/libraries/AP_Mount/AP_Mount_Topotek.cpp
+++ b/libraries/AP_Mount/AP_Mount_Topotek.cpp
@@ -739,7 +739,7 @@ void AP_Mount_Topotek::request_gimbal_model_name()
 }
 
 // send angle target in radians to gimbal
-void AP_Mount_Topotek::send_angle_target(const MountTarget& angle_rad)
+void AP_Mount_Topotek::send_angle_target(const MountAngleTarget& angle_rad)
 {
     // gimbal's earth-frame angle control drifts so always use body frame
     // set gimbal's lock state if it has changed
@@ -783,7 +783,7 @@ void AP_Mount_Topotek::send_angle_target(const MountTarget& angle_rad)
 }
 
 // send rate target in rad/s to gimbal
-void AP_Mount_Topotek::send_rate_target(const MountTarget& rate_rads)
+void AP_Mount_Topotek::send_rate_target(const MountRateTarget& rate_rads)
 {
     // set gimbal's lock state if it has changed
     if (!set_gimbal_lock(rate_rads.yaw_is_ef)) {

--- a/libraries/AP_Mount/AP_Mount_Topotek.h
+++ b/libraries/AP_Mount/AP_Mount_Topotek.h
@@ -182,10 +182,10 @@ private:
     void request_gimbal_model_name();
 
     // send angle target in radians to gimbal
-    void send_angle_target(const MountTarget& angle_rad);
+    void send_angle_target(const MountAngleTarget& angle_rad);
 
     // send rate target in rad/s to gimbal
-    void send_rate_target(const MountTarget& rate_rads);
+    void send_rate_target(const MountRateTarget& rate_rads);
 
     // send time and date to gimbal
     bool send_time_to_gimbal();

--- a/libraries/AP_Mount/AP_Mount_XFRobot.cpp
+++ b/libraries/AP_Mount/AP_Mount_XFRobot.cpp
@@ -355,7 +355,7 @@ void AP_Mount_XFRobot::process_packet()
 }
 
 // send_target_angles
-void AP_Mount_XFRobot::send_target_angles(const MountTarget& angle_target_rad)
+void AP_Mount_XFRobot::send_target_angles(const MountAngleTarget& angle_target_rad)
 {
     // exit immediately if not initialised or not enough space to send packet
     if (!_initialised || _uart->txspace() < sizeof(SetAttitudePacket)) {

--- a/libraries/AP_Mount/AP_Mount_XFRobot.h
+++ b/libraries/AP_Mount/AP_Mount_XFRobot.h
@@ -130,7 +130,7 @@ private:
     void process_packet();
 
     // send_target_angles
-    void send_target_angles(const MountTarget& angle_target_rad);
+    void send_target_angles(const MountAngleTarget& angle_target_rad);
 
     // send simple (1byte) command to gimbal (e.g. take pic, start recording)
     // returns true on success, false on failure to send


### PR DESCRIPTION
This stops us sharing the same object class for Angle and Rate targets.  As the patch shows, a lot of what's on here isn't required for the rate targets.

This opens the way for having `MountLocationTarget` etc etc in the future (see https://github.com/ArduPilot/ardupilot/pull/31732)

I'm quite confident this can't break anything - it adds a type safety, doesn't remove it.  Because the data is still going into and coming out of the `mnt_target.angle_rad` / `mnt_target.rate_rads` members we can't get the data routing incorrect.

I've tested this on a servo gimbal here and both angles and rates work as expected for both RC and mavlink inputs.
