### PR TITLE
Tools: pin numpy<2 in setup scripts for SITL compatibility

### DIFF
--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -214,7 +214,7 @@ if [ ${RELEASE_CODENAME} == 'trixie' ] ||
    [ ${RELEASE_CODENAME} == 'questing' ] ||
    false; then
     # on Lunar (and presumably later releases), we install in venv, below
-    PYTHON_PKGS+=" numpy pyparsing psutil"
+    PYTHON_PKGS+=" numpy<2 pyparsing psutil"
     SITL_PKGS="python3-dev"
 else
 SITL_PKGS="libtool libxml2-dev libxslt1-dev ${PYTHON_V}-dev ${PYTHON_V}-pip ${PYTHON_V}-setuptools ${PYTHON_V}-numpy ${PYTHON_V}-pyparsing ${PYTHON_V}-psutil"

--- a/Tools/scripts/configure-ci.sh
+++ b/Tools/scripts/configure-ci.sh
@@ -99,6 +99,6 @@ fi
 
 python3 -m pip install --progress-bar off --user -U argparse pyserial pexpect lxml
 python3 -m pip install --progress-bar off --user -U intelhex
-python3 -m pip install --progress-bar off --user -U numpy
+python3 -m pip install --progress-bar off --user -U "numpy<2"
 python3 -m pip install --progress-bar off --user -U edn_format
 python3 -m pip install --progress-bar off --user -U empy==3.3.4


### PR DESCRIPTION
pins numpy to <2 in the ubuntu setup script and CI config to fix the SITL MAVProxy crash caused by cv2 being incompatible with numpy 2.x. fixes #31411