### PR TITLE
AP_Parachute: fail arming checks if AP_Relay not not available

### DIFF
--- a/libraries/AP_Parachute/AP_Parachute.cpp
+++ b/libraries/AP_Parachute/AP_Parachute.cpp
@@ -232,6 +232,7 @@ bool AP_Parachute::arming_checks(size_t buflen, char *buffer) const
             }
 #else
             hal.util->snprintf(buffer, buflen, "AP_Relay not available");
+            return false;
 #endif
         }
 


### PR DESCRIPTION
.... and it is configured to be used to deploy the parachute

... you'll currently get a whole bunch of warning messages but no failure.

This is a more conservative approach and probably should have been done when `AP_RELAY_ENABLED` was added.

