### PR TITLE
AP_Bootloader: add board_types for UAV-DEV GmbH products

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -460,6 +460,9 @@ AP_HW_UAV-DEV-FC-M10S-H7             5231
 AP_HW_UAV-DEV-UM982-H7               5232
 AP_HW_UAV-DEV-PM-G4                  5233
 AP_HW_UAV-DEV-AUAV-G4                5234
+AP_HW_UAV-DEV-ETHERNET-H7            5235
+AP_HW_UAV-DEV-FC-PIZERO-H7           5236
+AP_HW_UAV-DEV-M10S-G4                5237
 
 # IDs 5240-5249 reserved for TM IT-Systemhaus
 AP_HW_TM-SYS-BeastFC                 5240


### PR DESCRIPTION
Add new board types for UAV-DEV GmbH products