### PR TITLE
AP_NavEKF3: only reset height from ext nav when POSZ is ExternalNav

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -478,9 +478,11 @@ void NavEKF3_core::setAidingMode()
                     GCS_SEND_TEXT(MAV_SEVERITY_INFO, "EKF3 IMU%u initial vel NED = %3.1f,%3.1f,%3.1f (m/s)",(unsigned)imu_index,(double)extNavVelDelayed.vel.x,(double)extNavVelDelayed.vel.y,(double)extNavVelDelayed.vel.z);
                 }
                 // handle height reset as special case
-                hgtMea = -extNavDataDelayed.pos.z;
-                posDownObsNoise = sq(constrain_ftype(extNavDataDelayed.posErr, 0.1f, 10.0f));
-                ResetHeight();
+                if (frontend->sources.getPosZSource(core_index) == AP_NavEKF_Source::SourceZ::EXTNAV) {
+                    hgtMea = -extNavDataDelayed.pos.z;
+                    posDownObsNoise = sq(constrain_ftype(extNavDataDelayed.posErr, 0.1f, 10.0f));
+                    ResetHeight();
+                }
 #endif // EK3_FEATURE_EXTERNAL_NAV
             }
 


### PR DESCRIPTION
## Summary

Closes https://github.com/ArduPilot/ardupilot/issues/32506 . Fixes a bug where using external nav, also resets Z when first entering absolute aiding, even though it's configured to some other source. 

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [x] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

Previously, EKF3 incorrectly reset vertical position from external navigation Z when starting horizontal aiding, ignoring EK3_SRCx_POSZ and causing sudden jumps. Now it reset height based on configured source set.

To reproduce:
1. Set SITL peripheral for vicon and rangefinder
2. Set:
EK3_SRC1_POSXY   6           # ExternalNav
EK3_SRC1_POSZ    2           # RangeFinder
EK3_SRC1_VELXY   5           # OpticalFlow
EK3_SRC1_VELZ    0           # None
EK3_SRC1_YAW     1           # Compass
SIM_VICON_FAIL  1 
SIM_VICON_GLIT_Z  5

Takeoff with optical flow and after a stable altitude, set SIM_VICON_FAIL 0 to start getting vicon pos.

Before:
<img width="1200" height="563" alt="graph1" src="https://github.com/user-attachments/assets/4982d8a9-fb8f-4de5-beda-d2299e991437" />

After:
<img width="1200" height="563" alt="graph" src="https://github.com/user-attachments/assets/20bdbd80-603c-434d-bc13-deb5ef1bc8b7" />

Replay test passes and it doesn't appear to cause changes in existing tests.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
