### PR TITLE
AP_InertialSensor: CLKIN support for ICM42688

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
@@ -877,8 +877,9 @@ void AP_InertialSensor_Invensensev3::set_filter_and_scaling(void)
         const uint8_t v = register_read(INV3REG_42XXX_INTF_CONFIG1);
 #if defined(INVENSENSEV3_CLKIN_BITMASK)
         uint8_t intf_config1 = (v & 0x3F) | 0x40;
-        // we only support setting RTC mode on IIM42652 now
-        if ((INVENSENSEV3_CLKIN_BITMASK & (1U << gyro_instance)) && (inv3_type == Invensensev3_Type::IIM42652)) {
+        // we only support setting RTC mode on IIM42652 and ICM42688 now
+        if ((INVENSENSEV3_CLKIN_BITMASK & (1U << gyro_instance)) &&
+            (inv3_type == Invensensev3_Type::IIM42652 || inv3_type == Invensensev3_Type::ICM42688)) {
             intf_config1 |= 0x04;   // enable RTC mode
             // setup pin9 function to CLKIN
             const uint8_t intf_config5 = register_read_bank(1, INV3REG_42XXX_INTF_CONFIG5);


### PR DESCRIPTION
I've added and verified `CLKIN` support on my 4.6.x playground fork, but apparently 4.7.x already had similar code so this is just plug & play. Registers & values are the same, [cross checked with the datasheet](https://product.tdk.com/system/files/dam/doc/product/sensor/mortion-inertial/imu/data_sheet/ds-000347-icm-42688-p-v1.6.pdf).

Works as expected in my playground. `CLKIN` register setup:
```
ap-clkin-527     [001] .....   105.852997: spi_transfer_start: spi1.0 0000000032c7ccec len=2 tx=[7b-04] rx=[00-00]
ap-clkin-527     [001] .....   105.853089: spi_transfer_start: spi1.0 0000000032c7ccec len=2 tx=[4d-55] rx=[00-00]
```

`CLKIN` disabled:
```
ap-noclk-416     [001] .....    66.904613: spi_transfer_start: spi1.0 000000002dd9fa6a len=2 tx=[7b-00] rx=[00-00]
ap-noclk-416     [001] .....    66.904706: spi_transfer_start: spi1.0 000000002dd9fa6a len=2 tx=[4d-51] rx=[00-00]
```