### PR TITLE
Every user specifies the gimbal_device_id of the device(s) they intend to interact with

### DIFF
--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -602,14 +602,16 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_int_packet(const mavlink_command_i
 MAV_RESULT GCS_MAVLINK_Copter::handle_command_mount(const mavlink_command_int_t &packet, const mavlink_message_t &msg)
 {
     switch (packet.command) {
-    case MAV_CMD_DO_MOUNT_CONTROL:
-        // if vehicle has a camera mount but it doesn't do pan control then yaw the entire vehicle instead
+    case MAV_CMD_DO_MOUNT_CONTROL: {
+        // if vehicle has a camera mount (as mount1) but it doesn't do pan control then yaw the entire vehicle instead
+        const uint8_t mount1_dev_id = 1;
         if (((MAV_MOUNT_MODE)packet.z == MAV_MOUNT_MODE_MAVLINK_TARGETING) &&
-            (copter.camera_mount.get_mount_type() != AP_Mount::Type::None) &&
-            !copter.camera_mount.has_pan_control()) {
+            (copter.camera_mount.get_mount_type(mount1_dev_id) != AP_Mount::Type::None) &&
+            !copter.camera_mount.has_pan_control(mount1_dev_id)) {
             // Per the handler in AP_Mount, DO_MOUNT_CONTROL yaw angle is in body frame, which is
             // equivalent to an offset to the current yaw demand.
             copter.flightmode->auto_yaw.set_yaw_angle_offset_deg(packet.param3);
+        }
         }
         break;
     default:

--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -444,12 +444,12 @@ MAV_RESULT GCS_MAVLINK_Copter::_handle_command_preflight_calibration(const mavli
 }
 
 
-MAV_RESULT GCS_MAVLINK_Copter::handle_command_do_set_roi(const Location &roi_loc)
+MAV_RESULT GCS_MAVLINK_Copter::handle_command_do_set_roi_location(const uint8_t gimbal_device_id, const Location &roi_loc)
 {
     if (!roi_loc.check_latlng()) {
         return MAV_RESULT_FAILED;
     }
-    copter.flightmode->auto_yaw.set_roi(roi_loc);
+    copter.flightmode->auto_yaw.set_roi(gimbal_device_id, roi_loc);
     return MAV_RESULT_ACCEPTED;
 }
 

--- a/ArduCopter/GCS_MAVLink_Copter.h
+++ b/ArduCopter/GCS_MAVLink_Copter.h
@@ -28,7 +28,7 @@ protected:
     void send_position_target_global_int() override;
     void send_position_target_local_ned() override;
 
-    MAV_RESULT handle_command_do_set_roi(const Location &roi_loc) override;
+    MAV_RESULT handle_command_do_set_roi_location(const uint8_t gimbal_device_id, const Location &roi_loc) override;
     MAV_RESULT handle_preflight_reboot(const mavlink_command_int_t &packet, const mavlink_message_t &msg) override;
 #if HAL_MOUNT_ENABLED
     MAV_RESULT handle_command_mount(const mavlink_command_int_t &packet, const mavlink_message_t &msg) override;

--- a/ArduCopter/autoyaw.cpp
+++ b/ArduCopter/autoyaw.cpp
@@ -169,7 +169,7 @@ void Mode::AutoYaw::set_yaw_angle_offset_deg(const float yaw_angle_offset_deg)
 }
 
 // set_roi - sets the yaw to look at roi_ned_m for auto mode
-void Mode::AutoYaw::set_roi(const Location &roi_location)
+void Mode::AutoYaw::set_roi(const uint8_t gimbal_device_id, const Location &roi_location)
 {
     // if location is zero lat, lon and altitude turn off ROI
     if (!roi_location.initialised()) {
@@ -177,18 +177,18 @@ void Mode::AutoYaw::set_roi(const Location &roi_location)
         auto_yaw.set_mode_to_default(false);
 #if HAL_MOUNT_ENABLED
         // switch off the camera tracking if enabled
-        copter.camera_mount.clear_roi_target();
+        copter.camera_mount.clear_roi_target(gimbal_device_id);
 #endif  // HAL_MOUNT_ENABLED
     } else {
 #if HAL_MOUNT_ENABLED
         // check if mount type requires us to rotate the quad
-        if (!copter.camera_mount.has_pan_control()) {
+        if (!copter.camera_mount.has_pan_control(gimbal_device_id)) {
             if (roi_location.get_vector_from_origin_NED_m(roi_ned_m)) {
                 auto_yaw.set_mode(Mode::ROI);
             }
         }
         // send the command to the camera mount
-        copter.camera_mount.set_roi_target(roi_location);
+        copter.camera_mount.set_roi_target(gimbal_device_id, roi_location);
 
         // TO-DO: expand handling of the do_nav_roi to support all modes of the MAVLink.  Currently we only handle mode 4 (see below)
         //      0: do nothing

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -706,7 +706,6 @@ private:
     void do_yaw(const AP_Mission::Mission_Command& cmd);
     void do_change_speed(const AP_Mission::Mission_Command& cmd);
     void do_set_home(const AP_Mission::Mission_Command& cmd);
-    void do_roi(const AP_Mission::Mission_Command& cmd);
     void do_mount_control(const AP_Mission::Mission_Command& cmd);
 #if HAL_PARACHUTE_ENABLED
     void do_parachute(const AP_Mission::Mission_Command& cmd);

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -333,7 +333,7 @@ public:
         void set_rate_rad(float turn_rate_rads);
 
         // set_roi(...): set a "look at" location:
-        void set_roi(const Location &roi_location);
+        void set_roi(const uint8_t gimbal_device_id, const Location &roi_location);
 
         void set_fixed_yaw_rad(float angle_rad,
                                float turn_rate_rads,

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -74,7 +74,8 @@ void ModeAuto::exit()
         copter.mode_auto.mission.stop();
     }
 #if HAL_MOUNT_ENABLED
-    copter.camera_mount.set_mode_to_default();
+    const uint8_t gimbal_device_id = 0; // all gimbal devices
+    copter.camera_mount.set_mode_to_default(gimbal_device_id);
 #endif  // HAL_MOUNT_ENABLED
 
     auto_RTL = false;
@@ -2027,14 +2028,16 @@ void ModeAuto::do_set_home(const AP_Mission::Mission_Command& cmd)
 void ModeAuto::do_mount_control(const AP_Mission::Mission_Command& cmd)
 {
     // if vehicle has a camera mount but it doesn't do pan control then yaw the entire vehicle instead
-    if ((copter.camera_mount.get_mount_type() != AP_Mount::Type::None) &&
-        !copter.camera_mount.has_pan_control()) {
+    // Because MAVLink does not specify which sensor(s) is contolled by this command, the decision is made here.
+    const uint8_t gimbal_device_id = 0;
+    if ((copter.camera_mount.get_mount_type(gimbal_device_id) != AP_Mount::Type::None) &&
+        !copter.camera_mount.has_pan_control(gimbal_device_id)) {
         // Per the handler in AP_Mount, DO_MOUNT_CONTROL yaw angle is in body frame, which is
         // equivalent to an offset to the current yaw demand.
         auto_yaw.set_yaw_angle_offset_deg(cmd.content.mount_control.yaw);
     }
     // pass the target angles to the camera mount
-    copter.camera_mount.set_angle_target(cmd.content.mount_control.roll, cmd.content.mount_control.pitch, cmd.content.mount_control.yaw, false);
+    copter.camera_mount.set_angle_target(gimbal_device_id, cmd.content.mount_control.roll, cmd.content.mount_control.pitch, cmd.content.mount_control.yaw, false);
 }
 #endif  // HAL_MOUNT_ENABLED
 

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -794,8 +794,16 @@ bool ModeAuto::start_command(const AP_Mission::Mission_Command& cmd)
         do_set_home(cmd);
         break;
 
-    case MAV_CMD_DO_SET_ROI_LOCATION:       // 195
+    // point camera (and maybe the copter?) at a region of interest (ROI)
     case MAV_CMD_DO_SET_ROI_NONE:           // 197
+        // This case handled correctly by the "location" ROI handler because lat, lon, alt are always zero
+    case MAV_CMD_DO_SET_ROI_LOCATION:       // 195
+        auto_yaw.set_roi(cmd.p1, cmd.content.location);
+        break;
+
+    // this involves either moving the camera to point at the ROI (region of interest)
+    // and possibly rotating the copter to point at the ROI if our mount type does not support a yaw feature
+    // TO-DO: add support for other features ("modes") of MAV_CMD_DO_SET_ROI including pointing at a given waypoint
     case MAV_CMD_DO_SET_ROI:                // 201
         // point the copter and camera at a region of interest (ROI)
         // ROI_NONE can be handled by the regular ROI handler because lat, lon, alt are always zero

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -805,9 +805,8 @@ bool ModeAuto::start_command(const AP_Mission::Mission_Command& cmd)
     // and possibly rotating the copter to point at the ROI if our mount type does not support a yaw feature
     // TO-DO: add support for other features ("modes") of MAV_CMD_DO_SET_ROI including pointing at a given waypoint
     case MAV_CMD_DO_SET_ROI:                // 201
-        // point the copter and camera at a region of interest (ROI)
-        // ROI_NONE can be handled by the regular ROI handler because lat, lon, alt are always zero
-        do_roi(cmd);
+        // Because MAVLink does not specify which sensor(s) is contolled by this command, the decision is made here.
+        auto_yaw.set_roi(0, cmd.content.location);
         break;
 
 #if HAL_MOUNT_ENABLED
@@ -2021,15 +2020,6 @@ void ModeAuto::do_set_home(const AP_Mission::Mission_Command& cmd)
             // ignore failure
         }
     }
-}
-
-// do_roi - starts actions required by MAV_CMD_DO_SET_ROI
-//          this involves either moving the camera to point at the ROI (region of interest)
-//          and possibly rotating the copter to point at the ROI if our mount type does not support a yaw feature
-// TO-DO: add support for other features of MAV_CMD_DO_SET_ROI including pointing at a given waypoint
-void ModeAuto::do_roi(const AP_Mission::Mission_Command& cmd)
-{
-    auto_yaw.set_roi(cmd.content.location);
 }
 
 #if HAL_MOUNT_ENABLED

--- a/ArduCopter/mode_circle.cpp
+++ b/ArduCopter/mode_circle.cpp
@@ -29,10 +29,14 @@ bool ModeCircle::init(bool ignore_checks)
         if (!AP::ahrs().get_location_from_origin_offset_NED(circle_center, pos_ned_m)) {
             return false;
         }
-        // point at the ground:
+        // Per docs, copter points "mount" at circle center, ground-level.
         circle_center.set_alt_m(0, Location::AltFrame::ABOVE_TERRAIN);
+        // It does not specify 'primary' gimbal vs 'all' gimbals.
+        // Because the docs do not specify which gimbal(s) do this, the decision is implemented here.
+        uint8_t gimbal_device_id = 0;
+
         AP_Mount *s = AP_Mount::get_singleton();
-        s->set_roi_target(circle_center);
+        s->set_roi_target(gimbal_device_id, circle_center);
     }
 #endif
 

--- a/ArduCopter/mode_follow.cpp
+++ b/ArduCopter/mode_follow.cpp
@@ -25,7 +25,11 @@ bool ModeFollow::init(const bool ignore_checks)
     AP_Mount *mount = AP_Mount::get_singleton();
     // follow the lead vehicle using sysid
     if (g2.follow.option_is_enabled(AP_Follow::Option::MOUNT_FOLLOW_ON_ENTER) && mount != nullptr) {
-        mount->set_target_sysid(g2.follow.get_target_sysid());
+        // While the docs do not specify which mounts should point towards the lead vehicle,
+        // it makes sense to point only one of them.
+        // That (arbitrary?) decision is made clear here.
+        const uint8_t gimbal_device_id = 1;  // mount1
+        mount->set_target_sysid(gimbal_device_id, g2.follow.get_target_sysid());
     }
 #endif
 

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1010,6 +1010,9 @@ private:
     void do_within_distance(const AP_Mission::Mission_Command& cmd);
     bool do_change_speed(const AP_Mission::Mission_Command& cmd);
     void do_set_home(const AP_Mission::Mission_Command& cmd);
+    void do_set_roi(const AP_Mission::Mission_Command& cmd); // MAV_CMD_DO_SET_ROI (201)
+    void do_set_roi_location(const AP_Mission::Mission_Command& cmd); // MAV_CMD_DO_SET_ROI_LOCATION (195)
+    void do_set_roi(const uint8_t gimbal_device_id, const Location &loc); // (shared implementation details)
     bool start_command_callback(const AP_Mission::Mission_Command &cmd);
     bool verify_command_callback(const AP_Mission::Mission_Command& cmd);
     float get_wp_radius() const;

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -165,9 +165,12 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
         do_set_roi(cmd);
         break;
 
-    case MAV_CMD_DO_MOUNT_CONTROL:          // 205
+    case MAV_CMD_DO_MOUNT_CONTROL: {        // 205
         // point the camera to a specified angle
-        camera_mount.set_angle_target(cmd.content.mount_control.roll, cmd.content.mount_control.pitch, cmd.content.mount_control.yaw, false);
+        // Because MAVLink does not specify which sensor(s) is contolled by this command, the decision is made here.
+        const uint8_t gimbal_device_id = 0;
+        camera_mount.set_angle_target(gimbal_device_id, cmd.content.mount_control.roll, cmd.content.mount_control.pitch, cmd.content.mount_control.yaw, false);
+        }
         break;
 #endif
 

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -155,19 +155,14 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
     // system to control the vehicle attitude and the attitude of various
     // devices such as cameras.
     //    |Region of interest mode. (see MAV_ROI enum)| Waypoint index/ target ID. (see MAV_ROI enum)| ROI index (allows a vehicle to manage multiple cameras etc.)| Empty| x the location of the fixed ROI (see MAV_FRAME)| y| z|
-    // ROI_NONE can be handled by the regular ROI handler because lat, lon, alt are always zero
     case MAV_CMD_DO_SET_ROI_LOCATION:
+        // ROI_NONE can be handled by the regular ROI handler because lat, lon, alt are always zero
     case MAV_CMD_DO_SET_ROI_NONE:
+        do_set_roi_location(cmd);
+        break;
+
     case MAV_CMD_DO_SET_ROI:
-        if (!cmd.content.location.initialised()) {
-            // switch off the camera tracking if enabled
-            if (camera_mount.get_mode() == MAV_MOUNT_MODE_GPS_POINT) {
-                camera_mount.set_mode_to_default();
-            }
-        } else {
-            // set mount's target location
-            camera_mount.set_roi_target(cmd.content.location);
-        }
+        do_set_roi(cmd);
         break;
 
     case MAV_CMD_DO_MOUNT_CONTROL:          // 205
@@ -1012,6 +1007,32 @@ void Plane::do_set_home(const AP_Mission::Mission_Command& cmd)
         if (!AP::ahrs().set_home(cmd.content.location)) {
             // silently ignore failure
         }
+    }
+}
+
+// MAV_CMD_DO_SET_ROI (201)
+void Plane::do_set_roi(const AP_Mission::Mission_Command& cmd)
+{
+    // Because MAVLink does not specify which sensor(s) is contolled by this command, the decision is made here.
+    constexpr uint8_t gimbal_device_id = 0;
+    do_set_roi(gimbal_device_id, cmd.content.location);
+}
+
+// MAV_CMD_DO_SET_ROI_LOCATION (195)
+void Plane::do_set_roi_location(const AP_Mission::Mission_Command& cmd)
+{
+    const uint8_t gimbal_device_id = cmd.p1;
+    do_set_roi(gimbal_device_id, cmd.content.location);
+}
+
+void Plane::do_set_roi(const uint8_t gimbal_device_id, const Location &loc) {
+    if (loc.initialised()) {
+        camera_mount.set_roi_target(gimbal_device_id, loc);
+        return;
+    }
+
+    if (camera_mount.get_mode(gimbal_device_id) == MAV_MOUNT_MODE_GPS_POINT) {
+        camera_mount.set_mode_to_default(gimbal_device_id);
     }
 }
 

