### PR TITLE
AP_Baro: print message on baro calibration failure

### DIFF
--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -369,10 +369,12 @@ void AP_Baro::calibrate(bool save)
     // panic if all sensors are not calibrated
     uint8_t num_calibrated = 0;
     for (uint8_t i=0; i<_num_sensors; i++) {
+        const char *state = "complete";
         if (sensors[i].calibrated) {
-            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Barometer %u calibration complete", i+1);
             num_calibrated++;
+            state = "failed";
         }
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Barometer %u calibration %s", i+1, state);
     }
     if (num_calibrated) {
         return;


### PR DESCRIPTION
# Summary

Ensures message printed one way or the other after baro calibration

## Testing (more checks increases chance of being merged)

- [X] Checked by a human programmer
- [X] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

While diagnosing a failure for Baros associated with externalahrs to be calibrated I found it confusing when we didn't emit any failure message, just success messages.  If baros fail to calibrate then we get a prearm failure warning about baro unhealthy, but tracing that back to a cause is harder without this patch.
