### PR TITLE
AR_Motors: Make power limiting eaiser for end-users

### DIFF
--- a/libraries/AR_Motors/AP_MotorsUGV.cpp
+++ b/libraries/AR_Motors/AP_MotorsUGV.cpp
@@ -1024,8 +1024,8 @@ float AP_MotorsUGV::get_power_limit_max_throttle(float dt)
 
     _throttle_limit += (dt / (dt + _batt_power_time_constant)) * (1.0f - power_ratio);
 
-    // throttle limit drops to 5% minimum when over power limit
-    _throttle_limit = constrain_float(_throttle_limit, _throttle_min, _throttle_max);
+    // ensure throttle limit is within min and max throttle limits
+    _throttle_limit = constrain_float(_throttle_limit, _throttle_min * 0.01f, _throttle_max * 0.01f);
 
     return _throttle_limit;
 }

--- a/libraries/AR_Motors/AP_MotorsUGV.cpp
+++ b/libraries/AR_Motors/AP_MotorsUGV.cpp
@@ -136,7 +136,7 @@ const AP_Param::GroupInfo AP_MotorsUGV::var_info[] = {
     // @Range: 0 10
     // @Units: s
     // @User: Advanced
-    AP_GROUPINFO("BAT_WATT_TC", 16, AP_MotorsUGV, _batt_power_time_constant, 5.0f),
+    AP_GROUPINFO("BAT_WATT_TC", 16, AP_MotorsUGV, _batt_power_time_constant, 2.0f),
 #endif
 
     AP_GROUPEND


### PR DESCRIPTION
### Summary

Based on the conversation at https://discuss.ardupilot.org/t/rover-4-7-0-beta2-available-for-beta-testing/143065/12, I've made a few change to the Rover power limiting feature to make it easier for users:

This includes:
-Notifying the user (once per 5 seconds) if power limiting is active
-Reducing the default MOT_BAT_WATT_TC from 5 to 2, to reduce lag in the low-pass filter.

Tested in SITL and a real rover.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [X] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request


