### PR TITLE
AP_InertialSensor: fix ADIS16507 data processing anomaly

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_ADIS1647x.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_ADIS1647x.cpp
@@ -169,7 +169,7 @@ bool AP_InertialSensor_ADIS1647x::check_product_id(uint16_t &prod_id)
     case PROD_ID_16507: {
         // can do up to 40G
         opmode = OpMode::Delta32;
-        expected_sample_rate_hz = 1200;
+        expected_sample_rate_hz = 1000;
         accel_scale = 392.0 / 2097152000.0;
         dvel_scale = 400.0 / (float)0x7FFFFFFF;
         _clip_limit = (40.0f - 0.5f) * GRAVITY_MSS;


### PR DESCRIPTION
Fixed issues related to ADIS16507 IMU data processing that caused incorrect gyroscope and acceleration values:
<img width="554" height="463" alt="image" src="https://github.com/user-attachments/assets/d49ace09-8688-4f4b-b293-1536d5f87962" />

- According to the if in line 235 , both 1200 and 1000 can obtain the value of REG_DEC_RATE_1000Hz(REG_DEC_RATE 1).

- However, the values ​​used in the calculation for lines 562 and 563 were incorrectly assigned as 1200, while the calculation formula in the Decimation Filter manual is 2000/(DEC_RATE + 1)=1000.
<img width="927" height="1266" alt="9cf0e8f563083d70473da8741edfa4d8" src="https://github.com/user-attachments/assets/45e4502c-ab90-4848-bf33-796fd69c6ef6" />
<img width="772" height="1039" alt="1e090a90e6ccd4aaf8f0e3fca3d04813" src="https://github.com/user-attachments/assets/0c9e893c-4714-4252-8fcf-646f669d332b" />

- Incorrect assignments led to abnormal sensor calculations and abnormal refresh rates.