### PR TITLE
Tradheli: rework of Rotor Speed Control library to improve code functionality and readability

### DIFF
--- a/ArduCopter/heli.cpp
+++ b/ArduCopter/heli.cpp
@@ -160,7 +160,7 @@ void Copter::heli_update_rotor_speed_targets()
     // get rotor control method
     uint8_t rsc_control_mode = motors->get_rsc_mode();
 
-    if (rsc_control_mode==ROTOR_CONTROL_MODE_PASSTHROUGH) {
+    if (rsc_control_mode == ROTOR_CONTROL_MODE_PASSTHROUGH) {
         // pass through pilot desired rotor speed from the RC
         if (get_pilot_desired_rotor_speed() > 0.01) {
             ap.motor_interlock_switch = true;

--- a/ArduCopter/heli.cpp
+++ b/ArduCopter/heli.cpp
@@ -160,8 +160,7 @@ void Copter::heli_update_rotor_speed_targets()
     // get rotor control method
     uint8_t rsc_control_mode = motors->get_rsc_mode();
 
-    switch (rsc_control_mode) {
-    case ROTOR_CONTROL_MODE_PASSTHROUGH:
+    if (rsc_control_mode==ROTOR_CONTROL_MODE_PASSTHROUGH) {
         // pass through pilot desired rotor speed from the RC
         if (get_pilot_desired_rotor_speed() > 0.01) {
             ap.motor_interlock_switch = true;
@@ -170,16 +169,6 @@ void Copter::heli_update_rotor_speed_targets()
             ap.motor_interlock_switch = false;
             motors->set_desired_rotor_speed(0.0f);
         }
-        break;
-    case ROTOR_CONTROL_MODE_SETPOINT:
-    case ROTOR_CONTROL_MODE_THROTTLECURVE:
-    case ROTOR_CONTROL_MODE_AUTOTHROTTLE:
-        if (motors->get_interlock()) {
-            motors->set_desired_rotor_speed(motors->get_rsc_setpoint());
-        } else {
-            motors->set_desired_rotor_speed(0.0f);
-        }
-        break;
     }
 
 }

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -361,7 +361,7 @@ bool Copter::set_mode(Mode::Number mode, ModeReason reason)
 #if FRAME_CONFIG == HELI_FRAME
     // do not allow helis to enter a non-manual throttle mode if the
     // rotor runup is not complete
-    if (!ignore_checks && !new_flightmode->has_manual_throttle() && !(motors->get_spool_state()==AP_MotorsHeli::SpoolState::THROTTLE_UNLIMITED)) {
+    if (!ignore_checks && !new_flightmode->has_manual_throttle() && motors->get_spool_state() != AP_Motors::SpoolState::THROTTLE_UNLIMITED) {
         mode_change_failed(new_flightmode, "runup not complete");
         return false;
     }

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -361,7 +361,7 @@ bool Copter::set_mode(Mode::Number mode, ModeReason reason)
 #if FRAME_CONFIG == HELI_FRAME
     // do not allow helis to enter a non-manual throttle mode if the
     // rotor runup is not complete
-    if (!ignore_checks && !new_flightmode->has_manual_throttle() && !motors->rotor_runup_complete()) {
+    if (!ignore_checks && !new_flightmode->has_manual_throttle() && !(motors->get_spool_state()==AP_MotorsHeli::SpoolState::THROTTLE_UNLIMITED)) {
         mode_change_failed(new_flightmode, "runup not complete");
         return false;
     }

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
@@ -424,7 +424,7 @@ void AC_AttitudeControl_Heli::rate_bf_to_motor_roll_pitch(const Vector3f &rate_r
 // rate_bf_to_motor_yaw - ask the rate controller to calculate the motor outputs to achieve the target rate in radians/second
 float AC_AttitudeControl_Heli::rate_target_to_motor_yaw(float rate_yaw_actual_rads, float rate_target_rads)
 {
-    if (!(_motors.get_spool_state()==AP_MotorsHeli::SpoolState::THROTTLE_UNLIMITED)) {
+    if (_motors.get_spool_state() != AP_Motors::SpoolState::THROTTLE_UNLIMITED) {
         _pid_rate_yaw.update_leaky_i(AC_ATTITUDE_HELI_RATE_INTEGRATOR_LEAK_RATE);
     }
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
@@ -424,7 +424,7 @@ void AC_AttitudeControl_Heli::rate_bf_to_motor_roll_pitch(const Vector3f &rate_r
 // rate_bf_to_motor_yaw - ask the rate controller to calculate the motor outputs to achieve the target rate in radians/second
 float AC_AttitudeControl_Heli::rate_target_to_motor_yaw(float rate_yaw_actual_rads, float rate_target_rads)
 {
-    if (!((AP_MotorsHeli&)_motors).rotor_runup_complete()) {
+    if (!(_motors.get_spool_state()==AP_MotorsHeli::SpoolState::THROTTLE_UNLIMITED)) {
         _pid_rate_yaw.update_leaky_i(AC_ATTITUDE_HELI_RATE_INTEGRATOR_LEAK_RATE);
     }
 

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -196,9 +196,9 @@ void AP_MotorsHeli::output_min()
     // move swash to mid
     move_actuators(0.0f,0.0f,0.5f,0.0f);
     
+    // _spool_state is enforced to SHUT_DOWN when _spool_desired is SHUT_DOWN.
     set_desired_spool_state(DesiredSpoolState::SHUT_DOWN);
-    _spool_state = SpoolState::SHUT_DOWN;
-    update_motor_control(_spool_desired);
+    _spool_state = update_motor_control(_spool_desired);
 
     output_to_motors();
 
@@ -353,13 +353,13 @@ void AP_MotorsHeli::output_logic()
         }
     } else {
         _heliflags.init_targets_on_arming = true;
-        _spool_desired = DesiredSpoolState::SHUT_DOWN;
-        _spool_state = SpoolState::SHUT_DOWN;
+        _spool_desired = DesiredSpoolState::SHUT_DOWN; // RSC will enforce _spool_state to SHUT_DOWN when spool_desired is SHUT_DOWN
     }
 
     // send desired spool state update to Heli RSC and update outputs
     // the Heli RSC will return the current spool state which is used to update _spool_state variable
-    _spool_state=update_motor_control(_spool_desired);
+    // _spool_state is enforced to SHUT_DOWN when _spool_desired is SHUT_DOWN.
+    _spool_state = update_motor_control(_spool_desired);
 
     // Always reset the collective limit flags, they get set in move_actuators() if collective reaches a limit
     limit.set_throttle(false);

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -578,9 +578,9 @@ uint32_t AP_MotorsHeli::get_motor_mask()
 }
 
 // set_desired_rotor_speed
-void AP_MotorsHeli::set_desired_rotor_speed(float desired_speed)
+void AP_MotorsHeli::set_desired_rotor_speed(float desired_rotor_speed)
 {
-    _main_rotor.set_passthrough_desired_speed(desired_speed);
+    _main_rotor.set_passthru_desired_rotor_speed(desired_rotor_speed);
 }
 
 // Update _heliflags.rotor_runup_complete value writing log event on state change

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -195,8 +195,12 @@ void AP_MotorsHeli::output_min()
 {
     // move swash to mid
     move_actuators(0.0f,0.0f,0.5f,0.0f);
+    
+    set_desired_spool_state(DesiredSpoolState::SHUT_DOWN);
+    _spool_state = SpoolState::SHUT_DOWN;
+    update_motor_control(get_rotor_control_state());
 
-    update_motor_control(AP_MotorsHeli_RSC::RotorControlState::STOP);
+    output_to_motors();
 
     // override limits flags
     limit.set_rpy(true);
@@ -216,7 +220,6 @@ void AP_MotorsHeli::output()
     if (armed()) {
         // block servo_test from happening at disarm
         _servo_test_cycle_counter = 0;
-        calculate_armed_scalars();
         output_armed_stabilizing();
     } else {
         output_disarmed();
@@ -436,7 +439,6 @@ void AP_MotorsHeli::output_logic()
                 break;
             }
 
-
             break;
 
         case SpoolState::SPOOLING_DOWN:
@@ -460,6 +462,8 @@ void AP_MotorsHeli::output_logic()
             }
             break;
     }
+    // send state update to motors and update outputs
+    update_motor_control(get_rotor_control_state());
 }
 
 // update the throttle input filter
@@ -614,30 +618,26 @@ uint32_t AP_MotorsHeli::get_motor_mask()
 // set_desired_rotor_speed
 void AP_MotorsHeli::set_desired_rotor_speed(float desired_speed)
 {
-    _main_rotor.set_desired_speed(desired_speed);
+    _main_rotor.set_passthrough_desired_speed(desired_speed);
 }
 
-// Converts AP_Motors::SpoolState from _spool_state variable to AP_MotorsHeli_RSC::RotorControlState
-AP_MotorsHeli_RSC::RotorControlState AP_MotorsHeli::get_rotor_control_state() const
+// Converts AP_Motors::SpoolDesired from _spool_desired variable to AP_MotorsHeli_RSC::DesiredRSCSpoolState
+AP_MotorsHeli_RSC::DesiredRSCSpoolState AP_MotorsHeli::get_rotor_control_state() const
 {
-    switch (_spool_state) {
-        case SpoolState::SHUT_DOWN:
+    switch (_spool_desired) {
+        case DesiredSpoolState::SHUT_DOWN:
             // sends minimum values out to the motors
-            return AP_MotorsHeli_RSC::RotorControlState::STOP;
-        case SpoolState::GROUND_IDLE:
+            return AP_MotorsHeli_RSC::DesiredRSCSpoolState::SHUT_DOWN;
+        case DesiredSpoolState::GROUND_IDLE:
             // sends idle output to motors when armed. rotor could be static or turning (autorotation)
-            return AP_MotorsHeli_RSC::RotorControlState::IDLE;
-        case SpoolState::SPOOLING_UP:
-        case SpoolState::THROTTLE_UNLIMITED:
+            return AP_MotorsHeli_RSC::DesiredRSCSpoolState::GROUND_IDLE;
+        case DesiredSpoolState::THROTTLE_UNLIMITED:
             // set motor output based on thrust requests
-            return AP_MotorsHeli_RSC::RotorControlState::ACTIVE;
-        case SpoolState::SPOOLING_DOWN:
-            // sends idle output to motors and wait for rotor to stop
-            return AP_MotorsHeli_RSC::RotorControlState::IDLE;
+            return AP_MotorsHeli_RSC::DesiredRSCSpoolState::THROTTLE_UNLIMITED;
     }
 
     // Should be unreachable, but needed to keep the compiler happy
-    return AP_MotorsHeli_RSC::RotorControlState::STOP;
+    return AP_MotorsHeli_RSC::DesiredRSCSpoolState::SHUT_DOWN;
 }
 
 // Update _heliflags.rotor_runup_complete value writing log event on state change

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -357,6 +357,10 @@ void AP_MotorsHeli::output_logic()
         _spool_state = SpoolState::SHUT_DOWN;
     }
 
+    // send desired spool state update to Heli RSC and update outputs
+    // the Heli RSC will return the current spool state which is used to update _spool_state variable
+    _spool_state=update_motor_control(get_rotor_control_state());
+
     // Always reset the collective limit flags, they get set in move_actuators() if collective reaches a limit
     limit.set_throttle(false);
 
@@ -371,13 +375,6 @@ void AP_MotorsHeli::output_logic()
             } else {
                 limit.set_rpy(false);
             }
-
-            // make sure the motors are spooling in the correct direction
-            if (_spool_desired != DesiredSpoolState::SHUT_DOWN) {
-                _spool_state = SpoolState::GROUND_IDLE;
-                break;
-            }
-
             break;
 
         case SpoolState::GROUND_IDLE: {
@@ -388,16 +385,6 @@ void AP_MotorsHeli::output_logic()
             } else {
                 limit.set_rpy(false);
             }
-
-            // Servos should be moving to correct the current attitude.
-            if (_spool_desired == DesiredSpoolState::SHUT_DOWN){
-                _spool_state = SpoolState::SHUT_DOWN;
-            } else if(_spool_desired == DesiredSpoolState::THROTTLE_UNLIMITED) {
-                _spool_state = SpoolState::SPOOLING_UP;
-            } else {    // _spool_desired == GROUND_IDLE
-
-            }
-
             break;
         }
         case SpoolState::SPOOLING_UP:
@@ -411,15 +398,6 @@ void AP_MotorsHeli::output_logic()
                 limit.set_rpy(false);
             }
 
-            // make sure the motors are spooling in the correct direction
-            if (_spool_desired != DesiredSpoolState::THROTTLE_UNLIMITED ){
-                _spool_state = SpoolState::SPOOLING_DOWN;
-                break;
-            }
-
-            if (_heliflags.rotor_runup_complete){
-                _spool_state = SpoolState::THROTTLE_UNLIMITED;
-            }
             break;
 
         case SpoolState::THROTTLE_UNLIMITED:
@@ -431,12 +409,6 @@ void AP_MotorsHeli::output_logic()
                 limit.set_rpy(true);
             } else {
                 limit.set_rpy(false);
-            }
-
-            // make sure the motors are spooling in the correct direction
-            if (_spool_desired != DesiredSpoolState::THROTTLE_UNLIMITED) {
-                _spool_state = SpoolState::SPOOLING_DOWN;
-                break;
             }
 
             break;
@@ -451,19 +423,9 @@ void AP_MotorsHeli::output_logic()
             } else {
                 limit.set_rpy(false);
             }
-
-            // make sure the motors are spooling in the correct direction
-            if (_spool_desired == DesiredSpoolState::THROTTLE_UNLIMITED) {
-                _spool_state = SpoolState::SPOOLING_UP;
-                break;
-            }
-            if (_heliflags.rotor_spooldown_complete){
-                _spool_state = SpoolState::GROUND_IDLE;
-            }
             break;
     }
