### PR TITLE
Convert QURT HAL to using hwdef system

### DIFF
--- a/.github/workflows/qurt_build.yml
+++ b/.github/workflows/qurt_build.yml
@@ -151,14 +151,15 @@ jobs:
 
       - name: Build QURT
         run: |
-          ./waf configure --board QURT
+          set -ex
+          ./waf configure --board ModalAI-VOXL2
           ./waf copter
           ./waf plane
           ./waf rover
-          cp -a build/QURT/bin/arducopter build/QURT/ArduPilot.so
-          cp -a build/QURT/bin/arducopter build/QURT/ArduPilot_Copter.so
-          cp -a build/QURT/bin/arduplane build/QURT/ArduPilot_Plane.so
-          cp -a build/QURT/bin/ardurover build/QURT/ArduPilot_Rover.so
+          cp -a build/ModalAI-VOXL2/bin/arducopter build/ModalAI-VOXL2/ArduPilot.so
+          cp -a build/ModalAI-VOXL2/bin/arducopter build/ModalAI-VOXL2/ArduPilot_Copter.so
+          cp -a build/ModalAI-VOXL2/bin/arduplane build/ModalAI-VOXL2/ArduPilot_Plane.so
+          cp -a build/ModalAI-VOXL2/bin/ardurover build/ModalAI-VOXL2/ArduPilot_Rover.so
           libraries/AP_HAL_QURT/packaging/make_package.sh ArduCopter arducopter
           libraries/AP_HAL_QURT/packaging/make_package.sh ArduPlane arduplane
           libraries/AP_HAL_QURT/packaging/make_package.sh Rover ardurover
@@ -168,10 +169,10 @@ jobs:
         with:
           name: qurt-binaries
           path: |
