### PR TITLE
AP_Vehicle: Increase RPM Update Rate

### DIFF
--- a/libraries/AP_RPM/RPM_Pin.cpp
+++ b/libraries/AP_RPM/RPM_Pin.cpp
@@ -45,6 +45,14 @@ void AP_RPM_Pin::irq_handler(uint8_t pin, bool pin_state, uint32_t timestamp)
 
 void AP_RPM_Pin::update(void)
 {
+    const uint32_t now_ms = AP_HAL::millis();
+
+    // Rate Limiter to keep pin RPM update rate at 50Hz
+    if (now_ms - last_pubished_ms < 20) {
+        return;
+    }
+    last_pubished_ms = now_ms;
+    
     if (last_pin != get_pin()) {
         // detach from last pin
         if (interrupt_attached) {

--- a/libraries/AP_RPM/RPM_Pin.h
+++ b/libraries/AP_RPM/RPM_Pin.h
@@ -36,6 +36,7 @@ private:
     ModeFilterFloat_Size5 signal_quality_filter {3};
     int8_t last_pin = -1;       // last pin number checked vs PIN parameter
     bool interrupt_attached;    // true if an interrupt has been attached to last_pin
+    uint32_t last_pubished_ms = 0;
     struct IrqState {
         uint32_t last_pulse_us;
         uint32_t dt_sum;

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -663,7 +663,7 @@ const AP_Scheduler::Task AP_Vehicle::scheduler_tasks[] = {
     SCHED_TASK_CLASS(AP_Networking, &vehicle.networking,    update,                   10,  50, 238),
 #endif
 #if AP_RPM_ENABLED
-    SCHED_TASK_CLASS(AP_RPM, &vehicle.rpm_sensor, update,                             50, 100, 239),
+    SCHED_TASK_CLASS(AP_RPM, &vehicle.rpm_sensor, update,                            400, 100, 239),
 #endif
 #if OSD_ENABLED
     SCHED_TASK(publish_osd_info, 1, 10, 240),


### PR DESCRIPTION
# Summary

The purpose of this PR is to increase the RPM update rate from 50Hz to 400Hz to reduce latency and decrease the likelihood of bad RPM readings when paired with appropriate filtering and updates to the RSC library (separate PRs). 

## Testing (more checks increases chance of being merged)

- [ x ] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

Modified AP_Vehicle.cpp if statement that checks for RPM sensor and executes SCHED_TASK_CLASS at the requested rate. This rate was updated from 50Hz to 400Hz
