### PR TITLE
Tools: enhance Copter autotest routine "test_mount_pitch"

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -6210,6 +6210,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         return min(max(pitch_angle_deg, PITCH_MIN), PITCH_MAX)
 
     def test_mount_pitch(self, despitch, despitch_tolerance, mount_mode, timeout=10, hold=0, constrained=True):
+        self.set_mount_mode(mount_mode)
         tstart = self.get_sim_time()
         success_start = 0
 


### PR DESCRIPTION
enhance this routine to actually produce expected results of changing mount mode using the required argument (does nothing now)....tests currently works because the mode is actually changed before this call in sequences that use it, but this makes the call actually effect the change to enhance its use in the future...duplicating the mode change in current uses does nothing

tested by running the MOUNT tests after this change