### PR TITLE
AP_DDS: add new body fixed NED frame to cmd_vel

### DIFF
--- a/libraries/AP_DDS/AP_DDS_ExternalControl.cpp
+++ b/libraries/AP_DDS/AP_DDS_ExternalControl.cpp
@@ -71,8 +71,7 @@ bool AP_DDS_External_Control::handle_velocity_control(geometry_msgs_msg_TwistSta
         auto &ahrs = AP::ahrs();
         linear_velocity = ahrs.body_to_earth(linear_velocity_base_link);
         return external_control->set_linear_velocity_and_yaw_rate(linear_velocity, yaw_rate);
-    } else if (strcmp(cmd_vel.header.frame_id, BASE_LINK_NED_FRAME_ID) == 0)
-    {
+    } else if (strcmp(cmd_vel.header.frame_id, BASE_LINK_NED_FRAME_ID) == 0) {
         // Convert commands from body fixed NED (x-body-forward, y-body-left, z-earth-up) to NED.
         Vector3f linear_velocity;
         Vector2f linear_velocity_base_link_flat{


### PR DESCRIPTION
This PR adds a new option to control the aircraft via a yawed body frame. The frame is already defined in ardupilot. This allows copters to be steered similar to a rover where an X velocity moves the aircraft forward in a frame yawed to its forward. This is similar to how mavSDK  works.

An example of each of the frame options for command velocity are shown below:
In the 'map' frame a command of:
```
ros2 topic pub /ap/cmd_vel geometry_msgs/msg/TwistStamped 'header:
  stamp:
    sec: 0
    nanosec: 0
  frame_id: 'map'
twist:
  linear:
    x: 1.0
    y: 0.0
    z: 0.0
  angular:
    x: 0.0
    y: 0.0
    z: 0.5
' --times 10
```

Results in this:
<img width="650" height="439" alt="image" src="https://github.com/user-attachments/assets/a1c57d51-ae92-4bbe-8e09-c68a7796c9d7" />

In the 'base_link' frame a command of:
```ros2 topic pub /ap/cmd_vel geometry_msgs/msg/TwistStamped 'header:
  stamp:
    sec: 0
    nanosec: 0
  frame_id: 'base_link'
twist:
  linear:
    x: 1.0
    y: 0.0
    z: 0.0
  angular:
    x: 0.0
    y: 0.0
    z: 1.0
' --times 30
```
Results in this:
<img width="485" height="305" alt="image" src="https://github.com/user-attachments/assets/e9f72aab-9e8b-46ba-84d6-8849b16b8458" />


The new feature uses the existing 'base_link_ned' frame and a command of:
```ros2 topic pub /ap/cmd_vel geometry_msgs/msg/TwistStamped 'header:
  stamp:
    sec: 0
    nanosec: 0
  frame_id: 'base_link_ned'
twist:
  linear:
    x: 1.0
    y: 0.0
    z: 0.0
  angular:
    x: 0.0
    y: 0.0
    z: 1.0
' --times 30
```
Results in this:
<img width="758" height="297" alt="image" src="https://github.com/user-attachments/assets/fbfeca8d-dcc8-47cf-8d48-09a40198eb0b" />

As you can see, the command allows you to control the vehicle in XY and steer with yaw which adds a convenient control interface. 