### PR TITLE
Fix quad_plane.qautotune

### DIFF
--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -328,6 +328,10 @@ bool AC_AutoTune::currently_level()
 {
     // abort AutoTune if we pass 2 * AUTOTUNE_LEVEL_TIMEOUT_MS
     const uint32_t now_ms = AP_HAL::millis();
+    if (fabsf(attitude_control->get_rate_ef_target_rads().z) > 0.5 * attitude_control->get_slew_yaw_max_rads()) {
+        // reset if the target yaw rate is above half the slew rate
+        level_start_time_ms = now_ms;
+    }
     if (now_ms - level_start_time_ms > 3 * AUTOTUNE_LEVEL_TIMEOUT_MS) {
         GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "AutoTune: Failed to level, please tune manually");
         mode = TuneMode::FAILED;


### PR DESCRIPTION
This fixes an autotest and a small bug. The problem is the aircraft is moving enough under position hold in Autotune to get large heading changes that cause autotune to time out.

By adding a little wind, 1m/s we bias the aircraft to one side and reduce the largest of these heading changes.