### PR TITLE
AP_RCProtocol: Define an invalid PWM value to prevent overwriting

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol_Backend.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_Backend.cpp
@@ -68,10 +68,23 @@ void AP_RCProtocol_Backend::read(uint16_t *pwm, uint8_t n)
 /*
   provide input from a backend
  */
-void AP_RCProtocol_Backend::add_input(uint8_t num_values, uint16_t *values, bool in_failsafe, int16_t _rssi, int16_t _rx_link_quality)
+void AP_RCProtocol_Backend::add_input(uint8_t num_values, uint16_t *values, bool in_failsafe, int16_t _rssi, int16_t _rx_link_quality, uint32_t _active_mask)
 {
     num_values = MIN(num_values, MAX_RCIN_CHANNELS);
-    memcpy(_pwm_values, values, num_values*sizeof(uint16_t));
+
+    if (_active_mask == UINT32_MAX) {
+        memcpy(_pwm_values, values, num_values*sizeof(uint16_t));
+
+    } else {
+        // apply active mask
+        for (uint8_t i = 0; i < num_values; i++) {
+            if ((_active_mask & (1 << i)) != 0) {
+                _pwm_values[i] = values[i];
+
+            }
+        }
+    }
+
     _num_channels = num_values;
     rc_frame_count++;
     frontend.set_failsafe_active(in_failsafe);
@@ -88,6 +101,7 @@ void AP_RCProtocol_Backend::add_input(uint8_t num_values, uint16_t *values, bool
     }
     rssi = _rssi;
     rx_link_quality = _rx_link_quality;
+    active_mask = _active_mask;
 }
 
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
@@ -125,7 +125,7 @@ protected:
         uint32_t ch7 : 11;
     } PACKED;
 
-    void add_input(uint8_t num_channels, uint16_t *values, bool in_failsafe, int16_t rssi=-1, int16_t rx_link_quality=-1);
+    void add_input(uint8_t num_channels, uint16_t *values, bool in_failsafe, int16_t rssi=-1, int16_t rx_link_quality=-1, uint32_t active_mask=UINT32_MAX);
     AP_RCProtocol &frontend;
 
     void log_data(AP_RCProtocol::rcprotocol_t prot, uint32_t timestamp, const uint8_t *data, uint8_t len) const;
@@ -142,6 +142,7 @@ private:
     uint8_t  _num_channels;
     int16_t rssi = -1;
     int16_t rx_link_quality = -1;
+    uint32_t active_mask = UINT32_MAX;
 };
 
 #endif  // AP_RCPROTOCOL_ENABLED


### PR DESCRIPTION
### Motivation: The Dual-Operator Problem
Modern smart controllers (e.g., HereLink, SIYI, Skydroid) and GCS software (e.g., QGroundControl) possess MAVLink forwarding and joystick capabilities. Ideally, this hardware allows for a "Dual Operator" setup where:
1.  **Drone Operator:** Controls flight via physical sticks (Pilot).
2.  **Gimbal Operator:** Controls payload/camera via QGC touch interface or a secondary joystick (Co-Pilot).

**Legacy Approach:**
Historically, achieving this required two separate receiver systems on the drone (one for flight, one for gimbal), which is complex and heavy.

**New Approach with this PR:**
By allowing `UINT16_MAX` to signify "no change," we can merge inputs from multiple sources over a single radio link. The Gimbal Operator's commands can be forwarded through the Drone Operator's GCS without overwriting the Pilot's flight channels (by setting flight channels to `UINT16_MAX` in the gimbal packet, or vice versa).

### Operational Sequence
The following diagram illustrates the data flow enabled by this change:

![無効PWM定義 drawio](https://github.com/user-attachments/assets/daefaac5-adec-4690-bbb7-e5056e2d10c0)


### Implementation Details
* Modified `AP_RCProtocol::add_input` (or relevant decoding logic) to check for `UINT16_MAX`.
* If a channel value is `UINT16_MAX`, the value is not updated, preserving the current state from the other source.
* This allows `RADIO_RC_CHANNELS` to act as a sparse update mechanism, similar to `RC_CHANNELS_OVERRIDE`, but suitable for primary control links.
