### PR TITLE
AP_HAL: Fix sparse endian put_le64_ptr copy-paste and add test

### DIFF
--- a/libraries/AP_HAL/utility/sparse-endian.h
+++ b/libraries/AP_HAL/utility/sparse-endian.h
@@ -115,7 +115,7 @@ static inline double be64todouble_ptr(const uint8_t *p, const uint8_t offset) { 
 static inline void put_le16_ptr(uint8_t *p, uint16_t v) { p[0] = (v&0xFF); p[1] = (v>>8); }
 static inline void put_le24_ptr(uint8_t *p, uint32_t v) { p[0] = (v&0xFF); p[1] = (v>>8)&0xFF; p[2] = (v>>16)&0xFF; }
 static inline void put_le32_ptr(uint8_t *p, uint32_t v) { p[0] = (v&0xFF); p[1] = (v>>8)&0xFF; p[2] = (v>>16)&0xFF; p[3] = (v>>24)&0xFF; }
-static inline void put_le64_ptr(uint8_t *p, uint64_t v) { p[0] = (v&0xFF); p[1] = (v>>8)&0xFF; p[2] = (v>>16)&0xFF; p[3] = (v>>24)&0xFF; p[4] = (v>>24)&0xFF;p[5] = (v>>24)&0xFF; p[6] = (v>>24)&0xFF;p[7] = (v>>24)&0xFF;}
+static inline void put_le64_ptr(uint8_t *p, uint64_t v) { p[0] = (v&0xFF); p[1] = (v>>8)&0xFF; p[2] = (v>>16)&0xFF; p[3] = (v>>24)&0xFF; p[4] = (v>>32)&0xFF;p[5] = (v>>40)&0xFF; p[6] = (v>>48)&0xFF;p[7] = (v>>56)&0xFF;}
 static inline void put_be16_ptr(uint8_t *p, uint16_t v) { p[1] = (v&0xFF); p[0] = (v>>8); }
 static inline void put_be24_ptr(uint8_t *p, uint32_t v) { p[2] = (v&0xFF); p[1] = (v>>8)&0xFF; p[0] = (v>>16)&0xFF; }
 static inline void put_be32_ptr(uint8_t *p, uint32_t v) { p[3] = (v&0xFF); p[2] = (v>>8)&0xFF; p[1] = (v>>16)&0xFF; p[0] = (v>>24)&0xFF; }

--- a/libraries/AP_HAL/utility/tests/test_sparse_endian.cpp
+++ b/libraries/AP_HAL/utility/tests/test_sparse_endian.cpp
@@ -1,0 +1,68 @@
+#include <AP_gtest.h>
+#include <stdint.h>
+
+#include <AP_HAL/utility/sparse-endian.h>
+
+TEST(EndianTest, PutLe64BasicPattern)
+{
+    uint8_t buf[8] = {};
+    const uint64_t value = 0x1122334455667788ULL;
+
+    put_le64_ptr(buf, value);
+
+    // Expected little-endian layout:
+    // LSB first
+    EXPECT_EQ(buf[0], 0x88);
+    EXPECT_EQ(buf[1], 0x77);
+    EXPECT_EQ(buf[2], 0x66);
+    EXPECT_EQ(buf[3], 0x55);
+    EXPECT_EQ(buf[4], 0x44);
+    EXPECT_EQ(buf[5], 0x33);
+    EXPECT_EQ(buf[6], 0x22);
+    EXPECT_EQ(buf[7], 0x11);
+}
+
+TEST(EndianTest, PutLe64RoundTrip)
+{
+    uint8_t buf[8] = {};
+    const uint64_t value = 0xDEADBEEFCAFEBABEULL;
+
+    put_le64_ptr(buf, value);
+
+    // Read it back using existing helper
+    uint64_t result = le64toh_ptr(buf);
+
+    EXPECT_EQ(result, value);
+}
+
+TEST(EndianTest, PutLe64Zero)
+{
+    uint8_t buf[8];
+    memset(buf, 0xFF, sizeof(buf));  // ensure overwrite
+
+    put_le64_ptr(buf, 0ULL);
+
+    for (uint8_t i = 0; i < 8; i++) {
+        EXPECT_EQ(buf[i], 0x00);
+    }
+}
+
+TEST(EndianTest, PutLe64AllBytesDifferent)
+{
+    uint8_t buf[8] = {};
+    const uint64_t value = 0x0102030405060708ULL;
+
+    put_le64_ptr(buf, value);
+
+    // This test is particularly good at catching shift bugs
+    EXPECT_EQ(buf[0], 0x08);
+    EXPECT_EQ(buf[1], 0x07);
+    EXPECT_EQ(buf[2], 0x06);
+    EXPECT_EQ(buf[3], 0x05);
+    EXPECT_EQ(buf[4], 0x04);
+    EXPECT_EQ(buf[5], 0x03);
+    EXPECT_EQ(buf[6], 0x02);
+    EXPECT_EQ(buf[7], 0x01);
+}
+
+AP_GTEST_MAIN()


### PR DESCRIPTION
### Summary

I noticed a copy-paste bug here, and added a test for that function.
Nothing else in sparse-endian.h is tested.
This function is not yet used by the codebase so no one has noticed yet.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

Fix copy paste bug

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
