### PR TITLE
AP_NavEKF: fix typo in GSF accel_gain calculation

### DIFF
--- a/libraries/AP_NavEKF/EKFGSF_yaw.cpp
+++ b/libraries/AP_NavEKF/EKFGSF_yaw.cpp
@@ -1,7 +1,7 @@
 /*
   Definition of functions used to provide a backup estimate of yaw angle
   that doesn't use a magnetometer. Uses a bank of 3-state EKF's organised
-  as a Guassian sum filter where states are velocity N,E (m/s) and yaw angle (rad)
+  as a Gaussian sum filter where states are velocity N,E (m/s) and yaw angle (rad)
 
   Written by Paul Riseborough <p_riseborough@live.com.au>
 
@@ -69,7 +69,7 @@ void EKFGSF_yaw::update(const Vector3F &delAng,
 
     // Calculate AHRS acceleration fusion gain using a quadratic weighting function that is unity at 1g
     // and zero at the min and max g limits. This reduces the effect of large g transients on the attitude
-    // esitmates.
+    // estimates.
     ftype EKFGSF_ahrs_ng = ahrs_accel_norm / GRAVITY_MSS;
     if (EKFGSF_ahrs_ng > 1.0f) {
         if (is_positive(true_airspeed)) {
@@ -394,7 +394,7 @@ void EKFGSF_yaw::predict(const uint8_t mdl_idx)
 }
 
 // Update EKF states and covariance for specified model index using velocity measurement
-// Returns false if the sttae and covariance correction failed
+// Returns false if the state and covariance correction failed
 bool EKFGSF_yaw::correct(const uint8_t mdl_idx, const Vector2F &vel, const ftype velObsVar)
 {
     // calculate velocity observation innovations

--- a/libraries/AP_NavEKF/EKFGSF_yaw.h
+++ b/libraries/AP_NavEKF/EKFGSF_yaw.h
@@ -136,7 +136,7 @@ private:
     GSF_struct GSF;
 
     // Returns the probability for a selected model assuming a Gaussian error distribution
-    // Used by the Guassian Sum Filter to calculate the weightings when combining the outputs from the bank of EKF's
+    // Used by the Gaussian Sum Filter to calculate the weightings when combining the outputs from the bank of EKF's
     ftype gaussianDensity(const uint8_t mdl_idx) const;
 
     // number of models whose weights underflowed due to excessive


### PR DESCRIPTION
This replaces PR https://github.com/ArduPilot/ardupilot/pull/32076 with just the required changes.  This addresses issue https://github.com/ArduPilot/ardupilot/issues/32075.  This was discussed [here in the support forums](https://discuss.ardupilot.org/t/ekfgsf-yaw-update/142153).

Note: during the CoPilot review, it found a another issue when fixed wings experience acceleration >2G.  The accel gain was increasing with acceleration instead of being reduced to zero.

I do not fully understand the code but just from inspection is seems strange that the "accel_gain" variable would be used as a condition to its own calculation.  What seems much more likely is that the EKFGSF_ahrs_ng variable should be used as the condition.

The accel_gain variable is a global variable and is apparently used to determine how much the GSF trusts the accelerometer for tilt correction instead of just riding on the gyro values.

To help understand the impact of this potential bug, here's a before-vs-after table of the vehicle's acceleration vs the calculated **accel_gain**

Acceleration (G) | Gain Before | Gain After | Notes
-- | -- | -- | --
<=0.5 | 0 | 0 | Both correct
0.6 | 0 | 0.008 | Before incorrect: gain disabled
0.7 | 0 | 0.032 | Before incorrect: gain disabled
0.8 | 0 | 0.072 | Before incorrect: gain disabled
0.9 | 0 | 0.128 | Before incorrect: gain disabled
1 | 0 | 0.2 | Before incorrect: gain disabled at 1G
1.1 | 0.128 | 0.128 | Both correct
1.3 | 0.032 | 0.032 | Both correct
1.5 | 0 | 0 | Both correct
1.6 | 0.008 | 0 | Before incorrect: should be zero
2 | 0.2 | 0 | Before incorrect: max gain at high G
2.2 | 0.008 | 0 | Before incorrect: gain increasing with acceleration
2.5 | 0.05 | 0 | Before incorrect: gain increasing with acceleration
3.0 | 0.2 | 0 | Before incorrect: max gain at 3G

I've tested this lightly in SITL by doing the following:

1. Tools/autotest/sim_vehicle.py --map --console -L CMAC_South <-- vehicle starts facing south
2. map set showsimpos 1 <-- makes vehicle's actual yaw visible
3. ALT_HOLD
4. arm throttle
5. rc 3 2000
6. rc 3 1500 <-- after vehicle has climbed to 10m
7. rc 1 1000 <-- hard roll movement allows GSF to recognise the vehicle's actual heading
8. rc 1 1500

All this did was allow me to confirm that GSF still works after this change
<img width="816" height="1028" alt="gsf-fix-sitl-test" src="https://github.com/user-attachments/assets/d57df902-e54e-45da-bcf0-2dd8a8b10b46" />
