### PR TITLE
hwdef: correct double-tick fixed-width markup to single-tick

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/AEDROXH7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/AEDROXH7/README.md
@@ -29,7 +29,7 @@
 
 ## RC Input
 
-The default RC input is configured on the UART3 (RX3/SBUS). Non SBUS,  single wire serial inputs can be directly tied to RX3 if SBUS pin is left unconnected. RC could  be applied instead at a different UART port such as UART4 or UART8, and set the protocol to receive RC data: ``SERIALn_PROTOCOL = 23`` and change SERIAL3 _Protocol to something other than '23'.
+The default RC input is configured on the UART3 (RX3/SBUS). Non SBUS,  single wire serial inputs can be directly tied to RX3 if SBUS pin is left unconnected. RC could  be applied instead at a different UART port such as UART4 or UART8, and set the protocol to receive RC data: `SERIALn_PROTOCOL = 23` and change SERIAL3 _Protocol to something other than '23'.
 
 - PPM is supported.
 - SBUS/DSM/SRXL connects to the RX3 pin.

--- a/libraries/AP_HAL_ChibiOS/hwdef/AIRBRAINH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/AIRBRAINH743/README.md
@@ -38,7 +38,7 @@ receive pin. The TX pin is the transmit pin .
 ## RC Input
 
 The default RC input is configured on USART2. RC could  be applied instead to a different UART port,  and set
-the protocol to receive RC data ``SERIALn_PROTOCOL`` = 23 and change :ref:`SERIAL2 _PROTOCOL <SERIAL2 _PROTOCOL>`
+the protocol to receive RC data `SERIALn_PROTOCOL` = 23 and change :ref:`SERIAL2 _PROTOCOL <SERIAL2 _PROTOCOL>`
 to something other than '23'. For rc protocols other than unidirectional, the USART2_TX pin will need to be used:
 
 - FPort would require :ref:`SERIAL2_OPTIONS<SERIAL2_OPTIONS>` be set to "15".

--- a/libraries/AP_HAL_ChibiOS/hwdef/CORVON743V1/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CORVON743V1/README.md
@@ -36,7 +36,7 @@ The CORVON743V1 is a flight controller designed and produced by [CORVON]
 
 ## RC Input
 
-The default RC input is configured on the UART6. The SBUS pin is inverted and connected to RX6. Non SBUS, single wire serial inputs can be directly tied to RX6 if SBUS pin is left unconnected. RC could  be applied instead to a different UART port such as UART1, UART4 or UART8, and set the protocol to receive RC data ``SERIALn_PROTOCO`` =23 and change :ref:`SERIAL5 _PROTOCOL <SERIAL5 _PROTOCOL>` to something other than '23'. For rc protocols other than unidirectional, the TX6 pin will need to be used:
+The default RC input is configured on the UART6. The SBUS pin is inverted and connected to RX6. Non SBUS, single wire serial inputs can be directly tied to RX6 if SBUS pin is left unconnected. RC could  be applied instead to a different UART port such as UART1, UART4 or UART8, and set the protocol to receive RC data `SERIALn_PROTOCOL` = 23 and change :ref:`SERIAL5 _PROTOCOL <SERIAL5 _PROTOCOL>` to something other than '23'. For rc protocols other than unidirectional, the TX6 pin will need to be used:
 
 - :ref:`SERIAL5_PROTOCOL<SERIAL5_PROTOCOL>` should be set to "23".
 - FPort would require :ref:`SERIAL5_OPTIONS<SERIAL5_OPTIONS>` be set to "15".

--- a/libraries/AP_HAL_ChibiOS/hwdef/CUAV-X25-EVO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CUAV-X25-EVO/README.md
@@ -46,7 +46,7 @@ The USART3 connector is labelled debug, but is available as a general purpose UA
 
 ## RC Input
 
-All ArduPilot supported unidirectional RC protocols can be input on the port marked RC IN, including PPM. For bi-directional or half-duplex protocols, such as CRSF/ELRS a full UART will have to be used set to ``SERIALLx_PROTOCOL`` = 23. See :ref:`common-rc-systems` for more details.
+All ArduPilot supported unidirectional RC protocols can be input on the port marked RC IN, including PPM. For bi-directional or half-duplex protocols, such as CRSF/ELRS a full UART will have to be used set to `SERIALLx_PROTOCOL` = 23. See :ref:`common-rc-systems` for more details.
 
 ## PWM Output
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/JHEMCUF405WING/Readme.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/JHEMCUF405WING/Readme.md
@@ -113,11 +113,11 @@ The JHEMCUF405Wing does not have a built-in compass, but you can attach an exter
 
 ## VTX power control
 
-GPIO 81 controls the VTX BEC output to pins marked "9V". Setting this GPIO high removes voltage supply to pins. ``Relay2`` controls this GPIO by default.
+GPIO 81 controls the VTX BEC output to pins marked "9V". Setting this GPIO high removes voltage supply to pins. `Relay2` controls this GPIO by default.
 
 ## Camera Control
 
-GPIO 82 switches the C1 and C2 camera inputs. ``Relay 3`` controls this GPIO by default.
+GPIO 82 switches the C1 and C2 camera inputs. `Relay 3` controls this GPIO by default.
 
 ## Loading Firmware
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/JPilot-C/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/JPilot-C/README.md
@@ -139,7 +139,7 @@ Channels within the same group need to use the same output rate. If any channel 
 
 ## RC Input
 
