### PR TITLE
Libraries: Fix pessimizing-move warnings preventing copy elision

### DIFF
--- a/libraries/AP_ICEngine/AP_ICEngine_TCA9554.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine_TCA9554.cpp
@@ -32,7 +32,7 @@ extern const AP_HAL::HAL& hal;
  */
 bool AP_ICEngine_TCA9554::TCA9554_init()
 {
-    dev_TCA9554 = std::move(hal.i2c_mgr->get_device(TCA9554_I2C_BUS, TCA9554_I2C_ADDR));
+    dev_TCA9554 = hal.i2c_mgr->get_device(TCA9554_I2C_BUS, TCA9554_I2C_ADDR);
     if (!dev_TCA9554) {
         return false;
     }

--- a/libraries/AP_IRLock/AP_IRLock_I2C.cpp
+++ b/libraries/AP_IRLock/AP_IRLock_I2C.cpp
@@ -42,7 +42,7 @@ void AP_IRLock_I2C::init(int8_t bus)
         // default to i2c external bus
         bus = 1;
     }
-    dev = std::move(hal.i2c_mgr->get_device(bus, IRLOCK_I2C_ADDRESS));
+    dev = hal.i2c_mgr->get_device(bus, IRLOCK_I2C_ADDRESS);
     if (!dev) {
         return;
     }


### PR DESCRIPTION
Clang compiler flagged instances of 'pessimizing move' where std::move was being applied to a temporary object. This prevents Copy Elision (RVO). Removed std::move to allow the compiler to optimize the assignment.