### PR TITLE
Don't leak ansi color state from waf

### DIFF
--- a/Tools/ardupilotwaf/build_summary.py
+++ b/Tools/ardupilotwaf/build_summary.py
@@ -164,7 +164,7 @@ def _build_summary(bld):
             Logs.info('')
             Logs.pprint(
                 'NORMAL',
-                '\033[0;31;1mNote: Some targets were suppressed. Use --summary-all if you want information of all targets.',
+                '\033[0;31;1mNote: Some targets were suppressed. Use --summary-all if you want information of all targets.\033[0m',
             )
 
     if hasattr(bld, 'extra_build_summary'):


### PR DESCRIPTION
## Summary

End the red-bold formatting started by a waf after the print is done.

Before:
<img width="830" height="356" alt="image" src="https://github.com/user-attachments/assets/934a4e9a-06ef-4b06-b160-887c49475c95" />

After:
<img width="833" height="333" alt="image" src="https://github.com/user-attachments/assets/13a93dc0-bbd0-43f5-bf34-abea28008952" />

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
