### PR TITLE
AP_NavEKF3: stop leaking raw GPS location when GPS is not the position source

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -11623,6 +11623,55 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             raise NotAchievedException("Changed to ALT_HOLD with no altitude estimate")
         self.disarm_vehicle(force=True)
 
+    def EK3_NoGPSLeakWhenNotSource(self):
+        '''verify EKF does not leak GPS position when GPS is not the configured source'''
+        # With EKF configured to use optical flow (POSXY source is
+        # not GPS) and GPS simultaneously healthy, verify the
+        # reported vehicle position does not track a simulated GPS
+        # glitch.  On master, NavEKF3_core::getGPSLLH() returns the
+        # raw GPS fix irrespective of the configured POSXY source,
+        # so getLLH() fallbacks leak the glitched GPS lat/lon to
+        # callers (including GCS_MAVLINK::send_global_position_int
+        # which ignores the return value of ahrs.get_location()).
+        # This bypasses the EKF's source configuration and causes
+        # vehicle code to follow GPS glitches/spoofing that the EKF
+        # has correctly rejected.
+        self.set_parameters({
+            "EK3_SRC1_POSXY": 5,   # OPTFLOW (no optflow data provided)
+            "EK3_SRC1_VELXY": 5,   # OPTFLOW
+            "EK3_SRC1_POSZ": 1,    # BARO
+            "EK3_SRC1_VELZ": 0,    # None
+            "AHRS_EKF_TYPE": 3,
+        })
+        self.reboot_sitl()
+
+        # allow EKF to initialise: validOrigin set from GPS, filter
+        # reaches steady AID_NONE state
+        self.wait_statustext("EKF3 IMU0 initialised", timeout=30)
+        self.delay_sim_time(20)
+
+        # capture baseline reported position
+        m = self.assert_receive_message('GLOBAL_POSITION_INT')
+        baseline_lat = m.lat
+        baseline_lon = m.lon
+        self.progress("Baseline: lat=%d lon=%d" % (baseline_lat, baseline_lon))
+
+        # glitch simulated GPS by ~0.005 deg latitude (~555 m north)
+        self.set_parameter("SIM_GPS1_GLTCH_X", 0.005)
+        self.delay_sim_time(5)
+
+        m = self.assert_receive_message('GLOBAL_POSITION_INT')
+        lat_change_deg = abs(m.lat - baseline_lat) * 1e-7
+        self.progress("After GPS glitch: lat=%d lon=%d (baseline lat=%d, change=%.6f deg)" %
+                      (m.lat, m.lon, baseline_lat, lat_change_deg))
+
+        if lat_change_deg > 0.001:
+            raise NotAchievedException(
+                "GPS position leaked into reported location despite "
+                "EK3_SRC1_POSXY=OPTFLOW: baseline lat %d, after glitch %d "
+                "(delta %.6f deg)" %
+                (baseline_lat, m.lat, lat_change_deg))
+
     def EKFSource(self):
         '''Check EKF Source Prearms work'''
         self.wait_ready_to_arm()
@@ -16608,6 +16657,7 @@ return update, 1000
             self.CRSF,
             self.MotorTest,
             self.AltEstimation,
+            self.EK3_NoGPSLeakWhenNotSource,
             self.EKFSource,
             self.GSF,
             self.GSF_reset,

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -381,7 +381,14 @@ bool NavEKF3_core::getLLH(Location &loc) const
 bool NavEKF3_core::getGPSLLH(Location &loc) const
 {
     const auto &gps = dal.gps();
-    if ((gps.status(selected_gps) >= AP_GPS_FixType::FIX_3D)) {
+    // Only report a raw GPS location when GPS is the configured
+    // position source.  Otherwise getLLH() fallbacks would leak the
+    // GPS fix to callers (e.g. GLOBAL_POSITION_INT) despite the EKF
+    // being configured to ignore GPS for position this this ignores
+    // the source set configuration and causes vehicle code to follow
+    // GPS glitches/spoofing that the EKF has correctly rejected.
+    if (frontend->sources.getPosXYSource(core_index) == AP_NavEKF_Source::SourceXY::GPS &&
+        gps.status(selected_gps) >= AP_GPS_FixType::FIX_3D) {
         loc = gps.location(selected_gps);
         return true;
     }


### PR DESCRIPTION
## Summary

When `EK3_SRC1_POSXY` is set to a non-GPS source (e.g. OPTFLOW, EXTNAV, BEACON) but GPS is still physically present and healthy, the EKF leaks the raw GPS fix into `ahrs.get_location()`. Any caller that does not check the return value -- notably `GCS_MAVLINK::send_global_position_int()` (`UNUSED_RESULT(ahrs.get_location(...))`) -- publishes raw GPS lat/lon to the GCS, bypassing the EKF's source configuration entirely. A spoofed or jammed GPS that the EKF has correctly rejected for position fusion still ends up driving the reported vehicle location.

## Root cause

`NavEKF3_core::getLLH()` falls back to `getGPSLLH()` in several paths (`PV_AidingMode == AID_NONE`, or when `filterStatus.flags.horiz_pos_abs`/`horiz_pos_rel` are unset). On master, `getGPSLLH()` returns the raw GPS fix whenever GPS has a 3D fix -- no check that GPS is the configured position source.

## Fix

Add a POSXY-source guard to `getGPSLLH()`:

```cpp
if (frontend->sources.getPosXYSource(core_index) == AP_NavEKF_Source::SourceXY::GPS &&
    gps.status(selected_gps) >= AP_GPS_FixType::FIX_3D) {
    loc = gps.location(selected_gps);
    return true;
}
return false;
```

This is the minimum change required to fix the leak. The surrounding `readGpsData()` / `getPosNE()` guards from the broader original change (see Ancestry) are deliberately not included here.

## Test

`EK3_NoGPSLeakWhenNotSource` (added in this PR):

1. Reboot with `EK3_SRC1_POSXY=OPTFLOW`. No optflow data is provided, so the EKF reaches `AID_NONE` with `validOrigin=true` (origin set from GPS during init).
2. Capture baseline reported `GLOBAL_POSITION_INT.lat`.
3. Set `SIM_GPS1_GLTCH_X=0.005` (~555 m north glitch).
4. Capture reported lat after glitch.
5. Fail if the lat changed by more than 0.001 deg (i.e. if the GPS glitch leaked through).

On master: `delta = 0.005 deg` exactly -- the reported position is the raw glitched GPS.
With the fix: `delta = 0.000 deg` -- reported position is the EKF's own state.

Deterministic across repeated isolated runs.

## Ancestry

The guard matches the `getGPSLLH` piece of @tridge's commit on the `pr-ekf3-height-datum` branch (part of PR #32400). That commit also added guards to `readGpsData()` and `getPosNE()`; those are not included here:

- **`readGpsData` guard (dropped)**: @rmackay9 flagged this in #32400 -- keep reading GPS so scripts can see innovations. This PR does not change `readGpsData()` at all.
- **`getPosNE` guard (not included)**: `getPosNE()` already returns `false` in the leak path, so well-behaved callers see the signal. Defence-in-depth only; omitted to keep the scope minimal. Can be added as a follow-up if reviewers want it.

This PR is independent of the in-flight #32768 (baro drift on arm) -- different files, different bug.

## Test plan

Passing on this branch:
- [x] `EK3_NoGPSLeakWhenNotSource` (new; fails on master, passes with fix, deterministic 3/3)
- [x] `EKFSource`, `OpticalFlow`, `OpticalFlowLocation`, `FarOrigin`, `VisionPosition`, `AltEstimation`, `AutoRTL`