### PR TITLE
AP_Scripting: fix 'received' typo in RockBlock applet

### DIFF
--- a/libraries/AP_Scripting/applets/RockBlock.lua
+++ b/libraries/AP_Scripting/applets/RockBlock.lua
@@ -448,7 +448,7 @@ local function RockblockModem()
     
     local _modem_history = {}
     local _modem_to_send = {}
-    local _str_recieved = ""
+    local _str_received = ""
     
     -- Get any incoming data
     function self.rxdata(inchar)
@@ -457,30 +457,30 @@ local function RockblockModem()
         if _modem_history[#_modem_history] == 'AT+SBDRB' and self.in_read_cycle == false and self.rx_len > 0 then
             -- read buffer may include /r and /n, so need a special cycle to capture all up to the self.rx_len
             self.in_read_cycle = true
-            _str_recieved = _str_recieved .. read
-        elseif self.in_read_cycle and #_str_recieved == self.rx_len + 3 then
+            _str_received = _str_received .. read
+        elseif self.in_read_cycle and #_str_received == self.rx_len + 3 then
             -- get last byte in read cycle
-            _str_recieved = _str_recieved .. read
+            _str_received = _str_received .. read
             self.in_read_cycle = false
             self.rx_len = 0
-            table.insert(_modem_history, _str_recieved)
-            _str_recieved = ""
+            table.insert(_modem_history, _str_received)
+            _str_received = ""
             if RCK_DEBUG:get() == 1 then
                 gcs:send_text(3, "Rockblock: Modem rx msg: " ..
                                   self.nicestring(_modem_history[#_modem_history]))
             end
         elseif (read == '\r' or read == '\n') and not self.in_read_cycle then
-            if #_str_recieved > 0 then
-                table.insert(_modem_history, _str_recieved)
+            if #_str_received > 0 then
+                table.insert(_modem_history, _str_received)
                 if RCK_DEBUG:get() == 1 then
                     gcs:send_text(3, "Rockblock: Modem response: " ..
                                       self.nicestring(_modem_history[#_modem_history]))
                 end
                 maybepkt = self.check_cmd_return()
             end
-            _str_recieved = ""
+            _str_received = ""
         else
-            _str_recieved = _str_recieved .. read
+            _str_received = _str_received .. read
         end
         return maybepkt
     end

--- a/libraries/AP_Scripting/applets/RockBlock.md
+++ b/libraries/AP_Scripting/applets/RockBlock.md
@@ -47,4 +47,4 @@ Enables the modem transmission
 
 If RCK_FORCEHL=2, this is the number of seconds of no-messages from the GCS until High Latency mode is auto-enabled
 
-When GCS messages are recieved again, High Latency mode is auto-disabled.
+When GCS messages are received again, High Latency mode is auto-disabled.


### PR DESCRIPTION
Fixes a typo in a variable name and documentation in the RockBlock applet.