### PR TITLE
AP_Mount: move mavlink target timeout into update_mnt_target

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -45,14 +45,6 @@ void AP_Mount_Backend::update()
     const bool mount_open = (_mode == MAV_MOUNT_MODE_RETRACT);
     SRV_Channels::move_servo(_open_idx, mount_open, 0, 1);
 
-    // set target rate to zero if we have not received rate command for a while
-    if ((get_mode() == MAV_MOUNT_MODE_MAVLINK_TARGETING) &&
-        (mnt_target.target_type == MountTargetType::RATE) &&
-        (AP_HAL::millis() - mnt_target.last_rate_request_ms > 3000)) {
-        mnt_target.rate_rads.roll = 0;
-        mnt_target.rate_rads.pitch = 0;
-        mnt_target.rate_rads.yaw = 0;
-    }
     // location exists for mode
     Location current_loc;
     switch (_mode) {
@@ -942,6 +934,15 @@ void AP_Mount_Backend::update_mnt_target()
     case MAV_MOUNT_MODE_MAVLINK_TARGETING:
         // point to the angles given by a mavlink message
         // mavlink targets are stored while handling the incoming message
+
+        // set target rate to zero if we have not received rate
+        // command for a while
+        if ((mnt_target.target_type == MountTargetType::RATE) &&
+            (AP_HAL::millis() - mnt_target.last_rate_request_ms > 3000)) {
+            mnt_target.rate_rads.roll = 0;
+            mnt_target.rate_rads.pitch = 0;
+            mnt_target.rate_rads.yaw = 0;
+        }
         return;
 
     case MAV_MOUNT_MODE_RC_TARGETING:


### PR DESCRIPTION
Moves the timeout into update_mnt_target.

Really just to start getting rid of instances where we are calling `get_mode` on the backends where we don't need to.

Tested on a STorM32 gimbal.

Timeouts still work - in fact it required https://github.com/ArduPilot/MAVProxy/pull/1659 for me to test properly as MAVProxy was only ever sending the command once.
