### PR TITLE
AP_AHRS: respect DISABLE_DCM_FALLBACK when EKF has attitude

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -2136,16 +2136,21 @@ AP_AHRS::EKFType AP_AHRS::_active_EKF_type(void) const
         // Handle fallback for the case where the DCM or EKF is unable to provide attitude or height data.
         const bool can_use_dcm = dcm.yaw_source_available() || fly_forward;
         const bool can_use_ekf = filt_state.flags.attitude && filt_state.flags.vert_vel && filt_state.flags.vert_pos;
+        const bool disable_dcm_fallback = fly_forward?
+            option_set(Options::DISABLE_DCM_FALLBACK_FW) : option_set(Options::DISABLE_DCM_FALLBACK_VTOL);
         if (!can_use_dcm && can_use_ekf) {
             // no choice - continue to use EKF
             return ret;
         } else if (!can_use_ekf) {
-            // No choice - we have to use DCM
+            // EKF lost attitude, vert_vel, or vert_pos. If user disabled
+            // DCM fallback and EKF still has attitude, keep EKF — only
+            // fall back to DCM for genuine attitude loss.
+            if (disable_dcm_fallback && filt_state.flags.attitude) {
+                return (ret != EKFType::DCM) ? ret : configured_ekf_type();
+            }
             return EKFType::DCM;
         }
 
-        const bool disable_dcm_fallback = fly_forward?
-            option_set(Options::DISABLE_DCM_FALLBACK_FW) : option_set(Options::DISABLE_DCM_FALLBACK_VTOL);
         if (disable_dcm_fallback) {
             // don't fallback
             return ret;


### PR DESCRIPTION
  Fix AHRS_OPTIONS DISABLE_DCM_FALLBACK bits (0+1) being bypassed when the EKF loses vert_vel or vert_pos but still has
  attitude.

  In _active_EKF_type(), the !can_use_ekf path unconditionally returned DCM, positioned before the DISABLE_DCM_FALLBACK
  check. When GPS spoofing corrupted the EKF state covariance, the EKF could lose vert_vel or vert_pos while still
  having a valid IMU-based attitude estimate. The code fell through to DCM despite the user explicitly disabling DCM
  fallback.

  This caused rapid DCM/EKF toggling (5+ times in 15 seconds) during GPS spoofing events. Each toggle produced an
  attitude discontinuity that compounded flight controller instability. This toggling can
  amplify the uncontrolled descent despite AHRS_OPTIONS bits 0+1 being set.

  Fix: Check DISABLE_DCM_FALLBACK in the !can_use_ekf path, gated on whether the EKF still has attitude. Only genuine
  attitude loss (IMU failure, complete filter divergence) triggers DCM fallback when the disable bits are set.

  Also handles a secondary issue: on Plane, always_use_EKF() returns true when DISABLE_DCM_FALLBACK is set, which uses
  getFilterFaults() (zero during GPS spoofing) instead of EKF3.healthy() (false during GPS spoofing) to decide ret. When
   ret was stuck as DCM from fallback_active_EKF_type(), filt_state was never queried from EKF3, guaranteeing
  can_use_ekf=false. The fix uses ekf_type() to return the user's configured EKF type when ret is DCM but the user
  disabled DCM fallback.

  Validated in RealFlight with simulated GPS spoofing (200 m/s velocity error, 500m altitude offset on GPS1 while GPS2
  stays clean with EK3_AFFINITY=1). No DCM fallback during spoofing.
