### PR TITLE
AP_Mount: add send_target_to_gimbal on AP_Mount_Backend

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -85,15 +85,7 @@ void AP_Mount_Alexmos::update()
     update_mnt_target();
 
     // send target angles or rates depending on the target type
-    switch (mnt_target.target_type) {
-        case MountTargetType::RATE:
-            update_angle_target_from_rate(mnt_target.rate_rads, mnt_target.angle_rad);
-            FALLTHROUGH;
-        case MountTargetType::ANGLE:
-            // send latest angle targets to gimbal
-            control_axis(mnt_target.angle_rad);
-            break;
-    }
+    send_target_to_gimbal();
 }
 
 // has_pan_control - returns true if this mount can control its pan (required for multicopters)
@@ -155,7 +147,7 @@ void AP_Mount_Alexmos::get_boardinfo()
 /*
   control_axis : send new angle target to the gimbal at a fixed speed of 30 deg/s
 */
-void AP_Mount_Alexmos::control_axis(const MountAngleTarget& angle_target_rad)
+void AP_Mount_Alexmos::send_target_angles(const MountAngleTarget& angle_target_rad)
 {
     alexmos_parameters outgoing_buffer;
     outgoing_buffer.angle_speed.mode = AP_MOUNT_ALEXMOS_MODE_ANGLE;

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -33,6 +33,11 @@ protected:
     // get attitude as a quaternion.  returns true on success
     bool get_attitude_quaternion(Quaternion& att_quat) override;
 
+    // servo only natively supports angles:
+    uint8_t natively_supported_mount_target_types() const override {
+        return NATIVE_ANGLES_ONLY;
+    };
+
 private:
 
     // get_angles -
@@ -45,7 +50,7 @@ private:
     void get_boardinfo();
 
     // send new angles to the gimbal at a fixed speed of 30 deg/s
-    void control_axis(const MountAngleTarget& angle_target_rad);
+    void send_target_angles(const MountAngleTarget& angle_rad) override;
 
     // read_params - read current profile profile_id and global parameters from the gimbal settings
     void read_params(uint8_t profile_id);

--- a/libraries/AP_Mount/AP_Mount_CADDX.h
+++ b/libraries/AP_Mount/AP_Mount_CADDX.h
@@ -44,7 +44,7 @@ private:
     };
 
     // send_target_angles
-    void send_target_angles(const MountAngleTarget& angle_target_rad);
+    void send_target_angles(const MountAngleTarget& angle_target_rad) override;
 
     // internal variables
     uint32_t _last_send_ms;     // system time of last do_mount_control sent to gimbal

--- a/libraries/AP_Mount/AP_Mount_MAVLink.cpp
+++ b/libraries/AP_Mount/AP_Mount_MAVLink.cpp
@@ -34,14 +34,7 @@ void AP_Mount_MAVLink::update()
     }
 
     // send target angles or rates depending on the target type
-    switch (mnt_target.target_type) {
-        case MountTargetType::ANGLE:
-            send_gimbal_device_set_attitude(mnt_target.angle_rad.roll, mnt_target.angle_rad.pitch, mnt_target.angle_rad.yaw, mnt_target.angle_rad.yaw_is_ef);
-            break;
-        case MountTargetType::RATE:
-            send_gimbal_device_set_rate(mnt_target.rate_rads.roll, mnt_target.rate_rads.pitch, mnt_target.rate_rads.yaw, mnt_target.rate_rads.yaw_is_ef);
-            break;
-    }
+    send_target_to_gimbal();
 }
 
 // return true if healthy
@@ -231,9 +224,13 @@ void AP_Mount_MAVLink::send_gimbal_device_retract() const
 }
 
 // send GIMBAL_DEVICE_SET_ATTITUDE to gimbal to control rate
