### PR TITLE
Use OA distance-to-destination if applicable

### DIFF
--- a/libraries/AR_WPNav/AR_WPNav.h
+++ b/libraries/AR_WPNav/AR_WPNav.h
@@ -59,7 +59,7 @@ public:
     virtual bool reached_destination() const { return _reached_destination; }
 
     // return straight-line distance (in meters) to destination
-    float get_distance_to_destination() const { return _distance_to_destination; }
+    float get_distance_to_destination() const { return get_oa_distance_to_destination(); }
 
     // return true if destination is valid
     bool is_destination_valid() const { return _orig_and_dest_valid; }
@@ -193,4 +193,9 @@ protected:
     // variables for reporting
     float _distance_to_destination; // straight-line distance from vehicle to final destination in meters
     bool _reached_destination;      // true once the vehicle has reached the destination
+
+private:
+
+    // return straight-line distance from vehicle to final destination in meters
+    virtual float get_oa_distance_to_destination() const { return _distance_to_destination; }
 };

--- a/libraries/AR_WPNav/AR_WPNav_OA.h
+++ b/libraries/AR_WPNav/AR_WPNav_OA.h
@@ -32,6 +32,9 @@ private:
     // update distance and bearing from vehicle's current position to destination
     void update_oa_distance_and_bearing_to_destination();
 
+    // get straight-line OA-adjusted distance to destination in meters
+    float get_oa_distance_to_destination() const override { return _oa_distance_to_destination; }
+
     // object avoidance variables
     bool _oa_active;                // true if we should use alternative destination to avoid obstacles
     Location _origin_oabak;         // backup of _origin so it can be restored when oa completes


### PR DESCRIPTION
## Summary

`AR_WPNav_OA` should use its own `_oa_distance_to_destination` instead of parent's `_distance_to_destination`.

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

Previously, this member was unused.

This change was requested by @rmackay9 [here](https://github.com/ArduPilot/ardupilot/pull/32616#issuecomment-4159055145)

Authoring unit tests for this looks quite difficult. Alternative testing options may be pursued.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
