### PR TITLE
autotest: reduce circling time in Arc waypoint test

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -637,7 +637,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.wait_circling_point_with_radius(
             loc, radius,
             epsilon=1,
-            min_circle_time=10,
+            min_circle_time=7,
             timeout=30,
             track_angle=False,
         )


### PR DESCRIPTION
## Summary

Fixes [an autotest failure](https://github.com/ArduPilot/ardupilot/actions/runs/23669978666/job/68965120064?pr=32434)

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

we spent so long making sure the thing circled that it could end up on the way hme before we checked our distance!