### PR TITLE
.github: `shellcheck` is pre-installed in GitHub Actions runners

### DIFF
--- a/.github/workflows/test_scripts.yml
+++ b/.github/workflows/test_scripts.yml
@@ -39,13 +39,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y astyle
 
-      - name: Install shellcheck
-        if: matrix.config == 'shellcheck'
-        shell: bash
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes shellcheck
-
       - name: test ${{matrix.config}}
         env:
           CI_BUILD_TARGET: ${{matrix.config}}


### PR DESCRIPTION
### Summary

We can avoid `apt-get update && apt-get install --yes shellcheck` because it is pre-installed in GitHub Actions runners.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. ~unit test, autotest~ GitHub Actions)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

[Shellcheck](https://github.com/koalaman/shellcheck) is pre-installed in GitHub Actions runners.
* https://github.com/actions/runner-images/blob/main/images/ubuntu-slim/ubuntu-slim-Readme.md#installed-apt-packages

When we reinstall it, we get the message `shellcheck is already the newest version` after a few seconds of config.

### How was this tested?
Careful reading of the GitHub Actions logs for job `test scripts / build (shellcheck)`.
* https://github.com/ArduPilot/ardupilot/actions/workflows/test_scripts.yml