### PR TITLE
GCS_MAVLink: Add _MSG_NTC_LVL parameter to filter text messages by severity

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -551,6 +551,8 @@ protected:
     }
     AP_Int8 options_were_converted;
 
+    AP_Int8 msg_notice_level;
+
     virtual void handle_command_ack(const mavlink_message_t &msg);
     void handle_set_mode(const mavlink_message_t &msg);
     void handle_command_int(const mavlink_message_t &msg);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -869,6 +869,9 @@ void GCS_MAVLINK::handle_param_value(const mavlink_message_t &msg)
 
 void GCS_MAVLINK::send_text(MAV_SEVERITY severity, const char *fmt, ...) const
 {
+    if (int8_t(severity) > int8_t(msg_notice_level)) {
+        return;
+    }
     va_list arg_list;
     va_start(arg_list, fmt);
     gcs().send_textv(severity, fmt, arg_list, (1<<chan));

--- a/libraries/GCS_MAVLink/GCS_MAVLink_Parameters.cpp
+++ b/libraries/GCS_MAVLink/GCS_MAVLink_Parameters.cpp
@@ -221,6 +221,14 @@ const AP_Param::GroupInfo GCS_MAVLINK::var_info[] = {
     // This allows one time conversion while allowing user to flash between versions with and without converted params
     AP_GROUPINFO_FLAGS("_OPTIONSCNV",   21, GCS_MAVLINK, options_were_converted, 0, AP_PARAM_FLAG_HIDDEN),
 
+    // @Param: _MSG_LVL
+    // @DisplayName: Message Notification Level
+    // @Description: Filter level for GCS text messages. Only messages with a severity equal to or higher than this level will be sent. 0:Emergency only, 7:All (including Debug).
+    // @Values: 0:Emergency, 1:Alert, 2:Critical, 3:Error, 4:Warning, 5:Notice, 6:Info, 7:Debug
+    // @User: Standard
+    AP_GROUPINFO("_MSG_LVL", 22, GCS_MAVLINK, msg_notice_level, 7),
+
+
     AP_GROUPEND
 };
 #undef DRATE


### PR DESCRIPTION
### Summary
This PR introduces a new parameter `_MSG_NTC_LVL` to the `GCS` class to filter `STATUSTEXT` messages sent to the GCS based on their MAVLink severity level. This allows users to optimize the message flow by suppressing lower-priority messages while ensuring critical alerts are always received.

### Why this is needed
Currently, all `send_text` calls are transmitted to the GCS, which can lead to several operational challenges:
* **Information Overload**: Different stakeholders have different information requirements. A flight operator may only want to see Warnings and above, while an engineer needs full Debug logs.
* **Bandwidth Management**: In telemetry scenarios involving cellular or satellite links (e.g., Starlink/GCP), reducing unnecessary text traffic is crucial for maintaining link stability and reducing latency.
* **Operational Clarity**: By filtering out routine info messages, critical "PreArm" errors or flight mode changes become much more visible during flight operations.

### What this PR does
1. **Adds `_MSG_NTC_LVL` parameter**: A new integer parameter (0-7) to set the maximum severity level allowed to be sent to the GCS.
2. **Implements Severity Filter**: Modifies `GCS::send_text` to return early if the message's severity is numerically higher than the `_MSG_NTC_LVL` value.
3. **MAVLink Standard Alignment**: The filter logic follows the MAVLink severity standard where 0 is Emergency and 7 is Debug.
4. **Backward Compatibility**: **The default value is set to 7 (Debug)**. This ensures that existing users will not see any change in behavior unless they explicitly configure the filter.

### Testing performed
* **Environment**: Tested on ArduCopter V4.7.0-dev.
* **Hardware/SITL**: Verified that setting `_MSG_NTC_LVL` successfully filters messages in the Mission Planner/MAVProxy console.
* **Critical Path**: Confirmed that high-priority messages like "PreArm" errors are always displayed when the filter is set to an appropriate level (e.g., 4 or 5).

IMAGE
<img width="1054" height="775" alt="Screenshot from 2026-02-07 22-45-54" src="https://github.com/user-attachments/assets/dbd00759-7a1e-49e4-9dfc-608e196a92b9" />

AFTER
<img width="846" height="574" alt="Screenshot from 2026-02-08 01-09-46" src="https://github.com/user-attachments/assets/73396046-38c6-4f93-9599-4c97657e3939" />

BEFORE
<img width="834" height="715" alt="Screenshot from 2026-02-08 00-40-57" src="https://github.com/user-attachments/assets/055c7be4-c59f-42b6-9deb-d515315f98d7" />




