### PR TITLE
Tools: allow size_compare_branches.py to test boards with modified hwdefs

### DIFF
--- a/Tools/scripts/build_script_base.py
+++ b/Tools/scripts/build_script_base.py
@@ -8,10 +8,13 @@ AP_FLAKE8_CLEAN
 
 import os
 import pathlib
+import re
 import string
 import subprocess
 import sys
 import time
+
+import board_list
 
 
 class BuildScriptBase:
@@ -132,6 +135,88 @@ class BuildScriptBase:
             else:
                 raise Exception("BB-WAF: Missing compiler %s" % gcc_path)
         self.run_program("SCB-WAF", cmd_list, env=env, show_output=show_output, cwd=source_dir)
+
+    def get_modified_hwdef_paths(self, branch, master_branch, use_merge_base=True):
+        '''returns set of hwdef filepaths modified between branch and
+        master, relative to the repository root'''
+        if use_merge_base:
+            base_commit = self.find_git_branch_merge_base(branch, master_branch)
+        else:
+            base_commit = master_branch
+
+        delta_files = self.run_git([
+            'diff',
+            '--name-only',
+            base_commit,
+            branch,
+        ], show_output=False)
+
+        ret = set()
+        for f in delta_files.split("\n"):
+            f = f.strip()
+            if not f:
+                continue
+            if "/hwdef/" not in f:
+                continue
+            if not f.endswith(("hwdef.dat", "hwdef.inc", "hwdef-bl.dat", "hwdef-bl.inc")):
+                continue
+            ret.add(f)
+        return ret
+
+    def collect_hwdef_includes(self, filepath, seen=None):
+        '''recursively collect all hwdef file paths included from filepath'''
+        if seen is None:
+            seen = set()
+        filepath = os.path.realpath(filepath)
+        if filepath in seen:
+            return set()
+        seen.add(filepath)
+        paths = {filepath}
+        try:
+            with open(filepath) as fh:
+                for line in fh:
+                    m = re.match(r"^\s*include\s+(.+)\s*$", line)
+                    if m is not None:
+                        inc_path = os.path.join(os.path.dirname(filepath), m.group(1))
+                        paths.update(self.collect_hwdef_includes(inc_path, seen))
+        except FileNotFoundError:
+            pass
+        return paths
+
+    def find_modified_boards(self, branch, master_branch, use_merge_base=True):
+        '''find boards whose hwdef files have been modified between
+        branch and master'''
+        modified_paths = self.get_modified_hwdef_paths(
+            branch, master_branch, use_merge_base)
+        if not modified_paths:
+            return []
+
+        for p in modified_paths:
+            self.progress("Modified hwdef: %s" % p)
+
+        # convert to absolute paths for comparison
+        modified_abs = set()
+        for p in modified_paths:
+            modified_abs.add(os.path.realpath(p))
+
+        bl = board_list.BoardList()
+        modified_board_names = []
+
+        for board_obj in bl.boards:
+            for hwdef_dir in bl.hwdef_dir:
+                hwdef_path = os.path.join(hwdef_dir, board_obj.name, "hwdef.dat")
+                if not os.path.exists(hwdef_path):
+                    continue
+                includes = self.collect_hwdef_includes(hwdef_path)
+                hwdef_bl_path = os.path.join(hwdef_dir, board_obj.name, "hwdef-bl.dat")
+                if os.path.exists(hwdef_bl_path):
+                    includes.update(self.collect_hwdef_includes(hwdef_bl_path))
+                if includes & modified_abs:
+                    modified_board_names.append(board_obj.name)
+                    self.progress("Board %s uses modified hwdef" % board_obj.name)
+                    break
+
+        return sorted(modified_board_names, key=lambda x: x.lower())
 
     def progress(self, string):
         '''pretty-print progress'''

--- a/Tools/scripts/size_compare_branches.py
+++ b/Tools/scripts/size_compare_branches.py
@@ -75,6 +75,7 @@ class SizeCompareBranches(BuildScriptBase):
                  all_vehicles=False,
                  exclude_board_glob: list | None = None,
                  all_boards=False,
