### PR TITLE
SITL: construct multicopter frame dynamically to save RAM

### DIFF
--- a/libraries/SITL/SIM_Frame.cpp
+++ b/libraries/SITL/SIM_Frame.cpp
@@ -398,46 +398,52 @@ static Motor firefly_motors[] =
     Motor(AP_MOTORS_MOT_6, -60, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  6, -1, 0, 0, 6, 0, -90)
 };
 
+typedef struct {
+    const char *name;
+    uint8_t num_motors;
+    Motor *motors;
+} FrameTemplate;
+
 /*
   table of supported frame types. String order is important for
   partial name matching
  */
-static Frame supported_frames[] =
+static const FrameTemplate supported_frame_templates[] =
 {
-    Frame("+",         4, quad_plus_motors),
-    Frame("quad",      4, quad_plus_motors),
-    Frame("copter",    4, quad_plus_motors),
-    Frame("x",         4, quad_x_motors),
-    Frame("bfxrev",    4, quad_bf_x_rev_motors),
-    Frame("bfx",       4, quad_bf_x_motors),
+    {"+",         4, quad_plus_motors},
+    {"quad",      4, quad_plus_motors},
+    {"copter",    4, quad_plus_motors},
+    {"x",         4, quad_x_motors},
+    {"bfxrev",    4, quad_bf_x_rev_motors},
+    {"bfx",       4, quad_bf_x_motors},
 #if AP_SIM_FRAME_COPTER_DOTRIACONTA_OCTAQUAD_X_ENABLED
-    Frame("dotriaconta", 32, dotriaconta_octaquad_x_motors),
+    {"dotriaconta", 32, dotriaconta_octaquad_x_motors},
 #endif  // AP_SIM_FRAME_COPTER_DOTRIACONTA_OCTAQUAD_X_ENABLED
-    Frame("djix",      4, quad_dji_x_motors),
-    Frame("cwx",       4, quad_cw_x_motors),
-    Frame("tilthvec",  4, tiltquad_h_vectored_motors),
-    Frame("hexadeca-octa", 16, hexadeca_octa_motors),
-    Frame("hexadeca-octa-cwx", 16, hexadeca_octa_cw_x_motors),
-    Frame("hexax",     6, hexax_motors),
-    Frame("hexa-cwx",  6, hexa_cw_x_motors),
-    Frame("hexa-dji",  6, hexa_dji_x_motors),
-    Frame("hexa",      6, hexa_motors),
-    Frame("octa-cwx",  8, octa_cw_x_motors),
-    Frame("octa-dji",  8, octa_dji_x_motors),
-    Frame("octa-quad-cwx",8, octa_quad_cw_x_motors),
-    Frame("octa-quad-cor", 8, octa_quad_corotating_motors),
-    Frame("octa-quad-cw-cor", 8, octa_quad_cw_corotating_motors),
-    Frame("octa-quad", 8, octa_quad_motors),
-    Frame("octa",      8, octa_motors),
-    Frame("deca",     10, deca_motors),
-    Frame("deca-cwx", 10, deca_cw_x_motors),
-    Frame("dodeca-hexa", 12, dodeca_hexa_motors),
-    Frame("tri",       3, tri_motors),
-    Frame("tilttrivec",3, tilttri_vectored_motors),
-    Frame("tilttri",   3, tilttri_motors),
-    Frame("y6",        6, y6_motors),
-    Frame("firefly",   6, firefly_motors),
-    Frame("tilt",      4, tiltquad),
+    {"djix",      4, quad_dji_x_motors},
+    {"cwx",       4, quad_cw_x_motors},
+    {"tilthvec",  4, tiltquad_h_vectored_motors},
+    {"hexadeca-octa", 16, hexadeca_octa_motors},
+    {"hexadeca-octa-cwx", 16, hexadeca_octa_cw_x_motors},
+    {"hexax",     6, hexax_motors},
+    {"hexa-cwx",  6, hexa_cw_x_motors},
+    {"hexa-dji",  6, hexa_dji_x_motors},
+    {"hexa",      6, hexa_motors},
+    {"octa-cwx",  8, octa_cw_x_motors},
+    {"octa-dji",  8, octa_dji_x_motors},
+    {"octa-quad-cwx",8, octa_quad_cw_x_motors},
+    {"octa-quad-cor", 8, octa_quad_corotating_motors},
+    {"octa-quad-cw-cor", 8, octa_quad_cw_corotating_motors},
+    {"octa-quad", 8, octa_quad_motors},
+    {"octa",      8, octa_motors},
+    {"deca",     10, deca_motors},
+    {"deca-cwx", 10, deca_cw_x_motors},
+    {"dodeca-hexa", 12, dodeca_hexa_motors},
+    {"tri",       3, tri_motors},
+    {"tilttrivec",3, tilttri_vectored_motors},
+    {"tilttri",   3, tilttri_motors},
+    {"y6",        6, y6_motors},
+    {"firefly",   6, firefly_motors},
+    {"tilt",      4, tiltquad},
 };
 
 // get air density in kg/m^3
