### PR TITLE
autotest: drain mav before asserting satellite count

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -14565,6 +14565,7 @@ switch value'''
                 raise NotAchievedException(f"gps type {name} misbehaving")
 
     def assert_gps_satellite_count(self, messagename, count):
+        self.drain_mav()
         m = self.assert_receive_message(messagename)
         if m.satellites_visible != count:
             raise NotAchievedException("Expected %u sats, got %u" %


### PR DESCRIPTION
## Summary

drain mav to fix race condition on expected number of satellites

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [x] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

some sort of race condition where we're not picking up the correct satellite count:

```
2026-03-14T15:49:27.6130776Z AT-0976.7: Requesting (SIM_GPS2_NUMSATS) 2026-03-14T15:49:27.6131360Z AT-0976.7: Received wanted PARAM_VALUE SIM_GPS2_NUMSATS=10.000000 2026-03-14T15:49:27.6132337Z AT-0976.7: SIM_GPS2_NUMSATS want=12.000000 autopilot=10.0 (attempt=2/10) 2026-03-14T15:49:27.6133343Z AT-0976.7: Sending set (SIM_GPS2_NUMSATS) to (12.000000) (old=10.000000) 2026-03-14T15:49:27.6134305Z AT-0976.7: Received wanted PARAM_VALUE SIM_GPS2_NUMSATS=12.000000 2026-03-14T15:49:27.6135312Z AT-0976.7: SIM_GPS2_NUMSATS want=12.000000 autopilot=12.0 (attempt=3/10) 2026-03-14T15:49:27.6136115Z AT-0976.7: SIM_GPS2_NUMSATS is now 12.000000 2026-03-14T15:49:27.6136859Z AT-0976.8: Exception caught: Expected 12 sats, got 10 2026-03-14T15:49:27.6137512Z Traceback (most recent call last):
2026-03-14T15:49:27.6150448Z   File "/__w/ardupilot/ardupilot/Tools/autotest/vehicle_test_suite.py", line 9149, in run_one_test_attempt
2026-03-14T15:49:27.6151532Z     test_function(**test_kwargs)
2026-03-14T15:49:27.6152748Z   File "/__w/ardupilot/ardupilot/Tools/autotest/vehicle_test_suite.py", line 14679, in MultipleGPS
2026-03-14T15:49:27.6153825Z     self.assert_gps_satellite_count("GPS2_RAW", 12)
2026-03-14T15:49:27.6155287Z   File "/__w/ardupilot/ardupilot/Tools/autotest/vehicle_test_suite.py", line 14570, in assert_gps_satellite_count
2026-03-14T15:49:27.6157518Z     raise NotAchievedException("Expected %u sats, got %u" %
2026-03-14T15:49:27.6182937Z ##[error]vehicle_test_suite.NotAchievedException: Expected 12 sats, got 10
2026-03-14T15:49:27.6190519Z
```
