### PR TITLE
AP_Camera_Servo.cpp: Fix broken CAMERA_INFORMATION flags

### DIFF
--- a/libraries/AP_Camera/AP_Camera_Servo.cpp
+++ b/libraries/AP_Camera/AP_Camera_Servo.cpp
@@ -9,6 +9,9 @@ extern const AP_HAL::HAL& hal;
 // initialize the AP_Camera_Servo driver
 void AP_Camera_Servo::init()
 {
+    // call parent init to set default camera info (flags, focal length, etc.)
+    AP_Camera_Backend::init();
+
     // set the zoom and focus to the trim point
     SRV_Channels::set_output_scaled(SRV_Channel::k_cam_zoom, 500);
     SRV_Channels::set_output_scaled(SRV_Channel::k_cam_focus, 500);


### PR DESCRIPTION
It was sending CAMERA_INFORMATION flags to 0 ( no capabilities at all ).

QGC which populates camera trigger widgets based on this wasn't working properly for this camera backend.