### PR TITLE
SITL: Unit tests for Battery

### DIFF
--- a/libraries/SITL/SIM_Battery.cpp
+++ b/libraries/SITL/SIM_Battery.cpp
@@ -138,19 +138,19 @@ void Battery::init_capacity(float capacity)
 
 void Battery::set_current(float current)
 {
-    const uint64_t now_micros = AP_HAL::micros64();
-    set_current(current, now_micros);
+    const uint64_t now_us = AP_HAL::micros64();
+    set_current(current, now_us);
 }
 
-void Battery::set_current(float current, uint64_t now_micros)
+void Battery::set_current(float current, uint64_t now_us)
 {
-    constexpr float micros_to_sec = 1.0e-6f;
-    float dt = static_cast<float>(now_micros - last_micros) * micros_to_sec;
+    constexpr float microsec_to_sec = 1.0e-6f;
+    float dt = static_cast<float>(now_us - last_us) * microsec_to_sec;
     if (dt > 0.1) {
         // we stopped updating
         dt = 0;
     }
-    last_micros = now_micros;
+    last_us = now_us;
     float delta_Ah = current * dt / 3600;
     remaining_Ah -= delta_Ah;
     remaining_Ah = MAX(0, remaining_Ah);
@@ -166,8 +166,8 @@ void Battery::set_current(float current, uint64_t now_micros)
     voltage_filter.apply(voltage, dt);
 
     {
-        const uint64_t temperature_dt = now_micros - temperature.last_update_micros;
-        temperature.last_update_micros = now_micros;
+        const uint64_t temperature_dt = now_us - temperature.last_update_us;
+        temperature.last_update_us = now_us;
         // 1 amp*1 second == 0.1 degrees of energy.  Did those units hurt?
         temperature.kelvin += 0.1 * current * temperature_dt * 0.000001;
         // decay temperature at some %second towards ambient

--- a/libraries/SITL/SIM_Battery.h
+++ b/libraries/SITL/SIM_Battery.h
@@ -30,7 +30,7 @@ public:
     void init_capacity(float capacity);
 
     // set the current-draw at the instant identified as "now"
-    void set_current(float current_amps, uint64_t now_micros);
+    void set_current(float current_amps, uint64_t now_us);
     // set the current-draw using AP_HAL::micros64() as "now"
     void set_current(float current_amps);
 
@@ -46,11 +46,11 @@ private:
     float max_voltage;
     float voltage_set;
     float remaining_Ah;
-    uint64_t last_micros;
+    uint64_t last_us;
 
     struct {
         float kelvin = 273;
-        uint64_t last_update_micros;
+        uint64_t last_update_us;
     } temperature;
 
     // 10Hz filter for battery voltage

--- a/libraries/SITL/tests/test_battery.cpp
+++ b/libraries/SITL/tests/test_battery.cpp
@@ -19,7 +19,7 @@ constexpr float low_resistance_Ohm = 0.005f;
 constexpr float high_resistance_Ohm = 0.04f;
 
 // This can be any value, in operation it would come from AP_HAL::micros64().
-constexpr uint64_t initial_micros = 0;
+constexpr uint64_t initial_us = 0;
 
 class BatteryTest : public testing::Test {
 protected:
@@ -97,13 +97,13 @@ TEST_F(BatteryTest, EnergyConsumption)
         float prev_temperature = initial_temperature;
 
         for (float t = 0.0f; t <= test_duration_sec; t+=dt_sec) {
-            const uint64_t now_micros = initial_micros + static_cast<uint64_t>(t * 1e6);
+            const uint64_t now_us = initial_us + static_cast<uint64_t>(t * 1e6);
 
             // Consume battery energy (or not)
             if (t > 0.0f && t < first_half) {
-                battery.set_current(current_amps, now_micros);
+                battery.set_current(current_amps, now_us);
             } else {
-                battery.set_current(0.0f, now_micros);
+                battery.set_current(0.0f, now_us);
             }
 
             // Confirm temperature rise
@@ -198,7 +198,7 @@ void use_some_energy(SITL::Battery& battery) {
     constexpr float dt_sec = 0.01f;
 
     for (float t = 0.0f; t <= current_duration_sec; t+=dt_sec) {
-        battery.set_current(current_amps, initial_micros + static_cast<uint64_t>(t * 1e6));
+        battery.set_current(current_amps, initial_us + static_cast<uint64_t>(t * 1e6));
     }
 };
 } // namespace


### PR DESCRIPTION
## Summary

Contributes unit tests for SITL::Battery to document & enforce the behavior.

One behavior change is made and clearly flagged for review: **This PR makes it impossible to set a battery's voltage higher than its max voltage.**

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [x] Unit tested (this PR creates the passing unit tests)
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

The first code-change is adding an optional overload of the battery's main time-stepping function (named `set_current()`) which accepts a specified "now" time instant. No existing calls to `set_current()` use this new option; Users who do not receive identical behavior as before: "now" is provided by `AP_HAL::micros64()`.
The benefit of this new time-stepper is that unit tests can run (much) faster than wall-clock time.

The second code-change is to prevent initializing the voltage to a value higher than the battery's maximum voltage. This looks like a simple bug, is fixed with an obvious one-liner. (All other unexpected behavior can be discussed via future PRs.)

Finally, a strong set of unit tests is created which demonstrates the functionality. These tests will be especially valuable for upcoming discussions, changes, and refactors.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
