### PR TITLE
GCS_MAVLink: fix HIGHRES_IMU mag field units

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2317,7 +2317,7 @@ void GCS_MAVLINK::send_highres_imu()
 #if AP_COMPASS_ENABLED
     const Compass &compass = AP::compass();
     if (compass.get_count() >= 1) {
-        const Vector3f field = compass.get_field() * 1000.0f;
+        const Vector3f field = compass.get_field() * 0.001f;
         reply.xmag = field.x; // convert to gauss
         reply.ymag = field.y;
         reply.zmag = field.z;


### PR DESCRIPTION
# Summary

Fix a unit conversion error for the magnetometer fields of HIGHRES_IMU in GCS_Common.cpp. 

## Testing (more check increases chance of being merged)

- [X] Checked by a human programmer
- [X] Tested in SITL
- [X] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

In GCS_Common.cpp, compass.get_field() returns milligauss and HIGHRES_IMU expects gauss. This needs to divide by 1000, not multiple by 1000. I verified with SITL and a fresh Orange Cube by viewing the HIGHRES_IMU messages. Before the change, the magnitude of the mag components [sqrt(xmag^2+ymag^2+zmag^2)] is on the order of 500,000 gauss which is not realistic (on Earth). With this change it is on the order of 0.5 which is realistic.

I realized there was an issue while trying to include the compass data in an external factor graph state estimator. I was trying to add noise with SIM_MAG_RND but the units weren't making any sense. 