### PR TITLE
Copter: use an enumeration for GCS FS action

### DIFF
--- a/ArduCopter/AP_Arming_Copter.cpp
+++ b/ArduCopter/AP_Arming_Copter.cpp
@@ -213,7 +213,7 @@ bool AP_Arming_Copter::parameter_checks(bool display_failure)
                 return false;
             }
         }
-        if (copter.g.failsafe_gcs == FS_GCS_ENABLED_CONTINUE_MISSION) {
+        if (copter.g.failsafe_gcs == Copter::FS_GCS_Action::CONTINUE_MISSION) {
             // FS_GCS_ENABLE == 2 has been removed
             check_failed(Check::PARAMETERS, display_failure, "FS_GCS_ENABLE=2 removed, see FS_OPTIONS");
         }

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -419,6 +419,8 @@ private:
         return failsafe.radio || battery.has_failsafed() || failsafe.gcs || failsafe.ekf || failsafe.terrain || failsafe.adsb || failsafe.deadreckon;
     }
 
+    using FS_GCS_Action = Parameters::FS_GCS_Action;
+
     // dead reckoning state
     struct {
         bool active;        // true if dead reckoning (position estimate using estimated airspeed, no position or velocity source)

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -98,7 +98,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Description: Controls whether failsafe will be invoked (and what action to take) when connection with Ground station is lost for at least 5 seconds. See FS_OPTIONS param for additional actions, or for cases allowing Mission continuation, when GCS failsafe is enabled.
     // @Values: 0:Disabled/NoAction,1:RTL,2:RTL or Continue with Mission in Auto Mode (Removed in 4.0+-see FS_OPTIONS),3:SmartRTL or RTL,4:SmartRTL or Land,5:Land,6:Auto DO_LAND_START/DO_RETURN_PATH_START or RTL,7:Brake or Land
     // @User: Standard
-    GSCALAR(failsafe_gcs, "FS_GCS_ENABLE", FS_GCS_DISABLED),
+    GSCALAR(failsafe_gcs, "FS_GCS_ENABLE", static_cast<float>(FS_GCS_Action::DISABLED)),
 
     // @Param: GPS_HDOP_GOOD
     // @DisplayName: GPS Hdop Good

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -402,7 +402,19 @@ public:
     AP_Enum<ModeRTL::RTLAltType> rtl_alt_type;
 #endif
 
-    AP_Int8         failsafe_gcs;               // ground station failsafe behavior
+    // GCS failsafe definitions (FS_GCS_ENABLE parameter)
+    enum class FS_GCS_Action {
+        DISABLED                 = 0,
+        ALWAYS_RTL               = 1,
+        CONTINUE_MISSION         = 2,    // Removed in 4.0+, now use fs_options
+        ALWAYS_SMARTRTL_OR_RTL   = 3,
+        ALWAYS_SMARTRTL_OR_LAND  = 4,
+        ALWAYS_LAND              = 5,
+        AUTO_RTL_OR_RTL          = 6,
+        BRAKE_OR_LAND            = 7,
+    };
+
+    AP_Enum<FS_GCS_Action> failsafe_gcs;        // ground station failsafe behavior
     AP_Int16        gps_hdop_good;              // GPS Hdop value at or below this value represent a good position
 
     AP_Int8         super_simple;

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -124,16 +124,6 @@ enum LoggingParameters {
 #define FS_THR_ENABLED_AUTO_RTL_OR_RTL             6
 #define FS_THR_ENABLED_BRAKE_OR_LAND               7
 
-// GCS failsafe definitions (FS_GCS_ENABLE parameter)
-#define FS_GCS_DISABLED                        0
-#define FS_GCS_ENABLED_ALWAYS_RTL              1
-#define FS_GCS_ENABLED_CONTINUE_MISSION        2    // Removed in 4.0+, now use fs_options
-#define FS_GCS_ENABLED_ALWAYS_SMARTRTL_OR_RTL  3
-#define FS_GCS_ENABLED_ALWAYS_SMARTRTL_OR_LAND 4
-#define FS_GCS_ENABLED_ALWAYS_LAND             5
-#define FS_GCS_ENABLED_AUTO_RTL_OR_RTL         6
-#define FS_GCS_ENABLED_BRAKE_OR_LAND           7
-
 // EKF failsafe definitions (FS_EKF_ACTION parameter)
 #define FS_EKF_ACTION_REPORT_ONLY           0
 #define FS_EKF_ACTION_LAND                  1       // switch to LAND mode on EKF failsafe

--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -126,7 +126,7 @@ void Copter::handle_battery_failsafe(const char *type_str, const int8_t action)
 void Copter::failsafe_gcs_check()
 {
     // Bypass GCS failsafe checks if disabled or GCS never connected
-    if (g.failsafe_gcs == FS_GCS_DISABLED) {
+    if (g.failsafe_gcs == FS_GCS_Action::DISABLED) {
         return;
     }
 
@@ -167,27 +167,27 @@ void Copter::failsafe_gcs_on_event(void)
 
     // convert the desired failsafe response to the FailsafeAction enum
     FailsafeAction desired_action;
-    switch (g.failsafe_gcs) {
-        case FS_GCS_DISABLED:
+    switch ((FS_GCS_Action)g.failsafe_gcs) {
+        case FS_GCS_Action::DISABLED:
             desired_action = FailsafeAction::NONE;
             break;
-        case FS_GCS_ENABLED_ALWAYS_RTL:
-        case FS_GCS_ENABLED_CONTINUE_MISSION:
+        case FS_GCS_Action::ALWAYS_RTL:
+        case FS_GCS_Action::CONTINUE_MISSION:
             desired_action = FailsafeAction::RTL;
             break;
-        case FS_GCS_ENABLED_ALWAYS_SMARTRTL_OR_RTL:
+        case FS_GCS_Action::ALWAYS_SMARTRTL_OR_RTL:
             desired_action = FailsafeAction::SMARTRTL;
             break;
-        case FS_GCS_ENABLED_ALWAYS_SMARTRTL_OR_LAND:
+        case FS_GCS_Action::ALWAYS_SMARTRTL_OR_LAND:
             desired_action = FailsafeAction::SMARTRTL_LAND;
             break;
-        case FS_GCS_ENABLED_ALWAYS_LAND:
+        case FS_GCS_Action::ALWAYS_LAND:
             desired_action = FailsafeAction::LAND;
             break;
-        case FS_GCS_ENABLED_AUTO_RTL_OR_RTL:
+        case FS_GCS_Action::AUTO_RTL_OR_RTL:
             desired_action = FailsafeAction::AUTO_DO_LAND_START;
             break;
-        case FS_GCS_ENABLED_BRAKE_OR_LAND:
+        case FS_GCS_Action::BRAKE_OR_LAND:
             desired_action = FailsafeAction::BRAKE_LAND;
             break;
         default: // if an invalid parameter value is set, the fallback is RTL

--- a/ArduCopter/mode_turtle.cpp
+++ b/ArduCopter/mode_turtle.cpp
@@ -56,7 +56,7 @@ void ModeTurtle::arm_motors()
 
     // disable throttle and gcs failsafe
     g.failsafe_throttle.set(FS_THR_DISABLED);
-    g.failsafe_gcs.set(FS_GCS_DISABLED);
+    g.failsafe_gcs.set(Copter::FS_GCS_Action::DISABLED);
     g.fs_ekf_action.set(FS_EKF_ACTION_REPORT_ONLY);
 
     // ensure the arming library is aware of our meddling

--- a/ArduCopter/motor_test.cpp
+++ b/ArduCopter/motor_test.cpp
@@ -171,7 +171,7 @@ MAV_RESULT Copter::mavlink_motor_test_start(const GCS_MAVLINK &gcs_chan, uint8_t
 
             // disable throttle and gps failsafe
             g.failsafe_throttle.set(FS_THR_DISABLED);
-            g.failsafe_gcs.set(FS_GCS_DISABLED);
+            g.failsafe_gcs.set(FS_GCS_Action::DISABLED);
             g.fs_ekf_action.set(FS_EKF_ACTION_REPORT_ONLY);
 
             // turn on notify leds


### PR DESCRIPTION
### Summary

Replaces a bunch of defines with an enumeration for the GCS failsafe action

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board,copter
CubeOrangePlus,*
```

### Description

Uses an enumeration rather than defines for one of Copter's failsafe enumerations.

These form a pattern in our code we'd prefer not to have.  Inspired by https://github.com/ArduPilot/ardupilot/pull/32099/changes which introduces more of the old pattern.
