### PR TITLE
AC_AttitudeControl: reduce INPUT_TC defaults

### DIFF
--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -8,12 +8,12 @@ extern const AP_HAL::HAL& hal;
 
 #if APM_BUILD_TYPE(APM_BUILD_ArduPlane)
  // default gains for Plane
- # define AC_ATTITUDE_CONTROL_INPUT_TC_DEFAULT  0.2f    // Soft
+ # define AC_ATTITUDE_CONTROL_INPUT_TC_DEFAULT  0.15f    // Medium
  #define AC_ATTITUDE_CONTROL_ANGLE_LIMIT_MIN     5.0     // Min lean angle so that vehicle can maintain limited control
  #define AC_ATTITUDE_CONTROL_AFTER_RATE_CONTROL 0
 #else
  // default gains for Copter and Sub
- # define AC_ATTITUDE_CONTROL_INPUT_TC_DEFAULT  0.15f   // Medium
+ # define AC_ATTITUDE_CONTROL_INPUT_TC_DEFAULT  0.10f   // Crisp
  #define AC_ATTITUDE_CONTROL_ANGLE_LIMIT_MIN     10.0   // Min lean angle so that vehicle can maintain limited control
  #define AC_ATTITUDE_CONTROL_AFTER_RATE_CONTROL 1
 #endif


### PR DESCRIPTION
### Summary

This reduces the INPUT_TC parameter defaults for multicopters and quadplanes:

- Multicopter/TradHeli/Sub's ATC_INPUT_TC default reduced from 0.15 to 0.1
- QuadPlane's Q_A_INPUT_TC reduced from 0.2 to 0.15

This has come up during AP-4.7.0 beta testing ([issues list](https://github.com/ArduPilot/ardupilot/issues/32385)) and is a result of PR https://github.com/ArduPilot/ardupilot/pull/31848

This has been lightly tested in SITL.  I simply started the two vehicles affected and checked that the xxx_INPUT_TC parameter was the expected value.

<img width="462" height="75" alt="image" src="https://github.com/user-attachments/assets/9ee28c4f-ad74-4ee7-bf37-1c1929b00ec2" />

<img width="391" height="44" alt="image" src="https://github.com/user-attachments/assets/7e9793f5-676e-40d3-ad01-bcf6efcd1025" />

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
