### PR TITLE
Tools: install_prereqs_ubuntu.sh: enumerate all supported RELEASE_CODENAMEs

### DIFF
--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -97,16 +97,35 @@ esac
 PYTHON_V="python3"  # starting from ubuntu 20.04, python isn't symlink to default Python interpreter
 PIP=pip3
 
-if [ ${RELEASE_CODENAME} == 'bionic' ] ||
-      [ ${RELEASE_CODENAME} == 'buster' ] ||
-      [ ${RELEASE_CODENAME} == 'focal' ] ||
-      [ ${RELEASE_CODENAME} == 'groovy' ] ||
-      [ ${RELEASE_CODENAME} == 'lunar' ] ||
-      [ ${RELEASE_CODENAME} == 'mantic' ] ||
-      [ ${RELEASE_CODENAME} == 'oracular' ]; then
-    echo "ArduPilot no longer supports developing on this operating system that has reached end of standard support."
-    exit 1
-elif [ ${RELEASE_CODENAME} == 'trixie' ]; then
+case "${RELEASE_CODENAME}" in
+    bionic)   ;&
+    buster)   ;&
+    focal)    ;&
+    groovy)   ;&
+    lunar)    ;&
+    mantic)   ;&
+    oracular)
+        echo "ArduPilot no longer supports developing on this operating system that has reached end of standard support."
+        exit 1
+        ;;
+
+    bookworm) ;&
+    trixie)   ;&
+    bullseye) ;&
+    jammy)    ;&
+    noble)    ;&
+    plucky)   ;&
+    questing)
+        echo "${RELEASE_CODENAME} is supported"
+        ;;
+
+    *)
+        echo "This install script does not handle installation for ${RELEASE_CODENAME}"
+        exit 1
+        ;;
+esac
+
+if [ ${RELEASE_CODENAME} == 'trixie' ]; then
     SITLFML_VERSION="2.6"
     SITLCFML_VERSION="2.6"
     PYTHON_V="python3"


### PR DESCRIPTION
### Summary

forces any supported OS to be listed in install_prereqs_ubuntu.sh before we will attempt to install on it

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

this change will mean that you can't run on some derivative we do not actually understand exists.

We almost certainly would not have run on such a platform.

This will allow us to retire code from this file which is completely stale.

