### PR TITLE
Rover: always log when armed (ignoring safety state)

### DIFF
--- a/Rover/AP_Arming_Rover.cpp
+++ b/Rover/AP_Arming_Rover.cpp
@@ -126,9 +126,6 @@ void AP_Arming_Rover::update_soft_armed()
 {
     hal.util->set_soft_armed(is_armed() &&
                              hal.util->safety_switch_state() != AP_HAL::Util::SAFETY_DISARMED);
-#if HAL_LOGGING_ENABLED
-    AP::logger().set_vehicle_armed(hal.util->get_soft_armed());
-#endif
 }
 
 /*
@@ -149,6 +146,11 @@ bool AP_Arming_Rover::arm(AP_Arming::Method method, const bool do_arming_checks)
 
     // save home heading for use in sail vehicles
     rover.g2.windvane.record_home_heading();
+
+#if HAL_LOGGING_ENABLED
+    // Tell logger it can start logging
+    AP::logger().set_vehicle_armed(true);
+#endif
 
     update_soft_armed();
 
@@ -177,6 +179,11 @@ bool AP_Arming_Rover::disarm(const AP_Arming::Method method, bool do_disarm_chec
         // reset the mission on disarm if we are not in auto
         rover.mode_auto.mission.reset();
     }
+
+#if HAL_LOGGING_ENABLED
+    // Tell logger it can stop logging
+    AP::logger().set_vehicle_armed(false);
+#endif
 
     update_soft_armed();
 


### PR DESCRIPTION
Currently rover will only log when **both** armed and the safety is off. All other vehicles log when armed, irrelevant of safety state.

Note that the same is also true for the `hal.util->set_soft_armed` call on other vehicles, that is more serious change we probably should make that change at some point.

Since the logger state now only changes when either arming or disarming it can be moved into those functions rather in the `update_soft_armed` call which is called periodically. 
