### PR TITLE
Tools: add AIS autotest for Rover

### DIFF
--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6010,6 +6010,30 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         if abs(m.distance - want_range) > 0.5:
             raise NotAchievedException("Expected %fm got %fm" % (want_range, m.distance))
 
+    def AIS(self):
+        '''Test AIS receiver'''
+        self.customise_SITL_commandline([
+            "--serial5=sim:AIS",
+        ])
+        self.set_parameters({
+            "SERIAL5_PROTOCOL": 40,
+            "SERIAL5_BAUD": 38,
+            "AIS_TYPE": 1,
+        })
+        self.reboot_sitl()
+
+        # Set SIM parameter after reboot when AIS sim is loaded
+        self.set_parameter("SIM_AIS_COUNT", 5)
+
+        self.delay_sim_time(10)
+
+        m = self.assert_receive_message('AIS_VESSEL', timeout=60)
+
+        if m.MMSI == 0:
+            raise NotAchievedException("Invalid MMSI")
+
+        self.progress("Received AIS vessel MMSI=%u" % m.MMSI)
+
     def DepthFinder(self):
         '''Test multiple depthfinders for boats'''
         # Setup rangefinders
@@ -7214,6 +7238,7 @@ return update()
             self.SetpointGlobalVel,
             self.AccelCal,
             self.RangeFinder,
+            self.AIS,
             self.AP_Proximity_MAV,
             self.EndMissionBehavior,
             self.FlashStorage,


### PR DESCRIPTION
adds basic autotest for AIS receiver
The test enables AIS simulation in SITL, generates simulated vessels, and verifies that AIS_VESSEL MAVLink messages are received with valid data.

tested locally and passes:

<img width="1409" height="397" alt="Screenshot from 2026-01-20 00-23-23" src="https://github.com/user-attachments/assets/a548b9b0-26b3-49f9-8aa3-80ea2b48178d" />


Fixes #31950