### PR TITLE
AP_Compass: provide base class implementation for AP_Compass_Backend::read

### DIFF
--- a/libraries/AP_Compass/AP_Compass_BMM150.cpp
+++ b/libraries/AP_Compass/AP_Compass_BMM150.cpp
@@ -321,10 +321,4 @@ void AP_Compass_BMM150::_update()
     _dev->check_next_register();
 }
 
-void AP_Compass_BMM150::read()
-{
-    drain_accumulated_samples();
-}
-
-
 #endif  // AP_COMPASS_BMM150_ENABLED

--- a/libraries/AP_Compass/AP_Compass_BMM150.h
+++ b/libraries/AP_Compass/AP_Compass_BMM150.h
@@ -36,8 +36,6 @@ class AP_Compass_BMM150 : public AP_Compass_Backend
 public:
     static AP_Compass_Backend *probe(AP_HAL::OwnPtr<AP_HAL::Device> dev, bool force_external, enum Rotation rotation);
 
-    void read() override;
-
     static constexpr const char *name = "BMM150";
 
 private:

--- a/libraries/AP_Compass/AP_Compass_BMM350.cpp
+++ b/libraries/AP_Compass/AP_Compass_BMM350.cpp
@@ -477,9 +477,4 @@ void AP_Compass_BMM350::timer()
     accumulate_sample(field);
 }
 
-void AP_Compass_BMM350::read()
-{
-    drain_accumulated_samples();
-}
-
 #endif  // AP_COMPASS_BMM350_ENABLED

--- a/libraries/AP_Compass/AP_Compass_BMM350.h
+++ b/libraries/AP_Compass/AP_Compass_BMM350.h
@@ -38,8 +38,6 @@ public:
                                      bool force_external,
                                      enum Rotation rotation);
 
-    void read() override;
-
     static constexpr const char *name = "BMM350";
 
 private:

--- a/libraries/AP_Compass/AP_Compass_Backend.h
+++ b/libraries/AP_Compass/AP_Compass_Backend.h
@@ -42,7 +42,9 @@ public:
     virtual ~AP_Compass_Backend(void) {}
 
     // read sensor data
