### PR TITLE
Surface tracking: preserve full pilot climb/descent authority

### DIFF
--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -66,8 +66,11 @@ void Copter::update_throttle_hover()
     }
 }
 
-// get_pilot_desired_climb_rate_ms - transform pilot's throttle input to climb rate in cm/s
-// without any deadzone at the bottom
+// get_pilot_desired_climb_rate_ms - transform pilot's throttle input to climb rate in m/s
+// without any deadzone at the bottom.
+// The max climb and descent rates are adjusted for any climb/descent rate currently being
+// commanded by surface tracking, so full stick deflection always yields net vehicle climb
+// or descent at PILOT_SPD_UP  / PILOT_SPD_DN  (see get_pilot_speed_up_adjusted_ms()).
 float Copter::get_pilot_desired_climb_rate_ms()
 {
     // throttle failsafe check
@@ -99,10 +102,10 @@ float Copter::get_pilot_desired_climb_rate_ms()
     // check throttle is above, below or in the deadband
     if (throttle_control < deadband_bottom) {
         // below the deadband
-        desired_rate_ms = get_pilot_speed_dn_ms() * (throttle_control - deadband_bottom) / deadband_bottom;
+        desired_rate_ms = get_pilot_speed_dn_adjusted_ms() * (throttle_control - deadband_bottom) / deadband_bottom;
     } else if (throttle_control > deadband_top) {
         // above the deadband
-        desired_rate_ms = g2.pilot_speed_up_ms * (throttle_control - deadband_top) / (1000.0 - deadband_top);
+        desired_rate_ms = get_pilot_speed_up_adjusted_ms() * (throttle_control - deadband_top) / (1000.0 - deadband_top);
     } else {
         // must be in the deadband
         desired_rate_ms = 0.0f;
@@ -134,4 +137,25 @@ float Copter::get_pilot_speed_dn_ms() const
     } else {
         return fabsf(g2.pilot_speed_dn_ms);
     }
+}
+
+// Returns the maximum pilot climb rate (m/s) adjusted for the climb/descent rate currently
+// being commanded by surface tracking, to always result in at least PILOT_SPD_UP on full up stick.
+float Copter::get_pilot_speed_up_adjusted_ms() const
+{
+    // terrain velocity in Up-positive frame (m/s)
+    const float terrain_climb_ms = -pos_control->get_vel_terrain_D_ms();
+    // floored at zero to prevent sign flip if terrain velocity exceeds PILOT_SPD_UP
+    return MAX(0.0f, g2.pilot_speed_up_ms - terrain_climb_ms);
+}
+
+// Returns the maximum pilot descent rate (m/s, positive magnitude) adjusted for the
+// climb/descent rate currently being commanded by surface tracking, to always result in
+// at least PILOT_SPD_DN on full down stick.
+float Copter::get_pilot_speed_dn_adjusted_ms() const
+{
+    // terrain velocity in Up-positive frame (m/s)
+    const float terrain_climb_ms = -pos_control->get_vel_terrain_D_ms();
+    // floored at zero to prevent sign flip if terrain velocity exceeds PILOT_SPD_DN
+    return MAX(0.0f, get_pilot_speed_dn_ms() + terrain_climb_ms);
 }

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -731,6 +731,8 @@ private:
     float get_non_takeoff_throttle();
     void set_accel_throttle_I_from_pilot_throttle();
     float get_pilot_speed_dn_ms() const;
+    float get_pilot_speed_up_adjusted_ms() const;
+    float get_pilot_speed_dn_adjusted_ms() const;
     void run_rate_controller_main();
 
     // if AP_INERTIALSENSOR_FAST_SAMPLE_WINDOW_ENABLED

--- a/ArduCopter/mode_althold.cpp
+++ b/ArduCopter/mode_althold.cpp
@@ -40,7 +40,6 @@ void ModeAltHold::run()
 
     // get pilot desired climb rate
     float target_climb_rate_ms = get_pilot_desired_climb_rate_ms();
