### PR TITLE
AP_Mount: have SoloGimbal use update_mnt_target / send_target_to_gimbal

### DIFF
--- a/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
+++ b/libraries/AP_Mount/AP_Mount_SoloGimbal.cpp
@@ -36,71 +36,26 @@ void AP_Mount_SoloGimbal::update()
         return;
     }
 
-    // change to RC_TARGETING mode if RC input has changed
-    set_rctargeting_on_rcinput_change();
+    update_mnt_target();
 
-    // update based on mount mode
-    switch(get_mode()) {
-        // move mount to a "retracted" position.  we do not implement a separate servo based retract mechanism
-        case MAV_MOUNT_MODE_RETRACT:
-            _gimbal.set_lockedToBody(true);
-            mnt_target.target_type = MountTargetType::ANGLE;
-            mnt_target.angle_rad.set(Vector3f{0,0,0}, false);
-            break;
+    send_target_to_gimbal();
+}
 
-        // move mount to a neutral position, typically pointing forward
-        case MAV_MOUNT_MODE_NEUTRAL: {
-            _gimbal.set_lockedToBody(false);
-            const Vector3f &target = _params.neutral_angles.get();
-            mnt_target.target_type = MountTargetType::ANGLE;
-            mnt_target.angle_rad.set(target*DEG_TO_RAD, false);
-            break;
-        }
+// send angle target in radians to gimbal
+void AP_Mount_SoloGimbal::send_target_angles(const MountAngleTarget& angle_rad)
+{
+    // angles are *actually* inserted into the gimbal in
+    // handle_gimbal_report, not here!
 
-        // point to the angles given by a mavlink message
-        case MAV_MOUNT_MODE_MAVLINK_TARGETING:
-            // targets are stored while handling the incoming mavlink message
-            _gimbal.set_lockedToBody(false);
-            break;
+    // since angles are now valid, we can unlock from the body:
+    _gimbal.set_lockedToBody(false);
+ }
 
-        // RC radio manual angle control, but with stabilization from the AHRS
-        case MAV_MOUNT_MODE_RC_TARGETING:
-            _gimbal.set_lockedToBody(false);
-            update_mnt_target_from_rc_target();
-            break;
+void AP_Mount_SoloGimbal::send_target_retracted()
+{
+    AP_Mount_Backend::send_target_retracted();  // sets the angles for reporting
 
-        // point mount to a GPS point given by the mission planner
-        case MAV_MOUNT_MODE_GPS_POINT:
-            if (get_angle_target_to_roi(mnt_target.angle_rad)) {
-                mnt_target.target_type = MountTargetType::ANGLE;
-                _gimbal.set_lockedToBody(false);
-            }
-            break;
-
-        // point mount to Home location
-        case MAV_MOUNT_MODE_HOME_LOCATION:
-            if (get_angle_target_to_home(mnt_target.angle_rad)) {
-                mnt_target.target_type = MountTargetType::ANGLE;
-                _gimbal.set_lockedToBody(false);
-            }
-            break;
-
-        // point mount to another vehicle
-        case MAV_MOUNT_MODE_SYSID_TARGET:
-            if (get_angle_target_to_sysid(mnt_target.angle_rad)) {
-                mnt_target.target_type = MountTargetType::ANGLE;
-                _gimbal.set_lockedToBody(false);
-            }
-            break;
-
-        default:
-            // we do not know this mode so do nothing
-            break;
-    }
-
-    if (mnt_target.target_type == MountTargetType::RATE) {
-        update_angle_target_from_rate(mnt_target.rate_rads, mnt_target.angle_rad);
-    }
+    _gimbal.set_lockedToBody(true);
 }
 
 // get attitude as a quaternion.  returns true on success

--- a/libraries/AP_Mount/AP_Mount_SoloGimbal.h
+++ b/libraries/AP_Mount/AP_Mount_SoloGimbal.h
@@ -38,6 +38,18 @@ public:
 
 protected:
 
+    // Solo only supports ANGLE targets, but also can lock itself to the body for "retracted"
+    uint8_t natively_supported_mount_target_types() const override {
+        return (
+            (1U << uint8_t(MountTargetType::ANGLE)) |
+            (1U << uint8_t(MountTargetType::RETRACTED))
+            );
+    };
+
+    // send angle target in radians to gimbal
+    void send_target_angles(const MountAngleTarget& angle_rad) override;
+    void send_target_retracted() override;
+
     // returns true if heart beat should be suppressed for this gimbal
     bool suppress_heartbeat() const override { return true; }
 


### PR DESCRIPTION
I don't think anybody on the planet has one of these working on master.

These *are* tested in SITL, however.

I was as careful converting this as I was with the other backends - using `diff` to make sure of the differences between the backends.
