### PR TITLE
AP_HAL_SITL: Fix get_flow_control

### DIFF
--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -226,6 +226,14 @@ uint32_t UARTDriver::txspace(void)
     return _writebuffer.space();
 }
 
+enum AP_HAL::UARTDriver::flow_control UARTDriver::get_flow_control(void)
+{
+    if (_uart_path) {
+        return _sitlState->use_rtscts() ? FLOW_CONTROL_ENABLE : FLOW_CONTROL_DISABLE;
+    }
+    return FLOW_CONTROL_ENABLE;
+}
+
 ssize_t UARTDriver::_read(uint8_t *buffer, uint16_t count)
 {
     const ssize_t ret = _readbuffer.read(buffer, count);

--- a/libraries/AP_HAL_SITL/UARTDriver.h
+++ b/libraries/AP_HAL_SITL/UARTDriver.h
@@ -41,7 +41,7 @@ public:
 
     bool _unbuffered_writes;
 
-    enum flow_control get_flow_control(void) override { return FLOW_CONTROL_ENABLE; }
+    enum flow_control get_flow_control(void) override;
 
     void configure_parity(uint8_t v) override;
     void set_stop_bits(int n) override;


### PR DESCRIPTION
## Summary

<!-- a one or two line summary of what your PR does here -->
fix SITL get_flow_control return, previous is hardcode FLOW_CONTROL_ENABLE
## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [x] Tested in SITL
- [x] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request
- [ ] Autotest included

## Description

<!-- Describe your changes here -->

1. return result base on ```_sitlState->use_rtscts()```, to enable rtscts use ```--rtscts``` in sitl startup
2. when connect Septentrio SBF device with SITL, get_flow_control return hardcode FLOW_CONTROL_ENABLE would make the config process fail, ie keep sending "scs,COM1,baud230400,bits8,No,bit1,RTS|CTS" to none support flowcontrol interface will keep raising ```setCOMSettings: Argument 'FlowControl' could not be handled!``` https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_GPS/AP_GPS_SBF.cpp#L119, this PR would fix it

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
