### PR TITLE
AP_AHRS: factor out a _get_quaternion_for_ekf_type

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -931,6 +931,10 @@ private:
     // return the quaternion defining the rotation from NED to XYZ (body) axes
     bool _get_quaternion(Quaternion &quat) const WARN_IF_UNUSED;
 
+    // return the quaternion defining the rotation from NED to XYZ
+    // (body) axes for the passed-in type
+    bool _get_quaternion_for_ekf_type(Quaternion &quat, EKFType type) const;
+
     // return secondary position solution if available
     bool _get_secondary_position(Location &loc) const;
 


### PR DESCRIPTION
This is the difference between the two bodies which are being factored:
```
--- /tmp/primary	2026-01-01 11:44:16.251345538 +1100
+++ /tmp/secondary	2026-01-01 11:44:03.630086026 +1100
@@ -1,40 +1,49 @@
 {
-    // backends always return in autopilot XYZ frame; rotate result
-    // according to trim
-    switch (active_EKF_type()) {
+    EKFType secondary_ekf_type;
+    if (!_get_secondary_EKF_type(secondary_ekf_type)) {
+        return false;
+    }
+
+    switch (secondary_ekf_type) {
+
 #if AP_AHRS_DCM_ENABLED
     case EKFType::DCM:
+        // DCM is secondary
         if (!dcm.get_quaternion(quat)) {
             return false;
         }
         break;
 #endif
+
 #if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
+        // EKF2 is secondary
         if (!_ekf2_started) {
             return false;
         }
         EKF2.getQuaternion(quat);
         break;
 #endif
+
 #if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
+        // EKF3 is secondary
         if (!_ekf3_started) {
             return false;
         }
         EKF3.getQuaternion(quat);
         break;
 #endif
+
 #if AP_AHRS_SIM_ENABLED
     case EKFType::SIM:
-        if (!sim.get_quaternion(quat)) {
-            return false;
-        }
-        break;
+        // SITL is secondary (should never happen)
+        return false;
 #endif
+
 #if AP_AHRS_EXTERNAL_ENABLED
     case EKFType::EXTERNAL:
-        // we assume the external AHRS isn't trimmed with the autopilot!
+        // External is secondary
         return external.get_quaternion(quat);
 #endif
     }
```

It's clear that the only substantial difference here is the SITL case which is marked as "can't happen".  In the case it does happen then we will just return the SITL results, which is really what we should be doing anyway.

This method is only used for logging/telemetry.
