### PR TITLE
fixes#31748

### DIFF
--- a/Rover/GCS_MAVLink_Rover.cpp
+++ b/Rover/GCS_MAVLink_Rover.cpp
@@ -228,9 +228,9 @@ void GCS_MAVLINK_Rover::send_water_depth()
             continue;
         }
 
-        // get temperature
+        // get temperature (with external sensor override support)
         float temp_C;
-        if (!s->get_temp(temp_C)) {
+        if (!rangefinder->get_temp_with_override(ROTATION_PITCH_270, temp_C)) {
             temp_C = 0.0f;
         }
 

--- a/Rover/config.h
+++ b/Rover/config.h
@@ -55,6 +55,12 @@
 # define MODE_FOLLOW_ENABLED AP_FOLLOW_ENABLED
 #endif
 
+//////////////////////////////////////////////////////////////////////////////
+// Temperature sensor - enable for rangefinder temperature override support
+#ifndef AP_TEMPERATURE_SENSOR_ENABLED
+# define AP_TEMPERATURE_SENSOR_ENABLED 1
+#endif
+
 
 //////////////////////////////////////////////////////////////////////////////
 // Developer Items

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Params.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Params.cpp
@@ -58,7 +58,7 @@ const AP_Param::GroupInfo AP_TemperatureSensor_Params::var_info[] = {
     // @Param: SRC
     // @DisplayName: Sensor Source
     // @Description: Sensor Source is used to designate which device's temperature report will be replaced by this temperature sensor's data. If 0 (None) then the data is only available via log. In the future a new Motor temperature report will be created for returning data directly.
-    // @Values: 0: None, 1:ESC, 2:Motor, 3:Battery Index, 4:Battery ID/SerialNumber, 5:CAN based Pitot tube, 6:DroneCAN-out on AP_Periph, 7:Servo motor, 8:Servo PCB
+    // @Values: 0: None, 1:ESC, 2:Motor, 3:Battery Index, 4:Battery ID/SerialNumber, 5:CAN based Pitot tube, 6:DroneCAN-out on AP_Periph, 7:Servo motor, 8:Servo PCB,9:Rangefinder
     // @User: Standard
     AP_GROUPINFO("SRC", 4, AP_TemperatureSensor_Params, source, (float)Source::None),
 

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Params.h
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Params.h
@@ -39,7 +39,6 @@ public:
         MAX31865_3_wire             = 9,
     };
 
-    // option to map to another system component
     enum class Source : uint8_t {
         None                        = 0,
         ESC                         = 1,
@@ -50,6 +49,7 @@ public:
         DroneCAN                    = 6,
         Servo_Motor                 = 7,
         Servo_PCB                   = 8,
+        Rangefinder                 = 9,
     };
 
     AP_Enum<Type> type;             // 0=disabled, others see frontend enum TYPE


### PR DESCRIPTION
AP_TemperatureSensor: Add Rangefinder to TEMPx_SRC sensor source options
This PR adds support for using external temperature sensors to override rangefinder temperature readings in the WATER_DEPTH MAVLink message.

Changes:

Added [Rangefinder = 9](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to [AP_TemperatureSensor_Params::Source](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) enum
Implemented [get_temp_with_override()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) in AP_RangeFinder to check for external temperature sensor override
Updated Rover's WATER_DEPTH message handler to use the new override function
Enabled AP_TemperatureSensor for Rover
Usage:
Set TEMP1_SRC = 9 to have an external temperature sensor override the rangefinder's temperature reading. Falls back to rangefinder's built-in sensor if no override is configured.

Testing:
Tested in SITL with parameter verification.

