### PR TITLE
AP_Landing: Make DSTL message plane only

### DIFF
--- a/libraries/AP_Landing/LogStructure.h
+++ b/libraries/AP_Landing/LogStructure.h
@@ -9,6 +9,7 @@
 #if HAL_LANDING_DEEPSTALL_ENABLED
 
 // @LoggerMessage: DSTL
+// @Vehicles: Plane
 // @Description: Deepstall Landing data
 // @Field: TimeUS: Time since system startup
 // @Field: Stg: Deepstall landing stage


### PR DESCRIPTION
DSTL shouldn't show up in https://ardupilot.org/copter/docs/logmessages.html, it's only used by plane.