### PR TITLE
AP_ExternalAHRS: replace GPS_FIX_TYPE with AP_GPS_FixType

### DIFF
--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_MicroStrain5.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_MicroStrain5.cpp
@@ -234,7 +234,7 @@ bool AP_ExternalAHRS_MicroStrain5::pre_arm_check(char *failure_msg, uint8_t fail
         hal.util->snprintf(failure_msg, failure_msg_len, "MicroStrain5 unhealthy");
         return false;
     }
-    if (gnss_data[gnss_instance].fix_type < 3) {
+    if (gnss_data[gnss_instance].fix_type < AP_GPS_FixType::FIX_3D) {
         hal.util->snprintf(failure_msg, failure_msg_len, "MicroStrain5 no GPS lock");
         return false;
     }
@@ -257,7 +257,7 @@ void AP_ExternalAHRS_MicroStrain5::get_filter_status(nav_filter_status &status) 
         status.flags.vert_vel = true;
         status.flags.vert_pos = true;
 
-        if (gnss_data[gnss_instance].fix_type >= 3) {
+        if (gnss_data[gnss_instance].fix_type >= AP_GPS_FixType::FIX_3D) {
             status.flags.horiz_vel = true;
             status.flags.horiz_pos_rel = true;
             status.flags.horiz_pos_abs = true;

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_MicroStrain7.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_MicroStrain7.cpp
@@ -286,7 +286,7 @@ bool AP_ExternalAHRS_MicroStrain7::pre_arm_check(char *failure_msg, uint8_t fail
         return false;
     }
     static_assert(NUM_GNSS_INSTANCES == 2, "This check only works if there are two GPS types.");
-    if (gnss_data[0].fix_type < GPS_FIX_TYPE_3D_FIX && gnss_data[1].fix_type < GPS_FIX_TYPE_3D_FIX) {
+    if (gnss_data[0].fix_type < AP_GPS_FixType::FIX_3D && gnss_data[1].fix_type < AP_GPS_FixType::FIX_3D) {
         hal.util->snprintf(failure_msg, failure_msg_len, LOG_FMT, get_name(), "missing 3D GPS fix on either GPS");
         return false;
     }

--- a/libraries/AP_ExternalAHRS/MicroStrain_common.cpp
+++ b/libraries/AP_ExternalAHRS/MicroStrain_common.cpp
@@ -17,6 +17,7 @@
 #define AP_MATH_ALLOW_DOUBLE_FUNCTIONS 1
 
 #include "AP_ExternalAHRS_config.h"
+#include <AP_GPS/AP_GPS.h>
 
 #if AP_MICROSTRAIN_ENABLED
 
@@ -216,29 +217,29 @@ void AP_MicroStrain::handle_gnss(const MicroStrain_Packet &packet)
         case GNSSPacketField::FIX_INFO: {
             switch ((GNSSFixType) packet.payload[i+2]) {
             case (GNSSFixType::FIX_RTK_FLOAT): {
-                gnss_data[gnss_instance].fix_type = GPS_FIX_TYPE_RTK_FLOAT;
+                gnss_data[gnss_instance].fix_type = AP_GPS_FixType::RTK_FLOAT;
                 break;
             }
             case (GNSSFixType::FIX_RTK_FIXED): {
-                gnss_data[gnss_instance].fix_type = GPS_FIX_TYPE_RTK_FIXED;
+                gnss_data[gnss_instance].fix_type = AP_GPS_FixType::RTK_FIXED;
                 break;
             }
             case (GNSSFixType::FIX_3D): {
-                gnss_data[gnss_instance].fix_type = GPS_FIX_TYPE_3D_FIX;
+                gnss_data[gnss_instance].fix_type = AP_GPS_FixType::FIX_3D;
                 break;
             }
             case (GNSSFixType::FIX_2D): {
-                gnss_data[gnss_instance].fix_type = GPS_FIX_TYPE_2D_FIX;
+                gnss_data[gnss_instance].fix_type = AP_GPS_FixType::FIX_2D;
                 break;
             }
             case (GNSSFixType::TIME_ONLY):
             case (GNSSFixType::NONE): {
-                gnss_data[gnss_instance].fix_type = GPS_FIX_TYPE_NO_FIX;
+                gnss_data[gnss_instance].fix_type = AP_GPS_FixType::NONE;
                 break;
             }
             default:
             case (GNSSFixType::INVALID): {
-                gnss_data[gnss_instance].fix_type = GPS_FIX_TYPE_NO_GPS;
+                gnss_data[gnss_instance].fix_type = AP_GPS_FixType::NO_GPS;
                 break;
             }
             }

--- a/libraries/AP_ExternalAHRS/MicroStrain_common.h
+++ b/libraries/AP_ExternalAHRS/MicroStrain_common.h
@@ -20,7 +20,7 @@
 
 #if AP_MICROSTRAIN_ENABLED
 
-#include <AP_GPS/AP_GPS.h>
+#include <AP_GPS/AP_GPS_FixType.h>
 #include <AP_Math/vector3.h>
 #include <AP_Math/quaternion.h>
 
@@ -53,7 +53,7 @@ protected:
     struct {
         uint16_t week;
         uint32_t tow_ms;
-        GPS_FIX_TYPE fix_type;
+        AP_GPS_FixType fix_type;
         uint8_t satellites;
         float horizontal_position_accuracy;
         float vertical_position_accuracy;


### PR DESCRIPTION
This PR replaces the legacy GPS_FIX_TYPE enum with the new AP_GPS::GPS_Status enum in the AP_ExternalAHRS MicroStrain driver.
This addresses issue #23320 regarding removing mavlink enum dependencies.

Tested with: ./waf copter (Build Successful)