### PR TITLE
AP_Math: provide float and double norm variants

### DIFF
--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -288,6 +288,13 @@ ftype norm(const T first, const U second, const Params... parameters)
     return sqrtF(sq(first, second, parameters...));
 }
 
+inline float norm(const float first, const float second) {
+    return sqrtf(sq(first) + sq(second));
+}
+inline float norm(const float first, const float second, const float third) {
+    return sqrtf(sq(first) + sq(second) + sq(third));
+}
+
 #undef MIN
 template<typename A, typename B>
 static inline auto MIN(const A &one, const B &two) -> decltype(one < two ? one : two)


### PR DESCRIPTION
Where `sqrtF` is double, this prevents promotion of floating point values to doubles just because we are calling `norm` on them.

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  -40                               *                                                   
Durandal                            -64             -72    *           -88     -112              -120   -80    -96
Hitec-Airspeed           *                                 *                                                   
KakuteH7-bdshot                     -48             -48    *           -72     -96               -96    -56    -72
MatekF405                           0               0      *           0       0                 -8     0      0
Pixhawk1-1M-bdshot                  0               0                  0       0                 -8     0      0
SITL_x86_64_linux_gnu               0               0                  0       0                 -4096  0      0
f103-QiotekPeriph        0                                 *                                                   
f303-MatekGPS            0                                 *                                                   
f303-Universal           0                                 *                                                   
iomcu                                                                                *                         
mindpx-v2                           0               0      *           0       0                 -8     0      0
revo-mini                           0               0      *           0       0                 -8     0      0
skyviper-v2450                                                         0                                       
speedybeef4                         0               0      *           0       0                 -8     0      0
```

<img width="3734" height="865" alt="image" src="https://github.com/user-attachments/assets/922e6c54-9658-4f0a-8115-85d227b889cc" />

Typical change, 64-bit operations on the left, 32 on the right, and note no longer using `vcvt.f64.f32`
<img width="4796" height="3616" alt="image" src="https://github.com/user-attachments/assets/22cfde12-68d7-4607-a24d-aa7e7cebb88d" />
