### PR TITLE
AP_AHRS: Fixed wrong frame convention comments

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -641,7 +641,7 @@ public:
     // in result, x is forward, y is right
     Vector2f earth_to_body2D(const Vector2f &ef_vector) const;
 
-    // rotate a 2D vector from earth frame to body frame
+    // rotate a 2D vector from body frame to earth frame
     // in input, x is forward, y is right
     Vector2f body_to_earth2D(const Vector2f &bf) const WARN_IF_UNUSED;
     Vector2p body_to_earth2D_p(const Vector2p &bf) const WARN_IF_UNUSED;

--- a/libraries/AP_AHRS/AP_AHRS_Backend.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.cpp
@@ -242,14 +242,14 @@ Vector2f AP_AHRS::earth_to_body2D(const Vector2f &ef) const
                     -ef.x * _sin_yaw + ef.y * _cos_yaw);
 }
 
-// rotate a 2D vector from earth frame to body frame
+// rotate a 2D vector from body frame to earth frame
 Vector2f AP_AHRS::body_to_earth2D(const Vector2f &bf) const
 {
     return Vector2f(bf.x * _cos_yaw - bf.y * _sin_yaw,
                     bf.x * _sin_yaw + bf.y * _cos_yaw);
 }
 
-// rotate a 2D vector from earth frame to body frame
+// rotate a 2D vector from body frame to earth frame
 Vector2p AP_AHRS::body_to_earth2D_p(const Vector2p &bf) const
 {
     return Vector2p(bf.x * _cos_yaw - bf.y * _sin_yaw,

--- a/libraries/AP_AHRS/AP_AHRS_View.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_View.cpp
@@ -94,7 +94,7 @@ Vector2f AP_AHRS_View::earth_to_body2D(const Vector2f &ef) const
                     -ef.x * trig.sin_yaw + ef.y * trig.cos_yaw);
 }
 
-// rotate a 2D vector from earth frame to body frame
+// rotate a 2D vector from body frame to earth frame
 Vector2f AP_AHRS_View::body_to_earth2D(const Vector2f &bf) const
 {
     return Vector2f(bf.x * trig.cos_yaw - bf.y * trig.sin_yaw,

--- a/libraries/AP_AHRS/AP_AHRS_View.h
+++ b/libraries/AP_AHRS/AP_AHRS_View.h
@@ -161,7 +161,7 @@ public:
     // in result, x is forward, y is right
     Vector2f earth_to_body2D(const Vector2f &ef_vector) const;
 
-    // rotate a 2D vector from earth frame to body frame
+    // rotate a 2D vector from body frame to earth frame
     // in input, x is forward, y is right
     Vector2f body_to_earth2D(const Vector2f &bf) const;
 


### PR DESCRIPTION
This aligns the comments for the AP_AHRS body-to-earth functions to match the function name