### PR TITLE
AP_Motors: feat:add battery voltage compensation to HeliRSC

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -19,6 +19,7 @@
 #include "AP_MotorsHeli_RSC.h"
 #include <AP_RPM/AP_RPM.h>
 #include <AP_Logger/AP_Logger.h>
+#include <AP_BattMonitor/AP_BattMonitor.h>
 
 // default main rotor speed (ch8 out) as a number from 0 ~ 100
 #define AP_MOTORS_HELI_RSC_SETPOINT             70
@@ -224,6 +225,30 @@ const AP_Param::GroupInfo AP_MotorsHeli_RSC::var_info[] = {
 
     // 27 was AROT_IDLE, moved to RSC autorotation sub group
 
+    // @Param: BAT_IDX
+    // @DisplayName: Main rotor motor battery index
+    // @Description: Which battery monitor should be used for main rotor motor battery voltage compensation
+    // @Range: 0 15
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("BAT_IDX", 28, AP_MotorsHeli_RSC, batt_idx, 0),
+    
+    // @Param: BAT_V_MAX
+    // @DisplayName: Main rotor motor battery voltage compensation maximum voltage
+    // @Description: Main rotor motor voltage compensation maximum voltage (voltage above this will have no additional scaling effect on thrust). Should not be used with external governor. Recommend 4.2 * cell count, 0 = Disabled
+    // @Range: 6 53
+    // @Units: V
+    // @User: Standard
+    AP_GROUPINFO("BAT_V_MAX", 29, AP_MotorsHeli_RSC, batt_voltage_max, 0),
+
+    // @Param: BAT_V_MIN
+    // @DisplayName: Main rotor motor battery voltage compensation minimum voltage 
+    // @Description: Main rotor motor voltage compensation minimum voltage (voltage below this will have no additional scaling effect on thrust). Should not be used with external governor. Recommend 3.3 * cell count, 0 = Disabled
+    // @Range: 6 42
+    // @Units: V
+    // @User: Standard
+    AP_GROUPINFO("BAT_V_MIN", 30, AP_MotorsHeli_RSC, batt_voltage_min, 0),
+
     AP_GROUPEND
 };
 
@@ -377,6 +402,8 @@ void AP_MotorsHeli_RSC::output(RotorControlState state)
         }
         break;
     }
+    
+    _control_output = _control_output * update_battery_compensation(dt);
 
     // update rotor speed run-up estimate
     update_rotor_runup(dt);
@@ -508,6 +535,25 @@ float AP_MotorsHeli_RSC::calculate_throttlecurve(float collective_in)
     return throttle;
 
 }
+
+// battety compensation logic, to get value without updating filter use dt = 0
+// returns 1.0 if a) compensation voltages are not configured, b) v_min > v_max c) batt<0.25*v_min
+float AP_MotorsHeli_RSC::update_battery_compensation(float dt){
+    if ((batt_voltage_max <= 0) || (batt_voltage_min <= 0) || (batt_voltage_min >= batt_voltage_max))
+    {
+        batt_volt_filt.reset(1);
+        return 1.0f;
+    }
+    float batt_voltage = AP::battery().voltage_resting_estimate(batt_idx);
+    if (batt_voltage < 0.25 * batt_voltage_min) { //battery voltage this low leads to dangerously high compensation coefficient, disabling 
+        batt_volt_filt.reset(1);
+        return 1.0f;
+    } else {
+        batt_voltage_min.set(MAX(batt_voltage_min, batt_voltage_max * 0.6));
+        batt_voltage = constrain_float(batt_voltage, batt_voltage_min, batt_voltage_max);
+        return 1 / batt_volt_filt.apply(batt_voltage / batt_voltage_max, dt);
+    }
+}   
 
 // autothrottle_run - calculate throttle output for governor controlled throttle
 void AP_MotorsHeli_RSC::autothrottle_run()

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -6,6 +6,7 @@
 #include <SRV_Channel/SRV_Channel.h>
 #include <AP_Logger/AP_Logger_config.h>
 #include <AC_Autorotation/RSC_Autorotation.h>
+#include "Filter/LowPassFilter.h"
 
 // rotor control modes
 enum RotorControlMode {
@@ -141,7 +142,8 @@ private:
     uint8_t         _governor_fault_count;        // variable for tracking governor speed sensor faults
     float           _governor_torque_reference;   // governor reference for load calculations
     float           _idle_throttle;               // current idle throttle setting
-
+    LowPassFilterFloat batt_volt_filt{0.5f};      // filtered voltage used for compensation
+    
     RotorControlState _rsc_state;
 
     // update_rotor_ramp - slews rotor output scalar between 0 and 1, outputs float scalar to _rotor_ramp_output
@@ -156,6 +158,9 @@ private:
     // calculate_throttlecurve - uses throttle curve and collective input to determine throttle setting
     float           calculate_throttlecurve(float collective_in);
 
+    //calculate battery compensation
+    float          update_battery_compensation(float dt);
+
     // parameters
     AP_Int16        _power_slewrate;            // throttle slew rate (percentage per second)
     AP_Int16        _thrcrv[5];                 // throttle value sent to throttle servo at 0, 25, 50, 75 and 100 percent collective
@@ -166,6 +171,10 @@ private:
     AP_Float        _governor_ff;               // governor feedforward variable
     AP_Float        _governor_range;            // RPM range +/- governor rpm reference setting where governor is operational
     AP_Int16        _cooldown_time;             // cooldown time to provide a fast idle
+    
+    AP_Int8         batt_idx;                   // battery index used for compensation
+    AP_Float        batt_voltage_max;           // maximum voltage used to scale lift
+    AP_Float        batt_voltage_min;           // minimum voltage used to scale lift
 
     // parameter accessors to allow conversions
     float       get_critical_speed() const { return _critical_speed * 0.01; }


### PR DESCRIPTION
Adds battery voltage compensation to HeliRSC output, applies to external setpoint, throttle curve and governor modes.

