### PR TITLE
AP_Baro: allow for deferred calibration of sensors

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -4445,6 +4445,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "SERIAL5_PROTOCOL": 1,
         })
         self.reboot_sitl()
+        # wait for EKF to fully initialize after reboot — without
+        # GPS, the EKF needs time in AID_NONE before it can report
+        # position after origin is set
+        self.delay_sim_time(5)
         # without a GPS or some sort of external prompting, AP
         # doesn't send system_time messages.  So prompt it:
         self.mav.mav.system_time_send(int(time.time() * 1000000), 0)
@@ -4505,6 +4509,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "SIM_VICON_TMASK": 8,  # send VISION_POSITION_DELTA
         })
         self.reboot_sitl()
+        # wait for EKF to fully initialize after reboot
+        self.delay_sim_time(5)
         # without a GPS or some sort of external prompting, AP
         # doesn't send system_time messages.  So prompt it:
         self.mav.mav.system_time_send(int(time.time() * 1000000), 0)
@@ -11138,6 +11144,30 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             raise NotAchievedException("Changed to ALT_HOLD with no altitude estimate")
         self.disarm_vehicle(force=True)
 
+    def BaroDeferredCalibration(self):
+        '''Test that deferred baro calibration works with slow-starting sensor'''
+        # Simulate a slow-starting baro (e.g. external AHRS) that
+        # takes 5 seconds to produce data.  Verify:
+        # 1. Pre-arm check prevents arming before calibration
+        # 2. Calibration completes once data arrives
+        # 3. Vehicle can arm and fly normally afterwards
+        self.set_parameters({
+            "SIM_BARO_STRTDLY": 3,
+            "SIM_BAR2_STRTDLY": 3,
+        })
+        self.reboot_sitl(check_position=False)
+
+        # baro should not be calibrated yet — check pre-arm fails
+        self.delay_sim_time(1)
+        self.assert_prearm_failure("not calibrated")
+
+        # wait for calibration to complete (3s startup + ~2s calibration)
+        self.wait_ready_to_arm(timeout=30)
+
+        # verify we can arm and take off normally
+        self.takeoff(10, mode='LOITER')
+        self.do_RTL()
+
     def EKFSource(self):
         '''Check EKF Source Prearms work'''
         self.wait_ready_to_arm()
@@ -15960,6 +15990,7 @@ return update, 1000
             self.CRSF,
             self.MotorTest,
             self.AltEstimation,
+            self.BaroDeferredCalibration,
             self.EKFSource,
             self.GSF,
             self.GSF_reset,

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -11153,7 +11153,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
     def BaroDeferredCalibration(self):
         '''Test that deferred baro calibration works with slow-starting sensor'''
         # Simulate a slow-starting baro (e.g. external AHRS) that
-        # takes 5 seconds to produce data.  Verify:
+        # takes 3 seconds to produce data.  Verify:
         # 1. Pre-arm check prevents arming before calibration
         # 2. Calibration completes once data arrives
         # 3. Vehicle can arm and fly normally afterwards
@@ -11169,6 +11169,13 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         # wait for calibration to complete (3s startup + ~2s calibration)
         self.wait_ready_to_arm(timeout=60)
+
+        # clear the startup delay immediately so it cannot persist
+        # into subsequent tests if the flight phase below fails
+        self.set_parameters({
+            "SIM_BARO_STRTDLY": 0,
+            "SIM_BAR2_STRTDLY": 0,
+        })
 
         # verify we can arm and take off normally
         self.takeoff(10, mode='LOITER')

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -11162,7 +11162,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.assert_prearm_failure("not calibrated")
 
         # wait for calibration to complete (3s startup + ~2s calibration)
-        self.wait_ready_to_arm(timeout=30)
+        self.wait_ready_to_arm(timeout=60)
 
         # verify we can arm and take off normally
         self.takeoff(10, mode='LOITER')

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -4445,10 +4445,12 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "SERIAL5_PROTOCOL": 1,
         })
         self.reboot_sitl()
-        # wait for EKF to fully initialize after reboot — without
-        # GPS, the EKF needs time in AID_NONE before it can report
-        # position after origin is set
-        self.delay_sim_time(5)
+        # wait for EKF attitude convergence before setting origin
+        self.wait_ekf_flags(
+            mavutil.mavlink.EKF_ATTITUDE,
+            0,
+            timeout=30,
+        )
         # without a GPS or some sort of external prompting, AP
         # doesn't send system_time messages.  So prompt it:
         self.mav.mav.system_time_send(int(time.time() * 1000000), 0)
@@ -4509,8 +4511,12 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "SIM_VICON_TMASK": 8,  # send VISION_POSITION_DELTA
         })
         self.reboot_sitl()
-        # wait for EKF to fully initialize after reboot
-        self.delay_sim_time(5)
+        # wait for EKF attitude convergence before setting origin
+        self.wait_ekf_flags(
+            mavutil.mavlink.EKF_ATTITUDE,
+            0,
+            timeout=30,
+        )
         # without a GPS or some sort of external prompting, AP
         # doesn't send system_time messages.  So prompt it:
         self.mav.mav.system_time_send(int(time.time() * 1000000), 0)

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -3026,7 +3026,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.change_mode('LOITER')
         self.delay_sim_time(10)
         self.change_mode('CIRCLE')