-    virtual void read(void) = 0;
+    virtual void read(void) {
+        drain_accumulated_samples();
+    }
 
     /*
       device driver IDs. These are used to fill in the devtype field

--- a/libraries/AP_Compass/AP_Compass_DroneCAN.cpp
+++ b/libraries/AP_Compass/AP_Compass_DroneCAN.cpp
@@ -225,8 +225,4 @@ void AP_Compass_DroneCAN::handle_magnetic_field_hires(AP_DroneCAN *ap_dronecan, 
 }
 #endif  // AP_COMPASS_DRONECAN_HIRES_ENABLED
 
-void AP_Compass_DroneCAN::read(void)
-{
-    drain_accumulated_samples();
-}
 #endif  // AP_COMPASS_DRONECAN_ENABLED

--- a/libraries/AP_Compass/AP_Compass_DroneCAN.h
+++ b/libraries/AP_Compass/AP_Compass_DroneCAN.h
@@ -12,8 +12,6 @@ class AP_Compass_DroneCAN : public AP_Compass_Backend {
 public:
     AP_Compass_DroneCAN(AP_DroneCAN* ap_dronecan, uint32_t devid);
 
-    void        read(void) override;
-
     static bool subscribe_msgs(AP_DroneCAN* ap_dronecan);
     static AP_Compass_Backend* probe(uint8_t index);
     static uint32_t get_detected_devid(uint8_t index) { return _detected_modules[index].devid; }

--- a/libraries/AP_Compass/AP_Compass_ExternalAHRS.cpp
+++ b/libraries/AP_Compass/AP_Compass_ExternalAHRS.cpp
@@ -39,9 +39,4 @@ void AP_Compass_ExternalAHRS::handle_external(const AP_ExternalAHRS::mag_data_me
     accumulate_sample(field);
 }
 
-void AP_Compass_ExternalAHRS::read(void)
-{
-    drain_accumulated_samples();
-}
-
 #endif // AP_COMPASS_EXTERNALAHRS_ENABLED

--- a/libraries/AP_Compass/AP_Compass_ExternalAHRS.h
+++ b/libraries/AP_Compass/AP_Compass_ExternalAHRS.h
@@ -15,8 +15,6 @@ public:
 
     static AP_Compass_Backend *probe(uint8_t port);
 
-    void read(void) override;
-
 private:
     void handle_external(const AP_ExternalAHRS::mag_data_message_t &pkt) override;
 };

--- a/libraries/AP_Compass/AP_Compass_IIS2MDC.cpp
+++ b/libraries/AP_Compass/AP_Compass_IIS2MDC.cpp
@@ -161,9 +161,4 @@ void AP_Compass_IIS2MDC::timer()
     accumulate_sample(field);
 }
 
-void AP_Compass_IIS2MDC::read()
-{
-    drain_accumulated_samples();
-}
-
 #endif //AP_COMPASS_IIS2MDC_ENABLED

--- a/libraries/AP_Compass/AP_Compass_IIS2MDC.h
+++ b/libraries/AP_Compass/AP_Compass_IIS2MDC.h
@@ -44,8 +44,6 @@ public:
                                      bool force_external,
                                      enum Rotation rotation);
 
-    void read() override;
-
     static constexpr const char *name = "IIS2MDC";
 
 private:

--- a/libraries/AP_Compass/AP_Compass_IST8308.cpp
+++ b/libraries/AP_Compass/AP_Compass_IST8308.cpp
@@ -217,9 +217,4 @@ void AP_Compass_IST8308::timer()
     accumulate_sample(field);
 }
 
-void AP_Compass_IST8308::read()
-{
-    drain_accumulated_samples();
-}
-
 #endif  // AP_COMPASS_IST8308_ENABLED

--- a/libraries/AP_Compass/AP_Compass_IST8308.h
+++ b/libraries/AP_Compass/AP_Compass_IST8308.h
@@ -37,8 +37,6 @@ public:
                                      bool force_external,
                                      enum Rotation rotation);
 
-    void read() override;
-
     static constexpr const char *name = "IST8308";
 
 private:

--- a/libraries/AP_Compass/AP_Compass_IST8310.cpp
+++ b/libraries/AP_Compass/AP_Compass_IST8310.cpp
@@ -249,9 +249,4 @@ void AP_Compass_IST8310::timer()
     accumulate_sample(field);
 }
 
-void AP_Compass_IST8310::read()
-{
-    drain_accumulated_samples();
-}
-
 #endif  // AP_COMPASS_IST8310_ENABLED

--- a/libraries/AP_Compass/AP_Compass_IST8310.h
+++ b/libraries/AP_Compass/AP_Compass_IST8310.h
@@ -42,8 +42,6 @@ public:
                                      bool force_external,
                                      enum Rotation rotation);
 
-    void read() override;
-
     static constexpr const char *name = "IST8310";
 
 private:

--- a/libraries/AP_Compass/AP_Compass_LIS2MDL.cpp
+++ b/libraries/AP_Compass/AP_Compass_LIS2MDL.cpp
@@ -157,10 +157,4 @@ check_registers:
     dev->check_next_register();
 }
 
-// @brief Publish accumulated data to the frontend
-void AP_Compass_LIS2MDL::read()
-{
-    drain_accumulated_samples();
-}
-
 #endif  // AP_COMPASS_LIS2MDL_ENABLED

--- a/libraries/AP_Compass/AP_Compass_LIS2MDL.h
+++ b/libraries/AP_Compass/AP_Compass_LIS2MDL.h
@@ -36,8 +36,6 @@ public:
                                      bool force_external,
                                      enum Rotation rotation);
 
-    void read() override;
-
     static constexpr const char *name = "LIS2MDL";
 
 private:

--- a/libraries/AP_Compass/AP_Compass_LIS3MDL.cpp
+++ b/libraries/AP_Compass/AP_Compass_LIS3MDL.cpp
@@ -166,9 +166,4 @@ check_registers:
     dev->check_next_register();
 }
 
-void AP_Compass_LIS3MDL::read()
-{
-    drain_accumulated_samples();
-}
-
 #endif  // AP_COMPASS_LIS3MDL_ENABLED

--- a/libraries/AP_Compass/AP_Compass_LIS3MDL.h
+++ b/libraries/AP_Compass/AP_Compass_LIS3MDL.h
@@ -41,8 +41,6 @@ public:
                                      bool force_external,
                                      enum Rotation rotation);
 
-    void read() override;
-
     static constexpr const char *name = "LIS3MDL";
 
 private:

--- a/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp
+++ b/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp
@@ -152,11 +152,6 @@ void AP_Compass_LSM9DS1::_update(void)
     accumulate_sample(raw_field);
 }
 
-void AP_Compass_LSM9DS1::read()
-{
-    drain_accumulated_samples();
-}
-
 bool AP_Compass_LSM9DS1::_check_id(void)
 {
     // initially run the bus at low speed

--- a/libraries/AP_Compass/AP_Compass_LSM9DS1.h
+++ b/libraries/AP_Compass/AP_Compass_LSM9DS1.h
@@ -19,8 +19,6 @@ public:
 
     static constexpr const char *name = "LSM9DS1";
 
-    void read() override;
-
     virtual ~AP_Compass_LSM9DS1() {}
 
 private:

--- a/libraries/AP_Compass/AP_Compass_MMC3416.cpp
+++ b/libraries/AP_Compass/AP_Compass_MMC3416.cpp
@@ -297,9 +297,4 @@ void AP_Compass_MMC3416::timer()
     }
 }
 
-void AP_Compass_MMC3416::read()
-{
-    drain_accumulated_samples();
-}
-
 #endif  // AP_COMPASS_MMC3416_ENABLED

--- a/libraries/AP_Compass/AP_Compass_MMC3416.h
+++ b/libraries/AP_Compass/AP_Compass_MMC3416.h
@@ -37,8 +37,6 @@ public:
                                      bool force_external,
                                      enum Rotation rotation);
 
-    void read() override;
-
     static constexpr const char *name = "MMC3416";
 
 private:

--- a/libraries/AP_Compass/AP_Compass_MMC5xx3.cpp
+++ b/libraries/AP_Compass/AP_Compass_MMC5xx3.cpp
@@ -302,10 +302,5 @@ void AP_Compass_MMC5XX3::timer()
     }
 }
 
-void AP_Compass_MMC5XX3::read()
-{
-    drain_accumulated_samples();
-}
-
 #endif  // AP_COMPASS_MMC5XX3_ENABLED
 

--- a/libraries/AP_Compass/AP_Compass_MMC5xx3.h
+++ b/libraries/AP_Compass/AP_Compass_MMC5xx3.h
@@ -37,8 +37,6 @@ public:
                                      bool force_external,
                                      enum Rotation rotation);
 
-    void read() override;
-
     static constexpr const char *name = "MMC5983";
 
 private:

--- a/libraries/AP_Compass/AP_Compass_MSP.cpp
+++ b/libraries/AP_Compass/AP_Compass_MSP.cpp
@@ -53,10 +53,5 @@ void AP_Compass_MSP::handle_msp(const MSP::msp_compass_data_message_t &pkt)
     accumulate_sample(field, instance);
 }
 
-void AP_Compass_MSP::read(void)
-{
-    drain_accumulated_samples();
-}
-
 #endif // AP_COMPASS_MSP_ENABLED
 

--- a/libraries/AP_Compass/AP_Compass_MSP.h
+++ b/libraries/AP_Compass/AP_Compass_MSP.h
@@ -14,8 +14,6 @@ public:
 
     static AP_Compass_Backend *probe(uint8_t _msp_instance);
 
-    void read(void) override;
-
 private:
     AP_Compass_MSP(uint8_t _msp_instance) :
         msp_instance{_msp_instance} { }

--- a/libraries/AP_Compass/AP_Compass_QMC5883L.cpp
+++ b/libraries/AP_Compass/AP_Compass_QMC5883L.cpp
@@ -197,11 +197,6 @@ void AP_Compass_QMC5883L::timer()
     accumulate_sample(field, 20);
 }
 
-void AP_Compass_QMC5883L::read()
-{
-    drain_accumulated_samples();
-}
-
 void AP_Compass_QMC5883L::_dump_registers()
 {
 	  printf("QMC5883L registers dump\n");

--- a/libraries/AP_Compass/AP_Compass_QMC5883L.h
+++ b/libraries/AP_Compass/AP_Compass_QMC5883L.h
@@ -50,8 +50,6 @@ public:
 									 bool force_external,
                                      enum Rotation rotation);
 
-    void read() override;
-
     static constexpr const char *name = "QMC5883L";
 
 private:

--- a/libraries/AP_Compass/AP_Compass_QMC5883P.cpp
+++ b/libraries/AP_Compass/AP_Compass_QMC5883P.cpp
@@ -197,11 +197,6 @@ void AP_Compass_QMC5883P::timer()
     accumulate_sample(field, 20);
 }
 
-void AP_Compass_QMC5883P::read()
-{
-    drain_accumulated_samples();
-}
-
 void AP_Compass_QMC5883P::_dump_registers()
 {
     printf("QMC5883P registers dump\n");

--- a/libraries/AP_Compass/AP_Compass_QMC5883P.h
+++ b/libraries/AP_Compass/AP_Compass_QMC5883P.h
@@ -49,8 +49,6 @@ public:
                                      bool force_external,
                                      enum Rotation rotation);
 
-    void read() override;
-
     static constexpr const char *name = "QMC5883P";
 
 private:

--- a/libraries/AP_Compass/AP_Compass_RM3100.cpp
+++ b/libraries/AP_Compass/AP_Compass_RM3100.cpp
@@ -238,9 +238,4 @@ check_registers:
     dev->check_next_register();
 }
 
-void AP_Compass_RM3100::read()
-{
-	drain_accumulated_samples();
-}
-
 #endif  // AP_COMPASS_RM3100_ENABLED

--- a/libraries/AP_Compass/AP_Compass_RM3100.h
+++ b/libraries/AP_Compass/AP_Compass_RM3100.h
@@ -40,8 +40,6 @@ public:
                                      bool force_external,
                                      enum Rotation rotation);
 
-    void read() override;
-
     static constexpr const char *name = "RM3100";
 
 private:

--- a/libraries/AP_Compass/AP_Compass_SITL.cpp
+++ b/libraries/AP_Compass/AP_Compass_SITL.cpp
@@ -143,8 +143,4 @@ void AP_Compass_SITL::_timer()
         }
 }
 
-void AP_Compass_SITL::read()
-{
-    drain_accumulated_samples(nullptr);
-}
 #endif  // AP_COMPASS_SITL_ENABLED

--- a/libraries/AP_Compass/AP_Compass_SITL.h
+++ b/libraries/AP_Compass/AP_Compass_SITL.h
@@ -15,8 +15,6 @@ class AP_Compass_SITL : public AP_Compass_Backend {
 public:
     AP_Compass_SITL(uint8_t sitl_instance);
 
-    void read(void) override;
-
 private:
     SITL::SIM *_sitl;
 


### PR DESCRIPTION
## Summary

Removes methods of identical implementation which can be done by the base class instead.

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [x] Tested in SITL
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

Removes identical derived class methods and supplies a base-class implementation instead.

It's probably we can replace the other base class implementations with this, but will need to check on their behaviour when their initialised flag is false.

Saves a few bytes:
```
Board,AP_Periph,antennatracker,blimp,bootloader,copter,heli,plane,rover,sub
CubeOrangePlus,,-80,-80,*,-80,-80,-80,-80,-80
Pixhawk1-1M,,-48,-48,*,-48,-48,-48,-48,-48
f103-GPS,-24,,,*,,,,,
```

I've flashed this onto a CubeOrangePlus and all is as expected.
