### PR TITLE
Fix test_build_options failures

### DIFF
--- a/Tools/autotest/test_build_options.py
+++ b/Tools/autotest/test_build_options.py
@@ -279,6 +279,7 @@ class TestBuildOptions(object):
             'AP_COMPASS_AK8963_ENABLED',  # probed on a board-by-board basis, not on CubeOrange for example
             'AP_COMPASS_LSM303D_ENABLED',  # probed on a board-by-board basis, not on CubeOrange for example
             'AP_BARO_THST_COMP_ENABLED',  # compiler is optimising this symbol away
+            'AP_GPS_DEBUG_LOGGING_ENABLED',  # must have a backend compiled in to be present
         ])
         if target.lower() != "copter":
             feature_define_whitelist.add('MODE_ZIGZAG_ENABLED')
@@ -302,6 +303,7 @@ class TestBuildOptions(object):
             feature_define_whitelist.add('AP_INERTIALSENSOR_FAST_SAMPLE_WINDOW_ENABLED')
             feature_define_whitelist.add('AP_COPTER_AHRS_AUTO_TRIM_ENABLED')
             feature_define_whitelist.add('AP_RC_TRANSMITTER_TUNING_ENABLED')
+            feature_define_whitelist.add('AP_AVOIDANCE_ALTHOLD_ENABLED')
 
         if target.lower() in ['antennatracker', 'blimp', 'sub', 'plane', 'copter']:
             # plane has a dependency for AP_Follow which is not

--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -1,5 +1,6 @@
 #include <AP_HAL/AP_HAL_Boards.h>
 
+#include <stdio.h>
 #include <cstdio>
 
 #include "AP_DDS_config.h"


### PR DESCRIPTION
## Summary

Fix a few problems with `./Tools/autotest/test_build_options.py` - feature extractions mostly, but one genuine issue

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

Just running the script bare will reproduce the problems.  transitive include issue on the DDS library, other things are just new defines which weren't configured correctly when they were added (`test_build_options.py` needed extra bits)
