### PR TITLE
hwdef: StellarH7V2:  Fix compilation

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/StellarH7V2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/StellarH7V2/README.md
@@ -87,10 +87,13 @@ The default battery parameters are:
 * :ref:`BATT_MONITOR<BATT_MONITOR>` = 4
 * :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 10
 * :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 11 (CURR pin)
-* :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 11
-* :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 10
-* :ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN__AP_BattMonitor_Analog>` = 18 (ADC1 pin, PA4)
+* :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 11.0
+* :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 66.7
 
+Pads for a second analog battery monitor are provided (Voltage only). To use:
+* :ref:`BATT2_MONITOR<BATT2_MONITOR>` = 4
+* :ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN__AP_BattMonitor_Analog>` = 18 (ADC1 pin, PA4)
+* :ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT__AP_BattMonitor_Analog>` = 21.0
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/StellarH7V2/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/StellarH7V2/hwdef.dat
@@ -57,6 +57,7 @@ PC1 BATT_CURRENT_SENS ADC1 SCALE(1)
 PA4 BATT2_VOLTAGE_SENS ADC1 SCALE(1)
 
 define HAL_BATT_MONITOR_DEFAULT 4
+define HAL_BATT2_MONITOR_DEFAULT 4
 define HAL_BATT_VOLT_PIN 10
 define HAL_BATT_CURR_PIN 11
 define HAL_BATT2_VOLT_PIN 18
@@ -64,7 +65,7 @@ define HAL_BATT_VOLT_SCALE 11.0 # Onboard voltage divider 10k and 1k
 define HAL_BATT2_VOLT_SCALE 21.0 # PDB voltage divider 20k and 1k
 
 # External PDB INA169 current sensor: Rs = 0.15 mOhm, Rl = 100 kOhm (defines gain), 1 V = 66.7 A, 15 mV per 1 A
-#define HAL_BATT_CURR_SCALE 66.7
+define HAL_BATT_CURR_SCALE 66.7
 
 # LED
 # green LED1 marked as B/E


### PR DESCRIPTION
Reenable HAL_BATT_CURR_SCALE to fix compilation and define BATT2_MONITOR;
Update README for StellarH7V2;