### PR TITLE
Copter: add pending arm on switch for in-air arming

### DIFF
--- a/ArduCopter/AP_Arming_Copter.cpp
+++ b/ArduCopter/AP_Arming_Copter.cpp
@@ -784,6 +784,77 @@ bool AP_Arming_Copter::arm(const AP_Arming::Method method, const bool do_arming_
     return true;
 }
 
+// set_pending_arm - enter pending arm state, will retry until checks pass
+void AP_Arming_Copter::set_pending_arm(bool with_airmode)
+{
+    AP_Arming::set_pending_arm(with_airmode);
+    _pending_arm_airmode = with_airmode;
+    const uint32_t now_ms = millis();
+    _pending_arm_start_ms = now_ms;
+    _pending_arm_last_check_ms = 0;
+    _pending_arm_last_display_ms = now_ms;
+
+    // run checks with display to show actual failure reason immediately
+    gcs().send_text(MAV_SEVERITY_INFO, "Arm pending");
+    pre_arm_checks(true);
+}
+
+// clear_pending_arm - cancel pending arm state
+void AP_Arming_Copter::clear_pending_arm()
+{
+    if (_pending_arm) {
+        AP_Arming::clear_pending_arm();
+        gcs().send_text(MAV_SEVERITY_INFO, "Arm pending cancelled");
+    }
+}
+
+// update_pending_arm - retry arming periodically while pending
+// called at 10Hz from arm_motors_check
+void AP_Arming_Copter::update_pending_arm()
+{
+    if (!_pending_arm) {
+        return;
+    }
+
+    const uint32_t now_ms = millis();
+
+    // run pre-arm checks at 4Hz (every 250ms) for faster response
+    const bool run_checks = (now_ms - _pending_arm_last_check_ms >= 250);
+    if (run_checks) {
+        _pending_arm_last_check_ms = now_ms;
+
+        // display failure reason every 3 seconds
+        const bool display = (now_ms - _pending_arm_last_display_ms >= 3000);
+        if (pre_arm_checks(display)) {
+            // checks pass — attempt to arm
+            if (arm(AP_Arming::Method::AUXSWITCH)) {
+                if (_pending_arm_airmode) {
+                    copter.ap.armed_with_airmode_switch = true;
+                }
+                _pending_arm = false;
+                gcs().send_text(MAV_SEVERITY_INFO, "Arm pending complete");
+                return;
+            }
+        }
+        if (display) {
+            _pending_arm_last_display_ms = now_ms;
+        }
+    }
+#if AP_AHRS_EKF_RESET_ENABLED
+    // after timeout, reset EKF bootstrap once to force convergence.
+    // only fire once — repeated resets prevent the EKF from converging.
+    const float timeout_s = _pending_arm_timeout_s;
+    if (timeout_s > 0 && _pending_arm_start_ms != 0 &&
+        (now_ms - _pending_arm_start_ms >= uint32_t(timeout_s * 1000))) {
+        if (AP::ahrs().reset_configured_backend()) {
+            gcs().send_text(MAV_SEVERITY_INFO, "Arm pending: EKF bootstrap reset");
+        }
+        // clear so we don't reset again
+        _pending_arm_start_ms = 0;
+    }
+#endif
+}
+
 // arming.disarm - disarm motors
 bool AP_Arming_Copter::disarm(const AP_Arming::Method method, bool do_disarm_checks)
 {
@@ -791,6 +862,9 @@ bool AP_Arming_Copter::disarm(const AP_Arming::Method method, bool do_disarm_che
     if (!copter.motors->armed()) {
         return true;
     }
+
+    // cancel any pending arm request when actually disarming
+    clear_pending_arm();
 
     // do not allow disarm via mavlink if we think we are flying:
     if (do_disarm_checks &&

--- a/ArduCopter/AP_Arming_Copter.h
+++ b/ArduCopter/AP_Arming_Copter.h
@@ -23,6 +23,11 @@ public:
     bool disarm(AP_Arming::Method method, bool do_disarm_checks=true) override;
     bool arm(AP_Arming::Method method, bool do_arming_checks=true) override;
 
+    // pending arm - waits for pre-arm checks to pass after switch toggle
+    void set_pending_arm(bool with_airmode) override;
+    void clear_pending_arm() override;
+    void update_pending_arm();
+
 protected:
 
     bool pre_arm_checks(bool display_failure) override;
@@ -62,4 +67,9 @@ private:
     // we can store away success/failure of the checks.
     bool run_pre_arm_checks(bool display_failure);
 
+    // pending arm state - waits for checks to pass after switch toggle
+    bool _pending_arm_airmode;
+    uint32_t _pending_arm_start_ms;
+    uint32_t _pending_arm_last_check_ms;
+    uint32_t _pending_arm_last_display_ms;
 };

--- a/ArduCopter/RC_Channel_Copter.cpp
+++ b/ArduCopter/RC_Channel_Copter.cpp
@@ -650,10 +650,29 @@ bool RC_Channel_Copter::do_aux_function(const AuxFuncTrigger &trigger)
             }
             break;
 
+        case AUX_FUNC::ARMDISARM:
+            if (ch_flag == AuxSwitchPos::HIGH) {
+                if (!copter.arming.arm(AP_Arming::Method::AUXSWITCH)) {
+                    if (copter.arming.option_enabled(AP_Arming::Option::PENDING_ARM_ON_SWITCH)) {
+                        copter.arming.set_pending_arm(false);
+                    }
+                }
+            } else if (ch_flag == AuxSwitchPos::LOW) {
+                copter.arming.clear_pending_arm();
+                copter.arming.disarm(AP_Arming::Method::AUXSWITCH);
+            }
+            break;
+
         case AUX_FUNC::ARMDISARM_AIRMODE:
-            RC_Channel::do_aux_function_armdisarm(ch_flag);
-            if (copter.arming.is_armed()) {
-                copter.ap.armed_with_airmode_switch = true;
+            if (ch_flag == AuxSwitchPos::HIGH) {
+                if (copter.arming.arm(AP_Arming::Method::AUXSWITCH)) {
+                    copter.ap.armed_with_airmode_switch = true;
+                } else if (copter.arming.option_enabled(AP_Arming::Option::PENDING_ARM_ON_SWITCH)) {
+                    copter.arming.set_pending_arm(true);
+                }
+            } else if (ch_flag == AuxSwitchPos::LOW) {
+                copter.arming.clear_pending_arm();
+                copter.arming.disarm(AP_Arming::Method::AUXSWITCH);
             }
             break;
 

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -10,6 +10,9 @@ static uint32_t auto_disarm_begin;
 // unless takeoff/spool-up is being requested or auto-disarm is disabled.
 void Copter::auto_disarm_check()
 {
+    // service pending arm requests (retry arming until EKF ready)
+    arming.update_pending_arm();
+
     uint32_t tnow_ms = millis();
     uint32_t disarm_delay_ms = 1000*constrain_int16(g.disarm_delay, 0, INT8_MAX);
 

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -166,7 +166,7 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: Arming options
     // @Description: Options that can be applied to change arming behaviour
-    // @Bitmask: 0:Disable prearm display,1:Do not send status text on state change,2:Skip IMU consistency checks when ICE motor running
+    // @Bitmask: 0:Disable prearm display,1:Do not send status text on state change,2:Skip IMU consistency checks when ICE motor running,3:Pending arm on switch
     // @User: Advanced
     AP_GROUPINFO("OPTIONS", 9,   AP_Arming, _arming_options, 0),
 
@@ -203,6 +203,14 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     // @Bitmask{Plane}: 1:Barometer,2:Compass,3:GPS lock,4:INS,5:Parameters,6:RC Channels,7:Board voltage,8:Battery Level,9:Airspeed,10:Logging Available,11:Hardware safety switch,12:GPS Configuration,13:System,14:Mission,15:Rangefinder,16:Camera,17:AuxAuth,19:FFT
     // @User: Standard
     AP_GROUPINFO("SKIPCHK", 13, AP_Arming, checks_to_skip, 0),
+
+    // @Param: PEND_TIM
+    // @DisplayName: Pending Arm EKF Reset Time
+    // @Description: When pending arm on switch is active (ARMING_OPTIONS bit 3), the EKF bootstrap will be reset after this many seconds if arming has not yet succeeded. Set to 0 to disable the EKF reset.
+    // @Units: s
+    // @Range: 0 30
+    // @User: Advanced
+    AP_GROUPINFO("PEND_TIM", 15, AP_Arming, _pending_arm_timeout_s, 5),
 
     AP_GROUPEND
 };

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -108,6 +108,10 @@ public:
     bool is_armed() const;
     bool is_armed_and_safety_off() const;
 
+    // pending arm - waits for pre-arm checks to pass after switch toggle
+    virtual void set_pending_arm(bool with_airmode) { _pending_arm = true; }
+    virtual void clear_pending_arm() { _pending_arm = false; }
+
     // Returns the time since boot (in microseconds) that we armed. Returns 0 if disarmed.
     uint64_t arm_time_us() const { return is_armed() ? last_arm_time_us : 0; }
 
@@ -162,6 +166,7 @@ public:
         DISABLE_PREARM_DISPLAY             = (1U << 0),
         DISABLE_STATUSTEXT_ON_STATE_CHANGE = (1U << 1),
         SKIP_IMU_CONSISTENCY_ICE_RUNNING   = (1U << 2),
+        PENDING_ARM_ON_SWITCH              = (1U << 3),
     };
     bool option_enabled(Option option) const {
         return (_arming_options & uint32_t(option)) != 0;
@@ -189,11 +194,14 @@ protected:
     AP_Int32                _arming_options;
     AP_Int16                magfield_error_threshold;
     AP_Enum<RequireLocation> require_location;
+    AP_Float                 _pending_arm_timeout_s;
 
     // internal members
     bool                    armed;
     uint32_t                last_accel_pass_ms;
     uint32_t                last_gyro_pass_ms;
+    // pending arm flag
+    bool _pending_arm;
 
     virtual bool barometer_checks(bool report);
 

--- a/libraries/RC_Channel/RC_Channels.cpp
+++ b/libraries/RC_Channel/RC_Channels.cpp
@@ -460,12 +460,9 @@ void RC_Channels::rudder_arm_disarm_check()
     // time to try to arm or disarm:
     rudder_arm_timer = 0;
     if (control_in > 4000) {
-        if (!AP::arming().arm(AP_Arming::Method::RUDDER)) {
-            // arming failed, set pending arm if option is enabled
-            if (AP::arming().option_enabled(AP_Arming::Option::PENDING_ARM_ON_SWITCH)) {
-                AP::arming().set_pending_arm(false);
-            }
-        }
+        // PENDING_ARM_ON_SWITCH applies only to the arming switch, so a failed
+        // rudder arm does not enter the pending-arm retry state
+        AP::arming().arm(AP_Arming::Method::RUDDER);
         have_seen_neutral_rudder = false;
     } else {
         if (AP::arming().get_rudder_arming_type() == AP_Arming::RudderArming::ARMDISARM) {

--- a/libraries/RC_Channel/RC_Channels.cpp
+++ b/libraries/RC_Channel/RC_Channels.cpp
@@ -460,12 +460,19 @@ void RC_Channels::rudder_arm_disarm_check()
     // time to try to arm or disarm:
     rudder_arm_timer = 0;
     if (control_in > 4000) {
-        AP::arming().arm(AP_Arming::Method::RUDDER);
+        if (!AP::arming().arm(AP_Arming::Method::RUDDER)) {
+            // arming failed, set pending arm if option is enabled
+            if (AP::arming().option_enabled(AP_Arming::Option::PENDING_ARM_ON_SWITCH)) {
+                AP::arming().set_pending_arm(false);
+            }
+        }
         have_seen_neutral_rudder = false;
     } else {
         if (AP::arming().get_rudder_arming_type() == AP_Arming::RudderArming::ARMDISARM) {
             AP::arming().disarm(AP_Arming::Method::RUDDER);
         }
+        // cancel pending arm on left rudder even if already disarmed
+        AP::arming().clear_pending_arm();
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a "pending arm" mechanism that allows arming to be requested before the EKF is ready, with automatic completion once checks pass. This enables workflows where the pilot requests arm while the EKF is still bootstrapping (e.g. after a reset), and the vehicle arms automatically when ready.

- Add `PENDING_ARM_ON_SWITCH` arming option bit that enables pending arm via RC switch or rudder stick
- Add `ARMING_PEND_TIM` parameter to configure EKF bootstrap reset timeout during pending arm
- Perform EKF bootstrap reset when pending arm is requested, with configurable timeout
- Reinitialize position controllers after EKF bootstrap reset to avoid stale state
- Only perform bootstrap reset once per pending arm request
- Improve pending arm feedback with faster check intervals and better GCS messages
- Enable pending arm for rudder stick arming (set pending on arm failure, clear on disarm rudder)

**Depends on:** #32202 (EKF bootstrap reset aux function)

## Test plan

- [ ] Test pending arm via RC switch - verify arms when EKF ready
- [ ] Test pending arm via rudder stick - verify set on failed arm, clear on left rudder
- [ ] Test ARMING_PEND_TIM timeout - verify EKF reset occurs and times out correctly
- [ ] Test position controller reinit after reset - verify no position jump
- [ ] Verify pending arm only triggers bootstrap reset once
- [ ] Test cancel pending arm with left rudder or switch off