### PR TITLE
autotest: add test for Rover simple avoidance

### DIFF
--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6050,6 +6050,34 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         if abs(m.distance - want_range) > 0.5:
             raise NotAchievedException("Expected %fm got %fm" % (want_range, m.distance))
 
+    def SimpleAvoidance(self):
+        '''test AVOID_ENABLE=7 simple avoidance'''
+        # the following magic numbers correspond to the post locations in SITL
+        home_string = "%s,%s,%s,%s" % (51.8752066, 14.6487840, 54.15, 231)
+
+        params = {
+            "SIM_SONAR_ROT": 0,
+            "AVOID_ENABLE": 7,
+            "PRX1_TYPE": 4,
+        }
+        params.update(self.analog_rangefinder_parameters())
+        self.set_parameters(params)
+
+        self.customise_SITL_commandline([
+            "--home", home_string,
+        ])
+        self.wait_ready_to_arm()
+        if self.mavproxy is not None:
+            self.mavproxy.send('script /tmp/post-locations.scr\n')
+
+        self.change_mode('STEERING')
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        self.set_rc(3, 2000)
+        self.delay_sim_time(10)
+        self.set_rc(3, 1000)
+        self.disarm_vehicle()
+
     def AIS(self):
         '''Test AIS receiver'''
         self.customise_SITL_commandline([
@@ -7551,6 +7579,7 @@ return update()
             self.REQUIRE_LOCATION_FOR_ARMING,
             self.GetMessageInterval,
             self.SafetySwitch,
+            self.SimpleAvoidance,
             self.ThrottleFailsafe,
             self.DriveEachFrame,
             self.AP_ROVER_AUTO_ARM_ONCE_ENABLED,


### PR DESCRIPTION
### Summary

Adds a test that Rover simple avoidance works


### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<img width="1425" height="871" alt="image" src="https://github.com/user-attachments/assets/c25a7cfe-db40-4012-8f7a-df06b440fedf" />

```
./Tools/autotest/autotest.py --map --speedup 1  build.Rover test.Rover.SimpleAvoidance
```


### Description

(actually entirely hand-written despite branch name)

NOTE: still needs to be turned into a test with a couple of wait_groundspeed calls!
