### PR TITLE
Plane: Add PTCH_TRIM_DEG to ATT.DesPitch logging

### DIFF
--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -7,7 +7,7 @@ void Plane::Log_Write_Attitude(void)
 {
     Vector3f targets {       // Package up the targets into a vector for commonality with Copter usage of Log_Wrote_Attitude
         nav_roll_cd * 0.01f,
-        nav_pitch_cd * 0.01f,
+        (nav_pitch_cd * 0.01f) + g.pitch_trim.get(),
         0 //Plane does not have the concept of navyaw. This is a placeholder.
     };
 


### PR DESCRIPTION
Fixes #32246

**Bug report / Issue**
Currently in ArduPlane logs, `ATT.Pitch` and `ATT.DesPitch` have different zero-angle references, which differ exactly by the `PTCH_TRIM_DEG` parameter. This is because `ATT.Pitch` logs the absolute vehicle pitch (which includes the trim), while `ATT.DesPitch` logs `nav_pitch_cd`, which is relative to the trim.

**Proposed Solution**
This PR aligns `ATT.DesPitch` with `ATT.Pitch` by adding `g.pitch_trim` to the target pitch when `ATT` logging is done for ArduPlane in [Log.cpp](cci:7://file:///Users/urlampranita/Desktop/ardupilot/ardupilot/ArduPlane/Log.cpp:0:0-0:0). This brings the logged desired pitch to the same absolute frame as the logged pitch.
