### PR TITLE
AC_PrecLand: ORIENT param visible only for Rovers

### DIFF
--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -182,13 +182,13 @@ const AP_Param::GroupInfo AC_PrecLand::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("OPTIONS", 17, AC_PrecLand, _options, 0),
 
-    // @Param{Rover,Copter}: ORIENT
+    // @Param{Rover}: ORIENT
     // @DisplayName: Camera Orientation
     // @Description: Orientation of camera/sensor on body
     // @Values: 0:Forward, 4:Back, 25:Down
     // @User: Advanced
     // @RebootRequired: True
-    AP_GROUPINFO_FRAME("ORIENT", 18, AC_PrecLand, _orient, AC_PRECLAND_ORIENT_DEFAULT, AP_PARAM_FRAME_ROVER | AP_PARAM_FRAME_COPTER | AP_PARAM_FRAME_TRICOPTER | AP_PARAM_FRAME_HELI), 
+    AP_GROUPINFO_FRAME("ORIENT", 18, AC_PrecLand, _orient, AC_PRECLAND_ORIENT_DEFAULT, AP_PARAM_FRAME_ROVER), 
 
     AP_GROUPEND
 };


### PR DESCRIPTION
## Summary

Precision Landing is supported for Copters and Rovers but Copters only support using a downward facing sensor while Rovers only support forward or backwards facing sensors.

This change reverts PR https://github.com/ArduPilot/ardupilot/pull/31483 and makes the ORIENT parameter invisible for Copter users.

I've tested this lightly in SITL to confirm:

1. parameter is visible for Rover, invisible for Copter
2. default values are still correct (25 for Copter, 0 for Rover)

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [x] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included
