### PR TITLE
AP_Logger: correct multiplier for rally altitude

### DIFF
--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1259,7 +1259,7 @@ LOG_STRUCTURE_FROM_FENCE \
     { LOG_DF_FILE_STATS, sizeof(log_DSF), \
       "DSF", "QIHIIII", "TimeUS,Dp,Blk,Bytes,FMn,FMx,FAv", "s--b---", "F--0---" }, \
     { LOG_RALLY_MSG, sizeof(log_Rally), \
-      "RALY", "QBBLLhB", "TimeUS,Tot,Seq,Lat,Lng,Alt,Flags", "s--DUm-", "F--GGB-" },  \
+      "RALY", "QBBLLhB", "TimeUS,Tot,Seq,Lat,Lng,Alt,Flags", "s--DUm-", "F--GG0-" },  \
     { LOG_MAV_MSG, sizeof(log_MAV),   \
       "MAV", "QBHHHBHHI",   "TimeUS,chan,txp,rxp,rxdp,flags,ss,tf,mgs", "s#----s-s", "F-000-C-C" },   \
 LOG_STRUCTURE_FROM_VISUALODOM \


### PR DESCRIPTION
# Summary

Fixes incorrect metadata in the log message definition for RALY

## Testing (more check increases chance of being merged)

- [X] Checked by a human programmer
- [X] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

this is defined in RallyLocation as "int16_t alt;        //transit altitude (and loiter altitude) in meters (absolute);" - and we're just dropping that value directly into the packet.

correct the multiplier to indicate this is not in cm but in metres

```
2026-02-26 11:52:27.362: RALY
    TimeUS: 70561764 µs
    Tot: 1 
    Seq: 0 
    Lat: -35.3602381 deglatitude
    Lng: 149.1689639 deglongitude
    Alt: 50 m
    Flags: 12 
```

(new log message metadata)
