### PR TITLE
AP_AHRS: set active EKF type regardless of GCS being enabled

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -485,8 +485,8 @@ void AP_AHRS::update(bool skip_ins_update)
     // update AOA and SSA
     update_AOA_SSA();
 
-#if HAL_GCS_ENABLED
     state.active_EKF = _active_EKF_type();
+#if HAL_GCS_ENABLED
     if (state.active_EKF != last_active_ekf_type) {
         last_active_ekf_type = state.active_EKF;
         const char *shortname = "???";


### PR DESCRIPTION
this is the canonical backend type used to select results.

Not setting it because the GCS is not compiled in is Not Good.

No boards would currently have an AHRS but not a GCS, but it should be possible to do that and not have a bug like this!

Note that we could move setting of `last_active_ekf_type` too - but it *is* currently only used to determine whether we send the changed message out.
