### PR TITLE
Add and use i2c_probe_fn_t + probe_i2c_buses

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -282,6 +282,24 @@ __INITFUNC__ bool RangeFinder::_add_backend(AP_RangeFinder_Backend *backend, uin
 }
 
 /*
+ * probe all i2c buses for a backend type:
+ */
+__INITFUNC__ void RangeFinder::probe_i2c_buses(uint8_t instance, uint8_t addr, i2c_probe_fn_t detect_fn)
+{
+    FOREACH_I2C(i) {
+        auto *device_ptr = hal.i2c_mgr->get_device_ptr(i, addr);
+        if (device_ptr == nullptr) {
+            continue;
+        }
+        if (_add_backend(detect_fn(state[instance], params[instance], *device_ptr),
+                         instance)) {
+            return;
+        }
+        delete device_ptr;
+    }
+}
+
+/*
   detect if an instance of a rangefinder is connected. 
  */
 __INITFUNC__ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
@@ -308,18 +326,7 @@ __INITFUNC__ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial
         if (params[instance].address != 0) {
             addr = params[instance].address;
         }
-        FOREACH_I2C(i) {
-            auto *device_ptr = hal.i2c_mgr->get_device_ptr(i, addr);
-            if (device_ptr == nullptr) {
-                continue;
-            }
-            if (_add_backend(AP_RangeFinder_MaxsonarI2CXL::detect(state[instance], params[instance],
-                                                                  *device_ptr),
-                             instance)) {
-                break;
-            }
-            delete device_ptr;
-        }
+        probe_i2c_buses(instance, addr, AP_RangeFinder_MaxsonarI2CXL::detect);
         break;
     }
 #endif
@@ -340,17 +347,7 @@ __INITFUNC__ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial
                                                              instance);
             }
 #else
-            FOREACH_I2C(i) {
-                auto *device_ptr = hal.i2c_mgr->get_device_ptr(i, params[instance].address);
-                if (device_ptr == nullptr) {
-                    continue;
-                }
-                if (_add_backend(AP_RangeFinder_LightWareI2C::detect(state[instance], params[instance],
-                                                                     *device_ptr),
-                                 instance)) {
-                    break;
-                }
-            }
+            probe_i2c_buses(instance, params[instance].address, AP_RangeFinder_LightWareI2C::detect);
 #endif
         }
         break;
@@ -358,18 +355,7 @@ __INITFUNC__ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial
 #if AP_RANGEFINDER_TRI2C_ENABLED
     case Type::TRI2C:
         if (params[instance].address) {
-            FOREACH_I2C(i) {
-                auto *device_ptr = hal.i2c_mgr->get_device_ptr(i, params[instance].address);
-                if (device_ptr == nullptr) {
-                    continue;
-                }
-                if (_add_backend(AP_RangeFinder_TeraRangerI2C::detect(state[instance], params[instance],
-                                                                      *device_ptr),
-                                 instance)) {
-                    break;
-                }
-                delete device_ptr;
-            }
+            probe_i2c_buses(instance, params[instance].address, AP_RangeFinder_TeraRangerI2C::detect);
         }
         break;
 #endif
@@ -400,18 +386,7 @@ __INITFUNC__ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial
         if (params[instance].address != 0) {
             addr = params[instance].address;
         }
-        FOREACH_I2C(i) {
-            auto *device_ptr = hal.i2c_mgr->get_device_ptr(i, addr);
-            if (device_ptr == nullptr) {
-                continue;
-            }
-            if (_add_backend(AP_RangeFinder_Benewake_TFMiniPlus::detect(state[instance], params[instance],
-                                                                        *device_ptr),
-                    instance)) {
-                break;
-            }
-            delete device_ptr;
-        }
+        probe_i2c_buses(instance, addr, AP_RangeFinder_Benewake_TFMiniPlus::detect);
         break;
     }
 #endif
@@ -421,18 +396,7 @@ __INITFUNC__ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial
         if (params[instance].address != 0) {
             addr = params[instance].address;
         }
-        FOREACH_I2C(i) {
-            auto *device_ptr = hal.i2c_mgr->get_device_ptr(i, addr);
-            if (device_ptr == nullptr) {
-                continue;
-            }
-            if (_add_backend(AP_RangeFinder_Benewake_TFS20L::detect(state[instance], params[instance],
-                                                                    *device_ptr),
-                    instance)) {
-                break;
-            }
-            delete device_ptr;
-        }
+        probe_i2c_buses(instance, addr, AP_RangeFinder_Benewake_TFS20L::detect);
         break;
     }
 #endif

--- a/libraries/AP_RangeFinder/AP_RangeFinder.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.h
@@ -340,6 +340,10 @@ private:
 
     bool _add_backend(AP_RangeFinder_Backend *driver, uint8_t instance, uint8_t serial_instance=0);
 
+    // search all i2c buses for a device at addr
+    using i2c_probe_fn_t = AP_RangeFinder_Backend* (*)(RangeFinder::RangeFinder_State&, AP_RangeFinder_Params&, AP_HAL::I2CDevice&);
+    void probe_i2c_buses(uint8_t instance, uint8_t addr, i2c_probe_fn_t detect_fn);
+
     uint32_t _log_rfnd_bit = -1;
     void Log_RFND() const;
 };


### PR DESCRIPTION
Building on https://github.com/ArduPilot/ardupilot/pull/31384 , factors common iteration-of-rangefinder-buses into a method, saving LoC and flash.

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *                                                   
Durandal                            *               *      *           -392    -392              -392   -392   -392
Hitec-Airspeed           *                                 *                                                   
KakuteH7-bdshot                     *               *      *           -376    -376              -376   -376   -376
MatekF405                           *               *      *           32      24                32     24     24
Pixhawk1-1M-bdshot                  *               *                  -392    -384              -392   -384   -392
SITL_x86_64_linux_gnu               *               *                  0       0                 0      0      0
f103-QiotekPeriph        *                                 *                                                   
f303-MatekGPS            -344                              *                                                   
f303-Universal           -336                              *                                                   
iomcu                                                                                *                         
mindpx-v2                           *               *      *           -400    -392              -392   -392   -400
revo-mini                           *               *      *           24      24                32     32     24
skyviper-v2450                                                         *                                       
speedybeef4                         *               *      *           24      32                32     32     32
```

(the Matek board etc. only includes a single i2c backend, so it will only benefit if we add a second in there)
