### PR TITLE
AP_GPS: fix SBF undulation usage

### DIFF
--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -440,7 +440,7 @@ AP_GPS_SBF::parse(uint8_t temp)
 
 static bool is_DNU(double value)
 {
-    constexpr double DNU = -2e-10f;
+    constexpr double DNU = -2e10f;
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfloat-equal" // suppress -Wfloat-equal as it's false positive when testing for DNU values
     return value == DNU;


### PR DESCRIPTION
Correct handling of ellipsoid and AMSL altitudes
from SBF receivers. Previously, undulation
was not applied properly, causing altitude
values to be reported as elipsoid only.

This is a slightly simpler version of https://github.com/ArduPilot/ardupilot/pull/30971 which adds an epsilon check into the mix.  Since this is a magic value we're looking for I think it makes sense to be a direct comparison.
