### PR TITLE
AP_NavEKF3: add missing constraints to FuseDragForces

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_AirDataFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_AirDataFusion.cpp
@@ -656,6 +656,10 @@ void NavEKF3_core::FuseDragForces()
                 P[i][j] = P[i][j] - KHP[i][j];
             }
         }
+
+        // force the covariance matrix to be symmetrical and limit the variances to prevent ill-conditioning.
+        ForceSymmetry();
+        ConstrainVariances();
     }
 
     // record time of successful fusion


### PR DESCRIPTION
Unsure if this is a major issue since the next EKF loop would likely call some fusion function which would do the same things. But better safe than sorry, and consistency is good.

This creates rather significant replay differences (relatively speaking, this is much more than just float precision noise). But the replay test passes, and so does `test.Copter.BaroWindCorrection` which uses this feature. Probably worth confirming no crazy behavior on a real vehicle but I don't have one set up for it.