### PR TITLE
autotest: make change_mode much faster

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -16534,7 +16534,7 @@ return update, 1000
             self.GPSBlendingLog,
             self.GPSBlendingAffinity,
             self.DataFlash,
-            Test(self.DataFlashErase, attempts=8),
+            self.DataFlashErase,
             self.Callisto,
             self.PerfInfo,
             self.ModeAllowsEntryWhenNoPilotInput,

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -3360,6 +3360,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.reboot_sitl()
 
         self.change_mode('LOITER')
+        self.bodgy_race_condition_delay(5, "race condition introduced by fastermode change")
 
         class CheckOpticalFlow(vehicle_test_suite.TestSuite.MessageHook):
             '''ensures OPTICAL_FLOW data matches other data'''
@@ -4111,6 +4112,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "altitude": int(origin_alt*1000),  # m -> mm
         })
 
+    def bodgy_race_condition_delay(self, delay, msg):
+        '''delay delay seconds; msg *must* be supplied as these are all FIXMEs!'''
+        self.delay_sim_time(delay, reason=msg)
+
     def FarOrigin(self):
         '''fly a mission far from the vehicle origin'''
         # Fly mission #1
@@ -4119,6 +4124,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         })
         self.reboot_sitl()
         nz = mavutil.location(-43.730171, 169.983118, 1466.3, 270)
+        self.bodgy_race_condition_delay(2, "EKF public_origin not used to reset origin in Bootstrap")
         self.set_origin(nz)
         self.set_parameters({
             "SIM_GPS1_ENABLE": 1,

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -770,13 +770,13 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.context_pop()
 
     # enter RTL mode and wait for the vehicle to disarm
-    def do_RTL(self, distance_min=None, check_alt=True, distance_max=10, timeout=250, quiet=False):
+    def do_RTL(self, distance_min=None, check_alt=True, alt_max=1, distance_max=10, timeout=250, quiet=False):
         """Enter RTL mode and wait for the vehicle to disarm at Home."""
         self.change_mode("RTL")
         self.zero_throttle()
-        self.wait_rtl_complete(check_alt=check_alt, distance_max=distance_max, timeout=timeout, quiet=True)
+        self.wait_rtl_complete(check_alt=check_alt, alt_max=alt_max, distance_max=distance_max, timeout=timeout, quiet=True)
 
-    def wait_rtl_complete(self, check_alt=True, distance_max=10, timeout=250, quiet=False):
+    def wait_rtl_complete(self, check_alt=True, alt_max=1, distance_max=10, timeout=250, quiet=False):
         """Wait for RTL to reach home and disarm"""
         self.progress("Waiting RTL to reach Home and disarm")
         tstart = self.get_sim_time()
@@ -785,7 +785,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             alt = m.relative_alt / 1000.0 # mm -> m
             home_distance = self.distance_to_home(use_cached_home=True)
             home = ""
-            alt_valid = alt <= 1
+            alt_valid = alt <= alt_max
             distance_valid = home_distance < distance_max
             if check_alt:
                 if alt_valid and distance_valid:
@@ -2859,7 +2859,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 raise NotAchievedException("fly_gps_glitch_loiter_test2 failed, roll or pitch moved during GPS glitch")
 
         # RTL, remove glitch and reboot sitl
-        self.do_RTL()
+        self.do_RTL(alt_max=2)
         self.context_pop()
         self.reboot_sitl()
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -4036,6 +4036,14 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
     def set_origin(self, loc, timeout=60):
         '''set the GPS global origin to loc'''
+        delta_t = self.get_sim_time() - 2
+        if delta_t > 0:
+            # there's a 1 second delay before we init EKF3.  Setting
+            # origin too early exposes a bug where that init kills the
+            # origin in each of the backends.  FIXME!
+            self.progress("Delaying set origin until EKF3 will have initialised")
+            self.delay_sim_time(delta_t)
+
         self.progress("Setting origin")
         if isinstance(loc, mavutil.mavlink.MAVLink_global_position_int_message):
             lat_1e7 = loc.lat

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -5223,7 +5223,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.change_mode("TAKEOFF")
 
         # waiting for the EKF to be happy won't work
-        self.delay_sim_time(20)
+        self.wait_prearm_sys_status_healthy()
         self.arm_vehicle()
 
         target_alt = self.get_parameter("TKOFF_ALT")

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -5180,6 +5180,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         )
         self.set_parameters({
             "ARSPD_USE": 0.0,
+            "TKOFF_LVL_ALT": 30,
         })
         self.change_mode("TAKEOFF")
 

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -6979,6 +6979,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
                 mavutil.mavlink.MAV_CMD_DO_LAND_START,
             ),
             (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 800, 800, alt),
