### PR TITLE
AP_InertialSensor: add IMU low drift support low drift IMUs

### DIFF
--- a/Tools/Replay/LR_MsgHandler.cpp
+++ b/Tools/Replay/LR_MsgHandler.cpp
@@ -181,6 +181,11 @@ void LR_MsgHandler_RISI::process_message(uint8_t *msgbytes)
     MSG_CREATE(RISI, msgbytes);
     AP::dal().handle_message(msg);
 }
+void LR_MsgHandler_RISJ::process_message(uint8_t *msgbytes)
+{
+    MSG_CREATE(RISJ, msgbytes);
+    AP::dal().handle_message(msg);
+}
 
 void LR_MsgHandler_RASH::process_message(uint8_t *msgbytes)
 {

--- a/Tools/Replay/LR_MsgHandler.h
+++ b/Tools/Replay/LR_MsgHandler.h
@@ -150,6 +150,12 @@ public:
     using LR_MsgHandler::LR_MsgHandler;
     void process_message(uint8_t *msg) override;
 };
+class LR_MsgHandler_RISJ : public LR_MsgHandler
+{
+public:
+    using LR_MsgHandler::LR_MsgHandler;
+    void process_message(uint8_t *msg) override;
+};
 class LR_MsgHandler_RASH : public LR_MsgHandler
 {
 public:

--- a/Tools/Replay/LogReader.cpp
+++ b/Tools/Replay/LogReader.cpp
@@ -86,6 +86,8 @@ bool LogReader::handle_log_format_msg(const struct log_Format &f)
 	    msgparser[f.type] = NEW_NOTHROW LR_MsgHandler_RISH(formats[f.type]);
 	} else if (streq(name, "RISI")) {
 	    msgparser[f.type] = NEW_NOTHROW LR_MsgHandler_RISI(formats[f.type]);
+	} else if (streq(name, "RISJ")) {
+	    msgparser[f.type] = NEW_NOTHROW LR_MsgHandler_RISJ(formats[f.type]);
     } else if (streq(name, "RASH")) {
 	    msgparser[f.type] = NEW_NOTHROW LR_MsgHandler_RASH(formats[f.type]);
 	} else if (streq(name, "RASI")) {

--- a/libraries/AP_DAL/AP_DAL.h
+++ b/libraries/AP_DAL/AP_DAL.h
@@ -270,6 +270,9 @@ public:
     void handle_message(const log_RISI &msg) {
         _ins.handle_message(msg);
     }
+    void handle_message(const log_RISJ &msg) {
+        _ins.handle_message(msg);
+    }
 
     void handle_message(const log_RASH &msg) {
         if (_airspeed == nullptr) {

--- a/libraries/AP_DAL/AP_DAL_InertialSensor.cpp
+++ b/libraries/AP_DAL/AP_DAL_InertialSensor.cpp
@@ -41,6 +41,8 @@ void AP_DAL_InertialSensor::start_frame()
             RISI.get_delta_angle_ret = ins.get_delta_angle(i, RISI.delta_angle, RISI.delta_angle_dt);
         }
 
+        RISI.low_drift = ins.is_low_drift(i);
+
         update_filtered(i);
 
         WRITE_REPLAY_BLOCK_IFCHANGED(RISI, RISI, old_RISI);

--- a/libraries/AP_DAL/AP_DAL_InertialSensor.cpp
+++ b/libraries/AP_DAL/AP_DAL_InertialSensor.cpp
@@ -8,7 +8,13 @@ AP_DAL_InertialSensor::AP_DAL_InertialSensor()
     for (uint8_t i=0; i<ARRAY_SIZE(_RISI); i++) {
         _RISI[i].instance = i;
     }
-
+    // seed RISJ with legacy defaults so replay of older logs (with no
+    // RISJ messages) still gives the EKF sane gyro bias clamp/init values.
+    for (uint8_t i=0; i<ARRAY_SIZE(_RISJ); i++) {
+        _RISJ[i].instance = i;
+        _RISJ[i].gyro_bias_limit = 0.5f;
+        _RISJ[i].gyro_bias_init_dps = 2.5f;
+    }
 }
 
 void AP_DAL_InertialSensor::start_frame()
@@ -41,12 +47,17 @@ void AP_DAL_InertialSensor::start_frame()
             RISI.get_delta_angle_ret = ins.get_delta_angle(i, RISI.delta_angle, RISI.delta_angle_dt);
         }
 
-        RISI.gyro_bias_limit = ins.get_gyro_bias_limit_rads(i);
-        RISI.gyro_bias_init_dps = ins.get_gyro_bias_init_dps(i);
-
         update_filtered(i);
 
         WRITE_REPLAY_BLOCK_IFCHANGED(RISI, RISI, old_RISI);
+
+        // RISJ holds per-instance gyro bias metadata. These are constants
+        // set by the backend, so the message is only written when changed.
+        log_RISJ &RISJ = _RISJ[i];
+        const log_RISJ old_RISJ = RISJ;
+        RISJ.gyro_bias_limit = ins.get_gyro_bias_limit_rads(i);
+        RISJ.gyro_bias_init_dps = ins.get_gyro_bias_init_dps(i);
+        WRITE_REPLAY_BLOCK_IFCHANGED(RISJ, RISJ, old_RISJ);
 
         // update sensor position
         pos[i] = ins.get_imu_pos_offset(i);

