### PR TITLE
Allow mission jump counters to be reset without changing waypoint

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -4784,13 +4784,19 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         num_wp = self.get_mission_count()
         accepted_indices = [0, 1, num_wp-1]
-        failed_indices = [-1, num_wp]
+        failed_indices = [num_wp]
 
         for seq in accepted_indices:
             self.run_cmd(mavutil.mavlink.MAV_CMD_DO_SET_MISSION_CURRENT,
                          p1=seq,
                          timeout=1,
                          want_result=mavutil.mavlink.MAV_RESULT_ACCEPTED)
+
+        # param1=-1 means "don't change current item" (reset-only); accepted
+        self.run_cmd(mavutil.mavlink.MAV_CMD_DO_SET_MISSION_CURRENT,
+                     p1=-1,
+                     timeout=1,
+                     want_result=mavutil.mavlink.MAV_RESULT_ACCEPTED)
 
         for seq in failed_indices:
             self.run_cmd(mavutil.mavlink.MAV_CMD_DO_SET_MISSION_CURRENT,

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -4804,6 +4804,11 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                          timeout=1,
                          want_result=mavutil.mavlink.MAV_RESULT_FAILED)
 
+        self.run_cmd(mavutil.mavlink.MAV_CMD_DO_SET_MISSION_CURRENT,
+                     p1=-2,
+                     timeout=1,
+                     want_result=mavutil.mavlink.MAV_RESULT_DENIED)
+
     def InvalidJumpTags(self):
         '''Verify the behaviour when selecting invalid jump tags.'''
 

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -5959,6 +5959,56 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 mavutil.mavlink.MAV_MISSION_TYPE_MISSION),
         ])
 
+    def MAV_CMD_DO_SET_MISSION_CURRENT_looped_mission(self):
+        '''Test param1=-1 with reset=1 resets DO_JUMP counter without changing current waypoint'''
+        # home(0), WP1(1,30m N), WP2(2,60m N), WP3(3,90m N), DO_JUMP(4,to=2,repeat=1)
+        # The jump goes back to WP2 (not WP1), making it clear that
+        # param1=-1 resets the counter rather than setting the current waypoint.
+        self.start_driving_simple_relhome_mission([
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 30, 0, 0),
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 60, 0, 0),
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 90, 0, 0),
+            self.create_MISSION_ITEM_INT(
+                mavutil.mavlink.MAV_CMD_DO_JUMP,
+                p1=2,  # jump to item 2 (WP2)
+                p2=1,  # repeat once
+            ),
+        ])
+
+        # Wait for WP3 to be reached the first time; at this point the
+        # DO_JUMP has fired and current_waypoint is back at 2 (WP2).
+        while True:
+            m = self.assert_receive_message('MISSION_ITEM_REACHED', timeout=120)
+            if m.seq == 3:
+                break
+
+        # Reset jump counters without changing the current waypoint.
+        # Current is 2 because the DO_JUMP just looped us back to WP2,
+        # not because we are setting it via this command.
+        self.wait_current_waypoint(2, timeout=10)
+        self.run_cmd(
+            mavutil.mavlink.MAV_CMD_DO_SET_MISSION_CURRENT,
+            p1=-1,
+            p2=1,
+            timeout=1,
+        )
+        self.assert_current_waypoint(2)
+
+        # With the counter reset, DO_JUMP fires again when WP3 is next
+        # reached.  Without the reset the mission would complete after
+        # WP3 without returning to WP2.  Wait for WP2 then WP3 to
+        # confirm the extra loop occurred.
+        while True:
+            m = self.assert_receive_message('MISSION_ITEM_REACHED', timeout=120)
+            if m.seq == 2:
+                break
+        while True:
+            m = self.assert_receive_message('MISSION_ITEM_REACHED', timeout=120)
+            if m.seq == 3:
+                break
+
+        self.disarm_vehicle(force=True)
+
     def MAV_CMD_DO_SET_MISSION_CURRENT(self, target_sysid=None, target_compid=1):
         '''Test handling of CMD_DO_SET_MISSION_CURRENT'''
         if target_sysid is None:
