### PR TITLE
hwdef: avoid use of 'note' and 'raw' rst directives

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/ATOMRCF405NAVI-Deluxe/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ATOMRCF405NAVI-Deluxe/README.md
@@ -4,9 +4,7 @@
 
 the above image and some content courtesy of `ATOMRC <http://atomrc.com/>`__
 
-.. note::
-
-    Due to flash memory limitations, this board does not include all ArduPilot features. See :ref:`Firmware Limitations <common-limited_firmware>` for details.
+> **Note:** Due to flash memory limitations, this board does not include all ArduPilot features. See :ref:`Firmware Limitations <common-limited_firmware>` for details.
 
 ## Specifications
 
@@ -71,7 +69,7 @@ All motor/servo outputs are Dshot and PWM capable. Outputs 1/2 and 6/7 are Bi-Di
 
 Mixing Dshot and normal PWM operation for outputs is restricted into groups, ie. enabling Dshot for an output in a group requires that ALL outputs in that group be configured and used as Dshot, rather than PWM outputs. The output groups that must be the same (PWM rate or Dshot, when configured as a normal servo/motor output) are: 1/2, 3/4, 5/6/7, 8/9/10, and 11/12(LED).
 
-.. note:: PWM12 is marked as "LED" and defaulted to serial led protocol, so output 11 must also be used for serial LED unless output 12 function is changed.
+> **Note:** PWM12 is marked as "LED" and defaulted to serial led protocol, so output 11 must also be used for serial LED unless output 12 function is changed.
 
 ## RC Input
 
@@ -87,7 +85,7 @@ The SBUS pin, is passed by an inverter to RX2 (UART2 RX). UART2 is defaulted to 
 
 - SRXL2 requires a connection to TX2 and automatically provides telemetry.  Set :ref:`SERIAL6_OPTIONS<SERIAL6_OPTIONS>` to "4".
 
-.. note:: the 5v pin above the SBUS pin is powered when USB is connected. All other 5V pins are only powered when battery is present.
+> **Note:** the 5v pin above the SBUS pin is powered when USB is connected. All other 5V pins are only powered when battery is present.
 
 ## Battery Monitor Configuration
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BlitzH743Pro/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BlitzH743Pro/README.md
@@ -66,7 +66,7 @@ The PWM are in in five groups:
 - PWM 11-12 in group4
 - PWM 13 in group5
 
-.. note:: for users migrating from BetaflightX quads, the first four outputs M1-M4 have been configured for use with existing motor wiring using these default parameters:
+> **Note:** for users migrating from BetaflightX quads, the first four outputs M1-M4 have been configured for use with existing motor wiring using these default parameters:
 
 - :ref:`FRAME_CLASS<FRAME_CLASS>` = 1 (Quad)
 - :ref:`FRAME_TYPE<FRAME_TYPE>` = 12 (BetaFlightX)

--- a/libraries/AP_HAL_ChibiOS/hwdef/FlywooF405HD-AIOv2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/FlywooF405HD-AIOv2/README.md
@@ -69,7 +69,8 @@ LED: Group 3
 Channels within the same group need to use the same output rate. If
 any channel in a group uses DShot then all channels in the group need
 to use DShot. PWM 1-4 support bidirectional dshot.
-.. note:: for users migrating from BetaflightX quads, the first four outputs M1-M4 have been configured for use with existing motor wiring using these default parameters:
+
+> **Note:** for users migrating from BetaflightX quads, the first four outputs M1-M4 have been configured for use with existing motor wiring using these default parameters:
 
 - :ref:`FRAME_CLASS<FRAME_CLASS>` = 1 (Quad)
 - :ref:`FRAME_TYPE<FRAME_TYPE>` = 12 (BetaFlightX)

