### PR TITLE
AP_AHRS_External: Add missing override AP_AHRS_External::get_variances()

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_External.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_External.cpp
@@ -114,6 +114,11 @@ bool AP_AHRS_External::get_filter_status(nav_filter_status &status) const
     return true;
 }
 
+bool AP_AHRS_External::get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar) const
+{
+    return AP::externalAHRS().get_variances(velVar, posVar, hgtVar, magVar, tasVar);
+}
+
 void AP_AHRS_External::send_ekf_status_report(GCS_MAVLINK &link) const
 {
     AP::externalAHRS().send_status_report(link);

--- a/libraries/AP_AHRS/AP_AHRS_External.h
+++ b/libraries/AP_AHRS/AP_AHRS_External.h
@@ -75,6 +75,7 @@ public:
     bool get_relative_position_D_origin(postype_t &posD) const override;
 
     bool get_filter_status(nav_filter_status &status) const override;
+    bool get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar) const override;
     void send_ekf_status_report(class GCS_MAVLINK &link) const override;
 
     void get_control_limits(float &ekfGndSpdLimit, float &controlScaleXY) const override;


### PR DESCRIPTION
# Summary

This adds a missing override to `AP_AHRS_External::get_variances()`, which would otherwise default to returning `false`.

Related to #32363

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

In some call paths a call to `AP_AHRS_External::get_variances()` is made, which instead of going to the referenced `AP_ExternalAHRS` object, base `AP_AHRS_Backend::get_variances()` is called which simply returns `false`.

Before #32363 this call's return value will get ignored and random data will be used for the variances.

After #32363, this would return `false` and fail the `mandatory_position_checks()` call, preventing mission launch.