### PR TITLE
Tools: Use `with open() as:` to close file handles

### DIFF
--- a/Tools/PrintVersion.py
+++ b/Tools/PrintVersion.py
@@ -40,19 +40,18 @@ else:
     includefilepath = includefiles[vehicle]
 
 
-file = open(includefilepath)
-
 firmware_version_regex = re.compile(r".*define +FIRMWARE_VERSION.*")
 firmware_version_extract_regex = re.compile(r".*define +FIRMWARE_VERSION[	 ]+(?P<major>\d+)[ ]*,[ 	]*(?P<minor>\d+)[ ]*,[	 ]*(?P<point>\d+)[ ]*,[	 ]*(?P<type>[A-Z_]+)[	 ]*")  # noqa: E501
 
-for line in file:
-    if not firmware_version_regex.match(line):
-        continue
-    match = firmware_version_extract_regex.match(line)
-    if not match:
-        print("Failed to match FIRMWARE_VERSION line (%s)" % (line,))
-        sys.exit(1)
-    print("%d.%d.%d-%s" % (int(match.group("major")),
-                           int(match.group("minor")),
-                           int(match.group("point")),
-                           match.group("type")))
+with open(includefilepath) as in_file:
+    for line in in_file:
+        if not firmware_version_regex.match(line):
+            continue
+        match = firmware_version_extract_regex.match(line)
+        if not match:
+            print("Failed to match FIRMWARE_VERSION line (%s)" % (line,))
+            sys.exit(1)
+        print("%d.%d.%d-%s" % (int(match.group("major")),
+                               int(match.group("minor")),
+                               int(match.group("point")),
+                               match.group("type")))

--- a/Tools/Replay/examples/rewrite-RFND-values-to-floats.py
+++ b/Tools/Replay/examples/rewrite-RFND-values-to-floats.py
@@ -100,7 +100,6 @@ parser.add_argument("logout")
 args = parser.parse_args()
 
 login = mavutil.mavlink_connection(args.login)
-output = open(args.logout, mode='wb')
 
 type_name_map = {}
 
@@ -127,8 +126,9 @@ def rewrite_message(m):
     return buf
 
 
-while True:
-    m = login.recv_msg()
-    if m is None:
-        break
-    output.write(rewrite_message(m))
+with open(args.logout, mode='wb') as out_file:
+    while True:
+        m = login.recv_msg()
+        if m is None:
+            break
+        out_file.write(rewrite_message(m))

--- a/Tools/scripts/board_list.py
+++ b/Tools/scripts/board_list.py
@@ -148,9 +148,9 @@ class BoardList(object):
                 raise ValueError(f"Unable to determine HAL for {hwdef_dir}")
 
     def read_hwdef(self, filepath):
-        fh = open(filepath)
         ret = []
-        text = fh.readlines()
+        with open(filepath) as in_file:
+            text = in_file.readlines()
         for line in text:
             m = re.match(r"^\s*include\s+(.+)\s*$", line)
             if m is not None:

--- a/Tools/scripts/build_sizes/build_sizes.py
+++ b/Tools/scripts/build_sizes/build_sizes.py
@@ -51,13 +51,15 @@ def firmware_list(basedir):
             if f in LINUX_BINARIES:
                 git_version = os.path.join(root, "git-version.txt")
                 try:
-                    line = open(git_version, 'r').readline()
+                    with open(git_version, 'r') as in_file:
+                        line = in_file.readline()
                     githash = line.split()[1][:8]
                 except OSError:
                     githash = "unknown"
                 flash_free = 999999
             else:
-                fw_json = json.load(open(fname, "r"))
+                with open(fname, "r") as in_file:
+                    fw_json = json.load(in_file)
                 githash = fw_json['git_identity']
                 flash_free = fw_json.get('flash_free', -1)
             apjinfo = APJInfo(vehicle, board, githash, mtime, flash_free)
