### PR TITLE
Tools: clarify Feature() column in build_options.py

### DIFF
--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -28,9 +28,18 @@ class Feature:
         return "enable-" + self.label.replace(" ", "-")
 
 
-# list of build options to offer NOTE: the dependencies must be
-# written as a single string with commas and no spaces,
-# eg. 'dependency1,dependency2'
+# list of build options to offer
+
+# Feature(category, label, macro, description, default, dependencies)
+#
+# category      : The category/group this feature belongs to
+# label         : Globally unique identifier for the feature (max 30 chars)
+# macro         : The macro which enables/disables the feature at compile-time.
+#                 e.g., "AP_AIRSPEED_ENABLED".
+# description   : User visible description shown on Custom build server.
+# default       : Default state (1 = enabled, 0 = disabled)
+# dependencies  : Comma-separated list of feature labels that this feature depends on
+#                 (a single string with commas and no spaces). e.g., 'dependency1,dependency2'.
 BUILD_OPTIONS = [
     Feature('AHRS', 'EKF3', 'HAL_NAVEKF3_AVAILABLE', 'Enable EKF3', 1, None),
     Feature('AHRS', 'EKF2', 'HAL_NAVEKF2_AVAILABLE', 'Enable EKF2', 0, None),


### PR DESCRIPTION
This PR adds a small comment block above BUILD_OPTIONS to clarify the meaning
of each Feature() argument (group, name, dependency, description, default,
callback).

This is intended to make the build options table easier to understand for
new contributors.

Fixes #30886
