### PR TITLE
Use MAVLink flag value for "unused field" in Rover RC_CHANNELS_SCALED

### DIFF
--- a/Rover/GCS_MAVLink_Rover.cpp
+++ b/Rover/GCS_MAVLink_Rover.cpp
@@ -135,13 +135,13 @@ void GCS_MAVLINK_Rover::send_servo_out()
         millis(),
         0,  // port 0
         motor1,
-        UINT16_MAX,
+        -1,  // flag value for "not supplied in this message"
         motor3,
-        UINT16_MAX,
-        UINT16_MAX,
-        UINT16_MAX,
-        UINT16_MAX,
-        UINT16_MAX,
+        -1,  // flag value for "not supplied in this message"
+        -1,  // flag value for "not supplied in this message"
+        -1,  // flag value for "not supplied in this message"
+        -1,  // flag value for "not supplied in this message"
+        -1,  // flag value for "not supplied in this message"
 #if AP_RSSI_ENABLED
         receiver_rssi()
 #else

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -877,6 +877,17 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             self.progress("chan3=%f want=%f" % (m.chan3_raw, normal_rc_throttle))
             if m.chan3_raw == normal_rc_throttle:
                 break
+        self.progress("Checking RC_CHANNELS_SCALED inactive channels are UINT16_MAX")
+        m = self.poll_message('RC_CHANNELS_SCALED')
+        # Rover uses only chan1 (steering) and chan3 (throttle).
+        # All other channels must be UINT16_MAX per MAVLink spec.
+        # pymavlink decodes the int16_t wire value 0xFFFF as -1.
+        for ch in ('chan2_scaled', 'chan4_scaled', 'chan5_scaled',
+                   'chan6_scaled', 'chan7_scaled', 'chan8_scaled'):
+            val = getattr(m, ch)
+            if val != -1:
+                raise NotAchievedException(
+                    "RC_CHANNELS_SCALED %s=%d want UINT16_MAX (-1)" % (ch, val))
         self.disarm_vehicle()
 
     def RCOverrides(self):


### PR DESCRIPTION
# Summary

Changes how we emit unused fields in this mavlink message to conform to the spec.

## Testing (more check increases chance of being merged)

- [x] Checked by a human programmer
- [x] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [x] Autotest included

## Description

I don't think we should even really be emitting this message... we don't emit the equivalent on other vehicles *AND* this isn't a servo-output message, it's an RC-input message!

This is the description from the spec:
```
The scaled values of the RC channels received: (-100%) -10000, (0%) 0, (100%) 10000. Channels that are inactive should be set to UINT16_MAX.
```
