### PR TITLE
Subset - Fix clang and GCC compiler warnings

### DIFF
--- a/libraries/AP_Compass/AP_Compass_SITL.h
+++ b/libraries/AP_Compass/AP_Compass_SITL.h
@@ -18,7 +18,6 @@ public:
     void read(void) override;
 
 private:
-    uint8_t _compass_instance;
     SITL::SIM *_sitl;
 
     // delay buffer variables


### PR DESCRIPTION
This is a subset of the patches from https://github.com/ArduPilot/ardupilot/pull/31993/files

These were the only commits I could see as being correct and NFC, 'though there were several other patches that looked good.

