### PR TITLE
AC_PID: add units to I and D terms, fix typo

### DIFF
--- a/libraries/AC_PID/AC_HELI_PID.cpp
+++ b/libraries/AC_PID/AC_HELI_PID.cpp
@@ -13,11 +13,13 @@ const AP_Param::GroupInfo AC_HELI_PID::var_info[] = {
     // @Param: I
     // @DisplayName: PID Integral Gain
     // @Description: I Gain which produces an output that is proportional to both the magnitude and the duration of the error
+    // @Units: 1/s
     AP_GROUPINFO("I",    1, AC_HELI_PID, _ki, 0),
 
     // @Param: D
     // @DisplayName: PID Derivative Gain
     // @Description: D Gain which produces an output that is proportional to the rate of change of the error
+    // @Units: s
     AP_GROUPINFO("D",    2, AC_HELI_PID, _kd, 0),
 
     // 3 was for uint16 IMAX

--- a/libraries/AC_PID/AC_PID.cpp
+++ b/libraries/AC_PID/AC_PID.cpp
@@ -15,11 +15,13 @@ const AP_Param::GroupInfo AC_PID::var_info[] = {
     // @Param: I
     // @DisplayName: PID Integral Gain
     // @Description: I Gain which produces an output that is proportional to both the magnitude and the duration of the error
+    // @Units: 1/s
     AP_GROUPINFO_FLAGS_DEFAULT_POINTER("I", 1, AC_PID, _ki, default_ki),
 
     // @Param: D
     // @DisplayName: PID Derivative Gain
     // @Description: D Gain which produces an output that is proportional to the rate of change of the error
+    // @Units: s
     AP_GROUPINFO_FLAGS_DEFAULT_POINTER("D", 2, AC_PID, _kd, default_kd),
 
     // 3 was for uint16 IMAX

--- a/libraries/AC_PID/AC_PID_2D.cpp
+++ b/libraries/AC_PID/AC_PID_2D.cpp
@@ -15,6 +15,7 @@ const AP_Param::GroupInfo AC_PID_2D::var_info[] = {
     // @Param: I
     // @DisplayName: PID Integral Gain
     // @Description: I Gain which produces an output that is proportional to both the magnitude and the duration of the error
+    // @Units: 1/s
     AP_GROUPINFO_FLAGS_DEFAULT_POINTER("I",    1, AC_PID_2D, _ki, default_ki),
 
     // @Param: IMAX
@@ -31,12 +32,13 @@ const AP_Param::GroupInfo AC_PID_2D::var_info[] = {
     // @Param: D
     // @DisplayName: PID Derivative Gain
     // @Description: D Gain which produces an output that is proportional to the rate of change of the error
+    // @Units: s
     AP_GROUPINFO_FLAGS_DEFAULT_POINTER("D",    4, AC_PID_2D, _kd, default_kd),
 
     // @Param: FLTD
     // @DisplayName: D term filter frequency in Hz
     // @Description: Low-pass filter frequency applied to the derivative (Hz)
-    // @Units: Hzs
+    // @Units: Hz
     AP_GROUPINFO_FLAGS_DEFAULT_POINTER("FLTD", 5, AC_PID_2D, _filt_D_hz, default_filt_D_hz),
 
     // @Param: FF

--- a/libraries/AC_PID/AC_PID_Basic.cpp
+++ b/libraries/AC_PID/AC_PID_Basic.cpp
@@ -17,6 +17,7 @@ const AP_Param::GroupInfo AC_PID_Basic::var_info[] = {
     // @Param: I
     // @DisplayName: PID Integral Gain
     // @Description: I Gain which produces an output that is proportional to both the magnitude and the duration of the error
+    // @Units: 1/s
     AP_GROUPINFO_FLAGS_DEFAULT_POINTER("I",    1, AC_PID_Basic, _ki, default_ki),
 
     // @Param: IMAX
@@ -33,6 +34,7 @@ const AP_Param::GroupInfo AC_PID_Basic::var_info[] = {
     // @Param: D
     // @DisplayName: PID Derivative Gain
     // @Description: D Gain which produces an output that is proportional to the rate of change of the error
+    // @Units: s
     AP_GROUPINFO_FLAGS_DEFAULT_POINTER("D",    4, AC_PID_Basic, _kd, default_kd),
 
     // @Param: FLTD


### PR DESCRIPTION
This PR adds `@Units` annotations to the Integral (I) and Derivative (D) terms across the `AC_PID` libraries and fixes a minor typo.

**Changes:**
* Added `@Units: 1/s` to `_ki` (I term).
* Added `@Units: s` to `_kd` (D term).
* Fixed a typo in `AC_PID_2D.cpp` (`Hzs` -> `Hz`).
* Applied to `AC_PID`, `AC_PID_Basic`, `AC_PID_2D`, and `AC_HELI_PID`.

**Reasoning:**
While the physical units of the P term change depending on the controller instance (e.g., Rate vs Position), the I and D terms are mathematically consistent relative to the P term:
* **I term:** Always acts over time, effectively `1/s`.
* **D term:** Always acts on the rate of change, effectively `s`.

P and FF terms remain unitless in this PR as they are strictly context-dependent.

Ref: #31729