### PR TITLE
Plane: convert distance params from AP_Int16 to AP_Float for GCS unit conversion

### DIFF
--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -393,9 +393,9 @@ public:
 
     // Waypoints
     //
-    AP_Int16 waypoint_radius;
-    AP_Int16 waypoint_max_radius;
-    AP_Int16 rtl_radius;
+    AP_Float waypoint_radius;
+    AP_Float waypoint_max_radius;
+    AP_Float rtl_radius;
 
     // Fly-by-wire
     //

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -660,7 +660,7 @@ bool Plane::verify_nav_wp(const AP_Mission::Mission_Command& cmd)
     // see if the user has specified a maximum distance to waypoint
     // If override with p3 - then this is not used as it will overfly badly
     if (g.waypoint_max_radius > 0 &&
-        auto_state.wp_distance > (uint16_t)g.waypoint_max_radius) {
+        auto_state.wp_distance > g.waypoint_max_radius) {
         if (current_loc.past_interval_finish_line(prev_WP_loc, flex_next_WP_loc)) {
             // this is needed to ensure completion of the waypoint
             if (cmd_passby == 0) {

--- a/libraries/AP_Vehicle/AP_FixedWing.h
+++ b/libraries/AP_Vehicle/AP_FixedWing.h
@@ -26,7 +26,7 @@ struct AP_FixedWing {
     AP_Int8  autotune_level;
     AP_Int32 autotune_options;
     AP_Int8  stall_prevention;
-    AP_Int16 loiter_radius;
+    AP_Float loiter_radius;
     AP_Float takeoff_throttle_max_t;
 
     struct Rangefinder_State {


### PR DESCRIPTION

## Summary
Convert RTL_RADIUS, WP_RADIUS, WP_MAX_RADIUS and WP_LOITER_RAD from AP_Int16 to AP_Float to enable GCS unit conversion (meters to feet).

## Testing
- [x] Checked by a human programmer
- [x] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included


## Description

Fixes #32606

RTL_RADIUS, WP_RADIUS, WP_MAX_RADIUS and WP_LOITER_RAD were declared as AP_Int16 which prevents GCS applications (e.g. QGroundControl) from applying unit conversion (meters to feet). GCS apps skip unit conversion for integer-typed parameters to avoid precision loss on round-trip conversion.

The MAVLink protocol already sends all parameters as floats (PARAM_VALUE.param_value is a float field), so there is no wire format change.

Also removed an explicit uint16_t cast in commands_logic.cpp that became unnecessary after the type change.