--- a/libraries/AP_DAL/AP_DAL_InertialSensor.cpp
+++ b/libraries/AP_DAL/AP_DAL_InertialSensor.cpp
@@ -41,7 +41,8 @@ void AP_DAL_InertialSensor::start_frame()
             RISI.get_delta_angle_ret = ins.get_delta_angle(i, RISI.delta_angle, RISI.delta_angle_dt);
         }
 
-        RISI.low_drift = ins.is_low_drift(i);
+        RISI.gyro_bias_limit = ins.get_gyro_bias_limit_rads(i);
+        RISI.gyro_bias_init_dps = ins.get_gyro_bias_init_dps(i);
 
         update_filtered(i);
 

--- a/libraries/AP_DAL/AP_DAL_InertialSensor.h
+++ b/libraries/AP_DAL/AP_DAL_InertialSensor.h
@@ -33,6 +33,7 @@ public:
     uint8_t get_first_usable_gyro(void) const { return _RISH.first_usable_gyro; };
 
     bool use_gyro(uint8_t instance) const { return _RISI[instance].use_gyro; }
+    bool is_low_drift(uint8_t instance) const { return _RISI[instance].low_drift; }
     const Vector3f     &get_gyro(uint8_t i) const { return gyro_filtered[i]; }
     const Vector3f     &get_gyro() const { return get_gyro(_primary_gyro); }
     bool get_delta_angle(uint8_t i, Vector3f &delta_angle, float &delta_angle_dt) const {

--- a/libraries/AP_DAL/AP_DAL_InertialSensor.h
+++ b/libraries/AP_DAL/AP_DAL_InertialSensor.h
@@ -33,8 +33,8 @@ public:
     uint8_t get_first_usable_gyro(void) const { return _RISH.first_usable_gyro; };
 
     bool use_gyro(uint8_t instance) const { return _RISI[instance].use_gyro; }
-    float get_gyro_bias_limit(uint8_t instance) const { return _RISI[instance].gyro_bias_limit; }
-    float get_gyro_bias_init_dps(uint8_t instance) const { return _RISI[instance].gyro_bias_init_dps; }
+    float get_gyro_bias_limit(uint8_t instance) const { return _RISJ[instance].gyro_bias_limit; }
+    float get_gyro_bias_init_dps(uint8_t instance) const { return _RISJ[instance].gyro_bias_init_dps; }
     const Vector3f     &get_gyro(uint8_t i) const { return gyro_filtered[i]; }
     const Vector3f     &get_gyro() const { return get_gyro(_primary_gyro); }
     bool get_delta_angle(uint8_t i, Vector3f &delta_angle, float &delta_angle_dt) const {
@@ -59,10 +59,14 @@ public:
         pos[msg.instance] = AP::ins().get_imu_pos_offset(msg.instance);
         update_filtered(msg.instance);
     }
+    void handle_message(const log_RISJ &msg) {
+        _RISJ[msg.instance] = msg;
+    }
 
 private:
     struct log_RISH _RISH;
     struct log_RISI _RISI[INS_MAX_INSTANCES];
+    struct log_RISJ _RISJ[INS_MAX_INSTANCES];
     float alpha;
 
     // sensor positions

--- a/libraries/AP_DAL/AP_DAL_InertialSensor.h
+++ b/libraries/AP_DAL/AP_DAL_InertialSensor.h
@@ -33,7 +33,8 @@ public:
     uint8_t get_first_usable_gyro(void) const { return _RISH.first_usable_gyro; };
 
     bool use_gyro(uint8_t instance) const { return _RISI[instance].use_gyro; }
-    bool is_low_drift(uint8_t instance) const { return _RISI[instance].low_drift; }
+    float get_gyro_bias_limit(uint8_t instance) const { return _RISI[instance].gyro_bias_limit; }
+    float get_gyro_bias_init_dps(uint8_t instance) const { return _RISI[instance].gyro_bias_init_dps; }
     const Vector3f     &get_gyro(uint8_t i) const { return gyro_filtered[i]; }
     const Vector3f     &get_gyro() const { return get_gyro(_primary_gyro); }
     bool get_delta_angle(uint8_t i, Vector3f &delta_angle, float &delta_angle_dt) const {

--- a/libraries/AP_DAL/LogStructure.h
+++ b/libraries/AP_DAL/LogStructure.h
@@ -19,6 +19,7 @@
     LOG_RFRN_MSG, \
     LOG_RISH_MSG, \
     LOG_RISI_MSG, \
+    LOG_RISJ_MSG, \
     LOG_RBRH_MSG, \
     LOG_RBRI_MSG, \
     LOG_RRNH_MSG, \
@@ -125,8 +126,6 @@ struct log_RISH {
 // @Field: DAZ: z-axis delta-angle
 // @Field: DVDT: delta-velocity-delta-time
 // @Field: DADT: delta-angle-delta-time
-// @Field: GBL: gyro bias limit (rad/s) for the EKF gyro bias state clamp
-// @Field: GBI: initial gyro bias 1-sigma uncertainty (deg/s)
 // @Field: Flags: use-accel, use-gyro, delta-vel-valid, delta-accel-valid
 // @Field: I: IMU instance
 struct log_RISI {
@@ -134,12 +133,22 @@ struct log_RISI {
     Vector3f delta_angle;
     float delta_velocity_dt;
     float delta_angle_dt;
-    float gyro_bias_limit;
-    float gyro_bias_init_dps;
     uint8_t use_accel:1;
     uint8_t use_gyro:1;
     uint8_t get_delta_velocity_ret:1;
     uint8_t get_delta_angle_ret:1;
+    uint8_t instance;
+    uint8_t _end;
+};
+
+// @LoggerMessage: RISJ
+// @Description: Replay Inertial Sensor instance metadata (low-rate, only logged when changed)
+// @Field: GBL: gyro bias limit (rad/s) for the EKF gyro bias state clamp
+// @Field: GBI: initial gyro bias 1-sigma uncertainty (deg/s)
+// @Field: I: IMU instance
+struct log_RISJ {
+    float gyro_bias_limit;
+    float gyro_bias_init_dps;
     uint8_t instance;
     uint8_t _end;
 };
@@ -619,7 +628,9 @@ struct log_RTER {
     { LOG_RISH_MSG, RLOG_SIZE(RISH),                                   \
       "RISH", "HBBfBB", "LR,PG,PA,LD,AC,GC", "------", "------" }, \
     { LOG_RISI_MSG, RLOG_SIZE(RISI),                                   \
-      "RISI", "ffffffffffBB", "DVX,DVY,DVZ,DAX,DAY,DAZ,DVDT,DADT,GBL,GBI,Flags,I", "-----------#", "------------" }, \
+      "RISI", "ffffffffBB", "DVX,DVY,DVZ,DAX,DAY,DAZ,DVDT,DADT,Flags,I", "---------#", "----------" }, \
+    { LOG_RISJ_MSG, RLOG_SIZE(RISJ),                                   \
+      "RISJ", "ffB", "GBL,GBI,I", "--#", "---" }, \
     { LOG_RASH_MSG, RLOG_SIZE(RASH),                                   \
       "RASH", "BB", "Primary,NumInst", "--", "--" },  \
     { LOG_RASI_MSG, RLOG_SIZE(RASI),                                   \

--- a/libraries/AP_DAL/LogStructure.h
+++ b/libraries/AP_DAL/LogStructure.h
@@ -125,18 +125,21 @@ struct log_RISH {
 // @Field: DAZ: z-axis delta-angle
 // @Field: DVDT: delta-velocity-delta-time
 // @Field: DADT: delta-angle-delta-time
-// @Field: Flags: use-accel, use-gyro, delta-vel-valid, delta-accel-valid, low-drift
+// @Field: GBL: gyro bias limit (rad/s) for the EKF gyro bias state clamp
+// @Field: GBI: initial gyro bias 1-sigma uncertainty (deg/s)
+// @Field: Flags: use-accel, use-gyro, delta-vel-valid, delta-accel-valid
 // @Field: I: IMU instance
 struct log_RISI {
     Vector3f delta_velocity;
     Vector3f delta_angle;
     float delta_velocity_dt;
     float delta_angle_dt;
+    float gyro_bias_limit;
+    float gyro_bias_init_dps;
     uint8_t use_accel:1;
     uint8_t use_gyro:1;
     uint8_t get_delta_velocity_ret:1;
     uint8_t get_delta_angle_ret:1;
-    uint8_t low_drift:1;
     uint8_t instance;
     uint8_t _end;
 };
@@ -616,7 +619,7 @@ struct log_RTER {
     { LOG_RISH_MSG, RLOG_SIZE(RISH),                                   \
       "RISH", "HBBfBB", "LR,PG,PA,LD,AC,GC", "------", "------" }, \
     { LOG_RISI_MSG, RLOG_SIZE(RISI),                                   \
-      "RISI", "ffffffffBB", "DVX,DVY,DVZ,DAX,DAY,DAZ,DVDT,DADT,Flags,I", "---------#", "----------" }, \
+      "RISI", "ffffffffffBB", "DVX,DVY,DVZ,DAX,DAY,DAZ,DVDT,DADT,GBL,GBI,Flags,I", "-----------#", "------------" }, \
     { LOG_RASH_MSG, RLOG_SIZE(RASH),                                   \
       "RASH", "BB", "Primary,NumInst", "--", "--" },  \
     { LOG_RASI_MSG, RLOG_SIZE(RASI),                                   \

--- a/libraries/AP_DAL/LogStructure.h
+++ b/libraries/AP_DAL/LogStructure.h
@@ -125,7 +125,7 @@ struct log_RISH {
 // @Field: DAZ: z-axis delta-angle
 // @Field: DVDT: delta-velocity-delta-time
 // @Field: DADT: delta-angle-delta-time
-// @Field: Flags: use-accel, use-gyro, delta-vel-valid, delta-accel-valid
+// @Field: Flags: use-accel, use-gyro, delta-vel-valid, delta-accel-valid, low-drift
 // @Field: I: IMU instance
 struct log_RISI {
     Vector3f delta_velocity;
@@ -136,6 +136,7 @@ struct log_RISI {
     uint8_t use_gyro:1;
     uint8_t get_delta_velocity_ret:1;
     uint8_t get_delta_angle_ret:1;
+    uint8_t low_drift:1;
     uint8_t instance;
     uint8_t _end;
 };

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -722,8 +722,6 @@ AP_InertialSensor::AP_InertialSensor() :
 
     for (uint8_t i=0; i<INS_MAX_INSTANCES; i++) {
         _gyro_cal_ok[i] = true;
-        _gyro_bias_limit_rads[i] = 0.5f;
-        _gyro_bias_init_dps[i] = 2.5f;
     }
     for (uint8_t i=0; i<INS_VIBRATION_CHECK_INSTANCES; i++) {
         _accel_vibe_floor_filter[i].set_cutoff_frequency(AP_INERTIAL_SENSOR_ACCEL_VIBE_FLOOR_FILT_HZ);
@@ -1510,6 +1508,36 @@ bool AP_InertialSensor::use_gyro(uint8_t instance) const
     }
 
     return (get_gyro_health(instance) && _use(instance));
+}
+
+// look up the backend that owns the given gyro instance, or nullptr
+const AP_InertialSensor_Backend *AP_InertialSensor::_find_gyro_backend(uint8_t instance) const
+{
+    for (uint8_t i = 0; i < _backend_count; i++) {
+        if (_backends[i] != nullptr && _backends[i]->get_gyro_instance() == instance) {
+            return _backends[i];
+        }
+    }
+    return nullptr;
+}
+
+float AP_InertialSensor::get_gyro_bias_limit_rads(uint8_t instance) const
+{
+    const auto *backend = _find_gyro_backend(instance);
+    if (backend == nullptr) {
+        // fall back to the legacy default if no backend has claimed this instance yet
+        return 0.5f;
+    }
+    return backend->gyro_bias_limit_rads();
+}
+
+float AP_InertialSensor::get_gyro_bias_init_dps(uint8_t instance) const
+{
+    const auto *backend = _find_gyro_backend(instance);
+    if (backend == nullptr) {
+        return 2.5f;
+    }
+    return backend->gyro_bias_init_dps();
 }
 
 // get_accel_health_all - return true if all accels are healthy

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -722,6 +722,8 @@ AP_InertialSensor::AP_InertialSensor() :
 
     for (uint8_t i=0; i<INS_MAX_INSTANCES; i++) {
         _gyro_cal_ok[i] = true;
+        _gyro_bias_limit_rads[i] = 0.5f;
+        _gyro_bias_init_dps[i] = 2.5f;
     }
     for (uint8_t i=0; i<INS_VIBRATION_CHECK_INSTANCES; i++) {
         _accel_vibe_floor_filter[i].set_cutoff_frequency(AP_INERTIAL_SENSOR_ACCEL_VIBE_FLOOR_FILT_HZ);

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -187,9 +187,16 @@ public:
         return _accel_pos(_first_usable_accel);
     }
 
-    // return true if this IMU instance is marked as low drift
-    bool is_low_drift(uint8_t instance) const {
-        return (_low_drift_mask & (1U<<instance)) != 0;
+    // return the gyro bias limit (rad/s) for this IMU instance.
+    // The EKF clamps its gyro bias state to this value.
+    float get_gyro_bias_limit_rads(uint8_t instance) const {
+        return _gyro_bias_limit_rads[instance];
+    }
+
+    // return the initial gyro bias 1-sigma uncertainty (deg/s) for this
+    // IMU instance, used to seed the EKF's gyro bias covariance.
+    float get_gyro_bias_init_dps(uint8_t instance) const {
+        return _gyro_bias_init_dps[instance];
     }
 
     // return the temperature if supported. Zero is returned if no
@@ -661,8 +668,12 @@ private:
     enum Rotation _gyro_orientation[INS_MAX_INSTANCES];
     enum Rotation _accel_orientation[INS_MAX_INSTANCES];
 
-    // bitmask of IMU instances marked as low drift
-    uint8_t _low_drift_mask;
+    // per-instance gyro bias metadata, populated by backends. The
+    // limit is the EKF gyro bias state clamp (rad/s); the init value
+    // is the initial 1-sigma bias uncertainty (deg/s) used to seed
+    // the EKF covariance at filter start.
+    float _gyro_bias_limit_rads[INS_MAX_INSTANCES];
+    float _gyro_bias_init_dps[INS_MAX_INSTANCES];
 
     // calibrated_ok/id_ok flags
     bool _gyro_cal_ok[INS_MAX_INSTANCES];

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -189,15 +189,11 @@ public:
 
     // return the gyro bias limit (rad/s) for this IMU instance.
     // The EKF clamps its gyro bias state to this value.
-    float get_gyro_bias_limit_rads(uint8_t instance) const {
-        return _gyro_bias_limit_rads[instance];
-    }
+    float get_gyro_bias_limit_rads(uint8_t instance) const;
 
     // return the initial gyro bias 1-sigma uncertainty (deg/s) for this
     // IMU instance, used to seed the EKF's gyro bias covariance.
-    float get_gyro_bias_init_dps(uint8_t instance) const {
-        return _gyro_bias_init_dps[instance];
-    }
+    float get_gyro_bias_init_dps(uint8_t instance) const;
 
     // return the temperature if supported. Zero is returned if no
     // temperature is available
@@ -513,7 +509,10 @@ private:
 
     // Logging function
     void Write_IMU_instance(const uint64_t time_us, const uint8_t imu_instance) const;
-    
+
+    // look up the backend that owns the given gyro instance, or nullptr
+    const AP_InertialSensor_Backend *_find_gyro_backend(uint8_t instance) const;
+
     // backend objects
     AP_InertialSensor_Backend *_backends[INS_MAX_BACKENDS];
 
@@ -667,13 +666,6 @@ private:
     // per-sensor orientation to allow for board type defaults at runtime
     enum Rotation _gyro_orientation[INS_MAX_INSTANCES];
     enum Rotation _accel_orientation[INS_MAX_INSTANCES];
-
-    // per-instance gyro bias metadata, populated by backends. The
-    // limit is the EKF gyro bias state clamp (rad/s); the init value
-    // is the initial 1-sigma bias uncertainty (deg/s) used to seed
-    // the EKF covariance at filter start.
-    float _gyro_bias_limit_rads[INS_MAX_INSTANCES];
-    float _gyro_bias_init_dps[INS_MAX_INSTANCES];
 
     // calibrated_ok/id_ok flags
     bool _gyro_cal_ok[INS_MAX_INSTANCES];

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -187,6 +187,11 @@ public:
         return _accel_pos(_first_usable_accel);
     }
 
+    // return true if this IMU instance is marked as low drift
+    bool is_low_drift(uint8_t instance) const {
+        return (_low_drift_mask & (1U<<instance)) != 0;
+    }
+
     // return the temperature if supported. Zero is returned if no
     // temperature is available
     float get_temperature(uint8_t instance) const { return _temperature[instance]; }
@@ -655,6 +660,9 @@ private:
     // per-sensor orientation to allow for board type defaults at runtime
     enum Rotation _gyro_orientation[INS_MAX_INSTANCES];
     enum Rotation _accel_orientation[INS_MAX_INSTANCES];
+
+    // bitmask of IMU instances marked as low drift
+    uint8_t _low_drift_mask;
 
     // calibrated_ok/id_ok flags
     bool _gyro_cal_ok[INS_MAX_INSTANCES];

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -107,6 +107,25 @@ public:
         return _gyro_raw_sample_rate(gyro_instance);
     }
 
+    // return the maximum allowed gyro bias for this sensor (rad/s).
+    // The EKF clamps its gyro bias state to this value.
+    virtual float gyro_bias_limit_rads() const {
+        return 0.5f;
+    }
+
+    // return the initial 1-sigma gyro bias uncertainty for this sensor (deg/s)
+    virtual float gyro_bias_init_dps() const {
+        return 2.5f;
+    }
+
+    uint8_t get_gyro_instance() const {
+        return gyro_instance;
+    }
+
+    uint8_t get_accel_instance() const {
+        return accel_instance;
+    }
+
     /*
       device driver IDs. These are used to fill in the devtype field
       of the device ID, which shows up as INS*ID* parameters to
@@ -315,32 +334,6 @@ protected:
 
     void set_accel_orientation(uint8_t instance, enum Rotation rotation) {
         _imu._accel_orientation[instance] = rotation;
-    }
-
-    // return the maximum allowed gyro bias for this sensor (rad/s).
-    // The EKF clamps its gyro bias state to this value.
-    virtual float gyro_bias_limit_rads() const {
-        return 0.5f;
-    }
-
-    // return the initial 1-sigma gyro bias uncertainty for this sensor (deg/s)
-    virtual float gyro_bias_init_dps() const {
-        return 2.5f;
-    }
-
-    // publish this backend's gyro bias metadata into the frontend's
-    // per-instance arrays so the EKF (via the DAL) can use it.
-    void set_gyro_bias_metadata(uint8_t instance) {
-        _imu._gyro_bias_limit_rads[instance] = gyro_bias_limit_rads();
-        _imu._gyro_bias_init_dps[instance] = gyro_bias_init_dps();
-    }
-
-    uint8_t get_gyro_instance() const {
-        return gyro_instance;
-    }
-
-    uint8_t get_accel_instance() const {
-        return accel_instance;
     }
 
     // increment clipping counted. Used by drivers that do decimation before supplying

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -317,9 +317,22 @@ protected:
         _imu._accel_orientation[instance] = rotation;
     }
 
-    // mark an IMU instance as low drift for EKF bias learning
-    void set_low_drift(uint8_t instance) {
-        _imu._low_drift_mask |= (1U<<instance);
+    // return the maximum allowed gyro bias for this sensor (rad/s).
+    // The EKF clamps its gyro bias state to this value.
+    virtual float gyro_bias_limit_rads() const {
+        return 0.5f;
+    }
+
+    // return the initial 1-sigma gyro bias uncertainty for this sensor (deg/s)
+    virtual float gyro_bias_init_dps() const {
+        return 2.5f;
+    }
+
+    // publish this backend's gyro bias metadata into the frontend's
+    // per-instance arrays so the EKF (via the DAL) can use it.
+    void set_gyro_bias_metadata(uint8_t instance) {
+        _imu._gyro_bias_limit_rads[instance] = gyro_bias_limit_rads();
+        _imu._gyro_bias_init_dps[instance] = gyro_bias_init_dps();
     }
 
     uint8_t get_gyro_instance() const {

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -33,6 +33,11 @@
 #define HAL_INS_HIGHRES_SAMPLE 0
 #endif
 
+// define to control EKF low-noise bias learning
+#ifndef HAL_INS_LOW_NOISE
+#define HAL_INS_LOW_NOISE 0
+#endif
+
 class AuxiliaryBus;
 class AP_Logger;
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -33,11 +33,6 @@
 #define HAL_INS_HIGHRES_SAMPLE 0
 #endif
 
-// define to control EKF low-noise bias learning
-#ifndef HAL_INS_LOW_NOISE
-#define HAL_INS_LOW_NOISE 0
-#endif
-
 class AuxiliaryBus;
 class AP_Logger;
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -317,6 +317,11 @@ protected:
         _imu._accel_orientation[instance] = rotation;
     }
 
+    // mark an IMU instance as low drift for EKF bias learning
+    void set_low_drift(uint8_t instance) {
+        _imu._low_drift_mask |= (1U<<instance);
+    }
+
     uint8_t get_gyro_instance() const {
         return gyro_instance;
     }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
@@ -379,6 +379,9 @@ void AP_InertialSensor_Invensensev3::start()
     set_gyro_orientation(gyro_instance, rotation);
     set_accel_orientation(accel_instance, rotation);
 
+    // Invensensev3 sensors are low drift
+    set_low_drift(gyro_instance);
+
     // allocate fifo buffer
 #if HAL_INS_HIGHRES_SAMPLE
     if (highres_sampling) {

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
@@ -379,9 +379,6 @@ void AP_InertialSensor_Invensensev3::start()
     set_gyro_orientation(gyro_instance, rotation);
     set_accel_orientation(accel_instance, rotation);
 
-    // publish per-instance gyro bias metadata to the frontend
-    set_gyro_bias_metadata(gyro_instance);
-
     // allocate fifo buffer
 #if HAL_INS_HIGHRES_SAMPLE
     if (highres_sampling) {

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
@@ -256,6 +256,43 @@ void AP_InertialSensor_Invensensev3::fifo_reset()
     notify_gyro_fifo_reset(gyro_instance);
 }
 
+// see header for the per-variant rationale and datasheet references
+float AP_InertialSensor_Invensensev3::gyro_bias_limit_rads() const
+{
+    switch (inv3_type) {
+    case Invensensev3_Type::ICM42688:
+    case Invensensev3_Type::ICM45686:
+        return radians(2.0f);
+    case Invensensev3_Type::ICM42605:
+    case Invensensev3_Type::ICM40609:
+    case Invensensev3_Type::ICM42670:
+    case Invensensev3_Type::IIM42652:
+        return radians(3.0f);
+    case Invensensev3_Type::ICM40605:
+    case Invensensev3_Type::IIM42653:
+        break;
+    }
+    return AP_InertialSensor_Backend::gyro_bias_limit_rads();
+}
+
+float AP_InertialSensor_Invensensev3::gyro_bias_init_dps() const
+{
+    switch (inv3_type) {
+    case Invensensev3_Type::ICM42688:
+    case Invensensev3_Type::ICM45686:
+        return 1.0f;
+    case Invensensev3_Type::ICM42605:
+    case Invensensev3_Type::ICM40609:
+    case Invensensev3_Type::ICM42670:
+    case Invensensev3_Type::IIM42652:
+        return 1.5f;
+    case Invensensev3_Type::ICM40605:
+    case Invensensev3_Type::IIM42653:
+        break;
+    }
+    return AP_InertialSensor_Backend::gyro_bias_init_dps();
+}
+
 void AP_InertialSensor_Invensensev3::start()
 {
     // pre-fetch instance numbers for checking fast sampling settings

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
@@ -379,8 +379,8 @@ void AP_InertialSensor_Invensensev3::start()
     set_gyro_orientation(gyro_instance, rotation);
     set_accel_orientation(accel_instance, rotation);
 
-    // Invensensev3 sensors are low drift
-    set_low_drift(gyro_instance);
+    // publish per-instance gyro bias metadata to the frontend
+    set_gyro_bias_metadata(gyro_instance);
 
     // allocate fifo buffer
 #if HAL_INS_HIGHRES_SAMPLE

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.h
@@ -83,9 +83,14 @@ private:
         return backend_rate_hz;
     }
 
-    // Invensensev3 sensors have very low gyro drift compared to the
-    // legacy default, so the EKF can clamp the bias state much tighter
-    // and seed the bias covariance with a smaller initial uncertainty.
+    // The EKF clamps and the initial covariance below act on the
+    // residual gyro bias after ArduPilot's startup calibration has
+    // removed the static offset. Across the v3 family (ICM-42605,
+    // ICM-42688, ICM-40605, ICM-40609, ICM-42670, ICM-45686, IIM-42652,
+    // IIM-42653), residual drift over a flight is dominated by bias
+    // instability plus temperature drift and is well under 1 deg/s, so
+    // a 2 deg/s clamp and 1 deg/s init uncertainty are conservative for
+    // all variants.
     float gyro_bias_limit_rads() const override {
         return radians(2.0f); // 0.035 rad/s
     }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.h
@@ -83,20 +83,24 @@ private:
         return backend_rate_hz;
     }
 
-    // The EKF clamps and the initial covariance below act on the
-    // residual gyro bias after ArduPilot's startup calibration has
-    // removed the static offset. Across the v3 family (ICM-42605,
-    // ICM-42688, ICM-40605, ICM-40609, ICM-42670, ICM-45686, IIM-42652,
-    // IIM-42653), residual drift over a flight is dominated by bias
-    // instability plus temperature drift and is well under 1 deg/s, so
-    // a 2 deg/s clamp and 1 deg/s init uncertainty are conservative for
-    // all variants.
-    float gyro_bias_limit_rads() const override {
-        return radians(2.0f); // 0.035 rad/s
-    }
-    float gyro_bias_init_dps() const override {
-        return 1.0f;
-    }
+    // The EKF clamp acts on residual gyro bias after ArduPilot's
+    // startup calibration has removed the static ZRO. Residual drift
+    // over a flight is therefore dominated by ZRO temperature drift
+    // (temp coefficient x in-flight temperature swing). The v3 family
+    // has a wide spread in this coefficient, so the override is tiered:
+    //
+    //   tier  parts                    ZRO drift   limit / init
+    //   ----  -----------------------  ----------  ------------------
+    //   low   ICM-42688-P, ICM-45686   0.005/C     radians(2.0) / 1.0
+    //   mid   ICM-42605, ICM-40609-D,  0.01-0.02/C radians(3.0) / 1.5
+    //         ICM-42670-P, IIM-42652
+    //   none  ICM-40605, IIM-42653,    0.04/C or   base default
+    //         (anything else)          unknown     (0.5 rad/s / 2.5)
+    //
+    // See datasheets DS-000347, DS-000489, DS-000292, DS-000330,
+    // DS-000451, DS-000440, DS-000529.
+    float gyro_bias_limit_rads() const override;
+    float gyro_bias_init_dps() const override;
 
     // reset FIFO configure1 register
     uint8_t fifo_config1;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.h
@@ -83,6 +83,16 @@ private:
         return backend_rate_hz;
     }
 
+    // Invensensev3 sensors have very low gyro drift compared to the
+    // legacy default, so the EKF can clamp the bias state much tighter
+    // and seed the bias covariance with a smaller initial uncertainty.
+    float gyro_bias_limit_rads() const override {
+        return radians(2.0f); // 0.035 rad/s
+    }
+    float gyro_bias_init_dps() const override {
+        return 1.0f;
+    }
+
     // reset FIFO configure1 register
     uint8_t fifo_config1;
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_config.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_config.h
@@ -91,3 +91,8 @@
 #ifndef AP_INERTIALSENSOR_RST_ENABLED
 #define AP_INERTIALSENSOR_RST_ENABLED 0
 #endif // AP_INERTIALSENSOR_RST_ENABLED
+
+// define to control EKF low-noise bias learning
+#ifndef AP_INERTIALSENSOR_LOW_NOISE
+#define AP_INERTIALSENSOR_LOW_NOISE 0
+#endif

--- a/libraries/AP_InertialSensor/AP_InertialSensor_config.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_config.h
@@ -91,8 +91,3 @@
 #ifndef AP_INERTIALSENSOR_RST_ENABLED
 #define AP_INERTIALSENSOR_RST_ENABLED 0
 #endif // AP_INERTIALSENSOR_RST_ENABLED
-
-// define to control EKF low-noise bias learning
-#ifndef AP_INERTIALSENSOR_LOW_NOISE
-#define AP_INERTIALSENSOR_LOW_NOISE 0
-#endif

--- a/libraries/AP_NavEKF3/AP_NavEKF3_GyroBias.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_GyroBias.cpp
@@ -16,24 +16,18 @@ void NavEKF3_core::resetGyroBias(void)
 }
 
 /*
-   vehicle specific initial gyro bias uncertainty in deg/sec
+   sensor specific initial gyro bias 1-sigma uncertainty in deg/sec
  */
 ftype NavEKF3_core::InitialGyroBiasUncertainty(void) const
 {
-    if (dal.ins().is_low_drift(imu_index)) {
-        return 1.0f;
-    }
-    return 2.5f;
+    return dal.ins().get_gyro_bias_init_dps(imu_index);
 }
 
 /*
-   get the gyro bias limit for this core's IMU
+   get the gyro bias state clamp (rad/s) for this core's IMU
  */
 ftype NavEKF3_core::getGyroBiasLimit(void) const
 {
-    if (dal.ins().is_low_drift(imu_index)) {
-        return GYRO_BIAS_LIMIT_LOW_DRIFT;
-    }
-    return GYRO_BIAS_LIMIT;
+    return dal.ins().get_gyro_bias_limit(imu_index);
 }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_GyroBias.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_GyroBias.cpp
@@ -19,6 +19,10 @@ void NavEKF3_core::resetGyroBias(void)
  */
 ftype NavEKF3_core::InitialGyroBiasUncertainty(void) const
 {
+#if AP_INERTIALSENSOR_LOW_NOISE
+    return 1.0f;
+#else
     return 2.5f;
+#endif
 }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_GyroBias.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_GyroBias.cpp
@@ -1,4 +1,5 @@
 #include "AP_NavEKF3_core.h"
+#include <AP_DAL/AP_DAL.h>
 
 // reset the body axis gyro bias states to zero and re-initialise the corresponding covariances
 // Assume that the calibration is performed to an accuracy of 0.5 deg/sec which will require averaging under static conditions
@@ -19,10 +20,20 @@ void NavEKF3_core::resetGyroBias(void)
  */
 ftype NavEKF3_core::InitialGyroBiasUncertainty(void) const
 {
-#if AP_INERTIALSENSOR_LOW_NOISE
-    return 1.0f;
-#else
+    if (dal.ins().is_low_drift(imu_index)) {
+        return 1.0f;
+    }
     return 2.5f;
-#endif
+}
+
+/*
+   get the gyro bias limit for this core's IMU
+ */
+ftype NavEKF3_core::getGyroBiasLimit(void) const
+{
+    if (dal.ins().is_low_drift(imu_index)) {
+        return GYRO_BIAS_LIMIT_LOW_DRIFT;
+    }
+    return GYRO_BIAS_LIMIT;
 }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -2087,7 +2087,8 @@ void NavEKF3_core::ConstrainStates()
     // height limit covers home alt on everest through to home alt at SL and balloon drop
     stateStruct.position.z = constrain_ftype(stateStruct.position.z,-4.0e4f,1.0e4f);
     // gyro bias limit (this needs to be set based on manufacturers specs)
-    for (uint8_t i=10; i<=12; i++) statesArray[i] = constrain_ftype(statesArray[i],-GYRO_BIAS_LIMIT*dtEkfAvg,GYRO_BIAS_LIMIT*dtEkfAvg);
+    const ftype gyro_bias_limit = getGyroBiasLimit();
+    for (uint8_t i=10; i<=12; i++) statesArray[i] = constrain_ftype(statesArray[i],-gyro_bias_limit*dtEkfAvg,gyro_bias_limit*dtEkfAvg);
     // the accelerometer bias limit is controlled by a user adjustable parameter
     for (uint8_t i=13; i<=15; i++) statesArray[i] = constrain_ftype(statesArray[i],-frontend->_accBiasLim*dtEkfAvg,frontend->_accBiasLim*dtEkfAvg);
     // earth magnetic field limit

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -49,7 +49,11 @@
 #define earthRate 0.000072921f // earth rotation rate (rad/sec)
 
 // maximum allowed gyro bias (rad/sec)
+#if AP_INERTIALSENSOR_LOW_NOISE
+#define GYRO_BIAS_LIMIT radians(2.0f)
+#else
 #define GYRO_BIAS_LIMIT 0.5f
+#endif
 
 // initial accel bias uncertainty as a fraction of the state limit
 #define ACCEL_BIAS_LIM_SCALER 0.2f

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -48,10 +48,6 @@
 
 #define earthRate 0.000072921f // earth rotation rate (rad/sec)
 
-// maximum allowed gyro bias (rad/sec)
-#define GYRO_BIAS_LIMIT 0.5f
-#define GYRO_BIAS_LIMIT_LOW_DRIFT radians(2.0f) // 0.035
-
 // initial accel bias uncertainty as a fraction of the state limit
 #define ACCEL_BIAS_LIM_SCALER 0.2f
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -50,7 +50,7 @@
 
 // maximum allowed gyro bias (rad/sec)
 #define GYRO_BIAS_LIMIT 0.5f
-#define GYRO_BIAS_LIMIT_LOW_DRIFT radians(2.0f)
+#define GYRO_BIAS_LIMIT_LOW_DRIFT radians(2.0f) // 0.035
 
 // initial accel bias uncertainty as a fraction of the state limit
 #define ACCEL_BIAS_LIM_SCALER 0.2f

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -49,11 +49,8 @@
 #define earthRate 0.000072921f // earth rotation rate (rad/sec)
 
 // maximum allowed gyro bias (rad/sec)
-#if AP_INERTIALSENSOR_LOW_NOISE
-#define GYRO_BIAS_LIMIT radians(2.0f)
-#else
 #define GYRO_BIAS_LIMIT 0.5f
-#endif
+#define GYRO_BIAS_LIMIT_LOW_DRIFT radians(2.0f)
 
 // initial accel bias uncertainty as a fraction of the state limit
 #define ACCEL_BIAS_LIM_SCALER 0.2f
@@ -1618,6 +1615,9 @@ private:
 
     // vehicle specific initial gyro bias uncertainty
     ftype InitialGyroBiasUncertainty(void) const;
+
+    // get the gyro bias limit for this core's IMU
+    ftype getGyroBiasLimit(void) const;
 
     /*
       learn magnetometer biases from GPS yaw. Return true if the


### PR DESCRIPTION
## Summary

- Add `AP_INERTIALSENSOR_LOW_NOISE` define that boards can set in their hwdef to indicate a low-noise IMU configuration
- When enabled, reduce EKF3 gyro bias learning limits (`GYRO_BIAS_LIMIT` from 0.5 to `radians(2.0)` and `InitialGyroBiasUncertainty` from 2.5 to 1.0) since low-noise IMUs don't need as wide bias estimation range

This allows boards with known low-noise IMUs (e.g. ICM-42688-P with good vibration isolation) to get tighter EKF tuning automatically, improving convergence speed and reducing false bias estimates.

## Test plan

- [x] Build with `AP_INERTIALSENSOR_LOW_NOISE0` (default) - verify unchanged behavior
- [x] Build with `AP_INERTIALSENSOR_LOW_NOISE1` in hwdef - verify tighter bias limits
- [x] SITL test comparing EKF3 gyro bias convergence with and without the flag
- [x] Verify no build warnings or errors on common boards