### PR TITLE
Copter: Block ZigZag move requests while landed, landing, or below low altitude

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -2072,6 +2072,8 @@ private:
     void spray(bool b);
     bool calculate_side_dest_m(Vector3p& next_dest_ned_m, bool& is_terrain_alt) const;
     void move_to_side();
+    bool is_low_altitude();
+    bool move_allowed();
 
     Vector2p dest_A_ne_m;    // in NE frame in m relative to ekf origin
     Vector2p dest_B_ne_m;    // in NE frame in m relative to ekf origin
@@ -2087,6 +2089,7 @@ private:
     AP_Float _side_dist_m;     // sideways distance
     AP_Int8  _direction;       // sideways direction
     AP_Int16 _line_num;        // total number of lines
+    AP_Float _low_alt_m;       // minimum altitude required for manual move requests
 
     enum ZigZagState {
         STORING_POINTS, // storing points A and B, pilot has manual control

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -56,6 +56,14 @@ const AP_Param::GroupInfo ModeZigZag::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("LINE_NUM", 6, ModeZigZag, _line_num, 0),
 
+    // @Param: LOW_ALT
+    // @DisplayName: Minimum altitude for ZigZag move
+    // @Description: ZigZag move requests are rejected when the vehicle is landed, possibly landed, or below this altitude above ground
+    // @Units: m
+    // @Range: 0 10
+    // @User: Advanced
+    AP_GROUPINFO("LOW_ALT", 7, ModeZigZag, _low_alt_m, 1.0f),
+
     AP_GROUPEND
 };
 
@@ -186,6 +194,10 @@ void ModeZigZag::save_or_move_to_destination(Destination ab_dest)
 
         case AUTO:
         case MANUAL_REGAIN:
+            if (!move_allowed()) {
+                break;
+            }
+
             // A and B have been defined, move vehicle to destination A or B
             Vector3p next_dest_ned_m;
             bool is_terrain_alt;
@@ -210,8 +222,52 @@ void ModeZigZag::save_or_move_to_destination(Destination ab_dest)
     }
 }
 
+/**
+ * Return true if the vehicle is below the configured low altitude threshold above ground
+ *
+ * @retval true if the vehicle is below the configured low altitude threshold above ground
+ * @retval false if the vehicle is above the configured low altitude threshold above ground
+ */
+bool ModeZigZag::is_low_altitude()
+{
+    const float low_alt_m = MAX(_low_alt_m, 0.0f);
+    return get_alt_above_ground_m() <= low_alt_m;
+}
+
+/**
+ * Return true if ZigZag is allowed to initiate movement
+ *
+ * @retval true if movement is allowed
+ * @retval false if movement is blocked because the vehicle is disarmed, landed,
+ *               possibly landed, or below the configured low altitude threshold
+ */
+bool ModeZigZag::move_allowed()
+{
+    if (!motors->armed()) {
+        return false;
+    }
+
+    if (copter.ap.land_complete) {
+        return false;
+    }
+
+    if (copter.ap.land_complete_maybe) {
+        return false;
+    }
+
+    if (is_low_altitude()) {
+        return false;
+    }
+
+    return true;
+}
+
 void ModeZigZag::move_to_side()
 {
+    if (!move_allowed()) {
+        return;
+    }
+
     if (!dest_A_ne_m.is_zero() && !dest_B_ne_m.is_zero() && !is_zero((dest_B_ne_m - dest_A_ne_m).length_squared())) {
         Vector3p next_dest_ned_m;
         bool is_terrain_alt;
@@ -505,6 +561,10 @@ void ModeZigZag::run_auto()
 
     // make sure both A and B point are registered and not when moving to A or B
     if (stage != MANUAL_REGAIN) {
+        return;
+    }
+
+    if (!move_allowed()) {
         return;
     }
 


### PR DESCRIPTION
## Summary

Implement the safety improvement proposed in #32429 by blocking ZigZag move requests while the vehicle is landed, possibly landed, or below a configurable low-altitude threshold.

This change adds a common safety guard for ZigZag move initiation and auto re-entry in near-ground unsafe states.

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [x] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request
- [ ] Autotest included

## Description

This PR implements the safety improvement proposed in #32429.

Issue #32429 describes a safety concern in ZigZag mode: the vehicle can descend using throttle while remaining in ZigZag, and ZigZag move requests may still be accepted when the vehicle is landed, possibly landed, or flying at very low altitude.

To address this, this PR adds a common `move_allowed()` guard and applies it to the relevant ZigZag move entry points.

Specifically, this PR adds:

- a new `ZIGZ_LOW_ALT` parameter
- `is_low_altitude()` helper logic
- `move_allowed()` helper logic
- guards in:
  - `save_or_move_to_destination()`
  - `move_to_side()`
  - `run_auto()`

ZigZag move requests are now rejected when any of the following are true:

- the vehicle is not armed
- `land_complete == true`
- `land_complete_maybe == true`
- the vehicle is below `ZIGZ_LOW_ALT`

This means ZigZag will no longer initiate movement or auto re-entry in these near-ground unsafe states.

The goal is to close the safety gap discussed in #32429 while preserving the existing ZigZag workflow and A/B operation behavior.

This PR closes #32429.
