### PR TITLE
hwdef: correct BATT2_MONIOTOR -> BATT2_MONITOR

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/NarinFC-X3/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/NarinFC-X3/README.md
@@ -184,7 +184,7 @@ The correct battery setting parameters are:
 
 Pads for a second analog battery monitor are provided. To use:
 
-- Set BATT2_MONIOTOR = 4
+- BATT2_MONITOR = 4
 - BATT2_VOLT_PIN = 18
 - BATT2_CURR_PIN = 7
 - BATT2_VOLT_MULT = 11.0

--- a/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7/README.md
@@ -95,7 +95,7 @@ The correct battery setting parameters are:
 
 Pads for a second analog battery monitor are provided. To use:
 
-- Set BATT2_MONIOTOR 4
+- BATT2_MONITOR 4
 - BATT2_VOLT_PIN 18
 - BATT2_CURR_PIN 7
 - BATT2_VOLT_MULT 11.0


### PR DESCRIPTION
### Summary

Corrects a simple mis-speeling in the markdown.

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

also remove "Set" as this is in a list of things to set