--- a/libraries/AP_HAL_ChibiOS/hwdef/JHEMCUF405WING/Readme.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/JHEMCUF405WING/Readme.md
@@ -69,7 +69,7 @@ To allow CRSF and embedded telemetry available in Fport, CRSF, and SRXL2 receive
 
 - SRXL2 requires a connection to TX1 and automatically provides telemetry.  Set :ref:`SERIAL1_OPTIONS<SERIAL1_OPTIONS>` to "4".
 
-.. note:: UART1 is configured by default for serial receivers. You can also have more than one receiver in the system at a time (usually used for long range hand-offs to a remote TX). See :ref:`common-multiple-rx` for details.
+> **Note:** UART1 is configured by default for serial receivers. You can also have more than one receiver in the system at a time (usually used for long range hand-offs to a remote TX). See :ref:`common-multiple-rx` for details.
 
 Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM (SBUS requires external inversion on other UARTs). See :ref:`common-rc-systems` for details.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixSurveyA2-IND/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixSurveyA2-IND/README.md
@@ -145,9 +145,7 @@ support all normal PWM output formats. All outputs also support DShot. Outputs 9
 
 All PWM outputs can be used as GPIOs (relays, camera, RPM etc). To use them you need to set the output’s `SERVOx_FUNCTION` to -1. The numbering of the GPIOs for PIN variables in ArduPilot is:
 
-.. raw:: html
-
-   | IO Pins |  | FMU Pins |
+| IO Pins |  | FMU Pins |
 | --- | --- | --- |
 | Name | Value | Option |
 |  | Name | Value |
@@ -187,7 +185,7 @@ Then reboot.
 - :ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT__AP_BattMonitor>` 18.0
 - :ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT__AP_BattMonitor>` 24.0
 
-.. note:: OSDs will by default display the first battery monitor unless the second battery monitor panel is setup in OSD parameters.
+> **Note:** OSDs will by default display the first battery monitor unless the second battery monitor panel is setup in OSD parameters.
 
 ## DroneCAN capability
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SDMODELH7V2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SDMODELH7V2/README.md
@@ -76,7 +76,7 @@ Channels within the same group need to use the same output rate. If
 any channel in a group uses DShot then all channels in the group need
 to use DShot.
 
-.. note:: for users migrating from BetaflightX quads, the first four outputs M1-M4 have been configured for use with existing motor wiring using these default parameters:
+> **Note:** for users migrating from BetaflightX quads, the first four outputs M1-M4 have been configured for use with existing motor wiring using these default parameters:
 
 - :ref:`FRAME_CLASS<FRAME_CLASS>` = 1 (Quad)
 - :ref:`FRAME_TYPE<FRAME_TYPE>` = 12 (BetaFlightX)

--- a/libraries/AP_HAL_ChibiOS/hwdef/SpeedyBeeF405AIO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SpeedyBeeF405AIO/README.md
@@ -27,7 +27,7 @@ The SpeedyBee F405 AIO is a flight controller produced by [SpeedyBee](https://ww
 
 ![SpeedyBee F405 AIO](SpeedyBeeF405AIO_Pinout.png "SpeedyBee F405 AIO")
 
-.. note:: S pin for "Meteor LED" does not work with this firmware
+> **Note:** S pin for "Meteor LED" does not work with this firmware
 
 ## UART Mapping
 


### PR DESCRIPTION
### Summary

Fix stray rst directives in markdown....

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Master:
<img width="2037" height="451" alt="image" src="https://github.com/user-attachments/assets/52391f62-1ab2-464c-b89b-5c9d007ce351" />

New:
<img width="2037" height="451" alt="image" src="https://github.com/user-attachments/assets/888b76d8-2016-4674-8e6a-5d40e0700367" />

Master:
<img width="2037" height="451" alt="image" src="https://github.com/user-attachments/assets/eed4236a-ed18-4362-8450-7300cf3a2d37" />

New:
<img width="2037" height="451" alt="image" src="https://github.com/user-attachments/assets/0684c01f-23df-4e12-bc6b-94d06ccadbb8" />

### Description

we do markdown in these files, not rst!