### PR TITLE
Add FAST_BOOT bitmask parameter

### DIFF
--- a/ArduCopter/esc_calibration.cpp
+++ b/ArduCopter/esc_calibration.cpp
@@ -9,6 +9,11 @@
 // check if we should enter esc calibration mode
 void Copter::esc_calibration_startup_check()
 {
+    if (BoardConfig.fast_boot_esc()) {
+        // ESC calibration startup check skipped in fast boot mode
+        return;
+    }
+
     if (g.esc_calibrate == ESCCalibrationModes::ESCCAL_DISABLED) {
         // esc calibration disabled
         return;

--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -441,6 +441,14 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
     AP_GROUPINFO("IDLE_STATS", 33, AP_BoardConfig, state.idle_stats, 0),
 #endif
 
+    // @Param: FAST_BOOT
+    // @DisplayName: Fast boot
+    // @Description: Bitmask of startup blocking procedures to skip for a faster boot. Set to 0 to disable all fast boot features and use normal startup. Only enable bits you understand and require.
+    // @Bitmask: 0:AllFeatures, 1:DroneCAN
+    // @Bitmask{Copter}: 0:AllFeatures, 1:DroneCAN, 2:ESCCalibration
+    // @User: Advanced
+    AP_GROUPINFO("FAST_BOOT", 34, AP_BoardConfig, _fast_boot, 0),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -242,6 +242,9 @@ public:
     }
 #endif
 
+    bool fast_boot_dronecan() const { return fast_boot_option_set(FastBootOption::DRONECAN); }
+    bool fast_boot_esc() const { return fast_boot_option_set(FastBootOption::ESC); }
+
 private:
     static AP_BoardConfig *_singleton;
     
@@ -338,6 +341,19 @@ private:
     AP_Int32 _options;
 
     AP_Int8  _alt_config;
+
+    // Bit definitions for the FAST_BOOT bitmask parameter
+    enum class FastBootOption : int32_t {
+        ALL      = (1 << 0),  // enable all fast boot features
+        DRONECAN = (1 << 1),  // skip blocking DroneCAN device discovery
+        ESC      = (1 << 2),  // skip ESC calibration startup check
+    };
+    bool fast_boot_option_set(FastBootOption option) const {
+        return (_fast_boot.get() & (int32_t(FastBootOption::ALL) | int32_t(option))) != 0;
+    }
+
+    // Bitmask controlling which startup blocking procedures are skipped for faster boot
+    AP_Int32 _fast_boot;
 };
 
 namespace AP {

--- a/libraries/AP_DroneCAN/AP_DroneCAN.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.cpp
@@ -498,10 +498,14 @@ void AP_DroneCAN::init(uint8_t driver_index)
     node_status_msg.mode = UAVCAN_PROTOCOL_NODESTATUS_MODE_OPERATIONAL;
     node_status_msg.sub_mode = 0;
 
-    // Spin node for device discovery
-    for (uint8_t i = 0; i < 5; i++) {
-        send_node_status();
-        canard_iface.process(1000);
+    // If fast boot is not requested, block here to discover CAN devices before
+    // the rest of the system initialises. This is safer but adds ~5s to boot time.
+    AP_BoardConfig *boardconfig = AP_BoardConfig::get_singleton();
+    if (boardconfig == nullptr || !boardconfig->fast_boot_dronecan()) {
+        for (uint8_t i = 0; i < 5; i++) {
+            send_node_status();
+            canard_iface.process(1000);
+        }
     }
 
     hal.util->snprintf(_thread_name, sizeof(_thread_name), "dronecan_%u", driver_index);
@@ -521,6 +525,17 @@ void AP_DroneCAN::init(uint8_t driver_index)
 
 void AP_DroneCAN::loop(void)
 {
+    // In fast boot mode, device discovery was not done in init(), so do it
+    // here in the DroneCAN thread to avoid blocking the main boot sequence.
+    // Some devices may not be ready before the rest of the system initialises.
+    AP_BoardConfig *boardconfig = AP_BoardConfig::get_singleton();
+    if (boardconfig != nullptr && boardconfig->fast_boot_dronecan()) {
+        for (uint8_t i = 0; i < 5; i++) {
+            send_node_status();
+            canard_iface.process(1000);
+        }
+    }
+
     while (true) {
         if (!_initialized) {
             hal.scheduler->delay_microseconds(1000);


### PR DESCRIPTION
Added a new FAST_BOOT parameter to avoid some startup blocking calls in hopes of getting quicker boots, which is important for some use cases. 

I will update this bitmask to add more things. 

