### PR TITLE
Sub: add uneven thrust simulation and correction parameter

### DIFF
--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -1238,6 +1238,63 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
             elif m.chan == 2:
                 chan2_last_timestamp_us = att_ts_us
 
+    def AsymmetricThrustCoupling(self):
+        """Confirm thruster asymmetry effects, and that compensation negates them.
+        Asymmetric thrust causes unintentionally coupled motion axes, like altitude change when
+        commanding roll using vertically-oriented thrusters (as is present in the default Sub frame).
+        This test confirms that behaviour, and its removal when asymmetry compensation is applied.
+        """
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        self.change_mode('STABILIZE')
+        self.set_parameter("SIM_BUOYANCY", 0)
+
+        # dive to 5m with symmetric thrust and stabilize
+        self.set_rc(Joystick.Throttle, 1300)
+        self.wait_altitude(altitude_min=-6, altitude_max=-5, relative=False, timeout=60)
+        self.set_rc(Joystick.Throttle, 1500)
+        self.wait_climbrate(-0.02, 0.02, timeout=10)
+
+        # threshold for validation of altitude change
+        altitude_change_threshold = 0.2
+
+        # verify that roll causes depth change without compensation
+        self.set_parameter("SIM_THRUST_ASYM", 0.8)
+        self.set_parameter("MOT_ASYMMETRY", 1.0)
+        alt_before = self.assert_receive_message('VFR_HUD').alt
+        self.set_rc(Joystick.Roll, 1700)
+        self.delay_sim_time(5)
+        self.set_rc(Joystick.Roll, 1500)
+        alt_after = self.assert_receive_message('VFR_HUD').alt
+        alt_delta = abs(alt_after - alt_before)
+        self.progress("Uncompensated altitude change: %.2f m" % alt_delta)
+        if alt_delta < altitude_change_threshold:
+            raise NotAchievedException(
+                "Expected altitude change without compensation, got only %.2f m" % alt_delta)
+
+        # test compensation across a range of asymmetry factors
+        for asymmetry in [0.5, 0.8, 1.0, 1.5, 2.0]:
+            self.progress("Testing asymmetry factor %.1f" % asymmetry)
+            self.set_parameter("SIM_THRUST_ASYM", asymmetry)
+            self.set_parameter("MOT_ASYMMETRY", asymmetry)
+
+            self.set_rc(Joystick.Throttle, 1500)
+            self.wait_climbrate(-0.005, 0.005, timeout=50)
+
+            alt_before = self.assert_receive_message('VFR_HUD').alt
+            self.set_rc(Joystick.Roll, 1700)
+            self.delay_sim_time(5)
+            self.set_rc(Joystick.Roll, 1500)
+            alt_after = self.assert_receive_message('VFR_HUD').alt
+            alt_delta = abs(alt_after - alt_before)
+            self.progress("Compensated altitude change (asymmetry %.1f): %.2f m" % (asymmetry, alt_delta))
+            if alt_delta > altitude_change_threshold:
+                raise NotAchievedException(
+                    "Expected altitude to be maintained with compensation (asymmetry %.1f), got %.2f m change"
+                    % (asymmetry, alt_delta))
+
+        self.disarm_vehicle()
+
     def SurfaceSensorless(self):
         """Test surface mode with sensorless thrust"""
         # set GCS failsafe to SURFACE
@@ -1516,6 +1573,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
             self.PosHoldBounceBack,
             self.SHT3X,
             self.SurfaceSensorless,
+            self.AsymmetricThrustCoupling,
             self.GPSForYaw,
             self.WaterDepth,
             self.VisoForYaw,

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -1278,6 +1278,63 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
             elif m.chan == 2:
                 chan2_last_timestamp_us = att_ts_us
 
