### PR TITLE
AP_ADSB: correct copying of callsign in Sagetech XP ADSB driver

### DIFF
--- a/libraries/AP_ADSB/AP_ADSB_Sagetech.cpp
+++ b/libraries/AP_ADSB/AP_ADSB_Sagetech.cpp
@@ -241,7 +241,8 @@ void AP_ADSB_Sagetech::handle_adsb_in_msg(const Packet_XP &msg)
 
         if (msg.payload[16] != 0) {
             // if string is non-null, consider it valid
-            memcpy(&vehicle.info, &msg.payload[16], 8);
+            // "The callsign, 8+null" (from the mavlink spec) means we subtract one here
+            memcpy(&vehicle.info.callsign, &msg.payload[16], MIN(ARRAY_SIZE(vehicle.info.callsign)-1, 8U));
             vehicle.info.flags |= ADSB_FLAGS_VALID_CALLSIGN;
         }
 


### PR DESCRIPTION
## Summary

this appeared to be overwriting all of the data at the start of the mavlink packet, rather than overwriting the callsign within the packet.

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

This appears to have been DOA.

This issue was responsibly disclosed to the ArduPilot development team by [secmate.dev](https://secmate.dev/).
