### PR TITLE
Spoolup reporting

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -333,9 +333,6 @@ private:
     bool variances_valid;
     uint32_t last_ekf_check_us;
 
-    // takeoff check
-    uint32_t takeoff_check_warning_ms;  // system time user was last warned of takeoff check failure
-
     // GCS selection
     GCS_Copter _gcs; // avoid using this; use gcs()
     GCS_Copter &gcs() { return _gcs; }

--- a/ArduCopter/takeoff_check.cpp
+++ b/ArduCopter/takeoff_check.cpp
@@ -14,19 +14,24 @@ void Copter::takeoff_check()
         return;
     }
 
-    // Run the common motor checks (called early so it can clear its warning timer when disarmed)
-    const bool motor_check_passed = motors_takeoff_check(g2.takeoff_rpm_min, g2.takeoff_rpm_max);
-
-    // block takeoff when disarmed but do not display warnings
-    if (!motors->armed()) {
+    // block takeoff when disarmed or motors stopped but do not display warnings
+    if (!motors->get_spoolup_ready()) {
         motors->set_spoolup_block(true);
-        takeoff_check_warning_ms = 0;
+        takeoff_check_state.warning_ms = 0;
         return;
     }
 
     // if motors have become unblocked return immediately
     // this ensures the motors can only be blocked immediate after arming
     if (!motors->get_spoolup_block()) {
+        return;
+    }
+
+    // Run the common motor checks
+    const bool motor_check_passed = motors_takeoff_check(g2.takeoff_rpm_min, g2.takeoff_rpm_max);
+
+    // early return if motor checks failed as we will already have output a message
+    if (!motor_check_passed) {
         return;
     }
 
@@ -47,11 +52,8 @@ void Copter::takeoff_check()
 
     // warn about CPU load every 5 seconds
     uint32_t now_ms = AP_HAL::millis();
-    if (takeoff_check_warning_ms == 0) {
-        takeoff_check_warning_ms = now_ms;
-    }
-    if (now_ms - takeoff_check_warning_ms > 5000) {
-        takeoff_check_warning_ms = now_ms;
+    if (now_ms - takeoff_check_state.warning_ms > 5000) {
+        takeoff_check_state.warning_ms = now_ms;
         const char* prefix_str = "Takeoff blocked:";
         if (!load_adequate) {
             gcs().send_text(MAV_SEVERITY_CRITICAL, "%s CPU overload (%4.1f%%)", prefix_str, avg_load);

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1567,6 +1567,25 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
     # Tests the motor failsafe
     def TakeoffCheck(self):
         '''Test takeoff check'''
+
+        self.start_subtest("Test blocking doesn't occur with in-range RPM")
+        self.context_push()
+        self.context_collect('STATUSTEXT')
+        self.set_parameters({
+            "AHRS_EKF_TYPE": 10,
+            'SIM_ESC_TELEM': 1,
+            'SIM_ESC_ARM_RPM': 1000,
+            'TKOFF_RPM_MIN': 900,
+            'TKOFF_RPM_MAX': 1100,
+        })
+        self.takeoff(10, mode="LOITER")
+        self.land_and_disarm()
+        # ensure no spurious takeoff blocked warnings during spoolup
+        for m in self.context_collection('STATUSTEXT'):
+            if "Takeoff blocked" in m.text:
+                raise NotAchievedException("Spurious takeoff blocked message: %s" % m.text)
+        self.context_pop()
+
         self.set_parameters({
             "AHRS_EKF_TYPE": 10,
             'SIM_ESC_TELEM': 1,

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -3069,6 +3069,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
 
         self.start_subtest("Test blocking doesn't occur with in-range RPM")
         self.context_push()
+        self.context_collect('STATUSTEXT')
         self.set_parameters({
             'SIM_VIB_MOT_MAX': 150, # Hz, 9000 RPM, ensures the test fails if check occurs after takeoff starts
             'SIM_ESC_ARM_RPM': 1000,
@@ -3085,6 +3086,10 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.wait_current_waypoint(2)
         self.wait_disarmed()
         self.set_current_waypoint(0, check_afterwards=False)
+        # ensure no spurious takeoff blocked warnings during spoolup
+        for m in self.context_collection('STATUSTEXT'):
+            if "Takeoff blocked" in m.text:
+                raise NotAchievedException("Spurious takeoff blocked message: %s" % m.text)
         self.context_pop()
 
         self.start_subtest("Ensure blocked if motors don't spool up")

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -711,13 +711,8 @@ void AP_MotorsMulticopter::output_logic()
             // constrain ramp value and update mode
             if (_spin_up_ratio >= 1.0f) {
                 _spin_up_ratio = 1.0f;
-                if (!get_spoolup_block()) {
-                    // only advance from ground idle when pre-takeoff checks have cleared
-                    // get_spoolup_block() is true while takeoff_check() is blocking spool-up
-                    // (e.g. esc telemetry inactive, rpm not in range, cpu overload, or disarmed)
-                    // must be false to proceed
-                    _spool_state = SpoolState::SPOOLING_UP;
-                }
+                set_spoolup_block(true);
+                _spool_state = SpoolState::SPOOLING_UP;
             }
             break;
         }

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -96,6 +96,8 @@ public:
     bool                get_thrust(uint8_t motor_num, float& thr_out) const override;
 
     bool                get_raw_motor_throttle(uint8_t motor_num, float& thr_out) const override;
+    // no point checking for spoolup conditions until the motors are in a state ready to spoolup
+    bool                get_spoolup_ready() const override { return _spin_up_ratio >= 1.0; }
 
 #if HAL_LOGGING_ENABLED
     // 10hz logging of voltage scaling and max trust

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -123,6 +123,8 @@ public:
     // get motor interlock status.  true means motors run, false motors don't run
     bool                get_interlock() const { return _interlock; }
 
+    // no point checking for spoolup conditions until the motors are in a state ready to spoolup
+    virtual bool        get_spoolup_ready() const { return true; }
     // get/set spoolup block
     bool                get_spoolup_block() const { return _spoolup_block; }
     void                set_spoolup_block(bool set) { _spoolup_block = set; }

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -1163,8 +1163,8 @@ bool AP_Vehicle::motors_takeoff_check(float rpm_min, float rpm_max)
         return true;
     }
 
-    // clear warning timer when disarmed or motors stopped
-    if (!motors->get_spoolup_ready()) {
+    // clear warning timer when disarmed or motors not yet spinning
+    if (!motors->armed() || motors->get_spool_state() == AP_Motors::SpoolState::SHUT_DOWN) {
         takeoff_check_state.warning_ms = 0;
         return false;
     }

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -1163,10 +1163,16 @@ bool AP_Vehicle::motors_takeoff_check(float rpm_min, float rpm_max)
         return true;
     }
 
-    // clear warning timer when disarmed
-    if (!motors->armed()) {
+    // clear warning timer when disarmed or motors stopped
+    if (!motors->get_spoolup_ready()) {
         takeoff_check_state.warning_ms = 0;
         return false;
+    }
+
+    // motors are in a state that we can start reporting on them - start the counter now
+    uint32_t now_ms = AP_HAL::millis();
+    if (takeoff_check_state.warning_ms == 0) {
+        takeoff_check_state.warning_ms = now_ms;
     }
 
     // check ESCs are sending RPM at expected level
@@ -1180,10 +1186,6 @@ bool AP_Vehicle::motors_takeoff_check(float rpm_min, float rpm_max)
     }
 
     // warn user telem inactive or rpm is inadequate every 5 seconds
-    uint32_t now_ms = AP_HAL::millis();
-    if (takeoff_check_state.warning_ms == 0) {
-        takeoff_check_state.warning_ms = now_ms;
-    }
     if (now_ms - takeoff_check_state.warning_ms > 5000) {
         takeoff_check_state.warning_ms = now_ms;
         const char* prefix_str = "Takeoff blocked:";


### PR DESCRIPTION
Some timing changes in the spool-up code and refactoring of the spool-up block mean that we get spurious errors on arming. This PR changes the checks to only start happening once spin min is reached which is the point at which the motors are ready to go unlimited. The timeout has also been changed to start timing from that point giving the motors a little time to settle before erroring to the user.

## Testing (more checks increases chance of being merged)

- [X] Checked by a human programmer
- [X] Tested in SITL
- [X] Tested on hardware
