### PR TITLE
Plane: drop AHRS out of full rate attitude logging

### DIFF
--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -53,8 +53,6 @@ void Plane::Log_Write_Attitude(void)
     if (steerController.active()) {
         logger.Write_PID(LOG_PIDS_MSG, steerController.get_pid_info());
     }
-
-    AP::ahrs().Log_Write();
 }
 
 // do fast logging for plane

--- a/ArduPlane/Plane.cpp
+++ b/ArduPlane/Plane.cpp
@@ -268,13 +268,20 @@ void Plane::update_compass(void)
  */
 void Plane::update_logging10(void)
 {
-    bool log_faster = (should_log(MASK_LOG_ATTITUDE_FULLRATE) || should_log(MASK_LOG_ATTITUDE_FAST));
-    if (should_log(MASK_LOG_ATTITUDE_MED) && !log_faster) {
+    const bool attitude_med = should_log(MASK_LOG_ATTITUDE_MED);
+    const bool attitude_faster = should_log(MASK_LOG_ATTITUDE_FULLRATE) || should_log(MASK_LOG_ATTITUDE_FAST);
+
+    // Log attitude only if no faster logging is selected
+    if (attitude_med && !attitude_faster) {
         Log_Write_Attitude();
-        ahrs.Write_AOA_SSA();
-    } else if (log_faster) {
+        AP::ahrs().Log_Write();
+    }
+
+    // If any attitude logging is enabled log AOA and SSA
+    if (attitude_med || attitude_faster) {
         ahrs.Write_AOA_SSA();
     }
+
 #if HAL_MOUNT_ENABLED
     if (should_log(MASK_LOG_CAMERA)) {
         camera_mount.write_log();
@@ -295,11 +302,17 @@ void Plane::update_logging10(void)
  */
 void Plane::update_logging25(void)
 {
-    // MASK_LOG_ATTITUDE_FULLRATE logs at 400Hz, MASK_LOG_ATTITUDE_FAST at 25Hz, MASK_LOG_ATTIUDE_MED logs at 10Hz
-    // highest rate selected wins
-    bool log_faster = should_log(MASK_LOG_ATTITUDE_FULLRATE);
-    if (should_log(MASK_LOG_ATTITUDE_FAST) && !log_faster) {
+    const bool attitude_fast = should_log(MASK_LOG_ATTITUDE_FAST);
+    const bool attitude_full_rate = should_log(MASK_LOG_ATTITUDE_FULLRATE);
+
+    // Log at fast rate if fast logging is the fastest enabled
+    if (attitude_fast && !attitude_full_rate) {
         Log_Write_Attitude();
+    }
+
+    // Log AHRS at fast rate if either fast or full rate is selected
+    if (attitude_fast || attitude_full_rate) {
+        AP::ahrs().Log_Write();
     }
 
     if (should_log(MASK_LOG_CTUN)) {


### PR DESCRIPTION
Full rate logging currently includes AHRS logging. This includes all the EKF messages. On quadplane with 300Hz loop rate this results in huge log files and often dropping data. This drops AHRS logging out the full rate. If full rate is selected AHRS logs will still be done at 25Hz as they would with fast attitude. Copter only ever logs AHRS at upto 25Hz, so this is inline with that.

This was tested using `graph 1000000/diff(AHR2.TimeUS,0) 1000000/diff(ATT.TimeUS,1)` to compare the rate of the `AHR2` message logged by the AHRS and `ATT` logged in planes `Log_Write_Attitude` function.

This is the new behavior with full rate attitude selected, `ATT` at loop rate, `AHR2` at 25Hz.
```
LOG_BITMASK      1081279.000000 # Fast Attitude|Medium Attitude|GPS|Performance|Control Tuning|Navigation Tuning|IMU|Mission Commands|Battery Monitor|Compass|TECS|Camera|RC Input-Output|Rangefinder|Fullrate Attitude
```
<img width="1243" height="666" alt="image" src="https://github.com/user-attachments/assets/2f7dbe54-0ebf-4803-bd14-7a7d148c2da5" />

With fast attitude, both at 25Hz:
```
LOG_BITMASK      65535.000000 # Fast Attitude|Medium Attitude|GPS|Performance|Control Tuning|Navigation Tuning|IMU|Mission Commands|Battery Monitor|Compass|TECS|Camera|RC Input-Output|Rangefinder|Uknownbit6|Uknownbit15
```
<img width="1292" height="705" alt="image" src="https://github.com/user-attachments/assets/201324c1-24a4-4fe4-b43f-e1dfb5062820" />

With medium attitude, both at 10Hz:
```
LOG_BITMASK      32702.000000 # Medium Attitude|GPS|Performance|Control Tuning|Navigation Tuning|IMU|Mission Commands|Battery Monitor|Compass|TECS|Camera|RC Input-Output|Rangefinder
```
<img width="1252" height="676" alt="image" src="https://github.com/user-attachments/assets/c5a7235b-1026-466b-8c33-b24e2fb7622e" />



