### PR TITLE
SRV_Channel: Slew limit: always allocate even if disabled

### DIFF
--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -813,10 +813,9 @@ void SRV_Channels::set_slew_rate(SRV_Channel::Function function, float slew_rate
         }
     }
 
-    if (!is_positive(max_change)) {
-        // no point in adding a disabled slew limit
-        return;
-    }
+    // The slew limit is still allocated even if the slew rate is 0 for disabled.
+    // This means that if the slew limit is changed at some point in the future we still have
+    // a valid last output to slew from.
 
     // add new item
     slew_list *new_slew = NEW_NOTHROW slew_list(function);


### PR DESCRIPTION
Fixes #32377, see explanation comment: https://github.com/ArduPilot/ardupilot/issues/32377#issuecomment-4009738799

Currently slew is bypassed: 

<img width="1068" height="507" alt="image" src="https://github.com/user-attachments/assets/dbc1966f-115c-498f-9226-5fdd7fe9cc35" />

With this patch:

<img width="1068" height="507" alt="image" src="https://github.com/user-attachments/assets/41aa949b-89a8-4bfb-a5c5-7548e3309414" />

The `set_slew_rate` function is only used by plane. Assuming there is a slew rate set either in `TKOFF_THR_SLEW` or `THR_SLEWRATE` then the slew limiter will get allocated eventually. So there is not any real loss in memory to allocate them immediately.