-    // send state update to motors and update outputs
-    update_motor_control(get_rotor_control_state());
+
 }
 
 // update the throttle input filter
@@ -638,6 +600,31 @@ AP_MotorsHeli_RSC::DesiredRSCSpoolState AP_MotorsHeli::get_rotor_control_state()
 
     // Should be unreachable, but needed to keep the compiler happy
     return AP_MotorsHeli_RSC::DesiredRSCSpoolState::SHUT_DOWN;
+}
+
+// Converts AP_MotorsHeli_RSC::RSCSpoolState from _rotor_spool_state variable to AP_Motors::SpoolState
+AP_Motors::SpoolState AP_MotorsHeli::convert_spool_state(AP_MotorsHeli_RSC::RSCSpoolState rotor_spool_state) const
+{
+    switch (rotor_spool_state) {
+        case AP_MotorsHeli_RSC::RSCSpoolState::SHUT_DOWN:
+            // sends minimum values out to the motors
+            return AP_Motors::SpoolState::SHUT_DOWN;
+        case AP_MotorsHeli_RSC::RSCSpoolState::GROUND_IDLE:
+            // sends idle output to motors when armed. rotor could be static or turning (autorotation)
+            return AP_Motors::SpoolState::GROUND_IDLE;
+        case AP_MotorsHeli_RSC::RSCSpoolState::THROTTLE_UNLIMITED:
+            // set motor output based on thrust requests
+            return AP_Motors::SpoolState::THROTTLE_UNLIMITED;
+        case AP_MotorsHeli_RSC::RSCSpoolState::SPOOLING_UP:
+            // sends idle output to motors when armed. rotor could be static or turning (autorotation)
+            return AP_Motors::SpoolState::SPOOLING_UP;
+        case AP_MotorsHeli_RSC::RSCSpoolState::SPOOLING_DOWN:
+            // set motor output based on thrust requests
+            return AP_Motors::SpoolState::SPOOLING_DOWN;
+    }
+
+    // Should be unreachable, but needed to keep the compiler happy
+    return AP_Motors::SpoolState::SHUT_DOWN;
 }
 
 // Update _heliflags.rotor_runup_complete value writing log event on state change

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -234,6 +234,8 @@ void AP_MotorsHeli::output()
 // sends commands to the motors
 void AP_MotorsHeli::output_armed_stabilizing()
 {
+    _main_rotor.configure_armed();
+
     // if manual override active after arming, deactivate it and reinitialize servos
     if (_servo_mode != SERVO_CONTROL_MODE_AUTOMATED) {
         reset_flight_controls();

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -198,7 +198,7 @@ void AP_MotorsHeli::output_min()
     
     set_desired_spool_state(DesiredSpoolState::SHUT_DOWN);
     _spool_state = SpoolState::SHUT_DOWN;
-    update_motor_control(get_rotor_control_state());
+    update_motor_control(_spool_desired);
 
     output_to_motors();
 
@@ -359,7 +359,7 @@ void AP_MotorsHeli::output_logic()
 
     // send desired spool state update to Heli RSC and update outputs
     // the Heli RSC will return the current spool state which is used to update _spool_state variable
-    _spool_state=update_motor_control(get_rotor_control_state());
+    _spool_state=update_motor_control(_spool_desired);
 
     // Always reset the collective limit flags, they get set in move_actuators() if collective reaches a limit
     limit.set_throttle(false);
@@ -581,50 +581,6 @@ uint32_t AP_MotorsHeli::get_motor_mask()
 void AP_MotorsHeli::set_desired_rotor_speed(float desired_speed)
 {
     _main_rotor.set_passthrough_desired_speed(desired_speed);
-}
-
-// Converts AP_Motors::SpoolDesired from _spool_desired variable to AP_MotorsHeli_RSC::DesiredRSCSpoolState
-AP_MotorsHeli_RSC::DesiredRSCSpoolState AP_MotorsHeli::get_rotor_control_state() const
-{
-    switch (_spool_desired) {
-        case DesiredSpoolState::SHUT_DOWN:
-            // sends minimum values out to the motors
-            return AP_MotorsHeli_RSC::DesiredRSCSpoolState::SHUT_DOWN;
-        case DesiredSpoolState::GROUND_IDLE:
-            // sends idle output to motors when armed. rotor could be static or turning (autorotation)
-            return AP_MotorsHeli_RSC::DesiredRSCSpoolState::GROUND_IDLE;
-        case DesiredSpoolState::THROTTLE_UNLIMITED:
-            // set motor output based on thrust requests
-            return AP_MotorsHeli_RSC::DesiredRSCSpoolState::THROTTLE_UNLIMITED;
-    }
-
-    // Should be unreachable, but needed to keep the compiler happy
-    return AP_MotorsHeli_RSC::DesiredRSCSpoolState::SHUT_DOWN;
-}
-
-// Converts AP_MotorsHeli_RSC::RSCSpoolState from _rotor_spool_state variable to AP_Motors::SpoolState
-AP_Motors::SpoolState AP_MotorsHeli::convert_spool_state(AP_MotorsHeli_RSC::RSCSpoolState rotor_spool_state) const
-{
-    switch (rotor_spool_state) {
-        case AP_MotorsHeli_RSC::RSCSpoolState::SHUT_DOWN:
-            // sends minimum values out to the motors
-            return AP_Motors::SpoolState::SHUT_DOWN;
-        case AP_MotorsHeli_RSC::RSCSpoolState::GROUND_IDLE:
-            // sends idle output to motors when armed. rotor could be static or turning (autorotation)
-            return AP_Motors::SpoolState::GROUND_IDLE;
-        case AP_MotorsHeli_RSC::RSCSpoolState::THROTTLE_UNLIMITED:
-            // set motor output based on thrust requests
-            return AP_Motors::SpoolState::THROTTLE_UNLIMITED;
-        case AP_MotorsHeli_RSC::RSCSpoolState::SPOOLING_UP:
-            // sends idle output to motors when armed. rotor could be static or turning (autorotation)
-            return AP_Motors::SpoolState::SPOOLING_UP;
-        case AP_MotorsHeli_RSC::RSCSpoolState::SPOOLING_DOWN:
-            // set motor output based on thrust requests
-            return AP_Motors::SpoolState::SPOOLING_DOWN;
-    }
-
-    // Should be unreachable, but needed to keep the compiler happy
-    return AP_Motors::SpoolState::SHUT_DOWN;
 }
 
 // Update _heliflags.rotor_runup_complete value writing log event on state change

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -173,12 +173,6 @@ protected:
     // update_motor_controls - sends commands to motor controllers
     virtual AP_Motors::SpoolState update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state) = 0;
 
-    // Converts AP_Motors::SpoolState from _spool_state variable to AP_MotorsHeli_RSC::RotorControlState
-    AP_MotorsHeli_RSC::DesiredRSCSpoolState get_rotor_control_state() const;
-
-    // Converts AP_MotorsHeli_RSC::RSCSpoolState from _rotor_spool_state variable to AP_Motors::SpoolState
-    AP_Motors::SpoolState convert_spool_state(AP_MotorsHeli_RSC::RSCSpoolState rotor_spool_state) const;
-
 // run spool logic
     void                output_logic();
 

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -73,7 +73,7 @@ public:
     void set_collective_for_landing(bool landing) { _heliflags.landing_collective = landing; }
 
     // get_rsc_mode - gets the current rotor speed control method
-    uint8_t get_rsc_mode() const { return _main_rotor.get_control_mode(); }
+    uint8_t get_rsc_mode() const { return _main_rotor.get_rsc_control_mode(); }
 
     // get_rsc_setpoint - gets contents of _rsc_setpoint parameter (0~1)
     float get_rsc_setpoint() const { return _main_rotor._rsc_setpoint.get() * 0.01f; }
@@ -82,7 +82,7 @@ public:
     virtual void set_desired_rotor_speed(float desired_speed);
 
     // get_desired_rotor_speed - gets target rotor speed as a number from 0 ~ 1
-    float get_desired_rotor_speed() const { return _main_rotor.get_desired_speed(); }
+    float get_desired_rotor_speed() const { return _main_rotor.get_desired_rotor_speed(); }
 
     // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
@@ -173,7 +173,7 @@ protected:
     // update_motor_controls - sends commands to motor controllers
     virtual AP_Motors::SpoolState update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state) = 0;
 
-// run spool logic
+    // run spool logic
     void                output_logic();
 
     // output_to_motors - sends commands to the motors

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -174,10 +174,10 @@ protected:
     AP_MotorsHeli_RSC   _main_rotor;            // main rotor
 
     // update_motor_controls - sends commands to motor controllers
-    virtual void update_motor_control(AP_MotorsHeli_RSC::RotorControlState state) = 0;
+    virtual void update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state) = 0;
 
     // Converts AP_Motors::SpoolState from _spool_state variable to AP_MotorsHeli_RSC::RotorControlState
-    AP_MotorsHeli_RSC::RotorControlState get_rotor_control_state() const;
+    AP_MotorsHeli_RSC::DesiredRSCSpoolState get_rotor_control_state() const;
 
     // run spool logic
     void                output_logic();
@@ -197,9 +197,6 @@ protected:
     // init_outputs - initialise Servo/PWM ranges and endpoints.  This
     // method also updates the initialised flag.
     virtual void init_outputs() = 0;
-
-    // calculate_armed_scalars - must be implemented by child classes
-    virtual void calculate_armed_scalars() = 0;
 
     // calculate_scalars - must be implemented by child classes
     virtual void calculate_scalars() = 0;

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -84,9 +84,6 @@ public:
     // get_desired_rotor_speed - gets target rotor speed as a number from 0 ~ 1
     float get_desired_rotor_speed() const { return _main_rotor.get_desired_speed(); }
 
-    // return true if the main rotor is up to speed
-    bool rotor_runup_complete() const { return _heliflags.rotor_runup_complete; }
-
     // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
     virtual uint32_t get_motor_mask() override;
@@ -174,12 +171,15 @@ protected:
     AP_MotorsHeli_RSC   _main_rotor;            // main rotor
 
     // update_motor_controls - sends commands to motor controllers
-    virtual void update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state) = 0;
+    virtual AP_Motors::SpoolState update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state) = 0;
 
     // Converts AP_Motors::SpoolState from _spool_state variable to AP_MotorsHeli_RSC::RotorControlState
     AP_MotorsHeli_RSC::DesiredRSCSpoolState get_rotor_control_state() const;
 
-    // run spool logic
+    // Converts AP_MotorsHeli_RSC::RSCSpoolState from _rotor_spool_state variable to AP_Motors::SpoolState
+    AP_Motors::SpoolState convert_spool_state(AP_MotorsHeli_RSC::RSCSpoolState rotor_spool_state) const;
+
+// run spool logic
     void                output_logic();
 
     // output_to_motors - sends commands to the motors
@@ -244,7 +244,6 @@ protected:
         uint8_t land_complete           : 1;    // true if aircraft is landed
         uint8_t takeoff_collective      : 1;    // true if collective is above 30% between H_COL_MID and H_COL_MAX
         uint8_t below_land_min_coll     : 1;    // true if collective is below H_COL_LAND_MIN
