### PR TITLE
AP_Mount: add and use MountTargetType::LOCATION

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -764,12 +764,13 @@ bool AP_Mount_Backend::get_angle_target_to_location(const Location &loc, MountAn
 
 // get angle targets (in radians) to ROI location
 // returns true on success, false on failure
-bool AP_Mount_Backend::get_angle_target_to_roi(MountAngleTarget& angle_rad) const
+bool AP_Mount_Backend::get_location_target_for_roi(MountLocationTarget& location) const
 {
     if (!_roi_target.initialised()) {
         return false;
     }
-    return get_angle_target_to_location(_roi_target, angle_rad);
+    location.loc = _roi_target;
+    return true;
 }
 
 // return body-frame yaw angle from a mount target
@@ -854,6 +855,9 @@ uint16_t AP_Mount_Backend::get_gimbal_device_flags() const
         case MountTargetType::ANGLE:
             yaw_lock_state = mnt_target.angle_rad.yaw_is_ef;
             break;
+        case MountTargetType::LOCATION:
+            yaw_lock_state = true;   // locked onto the scenery
+            break;
         case MountTargetType::RETRACTED:
         case MountTargetType::NEUTRAL:
             yaw_lock_state = false;  // not locked onto the scenery
@@ -886,18 +890,19 @@ uint16_t AP_Mount_Backend::get_gimbal_device_flags() const
 
 // get angle targets (in radians) to home location
 // returns true on success, false on failure
-bool AP_Mount_Backend::get_angle_target_to_home(MountAngleTarget& angle_rad) const
+bool AP_Mount_Backend::get_location_target_for_home(MountLocationTarget& location) const
 {
     // exit immediately if home is not set
     if (!AP::ahrs().home_is_set()) {
         return false;
     }
-    return get_angle_target_to_location(AP::ahrs().get_home(), angle_rad);
+    location.loc = AP::ahrs().get_home();
+    return true;
 }
 
 // get angle targets (in radians) to a vehicle with sysid of  _target_sysid
 // returns true on success, false on failure
-bool AP_Mount_Backend::get_angle_target_to_sysid(MountAngleTarget& angle_rad) const
+bool AP_Mount_Backend::get_location_target_for_sysid(MountLocationTarget& location) const
 {
     // exit immediately if sysid is not set or no location available
     if (!_target_sysid_location.initialised()) {
@@ -906,7 +911,8 @@ bool AP_Mount_Backend::get_angle_target_to_sysid(MountAngleTarget& angle_rad) co
     if (!_target_sysid) {
         return false;
     }
-    return get_angle_target_to_location(_target_sysid_location, angle_rad);
+    location.loc = _target_sysid_location;
+    return true;
 }
 
 
@@ -950,22 +956,22 @@ void AP_Mount_Backend::update_mnt_target()
 
     case MAV_MOUNT_MODE_GPS_POINT:
         // point mount to a GPS point given by the mission planner
-        if (get_angle_target_to_roi(mnt_target.angle_rad)) {
-            mnt_target.target_type = MountTargetType::ANGLE;
+        if (get_location_target_for_roi(mnt_target.location)) {
+            mnt_target.target_type = MountTargetType::LOCATION;
         }
         return;
 
     case MAV_MOUNT_MODE_HOME_LOCATION:
         // point mount to Home location
-        if (get_angle_target_to_home(mnt_target.angle_rad)) {
-            mnt_target.target_type = MountTargetType::ANGLE;
+        if (get_location_target_for_home(mnt_target.location)) {
+            mnt_target.target_type = MountTargetType::LOCATION;
         }
         return;
 
     case MAV_MOUNT_MODE_SYSID_TARGET:
         // point mount to another vehicle
-        if (get_angle_target_to_sysid(mnt_target.angle_rad)) {
-            mnt_target.target_type = MountTargetType::ANGLE;
+        if (get_location_target_for_sysid(mnt_target.location)) {
+            mnt_target.target_type = MountTargetType::LOCATION;
         }
         return;
     case MAV_MOUNT_MODE_ENUM_END:
@@ -991,6 +997,9 @@ void AP_Mount_Backend::send_target_to_gimbal()
             return;
         case MountTargetType::NEUTRAL:
             send_target_neutral();
+            return;
+        case MountTargetType::LOCATION:
+            send_target_location(mnt_target.location);
             return;
         }
         return;  // should not reach this as all cases return
@@ -1028,6 +1037,16 @@ void AP_Mount_Backend::send_target_to_gimbal()
             // we update mnt_target for reporting purposes
             const Vector3f &angle_bf_target = _params.neutral_angles.get();
             mnt_target.angle_rad.set(angle_bf_target*DEG_TO_RAD, false);
+            send_target_angles(mnt_target.angle_rad);
+            return;
+        }
+        break;
+    case MountTargetType::LOCATION:
+        if (natively_supports(MountTargetType::ANGLE)) {
+            // we update mnt_target for reporting purposes
+            if (!get_angle_target_to_location(mnt_target.location.loc, mnt_target.angle_rad)) {
+                return;
+            }
             send_target_angles(mnt_target.angle_rad);
             return;
         }

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -33,6 +33,8 @@
 
 class AP_Mount_Backend
 {
+    friend class AP_Mount_SoloGimbal;  // temporary access to e.g. _roi_target
+
 public:
     // Constructor
     AP_Mount_Backend(class AP_Mount &frontend, class AP_Mount_Params &params, uint8_t instance) :
@@ -232,6 +234,7 @@ protected:
         RATE      = 1,
         RETRACTED = 2,
         NEUTRAL   = 3,
+        LOCATION  = 4,
     };
 
     // class for a single angle or rate target
@@ -259,6 +262,10 @@ protected:
         float pitch;     // roll rate in radians/second
         float yaw;       // roll rate in radians/second
         bool yaw_is_ef;  // if set then `yaw` is a rate in earth frame
+    };
+    class MountLocationTarget {
+    public:
+        Location loc;
     };
 
     // returns a bitmask of MountTargetTypes which this backend supports
@@ -295,6 +302,7 @@ protected:
     virtual void send_target_rates(const MountRateTarget &rate_rads) { }
     virtual void send_target_retracted() { }
     virtual void send_target_neutral() { }
+    virtual void send_target_location(const MountLocationTarget &location) { }
 
     // options parameter bitmask handling
     enum class Options : uint8_t {
@@ -333,15 +341,15 @@ protected:
 
     // get angle targets (in radians) to ROI location
     // returns true on success, false on failure
-    bool get_angle_target_to_roi(MountAngleTarget& angle_rad) const WARN_IF_UNUSED;
+    bool get_location_target_for_roi(MountLocationTarget& location) const WARN_IF_UNUSED;
 
     // get angle targets (in radians) to home location
     // returns true on success, false on failure
-    bool get_angle_target_to_home(MountAngleTarget& angle_rad) const WARN_IF_UNUSED;
+    bool get_location_target_for_home(MountLocationTarget& location) const WARN_IF_UNUSED;
 
     // get angle targets (in radians) to a vehicle with sysid of _target_sysid
     // returns true on success, false on failure
-    bool get_angle_target_to_sysid(MountAngleTarget& angle_rad) const WARN_IF_UNUSED;
+    bool get_location_target_for_sysid(MountLocationTarget& location) const WARN_IF_UNUSED;
 
     // update angle targets using a given rate target
     // the resulting angle_rad yaw frame will match the rate_rad yaw frame
@@ -366,6 +374,7 @@ protected:
         MountAngleTarget angle_rad; // angle target in radians
         MountRateTarget rate_rads;  // rate target in rad/s
         uint32_t last_rate_request_ms;
+        MountLocationTarget location;  // location in lat/lng/absalt
     } mnt_target;
     
     // RP earth frame locks accessible by backend

--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -108,6 +108,7 @@ void AP_Mount_Servo::update_angle_outputs(const MountAngleTarget& angle_rad)
     case MountTargetType::NEUTRAL:
     case MountTargetType::RETRACTED:
         return;
+    case MountTargetType::LOCATION:
     case MountTargetType::ANGLE:
     case MountTargetType::RATE:
         break;

--- a/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
+++ b/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
@@ -8,6 +8,7 @@
 #include <AP_Logger/AP_Logger.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <GCS_MAVLink/GCS.h>
+#include <AP_AHRS/AP_AHRS.h>
 
 AP_Mount_SoloGimbal::AP_Mount_SoloGimbal(AP_Mount &frontend, AP_Mount_Params &params, uint8_t instance) :
     AP_Mount_Backend(frontend, params, instance),
@@ -24,6 +25,41 @@ void AP_Mount_SoloGimbal::init()
 void AP_Mount_SoloGimbal::update_fast()
 {
     _gimbal.update_fast();
+}
+
+// get angle targets (in radians) to ROI location
+// returns true on success, false on failure
+bool AP_Mount_SoloGimbal::get_angle_target_to_roi(MountAngleTarget& angle_rad) const
+{
+    if (!_roi_target.initialised()) {
+        return false;
+    }
+    return get_angle_target_to_location(_roi_target, angle_rad);
+}
+
+// get angle targets (in radians) to home location
+// returns true on success, false on failure
+bool AP_Mount_SoloGimbal::get_angle_target_to_home(MountAngleTarget& angle_rad) const
+{
+    // exit immediately if home is not set
+    if (!AP::ahrs().home_is_set()) {
+        return false;
+    }
+    return get_angle_target_to_location(AP::ahrs().get_home(), angle_rad);
+}
+
+// get angle targets (in radians) to a vehicle with sysid of  _target_sysid
+// returns true on success, false on failure
+bool AP_Mount_SoloGimbal::get_angle_target_to_sysid(MountAngleTarget& angle_rad) const
+{
+    // exit immediately if sysid is not set or no location available
+    if (!_target_sysid_location.initialised()) {
+        return false;
+    }
+    if (!_target_sysid) {
+        return false;
+    }
+    return get_angle_target_to_location(_target_sysid_location, angle_rad);
 }
 
 // update mount position - should be called periodically

--- a/libraries/AP_Mount/AP_Mount_SoloGimbal.h
+++ b/libraries/AP_Mount/AP_Mount_SoloGimbal.h
@@ -53,6 +53,18 @@ private:
 
     bool _params_saved;
     SoloGimbal _gimbal;
+
+    // get angle targets (in radians) to ROI location
+    // returns true on success, false on failure
+    bool get_angle_target_to_roi(MountAngleTarget& angle_rad) const WARN_IF_UNUSED;
+
+    // get angle targets (in radians) to home location
+    // returns true on success, false on failure
+    bool get_angle_target_to_home(MountAngleTarget& angle_rad) const WARN_IF_UNUSED;
+
+    // get angle targets (in radians) to a vehicle with sysid of _target_sysid
+    // returns true on success, false on failure
+    bool get_angle_target_to_sysid(MountAngleTarget& angle_rad) const WARN_IF_UNUSED;
 };
 
 #endif // HAL_SOLO_GIMBAL_ENABLED


### PR DESCRIPTION
defers the calculation of the angles until we know we need them

allows for backends to override send_target_location if they know how to send a lat/lng/alt directly to the mount