### PR TITLE
autotest: stop moving logs on failure

### DIFF
--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -1074,13 +1074,6 @@ if __name__ == "__main__":
     if opts.move_logs_on_test_failure is None:
         opts.move_logs_on_test_failure = opts.autotest_server
 
-        # temporarily default it to the old behaviour, but allow a
-        # user to test it by setting an environment variable:
-        if os.getenv("AP_AUTOTEST_MOVE_LOGS_ON_FAILURE") is not None:
-            opts.move_logs_on_test_failure = os.getenv("AP_AUTOTEST_MOVE_LOGS_ON_FAILURE") == "1"
-        else:
-            opts.move_logs_on_test_failure = True
-
     steps = [
         'prerequisites',
         'build.Binaries',


### PR DESCRIPTION
tracking down the logs on test failure is just painful.

I've been setting the environment variable for a long time and it works well