### PR TITLE
.github: timeout colcon workflow after 60 minutes

### DIFF
--- a/.github/workflows/colcon.yml
+++ b/.github/workflows/colcon.yml
@@ -139,6 +139,7 @@ concurrency:
 jobs:
   build-test:
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
     container:
       image: ardupilot/ardupilot-dev-ros:latest
     strategy:


### PR DESCRIPTION
this one can get stuck for 10 hours - it doesn't take that long to pass!