### PR TITLE
Tools: check_branch_conventions: reject blacklisted subsystem prefixes

### DIFF
--- a/Tools/scripts/check_branch_conventions.py
+++ b/Tools/scripts/check_branch_conventions.py
@@ -25,6 +25,13 @@ import build_script_base
 
 DOCS_URL = "https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html"
 MAX_SUBJECT_LEN = 160
+BLACKLISTED_PREFIXES = {
+    "DEBUG",
+    "DRAFT",
+    "TEMP",
+    "TMP",
+    "WIP",
+}
 # spaces and quotes allowed to support Revert commits e.g. 'Revert "AP_Periph: ...'
 PREFIX_RE = re.compile(r'^[-A-Za-z0-9._/" ]+$')
 
@@ -97,6 +104,10 @@ class CheckBranchConventions(build_script_base.BuildScriptBase):
                 ok = False
                 continue
             prefix = subject.split(":")[0]
+            if prefix.strip().upper() in BLACKLISTED_PREFIXES:
+                print(f"{FAIL} Bad subsystem prefix '{prefix}': {line}")
+                print(f"       See: {DOCS_URL}")
+                ok = False
             if not PREFIX_RE.match(prefix):
                 print(f"{FAIL} Malformed subsystem prefix '{prefix}': {line}")
                 print("       Prefix must contain only letters, digits, '.', '_', '/', '-', spaces, quotes.")


### PR DESCRIPTION
## Summary

Adds check_good_commit_subsystem() which fails if any commit in the PR uses a prefix from BLACKLISTED_PREFIXES (currently just "DEBUG").

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

I often add DEBUG: commits and I'm always a bit worried I'll leave them in!  This will cause CI to fail on branches with DEBUG: in the commit list.

```
     Checking 2 commit(s) since origin/master...

     ✓ No merge commits.
     ✓ No fixup! commits.
     ✗ Bad subsystem prefix 'DEBUG': 4bc517c2cdd DEBUG: this is a bad commit
            See: https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
     ✓ All commit subject lines within 160 characters.
     ✓ No markdown files changed.
```

... I did look at creating a whitelist.  It was harder than I thought.
