### PR TITLE
AP_Vehicle: store currently running firmware version into a parameter

### DIFF
--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -290,6 +290,13 @@ const AP_Param::GroupInfo AP_Vehicle::var_info[] = {
     AP_SUBGROUPINFO(rpm_sensor, "RPM", 32, AP_Vehicle, AP_RPM),
 #endif
 
+    // @Param: FW_VER_LAST
+    // @DisplayName: Last firmware version
+    // @Description: Firmware version that last ran on this board, encoded as major*65536+minor*256+patch. Automatically updated on boot.
+    // @ReadOnly: True
+    // @User: Advanced
+    AP_GROUPINFO_FLAGS("FW_VER_LAST", 33, AP_Vehicle, _last_firmware_version, 0, AP_PARAM_FLAG_INTERNAL_USE_ONLY),
+
     AP_GROUPEND
 };
 
@@ -326,6 +333,8 @@ void AP_Vehicle::setup()
     // values from storage:
     AP_Param::check_var_info();
     load_parameters();
+
+    check_firmware_version();
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
     if (AP_BoardConfig::get_sdcard_slowdown() != 0) {

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -320,6 +320,7 @@ protected:
     virtual void init_ardupilot() = 0;
     virtual void load_parameters() = 0;
     void load_parameters(AP_Int16 &format_version, const uint16_t expected_format_version);
+    void check_firmware_version();
 
     virtual void set_control_channels() {}
 
@@ -603,6 +604,8 @@ private:
 
     // Bitmask of modes to disable from gcs
     AP_Int32 flight_mode_GCS_block;
+
+    AP_Int32 _last_firmware_version;
 };
 
 namespace AP {

--- a/libraries/AP_Vehicle/Parameters.cpp
+++ b/libraries/AP_Vehicle/Parameters.cpp
@@ -2,6 +2,7 @@
 
 #if AP_VEHICLE_ENABLED
 
+#include <AP_Common/AP_FWVersion.h>
 #include <AP_Param/AP_Param.h>
 #include <StorageManager/StorageManager.h>
 
@@ -23,6 +24,22 @@ void AP_Vehicle::load_parameters(AP_Int16 &format_version, const uint16_t expect
 
     // Load all auto-loaded EEPROM variables
     AP_Param::load_all();
+}
+
+// save the currently running firmware version into a parameter.  Into
+// the future we may use this number to prevent a user from attempting
+// to upgrade from a truly ancient version of the firmware to a more
+// modern one where we may have removed parameter upgrade code.
+void AP_Vehicle::check_firmware_version()
+{
+    const auto &fwver = AP::fwversion();
+    const uint32_t current_version = (uint32_t(fwver.major) << 16) |
+                                     (uint32_t(fwver.minor) << 8) |
+                                     (uint32_t(fwver.patch) << 0);
+    const uint32_t mask = 0x00FFFFFF;
+    if ((uint32_t(_last_firmware_version.get()) & mask) != current_version) {
+        _last_firmware_version.set_and_save(int32_t(current_version));
+    }
 }
 
 #endif  // AP_VEHICLE_ENABLED


### PR DESCRIPTION
save the currently running firmware version into a parameter.  Into the future we may use this number to prevent a user from attempting to upgrade from a truly ancient version of the firmware to a more modern one where we may have removed parameter upgrade code.

Tested in SITL:
```
MANUAL> FW_VER_LAST      263936
```

```
pbarker@crun:~$ i 263936
263936 0x40700 01003400 0b1000000011100000000
pbarker@crun:~$ 
```
