### PR TITLE
AP_HAL: increase max notch filters for Linux boards

### DIFF
--- a/libraries/AP_HAL/AP_HAL_Boards.h
+++ b/libraries/AP_HAL/AP_HAL_Boards.h
@@ -329,7 +329,7 @@
 // On an F7 The difference in CPU load between 1 notch and 24 notches is about 2%
 // The difference in CPU load between 1Khz backend and 2Khz backend is about 10%
 // So at 1Khz almost all notch combinations can be supported on F7 and certainly H7
-#if defined(STM32H7) || CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#if defined(STM32H7) || CONFIG_HAL_BOARD == HAL_BOARD_SITL || CONFIG_HAL_BOARD == HAL_BOARD_LINUX
 // Enough for a double-notch per motor on an octa using three IMUs and one harmonics
 // plus one static notch with one double-notch harmonics
 #define HAL_HNF_MAX_FILTERS 54


### PR DESCRIPTION
Linux boards have plenty of CPU headroom, so increase HAL_HNF_MAX_FILTERS from 24 to 54 (same as H7 and SITL).

This allows more complex notch filter configurations on platforms like Raspberry Pi.