-        self.wait_altitude(alt*0.9, alt*1.1, minimum_duration=10, relative=True)
+        self.wait_altitude(alt*0.85, alt*1.15, minimum_duration=10, relative=True)
         self.fly_home_land_and_disarm()
 
     def fly_generic_mission(self, filename, mission_timeout=60.0, strict=True):

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -15045,11 +15045,13 @@ SERIAL5_BAUD 128
         params = copy.copy(self.FenceRelativeToHome_params())
         params.update({
             "FENCE_TYPE": 8,   # ALT_MIN only
-            "FENCE_ALT_MIN": fence_alt_min,
             "FENCE_ALT_MAX": 50,  # generous ceiling
         })
         self.set_parameters(params)
         self.wait_ready_to_arm()
+        # set min-alt after arming checks pass — on the ground the
+        # vehicle would be below the min-alt fence and block arming
+        self.set_parameter("FENCE_ALT_MIN", fence_alt_min)
         original_home = self.home_position_as_mav_location()
         home_ofs = 20
         offset_home = self.offset_location_up(original_home, home_ofs)
@@ -15094,11 +15096,13 @@ SERIAL5_BAUD 128
         params = self.FenceRelativeToHome_params()
         params.update({
             "FENCE_TYPE": 8,   # ALT_MIN only
-            "FENCE_ALT_MIN": fence_alt_min,
             "FENCE_ALT_MAX": 50,  # generous ceiling
         })
         self.set_parameters(params)
         self.wait_ready_to_arm()
+        # set min-alt after arming checks pass — on the ground the
+        # vehicle would be below the min-alt fence and block arming
+        self.set_parameter("FENCE_ALT_MIN", fence_alt_min)
         original_home = self.home_position_as_mav_location()
         home_ofs = -20
         offset_home = self.offset_location_up(original_home, home_ofs)
@@ -15170,11 +15174,13 @@ SERIAL5_BAUD 128
         params = self.FenceRelativeToOrigin_params()
         params.update({
             "FENCE_TYPE": 8,   # ALT_MIN only
-            "FENCE_ALT_MIN": fence_alt_min,
             "FENCE_ALT_MAX": 50,  # generous ceiling
         })
         self.set_parameters(params)
         self.wait_ready_to_arm()
+        # set min-alt after arming checks pass — on the ground the
+        # vehicle would be below the min-alt fence and block arming
+        self.set_parameter("FENCE_ALT_MIN", fence_alt_min)
         origin_alt_m = self.poll_message("GPS_GLOBAL_ORIGIN").altitude / 1000.0
         original_home = self.home_position_as_mav_location()
         self.set_home(self.offset_location_up(original_home, -20))
@@ -15223,11 +15229,13 @@ SERIAL5_BAUD 128
         params = self.FenceRelativeToOrigin_params()
         params.update({
             "FENCE_TYPE": 8,   # ALT_MIN only
-            "FENCE_ALT_MIN": fence_alt_min,
             "FENCE_ALT_MAX": 80,  # generous ceiling
         })
         self.set_parameters(params)
         self.wait_ready_to_arm()
+        # set min-alt after arming checks pass — on the ground the
+        # vehicle would be below the min-alt fence and block arming
+        self.set_parameter("FENCE_ALT_MIN", fence_alt_min)
         ground_loc = self.home_position_as_mav_location()
         origin_alt_m = self.poll_message("GPS_GLOBAL_ORIGIN").altitude / 1000.0
         # take off first from home==origin so relative alt starts at 0

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -15044,19 +15044,19 @@ SERIAL5_BAUD 128
         fence_alt_min = 5   # m above home = 25 m above origin
         params = copy.copy(self.FenceRelativeToHome_params())
         params.update({
-            "FENCE_TYPE": 8,   # ALT_MIN only
+            "FENCE_ENABLE": 0,  # defer enable until after takeoff
+            "FENCE_TYPE": 8,    # ALT_MIN only
+            "FENCE_ALT_MIN": fence_alt_min,
             "FENCE_ALT_MAX": 50,  # generous ceiling
         })
         self.set_parameters(params)
         self.wait_ready_to_arm()
-        # set min-alt after arming checks pass — on the ground the
-        # vehicle would be below the min-alt fence and block arming
-        self.set_parameter("FENCE_ALT_MIN", fence_alt_min)
         original_home = self.home_position_as_mav_location()
         home_ofs = 20
         offset_home = self.offset_location_up(original_home, home_ofs)
         self.set_home(offset_home)
         self.takeoff(10, mode=self.FenceRelative_TakeoffMode())
+        self.set_parameter("FENCE_ENABLE", 1)
         self.do_fence_enable()
         self.set_rc(3, 1200)
         self.wait_mode('RTL', timeout=120)
@@ -15095,19 +15095,19 @@ SERIAL5_BAUD 128
         fence_alt_min = 26
         params = self.FenceRelativeToHome_params()
         params.update({
-            "FENCE_TYPE": 8,   # ALT_MIN only
+            "FENCE_ENABLE": 0,  # defer enable until after takeoff
+            "FENCE_TYPE": 8,    # ALT_MIN only
+            "FENCE_ALT_MIN": fence_alt_min,
             "FENCE_ALT_MAX": 50,  # generous ceiling
         })
         self.set_parameters(params)
         self.wait_ready_to_arm()
-        # set min-alt after arming checks pass — on the ground the
-        # vehicle would be below the min-alt fence and block arming
-        self.set_parameter("FENCE_ALT_MIN", fence_alt_min)
         original_home = self.home_position_as_mav_location()
         home_ofs = -20
         offset_home = self.offset_location_up(original_home, home_ofs)
         self.set_home(offset_home)
         self.takeoff(30, mode=self.FenceRelative_TakeoffMode())
