### PR TITLE
Move ::set_home up from vehicles to AP_AHRS

### DIFF
--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -123,12 +123,8 @@ bool Tracker::set_home_to_current_location(bool lock)
 
 bool Tracker::set_home(const Location &temp, bool lock)
 {
-    // check EKF origin has been set
-    Location ekf_origin;
-    if (ahrs.get_origin(ekf_origin)) {
-        if (!ahrs.set_home(temp)) {
-            return false;
-        }
+    if (!ahrs.set_home(temp, lock)) {
+        return false;
     }
 
     if (!set_home_eeprom(temp)) {

--- a/ArduCopter/commands.cpp
+++ b/ArduCopter/commands.cpp
@@ -57,22 +57,5 @@ bool Copter::set_home_to_current_location(bool lock) {
 //  returns true if home location set successfully
 bool Copter::set_home(const Location& loc, bool lock)
 {
-    // check EKF origin has been set
-    Location ekf_origin;
-    if (!ahrs.get_origin(ekf_origin)) {
-        return false;
-    }
-
-    // set ahrs home (used for RTL)
-    if (!ahrs.set_home(loc)) {
-        return false;
-    }
-
-    // lock home position
-    if (lock) {
-        ahrs.lock_home();
-    }
-
-    // return success
-    return true;
+    return ahrs.set_home(loc);
 }

--- a/ArduCopter/commands.cpp
+++ b/ArduCopter/commands.cpp
@@ -39,6 +39,10 @@ void Copter::set_home_to_current_location_inflight() {
 // set_home_to_current_location - set home to current GPS location
 bool Copter::set_home_to_current_location(bool lock) {
     // get current location from EKF
+    if (!ahrs.has_origin()) {
+        // EKF3 will return GPS position and "true" if there is no origin
+        return false;
+    }
     Location temp_loc;
     if (ahrs.get_location(temp_loc)) {
         if (!set_home(temp_loc, lock)) {

--- a/ArduPlane/GCS_MAVLink_Plane.cpp
+++ b/ArduPlane/GCS_MAVLink_Plane.cpp
@@ -537,11 +537,8 @@ bool Plane::set_home_to_current_location(bool _lock)
 }
 bool Plane::set_home(const Location& loc, bool _lock)
 {
-    if (!AP::ahrs().set_home(loc)) {
+    if (!ahrs.set_home(loc, _lock)) {
         return false;
-    }
-    if (_lock) {
-        AP::ahrs().lock_home();
     }
     if ((control_mode == &mode_rtl)
 #if HAL_QUADPLANE_ENABLED

--- a/ArduSub/commands.cpp
+++ b/ArduSub/commands.cpp
@@ -16,6 +16,10 @@ void Sub::update_home_from_EKF()
 bool Sub::set_home_to_current_location(bool lock)
 {
     // get current location from EKF
+    if (!ahrs.has_origin()) {
+        // EKF3 will return GPS position and "true" if there is no origin
+        return false;
+    }
     Location temp_loc;
     if (ahrs.get_location(temp_loc)) {
 

--- a/ArduSub/commands.cpp
+++ b/ArduSub/commands.cpp
@@ -33,22 +33,5 @@ bool Sub::set_home_to_current_location(bool lock)
 //  returns true if home location set successfully
 bool Sub::set_home(const Location& loc, bool lock)
 {
-    // check if EKF origin has been set
-    Location ekf_origin;
-    if (!ahrs.get_origin(ekf_origin)) {
-        return false;
-    }
-
-    // set ahrs home (used for RTL)
-    if (!ahrs.set_home(loc)) {
-        return false;
-    }
-
-    // lock home position
-    if (lock) {
-        ahrs.lock_home();
-    }
-
-    // return success
-    return true;
+    return ahrs.set_home(loc, lock);
 }

--- a/Blimp/commands.cpp
+++ b/Blimp/commands.cpp
@@ -52,22 +52,5 @@ bool Blimp::set_home_to_current_location(bool lock)
 //  returns true if home location set successfully
 bool Blimp::set_home(const Location& loc, bool lock)
 {
-    // check EKF origin has been set
-    Location ekf_origin;
-    if (!ahrs.get_origin(ekf_origin)) {
-        return false;
-    }
-
-    // set ahrs home (used for RTL)
-    if (!ahrs.set_home(loc)) {
-        return false;
-    }
-
-    // lock home position
-    if (lock) {
-        ahrs.lock_home();
-    }
-
-    // return success
-    return true;
+    return ahrs.set_home(loc);
 }

--- a/Blimp/commands.cpp
+++ b/Blimp/commands.cpp
@@ -22,6 +22,10 @@ void Blimp::update_home_from_EKF()
 // set_home_to_current_location_inflight - set home to current GPS location (horizontally) and EKF origin vertically
 void Blimp::set_home_to_current_location_inflight()
 {
+    if (!ahrs.has_origin()) {
+        // EKF3 will return GPS position and "true" if there is no origin
+        return;
+    }
     // get current location from EKF
     Location temp_loc;
     Location ekf_origin;

--- a/Rover/commands.cpp
+++ b/Rover/commands.cpp
@@ -19,24 +19,7 @@ bool Rover::set_home_to_current_location(bool lock)
 // returns true if home location set successfully
 bool Rover::set_home(const Location& loc, bool lock)
 {
-    // set ahrs home
-    if (!ahrs.set_home(loc)) {
-        return false;
-    }
-
-    // lock home position
-    if (lock) {
-        ahrs.lock_home();
-    }
-
-    // send text of home position to ground stations
-    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Set HOME to %.6f %.6f at %.2fm",
-            static_cast<double>(loc.lat * 1.0e-7f),
-            static_cast<double>(loc.lng * 1.0e-7f),
-            static_cast<double>(loc.alt * 0.01f));
-
-    // return success
-    return true;
+    return ahrs.set_home(loc, lock);
 }
 
 // called periodically while disarmed to update our home position to

--- a/Rover/commands.cpp
+++ b/Rover/commands.cpp
@@ -3,6 +3,10 @@
 // set ahrs home to current location from inertial-nav location
 bool Rover::set_home_to_current_location(bool lock)
 {
+    if (!ahrs.has_origin()) {
+        // EKF3 will return GPS position and "true" if there is no origin
+        return false;
+    }
     Location temp_loc;
     if (ahrs.have_inertial_nav() && ahrs.get_location(temp_loc)) {
         if (!set_home(temp_loc, lock)) {

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -3035,7 +3035,7 @@ bool AP_AHRS::_get_origin(Location &ret) const
     return false;
 }
 
-bool AP_AHRS::set_home(const Location &loc)
+bool AP_AHRS::set_home(const Location &loc, bool lock)
 {
     WITH_SEMAPHORE(_rsem);
     // check location is valid
@@ -3062,6 +3062,11 @@ bool AP_AHRS::set_home(const Location &loc)
 
     _home = tmp;
     _home_is_set = true;
+
+    // lock home position
+    if (lock) {
+        lock_home();
+    }
 
 #if HAL_LOGGING_ENABLED
     Log_Write_Home_And_Origin();

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -271,6 +271,8 @@ public:
 
     // returns the inertial navigation origin in lat/lon/alt
     bool get_origin(Location &ret) const WARN_IF_UNUSED;
+    // returns true if the global navigation origin is valid
+    bool has_origin() const WARN_IF_UNUSED { return state.origin_ok; }
 
     bool have_inertial_nav() const;
 

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -584,7 +584,7 @@ public:
     // set the home location in 10e7 degrees. This should be called
     // when the vehicle is at this position. It is assumed that the
     // current barometer and GPS altitudes correspond to this altitude
-    bool set_home(const Location &loc) WARN_IF_UNUSED;
+    bool set_home(const Location &loc, bool lock=false) WARN_IF_UNUSED;
 
     /*
      * Attitude-related public methods and attributes:


### PR DESCRIPTION
This is not NFC ~~; both Plane and Rover will be unable to set their home unless their origin has also been set.  I don't think this will break people's workflows.  Rover won't emit a text message now.~~

update: after  DevCallEU, we decided that origin would not be required to set home - this PR now reflects that.

~~I don't think we *should* require home to be set before you set origin.... but at least this way we are consistent, and this is the more conservative approach to getting our vehicles having the same behaviour.~~

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *                                                   
Durandal                            0               -40    *           -40     -32               16     -128   -40
Hitec-Airspeed           *                                 *                                                   
KakuteH7-bdshot                     0               -40    *           -32     -40               16     -128   -40
MatekF405                           0               -40    *           -40     -40               16     -152   -40
MatekH7A3                           0               -40    *           -32     -32               16     -136   -40
Pixhawk1-1M-bdshot                  0               -40                -40     -40               16     -152   -40
SITL_x86_64_linux_gnu               0               -4096              0       8                 0      0      0
YJUAV_A6SE                          16              -40    *           -32     -40               24     -120   -48
f103-QiotekPeriph        *                                 *                                                   
f303-MatekGPS            *                                 *                                                   
f303-Universal           *                                 *                                                   
iomcu                                                                                *                         
mindpx-v2                           0               -32    *           -32     -32               8      -152   -32
revo-mini                           0               -40    *           -40     -40               16     -152   -40
skyviper-v2450                                                         -32                                     
speedybeef4                         0               -40    *           -40     -40               16     -160   -40
```
(edit: sizes updated)

Future PRs will be based on my branches `pr/set-home-up-next` and `pr/set-home-up-next-next`

We're also going to start drifting home the same on all vehicles (presumably with the exception of Tracker).
