### PR TITLE
.github: Upgrade from luacheck v0.25.0 to v1.1.2

### DIFF
--- a/.github/workflows/test_scripting.yml
+++ b/.github/workflows/test_scripting.yml
@@ -8,6 +8,7 @@ on:
       - '**.lua'
       - 'Tools/scripts/run_lua_language_check.py'
       - 'Tools/scripts/run_luacheck.sh'
+      - '.github/workflows/test_scripting.yml'
 
   pull_request:
     paths: # only run for scripting changes
@@ -16,6 +17,7 @@ on:
       - '**.lua'
       - 'Tools/scripts/run_lua_language_check.py'
       - 'Tools/scripts/run_luacheck.sh'
+      - '.github/workflows/test_scripting.yml'
 
   workflow_dispatch:
 
@@ -25,7 +27,7 @@ concurrency:
 
 jobs:
   test-scripting:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: ardupilot/ardupilot-dev-base:v0.1.3
     steps:
       # git checkout the PR
@@ -43,6 +45,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get -y install lua-check
+          luacheck --version
           ./Tools/scripts/run_luacheck.sh
 
       - name: Register lua language server problem matcher


### PR DESCRIPTION
### Summary

<!-- Put a one or two-line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below ~(e.g. SITL)~
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

% `apt-get install lua-check`
Ubuntu | luacheck
---:| ---
22.04 LTS | v0.25.0
24.04 LTS | v1.1.2
26.04 LTS | v1.2.0

% `docker run -it ubuntu:24.04`
\# `apt update && DEBIAN_FRONTEND=noninteractive apt install --yes lsb-release lua-check && lsb_release -ds && luacheck --version`

### How was this tested?
See:
* #32763
* https://github.com/ArduPilot/ardupilot/actions/workflows/test_scripting.yml