### PR TITLE
Copter: add VALT velocity alt-hold flight mode

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -227,6 +227,7 @@ public:
     friend class ModeZigZag;
     friend class ModeAutorotate;
     friend class ModeTurtle;
+    friend class ModeVelAltHold;
 
     friend class _AutoTakeoff;
 
@@ -1108,6 +1109,9 @@ private:
 #endif
 #if MODE_TURTLE_ENABLED
     ModeTurtle mode_turtle;
+#endif
+#if MODE_VALT_ENABLED
+    ModeVelAltHold mode_valt;
 #endif
 
     // mode.cpp

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -155,6 +155,10 @@
   #error Brake mode requires AltHold; disable MODE_BRAKE_ENABLED or enable MODE_ALTHOLD_ENABLED
 #endif
 
+#if MODE_VALT_ENABLED && !MODE_ALTHOLD_ENABLED
+  #error VALT mode requires AltHold; disable MODE_VALT_ENABLED or enable MODE_ALTHOLD_ENABLED
+#endif
+
 #if AP_AVOIDANCE_ENABLED && !AP_FENCE_ENABLED
   #error AC_Avoidance relies on AP_FENCE_ENABLED which is disabled
 #endif
@@ -226,6 +230,7 @@ public:
     friend class ModeZigZag;
     friend class ModeAutorotate;
     friend class ModeTurtle;
+    friend class ModeVelAltHold;
 
     friend class _AutoTakeoff;
 
@@ -1105,6 +1110,9 @@ private:
 #endif
 #if MODE_TURTLE_ENABLED
     ModeTurtle mode_turtle;
+#endif
+#if MODE_VALT_ENABLED
+    ModeVelAltHold mode_valt;
 #endif
 
     // mode.cpp

--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -1426,6 +1426,9 @@ uint8_t GCS_MAVLINK_Copter::send_available_mode(uint8_t index) const
 #if MODE_TURTLE_ENABLED
         &copter.mode_turtle,
 #endif
+#if MODE_VALT_ENABLED
+        &copter.mode_valt,
+#endif
     };
 
     const uint8_t base_mode_count = ARRAY_SIZE(modes);

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1188,6 +1188,15 @@ const AP_Param::GroupInfo ParametersG2::var_info2[] = {
     AP_GROUPINFO("SURFTRAK_GLSAM", 22, ParametersG2, surf_dist_parameters.glitch_num_samples, AP_SURFACEDISTANCE_GLITCH_NUM_SAMPLES_DEFAULT),
 #endif
 
+#if MODE_VALT_ENABLED
+    // @Param: VALT_POS_EXPO
+    // @DisplayName: VALT position-authority blend expo
+    // @Description: In VALT (velocity alt hold) this blends position control back in near stick centre and near the stick edges. 0 disables the blend (original hard cutoff - pure velocity control whenever the stick is off centre). With a positive value the position authority follows a valley in stick deflection: full at centre (altitude hold) and at full deflection (a position trajectory that backstops a velocity-loop failure), lowest in between (clean velocity-rate feel). Higher values widen the velocity region, confining position authority closer to centre and the edges; values toward 1 keep more position authority across the whole range.
+    // @Range: 0 8
+    // @Increment: 0.5
+    // @User: Advanced
+    AP_GROUPINFO("VALT_POS_EXPO", 29, ParametersG2, valt_pos_expo, 0),
+#endif
     // ID 62 is reserved for the AP_SUBGROUPEXTENSION
 
     AP_GROUPEND

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -150,7 +150,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: FLTMODE1
     // @DisplayName: Flight Mode 1
     // @Description: Flight mode when pwm of Flightmode channel(FLTMODE_CH) is <= 1230
-    // @Values: 0:Stabilize,1:Acro,2:AltHold,3:Auto,4:Guided,5:Loiter,6:RTL,7:Circle,9:Land,11:Drift,13:Sport,14:Flip,15:AutoTune,16:PosHold,17:Brake,18:Throw,19:Avoid_ADSB,20:Guided_NoGPS,21:Smart_RTL,22:FlowHold,23:Follow,24:ZigZag,25:SystemID,26:Heli_Autorotate,27:Auto RTL,28:Turtle
+    // @Values: 0:Stabilize,1:Acro,2:AltHold,3:Auto,4:Guided,5:Loiter,6:RTL,7:Circle,9:Land,11:Drift,13:Sport,14:Flip,15:AutoTune,16:PosHold,17:Brake,18:Throw,19:Avoid_ADSB,20:Guided_NoGPS,21:Smart_RTL,22:FlowHold,23:Follow,24:ZigZag,25:SystemID,26:Heli_Autorotate,27:Auto RTL,28:Turtle,29:VALT
     // @User: Standard
     GARRAY(flight_modes, 0, "FLTMODE1", (uint8_t)FLIGHT_MODE_1),
 

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1192,6 +1192,15 @@ const AP_Param::GroupInfo ParametersG2::var_info2[] = {
     AP_SUBGROUPPTR(mode_flip_ptr, "FLIP_", 23, ParametersG2, ModeFlip),
 #endif
 
+#if MODE_VALT_ENABLED
+    // @Param: VALT_POS_EXPO
+    // @DisplayName: VALT position-authority blend expo
+    // @Description: In VALT (velocity alt hold) this blends position control back in near stick centre and near the stick edges. 0 is the hard cutoff: pure velocity control whenever the stick is off centre. Above 1 the position authority follows a valley in stick deflection, full at centre (altitude hold) and at full deflection (a position trajectory that backstops a velocity-loop failure) and lowest in between; higher values widen the velocity region. Values above 0 up to and including 1 give full position authority at every stick position, which is altitude hold without surface tracking.
+    // @Range: 0 8
+    // @Increment: 0.5
+    // @User: Advanced
+    AP_GROUPINFO("VALT_POS_EXPO", 25, ParametersG2, valt_pos_expo, 0),
+#endif
     // ID 62 is reserved for the AP_SUBGROUPEXTENSION
 
     AP_GROUPEND

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -543,6 +543,10 @@ public:
     AP_Enum<ModeThrow::ThrowType> throw_type;
 #endif
 
+#if MODE_VALT_ENABLED
+    AP_Float valt_pos_expo;    // VALT stick-to-position-authority blend expo (0 = hard cutoff)
+#endif
+
     // ground effect compensation enable/disable
     AP_Int8 gndeffect_comp_enabled;
 

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -549,6 +549,10 @@ public:
     AP_GroundEffect ground_effect;
 #endif
 
+#if MODE_VALT_ENABLED
+    AP_Float valt_pos_expo;    // VALT stick-to-position-authority blend expo (0 = hard cutoff)
+#endif
+
 #if AP_TEMPCALIBRATION_ENABLED
     // temperature calibration handling
     AP_TempCalibration temp_calibration;

--- a/ArduCopter/baro_ground_effect.cpp
+++ b/ArduCopter/baro_ground_effect.cpp
@@ -9,10 +9,12 @@ void Copter::update_ground_effect_detector(void)
     gndeff.enable_takeoff_comp(flightmode->mode_number() != Mode::Number::THROW);
     gndeff.set_high_vibrations(vibration_check.high_vibes);
 
-    // ALT_HOLD has manual attitude and no NE controller, so a near-level
-    // attitude target stands in for "pilot is asking for slow horizontal"
+    // ALT_HOLD and VALT have manual attitude and no NE controller, so a
+    // near-level attitude target stands in for "pilot is asking for slow
+    // horizontal"
     bool pilot_slow_horizontal = false;
-    if (flightmode->mode_number() == Mode::Number::ALT_HOLD) {
+    if (flightmode->mode_number() == Mode::Number::ALT_HOLD ||
+        flightmode->mode_number() == Mode::Number::VALT) {
         const Vector3f angle_target_rad = attitude_control->get_att_target_euler_rad();
         pilot_slow_horizontal = cosf(angle_target_rad.x) * cosf(angle_target_rad.y) > cosf(radians(7.5f));
     }

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -247,6 +247,12 @@
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
+// VALT - velocity-controlled alt hold
+#ifndef MODE_VALT_ENABLED
+# define MODE_VALT_ENABLED 1
+#endif
+
+//////////////////////////////////////////////////////////////////////////////
 // Flowhold - use optical flow to hover in place
 #ifndef MODE_FLOWHOLD_ENABLED
 # define MODE_FLOWHOLD_ENABLED AP_OPTICALFLOW_ENABLED

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -257,6 +257,12 @@
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
+// VALT - velocity-controlled alt hold
+#ifndef MODE_VALT_ENABLED
+# define MODE_VALT_ENABLED 1
+#endif
+
+//////////////////////////////////////////////////////////////////////////////
 // Flowhold - use optical flow to hover in place
 #ifndef MODE_FLOWHOLD_ENABLED
 # define MODE_FLOWHOLD_ENABLED AP_OPTICALFLOW_ENABLED

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -152,6 +152,11 @@ Mode *Copter::mode_from_mode_num(const Mode::Number mode)
             return &mode_turtle;
 #endif
 
+#if MODE_VALT_ENABLED
+        case Mode::Number::VALT:
+            return &mode_valt;
+#endif
+
         default:
             break;
     }
@@ -208,7 +213,8 @@ bool Copter::gcs_mode_enabled(const Mode::Number mode_num)
         (uint8_t)Mode::Number::SYSTEMID,
         (uint8_t)Mode::Number::AUTOROTATE,
         (uint8_t)Mode::Number::AUTO_RTL,
-        (uint8_t)Mode::Number::TURTLE
+        (uint8_t)Mode::Number::TURTLE,
+        (uint8_t)Mode::Number::VALT
     };
 
     return !block_GCS_mode_change((uint8_t)mode_num, mode_list, ARRAY_SIZE(mode_list));

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -1055,7 +1055,10 @@ Mode::AltHoldModeState Mode::get_alt_hold_state_D_ms(float target_climb_rate_ms)
 
     } else if (!copter.ap.auto_armed || copter.ap.land_complete) {
         // the aircraft is armed and landed
-        if (target_climb_rate_ms < 0.0f && !copter.ap.using_interlock) {
+        const bool request_ground_idle = !copter.ap.using_interlock &&
+            (target_climb_rate_ms < 0.0f ||
+             (is_zero(target_climb_rate_ms) && !spool_up_at_zero_climb_on_ground()));
+        if (request_ground_idle) {
             // the aircraft should move to a ground idle state
             motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::GROUND_IDLE);
         } else {

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -154,6 +154,11 @@ Mode *Copter::mode_from_mode_num(const Mode::Number mode)
             return &mode_turtle;
 #endif
 
+#if MODE_VALT_ENABLED
+        case Mode::Number::VALT:
+            return &mode_valt;
+#endif
+
         default:
             break;
     }
@@ -210,7 +215,8 @@ bool Copter::gcs_mode_enabled(const Mode::Number mode_num)
         (uint8_t)Mode::Number::SYSTEMID,
         (uint8_t)Mode::Number::AUTOROTATE,
         (uint8_t)Mode::Number::AUTO_RTL,
-        (uint8_t)Mode::Number::TURTLE
+        (uint8_t)Mode::Number::TURTLE,
+        (uint8_t)Mode::Number::VALT
     };
 
     return !block_GCS_mode_change((uint8_t)mode_num, mode_list, ARRAY_SIZE(mode_list));
