### PR TITLE
AP_BattMonitor: add option for voltage-curve-based battery percentage calculation

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
@@ -17,10 +17,10 @@
 
 #if AP_BATTERY_ENABLED
 
-#include <AP_Common/AP_Common.h>
-#include <AP_HAL/AP_HAL.h>
 #include "AP_BattMonitor.h"
 #include "AP_BattMonitor_Backend.h"
+#include <AP_Common/AP_Common.h>
+#include <AP_HAL/AP_HAL.h>
 
 #if AP_BATTERY_ESC_TELEM_OUTBOUND_ENABLED
 #include "AP_ESC_Telem/AP_ESC_Telem.h"
@@ -36,9 +36,8 @@
     20:     AP_BattMonitor_Sum.cpp
     22-24:  AP_BattMonitor_INA3221.cpp
     25-26:  AP_BattMonitor_INA2xx.cpp
-    27-28:  AP_BattMonitor_INA2xx.cpp, AP_BattMonitor_INA239.cpp (legacy duplication)
-    30:     AP_BattMonitor_DroneCAN.cpp
-    36:     AP_BattMonitor_ESC.cpp
+    27-28:  AP_BattMonitor_INA2xx.cpp, AP_BattMonitor_INA239.cpp (legacy
+  duplication) 30:     AP_BattMonitor_DroneCAN.cpp 36: AP_BattMonitor_ESC.cpp
     40-43:  AP_BattMonitor_FuelLevel_Analog.cpp
     45-48:  AP_BattMonitor_FuelLevel_Analog.cpp
     50-51:  AP_BattMonitor_Synthetic_Current.cpp
@@ -51,283 +50,377 @@
   base class constructor.
   This incorporates initialisation as well.
 */