--- a/ArduSub/GCS_MAVLink_Sub.cpp
+++ b/ArduSub/GCS_MAVLink_Sub.cpp
@@ -301,12 +301,12 @@ MAV_RESULT GCS_MAVLINK_Sub::_handle_command_preflight_calibration(const mavlink_
     return GCS_MAVLINK::_handle_command_preflight_calibration(packet, msg);
 }
 
-MAV_RESULT GCS_MAVLINK_Sub::handle_command_do_set_roi(const Location &roi_loc)
+MAV_RESULT GCS_MAVLINK_Sub::handle_command_do_set_roi_location(const uint8_t gimbal_device_id, const Location &roi_loc)
 {
     if (!roi_loc.check_latlng()) {
         return MAV_RESULT_FAILED;
     }
-    sub.mode_auto.set_auto_yaw_roi(roi_loc);
+    sub.mode_auto.set_auto_yaw_roi(gimbal_device_id, roi_loc);
     return MAV_RESULT_ACCEPTED;
 }
 

--- a/ArduSub/GCS_MAVLink_Sub.h
+++ b/ArduSub/GCS_MAVLink_Sub.h
@@ -12,7 +12,7 @@ protected:
 
     MAV_RESULT handle_flight_termination(const mavlink_command_int_t &packet) override;
 
-    MAV_RESULT handle_command_do_set_roi(const Location &roi_loc) override;
+    MAV_RESULT handle_command_do_set_roi_location(const uint8_t gimbal_device_id, const Location &roi_loc) override;
     MAV_RESULT _handle_command_preflight_calibration_baro(const mavlink_message_t &msg) override;
     MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_int_t &packet, const mavlink_message_t &msg) override;
 

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -549,7 +549,8 @@ private:
     void do_yaw(const AP_Mission::Mission_Command& cmd);
     void do_change_speed(const AP_Mission::Mission_Command& cmd);
     void do_set_home(const AP_Mission::Mission_Command& cmd);
-    void do_roi(const AP_Mission::Mission_Command& cmd);
+    void do_set_roi(const AP_Mission::Mission_Command& cmd);
+    void do_set_roi_location(const AP_Mission::Mission_Command& cmd);
     void do_mount_control(const AP_Mission::Mission_Command& cmd);
 
     bool verify_nav_wp(const AP_Mission::Mission_Command& cmd);

--- a/ArduSub/joystick.cpp
+++ b/ArduSub/joystick.cpp
@@ -198,10 +198,13 @@ void Sub::handle_jsbutton_press(uint8_t _button, bool shift, bool held)
         break;
 #endif
 #if HAL_MOUNT_ENABLED
-    case JSButton::button_function_t::k_mount_center:
-        camera_mount.set_angle_target(0, 0, 0, false);
+    case JSButton::button_function_t::k_mount_center: {
+        // While ArduSub seems to only support 1 mount, send to all gimbal devices just to be sure.
+        const uint8_t all_gimbal_devices = 0;
+        camera_mount.set_angle_target(all_gimbal_devices, 0, 0, 0, false);
         // for some reason the call to set_angle_targets changes the mode to mavlink targeting!
-        camera_mount.set_mode(MAV_MOUNT_MODE_RC_TARGETING);
+        camera_mount.set_mode(all_gimbal_devices, MAV_MOUNT_MODE_RC_TARGETING);
+        }
         break;
     case JSButton::button_function_t::k_mount_tilt_up:
         cam_tilt = 1900;

--- a/ArduSub/mode.cpp
+++ b/ArduSub/mode.cpp
@@ -140,7 +140,8 @@ void Sub::exit_mode(Mode::Number old_control_mode, Mode::Number new_control_mode
             mission.stop();
         }
 #if HAL_MOUNT_ENABLED
-        camera_mount.set_mode_to_default();
+        const uint8_t all_gimbal_devices = 0;
+        camera_mount.set_mode_to_default(all_gimbal_devices);
 #endif  // HAL_MOUNT_ENABLED
     }
     motors.set_max_throttle(1.0f);
@@ -162,7 +163,8 @@ void Sub::update_flight_mode()
 // exit_mode - high level call to organise cleanup as a flight mode is exited
 void Sub::exit_mode(Mode *&old_flightmode, Mode *&new_flightmode){
 #if HAL_MOUNT_ENABLED
-        camera_mount.set_mode_to_default();
+    const uint8_t all_gimbal_devices = 0;
+    camera_mount.set_mode_to_default(all_gimbal_devices);
 #endif  // HAL_MOUNT_ENABLED
     motors.set_max_throttle(1.0f);
 }

--- a/ArduSub/mode.h
+++ b/ArduSub/mode.h
@@ -321,7 +321,7 @@ public:
     void auto_circle_movetoedge_start(const Location &circle_center, float radius_m, bool ccw_turn);
     void auto_circle_start();
     void auto_nav_guided_start();
-    void set_auto_yaw_roi(const Location &roi_location);
+    void set_auto_yaw_roi(const uint8_t gimbal_device_id, const Location &roi_location);
     void set_auto_yaw_look_at_heading(float angle_deg, float turn_rate_dps, int8_t direction, uint8_t relative_angle);
     void set_yaw_rate(float turn_rate_dps);
     bool auto_terrain_recover_start();

--- a/ArduSub/mode_auto.cpp
+++ b/ArduSub/mode_auto.cpp
@@ -387,7 +387,7 @@ void ModeAuto::set_yaw_rate(float turn_rate_dps)
 }
 
 // set_auto_yaw_roi - sets the yaw to look at roi for auto mode
-void ModeAuto::set_auto_yaw_roi(const Location &roi_location)
+void ModeAuto::set_auto_yaw_roi(const uint8_t gimbal_device_id, const Location &roi_location)
 {
     // if location is zero lat, lon and altitude turn off ROI
     if (!roi_location.initialised()) {
@@ -395,18 +395,18 @@ void ModeAuto::set_auto_yaw_roi(const Location &roi_location)
         set_auto_yaw_mode(get_default_auto_yaw_mode(false));
 #if HAL_MOUNT_ENABLED
         // switch off the camera tracking if enabled
-        sub.camera_mount.clear_roi_target();
+        sub.camera_mount.clear_roi_target(gimbal_device_id);
 #endif  // HAL_MOUNT_ENABLED
     } else {
 #if HAL_MOUNT_ENABLED
         // check if mount type requires us to rotate the sub
-        if (!sub.camera_mount.has_pan_control()) {
+        if (!sub.camera_mount.has_pan_control(gimbal_device_id)) {
             if (roi_location.get_vector_from_origin_NEU_cm(sub.roi_WP)) {
                 set_auto_yaw_mode(AUTO_YAW_ROI);
             }
         }
         // send the command to the camera mount
-        sub.camera_mount.set_roi_target(roi_location);
+        sub.camera_mount.set_roi_target(gimbal_device_id, roi_location);
 
         // TO-DO: expand handling of the do_nav_roi to support all modes of the MAVLink.  Currently we only handle mode 4 (see below)
         //      0: do nothing

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -89,10 +89,12 @@ void Sub::init_ardupilot()
 #if HAL_MOUNT_ENABLED
     // initialise camera mount
     camera_mount.init();
+    // While ArduSub seems to only support 1 mount, send commands to all gimbal devices just to be sure.
+    const uint8_t all_gimbal_devices = 0;
     // This step is necessary so that the servo is properly initialized
-    camera_mount.set_angle_target(0, 0, 0, false);
+    camera_mount.set_angle_target(all_gimbal_devices, 0, 0, 0, false);
     // for some reason the call to set_angle_targets changes the mode to mavlink targeting!
-    camera_mount.set_mode(MAV_MOUNT_MODE_RC_TARGETING);
+    camera_mount.set_mode(all_gimbal_devices, MAV_MOUNT_MODE_RC_TARGETING);
 #endif
 
 #if AP_CAMERA_ENABLED

--- a/Blimp/GCS_MAVLink_Blimp.cpp
+++ b/Blimp/GCS_MAVLink_Blimp.cpp
@@ -227,12 +227,12 @@ MAV_RESULT GCS_MAVLINK_Blimp::_handle_command_preflight_calibration(const mavlin
 }
 
 
-MAV_RESULT GCS_MAVLINK_Blimp::handle_command_do_set_roi(const Location &roi_loc)
+MAV_RESULT GCS_MAVLINK_Blimp::handle_command_do_set_roi_location(const uint8_t gimbal_device_id, const Location &roi_loc)
 {
     if (!roi_loc.check_latlng()) {
         return MAV_RESULT_FAILED;
     }
-    // blimp.flightmode->auto_yaw.set_roi(roi_loc);
+    // blimp.flightmode->auto_yaw.set_roi(gimbal_device_id, roi_loc);
     return MAV_RESULT_ACCEPTED;
 }
 

--- a/Blimp/GCS_MAVLink_Blimp.h
+++ b/Blimp/GCS_MAVLink_Blimp.h
@@ -22,7 +22,7 @@ protected:
 
     void send_position_target_global_int() override;
 
-    MAV_RESULT handle_command_do_set_roi(const Location &roi_loc) override;
+    MAV_RESULT handle_command_do_set_roi_location(const uint8_t gimbal_device_id, const Location &roi_loc) override;
     MAV_RESULT handle_command_int_packet(const mavlink_command_int_t &packet, const mavlink_message_t &msg) override;
     MAV_RESULT handle_command_int_do_reposition(const mavlink_command_int_t &packet);
 

--- a/Rover/mode.h
+++ b/Rover/mode.h
@@ -354,6 +354,9 @@ private:
     bool verify_within_distance();
     void do_change_speed(const AP_Mission::Mission_Command& cmd);
     void do_set_home(const AP_Mission::Mission_Command& cmd);
+    void do_set_roi(const AP_Mission::Mission_Command& cmd); // MAV_CMD_DO_SET_ROI (201)
+    void do_set_roi_location(const AP_Mission::Mission_Command& cmd); // MAV_CMD_DO_SET_ROI_LOCATION (195)
+    void do_set_roi(const uint8_t gimbal_device_id, const Location &loc); // (shared implementation details)
     void do_set_reverse(const AP_Mission::Mission_Command& cmd);
     void do_guided_limits(const AP_Mission::Mission_Command& cmd);
 #if AP_SCRIPTING_ENABLED

--- a/Rover/mode_auto.cpp
+++ b/Rover/mode_auto.cpp
@@ -569,21 +569,16 @@ bool ModeAuto::start_command(const AP_Mission::Mission_Command& cmd)
     // system to control the vehicle attitude and the attitude of various
     // devices such as cameras.
     //    |Region of interest mode. (see MAV_ROI enum)| Waypoint index/ target ID. (see MAV_ROI enum)| ROI index (allows a vehicle to manage multiple cameras etc.)| Empty| x the location of the fixed ROI (see MAV_FRAME)| y| z|
-    // ROI_NONE can be handled by the regular ROI handler because lat, lon, alt are always zero
     case MAV_CMD_DO_SET_ROI_LOCATION:
+        // ROI_NONE can be handled by the regular ROI handler because lat, lon, alt are always zero
     case MAV_CMD_DO_SET_ROI_NONE:
-    case MAV_CMD_DO_SET_ROI:
-        if (!cmd.content.location.initialised()) {
-            // switch off the camera tracking if enabled
-            if (rover.camera_mount.get_mode() == MAV_MOUNT_MODE_GPS_POINT) {
-                rover.camera_mount.set_mode_to_default();
-            }
-        } else {
-            // send the command to the camera mount
-            rover.camera_mount.set_roi_target(cmd.content.location);
-        }
+        do_set_roi_location(cmd);
         break;
-#endif
+
+    case MAV_CMD_DO_SET_ROI:
+        do_set_roi(cmd);
+        break;
+#endif // HAL_MOUNT_ENABLED
 
     case MAV_CMD_DO_SET_REVERSE:
         do_set_reverse(cmd);
@@ -1007,6 +1002,35 @@ void ModeAuto::do_set_home(const AP_Mission::Mission_Command& cmd)
         }
     }
 }
