### PR TITLE
AP_RCProtocol: Remove unused citations

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol_DroneCAN.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_DroneCAN.cpp
@@ -7,8 +7,6 @@
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include "AP_RCProtocol_DroneCAN.h"
 
-extern const AP_HAL::HAL& hal;
-
 #define LOG_TAG "RCInput"
 
 AP_RCProtocol_DroneCAN::Registry AP_RCProtocol_DroneCAN::registry;


### PR DESCRIPTION
# Summary

AP_RCProtocol: remove unused hal reference in DroneCAN

## Testing (more checks increases chance of being merged)

- [X] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

This PR removes the extern const AP_HAL::HAL& hal; declaration in AP_RCProtocol_DroneCAN.cpp as it is not used anywhere in the file. This is a minor cleanup to reduce unnecessary declarations and improve code maintainability.