### PR TITLE
Action slim2

### DIFF
--- a/.github/workflows/test_scripts.yml
+++ b/.github/workflows/test_scripts.yml
@@ -8,8 +8,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
-    container: ardupilot/ardupilot-dev-base:v0.1.3
+    runs-on: ubuntu-slim
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:
@@ -21,12 +20,24 @@ jobs:
             validate_board_list,
             logger_metadata,
             param-file-validation,
-       ]
+          ]
     steps:
       # git checkout the PR
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: 'pip' # caching pip dependencies
+          pip-install: flake8 lxml popen pexpect
+
+      - name: Install checker stuffs
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y astyle
+
       - name: test ${{matrix.config}}
         env:
           CI_BUILD_TARGET: ${{matrix.config}}


### PR DESCRIPTION
## Summary

Follow from https://github.com/ArduPilot/ardupilot/pull/32554 : move test_scripts to ubuntu-slim and out of ardupilot
## Testing (more checks increases chance of being merged)
Bit slower than previously but we should have the result faster than waiting for the other machine to free

- [X ] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

