### PR TITLE
Copter: trad-heli handling of Leaky-I during power-off status

### DIFF
--- a/ArduCopter/heli.cpp
+++ b/ArduCopter/heli.cpp
@@ -23,7 +23,7 @@ void Copter::heli_init()
 // should be called at 50hz
 void Copter::check_dynamic_flight(void)
 {
-    if (motors->get_spool_state() != AP_Motors::SpoolState::THROTTLE_UNLIMITED ||
+    if ((motors->get_spool_state() != AP_Motors::SpoolState::THROTTLE_UNLIMITED && !motors->in_autorotation()) ||
         flightmode->is_landing()) {
         heli_dynamic_flight_counter = 0;
         heli_flags.dynamic_flight = false;


### PR DESCRIPTION
On Trad-Heli, If using H_OPTIONS = 1, current handling of I-terms during non-powered flight status causes the leaky-I to limit I-terms within ATC_RAT_PIT/RLL_ILMI boundaries:
<img width="1680" height="925" alt="image" src="https://github.com/user-attachments/assets/35c836bc-b1e9-4b1f-b817-938201f9cbe5" />
Proposed code extends Dynamic Flight check to include the engine-inoperative condition, thus maintaining full authority on cyclic control:
<img width="1676" height="960" alt="image" src="https://github.com/user-attachments/assets/03024782-ee2d-4c3c-91fd-e81c53aaac57" />
