### PR TITLE
AP_RangeFinder: add RECV_ID parameter to DroneCAN backend

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -20085,13 +20085,19 @@ return update, 1000
             )
             return int(re.match(r".*node (\d+) addr", text).group(1))
 
-        def assert_distance_sensor_ids(want_ids):
-            self.context_collect('DISTANCE_SENSOR')
-            self.delay_sim_time(2, reason="collect rangefinder output")
-            got_ids = set(m.id for m in self.context_stop_collecting('DISTANCE_SENSOR'))
-            if got_ids != want_ids:
-                raise NotAchievedException(
-                    "DISTANCE_SENSOR ids mismatch (want=%s got=%s)" % (sorted(want_ids), sorted(got_ids)))
+        def assert_distance_sensor_ids(want_ids, absent_ids=()):
+            for want in want_ids:
+                self.assert_receive_message(
+                    'DISTANCE_SENSOR',
+                    timeout=10,
+                    condition="DISTANCE_SENSOR.id==%u" % want,
+                )
+            for absent in absent_ids:
+                self.assert_not_receive_message(
+                    'DISTANCE_SENSOR',
+                    timeout=2,
+                    condition="DISTANCE_SENSOR.id==%u" % absent,
+                )
 
         # both periphs report sensor_id 0, so each instance takes the
         # first node it hears from
@@ -20120,8 +20126,9 @@ return update, 1000
 
         self.start_subtest("RECV_ID for an absent node starves the instance")
         self.set_parameter("RNGFND2_RECV_ID", 100)
