### PR TITLE
hwdef: remove Sphinx paragraph-anchor artifacts from markdown

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/BrahmaF4/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BrahmaF4/README.md
@@ -86,10 +86,9 @@ The default battery configuration is:
 
  The autopilot does not have a built-in compass, however you can attach an external compass using I2C on the SDA and SCL pads.
 
-## Firmware¶
+## Loading Firmware
 
-Firmware for this board can be found `here <https://firmware.ardupilot.org`__  in sub-folders labeled “BrahmaF4”.
-Loading Firmware¶
+Firmware for this board can be found [here](https://firmware.ardupilot.org) in sub-folders labeled “BrahmaF4”.
 
 Initial firmware load can be done with DFU by plugging in USB with the bootloader button pressed. Then you should load the “with_bl.hex” firmware, using your favourite DFU loading tool.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SDMODELH7V1/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SDMODELH7V1/README.md
@@ -6,7 +6,7 @@
 
 above image and some content courtesy of SDMODEL
 
-## Specifications¶
+## Specifications
 
 - Processor
   - STM32H743 32-bit processor
@@ -91,7 +91,7 @@ DJI Connector JST-SH-6P-3
 | G | Ground |
 | R6 | UART6 RX |
 
-## UART Mapping¶
+## UART Mapping
 
 The UARTs are marked Rn and Tn in the above pinouts. The Rn pin is the receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
 
@@ -108,11 +108,11 @@ The SERIAL7 port (UART7) is normally for ESC telemetry, and has an R7 pin on bot
 
 Any UART may be re-tasked by changing its protocol parameter.
 
-## Copter Default Frame Type¶
+## Copter Default Frame Type
 
 For Copter firmware the FRAME_TYPE is already defaulted to type "12" (BetaFlight X) allowing existing BetaFlight configurations with ESCs attached to have the correct motor ordering without changes to the FRAME_TYPE and FRAME_CLASS parameters or ESC wiring.
 
-## RC Input¶
+## RC Input
 
 RC input is configured on the R6 (UART6_RX) pin. It supports all RC protocols except PPM. See Radio Control Systems for details for a specific RC system. SERIAL6_PROTOCOL is set to "23", by default, to enable this.
 
@@ -122,19 +122,19 @@ RC input is configured on the R6 (UART6_RX) pin. It supports all RC protocols ex
 - SRXL2 requires a connection to T6 and automatically provides telemetry. Set SERIAL6_OPTIONS to "4".
 
 Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM. See Radio Control Systems for details.
-FrSky Telemetry¶
+
+## FrSky Telemetry
 
 FrSky Telemetry is supported using the Tx pin of any UART. You need to set the following parameters to enable support for FrSky S.PORT (example shows SERIAL2).
 
 - SERIAL2_PROTOCOL 10
 - SERIAL2_OPTIONS 7
 
-## OSD Support¶
+## OSD Support
 
 The SDH7V1 supports OSD using OSD_TYPE 1 (MAX7456 driver). The defaults are also setup to allow DJI Goggle OSD support on UART1.
-PWM Output¶
 
-## PWM Outputs
+## PWM Output
 
 The SDH7V1 supports up to 8 PWM outputs. Outputs are available via two JST-SH connectors. All 8 outputs support DShot and bi-directional DShot, as well as all PWM types.
 
@@ -148,10 +148,11 @@ The PWM is in 3 groups:
 
 Channels within the same group need to use the same output rate, whether PWM or Dshot. If any channel in a group uses DShot then all channels in the group need to use DShot.
 
-## LED Output¶
+## LED Output
 
 The LED output is configured by default to support NeoPixel LED strings.
-Battery Monitoring¶
+
+## Battery Monitoring
 
 The board has a built-in voltage sensor via the B+ pin, but no internal current sensor. An external current sensor can be connected to the CUR pin.
 
@@ -163,12 +164,11 @@ The correct battery setting parameters are:
 - BATT_VOLT_MULT 10.1
 - BATT_AMP_PERVLT varies depending on external current sensor
 
-## Compass¶
+## Compass
 
 The SDMODEL SDH7V1 does not have a built-in compass, however you can attach an external compass using I2C on the SDA and SCL pads.
-Firmware¶
 
-## Loading Firmware¶
+## Loading Firmware
 
 Initial firmware load can be done with DFU by plugging in USB with the bootloader button pressed. Then you should load the "with_bl.hex" firmware, using your favourite DFU loading tool.
 


### PR DESCRIPTION
## Summary

Remove bad pilcrow characters, add some missing headings, make more like other hwdef files.

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

I've spot-checked some files to make sure they look fine.

## Description

Two README files had `¶` paragraph anchor characters left over from RST-to-Markdown conversion, some as part of H2 headings and some as orphaned plain-text pseudo-headings with no leading `##`.

BrahmaF4: consolidate duplicate Firmware/Loading Firmware section, fix RST hyperlink to standard Markdown syntax.

SDMODELH7V1: fix all affected headings (Specifications, UART Mapping, Copter Default Frame Type, RC Input, OSD Support, LED Output, Compass, Loading Firmware) and promote orphaned FrSky Telemetry, Battery Monitoring, and PWM Output lines to proper H2 headings.

