### PR TITLE
Tools: Print the Artistic Style version in CI

### DIFF
--- a/.github/workflows/test_scripts.yml
+++ b/.github/workflows/test_scripts.yml
@@ -34,10 +34,11 @@ jobs:
           pip-install: flake8 lxml pexpect
 
       - name: Install astyle
+        if: matrix.config == 'astyle-cleanliness'
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install -y astyle
+          sudo apt-get install --yes astyle
 
       - name: Install shellcheck
         if: matrix.config == 'shellcheck'

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -518,9 +518,6 @@ for t in $CI_BUILD_TARGET; do
         echo "Checking AStyle code cleanliness"
 
         ./Tools/scripts/run_astyle.py --dry-run
-        if [ $? -ne 0 ]; then
-            echo The code failed astyle cleanliness checks. Please run ./Tools/scripts/run_astyle.py
-        fi
         continue
     fi
 

--- a/Tools/scripts/run_astyle.py
+++ b/Tools/scripts/run_astyle.py
@@ -7,6 +7,7 @@ Runs astyle over directory sub-trees known to be "astyle-clean"
 """
 
 import argparse
+import contextlib
 import os
 import pathlib
 import subprocess
@@ -37,13 +38,16 @@ class AStyleChecker(object):
         self.dry_run = dry_run
 
     def progress(self, string):
-        print("****** %s" % (string,))
+        print(f"****** {string}")
 
     def check(self):
         '''run astyle on all files in self.files_to_check'''
         # for path in self.files_to_check:
         #     self.progress("Checking (%s)" % path)
         astyle_command = ["astyle"]
+        # Show the astyle version suppressing all exceptions
+        with contextlib.suppress():
+            _ = subprocess.run(astyle_command + ["--version"])
         if self.dry_run:
             astyle_command.append("--dry-run")
 
@@ -56,7 +60,7 @@ class AStyleChecker(object):
             text=True
         )
         if ret.returncode != 0:
-            self.progress("astyle check failed: (%s)" % (ret.stdout))
+            self.progress(f"astyle check failed: ({ret.stdout})")
             self.retcode = 1
         if "Formatted" in ret.stdout:
             self.progress("Files needing formatting found.")
@@ -72,7 +76,7 @@ class AStyleChecker(object):
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Check all Python files for astyle cleanliness')
+    parser = argparse.ArgumentParser(description='Check C and C++ files for astyle cleanliness')
     parser.add_argument('--dry-run',
                         action='store_true',
                         default=DRY_RUN_DEFAULT,


### PR DESCRIPTION
### Summary

Tools: Print the [Artistic Style](https://astyle.sourceforge.net) version in CI because the local version of `astyle` matters when running:
% `CI_BUILD_TARGET=astyle-cleanliness Tools/scripts/build_ci.sh`
as is done in CI job`test scripts / build (astyle-cleanliness)`.

Printing the `astyle` version helps us understand changes proposed in future pull requests.

macOS: `brew install astyle` delivers Artistic Style Version 3.6.14.

Windows users might get v3.6.2
* https://community.chocolatey.org/packages/astyle

Linux users will get different versions based on their distro.
ubuntu:24.04: Artistic Style Version 3.1
ubuntu:26.04: Artistic Style Version 3.6.12

Related to:
* #32566

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g., unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g., unit test, autotest)
- [x] Tested manually, ~description below (e.g. SITL)~
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

Modify `Tools/scripts/build_ci.sh` so that `astyle-cleanliness` raises an error in CI if any files need formatting.

Modify `Tools/scripts/run_astyle.py`:
* Change its description because `astyle` is a C and C++ formatter, not a Python formatter.
* Print the `astyle` version but suppress all exceptions.
* Use Python f-strings, which are shorter, faster, and more readable.

The `astyle` version is important to print because Ubuntu 24.04 LTS defaults to Artistic Style 3.1 (January 2018) while this month's Ubuntu 26.04 LTS defaults to Artistic Style 3.6 (August 2024).
* Artistic Style version info: https://astyle.sourceforge.net/news.html

### How was this tested?
1. % `code ArduCopter/AP_ExternalControl_Copter.cpp libraries/AP_DDS/AP_DDS_ExternalControl.cpp`
2. Make similar leading and trailing whitespace changes to both files.
3. % `CI_BUILD_TARGET=astyle-cleanliness Tools/scripts/build_ci.sh`
---
Inside the Docker container, run the command:
```
# cd app && \
    apt update && \
    DEBIAN_FRONTEND=noninteractive apt install --yes astyle python3 && \
    astyle --version && \
    Tools/scripts/run_astyle.py --dry-run ; echo $?
```
% `docker run -it -v "$(pwd)":/app ubuntu:24.04`
```
Artistic Style Version 3.1
0
```
% `docker run -it -v "$(pwd)":/app ubuntu:26.04`
```
Artistic Style Version 3.6.12
****** Files needing formatting found.
[ ... ]
1
```
@Ryanf55 