### PR TITLE
AntennaTracker: cork PWM outputs

### DIFF
--- a/AntennaTracker/mode_servotest.cpp
+++ b/AntennaTracker/mode_servotest.cpp
@@ -18,6 +18,8 @@ bool ModeServoTest::set_servo(uint8_t servo_num, uint16_t pwm)
         return false;
     }
 
+    hal.rcout->cork();
+
     // set yaw servo pwm and send output to servo
     if (servo_num == CH_YAW) {
         SRV_Channels::set_output_pwm(SRV_Channel::k_tracker_yaw, pwm);
@@ -32,7 +34,9 @@ bool ModeServoTest::set_servo(uint8_t servo_num, uint16_t pwm)
 
     SRV_Channels::calc_pwm();
     SRV_Channels::output_ch_all();
-    
+
+    hal.rcout->push();
+
     // return success
     return true;
 }

--- a/AntennaTracker/tracking.cpp
+++ b/AntennaTracker/tracking.cpp
@@ -103,6 +103,9 @@ void Tracker::update_tracking(void)
     if (hal.util->safety_switch_state() == AP_HAL::Util::SAFETY_DISARMED) {
         return;
     }
+
+    hal.rcout->cork();
+
     // do not move if we are not armed:
     if (!hal.util->get_soft_armed()) {
         switch ((PWMDisarmed)g.disarm_pwm.get()) {
@@ -123,6 +126,9 @@ void Tracker::update_tracking(void)
     // convert servo_out to radio_out and send to servo
     SRV_Channels::calc_pwm();
     SRV_Channels::output_ch_all();
+
+    hal.rcout->push();
+
     return;
 }
 


### PR DESCRIPTION
# Summary

Cork PWM outputs during tracker servo updates.

## Testing (more checks increases chance of being merged)

- [X] Checked by a human programmer
- [X] Tested in SITL
- [X] Tested on hardware
- [X] Logs attached
- [X] Logs available on request
- [ ] Autotest included

## Description

Tracker is outputting PWM several times per loop in certain modes. In particular `MANUAL` first sets the PWM, then runs it on a contraint, then goes to scaled values recalculation an re-outputs everything. This causes PWM being set at least twice in a rapid succession. On the face of it, not a big deal, but at least in Linux HAL the behavior is at the mercy of the kernel implementation of PWM setup. A particular case is NXP hardware where the kernel driver locks on a FIFO and also has additional logic which may cause long sleeping up to a whole PWM period. The end result is that setting a 2000 µs PWM on a servo limited to 1900 µs causes it to constantly twitch an the entirety of the main loop falls apart too. The kernel also ignores `O_NONBLOCK` on PWM sysfs entries which could be a clean-ish solution. E.g. (extra `printfs` added):
```
Tracker::update_tracking enter
channel 0 pwm 2000 set
HAL: channel 0 pwm 2000 set
HAL write: 27590 usec
channel 1 pwm 0 set
HAL: channel 1 pwm 0 set
HAL write: 13 usec
Tracker::update_tracking calc_pwm()
channel 0 pwm 1900 set
HAL: channel 0 pwm 1900 set
HAL write: 27911 usec
channel 1 pwm 1100 set
HAL: channel 1 pwm 1100 set
HAL write: 9 usec
channel 2 pwm 0 set
HAL: channel 2 pwm 0 set
HAL write: 5 usec
channel 3 pwm 0 set
HAL: channel 3 pwm 0 set
HAL write: 5 usec
Tracker::update_tracking exit(normal)
```

The PR doesn't really change much in terms of behavior of the system but ensures there won't be any PWM double-tapping and only the final value after all scalings and constrainings is ever sent to HAL.