+        self.set_parameter("FENCE_ENABLE", 1)
         self.do_fence_enable()
         self.assert_mode_is(self.FenceRelative_TakeoffMode())
         self.set_rc(3, 1200)
@@ -15173,18 +15173,18 @@ SERIAL5_BAUD 128
         fence_alt_min = 3   # m above origin = 23 m above home
         params = self.FenceRelativeToOrigin_params()
         params.update({
-            "FENCE_TYPE": 8,   # ALT_MIN only
+            "FENCE_ENABLE": 0,  # defer enable until after takeoff
+            "FENCE_TYPE": 8,    # ALT_MIN only
+            "FENCE_ALT_MIN": fence_alt_min,
             "FENCE_ALT_MAX": 50,  # generous ceiling
         })
         self.set_parameters(params)
         self.wait_ready_to_arm()
-        # set min-alt after arming checks pass — on the ground the
-        # vehicle would be below the min-alt fence and block arming
-        self.set_parameter("FENCE_ALT_MIN", fence_alt_min)
         origin_alt_m = self.poll_message("GPS_GLOBAL_ORIGIN").altitude / 1000.0
         original_home = self.home_position_as_mav_location()
         self.set_home(self.offset_location_up(original_home, -20))
         self.takeoff(25, mode=self.FenceRelative_TakeoffMode())
+        self.set_parameter("FENCE_ENABLE", 1)
         self.do_fence_enable()
         self.set_rc(3, 1200)
         self.wait_mode('RTL', timeout=120)
@@ -15228,14 +15228,13 @@ SERIAL5_BAUD 128
         fence_alt_min = 15
         params = self.FenceRelativeToOrigin_params()
         params.update({
-            "FENCE_TYPE": 8,   # ALT_MIN only
+            "FENCE_ENABLE": 0,  # defer enable until after takeoff
+            "FENCE_TYPE": 8,    # ALT_MIN only
+            "FENCE_ALT_MIN": fence_alt_min,
             "FENCE_ALT_MAX": 80,  # generous ceiling
         })
         self.set_parameters(params)
         self.wait_ready_to_arm()
-        # set min-alt after arming checks pass — on the ground the
-        # vehicle would be below the min-alt fence and block arming
-        self.set_parameter("FENCE_ALT_MIN", fence_alt_min)
         ground_loc = self.home_position_as_mav_location()
         origin_alt_m = self.poll_message("GPS_GLOBAL_ORIGIN").altitude / 1000.0
         # take off first from home==origin so relative alt starts at 0
@@ -15244,6 +15243,7 @@ SERIAL5_BAUD 128
         # is safely above the fence min at 15 m above origin
         original_home = self.mav.location()
         self.set_home(self.offset_location_up(original_home, -10))
+        self.set_parameter("FENCE_ENABLE", 1)
         self.do_fence_enable()
         self.assert_mode_is(self.FenceRelative_TakeoffMode())
         self.set_rc(3, 1200)

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -320,28 +320,7 @@ void AP_Baro::calibrate(bool save)
     }
     #endif
 
-    // Check if external AHRS is providing baro - needs special handling
-    bool eahrs_baro = false;
-#if AP_BARO_EXTERNALAHRS_ENABLED
-    // External AHRS may take time to establish communication
-    // (CRSF baud negotiation can take 1.5+ seconds, then baro frames at ~10Hz)
-    const int8_t eahrs_port = AP::externalAHRS().get_port(AP_ExternalAHRS::AvailableSensor::BARO);
-    if (eahrs_port >= 0) {
-        eahrs_baro = true;
-        const uint32_t start_ms = AP_HAL::millis();
-        // Wait for AHRS to initialize (receives first packet)
-        while (!AP::externalAHRS().initialised() && (AP_HAL::millis() - start_ms < 10000)) {
-            hal.scheduler->delay(10);
-        }
-        if (AP::externalAHRS().initialised()) {
-            // Wait for baro to become healthy (receives baro frames)
-            while (!healthy() && (AP_HAL::millis() - start_ms < 15000)) {
-                update();
-                hal.scheduler->delay(100);
-            }
-        }
-    }
-#endif
+    _cal_save = save;
 
     GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Calibrating barometer");
 
@@ -357,72 +336,66 @@ void AP_Baro::calibrate(bool save)
         do {
             update();
             if (AP_HAL::millis() - tstart > 500) {
-                if (!eahrs_baro) {
-                    // Internal sensors should always be ready - fail fast
-                    AP_BoardConfig::config_error("Baro: unable to calibrate");
-                }
-                // External AHRS baro may have gaps - continue to next iteration
-                break;
+                // sensor not responding yet; deferred calibration
+                // in update() will handle slow-starting sensors
+                goto deferred;
             }
             hal.scheduler->delay(10);
         } while (!healthy());
         hal.scheduler->delay(100);
     }
 
