### PR TITLE
Correct probing of IST8310 compasses on fmuv3-based boards

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/fmuv3/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/fmuv3/hwdef.dat
@@ -465,3 +465,6 @@ define AP_BATTERY_SMBUS_SOLO_ENABLED (AP_BATTERY_SMBUS_ENABLED && BOARD_FLASH_SI
 
 # produce this error if we are on a 1M board
 define BOARD_CHECK_F427_USE_1M "ERROR: 1M flash use fmuv2"
+
+# probe for external IST8310 compasses:
+define AP_COMPASS_IST8310_EXTERNAL_BUS_PROBING_ENABLED 1


### PR DESCRIPTION
## Summary

I broke external probing on fmuv3 boards for the IST8310 as part of https://github.com/ArduPilot/ardupilot/pull/31831 - this fixes that.

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

fmuv3 doesn't do compass probing as such as it does the probing as part of being a feature-detect board.

Tested by dropping a #error into the relevant bit:
```
[ 212/1254] Compiling libraries/AP_EFI/AP_EFI_Serial_Lutan.cpp
../../libraries/AP_Compass/AP_Compass.cpp:1290:2: error: #error hi
 1290 | #error hi
      |  ^~~~~
compilation terminated due to -Wfatal-errors.

Waf: Leaving directory `/home/pbarker/rc/ardupilot/build/mindpx-v2'
Build failed
 -> task in 'objs/AP_Compass' failed (exit status 1): 
	{task 139967551969040: cxx AP_Compass.cpp -> AP_Compass.cpp.0.o}
 (run with -v to display more information)
pbarker@crun:~/rc/ardupilot(master)$ git diff
diff --git a/libraries/AP_Compass/AP_Compass.cpp b/libraries/AP_Compass/AP_Compass.cpp
index 127afd6dbda..de81914071e 100644
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -1287,6 +1287,7 @@ void Compass::_probe_external_i2c_compasses(void)
 
         for (uint8_t a=0; a<ARRAY_SIZE(ist8310_addr); a++) {
 #if AP_COMPASS_IST8310_EXTERNAL_BUS_PROBING_ENABLED
+#error hi
             FOREACH_I2C_EXTERNAL(i) {
                 probe_i2c_dev(DRIVER_IST8310, AP_Compass_IST8310::probe, i, ist8310_addr[a], true, default_rotation);
                 RETURN_IF_NO_SPACE;
```