@@ -290,6 +296,9 @@ uint32_t Copter::get_available_mode_enabled_mask() const
 #endif
 #if MODE_TURTLE_ENABLED
         &copter.mode_turtle,
+#endif
+#if MODE_VALT_ENABLED
+        &copter.mode_valt,
 #endif
     };
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -101,6 +101,7 @@ public:
         AUTOROTATE =   26,  // Autonomous autorotation
         AUTO_RTL =     27,  // Auto RTL, this is not a true mode, AUTO will report as this mode if entered to perform a DO_LAND_START Landing sequence
         TURTLE =       28,  // Flip over after crash
+        VALT =         29,  // Velocity-controlled alt hold
 
         // Mode number 30 reserved for "offboard" for external/lua control.
 
@@ -524,7 +525,9 @@ protected:
     const char *name() const override { return "Altitude Hold"; }
     const char *name4() const override { return "ALTH"; }
 
-private:
+    // handle the Flying state inside run(); virtual so ModeVelAltHold
+    // can override just this piece
+    virtual void alt_hold_run_flying(float &target_roll_rad, float &target_pitch_rad, float target_climb_rate_ms);
 
 };
 
@@ -1947,6 +1950,26 @@ private:
     // Semaphore to protect the motors from the arming state
     HAL_Semaphore msem;
     bool shutdown;
+};
+#endif
+
+#if MODE_VALT_ENABLED
+class ModeVelAltHold : public ModeAltHold {
+
+public:
+    // inherit constructor
+    using ModeAltHold::Mode;
+    Number mode_number() const override { return Number::VALT; }
+
+protected:
+
+    const char *name() const override { return "VALT Hold"; }
+    const char *name4() const override { return "VALT"; }
+
+    // velocity-controlled Flying state: no surface tracking,
+    // pos_desired override for velocity control
+    void alt_hold_run_flying(float &target_roll_rad, float &target_pitch_rad, float target_climb_rate_ms) override;
+
 };
 #endif
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -101,6 +101,7 @@ public:
         AUTOROTATE =   26,  // Autonomous autorotation
         AUTO_RTL =     27,  // Auto RTL, this is not a true mode, AUTO will report as this mode if entered to perform a DO_LAND_START Landing sequence
         TURTLE =       28,  // Flip over after crash
+        VALT =         29,  // Velocity-controlled alt hold
 
         // Mode number 30 reserved for "offboard" for external/lua control.
 
@@ -524,7 +525,8 @@ protected:
     const char *name() const override { return "Altitude Hold"; }
     const char *name4() const override { return "ALTH"; }
 
-private:
+    // handle the Flying state inside run(); virtual so ModeVelAltHold can replace it
+    virtual void alt_hold_run_flying(float &target_roll_rad, float &target_pitch_rad, float target_climb_rate_ms);
 
 };
 
@@ -1958,6 +1960,26 @@ private:
     // Semaphore to protect the motors from the arming state
     HAL_Semaphore msem;
     bool shutdown;
+};
+#endif
+
+#if MODE_VALT_ENABLED
+class ModeVelAltHold : public ModeAltHold {
+
+public:
+    // inherit constructor
+    using ModeAltHold::Mode;
+    bool init(bool ignore_checks) override;
+    Number mode_number() const override { return Number::VALT; }
+
+protected:
+
+    const char *name() const override { return "VALT Hold"; }
+    const char *name4() const override { return "VALT"; }
+
+    // velocity-controlled Flying state
+    void alt_hold_run_flying(float &target_roll_rad, float &target_pitch_rad, float target_climb_rate_ms) override;
+
 };
 #endif
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -163,6 +163,9 @@ public:
     virtual bool is_taking_off() const;
     static void takeoff_stop() { takeoff.stop(); }
 
