### PR TITLE
Remove rst-style underlining from newly-introduced markdown, add regression check

### DIFF
--- a/Tools/scripts/check_branch_conventions.py
+++ b/Tools/scripts/check_branch_conventions.py
@@ -372,6 +372,42 @@ class CheckBranchConventions(build_script_base.BuildScriptBase):
                 print(f"{PASS} No submodule reference changes to check.")
         return ok
 
+    def check_markdown_rst_underlines(self) -> bool:
+        '''flag setext/RST underline-style headings in changed markdown files'''
+        changed_md = self.run_git(
+            ["diff", "--name-only", "--diff-filter=AM",
+             f"{self.base_branch}...HEAD", "--", "*.md"],
+            show_output=False,
+        ).strip()
+        if not changed_md:
+            print(f"{PASS} No markdown files changed (underline heading check).")
+            return True
+
+        underline_re = re.compile(r'^([=\-~^#+*])\1{2,}$')
+        errors = []
+        for path in changed_md.splitlines():
+            path = path.strip()
+            if not path or not os.path.exists(path):
+                continue
+            with open(path, encoding="utf-8", errors="replace") as fh:
+                prev_line = ""
+                for lineno, raw in enumerate(fh, 1):
+                    line = raw.rstrip("\n")
+                    if (underline_re.match(line)
+                            and len(line.strip()) == len(prev_line.strip())):
+                        errors.append((path, lineno, line.strip()))
+                    prev_line = line
+
+        if errors:
+            print(f"{FAIL} Setext/RST underline-style headings found in markdown file(s):")
+            for path, lineno, text in errors:
+                print(f"         {path}:{lineno}: {text!r}")
+            print("       Use ATX-style headings (# prefix) instead.")
+            return False
+
+        print(f"{PASS} No setext/RST underline headings in changed markdown files.")
+        return True
+
     def check_markdown(self) -> bool:
         changed_md = self.run_git(
             ["diff", "--name-only", "--diff-filter=AM",
@@ -417,6 +453,7 @@ class CheckBranchConventions(build_script_base.BuildScriptBase):
             self.check_submodule_isolation(),
             self.check_submodule_references_exist(),
             self.check_markdown(),
+            self.check_markdown_rst_underlines(),
         ]
 
         failures = results.count(False)

--- a/libraries/AP_HAL_ChibiOS/hwdef/PrincipIoTH7Pi/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PrincipIoTH7Pi/README.md
@@ -1,7 +1,4 @@
-
-================
-PrincipIoT H7 Pi
-================
+# PrincipIoT H7 Pi
 
 The PrincipIoT H7 Pi autopilot is manufactured by
 [PrincipIoT](https://principiot.com>). It's designed to be paired with a
@@ -9,13 +6,11 @@ Raspberry Pi Zero 2 for low cost onboard computing applications.
 
 ![PrincipIoT H7 Pi](H7-Pi-board-image.jpg)
 
-Where to Buy
-============
+## Where to Buy
 
 [PrincipIoT Website](https://principiot.com>)
 
-Specifications
-==============
+## Specifications
 
 - Processor
 
@@ -55,14 +50,12 @@ Specifications
 For more information, see the
 [PrincipIoT Wiki](https://principiot.gitbook.io/principiot-docs/h7-pi/).
 
-Pinout
-======
+## Pinout
 
 ![Front side](H7-Pi-Rev-3-Pinout-Front.png)
 ![Back side](H7-Pi-Rev-3-Pinout-Back.png)
 
-UART Mapping
-============
+## UART Mapping
 
 The UARTs are marked in the above pinouts. The RX pin is the receive pin
 for the MCU (input). The TX pin is the transmit pin for the MCU (output).
@@ -83,8 +76,7 @@ USART3 is wired to the UART on the 40 pin Raspberry Pi header and the external
 UART connector.
 UART7 is receive only.
 
-RC input
-========
+## RC input
 
 The PrincipIoT H7 Pi defaults SERIAL 6 as RC input. It can be used with any
 ArduPilot compatible serial protocol. It does not support PPM protocols.
@@ -100,8 +92,7 @@ SBUS/DSM would connect to UART8 RX input.
 Any other UART can be used for RC system connections in ArduPilot also, see
 :ref:`common-rc-systems` for details.
 
-PWM Outputs
-===========
+## PWM Outputs
 
 The PrincipIoT H7 Pi controller supports up to 8 PWM outputs.
 
@@ -119,8 +110,7 @@ All outputs are directly wired to the H743 MCU. All 8 outputs support normal
 PWM output formats. All outputs support DShot, outputs 1-6 support
 Bi-Directional DShot.
 
-Analog Video and OSD Support
-============================
+## Analog Video and OSD Support
 
 The Raspberry Pi Zero 2 support analog video output through a pad on its PCB.
 Installing the included POGO pin connects this pad to the H7 Pi and routes the
@@ -131,30 +121,26 @@ The SH1.0-5P connector supports a connection to a VTX. Protocol defaults to
 DisplayPort. Pin 1 of the connector is +10V so be careful not to connect this
 to a peripheral requiring 5v. DisplayPort OSD is enabled by default on SERIAL5.
 
-VTX power control
-=================
+## VTX power control
 
 GPIO 81 controls the VTX BEC output to pins marked "10V" and is included on
 the HD VTX connector. Setting this GPIO high turns off the voltage regulator.
 By default this pin is set low (regulator on) at boot and is controlled by
 RELAY2.
 
-Camera Switch
-=============
+## Camera Switch
 
 GPIO 82 controls the PINIO2 GPIO pin which can be used as a camera switch or
 other user defined function. It defaults to low on boot.
 
-Compass
-=======
+## Compass
 
 An on-board IIS2MDC compass is provided. This compass is on the external I2C bus.
 Do not connect an external IIS2MDC compass or both may not be detected as they
 only have one address. If you need to use an external compass, use a different
 model or desolder the onboard one.
 
-GPIOs
-=====
+## GPIOs
 
 |Pin           |GPIO Number |Function        |
 |--------------|------------|----------------|
@@ -173,8 +159,7 @@ GPIOs
 |LED0          | 90         |Blue LED        |
 |LED1          | 91         |Green LED       |
 
-Battery Monitor
-===============
+## Battery Monitor
 
 The board has a internal voltage sensor and connections on the ESC connector
 for an external current sensor input.
@@ -188,15 +173,13 @@ The default battery parameters are:
 - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 11.0
 - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 40
 
-Firmware
-========
+## Firmware
 
 Firmware for the PrincipIoT H7 Pi is available from
 [ArduPilot Firmware Server](https://firmware.ardupilot.org) under
 the `PrincipIoTH7Pi` target.
 
-Loading Firmware
-================
+## Loading Firmware
 
 To flash firmware initially, connect USB while holding the bootloader
 button and use DFU to load the `with_bl.hex` file. Subsequent updates can


### PR DESCRIPTION
### Summary

Fixes regression in markdown sanity, adds a regression check

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

When bug is re-introduced;
```
Checking 2 commit(s) since master...

✓ No merge commits.
✓ No fixup! commits.
✓ All commit messages have well-formed subsystem tags.
✓ All commit subject lines within 160 characters.
✓ No unacceptable author emails.
✓ All submodule updates are isolated in their own commits.
~ markdownlint-cli2 not installed.
✗ Setext/RST underline-style headings found in markdown file(s):
         libraries/AP_HAL_ChibiOS/hwdef/PrincipIoTH7Pi/README.md:10: '============'
       Use ATX-style headings (# prefix) instead.

1 check(s) failed.
```

### Description

Fixes new markdown to remove udnerlines (it's the only markdown file in-tree which uses them)

Makes sure they can't sneak in again!
