### PR TITLE
AP_HAL_ChibiOS: enable DroneCAN scripting for CubeOrangePlus

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrangePlus/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrangePlus/hwdef.dat
@@ -8,6 +8,9 @@ define SMPS_PWR
 
 include ../CubeOrange/hwdef.inc
 
+# Enable DroneCAN scripting bindings for Lua
+define HAL_ENABLE_DRONECAN_DRIVERS 1
+
 undef USB_STRING_PRODUCT
 undef USB_STRING_MANUFACTURER
 undef APJ_BOARD_ID


### PR DESCRIPTION
Adds HAL_ENABLE_DRONECAN_DRIVERS define to enable DroneCAN scripting bindings for Lua on CubeOrangePlus hardware. This allows Lua scripts to access DroneCAN functionality on this board.