### PR TITLE
AP_Baro: correct duplication check for i2c baro devices

### DIFF
--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -504,7 +504,7 @@ bool AP_Baro::_add_backend(AP_Baro_Backend *backend)
  */
 bool AP_Baro::_i2c_sensor_is_registered(uint8_t bus, uint8_t address) const
 {
-    for (int i=0; i<_num_drivers; ++i) {
+    for (int i=0; i<_num_sensors; ++i) {
         if (AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_I2C, bus, address, 0) ==
             AP_HAL::Device::change_bus_id(uint32_t(sensors[i].bus_id.get()), 0)) {
             // device already has been defined.


### PR DESCRIPTION
we're indexing into the sensors array, so we should only iterate up to the number of sensors we have

could be a problem if there are DroneCAN backends involved as that can cause a mismatch between _num_sensors and _num_drivers