### PR TITLE
AP_Baro: Optimize BMP388 data conversion by scoping to status checks

### DIFF
--- a/libraries/AP_Baro/AP_Baro_BMP388.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP388.cpp
@@ -135,14 +135,14 @@ void AP_Baro_BMP388::timer(void)
     // call.  Retrieve what we need from it beforehand to avoid a
     // warning.
     const uint8_t status = buf[0];
-    const uint32_t pressure_data = (buf[3] << 16) | (buf[2] << 8) | buf[1];
-    const uint32_t temperature_data = (buf[6] << 16) | (buf[5] << 8) | buf[4];
     if ((status & 0x20) != 0) {
         // we have pressure data
+         const uint32_t pressure_data = (buf[3] << 16) | (buf[2] << 8) | buf[1];
         update_pressure(pressure_data);
     }
     if ((status & 0x40) != 0) {
         // we have temperature data
+        const uint32_t temperature_data = (buf[6] << 16) | (buf[5] << 8) | buf[4];
         update_temperature(temperature_data);
     }
 


### PR DESCRIPTION
## Description
This PR optimizes the data reading logic in the BMP388 driver. 

Currently, `pressure_data` and `temperature_data` are calculated unconditionally, even if the corresponding status bits (0x20 for pressure, 0x40 for temperature) are not set. 

## Changes
- Moved the bitwise conversion logic for pressure and temperature inside their respective status check blocks.
- This avoids redundant calculations when data is not yet available and narrows the variable scope.
- Maintained the early retrieval of `status` to respect the existing GCC workaround mentioned in the comments.
