### PR TITLE
AP_Bootloader: add board ID for PilotGaeaSH7V1 #32027

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -331,6 +331,7 @@ AP_HW_Morakot                        1210
 AP_HW_CORVON_V5                      1211
 
 AP_HW_CSKY_PMU                       1212
+AP_HW_PilotGaeaSH7V1                 1213
 
 AP_HW_MUPilot                        1222
 AP_HW_HWH7                           1223


### PR DESCRIPTION
Add board ID 1213 for PilotGaeaSH7V1 flight controller.

## Board Specifications
- **MCU**: STM32H743
- **IMU**: ICM42688P x2 (SPI)
- **Barometer**: DPS310 (I2C)
- **Compass**: External compass (I2C)
- **Target vehicles**: Copter, Plane, Rover
- **Intended usage**: Commercial product

## Changes
- Assigned board ID **1213** in an available gap between IDs 1212 and 1222
- Followed the file's guidance to "fill gaps rather than adding past ID #7109"

## Status
- Hardware: Prototype available
- ArduPilot: hwdef completed and builds successfully
- Basic testing: Board powers on, runs Copter/Plane/Rover modes, sensors detected

Fixes #32027