### PR TITLE
AP_Proximity, SITL: replace MAV_SENSOR_ROTATION with Rotation enum

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity_MAV.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_MAV.cpp
@@ -20,7 +20,12 @@
 #include "AP_Proximity_MAV.h"
 #include <AP_HAL/AP_HAL.h>
 #include <ctype.h>
+#include <AP_Math/rotations.h>
 #include <stdio.h>
+
+// ensure MAVLink and local rotation constants stay in sync
+static_assert((uint32_t)ROTATION_YAW_315 == (uint32_t)MAV_SENSOR_ROTATION_YAW_315, "ROTATION_YAW_315 mismatch");
+static_assert((uint32_t)ROTATION_PITCH_90 == (uint32_t)MAV_SENSOR_ROTATION_PITCH_90, "ROTATION_PITCH_90 mismatch");
 
 extern const AP_HAL::HAL& hal;
 
@@ -74,7 +79,7 @@ void AP_Proximity_MAV::handle_distance_sensor_msg(const mavlink_message_t &msg)
     mavlink_msg_distance_sensor_decode(&msg, &packet);
 
     // store distance to appropriate sector based on orientation field
-    if (packet.orientation <= MAV_SENSOR_ROTATION_YAW_315) {
+    if (packet.orientation <= ROTATION_YAW_315) {
         const uint32_t previous_sys_time = _last_update_ms;
         _last_update_ms = AP_HAL::millis();
 
@@ -109,7 +114,7 @@ void AP_Proximity_MAV::handle_distance_sensor_msg(const mavlink_message_t &msg)
     }
 
     // store upward distance
-    if (packet.orientation == MAV_SENSOR_ROTATION_PITCH_90) {
+    if (packet.orientation == ROTATION_PITCH_90) {
         _distance_upward = packet.current_distance * 0.01f;
         _last_upward_update_ms = AP_HAL::millis();
     }

--- a/libraries/SITL/SIM_RF_MAVLink.cpp
+++ b/libraries/SITL/SIM_RF_MAVLink.cpp
@@ -17,8 +17,12 @@
 */
 
 #include "SIM_RF_MAVLink.h"
+#include <AP_Math/rotations.h>
 
 #include <GCS_MAVLink/GCS.h>
+
+// ensure MAVLink and local rotation constants stay in sync
+static_assert((uint32_t)ROTATION_PITCH_270 == (uint32_t)MAV_SENSOR_ROTATION_PITCH_270, "ROTATION_PITCH_270 mismatch");
 
 #include <stdio.h>
 #include <string.h>
@@ -38,7 +42,7 @@ uint32_t RF_MAVLink::packet_for_alt(float alt_m, uint8_t *buffer, uint8_t buflen
         .current_distance = alt_cm,
         .type = 0,
         .id = 72, // ID
-        .orientation = MAV_SENSOR_ROTATION_PITCH_270,
+        .orientation = ROTATION_PITCH_270,
         .covariance = 255, // 255 is unknown covariance
         .horizontal_fov = 0, // 0 is unknown horizontal fov
         .vertical_fov = 0, // 0 is unknown vertical fov


### PR DESCRIPTION
## Summary
- Replace direct MAV_SENSOR_ROTATION_* MAVLink enum usage with the existing Rotation enum from AP_Math/rotations.h
- Reduces MAVLink coupling in AP_Proximity and SITL libraries

## Changes
- libraries/AP_Proximity/AP_Proximity_MAV.cpp: Replace MAV_SENSOR_ROTATION_YAW_315 and MAV_SENSOR_ROTATION_PITCH_90 with ROTATION_YAW_315 and ROTATION_PITCH_90
- libraries/SITL/SIM_RF_MAVLink.cpp: Replace MAV_SENSOR_ROTATION_PITCH_270 with ROTATION_PITCH_270

The Rotation enum values in AP_Math/rotations.h are intentionally kept in sync with MAV_SENSOR_ORIENTATION (as noted in the header comments), so this is a safe 1:1 replacement.

Relates to #23320

## Test plan
- [x] SITL Copter build passes