### PR TITLE
Global: Update multiple processes to use 8 bit constrain functions

### DIFF
--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -114,7 +114,7 @@ void ModeZigZag::run()
     pos_control->D_set_max_speed_accel_m(get_pilot_speed_dn_ms(), get_pilot_speed_up_ms(), get_pilot_accel_D_mss());
 
     // set the direction and the total number of lines
-    zigzag_direction = (Direction)constrain_int16(_direction, 0, 3);
+    zigzag_direction = (Direction)constrain_int8(_direction, 0, 3);
     line_num = constrain_int16(_line_num, ZIGZAG_LINE_INFINITY, INT16_MAX);
 
     // auto control
@@ -399,7 +399,7 @@ bool ModeZigZag::reached_destination()
     if (reach_wp_time_ms == 0) {
         reach_wp_time_ms = now;
     }
-    return ((now - reach_wp_time_ms) >= (uint16_t)constrain_int16(_wp_delay_s, 0, 127) * 1000);
+    return ((now - reach_wp_time_ms) >= (uint16_t)constrain_int8(_wp_delay_s, 0, 127) * 1000);
 }
 
 // calculate next destination according to vector A-B and current position

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -10,7 +10,7 @@ static uint32_t auto_disarm_begin;
 void Copter::auto_disarm_check()
 {
     uint32_t tnow_ms = millis();
-    uint32_t disarm_delay_ms = 1000*constrain_int16(g.disarm_delay, 0, INT8_MAX);
+    uint32_t disarm_delay_ms = 1000*constrain_int8(g.disarm_delay, 0, INT8_MAX);
 
     // exit immediately if we are already disarmed, or if auto
     // disarming is disabled

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -456,7 +456,7 @@ int8_t Plane::throttle_percentage(void)
 #endif
     float throttle = SRV_Channels::get_output_scaled(SRV_Channel::k_throttle);
     if (!have_reverse_thrust()) {
-        return constrain_int16(throttle, 0, 100);
+        return constrain_int8(throttle, 0, 100);
     }
-    return constrain_int16(throttle, -100, 100);
+    return constrain_int8(throttle, -100, 100);
 }

--- a/ArduSub/joystick.cpp
+++ b/ArduSub/joystick.cpp
@@ -308,7 +308,7 @@ void Sub::handle_jsbutton_press(uint8_t _button, bool shift, bool held)
             // check that our gain parameters are in correct range, update in eeprom and notify gcs if needed
             g.minGain.set_and_save(constrain_float(g.minGain, 0.10, 0.80));
             g.maxGain.set_and_save(constrain_float(g.maxGain, g.minGain, 1.0));
