### PR TITLE
AP_NavEKF3: reduce FuseMagnetometer computation time 25-35%

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -582,6 +582,8 @@ void NavEKF3_core::FuseMagnetometer()
     }
 
     Vector24 H_MAG;
+    // index of H_MAG which is exactly 1, for more efficient computation below
+    int H_MAG_unit_index;
     for (uint8_t obsIndex = 0; obsIndex <= 2; obsIndex++) {
 
         if (obsIndex == 0) {
@@ -597,6 +599,7 @@ void NavEKF3_core::FuseMagnetometer()
             H_MAG[19] = 1.0f;
             H_MAG[20] = 0.0f;
             H_MAG[21] = 0.0f;
+            H_MAG_unit_index = 19;
 
             // calculate Kalman gain
             const Vector5 SK_MX {
@@ -679,6 +682,7 @@ void NavEKF3_core::FuseMagnetometer()
             H_MAG[19] = 0.0f;
             H_MAG[20] = 1.0f;
             H_MAG[21] = 0.0f;
+            H_MAG_unit_index = 20;
 
             // calculate Kalman gain
             const Vector5 SK_MY {
@@ -763,6 +767,7 @@ void NavEKF3_core::FuseMagnetometer()
             H_MAG[19] = 0.0f;
             H_MAG[20] = 0.0f;
             H_MAG[21] = 1.0f;
+            H_MAG_unit_index = 21;
 
             // calculate Kalman gain
             const Vector5 SK_MZ {
@@ -847,9 +852,9 @@ void NavEKF3_core::FuseMagnetometer()
                 res += (Kfusion[i] * H_MAG[16]) * P[16][j];
                 res += (Kfusion[i] * H_MAG[17]) * P[17][j];
                 res += (Kfusion[i] * H_MAG[18]) * P[18][j];
-                res += (Kfusion[i] * H_MAG[19]) * P[19][j];
-                res += (Kfusion[i] * H_MAG[20]) * P[20][j];
-                res += (Kfusion[i] * H_MAG[21]) * P[21][j];
+                // one value in H is always 1, and the others not mentioned here
+                // are zero, so we can skip that H product to save an operation.
+                res += Kfusion[i] * P[H_MAG_unit_index][j];
                 KHP[i][j] = res;
             }
         }


### PR DESCRIPTION
Some code optimizations that reduce the total execution time of `NavEKF3_core::FuseMagnetometer` 25% on H7 and 35% on F4. There should be no change in the order of operations so the results should be bit-identical but I don't know if this is possible to verify with our replay framework. If this PR is well-received there are lots of other similar opportunities, and getting rid of the `KH` intermediate array would save 2-4K of static RAM.

I did timing of that function using `AP_HAL::micros()` with interrupts off. For CubeOrange, this PR takes execution time from 699us to 524us. For CubeBlack it is 1138us to 704us. Execution is not as bad as I thought on CubeBlack, I thought it would be less than half the speed.

I made sure my boards behaved well on the bench but did not do any flight tests. I also ran `Tools/Replay/check_replay_branch.py` to show that there were no differences in replay. It did show 20-30 errors in the beacon test (I think), but it showed the same thing without this PR applied so I think it is just slightly broken. There were otherwise no errors.