### PR TITLE
Copter: indicate what caused an EKF failsafe

### DIFF
--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -83,7 +83,7 @@ void Copter::ekf_check()
                 LOGGER_WRITE_ERROR(LogErrorSubsystem::EKFCHECK, LogErrorCode::EKFCHECK_BAD_VARIANCE);
                 // send message to gcs
                 if ((AP_HAL::millis() - ekf_check_state.last_warn_time) > EKF_CHECK_WARNING_TIME) {
-                    gcs().send_text(MAV_SEVERITY_CRITICAL,"EKF variance");
+                    gcs().send_text(MAV_SEVERITY_CRITICAL,"EKF variance: %s", over_threshold ? "over thresholds" : "position lost");
                     ekf_check_state.last_warn_time = AP_HAL::millis();
                 }
                 failsafe_ekf_event();


### PR DESCRIPTION
## Summary

- Change the EKF failsafe GCS message from generic "EKF variance" to indicate the specific cause
- Reports "EKF variance: over thresholds" when variance exceeds FS_EKF_THRESH, or "EKF variance: position lost" when the EKF reports position is unreliable
- Helps diagnose EKF failsafe events without requiring log analysis

## Test plan

- [x] Trigger EKF failsafe via variance threshold - verify message says "over thresholds"
- [x] Trigger EKF failsafe via position lost - verify message says "position lost"
- [x] Verify no regression in failsafe behavior