### PR TITLE
AP_Terrain: check for old DAT files in pre-arm

### DIFF
--- a/libraries/AP_Terrain/AP_Terrain.cpp
+++ b/libraries/AP_Terrain/AP_Terrain.cpp
@@ -57,8 +57,8 @@ const AP_Param::GroupInfo AP_Terrain::var_info[] = {
 
     // @Param: OPTIONS
     // @DisplayName: Terrain options
-    // @Description: Options to change behaviour of terrain system
-    // @Bitmask: 0:Disable Download,1:Disable Disk
+    // @Description: Options to change behavior of terrain system. The Accept Old Terrain Data option can be used to accept terrain data generated from before the terrain database bugs were fixed. The bugs in the data were all fixed from 24th February 2026. If you really want to risk using the old terrain data then you can set this option, otherwise remove the old terrain data by formatting your microSD card or renaming the /APM/TERRAIN folder. Then downloaded updated data from https://terrain.ardupilot.org, or let the automatic terrain download repopulate your terrain data.
+    // @Bitmask: 0:Disable Download,1:Disable Disk,2:Accept Old Terrain Data
     // @User: Advanced
     AP_GROUPINFO("OPTIONS",   2, AP_Terrain, options, 0),
 
@@ -446,6 +446,16 @@ bool AP_Terrain::pre_arm_checks(char *failure_msg, uint8_t failure_msg_len) cons
     }
     if (grid_spacing <= 0) {
         hal.util->snprintf(failure_msg, failure_msg_len, "TERRAIN_SPACING can't be <= 0");
+        return false;
+    }
+
+    if (!option_set(Options::AcceptOldData) && found_old_data) {
+        /*
+          we have found old terrain data on the microSD card, warn the
+          user that they have out of date terrain data that may
+          contain errors.
+         */
+        hal.util->snprintf(failure_msg, failure_msg_len, "terrain data expired, possible errors");
         return false;
     }
 

--- a/libraries/AP_Terrain/TerrainGCS.cpp
+++ b/libraries/AP_Terrain/TerrainGCS.cpp
@@ -44,7 +44,7 @@ bool AP_Terrain::request_missing(GCS_MAVLINK &link, struct grid_cache &gcache)
 
     struct grid_block &grid = gcache.grid;
 
-    if (options.get() & uint16_t(Options::DisableDownload)) {
+    if (option_set(Options::DisableDownload)) {
         return false;
     }
 

--- a/libraries/AP_Terrain/TerrainUtil.cpp
+++ b/libraries/AP_Terrain/TerrainUtil.cpp
@@ -135,6 +135,7 @@ AP_Terrain::grid_cache &AP_Terrain::find_grid_cache(const struct grid_info &info
     grid.grid.lat_degrees = info.lat_degrees;
     grid.grid.lon_degrees = info.lon_degrees;
     grid.grid.version = TERRAIN_GRID_FORMAT_VERSION;
+    grid.grid.version_minor = TERRAIN_VERSION_MINOR_MIN;
     grid.last_access_ms = now_ms;
 
     // mark as waiting for disk read
@@ -173,7 +174,12 @@ uint16_t AP_Terrain::get_block_crc(struct grid_block &block)
 {
     uint16_t saved_crc = block.crc;
     block.crc = 0;
-    uint16_t ret = crc16_ccitt((const uint8_t *)&block, sizeof(block), 0);
+    /*
+      note that we exclude version_minor and any later bytes from the
+      CRC to maintain backwards compatibility so old versions of
+      ArduPilot accept new terrain blocks
+     */
+    uint16_t ret = crc16_ccitt((const uint8_t *)&block, offsetof(struct grid_block, version_minor), 0);
     block.crc = saved_crc;
     return ret;
 }


### PR DESCRIPTION
Add a version_minor to the terrain data structure to allow checking for old DAT files. This pushes users towards downloading new terrain data to avoid issues with old terrain data that have been recently fixed.

See also https://github.com/ArduPilot/terraingen/pull/25

If the user has not set the TERRAIN_OPTIONS bit to accept old terrain data then they will get a pre-arm error if any old terrain data is found during the normal pre-flight check of terrain data.

Note that this doesn't check every block in all DAT files as that will take too long, but it is likely to push users to clear their old data or download new data from the server.

Status
 - The terrain.ardupilot.org DAT files for SRTM3 have all been updated for version_minor=1
 - the SRTM1 DAT files are still being repacked for version_minor=1, should be done in a about 1 day

I'd like input on a better pre-arm warning message

need a if-modified-since check in mavproxy