+            (mavutil.mavlink.MAV_CMD_NAV_LAND, 400, 400, 0),
         ])
 
         self.upload_fences_from_locations([

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -1425,7 +1425,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.wait_rpm(1, 0, 0, minimum_duration=1)
 
             self.change_mode('QLAND')
-            self.wait_disarmed()
+            self.wait_disarmed(timeout=45)
 
     def Ship(self):
         '''Ensure we can take off from simulated ship'''

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -7313,8 +7313,7 @@ return update()
             self.drive_mission(mission_file, strict=False, ignore_MANUAL_mode_change=True)
             self.wait_mode('MANUAL')
 
-            if self.distance_to_home() > 2:
-                raise NotAchievedException("Did not get home!")
+            self.wait_distance_to_home(0, 5, timeout=1)
 
     def start_driving_simple_relhome_mission(self, items):
         '''uploads items, changes mode to AUTO, waits ready to arm and starts mission'''

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -2363,7 +2363,7 @@ class TestSuite(abc.ABC):
             p1=p1, # enable/disable
         )
 
-    def reboot_sitl_mav(self, required_bootcount=None, force=False):
+    def reboot_sitl_mav(self, required_bootcount=None, force=False, invalid_heartbeat_sys_status=None):
         """Reboot SITL instance using mavlink and wait for it to reconnect."""
         # we must make sure that stats have been reset - otherwise
         # when we reboot we'll reset statistics again and lose our
@@ -2418,7 +2418,11 @@ class TestSuite(abc.ABC):
                     raise NotAchievedException("Bad reboot ACK detected")
             self.install_message_hook_context(hook)
 
-        self.detect_and_handle_reboot(old_bootcount, required_bootcount=required_bootcount)
+        self.detect_and_handle_reboot(
+            old_bootcount,
+            required_bootcount=required_bootcount,
+            invalid_heartbeat_sys_status=invalid_heartbeat_sys_status,
+        )
 
         if do_context:
             self.context_pop()
@@ -2443,12 +2447,17 @@ class TestSuite(abc.ABC):
                     check_position=True,
                     mark_context=True,
                     startup_location_dist_max=1,
+                    invalid_heartbeat_sys_status=None,
                     ):
         """Reboot SITL instance and wait for it to reconnect."""
         if self.armed() and not force:
             raise NotAchievedException("Reboot attempted while armed")
         self.progress("Rebooting SITL")
-        self.reboot_sitl_mav(required_bootcount=required_bootcount, force=force)
+        self.reboot_sitl_mav(
+            required_bootcount=required_bootcount,
+            force=force,
+            invalid_heartbeat_sys_status=invalid_heartbeat_sys_status,
+        )
         self.do_heartbeats(force=True)
         if check_position and self.frame != 'sailboat':  # sailboats drift with wind!
             self.assert_simstate_location_is_at_startup_location(dist_max=startup_location_dist_max)
@@ -2465,7 +2474,7 @@ class TestSuite(abc.ABC):
         self.mavproxy.send("reboot\n")
         self.detect_and_handle_reboot(old_bootcount, required_bootcount=required_bootcount)
 
-    def detect_and_handle_reboot(self, old_bootcount, required_bootcount=None, timeout=10):
+    def detect_and_handle_reboot(self, old_bootcount, required_bootcount=None, timeout=10, invalid_heartbeat_sys_status=None):
         tstart = time.time()
         if required_bootcount is None:
             required_bootcount = old_bootcount + 1
