### PR TITLE
Fix filehandle leaks in autotest suite and pass ruff checks

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -14802,13 +14802,13 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
     def ReadOnlyDefaults(self):
         '''test that defaults marked "readonly" can't be set'''
-        defaults_filepath = tempfile.NamedTemporaryFile(mode='w', delete=False)
-        defaults_filepath.write("""
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as defaults_filepath:
+            defaults_filepath.write("""
 DISARM_DELAY 77 @READONLY
 RTL_ALT_M 123
 RTL_ALT_FINAL_M 129
 """)
-        defaults_filepath.close()
+        # defaults_filepath.close()
         self.customise_SITL_commandline([
         ], defaults_filepath=defaults_filepath.name)
 
@@ -14821,13 +14821,13 @@ RTL_ALT_FINAL_M 129
 
         self.start_subtest('Ensure something is writable....')
         self.set_parameter('RTL_ALT_FINAL_M', 101)
-
-        new_values_filepath = tempfile.NamedTemporaryFile(mode='w', delete=False)
-        new_values_filepath.write("""
+        
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as new_values_filepath:
+            new_values_filepath.write("""
 DISARM_DELAY 99
 RTL_ALT_M 111
 """)
-        new_values_filepath.close()
+        # new_values_filepath.close()
 
         self.start_subtest("Ensure parameters can't be set via FTP either")
         mavproxy = self.start_mavproxy()

--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -658,9 +658,9 @@ def write_webresults(results_to_write):
     t = mavtemplate.MAVTemplate()
     for h in glob.glob(util.reltopdir('Tools/autotest/web/*.html')):
         html = util.loadfile(h)
-        f = open(buildlogs_path(os.path.basename(h)), mode='w')
-        t.write(f, html, results_to_write)
-        f.close()
+        with open(buildlogs_path(os.path.basename(h)), mode='w') as f:
+            t.write(f, html, results_to_write)
+        # f.close()
     for f in glob.glob(util.reltopdir('Tools/autotest/web/*.png')):
         shutil.copy(f, buildlogs_path(os.path.basename(f)))
     copy_tree(util.reltopdir("Tools/autotest/web/css"), buildlogs_path("css"), dirs_exist_ok=True)

--- a/Tools/autotest/check_autotest_speedup.py
+++ b/Tools/autotest/check_autotest_speedup.py
@@ -74,27 +74,27 @@ class CheckAutoTestSpeedup(object):
         self.run_program("BUILD", build_args)
         results = {
         }
-        f = open(os.path.join("/tmp/speedup.txt"), "w")
-        for i in range(self.max_speedup, self.min_speedup-1, -1):
-            self.progress("Checking speedup %u" % i)
-            run_args = [
-                "./Tools/autotest/autotest.py",
-                "--speedup", str(i),
-                "--show-test-timings",
-                self.test_target,
-            ]
-            if opts.gdb:
-                run_args.append("--gdb")
-            self.run_program("SPEEDUP-%03u" % i, run_args)
-            for line in self.program_output.split("\n"):
-                match = re.match(".*tests_total_time.*?([0-9.]+)s.*", line)
-                if match is not None:
-                    break
-            results[i] = float(match.group(1))
-            prog = "%u %f" % (i, results[i])
-            self.progress(prog)
-            print(prog, file=f)
-            f.flush()
+        with open(os.path.join("/tmp/speedup.txt"), "w") as f:
+            for i in range(self.max_speedup, self.min_speedup-1, -1):
+                self.progress("Checking speedup %u" % i)
+                run_args = [
+                    "./Tools/autotest/autotest.py",
+                    "--speedup", str(i),
+                    "--show-test-timings",
+                    self.test_target,
+                ]
+                if opts.gdb:
+                    run_args.append("--gdb")
+                self.run_program("SPEEDUP-%03u" % i, run_args)
+                for line in self.program_output.split("\n"):
+                    match = re.match(".*tests_total_time.*?([0-9.]+)s.*", line)
+                    if match is not None:
+                        break
+                results[i] = float(match.group(1))
+                prog = "%u %f" % (i, results[i])
+                self.progress(prog)
+                print(prog, file=f)
+                f.flush()
 
         for (speedup, t) in results.items():
             print("%u %f" % (speedup, t))

--- a/Tools/autotest/examples.py
+++ b/Tools/autotest/examples.py
@@ -23,8 +23,8 @@ def run_example(name, filepath, valgrind=False, gdb=False):
         cmd.append("gdb")
     cmd.append(filepath)
     print("Running: (%s)" % str(cmd))
-    devnull = open("/dev/null", "w")
-    bob = subprocess.Popen(cmd, stdin=devnull, stdout=devnull, stderr=devnull, close_fds=True)
+    with open("/dev/null", "w") as devnull:
+        bob = subprocess.Popen(cmd, stdin=devnull, stdout=devnull, stderr=devnull, close_fds=True)
 
     expect_exit = False
     timeout = 10

--- a/Tools/autotest/logger_metadata/emit_html.py
+++ b/Tools/autotest/logger_metadata/emit_html.py
@@ -27,7 +27,7 @@ DO NOT EDIT
         return ""
 
     def start(self):
-        self.fh = open("LogMessages.html", mode='w')
+        self.fh = open("LogMessages.html", mode='w')   # noqa: SIM115
         print(self.preface(), file=self.fh)
 
     def emit(self, doccos, enumerations):

--- a/Tools/autotest/logger_metadata/emit_md.py
+++ b/Tools/autotest/logger_metadata/emit_md.py
@@ -61,7 +61,7 @@ DO NOT EDIT
         return ""
 
     def start(self):
-        self.fh = open("LogMessages.md", mode='w')
+        self.fh = open("LogMessages.md", mode='w')   # noqa: SIM115
         print(self.preface(), file=self.fh)
 
     def emit(self, doccos, enumerations=None):

--- a/Tools/autotest/logger_metadata/emit_rst.py
+++ b/Tools/autotest/logger_metadata/emit_rst.py
@@ -24,7 +24,7 @@ This is a list of log messages which may be present in logs produced and stored 
         return ""
 
     def start(self):
-        self.fh = open("LogMessages.rst", mode='w')
+        self.fh = open("LogMessages.rst", mode='w')   # noqa: SIM115
         print(self.preface(), file=self.fh)
 
     def emit(self, doccos, enumerations):

--- a/Tools/autotest/logger_metadata/emit_xml.py
+++ b/Tools/autotest/logger_metadata/emit_xml.py
@@ -17,7 +17,7 @@ class XMLEmitter(emitter.Emitter):
 
     def start(self):
         self.logname = "LogMessages.xml"
-        self.fh = open("LogMessages.xml", mode='w')
+        self.fh = open("LogMessages.xml", mode='w')   # noqa: SIM115
         print(self.preface(), file=self.fh)
         self.loggermessagefile = etree.Element('loggermessagefile')
 

--- a/Tools/autotest/param_metadata/ednemit.py
+++ b/Tools/autotest/param_metadata/ednemit.py
@@ -27,10 +27,8 @@ class EDNEmit(Emit):
         else:
             raise Exception('Vehicle name never found')
         self.output += "}"
-        f = open("parameters.edn", mode='w')
-        f.write(self.output)
-        f.close()
-
+        with open("parameters.edn", mode='w') as f:
+            f.write(self.output)
     def start_libraries(self):
         pass
 

--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -180,9 +180,8 @@ def process_vehicle(vehicle):
     debug("===\n\n\nProcessing %s" % vehicle.name)
     current_file = vehicle.path+'/Parameters.cpp'
 
-    f = open(current_file)
-    p_text = f.read()
-    f.close()
+    with open(current_file) as f:
+        p_text = f.read()
     group_matches = prog_groups.findall(p_text)
 
     debug(group_matches)
@@ -283,9 +282,8 @@ def process_library(vehicle, library, pathprefix=None):
         else:
             libraryfname = os.path.normpath(os.path.join(apm_path + '/libraries/' + path))
         if path and os.path.exists(libraryfname):
-            f = open(libraryfname)
-            p_text = f.read()
-            f.close()
+            with open (libraryfname) as f:
+                p_text = f.read()
         else:
             error("Path %s not found for library %s (fname=%s)" % (path, library.name, libraryfname))
             continue

--- a/Tools/autotest/pysim/util.py
+++ b/Tools/autotest/pysim/util.py
@@ -477,26 +477,25 @@ def start_SITL(binary,
         cmd.extend(['gdbserver', 'localhost:3333'])
         if gdb:
             # attach gdb to the gdbserver:
-            f = open("/tmp/x.gdb", "w")
-            f.write("target extended-remote localhost:3333\nc\n")
+            with open("/tmp/x.gdb", "w") as f:
+                f.write("target extended-remote localhost:3333\nc\n")
+                for breakingpoint in breakpoints:
+                    f.write("b %s\n" % (breakingpoint,))
+                if disable_breakpoints:
+                    f.write("disable\n")
+                # f.close()
+            run_cmd('screen -d -m -S ardupilot-gdbserver '
+                    'bash -c "gdb -x /tmp/x.gdb"')
+    elif gdb:
+        with open("/tmp/x.gdb", "w") as f:
+            f.write("set pagination off\n")
             for breakingpoint in breakpoints:
                 f.write("b %s\n" % (breakingpoint,))
             if disable_breakpoints:
                 f.write("disable\n")
-            f.close()
-            run_cmd('screen -d -m -S ardupilot-gdbserver '
-                    'bash -c "gdb -x /tmp/x.gdb"')
-    elif gdb:
-        f = open("/tmp/x.gdb", "w")
-        f.write("set pagination off\n")
-        for breakingpoint in breakpoints:
-            f.write("b %s\n" % (breakingpoint,))
-        if disable_breakpoints:
-            f.write("disable\n")
-        if not gdb_no_tui:
-            f.write("tui enable\n")
-        f.write("r\n")
-        f.close()
+            if not gdb_no_tui:
+                f.write("tui enable\n")
+            f.write("r\n")
         if sys.platform == "darwin" and os.getenv('DISPLAY'):
             cmd.extend(['gdb', '-x', '/tmp/x.gdb', '--args'])
         elif os.environ.get('DISPLAY'):
@@ -513,14 +512,13 @@ def start_SITL(binary,
         strace_options = ['-f', '-o', binary + '.strace', '-s', '8000', '-ttt']
         cmd.extend(strace_options)
     elif lldb:
-        f = open("/tmp/x.lldb", "w")
-        for breakingpoint in breakpoints:
-            f.write("b %s\n" % (breakingpoint,))
-        if disable_breakpoints:
-            f.write("disable\n")
-        f.write("settings set target.process.stop-on-exec false\n")
-        f.write("process launch\n")
-        f.close()
+        with open("/tmp/x.lldb", "w") as f:
+            for breakingpoint in breakpoints:
+                f.write("b %s\n" % (breakingpoint,))
+            if disable_breakpoints:
+                f.write("disable\n")
+            f.write("settings set target.process.stop-on-exec false\n")
+            f.write("process launch\n")
         if sys.platform == "darwin" and os.getenv('DISPLAY'):
             cmd.extend(['lldb', '-s', '/tmp/x.lldb', '--'])
         elif os.environ.get('DISPLAY'):
@@ -538,10 +536,11 @@ def start_SITL(binary,
 
     if param_defaults is not None:
         text = "".join([f"{name} {value}\n" for (name, value) in param_defaults.items()])
-        filepath = tempfile.NamedTemporaryFile(mode="w", delete=False)
-        print(text, file=filepath)
-        filepath.close()
-        defaults.append(str(filepath.name))
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as filepath:
+            print(text, file=filepath)
+            tmp_filepath = filepath.name
+            # filepath.close()
+        defaults.append(str(tmp_filepath))
 
     if not supplementary:
         if wipe:
@@ -551,12 +550,13 @@ def start_SITL(binary,
         if model is not None:
             cmd.extend(['--model', model])
         if speedup is not None and speedup != 1:
-            ntf = tempfile.NamedTemporaryFile(mode="w", delete=False)
-            print(f"SIM_SPEEDUP {speedup}", file=ntf)
-            ntf.close()
+            with tempfile.NamedTemporaryFile(mode="w", delete=False) as ntf:
+                print(f"SIM_SPEEDUP {speedup}", file=ntf)
+                ntf_name= ntf.name
+                # ntf.close()
             # prepend it so that a caller can override the speedup in
             # passed-in defaults:
-            defaults = [ntf.name] + defaults
+            defaults = [ntf_name] + defaults
         if sim_rate_hz is not None:
             cmd.extend(['--rate', str(sim_rate_hz)])
         if unhide_parameters:
@@ -744,16 +744,14 @@ def mkdir_p(directory):
 
 def loadfile(fname):
     """Load a file as a string."""
-    f = open(fname, mode='r')
-    r = f.read()
-    f.close()
-    return r
+    with open(fname, mode='r') as f:
+        return f.read()
 
 
 def lock_file(fname):
     """Lock a file."""
     import fcntl
-    f = open(fname, mode='w')
+    f = open(fname, mode='w')  # noqa: SIM115
     try:
         fcntl.lockf(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
     except OSError:

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -708,13 +708,14 @@ def start_CAN_Periph(opts, frame_info):
     if opts.gdb or opts.gdb_stopped:
         cmd_name += " (gdb)"
         cmd.append("gdb")
-        gdb_commands_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
-        atexit.register(os.unlink, gdb_commands_file.name)
-        gdb_commands_file.write("set pagination off\n")
-        if not opts.gdb_stopped:
-            gdb_commands_file.write("r\n")
-        gdb_commands_file.close()
-        cmd.extend(["-x", gdb_commands_file.name])
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as gdb_commands_file:
+            gdb_commands_file.write("set pagination off\n")
+            if not opts.gdb_stopped:
+                gdb_commands_file.write("r\n")
+                gdb_file_path=gdb_commands_file.name
+            # gdb_commands_file.close()
+        atexit.register(os.unlink, gdb_file_path)
+        cmd.extend(["-x", gdb_file_path])
         cmd.append("--args")
     cmd.append(exe)
     if defaults_path is not None:
@@ -742,31 +743,30 @@ def start_vehicle(binary, opts, stuff, spawns=None):
     if opts.gdb or opts.gdb_stopped:
         cmd_name += " (gdb)"
         cmd.append("gdb")
-        gdb_commands_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
-        atexit.register(os.unlink, gdb_commands_file.name)
-
-        for breakpoint in opts.breakpoint:
-            gdb_commands_file.write("b %s\n" % (breakpoint,))
-        if opts.disable_breakpoints:
-            gdb_commands_file.write("disable\n")
-        gdb_commands_file.write("set pagination off\n")
-        if not opts.gdb_stopped:
-            gdb_commands_file.write("r\n")
-        gdb_commands_file.close()
-        cmd.extend(["-x", gdb_commands_file.name])
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as gdb_commands_file:
+            for breakpoint in opts.breakpoint:
+                gdb_commands_file.write("b %s\n" % (breakpoint,))
+            if opts.disable_breakpoints:
+                gdb_commands_file.write("disable\n")
+            gdb_commands_file.write("set pagination off\n")
+            if not opts.gdb_stopped:
+                gdb_commands_file.write("r\n")
+            gdb_file_path=gdb_commands_file.name
+        atexit.register(os.unlink, gdb_file_path)
+        cmd.extend(["-x", gdb_file_path])
         cmd.append("--args")
     elif opts.lldb or opts.lldb_stopped:
         cmd_name += " (lldb)"
         cmd.append("lldb")
-        lldb_commands_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
-        atexit.register(os.unlink, lldb_commands_file.name)
-
-        for breakpoint in opts.breakpoint:
-            lldb_commands_file.write("b %s\n" % (breakpoint,))
-        if not opts.lldb_stopped:
-            lldb_commands_file.write("process launch\n")
-        lldb_commands_file.close()
-        cmd.extend(["-s", lldb_commands_file.name])
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as lldb_commands_file:
+            for breakpoint in opts.breakpoint:
+                lldb_commands_file.write("b %s\n" % (breakpoint,))
+            if not opts.lldb_stopped:
+                lldb_commands_file.write("process launch\n")
+            # lldb_commands_file.close()
+            file_path=lldb_commands_file.name
+        atexit.register(os.unlink, file_path)
+        cmd.extend(["-s", file_path])
         cmd.append("--")
     if opts.strace:
         cmd_name += " (strace)"
@@ -825,16 +825,16 @@ def start_vehicle(binary, opts, stuff, spawns=None):
 
             progress("Adding parameters from (%s)" % (str(file),))
     if opts.param:
-        param_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
-        atexit.register(os.unlink, param_file.name)
-        param_dir = os.path.join(param_file.name)
-        single_params = []
-        for p in opts.param:
-            single_params.extend(p.split(','))
-        for sp in single_params:
-            sp.replace("=", " ")
-            sp = sp.strip()
-            param_file.write(f"{sp}\n")
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as param_file:
+            atexit.register(os.unlink, param_file.name)
+            param_dir = os.path.join(param_file.name)
+            single_params = []
+            for p in opts.param:
+                single_params.extend(p.split(','))
+            for sp in single_params:
+                sp.replace("=", " ")
+                sp = sp.strip()
+                param_file.write(f"{sp}\n")
         if path is not None:
             path += "," + str(param_dir)
         else:

--- a/Tools/autotest/test_build_options.py
+++ b/Tools/autotest/test_build_options.py
@@ -446,9 +446,10 @@ class TestBuildOptions(object):
         extra_hwdef_filepath = "/tmp/extra.hwdef"
         self.write_defines_to_file(defines, extra_hwdef_filepath)
         if self.extra_hwdef is not None:
-            content = open(self.extra_hwdef, "r").read()
-            with open(extra_hwdef_filepath, "a") as f:
-                f.write(content)
+            with open(self.extra_hwdef, "r") as f_in:
+                content = f_in.read()
+            with open(extra_hwdef_filepath, "a") as f_out:
+                f_out.write(content)
         util.waf_configure(
             self.board(),
             extra_hwdef=extra_hwdef_filepath,

--- a/Tools/autotest/unittest/annotate_params_unittest.py
+++ b/Tools/autotest/unittest/annotate_params_unittest.py
@@ -39,8 +39,8 @@ class TestParamDocsUpdate(unittest.TestCase):
         self.temp_dir = tempfile.mkdtemp()
 
         # Create a temporary file
-        self.temp_file = tempfile.NamedTemporaryFile(delete=False)
-
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as temp_file:
+            self.temp_file = temp_file.name
         # Create a dictionary of parameter documentation
         self.doc_dict = {
             "PARAM1": {

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -216,15 +216,23 @@ class Context(object):
 class TeeBoth(object):
     def __init__(self, name, mode, mavproxy_logfile, suppress_stdout=False):
         self.suppress_stdout = suppress_stdout
-        self.file = open(name, mode)
+        self.file = open(name, mode)  # noqa: SIM115
         self.stdout = sys.stdout
         self.stderr = sys.stderr
         self.mavproxy_logfile = mavproxy_logfile
         self.mavproxy_logfile.set_fh(self)
         sys.stdout = self
         sys.stderr = self
+    def __enter__(self):
+        return self 
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close() 
 
     def close(self):
+        if self.file is not None:
+            self.file.close()
+            self.file = None
         sys.stdout = self.stdout
         sys.stderr = self.stderr
         self.mavproxy_logfile.set_fh(None)
@@ -2194,16 +2202,17 @@ class TestSuite(abc.ABC):
     def count_expected_fence_lines_in_filepath(self, filepath):
         count = 0
         is_qgc = False
-        for i in open(filepath):
-            i = re.sub("#.*", "", i) # trim comments
-            if i.isspace():
-                # skip empty lines
-                continue
-            if re.match("QGC", i):
-                # skip QGC header line
-                is_qgc = True
-                continue
-            count += 1
+        with open(filepath) as f:
+            for i in f:
+                i = re.sub("#.*", "", i) # trim comments
+                if i.isspace():
+                    # skip empty lines
+                    continue
+                if re.match("QGC", i):
+                    # skip QGC header line
+                    is_qgc = True
+                    continue
+                count += 1
         if is_qgc:
             count += 2 # file doesn't include return point + closing point
         return count
@@ -2289,13 +2298,14 @@ class TestSuite(abc.ABC):
             filepath = self.generic_mission_filepath_for_filename(filename)
         self.progress("Loading fence from (%s)" % str(filepath))
         locs = []
-        for line in open(filepath, 'rb'):
-            if len(line) == 0:
-                continue
-            m = re.match(r"([-\d.]+)\s+([-\d.]+)\s*", line.decode('ascii'))
-            if m is None:
-                raise ValueError("Did not match (%s)" % line)
-            locs.append(mavutil.location(float(m.group(1)), float(m.group(2)), 0, 0))
+        with open(filepath, 'rb') as f:
+            for line in f:
+                if len(line) == 0:
+                    continue
+                m = re.match(r"([-\d.]+)\s+([-\d.]+)\s*", line.decode('ascii'))
+                if m is None:
+                    raise ValueError("Did not match (%s)" % line)
+                locs.append(mavutil.location(float(m.group(1)), float(m.group(2)), 0, 0))
         if self.is_plane():
             # create return point as the centroid:
             total_lat = 0
@@ -2566,7 +2576,8 @@ class TestSuite(abc.ABC):
 
     def htree_from_xml(self, xml_filepath):
         '''swiped from mavproxy_param.py'''
-        xml = open(xml_filepath, 'rb').read()
+        with open(xml_filepath) as f:
+           xml=f.read()  
         from lxml import objectify
         objectify.enable_recursive_str()
         tree = objectify.fromstring(xml)
@@ -2692,7 +2703,8 @@ class TestSuite(abc.ABC):
         structure_files = self.find_LogStructureFiles()
         structure_lines = []
         for f in structure_files:
-            structure_lines.extend(open(f).readlines())
+            with open(f) as f2:
+                structure_lines.extend(f2.readlines())
 
         defines = self.find_format_defines(structure_lines)
 
@@ -2710,79 +2722,80 @@ class TestSuite(abc.ABC):
             debug = False
             if f == "/home/pbarker/rc/ardupilot/libraries/AP_HAL_ChibiOS/LogStructure.h":
                 debug = True
-            for line in open(f).readlines():
-                if debug:
-                    print("line: %s" % line)
-                if isinstance(line, bytes):
-                    line = line.decode("utf-8")
-                line = re.sub("//.*", "", line) # trim comments
-                if re.match(r"\s*$", line):
-                    # blank line
-                    continue
-                if state == state_outside:
-                    if ("#define LOG_COMMON_STRUCTURES" in line or
-                            re.match("#define LOG_STRUCTURE_FROM_.*", line) or
-                            re.match("#define LOG_RTC_MESSAGE.*", line)):
-                        if debug:
-                            self.progress("Moving inside")
-                        state = state_inside
-                    continue
-                if state == state_inside:
-                    if linestate == linestate_none:
-                        allowed_list = [
-                            'LOG_STRUCTURE_FROM_',
-                            'LOG_RTC_MESSAGE',
-                        ]
+            with open(f) as fh:
+                for line in fh.readlines():
+                    if debug:
+                        print("line: %s" % line)
+                    if isinstance(line, bytes):
+                        line = line.decode("utf-8")
+                    line = re.sub("//.*", "", line) # trim comments
+                    if re.match(r"\s*$", line):
+                        # blank line
+                        continue
+                    if state == state_outside:
+                        if ("#define LOG_COMMON_STRUCTURES" in line or
+                                re.match("#define LOG_STRUCTURE_FROM_.*", line) or
+                                re.match("#define LOG_RTC_MESSAGE.*", line)):
+                            if debug:
+                                self.progress("Moving inside")
+                            state = state_inside
+                        continue
+                    if state == state_inside:
+                        if linestate == linestate_none:
+                            allowed_list = [
+                                'LOG_STRUCTURE_FROM_',
+                                'LOG_RTC_MESSAGE',
+                            ]
 
-                        allowed = False
-                        for a in allowed_list:
-                            if a in line:
-                                allowed = True
-                        if allowed:
-                            continue
-                        m = re.match(r"\s*{(.*)},\s*", line)
-                        if m is not None:
-                            # complete line
+                            allowed = False
+                            for a in allowed_list:
+                                if a in line:
+                                    allowed = True
+                            if allowed:
+                                continue
+                            m = re.match(r"\s*{(.*)},\s*", line)
+                            if m is not None:
+                                # complete line
+                                if debug:
+                                    print("Complete line: %s" % str(line))
+                                message_infos.append(m.group(1))
+                                continue
+                            m = re.match(r"\s*{(.*)\\", line)
+                            if m is None:
+                                if debug:
+                                    self.progress("Moving outside")
+                                state = state_outside
+                                continue
+                            partial_line = m.group(1)
                             if debug:
-                                print("Complete line: %s" % str(line))
-                            message_infos.append(m.group(1))
+                                self.progress("partial line")
+                            linestate = linestate_within
                             continue
-                        m = re.match(r"\s*{(.*)\\", line)
-                        if m is None:
+                        if linestate == linestate_within:
                             if debug:
-                                self.progress("Moving outside")
-                            state = state_outside
+                                self.progress("Looking for close-brace")
+                            m = re.match("(.*)}", line)
+                            if m is None:
+                                if debug:
+                                    self.progress("no close-brace")
+                                line = line.rstrip()
+                                newline = re.sub(r"\\$", "", line)
+                                if newline == line:
+                                    raise NotAchievedException("Expected backslash at end of line")
+                                line = newline
+                                line = line.rstrip()
+                                # cpp-style string concatenation:
+                                if debug:
+                                    self.progress("more partial line")
+                                line = re.sub(r'"\s*"', '', line)
+                                partial_line += line
+                                continue
+                            if debug:
+                                self.progress("found close-brace")
+                            message_infos.append(partial_line + m.group(1))
+                            linestate = linestate_none
                             continue
-                        partial_line = m.group(1)
-                        if debug:
-                            self.progress("partial line")
-                        linestate = linestate_within
-                        continue
-                    if linestate == linestate_within:
-                        if debug:
-                            self.progress("Looking for close-brace")
-                        m = re.match("(.*)}", line)
-                        if m is None:
-                            if debug:
-                                self.progress("no close-brace")
-                            line = line.rstrip()
-                            newline = re.sub(r"\\$", "", line)
-                            if newline == line:
-                                raise NotAchievedException("Expected backslash at end of line")
-                            line = newline
-                            line = line.rstrip()
-                            # cpp-style string concatenation:
-                            if debug:
-                                self.progress("more partial line")
-                            line = re.sub(r'"\s*"', '', line)
-                            partial_line += line
-                            continue
-                        if debug:
-                            self.progress("found close-brace")
-                        message_infos.append(partial_line + m.group(1))
-                        linestate = linestate_none
-                        continue
-                    raise NotAchievedException("Bad line (%s)")
+                        raise NotAchievedException("Bad line (%s)")
 
             if linestate != linestate_none:
                 raise NotAchievedException("Must be linestate-none at end of file")
@@ -2795,64 +2808,65 @@ class TestSuite(abc.ABC):
         linestate_none = 89
         linestate_within = 90
         linestate = linestate_none
-        for line in open(filepath, 'rb').readlines():
-            if isinstance(line, bytes):
-                line = line.decode("utf-8")
-            line = re.sub("//.*", "", line) # trim comments
-            if re.match(r"\s*$", line):
-                # blank line
-                continue
-            if state == state_outside:
-                if ("const LogStructure" in line or
-                        "const struct LogStructure" in line):
-                    state = state_inside
-                continue
-            if state == state_inside:
-                if re.match("};", line):
-                    state = state_outside
-                    break
-                if linestate == linestate_none:
-                    if "#if HAL_QUADPLANE_ENABLED" in line:
-                        continue
-                    if "#if FRAME_CONFIG == HELI_FRAME" in line:
-                        continue
-                    if "#if AC_PRECLAND_ENABLED" in line:
-                        continue
-                    if "#if AP_PLANE_OFFBOARD_GUIDED_SLEW_ENABLED" in line:
-                        continue
-                    if "#end" in line:
-                        continue
-                    if "LOG_COMMON_STRUCTURES" in line:
-                        continue
-                    m = re.match(r"\s*{(.*)},\s*", line)
-                    if m is not None:
-                        # complete line
-                        # print("Complete line: %s" % str(line))
-                        message_infos.append(m.group(1))
-                        continue
-                    m = re.match(r"\s*{(.*)", line)
-                    if m is None:
-                        raise NotAchievedException("Bad line %s" % line)
-                    partial_line = m.group(1)
-                    linestate = linestate_within
+        with open(filepath, 'rb') as fh:
+            for line in fh.readlines():
+                if isinstance(line, bytes):
+                    line = line.decode("utf-8")
+                line = re.sub("//.*", "", line) # trim comments
+                if re.match(r"\s*$", line):
+                    # blank line
                     continue
-                if linestate == linestate_within:
-                    m = re.match("(.*)}", line)
-                    if m is None:
-                        line = line.rstrip()
-                        newline = re.sub(r"\\$", "", line)
-                        if newline == line:
-                            raise NotAchievedException("Expected backslash at end of line")
-                        line = newline
-                        line = line.rstrip()
-                        # cpp-style string concatenation:
-                        line = re.sub(r'"\s*"', '', line)
-                        partial_line += line
-                        continue
-                    message_infos.append(partial_line + m.group(1))
-                    linestate = linestate_none
+                if state == state_outside:
+                    if ("const LogStructure" in line or
+                            "const struct LogStructure" in line):
+                        state = state_inside
                     continue
-                raise NotAchievedException("Bad line (%s)")
+                if state == state_inside:
+                    if re.match("};", line):
+                        state = state_outside
+                        break
+                    if linestate == linestate_none:
+                        if "#if HAL_QUADPLANE_ENABLED" in line:
+                            continue
+                        if "#if FRAME_CONFIG == HELI_FRAME" in line:
+                            continue
+                        if "#if AC_PRECLAND_ENABLED" in line:
+                            continue
+                        if "#if AP_PLANE_OFFBOARD_GUIDED_SLEW_ENABLED" in line:
+                            continue
+                        if "#end" in line:
+                            continue
+                        if "LOG_COMMON_STRUCTURES" in line:
+                            continue
+                        m = re.match(r"\s*{(.*)},\s*", line)
+                        if m is not None:
+                            # complete line
+                            # print("Complete line: %s" % str(line))
+                            message_infos.append(m.group(1))
+                            continue
+                        m = re.match(r"\s*{(.*)", line)
+                        if m is None:
+                            raise NotAchievedException("Bad line %s" % line)
+                        partial_line = m.group(1)
+                        linestate = linestate_within
+                        continue
+                    if linestate == linestate_within:
+                        m = re.match("(.*)}", line)
+                        if m is None:
+                            line = line.rstrip()
+                            newline = re.sub(r"\\$", "", line)
+                            if newline == line:
+                                raise NotAchievedException("Expected backslash at end of line")
+                            line = newline
+                            line = line.rstrip()
+                            # cpp-style string concatenation:
+                            line = re.sub(r'"\s*"', '', line)
+                            partial_line += line
+                            continue
+                        message_infos.append(partial_line + m.group(1))
+                        linestate = linestate_none
+                        continue
+                    raise NotAchievedException("Bad line (%s)")
 
         if state == state_inside:
             raise NotAchievedException("Should not be in state_inside at end")
@@ -2895,27 +2909,28 @@ class TestSuite(abc.ABC):
                         # this is the sample file which contains examples...
                         continue
                     count = 0
-                    for line in open(filepath, 'rb').readlines():
-                        if isinstance(line, bytes):
-                            line = line.decode("utf-8")
-                        if state == state_outside:
-                            if (re.match(r"\s*AP::logger\(\)[.]Write(?:Streaming)?\(", line) or
-                                    re.match(r"\s*logger[.]Write(?:Streaming)?\(", line)):
-                                state = state_inside
+                    with open(filepath, 'rb') as fh:
+                        for line in fh:
+                            if isinstance(line, bytes):
+                                line = line.decode("utf-8")
+                            if state == state_outside:
+                                if (re.match(r"\s*AP::logger\(\)[.]Write(?:Streaming)?\(", line) or
+                                        re.match(r"\s*logger[.]Write(?:Streaming)?\(", line)):
+                                    state = state_inside
+                                    line = re.sub("//.*", "", line) # trim comments
+                                    log_write_statement = line
+                                continue
+                            if state == state_inside:
                                 line = re.sub("//.*", "", line) # trim comments
-                                log_write_statement = line
-                            continue
-                        if state == state_inside:
-                            line = re.sub("//.*", "", line) # trim comments
-                            # cpp-style string concatenation:
-                            line = re.sub(r'"\s*"', '', line)
-                            log_write_statement += line
-                            if re.match(r".*\);", line):
-                                log_write_statements.append(log_write_statement)
-                                state = state_outside
-                        count += 1
-                    if state != state_outside:
-                        raise NotAchievedException("Expected to be outside at end of file")
+                                # cpp-style string concatenation:
+                                line = re.sub(r'"\s*"', '', line)
+                                log_write_statement += line
+                                if re.match(r".*\);", line):
+                                    log_write_statements.append(log_write_statement)
+                                    state = state_outside
+                            count += 1
+                        if state != state_outside:
+                            raise NotAchievedException("Expected to be outside at end of file")
 #                    print("%s has %u lines" % (f, count))
         # change all whitespace to single space
         log_write_statements = [re.sub(r"\s+", " ", x) for x in log_write_statements]
@@ -3037,7 +3052,8 @@ class TestSuite(abc.ABC):
         self.progress("xml file length is %u" % length)
 
         from lxml import objectify
-        xml = open(xml_filepath, 'rb').read()
+        with open(xml_filepath, 'rb') as f:
+            xml = f.read()
         objectify.enable_recursive_str()
         tree = objectify.fromstring(xml)
 
@@ -3441,7 +3457,7 @@ class TestSuite(abc.ABC):
         usec = int(time.time() * 1.0e6)
         if self.tlog is None:
             tlog_filename = "autotest-%u.tlog" % usec
-            self.tlog = open(tlog_filename, 'wb')
+            self.tlog = open(tlog_filename, 'wb')   # noqa: SIM115
 
         content = bytearray(struct.pack('>Q', usec) + msg.get_msgbuf())
         self.tlog.write(content)
@@ -5023,10 +5039,9 @@ class TestSuite(abc.ABC):
     def assert_mission_files_same(self, file1, file2, match_comments=False):
         self.progress("Comparing (%s) and (%s)" % (file1, file2, ))
 
-        f1 = open(file1)
-        f2 = open(file2)
-        lines1 = f1.readlines()
-        lines2 = f2.readlines()
+        with open(file1) as f1, open(file2) as f2:
+            lines1 = f1.readlines()
+            lines2 = f2.readlines()
 
         if not match_comments:
             # strip comments from all lines
@@ -5179,15 +5194,14 @@ class TestSuite(abc.ABC):
 
     def assert_rally_files_same(self, file1, file2):
         self.progress("Comparing (%s) and (%s)" % (file1, file2, ))
-        f1 = open(file1)
-        f2 = open(file2)
-        lines_f1 = f1.readlines()
-        lines_f2 = f2.readlines()
+        with open(file1) as f1, open(file2) as f2:
+            lines_f1 = f1.readlines()
+            lines_f2 = f2.readlines()
         self.assert_rally_content_same(lines_f1, lines_f2)
 
     def assert_rally_filepath_content(self, file1, content):
-        f1 = open(file1)
-        lines_f1 = f1.readlines()
+        with open(file1) as f1:
+            lines_f1 = f1.readlines()
         lines_content = content.split("\n")
         print("lines content: %s" % str(lines_content))
         self.assert_rally_content_same(lines_f1, lines_content)
@@ -14723,38 +14737,39 @@ switch value'''
         mavproxy = self.start_mavproxy()
         mavproxy.expect("Saved .* parameters to")
         ex = None
-        tmpfile = tempfile.NamedTemporaryFile(mode='r', delete=False)
-        try:
-            mavproxy.send("module load ftp\n")
-            mavproxy.expect(["Loaded module ftp", "module ftp already loaded"])
-            mavproxy.send("ftp set debug 1\n")  # so we get the "Terminated session" message
-            mavproxy.send("ftp get %s %s\n" % (path, tmpfile.name))
-            mavproxy.expect("Getting")
-            tstart = self.get_sim_time()
-            while True:
-                now = self.get_sim_time()
-                if now - tstart > timeout:
-                    raise NotAchievedException("expected complete transfer")
-                self.progress("Polling status")
-                mavproxy.send("ftp status\n")
-                try:
-                    mavproxy.expect("No transfer in progress", timeout=1)
-                    break
-                except Exception:  # noqa: BLE001
-                    continue
-            # terminate the connection, or it may still be in progress the next time an FTP is attempted:
-            mavproxy.send("ftp cancel\n")
-            mavproxy.expect("Terminated session")
-        except Exception as e:  # noqa: BLE001
-            self.print_exception_caught(e)
-            ex = e
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmpfile:
+            try:
+                mavproxy.send("module load ftp\n")
+                mavproxy.expect(["Loaded module ftp", "module ftp already loaded"])
+                mavproxy.send("ftp set debug 1\n")  # so we get the "Terminated session" message
+                mavproxy.send("ftp get %s %s\n" % (path, tmpfile.name))
+                mavproxy.expect("Getting")
+                tstart = self.get_sim_time()
+                while True:
+                    now = self.get_sim_time()
+                    if now - tstart > timeout:
+                        raise NotAchievedException("expected complete transfer")
+                    self.progress("Polling status")
+                    mavproxy.send("ftp status\n")
+                    try:
+                        mavproxy.expect("No transfer in progress", timeout=1)
+                        break
+                    except Exception:  # noqa: BLE001
+                        continue
+                # terminate the connection, or it may still be in progress the next time an FTP is attempted:
+                mavproxy.send("ftp cancel\n")
+                mavproxy.expect("Terminated session")
+            except Exception as e:  # noqa: BLE001
+                self.print_exception_caught(e)
+                ex = e
 
-        self.stop_mavproxy(mavproxy)
+            self.stop_mavproxy(mavproxy)
 
-        if ex is not None:
-            raise ex
+            if ex is not None:
+                raise ex
+            tempfile_content=tmpfile.read()
 
-        return tmpfile.read()
+        return tempfile_content
 
     def MAVFTP(self):
         '''ensure MAVProxy can do MAVFTP to ardupilot'''


### PR DESCRIPTION
## Summary

<!-- a one or two line summary of what your PR does here -->

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included
- [x] ruff checks locally

Key Implementation Details:

Context Managers: Refactored standard file opening logic to use with statements where the file lifecycle is local, ensuring automatic closure (e.g., in arducopter.py and loadfile utilities).

Temporary Files: Updated tempfile.NamedTemporaryFile usage to work within context managers, safely capturing the filename for external process calls (like SITL and unit tests) before the context closes.

Linting Overrides (# noqa: SIM115): Applied selective overrides in cases where file handles must persist as object attributes (self.fh) for continuous logging (e.g., in metadata emitters and lock_file), as a standard with block is impractical in these specific architectural patterns.

General Cleanup: Removed redundant manual .close() calls following the refactor

References
[Python documentation: open](https://docs.python.org/3/library/functions.html#open)