### PR TITLE
AP_DDS: Tools/scripts/run_astyle.py on Artistic Style v3.6.14

### DIFF
--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -832,9 +832,9 @@ void AP_DDS_Client::on_topic(uxrSession* uxr_session, uxrObjectId object_id, uin
                 } else {
                     const uint16_t mapped_data = static_cast<uint16_t>(
                                                      linear_interpolate(rc().channel(i)->get_radio_min(),
-                                                             rc().channel(i)->get_radio_max(),
-                                                             rx_joy_topic.axes[i],
-                                                             -1.0, 1.0));
+                                                         rc().channel(i)->get_radio_max(),
+                                                         rx_joy_topic.axes[i],
+                                                         -1.0, 1.0));
                     RC_Channels::set_override(i, mapped_data, t_now);
                 }
             }


### PR DESCRIPTION
### Summary

Running Tools/scripts/run_astyle.py on the current version of Artistic Style dedents three lines.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g., unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g., unit test, autotest)
- [ ] Tested manually, description below (e.g,. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description
% `astyle --version`
```
Artistic Style Version 3.6.14  # The current release: https://gitlab.com/saalen/astyle/-/releases
```
% `Tools/scripts/run_astyle.py`
```
****** Files needing formatting found.
Unchanged  [ ... ]
Formatted  libraries/AP_DDS/AP_DDS_Client.cpp
Unchanged  [ ... ]
```
* https://astyle.sourceforge.net/news.html
* https://astyle.sourceforge.net/notes.html
* https://github.com/ArduPilot/ardupilot/actions/workflows/test_scripts.yml

### Results:
```diff
@@ -832,9 +832,9 @@ void AP_DDS_Client::on_topic(uxrSession* uxr_session, uxrObjectId object_id, uin
                    const uint16_t mapped_data = static_cast<uint16_t>(
                                                     linear_interpolate(rc().channel(i)->get_radio_min(),
-                                                            rc().channel(i)->get_radio_max(),
-                                                            rx_joy_topic.axes[i],
-                                                            -1.0, 1.0));
+                                                        rc().channel(i)->get_radio_max(),
+                                                        rx_joy_topic.axes[i],
+                                                        -1.0, 1.0));
                    RC_Channels::set_override(i, mapped_data, t_now);
```
### Why?
Contributors often have up-to-date versions of these tools on their local machines and are see linting errors and warnings that do not appear in CI.

% `apt-get install lsb-release astyle lua-check shellcheck`
Ubuntu | astyle | luacheck | shellcheck
--- | --- | --- | ---
22.04 LTS | v3.1 | v0.25.0 | v0.8.0
26.04 LTS | v3.6.12 | v1.2.0 | v0.11.0

% `docker run -it ubuntu:22.04`
```
# apt update && \
    DEBIAN_FRONTEND=noninteractive apt install --yes lsb-release astyle lua-check shellcheck && \
    lsb_release -ds && \
    astyle --version && \
    luacheck --version && \
    shellcheck --version
```