### PR TITLE
AP_AHRS: Move velocity results into backend results structure

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -1620,7 +1620,7 @@ bool AP_AHRS::get_vert_pos_rate_D(float &velocity) const
     switch (active_EKF_type()) {
 #if AP_AHRS_DCM_ENABLED
     case EKFType::DCM:
-        return dcm.get_vert_pos_rate_D(velocity);
+        return dcm_estimates.get_vert_pos_rate_D(velocity);
 #endif
 
 #if HAL_NAVEKF2_AVAILABLE
@@ -1637,11 +1637,11 @@ bool AP_AHRS::get_vert_pos_rate_D(float &velocity) const
 
 #if AP_AHRS_SIM_ENABLED
     case EKFType::SIM:
-        return sim.get_vert_pos_rate_D(velocity);
+        return sim_estimates.get_vert_pos_rate_D(velocity);
 #endif
 #if AP_AHRS_EXTERNAL_ENABLED
     case EKFType::EXTERNAL:
-        return external.get_vert_pos_rate_D(velocity);
+        return external_estimates.get_vert_pos_rate_D(velocity);
 #endif
     }
     // since there is no default case above, this is unreachable

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -77,6 +77,28 @@ public:
             return true;
         };
 
+        // a derivative of the vertical position in m/s which is
+        // kinematically consistent with the vertical position is
+        // required by some control loops.
+        // This is different to the vertical velocity from the EKF
+        // which is not always consistent with the vertical position
+        // due to the various errors that are being corrected for.
+        float vert_pos_rate_D;
+        bool vert_pos_rate_D_valid;
+        // Get a derivative of the vertical position in m/s which is
+        // kinematically consistent with the vertical position is
+        // required by some control loops.
+        // This is different to the vertical velocity from the EKF
+        // which is not always consistent with the vertical position
+        // due to the various errors that are being corrected for.
+        bool get_vert_pos_rate_D(float &velocity) const {
+            if (!vert_pos_rate_D_valid) {
+                return false;
+            }
+            velocity = vert_pos_rate_D;
+            return true;
+        }
+
         Location location;
         bool location_valid;
 
@@ -179,11 +201,6 @@ public:
     // return a ground vector estimate in meters/second, in North/East order
     virtual Vector2f groundspeed_vector(void) = 0;
 
-    // Get a derivative of the vertical position in m/s which is kinematically consistent with the vertical position is required by some control loops.
-    // This is different to the vertical velocity from the EKF which is not always consistent with the vertical position due to the various errors that are being corrected for.
-    virtual bool get_vert_pos_rate_D(float &velocity) const = 0;
-
-    //
     virtual bool set_origin(const Location &loc) {
         return false;
     }

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -159,6 +159,7 @@ void AP_AHRS_DCM::get_results(AP_AHRS_Backend::Estimates &results)
     results.accel_ef = _accel_ef;
 
     results.velocity_NED_valid = get_velocity_NED(results.velocity_NED);
+    results.vert_pos_rate_D_valid = get_vert_pos_rate_D(results.vert_pos_rate_D);
 
     results.location_valid = get_location(results.location);
 }

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -98,10 +98,6 @@ public:
     // is the AHRS subsystem healthy?
     bool healthy() const override;
 
-    // Get a derivative of the vertical position in m/s which is kinematically consistent with the vertical position is required by some control loops.
-    // This is different to the vertical velocity from the EKF which is not always consistent with the vertical position due to the various errors that are being corrected for.
-    bool get_vert_pos_rate_D(float &velocity) const override;
-
     // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
     // requires_position should be true if horizontal position configuration should be checked (not used)
     bool pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const override;
@@ -120,6 +116,10 @@ public:
     void get_control_limits(float &ekfGndSpdLimit, float &controlScaleXY) const override;
 
 private:
+
+    // Get a derivative of the vertical position in m/s which is kinematically consistent with the vertical position is required by some control loops.
+    // This is different to the vertical velocity from the EKF which is not always consistent with the vertical position due to the various errors that are being corrected for.
+    bool get_vert_pos_rate_D(float &velocity) const;
 
     bool get_velocity_NED(Vector3f &vec) const;
 

--- a/libraries/AP_AHRS/AP_AHRS_External.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_External.cpp
@@ -49,6 +49,10 @@ void AP_AHRS_External::get_results(AP_AHRS_Backend::Estimates &results)
     results.accel_ef = accel_ef;
 
     results.velocity_NED_valid = AP::externalAHRS().get_velocity_NED(results.velocity_NED);
