### PR TITLE
autotest: move logs on test failure in CI

### DIFF
--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -1074,6 +1074,9 @@ if __name__ == "__main__":
     if opts.move_logs_on_test_failure is None:
         opts.move_logs_on_test_failure = opts.autotest_server
 
+    if os.getenv("GITHUB_ACTIONS") == "true":
+        opts.move_logs_on_test_failure = True
+
     steps = [
         'prerequisites',
         'build.Binaries',


### PR DESCRIPTION
# Summary

Correct moving of failure logs on CI failure

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

Recently we changed the defaults such that we didn't move test logs when the tests failed.

We really still want to do that in CI, so make that happen.

I've checked a failed test and the logs are available for download

<img width="2304" height="379" alt="image" src="https://github.com/user-attachments/assets/ebfa8445-bc7d-4ffc-ab6b-3d0f6f4409d3" />