@@ -2498,7 +2507,7 @@ class TestSuite(abc.ABC):
         self.do_timesync_roundtrip(timeout_in_wallclock=True)
 
         self.progress("Calling initialise-after-reboot")
-        self.initialise_after_reboot_sitl()
+        self.initialise_after_reboot_sitl(invalid_heartbeat_sys_status=invalid_heartbeat_sys_status)
 
     def scripting_restart(self):
         '''restart scripting subsystem'''
@@ -3120,17 +3129,18 @@ class TestSuite(abc.ABC):
         if len(missing) > 0:
             raise NotAchievedException("Documented messages (%s) not in code" % missing)
 
-    def initialise_after_reboot_sitl(self):
+    def initialise_after_reboot_sitl(self, invalid_heartbeat_sys_status=None):
 
-        # after reboot stream-rates may be zero.  Request streams.
-        self.drain_mav()
-        self.wait_heartbeat(
-            invalid_sys_status=(
+        if invalid_heartbeat_sys_status is None:
+            invalid_heartbeat_sys_status = (
                 mavutil.mavlink.MAV_STATE_UNINIT,
                 mavutil.mavlink.MAV_STATE_BOOT,
                 mavutil.mavlink.MAV_STATE_CALIBRATING,
-            ),
-        )
+            )
+
+        # after reboot stream-rates may be zero.  Request streams.
+        self.drain_mav()
+        self.wait_heartbeat(invalid_sys_status=invalid_heartbeat_sys_status)
         self.set_streamrate(self.sitl_streamrate())
         self.progress("Reboot complete")
 
@@ -11550,13 +11560,14 @@ Also, ignores heartbeats not from our target system'''
                 self.progress("Disarming tracker")
                 self.disarm_vehicle(force=True)
 
-            self.reboot_sitl(required_bootcount=1)
+            self.reboot_sitl(required_bootcount=1, invalid_heartbeat_sys_status=())
             self.progress("Waiting for 'Config error'")
             # SYSTEM_TIME not sent in config error loop:
             self.wait_statustext("Config error", wallclock_timeout=True)
             self.progress("Setting %s to %f" % (parameter_name, new_parameter_value))
             self.set_parameter(parameter_name, new_parameter_value)
         except Exception as e:  # noqa: BLE001
+            self.print_exception_caught(e)
             ex = e
 
         self.progress("Resetting SIM_BARO_COUNT")

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -6561,7 +6561,7 @@ class TestSuite(abc.ABC):
         for i in range(0, attempts):
             mavproxy.send("param fetch %s\n" % name)
             try:
-                mavproxy.expect("%s = ([-0-9.]*)\r\n" % (name,), timeout=timeout/attempts)
+                mavproxy.expect("%s = ([-0-9.]*)" % (name,), timeout=timeout/attempts)
                 try:
                     # sometimes race conditions garble the MAVProxy output
                     ret = float(mavproxy.match.group(1))

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -3796,13 +3796,13 @@ class TestSuite(abc.ABC):
         if ex is not None:
             raise ex
 
-    def download_full_log_list(self, print_logs=True):
+    def download_full_log_list(self, print_logs=True, LOG_ENTRY_sanity_check=True):
         tstart = self.get_sim_time()
         self.mav.mav.log_request_list_send(self.sysid_thismav(),
                                            1, # target component
                                            0,
                                            0xffff)
-        logs = {}
+        logs : dict[int : mavutil.MAVLink.MAVLink_log_entry_message] = {}
         last_id = None
         num_logs = None
         while True:
@@ -3838,7 +3838,8 @@ class TestSuite(abc.ABC):
                 break
 
         # ensure we don't get any extras:
-        self.assert_not_receiving_message('LOG_ENTRY', timeout=2)
+        if LOG_ENTRY_sanity_check:
+            self.assert_not_receiving_message('LOG_ENTRY', timeout=2)
 
         return logs
 
@@ -10788,6 +10789,25 @@ Also, ignores heartbeats not from our target system'''
         if herrors > header_errors:
             raise NotAchievedException("Error parsing log file %s, %d header errors" % (logname, herrors))
 
