### PR TITLE
AP_RangeFinder: DroneCAN: update state before calling `update_status`

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_DroneCAN.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_DroneCAN.cpp
@@ -91,6 +91,10 @@ void AP_RangeFinder_DroneCAN::update()
         return;
     }
 
+    state.distance_m = _distance_m;
+    state.last_reading_ms = _last_reading_ms;
+    new_data = false;
+
     if (_status == RangeFinder::Status::Good) {
         // copy over states
         update_status();
@@ -99,9 +103,6 @@ void AP_RangeFinder_DroneCAN::update()
         set_status(_status);
     }
 
-    state.distance_m = _distance_m;
-    state.last_reading_ms = _last_reading_ms;
-    new_data = false;
 }
 
 //RangeFinder message handler


### PR DESCRIPTION
Need to set the state values before calling `update_status` which uses those values. Currently the state is from the last measurement not the current one. 

update state is:

https://github.com/ArduPilot/ardupilot/blob/46ae78597c1f5ff2c918ee1169e7013c68032be7/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h#L90

It passes `state` to:

https://github.com/ArduPilot/ardupilot/blob/46ae78597c1f5ff2c918ee1169e7013c68032be7/libraries/AP_RangeFinder/AP_RangeFinder_Backend.cpp#L59-L70

It uses `state_arg.distance_m`.
