### PR TITLE
Tools: ros2: add launch argument `use_instance_dir`

### DIFF
--- a/Tools/ros2/ardupilot_sitl/src/ardupilot_sitl/launch.py
+++ b/Tools/ros2/ardupilot_sitl/src/ardupilot_sitl/launch.py
@@ -14,6 +14,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 """Launch actions for ArduPilot."""
+from pathlib import Path
 from typing import Dict
 from typing import List
 from typing import Text
@@ -393,6 +394,7 @@ class SITLLaunch:
         sim_address = LaunchConfiguration("sim_address").perform(context)
         instance = LaunchConfiguration("instance").perform(context)
         defaults = LaunchConfiguration("defaults").perform(context)
+        use_instance_dir = LaunchConfiguration("use_instance_dir").perform(context)
 
         # Display launch arguments.
         print(f"command:          {command}")
@@ -402,6 +404,7 @@ class SITLLaunch:
         print(f"sim_address:      {sim_address}")
         print(f"instance:         {instance}")
         print(f"defaults:         {defaults}")
+        print(f"use_instance_dir: {use_instance_dir}")
 
         # Required arguments.
         cmd_args = [
@@ -482,9 +485,17 @@ class SITLLaunch:
             cmd_args.append(f"--sysid {sysid} ")
             print(f"sysid:            {sysid}")
 
+        cwd = Path.cwd()
+        if use_instance_dir == TRUE_STRING:
+            # Create an instance directory to store eeprom.bin.
+            cwd = cwd / f"{instance}"
+            Path(cwd).mkdir(exist_ok=True)
+            print(f"cwd:              {cwd}")
+
         # Create action.
         sitl_process = ExecuteProcess(
             cmd=[cmd_args],
+            cwd=str(cwd),
             shell=True,
             output="both",
             respawn=False,
@@ -633,6 +644,12 @@ class SITLLaunch:
                 "sysid",
                 default_value="",
                 description="Set MAV_SYSID.",
+            ),
+            DeclareLaunchArgument(
+                "use_instance_dir",
+                default_value="False",
+                description="If True create instance directories for the eeprom.bin.",
+                choices=BOOL_STRING_CHOICES,
             ),
         ]
 


### PR DESCRIPTION
## Summary

Add an optional boolean launch argument to the ROS 2 SITL launch scripts. If `use_instance_dir` is True then create a directory based on the instance to store `eeprom.bin` and other files created by SITL.  This is required for multi-vehicle launches to avoid conflict.

Related: https://github.com/ArduPilot/ardupilot_gz/pull/67

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [x] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

Add a new launch argument `use_instance_dir` to the `SITLLaunch`. The default is `False` preserving existing behaviour.
When `True` a subdirectory is created in the current working directory using the `instance` argument. This is passed to the `ExecuteProcess` launch directive ensuring SITL is started in the scoped directory. 