+    def print_downloaded_full_log_list(self, file_list):
+        self.progress("Downloaded log list")
+        for message in file_list.values():
+            self.progress(f"    {message.id} {message.size} {message.time_utc}")
+
+    def assert_current_log_filesizes(self, sizes):
+        file_list = self.download_full_log_list(LOG_ENTRY_sanity_check=False)
+        self.print_downloaded_full_log_list(file_list)
+        for file_id, minmax in sizes.items():
+            (minsize, maxsize) = minmax
+            self.progress(f"want Log {file_id} between {minsize} and {maxsize}")
+            if file_id not in file_list:
+                raise NotAchievedException(f"{file_id} not in downloaded log info")
+            m = file_list[file_id]
+            if m.size < minsize:
+                raise NotAchievedException(f"{file_id} too small; got={m.size} want>{minsize} and <{maxsize}")
+            if m.size > maxsize:
+                raise NotAchievedException(f"{file_id} too large; got={m.size} want<{maxsize} and >{minsize}")
+
     def DataFlashErase(self):
         """Test that erasing the dataflash chip and creating a new log is error free"""
         mavproxy = self.start_mavproxy()
@@ -10795,39 +10815,65 @@ Also, ignores heartbeats not from our target system'''
         ex = None
         self.context_push()
         try:
-            self.set_parameter("LOG_BACKEND_TYPE", 4)
+            self.set_parameters({
+                "LOG_DISARMED": 0,
+                "LOG_BACKEND_TYPE": 4,
+                "SIM_SPEEDUP": 10,
+            })
             self.reboot_sitl()
             mavproxy.send("module load log\n")
             mavproxy.send("log erase\n")
             mavproxy.expect("Chip erase complete")
-            self.set_parameter("LOG_DISARMED", 1)
-            self.delay_sim_time(3)
-            self.set_parameter("LOG_DISARMED", 0)
+
+            self.set_autodisarm_delay(6)
+
+            self.progress("Creating a very short log")
+            self.wait_ready_to_arm()
+            self.arm_vehicle()
+            self.wait_disarmed()
+            self.assert_current_log_filesizes({
+                1: (400*1024, 900*1024),
+            })
             mavproxy.send("log download 1 logs/dataflash-log-erase.BIN\n")
             mavproxy.expect("Finished downloading", timeout=120)
             # read the downloaded log - it must parse without error
             self.validate_log_file("logs/dataflash-log-erase.BIN")
 
             self.start_subtest("Test file wrapping results in a valid file")
-            # roughly 4mb
             self.set_parameter("LOG_FILE_DSRMROT", 1)
             self.set_parameter("LOG_BITMASK", 131071)
             self.wait_ready_to_arm()
-            if self.is_copter() or self.is_plane():
-                self.set_autodisarm_delay(0)
+
+            self.progress("Appending to create larger log")
+            self.set_autodisarm_delay(10)
             self.arm_vehicle()
-            self.delay_sim_time(30)
-            self.disarm_vehicle()
-            # roughly 4mb
+            self.wait_disarmed()
+            self.assert_current_log_filesizes({
+                1: (1900*1024, 3000*1024),
+            })
+            self.progress("Creating a second large log")
             self.arm_vehicle()
-            self.delay_sim_time(30)
-            self.disarm_vehicle()
-            # roughly 9mb, should wrap around
+            self.wait_disarmed()
+            self.assert_current_log_filesizes({
+                1: (1900*1024, 3000*1024),
+                2: (900*1024, 1700*1024),
+            })
+
+            self.set_autodisarm_delay(0)
+
+            self.progress("Creating a very large log which wipes the other ones out")
+            self.context_collect('STATUSTEXT')
             self.arm_vehicle()
-            self.delay_sim_time(50)
+            self.wait_statustext('Chip full, logging stopped', check_context=True, timeout=60)
             self.disarm_vehicle()
+
             # make sure we have finished logging
             self.delay_sim_time(15)
+
+            self.assert_current_log_filesizes({
+                1: (3809996, 4109996),
+            })
+
             mavproxy.send("log list\n")
             try:
                 mavproxy.expect("Log ([0-9]+)  numLogs ([0-9]+) lastLog ([0-9]+) size ([0-9]+)", timeout=120)
@@ -10837,16 +10883,12 @@ Also, ignores heartbeats not from our target system'''
                 else:
                     self.progress("SITL is NOT running")
                 raise NotAchievedException("Received %s" % str(e))
