### PR TITLE
AP_DAL: correctly comment all fields of replay beacon data message

### DIFF
--- a/libraries/AP_DAL/LogStructure.h
+++ b/libraries/AP_DAL/LogStructure.h
@@ -404,10 +404,10 @@ struct log_RMGI {
 
 // @LoggerMessage: RBCH
 // @Description: Replay Data Beacon Header
-// @Field: PX: zero, unused
-// @Field: PY: zero, unused
-// @Field: PZ: zero, unused
-// @Field: AE: zero, unused
+// @Field: PX: beacon system estimated vehicle position, North
+// @Field: PY: beacon system estimated vehicle position, East
+// @Field: PZ: beacon system estimated vehicle position, Down
+// @Field: AE: beacon system estimated vehicle position accuracy
 // @Field: OLat: origin latitude
 // @Field: OLng: origin longitude
 // @Field: OAlt: origin altitude


### PR DESCRIPTION
## Summary

Fix mis-documented fields from https://github.com/ArduPilot/ardupilot/pull/30186 .

## Testing (more checks increases chance of being merged)

- [X] Checked by a human programmer
- [X] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

A replay log plainly shows these fields are not zero and are used. They are filled in by `get_vehicle_position_ned` in
`AP_DAL_Beacon::start_frame`.

Some code sleuthing shows the estimates are the ones generated by the beeacon system, rather than the vehicle itself.
<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
