### PR TITLE
Disentangle SITL::Frame, SITL::Aircraft, and SITL::Battery

### DIFF
--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -50,8 +50,7 @@ Aircraft *Aircraft::instances[MAX_SIM_INSTANCES];
   parent class for all simulator types
  */
 
-Aircraft::Aircraft(const char *frame_str) :
-    frame(frame_str)
+Aircraft::Aircraft(const char *frame_str)
 {
     // make the SIM_* variables available to simulator backends
     sitl = AP::sitl();

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -292,7 +292,6 @@ protected:
     uint32_t last_frame_count;
     uint8_t instance;
     const char *autotest_dir;
-    const char *frame;
     bool use_time_sync = true;
     float last_speedup = -1.0f;
     const char *config_ = "";

--- a/libraries/SITL/SIM_Battery.cpp
+++ b/libraries/SITL/SIM_Battery.cpp
@@ -120,6 +120,25 @@ void Battery::setup(float _capacity_Ah, float _resistance, float _max_voltage)
     capacity_Ah = _capacity_Ah;
     resistance = _resistance;
     max_voltage = _max_voltage;
+
+    voltage_set = max_voltage;
+    voltage_filter.reset(voltage_set);
+    set_initial_SoC(voltage_set);
+}
+
+void Battery::maybe_reset(float desired_voltage, float desired_capacity_Ah)
+{
+    const bool reset_not_needed = (is_equal(voltage_set, desired_voltage)
+                                   && is_equal(capacity_Ah, desired_capacity_Ah));
+    if (reset_not_needed) {
+        return;
+    }
+
+    capacity_Ah = desired_capacity_Ah;
+    // a negative desired voltage is unexpected, but not problematic
+    voltage_set = MIN(desired_voltage, max_voltage);
+    voltage_filter.reset(voltage_set);
+    set_initial_SoC(voltage_set);
 }
 
 void Battery::init_voltage(float voltage)