-        self.delay_sim_time(2, reason="instance to time out")
-        assert_distance_sensor_ids({0})
+        # the instance drops to NoData 500ms after its last measurement
+        self.delay_sim_time(1, reason="instance to time out")
+        assert_distance_sensor_ids({0}, absent_ids={1})
 
     def testcan(self):
         ret = ([

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -20064,9 +20064,69 @@ return update, 1000
             # post-test reboot_sitl() location check passes
             self.customise_SITL_commandline([])
 
+    def DroneCANRangeFinderRecvID(self):
+        '''assign DroneCAN rangefinders reporting the same sensor ID to instances via RNGFNDx_RECV_ID'''
+        self.set_parameters({
+            "CAN_P1_DRIVER": 1,
+            "RNGFND1_TYPE": 24,
+            "RNGFND1_MAX": 110.00,
+            "RNGFND2_TYPE": 24,
+            "RNGFND2_MAX": 110.00,
+        })
+        self.context_collect('STATUSTEXT')
+        self.reboot_sitl()
+
+        def wait_bound_node(instance, timeout=30):
+            text = self.wait_text(
+                r"RangeFinder\[%u\]: added DroneCAN node (\d+) addr 0" % instance,
+                regex=True,
+                check_context=True,
+                timeout=timeout,
+            )
+            return int(re.match(r".*node (\d+) addr", text).group(1))
+
+        def assert_distance_sensor_ids(want_ids):
+            self.context_collect('DISTANCE_SENSOR')
+            self.delay_sim_time(2, reason="collect rangefinder output")
+            got_ids = set(m.id for m in self.context_stop_collecting('DISTANCE_SENSOR'))
+            if got_ids != want_ids:
+                raise NotAchievedException(
+                    "DISTANCE_SENSOR ids mismatch (want=%s got=%s)" % (sorted(want_ids), sorted(got_ids)))
+
+        # both periphs report sensor_id 0, so each instance takes the
+        # first node it hears from
+        node_a = wait_bound_node(0)
+        node_b = wait_bound_node(1)
+        if node_a == node_b:
+            raise NotAchievedException("Both instances bound to node %u" % node_a)
+        assert_distance_sensor_ids({0, 1})
+
+        self.start_subtest("Swap instances at runtime using RECV_ID")
+        self.context_clear_collection('STATUSTEXT')
+        self.set_parameters({
+            "RNGFND1_RECV_ID": node_b,
+            "RNGFND2_RECV_ID": node_a,
+        })
+        if wait_bound_node(0) != node_b or wait_bound_node(1) != node_a:
+            raise NotAchievedException("RECV_ID not honoured at runtime")
+        assert_distance_sensor_ids({0, 1})
+
+        self.start_subtest("RECV_ID persists across reboot")
+        self.context_clear_collection('STATUSTEXT')
+        self.reboot_sitl()
+        if wait_bound_node(0) != node_b or wait_bound_node(1) != node_a:
+            raise NotAchievedException("RECV_ID not honoured after reboot")
+        assert_distance_sensor_ids({0, 1})
+
+        self.start_subtest("RECV_ID for an absent node starves the instance")
+        self.set_parameter("RNGFND2_RECV_ID", 100)
+        self.delay_sim_time(2, reason="instance to time out")
+        assert_distance_sensor_ids({0})
+
     def testcan(self):
         ret = ([
             self.CANGPSCopterMission,
+            self.DroneCANRangeFinderRecvID,
             self.TestLogDownloadMAVProxyCAN,
         ])
         return ret

--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -224,15 +224,7 @@ __INITFUNC__ void RangeFinder::init(enum Rotation orientation_default)
     for (uint8_t i=0, serial_instance = 0; i<RANGEFINDER_MAX_INSTANCES; i++) {
         // serial_instance will be increased inside detect_instance
         // if a serial driver is loaded for this instance
-        WITH_SEMAPHORE(detect_sem);
         detect_instance(i, serial_instance);
-        if (drivers[i] != nullptr) {
-            // we loaded a driver for this instance, so it must be
-            // present (although it may not be healthy). We use MAX()
-            // here as a UAVCAN rangefinder may already have been
-            // found
-            num_instances = MAX(num_instances, i+1);
-        }
 
         // initialise status
         state[i].status = Status::NotConnected;
@@ -527,12 +519,7 @@ __INITFUNC__ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial
 
 #if AP_RANGEFINDER_DRONECAN_ENABLED
     case Type::UAVCAN:
-        /*
-          the UAVCAN driver gets created when we first receive a
-          measurement. We take the instance slot now, even if we don't
-          yet have the driver
-         */
-        num_instances = MAX(num_instances, instance+1);
+        _add_backend(NEW_NOTHROW AP_RangeFinder_DroneCAN(state[instance], params[instance]), instance);
         break;
 #endif
 
@@ -724,26 +711,7 @@ void RangeFinder::handle_msp(const MSP::msp_rangefinder_data_message_t &pkt)
 // return true if we have a range finder with the specified orientation
 bool RangeFinder::has_orientation(enum Rotation orientation) const
 {
-    if ((find_instance(orientation) != nullptr)) {
-        // we have a rangefinder with this orientation
-        return true;
-    }
-
-    // special case for DroneCAN
-    // DroneCAN rangefinder backend is not created until we receive a
-    // measurement, so we need to check the params directly
-#if AP_RANGEFINDER_DRONECAN_ENABLED
-     for (uint8_t i = 0; i < RANGEFINDER_MAX_INSTANCES; i++) {
-        if ((RangeFinder::Type)params[i].type.get() == RangeFinder::Type::UAVCAN) {
-            if (params[i].orientation.get() == orientation) {
-                return true;
-            }
-        }
-    }
-#endif
-
-    // no rangefinder with this orientation
-    return false;
+    return find_instance(orientation) != nullptr;
 }
 
 // find first range finder instance with the specified orientation

--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -84,7 +84,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
 	AP_SUBGROUPINFO(params[0], "1_", 25, RangeFinder, AP_RangeFinder_Params),
 
     // @Group: 1_
-    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Backend_CAN.cpp,AP_RangeFinder_LightWare_GRF.cpp,AP_RangeFinder_LightWare_GRF_I2C.cpp
+    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Backend_CAN.cpp,AP_RangeFinder_LightWare_GRF.cpp,AP_RangeFinder_LightWare_GRF_I2C.cpp,AP_RangeFinder_DroneCAN.cpp
     AP_SUBGROUPVARPTR(drivers[0], "1_",  57, RangeFinder, backend_var_info[0]),
 
 #if RANGEFINDER_MAX_INSTANCES > 1
@@ -93,7 +93,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     AP_SUBGROUPINFO(params[1], "2_", 27, RangeFinder, AP_RangeFinder_Params),
 
     // @Group: 2_
-    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Backend_CAN.cpp,AP_RangeFinder_LightWare_GRF.cpp,AP_RangeFinder_LightWare_GRF_I2C.cpp
+    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Backend_CAN.cpp,AP_RangeFinder_LightWare_GRF.cpp,AP_RangeFinder_LightWare_GRF_I2C.cpp,AP_RangeFinder_DroneCAN.cpp
     AP_SUBGROUPVARPTR(drivers[1], "2_",  58, RangeFinder, backend_var_info[1]),
 #endif
 
@@ -103,7 +103,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     AP_SUBGROUPINFO(params[2], "3_", 29, RangeFinder, AP_RangeFinder_Params),
 
     // @Group: 3_
-    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Backend_CAN.cpp,AP_RangeFinder_LightWare_GRF.cpp,AP_RangeFinder_LightWare_GRF_I2C.cpp
+    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Backend_CAN.cpp,AP_RangeFinder_LightWare_GRF.cpp,AP_RangeFinder_LightWare_GRF_I2C.cpp,AP_RangeFinder_DroneCAN.cpp
     AP_SUBGROUPVARPTR(drivers[2], "3_",  59, RangeFinder, backend_var_info[2]),
 #endif
 
@@ -113,7 +113,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     AP_SUBGROUPINFO(params[3], "4_", 31, RangeFinder, AP_RangeFinder_Params),
 
     // @Group: 4_
-    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Backend_CAN.cpp,AP_RangeFinder_LightWare_GRF.cpp,AP_RangeFinder_LightWare_GRF_I2C.cpp
+    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Backend_CAN.cpp,AP_RangeFinder_LightWare_GRF.cpp,AP_RangeFinder_LightWare_GRF_I2C.cpp,AP_RangeFinder_DroneCAN.cpp
     AP_SUBGROUPVARPTR(drivers[3], "4_",  60, RangeFinder, backend_var_info[3]),
 #endif
 
@@ -123,7 +123,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     AP_SUBGROUPINFO(params[4], "5_", 33, RangeFinder, AP_RangeFinder_Params),
 
     // @Group: 5_
-    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Backend_CAN.cpp,AP_RangeFinder_LightWare_GRF.cpp,AP_RangeFinder_LightWare_GRF_I2C.cpp
+    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Backend_CAN.cpp,AP_RangeFinder_LightWare_GRF.cpp,AP_RangeFinder_LightWare_GRF_I2C.cpp,AP_RangeFinder_DroneCAN.cpp
     AP_SUBGROUPVARPTR(drivers[4], "5_",  34, RangeFinder, backend_var_info[4]),
 #endif
 
@@ -133,7 +133,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     AP_SUBGROUPINFO(params[5], "6_", 35, RangeFinder, AP_RangeFinder_Params),
 
     // @Group: 6_
-    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Backend_CAN.cpp,AP_RangeFinder_LightWare_GRF.cpp,AP_RangeFinder_LightWare_GRF_I2C.cpp
+    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Backend_CAN.cpp,AP_RangeFinder_LightWare_GRF.cpp,AP_RangeFinder_LightWare_GRF_I2C.cpp,AP_RangeFinder_DroneCAN.cpp
     AP_SUBGROUPVARPTR(drivers[5], "6_",  36, RangeFinder, backend_var_info[5]),
 #endif
 
@@ -143,7 +143,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     AP_SUBGROUPINFO(params[6], "7_", 37, RangeFinder, AP_RangeFinder_Params),
 
     // @Group: 7_
-    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Backend_CAN.cpp,AP_RangeFinder_LightWare_GRF.cpp,AP_RangeFinder_LightWare_GRF_I2C.cpp
+    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Backend_CAN.cpp,AP_RangeFinder_LightWare_GRF.cpp,AP_RangeFinder_LightWare_GRF_I2C.cpp,AP_RangeFinder_DroneCAN.cpp
     AP_SUBGROUPVARPTR(drivers[6], "7_",  38, RangeFinder, backend_var_info[6]),
 #endif
 
@@ -153,7 +153,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     AP_SUBGROUPINFO(params[7], "8_", 39, RangeFinder, AP_RangeFinder_Params),
 
     // @Group: 8_
-    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Backend_CAN.cpp,AP_RangeFinder_LightWare_GRF.cpp,AP_RangeFinder_LightWare_GRF_I2C.cpp
+    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Backend_CAN.cpp,AP_RangeFinder_LightWare_GRF.cpp,AP_RangeFinder_LightWare_GRF_I2C.cpp,AP_RangeFinder_DroneCAN.cpp
     AP_SUBGROUPVARPTR(drivers[7], "8_",  40, RangeFinder, backend_var_info[7]),
 #endif
 
@@ -163,7 +163,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     AP_SUBGROUPINFO(params[8], "9_", 41, RangeFinder, AP_RangeFinder_Params),
 
     // @Group: 9_
-    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Backend_CAN.cpp,AP_RangeFinder_LightWare_GRF.cpp,AP_RangeFinder_LightWare_GRF_I2C.cpp
+    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Backend_CAN.cpp,AP_RangeFinder_LightWare_GRF.cpp,AP_RangeFinder_LightWare_GRF_I2C.cpp,AP_RangeFinder_DroneCAN.cpp
     AP_SUBGROUPVARPTR(drivers[8], "9_",  42, RangeFinder, backend_var_info[8]),
 #endif
 
@@ -173,7 +173,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] = {
     AP_SUBGROUPINFO(params[9], "A_", 43, RangeFinder, AP_RangeFinder_Params),
 
     // @Group: A_
-    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Backend_CAN.cpp,AP_RangeFinder_LightWare_GRF.cpp,AP_RangeFinder_LightWare_GRF_I2C.cpp
+    // @Path: AP_RangeFinder_Wasp.cpp,AP_RangeFinder_Backend_CAN.cpp,AP_RangeFinder_LightWare_GRF.cpp,AP_RangeFinder_LightWare_GRF_I2C.cpp,AP_RangeFinder_DroneCAN.cpp
     AP_SUBGROUPVARPTR(drivers[9], "A_",  44, RangeFinder, backend_var_info[9]),
 #endif
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -236,6 +236,7 @@ __INITFUNC__ void RangeFinder::init(enum Rotation orientation_default)
         state[i].temperature_update_ms = 0;
 #endif
     }
+    init_done = true;
 }
 
 /*

--- a/libraries/AP_RangeFinder/AP_RangeFinder.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.h
@@ -49,7 +49,7 @@ class AP_RangeFinder_Backend;
 class RangeFinder
 {
     friend class AP_RangeFinder_Backend;
-    //UAVCAN drivers are initialised in the Backend, hence list of drivers is needed there.
+    // the DroneCAN backend looks up instances by node ID and sensor ID on each message
     friend class AP_RangeFinder_DroneCAN;
 public:
     RangeFinder();
@@ -351,7 +351,6 @@ private:
     RangeFinder_State state[RANGEFINDER_MAX_INSTANCES];
     AP_RangeFinder_Backend *drivers[RANGEFINDER_MAX_INSTANCES];
     uint8_t num_instances;
-    HAL_Semaphore detect_sem;
     float estimated_terrain_height;
     Vector3f pos_offset_zero;   // allows returning position offsets of zero for invalid requests
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.h
@@ -351,6 +351,7 @@ private:
     RangeFinder_State state[RANGEFINDER_MAX_INSTANCES];
     AP_RangeFinder_Backend *drivers[RANGEFINDER_MAX_INSTANCES];
     uint8_t num_instances;
+    bool init_done;
     float estimated_terrain_height;
     Vector3f pos_offset_zero;   // allows returning position offsets of zero for invalid requests
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_DroneCAN.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_DroneCAN.cpp
@@ -63,6 +63,11 @@ AP_RangeFinder_DroneCAN* AP_RangeFinder_DroneCAN::get_dronecan_backend(AP_DroneC
         return nullptr;
     }
     RangeFinder &frontend = *AP::rangefinder();
+    if (!frontend.init_done) {
+        // drivers[] is visible before the backend's saved RECV_ID is
+        // loaded; don't bind on the default
+        return nullptr;
+    }
     WITH_SEMAPHORE(_bind_sem);
 
     int8_t configured = -1;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_DroneCAN.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_DroneCAN.cpp
@@ -16,7 +16,7 @@ const AP_Param::GroupInfo AP_RangeFinder_DroneCAN::var_info[] = {
 
     // @Param: RECV_ID
     // @DisplayName: RangeFinder DroneCAN node ID
-    // @Description: DroneCAN node ID of the sensor to accept measurements from. Zero accepts the first node seen reporting the sensor ID set in ADDR.
+    // @Description: DroneCAN node ID of the sensor to accept measurements from. Zero accepts the first node seen reporting the sensor ID set in ADDR. Node IDs are only unique within one CAN network, so the node must not share its ID with a node on another DroneCAN network. Each instance needs a different node ID; a second instance with the same value never receives data.
     // @Range: 0 127
     // @User: Advanced
     AP_GROUPINFO("RECV_ID", 10, AP_RangeFinder_DroneCAN, receive_node_id, 0),

--- a/libraries/AP_RangeFinder/AP_RangeFinder_DroneCAN.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_DroneCAN.cpp
@@ -24,6 +24,8 @@ const AP_Param::GroupInfo AP_RangeFinder_DroneCAN::var_info[] = {
     AP_GROUPEND
 };
 
+HAL_Semaphore AP_RangeFinder_DroneCAN::_bind_sem;
+
 AP_RangeFinder_DroneCAN::AP_RangeFinder_DroneCAN(RangeFinder::RangeFinder_State &_state, AP_RangeFinder_Params &_params) :
     AP_RangeFinder_Backend(_state, _params)
 {
@@ -61,6 +63,7 @@ AP_RangeFinder_DroneCAN* AP_RangeFinder_DroneCAN::get_dronecan_backend(AP_DroneC
         return nullptr;
     }
     RangeFinder &frontend = *AP::rangefinder();
+    WITH_SEMAPHORE(_bind_sem);
 
     int8_t configured = -1;
     int8_t bound = -1;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_DroneCAN.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_DroneCAN.cpp
@@ -12,6 +12,25 @@ extern const AP_HAL::HAL& hal;
 
 #define debug_range_finder_uavcan(level_debug, can_driver, fmt, args...) do { if ((level_debug) <= AP::can().get_debug_level_driver(can_driver)) { hal.console->printf(fmt, ##args); }} while (0)
 
+const AP_Param::GroupInfo AP_RangeFinder_DroneCAN::var_info[] = {
+
+    // @Param: RECV_ID
+    // @DisplayName: RangeFinder DroneCAN node ID
+    // @Description: DroneCAN node ID of the sensor to accept measurements from. Zero accepts the first node seen reporting the sensor ID set in ADDR.
+    // @Range: 0 127
+    // @User: Advanced
+    AP_GROUPINFO("RECV_ID", 10, AP_RangeFinder_DroneCAN, receive_node_id, 0),
+
+    AP_GROUPEND
+};
+
+AP_RangeFinder_DroneCAN::AP_RangeFinder_DroneCAN(RangeFinder::RangeFinder_State &_state, AP_RangeFinder_Params &_params) :
+    AP_RangeFinder_Backend(_state, _params)
+{
+    AP_Param::setup_object_defaults(this, var_info);
+    state.var_info = var_info;
+}
+
 //links the rangefinder uavcan message to this backend
 bool AP_RangeFinder_DroneCAN::subscribe_msgs(AP_DroneCAN* ap_dronecan)
 {
@@ -20,39 +39,67 @@ bool AP_RangeFinder_DroneCAN::subscribe_msgs(AP_DroneCAN* ap_dronecan)
     return (Canard::allocate_sub_arg_callback(ap_dronecan, &handle_measurement, driver_index) != nullptr);
 }
 
-// find the backend bound to node_id and sensor_id, binding an unused
-// instance with a matching ADDR on first contact. An instance stays
-// bound so that two sensors reporting the same sensor_id cannot both
-// feed it.
+void AP_RangeFinder_DroneCAN::bind(AP_DroneCAN *ap_dronecan, uint8_t node_id, uint8_t instance)
+{
+    if (bound_to(ap_dronecan, node_id)) {
+        return;
+    }
+    _ap_dronecan = ap_dronecan;
+    _node_id = node_id;
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "RangeFinder[%u]: added DroneCAN node %u addr %u",
+                  unsigned(instance), unsigned(node_id), unsigned(params.address.get()));
+}
+
+// find the backend for a measurement from node_id with sensor_id. An
+// instance with RECV_ID set to node_id takes precedence; otherwise the
+// instance already bound to node_id, or the first unbound instance
+// accepting any node, is used. An instance stays bound to its node so
+// two sensors reporting the same sensor_id cannot both feed it.
 AP_RangeFinder_DroneCAN* AP_RangeFinder_DroneCAN::get_dronecan_backend(AP_DroneCAN* ap_dronecan, uint8_t node_id, uint8_t sensor_id)
 {
     if (ap_dronecan == nullptr) {
         return nullptr;
     }
     RangeFinder &frontend = *AP::rangefinder();
+
+    int8_t configured = -1;
+    int8_t bound = -1;
+    int8_t unbound = -1;
     for (uint8_t i = 0; i < RANGEFINDER_MAX_INSTANCES; i++) {
         if ((RangeFinder::Type)frontend.params[i].type.get() != RangeFinder::Type::UAVCAN ||
             frontend.params[i].address != sensor_id) {
             continue;
         }
-        auto *driver = (AP_RangeFinder_DroneCAN*)frontend.drivers[i];
+        const auto *driver = (AP_RangeFinder_DroneCAN*)frontend.drivers[i];
         if (driver == nullptr || driver->_backend_type != RangeFinder::Type::UAVCAN) {
             continue;
         }
-        if (driver->_ap_dronecan == ap_dronecan && driver->_node_id == node_id) {
-            return driver;
+        if (driver->receive_node_id != 0) {
+            if (driver->receive_node_id == node_id && configured < 0) {
+                configured = i;
+            }
+        } else if (driver->_ap_dronecan == nullptr) {
+            if (unbound < 0) {
+                unbound = i;
+            }
+        } else if (driver->bound_to(ap_dronecan, node_id)) {
+            bound = i;
         }
-        if (driver->_ap_dronecan != nullptr) {
-            // bound to another sensor with the same sensor_id
-            continue;
-        }
-        driver->_ap_dronecan = ap_dronecan;
-        driver->_node_id = node_id;
-        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "RangeFinder[%u]: added DroneCAN node %u addr %u",
-                      unsigned(i), unsigned(node_id), unsigned(sensor_id));
-        return driver;
     }
-    return nullptr;
+
+    if (configured >= 0 && bound >= 0) {
+        // RECV_ID was set at runtime to a node another instance had
+        // already taken; release that instance for another node
+        ((AP_RangeFinder_DroneCAN*)frontend.drivers[bound])->_ap_dronecan = nullptr;
+        bound = -1;
+    }
+    const int8_t selected = configured >= 0 ? configured : (bound >= 0 ? bound : unbound);
+    if (selected < 0) {
+        return nullptr;
+    }
+    auto *driver = (AP_RangeFinder_DroneCAN*)frontend.drivers[selected];
+    driver->bind(ap_dronecan, node_id, selected);
+    return driver;
 }
 
 //Called from frontend to update with the readings received by handler

--- a/libraries/AP_RangeFinder/AP_RangeFinder_DroneCAN.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_DroneCAN.cpp
@@ -20,61 +20,39 @@ bool AP_RangeFinder_DroneCAN::subscribe_msgs(AP_DroneCAN* ap_dronecan)
     return (Canard::allocate_sub_arg_callback(ap_dronecan, &handle_measurement, driver_index) != nullptr);
 }
 
-//Method to find the backend relating to the node id
-AP_RangeFinder_DroneCAN* AP_RangeFinder_DroneCAN::get_dronecan_backend(AP_DroneCAN* ap_dronecan, uint8_t node_id, uint8_t address, bool create_new)
+// find the backend bound to node_id and sensor_id, binding an unused
+// instance with a matching ADDR on first contact. An instance stays
+// bound so that two sensors reporting the same sensor_id cannot both
+// feed it.
+AP_RangeFinder_DroneCAN* AP_RangeFinder_DroneCAN::get_dronecan_backend(AP_DroneCAN* ap_dronecan, uint8_t node_id, uint8_t sensor_id)
 {
     if (ap_dronecan == nullptr) {
         return nullptr;
     }
-    AP_RangeFinder_DroneCAN* driver = nullptr;
     RangeFinder &frontend = *AP::rangefinder();
-    //Scan through the Rangefinder params to find UAVCAN RFND with matching address.
     for (uint8_t i = 0; i < RANGEFINDER_MAX_INSTANCES; i++) {
-        if ((RangeFinder::Type)frontend.params[i].type.get() == RangeFinder::Type::UAVCAN &&
-            frontend.params[i].address == address) {
-            driver = (AP_RangeFinder_DroneCAN*)frontend.drivers[i];
+        if ((RangeFinder::Type)frontend.params[i].type.get() != RangeFinder::Type::UAVCAN ||
+            frontend.params[i].address != sensor_id) {
+            continue;
         }
-        //Double check if the driver was initialised as UAVCAN Type
-        if (driver != nullptr && (driver->_backend_type == RangeFinder::Type::UAVCAN)) {
-            if (driver->_ap_dronecan == ap_dronecan && 
-                driver->_node_id == node_id) {
-                return driver;
-            } else {
-                //we found a possible duplicate addressed sensor
-                //we return nothing in such scenario
-                return nullptr;
-            }
+        auto *driver = (AP_RangeFinder_DroneCAN*)frontend.drivers[i];
+        if (driver == nullptr || driver->_backend_type != RangeFinder::Type::UAVCAN) {
+            continue;
         }
+        if (driver->_ap_dronecan == ap_dronecan && driver->_node_id == node_id) {
+            return driver;
+        }
+        if (driver->_ap_dronecan != nullptr) {
+            // bound to another sensor with the same sensor_id
+            continue;
+        }
+        driver->_ap_dronecan = ap_dronecan;
+        driver->_node_id = node_id;
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "RangeFinder[%u]: added DroneCAN node %u addr %u",
+                      unsigned(i), unsigned(node_id), unsigned(sensor_id));
+        return driver;
     }
-    
-    if (create_new) {
-        for (uint8_t i = 0; i < RANGEFINDER_MAX_INSTANCES; i++) {
-            if ((RangeFinder::Type)frontend.params[i].type.get() == RangeFinder::Type::UAVCAN &&
-                frontend.params[i].address == address) {
-                WITH_SEMAPHORE(frontend.detect_sem);
-                if (frontend.drivers[i] != nullptr) {
-                    //we probably initialised this driver as something else, reboot is required for setting
-                    //it up as UAVCAN type
-                    return nullptr;
-                }
-                frontend.drivers[i] = NEW_NOTHROW AP_RangeFinder_DroneCAN(frontend.state[i], frontend.params[i]);
-                driver = (AP_RangeFinder_DroneCAN*)frontend.drivers[i];
-                if (driver == nullptr) {
-                    break;
-                }
-                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "RangeFinder[%u]: added DroneCAN node %u addr %u",
-                                unsigned(i), unsigned(node_id), unsigned(address));
-                //Assign node id and respective uavcan driver, for identification
-                if (driver->_ap_dronecan == nullptr) {
-                    driver->_ap_dronecan = ap_dronecan;
-                    driver->_node_id = node_id;
-                    break;
-                }
-            }
-        }
-    }
-
-    return driver;
+    return nullptr;
 }
 
 //Called from frontend to update with the readings received by handler
@@ -109,7 +87,7 @@ void AP_RangeFinder_DroneCAN::update()
 void AP_RangeFinder_DroneCAN::handle_measurement(AP_DroneCAN *ap_dronecan, const CanardRxTransfer& transfer, const uavcan_equipment_range_sensor_Measurement &msg)
 {
     //fetch the matching uavcan driver, node id and sensor id backend instance
-    AP_RangeFinder_DroneCAN* driver = get_dronecan_backend(ap_dronecan, transfer.source_node_id, msg.sensor_id, true);
+    AP_RangeFinder_DroneCAN* driver = get_dronecan_backend(ap_dronecan, transfer.source_node_id, msg.sensor_id);
     if (driver == nullptr) {
         return;
     }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_DroneCAN.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_DroneCAN.h
@@ -17,8 +17,7 @@ public:
     void update() override;
 
     static bool subscribe_msgs(AP_DroneCAN* ap_dronecan);
-    static AP_RangeFinder_DroneCAN* get_dronecan_backend(AP_DroneCAN* ap_dronecan, uint8_t node_id, uint8_t address, bool create_new);
-    static AP_RangeFinder_Backend* detect(RangeFinder::RangeFinder_State &_state, AP_RangeFinder_Params &_params);
+    static AP_RangeFinder_DroneCAN* get_dronecan_backend(AP_DroneCAN* ap_dronecan, uint8_t node_id, uint8_t sensor_id);
 
     static void handle_measurement(AP_DroneCAN *ap_dronecan, const CanardRxTransfer& transfer, const uavcan_equipment_range_sensor_Measurement &msg);
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_DroneCAN.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_DroneCAN.h
@@ -39,6 +39,9 @@ private:
 
     AP_Int8 receive_node_id;  // only accept measurements from this node; 0 for any
 
+    // binding state is read and written from every AP_DroneCAN thread
+    static HAL_Semaphore _bind_sem;
+
     void bind(AP_DroneCAN *ap_dronecan, uint8_t node_id, uint8_t instance);
     bool bound_to(const AP_DroneCAN *ap_dronecan, uint8_t node_id) const {
         return _ap_dronecan == ap_dronecan && _node_id == node_id;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_DroneCAN.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_DroneCAN.h
@@ -11,8 +11,7 @@ class MeasurementCb;
 
 class AP_RangeFinder_DroneCAN : public AP_RangeFinder_Backend {
 public:
-    //constructor - registers instance at top RangeFinder driver
-    using AP_RangeFinder_Backend::AP_RangeFinder_Backend;
+    AP_RangeFinder_DroneCAN(RangeFinder::RangeFinder_State &_state, AP_RangeFinder_Params &_params);
 
     void update() override;
 
@@ -20,6 +19,8 @@ public:
     static AP_RangeFinder_DroneCAN* get_dronecan_backend(AP_DroneCAN* ap_dronecan, uint8_t node_id, uint8_t sensor_id);
 
     static void handle_measurement(AP_DroneCAN *ap_dronecan, const CanardRxTransfer& transfer, const uavcan_equipment_range_sensor_Measurement &msg);
+
+    static const struct AP_Param::GroupInfo var_info[];
 
 protected:
     virtual MAV_DISTANCE_SENSOR _get_mav_distance_sensor_type() const override {
@@ -35,5 +36,12 @@ private:
     uint8_t _node_id;
     bool new_data;
     MAV_DISTANCE_SENSOR _sensor_type;
+
+    AP_Int8 receive_node_id;  // only accept measurements from this node; 0 for any
+
+    void bind(AP_DroneCAN *ap_dronecan, uint8_t node_id, uint8_t instance);
+    bool bound_to(const AP_DroneCAN *ap_dronecan, uint8_t node_id) const {
+        return _ap_dronecan == ap_dronecan && _node_id == node_id;
+    }
 };
 #endif  // AP_RANGEFINDER_DRONECAN_ENABLED


### PR DESCRIPTION
## Summary
Adds `RNGFNDx_RECV_ID` to the DroneCAN rangefinder backend so an instance can be pinned to a node ID. Multiple DroneCAN rangefinders reporting the same `sensor_id` (e.g. two AP_Periph nodes with the default `RNGFND1_ADDR`) could only be told apart by reconfiguring the sensors; the first node seen took the instance and the rest were dropped.

- The DroneCAN backend is now created in `detect_instance()` like every other backend instead of on first measurement from the CAN thread. That is what lets it carry a backend parameter through `backend_var_info` (the earlier revision never registered the parameter, so it was inert), and it removes `detect_sem` and the DroneCAN special case in `has_orientation()`.
- An instance with `RECV_ID` set takes precedence over instances accepting any node. The check runs on every measurement, so changing `RECV_ID` at runtime re-assigns nodes without a reboot.
- `RECV_ID = 0` keeps the previous behaviour: the first node reporting a matching `ADDR` binds the instance and stays bound.

## Testing
New autotest `test.CAN.DroneCANRangeFinderRecvID` uses the two `sitl_periph_universal` nodes already spawned for `test.CAN` (both report `sensor_id` 0): both instances bind and stream `DISTANCE_SENSOR`; `RECV_ID` swaps them at runtime; the assignment survives a reboot; pinning an instance to an absent node starves it. `test.CAN` passes locally (`CANGPSCopterMission` flaked once on a transient `GPS 1: not healthy` at arming, passes on re-run). CubeOrange builds.
