### PR TITLE
move save_trim() from RC_Channels_Copter to Copter class

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -968,6 +968,7 @@ private:
 
     // radio.cpp
     void default_dead_zones();
+    void save_trim();
     void init_rc_in();
     void init_rc_out();
     void read_radio();

--- a/ArduCopter/RC_Channel_Copter.cpp
+++ b/ArduCopter/RC_Channel_Copter.cpp
@@ -219,7 +219,7 @@ bool RC_Channel_Copter::do_aux_function(const AuxFuncTrigger &trigger)
             if ((ch_flag == AuxSwitchPos::HIGH) &&
                 (copter.flightmode->allows_save_trim()) &&
                 (copter.channel_throttle->get_control_in() == 0)) {
-                copter.g2.rc_channels.save_trim();
+                copter.save_trim();
             }
             break;
 
@@ -721,32 +721,6 @@ void RC_Channel_Copter::do_aux_function_change_force_flying(const AuxSwitchPos c
     }
 }
 
-// note that this is a method on the RC_Channels object, not the
-// individual channel
-// save_trim - adds roll and pitch trims from the radio to ahrs
-void RC_Channels_Copter::save_trim()
-{
-    float roll_trim_rad = 0.0;
-    float pitch_trim_rad = 0.0;
-
-#if AP_COPTER_AHRS_AUTO_TRIM_ENABLED
-    if (auto_trim.running) {
-        auto_trim.running = false;
-    } else {
-#endif
-
-    // get roll and pitch trim adjustment
-    copter.flightmode->get_pilot_desired_lean_angles_rad(roll_trim_rad, pitch_trim_rad, copter.attitude_control->lean_angle_max_rad(), copter.attitude_control->get_althold_lean_angle_max_rad());
-
-#if AP_COPTER_AHRS_AUTO_TRIM_ENABLED
-    }
-#endif
-
-    // save roll and pitch trim
-    AP::ahrs().add_trim(roll_trim_rad, pitch_trim_rad);
-    LOGGER_WRITE_EVENT(LogEvent::SAVE_TRIM);
-    gcs().send_text(MAV_SEVERITY_INFO, "Trim saved");
-}
 
 #if AP_COPTER_AHRS_AUTO_TRIM_ENABLED
 // start/stop ahrs auto trim
@@ -768,7 +742,7 @@ void RC_Channels_Copter::do_aux_function_ahrs_auto_trim(const RC_Channel::AuxSwi
     case RC_Channel::AuxSwitchPos::LOW:
         if (auto_trim.running) {
             AP_Notify::flags.save_trim = false;
-            save_trim();
+            copter.save_trim();
         }
         break;
     }

--- a/ArduCopter/RC_Channel_Copter.h
+++ b/ArduCopter/RC_Channel_Copter.h
@@ -56,7 +56,6 @@ public:
     void auto_trim_run();
     void auto_trim_cancel();
 #endif  // AP_COPTER_AHRS_AUTO_TRIM_ENABLED
-    void save_trim();
 
 protected:
 

--- a/ArduCopter/radio.cpp
+++ b/ArduCopter/radio.cpp
@@ -218,3 +218,29 @@ int16_t Copter::get_throttle_mid(void)
 #endif
     return channel_throttle->get_control_mid();
 }
+
+// save_trim - adds roll and pitch trims from the radio to AHRS
+// called via the SAVE_TRIM aux function switch
+void Copter::save_trim()
+{
+    float roll_trim_rad = 0.0f;
+    float pitch_trim_rad = 0.0f;
+
+#if AP_COPTER_AHRS_AUTO_TRIM_ENABLED
+    if (g2.rc_channels.auto_trim.running) {
+        g2.rc_channels.auto_trim.running = false;
+    } else {
+#endif
+
+    // get roll and pitch trim from the attitude controller target
+    flightmode->get_pilot_desired_lean_angles_rad(roll_trim_rad, pitch_trim_rad, attitude_control->lean_angle_max_rad(), attitude_control->get_althold_lean_angle_max_rad());
+
+#if AP_COPTER_AHRS_AUTO_TRIM_ENABLED
+    }
+#endif
+
+    // save roll and pitch trim
+    AP::ahrs().add_trim(roll_trim_rad, pitch_trim_rad);
+    LOGGER_WRITE_EVENT(LogEvent::SAVE_TRIM);
+    gcs().send_text(MAV_SEVERITY_INFO, "Trim saved");
+}


### PR DESCRIPTION
save_trim() operates on Copter member variables (flightmode,
attitude_control, g2.rc_channels) and is more naturally a method
of the Copter class than of RC_Channels_Copter.
Changes:
- Remove save_trim() declaration and definition from RC_Channels_Copter
- Add save_trim() declaration to Copter class (under radio.cpp section)
- Implement save_trim() in ArduCopter/radio.cpp
- Update both call sites in RC_Channel_Copter.cpp to use copter.save_trim()

this is work on #32279 