### PR TITLE
ardupilotwaf: rerun mavgen if pymavlink sources change

### DIFF
--- a/Tools/ardupilotwaf/mavgen.py
+++ b/Tools/ardupilotwaf/mavgen.py
@@ -79,6 +79,16 @@ def process_mavgen(self):
         self.bld.fatal('mavgen: missing option output_dir')
 
     inputs = self.to_nodes(self.bld.srcnode.find_node(self.source))
+    # depend on fixed headers so a rebuild occurs if they change
+    mavlink_dir = self.env.get_flat('MAVLINK_DIR')
+    headers_dir = mavlink_dir+"/pymavlink/generator/C/include_v2.0"
+    headers = self.bld.root.find_node(headers_dir) # expected to be absolute
+    inputs.extend(headers.ant_glob("*.h"))
+    # also depend on the generator source itself
+    gen_src_dir = mavlink_dir+"/pymavlink/"
+    gen_src = self.bld.root.find_node(gen_src_dir)
+    inputs.extend(gen_src.ant_glob("__init__.py generator/*.py"))
+
     outputs = []
 
     self.source = []


### PR DESCRIPTION
If the C header files or the Python generator sources change, then this causes the generator to rerun, fixed headers to get copied again, and dependent files to be rebuilt.

https://github.com/ArduPilot/ardupilot/pull/28106 but for pymavlink