### PR TITLE
Copter: hide PLDP_* params when payload place is disabled

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1068,6 +1068,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
  */
 const AP_Param::GroupInfo ParametersG2::var_info2[] = {
 
+#if AC_PAYLOAD_PLACE_ENABLED
     // @Param: PLDP_THRESH
     // @DisplayName: Payload Place thrust ratio threshold
     // @Description: Ratio of vertical thrust during decent below which payload touchdown will trigger.
@@ -1098,6 +1099,7 @@ const AP_Param::GroupInfo ParametersG2::var_info2[] = {
     // @Range: 0 5
     // @User: Standard
     AP_GROUPINFO("PLDP_SPEED_DN", 4, ParametersG2, pldp_descent_speed_ms, 0.0),
+#endif  // AC_PAYLOAD_PLACE_ENABLED
 
     // @Param: SURFTRAK_TC
     // @DisplayName: Surface Tracking Filter Time Constant

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -679,11 +679,13 @@ public:
     AC_WeatherVane weathervane;
 #endif
 
+#if AC_PAYLOAD_PLACE_ENABLED
     // payload place parameters
     AP_Float pldp_thrust_placed_fraction;
     AP_Float pldp_range_finder_maximum_m;
     AP_Float pldp_delay_s;
     AP_Float pldp_descent_speed_ms;
+#endif  // AC_PAYLOAD_PLACE_ENABLED
 
     AP_Int8 att_enable;
     AP_Int8 att_decimation;


### PR DESCRIPTION
PLDP_* parameters are currently exposed even when payload place is disabled (AC_PAYLOAD_PLACE_ENABLED=0).

I confirmed in SITL that this change causes the PLDP_* parameters to become invisible when AC_PAYLOAD_PLACE_ENABLED=0.

- Before
```
Received 1364 parameters (ftp)
param show PLDP*
PLDP_DELAY       0.0
PLDP_RNG_MAX     0.0
PLDP_SPEED_DN    0.0
PLDP_THRESH      0.8999999761581421
```

- After
```
Received 1360 parameters (ftp)
param show PLDP*
```