### PR TITLE
.github: Add a missing comma to labels-by-language workflow

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -15,7 +15,7 @@ jobs:
           script: |
             const filenames = (await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
-              repo: context.repo.repo,git 
+              repo: context.repo.repo,git,
               pull_number: context.issue.number,
               per_page: 100,
             })).map(file => file.filename);


### PR DESCRIPTION
### Summary

Add a missing comma to the labels-by-language workflow.
* https://github.com/ArduPilot/ardupilot/actions/workflows/labels.yml
* `SyntaxError: Unexpected identifier 'pull_number'`

> [!NOTE]
> One of the strange things about failing GitHub Actions `pull_request_trigger` jobs is that they will continue to fail until ___after___ they are merged.  This is because `pull_request_trigger` jobs run on the `master` branch, not on the pull request branch.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
