### PR TITLE
AP_AHRS: don't use recorded origin when sources require GPS

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -1554,6 +1554,14 @@ void AP_AHRS::use_recorded_origin_maybe()
         return;
     }
 
+    // don't use recorded origin if sources require GPS — GPS will set
+    // a correct origin when it becomes available. Using the recorded
+    // origin here would prevent GPS from setting it later (EKF origin
+    // is immutable once set).
+    if (using_gps()) {
+        return;
+    }
+
     // try to set origin
     const Location loc {
         int32_t(_origin_lat.get() * 1e7),


### PR DESCRIPTION
## Summary
- When EKF sources are configured to use GPS, skip setting the origin from `AHRS_ORIGIN` parameters
- The EKF origin is immutable once set, so using the recorded origin before GPS gets a fix prevents GPS from later setting the correct origin
- GPS-denied configurations (sources set to None) still use the recorded origin as before

## Test plan
- [ ] SITL test with GPS sources configured: verify origin is not set from AHRS_ORIGIN params, and GPS sets the origin on fix
- [ ] SITL test with sources set to None: verify recorded origin is still used
- [ ] Build check: `./waf copter`