### PR TITLE
GCS_MAVLink: fix buffer overread on invalid SERIAL_CONTROL write

### DIFF
--- a/libraries/GCS_MAVLink/GCS_serial_control.cpp
+++ b/libraries/GCS_MAVLink/GCS_serial_control.cpp
@@ -116,6 +116,10 @@ void GCS_MAVLINK::handle_serial_control(const mavlink_message_t &msg)
 
     // write the data
     if (packet.count != 0) {
+        if (packet.count > sizeof(packet.data)) {
+            packet.count = sizeof(packet.data);
+        }
+
         if ((packet.flags & SERIAL_CONTROL_FLAG_BLOCKING) == 0) {
             stream->write(packet.data, packet.count);
         } else {


### PR DESCRIPTION
## Summary

Fix sending junk if an incorrectly large count is sent in the SERIAL_CONTROL message.

Closes #32524 .

## Testing (more checks increases chance of being merged)

- [X] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

Setting a count in the packet bigger than the data buffer size could result in reading past the decoded packet and sending random junk off the stack. Fix by capping the size to send at the buffer size, as there is no ability for returning failure at this time. The recieve path is already protected similarly.


<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
