### PR TITLE
AP_TemperatureSensor: Add additional sensor slots

### DIFF
--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor.cpp
@@ -179,6 +179,90 @@ const AP_Param::GroupInfo AP_TemperatureSensor::var_info[] = {
     AP_SUBGROUPVARPTR(drivers[8], "9_", 27, AP_TemperatureSensor, backend_var_info[8]),
 #endif
 
+#if AP_TEMPERATURE_SENSOR_MAX_INSTANCES >= 10
+    // @Group: 10_
+    // @Path: AP_TemperatureSensor_Params.cpp
+    AP_SUBGROUPINFO(_params[9], "10_", 28, AP_TemperatureSensor, AP_TemperatureSensor_Params),
+
+    // @Group: 10_
+    // @Path: AP_TemperatureSensor_Analog.cpp
+    // @Group: 10_
+    // @Path: AP_TemperatureSensor_DroneCAN.cpp
+    // @Group: 10_
+    // @Path: AP_TemperatureSensor_MAX31865.cpp
+    AP_SUBGROUPVARPTR(drivers[9], "10_", 29, AP_TemperatureSensor, backend_var_info[9]),
+#endif
+
+#if AP_TEMPERATURE_SENSOR_MAX_INSTANCES >= 11
+    // @Group: 11_
+    // @Path: AP_TemperatureSensor_Params.cpp
+    AP_SUBGROUPINFO(_params[10], "11_", 30, AP_TemperatureSensor, AP_TemperatureSensor_Params),
+
+    // @Group: 11_
+    // @Path: AP_TemperatureSensor_Analog.cpp
+    // @Group: 11_
+    // @Path: AP_TemperatureSensor_DroneCAN.cpp
+    // @Group: 11_
+    // @Path: AP_TemperatureSensor_MAX31865.cpp
+    AP_SUBGROUPVARPTR(drivers[10], "11_", 31, AP_TemperatureSensor, backend_var_info[10]),
+#endif
+
+#if AP_TEMPERATURE_SENSOR_MAX_INSTANCES >= 12
+    // @Group: 12_
+    // @Path: AP_TemperatureSensor_Params.cpp
+    AP_SUBGROUPINFO(_params[11], "12_", 32, AP_TemperatureSensor, AP_TemperatureSensor_Params),
+
+    // @Group: 12_
+    // @Path: AP_TemperatureSensor_Analog.cpp
+    // @Group: 12_
+    // @Path: AP_TemperatureSensor_DroneCAN.cpp
+    // @Group: 12_
+    // @Path: AP_TemperatureSensor_MAX31865.cpp
+    AP_SUBGROUPVARPTR(drivers[11], "12_", 33, AP_TemperatureSensor, backend_var_info[11]),
+#endif
+
+#if AP_TEMPERATURE_SENSOR_MAX_INSTANCES >= 13
+    // @Group: 13_
+    // @Path: AP_TemperatureSensor_Params.cpp
+    AP_SUBGROUPINFO(_params[12], "13_", 34, AP_TemperatureSensor, AP_TemperatureSensor_Params),
+
+    // @Group: 13_
+    // @Path: AP_TemperatureSensor_Analog.cpp
+    // @Group: 13_
+    // @Path: AP_TemperatureSensor_DroneCAN.cpp
+    // @Group: 13_
+    // @Path: AP_TemperatureSensor_MAX31865.cpp
+    AP_SUBGROUPVARPTR(drivers[12], "13_", 35, AP_TemperatureSensor, backend_var_info[12]),
+#endif
+
+#if AP_TEMPERATURE_SENSOR_MAX_INSTANCES >= 14
+    // @Group: 14_
+    // @Path: AP_TemperatureSensor_Params.cpp
+    AP_SUBGROUPINFO(_params[13], "14_", 36, AP_TemperatureSensor, AP_TemperatureSensor_Params),
+
+    // @Group: 14_
+    // @Path: AP_TemperatureSensor_Analog.cpp
+    // @Group: 14_
+    // @Path: AP_TemperatureSensor_DroneCAN.cpp
+    // @Group: 14_
+    // @Path: AP_TemperatureSensor_MAX31865.cpp
+    AP_SUBGROUPVARPTR(drivers[13], "14_", 37, AP_TemperatureSensor, backend_var_info[13]),
+#endif
+
+#if AP_TEMPERATURE_SENSOR_MAX_INSTANCES >= 15
+    // @Group: 15_
+    // @Path: AP_TemperatureSensor_Params.cpp
+    AP_SUBGROUPINFO(_params[14], "15_", 38, AP_TemperatureSensor, AP_TemperatureSensor_Params),
+
+    // @Group: 15_
+    // @Path: AP_TemperatureSensor_Analog.cpp
+    // @Group: 15_
+    // @Path: AP_TemperatureSensor_DroneCAN.cpp
+    // @Group: 15_
+    // @Path: AP_TemperatureSensor_MAX31865.cpp
+    AP_SUBGROUPVARPTR(drivers[14], "15_", 39, AP_TemperatureSensor, backend_var_info[14]),
+#endif
+
     AP_GROUPEND
 };
 


### PR DESCRIPTION
Add parameters to support up to 15 temperature sensor instances

Built code adding `--define AP_TEMPERATURE_SENSOR_MAX_INSTANCES=15` to the configure stage.

Tested in SITL using `SIM_Temperature_SHT3x` by setting:
- TEMPF_TYPE = 8
- TEMPF_BUS = 1
- TEMPF_ADDR = 68 (0x44)
- TEMPF_SRC = 3
- TEMPF_SRC_ID = 1

Observed that battery_temp in Mission Planner status tab was being updated.