### PR TITLE
Scripting OSD

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -17543,6 +17543,62 @@ RTL_ALT_M 111
         self.wait_waypoint(num_wp-1, num_wp-1, timeout=120)
         self.wait_disarmed(timeout=60)
 
+    def ScriptingOSD(self):
+        '''test OSD scripting with waypoint mission - requires SFML OSD'''
+        # This test requires SITL to be built with SFML support:
+        #   ./waf configure --board sitl --enable-sfml --sitl-osd
+        # Without SFML, the OSD scripting bindings return nil and scripts fail.
+
+        # Check if OSD is compiled in by looking for OSD_TYPE parameter
+        try:
+            self.get_parameter("OSD_TYPE", timeout=5)
+        except NotAchievedException:
+            self.progress("OSD not compiled in, skipping test")
+            return
+
+        self.context_collect('STATUSTEXT')
+
+        # Install the OSD example script
+        self.install_example_script_context('osd.lua')
+
+        # When built with --sitl-osd, OSD_TYPE defaults to 2 and the OSD backend
+        # is initialized at process start. The OSD backend cannot be created
+        # after boot (OSD_TYPE requires process restart), so if not built with
+        # --sitl-osd, the test will detect this and skip gracefully.
+        # SIM_SPEEDUP=5 makes the OSD window visible longer for visual testing.
+        self.set_parameters({
+            "SCR_ENABLE": 1,
+            "OSD_TYPE": 2,  # SITL OSD (requires --sitl-osd at configure time)
+            "SIM_SPEEDUP": 5,  # Slow enough to see the OSD
+        })
+        self.reboot_sitl()
+
+        # The script prints "osd not available" when no OSD backend is present
+        # (SITL built without --sitl-osd); detect that and skip gracefully.
+        try:
+            self.wait_statustext("osd not available", timeout=5, check_context=True)
+            self.progress("OSD scripting not functional (SFML not enabled), skipping test")
+            return
+        except AutoTestTimeoutException:
+            # no error message means the OSD is working
+            pass
+
+        # AUTO_OPTIONS=3 allows arming and taking off in AUTO
+        self.set_parameter("AUTO_OPTIONS", 3)
+
+        # fly a mission while the script draws waypoint info to the OSD
+        # (type, north_offset_m, east_offset_m, alt_m)
+        self.start_flying_simple_relhome_mission([
+            (mavutil.mavlink.MAV_CMD_NAV_TAKEOFF, 0, 0, 20),
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 50, 0, 20),    # 50m North
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 50, 50, 20),   # 50m North, 50m East
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 0, 50, 20),    # 50m East
+            (mavutil.mavlink.MAV_CMD_NAV_RETURN_TO_LAUNCH, 0, 0, 0),
+        ])
+
+        # Wait for mission to complete (land and disarm)
+        self.wait_disarmed(timeout=180)
+
     def RTLYaw(self):
         '''test that vehicle yaws to original heading on RTL'''
         # 0 is WP_YAW_BEHAVIOR_NONE
@@ -18804,6 +18860,7 @@ return update, 1000
             self.RC_OPTIONS_1_FS_THR_ENABLE_0,
             self.ScriptingFlyVelocity,
             self.Scripting6DoFMotors,
+            self.ScriptingOSD,
             self.EK3_EXT_NAV_vel_without_vert,
             self.CompassLearnCopyFromEKF,
             self.AHRSAutoTrim,
@@ -19062,6 +19119,7 @@ return update, 1000
             "SMART_RTL_EnterLeave": "Causes a panic",
             "SMART_RTL_Repeat": "Currently fails due to issue with loop detection",
             "RTLStoppingDistanceSpeed": "Currently fails due to vehicle going off-course",
+            "ScriptingOSD": "Requires SFML which is not available in CI",
         }
 
 

--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -320,6 +320,11 @@ void AP_OSD::init()
 
 bool AP_OSD::init_backend(const AP_OSD::osd_types type, const uint8_t instance)
 {
+    // don't re-initialize if backend already exists
+    if (_backends[instance] != nullptr) {
+        return false;
+    }
+
     // check if we can run this backend instance in parallel with backend instance 0
     if (instance > 0) {
         if (_backends[0] && !_backends[0]->is_compatible_with_backend_type(type)) {
@@ -403,7 +408,20 @@ void AP_OSD::osd_thread()
             update_stats();
             update_current_screen();
         }
-        update_osd();
+#if AP_SCRIPTING_ENABLED
+        if (!scripting_override) {
+#endif
+            update_osd();
+#if AP_SCRIPTING_ENABLED
+        } else {
+            override_count++;
+            if (override_count > 20) {
+                // timeout after 2 seconds and return to normal OSD
+                scripting_override = false;
+                override_count = 0;
+            }
+        }
+#endif // AP_SCRIPTING_ENABLED
     }
 }
 

