### PR TITLE
AP_Periph: Servo telem: don't send stale data

### DIFF
--- a/Tools/AP_Periph/Servo_telem.cpp
+++ b/Tools/AP_Periph/Servo_telem.cpp
@@ -43,6 +43,11 @@ void AP_Periph_FW::servo_telem_update()
             continue;
         }
 
+        // Don't send stale data, timeout after five seconds
+        if (AP_HAL::timeout_expired(data.last_update_ms, now_ms, 5000U)) {
+            continue;
+        }
+
         // Blank packet
         const float nan = nanf("");
         uavcan_equipment_actuator_Status pkt {


### PR DESCRIPTION
Same idea as https://github.com/ArduPilot/ardupilot/pull/32256 we should stop sending telem data if we don't get any for a while. Currently we will continue sending the last received data forever. This means we stop after 5 seconds, this is inline with the timeout for ESC telem.