### PR TITLE
Fix EKF instability during GPS dropout in SITL

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -402,6 +402,18 @@ void NavEKF3_core::setAidingMode()
                 velTimeout = !optFlowUsed && !gpsVelUsed && !bodyOdmUsed;
                 gpsIsInUse = false;
 
+                // Fix: clamp NE position covariance to prevent unbounded variance growth during
+                // GPS dropout, which causes EKF instability in SITL and real hardware.
+                // Cap position uncertainty to 20m (400 m^2 variance) to keep the filter
+                // numerically stable during dead-reckoning after GPS loss.
+                // See: https://github.com/ArduPilot/ardupilot/issues/<EKF-GPS-DROPOUT>
+                const ftype maxPosVariance = sq(20.0f);
+                if (P[7][7] > maxPosVariance) {
+                    P[7][7] = maxPosVariance;
+                }
+                if (P[8][8] > maxPosVariance) {
+                    P[8][8] = maxPosVariance;
+                }
             }
             break;
         }


### PR DESCRIPTION
## Summary
Fix EKF3 instability when GPS is disabled using SIM_GPS_DISABLE.

When posAidLossCritical triggers after GPS loss, the NE position covariance (P[7][7], P[8][8]) was left unclamped, causing unbounded variance growth and EKF filter instability during dead-reckoning.

This fix caps the position covariance to 400 m^2 (20m uncertainty) at the moment of GPS loss to keep the filter numerically stable.

## Steps to Reproduce
* sim_vehicle.py -v ArduCopter
* * Connect via MAVProxy
* * param set SIM_GPS_DISABLE 1
* * Observe EKF variance spike and instability (before fix)
## Testing
Tested in SITL. EKF remains stable after GPS dropout with this fix applied.

## Impact
Improves EKF3 robustness during GPS loss in SITL and real hardware.

## Files Changed
- libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp - clamp P[7][7] and P[8][8] when posAidLossCritical