### PR TITLE
hwdef: convert RST external hyperlinks to markdown syntax

### DIFF
--- a/Tools/scripts/check_branch_conventions.py
+++ b/Tools/scripts/check_branch_conventions.py
@@ -372,6 +372,35 @@ class CheckBranchConventions(build_script_base.BuildScriptBase):
                 print(f"{PASS} No submodule reference changes to check.")
         return ok
 
+    def check_markdown_rst_hyperlinks(self) -> bool:
+        '''flag RST-style external hyperlinks (`text <url>`__) in changed markdown files'''
+        changed_md = self.run_git(
+            ["diff", "--name-only", "--diff-filter=AM",
+             f"{self.base_branch}...HEAD", "--", "*.md"],
+            show_output=False,
+        ).strip()
+        if not changed_md:
+            print(f"{PASS} No markdown files changed (RST hyperlink check).")
+            return True
+
+        result = subprocess.run(
+            ["git", "grep", "-n", r"`[^`]*`__", "--"] + changed_md.splitlines(),
+            capture_output=True, text=True,
+        )
+        # git grep exits 1 for no matches, 0 for matches, >1 for errors
+        if result.returncode > 1:
+            print(f"{SKIP} git grep failed: {result.stderr.strip()}")
+            return True
+        if not result.stdout.strip():
+            print(f"{PASS} No RST-style hyperlinks in changed markdown files.")
+            return True
+
+        print(f"{FAIL} RST-style hyperlinks found in markdown file(s):")
+        for line in result.stdout.splitlines():
+            print(f"         {line}")
+        print("       Use markdown link syntax [text](url) instead.")
+        return False
+
     def check_markdown_rst_underlines(self) -> bool:
         '''flag setext/RST underline-style headings in changed markdown files'''
         changed_md = self.run_git(
@@ -453,6 +482,7 @@ class CheckBranchConventions(build_script_base.BuildScriptBase):
             self.check_submodule_isolation(),
             self.check_submodule_references_exist(),
             self.check_markdown(),
+            self.check_markdown_rst_hyperlinks(),
             self.check_markdown_rst_underlines(),
         ]
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/AIRBRAINH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/AIRBRAINH743/README.md
@@ -84,7 +84,7 @@ The AIRBRAINH743 has builtin compass. You can also attach an external compass us
 
 ## Loading Firmware
 
