### PR TITLE
AP_ADSB: add sanity check for access to msg.raw buffer

### DIFF
--- a/libraries/AP_ADSB/AP_ADSB_uAvionix_UCP.cpp
+++ b/libraries/AP_ADSB/AP_ADSB_uAvionix_UCP.cpp
@@ -617,8 +617,12 @@ bool AP_ADSB_uAvionix_UCP::parseByte(const uint8_t data, GDL90_RX_MESSAGE &msg, 
         break;
 
     case GDL90_RX_UNSTUFF:
-        msg.raw[status.length++] = data ^ GDL90_STUFF_BYTE;
-        status.state = GDL90_RX_IN_PACKET;
+        if (status.length < ARRAY_SIZE(msg.raw)) {
+            msg.raw[status.length++] = data ^ GDL90_STUFF_BYTE;
+            status.state = GDL90_RX_IN_PACKET;
+        } else {
+            status.state = GDL90_RX_IDLE;
+        }
         break;
     }
     status.prev_data = data;


### PR DESCRIPTION
## Summary

similarly to the code in GDL90_RX_IN_PACKET, we should check if there is space in this buffer before actually writing data into it.

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

This appears to fix an arbitrary-length buffer-overwrite problem; a sequence that only contains escape-byte/normal-byte/escape-byte/normal-byte repeatedly will just continue to overwrite past the buffer.

This issue was responsibly disclosed to the ArduPilot development team by [secmate.dev](https://secmate.dev/).  Many thanks to them for supplying a candidate patch - I have applied their fix here in only a slightly different manner.
