### PR TITLE
Copter: disable takeoff RPM check in throw mode

### DIFF
--- a/ArduCopter/takeoff_check.cpp
+++ b/ArduCopter/takeoff_check.cpp
@@ -8,8 +8,11 @@
 void Copter::takeoff_check()
 {
 #if HAL_WITH_ESC_TELEM && FRAME_CONFIG != HELI_FRAME
-    // If takeoff check is disabled or vehicle is armed and flying then clear block and return
-    if ((g2.takeoff_rpm_min <= 0) || (motors->armed() && !ap.land_complete)) {
+    // If takeoff check is disabled, vehicle is armed and flying, or in
+    // throw mode (where motors must spool before land_complete is cleared)
+    // then clear block and return
+    if ((g2.takeoff_rpm_min <= 0) || (motors->armed() && !ap.land_complete) ||
+        flightmode->mode_number() == Mode::Number::THROW) {
         motors->set_spoolup_block(false);
         return;
     }


### PR DESCRIPTION
## Summary
- Bypass the `TKOFF_RPM_MIN` spoolup block when in throw mode
- In throw mode `land_complete` remains true until throw detection succeeds, so the takeoff RPM check never clears the spoolup block, preventing motors from reaching `THROTTLE_UNLIMITED` and deadlocking throw detection

## Test plan
- [x] Build ArduCopter for SITL and verify compilation
- [x] Verify throw mode works correctly with `TKOFF_RPM_MIN` set to a non-zero value
- [x] Verify `TKOFF_RPM_MIN` still functions normally in other flight modes (e.g., Stabilize, AltHold)