### PR TITLE
AP_GPS: add an option to not autobaud for a specific GPS

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -683,21 +683,26 @@ AP_GPS_Backend *AP_GPS::_detect_instance(const uint8_t instance)
 
     // all remaining drivers automatically cycle through baud rates to detect
     // the correct baud rate, and should have the selected baud broadcast
-    dstate->auto_detected_baud = true;
+    dstate->auto_detected_baud = !params[instance].option_is_set(Params::Option::DISABLE_AUTOBAUDING);
     const uint32_t now = AP_HAL::millis();
 
     if (now - dstate->last_baud_change_ms > GPS_BAUD_TIME_MS) {
-        // try the next baud rate
-        // incrementing like this will skip the first element in array of bauds
-        // this is okay, and relied upon
-        if (dstate->probe_baud == 0) {
-            dstate->probe_baud = port->get_baud_rate();
-        } else {
-            dstate->current_baud++;
-            if (dstate->current_baud == ARRAY_SIZE(_baudrates)) {
-                dstate->current_baud = 0;
+        if (dstate->auto_detected_baud) {
+            // try the next baud rate
+            // incrementing like this will skip the first element in array of bauds
+            // this is okay, and relied upon
+            if (dstate->probe_baud == 0) {
+                dstate->probe_baud = port->get_baud_rate();
+            } else {
+                dstate->current_baud++;
+                if (dstate->current_baud == ARRAY_SIZE(_baudrates)) {
+                    dstate->current_baud = 0;
+                }
+                dstate->probe_baud = _baudrates[dstate->current_baud];
             }
-            dstate->probe_baud = _baudrates[dstate->current_baud];
+        } else {
+            // baud rate is fixed at the parameter-configured baud
+            dstate->probe_baud = port->get_baud_rate();
         }
         uint16_t rx_size=0, tx_size=0;
         if (type == GPS_TYPE_UBLOX_RTK_ROVER) {

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -139,6 +139,15 @@ public:
         MovingBase mb_params;
 #endif // GPS_MOVING_BASELINE
 
+        // bitmask of options
+        enum class Option : uint16_t {
+            DISABLE_AUTOBAUDING = (1U<<0),
+        };
+        AP_Int16 options;
+        bool option_is_set(Option opt) const {
+            return (options.get() & uint16_t(opt)) != 0;
+        }
+
         static const struct AP_Param::GroupInfo var_info[];
     };
 

--- a/libraries/AP_GPS/AP_GPS_DroneCAN.cpp
+++ b/libraries/AP_GPS/AP_GPS_DroneCAN.cpp
@@ -858,14 +858,14 @@ bool AP_GPS_DroneCAN::handle_param_get_set_response_int(AP_DroneCAN* ap_dronecan
     }
 
     if (strcmp(name, "GPS_MB_ONLY_PORT") == 0 && cfg_step == STEP_SET_MB_CAN_TX) {
-        if (option_set(AP_GPS::UAVCAN_MBUseDedicatedBus) && !value) {
+        if (gps_option_is_set(AP_GPS::UAVCAN_MBUseDedicatedBus) && !value) {
             // set up so that another CAN port is used for the Moving Baseline Data
             // setting this value will allow another CAN port to be used as dedicated
             // line for the Moving Baseline Data
             value = 1;
             requires_save_and_reboot = true;
             return true;
-        } else if (!option_set(AP_GPS::UAVCAN_MBUseDedicatedBus) && value) {
+        } else if (!gps_option_is_set(AP_GPS::UAVCAN_MBUseDedicatedBus) && value) {
             // set up so that all CAN ports are used for the Moving Baseline Data
             value = 0;
             requires_save_and_reboot = true;

--- a/libraries/AP_GPS/AP_GPS_Params.cpp
+++ b/libraries/AP_GPS/AP_GPS_Params.cpp
@@ -113,6 +113,13 @@ const AP_Param::GroupInfo AP_GPS::Params::var_info[] = {
     AP_GROUPINFO("CAN_OVRIDE", 9, AP_GPS::Params, override_node_id, 0),
 #endif
 
+    // @Param: OPTIONS
+    // @DisplayName: GPS options
+    // @Description: When bit 0 is set the baud rate is fixed to the configured serial port rate for serial-based GPSs
+    // @Bitmask: 0:Disable auto-bauding
+    // @User: Standard
+    AP_GROUPINFO("OPTIONS", 10, AP_GPS::Params, options, 0),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -72,7 +72,7 @@ AP_GPS_SBF::AP_GPS_SBF(AP_GPS &_gps,
     state.rtk_baseline_coords_type = RTK_BASELINE_COORDINATE_SYSTEM_NED;
 
     // yaw available when option bit set or using dual antenna
-    if (option_set(AP_GPS::DriverOptions::SBF_UseBaseForYaw) ||
+    if (gps_option_is_set(AP_GPS::DriverOptions::SBF_UseBaseForYaw) ||
         (get_type() == AP_GPS::GPS_Type::GPS_TYPE_SBF_DUAL_ANTENNA)) {
         state.gps_yaw_configured = true;
     }
@@ -661,14 +661,14 @@ AP_GPS_SBF::process_message(void)
 
 #if GPS_MOVING_BASELINE
             // copy the baseline data as a yaw source
-            if (option_set(AP_GPS::DriverOptions::SBF_UseBaseForYaw)) {
+            if (gps_option_is_set(AP_GPS::DriverOptions::SBF_UseBaseForYaw)) {
                 calculate_moving_base_yaw(temp.info.Azimuth * 0.01f + 180.0f,
                                           Vector3f(temp.info.DeltaNorth, temp.info.DeltaEast, temp.info.DeltaUp).length(),
                                           -temp.info.DeltaUp);
             }
 #endif // GPS_MOVING_BASELINE
 
-        } else if (option_set(AP_GPS::DriverOptions::SBF_UseBaseForYaw)) {
+        } else if (gps_option_is_set(AP_GPS::DriverOptions::SBF_UseBaseForYaw)) {
             state.rtk_baseline_y_mm = 0;
             state.rtk_baseline_x_mm = 0;
             state.rtk_baseline_z_mm = 0;

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -397,13 +397,13 @@ AP_GPS_UBLOX::_request_next_config(void)
     }
 
     case STEP_L5: {
-        if (supports_l5 && option_set(AP_GPS::DriverOptions::GPSL5HealthOverride)) {
+        if (supports_l5 && gps_option_is_set(AP_GPS::DriverOptions::GPSL5HealthOverride)) {
             const config_list *list = config_L5_ovrd_ena;
             const uint8_t list_length = ARRAY_SIZE(config_L5_ovrd_ena);
             if (!_configure_config_set(list, list_length, CONFIG_L5, UBX_VALSET_LAYER_RAM | UBX_VALSET_LAYER_BBR)) {
                 _next_message--;
             }
-        } else if (supports_l5 && !option_set(AP_GPS::DriverOptions::GPSL5HealthOverride)) {
+        } else if (supports_l5 && !gps_option_is_set(AP_GPS::DriverOptions::GPSL5HealthOverride)) {
             const config_list *list = config_L5_ovrd_dis;
             const uint8_t list_length = ARRAY_SIZE(config_L5_ovrd_dis);
             if (!_configure_config_set(list, list_length, CONFIG_L5, UBX_VALSET_LAYER_RAM | UBX_VALSET_LAYER_BBR)) {

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -916,7 +916,7 @@ private:
 #if GPS_MOVING_BASELINE
     // see if we should use uart2 for moving baseline config
     bool mb_use_uart2(void) const {
-        return option_set(AP_GPS::DriverOptions::UBX_MBUseUart2)?true:false;
+        return gps_option_is_set(AP_GPS::DriverOptions::UBX_MBUseUart2)?true:false;
     }
 #endif
 

--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -453,7 +453,7 @@ good_yaw:
  */
 void AP_GPS_Backend::set_alt_amsl_cm(AP_GPS::GPS_State &_state, int32_t alt_amsl_cm)
 {
-    if (option_set(AP_GPS::HeightEllipsoid) && _state.have_undulation) {
+    if (gps_option_is_set(AP_GPS::HeightEllipsoid) && _state.have_undulation) {
         // user has asked ArduPilot to use ellipsoid height in the
         // canonical height for mission and navigation
         _state.location.alt = alt_amsl_cm - _state.undulation*100;

--- a/libraries/AP_GPS/GPS_Backend.h
+++ b/libraries/AP_GPS/GPS_Backend.h
@@ -113,12 +113,15 @@ public:
     uint32_t get_last_itow_ms(void) const;
 
     // check if an option is set
-    bool option_set(const AP_GPS::DriverOptions option) const {
+    bool gps_option_is_set(const AP_GPS::DriverOptions option) const {
         return gps.option_set(option);
     }
 
     // Convert BCD date (DDMMYY) and time (MTK19 millisecond form) to GPS week and time
     static void BCD_to_gps_time(uint32_t bcd_date, uint32_t bcd_time_ms, uint16_t& gps_week, uint32_t& gps_time_ms);
+
+    using Option = AP_GPS::Params::Option;
+    bool option_is_set(Option opt) const { return params.option_is_set(opt); }
 
 protected:
     AP_HAL::UARTDriver *port;           ///< UART we are attached to


### PR DESCRIPTION
## Summary

Allow the user to disable GPS auto-bauding.

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

ArduPilot has auto-detected baud rates for a long time.

Sometimes this is unfortunate as it can take a very long time to settle on the appropriate baud rate.  Particularly noticeable on Septentrio GPSs where the device seems to take a long time to boot so we skip past the correct baud rate at boot and need to do a complete lap of the available baudrates before finding it.

half this change is renaming the existing "option_set" to not have a name so similar to the new method.
