### PR TITLE
Add WARN_IF_UNUSED to AP_AHRS::get_location

### DIFF
--- a/ArduCopter/inertia.cpp
+++ b/ArduCopter/inertia.cpp
@@ -11,7 +11,8 @@ void Copter::read_inertia()
 
     // pull position from ahrs
     Location loc;
-    ahrs.get_location(loc);
+    // AHRS provides a best-guess in case of failure
+    UNUSED_RESULT(ahrs.get_location(loc));
     current_loc.lat = loc.lat;
     current_loc.lng = loc.lng;
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2844,7 +2844,9 @@ void QuadPlane::vtol_position_controller(void)
             }
         }
         if (plane.control_mode == &plane.mode_guided || vtol_loiter_auto) {
-            plane.ahrs.get_location(plane.current_loc);
+            // FIXME: we have updated current_loc without updating the
+            // health flag.  And why are we doing this here?!
+            UNUSED_RESULT(plane.ahrs.get_location(plane.current_loc));
             int32_t target_altitude_cm;
             if (!plane.next_WP_loc.get_alt_cm(Location::AltFrame::ABOVE_ORIGIN,target_altitude_cm)) {
                 break;

--- a/ArduSub/inertia.cpp
+++ b/ArduSub/inertia.cpp
@@ -9,7 +9,8 @@ void Sub::read_inertia()
 
     // pull position from ahrs
     Location loc;
-    ahrs.get_location(loc);
+    // AHRS provides a best-guess in case of failure
+    UNUSED_RESULT(ahrs.get_location(loc));
     current_loc.lat = loc.lat;
     current_loc.lng = loc.lng;
 

--- a/Blimp/inertia.cpp
+++ b/Blimp/inertia.cpp
@@ -8,7 +8,8 @@ void Blimp::read_inertia()
 
     // pull position from ahrs
     Location loc;
-    ahrs.get_location(loc);
+    // AHRS provides a best-guess in case of failure
+    UNUSED_RESULT(ahrs.get_location(loc));
     current_loc.lat = loc.lat;
     current_loc.lng = loc.lng;
 

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -99,7 +99,7 @@ public:
     void            reset();
 
     // get current location estimate
-    bool get_location(Location &loc) const;
+    bool get_location(Location &loc) const WARN_IF_UNUSED;
 
     // get latest altitude estimate above ground level in meters and validity flag
     bool get_hagl(float &hagl) const WARN_IF_UNUSED;

--- a/libraries/AP_OpenDroneID/AP_OpenDroneID.cpp
+++ b/libraries/AP_OpenDroneID/AP_OpenDroneID.cpp
@@ -225,7 +225,9 @@ void AP_OpenDroneID::update()
     const bool armed = hal.util->get_soft_armed();
     if (armed && !_was_armed) {
         // use arm location as takeoff location
-        AP::ahrs().get_location(_takeoff_location);
+        // if the AHRS can't give us a result it will pass GPS
+        // location in _takeoff_location while returning false:
+        UNUSED_RESULT(AP::ahrs().get_location(_takeoff_location));
     }
     _was_armed = armed;
 


### PR DESCRIPTION
### Summary

Annotates AP_AHRS::get_location as must-check

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *                                                   
Durandal                            *               *      *           *       *                 *      *      *
Hitec-Airspeed           *                                 *                                                   
KakuteH7-bdshot                     *               *      *           *       *                 *      *      *
MatekF405                           *               *      *           *       *                 *      *      *
MatekH7A3                           *               *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *               *                  *       *                 *      *      *
YJUAV_A6SE                          *               *      *           *       *                 *      *      *
f103-QiotekPeriph        *                                 *                                                   
f303-MatekGPS            *                                 *                                                   
f303-Universal           *                                 *                                                   
iomcu                                                                                *                         
mindpx-v2                           *               *      *           *       *                 *      *      *
revo-mini                           *               *      *           *       *                 *      *      *
skyviper-v2450                                                         *                                       
speedybeef4                         *               *      *           *       *                 *      *      *
```
### Description

Ensures callers to this method actually do check the return value.  This will prompt people to comment on why it is OK for the return value to be ignored (in this case because the AHRS is supposed to fill the fields in with best-guess data.
