### PR TITLE
AP_AHRS: Ensure checking of the return value of ahrs.get_variances()

### DIFF
--- a/ArduCopter/AP_Arming_Copter.cpp
+++ b/ArduCopter/AP_Arming_Copter.cpp
@@ -492,7 +492,10 @@ bool AP_Arming_Copter::mandatory_position_checks(bool display_failure)
     if (copter.g.fs_ekf_thresh > 0.0f) {
         float vel_variance, pos_variance, hgt_variance, tas_variance;
         Vector3f mag_variance;
-        ahrs.get_variances(vel_variance, pos_variance, hgt_variance, mag_variance, tas_variance);
+        if (!ahrs.get_variances(vel_variance, pos_variance, hgt_variance, mag_variance, tas_variance)) {
+            check_failed(display_failure, "Failed to get AHRS variances");
+            return false;
+        }
         const struct {
             const char *name;
             float value;

--- a/ArduSub/failsafe.cpp
+++ b/ArduSub/failsafe.cpp
@@ -112,10 +112,10 @@ void Sub::failsafe_ekf_check()
     Vector3f magVar;
     float compass_variance;
     float vel_variance;
-    ahrs.get_variances(vel_variance, posVar, hgtVar, magVar, tasVar);
-    compass_variance = magVar.length();
+    bool variances_valid = ahrs.get_variances(vel_variance, posVar, hgtVar, magVar, tasVar);
 
-    if (compass_variance < g.fs_ekf_thresh && vel_variance < g.fs_ekf_thresh) {
+    compass_variance = magVar.length();
+    if (variances_valid && compass_variance < g.fs_ekf_thresh && vel_variance < g.fs_ekf_thresh) {
         last_ekf_good_ms = AP_HAL::millis();
         failsafe.ekf = false;
         AP_Notify::flags.ekf_bad = false;
@@ -542,7 +542,7 @@ void Sub::failsafe_radio_on_event()
             break;
         case FS_THR_DISABLED:
             break;
-    }    
+    }
 }
 
 // failsafe_radio_off event- respond to radio contact being regained

--- a/Blimp/ekf_check.cpp
+++ b/Blimp/ekf_check.cpp
@@ -110,7 +110,9 @@ bool Blimp::ekf_over_threshold()
     // use EKF to get variance
     float position_variance, vel_variance, height_variance, tas_variance;
     Vector3f mag_variance;
-    ahrs.get_variances(vel_variance, position_variance, height_variance, mag_variance, tas_variance);
+    if (!ahrs.get_variances(vel_variance, position_variance, height_variance, mag_variance, tas_variance)) {
+        return true;
+    }
 
     const float mag_max = fmaxf(fmaxf(mag_variance.x,mag_variance.y),mag_variance.z);
 

--- a/Rover/ekf_check.cpp
+++ b/Rover/ekf_check.cpp
@@ -105,7 +105,9 @@ bool Rover::ekf_over_threshold()
     // use EKF to get variance
     float position_variance, vel_variance, height_variance, tas_variance;
     Vector3f mag_variance;
-    ahrs.get_variances(vel_variance, position_variance, height_variance, mag_variance, tas_variance);
+    if(!ahrs.get_variances(vel_variance, position_variance, height_variance, mag_variance, tas_variance)) {
+        return true;
+    }
 
     // return true if two of compass, velocity and position variances are over the threshold
     uint8_t over_thresh_count = 0;
@@ -128,7 +130,7 @@ bool Rover::ekf_over_threshold()
     } else if (vel_variance >= g.fs_ekf_thresh) {
         over_thresh_count++;
     }
-    
+
     if (over_thresh_count >= 2) {
         return true;
     }

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -427,7 +427,7 @@ public:
     // indicates perfect consistency between the measurement and the EKF solution and a value of 1 is the maximum
     // inconsistency that will be accepted by the filter
     // boolean false is returned if variances are not available
-    bool get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar) const {
+    bool get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar) const WARN_IF_UNUSED {
         velVar = configured_estimates->velVar;
         posVar = configured_estimates->posVar;
         hgtVar = configured_estimates->hgtVar;


### PR DESCRIPTION
# Summary

The implementation of `get_variances()` can return `false`, particularly with `ExternalAHRS`.  This fixes an issue where random memory is read in as variances in this condition.

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

Checks return code from `get_variances()` before reading the values set by the call.