### PR TITLE
Tidy char-to-hex functions

### DIFF
--- a/Tools/AP_Bootloader/flash_from_sd.cpp
+++ b/Tools/AP_Bootloader/flash_from_sd.cpp
@@ -15,30 +15,11 @@
 
 #include <AP_HAL_ChibiOS/hwdef/common/flash.h>
 #include <AP_Math/AP_Math.h>
+#include <AP_Common/AP_Common.h>
 #include "support.h"
 
 // swiped from support.cpp:
 static const uint8_t *flash_base = (const uint8_t *)(0x08000000 + (FLASH_BOOTLOADER_LOAD_KB + APP_START_OFFSET_KB)*1024U);
-
-
-// taken from AP_Common.cpp as we don't want to compile the AP_Common
-// directory.  This function is defined in AP_Common.h - so we can't
-// use "static" here.
-/**
- * return the numeric value of an ascii hex character
- * 
- * @param[in] a Hexadecimal character 
- * @return  Returns a binary value
- */
-uint8_t char_to_hex(char a)
-{
-    if (a >= 'A' && a <= 'F')
-        return a - 'A' + 10;
-    else if (a >= 'a' && a <= 'f')
-        return a - 'a' + 10;
-    else
-        return a - '0';
-}
 
 #define MAX_IO_SIZE 4096
 static uint8_t buffer[MAX_IO_SIZE];
@@ -219,8 +200,8 @@ protected:
         }
 
         // convert from 32-byte-string to 16-byte number:
-        for (uint8_t j=0; j<16; j++) {
-            expected_md5[j] = (char_to_hex(value[j*2]) << 4) | char_to_hex(value[j*2+1]);
+        if (!hex_charpairs_to_uint8s(value, 16, expected_md5)) {
+            return;
         }
     }
 

--- a/libraries/AP_AIS/AP_AIS.cpp
+++ b/libraries/AP_AIS/AP_AIS.cpp
@@ -972,7 +972,10 @@ bool AP_AIS::decode_latest_term()
     // handle the last term in a message
     if (_term_is_checksum) {
         _sentence_done = true;
-        uint8_t checksum = 16 * char_to_hex(_term[0]) + char_to_hex(_term[1]);
+        uint8_t checksum;
+        if (!hex_twochars_to_uint8(_term, checksum)) {
+            return false;
+        }
         return ((checksum == _checksum) && _sentence_valid);
     }
 

