### PR TITLE
add support for water barometers

### DIFF
--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -7263,6 +7263,7 @@ return update()
         ret = super(AutoTestRover, self).tests()
 
         ret.extend([
+            self.WaterBaroParams,
             self.MAVProxy_SetModeUsingSwitch,
             self.HIGH_LATENCY2,
             self.MAVProxy_SetModeUsingMode,
@@ -7390,3 +7391,17 @@ return update()
 
     def default_mode(self):
         return 'MANUAL'
+
+    def WaterBaroParams(self):
+        '''Test water barometer recognition and depth reporting for Rover'''
+        self.progress("Testing Water Barometer support")
+
+        # Set density and reboot to trigger the new probe logic
+        self.set_parameter("BARO_SPEC_GRAV", 1.024)
+        self.reboot_sitl()
+
+        # Add this delay to let the SITL fully boot before RC is checked
+        self.delay_sim_time(5)
+
+        self.progress("Wait for barometer depth reading")
+        self.wait_altitude(1580, 1590, relative=False)

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -135,12 +135,12 @@ const AP_Param::GroupInfo AP_Baro::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("_EXT_BUS", 7, AP_Baro, _ext_bus, HAL_BARO_EXTERNAL_BUS_DEFAULT),
 
-    // @Param{Sub}: _SPEC_GRAV
+    // @Param{Sub,Rover}: _SPEC_GRAV
     // @DisplayName: Specific Gravity (For water depth measurement)
     // @Description: This sets the specific gravity of the fluid when flying an underwater ROV.
     // @Values: 1.0:Freshwater,1.024:Saltwater
     // @Range: 0.98 1.05
-    AP_GROUPINFO_FRAME("_SPEC_GRAV", 8, AP_Baro, _specific_gravity, 1.0, AP_PARAM_FRAME_SUB),
+    AP_GROUPINFO_FRAME("_SPEC_GRAV", 8, AP_Baro, _specific_gravity, 1.0, AP_PARAM_FRAME_SUB | AP_PARAM_FRAME_ROVER),
 
 #if BARO_MAX_INSTANCES > 1
     // @Param: 2_GND_PRESS
@@ -709,7 +709,9 @@ void AP_Baro::init(void)
 
     // can optionally have baro on I2C too
     if (_ext_bus >= 0) {
-#if APM_BUILD_TYPE(APM_BUILD_ArduSub)
+#if APM_BUILD_TYPE(APM_BUILD_ArduSub) || APM_BUILD_TYPE(APM_BUILD_Rover)
+        // Only probe water barometers if specific gravity is set !0
+        if (_specific_gravity.get() > 0.0f) {
 #if AP_BARO_MS5837_ENABLED
         probe_i2c_dev(AP_Baro_MS5837::probe, _ext_bus, HAL_BARO_MS5837_I2C_ADDR);
         RETURN_IF_NO_SPACE;
@@ -718,12 +720,13 @@ void AP_Baro::init(void)
         probe_i2c_dev(AP_Baro_KellerLD::probe, _ext_bus, HAL_BARO_KELLERLD_I2C_ADDR);
         RETURN_IF_NO_SPACE;
 #endif
+        }
 #else
 #if AP_BARO_MS5611_ENABLED
         probe_i2c_dev(AP_Baro_MS5611::probe, _ext_bus, HAL_BARO_MS5611_I2C_ADDR);
         RETURN_IF_NO_SPACE;
 #endif
-#endif
+#endif // APM_BUILD_TYPE(APM_BUILD_ArduSub) || APM_BUILD_TYPE(APM_BUILD_Rover)
     }
 
 #if AP_BARO_PROBE_EXTERNAL_I2C_BUSES
@@ -834,14 +837,14 @@ void AP_Baro::_probe_i2c_barometers(void)
         { PROBE_AUAV, AP_Baro_AUAV::probe, HAL_BARO_AUAV_I2C_ADDR },
 #endif
 
-#if APM_BUILD_TYPE(APM_BUILD_ArduSub)
+#if APM_BUILD_TYPE(APM_BUILD_ArduSub) || APM_BUILD_TYPE(APM_BUILD_Rover)
 #if AP_BARO_KELLERLD_ENABLED
         { PROBE_KELLER, AP_Baro_KellerLD::probe, HAL_BARO_KELLERLD_I2C_ADDR },
 #endif
 #if AP_BARO_MS5837_ENABLED
         { PROBE_MS5837, AP_Baro_MS5837::probe, HAL_BARO_MS5837_I2C_ADDR },
 #endif
-#endif  // APM_BUILD_TYPE(APM_BUILD_ArduSub)
+#endif  // APM_BUILD_TYPE(APM_BUILD_ArduSub) || APM_BUILD_TYPE(APM_BUILD_Rover)
     };
 
     for (const auto &spec : baroprobespec) {

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -70,6 +70,7 @@ public:
     // pressure in Pascal. Divide by 100 for millibars or hectopascals
     float get_pressure(void) const { return get_pressure(_primary); }
     float get_pressure(uint8_t instance) const { return sensors[instance].pressure; }
+    float get_specific_gravity(void) const { return _specific_gravity.get(); }
 #if HAL_BARO_WIND_COMP_ENABLED
     // dynamic pressure in Pascal. Divide by 100 for millibars or hectopascals
     const Vector3f& get_dynamic_pressure(uint8_t instance) const { return sensors[instance].dynamic_pressure; }

--- a/libraries/AP_Baro/AP_Baro_SITL.cpp
+++ b/libraries/AP_Baro/AP_Baro_SITL.cpp
@@ -17,8 +17,11 @@ AP_Baro_SITL::AP_Baro_SITL(AP_Baro &baro) :
 {
     if (_sitl != nullptr) {
         _instance = _frontend.register_sensor();
-#if APM_BUILD_TYPE(APM_BUILD_ArduSub)
+#if APM_BUILD_TYPE(APM_BUILD_ArduSub) || APM_BUILD_TYPE(APM_BUILD_Rover)
+    // If specific gravity is set, treat this as an underwater sensor
+    if (_frontend.get_specific_gravity() > 0.0f) {
         _frontend.set_type(_instance, AP_Baro::BARO_TYPE_WATER);
+    }
 #endif
         set_bus_id(_instance, AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_SITL, 0, _instance, DEVTYPE_BARO_SITL));
         hal.scheduler->register_timer_process(FUNCTOR_BIND(this, &AP_Baro_SITL::_timer, void));
@@ -51,6 +54,8 @@ void AP_Baro_SITL::temperature_adjustment(float &p, float &T)
 
 void AP_Baro_SITL::_timer()
 {
+    float p = 0.0f;
+    float T = 0.0f;
 
     // 100Hz
     const uint32_t now = AP_HAL::millis();
@@ -117,16 +122,25 @@ void AP_Baro_SITL::_timer()
         sim_alt = _buffer[best_index].data;
     }
 
-#if !APM_BUILD_TYPE(APM_BUILD_ArduSub)
-    float p, T_K;
+#if !APM_BUILD_TYPE(APM_BUILD_ArduSub) && !APM_BUILD_TYPE(APM_BUILD_Rover)
+    float T_K;
     AP_Baro::get_pressure_temperature_for_alt_amsl(sim_alt, p, T_K);
-    float T = KELVIN_TO_C(T_K);
+    T = KELVIN_TO_C(T_K);
     temperature_adjustment(p, T);
 #else
-    float rho, delta, theta;
-    AP_Baro::SimpleUnderWaterAtmosphere(-sim_alt * 0.001f, rho, delta, theta);
-    float p = SSL_AIR_PRESSURE * delta;
-    float T = KELVIN_TO_C(SSL_AIR_TEMPERATURE * theta);
+    // Use this only when actually underwater
+    if (_frontend.get_specific_gravity() > 0.0f && sim_alt <= 0.0f) {
+        float rho, delta, theta;
+        AP_Baro::SimpleUnderWaterAtmosphere(-sim_alt * 0.001f, rho, delta, theta);
+        p = SSL_AIR_PRESSURE * delta;
+        T = KELVIN_TO_C(SSL_AIR_TEMPERATURE * theta);
+    } else {
+        // For standard Rovers, or when the vehicle is above sea level
+        float T_K_fallback;
+        AP_Baro::get_pressure_temperature_for_alt_amsl(sim_alt, p, T_K_fallback);
+        T = KELVIN_TO_C(T_K_fallback);
+        temperature_adjustment(p, T);
+    }
 #endif
 
     // add in correction for wind effects

--- a/libraries/AP_Scripting/examples/rover_depth_failsafe.lua
+++ b/libraries/AP_Scripting/examples/rover_depth_failsafe.lua
@@ -1,0 +1,56 @@
+-- This script is a depth failsafe for ArduRover.
+-- It is useful for amphibious rovers or boats.
+-- It prevents driving deeper if the vehicle fills up with water or flips.
+-- It monitors the water barometer and switches to HOLD mode if depth exceeds limits.
+
+-- depth to trigger failsafe
+local CRITICAL_DEPTH = 2.0
+local DEBOUNCE_MS = 2000
+-- run every 100ms
+local UPDATE_RATE_MS = 100
+
+-- Internal variables
+local time_below_depth = 0
+local failsafe_triggered = false
+local ROVER_MODE_HOLD = 4
+
+function update()
+  -- If already triggered the failsafe, no need to send messages the Ground Control
+  if failsafe_triggered then
+    return update, 5000
+  end
+
+  -- Read altitude from the barometer
+  local current_alt = baro:get_altitude()
+
+  -- If barometer isn't initialized, wait and try again
+  if current_alt == nil then
+    return update, UPDATE_RATE_MS
+  end
+
+  -- Water depth
+  local current_depth = -current_alt
+
+  if current_depth >= CRITICAL_DEPTH then
+    time_below_depth = time_below_depth + UPDATE_RATE_MS
+    
+    -- If the rover has been too deep longer than the debounce time
+    if time_below_depth >= DEBOUNCE_MS then
+        -- Send a Warning text
+        gcs:send_text(4, string.format("Depth Failsafe! Depth: %.1fm", current_depth))
+        
+        -- Switch Rover to HOLD mode
+        vehicle:set_mode(ROVER_MODE_HOLD)
+        
+        -- Lock the failsafe so it doesn't trigger
+        failsafe_triggered = true
+    end
+  else
+    -- Safe, Reset the timer
+    time_below_depth = 0
+  end
+
+  return update, UPDATE_RATE_MS
+end
+
+return update()


### PR DESCRIPTION
# Summary

continuing

Relevant to #32091
Enables water barometer support for Rover

Changes:

- Allows MS5837 and KellerLD water barometer drivers to compile for Rover.
- Exposes the `BARO_SPEC_GRAV` parameter for Rover so water density can be configured.
- Added an example Lua script for depth(pressure) failsafe.