### PR TITLE
ArduPlane: fix bicopter tiltrotor throttle source for tilt calculations

### DIFF
--- a/ArduPlane/tiltrotor.cpp
+++ b/ArduPlane/tiltrotor.cpp
@@ -209,6 +209,20 @@ float Tiltrotor::get_forward_flight_tilt() const
 }
 
 /*
+  get throttle value adjusted for bicopter tiltrotors which use
+  throttleLeft/throttleRight instead of the generic throttle channel
+ */
+float Tiltrotor::get_bicopter_adjusted_throttle() const
+{
+    if (type == TILT_TYPE_BICOPTER) {
+        const float left = SRV_Channels::get_output_scaled(SRV_Channel::k_throttleLeft);
+        const float right = SRV_Channels::get_output_scaled(SRV_Channel::k_throttleRight);
+        return (left + right) * 0.5;
+    }
+    return SRV_Channels::get_output_scaled(SRV_Channel::k_throttle);
+}
+
+/*
   update motor tilt for continuous tilt servos
  */
 void Tiltrotor::continuous_update(void)
@@ -229,7 +243,7 @@ void Tiltrotor::continuous_update(void)
 
         max_change = tilt_max_change(false);
 
-        float new_throttle = constrain_float(SRV_Channels::get_output_scaled(SRV_Channel::k_throttle)*0.01, 0, 1);
+        float new_throttle = constrain_float(get_bicopter_adjusted_throttle()*0.01, 0, 1);
         if (current_tilt < get_fully_forward_tilt()) {
             current_throttle = constrain_float(new_throttle,
                                                     current_throttle-max_change,
@@ -327,7 +341,7 @@ void Tiltrotor::continuous_update(void)
         // Q_TILT_MAX. Anything above 50% throttle gets
         // Q_TILT_MAX. Below 50% throttle we decrease linearly. This
         // relies heavily on Q_VFWD_GAIN being set appropriately.
-       float settilt = constrain_float((SRV_Channels::get_output_scaled(SRV_Channel::k_throttle)-MAX(plane.aparm.throttle_min.get(),0)) * 0.02, 0, 1);
+       float settilt = constrain_float((get_bicopter_adjusted_throttle()-MAX(plane.aparm.throttle_min.get(),0)) * 0.02, 0, 1);
        slew(MIN(settilt * max_angle_deg * (1/90.0), get_forward_flight_tilt())); 
     }
 }
@@ -677,7 +691,7 @@ void Tiltrotor::bicopter_output(void)
         return;
     }
 
-    float throttle = SRV_Channels::get_output_scaled(SRV_Channel::k_throttle);
+    float throttle = get_bicopter_adjusted_throttle();
     if (quadplane.assisted_flight) {
         quadplane.hold_stabilize(throttle * 0.01f);
         quadplane.motors_output(true);

--- a/ArduPlane/tiltrotor.h
+++ b/ArduPlane/tiltrotor.h
@@ -130,6 +130,8 @@ private:
     QuadPlane& quadplane;
     AP_MotorsMulticopter*& motors;
 
+    float get_bicopter_adjusted_throttle() const;
+
     Tiltrotor_Transition* transition;
 
 };


### PR DESCRIPTION
## Summary

- Bicopter tiltrotors use `throttleLeft`/`throttleRight` servo channels rather than the generic `throttle` channel, but the tilt calculation code was reading `SRV_Channel::k_throttle` which is not driven on bicopters
- This resulted in incorrect throttle-based tilt angle calculations during continuous tilt updates and assisted flight
- Added `get_bicopter_adjusted_throttle()` which returns the average of left and right throttle channels for `TILT_TYPE_BICOPTER`, falling back to the standard throttle channel for all other tilt types

## Test plan

- [ ] Test bicopter tiltrotor in SITL to verify correct tilt behavior during VTOL-to-forward-flight transition
- [ ] Verify non-bicopter tiltrotor behavior is unchanged
- [ ] Verify tilt angle responds correctly to throttle during assisted flight on bicopter