### PR TITLE
Dockerfile: raise default version to ubuntu24.04 and fixup user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 ARG BASE_IMAGE="ubuntu"
-ARG TAG="22.04"
+ARG TAG="24.04"
 FROM ${BASE_IMAGE}:${TAG}
-WORKDIR /ardupilot
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG USER_NAME=ardupilot
@@ -13,33 +12,65 @@ ARG SKIP_AP_COV_ENV=1
 ARG SKIP_AP_GIT_CHECK=1
 ARG DO_AP_STM_ENV=1
 
-RUN groupadd ${USER_NAME} --gid ${USER_GID}\
-    && useradd -l -m ${USER_NAME} -u ${USER_UID} -g ${USER_GID} -s /bin/bash
+WORKDIR /${USER_NAME}
+
+RUN set -eux; \
+    # Ensure the requested UID/GID is available. If something already exists with that ID
+    # (e.g. the default "ubuntu" user), rename it to the requested USER_NAME.
+    existing_group=$(getent group "${USER_GID}" | cut -d: -f1 || true); \
+    if [ -n "$existing_group" ]; then \
+        if [ "$existing_group" != "${USER_NAME}" ]; then \
+            groupmod -n "${USER_NAME}" "$existing_group"; \
+        fi; \
+    else \
+        groupadd "${USER_NAME}" --gid "${USER_GID}"; \
+    fi; \
+    existing_user=$(getent passwd "${USER_UID}" | cut -d: -f1 || true); \
+    if [ -n "$existing_user" ]; then \
+        if [ "$existing_user" != "${USER_NAME}" ]; then \
+            usermod -l "${USER_NAME}" -d "/home/${USER_NAME}" -m "$existing_user"; \
+        fi; \
+    else \
+        useradd -l -m "${USER_NAME}" -u "${USER_UID}" -g "${USER_GID}" -s /bin/bash; \
+    fi
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     lsb-release \
     sudo \
     tzdata \
     git \
-    default-jre \
-    bash-completion
+    openjdk-17-jre-headless \
+    bash-completion \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-COPY Tools/environment_install/install-prereqs-ubuntu.sh /ardupilot/Tools/environment_install/
-COPY Tools/completion /ardupilot/Tools/completion/
+# Ensure Gradle uses a supported JDK (Ubuntu 24.04 defaults to Java 21, which
+# Gradle 7.6 does not support). This is only needed for the Docker build.
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+ENV PATH="$JAVA_HOME/bin:$PATH"
 
-# Create non root user for pip
-RUN echo "ardupilot ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/${USER_NAME}
-RUN chmod 0440 /etc/sudoers.d/${USER_NAME}
+COPY Tools/environment_install/install-prereqs-ubuntu.sh /${USER_NAME}/Tools/environment_install/
+COPY Tools/completion /${USER_NAME}/Tools/completion/
 
-RUN chown -R ${USER_NAME}:${USER_NAME} /${USER_NAME}
+# Set passwordless sudo for user to allow to use our scripts.
+RUN echo "${USER_NAME} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/${USER_NAME} \
+    && chmod 0440 /etc/sudoers.d/${USER_NAME}
+
+RUN chown -R ${USER_NAME}:${USER_NAME} /home/${USER_NAME} \
+    && chown -R ${USER_NAME}:${USER_NAME} /${USER_NAME}
 
 USER ${USER_NAME}
 
-RUN SKIP_AP_EXT_ENV=$SKIP_AP_EXT_ENV SKIP_AP_GRAPHIC_ENV=$SKIP_AP_GRAPHIC_ENV SKIP_AP_COV_ENV=$SKIP_AP_COV_ENV SKIP_AP_GIT_CHECK=$SKIP_AP_GIT_CHECK \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/home/${USER_NAME}/.cache/pip,sharing=locked,uid=${USER_UID},gid=${USER_GID} \
+    SKIP_AP_EXT_ENV=$SKIP_AP_EXT_ENV SKIP_AP_GRAPHIC_ENV=$SKIP_AP_GRAPHIC_ENV SKIP_AP_COV_ENV=$SKIP_AP_COV_ENV SKIP_AP_GIT_CHECK=$SKIP_AP_GIT_CHECK \
     DO_AP_STM_ENV=$DO_AP_STM_ENV \
     AP_DOCKER_BUILD=1 \
     USER=${USER_NAME} \
-    Tools/environment_install/install-prereqs-ubuntu.sh -y
+    Tools/environment_install/install-prereqs-ubuntu.sh -y \
+    && sudo apt-get clean \
+    && sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Rectify git perms issue that seems to crop up only on OSX
 RUN git config --global --add safe.directory $PWD
@@ -65,10 +96,6 @@ RUN export ARDUPILOT_ENTRYPOINT="/home/${USER_NAME}/ardupilot_entrypoint.sh" \
 
 # Set the buildlogs directory into /tmp as other directory aren't accessible
 ENV BUILDLOGS=/tmp/buildlogs
-
-# Cleanup
-RUN sudo apt-get clean \
-    && sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENV CCACHE_MAXSIZE=1G
 ENTRYPOINT ["/ardupilot_entrypoint.sh"]


### PR DESCRIPTION
## Summary

Raise container default version to 24.04 and fixup user

## Testing (more checks increases chance of being merged)

- [ X] Checked by a human programmer
- [ X] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ X] Logs available on request
- [ ] Autotest included

## Description

Raise ubuntu version to 24.04. Fix user for image like ubuntu have already an user with 1000:1000
Set openjdk-17 to build xrce dds as gradle version require it fixed.
Add build cache for apt and pip
Do proper cleanup on layer with apt install

22.04 still build

Tested with 
`docker build . -t ardupilot --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g)`

inside container
`docker run --rm -it -v "$(pwd):/ardupilot" -u "$(id -u):$(id -g)" ardupilot:latest bash`
then ./waf configure and ./waf copter

outside container
```
docker run --rm -it -v "$(pwd):/ardupilot" -u "$(id -u):$(id -g)" ardupilot:latest ./waf configure --enable-DDS
docker run --rm -it -v "$(pwd):/ardupilot" -u "$(id -u):$(id -g)" ardupilot:latest ./waf copter
```