-Any of the serial ports can be used for a bidirectional RC connection. Change its ``SERIALx_PROTOCOL`` to "23" and follow the instructions in :ref:`common-rc-systems` to other setup info for the RC system being used.
+Any of the serial ports can be used for a bidirectional RC connection. Change its `SERIALx_PROTOCOL` to "23" and follow the instructions in :ref:`common-rc-systems` to other setup info for the RC system being used.
 
 ## Battery Monitor
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/NarinFC-H7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/NarinFC-H7/README.md
@@ -177,7 +177,7 @@ ALL outputs within the same group need to use the same output rate and protocol.
 
 ## GPIOs
 
-The 14 outputs can be used as GPIOs (relays, buttons, RPM etc). To use them you need to set the output’s ``SERVOx_FUNCTION`` to -1. See GPIOs page for more information.
+The 14 outputs can be used as GPIOs (relays, buttons, RPM etc). To use them you need to set the output’s `SERVOx_FUNCTION` to -1. See GPIOs page for more information.
 
 The numbering of the GPIOs for use in the PIN parameters in ArduPilot is:
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ORBITH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ORBITH743/README.md
@@ -87,7 +87,7 @@ The ORBITH743 has an onboard OSD using a MAX7456 chip and is enabled by default.
 
 ## DJI Video and OSD
 
-An **SH1.0 6P** connector supports a standard DJI HD VTX. ``SERIAL3`` is configured by default for DisplayPort. Pin 1 provides 10V which is controlled by GPIO81 -**do not** connect peripherals that require 5V to this pin.
+An **SH1.0 6P** connector supports a standard DJI HD VTX. `SERIAL3` is configured by default for DisplayPort. Pin 1 provides 10V which is controlled by GPIO81 -**do not** connect peripherals that require 5V to this pin.
 
 ## DShot Capability
 
@@ -105,7 +105,7 @@ Servo outputs (Outputs 9-12, marked S1-S4) on PA15, PB3, PD12, and PD13 (TIM2 an
 ## GPIOs
 
 ORBITH743 outputs can be used as GPIOs (relays, buttons, RPM, etc.).  
-Set the ``SERVOx_FUNCTION`` = -1 to enable GPIO functionality. See [ArduPilot GPIO docs](https://ardupilot.org) for more info.
+Set the `SERVOx_FUNCTION` = -1 to enable GPIO functionality. See [ArduPilot GPIO docs](https://ardupilot.org) for more info.
 
 ### GPIO Pin Mapping
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixSurveyA2-IND/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixSurveyA2-IND/README.md
@@ -143,7 +143,7 @@ support all normal PWM output formats. All outputs also support DShot. Outputs 9
 
 ## GPIOs
 
-All PWM outputs can be used as GPIOs (relays, camera, RPM etc). To use them you need to set the output’s ``SERVOx_FUNCTION`` to -1. The numbering of the GPIOs for PIN variables in ArduPilot is:
+All PWM outputs can be used as GPIOs (relays, camera, RPM etc). To use them you need to set the output’s `SERVOx_FUNCTION` to -1. The numbering of the GPIOs for PIN variables in ArduPilot is:
 
 .. raw:: html
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SequreH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SequreH743/README.md
@@ -34,7 +34,7 @@ receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
 ## RC Input
 
 The default RC input is configured on USART1. RC could  be applied instead to a different UART port such as  and set
-the protocol to receive RC data ``SERIALn_PROTOCOL`` = 23 and change :ref:`SERIAL1 _PROTOCOL <SERIAL1 _PROTOCOL>`
+the protocol to receive RC data `SERIALn_PROTOCOL` = 23 and change :ref:`SERIAL1 _PROTOCOL <SERIAL1 _PROTOCOL>`
 to something other than '23'. For rc protocols other than unidirectional, the USART1_TX pin will need to be used:
 
 - :ref:`SERIAL1_PROTOCOL<SERIAL1_PROTOCOL>` should be set to "23".

--- a/libraries/AP_HAL_ChibiOS/hwdef/SkystarsF405v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SkystarsF405v2/README.md
@@ -32,7 +32,7 @@ receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
 ## RC Input
 
 The default RC input is configured on USART2. RC could  be applied instead to a different UART port such as  and set
-the protocol to receive RC data ``SERIALn_PROTOCOL`` = 23 and change :ref:`SERIAL2 _PROTOCOL <SERIAL2 _PROTOCOL>`
+the protocol to receive RC data `SERIALn_PROTOCOL` = 23 and change :ref:`SERIAL2 _PROTOCOL <SERIAL2 _PROTOCOL>`
 to something other than '23'. For rc protocols other than unidirectional, the USART2_TX pin will need to be used:
 
 - :ref:`SERIAL2_PROTOCOL<SERIAL2_PROTOCOL>` should be set to "23".


### PR DESCRIPTION
### Summary

Replace rst-style double-tick markup to single-tick markdown style

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

From the AEDROXH7 README.md, first patch here:

<img width="1712" height="363" alt="image" src="https://github.com/user-attachments/assets/705eb60b-1152-47f9-b538-577ea772a680" />

### Description

former is rst-style, latter is markdown-style
