### PR TITLE
Rover: populate avalable modes user selectable bit and track changes

### DIFF
--- a/Rover/GCS_MAVLink_Rover.cpp
+++ b/Rover/GCS_MAVLink_Rover.cpp
@@ -1057,15 +1057,19 @@ uint8_t GCS_MAVLINK_Rover::send_available_mode(uint8_t index) const
 
     // Ask the mode for its name and number
     const char* name = modes[index_zero]->name();
-    const uint8_t mode_number = (uint8_t)modes[index_zero]->mode_number();
+    const Mode::Number mode_number = modes[index_zero]->mode_number();
+
+    // the check here must be the same as the one in `get_available_mode_enabled_mask`
+    const bool user_selectable = modes[index_zero]->enabled() && rover.gcs_mode_enabled(mode_number);
 
     mavlink_msg_available_modes_send(
         chan,
         mode_count,
         index,
         MAV_STANDARD_MODE::MAV_STANDARD_MODE_NON_STANDARD,
-        mode_number,
-        0, // MAV_MODE_PROPERTY bitmask
+        (uint8_t)mode_number,
+        // MAV_MODE_PROPERTY bitmask,
+        user_selectable ? 0 : MAV_MODE_PROPERTY_NOT_USER_SELECTABLE,
         name
     );
 

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -390,6 +390,9 @@ private:
         return control_mode == &mode_auto;
     }
 
+    // Return mask of enabled modes, order does not matter, its just for tracking changes
+    uint32_t get_available_mode_enabled_mask() const override;
+
     void startup_INS(void);
     void notify_mode(const Mode *new_mode);
     uint8_t check_digital_pin(uint8_t pin);

--- a/Rover/mode.h
+++ b/Rover/mode.h
@@ -37,6 +37,9 @@ public:
     // do not allow copying
     CLASS_NO_COPY(Mode);
 
+    // Return true if this mode is enabled, used by MAVLink available mode
+    virtual bool enabled() const { return true; }
+
     // enter this mode, returns false if we failed to enter
     bool enter();
 
@@ -741,6 +744,9 @@ public:
     const char *name() const override { return "Smart RTL"; }
     const char *name4() const override { return "SRTL"; }
 
+    // Return true if this mode is enabled, used by MAVLink available mode
+    bool enabled() const override;
+
     // methods that affect movement of the vehicle in this mode
     void update() override;
 
@@ -814,6 +820,9 @@ public:
     const char *name() const override { return "Initialising"; }
     const char *name4() const override { return "INIT"; }
 
+    // Return true if this mode is enabled, used by MAVLink available mode
+    bool enabled() const override { return false; };
+
     // methods that affect movement of the vehicle in this mode
     void update() override { }
 
@@ -835,6 +844,9 @@ public:
     Number mode_number() const override { return Number::FOLLOW; }
     const char *name() const override { return "Follow"; }
     const char *name4() const override { return "FOLL"; }
+
+    // Return true if this mode is enabled, used by MAVLink available mode
+    bool enabled() const override;
 
     // methods that affect movement of the vehicle in this mode
     void update() override;
@@ -903,6 +915,9 @@ public:
     Number mode_number() const override { return Number::DOCK; }
     const char *name() const override { return "Dock"; }
     const char *name4() const override { return "DOCK"; }
+
+    // Return true if this mode is enabled, used by MAVLink available mode
+    bool enabled() const override;
 
     // methods that affect movement of the vehicle in this mode
     void update() override;

--- a/Rover/mode_dock.cpp
+++ b/Rover/mode_dock.cpp
@@ -55,11 +55,18 @@ ModeDock::ModeDock(void) : Mode()
 
 #define AR_DOCK_ACCEL_MAX              20.0    // acceleration used when user has specified no acceleration limit
 
+// Return true if this mode is enabled
+bool ModeDock::enabled() const
+{
+    // Dock mode requires precland
+    return rover.precland.enabled();
+}
+
 // initialize dock mode
 bool ModeDock::_enter()
 {
     // refuse to enter the mode if dock is not in sight
-    if (!rover.precland.enabled() || !rover.precland.target_acquired()) {
+    if (!enabled() || !rover.precland.target_acquired()) {
         GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Dock: target not acquired");
         return false;
     }

--- a/Rover/mode_follow.cpp
+++ b/Rover/mode_follow.cpp
@@ -1,10 +1,18 @@
 #include "Rover.h"
 
 #if MODE_FOLLOW_ENABLED
+
+// Return true if this mode is enabled
+bool ModeFollow::enabled() const
+{
+    // Follow mode requires follow lib
+    return g2.follow.enabled();
+}
+
 // initialize follow mode
 bool ModeFollow::_enter()
 {
-    if (!g2.follow.enabled()) {
+    if (!enabled()) {
         return false;
     }
 

--- a/Rover/mode_smart_rtl.cpp
+++ b/Rover/mode_smart_rtl.cpp
@@ -1,5 +1,12 @@
 #include "Rover.h"
 
+// Return true if this mode is enabled, used by MAVLink available mode
+bool ModeSmartRTL::enabled() const
+{
+    // Smart RTL mode requires smart RTL lib
+    return g2.smart_rtl.enabled();
+}
+
 bool ModeSmartRTL::_enter()
 {
     // SmartRTL requires EKF (not DCM)
@@ -9,7 +16,7 @@ bool ModeSmartRTL::_enter()
     }
 
     // refuse to enter SmartRTL if smart RTL's home has not been set
-    if (!g2.smart_rtl.is_active()) {
+    if (!enabled() || !g2.smart_rtl.is_active()) {
         return false;
     }
 


### PR DESCRIPTION
This brings rover inline with copter (https://github.com/ArduPilot/ardupilot/pull/32135) and plane (https://github.com/ArduPilot/ardupilot/pull/32271) in supporting the user select bit in the MAVLink available modes protocol. This is improves https://github.com/ArduPilot/ardupilot/issues/31761.

Currently on master QGC shows all modes:

<img width="180" height="651" alt="image" src="https://github.com/user-attachments/assets/9179ca0e-79f1-43fd-a1f5-5076f18ed45c" />

With this patch some are removed by defualt. Initializing is removed because you can never enter. Follow and dock mode are removed because they need the follow lib and the prec-land lib enabled respectively.

<img width="194" height="537" alt="image" src="https://github.com/user-attachments/assets/76f50aff-606a-4ecc-ae94-8187d784be9e" />

`FLTMODE_GCSBLOCK` can then be used to further reduce the list, with a value of 3702 for example:

<img width="164" height="317" alt="image" src="https://github.com/user-attachments/assets/47c522c0-dfac-4ec2-85f2-ac4f64522885" />

Changes to the param will be reflected in real (ish) time.