### PR TITLE
hwdef: stop some fmuv5 boards being HAL_CHIBIOS_ARCH_FMUV5

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/JFB100/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/JFB100/hwdef.dat
@@ -8,8 +8,6 @@ MCU STM32F7xx STM32F767xx
 # crystal frequency
 OSCILLATOR_HZ 16000000
 
-define HAL_CHIBIOS_ARCH_FMUV5 1
-
 # board ID. See Tools/AP_Bootloader/board_types.txt
 APJ_BOARD_ID AP_HW_JFB100
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixC4-Jetson/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixC4-Jetson/hwdef.dat
@@ -9,8 +9,6 @@ MCU STM32H7xx STM32H743xx
 # crystal frequency
 OSCILLATOR_HZ 16000000
 
-define HAL_CHIBIOS_ARCH_FMUV5 1
-
 # board ID. See Tools/AP_Bootloader/board_types.txt
 APJ_BOARD_ID AP_HW_H31_PIXC4_JETSON
 
@@ -249,8 +247,7 @@ IMU Invensense SPI:icm20602_2 ROTATION_YAW_90
 
 define HAL_DEFAULT_INS_FAST_SAMPLE 7
 
-# probe external I2C compasses plus some internal IST8310
-# we also probe some external IST8310 with a non-standard orientation
+# probe external I2C compasses plus an internal RM3100
 define AP_COMPASS_PROBING_ENABLED 1
 COMPASS RM3100 I2C:0:0x20 false ROTATION_NONE
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/fmuv5/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/fmuv5/hwdef.dat
@@ -8,8 +8,6 @@ MCU STM32F7xx STM32F767xx
 # crystal frequency
 OSCILLATOR_HZ 16000000
 
-define HAL_CHIBIOS_ARCH_FMUV5 1
-
 # board ID. See Tools/AP_Bootloader/board_types.txt
 APJ_BOARD_ID TARGET_HW_PX4_FMU_V5
 


### PR DESCRIPTION
these boards all define IMUs, compasses and baros so don't need to do the board-detect thing

```
Board,plane
JFB100,-672
PixC4-Jetson,-672
fmuv5,-664
```

These boards don't need to look at which board they are running on - we don't need the feature-detect code.  They all specify all of their compasses, IMUs and baros.  They're not pixhawk2, so they don't need the all-external code at all.

Following PRs will be removing HAL_CHIBIOS_ARCH_FMUV5 and PX4_BOARD_FMUV5 - but Durandal is a little more involved (does not specify one of the sensors)

~I've yet to test this on hardware.~
