### PR TITLE
AP_Math: SCurve: extract extend_const_vel_to helper

### DIFF
--- a/libraries/AP_Math/SCurve.cpp
+++ b/libraries/AP_Math/SCurve.cpp
@@ -216,14 +216,7 @@ void SCurve::set_speed_max(float speed_xy, float speed_up, float speed_down)
         }
 
         // set change segments to last acceleration speed
-        for (uint8_t i = SEG_ACCEL_END+1; i <= SEG_SPEED_CHANGE_END; i++) {
-            segment[i].seg_type = SegmentType::CONSTANT_JERK;
-            segment[i].jerk_ref = 0.0f;
-            segment[i].end_time = segment[SEG_ACCEL_END].end_time;
-            segment[i].end_accel = 0.0f;
-            segment[i].end_vel = segment[SEG_ACCEL_END].end_vel;
-            segment[i].end_pos = segment[SEG_ACCEL_END].end_pos;
-        }
+        fill_empty_segments(SEG_ACCEL_END+1, SEG_SPEED_CHANGE_END, SEG_ACCEL_END);
 
     } else if ((time > segment[SEG_SPEED_CHANGE_END].end_time) && (time <= segment[SEG_CONST].end_time)) {
         // in the constant speed phase
@@ -272,14 +265,7 @@ void SCurve::set_speed_max(float speed_xy, float speed_up, float speed_down)
         segment[SEG_ACCEL_END].end_accel = 0.0f;
 
         // add empty speed adjust segments
-        for (uint8_t i = SEG_ACCEL_END+1; i <= SEG_CONST; i++) {
-            segment[i].seg_type = SegmentType::CONSTANT_JERK;
-            segment[i].jerk_ref = 0.0f;
-            segment[i].end_time = segment[SEG_ACCEL_END].end_time;
-            segment[i].end_accel = 0.0f;
-            segment[i].end_vel = segment[SEG_ACCEL_END].end_vel;
-            segment[i].end_pos = segment[SEG_ACCEL_END].end_pos;
-        }
+        fill_empty_segments(SEG_ACCEL_END+1, SEG_CONST, SEG_ACCEL_END);
 
         calculate_path(snap_max, jerk_max, 0.0f, accel_max, MAX(Vmin, vel_max), Pend * 0.5f, Jm, tj, t2, t4, t6);
 
@@ -298,14 +284,7 @@ void SCurve::set_speed_max(float speed_xy, float speed_up, float speed_down)
 
     // adjust the speed change segments (8 to 14) for new speed
     // start with empty speed adjust segments
-    for (uint8_t i = SEG_ACCEL_END+1; i <= SEG_SPEED_CHANGE_END; i++) {
-        segment[i].seg_type = SegmentType::CONSTANT_JERK;
-        segment[i].jerk_ref = 0.0f;
-        segment[i].end_time = segment[SEG_ACCEL_END].end_time;
-        segment[i].end_accel = 0.0f;
-        segment[i].end_vel = segment[SEG_ACCEL_END].end_vel;
-        segment[i].end_pos = segment[SEG_ACCEL_END].end_pos;
-    }
+    fill_empty_segments(SEG_ACCEL_END+1, SEG_SPEED_CHANGE_END, SEG_ACCEL_END);
     if (!is_equal(vel_max, segment[SEG_ACCEL_END].end_vel)) {
         // add velocity adjustment
         // check there is enough time to make velocity change
@@ -351,14 +330,7 @@ void SCurve::set_speed_max(float speed_xy, float speed_up, float speed_down)
         add_segments_jerk(seg, tj, Jm, t2);
     } else {
         // No deceleration is required
-        for (uint8_t i = SEG_CONST+1; i <= SEG_DECEL_END; i++) {
-            segment[i].seg_type = SegmentType::CONSTANT_JERK;
-            segment[i].jerk_ref = 0.0f;
-            segment[i].end_time = segment[SEG_CONST].end_time;
-            segment[i].end_accel = 0.0f;
-            segment[i].end_vel = segment[SEG_CONST].end_vel;
-            segment[i].end_pos = segment[SEG_CONST].end_pos;
-        }
+        fill_empty_segments(SEG_CONST+1, SEG_DECEL_END, SEG_CONST);
     }
 
     // remove numerical errors
@@ -420,14 +392,7 @@ float SCurve::set_origin_speed_max(float speed)
     }
 
     // add empty speed change segments and constant speed segment
-    for (uint8_t i = SEG_ACCEL_END+1; i <= SEG_SPEED_CHANGE_END; i++) {
-        segment[i].seg_type = SegmentType::CONSTANT_JERK;
-        segment[i].jerk_ref = 0.0f;
-        segment[i].end_time = segment[SEG_ACCEL_END].end_time;
-        segment[i].end_accel = 0.0f;
-        segment[i].end_vel = segment[SEG_ACCEL_END].end_vel;
-        segment[i].end_pos = segment[SEG_ACCEL_END].end_pos;
-    }
+    fill_empty_segments(SEG_ACCEL_END+1, SEG_SPEED_CHANGE_END, SEG_ACCEL_END);
 
     seg = SEG_CONST;
     add_segment_const_jerk(seg, 0.0f, 0.0f);
