### PR TITLE
Added reserved IDs for ZERODRAG

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -432,6 +432,8 @@ AP_HW_SkyRukh_Surge_H7               2815
 # IDs 4000-4009 reserved for Karshak Drones
 AP_HW_KRSHKF7_MINI                   4000
 
+# IDs 4100-4150 reserved for ZERODRAG
+
 # IDs 4200-4220 reserved for HAKRC
 AP_HW_HAKRC_F405                     4200
 AP_HW_HAKRC_F405Wing                 4201


### PR DESCRIPTION

## Summary

Reserved IDs 4100-4150 (50 IDs) for ZERODRAG Technologies.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