@@ -185,8 +187,8 @@ def write_table(h, build_type):
 ''')
 
 
-h = open(args.outfile, "w")
-write_headers(h)
-for t in build_dirs:
-    write_table(h, t)
-write_footer(h)
+with open(args.outfile, "w") as out_file:
+    write_headers(out_file)
+    for t in build_dirs:
+        write_table(out_file, t)
+    write_footer(out_file)

--- a/Tools/scripts/generate_manifest.py
+++ b/Tools/scripts/generate_manifest.py
@@ -182,7 +182,8 @@ class ManifestGenerator():
     def git_sha_from_git_version(self, filepath):
         '''parses get-version.txt (as emitted by build_binaries.py, returns
         git sha from it'''
-        content = open(filepath).read()
+        with open(filepath) as in_file:
+            content = in_file.read()
         sha_regex = re.compile("commit (?P<sha>[0-9a-f]+)")
         m = sha_regex.search(content)
         if m is None:
@@ -193,7 +194,8 @@ class ManifestGenerator():
     def fwversion_from_git_version(self, filepath):
         '''parses get-version.txt (as emitted by build_binaries.py, returns
         git sha from it'''
-        content = open(filepath).read()
+        with open(filepath) as in_file:
+            content = in_file.read()
         sha_regex = re.compile(r"APMVERSION: \S+\s+(\S+)")
         m = sha_regex.search(content)
         if m is None:
@@ -229,7 +231,8 @@ class ManifestGenerator():
         if not os.path.exists(apj_path):
             print("bad apj path %s" % apj_path, file=sys.stderr)
             return
-        apj_json = json.load(open(apj_path, 'r'))
+        with open(apj_path, 'r') as in_file:
+            apj_json = json.load(in_file)
         if 'board_id' not in apj_json:
             print("no board_id in %s" % apj_path, file=sys.stderr)
             return
@@ -382,9 +385,9 @@ class ManifestGenerator():
                 continue
 
             try:
-                firmware_version = open(firmware_version_file).read()
-                firmware_version = firmware_version.strip()
-                (_, _) = firmware_version.split("-")
+                with open(firmware_version_file) as in_file:
+                    firmware_version = in_file.read()
+                (_, _) = firmware_version.strip().split("-")
             except ValueError:
                 print("malformed firmware-version.txt at (%s)" % (firmware_version_file,), file=sys.stderr)
                 continue
@@ -410,7 +413,8 @@ class ManifestGenerator():
             features_text = None
             features_filepath = os.path.join(some_dir, "features.txt")
             if os.path.exists(features_filepath):
-                features_text = sorted(open(features_filepath).read().rstrip().split("\n"))
+                with open(features_filepath) as in_file:
+                    features_text = sorted(in_file.read().rstrip().split("\n"))
 
             for filename in os.listdir(some_dir):
                 if filename in ["git-version.txt", "firmware-version.txt", "files.html", "features.txt"]:

--- a/Tools/scripts/make_apj.py
+++ b/Tools/scripts/make_apj.py
@@ -18,7 +18,8 @@ parser.add_argument('--board-id', type=int, default=1, help='board ID')
 
 args = parser.parse_args()
 
-img = open(args.bin, 'rb').read()
+with open(args.bin, 'rb') as in_file:
+    img = in_file.read()
 d = {
     "board_id": int(args.board_id),
     "magic": "APJFWv1",
@@ -31,6 +32,5 @@ d = {
     "signed_firmware": False,
 }
 
-f = open(args.apj, "w")
-f.write(json.dumps(d, indent=4))
-f.close()
+with open(args.apj, "w") as out_file:
+    out_file.write(json.dumps(d, indent=4))

--- a/Tools/scripts/sitl-on-hardware/sitl-on-hw.py
+++ b/Tools/scripts/sitl-on-hardware/sitl-on-hw.py
@@ -68,8 +68,8 @@ if args.frame and args.frame not in frame_options and not not args.simclass.star
     sys.exit(1)
 
 
-extra_hwdef = tempfile.NamedTemporaryFile(mode='w', delete=False)
-extra_defaults = tempfile.NamedTemporaryFile(mode='w')
+extra_hwdef = tempfile.NamedTemporaryFile(mode='w', delete=False)  # noqa: SIM115
+extra_defaults = tempfile.NamedTemporaryFile(mode='w')  # noqa: SIM115
 
 
 def hwdef_write(s):
@@ -95,17 +95,21 @@ else:
     defaults_base = "default.param"
 
 # add base hwdef to extra_hwdef
-hwdef_write(open(sohw_path(extra_hwdef_base), "r").read() + "\n")
+with open(sohw_path(extra_hwdef_base), "r") as in_file:
+    hwdef_write(in_file.read() + "\n")
 
 for f in args.extra_hwdef:
-    hwdef_write(open(f, "r").read() + "\n")
+    with open(f, "r") as in_file:
+        hwdef_write(in_file.read() + "\n")
 
 # add base defaults to extra_defaults
-defaults_write(open(sohw_path(defaults_base), "r").read() + "\n")
+with open(sohw_path(defaults_base), "r") as in_file:
+    defaults_write(in_file.read() + "\n")
 
 if args.defaults:
     for d in args.defaults.split(","):
-        defaults_write(open(d, "r").read() + "\n")
+        with open(d, "r") as in_file:
+            defaults_write(in_file.read() + "\n")
 
 if args.simclass:
     if args.simclass == 'Glider':

--- a/Tools/scripts/size_compare_branches.py
+++ b/Tools/scripts/size_compare_branches.py
@@ -652,15 +652,13 @@ class SizeCompareBranches(BuildScriptBase):
         # slurp all content into a variable:
         content = bytearray()
         for extra_hwdef in extra_hwdefs:
-            with open(extra_hwdef, "r+b") as f:
-                content += f.read()
+            with open(extra_hwdef, "r+b") as in_file:
+                content += in_file.read()
 
         # spew content to single file:
-        f = tempfile.NamedTemporaryFile(delete=False)
-        f.write(content)
-        f.close()
-
-        return f.name
+        with tempfile.NamedTemporaryFile(delete=False) as out_file:
+            out_file.write(content)
+            return out_file.name
 
     def run_build_task(self, task, source_dir=None, jobs=None):
         self.progress(f"Building {task}")

--- a/Tools/scripts/uploader.py
+++ b/Tools/scripts/uploader.py
@@ -164,9 +164,8 @@ class firmware(object):
     def __init__(self, path):
 
         # read the file
-        f = open(path, "r")
-        self.desc = json.load(f)
-        f.close()
+        with open(path, "r") as in_file:
+            self.desc = json.load(in_file)
 
         self.image = bytearray(zlib.decompress(base64.b64decode(self.desc['image'])))
         if 'extf_image' in self.desc:
@@ -587,24 +586,22 @@ class uploader(object):
     # download code
     def __download(self, label, fw):
         print("\n", end='')
-        f = open(fw, 'wb')
-
         downloadProgress = 0
         readsize = uploader.READ_MULTI_MAX
         total = 0
-        while True:
-            n = min(self.fw_maxsize - total, readsize)
-            bb = self.__read_multi(n)
-            f.write(bb)
+        with open(fw, 'wb') as out_file:
+            while True:
+                n = min(self.fw_maxsize - total, readsize)
+                bb = self.__read_multi(n)
+                out_file.write(bb)
 
-            total += len(bb)
-            # Print download progress (throttled, so it does not delay download progress)
-            downloadProgress += 1
-            if downloadProgress % 256 == 0:
-                self.__drawProgressBar(label, total, self.fw_maxsize)
-            if len(bb) < readsize:
-                break
-        f.close()
+                total += len(bb)
+                # Print download progress (throttled, so it does not delay download progress)
+                downloadProgress += 1
+                if downloadProgress % 256 == 0:
+                    self.__drawProgressBar(label, total, self.fw_maxsize)
+                if len(bb) < readsize:
+                    break
         self.__drawProgressBar(label, total, self.fw_maxsize)
         print("\nReceived %u bytes to %s" % (total, fw))
 
@@ -888,10 +885,8 @@ class uploader(object):
                     filepath = os.path.join(hwdef_dir, adir, "hwdef.dat")
                     if not os.path.exists(filepath):
                         continue
-                    fh = open(filepath)
-                    if fh is None:
-                        continue
-                    text = fh.readlines()
+                    with open(filepath) as in_file:
+                        text = in_file.readlines()
                     for line in text:
                         m = re.match(r"^\s*APJ_BOARD_ID\s+(\d+)\s*$", line)
                         if m is None:


### PR DESCRIPTION
## Summary

Tools: Use `with open() as:` to close file handles

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

Like:
* ArduPilot/ardupilot#32533, but on other Tools files.

% [`ruff rule SIM115`](https://docs.astral.sh/ruff/rules/open-file-with-context-handler)
# open-file-with-context-handler (SIM115)

In almost all cases, we read or write whole files in a single `.read()` or `.write()`, so there is only one command under the context manager and no intervening code to test between the open()/.read()/.close() or open/.write()/.close().

There is a test for returning a temporary file's name in `Tools/scripts/size_compare_branches.py`.

Derived from the **flake8-simplify** linter.

## What it does
Checks for cases where files are opened (e.g., using the builtin `open()` function)
without using a context manager.

## Why is this bad?
If a file is opened without a context manager, it is not guaranteed that
the file will be closed (e.g., if an exception is raised), which can cause
resource leaks. The rule detects a wide array of IO calls where context managers
could be used, such as `open`, `pathlib.Path(...).open()`, `tempfile.TemporaryFile()`
or`tarfile.TarFile(...).gzopen()`.

## Example
```python
file = open("foo.txt")
...
file.close()
```

Use instead:
```python
with open("foo.txt") as file:
    ...
```

## References
- [Python documentation: `open`](https://docs.python.org/3/library/functions.html#open)

@tpwrules Your review, please.