### PR TITLE
Permit verifying no-compiler-change for Mac (darwin) builds

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -593,10 +593,11 @@ class Board:
             # affecting the compiler output:
             env.CXXFLAGS += ['-frandom-seed=4']  # ob. xkcd
 
-            # disable setting build ID in the ELF header. though if two binaries
-            # are identical they will have the same build ID, setting it avoids
-            # creating a difference if they are not in a way we care about.
-            env.LDFLAGS += ['-Wl,--build-id=none']
+            # Disable setting build ID in the ELF header.
+            # This avoids flagging if two binaries differ in a way we don't care about.
+            # MacOS (darwin) outputs (Mach-O, not ELF) do not need this.
+            if cfg.env.DEST_OS != 'darwin':
+                env.LDFLAGS += ['-Wl,--build-id=none']
             # squash all line numbers to be the number 17
             env.CXXFLAGS += [
                 "-D__AP_LINE__=17",


### PR DESCRIPTION
## Summary

The linker option `--build-id=none` fails on MacOS (darwin). So in that case don't use it.

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included
- [x] Tested manually on a few personal examples

Commands like
```
./Tools/scripts/size_compare_branches.py --master-branch=<...> --vehicle=blimp --board=still
```
on a Mac fail without it, but succeed after it.

## Description

I'm not experienced in this area. While originally I proposed using `-Wl,-no_uuid` for darwin, now I think the linker's Mach-O outputs are already "what we want" without that.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
