### PR TITLE
Sub: fix remote leak detection

### DIFF
--- a/ArduSub/GCS_MAVLink_Sub.cpp
+++ b/ArduSub/GCS_MAVLink_Sub.cpp
@@ -743,16 +743,14 @@ void GCS_MAVLINK_Sub::handle_message(const mavlink_message_t &msg)
         break;
     }
 
-    // This adds support for leak detectors in a separate enclosure
-    // connected to a mavlink enabled subsystem
+    // Remote leak sensor support (e.g. in a separate enclosure), via MAVLink status messages.
     case MAVLINK_MSG_ID_SYS_STATUS: {
-        uint32_t MAV_SENSOR_WATER = 0x20000000;
         mavlink_sys_status_t packet;
         mavlink_msg_sys_status_decode(&msg, &packet);
         if ((msg.sysid == gcs().sysid_this_mav()) &&
-            (packet.onboard_control_sensors_enabled & MAV_SENSOR_WATER) &&
-            !(packet.onboard_control_sensors_health & MAV_SENSOR_WATER)
-        ) {
+            (packet.onboard_control_sensors_present & MAV_SYS_STATUS_EXTENSION_USED) &&
+            (packet.onboard_control_sensors_enabled_extended & MAV_SYS_STATUS_SENSOR_LEAK) &&
+            !(packet.onboard_control_sensors_health_extended & MAV_SYS_STATUS_SENSOR_LEAK)) {
             sub.leak_detector.set_detect();
         }
         break;


### PR DESCRIPTION
## Summary

Fixes invalid MAVLink support for remote leak detections.

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
    - Built successfully, but not yet tested
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

Builds on ArduPilot/mavlink#494, adding implementation support for the `MAV_SYS_STATUS_SENSOR_EXTENDED`, and using that for the new `MAV_SYS_STATUS_SENSOR_LEAK` flag, instead of the unofficial bit value used previously.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