@@ -7476,6 +7526,7 @@ return update()
             self.SET_ATTITUDE_TARGET_heading,
             self.SET_POSITION_TARGET_LOCAL_NED,
             self.MAV_CMD_DO_SET_MISSION_CURRENT,
+            self.MAV_CMD_DO_SET_MISSION_CURRENT_looped_mission,
             self.MAV_CMD_DO_CHANGE_SPEED,
             self.MAV_CMD_MISSION_START,
             self.MAV_CMD_NAV_SET_YAW_SPEED,

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -539,6 +539,9 @@ public:
     /// reset - reset mission to the first command
     void reset();
 
+    /// reset_jump_counters - reset DO_JUMP counters to their initial values without affecting current position
+    void reset_jump_counters() { init_jump_tracking(); }
+
     /// clear - clears out mission
     bool clear();
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -5025,6 +5025,15 @@ MAV_RESULT GCS_MAVLINK::handle_command_do_set_mission_current(const mavlink_comm
         return MAV_RESULT_UNSUPPORTED;
     }
 
+    if (is_equal(packet.param1, -1.0f) || packet.param1 >= 0) {
+        // these are the only values we handle - either -1 meaning do
+        // not reset waypoint (but reset counters) or a non-negative
+        // waypoint number
+    } else {
+        // invalid param1
+        return MAV_RESULT_DENIED;
+    }
+
     if (packet.param1 >= 0) {
         const uint32_t seq = (uint32_t)packet.param1;
         if (seq > INT16_MAX || !mission->is_valid_index(seq)) {

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -5038,7 +5038,8 @@ MAV_RESULT GCS_MAVLINK::handle_command_do_set_mission_current(const mavlink_comm
     //       and changes mission state "completed" to be "active" or "paused".
     const bool reset_and_restart = is_equal(packet.param2, 1.0f);
     if (reset_and_restart) {
-        mission->reset();
+        // reset jump counters only
+        mission->reset_jump_counters();
     }
     if (packet.param1 >= 0) {
         const uint32_t seq = (uint32_t)packet.param1;
@@ -5046,7 +5047,7 @@ MAV_RESULT GCS_MAVLINK::handle_command_do_set_mission_current(const mavlink_comm
             return MAV_RESULT_FAILED;
         }
     }
-    if (reset_and_restart) {
+    if (reset_and_restart && packet.param1 >= 0) {
         mission->resume();
     }
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -5025,9 +5025,11 @@ MAV_RESULT GCS_MAVLINK::handle_command_do_set_mission_current(const mavlink_comm
         return MAV_RESULT_UNSUPPORTED;
     }
 
-    const uint32_t seq = (uint32_t)packet.param1;
-    if (!mission->is_valid_index(seq)) {
-        return MAV_RESULT_FAILED;
+    if (packet.param1 >= 0) {
+        const uint32_t seq = (uint32_t)packet.param1;
+        if (seq > INT16_MAX || !mission->is_valid_index(seq)) {
+            return MAV_RESULT_FAILED;
+        }
     }
 
     // From https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_MISSION_CURRENT:
@@ -5038,8 +5040,11 @@ MAV_RESULT GCS_MAVLINK::handle_command_do_set_mission_current(const mavlink_comm
     if (reset_and_restart) {
         mission->reset();
     }
-    if (!mission->set_current_cmd(seq)) {
-        return MAV_RESULT_FAILED;
+    if (packet.param1 >= 0) {
+        const uint32_t seq = (uint32_t)packet.param1;
+        if (!mission->set_current_cmd(seq)) {
+            return MAV_RESULT_FAILED;
+        }
     }
     if (reset_and_restart) {
         mission->resume();


### PR DESCRIPTION
### Summary

Allows resetting the jump counters without resetting the current waypoint.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Previously it wasn't possible to reset the jump counters without also setting the waypoint, meaning you're stuck with a race condition.

This understands new meanings given in the mavlink message where "-1" for your waypoint number means "ignore".

ArduPilot MAVLink PR is here: https://github.com/ArduPilot/mavlink/pull/498
