### PR TITLE
Tools: Fix ruff rule E402 Module level import not at top of file

### DIFF
--- a/Tools/scripts/build_binaries.py
+++ b/Tools/scripts/build_binaries.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import annotations
-
 """
 script to build the latest binaries for each vehicle type, ready to upload
 Peter Barker, August 2017
@@ -9,6 +7,8 @@ based on build_binaries.sh by Andrew Tridgell, March 2013
 
 AP_FLAKE8_CLEAN
 """
+
+from __future__ import annotations
 
 import datetime
 import optparse

--- a/Tools/scripts/build_script_base.py
+++ b/Tools/scripts/build_script_base.py
@@ -1,10 +1,10 @@
-from __future__ import annotations
-
 '''
 Base class for ArduPilot build scripts providing common utilities
 
 AP_FLAKE8_CLEAN
 '''
+
+from __future__ import annotations
 
 import os
 import pathlib

--- a/Tools/scripts/check_branch_conventions.py
+++ b/Tools/scripts/check_branch_conventions.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import annotations
-
 '''
 Check PR branch commit conventions and markdown linting.
 
@@ -14,6 +12,8 @@ Validates:
 
 AP_FLAKE8_CLEAN
 '''
+
+from __future__ import annotations
 
 import argparse
 import os

--- a/Tools/scripts/size_compare_branches.py
+++ b/Tools/scripts/size_compare_branches.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import annotations
-
 '''
 Wrapper around elf_diff (https://github.com/noseglasses/elf_diff)
 to create a html report comparing an ArduPilot build across two
@@ -17,6 +15,8 @@ Starting in the ardupilot directory.
 
 Output is placed into ELF_DIFF_[VEHICLE_NAME]
 '''
+
+from __future__ import annotations
 
 import copy
 import fnmatch

--- a/Tools/scripts/size_history.py
+++ b/Tools/scripts/size_history.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import annotations
-
 '''
 Build N commits on a branch and track flash size and feature changes.
 
@@ -16,6 +14,8 @@ Usage:
 
 AP_FLAKE8_CLEAN
 '''
+
+from __future__ import annotations
 
 import argparse
 import html

--- a/Tools/scripts/test_new_boards.py
+++ b/Tools/scripts/test_new_boards.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import annotations
-
 '''
 Look at the difference between this and its merge-base with master
 
@@ -9,6 +7,8 @@ for each new hwdef file, build the board
 
 AP_FLAKE8_CLEAN
 '''
+
+from __future__ import annotations
 
 import optparse
 import os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,5 @@
 [tool.ruff]
 target-version = "py310"
-lint.ignore = [
-    "E402",  # module-import-not-at-top-of-file
-]
 lint.extend-select = [
     "I",    # isort
     "TID",  # flake8-tidy-imports


### PR DESCRIPTION
## Summary

<!-- a one or two-line summary of what your PR does here -->

Tools: Fix Python module-level import not at top of file
% `ruff rule E402`
# module-import-not-at-top-of-file (E402)

Derived from the **pycodestyle** linter.

## What it does
Checks for imports that are not at the top of the file.

## Why is this bad?
According to [PEP 8], "imports are always put at the top of the file, just after any
module comments and docstrings, and before module globals and constants."

This rule makes an exception for both `sys.path` modifications (allowing for
`sys.path.insert`, `sys.path.append`, etc.) and `os.environ` modifications
between imports.

## Example
```python
"One string"
"Two string"
a = 1
import os
from sys import x
```

Use instead:
```python
import os
from sys import x

"One string"
"Two string"
a = 1
```

## Notebook behavior
For Jupyter notebooks, this rule checks for imports that are not at the top of a *cell*.

[PEP 8]: https://peps.python.org/pep-0008/#imports


## Testing (more checks increase the chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

<!-- Describe your changes here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