+    // whether mid-stick on the ground spools the motors up ready for take off
+    virtual bool spool_up_at_zero_climb_on_ground() const { return true; }
+
     virtual bool is_landing() const { return false; }
 
     // mode requires terrain to be present to be functional
@@ -1979,6 +1982,9 @@ protected:
 
     // velocity-controlled Flying state
     void alt_hold_run_flying(float &target_roll_rad, float &target_pitch_rad, float target_climb_rate_ms) override;
+
+    // mid-stick is the resting hold state, not a take-off cue
+    bool spool_up_at_zero_climb_on_ground() const override { return false; }
 
 };
 #endif

--- a/ArduCopter/mode_althold.cpp
+++ b/ArduCopter/mode_althold.cpp
@@ -76,22 +76,7 @@ void ModeAltHold::run()
         break;
 
     case AltHoldModeState::Flying:
-
-#if AP_AVOIDANCE_ALTHOLD_ENABLED
-        // apply avoidance
-        copter.avoid.adjust_roll_pitch_rad(target_roll_rad, target_pitch_rad, attitude_control->lean_angle_max_rad());
-#endif
-
-        // get avoidance adjusted climb rate
-        target_climb_rate_ms = get_avoidance_adjusted_climbrate_ms(target_climb_rate_ms);
-
-#if AP_RANGEFINDER_ENABLED
-        // update the vertical offset based on the surface measurement
-        copter.surface_tracking.update_surface_offset();
-#endif
-
-        // Send the commanded climb rate to the position controller
-        pos_control->D_set_pos_target_from_climb_rate_ms(target_climb_rate_ms);
+        alt_hold_run_flying(target_roll_rad, target_pitch_rad, target_climb_rate_ms);
         break;
     }
 
@@ -100,4 +85,25 @@ void ModeAltHold::run()
 
     // run the vertical position controller and set output throttle
     pos_control->D_update_controller();
+}
+
+// alt_hold_run_flying - handle the Flying state; virtual so subclasses
+// (ModeVelAltHold) can replace just this piece
+void ModeAltHold::alt_hold_run_flying(float &target_roll_rad, float &target_pitch_rad, float target_climb_rate_ms)
+{
+#if AP_AVOIDANCE_ALTHOLD_ENABLED
+    // apply avoidance
+    copter.avoid.adjust_roll_pitch_rad(target_roll_rad, target_pitch_rad, attitude_control->lean_angle_max_rad());
+#endif
+
+    // get avoidance adjusted climb rate
+    target_climb_rate_ms = get_avoidance_adjusted_climbrate_ms(target_climb_rate_ms);
+
+#if AP_RANGEFINDER_ENABLED
+    // update the vertical offset based on the surface measurement
+    copter.surface_tracking.update_surface_offset();
+#endif
+
+    // Send the commanded climb rate to the position controller
+    pos_control->D_set_pos_target_from_climb_rate_ms(target_climb_rate_ms);
 }

--- a/ArduCopter/mode_althold.cpp
+++ b/ArduCopter/mode_althold.cpp
@@ -74,22 +74,7 @@ void ModeAltHold::run()
         break;
 
     case AltHoldModeState::Flying:
-
-#if AP_AVOIDANCE_ALTHOLD_ENABLED
-        // apply avoidance
-        copter.avoid.adjust_roll_pitch_rad(target_roll_rad, target_pitch_rad, attitude_control->lean_angle_max_rad());
-#endif
-
-        // get avoidance adjusted climb rate
-        target_climb_rate_ms = get_avoidance_adjusted_climbrate_ms(target_climb_rate_ms);
-
-#if AP_RANGEFINDER_ENABLED
-        // update the vertical offset based on the surface measurement
-        copter.surface_tracking.update_surface_offset();
-#endif
-
-        // Send the commanded climb rate to the position controller
-        pos_control->D_set_pos_target_from_climb_rate_ms(target_climb_rate_ms);
+        alt_hold_run_flying(target_roll_rad, target_pitch_rad, target_climb_rate_ms);
         break;
     }
 
@@ -98,6 +83,25 @@ void ModeAltHold::run()
 
     // run the vertical position controller and set output throttle
     pos_control->D_update_controller();
+}
+
+void ModeAltHold::alt_hold_run_flying(float &target_roll_rad, float &target_pitch_rad, float target_climb_rate_ms)
+{
+#if AP_AVOIDANCE_ALTHOLD_ENABLED
+    // apply avoidance
+    copter.avoid.adjust_roll_pitch_rad(target_roll_rad, target_pitch_rad, attitude_control->lean_angle_max_rad());
+#endif
+
+    // get avoidance adjusted climb rate
+    target_climb_rate_ms = get_avoidance_adjusted_climbrate_ms(target_climb_rate_ms);
+
+#if AP_RANGEFINDER_ENABLED
+    // update the vertical offset based on the surface measurement
+    copter.surface_tracking.update_surface_offset();
+#endif
+
+    // Send the commanded climb rate to the position controller
+    pos_control->D_set_pos_target_from_climb_rate_ms(target_climb_rate_ms);
 }
 
 #endif // MODE_ALTHOLD_ENABLED

--- a/ArduCopter/mode_valt.cpp
+++ b/ArduCopter/mode_valt.cpp
@@ -1,0 +1,35 @@
+#include "Copter.h"
+
+#if MODE_VALT_ENABLED
+
+/*
+ * VALT (velocity alt hold) flight mode.
+ *
+ * Inherits from AltHold, overriding only the Flying state.  Surface
+ * tracking is skipped so its offsets do not fight pilot stick input,
+ * and pos_desired is overridden with the current position when the
+ * stick is off-centre so the position P loop is bypassed.  When the
+ * stick returns to centre pos_desired freezes and position P gently
+ * holds height.
+ */
+
+// velocity-controlled Flying state
+void ModeVelAltHold::alt_hold_run_flying(float &target_roll_rad, float &target_pitch_rad, float target_climb_rate_ms)
+{
+    // get avoidance adjusted climb rate
+    target_climb_rate_ms = get_avoidance_adjusted_climbrate_ms(target_climb_rate_ms);
+
+    // Send the commanded climb rate to the position controller
+    pos_control->D_set_pos_target_from_climb_rate_ms(target_climb_rate_ms);
+
+    // Override pos_desired with the current position so the position P
+    // loop does not fight the pilot's stick input.  When the stick
+    // returns to centre (zero climb rate), stop overriding so that
+    // pos_desired freezes at the current altitude and position P gently
+    // holds height.
+    if (!is_zero(target_climb_rate_ms)) {
+        pos_control->set_pos_desired_U_m(pos_control->get_pos_estimate_U_m());
+    }
+}
+
+#endif  // MODE_VALT_ENABLED

--- a/ArduCopter/mode_valt.cpp
+++ b/ArduCopter/mode_valt.cpp
@@ -6,11 +6,12 @@
  * VALT (velocity alt hold) flight mode.
  *
  * Inherits from AltHold, overriding only the Flying state.  Surface
- * tracking is skipped so its offsets do not fight pilot stick input,
- * and pos_desired is overridden with the current position when the
- * stick is off-centre so the position P loop is bypassed.  When the
- * stick returns to centre pos_desired freezes and position P gently
- * holds height.
+ * tracking is skipped so its offsets do not fight pilot stick input, and
+ * pos_desired is snapped towards the current position off-centre so the
+ * position P loop is bypassed (velocity control).  VALT_POS_EXPO blends how
+ * hard that snap is with stick deflection, so position authority returns near
+ * centre (altitude hold) and at full deflection (position backstop); 0 keeps
+ * the original hard cutoff.
  */
 
 // velocity-controlled Flying state
