### PR TITLE
Remove unused private member AR_WPNav_OA::_oa_distance_to_destination

### DIFF
--- a/libraries/AR_WPNav/AR_WPNav_OA.cpp
+++ b/libraries/AR_WPNav/AR_WPNav_OA.cpp
@@ -133,7 +133,7 @@ void AR_WPNav_OA::update(float dt)
         } // switch (oa_retstate) {
     } // if (oa != nullptr) {
 
-    update_oa_distance_and_bearing_to_destination();
+    update_oa_bearing_to_destination();
 
     // handle stopping vehicle if avoidance has failed
     if (stop_vehicle) {
@@ -204,16 +204,13 @@ float AR_WPNav_OA::oa_wp_bearing_cd() const
     return AR_WPNav::oa_wp_bearing_cd();
 }
 
-// update distance from vehicle's current position to destination
-void AR_WPNav_OA::update_oa_distance_and_bearing_to_destination()
+// update bearing from vehicle's current position to destination
+void AR_WPNav_OA::update_oa_bearing_to_destination()
 {
-    // update OA adjusted values
     Location current_loc;
     if (_oa_active && AP::ahrs().get_location(current_loc)) {
-        _oa_distance_to_destination = current_loc.get_distance(_oa_destination);
         _oa_wp_bearing_cd = current_loc.get_bearing_to(_oa_destination);
     } else {
-        _oa_distance_to_destination = AR_WPNav::get_distance_to_destination();
         _oa_wp_bearing_cd = AR_WPNav::wp_bearing_cd();
     }
 }

--- a/libraries/AR_WPNav/AR_WPNav_OA.h
+++ b/libraries/AR_WPNav/AR_WPNav_OA.h
@@ -29,8 +29,8 @@ public:
 
 private:
 
-    // update distance and bearing from vehicle's current position to destination
-    void update_oa_distance_and_bearing_to_destination();
+    // update bearing from vehicle's current position to destination
+    void update_oa_bearing_to_destination();
 
     // object avoidance variables
     bool _oa_active;                // true if we should use alternative destination to avoid obstacles
@@ -40,6 +40,5 @@ private:
     Location _oa_origin;            // intermediate origin during avoidance
     Location _oa_destination;       // intermediate destination during avoidance
     Location _oa_next_destination;  // intermediate next destination during avoidance
-    float _oa_distance_to_destination; // OA (object avoidance) distance from vehicle to _oa_destination in meters
     float _oa_wp_bearing_cd;        // OA adjusted heading to _oa_destination in centi-degrees
 };


### PR DESCRIPTION
## Summary

Does what title says. (Also renames an update-function accordingly.)

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [x] Tested in SITL (I think autotest covers this class.)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

The main concern of this change is to confirm that removing it is **desired**. Perhaps instead it being unused is an accident, and we should fix that?

This was split off separately from #32454 (per reviewer's request).
 
<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