-        uint8_t rotor_spooldown_complete : 1;    // true if the rotors have spooled down completely
         uint8_t start_engine            : 1;    // true if turbine start RC option is initiated
     } _heliflags;
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -348,7 +348,7 @@ AP_Motors::SpoolState AP_MotorsHeli_Dual::update_motor_control(AP_MotorsHeli_RSC
     // Check if rotors are run-up
     set_rotor_runup_complete(main_rotor_state == AP_MotorsHeli_RSC::RSCSpoolState::THROTTLE_UNLIMITED);
 
-    return convert_spool_state(main_rotor_state);
+    return main_rotor_state;
 }
 
 //

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -225,29 +225,10 @@ void AP_MotorsHeli_Dual::init_outputs()
 {
     if (!initialised_ok()) {
         // set rotor servo range
-        _main_rotor.init_servo();
+        _main_rotor.initialize();
     }
 
     set_initialised_ok(_frame_class == MOTOR_FRAME_HELI_DUAL);
-}
-
-// calculate_armed_scalars
-void AP_MotorsHeli_Dual::calculate_armed_scalars()
-{
-    // Set rsc mode specific parameters
-    if (_main_rotor._rsc_mode.get() == ROTOR_CONTROL_MODE_THROTTLECURVE || _main_rotor._rsc_mode.get() == ROTOR_CONTROL_MODE_AUTOTHROTTLE) {
-        _main_rotor.set_throttle_curve();
-    }
-    // keeps user from changing RSC mode while armed
-    if (_main_rotor._rsc_mode.get() != _main_rotor.get_control_mode()) {
-        _main_rotor.reset_rsc_mode_param();
-        _heliflags.save_rsc_mode = true;
-    }
-    // saves rsc mode parameter when disarmed if it had been reset while armed
-    if (_heliflags.save_rsc_mode && !armed()) {
-        _main_rotor._rsc_mode.save();
-        _heliflags.save_rsc_mode = false;
-    }
 }
 
 // calculate_scalars
@@ -289,9 +270,8 @@ void AP_MotorsHeli_Dual::calculate_scalars()
     // configure swashplate 2 and update scalars
     _swashplate2.configure();
 
-    // set mode of main rotor controller and trigger recalculation of scalars
-    _main_rotor.set_control_mode(static_cast<RotorControlMode>(_main_rotor._rsc_mode.get()));
-    calculate_armed_scalars();
+    // configure main rotor and update scalars
+    _main_rotor.configure();
 }
 
 // Mix and output swashplates for tandem
@@ -352,12 +332,12 @@ void AP_MotorsHeli_Dual::mix_intermeshing(float pitch_input, float roll_input, f
 }
 
 // update_motor_controls - sends commands to motor controllers
-void AP_MotorsHeli_Dual::update_motor_control(AP_MotorsHeli_RSC::RotorControlState state)
+void AP_MotorsHeli_Dual::update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state)
 {
     // Send state update to motors
-    _main_rotor.output(state);
+    _main_rotor.update(state);
 
-    if (state == AP_MotorsHeli_RSC::RotorControlState::STOP) {
+    if (state == AP_MotorsHeli_RSC::DesiredRSCSpoolState::SHUT_DOWN) {
         // set engine run enable aux output to not run position to kill engine when disarmed
         SRV_Channels::set_output_limit(SRV_Channel::k_engine_run_enable, SRV_Channel::Limit::MIN);
     } else {
@@ -507,7 +487,7 @@ void AP_MotorsHeli_Dual::output_to_motors()
     _swashplate1.output();
     _swashplate2.output();
 
-    update_motor_control(get_rotor_control_state());
+    _main_rotor.output_to_servo();
 
 }
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -332,10 +332,10 @@ void AP_MotorsHeli_Dual::mix_intermeshing(float pitch_input, float roll_input, f
 }
 
 // update_motor_controls - sends commands to motor controllers
-void AP_MotorsHeli_Dual::update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state)
+AP_Motors::SpoolState AP_MotorsHeli_Dual::update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state)
 {
     // Send state update to motors
-    _main_rotor.update(state);
+    AP_MotorsHeli_RSC::RSCSpoolState main_rotor_state = _main_rotor.update(state);
 
     if (state == AP_MotorsHeli_RSC::DesiredRSCSpoolState::SHUT_DOWN) {
         // set engine run enable aux output to not run position to kill engine when disarmed
@@ -346,10 +346,9 @@ void AP_MotorsHeli_Dual::update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpool
     }
 
     // Check if rotors are run-up
-    set_rotor_runup_complete(_main_rotor.is_runup_complete());
+    set_rotor_runup_complete(main_rotor_state == AP_MotorsHeli_RSC::RSCSpoolState::THROTTLE_UNLIMITED);
 
-    // Check if rotors are spooled down
-    _heliflags.rotor_spooldown_complete = _main_rotor.is_spooldown_complete();
+    return convert_spool_state(main_rotor_state);
 }
 
 //

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.h
@@ -70,7 +70,7 @@ protected:
     void init_outputs () override;
 
     // update_motor_controls - sends commands to motor controllers
-    void update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state) override;
+    AP_Motors::SpoolState update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state) override;
 
     // get_swashplate - calculate movement of each swashplate based on configuration
     float get_swashplate(int8_t swash_num, int8_t swash_axis, float pitch_input, float roll_input, float yaw_input, float coll_input);

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.h
@@ -47,9 +47,6 @@ public:
     // calculate_scalars - recalculates various scalars used
     void calculate_scalars() override;
 
-    // calculate_armed_scalars - recalculates scalars that can change while armed
-    void calculate_armed_scalars() override;
-
     // servo_test - move servos through full range of movement
     void servo_test() override;
 
@@ -73,7 +70,7 @@ protected:
     void init_outputs () override;
 
     // update_motor_controls - sends commands to motor controllers
-    void update_motor_control(AP_MotorsHeli_RSC::RotorControlState state) override;
+    void update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state) override;
 
     // get_swashplate - calculate movement of each swashplate based on configuration
     float get_swashplate(int8_t swash_num, int8_t swash_axis, float pitch_input, float roll_input, float yaw_input, float coll_input);

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -133,7 +133,7 @@ AP_Motors::SpoolState  AP_MotorsHeli_Quad::update_motor_control(AP_MotorsHeli_RS
     // Check if rotors are run-up
     set_rotor_runup_complete(main_rotor_state == AP_MotorsHeli_RSC::RSCSpoolState::THROTTLE_UNLIMITED);
 
-    return convert_spool_state(main_rotor_state);
+    return main_rotor_state;
 
 }
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -117,10 +117,10 @@ void AP_MotorsHeli_Quad::calculate_roll_pitch_collective_factors()
 }
 
 // update_motor_controls - sends commands to motor controllers
-void AP_MotorsHeli_Quad::update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state)
+AP_Motors::SpoolState  AP_MotorsHeli_Quad::update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state)
 {
     // Send state update to motors
-    _main_rotor.update(state);
+    AP_MotorsHeli_RSC::RSCSpoolState main_rotor_state = _main_rotor.update(state);
 
     if (state == AP_MotorsHeli_RSC::DesiredRSCSpoolState::SHUT_DOWN) {
         // set engine run enable aux output to not run position to kill engine when disarmed
@@ -131,10 +131,10 @@ void AP_MotorsHeli_Quad::update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpool
     }
 
     // Check if rotors are run-up
-    set_rotor_runup_complete(_main_rotor.is_runup_complete());
+    set_rotor_runup_complete(main_rotor_state == AP_MotorsHeli_RSC::RSCSpoolState::THROTTLE_UNLIMITED);
 
-    // Check if rotors are spooled down
-    _heliflags.rotor_spooldown_complete = _main_rotor.is_spooldown_complete();
+    return convert_spool_state(main_rotor_state);
+
 }
 
 //

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -58,28 +58,9 @@ void AP_MotorsHeli_Quad::init_outputs()
     }
 
     // set rotor servo range
-    _main_rotor.init_servo();
+    _main_rotor.initialize();
 
     set_initialised_ok(_frame_class == MOTOR_FRAME_HELI_QUAD);
-}
-
-// calculate_armed_scalars
-void AP_MotorsHeli_Quad::calculate_armed_scalars()
-{
-    // Set rsc mode specific parameters
-    if (_main_rotor._rsc_mode.get() == ROTOR_CONTROL_MODE_THROTTLECURVE || _main_rotor._rsc_mode.get() == ROTOR_CONTROL_MODE_AUTOTHROTTLE) {
-        _main_rotor.set_throttle_curve();
-    }
-    // keeps user from changing RSC mode while armed
-    if (_main_rotor._rsc_mode.get() != _main_rotor.get_control_mode()) {
-        _main_rotor.reset_rsc_mode_param();
-        _heliflags.save_rsc_mode = true;
-    }
-    // saves rsc mode parameter when disarmed if it had been reset while armed
-    if (_heliflags.save_rsc_mode && !armed()) {
-        _main_rotor._rsc_mode.save();
-        _heliflags.save_rsc_mode = false;
-    }
 }
 
 // calculate_scalars
@@ -109,9 +90,8 @@ void AP_MotorsHeli_Quad::calculate_scalars()
     // calculate factors based on swash type and servo position
     calculate_roll_pitch_collective_factors();
 
-    // set mode of main rotor controller and trigger recalculation of scalars
-    _main_rotor.set_control_mode(static_cast<RotorControlMode>(_main_rotor._rsc_mode.get()));
-    calculate_armed_scalars();
+    // configure main rotor and update scalars
+    _main_rotor.configure();
 }
 
 // calculate_swash_factors - calculate factors based on swash type and servo position
@@ -137,12 +117,12 @@ void AP_MotorsHeli_Quad::calculate_roll_pitch_collective_factors()
 }
 
 // update_motor_controls - sends commands to motor controllers
-void AP_MotorsHeli_Quad::update_motor_control(AP_MotorsHeli_RSC::RotorControlState state)
+void AP_MotorsHeli_Quad::update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state)
 {
     // Send state update to motors
-    _main_rotor.output(state);
+    _main_rotor.update(state);
 
-    if (state == AP_MotorsHeli_RSC::RotorControlState::STOP) {
+    if (state == AP_MotorsHeli_RSC::DesiredRSCSpoolState::SHUT_DOWN) {
         // set engine run enable aux output to not run position to kill engine when disarmed
         SRV_Channels::set_output_limit(SRV_Channel::k_engine_run_enable, SRV_Channel::Limit::MIN);
     } else {
@@ -254,7 +234,7 @@ void AP_MotorsHeli_Quad::output_to_motors()
         rc_write_angle(AP_MOTORS_MOT_1+i, _out[i] * QUAD_SERVO_MAX_ANGLE);
     }
 
-    update_motor_control(get_rotor_control_state());
+    _main_rotor.output_to_servo();
 
 }
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.h
@@ -34,9 +34,6 @@ public:
     // calculate_scalars - recalculates various scalars used
     void calculate_scalars() override;
 
-    // calculate_armed_scalars - recalculates scalars that can change while armed
-    void calculate_armed_scalars() override;
-
     // servo_test - move servos through full range of movement
     void servo_test() override;
 
@@ -54,7 +51,7 @@ protected:
     void init_outputs () override;
 
     // update_motor_controls - sends commands to motor controllers
-    void update_motor_control(AP_MotorsHeli_RSC::RotorControlState state) override;
+    void update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state) override;
 
     // calculate_roll_pitch_collective_factors - setup rate factors
     void calculate_roll_pitch_collective_factors ();

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.h
@@ -51,7 +51,7 @@ protected:
     void init_outputs () override;
 
     // update_motor_controls - sends commands to motor controllers
-    void update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state) override;
+    AP_Motors::SpoolState update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state) override;
 
     // calculate_roll_pitch_collective_factors - setup rate factors
     void calculate_roll_pitch_collective_factors ();

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -753,22 +753,20 @@ void AP_MotorsHeli_RSC::write_log(void) const
     // @Field: Gov: Governor Output
     // @Field: Throt: Throttle output
     // @Field: Ramp: throttle ramp up
