### PR TITLE
Copter: add separate LEVEL arming check for lean angle

### DIFF
--- a/ArduCopter/AP_Arming_Copter.cpp
+++ b/ArduCopter/AP_Arming_Copter.cpp
@@ -596,7 +596,7 @@ bool AP_Arming_Copter::arm_checks(AP_Arming::Method method)
     }
 
     // check lean angle
-    if (check_enabled(Check::INS)) {
+    if (check_enabled(Check::LEVEL)) {
         if (acosf(ahrs.cos_roll()*ahrs.cos_pitch()) > copter.attitude_control->lean_angle_max_rad()) {
             check_failed(Check::INS, true, "Leaning");
             return false;

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -195,8 +195,9 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     // @Param: SKIPCHK
     // @DisplayName: Arm Checks to Skip (bitmask)
     // @Description: Checks to skip prior to arming motor. This is a bitmask of checks before allowing arming that will be skipped. For most users it is recommended to leave this at the default of 0 (no checks skipped). In extreme circumstances, a value of -1 can be used to skip all non-mandatory current and future checks.
-    // @Bitmask: 1:Barometer,2:Compass,3:GPS lock,4:INS,5:Parameters,6:RC Channels,7:Board voltage,8:Battery Level,10:Logging Available,11:Hardware safety switch,12:GPS Configuration,13:System,14:Mission,15:Rangefinder,16:Camera,17:AuxAuth,18:VisualOdometry,19:FFT
-    // @Bitmask{Plane}: 1:Barometer,2:Compass,3:GPS lock,4:INS,5:Parameters,6:RC Channels,7:Board voltage,8:Battery Level,9:Airspeed,10:Logging Available,11:Hardware safety switch,12:GPS Configuration,13:System,14:Mission,15:Rangefinder,16:Camera,17:AuxAuth,19:FFT
+    // @Bitmask: 1:Barometer,2:Compass,3:GPS lock,4:INS,5:Parameters,6:RC Channels,7:Board voltage,8:Battery Level,10:Logging Available,11:Hardware safety switch,12:GPS Configuration,13:System,14:Mission,15:Rangefinder,16:Camera,17:AuxAuth,18:VisualOdometry,19:FFT,20:OSD
+    // @Bitmask{Copter}: 1:Barometer,2:Compass,3:GPS lock,4:INS,5:Parameters,6:RC Channels,7:Board voltage,8:Battery Level,9:Level,10:Logging Available,11:Hardware safety switch,12:GPS Configuration,13:System,14:Mission,15:Rangefinder,16:Camera,17:AuxAuth,18:VisualOdometry,19:FFT,20:OSD
+    // @Bitmask{Plane}: 1:Barometer,2:Compass,3:GPS lock,4:INS,5:Parameters,6:RC Channels,7:Board voltage,8:Battery Level,9:Airspeed,10:Logging Available,11:Hardware safety switch,12:GPS Configuration,13:System,14:Mission,15:Rangefinder,16:Camera,17:AuxAuth,19:FFT,20:OSD
     // @User: Standard
     AP_GROUPINFO("SKIPCHK", 13, AP_Arming, checks_to_skip, 0),
 

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -34,7 +34,8 @@ public:
         RC          = (1U << 6),
         VOLTAGE     = (1U << 7),
         BATTERY     = (1U << 8),
-        AIRSPEED    = (1U << 9),
+        AIRSPEED    = (1U << 9),    // plane only
+        LEVEL       = (1U << 9),    // copter only
         LOGGING     = (1U << 10),
         SWITCH      = (1U << 11),
         GPS_CONFIG  = (1U << 12),


### PR DESCRIPTION
## Summary
- Add a new `LEVEL` bit (bit 21) to `ARMING_SKIPCHK` so the lean-angle check can be disabled independently from the INS check, allowing arming while inverted
- Document the previously-undocumented `OSD` check (bit 20) in the bitmask descriptions for all vehicles
- Copter's leaning pre-arm check now uses `Check::LEVEL` instead of `Check::INS`

## Test plan
- [x] Build ArduCopter for SITL and verify compilation
- [x] Verify that with `ARMING_SKIPCHK` bit 21 set, Copter can arm while leaning beyond `ANGLE_MAX`
- [x] Verify that with bit 21 unset, the "Leaning" pre-arm check still triggers normally
- [x] Verify that disabling INS check (bit 4) no longer bypasses the lean angle check