### PR TITLE
Copter: convert CTUN climb rates to m/s

### DIFF
--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -19,8 +19,8 @@ struct PACKED log_Control_Tuning {
     float    desired_rangefinder_alt;
     float    rangefinder_alt;
     float    terr_alt;
-    int16_t  target_climb_rate_cms;
-    int16_t  climb_rate_cms;
+    float    target_climb_rate_ms;
+    float    climb_rate_ms;
 };
 
 // Write a control tuning packet
@@ -67,8 +67,8 @@ void Copter::Log_Write_Control_Tuning()
         rangefinder_alt         : AP_Logger::quiet_nanf(),
 #endif
         terr_alt                : terr_alt,
-        target_climb_rate_cms   : int16_t(target_climb_rate_ms * 100.0),
-        climb_rate_cms          : int16_t(pos_control->get_vel_estimate_U_ms() * 100.0) // float -> int16_t
+        target_climb_rate_ms    : target_climb_rate_ms,
+        climb_rate_ms           : pos_control->get_vel_estimate_U_ms()
     };
     logger.WriteBlock(&pkt, sizeof(pkt));
 }
@@ -484,7 +484,7 @@ const struct LogStructure Copter::log_structure[] = {
 // @Field: Value: Value
 
     { LOG_CONTROL_TUNING_MSG, sizeof(log_Control_Tuning),
-      "CTUN", "Qffffffffffhh", "TimeUS,ThI,ABst,ThO,ThH,DAlt,Alt,BAlt,DSAlt,SAlt,TAlt,DCRt,CRt", "s----mmmmmmnn", "F----000000BB" , true },
+      "CTUN", "Qffffffffffff", "TimeUS,ThI,ABst,ThO,ThH,DAlt,Alt,BAlt,DSAlt,SAlt,TAlt,DCRt,CRt", "s----mmmmmmnn", "F----00000000", true },
     { LOG_DATA_INT16_MSG, sizeof(log_Data_Int16t),         
       "D16",   "QBh",         "TimeUS,Id,Value", "s--", "F--" },
     { LOG_DATA_UINT16_MSG, sizeof(log_Data_UInt16t),         


### PR DESCRIPTION
This changes the DCRt and CRt fields in the CTUN log message  from cm/s to m/s. It also converts these fields to float  to maintain precision

## Summary

This PR resolves the issue where Copter climb rates were logged in $cm/s$ as integers. It standardizes these to $m/s$ as floats, aligning with ArduPilot’s move toward SI units for logging

## Testing (more checks increases chance of being merged)

- [X] Checked by a human programmer
- [X] Tested in SITL
- [ ] Tested on hardware
- [X] Logs attached
- [X] Logs available on request
- [ ] Autotest included

## Description

Changes
Updated Log_Write_Control_Tuning in Log.cpp to remove 100 times scaling.
Modified struct log_Control_Tuning to use float for target_climb_rate_ms and climb_rate_ms.
Updated LogStructure table entry for CTUN with format f and units n ($m/s$).

Testing performed
SITL: Performed test flights in ArduCopter.Log 
Analysis: Verified via Mission Planner Log Browser. (Attached screenshot shows decimal precision on the Y-axis)

<img width="1920" height="1080" alt="Screenshot 2026-03-18 113958" src="https://github.com/user-attachments/assets/8fb91130-b38d-4ee8-a600-cbb84df50fdb" />


log file: https://drive.google.com/file/d/12XPbx4gJ3XWTJLYXhIM4meQp69RHk55p/view?usp=sharing

Gist : https://gist.github.com/piVerified/78a6f43b96f1b7528aa5088406dc14ca
<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
