### PR TITLE
AP_AHRS: continue Write_POS when get_location returns false

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_Logging.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Logging.cpp
@@ -90,9 +90,10 @@ void AP_AHRS::Write_Origin(LogOriginType origin_type, const Location &loc) const
 void AP_AHRS::Write_POS() const
 {
     Location loc;
-    if (!get_location(loc)) {
-        return;
-    }
+    // get_location() fills loc with the best available position even when
+    // returning false.  Continue logging so the estimated path is preserved
+    // for post-processing and analysis.
+    get_location(loc);
     float home;
     AP::ahrs().get_relative_position_D_home(home);
 


### PR DESCRIPTION
## Summary

Write_POS() now logs the best-guess position when get_location() returns false instead of silently skipping the record.

Fixes issue #32458.

## Testing

- [x] Checked by a human programmer

## Description

get_location() fills loc with the best available position estimate even when it returns false (e.g. when GPS fix has not been acquired). The early return in Write_POS() caused the POS log message to be silently skipped during that window, losing estimated-path data that is useful for post-flight analysis and EKF debugging.

Remove the early return and unconditionally call get_location(loc) so that a POS record is always written, using whatever position estimate the AHRS currently holds.

No AI used.