### PR TITLE
AC_PosControl: compensate for velocity FF when initializing controller

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -557,7 +557,10 @@ void AC_PosControl::NE_init_controller()
     _pos_target_ned_m.xy() = _pos_estimate_ned_m.xy();
     _pos_desired_ned_m.xy() = _pos_target_ned_m.xy() - _pos_offset_ned_m.xy();
 
-    _vel_target_ned_ms.xy() = _vel_estimate_ned_ms.xy();
+    // Set velocity target so that P and FF sum to zero on the first cycle:
+    //   0 = (target - measurement) * kP + target * kFF
+    //   target = measurement * kP / (kP + kFF)
+    _vel_target_ned_ms.xy() = _vel_estimate_ned_ms.xy() * (_pid_vel_ne_m.kP() / (_pid_vel_ne_m.kP() + MAX(_pid_vel_ne_m.ff(), 0)));
     _vel_desired_ned_ms.xy() = _vel_target_ned_ms.xy() - _vel_offset_ned_ms.xy();
 
     // Set desired acceleration to zero because raw acceleration is prone to noise
@@ -574,9 +577,7 @@ void AC_PosControl::NE_init_controller()
 
     // initialise I terms from lean angles
     _pid_vel_ne_m.reset_filter();
-    // initialise the I term to (_accel_target_ned_mss - _accel_desired_ned_mss)
-    // _accel_desired_ned_mss is zero and can be removed from the equation
-    _pid_vel_ne_m.set_integrator((_accel_target_ned_mss.xy() - _vel_target_ned_ms.xy() * _pid_vel_ne_m.ff()));
+    _pid_vel_ne_m.set_integrator(_accel_target_ned_mss.xy());
 
     // initialise ekf xy reset handler
     NE_init_ekf_reset();
@@ -896,7 +897,10 @@ void AC_PosControl::D_init_controller()
     _pos_target_ned_m.z = _pos_estimate_ned_m.z;
     _pos_desired_ned_m.z = _pos_target_ned_m.z - _pos_offset_ned_m.z;
 
-    _vel_target_ned_ms.z = _vel_estimate_ned_ms.z;
+    // Set velocity target so that P and FF sum to zero on the first cycle:
+    //   0 = (target - measurement) * kP + target * kFF
+    //   target = measurement * kP / (kP + kFF)
+    _vel_target_ned_ms.z = _vel_estimate_ned_ms.z * (_pid_vel_d_m.kP() / (_pid_vel_d_m.kP() + MAX(_pid_vel_d_m.ff(), 0)));
     _vel_desired_ned_ms.z = _vel_target_ned_ms.z - _vel_offset_ned_ms.z;
 
     // Reset I term of velocity PID


### PR DESCRIPTION
### Summary

Adjust the velocity target during NE and D controller initialization so the velocity PID P and FF terms sum to zero on the first cycle, eliminating a transient bump on controller init
Simplify integrator initialization by removing the now-unnecessary FF compensation from set_integrator

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

SITL only.

### Description

When a position controller is initialized (e.g. on mode switch), the velocity target was set directly to the current velocity estimate. With a non-zero feed-forward gain, this caused a net output on the first cycle because P * (target - measurement) is zero but FF * target is not, producing a transient.

The fix sets the velocity target to:
`target = measurement * kP / (kP + kFF)`
so that P * (target - measurement) + FF * target = 0 on the first cycle. This is applied to both the NE (horizontal) and D (vertical) init paths.

Since the velocity target now correctly accounts for FF, the integrator init simplifies to just the current acceleration target without needing to subtract the FF term.