+                 modified_boards=False,
                  use_merge_base=True,
                  waf_consistent_builds=True,
                  show_empty=True,
@@ -145,6 +146,13 @@ class SizeCompareBranches(BuildScriptBase):
 
         if all_boards:
             self.board = sorted(list(self.boards_by_name.keys()), key=lambda x: x.lower())
+        elif modified_boards:
+            self.board = self.find_modified_boards(
+                self.branch, self.master_branch, self.use_merge_base)
+            if not self.board:
+                raise ValueError(
+                    "No modified boards found between %s and %s" %
+                    (self.branch, self.master_branch))
         else:
             # validate boards
             all_boards = set(self.boards_by_name.keys())
@@ -936,6 +944,11 @@ def main():
                       default=False,
                       help="Build all boards")
     parser.add_option("",
+                      "--modified-boards",
+                      action='store_true',
+                      default=False,
+                      help="Build all boards with modified hwdef files")
+    parser.add_option("",
                       "--exclude-board-glob",
                       default=[],
                       action="append",
@@ -994,6 +1007,7 @@ def main():
         run_elf_diff=(cmd_opts.elf_diff),
         all_vehicles=cmd_opts.all_vehicles,
         all_boards=cmd_opts.all_boards,
+        modified_boards=cmd_opts.modified_boards,
         exclude_board_glob=cmd_opts.exclude_board_glob,
         use_merge_base=not cmd_opts.no_merge_base,
         waf_consistent_builds=not cmd_opts.no_waf_consistent_builds,


### PR DESCRIPTION
With just this commit: 
```
ValueError: No modified boards found between pr/size-compare-branches-test-modifies-boards and master
```

Modifying `libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/hwdef.inc` in a test commit on top:
```
pbarker@crun:~/rc/ardupilot-claude(pr-claude/size-compare-branches-test-modifies-boards)$ ./Tools/scripts/size_compare_branches.py --modified-boards
SCB: Running (git symbolic-ref --short HEAD) in (.)
SCB-GIT: pr-claude/size-compare-branches-test-modifies-boards
SCB: Running (git merge-base pr-claude/size-compare-branches-test-modifies-boards master) in (.)
SCB-GIT: 92d46eca62c3e380af26737f74a6fa914739a5ea
SCB: Running (git diff --name-only 92d46eca62c3e380af26737f74a6fa914739a5ea pr-claude/size-compare-branches-test-modifies-boards) in (.)
SCB: Modified hwdef: libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/hwdef.inc
SCB: Board CubeOrange-periph-heavy uses modified hwdef
SCB: Board CubeOrange-bdshot uses modified hwdef
SCB: Board CubeOrangePlus-bdshot uses modified hwdef
SCB: Board CubeOrange-ODID uses modified hwdef
SCB: Board CubeOrange-periph uses modified hwdef
SCB: Board CubeOrange-joey uses modified hwdef
SCB: Board CubeOrangePlus-ODID uses modified hwdef
SCB: Board CubeOrange-SimOnHardWare uses modified hwdef
SCB: Board CubeOrangePlus-SimOnHardWare uses modified hwdef
SCB: Board CubeOrange uses modified hwdef
SCB: Board CubeOrangePlus uses modified hwdef
SCB: Running (git merge-base pr-claude/size-compare-branches-test-modifies-boards master) in (.)
SCB-GIT: 92d46eca62c3e380af26737f74a6fa914739a5ea
SCB: Using merge base (92d46eca62c3e380af26737f74a6fa914739a5ea)
.
.
.
SCB: Running (rsync -ap build/ /tmp/tmpe56a2y80/out-branch-CubeOrangePlus-SimOnHardWare) in (.)
Board,plane
CubeOrange,0
CubeOrange-ODID,*
CubeOrange-bdshot,*
CubeOrange-joey,*
CubeOrangePlus,*
CubeOrangePlus-ODID,*
CubeOrangePlus-bdshot,*

pbarker@crun:~/rc/ardupilot-claude(pr-claude/size-compare-branches-test-modifies-boards)$ 
```
