### PR TITLE
AP_Scripting: plane_follow.lua fix sendtext error if no target vehicle

### DIFF
--- a/libraries/AP_Scripting/applets/plane_follow.lua
+++ b/libraries/AP_Scripting/applets/plane_follow.lua
@@ -564,14 +564,13 @@ local follow_mode = {
       else
          if reported_target then -- i.e. if we previously reported a target but lost it
             if (now_ms - lost_target_now_ms) > 5000 then
-               gcs:send_text(MAV_SEVERITY.WARNING, SCRIPT_NAME_SHORT .. ": lost prior target: " .. follow:get_target_sysid())
+               gcs:send_text(MAV_SEVERITY.WARNING, SCRIPT_NAME_SHORT .. ": lost prior SYSID: " .. tostring(follow:get_target_sysid()) )
                lost_target_now_ms = now_ms
             end
          end
          reported_target = false
-         gcs:send_text(MAV_SEVERITY.WARNING, SCRIPT_NAME_SHORT .. ": no target: " .. follow:get_target_sysid())
+         gcs:send_text(MAV_SEVERITY.WARNING, SCRIPT_NAME_SHORT .. ": no target SYSID: " .. tostring(follow:get_target_sysid()) )
       end
-
       return reported_target
    end
    function follow_mode.enable()


### PR DESCRIPTION
## Summary

Fixes a formatting error in a couple of gcs:send_text() method calls that which would cause the script to crash with an error if there was no follow target available. Ironically the messages are trying to display that there is no follow target available.

## Testing (more checks increases chance of being merged)

- [X] Checked by a human programmer
- [X] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

put tostring() around follow:get_target_sysid()