-Firmware for these boards can be found `here <https://firmware.ardupilot.org>`__ in sub-folders labeled "AIRBRAINH743".
+Firmware for these boards can be found [here](https://firmware.ardupilot.org) in sub-folders labeled "AIRBRAINH743".
 
 Initial firmware load can be done with DFU by plugging in USB with the
 bootloader button pressed. Then you should load the "with_bl.hex"

--- a/libraries/AP_HAL_ChibiOS/hwdef/ATOMRCF405NAVI-Deluxe/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ATOMRCF405NAVI-Deluxe/README.md
@@ -2,7 +2,7 @@
 
 ![ATOMRCF405NAVI-Deluxe](atomrcf405-navi-deluxe.jpg)
 
-the above image and some content courtesy of `ATOMRC <http://atomrc.com/>`__
+the above image and some content courtesy of [ATOMRC](http://atomrc.com/)
 
 > **Note:** Due to flash memory limitations, this board does not include all ArduPilot features. See :ref:`Firmware Limitations <common-limited_firmware>` for details.
 
@@ -112,7 +112,7 @@ An integrated BLE RF module is attached to UART1 and its power controlled by a p
 
 ## Loading Firmware
 
-Firmware for this board can be found `here <https://firmware.ardupilot.org>`__  in sub-folders labeled “ATOMRCF405NAVI-Deluxe”.
+Firmware for this board can be found [here](https://firmware.ardupilot.org) in sub-folders labeled “ATOMRCF405NAVI-Deluxe”.
 
 Initial firmware load can be done with DFU by plugging in USB with the
 boot button pressed. Then you should load the "with_bl.hex"

--- a/libraries/AP_HAL_ChibiOS/hwdef/Airvolute-DCS2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Airvolute-DCS2/README.md
@@ -1,7 +1,7 @@
 # Onboard FMU on Airvolute DCS2.Pilot board
 
 DroneCore 2.0 is a modular AI-driven open architecture autopilot designed for complex use cases that combines high computational processing power, redundant connectivity, small size, and low weight.The autopilot represents a one-stop-solution for developers integrating the functionality of carrier board, companion computer, and power distribution board into a single compact form factor.
-This system usually uses a "CUBE" autopilot as its primary FMU, but can use an onboard STM32H743 as the FMU. This board definition and firmware on `the ArduPilot firmware server <https://firmware.ardupilot.org>`__ is for this secondary FMU
+This system usually uses a "CUBE" autopilot as its primary FMU, but can use an onboard STM32H743 as the FMU. This board definition and firmware on [the ArduPilot firmware server](https://firmware.ardupilot.org) is for this secondary FMU
 For more information on DCS2.Pilot board see:
 [Airvolute documentation](https://docs.airvolute.com/dronecore-autopilot/dcs2)
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BOTWINGF405/Readme.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BOTWINGF405/Readme.md
@@ -140,7 +140,7 @@ Analog RSSI input is via pin 12.  Set :ref:`RSSI_ANA_PIN<RSSI_ANA_PIN>` to "12" 
 
 ## Loading Firmware
 
-Firmware for the autopilot can be found `here <https://firmware.ardupilot.org>`__ in sub-folders labeled "BOTWINGF405".
+Firmware for the autopilot can be found [here](https://firmware.ardupilot.org) in sub-folders labeled "BOTWINGF405".
 
 Initial firmware load can be done with DFU by plugging in USB with the
 bootloader button pressed. Then you should load the "with_bl.hex"

--- a/libraries/AP_HAL_ChibiOS/hwdef/CORVON743V1/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CORVON743V1/README.md
@@ -92,7 +92,7 @@ The CORVON743V1 has a built-in compass sensor (IST8310), and you can also attach
 
 ## Loading Firmware
 
-Firmware for these boards can be found `here <https://firmware.ardupilot.org>`__ in sub-folders labeled "CORVON743V_1".
+Firmware for these boards can be found [here](https://firmware.ardupilot.org) in sub-folders labeled "CORVON743V_1".
 
 Initial firmware load can be done with DFU by plugging in USB with the bootloader button pressed. Then you should load the "with_bl.hex" firmware, using your favorite DFU loading tool.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVF405/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVF405/README.md
@@ -104,7 +104,7 @@ GPIO 82 controls the camera output to the connectors marked "CAM1" and "CAM2". S
 
 ## Loading Firmware
 
-Firmware for these boards can be found `here <https://firmware.ardupilot.org>`__ in sub-folders labeled "DAKEFPVF405".
+Firmware for these boards can be found [here](https://firmware.ardupilot.org) in sub-folders labeled "DAKEFPVF405".
 
 Initial firmware load can be done with DFU by plugging in USB with the
 bootloader button pressed. Then you should load the "with_bl.hex"

--- a/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743/README.md
@@ -118,7 +118,7 @@ The HD VTX connector can have RX4 replaced by the analog VTX signal if that conn
 
 ## Loading Firmware
 
-Firmware for these boards can be found `here <https://firmware.ardupilot.org>`__ in sub-folders labeled "DAKEFPVH743".
+Firmware for these boards can be found [here](https://firmware.ardupilot.org) in sub-folders labeled "DAKEFPVH743".
 Initial firmware load can be done with DFU by plugging in USB with the
 bootloader button pressed. Then you should load the "with_bl.hex"
 firmware, using your favourite DFU loading tool.

--- a/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743Pro/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743Pro/README.md
@@ -127,7 +127,7 @@ The HD VTX connector can have RX4 replaced by the analog VTX signal if that conn
 
 ## Loading Firmware
 
-Firmware for these boards can be found `here <https://firmware.ardupilot.org>`__ in sub-folders labeled "DAKEFPVH743Pro".
+Firmware for these boards can be found [here](https://firmware.ardupilot.org) in sub-folders labeled "DAKEFPVH743Pro".
 Initial firmware load can be done with DFU by plugging in USB with the
 bootloader button pressed. Then you should load the "with_bl.hex"
 firmware, using your favourite DFU loading tool.

--- a/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743_SLIM/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743_SLIM/README.md
@@ -129,7 +129,7 @@ The HD VTX connector can have RX4 replaced by the analog VTX signal if that conn
 
 ## Loading Firmware
 
-Firmware for these boards can be found `here <https://firmware.ardupilot.org>`__ in sub-folders labeled "DAKEFPVH743_SLIM".
+Firmware for these boards can be found [here](https://firmware.ardupilot.org) in sub-folders labeled "DAKEFPVH743_SLIM".
 Initial firmware load can be done with DFU by plugging in USB with the
 bootloader button pressed. Then you should load the "with_bl.hex"
 firmware, using your favourite DFU loading tool.

--- a/libraries/AP_HAL_ChibiOS/hwdef/F4BY_H743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/F4BY_H743/README.md
@@ -1,13 +1,13 @@
 # F4BY_H743
 
-The F4BY_H743 autopilot is manufactured by `F4BY Team <https://f4by.com>`__
+The F4BY_H743 autopilot is manufactured by [F4BY Team](https://f4by.com)
 
 ![F4BY_H743](F4BY_H743_board_image.jpg)
 
 ## Where to Buy
 
-Shop `here https://f4by.com/en/?order/our_product`__
-The instructions, schematic, 3D model  are available `here https://f4by.com/en/?doc/fc_f4by_v3.0.1_h743`__
+Shop [here](https://f4by.com/en/?order/our_product)
+The instructions, schematic, 3D model  are available [here](https://f4by.com/en/?doc/fc_f4by_v3.0.1_h743)
 
 ## Specifications
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/HWH7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/HWH7/README.md
@@ -116,7 +116,7 @@ The bootloader hwdef enables flashing firmware from microSD (`AP_BOOTLOADER_FLAS
 
 Initial firmware load can be done with DFU by plugging in USB with the bootloader button pressed.
 
-Firmware can be found on the `firmware server <https://firmare.ardupilot.org>`__ in folders marked "HWH7"
+Firmware can be found on the [firmware server](https://firmare.ardupilot.org) in folders marked "HWH7"
 
 Then load the `*_with_bl.hex` firmware using a DFU tool.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/JHEMCUF405PRO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/JHEMCUF405PRO/README.md
@@ -86,7 +86,7 @@ The SCL/SDA pads are exposed as two tiny circles.
 
 ## Loading Firmware
 
-Firmware for this board can be found `here <https://firmware.ardupilot.org>`__  in sub-folders labeled “JHEMCUF405PRO”.
+Firmware for this board can be found [here](https://firmware.ardupilot.org) in sub-folders labeled “JHEMCUF405PRO”.
 
 Initial firmware load can be done with DFU by plugging in USB with the
 bootloader button pressed. Then you should load the "with_bl.hex"

--- a/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743-Lite/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743-Lite/README.md
@@ -108,7 +108,7 @@ The MicoAir743-Lite has an on board BlueTooth module connected to UART8(SERIAL8)
 
 ## Loading Firmware
 
-Firmware can be found on the `firmware server <https://firmare.ardupilot.org>`__ in folders marked "MicoAir743-Lite"
+Firmware can be found on the [firmware server](https://firmare.ardupilot.org) in folders marked "MicoAir743-Lite"
 
 Initial firmware load can be done with DFU by plugging in USB with the bootloader button pressed. Then you should load the "XXXX_with_bl.hex" firmware, using your favorite DFU loading tool.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/NarinFC-H7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/NarinFC-H7/README.md
@@ -232,7 +232,7 @@ The power rail associated with this connector position is powered via USB or PMU
 
 This board comes with ArduPilot firmware pre-installed and other vehicle/revision ArduPilot firmware can be loaded using most Ground Control Stations.
 
-Firmware for these boards can be found `here  <https://firmware.ardupilot.org>`__ in sub-folders labeled “NarinFC-H7”.
+Firmware for these boards can be found [here](https://firmware.ardupilot.org) in sub-folders labeled “NarinFC-H7”.
 
 The board comes pre-installed with an ArduPilot bootloader, allowing the loading of \*.apj firmware files with any ArduPilot compatible ground station, such as Mission Planner.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ResoluteH7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ResoluteH7/README.md
@@ -96,7 +96,7 @@ The Resolute H7 has an onboard OSD using a MAX7456 chip and is enabled by defaul
 
 ## Loading Firmware
 
-Firmware for these boards can be found `here <https://firmware.ardupilot.org>`__ in sub-folders labeled "ResoluteH7".
+Firmware for these boards can be found [here](https://firmware.ardupilot.org) in sub-folders labeled "ResoluteH7".
 Initial firmware load can be done with DFU by plugging in USB with the
 bootloader button pressed. Then you should load the "with_bl.hex"
 firmware, using your favourite DFU loading tool.

--- a/libraries/AP_HAL_ChibiOS/hwdef/SequreH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SequreH743/README.md
@@ -93,7 +93,7 @@ The SequreH743 does not have a builtin compass, but you can attach an external c
 
 ## Loading Firmware
 
-Firmware for these boards can be found `here <https://firmware.ardupilot.org>`__ in sub-folders labeled "SequreH743".
+Firmware for these boards can be found [here](https://firmware.ardupilot.org) in sub-folders labeled "SequreH743".
 
 Initial firmware load can be done with DFU by plugging in USB with the
 bootloader button pressed. Then you should load the "with_bl.hex"

--- a/libraries/AP_HAL_ChibiOS/hwdef/SkySakuraH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SkySakuraH743/README.md
@@ -101,7 +101,7 @@ PWM13 provides external NeoPixel LED support.
 
 ## Firmware
 
-Firmware can bee found on the `firmware server < https://firmware.ardupilot.org`__ in the "SkySakuraH743"  folders
+Firmware can bee found on the [firmware server](https://firmware.ardupilot.org) in the "SkySakuraH743"  folders
 
 ## Loading Firmware
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SkystarsF405v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SkystarsF405v2/README.md
@@ -97,7 +97,7 @@ from CAM1 to CAM2. By default RELAY2 is configured to control this pin and sets 
 
 ## Loading Firmware
 
-Firmware for these boards can be found `here <https://firmware.ardupilot.org>`__ in sub-folders labeled "SkystarsF405v2".
+Firmware for these boards can be found [here](https://firmware.ardupilot.org) in sub-folders labeled "SkystarsF405v2".
 
 Initial firmware load can be done with DFU by plugging in USB with the
 bootloader button pressed. Then you should load the "with_bl.hex"

--- a/libraries/AP_HAL_ChibiOS/hwdef/SkystarsH7HDv2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SkystarsH7HDv2/README.md
@@ -90,7 +90,7 @@ GPIO 83 is marked as "OSD". It can be used as a general GPIO pin. By default REL
 
 ## Loading Firmware
 
-Firmware for these boards can be found `here <https://firmware.ardupilot.org>`__ in sub-folders labeled "SkystarsH7HDv2".
+Firmware for these boards can be found [here](https://firmware.ardupilot.org) in sub-folders labeled "SkystarsH7HDv2".
 
 Initial firmware load can be done with DFU by plugging in USB with the
 bootloader button pressed. Then you should load the "with_bl.hex"

--- a/libraries/AP_HAL_ChibiOS/hwdef/SpeedyBeeF405AIO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SpeedyBeeF405AIO/README.md
@@ -104,7 +104,7 @@ The board includes a NeoPixel LED pad.
 
 ## Firmware
 
-Firmware for this board can be found: `here <https://firmware.ardupilot.org>`__ in sub-folders labeled “SpeedyBeeF405AIO”.
+Firmware for this board can be found: [here](https://firmware.ardupilot.org) in sub-folders labeled “SpeedyBeeF405AIO”.
 
 ## Loading Firmware (you will need to compile your own firmware)
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_PRO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_PRO/README.md
@@ -90,7 +90,7 @@ The TBS LUCID PRO does not have a builtin compass, but you can attach an externa
 
 ## Firmware
 
-Firmware for this board can be found `here <https://firmware.ardupilot.org>`__ in sub-folders labeled “TBS_LUCID_PRO”
+Firmware for this board can be found [here](https://firmware.ardupilot.org) in sub-folders labeled “TBS_LUCID_PRO”
 
 ## Loading Firmware
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/sparknavi-blue/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/sparknavi-blue/README.md
@@ -1,12 +1,12 @@
 # SparkNavi Blue
 
-The SparkNavi Blue autopilot is manufactured by `SparkNavi <https://www.sparknavi.com>`__
+The SparkNavi Blue autopilot is manufactured by [SparkNavi](https://www.sparknavi.com)
 
 ![SparkNavi Blue](sparknavi-blue.png)
 
 ## Where to Buy
 
-`SparkNavi Official <https://www.sparknavi.com>`__
+[SparkNavi Official](https://www.sparknavi.com)
 
 ## Specifications
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/speedybeef4v5/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/speedybeef4v5/README.md
@@ -108,7 +108,7 @@ By default, RELAY4 is configured to control this GPIO and keeps it low.This pin 
 
 ## Firmware
 
-Firmware for this board can be found: `here <https://firmware.ardupilot.org>`__ in sub-folders labeled “speedybeef4v5”.
+Firmware for this board can be found: [here](https://firmware.ardupilot.org) in sub-folders labeled “speedybeef4v5”.
 
 ## Loading Firmware (you will need to compile your own firmware)
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/uav-dev-fc-um982/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/uav-dev-fc-um982/README.md
@@ -161,7 +161,7 @@ All outputs are capable of PWM and DShot. Motors 1 through 4 are capable of Bidi
 
 ## Firmware
 
-Firmware for this board can be found `here <https://firmware.ardupilot.org>`__  in sub-folders labeled “uav-dev-fc-um982”.
+Firmware for this board can be found [here](https://firmware.ardupilot.org) in sub-folders labeled “uav-dev-fc-um982”.
 
 ## Loading Firmware
 


### PR DESCRIPTION
### Summary

Replace invalid markdown (rst) with valid markdown - external links only in this PR.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest) (ish)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

I've spot-checked some of the renderings in the github interface.

### Description

Some of these links were also invalid and have been fixed.  The links are live and return 200.
