### PR TITLE
AP_RangeFinder: limit the list of rangefinders on minimised boards

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/include/minimize_common.inc
+++ b/libraries/AP_HAL_ChibiOS/hwdef/include/minimize_common.inc
@@ -144,3 +144,7 @@ define AP_SERVO_TELEM_ENABLED 0
 
 # don't send extra flight information on small boards
 define AP_MAVLINK_MSG_FLIGHT_INFORMATION_ENABLED 0
+
+# remove new rangefinders:
+define AP_RANGEFINDER_BENEWAKE_TFS20L_ENABLED 0
+define AP_RANGEFINDER_LIGHTWARE_GRF_ENABLED 0


### PR DESCRIPTION
freezes the list in time.  No new rangefinder support, keep old support.  Removes a pair of rangefinders which were added in the 4.7 cycle from these boards.
