### PR TITLE
Copter: skip esc calibration startup check for DSHOT ESCs

### DIFF
--- a/ArduCopter/esc_calibration.cpp
+++ b/ArduCopter/esc_calibration.cpp
@@ -9,8 +9,13 @@
 // check if we should enter esc calibration mode
 void Copter::esc_calibration_startup_check()
 {
-    if (motors->is_brushed_pwm_type()) {
-        // ESC cal not valid for brushed motors
+    if (g.esc_calibrate == ESCCalibrationModes::ESCCAL_DISABLED) {
+        // esc calibration disabled
+        return;
+    }
+
+    if (motors->is_brushed_pwm_type() || motors->is_digital_pwm_type()) {
+        // ESC cal not valid for brushed motors or DSHOT ESCs
         return;
     }
 
@@ -25,7 +30,7 @@ void Copter::esc_calibration_startup_check()
     // exit immediately if pre-arm rc checks fail
     if (!arming.rc_calibration_checks(true)) {
         // clear esc flag for next time
-        if ((g.esc_calibrate != ESCCalibrationModes::ESCCAL_NONE) && (g.esc_calibrate != ESCCalibrationModes::ESCCAL_DISABLED)) {
+        if ((g.esc_calibrate != ESCCalibrationModes::ESCCAL_NONE)) {
             g.esc_calibrate.set_and_save(ESCCalibrationModes::ESCCAL_NONE);
         }
         return;
@@ -68,9 +73,8 @@ void Copter::esc_calibration_startup_check()
     }
 
     // clear esc flag for next time
-    if (g.esc_calibrate != ESCCalibrationModes::ESCCAL_DISABLED) {
-        g.esc_calibrate.set_and_save(ESCCalibrationModes::ESCCAL_NONE);
-    }
+    g.esc_calibrate.set_and_save(ESCCalibrationModes::ESCCAL_NONE);
+
 #endif  // FRAME_CONFIG != HELI_FRAME
 }
 


### PR DESCRIPTION
This could potentially waste 2 seconds of startup time