### PR TITLE
AP_Mount: added tracking information

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Topotek.cpp
+++ b/libraries/AP_Mount/AP_Mount_Topotek.cpp
@@ -967,6 +967,9 @@ void AP_Mount_Topotek::gimbal_track_analyse()
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s %s started", send_message_prefix, tracking_str);
         _is_tracking = true;
         break;
+    case TrackingStatus::LENS_UNSUPPORT_TRACK:
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s %s unsupported lens", send_message_prefix, tracking_str);
+        break;
     }
 }
 

--- a/libraries/AP_Mount/AP_Mount_Topotek.h
+++ b/libraries/AP_Mount/AP_Mount_Topotek.h
@@ -154,7 +154,8 @@ private:
     enum class TrackingStatus : uint8_t {
         STOPPED_TRACKING = 0x30,                // not tracking
         WAITING_FOR_TRACKING = 0x31,            // wait to track command status
-        TRACKING_IN_PROGRESS = 0x32             // the status is being tracked.
+        TRACKING_IN_PROGRESS = 0x32,            // the status is being tracked
+        LENS_UNSUPPORT_TRACK = 0x34,            // this lens does not support tracking
     };
 
     // identifier bytes


### PR DESCRIPTION
Description added by Randy:

This improves the Topotek gimbal's error handling while using vision based tracking.  If an invalid lens has been selected, the user will see the message, "Mount: Topotek tracking unsupported this lens"