### PR TITLE
SITL: add SIM_VICON_QUAL parameter for Vicon odometry quality

### DIFF
--- a/libraries/SITL/SIM_Vicon.cpp
+++ b/libraries/SITL/SIM_Vicon.cpp
@@ -141,6 +141,14 @@ const AP_Param::GroupInfo SIM::ViconParms::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("RATE",  10, ViconParms,  rate_hz, 50),
 
+    // @Param: QUAL
+    // @DisplayName: SITL vicon odometry quality
+    // @Description: SITL vicon odometry quality field sent in MAVLink ODOMETRY message (-1=failure, 0=unknown, 1-100=quality)
+    // @Units: %
+    // @Range: -1 100
+    // @User: Advanced
+    AP_GROUPINFO("QUAL", 11, ViconParms, quality, 50),
+
     AP_GROUPEND
 };
 
@@ -410,7 +418,7 @@ void Vicon::update_vicon_position_estimate(const Location &loc,
         child_frame_id: MAV_FRAME_BODY_FRD,
         reset_counter: 0,
         estimator_type: MAV_ESTIMATOR_TYPE_VIO,
-        quality: 50, // quality hardcoded to 50%
+        quality: (int8_t)constrain_int16(_sitl->vicon.quality.get(), -1, 100),
         };
         memcpy(odometry.pose_covariance, pose_cov, sizeof(pose_cov));
         memcpy(odometry.velocity_covariance, vel_cov, sizeof(vel_cov));

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -361,6 +361,7 @@ public:
         AP_Int8 type_mask;    // vicon message type mask (bit0:vision position estimate, bit1:vision speed estimate, bit2:vicon position estimate)
         AP_Vector3f vel_glitch;   // velocity glitch in m/s in vicon's local frame
         AP_Int16 rate_hz;     // vicon data rate in Hz
+        AP_Int8 quality;      // odometry quality [-1,100]
     };
     ViconParms vicon;
 #endif  // AP_SIM_VICON_ENABLED


### PR DESCRIPTION
This PR adds `SIM_VICON_QUAL` parameter to the SITL Vicon to make the MAVLink
ODOMETRY `quality` field configurable.
The default value is set to 50 to preserve existing behavior.
This allows testing failsafe behavior and arming checks based on quality threshold (`VISO_QUAL_MIN` parameter).

I tested in SITL.

- Case 1: `SIM_VICON_QUAL < VISO_QUAL_MIN`
  - EKF failsafe is triggered
  - Arming checks fail (`Need Position Estimate`)

```
param set SIM_VICON_QUAL 20
param set VISO_QUAL_MIN 21
AP: PreArm: Need Position Estimate
AP: EKF3 lane switch 1
AP: EKF variance

arm throttle
Got COMMAND_ACK: COMPONENT_ARM_DISARM: FAILED
AP: Arm: Need Position Estimate
AP: EKF3 IMU1 stopped aiding
AP: EKF3 IMU0 stopped aiding
```


- Case 2: `SIM_VICON_QUAL >= VISO_QUAL_MIN`
  - EKF resumes external nav aiding
  - Vehicle can arm successfully

```
param set VISO_QUAL_MIN 20
AP: EKF3 IMU1 is using external nav data
AP: EKF3 IMU1 initial pos NED = 0.1,-0.1,-0.1 (m)
AP: EKF3 IMU1 initial vel NED = 0.0,0.0,0.0 (m/s)
AP: EKF3 IMU0 is using external nav data
AP: EKF3 IMU0 initial pos NED = 0.1,-0.1,-0.1 (m)
AP: EKF3 IMU0 initial vel NED = 0.0,0.0,0.0 (m/s)

arm throttle
Got COMMAND_ACK: COMPONENT_ARM_DISARM: ACCEPTED
AP: Arming motors
ARMED
Arming checks disable
```