### PR TITLE
AP_NavEKF3: flush baro and output observer buffers in resetHeightDatum

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -8205,6 +8205,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.PreflightRebootComponent,
             self.UTMGlobalPosition,
             self.UTMGlobalPositionWaypoint,
+            self.EK3HeightDatumResetFlushesBuffers,
         ]
 
     def UTMGlobalPositionWaypoint(self):
@@ -8271,6 +8272,92 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             "flight_state": mavutil.mavlink.UTM_FLIGHT_STATE_AIRBORNE,
         }, poll=True)
         self.fly_home_land_and_disarm()
+
+    def EK3HeightDatumResetFlushesBuffers(self):
+        '''Verify resetHeightDatum flushes baro and output observer buffers'''
+        # Plane::update_home() runs every 5 s while disarmed (with
+        # GPS lock) and calls ahrs.resetHeightDatum() after a baro
+        # recalibration.  Without the buffer-flush fix, stale pre-
+        # recalibration baro samples in storedBaro continue to be
+        # fused as delayed observations after the reset, producing
+        # a brief altitude transient (~0.3-0.5 m).  With the fix
+        # storedBaro and the output observer buffers are cleared
+        # so reported altitude stays near zero post-reset.
+        #
+        # The default 5 s update_home cadence does not let drift
+        # accumulate enough to make the transient unambiguous, so
+        # we suspend periodic resets (HOME_RESET_ALT=-1), inject
+        # drift, then re-enable to fire one observable reset.
+        #
+        # resetHeightDatum is a no-op while !onGround in the EKF, so
+        # the test must start from a known on-ground state.  Earlier
+        # tests in PlaneTests1b can leave the simulated aircraft
+        # airborne (e.g. mid-descent), in which case Plane's
+        # barometer.update_calibration() would still run while the
+        # EKF reset was skipped, producing a baro-vs-EKF discontinuity
+        # that the EKF then chases via the slow baroHgtOffset filter
+        # -- exactly the post-reset transient this test is meant to
+        # rule out.  Reboot so the SITL aircraft is reliably on the
+        # ground at the start of the test.
+        self.reboot_sitl()
+        self.wait_ready_to_arm()
+
+        # suspend periodic resets so baro drift can accumulate
+        self.set_parameter("HOME_RESET_ALT", -1)
+        self.delay_sim_time(2)
+
+        # populate storedBaro with samples offset from where the
+        # post-recalibration ground reference will sit.  4 s of
+        # 0.5 m/s drift offsets the buffer by ~2 m -- well above
+        # natural noise so any post-reset transient is unambiguous.
+        drift_start_us = int(self.get_sim_time() * 1.0e6)
+        self.set_parameter("SIM_BARO_DRIFT", 0.5)
+        self.delay_sim_time(4)
+        self.set_parameter("SIM_BARO_DRIFT", 0)
+
+        # re-enable periodic resets; the next 5 s tick fires
+        # update_home -> resetHeightDatum
+        self.set_parameter("HOME_RESET_ALT", 0)
+        self.delay_sim_time(8)
+
+        # find the reset in the dataflash log: PD jumps by >0.5 m
+        # between adjacent samples when resetHeightDatum fires
+        # (drift makes PD change at ~0.5 m/s, far slower than
+        # one sample interval).  Then measure peak |PD| in the
+        # 2 s window post-reset.
+        dfreader = self.dfreader_for_current_onboard_log()
+        last_pd = None
+        reset_us = None
+        peak_excursion = 0.0
+        while True:
+            m = dfreader.recv_match(type='XKF1', condition='XKF1.C==0')
+            if m is None:
+                break
+            if m.TimeUS < drift_start_us:
+                continue
+            if reset_us is None:
+                if last_pd is not None and abs(m.PD - last_pd) > 0.5:
+                    reset_us = m.TimeUS
+                    self.progress("Reset detected at %.2f s (PD %.3f -> %.3f)" %
+                                  (m.TimeUS / 1.0e6, last_pd, m.PD))
+                last_pd = m.PD
+                continue
+            if m.TimeUS - reset_us > 2.0e6:
+                break
+            peak_excursion = max(peak_excursion, abs(m.PD))
+
+        if reset_us is None:
+            raise NotAchievedException(
+                "Did not detect resetHeightDatum in log "
+                "(was update_home triggered?)")
+
+        self.progress("Peak |XKF1.PD| over 2 s post-reset: %.3f m" %
+                      peak_excursion)
+        if peak_excursion > 0.1:
+            raise NotAchievedException(
+                "Post-reset altitude transient exceeds 0.1 m: %.3f m "
+                "(stale baro buffer not flushed on resetHeightDatum)" %
+                peak_excursion)
 
     def tests1c(self):
         '''kind of reserved for flapping tests which we still have hopes for'''

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -376,8 +376,30 @@ bool NavEKF3_core::resetHeightDatum(void)
     ftype oldHgt = -stateStruct.position.z;
     // reset the barometer so that it reads zero at the current height
     dal.baro().update_calibration();
