### PR TITLE
AP_Camera: fix conversion for runcam

### DIFF
--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -211,6 +211,9 @@ void AP_Camera::init()
 
     // perform any required parameter conversion
     convert_params();
+#if AP_CAMERA_RUNCAM_ENABLED && (AP_CAMERA_MAX_INSTANCES > 1)
+    convert_runcam_params();
+#endif // AP_CAMERA_RUNCAM_ENABLED && (AP_CAMERA_MAX_INSTANCES > 1)
 
     // create each instance
     for (uint8_t instance = 0; instance < AP_CAMERA_MAX_INSTANCES; instance++) {
@@ -922,35 +925,15 @@ AP_Camera_Backend *AP_Camera::get_instance(uint8_t instance) const
     return _backends[instance];
 }
 
-// perform any required parameter conversion
-void AP_Camera::convert_params()
+#if AP_CAMERA_RUNCAM_ENABLED && (AP_CAMERA_MAX_INSTANCES > 1)
+// Convert to runcam specific backend
+void AP_Camera::convert_runcam_params()
 {
-    // exit immediately if CAM1_TYPE has already been configured
-    if (_params[0].type.configured()
-#if AP_CAMERA_RUNCAM_ENABLED
-        && _params[1].type.configured()
-#endif
-       ) {
+    // exit immediately if CAM2_TYPE has already been configured
+    if (_params[1].type.configured()) {
         return;
     }
 
-    // PARAMETER_CONVERSION - Added: Feb-2023 ahead of 4.4 release
-
-    // convert CAM_TRIGG_TYPE to CAM1_TYPE
-    int8_t cam_trigg_type = 0;
-    int8_t cam1_type = 0;
-    IGNORE_RETURN(AP_Param::get_param_by_index(this, 0, AP_PARAM_INT8, &cam_trigg_type));
-    if ((cam_trigg_type == 0) && SRV_Channels::function_assigned(SRV_Channel::k_cam_trigger)) {
-        // CAM_TRIGG_TYPE was 0 (Servo) and camera trigger servo function was assigned so set CAM1_TYPE = 1 (Servo)
-        cam1_type = 1;
-    }
-    if ((cam_trigg_type >= 1) && (cam_trigg_type <= 3)) {
-        // CAM_TRIGG_TYPE was set to Relay, GoPro or Mount
-        cam1_type = cam_trigg_type + 1;
-    }
-    _params[0].type.set_and_save(cam1_type);
-
-#if AP_CAMERA_RUNCAM_ENABLED
     // RunCam PARAMETER_CONVERSION - Added: Nov-2024 ahead of 4.7 release
 
     // Since slot 1 is essentially used by the trigger type, we will use slot 2 for runcam
@@ -984,7 +967,33 @@ void AP_Camera::convert_params()
     }
 
     _params[1].type.set_and_save(rc_type);
-#endif // AP_CAMERA_RUNCAM_ENABLED
+
+}
+#endif // AP_CAMERA_RUNCAM_ENABLED && (AP_CAMERA_MAX_INSTANCES > 1)
+
+// perform any required parameter conversion
+void AP_Camera::convert_params()
+{
+    // exit immediately if CAM1_TYPE has already been configured
+    if (_params[0].type.configured()) {
+        return;
+    }
+
+    // PARAMETER_CONVERSION - Added: Feb-2023 ahead of 4.4 release
+
+    // convert CAM_TRIGG_TYPE to CAM1_TYPE
+    int8_t cam_trigg_type = 0;
+    int8_t cam1_type = 0;
+    IGNORE_RETURN(AP_Param::get_param_by_index(this, 0, AP_PARAM_INT8, &cam_trigg_type));
+    if ((cam_trigg_type == 0) && SRV_Channels::function_assigned(SRV_Channel::k_cam_trigger)) {
+        // CAM_TRIGG_TYPE was 0 (Servo) and camera trigger servo function was assigned so set CAM1_TYPE = 1 (Servo)
+        cam1_type = 1;
+    }
+    if ((cam_trigg_type >= 1) && (cam_trigg_type <= 3)) {
+        // CAM_TRIGG_TYPE was set to Relay, GoPro or Mount
+        cam1_type = cam_trigg_type + 1;
+    }
+    _params[0].type.set_and_save(cam1_type);
 
     // convert CAM_DURATION (in deci-seconds) to CAM1_DURATION (in seconds)
     int8_t cam_duration = 0;

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -240,6 +240,9 @@ private:
 
     // perform any required parameter conversion
     void convert_params();
+#if AP_CAMERA_RUNCAM_ENABLED && (AP_CAMERA_MAX_INSTANCES > 1)
+    void convert_runcam_params();
+#endif // AP_CAMERA_RUNCAM_ENABLED && (AP_CAMERA_MAX_INSTANCES > 1)
 
     // send camera feedback message to GCS
     void send_feedback(mavlink_channel_t chan);


### PR DESCRIPTION
This fixes the AP Camera param conversion running for type 1 when type 2 has not been configured. This bug was introduced in 399f9f6f9805582dfb7208d8f9317b7b30c0ab5c as part of https://github.com/ArduPilot/ardupilot/pull/26887

The fix is to split the runcam conversion to its own function which only checks type 2. The existing conversion returns to how it was prior to 399f9f6f9805582dfb7208d8f9317b7b30c0ab5c .

Original report: https://discuss.ardupilot.org/t/plane-4-7-0-beta1-available-for-beta-testing/142742/3?u=iampete
