### PR TITLE
Unlimit markdown line-length

### DIFF
--- a/.github/.markdownlint.jsonc
+++ b/.github/.markdownlint.jsonc
@@ -1,3 +1,4 @@
 {
+  "MD013": false,
   "MD041": false                                                      
 }  


### PR DESCRIPTION
## Summary

Permit linted markdown lines to be longer than 80 chars.

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included