### PR TITLE
Copter: reset EKF failsafe gate on source set change

### DIFF
--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -24,6 +24,7 @@ static struct {
     bool has_ever_passed;       // true if the ekf checks have ever passed
     uint32_t last_warn_time;    // system time of last warning in milliseconds.  Used to throttle text warnings sent to GCS
     uint8_t last_source_set;    // last known EKF source set, used to detect intentional switches
+    uint32_t source_switch_ms;  // time of last source set change, used for holdoff
 } ekf_check_state;
 
 // ekf_check - detects if ekf variance are out of tolerance and triggers failsafe
@@ -54,11 +55,26 @@ void Copter::ekf_check()
     // triggers on the position loss even though the new configuration
     // may not need position.  Resetting has_ever_passed lets the new
     // source set establish itself before the failsafe can fire.
+    //
+    // A holdoff period is needed because the EKF takes up to 10 seconds
+    // (posRetryTimeUseVel_ms) to update its aiding mode after a source
+    // change.  During that window the EKF still reports position from
+    // the old source, which would immediately re-latch has_ever_passed
+    // and defeat the reset.  The holdoff suppresses the check entirely
+    // until the EKF has reached steady state under the new source set.
     const uint8_t current_source_set = ahrs.get_posvelyaw_source_set();
     if (current_source_set != ekf_check_state.last_source_set) {
         ekf_check_state.last_source_set = current_source_set;
         ekf_check_state.has_ever_passed = false;
         ekf_check_state.fail_count = 0;
+        ekf_check_state.source_switch_ms = AP_HAL::millis();
+    }
+
+    // suppress check during source transition holdoff
+    const uint16_t SOURCE_SWITCH_HOLDOFF_MS = 12000;
+    if (ekf_check_state.source_switch_ms > 0 &&
+        (AP_HAL::millis() - ekf_check_state.source_switch_ms) < SOURCE_SWITCH_HOLDOFF_MS) {
+        return;
     }
 
     // compare compass and velocity variance vs threshold and also check

--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -23,6 +23,7 @@ static struct {
     bool bad_variance;          // true if ekf should be considered untrusted (fail_count has exceeded EKF_CHECK_ITERATIONS_MAX)
     bool has_ever_passed;       // true if the ekf checks have ever passed
     uint32_t last_warn_time;    // system time of last warning in milliseconds.  Used to throttle text warnings sent to GCS
+    uint8_t last_source_set;    // last known EKF source set, used to detect intentional switches
 } ekf_check_state;
 
 // ekf_check - detects if ekf variance are out of tolerance and triggers failsafe
@@ -45,6 +46,19 @@ void Copter::ekf_check()
         AP_Notify::flags.ekf_bad = ekf_check_state.bad_variance;
         failsafe_ekf_off_event();   // clear failsafe
         return;
+    }
+
+    // Reset failsafe gate on EKF source set change.  An intentional
+    // source switch (e.g. via RC channel, Lua or MAVLink) may
+    // legitimately lose position.  Without this reset, the failsafe
+    // triggers on the position loss even though the new configuration
+    // may not need position.  Resetting has_ever_passed lets the new
+    // source set establish itself before the failsafe can fire.
+    const uint8_t current_source_set = ahrs.get_posvelyaw_source_set();
+    if (current_source_set != ekf_check_state.last_source_set) {
+        ekf_check_state.last_source_set = current_source_set;
+        ekf_check_state.has_ever_passed = false;
+        ekf_check_state.fail_count = 0;
     }
 
     // compare compass and velocity variance vs threshold and also check

--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -68,6 +68,16 @@ void Copter::ekf_check()
         ekf_check_state.has_ever_passed = false;
         ekf_check_state.fail_count = 0;
         ekf_check_state.source_switch_ms = AP_HAL::millis();
+        // Clear a latched failsafe too. fail_count is zeroed above, but the
+        // recovery path below only clears bad_variance while decrementing a
+        // positive fail_count, so a failsafe latched under the old source set
+        // would otherwise never clear and position_ok() would keep rejecting
+        // mode changes that require position.
+        if (ekf_check_state.bad_variance) {
+            ekf_check_state.bad_variance = false;
+            LOGGER_WRITE_ERROR(LogErrorSubsystem::EKFCHECK, LogErrorCode::EKFCHECK_VARIANCE_CLEARED);
+            failsafe_ekf_off_event();
+        }
     }
 
     // suppress check during source transition holdoff

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -11103,6 +11103,58 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.assert_prearm_failure("EK3 sources require Compass")
         self.context_pop()
 
