### PR TITLE
libraries: fix confirmed cleanup leaks in DDS, OpenDroneID, and bootloader

### DIFF
--- a/Tools/AP_Bootloader/flash_from_sd.cpp
+++ b/Tools/AP_Bootloader/flash_from_sd.cpp
@@ -351,7 +351,7 @@ bool flash_from_sd()
     if (f_rename(verify_abin_path, flash_abin_path) != FR_OK) {
         // we would be nice to indicate an error here.
         // we could try to drop a message on the SD card?
-        return false;
+        goto out;
     }
 
     flasher = NEW_NOTHROW ABinFlasher{flash_abin_path};
@@ -363,7 +363,7 @@ bool flash_from_sd()
     if (f_rename(flash_abin_path, flashed_abin_path) != FR_OK) {
         // we would be nice to indicate an error here.
         // we could try to drop a message on the SD card?
-        return false;
+        goto out;
     }
 
     ret = true;

--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -184,6 +184,12 @@ static void initialize(geometry_msgs_msg_Quaternion& q)
 
 AP_DDS_Client::~AP_DDS_Client()
 {
+    cleanup_session();
+
+    if (!transport_initialized) {
+        return;
+    }
+
     // close transport
     if (is_using_serial) {
         uxr_close_custom_transport(&serial.transport);
@@ -192,6 +198,22 @@ AP_DDS_Client::~AP_DDS_Client()
         uxr_close_custom_transport(&udp.transport);
 #endif
     }
+}
+
+void AP_DDS_Client::cleanup_session()
+{
+    if (session_created) {
+        uxr_delete_session(&session);
+        session_created = false;
+    }
+
+    delete[] input_reliable_stream;
+    input_reliable_stream = nullptr;
+
+    delete[] output_reliable_stream;
+    output_reliable_stream = nullptr;
+
+    connected = false;
 }
 
 #if AP_DDS_TIME_PUB_ENABLED
@@ -1262,6 +1284,7 @@ void AP_DDS_Client::main_loop(void)
 
         // create session
         if (!init_session() || !create()) {
+            cleanup_session();
             GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s Creation Requests failed", msg_prefix);
             return;
         }
@@ -1312,15 +1335,14 @@ void AP_DDS_Client::main_loop(void)
             }
         }
 
-        // delete session if connected
-        if (connected) {
-            uxr_delete_session(&session);
-        }
+        cleanup_session();
     }
 }
 
 bool AP_DDS_Client::init_transport()
 {
+    transport_initialized = false;
+
     // serial init will fail if the SERIALn_PROTOCOL is not setup
     bool initTransportStatus = ddsSerialInit();
     is_using_serial = initTransportStatus;
@@ -1342,11 +1364,14 @@ bool AP_DDS_Client::init_transport()
         return false;
     }
 
+    transport_initialized = true;
     return true;
 }
 
 bool AP_DDS_Client::init_session()
 {
+    cleanup_session();
+
     // init session
     uxr_init_session(&session, comm, key);
 
@@ -1360,12 +1385,14 @@ bool AP_DDS_Client::init_session()
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s Initialization waiting...", msg_prefix);
         hal.scheduler->delay(1000);
     }
+    session_created = true;
 
     // setup reliable stream buffers
     input_reliable_stream = NEW_NOTHROW uint8_t[DDS_BUFFER_SIZE];
     output_reliable_stream = NEW_NOTHROW uint8_t[DDS_BUFFER_SIZE];
     if (input_reliable_stream == nullptr || output_reliable_stream == nullptr) {
         GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s Allocation failed", msg_prefix);
+        cleanup_session();
         return false;
     }
 

--- a/libraries/AP_DDS/AP_DDS_Client.h
+++ b/libraries/AP_DDS/AP_DDS_Client.h
@@ -90,11 +90,13 @@ private:
 
     // Serial Allocation
     uxrSession session; //Session
-    bool is_using_serial; // true when using serial transport
+    bool is_using_serial{false}; // true when using serial transport
+    bool transport_initialized{false};
+    bool session_created{false};
 
     // input and output stream
-    uint8_t *input_reliable_stream;
-    uint8_t *output_reliable_stream;
+    uint8_t *input_reliable_stream{nullptr};
+    uint8_t *output_reliable_stream{nullptr};
     uxrStreamId reliable_in;
     uxrStreamId reliable_out;
 
@@ -277,12 +279,13 @@ private:
 
     // functions for serial transport
     bool ddsSerialInit();
+    void cleanup_session();
     static bool serial_transport_open(uxrCustomTransport* args);
     static bool serial_transport_close(uxrCustomTransport* transport);
     static size_t serial_transport_write(uxrCustomTransport* transport, const uint8_t* buf, size_t len, uint8_t* error);
     static size_t serial_transport_read(uxrCustomTransport* transport, uint8_t* buf, size_t len, int timeout, uint8_t* error);
     struct {
-        AP_HAL::UARTDriver *port;
+        AP_HAL::UARTDriver *port{nullptr};
         uxrCustomTransport transport;
     } serial;
 
@@ -300,7 +303,7 @@ private:
         AP_Networking_IPV4 ip{AP_DDS_DEFAULT_UDP_IP_ADDR};
         // UDP Allocation
         uxrCustomTransport transport;
-        SocketAPM *socket;
+        SocketAPM *socket{nullptr};
     } udp;
 #endif
     // pointer to transport's communication structure
@@ -406,5 +409,4 @@ public:
 };
 
 #endif // AP_DDS_ENABLED
-
 

--- a/libraries/AP_OpenDroneID/AP_OpenDroneID_DroneCAN.cpp
+++ b/libraries/AP_OpenDroneID/AP_OpenDroneID_DroneCAN.cpp
@@ -86,6 +86,21 @@ void AP_OpenDroneID::dronecan_init(AP_DroneCAN *uavcan)
     return;
 
 alloc_failed:
+    delete dc_location[driver_index];
+    dc_location[driver_index] = nullptr;
+
+    delete dc_basic_id[driver_index];
+    dc_basic_id[driver_index] = nullptr;
+
+    delete dc_self_id[driver_index];
+    dc_self_id[driver_index] = nullptr;
+
+    delete dc_system[driver_index];
+    dc_system[driver_index] = nullptr;
+
+    delete dc_operator_id[driver_index];
+    dc_operator_id[driver_index] = nullptr;
+
     dronecan_init_failed |= driver_mask;
     GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "OpenDroneID DroneCAN alloc failed");
 }


### PR DESCRIPTION
## Summary

<!-- a one or two line summary of what your PR does here -->

Fix confirmed cleanup leaks in DDS, OpenDroneID, and bootloader code.

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request
- [ ] Autotest included

## Description

<!-- Describe your changes here -->

This PR fixes three confirmed cleanup leak paths.

- `AP_DDS`: free XRCE session state and reliable stream buffers on reconnect,
  setup failure, and destruction
- `AP_OpenDroneID`: free already-created DroneCAN publishers when initialization
  fails partway through
- `Tools/AP_Bootloader`: route `flash_from_sd()` rename failures through the
  existing cleanup path after verifier/flasher allocation

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
