### PR TITLE
Fix compilation in mode_sport.cpp

### DIFF
--- a/ArduCopter/mode_sport.cpp
+++ b/ArduCopter/mode_sport.cpp
@@ -113,7 +113,7 @@ void ModeSport::run()
 #endif
 
         // Send the commanded climb rate to the position controller
-        pos_control->set_pos_target_D_from_climb_rate_m(target_climb_rate_ms);
+        pos_control->D_set_pos_target_from_climb_rate_ms(target_climb_rate_ms);
         break;
     }
 


### PR DESCRIPTION
In my copy I enable Sport Mode for my machines, and this time it did not compile.
The breaking changes were related to the recent NED conversion.
This could have been caught, but apparently CI/CD never compiles this file, which should likely be fixed too.