### PR TITLE
AP_HAL_ChibiOS: fix -Woverloaded-virtual warning with GCC 15.2.1

### DIFF
--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -112,6 +112,9 @@ public:
     /*
       timer push (for oneshot min rate)
      */
+#if defined(__GNUC__) && (__GNUC__ >= 15)
+    using AP_HAL::RCOutput::timer_tick;
+#endif
     void timer_tick(rcout_timer_t cycle_start_us, rcout_timer_t timeout_period_us);
 
     /*


### PR DESCRIPTION
# Summary

This PR fixes a -Woverloaded-virtual compiler warning in the ChibiOS RCOutput backend when building with GCC 15.2.1.

## Testing (more checks increases chance of being merged)

- [X] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

When building with the ARM GNU Toolchain 15.2.rel1 (GCC 15.2.1), the compiler emits a warning regarding AP_HAL::RCOutput::timer_tick() being hidden by the overloaded version in ChibiOS::RCOutput.

In C++, defining a function in a derived class with the same name but different parameters hides all other versions of that function from the base class. This PR resolves the issue by adding a using declaration in libraries/AP_HAL_ChibiOS/RCOutput.h to explicitly bring the base class's timer_tick into the scope of the derived class.

This ensures compatibility with newer compiler versions while maintaining the existing functionality for ChibiOS-based boards.

```xml

../../libraries/AP_HAL/RCOutput.h:172:18: warning: 'virtual void AP_HAL::RCOutput::timer_tick()' was hidden [-Woverloaded-virtual=]
  172 |     virtual void timer_tick(void) { }
      |                  ^~~~~~~~~~
../../libraries/AP_HAL_ChibiOS/RCOutput.h:115:10: note:   by 'void ChibiOS::RCOutput::timer_tick(rcout_timer_t, rcout_timer_t)'
  115 |     void timer_tick(rcout_timer_t cycle_start_us, rcout_timer_t timeout_period_us);
      |          ^~~~~~~~~~

```
