### PR TITLE
Copter: run takeoff CPU check even if RPM check is disabled

### DIFF
--- a/ArduCopter/takeoff_check.cpp
+++ b/ArduCopter/takeoff_check.cpp
@@ -9,13 +9,16 @@ void Copter::takeoff_check()
 {
 #if HAL_WITH_ESC_TELEM && FRAME_CONFIG != HELI_FRAME
     // If takeoff check is disabled or vehicle is armed and flying then clear block and return
-    if ((g2.takeoff_rpm_min <= 0) || (motors->armed() && !ap.land_complete)) {
+    if (motors->armed() && !ap.land_complete) {
         motors->set_spoolup_block(false);
         return;
     }
 
     // Run the common motor checks (called early so it can clear its warning timer when disarmed)
-    const bool motor_check_passed = motors_takeoff_check(g2.takeoff_rpm_min, g2.takeoff_rpm_max);
+    bool motor_check_ok = true;
+    if (g2.takeoff_rpm_min > 0) {
+        motor_check_ok = motors_takeoff_check(g2.takeoff_rpm_min, g2.takeoff_rpm_max);
+    }
 
     // block takeoff when disarmed but do not display warnings
     if (!motors->armed()) {
@@ -40,7 +43,7 @@ void Copter::takeoff_check()
     }
 
     // Clear block if all checks passed
-    if (motor_check_passed && load_adequate) {
+    if (motor_check_ok && load_adequate) {
         motors->set_spoolup_block(false);
         return;
     }


### PR DESCRIPTION
## Summary

Makes Copter check the CPU load before allowing takeoff, even when RPM checking is disabled.

## Testing (more checks increases chance of being merged)

- [ ] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

When reviewing https://github.com/ArduPilot/ardupilot/pull/32393 I noticed we omit the CPU check if the RPM check is disabled (via an early return).

There are several better ways to do this - but this is a small-delta PR.

I am marking this draft as it will conflict horribly with Andy's fix PR - and that should go in ahead of this.

I will test this once we work through the problem.
