### PR TITLE
Copter: stop passing reference to do_pilot_takeoff_ms

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -287,7 +287,7 @@ protected:
     public:
         void start_m(float alt_m);
         void stop();
-        void do_pilot_takeoff_ms(float& pilot_climb_rate_ms);
+        void do_pilot_takeoff_ms(float pilot_climb_rate_ms);
         bool triggered_ms(float target_climb_rate_ms) const;
 
         bool running() const { return _running; }

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -71,7 +71,7 @@ void Mode::_TakeOff::stop()
 //  take off is complete when the vertical target reaches the take off altitude.
 //  climb is cancelled if pilot_climb_rate_ms becomes negative
 //  sets take off to complete when target altitude is within 1% of the take off altitude
-void Mode::_TakeOff::do_pilot_takeoff_ms(float& pilot_climb_rate_ms)
+void Mode::_TakeOff::do_pilot_takeoff_ms(float pilot_climb_rate_ms)
 {
     // return pilot_climb_rate if take-off inactive
     if (!_running) {


### PR DESCRIPTION
the called function does not modify this parameter, stop misleading people by taking a reference

I have tested this branch using this patch, which is contrary to our coding standards (`const` keyword is not permitted in method declarations or definitions on simple types) but will absolutely catch the sort of bug that this PR could possibly introduce:
```
diff --git a/ArduCopter/takeoff.cpp b/ArduCopter/takeoff.cpp
index 3660397d751..2614e44947a 100644
--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -71,7 +71,7 @@ void Mode::_TakeOff::stop()
 //  take off is complete when the vertical target reaches the take off altitude.
 //  climb is cancelled if pilot_climb_rate_ms becomes negative
 //  sets take off to complete when target altitude is within 1% of the take off altitude
-void Mode::_TakeOff::do_pilot_takeoff_ms(float pilot_climb_rate_ms)
+void Mode::_TakeOff::do_pilot_takeoff_ms(const float pilot_climb_rate_ms)
 {
     // return pilot_climb_rate if take-off inactive
     if (!_running) {
```

If an assignment is introduced with that patch in place:
```
../../ArduCopter/takeoff.cpp: In member function ‘void Mode::_TakeOff::do_pilot_takeoff_ms(float)’:
../../ArduCopter/takeoff.cpp:81:25: error: assignment of read-only parameter ‘pilot_climb_rate_ms’
   81 |     pilot_climb_rate_ms = 3;
      |     ~~~~~~~~~~~~~~~~~~~~^~~
compilation terminated due to -Wfatal-errors.
```

Saves an inordinate amount of flash:
```
Board,copter
CubeOrange,-48
```

.... but that's because several call sits get smaller:
<img width="3217" height="430" alt="image" src="https://github.com/user-attachments/assets/1990b744-1864-40c3-b234-9633a393acfc" />
