### PR TITLE
Copter: move RC_Channels_Copter::save_trim to Copter class

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -997,3 +997,28 @@ Copter copter;
 AP_Vehicle& vehicle = copter;
 
 AP_HAL_MAIN_CALLBACKS(&copter);
+
+// save_trim - adds roll and pitch trims from the radio to ahrs
+void Copter::save_trim()
+{
+    float roll_trim_rad = 0.0;
+    float pitch_trim_rad = 0.0;
+
+#if AP_COPTER_AHRS_AUTO_TRIM_ENABLED
+    if (g2.rc_channels.auto_trim.running) {
+        g2.rc_channels.auto_trim.running = false;
+    } else {
+#endif
+
+    // get roll and pitch trim adjustment
+    flightmode->get_pilot_desired_lean_angles_rad(roll_trim_rad, pitch_trim_rad, attitude_control->lean_angle_max_rad(), attitude_control->get_althold_lean_angle_max_rad());
+
+#if AP_COPTER_AHRS_AUTO_TRIM_ENABLED
+    }
+#endif
+
+    // save roll and pitch trim
+    AP::ahrs().add_trim(roll_trim_rad, pitch_trim_rad);
+    LOGGER_WRITE_EVENT(LogEvent::SAVE_TRIM);
+    gcs().send_text(MAV_SEVERITY_INFO, "Trim saved");
+}

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -1112,6 +1112,7 @@ private:
     bool using_rate_thread;
 
 public:
+    void save_trim();
     void failsafe_check();      // failsafe.cpp
 };
 

--- a/ArduCopter/RC_Channel_Copter.cpp
+++ b/ArduCopter/RC_Channel_Copter.cpp
@@ -219,7 +219,7 @@ bool RC_Channel_Copter::do_aux_function(const AuxFuncTrigger &trigger)
             if ((ch_flag == AuxSwitchPos::HIGH) &&
                 (copter.flightmode->allows_save_trim()) &&
                 (copter.channel_throttle->get_control_in() == 0)) {
-                copter.g2.rc_channels.save_trim();
+                copter.save_trim();
             }
             break;
 
@@ -724,29 +724,7 @@ void RC_Channel_Copter::do_aux_function_change_force_flying(const AuxSwitchPos c
 // note that this is a method on the RC_Channels object, not the
 // individual channel
 // save_trim - adds roll and pitch trims from the radio to ahrs
-void RC_Channels_Copter::save_trim()
-{
-    float roll_trim_rad = 0.0;
-    float pitch_trim_rad = 0.0;
 
-#if AP_COPTER_AHRS_AUTO_TRIM_ENABLED
-    if (auto_trim.running) {
-        auto_trim.running = false;
-    } else {
-#endif
-
-    // get roll and pitch trim adjustment
-    copter.flightmode->get_pilot_desired_lean_angles_rad(roll_trim_rad, pitch_trim_rad, copter.attitude_control->lean_angle_max_rad(), copter.attitude_control->get_althold_lean_angle_max_rad());
-
-#if AP_COPTER_AHRS_AUTO_TRIM_ENABLED
-    }
-#endif
-
-    // save roll and pitch trim
-    AP::ahrs().add_trim(roll_trim_rad, pitch_trim_rad);
-    LOGGER_WRITE_EVENT(LogEvent::SAVE_TRIM);
-    gcs().send_text(MAV_SEVERITY_INFO, "Trim saved");
-}
 
 #if AP_COPTER_AHRS_AUTO_TRIM_ENABLED
 // start/stop ahrs auto trim
@@ -768,7 +746,7 @@ void RC_Channels_Copter::do_aux_function_ahrs_auto_trim(const RC_Channel::AuxSwi
     case RC_Channel::AuxSwitchPos::LOW:
         if (auto_trim.running) {
             AP_Notify::flags.save_trim = false;
-            save_trim();
+            copter.save_trim();
         }
         break;
     }

--- a/ArduCopter/RC_Channel_Copter.h
+++ b/ArduCopter/RC_Channel_Copter.h
@@ -56,7 +56,6 @@ public:
     void auto_trim_run();
     void auto_trim_cancel();
 #endif  // AP_COPTER_AHRS_AUTO_TRIM_ENABLED
-    void save_trim();
 
 protected:
 


### PR DESCRIPTION
Fixes #32279.

Moved save_trim out of RC_Channels_Copter and directly into the main Copter class as requested. Updated the header files and internal variable scoping, and verified successful compilation via SITL.

@rmackay9 Let me know if you need any further adjustments to the scoping!