### PR TITLE
AP_Mount: use send_target_to_gimbal on remaining backends

### DIFF
--- a/libraries/AP_Mount/AP_Mount_CADDX.cpp
+++ b/libraries/AP_Mount/AP_Mount_CADDX.cpp
@@ -23,12 +23,8 @@ void AP_Mount_CADDX::update()
 
     AP_Mount_Backend::update_mnt_target();
 
-    // update angle targets from angle rates
-    if (mnt_target.target_type == MountTargetType::RATE) {
-        update_angle_target_from_rate(mnt_target.rate_rads, mnt_target.angle_rad);
-    }
-
-    send_target_angles(mnt_target.angle_rad);
+    // send target angles (which may be derived from other target types)
+    AP_Mount_Backend::send_target_to_gimbal();
 }
 
 // get attitude as a quaternion.  returns true on success

--- a/libraries/AP_Mount/AP_Mount_SToRM32.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.cpp
@@ -24,12 +24,8 @@ void AP_Mount_SToRM32::update()
 
     AP_Mount_Backend::update_mnt_target();
 
-    // update angle targets from angle rates
-    if (mnt_target.target_type == MountTargetType::RATE) {
-        update_angle_target_from_rate(mnt_target.rate_rads, mnt_target.angle_rad);
-    }
-
-    send_do_mount_control(mnt_target.angle_rad);
+    // send target angles (which may be derived from other target types)
+    AP_Mount_Backend::send_target_to_gimbal();
 }
 
 // get attitude as a quaternion.  returns true on success
@@ -61,8 +57,8 @@ void AP_Mount_SToRM32::find_gimbal()
     }
 }
 
-// send_do_mount_control - send a COMMAND_LONG containing a do_mount_control message
-void AP_Mount_SToRM32::send_do_mount_control(const MountAngleTarget& angle_target_rad)
+// send_target_angles - send a COMMAND_LONG containing a do_mount_control message
+void AP_Mount_SToRM32::send_target_angles(const MountAngleTarget& angle_target_rad)
 {
     // exit immediately if not initialised
     if (!_initialised) {

--- a/libraries/AP_Mount/AP_Mount_SToRM32.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.h
@@ -35,8 +35,13 @@ private:
     // search for gimbal in GCS_MAVLink routing table
     void find_gimbal();
 
+    // SToRM32 can only send angles:
+    uint8_t natively_supported_mount_target_types() const override {
+        return NATIVE_ANGLES_ONLY;
+    };
+
     // send_do_mount_control with latest angle targets
-    void send_do_mount_control(const MountAngleTarget& angle_target_rad);
+    void send_target_angles(const MountAngleTarget& angle_target_rad) override;
 
     // internal variables
     bool _initialised;              // true once the driver has been initialised

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
@@ -37,6 +37,11 @@ protected:
 
 private:
 
+    // SToRM32-serial can only send angles
+    uint8_t natively_supported_mount_target_types() const override {
+        return NATIVE_ANGLES_ONLY;
+    };
+
     // send_target_angles
     void send_target_angles(const MountAngleTarget& angle_target_rad) override;
 

--- a/libraries/AP_Mount/AP_Mount_XFRobot.cpp
+++ b/libraries/AP_Mount/AP_Mount_XFRobot.cpp
@@ -131,12 +131,8 @@ void AP_Mount_XFRobot::update()
 
     AP_Mount_Backend::update_mnt_target();
 
-    // update angle targets from angle rates
-    if (mnt_target.target_type == MountTargetType::RATE) {
-        update_angle_target_from_rate(mnt_target.rate_rads, mnt_target.angle_rad);
-    }
-
-    send_target_angles(mnt_target.angle_rad);
+    // send target angles (which may be derived from other target types)
+    send_target_to_gimbal();
 }
 
 // return true if healthy

--- a/libraries/AP_Mount/AP_Mount_XFRobot.h
+++ b/libraries/AP_Mount/AP_Mount_XFRobot.h
@@ -129,6 +129,11 @@ private:
     // process successfully decoded packets held in the _msg_buff structure
     void process_packet();
 
+    // XFRobot can only send angles
+    uint8_t natively_supported_mount_target_types() const override {
+        return NATIVE_ANGLES_ONLY;
+    };
+
     // send_target_angles
     void send_target_angles(const MountAngleTarget& angle_target_rad) override;
 


### PR DESCRIPTION
Tested on a storm32; angles/rates/retract/neutral all work entirely as expected.
