### PR TITLE
Fix a flaky (copter) autotest

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -166,7 +166,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.change_mode("LAND")
         self.wait_landed_and_disarmed(timeout=timeout)
 
-    def wait_landed_and_disarmed(self, min_alt=6, timeout=60):
+    def wait_landed_and_disarmed(self, min_alt=0, timeout=60):
         """Wait to be landed and disarmed"""
         m = self.assert_receive_message('GLOBAL_POSITION_INT')
         alt = m.relative_alt / 1000.0 # mm -> m


### PR DESCRIPTION
Why is the default, when waiting for a landing, to require the copter to report an altitude between 5 m and 11 m?
IMO, that makes no sense, and is likely an accidental oversight.

In case more details are desired:
- The specific flaky test (for me) is `test.Copter.BatteryMissing`.
- The failure is well-summarized in this line: `BatteryMissing ( Test battery health pre-arm and missing failsafe) (Failed to attain Altitude want 8.0, reached 0.008)`  Observe that an altitude of 8 m +/- 3 m (i.e. 5 - 11 m) is never seen, because copter is already on ground at altitude of 0.008 m.
- The PR which seems to have introduced this default is https://github.com/ArduPilot/ardupilot/pull/14882 . I can't tell why that decision was made there, but perhaps also the actual flake started after it? 🤷 

REVIEWERS: I don't know what level of testing is appropriate for a change like this. (What if some tests were depending on this odd assumption to pass?) Please help me learn what's expected.
For example, one org I worked with had a bar like ">1 flaky failure in 1000 retries before, and 0 flaky failures in 1000 retries after". Based on a ~50% flake rate locally, I'd be glad to script some test like that overnight and post the results. Should take me 10 or less, so maybe 100 repetitions is confident enough.
Also it would be great if someone else could reproduce the flake I'm seeing, and confirm this seems to fix it for them. (I'm on a ~2021 Macbook Air, in case that's very different than most dev's setups.)