### PR TITLE
Tools: remove no-longer-required running_python3 variables

### DIFF
--- a/Tools/scripts/build_binaries.py
+++ b/Tools/scripts/build_binaries.py
@@ -29,11 +29,6 @@ import build_binaries_history
 import board_list
 from board_list import AP_PERIPH_BOARDS
 
-if sys.version_info[0] < 3:
-    running_python3 = False
-else:
-    running_python3 = True
-
 
 def topdir():
     '''return path to ardupilot checkout directory.  This is to cope with
@@ -137,10 +132,9 @@ class build_binaries(object):
                     # select not available on Windows... probably...
                 time.sleep(0.1)
                 continue
-            if running_python3:
-                x = bytearray(x)
-                x = filter(lambda x : chr(x) in string.printable, x)
-                x = "".join([chr(c) for c in x])
+            x = bytearray(x)
+            x = filter(lambda x : chr(x) in string.printable, x)
+            x = "".join([chr(c) for c in x])
             output += x
             x = x.rstrip()
             if show_output:
@@ -364,10 +358,7 @@ is bob we will attempt to checkout bob-AVR'''
         with open(filepath, 'rb') as fh:
             content = fh.read()
 
-        if running_python3:
-            return content.decode('ascii')
-
-        return content
+        return content.decode('ascii')
 
     def string_in_filepath(self, string, filepath):
         '''returns true if string exists in the contents of filepath'''

--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -7,15 +7,8 @@ AP_FLAKE8_CLEAN
 """
 import argparse
 import re
-import sys
 import build_options
 from build_script_base import BuildScriptBase
-
-
-if sys.version_info[0] < 3:
-    running_python3 = False
-else:
-    running_python3 = True
 
 
 class ExtractFeatures(BuildScriptBase):

--- a/Tools/scripts/generate_manifest.py
+++ b/Tools/scripts/generate_manifest.py
@@ -14,16 +14,6 @@ import subprocess
 import shutil
 import sys
 
-if sys.version_info[0] < 3:
-    running_python3 = False
-    running_python310 = False
-elif sys.version_info[1] < 10:
-    running_python3 = True
-    running_python310 = False
-else:
-    running_python3 = True
-    running_python310 = True
-
 FIRMWARE_TYPES = ["AntennaTracker", "Copter", "Plane", "Rover", "Sub", "AP_Periph", "Blimp"]
 RELEASE_TYPES = ["beta", "latest", "stable", "stable-*", "dirty"]
 
@@ -339,8 +329,7 @@ class ManifestGenerator():
             return "".join(filename.split(".")[-1:])
         # no extension; ensure this is an elf:
         text = subprocess.check_output(["file", "-b", filepath])
-        if running_python3:
-            text = text.decode('ascii')
+        text = text.decode('ascii')
 
         if re.match("^ELF", text):
             return "ELF"
@@ -638,8 +627,7 @@ class ManifestGenerator():
         # "gzip -9"s to 300k in 1 second, "xz -e"s to 80k in 26 seconds
         new_json_filepath_gz = path + ".gz.new"
         with gzip.open(new_json_filepath_gz, 'wb') as gf:
-            if running_python3:
-                content = bytes(content, 'ascii')
+            content = bytes(content, 'ascii')
             gf.write(content)
             gf.close()
         shutil.move(new_json_filepath, path)


### PR DESCRIPTION
this is always true now-adays

I've run build_binaries.py (which uses generate_manifest.py an extract_features.py and all is well.

This patch makes things manageable:
```
diff --git a/Tools/scripts/build_binaries.py b/Tools/scripts/build_binaries.py
index e783da17c41..4b635fac7d6 100755
--- a/Tools/scripts/build_binaries.py
+++ b/Tools/scripts/build_binaries.py
@@ -590,6 +590,7 @@ is bob we will attempt to checkout bob-AVR'''
         boards = []
         boards.extend(["aerofc-v1"])
         boards.extend(self.board_list.find_autobuild_boards('Copter'))
+        boards = boards[0:2]
         self.build_vehicle(tag,
                            "ArduCopter",
                            boards,
@@ -731,12 +732,12 @@ is bob we will attempt to checkout bob-AVR'''
         for tag in self.tags:
             t0 = time.time()
             self.build_arducopter(tag)
-            self.build_arduplane(tag)
-            self.build_rover(tag)
-            self.build_antennatracker(tag)
-            self.build_ardusub(tag)
-            self.build_AP_Periph(tag)
-            self.build_blimp(tag)
+            # self.build_arduplane(tag)
+            # self.build_rover(tag)
+            # self.build_antennatracker(tag)
+            # self.build_ardusub(tag)
+            # self.build_AP_Periph(tag)
+            # self.build_blimp(tag)
             self.history.record_run(githash, tag, t0, time.time()-t0)
 
         if os.path.exists(self.tmpdir):
```

```
pbarker@crun:~/rc/ardupilot(pr/remove-run_python3)$ ./Tools/scripts/build_binaries.py --tags=dirty 
.
.
BB: Manifest generation successful
BB: Generating stable releases
Missing /home/pbarker/rc/ardupilot/../buildlogs/binaries/AntennaTracker/stable
Missing /home/pbarker/rc/ardupilot/../buildlogs/binaries/Copter/stable
Missing /home/pbarker/rc/ardupilot/../buildlogs/binaries/Plane/stable
Missing /home/pbarker/rc/ardupilot/../buildlogs/binaries/Rover/stable
Missing /home/pbarker/rc/ardupilot/../buildlogs/binaries/Sub/stable
BB: Generate stable releases done
pbarker@crun:~/rc/ardupilot(pr/remove-run_python3)$ 
```

```
pbarker@crun:~/rc/ardupilot(pr/remove-run_python3)$ ./Tools/scripts/extract_features.py build/CubeRedPrimary/bin/arduplane | wc
    405     416   11348
pbarker@crun:~/rc/ardupilot(pr/remove-run_python3)$ 
```
