### PR TITLE
Tools: fix build_bootloaders debug symbol flag

### DIFF
--- a/Tools/scripts/build_bootloaders.py
+++ b/Tools/scripts/build_bootloaders.py
@@ -18,7 +18,8 @@ from argparse import ArgumentParser
 parser = ArgumentParser(description='This Program is used to build ArduPilot bootloaders for boards.')
 parser.add_argument("--signing-key", type=str, action='append', help="signing key for secure bootloader (can be used multiple times)")
 parser.add_argument("--omit-ardupilot-keys", action='store_true', default=False, help="omit ArduPilot signing keys")
-parser.add_argument("--debug", action='store_true', default=False, help="build with debug symbols")
+parser.add_argument("--debug", action='store_true', default=False, help="configure as debug variant")
+parser.add_argument("--debug-symbols", "-g", action='store_true', default=False, help="add debug symbols to build")
 parser.add_argument("--periph-only", action='store_true', default=False, help="only build AP_Periph boards")
 parser.add_argument("pattern", type=str, default='*', help="board wildcard pattern", nargs='?')
 args = parser.parse_args()
@@ -113,8 +114,11 @@ def build_board(board):
         print("Building secure bootloader")
         configure_args.append("--signed-fw")
     if args.debug:
-        print("Building with debug symbols")
+        print("Building debug variant")
         configure_args.append("--debug")
+    if args.debug_symbols:
+        print("Building with debug symbols")
+        configure_args.append("--debug-symbols")
     if not run_program(["./waf", "configure"] + configure_args):
         return False
     if not run_program(["./waf", "clean"]):


### PR DESCRIPTION
### Summary

The debug flag, contrary to its documentation, enables a debug build, increasing the size of the binary and changing its contents. Fix the documentation to describe what it actually does.

Then add the same flag as waf to just add symbols without changing the actual binary.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

Confirmed that building with `-g` or without does not change binary.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
