### PR TITLE
Sub: Parameters.h: fix outdated default lights output config

### DIFF
--- a/ArduSub/Parameters.h
+++ b/ArduSub/Parameters.h
@@ -461,7 +461,7 @@ static const struct AP_Param::defaults_table_struct defaults_table[] = {
 #if AP_BARO_PROBE_EXT_PARAMETER_ENABLED
     { "BARO_PROBE_EXT",      768},
 #endif
-    { "SERVO9_FUNCTION",     59},    // k_rcin9, lights 1
+    { "SERVO9_FUNCTION",     181},   // k_lights1
     { "SERVO10_FUNCTION",    7},     // k_mount_tilt
 #endif
 };


### PR DESCRIPTION
### Summary

Fixes the default servo configuration for lights control on non-Navigator flight controller boards.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

This section of the default params seems to have been missed during #29863, when the migration was made from RCIN being overloaded as lights 1 output to there being a dedicated value for it.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
