### PR TITLE
Plane: fix roll lock mode in normal stabilize during ACRO mode

### DIFF
--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -241,7 +241,7 @@ protected:
     struct {
         bool locked_roll;
         bool locked_pitch;
-        float locked_roll_err;
+        float locked_roll_cd;
         int32_t locked_pitch_cd;
         Quaternion q;
         bool roll_active_last;

--- a/ArduPlane/mode_acro.cpp
+++ b/ArduPlane/mode_acro.cpp
@@ -13,7 +13,7 @@ void ModeAcro::update()
 {
     // handle locked/unlocked control
     if (acro_state.locked_roll) {
-        plane.nav_roll_cd = acro_state.locked_roll_err;
+        plane.nav_roll_cd = acro_state.locked_roll_cd;
     } else {
         plane.nav_roll_cd = ahrs.roll_sensor;
     }
@@ -63,17 +63,14 @@ void ModeAcro::stabilize()
          */
         if (!acro_state.locked_roll) {
             acro_state.locked_roll = true;
-            acro_state.locked_roll_err = 0;
-        } else {
-            acro_state.locked_roll_err += ahrs.get_gyro().x * plane.G_Dt;
+            acro_state.locked_roll_cd = ahrs.roll_sensor;
         }
-        int32_t roll_error_cd = -degrees(acro_state.locked_roll_err)*100;
-        plane.nav_roll_cd = ahrs.roll_sensor + roll_error_cd;
         // try to reduce the integrated angular error to zero. We set
         // 'stabilize' to true, which disables the roll integrator
-        SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, plane.rollController.get_servo_out(roll_error_cd,
-                                                                                             speed_scaler,
-                                                                                             true, false));
+        plane.nav_roll_cd = acro_state.locked_roll_cd;
+        SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, plane.rollController.get_servo_out(plane.nav_roll_cd - ahrs.roll_sensor,
+                                                                                         speed_scaler,
+                                                                                         true, false));
     } else {
         /*
           aileron stick is non-zero, use pure rate control until the


### PR DESCRIPTION
In Acro mode, when using `acro_locking`, we expect that with no roll stick input, the aircraft holds the roll at a fixed value. This is not the case, as show in the following screenshot, where we can see a drift of the roll value:
![acro_stabilze_base](https://github.com/user-attachments/assets/d97ef084-ac0c-4218-a3e7-c97291a880a8)
This PR fixes the issue by controlling the roll rate in the same way as the pitch rate, i.e. tracking a constant roll angle when there is no stick input. Resulting behavior is shown below:
![acro_stabilize_fixed](https://github.com/user-attachments/assets/cab08de5-794e-438a-8dcd-c8010fefcdeb)