+    def AsymmetricThrustCoupling(self):
+        """Confirm thruster asymmetry effects, and that compensation negates them.
+        Asymmetric thrust causes unintentionally coupled motion axes, like altitude change when
+        commanding roll using vertically-oriented thrusters (as is present in the default Sub frame).
+        This test confirms that behaviour, and its removal when asymmetry compensation is applied.
+        """
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        self.change_mode('STABILIZE')
+        self.set_parameter("SIM_BUOYANCY", 0)
+
+        # dive to 5m with symmetric thrust and stabilize
+        self.set_rc(Joystick.Throttle, 1300)
+        self.wait_altitude(altitude_min=-6, altitude_max=-5, relative=False, timeout=60)
+        self.set_rc(Joystick.Throttle, 1500)
+        self.wait_climbrate(-0.02, 0.02, timeout=10)
+
+        # threshold for validation of altitude change
+        altitude_change_threshold = 0.2
+
+        # verify that roll causes depth change without compensation
+        self.set_parameter("SIM_THRUST_ASYM", 0.8)
+        self.set_parameter("MOT_THST_ASYM", 1.0)
+        alt_before = self.assert_receive_message('VFR_HUD').alt
+        self.set_rc(Joystick.Roll, 1700)
+        self.delay_sim_time(5, reason="wait for roll change to take effect")
+        self.set_rc(Joystick.Roll, 1500)
+        alt_after = self.assert_receive_message('VFR_HUD').alt
+        alt_delta = abs(alt_after - alt_before)
+        self.progress("Uncompensated altitude change: %.2f m" % alt_delta)
+        if alt_delta < altitude_change_threshold:
+            raise NotAchievedException(
+                "Expected altitude change without compensation, got only %.2f m" % alt_delta)
+
+        # test compensation across a range of asymmetry factors
+        for asymmetry in [0.5, 0.8, 1.0, 1.5, 2.0]:
+            self.progress("Testing asymmetry factor %.1f" % asymmetry)
+            self.set_parameter("SIM_THRUST_ASYM", asymmetry)
+            self.set_parameter("MOT_THST_ASYM", asymmetry)
+
+            self.set_rc(Joystick.Throttle, 1500)
+            self.wait_climbrate(-0.005, 0.005, timeout=50)
+
+            alt_before = self.assert_receive_message('VFR_HUD').alt
+            self.set_rc(Joystick.Roll, 1700)
+            self.delay_sim_time(5, reason="wait for roll change to take effect")
+            self.set_rc(Joystick.Roll, 1500)
+            alt_after = self.assert_receive_message('VFR_HUD').alt
+            alt_delta = abs(alt_after - alt_before)
+            self.progress("Compensated altitude change (asymmetry %.1f): %.2f m" % (asymmetry, alt_delta))
+            if alt_delta > altitude_change_threshold:
+                raise NotAchievedException(
+                    "Expected altitude to be maintained with compensation (asymmetry %.1f), got %.2f m change"
+                    % (asymmetry, alt_delta))
+
+        self.disarm_vehicle()
+
     def SurfaceSensorless(self):
         """Test surface mode with sensorless thrust"""
         # this drives the throttle down and waits to arrive at 9.5m, so
@@ -1720,6 +1777,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
             self.PosHoldBounceBack,
             self.SHT3X,
             self.SurfaceSensorless,
+            self.AsymmetricThrustCoupling,
             self.GPSForYaw,
             self.WaterDepth,
             self.VisoForYaw,

--- a/libraries/AP_Motors/AP_Motors6DOF.cpp
+++ b/libraries/AP_Motors/AP_Motors6DOF.cpp
@@ -118,6 +118,14 @@ const AP_Param::GroupInfo AP_Motors6DOF::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("12_DIRECTION", 13, AP_Motors6DOF, _motor_reverse[11], 1),
 
+    // @Param: ASYMMETRY
+    // @DisplayName: Motor thrust asymmetry
+    // @Description: Ratio of reverse to forward thrust at matching input magnitude. (Below 1: reverse is weaker than forward.) Controller will compensate for weaker by increasing reverse thrust magnitude (which may clip) and for stronger by reducing thrust magnitude.
+    // @Range: 0.5 2.0
+    // @Increment: 0.05
+    // @User: Standard
+    AP_GROUPINFO("ASYMMETRY", 14, AP_Motors6DOF, _thrust_asymmetry, 1.0f),
+
     AP_GROUPEND
 };
 
@@ -234,6 +242,17 @@ int16_t AP_Motors6DOF::calc_thrust_to_pwm(float thrust_in) const
     return 1500 + thrust_in * (thrust_in > 0 ? range_up : range_down);
 }
 
