### PR TITLE
.github: test_branch_conventions.yml: limit commit subject to 160 cha…

### DIFF
--- a/.github/workflows/test_branch_conventions.yml
+++ b/.github/workflows/test_branch_conventions.yml
@@ -106,3 +106,14 @@ jobs:
             echo "❌ Markdown linting errors found."
             exit 1
           fi
+
+          # check that no commit subject line exceeds 160 characters:
+          while IFS= read -r line; do
+            if [[ ${#line} -gt 160 ]]; then
+              echo "❌ Commit subject line exceeds 160 characters:"
+              echo "$line"
+              echo "Please keep the commit subject line to 160 characters or fewer."
+              exit 1
+            fi
+          done <<< "$COMMITS"
+          echo "✅ All commit subject lines are within 160 characters."


### PR DESCRIPTION
…racters

sometimes people just forget the linefeed between the subject and commit message body.

Add a very loose limit to try to catch the problem.

<img width="2697" height="833" alt="image" src="https://github.com/user-attachments/assets/1a84fde9-61d8-4f6d-a72a-294b379e298e" />

160 is very generous, really only meant to catch screw-ups.  The good taste limit is rather less than that.

In response to the top commit in AP at the moment where a linefeed wasn't added:
```
pbarker@crun:~/rc/ardupilot(pr/rangefinder-i2c-baseclass-maxbotix)$ git log master --oneline | head
6870d06370f AP_HAL_ESP32: fix GPIO pinMode bugs when using relays Fix overwhelming logging caused by unnecessary pinMode calls when GPIOs are used to drive relays and fix GPIO::read behavior when it is configured for output on ESP32. - Add GPIO mode cache as a member of GPIO class to avoid unnecessary gpio_config calls - Remove duplicated logic in DigitalSource by using corresponding hal.gpio methods Tested on L298N motor driver.
3b7558acb85 autotest: add Copter EKF Replay wind and airspeed subtest
4c4f426ecba autotest: reset throttle between Copter Replay tests
ac970b0213a AP_HAL_ESP32: init SITL very early
8b9bc4e5b02 AP_HAL_ESP32: make empty boards work a bit more
```