@@ -840,13 +805,9 @@ void SCurve::add_segments(float L)
     segment[SEG_ACCEL_END].end_accel = 0.0f;
 
     // add empty speed adjust segments
-    add_segment_const_jerk(num_segs, 0.0f, 0.0f);
-    add_segment_const_jerk(num_segs, 0.0f, 0.0f);
-    add_segment_const_jerk(num_segs, 0.0f, 0.0f);
-    add_segment_const_jerk(num_segs, 0.0f, 0.0f);
-    add_segment_const_jerk(num_segs, 0.0f, 0.0f);
-    add_segment_const_jerk(num_segs, 0.0f, 0.0f);
-    add_segment_const_jerk(num_segs, 0.0f, 0.0f);
+    for (uint8_t i = SEG_ACCEL_END + 1; i <= SEG_SPEED_CHANGE_END; i++) {
+        add_segment_const_jerk(num_segs, 0.0f, 0.0f);
+    }
 
     const float t15 = MAX(0.0f, (L - 2.0f * segment[SEG_SPEED_CHANGE_END].end_pos) / segment[SEG_SPEED_CHANGE_END].end_vel);
     add_segment_const_jerk(num_segs, t15, 0.0f);
@@ -1107,6 +1068,19 @@ void SCurve::extend_const_vel_to(float target_pos)
     for (uint8_t i = SEG_CONST; i <= SEG_DECEL_END; i++) {
         segment[i].end_time += t15;
         segment[i].end_pos += dP;
+    }
+}
+
+// fill segment[first..last] with zero-delta constant-jerk segments anchored to segment[src]
+void SCurve::fill_empty_segments(uint8_t first, uint8_t last, uint8_t src)
+{
+    for (uint8_t i = first; i <= last; i++) {
+        segment[i].seg_type = SegmentType::CONSTANT_JERK;
+        segment[i].jerk_ref = 0.0f;
+        segment[i].end_time = segment[src].end_time;
+        segment[i].end_accel = 0.0f;
+        segment[i].end_vel = segment[src].end_vel;
+        segment[i].end_pos = segment[src].end_pos;
     }
 }
 

--- a/libraries/AP_Math/SCurve.cpp
+++ b/libraries/AP_Math/SCurve.cpp
@@ -293,12 +293,7 @@ void SCurve::set_speed_max(float speed_xy, float speed_up, float speed_down)
         segment[SEG_DECEL_END].end_vel = MAX(0.0f, segment[SEG_DECEL_END].end_vel);
 
         // add to constant velocity segment to end at the correct position
-        const float dP = MAX(0.0f, Pend - segment[SEG_DECEL_END].end_pos);
-        const float t15 = is_positive(segment[SEG_CONST].end_vel) ? dP / segment[SEG_CONST].end_vel : 0.0f;
-        for (uint8_t i = SEG_CONST; i <= SEG_DECEL_END; i++) {
-            segment[i].end_time += t15;
-            segment[i].end_pos += dP;
-        }
+        extend_const_vel_to(Pend);
     }
 
     // adjust the speed change segments (8 to 14) for new speed
@@ -371,12 +366,7 @@ void SCurve::set_speed_max(float speed_xy, float speed_up, float speed_down)
     segment[SEG_DECEL_END].end_vel = MAX(0.0f, segment[SEG_DECEL_END].end_vel);
 
     // add to constant velocity segment to end at the correct position