--- a/libraries/SITL/SIM_Battery.h
+++ b/libraries/SITL/SIM_Battery.h
@@ -26,6 +26,9 @@ class Battery {
 public:
     void setup(float _capacity_Ah, float _resistance, float _max_voltage);
 
+    // Resets the battery state if the configuration (e.g. from SIM_BATT_* parameters) has changed.
+    void maybe_reset(float desired_voltage, float desired_capacity_Ah);
+
     void init_voltage(float voltage);
     void init_capacity(float capacity);
 

--- a/libraries/SITL/SIM_Frame.cpp
+++ b/libraries/SITL/SIM_Frame.cpp
@@ -577,10 +577,9 @@ void Frame::parse_vector3(AP_JSON::value val, const char* label, Vector3f &param
 /*
   initialise the frame
  */
-void Frame::init(const char *frame_str, Battery *_battery)
+void Frame::init(const char *frame_str)
 {
     model = default_model;
-    battery = _battery;
 
     const char *colon = strchr(frame_str, ':');
     size_t slen = strlen(frame_str);
@@ -619,8 +618,6 @@ void Frame::init(const char *frame_str, Battery *_battery)
 
     // power_factor is ratio of power consumed per newton of thrust
     float power_factor = hover_power / hover_thrust;
-
-    battery->setup(model.battCapacityAh, model.refBatRes, model.maxVoltage);
 
     if (uint8_t(model.num_motors) != num_motors) {
         ::printf("Warning model expected %u motors and got %u\n", uint8_t(model.num_motors), num_motors);
@@ -682,7 +679,8 @@ void Frame::calculate_forces(const Aircraft &aircraft,
     const auto *_sitl = AP::sitl();
     for (uint8_t i=0; i<num_motors; i++) {
         Vector3f mtorque, mthrust;
-        motors[i].calculate_forces(input, motor_offset, mtorque, mthrust, vel_air_bf, gyro, air_density, battery->get_voltage(), use_drag);
+        motors[i].calculate_forces(input, motor_offset, mtorque, mthrust, vel_air_bf,
+                                   gyro, air_density, aircraft.get_battery_voltage(), use_drag);
         torque += mtorque;
         thrust += mthrust;
         // simulate motor rpm
@@ -727,23 +725,13 @@ void Frame::calculate_forces(const Aircraft &aircraft,
     body_accel = thrust/aircraft.gross_mass();
 }
 
-
-// calculate current and voltage
-void Frame::current_and_voltage(float &voltage, float &current)
+// computes (total) instantaneous current
+float Frame::get_current_amp(void)
 {
-    float param_voltage = AP::sitl()->batt_voltage;
-    if (!is_equal(last_param_voltage,param_voltage)) {
-        battery->init_voltage(param_voltage);
-        last_param_voltage = param_voltage;
-    }
-    const float param_capacity = AP::sitl()->batt_capacity_ah;
-    if (!is_equal(battery->get_capacity(), param_capacity)) {
-        battery->init_capacity(param_capacity);
-    }
-    voltage = battery->get_voltage();
-    current = 0;
+    float current = 0;
     for (uint8_t i=0; i<num_motors; i++) {
         current += motors[i].get_current();
     }
+    return current;
 }
 #endif // AP_SIM_ENABLED

--- a/libraries/SITL/SIM_Frame.h
+++ b/libraries/SITL/SIM_Frame.h
@@ -49,7 +49,7 @@ public:
     static Frame *create_frame(const char *name);
     
     // initialise frame
-    void init(const char *frame_str, Battery *_battery);
+    void init(const char *frame_str);
 
     // calculate rotational and linear accelerations
     void calculate_forces(const Aircraft &aircraft,
@@ -62,8 +62,7 @@ public:
     float terminal_rotation_rate;
     uint8_t motor_offset;
 
-    // calculate current and voltage
-    void current_and_voltage(float &voltage, float &current);
+    float get_current_amp(void);
 
     // get mass in kg
     float get_mass(void) const {
@@ -74,6 +73,10 @@ public:
     void set_mass(float new_mass) {
         mass = new_mass;
     }
+
+    float get_model_batt_max_voltage(void) const { return model.maxVoltage; }
+    float get_model_batt_capacity_ah(void) const { return model.battCapacityAh; }
+    float get_model_batt_resistance_ohm(void) const { return model.refBatRes; }
     
 private:
     /*
@@ -96,7 +99,9 @@ private:
         float refCurrent = 29.3; // Amps
         float refAlt = 593; // altitude AMSL
         float refTempC = 25; // temperature C
-        float refBatRes = 0.01; // BAT.Res
+
+        // battery resistance reference value in Ohms
+        float refBatRes = 0.01;
 
         // full pack voltage
         float maxVoltage = 4.2*3;
@@ -158,10 +163,6 @@ private:
     // exposed area times coefficient of drag
     float areaCd;
     float mass;
-    float last_param_voltage;
-#if AP_SIM_ENABLED
-    Battery *battery;
-#endif
 
     // json parsing helpers
     void parse_float(AP_JSON::value val, const char* label, float &param);

--- a/libraries/SITL/SIM_Multicopter.cpp
+++ b/libraries/SITL/SIM_Multicopter.cpp
@@ -32,7 +32,10 @@ MultiCopter::MultiCopter(const char *frame_str) :
         exit(1);
     }
 
-    frame->init(frame_str, &battery);
+    frame->init(frame_str);
+    battery.setup(frame->get_model_batt_capacity_ah(),
+                  frame->get_model_batt_resistance_ohm(),
+                  frame->get_model_batt_max_voltage());
 
     mass = frame->get_mass();
     frame_height = 0.1;
@@ -70,8 +73,9 @@ void MultiCopter::update(const struct sitl_input &input)
         accel_body.zero();
     }
 
-    // estimate voltage and current
-    frame->current_and_voltage(battery_voltage, battery_current);
+    battery.maybe_reset(sitl->batt_voltage, sitl->batt_capacity_ah);
+    battery_voltage = battery.get_voltage();
+    battery_current = frame->get_current_amp();
 
     const uint64_t now_us = AP_HAL::micros64();
     battery.set_current(battery_current, now_us);

--- a/libraries/SITL/SIM_Plane.cpp
+++ b/libraries/SITL/SIM_Plane.cpp
@@ -401,7 +401,6 @@ void Plane::calculate_forces(const struct sitl_input &input, Vector3f &rot_accel
     float elevator = filtered_servo_angle(input, 1);
     float rudder   = filtered_servo_angle(input, 3);
     bool launch_triggered = input.servos[6] > 1700;
-    float throttle;
     if (reverse_elevator_rudder) {
         elevator = -elevator;
         rudder = -rudder;
@@ -444,16 +443,7 @@ void Plane::calculate_forces(const struct sitl_input &input, Vector3f &rot_accel
     }
     //printf("Aileron: %.1f elevator: %.1f rudder: %.1f\n", aileron, elevator, rudder);
 
-    if (reverse_thrust) {
-        throttle = filtered_servo_angle(input, 2);
-    } else {
-        throttle = filtered_servo_range(input, 2);
-    }
-    
-    float thrust     = throttle;
-
-    battery_voltage = sitl->batt_voltage - 0.7*throttle;
-    battery_current = (battery_voltage/sitl->batt_voltage)*50.0f*sq(throttle);
+    float thrust = reverse_thrust ? filtered_servo_angle(input, 2) : filtered_servo_range(input, 2);
 
     if (ice_engine) {
         thrust = icengine.update(input);
@@ -526,7 +516,11 @@ void Plane::update(const struct sitl_input &input)
     update_wind(input);
     
     calculate_forces(input, rot_accel);
-    
+
+    float throttle = reverse_thrust ? filtered_servo_angle(input, 2) : filtered_servo_range(input, 2);
+    battery_voltage = sitl->batt_voltage - 0.7*throttle;
+    battery_current = (battery_voltage/sitl->batt_voltage)*50.0f*sq(throttle);
+
     update_dynamics(rot_accel);
 
     /*

--- a/libraries/SITL/SIM_QuadPlane.cpp
+++ b/libraries/SITL/SIM_QuadPlane.cpp
@@ -101,7 +101,10 @@ QuadPlane::QuadPlane(const char *frame_str) :
     frame->motor_offset = motor_offset;
 
     // we use zero terminal velocity to let the plane model handle the drag
-    frame->init(frame_str, &battery);
+    frame->init(frame_str);
+    battery.setup(frame->get_model_batt_capacity_ah(),
+                  frame->get_model_batt_resistance_ohm(),
+                  frame->get_model_batt_max_voltage());
 
     // increase mass for plane components
     mass = frame->get_mass() * 1.5;
@@ -135,8 +138,9 @@ void QuadPlane::update(const struct sitl_input &input)
         quad_accel_body.rotate(ROTATION_PITCH_270);
     }
 
-    // estimate voltage and current
-    frame->current_and_voltage(battery_voltage, battery_current);
+    battery.maybe_reset(sitl->batt_voltage, sitl->batt_capacity_ah);
+    battery_voltage = battery.get_voltage();
+    battery_current = frame->get_current_amp();
 
     const uint64_t now_us = AP_HAL::micros64();
     battery.set_current(battery_current, now_us);

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -116,14 +116,14 @@ const AP_Param::GroupInfo SIM::var_info[] = {
     // @Description: Sonar rotation from rotations enumeration
     AP_GROUPINFO("SONAR_ROT",     17, SIM,  sonar_rot, Rotation::ROTATION_PITCH_270),
     // @Param: BATT_VOLTAGE
-    // @DisplayName: Simulated battery voltage
-    // @Description: Simulated battery voltage. Constant voltage when SIM_BATT_CAP_AH is 0, otherwise changing this parameter will re-initialize the state of charge of the battery based on this voltage versus the battery's maximum voltage (default is max voltage).
+    // @DisplayName: Simulated battery resting voltage
+    // @Description: Simulated battery resting voltage (no load sag). Defaults to and clipped to the battery model's maximum voltage. Changes re-initialize the state of charge, and values below the maximum indicate a partially-charged battery. For batteries with unlimited capacity, see `SIM_BATT_CAP_AH`. Value ignored when receiving battery state updates from an external source.
     // @Units: V
     // @User: Advanced
     AP_GROUPINFO("BATT_VOLTAGE",  19, SIM,  batt_voltage,  12.6f),
     // @Param: BATT_CAP_AH
     // @DisplayName: Simulated battery capacity
-    // @Description: Simulated battery capacity. Set to 0 for unlimited capacity. Changing this parameter will re-initialize the state of charge of the battery.
+    // @Description: Simulated battery capacity. Changes re-initialize the state of charge of the battery. Set to 0 for unlimited capacity. Value ignored when receiving battery state updates from an external source.
     // @Units: Ah
     // @User: Advanced
     AP_GROUPINFO("BATT_CAP_AH",   20, SIM,  batt_capacity_ah,  0),


### PR DESCRIPTION
## Summary

This PR prepares the way for a better SITL::Battery and every simulated vehicle able to use it (#10050). It causes minimal (no?) changes in observed behavior.

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [x] Tested in SITL (EvaluateBatteryModel example in CI)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

The commits were structured step-by-step for ease of review. **They will be squashed together before merge.**

The software design covering this is found [here in the issue](https://github.com/ArduPilot/ardupilot/issues/10050#issuecomment-4085867008). It was green-lighted on the 2026-03-23 dev call.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
