### PR TITLE
GCS_MAVLink: fix SET_POSITION_TARGET_GLOBAL_INT altitude units

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -6176,8 +6176,8 @@ void GCS_MAVLINK::send_set_position_target_global_int(uint8_t target_system, uin
                                POSITION_TARGET_TYPEMASK_YAW_IGNORE | POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE;
 
     // convert altitude to relative to home
-    int32_t rel_alt;
-    if (!loc.get_alt_cm(Location::AltFrame::ABOVE_HOME, rel_alt)) {
+    float rel_alt_m;
+    if (!loc.get_alt_m(Location::AltFrame::ABOVE_HOME, rel_alt_m)) {
         return;
     }
 
@@ -6190,7 +6190,7 @@ void GCS_MAVLINK::send_set_position_target_global_int(uint8_t target_system, uin
             type_mask,
             loc.lat,
             loc.lng,
-            rel_alt,
+            rel_alt_m,
             0,0,0,  // vx, vy, vz
             0,0,0,  // ax, ay, az
             0,0);   // yaw, yaw_rate


### PR DESCRIPTION
# Summary

Corrects the altitude sent through to companion computers when Rover is set up to do offboard navigation.

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [x] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

send_set_position_target_global_int() was passing rel_alt (int32_t, centimetres from get_alt_cm()) directly to the alt field, which expects a float in metres. Send metres.


Tested in SITL by creating a mission which puts the thing in the right submode and:
```
AUTO>   message SET_POSITION_TARGET_GLOBAL_INT 0 1 1 3 4088 -353572610 1491652300 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0
AUTO> > SET_POSITION_TARGET_GLOBAL_INT {time_boot_ms : 0, target_system : 1, target_component : 1, coordinate_frame : 3, type_mask : 4088, lat_int : -353572610, lon_int : 1491652300, alt : 0.0, vx : 0.0, vy : 0.0, vz : 0.0, afx : 0.0, afy : 0.0, afz : 0.0, yaw : 0.0, yaw_rate : 0.0}
```

(the emitted message is because of a `watch` in MAVProxy for that message)

Being Rover, the factor of 10 in an altitude target probably doesn't really matter....
