### PR TITLE
AP_Bootloader: rename save_comms_ip to restore_comms_ip

### DIFF
--- a/Tools/AP_Bootloader/AP_Bootloader.cpp
+++ b/Tools/AP_Bootloader/AP_Bootloader.cpp
@@ -100,7 +100,7 @@ int main(void)
 #endif
 
 #if AP_BOOTLOADER_NETWORK_ENABLED
-    network.save_comms_ip();
+    network.restore_comms_ip();
 #endif
 
 #if AP_FASTBOOT_ENABLED

--- a/Tools/AP_Bootloader/network.cpp
+++ b/Tools/AP_Bootloader/network.cpp
@@ -632,9 +632,9 @@ void BL_Network::init()
 }
 
 /*
-  save IP address from AP_Periph
+  restore IP address stashed away by AP_Periph
  */
-void BL_Network::save_comms_ip(void)
+void BL_Network::restore_comms_ip(void)
 {
     struct app_bootloader_comms *comms = (struct app_bootloader_comms *)HAL_RAM0_START;
     if (comms->magic == APP_BOOTLOADER_COMMS_MAGIC && comms->ip != 0) {

--- a/Tools/AP_Bootloader/network.h
+++ b/Tools/AP_Bootloader/network.h
@@ -13,7 +13,7 @@ class SocketAPM;
 class BL_Network {
 public:
     void init(void);
-    void save_comms_ip(void);
+    void restore_comms_ip(void);
     void status_printf(const char *fmt, ...);
 
 private:


### PR DESCRIPTION
## Summary

copies data from a memory segment not cleared on reboot into a normal variable

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

Simply renames the method to more-accurately reflect what it does.

Instead of 'saving the data from AP_Periph' we 'restore the data from where AP_Periph stashed it'

```
Board,bootloader
CubeNode-ETH,*
```
