### PR TITLE
AP_Mission: protect against FPE in mavlink_int_to_mission_cmd

### DIFF
--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -1100,7 +1100,11 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
         cmd.p1 = (passby << 8) | (acp & 0x00FF);
 #else
         // delay at waypoint in seconds (this is for copters???)
-        cmd.p1 = packet.param1;
+        // reject invalid param1 values to prevent floating point exception
+        if (packet.param1 < 0 || packet.param1 > UINT16_MAX) {
+            return MAV_MISSION_INVALID_PARAM1;
+        }
+        cmd.p1 = (uint16_t)packet.param1;
 #endif
     }
     break;


### PR DESCRIPTION
#31902  
This PR fixes a SIGFPE (Floating Point Exception) crash that occurs when uploading a mission file with an invalid large value in param1.

The Fix: Constrains the packet.param1 float value to UINT16_MAX before casting it to uint16_t. This prevents the overflow that was causing the arithmetic exception.

Verification: Tested in SITL using the reproduction steps from the issue (uploading a mission with 1e+10 in param1). Verified that the crash no longer occurs.