### PR TITLE
AP_Compass: MAG_CAL: only autoreboot if calibration succeeds

### DIFF
--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -397,7 +397,6 @@ private:
     uint8_t _get_cal_mask();
     bool _start_calibration(uint8_t i, bool retry=false, float delay_sec=0.0f);
     bool _start_calibration_mask(uint8_t mask, bool retry=false, bool autosave=false, float delay_sec=0.0f, bool autoreboot=false);
-    bool _auto_reboot() const { return _compass_cal_autoreboot; }
 #if HAL_MAVLINK_BINDINGS_ENABLED
     Priority next_cal_progress_idx[MAVLINK_COMM_NUM_BUFFERS];
     Priority next_cal_report_idx[MAVLINK_COMM_NUM_BUFFERS];

--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -18,20 +18,35 @@ void Compass::cal_update()
     }
 
     bool running = false;
-
+    uint8_t num_compass = 0;
+    uint8_t num_compass_successful = 0;
+    
     for (Priority i(0); i<COMPASS_MAX_INSTANCES; i++) {
         if (_calibrator[i] == nullptr) {
             continue;
         }
+        num_compass++;
         if (_calibrator[i]->failed()) {
             AP_Notify::events.compass_cal_failed = 1;
         }
 
         if (_calibrator[i]->running()) {
             running = true;
-        } else if (_cal_autosave && !_cal_saved[i] && _calibrator[i]->get_state().status == CompassCalibrator::Status::SUCCESS) {
-            _accept_calibration(uint8_t(i));
+            continue;
         }
+        if (_calibrator[i]->get_state().status != CompassCalibrator::Status::SUCCESS) {
+            continue;
+        }
+        num_compass_successful++;
+        if (!_cal_autosave) {
+            // user requested to not automatically save the calibration values
+            continue;
+        }
+        if (_cal_saved[i]) {
+            // user already manually applied changes via MAV_CMD_DO_ACCEPT_MAG_CAL
+            continue;
+        }
+        _accept_calibration(uint8_t(i));
     }
 
     AP_Notify::flags.compass_cal_running = running;
@@ -39,10 +54,21 @@ void Compass::cal_update()
     if (is_calibrating()) {
         _cal_has_run = true;
         return;
-    } else if (_cal_has_run && _auto_reboot()) {
-        hal.scheduler->delay(1000);
-        hal.scheduler->reboot();
+    } 
+    if (!_cal_has_run) {
+        // calibration hasn't started yet
+        return;
     }
+    if (num_compass != num_compass_successful) {
+        // only reboot if all successful
+        return;
+    }
+    if (!_compass_cal_autoreboot) {
+        // user did not request autoreboot
+        return;
+    }
+    hal.scheduler->delay(1000);
+    hal.scheduler->reboot();
 }
 
 bool Compass::_start_calibration(uint8_t i, bool retry, float delay)


### PR DESCRIPTION
Implements #31948 

Patches MAV_CMD_DO_START_MAG_CAL param5 (autoreboot) so that setting it only causes a reboot when the calibration succeeds. Previously it would reboot upon any final state of calibration such as failure or user cancellation.

I've also removed the `_auto_reboot()` getter since the variable it protects is only used within the class. This matches how the autosave param is already handled.

Because compass cal requires moving the autopilot, I'm unable to test in SITL. I'll add a comment when I'm able to confirm on a real autopilot.