-            if int(mavproxy.match.group(2)) != 3:
-                raise NotAchievedException("Expected 3 logs got %s" % (mavproxy.match.group(2)))
+            if int(mavproxy.match.group(2)) != 1:
+                raise NotAchievedException("Expected 1 log got %s" % (mavproxy.match.group(2)))
 
             mavproxy.send("log download 1 logs/dataflash-log-erase2.BIN\n")
             mavproxy.expect("Finished downloading", timeout=120)
-            self.validate_log_file("logs/dataflash-log-erase2.BIN", 1)
-
-            mavproxy.send("log download latest logs/dataflash-log-erase3.BIN\n")
-            mavproxy.expect("Finished downloading", timeout=120)
-            self.validate_log_file("logs/dataflash-log-erase3.BIN", 1)
+            self.validate_log_file("logs/dataflash-log-erase2.BIN", header_errors=1)
 
             # clean up
             mavproxy.send("log erase\n")
@@ -12618,6 +12660,7 @@ switch value'''
         return latest
 
     def dfreader_for_path(self, path):
+        self.progress(f"Returning dfreader for {path}")
         return DFReader.DFReader_binary(path,
                                         zero_time_base=True)
 

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -7065,10 +7065,9 @@ class TestSuite(abc.ABC):
 
     def change_mode(self, mode, timeout=60):
         '''change vehicle flightmode'''
-        self.wait_heartbeat()
         self.progress("Changing mode to %s" % mode)
-        self.send_cmd_do_set_mode(mode)
         tstart = self.get_sim_time()
+        self.send_cmd_do_set_mode(mode)
         while not self.mode_is(mode):
             custom_num = self.mav.messages['HEARTBEAT'].custom_mode
             self.progress("mav.flightmode=%s Want=%s custom=%u" % (

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -2503,9 +2503,6 @@ class TestSuite(abc.ABC):
                 self.progress("Got unexpected exception (%s)" % str(type(e)))
                 pass
 
-        # empty mav to avoid getting old timestamps:
-        self.do_timesync_roundtrip(timeout_in_wallclock=True)
-
         self.progress("Calling initialise-after-reboot")
         self.initialise_after_reboot_sitl(invalid_heartbeat_sys_status=invalid_heartbeat_sys_status)
 
@@ -3139,7 +3136,8 @@ class TestSuite(abc.ABC):
             )
 
         # after reboot stream-rates may be zero.  Request streams.
-        self.drain_mav()
+        self.do_timesync_roundtrip(timeout_in_wallclock=True)
+
         self.wait_heartbeat(invalid_sys_status=invalid_heartbeat_sys_status)
         self.set_streamrate(self.sitl_streamrate())
         self.progress("Reboot complete")
@@ -8718,6 +8716,8 @@ Also, ignores heartbeats not from our target system'''
                 if not self.sitl_is_running():
                     self.progress("SITL is not running")
                 raise AutoTestTimeoutException("Did not receive heartbeat")
+            # request the heartbeat:
+            self.send_cmd(mavutil.mavlink.MAV_CMD_REQUEST_MESSAGE, 0, quiet=True)
             m = self.mav.wait_heartbeat(*args, **x)
             if m is None:
                 continue

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -3124,7 +3124,13 @@ class TestSuite(abc.ABC):
 
         # after reboot stream-rates may be zero.  Request streams.
         self.drain_mav()