@@ -22,14 +23,38 @@ void ModeVelAltHold::alt_hold_run_flying(float &target_roll_rad, float &target_p
     // Send the commanded climb rate to the position controller
     pos_control->D_set_pos_target_from_climb_rate_ms(target_climb_rate_ms);
 
-    // Override pos_desired with the current position so the position P
-    // loop does not fight the pilot's stick input.  When the stick
-    // returns to centre (zero climb rate), stop overriding so that
-    // pos_desired freezes at the current altitude and position P gently
-    // holds height.
-    if (!is_zero(target_climb_rate_ms)) {
-        pos_control->set_pos_desired_U_m(pos_control->get_pos_estimate_U_m());
+    // Snap pos_desired towards the current position so the position P loop
+    // does not fight the pilot's stick input -- this is what turns AltHold
+    // into velocity control.  How hard it snaps is blended with stick
+    // deflection so position authority is full at centre (altitude hold),
+    // backed off in the mid range (clean velocity-rate feel), and returns at
+    // full deflection (a held command leaves pos_desired marching so a
+    // growing position error backstops a stuck velocity loop).  VALT_POS_EXPO
+    // = 0 keeps the original hard cutoff.
+    const float expo = g2.valt_pos_expo;
+    if (expo <= 0) {
+        if (!is_zero(target_climb_rate_ms)) {
+            pos_control->set_pos_desired_U_m(pos_control->get_pos_estimate_U_m());
+        }
+        return;
     }
+
+    // normalised stick deflection from centre, 0..1
+    const float up_max = get_pilot_speed_up_ms();
+    const float dn_max = get_pilot_speed_dn_ms();
+    float deflection = 0.0f;
+    if (is_positive(target_climb_rate_ms) && is_positive(up_max)) {
+        deflection = target_climb_rate_ms / up_max;
+    } else if (is_negative(target_climb_rate_ms) && is_positive(dn_max)) {
+        deflection = -target_climb_rate_ms / dn_max;
+    }
+    deflection = constrain_float(deflection, 0.0f, 1.0f);
+
+    // position-authority weight: a valley in deflection, 1 at centre and edge
+    const float w_pos = constrain_float(powf(1.0f - deflection, expo) + powf(deflection, expo), 0.0f, 1.0f);
+    const float pos_est_m = pos_control->get_pos_estimate_U_m();
+    const float pos_des_m = pos_control->get_pos_desired_U_m();
+    pos_control->set_pos_desired_U_m(pos_est_m + w_pos * (pos_des_m - pos_est_m));
 }
 
 #endif  // MODE_VALT_ENABLED

--- a/ArduCopter/mode_valt.cpp
+++ b/ArduCopter/mode_valt.cpp
@@ -29,6 +29,9 @@ bool ModeVelAltHold::init(bool ignore_checks)
 // velocity-controlled Flying state
 void ModeVelAltHold::alt_hold_run_flying(float &target_roll_rad, float &target_pitch_rad, float target_climb_rate_ms)
 {
+    // stick deflection is the pilot's demand, before avoidance clips it
+    const float pilot_climb_rate_ms = target_climb_rate_ms;
+
 #if AP_AVOIDANCE_ALTHOLD_ENABLED
     // apply avoidance
     copter.avoid.adjust_roll_pitch_rad(target_roll_rad, target_pitch_rad, attitude_control->lean_angle_max_rad());
@@ -41,11 +44,34 @@ void ModeVelAltHold::alt_hold_run_flying(float &target_roll_rad, float &target_p
     pos_control->D_set_pos_target_from_climb_rate_ms(target_climb_rate_ms);
 
     // Snap pos_desired towards the estimate so the position P loop does not
-    // fight the pilot's stick input.  When the stick returns to centre the
-    // snap stops, pos_desired freezes and position P holds height.
-    if (!is_zero(target_climb_rate_ms)) {
-        pos_control->set_pos_desired_U_m(pos_control->get_pos_estimate_U_m());
+    // fight the pilot's stick input.  VALT_POS_EXPO weights the snap with
+    // stick deflection; 0 keeps the original hard cutoff.
+    const float expo = g2.valt_pos_expo;
+    if (!is_positive(expo)) {
+        if (!is_zero(target_climb_rate_ms)) {
+            pos_control->set_pos_desired_U_m(pos_control->get_pos_estimate_U_m());
+        }
+        return;
     }
+
+    // normalised stick deflection from centre, 0..1
+    const float up_max = get_pilot_speed_up_ms();
+    const float dn_max = get_pilot_speed_dn_ms();
+    float deflection = 0.0f;
+    if (is_positive(pilot_climb_rate_ms) && is_positive(up_max)) {
+        deflection = pilot_climb_rate_ms / up_max;
+    } else if (is_negative(pilot_climb_rate_ms) && is_positive(dn_max)) {
+        deflection = -pilot_climb_rate_ms / dn_max;
+    }
+    deflection = constrain_float(deflection, 0.0f, 1.0f);
+
+    // position-authority weight: a valley in deflection, 1 at centre and edge.
+    // expo at or below 1 leaves this at 1 throughout, i.e. full position
+    // authority everywhere (see VALT_POS_EXPO)
+    const float w_pos = constrain_float(powf(1.0f - deflection, expo) + powf(deflection, expo), 0.0f, 1.0f);
+    const float pos_est_m = pos_control->get_pos_estimate_U_m();
+    const float pos_des_m = pos_control->get_pos_desired_U_m();
+    pos_control->set_pos_desired_U_m(pos_est_m + w_pos * (pos_des_m - pos_est_m));
 }
 
 #endif  // MODE_VALT_ENABLED

--- a/ArduCopter/mode_valt.cpp
+++ b/ArduCopter/mode_valt.cpp
@@ -1,0 +1,51 @@
+#include "Copter.h"
+
+#if MODE_VALT_ENABLED
+
+/*
+ * VALT (velocity alt hold) flight mode.
+ *
+ * AltHold with the Flying state replaced: surface tracking is skipped and
+ * pos_desired is snapped towards the estimate off-centre, so the position P
+ * loop is bypassed and the pilot commands a rate.  Any baro offset picked up
+ * during the manoeuvre cancels, because both sides of the error saw it.
+ */
+
+bool ModeVelAltHold::init(bool ignore_checks)
+{
+    if (!ModeAltHold::init(ignore_checks)) {
+        return false;
+    }
+
+    // VALT does not run surface tracking, so nothing would update or time out
+    // a terrain offset inherited from the previous mode.  It would otherwise
+    // sit in the position error for the whole flight and defeat the snap
+    // below, which assumes the error goes to zero.
+    pos_control->init_pos_terrain_D_m(0);
+
+    return true;
+}
+
+// velocity-controlled Flying state
+void ModeVelAltHold::alt_hold_run_flying(float &target_roll_rad, float &target_pitch_rad, float target_climb_rate_ms)
+{
+#if AP_AVOIDANCE_ALTHOLD_ENABLED
+    // apply avoidance
+    copter.avoid.adjust_roll_pitch_rad(target_roll_rad, target_pitch_rad, attitude_control->lean_angle_max_rad());
+#endif
+
+    // get avoidance adjusted climb rate
+    target_climb_rate_ms = get_avoidance_adjusted_climbrate_ms(target_climb_rate_ms);
+
+    // Send the commanded climb rate to the position controller
+    pos_control->D_set_pos_target_from_climb_rate_ms(target_climb_rate_ms);
+
+    // Snap pos_desired towards the estimate so the position P loop does not
+    // fight the pilot's stick input.  When the stick returns to centre the
+    // snap stops, pos_desired freezes and position P holds height.
+    if (!is_zero(target_climb_rate_ms)) {
+        pos_control->set_pos_desired_U_m(pos_control->get_pos_estimate_U_m());
+    }
+}
+
+#endif  // MODE_VALT_ENABLED

--- a/ArduCopter/mode_valt.cpp
+++ b/ArduCopter/mode_valt.cpp
@@ -11,6 +11,10 @@
  * during the manoeuvre cancels, because both sides of the error saw it.
  */
 
+// position correction limit in ground effect, still above the 0.03-0.05 m/s
+// drift seen with no position authority at all
+#define VALT_GNDEFF_CORR_SPEED_MS 0.1f
+
 bool ModeVelAltHold::init(bool ignore_checks)
 {
     if (!ModeAltHold::init(ignore_checks)) {
@@ -39,6 +43,16 @@ void ModeVelAltHold::alt_hold_run_flying(float &target_roll_rad, float &target_p
 
     // get avoidance adjusted climb rate
     target_climb_rate_ms = get_avoidance_adjusted_climbrate_ms(target_climb_rate_ms);
+
+    // rotor wash steps the baro by metres at ground contact; limiting the
+    // correction saturates that error instead of turning it into a climb.
+    // ModeAltHold::run() only refreshes the trajectory limits, so the
+    // unlimited value has to be restored here
+    if (ahrs.get_takeoff_expected() || ahrs.get_touchdown_expected()) {
+        pos_control->D_set_correction_speed_accel_m(VALT_GNDEFF_CORR_SPEED_MS, VALT_GNDEFF_CORR_SPEED_MS, get_pilot_accel_D_mss());
+    } else {
+        pos_control->D_set_correction_speed_accel_m(get_pilot_speed_dn_ms(), get_pilot_speed_up_ms(), get_pilot_accel_D_mss());
+    }
 
     // Send the commanded climb rate to the position controller
     pos_control->D_set_pos_target_from_climb_rate_ms(target_climb_rate_ms);

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -347,6 +347,22 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             minimum_duration=3,
         )
 
+        # repeat hold and descent with the position-authority blend enabled
+        # (VALT_POS_EXPO > 0) to confirm it does not regress normal behaviour:
+        # mid-stick still holds, and a full-down command still descends.
+        self.progress("Enabling VALT_POS_EXPO blend")
+        self.set_parameter("VALT_POS_EXPO", 3)
+        self.watch_altitude_maintained(
+            altitude_min=settled_alt - 1,
+            altitude_max=settled_alt + 1,
+            minimum_duration=3,
+        )
+        self.progress("Commanding descent with throttle 1200")
+        self.set_rc(3, 1200)
+        self.wait_altitude(3, settled_alt - 3, relative=True, timeout=20)
+        self.set_rc(3, 1500)
+        self.watch_altitude_maintained(altitude_min=2, altitude_max=settled_alt - 2)
+
         self.do_RTL()
 
     def fly_to_origin(self, final_alt=10):

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -302,6 +302,53 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         })
         self.do_RTL()
 
+    def ModeVAltHold(self):
+        '''Test VALT velocity alt-hold mode (mode 29)'''
+        # use mode number directly since pymavlink does not know VALT
+        VALT = 29
+
+        self.takeoff(10, mode="ALT_HOLD")
+        self.change_mode(VALT)
+
+        # verify altitude is maintained with neutral sticks
+        self.progress("Checking altitude hold with velocity control")
+        self.watch_altitude_maintained(altitude_min=9, altitude_max=11)
+
+        # verify altitude is maintained while flying laterally
+        self.progress("Checking altitude hold during lateral flight")
+        self.set_rc_from_map({
+            1: 1000,
+            2: 1000,
+        })
+        self.watch_altitude_maintained(altitude_min=9, altitude_max=11)
+        self.set_rc_from_map({
+            1: 1500,
+            2: 1500,
+        })
+
+        # command a climb and verify altitude increases
+        self.progress("Commanding climb with throttle 1800")
+        self.set_rc(3, 1800)
+        self.wait_altitude(12, 25, relative=True, timeout=10)
+        alt_after_climb = self.get_altitude(relative=True)
+        self.progress("Altitude after climb: %.1f" % alt_after_climb)
+
+        # release stick to neutral and let it settle
+        self.progress("Releasing stick, checking altitude settles")
+        self.set_rc(3, 1500)
+        self.delay_sim_time(3)
+        settled_alt = self.get_altitude(relative=True)
+        self.progress("Settled altitude: %.1f" % settled_alt)
+
+        # verify altitude is maintained at the new altitude
+        self.watch_altitude_maintained(
+            altitude_min=settled_alt - 1,
+            altitude_max=settled_alt + 1,
+            minimum_duration=3,
+        )
+
+        self.do_RTL()
+
     def fly_to_origin(self, final_alt=10):
         origin = self.poll_message("GPS_GLOBAL_ORIGIN")
         self.change_mode("GUIDED")
@@ -14406,6 +14453,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.GPSGlitchAuto,
              self.GPSFixTypes,
              self.ModeAltHold,
+             self.ModeVAltHold,
              self.ModeLoiter,
              self.SimpleMode,
              self.SuperSimpleCircle,

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import copy
 import math
+import operator
 import os
 import pathlib
 import re
@@ -564,17 +565,67 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         })
         self.do_RTL()
 
+    def valt_pos_desired_error(self, dfreader, tstart, tend):
+        """mean |DPD - PD| from PSCD over a sim-time window, in metres"""
+        total = 0.0
+        count = 0
+        while True:
+            m = dfreader.recv_match(type='PSCD')
+            if m is None:
+                break
+            t = m.TimeUS * 1.0e-6
+            if t < tstart:
+                continue
+            if t > tend:
+                break
+            total += abs(m.DPD - m.PD)
+            count += 1
+        if count == 0:
+            raise NotAchievedException("No PSCD in window %f-%f" % (tstart, tend))
+        return total / count
+
     def ModeVAltHold(self):
-        '''Test VALT velocity alt-hold mode (mode 29)'''
-        # use mode number directly since pymavlink does not know VALT
+        '''Test VALT velocity alt-hold mode'''
+        # the mode number is used directly: COPTER_MODE_VALT is not in the
+        # pinned pymavlink, which still maps 29 to RATE_ACRO
         VALT = 29
 
+        self.start_subtest("VALT stays in ground idle at mid-stick")
+        # Regression guard for spool_up_at_zero_climb_on_ground(): VALT keeps
+        # the motors in ground idle at mid-stick (its resting hold state), so a
+        # neutral stick must NOT take off, while a deliberate climb command must
+        # spool up from ground idle and lift off cleanly.
+        self.change_mode(VALT)
+        self.set_rc(3, 1000)
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+
+        # mid-stick: AltHold spools the motors up ready for take-off, VALT
+        # stays in ground idle, so its motor output must sit below AltHold's
+        self.set_rc(3, 1500)
+        self.change_mode('ALT_HOLD')
+        self.delay_sim_time(3, "let the motors spool in AltHold")
+        spooled = self.assert_receive_message('SERVO_OUTPUT_RAW', timeout=10).servo1_raw
+        self.progress("AltHold spooled output: %u" % spooled)
+        self.change_mode(VALT)
+        self.wait_servo_channel_value(1, spooled - 20, timeout=10, comparator=operator.lt)
+        self.wait_altitude(-1, 1, relative=True, minimum_duration=5, timeout=20)
+        if not self.armed():
+            raise NotAchievedException("VALT disarmed on the ground at mid-stick")
+
+        # a deliberate climb command must spool up from ground idle and lift off
+        self.progress("Commanding climb from the ground")
+        self.set_rc(3, 1800)
+        self.wait_altitude(5, 15, relative=True, timeout=30)
+        self.set_rc(3, 1500)
+        self.do_RTL()
+
+        self.start_subtest("VALT holds altitude and tracks stick rate")
         self.takeoff(10, mode="ALT_HOLD")
         self.change_mode(VALT)
 
         # verify altitude is maintained with neutral sticks
-        self.progress("Checking altitude hold with velocity control")
-        self.wait_altitude(9, 11, relative=True, minimum_duration=5, timeout=6)
+        self.wait_altitude(9, 11, relative=True, minimum_duration=5, timeout=20)
 
         # verify altitude is maintained while flying laterally
         self.progress("Checking altitude hold during lateral flight")
@@ -582,7 +633,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             1: 1000,
             2: 1000,
         })
