### PR TITLE
Make lat/lng bounds check part of extracting location from mavlink message

### DIFF
--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -462,11 +462,6 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_int_do_reposition(const mavlink_co
         return MAV_RESULT_DENIED;
     }
 
-    // sanity check location
-    if (!check_latlng(packet.x, packet.y)) {
-        return MAV_RESULT_DENIED;
-    }
-
     Location request_location;
     if (!location_from_command_t(packet, request_location)) {
         return MAV_RESULT_DENIED;

--- a/ArduPlane/GCS_MAVLink_Plane.cpp
+++ b/ArduPlane/GCS_MAVLink_Plane.cpp
@@ -580,11 +580,6 @@ bool Plane::set_home(const Location& loc, bool _lock)
 
 MAV_RESULT GCS_MAVLINK_Plane::handle_command_int_do_reposition(const mavlink_command_int_t &packet)
 {
-    // sanity check location
-    if (!check_latlng(packet.x, packet.y)) {
-        return MAV_RESULT_DENIED;
-    }
-
     Location requested_position;
     if (!location_from_command_t(packet, requested_position)) {
         return MAV_RESULT_DENIED;

--- a/ArduSub/GCS_MAVLink_Sub.cpp
+++ b/ArduSub/GCS_MAVLink_Sub.cpp
@@ -377,11 +377,6 @@ MAV_RESULT GCS_MAVLINK_Sub::handle_command_int_do_reposition(const mavlink_comma
         return MAV_RESULT_DENIED;
     }
 
-    // sanity check location
-    if (!check_latlng(packet.x, packet.y)) {
-        return MAV_RESULT_DENIED;
-    }
-
     Location request_location;
     if (!location_from_command_t(packet, request_location)) {
         return MAV_RESULT_DENIED;

--- a/Blimp/GCS_MAVLink_Blimp.cpp
+++ b/Blimp/GCS_MAVLink_Blimp.cpp
@@ -243,11 +243,6 @@ MAV_RESULT GCS_MAVLINK_Blimp::handle_command_int_do_reposition(const mavlink_com
         return MAV_RESULT_DENIED;
     }
 
-    // sanity check location
-    if (!check_latlng(packet.x, packet.y)) {
-        return MAV_RESULT_DENIED;
-    }
-
     Location request_location {};
     if (!location_from_command_t(packet, request_location)) {
         return MAV_RESULT_DENIED;

--- a/Rover/GCS_MAVLink_Rover.cpp
+++ b/Rover/GCS_MAVLink_Rover.cpp
@@ -573,10 +573,6 @@ MAV_RESULT GCS_MAVLINK_Rover::handle_command_int_do_reposition(const mavlink_com
         return MAV_RESULT_DENIED;
     }
 
-    // sanity check location
-    if (!check_latlng(packet.x, packet.y)) {
-        return MAV_RESULT_DENIED;
-    }
     if (packet.x == 0 && packet.y == 0) {
         return MAV_RESULT_DENIED;
     }

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -15385,6 +15385,17 @@ RTL_ALT_M 111
         self.change_mode('LAND')
         self.wait_disarmed()
 
+    def MAV_CMD_DO_SET_HOME_bad_location(self):
+        '''test setting of bad home location'''
+        self.wait_ready_to_arm()
+        self.run_cmd(
+            mavutil.mavlink.MAV_CMD_DO_SET_HOME,
+            p5=190,
+            p6=190,
+            p7=0,
+            want_result=mavutil.mavlink.MAV_RESULT_DENIED,
+        )
+
     def PeriphMultiUARTTunnel(self):
         '''test peripheral multi-uart tunneling'''
 
@@ -15838,6 +15849,7 @@ return update, 1000
             self.AP_Avoidance,
             self.RTL_ALT_FINAL_M,
             self.SMART_RTL,
+            self.MAV_CMD_DO_SET_HOME_bad_location,
             self.SMART_RTL_EnterLeave,
             self.SMART_RTL_Repeat,
             self.RTL_TO_RALLY,

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -5262,6 +5262,11 @@ MAV_RESULT GCS_MAVLINK::handle_command_component_arm_disarm(const mavlink_comman
 
 bool GCS_MAVLINK::location_from_command_t(const mavlink_command_int_t &in, Location &out)
 {
+    // sanity check location
+    if (!check_latlng(in.x, in.y)) {
+        return false;
+    }
+
     if (!command_long_stores_location((MAV_CMD)in.command)) {
         return false;
     }


### PR DESCRIPTION
## Summary

The additional check makes sure that the lat/lng have reasonable maximum ranges.

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [x] Autotest included

## Description

This will stop bad locations entering the vehicle.  The new tests previously died with a MAV_RESULT_FAILED as the AHRS library bounces the bad location, but we can return DENIED from the mavlink layer cheaply.