-    const float dP = MAX(0.0f, Pend - segment[SEG_DECEL_END].end_pos);
-    const float t15 = is_positive(segment[SEG_CONST].end_vel) ? dP / segment[SEG_CONST].end_vel : 0.0f;
-    for (uint8_t i = SEG_CONST; i <= SEG_DECEL_END; i++) {
-        segment[i].end_time += t15;
-        segment[i].end_pos += dP;
-    }
+    extend_const_vel_to(Pend);
 
     // catch calculation errors
     if (!valid()) {
@@ -453,12 +443,7 @@ float SCurve::set_origin_speed_max(float speed)
     segment[SEG_DECEL_END].end_vel = MAX(0.0f, segment[SEG_DECEL_END].end_vel);
 
     // add to constant velocity segment to end at the correct position
-    const float dP = MAX(0.0f, seg_length - segment[SEG_DECEL_END].end_pos);
-    const float t15 = is_positive(segment[SEG_CONST].end_vel) ? dP / segment[SEG_CONST].end_vel : 0.0f;
-    for (uint8_t i = SEG_CONST; i <= SEG_DECEL_END; i++) {
-        segment[i].end_time += t15;
-        segment[i].end_pos += dP;
-    }
+    extend_const_vel_to(seg_length);
 
     // catch calculation errors
     if (!valid()) {
@@ -508,12 +493,7 @@ void SCurve::set_destination_speed_max(float speed)
     segment[SEG_DECEL_END].end_vel = MAX(0.0f, segment[SEG_DECEL_END].end_vel);
 
     // add to constant velocity segment to end at the correct position
-    const float dP = MAX(0.0f, seg_length - segment[SEG_DECEL_END].end_pos);
-    const float t15 = is_positive(segment[SEG_CONST].end_vel) ? dP / segment[SEG_CONST].end_vel : 0.0f;
-    for (uint8_t i = SEG_CONST; i <= SEG_DECEL_END; i++) {
-        segment[i].end_time += t15;
-        segment[i].end_pos += dP;
-    }
+    extend_const_vel_to(seg_length);
 
     // catch calculation errors
     if (!valid()) {
@@ -1117,6 +1097,17 @@ void SCurve::add_segment_decr_jerk(uint8_t &index, float tj, float Jm)
     const float V = (segment[index - 1].end_vel - VT) + (segment[index - 1].end_accel - AT) * tj + V2T;
     const float P = (segment[index - 1].end_pos - PT) + (segment[index - 1].end_vel - VT) * tj + 0.5f * (segment[index - 1].end_accel - AT) * sq(tj) + P2T;
     add_segment(index, T, SegmentType::NEGATIVE_JERK, J, A, V, P);
+}
+
+// extend the constant velocity segment so the deceleration finishes at target_pos
+void SCurve::extend_const_vel_to(float target_pos)
+{
+    const float dP = MAX(0.0f, target_pos - segment[SEG_DECEL_END].end_pos);
+    const float t15 = is_positive(segment[SEG_CONST].end_vel) ? dP / segment[SEG_CONST].end_vel : 0.0f;
+    for (uint8_t i = SEG_CONST; i <= SEG_DECEL_END; i++) {
+        segment[i].end_time += t15;
+        segment[i].end_pos += dP;
+    }
 }
 
 // add single S-Curve segment

--- a/libraries/AP_Math/SCurve.h
+++ b/libraries/AP_Math/SCurve.h
@@ -176,6 +176,9 @@ private:
     // extend the constant velocity segment so the deceleration finishes at target_pos
     void extend_const_vel_to(float target_pos);
 
+    // fill segment[first..last] with zero-delta constant-jerk segments anchored to segment[src]
+    void fill_empty_segments(uint8_t first, uint8_t last, uint8_t src);
+
     // set speed and acceleration limits for the path
     // origin and destination are offsets from EKF origin
     // speed and acceleration parameters are given in horizontal, up and down.

--- a/libraries/AP_Math/SCurve.h
+++ b/libraries/AP_Math/SCurve.h
@@ -173,6 +173,9 @@ private:
     // generate decreasing jerk magnitude time segment based on a raised cosine profile
     void add_segment_decr_jerk(uint8_t &seg_pnt, float Jm, float tj);
 
+    // extend the constant velocity segment so the deceleration finishes at target_pos
+    void extend_const_vel_to(float target_pos);
+
     // set speed and acceleration limits for the path
     // origin and destination are offsets from EKF origin
     // speed and acceleration parameters are given in horizontal, up and down.


### PR DESCRIPTION
### Summary

Two small refactors to `AP_Math/SCurve` that remove duplicated blocks
without changing behaviour. Both extract patterns that appeared verbatim
in multiple call sites into private helpers, making the surrounding
control flow easier to read and the invariants (guarded divides, matched
end_time/end_pos updates, segment-range fills) live in one place.

- **Commit 1** — extract `extend_const_vel_to(target_pos)`, replacing
  four identical 7-line blocks that extend the constant-velocity segment
  so deceleration finishes at the target position.
- **Commit 2** — extract `fill_empty_segments(first, last, src)`,
  replacing five identical 7-line blocks that fill a segment range with
  zero-delta constant-jerk segments anchored to a source segment. Also
  collapses seven repeated `add_segment_const_jerk()` calls in
  `add_segments()` into a loop bounded by the speed-change range so the
  count is self-documenting.
  
After first commit:
```
Board,antennatracker,blimp,bootloader,copter,heli,plane,rover,sub
CubeOrange,*,*,*,-216,-208,-216,-216,-216
```

After second commit:
```
Board,antennatracker,blimp,bootloader,copter,heli,plane,rover,sub
CubeOrange,*,*,*,-416,-408,-416,-416,-416
```

This is to compensate for the added size in this PR #32730
```
Board,antennatracker,blimp,bootloader,copter,heli,plane,rover,sub
CubeOrange,*,*,*,128,128,136,136,128
```

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
