### PR TITLE
Refactor AP_Mount's backend-from-device-id to a single spot

### DIFF
--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -345,6 +345,7 @@ private:
     // Check if instance backend is ok
     AP_Mount_Backend *get_primary() const;
     AP_Mount_Backend *get_instance(uint8_t instance) const;
+    AP_Mount_Backend *mount_device_from_mavlink_gimbal_id(uint8_t gimbal_device_id) const;
 
     void handle_gimbal_report(mavlink_channel_t chan, const mavlink_message_t &msg);
 


### PR DESCRIPTION
Previously it was copy-pasted (4x). This PR puts it in a single function.

As seen in the comments, it also documents a bug (for which #31940 has been created).

~A small and tangentially-related improvement is included as a 2nd commit.~

This was tested by building the code `./waf all` without errors.

This is the first (small) step towards #29566. Many more changes are already drafted, and should be in PR by the time you read this.

**NOTE**: This is my first PR to ArduPilot. Please help educate me in the review-and-merging process!!
Especially regarding sufficient testing, I want help learning how the community assesses that.
(Since this PR is small, perhaps very little testing is OK for this one, and I can learn better practices via the more substantial ones which are coming quickly.)