### PR TITLE
AP_NavEKF3: ground clearance fusion fix

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -15243,6 +15243,208 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # we are not at the home location - reboot so the next test starts there
         self.reboot_sitl()
 
+    def assert_ekf_height_tracks_climb(self, climb_m, timeout=90):
+        '''check the EKF height estimate follows climb_m of real altitude'''
+        gnd_alt = self.get_altitude(altitude_source="SIM_STATE.alt")
+        start_z = self.assert_receive_message('LOCAL_POSITION_NED', timeout=10).z
+        # wait on the simulated altitude rather than any estimate-derived
+        # altitude, because the estimate is the thing under test
+        self.wait_altitude(gnd_alt + climb_m, gnd_alt + climb_m + 30,
+                           altitude_source="SIM_STATE.alt", timeout=timeout)
+        true_climb = self.get_altitude(altitude_source="SIM_STATE.alt") - gnd_alt
+        est_climb = start_z - self.assert_receive_message('LOCAL_POSITION_NED', timeout=10).z
+        self.progress("climbed %.1fm, EKF estimated %.1fm" % (true_climb, est_climb))
+        # bound by the climb asked for, not the one achieved: a vehicle flying a
+        # lagging estimate over-throttles and would otherwise widen its own bound
+        if abs(true_climb - est_climb) > 0.25 * climb_m:
+            raise NotAchievedException(
+                "EKF height did not track the climb: true=%.1fm est=%.1fm" %
+                (true_climb, est_climb))
+
+    def assert_ekf_terrain_offset_above(self, want_m):
+        '''check the EKF terrain offset in the current log stayed above -want_m'''
+        dfreader = self.dfreader_for_current_onboard_log()
+        low = None
+        while True:
+            m = dfreader.recv_match(type='XKF5')
+            if m is None:
+                break
+            if m.C != 0:
+                continue
+            # XKF5.TOfs is the terrain position relative to the EKF datum,
+            # logged as int16 centimetres and scaled by the reader. Feeding the
+            # estimator a range that never leaves the ground drags the terrain up
+            # under the vehicle, which puts the datum far below it, so the floor
+            # is what shows the damage - HAGL only dips once TOfs has walked.
+            if low is None or m.TOfs < low:
+                low = m.TOfs
+        if low is None:
+            raise NotAchievedException("No XKF5 messages in the log")
+        self.progress("lowest EKF terrain offset %.1fm" % low)
+        if low < -want_m:
+            raise NotAchievedException(
+                "Terrain datum walked away from the vehicle: TOfs=%.1fm want>-%.1fm" % (low, want_m))
+
+    def assert_ekf_moved_since_arming_was_set(self):
+        '''check the movement latch was published in the current log'''
+        # bit 10 of the filter status, which this PR redefines from optical flow
+        # takeoff detection to "has moved since arming"
+        moved_bit = 1 << 10
+        dfreader = self.dfreader_for_current_onboard_log()
+        seen = False
+        while True:
+            m = dfreader.recv_match(type='XKF4')
+            if m is None:
+                break
+            if m.C == 0 and (m.SS & moved_bit):
+                seen = True
+                break
+        if not seen:
+            raise NotAchievedException(
+                "Movement was never detected: filter status bit 10 stayed clear")
+        self.progress("movement latch was set during the flight")
+
+    def EKF3RangeFinderOnGround(self):
+        '''Test the EKF assumes the on-ground range until the vehicle moves'''
+        # A range finder whose minimum range is above its ground clearance
+        # reads out-of-range-low while the vehicle sits on the ground, so the
+        # EKF substitutes RNGFND1_GNDCLR for the missing measurement. That
+        # substitution is released by the movement detector rather than by the
+        # arming state, so it has to survive arming, and it has to stop once
+        # the vehicle is up - whether or not the sensor ever comes into range.
+        self.set_parameters({
+            "RNGFND1_TYPE": 100,     # SITL
+            "RNGFND1_GNDCLR": 0.4,
+            "RNGFND1_MIN": 1.0,      # on the ground the sensor is out of range low
+            "RNGFND1_MAX": 60.0,
+            "EK3_SRC1_POSZ": 2,      # rangefinder, so losing it shows up in the height
+            "DISARM_DELAY": 0,       # sit armed on the ground for as long as we like
+        })
+        self.reboot_sitl()
+        # the default 5Hz lags the truth sample by most of a metre in a climb
+        self.set_message_rate_hz('LOCAL_POSITION_NED', 20)
+
+        self.start_subtest("On-ground range is still fused while armed and stationary")
+        self.change_mode('ALT_HOLD')
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        # Walk the baro away only once we are armed, so all of the drift falls
+        # inside the window the substitution is meant to cover. Both instances,
+        # because the EKF is free to pick either.
+        self.set_parameters({
+            "SIM_BARO_DRIFT": 0.3,
+            "SIM_BAR2_DRIFT": 0.3,
+        })
+        # nothing observable marks the drift accumulating, so this one is a
+        # plain wait: 20s at 0.3m/s puts 6m between the baro and the truth
+        self.delay_sim_time(20, reason='let the baro drift while armed on the ground')
+        m = self.assert_receive_message('LOCAL_POSITION_NED')
+        self.progress("EKF height while armed on the ground: %.2fm" % -m.z)
+        # with the on-ground range still fused the estimate is pinned near
+        # RNGFND1_GNDCLR; on the baro it walks off with the drift
+        if abs(m.z) > 1:
+            raise NotAchievedException(
+                "EKF followed the drifting baro on the ground (z=%.2fm, want<1m)" % m.z)
+        self.set_parameters({
+            "SIM_BARO_DRIFT": 0,
+            "SIM_BAR2_DRIFT": 0,
+        })
+
+        self.start_subtest("Coming into range releases the on-ground assumption")
+        # the sensor crosses RNGFND1_MIN early in this climb, which is the
+        # release the range term of the detector exists for
+        self.set_rc(3, 1800)
+        self.assert_ekf_height_tracks_climb(6)
+        self.set_rc(3, 1500)
+        self.land_and_disarm()
+        # the next arm is refused while the throttle stick is still centred
+        self.zero_throttle()
+
+        self.start_subtest("Movement releases it even if the sensor never comes into range")
+        # Nothing can bring this sensor into range, so the range term can never
+        # fire and the estimate can only follow the climb if the detector
+        # releases on movement. If it never does, the EKF keeps reading GNDCLR
+        # as its height and the vehicle climbs away.
+        self.set_parameter("RNGFND1_MIN", 50.0)
+        # no horizontal position control in ALT_HOLD, so allow the drift Copter
+        # already records for a takeoff and land
+        self.reboot_sitl(startup_location_dist_max=2)
+        self.change_mode('ALT_HOLD')
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        self.set_rc(3, 1800)
+        # The estimate is pinned until the detector releases, and the baro
+        # offset filter tracks the pinned height, so the error accumulated
+        # before the release is carried forward rather than corrected. Climb
+        # clear of that first and measure a leg that starts after it.
+        gnd_alt = self.get_altitude(altitude_source="SIM_STATE.alt")
+        self.wait_altitude(gnd_alt + 8, gnd_alt + 40,
+                           altitude_source="SIM_STATE.alt", timeout=90)
+        self.assert_ekf_height_tracks_climb(6)
+        self.set_rc(3, 1500)
+        self.land_and_disarm()
+        self.zero_throttle()
+
+        self.start_subtest("The terrain offset is not built from the on-ground assumption")
+        # With the baro as the height source the substituted range no longer
+        # drives the height estimate, it drives the terrain estimator. A sensor
+        # reading short for the whole flight must not be able to place the
+        # terrain right underneath a vehicle that is ten metres up.
+        self.set_parameters({
+            "EK3_SRC1_POSZ": 1,      # baro, so the range only reaches terrain
+            "RNGFND1_MIN": 50.0,     # reads short for the whole flight
+        })
+        # also starts the log this leg is read from
+        self.reboot_sitl(startup_location_dist_max=2)
+        self.change_mode('ALT_HOLD')
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        self.set_rc(3, 1800)
+        gnd_alt = self.get_altitude(altitude_source="SIM_STATE.alt")
+        self.wait_altitude(gnd_alt + 10, gnd_alt + 40,
+                           altitude_source="SIM_STATE.alt", timeout=90)
+        self.set_rc(3, 1500)
+        self.delay_sim_time(5, reason='let the terrain estimator settle at altitude')
+        self.land_and_disarm()
+        self.zero_throttle()
+        self.assert_ekf_terrain_offset_above(2)
+        self.assert_ekf_moved_since_arming_was_set()
+
+        self.start_subtest("Indoor config, no vertical velocity source")
+        # optical flow for XY, range finder for Z, no GPS. This is the config
+        # the EKF3 playbook recommends indoors, and the one where the range
+        # finder is the only vertical observation the filter has.
+        self.set_parameters({
+            "SIM_FLOW_ENABLE": 1,
+            "FLOW_TYPE": 10,
+            "SIM_GPS1_ENABLE": 0,
+            "SIM_TERRAIN": 0,
+        })
+        self.configure_EKFs_to_use_optical_flow_instead_of_GPS()  # sets EK3_SRC1_VELZ=0
+        self.set_parameters({
+            "EK3_SRC1_POSZ": 2,
+            "RNGFND1_MIN": 50.0,
+        })
+        self.reboot_sitl()
+        self.change_mode('ALT_HOLD')
+        self.wait_ready_to_arm(require_absolute=False)
+        self.arm_vehicle()
+        self.set_rc(3, 1800)
+        gnd_alt = self.get_altitude(altitude_source="SIM_STATE.alt")
+        self.wait_altitude(gnd_alt + 8, gnd_alt + 40,
+                           altitude_source="SIM_STATE.alt", timeout=90)
+        # with no vertical velocity source the estimate lags harder, and that lag
+        # is roughly fixed in metres, so measure over a longer climb
+        self.assert_ekf_height_tracks_climb(10)
+        self.set_rc(3, 1500)
+        self.land_and_disarm()
+        self.zero_throttle()
+
+        # Copter only: this says nothing about the fly-forward branch of
+        # detectFlight() that a Plane takes. Nor does it cover a premature
+        # release from airframe vibration - SITL models no gyro noise, so the
+        # detector's 0.1 rad/s threshold is never approached on the ground.
+
     def _MAV_CMD_CONDITION_YAW(self, command):
         self.start_subtest("absolute")
         self.takeoff(20, mode='GUIDED')
