### PR TITLE
AP_Mount:add roll/pitch body frame lock to select gimbals

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -39,6 +39,10 @@ protected:
     };
 
 private:
+    // allow removing lean angles for pitch and roll locks
+    bool apply_bf_roll_pitch_adjustments_in_rc_targeting() const override {
+        return true;
+    }
 
     // get_angles -
     void get_angles();

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -302,11 +302,26 @@ protected:
 
     // called when mount mode is RC-targetting, updates the mnt_target object from RC inputs:
     void update_mnt_target_from_rc_target();
+    
+    //called to remove lean angle in roll/pitch mount angle to convert to bodyframe
+    void adjust_mnt_target_if_RP_locked();
+    
+    // if this function returns true, then when roll and pitch have
+    // been locked to body frame (e.g. the user is using a switch or mount option to
+    // lock them to body frame) we add in the vehicle's roll and
+    // pitch to the target angles to position the gimbal in body
+    // frame.  This is used on mounts which do not have the option to
+    // move in body frame themselves (e.g. SToRM32 in its normal
+    // configuration) and can be overriden in their heading files
+    virtual bool apply_bf_roll_pitch_adjustments_in_rc_targeting() const {
+        return false;
+    }
 
     // method for the mount backends to call to update mnt_target based on
     // the mount mode.  Methods in here may be overridden by the derived
     // class to customise behaviour
     void update_mnt_target();
+    void _update_mnt_target();
 
     // returns true if user has configured a valid roll angle range
     // allows user to disable roll even on 3-axis gimbal

--- a/libraries/AP_Mount/AP_Mount_SToRM32.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.h
@@ -39,6 +39,11 @@ private:
     uint8_t natively_supported_mount_target_types() const override {
         return NATIVE_ANGLES_ONLY;
     };
+    
+    // allow removing lean angles for pitch and roll locks
+    bool apply_bf_roll_pitch_adjustments_in_rc_targeting() const override {
+        return true;
+    }
 
     // send_do_mount_control with latest angle targets
     void send_target_angles(const MountAngleTarget& angle_target_rad) override;

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
@@ -41,6 +41,11 @@ private:
     uint8_t natively_supported_mount_target_types() const override {
         return NATIVE_ANGLES_ONLY;
     };
+    
+    // allow removing lean angles for pitch and roll locks
+    bool apply_bf_roll_pitch_adjustments_in_rc_targeting() const override {
+        return true;
+    }
 
     // send_target_angles
     void send_target_angles(const MountAngleTarget& angle_target_rad) override;

--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -112,9 +112,10 @@ void AP_Mount_Servo::update_angle_outputs(const MountAngleTarget& angle_rad)
         break;
     }
 
-    // this is sufficient for self-stabilising brushless gimbals
+    // only have to adjust roll/pitch for body frame in self-stabilising brushless gimbals
     if (!requires_stabilization) {
-    //todo: subtract ahrs leans for body frame roll/pitch if roll/pich lock not true to get locks in stablized servo input gimbals like Storm32
+        //since this is a shared backend, must call this directly
+        AP_Mount_Backend::adjust_mnt_target_if_RP_locked();
         return;
     }
 


### PR DESCRIPTION
This allows the RP aux switches and FPV_LOCK option to work in RC Targeting modes on gimbals without a command that we could add to the backend to do this.... high-end gimbals like XACTI and VIEWPRO have not been investigated yet but may need this added in the future.... 

The SERVO backend required a direct call since this is a shared backend, unfortunately, unless there is a way in the constructor to do it using the requires stabilization input to it...or some other header trick I don't know

MAVLINK backend would require using the capabilities flags to determine if roll or pitch or both bf locks could be implemented directly in the MAVLink command structure it sends...a future project I intend to tackle next

The math of the base method to remove the lean angles has been bench tested and verified by PeterB on STorM32 and by me on servo stabilized, but testing on AlexMOS and STorm32 (MAVLINK mode, which does not support queries) gimbals is welcomed