### PR TITLE
SITL: Fix JSBSim port initialization 

### DIFF
--- a/libraries/SITL/SIM_JSBSim.cpp
+++ b/libraries/SITL/SIM_JSBSim.cpp
@@ -64,11 +64,6 @@ JSBSim::JSBSim(const char *frame_str) :
     if (model_name != nullptr) {
         jsbsim_model = model_name + 1;
     }
-    control_port = 5505 + instance*10;
-    fdm_port = 5504 + instance*10;
-
-    printf("JSBSim backend started: control_port=%u fdm_port=%u\n",
-           control_port, fdm_port);
 }
 
 /*
@@ -76,6 +71,12 @@ JSBSim::JSBSim(const char *frame_str) :
  */
 bool JSBSim::create_templates(void)
 {
+	control_port = 5505 + instance*10;
+	fdm_port = 5504 + instance*10;
+
+	printf("JSBSim backend started: instance=%u control_port=%u fdm_port=%u\n",
+		   instance, control_port, fdm_port);
+		   
     if (created_templates) {
         return true;
     }


### PR DESCRIPTION
To run multiple JSBSim models simultaneously, each model must have its own control_port and fdm_port. The ports are calculated in the JSBSim constructor, but set_instance() is called AFTER the object is created. Therefore, instance is always 0 (the default value).

This change allows to run multiple models JSBSim simultaneously.

<img width="1594" height="1384" alt="528011166-fd43d026-8bcd-4c5b-8c6d-726fe5cf016c" src="https://github.com/user-attachments/assets/743a6bf0-c058-4299-8850-08585d73323a" />
