### PR TITLE
.github: move non building job to ubuntu-slim

### DIFF
--- a/.github/workflows/cache_cleanup.yml
+++ b/.github/workflows/cache_cleanup.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   cleanup:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-slim
     permissions:
       # `actions:write` permission is required to delete caches
       #   See also: https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#delete-a-github-actions-cache-for-a-repository-using-a-cache-id

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6

--- a/.github/workflows/test_scripts.yml
+++ b/.github/workflows/test_scripts.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-slim
     container: ardupilot/ardupilot-dev-base:v0.1.3
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
@@ -21,7 +21,7 @@ jobs:
             validate_board_list,
             logger_metadata,
             param-file-validation,
-       ]
+          ]
     steps:
       # git checkout the PR
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Unclog our CI by using ubuntu-slim instance for non building jobs : https://docs.github.com/en/actions/reference/runners/github-hosted-runners . Those are 1cpu but should be enought for python docs/python checking and will free up machine for building.

## Testing (more checks increases chance of being merged)

- [ X] Checked by a human programmer
- [X ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