-        self.wait_altitude(9, 11, relative=True, minimum_duration=5, timeout=6)
+        self.wait_altitude(9, 11, relative=True, minimum_duration=5, timeout=20)
         self.set_rc_from_map({
             1: 1500,
             2: 1500,
@@ -592,44 +643,92 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.progress("Commanding climb with throttle 1800")
         self.set_rc(3, 1800)
         self.wait_altitude(12, 25, relative=True, timeout=10)
-        alt_after_climb = self.get_altitude(relative=True)
-        self.progress("Altitude after climb: %.1f" % alt_after_climb)
 
-        # release stick to neutral and let it settle
-        self.progress("Releasing stick, checking altitude settles")
+        # release stick to neutral and verify the altitude settles and holds
         self.set_rc(3, 1500)
-        self.delay_sim_time(3, "let the altitude settle")
+        self.wait_climbrate(-0.2, 0.2, minimum_duration=1, timeout=20)
         settled_alt = self.get_altitude(relative=True)
         self.progress("Settled altitude: %.1f" % settled_alt)
-
-        # verify altitude is maintained at the new altitude
         self.wait_altitude(
             settled_alt - 1,
             settled_alt + 1,
             relative=True,
-            minimum_duration=3,
-            timeout=4,
+            minimum_duration=5,
+            timeout=20,
         )
 
-        # repeat hold and descent with the position-authority blend enabled
-        # (VALT_POS_EXPO > 0) to confirm it does not regress normal behaviour:
-        # mid-stick still holds, and a full-down command still descends.
-        self.progress("Enabling VALT_POS_EXPO blend")
-        self.set_parameter("VALT_POS_EXPO", 3)
-        self.wait_altitude(
-            settled_alt - 1,
-            settled_alt + 1,
-            relative=True,
-            minimum_duration=3,
-            timeout=4,
-        )
-        self.progress("Commanding descent with throttle 1200")
-        self.set_rc(3, 1200)
-        self.wait_altitude(3, settled_alt - 3, relative=True, timeout=20)
+        # VALT_POS_EXPO leaves pos_desired marching at full deflection instead
+        # of snapping it to the estimate, so a held full-down command builds a
+        # position error the velocity loop would otherwise never see.  Measure
+        # |DPD - PD| over a held full-down descent with the blend off and on;
+        # with the blend off the snap makes it identically zero.
+        self.start_subtest("VALT_POS_EXPO leaves pos_desired marching at the stick edge")
+        expo_windows = []
+        for expo in 0, 3:
+            self.set_parameter("VALT_POS_EXPO", expo)
+            self.set_rc(3, 1800)
+            self.wait_altitude(30, 60, relative=True, timeout=60)
+            self.set_rc(3, 1500)
+            self.wait_climbrate(-0.2, 0.2, minimum_duration=1, timeout=20)
+            self.progress("Holding full-down with VALT_POS_EXPO=%u" % expo)
+            self.set_rc(3, 1000)
+            tstart = self.get_sim_time()
+            self.delay_sim_time(5, "hold full-down stick")
+            expo_windows.append((expo, tstart, self.get_sim_time()))
+            self.set_rc(3, 1500)
+            self.wait_climbrate(-0.2, 0.2, minimum_duration=1, timeout=20)
+
+        # Fly the ground-effect path with a perturbed baro.  This is an
+        # exercise, not coverage: the correction limit only bites once the
+        # height estimate itself has stepped by more than the 0.1 m leash,
+        # and SITL's EKF gates a baro glitch long before that (measured
+        # 0.0036 m of position error with the limit, 0.0055 m without).
+        # Reproducing it needs SIM_BARO_GEFF_M from the pr-ground-effect
+        # branch; the flown evidence is the 3.80 m estimate excursion in
+        # FPV-4C log81.
+        self.start_subtest("VALT flies the ground-effect path with a perturbed baro")
+        # the blend must be on: with the hard cutoff the snap zeroes the
+        # position error itself, so there is nothing for the limit to bound
+        self.set_parameters({
+            "VALT_POS_EXPO": 3,
+            "GNDEFF_ALT": 30,    # keep the window open at test height
+        })
         self.set_rc(3, 1500)
-        self.wait_altitude(2, settled_alt - 2, relative=True, minimum_duration=5, timeout=6)
+        self.wait_altitude(8, 20, relative=True, timeout=60)
+        self.set_rc(3, 1500)
+        self.wait_climbrate(-0.2, 0.2, minimum_duration=1, timeout=20)
+
+        # a gentle demanded descent is what latches touchdown_expected
+        self.set_rc(3, 1350)
+        self.delay_sim_time(3, "latch the ground effect window")
+        self.set_parameter("SIM_BARO_GLITCH", -8)
+        self.delay_sim_time(6, "baro glitch to take effect")
+        self.set_parameter("SIM_BARO_GLITCH", 0)
+        self.set_rc(3, 1500)
 
         self.do_RTL()
+        self.wait_disarmed()
+
+        # the ground-effect window must actually have been open across the
+        # glitch, or the subtest above proved nothing
+        durations = self.get_touchdownexpected_durations_from_current_onboard_log(ignore_multi=True)
+        self.progress("touchdown_expected durations: %s" % str(durations))
+        if not durations or max(durations) < 3:
+            raise NotAchievedException(
+                "ground effect window was not open during the baro glitch (%s)" % str(durations))
+
+        errors = {}
+        for (expo, tstart, tend) in expo_windows:
+            dfreader = self.dfreader_for_current_onboard_log()
+            errors[expo] = self.valt_pos_desired_error(dfreader, tstart, tend)
+            self.progress("VALT_POS_EXPO=%u mean |DPD-PD| = %.4f m" % (expo, errors[expo]))
+        # measured in SITL: 0.0000 m with the snap, 0.0398 m with the blend
+        if errors[0] > 0.005:
+            raise NotAchievedException(
+                "VALT_POS_EXPO=0 should snap pos_desired to the estimate (got %.4f m)" % errors[0])
+        if errors[3] < 0.02:
+            raise NotAchievedException(
+                "VALT_POS_EXPO=3 should leave pos_desired marching at full stick (got %.4f m)" % errors[3])
 
     def fly_to_origin(self, final_alt=10):
         origin = self.poll_message("GPS_GLOBAL_ORIGIN")

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -611,6 +611,24 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             timeout=4,
         )
 
+        # repeat hold and descent with the position-authority blend enabled
+        # (VALT_POS_EXPO > 0) to confirm it does not regress normal behaviour:
+        # mid-stick still holds, and a full-down command still descends.
+        self.progress("Enabling VALT_POS_EXPO blend")
+        self.set_parameter("VALT_POS_EXPO", 3)
+        self.wait_altitude(
+            settled_alt - 1,
+            settled_alt + 1,
+            relative=True,
+            minimum_duration=3,
+            timeout=4,
+        )
+        self.progress("Commanding descent with throttle 1200")
+        self.set_rc(3, 1200)
+        self.wait_altitude(3, settled_alt - 3, relative=True, timeout=20)
+        self.set_rc(3, 1500)
+        self.wait_altitude(2, settled_alt - 2, relative=True, minimum_duration=5, timeout=6)
+
         self.do_RTL()
 
     def fly_to_origin(self, final_alt=10):

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -564,6 +564,55 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         })
         self.do_RTL()
 
