### PR TITLE
AP_ExternalAHRS: Fix duplicate barometer temperature compensation

### DIFF
--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_InertialLabs.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_InertialLabs.cpp
@@ -412,7 +412,8 @@ bool AP_ExternalAHRS_InertialLabs::check_uart()
         case MessageType::TEMPERATURE: {
             CHECK_SIZE(u.temperature);
             // assume same temperature for baro and airspeed
-            baro_data.temperature = u.temperature*0.1; // degC
+            // setting temp to 25 effectively disables barometer temperature calibrations - these are already performed by InertialLabs
+            baro_data.temperature = 25;
             airspeed_data.temperature = u.temperature*0.1; // degC
             ins_data.temperature = u.temperature*0.1;
             break;

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_SBG.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_SBG.cpp
@@ -551,7 +551,8 @@ void AP_ExternalAHRS_SBG::handle_msg(const sbgMessage &msg)
                 
                 if ((cached.sbg.airData.status & SBG_ECOM_AIR_DATA_TEMPERATURE_VALID) && (updated_baro || updated_airspeed)) {
                     cached.sensors.airspeed_data.temperature = cached.sbg.airData.airTemperature;
-                    cached.sensors.baro_data.temperature = cached.sbg.airData.airTemperature;
+                    // setting temp to 25 effectively disables barometer temperature calibrations - these are already performed by SBG
+                    cached.sensors.baro_data.temperature = 25;
                 }
                 break;
 

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.cpp
@@ -546,7 +546,8 @@ void AP_ExternalAHRS_VectorNav::process_imu_packet(const uint8_t *b)
         AP_ExternalAHRS::baro_data_message_t baro;
         baro.instance = 0;
         baro.pressure_pa = pkt.pressure * 1e3;
-        baro.temperature = pkt.temp;
+        // setting temp to 25 effectively disables barometer temperature calibrations - these are already performed by VectorNav
+        baro.temperature = 25;
 
         AP::baro().handle_external(baro);
     }


### PR DESCRIPTION
This PR fixes a logic error where barometer temperature compensation was being applied twice for certain external AHRS drivers (VectorNav, SBG, InertialLabs).

**The Issue:**
These external AHRS units typically perform their own pressure/temperature compensation internally. However, by passing the raw temperature to `baro_data.temperature`, ArduPilot's `AP_Baro` library was triggering a second round of compensation calculations, potentially degrading the data accuracy.

**The Fix:**
Following the pattern already established in the `MicroStrain5` driver, the barometer temperature is now hardcoded to `25`. This effectively bypasses the internal ArduPilot compensation (since `25 - 25 = 0` delta), allowing the already-calibrated pressure data from the external unit to be used as-is.

**Changes:**
- Applied fix to `AP_ExternalAHRS_VectorNav.cpp`
- Applied fix to `AP_ExternalAHRS_InertialLabs.cpp`
- Applied fix to `AP_ExternalAHRS_SBG.cpp`