### PR TITLE
Refactor sending of camera_description message up into AP_Camera_backend

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -373,6 +373,39 @@ void AP_Mount_Backend::set_target_sysid(uint8_t sysid)
 }
 
 #if HAL_GCS_ENABLED
+// send a CAMERA_INFORMATION message to GCS
+void AP_Mount_Backend::send_camera_information(mavlink_channel_t chan) const
+{
+    if (!has_camera_information()) {
+        return;
+    }
+
+    uint8_t vendor_name[MAVLINK_MSG_CAMERA_INFORMATION_FIELD_VENDOR_NAME_LEN+1] {};
+    get_camera_vendor_name((char*)vendor_name, ARRAY_SIZE(vendor_name)-1);
+
+    uint8_t model_name[MAVLINK_MSG_CAMERA_INFORMATION_FIELD_MODEL_NAME_LEN+1] {};
+    get_camera_model_name((char*)model_name, ARRAY_SIZE(model_name)-1);
+
+    const char cam_definition_uri[MAVLINK_MSG_CAMERA_INFORMATION_FIELD_CAM_DEFINITION_URI_LEN] {};
+
+    mavlink_msg_camera_information_send(
+        chan,
+        AP_HAL::millis(),              // time_boot_ms
+        vendor_name,                   // vendor_name uint8_t[32]
+        model_name,                    // model_name uint8_t[32]
+        get_camera_firmware_version(), // firmware_version uint32_t
+        get_camera_focal_length_mm(),  // focal_length float (mm)
+        NaNf,                          // sensor_size_h float (mm)
+        NaNf,                          // sensor_size_v float (mm)
+        0,                             // resolution_h uint16_t (pix)
+        0,                             // resolution_v uint16_t (pix)
+        get_camera_lens_id(),          // lens_id uint8_t
+        get_camera_cap_flags(),        // flags uint32_t (CAMERA_CAP_FLAGS)
+        0,                             // cam_definition_version uint16_t
+        cam_definition_uri,            // cam_definition_uri char[140]
+        _instance + 1);                // gimbal_device_id uint8_t
+}
+
 // send a GIMBAL_DEVICE_ATTITUDE_STATUS message to GCS
 void AP_Mount_Backend::send_gimbal_device_attitude_status(mavlink_channel_t chan)
 {

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -212,7 +212,18 @@ public:
 #endif
 
     // send camera information message to GCS
-    virtual void send_camera_information(mavlink_channel_t chan) const {}
+    void send_camera_information(mavlink_channel_t chan) const;
+
+    // virtual methods supplying data for send_camera_information
+    // backends that have no associated camera (e.g. pass-through gimbals like STorM32)
+    // should leave has_camera_information() returning false to suppress sending
+    virtual bool has_camera_information() const { return false; }
+    virtual void get_camera_vendor_name(char *buf, uint8_t buflen) const { }
+    virtual void get_camera_model_name(char *buf, uint8_t buflen) const { }
+    virtual uint32_t get_camera_firmware_version() const { return 0; }
+    virtual float get_camera_focal_length_mm() const { return NaNf; }
+    virtual uint8_t get_camera_lens_id() const { return 0; }
+    virtual uint32_t get_camera_cap_flags() const { return 0; }
 
     // send camera settings message to GCS
     virtual void send_camera_settings(mavlink_channel_t chan) const {}

--- a/libraries/AP_Mount/AP_Mount_Siyi.cpp
+++ b/libraries/AP_Mount/AP_Mount_Siyi.cpp
@@ -985,63 +985,23 @@ bool AP_Mount_Siyi::set_camera_source(uint8_t primary_source, uint8_t secondary_
     return send_1byte_packet(SiyiCommandId::SET_CAMERA_IMAGE_TYPE, (uint8_t)cam_image_type);
 }
 
-// send camera information message to GCS
-void AP_Mount_Siyi::send_camera_information(mavlink_channel_t chan) const
+// return focal length in mm for the current hardware model
+float AP_Mount_Siyi::get_camera_focal_length_mm() const
 {
-    // exit immediately if not initialised
-    if (!_initialised || !_fw_version.received) {
-        return;
-    }
-
-    static const uint8_t vendor_name[MAVLINK_MSG_CAMERA_INFORMATION_FIELD_VENDOR_NAME_LEN] { "Siyi" };
-    uint8_t model_name[MAVLINK_MSG_CAMERA_INFORMATION_FIELD_MODEL_NAME_LEN] {};
-    const uint32_t fw_version = _fw_version.camera.major | (_fw_version.camera.minor << 8) | (_fw_version.camera.patch << 16);
-    const char cam_definition_uri[MAVLINK_MSG_CAMERA_INFORMATION_FIELD_CAM_DEFINITION_URI_LEN] {};
-
-    // copy model name
-    strncpy_noterm((char *)model_name, get_model_name(), sizeof(model_name));
-
-    // focal length
     // To-Do: check these values are correct for A2, ZR30, ZT30
-    float focal_length_mm = 0;
     switch (_hardware_model) {
     case HardwareModel::UNKNOWN:
     case HardwareModel::A2:
     case HardwareModel::A8:
     case HardwareModel::ZT6:
-        focal_length_mm = 21;
-        break;
+        return 21;
     case HardwareModel::ZR10:
     case HardwareModel::ZR30:
     case HardwareModel::ZT30:
         // focal length range from 5.15 ~ 47.38
-        focal_length_mm = 5.15;
-        break;
+        return 5.15;
     }
-
-    // capability flags
-    const uint32_t flags = CAMERA_CAP_FLAGS_CAPTURE_VIDEO |
-                           CAMERA_CAP_FLAGS_CAPTURE_IMAGE |
-                           CAMERA_CAP_FLAGS_HAS_BASIC_ZOOM |
-                           CAMERA_CAP_FLAGS_HAS_BASIC_FOCUS;
-
-    // send CAMERA_INFORMATION message
-    mavlink_msg_camera_information_send(
-        chan,
-        AP_HAL::millis(),       // time_boot_ms
-        vendor_name,            // vendor_name uint8_t[32]
-        model_name,             // model_name uint8_t[32]
-        fw_version,             // firmware version uint32_t
-        focal_length_mm,        // focal_length float (mm)
-        NaNf,                   // sensor_size_h float (mm)
-        NaNf,                   // sensor_size_v float (mm)
-        0,                      // resolution_h uint16_t (pix)
-        0,                      // resolution_v uint16_t (pix)
-        0,                      // lens_id uint8_t
-        flags,                  // flags uint32_t (CAMERA_CAP_FLAGS)
-        0,                      // cam_definition_version uint16_t
-        cam_definition_uri,     // cam_definition_uri char[140]
-        _instance + 1);         // gimbal_device_id uint8_t
+    return 0;
 }
 
 // send camera settings message to GCS

--- a/libraries/AP_Mount/AP_Mount_Siyi.h
+++ b/libraries/AP_Mount/AP_Mount_Siyi.h
@@ -78,8 +78,24 @@ public:
     // primary and secondary sources use the AP_Camera::CameraSource enum cast to uint8_t
     bool set_camera_source(uint8_t primary_source, uint8_t secondary_source) override;
 
-    // send camera information message to GCS
-    void send_camera_information(mavlink_channel_t chan) const override;
+    bool has_camera_information() const override { return true; }
+    // return camera vendor name
+    void get_camera_vendor_name(char *buf, uint8_t buflen) const override { strncpy(buf, "Siyi", buflen); }
+    // return camera model name
+    void get_camera_model_name(char *buf, uint8_t buflen) const override { strncpy(buf, get_model_name(), buflen); }
+    // return camera firmware version
+    uint32_t get_camera_firmware_version() const override {
+        return _fw_version.camera.major | (_fw_version.camera.minor << 8) | (_fw_version.camera.patch << 16);
+    }
+    // return focal length in mm for the current hardware model
+    float get_camera_focal_length_mm() const override;
+    // return camera capability flags
+    uint32_t get_camera_cap_flags() const override {
+        return (CAMERA_CAP_FLAGS_CAPTURE_VIDEO |
+                CAMERA_CAP_FLAGS_CAPTURE_IMAGE |
+                CAMERA_CAP_FLAGS_HAS_BASIC_ZOOM |
+                CAMERA_CAP_FLAGS_HAS_BASIC_FOCUS);
+    }
 
     // send camera settings message to GCS
     void send_camera_settings(mavlink_channel_t chan) const override;

--- a/libraries/AP_Mount/AP_Mount_Topotek.cpp
+++ b/libraries/AP_Mount/AP_Mount_Topotek.cpp
@@ -445,50 +445,6 @@ bool AP_Mount_Topotek::set_camera_source(uint8_t primary_source, uint8_t seconda
 }
 #endif  // HAL_MOUNT_SET_CAMERA_SOURCE_ENABLED
 
-// send camera information message to GCS
-void AP_Mount_Topotek::send_camera_information(mavlink_channel_t chan) const
-{
-    // exit immediately if not initialised
-    if (!_initialised) {
-        return;
-    }
-
-    static const uint8_t vendor_name[MAVLINK_MSG_CAMERA_INFORMATION_FIELD_VENDOR_NAME_LEN] { "Topotek" };
-    uint8_t model_name[MAVLINK_MSG_CAMERA_INFORMATION_FIELD_MODEL_NAME_LEN] {};
-    const char cam_definition_uri[MAVLINK_MSG_CAMERA_INFORMATION_FIELD_CAM_DEFINITION_URI_LEN] {};
-
-    // copy model name if available
-    if (_got_gimbal_model_name) {
-        strncpy_noterm((char*)model_name, _model_name, ARRAY_SIZE(model_name));
-    }
-
-    // capability flags
-    const uint32_t flags = CAMERA_CAP_FLAGS_CAPTURE_VIDEO |
-                           CAMERA_CAP_FLAGS_CAPTURE_IMAGE |
-                           CAMERA_CAP_FLAGS_HAS_BASIC_ZOOM |
-                           CAMERA_CAP_FLAGS_HAS_BASIC_FOCUS |
-                           CAMERA_CAP_FLAGS_HAS_TRACKING_POINT |
-                           CAMERA_CAP_FLAGS_HAS_TRACKING_RECTANGLE;
-
-    // send CAMERA_INFORMATION message
-    mavlink_msg_camera_information_send(
-        chan,
-        AP_HAL::millis(),       // time_boot_ms
-        vendor_name,            // vendor_name uint8_t[32]
-        model_name,             // model_name uint8_t[32]
-        _firmware_ver,          // firmware version uint32_t
-        0,                      // focal_length float (mm)
-        NaNf,                   // sensor_size_h float (mm)
-        NaNf,                   // sensor_size_v float (mm)
-        0,                      // resolution_h uint16_t (pix)
-        0,                      // resolution_v uint16_t (pix)
-        0,                      // lens_id uint8_t
-        flags,                  // flags uint32_t (CAMERA_CAP_FLAGS)
-        0,                      // cam_definition_version uint16_t
-        cam_definition_uri,     // cam_definition_uri char[140]
-        _instance + 1);         // gimbal_device_id uint8_t
-}
-
 // send camera settings message to GCS
 void AP_Mount_Topotek::send_camera_settings(mavlink_channel_t chan) const
 {

--- a/libraries/AP_Mount/AP_Mount_Topotek.h
+++ b/libraries/AP_Mount/AP_Mount_Topotek.h
@@ -85,8 +85,27 @@ public:
     bool set_camera_source(uint8_t primary_source, uint8_t secondary_source) override;
 #endif
 
-    // send camera information message to GCS
-    void send_camera_information(mavlink_channel_t chan) const override;
+    bool has_camera_information() const override { return true; }
+    // return camera vendor name
+    void get_camera_vendor_name(char *buf, uint8_t buflen) const override { strncpy(buf, "Topotek", buflen); }
+    // return camera model name
+    void get_camera_model_name(char *buf, uint8_t buflen) const override {
+        if (!_got_gimbal_model_name) {
+            return;
+        }
+        strncpy(buf, _model_name, buflen);
+    }
+    // return camera firmware version
+    uint32_t get_camera_firmware_version() const override { return _firmware_ver; }
+    // return camera capability flags
+    uint32_t get_camera_cap_flags() const override {
+        return (CAMERA_CAP_FLAGS_CAPTURE_VIDEO |
+                CAMERA_CAP_FLAGS_CAPTURE_IMAGE |
+                CAMERA_CAP_FLAGS_HAS_BASIC_ZOOM |
+                CAMERA_CAP_FLAGS_HAS_BASIC_FOCUS |
+                CAMERA_CAP_FLAGS_HAS_TRACKING_POINT |
+                CAMERA_CAP_FLAGS_HAS_TRACKING_RECTANGLE);
+    }
 
     // send camera settings message to GCS
     void send_camera_settings(mavlink_channel_t chan) const override;

--- a/libraries/AP_Mount/AP_Mount_Viewpro.cpp
+++ b/libraries/AP_Mount/AP_Mount_Viewpro.cpp
@@ -862,48 +862,6 @@ bool AP_Mount_Viewpro::set_camera_source(uint8_t primary_source, uint8_t seconda
     return send_camera_command(new_image_sensor, CameraCommand::NO_ACTION, 0);
 }
 
-// send camera information message to GCS
-void AP_Mount_Viewpro::send_camera_information(mavlink_channel_t chan) const
-{
-    // exit immediately if not initialised
-    if (!_initialised) {
-        return;
-    }
-
-    static const uint8_t vendor_name[MAVLINK_MSG_CAMERA_INFORMATION_FIELD_VENDOR_NAME_LEN] { "Viewpro" };
-    uint8_t model_name[MAVLINK_MSG_CAMERA_INFORMATION_FIELD_MODEL_NAME_LEN] {};
-    if (_got_model_name) {
-        strncpy_noterm((char *)model_name, _model_name, sizeof(model_name));
-    }
-    const char cam_definition_uri[MAVLINK_MSG_CAMERA_INFORMATION_FIELD_CAM_DEFINITION_URI_LEN] {};
-
-    // capability flags
-    const uint32_t flags = CAMERA_CAP_FLAGS_CAPTURE_VIDEO |
-                           CAMERA_CAP_FLAGS_CAPTURE_IMAGE |
-                           CAMERA_CAP_FLAGS_HAS_BASIC_ZOOM |
-                           CAMERA_CAP_FLAGS_HAS_BASIC_FOCUS |
-                           CAMERA_CAP_FLAGS_HAS_TRACKING_POINT |
-                           CAMERA_CAP_FLAGS_HAS_TRACKING_RECTANGLE;
-
-    // send CAMERA_INFORMATION message
-    mavlink_msg_camera_information_send(
-        chan,
-        AP_HAL::millis(),       // time_boot_ms
-        vendor_name,            // vendor_name uint8_t[32]
-        model_name,             // model_name uint8_t[32]
-        _firmware_version,      // firmware version uint32_t
-        NaNf,                   // sensor_size_h float (mm)
-        NaNf,                   // sensor_size_v float (mm)
-        0,                      // sensor_size_v float (mm)
-        0,                      // resolution_h uint16_t (pix)
-        0,                      // resolution_v uint16_t (pix)
-        (uint8_t)_image_sensor, // lens_id uint8_t
-        flags,                  // flags uint32_t (CAMERA_CAP_FLAGS)
-        0,                      // cam_definition_version uint16_t
-        cam_definition_uri,     // cam_definition_uri char[140]
-        _instance + 1);         // gimbal_device_id uint8_t
-}
-
 // send camera settings message to GCS
 void AP_Mount_Viewpro::send_camera_settings(mavlink_channel_t chan) const
 {

--- a/libraries/AP_Mount/AP_Mount_Viewpro.h
+++ b/libraries/AP_Mount/AP_Mount_Viewpro.h
@@ -81,8 +81,29 @@ public:
     // primary and secondary sources use the AP_Camera::CameraSource enum cast to uint8_t
     bool set_camera_source(uint8_t primary_source, uint8_t secondary_source) override;
 
-    // send camera information message to GCS
-    void send_camera_information(mavlink_channel_t chan) const override;
+    bool has_camera_information() const override { return true; }
+    // return camera vendor name
+    void get_camera_vendor_name(char *buf, uint8_t buflen) const override { strncpy(buf, "Viewpro", buflen); }
+    // return camera model name
+    void get_camera_model_name(char *buf, uint8_t buflen) const override {
+        if (!_got_model_name) {
+            return;
+        }
+        strncpy(buf, _model_name, buflen);
+    }
+    // return camera firmware version
+    uint32_t get_camera_firmware_version() const override { return _firmware_version; }
+    // return current camera lens ID
+    uint8_t get_camera_lens_id() const override { return (uint8_t)_image_sensor; }
+    // return camera capability flags
+    uint32_t get_camera_cap_flags() const override {
+        return (CAMERA_CAP_FLAGS_CAPTURE_VIDEO |
+                CAMERA_CAP_FLAGS_CAPTURE_IMAGE |
+                CAMERA_CAP_FLAGS_HAS_BASIC_ZOOM |
+                CAMERA_CAP_FLAGS_HAS_BASIC_FOCUS |
+                CAMERA_CAP_FLAGS_HAS_TRACKING_POINT |
+                CAMERA_CAP_FLAGS_HAS_TRACKING_RECTANGLE);
+    }
 
     // send camera settings message to GCS
     void send_camera_settings(mavlink_channel_t chan) const override;

--- a/libraries/AP_Mount/AP_Mount_Xacti.cpp
+++ b/libraries/AP_Mount/AP_Mount_Xacti.cpp
@@ -281,42 +281,6 @@ bool AP_Mount_Xacti::set_camera_source(uint8_t primary_source, uint8_t secondary
     return set_param_int32(Param::SensorMode, (uint8_t)new_sensor_mode);
 }
 
-// send camera information message to GCS
-void AP_Mount_Xacti::send_camera_information(mavlink_channel_t chan) const
-{
-    // exit immediately if not initialised
-    if (!_initialised) {
-        return;
-    }
-
-    static const uint8_t vendor_name[MAVLINK_MSG_CAMERA_INFORMATION_FIELD_VENDOR_NAME_LEN] { "Xacti" };
-    static uint8_t model_name[MAVLINK_MSG_CAMERA_INFORMATION_FIELD_MODEL_NAME_LEN] { "CX-GB100" };
-    const char cam_definition_uri[MAVLINK_MSG_CAMERA_INFORMATION_FIELD_CAM_DEFINITION_URI_LEN] {};
-
-    // capability flags
-    const uint32_t flags = CAMERA_CAP_FLAGS_CAPTURE_VIDEO |
-                           CAMERA_CAP_FLAGS_CAPTURE_IMAGE |
-                           CAMERA_CAP_FLAGS_HAS_BASIC_FOCUS;
-
-    // send CAMERA_INFORMATION message
-    mavlink_msg_camera_information_send(
-        chan,
-        AP_HAL::millis(),       // time_boot_ms
-        vendor_name,            // vendor_name uint8_t[32]
-        model_name,             // model_name uint8_t[32]
-        _firmware_version.received ? _firmware_version.mav_ver : 0, // firmware version uint32_t
-        NaNf,                   // focal_length float (mm)
-        NaNf,                   // sensor_size_h float (mm)
-        NaNf,                   // sensor_size_v float (mm)
-        0,                      // resolution_h uint16_t (pix)
-        0,                      // resolution_v uint16_t (pix)
-        0,                      // lens_id uint8_t
-        flags,                  // flags uint32_t (CAMERA_CAP_FLAGS)
-        0,                      // cam_definition_version uint16_t
-        cam_definition_uri,     // cam_definition_uri char[140]
-        _instance + 1);         // gimbal_device_id uint8_t
-}
-
 // send camera settings message to GCS
 void AP_Mount_Xacti::send_camera_settings(mavlink_channel_t chan) const
 {

--- a/libraries/AP_Mount/AP_Mount_Xacti.h
+++ b/libraries/AP_Mount/AP_Mount_Xacti.h
@@ -68,8 +68,19 @@ public:
     // primary and secondary sources use the AP_Camera::CameraSource enum cast to uint8_t
     bool set_camera_source(uint8_t primary_source, uint8_t secondary_source) override;
 
-    // send camera information message to GCS
-    void send_camera_information(mavlink_channel_t chan) const override;
+    bool has_camera_information() const override { return true; }
+    // return camera vendor name
+    void get_camera_vendor_name(char *buf, uint8_t buflen) const override { strncpy(buf, "Xacti", buflen); }
+    // return camera model name
+    void get_camera_model_name(char *buf, uint8_t buflen) const override { strncpy(buf, "CX-GB100", buflen); }
+    // return camera firmware version
+    uint32_t get_camera_firmware_version() const override { return _firmware_version.received ? _firmware_version.mav_ver : 0; }
+    // return camera capability flags
+    uint32_t get_camera_cap_flags() const override {
+        return (CAMERA_CAP_FLAGS_CAPTURE_VIDEO |
+                CAMERA_CAP_FLAGS_CAPTURE_IMAGE |
+                CAMERA_CAP_FLAGS_HAS_BASIC_FOCUS);
+    }
 
     // send camera settings message to GCS
     void send_camera_settings(mavlink_channel_t chan) const override;


### PR DESCRIPTION
## Summary

Moves the sending of CAMERA_INFORMATION up into the base class, with the subclasses providing data via callback.  this makes it look rather like the sending of the attitude message.

Fixes several buffer over-read and over-write bugs along the way.

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

  This PR refactors send_camera_information across the Siyi, Topotek, Viewpro
  and Xacti backends, moving the common mavlink_msg_camera_information_send call
   into AP_Mount_Backend, following the same pattern already used by
  send_gimbal_device_attitude_status. Backends provide their specific data via
  virtual getter overrides (get_camera_vendor_name, get_camera_model_name,
  get_camera_firmware_version, get_camera_focal_length_mm, get_camera_lens_id,
  get_camera_cap_flags). Returning nullptr from get_camera_vendor_name
  suppresses sending entirely.

  The process found the following bugs, which are fixed in this branch:

  - Buffer over-read (Viewpro): send_camera_information passed _model_name[11]
  directly as the model_name uint8_t[32] argument.
  mavlink_msg_camera_information_send unconditionally reads 32 bytes via memcpy,
   causing a 21-byte over-read into adjacent memory. The local 32-byte
  model_name buffer was prepared but never used.
  - Hardcoded MAVLink field sizes: All backends used literal 32 and 140 for the
  vendor name, model name and cam definition URI buffer sizes instead of
  MAVLINK_MSG_CAMERA_INFORMATION_FIELD_VENDOR_NAME_LEN / MODEL_NAME_LEN /
  CAM_DEFINITION_URI_LEN. A future spec change would silently mismatch.
  - strncpy instead of strncpy_noterm: MAVLink strings are optionally
  null-terminated; if a string exactly fills the field no null terminator is
  required. strncpy with n-1 unnecessarily wastes a byte and can still fail to
  null-terminate. strncpy_noterm is the correct function for this case.
  - static mutable buffer shared across instances: model_name in Siyi and
  Topotek's send_camera_information was declared static, meaning all instances
  of that backend class share the same buffer. Incorrect for configurations with
   multiple gimbals of the same type.
  - Misaligned parameter comments (Viewpro): The focal_length argument was
  labelled sensor_size_h, and subsequent comments were each shifted by one.
  Values were correct; comments were wrong. Now there is one canonical copy of
  these comments in the base class.
  - Buffer overwrite from untrusted packet data (Topotek): In
  gimbal_model_name_analyse, the number of bytes copied into _model_name[16] was
   taken directly from char_to_hex(_msg_buff[5]) — a length field in the
  received packet — with no upper bound. A gimbal (or attacker) sending a length
   field value greater than 15 would cause strncpy to write beyond the end of
  _model_name, corrupting adjacent member variables. Fixed by capping with
  MIN(char_to_hex(_msg_buff[5]), sizeof(_model_name)-1).
  - Topotek firmware version loop reads uncapped wire-data length:
  gimbal_version_analyse derives data_buf_len from char_to_hex(_msg_buff[5]),
  which returns 255 for an invalid (non-hex) length byte. This value was then
  used directly to bound two loops accessing _msg_buff[10 + i], potentially
  reading 265 bytes into a 36-byte buffer. Fixed by returning early on a 255
  result, treating it as a malformed packet.
  - Viewpro QUERY_MODEL copies without bounding to received length: The memcpy
  into _model_name used a fixed length of sizeof(_model_name)-1 with no check
  against the number of bytes actually received in the packet. A response
  shorter than the expected 10 bytes would cause stale data from a previous
  packet to be copied into the model name. Fixed using
  MIN(sizeof(_model_name)-1, data_bytes_received-1) to copy only what was
  actually received.