+// Scale thrust values to compensate for asymmetric forward/reverse motor output.
+// Controller will compensate for weaker by increasing reverse thrust magnitude (which may clip)
+// and for stronger by reducing thrust magnitude (which limits performance).
+float AP_Motors6DOF::compensate_for_thrust_asymmetry(float thrust_in) const
+{
+    if (is_negative(thrust_in) && is_positive(_thrust_asymmetry.get())) {
+        return constrain_float(thrust_in / sqrtf(_thrust_asymmetry.get()), -1.0f, 1.0f);
+    }
+    return thrust_in;
+}
+
 void AP_Motors6DOF::output_to_motors()
 {
     int8_t i;
@@ -263,7 +282,8 @@ void AP_Motors6DOF::output_to_motors()
         // set motor output based on thrust requests
         for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
             if (motor_enabled[i]) {
-                motor_out[i] = calc_thrust_to_pwm(_thrust_rpyt_out[i]);
+                const float thrust_adjusted = compensate_for_thrust_asymmetry(_thrust_rpyt_out[i]);
+                motor_out[i] = calc_thrust_to_pwm(thrust_adjusted);
             }
         }
         break;

--- a/libraries/AP_Motors/AP_Motors6DOF.cpp
+++ b/libraries/AP_Motors/AP_Motors6DOF.cpp
@@ -118,6 +118,14 @@ const AP_Param::GroupInfo AP_Motors6DOF::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("12_DIRECTION", 13, AP_Motors6DOF, _motor_reverse[11], 1),
 
+    // @Param: THST_ASYM
+    // @DisplayName: Motor thrust asymmetry
+    // @Description: Ratio of reverse to forward thrust at matching input magnitude. (Below 1: reverse is weaker than forward.) Controller will compensate for weaker by increasing reverse thrust magnitude (which may clip) and for stronger by reducing thrust magnitude.
+    // @Range: 0.5 2.0
+    // @Increment: 0.05
+    // @User: Standard
+    AP_GROUPINFO("THST_ASYM", 14, AP_Motors6DOF, _thrust_asymmetry, 1.0f),
+
     AP_GROUPEND
 };
 
@@ -234,6 +242,17 @@ int16_t AP_Motors6DOF::calc_thrust_to_pwm(float thrust_in) const
     return 1500 + thrust_in * (thrust_in > 0 ? range_up : range_down);
 }
 
+// Scale thrust values to compensate for asymmetric forward/reverse motor output.
+// Controller will compensate for weaker by increasing reverse thrust magnitude (which may clip)
+// and for stronger by reducing thrust magnitude (which limits performance).
+float AP_Motors6DOF::compensate_for_thrust_asymmetry(float thrust_in) const
+{
+    if (is_negative(thrust_in) && is_positive(_thrust_asymmetry.get())) {
+        return constrain_float(thrust_in / sqrtf(_thrust_asymmetry.get()), -1.0f, 1.0f);
+    }
+    return thrust_in;
+}
+
 void AP_Motors6DOF::output_to_motors()
 {
     int8_t i;
@@ -263,7 +282,8 @@ void AP_Motors6DOF::output_to_motors()
         // set motor output based on thrust requests
         for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
             if (motor_enabled[i]) {
-                motor_out[i] = calc_thrust_to_pwm(_thrust_rpyt_out[i]);
+                const float thrust_adjusted = compensate_for_thrust_asymmetry(_thrust_rpyt_out[i]);
+                motor_out[i] = calc_thrust_to_pwm(thrust_adjusted);
             }
         }
         break;

--- a/libraries/AP_Motors/AP_Motors6DOF.h
+++ b/libraries/AP_Motors/AP_Motors6DOF.h
@@ -38,6 +38,9 @@ public:
     // Map thrust input -1~1 to pwm output 1100~1900
     int16_t calc_thrust_to_pwm(float thrust_in) const;
 
+    // Compensate thrust input -1~1 for asymmetric forward/reverse thrust
+    float compensate_for_thrust_asymmetry(float thrust_in) const;
+
     // output_to_motors - sends minimum values out to the motors
     void output_to_motors() override;
 
@@ -76,4 +79,7 @@ protected:
     // current limiting
     float _output_limited = 1.0f;
     float _batt_current_last = 0.0f;
+
+    // Non-positive values are treated identically to 1.0
+    AP_Float _thrust_asymmetry;
 };

--- a/libraries/SITL/SIM_Submarine.cpp
+++ b/libraries/SITL/SIM_Submarine.cpp
@@ -90,6 +90,9 @@ void Submarine::calculate_forces(const struct sitl_input &input, Vector3f &rot_a
         }
 
         float thrust = output * fabs(output) * frame_property.thrust; // approximate pwm to thrust function using a quadratic curve
+        if (is_negative(thrust) && !is_zero(sitl->thrust_asymmetry)) {
+            thrust *= sitl->thrust_asymmetry;
+        }
         body_accel += t.linear * thrust / frame_property.weight;
         rot_accel += t.rotational * thrust * frame_property.thruster_mount_radius / frame_property.moment_of_inertia;
     }

