### PR TITLE
AP_NavEKF3: remove unused usingVertVel

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -480,12 +480,6 @@ public:
     // returns true when the state estimates are significantly degraded by vibration
     bool isVibrationAffected() const { return badIMUdata; }
 
-    // return true if we are using vertical velocity measurements (GPS or external nav)
-    // This indicates the VD estimate is reliable enough for bias learning
-    bool usingVertVel(void) const {
-        return useGpsVertVel || useExtNavVel;
-    }
-
     // get a yaw estimator instance
     const EKFGSF_yaw *get_yawEstimator(void) const { return yawEstimator; }
 


### PR DESCRIPTION
### Summary

This removes an unused method from AP_NavEKF3 that was added in PR https://github.com/ArduPilot/ardupilot/pull/32396

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

This method appears to be unused and removing it doesn't cause a compiler error so I think this is a safe change.

This has no effect on the binary size for Durandal so the compiler was getting rid of the method anyway it seems

```
Binary Name      Text [B]     Data [B]     BSS (B)      Total Flash Change [B] (%)      Flash Free After PR (B)
---------------  -----------  -----------  -----------  ----------------------------  -------------------------
blimp            0 (0.0000%)  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                      780972
arducopter       0 (0.0000%)  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                      374244
ardusub          0 (0.0000%)  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                      530548
arducopter-heli  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                      378636
arduplane        0 (0.0000%)  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                      378304
ardurover        0 (0.0000%)  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                      512996
antennatracker   0 (0.0000%)  0 (0.0000%)  0 (0.0000%)  0 (0.0000%)                                      800056
```


