### PR TITLE
Tools: Simplify the installation of `python3-venv`

### DIFF
--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -418,20 +418,13 @@ ARDUPILOT_ROOT=$(realpath "$SCRIPT_DIR/../../")
 PIP_USER_ARGUMENT="--user"
 
 # create a Python venv on more recent releases:
-PYTHON_VENV_PACKAGE=""
-if [ ${RELEASE_CODENAME} == 'bookworm' ]; then
-    PYTHON_VENV_PACKAGE=python3.11-venv
-elif [ ${RELEASE_CODENAME} == 'noble' ]; then
-    PYTHON_VENV_PACKAGE=python3.12-venv
-elif [ ${RELEASE_CODENAME} == 'trixie' ] ||
+if [ ${RELEASE_CODENAME} == 'bookworm' ] ||
+     [ ${RELEASE_CODENAME} == 'trixie' ] ||
+     [ ${RELEASE_CODENAME} == 'noble' ] ||
      [ ${RELEASE_CODENAME} == 'plucky' ] ||
      [ ${RELEASE_CODENAME} == 'questing' ] ||
      false; then
-    PYTHON_VENV_PACKAGE=python3-venv
-fi
-
-if [ -n "$PYTHON_VENV_PACKAGE" ]; then
-    $APT_GET install $PYTHON_VENV_PACKAGE
+    $APT_GET install python3-venv
 
     # Check if venv already exists in ARDUPILOT_ROOT (check both venv-ardupilot and venv)
     VENV_PATH=""
@@ -469,7 +462,7 @@ fi
 
 # try update packaging, setuptools and wheel before installing pip package that may need compilation
 SETUPTOOLS="setuptools"
-$PIP install $PIP_USER_ARGUMENT -U pip packaging $SETUPTOOLS wheel
+$PIP install $PIP_USER_ARGUMENT --upgrade pip packaging $SETUPTOOLS wheel
 
 if [ "$GITHUB_ACTIONS" == "true" ]; then
     PIP_USER_ARGUMENT+=" --progress-bar off"
@@ -482,7 +475,7 @@ if [ ${RELEASE_CODENAME} == 'trixie' ] ||
    [ ${RELEASE_CODENAME} == 'questing' ] ||
    false; then
     # must do this ahead of wxPython pip3 run :-/
-    $PIP install $PIP_USER_ARGUMENT -U attrdict3
+    $PIP install $PIP_USER_ARGUMENT --upgrade attrdict3
 fi
 
 # install Python packages one-at-a-time so it is clear which package
@@ -495,20 +488,20 @@ for PACKAGE in $PYTHON_PKGS; do
             jammy)
                 echo "##### Adding wxpython wheel repository for faster installation"
                 WXPYTHON_WHEEL_REPO="https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04"
-                time $PIP install $PIP_USER_ARGUMENT -U -f $WXPYTHON_WHEEL_REPO $PACKAGE
+                time $PIP install $PIP_USER_ARGUMENT --upgrade --find-links $WXPYTHON_WHEEL_REPO $PACKAGE
                 ;;
             noble)
                 echo "##### Adding wxpython wheel repository for faster installation"
                 WXPYTHON_WHEEL_REPO="https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-24.04"
-                time $PIP install $PIP_USER_ARGUMENT -U -f $WXPYTHON_WHEEL_REPO $PACKAGE
+                time $PIP install $PIP_USER_ARGUMENT --upgrade --find-links $WXPYTHON_WHEEL_REPO $PACKAGE
                 ;;
             *)
                 echo "##### Installing wxpython from PyPI (no specific wheel repository for this release)"
-                time $PIP install $PIP_USER_ARGUMENT -U $PACKAGE
+                time $PIP install $PIP_USER_ARGUMENT --upgrade $PACKAGE
                 ;;
         esac
     else
-        time $PIP install $PIP_USER_ARGUMENT -U $PACKAGE
+        time $PIP install $PIP_USER_ARGUMENT --upgrade $PACKAGE
     fi
 done
 


### PR DESCRIPTION
### Summary

`python3-venv` works on all currently supported Debian and Ubuntu distros, so let's simplify the installation logic.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below ~(e.g. SITL)~
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description
`ubuntu:jammy` and `debian:bullseye` also work the same way.  Should we change them as well?

Also,

`pip install -U` can be quite opaque to readers because pip install currently has six `--u*` options, including `--user`.

`pip install --upgrade` makes the intention clearer in code that others will read.

% `python3 -m pip install --help | grep "\-\-u"`
```
  --user                      Install to the Python user install directory for
  -U, --upgrade               Upgrade all specified packages to the newest
  --upgrade-strategy <upgrade_strategy>
  --use-pep517                Use PEP 517 for building source distributions
  --use-feature <feature>     Enable new functionality, that may be backward
  --use-deprecated <feature>  Enable deprecated functionality, that will be
``` 
% `python3 -m pip install --help | grep "\-\-f"`
```
  --force-reinstall           Reinstall all packages even if they are already
                              at --find-links URLs
  -f, --find-links <url>      If a URL or path to an html file, then parse for
```
### How was this tested?

% `docker run -it ubuntu:noble`
```
# apt update && \
    DEBIAN_FRONTEND=noninteractive apt install --yes lsb-release python3-venv && \
    lsb_release -ds && \
    python3 -m venv --upgrade-deps .venv && \
    source .venv/bin/activate && 
    python -V && \
    pip -V  

Ubuntu 24.04.4 LTS
Python 3.12.3
pip 26.0.1 from /.venv/lib/python3.12/site-packages/pip (python 3.12)
```
---
% `docker run -it debian:bookworm`
```
Debian GNU/Linux 12 (bookworm)
Python 3.11.2
pip 26.0.1 from /.venv/lib/python3.11/site-packages/pip (python 3.11)
```
---
% `docker run -it ubuntu:jammy`
```
Ubuntu 22.04.5 LTS
Python 3.10.12
pip 26.0.1 from /.venv/lib/python3.10/site-packages/pip (python 3.10)
```
---
% `docker run -it debian:bullseye`
```
Debian GNU/Linux 11 (bullseye)
Python 3.9.2
pip 26.0.1 from /.venv/lib/python3.9/site-packages/pip (python 3.9)
```
---
> [!NOTE]
> This month, Plucky will probably disappear from https://ports.ubuntu.com/ubuntu-ports/dists