### PR TITLE
Tools/environment_install: Update Linux Mint codename handling in script

### DIFF
--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -72,7 +72,7 @@ case ${RELEASE_DISTRIBUTOR} in
     linuxmint)
         # translate Mint-codenames to Ubuntu-codenames based on https://www.linuxmint.com/download_all.php
         case ${RELEASE_CODENAME} in
-            wilma | xia)
+            zena | wilma | xia)
                 RELEASE_CODENAME='noble'
                 ;;
             vanessa | vera | victoria | virginia)


### PR DESCRIPTION
**Title**
Tools: add Linux Mint 'zena' codename to Ubuntu prerequisite script

**Description**
This PR adds support for Linux Mint "Zena" to the Ubuntu prerequisite installation script.

Currently, the script fails on Mint Zena because it cannot map the codename to an underlying Ubuntu release. Since Zena is based on Ubuntu 24.04 (Noble), I have added it to the existing mapping logic for wilma and xia.

**Changes:**
Updated `Tools/environment_install/install-prereqs-ubuntu.sh` to include zena in the Linux Mint codename translation case statement.

**Testing Performed**

- Verified that the script now correctly identifies the OS as noble on a Linux Mint Zena installation.
- Successfully ran the full installation of prerequisites, including the STM32 toolchain and Python environment.