--- a/libraries/AP_Airspeed/AP_Airspeed_NMEA.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_NMEA.cpp
@@ -173,12 +173,10 @@ bool AP_Airspeed_NMEA::decode_latest_term()
     // handle the last term in a message
     if (_term_is_checksum) {
         _sentence_done = true;
-        uint8_t nibble_high = 0;
-        uint8_t nibble_low  = 0;
-        if (!hex_to_uint8(_term[0], nibble_high) || !hex_to_uint8(_term[1], nibble_low)) {
+        uint8_t checksum;
+        if (!hex_twochars_to_uint8(_term, checksum)) {
             return false;
         }
-        const uint8_t checksum = (nibble_high << 4u) | nibble_low;
         return checksum == _checksum;
     }
 

--- a/libraries/AP_CANManager/AP_SLCANIface.cpp
+++ b/libraries/AP_CANManager/AP_SLCANIface.cpp
@@ -69,8 +69,6 @@ const AP_Param::GroupInfo SLCAN::CANIface::var_info[] = {
 
 ////////Helper Methods//////////
 
-static bool hex2nibble_error;
-
 static uint8_t nibble2hex(uint8_t x)
 {
     // Allocating in RAM because it's faster
@@ -78,16 +76,6 @@ static uint8_t nibble2hex(uint8_t x)
         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
     };
     return ConversionTable[x & 0x0F];
-}
-
-static uint8_t hex2nibble(char c)
-{
-    uint8_t out = char_to_hex(c);
-
-    if (out == 255) {
-        hex2nibble_error = true;
-    }
-    return out;
 }
 
 bool SLCAN::CANIface::push_Frame(AP_HAL::CANFrame &frame)
@@ -107,30 +95,21 @@ bool SLCAN::CANIface::push_Frame(AP_HAL::CANFrame &frame)
 bool SLCAN::CANIface::handle_FrameDataExt(const char* cmd, bool canfd)
 {
     AP_HAL::CANFrame f {};
-    hex2nibble_error = false;
     f.canfd = canfd;
-    f.id = f.FlagEFF |
-           (hex2nibble(cmd[1]) << 28) |
-           (hex2nibble(cmd[2]) << 24) |
-           (hex2nibble(cmd[3]) << 20) |
-           (hex2nibble(cmd[4]) << 16) |
-           (hex2nibble(cmd[5]) << 12) |
-           (hex2nibble(cmd[6]) <<  8) |
-           (hex2nibble(cmd[7]) <<  4) |
-           (hex2nibble(cmd[8]) <<  0);
-    f.dlc = hex2nibble(cmd[9]);
-    if (hex2nibble_error || f.dlc > (canfd?15:8)) {
+    uint32_t id;
+    if (!hex_chars_to_uint32(&cmd[1], 8, id)) {
         return false;
     }
-    {
-        const char* p = &cmd[10];
-        const uint8_t dlen = AP_HAL::CANFrame::dlcToDataLength(f.dlc);
-        for (unsigned i = 0; i < dlen; i++) {
-            f.data[i] = (hex2nibble(*p) << 4) | hex2nibble(*(p + 1));
-            p += 2;
-        }
+    f.id = f.FlagEFF | id;
+    if (!hex_char_to_nibble(cmd[9], f.dlc)) {
+        return false;
     }
-    if (hex2nibble_error) {
+    if (f.dlc > (canfd?15:8)) {
+        // invalid dlc in frame
+        return false;
+    }
+    const uint8_t dlen = AP_HAL::CANFrame::dlcToDataLength(f.dlc);
+    if (!hex_charpairs_to_uint8s(&cmd[10], dlen, f.data)) {
         return false;
     }
     return push_Frame(f);
@@ -147,29 +126,16 @@ bool SLCAN::CANIface::handle_FDFrameDataExt(const char* cmd)
     return false;
 #else
     AP_HAL::CANFrame f {};
-    hex2nibble_error = false;
     f.canfd = true;
-    f.id = f.FlagEFF |
-           (hex2nibble(cmd[1]) << 28) |
-           (hex2nibble(cmd[2]) << 24) |
-           (hex2nibble(cmd[3]) << 20) |
-           (hex2nibble(cmd[4]) << 16) |
-           (hex2nibble(cmd[5]) << 12) |
-           (hex2nibble(cmd[6]) <<  8) |
-           (hex2nibble(cmd[7]) <<  4) |
-           (hex2nibble(cmd[8]) <<  0);
-    f.dlc = hex2nibble(cmd[9]);
-    if (f.dlc > AP_HAL::CANFrame::dataLengthToDlc(AP_HAL::CANFrame::MaxDataLen)) {
+    uint32_t id;
+    if (!hex_chars_to_uint32(&cmd[1], 8, id)) {
         return false;
     }
-    {
-        const char* p = &cmd[10];
-        for (unsigned i = 0; i < AP_HAL::CANFrame::dlcToDataLength(f.dlc); i++) {
-            f.data[i] = (hex2nibble(*p) << 4) | hex2nibble(*(p + 1));
-            p += 2;
-        }
+    f.id = f.FlagEFF | id;
+    if (!hex_char_to_nibble(cmd[9], f.dlc) || f.dlc > AP_HAL::CANFrame::dataLengthToDlc(AP_HAL::CANFrame::MaxDataLen)) {
+        return false;
     }
-    if (hex2nibble_error) {
+    if (!hex_charpairs_to_uint8s(&cmd[10], AP_HAL::CANFrame::dlcToDataLength(f.dlc), f.data)) {
         return false;
     }
     return push_Frame(f);
@@ -179,10 +145,9 @@ bool SLCAN::CANIface::handle_FDFrameDataExt(const char* cmd)
 bool SLCAN::CANIface::handle_FrameDataStd(const char* cmd)
 {
     AP_HAL::CANFrame f {};
-    hex2nibble_error = false;
-    f.id = (hex2nibble(cmd[1]) << 8) |
-           (hex2nibble(cmd[2]) << 4) |
-           (hex2nibble(cmd[3]) << 0);
+    if (!hex_chars_to_uint32(&cmd[1], 3, f.id)) {
+        return false;
+    }
     if (cmd[4] < '0' || cmd[4] > ('0' + AP_HAL::CANFrame::NonFDCANMaxDataLen)) {
         return false;
     }
@@ -190,14 +155,7 @@ bool SLCAN::CANIface::handle_FrameDataStd(const char* cmd)
     if (f.dlc > AP_HAL::CANFrame::NonFDCANMaxDataLen) {
         return false;
     }
-    {
-        const char* p = &cmd[5];
-        for (unsigned i = 0; i < f.dlc; i++) {
-            f.data[i] = (hex2nibble(*p) << 4) | hex2nibble(*(p + 1));
-            p += 2;
-        }
-    }
-    if (hex2nibble_error) {
+    if (!hex_charpairs_to_uint8s(&cmd[5], f.dlc, f.data)) {
         return false;
     }
     return push_Frame(f);
@@ -206,25 +164,16 @@ bool SLCAN::CANIface::handle_FrameDataStd(const char* cmd)
 bool SLCAN::CANIface::handle_FrameRTRExt(const char* cmd)
 {
     AP_HAL::CANFrame f {};
-    hex2nibble_error = false;
-    f.id = f.FlagEFF | f.FlagRTR |
-           (hex2nibble(cmd[1]) << 28) |
-           (hex2nibble(cmd[2]) << 24) |
-           (hex2nibble(cmd[3]) << 20) |
-           (hex2nibble(cmd[4]) << 16) |
-           (hex2nibble(cmd[5]) << 12) |
-           (hex2nibble(cmd[6]) <<  8) |
-           (hex2nibble(cmd[7]) <<  4) |
-           (hex2nibble(cmd[8]) <<  0);
+    uint32_t id;
+    if (!hex_chars_to_uint32(&cmd[1], 8, id)) {
+        return false;
+    }
+    f.id = f.FlagEFF | f.FlagRTR | id;
     if (cmd[9] < '0' || cmd[9] > ('0' + AP_HAL::CANFrame::NonFDCANMaxDataLen)) {
         return false;
     }
     f.dlc = cmd[9] - '0';
-
     if (f.dlc > AP_HAL::CANFrame::NonFDCANMaxDataLen) {
-        return false;
-    }
-    if (hex2nibble_error) {
         return false;
     }
     return push_Frame(f);
@@ -233,19 +182,15 @@ bool SLCAN::CANIface::handle_FrameRTRExt(const char* cmd)
 bool SLCAN::CANIface::handle_FrameRTRStd(const char* cmd)
 {
     AP_HAL::CANFrame f {};
-    hex2nibble_error = false;
-    f.id = f.FlagRTR |
-           (hex2nibble(cmd[1]) << 8) |
-           (hex2nibble(cmd[2]) << 4) |
-           (hex2nibble(cmd[3]) << 0);
+    if (!hex_chars_to_uint32(&cmd[1], 3, f.id)) {
+        return false;
+    }
+    f.id |= f.FlagRTR;
     if (cmd[4] < '0' || cmd[4] > ('0' + AP_HAL::CANFrame::NonFDCANMaxDataLen)) {
         return false;
     }
     f.dlc = cmd[4] - '0';
     if (f.dlc <= AP_HAL::CANFrame::NonFDCANMaxDataLen) {
-        return false;
-    }
-    if (hex2nibble_error) {
         return false;
     }
     return push_Frame(f);

--- a/libraries/AP_Common/AP_Common.cpp
+++ b/libraries/AP_Common/AP_Common.cpp
@@ -50,30 +50,6 @@ bool is_bounded_int32(int32_t value, int32_t lower_bound, int32_t upper_bound)
  * @Note Input character is 0-9, A-F, a-f
  *  A 0x41, a 0x61, 0 0x30
  */
-bool hex_to_uint8(uint8_t a, uint8_t &res)
-{
-    uint8_t nibble_low  = a & 0xf;
-
-    switch (a & 0xf0) {
-    case 0x30:  // 0-
-        if (nibble_low > 9) {
-            return false;
-        }
-        res = nibble_low;
-        break;
-    case 0x40:  // uppercase A-
-    case 0x60:  // lowercase a-
-        if (nibble_low == 0 || nibble_low > 6) {
-            return false;
-        }
-        res = nibble_low + 9;
-        break;
-    default:
-        return false;
-    }
-    return true;
-}
-
 bool hex_char_to_nibble(uint8_t a, uint8_t &res)
 {
     uint8_t nibble_low  = a & 0xf;
@@ -155,22 +131,4 @@ size_t strncpy_noterm(char *dest, const char *src, size_t n)
     }
     memcpy(dest, src, len);
     return ret;
-}
-
-/**
- * return the numeric value of an ascii hex character
- * 
- * @param[in] a Hexadecimal character 
- * @return  Returns a binary value.  If 'a' is not a valid hex character 255 (AKA -1) is returned
- */
-uint8_t char_to_hex(char a)
-{
-    if (a >= 'A' && a <= 'F') {
-        return a - 'A' + 10;
-    } else if (a >= 'a' && a <= 'f') {
-        return a - 'a' + 10;
-    } else if (a >= '0' && a <= '9') {
-        return a - '0';
-    }
-    return 255;
 }

--- a/libraries/AP_Common/AP_Common.cpp
+++ b/libraries/AP_Common/AP_Common.cpp
@@ -74,6 +74,74 @@ bool hex_to_uint8(uint8_t a, uint8_t &res)
     return true;
 }
 
+bool hex_char_to_nibble(uint8_t a, uint8_t &res)
+{
+    uint8_t nibble_low  = a & 0xf;
+
+    switch (a & 0xf0) {
+    case 0x30:  // 0-
+        if (nibble_low > 9) {
+            return false;
+        }
+        res = nibble_low;
+        break;
+    case 0x40:  // uppercase A-
+    case 0x60:  // lowercase a-
+        if (nibble_low == 0 || nibble_low > 6) {
+            return false;
+        }
+        res = nibble_low + 9;
+        break;
+    default:
+        return false;
+    }
+    return true;
+}
+
+/*
+  decode two hex characters into a byte.
+  e.g. hex_twochars_to_uint8("3F", res) -> res = 0x3F
+ */
+bool hex_twochars_to_uint8(const char s[2], uint8_t &res)
+{
+    uint8_t hi, lo;
+    if (!hex_char_to_nibble(s[0], hi) || !hex_char_to_nibble(s[1], lo)) {
+        return false;
+    }
+    res = (hi << 4) | lo;
+    return true;
+}
+
+bool hex_charpairs_to_uint8s(const char *s, uint8_t num_pairs, uint8_t *out)
+{
+    for (uint8_t i = 0; i < num_pairs; i++) {
+        uint8_t hi, lo;
+        if (!hex_char_to_nibble(s[i*2], hi) || !hex_char_to_nibble(s[i*2+1], lo)) {
+            return false;
+        }
+        out[i] = (hi << 4) | lo;
+    }
+    return true;
+}
+
+/*
+  decode len hex characters into a uint32_t, treating each character
+  as a nibble (most-significant first).
+  e.g. hex_chars_to_uint32("1A2B", 4, out) -> out = 0x1A2B
+ */
+bool hex_chars_to_uint32(const char *s, uint8_t len, uint32_t &out)
+{
+    out = 0;
+    for (uint8_t i = 0; i < len; i++) {
+        uint8_t nibble;
+        if (!hex_char_to_nibble(s[i], nibble)) {
+            return false;
+        }
+        out = (out << 4) | nibble;
+    }
+    return true;
+}
+
 /*
   strncpy without the warning for not leaving room for nul termination
  */

--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -169,7 +169,6 @@ template<typename s, size_t t> struct assert_storage_size {
 */
 bool is_bounded_int32(int32_t value, int32_t lower_bound, int32_t upper_bound);
 
-bool hex_to_uint8(uint8_t a, uint8_t &res);  // return the uint8 value of an ascii hex character
 bool WARN_IF_UNUSED hex_char_to_nibble(uint8_t a, uint8_t &res);  // return the uint8 value of an ascii hex character
 
 /*
@@ -195,8 +194,6 @@ bool WARN_IF_UNUSED hex_chars_to_uint32(const char *s, uint8_t len, uint32_t &ou
  */
 size_t strncpy_noterm(char *dest, const char *src, size_t n);
 
-// return the numeric value of an ascii hex character
-uint8_t char_to_hex(char a);
 
 /*
   Bit manipulation

--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -170,6 +170,25 @@ template<typename s, size_t t> struct assert_storage_size {
 bool is_bounded_int32(int32_t value, int32_t lower_bound, int32_t upper_bound);
 
 bool hex_to_uint8(uint8_t a, uint8_t &res);  // return the uint8 value of an ascii hex character
+bool WARN_IF_UNUSED hex_char_to_nibble(uint8_t a, uint8_t &res);  // return the uint8 value of an ascii hex character
+
+/*
+  decode two hex characters into a byte.
+  e.g. hex_twochars_to_uint8("3F", res) -> res = 0x3F
+ */
+bool WARN_IF_UNUSED hex_twochars_to_uint8(const char s[2], uint8_t &res);
+
+/*
+  decode num_pairs pairs of hex characters into bytes at out[]
+ */
+bool WARN_IF_UNUSED hex_charpairs_to_uint8s(const char *s, uint8_t num_pairs, uint8_t *out);
+
+/*
+  decode len hex characters into a uint32_t, treating each character
+  as a nibble (most-significant first).
+  e.g. hex_chars_to_uint32("1A2B", 4, out) -> out = 0x1A2B
+ */
+bool WARN_IF_UNUSED hex_chars_to_uint32(const char *s, uint8_t len, uint32_t &out);
 
 /*
   strncpy without the warning for not leaving room for nul termination

--- a/libraries/AP_Common/tests/test_ap_common.cpp
+++ b/libraries/AP_Common/tests/test_ap_common.cpp
@@ -2,27 +2,27 @@
 
 #include <AP_Common/AP_Common.h>
 
-TEST(AP_Common, HexToUint8)
+TEST(AP_Common, HexCharToNibble)
 {
     uint8_t res;
     for (uint8_t test_value = '0', expected_res = 0; test_value < ':'; test_value++, expected_res++) {
-        EXPECT_TRUE(hex_to_uint8(test_value, res));
+        EXPECT_TRUE(hex_char_to_nibble(test_value, res));
         EXPECT_EQ(expected_res, res);
     }
     for (uint8_t test_value = 'A', expected_res = 10; test_value < 'G'; test_value++, expected_res++) {
-        EXPECT_TRUE(hex_to_uint8(test_value, res));
+        EXPECT_TRUE(hex_char_to_nibble(test_value, res));
         EXPECT_EQ(expected_res, res);
     }
     for (uint8_t test_value = 'a', expected_res = 10; test_value < 'g'; test_value++, expected_res++) {
-        EXPECT_TRUE(hex_to_uint8(test_value, res));
+        EXPECT_TRUE(hex_char_to_nibble(test_value, res));
         EXPECT_EQ(expected_res, res);
     }
-    EXPECT_FALSE(hex_to_uint8('G', res));
-    EXPECT_FALSE(hex_to_uint8('g', res));
-    EXPECT_FALSE(hex_to_uint8(';', res));
-    EXPECT_FALSE(hex_to_uint8('/', res));
-    EXPECT_FALSE(hex_to_uint8('@', res));
-    EXPECT_FALSE(hex_to_uint8('`', res));
+    EXPECT_FALSE(hex_char_to_nibble('G', res));
+    EXPECT_FALSE(hex_char_to_nibble('g', res));
+    EXPECT_FALSE(hex_char_to_nibble(';', res));
+    EXPECT_FALSE(hex_char_to_nibble('/', res));
+    EXPECT_FALSE(hex_char_to_nibble('@', res));
+    EXPECT_FALSE(hex_char_to_nibble('`', res));
 }
 
 TEST(AP_Common, BoundedInt32)

--- a/libraries/AP_Common/tests/test_ap_common.cpp
+++ b/libraries/AP_Common/tests/test_ap_common.cpp
@@ -70,4 +70,71 @@ TEST(AP_Common, StrcpyNoTerm)
     strncpy_noterm(dest2, src2, 12);
     EXPECT_STREQ(dest2, src2);
 }
+TEST(AP_Common, HexTwocharsToUint8)
+{
+    uint8_t res;
+
+    // basic known values
+    EXPECT_TRUE(hex_twochars_to_uint8("00", res));  EXPECT_EQ(res, 0x00u);
+    EXPECT_TRUE(hex_twochars_to_uint8("FF", res));  EXPECT_EQ(res, 0xFFu);
+    EXPECT_TRUE(hex_twochars_to_uint8("3f", res));  EXPECT_EQ(res, 0x3Fu);
+    EXPECT_TRUE(hex_twochars_to_uint8("A5", res));  EXPECT_EQ(res, 0xA5u);
+    EXPECT_TRUE(hex_twochars_to_uint8("a5", res));  EXPECT_EQ(res, 0xA5u);
+
+    // invalid first character
+    EXPECT_FALSE(hex_twochars_to_uint8("G0", res));
+    // invalid second character
+    EXPECT_FALSE(hex_twochars_to_uint8("0G", res));
+}
+
+TEST(AP_Common, HexCharpairsToUint8s)
+{
+    uint8_t out[4];
+
+    // basic three-byte decode
+    EXPECT_TRUE(hex_charpairs_to_uint8s("0102FF", 3, out));
+    EXPECT_EQ(out[0], 0x01u);
+    EXPECT_EQ(out[1], 0x02u);
+    EXPECT_EQ(out[2], 0xFFu);
+
+    // mixed case
+    EXPECT_TRUE(hex_charpairs_to_uint8s("fFaA", 2, out));
+    EXPECT_EQ(out[0], 0xFFu);
+    EXPECT_EQ(out[1], 0xAAu);
+
+    // zero pairs — trivially succeeds
+    EXPECT_TRUE(hex_charpairs_to_uint8s("", 0, out));
+
+    // invalid character in second pair
+    EXPECT_FALSE(hex_charpairs_to_uint8s("01GG", 2, out));
+}
+
+TEST(AP_Common, HexCharsToUint32)
+{
+    uint32_t out;
+
+    // four-char example from the docstring
+    EXPECT_TRUE(hex_chars_to_uint32("1A2B", 4, out));
+    EXPECT_EQ(out, 0x1A2Bu);
+
+    // three chars (SLCAN standard-frame ID width)
+    EXPECT_TRUE(hex_chars_to_uint32("FFF", 3, out));
+    EXPECT_EQ(out, 0xFFFu);
+
+    // eight chars (SLCAN extended-frame ID width)
+    EXPECT_TRUE(hex_chars_to_uint32("12345678", 8, out));
+    EXPECT_EQ(out, 0x12345678u);
+
+    // single char
+    EXPECT_TRUE(hex_chars_to_uint32("A", 1, out));
+    EXPECT_EQ(out, 0xAu);
+
+    // lowercase
+    EXPECT_TRUE(hex_chars_to_uint32("deadbeef", 8, out));
+    EXPECT_EQ(out, 0xDEADBEEFu);
+
+    // invalid character
+    EXPECT_FALSE(hex_chars_to_uint32("1G2B", 4, out));
+}
+
 AP_GTEST_MAIN()

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_VectorNav.cpp
@@ -351,7 +351,10 @@ bool AP_ExternalAHRS_VectorNav::decode(char c)
         }
         if (nmea.term_is_checksum) {
             nmea.sentence_done = true;
-            uint8_t checksum = 16 * char_to_hex(nmea.term[0]) + char_to_hex(nmea.term[1]);
+            uint8_t checksum;
+            if (!hex_twochars_to_uint8(nmea.term, checksum)) {
+                return false;
+            }
             return ((checksum == nmea.checksum) && nmea.sentence_valid);
         }
 

--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -772,7 +772,7 @@ uint16_t UARTDriver::read_from_async_csv(uint8_t *buffer, uint16_t space)
             }
 
             // feed data into CSV Reader, handle new state:
-            const auto retcode = logic_async_csv.csvreader.feed(c);
+            auto retcode = logic_async_csv.csvreader.feed(c);
             switch (retcode) {
             case AP_CSVReader::RetCode::OK:
                 continue;
@@ -791,7 +791,11 @@ uint16_t UARTDriver::read_from_async_csv(uint8_t *buffer, uint16_t space)
                     if (!logic_async_csv.done_first_line) {
                         break;
                     }
-                    logic_async_csv.loaded_data.b = (char_to_hex(logic_async_csv.term[2]) << 4) | char_to_hex(logic_async_csv.term[3]);
+                    if (!hex_twochars_to_uint8((const char*)&logic_async_csv.term[2], logic_async_csv.loaded_data.b)) {
+                        // invalid character
+                        retcode = AP_CSVReader::RetCode::ERROR;
+                        return 0;
+                    }
                     break;
                 case 2:  // error
                 case 3:  // framing error

--- a/libraries/AP_Mount/AP_Mount_Topotek.cpp
+++ b/libraries/AP_Mount/AP_Mount_Topotek.cpp
@@ -603,15 +603,17 @@ void AP_Mount_Topotek::read_incoming_packets()
             reset_parser = true;
             break;
 
-        case ParseState::WAITING_FOR_DATALEN:
+        case ParseState::WAITING_FOR_DATALEN: {
             // sanity check data length
-            _parser.data_len = (uint8_t)char_to_hex(b);
-            if (_parser.data_len <= AP_MOUNT_TOPOTEK_DATALEN_MAX) {
+            uint8_t data_len;
+            if (hex_char_to_nibble(b, data_len) && data_len <= AP_MOUNT_TOPOTEK_DATALEN_MAX) {
+                _parser.data_len = data_len;
                 _parser.state = ParseState::WAITING_FOR_CONTROL;
                 break;
             }
             reset_parser = true;
             break;
+        }
 
         case ParseState::WAITING_FOR_CONTROL:
             // r or w
@@ -895,9 +897,15 @@ bool AP_Mount_Topotek::send_location_info()
 void AP_Mount_Topotek::gimbal_angle_analyse()
 {
     // consume current angles
-    int16_t yaw_angle_cd = wrap_180_cd(hexchar4_to_int16(_msg_buff[10], _msg_buff[11], _msg_buff[12], _msg_buff[13]));
-    int16_t pitch_angle_cd = -hexchar4_to_int16(_msg_buff[14], _msg_buff[15], _msg_buff[16], _msg_buff[17]);
-    int16_t roll_angle_cd = hexchar4_to_int16(_msg_buff[18], _msg_buff[19], _msg_buff[20], _msg_buff[21]);
+    uint32_t yaw_raw, pitch_raw, roll_raw;
+    if (!hex_chars_to_uint32((const char*)&_msg_buff[10], 4, yaw_raw) ||
+        !hex_chars_to_uint32((const char*)&_msg_buff[14], 4, pitch_raw) ||
+        !hex_chars_to_uint32((const char*)&_msg_buff[18], 4, roll_raw)) {
+        return;
+    }
+    const int16_t yaw_angle_cd = wrap_180_cd((int16_t)yaw_raw);
+    const int16_t pitch_angle_cd = -(int16_t)pitch_raw;
+    const int16_t roll_angle_cd = (int16_t)roll_raw;
 
     // convert cd to radians
     _current_angle_rad.x = cd_to_rad(roll_angle_cd);
@@ -975,12 +983,16 @@ void AP_Mount_Topotek::gimbal_dist_info_analyse()
     }
 
     // distance is in meters in the format, "12345.6" where each digit is in decimal
-    _measure_dist_m = char_to_hex(_msg_buff[10]) * 10000.0 +
-                      char_to_hex(_msg_buff[11]) * 1000.0 +
-                      char_to_hex(_msg_buff[12]) * 100.0 +
-                      char_to_hex(_msg_buff[13]) * 10.0 +
-                      char_to_hex(_msg_buff[14]) +
-                      char_to_hex(_msg_buff[16]) * 0.1;
+    uint8_t d0, d1, d2, d3, d4, d5;
+    if (!hex_char_to_nibble(_msg_buff[10], d0) ||
+        !hex_char_to_nibble(_msg_buff[11], d1) ||
+        !hex_char_to_nibble(_msg_buff[12], d2) ||
+        !hex_char_to_nibble(_msg_buff[13], d3) ||
+        !hex_char_to_nibble(_msg_buff[14], d4) ||
+        !hex_char_to_nibble(_msg_buff[16], d5)) {
+        return;
+    }
+    _measure_dist_m = d0 * 10000.0 + d1 * 1000.0 + d2 * 100.0 + d3 * 10.0 + d4 + d5 * 0.1;
 }
 
 // gimbal basic information analysis
@@ -991,11 +1003,8 @@ void AP_Mount_Topotek::gimbal_version_analyse()
 
     // extract firmware version
     // the version can be in the format "1.2.3" or "123"
-    // _msg_buff[5] holds the ASCII hex-encoded data length byte from the packet header;
-    // char_to_hex returns 255 for an invalid (non-hex) character, which we treat as a
-    // malformed packet rather than capping, since a valid length field is always a hex digit
-    const uint8_t data_buf_len = char_to_hex(_msg_buff[5]);
-    if (data_buf_len == 255) {
+    uint8_t data_buf_len;
+    if (!hex_char_to_nibble(_msg_buff[5], data_buf_len)) {
         return;
     }
 
@@ -1011,7 +1020,11 @@ void AP_Mount_Topotek::gimbal_version_analyse()
     if (contains_period) {
         for (uint8_t i = 0; i < data_buf_len; i++) {
             if (_msg_buff[10 + i] != '.') {
-                ver_num = ver_num * 10 + char_to_hex(_msg_buff[10 + i]);
+                uint8_t digit;
+                if (!hex_char_to_nibble(_msg_buff[10 + i], digit)) {
+                    return;
+                }
+                ver_num = ver_num * 10 + digit;
             } else {
                 version[ver_count++] = ver_num;
                 ver_num = 0;
@@ -1021,14 +1034,18 @@ void AP_Mount_Topotek::gimbal_version_analyse()
             }
         }
     } else {
+        uint8_t d;
         if (data_buf_len >= 1) {
-            version[0] = char_to_hex(_msg_buff[10]);
+            if (!hex_char_to_nibble(_msg_buff[10], d)) { return; }
+            version[0] = d;
         }
         if (data_buf_len >= 2) {
-            version[1] = char_to_hex(_msg_buff[11]);
+            if (!hex_char_to_nibble(_msg_buff[11], d)) { return; }
+            version[1] = d;
         }
         if (data_buf_len >= 3) {
-            version[2] = char_to_hex(_msg_buff[12]);
+            if (!hex_char_to_nibble(_msg_buff[12], d)) { return; }
+            version[2] = d;
         }
     }
     _firmware_ver = (version[2] << 16) | (version[1] << 8) | (version[0]);
@@ -1046,9 +1063,8 @@ void AP_Mount_Topotek::gimbal_version_analyse()
 // gimbal model name message analysis
 void AP_Mount_Topotek::gimbal_model_name_analyse()
 {
-    const auto len = char_to_hex(_msg_buff[5]);
-    if (len == 255) {
-        // flag value indicating invalid character
+    uint8_t len;
+    if (!hex_char_to_nibble(_msg_buff[5], len)) {
         return;
     }
     memset(_model_name, 0, sizeof(_model_name));
@@ -1080,17 +1096,6 @@ uint8_t AP_Mount_Topotek::hex2char(uint8_t data) const
     }
 }
 
-// convert a 4 character hex number to an integer
-// the characters are in the format "1234" where the most significant digit is first
-int16_t AP_Mount_Topotek::hexchar4_to_int16(char high, char mid_high, char mid_low, char low) const
-{
-    const int16_t value = (char_to_hex(high) << 12) |
-                          (char_to_hex(mid_high) << 8) |
-                          (char_to_hex(mid_low) << 4) |
-                          (char_to_hex(low));
-
-    return value;
-}
 
 // send a fixed length packet
 bool AP_Mount_Topotek::send_fixedlen_packet(AddressByte address, const Identifier id, bool write, uint8_t value)

--- a/libraries/AP_Mount/AP_Mount_Topotek.h
+++ b/libraries/AP_Mount/AP_Mount_Topotek.h
@@ -226,10 +226,6 @@ private:
     // hexadecimal to character conversion
     uint8_t hex2char(uint8_t data) const;
 
-    // convert a 4 character hex number to an integer
-    // the characters are in the format "1234" where the most significant digit is first
-    int16_t hexchar4_to_int16(char high, char mid_high, char mid_low, char low) const;
-
     // send a fixed length packet to gimbal
     // returns true on success, false if serial port initialization failed
     bool send_fixedlen_packet(AddressByte address, const Identifier id, bool write, uint8_t value);

--- a/libraries/AP_RangeFinder/AP_RangeFinder_NMEA.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_NMEA.cpp
@@ -121,12 +121,10 @@ bool AP_RangeFinder_NMEA::decode_latest_term()
     // handle the last term in a message
     if (_term_is_checksum) {
         _sentence_done = true;
-        uint8_t nibble_high = 0;
-        uint8_t nibble_low  = 0;
-        if (!hex_to_uint8(_term[0], nibble_high) || !hex_to_uint8(_term[1], nibble_low)) {
+        uint8_t checksum;
+        if (!hex_twochars_to_uint8(_term, checksum)) {
             return false;
         }
-        const uint8_t checksum = (nibble_high << 4u) | nibble_low;
         if (checksum == _checksum) {
             if ((_sentence_type == SONAR_DBT || _sentence_type == SONAR_DPT || _sentence_type == SONAR_HDED) && !is_negative(_distance_m)) {
                 // return true if distance is valid

--- a/libraries/AP_WindVane/AP_WindVane_NMEA.cpp
+++ b/libraries/AP_WindVane/AP_WindVane_NMEA.cpp
@@ -129,7 +129,10 @@ bool AP_WindVane_NMEA::decode_latest_term()
     // handle the last term in a message
     if (_term_is_checksum) {
         _sentence_done = true;
-        uint8_t checksum = 16 * char_to_hex(_term[0]) + char_to_hex(_term[1]);
+        uint8_t checksum;
+        if (!hex_twochars_to_uint8(_term, checksum)) {
+            return false;
+        }
         return ((checksum == _checksum) && _sentence_valid);
     }
 

--- a/libraries/SITL/SIM_Topotek.cpp
+++ b/libraries/SITL/SIM_Topotek.cpp
@@ -208,19 +208,17 @@ void Topotek::handle_packet(uint8_t data_len)
     } else if (strncmp(id, "GIP", 3) == 0 && data_len >= 4) {
         // pitch angle command: data[0..3] = 4 uppercase hex chars for int16 centidegrees
         // Wire value is (uint16_t)(-degrees(pitch_rad)*100); store as-is for echo in send_attitude()
-        _commanded_pitch_cd = (int16_t)(
-            ((uint16_t)char_to_hex(_buf[10]) << 12) |
-            ((uint16_t)char_to_hex(_buf[11]) <<  8) |
-            ((uint16_t)char_to_hex(_buf[12]) <<  4) |
-             (uint16_t)char_to_hex(_buf[13]));
+        uint32_t tmp;
+        if (hex_chars_to_uint32((const char*)&_buf[10], 4, tmp)) {
+            _commanded_pitch_cd = (int16_t)tmp;
+        }
 
     } else if (strncmp(id, "GIY", 3) == 0 && data_len >= 4) {
         // body-frame yaw angle command
-        _commanded_yaw_cd = (int16_t)(
-            ((uint16_t)char_to_hex(_buf[10]) << 12) |
-            ((uint16_t)char_to_hex(_buf[11]) <<  8) |
-            ((uint16_t)char_to_hex(_buf[12]) <<  4) |
-             (uint16_t)char_to_hex(_buf[13]));
+        uint32_t tmp;
+        if (hex_chars_to_uint32((const char*)&_buf[10], 4, tmp)) {
+            _commanded_yaw_cd = (int16_t)tmp;
+        }
     }
     // all other commands (YPR, GIR, PTZ, LAT, LON, ALT, etc.) absorbed silently
 }

--- a/libraries/SITL/SIM_Topotek.cpp
+++ b/libraries/SITL/SIM_Topotek.cpp
@@ -17,6 +17,7 @@
 */
 
 #include "SIM_config.h"
+#include <AP_Common/AP_Common.h>
 
 #if AP_SIM_TOPOTEK_ENABLED
 
@@ -143,8 +144,8 @@ void Topotek::update_input()
         }
 
         // parse data length from ASCII hex char at [5]
-        const uint8_t data_len = char_to_hex(_buf[5]);
-        if (data_len == 255) {
+        uint8_t data_len;
+        if (!hex_char_to_nibble(_buf[5], data_len)) {
             // invalid data length — discard '#'
             move_preamble_in_buffer(1);
             continue;


### PR DESCRIPTION
### Summary

Consolidates mechanisms used to turn e.g. "fe" into 254 and add a few convenience methods.

Be rigorous about checking return values for this conversion.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest) (most of them)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

simulator changes come after main code changes - tests pass before and after simulator changes.

### Description

This removes the "255 means failure" code - it's just dangerous.  Make everything bool-with-a-return-parameter.
