### PR TITLE
autotest: accept any of several messages to supply time_boot_ms

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -4153,6 +4153,13 @@ class TestSuite(abc.ABC):
     #################################################
     # SIM UTILITIES
     #################################################
+    SIM_TIME_MESSAGES = [
+        'SYSTEM_TIME',
+        'ATTITUDE',
+        'RC_CHANNELS',
+        'SCALED_IMU2',
+    ]
+
     def get_sim_time(self, timeout=60, drain_mav=True):
         """Get SITL time in seconds."""
         if drain_mav:
@@ -4161,9 +4168,9 @@ class TestSuite(abc.ABC):
         while True:
             self.drain_all_pexpects()
             if time.time() - tstart > timeout:
-                raise AutoTestTimeoutException("Did not get SYSTEM_TIME message after %f seconds" % timeout)
+                raise AutoTestTimeoutException("Did not get boot-time-containing message after %f seconds" % timeout)
 
-            m = self.mav.recv_match(type='SYSTEM_TIME', blocking=True, timeout=0.1)
+            m = self.mav.recv_match(type=self.SIM_TIME_MESSAGES, blocking=True, timeout=0.1)
             if m is None:
                 continue
             if m.get_srcSystem() != self.sysid_thismav():
@@ -4173,10 +4180,16 @@ class TestSuite(abc.ABC):
 
     def get_sim_time_cached(self):
         """Get SITL time in seconds."""
-        x = self.mav.messages.get("SYSTEM_TIME", None)
-        if x is None:
+        time_boot_ms = 0
+        for t in self.SIM_TIME_MESSAGES:
+            m = self.mav.messages.get(t, None)
+            if m is None:
+                continue
+            if m.time_boot_ms > time_boot_ms:
+                time_boot_ms = m.time_boot_ms
+        if time_boot_ms == 0:
             raise NotAchievedException("No cached time available (%s)" % (self.mav.sysid,))
-        ret = x.time_boot_ms * 1.0e-3
+        ret = time_boot_ms * 1.0e-3
         if ret != self.last_sim_time_cached:
             self.last_sim_time_cached = ret
             self.last_sim_time_cached_wallclock = time.time()


### PR DESCRIPTION
SYSTEM_TIME doesn't come that fast - and we don't really need it specifically, just a known-good time_boot_ms

All of these messages come from the main thread, so no risk of time going backwards.

