### PR TITLE
AP_Scripting: hobbywing datalink link fix

### DIFF
--- a/libraries/AP_Scripting/drivers/Hobbywing_DataLink.md
+++ b/libraries/AP_Scripting/drivers/Hobbywing_DataLink.md
@@ -1,6 +1,6 @@
 # HobbyWing ESC DataLink Driver
 
-[Hobbywing](https://www.hobbywing.com/en/products?id=59)
+[Hobbywing Datalink v2](https://www.hobbywing.com/en/products/datalinkv2273)
 
 This driver implements support the HobbyWing DataLink for HobbyWing
 ESCs connected via a UART to an ArduPilot serial port. It supports up


### PR DESCRIPTION
### Summary

This corrects a link within the HobbyWing ESC DataLink Driver's md file.  The link was to https://www.hobbywing.com/en/products?id=59 but this is no longer valid so I've replaced it with https://www.hobbywing.com/en/products/datalinkv2273 which is the closest equivalent I could find

It looks correct to me and is similar to what [the WaybackMachine shows for the page before it was removed.
](https://web.archive.org/web/20250117112138/https://www.hobbywing.com/en/products?id=59)
Related wiki issue: https://github.com/ArduPilot/ardupilot_wiki/issues/7604
Related wiki PR: https://github.com/ArduPilot/ardupilot_wiki/pull/7605
Related discussion: https://discuss.ardupilot.org/t/datalink-hobbywing-com-t-motor/143263

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

