### PR TITLE
autotest: reduce SIM_FLOW_RND for OpticalFlow test

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -3087,6 +3087,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.set_parameters({
             "SIM_FLOW_ENABLE": 1,
+            "SIM_FLOW_RND": 0.02,
             "FLOW_TYPE": 10,
         })
 


### PR DESCRIPTION
## Summary

Reduce the amount of OpticalFlow noise in OpticalFlow test

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [x] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

We're very close to the edge a lot of the time, and the signal/noise ratio is just too low.



Failing:
<img width="1926" height="904" alt="image" src="https://github.com/user-attachments/assets/a2929322-3405-4029-b7e8-270ba8f6d13c" />

Passing:
<img width="1926" height="904" alt="image" src="https://github.com/user-attachments/assets/6ea82312-4022-490b-b69c-46f5a7da2dc7" />

Body rate is smooth:
<img width="1926" height="904" alt="image" src="https://github.com/user-attachments/assets/e63af58a-4aae-4c10-b45f-9ec4d9e7acf6" />

... but so much noise!
<img width="1926" height="904" alt="image" src="https://github.com/user-attachments/assets/7045c9ec-1f24-409a-ade0-fa2ffc5f92f7" />
(before shot)
