### PR TITLE
fix: replace 9 bare except clauses with except Exception

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -1011,7 +1011,7 @@ class esp32(Board):
             return cfg.root.find_dir(env.IDF+p).abspath()
         try:
             env.IDF = os.environ['IDF_PATH'] 
-        except:
+        except Exception:
             env.IDF = cfg.srcnode.abspath()+"/modules/esp_idf"
 
         super(esp32, self).configure_env(cfg, env)

--- a/Tools/ardupilotwaf/build_summary.py
+++ b/Tools/ardupilotwaf/build_summary.py
@@ -262,7 +262,7 @@ def size_summary(bld, nodes):
             for i, data in enumerate(parsed):
                 try:
                     d.update(data)
-                except:
+                except Exception:
                     print("build summary debug: "+str(i)+"->"+str(data))
 
     return l

--- a/Tools/ardupilotwaf/esp32.py
+++ b/Tools/ardupilotwaf/esp32.py
@@ -53,7 +53,7 @@ def configure(cfg):
     #Check if esp-idf env are loaded, or load it
     try:
         env.IDF = os.environ['IDF_PATH']
-    except:
+    except Exception:
         env.IDF = cfg.srcnode.abspath()+"/modules/esp_idf"
     print("USING EXPRESSIF IDF:"+str(env.IDF))
 

--- a/Tools/autotest/pysim/fdpexpect.py
+++ b/Tools/autotest/pysim/fdpexpect.py
@@ -73,7 +73,7 @@ class fdspawn(spawn):
         try:
             os.fstat(self.child_fd)
             return True
-        except:
+        except Exception:
             return False
 
     def terminate(self, force=False):

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_joy_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_joy_msg_received.py
@@ -107,7 +107,7 @@ class PlaneFbwbJoyControl(Node):
         time.sleep(0.2)
         try:
             return future.result().result
-        except:
+        except Exception:
             return False
 
     def arm_with_timeout(self, timeout: rclpy.duration.Duration):
@@ -126,7 +126,7 @@ class PlaneFbwbJoyControl(Node):
         time.sleep(1)
         try:
             return future.result().status and future.result().curr_mode == mode
-        except:
+        except Exception:
             return False
 
     def switch_mode_with_timeout(self, desired_mode: int, timeout: rclpy.duration.Duration):

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_prearm_service.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_prearm_service.py
@@ -80,7 +80,7 @@ class PreamService(rclpy.node.Node):
     def start_prearm(self):
         try:
             self.prearm_thread.stop()
-        except:
+        except Exception:
             print("start_prearm not started yet")
         self.prearm_thread = threading.Thread(target=self.process_prearm)
         self.prearm_thread.start()

--- a/Tools/scripts/bin2hex.py
+++ b/Tools/scripts/bin2hex.py
@@ -82,7 +82,7 @@ Options:
                     base = 16
                 try:
                     offset = int(a, base)
-                except:
+                except Exception:
                     raise getopt.GetoptError('Bad offset value')
 
         if not args:

--- a/Tools/scripts/tfminiplus.py
+++ b/Tools/scripts/tfminiplus.py
@@ -13,7 +13,7 @@ import time
 
 try:
     import argcomplete
-except:
+except Exception:
     pass
 
 SYSTEM_RESET  = struct.pack('B' * 4, 0x5A, 0x04, 0x02, 0x60)


### PR DESCRIPTION
Replace bare `except:` clauses with `except Exception:` for PEP 8 compliance.