### PR TITLE
SITL: make GPS jamming loop-rate independent

### DIFF
--- a/libraries/SITL/SIM_GPS.cpp
+++ b/libraries/SITL/SIM_GPS.cpp
@@ -275,12 +275,10 @@ void GPS::simulate_jamming(struct GPS_Data &d)
 {
     auto &jam = jamming[instance];
     const uint32_t now_ms = AP_HAL::millis();
-    if (now_ms - jam.last_jam_ms > 1000) {
-        jam.jam_start_ms = now_ms;
-        jam.latitude = d.latitude;
-        jam.longitude = d.longitude;
-    }
-    jam.last_jam_ms = now_ms;
+
+    const auto rand_delay_ms = [](float hz) {
+        return MAX(1, int((1000.0f/hz) * 2.0f * fabsf(rand_float())));
+    };
 
     // how often each of the key state variables change during jamming
     const float vz_change_hz = 0.5;
@@ -289,13 +287,26 @@ void GPS::simulate_jamming(struct GPS_Data &d)
     const float sats_change_hz = 3;
     const float acc_change_hz = 3;
 
-    if (now_ms - jam.jam_start_ms < unsigned(1000U+(get_random16()%5000))) {
+    if (now_ms - jam.last_jam_ms > 1000) {
+        jam.jam_start_ms = now_ms;
+        jam.initial_loss_duration_ms = 1000 + (get_random16() % 5000);
+        const uint32_t loss_end_ms = jam.jam_start_ms + jam.initial_loss_duration_ms;
+        jam.last_sats_change_ms = loss_end_ms + rand_delay_ms(sats_change_hz);
+        jam.last_vz_change_ms = loss_end_ms + rand_delay_ms(vz_change_hz);
+        jam.last_vel_change_ms = loss_end_ms + rand_delay_ms(vel_change_hz);
+        jam.last_pos_change_ms = loss_end_ms + rand_delay_ms(pos_change_hz);
+        jam.last_acc_change_ms = loss_end_ms + rand_delay_ms(acc_change_hz);
+        jam.latitude = d.latitude;
+        jam.longitude = d.longitude;
+    }
+    jam.last_jam_ms = now_ms;
+
+    if (now_ms - jam.jam_start_ms < jam.initial_loss_duration_ms) {
         // total loss of signal for a period at the start is common
         d.num_sats = 0;
         d.have_lock = false;
     } else {
-        if ((now_ms - jam.last_sats_change_ms)*0.001 > 2*fabsf(rand_float())/sats_change_hz) {
-            jam.last_sats_change_ms = now_ms;
+        while (now_ms >= jam.last_sats_change_ms) {
             d.num_sats = 2 + (get_random16() % 15);
             if (d.num_sats >= 4) {
                 if (get_random16() % 2 == 0) {
@@ -306,26 +317,27 @@ void GPS::simulate_jamming(struct GPS_Data &d)
             } else {
                 d.have_lock = false;
             }
+            jam.last_sats_change_ms += rand_delay_ms(sats_change_hz);
         }
-        if ((now_ms - jam.last_vz_change_ms)*0.001 > 2*fabsf(rand_float())/vz_change_hz) {
-            jam.last_vz_change_ms = now_ms;
+        while (now_ms >= jam.last_vz_change_ms) {
             d.speedD = rand_float() * 400;
+            jam.last_vz_change_ms += rand_delay_ms(vz_change_hz);
         }
-        if ((now_ms - jam.last_vel_change_ms)*0.001 > 2*fabsf(rand_float())/vel_change_hz) {
-            jam.last_vel_change_ms = now_ms;
+        while (now_ms >= jam.last_vel_change_ms) {
             d.speedN = rand_float() * 400;
             d.speedE = rand_float() * 400;
+            jam.last_vel_change_ms += rand_delay_ms(vel_change_hz);
         }
-        if ((now_ms - jam.last_pos_change_ms)*0.001 > 2*fabsf(rand_float())/pos_change_hz) {
-            jam.last_pos_change_ms = now_ms;
+        while (now_ms >= jam.last_pos_change_ms) {
             jam.latitude += rand_float()*200 * LATLON_TO_M_INV * 1e-7;
             jam.longitude += rand_float()*200 * LATLON_TO_M_INV * 1e-7;
+            jam.last_pos_change_ms += rand_delay_ms(pos_change_hz);
         }
-        if ((now_ms - jam.last_acc_change_ms)*0.001 > 2*fabsf(rand_float())/acc_change_hz) {
-            jam.last_acc_change_ms = now_ms;
+        while (now_ms >= jam.last_acc_change_ms) {
             d.vertical_acc = fabsf(rand_float())*300;
             d.horizontal_acc = fabsf(rand_float())*300;
             d.speed_acc = fabsf(rand_float())*50;
+            jam.last_acc_change_ms += rand_delay_ms(acc_change_hz);
         }
     }
 

--- a/libraries/SITL/SIM_GPS.h
+++ b/libraries/SITL/SIM_GPS.h
@@ -155,6 +155,7 @@ private:
     struct {
         uint32_t last_jam_ms;
         uint32_t jam_start_ms;
+        uint32_t initial_loss_duration_ms;
         uint32_t last_sats_change_ms;
         uint32_t last_vz_change_ms;
         uint32_t last_vel_change_ms;


### PR DESCRIPTION
# Summary

Reworked GPS jamming timing to sample initial loss duration once per jam episode and to schedule per-state jam updates from absolute timestamps, with catch-up on delayed calls.

## Testing (more check increases chance of being merged)

- [X] Checked by a human programmer
- [X] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [X] Logs available on request
- [ ] Autotest included

## Description

This preserves the original randomized rates while removing timing sensitivity, fixing inconsistencies between local and remote CI runs of the DeadReckoningNoAirspeed autotest.

It doesn't change the fact that on remote CI, the DeadReckoningNoAirspeed test achieves lower divergences on remote CI compared to local testing, and therefore passes much easier. That's probably because of another timing sensitive routine somewhere else in the chain. What it DOES fix, is a bug where that autotest would instantly fail from basically one sim step to the next (when run on remote CI), like so:

<img width="908" height="233" alt="imagen" src="https://github.com/user-attachments/assets/4cd140f2-9015-4d31-8fd7-263b5bd748ff" />