### PR TITLE
Compass: report reason when mag calibration fails

### DIFF
--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -407,6 +407,10 @@ MAV_RESULT Compass::handle_mag_cal_command(const mavlink_command_int_t &packet)
             }
         }
 
+        if (result != MAV_RESULT_ACCEPTED) {
+            GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Compass calibration failed to start");
+        }
+
         break;
     }
 


### PR DESCRIPTION
When MAV_CMD_DO_START_MAG_CAL fails because no compasses are available for calibration, the command currently returns MAV_RESULT_FAILED but does not send a message to the GCS.

Send a STATUSTEXT message so the user receives feedback instead of a silent failure.

## Summary

<!-- a one or two line summary of what your PR does here -->
(in the commit message above)

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [x] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request
- [ ] Autotest included

## Description

<!-- Describe your changes here -->


<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
Fixes #13257
