### PR TITLE
AP_AHRS: use horizontal wind speed for heading consistency check

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -488,7 +488,7 @@ bool AP_AHRS_DCM::use_compass(void)
     // ground speed, then switch to GPS navigation. This will help
     // prevent flyaways with very bad compass offsets
     const float error = fabsf(wrap_180(degrees(yaw) - AP::gps().ground_course()));
-    if (error > 45 && _wind.length() < AP::gps().ground_speed()*0.8f) {
+    if (error > 45 && _wind.xy().length() < AP::gps().ground_speed()*0.8f) {
         if (AP_HAL::millis() - _last_consistent_heading > 2000) {
             // start using the GPS for heading if the compass has been
             // inconsistent with the GPS for 2 seconds


### PR DESCRIPTION
# Summary

Use the horizontal (2D) wind speed component for AHRS heading consistency checks and MAVLink telemetry to ensure dimensional consistency with ground speed.

## Testing (more checks increases chance of being merged)

- [X] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

This PR changes the wind speed calculation from 3D length() to 2D xy().length() in AP_AHRS_DCM and GCS_MAVLink.

The primary motivation is to align the wind speed measurement with the GPS ground speed, which is a horizontal (2D) vector. In the current implementation of use_compass(), comparing a 3D wind vector (which includes vertical components) against a 2D ground speed can introduce inaccuracies, especially in environments with significant vertical airflow.

By isolating the horizontal wind component:

Consistency Check: The "bad compass" detection logic becomes more robust by comparing like-for-like horizontal velocities.

Telemetry: MAVLink wind telemetry becomes more consistent with expected horizontal wind values, avoiding the inclusion of vertical gusts in the primary wind speed field.

This is a logical refinement to ensure physical consistency in the AHRS and GCS libraries.