### PR TITLE
AP_Bootloader: Reserve board ID 1214 for AP_HW_H7_VELVET

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -333,6 +333,8 @@ AP_HW_CORVON_V5                      1211
 AP_HW_CSKY_PMU                       1212
 AP_HW_PilotGaeaSH7V1                 1213
 
+AP_HW_H7_VELVET                      1214
+
 AP_HW_MUPilot                        1222
 AP_HW_HWH7                           1223
 


### PR DESCRIPTION
Reserving board ID 1214 for the H7_VELVET flight controller by Reflex Drive.
- Hardware: STM32H743-based.
- Intent: Reserving the ID to avoid conflicts during hardware development.