### PR TITLE
AP_NavEKF3: Do not go into AID_NONE when in AID_RELATIVE without yaw source

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -243,12 +243,13 @@ void NavEKF3_core::setAidingMode()
     checkGyroCalStatus();
 
     // Handle the special case where we are on ground and disarmed without a yaw measurement
-    // and navigating. This can occur if not using a magnetometer and yaw was aligned using GPS
-    // during the previous flight.
+    // and in AID_ABSOLUTE mode. This can occur if not using a magnetometer and yaw was aligned
+    // using GPS during the previous flight. AID_RELATIVE is excluded because optical flow and
+    // body odometry are body-frame sensors that do not require yaw alignment.
     if (yaw_source_last == AP_NavEKF_Source::SourceYaw::NONE &&
         !motorsArmed &&
         onGround &&
-        PV_AidingMode != AID_NONE)
+        PV_AidingMode == AID_ABSOLUTE)
     {
         PV_AidingMode = AID_NONE;
         yawAlignComplete = false;


### PR DESCRIPTION
When optical flow is available but there's no compass and the vehicle is on the ground disarmed, the EKF was rapidly oscillating between AID_NONE and AID_RELATIVE modes every frame because the mode selection logic would try to enter AID_RELATIVE (since flow is ready), but then the special case handler just a few lines above would immediately force it back to AID_NONE (I think that logic exists because yaw is unobservable when stationary without a compass), creating an infinite loop of mode changes and state resets every single frame.

I have been testing this on replay logs that clearly show the before/after behaviour. The unfixed version shows mode changes every frame with growing attitude errors and drift, while the fixed version stays stable in AID_NONE with proper attitude estimation and no drift. This is also somewhat reproducible on SITL, where if you set up optical flow with no compass/GPS, you'd immediately see a spam:
<img width="763" height="1076" alt="image" src="https://github.com/user-attachments/assets/50895112-c39e-48d4-a806-4205d4f01bfc" />