-            g.numGainSettings.set_and_save(constrain_int16(g.numGainSettings, 1, 10));
+            g.numGainSettings.set_and_save(constrain_int8(g.numGainSettings, 1, 10));
 
             if (g.numGainSettings == 1) {
                 gain = constrain_float(g.gain_default, g.minGain, g.maxGain);
@@ -324,7 +324,7 @@ void Sub::handle_jsbutton_press(uint8_t _button, bool shift, bool held)
             // check that our gain parameters are in correct range, update in eeprom and notify gcs if needed
             g.minGain.set_and_save(constrain_float(g.minGain, 0.10, 0.80));
             g.maxGain.set_and_save(constrain_float(g.maxGain, g.minGain, 1.0));
-            g.numGainSettings.set_and_save(constrain_int16(g.numGainSettings, 1, 10));
+            g.numGainSettings.set_and_save(constrain_int8(g.numGainSettings, 1, 10));
 
             if (g.numGainSettings == 1) {
                 gain = constrain_float(g.gain_default, g.minGain, g.maxGain);

--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -645,9 +645,9 @@ void AP_Periph_FW::handle_lightscommand(CanardInstance* canard_instance, CanardR
 #endif
         if (brightness != 100 && brightness >= 0) {
             const float scale = brightness * 0.01;
-            red = constrain_int16(red * scale, 0, 255);
-            green = constrain_int16(green * scale, 0, 255);
-            blue = constrain_int16(blue * scale, 0, 255);
+            red = constrain_uint8(red * scale, 0, 255);
+            green = constrain_uint8(green * scale, 0, 255);
+            blue = constrain_uint8(blue * scale, 0, 255);
         }
         set_rgb_led(red, green, blue);
     }

--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -466,7 +466,7 @@ void AP_BoardConfig::init()
     }
     
 #if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS && defined(USE_POSIX)
-    uint8_t slowdown = constrain_int16(_sdcard_slowdown.get(), 0, 32);
+    uint8_t slowdown = constrain_int8(_sdcard_slowdown.get(), 0, 32);
     const uint8_t max_slowdown = 8;
     do {
         if (AP::FS().retry_mount()) {

--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -858,9 +858,9 @@ void CompassCalibrator::AttitudeSample::set_from_ahrs(void)
     const Matrix3f &dcm = AP::ahrs().get_DCM_rotation_body_to_ned();
     float roll_rad, pitch_rad, yaw_rad;
     dcm.to_euler(&roll_rad, &pitch_rad, &yaw_rad);
-    roll = constrain_int16(127 * (roll_rad / M_PI), -INT8_MAX, INT8_MAX);
-    pitch = constrain_int16(127 * (pitch_rad / M_PI_2), -INT8_MAX, INT8_MAX);
-    yaw = constrain_int16(127 * (yaw_rad / M_PI), -INT8_MAX, INT8_MAX);
+    roll = constrain_int8(127 * (roll_rad / M_PI), -INT8_MAX, INT8_MAX);
+    pitch = constrain_int8(127 * (pitch_rad / M_PI_2), -INT8_MAX, INT8_MAX);
+    yaw = constrain_int8(127 * (yaw_rad / M_PI), -INT8_MAX, INT8_MAX);
 }
 
 Matrix3f CompassCalibrator::AttitudeSample::get_rotmat(void) const

--- a/libraries/AP_HAL_ChibiOS/SPIDevice.cpp
+++ b/libraries/AP_HAL_ChibiOS/SPIDevice.cpp
@@ -163,7 +163,7 @@ bool SPIDevice::set_speed(AP_HAL::Device::Speed speed)
  */
 void SPIDevice::set_slowdown(uint8_t slowdown)
 {
-    slowdown = constrain_int8(slowdown+1, 1, 32);
+    slowdown = constrain_uint8(slowdown+1, 1, 32);
     freq_flag_high = derive_freq_flag(device_desc.highspeed / slowdown);
 }
 

--- a/libraries/AP_HAL_ChibiOS/SPIDevice.cpp
+++ b/libraries/AP_HAL_ChibiOS/SPIDevice.cpp
@@ -163,7 +163,7 @@ bool SPIDevice::set_speed(AP_HAL::Device::Speed speed)
  */
 void SPIDevice::set_slowdown(uint8_t slowdown)
 {
-    slowdown = constrain_int16(slowdown+1, 1, 32);
+    slowdown = constrain_int8(slowdown+1, 1, 32);
     freq_flag_high = derive_freq_flag(device_desc.highspeed / slowdown);
 }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SCHA63T.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SCHA63T.cpp
@@ -94,7 +94,7 @@ void AP_InertialSensor_SCHA63T::start()
         bool fast_sampling = dev_uno->bus_type() == AP_HAL::Device::BUS_TYPE_SPI;
         if (fast_sampling) {
             // constrain the gyro rate to be a 2^N multiple
-            uint8_t fast_sampling_rate = constrain_int16(get_fast_sampling_rate(), 1, 4);
+            uint8_t fast_sampling_rate = constrain_uint8(get_fast_sampling_rate(), 1, 4);
             // calculate rate we will be giving samples to the backend
             backend_rate_hz = constrain_int16(backend_rate_hz * fast_sampling_rate, backend_rate_hz, BACKEND_SAMPLE_RATE_MAX);
         }

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -499,7 +499,7 @@ uint32_t AP_MotorsHeli_RSC::get_output_mask() const
 float AP_MotorsHeli_RSC::calculate_throttlecurve(float collective_in)
 {
     const float inpt = collective_in * 4.0f + 1.0f;
-    uint8_t idx = constrain_int16(int8_t(collective_in * 4), 0, 3);
+    uint8_t idx = constrain_int8(int8_t(collective_in * 4), 0, 3);
     const float a = inpt - (idx + 1.0f);
     const float b = (idx + 1.0f) - inpt + 1.0f;
     float throttle = _thrcrv_poly[idx][0] * a + _thrcrv_poly[idx][1] * b + _thrcrv_poly[idx][2] * (powf(a,3.0f) - a) / 6.0f + _thrcrv_poly[idx][3] * (powf(b,3.0f) - b) / 6.0f;

--- a/libraries/AP_OSD/AP_OSD_MAX7456.cpp
+++ b/libraries/AP_OSD/AP_OSD_MAX7456.cpp
@@ -342,8 +342,8 @@ void AP_OSD_MAX7456::reinit()
     _dev->write_register(MAX7456ADD_DMM, DMM_CLEAR_DISPLAY);
 
     //write osd position
-    int8_t hos = constrain_int16(_osd.h_offset, 0, 63);
-    int8_t vos = constrain_int16(_osd.v_offset, 0, 31);
+    int8_t hos = constrain_int8(_osd.h_offset, 0, 63);
+    int8_t vos = constrain_int8(_osd.v_offset, 0, 31);
     _dev->write_register(MAX7456ADD_HOS, hos);
     _dev->write_register(MAX7456ADD_VOS, vos);
     last_v_offset = _osd.v_offset;
@@ -363,14 +363,14 @@ void AP_OSD_MAX7456::flush()
 
     // check for offset changes
     if (last_v_offset != _osd.v_offset) {
-        int8_t vos = constrain_int16(_osd.v_offset, 0, 31);
+        int8_t vos = constrain_int8(_osd.v_offset, 0, 31);
         _dev->get_semaphore()->take_blocking();
         _dev->write_register(MAX7456ADD_VOS, vos);
         _dev->get_semaphore()->give();
         last_v_offset = _osd.v_offset;
     }
     if (last_h_offset != _osd.h_offset) {
-        int8_t hos = constrain_int16(_osd.h_offset, 0, 63);
+        int8_t hos = constrain_int8(_osd.h_offset, 0, 63);
         _dev->get_semaphore()->take_blocking();
         _dev->write_register(MAX7456ADD_HOS, hos);
         _dev->get_semaphore()->give();

--- a/libraries/AP_Radio/AP_Radio_backend.h
+++ b/libraries/AP_Radio/AP_Radio_backend.h
@@ -115,12 +115,12 @@ protected:
 
     uint8_t get_transmit_power(void) const
     {
-        return constrain_int16(radio.transmit_power.get(), 1, 8);
+        return constrain_int8(radio.transmit_power.get(), 1, 8);
     }
 
     uint8_t get_tx_max_power(void) const
     {
-        return constrain_int16(radio.tx_max_power.get(), 1, 8);
+        return constrain_int8(radio.tx_max_power.get(), 1, 8);
     }
 
     void set_tx_max_power_default(uint8_t v)

--- a/libraries/AR_Motors/AP_MotorsUGV.cpp
+++ b/libraries/AR_Motors/AP_MotorsUGV.cpp
@@ -590,8 +590,8 @@ bool AP_MotorsUGV::pre_arm_check(bool report) const
 // sanity check parameters
 void AP_MotorsUGV::sanity_check_parameters()
 {
-    _throttle_max.set(constrain_int16(_throttle_max, 5, 100));
-    _throttle_min.set(constrain_int16(_throttle_min, 0, MIN(20, _throttle_max)));
+    _throttle_max.set(constrain_int8(_throttle_max, 5, 100));
+    _throttle_min.set(constrain_int8(_throttle_min, 0, MIN(20, _throttle_max)));
     _vector_angle_max.set(constrain_float(_vector_angle_max, 0.0f, 90.0f));
 }
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -414,7 +414,7 @@ void GCS_MAVLINK::send_battery_status(const uint8_t instance) const
                                     current,      // current in centiampere
                                     consumed_mah, // total consumed current in milliampere.hour
                                     consumed_wh,  // consumed energy in hJ (hecto-Joules)
-                                    constrain_int16(percentage, -1, 100),
+                                    constrain_int8(percentage, -1, 100),
                                     time_remaining, // time remaining, seconds
                                     battery.get_mavlink_charge_state(instance), // battery charge state
                                     cell_mvolts_ext, // Cell 11..14 voltages


### PR DESCRIPTION
I am refactoring several locations to use constrain_int8 and constrain_uint8 where the variables are 8-bit types. This ensures type consistency and improves code clarity.