### PR TITLE
SRV_Channel: Zero output_scaled values when disarming

### DIFF
--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -602,6 +602,9 @@ public:
 
     static void zero_rc_outputs();
 
+    // zero all output_scaled values for all functions
+    static void zero_output_scaled_all();
+
     // initialize before any call to push
     void init(uint32_t motor_mask = 0, AP_HAL::RCOutput::output_mode mode = AP_HAL::RCOutput::MODE_PWM_NONE);
 

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -561,6 +561,20 @@ void SRV_Channels::zero_rc_outputs()
         hal.rcout->write(i, 0);
     }
     srv.push();
+
+    // Also zero all output_scaled values so get_output_scaled() returns 0
+    zero_output_scaled_all();
+}
+
+/*
+  zero all output_scaled values for all functions
+  this is called when disarming to ensure get_output_scaled() returns zero
+ */
+void SRV_Channels::zero_output_scaled_all()
+{
+    for (uint16_t i = 0; i < SRV_Channel::k_nr_aux_servo_functions; i++) {
+        functions[i].output_scaled = 0;
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary

Fix an issue where `SRV_Channels:get_output_scaled()` returns stale non-zero values when the vehicle is disarmed.

## Issue Details

When reading `SRV_Channels:get_output_scaled()` in Lua scripts, the value does not update when disarmed. It can produce non-zero values when disarmed because:

- The `output_scaled` values are stored per-function and only updated by `set_output_scaled()` calls
- When disarmed, motor control code doesn't always reset these values
- The existing `zero_rc_outputs()` function only zeroed PWM values, not the `output_scaled` values

## Changes

### SRV_Channels.cpp
- Add `zero_output_scaled_all()` function to reset all `output_scaled` values to zero
- Modify `zero_rc_outputs()` to also call `zero_output_scaled_all()`

### SRV_Channel.h
- Add declaration for `zero_output_scaled_all()`

## Impact

When `zero_rc_outputs()` is called during disarm:
- All `output_scaled` values are now reset to 0
- `get_output_scaled()` returns 0 for all functions when disarmed
- Lua scripts will see correct zero values when vehicle is disarmed

## Platform
- Affects: Rover (and likely all platforms)