### PR TITLE
User of SITL::Battery supplies wall-clock timestamp

### DIFF
--- a/libraries/SITL/SIM_Battery.cpp
+++ b/libraries/SITL/SIM_Battery.cpp
@@ -136,12 +136,6 @@ void Battery::init_capacity(float capacity)
     set_initial_SoC(voltage_set);
 }
 
-void Battery::set_current(float current)
-{
-    const uint64_t now_us = AP_HAL::micros64();
-    set_current(current, now_us);
-}
-
 void Battery::set_current(float current, uint64_t now_us)
 {
     constexpr float microsec_to_sec = 1.0e-6f;

--- a/libraries/SITL/SIM_Battery.h
+++ b/libraries/SITL/SIM_Battery.h
@@ -31,8 +31,6 @@ public:
 
     // set the current-draw at the instant identified as "now"
     void set_current(float current_amps, uint64_t now_us);
-    // set the current-draw using AP_HAL::micros64() as "now"
-    void set_current(float current_amps);
 
     float get_voltage(void) const;
     float get_capacity(void) const { return capacity_Ah; }

--- a/libraries/SITL/SIM_Multicopter.cpp
+++ b/libraries/SITL/SIM_Multicopter.cpp
@@ -73,7 +73,8 @@ void MultiCopter::update(const struct sitl_input &input)
     // estimate voltage and current
     frame->current_and_voltage(battery_voltage, battery_current);
 
-    battery.set_current(battery_current);
+    const uint64_t now_us = AP_HAL::micros64();
+    battery.set_current(battery_current, now_us);
 
     update_dynamics(rot_accel);
     update_external_payload(input);

--- a/libraries/SITL/SIM_QuadPlane.cpp
+++ b/libraries/SITL/SIM_QuadPlane.cpp
@@ -138,7 +138,8 @@ void QuadPlane::update(const struct sitl_input &input)
     // estimate voltage and current
     frame->current_and_voltage(battery_voltage, battery_current);
 
-    battery.set_current(battery_current);
+    const uint64_t now_us = AP_HAL::micros64();
+    battery.set_current(battery_current, now_us);
 
     float throttle;
     if (reverse_thrust) {

--- a/libraries/SITL/examples/EvaluateBatteryModel/EvaluateBatteryModel.cpp
+++ b/libraries/SITL/examples/EvaluateBatteryModel/EvaluateBatteryModel.cpp
@@ -64,18 +64,18 @@ void setup(void)
     battery.setup(amp_hour_capacity, resistance, max_voltage);
     battery.init_voltage(max_voltage);
 
-    uint64_t time = 0;
-    hal.scheduler->stop_clock(time);
-    const double time_step = 0.05;
+    uint64_t time_us = 0;
+    const double time_step_s = 0.05;
+    constexpr double seconds_to_us = 1.0e6;
+    constexpr double us_to_seconds = 1.0 / seconds_to_us;
 
     ::printf("time, voltage\n");
     while (battery.get_voltage() >= min_voltage) {
-        battery.set_current(current);
+        battery.set_current(current, time_us);
 
-        ::printf("%0.2f, %0.2f\n", time * 1.0e-6, battery.get_voltage());
+        ::printf("%0.2f, %0.2f\n", time_us * us_to_seconds, battery.get_voltage());
 
-        time += time_step*1e6;
-        hal.scheduler->stop_clock(time);
+        time_us += static_cast<uint64_t>(time_step_s * seconds_to_us);
     }
 }
 


### PR DESCRIPTION
### Summary

The user of SITL::Battery is in a better position to be responsible for determining what wall-clock time is used.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

The unit tests for SITL::Battery (in gtest) already supply wall-clock time so that they can run faster than real-time.

### Description

Deletes the now-unnecessary wrapper-function in which SITL::Battery provided the wall-clock time.

This is part of the work for issue #10050 under [this design](https://github.com/ArduPilot/ardupilot/issues/10050#issuecomment-4085867008).

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->