### PR TITLE
AP_HAL_ChibiOS: CubeNode-ETH: set SERIAL1 protocol to PPP

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeNode-ETH/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeNode-ETH/hwdef.dat
@@ -38,3 +38,5 @@ include ../include/network_PPPGW.inc
 define AP_NETWORKING_TESTS_ENABLED 1
 
 define HAL_PERIPH_SHOW_SERIAL_MANAGER_PARAMS 1
+
+define DEFAULT_SERIAL1_PROTOCOL SerialProtocol_PPP


### PR DESCRIPTION
The issue is that serial_manager.init() was disabling rxtx pins if SerialProtocol_None was selected.

https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_SerialManager/AP_SerialManager.cpp#L466

Serial Manager is only enabled if MAVLink is on AP_Periph, that's why PPP GW was getting broken on CubeNode when MAVLink is enabled.