### PR TITLE
SCurve: fix calculate_path bugs and add comprehensive tests

### DIFF
--- a/libraries/AP_Math/SCurve.cpp
+++ b/libraries/AP_Math/SCurve.cpp
@@ -294,7 +294,7 @@ void SCurve::set_speed_max(float speed_xy, float speed_up, float speed_down)
 
         // add to constant velocity segment to end at the correct position
         const float dP = MAX(0.0f, Pend - segment[SEG_DECEL_END].end_pos);
-        const float t15 = dP / segment[SEG_CONST].end_vel;
+        const float t15 = is_positive(segment[SEG_CONST].end_vel) ? dP / segment[SEG_CONST].end_vel : 0.0f;
         for (uint8_t i = SEG_CONST; i <= SEG_DECEL_END; i++) {
             segment[i].end_time += t15;
             segment[i].end_pos += dP;
@@ -321,7 +321,7 @@ void SCurve::set_speed_max(float speed_xy, float speed_up, float speed_down)
         float t2 = 0;
         float t4 = 0;
         float t6 = 0;
-        float jerk_time = MIN(powf((fabsf(vel_max - segment[SEG_ACCEL_END].end_vel) * M_PI) / (4 * snap_max), 1/3), jerk_max * M_PI / (2 * snap_max));
+        float jerk_time = MIN(powf((fabsf(vel_max - segment[SEG_ACCEL_END].end_vel) * M_PI) / (4 * snap_max), 1.0f / 3.0f), jerk_max * M_PI / (2 * snap_max));
         if ((vel_max < segment[SEG_ACCEL_END].end_vel) && (jerk_time*12.0f < L/segment[SEG_ACCEL_END].end_vel)) {
             // we have a problem here with small segments.
             calculate_path(snap_max, jerk_max, vel_max, accel_max, segment[SEG_ACCEL_END].end_vel, L * 0.5f, Jm, tj, t6, t4, t2);
@@ -372,7 +372,7 @@ void SCurve::set_speed_max(float speed_xy, float speed_up, float speed_down)
 
     // add to constant velocity segment to end at the correct position
     const float dP = MAX(0.0f, Pend - segment[SEG_DECEL_END].end_pos);
-    const float t15 = dP / segment[SEG_CONST].end_vel;
+    const float t15 = is_positive(segment[SEG_CONST].end_vel) ? dP / segment[SEG_CONST].end_vel : 0.0f;
     for (uint8_t i = SEG_CONST; i <= SEG_DECEL_END; i++) {
         segment[i].end_time += t15;
         segment[i].end_pos += dP;
@@ -454,7 +454,7 @@ float SCurve::set_origin_speed_max(float speed)
 
     // add to constant velocity segment to end at the correct position
     const float dP = MAX(0.0f, seg_length - segment[SEG_DECEL_END].end_pos);
-    const float t15 = dP / segment[SEG_CONST].end_vel;
+    const float t15 = is_positive(segment[SEG_CONST].end_vel) ? dP / segment[SEG_CONST].end_vel : 0.0f;
     for (uint8_t i = SEG_CONST; i <= SEG_DECEL_END; i++) {
         segment[i].end_time += t15;
         segment[i].end_pos += dP;
@@ -509,7 +509,7 @@ void SCurve::set_destination_speed_max(float speed)
 
     // add to constant velocity segment to end at the correct position
     const float dP = MAX(0.0f, seg_length - segment[SEG_DECEL_END].end_pos);
-    const float t15 = dP / segment[SEG_CONST].end_vel;
+    const float t15 = is_positive(segment[SEG_CONST].end_vel) ? dP / segment[SEG_CONST].end_vel : 0.0f;
     for (uint8_t i = SEG_CONST; i <= SEG_DECEL_END; i++) {
         segment[i].end_time += t15;
         segment[i].end_pos += dP;
@@ -912,9 +912,12 @@ void SCurve::calculate_path(float Sm, float Jm, float V0, float Am, float Vm, fl
     }
 
     float tj = Jm * M_PI / (2 * Sm);
-    float At = MIN(MIN(Am, 
-        (Vm - V0) / (2.0f * tj) ), 
-        (L + 4.0f * V0 * tj) / (4.0f * sq(tj)) );
+    float At = MIN(MIN(Am,
+        (Vm - V0) / (2.0f * tj) ),
+        (L - 4.0f * V0 * tj) / (4.0f * sq(tj)) );
+    if (!is_positive(At)) {
+        return;
+    }
     if (fabsf(At) < Jm * tj) {
         if (is_zero(V0)) {
             // we do not have a solution for non-zero initial velocity

--- a/libraries/AP_Math/SCurve.cpp
+++ b/libraries/AP_Math/SCurve.cpp
@@ -55,7 +55,7 @@ void SCurve::init()
 
     is_arc_segment = false;
     seg_delta.zero();
-    seg_length = 0.0;
+    seg_length = 0.0f;
     arc = {};
 }
 
@@ -84,7 +84,7 @@ void SCurve::calculate_track(const Vector3p &origin, const Vector3p &destination
 
     const Vector2f chord = seg_delta.xy();
     const float chord_length = seg_delta.xy().length();
-    if (!is_positive(chord_length) || fabsf(wrap_PI(arc_ang_rad)) < radians(1.0)) {
+    if (!is_positive(chord_length) || fabsf(wrap_PI(arc_ang_rad)) < radians(1.0f)) {
         // straight segment
         is_arc_segment = false;
         arc.angle_rad = 0.0f;
@@ -321,7 +321,7 @@ void SCurve::set_speed_max(float speed_xy, float speed_up, float speed_down)
         float t2 = 0;
         float t4 = 0;
         float t6 = 0;
-        float jerk_time = MIN(powf((fabsf(vel_max - segment[SEG_ACCEL_END].end_vel) * M_PI) / (4 * snap_max), 1.0f / 3.0f), jerk_max * M_PI / (2 * snap_max));
+        float jerk_time = MIN(powf((fabsf(vel_max - segment[SEG_ACCEL_END].end_vel) * M_PI) / (4.0f * snap_max), 1.0f / 3.0f), jerk_max * M_PI / (2.0f * snap_max));
         if ((vel_max < segment[SEG_ACCEL_END].end_vel) && (jerk_time*12.0f < L/segment[SEG_ACCEL_END].end_vel)) {
             // we have a problem here with small segments.
             calculate_path(snap_max, jerk_max, vel_max, accel_max, segment[SEG_ACCEL_END].end_vel, L * 0.5f, Jm, tj, t6, t4, t2);
@@ -668,7 +668,7 @@ void SCurve::project_scurve_onto_track(float scurve_A1, float scurve_V1, float s
 float SCurve::time_end() const
 {
     if (num_segs != segments_max) {
-        return 0.0;
+        return 0.0f;
     }
     return segment[SEG_DECEL_END].end_time;
 }
@@ -677,7 +677,7 @@ float SCurve::time_end() const
 float SCurve::get_time_remaining() const
 {
     if (num_segs != segments_max) {
-        return 0.0;
+        return 0.0f;
     }
     return segment[SEG_DECEL_END].end_time - time;
 }
@@ -686,7 +686,7 @@ float SCurve::get_time_remaining() const
 float SCurve::get_accel_finished_time() const
 {
     if (num_segs != segments_max) {
-        return 0.0;
+        return 0.0f;
     }
     return segment[SEG_ACCEL_END].end_time;
 }
@@ -705,7 +705,7 @@ bool SCurve::braking() const
 float SCurve::time_accel_end() const
 {
     if (num_segs != segments_max) {
-        return 0.0;
+        return 0.0f;
     }
     return segment[SEG_ACCEL_END].end_time;
 }
@@ -715,7 +715,7 @@ float SCurve::time_accel_end() const
 float SCurve::time_decel_start() const
 {
     if (num_segs != segments_max) {
-        return 0.0;
+        return 0.0f;
     }
     return segment[SEG_DECEL_START].end_time;
 }
@@ -730,10 +730,10 @@ void SCurve::advance_time(float dt)
 void SCurve::get_jerk_accel_vel_pos_at_time(float time_now, float &Jt_out, float &At_out, float &Vt_out, float &Pt_out) const
 {
     // start with zeros as function is void and we want to guarantee all outputs are initialised
-    Jt_out = 0;
-    At_out = 0;
-    Vt_out = 0;
-    Pt_out = 0;
+    Jt_out = 0.0f;
+    At_out = 0.0f;
+    Vt_out = 0.0f;
+    Pt_out = 0.0f;
     if (num_segs != segments_max) {
         return;
     }
@@ -801,7 +801,7 @@ void SCurve::calc_javp_for_segment_const_jerk(float time_now, float J0, float A0
 void SCurve::calc_javp_for_segment_incr_jerk(float time_now, float tj, float Jm, float A0, float V0, float P0, float &Jt, float &At, float &Vt, float &Pt) const
 {
     if (!is_positive(tj)) {
-        Jt = 0.0;
+        Jt = 0.0f;
         At = A0;
         Vt = V0;
         Pt = P0;
@@ -819,7 +819,7 @@ void SCurve::calc_javp_for_segment_incr_jerk(float time_now, float tj, float Jm,
 void SCurve::calc_javp_for_segment_decr_jerk(float time_now, float tj, float Jm, float A0, float V0, float P0, float &Jt, float &At, float &Vt, float &Pt) const
 {
     if (!is_positive(tj)) {
-        Jt = 0.0;
+        Jt = 0.0f;
         At = A0;
         Vt = V0;
         Pt = P0;
@@ -911,7 +911,7 @@ void SCurve::calculate_path(float Sm, float Jm, float V0, float Am, float Vm, fl
         return;
     }
 
-    float tj = Jm * M_PI / (2 * Sm);
+    float tj = Jm * M_PI / (2.0f * Sm);
     float At = MIN(MIN(Am,
         (Vm - V0) / (2.0f * tj) ),
         (L - 4.0f * V0 * tj) / (4.0f * sq(tj)) );
@@ -922,10 +922,10 @@ void SCurve::calculate_path(float Sm, float Jm, float V0, float Am, float Vm, fl
         if (is_zero(V0)) {
             // we do not have a solution for non-zero initial velocity
             tj = MIN( MIN( MIN( tj,
-                powf((L * M_PI) / (8.0 * Sm), 1.0/4.0) ), 
-                powf((Vm * M_PI) / (4.0 * Sm), 1.0/3.0) ), 
-                safe_sqrt((Am * M_PI) / (2.0 * Sm)) );
-            Jm = 2.0 * Sm * tj / M_PI;
+                powf((L * M_PI) / (8.0f * Sm), 1.0f / 4.0f) ),
+                powf((Vm * M_PI) / (4.0f * Sm), 1.0f / 3.0f) ),
+                safe_sqrt((Am * M_PI) / (2.0f * Sm)) );
+            Jm = 2.0f * Sm * tj / M_PI;
             Am = Jm * tj;
         } else {
             // When doing speed change we use fixed tj and adjust Jm for small changes
@@ -941,7 +941,7 @@ void SCurve::calculate_path(float Sm, float Jm, float V0, float Am, float Vm, fl
             // solution = 2 - t6 t4 t2 = 0 1 0
             t2_out = 0.0f;
             t4_out = MIN(-(V0 - Vm + Am * tj + (Am * Am) / Jm) / Am, MAX(((Am * Am) * (-3.0f / 2.0f) + safe_sqrt((Am * Am * Am * Am) * (1.0f / 4.0f) + (Jm * Jm) * (V0 * V0) + (Am * Am) * (Jm * Jm) * (tj * tj) * (1.0f / 4.0f) + Am * (Jm * Jm) * L * 2.0f - (Am * Am) * Jm * V0 + (Am * Am * Am) * Jm * tj * (1.0f / 2.0f) - Am * (Jm * Jm) * V0 * tj) - Jm * V0 - Am * Jm * tj * (3.0f / 2.0f)) / (Am * Jm), ((Am * Am) * (-3.0f / 2.0f) - safe_sqrt((Am * Am * Am * Am) * (1.0f / 4.0f) + (Jm * Jm) * (V0 * V0) + (Am * Am) * (Jm * Jm) * (tj * tj) * (1.0f / 4.0f) + Am * (Jm * Jm) * L * 2.0f - (Am * Am) * Jm * V0 + (Am * Am * Am) * Jm * tj * (1.0f / 2.0f) - Am * (Jm * Jm) * V0 * tj) - Jm * V0 - Am * Jm * tj * (3.0f / 2.0f)) / (Am * Jm)));
-            t4_out = MAX(t4_out, 0.0);
+            t4_out = MAX(t4_out, 0.0f);
             t6_out = 0.0f;
         }
     } else {
@@ -955,7 +955,7 @@ void SCurve::calculate_path(float Sm, float Jm, float V0, float Am, float Vm, fl
             // solution = 7 - t6 t4 t2 = 1 1 1
             t2_out = Am / Jm - tj;
             t4_out = MIN(-(V0 - Vm + Am * tj + (Am * Am) / Jm) / Am, MAX(((Am * Am) * (-3.0f / 2.0f) + safe_sqrt((Am * Am * Am * Am) * (1.0f / 4.0f) + (Jm * Jm) * (V0 * V0) + (Am * Am) * (Jm * Jm) * (tj * tj) * (1.0f / 4.0f) + Am * (Jm * Jm) * L * 2.0f - (Am * Am) * Jm * V0 + (Am * Am * Am) * Jm * tj * (1.0f / 2.0f) - Am * (Jm * Jm) * V0 * tj) - Jm * V0 - Am * Jm * tj * (3.0f / 2.0f)) / (Am * Jm), ((Am * Am) * (-3.0f / 2.0f) - safe_sqrt((Am * Am * Am * Am) * (1.0f / 4.0f) + (Jm * Jm) * (V0 * V0) + (Am * Am) * (Jm * Jm) * (tj * tj) * (1.0f / 4.0f) + Am * (Jm * Jm) * L * 2.0f - (Am * Am) * Jm * V0 + (Am * Am * Am) * Jm * tj * (1.0f / 2.0f) - Am * (Jm * Jm) * V0 * tj) - Jm * V0 - Am * Jm * tj * (3.0f / 2.0f)) / (Am * Jm)));
-            t4_out = MAX(t4_out, 0.0);
+            t4_out = MAX(t4_out, 0.0f);
             t6_out = t2_out;
         }
     }
@@ -1067,7 +1067,7 @@ void SCurve::add_segment_incr_jerk(uint8_t &index, float tj, float Jm)
     if (!is_positive(tj)) {
         add_segment(index, segment[index - 1].end_time,
                     SegmentType::CONSTANT_JERK,
-                    0.0,
+                    0.0f,
                     segment[index - 1].end_accel,
                     segment[index - 1].end_vel,
                     segment[index - 1].end_pos);
@@ -1096,7 +1096,7 @@ void SCurve::add_segment_decr_jerk(uint8_t &index, float tj, float Jm)
     if (!is_positive(tj)) {
         add_segment(index, segment[index - 1].end_time,
                     SegmentType::CONSTANT_JERK,
-                    0.0,
+                    0.0f,
                     segment[index - 1].end_accel,
                     segment[index - 1].end_vel,
                     segment[index - 1].end_pos);

--- a/libraries/AP_Math/SCurve.cpp
+++ b/libraries/AP_Math/SCurve.cpp
@@ -98,7 +98,7 @@ void SCurve::calculate_track(const Vector3p &origin, const Vector3p &destination
         arc.radius_ne = fabsf(chord_length / (2.0f * fabsf(sinf(arc.angle_rad * 0.5f))));
         const float center_offset = safe_sqrt(sq(arc.radius_ne) - sq(chord_length * 0.5f)); // perpendicular offset from chord to circle center
         const float turn_dir = is_negative(arc.angle_rad) ? -1.0f : 1.0f; // -1 for CCW, 1 for CW 
-        const float center_side = (is_positive(wrap_PI(fabsf(arc.angle_rad)))) ? 1.0f : -1.0f; // -1 for CCW, 1 for CW
+        const float center_side = (is_positive(wrap_PI(fabsf(arc.angle_rad)))) ? 1.0f : -1.0f; // 1 for |angle| < PI, -1 for |angle| > PI
         if (!is_zero(arc.radius_ne) && !is_zero(chord_length)) {
             arc.center_ne = chord * 0.5f + Vector2f(-chord.y, chord.x) * (center_side * turn_dir * center_offset / chord_length);
             arc.length_ne = arc.radius_ne * fabsf(arc.angle_rad);
@@ -322,13 +322,13 @@ void SCurve::set_speed_max(float speed_xy, float speed_up, float speed_down)
         float t4 = 0;
         float t6 = 0;
         float jerk_time = MIN(powf((fabsf(vel_max - segment[SEG_ACCEL_END].end_vel) * M_PI) / (4.0f * snap_max), 1.0f / 3.0f), jerk_max * M_PI / (2.0f * snap_max));
-        if ((vel_max < segment[SEG_ACCEL_END].end_vel) && (jerk_time*12.0f < L/segment[SEG_ACCEL_END].end_vel)) {
+        if ((vel_max < segment[SEG_ACCEL_END].end_vel) && (jerk_time * 12.0f < L / segment[SEG_ACCEL_END].end_vel)) {
             // we have a problem here with small segments.
             calculate_path(snap_max, jerk_max, vel_max, accel_max, segment[SEG_ACCEL_END].end_vel, L * 0.5f, Jm, tj, t6, t4, t2);
             Jm = -Jm;
 
-        } else if ((vel_max > segment[SEG_ACCEL_END].end_vel) && (L/(jerk_time*12.0f) > segment[SEG_ACCEL_END].end_vel)) {
-            float Vm = MIN(vel_max, L/(jerk_time*12.0f));
+        } else if ((vel_max > segment[SEG_ACCEL_END].end_vel) && (L / (jerk_time * 12.0f) > segment[SEG_ACCEL_END].end_vel)) {
+            float Vm = MIN(vel_max, L / (jerk_time * 12.0f));
             calculate_path(snap_max, jerk_max, segment[SEG_ACCEL_END].end_vel, accel_max, Vm, L * 0.5f, Jm, tj, t2, t4, t6);
         }
 
@@ -723,7 +723,7 @@ float SCurve::time_decel_start() const
 // increment the internal time
 void SCurve::advance_time(float dt)
 {
-    time = MIN(time+dt, time_end());
+    time = MIN(time + dt, time_end());
 }
 
 // calculate the jerk, acceleration, velocity and position at the provided time
@@ -888,7 +888,7 @@ void SCurve::add_segments(float L)
 // Vm - maximum constant velocity
 // L - Length of the path
 // tj_out, t2_out, t4_out, t6_out are the segment durations needed to achieve the kinematic path specified by the input variables
-void SCurve::calculate_path(float Sm, float Jm, float V0, float Am, float Vm, float L,float &Jm_out, float &tj_out,  float &t2_out, float &t4_out, float &t6_out)
+void SCurve::calculate_path(float Sm, float Jm, float V0, float Am, float Vm, float L, float &Jm_out, float &tj_out,  float &t2_out, float &t4_out, float &t6_out)
 {
     // init outputs
     Jm_out = 0.0f;

--- a/libraries/AP_Math/tests/test_scurve.cpp
+++ b/libraries/AP_Math/tests/test_scurve.cpp
@@ -5,18 +5,93 @@
 #include <AP_Math/vector3.h>
 #include <AP_Math/SCurve.h>
 
-TEST(LinesScurve, test_calculate_path)
-{
-    // this test doesn't do much...
-    float Jm_out, tj_out, t2_out, t4_out, t6_out;
-    SCurve::calculate_path(62.8319, 10, 0, 5, 10, 100,
-                           Jm_out, tj_out, t2_out, t4_out, t6_out);
-    EXPECT_FLOAT_EQ(Jm_out, 10);
-    EXPECT_FLOAT_EQ(t2_out, 0.25000018);
-    EXPECT_FLOAT_EQ(t4_out, 1.2500002);
-    EXPECT_FLOAT_EQ(t6_out, 0.25000018);
-}
+// Test inputs and expected outputs for each code path in calculate_path.
+//
+// With Sm=62.8319, Jm=10: tj ≈ 0.25, Jm*tj ≈ 2.5
+// At = MIN(Am, (Vm-V0)/(2*tj), (L - 4*V0*tj)/(4*tj²))
+//    ≈ MIN(Am, (Vm-V0)/0.5, (L-V0)/0.25)
+//
+// Paths exercised:
+//   B: V0 >= Vm
+//   C: At <= 0 (requires L < V0 approx, sign fix path)
+//   D: At<Jm*tj, V0==0, solution=0
+//   E: At<Jm*tj, V0==0, solution=2
+//   F: At<Jm*tj, V0>0, solution=0
+//   G: At<Jm*tj, V0>0, solution=2
+//   H: At>=Jm*tj, solution=5
+//   I: At>=Jm*tj, solution=7
+struct PathTest {
+    const char *name;
+    float Sm, Jm, V0, Am, Vm, L;
+    float exp_Jm, exp_tj, exp_t2, exp_t4, exp_t6;
+};
 
+static const PathTest path_tests[] = {
+
+    // ---- Path B: V0 >= Vm ----
+    {"B1_exact",  62.8319, 10, 10,   5,  10,  100,    0, 0, 0, 0, 0},
+    {"B2_just",   62.8319, 10, 5.1,  5,  5,   100,    0, 0, 0, 0, 0},
+    {"B3_mid",    62.8319, 10, 20,   5,  10,  100,    0, 0, 0, 0, 0},
+    {"B4_low",    62.8319, 10, 3,    5,  2,   100,    0, 0, 0, 0, 0},
+
+    // ---- Path C: At <= 0 (sign fix) ----
+    {"C1_just",   62.8319, 10, 5,    5,  10,  4.9,    0, 0, 0, 0, 0},
+    {"C2_deep",   62.8319, 10, 8,    5,  10,  5,      0, 0, 0, 0, 0},
+    {"C3_v3",     62.8319, 10, 3,    5,  10,  2.9,    0, 0, 0, 0, 0},
+    {"C4_hiV0",   62.8319, 10, 9,    5,  10,  8,      0, 0, 0, 0, 0},
+
+    // ---- Path D: At<Jm*tj, V0==0, solution=0 ----
+    {"D1_tiny",   62.8319, 10, 0,    5,  10,  0.01,   3.55656075f, 0.08891395f, 0, 0, 0},
+    {"D2_short",  62.8319, 10, 0,    5,  10,  0.1,    6.32455873f, 0.15811385f, 0, 0, 0},
+    {"D3_nearE",  62.8319, 10, 0,    5,  10,  0.2,    7.52121019f, 0.18803012f, 0, 0, 0},
+    {"D4_lowAm",  62.8319, 10, 0,    1,  10,  0.005,  2.99069929f, 0.07476743f, 0, 0, 0},
+
+    // ---- Path E: At<Jm*tj, V0==0, solution=2 ----
+    {"E1_deep",   62.8319, 10, 0,    2,    10,  50,    8.94427586f, 0.22360672f, 0, 4.55278635f, 0},
+    {"E2_nearD",  62.8319, 10, 0,    2,    10,  5,     8.94427586f, 0.22360672f, 0, 1.57640016f, 0},
+    {"E3_nearI",  62.8319, 10, 0,    2.4,  10,  50,    9.79796314f, 0.24494889f, 0, 3.67676854f, 0},
+    {"E4_lowAm",  62.8319, 10, 0,    1,    10,  50,    6.32455778f, 0.15811382f, 0, 9.52690887f, 0},
+
+    // ---- Path F: At<Jm*tj, V0>0, solution=0 ----
+    {"F1_nearC",  62.8319, 10, 5,    5,  10,  5.1,    1.60006297f, 0.24999982f, 0, 0, 0},
+    {"F2_mid",    62.8319, 10, 1,    5,  10,  1.5,    8.00002861f, 0.24999982f, 0, 0, 0},
+    {"F3_v2",     62.8319, 10, 2,    5,  10,  2.3,    4.80003214f, 0.24999982f, 0, 0, 0},
+    {"F4_amBind", 62.8319, 10, 0.5,  2,  10,  0.8,    4.80001593f, 0.24999982f, 0, 0, 0},
+
+    // ---- Path G: At<Jm*tj, V0>0, solution=2 ----
+    {"G1_deep",   62.8319, 10, 1,    2,  10,  50,     8.00000572f, 0.24999982f, 0, 4.00000000f, 0},
+    {"G2_mod",    62.8319, 10, 0.5,  2,  10,  10,     8.00000572f, 0.24999982f, 0, 2.16227818f, 0},
+    {"G3_nearF",  62.8319, 10, 2,    2,  10,  10,     8.00000572f, 0.24999982f, 0, 1.50000060f, 0},
+    {"G4_loV0",   62.8319, 10, 0.1,  2,  10,  50,     8.00000572f, 0.24999982f, 0, 4.44999981f, 0},
+
+    // ---- Path H: At>=Jm*tj, solution=5 ----
+    {"H1_nearI",  62.8319, 10, 0,    5,  3.7, 100,    10.0f, 0.24999982f, 0.24598742f, 0, 0.24598742f},
+    {"H2_mid",    62.8319, 10, 0,    5,  3.5, 100,    10.0f, 0.24999982f, 0.22966957f, 0, 0.22966957f},
+    {"H3_shortL", 62.8319, 10, 0,    5,  10,  1.5,    10.0f, 0.24999982f, 0.12905994f, 0, 0.12905994f},
+    {"H4_v0p",    62.8319, 10, 2,    5,  5.5, 100,    10.0f, 0.24999982f, 0.22966957f, 0, 0.22966957f},
+
+    // ---- Path I: At>=Jm*tj, solution=7 ----
+    {"I1_nearH",  62.8319, 10, 0,    5,  3.8, 100,    10.0f, 0.24999982f, 0.25000018f, 0.01000018f, 0.25000018f},
+    {"I2_deep",   62.8319, 10, 0,    5,  10,  100,    10.0f, 0.24999982f, 0.25000018f, 1.25000024f, 0.25000018f},
+    {"I3_v0p",    62.8319, 10, 2,    5,  10,  100,    10.0f, 0.24999982f, 0.25000018f, 0.85000020f, 0.25000018f},
+    {"I4_lowAm",  62.8319, 10, 0,    3,  5,   100,    10.0f, 0.24999982f, 0.05000019f, 1.11666679f, 0.05000019f},
+};
+
+TEST(SCurveCalcPath, coverage_and_outputs)
+{
+    float Jm_out, tj_out, t2_out, t4_out, t6_out;
+
+    for (const auto &t : path_tests) {
+        SCurve::calculate_path(t.Sm, t.Jm, t.V0, t.Am, t.Vm, t.L,
+                               Jm_out, tj_out, t2_out, t4_out, t6_out);
+
+        EXPECT_FLOAT_EQ(Jm_out, t.exp_Jm) << "Jm mismatch: " << t.name;
+        EXPECT_FLOAT_EQ(tj_out, t.exp_tj) << "tj mismatch: " << t.name;
+        EXPECT_FLOAT_EQ(t2_out, t.exp_t2) << "t2 mismatch: " << t.name;
+        EXPECT_FLOAT_EQ(t4_out, t.exp_t4) << "t4 mismatch: " << t.name;
+        EXPECT_FLOAT_EQ(t6_out, t.exp_t6) << "t6 mismatch: " << t.name;
+    }
+}
 
 AP_GTEST_MAIN()
 int hal = 0; //weirdly the build will fail without this

--- a/libraries/AP_Math/tests/test_scurve.cpp
+++ b/libraries/AP_Math/tests/test_scurve.cpp
@@ -77,6 +77,63 @@ static const PathTest path_tests[] = {
     {"I4_lowAm",  62.8319, 10, 0,    3,  5,   100,    10.0f, 0.24999982f, 0.05000019f, 1.11666679f, 0.05000019f},
 };
 
+// Segment state used to integrate through the profile
+struct SegState {
+    float A, V, P;
+};
+
+// Integrate an increasing-jerk segment (raised cosine from 0 to Jm)
+static SegState seg_incr_jerk(SegState s, float tj, float Jm)
+{
+    if (tj <= 0) return s;
+    const float Alpha = Jm * 0.5f;
+    const float Beta = M_PI / tj;
+    const float AT = Alpha * tj;
+    const float VT = Alpha * (sq(tj) * 0.5f - 2.0f / sq(Beta));
+    const float PT = Alpha * ((-1.0f / sq(Beta)) * tj + (1.0f / 6.0f) * powf(tj, 3.0f));
+    return {s.A + AT,
+            s.V + s.A * tj + VT,
+            s.P + s.V * tj + 0.5f * s.A * sq(tj) + PT};
+}
+
+// Integrate a constant-jerk segment
+static SegState seg_const_jerk(SegState s, float t, float J)
+{
+    if (t <= 0) return s;
+    return {s.A + J * t,
+            s.V + s.A * t + 0.5f * J * sq(t),
+            s.P + s.V * t + 0.5f * s.A * sq(t) + (1.0f / 6.0f) * J * powf(t, 3.0f)};
+}
+
+// Integrate a decreasing-jerk segment (raised cosine from Jm to 0)
+static SegState seg_decr_jerk(SegState s, float tj, float Jm)
+{
+    if (tj <= 0) return s;
+    const float Alpha = Jm * 0.5f;
+    const float Beta = M_PI / tj;
+    const float AT = Alpha * tj;
+    const float VT = Alpha * (sq(tj) * 0.5f - 2.0f / sq(Beta));
+    const float PT = Alpha * ((-1.0f / sq(Beta)) * tj + (1.0f / 6.0f) * powf(tj, 3.0f));
+    const float A2T = Jm * tj;
+    const float V2T = Jm * sq(tj);
+    const float P2T = Alpha * ((-1.0f / sq(Beta)) * 2.0f * tj + (4.0f / 3.0f) * powf(tj, 3.0f));
+    return {(s.A - AT) + A2T,
+            (s.V - VT) + (s.A - AT) * tj + V2T,
+            (s.P - PT) + (s.V - VT) * tj + 0.5f * (s.A - AT) * sq(tj) + P2T};
+}
+
+// Integrate a 3-segment jerk block: incr, const, decr
+static SegState seg_jerk_block(SegState s, float tj, float Jm, float Tcj, float &peak_A)
+{
+    s = seg_incr_jerk(s, tj, Jm);
+    peak_A = MAX(peak_A, fabsf(s.A));
+    s = seg_const_jerk(s, Tcj, Jm);
+    peak_A = MAX(peak_A, fabsf(s.A));
+    s = seg_decr_jerk(s, tj, Jm);
+    peak_A = MAX(peak_A, fabsf(s.A));
+    return s;
+}
+
 TEST(SCurveCalcPath, coverage_and_outputs)
 {
     float Jm_out, tj_out, t2_out, t4_out, t6_out;
@@ -90,6 +147,100 @@ TEST(SCurveCalcPath, coverage_and_outputs)
         EXPECT_FLOAT_EQ(t2_out, t.exp_t2) << "t2 mismatch: " << t.name;
         EXPECT_FLOAT_EQ(t4_out, t.exp_t4) << "t4 mismatch: " << t.name;
         EXPECT_FLOAT_EQ(t6_out, t.exp_t6) << "t6 mismatch: " << t.name;
+    }
+}
+
+// Verify that calculate_path outputs, when applied through add_segments logic,
+// produce a full path that:
+// - total distance == 2*L (add_segments calls calculate_path with L*0.5)
+// - peak velocity <= Vm
+// - peak acceleration <= Am
+// - output jerk <= input Jm
+// - final velocity == V0 (returns to initial speed)
+// - final acceleration == 0
+//
+// add_segments builds:
+//   Accel half:  jerk_block(tj, +Jm, t2) + const(t4, 0) + jerk_block(tj, -Jm, t6)
+//   Coast:       const(t_coast, 0) where t_coast fills remaining distance at Vm
+//   Decel half:  jerk_block(tj, -Jm, t6) + const(t4, 0) + jerk_block(tj, +Jm, t2)
+TEST(SCurveCalcPath, constraints)
+{
+    const float tol = 1.0e-3f;
+    float Jm_out, tj_out, t2_out, t4_out, t6_out;
+
+    for (const auto &t : path_tests) {
+        SCurve::calculate_path(t.Sm, t.Jm, t.V0, t.Am, t.Vm, t.L,
+                               Jm_out, tj_out, t2_out, t4_out, t6_out);
+
+        // skip zero-output cases (paths B, C)
+        if (is_zero(Jm_out) && is_zero(tj_out)) {
+            continue;
+        }
+
+        // jerk limit: output Jm must not exceed input Jm
+        EXPECT_LE(Jm_out, t.Jm + tol) << "Jm exceeded: " << t.name;
+
+        // --- Accel half ---
+        float peak_A = 0.0f;
+        SegState s = {0.0f, t.V0, 0.0f};
+
+        // accel up: jerk_block(tj, +Jm, t2)
+        s = seg_jerk_block(s, tj_out, Jm_out, t2_out, peak_A);
+        float peak_V = s.V;
+
+        // coast within accel half: const(t4, 0)
+        s = seg_const_jerk(s, t4_out, 0.0f);
+        peak_V = MAX(peak_V, s.V);
+
+        // accel down: jerk_block(tj, -Jm, t6)
+        s = seg_jerk_block(s, tj_out, -Jm_out, t6_out, peak_A);
+
+        // end of accel half: acceleration should be ~0
+        EXPECT_NEAR(s.A, 0.0f, tol) << "accel half final A non-zero: " << t.name;
+
+        const float accel_half_P = s.P;
+        const float cruise_V = s.V;
+
+        // --- Coast segment (fill remaining distance at cruise velocity) ---
+        const float L_total = 2.0f * t.L;
+        const float coast_dist = MAX(0.0f, L_total - 2.0f * accel_half_P);
+        float t_coast = 0.0f;
+        if (cruise_V > 0.0f) {
+            t_coast = coast_dist / cruise_V;
+        }
+        s = seg_const_jerk(s, t_coast, 0.0f);
+        peak_V = MAX(peak_V, s.V);
+
+        // --- Decel half (mirror of accel) ---
+        // decel down: jerk_block(tj, -Jm, t6)
+        s = seg_jerk_block(s, tj_out, -Jm_out, t6_out, peak_A);
+
+        // coast within decel half: const(t4, 0)
+        s = seg_const_jerk(s, t4_out, 0.0f);
+
+        // decel up: jerk_block(tj, +Jm, t2)
+        s = seg_jerk_block(s, tj_out, Jm_out, t2_out, peak_A);
+
+        // --- Check constraints ---
+
+        // total distance must match 2*L
+        EXPECT_NEAR(s.P, L_total, tol) << "distance mismatch: " << t.name
+            << " P=" << s.P << " expected=" << L_total;
+
+        // final velocity must return to V0
+        EXPECT_NEAR(s.V, t.V0, tol) << "final velocity mismatch: " << t.name
+            << " V=" << s.V << " V0=" << t.V0;
+
+        // final acceleration must be zero
+        EXPECT_NEAR(s.A, 0.0f, tol) << "final accel non-zero: " << t.name;
+
+        // peak velocity must not exceed Vm
+        EXPECT_LE(peak_V, t.Vm + tol) << "velocity exceeded Vm: " << t.name
+            << " peak_V=" << peak_V << " Vm=" << t.Vm;
+
+        // peak acceleration must not exceed Am
+        EXPECT_LE(peak_A, t.Am + tol) << "accel exceeded Am: " << t.name
+            << " peak_A=" << peak_A << " Am=" << t.Am;
     }
 }
 


### PR DESCRIPTION
### Summary

Fix three bugs in SCurve::calculate_path and set_speed_max, add tests
that cover all code paths, and clean up float literal consistency.

Fixes #32724

Bug fixes:
- Fix sign error in path length acceleration constraint: (L + 4*V0*tj)
  should be (L - 4*V0*tj). The old formula inflated the allowed
  acceleration when V0 > 0, producing invalid motion profiles.
- Add early return when At <= 0. After the sign fix, At can go negative
  when the path is too short for the initial velocity.
- Fix integer division in set_speed_max: powf(x, 1/3) evaluated the
  exponent as 0, making powf always return 1.0 instead of the cube
  root. This disabled the velocity-based jerk time limit.
- Guard against divide-by-zero where dP is divided by
  segment[SEG_CONST].end_vel in four places.

Tests:
- 32 test cases covering all 8 code paths in calculate_path with 4
  inputs per path near transitions and midpoints.
- Constraint validation replicating the add_segments path structure to
  verify total distance, final velocity, final acceleration, and that
  velocity, acceleration, and jerk limits are not exceeded.

Cleanup:
- Replace double literals with float literals throughout to avoid
  implicit double-to-float conversions.
- Fix misleading comment, whitespace, and operator spacing.

```
Board,antennatracker,blimp,bootloader,copter,heli,plane,rover,sub
CubeOrange,*,*,*,128,128,136,136,128
```

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request