+
+#if HAL_MOUNT_ENABLED
+// MAV_CMD_DO_SET_ROI (201)
+void ModeAuto::do_set_roi(const AP_Mission::Mission_Command& cmd)
+{
+    // Because MAVLink does not specify which sensor(s) is contolled by this command, the decision is made here.
+    constexpr uint8_t gimbal_device_id = 0;
+    do_set_roi(gimbal_device_id, cmd.content.location);
+}
+
+// MAV_CMD_DO_SET_ROI_LOCATION (195)
+void ModeAuto::do_set_roi_location(const AP_Mission::Mission_Command& cmd)
+{
+    const uint8_t gimbal_device_id = cmd.p1;
+    do_set_roi(gimbal_device_id, cmd.content.location);
+}
+
+void ModeAuto::do_set_roi(const uint8_t gimbal_device_id, const Location &loc) {
+    if (loc.initialised()) {
+        rover.camera_mount.set_roi_target(gimbal_device_id, loc);
+        return;
+    }
+
+    if (rover.camera_mount.get_mode(gimbal_device_id) == MAV_MOUNT_MODE_GPS_POINT) {
+        rover.camera_mount.set_mode_to_default(gimbal_device_id);
+    }
+}
+#endif // HAL_MOUNT_ENABLED
+
 
 void ModeAuto::do_set_reverse(const AP_Mission::Mission_Command& cmd)
 {

--- a/libraries/AP_Camera/AP_Camera_Backend.h
+++ b/libraries/AP_Camera/AP_Camera_Backend.h
@@ -26,6 +26,9 @@
 #include <AP_Common/Location.h>
 #include <AP_Logger/LogStructure.h>
 
+// Per MAVLink CAMERA_INFORMATION (259) specification
+constexpr uint8_t CAMERA_HAS_NO_GIMBAL = 0;
+
 class AP_Camera_Backend
 {
 public:
@@ -188,7 +191,7 @@ protected:
     // get corresponding mount instance for the camera
     uint8_t get_mount_instance() const;
 
-    // get mavlink gimbal device id which is normally mount_instance+1
+    // get mavlink gimbal device id, or 0 if no gimbal is associated with this camera.
     uint8_t get_gimbal_device_id() const;
 
 #if AP_CAMERA_INFO_FROM_SCRIPT_ENABLED

--- a/libraries/AP_Camera/AP_Camera_Logging.cpp
+++ b/libraries/AP_Camera/AP_Camera_Logging.cpp
@@ -71,7 +71,8 @@ void AP_Camera_Backend::Write_CameraInfo(enum LogMessages msg, uint64_t timestam
 #if HAL_MOUNT_ENABLED
     auto *mount = AP_Mount::get_singleton();
     if (mount!= nullptr) {
-        mount->write_log(get_mount_instance(), timestamp_us);
+        const uint8_t gimbal_device_id = get_mount_instance() + 1;
+        mount->write_log(gimbal_device_id, timestamp_us);
     }
 #endif
 }

--- a/libraries/AP_Camera/AP_Camera_Mount.cpp
+++ b/libraries/AP_Camera/AP_Camera_Mount.cpp
@@ -10,7 +10,8 @@ bool AP_Camera_Mount::trigger_pic()
 {
     AP_Mount* mount = AP::mount();
     if (mount != nullptr) {
-        return mount->take_picture(get_mount_instance());
+        const uint8_t gimbal_device_id = get_mount_instance() + 1;
+        return mount->take_picture(gimbal_device_id);
     }
     return false;
 }
@@ -21,7 +22,8 @@ bool AP_Camera_Mount::record_video(bool start_recording)
 {
     AP_Mount* mount = AP::mount();
     if (mount != nullptr) {
-        return mount->record_video(get_mount_instance(), start_recording);
+        const uint8_t gimbal_device_id = get_mount_instance() + 1;
+        return mount->record_video(gimbal_device_id, start_recording);
     }
     return false;
 }
@@ -31,7 +33,8 @@ bool AP_Camera_Mount::set_zoom(ZoomType zoom_type, float zoom_value)
 {
     AP_Mount* mount = AP::mount();
     if (mount != nullptr) {
-        return mount->set_zoom(get_mount_instance(), zoom_type, zoom_value);
+        const uint8_t gimbal_device_id = get_mount_instance() + 1;
+        return mount->set_zoom(gimbal_device_id, zoom_type, zoom_value);
     }
     return false;
 }
@@ -42,7 +45,8 @@ SetFocusResult AP_Camera_Mount::set_focus(FocusType focus_type, float focus_valu
 {
     AP_Mount* mount = AP::mount();
     if (mount != nullptr) {
-        return mount->set_focus(get_mount_instance(), focus_type, focus_value);
+        const uint8_t gimbal_device_id = get_mount_instance() + 1;
+        return mount->set_focus(gimbal_device_id, focus_type, focus_value);
     }
     return SetFocusResult::FAILED;
 }
@@ -54,7 +58,8 @@ bool AP_Camera_Mount::set_tracking(TrackingType tracking_type, const Vector2f& p
 {
     AP_Mount* mount = AP::mount();
     if (mount != nullptr) {
-        return mount->set_tracking(get_mount_instance(), tracking_type, p1, p2);
+        const uint8_t gimbal_device_id = get_mount_instance() + 1;
+        return mount->set_tracking(gimbal_device_id, tracking_type, p1, p2);
     }
     return false;
 }
@@ -65,7 +70,8 @@ bool AP_Camera_Mount::set_lens(uint8_t lens)
 {
     AP_Mount* mount = AP::mount();
     if (mount != nullptr) {
-        return mount->set_lens(get_mount_instance(), lens);
+        const uint8_t gimbal_device_id = get_mount_instance() + 1;
+        return mount->set_lens(gimbal_device_id, lens);
     }
     return false;
 }
@@ -76,7 +82,8 @@ bool AP_Camera_Mount::set_camera_source(AP_Camera::CameraSource primary_source, 
 {
     AP_Mount* mount = AP::mount();
     if (mount != nullptr) {
-        return mount->set_camera_source(get_mount_instance(), (uint8_t)primary_source, (uint8_t)secondary_source);
+        const uint8_t gimbal_device_id = get_mount_instance() + 1;
+        return mount->set_camera_source(gimbal_device_id, (uint8_t)primary_source, (uint8_t)secondary_source);
     }
     return false;
 }
@@ -87,7 +94,8 @@ void AP_Camera_Mount::send_camera_information(mavlink_channel_t chan) const
 {
     AP_Mount* mount = AP::mount();
     if (mount != nullptr) {
-        return mount->send_camera_information(get_mount_instance(), chan);
+        const uint8_t gimbal_device_id = get_mount_instance() + 1;
+        return mount->send_camera_information(gimbal_device_id, chan);
     }
 }
 
@@ -96,7 +104,8 @@ void AP_Camera_Mount::send_camera_settings(mavlink_channel_t chan) const
 {
     AP_Mount* mount = AP::mount();
     if (mount != nullptr) {
-        return mount->send_camera_settings(get_mount_instance(), chan);
+        const uint8_t gimbal_device_id = get_mount_instance() + 1;
+        return mount->send_camera_settings(gimbal_device_id, chan);
     }
 }
 
@@ -105,7 +114,8 @@ void AP_Camera_Mount::send_camera_capture_status(mavlink_channel_t chan) const
 {
     AP_Mount* mount = AP::mount();
     if (mount != nullptr) {
-        return mount->send_camera_capture_status(get_mount_instance(), chan);
+        const uint8_t gimbal_device_id = get_mount_instance() + 1;
+        return mount->send_camera_capture_status(gimbal_device_id, chan);
     }
 }
 
@@ -116,7 +126,8 @@ void AP_Camera_Mount::send_camera_thermal_range(mavlink_channel_t chan) const
 #if AP_MOUNT_SEND_THERMAL_RANGE_ENABLED
     AP_Mount* mount = AP::mount();
     if (mount != nullptr) {
-        mount->send_camera_thermal_range(get_mount_instance(), chan);
+        const uint8_t gimbal_device_id = get_mount_instance() + 1;
+        mount->send_camera_thermal_range(gimbal_device_id, chan);
     }
 #endif
 }
@@ -128,7 +139,8 @@ bool AP_Camera_Mount::change_setting(CameraSetting setting, float value)
 {
     AP_Mount* mount = AP::mount();
     if (mount != nullptr) {
-        return mount->change_setting(get_mount_instance(), setting, value);
+        const uint8_t gimbal_device_id = get_mount_instance() + 1;
+        return mount->change_setting(gimbal_device_id, setting, value);
     }
     return false;
 }

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -1265,7 +1265,8 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
         break;
 
     case MAV_CMD_DO_SET_ROI:                            // MAV ID: 201
-        cmd.p1 = packet.param1;                         // 0 = no roi, 1 = next waypoint, 2 = waypoint number, 3 = fixed location, 4 = given target (not supported)
+        // Reminder: some of these roi modes may not be supported.
+        cmd.p1 = packet.param1;                         // 0 = no roi, 1 = next waypoint, 2 = waypoint number, 3 = fixed location, 4 = given target
         break;
 
     case MAV_CMD_DO_DIGICAM_CONFIGURE:                  // MAV ID: 202

--- a/libraries/AP_Mission/AP_Mission_Commands.cpp
+++ b/libraries/AP_Mission/AP_Mission_Commands.cpp
@@ -312,20 +312,15 @@ bool AP_Mission::start_command_do_gimbal_manager_pitchyaw(const AP_Mission::Miss
         return false;
     }
 
-    // check gimbal device id.  0 is primary, 1 is 1st gimbal, 2 is 2nd gimbal, etc
-    uint8_t gimbal_instance = mount->get_primary_instance();
-    if (cmd.content.gimbal_manager_pitchyaw.gimbal_id > 0) {
-        gimbal_instance = cmd.content.gimbal_manager_pitchyaw.gimbal_id - 1;
-    }
-
     // check flags for change to RETRACT
     if ((cmd.content.gimbal_manager_pitchyaw.flags & GIMBAL_MANAGER_FLAGS_RETRACT) > 0) {
-        mount->set_mode(gimbal_instance, MAV_MOUNT_MODE_RETRACT);
+        mount->set_mode(cmd.content.gimbal_manager_pitchyaw.gimbal_id, MAV_MOUNT_MODE_RETRACT);
         return true;
     }
+
     // check flags for change to NEUTRAL
     if ((cmd.content.gimbal_manager_pitchyaw.flags & GIMBAL_MANAGER_FLAGS_NEUTRAL) > 0) {
-        mount->set_mode(gimbal_instance, MAV_MOUNT_MODE_NEUTRAL);
+        mount->set_mode(cmd.content.gimbal_manager_pitchyaw.gimbal_id, MAV_MOUNT_MODE_NEUTRAL);
         return true;
     }
 
@@ -333,13 +328,25 @@ bool AP_Mission::start_command_do_gimbal_manager_pitchyaw(const AP_Mission::Miss
     const bool pitch_angle_valid = abs(cmd.content.gimbal_manager_pitchyaw.pitch_angle_deg) <= 90;
     const bool yaw_angle_valid = abs(cmd.content.gimbal_manager_pitchyaw.yaw_angle_deg) <= 360;
     if (pitch_angle_valid && yaw_angle_valid) {
-        mount->set_angle_target(gimbal_instance, 0, cmd.content.gimbal_manager_pitchyaw.pitch_angle_deg, cmd.content.gimbal_manager_pitchyaw.yaw_angle_deg, cmd.content.gimbal_manager_pitchyaw.flags & GIMBAL_MANAGER_FLAGS_YAW_LOCK);
+        constexpr float zero_roll_angle_deg = 0.0f;
+        mount->set_angle_target(cmd.content.gimbal_manager_pitchyaw.gimbal_id,
+                                zero_roll_angle_deg,
+                                cmd.content.gimbal_manager_pitchyaw.pitch_angle_deg,
+                                cmd.content.gimbal_manager_pitchyaw.yaw_angle_deg,
+                                cmd.content.gimbal_manager_pitchyaw.flags & GIMBAL_MANAGER_FLAGS_YAW_LOCK);
         return true;
     }
 
     // handle rate target
-    if (!isnan(cmd.content.gimbal_manager_pitchyaw.pitch_rate_degs) && !isnan(cmd.content.gimbal_manager_pitchyaw.yaw_rate_degs)) {
-        mount->set_rate_target(gimbal_instance, 0, cmd.content.gimbal_manager_pitchyaw.pitch_rate_degs, cmd.content.gimbal_manager_pitchyaw.yaw_rate_degs, cmd.content.gimbal_manager_pitchyaw.flags & GIMBAL_MANAGER_FLAGS_YAW_LOCK);
+    const bool pitch_rate_valid = !isnan(cmd.content.gimbal_manager_pitchyaw.pitch_rate_degs);
+    const bool yaw_rate_valid = !isnan(cmd.content.gimbal_manager_pitchyaw.yaw_rate_degs);
+    if (pitch_rate_valid && yaw_rate_valid) {
+        constexpr float zero_roll_rate_degs = 0.0f;
+        mount->set_rate_target(cmd.content.gimbal_manager_pitchyaw.gimbal_id,
+                               zero_roll_rate_degs,
+                               cmd.content.gimbal_manager_pitchyaw.pitch_rate_degs,
+                               cmd.content.gimbal_manager_pitchyaw.yaw_rate_degs,
+                               cmd.content.gimbal_manager_pitchyaw.flags & GIMBAL_MANAGER_FLAGS_YAW_LOCK);
         return true;
     }
 

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -631,8 +631,7 @@ bool AP_Mount::get_poi(uint8_t gimbal_device_id, Quaternion &quat, Location &loc
     if (device == nullptr) {
         return false;
     }
-    const uint8_t UNUSED = 0; // This will be removed in a commit in this same PR.
-    return device->get_poi(UNUSED, quat, loc, poi_loc);
+    return device->get_poi(quat, loc, poi_loc);
 }
 #endif
 

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -972,11 +972,6 @@ bool AP_Mount::set_rangefinder_enable(uint8_t gimbal_device_id, bool enable)
     return device->set_rangefinder_enable(enable);
 }
 
-AP_Mount_Backend *AP_Mount::get_primary() const
-{
-    return get_instance(_primary);
-}
-
 AP_Mount_Backend *AP_Mount::get_instance(uint8_t instance_index) const
 {
     if (instance_index >= ARRAY_SIZE(_backends)) {
@@ -993,7 +988,7 @@ AP_Mount_Backend *AP_Mount::mount_device_from_gimbal_id(uint8_t gimbal_device_id
     // Workaround: Leave this as-is until it can be fixed in synchrony with upstream to prevent unexpected behavior-change.
     // See: https://github.com/ArduPilot/ardupilot/issues/31940
     if (gimbal_device_id == 0) {
-        return get_primary();
+        return get_instance(_primary);
     } else {
         return get_instance(gimbal_device_id - 1);
     }

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -549,7 +549,9 @@ void AP_Mount::handle_gimbal_manager_set_pitchyaw(const mavlink_message_t &msg)
 
 MAV_RESULT AP_Mount::handle_command_do_set_roi_sysid(const mavlink_command_int_t &packet)
 {
-    set_target_sysid((uint8_t)packet.param1);
+    uint8_t system_id = packet.param1;
+    uint8_t gimbal_device_id = packet.param2;
+    set_target_sysid(gimbal_device_id, system_id);
     return MAV_RESULT_ACCEPTED;
 }
 

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -381,16 +381,7 @@ MAV_RESULT AP_Mount::handle_command_do_mount_control(const mavlink_command_int_t
 
 MAV_RESULT AP_Mount::handle_command_do_gimbal_manager_pitchyaw(const mavlink_command_int_t &packet)
 {
-    AP_Mount_Backend *backend;
-
-    // check gimbal device id.  0 is primary, 1 is 1st gimbal, 2 is
-    // 2nd gimbal, etc
-    const uint8_t instance = packet.z;
-    if (instance == 0) {
-        backend = get_primary();
-    } else {
-        backend = get_instance(instance - 1);
-    }
+    auto *backend = mount_device_from_gimbal_id(packet.z);
 
     if (backend == nullptr) {
         return MAV_RESULT_FAILED;
@@ -438,15 +429,7 @@ MAV_RESULT AP_Mount::handle_command_do_gimbal_manager_pitchyaw(const mavlink_com
 // handle mav_cmd_do_gimbal_manager_configure for deconflicting different mavlink message senders
 MAV_RESULT AP_Mount::handle_command_do_gimbal_manager_configure(const mavlink_command_int_t &packet, const mavlink_message_t &msg)
 {
-    AP_Mount_Backend *backend;
-
-    // check gimbal device id.  0 is primary, 1 is 1st gimbal, 2 is 2nd gimbal, etc
-    const uint8_t instance = packet.z;
-    if (instance == 0) {
-        backend = get_primary();
-    } else {
-        backend = get_instance(instance - 1);
-    }
+    auto *backend = mount_device_from_gimbal_id(packet.z);
 
     if (backend == nullptr) {
         return MAV_RESULT_FAILED;
@@ -455,20 +438,12 @@ MAV_RESULT AP_Mount::handle_command_do_gimbal_manager_configure(const mavlink_co
     return backend->handle_command_do_gimbal_manager_configure(packet, msg);
 }
 
-void AP_Mount::handle_gimbal_manager_set_attitude(const mavlink_message_t &msg) {
+void AP_Mount::handle_gimbal_manager_set_attitude(const mavlink_message_t &msg)
+{
     mavlink_gimbal_manager_set_attitude_t packet;
     mavlink_msg_gimbal_manager_set_attitude_decode(&msg,&packet);
 
-    AP_Mount_Backend *backend;
-
-    // check gimbal device id.  0 is primary, 1 is 1st gimbal, 2 is
-    // 2nd gimbal, etc
-    const uint8_t instance = packet.gimbal_device_id;
-    if (instance == 0) {
-        backend = get_primary();
-    } else {
-        backend = get_instance(instance - 1);
-    }
+    auto *backend = mount_device_from_gimbal_id(packet.gimbal_device_id);
 
     if (backend == nullptr) {
         return;
@@ -525,16 +500,7 @@ void AP_Mount::handle_gimbal_manager_set_pitchyaw(const mavlink_message_t &msg)
     mavlink_gimbal_manager_set_pitchyaw_t packet;
     mavlink_msg_gimbal_manager_set_pitchyaw_decode(&msg,&packet);
 
-    AP_Mount_Backend *backend;
-
-    // check gimbal device id.  0 is primary, 1 is 1st gimbal, 2 is
-    // 2nd gimbal, etc
-    const uint8_t instance = packet.gimbal_device_id;
-    if (instance == 0) {
-        backend = get_primary();
-    } else {
-        backend = get_instance(instance - 1);
-    }
+    auto *backend = mount_device_from_gimbal_id(packet.gimbal_device_id);
 
     if (backend == nullptr) {
         return;
@@ -1022,6 +988,20 @@ AP_Mount_Backend *AP_Mount::get_instance(uint8_t instance) const
         return nullptr;
     }
     return _backends[instance];
+}
+
+// This is the mapping between gimbal_device_id (defined by MAVLink) and actual devices (aka 'instances', 'backends')
+AP_Mount_Backend *AP_Mount::mount_device_from_gimbal_id(uint8_t gimbal_device_id) const
+{
+    // FIXME: This function's behavior when gimbal_device_id == 0 is a bug. (That should indicate 'all mounts', not 'primary'.)
+    // Affects: Users working with multiple mounts.
+    // Workaround: Leave this as-is until it can be fixed in synchrony with upstream to prevent unexpected behavior-change.
+    // See: https://github.com/ArduPilot/ardupilot/issues/31940
+    if (gimbal_device_id == 0) {
+        return get_primary();
+    } else {
+        return get_instance(gimbal_device_id - 1);
+    }
 }
 
 // pass a GIMBAL_REPORT message to the backend

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -233,13 +233,22 @@ void AP_Mount::update_fast()
 }
 
 // get_mount_type - returns the type of mount
-AP_Mount::Type AP_Mount::get_mount_type(uint8_t instance) const
+AP_Mount::Type AP_Mount::get_mount_type(uint8_t gimbal_device_id) const
 {
-    if (instance >= AP_MOUNT_MAX_INSTANCES) {
+    const auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return Type::None;
     }
 
-    return (Type)_params[instance].type.get();
+    // Because a device (aka "instance", "backend") does not own its params, utilize the index-alignment
+    // of the device & params arrays to retrieve them.
+    for (uint8_t instance=0; instance<AP_MOUNT_MAX_INSTANCES; instance++) {
+        if (device == _backends[instance]) {
+            return static_cast<Type>(_params[instance].type.get());
+        }
+    }
+    // This return should never be encountered, it exists merely as defensive programming.
+    return Type::None;
 }
 
 // has_pan_control - returns true if the mount has yaw control (required for copters)

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -253,27 +253,23 @@ AP_Mount::Type AP_Mount::get_mount_type(uint8_t gimbal_device_id) const
 }
 
 // has_pan_control - returns true if the mount has yaw control (required for copters)
-bool AP_Mount::has_pan_control(uint8_t instance) const
+bool AP_Mount::has_pan_control(uint8_t gimbal_device_id) const
 {
-    const auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    const auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return false;
     }
-
-    // ask backend if it support pan
-    return backend->has_pan_control();
+    return device->has_pan_control();
 }
 
 // get_mode - returns current mode of mount (i.e. Retracted, Neutral, RC_Targeting, GPS Point)
-MAV_MOUNT_MODE AP_Mount::get_mode(uint8_t instance) const
+MAV_MOUNT_MODE AP_Mount::get_mode(uint8_t gimbal_device_id) const
 {
-    const auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    const auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return MAV_MOUNT_MODE_RETRACT;
     }
-
-    // ask backend its mode
-    return backend->get_mode();
+    return device->get_mode();
 }
 
 // set_mode_to_default - restores the mode to it's default mode held in the MNTx__DEFLT_MODE parameter
@@ -295,82 +291,70 @@ void AP_Mount::set_mode_to_default(uint8_t gimbal_device_id)
 }
 
 // set_mode - sets mount's mode
-void AP_Mount::set_mode(uint8_t instance, enum MAV_MOUNT_MODE mode)
+void AP_Mount::set_mode(uint8_t gimbal_device_id, MAV_MOUNT_MODE mode)
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return;
     }
-
-    // call backend's set_mode
-    backend->set_mode(mode);
+    device->set_mode(mode);
 }
 
 // set yaw_lock used in RC_TARGETING mode.  If true, the gimbal's yaw target is maintained in earth-frame meaning it will lock onto an earth-frame heading (e.g. North)
 // If false (aka "follow") the gimbal's yaw is maintained in body-frame meaning it will rotate with the vehicle
-void AP_Mount::set_yaw_lock(uint8_t instance, bool yaw_lock)
+void AP_Mount::set_yaw_lock(uint8_t gimbal_device_id, bool yaw_lock)
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return;
     }
-
-    // call backend's set_yaw_lock
-    backend->set_yaw_lock(yaw_lock);
+    device->set_yaw_lock(yaw_lock);
 }
 
 // set roll_lock used in RC_TARGETING mode.  If true, the gimbal's roll target is maintained in earth-frame
 // If false (aka "follow") the gimbal's roll is maintained in body-frame meaning it will rotate with the vehicle
-void AP_Mount::set_roll_lock(uint8_t instance, bool roll_lock)
+void AP_Mount::set_roll_lock(uint8_t gimbal_device_id, bool roll_lock)
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return;
     }
-
-    // call backend's set_roll_lock
-    backend->set_roll_lock(roll_lock);
+    device->set_roll_lock(roll_lock);
 }
 
 // set pitch_lock used in RC_TARGETING mode.  If true, the gimbal's tilt target is maintained in earth-frame
 // If false (aka "follow") the gimbal's tilt is maintained in body-frame meaning it will tilt with the vehicle
-void AP_Mount::set_pitch_lock(uint8_t instance, bool pitch_lock)
+void AP_Mount::set_pitch_lock(uint8_t gimbal_device_id, bool pitch_lock)
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return;
     }
-
-    // call backend's set_pitch_lock
-    backend->set_pitch_lock(pitch_lock);
+    device->set_pitch_lock(pitch_lock);
 }
 
 
 // set angle target in degrees
 // roll and pitch are in earth-frame
 // yaw_is_earth_frame (aka yaw_lock) should be true if yaw angle is earth-frame, false if body-frame
-void AP_Mount::set_angle_target(uint8_t instance, float roll_deg, float pitch_deg, float yaw_deg, bool yaw_is_earth_frame)
+void AP_Mount::set_angle_target(uint8_t gimbal_device_id, float roll_deg, float pitch_deg, float yaw_deg, bool yaw_is_earth_frame)
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return;
     }
-
-    // send command to backend
-    backend->set_angle_target(roll_deg, pitch_deg, yaw_deg, yaw_is_earth_frame);
+    device->set_angle_target(roll_deg, pitch_deg, yaw_deg, yaw_is_earth_frame);
 }
 
 // sets rate target in deg/s
 // yaw_lock should be true if the yaw rate is earth-frame, false if body-frame (e.g. rotates with body of vehicle)
-void AP_Mount::set_rate_target(uint8_t instance, float roll_degs, float pitch_degs, float yaw_degs, bool yaw_lock)
+void AP_Mount::set_rate_target(uint8_t gimbal_device_id, float roll_degs, float pitch_degs, float yaw_degs, bool yaw_lock)
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return;
     }