@@ -16573,6 +16775,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.EK3_ZeroVelFusionNotUsedWithGPS,
              self.TakeoffGroundEffectAlt,
              self.TouchdownGroundEffectAlt,
+             self.EKF3RangeFinderOnGround,
              self.StabilityPatch,
              self.OBSTACLE_DISTANCE_3D,
              self.AC_Avoidance_Proximity,

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -15320,9 +15320,14 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "EK3_SRC1_POSZ": 2,      # rangefinder, so losing it shows up in the height
             "DISARM_DELAY": 0,       # sit armed on the ground for as long as we like
         })
-        self.reboot_sitl()
-        # the default 5Hz lags the truth sample by most of a metre in a climb
-        self.set_message_rate_hz('LOCAL_POSITION_NED', 20)
+
+        def reboot_and_restream(**kwargs):
+            # every reboot puts the stream rate back to sitl_streamrate(), and
+            # the default 5Hz lags the truth sample by most of a metre in a climb
+            self.reboot_sitl(**kwargs)
+            self.set_message_rate_hz('LOCAL_POSITION_NED', 20)
+
+        reboot_and_restream()
 
         self.start_subtest("On-ground range is still fused while armed and stationary")
         self.change_mode('ALT_HOLD')
@@ -15368,7 +15373,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_parameter("RNGFND1_MIN", 50.0)
         # no horizontal position control in ALT_HOLD, so allow the drift Copter
         # already records for a takeoff and land