--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -409,10 +409,11 @@ void AP_OSD::osd_thread()
             update_current_screen();
         }
 #if AP_SCRIPTING_ENABLED
+        // hold the semaphore so scripting cannot draw to the OSD while the
+        // OSD thread is updating it, and vice versa
+        WITH_SEMAPHORE(_sem);
         if (!scripting_override) {
-#endif
             update_osd();
-#if AP_SCRIPTING_ENABLED
         } else {
             override_count++;
             if (override_count > 20) {
@@ -421,6 +422,8 @@ void AP_OSD::osd_thread()
                 override_count = 0;
             }
         }
+#else
+        update_osd();
 #endif // AP_SCRIPTING_ENABLED
     }
 }

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -657,6 +657,20 @@ public:
     void enable() {
         _disable = false;
     }
+#if AP_SCRIPTING_ENABLED
+    AP_OSD_Backend *scripting_get_backend() {
+        scripting_override = true;
+        override_count = 0;
+        return _backends[0];
+    }
+    void draw_screen() {
+        if (scripting_override) {
+            update_osd();
+        }
+    }
+    bool display_disabled() const { return _disable; }
+    uint8_t get_screen() const { return current_screen; }
+#endif // AP_SCRIPTING_ENABLED
 
     AP_OSD_AbstractScreen& get_screen(uint8_t idx) {
 #if OSD_PARAM_ENABLED
@@ -718,6 +732,11 @@ private:
     AP_OSD_Backend *_backends[OSD_MAX_INSTANCES];
     uint8_t _backend_count;
 
+#if AP_SCRIPTING_ENABLED
+    // bool for scripting override and counter to timeout override
+    bool scripting_override;
+    uint8_t override_count;
+#endif // AP_SCRIPTING_ENABLED
     static AP_OSD *_singleton;
     // multi-thread access support
     HAL_Semaphore _sem;

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -659,6 +659,9 @@ public:
     }
 #if AP_SCRIPTING_ENABLED
     AP_OSD_Backend *scripting_get_backend() {
+        // set the override under the semaphore so the OSD thread sees a
+        // consistent value; the scripting binding takes it again for the call
+        WITH_SEMAPHORE(_sem);
         scripting_override = true;
         override_count = 0;
         return _backends[0];

--- a/libraries/AP_OSD/AP_OSD_Backend.h
+++ b/libraries/AP_OSD/AP_OSD_Backend.h
@@ -61,6 +61,16 @@ public:
     // called by the OSD thread once
     virtual void osd_thread_run_once() { return; }
 
+#if OSD_ENABLED && AP_SCRIPTING_ENABLED
+    // passthrough OSD functions for use by scripting
+    bool display_disabled() const { return _osd.display_disabled(); }
+    uint8_t get_screen() const { return _osd.get_screen(); }
+    void draw_screen() { _osd.draw_screen(); }
+
+    // get semaphore for thread-safe access from scripting
+    HAL_Semaphore &get_semaphore() { return _osd.get_semaphore(); }
+#endif
+
     AP_OSD * get_osd()
     {
         return &_osd;

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -4500,3 +4500,33 @@ function DroneCAN_Handle_ud:request(target_node, payload) end
 ---@return boolean -- true if send succeeded
 function DroneCAN_Handle_ud:broadcast(payload) end
 
+-- OSD scripting backend access
+osd = {}
+
+-- write a string to the OSD at the given column and row
+---@param col integer -- column (0-29 typically)
+---@param row integer -- row (0-15 typically)
+---@param text string -- text to display
+function osd:write(col, row, text) end
+
+-- flush the OSD buffer to the display
+function osd:flush() end
+
+-- clear the OSD buffer
+function osd:clear() end
+
+-- request a screen redraw
+function osd:draw_screen() end
+
+-- get the aspect ratio correction factor
+---@return number
+function osd:get_aspect_ratio_correction() end
+
+-- get the current screen number
+---@return integer
+function osd:get_screen() end
+
+-- check if display is disabled
+---@return boolean
+function osd:display_disabled() end
+

--- a/libraries/AP_Scripting/examples/osd.lua
+++ b/libraries/AP_Scripting/examples/osd.lua
@@ -1,0 +1,243 @@
+--[[
+   OSD scripting example
+
+   This example demonstrates:
+   1. Taking control of the OSD display from a Lua script
+   2. Using OSD special symbols/characters
+   3. Calculating and displaying a direction arrow to the next waypoint
+--]]
+
+------------------------------------------------------------
+-- OSD Symbol Definitions
+-- Symbol codes differ between OSD backends:
+--   OSD_TYPE 1 = MAX7456 (analog OSD chip)
+--   OSD_TYPE 2 = SITL (uses MAX7456 font)
+--   OSD_TYPE 5 = MSP DisplayPort (digital HDZero, Walksnail, DJI)
+-- The script auto-detects the backend and uses appropriate symbols
+------------------------------------------------------------
+
+-- MAX7456 symbol codes (used by OSD_TYPE 1 and 2)
+local SYM_MAX7456 = {
+    M           = 0xB9, KM          = 0xBA, FT          = 0x0F, MI          = 0xBB,
+    ALT_M       = 0xB1, ALT_FT      = 0xB3, BATT_FULL   = 0x90, RSSI        = 0x01,
+    VOLT        = 0x06, AMP         = 0x9A, MAH         = 0x07, MS          = 0x9F,
+    FS          = 0x99, KMH         = 0xA1, MPH         = 0xB0, DEGR        = 0xA8,
+    PCNT        = 0x25, RPM         = 0xE0, ASPD        = 0xE1, GSPD        = 0xE2,
+    WSPD        = 0xE3, VSPD        = 0xE4, WPNO        = 0xE5, WPDIR       = 0xE6,
+    WPDST       = 0xE7, SAT_L       = 0x1E, SAT_R       = 0x1F, HDOP_L      = 0xBD,
+    HDOP_R      = 0xBE, GPS_LAT     = 0xA6, GPS_LONG    = 0xA7, HOME        = 0xBF,
+    WIND        = 0x16, DIST        = 0x22, NM          = 0xF1, ARROW_START = 0x60,
+    ARROW_COUNT = 16,   ARROW_RIGHT = 0xFD, ARROW_LEFT  = 0xFE, AH_H_START  = 0x80,
+    AH_H_COUNT  = 9,    AH_V_START  = 0xCA, AH_V_COUNT  = 6,    AH_CENTER_LINE_LEFT = 0x26,
+    AH_CENTER_LINE_RIGHT = 0x27, AH_CENTER = 0x7E, AH = 0xF3, HEADING_N   = 0x18,
+    HEADING_S   = 0x19, HEADING_E   = 0x1A, HEADING_W   = 0x1B, HEADING_DIVIDED_LINE = 0x1C,
+    HEADING_LINE = 0x1D, HEADING    = 0x89, UP_UP       = 0xA2, UP          = 0xA3,
+    DOWN        = 0xA4, DOWN_DOWN   = 0xA5, DEGREES_C   = 0x0E, DEGREES_F   = 0x0D,
+    ARMED       = 0x00, DISARMED    = 0xE9, ROLL0       = 0x2D, ROLLR       = 0xEA,
+    ROLLL       = 0xEB, PTCH0       = 0x7C, PTCHUP      = 0xEC, PTCHDWN     = 0xED,
+    ROLL        = 0xA9, PITCH       = 0xAF, XERR        = 0xEE, FLY         = 0x9C,
+    EFF         = 0xF2, MW          = 0xF4, CLK         = 0xBC, KILO        = 0x4B,
+    TERALT      = 0xEF, FENCE_ENABLED = 0xF5, FENCE_DISABLED = 0xF6, RNGFD = 0xF7,
+    LQ          = 0xF8, WATT        = 0xAE, WH          = 0xAB, BATT_UNKNOWN = 0x97,
+    DPS         = 0xAA, G           = 0xDF, KN          = 0xF0, FTMIN       = 0xE8,
+    FTSEC       = 0x99, RADIUS      = 0x7A, FLAP        = 0x23, SIDEBAR_R_ARROW = 0x09,
+    SIDEBAR_L_ARROW = 0x0A, SIDEBAR_A = 0x13, SIDEBAR_B = 0x14, SIDEBAR_C = 0x15,
+    SIDEBAR_D   = 0xDD, SIDEBAR_E   = 0xDB, SIDEBAR_F   = 0xDC, SIDEBAR_G   = 0xDA,
+    SIDEBAR_H   = 0xDE, SIDEBAR_I   = 0x11, SIDEBAR_J   = 0x12, DB          = 0xF9,
+    DBM         = 0xFA, SNR         = 0xFB, ANT         = 0xFC,
+}
+
+-- MSP DisplayPort symbol codes (used by OSD_TYPE 5)
+local SYM_MSP = {
+    M           = 0x0C, KM          = 0x7D, FT          = 0x0F, MI          = 0x7E,
+    ALT_M       = 0x0C, ALT_FT      = 0x0F, BATT_FULL   = 0x90, RSSI        = 0x01,
+    VOLT        = 0x06, AMP         = 0x9A, MAH         = 0x07, MS          = 0x9F,
+    FS          = 0x99, KMH         = 0x9E, MPH         = 0x9D, DEGR        = 0x08,
+    PCNT        = 0x25, RPM         = 0x12, ASPD        = 0x41, GSPD        = 0x47,
+    WSPD        = 0x57, VSPD        = 0x5E, WPNO        = 0x23, WPDIR       = 0xE6,
+    WPDST       = 0xE7, SAT_L       = 0x1E, SAT_R       = 0x1F, HDOP_L      = 0x48,
+    HDOP_R      = 0x44, GPS_LAT     = 0x89, GPS_LONG    = 0x98, HOME        = 0x11,
+    WIND        = 0x57, DIST        = 0x04, NM          = 0xF1, ARROW_START = 0x60,
+    ARROW_COUNT = 16,   ARROW_RIGHT = 0xFD, ARROW_LEFT  = 0xFE, AH_H_START  = 0x80,
+    AH_H_COUNT  = 9,    AH_V_START  = 0x82, AH_V_COUNT  = 6,    AH_CENTER_LINE_LEFT = 0x84,
+    AH_CENTER_LINE_RIGHT = 0x84, AH_CENTER = 0x2B, AH = 0xF3, HEADING_N   = 0x18,
+    HEADING_S   = 0x19, HEADING_E   = 0x1A, HEADING_W   = 0x1B, HEADING_DIVIDED_LINE = 0x1C,
+    HEADING_LINE = 0x1D, HEADING    = 0x89, UP_UP       = 0x68, UP          = 0x68,
+    DOWN        = 0x60, DOWN_DOWN   = 0x60, DEGREES_C   = 0x0E, DEGREES_F   = 0x0D,
+    ARMED       = 0x00, DISARMED    = 0x2A, ROLL0       = 0x2D, ROLLR       = 0x64,
+    ROLLL       = 0x6C, PTCH0       = 0x7C, PTCHUP      = 0x68, PTCHDWN     = 0x60,
+    ROLL        = 0xA9, PITCH       = 0xAF, XERR        = 0x21, FLY         = 0x9C,
+    EFF         = 0xF2, MW          = 0xF4, CLK         = 0x08, KILO        = 0x4B,
+    TERALT      = 0x7F, FENCE_ENABLED = 0xF5, FENCE_DISABLED = 0xF6, RNGFD = 0x7F,
+    LQ          = 0xF8, WATT        = 0xAE, WH          = 0xAB, BATT_UNKNOWN = 0x97,
+    DPS         = 0xAA, G           = 0xDF, KN          = 0xF0, FTMIN       = 0xE8,
+    FTSEC       = 0x99, RADIUS      = 0x7A, FLAP        = 0x23, SIDEBAR_R_ARROW = 0x03,
+    SIDEBAR_L_ARROW = 0x02, SIDEBAR_A = 0x13, SIDEBAR_B = 0x13, SIDEBAR_C = 0x13,
+    SIDEBAR_D   = 0x13, SIDEBAR_E   = 0x13, SIDEBAR_F   = 0x13, SIDEBAR_G   = 0x13,
+    SIDEBAR_H   = 0x13, SIDEBAR_I   = 0x13, SIDEBAR_J   = 0x13, DB          = 0xF9,
+    DBM         = 0xFA, SNR         = 0xFB, ANT         = 0xFC,
+}
+
+-- Select symbol table based on OSD_TYPE parameter
+-- OSD_TYPE: 1=MAX7456, 2=SITL, 3=MSP, 4=TXOnly, 5=MSP_DisplayPort
+local osd_type = param:get("OSD_TYPE")
+local SYM
+if osd_type == 5 then
+    SYM = SYM_MSP
+    gcs:send_text(6, "OSD script: using MSP DisplayPort symbols")
+else
+    SYM = SYM_MAX7456
+    gcs:send_text(6, "OSD script: using MAX7456 symbols")
+end
+
+------------------------------------------------------------
+-- Helper function to get arrow character for a given angle
+-- angle_deg: direction in degrees (0 = North, 90 = East, etc)
+-- Returns the appropriate arrow character from the 16-direction set
+------------------------------------------------------------
+local function get_arrow_char(angle_deg)
+    -- Normalize angle to 0-360
+    angle_deg = angle_deg % 360
+    if angle_deg < 0 then
+        angle_deg = angle_deg + 360
+    end
+
+    -- 16 arrows, each covers 22.5 degrees
+    -- Add 11.25 (half interval) for proper rounding
+    local arrow_index = math.floor((angle_deg + 11.25) / 22.5) % 16
+
+    return string.char(SYM.ARROW_START + arrow_index)
+end
+
+------------------------------------------------------------
+-- Helper to convert symbol index to character
+------------------------------------------------------------
+local function sym(index)
+    return string.char(index)
+end
+
+------------------------------------------------------------
+-- Calculate bearing between two locations
+-- Returns bearing in degrees (0-360, 0 = North)
+------------------------------------------------------------
+local function get_bearing_deg(loc1, loc2)
+    if not loc1 or not loc2 then
+        return nil
+    end
+    -- get_bearing returns centidegrees
+    return loc1:get_bearing(loc2) * 0.01
+end
+
+------------------------------------------------------------
+-- Check OSD availability
+------------------------------------------------------------
+-- The osd binding exists but may have no backend available at runtime
+-- (e.g., when SITL is not built with --enable-sfml --sitl-osd)
+-- We test availability by attempting a method call with pcall
+if not osd then
+    gcs:send_text(6, "OSD example: osd not available")
+    return
+end
+
+-- Test if the OSD backend is actually available by calling a method
+local osd_available = pcall(function() return osd:get_screen() end)
+if not osd_available then
+    gcs:send_text(6, "OSD example: osd not available")
+    return
+end
+
+------------------------------------------------------------
+-- Main update function
+------------------------------------------------------------
+local function update()
+    -- Clear the OSD
+    osd:clear()
+
+    -- Display the standard ArduPilot OSD screen as base
+    osd:draw_screen()
+
+    -- Get current vehicle location and heading
+    local current_loc = ahrs:get_location()
+    local heading_deg = ahrs:get_yaw_rad() * 57.2958  -- radians to degrees
+
+    -- Only show waypoint info if we have a mission loaded and are in AUTO mode
+    local dominated_by_vehicle_mode = function()
+        local mode = vehicle:get_mode()
+        -- AUTO mode is typically 3 for copter, check if navigating
+        return mode == 3  -- AUTO
+    end
+
+    local has_mission = mission and mission:num_commands() > 1
+
+    if has_mission and dominated_by_vehicle_mode() then
+        -- Get next waypoint location
+        local wp_loc = vehicle:get_target_location()
+
+        -- Display waypoint direction arrow if we have valid positions
+        if current_loc and wp_loc then
+            local dist_m = current_loc:get_distance(wp_loc)
+
+            -- Only show if distance is reasonable (< 100km)
+            if dist_m < 100000 then
+                -- Calculate absolute bearing to waypoint
+                local bearing_to_wp = get_bearing_deg(current_loc, wp_loc)
+
+                if bearing_to_wp then
+                    -- Calculate relative bearing (direction to turn)
+                    local relative_bearing = bearing_to_wp - heading_deg
+
+                    -- Get the arrow character for this relative bearing
+                    local arrow = get_arrow_char(relative_bearing)
+
+                    -- Display waypoint info in center, below status text (row 8)
+                    -- Format: [WP icon] [arrow] [distance]m
+                    osd:write(12, 9, sym(SYM.WPDIR) .. arrow .. string.format(" %d", math.floor(dist_m)) .. sym(SYM.M))
+                end
+            end
+        end
+    else
+        -- No active waypoint navigation, show home direction instead if available
+        local home_loc = ahrs:get_home()
+        if current_loc and home_loc then
+            local dist_m = current_loc:get_distance(home_loc)
+
+            -- Only show if distance is reasonable (< 100km) and we have a valid home
+            if dist_m < 100000 and dist_m > 0 then
+                local bearing_to_home = get_bearing_deg(current_loc, home_loc)
+                if bearing_to_home then
+                    local relative_bearing = bearing_to_home - heading_deg
+                    local arrow = get_arrow_char(relative_bearing)
+
+                    osd:write(12, 9, sym(SYM.HOME) .. arrow .. string.format(" %d", math.floor(dist_m)) .. sym(SYM.M))
+                end
+            end
+        end
+    end
+
+    -- Show some symbol examples at bottom of screen
+    local example_row = 13
+
+    -- Armed/disarmed status
+    if arming:is_armed() then
+        osd:write(1, example_row, sym(SYM.ARMED) .. " ARMED")
+    else
+        osd:write(1, example_row, sym(SYM.DISARMED) .. " DISARMED")
+    end
+
+    -- GPS satellite count with icon
+    local gps_sats = gps:num_sats(0)
+    osd:write(15, example_row, sym(SYM.SAT_L) .. sym(SYM.SAT_R) .. string.format("%d", gps_sats))
+
+    -- Battery voltage with icon
+    local voltage = battery:voltage(0)
+    if voltage then
+        osd:write(22, example_row, sym(SYM.VOLT) .. string.format("%.1f", voltage))
+    end
+
+    -- Flush the display
+    osd:flush()
+
+    return update, 100
+end
+
+return update()

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -1165,8 +1165,8 @@ userdata DroneCAN_Handle method subscribe boolean
 userdata DroneCAN_Handle manual check_message DroneCAN_Handle::check_message 0 4
 userdata DroneCAN_Handle manual_operator __gc DroneCAN_Handle::__gc
 
-include AP_OSD/AP_OSD_Backend.h depends defined(OSD_ENABLED) && OSD_ENABLED
-singleton AP_OSD_Backend depends defined(OSD_ENABLED) && OSD_ENABLED
+include AP_OSD/AP_OSD_Backend.h depends defined(OSD_ENABLED) && OSD_ENABLED && !defined(HAL_BUILD_AP_PERIPH)
+singleton AP_OSD_Backend depends defined(OSD_ENABLED) && OSD_ENABLED && !defined(HAL_BUILD_AP_PERIPH)
 singleton AP_OSD_Backend rename osd
 singleton AP_OSD_Backend get AP_OSD::get_singleton() == nullptr ? nullptr : AP_OSD::get_singleton()->scripting_get_backend()
 singleton AP_OSD_Backend semaphore

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -1165,3 +1165,15 @@ userdata DroneCAN_Handle method subscribe boolean
 userdata DroneCAN_Handle manual check_message DroneCAN_Handle::check_message 0 4
 userdata DroneCAN_Handle manual_operator __gc DroneCAN_Handle::__gc
 
+include AP_OSD/AP_OSD_Backend.h depends defined(OSD_ENABLED) && OSD_ENABLED
+singleton AP_OSD_Backend depends defined(OSD_ENABLED) && OSD_ENABLED
+singleton AP_OSD_Backend rename osd
+singleton AP_OSD_Backend get AP_OSD::get_singleton() == nullptr ? nullptr : AP_OSD::get_singleton()->scripting_get_backend()
+singleton AP_OSD_Backend semaphore
+singleton AP_OSD_Backend method write void uint8_t 0 UINT8_MAX uint8_t 0 UINT8_MAX string
+singleton AP_OSD_Backend method flush void
+singleton AP_OSD_Backend method clear void
+singleton AP_OSD_Backend method draw_screen void
+singleton AP_OSD_Backend method get_aspect_ratio_correction float
+singleton AP_OSD_Backend method get_screen uint8_t
+singleton AP_OSD_Backend method display_disabled boolean

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -33,6 +33,7 @@ char keyword_creation[]            = "creation";
 char keyword_manual_operator[]     = "manual_operator";
 char keyword_operator_getter[]     = "operator_getter";
 char keyword_field_valid_mask[]    = "valid_mask";
+char keyword_get[]                 = "get";
 
 
 // attributes (should include the leading ' )
@@ -429,6 +430,7 @@ struct userdata {
   char *creation; // name of a manual creation function if set, note that this will not be used internally
   int creation_args; // number of args for custom creation function
   char *operator_getter; // Custom function to get values for use in operators
+  char *get_string; // custom string to get object pointer
 };
 
 static struct userdata *parsed_userdata;
@@ -1163,6 +1165,15 @@ void handle_singleton(void) {
       error(ERROR_DEPENDS, "Expected a depends string for %s",node->name);
     }
     string_copy(&(node->dependency), depends);
+  } else if (strcmp(type, keyword_get) == 0) {
+    if (node->get_string != NULL) {
+      error(ERROR_SINGLETON, "Singletons only support a single get");
+    }
+    char *get = strtok(NULL, "");
+    if (get == NULL) {
+      error(ERROR_DEPENDS, "Expected a get string for %s",node->name);
+    }
+    string_copy(&(node->get_string), get);
   } else if (strcmp(type, keyword_literal) == 0) {
     node->flags |= UD_FLAG_LITERAL;
   } else if (strcmp(type, keyword_field) == 0) {
@@ -1172,7 +1183,7 @@ void handle_singleton(void) {
   } else if (strcmp(type, keyword_manual) == 0) {
     handle_manual(node, ALIAS_TYPE_MANUAL);
   } else {
-    error(ERROR_SINGLETON, "Singletons only support renames, methods, semaphore, depends, literal or manual keywords (got %s)", type);
+    error(ERROR_SINGLETON, "Singletons only support renames, methods, semaphore, depends, get, literal or manual keywords (got %s)", type);
   }
 
   // ensure no more tokens on the line
@@ -1420,7 +1431,11 @@ void emit_singleton_checkers(void) {
     if (!(node->flags & UD_FLAG_LITERAL) && (node->methods != NULL)) {
       start_dependency(source, node->dependency);
       fprintf(source, "%s * check_%s(lua_State *L) {\n", node->name, node->sanitized_name);
-      fprintf(source, "    %s * ud = %s::get_singleton();\n", node->name, node->name);
+      if (node->get_string == NULL) {
+        fprintf(source, "    %s * ud = %s::get_singleton();\n", node->name, node->name);
+      } else {
+        fprintf(source, "    %s * ud = %s;\n", node->name, node->get_string);
+      }
       fprintf(source, "    if (ud == nullptr) {\n");
       fprintf(source, "        // This error will never return, so there is no danger of returning a nullptr\n");
       fprintf(source, "        not_supported_error(L, 1, \"%s\");\n", node->rename ? node->rename : node->name);


### PR DESCRIPTION
This is a rebase of https://github.com/ArduPilot/ardupilot/pull/18000

## Summary
Adds Lua scripting bindings for OSD, allowing scripts to write custom content to OSD displays.

### Features
- `osd:write(col, row, text)` - Write text at position
- `osd:clear()` - Clear OSD buffer
- `osd:flush()` - Push buffer to display
- `osd:draw_screen()` - Request screen redraw
- `osd:get_backend_count()` - Get number of backends
- `osd:get_backend_type(i)` - Get backend type

### Example Script
See `libraries/AP_Scripting/examples/osd.lua` for a full example demonstrating:
- Flight mode display
- Battery status with symbol
- Altitude and ground speed
- GPS status
- Waypoint navigation info (when in AUTO mode with mission)
- Support for both MAX7456 and MSP DisplayPort symbol tables

## Testing

### Running the autotest with SFML OSD display

To see the OSD window during testing, build SITL with SFML support:

```bash
# Configure with SFML OSD enabled
./waf configure --board sitl --enable-sfml --sitl-osd

# Build copter
./waf copter

# Run the ScriptingOSD test at slow speed (SIM_SPEEDUP=5 for visibility)
Tools/autotest/autotest.py test.Copter.ScriptingOSD
```

The test will:
1. Enable scripting and OSD
2. Install the example OSD script
3. Load a waypoint mission
4. Arm and fly the mission in AUTO mode
5. Display custom OSD content including waypoint distance

The SFML window shows the OSD output in real-time.

### Manual testing

```bash
# Start SITL with OSD
Tools/autotest/sim_vehicle.py -v ArduCopter --osd

# In MAVProxy console:
param set SCR_ENABLE 1
reboot

# Copy the example script
# scripts/osd.lua -> APM/scripts/osd.lua

# Reboot to load script
reboot
```

<img width="796" height="672" alt="image" src="https://github.com/user-attachments/assets/4641ed49-a99e-4b69-afcd-906525ebe251" />
