### PR TITLE
AP_Compass: reset MMC3416 before WHOAMI read to fix intermittent detection

### DIFF
--- a/libraries/AP_Compass/AP_Compass_MMC3416.cpp
+++ b/libraries/AP_Compass/AP_Compass_MMC3416.cpp
@@ -73,7 +73,11 @@ bool AP_Compass_MMC3416::init()
     dev->get_semaphore()->take_blocking();
 
     dev->set_retries(10);
-    
+
+    // reset sensor. This seems to solve some unreliablity on boot reading WHOAMI
+    dev->write_register(REG_CONTROL1, 0x80);
+    hal.scheduler->delay(10);
+
     uint8_t whoami;
     if (!dev->read_registers(REG_PRODUCT_ID, &whoami, 1) ||
         whoami != 0x06) {


### PR DESCRIPTION

## Summary

 A custom AP_Periph device I have been testing uses the MMC3416 compass. It was intermittently failing to detect the compass on short power cycles. On debugging, I found that the WHOAMI register read itself was failing during probe and even repeated probing wasn't helping. The only thing that reliably brought the chip back was issuing a software reset before attempting the read.

 Thereofre I have added a reset before the WHOAMI check, this is somewhat similar to what IST8310 already does.

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included
