### PR TITLE
Copter: fix failsafe disarm logic for ACRO/STABILIZE modes

### DIFF
--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -468,8 +468,8 @@ bool Copter::should_disarm_on_failsafe() {
     switch (flightmode->mode_number()) {
         case Mode::Number::STABILIZE:
         case Mode::Number::ACRO:
-            // if throttle is zero OR vehicle is landed disarm motors
-            return ap.throttle_zero || ap.land_complete;
+            // if throttle is zero AND vehicle is landed disarm motors
+            return ap.throttle_zero && ap.land_complete;
         case Mode::Number::AUTO:
         case Mode::Number::AUTO_RTL:
             // if mission has not started AND vehicle is landed, disarm motors


### PR DESCRIPTION
## Description

Fixes unexpected disarm behavior in ACRO/STABILIZE modes during failsafe events when airborne with zero throttle.

## Problem

The `should_disarm_on_failsafe()` function was using OR logic:
```cpp
return ap.throttle_zero || ap.land_complete;
```

This caused the copter to disarm immediately during any failsafe (radio, GCS, battery) if throttle was at minimum, even when flying at altitude.

## solution

changed to AND logic:
```cpp
return ap.throttle_zero && ap.land_complete;
```

now only disarms when both conditions are true - throttle at zero AND vehicle has actually landed.

## testing

tested in SITL - copter at 280m altitude, zero throttle in ACRO mode, triggered RC failsafe. 

Before fix: immediately disarmed and fell
After fix: switched to RTL mode. copter still crashed because it was already falling hard in ACRO when RTL kicked in, but at least it attempted the failsafe action instead of just giving up.

the point is to give the copter a chance to recover rather than guaranteeing a crash by disarming.

Fixes #31798