+    def ModeVAltHold(self):
+        '''Test VALT velocity alt-hold mode (mode 29)'''
+        # use mode number directly since pymavlink does not know VALT
+        VALT = 29
+
+        self.takeoff(10, mode="ALT_HOLD")
+        self.change_mode(VALT)
+
+        # verify altitude is maintained with neutral sticks
+        self.progress("Checking altitude hold with velocity control")
+        self.wait_altitude(9, 11, relative=True, minimum_duration=5, timeout=6)
+
+        # verify altitude is maintained while flying laterally
+        self.progress("Checking altitude hold during lateral flight")
+        self.set_rc_from_map({
+            1: 1000,
+            2: 1000,
+        })
+        self.wait_altitude(9, 11, relative=True, minimum_duration=5, timeout=6)
+        self.set_rc_from_map({
+            1: 1500,
+            2: 1500,
+        })
+
+        # command a climb and verify altitude increases
+        self.progress("Commanding climb with throttle 1800")
+        self.set_rc(3, 1800)
+        self.wait_altitude(12, 25, relative=True, timeout=10)
+        alt_after_climb = self.get_altitude(relative=True)
+        self.progress("Altitude after climb: %.1f" % alt_after_climb)
+
+        # release stick to neutral and let it settle
+        self.progress("Releasing stick, checking altitude settles")
+        self.set_rc(3, 1500)
+        self.delay_sim_time(3, "let the altitude settle")
+        settled_alt = self.get_altitude(relative=True)
+        self.progress("Settled altitude: %.1f" % settled_alt)
+
+        # verify altitude is maintained at the new altitude
+        self.wait_altitude(
+            settled_alt - 1,
+            settled_alt + 1,
+            relative=True,
+            minimum_duration=3,
+            timeout=4,
+        )
+
+        self.do_RTL()
+
     def fly_to_origin(self, final_alt=10):
         origin = self.poll_message("GPS_GLOBAL_ORIGIN")
         self.change_mode("GUIDED")