-
-    // send command to backend
-    backend->set_rate_target(roll_degs, pitch_degs, yaw_degs, yaw_lock);
+    device->set_rate_target(roll_degs, pitch_degs, yaw_degs, yaw_lock);
 }
 
 MAV_RESULT AP_Mount::handle_command_do_mount_configure(const mavlink_command_int_t &packet)
@@ -641,62 +625,57 @@ void AP_Mount::send_gimbal_manager_status(mavlink_channel_t chan)
 
 #if AP_MOUNT_POI_TO_LATLONALT_ENABLED
 // get poi information.  Returns true on success and fills in gimbal attitude, location and poi location
-bool AP_Mount::get_poi(uint8_t instance, Quaternion &quat, Location &loc, Location &poi_loc) const
+bool AP_Mount::get_poi(uint8_t gimbal_device_id, Quaternion &quat, Location &loc, Location &poi_loc) const
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return false;
     }
-    return backend->get_poi(instance, quat, loc, poi_loc);
+    const uint8_t UNUSED = 0; // This will be removed in a commit in this same PR.
+    return device->get_poi(UNUSED, quat, loc, poi_loc);
 }
 #endif
 
 #if AP_MOUNT_POI_LOCK_ENABLED
 // lock currently viewed GPS point and switch to GPS Targeting mode
