### PR TITLE
AP_Mount_Backend: set RC rate yaw_is_ef flag

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -120,6 +120,9 @@ void AP_Mount_Backend::update_mnt_target_from_rc_target()
     mnt_target.angle_rad.yaw_is_ef = FPV_option ? false : _yaw_lock;
     mnt_target.angle_rad.roll_is_ef = FPV_option ? false : _roll_lock;
     mnt_target.angle_rad.pitch_is_ef = FPV_option ? false : _pitch_lock;
+    mnt_target.rate_rads.yaw_is_ef = FPV_option ? false : _yaw_lock;
+    mnt_target.rate_rads.roll_is_ef = FPV_option ? false : _roll_lock;
+    mnt_target.rate_rads.pitch_is_ef = FPV_option ? false : _pitch_lock;
 
     // if RC_RATE is zero, targets are angle
     if (_params.rc_rate_max <= 0) {

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -270,6 +270,8 @@ protected:
         float roll;      // roll rate in radians/second
         float pitch;     // roll rate in radians/second
         float yaw;       // roll rate in radians/second
+        bool pitch_is_ef = true;
+        bool roll_is_ef = true;
         bool yaw_is_ef;  // if set then `yaw` is a rate in earth frame
     };
 


### PR DESCRIPTION
## Summary

Set the RC rate yaw_is_ef flag.
Currently, only angle flag is set.

Bug encountered:
Initial state:
- MNT1_OPTIONS = 1 (RCTARGETING_LOCK_FROM_PREVMODE enabled)
- In QGC Fly view, yaw locked state.
- Move the RC to pan/tilt
Expected:
- yaw_is_ef flag should be set to 1 since we are in yaw locked state
Actual 
- yaw_is_ef flag is set to 0

## Testing
Changes are tested using
QGC Daily build
AVT gimbal

