### PR TITLE
Cleanup: Remove unused private fields and fix polynomial calculation in MAX31865

### DIFF
--- a/libraries/AP_Compass/AP_Compass_SITL.h
+++ b/libraries/AP_Compass/AP_Compass_SITL.h
@@ -18,7 +18,6 @@ public:
     void read(void) override;
 
 private:
-    uint8_t _compass_instance;
     SITL::SIM *_sitl;
 
     // delay buffer variables

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_MAX31865.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_MAX31865.cpp
@@ -154,14 +154,18 @@ float AP_TemperatureSensor_MAX31865::calculate_temperature(const uint16_t raw) c
     float rpoly = norm_resistance;
     temp = -242.02;
     temp += 2.2228 * norm_resistance;
-    rpoly *= norm_resistance;
-    temp += 2.5859e-3 * norm_resistance;
-    rpoly *= norm_resistance;
-    temp -= 4.8260e-6 * norm_resistance;
-    rpoly *= norm_resistance;
-    temp -= 2.8183e-8 * norm_resistance;
-    rpoly *= norm_resistance;
-    temp += 1.5243e-10 * norm_resistance;
+    
+    rpoly *= norm_resistance;         // rpoly is now R^2
+    temp += 2.5859e-3 * rpoly;        // Fixed
+    
+    rpoly *= norm_resistance;         // rpoly is now R^3
+    temp -= 4.8260e-6 * rpoly;        // Fixed
+    
+    rpoly *= norm_resistance;         // rpoly is now R^4
+    temp -= 2.8183e-8 * rpoly;        // Fixed
+    
+    rpoly *= norm_resistance;         // rpoly is now R^5
+    temp += 1.5243e-10 * rpoly;       // Fixed
 
     return temp;
 }

--- a/libraries/SITL/SIM_INA3221.h
+++ b/libraries/SITL/SIM_INA3221.h
@@ -77,7 +77,6 @@ private:
     } registers;
 
     // 256 2-byte registers:
-    assert_storage_size<Registers::ByName, 512> assert_storage_size_registers_reg;
 
     Bitmask<256> writable_registers;
 

--- a/libraries/SITL/SIM_JSON.h
+++ b/libraries/SITL/SIM_JSON.h
@@ -191,7 +191,7 @@ private:
     };
     uint32_t last_received_bitmask;
 
-    uint32_t last_debug_ms;
+
 };
 
 }


### PR DESCRIPTION
While compiling with Clang on macOS, I identified several warnings for unused private fields and variables that were set but not used.

**Changes:**

1. **Dead Code Removal:** Removed unused private members in:
   * `libraries/AP_Compass/AP_Compass_SITL.h`
   * `libraries/SITL/SIM_INA3221.h`
   * `libraries/SITL/SIM_JSON.h`

2. **Bug Fix in MAX31865:**
   In `AP_TemperatureSensor_MAX31865.cpp`, the variable `rpoly` was being updated to calculate polynomial terms ($R^2, R^3, etc.$), but the result was ignored in the final temperature summation. This effectively reduced the 5th-order polynomial compensation to a linear equation.
   * **Fix:** Updated the calculation to correctly multiply the coefficients by `rpoly` as intended.