### PR TITLE
AP_InternalError: add INTERNAL_ERROR_IN_SITL macro

### DIFF
--- a/libraries/AP_InternalError/AP_InternalError.h
+++ b/libraries/AP_InternalError/AP_InternalError.h
@@ -113,6 +113,16 @@ namespace AP {
 #define INTERNAL_ERROR(error_number) \
     AP::internalerror().error(error_number, __AP_LINE__);
 
+// INTERNAL_ERROR_IN_SITL: like INTERNAL_ERROR but only raises the
+// error when running in SITL.  Use this for conditions that indicate
+// a programming error but are not expected to occur on real hardware.
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#define INTERNAL_ERROR_IN_SITL(error_number) INTERNAL_ERROR(error_number)
+#else
+#define INTERNAL_ERROR_IN_SITL(error_number)
+#endif
+
 #else  // AP_INTERNALERROR_ENABLED is false
 #define INTERNAL_ERROR(error_number)
+#define INTERNAL_ERROR_IN_SITL(error_number)
 #endif // AP_INTERNALERROR_ENABLED


### PR DESCRIPTION
### Summary

Adds a new macro which works like INTERNAL_ERROR but is only active in SITL.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

I've verified that shoving one of these into a prominent place in AP_Vehicle causes the thing to panic on crossing the codepath in SITL but is a no-compiler-output change on CubeOrangePlus.

```
Board,plane
CubeOrangePlus,*
```

```
--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -544,6 +544,9 @@ void AP_Vehicle::setup()
 
     GCS_SEND_TEXT(MAV_SEVERITY_INFO, "ArduPilot Ready");
 
+    // TEST: verify INTERNAL_ERROR_IN_SITL fires on SITL and is a no-op on hardware
+    INTERNAL_ERROR_IN_SITL(AP_InternalError::error_t::flow_of_control);
+
 #if AP_DDS_ENABLED
     if (!init_dds_client()) {
         GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s Failed to Initialize", AP_DDS_Client::msg_prefix);
```

### Description

Like INTERNAL_ERROR but expands to a no-op on non-SITL boards. Useful for conditions that indicate a programming error but are not expected to occur on real hardware.

As requested at DevCall.