-void AP_Mount::set_poi_lock(uint8_t instance)
+void AP_Mount::set_poi_lock(uint8_t gimbal_device_id)
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return;
     }
-
-    // call backend's set_poi_lock
-    backend->set_poi_lock();
+    device->set_poi_lock();
 }
 
-void AP_Mount::clear_poi_lock(uint8_t instance)
+void AP_Mount::clear_poi_lock(uint8_t gimbal_device_id)
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return;
     }
-
-    // call backend's clear_poi_lock
-    backend->clear_poi_lock();
+    device->clear_poi_lock();
 }
 
-void AP_Mount::suspend_poi_lock(uint8_t instance)
+void AP_Mount::suspend_poi_lock(uint8_t gimbal_device_id)
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return;
     }
-
-    // call backend's suspend_poi_lock
-    backend->suspend_poi_lock();
+    device->suspend_poi_lock();
 }
 #endif // AP_MOUNT_POI_LOCK_ENABLED
 
 // get attitude as a quaternion.  returns true on success.
 // att_quat will be an earth-frame quaternion rotated such that
 // yaw is in body-frame.
-bool AP_Mount::get_attitude_quaternion(uint8_t instance, Quaternion& att_quat)
+bool AP_Mount::get_attitude_quaternion(uint8_t gimbal_device_id, Quaternion& att_quat)
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return false;
     }
-    return backend->get_attitude_quaternion(att_quat);
+    return device->get_attitude_quaternion(att_quat);
 }
 
 // get mount's current attitude in euler angles in degrees.  yaw angle is in body-frame
@@ -746,45 +725,45 @@ bool AP_Mount::pre_arm_checks(char *failure_msg, uint8_t failure_msg_len)
 }
 
 // get target rate in deg/sec. returns true on success
-bool AP_Mount::get_rate_target(uint8_t instance, float& roll_degs, float& pitch_degs, float& yaw_degs, bool& yaw_is_earth_frame)
+bool AP_Mount::get_rate_target(uint8_t gimbal_device_id, float& roll_degs, float& pitch_degs, float& yaw_degs, bool& yaw_is_earth_frame)
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return false;
     }
-    return backend->get_rate_target(roll_degs, pitch_degs, yaw_degs, yaw_is_earth_frame);
+    return device->get_rate_target(roll_degs, pitch_degs, yaw_degs, yaw_is_earth_frame);
 }
 
 // get target angle in deg. returns true on success
-bool AP_Mount::get_angle_target(uint8_t instance, float& roll_deg, float& pitch_deg, float& yaw_deg, bool& yaw_is_earth_frame)
+bool AP_Mount::get_angle_target(uint8_t gimbal_device_id, float& roll_deg, float& pitch_deg, float& yaw_deg, bool& yaw_is_earth_frame)
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return false;
     }
-    return backend->get_angle_target(roll_deg, pitch_deg, yaw_deg, yaw_is_earth_frame);
+    return device->get_angle_target(roll_deg, pitch_deg, yaw_deg, yaw_is_earth_frame);
 }
 
 #if AP_SCRIPTING_ENABLED
 // get mount target location. returns true on success
-bool AP_Mount::get_location_target(uint8_t instance, Location& target_loc)
+bool AP_Mount::get_location_target(uint8_t gimbal_device_id, Location& target_loc)
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return false;
     }
-    return backend->get_location_target(target_loc);
+    return device->get_location_target(target_loc);
 }
 #endif
 
 // accessory for scripting backends and logging
-void AP_Mount::set_attitude_euler(uint8_t instance, float roll_deg, float pitch_deg, float yaw_bf_deg)
+void AP_Mount::set_attitude_euler(uint8_t gimbal_device_id, float roll_deg, float pitch_deg, float yaw_bf_deg)
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return;
     }
-    backend->set_attitude_euler(roll_deg, pitch_deg, yaw_bf_deg);
+    device->set_attitude_euler(roll_deg, pitch_deg, yaw_bf_deg);
 }
 
 #if HAL_LOGGING_ENABLED
@@ -799,45 +778,44 @@ void AP_Mount::write_log()
     }
 }
 
-void AP_Mount::write_log(uint8_t instance, uint64_t timestamp_us)
+void AP_Mount::write_log(uint8_t gimbal_device_id, uint64_t timestamp_us)
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return;
     }
-    backend->write_log(timestamp_us);
+    device->write_log(timestamp_us);
 }
 #endif
 
 // point at system ID sysid
-void AP_Mount::set_target_sysid(uint8_t instance, uint8_t sysid)
+void AP_Mount::set_target_sysid(uint8_t gimbal_device_id, uint8_t sysid)
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return;
     }
-    // call instance's set target SYSID cmd
-    backend->set_target_sysid(sysid);
+    device->set_target_sysid(sysid);
 }
 
 // set_roi_target - sets target location that mount should attempt to point towards
-void AP_Mount::set_roi_target(uint8_t instance, const Location &target_loc)
+void AP_Mount::set_roi_target(uint8_t gimbal_device_id, const Location &target_loc)
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return;
     }
-    backend->set_roi_target(target_loc);
+    device->set_roi_target(target_loc);
 }
 
 // clear_roi_target - clears target location that mount should attempt to point towards
-void AP_Mount::clear_roi_target(uint8_t instance)
+void AP_Mount::clear_roi_target(uint8_t gimbal_device_id)
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return;
     }
-    backend->clear_roi_target();
+    device->clear_roi_target();
 }
 
 //
@@ -845,153 +823,153 @@ void AP_Mount::clear_roi_target(uint8_t instance)
 //
 
 // take a picture.  returns true on success
-bool AP_Mount::take_picture(uint8_t instance)
+bool AP_Mount::take_picture(uint8_t gimbal_device_id)
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return false;
     }
-    return backend->take_picture();
+    return device->take_picture();
 }
 
 // start or stop video recording.  returns true on success
 // set start_recording = true to start record, false to stop recording
-bool AP_Mount::record_video(uint8_t instance, bool start_recording)
+bool AP_Mount::record_video(uint8_t gimbal_device_id, bool start_recording)
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return false;
     }
-    return backend->record_video(start_recording);
+    return device->record_video(start_recording);
 }
 
 // set zoom specified as a rate or percentage
-bool AP_Mount::set_zoom(uint8_t instance, ZoomType zoom_type, float zoom_value)
+bool AP_Mount::set_zoom(uint8_t gimbal_device_id, ZoomType zoom_type, float zoom_value)
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return false;
     }
-    return backend->set_zoom(zoom_type, zoom_value);
+    return device->set_zoom(zoom_type, zoom_value);
 }
 
 // set focus specified as rate, percentage or auto
 // focus in = -1, focus hold = 0, focus out = 1
-SetFocusResult AP_Mount::set_focus(uint8_t instance, FocusType focus_type, float focus_value)
+SetFocusResult AP_Mount::set_focus(uint8_t gimbal_device_id, FocusType focus_type, float focus_value)
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return SetFocusResult::FAILED;
     }
-    return backend->set_focus(focus_type, focus_value);
+    return device->set_focus(focus_type, focus_value);
 }
 
 // set tracking to none, point or rectangle (see TrackingType enum)
 // if POINT only p1 is used, if RECTANGLE then p1 is top-left, p2 is bottom-right
 // p1,p2 are in range 0 to 1.  0 is left or top, 1 is right or bottom
-bool AP_Mount::set_tracking(uint8_t instance, TrackingType tracking_type, const Vector2f& p1, const Vector2f& p2)
+bool AP_Mount::set_tracking(uint8_t gimbal_device_id, TrackingType tracking_type, const Vector2f& p1, const Vector2f& p2)
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return false;
     }
-    return backend->set_tracking(tracking_type, p1, p2);
+    return device->set_tracking(tracking_type, p1, p2);
 }
 
 // set camera lens as a value from 0 to 5
-bool AP_Mount::set_lens(uint8_t instance, uint8_t lens)
+bool AP_Mount::set_lens(uint8_t gimbal_device_id, uint8_t lens)
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return false;
     }
-    return backend->set_lens(lens);
+    return device->set_lens(lens);
 }
 
 #if HAL_MOUNT_SET_CAMERA_SOURCE_ENABLED
 // set_camera_source is functionally the same as set_lens except primary and secondary lenses are specified by type
 // primary and secondary sources use the AP_Camera::CameraSource enum cast to uint8_t
-bool AP_Mount::set_camera_source(uint8_t instance, uint8_t primary_source, uint8_t secondary_source)
+bool AP_Mount::set_camera_source(uint8_t gimbal_device_id, uint8_t primary_source, uint8_t secondary_source)
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return false;
     }
-    return backend->set_camera_source(primary_source, secondary_source);
+    return device->set_camera_source(primary_source, secondary_source);
 }
 #endif
 
 // send camera information message to GCS
-void AP_Mount::send_camera_information(uint8_t instance, mavlink_channel_t chan) const
+void AP_Mount::send_camera_information(uint8_t gimbal_device_id, mavlink_channel_t chan) const
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    const auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return;
     }
-    backend->send_camera_information(chan);
+    device->send_camera_information(chan);
 }
 
 // send camera settings message to GCS
-void AP_Mount::send_camera_settings(uint8_t instance, mavlink_channel_t chan) const
+void AP_Mount::send_camera_settings(uint8_t gimbal_device_id, mavlink_channel_t chan) const
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    const auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return;
     }
-    backend->send_camera_settings(chan);
+    device->send_camera_settings(chan);
 }
 
 // send camera capture status message to GCS
-void AP_Mount::send_camera_capture_status(uint8_t instance, mavlink_channel_t chan) const
+void AP_Mount::send_camera_capture_status(uint8_t gimbal_device_id, mavlink_channel_t chan) const
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    const auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return;
     }
-    backend->send_camera_capture_status(chan);
+    device->send_camera_capture_status(chan);
 }
 
 #if AP_MOUNT_SEND_THERMAL_RANGE_ENABLED
 // send camera thermal range message to GCS
-void AP_Mount::send_camera_thermal_range(uint8_t instance, mavlink_channel_t chan) const
+void AP_Mount::send_camera_thermal_range(uint8_t gimbal_device_id, mavlink_channel_t chan) const
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    const auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return;
     }
-    backend->send_camera_thermal_range(chan);
+    device->send_camera_thermal_range(chan);
 }
 #endif
 
 // change camera settings not normally used by autopilot
 // setting values from AP_Camera::Setting enum
-bool AP_Mount::change_setting(uint8_t instance, CameraSetting setting, float value)
+bool AP_Mount::change_setting(uint8_t gimbal_device_id, CameraSetting setting, float value)
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return false;
     }
-    return backend->change_setting(setting, value);
+    return device->change_setting(setting, value);
 }
 
 // get rangefinder distance.  Returns true on success
-bool AP_Mount::get_rangefinder_distance(uint8_t instance, float& distance_m) const
+bool AP_Mount::get_rangefinder_distance(uint8_t gimbal_device_id, float& distance_m) const
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    const auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return false;
     }
-    return backend->get_rangefinder_distance(distance_m);
+    return device->get_rangefinder_distance(distance_m);
 }
 
 // enable/disable rangefinder.  Returns true on success
