### PR TITLE
AP_Mission: Update get_next_nav_cmd to account for do_jump

### DIFF
--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -551,8 +551,8 @@ bool AP_Mission::is_nav_cmd(const Mission_Command& cmd)
 ///     accounts for do_jump commands but never increments the jump's num_times_run (advance_current_nav_cmd is responsible for this)
 bool AP_Mission::get_next_nav_cmd(uint16_t start_index, Mission_Command& cmd)
 {
-  uint16_t cmd_index = start_index;
-  uint16_t jump_index = AP_MISSION_CMD_INDEX_NONE;
+    uint16_t cmd_index = start_index;
+    uint16_t jump_index = AP_MISSION_CMD_INDEX_NONE;
   
     while (cmd_index < (unsigned)_cmd_total) {
         // get next command


### PR DESCRIPTION
Updated AP_Mission get_next_nav_cmd to handle jumps more effectively. Now checks if the cmd_index has gone backwards and if so assumes it was a jump, and keeps checking instead of before where it was just going to the next command after the do_jumo.

This fixes a bug where if a DO_JUMP is performed and the target WP index is DO command, it won't be performed and skips to the next NAV command. Solves an issue where a LOITER_TO_ALT with a tangent exit is followed by a DO_JUMP_TAG and because the tag is not a NAV waypoint, it does not do the tangent exit.

This has been briefly tested in ArduPlane SITL and worked as intended.

Happy for more optimisation to be made if possible.

See issue #21534