-        self.wait_heartbeat()
+        self.wait_heartbeat(
+            invalid_sys_status=(
+                mavutil.mavlink.MAV_STATE_UNINIT,
+                mavutil.mavlink.MAV_STATE_BOOT,
+                mavutil.mavlink.MAV_STATE_CALIBRATING,
+            ),
+        )
         self.set_streamrate(self.sitl_streamrate())
         self.progress("Reboot complete")
 
@@ -3150,7 +3156,11 @@ class TestSuite(abc.ABC):
             if time.time() - tstart > 30:
                 raise NotAchievedException("Failed to customise")
             try:
-                m = self.wait_heartbeat(drain_mav=True)
+                m = self.wait_heartbeat(drain_mav=True, invalid_sys_status=(
+                    mavutil.mavlink.MAV_STATE_UNINIT,
+                    mavutil.mavlink.MAV_STATE_BOOT,
+                    mavutil.mavlink.MAV_STATE_CALIBRATING,
+                ))
                 if m.type == 0:
                     self.progress("Bad heartbeat: %s" % str(m))
                     continue
@@ -8685,7 +8695,7 @@ class TestSuite(abc.ABC):
         self.total_waiting_to_arm_time += armable_time
         self.waiting_to_arm_count += 1
 
-    def wait_heartbeat(self, drain_mav=True, quiet=False, *args, **x):
+    def wait_heartbeat(self, drain_mav=True, quiet=False, invalid_sys_status=None, *args, **x):
         '''as opposed to mav.wait_heartbeat, raises an exception on timeout.
 Also, ignores heartbeats not from our target system'''
         if drain_mav:
