### PR TITLE
AP_Scripting: Function `setfenv` was removed in Lua >= v5.2

### DIFF
--- a/libraries/AP_Scripting/tests/luacheck.lua
+++ b/libraries/AP_Scripting/tests/luacheck.lua
@@ -16,7 +16,14 @@ stds.ArduPilot = {}
 stds.ArduPilot.read_globals = {}
 
 local env = setmetatable({}, {__index = _G})
-assert(pcall(setfenv(assert(loadfile("libraries/AP_Scripting/docs/docs.lua")), env)))
+local docs_loader
+if _VERSION == "Lua 5.1" then
+    docs_loader = assert(loadfile("libraries/AP_Scripting/docs/docs.lua"))
+    setfenv(docs_loader, env)
+else
+    docs_loader = assert(loadfile("libraries/AP_Scripting/docs/docs.lua", "t", env))
+end
+assert(pcall(docs_loader))
 
 for key, value in pairs(env) do
     local singleton = { other_fields = false }


### PR DESCRIPTION
## Summary
Function `setfenv` was removed in Lua >= v5.2.  https://www.lua.org/manual/5.2/manual.html#8.2

Fix a Lua version compatibility in `libraries/AP_Scripting/tests/luacheck.lua` by replacing unconditional `setfenv` usage with a Lua-version-aware loader path.

## Details
- There might be better ways to fix this!!
- Lua 5.1: load chunk with `loadfile(path)` and apply `setfenv`
- Lua >= 5.2: load chunk with `loadfile(path, "t", env)`
- Execute loaded chunk with `pcall`

This is the only call to `setenv` in the codebase:
* https://github.com/search?q=repo:ArduPilot/ardupilot+setfenv

## Testing
% `brew install luacheck`
% `luacheck --version ` # Luacheck: 1.2.0
% `Tools/scripts/run_luacheck.sh`

Replicates the two warnings discovered and fixed in:
* #32734

https://github.com/cclauss/itinerant-tester/actions/workflows/itinerant_luacheck.yml

## AI Assistance
This pull request was prepared with AI assistance (GitHub Copilot).

@IamPete1, your review please.
