### PR TITLE
.github: move non building job to ubuntu-slim

### DIFF
--- a/.github/workflows/cache_cleanup.yml
+++ b/.github/workflows/cache_cleanup.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   cleanup:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-slim
     permissions:
       # `actions:write` permission is required to delete caches
       #   See also: https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#delete-a-github-actions-cache-for-a-repository-using-a-cache-id

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6


### PR DESCRIPTION
## Summary

Unclog our CI by using ubuntu-slim instance for non building jobs : https://docs.github.com/en/actions/reference/runners/github-hosted-runners . Those are 1cpu but should be enought for python docs/python checking and will free up machine for building.

Those machine are already docker containers so we cannot use Ardupilot containers

<img width="797" height="418" alt="Capture d’écran du 2026-03-25 17-20-36" src="https://github.com/user-attachments/assets/55b4bbb3-a8cd-41e0-be9b-d79ddc19669b" />

^ show it works by launching the machine when all the other test are long on wait list !

## Testing (more checks increases chance of being merged)

- [ X] Checked by a human programmer
- [ X] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included
