### PR TITLE
AP_Logger: correct coverage compilation

### DIFF
--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -13,7 +13,6 @@
 #include <AP_Mission/AP_Mission.h>
 #include <AP_Logger/LogStructure.h>
 #include <AP_Vehicle/ModeReason.h>
-#include <AP_RCProtocol/AP_RCProtocol.h>
 
 #include <stdint.h>
 

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -18,6 +18,7 @@
 #include "AP_Logger_File.h"
 #include "AP_Logger_MAVLink.h"
 #include "LoggerMessageWriter.h"
+#include <AP_RCProtocol/AP_RCProtocol.h>
 
 extern const AP_HAL::HAL& hal;
 


### PR DESCRIPTION
Fixes:

```
[1103/1501] Compiling libraries/SITL/SIM_Parachute.cpp In file included from ../../libraries/AP_HAL/utility/sparse-endian.h:28,
                 from ../../libraries/AP_RCProtocol/AP_RCProtocol_Backend.h:24,
                 from ../../libraries/AP_RCProtocol/AP_RCProtocol.h:316,
                 from ../../libraries/AP_Logger/AP_Logger.h:16,
                 from ../../libraries/SITL/SIM_FlightAxis.cpp:33:
../../libraries/AP_Common/missing/byteswap.h:9:24: error: redefinition of ‘uint16_t __bswap_16(uint16_t)’
    9 | static inline uint16_t __bswap_16(uint16_t u)
      |                        ^~~~~~~~~~
compilation terminated due to -Wfatal-errors.

In file included from ../../libraries/AP_HAL/utility/sparse-endian.h:28,
                 from ../../libraries/AP_RCProtocol/AP_RCProtocol_Backend.h:24,
                 from ../../libraries/AP_RCProtocol/AP_RCProtocol.h:316,
                 from ../../libraries/AP_Logger/AP_Logger.h:16,
                 from ../../libraries/SITL/SIM_JSON.cpp:30:
../../libraries/AP_Common/missing/byteswap.h:9:24: error: redefinition of ‘uint16_t __bswap_16(uint16_t)’
    9 | static inline uint16_t __bswap_16(uint16_t u)
      |                        ^~~~~~~~~~
compilation terminated due to -Wfatal-errors.
```

Can be replicated with
`./Tools/autotest/autotest.py --debug --coverage build.unit_tests`

Introduced in https://github.com/ArduPilot/ardupilot/pull/31415 - that include really doesn't need to be in the header, originally the enumeration entry was protected with `#if`, I believe.
 