### PR TITLE
Tools: correct syntax in install-prereqs-ubuntu

### DIFF
--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -559,9 +559,10 @@ done
 
 # somehow Plucky really wants Pillow reinstalled or MAVProxy's map
 # won't load (version mismatch between "Core" and "Pillow")
-if [ ${RELEASE_CODENAME} == 'plucky' ] ||
-       ${RELEASE_CODENAME} == 'questing' ] ||
-       false; then
+if false || \
+        [ ${RELEASE_CODENAME} == 'plucky' ] || \
+        [ ${RELEASE_CODENAME} == 'questing' ] || \
+        false; then
     $PIP install --force-reinstall pillow
 fi
 


### PR DESCRIPTION
## Summary

Fixes shell syntaxes

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

Replaces https://github.com/ArduPilot/ardupilot/pull/32579/files
