### PR TITLE
Sub: transition to manual_override, deprecate roll-pitch toggle

### DIFF
--- a/ArduSub/GCS_MAVLink_Sub.cpp
+++ b/ArduSub/GCS_MAVLink_Sub.cpp
@@ -164,9 +164,6 @@ bool GCS_MAVLINK_Sub::send_info()
     send_named_float("InputHold", sub.input_hold_engaged);
 
     CHECK_PAYLOAD_SIZE(NAMED_VALUE_FLOAT);
-    send_named_float("RollPitch", sub.roll_pitch_flag);
-
-    CHECK_PAYLOAD_SIZE(NAMED_VALUE_FLOAT);
     send_named_float("RFTarget", sub.mode_surftrak.get_rangefinder_target_cm() * 0.01f);
 
     return true;

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -302,9 +302,6 @@ private:
     // Flag indicating if we are currently using input hold
     bool input_hold_engaged;
 
-    // Flag indicating if we are currently controlling Pitch and Roll instead of forward/lateral
-    bool roll_pitch_flag = false;
-
     // 3D Location vectors
     // Current location of the Sub (altitude is relative to home)
     Location current_loc;

--- a/ArduSub/joystick.cpp
+++ b/ArduSub/joystick.cpp
@@ -57,11 +57,6 @@ void Sub::transform_manual_control_to_rc_override(int16_t x, int16_t y, int16_t 
             int16_t aux6)
 {
 
-    float rpyScale = 0.4*gain; // Scale -1000-1000 to -400-400 with gain
-    float throttleScale = 0.8*gain*g.throttle_gain; // Scale 0-1000 to 0-800 times gain
-    int16_t rpyCenter = 1500;
-    int16_t throttleBase = 1500-500*throttleScale;
-
     bool shift = false;
 
 #if HAL_MOUNT_ENABLED
@@ -109,14 +104,17 @@ void Sub::transform_manual_control_to_rc_override(int16_t x, int16_t y, int16_t 
         xTot = x + xTrim;
     }
 
-    channel_pitch->set_override(constrain_int16(s + pitchTrim + rpyCenter,1100,1900), tnow);
-    channel_roll->set_override(constrain_int16(t + rollTrim  + rpyCenter,1100,1900), tnow);
+    GCS_MAVLINK *const gcs_mav = gcs().chan(0);
+    
+    gcs_mav->manual_override(channel_pitch, s, pitchTrim + 1000, 2000, tnow);
+    gcs_mav->manual_override(channel_roll, t, rollTrim + 1000, 2000, tnow);
+    // For legacy reasons, throttle input is in the range 0..1000 (not -1000..1000)
+    gcs_mav->manual_override(channel_throttle, zTot, 0, 1000.0f / (gain * g.throttle_gain), tnow);
 
-    channel_throttle->set_override(constrain_int16((zTot)*throttleScale+throttleBase,1100,1900), tnow);
-    channel_yaw->set_override(constrain_int16(r*rpyScale+rpyCenter,1100,1900), tnow);
-
-    channel_forward->set_override(constrain_int16((xTot)*rpyScale+rpyCenter,1100,1900), tnow);
-    channel_lateral->set_override(constrain_int16((yTot)*rpyScale+rpyCenter,1100,1900), tnow);
+    float gain_scaled_range = 2000.0f / gain;
+    gcs_mav->manual_override(channel_yaw, r, 1000, gain_scaled_range, tnow);
+    gcs_mav->manual_override(channel_forward, xTot, 1000, gain_scaled_range, tnow);
+    gcs_mav->manual_override(channel_lateral, yTot, 1000, gain_scaled_range, tnow);
 
 #if HAL_MOUNT_ENABLED
     RC_Channel *cam_pan_chan = rc().find_channel_for_option(RC_Channel::AUX_FUNC::MOUNT1_YAW);

--- a/ArduSub/joystick.cpp
+++ b/ArduSub/joystick.cpp
@@ -91,13 +91,6 @@ void Sub::transform_manual_control_to_rc_override(int16_t x, int16_t y, int16_t 
 
     buttons_prev = all_buttons;
 
-    // attitude mode:
-    if (roll_pitch_flag == 1) {
-    // adjust roll/pitch trim with joystick input instead of forward/lateral
-        pitchTrim = -x * rpyScale;
-        rollTrim  =  y * rpyScale;
-    }
-
     uint32_t tnow = AP_HAL::millis();
 
     int16_t zTot;
@@ -122,16 +115,8 @@ void Sub::transform_manual_control_to_rc_override(int16_t x, int16_t y, int16_t 
     channel_throttle->set_override(constrain_int16((zTot)*throttleScale+throttleBase,1100,1900), tnow);
     channel_yaw->set_override(constrain_int16(r*rpyScale+rpyCenter,1100,1900), tnow);
 
-    // maneuver mode:
-    if (roll_pitch_flag == 0) {
-        // adjust forward and lateral with joystick input instead of roll and pitch
-        channel_forward->set_override(constrain_int16((xTot)*rpyScale+rpyCenter,1100,1900), tnow);
-        channel_lateral->set_override(constrain_int16((yTot)*rpyScale+rpyCenter,1100,1900), tnow);
-    } else {
-        // neutralize forward and lateral input while we are adjusting roll and pitch
-        channel_forward->set_override(constrain_int16(xTrim*rpyScale+rpyCenter,1100,1900), tnow);
-        channel_lateral->set_override(constrain_int16(yTrim*rpyScale+rpyCenter,1100,1900), tnow);
-    }
+    channel_forward->set_override(constrain_int16((xTot)*rpyScale+rpyCenter,1100,1900), tnow);
+    channel_lateral->set_override(constrain_int16((yTot)*rpyScale+rpyCenter,1100,1900), tnow);
 
 #if HAL_MOUNT_ENABLED
     RC_Channel *cam_pan_chan = rc().find_channel_for_option(RC_Channel::AUX_FUNC::MOUNT1_YAW);
@@ -602,15 +587,8 @@ void Sub::handle_jsbutton_press(uint8_t _button, bool shift, bool held)
 #endif  // AP_SERVORELAYEVENTS_ENABLED
 
     case JSButton::button_function_t::k_roll_pitch_toggle:
-        if (!held) {
-            roll_pitch_flag = !roll_pitch_flag;
-            if (roll_pitch_flag) {
-                gcs().send_text(MAV_SEVERITY_INFO, "#Attitude Control");
-            }
-            else {
-                gcs().send_text(MAV_SEVERITY_INFO, "#Movement Control");
-            }
-        }
+        // Deprecated: dynamic axis input remapping should be handled by the joystick or GCS
+        gcs().send_text(MAV_SEVERITY_ERROR, "Axis toggling deprecated. Configure at topside.");
         break;
 
     case JSButton::button_function_t::k_custom_1:

--- a/libraries/AP_JSButton/AP_JSButton.h
+++ b/libraries/AP_JSButton/AP_JSButton.h
@@ -48,7 +48,7 @@ public:
         k_trim_pitch_inc        = 46,           ///< increase pitch trim
         k_trim_pitch_dec        = 47,           ///< decrease pitch trim
         k_input_hold_set        = 48,           ///< toggle input hold (trim to current controls)
-        k_roll_pitch_toggle     = 49,           ///< adjust roll/pitch input instead of forward/lateral
+        k_roll_pitch_toggle     = 49,           // Deprecated: axis remapping should be handled by the joystick or GCS
 
         // 50 reserved for future function
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -178,6 +178,7 @@ public:
 #if AP_MAVLINK_FTP_ENABLED
     friend class GCS_FTP;
 #endif
+    friend class Sub;
     friend class MAVLink_routing;
 
     GCS_MAVLINK(AP_HAL::UARTDriver &uart);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -7625,7 +7625,7 @@ void GCS_MAVLINK::manual_override(RC_Channel *c, int16_t value_in, const uint16_
         if (reversed) {
             value_in *= -1;
         }
-        override_value = radio_min + (radio_max - radio_min) * (value_in + offset) / scaler;
+        override_value = constrain_float(radio_min + (radio_max - radio_min) * (value_in + offset) / scaler, radio_min, radio_max);
     }
     c->set_override(override_value, tnow);
 }


### PR DESCRIPTION
## Summary

Refactors ArduSub MAVLink `MANUAL_CONTROL` handling to allow ignoring axes and support channel ranges, and deprecates the roll-pitch toggle joystick button function to aid in doing so.

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
    - Builds, but not yet tested
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

1. Refactors MAVLink `MANUAL_CONTROL` handling to (generally) ignore axes when specified as `INT16_MAX`, [per the spec](https://github.com/ArduPilot/ardupilot/issues/8818)
    - Switches from direct channel overrides to using the `GCS_MAVLINK::manual_override` method, per @peterbarker's [suggestion](https://github.com/ArduPilot/ardupilot/pull/32348#pullrequestreview-3879700008)
        - To make this work I had to add value constraining to the `manual_override` implementation, and friend the `Sub` class
            - Not sure whether either of those changes will be considered problematic 🤷‍♂️ 
2. To simplify 1., deprecates the joystick button functionality that toggles between forward+vertical <> roll+pitch axis control
    - Philosophically, joystick axis input configuration is better handled in the joystick hardware and/or in the GCS, which can then send consistent and reasonable values through MAVLink to the autopilot
    - I believe this feature is minimally used - Sub users are more likely to use the roll/pitch trim joystick button functions, and/or the `s` and `t` axes with a 6-axis joystick
    - Accidentally switching into this mode has been a source of confusion for various users over the years
    - Maintaining this code is rather unpleasant, and makes other functionality hard to implement
    - Preferably not merged until bluerobotics/cockpit#2476 (so there's some kind of viable GCS alternative for users without extra axes or dynamic axis remapping functionality in their controller)
    - Ideally not merged until bluerobotics/cockpit#2524 is resolved, so there's at least one _nice_ reference implementation of a GCS alternative, but not critical

If merged, closes #32348, though I'm currently unsure which is the lesser evil...