### PR TITLE
.github: add cancel-in-progress to a pair of workflows

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,6 +3,11 @@ on:
   pull_request:
   push:
     branches: [master]
+
+concurrency:
+  group: ci-${{github.workflow}}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_branch_conventions.yml
+++ b/.github/workflows/test_branch_conventions.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ci-${{github.workflow}}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-merge-commits:
     runs-on: ubuntu-latest


### PR DESCRIPTION
this means if you push your branch existing running workflows will be cancelled

block is the same as present in most other workflows.
