### PR TITLE
AP_RangeFinder: add NOAVG param to LightWareSerial driver

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
@@ -32,7 +32,8 @@ bool AP_RangeFinder_LightWareSerial::get_reading(float &reading_m)
         return false;
     }
 
-    float sum = 0;              // sum of all readings taken
+    const bool no_avg = params.no_average;
+    float sum = 0;              // sum of all readings taken (or last valid reading when no_avg is set)
     uint16_t valid_count = 0;   // number of valid readings
     uint16_t invalid_count = 0; // number of invalid readings
 
@@ -51,7 +52,7 @@ bool AP_RangeFinder_LightWareSerial::get_reading(float &reading_m)
                 linebuf[linebuf_len] = 0;
                 const float dist = strtof(linebuf, nullptr);
                 if (!is_negative(dist) && !is_lost_signal_distance(dist * 100, distance_cm_max)) {
-                    sum += dist;
+                    sum = no_avg ? dist : sum + dist;
                     valid_count++;
                     // if still determining protocol update legacy valid count
                     if (protocol_state == ProtocolState::UNKNOWN) {
@@ -82,7 +83,7 @@ bool AP_RangeFinder_LightWareSerial::get_reading(float &reading_m)
                 if (high_byte_received) {
                     const int16_t dist = (high_byte & 0x7f) << 7 | (c & 0x7f);
                     if (dist >= 0 && !is_lost_signal_distance(dist, distance_cm_max)) {
-                        sum += dist * 0.01f;
+                        sum = no_avg ? dist * 0.01f : sum + dist * 0.01f;
                         valid_count++;
                         // if still determining protocol update binary valid count
                         if (protocol_state == ProtocolState::UNKNOWN) {
@@ -119,9 +120,9 @@ bool AP_RangeFinder_LightWareSerial::get_reading(float &reading_m)
         uart->write('d');
     }
 
-    // return average of all valid readings
+    // return average of all valid readings, or the last valid reading if NOAVG is set
     if (valid_count > 0) {
-        reading_m = sum / valid_count;
+        reading_m = no_avg ? sum : sum / valid_count;
         no_signal = false;
         return true;
     }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
@@ -187,6 +187,13 @@ const AP_Param::GroupInfo AP_RangeFinder_Params::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("ORIENT", 53, AP_RangeFinder_Params, orientation, AP_RANGEFINDER_DEFAULT_ORIENTATION),
 
+    // @Param: NOAVG
+    // @DisplayName: Disable averaging
+    // @Description: When enabled, LightWareSerial rangefinders return the last valid reading from the buffer instead of the average of all valid readings. Only applies to the LightWareSerial driver.
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+    AP_GROUPINFO("NOAVG", 54, AP_RangeFinder_Params, no_average, 0),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.h
@@ -31,6 +31,7 @@ public:
     AP_Float ground_clearance;
     AP_Int8  address;
     AP_Int8  orientation;
+    AP_Int8  no_average;
 };
 
 #endif  // AP_RANGEFINDER_ENABLED


### PR DESCRIPTION
### Summary

  Add a per-instance `RNGFND*_NOAVG` parameter (default 0) to opt out of
  averaging in the LightWareSerial rangefinder driver.

  ### Classification & Testing (check all that apply and add your own)

  - [x] Checked by a human programmer
  - [ ] Non-functional change
  - [ ] No-binary change
  - [ ] Infrastructure change (e.g. unit tests, helper scripts)
  - [ ] Automated test(s) verify changes (e.g. unit test, autotest)
  - [x] Tested manually, description below (e.g. SITL)
  - [x] Tested on hardware
  - [ ] Logs attached
  - [x] Logs available on request

  ### Description

  `AP_RangeFinder_LightWareSerial::get_reading()` reads every byte
  available on the UART in a single call and, until now, returned the
  average of all valid distances it decoded. For applications that want
  to filter the rangefinder signal themselves, that in-driver averaging
  adds noise that is hard to undo downstream. The function's own
  docstring ("return last value measured by sensor") suggests the
  averaging was drift from the original intent.

  This PR adds a per-instance `RNGFND*_NOAVG` parameter (`AP_Int8`,
  default `0`). Behavior:

  - `NOAVG = 0` (default): unchanged — `get_reading()` returns
    `sum / valid_count` across all valid readings decoded during the
    call.
  - `NOAVG = 1`: `get_reading()` returns the **last** valid reading
    decoded during the call, discarding earlier ones.

  The gate is implemented by rewriting the in-loop accumulator as
  `sum = no_avg ? dist : sum + dist` (and the cm→m variant for the
  binary protocol), then returning `no_avg ? sum : sum / valid_count`.
  When `NOAVG = 0`, the emitted code path is byte-identical to master.

  Scope is intentionally narrow:

  - Only `AP_RangeFinder_LightWareSerial` is touched; other drivers are
    unaffected.
  - No new log messages, no new getters on `RangeFinder`, no autotest
    changes.

  **Testing**: 
<img width="1132" height="570" alt="image" src="https://github.com/user-attachments/assets/0fcf6a8b-6ad0-4444-9e9c-6818482c6ddf" />

Tested on SF11C. These ghost points are not helping performance.