### PR TITLE
AP_Mount: add MountTargetType::RETRACTED / MountTargetType::NEUTRAL

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -230,6 +230,8 @@ protected:
     enum class MountTargetType {
         ANGLE     = 0,
         RATE      = 1,
+        RETRACTED = 2,
+        NEUTRAL   = 3,
     };
 
     // class for a single angle or rate target
@@ -291,6 +293,8 @@ protected:
     // FIXME: make it an internal error for these to ever be called:
     virtual void send_target_angles(const MountAngleTarget &angle_rad) { }
     virtual void send_target_rates(const MountRateTarget &rate_rads) { }
+    virtual void send_target_retracted() { }
+    virtual void send_target_neutral() { }
 
     // options parameter bitmask handling
     enum class Options : uint8_t {

--- a/libraries/AP_Mount/AP_Mount_MAVLink.cpp
+++ b/libraries/AP_Mount/AP_Mount_MAVLink.cpp
@@ -25,15 +25,7 @@ void AP_Mount_MAVLink::update()
 
     update_mnt_target();
 
-    // FIXME: create and use MountTargetType::RETRACTED
-    if (get_mode() == MAV_MOUNT_MODE_RETRACT) {
-        mnt_target.target_type = MountTargetType::ANGLE;
-        mnt_target.angle_rad.set(Vector3f{0,0,0}, false);
-        send_gimbal_device_retract();
-        return;
-    }
-
-    // send target angles or rates depending on the target type
+    // send target angles/rates/retract depending on the target type
     send_target_to_gimbal();
 }
 
@@ -208,8 +200,13 @@ bool AP_Mount_MAVLink::start_sending_attitude_to_gimbal()
 }
 
 // send GIMBAL_DEVICE_SET_ATTITUDE to gimbal to command gimbal to retract (aka relax)
-void AP_Mount_MAVLink::send_gimbal_device_retract() const
+void AP_Mount_MAVLink::send_target_retracted()
 {
+    // update the target angles.  These may be absolutely bogus, of
+    // course, but may be useful in logs to see what the gimbal was
+    // doing.  This is also preserving existing behaviour in a change...
+    mnt_target.angle_rad.set(Vector3f{0,0,0}, false);
+
     const mavlink_gimbal_device_set_attitude_t pkt {
         {NAN, NAN, NAN, NAN},  // attitude
         0,   // angular velocity x

--- a/libraries/AP_Mount/AP_Mount_MAVLink.h
+++ b/libraries/AP_Mount/AP_Mount_MAVLink.h
@@ -37,9 +37,14 @@ public:
 
 protected:
 
-    // MVAVLink can send either rates or angles
+    // MVAVLink can send either rates or angles, and can also be
+    // directly commanded to move to a retracted state
     uint8_t natively_supported_mount_target_types() const override {
-        return NATIVE_ANGLES_AND_RATES_ONLY;
+        return (
+            (1U<<unsigned(MountTargetType::ANGLE)) |
+            (1U<<unsigned(MountTargetType::RATE)) |
+            (1U<<unsigned(MountTargetType::RETRACTED))
+            );
     };
 
     // get attitude as a quaternion.  returns true on success
@@ -58,7 +63,7 @@ private:
     bool start_sending_attitude_to_gimbal();
 
     // send GIMBAL_DEVICE_SET_ATTITUDE to gimbal to command gimbal to retract (aka relax)
-    void send_gimbal_device_retract() const;
+    void send_target_retracted() override;
 
     // send GIMBAL_DEVICE_SET_ATTITUDE to gimbal to control rate
     void send_target_rates(const MountRateTarget &rate_rads) override;

--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -104,11 +104,12 @@ void AP_Mount_Servo::update_angle_outputs(const MountAngleTarget& angle_rad)
     _angle_bf_output_rad.z = yaw_bf_rad;
 
     // do no stabilization in retract or neutral:
-    switch (get_mode()) {
-    case MAV_MOUNT_MODE_RETRACT:
-    case MAV_MOUNT_MODE_NEUTRAL:
+    switch (mnt_target.target_type) {
+    case MountTargetType::NEUTRAL:
+    case MountTargetType::RETRACTED:
         return;
-    case MAV_MOUNT_MODE_MAVLINK_TARGETING...MAV_MOUNT_MODE_ENUM_END:
+    case MountTargetType::ANGLE:
+    case MountTargetType::RATE:
         break;
     }
 


### PR DESCRIPTION
This has been tested to make sure everything (and particularly retract/neutral) still works.

Tested:
 - storm32
 - servo
 - Siyi A8
 - Gremsy PixyU (i.e. MAVLink gimbal)
