### PR TITLE
AP_Compass: just return rather than panic when too many compasses

### DIFF
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -1017,8 +1017,8 @@ bool Compass::register_compass(int32_t dev_id, uint8_t& instance)
 
 #if COMPASS_MAX_UNREG_DEV
     // Set extra dev id
-    if (_unreg_compass_count >= COMPASS_MAX_UNREG_DEV) {
-        AP_HAL::panic("Too many compass instances");
+    if (_unreg_compass_count >= ARRAY_SIZE(extra_dev_id)) {
+        return false;
     }
 
     for (uint8_t i=0; i<COMPASS_MAX_UNREG_DEV; i++) {
@@ -1034,9 +1034,7 @@ bool Compass::register_compass(int32_t dev_id, uint8_t& instance)
             return false;
         }
     }
-#else
-    AP_HAL::panic("Too many compass instances");
-#endif
+#endif  // COMPASS_MAX_UNREG_DEV
 
     return false;
 }


### PR DESCRIPTION
We now just return false, ignoring too-many-compasses.

This could lead to situations where we can't arm because we've failed to register a compass that's in our priority list, but it's better than potentially falling out of the sky if we suddenly find another compass.

I originally formulated this as call-config-error, but it's possibly worse than a panic as we watchdog-reset from the panic.

~panic leads to a rather uninformative reboot and internal error.~

~.... in some ways this is actually worse, because if you get a watchdog on a plane (which panic causes) then you can notionally keep flying.  A config error won't reboot, a panic will.~

~I'm not sure we should do either - I think we should set a flag which causes a pre-arm failure instead and just return false.  However, I vaguely recall @bugobliterator saying something along the lines of that might be bad for saved parameter values... (which my patches here would also be....)~