### PR TITLE
ESP32: Core Stability and Build Environment Fixes (Step 1)

### DIFF
--- a/libraries/AP_Filesystem/posix_compat.cpp
+++ b/libraries/AP_Filesystem/posix_compat.cpp
@@ -22,6 +22,7 @@
   uniform implementation across all platforms
  */
 
+#include <stdio.h>
 #include "AP_Filesystem.h"
 
 #if AP_FILESYSTEM_FATFS_ENABLED || AP_FILESYSTEM_POSIX_ENABLED || AP_FILESYSTEM_ESP32_ENABLED || AP_FILESYSTEM_ROMFS_ENABLED

--- a/libraries/AP_HAL_ESP32/Semaphores.h
+++ b/libraries/AP_HAL_ESP32/Semaphores.h
@@ -17,7 +17,6 @@
 
 #include <stdint.h>
 #include <AP_HAL/AP_HAL_Boards.h>
-#include <AP_HAL/AP_HAL_Macros.h>
 #include <AP_HAL/Semaphores.h>
 #include "HAL_ESP32_Namespace.h"
 #include <freertos/FreeRTOS.h>


### PR DESCRIPTION
This is the first of several planned PRs to modernize the ESP32 build system and improve core stability.

### Focus: Stability & Environment
This PR resolves fundamental issues in the ESP32 port to provide a stable foundation for upcoming infrastructure improvements.

### Changes:
- **Build Environment**: Automated ESP-IDF environment sourcing in `boards.py`. This ensures the xtensa toolchain is found correctly without manual `export.sh` calls by checking common paths and sourcing `export.sh` if found.
- **libc extensions**: Centralized `_GNU_SOURCE` in `boards.py` to enable required features like `vasprintf()` across the build.
- **Circular Inclusions**: Removed redundant board includes from `Semaphores.h` to stabilize the math macro environment and prevent math redefinition errors (specifically fixing QURT/Hexagon build failures).
- **WDT Stability**: Set `idle_core_mask` to 0 in `Scheduler.cpp` to stop monitoring FreeRTOS idle tasks, fixing spurious panics under high CPU load.
- **IDF 6.0 Support**: Added logic to handle the switch from Newlib to PicoLibC in upcoming IDF 6.0 versions.

### Verification:
Builds successfully for:
- `sitl` (Native build)
- `esp32buzz` (Legacy ESP32)
- `CubeOrange` (Ensuring no cross-platform regressions)