### PR TITLE
Tools: correct feature extraction for compasses

### DIFF
--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -45,8 +45,10 @@ class ExtractFeatures(BuildScriptBase):
             ('HAL_ADSB_{type}_ENABLED', r'AP_ADSB_(?P<type>.*)::update',),
             ('HAL_ADSB_UCP_ENABLED', 'AP_ADSB_uAvionix_UCP::update',),
 
-            ('AP_COMPASS_{type}_ENABLED', r'AP_Compass_(?P<type>.*)::read\b',),
+            ('AP_COMPASS_{type}_ENABLED', r'AP_Compass_(?P<type>.*)::probe\b',),
             ('AP_COMPASS_ICM20948_ENABLED', r'AP_Compass_AK09916::probe_ICM20948',),
+            ('AP_COMPASS_AK8963_ENABLED', r'AP_Compass_AK8963::probe_mpu9250',),
+            ('AP_COMPASS_HMC5843_ENABLED', r'AP_Compass_HMC5843::probe_mpu6000',),
             ('AP_COMPASS_DRONECAN_HIRES_ENABLED', r'AP_Compass_DroneCAN::handle_magnetic_field_hires',),
 
             ('AP_AIS_ENABLED', 'AP_AIS::decode_position_report',),


### PR DESCRIPTION
## Summary

Correct feature extraction on Compass backends

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

https://github.com/ArduPilot/ardupilot/pull/32449 removed a bunch of read symbols from the compass backends - but we relied on that for feature extraction.

Use different symbols to determine presence of backend

```
--- /tmp/master-features	2026-03-17 13:51:44.484179640 +1100
+++ /tmp/new-features	2026-03-17 14:18:59.724240732 +1100
@@ -72,28 +72,28 @@
 AP_CAN_SLCAN_ENABLED
 AP_COMPASS_AK09916_ENABLED
 AP_COMPASS_AK8963_ENABLED
-!AP_COMPASS_BMM150_ENABLED
-!AP_COMPASS_BMM350_ENABLED
+AP_COMPASS_BMM150_ENABLED
+AP_COMPASS_BMM350_ENABLED
 AP_COMPASS_CALIBRATION_FIXED_YAW_ENABLED
-!AP_COMPASS_DRONECAN_ENABLED
+AP_COMPASS_DRONECAN_ENABLED
 !AP_COMPASS_DRONECAN_HIRES_ENABLED
 !AP_COMPASS_EXTERNALAHRS_ENABLED
 AP_COMPASS_HMC5843_ENABLED
 AP_COMPASS_ICM20948_ENABLED
 !AP_COMPASS_IIS2MDC_ENABLED
-!AP_COMPASS_IST8308_ENABLED
-!AP_COMPASS_IST8310_ENABLED
-!AP_COMPASS_LIS2MDL_ENABLED
-!AP_COMPASS_LIS3MDL_ENABLED
+AP_COMPASS_IST8308_ENABLED
+AP_COMPASS_IST8310_ENABLED
+AP_COMPASS_LIS2MDL_ENABLED
+AP_COMPASS_LIS3MDL_ENABLED
 AP_COMPASS_LSM303D_ENABLED
 !AP_COMPASS_LSM9DS1_ENABLED
 !AP_COMPASS_MAG3110_ENABLED
-!AP_COMPASS_MMC3416_ENABLED
-!AP_COMPASS_MMC5XX3_ENABLED
-!AP_COMPASS_MSP_ENABLED
-!AP_COMPASS_QMC5883L_ENABLED
-!AP_COMPASS_QMC5883P_ENABLED
-!AP_COMPASS_RM3100_ENABLED
+AP_COMPASS_MMC3416_ENABLED
+AP_COMPASS_MMC5XX3_ENABLED
+AP_COMPASS_MSP_ENABLED
+AP_COMPASS_QMC5883L_ENABLED
+AP_COMPASS_QMC5883P_ENABLED
+AP_COMPASS_RM3100_ENABLED
 !AP_COPTER_ADVANCED_FAILSAFE_ENABLED
 AP_COPTER_AHRS_AUTO_TRIM_ENABLED
 AP_CPU_IDLE_STATS_ENABLED
```
