### PR TITLE
Plane: change WAIT_AIRSPEED condition from pitch to min_airspeed_alt and pitch both

### DIFF
--- a/ArduPlane/pullup.cpp
+++ b/ArduPlane/pullup.cpp
@@ -99,6 +99,7 @@ bool GliderPullup::pullup_start(void)
     if (!plane.ahrs.airspeed_EAS(aspeed)) {
         aspeed = -1;
     }
+    release_alt = plane.current_loc.alt*0.01;
     gcs().send_text(MAV_SEVERITY_INFO, "Start pullup airspeed %.1fm/s at %.1fm AMSL", aspeed, plane.current_loc.alt*0.01);
     return true;
 }
@@ -115,7 +116,8 @@ bool GliderPullup::verify_pullup(void)
     switch (stage) {
     case Stage::WAIT_AIRSPEED: {
         float aspeed;
-        if (ahrs.airspeed_EAS(aspeed) && (aspeed > airspeed_start || ahrs.get_pitch_deg() > pitch_start)) {
+        bool min_fallen_alt = (release_alt - current_loc.alt*0.01) > 2.0f;
+        if (ahrs.airspeed_EAS(aspeed) && (aspeed > airspeed_start || (min_fallen_alt && ahrs.pitch_sensor*0.01 > pitch_start))) {
             gcs().send_text(MAV_SEVERITY_INFO, "Pullup airspeed %.1fm/s alt %.1fm AMSL", aspeed, current_loc.alt*0.01);
             stage = Stage::WAIT_PITCH;
         }

--- a/ArduPlane/pullup.h
+++ b/ArduPlane/pullup.h
@@ -44,6 +44,7 @@ private:
     AP_Float ng_jerk_limit;
     AP_Float pitch_dem;
     float ng_demand;
+    float release_alt;
 };
 
 #endif // AP_PLANE_GLIDER_PULLUP_ENABLED


### PR DESCRIPTION
# Summary

This pull request forces a minimal wait time of if the glider was falling down like a rock with no drag, after which the state machine moves onto the next phase.

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [x] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

This pull request attempts to implement a slightly better solution (than [this one](1c194878ee6d527ba30cc35c44d4780f79dbc1cc)) for the glider pull up state machine being in wait airspeed forever, in case of bad pitch trim where the glider pulls up before the `airspeed_start` is reached. As described in [this issue](https://github.com/ArduPilot/ardupilot/issues/28712), in some cases, the pull up starts at significantly lower airspeeds. This also accounts for the problem pointed out in the comment [here](https://github.com/ArduPilot/ardupilot/pull/28259/changes#r1780169313) by @tridge , to make sure the state machine does not get stuck in the `WAIT_AIRSPEED` for too long in case of a bad release.

A new variable `min_fallen_alt` will be used to make sure that the glider has been successfully released from the balloon to make sure the state machine does not simply move ahead on pitch value alone.

This pull request passes the AutoTest for GliderPullup.

<img width="921" height="572" alt="image" src="https://github.com/user-attachments/assets/ee6a88e5-0dea-4a54-9a08-0c505df6d042" />