-            build/QURT/ardupilot
-            build/QURT/ArduPilot_Copter.so
-            build/QURT/ArduPilot_Plane.so
-            build/QURT/ArduPilot_Rover.so
-            build/QURT/ArduPilot.so
+            build/ModalAI-VOXL2/ardupilot
+            build/ModalAI-VOXL2/ArduPilot_Copter.so
+            build/ModalAI-VOXL2/ArduPilot_Plane.so
+            build/ModalAI-VOXL2/ArduPilot_Rover.so
+            build/ModalAI-VOXL2/ArduPilot.so
             libraries/AP_HAL_QURT/packaging/*.deb
           retention-days: 7

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -665,6 +665,10 @@ def add_dynamic_boards_linux():
     '''add boards based on existence of hwdef.dat in subdirectories for '''
     add_dynamic_boards_from_hwdef_dir(LinuxBoard, 'libraries/AP_HAL_Linux/hwdef')
 
+def add_dynamic_boards_qurt():
+    '''add boards based on existence of hwdef.dat in subdirectories for '''
+    add_dynamic_boards_from_hwdef_dir(QURTBoard, 'libraries/AP_HAL_QURT/hwdef')
+
 def add_dynamic_boards_sitl():
     '''add boards based on existence of hwdef.dat in subdirectories for '''
     add_dynamic_boards_from_hwdef_dir(SITLBoard, 'libraries/AP_HAL_SITL/hwdef')
@@ -698,6 +702,7 @@ def get_boards_names():
     add_dynamic_boards_chibios()
     add_dynamic_boards_esp32()
     add_dynamic_boards_linux()
+    add_dynamic_boards_qurt()
     add_dynamic_boards_sitl()
 
     return sorted(list(_board_classes.keys()), key=str.lower)
@@ -1479,7 +1484,7 @@ class LinuxBoard(Board):
         # get name of class
         return self.__class__.__name__
 
-class QURT(Board):
+class QURTBoard(Board):
     '''support for QURT based boards'''
     toolchain = 'custom'
 
@@ -1487,6 +1492,11 @@ class QURT(Board):
         super().__init__()
 
         self.with_can = False
+
+    def configure(self, cfg):
+        # load hwdef, extract toolchain from cfg.env:
+        cfg.load('qurt')
+        super().configure(cfg)
 
     def configure_toolchain(self, cfg):
         cfg.env.CXX_NAME = 'gcc'
@@ -1522,7 +1532,7 @@ class QURT(Board):
         ]
 
     def configure_env(self, cfg, env):
-        super(QURT, self).configure_env(cfg, env)
+        super().configure_env(cfg, env)
 
         env.BOARD_CLASS = "QURT"
         env.HEXAGON_APP = "libardupilot.so"
@@ -1568,7 +1578,7 @@ class QURT(Board):
         ]
 
     def build(self, bld):
-        super(QURT, self).build(bld)
+        super().build(bld)
         bld.load('qurt')
 
     def get_name(self):

--- a/Tools/ardupilotwaf/qurt.py
+++ b/Tools/ardupilotwaf/qurt.py
@@ -6,6 +6,56 @@
 Waf tool for QURT build
 """
 
+import os
+import sys
+import traceback
+
+import hal_common
+
+sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../libraries/AP_HAL_QURT/hwdef/scripts'))
+import qurt_hwdef  # noqa: E402
+
+def generate_hwdef_h(env):
+    '''run qurt_hwdef.py'''
+    print(f"{env.SRCROOT=} {type(env.SRCROOT)=}")
+    hwdef_dir = os.path.join(env.SRCROOT, 'libraries/AP_HAL_QURT/hwdef')
+
+    if len(env.HWDEF) == 0:
+        env.HWDEF = os.path.join(hwdef_dir, env.BOARD, 'hwdef.dat')
+    hwdef_out = env.BUILDROOT
+    if not os.path.exists(hwdef_out):
+        os.mkdir(hwdef_out)
+    hwdef = [env.HWDEF]
+    if env.HWDEF_EXTRA:
+        hwdef.append(env.HWDEF_EXTRA)
+
+    hwdef_obj = qurt_hwdef.QURTHWDef(
+        outdir=hwdef_out,
+        hwdef=hwdef,
+        quiet=False,
+    )
+    hwdef_obj.run()
+
+    return hwdef_obj
+
+def configure(cfg):
+    def srcpath(path):
+        return cfg.srcnode.make_node(path).abspath()
+    def bldpath(path):
+        return bldnode.make_node(path).abspath()
+
+    env = cfg.env
+    bldnode = cfg.bldnode.make_node(cfg.variant)
+    env.SRCROOT = srcpath('')
+    env.BUILDROOT = bldpath('')
+
+    try:
+        hwdef_obj = generate_hwdef_h(env)
+    except Exception:  # noqa: BLE001
+        traceback.print_exc()
+        cfg.fatal("Failed to process hwdef.dat")
+    hal_common.process_hwdef_results(cfg, hwdef_obj)
+
 def build(bld):
     AARCH64_SDK_DIR = "/opt/aarch64-sdk/gcc-linaro-7.5.0-2019.12-x86_64_aarch64-linux-gnu"
     AARCH64_CC = AARCH64_SDK_DIR + "/bin/aarch64-linux-gnu-gcc"

--- a/Tools/scripts/board_list.py
+++ b/Tools/scripts/board_list.py
@@ -67,7 +67,7 @@ class BoardList(object):
         )
 
         self.hwdef_dir = []
-        for haldir in 'AP_HAL_ChibiOS', 'AP_HAL_Linux', 'AP_HAL_ESP32', 'AP_HAL_SITL':
+        for haldir in 'AP_HAL_ChibiOS', 'AP_HAL_Linux', 'AP_HAL_ESP32', 'AP_HAL_QURT', 'AP_HAL_SITL':
             self.hwdef_dir.append(os.path.join(realpath, haldir, "hwdef"))
 
     def __init__(self):
@@ -131,6 +131,8 @@ class BoardList(object):
                     board.toolchain = 'arm-none-eabi'
                 elif "ESP32" in hwdef_dir:
                     board.toolchain = 'xtensa-esp32-elf'
+                elif "QURT" in hwdef_dir:
+                    board.toolchain = "aarch64-linux-gnu"
                 elif "SITL" in hwdef_dir:
                     board.toolchain = None
                 else:
@@ -144,6 +146,8 @@ class BoardList(object):
                 board.hal = "ESP32"
             elif "SITL" in hwdef_dir:
                 board.hal = "SITL"
+            elif "QURT" in hwdef_dir:
+                board.hal = "QURT"
             else:
                 raise ValueError(f"Unable to determine HAL for {hwdef_dir}")
 

--- a/Tools/scripts/test_new_boards.py
+++ b/Tools/scripts/test_new_boards.py
@@ -159,6 +159,11 @@ class TestNewBoards(BuildScriptBase):
                 self.progress(f"Skipping ESP32 board {board.name}")
                 continue
 
+            # Skip QURT boards - CI machine can't build them
+            if board.hal == "QURT":
+                self.progress(f"Skipping QURT board {board.name}")
+                continue
+
             # Skip arms board - CI machine can't build it
             if board.toolchain == "arm-linux-gnueabihf":
                 self.progress(f"Skipping arm-linux board {board.name}")

--- a/libraries/AP_HAL/board/qurt.h
+++ b/libraries/AP_HAL/board/qurt.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <hwdef.h>
+
 #include <AP_HAL_QURT/AP_HAL_QURT_Main.h>
 
 #define HAL_BOARD_NAME "QURT"
@@ -91,24 +93,6 @@
 #define HAL_BATT_CURR_SCALE 1
 
 #define AP_COMPASS_PROBING_ENABLED 1
-
-/*
-  compass list
- */
-#define PROBE_MAG_I2C(driver, bus, addr, args ...) add_backend(DRIVER_ ##driver, AP_Compass_ ## driver::probe(GET_I2C_DEVICE(bus, addr),##args)); RETURN_IF_NO_SPACE;
-#define HAL_MAG_PROBE_LIST PROBE_MAG_I2C(QMC5883L, 0, 0x0d, true, ROTATION_NONE)
-
-/*
-  barometer list
- */
-#define HAL_BARO_PROBE_LIST \
-    probe_i2c_dev(AP_Baro_ICP101XX::probe, 2, 0x63);
-
-/*
-  IMU list
- */
-#define PROBE_IMU_SPI(driver, devname, args ...) ADD_BACKEND(AP_InertialSensor_ ## driver::probe(*this,hal.spi->get_device(devname),##args))
-#define HAL_INS_PROBE_LIST PROBE_IMU_SPI(Invensensev3, "INV3", ROTATION_NONE)
 
 /*
   bring in missing standard library functions

--- a/libraries/AP_HAL_QURT/SPIDevice.cpp
+++ b/libraries/AP_HAL_QURT/SPIDevice.cpp
@@ -27,7 +27,11 @@ using namespace QURT;
 #define MHZ (1000U*1000U)
 #define KHZ (1000U)
 
-const char *device_names[] = {"INV1", "INV2", "INV3"};
+#ifdef HAL_SPI_DEVICE_LIST
+const char *device_names[] = {
+    HAL_SPI_DEVICE_LIST
+};
+#endif  // HAL_SPI_DEVICE_LIST
 
 static SPIBus *spi_bus;
 

--- a/libraries/AP_HAL_QURT/hwdef/ModalAI-VOXL2/README.md
+++ b/libraries/AP_HAL_QURT/hwdef/ModalAI-VOXL2/README.md
@@ -1,0 +1,3 @@
+# ModalAI-VOXL2 Flight Controller
+
+The [ModalAI-VOXL2 flight controller](https://www.modalai.com/products/voxl-2?variant=39914779836467) is produced by [ModalAI](https://www.modalai.com).

--- a/libraries/AP_HAL_QURT/hwdef/ModalAI-VOXL2/hwdef.dat
+++ b/libraries/AP_HAL_QURT/hwdef/ModalAI-VOXL2/hwdef.dat
@@ -1,0 +1,15 @@
+# SPI devices
+#           NAME
+QURT_SPIDEV "INV3"
+
+#  compass list
+#       Driver   BusAndAddr External Rotation
+COMPASS QMC5883L I2C:0:0x0d true     ROTATION_NONE
+
+#  barometer list
+#    Driver   I2C Bus+Addr
+BARO ICP101XX I2C:2:0x63
+
+#  IMU list
+    driver       Bus+Addr   Rotation
+IMU Invensensev3 SPI:INV3   ROTATION_NONE

--- a/libraries/AP_HAL_QURT/hwdef/scripts/qurt_hwdef.py
+++ b/libraries/AP_HAL_QURT/hwdef/scripts/qurt_hwdef.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+'''
+setup board.h for QURT
+
+AP_FLAKE8_CLEAN
+
+'''
+
+import argparse
+import os
+import shlex
+import sys
+
+from dataclasses import dataclass
+
+sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../../libraries/AP_HAL/hwdef/scripts'))
+import hwdef  # noqa:E402
+
+
+@dataclass
+class QURTSPIDev():
+    name : str
+
+
+class QURTHWDef(hwdef.HWDef):
+
+    def __init__(self, **kwargs):
+        super(QURTHWDef, self).__init__(**kwargs)
+        # a list of QURT_SPIDEV devices
+        self.qurt_spidev = []
+
+    def write_hwdef_header_content(self, f):
+        for d in self.alllines:
+            if d.startswith('define '):
+                f.write('#define %s\n' % d[7:])
+
+        self.write_SPI_config(f)
+        self.write_IMU_config(f)
+        self.write_MAG_config(f)
+        self.write_BARO_config(f)
+
+    def process_line(self, line, depth):
+        '''process one line of pin definition file'''
+        # keep all config lines for later use
+        self.all_lines.append(line)
+        self.alllines.append(line)
+
+        a = shlex.split(line, posix=False)
+        if a[0] == 'QURT_SPIDEV':
+            self.process_line_qurt_spidev(line, depth, a)
+
+        super(QURTHWDef, self).process_line(line, depth)
+
+    def process_line_undef(self, line, depth, a):
+        for u in a[1:]:
+            for dev in self.qurt_spidev:
+                if u == dev.name:
+                    self.qurt_spidev.remove(dev)
+
+        super(QURTHWDef, self).process_line_undef(line, depth, a)
+
+    def process_line_qurt_spidev(self, line, depth, a):
+        (cmd, devname) = a
+        self.qurt_spidev.append(QURTSPIDev(devname))
+
+    def write_SPI_device_table(self, f):
+        '''write SPI device table'''
+
+        devlist = []
+        for dev in self.qurt_spidev:
+            f.write(
+                f'#define HAL_SPI_DEVICE{len(devlist)+1} {dev.name}'
+            )
+            devlist.append('HAL_SPI_DEVICE%u' % (len(devlist)+1))
+
+        self.write_device_table(f, "spi devices", "HAL_SPI_DEVICE_LIST", devlist)
+
+    def write_SPI_config(self, f):
+        '''write SPI config defines'''
+
+        self.write_SPI_device_table(f)
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser("qurt_hwdef.py")
+    parser.add_argument(
+        '-D', '--outdir', type=str, default="/tmp", help='Output directory')
+    parser.add_argument(
+        'hwdef', type=str, nargs='+', default=None, help='hardware definition file')
+    parser.add_argument(
+        '--quiet', action='store_true', default=False, help='quiet running')
+
+    args = parser.parse_args()
+
+    c = QURTHWDef(
+        outdir=args.outdir,
+        hwdef=args.hwdef,
+        quiet=args.quiet,
+    )
+    c.run()

--- a/libraries/AP_HAL_QURT/packaging/make_package.sh
+++ b/libraries/AP_HAL_QURT/packaging/make_package.sh
@@ -7,6 +7,7 @@ set -e # exit on error to prevent bad ipk from being generated
     exit 1
 }
 
+BOARD="ModalAI-VOXL2"
 VEHICLETYPE="$1"
 VEHICLE_BINARY="$2"
 
@@ -53,16 +54,16 @@ rm -rf $DEB_DIR
 ## install compiled stuff into data directory
 ################################################################################
 
-if [ -f ../../../build/QURT/ardupilot ] && \
-   [ -f ../../../build/QURT/bin/$VEHICLE_BINARY ]; then
+if [ -f ../../../build/$BOARD/ardupilot ] && \
+   [ -f ../../../build/$BOARD/bin/$VEHICLE_BINARY ]; then
 
 	# Copy the SLPI DSP AP library
     mkdir -p $DATA_DIR/usr/lib/rfsa/adsp
-	cp ../../../build/QURT/bin/$VEHICLE_BINARY $DATA_DIR/usr/lib/rfsa/adsp/ArduPilot.so
+	cp ../../../build/$BOARD/bin/$VEHICLE_BINARY $DATA_DIR/usr/lib/rfsa/adsp/ArduPilot.so
 
     # Install executables
 	mkdir -p $DATA_DIR/usr/bin
-	cp ../../../build/QURT/ardupilot $DATA_DIR/usr/bin
+	cp ../../../build/$BOARD/ardupilot $DATA_DIR/usr/bin
 	cp ../ap_host/service/voxl-ardupilot $DATA_DIR/usr/bin
 	chmod a+x $DATA_DIR/usr/bin/ardupilot
 	chmod a+x $DATA_DIR/usr/bin/voxl-ardupilot


### PR DESCRIPTION
### Summary

Convert QURT HAL to use hwdef system

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Will be expecting build server to be able to build QURT board.  Then relying on @katzfey to test on hardware.

### Description

Uses hwdef infrastructure for the final non-converted HAL.

Will allow for easy addition of VOXL3.

There's a question as to what we should do with the existing `QURT` target which is for the VOXL2 boards.  SHould we alias, leave it as QURT or remove QURT as a board name?
