### PR TITLE
autotest: Fix race in satellite count in MultipleGPS

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -14584,12 +14584,10 @@ switch value'''
             if distance > 1:
                 raise NotAchievedException(f"gps type {name} misbehaving")
 
-    def assert_gps_satellite_count(self, messagename, count):
+    def wait_gps_satellite_count(self, messagename, count, timeout):
+        """Wait for a GPS message to report a specific satellite count."""
         self.drain_mav()
-        m = self.assert_receive_message(messagename)
-        if m.satellites_visible != count:
-            raise NotAchievedException("Expected %u sats, got %u" %
-                                       (count, m.satellites_visible))
+        self.wait_message_field_values(messagename, {"satellites_visible": count}, timeout=timeout)
 
     def check_attitudes_match(self):
         '''make sure ahrs2 and simstate and ATTTIUDE_QUATERNION all match'''
@@ -14688,16 +14686,17 @@ switch value'''
         if m.fix_type != mavutil.mavlink.GPS_FIX_TYPE_RTK_FIXED:
             raise NotAchievedException("Incorrect fix type")
 
+        GPS_NSATS_TIMEOUT_SEC = 3.0
         self.start_subtest("Check parameters are per-GPS")
         self.assert_parameter_value("SIM_GPS1_NUMSATS", 10)
-        self.assert_gps_satellite_count("GPS_RAW_INT", 10)
+        self.wait_gps_satellite_count("GPS_RAW_INT", 10, GPS_NSATS_TIMEOUT_SEC)
         self.set_parameter("SIM_GPS1_NUMSATS", 13)
-        self.assert_gps_satellite_count("GPS_RAW_INT", 13)
+        self.wait_gps_satellite_count("GPS_RAW_INT", 13, GPS_NSATS_TIMEOUT_SEC)
 
         self.assert_parameter_value("SIM_GPS2_NUMSATS", 10)
-        self.assert_gps_satellite_count("GPS2_RAW", 10)
+        self.wait_gps_satellite_count("GPS2_RAW", 10, GPS_NSATS_TIMEOUT_SEC)
         self.set_parameter("SIM_GPS2_NUMSATS", 12)
-        self.assert_gps_satellite_count("GPS2_RAW", 12)
+        self.wait_gps_satellite_count("GPS2_RAW", 12, GPS_NSATS_TIMEOUT_SEC)
 
         self.start_subtest("check that GLOBAL_POSITION_INT fails over")
         m = self.assert_receive_message("GLOBAL_POSITION_INT")


### PR DESCRIPTION


### Summary

Adds a timeout waiting for the right satellite count rather than relying on a race condition of the GPS satellite count to be updated by the time it's published via mavlink and received by pymavlink.

This is better than a straight sleep.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request


Tested 10x on my desktop, no failures.

### Description

* Wait for up to 3s after draining messages for the expected satellite count
* This test had a race condition between updating satellite count in SITL and pymavlink receiving the right sat count

### Failure mode

If the test fails, then the logs look like this. We do not need the verbose flag changed from default.
```
AT-0003.6: Expected GPS2_RAW.satellites_visible to be 11, got 12
AT-0003.6: Exception caught: Field never reached values
Traceback (most recent call last):
  File "/home/ryan/Dev/ardu_ws/src/ardupilot/Tools/autotest/vehicle_test_suite.py", line 9158, in run_one_test_attempt
    test_function(**test_kwargs)
  File "/home/ryan/Dev/ardu_ws/src/ardupilot/Tools/autotest/vehicle_test_suite.py", line 14699, in MultipleGPS
    self.wait_gps_satellite_count("GPS2_RAW", 11, GPS_NSATS_TIMEOUT_SEC)
  File "/home/ryan/Dev/ardu_ws/src/ardupilot/Tools/autotest/vehicle_test_suite.py", line 14590, in wait_gps_satellite_count
    self.wait_message_field_values(messagename, {"satellites_visible": count}, timeout=timeout)
  File "/home/ryan/Dev/ardu_ws/src/ardupilot/Tools/autotest/vehicle_test_suite.py", line 4513, in wait_message_field_values
    raise NotAchievedException("Field never reached values")
vehicle_test_suite.NotAchievedException: Field never reached values
```

# Ticket

* Closes #32767
* Relates to #32446

