### PR TITLE
AP_HAL_SITL: implement get_system_outqueue_length for MacOSX

### DIFF
--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -1013,7 +1013,10 @@ ssize_t UARTDriver::get_system_outqueue_length() const
 #if defined(__CYGWIN__) || defined(__CYGWIN64__) || defined(CYGWIN_BUILD)
     return 0;
 #elif defined(__APPLE__) && defined(__MACH__)
-    return 0;
+    int n;
+    socklen_t len = sizeof(n);
+    getsockopt(_fd, SOL_SOCKET, SO_NWRITE, &n, &len);
+    return n;
 #else
     int size;
     if (ioctl(_fd, TIOCOUTQ, &size) == -1) {


### PR DESCRIPTION
## Summary

allows us to not overflow the output buffer

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

When ArduPilot writes too much stuff to a socket in SITL it's probable that on MacOSX we will just drop that data.  Try to return something on MacOSX which is equivalent to the Linux implementation.


Hopefully leads to a better resolution on https://github.com/ArduPilot/ardupilot/issues/32369
