### PR TITLE
AP_HAL_ChibiOS: fix DMA buffer allocation for SDMMC1 with USE_ALT_RAM_MAP

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/malloc.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/malloc.c
@@ -139,10 +139,14 @@ static void *malloc_flags(size_t size, uint32_t flags)
         size = (size + (DMA_ALIGNMENT-1)) & ~(DMA_ALIGNMENT-1);
     }
 
-    // if no flags are set or this is a DMA request and default heap
-    // is DMA safe then start with default heap
+    // start with default heap if:
+    // - no flags are set, or
+    // - DMA is requested and default heap is DMA safe
+    // - AXI bus is requested and default heap is AXI bus capable(needed when USE_ALT_RAM_MAP places AXI SRAM as region 0)
     if (flags == 0 || (flags == MEM_REGION_FLAG_DMA_OK &&
-                       (memory_regions[0].flags & MEM_REGION_FLAG_DMA_OK))) {
+                       (memory_regions[0].flags & MEM_REGION_FLAG_DMA_OK)) ||
+        (flags == MEM_REGION_FLAG_AXI_BUS &&
+         (memory_regions[0].flags & MEM_REGION_FLAG_AXI_BUS))) {
         p = chHeapAllocAligned(NULL, size, alignment);
         if (p) {
             goto found;


### PR DESCRIPTION
### Summary

<!-- Put a one or two line summary of what your PR does here -->
fix DMA buffer allocation for SDMMC1 with USE_ALT_RAM_MAP
### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description
<!-- Describe the PR's content here -->
To fix a bug that casue SDCard mount failed when enable ```USE_ALT_RAM_MAP``` on H7 board with SDMMC1

`USE_ALT_RAM_MAP` places AXI SRAM as `memory_regions[0]`, but `malloc_flags()` has no fast-path for `MEM_REGION_FLAG_AXI_BUS`, causing SDMMC1's IDMA buffer to be allocated in inaccessible memory. Fix by adding the missing fast-path, mirroring the existing `MEM_REGION_FLAG_DMA_OK` logic.

Tested on STM32H743 with `USE_ALT_RAM_MAP`. SDMMC1 SD card mounts successfully.

How to reproduce:
add ```env USE_ALT_RAM_MAP 1``` in hwdef.dat with H7 board using SDMMC1 for SDCard

related issue:

- https://discuss.ardupilot.org/t/sdmmc-not-working-on-h7-controller/123375

- https://github.com/ArduPilot/ardupilot/issues/31546

<img width="1996" height="1582" alt="image" src="https://github.com/user-attachments/assets/db2fd63d-6cd7-4da2-b433-156c907082b9" />

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
