### PR TITLE
.github: Run luacheck v1.2.0 in CI

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,3 +20,9 @@ jobs:
     - run: python3 -m pip install --upgrade pip
     - run: python3 -m pip install pytest
     - run: PYTHONPATH="." pytest tests/test_pre_commit_copyright.py
+
+  luacheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: lunarmodules/luacheck@v1

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,16 @@
+std = "lua53"  -- Lua 5.3 standard
+
+max_line_length = 678
+
+ignore = {
+  "111",  -- setting non-standard global
+  "112",  -- mutating an undefined global variable.
+  "113",  -- accessing undefined variable
+  "212",  -- Unused argument
+  "214",  -- used variable with unused hint
+  "611",  -- line consists only of whitespace
+  "612",  -- trailing whitespace
+  "613",  -- trailing whitespace in string
+  "614",  -- trailing whitespace in comment
+  "621",  -- inconsistent indentation
+}


### PR DESCRIPTION
### Summary

Run [luacheck](https://luacheck.readthedocs.io) in GitHub Actions CI.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

* https://luacheck.readthedocs.io
* https://github.com/lunarmodules/luacheck
* https://github.com/lunarmodules/luacheck/?tab=readme-ov-file#use-as-a-ci-job

> Total: 12812 warnings / 0 errors in 256 files
* https://luacheck.readthedocs.io/en/stable/config.html

As discussed below, we already run an old version of luacheck in GitHub Actions, which finds no issues.

Ubuntu | Luacheck
---:| ---
22.04 LTS | v0.25.0
24.04 LTS | v1.1.2
26.04 LTS | v1.2.0

The GitHub Action from the luacheck team enables us to run the current version, which raises 12k+ warnings.

With the `.luacheckrc` file:
* https://github.com/ArduPilot/ardupilot/actions/runs/24320180226/job/71004785009?pr=32755
> Total: 0 warnings / 0 errors in 256 files