### PR TITLE
ArduPlane: Fix roll error in takeoff when flying inverted

### DIFF
--- a/ArduPlane/takeoff.cpp
+++ b/ArduPlane/takeoff.cpp
@@ -238,7 +238,17 @@ void Plane::takeoff_calc_pitch(void)
         // increase the robustness of hand launches, particularly
         // in cross-winds. If we start to roll over then we reduce
         // pitch demand until the roll recovers
-        float roll_error_rad = cd_to_rad(constrain_float(labs(nav_roll_cd - ahrs.roll_sensor), 0, 9000));
+
+        // Handle target roll for inverted flight with a local variable,
+        // so internal state is still updated once by Plane::stabilize_roll
+        int32_t local_nav_roll_cd = nav_roll_cd;
+        if (fly_inverted()) {
+            local_nav_roll_cd += 18000;
+            if (ahrs.roll_sensor < 0) {
+                local_nav_roll_cd -= 36000;
+            }
+        }
+        float roll_error_rad = cd_to_rad(constrain_float(labs(local_nav_roll_cd - ahrs.roll_sensor), 0, 9000));
         float reduction = sq(cosf(roll_error_rad));
         nav_pitch_cd *= reduction;
 


### PR DESCRIPTION
Before this change, the target roll was not taking into account inverted flight, so roll control priority was setting the target pitch to zero. This is also relevant for aborted landing, which is where it was noticed.

To handle roll target for inverted flight, I reused the logic from `Plane::stabilize_roll` that actually updates it before it goes through PID. I tested the behaviour before and after using SITL.

Steps to reproduce:
- Plan an AUTO mission:
  - some waypoint
  - MAV_CMD_DO_INVERTED_FLIGHT
  - fixed wing landing sequence
- Take off and switch to AUTO mode
- During landing sequence in inverted flight, raise throttle over 90% and abort the landing
- Observe the result:
  - *Before:* pitch stays horizontal and aircraft slowly runs into ground
  - *After:* the aircraft pitches away from the ground and climbs

*(Contribution on behalf of @FlyfocusUAV)*