### PR TITLE
waf: Set minimum Python to match oldest Standard Support Ubuntu LTS

### DIFF
--- a/.github/workflows/cygwin_build.yml
+++ b/.github/workflows/cygwin_build.yml
@@ -160,7 +160,7 @@ jobs:
 
       - uses: cygwin/cygwin-install-action@v6
         with:
-          packages: cygwin64 gcc-g++=10.2.0-1 ccache python39 python39-lxml python39-pip python39-setuptools python39-wheel git procps gettext
+          packages: cygwin64 gcc-g++=10.2.0-1 ccache python312-pip git procps gettext
           add-to-path: false
       # Put ccache into github cache for faster build
       - name: setup ccache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [tool.ruff]
-target-version = "py310"
+target-version = "py310"  # Default Python of the oldest Standard Support Ubuntu LTS.
+# This should be kept in sync with `min_ver` in the files `./wscript` and `./waf`.
 line-length = 127
 lint.select = [
     "BLE001",  # flake8-blind-except

--- a/waf
+++ b/waf
@@ -4,8 +4,10 @@ import os.path as p
 import subprocess
 import sys
 
-# also update `cfg.check_python_version` in `./wscript`
-MIN_VER = (3, 8, 0)
+# default Python of the oldest Standard Support Ubuntu LTS.
+# https://releases.ubuntu.com
+# also update `cfg.check_python_version` in `./wscript` and `target-version` in `pyproject.toml`
+MIN_VER = (3, 10, 0)
 
 # check before we start loading code and e.g. encounter SyntaxErrors. this means
 # this file should remain compatible with any Python 3 (at least syntax-wise).

--- a/wscript
+++ b/wscript
@@ -539,10 +539,11 @@ def configure(cfg):
         # also in env for hrt.c
         cfg.env.AP_BOARD_START_TIME = cfg.options.board_start_time
 
-    # require python 3.8.x or later
-    # also update `MIN_VER` in `./waf`
+    # default Python of the oldest Standard Support Ubuntu LTS.
+    # https://releases.ubuntu.com
+    # also update `MIN_VER` in `./waf` and `target-version` in `pyproject.toml`
     cfg.load('python')
-    cfg.check_python_version(minver=(3,8,0))
+    cfg.check_python_version(minver=(3, 10, 0))
 
     cfg.load('ap_library')
 


### PR DESCRIPTION
## Summary

Blocked by `.github/workflows/cygwin_build.yml`
> ERROR: Python minimum supported version is 3.10.0, but you have 3.9.16

Perhaps this solves things?
https://cygwin.com/packages/summary/python312.html vs.
https://cygwin.com/packages/summary/python3.html (v3.9).

* cygwin/cygwin-install-action#55

---
As recommended at:
* https://github.com/ArduPilot/ardupilot/pull/32453#discussion_r2951643145

Set the minimum Python version to match the default Python of the oldest Standard Support Ubuntu LTS.

Ubuntu and Python releases are both on five-year LTS cycles.

`20.04 focal` dropped off [Standard Support](https://releases.ubuntu.com) in May of 2025.

Version | Codename | Default Python
-- | -- | --
~20.04~ | ~focal~ | ~Python 3.8~
22.04 | jammy | Python 3.10
24.04 | noble | Python 3.12
26.04 | resolute | Python 3.14

https://docs.python.org/3/whatsnew/3.9.html + https://docs.python.org/3/whatsnew/3.10.html

## Testing (more checks increase the chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

<!-- Describe your changes here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