--- a/libraries/SITL/SIM_Submarine.cpp
+++ b/libraries/SITL/SIM_Submarine.cpp
@@ -96,6 +96,9 @@ void Submarine::calculate_forces(const struct sitl_input &input, Vector3f &rot_a
         }
 
         float thrust = output * fabs(output) * frame_property.thrust; // approximate pwm to thrust function using a quadratic curve
+        if (is_negative(thrust) && !is_zero(sitl->thrust_asymmetry)) {
+            thrust *= sitl->thrust_asymmetry;
+        }
         body_accel += t.linear * thrust / frame_property.weight;
         rot_accel += t.rotational * thrust * frame_property.thruster_mount_radius / frame_property.moment_of_inertia;
     }

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -521,6 +521,13 @@ const AP_Param::GroupInfo SIM::var_info3[] = {
     // @Description: Buyoancy for submarines
     AP_GROUPINFO_FRAME("BUOYANCY", 15, SIM, buoyancy, 1, AP_PARAM_FRAME_SUB),
 
+    // @Param{Sub}: THRUST_ASYM
+    // @DisplayName: Thrust asymmetry
+    // @Description: Ratio of reverse to forward thrust for simulated thrusters. 1.0 means equal thrust, 0.8 means reverse thrust is 80% of forward thrust.
+    // @Range: 0.5 2.0
+    // @User: Advanced
+    AP_GROUPINFO_FRAME("THRUST_ASYM", 16, SIM, thrust_asymmetry, 1.0, AP_PARAM_FRAME_SUB),
+
     // @Param: RATE_HZ
     // @DisplayName: Loop rate
     // @Description: SITL Loop rate

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -547,6 +547,13 @@ const AP_Param::GroupInfo SIM::var_info3[] = {
     // @Description: Buyoancy for submarines
     AP_GROUPINFO_FRAME("BUOYANCY", 15, SIM, buoyancy, 1, AP_PARAM_FRAME_SUB),
 
+    // @Param{Sub}: THRUST_ASYM
+    // @DisplayName: Thrust asymmetry
+    // @Description: Ratio of reverse to forward thrust for simulated thrusters. 1.0 means equal thrust, 0.8 means reverse thrust is 80% of forward thrust.
+    // @Range: 0.5 2.0
+    // @User: Advanced
+    AP_GROUPINFO_FRAME("THRUST_ASYM", 16, SIM, thrust_asymmetry, 1.0, AP_PARAM_FRAME_SUB),
+
     // @Param: RATE_HZ
     // @DisplayName: Loop rate
     // @Description: SITL Loop rate

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -259,6 +259,7 @@ public:
     AP_Float mag_scaling[MAX_CONNECTED_MAGS]; // scaling factor
     AP_Int32 mag_devid[MAX_CONNECTED_MAGS]; // Mag devid
     AP_Float buoyancy; // submarine buoyancy in Newtons
+    AP_Float thrust_asymmetry; // ratio of reverse to forward thrust (only use positive values)
     AP_Int16 loop_rate_hz;
     AP_Int16 loop_time_jitter_us;
     AP_Int32 on_hardware_output_enable_mask;  // mask of output channels passed through to actual hardware

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -257,6 +257,7 @@ public:
     AP_Float mag_scaling[MAX_CONNECTED_MAGS]; // scaling factor
     AP_Int32 mag_devid[MAX_CONNECTED_MAGS]; // Mag devid
     AP_Float buoyancy; // submarine buoyancy in Newtons
+    AP_Float thrust_asymmetry; // ratio of reverse to forward thrust (only use positive values)
     AP_Int16 loop_rate_hz;
     AP_Int16 loop_time_jitter_us;
     AP_Int32 on_hardware_output_enable_mask;  // mask of output channels passed through to actual hardware


### PR DESCRIPTION
Underwater thrusters often have asymmetric thrust. 
The [T200](https://bluerobotics.com/store/thrusters/t100-t200-thrusters/t200-thruster-r2-rp/) for example, has a forward/backwards ratio of ~0.78.

This PR attemprs to correct this asymmetry. This is a step towards improving the 6dof behaviors on Sub.

<img width="1162" height="532" alt="Screenshot 2026-03-27 at 15 05 56" src="https://github.com/user-attachments/assets/188dca51-bd32-4a3e-ac45-c5d7e993aa64" />
