### PR TITLE
Copter: Refactor coordinate_frame handling in SET_POSITION_TARGET_LOCAL_NED using switch for clarity

### DIFF
--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -1007,10 +1007,13 @@ void GCS_MAVLINK_Copter::handle_message_set_position_target_local_ned(const mavl
     }
 
     // check for supported coordinate frames
-    if (packet.coordinate_frame != MAV_FRAME_LOCAL_NED &&
-        packet.coordinate_frame != MAV_FRAME_LOCAL_OFFSET_NED &&
-        packet.coordinate_frame != MAV_FRAME_BODY_NED &&
-        packet.coordinate_frame != MAV_FRAME_BODY_OFFSET_NED) {
+    switch (packet.coordinate_frame) {
+    case MAV_FRAME_LOCAL_NED:
+    case MAV_FRAME_LOCAL_OFFSET_NED:
+    case MAV_FRAME_BODY_NED:
+    case MAV_FRAME_BODY_OFFSET_NED:
+        break;
+    default:
         // unsupported coordinate frame
         copter.mode_guided.hold_position();
         return;
@@ -1035,15 +1038,14 @@ void GCS_MAVLINK_Copter::handle_message_set_position_target_local_ned(const mavl
     if (!pos_ignore) {
         // convert to m
         pos_ned_m = Vector3p{packet.x, packet.y, packet.z};
+        switch (packet.coordinate_frame) {
         // rotate to body-frame if necessary
-        if (packet.coordinate_frame == MAV_FRAME_BODY_NED ||
-            packet.coordinate_frame == MAV_FRAME_BODY_OFFSET_NED) {
+        case MAV_FRAME_BODY_NED:
+        case MAV_FRAME_BODY_OFFSET_NED:
             pos_ned_m.xy() = copter.ahrs.body_to_earth2D_p(pos_ned_m.xy());
-        }
+            FALLTHROUGH;
         // add body offset if necessary
-        if (packet.coordinate_frame == MAV_FRAME_LOCAL_OFFSET_NED ||
-            packet.coordinate_frame == MAV_FRAME_BODY_NED ||
-            packet.coordinate_frame == MAV_FRAME_BODY_OFFSET_NED) {
+        case MAV_FRAME_LOCAL_OFFSET_NED: {
             Vector3p rel_pos_ned_m;
             if (!AP::ahrs().get_relative_position_NED_origin(rel_pos_ned_m)) {
                 // need position estimate to calculate target position
@@ -1051,6 +1053,10 @@ void GCS_MAVLINK_Copter::handle_message_set_position_target_local_ned(const mavl
                 return;
             }
             pos_ned_m += rel_pos_ned_m;
+            break;
+        }
+        default:
+            break;
         }
     }
 


### PR DESCRIPTION
This change replaces chained inequality checks and repeated conditional blocks for `coordinate_frame` handling in `SET_POSITION_TARGET_LOCAL_NED` with a structured `switch` statement.

### Motivation
The previous implementation used multiple `if` conditions with negated comparisons (`!=`) and overlapping frame checks. While functionally correct, this structure made the intended set of supported frames less explicit and increased cognitive load when reviewing or extending the logic.

Using a `switch` statement:

- Clearly expresses the supported `MAV_FRAME` values
- Eliminates duplicated conditional checks
- Improves maintainability and readability
- Reduces the risk of errors when adding new frame types in the future

### Behavioral Impact
There is **no functional change** in behavior.

The handling of the following frames remains unchanged:

- `MAV_FRAME_LOCAL_NED`
- `MAV_FRAME_LOCAL_OFFSET_NED`
- `MAV_FRAME_BODY_NED`
- `MAV_FRAME_BODY_OFFSET_NED`

The refactoring preserves:

- Body-to-earth rotation for BODY frames
- Offset addition for OFFSET-based frames
- Hold behavior for unsupported frames

This change is strictly a structural improvement for clarity and long-term maintainability.