### PR TITLE
AP_GPS: fix SBF BaseVectorGeod double DNU sentinel value

### DIFF
--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -633,7 +633,7 @@ AP_GPS_SBF::process_message(void)
         const msg4028 &temp = sbf_msg.data.msg4028u;
 
         // just breakout any consts we need for Do Not Use (DNU) reasons
-        constexpr double doubleDNU = -2e-10;
+        constexpr double doubleDNU = -2e+10;
         constexpr uint16_t uint16DNU = 65535;
 
         check_new_itow(temp.TOW, sbf_msg.length);


### PR DESCRIPTION
In the SBF (Septentrio Binary Format) protocol, the Do Not Use (DNU) sentinel value for double-precision fields is -2e+10 (i.e., -2e10), not -2e-10. I, therefore, adjusted the value to be -2e+10.