### PR TITLE
AHRS: check backend return values when setting common origin

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -714,13 +714,15 @@ void AP_AHRS::update_EKF2(void)
         if (!done_common_origin) {
             Location new_origin;
             if (EKF2.getOriginLLH(new_origin)) {
-                done_common_origin = true;
+                bool set_origin_success = true;
 #if HAL_NAVEKF3_AVAILABLE
-                EKF3.setOriginLLH(new_origin);
+                set_origin_success &= EKF3.setOriginLLH(new_origin);
 #endif
 #if AP_AHRS_EXTERNAL_ENABLED
-                external.set_origin(new_origin);
+                set_origin_success &= external.set_origin(new_origin);
 #endif
+                // Only stop trying once everyone has reported success
+                done_common_origin = set_origin_success;
             }
         }
     }
@@ -798,13 +800,15 @@ void AP_AHRS::update_EKF3(void)
         if (!done_common_origin) {
             Location new_origin;
             if (EKF3.getOriginLLH(new_origin)) {
-                done_common_origin = true;
+                bool set_origin_success = true;
 #if HAL_NAVEKF2_AVAILABLE
-                EKF2.setOriginLLH(new_origin);
+                set_origin_success &= EKF2.setOriginLLH(new_origin);
 #endif
 #if AP_AHRS_EXTERNAL_ENABLED
-                external.set_origin(new_origin);
+                set_origin_success &= external.set_origin(new_origin);
 #endif
+                // Only stop trying once everyone has reported success
+                done_common_origin = set_origin_success;
             }
         }
     }
@@ -827,13 +831,15 @@ void AP_AHRS::update_external(void)
     if (!done_common_origin) {
         Location new_origin;
         if (external.get_origin(new_origin)) {
-            done_common_origin = true;
+            bool set_origin_success = true;
 #if HAL_NAVEKF2_AVAILABLE
-            EKF2.setOriginLLH(new_origin);
+            set_origin_success &= EKF2.setOriginLLH(new_origin);
 #endif
 #if HAL_NAVEKF3_AVAILABLE
-            EKF3.setOriginLLH(new_origin);
+            set_origin_success &= EKF3.setOriginLLH(new_origin);
 #endif
+            // Only stop trying once everyone has reported success
+            done_common_origin = set_origin_success;
         }
     }
 }


### PR DESCRIPTION
## Summary

Fix handling of common origin across AHRS backends by checking return values when setting origin.

## Testing (more checks increases chance of being merged)

- [ ] Checked by a human programmer
- [X] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

Previously, done_common_origin was set to true even if one or more backends failed to set the origin.
This change ensures that done_common_origin is only set when all available backends successfully set the origin.
Addresses issue #32539