### PR TITLE
AP_Periph: ESC  Telem: call update to invalidate stale data

### DIFF
--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -1758,6 +1758,9 @@ uint8_t AP_Periph_FW::get_motor_number(const uint8_t esc_number) const
  */
 void AP_Periph_FW::esc_telem_update()
 {
+    // update telem lib, this invalidates stale data
+    esc_telem.update();
+
     uint32_t mask = esc_telem.get_active_esc_mask();
     while (mask != 0) {
         int8_t i = __builtin_ffs(mask) - 1;


### PR DESCRIPTION
The update function in AP ESC Telem marks data as stale, currently on periph we do not call it. This means data never goes stale and we just continue sending what we last got forever. This makes detecting failed ESCs harder because on the vehicle side the data never goes stale as periph is still sending.

https://github.com/ArduPilot/ardupilot/blob/318a2ec3184dee331a18a4305cfa39e098c8c21e/libraries/AP_ESC_Telem/AP_ESC_Telem.cpp#L802-L816