### PR TITLE
AP_TECS: document all logged flag bits

### DIFF
--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -1376,7 +1376,7 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
         // @Field: pmax: pitch upper limit
         // @Field: dspdem: demanded acceleration output ("delta-speed demand")
         // @Field: f: flags
-        // @FieldBits: f: Underspeed,UnachievableDescent,AutoLanding,ReachedTakeoffSpd
+        // @FieldBits: f: Underspeed,UnachievableDescent,AutoLanding,ReachedTakeoffSpd,GlidingRequested,isGliding,PropulsionFailed,Reset
         AP::logger().WriteStreaming("TECS", "TimeUS,h,dh,hin,hdem,dhdem,spdem,sp,dsp,th,ph,pmin,pmax,dspdem,f",
                                     "smnmmnnnn------",
                                     "F00000000------",


### PR DESCRIPTION
Bits are defined here:

https://github.com/ArduPilot/ardupilot/blob/da4ca237f6af5e7d0d506b6c539f4c7d42e3eea6/libraries/AP_TECS/AP_TECS.h#L325-L353

Currently they are not all documented so log tools don't show them:
<img width="217" height="342" alt="image" src="https://github.com/user-attachments/assets/64a77a02-3fbf-4716-a04a-5714ef88d111" />
