### PR TITLE
AP_HAL_ESP32: fix GPIO pinMode bugs when using relays 

### DIFF
--- a/libraries/AP_HAL_ESP32/GPIO.h
+++ b/libraries/AP_HAL_ESP32/GPIO.h
@@ -15,7 +15,8 @@
 
 #pragma once
 
-#include "AP_HAL_ESP32.h"
+#include <AP_HAL/AP_HAL.h>
+#include "hal/gpio_types.h"
 
 class ESP32::GPIO : public AP_HAL::GPIO {
 public:
@@ -31,6 +32,9 @@ public:
 
     /* return true if USB cable is connected */
     bool    usb_connected(void) override;
+private:
+    /* inits with GPIO_MODE_DISABLE, which is safe */
+    gpio_mode_t _gpio_mode_cache[GPIO_NUM_MAX];
 };
 
 class ESP32::DigitalSource : public AP_HAL::DigitalSource {


### PR DESCRIPTION
fixes ArduPilot/ardupilot#32054

Unfortunately there is no [gpio_get_io_config function](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/peripherals/gpio.html#_CPPv418gpio_get_io_config10gpio_num_tP16gpio_io_config_t) in [esp idf v5.3](https://docs.espressif.com/projects/esp-idf/en/v5.3.4/esp32/api-reference/peripherals/gpio.html) that is currently used by AP_HAL_ESP32, so for now i have decided to store the current pin mode in static variable in pinMode method.