### PR TITLE
Plane: correct use of __LINE__ to __AP_LINE__

### DIFF
--- a/ArduPlane/GCS_MAVLink_Plane.cpp
+++ b/ArduPlane/GCS_MAVLink_Plane.cpp
@@ -497,7 +497,7 @@ bool GCS_MAVLINK_Plane::handle_guided_request(AP_Mission::Mission_Command &cmd)
  */
 void GCS_MAVLINK_Plane::handle_change_alt_request(Location &location)
 {
-    plane.fix_terrain_WP(location, __LINE__);
+    plane.fix_terrain_WP(location, __AP_LINE__);
 
     if (location.terrain_alt) {
         plane.next_WP_loc.copy_alt_from(location);
@@ -589,7 +589,7 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_command_int_do_reposition(const mavlink_com
     if (!location_from_command_t(packet, requested_position)) {
         return MAV_RESULT_DENIED;
     }
-    plane.fix_terrain_WP(requested_position, __LINE__);
+    plane.fix_terrain_WP(requested_position, __AP_LINE__);
 
     if (isnan(packet.param4) || is_zero(packet.param4)) {
         requested_position.loiter_ccw = 0;

--- a/ArduPlane/Plane.cpp
+++ b/ArduPlane/Plane.cpp
@@ -882,7 +882,7 @@ bool Plane::get_wp_crosstrack_error_m(float &xtrack_error) const
 bool Plane::set_target_location(const Location &target_loc)
 {
     Location loc{target_loc};
-    fix_terrain_WP(loc, __LINE__);
+    fix_terrain_WP(loc, __AP_LINE__);
 
     if (plane.control_mode != &plane.mode_guided) {
         // only accept position updates when in GUIDED mode
@@ -938,7 +938,7 @@ bool Plane::update_target_location(const Location &old_loc, const Location &new_
     }
     next_WP_loc = new_loc;
 
-    fix_terrain_WP(next_WP_loc, __LINE__);
+    fix_terrain_WP(next_WP_loc, __AP_LINE__);
 
 #if HAL_QUADPLANE_ENABLED
     if (control_mode == &mode_qland || control_mode == &mode_qloiter) {

--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -34,7 +34,7 @@ void Plane::check_home_alt_change(void)
     if (home_alt_cm != auto_state.last_home_alt_cm && hal.util->get_soft_armed()) {
         // cope with home altitude changing
         const int32_t alt_change_cm = home_alt_cm - auto_state.last_home_alt_cm;
-        fix_terrain_WP(next_WP_loc, __LINE__);
+        fix_terrain_WP(next_WP_loc, __AP_LINE__);
 
         // reset TECS to force the field elevation estimate to reset
         TECS_controller.offset_altitude(alt_change_cm * 0.01f);

--- a/ArduPlane/commands.cpp
+++ b/ArduPlane/commands.cpp
@@ -37,7 +37,7 @@ void Plane::set_next_WP(const Location &loc)
         }
     }
 
-    fix_terrain_WP(next_WP_loc, __LINE__);
+    fix_terrain_WP(next_WP_loc, __AP_LINE__);
 
     // convert relative alt to absolute alt
     if (!next_WP_loc.terrain_alt) {
@@ -84,7 +84,7 @@ void Plane::set_guided_WP(const Location &loc)
     // ---------------------
     next_WP_loc = loc;
 
-    fix_terrain_WP(next_WP_loc, __LINE__);
+    fix_terrain_WP(next_WP_loc, __AP_LINE__);
 
     // used to control FBW and limit the rate of climb
     // -----------------------------------------------

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -341,7 +341,7 @@ void Plane::do_RTL(int32_t rtl_altitude_AMSL_cm)
     prev_WP_loc = current_loc;
     next_WP_loc = calc_best_rally_or_home_location(current_loc, rtl_altitude_AMSL_cm);
 
-    fix_terrain_WP(next_WP_loc, __LINE__);
+    fix_terrain_WP(next_WP_loc, __AP_LINE__);
 
     setup_terrain_target_alt(next_WP_loc);
     set_target_altitude_location(next_WP_loc);

--- a/ArduPlane/mode_guided.cpp
+++ b/ArduPlane/mode_guided.cpp
@@ -108,7 +108,7 @@ void ModeGuided::navigate()
 
 bool ModeGuided::handle_guided_request(Location target_loc)
 {
-    plane.fix_terrain_WP(target_loc, __LINE__);
+    plane.fix_terrain_WP(target_loc, __AP_LINE__);
     // add home alt if needed
     if (!target_loc.terrain_alt) {
         target_loc.change_alt_frame(Location::AltFrame::ABSOLUTE);


### PR DESCRIPTION
## Summary

If we do not use `__AP_LINE__` we don't get reproducible builds if you add a line above either of these.

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

Compiler output is now identical on my branch after making this change, rather than being a zero-byte change.

