### PR TITLE
AP_Bootloader: Added board ID reservation block and board ID

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -546,6 +546,9 @@ AP_HW_BrotherHobbyF405v3             5811
 #IDs 5820 ~ 5829 reserved for VimDrones
 AP_HW_VIMDRONES_BMS                  5820
 
+#IDs 5830-5839 reserved for SectionBlue
+AP_HW_SectionBlue_SDP33_CAN          5830
+
 # IDs 6000-6099 reserved for SpektreWorks
 AP_HW_sw-spar-f407                   6000
 AP_HW_sw-boom-f407                   6001


### PR DESCRIPTION
### Summary

Added a reservation of Board IDs and an individual board ID for: AP_HW_SectionBlue_SDP33_CAN


- [X] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request


### Description

Board ID block reservation and board ID addition