@@ -8701,6 +8711,9 @@ Also, ignores heartbeats not from our target system'''
             m = self.mav.wait_heartbeat(*args, **x)
             if m is None:
                 continue
+            if invalid_sys_status is not None:
+                if m.system_status in invalid_sys_status:
+                    continue
             if m.get_srcSystem() == self.sysid_thismav():
                 return m
 

--- a/libraries/AP_HAL_SITL/SITL_Periph_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_Periph_State.cpp
@@ -126,19 +126,12 @@ void SITL_State::init(int argc, char * const argv[]) {
     sitl_model->set_i2c(&_sitl->i2c_sim);
 }
 
-void SITL_State::wait_clock(uint64_t wait_time_usec)
+void SITL_State::_fdm_input_step(void)
 {
-    while (AP_HAL::micros64() < wait_time_usec) {
-        if (hal.scheduler->in_main_thread() ||
-            Scheduler::from(hal.scheduler)->semaphore_wait_hack_required()) {
             struct sitl_input input {};
             sitl_model->update(input); // delays up to 1 millisecond
             sim_update();
             update_voltage_current(input, 0);
-        } else {
-            usleep(1000);
-        }
-    }
 }
 
 /*

--- a/libraries/AP_HAL_SITL/SITL_Periph_State.h
+++ b/libraries/AP_HAL_SITL/SITL_Periph_State.h
@@ -82,7 +82,7 @@ public:
 
 private:
 
-    void wait_clock(uint64_t wait_time_usec);
+    void _fdm_input_step(void) override;
     bool _use_rtscts;
     uint16_t _base_port;
 

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -143,7 +143,7 @@ void SITL_State::wait_clock(uint64_t wait_time_usec)
                 }
             }
 #endif
-            usleep(1000);
+            usleep(10);
         }
     }
     // check the outbound TCP queue size.  If it is too long then

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -117,40 +117,13 @@ void SITL_State::_fdm_input_step(void)
 
 void SITL_State::wait_clock(uint64_t wait_time_usec)
 {
-    float speedup = sitl_model->get_speedup();
-    if (speedup < 1) {
-        // for purposes of sleeps treat low speedups as 1
-        speedup = 1.0;
-    }
-    while (AP_HAL::micros64() < wait_time_usec) {
-        if (hal.scheduler->in_main_thread() ||
-            Scheduler::from(hal.scheduler)->semaphore_wait_hack_required()) {
-            _fdm_input_step();
-        } else {
-#ifdef CYGWIN_BUILD
-            if (speedup > 2 && hal.util->get_soft_armed()) {
-                const char *current_thread = Scheduler::from(hal.scheduler)->get_current_thread_name();
-                if (current_thread && strcmp(current_thread, "Scripting") == 0) {
-                    // this effectively does a yield of the CPU. The
-                    // granularity of sleeps on cygwin is very high,
-                    // so this is needed for good thread performance
-                    // in scripting. We don't do this at low speedups
-                    // as it causes the cpu to run hot
-                    // We also don't do it while disarmed, as lua performance is less
-                    // critical while disarmed
-                    usleep(0);
-                    continue;
-                }
-            }
-#endif
-            usleep(10);
-        }
-    }
+    SITL_State_Common::wait_clock(wait_time_usec);
+
     // check the outbound TCP queue size.  If it is too long then
     // MAVProxy/pymavlink take too long to process packets and it ends
     // up seeing traffic well into our past and hits time-out
     // conditions.
-    if (speedup > 1 && hal.scheduler->in_main_thread()) {
+    if (sitl_model->get_speedup() > 1 && hal.scheduler->in_main_thread()) {
         while (true) {
             HALSITL::UARTDriver *uart = (HALSITL::UARTDriver*)hal.serial(0);
             const int queue_length = uart->get_system_outqueue_length();

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -70,9 +70,9 @@ private:
     void _fdm_input_local(void);
     void _output_to_flightgear(void);
     void _simulator_servos(struct sitl_input &input);
-    void _fdm_input_step(void);
+    void _fdm_input_step(void) override;
 
-    void wait_clock(uint64_t wait_time_usec);
+    void wait_clock(uint64_t wait_time_usec) override;
 
     // internal state
     uint8_t _instance;

--- a/libraries/AP_HAL_SITL/SITL_State_common.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State_common.cpp
@@ -47,6 +47,42 @@
 
 using namespace HALSITL;
 
+extern const AP_HAL::HAL& hal;
+
+// this method is shared between periph and normal firmwares
+void SITL_State_Common::wait_clock(uint64_t wait_time_usec)
+{
+    float speedup = sitl_model->get_speedup();
+    if (speedup < 1) {
+        // for purposes of sleeps treat low speedups as 1
+        speedup = 1.0;
+    }
+    while (AP_HAL::micros64() < wait_time_usec) {
+        if (hal.scheduler->in_main_thread() ||
+            Scheduler::from(hal.scheduler)->semaphore_wait_hack_required()) {
+            _fdm_input_step();
+        } else {
+#ifdef CYGWIN_BUILD
+            if (speedup > 2 && hal.util->get_soft_armed()) {
+                const char *current_thread = Scheduler::from(hal.scheduler)->get_current_thread_name();
+                if (current_thread && strcmp(current_thread, "Scripting") == 0) {
+                    // this effectively does a yield of the CPU. The
+                    // granularity of sleeps on cygwin is very high,
+                    // so this is needed for good thread performance
+                    // in scripting. We don't do this at low speedups
+                    // as it causes the cpu to run hot
+                    // We also don't do it while disarmed, as lua performance is less
+                    // critical while disarmed
+                    usleep(0);
+                    continue;
+                }
+            }
+#endif
+            usleep(10);
+        }
+    }
+}
+
 static const struct {
     const char *name;
     SITL::SerialRangeFinder *(*createfn)();

--- a/libraries/AP_HAL_SITL/SITL_State_common.h
+++ b/libraries/AP_HAL_SITL/SITL_State_common.h
@@ -229,6 +229,9 @@ protected:
     SITL::SIM *_sitl;
 
     void update_voltage_current(struct sitl_input &input, float throttle);
+
+    virtual void _fdm_input_step(void) = 0;
+    virtual void wait_clock(uint64_t wait_time_usec);
 };
 
 #endif // CONFIG_HAL_BOARD == HAL_BOARD_SITL


### PR DESCRIPTION
we don't need to know the current mode, so no need to wait for a heartbeat.

Send command after getting the current sim time so the insta-heartbeat-on-mode-change that ArduPilot sends out isn't swallowed by the get_sim_time call