+    // a derivative of the vertical position in m/s which is kinematically consistent with the vertical position is required by some control loops.
+    // This is different to the vertical velocity from the EKF which is not always consistent with the vertical position due to the various errors that are being corrected for.
+    results.vert_pos_rate_D_valid = AP::externalAHRS().get_speed_down(results.vert_pos_rate_D);
+
 
     results.location_valid = AP::externalAHRS().get_location(results.location);
 }
@@ -97,11 +101,6 @@ bool AP_AHRS_External::get_relative_position_D_origin(postype_t &posD) const
     }
     posD = -(loc.alt - orgn.alt)*0.01;
     return true;
-}
-
-bool AP_AHRS_External::get_vert_pos_rate_D(float &velocity) const
-{
-    return AP::externalAHRS().get_speed_down(velocity);
 }
 
 bool AP_AHRS_External::pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const

--- a/libraries/AP_AHRS/AP_AHRS_External.h
+++ b/libraries/AP_AHRS/AP_AHRS_External.h
@@ -64,10 +64,6 @@ public:
     // is the AHRS subsystem healthy?
     bool healthy() const override;
 
-    // Get a derivative of the vertical position in m/s which is kinematically consistent with the vertical position is required by some control loops.
-    // This is different to the vertical velocity from the EKF which is not always consistent with the vertical position due to the various errors that are being corrected for.
-    bool get_vert_pos_rate_D(float &velocity) const override;
-
     // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
     // requires_position should be true if horizontal position configuration should be checked (not used)
     bool pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const override;

--- a/libraries/AP_AHRS/AP_AHRS_SIM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_SIM.cpp
@@ -56,17 +56,6 @@ Vector2f AP_AHRS_SIM::groundspeed_vector(void)
     return Vector2f(fdm.speedN, fdm.speedE);
 }
 
-bool AP_AHRS_SIM::get_vert_pos_rate_D(float &velocity) const
-{
-    if (_sitl == nullptr) {
-        return false;
-    }
-
-    velocity = _sitl->state.speedD;
-
-    return true;
-}
-
 bool AP_AHRS_SIM::get_hagl(float &height) const
 {
     if (_sitl == nullptr) {
@@ -231,6 +220,11 @@ void AP_AHRS_SIM::get_results(AP_AHRS_Backend::Estimates &results)
 
     results.velocity_NED = Vector3f(fdm.speedN, fdm.speedE, fdm.speedD);
     results.velocity_NED_valid = true;
+
+    // a derivative of the vertical position in m/s which is kinematically consistent with the vertical position is required by some control loops.
+    // This is different to the vertical velocity from the EKF which is not always consistent with the vertical position due to the various errors that are being corrected for.
+    results.vert_pos_rate_D_valid = true;
+    results.vert_pos_rate_D = _sitl->state.speedD;
 
     results.location_valid = get_location(results.location);
 

--- a/libraries/AP_AHRS/AP_AHRS_SIM.h
+++ b/libraries/AP_AHRS/AP_AHRS_SIM.h
@@ -82,10 +82,6 @@ public:
     // is the AHRS subsystem healthy?
     bool healthy() const override { return true; }
 
-    // Get a derivative of the vertical position in m/s which is kinematically consistent with the vertical position is required by some control loops.
-    // This is different to the vertical velocity from the EKF which is not always consistent with the vertical position due to the various errors that are being corrected for.
-    bool get_vert_pos_rate_D(float &velocity) const override;
-
     // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
     // requires_position should be true if horizontal position configuration should be checked (not used)
     bool pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const override { return true; }


### PR DESCRIPTION
```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *                                                   
Durandal                            72              56     *           32      56                136    80     200
Hitec-Airspeed           *                                 *                                                   
KakuteH7-bdshot                     40              48     *           56      40                -72    56     40
MatekF405                           56              72     *           -24     -48               32     72     56
Pixhawk1-1M-bdshot                  40              -16                -128    -112              24     16     32
SITL_x86_64_linux_gnu               -360            -360               -360    -360              -360   -360   -4456
f103-QiotekPeriph        *                                 *                                                   
f303-MatekGPS            *                                 *                                                   
f303-Universal           *                                 *                                                   
iomcu                                                                                *                         
mindpx-v2                           56              56     *           16      24                -24    56     48
revo-mini                           48              16     *           32      16                -8     48     24
skyviper-v2450                                                         112                                     
speedybeef4                         104             24     *           40      8                 440    16     24
```