-// earth_frame should be true if yaw_rads target is an earth frame rate, false if body_frame
-void AP_Mount_MAVLink::send_gimbal_device_set_rate(float roll_rads, float pitch_rads, float yaw_rads, bool earth_frame) const
+void AP_Mount_MAVLink::send_target_rates(const MountRateTarget &rate_rads)
 {
+    const float roll_rads = rate_rads.roll;
+    const float pitch_rads = rate_rads.pitch;
+    const float yaw_rads = rate_rads.yaw;
+    const bool earth_frame = rate_rads.yaw_is_ef;
+
     // prepare flags
     const uint16_t flags = earth_frame ? (GIMBAL_DEVICE_FLAGS_ROLL_LOCK | GIMBAL_DEVICE_FLAGS_PITCH_LOCK | GIMBAL_DEVICE_FLAGS_YAW_LOCK) : 0;
 
@@ -251,9 +248,13 @@ void AP_Mount_MAVLink::send_gimbal_device_set_rate(float roll_rads, float pitch_
 }
 
 // send GIMBAL_DEVICE_SET_ATTITUDE to gimbal to control attitude
-// earth_frame should be true if yaw_rad target is in earth frame angle, false if body_frame
-void AP_Mount_MAVLink::send_gimbal_device_set_attitude(float roll_rad, float pitch_rad, float yaw_rad, bool earth_frame) const
+void AP_Mount_MAVLink::send_target_angles(const MountAngleTarget &angle_rad)
 {
+    const float roll_rad = angle_rad.roll;
+    const float pitch_rad = angle_rad.pitch;
+    const float yaw_rad = angle_rad.yaw;
+    const bool earth_frame = angle_rad.yaw_is_ef;
+
     // exit immediately if not initialised
     if (!_initialised) {
         return;

--- a/libraries/AP_Mount/AP_Mount_MAVLink.h
+++ b/libraries/AP_Mount/AP_Mount_MAVLink.h
@@ -37,6 +37,11 @@ public:
 
 protected:
 
+    // MVAVLink can send either rates or angles
+    uint8_t natively_supported_mount_target_types() const override {
+        return NATIVE_ANGLES_AND_RATES_ONLY;
+    };
+
     // get attitude as a quaternion.  returns true on success
     bool get_attitude_quaternion(Quaternion& att_quat) override;
 
@@ -56,12 +61,10 @@ private:
     void send_gimbal_device_retract() const;
 
     // send GIMBAL_DEVICE_SET_ATTITUDE to gimbal to control rate
-    // earth_frame should be true if yaw_rads target is an earth frame rate, false if body_frame
-    void send_gimbal_device_set_rate(float roll_rads, float pitch_rads, float yaw_rads, bool earth_frame) const;
+    void send_target_rates(const MountRateTarget &rate_rads) override;
 
     // send GIMBAL_DEVICE_SET_ATTITUDE to gimbal to control attitude
-    // earth_frame should be true if yaw_rad target is an earth frame angle, false if body_frame
-    void send_gimbal_device_set_attitude(float roll_rad, float pitch_rad, float yaw_rad, bool earth_frame) const;
+    void send_target_angles(const MountAngleTarget &angle_rad) override;
 
     // internal variables
     bool _got_device_info;          // true once gimbal has provided device info

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
@@ -36,7 +36,7 @@ protected:
 private:
 
     // send_target_angles
-    void send_target_angles(const MountAngleTarget& angle_target_rad);
+    void send_target_angles(const MountAngleTarget& angle_target_rad) override;
 
     // send read data request
     void get_angles();

--- a/libraries/AP_Mount/AP_Mount_Scripting.h
+++ b/libraries/AP_Mount/AP_Mount_Scripting.h
@@ -38,6 +38,13 @@ public:
 
 protected:
 
+    // Scripting doesn't actually send anything (the script polls the
+    // library for the targets)
+    uint8_t natively_supported_mount_target_types() const override {
+        return NATIVE_ANGLES_ONLY;
+    };
+    void send_target_angles(const MountAngleTarget &angle_rad) override {};
+
     // get attitude as a quaternion.  returns true on success
     bool get_attitude_quaternion(Quaternion& att_quat) override;
 

--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -32,16 +32,14 @@ void AP_Mount_Servo::update()
 
     update_mnt_target();
 
-    // send target angles or rates depending on the target type
-    switch (mnt_target.target_type) {
-        case MountTargetType::RATE:
-            update_angle_target_from_rate(mnt_target.rate_rads, mnt_target.angle_rad);
-            FALLTHROUGH;
-        case MountTargetType::ANGLE:
-            // update _angle_bf_output_rad based on angle target
-            update_angle_outputs(mnt_target.angle_rad);
-            break;
-    }
+    // have our base class call send_target_angles to command the gimbal:
+    send_target_to_gimbal();
+}
+
+// called by the backend to set the servo angles:
+void AP_Mount_Servo::send_target_angles(const MountAngleTarget& angle_rad)
+{
+    update_angle_outputs(mnt_target.angle_rad);
 
     // write the results to the servos
     move_servo(_roll_idx, degrees(_angle_bf_output_rad.x)*10, _params.roll_angle_min*10, _params.roll_angle_max*10);

--- a/libraries/AP_Mount/AP_Mount_Servo.h
+++ b/libraries/AP_Mount/AP_Mount_Servo.h
@@ -45,7 +45,15 @@ protected:
     // get attitude as a quaternion.  returns true on success
     bool get_attitude_quaternion(Quaternion& att_quat) override;
 
+    // servo only natively supports angles:
+    uint8_t natively_supported_mount_target_types() const override {
+        return NATIVE_ANGLES_ONLY;
+    };
+
 private:
+
+    // called by the backend to set the servo angles:
+    void send_target_angles(const MountAngleTarget& angle_rad) override;
 
     // update body-frame angle outputs from earth-frame targets
     void update_angle_outputs(const MountAngleTarget& angle_rad);

--- a/libraries/AP_Mount/AP_Mount_Siyi.h
+++ b/libraries/AP_Mount/AP_Mount_Siyi.h
@@ -282,13 +282,16 @@ private:
     // Returns true if message successfully sent to Gimbal
     bool set_motion_mode(const GimbalMotionMode mode, const bool force=false);
 
+    // Siyi can send either rates or angles
+    uint8_t natively_supported_mount_target_types() const override {
+        return NATIVE_ANGLES_AND_RATES_ONLY;
+    };
+
     // send target pitch and yaw rates to gimbal
-    // yaw_is_ef should be true if yaw_rads target is an earth frame rate, false if body_frame
-    void send_target_rates(float pitch_rads, float yaw_rads, bool yaw_is_ef);
+    void send_target_rates(const MountRateTarget &rate_rads) override;
 
     // send target pitch and yaw angles to gimbal
-    // yaw_is_ef should be true if yaw_rad target is an earth frame angle, false if body_frame
-    void send_target_angles(float pitch_rad, float yaw_rad, bool yaw_is_ef);
+    void send_target_angles(const MountAngleTarget &angle_rad) override;
 
     // send zoom rate command to camera. zoom out = -1, hold = 0, zoom in = 1
     bool send_zoom_rate(float zoom_value);

--- a/libraries/AP_Mount/AP_Mount_Topotek.cpp
+++ b/libraries/AP_Mount/AP_Mount_Topotek.cpp
@@ -137,14 +137,7 @@ void AP_Mount_Topotek::update()
     update_mnt_target();
 
     // send target angles or rates depending on the target type
-    switch (mnt_target.target_type) {
-        case MountTargetType::ANGLE:
-            send_angle_target(mnt_target.angle_rad);
-            break;
-        case MountTargetType::RATE:
-            send_rate_target(mnt_target.rate_rads);
-            break;
-    }
+    send_target_to_gimbal();
 }
 
 // return true if healthy
@@ -739,7 +732,7 @@ void AP_Mount_Topotek::request_gimbal_model_name()
 }
 
 // send angle target in radians to gimbal
-void AP_Mount_Topotek::send_angle_target(const MountAngleTarget& angle_rad)
+void AP_Mount_Topotek::send_target_angles(const MountAngleTarget& angle_rad)
 {
     // gimbal's earth-frame angle control drifts so always use body frame
     // set gimbal's lock state if it has changed
@@ -783,7 +776,7 @@ void AP_Mount_Topotek::send_angle_target(const MountAngleTarget& angle_rad)
 }
 
 // send rate target in rad/s to gimbal
-void AP_Mount_Topotek::send_rate_target(const MountRateTarget& rate_rads)
+void AP_Mount_Topotek::send_target_rates(const MountRateTarget& rate_rads)
 {
     // set gimbal's lock state if it has changed
     if (!set_gimbal_lock(rate_rads.yaw_is_ef)) {

--- a/libraries/AP_Mount/AP_Mount_Topotek.h
+++ b/libraries/AP_Mount/AP_Mount_Topotek.h
@@ -106,6 +106,11 @@ protected:
     // get attitude as a quaternion.  returns true on success
     bool get_attitude_quaternion(Quaternion& att_quat) override;
 
+    // Topotek can send either rates or angles
+    uint8_t natively_supported_mount_target_types() const override {
+        return NATIVE_ANGLES_AND_RATES_ONLY;
+    };
+
 private:
 
     // header type (fixed or variable length)
@@ -182,10 +187,10 @@ private:
     void request_gimbal_model_name();
 
     // send angle target in radians to gimbal
-    void send_angle_target(const MountAngleTarget& angle_rad);
+    void send_target_angles(const MountAngleTarget& angle_rad) override;
 
     // send rate target in rad/s to gimbal
-    void send_rate_target(const MountRateTarget& rate_rads);
+    void send_target_rates(const MountRateTarget& rate_rads) override;
 
     // send time and date to gimbal
     bool send_time_to_gimbal();

--- a/libraries/AP_Mount/AP_Mount_Viewpro.h
+++ b/libraries/AP_Mount/AP_Mount_Viewpro.h
@@ -99,6 +99,11 @@ public:
 
 protected:
 
+    // Viewpro can send either rates or angles
+    uint8_t natively_supported_mount_target_types() const override {
+        return NATIVE_ANGLES_AND_RATES_ONLY;
+    };
+
     // get attitude as a quaternion.  returns true on success
     bool get_attitude_quaternion(Quaternion& att_quat) override;
 
@@ -356,12 +361,10 @@ private:
     bool send_comm_config_cmd(CommConfigCmd cmd);
 
     // send target pitch and yaw rates to gimbal
-    // yaw_is_ef should be true if yaw_rads target is an earth frame rate, false if body_frame
-    bool send_target_rates(float pitch_rads, float yaw_rads, bool yaw_is_ef);
+    void send_target_rates(const MountRateTarget &rate_rads) override;
 
     // send target pitch and yaw angles to gimbal
-    // yaw_is_ef should be true if yaw_rad target is an earth frame angle, false if body_frame
-    bool send_target_angles(float pitch_rad, float yaw_rad, bool yaw_is_ef);
+    void send_target_angles(const MountAngleTarget &angle_rad) override;
 
     // send camera command, affected image sensor and value (e.g. zoom speed)
     bool send_camera_command(ImageSensor img_sensor, CameraCommand cmd, uint8_t value, LRFCommand lrf_cmd = LRFCommand::NO_ACTION);

--- a/libraries/AP_Mount/AP_Mount_XFRobot.h
+++ b/libraries/AP_Mount/AP_Mount_XFRobot.h
@@ -130,7 +130,7 @@ private:
     void process_packet();
 
     // send_target_angles
-    void send_target_angles(const MountAngleTarget& angle_target_rad);
+    void send_target_angles(const MountAngleTarget& angle_target_rad) override;
 
     // send simple (1byte) command to gimbal (e.g. take pic, start recording)
     // returns true on success, false on failure to send

--- a/libraries/AP_Mount/AP_Mount_Xacti.cpp
+++ b/libraries/AP_Mount/AP_Mount_Xacti.cpp
@@ -116,14 +116,7 @@ void AP_Mount_Xacti::update()
     update_mnt_target();
 
     // send target angles or rates depending on the target type
-    switch (mnt_target.target_type) {
-        case MountTargetType::ANGLE:
-            send_target_angles(mnt_target.angle_rad.pitch, mnt_target.angle_rad.yaw, mnt_target.angle_rad.yaw_is_ef);
-            break;
-        case MountTargetType::RATE:
-            send_target_rates(mnt_target.rate_rads.pitch, mnt_target.rate_rads.yaw, mnt_target.rate_rads.yaw_is_ef);
-            break;
-    }
+    send_target_to_gimbal();
 }
 
 // return true if healthy
@@ -344,17 +337,22 @@ bool AP_Mount_Xacti::get_attitude_quaternion(Quaternion& att_quat)
 }
 
 // send target pitch and yaw rates to gimbal
-// yaw_is_ef should be true if yaw_rads target is an earth frame rate, false if body_frame
-void AP_Mount_Xacti::send_target_rates(float pitch_rads, float yaw_rads, bool yaw_is_ef)
+void AP_Mount_Xacti::send_target_rates(const MountRateTarget &rate_rads)
 {
+    const float pitch_rads = rate_rads.pitch;
+    const float yaw_rads = rate_rads.yaw;
+
     // send gimbal rate target to gimbal
     send_gimbal_control(3, degrees(pitch_rads) * 100, degrees(yaw_rads) * 100);
 }
 
 // send target pitch and yaw angles to gimbal
-// yaw_is_ef should be true if yaw_rad target is an earth frame angle, false if body_frame
-void AP_Mount_Xacti::send_target_angles(float pitch_rad, float yaw_rad, bool yaw_is_ef)
+void AP_Mount_Xacti::send_target_angles(const MountAngleTarget &angle_rad)
 {
+    const float pitch_rad = angle_rad.pitch;
+    const float yaw_rad = angle_rad.yaw;
+    const bool yaw_is_ef = angle_rad.yaw_is_ef;
+
     // convert yaw to body frame
     const float yaw_bf_rad = yaw_is_ef ? wrap_PI(yaw_rad - AP::ahrs().get_yaw_rad()) : yaw_rad;
 

--- a/libraries/AP_Mount/AP_Mount_Xacti.h
+++ b/libraries/AP_Mount/AP_Mount_Xacti.h
@@ -86,6 +86,11 @@ protected:
     // get attitude as a quaternion.  returns true on success
     bool get_attitude_quaternion(Quaternion& att_quat) override;
 
+    // Xacti can send either rates or angles
+    uint8_t natively_supported_mount_target_types() const override {
+        return NATIVE_ANGLES_AND_RATES_ONLY;
+    };
+
 private:
 
     // send text prefix string to reduce flash cost
@@ -103,12 +108,10 @@ private:
     static const char* sensor_mode_str[];
 
     // send target pitch and yaw rates to gimbal
-    // yaw_is_ef should be true if yaw_rads target is an earth frame rate, false if body_frame
-    void send_target_rates(float pitch_rads, float yaw_rads, bool yaw_is_ef);
+    void send_target_rates(const MountRateTarget &rate_rads) override;
 
     // send target pitch and yaw angles to gimbal
-    // yaw_is_ef should be true if yaw_rad target is an earth frame angle, false if body_frame
-    void send_target_angles(float pitch_rad, float yaw_rad, bool yaw_is_ef);
+    void send_target_angles(const MountAngleTarget &angle_rad) override;
 
     // register backend in detected modules array used to map DroneCAN port and node id to backend
     void register_backend();


### PR DESCRIPTION
calls virtual methods which sends commands to the gimbal

Tested on CUAVv5 with a 3-axis servo gimbal.  Rates and angles and stabilisation all work as expected.  This shows that the rate integration to get an angle still works.

Tested on a CubeOrange with a PixyU (MAVLink) gimbal.  Everything works as expected.

Tested on a CubeOrange on a SiyiA8, everything working as expected.

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *
Durandal                            0               0      *           160     160               168    168    168
Hitec-Airspeed           *                                 *
KakuteH7-bdshot                     8               8      *           184     184               184    184    184
MatekF405                           *               *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *               *                  *       *                 *      *      *
SITL_x86_64_linux_gnu               0               0                  5888    5880              1784   1784   1792
f103-QiotekPeriph        *                                 *
f303-MatekGPS            *                                 *
f303-Universal           *                                 *
iomcu                                                                                *
revo-mini                           *               *      *           *       *                 *      *      *
skyviper-v2450                                                         *
speedybeef4                         *               *      *           *       *                 *      *      *
```


This is about half the backends; the other half have don't-send-often-in-neutral-and-retract requirements which I will need to emulate.
