### PR TITLE
AP_HAL_ChibiOS: X-MAV-AP-H743r1 Switch to SPL06 Only Due to Indistinguishable DPS310 and SPL06 IDs.

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/X-MAV-AP-H743r1/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/X-MAV-AP-H743r1/README.md
@@ -16,7 +16,7 @@ It brings you ultimate performance, stability, and reliability in every aspect.
 - On-board sensors
 - Accel/Gyro: ICM-42688-P\*2(Version1), BMI270\*2(Version2)
 - Mag: QMC5883P
-- Barometer: DPS310(Version1),SPL06(Version2)
+- Barometer: SPL06
 
 ## Interfaces
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/X-MAV-AP-H743r1/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/X-MAV-AP-H743r1/hwdef.dat
@@ -149,9 +149,6 @@ PC12 SPI3_MOSI SPI3
 PD4 FRAM_CS CS
 
 # barometers
-# Version1:
-BARO DPS310 I2C:0:0x76
-# Version2:
 BARO SPL06 I2C:0:0x76
 
 # SPI devices


### PR DESCRIPTION
The DPS310 and SPL06 barometers share identical register addresses and ID values, making it impossible to reliably distinguish between the two at runtime. To resolve this ambiguity, we have decided to support only the SPL06 moving forward.

This change is being made during final testing and prior to mass production, so it should have no impact on existing deployments or users.