### PR TITLE
AP_Mission: instantly complete non-blocking DO_CMDs instead of at 10Hz

### DIFF
--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -2130,6 +2130,11 @@ bool AP_Mission::advance_current_nav_cmd(uint16_t starting_index)
                 _do_cmd = cmd;
                 _flags.do_cmd_loaded = true;
                 start_command(_do_cmd);
+                // run verify to check if it completes instantly
+                if (verify_command(_do_cmd)) {
+                    // mark _do_cmd as complete
+                    _flags.do_cmd_loaded = false;
+                }
             }
         }
         // move onto next command

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -91,6 +91,7 @@ function millis() end
 function micros() end
 
 -- receive mission command from running mission
+-- up to 5 items can be queued, if the queue is full further entries will be discarded
 ---@return uint32_t_ud|nil -- command start time milliseconds
 ---@return integer|nil -- command param 1
 ---@return number|nil -- command param 2


### PR DESCRIPTION
AP_Mission: instantly complete non-blocking DO_CMDs instead of at 10Hz. I added a timestamp to the AP_MISSION change announcement (not part of this PR) to show delta time starting at mission index=2 so it's synced up for the comparison

if there are multiple DO commands they sort of get assync queued by running as a different index that runs at 10Hz while the nav_index blocks. However, when nav_index increments it it will start a d0_cmd but if there's two then the second one will not "start" until after the next nav command runs, no matter how many do_cmd's there are on the way there


All DO_CMD's complete instantly except for the _CONDITION ones but they *can* return instantly if the condition is already met.

<img width="697" height="501" alt="image" src="https://github.com/user-attachments/assets/1ee65e94-d24b-4c2e-b8d2-21dddcad2019" />