-bool AP_Mount::set_rangefinder_enable(uint8_t instance, bool enable)
+bool AP_Mount::set_rangefinder_enable(uint8_t gimbal_device_id, bool enable)
 {
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
+    auto *device = mount_device_from_gimbal_id(gimbal_device_id);
+    if (device == nullptr) {
         return false;
     }
-    return backend->set_rangefinder_enable(enable);
+    return device->set_rangefinder_enable(enable);
 }
 
 AP_Mount_Backend *AP_Mount::get_primary() const

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -72,7 +72,7 @@ void AP_Mount::init()
 
     // create each instance
     for (uint8_t instance=0; instance<AP_MOUNT_MAX_INSTANCES; instance++) {
-        switch (get_mount_type(instance)) {
+        switch (static_cast<Type>(_params[instance].type.get())) {
         case Type::None:
             break;
 #if HAL_MOUNT_SERVO_ENABLED
@@ -700,9 +700,9 @@ bool AP_Mount::get_attitude_euler(uint8_t gimbal_device_id, float& roll_deg, flo
 // any failure_msg returned will not include a prefix
 bool AP_Mount::pre_arm_checks(char *failure_msg, uint8_t failure_msg_len)
 {
-    // check type parameters
+    // Check that every mount with a non-none type was instantiated.
     for (uint8_t i=0; i<AP_MOUNT_MAX_INSTANCES; i++) {
-        if ((get_mount_type(i) != Type::None) && (_backends[i] == nullptr)) {
+        if ((static_cast<Type>(_params[i].type.get()) != Type::None) && (_backends[i] == nullptr)) {
             strncpy(failure_msg, "check TYPE", failure_msg_len);
             return false;
         }

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -676,11 +676,11 @@ bool AP_Mount::get_attitude_quaternion(uint8_t gimbal_device_id, Quaternion& att
 
 // get mount's current attitude in euler angles in degrees.  yaw angle is in body-frame
 // returns true on success
-bool AP_Mount::get_attitude_euler(uint8_t instance, float& roll_deg, float& pitch_deg, float& yaw_bf_deg)
+bool AP_Mount::get_attitude_euler(uint8_t gimbal_device_id, float& roll_deg, float& pitch_deg, float& yaw_bf_deg)
 {
     // re-use get_attitude_quaternion and convert to Euler angles
     Quaternion att_quat;
-    if (!get_attitude_quaternion(instance, att_quat)) {
+    if (!get_attitude_quaternion(gimbal_device_id, att_quat)) {
         return false;
     }
 

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -359,12 +359,14 @@ void AP_Mount::set_rate_target(uint8_t gimbal_device_id, float roll_degs, float 
 
 MAV_RESULT AP_Mount::handle_command_do_mount_configure(const mavlink_command_int_t &packet)
 {
-    auto *backend = get_primary();
-    if (backend == nullptr) {
+    // MAVLink does not support gimbal_device_id in this message.
+    // Since it is unclear whether the spec implies commanding "the primary gimbal device" or "ALL gimbal devices",
+    // the (arbitrary?) choice is made clear here.
+    auto *device = mount_device_from_gimbal_id(get_gimbal_device_id_of_primary());
+    if (device == nullptr) {
         return MAV_RESULT_FAILED;
     }
-
-    backend->set_mode((MAV_MOUNT_MODE)packet.param1);
+    device->set_mode((MAV_MOUNT_MODE)packet.param1);
 
     return MAV_RESULT_ACCEPTED;
 }
@@ -372,12 +374,14 @@ MAV_RESULT AP_Mount::handle_command_do_mount_configure(const mavlink_command_int
 
 MAV_RESULT AP_Mount::handle_command_do_mount_control(const mavlink_command_int_t &packet)
 {
-    auto *backend = get_primary();
-    if (backend == nullptr) {
+    // MAVLink does not support gimbal_device_id in this message.
+    // Since it is unclear whether the spec implies commanding "the primary gimbal device" or "ALL gimbal devices",
+    // the (arbitrary?) choice is made clear here.
+    auto *device = mount_device_from_gimbal_id(get_gimbal_device_id_of_primary());
+    if (device == nullptr) {
         return MAV_RESULT_FAILED;
     }
-
-    return backend->handle_command_do_mount_control(packet);
+    return device->handle_command_do_mount_control(packet);
 }
 
 MAV_RESULT AP_Mount::handle_command_do_gimbal_manager_pitchyaw(const mavlink_command_int_t &packet)

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -982,12 +982,12 @@ AP_Mount_Backend *AP_Mount::get_primary() const
     return get_instance(_primary);
 }
 
-AP_Mount_Backend *AP_Mount::get_instance(uint8_t instance) const
+AP_Mount_Backend *AP_Mount::get_instance(uint8_t instance_index) const
 {
-    if (instance >= ARRAY_SIZE(_backends)) {
+    if (instance_index >= ARRAY_SIZE(_backends)) {
         return nullptr;
     }
-    return _backends[instance];
+    return _backends[instance_index];
 }
 
 // This is the mapping between gimbal_device_id (defined by MAVLink) and actual devices (aka 'instances', 'backends')

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -197,7 +197,6 @@ public:
 
     // sets rate target in deg/s
     // yaw_lock should be true if the yaw rate is earth-frame, false if body-frame (e.g. rotates with body of vehicle)
-    void set_rate_target(float roll_degs, float pitch_degs, float yaw_degs, bool yaw_lock) { set_rate_target(get_gimbal_device_id_of_primary(), roll_degs, pitch_degs, yaw_degs, yaw_lock); }
     void set_rate_target(uint8_t gimbal_device_id, float roll_degs, float pitch_degs, float yaw_degs, bool yaw_lock);
 
     // set_roi_target - sets target location that mount should attempt to point towards

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -344,7 +344,7 @@ protected:
 private:
     // Check if instance backend is ok
     AP_Mount_Backend *get_primary() const;
-    AP_Mount_Backend *get_instance(uint8_t instance) const;
+    AP_Mount_Backend *get_instance(uint8_t instance_index) const;
     AP_Mount_Backend *mount_device_from_gimbal_id(uint8_t gimbal_device_id) const;
 
     void handle_gimbal_report(mavlink_channel_t chan, const mavlink_message_t &msg);

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -150,17 +150,16 @@ public:
     Type get_mount_type(uint8_t gimbal_device_id) const;
 
     // has_pan_control - returns true if the mount has yaw control (required for copters)
-    bool has_pan_control() const { return has_pan_control(_primary); }
-    bool has_pan_control(uint8_t instance) const;
+    bool has_pan_control() const { return has_pan_control(get_gimbal_device_id_of_primary()); }
+    bool has_pan_control(uint8_t gimbal_device_id) const;
 
     // get_mode - returns current mode of mount (i.e. Retracted, Neutral, RC_Targeting, GPS Point)
-    enum MAV_MOUNT_MODE get_mode() const { return get_mode(_primary); }
-    enum MAV_MOUNT_MODE get_mode(uint8_t instance) const;
+    MAV_MOUNT_MODE get_mode() const { return get_mode(get_gimbal_device_id_of_primary()); }
+    MAV_MOUNT_MODE get_mode(uint8_t gimbal_device_id) const;
 
     // set_mode - sets mount's mode
-    //  returns true if mode is successfully set
-    void set_mode(enum MAV_MOUNT_MODE mode) { return set_mode(_primary, mode); }
-    void set_mode(uint8_t instance, enum MAV_MOUNT_MODE mode);
+    void set_mode(MAV_MOUNT_MODE mode) { return set_mode(get_gimbal_device_id_of_primary(), mode); }
+    void set_mode(uint8_t gimbal_device_id, MAV_MOUNT_MODE mode);
 
     // set_mode_to_default - restores the mode to it's default mode held in the MNTx_DEFLT_MODE parameter
     //      this operation requires 60us on a Pixhawk/PX4
@@ -168,50 +167,50 @@ public:
     void set_mode_to_default(uint8_t gimbal_device_id);
 
     // set pitch_lock used in RC_TARGETING mode.  If true, the gimbal's pitch target is maintained in earth-frame (horizon does not move up and down) rather than body frame
-    void set_pitch_lock(bool pitch_lock) { set_pitch_lock(_primary, pitch_lock); }
-    void set_pitch_lock(uint8_t instance, bool pitch_lock);
+    void set_pitch_lock(bool pitch_lock) { set_pitch_lock(get_gimbal_device_id_of_primary(), pitch_lock); }
+    void set_pitch_lock(uint8_t gimbal_device_id, bool pitch_lock);
 
     // set roll_lock used in RC_TARGETING mode.  If true, the gimbal's roll target is maintained in earth-frame (horizon does not rotate) rather than body frame
-    void set_roll_lock(bool roll_lock) { set_roll_lock(_primary, roll_lock); }
-    void set_roll_lock(uint8_t instance, bool roll_lock);
+    void set_roll_lock(bool roll_lock) { set_roll_lock(get_gimbal_device_id_of_primary(), roll_lock); }
+    void set_roll_lock(uint8_t gimbal_device_id, bool roll_lock);
 
     // set yaw_lock used in RC_TARGETING mode.  If true, the gimbal's yaw target is maintained in earth-frame meaning it will lock onto an earth-frame heading (e.g. North)
     // If false (aka "follow") the gimbal's yaw is maintained in body-frame meaning it will rotate with the vehicle
-    void set_yaw_lock(bool yaw_lock) { set_yaw_lock(_primary, yaw_lock); }
-    void set_yaw_lock(uint8_t instance, bool yaw_lock);
-    
+    void set_yaw_lock(bool yaw_lock) { set_yaw_lock(get_gimbal_device_id_of_primary(), yaw_lock); }
+    void set_yaw_lock(uint8_t gimbal_device_id, bool yaw_lock);
+
 #if AP_MOUNT_POI_LOCK_ENABLED
     // controls POI lock which locks gimbal to GPS point currently in view and switches to GPS Targeting mode, suspends tracking poi or clears it
-    void set_poi_lock() { set_poi_lock(_primary); }
-    void set_poi_lock(uint8_t instance);
-    void clear_poi_lock() { clear_poi_lock(_primary); }
-    void clear_poi_lock(uint8_t instance);
-    void suspend_poi_lock() { suspend_poi_lock(_primary); }
-    void suspend_poi_lock(uint8_t instance);
+    void set_poi_lock() { set_poi_lock(get_gimbal_device_id_of_primary()); }
+    void set_poi_lock(uint8_t gimbal_device_id);
+    void clear_poi_lock() { clear_poi_lock(get_gimbal_device_id_of_primary()); }
+    void clear_poi_lock(uint8_t gimbal_device_id);
+    void suspend_poi_lock() { suspend_poi_lock(get_gimbal_device_id_of_primary()); }
+    void suspend_poi_lock(uint8_t gimbal_device_id);
 #endif
 
     // set angle target in degrees
     // roll and pitch are in earth-frame
     // yaw_is_earth_frame (aka yaw_lock) should be true if yaw angle is earth-frame, false if body-frame
-    void set_angle_target(float roll_deg, float pitch_deg, float yaw_deg, bool yaw_is_earth_frame) { set_angle_target(_primary, roll_deg, pitch_deg, yaw_deg, yaw_is_earth_frame); }
-    void set_angle_target(uint8_t instance, float roll_deg, float pitch_deg, float yaw_deg, bool yaw_is_earth_frame);
+    void set_angle_target(float roll_deg, float pitch_deg, float yaw_deg, bool yaw_is_earth_frame) { set_angle_target(get_gimbal_device_id_of_primary(), roll_deg, pitch_deg, yaw_deg, yaw_is_earth_frame); }
+    void set_angle_target(uint8_t gimbal_device_id, float roll_deg, float pitch_deg, float yaw_deg, bool yaw_is_earth_frame);
 
     // sets rate target in deg/s
     // yaw_lock should be true if the yaw rate is earth-frame, false if body-frame (e.g. rotates with body of vehicle)
-    void set_rate_target(float roll_degs, float pitch_degs, float yaw_degs, bool yaw_lock) { set_rate_target(_primary, roll_degs, pitch_degs, yaw_degs, yaw_lock); }
-    void set_rate_target(uint8_t instance, float roll_degs, float pitch_degs, float yaw_degs, bool yaw_lock);
+    void set_rate_target(float roll_degs, float pitch_degs, float yaw_degs, bool yaw_lock) { set_rate_target(get_gimbal_device_id_of_primary(), roll_degs, pitch_degs, yaw_degs, yaw_lock); }
+    void set_rate_target(uint8_t gimbal_device_id, float roll_degs, float pitch_degs, float yaw_degs, bool yaw_lock);
 
     // set_roi_target - sets target location that mount should attempt to point towards
-    void set_roi_target(const Location &target_loc) { set_roi_target(_primary,target_loc); }
-    void set_roi_target(uint8_t instance, const Location &target_loc);
+    void set_roi_target(const Location &target_loc) { set_roi_target(get_gimbal_device_id_of_primary(), target_loc); }
+    void set_roi_target(uint8_t gimbal_device_id, const Location &target_loc);
 
     // clear_roi_target - clears target location that mount should attempt to point towards
-    void clear_roi_target() { clear_roi_target(_primary); }
-    void clear_roi_target(uint8_t instance);
+    void clear_roi_target() { clear_roi_target(get_gimbal_device_id_of_primary()); }
+    void clear_roi_target(uint8_t gimbal_device_id);
 
     // point at system ID sysid
-    void set_target_sysid(uint8_t sysid) { set_target_sysid(_primary, sysid); }
-    void set_target_sysid(uint8_t instance, uint8_t sysid);
+    void set_target_sysid(uint8_t sysid) { set_target_sysid(get_gimbal_device_id_of_primary(), sysid); }
+    void set_target_sysid(uint8_t gimbal_device_id, uint8_t sysid);
 
     // handling of set_roi_sysid message
     MAV_RESULT handle_command_do_set_roi_sysid(const mavlink_command_int_t &packet);
@@ -232,13 +231,13 @@ public:
 
 #if AP_MOUNT_POI_TO_LATLONALT_ENABLED
     // get poi information.  Returns true on success and fills in gimbal attitude, location and poi location
-    bool get_poi(uint8_t instance, Quaternion &quat, Location &loc, Location &poi_loc) const;
+    bool get_poi(uint8_t gimbal_device_id, Quaternion &quat, Location &loc, Location &poi_loc) const;
 #endif
 
     // get attitude as a quaternion.  returns true on success.
     // att_quat will be an earth-frame quaternion rotated such that
     // yaw is in body-frame.
-    bool get_attitude_quaternion(uint8_t instance, Quaternion& att_quat);
+    bool get_attitude_quaternion(uint8_t gimbal_device_id, Quaternion& att_quat);
 
     // get mount's current attitude in euler angles in degrees.  yaw angle is in body-frame
     // returns true on success
@@ -249,84 +248,84 @@ public:
     bool pre_arm_checks(char *failure_msg, uint8_t failure_msg_len);
 
     // get target rate in deg/sec. returns true on success
-    bool get_rate_target(uint8_t instance, float& roll_degs, float& pitch_degs, float& yaw_degs, bool& yaw_is_earth_frame);
+    bool get_rate_target(uint8_t gimbal_device_id, float& roll_degs, float& pitch_degs, float& yaw_degs, bool& yaw_is_earth_frame);
 
     // get target angle in deg. returns true on success
-    bool get_angle_target(uint8_t instance, float& roll_deg, float& pitch_deg, float& yaw_deg, bool& yaw_is_earth_frame);
+    bool get_angle_target(uint8_t gimbal_device_id, float& roll_deg, float& pitch_deg, float& yaw_deg, bool& yaw_is_earth_frame);
 
 #if AP_SCRIPTING_ENABLED
     // get mount target location. returns true on success
-    bool get_location_target(uint8_t instance, Location& target_loc);
+    bool get_location_target(uint8_t gimbal_device_id, Location& target_loc);
 #endif
 
     // accessors for scripting backends and logging
-    void set_attitude_euler(uint8_t instance, float roll_deg, float pitch_deg, float yaw_bf_deg);
+    void set_attitude_euler(uint8_t gimbal_device_id, float roll_deg, float pitch_deg, float yaw_bf_deg);
 
     // write mount log packet for all backends
     void write_log();
 
     // write mount log packet for a single backend (called by camera library)
-    void write_log(uint8_t instance, uint64_t timestamp_us);
+    void write_log(uint8_t gimbal_device_id, uint64_t timestamp_us);
 
     //
     // camera controls for gimbals that include a camera
     //
 
     // take a picture
-    bool take_picture(uint8_t instance);
+    bool take_picture(uint8_t gimbal_device_id);
 
     // start or stop video recording
     // set start_recording = true to start record, false to stop recording
-    bool record_video(uint8_t instance, bool start_recording);
+    bool record_video(uint8_t gimbal_device_id, bool start_recording);
 
     // set zoom specified as a rate or percentage
-    bool set_zoom(uint8_t instance, ZoomType zoom_type, float zoom_value);
+    bool set_zoom(uint8_t gimbal_device_id, ZoomType zoom_type, float zoom_value);
 
     // set focus specified as rate, percentage or auto
     // focus in = -1, focus hold = 0, focus out = 1
-    SetFocusResult set_focus(uint8_t instance, FocusType focus_type, float focus_value);
+    SetFocusResult set_focus(uint8_t gimbal_device_id, FocusType focus_type, float focus_value);
 
     // set tracking to none, point or rectangle (see TrackingType enum)
     // if POINT only p1 is used, if RECTANGLE then p1 is top-left, p2 is bottom-right
     // p1,p2 are in range 0 to 1.  0 is left or top, 1 is right or bottom
-    bool set_tracking(uint8_t instance, TrackingType tracking_type, const Vector2f& p1, const Vector2f& p2);
+    bool set_tracking(uint8_t gimbal_device_id, TrackingType tracking_type, const Vector2f& p1, const Vector2f& p2);
 
     // set camera lens as a value from 0 to 5
-    bool set_lens(uint8_t instance, uint8_t lens);
+    bool set_lens(uint8_t gimbal_device_id, uint8_t lens);
 
 #if HAL_MOUNT_SET_CAMERA_SOURCE_ENABLED
     // set_camera_source is functionally the same as set_lens except primary and secondary lenses are specified by type
     // primary and secondary sources use the AP_Camera::CameraSource enum cast to uint8_t
-    bool set_camera_source(uint8_t instance, uint8_t primary_source, uint8_t secondary_source);
+    bool set_camera_source(uint8_t gimbal_device_id, uint8_t primary_source, uint8_t secondary_source);
 #endif
 
     // send camera information message to GCS
-    void send_camera_information(uint8_t instance, mavlink_channel_t chan) const;
+    void send_camera_information(uint8_t gimbal_device_id, mavlink_channel_t chan) const;
 
     // send camera settings message to GCS
-    void send_camera_settings(uint8_t instance, mavlink_channel_t chan) const;
+    void send_camera_settings(uint8_t gimbal_device_id, mavlink_channel_t chan) const;
 
     // send camera capture status message to GCS
-    void send_camera_capture_status(uint8_t instance, mavlink_channel_t chan) const;
+    void send_camera_capture_status(uint8_t gimbal_device_id, mavlink_channel_t chan) const;
 
 #if AP_MOUNT_SEND_THERMAL_RANGE_ENABLED
     // send camera thermal range message to GCS
-    void send_camera_thermal_range(uint8_t instance, mavlink_channel_t chan) const;
+    void send_camera_thermal_range(uint8_t gimbal_device_id, mavlink_channel_t chan) const;
 #endif
 
     // change camera settings not normally used by autopilot
     // setting values from AP_Camera::Setting enum
-    bool change_setting(uint8_t instance, CameraSetting setting, float value);
+    bool change_setting(uint8_t gimbal_device_id, CameraSetting setting, float value);
 
     //
     // rangefinder
     //
 
     // get rangefinder distance.  Returns true on success
-    bool get_rangefinder_distance(uint8_t instance, float& distance_m) const;
+    bool get_rangefinder_distance(uint8_t gimbal_device_id, float& distance_m) const;
 
     // enable/disable rangefinder.  Returns true on success
-    bool set_rangefinder_enable(uint8_t instance, bool enable);
+    bool set_rangefinder_enable(uint8_t gimbal_device_id, bool enable);
 
     // parameter var table
     static const struct AP_Param::GroupInfo        var_info[];

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -146,11 +146,9 @@ public:
     uint8_t get_gimbal_device_id_of_primary() const { return _primary + 1; }
 
     // get_mount_type - returns the type of mount
-    Type get_mount_type() const { return get_mount_type(get_gimbal_device_id_of_primary()); }
     Type get_mount_type(uint8_t gimbal_device_id) const;
 
     // has_pan_control - returns true if the mount has yaw control (required for copters)
-    bool has_pan_control() const { return has_pan_control(get_gimbal_device_id_of_primary()); }
     bool has_pan_control(uint8_t gimbal_device_id) const;
 
     // get_mode - returns current mode of mount (i.e. Retracted, Neutral, RC_Targeting, GPS Point)
@@ -163,20 +161,16 @@ public:
 
     // set_mode_to_default - restores the mode to it's default mode held in the MNTx_DEFLT_MODE parameter
     //      this operation requires 60us on a Pixhawk/PX4
-    void set_mode_to_default() { set_mode_to_default(get_gimbal_device_id_of_primary()); }
     void set_mode_to_default(uint8_t gimbal_device_id);
 
     // set pitch_lock used in RC_TARGETING mode.  If true, the gimbal's pitch target is maintained in earth-frame (horizon does not move up and down) rather than body frame
-    void set_pitch_lock(bool pitch_lock) { set_pitch_lock(get_gimbal_device_id_of_primary(), pitch_lock); }
     void set_pitch_lock(uint8_t gimbal_device_id, bool pitch_lock);
 
     // set roll_lock used in RC_TARGETING mode.  If true, the gimbal's roll target is maintained in earth-frame (horizon does not rotate) rather than body frame
-    void set_roll_lock(bool roll_lock) { set_roll_lock(get_gimbal_device_id_of_primary(), roll_lock); }
     void set_roll_lock(uint8_t gimbal_device_id, bool roll_lock);
 
     // set yaw_lock used in RC_TARGETING mode.  If true, the gimbal's yaw target is maintained in earth-frame meaning it will lock onto an earth-frame heading (e.g. North)
     // If false (aka "follow") the gimbal's yaw is maintained in body-frame meaning it will rotate with the vehicle
-    void set_yaw_lock(bool yaw_lock) { set_yaw_lock(get_gimbal_device_id_of_primary(), yaw_lock); }
     void set_yaw_lock(uint8_t gimbal_device_id, bool yaw_lock);
 
 #if AP_MOUNT_POI_LOCK_ENABLED
@@ -192,7 +186,6 @@ public:
     // set angle target in degrees
     // roll and pitch are in earth-frame
     // yaw_is_earth_frame (aka yaw_lock) should be true if yaw angle is earth-frame, false if body-frame
-    void set_angle_target(float roll_deg, float pitch_deg, float yaw_deg, bool yaw_is_earth_frame) { set_angle_target(get_gimbal_device_id_of_primary(), roll_deg, pitch_deg, yaw_deg, yaw_is_earth_frame); }
     void set_angle_target(uint8_t gimbal_device_id, float roll_deg, float pitch_deg, float yaw_deg, bool yaw_is_earth_frame);
 
     // sets rate target in deg/s
@@ -206,7 +199,6 @@ public:
     void clear_roi_target(uint8_t gimbal_device_id);
 
     // point at system ID sysid
-    void set_target_sysid(uint8_t sysid) { set_target_sysid(get_gimbal_device_id_of_primary(), sysid); }
     void set_target_sysid(uint8_t gimbal_device_id, uint8_t sysid);
 
     // handling of set_roi_sysid message

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -200,11 +200,9 @@ public:
     void set_rate_target(uint8_t gimbal_device_id, float roll_degs, float pitch_degs, float yaw_degs, bool yaw_lock);
 
     // set_roi_target - sets target location that mount should attempt to point towards
-    void set_roi_target(const Location &target_loc) { set_roi_target(get_gimbal_device_id_of_primary(), target_loc); }
     void set_roi_target(uint8_t gimbal_device_id, const Location &target_loc);
 
     // clear_roi_target - clears target location that mount should attempt to point towards
-    void clear_roi_target() { clear_roi_target(get_gimbal_device_id_of_primary()); }
     void clear_roi_target(uint8_t gimbal_device_id);
 
     // point at system ID sysid

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -140,8 +140,10 @@ public:
     // used for gimbals that need to read INS data at full rate
     void update_fast();
 
-    // return primary instance ID
-    uint8_t get_primary_instance() const { return _primary; }
+    // This is useful for the transition to properly supporting gimbal device id.
+    // (ref: https://github.com/ArduPilot/ardupilot/issues/31940)
+    // Likely after that is complete, this can be removed.
+    uint8_t get_gimbal_device_id_of_primary() const { return _primary + 1; }
 
     // get_mount_type - returns the type of mount
     Type get_mount_type() const { return get_mount_type(_primary); }

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -343,8 +343,6 @@ protected:
     AP_Mount_Backend    *_backends[AP_MOUNT_MAX_INSTANCES];         // pointers to instantiated mounts
 
 private:
-    // Check if instance backend is ok
-    AP_Mount_Backend *get_primary() const;
     AP_Mount_Backend *get_instance(uint8_t instance_index) const;
     AP_Mount_Backend *mount_device_from_gimbal_id(uint8_t gimbal_device_id) const;
 

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -345,6 +345,7 @@ private:
     // Check if instance backend is ok
     AP_Mount_Backend *get_primary() const;
     AP_Mount_Backend *get_instance(uint8_t instance) const;
+    AP_Mount_Backend *mount_device_from_gimbal_id(uint8_t gimbal_device_id) const;
 
     void handle_gimbal_report(mavlink_channel_t chan, const mavlink_message_t &msg);
 

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -146,8 +146,8 @@ public:
     uint8_t get_gimbal_device_id_of_primary() const { return _primary + 1; }
 
     // get_mount_type - returns the type of mount
-    Type get_mount_type() const { return get_mount_type(_primary); }
-    Type get_mount_type(uint8_t instance) const;
+    Type get_mount_type() const { return get_mount_type(get_gimbal_device_id_of_primary()); }
+    Type get_mount_type(uint8_t gimbal_device_id) const;
 
     // has_pan_control - returns true if the mount has yaw control (required for copters)
     bool has_pan_control() const { return has_pan_control(_primary); }

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -241,7 +241,7 @@ public:
 
     // get mount's current attitude in euler angles in degrees.  yaw angle is in body-frame
     // returns true on success
-    bool get_attitude_euler(uint8_t instance, float& roll_deg, float& pitch_deg, float& yaw_bf_deg);
+    bool get_attitude_euler(uint8_t gimbal_device_id, float& roll_deg, float& pitch_deg, float& yaw_bf_deg);
 
     // run pre-arm check.  returns false on failure and fills in failure_msg
     // any failure_msg returned will not include a prefix

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -164,8 +164,8 @@ public:
 
     // set_mode_to_default - restores the mode to it's default mode held in the MNTx_DEFLT_MODE parameter
     //      this operation requires 60us on a Pixhawk/PX4
-    void set_mode_to_default() { set_mode_to_default(_primary); }
-    void set_mode_to_default(uint8_t instance);
+    void set_mode_to_default() { set_mode_to_default(get_gimbal_device_id_of_primary()); }
+    void set_mode_to_default(uint8_t gimbal_device_id);
 
     // set pitch_lock used in RC_TARGETING mode.  If true, the gimbal's pitch target is maintained in earth-frame (horizon does not move up and down) rather than body frame
     void set_pitch_lock(bool pitch_lock) { set_pitch_lock(_primary, pitch_lock); }

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -285,7 +285,7 @@ void AP_Mount_Backend::update_poi_lock_target()
     Location vehicle_location;
     Location target_location;
     // if poi available, use it and start tracking, otherwise give warning, stop poi retrieval attempts
-    if (get_poi(_instance, quat, vehicle_location, target_location)) {
+    if (get_poi(quat, vehicle_location, target_location)) {
         set_roi_target(target_location);
         mnt_target.poi_start_ms = 0;
     } else if (AP_HAL::millis() - mnt_target.poi_start_ms > 5000) {
@@ -618,7 +618,7 @@ void AP_Mount_Backend::write_log(uint64_t timestamp_us)
 
 #if AP_MOUNT_POI_TO_LATLONALT_ENABLED
 // get poi information.  Returns true on success and fills in gimbal attitude, location and poi location
-bool AP_Mount_Backend::get_poi(uint8_t instance, Quaternion &quat, Location &loc, Location &poi_loc)
+bool AP_Mount_Backend::get_poi(Quaternion &quat, Location &loc, Location &poi_loc)
 {
     WITH_SEMAPHORE(poi_calculation.sem);
 

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -581,7 +581,8 @@ void AP_Mount_Backend::write_log(uint64_t timestamp_us)
     float pitch = nanf;
     float yaw_bf = nanf;
     float yaw_ef = nanf;
-    if (_frontend.get_attitude_euler(_instance, roll, pitch, yaw_bf)) {
+    const uint8_t gimbal_device_id = _instance + 1;
+    if (_frontend.get_attitude_euler(gimbal_device_id, roll, pitch, yaw_bf)) {
         yaw_ef = wrap_180(yaw_bf + degrees(ahrs_yaw));
     }
 

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -223,7 +223,7 @@ public:
 
 #if AP_MOUNT_POI_TO_LATLONALT_ENABLED
     // get poi information.  Returns true on success and fills in gimbal attitude, location and poi location
-    bool get_poi(uint8_t instance, Quaternion &quat, Location &loc, Location &poi_loc);
+    bool get_poi(Quaternion &quat, Location &loc, Location &poi_loc);
 #endif
 
     //

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -712,8 +712,10 @@ protected:
     MAV_RESULT handle_command_fixed_mag_cal_yaw(const mavlink_command_int_t &packet);
 
     MAV_RESULT handle_command_camera(const mavlink_command_int_t &packet);
-    MAV_RESULT handle_command_do_set_roi(const mavlink_command_int_t &packet);
-    virtual MAV_RESULT handle_command_do_set_roi(const Location &roi_loc);
+    MAV_RESULT handle_command_do_set_roi(const mavlink_command_int_t &packet); // For MAV_CMD_DO_SET_ROI (201)
+    MAV_RESULT handle_command_do_set_roi_location(const mavlink_command_int_t &packet); // For MAV_CMD_DO_SET_ROI_LOCATION (195)
+    virtual MAV_RESULT handle_command_do_set_roi_location(const uint8_t gimbal_device_id, const Location &roi_loc);
+    MAV_RESULT handle_command_do_set_roi_none(const mavlink_command_int_t &packet); // MAV_CMD_DO_SET_ROI_NONE (197)
     MAV_RESULT handle_command_do_gripper(const mavlink_command_int_t &packet);
     MAV_RESULT handle_command_do_sprayer(const mavlink_command_int_t &packet);
     MAV_RESULT handle_command_do_set_mode(const mavlink_command_int_t &packet);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -5415,31 +5415,6 @@ void GCS_MAVLINK::handle_command_long(const mavlink_message_t &msg)
 }
 #endif  // AP_MAVLINK_COMMAND_LONG_ENABLED
 
-MAV_RESULT GCS_MAVLINK::handle_command_do_set_roi(const Location &roi_loc)
-{
-#if HAL_MOUNT_ENABLED
-    AP_Mount *mount = AP::mount();
-    if (mount == nullptr) {
-        return MAV_RESULT_UNSUPPORTED;
-    }
-
-    // sanity check location
-    if (!roi_loc.check_latlng()) {
-        return MAV_RESULT_FAILED;
-    }
-
-    if (!roi_loc.initialised()) {
-        mount->clear_roi_target();
-    } else {
-        mount->set_roi_target(roi_loc);
-    }
-    return MAV_RESULT_ACCEPTED;
-#else
-    return MAV_RESULT_UNSUPPORTED;
-#endif
-}
-
-
 void GCS_MAVLINK::handle_landing_target(const mavlink_message_t &msg)
 {
     mavlink_landing_target_t m;
@@ -5539,26 +5514,68 @@ MAV_RESULT GCS_MAVLINK::handle_command_int_external_wind_estimate(const mavlink_
 }
 #endif // AP_AHRS_EXTERNAL_WIND_ESTIMATE_ENABLED
 
+// For MAV_CMD_DO_SET_ROI (201)
 MAV_RESULT GCS_MAVLINK::handle_command_do_set_roi(const mavlink_command_int_t &packet)
 {
-    // be aware that this method is called for both MAV_CMD_DO_SET_ROI
-    // and MAV_CMD_DO_SET_ROI_LOCATION.  If you intend to support any
-    // of the extra fields in the former then you will need to split
-    // off support for MAV_CMD_DO_SET_ROI_LOCATION (which doesn't
-    // support the extra fields).
+    // For parameter definitions, see https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_ROI
+    // Param1 _should_ always be an integer value, the choice to round is merely defensive programming.
+    const uint8_t roi_mode = static_cast<uint8_t>(std::round(packet.param1));
+    if (roi_mode != MAV_ROI::MAV_ROI_TARGET) {
+        return MAV_RESULT_UNSUPPORTED;
+    }
 
-    // param1 : /* Region of interest mode (not used)*/
-    // param2 : /* MISSION index/ target ID (not used)*/
-    // param3 : /* ROI index (not used)*/
-    // param4 : /* empty */
-    // x : lat
-    // y : lon
-    // z : alt
+    // Because MAVLink does not specify which sensor(s) is contolled by this command, the decision is made here.
+    const uint8_t gimbal_device_id_to_command = 0;
+
+    mavlink_command_int_t corresponding_packet{};
+    corresponding_packet.param1 = gimbal_device_id_to_command;
+    corresponding_packet.x = packet.x;
+    corresponding_packet.y = packet.y;
+    corresponding_packet.z = packet.z;
+    return handle_command_do_set_roi_location(corresponding_packet);
+}
+
+// For MAV_CMD_DO_SET_ROI_LOCATION (195)
+MAV_RESULT GCS_MAVLINK::handle_command_do_set_roi_location(const mavlink_command_int_t &packet)
+{
+    // For parameter definitions, see https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_ROI_LOCATION
     Location roi_loc;
     if (!location_from_command_t(packet, roi_loc)) {
         return MAV_RESULT_DENIED;
     }
-    return handle_command_do_set_roi(roi_loc);
+    return handle_command_do_set_roi_location(packet.param1, roi_loc);
+}
+
+MAV_RESULT GCS_MAVLINK::handle_command_do_set_roi_location(const uint8_t gimbal_device_id, const Location &roi_loc)
+{
+#if HAL_MOUNT_ENABLED
+    AP_Mount *mount = AP::mount();
+    if (mount == nullptr) {
+        return MAV_RESULT_UNSUPPORTED;
+    }
+
+    // sanity check location
+    if (!roi_loc.check_latlng()) {
+        return MAV_RESULT_FAILED;
+    }
+
+    if (!roi_loc.initialised()) {
+        mount->clear_roi_target(gimbal_device_id);
+    } else {
+        mount->set_roi_target(gimbal_device_id, roi_loc);
+    }
+    return MAV_RESULT_ACCEPTED;
+#else
+    return MAV_RESULT_UNSUPPORTED;
+#endif
+}
+
+// For MAV_CMD_DO_SET_ROI_NONE (197)
+MAV_RESULT GCS_MAVLINK::handle_command_do_set_roi_none(const mavlink_command_int_t &packet)
+{
+    // For parameter definitions, see https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_ROI_NONE
+    const Location uninitialized_loc;
+    return handle_command_do_set_roi_location(packet.param1, uninitialized_loc);
 }
 
 #if AP_FILESYSTEM_FORMAT_ENABLED
@@ -5711,13 +5728,13 @@ MAV_RESULT GCS_MAVLINK::handle_command_int_packet(const mavlink_command_int_t &p
         return handle_command_camera(packet);
 #endif
 
-    case MAV_CMD_DO_SET_ROI_NONE: {
-        const Location zero_loc;
-        return handle_command_do_set_roi(zero_loc);
-    }
+    case MAV_CMD_DO_SET_ROI_LOCATION:
+        return handle_command_do_set_roi_location(packet);
+
+    case MAV_CMD_DO_SET_ROI_NONE:
+        return handle_command_do_set_roi_none(packet);
 
     case MAV_CMD_DO_SET_ROI:
-    case MAV_CMD_DO_SET_ROI_LOCATION:
         return handle_command_do_set_roi(packet);
 
 #if HAL_MOUNT_ENABLED

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -1793,7 +1793,8 @@ bool RC_Channel::do_aux_function(const AuxFuncTrigger &trigger)
         if (mount == nullptr) {
             break;
         }
-        mount->set_yaw_lock(ch_flag == AuxSwitchPos::HIGH);
+        const uint8_t gimbal_device_id = 0; // command all mounts
+        mount->set_yaw_lock(gimbal_device_id, ch_flag == AuxSwitchPos::HIGH);
         break;
     }
 
@@ -1802,19 +1803,20 @@ bool RC_Channel::do_aux_function(const AuxFuncTrigger &trigger)
         if (mount == nullptr) {
             break;
         }
+        const uint8_t gimbal_device_id = 0; // command all mounts
         //low is FPV:no ef locks,high is HORIZON lock:roll/pitch ef lock,middle is only pitch ef lock
         switch (ch_flag) {
         case AuxSwitchPos::HIGH:
-            mount->set_roll_lock(true);
-            mount->set_pitch_lock(true);
+            mount->set_roll_lock(gimbal_device_id, true);
+            mount->set_pitch_lock(gimbal_device_id, true);
             break;
         case AuxSwitchPos::MIDDLE:
-            mount->set_roll_lock(false);
-            mount->set_pitch_lock(true);
+            mount->set_roll_lock(gimbal_device_id, false);
+            mount->set_pitch_lock(gimbal_device_id, true);
             break;
         case AuxSwitchPos::LOW:
-            mount->set_roll_lock(false);
-            mount->set_pitch_lock(false);
+            mount->set_roll_lock(gimbal_device_id, false);
+            mount->set_pitch_lock(gimbal_device_id, false);
             break;
         }
         break;

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -1411,11 +1411,11 @@ void RC_Channel::do_aux_function_fft_notch_tune(const AuxSwitchPos ch_flag)
  * Perform the RETRACT_MOUNT 1/2 process.
  * 
  * @param [in] ch_flag  Position of the switch. HIGH, MIDDLE and LOW.
- * @param [in] instance 0: RETRACT MOUNT 1 <br>
- *                      1: RETRACT MOUNT 2
+ * @param [in] gimbal_device_id 1: RETRACT MOUNT 1 <br>
+ *                              2: RETRACT MOUNT 2
 */
 #if HAL_MOUNT_ENABLED
-void RC_Channel::do_aux_function_retract_mount(const AuxSwitchPos ch_flag, const uint8_t instance)
+void RC_Channel::do_aux_function_retract_mount(const AuxSwitchPos ch_flag, const uint8_t gimbal_device_id)
 {
     AP_Mount *mount = AP::mount();
     if (mount == nullptr) {
@@ -1423,13 +1423,13 @@ void RC_Channel::do_aux_function_retract_mount(const AuxSwitchPos ch_flag, const
     }
     switch (ch_flag) {
     case AuxSwitchPos::HIGH:
-        mount->set_mode(instance,MAV_MOUNT_MODE_RETRACT);
+        mount->set_mode(gimbal_device_id, MAV_MOUNT_MODE_RETRACT);
         break;
     case AuxSwitchPos::MIDDLE:
         // nothing
         break;
     case AuxSwitchPos::LOW:
-        mount->set_mode_to_default(instance);
+        mount->set_mode_to_default(gimbal_device_id);
         break;
     }
 }
@@ -1781,11 +1781,11 @@ bool RC_Channel::do_aux_function(const AuxFuncTrigger &trigger)
 
 #if HAL_MOUNT_ENABLED
     case AUX_FUNC::RETRACT_MOUNT1:
-        do_aux_function_retract_mount(ch_flag, 0);
+        do_aux_function_retract_mount(ch_flag, 1);
         break;
 
     case AUX_FUNC::RETRACT_MOUNT2:
-        do_aux_function_retract_mount(ch_flag, 1);
+        do_aux_function_retract_mount(ch_flag, 2);
         break;
 
     case AUX_FUNC::MOUNT_YAW_LOCK: {
@@ -1845,7 +1845,8 @@ bool RC_Channel::do_aux_function(const AuxFuncTrigger &trigger)
         if (mount == nullptr) {
             break;
         }
-        mount->set_rangefinder_enable(0, ch_flag == AuxSwitchPos::HIGH);
+        const uint8_t gimbal_device_id = 1;
+        mount->set_rangefinder_enable(gimbal_device_id, ch_flag == AuxSwitchPos::HIGH);
         break;
     }
 #endif

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -510,7 +510,7 @@ protected:
     void do_aux_function_sprayer(const AuxSwitchPos ch_flag);
     void do_aux_function_generator(const AuxSwitchPos ch_flag);
     void do_aux_function_fft_notch_tune(const AuxSwitchPos ch_flag);
-    void do_aux_function_retract_mount(const AuxSwitchPos ch_flag, const uint8_t instance);
+    void do_aux_function_retract_mount(const AuxSwitchPos ch_flag, const uint8_t gimbal_device_id);
 
     typedef int8_t modeswitch_pos_t;
     virtual void mode_switch_changed(modeswitch_pos_t new_pos) {


### PR DESCRIPTION
This completes the conceptual improvement which began in #31980 : Users are responsible for specifying which gimbal device(s) they want to interact with.

In spots where the desired behavior was not clear, I made an educated guess. But more importantly, the code / comments make the choice explicit (in case it should be changed).

It is "chained" behind #31983 . (But since I can't do PR chains, it has all the commits from that and further-upstream PRs which have not yet landed in master.)

IMO there is opportunity for design-level clarity / improvement. I have ideas, but first should chat with folks who have more historical context & experience.

This PR is being created as "draft" because it is unlikely to land soon. I wanted to document the direction + share that the work exists.

It is tangential to issue #31940 .