### PR TITLE
AP_Bootloader: add DFU mode via STM32 system bootloader

### DIFF
--- a/Tools/AP_Bootloader/AP_Bootloader.cpp
+++ b/Tools/AP_Bootloader/AP_Bootloader.cpp
@@ -43,6 +43,7 @@ extern "C" {
     int main(void);
 }
 
+
 struct boardinfo board_info = {
     .board_type = APJ_BOARD_ID,
     .board_rev = 0,
@@ -210,6 +211,80 @@ int main(void)
 
 #if defined(BOOTLOADER_DEV_LIST)
     init_uarts();
+#endif
+
+#if HAL_ENABLE_DFU_BOOT && defined(STM32H7)
+    /*
+      check if the main firmware requested a reboot into DFU mode
+      (STM32 system bootloader for USB firmware upload).
+
+      this check is placed here deliberately — after ChibiOS init and
+      init_uarts() — for two reasons:
+
+      1. D-Cache flush requires caches to be enabled. the firmware
+         uses AXI SRAM as primary RAM with write-back D-Cache. dirty
+         cache lines persist through NVIC_SystemReset. if not flushed,
+         the system bootloader reads stale data from AXI SRAM and its
+         USB OTG core soft reset (GRSTCTL.CSRST) hangs permanently.
+         SCB_CleanDCache() is a no-op when caches are disabled, so we
+         must wait until __cpu_init has re-enabled them.
+
+      2. the USB OTG FS peripheral is configured by init_uarts() and
+         must be fully de-initialised before the system bootloader can
+         re-initialise it. without this, the USB PHY is left in an
+         active state that prevents the system bootloader's core reset
+         from completing.
+
+      the firmware signals DFU mode by setting boot_to_dfu in the
+      persistent data (RTC backup registers) and rebooting with
+      RTC_BOOT_HOLD so the bootloader stays long enough to reach here.
+    */
+    {
+        AP_HAL::Util::PersistentData pd;
+        stm32_watchdog_load((uint32_t *)&pd, (sizeof(pd)+3)/4);
+        if (pd.boot_to_dfu) {
+            pd.boot_to_dfu = false;
+            stm32_watchdog_save((uint32_t *)&pd, (sizeof(pd)+3)/4);
+
+            // fully de-initialise the USB OTG FS peripheral:
+            // disconnect from bus, power down the analog PHY,
+            // complete a core soft reset, then reset via RCC
+            // and gate the clock
+            RCC->AHB1ENR |= RCC_AHB1ENR_USB2OTGHSEN;
+            __DSB();
+            *(__IO uint32_t *)(0x40080804U) |= 2;   // DCTL: set SDIS (disconnect)
+            *(__IO uint32_t *)(0x40080038U) = 0;     // GCCFG: PWRDWN=0 (PHY off)
+            *(__IO uint32_t *)(0x40080010U) = 1;     // GRSTCTL: CSRST=1
+            while (*(__IO uint32_t *)(0x40080010U) & 1) {} // wait for CSRST
+            RCC->AHB1RSTR |= RCC_AHB1RSTR_USB2OTGHSRST;
+            __DSB();
+            RCC->AHB1RSTR &= ~RCC_AHB1RSTR_USB2OTGHSRST;
+            RCC->AHB1ENR &= ~RCC_AHB1ENR_USB2OTGHSEN;
+
+            // flush dirty D-Cache lines to RAM — the firmware's
+            // cached writes to AXI SRAM must reach physical memory
+            // before the system bootloader reads it
+            SCB_CleanDCache();
+            SCB_DisableDCache();
+            SCB_InvalidateICache();
+            SCB_DisableICache();
+
+            // restore remaining CPU state to reset defaults.
+            // the system bootloader expects the state it would
+            // see after a hardware power-on reset.
+            __enable_irq();
+            SCB->VTOR = 0;
+            SCB->CPACR = 0;
+            __set_CONTROL(0);
+            __ISB();
+
+            // jump to STM32 system bootloader in system memory
+            const uint32_t *app_base = (const uint32_t *)(0x1FF09800);
+            __set_MSP(*app_base);
+            ((void (*)())*(&app_base[1]))();
+            while (true);
+        }
+    }
 #endif
 #if HAL_USE_CAN == TRUE || HAL_NUM_CAN_IFACES
     can_start();

--- a/Tools/AP_Bootloader/AP_Bootloader.cpp
+++ b/Tools/AP_Bootloader/AP_Bootloader.cpp
@@ -272,6 +272,14 @@ int main(void)
             SCB_DisableICache();
 #endif
 
+            // reset clock tree to HSI — the system bootloader
+            // expects HSI as clock source. PLL settings vary by
+            // board (crystal frequency) and must be cleared.
+            RCC->CFGR = 0;
+            while ((RCC->CFGR & RCC_CFGR_SWS) != 0) {}
+            RCC->CR &= ~(RCC_CR_PLL1ON | RCC_CR_PLL2ON | RCC_CR_PLL3ON |
+                         RCC_CR_HSEON | RCC_CR_HSI48ON);
+
             // restore CPU state to power-on reset defaults
             __enable_irq();
             SCB->VTOR = 0;

--- a/Tools/AP_Bootloader/AP_Bootloader.cpp
+++ b/Tools/AP_Bootloader/AP_Bootloader.cpp
@@ -263,14 +263,13 @@ int main(void)
             rccDisableOTG_FS();
 
 #if CORTEX_MODEL == 7
-            // invalidate and disable D-Cache. we discard dirty lines
-            // rather than flushing them — the system bootloader
-            // re-initialises RAM and flushing could stall if dirty
-            // lines target peripherals with clocks disabled.
-            SCB_InvalidateDCache();
-            SCB_DisableDCache();
-            SCB_InvalidateICache();
-            SCB_DisableICache();
+            // disable D-Cache and I-Cache by clearing CCR bits directly.
+            // we avoid SCB_CleanDCache/SCB_InvalidateDCache because
+            // set/way operations can hang if dirty cache lines target
+            // peripherals whose clocks have been disabled.
+            SCB->CCR &= ~(SCB_CCR_DC_Msk | SCB_CCR_IC_Msk);
+            __DSB();
+            __ISB();
 #endif
 
             // reset clock tree to HSI — the system bootloader

--- a/Tools/AP_Bootloader/AP_Bootloader.cpp
+++ b/Tools/AP_Bootloader/AP_Bootloader.cpp
@@ -213,7 +213,7 @@ int main(void)
     init_uarts();
 #endif
 
-#if HAL_ENABLE_DFU_BOOT && defined(STM32H7)
+#if HAL_ENABLE_DFU_BOOT
     /*
       check if the main firmware requested a reboot into DFU mode
       (STM32 system bootloader for USB firmware upload).
@@ -221,19 +221,18 @@ int main(void)
       this check is placed here deliberately — after ChibiOS init and
       init_uarts() — for two reasons:
 
-      1. D-Cache flush requires caches to be enabled. the firmware
-         uses AXI SRAM as primary RAM with write-back D-Cache. dirty
-         cache lines persist through NVIC_SystemReset. if not flushed,
-         the system bootloader reads stale data from AXI SRAM and its
-         USB OTG core soft reset (GRSTCTL.CSRST) hangs permanently.
-         SCB_CleanDCache() is a no-op when caches are disabled, so we
-         must wait until __cpu_init has re-enabled them.
+      1. on Cortex-M7 (F7/H7), D-Cache flush requires caches to be
+         enabled. the firmware uses write-back D-Cache and dirty cache
+         lines persist through NVIC_SystemReset. if not flushed, the
+         system bootloader reads stale data and its USB OTG core soft
+         reset (GRSTCTL.CSRST) hangs. SCB_CleanDCache() is a no-op
+         when caches are disabled, so we must wait until __cpu_init
+         has re-enabled them.
 
       2. the USB OTG FS peripheral is configured by init_uarts() and
          must be fully de-initialised before the system bootloader can
          re-initialise it. without this, the USB PHY is left in an
-         active state that prevents the system bootloader's core reset
-         from completing.
+         active state that prevents the core reset from completing.
 
       the firmware signals DFU mode by setting boot_to_dfu in the
       persistent data (RTC backup registers) and rebooting with
@@ -246,32 +245,49 @@ int main(void)
             pd.boot_to_dfu = false;
             stm32_watchdog_save((uint32_t *)&pd, (sizeof(pd)+3)/4);
 
+            // determine USB OTG FS base address and RCC bits per family
+#if defined(STM32H7)
+            const uint32_t usb_base = 0x40080000U;  // USB2_OTG_FS
+            RCC->AHB1ENR |= RCC_AHB1ENR_USB2OTGHSEN;
+#elif defined(STM32F7) || defined(STM32F4)
+            const uint32_t usb_base = 0x50000000U;  // USB_OTG_FS
+            RCC->AHB2ENR |= RCC_AHB2ENR_OTGFSEN;
+#endif
+            __DSB();
+
             // fully de-initialise the USB OTG FS peripheral:
             // disconnect from bus, power down the analog PHY,
             // complete a core soft reset, then reset via RCC
-            // and gate the clock
-            RCC->AHB1ENR |= RCC_AHB1ENR_USB2OTGHSEN;
-            __DSB();
-            *(__IO uint32_t *)(0x40080804U) |= 2;   // DCTL: set SDIS (disconnect)
-            *(__IO uint32_t *)(0x40080038U) = 0;     // GCCFG: PWRDWN=0 (PHY off)
-            *(__IO uint32_t *)(0x40080010U) = 1;     // GRSTCTL: CSRST=1
-            while (*(__IO uint32_t *)(0x40080010U) & 1) {} // wait for CSRST
+            // and gate the clock. register offsets are the same
+            // across all STM32 families (DWC OTG IP).
+            *(__IO uint32_t *)(usb_base + 0x804U) |= 2;  // DCTL: SDIS
+            *(__IO uint32_t *)(usb_base + 0x038U) = 0;    // GCCFG: PHY off
+            *(__IO uint32_t *)(usb_base + 0x010U) = 1;    // GRSTCTL: CSRST
+            while (*(__IO uint32_t *)(usb_base + 0x010U) & 1) {}
+
+#if defined(STM32H7)
             RCC->AHB1RSTR |= RCC_AHB1RSTR_USB2OTGHSRST;
             __DSB();
             RCC->AHB1RSTR &= ~RCC_AHB1RSTR_USB2OTGHSRST;
             RCC->AHB1ENR &= ~RCC_AHB1ENR_USB2OTGHSEN;
+#elif defined(STM32F7) || defined(STM32F4)
+            RCC->AHB2RSTR |= RCC_AHB2RSTR_OTGFSRST;
+            __DSB();
+            RCC->AHB2RSTR &= ~RCC_AHB2RSTR_OTGFSRST;
+            RCC->AHB2ENR &= ~RCC_AHB2ENR_OTGFSEN;
+#endif
 
-            // flush dirty D-Cache lines to RAM — the firmware's
-            // cached writes to AXI SRAM must reach physical memory
-            // before the system bootloader reads it
+#if CORTEX_MODEL == 7
+            // flush dirty D-Cache lines to RAM and disable caches.
+            // on Cortex-M7 (F7/H7) the firmware's cached writes
+            // persist through NVIC_SystemReset and must be flushed.
             SCB_CleanDCache();
             SCB_DisableDCache();
             SCB_InvalidateICache();
             SCB_DisableICache();
+#endif
 
-            // restore remaining CPU state to reset defaults.
-            // the system bootloader expects the state it would
-            // see after a hardware power-on reset.
+            // restore CPU state to power-on reset defaults
             __enable_irq();
             SCB->VTOR = 0;
             SCB->CPACR = 0;
@@ -279,7 +295,13 @@ int main(void)
             __ISB();
 
             // jump to STM32 system bootloader in system memory
+#if defined(STM32H7)
             const uint32_t *app_base = (const uint32_t *)(0x1FF09800);
+#elif defined(STM32F7)
+            const uint32_t *app_base = (const uint32_t *)(0x1FF00000);
+#else
+            const uint32_t *app_base = (const uint32_t *)(0x1FFF0000);
+#endif
             __set_MSP(*app_base);
             ((void (*)())*(&app_base[1]))();
             while (true);

--- a/Tools/AP_Bootloader/AP_Bootloader.cpp
+++ b/Tools/AP_Bootloader/AP_Bootloader.cpp
@@ -245,6 +245,16 @@ int main(void)
             pd.boot_to_dfu = false;
             stm32_watchdog_save((uint32_t *)&pd, (sizeof(pd)+3)/4);
 
+#if CORTEX_MODEL == 7
+            // flush and disable D-Cache and I-Cache BEFORE disabling
+            // peripheral clocks. set/way cache operations hang if
+            // dirty lines target peripherals with clocks disabled.
+            SCB_CleanDCache();
+            SCB_DisableDCache();
+            SCB_InvalidateICache();
+            SCB_DisableICache();
+#endif
+
             // ensure USB OTG FS clock is enabled so we can
             // access its registers for de-initialisation
             rccEnableOTG_FS(false);
@@ -261,16 +271,6 @@ int main(void)
             // reset the peripheral via RCC and disable its clock
             rccResetOTG_FS();
             rccDisableOTG_FS();
-
-#if CORTEX_MODEL == 7
-            // disable D-Cache and I-Cache by clearing CCR bits directly.
-            // we avoid SCB_CleanDCache/SCB_InvalidateDCache because
-            // set/way operations can hang if dirty cache lines target
-            // peripherals whose clocks have been disabled.
-            SCB->CCR &= ~(SCB_CCR_DC_Msk | SCB_CCR_IC_Msk);
-            __DSB();
-            __ISB();
-#endif
 
             // reset clock tree to HSI — the system bootloader
             // expects HSI as clock source. PLL settings vary by

--- a/Tools/AP_Bootloader/AP_Bootloader.cpp
+++ b/Tools/AP_Bootloader/AP_Bootloader.cpp
@@ -245,37 +245,22 @@ int main(void)
             pd.boot_to_dfu = false;
             stm32_watchdog_save((uint32_t *)&pd, (sizeof(pd)+3)/4);
 
-            // determine USB OTG FS base address and RCC bits per family
-#if defined(STM32H7)
-            const uint32_t usb_base = 0x40080000U;  // USB2_OTG_FS
-            RCC->AHB1ENR |= RCC_AHB1ENR_USB2OTGHSEN;
-#elif defined(STM32F7) || defined(STM32F4)
-            const uint32_t usb_base = 0x50000000U;  // USB_OTG_FS
-            RCC->AHB2ENR |= RCC_AHB2ENR_OTGFSEN;
-#endif
-            __DSB();
+            // ensure USB OTG FS clock is enabled so we can
+            // access its registers for de-initialisation
+            rccEnableOTG_FS(false);
 
             // fully de-initialise the USB OTG FS peripheral:
             // disconnect from bus, power down the analog PHY,
-            // complete a core soft reset, then reset via RCC
-            // and gate the clock. register offsets are the same
-            // across all STM32 families (DWC OTG IP).
-            *(__IO uint32_t *)(usb_base + 0x804U) |= 2;  // DCTL: SDIS
-            *(__IO uint32_t *)(usb_base + 0x038U) = 0;    // GCCFG: PHY off
-            *(__IO uint32_t *)(usb_base + 0x010U) = 1;    // GRSTCTL: CSRST
-            while (*(__IO uint32_t *)(usb_base + 0x010U) & 1) {}
+            // and complete a core soft reset. the register layout
+            // (stm32_otg_t) is the same across all STM32 families.
+            OTG_FS->DCTL |= DCTL_SDIS;
+            OTG_FS->GCCFG = 0;
+            OTG_FS->GRSTCTL = GRSTCTL_CSRST;
+            while (OTG_FS->GRSTCTL & GRSTCTL_CSRST) {}
 
-#if defined(STM32H7)
-            RCC->AHB1RSTR |= RCC_AHB1RSTR_USB2OTGHSRST;
-            __DSB();
-            RCC->AHB1RSTR &= ~RCC_AHB1RSTR_USB2OTGHSRST;
-            RCC->AHB1ENR &= ~RCC_AHB1ENR_USB2OTGHSEN;
-#elif defined(STM32F7) || defined(STM32F4)
-            RCC->AHB2RSTR |= RCC_AHB2RSTR_OTGFSRST;
-            __DSB();
-            RCC->AHB2RSTR &= ~RCC_AHB2RSTR_OTGFSRST;
-            RCC->AHB2ENR &= ~RCC_AHB2ENR_OTGFSEN;
-#endif
+            // reset the peripheral via RCC and disable its clock
+            rccResetOTG_FS();
+            rccDisableOTG_FS();
 
 #if CORTEX_MODEL == 7
             // flush dirty D-Cache lines to RAM and disable caches.

--- a/Tools/AP_Bootloader/AP_Bootloader.cpp
+++ b/Tools/AP_Bootloader/AP_Bootloader.cpp
@@ -263,10 +263,11 @@ int main(void)
             rccDisableOTG_FS();
 
 #if CORTEX_MODEL == 7
-            // flush dirty D-Cache lines to RAM and disable caches.
-            // on Cortex-M7 (F7/H7) the firmware's cached writes
-            // persist through NVIC_SystemReset and must be flushed.
-            SCB_CleanDCache();
+            // invalidate and disable D-Cache. we discard dirty lines
+            // rather than flushing them — the system bootloader
+            // re-initialises RAM and flushing could stall if dirty
+            // lines target peripherals with clocks disabled.
+            SCB_InvalidateDCache();
             SCB_DisableDCache();
             SCB_InvalidateICache();
             SCB_DisableICache();

--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -596,8 +596,6 @@ def configure(cfg):
         env.CHIBIOS_BUILD_FLAGS += ' ENABLE_MALLOC_GUARD=yes'
     if env.ENABLE_STATS:
         env.CHIBIOS_BUILD_FLAGS += ' ENABLE_STATS=yes'
-    if env.ENABLE_DFU_BOOT and env.BOOTLOADER:
-        env.CHIBIOS_BUILD_FLAGS += ' USE_ASXOPT=-DCRT0_ENTRY_HOOK=TRUE'
     if env.AP_BOARD_START_TIME:
         env.CHIBIOS_BUILD_FLAGS += ' AP_BOARD_START_TIME=0x%x' % env.AP_BOARD_START_TIME
 

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -837,6 +837,11 @@ void Util::boot_to_dfu()
 {
     hal.util->persistent_data.boot_to_dfu = true;
     stm32_watchdog_save((uint32_t *)&hal.util->persistent_data, (sizeof(hal.util->persistent_data)+3)/4);
+    // set RTC_BOOT_HOLD before the shutdown sequence in reboot() —
+    // on boards with IOMCU the shutdown can take long enough for
+    // the watchdog to fire, and set_fast_reboot inside reboot()
+    // would never be reached
+    set_fast_reboot(RTC_BOOT_HOLD);
     hal.scheduler->reboot(true);
 }
 #endif

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -826,11 +826,18 @@ void* Util::last_crash_dump_ptr() const
 #endif // AP_CRASHDUMP_ENABLED
 
 #if HAL_ENABLE_DFU_BOOT && !defined(HAL_BOOTLOADER_BUILD)
+/*
+  reboot into the STM32 system bootloader for DFU firmware upload.
+  sets boot_to_dfu flag in persistent data and reboots with
+  hold_in_bootloader=true (RTC_BOOT_HOLD) so the ArduPilot bootloader
+  stays in its main loop and reaches the DFU jump code rather than
+  fast-booting back to this firmware.
+*/
 void Util::boot_to_dfu()
 {
     hal.util->persistent_data.boot_to_dfu = true;
     stm32_watchdog_save((uint32_t *)&hal.util->persistent_data, (sizeof(hal.util->persistent_data)+3)/4);
-    hal.scheduler->reboot();
+    hal.scheduler->reboot(true);
 }
 #endif
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7/hwdef.dat
@@ -216,3 +216,8 @@ define OSD_ENABLED 1
 define HAL_OSD_TYPE_DEFAULT 1
 ROMFS_WILDCARD libraries/AP_OSD/fonts/font*.bin
 define DEFAULT_NTF_LED_TYPES 455
+
+# enable DFU reboot for installing bootloader
+# note that if firmware is build with --secure-bl then DFU is
+# disabled
+ENABLE_DFU_BOOT 1

--- a/libraries/AP_HAL_ChibiOS/system.cpp
+++ b/libraries/AP_HAL_ChibiOS/system.cpp
@@ -288,27 +288,6 @@ void __cxa_pure_virtual() { while (1); } //TODO: Handle properly, maybe generate
 void NMI_Handler(void);
 void NMI_Handler(void) { while (1); }
 
-#if defined(HAL_BOOTLOADER_BUILD) && HAL_ENABLE_DFU_BOOT
-void __entry_hook(void);
-void __entry_hook()
-{
-    // read the persistent data
-    AP_HAL::Util::PersistentData pd;
-    stm32_watchdog_load((uint32_t *)&pd, (sizeof(pd)+3)/4);
-    if (pd.boot_to_dfu) {
-        pd.boot_to_dfu = false;
-        stm32_watchdog_save((uint32_t *)&pd, (sizeof(pd)+3)/4);
-#if defined(STM32H7)
-        const uint32_t *app_base = (const uint32_t *)(0x1FF09800); 
-#else
-        const uint32_t *app_base = (const uint32_t *)(0x1FFF0000);
-#endif
-        __set_MSP(*app_base);
-        ((void (*)())*(&app_base[1]))();
-        while(true);
-    }
-}
-#endif
 
 uint32_t chibios_rand_generate()
 {


### PR DESCRIPTION
ff56b1cf144b8491b10a00be72a78a4d8e3866c2 was lost in the ChibiOS upgrade but it pretty much worked quite by accident. This is a much more comprehensive fix that works on new ChibiOS and more than just H7.

##  Summary

Add support for rebooting into the STM32 ROM system bootloader for USB DFU firmware upload, triggered via MAVLink
PREFLIGHT_REBOOT_SHUTDOWN with the magic parameter sequence (param1=42, param2=24, param3=71, param4=99).

This replaces the previous __entry_hook approach which stopped working after a ChibiOS upgrade.

## How it works

 1. The firmware sets boot_to_dfu = true in the persistent data (RTC backup registers) and reboots with RTC_BOOT_HOLD so the bootloader enters its main loop rather than fast-booting back to the firmware.
 2. The bootloader checks the flag in main() after init_uarts(). Before jumping to the system bootloader at 0x1FF09800 (H7)
  / 0x1FF00000 (F7) / 0x1FFF0000 (F4), it:
    - De-initialises the USB OTG FS peripheral (disconnect, PHY power-down, core soft reset, RCC reset)
    - On Cortex-M7: flushes and disables D-Cache and I-Cache
    - Restores CPU state to power-on defaults (VTOR, CPACR, CONTROL, interrupts)

##  Why the previous approach failed

The original implementation used __entry_hook (called from CRT0 before any ChibiOS init) to jump to the system bootloader. This stopped working because:

D-Cache dirty lines persist through NVIC_SystemReset

On STM32H7, the firmware uses AXI SRAM (0x24000000) as primary RAM with write-back D-Cache. When the firmware calls NVIC_SystemReset, the digital peripheral registers are reset but dirty D-Cache lines are not flushed. The system bootloader uses the same AXI SRAM region and reads stale cached data, causing its USB OTG core soft reset (GRSTCTL.CSRST) to hang permanently. With CSRST stuck, writes to the device control register (DCTL) are silently ignored, so the USB D+ pull-up (SDIS) is never asserted and the host never sees the DFU device.

SCB_CleanDCache() can only flush dirty lines when the D-Cache is enabled. In __entry_hook (before CRT0 init), caches are
disabled, so the flush is a no-op. The fix requires waiting until __cpu_init has re-enabled caches before flushing.

USB peripheral must be de-initialised

The bootloader's own init_uarts() configures the USB OTG FS peripheral for its upload protocol. This leaves the USB PHY in
an active state. The system bootloader's attempt to re-initialise USB fails unless the peripheral is fully torn down first
(PHY power-down, core reset, RCC reset, clock disable).

Both issues require the DFU check to happen late

The DFU jump must occur in main() after both __cpu_init (caches enabled for flush) and init_uarts() (USB configured so it
can be properly torn down). This is why __entry_hook cannot be used and CRT0_ENTRY_HOOK is no longer needed.

## Root cause investigation

The issue was traced by reverse-engineering the STM32H743 system bootloader ROM and comparing register state between working (ArduPilot 4.3) and broken (current) configurations:

 - GRSTCTL.CSRST stuck at 1: The USB core soft reset never completes, blocking all DCTL writes
 - GOTGCTL.BSESVLD = 0: B-session valid never asserted, preventing USB cable detection
 - DCTL.SDIS = 1: Soft disconnect permanently active, D+ never pulled up

Cross-version testing confirmed the firmware (not the bootloader binary) was the culprit — the same bootloader worked with 4.3 firmware but failed with current firmware. Incremental testing narrowed it to __cpu_init enabling D-Cache over the
firmware's AXI SRAM data.

## Boards

Supports all STM32 families with USB OTG FS:
  - H7: tested on Pixhawk6X, TBS_LUCID_H7, CubeOrange
  - F7/F4: tested on BlitzF745AIO and speedybeef4v4

To enable on a board, add ENABLE_DFU_BOOT 1 to its hwdef.dat and hwdef-bl.dat.

## Testing

 - DFU device enumerates correctly on Windows (0483:df11)
 - Firmware upload via dfu-util/STM32CubeProgrammer works
 - Board boots normally after DFU session
 - Bootloader and AP_Periph builds verified (H7, L431)
 - No impact on boards without ENABLE_DFU_BOOT