### PR TITLE
AP_Arming: arm_check: always check for estop

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1777,6 +1777,13 @@ bool AP_Arming::arm_checks(AP_Arming::Method method)
     }
 #endif
 
+    // Run estop check again, here in the arm checks there is no need
+    // bypass the check if arm emergency stop aux function is setup
+    if (SRV_Channels::get_emergency_stop()) {
+        check_failed(true, "Motors Emergency Stopped");
+        return false;
+    }
+
     // ensure the GPS drivers are ready on any final changes
     if (check_enabled(Check::GPS_CONFIG)) {
         if (!AP::gps().prepare_for_arming()) {


### PR DESCRIPTION
If someone setups the arm - emergency stop aux function and you arm another way its very easy to get confused as to why the motors don't work. 

In the pre-arm checks we don't check for estop if the arm-estop function is assigned because it would always fail.

https://github.com/ArduPilot/ardupilot/blob/ecb7568eed8b9637b29dd7be10ab0364ec9fe6ce/libraries/AP_Arming/AP_Arming.cpp#L1661-L1669

In the arm check itself that aux function will no longer be in the e-stop position if it has been used to trigger the arming attempt. If your trying to arm some other way you will see the message.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested in SITL that the arm - emergency stop aux function still works as expected but now we get the arm check if arming using another method.