-    target_climb_rate_ms = constrain_float(target_climb_rate_ms, -get_pilot_speed_dn_ms(), get_pilot_speed_up_ms());
 
     // Alt Hold State Machine Determination
     AltHoldModeState althold_state = get_alt_hold_state_D_ms(target_climb_rate_ms);

--- a/ArduCopter/mode_flowhold.cpp
+++ b/ArduCopter/mode_flowhold.cpp
@@ -253,7 +253,6 @@ void ModeFlowHold::run()
 
     // get pilot desired climb rate
     float target_climb_rate_ms = copter.get_pilot_desired_climb_rate_ms();
-    target_climb_rate_ms = constrain_float(target_climb_rate_ms, -get_pilot_speed_dn_ms(), get_pilot_speed_up_ms());
 
     // get pilot's desired yaw rate
     float target_yaw_rate_rads = get_pilot_desired_yaw_rate_rads();

--- a/ArduCopter/mode_loiter.cpp
+++ b/ArduCopter/mode_loiter.cpp
@@ -100,7 +100,6 @@ void ModeLoiter::run()
 
     // get pilot desired climb rate
     target_climb_rate_ms = get_pilot_desired_climb_rate_ms();
-    target_climb_rate_ms = constrain_float(target_climb_rate_ms, -get_pilot_speed_dn_ms(), get_pilot_speed_up_ms());
 
     // relax loiter target if we might be landed
     if (copter.ap.land_complete_maybe) {

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -136,7 +136,6 @@ void ModePosHold::run()
 
     // pilot desired climb rate (m/s)
     float target_climb_rate_ms = get_pilot_desired_climb_rate_ms();
-    target_climb_rate_ms = constrain_float(target_climb_rate_ms, -get_pilot_speed_dn_ms(), get_pilot_speed_up_ms());
 
     // relax loiter target if we might be landed
     if (copter.ap.land_complete_maybe) {

--- a/ArduCopter/mode_sport.cpp
+++ b/ArduCopter/mode_sport.cpp
@@ -65,7 +65,6 @@ void ModeSport::run()
 
     // get pilot desired climb rate
     float target_climb_rate_ms = get_pilot_desired_climb_rate_ms();
-    target_climb_rate_ms = constrain_float(target_climb_rate_ms, -get_pilot_speed_dn_ms(), get_pilot_speed_up_ms());
 
     // Sport State Machine Determination
     AltHoldModeState sport_state = get_alt_hold_state_D_ms(target_climb_rate_ms);

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -302,8 +302,6 @@ void ModeZigZag::manual_control()
 
     // get pilot desired climb rate
     target_climb_rate_ms = get_pilot_desired_climb_rate_ms();
-    // make sure the climb rate is in the given range, prevent floating point errors
-    target_climb_rate_ms = constrain_float(target_climb_rate_ms, -get_pilot_speed_dn_ms(), get_pilot_speed_up_ms());
 
     // relax loiter target if we might be landed
     if (copter.ap.land_complete_maybe) {

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -449,6 +449,9 @@ public:
     // Returns the current terrain altitude (Down-positive, relative to EKF origin, in meters).
     float get_pos_terrain_D_m() const { return _pos_terrain_d_m; }
 
+    // Returns the current terrain correction velocity (Down-positive, m/s).
+    float get_vel_terrain_D_ms() const { return _vel_terrain_d_ms; }
+
 
     /// Offset
 


### PR DESCRIPTION
### Summary
Surface tracking can currently saturate vertical rate limits, preventing the pilot from commanding climb or descent when terrain-following is active.

This change adjusts the pilot’s effective climb/descent limits based on the terrain-following command, ensuring the pilot always retains full vertical authority while still allowing terrain tracking to operate within the overall limits.

```
Board,antennatracker,blimp,bootloader,copter,heli,plane,rover,sub
CubeOrange,*,*,*,-104,-104,*,*,*
```

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request