### PR TITLE
AC_PosControl: correct @Increment for NE_VEL_IMAX and JERK params

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -122,7 +122,7 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // @Description: Jerk limit of the horizontal kinematic path generation used to determine how quickly the aircraft varies the acceleration target
     // @Units: m/s/s/s
     // @Range: 1 50
-    // @Increment: 1
+    // @Increment: 0.1
     // @User: Advanced
     AP_GROUPINFO("_JERK_NE", 10, AC_PosControl, _shaping_jerk_ne_msss, POSCONTROL_JERK_NE_MSSS),
 
@@ -131,7 +131,7 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // @Description: Jerk limit of the vertical kinematic path generation used to determine how quickly the aircraft varies the acceleration target
     // @Units: m/s/s/s
     // @Range: 1 50
-    // @Increment: 1
+    // @Increment: 0.1
     // @User: Advanced
     AP_GROUPINFO("_JERK_D", 11, AC_PosControl, _shaping_jerk_d_msss, POSCONTROL_JERK_D_MSSS),
 


### PR DESCRIPTION
This PR addresses issue #31728 regarding parameter metadata display precision.

The parameter `PSC_NE_VEL_IMAX` (Horizontal Velocity Integrator Max) currently has an `@Increment` of `1`. This granularity is too coarse for precise tuning, as it forces users to jump between integer values (e.g., 2.0 to 3.0 m/s/s), representing a massive step in control authority.

**Changes:**
* Changed `@Increment` from `1` to `0.1` for `PSC_NE_VEL_IMAX`.
* Changed `@Increment` from `1` to `0.1` for `PSC_JERK_NE` and `PSC_JERK_D`.

**Reasoning:**
* **Consistency:** The vertical velocity limit `PSC_D_VEL_IMAX` already uses 0.1 precision. Horizontal should match.
* **Jerk Tuning:** An increment of `1` for Jerk (m/s/s/s) is too coarse. A jump from 1 to 2 is a 100% increase in harshness. Users need decimal precision (e.g., 1.5) to tune smooth starts/stops.

**Verification:**
* Verified via code inspection that the metadata tag now aligns with the vertical controller's precision.