### PR TITLE
AP_HAL_ChibiOS: SDIO: add hwdef option for 1-bit bus mode

### DIFF
--- a/libraries/AP_HAL_ChibiOS/sdcard.cpp
+++ b/libraries/AP_HAL_ChibiOS/sdcard.cpp
@@ -36,7 +36,7 @@ static bool sdcard_running;
 
 #if HAL_USE_SDC
 static SDCConfig sdcconfig = {
-#if defined(SDIO_BUS_WIDE_1B) && (SDIO_BUS_WIDE_1B == 1)
+#if defined(HAL_SDIO_BUS_WIDE_1B) && (HAL_SDIO_BUS_WIDE_1B == 1)
     SDC_MODE_1BIT,
 #else
     SDC_MODE_4BIT,


### PR DESCRIPTION
# Summary

Add an hwdef-controlled option to force the ChibiOS SDC driver to use 1-bit bus mode.

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [x] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

Some boards (especially custom designs) route only SDIO/SDMMC D0 (or have unreliable D1..D3). This change adds an hwdef-controlled compile-time option to select the bus width used by the ChibiOS SDC driver:

- If `SDIO_BUS_WIDE_1B` is defined in a board hwdef, `SDC_MODE_1BIT` is used.
- Otherwise the existing default `SDC_MODE_4BIT` is kept (no behavior change for existing boards).

This allows boards that require 1-bit operation to enable it via hwdef without affecting other targets.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
