### PR TITLE
AP_Scripting: fix LTE modem bad tac string decode error

### DIFF
--- a/libraries/AP_Scripting/drivers/LTE_modem.lua
+++ b/libraries/AP_Scripting/drivers/LTE_modem.lua
@@ -1123,7 +1123,8 @@ local function check_CPSI(s)
 
     if system_mode and sinr_str then
         -- Convert strings to numbers
-        local tac = tonumber(tac_str:match("0x(%w+)"), 16) or tonumber(tac_str) or 0
+        local tac_hex = tac_str:match("^0x(%x+)$")
+        local tac = (tac_hex and tonumber(tac_hex, 16)) or tonumber(tac_str) or 0
         local scell_id = tonumber(scell_id_str) or 0
         local pcid = tonumber(pcid_str) or 0
         local ul_freq = tonumber(ul_freq_str) or 0


### PR DESCRIPTION
## Summary

<!-- a one or two line summary of what your PR does here -->

## Testing (more checks increases chance of being merged)
Fix error raised in the LTE modem lua
```AP: LTE_modem error: ./scripts/LTE_modem.lua:1126: bad argument #1 to 'tonumber' (string expected, got nil)```
- [x] Checked by a human programmer
- [x] Tested in SITL
- [x] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request
- [ ] Autotest included

## Description

<!-- Describe your changes here -->

1. fix hex regex expression to filter string like ```abc 0x1234```, ```0x1234 xyz```,  ```0xGHIJK```, ```0x12_34```
2. fix passing nil to ```to_numbder``` with 16 base

bad data captured
```+CPSI: LTE,Online,***-..,.x1234,*********,76,EUTRAN-BAND3,1300,5,5,-92,-952,-667,14```


<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