+    def EKFSourceSetFailsafe(self):
+        '''Test EKF failsafe gate resets on source set switch'''
+        # Configure source set 2 with no position/velocity aiding.
+        # When the vehicle switches from GPS (set 1) to no-aiding (set 2),
+        # has_position drops to false.  Without the ekf_check source-reset
+        # fix, the failsafe fires within 1 second because has_ever_passed
+        # is still true from the GPS fix.
+        self.set_parameters({
+            "EK3_SRC2_POSXY": 0,  # none
+            "EK3_SRC2_VELXY": 0,  # none
+            "EK3_SRC2_POSZ": 1,   # baro
+            "EK3_SRC2_VELZ": 0,   # none
+            "EK3_SRC2_YAW": 1,    # compass
+            "RC8_OPTION": 90,      # EKF source selector
+        })
+        self.set_rc(8, 1000)  # ensure source set 1 (GPS)
+        self.reboot_sitl()
+
+        # take off with GPS — EKF establishes position, has_ever_passed latches true
+        self.takeoff(10, mode="LOITER")
+        self.delay_sim_time(5)
+
+        # switch to ALT_HOLD which does not require position
+        self.change_mode('ALT_HOLD')
+
+        self.context_collect('STATUSTEXT')
+
+        # switch to source set 2 (no position aiding)
+        self.progress("Switching to no-aiding source set")
+        self.set_rc(8, 1500)
+
+        # wait for EKF to lose position.  The EKF stays in AID_ABSOLUTE
+        # for posRetryTimeNoVel_ms (7s) after the last GPS fusion, then
+        # posTimeout fires and horiz_pos_abs goes false.  Once
+        # has_position is false and has_ever_passed is true, ekf_check
+        # increments fail_count at 10Hz — failsafe fires after 1s.
+        # Total: ~8s without the fix.  Wait 10s to be safe.
+        self.delay_sim_time(10)
+
+        # verify no EKF failsafe fired
+        if self.statustext_in_collections("EKF variance"):
+            raise NotAchievedException(
+                "EKF failsafe triggered on intentional source set switch")
+
+        # switch back to GPS source set
+        self.progress("Switching back to GPS source set")
+        self.set_rc(8, 1000)
+        self.delay_sim_time(2)
+
+        # return and land
+        self.do_RTL()
+
     def EK3_EXT_NAV_vel_without_vert(self):
         '''Test that EK3 External Navigation velocity works without vertical velocity.'''
 
@@ -15833,6 +15885,7 @@ return update, 1000
             self.MotorTest,
             self.AltEstimation,
             self.EKFSource,
+            self.EKFSourceSetFailsafe,
             self.GSF,
             self.GSF_reset,
             self.AP_Avoidance,


### PR DESCRIPTION
## Summary

Reset the EKF failsafe `has_ever_passed` gate and fail counter when the active EKF source set changes.

The EKF failsafe check (`ekf_check`) requires position to pass. When a source set that provides position (e.g. GPS) is active, `has_ever_passed` latches true. If the operator then switches to a source set without position (e.g. for optical-flow-only or compass-free operation via RC channel, Lua, or MAVLink), the failsafe triggers within 1 second because it treats the intentional position loss as a failure.

This does not affect vehicles that boot without position — the `has_ever_passed` gate correctly prevents the failsafe from firing when position was never available. The issue only occurs when switching **from** a position source set **to** a non-position source set.

## Fix

On each `ekf_check()` call, compare the current source set index against the previously seen value. On change, reset `has_ever_passed` and `fail_count` so the new source set starts with a clean slate. If the new set provides position, the gate re-latches and normal failsafe protection resumes. If it does not, the failsafe stays dormant.

## Test plan

- [x] Build (SITL)
- [x] `test.Copter.EKFSource` passes
- [x] `test.Copter.ThrowMode` passes
- [ ] Test source set switch via RC channel from GPS to non-GPS source set — verify no EKF failsafe
- [ ] Test source set switch back to GPS — verify failsafe protection resumes