### PR TITLE
WIP: AP_Mission: Comprehensive edge-case handling for MAVLink inputs (GSoC PoC)

### DIFF
--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -3196,4 +3196,29 @@ AP_Mission *mission()
 
 }
 
+
+
+// -------------------------------------------------------------------------
+// GSoC 2026 Draft: MAVLink Input Sanitization
+// -------------------------------------------------------------------------
+
+/*
+  Check if a DO_SET_SERVO command contains mathematically and physically valid parameters.
+  Returns false if parameters are out of bounds, allowing graceful rejection.
+*/
+bool AP_Mission::is_valid_do_set_servo(const mavlink_mission_item_int_t &packet) 
+{
+    // Param 1: Ensure servo channel is within valid physical range (e.g., 1 to 16)
+    if (packet.param1 < 1.0f || packet.param1 > 16.0f) {
+        return false;
+    }
+    
+    // Param 2: Ensure PWM value is within safe operational bounds (800 to 2200)
+    // Value 0 is used to disable/ignore, so we allow 0 as an exception
+    if (!is_zero(packet.param2) && (packet.param2 < 800.0f || packet.param2 > 2200.0f)) {
+        return false;
+    }
+    
+    return true;
+}
 #endif  // AP_MISSION_ENABLED

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -203,6 +203,9 @@ public:
         bool allow_disarmed_start; // allow starting the engine while disarmed
     };
 
+    // GSoC Draft: Boundary check helper for DO_SET_SERVO
+    static bool is_valid_do_set_servo(const mavlink_mission_item_int_t &packet);
+
     // NAV_SET_YAW_SPEED support
     struct PACKED Set_Yaw_Speed {
         float angle_deg;        // target angle in degrees (0=north, 90=east)


### PR DESCRIPTION
### Description
Hi, @peterbarker and team
This is a **Draft PR** serving as a Proof of Concept (PoC) for my GSoC 2026 proposal: **Hardening AP_Mission**. 

As discussed in Peter Barker's recent wiki issue regarding attack surfaces (#7359), and following my recent patch for the `AP_Mission` SIGFPE crash (#32009), this PR demonstrates the architecture for sanitizing MAVLink inputs *before* they are accepted into the mission queue.

**Changes here:**
* Added a `static bool` helper function for `MAV_CMD_DO_SET_SERVO` to safely check channel and PWM boundaries using ArduPilot's standard `is_zero()` math function.
* The ultimate goal of my GSoC project is to integrate these boundary checks directly into the MAVLink parsing logic. This will ensure the flight controller gracefully rejects malformed data by returning `MAV_MISSION_INVALID_PARAM`, preventing silent failures or hardware exceptions.

*Note: This is currently in Draft state to accompany my GSoC proposal and demonstrate the intended C++ memory footprint.*
