### PR TITLE
AP_NavEKF3: fix incorrect delta velocity bias covariance inhibit

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -1753,6 +1753,7 @@ void NavEKF3_core::CovariancePrediction(Vector3F *rotVarVecPtr)
         for (uint8_t index=0; index<3; index++) {
             const uint8_t stateIndex = index + 13;
             if (dvelBiasAxisInhibit[index]) {
+                zeroRows(nextP,stateIndex,stateIndex);
                 zeroCols(nextP,stateIndex,stateIndex);
                 nextP[stateIndex][stateIndex] = dvelBiasAxisVarPrev[index];
             }


### PR DESCRIPTION
`inhibitDelVelBiasStates` becomes false once tilt alignment is complete, which unlocks processing of states 13-15. If on the ground but tilted a bit ("not aligned with the gravity vector") in some axis, then `dvelBiasAxisInhibit[index]` becomes true to stop updates of variance in that axis.

In this case, according to the comment, the covariances for that axis state are zeroed to prevent interaction with other states, and the saved variance from when the inhibit began is restored.

However, this zeroing was done incorrectly by only zeroing the columns of `nextP`. As it is lower triangular, only covariances to states with a higher index are in the same column; states with a lower index are instead in the same row. This skipped zeroing the covariances to the more important states and led to state divergence on the ground.

Fix by also zeroing the row to zero the lower covariances. Confirmed that this fixes at least one replay log which showed ground divergence while tilted. This is possibly a new feature of EKF3, or at least implemented differently, so EKF2 does not need the same fix.

I did not investigate anything about why the innovations seem okay, but it seems possibly expected if we are so badly corrupting the covariances? The log in question is log 82 in #29384 (this has not otherwise been really tested, nor had the above theories verified e.g. in a debugger):

<img width="1260" height="970" alt="Screenshot from 2026-02-01 15-33-41" src="https://github.com/user-attachments/assets/4a2c89a3-d131-408e-a835-52f52b3a0b19" />

