### PR TITLE
hwdef: MPU6000 version of TBS_LUCID_H7

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7/README.md
@@ -5,7 +5,7 @@ The TBS LUCID H7 is a flight controller produced by [TBS](https://www.team-black
 ## Features
 
 - MCU - STM32H743 32-bit processor running at 480 MHz
-- IMU - Dual ICM42688
+- IMU - Dual ICM42688 (Dual MPU6000 on some v2 boards)
 - Barometer - DPS310
 - OSD - AT7456E
 - microSD card slot

--- a/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7/hwdef.dat
@@ -193,6 +193,8 @@ STORAGE_FLASH_PAGE 14
 # spi devices
 SPIDEV imu1  SPI1 DEVID1 IMU1_CS      MODE3  2*MHZ 16*MHZ   # Clock is 100Mhz so highest clock <= 24Mhz is 100Mhz/8
 SPIDEV imu2  SPI4 DEVID1 IMU2_CS      MODE3  2*MHZ 16*MHZ   # Clock is 100Mhz so highest clock <= 24Mhz is 100Mhz/8
+SPIDEV mpu6000_1  SPI1 DEVID1 IMU1_CS  MODE3  1*MHZ 4*MHZ
+SPIDEV mpu6000_2  SPI4 DEVID1 IMU2_CS  MODE3  1*MHZ 4*MHZ
 SPIDEV osd   SPI2 DEVID4 MAX7456_CS   MODE0 10*MHZ 10*MHZ
 
 # no built-in compass, but probe the i2c bus for all possible
@@ -204,6 +206,8 @@ define HAL_COMPASS_AUTO_ROT_DEFAULT 2
 
 IMU Invensensev3 SPI:imu1 ROTATION_YAW_270
 IMU Invensensev3 SPI:imu2 ROTATION_YAW_180
+IMU Invensense SPI:mpu6000_1 ROTATION_ROLL_180
+IMU Invensense SPI:mpu6000_2 ROTATION_ROLL_180_YAW_270
 define HAL_DEFAULT_INS_FAST_SAMPLE 3
 
 # DPS310 integrated on I2C2 bus


### PR DESCRIPTION
Worldwide shortage of ICM42688 so TBS are putting MPU6000 on their TBS_LUCID_H7.

This PR adds optional support for MPU6000 on v2 boards

Tested by vendor.
