### PR TITLE
Copter: make ARM_DELAY customizable via hwdef and avoid race in ARMING_DELAY_MSEC

### DIFF
--- a/ArduCopter/AP_Arming_Copter.cpp
+++ b/ArduCopter/AP_Arming_Copter.cpp
@@ -776,7 +776,9 @@ bool AP_Arming_Copter::arm(const AP_Arming::Method method, const bool do_arming_
     copter.arm_time_ms = millis();
 
     // Start the arming delay
+#if ARMING_DELAY_MS > 0
     copter.ap.in_arming_delay = true;
+#endif
 
     // assumed armed without a arming, switch. Overridden in switches.cpp
     copter.ap.armed_with_airmode_switch = false;
@@ -832,7 +834,9 @@ bool AP_Arming_Copter::disarm(const AP_Arming::Method method, bool do_disarm_che
 
     hal.util->set_soft_armed(false);
 
+#if ARMING_DELAY_MS > 0
     copter.ap.in_arming_delay = false;
+#endif
 
 #if AUTOTUNE_ENABLED
     // Possibly save auto tuned parameters

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -43,8 +43,12 @@
 #error CONFIG_HAL_BOARD must be defined to build ArduCopter
 #endif
 
-#ifndef ARMING_DELAY_SEC
-    # define ARMING_DELAY_SEC 2.0f
+#ifdef ARMING_DELAY_SEC
+#error ARMING_DELAY_SEC has been replaced by ARMING_DELAY_MS
+#endif
+
+#ifndef ARMING_DELAY_MS
+    # define ARMING_DELAY_MS 2000
 #endif
 
 //////////////////////////////////////////////////////////////////////////////

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -74,10 +74,12 @@ void Copter::motors_output(bool full_push)
     }
 #endif
 
+#if ARMING_DELAY_MS > 0
     // Update arming delay state
-    if (ap.in_arming_delay && (!motors->armed() || millis()-arm_time_ms > ARMING_DELAY_SEC*1.0e3f || flightmode->mode_number() == Mode::Number::THROW)) {
+    if (ap.in_arming_delay && (!motors->armed() || millis()-arm_time_ms > ARMING_DELAY_MS || flightmode->mode_number() == Mode::Number::THROW)) {
         ap.in_arming_delay = false;
     }
+#endif
 
     // output any servo channels
     SRV_Channels::calc_pwm();

--- a/libraries/AP_HAL_ChibiOS/hwdef/skyviper-f412-rev1/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/skyviper-f412-rev1/hwdef.dat
@@ -121,7 +121,7 @@ define HAL_STORAGE_SIZE 15360
 
 # setup defines for ArduCopter config
 define TOY_MODE_ENABLED 1
-define ARMING_DELAY_SEC 0
+define ARMING_DELAY_MS 0
 define LAND_DETECTOR_ACCEL_MAX 2.0f
 
 COMPASS BMM150 I2C:0:0x10 false ROTATION_NONE

--- a/libraries/AP_HAL_ChibiOS/hwdef/skyviper-journey/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/skyviper-journey/hwdef.dat
@@ -114,7 +114,7 @@ define HAL_STORAGE_SIZE 15360
 
 # setup defines for ArduCopter config
 define TOY_MODE_ENABLED 1
-define ARMING_DELAY_SEC 0
+define ARMING_DELAY_MS 0
 define LAND_DETECTOR_ACCEL_MAX 2.0f
 
 COMPASS BMM150 I2C:0:0x10 false ROTATION_NONE

--- a/libraries/AP_HAL_ChibiOS/hwdef/skyviper-v2450/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/skyviper-v2450/hwdef.dat
@@ -174,7 +174,7 @@ define HAL_GPIO_RADIO_IRQ       100
 
 # setup defines for ArduCopter config
 define TOY_MODE_ENABLED 1
-define ARMING_DELAY_SEC 0
+define ARMING_DELAY_MS 0
 define LAND_DETECTOR_ACCEL_MAX 2.0f
 
 # support cypress and cc2500 radios


### PR DESCRIPTION
### Summary

Take the arming delay in milliseconds and compile it out entirely when it is zero, so a board can set a short sub-second delay or none at all.

### Classification & Testing (check all that apply and add your own)

- [x] Tested manually, description below (e.g. SITL)

Built for SITL with the default, `ARMING_DELAY_MS 250` and `ARMING_DELAY_MS 0`, and confirmed a stale `ARMING_DELAY_SEC` stops the build.

### Description

`ARMING_DELAY_SEC` was a float (`2.0f`), which cannot express a sub-second delay cleanly in a hwdef and cannot be tested in the preprocessor, so a zero delay could never be compiled out. This takes the delay as `ARMING_DELAY_MS`, an integer defaulting to 2000.

Zero did not previously mean zero. `in_arming_delay` was still set at arm and only cleared once `millis()` had passed `arm_time_ms`, so an arm and a `motors_output()` pass inside the same millisecond held the motor interlock off for that pass. With `ARMING_DELAY_MS 0` the flag and its state machine are not compiled in.

The three skyviper boards move from `ARMING_DELAY_SEC 0` to `ARMING_DELAY_MS 0`. A stale `ARMING_DELAY_SEC` now raises `#error` rather than being silently ignored, because ignoring it would put a 2 s delay back on a board that had asked for none.

An earlier revision also let `ARM_DELAY`, the rudder-arm hold count, be redefined. That is gone, so there is one pattern rather than two. Review suggested keeping `ARMING_DELAY_SEC` as the input and deriving milliseconds from it, which works for whole seconds, but a fractional value such as `0.25` is a floating constant in a preprocessor expression and does not compile - and sub-second delays are the reason for the change.
