### PR TITLE
Fix dds overflow

### DIFF
--- a/libraries/AP_DDS/AP_DDS_External_Odom.cpp
+++ b/libraries/AP_DDS/AP_DDS_External_Odom.cpp
@@ -28,8 +28,10 @@ void AP_DDS_External_Odom::handle_external_odom(const tf2_msgs_msg_TFMessage& ms
         convert_transform(ros_transform_stamped.transform, ap_position, ap_rotation);
         // Although ROS convention states quaternions in ROS messages should be normalized, it's not guaranteed.
         // Before propagating a potentially inaccurate quaternion to the rest of AP, normalize it here.
-        // TODO what if the quaternion is NaN?
-        ap_rotation.normalize();
+        // If quaternion is NaN, use position only update, by setting a large error.
+        if (!ap_rotation.is_nan()) {
+            ap_rotation.normalize();
+        }
 
         // No error is available in TF, trust the data as-is
         const float posErr {0.0};
@@ -38,8 +40,9 @@ void AP_DDS_External_Odom::handle_external_odom(const tf2_msgs_msg_TFMessage& ms
         // https://www.ros.org/reps/rep-0105.html#id16
         // Thus, there will not be any resets.
         const uint8_t reset_counter {0};
-        // TODO implement jitter correction similar to GCS_MAVLINK::correct_offboard_timestamp_usec_to_ms(remote_time_us, sizeof(msg));
-        const uint32_t time_ms {static_cast<uint32_t>(remote_time_us * 1E-3)};
+        // The provided timestamp is used for logging purposes only.
+        // Latency is handled by the VISO_DELAY_MS parameter.
+        const uint32_t time_ms = AP_HAL::millis();
         visual_odom->handle_pose_estimate(remote_time_us, time_ms, ap_position.x, ap_position.y, ap_position.z, ap_rotation, posErr, angErr, reset_counter, 0);
 
     }


### PR DESCRIPTION
@peterbarker @tizianofiorenzani 
Resolves #31979

This PR fixes an integer overflow issue where the external odometry timestamp (uint64 microseconds) was being cast to milliseconds (uint32), causing overflow.

**Changes:**
- Replaced the direct casting of `remote_time_us` with `AP_HAL::millis()` to use the local boot time, as suggested in the issue discussion.
- This prevents the overflow while maintaining correct timing logic relative to the autopilot's boot.