### PR TITLE
Fixes #20716

### DIFF
--- a/libraries/AP_SmartRTL/AP_SmartRTL.cpp
+++ b/libraries/AP_SmartRTL/AP_SmartRTL.cpp
@@ -442,6 +442,11 @@ void AP_SmartRTL::routine_cleanup(uint16_t path_points_count, uint16_t path_poin
     const uint16_t points_to_simplify = (path_points_count > _simplify.path_points_completed) ? (path_points_count - _simplify.path_points_completed) : 0 ;
     const bool low_on_space = (_path_points_max - path_points_count) <= SMARTRTL_CLEANUP_START_MARGIN;
 
+    if(_prune.loops_count > 0 && low_on_space){
+        remove_points_by_loops(SMARTRTL_CLEANUP_POINT_MIN);
+        return;
+    }
+
     // if 50 points can be simplified or we are low on space and at least 10 points can be simplified
     if ((points_to_simplify >= SMARTRTL_CLEANUP_POINT_TRIGGER) || (low_on_space && (points_to_simplify >= SMARTRTL_CLEANUP_POINT_MIN))) {
         restart_simplification(path_points_count);
@@ -602,7 +607,7 @@ void AP_SmartRTL::detect_loops()
 
         // find the closest distance between two line segments and the mid-point
         dist_point dp = segment_segment_dist(_path[_prune.i], _path[_prune.i-1], _path[_prune.j-1], _path[_prune.j]);
-        if (dp.distance < SMARTRTL_PRUNING_DELTA) {
+        if (dp.distance < (_accuracy * 0.99f)) {
             // if there is a loop here, add to loop array
             if (!add_loop(_prune.j, _prune.i-1, dp.midpoint)) {
                 // if the buffer is full, stop trying to prune
@@ -657,6 +662,7 @@ void AP_SmartRTL::restart_pruning(uint16_t path_points_count)
     _prune.i = (path_points_count > 0) ? path_points_count - 1 : 0;
     _prune.j = 0;
     _prune.path_points_count = path_points_count;
+    _prune.path_points_completed = 0;
 }
 
 // reset pruning algorithm so that it will re-check all points in the path

--- a/libraries/AP_SmartRTL/AP_SmartRTL.h
+++ b/libraries/AP_SmartRTL/AP_SmartRTL.h
@@ -18,7 +18,7 @@
                                                 // The minimum is int((s/2-1)+min(s/2, SMARTRTL_POINTS_MAX-s)), where s = pow(2, floor(log(SMARTRTL_POINTS_MAX)/log(2)))
                                                 // To avoid this annoying math, a good-enough overestimate is ceil(SMARTRTL_POINTS_MAX*2.0f/3.0f)
 #define SMARTRTL_SIMPLIFY_TIME_US        200    // maximum time (in microseconds) the simplification algorithm will run before returning
-#define SMARTRTL_PRUNING_DELTA (_accuracy * 0.99)   // How many meters apart must two points be, such that we can assume that there is no obstacle between them.  must be smaller than _ACCURACY parameter
+#define SMARTRTL_PRUNING_DELTA (SMARTRTL_ACCURACY_DEFAULT * 0.5)   // How many meters apart must two points be, such that we can assume that there is no obstacle between them.  must be smaller than _ACCURACY parameter
 #define SMARTRTL_PRUNING_LOOP_BUFFER_LEN_MULT 0.25f // pruning loop buffer size as compared to maximum number of points
 #define SMARTRTL_PRUNING_LOOP_TIME_US    200    // maximum time (in microseconds) that the loop finding algorithm will run before returning
 


### PR DESCRIPTION
Problem:

In Circle mode, SmartRTL deactivates because the path buffer fills faster than pruning can remove circular loops.

Changes:

Removed invalid SMARTRTL_SIMPLIFY_EPSILON macro and replaced it with _accuracy * 0.5f directly in detect_simplifications()

Proactively remove detected loops in routine_cleanup() when buffer space is low

Reset path_points_completed in restart_pruning() to rescan the full path for new loops

Testing:

Verified in SITL: Loiter → Arm → Takeoff → Circle → sim_speedup 100
SmartRTL stays active during circular flight.

Fixes #20716