### PR TITLE
Move more enumerations out of Copter/defines.h

### DIFF
--- a/ArduCopter/AP_Arming_Copter.cpp
+++ b/ArduCopter/AP_Arming_Copter.cpp
@@ -100,7 +100,7 @@ bool AP_Arming_Copter::rc_throttle_failsafe_checks(bool display_failure) const
     // likely to pass if the user is relying on no-pulses to detect RC
     // failure.  However, arming is precluded in that case by being in
     // RC failsafe.
-    if (copter.g.failsafe_throttle == FS_THR_DISABLED) {
+    if (copter.g.failsafe_throttle == Copter::FS_THR_Action::DISABLED) {
         return true;
     }
 

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -421,6 +421,7 @@ private:
 
     using FS_GCS_Action = Parameters::FS_GCS_Action;
     using FS_THR_Action = Parameters::FS_THR_Action;
+    using FS_EKF_Action = Parameters::FS_EKF_Action;
 
     // dead reckoning state
     struct {

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -420,6 +420,7 @@ private:
     }
 
     using FS_GCS_Action = Parameters::FS_GCS_Action;
+    using FS_THR_Action = Parameters::FS_THR_Action;
 
     // dead reckoning state
     struct {

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -422,6 +422,7 @@ private:
     using FS_GCS_Action = Parameters::FS_GCS_Action;
     using FS_THR_Action = Parameters::FS_THR_Action;
     using FS_EKF_Action = Parameters::FS_EKF_Action;
+    using WPYawBehavior = Parameters::WPYawBehavior;
 
     // dead reckoning state
     struct {

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -119,7 +119,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Description: Determines how the autopilot controls the yaw during missions and RTL
     // @Values: 0:Never change yaw, 1:Face next waypoint, 2:Face next waypoint except RTL, 3:Face along GPS course
     // @User: Standard
-    GSCALAR(wp_yaw_behavior,  "WP_YAW_BEHAVIOR",    WP_YAW_BEHAVIOR_DEFAULT),
+    GSCALAR(wp_yaw_behavior,  "WP_YAW_BEHAVIOR",    static_cast<float>(WP_YAW_BEHAVIOR_DEFAULT)),
 
     // @Param: FS_THR_ENABLE
     // @DisplayName: Throttle Failsafe Enable

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -269,7 +269,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Description: Controls the action that will be taken when an EKF failsafe is invoked
     // @Values: 0:Report only, 1:Switch to Land mode if current mode requires position, 2:Switch to AltHold mode if current mode requires position, 3:Switch to Land mode from all modes
     // @User: Advanced
-    GSCALAR(fs_ekf_action, "FS_EKF_ACTION",    FS_EKF_ACTION_DEFAULT),
+    GSCALAR(fs_ekf_action, "FS_EKF_ACTION",    static_cast<float>(FS_EKF_ACTION_DEFAULT)),
 
     // @Param: FS_EKF_THRESH
     // @DisplayName: EKF failsafe variance threshold

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -126,7 +126,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Description: The throttle failsafe allows you to configure a software failsafe activated by a setting on the throttle input channel
     // @Values:  0:Disabled,1:Enabled always RTL,2:Enabled Continue with Mission in Auto Mode (Removed in 4.0+),3:Enabled always Land,4:Enabled always SmartRTL or RTL,5:Enabled always SmartRTL or Land,6:Enabled Auto DO_LAND_START/DO_RETURN_PATH_START or RTL,7:Enabled always Brake or Land
     // @User: Standard
-    GSCALAR(failsafe_throttle,  "FS_THR_ENABLE",   FS_THR_ENABLED_ALWAYS_RTL),
+    GSCALAR(failsafe_throttle,  "FS_THR_ENABLE",   static_cast<float>(FS_THR_Action::ALWAYS_RTL)),
 
     // @Param: FS_THR_VALUE
     // @DisplayName: Throttle Failsafe Value

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -425,9 +425,21 @@ public:
     AP_Int16        poshold_brake_rate_degs;    // PosHold flight mode's rotation rate during braking in deg/sec
 #endif
 
+    // Throttle failsafe definitions (FS_THR_ENABLE parameter)
+    enum class FS_THR_Action {
+        DISABLED                 = 0,
+        ALWAYS_RTL               = 1,
+        CONTINUE_MISSION         = 2,    // Removed in 4.0+, now use fs_options
+        ALWAYS_LAND              = 3,
+        ALWAYS_SMARTRTL_OR_RTL   = 4,
+        ALWAYS_SMARTRTL_OR_LAND  = 5,
+        AUTO_RTL_OR_RTL          = 6,
+        BRAKE_OR_LAND            = 7,
+    };
+
     // Throttle
     //
-    AP_Int8         failsafe_throttle;
+    AP_Enum<FS_THR_Action> failsafe_throttle;
     AP_Int16        failsafe_throttle_value;
     AP_Int16        throttle_deadzone;
 

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -419,7 +419,15 @@ public:
 
     AP_Int8         super_simple;
 
-    AP_Int8         wp_yaw_behavior;            // controls how the autopilot controls yaw during missions
+    // Yaw behaviours during missions (WP_YAW_BEHAVIOR parameter)
+    enum class WPYawBehavior {
+        NONE                       = 0,
+        LOOK_AT_NEXT_WP            = 1,
+        LOOK_AT_NEXT_WP_EXCEPT_RTL = 2,
+        LOOK_AHEAD                 = 3,
+    };
+
+    AP_Enum<WPYawBehavior> wp_yaw_behavior;     // controls how the autopilot controls yaw during missions
 
 #if MODE_POSHOLD_ENABLED
     AP_Int16        poshold_brake_rate_degs;    // PosHold flight mode's rotation rate during braking in deg/sec

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -466,7 +466,16 @@ public:
     AP_Int8         disarm_delay;
 
     AP_Int8         land_repositioning;
-    AP_Int8         fs_ekf_action;
+
+    // EKF failsafe definitions (FS_EKF_ACTION parameter)
+    enum class FS_EKF_Action {
+        REPORT_ONLY          = 0,
+        LAND                 = 1,
+        ALTHOLD              = 2,
+        LAND_EVEN_STABILIZE  = 3,
+    };
+
+    AP_Enum<FS_EKF_Action> fs_ekf_action;
     AP_Int8         fs_crash_check;
     AP_Float        fs_ekf_thresh;
     AP_Int16        gcs_pid_mask;

--- a/ArduCopter/autoyaw.cpp
+++ b/ArduCopter/autoyaw.cpp
@@ -35,22 +35,22 @@ void Mode::AutoYaw::set_mode_to_default(bool rtl)
 // set rtl parameter to true if this is during an RTL
 Mode::AutoYaw::Mode Mode::AutoYaw::default_mode(bool rtl) const
 {
-    switch (copter.g.wp_yaw_behavior) {
+    switch ((Copter::WPYawBehavior)copter.g.wp_yaw_behavior) {
 
-    case WP_YAW_BEHAVIOR_NONE:
+    case Copter::WPYawBehavior::NONE:
         return Mode::HOLD;
 
-    case WP_YAW_BEHAVIOR_LOOK_AT_NEXT_WP_EXCEPT_RTL:
+    case Copter::WPYawBehavior::LOOK_AT_NEXT_WP_EXCEPT_RTL:
         if (rtl) {
             return Mode::HOLD;
         } else {
             return Mode::LOOK_AT_NEXT_WP;
         }
 
-    case WP_YAW_BEHAVIOR_LOOK_AHEAD:
+    case Copter::WPYawBehavior::LOOK_AHEAD:
         return Mode::LOOK_AHEAD;
 
-    case WP_YAW_BEHAVIOR_LOOK_AT_NEXT_WP:
+    case Copter::WPYawBehavior::LOOK_AT_NEXT_WP:
     default:
         return Mode::LOOK_AT_NEXT_WP;
     }

--- a/ArduCopter/compassmot.cpp
+++ b/ArduCopter/compassmot.cpp
@@ -102,7 +102,7 @@ MAV_RESULT Copter::mavlink_compassmot(const GCS_MAVLINK &gcs_chan)
     }
 
     // disable throttle failsafe
-    g.failsafe_throttle.set(FS_THR_DISABLED);
+    g.failsafe_throttle.set(FS_THR_Action::DISABLED);
 
     // disable motor compensation
     compass.motor_compensation_type(AP_COMPASS_MOT_COMP_DISABLED);

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -100,7 +100,7 @@
 //////////////////////////////////////////////////////////////////////////////
 //  EKF Failsafe
 #ifndef FS_EKF_ACTION_DEFAULT
- # define FS_EKF_ACTION_DEFAULT         FS_EKF_ACTION_LAND  // EKF failsafe triggers land by default
+ # define FS_EKF_ACTION_DEFAULT         FS_EKF_Action::LAND  // EKF failsafe triggers land by default
 #endif
 #ifndef FS_EKF_THRESHOLD_DEFAULT
  # define FS_EKF_THRESHOLD_DEFAULT      0.8f    // EKF failsafe's default compass and velocity variance threshold above which the EKF failsafe will be triggered

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -56,7 +56,7 @@
 // TradHeli defaults
 #if FRAME_CONFIG == HELI_FRAME
   # define RC_FAST_SPEED                        125
-  # define WP_YAW_BEHAVIOR_DEFAULT              WP_YAW_BEHAVIOR_LOOK_AHEAD
+  # define WP_YAW_BEHAVIOR_DEFAULT              WPYawBehavior::LOOK_AHEAD
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
@@ -452,7 +452,7 @@
 
 // AUTO Mode
 #ifndef WP_YAW_BEHAVIOR_DEFAULT
- # define WP_YAW_BEHAVIOR_DEFAULT   WP_YAW_BEHAVIOR_LOOK_AT_NEXT_WP_EXCEPT_RTL
+ # define WP_YAW_BEHAVIOR_DEFAULT   WPYawBehavior::LOOK_AT_NEXT_WP_EXCEPT_RTL
 #endif
 
 #ifndef YAW_LOOK_AHEAD_MIN_SPEED_MS

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -54,13 +54,6 @@ enum tuning_func {
     TUNING_WP_SPEED_MS =                61, // maximum speed to next waypoint in m/s
 };
 
-// Yaw behaviours during missions - possible values for WP_YAW_BEHAVIOR parameter
-#define WP_YAW_BEHAVIOR_NONE                          0   // auto pilot will never control yaw during missions or rtl (except for DO_CONDITIONAL_YAW command received)
-#define WP_YAW_BEHAVIOR_LOOK_AT_NEXT_WP               1   // auto pilot will face next waypoint or home during rtl
-#define WP_YAW_BEHAVIOR_LOOK_AT_NEXT_WP_EXCEPT_RTL    2   // auto pilot will face next waypoint except when doing RTL at which time it will stay in it's last
-#define WP_YAW_BEHAVIOR_LOOK_AHEAD                    3   // auto pilot will look ahead during missions and rtl (primarily meant for traditional helicopters)
-
-
 // Airmode
 enum class AirMode {
     AIRMODE_NONE,

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -114,12 +114,6 @@ enum LoggingParameters {
 #define MASK_LOG_FTN_FAST               (1UL<<21)
 #define MASK_LOG_ANY                    0xFFFF
 
-// EKF failsafe definitions (FS_EKF_ACTION parameter)
-#define FS_EKF_ACTION_REPORT_ONLY           0
-#define FS_EKF_ACTION_LAND                  1       // switch to LAND mode on EKF failsafe
-#define FS_EKF_ACTION_ALTHOLD               2       // switch to ALTHOLD mode on EKF failsafe
-#define FS_EKF_ACTION_LAND_EVEN_STABILIZE   3       // switch to Land mode on EKF failsafe even if in a manual flight mode like stabilize
-
 // for PILOT_THR_BHV parameter
 #define THR_BEHAVE_FEEDBACK_FROM_MID_STICK (1<<0)
 #define THR_BEHAVE_HIGH_THROTTLE_CANCELS_LAND (1<<1)

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -114,16 +114,6 @@ enum LoggingParameters {
 #define MASK_LOG_FTN_FAST               (1UL<<21)
 #define MASK_LOG_ANY                    0xFFFF
 
-// Radio failsafe definitions (FS_THR parameter)
-#define FS_THR_DISABLED                            0
-#define FS_THR_ENABLED_ALWAYS_RTL                  1
-#define FS_THR_ENABLED_CONTINUE_MISSION            2    // Removed in 4.0+, now use fs_options
-#define FS_THR_ENABLED_ALWAYS_LAND                 3
-#define FS_THR_ENABLED_ALWAYS_SMARTRTL_OR_RTL      4
-#define FS_THR_ENABLED_ALWAYS_SMARTRTL_OR_LAND     5
-#define FS_THR_ENABLED_AUTO_RTL_OR_RTL             6
-#define FS_THR_ENABLED_BRAKE_OR_LAND               7
-
 // EKF failsafe definitions (FS_EKF_ACTION parameter)
 #define FS_EKF_ACTION_REPORT_ONLY           0
 #define FS_EKF_ACTION_LAND                  1       // switch to LAND mode on EKF failsafe

--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -178,7 +178,7 @@ void Copter::failsafe_ekf_event()
     AP_Notify::flags.failsafe_ekf = true;
 
     // True if no action should be taken
-    const bool report_only = g.fs_ekf_action == FS_EKF_ACTION_REPORT_ONLY;
+    const bool report_only = g.fs_ekf_action == FS_EKF_Action::REPORT_ONLY;
 
     // sometimes LAND *does* require GPS so ensure we are in non-GPS land
     const bool landing_with_position = landing_with_GPS();
@@ -187,7 +187,7 @@ void Copter::failsafe_ekf_event()
     }
 
     // does this mode require position?
-    const bool no_action_in_current_mode = !copter.flightmode->requires_position() && (g.fs_ekf_action != FS_EKF_ACTION_LAND_EVEN_STABILIZE);
+    const bool no_action_in_current_mode = !copter.flightmode->requires_position() && (g.fs_ekf_action != FS_EKF_Action::LAND_EVEN_STABILIZE);
 
     if (report_only || landing_with_position || no_action_in_current_mode) {
         gcs().send_text(MAV_SEVERITY_CRITICAL, "EKF Failsafe");
@@ -195,18 +195,18 @@ void Copter::failsafe_ekf_event()
     }
 
     // take action based on fs_ekf_action parameter
-    switch (g.fs_ekf_action) {
-        case FS_EKF_ACTION_REPORT_ONLY:
+    switch ((FS_EKF_Action)g.fs_ekf_action) {
+        case FS_EKF_Action::REPORT_ONLY:
             // Should have early returned above
             break;
-        case FS_EKF_ACTION_ALTHOLD:
+        case FS_EKF_Action::ALTHOLD:
             // AltHold
             if (failsafe.radio || !set_mode(Mode::Number::ALT_HOLD, ModeReason::EKF_FAILSAFE)) {
                 set_mode_land_with_pause(ModeReason::EKF_FAILSAFE);
             }
             break;
-        case FS_EKF_ACTION_LAND:
-        case FS_EKF_ACTION_LAND_EVEN_STABILIZE:
+        case FS_EKF_Action::LAND:
+        case FS_EKF_Action::LAND_EVEN_STABILIZE:
         default:
             set_mode_land_with_pause(ModeReason::EKF_FAILSAFE);
             break;

--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -16,27 +16,27 @@ void Copter::failsafe_radio_on_event()
 
     // set desired action based on FS_THR_ENABLE parameter
     FailsafeAction desired_action;
-    switch (g.failsafe_throttle) {
-        case FS_THR_DISABLED:
+    switch ((FS_THR_Action)g.failsafe_throttle) {
+        case FS_THR_Action::DISABLED:
             desired_action = FailsafeAction::NONE;
             break;
-        case FS_THR_ENABLED_ALWAYS_RTL:
-        case FS_THR_ENABLED_CONTINUE_MISSION:
+        case FS_THR_Action::ALWAYS_RTL:
+        case FS_THR_Action::CONTINUE_MISSION:
             desired_action = FailsafeAction::RTL;
             break;
-        case FS_THR_ENABLED_ALWAYS_SMARTRTL_OR_RTL:
+        case FS_THR_Action::ALWAYS_SMARTRTL_OR_RTL:
             desired_action = FailsafeAction::SMARTRTL;
             break;
-        case FS_THR_ENABLED_ALWAYS_SMARTRTL_OR_LAND:
+        case FS_THR_Action::ALWAYS_SMARTRTL_OR_LAND:
             desired_action = FailsafeAction::SMARTRTL_LAND;
             break;
-        case FS_THR_ENABLED_ALWAYS_LAND:
+        case FS_THR_Action::ALWAYS_LAND:
             desired_action = FailsafeAction::LAND;
             break;
-        case FS_THR_ENABLED_AUTO_RTL_OR_RTL:
+        case FS_THR_Action::AUTO_RTL_OR_RTL:
             desired_action = FailsafeAction::AUTO_DO_LAND_START;
             break;
-        case FS_THR_ENABLED_BRAKE_OR_LAND:
+        case FS_THR_Action::BRAKE_OR_LAND:
             desired_action = FailsafeAction::BRAKE_LAND;
             break;
         default:

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -478,7 +478,7 @@ bool ModeAuto::wp_start(const Location& dest_loc)
 
     // initialise yaw
     // To-Do: reset the yaw only when the previous navigation command is not a WP.  this would allow removing the special check for ROI
-    if (auto_yaw.mode() != AutoYaw::Mode::ROI && !(auto_yaw.mode() == AutoYaw::Mode::FIXED && copter.g.wp_yaw_behavior == WP_YAW_BEHAVIOR_NONE)) {
+    if (auto_yaw.mode() != AutoYaw::Mode::ROI && !(auto_yaw.mode() == AutoYaw::Mode::FIXED && copter.g.wp_yaw_behavior == Copter::WPYawBehavior::NONE)) {
         auto_yaw.set_mode_to_default(false);
     }
 
@@ -1851,7 +1851,7 @@ void ModeAuto::do_spline_wp(const AP_Mission::Mission_Command& cmd)
 
     // initialise yaw
     // To-Do: reset the yaw only when the previous navigation command is not a WP.  this would allow removing the special check for ROI
-    if (auto_yaw.mode() != AutoYaw::Mode::ROI && !(auto_yaw.mode() == AutoYaw::Mode::FIXED && copter.g.wp_yaw_behavior == WP_YAW_BEHAVIOR_NONE)) {
+    if (auto_yaw.mode() != AutoYaw::Mode::ROI && !(auto_yaw.mode() == AutoYaw::Mode::FIXED && copter.g.wp_yaw_behavior == Copter::WPYawBehavior::NONE)) {
         auto_yaw.set_mode_to_default(false);
     }
 

--- a/ArduCopter/mode_turtle.cpp
+++ b/ArduCopter/mode_turtle.cpp
@@ -57,7 +57,7 @@ void ModeTurtle::arm_motors()
     // disable throttle and gcs failsafe
     g.failsafe_throttle.set(Copter::FS_THR_Action::DISABLED);
     g.failsafe_gcs.set(Copter::FS_GCS_Action::DISABLED);
-    g.fs_ekf_action.set(FS_EKF_ACTION_REPORT_ONLY);
+    g.fs_ekf_action.set(Copter::FS_EKF_Action::REPORT_ONLY);
 
     // ensure the arming library is aware of our meddling
     // even if it fails we don't want to prevent people getting into turtle mode

--- a/ArduCopter/mode_turtle.cpp
+++ b/ArduCopter/mode_turtle.cpp
@@ -55,7 +55,7 @@ void ModeTurtle::arm_motors()
     change_motor_direction(true);
 
     // disable throttle and gcs failsafe
-    g.failsafe_throttle.set(FS_THR_DISABLED);
+    g.failsafe_throttle.set(Copter::FS_THR_Action::DISABLED);
     g.failsafe_gcs.set(Copter::FS_GCS_Action::DISABLED);
     g.fs_ekf_action.set(FS_EKF_ACTION_REPORT_ONLY);
 

--- a/ArduCopter/motor_test.cpp
+++ b/ArduCopter/motor_test.cpp
@@ -172,7 +172,7 @@ MAV_RESULT Copter::mavlink_motor_test_start(const GCS_MAVLINK &gcs_chan, uint8_t
             // disable throttle and gps failsafe
             g.failsafe_throttle.set(FS_THR_Action::DISABLED);
             g.failsafe_gcs.set(FS_GCS_Action::DISABLED);
-            g.fs_ekf_action.set(FS_EKF_ACTION_REPORT_ONLY);
+            g.fs_ekf_action.set(FS_EKF_Action::REPORT_ONLY);
 
             // turn on notify leds
             AP_Notify::flags.esc_calibration = true;

--- a/ArduCopter/motor_test.cpp
+++ b/ArduCopter/motor_test.cpp
@@ -170,7 +170,7 @@ MAV_RESULT Copter::mavlink_motor_test_start(const GCS_MAVLINK &gcs_chan, uint8_t
             }
 
             // disable throttle and gps failsafe
-            g.failsafe_throttle.set(FS_THR_DISABLED);
+            g.failsafe_throttle.set(FS_THR_Action::DISABLED);
             g.failsafe_gcs.set(FS_GCS_Action::DISABLED);
             g.fs_ekf_action.set(FS_EKF_ACTION_REPORT_ONLY);
 

--- a/ArduCopter/radio.cpp
+++ b/ArduCopter/radio.cpp
@@ -139,7 +139,7 @@ void Copter::read_radio()
 void Copter::set_throttle_and_failsafe(uint16_t throttle_pwm)
 {
     // if failsafe not enabled pass through throttle and exit
-    if(g.failsafe_throttle == FS_THR_DISABLED) {
+    if(g.failsafe_throttle == FS_THR_Action::DISABLED) {
         set_failsafe_radio(false);
         return;
     }


### PR DESCRIPTION
### Summary

Moves more defines out of defines.h and makes them enum class

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board,copter
CubeOrange,*
```

### Description

Similar to another PR we merged, this makes some define-lists enum-class.  More type safety.
