### PR TITLE
AC_AttitudeControl: correct @Increment for Angle P gains

### DIFF
--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -86,6 +86,7 @@ const AP_Param::GroupInfo AC_AttitudeControl::var_info[] = {
     // @Description: Roll axis angle controller P gain.  Converts the error between the desired roll angle and actual angle to a desired roll rate
     // @Range: 3.000 12.000
     // @Range{Sub}: 0.0 12.000
+    // @Increment: 0.01
     // @User: Standard
     AP_SUBGROUPINFO(_p_angle_roll, "ANG_RLL_", 13, AC_AttitudeControl, AC_P),
 
@@ -94,6 +95,7 @@ const AP_Param::GroupInfo AC_AttitudeControl::var_info[] = {
     // @Description: Pitch axis angle controller P gain.  Converts the error between the desired pitch angle and actual angle to a desired pitch rate
     // @Range: 3.000 12.000
     // @Range{Sub}: 0.0 12.000
+    // @Increment: 0.01
     // @User: Standard
     AP_SUBGROUPINFO(_p_angle_pitch, "ANG_PIT_", 14, AC_AttitudeControl, AC_P),
 
@@ -102,6 +104,7 @@ const AP_Param::GroupInfo AC_AttitudeControl::var_info[] = {
     // @Description: Yaw axis angle controller P gain.  Converts the error between the desired yaw angle and actual angle to a desired yaw rate
     // @Range: 3.000 12.000
     // @Range{Sub}: 0.0 6.000
+    // @Increment: 0.01
     // @User: Standard
     AP_SUBGROUPINFO(_p_angle_yaw, "ANG_YAW_", 15, AC_AttitudeControl, AC_P),
 


### PR DESCRIPTION
This PR addresses issue #31728 regarding parameter metadata display precision.

The `ANG_RLL_P`, `ANG_PIT_P`, and `ANG_YAW_P` parameters relied on default increment values, causing Ground Control Stations (like Mission Planner) to round displayed values to `0.1`. This granularity is insufficient for precise tuning of attitude controllers.

**Changes:**
- Added `@Increment: 0.01` metadata tag to Roll, Pitch, and Yaw Angle P gains in `AC_AttitudeControl.cpp`.

**Verification:**
- Verified via code inspection that the metadata tag aligns with the schema required for higher precision display in GCS.

**Checkboxes:**
- [x] Documentation
- [x] Test (Code inspection)