### PR TITLE
CONTRIBUTING.md: recommend avoiding duplicate PRs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -25,7 +25,9 @@ Please see our [wiki article](https://ardupilot.org/dev/docs/submitting-patches-
 
 We use github's Issue tracking feature to keep a list of outstanding Bugs and Feature Requests.  We specifically label some issues as [good first issues](https://github.com/ArduPilot/ardupilot/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22) because they are straight forward tasks that someone new to the codebase may be able to deal with.
 
-We typically do not assign issues - *particularly* "Good First Issue"s to specific contributors - if you feel you can contribute towards resolving an issue, simply work on it and create a PR which addresses it.
+We typically do not assign issues - *particularly* "Good First Issue"s to specific contributors - if you feel you can contribute towards resolving an issue, simply work on it\* and create a PR which addresses it.
+
+> \**Before* working on an issue, check the existing pull requests first (related ones may be linked to the issue, or appear when searching some relevant key words or phrases). If there is one you can review it and join the discussion there, instead of creating your own.
 
 ## Development Team
 


### PR DESCRIPTION
Due to some recent cases of people submitting PRs to solve issues without realising there's a linked one already being worked on, it seems worthwhile to recommend checking that before starting to work on an issue.