@@ -16616,6 +16665,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.AirModeStabZeroThrottle,
              self.AirModeLanding,
              self.ModeAltHold,
+             self.ModeVAltHold,
              self.ModeLoiter,
              self.SimpleMode,
              self.SuperSimpleCircle,

--- a/Tools/autotest/test_build_options.py
+++ b/Tools/autotest/test_build_options.py
@@ -302,6 +302,7 @@ class TestBuildOptions(object):
             feature_define_whitelist.add('MODE_SPORT_ENABLED')
             feature_define_whitelist.add('MODE_FOLLOW_ENABLED')
             feature_define_whitelist.add('MODE_TURTLE_ENABLED')
+            feature_define_whitelist.add('MODE_VALT_ENABLED')
             feature_define_whitelist.add('MODE_GUIDED_NOGPS_ENABLED')
             feature_define_whitelist.add('MODE_FLOWHOLD_ENABLED')
             feature_define_whitelist.add('MODE_FLIP_ENABLED')

--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -194,6 +194,7 @@ BUILD_OPTIONS = [
     Feature('Copter', 'MODE_SPORT', 'MODE_SPORT_ENABLED', 'Enable Mode Sport', 0, None),
     Feature('Copter', 'MODE_FOLLOW', 'MODE_FOLLOW_ENABLED', 'Enable Mode Follow', 0, 'AC_AVOID,AP_FOLLOW'),
     Feature('Copter', 'MODE_TURTLE', 'MODE_TURTLE_ENABLED', 'Enable Mode Turtle', 0, None),
+    Feature('Copter', 'MODE_VALT', 'MODE_VALT_ENABLED', 'Enable Mode VALT', 0, None),
     Feature('Copter', 'MODE_GUIDED_NOGPS', 'MODE_GUIDED_NOGPS_ENABLED', 'Enable Mode Guided NoGPS', 0, None),
     Feature('Copter', 'MODE_FLOWHOLD', 'MODE_FLOWHOLD_ENABLED', 'Enable Mode Flowhold', 0, "OPTICALFLOW"),
     Feature('Copter', 'MODE_FLIP', 'MODE_FLIP_ENABLED', 'Enable Mode Flip', 0, None),

--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -196,6 +196,7 @@ BUILD_OPTIONS = [
     Feature('Copter', 'MODE_SPORT', 'MODE_SPORT_ENABLED', 'Enable Mode Sport', 0, None),
     Feature('Copter', 'MODE_FOLLOW', 'MODE_FOLLOW_ENABLED', 'Enable Mode Follow', 0, 'AC_AVOID,AP_FOLLOW'),
     Feature('Copter', 'MODE_TURTLE', 'MODE_TURTLE_ENABLED', 'Enable Mode Turtle', 0, None),
+    Feature('Copter', 'MODE_VALT', 'MODE_VALT_ENABLED', 'Enable Mode VALT', 0, 'MODE_ALTHOLD'),
     Feature('Copter', 'MODE_GUIDED_NOGPS', 'MODE_GUIDED_NOGPS_ENABLED', 'Enable Mode Guided NoGPS', 0, None),
     Feature('Copter', 'MODE_FLOWHOLD', 'MODE_FLOWHOLD_ENABLED', 'Enable Mode Flowhold', 0, "OPTICALFLOW"),
     Feature('Copter', 'MODE_FLIP', 'MODE_FLIP_ENABLED', 'Enable Mode Flip', 0, None),

--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -135,6 +135,7 @@ class ExtractFeatures(BuildScriptBase):
             ('MODE_AUTOLAND_ENABLED', 'ModeAutoLand::update'),
             ('MODE_{type}_ENABLED', r'Mode(?P<type>.+)::init',),
             ('MODE_GUIDED_NOGPS_ENABLED', r'ModeGuidedNoGPS::init',),
+            ('MODE_VALT_ENABLED', r'ModeVelAltHold::alt_hold_run_flying',),
 
             ('AP_CAMERA_ENABLED', 'AP_Camera::var_info',),
             ('AP_CAMERA_{type}_ENABLED', 'AP_Camera_(?P<type>.*)::trigger_pic',),

--- a/libraries/AP_HAL_ChibiOS/hwdef/include/minimize_common.inc
+++ b/libraries/AP_HAL_ChibiOS/hwdef/include/minimize_common.inc
@@ -108,6 +108,7 @@ define AP_PLANE_OFFBOARD_GUIDED_SLEW_ENABLED 0
 #  directory, but are seen across the entire codebase:
 define MODE_FLOWHOLD_ENABLED 0
 define MODE_ZIGZAG_ENABLED 0
+define MODE_VALT_ENABLED 0
 define AC_NAV_GUIDED 0
 define AP_OAPATHPLANNER_ENABLED 0
 define AP_FOLLOW_ENABLED 0

--- a/libraries/AP_OSD/AP_OSD_ParamSetting.cpp
+++ b/libraries/AP_OSD/AP_OSD_ParamSetting.cpp
@@ -227,7 +227,7 @@ static const char* FLTMODES[] = {
     "STAB", "ACRO", "ALTHOLD", "AUTO", "GUIDED", "LOIT", "RTL", "CIRC", "", "LAND",
     "", "DRFT", "", "SPORT", "FLIP", "ATUN", "POSHLD", "BRAKE", "THROW", "AVD_ADSB",
     "GUID_NOGPS", "SMRTRTL", "FLOHOLD", "FOLLOW", "ZIGZAG", "SYSID", "HELI_ARO", "AUTORTL",
-    "TRTLE"
+    "TRTLE", "VALT"
 };
 
 static const char* FS_OPTIONS[] = {
@@ -248,7 +248,7 @@ const AP_OSD_ParamSetting::ParamMetadata AP_OSD_ParamSetting::_param_metadata[un
     { -1, AP_SerialManager::SerialProtocol_NumProtocols - 1,    1, ARRAY_SIZE(SERIAL_PROTOCOL_VALUES), SERIAL_PROTOCOL_VALUES },  // OSD_PARAM_SERIAL_PROTOCOL
     { 0, SRV_Channel::k_nr_aux_servo_functions - 1,             1, ARRAY_SIZE(SERVO_FUNCTIONS), SERVO_FUNCTIONS },                // OSD_PARAM_SERVO_FUNCTION
     { 0, 105, 1, ARRAY_SIZE(AUX_OPTIONS), AUX_OPTIONS },                        // OSD_PARAM_AUX_FUNCTION
-    { 0, 28, 1,  ARRAY_SIZE(FLTMODES), FLTMODES },                              // OSD_PARAM_FLIGHT_MODE
+    { 0, 29, 1,  ARRAY_SIZE(FLTMODES), FLTMODES },                              // OSD_PARAM_FLIGHT_MODE
     { 0, 3, 1,   ARRAY_SIZE(FS_OPTIONS), FS_OPTIONS },                          // OSD_PARAM_FAILSAFE_ACTION
     { 0, 5, 1,   ARRAY_SIZE(FS_ACT), FS_ACT },                                  // OSD_PARAM_FAILSAFE_ACTION_1
     { 0, 5, 1,   ARRAY_SIZE(THR_FS_ACT), THR_FS_ACT },                          // OSD_PARAM_FAILSAFE_ACTION_2

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -174,6 +174,7 @@ const AP_Param::GroupInfo AP_Vehicle::var_info[] = {
     // @Bitmask{Copter}: 21:Heli_Autorotate
     // @Bitmask{Copter}: 22:Auto RTL
     // @Bitmask{Copter}: 23:Turtle
+    // @Bitmask{Copter}: 24:VALT
     // @Bitmask{Plane}: 0:Manual
     // @Bitmask{Plane}: 1:Circle
     // @Bitmask{Plane}: 2:Stabilize


### PR DESCRIPTION
## Summary
Adds VALT (velocity alt hold), flight mode 29: the pilot stick commands climb/descent rate rather than driving a jerk-limited position trajectory. VALT inherits from AltHold and overrides only the flying state.

- During stick input the position-P loop is bypassed and pos_desired tracks the current altitude, so any baro offset accumulated during the manoeuvre (for example from prop wash) cancels out instead of feeding a position trajectory.
- When the stick returns to centre, pos_desired freezes at the current altitude with zero initial position error and the position-P loop holds height.
- Surface tracking is skipped in the flying state so its offsets do not fight pilot stick input.
- Ships with OSD display support, a build option (MODE_VALT_ENABLED, which requires MODE_ALTHOLD_ENABLED), and autotest. The one new parameter, VALT_POS_EXPO, defaults to 0, which keeps the original hard cutoff, so the mode is inert until opted in.
- Needs a companion mavlink PR adding COPTER_MODE_VALT = 29 (and the pymavlink mode mapping, which still names 29 RATE_ACRO).

### Position-authority blend
The base mode hard-switches: altitude hold at stick centre, pure velocity control everywhere off centre. That override snaps pos_desired to the estimate and disables the position loop, so if the vertical velocity estimate is wrong the velocity loop has no backstop and a commanded descent can be silently ignored.

VALT_POS_EXPO blends position authority back in as a function of stick deflection: a valley that is full at centre (hold), backed off through the mid range (clean velocity-rate feel), and returns at full deflection, where pos_desired is allowed to march so a growing position error backstops a stuck velocity loop. The expo shapes the valley.

### Ground idle at mid-stick
Mid-stick is VALT's resting hold state, but the shared AltHold ground state machine spools the motors to THROTTLE_UNLIMITED at any stick position at or above mid while a take-off only triggers on a positive climb rate. A VALT vehicle parked at mid-stick therefore sits spooled-but-not-taking-off with land_complete still true. If throttle_out then crosses hover/2 (angle boost while the airframe is handled on the ground) the land detector's missing-take-off guard raises a flow_of_control internal error, which latches and blocks arming until power cycle.

A Mode::spool_up_at_zero_climb_on_ground() virtual (default true, the stock behaviour) lets VALT keep the motors in ground idle at zero climb rate, so they only spool on a deliberate climb command. AltHold and every other mode are byte-identical. Take-off from mid-stick now waits for the spool-up, and a VALT vehicle parked on the ground auto-disarms after DISARM_DELAY where an AltHold one would not.

### Position correction limit in ground effect
Rotor wash moves the barometer by metres at ground contact on high disc-loading airframes, so the height estimate can step further than any real deviation; one measured case stepped 2.4 m, which the position P loop turned into a 2.4 m/s climb demand off the deck. While the baro is in ground effect the vertical position correction is limited to 0.1 m/s: AC_P_1D turns that into an error limit, so small errors are still corrected at full gain while a large one saturates rather than commanding a climb. Measured drift with no position authority at all is 0.03-0.05 m/s, so the limit still arrests it. Dropping position authority outright near the ground was tried first: it stops the launch but leaves nothing to arrest drift, and hands-off holds wandered 0.5-1.0 m per 20 s. The limit follows the ground effect flags, which also expect a touchdown during any slow demanded descent, so it is in force through a gentle descent at height as well and the VALT_POS_EXPO backstop is limited with it there.

### Why a separate mode instead of an AltHold option?
Velocity alt hold is inherently more robust to barometric pressure corruption: during stick input pos_desired = pos_actual, so any baro offset accumulated during the manoeuvre cancels out, and when the stick returns to centre there is zero initial position error by construction. This suits small, high-disc-loading copters with significant baro ground effect, where AltHold's jerk-limited trajectory can diverge from the corrupted EKF estimate. The behavioural difference is large enough to warrant a distinct mode rather than a runtime option within AltHold.

## Test plan
- [x] SITL build passes
- [x] test.Copter.ModeVAltHold - ground idle at mid-stick (motor output below AltHold's at the same stick), climb command lifts off, altitude hold at neutral and during lateral flight, climb/descent tracks stick, altitude freezes on return to centre, VALT_POS_EXPO blend
- [x] Ground idle at mid-stick and the ground-effect correction limit flown on hardware
- [ ] Hardware test with baro prop wash effects