-    // @Field: Stat: RSC state
 
     // Write to data flash log
     AP::logger().WriteStreaming("HRSC",
-                        "TimeUS,I,DRRPM,ERRPM,Gov,Throt,Ramp,Stat",
-                        "s#------",
-                        "F-------",
-                        "QBfffffB",
+                        "TimeUS,I,DRRPM,ERRPM,Gov,Throt,Ramp",
+                        "s#-----",
+                        "F------",
+                        "QBfffff",
                         AP_HAL::micros64(),
                         _instance,
                         get_desired_rotor_speed(),
                         _rotor_runup_output,
                         _governor_output,
                         get_control_output(),
-                        _rotor_ramp_output,
-                        uint8_t(_desired_spool_state));
+                        _rotor_ramp_output);
 }
 #endif
 

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -281,6 +281,10 @@ void AP_MotorsHeli_RSC::configure_armed()
             // throttle curve and autothrottle both use the pilot's desired speed as the input to the throttle curve, so set the desired speed to the pilot's input
             _desired_rotor_speed = 1.0f;
             break;
+        case ROTOR_CONTROL_MODE_DISABLED:
+            // in disabled mode the desired speed is not used, but set it to zero for safety
+            _desired_rotor_speed = 0.0f;
+            break;
     }
 
     // Set rsc mode specific parameters
@@ -317,6 +321,15 @@ void AP_MotorsHeli_RSC::set_throttle_curve()
 // update - ran each loop to update the RSC
 AP_MotorsHeli_RSC::RSCSpoolState AP_MotorsHeli_RSC::update(DesiredRSCSpoolState desired_spool_state)
 {
+
+    // if control mode is disabled, then we should always be in SHUT_DOWN spool state and ignore any other desired spool state inputs
+    if (_rsc_control_mode == ROTOR_CONTROL_MODE_DISABLED) {
+        _desired_spool_state = DesiredRSCSpoolState::SHUT_DOWN;
+        update_spool_state();
+        _control_output = 0.0f;
+        return _spool_state;
+    }
+
     // set desired spool state
     _desired_spool_state = desired_spool_state;
 

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -466,6 +466,12 @@ AP_MotorsHeli_RSC::RSCSpoolState AP_MotorsHeli_RSC::update(DesiredRSCSpoolState 
 // update_spool_state - updates the spool state machine based on the desired spool state and current spool state
 void AP_MotorsHeli_RSC::update_spool_state(DesiredRSCSpoolState _spool_desired)
 {
+
+    if (_spool_desired == DesiredRSCSpoolState::SHUT_DOWN) {
+        // if we are shutting down, we want to immediately go to SHUT_DOWN state and not wait for spool down to complete
+        _spool_state = RSCSpoolState::SHUT_DOWN;
+        return;
+    }
     switch (_spool_state) {
         case RSCSpoolState::SHUT_DOWN:
             // Motors should be stationary.
@@ -524,7 +530,6 @@ void AP_MotorsHeli_RSC::update_spool_state(DesiredRSCSpoolState _spool_desired)
             break;
     }
 }
-
 
 // update_rotor_ramp - slews rotor output scalar between 0 and 1, outputs float scalar to _rotor_ramp_output
 void AP_MotorsHeli_RSC::update_rotor_ramp(float rotor_ramp_input, float dt)

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -228,10 +228,78 @@ const AP_Param::GroupInfo AP_MotorsHeli_RSC::var_info[] = {
 };
 
 // init_servo - servo initialization on start-up
-void AP_MotorsHeli_RSC::init_servo()
+void AP_MotorsHeli_RSC::initialize()
 {
     // setup RSC on specified channel by default
     SRV_Channels::set_aux_channel_default(_aux_fn, _default_channel);
+
+    // configure RSC on initialization
+    configure();
+
+}
+
+// configure - configure the RSC.
+void AP_MotorsHeli_RSC::configure()
+{
+
+    set_control_mode(static_cast<RotorControlMode>(_rsc_mode.get()));
+    set_ramp_time(_ramp_time.get());
+    set_runup_time(_runup_time.get());
+    set_critical_speed(_critical_speed.get());
+    set_idle_output(_idle_output.get());
+
+    configure_armed();
+}
+
+// configure - configure the RSC with specific settings, allows caller to specify settings instead of using parameters.
+void AP_MotorsHeli_RSC::configure(RotorControlMode control_mode, int8_t ramp_time, int8_t runup_time, float critical_speed, float idle_output)
+{
+    set_control_mode(control_mode);
+    set_ramp_time(ramp_time);
+    set_runup_time(runup_time);
+    set_critical_speed(critical_speed);
+    set_idle_output(idle_output);
+
+    configure_armed();
+}
+
+// configure - configure the RSC.
+void AP_MotorsHeli_RSC::configure_armed()
+{
+
+    // set desired speed for each control mode
+    switch(_control_mode) {
+    case ROTOR_CONTROL_MODE_PASSTHROUGH:
+        // passthrough mode uses the pilot's desired speed directly as the control output, so set the desired speed to the pilot's input
+        _desired_speed = _pilot_desired_speed;
+        break;
+    case ROTOR_CONTROL_MODE_SETPOINT:
+        _desired_speed = _rsc_setpoint.get() * 0.01f;
+        break;
+    case ROTOR_CONTROL_MODE_THROTTLECURVE:
+    case ROTOR_CONTROL_MODE_AUTOTHROTTLE:
+        // throttle curve and autothrottle both use the pilot's desired speed as the input to the throttle curve, so set the desired speed to the pilot's input
+        _desired_speed = 1.0f;
+        break;
+    default:
+        _desired_speed = 0.0f;
+        break;
+    }
+
+    // Set rsc mode specific parameters
+    if (_rsc_mode.get() == ROTOR_CONTROL_MODE_THROTTLECURVE || _rsc_mode.get() == ROTOR_CONTROL_MODE_AUTOTHROTTLE) {
+        set_throttle_curve();
+    }
+    // keeps user from changing RSC mode while armed
+    if (_rsc_mode.get() != get_control_mode()) {
+        reset_rsc_mode_param();
+        _save_rsc_mode = true;
+    }
+    // saves rsc mode parameter when disarmed if it had been reset while armed
+    if (_save_rsc_mode && _desired_spool_state != DesiredRSCSpoolState::SHUT_DOWN) {
+        _rsc_mode.save();
+        _save_rsc_mode = false;
+    }
 
 }
 
@@ -249,11 +317,14 @@ void AP_MotorsHeli_RSC::set_throttle_curve()
     splinterp5(thrcrv,_thrcrv_poly);
 }
 
-// output - update value to send to ESC/Servo
-void AP_MotorsHeli_RSC::output(RotorControlState state)
+// update - ran each loop to update the RSC
+void AP_MotorsHeli_RSC::update(DesiredRSCSpoolState desired_spool_state)
 {
-    // Store rsc state for logging
-    _rsc_state = state;
+    // set desired spool state
+    _desired_spool_state = desired_spool_state;
+
+    configure_armed();
+
     // _rotor_RPM available to the RSC output
 #if AP_RPM_ENABLED
     const AP_RPM *rpm = AP_RPM::get_singleton();
@@ -282,8 +353,8 @@ void AP_MotorsHeli_RSC::output(RotorControlState state)
         _last_update_us = now;
     }
 
-    switch (state) {
-    case RotorControlState::STOP:
+    switch (desired_spool_state) {
+    case DesiredRSCSpoolState::SHUT_DOWN:
         // set rotor ramp to decrease speed to zero, this happens instantly inside update_rotor_ramp()
         update_rotor_ramp(0.0f, dt);
 
@@ -305,10 +376,9 @@ void AP_MotorsHeli_RSC::output(RotorControlState state)
 
         // reset fast idle timer
         _fast_idle_timer = 0.0;
-
         break;
 
-    case RotorControlState::IDLE:
+    case DesiredRSCSpoolState::GROUND_IDLE:
         // set rotor ramp to decrease speed to zero
         update_rotor_ramp(0.0f, dt);
 
@@ -347,9 +417,10 @@ void AP_MotorsHeli_RSC::output(RotorControlState state)
         }
 
         _control_output = _idle_throttle;
+
         break;
 
-    case RotorControlState::ACTIVE:
+    case DesiredRSCSpoolState::THROTTLE_UNLIMITED:
         // set main rotor ramp to increase to full speed
         update_rotor_ramp(1.0f, dt);
 
@@ -387,8 +458,6 @@ void AP_MotorsHeli_RSC::output(RotorControlState state)
         _control_output = constrain_float(_control_output, last_control_output-max_delta, last_control_output+max_delta);
     }
 
-    // output to rsc servo
-    write_rsc(_control_output);
 }
 
 // update_rotor_ramp - slews rotor output scalar between 0 and 1, outputs float scalar to _rotor_ramp_output
@@ -623,7 +692,7 @@ void AP_MotorsHeli_RSC::write_log(void) const
                         _governor_output,
                         get_control_output(),
                         _rotor_ramp_output,
-                        uint8_t(_rsc_state));
+                        uint8_t(_desired_spool_state));
 }
 #endif
 

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -269,21 +269,18 @@ void AP_MotorsHeli_RSC::configure_armed()
 
     // set desired speed for each control mode
     switch (_rsc_control_mode) {
-    case ROTOR_CONTROL_MODE_PASSTHROUGH:
-        // passthrough mode uses the pilot's desired speed directly as the control output, so set the desired speed to the pilot's input
-        _desired_rotor_speed = _passthru_desired_rotor_speed;
-        break;
-    case ROTOR_CONTROL_MODE_SETPOINT:
-        _desired_rotor_speed = _rsc_setpoint.get() * 0.01f;
-        break;
-    case ROTOR_CONTROL_MODE_THROTTLECURVE:
-    case ROTOR_CONTROL_MODE_AUTOTHROTTLE:
-        // throttle curve and autothrottle both use the pilot's desired speed as the input to the throttle curve, so set the desired speed to the pilot's input
-        _desired_rotor_speed = 1.0f;
-        break;
-    default:
-        _desired_rotor_speed = 0.0f;
-        break;
+        case ROTOR_CONTROL_MODE_PASSTHROUGH:
+            // passthrough mode uses the pilot's desired speed directly as the control output, so set the desired speed to the pilot's input
+            _desired_rotor_speed = _passthru_desired_rotor_speed;
+            break;
+        case ROTOR_CONTROL_MODE_SETPOINT:
+            _desired_rotor_speed = _rsc_setpoint.get() * 0.01f;
+            break;
+        case ROTOR_CONTROL_MODE_THROTTLECURVE:
+        case ROTOR_CONTROL_MODE_AUTOTHROTTLE:
+            // throttle curve and autothrottle both use the pilot's desired speed as the input to the throttle curve, so set the desired speed to the pilot's input
+            _desired_rotor_speed = 1.0f;
+            break;
     }
 
     // Set rsc mode specific parameters
@@ -353,106 +350,106 @@ AP_MotorsHeli_RSC::RSCSpoolState AP_MotorsHeli_RSC::update(DesiredRSCSpoolState 
         _last_update_us = now;
     }
 
