### PR TITLE
Improve SITL::Battery heat model

### DIFF
--- a/libraries/SITL/SIM_Battery.cpp
+++ b/libraries/SITL/SIM_Battery.cpp
@@ -168,10 +168,14 @@ void Battery::set_current(float current, uint64_t now_us)
     {
         const uint64_t temperature_dt = now_us - temperature.last_update_us;
         temperature.last_update_us = now_us;
-        // 1 amp*1 second == 0.1 degrees of energy.  Did those units hurt?
-        temperature.kelvin += 0.1 * current * temperature_dt * 0.000001;
+        // thermal_capacity value chosen to match previous steady-state behavior at 28amps
+        // (reminder: thermal_capacity = mass * specific_heat)
+        constexpr float thermal_capacity = 2.8f;  // watt*seconds/degC
+        constexpr float inverse_of_thermal_capacity = 1 / thermal_capacity;  // use inverse so we can multiply, not divide
+        const float temp_increase = (current * current) * resistance * inverse_of_thermal_capacity * (temperature_dt * 0.000001);
         // decay temperature at some %second towards ambient
-        temperature.kelvin -= (temperature.kelvin - 273) * 0.10 * temperature_dt * 0.000001;
+        const float temp_decrease = (temperature.kelvin - 273.15f) * 0.10 * temperature_dt * 0.000001;
+        temperature.kelvin += (temp_increase - temp_decrease);
     }
 }
 


### PR DESCRIPTION
### Summary

The existing `SITL::Battery` heat-growth model looks erroneous. This changes the equations while approximately preserving behavior.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

The unit tests for SITL::Battery (in gtest) already cover this. 

### Description

These choices constrain the new model:
- Don't change the heat dissipation model. (Despite that it seems chosen arbitrarily.)
- Preserve steady-state behavior at "reasonable current" (28 amps).

A small con: Those lead to an unrealistic thermal capacity (~2 orders of magnitude low). A future PR will propose changing the heat-dissipation model coefficient so that the thermal capacity becomes reasonable while preserving 'typical' steady-state behavior.

A final small change: The temperature decrease is now computed using pre-increase temperature, rather than post-increase. This change is worst-case a 1% impact on the equations, in practice I expect ~0.1%.
This might give a (tiny) computational efficiency improvement, but the primary motivation is a simpler system.

This is part of the work for issue #10050 under [this design](https://github.com/ArduPilot/ardupilot/issues/10050#issuecomment-4085867008).

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->