-        self.reboot_sitl(startup_location_dist_max=2)
+        reboot_and_restream(startup_location_dist_max=2)
         self.change_mode('ALT_HOLD')
         self.wait_ready_to_arm()
         self.arm_vehicle()
@@ -15395,7 +15400,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "RNGFND1_MIN": 50.0,     # reads short for the whole flight
         })
         # also starts the log this leg is read from
-        self.reboot_sitl(startup_location_dist_max=2)
+        reboot_and_restream(startup_location_dist_max=2)
         self.change_mode('ALT_HOLD')
         self.wait_ready_to_arm()
         self.arm_vehicle()
@@ -15425,7 +15430,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "EK3_SRC1_POSZ": 2,
             "RNGFND1_MIN": 50.0,
         })
-        self.reboot_sitl()
+        reboot_and_restream(startup_location_dist_max=2)
         self.change_mode('ALT_HOLD')
         self.wait_ready_to_arm(require_absolute=False)
         self.arm_vehicle()

--- a/libraries/AP_NavEKF/AP_Nav_Common.h
+++ b/libraries/AP_NavEKF/AP_Nav_Common.h
@@ -34,7 +34,7 @@ enum class NavFilterStatusBit {
     CONST_POS_MODE     =    128, // in constant position mode
     PRED_HORIZ_POS_REL =    256, // expected good relative horizontal position estimate - used before takeoff
     PRED_HORIZ_POS_ABS =    512, // expected good absolute horizontal position estimate - used before takeoff
-    TAKEOFF_DETECTED   =   1024, // optical flow takeoff has been detected
+    TAKEOFF_DETECTED   =   1024, // EKF2: optical flow takeoff detected. EKF3: vehicle has moved since arming
     TAKEOFF_EXPECTED   =   2048, // compensating for baro errors during takeoff
     TOUCHDOWN_EXPECTED =   4096, // compensating for baro errors during touchdown
     USING_GPS          =   8192, // using GPS position
@@ -57,7 +57,7 @@ union nav_filter_status {
         bool const_pos_mode     : 1; // 7 - true if we are in const position mode
         bool pred_horiz_pos_rel : 1; // 8 - true if filter expects it can produce a good relative horizontal position estimate - used before takeoff
         bool pred_horiz_pos_abs : 1; // 9 - true if filter expects it can produce a good absolute horizontal position estimate - used before takeoff
-        bool takeoff_detected   : 1; // 10 - true if optical flow takeoff has been detected
+        bool takeoff_detected   : 1; // 10 - EKF2: true if optical flow takeoff detected; EKF3: true if the vehicle has moved since arming
         bool takeoff            : 1; // 11 - true if filter is compensating for baro errors during takeoff
         bool touchdown          : 1; // 12 - true if filter is compensating for baro errors during touchdown
         bool using_gps          : 1; // 13 - true if we are using GPS position

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -20,6 +20,9 @@ void NavEKF3_core::controlFilterModes()
     // Detect if we are in flight on or ground
     detectFlight();
 
+    // Detect takeoff using gyro and range finder data
+    detectTakeoff();
+
     // Determine if learning of wind and magnetic field will be enabled and set corresponding indexing limits to
     // avoid unnecessary operations
     setWindMagStateLearningMode();
@@ -797,7 +800,7 @@ void  NavEKF3_core::updateFilterStatus(void)
     status.flags.const_pos_mode = (PV_AidingMode == AID_NONE) && filterHealthy;     // constant position mode
     status.flags.pred_horiz_pos_rel = status.flags.horiz_pos_rel; // EKF3 enters the required mode before flight
     status.flags.pred_horiz_pos_abs = status.flags.horiz_pos_abs; // EKF3 enters the required mode before flight
-    status.flags.takeoff_detected = takeOffDetected; // takeoff for optical flow navigation has been detected
+    status.flags.takeoff_detected = takeOffDetected; // takeoff has been detected
     status.flags.takeoff = dal.get_takeoff_expected(); // The EKF has been told to expect takeoff is in a ground effect mitigation mode and has started the EKF-GSF yaw estimator
     status.flags.touchdown = dal.get_touchdown_expected(); // The EKF has been told to detect touchdown and is in a ground effect mitigation mode
     status.flags.using_gps = ((imuSampleTime_ms - lastGpsPosPassTime_ms) < 4000) && (PV_AidingMode == AID_ABSOLUTE);

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -20,8 +20,7 @@ void NavEKF3_core::controlFilterModes()
     // Detect if we are in flight on or ground
     detectFlight();
 
-    // Detect takeoff using gyro and range finder data
-    detectTakeoff();
+    detectMovementSinceArming();
 
     // Determine if learning of wind and magnetic field will be enabled and set corresponding indexing limits to
     // avoid unnecessary operations
@@ -800,7 +799,7 @@ void  NavEKF3_core::updateFilterStatus(void)
     status.flags.const_pos_mode = (PV_AidingMode == AID_NONE) && filterHealthy;     // constant position mode
     status.flags.pred_horiz_pos_rel = status.flags.horiz_pos_rel; // EKF3 enters the required mode before flight
     status.flags.pred_horiz_pos_abs = status.flags.horiz_pos_abs; // EKF3 enters the required mode before flight
-    status.flags.takeoff_detected = takeOffDetected; // takeoff has been detected
+    status.flags.takeoff_detected = movedSinceArming; // the vehicle has moved since it was armed
     status.flags.takeoff = dal.get_takeoff_expected(); // The EKF has been told to expect takeoff is in a ground effect mitigation mode and has started the EKF-GSF yaw estimator
     status.flags.touchdown = dal.get_touchdown_expected(); // The EKF has been told to detect touchdown and is in a ground effect mitigation mode
     status.flags.using_gps = ((imuSampleTime_ms - lastGpsPosPassTime_ms) < 4000) && (PV_AidingMode == AID_ABSOLUTE);

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -26,6 +26,8 @@ void NavEKF3_core::readRangeFinder(void)
     if (_rng == nullptr) {
         return;
     }
+
+    // update global range-on-ground, used for all rangefinders
     rngOnGnd = MAX(_rng->ground_clearance_orient(ROTATION_PITCH_270), 0.05f);
 
     // limit update rate to maximum allowed by data buffers
@@ -36,22 +38,34 @@ void NavEKF3_core::readRangeFinder(void)
 
         // store samples and sample time into a ring buffer if valid
         // use data from two range finders if available
-
+        float range_distance = 0.0f;
         for (uint8_t sensorIndex = 0; sensorIndex < ARRAY_SIZE(rngMeasIndex); sensorIndex++) {
             const auto *sensor = _rng->get_backend(sensorIndex);
             if (sensor == nullptr) {
                 continue;
             }
-            if ((sensor->orientation() == ROTATION_PITCH_270) && (sensor->status() == AP_DAL_RangeFinder::Status::Good)) {
-                rngMeasIndex[sensorIndex] ++;
-                if (rngMeasIndex[sensorIndex] > 2) {
-                    rngMeasIndex[sensorIndex] = 0;
-                }
-                storedRngMeasTime_ms[sensorIndex][rngMeasIndex[sensorIndex]] = imuSampleTime_ms - 25;
-                storedRngMeas[sensorIndex][rngMeasIndex[sensorIndex]] = sensor->distance();
-            } else {
+            if (sensor->orientation() != ROTATION_PITCH_270) {
+                // only consume downward facing rangefinder data
                 continue;
             }
+            if (sensor->status() == AP_DAL_RangeFinder::Status::Good) {
+                // get the current range measurement
+                range_distance = sensor->distance();
+            } else if (onGround && sensor->status() == AP_DAL_RangeFinder::Status::OutOfRangeLow) {
+                // use ground clearance range if on ground
+                range_distance = rngOnGnd;
+            } else {
+                // ignore out-of-range data
+                continue;
+            }
+
+            // place distance in the range data buffer
+            rngMeasIndex[sensorIndex]++;
+            if (rngMeasIndex[sensorIndex] > 2) {
+                rngMeasIndex[sensorIndex] = 0;
+            }
+            storedRngMeasTime_ms[sensorIndex][rngMeasIndex[sensorIndex]] = imuSampleTime_ms - 25;
+            storedRngMeas[sensorIndex][rngMeasIndex[sensorIndex]] = range_distance;
 
             // check for three fresh samples
             bool sampleFresh[DOWNWARD_RANGEFINDER_MAX_INSTANCES][3] = {};
@@ -92,18 +106,6 @@ void NavEKF3_core::readRangeFinder(void)
 
                 // indicate we have updated the measurement
                 rngValidMeaTime_ms = imuSampleTime_ms;
-
-            } else if (onGround && ((imuSampleTime_ms - rngValidMeaTime_ms) > 200)) {
-                // before takeoff we assume on-ground range value if there is no data
-                rangeDataNew.time_ms = imuSampleTime_ms;
-                rangeDataNew.rng = rngOnGnd;
-
-                // write data to buffer with time stamp to be fused when the fusion time horizon catches up with it
-                storedRange.push(rangeDataNew);
-
-                // indicate we have updated the measurement
-                rngValidMeaTime_ms = imuSampleTime_ms;
-
             }
         }
     }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -51,8 +51,10 @@ void NavEKF3_core::readRangeFinder(void)
             if (sensor->status() == AP_DAL_RangeFinder::Status::Good) {
                 // get the current range measurement
                 range_distance = sensor->distance();
-            } else if (onGround && sensor->status() == AP_DAL_RangeFinder::Status::OutOfRangeLow) {
-                // use ground clearance range if on ground
+            } else if (!takeOffDetected && sensor->status() == AP_DAL_RangeFinder::Status::OutOfRangeLow) {
+                // use ground clearance range until takeoff is detected.
+                // once the rangefinder comes into range on climb, the Good
+                // status branch above takes over automatically.
                 range_distance = rngOnGnd;
             } else {
                 // ignore out-of-range data
@@ -198,8 +200,8 @@ void NavEKF3_core::writeOptFlowMeas(const uint8_t rawFlowQuality, const Vector2f
         delTimeOF = 0.0f;
     }
     // by definition if this function is called, then flow measurements have been provided so we
-    // need to run the optical flow takeoff detection
-    detectOptFlowTakeoff();
+    // need to run the takeoff detection
+    detectTakeoff();
 
     // don't use data with a low quality indicator or extreme rates (helps catch corrupt sensor data)
     if ((rawFlowQuality > 0) && rawFlowRates.length() < 4.2f && rawGyroRates.length() < 4.2f) {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -51,10 +51,8 @@ void NavEKF3_core::readRangeFinder(void)
             if (sensor->status() == AP_DAL_RangeFinder::Status::Good) {
                 // get the current range measurement
                 range_distance = sensor->distance();
-            } else if (!takeOffDetected && sensor->status() == AP_DAL_RangeFinder::Status::OutOfRangeLow) {
-                // use ground clearance range until takeoff is detected.
-                // once the rangefinder comes into range on climb, the Good
-                // status branch above takes over automatically.
+            } else if (!movedSinceArming && sensor->status() == AP_DAL_RangeFinder::Status::OutOfRangeLow) {
+                // assume the on-ground range until the vehicle moves
                 range_distance = rngOnGnd;
             } else {
                 // ignore out-of-range data

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -199,10 +199,6 @@ void NavEKF3_core::writeOptFlowMeas(const uint8_t rawFlowQuality, const Vector2f
         delAngBodyOF.zero();
         delTimeOF = 0.0f;
     }
-    // by definition if this function is called, then flow measurements have been provided so we
-    // need to run the takeoff detection
-    detectTakeoff();
-
     // don't use data with a low quality indicator or extreme rates (helps catch corrupt sensor data)
     if ((rawFlowQuality > 0) && rawFlowRates.length() < 4.2f && rawGyroRates.length() < 4.2f) {
         // correct flow sensor body rates for bias and write

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -38,7 +38,6 @@ void NavEKF3_core::readRangeFinder(void)
 
         // store samples and sample time into a ring buffer if valid
         // use data from two range finders if available
-        float range_distance = 0.0f;
         for (uint8_t sensorIndex = 0; sensorIndex < ARRAY_SIZE(rngMeasIndex); sensorIndex++) {
             const auto *sensor = _rng->get_backend(sensorIndex);
             if (sensor == nullptr) {
@@ -48,6 +47,7 @@ void NavEKF3_core::readRangeFinder(void)
                 // only consume downward facing rangefinder data
                 continue;
             }
+            float range_distance = 0.0f;
             if (sensor->status() == AP_DAL_RangeFinder::Status::Good) {
                 // get the current range measurement
                 range_distance = sensor->distance();

--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -42,10 +42,10 @@ void NavEKF3_core::SelectFlowFusion()
     gndOffsetValid = ((imuSampleTime_ms - gndHgtValidTime_ms) < 5000) || (activeHgtSource == AP_NavEKF_Source::SourceZ::RANGEFINDER);
     // Perform tilt check
     bool tiltOK = (prevTnb.c.z > frontend->DCM33FlowMin);
-    // Constrain measurements to zero if takeoff is not detected and the height above ground
+    // Constrain measurements to zero if the vehicle has not moved since arming and the height above ground
     // is insufficient to achieve acceptable focus. This allows the vehicle to be picked up
     // and carried to test optical flow operation
-    if (!takeOffDetected && ((terrainState - stateStruct.position.z) < 0.5f)) {
+    if (!movedSinceArming && ((terrainState - stateStruct.position.z) < 0.5f)) {
         ofDataDelayed.flowRadXYcomp.zero();
         ofDataDelayed.flowRadXY.zero();
         flowDataValid = true;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
@@ -461,9 +461,8 @@ void NavEKF3_core::setTerrainHgtStable(bool val)
     terrainHgtStable = val;
 }
 
-#if EK3_FEATURE_OPTFLOW_FUSION
-// Detect takeoff for optical flow navigation
-void NavEKF3_core::detectOptFlowTakeoff(void)
+// Detect takeoff by looking at inertial and range finder data
+void NavEKF3_core::detectTakeoff(void)
 {
     if (!onGround && !takeOffDetected && (imuSampleTime_ms - timeAtArming_ms) > 1000) {
         // we are no longer confidently on the ground so check the range finder and gyro for signs of takeoff
@@ -479,4 +478,3 @@ void NavEKF3_core::detectOptFlowTakeoff(void)
         takeOffDetected = false;
     }
 }
-#endif  // EK3_FEATURE_OPTFLOW_FUSION

--- a/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
@@ -481,13 +481,16 @@ void NavEKF3_core::detectMovementSinceArming(void)
         // while the on-ground reading is being substituted for the measurement, so
         // back both up with the height flown since we were last on the ground
 #if APM_BUILD_TYPE(APM_BUILD_ArduSub)
-        // a Sub moves away from the surface, so its depth increases
+        // a Sub moves away from the surface, so its depth increases and the
+        // range to the bottom closes - both senses as detectFlight() uses them
         const bool movedVertically = (stateStruct.position.z - posDownAtTakeoff) > 1.5f;
+        const bool movedInRange = (rangeDataNew.rng - rngAtStartOfFlight) < -0.1f;
 #else
         const bool movedVertically = (posDownAtTakeoff - stateStruct.position.z) > 1.5f;
+        const bool movedInRange = (rangeDataNew.rng - rngAtStartOfFlight) > 0.1f;
 #endif
         movedSinceArming = (angRateVec.length() > 0.1f) ||
-                           (rngDataFresh && (rangeDataNew.rng > (rngAtStartOfFlight + 0.1f))) ||
+                           (rngDataFresh && movedInRange) ||
                            movedVertically;
     } else if (onGround) {
         // we are confidently on the ground so reset the latch for the next arm

--- a/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
@@ -472,7 +472,9 @@ void NavEKF3_core::detectTakeoff(void)
         getGyroBias(gyroBias);
         angRateVec = ins.get_gyro(gyro_index_active) - gyroBias;
 
-        takeOffDetected = (takeOffDetected || (angRateVec.length() > 0.1f) || (rangeDataNew.rng > (rngAtStartOfFlight + 0.1f)));
+        // the range change only means anything while the range finder is supplying data
+        const bool rngDataFresh = (imuSampleTime_ms - rngValidMeaTime_ms) < 500;
+        takeOffDetected = (angRateVec.length() > 0.1f) || (rngDataFresh && (rangeDataNew.rng > (rngAtStartOfFlight + 0.1f)));
     } else if (onGround) {
         // we are confidently on the ground so set the takeoff detected status to false
         takeOffDetected = false;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
@@ -476,7 +476,19 @@ void NavEKF3_core::detectMovementSinceArming(void)
 
         // the range change only means anything while the range finder is supplying data
         const bool rngDataFresh = (imuSampleTime_ms - rngValidMeaTime_ms) < 500;
-        movedSinceArming = (angRateVec.length() > 0.1f) || (rngDataFresh && (rangeDataNew.rng > (rngAtStartOfFlight + 0.1f)));
+
+        // the gyro test is on a 10Hz filtered rate and the range test cannot fire
+        // while the on-ground reading is being substituted for the measurement, so
+        // back both up with the height flown since we were last on the ground
+#if APM_BUILD_TYPE(APM_BUILD_ArduSub)
+        // a Sub moves away from the surface, so its depth increases
+        const bool movedVertically = (stateStruct.position.z - posDownAtTakeoff) > 1.5f;
+#else
+        const bool movedVertically = (posDownAtTakeoff - stateStruct.position.z) > 1.5f;
+#endif
+        movedSinceArming = (angRateVec.length() > 0.1f) ||
+                           (rngDataFresh && (rangeDataNew.rng > (rngAtStartOfFlight + 0.1f))) ||
+                           movedVertically;
     } else if (onGround) {
         // we are confidently on the ground so reset the latch for the next arm
         movedSinceArming = false;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
@@ -461,11 +461,13 @@ void NavEKF3_core::setTerrainHgtStable(bool val)
     terrainHgtStable = val;
 }
 
-// Detect takeoff by looking at inertial and range finder data
-void NavEKF3_core::detectTakeoff(void)
+// this is a motion check rather than a vehicle specific takeoff detector: a
+// fixed wing ground roll trips the gyro term well before the wheels leave the
+// runway, which is the safe direction for both consumers
+void NavEKF3_core::detectMovementSinceArming(void)
 {
-    if (!onGround && !takeOffDetected && (imuSampleTime_ms - timeAtArming_ms) > 1000) {
-        // we are no longer confidently on the ground so check the range finder and gyro for signs of takeoff
+    if (!onGround && !movedSinceArming && (imuSampleTime_ms - timeAtArming_ms) > 1000) {
+        // we are no longer confidently on the ground so check the range finder and gyro for signs of movement
         const auto &ins = dal.ins();
         Vector3f angRateVec;
         Vector3f gyroBias;
@@ -474,9 +476,9 @@ void NavEKF3_core::detectTakeoff(void)
 
         // the range change only means anything while the range finder is supplying data
         const bool rngDataFresh = (imuSampleTime_ms - rngValidMeaTime_ms) < 500;
-        takeOffDetected = (angRateVec.length() > 0.1f) || (rngDataFresh && (rangeDataNew.rng > (rngAtStartOfFlight + 0.1f)));
+        movedSinceArming = (angRateVec.length() > 0.1f) || (rngDataFresh && (rangeDataNew.rng > (rngAtStartOfFlight + 0.1f)));
     } else if (onGround) {
-        // we are confidently on the ground so set the takeoff detected status to false
-        takeOffDetected = false;
+        // we are confidently on the ground so reset the latch for the next arm
+        movedSinceArming = false;
     }
 }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -985,10 +985,8 @@ private:
     // Apply a median filter to range finder data
     void readRangeFinder();
 
-#if EK3_FEATURE_OPTFLOW_FUSION
-    // check if the vehicle has taken off during optical flow navigation by looking at inertial and range finder data
-    void detectOptFlowTakeoff(void);
-#endif
+    // check if the vehicle has taken off by looking at inertial and range finder data
+    void detectTakeoff(void);
 
     // align the NE earth magnetic field states with the published declination
     void alignMagStateDeclination();
@@ -1494,7 +1492,7 @@ private:
     AP_NavEKF_Source::SourceZ prevHgtSource;    // previous height source used to detect changes in source
 
     // Movement detector
-    bool takeOffDetected;           // true when takeoff for optical flow navigation has been detected
+    bool takeOffDetected;           // true when takeoff has been detected
     ftype rngAtStartOfFlight;       // range finder measurement at start of flight
     uint32_t timeAtArming_ms;       // time in msec that the vehicle armed
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -985,8 +985,8 @@ private:
     // Apply a median filter to range finder data
     void readRangeFinder();
 
-    // check if the vehicle has taken off by looking at inertial and range finder data
-    void detectTakeoff(void);
+    // check if the vehicle has moved since arming by looking at inertial and range finder data
+    void detectMovementSinceArming(void);
 
     // align the NE earth magnetic field states with the published declination
     void alignMagStateDeclination();
@@ -1492,7 +1492,7 @@ private:
     AP_NavEKF_Source::SourceZ prevHgtSource;    // previous height source used to detect changes in source
 
     // Movement detector
-    bool takeOffDetected;           // true when takeoff has been detected
+    bool movedSinceArming;          // true when the vehicle has moved since it was armed
     ftype rngAtStartOfFlight;       // range finder measurement at start of flight
     uint32_t timeAtArming_ms;       // time in msec that the vehicle armed
 


### PR DESCRIPTION
### Summary

EKF3 substitutes `RNGFNDx_GNDCLR` for the range measurement when a downward range finder reads out-of-range-low. That substitution stopped the instant the vehicle armed, so a copter sitting armed on the ground fell back to the baro at exactly the point ground effect makes the baro least trustworthy. This keeps the on-ground reading until the vehicle has actually moved.

One correction to the original description, because it matters for review: on master the on-ground branch was unreachable for an out-of-range-low sensor. The loop `continue`d on any non-`Good` status before reaching it, so it was only ever reachable with a `Good` sensor and fewer than three fresh samples. The first commit therefore **adds a new fusion path**, it does not move an existing gate.

The release is `movedSinceArming`: gyro rate over 0.1 rad/s, a range increase, or 1.5 m flown since the last on-ground sample. It was `takeOffDetected`, renamed because it is a motion check rather than a vehicle-specific takeoff detector - a fixed wing ground roll trips the gyro term well before the wheels leave the runway - and because the range finder gate is now a second consumer. EKF2 already gates this same substitution on the same flag.

`!inFlight` was tried as the flight-state bound and withdrawn. The fly-forward branch of `detectFlight()` sets `inFlight` only from GPS ground speed, so on a GPS-denied plane it never sets, and the bound would have been absent on the vehicle class least able to notice.

### Classification & Testing

- [x] Checked by a human programmer
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)

`Copter.EKF3RangeFinderOnGround` covers five cases. Each was re-run with the change disabled to confirm it fails. The figures below are a 20-iteration soak at `8bec444e50`, 19 of which passed; error is estimate minus truth, and the bound is a quarter of the climb asked for. The disabled column is from the earlier set, which sampled legs 3, 4 and 5 at 5Hz before the test held its 20Hz stream across reboots.

| leg | error over 19 passing runs | fails at | disabled (earlier head) |
|---|---|---|---|
| armed and stationary, baro drifting 0.3 m/s | -0.01 m, every run | 1 m | +4.61 m, follows the baro |
| sensor comes into range on the climb | -0.4 to -0.5 m | 1.5 m | passes either way |
| sensor never in range | +0.1 to +0.3 m | 1.5 m | 7.5 / 4.9 m |
| terrain path, baro as the height source | 0.0 m, every run | -2 m | -10.7 m |
| indoor: flow for XY, no vertical velocity source | -0.3 to +0.7 m | 2.5 m | - |

Leg 2's half-metre is systematic rather than spread: the estimate lags the truth by about that much through the climb in every run, in the one leg that passes either way. The single failure in 20 was a `reboot_sitl()` reconnect stall before leg 3, with no position or EKF assertion involved.

SITL only, no hardware and no real flight logs. Copter only, so nothing here exercises the fly-forward branch of `detectFlight()`.

### Description

Known and deliberately not fixed here, so they are not re-found by every later reader:

- **Two downward range finders.** `RangeFinder::find_instance()` returns the first downward backend whose status is `Good`, so with one good sensor and one out of range, the substituted value carries the *good* sensor's `GNDCLR` into the other sensor's buffer, and is then corrected using that other sensor's body offset. Both push into the same `storedRange`. Fixing it properly needs per-instance ground clearance, which is not recorded in the DAL: `log_RRNH` carries a single global value and `log_RRNI` cannot be grown without misparsing existing replay logs. It would need a new message.
- **Mid-air disarm and re-arm.** A disarm clears the latch and `timeAtArming_ms` resets, so the substitution is live for at least a second after the re-arm. Backends that clamp a lost return to zero report out-of-range-low, so that status is not exotic in flight. Not reachable before this change.
- **Detector sample rate.** Moving the detector to `controlFilterModes()` runs it every filter update rather than at optical-flow message rate, roughly 40x more samples against the 0.1 rad/s threshold. The DAL gyro is 10 Hz filtered so this may be immaterial, but SITL models no gyro noise and cannot answer it. It wants a real log windowed from arm to +10 s.
- **Fixed wing gains little.** The fly-forward branch also clears `onGround` at arming, so a plane's latch trips on ground-roll gyro about a second later, close to the previous behaviour.
- **Master's on-ground fallback went with it.** Master's `else if (onGround && ...)` sat inside the sensor loop after the `continue`, so it was reachable for a `Good` sensor whose three samples were not all fresh, while disarmed: an intermittent sensor pushed `rngOnGnd` pre-arm. There is no equivalent here, because the head pushes only from the three-fresh-samples branch. For that sensor `POSZ=RANGEFINDER` now falls back to baro pre-arm where master kept the range finder. Narrow and disarmed only, but the first commit removes a path as well as adding one.
- **The substitution is live while disarmed.** The gate has no arming condition - `movedSinceArming` is false whenever the vehicle is on the ground - so the on-ground reading is fused pre-arm too, and reaches `EstimateTerrainOffset()` including its five-second terrain reset. The first leg of the autotest measures exactly this, but the description did not say so.
- **The landing half is out of reach of this design.** The latch is set for the whole approach, so re-entering `OutOfRangeLow` in the last metre pushes nothing, the range data goes stale and `lostRngHgt` puts the filter on baro during touchdown - the ground effect window the motivation calls out. Identical to master, so not a regression, but the rationale applies symmetrically. `dal.get_touchdown_expected()` is the obvious second condition if it is ever worth closing.
- **EK3_RNG_USE_HGT now takes an out-of-range-low sensor.** With the range fresh on the ground, the height switch uses it the way master uses a sensor that reads on the ground. On Copter that is only in the takeoff and landing windows (`set_terrain_hgt_stable()`), so an ALT_HOLD takeoff switches back to baro at liftoff, in ground effect, and the baro offset carried the error into the flight: EKF height 2.5 m high in SITL with SIM_BARO_GEFF_M 3. Master does the same with a sensor that reads on the ground (2.5 m), so the fix is its own PR, #34432. Vehicles other than Copter leave the terrain stable flag set, so for them the switch can hold the range finder for the whole time on the ground.
- **The pinned climb is carried into the flight.** With `POSZ=RANGEFINDER` and a sensor that never comes into range, the height stays pinned until the detector releases, the baro offset takes in the lag, and the fallback to baro keeps it: 1.39 to 1.48 m low above 5 m in three SITL runs of leg 3's configuration climbing at full stick in ALT_HOLD. Leg 3 measures the climb after the release, so it does not see this. Master falls back to baro from the start with that sensor.
