### PR TITLE
hwdef: remove rst references from markdown

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/AIRBRAINH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/AIRBRAINH743/README.md
@@ -72,11 +72,11 @@ The voltage sensor can handle up to 6S LiPo batteries.
 
 The default battery parameters are:
 
-- :ref:`BATT_MONITOR<BATT_MONITOR>` = 4
-- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 4
-- :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 8 (CURRENT pin)
-- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 15.0
-- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 101.0
+BATT_MONITOR=4
+BATT_VOLT_PIN=4
+BATT_CURR_PIN=8
+BATT_VOLT_MULT=15.0
+BATT_AMP_PERVLT=101.0
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ATOMRCF405NAVI-Deluxe/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ATOMRCF405NAVI-Deluxe/README.md
@@ -91,21 +91,14 @@ The SBUS pin, is passed by an inverter to RX2 (UART2 RX). UART2 is defaulted to 
 
 ## Battery Monitor Configuration
 
-These settings are set as defaults when the firmware is loaded (except :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` which needs to be changed from the default value). However, if they are ever lost, you can manually set the parameters:
+These settings are set as defaults when the firmware is loaded (except `BATT_AMP_PERVLT` which needs to be changed from the default value). However, if they are ever lost, you can manually set the parameters:
 
-Enable Battery monitor.
+Enable Battery monitor with `BATT_MONITOR=4`, then reboot, then set:
 
-:ref:`BATT_MONITOR<BATT_MONITOR>` =4
-
-Then reboot.
-
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 10
-
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 11
-
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11
-
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 30
+BATT_VOLT_PIN=10
+BATT_CURR_PIN=11
+BATT_VOLT_MULT=11
+BATT_AMP_PERVLT=30
 
 ## Connecting a GPS/Compass module
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/AcctonGodwit_GA1/readme.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/AcctonGodwit_GA1/readme.md
@@ -135,11 +135,11 @@ This universal controller does not provide power to the servos. To power them, a
 
 The autopilot defaults are setup to DroneCAN BatteryInfo:
 
-- :ref:`BATT_MONITOR<BATT_MONITOR>` = 8
-- :ref:`CAN_P1_DRIVER<CAN_P1_DRIVER>` = 1
-- :ref:`CAN_P2_DRIVER<CAN_P2_DRIVER>` = 1
-- :ref:`CAN_D1_PROTOCOL<CAN_D1_PROTOCOL>` = 1
-- :ref:`CAN_D2_PROTOCOL<CAN_D2_PROTOCOL>` = 1
+BATT_MONITOR=8
+CAN_P1_DRIVER=1
+CAN_P2_DRIVER=1
+CAN_D1_PROTOCOL=1
+CAN_D2_PROTOCOL=1
 
 ## SD Card
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BOTWINGF405/Readme.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BOTWINGF405/Readme.md
@@ -105,11 +105,11 @@ The board has a built-in voltage sensor and external current sensor input. The c
 sensor can read up to 120 Amps. The voltage sensor can handle up to 6S LiPo batteries.
 The default battery monitor parameters are:
 
-* :ref:`BATT_MONITOR<BATT_MONITOR>` 4
-* :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 11
-* :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 13
-* :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11.0
-* :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 37 (may need adjustment depending on external current sensor used)
+BATT_MONITOR=4
+BATT_VOLT_PIN=11
+BATT_CURR_PIN=13
+BATT_VOLT_MULT=11.0
+BATT_AMP_PERVLT=37
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CORVON405V2_1/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CORVON405V2_1/README.md
@@ -65,11 +65,11 @@ The voltage sensor can handle up to 6S LiPo batteries.
 
 The default battery parameters are:
 
-- :ref:`BATT_MONITOR<BATT_MONITOR>` = 4
-- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 10
-- :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 11 (CURR pin)
-- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 21.2
-- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 40.2
+BATT_MONITOR=4
+BATT_VOLT_PIN=10
+BATT_CURR_PIN=11
+BATT_VOLT_MULT=21.2
+BATT_AMP_PERVLT=40.2
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVF405/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVF405/README.md
@@ -79,11 +79,11 @@ sensor can read up to 130 Amps. The voltage sensor can handle up to 8S LiPo batt
 
 The correct battery setting parameters are:
 
-- :ref:`BATT_MONITOR<BATT_MONITOR>` 4
-- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 11
-- :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 10
-- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11.0
-- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 83.3
+BATT_MONITOR=4
+BATT_VOLT_PIN=11
+BATT_CURR_PIN=10
+BATT_VOLT_MULT=11.0
+BATT_AMP_PERVLT=83.3
 
 ## RSSI
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743/README.md
@@ -89,11 +89,11 @@ sensor can read up to 130 Amps. The voltage sensor can handle up to 12S LiPo bat
 
 The correct battery setting parameters are:
 
-- :ref:`BATT_MONITOR<BATT_MONITOR>` 4
-- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 11
-- :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 10
-- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 16.0
-- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 83.3
+BATT_MONITOR=4
+BATT_VOLT_PIN=11
+BATT_CURR_PIN=10
+BATT_VOLT_MULT=16.0
+BATT_AMP_PERVLT=83.3
 
 ## RSSI
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743Pro/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743Pro/README.md
@@ -98,11 +98,11 @@ sensor can read up to 130 Amps. The voltage sensor can handle up to 12S LiPo bat
 
 The correct battery setting parameters are:
 
-- :ref:`BATT_MONITOR<BATT_MONITOR>` 4
-- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 11
-- :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 10
-- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 16.0
-- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 83.3
+BATT_MONITOR=4
+BATT_VOLT_PIN=11
+BATT_CURR_PIN=10
+BATT_VOLT_MULT=16.0
+BATT_AMP_PERVLT=83.3
 
 ## RSSI
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743_SLIM/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743_SLIM/README.md
@@ -88,11 +88,11 @@ sensor can read up to 130 Amps. The voltage sensor can handle up to 12S LiPo bat
 
 The correct battery setting parameters are:
 
-- :ref:`BATT_MONITOR<BATT_MONITOR>` 4
-- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 11
-- :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 10
-- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 16.0
-- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 83.3
+BATT_MONITOR=4
+BATT_VOLT_PIN=11
+BATT_CURR_PIN=10
+BATT_VOLT_MULT=16.0
+BATT_AMP_PERVLT=83.3
 
 ## RSSI
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/F4BY_H743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/F4BY_H743/README.md
@@ -147,11 +147,11 @@ The board has a external current and voltage sensor input. The sensors range fro
 
 The default battery parameters are:
 
-- :ref:`BATT_MONITOR<BATT_MONITOR>` = 4
-- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 13
-- :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 12
-- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 16.04981
-- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 100 (will need to be adjusted for whichever current sensor is attached)
+BATT_MONITOR=4
+BATT_VOLT_PIN=13
+BATT_CURR_PIN=12
+BATT_VOLT_MULT=16.04981
+BATT_AMP_PERVLT=100
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/FlysparkF4/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/FlysparkF4/README.md
@@ -98,11 +98,11 @@ If any channel in a group uses DShot, all channels in that group must also use D
 The board includes a built-in voltage and current sensor connected to ADC pins.
 Default configuration:
 
-- :ref:`BATT_MONITOR<BATT_MONITOR>` 4
-- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 10
-- :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 11
-- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11.0
-- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 25.0
+BATT_MONITOR=4
+BATT_VOLT_PIN=10
+BATT_CURR_PIN=11
+BATT_VOLT_MULT=11.0
+BATT_AMP_PERVLT=25.0
 
 Supports direct 3 S-6 S LiPo voltage measurement.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/JHEMCUF405PRO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/JHEMCUF405PRO/README.md
@@ -72,11 +72,11 @@ JHEMCUF405PRO supports up to 5 motor/servo outputs. 4 motors and 1 LED strip or 
 
 The default battery configuration is:
 
-- :ref:`BATT_MONITOR<BATT_MONITOR>` = 4
-- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 13
-- :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 12
-- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 11
-- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 95.84
+BATT_MONITOR=4
+BATT_VOLT_PIN=13
+BATT_CURR_PIN=12
+BATT_VOLT_MULT=11
+BATT_AMP_PERVLT=95.84
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/JHEMCUF405WING/Readme.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/JHEMCUF405WING/Readme.md
@@ -101,15 +101,11 @@ LiPo batteries.
 
 The correct battery setting parameters are set by default and are:
 
-:ref:`BATT_MONITOR<BATT_MONITOR>` = 4
-
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 10
-
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 11
-
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11.05
-
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 50
+BATT_MONITOR=4
+BATT_VOLT_PIN=10
+BATT_CURR_PIN=11
+BATT_VOLT_MULT=11.05
+BATT_AMP_PERVLT=50
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/LumenierLUXF765-NDAA/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/LumenierLUXF765-NDAA/README.md
@@ -171,11 +171,11 @@ for an external current sensor input. The voltage sensor can handle up to an 8S 
 
 The default parameters are as follows:
 
-- :ref:`BATT_MONITOR<BATT_MONITOR>` = 4
-- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 12
-- :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 13
-- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 10.1
-- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 17.0 (will need to be adjusted for whichever current sensor is attached)
+BATT_MONITOR=4
+BATT_VOLT_PIN=12
+BATT_CURR_PIN=13
+BATT_VOLT_MULT=10.1
+BATT_AMP_PERVLT=17.0
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MUPilot/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MUPilot/README.md
@@ -233,14 +233,14 @@ The output levels of the auxiliary outputs can be selected by switch to be eithe
 The board has two dedicated power monitor ports on 6 pin
 connectors. The correct battery setting parameters are dependent on
 the type of power brick which is connected. The first is analog only, the second may be either analog or I2C, depending on baseboard jumpers.
-In order to enable monitoring, the BATT_MONITOR or BATT2_MONIOT parameter must be set. By default :ref:`BATT_MONITOR<BATT_MONITOR>` is set to "4" for the included power module..
+In order to enable monitoring, the BATT_MONITOR or BATT2_MONIOT parameter must be set. By default BATT_MONITOR is set to "4" for the included power module.
 
 Default params for the first monitor are set and are:
 
-- BATT_VOLT_PIN = 2
-- BATT_CURR_PIN = 1
-- BATT_VOLT_MULT = 18.0
-- BATT_AMP_PERVLT = 24.0 (may need adjustment if supplied monitor is not used)
+BATT_VOLT_PIN=2
+BATT_CURR_PIN=1
+BATT_VOLT_MULT=18.0
+BATT_AMP_PERVLT=24.0
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ORBITH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ORBITH743/README.md
@@ -163,25 +163,21 @@ This board does **not** include GPS or compass modules. An [external GPS/compass
 
 These are set by default. If reset:
 
-Enable battery monitor with:
-
-- :ref:`BATT_MONITOR<BATT_MONITOR>` = 4
-
-Then reboot.
+Enable battery monitor with `BATT_MONITOR=4`, then reboot, then set:
 
 **First battery monitor is enabled by default:**
 
-- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` = 10
-- :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` = 11
-- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` = 10.1
-- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` = 80.0 *(Calibrate as needed, depending on current sensor.)*
+BATT_VOLT_PIN=10
+BATT_CURR_PIN=11
+BATT_VOLT_MULT=10.1
+BATT_AMP_PERVLT=80.0
 
 **The second battery monitor is not enabled by default, but its parameter defaults have been set:**
 
-- :ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN>` = 4
-- :ref:`BATT2_CURR_PIN<BATT2_CURR_PIN>` = 18
-- :ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT>` = 10.1
-- :ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT>` = 80.0 *(Calibrate as needed, depending on current sensor)*
+BATT2_VOLT_PIN=4
+BATT2_CURR_PIN=18
+BATT2_VOLT_MULT=10.1
+BATT2_AMP_PERVLT=80.0
 
 ## Where to Buy
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-C3/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-C3/README.md
@@ -146,27 +146,16 @@ to use DShot.
 
 These should already be set by default. However, if lost or changed:
 
-Enable Battery monitor with these parameter settings :
+Enable Battery monitor with `BATT_MONITOR=4`, then reboot, then set:
 
-:ref:`BATT_MONITOR<BATT_MONITOR>` =4
-
-Then reboot.
-
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 2
-
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 3
-
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 18.0
-
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 24.0
-
-:ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN>` 14
-
-:ref:`BATT2_CURR_PIN<BATT2_CURR_PIN>` 13
-
-:ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT>` 18.0
-
-:ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT>` 24.0
+BATT_VOLT_PIN=2
+BATT_CURR_PIN=3
+BATT_VOLT_MULT=18.0
+BATT_AMP_PERVLT=24.0
+BATT2_VOLT_PIN=14
+BATT2_CURR_PIN=13
+BATT2_VOLT_MULT=18.0
+BATT2_AMP_PERVLT=24.0
 
 ## DroneCAN capability
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-V3/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-V3/README.md
@@ -144,27 +144,16 @@ to use DShot.
 
 These should already be set by default. However, if lost or changed:
 
-Enable Battery monitor with these parameter settings :
+Enable Battery monitor with `BATT_MONITOR=4`, then reboot, then set:
 
-:ref:`BATT_MONITOR<BATT_MONITOR>` =4
-
-Then reboot.
-
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 2
-
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 3
-
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 18.0
-
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 24.0
-
-:ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN>` 14
-
-:ref:`BATT2_CURR_PIN<BATT2_CURR_PIN>` 13
-
-:ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT>` 18.0
-
-:ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT>` 24.0
+BATT_VOLT_PIN=2
+BATT_CURR_PIN=3
+BATT_VOLT_MULT=18.0
+BATT_AMP_PERVLT=24.0
+BATT2_VOLT_PIN=14
+BATT2_CURR_PIN=13
+BATT2_VOLT_MULT=18.0
+BATT2_AMP_PERVLT=24.0
 
 ## DroneCAN capability
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-V6/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-V6/README.md
@@ -117,27 +117,16 @@ All compatible RC protocols can be decoded by attaching the Receiver's output to
 
 These should already be set by default. However, if lost or changed:
 
-Enable Battery monitor with these parameter settings :
+Enable Battery monitor with `BATT_MONITOR=4`, then reboot, then set:
 
-:ref:`BATT_MONITOR<BATT_MONITOR>` =4
-
-Then reboot.
-
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 14
-
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 15
-
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 18.0
-
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 24.0
-
-:ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN>` 13
-
-:ref:`BATT2_CURR_PIN<BATT2_CURR_PIN>` 4
-
-:ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT>` 18.0
-
-:ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT>` 24.0
+BATT_VOLT_PIN=14
+BATT_CURR_PIN=15
+BATT_VOLT_MULT=18.0
+BATT_AMP_PERVLT=24.0
+BATT2_VOLT_PIN=13
+BATT2_CURR_PIN=4
+BATT2_VOLT_MULT=18.0
+BATT2_AMP_PERVLT=24.0
 
 ## DroneCAN capability
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-V6PRO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-V6PRO/README.md
@@ -133,27 +133,16 @@ All compatible RC protocols can be decoded by attaching the Receiver's output to
 
 These should already be set by default. However, if lost or changed:
 
-Enable Battery monitor with these parameter settings :
+Enable Battery monitor with `BATT_MONITOR=4`, then reboot, then set:
 
-:ref:`BATT_MONITOR<BATT_MONITOR>` =4
-
-Then reboot.
-
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 14
-
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 15
-
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 18.0
-
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 24.0
-
-:ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN>` 13
-
-:ref:`BATT2_CURR_PIN<BATT2_CURR_PIN>` 4
-
-:ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT>` 18.0
-
-:ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT>` 24.0
+BATT_VOLT_PIN=14
+BATT_CURR_PIN=15
+BATT_VOLT_MULT=18.0
+BATT_AMP_PERVLT=24.0
+BATT2_VOLT_PIN=13
+BATT2_CURR_PIN=4
+BATT2_VOLT_MULT=18.0
+BATT2_AMP_PERVLT=24.0
 
 ## DroneCAN capability
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixSurveyA1-IND/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixSurveyA1-IND/README.md
@@ -157,27 +157,16 @@ to use DShot.
 
 These should already be set by default. However, if lost or changed:
 
-Enable Battery monitor with these parameter settings :
+Enable Battery monitor with `BATT_MONITOR=4`, then reboot, then set:
 
-:ref:`BATT_MONITOR<BATT_MONITOR>` =4
-
-Then reboot.
-
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 2
-
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 3
-
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 18.0
-
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 24.0
-
-:ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN>` 14
-
-:ref:`BATT2_CURR_PIN<BATT2_CURR_PIN>` 13
-
-:ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT>` 18.0
-
-:ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT>` 24.0
+BATT_VOLT_PIN=2
+BATT_CURR_PIN=3
+BATT_VOLT_MULT=18.0
+BATT_AMP_PERVLT=24.0
+BATT2_VOLT_PIN=14
+BATT2_CURR_PIN=13
+BATT2_VOLT_MULT=18.0
+BATT2_AMP_PERVLT=24.0
 
 ## DroneCAN capability
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/RadiolinkF405/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/RadiolinkF405/README.md
@@ -70,11 +70,11 @@ The voltage sensor can handle up to 6S LiPo batteries.
 
 The default battery parameters are:
 
-- :ref:`BATT_MONITOR<BATT_MONITOR>` = 4
-- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 12
-- :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 11 (CURR pin)
-- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 11.0
-- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 25
+BATT_MONITOR=4
+BATT_VOLT_PIN=12
+BATT_CURR_PIN=11
+BATT_VOLT_MULT=11.0
+BATT_AMP_PERVLT=25
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ResoluteH7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ResoluteH7/README.md
@@ -68,11 +68,11 @@ The board has a built-in voltage sensor and external current sensor input. The v
 
 The correct battery setting parameters are:
 
-- :ref:`BATT_MONITOR<BATT_MONITOR>` 4
-- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 10
-- :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 11
-- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11.0
-- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 40
+BATT_MONITOR=4
+BATT_VOLT_PIN=10
+BATT_CURR_PIN=11
+BATT_VOLT_MULT=11.0
+BATT_AMP_PERVLT=40
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SkystarsF405v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SkystarsF405v2/README.md
@@ -76,11 +76,11 @@ The voltage sensor can handle up to 6S LiPo batteries.
 
 The default battery parameters are:
 
-- :ref:`BATT_MONITOR<BATT_MONITOR>` = 4
-- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 10
-- :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 11 (CURR pin)
-- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 11.0
-- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 25.0
+BATT_MONITOR=4
+BATT_VOLT_PIN=10
+BATT_CURR_PIN=11
+BATT_VOLT_MULT=11.0
+BATT_AMP_PERVLT=25.0
 
 ## Analog RSSI input
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/StellarF4/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/StellarF4/README.md
@@ -82,11 +82,11 @@ The voltage input is compatible with 2~6S LiPo batteries.
 
 The default battery parameters are:
 
-- :ref:`BATT_MONITOR<BATT_MONITOR>` = 4
-- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 10
-- :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 11 (CURR pin)
-- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 11.2
-- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 52.7
+BATT_MONITOR=4
+BATT_VOLT_PIN=10
+BATT_CURR_PIN=11
+BATT_VOLT_MULT=11.2
+BATT_AMP_PERVLT=52.7
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/StellarF4V2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/StellarF4V2/README.md
@@ -81,11 +81,11 @@ The voltage input is compatible with 2~8S LiPo batteries.
 
 The default battery parameters are:
 
-- :ref:`BATT_MONITOR<BATT_MONITOR>` = 4
-- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 10
-- :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 11 (CURR pin)
-- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 11
-- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 10
+BATT_MONITOR=4
+BATT_VOLT_PIN=10
+BATT_CURR_PIN=11
+BATT_VOLT_MULT=11
+BATT_AMP_PERVLT=10
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/StellarH7V2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/StellarH7V2/README.md
@@ -84,17 +84,17 @@ The board has 1 built-in voltage divider and 2x current ADC. Support external 3.
 The voltage input is compatible with 2~8S LiPo batteries.
 The default battery parameters are:
 
-- :ref:`BATT_MONITOR<BATT_MONITOR>` = 4
-- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 10
-- :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 11 (CURR pin)
-- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 11.0
-- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 66.7
+BATT_MONITOR=4
+BATT_VOLT_PIN=10
+BATT_CURR_PIN=11
+BATT_VOLT_MULT=11.0
+BATT_AMP_PERVLT=66.7
 
 Pads for a second analog battery monitor are provided (Voltage only). To use:
 
-- :ref:`BATT2_MONITOR<BATT2_MONITOR>` = 4
-- :ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN__AP_BattMonitor_Analog>` = 18 (ADC1 pin, PA4)
-- :ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT__AP_BattMonitor_Analog>` = 21.0
+BATT2_MONITOR=4
+BATT2_VOLT_PIN=18
+BATT2_VOLT_MULT=21.0
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7_WING_AIO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7_WING_AIO/README.md
@@ -90,19 +90,19 @@ LiPo batteries.
 
 The correct battery setting parameters are:
 
-- :ref:`BATT_MONITOR<BATT_MONITOR>` 4
-- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 10
-- :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 11
-- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11.0
-- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 40.0
+BATT_MONITOR=4
+BATT_VOLT_PIN=10
+BATT_CURR_PIN=11
+BATT_VOLT_MULT=11.0
+BATT_AMP_PERVLT=40.0
 
 Pads for a second analog battery monitor are provided. To use:
 
-- :ref:`BATT2_MONITOR<BATT2_MONITOR>` 4
-- :ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN__AP_BattMonitor_Analog>` 18
-- :ref:`BATT2_CURR_PIN<BATT2_CURR_PIN__AP_BattMonitor_Analog>` 7
-- :ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT__AP_BattMonitor_Analog>` 11.0
-- :ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT__AP_BattMonitor_Analog>` as required
+BATT2_MONITOR=4
+BATT2_VOLT_PIN=18
+BATT2_CURR_PIN=7
+BATT2_VOLT_MULT=11.0
+BATT2_AMP_PERVLT=as required
 
 ## Analog RSSI and AIRSPEED inputs
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/YARIV6X/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/YARIV6X/README.md
@@ -106,11 +106,11 @@ Any UART can be used for RC system connections in ArduPilot also, and is compati
 
 The default battery parameters for use with a digital power module (with INA2xx) connected to Power1 port:
 
-- :ref:`BATT_I2C_BUS<BATT_I2C_BUS>` = 1
-- :ref:`BATT_I2C_ADDR<BATT_I2C_ADDR>` = 0
-- :ref:`BATT_MONITOR<BATT_MONITOR>` = 21
+BATT_I2C_BUS=1
+BATT_I2C_ADDR=0
+BATT_MONITOR=21
 
-For use with Power2 port update :ref:`BATT_I2C_BUS<BATT_I2C_BUS>` = 2
+For use with Power2 port update BATT_I2C_BUS = 2
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ZeroOneX6_Air/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ZeroOneX6_Air/README.md
@@ -139,11 +139,11 @@ All PWM outputs can be used as GPIOs (relays, camera, RPM etc). To use them you 
 The X6_Air flight controller has one six-pin power connectors, supporting CAN interface power supply.
 The autopilot defaults are setup for CAN Power Module use (normally supplied with autopilot):
 
-- :ref:`BATT_MONITOR<BATT_MONITOR>` = 8
-- :ref:`CAN_P1_DRIVER<CAN_P1_DRIVER>` = 1
-- :ref:`CAN_P2_DRIVER<CAN_P2_DRIVER>` = 1
-- :ref:`CAN_D1_PROTOCOL<CAN_D1_PROTOCOL>` = 1
-- :ref:`CAN_D2_PROTOCOL<CAN_D2_PROTOCOL>` = 1
+BATT_MONITOR=8
+CAN_P1_DRIVER=1
+CAN_P2_DRIVER=1
+CAN_D1_PROTOCOL=1
+CAN_D2_PROTOCOL=1
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/speedybeef4v5/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/speedybeef4v5/README.md
@@ -76,11 +76,11 @@ LiPo batteries.
 
 The default battery parameters are:
 
-- :ref:`BATT_MONITOR<BATT_MONITOR>` = 4
-- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 11
-- :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 15 (CURR pin)
-- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 11.2
-- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 1 (will need to be adjusted for whichever current sensor is attached)
+BATT_MONITOR=4
+BATT_VOLT_PIN=11
+BATT_CURR_PIN=15
+BATT_VOLT_MULT=11.2
+BATT_AMP_PERVLT=1
 
 ## RSSI
 


### PR DESCRIPTION
## Summary

Removes rst-style / Sphinx references from markdown

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

these were being added to link to the relevant pages, but should be independent in the markdown

I've spot-checked some files:

<img width="2208" height="1046" alt="image" src="https://github.com/user-attachments/assets/66a29ab2-3021-4c7c-912a-28b61365c79a" />