-AP_BattMonitor_Backend::AP_BattMonitor_Backend(AP_BattMonitor &mon, AP_BattMonitor::BattMonitor_State &mon_state,
-                                               AP_BattMonitor_Params &params) :
-        _mon(mon),
-        _state(mon_state),
-        _params(params)
-{
+AP_BattMonitor_Backend::AP_BattMonitor_Backend(
+    AP_BattMonitor &mon, AP_BattMonitor::BattMonitor_State &mon_state,
+    AP_BattMonitor_Params &params)
+    : _mon(mon), _state(mon_state), _params(params) {
+  _voltage_pct_filt = 0.0f;
+  _voltage_pct_timer_ms = 0;
 }
 
-// capacity_remaining_pct - returns true if the battery % is available and writes to the percentage argument
-// return false if the battery is unhealthy, does not have current monitoring, or the pack_capacity is too small
-bool AP_BattMonitor_Backend::capacity_remaining_pct(uint8_t &percentage) const
-{
-    // we consider anything under 10 mAh as being an invalid capacity and so will be our measurement of remaining capacity
-    if ( _params._pack_capacity <= 10) {
-        return false;
+// capacity_remaining_pct - returns true if the battery % is available and
+// writes to the percentage argument return false if the battery is unhealthy,
+// does not have current monitoring, or the pack_capacity is too small
+bool AP_BattMonitor_Backend::capacity_remaining_pct(uint8_t &percentage) const {
+  // Handle voltage-curve calculation
+  if (_params._pct_type == 1) {
+    if (!_state.healthy) {
+      return false;
     }
 
-    // the monitor must have current readings in order to estimate consumed_mah and be healthy
-    if (!has_current() || !_state.healthy) {
-        return false;
-    }
-    if (isnan(_state.consumed_mah) || _params._pack_capacity <= 0) {
-        return false;
+    const float v = _voltage_pct_filt;
+    const float volt_0 = _params._volt_0;
+    const float volt_25 = _params._volt_25;
+    const float volt_50 = _params._volt_50;
+    const float volt_75 = _params._volt_75;
+    const float volt_100 = _params._volt_100;
+
+    // Check if the curve is strictly monotonic and non-zero
+    if (volt_0 > 0.0f && volt_25 > volt_0 && volt_50 > volt_25 &&
+        volt_75 > volt_50 && volt_100 > volt_75) {
+
+      float pct;
+      if (v <= volt_0) {
+        pct = 0.0f;
+      } else if (v <= volt_25) {
+        pct = 25.0f * (v - volt_0) / (volt_25 - volt_0);
+      } else if (v <= volt_50) {
+        pct = 25.0f + 25.0f * (v - volt_25) / (volt_50 - volt_25);
+      } else if (v <= volt_75) {
+        pct = 50.0f + 25.0f * (v - volt_50) / (volt_75 - volt_50);
+      } else if (v <= volt_100) {
+        pct = 75.0f + 25.0f * (v - volt_75) / (volt_100 - volt_75);
+      } else {
+        pct = 100.0f;
+      }
+
+      percentage = constrain_float(pct, 0, UINT8_MAX);
+      return true;
     }
 
-    const float mah_remaining = _params._pack_capacity - _state.consumed_mah;
-    percentage = constrain_float(100 * mah_remaining / _params._pack_capacity, 0, UINT8_MAX);
-    return true;
+    // Configuration error, fall back to mAh if configured, or just return false
+    return false;
+  }
+
+  // Default mAh/coulomb counting
+  // we consider anything under 10 mAh as being an invalid capacity and so will
+  // be our measurement of remaining capacity
+  if (_params._pack_capacity <= 10) {
+    return false;
+  }
+
+  // the monitor must have current readings in order to estimate consumed_mah
+  // and be healthy
+  if (!has_current() || !_state.healthy) {
+    return false;
+  }
+  if (isnan(_state.consumed_mah) || _params._pack_capacity <= 0) {
+    return false;
+  }
+
+  const float mah_remaining = _params._pack_capacity - _state.consumed_mah;
+  percentage = constrain_float(100 * mah_remaining / _params._pack_capacity, 0,
+                               UINT8_MAX);
+  return true;
 }
 
 // update battery resistance estimate
-// faster rates of change of the current and voltage readings cause faster updates to the resistance estimate
-// the battery resistance is calculated by comparing the latest current and voltage readings to a low-pass filtered current and voltage
-// high current steps are integrated into the resistance estimate by varying the time constant of the resistance filter
-void AP_BattMonitor_Backend::update_resistance_estimate()
-{
-    // return immediately if no current
-    if (!has_current() || !is_positive(_state.current_amps)) {
-        return;
-    }
+// faster rates of change of the current and voltage readings cause faster
+// updates to the resistance estimate the battery resistance is calculated by
+// comparing the latest current and voltage readings to a low-pass filtered
+// current and voltage high current steps are integrated into the resistance
+// estimate by varying the time constant of the resistance filter
+void AP_BattMonitor_Backend::update_resistance_estimate() {
+  // Calculate filtered voltage for percentage estimation
+  uint32_t now = AP_HAL::millis();
+  const float dt = (now - _voltage_pct_timer_ms) * 0.001f;
+  _voltage_pct_timer_ms = now;
 
-    // update maximum current seen since startup and protect against divide by zero
-    _current_max_amps = MAX(_current_max_amps, _state.current_amps);
-    float current_delta = _state.current_amps - _current_filt_amps;
-    if (is_zero(current_delta)) {
-        return;
-    }
+  const float input_voltage =
+      option_is_set(AP_BattMonitor_Params::Options::Pct_Use_Resting_Voltage)
+          ? voltage_resting_estimate()
+          : _state.voltage;
+  const float tc = MAX(0.1f, _params._volt_pct_tc.get());
+  const float alpha = constrain_float(dt / (dt + tc), 0.0f, 1.0f);
 
-    // update reference voltage and current
-    if (_state.voltage > _resistance_voltage_ref) {
-        _resistance_voltage_ref = _state.voltage;
-        _resistance_current_ref = _state.current_amps;
-    }
+  if (_voltage_pct_filt < 0.1f) {
+    _voltage_pct_filt = input_voltage;
+  } else {
+    _voltage_pct_filt += (input_voltage - _voltage_pct_filt) * alpha;
+  }
 
-    // calculate time since last update
-    uint32_t now = AP_HAL::millis();
-    float loop_interval = (now - _resistance_timer_ms) * 0.001f;
-    _resistance_timer_ms = now;
+  // return immediately if no current
+  if (!has_current() || !is_positive(_state.current_amps)) {
+    return;
+  }
 
-    // estimate short-term resistance
-    float filt_alpha = constrain_float(loop_interval/(loop_interval + AP_BATT_MONITOR_RES_EST_TC_1), 0.0f, 0.5f);
-    float resistance_alpha = MIN(1, AP_BATT_MONITOR_RES_EST_TC_2*fabsf((_state.current_amps-_current_filt_amps)/_current_max_amps));
-    float resistance_estimate = -(_state.voltage-_voltage_filt)/current_delta;
-    if (is_positive(resistance_estimate)) {
-        _state.resistance = _state.resistance*(1-resistance_alpha) + resistance_estimate*resistance_alpha;
-    }
+  // update maximum current seen since startup and protect against divide by
+  // zero
+  _current_max_amps = MAX(_current_max_amps, _state.current_amps);
+  float current_delta = _state.current_amps - _current_filt_amps;
+  if (is_zero(current_delta)) {
+    return;
+  }
 
-    // calculate maximum resistance
-    if ((_resistance_voltage_ref > _state.voltage) && (_state.current_amps > _resistance_current_ref)) {
-        float resistance_max = (_resistance_voltage_ref - _state.voltage) / (_state.current_amps - _resistance_current_ref);
-        _state.resistance = MIN(_state.resistance, resistance_max);
-    }
+  // update reference voltage and current
+  if (_state.voltage > _resistance_voltage_ref) {
+    _resistance_voltage_ref = _state.voltage;
+    _resistance_current_ref = _state.current_amps;
+  }
 
-    // update the filtered voltage and currents
-    _voltage_filt = _voltage_filt*(1-filt_alpha) + _state.voltage*filt_alpha;
-    _current_filt_amps = _current_filt_amps*(1-filt_alpha) + _state.current_amps*filt_alpha;
+  // calculate time since last update
+  now = AP_HAL::millis();
+  float loop_interval = (now - _resistance_timer_ms) * 0.001f;
+  _resistance_timer_ms = now;
 
-    // update estimated voltage without sag
-    _state.voltage_resting_estimate = _state.voltage + _state.current_amps * _state.resistance;
+  // estimate short-term resistance
+  float filt_alpha = constrain_float(
+      loop_interval / (loop_interval + AP_BATT_MONITOR_RES_EST_TC_1), 0.0f,
+      0.5f);
+  float resistance_alpha =
+      MIN(1, AP_BATT_MONITOR_RES_EST_TC_2 *
+                 fabsf((_state.current_amps - _current_filt_amps) /
+                       _current_max_amps));
+  float resistance_estimate = -(_state.voltage - _voltage_filt) / current_delta;
+  if (is_positive(resistance_estimate)) {
+    _state.resistance = _state.resistance * (1 - resistance_alpha) +
+                        resistance_estimate * resistance_alpha;
+  }
+
+  // calculate maximum resistance
+  if ((_resistance_voltage_ref > _state.voltage) &&
+      (_state.current_amps > _resistance_current_ref)) {
+    float resistance_max = (_resistance_voltage_ref - _state.voltage) /
+                           (_state.current_amps - _resistance_current_ref);
+    _state.resistance = MIN(_state.resistance, resistance_max);
+  }
+
+  // update the filtered voltage and currents
+  _voltage_filt =
+      _voltage_filt * (1 - filt_alpha) + _state.voltage * filt_alpha;
+  _current_filt_amps =
+      _current_filt_amps * (1 - filt_alpha) + _state.current_amps * filt_alpha;
+
+  // update estimated voltage without sag
+  _state.voltage_resting_estimate =
+      _state.voltage + _state.current_amps * _state.resistance;
 }
 
 // return true if state of health can be provided and fills in soh_pct argument
-bool AP_BattMonitor_Backend::get_state_of_health_pct(uint8_t &soh_pct) const
-{
-    if (!_state.has_state_of_health_pct) {
-        return false;
-    }
-    soh_pct = _state.state_of_health_pct;
-    return true;
+bool AP_BattMonitor_Backend::get_state_of_health_pct(uint8_t &soh_pct) const {
+  if (!_state.has_state_of_health_pct) {
+    return false;
+  }
+  soh_pct = _state.state_of_health_pct;
+  return true;
 }
 
-float AP_BattMonitor_Backend::voltage_resting_estimate() const
-{
-    // resting voltage should always be greater than or equal to the raw voltage
-    return MAX(_state.voltage, _state.voltage_resting_estimate);
+float AP_BattMonitor_Backend::voltage_resting_estimate() const {
+  // resting voltage should always be greater than or equal to the raw voltage
+  return MAX(_state.voltage, _state.voltage_resting_estimate);
 }
 
-AP_BattMonitor::Failsafe AP_BattMonitor_Backend::update_failsafes(void)
-{
-    const uint32_t now = AP_HAL::millis();
+AP_BattMonitor::Failsafe AP_BattMonitor_Backend::update_failsafes(void) {
+  const uint32_t now = AP_HAL::millis();
 
-    bool low_voltage, low_capacity, critical_voltage, critical_capacity;
-    check_failsafe_types(low_voltage, low_capacity, critical_voltage, critical_capacity);
+  bool low_voltage, low_capacity, critical_voltage, critical_capacity;
+  check_failsafe_types(low_voltage, low_capacity, critical_voltage,
+                       critical_capacity);
 
-    if (critical_voltage) {
-        // this is the first time our voltage has dropped below minimum so start timer
-        if (_state.critical_voltage_start_ms == 0) {
-            _state.critical_voltage_start_ms = now;
-        } else if (_params._low_voltage_timeout > 0 &&
-                   now - _state.critical_voltage_start_ms > uint32_t(_params._low_voltage_timeout)*1000U) {
-            return AP_BattMonitor::Failsafe::Critical;
-        }
-    } else {
-        // acceptable voltage so reset timer
-        _state.critical_voltage_start_ms = 0;
+  if (critical_voltage) {
+    // this is the first time our voltage has dropped below minimum so start
+    // timer
+    if (_state.critical_voltage_start_ms == 0) {
+      _state.critical_voltage_start_ms = now;
+    } else if (_params._low_voltage_timeout > 0 &&
+               now - _state.critical_voltage_start_ms >
+                   uint32_t(_params._low_voltage_timeout) * 1000U) {
+      return AP_BattMonitor::Failsafe::Critical;
     }
+  } else {
+    // acceptable voltage so reset timer
+    _state.critical_voltage_start_ms = 0;
+  }
 
-    if (critical_capacity) {
-        return AP_BattMonitor::Failsafe::Critical;
+  if (critical_capacity) {
+    return AP_BattMonitor::Failsafe::Critical;
+  }
+
+  if (low_voltage) {
+    // this is the first time our voltage has dropped below minimum so start
+    // timer
+    if (_state.low_voltage_start_ms == 0) {
+      _state.low_voltage_start_ms = now;
+    } else if (_params._low_voltage_timeout > 0 &&
+               now - _state.low_voltage_start_ms >
+                   uint32_t(_params._low_voltage_timeout) * 1000U) {
+      return AP_BattMonitor::Failsafe::Low;
     }
+  } else {
+    // acceptable voltage so reset timer
+    _state.low_voltage_start_ms = 0;
+  }
 
-    if (low_voltage) {
-        // this is the first time our voltage has dropped below minimum so start timer
-        if (_state.low_voltage_start_ms == 0) {
-            _state.low_voltage_start_ms = now;
-        } else if (_params._low_voltage_timeout > 0 &&
-                   now - _state.low_voltage_start_ms > uint32_t(_params._low_voltage_timeout)*1000U) {
-            return AP_BattMonitor::Failsafe::Low;
-        }
-    } else {
-        // acceptable voltage so reset timer
-        _state.low_voltage_start_ms = 0;
-    }
+  if (low_capacity) {
+    return AP_BattMonitor::Failsafe::Low;
+  }
 
-    if (low_capacity) {
-        return AP_BattMonitor::Failsafe::Low;
-    }
+  // 5 second health timeout
+  if ((now - _state.last_healthy_ms) > 5000) {
+    return AP_BattMonitor::Failsafe::Unhealthy;
+  }
 
-    // 5 second health timeout
-    if ((now - _state.last_healthy_ms) > 5000) {
-        return AP_BattMonitor::Failsafe::Unhealthy;
-    }
-
-    // if we've gotten this far then battery is ok
-    return AP_BattMonitor::Failsafe::None;
+  // if we've gotten this far then battery is ok
+  return AP_BattMonitor::Failsafe::None;
 }
 
-static bool update_check(size_t buflen, char *buffer, bool failed, const char *message)
-{
-    if (failed) {
-        strncpy(buffer, message, buflen);
-        return false;
-    }
-    return true;
+static bool update_check(size_t buflen, char *buffer, bool failed,
+                         const char *message) {
+  if (failed) {
+    strncpy(buffer, message, buflen);
+    return false;
+  }
+  return true;
 }
 
-bool AP_BattMonitor_Backend::arming_checks(char * buffer, size_t buflen) const
-{
-    bool low_voltage, low_capacity, critical_voltage, critical_capacity;
-    check_failsafe_types(low_voltage, low_capacity, critical_voltage, critical_capacity);
+bool AP_BattMonitor_Backend::arming_checks(char *buffer, size_t buflen) const {
+  bool low_voltage, low_capacity, critical_voltage, critical_capacity;
+  check_failsafe_types(low_voltage, low_capacity, critical_voltage,
+                       critical_capacity);
 
-    bool below_arming_voltage = is_positive(_params._arming_minimum_voltage) &&
-                                (_state.voltage < _params._arming_minimum_voltage);
-    bool below_arming_capacity = (_params._arming_minimum_capacity > 0) &&
-                                 ((_params._pack_capacity - _state.consumed_mah) < _params._arming_minimum_capacity);
-    bool fs_capacity_inversion = is_positive(_params._critical_capacity) &&
-                                 is_positive(_params._low_capacity) &&
-                                 !(_params._low_capacity > _params._critical_capacity);
-    bool fs_voltage_inversion = is_positive(_params._critical_voltage) &&
-                                is_positive(_params._low_voltage) &&
-                                !(_params._low_voltage > _params._critical_voltage);
+  bool below_arming_voltage =
+      is_positive(_params._arming_minimum_voltage) &&
+      (_state.voltage < _params._arming_minimum_voltage);
+  bool below_arming_capacity = (_params._arming_minimum_capacity > 0) &&
+                               ((_params._pack_capacity - _state.consumed_mah) <
+                                _params._arming_minimum_capacity);
+  bool fs_capacity_inversion =
+      is_positive(_params._critical_capacity) &&
+      is_positive(_params._low_capacity) &&
+      !(_params._low_capacity > _params._critical_capacity);
+  bool fs_voltage_inversion =
+      is_positive(_params._critical_voltage) &&
+      is_positive(_params._low_voltage) &&
+      !(_params._low_voltage > _params._critical_voltage);
 
-    bool result = update_check(buflen, buffer, !_state.healthy, "unhealthy");
-    result = result && update_check(buflen, buffer, below_arming_voltage, "below minimum arming voltage");
-    result = result && update_check(buflen, buffer, below_arming_capacity, "below minimum arming capacity");
-    result = result && update_check(buflen, buffer, low_voltage,  "low voltage failsafe");
-    result = result && update_check(buflen, buffer, low_capacity, "low capacity failsafe");
-    result = result && update_check(buflen, buffer, critical_voltage, "critical voltage failsafe");
-    result = result && update_check(buflen, buffer, critical_capacity, "critical capacity failsafe");
-    result = result && update_check(buflen, buffer, fs_capacity_inversion, "capacity failsafe critical >= low");
-    result = result && update_check(buflen, buffer, fs_voltage_inversion, "voltage failsafe critical >= low");
+  bool result = update_check(buflen, buffer, !_state.healthy, "unhealthy");
+  result = result && update_check(buflen, buffer, below_arming_voltage,
+                                  "below minimum arming voltage");
+  result = result && update_check(buflen, buffer, below_arming_capacity,
+                                  "below minimum arming capacity");
+  result = result &&
+           update_check(buflen, buffer, low_voltage, "low voltage failsafe");
+  result = result &&
+           update_check(buflen, buffer, low_capacity, "low capacity failsafe");
+  result = result && update_check(buflen, buffer, critical_voltage,
+                                  "critical voltage failsafe");
+  result = result && update_check(buflen, buffer, critical_capacity,
+                                  "critical capacity failsafe");
+  result = result && update_check(buflen, buffer, fs_capacity_inversion,
+                                  "capacity failsafe critical >= low");
+  result = result && update_check(buflen, buffer, fs_voltage_inversion,
+                                  "voltage failsafe critical >= low");
 
-    return result;
+  return result;
 }
 
-void AP_BattMonitor_Backend::check_failsafe_types(bool &low_voltage, bool &low_capacity, bool &critical_voltage, bool &critical_capacity) const
-{
-    // use voltage or sag compensated voltage
-    float voltage_used;
-    switch (_params.failsafe_voltage_source()) {
-        case AP_BattMonitor_Params::BattMonitor_LowVoltageSource_Raw:
-        default:
-            voltage_used = _state.voltage;
-            break;
-        case AP_BattMonitor_Params::BattMonitor_LowVoltageSource_SagCompensated:
-            voltage_used = voltage_resting_estimate();
-            break;
-    }
+void AP_BattMonitor_Backend::check_failsafe_types(
+    bool &low_voltage, bool &low_capacity, bool &critical_voltage,
+    bool &critical_capacity) const {
+  // use voltage or sag compensated voltage
+  float voltage_used;
+  switch (_params.failsafe_voltage_source()) {
+  case AP_BattMonitor_Params::BattMonitor_LowVoltageSource_Raw:
+  default:
+    voltage_used = _state.voltage;
+    break;
+  case AP_BattMonitor_Params::BattMonitor_LowVoltageSource_SagCompensated:
+    voltage_used = voltage_resting_estimate();
+    break;
+  }
 
-    // check critical battery levels
-    if ((voltage_used > 0) && (_params._critical_voltage > 0) && (voltage_used < _params._critical_voltage)) {
-        critical_voltage = true;
-    } else {
-        critical_voltage = false;
-    }
+  // check critical battery levels
+  if ((voltage_used > 0) && (_params._critical_voltage > 0) &&
+      (voltage_used < _params._critical_voltage)) {
+    critical_voltage = true;
+  } else {
+    critical_voltage = false;
+  }
 
-    // check capacity failsafe if current monitoring is enabled
-    if (has_current() && (_params._critical_capacity > 0) &&
-        ((_params._pack_capacity - _state.consumed_mah) < _params._critical_capacity)) {
-        critical_capacity = true;
-    } else {
-        critical_capacity = false;
-    }
+  // check capacity failsafe if current monitoring is enabled
+  if (has_current() && (_params._critical_capacity > 0) &&
+      ((_params._pack_capacity - _state.consumed_mah) <
+       _params._critical_capacity)) {
+    critical_capacity = true;
+  } else {
+    critical_capacity = false;
+  }
 
-    if ((voltage_used > 0) && (_params._low_voltage > 0) && (voltage_used < _params._low_voltage)) {
-        low_voltage = true;
-    } else {
-        low_voltage = false;
-    }
+  if ((voltage_used > 0) && (_params._low_voltage > 0) &&
+      (voltage_used < _params._low_voltage)) {
+    low_voltage = true;
+  } else {
+    low_voltage = false;
+  }
 
-    // check capacity if current monitoring is enabled
-    if (has_current() && (_params._low_capacity > 0) &&
-        ((_params._pack_capacity - _state.consumed_mah) < _params._low_capacity)) {
-        low_capacity = true;
-    } else {
-        low_capacity = false;
-    }
+  // check capacity if current monitoring is enabled
+  if (has_current() && (_params._low_capacity > 0) &&
+      ((_params._pack_capacity - _state.consumed_mah) <
+       _params._low_capacity)) {
+    low_capacity = true;
+  } else {
+    low_capacity = false;
+  }
 }
 
 #if AP_BATTERY_ESC_TELEM_OUTBOUND_ENABLED
-void AP_BattMonitor_Backend::update_esc_telem_outbound()
-{
-    const uint8_t esc_index = _params._esc_telem_outbound_index;
-    if (esc_index == 0 || !_state.healthy) {
-        // Disabled if there's no ESC identified to route the data to or if the battery is unhealthy
-        return;
-    }
+void AP_BattMonitor_Backend::update_esc_telem_outbound() {
+  const uint8_t esc_index = _params._esc_telem_outbound_index;
+  if (esc_index == 0 || !_state.healthy) {
+    // Disabled if there's no ESC identified to route the data to or if the
+    // battery is unhealthy
+    return;
+  }
 
-    AP_ESC_Telem_Backend::TelemetryData telem {};
+  AP_ESC_Telem_Backend::TelemetryData telem{};
 
-    uint16_t type = AP_ESC_Telem_Backend::TelemetryType::VOLTAGE;
-    telem.voltage = _state.voltage; // all battery backends have voltage
+  uint16_t type = AP_ESC_Telem_Backend::TelemetryType::VOLTAGE;
+  telem.voltage = _state.voltage; // all battery backends have voltage
 
-    if (has_current()) {
-        telem.current = _state.current_amps;
-        type |= AP_ESC_Telem_Backend::TelemetryType::CURRENT;
-    }
+  if (has_current()) {
+    telem.current = _state.current_amps;
+    type |= AP_ESC_Telem_Backend::TelemetryType::CURRENT;
+  }
 
-    if (has_consumed_energy()) {
-        telem.consumption_mah = _state.consumed_mah;
-        type |= AP_ESC_Telem_Backend::TelemetryType::CONSUMPTION;
-    }
+  if (has_consumed_energy()) {
+    telem.consumption_mah = _state.consumed_mah;
+    type |= AP_ESC_Telem_Backend::TelemetryType::CONSUMPTION;
+  }
 
-    float temperature_c;
-    if (_mon.get_temperature(temperature_c, _state.instance)) {
-        // get the temperature from the frontend so we check for external temperature
-        telem.temperature_cdeg = temperature_c * 100;
-        type |= AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE;
-    }
+  float temperature_c;
+  if (_mon.get_temperature(temperature_c, _state.instance)) {
+    // get the temperature from the frontend so we check for external
+    // temperature
+    telem.temperature_cdeg = temperature_c * 100;
+    type |= AP_ESC_Telem_Backend::TelemetryType::TEMPERATURE;
+  }
 
-    AP::esc_telem().update_telem_data(esc_index-1, telem, type);
+  AP::esc_telem().update_telem_data(esc_index - 1, telem, type);
 }
 #endif
 
 // returns true if battery monitor provides temperature
-bool AP_BattMonitor_Backend::get_temperature(float &temperature) const
-{
+bool AP_BattMonitor_Backend::get_temperature(float &temperature) const {
 #if AP_TEMPERATURE_SENSOR_ENABLED
-    if (_state.temperature_external_use) {
-        temperature = _state.temperature_external;
-        return true;
-    }
+  if (_state.temperature_external_use) {
+    temperature = _state.temperature_external;
+    return true;
+  }
 #endif
 
-    temperature = _state.temperature;
+  temperature = _state.temperature;
 
-    return has_temperature();
+  return has_temperature();
 }
 
 /*
@@ -335,34 +428,33 @@ bool AP_BattMonitor_Backend::get_temperature(float &temperature) const
   and consumed_mah based on the given percentage. Use percentage=100
   for a full battery
 */
-bool AP_BattMonitor_Backend::reset_remaining(float percentage)
-{
-    percentage = constrain_float(percentage, 0, 100);
-    const float used_proportion = (100.0f - percentage) * 0.01f;
-    _state.consumed_mah = used_proportion * _params._pack_capacity;
-    // without knowing the history we can't do consumed_wh
-    // accurately. Best estimate is based on current voltage. This
-    // will be good when resetting the battery to a value close to
-    // full charge
-    _state.consumed_wh = _state.consumed_mah * 0.001f * _state.voltage;
+bool AP_BattMonitor_Backend::reset_remaining(float percentage) {
+  percentage = constrain_float(percentage, 0, 100);
+  const float used_proportion = (100.0f - percentage) * 0.01f;
+  _state.consumed_mah = used_proportion * _params._pack_capacity;
+  // without knowing the history we can't do consumed_wh
+  // accurately. Best estimate is based on current voltage. This
+  // will be good when resetting the battery to a value close to
+  // full charge
+  _state.consumed_wh = _state.consumed_mah * 0.001f * _state.voltage;
 
-    // reset failsafe state for this backend
-    _state.failsafe = update_failsafes();
+  // reset failsafe state for this backend
+  _state.failsafe = update_failsafes();
 
-    return true;
+  return true;
 }
 
 /*
   update consumed mAh and Wh
  */
-void AP_BattMonitor_Backend::update_consumed(AP_BattMonitor::BattMonitor_State &state, uint32_t dt_us)
-{
-    // update total current drawn since startup
-    if (state.last_time_micros != 0 && dt_us < 2000000) {
-        const float mah = calculate_mah(state.current_amps, dt_us);
-        state.consumed_mah += mah;
-        state.consumed_wh  += 0.001 * mah * state.voltage;
-    }
+void AP_BattMonitor_Backend::update_consumed(
+    AP_BattMonitor::BattMonitor_State &state, uint32_t dt_us) {
+  // update total current drawn since startup
+  if (state.last_time_micros != 0 && dt_us < 2000000) {
+    const float mah = calculate_mah(state.current_amps, dt_us);
+    state.consumed_mah += mah;
+    state.consumed_wh += 0.001 * mah * state.voltage;
+  }
 }
 
-#endif  // AP_BATTERY_ENABLED
+#endif // AP_BATTERY_ENABLED

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
@@ -22,130 +22,158 @@
 
 #include <AP_Common/AP_Common.h>
 
-class AP_BattMonitor_Backend
-{
+class AP_BattMonitor_Backend {
 public:
-    // constructor. This incorporates initialisation as well.
-    AP_BattMonitor_Backend(AP_BattMonitor &mon, AP_BattMonitor::BattMonitor_State &mon_state, AP_BattMonitor_Params &params);
+  // constructor. This incorporates initialisation as well.
+  AP_BattMonitor_Backend(AP_BattMonitor &mon,
+                         AP_BattMonitor::BattMonitor_State &mon_state,
+                         AP_BattMonitor_Params &params);
 
-    // we declare a virtual destructor so that BattMonitor driver can
-    // override with a custom destructor if need be
-    virtual ~AP_BattMonitor_Backend(void) {}
+  // we declare a virtual destructor so that BattMonitor driver can
+  // override with a custom destructor if need be
+  virtual ~AP_BattMonitor_Backend(void) {}
 
-    // initialise
-    virtual void init() {};
+  // initialise
+  virtual void init() {};
 
-    // read the latest battery voltage
-    virtual void read() = 0;
+  // read the latest battery voltage
+  virtual void read() = 0;
 
-    /// returns true if battery monitor instance provides time remaining info
-    virtual bool has_time_remaining() const { return false; }
+  /// returns true if battery monitor instance provides time remaining info
+  virtual bool has_time_remaining() const { return false; }
 
-    /// returns true if battery monitor instance provides consumed energy info
-    virtual bool has_consumed_energy() const { return false; }
+  /// returns true if battery monitor instance provides consumed energy info
+  virtual bool has_consumed_energy() const { return false; }
 
-    /// returns true if battery monitor instance provides current info
-    virtual bool has_current() const = 0;
+  /// returns true if battery monitor instance provides current info
+  virtual bool has_current() const = 0;
 
-    // returns true if battery monitor provides individual cell voltages
-    virtual bool has_cell_voltages() const { return false; }
+  // returns true if battery monitor provides individual cell voltages
+  virtual bool has_cell_voltages() const { return false; }
 
-    // returns true if battery monitor provides temperature
-    virtual bool has_temperature() const { return false; }
+  // returns true if battery monitor provides temperature
+  virtual bool has_temperature() const { return false; }
 
-    // returns true if temperature retrieved successfully
-    virtual bool get_temperature(float &temperature) const;
+  // returns true if temperature retrieved successfully
+  virtual bool get_temperature(float &temperature) const;
 
-    // capacity_remaining_pct - returns true if the battery % is available and writes to the percentage argument
-    // returns false if the battery is unhealthy, does not have current monitoring, or the pack_capacity is too small
-    virtual bool capacity_remaining_pct(uint8_t &percentage) const WARN_IF_UNUSED;
+  // capacity_remaining_pct - returns true if the battery % is available and
+  // writes to the percentage argument returns false if the battery is
+  // unhealthy, does not have current monitoring, or the pack_capacity is too
+  // small
+  virtual bool capacity_remaining_pct(uint8_t &percentage) const WARN_IF_UNUSED;
 
-    // return true if cycle count can be provided and fills in cycles argument
-    virtual bool get_cycle_count(uint16_t &cycles) const { return false; }
+  // return true if cycle count can be provided and fills in cycles argument
+  virtual bool get_cycle_count(uint16_t &cycles) const { return false; }
 
-    // return true if state of health (as a percentage) can be provided and fills in soh_pct argument
-    bool get_state_of_health_pct(uint8_t &soh_pct) const;
+  // return true if state of health (as a percentage) can be provided and fills
+  // in soh_pct argument
+  bool get_state_of_health_pct(uint8_t &soh_pct) const;
 
-    /// get voltage with sag removed (based on battery current draw and resistance)
-    /// this will always be greater than or equal to the raw voltage
-    float voltage_resting_estimate() const;
+  /// get voltage with sag removed (based on battery current draw and
+  /// resistance) this will always be greater than or equal to the raw voltage
+  float voltage_resting_estimate() const;
 
-    // update battery resistance estimate and voltage_resting_estimate
-    virtual void update_resistance_estimate();
+  // update battery resistance estimate and voltage_resting_estimate
+  virtual void update_resistance_estimate();
 
-    // updates failsafe timers, and returns what failsafes are active
-    virtual AP_BattMonitor::Failsafe update_failsafes(void);
+  // updates failsafe timers, and returns what failsafes are active
+  virtual AP_BattMonitor::Failsafe update_failsafes(void);
 
-    // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
-    bool arming_checks(char * buffer, size_t buflen) const;
+  // returns false if we fail arming checks, in which case the buffer will be
+  // populated with a failure message
+  bool arming_checks(char *buffer, size_t buflen) const;
 
-    // reset remaining percentage to given value
-    virtual bool reset_remaining(float percentage);
+  // reset remaining percentage to given value
+  virtual bool reset_remaining(float percentage);
 
-    // return mavlink fault bitmask (see MAV_BATTERY_FAULT enum)
-    virtual uint32_t get_mavlink_fault_bitmask() const { return 0; }
+  // return mavlink fault bitmask (see MAV_BATTERY_FAULT enum)
+  virtual uint32_t get_mavlink_fault_bitmask() const { return 0; }
 
-    // logging functions 
-    void Log_Write_BAT(const uint8_t instance, const uint64_t time_us) const;
-    void Log_Write_BCL(const uint8_t instance, const uint64_t time_us) const;
+  // logging functions
+  void Log_Write_BAT(const uint8_t instance, const uint64_t time_us) const;
+  void Log_Write_BCL(const uint8_t instance, const uint64_t time_us) const;
 
-    // set desired powered state (enabled/disabled)
-    virtual void set_powered_state(bool power_on) {};
+  // set desired powered state (enabled/disabled)
+  virtual void set_powered_state(bool power_on) {};
 
-    // Update an ESC telemetry channel's power information
-    void update_esc_telem_outbound();
+  // Update an ESC telemetry channel's power information
+  void update_esc_telem_outbound();
 
-    // amps: current (A)
-    // dt_us: time between samples (micro-seconds)
-    static float calculate_mah(float amps, float dt_us) { return (float) (amps * dt_us * AUS_TO_MAH); }
+  // amps: current (A)
+  // dt_us: time between samples (micro-seconds)
+  static float calculate_mah(float amps, float dt_us) {
+    return (float)(amps * dt_us * AUS_TO_MAH);
+  }
 
-    // check if a option is set
-    bool option_is_set(const AP_BattMonitor_Params::Options option) const {
-        return (uint16_t(_params._options.get()) & uint16_t(option)) != 0;
-    }
-    
+  // check if a option is set
+  bool option_is_set(const AP_BattMonitor_Params::Options option) const {
+    return (uint16_t(_params._options.get()) & uint16_t(option)) != 0;
+  }
+
 #if AP_BATTERY_SCRIPTING_ENABLED
-    virtual bool handle_scripting(const BattMonitorScript_State &battmon_state) { return false; }
+  virtual bool handle_scripting(const BattMonitorScript_State &battmon_state) {
+    return false;
+  }
 #endif
 
 protected:
-    AP_BattMonitor                      &_mon;      // reference to front-end
-    AP_BattMonitor::BattMonitor_State   &_state;    // reference to this instances state (held in the front-end)
-    AP_BattMonitor_Params               &_params;   // reference to this instances parameters (held in the front-end)
+  AP_BattMonitor &_mon; // reference to front-end
+  AP_BattMonitor::BattMonitor_State
+      &_state; // reference to this instances state (held in the front-end)
+  AP_BattMonitor_Params &
+      _params; // reference to this instances parameters (held in the front-end)
 
-    // checks what failsafes could be triggered
-    void check_failsafe_types(bool &low_voltage, bool &low_capacity, bool &critical_voltage, bool &critical_capacity) const;
-    void update_consumed(AP_BattMonitor::BattMonitor_State &state, uint32_t dt_us);
+  // checks what failsafes could be triggered
+  void check_failsafe_types(bool &low_voltage, bool &low_capacity,
+                            bool &critical_voltage,
+                            bool &critical_capacity) const;
+  void update_consumed(AP_BattMonitor::BattMonitor_State &state,
+                       uint32_t dt_us);
 
 private:
-    // resistance estimate
-    uint32_t    _resistance_timer_ms;    // system time of last resistance estimate update
-    float       _voltage_filt;           // filtered voltage
-    float       _current_max_amps;       // maximum current since start-up
-    float       _current_filt_amps;      // filtered current
-    float       _resistance_voltage_ref; // voltage used for maximum resistance calculation
-    float       _resistance_current_ref; // current used for maximum resistance calculation
+  // resistance estimate
+  uint32_t
+      _resistance_timer_ms; // system time of last resistance estimate update
+  float _voltage_filt;      // filtered voltage
+  float _current_max_amps;  // maximum current since start-up
+  float _current_filt_amps; // filtered current
+  float _resistance_voltage_ref; // voltage used for maximum resistance
+                                 // calculation
+  float _resistance_current_ref; // current used for maximum resistance
+                                 // calculation
+
+  // voltage curve percentage estimate
+  uint32_t
+      _voltage_pct_timer_ms; // system time of last voltage pct filter update
+  float _voltage_pct_filt;   // filtered voltage for percentage curve
 };
 
 #if AP_BATTERY_SCRIPTING_ENABLED
 struct BattMonitorScript_State {
-    float voltage; // Battery voltage in volts
-    bool healthy; // True if communicating properly
-    uint8_t cell_count; // Number of valid cells in state
-    uint8_t capacity_remaining_pct=UINT8_MAX; // Remaining battery capacity in percent, 255 for invalid
-    uint8_t state_of_health_pct=UINT8_MAX; // Remaining battery health in percent, 255 for invalid
-    uint16_t cell_voltages[32]; // allow script to have up to 32 cells, will be limited internally
-    uint16_t cycle_count=UINT16_MAX; // Battery cycle count, 65535 for unavailable
-    /*
-      all of the following float variables should be set to NaN by the
-      script if they are not known.
-      consumed_mah will auto-integrate if set to NaN
-     */
-    float current_amps=nanf(""); // Battery current in amperes
-    float consumed_mah=nanf(""); // Total current drawn since start-up in milliampere hours
-    float consumed_wh=nanf(""); // Total energy drawn since start-up in watt hours
-    float temperature=nanf(""); // Battery temperature in degrees Celsius
+  float voltage;      // Battery voltage in volts
+  bool healthy;       // True if communicating properly
+  uint8_t cell_count; // Number of valid cells in state
+  uint8_t capacity_remaining_pct =
+      UINT8_MAX; // Remaining battery capacity in percent, 255 for invalid
+  uint8_t state_of_health_pct =
+      UINT8_MAX; // Remaining battery health in percent, 255 for invalid
+  uint16_t cell_voltages[32]; // allow script to have up to 32 cells, will be
+                              // limited internally
+  uint16_t cycle_count =
+      UINT16_MAX; // Battery cycle count, 65535 for unavailable
+  /*
+    all of the following float variables should be set to NaN by the
+    script if they are not known.
+    consumed_mah will auto-integrate if set to NaN
+   */
+  float current_amps = nanf(""); // Battery current in amperes
+  float consumed_mah =
+      nanf(""); // Total current drawn since start-up in milliampere hours
+  float consumed_wh =
+      nanf(""); // Total energy drawn since start-up in watt hours
+  float temperature = nanf(""); // Battery temperature in degrees Celsius
 };
 #endif // AP_BATTERY_SCRIPTING_ENABLED
 
-#endif  // AP_BATTERY_ENABLED
+#endif // AP_BATTERY_ENABLED

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Params.h
@@ -1,56 +1,57 @@
 #pragma once
 
-#include <AP_Param/AP_Param.h>
 #include "AP_BattMonitor_config.h"
+#include <AP_Param/AP_Param.h>
 
 class AP_BattMonitor_Params {
 public:
-    static const struct AP_Param::GroupInfo var_info[];
+  static const struct AP_Param::GroupInfo var_info[];
 
-    AP_BattMonitor_Params(void);
+  AP_BattMonitor_Params(void);
 
-    /* Do not allow copies */
-    CLASS_NO_COPY(AP_BattMonitor_Params);
+  /* Do not allow copies */
+  CLASS_NO_COPY(AP_BattMonitor_Params);
 
-    enum class Type {
-        NONE                           = 0,
-        ANALOG_VOLTAGE_ONLY            = 3,
-        ANALOG_VOLTAGE_AND_CURRENT     = 4,
-        SOLO                           = 5,
-        BEBOP                          = 6,
-        SMBus_Generic                  = 7,
-        UAVCAN_BatteryInfo             = 8,
-        BLHeliESC                      = 9,
-        Sum                            = 10,
-        FuelFlow                       = 11,
-        FuelLevel_PWM                  = 12,
-        SUI3                           = 13,
-        SUI6                           = 14,
-        NeoDesign                      = 15,
-        MAXELL                         = 16,
-        GENERATOR_ELEC                 = 17,
-        GENERATOR_FUEL                 = 18,
-        Rotoye                         = 19,
-        // 20 was MPPT_PacketDigital
-        INA2XX                         = 21,
-        LTC2946                        = 22,
-        Torqeedo                       = 23,
-        FuelLevel_Analog               = 24,
-        Analog_Volt_Synthetic_Current  = 25,
-        INA239_SPI                     = 26,
-        EFI                            = 27,
-        AD7091R5                       = 28,
-        Scripting                      = 29,
-        INA3221                        = 30,
-        ANALOG_CURRENT_ONLY            = 31,
-        TIBQ76952_I2C                  = 32,
-    };
+  enum class Type {
+    NONE = 0,
+    ANALOG_VOLTAGE_ONLY = 3,
+    ANALOG_VOLTAGE_AND_CURRENT = 4,
+    SOLO = 5,
+    BEBOP = 6,
+    SMBus_Generic = 7,
+    UAVCAN_BatteryInfo = 8,
+    BLHeliESC = 9,
+    Sum = 10,
+    FuelFlow = 11,
+    FuelLevel_PWM = 12,
+    SUI3 = 13,
+    SUI6 = 14,
+    NeoDesign = 15,
+    MAXELL = 16,
+    GENERATOR_ELEC = 17,
+    GENERATOR_FUEL = 18,
+    Rotoye = 19,
+    // 20 was MPPT_PacketDigital
+    INA2XX = 21,
+    LTC2946 = 22,
+    Torqeedo = 23,
+    FuelLevel_Analog = 24,
+    Analog_Volt_Synthetic_Current = 25,
+    INA239_SPI = 26,
+    EFI = 27,
+    AD7091R5 = 28,
+    Scripting = 29,
+    INA3221 = 30,
+    ANALOG_CURRENT_ONLY = 31,
+    TIBQ76952_I2C = 32,
+  };
 
-    // low voltage sources (used for BATT_LOW_TYPE parameter)
-    enum BattMonitor_LowVoltage_Source {
-        BattMonitor_LowVoltageSource_Raw            = 0,
-        BattMonitor_LowVoltageSource_SagCompensated = 1
-    };
+  // low voltage sources (used for BATT_LOW_TYPE parameter)
+  enum BattMonitor_LowVoltage_Source {
+    BattMonitor_LowVoltageSource_Raw = 0,
+    BattMonitor_LowVoltageSource_SagCompensated = 1
+  };
+  // clang-format off
     enum class Options : uint16_t {
         Ignore_UAVCAN_SoC                   = (1U<<0),  // Ignore UAVCAN State-of-Charge (charge %) supplied value from the device and use the internally calculated one
         MPPT_Use_Input_Value                = (1U<<1),  // MPPT reports voltage and current from Input (usually solar panel) instead of the output
@@ -63,28 +64,50 @@ public:
         InternalUseOnly                     = (1U<<8),  // for use internally to ArduPilot, not to be (eg.) sent via MAVLink BATTERY_STATUS
         Minimum_Voltage                     = (1U<<9),  // sum monitor measures minimum voltage rather than average
         AllowDynamicNodeUpdate              = (1U<<10), // allow dynamic update of DroneCAN node ID during hot-swap when telemetry is lost
+        Pct_Use_Resting_Voltage             = (1U<<11), // use resting voltage instead of raw voltage for voltage-curve percentage calculation
     };
+  // clang-format on
 
-    BattMonitor_LowVoltage_Source failsafe_voltage_source(void) const { return (enum BattMonitor_LowVoltage_Source)_failsafe_voltage_source.get(); }
+  BattMonitor_LowVoltage_Source failsafe_voltage_source(void) const {
+    return (enum BattMonitor_LowVoltage_Source)_failsafe_voltage_source.get();
+  }
 
-    AP_Int32 _pack_capacity;            /// battery pack capacity less reserve in mAh
-    AP_Int32 _serial_number;            /// battery serial number, automatically filled in on SMBus batteries
-    AP_Float _low_voltage;              /// voltage level used to trigger a low battery failsafe
-    AP_Float _low_capacity;             /// capacity level used to trigger a low battery failsafe
-    AP_Float _critical_voltage;         /// voltage level used to trigger a critical battery failsafe
-    AP_Float _critical_capacity;        /// capacity level used to trigger a critical battery failsafe
-    AP_Int32 _arming_minimum_capacity;  /// capacity level required to arm
-    AP_Float _arming_minimum_voltage;   /// voltage level required to arm
-    AP_Int32 _options;                  /// Options
+  AP_Int32 _pack_capacity; /// battery pack capacity less reserve in mAh
+  AP_Int32 _serial_number; /// battery serial number, automatically filled in on
+                           /// SMBus batteries
+  AP_Float
+      _low_voltage; /// voltage level used to trigger a low battery failsafe
+  AP_Float
+      _low_capacity; /// capacity level used to trigger a low battery failsafe
+  AP_Float _critical_voltage;  /// voltage level used to trigger a critical
+                               /// battery failsafe
+  AP_Float _critical_capacity; /// capacity level used to trigger a critical
+                               /// battery failsafe
+  AP_Int32 _arming_minimum_capacity; /// capacity level required to arm
+  AP_Float _arming_minimum_voltage;  /// voltage level required to arm
+  AP_Int32 _options;                 /// Options
 #if AP_BATTERY_WATT_MAX_ENABLED
-    AP_Int16 _watt_max;                 /// max battery power allowed. Reduce max throttle to reduce current to satisfy t    his limit
+  AP_Int16 _watt_max; /// max battery power allowed. Reduce max throttle to
+                      /// reduce current to satisfy t    his limit
 #endif
-    AP_Enum<Type>  _type;                     /// 0=disabled, 3=voltage only, 4=voltage and current
-    AP_Int8  _low_voltage_timeout;      /// timeout in seconds before a low voltage event will be triggered
-    AP_Int8  _failsafe_voltage_source;  /// voltage type used for detection of low voltage event
-    AP_Int8  _failsafe_low_action;      /// action to preform on a low battery failsafe
-    AP_Int8  _failsafe_critical_action; /// action to preform on a critical battery failsafe
+  AP_Enum<Type> _type; /// 0=disabled, 3=voltage only, 4=voltage and current
+  AP_Int8 _low_voltage_timeout;     /// timeout in seconds before a low voltage
+                                    /// event will be triggered
+  AP_Int8 _failsafe_voltage_source; /// voltage type used for detection of low
+                                    /// voltage event
+  AP_Int8 _failsafe_low_action; /// action to preform on a low battery failsafe
+  AP_Int8 _failsafe_critical_action; /// action to preform on a critical battery
+                                     /// failsafe
 #if AP_BATTERY_ESC_TELEM_OUTBOUND_ENABLED
-    AP_Int8  _esc_telem_outbound_index; /// bitmask of ESCs to forward voltage, current, consumption and temperature to.
+  AP_Int8
+      _esc_telem_outbound_index; /// bitmask of ESCs to forward voltage,
+                                 /// current, consumption and temperature to.
 #endif
+  AP_Int8 _pct_type;     /// type of remaining percentage calculation
+  AP_Float _volt_0;      /// voltage at 0%
+  AP_Float _volt_25;     /// voltage at 25%
+  AP_Float _volt_50;     /// voltage at 50%
+  AP_Float _volt_75;     /// voltage at 75%
+  AP_Float _volt_100;    /// voltage at 100%
+  AP_Float _volt_pct_tc; /// time constant for voltage curve battery filter
 };


### PR DESCRIPTION
Fixes #32388

This PR introduces an optional method for calculating the remaining battery percentage based on a configurable piecewise-linear voltage curve.

**Changes:**
- Added `BATTx_PCT_TYPE` to select between traditional mAh counting (0) and the voltage curve method (1).
- Added `BATTx_VOLT_0`, `BATTx_VOLT_25`, `BATTx_VOLT_50`, `BATTx_VOLT_75`, and `BATTx_VOLT_100` parameters to define the voltage-to-percentage mapping.
- Added `BATTx_VOLT_TC` to configure a low-pass filter specifically for this voltage tracking, avoiding rapid fluctuations in the reported percentage.
- Added `Pct_Use_Resting_Voltage` bit in `BATTx_OPTIONS` to optionally use sag-compensated resting voltage instead of raw voltage for the calculation.
- Implemented the filtering and interpolation logic in `AP_BattMonitor_Backend::capacity_remaining_pct()`.

**Reasoning:**
mAh/Coulomb counting can drift or be inaccurate especially for degraded batteries or when swapping partially charged batteries. A tunable voltage curve provides a robust alternative for these scenarios.
