### PR TITLE
board_list: set SITL toolchain to None instead of 'native'

### DIFF
--- a/Tools/scripts/board_list.py
+++ b/Tools/scripts/board_list.py
@@ -131,7 +131,7 @@ class BoardList(object):
                 elif "ESP32" in hwdef_dir:
                     board.toolchain = 'xtensa-esp32-elf'
                 elif "SITL" in hwdef_dir:
-                    board.toolchain = 'native'
+                    board.toolchain = None
                 else:
                     raise ValueError(f"Unable to determine toolchain for {hwdef_dir}")
 


### PR DESCRIPTION
When the hwdef explicitly sets `env TOOLCHAIN native`, board_list.py correctly converts the toolchain to None. But when SITL boards fall through to the default toolchain assignment, the string 'native' was used without conversion. This caused size_compare_branches.py to try running 'native-strip' (which doesn't exist) instead of plain 'strip' when comparing SITL ELFs, resulting in a silently-caught FileNotFoundError and empty output.

This change changes the output from:
```
Board,plane
```

to
```
Board,plane
sitl,0
```

on top of commits which change the output of the compiler but not the size.


More reasoning from claude:
```
  Bug 1: toolchain='native' not converted to None in board_list.py
                                                                                
  At line 118-123, when the hwdef explicitly contains env TOOLCHAIN native, the 
  toolchain is correctly converted to None:
  if board.toolchain == 'native':
      board.toolchain = None

  But SITL's hwdef.dat doesn't contain a TOOLCHAIN directive. So the code falls
  through to the default at line 133-134:
  elif "SITL" in hwdef_dir:
      board.toolchain = 'native'

  This sets toolchain to the string 'native' without the None conversion. We can
   verify: SITL has toolchain='native' (not None).

  Bug 2: create_stripped_elf constructs native-strip which doesn't exist

  In size_compare_branches.py:723-731, create_stripped_elf builds the strip
  command:
  strip = "strip"
  if toolchain is not None:         # 'native' is not None!
      strip = "-".join([toolchain, strip])  # → "native-strip"

  native-strip doesn't exist on the system (only strip does). subprocess.Popen
  raises FileNotFoundError.
```
