### PR TITLE
Tools: check_branch_conventions.py: sanity check author emails on commits

### DIFF
--- a/Tools/scripts/check_branch_conventions.py
+++ b/Tools/scripts/check_branch_conventions.py
@@ -118,6 +118,23 @@ class CheckBranchConventions(build_script_base.BuildScriptBase):
             print(f"{PASS} All commit subject lines within {MAX_SUBJECT_LEN} characters.")
         return ok
 
+    def check_author_emails(self) -> bool:
+        emails = self.run_git(
+            ["log", f"{self.base_branch}..HEAD", "--format=%ae"],
+            show_output=False,
+        ).strip()
+        bad = []
+        for email in emails.splitlines():
+            if "example.com" in email:
+                bad.append(email)
+        if bad:
+            print(f"{FAIL} Author email(s) with example.com are not allowed:")
+            for email in bad:
+                print(f"         {email}")
+            return False
+        print(f"{PASS} No unacceptable author emails.")
+        return True
+
     def check_markdown(self) -> bool:
         changed_md = self.run_git(
             ["diff", "--name-only", "--diff-filter=AM",
@@ -159,6 +176,7 @@ class CheckBranchConventions(build_script_base.BuildScriptBase):
             self.check_fixup_commits(commits),
             self.check_commit_messages(commits),
             self.check_commit_lengths(commits),
+            self.check_author_emails(),
             self.check_markdown(),
         ]
 


### PR DESCRIPTION
## Summary

Add a sanity check that looks at the email addresses for commits, make sure they seem acceptable.

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

Test PR showing failure: https://github.com/peterbarker/ardupilot/pull/33

## Description

Someone suggested we sanity-check author email addresses on commits, having seen one go into master.   Apologies to whoever that was, I've lost that information.

This is an example of a patch which made its way into master which we are trying to avoid:
```
commit 27cda320d03287e38405ec28251992ffe5694984
Author: Your Name <you@example.com>
Date:   Mon Jan 26 16:18:31 2026 +0800
```
