### PR TITLE
Copter: fix Ch6 WP speed tuning overshoot on first mission leg

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -593,6 +593,7 @@ public:
     void circle_movetoedge_start(const Location &circle_center, float radius_m, bool ccw_turn);
     void circle_start();
     void nav_guided_start();
+    void do_wp_speed_change(float speed_cms);
 
     bool is_landing() const override;
 

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -2445,4 +2445,10 @@ float ModeAuto::get_alt_above_ground_m() const
     return Mode::get_alt_above_ground_m();
 }
 
+void ModeAuto::do_wp_speed_change(float speed_cms)
+{
+    wp_nav->set_speed_NE_cms(speed_cms);
+    desired_speed_override_ms.xy = speed_cms * 0.01f;
+}
+
 #endif

--- a/ArduCopter/tuning.cpp
+++ b/ArduCopter/tuning.cpp
@@ -126,6 +126,11 @@ void Copter::tuning(const RC_Channel *tuning_ch, int8_t tuning_param, float tuni
 
     case TUNING_WP_SPEED:
         wp_nav->set_speed_NE_cms(tuning_value);
+        
+        if (flightmode->mode_number() == Mode::Number::AUTO) {
+            mode_auto.do_wp_speed_change(tuning_value);
+        }
+        
         break;
 
 #if MODE_ACRO_ENABLED || MODE_SPORT_ENABLED


### PR DESCRIPTION

Copter: ensure WP speed tuning applies on first mission leg

WP speed tuning was not taking effect on the first mission leg because
do_wp_speed_change() was not updating desired_speed_override_ms.xy,
causing wp_nav to fall back to the default speed on initialization.

Fixed by updating desired_speed_override_ms.xy in do_wp_speed_change().

Fixes #31584