-    // now average over 5 values for the ground pressure settings
-    float sum_pressure[BARO_MAX_INSTANCES] = {0};
-    uint8_t count[BARO_MAX_INSTANCES] = {0};
-    const uint8_t num_samples = 5;
+    {
+        // now average over 5 values for the ground pressure settings
+        float sum_pressure[BARO_MAX_INSTANCES] = {0};
+        uint8_t count[BARO_MAX_INSTANCES] = {0};
+        const uint8_t num_samples = 5;
 
-    for (uint8_t c = 0; c < num_samples; c++) {
-        uint32_t tstart = AP_HAL::millis();
-        do {
-            update();
-            if (AP_HAL::millis() - tstart > 500) {
-                if (!eahrs_baro) {
-                    AP_BoardConfig::config_error("Baro: unable to calibrate");
+        for (uint8_t c = 0; c < num_samples; c++) {
+            uint32_t tstart = AP_HAL::millis();
+            do {
+                update();
+                if (AP_HAL::millis() - tstart > 500) {
+                    break;
                 }
-                break;
+            } while (!healthy());
+            for (uint8_t i=0; i<_num_sensors; i++) {
+                if (healthy(i)) {
+                    sum_pressure[i] += sensors[i].pressure;
+                    count[i] += 1;
+                }
             }
-            hal.scheduler->delay(10);
-        } while (!healthy());
-        for (uint8_t i=0; i<_num_sensors; i++) {
-            if (healthy(i)) {
-                sum_pressure[i] += sensors[i].pressure;
-                count[i] += 1;
-            }
+            hal.scheduler->delay(100);
         }
-        hal.scheduler->delay(100);
-    }
-    for (uint8_t i=0; i<_num_sensors; i++) {
-        if (count[i] == 0) {
-            sensors[i].calibrated = false;
-        } else {
-            if (save) {
-                float p0_sealevel = get_sealevel_pressure(sum_pressure[i] / count[i], _field_elevation_active);
-                sensors[i].ground_pressure.set_and_save(p0_sealevel);
+        for (uint8_t i=0; i<_num_sensors; i++) {
+            if (count[i] == 0) {
+                sensors[i].calibrated = false;
+            } else {
+                if (save) {
+                    float p0_sealevel = get_sealevel_pressure(sum_pressure[i] / count[i], _field_elevation_active);
+                    sensors[i].ground_pressure.set_and_save(p0_sealevel);
+                }
             }
         }
     }
 
     _guessed_ground_temperature = get_external_temperature();
 
-    // panic if all sensors are not calibrated
-    uint8_t num_calibrated = 0;
+    // report calibration status
     for (uint8_t i=0; i<_num_sensors; i++) {
         if (sensors[i].calibrated) {
             GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Barometer %u calibration complete", i+1);
-            num_calibrated++;
         }
     }
-    if (num_calibrated) {
-        return;
-    }
-    if (eahrs_baro) {
-        // External AHRS baro may recover later - warn but don't halt
-        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Baro: EAHRS baro not calibrated");
-    } else {
-        AP_BoardConfig::config_error("Baro: all sensors uncalibrated");
+
+deferred:
+    // mark uncalibrated sensors for deferred calibration in update()
+    for (uint8_t i=0; i<_num_sensors; i++) {
+        if (!sensors[i].calibrated) {
+            sensors[i].cal_start_ms = 0;
+            sensors[i].cal_sum = 0;
+            sensors[i].cal_count = 0;
+        }
     }
 }
 
@@ -952,9 +925,44 @@ void AP_Baro::update(void)
         drivers[i]->backend_update(i);
     }
 
-#if AP_BARO_THST_COMP_ENABLED
-    update_thrust_filter();
-#endif
+    // deferred calibration for sensors not ready during init
+    for (uint8_t i=0; i<_num_sensors; i++) {
+        if (sensors[i].calibrated) {
+            continue;
+        }
+        if (!sensors[i].healthy) {
+            // sensor not yet producing data, reset state
+            sensors[i].cal_start_ms = 0;
+            sensors[i].cal_count = 0;
+            sensors[i].cal_sum = 0;
+            continue;
+        }
+        const uint32_t now = AP_HAL::millis();
+        if (sensors[i].cal_start_ms == 0) {
+            // first time seeing sensor healthy, start settling
+            sensors[i].cal_start_ms = now;
+            continue;
+        }
+        // collect samples after 1s settling, spaced 100ms apart
+        const uint32_t sample_time_ms = 1000 + (uint32_t)sensors[i].cal_count * 100;
+        if (now - sensors[i].cal_start_ms < sample_time_ms) {
+            continue;
+        }
+        sensors[i].cal_sum += sensors[i].pressure;
+        sensors[i].cal_count++;
+        if (sensors[i].cal_count >= 5) {
+            const float avg = sensors[i].cal_sum / sensors[i].cal_count;
+            const float p0_sealevel = get_sealevel_pressure(avg, _field_elevation_active);
+            if (_cal_save) {
+                sensors[i].ground_pressure.set_and_save(p0_sealevel);
+            } else {
+                sensors[i].ground_pressure.set(p0_sealevel);
+            }
+            sensors[i].calibrated = true;
+            _guessed_ground_temperature = get_external_temperature();
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Barometer %u calibration complete", i+1);
+        }
+    }
 
     for (uint8_t i=0; i<_num_sensors; i++) {
         if (sensors[i].healthy) {
@@ -991,6 +999,10 @@ void AP_Baro::update(void)
             }
         }
     }
+
+#if AP_BARO_THST_COMP_ENABLED
+    update_thrust_filter();
+#endif
 
     // ensure the climb rate filter is updated
     if (healthy()) {

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -337,9 +337,14 @@ void AP_Baro::calibrate(bool save)
     // startup.  Sensors will be calibrated as data arrives with
     // settling and sampling handled in the deferred path.
     // A pre-arm check ensures calibration is complete before arming.
+    // Start the settling timer now so that sensors already producing
+    // data complete calibration sooner once the scheduler starts
+    // calling update().  Sensors not yet healthy will have
+    // cal_start_ms reset to 0 in the deferred path.
+    const uint32_t now = AP_HAL::millis();
     for (uint8_t i=0; i<_num_sensors; i++) {
         sensors[i].calibrated = false;
-        sensors[i].cal_start_ms = 0;
+        sensors[i].cal_start_ms = now;
         sensors[i].cal_sum = 0;
         sensors[i].cal_count = 0;
     }

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -355,61 +355,12 @@ void AP_Baro::calibrate(bool save)
         hal.scheduler->delay(100);
     }
 
-    if (settled) {
-        // now average over 5 values for the ground pressure settings
-        float sum_pressure[BARO_MAX_INSTANCES] = {0};
-        uint8_t count[BARO_MAX_INSTANCES] = {0};
-        const uint8_t num_samples = 5;
-
-        for (uint8_t c = 0; c < num_samples; c++) {
-            uint32_t tstart = AP_HAL::millis();
-            do {
-                update();
-                if (AP_HAL::millis() - tstart > 500) {
-                    break;
-                }
-            } while (!healthy());
-            for (uint8_t i=0; i<_num_sensors; i++) {
-                if (healthy(i)) {
-                    sum_pressure[i] += sensors[i].pressure;
-                    count[i] += 1;
-                }
-            }
-            hal.scheduler->delay(100);
-        }
-        for (uint8_t i=0; i<_num_sensors; i++) {
-            if (count[i] == 0) {
-                sensors[i].calibrated = false;
-            } else {
-                if (save) {
-                    float p0_sealevel = get_sealevel_pressure(sum_pressure[i] / count[i], _field_elevation_active);
-                    sensors[i].ground_pressure.set_and_save(p0_sealevel);
-                }
-            }
-        }
-
-        _guessed_ground_temperature = get_external_temperature();
-
-        // report calibration status
-        for (uint8_t i=0; i<_num_sensors; i++) {
-            if (sensors[i].calibrated) {
-                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Barometer %u calibration complete", i+1);
-            }
-        }
-    } else {
-        // sensors not yet producing data, mark all uncalibrated
-        for (uint8_t i=0; i<_num_sensors; i++) {
-            sensors[i].calibrated = false;
-        }
-    }
-
-    // initialize deferred calibration state for uncalibrated sensors
+    // sensors not yet producing data, mark all uncalibrated
     for (uint8_t i=0; i<_num_sensors; i++) {
-        if (!sensors[i].calibrated) {
-            sensors[i].cal_start_ms = 0;
-            sensors[i].cal_sum = 0;
-            sensors[i].cal_count = 0;
-        }
+        sensors[i].calibrated = false;
+        sensors[i].cal_start_ms = 0;
+        sensors[i].cal_sum = 0;
+        sensors[i].cal_count = 0;
     }
 }
 

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -1009,7 +1009,7 @@ bool AP_Baro::healthy(uint8_t instance) const {
     if (instance >= BARO_MAX_INSTANCES) {
         return false;
     }
-    return sensors[instance].healthy && sensors[instance].alt_ok && sensors[instance].calibrated;
+    return sensors[instance].healthy && sensors[instance].alt_ok;
 }
 #endif
 

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -322,6 +322,11 @@ void AP_Baro::calibrate(bool save)
 
     _cal_save = save;
 
+    if (_num_sensors == 0) {
+        AP_BoardConfig::config_error("Baro: unable to calibrate");
+        return;
+    }
+
     GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Calibrating barometer");
 
     // reset the altitude offset when we calibrate. The altitude
@@ -331,6 +336,7 @@ void AP_Baro::calibrate(bool save)
     // let the barometer settle for a full second after startup
     // the MS5611 reads quite a long way off for the first second,
     // leading to about 1m of error if we don't wait
+    bool settled = true;
     for (uint8_t i = 0; i < 10; i++) {
         uint32_t tstart = AP_HAL::millis();
         do {
@@ -338,14 +344,18 @@ void AP_Baro::calibrate(bool save)
             if (AP_HAL::millis() - tstart > 500) {
                 // sensor not responding yet; deferred calibration
                 // in update() will handle slow-starting sensors
-                goto deferred;
+                settled = false;
+                break;
             }
             hal.scheduler->delay(10);
         } while (!healthy());
+        if (!settled) {
+            break;
+        }
         hal.scheduler->delay(100);
     }
 
-    {
+    if (settled) {
         // now average over 5 values for the ground pressure settings
         float sum_pressure[BARO_MAX_INSTANCES] = {0};
         uint8_t count[BARO_MAX_INSTANCES] = {0};
@@ -377,19 +387,23 @@ void AP_Baro::calibrate(bool save)
                 }
             }
         }
-    }
 
-    _guessed_ground_temperature = get_external_temperature();
+        _guessed_ground_temperature = get_external_temperature();
 
-    // report calibration status
-    for (uint8_t i=0; i<_num_sensors; i++) {
-        if (sensors[i].calibrated) {
-            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Barometer %u calibration complete", i+1);
+        // report calibration status
+        for (uint8_t i=0; i<_num_sensors; i++) {
+            if (sensors[i].calibrated) {
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Barometer %u calibration complete", i+1);
+            }
+        }
+    } else {
+        // sensors not yet producing data, mark all uncalibrated
+        for (uint8_t i=0; i<_num_sensors; i++) {
+            sensors[i].calibrated = false;
         }
     }
 
-deferred:
-    // mark uncalibrated sensors for deferred calibration in update()
+    // initialize deferred calibration state for uncalibrated sensors
     for (uint8_t i=0; i<_num_sensors; i++) {
         if (!sensors[i].calibrated) {
             sensors[i].cal_start_ms = 0;

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -319,7 +319,30 @@ void AP_Baro::calibrate(bool save)
             return;
     }
     #endif
-    
+
+    // Check if external AHRS is providing baro - needs special handling
+    bool eahrs_baro = false;
+#if AP_BARO_EXTERNALAHRS_ENABLED
+    // External AHRS may take time to establish communication
+    // (CRSF baud negotiation can take 1.5+ seconds, then baro frames at ~10Hz)
+    const int8_t eahrs_port = AP::externalAHRS().get_port(AP_ExternalAHRS::AvailableSensor::BARO);
+    if (eahrs_port >= 0) {
+        eahrs_baro = true;
+        const uint32_t start_ms = AP_HAL::millis();
+        // Wait for AHRS to initialize (receives first packet)
+        while (!AP::externalAHRS().initialised() && (AP_HAL::millis() - start_ms < 10000)) {
+            hal.scheduler->delay(10);
+        }
+        if (AP::externalAHRS().initialised()) {
+            // Wait for baro to become healthy (receives baro frames)
+            while (!healthy() && (AP_HAL::millis() - start_ms < 15000)) {
+                update();
+                hal.scheduler->delay(100);
+            }
+        }
+    }
+#endif
+
     GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Calibrating barometer");
 
     // reset the altitude offset when we calibrate. The altitude
@@ -334,7 +357,12 @@ void AP_Baro::calibrate(bool save)
         do {
             update();
             if (AP_HAL::millis() - tstart > 500) {
-                AP_BoardConfig::config_error("Baro: unable to calibrate");
+                if (!eahrs_baro) {
+                    // Internal sensors should always be ready - fail fast
+                    AP_BoardConfig::config_error("Baro: unable to calibrate");
+                }
+                // External AHRS baro may have gaps - continue to next iteration
+                break;
             }
             hal.scheduler->delay(10);
         } while (!healthy());
@@ -351,8 +379,12 @@ void AP_Baro::calibrate(bool save)
         do {
             update();
             if (AP_HAL::millis() - tstart > 500) {
-                AP_BoardConfig::config_error("Baro: unable to calibrate");
+                if (!eahrs_baro) {
+                    AP_BoardConfig::config_error("Baro: unable to calibrate");
+                }
+                break;
             }
+            hal.scheduler->delay(10);
         } while (!healthy());
         for (uint8_t i=0; i<_num_sensors; i++) {
             if (healthy(i)) {
@@ -386,7 +418,12 @@ void AP_Baro::calibrate(bool save)
     if (num_calibrated) {
         return;
     }
-    AP_BoardConfig::config_error("Baro: all sensors uncalibrated");
+    if (eahrs_baro) {
+        // External AHRS baro may recover later - warn but don't halt
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Baro: EAHRS baro not calibrated");
+    } else {
+        AP_BoardConfig::config_error("Baro: all sensors uncalibrated");
+    }
 }
 
 /*

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -333,29 +333,10 @@ void AP_Baro::calibrate(bool save)
     // offset is supposed to be for within a flight
     _alt_offset.set_and_save(0);
 
-    // let the barometer settle for a full second after startup
-    // the MS5611 reads quite a long way off for the first second,
-    // leading to about 1m of error if we don't wait
-    bool settled = true;
-    for (uint8_t i = 0; i < 10; i++) {
-        uint32_t tstart = AP_HAL::millis();
-        do {
-            update();
-            if (AP_HAL::millis() - tstart > 500) {
-                // sensor not responding yet; deferred calibration
-                // in update() will handle slow-starting sensors
-                settled = false;
-                break;
-            }
-            hal.scheduler->delay(10);
-        } while (!healthy());
-        if (!settled) {
-            break;
-        }
-        hal.scheduler->delay(100);
-    }
-
-    // sensors not yet producing data, mark all uncalibrated
+    // all calibration is deferred to update() to avoid blocking
+    // startup.  Sensors will be calibrated as data arrives with
+    // settling and sampling handled in the deferred path.
+    // A pre-arm check ensures calibration is complete before arming.
     for (uint8_t i=0; i<_num_sensors; i++) {
         sensors[i].calibrated = false;
         sensors[i].cal_start_ms = 0;
@@ -1170,6 +1151,15 @@ void AP_Baro::handle_external(const AP_ExternalAHRS::baro_data_message_t &pkt)
 // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
 bool AP_Baro::arming_checks(size_t buflen, char *buffer) const
 {
+    // check calibration first — gives a more specific message than
+    // "not healthy" when deferred calibration hasn't completed
+    for (uint8_t i=0; i<_num_sensors; i++) {
+        if (!sensors[i].calibrated) {
+            hal.util->snprintf(buffer, buflen, "#%u not calibrated", i+1);
+            return false;
+        }
+    }
+
     if (!all_healthy()) {
         hal.util->snprintf(buffer, buflen, "not healthy");
         return false;

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -340,13 +340,13 @@ void AP_Baro::calibrate(bool save)
     // Start the settling timer now so that sensors already producing
     // data complete calibration sooner once the scheduler starts
     // calling update().  Sensors not yet healthy will have
-    // cal_start_ms reset to 0 in the deferred path.
+    // cal.start_ms reset to 0 in the deferred path.
     const uint32_t now = AP_HAL::millis();
     for (uint8_t i=0; i<_num_sensors; i++) {
         sensors[i].calibrated = false;
-        sensors[i].cal_start_ms = now;
-        sensors[i].cal_sum = 0;
-        sensors[i].cal_count = 0;
+        sensors[i].cal.start_ms = now;
+        sensors[i].cal.sum = 0;
+        sensors[i].cal.count = 0;
     }
 }
 
@@ -876,33 +876,33 @@ void AP_Baro::update(void)
         drivers[i]->backend_update(i);
     }
 
-    // deferred calibration for sensors not ready during init
+    // run-time calibration for sensors
     for (uint8_t i=0; i<_num_sensors; i++) {
         if (sensors[i].calibrated) {
             continue;
         }
         if (!sensors[i].healthy) {
             // sensor not yet producing data, reset state
-            sensors[i].cal_start_ms = 0;
-            sensors[i].cal_count = 0;
-            sensors[i].cal_sum = 0;
+            sensors[i].cal.start_ms = 0;
+            sensors[i].cal.count = 0;
+            sensors[i].cal.sum = 0;
             continue;
         }
         const uint32_t now = AP_HAL::millis();
-        if (sensors[i].cal_start_ms == 0) {
+        if (sensors[i].cal.start_ms == 0) {
             // first time seeing sensor healthy, start settling
-            sensors[i].cal_start_ms = now;
+            sensors[i].cal.start_ms = now;
             continue;
         }
         // collect samples after 1s settling, spaced 100ms apart
-        const uint32_t sample_time_ms = 1000 + (uint32_t)sensors[i].cal_count * 100;
-        if (now - sensors[i].cal_start_ms < sample_time_ms) {
+        const uint32_t sample_time_ms = 1000 + (uint32_t)sensors[i].cal.count * 100;
+        if (now - sensors[i].cal.start_ms < sample_time_ms) {
             continue;
         }
-        sensors[i].cal_sum += sensors[i].pressure;
-        sensors[i].cal_count++;
-        if (sensors[i].cal_count >= 5) {
-            const float avg = sensors[i].cal_sum / sensors[i].cal_count;
+        sensors[i].cal.sum += sensors[i].pressure;
+        sensors[i].cal.count++;
+        if (sensors[i].cal.count >= 5) {
+            const float avg = sensors[i].cal.sum / sensors[i].cal.count;
             const float p0_sealevel = get_sealevel_pressure(avg, _field_elevation_active);
             if (_cal_save) {
                 sensors[i].ground_pressure.set_and_save(p0_sealevel);

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -301,9 +301,11 @@ private:
         bool alt_ok;                    // true if calculated altitude is ok
         bool calibrated;                // true if calculated calibrated successfully
         // deferred calibration state for sensors not ready during init
-        uint32_t cal_start_ms;          // when sensor first seen healthy (0=not started)
-        float cal_sum;                  // accumulated pressure during sampling
-        uint8_t cal_count;              // number of calibration samples collected
+        struct {
+            uint32_t start_ms;          // when sensor first seen healthy (0=not started)
+            float sum;                  // accumulated pressure during sampling
+            uint8_t count;              // number of samples collected
+        } cal;
         AP_Int32 bus_id;
 #if HAL_BARO_WIND_COMP_ENABLED
         WindCoeff wind_coeff;

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -300,6 +300,10 @@ private:
         bool healthy;                   // true if sensor is healthy
         bool alt_ok;                    // true if calculated altitude is ok
         bool calibrated;                // true if calculated calibrated successfully
+        // deferred calibration state for sensors not ready during init
+        uint32_t cal_start_ms;          // when sensor first seen healthy (0=not started)
+        float cal_sum;                  // accumulated pressure during sampling
+        uint8_t cal_count;              // number of calibration samples collected
         AP_Int32 bus_id;
 #if HAL_BARO_WIND_COMP_ENABLED
         WindCoeff wind_coeff;
@@ -358,6 +362,9 @@ private:
 #endif
 
     AP_Int16                           _options;
+
+    // whether calibrate() was called with save=true
+    bool                               _cal_save;
 
     // semaphore for API access from threads
     HAL_Semaphore                      _rsem;

--- a/libraries/AP_Baro/AP_Baro_SITL.cpp
+++ b/libraries/AP_Baro/AP_Baro_SITL.cpp
@@ -57,12 +57,12 @@ void AP_Baro_SITL::_timer()
     if ((now - _last_sample_time) < 10) {
         return;
     }
-    _last_sample_time = now;
 
     float sim_alt = _sitl->state.altitude;
 
     if (_sitl->baro[_instance].disable) {
         // barometer is disabled
+        _last_sample_time = now;
         return;
     }
 
@@ -71,6 +71,8 @@ void AP_Baro_SITL::_timer()
     if (start_delay_s > 0 && now < (uint32_t)(start_delay_s * 1000)) {
         return;
     }
+
+    _last_sample_time = now;
 
     const auto drift_delta_t_ms = now - last_drift_delta_t_ms;
     last_drift_delta_t_ms = now;

--- a/libraries/AP_Baro/AP_Baro_SITL.cpp
+++ b/libraries/AP_Baro/AP_Baro_SITL.cpp
@@ -66,6 +66,12 @@ void AP_Baro_SITL::_timer()
         return;
     }
 
+    // simulate slow-starting sensor
+    const float start_delay_s = _sitl->baro[_instance].start_delay;
+    if (start_delay_s > 0 && now < (uint32_t)(start_delay_s * 1000)) {
+        return;
+    }
+
     const auto drift_delta_t_ms = now - last_drift_delta_t_ms;
     last_drift_delta_t_ms = now;
     total_alt_drift += _sitl->baro[_instance].drift * drift_delta_t_ms * 0.001f;

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -499,11 +499,11 @@ void AP_TECS::_update_speed_demand(void)
     // calculate velocity rate limits based on physical performance limits
     // provision to use a different rate limit if bad descent or underspeed condition exists
     // Use 50% of maximum energy rate on gain, 90% on dissipation to allow margin for total energy controller
-    const float velRateMax = 0.5f * _STEdot_max / _TAS_state;
+    const float velRateMax = 0.5f * _STEdot_max / MAX(_TAS_state, 0.1f);
     // Maximum permissible rate of deceleration value at max airspeed
-    const float velRateNegMax = 0.9f * _STEdot_neg_max / _TASmax;
+    const float velRateNegMax = 0.9f * _STEdot_neg_max / MAX(_TASmax, 0.1f);
     // Maximum permissible rate of deceleration value at cruise speed
-    const float velRateNegCruise = 0.9f * _STEdot_min / TAScruise;
+    const float velRateNegCruise = 0.9f * _STEdot_min / MAX(TAScruise, 0.1f);
     // Linear interpolation between velocity rate at cruise and max speeds, capped at those speeds
     const float velRateMin = linear_interpolate(velRateNegMax, velRateNegCruise, _TAS_state, _TASmax, TAScruise);
     const float TAS_dem_previous = _TAS_dem_adj;

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -276,6 +276,7 @@ public:
         AP_Int8  freeze; // freeze baro to last recorded altitude
         AP_Int8  disable; // disable simulated barometers
         AP_Int16 delay;  // barometer data delay in ms
+        AP_Float start_delay; // startup delay in seconds before sensor produces data
 
         // wind coefficients
         AP_Float wcof_xp;

--- a/libraries/SITL/SITL_Baro.cpp
+++ b/libraries/SITL/SITL_Baro.cpp
@@ -45,14 +45,6 @@ const AP_Param::GroupInfo SIM::BaroParm::var_info[] = {
     // @DisplayName: Wind coefficient forward
     // @Description: Barometer wind coefficient direction forward in SITL
     // @User: Advanced
-    // @Param: STRTDLY
-    // @DisplayName: Barometer startup delay
-    // @Description: Delay in seconds before barometer starts producing data. Simulates slow-starting sensors like external AHRS.
-    // @Units: s
-    // @Range: 0 30
-    // @User: Advanced
-    AP_GROUPINFO("STRTDLY", 13, SIM::BaroParm, start_delay, 0),
-
     AP_GROUPINFO("WCF_FWD", 7,  SIM::BaroParm, wcof_xp, 0.0),
     // @Param: WCF_BAK
     // @DisplayName: Wind coefficient backward
@@ -79,6 +71,15 @@ const AP_Param::GroupInfo SIM::BaroParm::var_info[] = {
     // @Description: Barometer wind coefficient direction down in SITL
     // @User: Advanced
     AP_GROUPINFO("WCF_DN",  12, SIM::BaroParm, wcof_zn, 0.0),
+
+    // @Param: STRTDLY
+    // @DisplayName: Barometer startup delay
+    // @Description: Delay in seconds before barometer starts producing data. Simulates slow-starting sensors like external AHRS.
+    // @Units: s
+    // @Range: 0 30
+    // @User: Advanced
+    AP_GROUPINFO("STRTDLY", 13, SIM::BaroParm, start_delay, 0),
+
     AP_GROUPEND
 };
 }

--- a/libraries/SITL/SITL_Baro.cpp
+++ b/libraries/SITL/SITL_Baro.cpp
@@ -45,6 +45,14 @@ const AP_Param::GroupInfo SIM::BaroParm::var_info[] = {
     // @DisplayName: Wind coefficient forward
     // @Description: Barometer wind coefficient direction forward in SITL
     // @User: Advanced
+    // @Param: STRTDLY
+    // @DisplayName: Barometer startup delay
+    // @Description: Delay in seconds before barometer starts producing data. Simulates slow-starting sensors like external AHRS.
+    // @Units: s
+    // @Range: 0 30
+    // @User: Advanced
+    AP_GROUPINFO("STRTDLY", 13, SIM::BaroParm, start_delay, 0),
+
     AP_GROUPINFO("WCF_FWD", 7,  SIM::BaroParm, wcof_xp, 0.0),
     // @Param: WCF_BAK
     // @DisplayName: Wind coefficient backward


### PR DESCRIPTION
  - External AHRS like CRSF may take time to establish communication (baud negotiation can take 1.5+ seconds, then baro frames at ~10Hz)
  - Adds special handling for external AHRS baro calibration:
    - Wait up to 15 seconds for AHRS to initialize and baro to become healthy
    - Be tolerant of occasional missed readings during calibration
    - Only warn (don't halt) if EAHRS baro fails to calibrate
  - Internal baro sensors retain the strict original behavior