@@ -643,14 +649,15 @@ void Frame::init(const char *frame_str, Battery *_battery)
 }
 
 /*
-  find a frame by name
+  create a frame by name from its template
  */
-Frame *Frame::find_frame(const char *name)
+Frame *Frame::create_frame(const char *name)
 {
-    for (uint8_t i=0; i < ARRAY_SIZE(supported_frames); i++) {
+    for (uint8_t i=0; i < ARRAY_SIZE(supported_frame_templates); i++) {
+        auto &tplate = supported_frame_templates[i]; // `template` is a reserved word
         // do partial name matching to allow for frame variants
-        if (strncasecmp(name, supported_frames[i].name, strlen(supported_frames[i].name)) == 0) {
-            return &supported_frames[i];
+        if (strncasecmp(name, tplate.name, strlen(tplate.name)) == 0) {
+            return NEW_NOTHROW Frame(tplate.name, tplate.num_motors, tplate.motors);
         }
     }
     return nullptr;

--- a/libraries/SITL/SIM_Frame.h
+++ b/libraries/SITL/SIM_Frame.h
@@ -45,8 +45,8 @@ public:
           motors(_motors) {}
 
 #if AP_SIM_ENABLED
-    // find a frame by name
-    static Frame *find_frame(const char *name);
+    // create a frame by name from its template
+    static Frame *create_frame(const char *name);
     
     // initialise frame
     void init(const char *frame_str, Battery *_battery);

--- a/libraries/SITL/SIM_Multicopter.cpp
+++ b/libraries/SITL/SIM_Multicopter.cpp
@@ -26,9 +26,9 @@ using namespace SITL;
 MultiCopter::MultiCopter(const char *frame_str) :
     Aircraft(frame_str)
 {
-    frame = Frame::find_frame(frame_str);
+    frame = Frame::create_frame(frame_str);
     if (frame == nullptr) {
-        printf("Frame '%s' not found", frame_str);
+        printf("Frame '%s' not found or insufficient memory", frame_str);
         exit(1);
     }
 

--- a/libraries/SITL/SIM_Multicopter.h
+++ b/libraries/SITL/SIM_Multicopter.h
@@ -31,6 +31,10 @@ class MultiCopter : public Aircraft {
 public:
     MultiCopter(const char *frame_str);
 
+    ~MultiCopter() {
+        delete frame;
+    }
+
     /* update model by one time step */
     void update(const struct sitl_input &input) override;
 

--- a/libraries/SITL/SIM_QuadPlane.cpp
+++ b/libraries/SITL/SIM_QuadPlane.cpp
@@ -83,9 +83,9 @@ QuadPlane::QuadPlane(const char *frame_str) :
         ground_behavior = GROUND_BEHAVIOR_TAILSITTER;
         thrust_scale *= 1.5;
     }
-    frame = Frame::find_frame(frame_type);
+    frame = Frame::create_frame(frame_type);
     if (frame == nullptr) {
-        printf("Failed to find frame '%s'\n", frame_type);
+        printf("Failed to find frame '%s' or insufficient memory\n", frame_type);
         exit(1);
     }
 

--- a/libraries/SITL/SIM_QuadPlane.h
+++ b/libraries/SITL/SIM_QuadPlane.h
@@ -31,6 +31,10 @@ class QuadPlane : public Plane {
 public:
     QuadPlane(const char *frame_str);
 
+    ~QuadPlane() {
+        delete frame;
+    }
+
     /* update model by one time step */
     void update(const struct sitl_input &input) override;
 


### PR DESCRIPTION
Only one ever exists so there's little reason to construct all possibilities ahead of time and store them in global RAM. Instead, keep a list of the parameters and only construct the one requested. Saves some 60K of RAM on hardware when using sim on hardware.

In particular, enough is saved to get esp32empty copter building again. But esp32 sim on hardware still does not work due to other regressions.

Tested SITL on HW on CubeBlack and it works okay. Had to disable terrain, the secondary IMU's EKF3 lane, and halve the log buf size to get enough RAM to do a flight still. ESP32 is still broken due to other regressions for which PRs will eventually come.

If we had some canonical list of frames and strings we could also avoid having all the frames and motors compiled in all the time.