### PR TITLE
AP_ADSB: avoid buffer overwrite in AP_ADSB_Sagetech_MXS

### DIFF
--- a/libraries/AP_ADSB/AP_ADSB_Sagetech_MXS.cpp
+++ b/libraries/AP_ADSB/AP_ADSB_Sagetech_MXS.cpp
@@ -279,6 +279,12 @@ bool AP_ADSB_Sagetech_MXS::parse_byte(const uint8_t data)
         case ParseState::WaitingFor_PayloadLen: 
             message_in.checksum += data;
             message_in.packet.payload_length = data;
+            // the checksum is also appended to the payload array, so
+            // we only allow a 254 byte payload here:
+            if (message_in.packet.payload_length >= ARRAY_SIZE(message_in.packet.payload)) {
+                message_in.state = ParseState::WaitingFor_Start;
+                break;
+            }
             message_in.index = 0;
             message_in.state = (data == 0) ? ParseState::WaitingFor_Checksum : ParseState::WaitingFor_PayloadContents;
             break;


### PR DESCRIPTION
## Summary

Corrects notional buffer overflow in the MXS driver.

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [ ] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] Autotest included

## Description

we were not bounds-checking this value, and then reading many bytes into a target buffer based on it.

Do the bounds check.

The payload buffer is 255 bytes - so this is a one-byte overflow.

This issue was responsibly disclosed to the ArduPilot development team by [secmate.dev](https://secmate.dev/).