### PR TITLE
Sub: When disarmed and in manual mode, set throttle out to neutral value

### DIFF
--- a/ArduSub/config.h
+++ b/ArduSub/config.h
@@ -189,6 +189,10 @@
 # define AUTO_DISARMING_DELAY  0
 #endif
 
+#ifndef NEUTRAL_THROTTLE
+# define NEUTRAL_THROTTLE (0.5f)   // Throttle output for "no vertical thrust"
+#endif
+
 //////////////////////////////////////////////////////////////////////////////
 // Logging control
 //

--- a/ArduSub/mode_acro.cpp
+++ b/ArduSub/mode_acro.cpp
@@ -19,7 +19,7 @@ void ModeAcro::run()
     // if not armed set throttle to zero and exit immediately
     if (!motors.armed()) {
         motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
-        attitude_control->set_throttle_out(0,true,g.throttle_filt);
+        attitude_control->set_throttle_out(NEUTRAL_THROTTLE,true,g.throttle_filt);
         attitude_control->relax_attitude_controllers();
         return;
     }

--- a/ArduSub/mode_althold.cpp
+++ b/ArduSub/mode_althold.cpp
@@ -40,7 +40,7 @@ void ModeAlthold::run_pre()
     if (!motors.armed()) {
         motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
         // Sub vehicles do not stabilize roll/pitch/yaw when not auto-armed (i.e. on the ground, pilot has never raised throttle)
-        attitude_control->set_throttle_out(0.5,true,g.throttle_filt);
+        attitude_control->set_throttle_out(NEUTRAL_THROTTLE,true,g.throttle_filt);
         attitude_control->relax_attitude_controllers();
         position_control->D_relax_controller(motors.get_throttle_hover());
         sub.last_pilot_heading_rad = ahrs.get_yaw_rad();

--- a/ArduSub/mode_auto.cpp
+++ b/ArduSub/mode_auto.cpp
@@ -111,7 +111,7 @@ void ModeAuto::auto_wp_run()
         // call attitude controller
         // Sub vehicles do not stabilize roll/pitch/yaw when disarmed
         motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
-        attitude_control->set_throttle_out(0,true,g.throttle_filt);
+        attitude_control->set_throttle_out(NEUTRAL_THROTTLE,true,g.throttle_filt);
         attitude_control->relax_attitude_controllers();
         sub.wp_nav.wp_and_spline_init_m();                                                // Reset xy target
         return;
@@ -302,7 +302,7 @@ void ModeAuto::auto_loiter_run()
     if (!motors.armed()) {
         motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
         // Sub vehicles do not stabilize roll/pitch/yaw when disarmed
-        attitude_control->set_throttle_out(0,true,g.throttle_filt);
+        attitude_control->set_throttle_out(NEUTRAL_THROTTLE,true,g.throttle_filt);
         attitude_control->relax_attitude_controllers();
 
         sub.wp_nav.wp_and_spline_init_m();                                                // Reset xy target
@@ -479,7 +479,7 @@ void ModeAuto::auto_terrain_recover_run()
     // if not armed set throttle to zero and exit immediately
     if (!motors.armed()) {
         motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
-        attitude_control->set_throttle_out(0,true,g.throttle_filt);
+        attitude_control->set_throttle_out(NEUTRAL_THROTTLE,true,g.throttle_filt);
         attitude_control->relax_attitude_controllers();
 
         sub.loiter_nav.init_target();                                       // Reset xy target

--- a/ArduSub/mode_circle.cpp
+++ b/ArduSub/mode_circle.cpp
@@ -46,7 +46,7 @@ void ModeCircle::run()
         // To-Do: add some initialisation of position controllers
         motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
         // Sub vehicles do not stabilize roll/pitch/yaw when disarmed
-        attitude_control->set_throttle_out(0,true,g.throttle_filt);
+        attitude_control->set_throttle_out(NEUTRAL_THROTTLE,true,g.throttle_filt);
         attitude_control->relax_attitude_controllers();
         sub.circle_nav.init();
         return;

--- a/ArduSub/mode_guided.cpp
+++ b/ArduSub/mode_guided.cpp
@@ -464,7 +464,7 @@ void ModeGuided::guided_pos_control_run()
     if (!motors.armed()) {
         motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
         // Sub vehicles do not stabilize roll/pitch/yaw when disarmed
-        attitude_control->set_throttle_out(0,true,g.throttle_filt);
+        attitude_control->set_throttle_out(NEUTRAL_THROTTLE,true,g.throttle_filt);
         attitude_control->relax_attitude_controllers();
         sub.wp_nav.wp_and_spline_init_m();
         return;
@@ -529,7 +529,7 @@ void ModeGuided::guided_vel_control_run()
     if (!motors.armed()) {
         motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
         // Sub vehicles do not stabilize roll/pitch/yaw when disarmed
-        attitude_control->set_throttle_out(0,true,g.throttle_filt);
+        attitude_control->set_throttle_out(NEUTRAL_THROTTLE,true,g.throttle_filt);
         attitude_control->relax_attitude_controllers();
         // initialise velocity controller
         position_control->D_init_controller();
@@ -602,7 +602,7 @@ void ModeGuided::guided_posvel_control_run()
     if (!motors.armed()) {
         motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
         // Sub vehicles do not stabilize roll/pitch/yaw when disarmed
-        attitude_control->set_throttle_out(0,true,g.throttle_filt);
+        attitude_control->set_throttle_out(NEUTRAL_THROTTLE,true,g.throttle_filt);
         attitude_control->relax_attitude_controllers();
         // initialise velocity controller
         position_control->D_init_controller();
@@ -682,7 +682,7 @@ void ModeGuided::guided_angle_control_run()
     if (!motors.armed()) {
         motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
         // Sub vehicles do not stabilize roll/pitch/yaw when disarmed
-        attitude_control->set_throttle_out(0.0f,true,g.throttle_filt);
+        attitude_control->set_throttle_out(NEUTRAL_THROTTLE,true,g.throttle_filt);
         attitude_control->relax_attitude_controllers();
         // initialise velocity controller
         position_control->D_init_controller();

--- a/ArduSub/mode_manual.cpp
+++ b/ArduSub/mode_manual.cpp
@@ -19,7 +19,7 @@ void ModeManual::run()
     // if not armed set throttle to zero and exit immediately
     if (!sub.motors.armed()) {
         sub.motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
-        attitude_control->set_throttle_out(0,true,g.throttle_filt);
+        attitude_control->set_throttle_out(NEUTRAL_THROTTLE,true,g.throttle_filt);
         attitude_control->relax_attitude_controllers();
         return;
     }

--- a/ArduSub/mode_poshold.cpp
+++ b/ArduSub/mode_poshold.cpp
@@ -26,7 +26,7 @@ bool ModePoshold::init(bool ignore_checks)
     position_control->D_init_controller();
 
     // Stop all thrusters
-    attitude_control->set_throttle_out(0.5f ,true, g.throttle_filt);
+    attitude_control->set_throttle_out(NEUTRAL_THROTTLE ,true, g.throttle_filt);
     attitude_control->relax_attitude_controllers();
     position_control->D_relax_controller(0.5f);
 
@@ -44,7 +44,7 @@ void ModePoshold::run()
     if (!motors.armed()) {
         motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
         // Sub vehicles do not stabilize roll/pitch/yaw when not auto-armed (i.e. on the ground, pilot has never raised throttle)
-        attitude_control->set_throttle_out(0.5f ,true, g.throttle_filt);
+        attitude_control->set_throttle_out(NEUTRAL_THROTTLE ,true, g.throttle_filt);
         attitude_control->relax_attitude_controllers();
         position_control->NE_init_controller_stopping_point();
         position_control->D_relax_controller(0.5f);

--- a/ArduSub/mode_stabilize.cpp
+++ b/ArduSub/mode_stabilize.cpp
@@ -18,7 +18,7 @@ void ModeStabilize::run()
     // if not armed set throttle to zero and exit immediately
     if (!motors.armed()) {
         motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
-        attitude_control->set_throttle_out(0,true,g.throttle_filt);
+        attitude_control->set_throttle_out(NEUTRAL_THROTTLE,true,g.throttle_filt);
         attitude_control->relax_attitude_controllers();
         sub.last_pilot_heading_rad = ahrs.get_yaw_rad();
         return;

--- a/ArduSub/mode_surface.cpp
+++ b/ArduSub/mode_surface.cpp
@@ -25,7 +25,7 @@ void ModeSurface::run()
     if (!motors.armed()) {
         motors.output_min();
         motors.set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
-        attitude_control->set_throttle_out(0,true,g.throttle_filt);
+        attitude_control->set_throttle_out(NEUTRAL_THROTTLE,true,g.throttle_filt);
         attitude_control->relax_attitude_controllers();
         position_control->D_init_controller();
         return;


### PR DESCRIPTION
Fixes #32056 

We are working to confirm the issue and this change with our other BlueROVs.

Testing on a BlueROV2 Heavy running BlueOS-1.4.2 with Ardupilot 4.5.7 (also tested with 4.5.5). 

Under a very specific set of circumstances:

1. Vehicle in the water, armed, running in alt hold
1. Disarm vehicle
1. Set to manual mode
1. Arm vehicle (now in manual mode)
1. Set to alt hold mode

The vehicle will descend suddenly by ~1m, then stabilize at a depth slightly below its original depth. The second and third steps are interchangeable (manual then disarm or disarm then manual).
 
This patch sets the vertical throttle to 0.5 (neutral, no vertical thrust) when the vehicle is disabled in any of these modes:

* Acro
* Auto
* Circle
* Guided
* Manual
* PosHold
* Stabilize
* Surface

# Expected behavior

On **all** transitions into alt hold mode, the vehicle should hold the current vehicle depth.   