### PR TITLE
AP_NavEKF3: reset terrain offset from baro when ground effect clears

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -112,27 +112,32 @@ void NavEKF3_core::EstimateTerrainOffset(const of_elements &ofDataDelayed)
         Popt += Pincrement;
         timeAtLastAuxEKF_ms = imuSampleTime_ms;
 
-        // Detect ground effect clearing.  When neither takeoff nor
-        // touchdown ground effect is expected, the baro is trustworthy
-        // again (configured via TKOFF_GNDEFF_ALT/TMO on the vehicle).
+        // Detect ground effect entry/exit.  Snapshot baroHgtOffset at
+        // entry while it is still uncontaminated, so we can convert
+        // raw baro height into EKF NED-D frame on exit.
         const bool gndEffectActive = dal.get_takeoff_expected() || dal.get_touchdown_expected();
+        const bool gndEffectJustEntered = !prevGndEffectActive && gndEffectActive;
         const bool gndEffectJustCleared = prevGndEffectActive && !gndEffectActive;
         prevGndEffectActive = gndEffectActive;
+        if (gndEffectJustEntered) {
+            baroHgtOffsetPreGndEffect = baroHgtOffset;
+        }
 
         // fuse range finder data
         if (rangeDataToFuse) {
             if (imuSampleTime_ms - gndHgtValidTime_ms > 5000) {
                 // reset terrain state if rangefinder data not fused for 5 seconds
                 terrainState = MAX(rangeDataDelayed.rng * prevTnb.c.z, rngOnGnd) + stateStruct.position.z;
-            } else if (gndEffectJustCleared) {
+            } else if (gndEffectJustCleared && activeHgtSource == AP_NavEKF_Source::SourceZ::BARO) {
                 // Reset terrain offset using raw baro height (now
                 // trusted) and rangefinder, independent of PD which
                 // may have been contaminated during ground effect.
-                // Use raw baroDataDelayed.hgt (not baroHgt - baroHgtOffset)
-                // because baroHgtOffset tracks the contaminated PD.
-                // Raw baro after datum reset reads height above takeoff.
+                // Convert raw baro into EKF NED-D frame using the
+                // baroHgtOffset snapshot from before ground effect,
+                // since the live baroHgtOffset tracks the contaminated PD.
+                // Only applies when baro is the active height source.
                 const ftype rngAgl = MAX(rangeDataDelayed.rng * prevTnb.c.z, rngOnGnd);
-                terrainState = -baroDataDelayed.hgt + rngAgl;
+                terrainState = -(baroDataDelayed.hgt - baroHgtOffsetPreGndEffect) + rngAgl;
                 Popt = sq(frontend->_rngNoise);
             }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -112,11 +112,28 @@ void NavEKF3_core::EstimateTerrainOffset(const of_elements &ofDataDelayed)
         Popt += Pincrement;
         timeAtLastAuxEKF_ms = imuSampleTime_ms;
 
+        // Detect ground effect clearing.  When neither takeoff nor
+        // touchdown ground effect is expected, the baro is trustworthy
+        // again (configured via TKOFF_GNDEFF_ALT/TMO on the vehicle).
+        const bool gndEffectActive = dal.get_takeoff_expected() || dal.get_touchdown_expected();
+        const bool gndEffectJustCleared = prevGndEffectActive && !gndEffectActive;
+        prevGndEffectActive = gndEffectActive;
+
         // fuse range finder data
         if (rangeDataToFuse) {
-            // reset terrain state if rangefinder data not fused for 5 seconds
             if (imuSampleTime_ms - gndHgtValidTime_ms > 5000) {
+                // reset terrain state if rangefinder data not fused for 5 seconds
                 terrainState = MAX(rangeDataDelayed.rng * prevTnb.c.z, rngOnGnd) + stateStruct.position.z;
+            } else if (gndEffectJustCleared) {
+                // Reset terrain offset using raw baro height (now
+                // trusted) and rangefinder, independent of PD which
+                // may have been contaminated during ground effect.
+                // Use raw baroDataDelayed.hgt (not baroHgt - baroHgtOffset)
+                // because baroHgtOffset tracks the contaminated PD.
+                // Raw baro after datum reset reads height above takeoff.
+                const ftype rngAgl = MAX(rangeDataDelayed.rng * prevTnb.c.z, rngOnGnd);
+                terrainState = -baroDataDelayed.hgt + rngAgl;
+                Popt = sq(frontend->_rngNoise);
             }
 
             // predict range

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -283,6 +283,7 @@ void NavEKF3_core::InitialiseVariables()
     gpsPosAccuracy = 0.0f;
     gpsHgtAccuracy = 0.0f;
     baroHgtOffset = 0.0f;
+    baroHgtOffsetPreGndEffect = 0.0f;
     rngOnGnd = 0.05f;
 #if EK3_FEATURE_OPTFLOW_AGL_KF
     // 2-state AGL KF initialisation

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1306,6 +1306,7 @@ private:
     uint32_t rngValidMeaTime_ms;    // time stamp from latest valid range measurement (msec)
     uint32_t flowMeaTime_ms;        // time stamp from latest flow measurement (msec)
     uint32_t gndHgtValidTime_ms;    // time stamp from last terrain offset state update (msec)
+    bool prevGndEffectActive;       // ground effect active from previous frame, for transition detection
     Vector2 flowVarInnov;           // optical flow innovations variances (rad/sec)^2
     Vector2 flowInnov;              // optical flow LOS innovations (rad/sec)
     uint32_t flowInnovTime_ms;      // system time that optical flow innovations and variances were recorded (to detect timeouts)

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1307,6 +1307,7 @@ private:
     uint32_t flowMeaTime_ms;        // time stamp from latest flow measurement (msec)
     uint32_t gndHgtValidTime_ms;    // time stamp from last terrain offset state update (msec)
     bool prevGndEffectActive;       // ground effect active from previous frame, for transition detection
+    ftype baroHgtOffsetPreGndEffect; // baroHgtOffset snapshotted at ground effect entry (m), used to map raw baro into EKF NED-D frame at ground effect exit
     Vector2 flowVarInnov;           // optical flow innovations variances (rad/sec)^2
     Vector2 flowInnov;              // optical flow LOS innovations (rad/sec)
     uint32_t flowInnovTime_ms;      // system time that optical flow innovations and variances were recorded (to detect timeouts)


### PR DESCRIPTION
### Summary

Resets the EKF3 terrain offset from baro plus rangefinder when the ground effect flags clear, for vehicles with a rangefinder height switch (EK3_RNG_USE_HGT > 0), where a terrain offset contaminated in ground effect holds the height estimate wrong. SITL work since the first version shows the reset does not reach the error in the flown configuration; see the status below before reviewing it as a fix.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Tested manually, description below (SITL)
- [x] Tested on hardware
- [x] Logs available on request

TerrainOffsetGroundEffectRecovery records the case in `disabled_tests()`: it fails on master and with this change (terrain offset mean +0.205 to +0.251 m on master EKF3, 3 runs, and +0.217 to +0.243 m with the reset, 4 runs, against a 0.15 m limit). The dwell in ground effect settles 0.75 to 0.9 m above the ground, measured on the rangefinder and bounded in the test, because ALT_HOLD holds a height the ground effect has already disturbed. How deep the dwell sits in the band decides the result.

### Description

The terrain offset is initialised from PD plus the rangefinder, so baro error that reaches PD while ground effect is expected is carried into `terrainState`. With EK3_RNG_USE_HGT > 0 the rangefinder height observation is referenced through `terrainState`, so a wrong offset then holds the height estimate wrong. Flight tests showed a 1.88 m terrain offset and a 1.74 m height error in a hover with baro and rangefinder both reading about 0.96 m.

When takeoff_expected or touchdown_expected clears, the edge is latched, and on the next cycle carrying range data, with baro as the active height source, `terrainState` is set from the baro height (live `baroHgtOffset` and the EK3_OGN_HGT_MASK origin correction, matching the observation `selectHeightForFusion()` builds) and the tilt-corrected range, with Popt reopened to the range noise. The latch is dropped if ground effect is expected again before range data arrives. Vehicles without a rangefinder never see range data, so the reset does not run for them.

Status, from SITL and flight data:

- An earlier form of the reset, flown with the ground effect release gated on height above ground, held the terrain offset at 0.3 m. The reset alone, flown without that gate, drifted from -0.19 to -1.08 m in 25 s.
- On master the 5 s `AP_GROUNDEFFECT_TAKEOFF_MAX_MS` cap releases takeoff_expected whatever the height, so on a long low hover the reset fires while the baro is still disturbed. In a rig with a 10 m rangefinder and EK3_RNG_USE_HGT=50, the reset alone leaves the terrain offset error at master's (about +0.24 m); with the takeoff window held while height above ground is below GNDEFF_ALT it goes to about -0.01 m. Neither change works alone.
- In a rig matching the flown EK3_RNG_USE_HGT=3 configuration the error is not in the terrain state. While the rangefinder is the height source, `calcFiltBaroOffset()` learns `baroHgtOffset` from the ground effect baro, and the switch to baro on the climb out puts it into PD (+0.44 to +1.25 m on master at 4 m, depending on the ground effect size). This reset does not change that. Stopping offset learning while ground effect is expected removes the climb-out step but moves the error into the hover, which is the flight signature. Details and numbers: https://github.com/ArduPilot/ardupilot/pull/32553#issuecomment-5681318760
- A replay of a later flight in the flown configuration was attempted and could not reproduce the flight in the air, because the logger dropped a third of the replay frames. That flight also showed a 3 m height error after landing with baro and rangefinder agreeing, which points at a ground reference captured in the air rather than the terrain state.

So the reset is kept here as a record while the fix is looked for in keeping the ground effect baro out of `baroHgtOffset` and PD. This does not address #32612, which is the rangefinder-to-baro datum offset with no ground effect involved.
