### PR TITLE
Fix buffer overflow in ESP32 WiFi drivers and XPlane SITL connector

### DIFF
--- a/libraries/AP_HAL_ESP32/WiFiDriver.cpp
+++ b/libraries/AP_HAL_ESP32/WiFiDriver.cpp
@@ -279,8 +279,8 @@ void WiFiDriver::initialize_wifi()
     ESP_ERROR_CHECK(esp_wifi_init(&cfg));
 
 
-    strcpy((char *)wifi_config.ap.ssid, WIFI_SSID);
-    strcpy((char *)wifi_config.ap.password, WIFI_PWD);
+    strlcpy((char *)wifi_config.ap.ssid, WIFI_SSID, sizeof(wifi_config.ap.ssid));
+    strlcpy((char *)wifi_config.ap.password, WIFI_PWD, sizeof(wifi_config.ap.password));
     wifi_config.ap.ssid_len = strlen(WIFI_SSID),
     wifi_config.ap.max_connection = WIFI_MAX_CONNECTION,
     wifi_config.ap.authmode = WIFI_AUTH_WPA2_PSK;
@@ -327,8 +327,9 @@ void WiFiDriver::initialize_wifi()
                                                         NULL,
                                                         &instance_got_ip));
 
-    strcpy((char *)wifi_config.sta.ssid, WIFI_SSID_STATION);
-    strcpy((char *)wifi_config.sta.password, WIFI_PWD);
+    // Defensive copy: prevents buffer overflow if SSID/password exceeds buffer size
+    strlcpy((char *)wifi_config.sta.ssid, WIFI_SSID_STATION, sizeof(wifi_config.sta.ssid));
+    strlcpy((char *)wifi_config.sta.password, WIFI_PWD, sizeof(wifi_config.sta.password));
     wifi_config.sta.threshold.authmode = WIFI_AUTH_OPEN;
     wifi_config.sta.sae_pwe_h2e = WPA3_SAE_PWE_BOTH;
 

--- a/libraries/AP_HAL_ESP32/WiFiUdpDriver.cpp
+++ b/libraries/AP_HAL_ESP32/WiFiUdpDriver.cpp
@@ -247,9 +247,9 @@ void WiFiUdpDriver::initialize_wifi()
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
     ESP_ERROR_CHECK(esp_wifi_init(&cfg));
 
-
-    strcpy((char *)wifi_config.ap.ssid, WIFI_SSID);
-    strcpy((char *)wifi_config.ap.password, WIFI_PWD);
+    // Defensive copy to prevent buffer overflow if SSID/password exceeds buffer size
+    strlcpy((char *)wifi_config.ap.ssid, WIFI_SSID, sizeof(wifi_config.ap.ssid));
+    strlcpy((char *)wifi_config.ap.password, WIFI_PWD, sizeof(wifi_config.ap.password));
     wifi_config.ap.ssid_len = strlen(WIFI_SSID),
     wifi_config.ap.max_connection = WIFI_MAX_CONNECTION,
     wifi_config.ap.authmode = WIFI_AUTH_WPA2_PSK;
@@ -295,9 +295,10 @@ void WiFiUdpDriver::initialize_wifi()
                                                         &_sta_event_handler,
                                                         NULL,
                                                         &instance_got_ip));
-
-    strcpy((char *)wifi_config.sta.ssid, WIFI_SSID_STATION);
-    strcpy((char *)wifi_config.sta.password, WIFI_PWD);
+    
+    // Defensive copy: prevents buffer overflow if SSID/password exceeds buffer size
+    strlcpy((char *)wifi_config.sta.ssid, WIFI_SSID_STATION, sizeof(wifi_config.sta.ssid));
+    strlcpy((char *)wifi_config.sta.password, WIFI_PWD, sizeof(wifi_config.sta.password));
     wifi_config.sta.threshold.authmode = WIFI_AUTH_OPEN;
     wifi_config.sta.sae_pwe_h2e = WPA3_SAE_PWE_BOTH;
 

--- a/libraries/SITL/SIM_XPlane.cpp
+++ b/libraries/SITL/SIM_XPlane.cpp
@@ -649,7 +649,7 @@ void XPlane::send_dref(const char *name, float value)
         char name[500];
     } d {};
     d.value = value;
-    strcpy(d.name, name);
+    strlcpy(d.name, name, sizeof(d.name));
     socket_out.send(&d, sizeof(d));
     if (dref_debug > 0) {
         ::printf("-> %s : %.3f\n", name, value);
@@ -669,7 +669,7 @@ void XPlane::request_dref(const char *name, uint8_t code, uint32_t rate)
     } d {};
     d.rate_hz = rate;
     d.code = code; // given back in responses
-    strcpy(d.name, name);
+    strlcpy(d.name, name, sizeof(d.name));
     socket_in.sendto(&d, sizeof(d), xplane_ip, xplane_port);
 }
 


### PR DESCRIPTION
This PR fixes buffer overflow vulnerabilities caused by unsafe strcpy usage in ArduPilot.

Changes:

Replaced strcpy with bounded copies (strlcpy) in ESP32 WiFi drivers (WiFiDriver.cpp, WiFiUdpDriver.cpp)
Replaced strcpy with bounded copies in XPlane SITL connector (SIM_XPlane.cpp)
Ensured proper null-termination to avoid memory corruption
Verification:

Reproduced overflow using AddressSanitizer in a minimal test case
Verified safe truncation after applying strlcpy (no ASan errors)


Fixes #31794