-    switch (desired_spool_state) {
-    case DesiredRSCSpoolState::SHUT_DOWN:
-        // set rotor ramp to decrease speed to zero, this happens instantly inside update_rotor_ramp()
-        update_rotor_ramp(0.0f, dt);
+    switch (_desired_spool_state) {
+        case DesiredRSCSpoolState::SHUT_DOWN:
+            // set rotor ramp to decrease speed to zero, this happens instantly inside update_rotor_ramp()
+            update_rotor_ramp(0.0f, dt);
 
-        // control output forced to zero
-        _control_output = 0.0f;
+            // control output forced to zero
+            _control_output = 0.0f;
 
-        // governor is forced to disengage status and reset outputs
-        governor_reset();
-        _autothrottle = false;
-        _governor_fault = false;
-        //turbine start flag on
-        _starting = true;
+            // governor is forced to disengage status and reset outputs
+            governor_reset();
+            _autothrottle = false;
+            _governor_fault = false;
+            //turbine start flag on
+            _starting = true;
 
-        // ensure we always deactivate the autorotation state if we disarm
-        autorotation.set_active(false, true);
+            // ensure we always deactivate the autorotation state if we disarm
+            autorotation.set_active(false, true);
 
-        // ensure _idle_throttle not set to invalid value
-        _idle_throttle = get_idle_output();
-
-        // reset fast idle timer
-        _fast_idle_timer = 0.0;
-        break;
-
-    case DesiredRSCSpoolState::GROUND_IDLE:
-        // set rotor ramp to decrease speed to zero
-        update_rotor_ramp(0.0f, dt);
-
-        // set rotor control speed to engine idle and ensure governor is reset, if used
-        governor_reset();
-        _autothrottle = false;
-        _governor_fault = false;
-
-        // turbine start sequence
-        if (_turbine_start && _starting == true ) {
-            _idle_throttle += 0.001f;
-            if (_control_output >= 1.0f) {
-                _idle_throttle = get_idle_output();
-                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Turbine startup");
-                _starting = false;
-            }
-            _control_output = _idle_throttle;
-            break;
-        }
-
-        // all other idle throttle functions below this require idle throttle to be reset to H_RSC_IDLE on each call
-        _idle_throttle = get_idle_output();
-
-        // check if we need to use autorotation idle throttle
-        if (autorotation.get_idle_throttle(_idle_throttle)) {
-            // if we are here then we are autorotating
-            _control_output = _idle_throttle;
-            break;
-        }
-
-        // check if we need to use engine cooldown
-        if (_fast_idle_timer > 0.0) {
-            // running at fast idle for engine cool down
-            _idle_throttle *= 1.5;
-            _fast_idle_timer -= dt;
-        }
-
-        _control_output = _idle_throttle;
-
-        break;
-
-    case DesiredRSCSpoolState::THROTTLE_UNLIMITED:
-        // set main rotor ramp to increase to full speed
-        update_rotor_ramp(1.0f, dt);
-
-        // set fast idle timer so next time RSC goes to idle, the cooldown timer starts
-        if (_cooldown_time.get() > 0) {
-            _fast_idle_timer = _cooldown_time.get();
-        }
-
-        // ensure _idle_throttle not set to invalid value due to premature switch out of turbine start
-        if (_starting) {
+            // ensure _idle_throttle not set to invalid value
             _idle_throttle = get_idle_output();
-        }
-        // if turbine engine started without using start sequence, set starting flag just to be sure it can't be triggered when back in idle
-        _starting = false;
 
-        if ((_rsc_control_mode == ROTOR_CONTROL_MODE_PASSTHROUGH) || (_rsc_control_mode == ROTOR_CONTROL_MODE_SETPOINT)) {
-            // set control rotor speed to ramp slewed value between idle and desired speed
-            _control_output = _idle_throttle + (_rotor_ramp_output * (_desired_rotor_speed - _idle_throttle));
-        } else if (_rsc_control_mode == ROTOR_CONTROL_MODE_THROTTLECURVE) {
-            // throttle output from throttle curve based on collective position
-            float throttlecurve = calculate_throttlecurve(_collective_in);
-            _control_output = _idle_throttle + (_rotor_ramp_output * (throttlecurve - _idle_throttle));
-        } else if (_rsc_control_mode == ROTOR_CONTROL_MODE_AUTOTHROTTLE) {
-            autothrottle_run();
-        }
-        break;
+            // reset fast idle timer
+            _fast_idle_timer = 0.0;
+            break;
+
+        case DesiredRSCSpoolState::GROUND_IDLE:
+            // set rotor ramp to decrease speed to zero
+            update_rotor_ramp(0.0f, dt);
+
+            // set rotor control speed to engine idle and ensure governor is reset, if used
+            governor_reset();
+            _autothrottle = false;
+            _governor_fault = false;
+
+            // turbine start sequence
+            if (_turbine_start && _starting == true ) {
+                _idle_throttle += 0.001f;
+                if (_control_output >= 1.0f) {
+                    _idle_throttle = get_idle_output();
+                    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Turbine startup");
+                    _starting = false;
+                }
+                _control_output = _idle_throttle;
+                break;
+            }
+
+            // all other idle throttle functions below this require idle throttle to be reset to H_RSC_IDLE on each call
+            _idle_throttle = get_idle_output();
+
+            // check if we need to use autorotation idle throttle
+            if (autorotation.get_idle_throttle(_idle_throttle)) {
+                // if we are here then we are autorotating
+                _control_output = _idle_throttle;
+                break;
+            }
+
+            // check if we need to use engine cooldown
+            if (_fast_idle_timer > 0.0) {
+                // running at fast idle for engine cool down
+                _idle_throttle *= 1.5;
+                _fast_idle_timer -= dt;
+            }
+
+            _control_output = _idle_throttle;
+
+            break;
+
+        case DesiredRSCSpoolState::THROTTLE_UNLIMITED:
+            // set main rotor ramp to increase to full speed
+            update_rotor_ramp(1.0f, dt);
+
+            // set fast idle timer so next time RSC goes to idle, the cooldown timer starts
+            if (_cooldown_time.get() > 0) {
+                _fast_idle_timer = _cooldown_time.get();
+            }
+
+            // ensure _idle_throttle not set to invalid value due to premature switch out of turbine start
+            if (_starting) {
+                _idle_throttle = get_idle_output();
+            }
+            // if turbine engine started without using start sequence, set starting flag just to be sure it can't be triggered when back in idle
+            _starting = false;
+
+            if ((_rsc_control_mode == ROTOR_CONTROL_MODE_PASSTHROUGH) || (_rsc_control_mode == ROTOR_CONTROL_MODE_SETPOINT)) {
+                // set control rotor speed to ramp slewed value between idle and desired speed
+                _control_output = _idle_throttle + (_rotor_ramp_output * (_desired_rotor_speed - _idle_throttle));
+            } else if (_rsc_control_mode == ROTOR_CONTROL_MODE_THROTTLECURVE) {
+                // throttle output from throttle curve based on collective position
+                float throttlecurve = calculate_throttlecurve(_collective_in);
+                _control_output = _idle_throttle + (_rotor_ramp_output * (throttlecurve - _idle_throttle));
+            } else if (_rsc_control_mode == ROTOR_CONTROL_MODE_AUTOTHROTTLE) {
+                autothrottle_run();
+            }
+            break;
     }
 
     // update rotor speed run-up estimate
     update_rotor_runup(dt);
 
-    update_spool_state(desired_spool_state);
+    update_spool_state();
 
     if (_power_slewrate > 0) {
         // implement slew rate for throttle
@@ -464,10 +461,10 @@ AP_MotorsHeli_RSC::RSCSpoolState AP_MotorsHeli_RSC::update(DesiredRSCSpoolState 
 }
 
 // update_spool_state - updates the spool state machine based on the desired spool state and current spool state
-void AP_MotorsHeli_RSC::update_spool_state(DesiredRSCSpoolState _spool_desired)
+void AP_MotorsHeli_RSC::update_spool_state()
 {
 
-    if (_spool_desired == DesiredRSCSpoolState::SHUT_DOWN) {
+    if (_desired_spool_state == DesiredRSCSpoolState::SHUT_DOWN) {
         // if we are shutting down, we want to immediately go to SHUT_DOWN state and not wait for spool down to complete
         _spool_state = RSCSpoolState::SHUT_DOWN;
         return;
@@ -476,7 +473,7 @@ void AP_MotorsHeli_RSC::update_spool_state(DesiredRSCSpoolState _spool_desired)
         case RSCSpoolState::SHUT_DOWN:
             // Motors should be stationary.
             // make sure the motors are spooling in the correct direction
-            if (_spool_desired != DesiredRSCSpoolState::SHUT_DOWN) {
+            if (_desired_spool_state != DesiredRSCSpoolState::SHUT_DOWN) {
                 _spool_state = RSCSpoolState::GROUND_IDLE;
                 break;
             }
@@ -485,11 +482,11 @@ void AP_MotorsHeli_RSC::update_spool_state(DesiredRSCSpoolState _spool_desired)
 
         case RSCSpoolState::GROUND_IDLE: {
             // Motors should be stationary or at ground idle.
-            if (_spool_desired == DesiredRSCSpoolState::SHUT_DOWN){
+            if (_desired_spool_state == DesiredRSCSpoolState::SHUT_DOWN){
                 _spool_state = RSCSpoolState::SHUT_DOWN;
-            } else if(_spool_desired == DesiredRSCSpoolState::THROTTLE_UNLIMITED) {
+            } else if(_desired_spool_state == DesiredRSCSpoolState::THROTTLE_UNLIMITED) {
                 _spool_state = RSCSpoolState::SPOOLING_UP;
-            } else {    // _spool_desired == GROUND_IDLE
+            } else {    // _desired_spool_state == GROUND_IDLE
 
             }
 
@@ -498,7 +495,7 @@ void AP_MotorsHeli_RSC::update_spool_state(DesiredRSCSpoolState _spool_desired)
         case RSCSpoolState::SPOOLING_UP:
             // Maximum throttle should move from minimum to maximum.
             // make sure the motors are spooling in the correct direction
-            if (_spool_desired != DesiredRSCSpoolState::THROTTLE_UNLIMITED ){
+            if (_desired_spool_state != DesiredRSCSpoolState::THROTTLE_UNLIMITED ){
                 _spool_state = RSCSpoolState::SPOOLING_DOWN;
                 break;
             }
@@ -511,7 +508,7 @@ void AP_MotorsHeli_RSC::update_spool_state(DesiredRSCSpoolState _spool_desired)
         case RSCSpoolState::THROTTLE_UNLIMITED:
             // Throttle should exhibit normal flight behavior.
             // make sure the motors are spooling in the correct direction
-            if (_spool_desired != DesiredRSCSpoolState::THROTTLE_UNLIMITED && !rotor_speed_above_critical()) {
+            if (_desired_spool_state != DesiredRSCSpoolState::THROTTLE_UNLIMITED && !rotor_speed_above_critical()) {
                 _spool_state = RSCSpoolState::SPOOLING_DOWN;
                 break;
             }
@@ -520,7 +517,7 @@ void AP_MotorsHeli_RSC::update_spool_state(DesiredRSCSpoolState _spool_desired)
 
         case RSCSpoolState::SPOOLING_DOWN:
             // make sure the motors are spooling in the correct direction
-            if (_spool_desired == DesiredRSCSpoolState::THROTTLE_UNLIMITED) {
+            if (_desired_spool_state == DesiredRSCSpoolState::THROTTLE_UNLIMITED) {
                 _spool_state = RSCSpoolState::SPOOLING_UP;
                 break;
             }

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -318,7 +318,7 @@ void AP_MotorsHeli_RSC::set_throttle_curve()
 }
 
 // update - ran each loop to update the RSC
-void AP_MotorsHeli_RSC::update(DesiredRSCSpoolState desired_spool_state)
+AP_MotorsHeli_RSC::RSCSpoolState AP_MotorsHeli_RSC::update(DesiredRSCSpoolState desired_spool_state)
 {
     // set desired spool state
     _desired_spool_state = desired_spool_state;
@@ -452,13 +452,79 @@ void AP_MotorsHeli_RSC::update(DesiredRSCSpoolState desired_spool_state)
     // update rotor speed run-up estimate
     update_rotor_runup(dt);
 
+    update_spool_state(desired_spool_state);
+
     if (_power_slewrate > 0) {
         // implement slew rate for throttle
         float max_delta = dt * _power_slewrate * 0.01f;
         _control_output = constrain_float(_control_output, last_control_output-max_delta, last_control_output+max_delta);
     }
+    return _spool_state;
 
 }
+
+
+void AP_MotorsHeli_RSC::update_spool_state(DesiredRSCSpoolState _spool_desired)
+{
+    switch (_spool_state) {
+        case RSCSpoolState::SHUT_DOWN:
+            // Motors should be stationary.
+            // make sure the motors are spooling in the correct direction
+            if (_spool_desired != DesiredRSCSpoolState::SHUT_DOWN) {
+                _spool_state = RSCSpoolState::GROUND_IDLE;
+                break;
+            }
+
+            break;
+
+        case RSCSpoolState::GROUND_IDLE: {
+            // Motors should be stationary or at ground idle.
+            if (_spool_desired == DesiredRSCSpoolState::SHUT_DOWN){
+                _spool_state = RSCSpoolState::SHUT_DOWN;
+            } else if(_spool_desired == DesiredRSCSpoolState::THROTTLE_UNLIMITED) {
+                _spool_state = RSCSpoolState::SPOOLING_UP;
+            } else {    // _spool_desired == GROUND_IDLE
+
+            }
+
+            break;
+        }
+        case RSCSpoolState::SPOOLING_UP:
+            // Maximum throttle should move from minimum to maximum.
+            // make sure the motors are spooling in the correct direction
+            if (_spool_desired != DesiredRSCSpoolState::THROTTLE_UNLIMITED ){
+                _spool_state = RSCSpoolState::SPOOLING_DOWN;
+                break;
+            }
+
+            if (_runup_complete){
+                _spool_state = RSCSpoolState::THROTTLE_UNLIMITED;
+            }
+            break;
+
+        case RSCSpoolState::THROTTLE_UNLIMITED:
+            // Throttle should exhibit normal flight behavior.
+            // make sure the motors are spooling in the correct direction
+            if (_spool_desired != DesiredRSCSpoolState::THROTTLE_UNLIMITED && !rotor_speed_above_critical()) {
+                _spool_state = RSCSpoolState::SPOOLING_DOWN;
+                break;
+            }
+
+            break;
+
+        case RSCSpoolState::SPOOLING_DOWN:
+            // make sure the motors are spooling in the correct direction
+            if (_spool_desired == DesiredRSCSpoolState::THROTTLE_UNLIMITED) {
+                _spool_state = RSCSpoolState::SPOOLING_UP;
+                break;
+            }
+            if (_spooldown_complete){
+                _spool_state = RSCSpoolState::GROUND_IDLE;
+            }
+            break;
+    }
+}
+
 
 // update_rotor_ramp - slews rotor output scalar between 0 and 1, outputs float scalar to _rotor_ramp_output
 void AP_MotorsHeli_RSC::update_rotor_ramp(float rotor_ramp_input, float dt)

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -242,7 +242,7 @@ void AP_MotorsHeli_RSC::initialize()
 void AP_MotorsHeli_RSC::configure()
 {
 
-    set_control_mode(static_cast<RotorControlMode>(_rsc_mode.get()));
+    set_rsc_control_mode(static_cast<RotorControlMode>(_rsc_mode.get()));
     set_ramp_time(_ramp_time.get());
     set_runup_time(_runup_time.get());
     set_critical_speed(_critical_speed.get());
@@ -254,7 +254,7 @@ void AP_MotorsHeli_RSC::configure()
 // configure - configure the RSC with specific settings, allows caller to specify settings instead of using parameters.
 void AP_MotorsHeli_RSC::configure(RotorControlMode control_mode, int8_t ramp_time, int8_t runup_time, float critical_speed, float idle_output)
 {
-    set_control_mode(control_mode);
+    set_rsc_control_mode(control_mode);
     set_ramp_time(ramp_time);
     set_runup_time(runup_time);
     set_critical_speed(critical_speed);
@@ -268,21 +268,21 @@ void AP_MotorsHeli_RSC::configure_armed()
 {
 
     // set desired speed for each control mode
-    switch(_control_mode) {
+    switch (_rsc_control_mode) {
     case ROTOR_CONTROL_MODE_PASSTHROUGH:
         // passthrough mode uses the pilot's desired speed directly as the control output, so set the desired speed to the pilot's input
-        _desired_speed = _pilot_desired_speed;
+        _desired_rotor_speed = _passthru_desired_rotor_speed;
         break;
     case ROTOR_CONTROL_MODE_SETPOINT:
-        _desired_speed = _rsc_setpoint.get() * 0.01f;
+        _desired_rotor_speed = _rsc_setpoint.get() * 0.01f;
         break;
     case ROTOR_CONTROL_MODE_THROTTLECURVE:
     case ROTOR_CONTROL_MODE_AUTOTHROTTLE:
         // throttle curve and autothrottle both use the pilot's desired speed as the input to the throttle curve, so set the desired speed to the pilot's input
-        _desired_speed = 1.0f;
+        _desired_rotor_speed = 1.0f;
         break;
     default:
-        _desired_speed = 0.0f;
+        _desired_rotor_speed = 0.0f;
         break;
     }
 
@@ -291,7 +291,7 @@ void AP_MotorsHeli_RSC::configure_armed()
         set_throttle_curve();
     }
     // keeps user from changing RSC mode while armed
-    if (_rsc_mode.get() != get_control_mode()) {
+    if (_rsc_mode.get() != get_rsc_control_mode()) {
         reset_rsc_mode_param();
         _save_rsc_mode = true;
     }
@@ -436,14 +436,14 @@ AP_MotorsHeli_RSC::RSCSpoolState AP_MotorsHeli_RSC::update(DesiredRSCSpoolState 
         // if turbine engine started without using start sequence, set starting flag just to be sure it can't be triggered when back in idle
         _starting = false;
 
-        if ((_control_mode == ROTOR_CONTROL_MODE_PASSTHROUGH) || (_control_mode == ROTOR_CONTROL_MODE_SETPOINT)) {
+        if ((_rsc_control_mode == ROTOR_CONTROL_MODE_PASSTHROUGH) || (_rsc_control_mode == ROTOR_CONTROL_MODE_SETPOINT)) {
             // set control rotor speed to ramp slewed value between idle and desired speed
-            _control_output = _idle_throttle + (_rotor_ramp_output * (_desired_speed - _idle_throttle));
-        } else if (_control_mode == ROTOR_CONTROL_MODE_THROTTLECURVE) {
+            _control_output = _idle_throttle + (_rotor_ramp_output * (_desired_rotor_speed - _idle_throttle));
+        } else if (_rsc_control_mode == ROTOR_CONTROL_MODE_THROTTLECURVE) {
             // throttle output from throttle curve based on collective position
             float throttlecurve = calculate_throttlecurve(_collective_in);
             _control_output = _idle_throttle + (_rotor_ramp_output * (throttlecurve - _idle_throttle));
-        } else if (_control_mode == ROTOR_CONTROL_MODE_AUTOTHROTTLE) {
+        } else if (_rsc_control_mode == ROTOR_CONTROL_MODE_AUTOTHROTTLE) {
             autothrottle_run();
         }
         break;
@@ -463,7 +463,7 @@ AP_MotorsHeli_RSC::RSCSpoolState AP_MotorsHeli_RSC::update(DesiredRSCSpoolState 
 
 }
 
-
+// update_spool_state - updates the spool state machine based on the desired spool state and current spool state
 void AP_MotorsHeli_RSC::update_spool_state(DesiredRSCSpoolState _spool_desired)
 {
     switch (_spool_state) {
@@ -586,13 +586,13 @@ void AP_MotorsHeli_RSC::update_rotor_runup(float dt)
     // update run-up complete flag
 
     // if control mode is disabled, then run-up complete always returns true
-    if ( _control_mode == ROTOR_CONTROL_MODE_DISABLED ) {
+    if ( _rsc_control_mode == ROTOR_CONTROL_MODE_DISABLED ) {
         _runup_complete = true;
         return;
     }
 
     // if rotor ramp and runup are both at full speed, then run-up has been completed
-    if (!_runup_complete && (_rotor_ramp_output >= 1.0f) && (_rotor_runup_output >= 1.0f) && (_control_mode == ROTOR_CONTROL_MODE_AUTOTHROTTLE ? _governor_engage : true)) {
+    if (!_runup_complete && (_rotor_ramp_output >= 1.0f) && (_rotor_runup_output >= 1.0f) && (_rsc_control_mode == ROTOR_CONTROL_MODE_AUTOTHROTTLE ? _governor_engage : true)) {
         _runup_complete = true;
         GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Runup Complete");
     }
@@ -613,7 +613,7 @@ void AP_MotorsHeli_RSC::update_rotor_runup(float dt)
 // servo_out parameter is of the range 0 ~ 1
 void AP_MotorsHeli_RSC::write_rsc(float servo_out)
 {
-    if (_control_mode == ROTOR_CONTROL_MODE_DISABLED) {
+    if (_rsc_control_mode == ROTOR_CONTROL_MODE_DISABLED) {
         // do not do servo output to avoid conflicting with other output on the channel
         // ToDo: We should probably use RC_Channel_Aux to avoid this problem
         return;
@@ -625,7 +625,7 @@ void AP_MotorsHeli_RSC::write_rsc(float servo_out)
 // Return mask of output channels which the RSC is outputting on
 uint32_t AP_MotorsHeli_RSC::get_output_mask() const
 {
-    if (_control_mode == ROTOR_CONTROL_MODE_DISABLED) {
+    if (_rsc_control_mode == ROTOR_CONTROL_MODE_DISABLED) {
         return 0;
     }
     return SRV_Channels::get_output_channel_mask(_aux_fn);
@@ -753,7 +753,7 @@ void AP_MotorsHeli_RSC::write_log(void) const
                         "QBfffffB",
                         AP_HAL::micros64(),
                         _instance,
-                        get_desired_speed(),
+                        get_desired_rotor_speed(),
                         _rotor_runup_output,
                         _governor_output,
                         get_control_output(),

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -238,17 +238,12 @@ void AP_MotorsHeli_RSC::initialize()
 
 }
 
-// configure - configure the RSC.
+// configure - configure the RSC using current parameters
 void AP_MotorsHeli_RSC::configure()
 {
 
-    set_rsc_control_mode((RotorControlMode)(_rsc_mode.get()));
-    set_ramp_time(_ramp_time.get());
-    set_runup_time(_runup_time.get());
-    set_critical_speed(_critical_speed.get());
-    set_idle_output(_idle_output.get());
+    configure((RotorControlMode)(_rsc_mode.get()), _ramp_time.get(), _runup_time.get(), _critical_speed.get(), _idle_output.get());
 
-    configure_armed();
 }
 
 // configure - configure the RSC with specific settings, allows caller to specify settings instead of using parameters.

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -242,7 +242,7 @@ void AP_MotorsHeli_RSC::initialize()
 void AP_MotorsHeli_RSC::configure()
 {
 
-    set_rsc_control_mode(static_cast<RotorControlMode>(_rsc_mode.get()));
+    set_rsc_control_mode((RotorControlMode)(_rsc_mode.get()));
     set_ramp_time(_ramp_time.get());
     set_runup_time(_runup_time.get());
     set_critical_speed(_critical_speed.get());
@@ -291,13 +291,15 @@ void AP_MotorsHeli_RSC::configure_armed()
     if (_rsc_mode.get() == ROTOR_CONTROL_MODE_THROTTLECURVE || _rsc_mode.get() == ROTOR_CONTROL_MODE_AUTOTHROTTLE) {
         set_throttle_curve();
     }
+
     // keeps user from changing RSC mode while armed
     if (_rsc_mode.get() != get_rsc_control_mode()) {
         reset_rsc_mode_param();
         _save_rsc_mode = true;
     }
+
     // saves rsc mode parameter when disarmed if it had been reset while armed
-    if (_save_rsc_mode && _desired_spool_state != DesiredRSCSpoolState::SHUT_DOWN) {
+    if (_save_rsc_mode && _desired_spool_state == DesiredRSCSpoolState::SHUT_DOWN) {
         _rsc_mode.save();
         _save_rsc_mode = false;
     }
@@ -332,8 +334,6 @@ AP_MotorsHeli_RSC::RSCSpoolState AP_MotorsHeli_RSC::update(DesiredRSCSpoolState 
 
     // set desired spool state
     _desired_spool_state = desired_spool_state;
-
-    configure_armed();
 
     // _rotor_RPM available to the RSC output
 #if AP_RPM_ENABLED

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -55,44 +55,17 @@ public:
     // update - runs RSC logic and outputs to motors, returns current spool state for use in motor output logic
     RSCSpoolState        update(DesiredRSCSpoolState desired_spool_state);
 
-    void     update_spool_state(DesiredRSCSpoolState desired_spool_state);
-
-// output_to_servo - outputs pwm onto output rsc channel.
+    // output_to_servo - outputs pwm onto output rsc channel.
     void        output_to_servo() { write_rsc(_control_output);}
 
-    // set_control_mode - sets control mode
-    void        set_control_mode(RotorControlMode mode) { _control_mode = mode; }
+    // get_rsc_control_mode - gets RSC control mode
+    uint8_t     get_rsc_control_mode() const { return _rsc_control_mode; }
 
-    // reset_rsc_mode_param - resets rsc mode param to current control mode
-    void        reset_rsc_mode_param() { _rsc_mode.set((uint8_t)_control_mode); }
+    // get_desired_rotor_speed
+    float       get_desired_rotor_speed() const { return _desired_rotor_speed; }
 
-    // get_control_mode - gets control mode
-    uint8_t     get_control_mode() const { return _control_mode; }
-
-    // set_critical_speed
-    void        set_critical_speed(float critical_speed) { _critical_speed.set(critical_speed); }
-
-    // get_desired_speed
-    float       get_desired_speed() const { return _desired_speed; }
-
-    // set_desired_speed - this requires input to be 0-1
-    void        set_passthrough_desired_speed(float desired_speed) { _pilot_desired_speed = desired_speed; }
-
-    // functions for autothrottle, throttle curve, governor, idle speed, output to servo
-    void        set_governor_output(float governor_output) {_governor_output = governor_output; }
-    void        governor_reset();
-    float       get_control_output() const { return _control_output; }
-    void        set_idle_output(float idle_output) { _idle_output.set(idle_output); }
-    void        autothrottle_run();
-    void        set_throttle_curve();
-
-    // functions for ramp and runup timers, runup_complete flag
-    void        set_ramp_time(int8_t ramp_time) { _ramp_time.set(ramp_time); }
-    void        set_runup_time(int8_t runup_time) { _runup_time.set(runup_time); }
-    bool        is_runup_complete() const { return _runup_complete; }
-
-    // is_spooldown_complete
-    bool        is_spooldown_complete() const { return _spooldown_complete; }
+    // set_passthru_desired_rotor_speed - this requires input to be 0-1
+    void        set_passthru_desired_rotor_speed(float desired_rotor_speed) { _passthru_desired_rotor_speed = desired_rotor_speed; }
 
     // set_collective. collective for throttle curve calculation
     void        set_collective(float collective) { _collective_in = collective; }
@@ -105,9 +78,6 @@ public:
 
     // Return mask of output channels which the RSC is outputting on
     uint32_t    get_output_mask() const;
-
-    // rotor_speed_above_critical - return true if rotor speed is above that critical for flight
-    bool        rotor_speed_above_critical(void) const { return _rotor_runup_output >= get_critical_speed(); }
 
 #if HAL_LOGGING_ENABLED
     // RSC logging
@@ -128,21 +98,60 @@ public:
     AP_Int16        _idle_output;             // Rotor control output while at idle
 
 private:
+
+    // update_spool_state - updates the spool state machine based on the desired spool state and current spool state
+    void            update_spool_state(DesiredRSCSpoolState desired_spool_state);
+
+    // set_rsc_control_mode - sets RSC control mode
+    void            set_rsc_control_mode(RotorControlMode mode) { _rsc_control_mode = mode; }
+
+    // reset_rsc_mode_param - resets rsc mode param to current control mode
+    void            reset_rsc_mode_param() { _rsc_mode.set((uint8_t)_rsc_control_mode); }
+
+    // set_critical_speed
+    void            set_critical_speed(float critical_speed) { _critical_speed.set(critical_speed); }
+
+    // functions for autothrottle, throttle curve, governor, idle speed, output to servo
+    void            set_governor_output(float governor_output) {_governor_output = governor_output; }
+    void            governor_reset();
+    float           get_control_output() const { return _control_output; }
+    void            set_idle_output(float idle_output) { _idle_output.set(idle_output); }
+    void            autothrottle_run();
+    void            set_throttle_curve();
+
+    // functions for ramp and runup timers
+    void            set_ramp_time(int8_t ramp_time) { _ramp_time.set(ramp_time); }
+    void            set_runup_time(int8_t runup_time) { _runup_time.set(runup_time); }
+
+    // update_rotor_ramp - slews rotor output scalar between 0 and 1, outputs float scalar to _rotor_ramp_output
+    void            update_rotor_ramp(float rotor_ramp_input, float dt);
+
+    // update_rotor_runup - function to slew rotor runup scalar, outputs float scalar to _rotor_runup_ouptut
+    void            update_rotor_runup(float dt);
+
+    // write_rsc - outputs pwm onto output rsc channel. servo_out parameter is of the range 0 ~ 1
+    void            write_rsc(float servo_out);
+
+    // calculate_throttlecurve - uses throttle curve and collective input to determine throttle setting
+    float           calculate_throttlecurve(float collective_in);
+
+    // rotor_speed_above_critical - return true if rotor speed is above that critical for flight
+    bool        rotor_speed_above_critical(void) const { return _rotor_runup_output >= get_critical_speed(); }
+
     uint64_t        _last_update_us;
     const uint8_t   _instance;
 
     // channel setup for aux function
     const SRV_Channel::Function _aux_fn;
-    const uint8_t _default_channel;
+    const uint8_t  _default_channel;
 
     RSCSpoolState          _spool_state;               // current spool state
-    DesiredRSCSpoolState   _desired_spool_state;
-
+    DesiredRSCSpoolState   _desired_spool_state;       // desired spool state
 
     // internal variables
-    RotorControlMode _control_mode = ROTOR_CONTROL_MODE_DISABLED;   // motor control mode, Passthrough or Setpoint
-    float           _pilot_desired_speed;         // latest pilot desired rotor speed, used for passthrough mode
-    float           _desired_speed;               // latest desired rotor speed
+    RotorControlMode _rsc_control_mode = ROTOR_CONTROL_MODE_DISABLED;   // RSC control mode, Passthrough, Setpoint, Throttle Curve or Autothrottle
+    float           _passthru_desired_rotor_speed;// latest pilot desired rotor speed, used for passthrough mode
+    float           _desired_rotor_speed;         // latest desired rotor speed
     float           _control_output;              // latest logic controlled output
     float           _rotor_ramp_output;           // scalar used to ramp rotor speed between _rsc_idle_output and full speed (0.0-1.0f)
     float           _rotor_runup_output;          // scalar used to store status of rotor run-up time (0.0-1.0f)
@@ -163,19 +172,6 @@ private:
     float           _idle_throttle;               // current idle throttle setting
     bool            _save_rsc_mode;               // flag to determine if we should save RSC mode changes to EEPROM, used to prevent saving changes to RSC mode param while armed.
 
-
-    // update_rotor_ramp - slews rotor output scalar between 0 and 1, outputs float scalar to _rotor_ramp_output
-    void            update_rotor_ramp(float rotor_ramp_input, float dt);
-
-    // update_rotor_runup - function to slew rotor runup scalar, outputs float scalar to _rotor_runup_ouptut
-    void            update_rotor_runup(float dt);
-
-    // write_rsc - outputs pwm onto output rsc channel. servo_out parameter is of the range 0 ~ 1
-    void            write_rsc(float servo_out);
-
-    // calculate_throttlecurve - uses throttle curve and collective input to determine throttle setting
-    float           calculate_throttlecurve(float collective_in);
-
     // parameters
     AP_Int16        _power_slewrate;            // throttle slew rate (percentage per second)
     AP_Int16        _thrcrv[5];                 // throttle value sent to throttle servo at 0, 25, 50, 75 and 100 percent collective
@@ -188,9 +184,9 @@ private:
     AP_Int16        _cooldown_time;             // cooldown time to provide a fast idle
 
     // parameter accessors to allow conversions
-    float       get_critical_speed() const { return _critical_speed * 0.01; }
-    float       get_idle_output() const { return _idle_output * 0.01; }
-    float       get_governor_torque() const { return _governor_torque * 0.01; }
-    float       get_governor_compensator() const { return _governor_compensator * 0.000001; }
+    float           get_critical_speed() const { return _critical_speed * 0.01; }
+    float           get_idle_output() const { return _idle_output * 0.01; }
+    float           get_governor_torque() const { return _governor_torque * 0.01; }
+    float           get_governor_compensator() const { return _governor_compensator * 0.000001; }
 
 };

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -32,15 +32,43 @@ public:
         AP_Param::setup_object_defaults(this, var_info);
     };
 
-    // rotor controller states
-    enum class RotorControlState {
-        STOP = 0,
-        IDLE,
-        ACTIVE
+    // desired spool states
+    enum class DesiredRSCSpoolState : uint8_t {
+        SHUT_DOWN = 0,              // all motors should move to stop
+        GROUND_IDLE = 1,            // all motors should move to ground idle
+        THROTTLE_UNLIMITED = 2,     // motors should move to being a state where throttle is unconstrained (e.g. by start up procedure)
     };
 
-    // init_servo - servo initialization on start-up
-    void        init_servo();
+    // spool states
+    enum class RSCSpoolState : uint8_t {
+        SHUT_DOWN = 0,                      // all motors stop
+        GROUND_IDLE = 1,                    // all motors at ground idle
+        SPOOLING_UP = 2,                       // increasing maximum throttle while stabilizing
+        THROTTLE_UNLIMITED = 3,             // throttle is no longer constrained by start up procedure
+        SPOOLING_DOWN = 4,                     // decreasing maximum throttle while stabilizing
+    };
+
+    // initialize - servo initialization and parameter setup on start-up
+    void        initialize();
+
+    // configure - configures RSC for current control mode, should be called on each update of control mode and on start-up after initialize() to setup parameters and scalars for the current control mode
+    void        configure();
+
+    // configure - configure the RSC with specific settings, allows caller to specify settings instead of using parameters.
+    void        configure(RotorControlMode control_mode,
+                          int8_t ramp_time,
+                          int8_t runup_time,
+                          float critical_speed,
+                          float idle_output);
+
+    // configure - configures the parameters for the armed state, should be called on each update of control mode and on start-up after initialize() to setup parameters and scalars for the current control mode
+    void        configure_armed();
+
+    // update - runs RSC logic and outputs to motors, returns current spool state for use in motor output logic
+    void        update(DesiredRSCSpoolState desired_spool_state);
+
+    // output_to_servo - outputs pwm onto output rsc channel.
+    void        output_to_servo() { write_rsc(_control_output);}
 
     // set_control_mode - sets control mode
     void        set_control_mode(RotorControlMode mode) { _control_mode = mode; }
@@ -58,7 +86,7 @@ public:
     float       get_desired_speed() const { return _desired_speed; }
 
     // set_desired_speed - this requires input to be 0-1
-    void        set_desired_speed(float desired_speed) { _desired_speed = desired_speed; }
+    void        set_passthrough_desired_speed(float desired_speed) { _pilot_desired_speed = desired_speed; }
 
     // functions for autothrottle, throttle curve, governor, idle speed, output to servo
     void        set_governor_output(float governor_output) {_governor_output = governor_output; }
@@ -84,9 +112,6 @@ public:
 
     // turbine start initialize sequence
     void        set_turbine_start(bool turbine_start) {_turbine_start = turbine_start; }
-
-    // output - update value to send to ESC/Servo
-    void        output(RotorControlState state);
 
     // Return mask of output channels which the RSC is outputting on
     uint32_t    get_output_mask() const;
@@ -120,9 +145,14 @@ private:
     const SRV_Channel::Function _aux_fn;
     const uint8_t _default_channel;
 
+    RSCSpoolState          _spool_state;               // current spool state
+    DesiredRSCSpoolState   _desired_spool_state;
+
+
     // internal variables
     RotorControlMode _control_mode = ROTOR_CONTROL_MODE_DISABLED;   // motor control mode, Passthrough or Setpoint
-    float           _desired_speed;               // latest desired rotor speed from pilot
+    float           _pilot_desired_speed;         // latest pilot desired rotor speed, used for passthrough mode
+    float           _desired_speed;               // latest desired rotor speed
     float           _control_output;              // latest logic controlled output
     float           _rotor_ramp_output;           // scalar used to ramp rotor speed between _rsc_idle_output and full speed (0.0-1.0f)
     float           _rotor_runup_output;          // scalar used to store status of rotor run-up time (0.0-1.0f)
@@ -141,8 +171,8 @@ private:
     uint8_t         _governor_fault_count;        // variable for tracking governor speed sensor faults
     float           _governor_torque_reference;   // governor reference for load calculations
     float           _idle_throttle;               // current idle throttle setting
+    bool            _save_rsc_mode;               // flag to determine if we should save RSC mode changes to EEPROM, used to prevent saving changes to RSC mode param while armed.
 
-    RotorControlState _rsc_state;
 
     // update_rotor_ramp - slews rotor output scalar between 0 and 1, outputs float scalar to _rotor_ramp_output
     void            update_rotor_ramp(float rotor_ramp_input, float dt);

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -65,9 +65,11 @@ public:
     void        configure_armed();
 
     // update - runs RSC logic and outputs to motors, returns current spool state for use in motor output logic
-    void        update(DesiredRSCSpoolState desired_spool_state);
+    RSCSpoolState        update(DesiredRSCSpoolState desired_spool_state);
 
-    // output_to_servo - outputs pwm onto output rsc channel.
+    void     update_spool_state(DesiredRSCSpoolState desired_spool_state);
+
+// output_to_servo - outputs pwm onto output rsc channel.
     void        output_to_servo() { write_rsc(_control_output);}
 
     // set_control_mode - sets control mode

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -6,6 +6,7 @@
 #include <SRV_Channel/SRV_Channel.h>
 #include <AP_Logger/AP_Logger_config.h>
 #include <AC_Autorotation/RSC_Autorotation.h>
+#include "AP_Motors_Class.h"
 
 // rotor control modes
 enum RotorControlMode {
@@ -32,21 +33,8 @@ public:
         AP_Param::setup_object_defaults(this, var_info);
     };
 
-    // desired spool states
-    enum class DesiredRSCSpoolState : uint8_t {
-        SHUT_DOWN = 0,              // all motors should move to stop
-        GROUND_IDLE = 1,            // all motors should move to ground idle
-        THROTTLE_UNLIMITED = 2,     // motors should move to being a state where throttle is unconstrained (e.g. by start up procedure)
-    };
-
-    // spool states
-    enum class RSCSpoolState : uint8_t {
-        SHUT_DOWN = 0,                      // all motors stop
-        GROUND_IDLE = 1,                    // all motors at ground idle
-        SPOOLING_UP = 2,                       // increasing maximum throttle while stabilizing
-        THROTTLE_UNLIMITED = 3,             // throttle is no longer constrained by start up procedure
-        SPOOLING_DOWN = 4,                     // decreasing maximum throttle while stabilizing
-    };
+    using DesiredRSCSpoolState = AP_Motors::DesiredSpoolState;
+    using RSCSpoolState = AP_Motors::SpoolState;
 
     // initialize - servo initialization and parameter setup on start-up
     void        initialize();

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -100,7 +100,7 @@ public:
 private:
 
     // update_spool_state - updates the spool state machine based on the desired spool state and current spool state
-    void            update_spool_state(DesiredRSCSpoolState desired_spool_state);
+    void            update_spool_state();
 
     // set_rsc_control_mode - sets RSC control mode
     void            set_rsc_control_mode(RotorControlMode mode) { _rsc_control_mode = mode; }
@@ -136,7 +136,7 @@ private:
     float           calculate_throttlecurve(float collective_in);
 
     // rotor_speed_above_critical - return true if rotor speed is above that critical for flight
-    bool        rotor_speed_above_critical(void) const { return _rotor_runup_output >= get_critical_speed(); }
+    bool            rotor_speed_above_critical(void) const { return _rotor_runup_output >= get_critical_speed(); }
 
     uint64_t        _last_update_us;
     const uint8_t   _instance;

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -282,7 +282,7 @@ AP_Motors::SpoolState AP_MotorsHeli_Single::update_motor_control(AP_MotorsHeli_R
     // Check if rotors are run-up
     set_rotor_runup_complete(main_rotor_state == AP_MotorsHeli_RSC::RSCSpoolState::THROTTLE_UNLIMITED);
 
-    return convert_spool_state(main_rotor_state);
+    return main_rotor_state;
 
 }
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -265,11 +265,11 @@ uint32_t AP_MotorsHeli_Single::get_motor_mask()
 }
 
 // update_motor_controls - sends commands to motor controllers
-void AP_MotorsHeli_Single::update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state)
+AP_Motors::SpoolState AP_MotorsHeli_Single::update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state)
 {
     // Send state update to motors
     _tail_rotor.update(state);
-    _main_rotor.update(state);
+    AP_MotorsHeli_RSC::RSCSpoolState main_rotor_state = _main_rotor.update(state);
 
     if (state == AP_MotorsHeli_RSC::DesiredRSCSpoolState::SHUT_DOWN){
         // set engine run enable aux output to not run position to kill engine when disarmed
@@ -278,12 +278,12 @@ void AP_MotorsHeli_Single::update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpo
         // else if armed, set engine run enable output to run position
         SRV_Channels::set_output_limit(SRV_Channel::k_engine_run_enable, SRV_Channel::Limit::MAX);
     }
+    
+    // Check if rotors are run-up
+    set_rotor_runup_complete(main_rotor_state == AP_MotorsHeli_RSC::RSCSpoolState::THROTTLE_UNLIMITED);
 
-    // Check if both rotors are run-up, tail rotor controller always returns true if not enabled
-    set_rotor_runup_complete(_main_rotor.is_runup_complete() && _tail_rotor.is_runup_complete());
+    return convert_spool_state(main_rotor_state);
 
-    // Check if both rotors are spooled down, tail rotor controller always returns true if not enabled
-    _heliflags.rotor_spooldown_complete = ( _main_rotor.is_spooldown_complete() );
 }
 
 //

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -279,7 +279,9 @@ AP_Motors::SpoolState AP_MotorsHeli_Single::update_motor_control(AP_MotorsHeli_R
         SRV_Channels::set_output_limit(SRV_Channel::k_engine_run_enable, SRV_Channel::Limit::MAX);
     }
     
-    // Check if rotors are run-up
+    // Check if main rotor is run-up complete.  Tail rotor run-up is not included in check because currently
+    // the tail rotor in DDVP uses the same ramp and runup time as the main rotor.  This may need changed if 
+    // the RSC is used for DDFP tail rotors.
     set_rotor_runup_complete(main_rotor_state == AP_MotorsHeli_RSC::RSCSpoolState::THROTTLE_UNLIMITED);
 
     return main_rotor_state;

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -192,7 +192,7 @@ void AP_MotorsHeli_Single::init_outputs()
         add_motor_num(CH_4);
 
         // initialize main rotor servo
-        _main_rotor.init_servo();
+        _main_rotor.initialize();
 
         switch (get_tail_type()) {
             case TAIL_TYPE::DIRECTDRIVE_FIXEDPITCH_CW:
@@ -203,7 +203,7 @@ void AP_MotorsHeli_Single::init_outputs()
 
             case TAIL_TYPE::DIRECTDRIVE_VARPITCH:
             case TAIL_TYPE::DIRECTDRIVE_VARPIT_EXT_GOV:
-                _tail_rotor.init_servo();
+                _tail_rotor.initialize();
                 // yaw servo is an angle from -4500 to 4500
                 SRV_Channels::set_angle(SRV_Channel::k_motor4, YAW_SERVO_MAX_ANGLE);
                 break;
@@ -217,34 +217,6 @@ void AP_MotorsHeli_Single::init_outputs()
     }
 
     set_initialised_ok(_frame_class == MOTOR_FRAME_HELI);
-}
-
-// set_desired_rotor_speed
-void AP_MotorsHeli_Single::set_desired_rotor_speed(float desired_speed)
-{
-    _main_rotor.set_desired_speed(desired_speed);
-
-    // always send desired speed to tail rotor control, will do nothing if not DDVP not enabled
-    _tail_rotor.set_desired_speed(_direct_drive_tailspeed*0.01f);
-}
-
-// calculate_scalars - recalculates various scalers used.
-void AP_MotorsHeli_Single::calculate_armed_scalars()
-{
-    // Set rsc mode specific parameters
-    if (_main_rotor._rsc_mode.get() == ROTOR_CONTROL_MODE_THROTTLECURVE || _main_rotor._rsc_mode.get() == ROTOR_CONTROL_MODE_AUTOTHROTTLE) {
-        _main_rotor.set_throttle_curve();
-    }
-    // keeps user from changing RSC mode while armed
-    if (_main_rotor._rsc_mode.get() != _main_rotor.get_control_mode()) {
-        _main_rotor.reset_rsc_mode_param();
-        _heliflags.save_rsc_mode = true;
-    }
-    // saves rsc mode parameter when disarmed if it had been reset while armed
-    if (_heliflags.save_rsc_mode && !armed()) {
-        _main_rotor._rsc_mode.save();
-        _heliflags.save_rsc_mode = false;
-    }
 }
 
 // calculate_scalars - recalculates various scalers used.
@@ -274,23 +246,14 @@ void AP_MotorsHeli_Single::calculate_scalars()
     // configure swashplate and update scalars
     _swashplate.configure();
 
-    // send setpoints to main rotor controller and trigger recalculation of scalars
-    _main_rotor.set_control_mode(static_cast<RotorControlMode>(_main_rotor._rsc_mode.get()));
-    calculate_armed_scalars();
+    // configure main rotor and update scalars
+    _main_rotor.configure();
 
     // send setpoints to DDVP rotor controller and trigger recalculation of scalars
     if (use_tail_RSC()) {
-        _tail_rotor.set_control_mode(ROTOR_CONTROL_MODE_SETPOINT);
-        _tail_rotor.set_ramp_time(_main_rotor._ramp_time.get());
-        _tail_rotor.set_runup_time(_main_rotor._runup_time.get());
-        _tail_rotor.set_critical_speed(_main_rotor._critical_speed.get());
-        _tail_rotor.set_idle_output(_main_rotor._idle_output.get());
+        _tail_rotor.configure(ROTOR_CONTROL_MODE_SETPOINT, _main_rotor._ramp_time.get(), _main_rotor._runup_time.get(), _main_rotor._critical_speed.get(), _main_rotor._idle_output.get());
     } else {
-        _tail_rotor.set_control_mode(ROTOR_CONTROL_MODE_DISABLED);
-        _tail_rotor.set_ramp_time(0);
-        _tail_rotor.set_runup_time(0);
-        _tail_rotor.set_critical_speed(0);
-        _tail_rotor.set_idle_output(0);
+        _tail_rotor.configure(ROTOR_CONTROL_MODE_DISABLED, 0, 0, 0, 0);
     }
 }
 
@@ -302,13 +265,13 @@ uint32_t AP_MotorsHeli_Single::get_motor_mask()
 }
 
 // update_motor_controls - sends commands to motor controllers
-void AP_MotorsHeli_Single::update_motor_control(AP_MotorsHeli_RSC::RotorControlState state)
+void AP_MotorsHeli_Single::update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state)
 {
     // Send state update to motors
-    _tail_rotor.output(state);
-    _main_rotor.output(state);
+    _tail_rotor.update(state);
+    _main_rotor.update(state);
 
-    if (state == AP_MotorsHeli_RSC::RotorControlState::STOP){
+    if (state == AP_MotorsHeli_RSC::DesiredRSCSpoolState::SHUT_DOWN){
         // set engine run enable aux output to not run position to kill engine when disarmed
         SRV_Channels::set_output_limit(SRV_Channel::k_engine_run_enable, SRV_Channel::Limit::MIN);
     } else {
@@ -443,7 +406,8 @@ void AP_MotorsHeli_Single::output_to_motors()
     _swashplate.output();
 
     // Output main rotor
-    update_motor_control(get_rotor_control_state());
+    _main_rotor.output_to_servo();
+    _tail_rotor.output_to_servo();
 
     // Output tail rotor
     switch (get_tail_type()) {

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.h
@@ -70,7 +70,7 @@ protected:
     void init_outputs() override;
 
     // update_motor_controls - sends commands to motor controllers
-    void update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state) override;
+    AP_Motors::SpoolState update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state) override;
 
     // heli_move_actuators - moves swash plate and tail rotor
     void move_actuators(float roll_out, float pitch_out, float coll_in, float yaw_out) override;

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.h
@@ -40,14 +40,8 @@ public:
     // output_to_motors - sends values out to the motors
     void output_to_motors() override;
 
-    // set_desired_rotor_speed - sets target rotor speed as a number from 0 ~ 1
-    void set_desired_rotor_speed(float desired_speed) override;
-
     // calculate_scalars - recalculates various scalars used
     void calculate_scalars() override;
-
-    // calculate_armed_scalars - recalculates scalars that can change while armed
-    void calculate_armed_scalars() override;
 
     // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
@@ -76,7 +70,7 @@ protected:
     void init_outputs() override;
 
     // update_motor_controls - sends commands to motor controllers
-    void update_motor_control(AP_MotorsHeli_RSC::RotorControlState state) override;
+    void update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state) override;
 
     // heli_move_actuators - moves swash plate and tail rotor
     void move_actuators(float roll_out, float pitch_out, float coll_in, float yaw_out) override;


### PR DESCRIPTION
## Summary

This PR removes RSC calls from the heli frames and puts as much of it into the RSC library. 

## Testing 

- [X] Checked by a human programmer
- [x] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

This is a pretty big rework of the Rotor Speed Controller.  It mainly affects how the heli frames interact with the RSC library.  The calls to the library were reduced to the following
initialize - initializes the servo
configure - sets the parameters that could affect the RSC operation for both unarmed state and armed state
update - updates the RSC parameters that allowed to be updated when the aircraft is armed. Conducts all calculations of the rotor state and control output
output_to_motors - writes the control output to the motor

The setpoint being set from the copter codebase was removed and is set internally to the RSC.  Only the passthrough mode value is not passed

The control mode was switched to desired spool state which is now passed to the RSC
the update method passes back the spool state rather than spool state being determined in output logic.  This removes the use of run up complete and spool down complete calls outside of RSC and keeps the spool state decision within the RSC.

