### PR TITLE
Ap math guard sqrt controller dt

### DIFF
--- a/libraries/AP_HAL_ESP32/WiFiDriver.cpp
+++ b/libraries/AP_HAL_ESP32/WiFiDriver.cpp
@@ -279,8 +279,8 @@ void WiFiDriver::initialize_wifi()
     ESP_ERROR_CHECK(esp_wifi_init(&cfg));
 
 
-    strcpy((char *)wifi_config.ap.ssid, WIFI_SSID);
-    strcpy((char *)wifi_config.ap.password, WIFI_PWD);
+    strlcpy((char *)wifi_config.ap.ssid, WIFI_SSID, sizeof(wifi_config.ap.ssid));
+    strlcpy((char *)wifi_config.ap.password, WIFI_PWD, sizeof(wifi_config.ap.password));
     wifi_config.ap.ssid_len = strlen(WIFI_SSID),
     wifi_config.ap.max_connection = WIFI_MAX_CONNECTION,
     wifi_config.ap.authmode = WIFI_AUTH_WPA2_PSK;
@@ -327,8 +327,9 @@ void WiFiDriver::initialize_wifi()
                                                         NULL,
                                                         &instance_got_ip));
 
-    strcpy((char *)wifi_config.sta.ssid, WIFI_SSID_STATION);
-    strcpy((char *)wifi_config.sta.password, WIFI_PWD);
+    // Defensive copy: prevents buffer overflow if SSID/password exceeds buffer size
+    strlcpy((char *)wifi_config.sta.ssid, WIFI_SSID_STATION, sizeof(wifi_config.sta.ssid));
+    strlcpy((char *)wifi_config.sta.password, WIFI_PWD, sizeof(wifi_config.sta.password));
     wifi_config.sta.threshold.authmode = WIFI_AUTH_OPEN;
     wifi_config.sta.sae_pwe_h2e = WPA3_SAE_PWE_BOTH;
 

--- a/libraries/AP_HAL_ESP32/WiFiUdpDriver.cpp
+++ b/libraries/AP_HAL_ESP32/WiFiUdpDriver.cpp
@@ -247,9 +247,9 @@ void WiFiUdpDriver::initialize_wifi()
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
     ESP_ERROR_CHECK(esp_wifi_init(&cfg));
 
-
-    strcpy((char *)wifi_config.ap.ssid, WIFI_SSID);
-    strcpy((char *)wifi_config.ap.password, WIFI_PWD);
+    // Defensive copy to prevent buffer overflow if SSID/password exceeds buffer size
+    strlcpy((char *)wifi_config.ap.ssid, WIFI_SSID, sizeof(wifi_config.ap.ssid));
+    strlcpy((char *)wifi_config.ap.password, WIFI_PWD, sizeof(wifi_config.ap.password));
     wifi_config.ap.ssid_len = strlen(WIFI_SSID),
     wifi_config.ap.max_connection = WIFI_MAX_CONNECTION,
     wifi_config.ap.authmode = WIFI_AUTH_WPA2_PSK;
@@ -295,9 +295,10 @@ void WiFiUdpDriver::initialize_wifi()
                                                         &_sta_event_handler,
                                                         NULL,
                                                         &instance_got_ip));
-
-    strcpy((char *)wifi_config.sta.ssid, WIFI_SSID_STATION);
-    strcpy((char *)wifi_config.sta.password, WIFI_PWD);
+    
+    // Defensive copy: prevents buffer overflow if SSID/password exceeds buffer size
+    strlcpy((char *)wifi_config.sta.ssid, WIFI_SSID_STATION, sizeof(wifi_config.sta.ssid));
+    strlcpy((char *)wifi_config.sta.password, WIFI_PWD, sizeof(wifi_config.sta.password));
     wifi_config.sta.threshold.authmode = WIFI_AUTH_OPEN;
     wifi_config.sta.sae_pwe_h2e = WPA3_SAE_PWE_BOTH;
 

--- a/libraries/AP_Math/control.cpp
+++ b/libraries/AP_Math/control.cpp
@@ -494,7 +494,10 @@ float sqrt_controller(float error, float p, float second_ord_lim, float dt)
             correction_rate = error * p;
         }
     }
-    if (is_positive(dt)) {
+    // Minimum time step threshold for numerical stability
+    // Prevents division by near-zero dt values that could cause overflow
+    const float MIN_DT = 1.0e-4f;  // 0.1 ms minimum
+    if (dt > MIN_DT) {
         // Clamp to ensure we do not overshoot the error in the last time step
         return constrain_float(correction_rate, -fabsf(error) / dt, fabsf(error) / dt);
     } else {

--- a/libraries/SITL/SIM_XPlane.cpp
+++ b/libraries/SITL/SIM_XPlane.cpp
@@ -649,7 +649,7 @@ void XPlane::send_dref(const char *name, float value)
         char name[500];
     } d {};
     d.value = value;
-    strcpy(d.name, name);
+    strlcpy(d.name, name, sizeof(d.name));
     socket_out.send(&d, sizeof(d));
     if (dref_debug > 0) {
         ::printf("-> %s : %.3f\n", name, value);
@@ -669,7 +669,7 @@ void XPlane::request_dref(const char *name, uint8_t code, uint32_t rate)
     } d {};
     d.rate_hz = rate;
     d.code = code; // given back in responses
-    strcpy(d.name, name);
+    strlcpy(d.name, name, sizeof(d.name));
     socket_in.sendto(&d, sizeof(d), xplane_ip, xplane_port);
 }
 


### PR DESCRIPTION
This change adds a minimum dt threshold in sqrt_controller() to prevent
numerical instability when dt is positive but extremely small.

The existing is_positive(dt) check allows near-zero dt values, which can
produce excessively large clamp bounds due to division by dt.

This is a small, self-contained safety fix with no API or behavior changes
for normal dt values.
