### PR TITLE
autotest: fix zero terrain height for SITL runs at non-default locations

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -8518,6 +8518,9 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # the following is a "magic" location SITL understands which
         # has some posts near it:
         home_string = "%s,%s,%s,%s" % (51.8752066, 14.6487840, 54.15, 0)
+        # install terrain handler before customising SITL so terrain
+        # requests from the non-default home location are answered:
+        self.install_terrain_handlers_context()
         for (name, prx_type, expected_distances) in sensors:
             self.start_subtest("Testing %s" % name)
             self.set_parameter("PRX1_TYPE", prx_type)
@@ -13444,6 +13447,9 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "SERIAL5_PROTOCOL": 11,
             "PRX1_TYPE": 5,
         })
+        # install terrain handler before customising SITL so terrain
+        # requests from the non-default home location are answered:
+        self.install_terrain_handlers_context()
         self.customise_SITL_commandline([
             "--serial5=sim:%s:" % sim_device_name,
             "--home", "51.8752066,14.6487840,0,0",  # SITL has "posts" here

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -5994,6 +5994,9 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         rangefinder_params.update(self.analog_rangefinder_parameters())
 
         self.set_parameters(rangefinder_params)
+        # install terrain handler before customising SITL so terrain
+        # requests from the non-default home location are answered:
+        self.install_terrain_handlers_context()
         self.customise_SITL_commandline([
             "--home", home_string,
         ])


### PR DESCRIPTION
## Summary

Fixes #32407 — `TERR.TerrH` stuck at 0m when running SITL at non-default coordinates.

**Root cause:** When SITL starts at a non-default location (i.e. not the pre-bundled Canberra terrain file `S36E149.DAT`), there is no terrain data file on disk for that coordinate. The AP_Terrain library correctly sends `TERRAIN_REQUEST` MAVLink messages to the GCS to fetch the missing data. However, several tests that use non-default `--home` locations were not calling `install_terrain_handlers_context()`, so those requests went unanswered and `TERR.TerrH` remained stuck at 0m for the duration of the test.

**Fix:** Add `install_terrain_handlers_context()` before `customise_SITL_commandline()` in every test that uses a non-default home location:

- `AutoTestCopter.ProximitySensors` — uses Germany coordinates (51.8752066, 14.6487840)
- `AutoTestCopter.test_rplidar` — uses Germany coordinates (51.8752066, 14.6487840)
- `AutoTestRover.RangeFinder` — uses Germany coordinates (51.8752066, 14.6487840)

The handler must be installed *before* `customise_SITL_commandline()` so that it is already active when SITL restarts at the new location and begins sending `TERRAIN_REQUEST` messages.

## How the terrain system works in SITL

For the default Canberra location, `S36E149.DAT` is pre-bundled in the `terrain/` directory, so terrain height is available from disk immediately without any GCS exchange. For any other location, the disk read returns an empty block, the grid cache enters `GRID_CACHE_VALID` state with an empty bitmap, and `request_missing()` sends `TERRAIN_REQUEST` to the GCS. `install_terrain_handlers_context()` installs a MAVLink hook that responds to these requests using an elevation model, filling the bitmap and allowing `height_amsl()` to return the correct value.

## Test plan

- [ ] Verify `TERR.TerrH` is non-zero in `ProximitySensors` test logs after this fix
- [ ] Verify `TERR.TerrH` is non-zero in `test_rplidar` test logs after this fix
- [ ] Verify `TERR.TerrH` is non-zero in `RangeFinder` (Rover) test logs after this fix
- [ ] Confirm no regressions in existing terrain-enabled tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)