### PR TITLE
AP_NavEKF3: delay external origin setting until filter is initialised

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -681,6 +681,13 @@ bool NavEKF3_core::assume_zero_sideslip(void) const
 // returns false if the origin is already set
 bool NavEKF3_core::setOriginLLH(const Location &loc)
 {
+    // reject external origin setting until the filter has finished
+    // bootstrap initialisation.  InitialiseVariables() resets
+    // validOrigin, so an origin set before that point is lost.
+    // Callers (e.g. AHRS use_recorded_origin_maybe) will retry.
+    if (!statesInitialised) {
+        return false;
+    }
     return setOrigin(loc);
 }
 


### PR DESCRIPTION
Fix a race condition where the recorded EKF origin is lost at startup, breaking position reporting and navigation.

### Problem

When using recorded origin (`AHRS_OPTIONS` bit 0), `use_recorded_origin_maybe()` sets the origin on EKF3 cores during the AHRS update loop. However, `InitialiseFilterBootstrap()` calls `InitialiseVariables()` ~1s after boot, which resets `validOrigin` on each core. Since `state.origin_ok` was already set true, the AHRS never re-applies the recorded origin.

**Impact:** `getLLH()` returns false for the rest of the session:
- `GLOBAL_POSITION_INT` lat/lng never updates — GCS shows stationary vehicle
- `have_position` is false — navigation modes (RTL, GUIDED, LOITER) cannot compute correct bearings or distances
- Vehicle drifts 1km+ instead of returning to launch on RTL

### Fix

Guard `NavEKF3_core::setOriginLLH()` to reject calls while `statesInitialised` is false. This prevents the origin from being set before `InitialiseVariables()` wipes it. AHRS's `use_recorded_origin_maybe()` naturally retries each cycle, so the origin is applied once the filter is ready.

This replaces the earlier AHRS-level workaround (detecting and re-applying the lost origin) with a fix at the source, per review feedback from @rmackay9.

## Testing

- [X] `AHRSOriginRecorded` autotest passes
- [X] Tested in SITL
- [ ] Tested on hardware