### PR TITLE
AP_Math: kinematic limit clean up

### DIFF
--- a/libraries/AP_Math/control.cpp
+++ b/libraries/AP_Math/control.cpp
@@ -725,7 +725,7 @@ float kinematic_limit(Vector3f direction, float max_xy, float max_z_neg, float m
 float kinematic_limit(float dir_xy, float dir_z, float max_xy, float max_z_neg, float max_z_pos)
 {
     // Reject invalid limits
-    if (!is_positive(max_xy) || !is_positive(max_z_pos) || !is_positive(max_z_neg)) {
+    if (is_negative(dir_xy) || !is_positive(max_xy) || !is_positive(max_z_pos) || !is_positive(max_z_neg)) {
         return 0.0;
     }
 
@@ -755,21 +755,21 @@ float kinematic_limit(float dir_xy, float dir_z, float max_xy, float max_z_neg, 
 
     if (is_positive(slope)) {
         // Positive-Z: constrained by max_z_pos
-        if (fabsf(slope) < max_z_pos / max_xy) {
+        if (slope < max_z_pos / max_xy) {
             // Shallow direction: horizontal limit reached first
             return max_xy / dir_xy;
         }
         // Steep direction: vertical limit reached first
-        return fabsf(max_z_pos / dir_z);
+        return max_z_pos / dir_z;
     }
 
     // Negative-Z: constrained by max_z_neg
-    if (fabsf(slope) < max_z_neg / max_xy) {
+    if (-slope < max_z_neg / max_xy) {
         // Shallow direction: horizontal limit reached first
         return max_xy / dir_xy;
     }
     // Steep direction: vertical limit reached first
-    return fabsf(max_z_neg / dir_z);
+    return -max_z_neg / dir_z;
 }
 
 // Applies an exponential curve to a normalized input in the range [-1, 1].

--- a/libraries/AP_Math/control.cpp
+++ b/libraries/AP_Math/control.cpp
@@ -702,11 +702,6 @@ float stopping_distance(float velocity, float p, float accel_max)
 // Returns 0 if the direction is zero or any limit is zero.
 float kinematic_limit(Vector3f direction, float max_xy, float max_z_neg, float max_z_pos)
 {
-    // Reject zero-length direction
-    if (is_zero(direction.length_squared())) {
-        return 0.0;
-    }
-
     // Decompose into horizontal magnitude and vertical component
     const float dir_xy = direction.xy().length();
 
@@ -730,24 +725,15 @@ float kinematic_limit(Vector3f direction, float max_xy, float max_z_neg, float m
 float kinematic_limit(float dir_xy, float dir_z, float max_xy, float max_z_neg, float max_z_pos)
 {
     // Reject invalid limits
-    if (is_zero(max_xy) || is_zero(max_z_pos) || is_zero(max_z_neg)) {
+    if (!is_positive(max_xy) || !is_positive(max_z_pos) || !is_positive(max_z_neg)) {
         return 0.0;
     }
-
-    // Ensure limits are positive magnitudes
-    max_xy = fabsf(max_xy);
-    max_z_pos = fabsf(max_z_pos);
-    max_z_neg = fabsf(max_z_neg);
 
     // Check for zero length direction vector
     const float dir_length = safe_sqrt(sq(dir_xy) + sq(dir_z));
     if (!is_positive(dir_length)) {
         return 0.0;
     }
-
-    // Normalize the direction vector (only ratio matters)
-    dir_xy /= dir_length;
-    dir_z /= dir_length;
 
     if (is_zero(dir_xy)) {
         // Pure vertical - constrained only by vertical limits
@@ -758,6 +744,10 @@ float kinematic_limit(float dir_xy, float dir_z, float max_xy, float max_z_neg, 
         // Pure horizontal - constrained only by horizontal limits
         return max_xy;
     }
+
+    // Normalize the direction vector (only ratio matters)
+    dir_xy /= dir_length;
+    dir_z /= dir_length;
 
     // Compare the direction slope (|dir_z/dir_xy|) to the limit slope
     // (max_z/max_xy) to determine which axis constraint is hit first.


### PR DESCRIPTION
This PR has a couple code improvements from feedback in #32607

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change (as used)
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

Only minor changes that improve the efficiency and readability of the code. Only change in behaviour is we no longer accept negative limits and convert to a magnitude.
