### PR TITLE
Tools: Add Linux Mint 'zara' support to install-prereqs-ubuntu.sh

### DIFF
--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -72,7 +72,7 @@ case ${RELEASE_DISTRIBUTOR} in
     linuxmint)
         # translate Mint-codenames to Ubuntu-codenames based on https://www.linuxmint.com/download_all.php
         case ${RELEASE_CODENAME} in
-            wilma | xia)
+            wilma | xia | zara)
                 RELEASE_CODENAME='noble'
                 ;;
             vanessa | vera | victoria | virginia)


### PR DESCRIPTION
Add mapping for Linux Mint 22.2 ("zara") to Ubuntu 24.04 ("noble") to allow the prerequisites script to run correctly on this distribution.

This fixes an issue where the script would fail to detect the release codename on Linux Mint 22.2.