-    // reset the height state
+
+    // clear the baro data buffer
+    storedBaro.reset();
+
+    // reset the vertical position and velocity states
     stateStruct.position.z = 0.0f;
+    stateStruct.velocity.z = 0.0f;
+    for (uint8_t i=0; i<imu_buffer_length; i++) {
+        storedOutput[i].position.z = stateStruct.position.z;
+        storedOutput[i].velocity.z = stateStruct.velocity.z;
+    }
+    outputDataNew.position.z = outputDataDelayed.position.z = stateStruct.position.z;
+    outputDataNew.velocity.z = outputDataDelayed.velocity.z = stateStruct.velocity.z;
+    vertCompFiltState.vel = outputDataNew.velocity.z;
+
+    // baroHgtOffset is a slow first-order filter (calcFiltBaroOffset)
+    // tracking baroDataDelayed.hgt + position.z.  Post-reset baro
+    // reads 0 and position.z is 0 so the steady-state offset is 0;
+    // without this, hgtMea = baroDataDelayed.hgt - baroHgtOffset
+    // would feed a non-zero observation into the EKF for the ~1 s
+    // the filter takes to relax, producing a post-reset altitude
+    // transient.
+    baroHgtOffset = 0.0f;
+
     // adjust the height of the EKF origin so that the origin plus baro height before and after the reset is the same
     if (validOrigin) {
         if (!gpsGoodToAlign) {


### PR DESCRIPTION
## Summary

`NavEKF3_core::resetHeightDatum()` recalibrates the baro and zeroes `position.z`, but on master it leaves three pieces of stale state behind: the `storedBaro` observation buffer, `velocity.z`, and the output-observer chain. After the reset those stale values are still fused as delayed observations, producing a ~0.3–0.5 m altitude transient for several hundred milliseconds. The same mechanism produced the observed −0.44 m at arming on a real copter (log15, small-fast-drone v4.6 build).

This PR clears the remaining state so the reset is clean, and adds a Plane autotest that catches the bug.

## The buggy state `resetHeightDatum` was leaving behind

1. **`storedBaro` observation buffer** — ~200 ms of baro samples taken *before* `update_calibration()` zeroed the baro. After the reset they are popped and fused as if current, pulling `state.position.z` away from zero.
2. **`stateStruct.velocity.z`** — not reset, carries whatever small value accumulated from IMU integration while disarmed.
3. **Output observer chain** (`storedOutput[].position.z`, `outputDataNew/Delayed.position.z/velocity.z`, `vertCompFiltState.vel`) — the complementary filter between delayed EKF state and reported output. Without resetting, reported altitude briefly continues at the pre-reset value before catching up.

## Fix

Cherry-picked from #32400, authored by @priseborough (commit `f2a8bcda1a`):

- `storedBaro.reset()` clears the observation buffer
- `stateStruct.velocity.z = 0` zeros the vertical velocity state
- Zero all entries of `storedOutput[]`, `outputDataNew/Delayed`, `vertCompFiltState.vel`

## Test

`EK3HeightDatumResetFlushesBuffers` (Plane). Plane's existing `update_home()` is the only on-master trigger for `resetHeightDatum()` we can drive on demand; the test temporarily suspends the periodic reset (`HOME_RESET_ALT=-1`), injects 4 s of `SIM_BARO_DRIFT=0.5` (~2 m offset in the buffer), then re-enables the reset and watches the next `update_home` cycle in the dataflash log.

| | Peak \|XKF1.PD\| in 2 s post-reset window |
|---|---|
| Without this fix | 0.372 m |
| With this fix | < 0.05 m |

The 0.1 m assertion sits comfortably in the gap.

## Stacking

This PR is the base for #32768 (arm-time drift reset). #32768 needs this fix because the arm-time `resetHeightDatum()` would otherwise produce the same post-arm transient.

## Ancestry

- Paul's EKF fix: cherry-pick of `f2a8bcda1a` from `pr-ekf3-height-datum` branch (PR #32400). Authorship preserved.
- Plane test: new work here.

## Test plan

- [x] `EK3HeightDatumResetFlushesBuffers` passes with peak excursion < 0.05 m
- [x] `EK3HeightDatumResetFlushesBuffers` fails with peak excursion = 0.372 m when Paul's fix reverted
- [x] No regression on `FarOrigin`, `HomeAltResetTest`, `AltEstimation`, `EKFSource`, `Clamp`
