### PR TITLE
GCS_MAVLink: fix uninitialized byte propagation in SERIAL_CONTROL

### DIFF
--- a/libraries/GCS_MAVLink/GCS_serial_control.cpp
+++ b/libraries/GCS_MAVLink/GCS_serial_control.cpp
@@ -35,6 +35,13 @@ void GCS_MAVLINK::handle_serial_control(const mavlink_message_t &msg)
     mavlink_serial_control_t packet;
     mavlink_msg_serial_control_decode(&msg, &packet);
 
+    // SANITIZATION: Prevent uninitialized byte propagation in the forwarding path
+    if (packet.count < sizeof(packet.data)) {
+        memset(&packet.data[packet.count], 0, sizeof(packet.data) - packet.count);
+    } else if (packet.count > sizeof(packet.data)) {
+        packet.count = sizeof(packet.data);
+    }
+
     AP_HAL::UARTDriver *port = nullptr;
     AP_HAL::BetterStream *stream = nullptr;
 


### PR DESCRIPTION
Fixes #32524.

When a `SERIAL_CONTROL` packet is forwarded, if the actual payload is smaller than the maximum buffer size, the remaining bytes in the array were left uninitialized before being sent out the port. 

This adds a boundary check to `handle_serial_control`. It zeroes out the remainder of the buffer using `memset` if the count is smaller than the buffer, and clamps the count if it maliciously/erroneously exceeds the buffer size. This prevents uninitialized memory exposure on the MAVLink forwarding path.