### PR TITLE
Change RST Wiki page references to links to the Wiki

### DIFF
--- a/Tools/scripts/check_branch_conventions.py
+++ b/Tools/scripts/check_branch_conventions.py
@@ -373,7 +373,7 @@ class CheckBranchConventions(build_script_base.BuildScriptBase):
         return ok
 
     def check_markdown_rst_hyperlinks(self) -> bool:
-        '''flag RST-style external hyperlinks (`text <url>`__) in changed markdown files'''
+        '''flag RST-style external hyperlinks (`text <url>`_ or `__) in changed markdown files'''
         changed_md = self.run_git(
             ["diff", "--name-only", "--diff-filter=AM",
              f"{self.base_branch}...HEAD", "--", "*.md"],
@@ -384,7 +384,7 @@ class CheckBranchConventions(build_script_base.BuildScriptBase):
             return True
 
         result = subprocess.run(
-            ["git", "grep", "-n", r"`[^`]*`__", "--"] + changed_md.splitlines(),
+            ["git", "grep", "-n", r"`[^`]*<[^>]*>`__\?", "--"] + changed_md.splitlines(),
             capture_output=True, text=True,
         )
         # git grep exits 1 for no matches, 0 for matches, >1 for errors

--- a/libraries/AP_HAL_ChibiOS/hwdef/ARK_FPV/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ARK_FPV/README.md
@@ -211,7 +211,7 @@ This requires building custom firmware. See the [Loading Firmware](#loading-firm
 
 ## RC Input
 
-RC input is configured on the RX6 (UART6_RX) pin. It supports all RC protocols except PPM. See :ref:`Radio Control Systems <common-rc-systems>` for details for a specific RC system. :ref:`SERIAL6_PROTOCOL<SERIAL6_PROTOCOL>` is set to “23”, by default, to enable this.
+RC input is configured on the RX6 (UART6_RX) pin. It supports all RC protocols except PPM. See [Radio Control Systems](https://ardupilot.org/copter/docs/common-rc-systems.html) for details for a specific RC system. :ref:`SERIAL6_PROTOCOL<SERIAL6_PROTOCOL>` is set to “23”, by default, to enable this.
 
 - SBUS/DSM/SRXL connects to the RX6 pin.
 - FPort requires connection to TX6 and :ref:`SERIAL6_OPTIONS<SERIAL2_OPTIONS>` be set to “7”.

--- a/libraries/AP_HAL_ChibiOS/hwdef/ARK_PI6X/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ARK_PI6X/README.md
@@ -144,7 +144,7 @@ Ports marked _Internal_ are connected directly to the Raspberry Pi.
 
 ## RC Input
 
-RC input is configured on the RX6 (UART6_RX) pin. It supports all RC protocols except PPM. See :ref:`Radio Control Systems <common-rc-systems>` for details for a specific RC system. :ref:`SERIAL6_PROTOCOL<SERIAL6_PROTOCOL>` is set to “23”, by default, to enable this.
+RC input is configured on the RX6 (UART6_RX) pin. It supports all RC protocols except PPM. See [Radio Control Systems](https://ardupilot.org/copter/docs/common-rc-systems.html) for details for a specific RC system. :ref:`SERIAL6_PROTOCOL<SERIAL6_PROTOCOL>` is set to “23”, by default, to enable this.
 
 - SBUS/DSM/SRXL connects to the RX6 pin.
 - FPort requires connection to TX6 and :ref:`SERIAL6_OPTIONS<SERIAL6_OPTIONS>` be set to “7”.

--- a/libraries/AP_HAL_ChibiOS/hwdef/ATOMRCF405NAVI-Deluxe/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ATOMRCF405NAVI-Deluxe/README.md
@@ -4,7 +4,7 @@
 
 the above image and some content courtesy of [ATOMRC](http://atomrc.com/)
 
-> **Note:** Due to flash memory limitations, this board does not include all ArduPilot features. See :ref:`Firmware Limitations <common-limited_firmware>` for details.
+> **Note:** Due to flash memory limitations, this board does not include all ArduPilot features. See [Firmware Limitations](https://ardupilot.org/copter/docs/common-limited_firmware.html) for details.
 
 ## Specifications
 
@@ -79,7 +79,7 @@ The SBUS pin, is passed by an inverter to RX2 (UART2 RX). UART2 is defaulted to 
 
 - DSM/SRXL connects to the RX2  pin, but SBUS would still be connected to SBUS.
 
-- FPort requires connection to TX2 and RX2 via a bi-directional inverter. See :ref:`common-FPort-receivers`.
+- FPort requires connection to TX2 and RX2 via a bi-directional inverter. See [FPort receivers](https://ardupilot.org/copter/docs/common-FPort-receivers.html).
 
 - CRSF/ELRS also requires a TX2 connection, in addition to RX2, and automatically provides telemetry.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ATOMRCF405NAVI-Deluxe/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ATOMRCF405NAVI-Deluxe/README.md
@@ -4,7 +4,7 @@
 
 the above image and some content courtesy of [ATOMRC](http://atomrc.com/)
 
-> **Note:** Due to flash memory limitations, this board does not include all ArduPilot features. See [Firmware Limitations](https://ardupilot.org/copter/docs/common-limited_firmware.html) for details.
+> **Note:** Due to flash memory limitations, this board does not include all ArduPilot features. See [Firmware Limitations](https://ardupilot.org/copter/docs/common-limited-firmware.html) for details.
 
 ## Specifications
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BOTWINGF405/Readme.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BOTWINGF405/Readme.md
@@ -83,7 +83,7 @@ With this option:
 * CRSF also requires a TX1 connection, in addition to R6, and automatically provides telemetry. Set :ref:`SERIAL1_OPTIONS<SERIAL1_OPTIONS>` to “0”.
 * SRXL2 requires a connection to T1 and automatically provides telemetry. Set :ref:`SERIAL1_OPTIONS<SERIAL1_OPTIONS>` to “4”.
 
-Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM. See :ref:`common-rc-systems` for more details.
+Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM. See [RC systems](https://ardupilot.org/copter/docs/common-rc-systems.html) for more details.
 
 ## OSD Support
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BROTHERHOBBYF405v3/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BROTHERHOBBYF405v3/README.md
@@ -34,7 +34,7 @@ The BROTHERHOBBYF405v3 is a flight controller produced by [BROTHERHOBBY](https:/
 The default RC input is configured on UART2, all ArduPilot compatible protocols, except PPM and SBUS, are supported. SBUS support is provided via the HD VTX connector on SERIAL1 and requires the protocol be set to :ref:`SERIAL1_PROTOCOL<SERIAL1_PROTOCOL>` = "23" and change SERIAL2 _Protocol to something other than '23'.
 
 - PPM is not supported
-- FPort requires an external bi-directional inverter (see :ref:`common-fport-receivers`)
+- FPort requires an external bi-directional inverter (see [FPort receivers](https://ardupilot.org/copter/docs/common-FPort-receivers.html))
 - CRSF requires connection to TX2 and automatically supports telemetry
 - DSM/SRXL connects to the RX2 pin, but SBUS would still be connected to SBUS.
 - SRXL2 requires a connection to TX2 and automatically provides telemetry. Set :ref:`SERIAL2_OPTIONS<SERIAL2_OPTIONS>` to "4".
@@ -93,7 +93,7 @@ The BROTHERHOBBYF405v3 does not have a built-in compass, but you can attach an e
 
 ## Firmware
 
-Firmware for the BROTHERHOBBYF405v3 can be found `here <https://firmware.ardupilot.org>`_ in sub-folders labeled “BROTHERHOBBYF405v3".
+Firmware for the BROTHERHOBBYF405v3 can be found [here](https://firmware.ardupilot.org) in sub-folders labeled “BROTHERHOBBYF405v3".
 
 ## Loading Firmware
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BROTHERHOBBYH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BROTHERHOBBYH743/README.md
@@ -33,7 +33,7 @@ The BROTHERHOBBYH743 is a flight controller produced by [BROTHERHOBBY](https://w
 
 The default RC input is configured on the UART2_RX inverted from the SBUS pin.  All unidirectional ArduPilot compatible protocols, except PPM, are supported. Receivers using bi-directional protocols such as CRSF/ELRS should be tied to the TX2 and RX2 pins.
 
-- FPort requires connection to TX2 . See :ref:`FPort Receivers<common-Fport-receivers>`.
+- FPort requires connection to TX2 . See [FPort Receivers](https://ardupilot.org/copter/docs/common-FPort-receivers.html).
 - CRSF/ELRS also requires a TX2 connection, in addition to RX2, and automatically provides telemetry.
 - SRXL2 requires a connection to TX2 and automatically provides telemetry. Set :ref:`SERIAL2_OPTIONS<SERIAL2_OPTIONS>` to "4".
 
@@ -46,7 +46,7 @@ FrSky Telemetry can be supported using the T1 pin (UART1 transmit). You need to 
 
 ## OSD Support
 
-The BROTHERHOBBYH743 supports using its internal OSD (MAX7456 driver). Simultaneous DisplayPort OSD operation  is also pre-configured on SERIAL 6. See :ref:`common-msp-osd-overview-4.2` for more info.
+The BROTHERHOBBYH743 supports using its internal OSD (MAX7456 driver). Simultaneous DisplayPort OSD operation  is also pre-configured on SERIAL 6. See [MSP OSD](https://ardupilot.org/copter/docs/common-msp-osd-overview-4.2.html) for more info.
 
 ## VTX Support
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BlitzH743Pro/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BlitzH743Pro/README.md
@@ -77,11 +77,11 @@ to use DShot.
 
 ## Video Power Control
 
-The 12V video power can be turned off/on  using GPIO 81 which is already assigned by default to RELAY2.  This relay can be controlled either from the GCS or using a transmitter channel (See :ref:`common-auxiliary-functions`)
+The 12V video power can be turned off/on  using GPIO 81 which is already assigned by default to RELAY2.  This relay can be controlled either from the GCS or using a transmitter channel (See [auxiliary functions](https://ardupilot.org/copter/docs/common-auxiliary-functions.html))
 
 ## Camera Switch
 
-The camera output can be switched using GPIO 82 which is already assigned by default to RELAY3.  This relay can be controlled either from the GCS or using a transmitter channel (See :ref:`common-auxiliary-functions`)
+The camera output can be switched using GPIO 82 which is already assigned by default to RELAY3.  This relay can be controlled either from the GCS or using a transmitter channel (See [auxiliary functions](https://ardupilot.org/copter/docs/common-auxiliary-functions.html))
 
 ## RSSI
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BlitzWingH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BlitzWingH743/README.md
@@ -71,11 +71,11 @@ to use DShot.
 
 ## Video Power Control
 
-The 9V video power can be turned off/on  using GPIO 81 which is already assigned by default to RELAY2.  This relay can be controlled either from the GCS or using a transmitter channel (See :ref:`common-auxiliary-functions`)
+The 9V video power can be turned off/on  using GPIO 81 which is already assigned by default to RELAY2.  This relay can be controlled either from the GCS or using a transmitter channel (See [auxiliary functions](https://ardupilot.org/copter/docs/common-auxiliary-functions.html))
 
 ## Camera Switch
 
-The camera output can be switched using GPIO 82 which is already assigned by default to RELAY3.  This relay can be controlled either from the GCS or using a transmitter channel (See :ref:`common-auxiliary-functions`)
+The camera output can be switched using GPIO 82 which is already assigned by default to RELAY3.  This relay can be controlled either from the GCS or using a transmitter channel (See [auxiliary functions](https://ardupilot.org/copter/docs/common-auxiliary-functions.html))
 
 ## Analog Airspeed Input
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CORVON405V2_1/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CORVON405V2_1/README.md
@@ -40,7 +40,7 @@ The default RC input is configured on the UART6_RX input which is inverted from 
 
 ## OSD Support
 
-The CORVON405V2.1 supports  internal analog OSD MAX7456. Simultaneous external HD OSD support is preconfigured on SERIAL6. See :ref:`common-msp-osd-overview-4.2` for more info.
+The CORVON405V2.1 supports  internal analog OSD MAX7456. Simultaneous external HD OSD support is preconfigured on SERIAL6. See [MSP OSD](https://ardupilot.org/copter/docs/common-msp-osd-overview-4.2.html) for more info.
 
 ## VTX Support
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CSKY405/Readme.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CSKY405/Readme.md
@@ -51,7 +51,7 @@ protocols except serial protocols such as CRSF, ELRS, etc. Instead, these device
 
 ## OSD Support
 
-The CSKY405 supports using its internal OSD using OSD_TYPE 1 (MAX7456 driver). External OSD support such as DJI or DisplayPort is supported using USART6 or any other free Uaet. See :ref:`common-msp-osd-overview-4.2` for more info.
+The CSKY405 supports using its internal OSD using OSD_TYPE 1 (MAX7456 driver). External OSD support such as DJI or DisplayPort is supported using USART6 or any other free Uaet. See [MSP OSD](https://ardupilot.org/copter/docs/common-msp-osd-overview-4.2.html) for more info.
 
 ## PWM Output
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CUAV-V6X-v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CUAV-V6X-v2/README.md
@@ -52,7 +52,7 @@ The USART3 connector is labelled debug, but is available as a general purpose UA
 
 ## RC Input
 
-RC input is configured on the port marked DSM/SBUS RC and PPM IN for all unidirectional protocols. For bi-directional or half duplex, a full UART should be used. See :ref:`common-rc-systems` for details for each protocol.
+RC input is configured on the port marked DSM/SBUS RC and PPM IN for all unidirectional protocols. For bi-directional or half duplex, a full UART should be used. See [RC systems](https://ardupilot.org/copter/docs/common-rc-systems.html) for details for each protocol.
 
 ## PWM Output
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CUAV-X25-EVO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CUAV-X25-EVO/README.md
@@ -46,7 +46,7 @@ The USART3 connector is labelled debug, but is available as a general purpose UA
 
 ## RC Input
 
-All ArduPilot supported unidirectional RC protocols can be input on the port marked RC IN, including PPM. For bi-directional or half-duplex protocols, such as CRSF/ELRS a full UART will have to be used set to `SERIALLx_PROTOCOL` = 23. See :ref:`common-rc-systems` for more details.
+All ArduPilot supported unidirectional RC protocols can be input on the port marked RC IN, including PPM. For bi-directional or half-duplex protocols, such as CRSF/ELRS a full UART will have to be used set to `SERIALLx_PROTOCOL` = 23. See [RC systems](https://ardupilot.org/copter/docs/common-rc-systems.html) for more details.
 
 ## PWM Output
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVF405/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVF405/README.md
@@ -44,7 +44,7 @@ receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
 
 RC input is configured by default via the USART2 RX input. It supports all unidirectional serial RC protocols except PPM and SBUS. The SBUS pin is inverted and applies to R2 for SBUS support.
 
-- FPort requires an external bi-directional inverter attached to T2 and :ref:`SERIAL1_OPTIONS<SERIAL1_OPTIONS>` set to 4 (half-duplex).  See :ref:`common-FPort-receivers`.
+- FPort requires an external bi-directional inverter attached to T2 and :ref:`SERIAL1_OPTIONS<SERIAL1_OPTIONS>` set to 4 (half-duplex).  See [FPort receivers](https://ardupilot.org/copter/docs/common-FPort-receivers.html).
 - CRSF/ELRS uses RX2/TX2.
 - SRXL2 requires a connection to T2 and automatically provides telemetry.  Set :ref:`SERIAL1_OPTIONS<SERIAL1_OPTIONS>` to "4".
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743/README.md
@@ -51,7 +51,7 @@ receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
 
 RC input is configured by default via the USART5 RX input. It supports all unidirectional serial RC protocols except PPM . The SBUS pin is inverted and tied to R5 for SBUS support.
 
-- FPort requires an external bi-directional inverter attached to T5 and :ref:`SERIAL5_OPTIONS<SERIAL5_OPTIONS>` set to 4 (half-duplex).  See :ref:`common-FPort-receivers`.
+- FPort requires an external bi-directional inverter attached to T5 and :ref:`SERIAL5_OPTIONS<SERIAL5_OPTIONS>` set to 4 (half-duplex).  See [FPort receivers](https://ardupilot.org/copter/docs/common-FPort-receivers.html).
 - CRSF/ELRS uses RX5/TX5.
 - SRXL2 requires a connection to T5 and automatically provides telemetry.  Set :ref:`SERIAL5_OPTIONS<SERIAL5_OPTIONS>` to "4".
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743Pro/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743Pro/README.md
@@ -52,7 +52,7 @@ receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
 
 RC input is configured by default via the USART5 RX input. It supports all unidirectional serial RC protocols except PPM . The SBUS pin is inverted and tied to R5 for SBUS support.
 
-- FPort requires an external bi-directional inverter attached to T5 and :ref:`SERIAL5_OPTIONS<SERIAL5_OPTIONS>` set to 4 (half-duplex).  See :ref:`common-FPort-receivers`.
+- FPort requires an external bi-directional inverter attached to T5 and :ref:`SERIAL5_OPTIONS<SERIAL5_OPTIONS>` set to 4 (half-duplex).  See [FPort receivers](https://ardupilot.org/copter/docs/common-FPort-receivers.html).
 - CRSF/ELRS uses RX5/TX5.
 - SRXL2 requires a connection to T5 and automatically provides telemetry.  Set :ref:`SERIAL5_OPTIONS<SERIAL5_OPTIONS>` to "4".
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743_SLIM/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743_SLIM/README.md
@@ -51,7 +51,7 @@ receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
 
 RC input is configured by default via the USART5 RX input. It supports all serial RC protocols except PPM .
 
-- FPort requires an external bi-directional inverter attached to T5 and :ref:`SERIAL5_OPTIONS<SERIAL5_OPTIONS>` set to 4 (half-duplex).  See :ref:`common-FPort-receivers`.
+- FPort requires an external bi-directional inverter attached to T5 and :ref:`SERIAL5_OPTIONS<SERIAL5_OPTIONS>` set to 4 (half-duplex).  See [FPort receivers](https://ardupilot.org/copter/docs/common-FPort-receivers.html).
 - CRSF/ELRS uses RX5/TX5.
 - SRXL2 requires a connection to T5 and automatically provides telemetry.  Set :ref:`SERIAL5_OPTIONS<SERIAL5_OPTIONS>` to "4".
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/HWH7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/HWH7/README.md
@@ -116,7 +116,7 @@ The bootloader hwdef enables flashing firmware from microSD (`AP_BOOTLOADER_FLAS
 
 Initial firmware load can be done with DFU by plugging in USB with the bootloader button pressed.
 
-Firmware can be found on the [firmware server](https://firmare.ardupilot.org) in folders marked "HWH7"
+Firmware can be found on the [firmware server](https://firmware.ardupilot.org) in folders marked "HWH7"
 
 Then load the `*_with_bl.hex` firmware using a DFU tool.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/JHEMCUF405PRO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/JHEMCUF405PRO/README.md
@@ -51,7 +51,7 @@ RC input is best configured on the RX1/TX1 (USART1_RX/USART1_TX) pins due to hav
 - CRSF also requires a T1 connection, in addition to R1, and automatically provides telemetry. Set :ref:`SERIAL1_OPTIONS<SERIAL1_OPTIONS>` to "0".
 - SRXL2 requires a connection to T1 and automatically provides telemetry. Set :ref:`SERIAL1_OPTIONS<SERIAL1_OPTIONS>` to "4".
 
-Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM. See :ref:`Radio Control Systems <common-rc-systems>` for details.
+Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM. See [Radio Control Systems](https://ardupilot.org/copter/docs/common-rc-systems.html) for details.
 
 ## OSD Support
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/JHEMCUF405WING/Readme.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/JHEMCUF405WING/Readme.md
@@ -63,19 +63,19 @@ To allow CRSF and embedded telemetry available in Fport, CRSF, and SRXL2 receive
 
 - DSM/SRXL connects to the RX1  pin, but SBUS would still be connected to SBUS.
 
-- FPort requires connection to TX1 and RX1 via a bi-directional inverter. See :ref:`common-FPort-receivers`.
+- FPort requires connection to TX1 and RX1 via a bi-directional inverter. See [FPort receivers](https://ardupilot.org/copter/docs/common-FPort-receivers.html).
 
 - CRSF also requires a TX1 connection, in addition to RX1 and automatically provides telemetry. ELRS is connected in the same way, but bit 13 of :ref:`RC_OPTIONS<RC_OPTIONS>` should be set.
 
 - SRXL2 requires a connection to TX1 and automatically provides telemetry.  Set :ref:`SERIAL1_OPTIONS<SERIAL1_OPTIONS>` to "4".
 
-> **Note:** UART1 is configured by default for serial receivers. You can also have more than one receiver in the system at a time (usually used for long range hand-offs to a remote TX). See :ref:`common-multiple-rx` for details.
+> **Note:** UART1 is configured by default for serial receivers. You can also have more than one receiver in the system at a time (usually used for long range hand-offs to a remote TX). See [multiple receivers](https://ardupilot.org/copter/docs/common-multiple-rx.html) for details.
 
-Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM (SBUS requires external inversion on other UARTs). See :ref:`common-rc-systems` for details.
+Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM (SBUS requires external inversion on other UARTs). See [RC systems](https://ardupilot.org/copter/docs/common-rc-systems.html) for details.
 
 ## OSD Support
 
-The JHEMCUF405Wing supports using its internal OSD using its MAX7456. Simultaneous external HD VTX OSD support such as DJI or DisplayPort is supported using UART5 and is configured by default. See :ref:`common-msp-osd-overview-4.2` for more info.
+The JHEMCUF405Wing supports using its internal OSD using its MAX7456. Simultaneous external HD VTX OSD support such as DJI or DisplayPort is supported using UART5 and is configured by default. See [MSP OSD](https://ardupilot.org/copter/docs/common-msp-osd-overview-4.2.html) for more info.
 
 ## PWM Output
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/JPilot-C/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/JPilot-C/README.md
@@ -139,7 +139,7 @@ Channels within the same group need to use the same output rate. If any channel 
 
 ## RC Input
 
-Any of the serial ports can be used for a bidirectional RC connection. Change its `SERIALx_PROTOCOL` to "23" and follow the instructions in :ref:`common-rc-systems` to other setup info for the RC system being used.
+Any of the serial ports can be used for a bidirectional RC connection. Change its `SERIALx_PROTOCOL` to "23" and follow the instructions in [RC systems](https://ardupilot.org/copter/docs/common-rc-systems.html) to other setup info for the RC system being used.
 
 ## Battery Monitor
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/LongBowF405WING/Readme.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/LongBowF405WING/Readme.md
@@ -57,7 +57,7 @@ Fport can be connected to USART1 TX also, but will require an external bi-direct
 
 ## OSD Support
 
-The LongBowF405WING supports using its internal OSD using OSD_TYPE 1 (MAX7456 driver). External OSD support such DisplayPor is setup by default using UART5. Simultaneous use of the internal OSD and Displayport is allowed. See :ref:`common-msp-osd-overview-4.2` for more info.
+The LongBowF405WING supports using its internal OSD using OSD_TYPE 1 (MAX7456 driver). External OSD support such DisplayPor is setup by default using UART5. Simultaneous use of the internal OSD and Displayport is allowed. See [MSP OSD](https://ardupilot.org/copter/docs/common-msp-osd-overview-4.2.html) for more info.
 
 ## PWM Output
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/LumenierLUXF765-NDAA/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/LumenierLUXF765-NDAA/README.md
@@ -187,7 +187,7 @@ Firmware for the LUX F765 - NDAA can be found [here](https://firmware.ardupilot.
 
 ## Loading Firmware
 
-The LUX F765 - NDAA does not come with ArduPilot firmware pre-installed. Use instructions here to load ArduPilot the first time :ref:`common-loading-firmware-onto-chibios-only-boards`.
+The LUX F765 - NDAA does not come with ArduPilot firmware pre-installed. Use instructions here to load ArduPilot the first time [loading firmware onto ChibiOS boards](https://ardupilot.org/copter/docs/common-loading-firmware-onto-chibios-only-boards.html).
 
 Initial firmware load can be done with DFU by plugging in USB with the
 bootloader button pressed. Then you should load the "with_bl.hex"

--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekH7A3-Wing/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekH7A3-Wing/README.md
@@ -64,7 +64,7 @@ RC input is configured on the USART2(SERIAL2). It supports all serial RC protoco
 
 ## OSD Support
 
-H7A3-SLIM supports using its internal OSD using OSD_TYPE 1 (MAX7456 driver). External OSD support such as DJI or DisplayPort is supported using any spare UART. See :ref:`common-msp-osd-overview-4.2` for more info.
+H7A3-SLIM supports using its internal OSD using OSD_TYPE 1 (MAX7456 driver). External OSD support such as DJI or DisplayPort is supported using any spare UART. See [MSP OSD](https://ardupilot.org/copter/docs/common-msp-osd-overview-4.2.html) for more info.
 
 ## PWM Output
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekH7A3/Readme.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekH7A3/Readme.md
@@ -65,7 +65,7 @@ RC input is configured on the USART2(SERIAL2). It supports all serial RC protoco
 
 ## OSD Support
 
-H7A3-SLIM supports using its internal OSD using OSD_TYPE 1 (MAX7456 driver). External OSD support such as DJI or DisplayPort is supported using any spare UART. See :ref:`common-msp-osd-overview-4.2` for more info.
+H7A3-SLIM supports using its internal OSD using OSD_TYPE 1 (MAX7456 driver). External OSD support such as DJI or DisplayPort is supported using any spare UART. See [MSP OSD](https://ardupilot.org/copter/docs/common-msp-osd-overview-4.2.html) for more info.
 
 ## PWM Output
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743-Lite/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743-Lite/README.md
@@ -108,7 +108,7 @@ The MicoAir743-Lite has an on board BlueTooth module connected to UART8(SERIAL8)
 
 ## Loading Firmware
 
-Firmware can be found on the [firmware server](https://firmare.ardupilot.org) in folders marked "MicoAir743-Lite"
+Firmware can be found on the [firmware server](https://firmware.ardupilot.org) in folders marked "MicoAir743-Lite"
 
 Initial firmware load can be done with DFU by plugging in USB with the bootloader button pressed. Then you should load the "XXXX_with_bl.hex" firmware, using your favorite DFU loading tool.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/NarinFC-H7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/NarinFC-H7/README.md
@@ -225,7 +225,7 @@ To allow CRSF and embedded telemetry available in Fport, CRSF, and SRXL2 receive
 - CRSF would require :ref:`SERIAL6_OPTIONS<SERIAL6_OPTIONS>` be set to "0".
 - SRXL2 would require :ref:`SERIAL6_OPTIONS<SERIAL6_OPTIONS>` be set to "4" and connects only the TX pin.
 
-Any UART can also be used for RC system connections in ArduPilot, and is compatible with all protocols except PPM. See :ref:`common-rc-systems` for details.
+Any UART can also be used for RC system connections in ArduPilot, and is compatible with all protocols except PPM. See [RC systems](https://ardupilot.org/copter/docs/common-rc-systems.html) for details.
 The power rail associated with this connector position is powered via USB or PMU.
 
 ## Loading Firmware

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-C3/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-C3/README.md
@@ -163,6 +163,6 @@ There are 2 CAN ports which allow connecting two independent CAN bus outputs. Ea
 
 ## Where to Buy
 
-`makeflyeasy <http://www.makeflyeasy.com>`_
+[makeflyeasy](http://www.makeflyeasy.com)
 
 [copywiki destination="plane,copter,rover,blimp"]

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-V3/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-V3/README.md
@@ -161,6 +161,6 @@ There are 2 CAN ports which allow connecting two independent CAN bus outputs. Ea
 
 ## Where to Buy
 
-`makeflyeasy <http://www.makeflyeasy.com>`_
+[makeflyeasy](http://www.makeflyeasy.com)
 
 [copywiki destination="plane,copter,rover,blimp"]

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-V6/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-V6/README.md
@@ -134,6 +134,6 @@ There are 2 CAN ports which allow connecting two independent CAN bus outputs. Ea
 
 ## Where to Buy
 
-`makeflyeasy <http://www.makeflyeasy.com>`_
+[makeflyeasy](http://www.makeflyeasy.com)
 
 [copywiki destination="plane,copter,rover,blimp"]

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-V6PRO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-V6PRO/README.md
@@ -150,6 +150,6 @@ There are 4 CAN ports which allow connecting two independent CAN bus outputs. Ea
 
 ## Where to Buy
 
-`makeflyeasy <http://www.makeflyeasy.com>`_
+[makeflyeasy](http://www.makeflyeasy.com)
 
 [copywiki destination="plane,copter,rover,blimp"]

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixSurveyA1-IND/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixSurveyA1-IND/README.md
@@ -174,6 +174,6 @@ There are 2 CAN ports that allow connecting two independent CAN bus outputs. Eac
 
 ## Where to Buy
 
-`makeflyeasy <http://www.makeflyeasy.com>`_
+[makeflyeasy](http://www.makeflyeasy.com)
 
 [copywiki destination="plane,copter,rover,blimp"]

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixSurveyA2-IND/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixSurveyA2-IND/README.md
@@ -25,7 +25,7 @@ The PixSurveyA2-IND flight controller is sold by a range of resellers listed at 
 
 ## Where to Buy
 
-`makeflyeasy <http://www.makeflyeasy.com>`_
+[makeflyeasy](http://www.makeflyeasy.com)
 
 ## Pinout
 
@@ -197,4 +197,4 @@ The board comes pre-installed with an ArduPilot compatible bootloader,
 allowing the loading of xxxxxx.apj firmware files with any ArduPilot
 compatible ground station.
 
-Firmware for these boards can be found `here <https://firmware.ardupilot.org>`_ in  sub-folders labeled "PixSurveyA2-IND".
+Firmware for these boards can be found [here](https://firmware.ardupilot.org) in  sub-folders labeled "PixSurveyA2-IND".

--- a/libraries/AP_HAL_ChibiOS/hwdef/PrincipIoTH7Pi/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PrincipIoTH7Pi/README.md
@@ -90,7 +90,7 @@ SBUS/DSM would connect to UART8 RX input.
  and connects only the TX pin.
 
 Any other UART can be used for RC system connections in ArduPilot also, see
-:ref:`common-rc-systems` for details.
+[RC systems](https://ardupilot.org/copter/docs/common-rc-systems.html) for details.
 
 ## PWM Outputs
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/RadiolinkF405/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/RadiolinkF405/README.md
@@ -32,7 +32,7 @@ receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
 ## RC Input
 
 RC input is configured on the R2 (UART2_RX) pin for most RC unidirectional protocols except SBUS which should be applied at the SBUS pin. PPM is not supported.
-For CRSF/ELRS/SRXL2 connection of the receiver to T2 will also be required. See :ref:`common-rc-systems` for more info
+For CRSF/ELRS/SRXL2 connection of the receiver to T2 will also be required. See [RC systems](https://ardupilot.org/copter/docs/common-rc-systems.html) for more info
 
 ## OSD Support
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ResoluteH7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ResoluteH7/README.md
@@ -40,7 +40,7 @@ receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
 
 RC input is configured by default via the USART2 RX input. It supports all serial RC protocols except PPM.
 
-- FPort requires an external bi-directional inverter attached to T5 and :ref:`SERIAL2_OPTIONS<SERIAL2_OPTIONS>` set to 4 (half-duplex).  See :ref:`common-FPort-receivers`.
+- FPort requires an external bi-directional inverter attached to T5 and :ref:`SERIAL2_OPTIONS<SERIAL2_OPTIONS>` set to 4 (half-duplex).  See [FPort receivers](https://ardupilot.org/copter/docs/common-FPort-receivers.html).
 - CRSF/ELRS uses RX2/TX2.
 - SRXL2 requires a connection to TX2 and automatically provides telemetry.  Set :ref:`SERIAL2_OPTIONS<SERIAL2_OPTIONS>` to "4".
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SDMODELH7V2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SDMODELH7V2/README.md
@@ -56,7 +56,7 @@ this to a peripheral requiring 5v. The 9v supply is controlled by RELAY2_PIN set
 
 ## Camera Control
 
-The Cam pin is GPIO82 and is set to be controlled by RELAY4 by default. Relay pins can be controlled either by an RC switch or GCS command. See :ref:`common-relay` for more information.
+The Cam pin is GPIO82 and is set to be controlled by RELAY4 by default. Relay pins can be controlled either by an RC switch or GCS command. See [relay documentation](https://ardupilot.org/copter/docs/common-relay.html) for more information.
 
 ## PWM Output
 
@@ -101,7 +101,7 @@ SDMODEL SDH7 V2 has a built-in compass IST8310, but you can add an external comp
 
 ## Firmware
 
-Firmware for these boards can be found `here <https://firmware.ardupilot.org>`_ in  sub-folders labeled "SDMODELH7V2".
+Firmware for these boards can be found [here](https://firmware.ardupilot.org) in  sub-folders labeled "SDMODELH7V2".
 
 ## Loading Firmware
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SULILGH7-P1-P2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SULILGH7-P1-P2/README.md
@@ -60,7 +60,7 @@ To allow CRSF and embedded telemetry available in Fport, CRSF, and SRXL2 receive
 
 - The SBUS_IN pin is internally tied to the RCIN pin.
 
-Any UART can also be used for RC system connections in ArduPilot and is compatible with all protocols except PPM. See :ref:`Radio Control Systems <common-rc-systems>` for details.
+Any UART can also be used for RC system connections in ArduPilot and is compatible with all protocols except PPM. See [Radio Control Systems](https://ardupilot.org/copter/docs/common-rc-systems.html) for details.
 
 ## PWM Output
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SVehicle-E2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SVehicle-E2/README.md
@@ -50,7 +50,7 @@ All UARTs have full DMA capability. TELEM3 can be used as an RS422 interface, th
 
 ## RC Input
 
-RC input is configured on the RCIN pin, at one end of the servo rail, marked PPM in the above diagram. All ArduPilot supported unidirectional RC protocols can be input here including PPM. For bi-directional or half-duplex protocols, such as CRSF/ELRS a full UART will have to be used. See :ref:`common-rc-systems` for details on USRT setup for other protocols.
+RC input is configured on the RCIN pin, at one end of the servo rail, marked PPM in the above diagram. All ArduPilot supported unidirectional RC protocols can be input here including PPM. For bi-directional or half-duplex protocols, such as CRSF/ELRS a full UART will have to be used. See [RC systems](https://ardupilot.org/copter/docs/common-rc-systems.html) for details on USRT setup for other protocols.
 
 ## PWM Output
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SpeedyBeeF405AIO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SpeedyBeeF405AIO/README.md
@@ -47,7 +47,7 @@ USART6 supports RX and TX DMA.
 
 ## RC Input
 
-RC input is configured on UART6. It supports all RC protocols except PPM, FPort, and SBUS. See:ref:`[Radio Control Systems<common-rc-systems>` for details for a specific RC system. :ref:`SERIAL6_PROTOCOL<SERIAL6_PROTOCOL>` is set to “23”, by default, to enable this.
+RC input is configured on UART6. It supports all RC protocols except PPM, FPort, and SBUS. See [Radio Control Systems](https://ardupilot.org/copter/docs/common-rc-systems.html) for details for a specific RC system. :ref:`SERIAL6_PROTOCOL<SERIAL6_PROTOCOL>` is set to “23”, by default, to enable this.
 
 - FPort requires an external bi-directional inverter and connects to TX 6 with :ref:`SERIAL6_OPTIONS<SERIAL6_OPTIONS>` set to "7".
 - CRSF requires a TX6 connection, in addition to RX6, and automatically provides telemetry.
@@ -96,7 +96,7 @@ The SpeedyBee F405 AIO does not have a builtin compass but an external compass c
 
 ## Camera Control
 
-The CC pin is a GPIO (pin 70) and is assigned by default to RELAY2 functionality. This pin can be controlled via GCS or by RC transmitter using the :ref:`Auxiliary Function<common-auxiliary-functions>` feature.
+The CC pin is a GPIO (pin 70) and is assigned by default to RELAY2 functionality. This pin can be controlled via GCS or by RC transmitter using the [Auxiliary Function](https://ardupilot.org/copter/docs/common-auxiliary-functions.html) feature.
 
 ## NeoPixel LED
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SpeedyBeeF405WING/Readme.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SpeedyBeeF405WING/Readme.md
@@ -53,7 +53,7 @@ Fport can be connected to USART1 TX also, but will require an external bi-direct
 
 ## OSD Support
 
-The SpeedyBeeF405Wing supports using its internal OSD using OSD_TYPE 1 (MAX7456 driver). External OSD support such as DJI or DisplayPort is supported using UART5 or any other free UART5. See :ref:`common-msp-osd-overview-4.2` for more info.
+The SpeedyBeeF405Wing supports using its internal OSD using OSD_TYPE 1 (MAX7456 driver). External OSD support such as DJI or DisplayPort is supported using UART5 or any other free UART5. See [MSP OSD](https://ardupilot.org/copter/docs/common-msp-osd-overview-4.2.html) for more info.
 
 ## PWM Output
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/StellarF4/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/StellarF4/README.md
@@ -60,11 +60,11 @@ The default RC input is configured on the UART2 RX2 input and can be used for al
 
 - SBUS/DSM/SRXL connects to the PPM pad or RX2 pin on the HD VTX connector. PPM pin connected to RX2 via inverter.
 - CRSF also requires a TX2 connection, in addition to RX2, and automatically provides telemetry.
-- FPort requires connection to TX2 and :ref:`SERIAL2_OPTIONS<SERIAL2_OPTIONS>` set to "7". See :ref:`common-FPort-receivers`.
+- FPort requires connection to TX2 and :ref:`SERIAL2_OPTIONS<SERIAL2_OPTIONS>` set to "7". See [FPort receivers](https://ardupilot.org/copter/docs/common-FPort-receivers.html).
 
 ## OSD Support
 
-StellarF4 supports using its internal OSD, and/or DisplayPort on Serial1, by default. See :ref:`common-msp-osd-overview-4.2` for more info.
+StellarF4 supports using its internal OSD, and/or DisplayPort on Serial1, by default. See [MSP OSD](https://ardupilot.org/copter/docs/common-msp-osd-overview-4.2.html) for more info.
 
 ## PWM Output
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/StellarF4V2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/StellarF4V2/README.md
@@ -56,13 +56,13 @@ The default RC input is configured on the UART2(SERIAL1) RX2 input and can be us
 
 - SBUS/DSM/SRXL/PPM connects to the SBUS pad or pin on the HD VTX connector. SBUS pad connected to RX2 via inverter.
 - CRSF also requires a TX2 connection, in addition to RX2, and automatically provides telemetry.
-- FPort requires connection to TX2 and :ref:`SERIAL1_OPTIONS<SERIAL1_OPTIONS>` set to "7". See :ref:`common-FPort-receivers`.
+- FPort requires connection to TX2 and :ref:`SERIAL1_OPTIONS<SERIAL1_OPTIONS>` set to "7". See [FPort receivers](https://ardupilot.org/copter/docs/common-FPort-receivers.html).
 - SRXL2 requires a connection to TX2 and automatically provides telemetry. Set :ref:`SERIAL1_OPTIONS<SERIAL1_OPTIONS>` to "4".
 
 ## OSD Support
 
 StellarF4V2 supports using its internal OSD using OSD_TYPE 1 (MAX7456 driver).
-External OSD support such as DJI or DisplayPort is preconfigured on SERIAL3 but supported on any spare UART. See :ref:`common-msp-osd-overview-4.2` for more info.
+External OSD support such as DJI or DisplayPort is preconfigured on SERIAL3 but supported on any spare UART. See [MSP OSD](https://ardupilot.org/copter/docs/common-msp-osd-overview-4.2.html) for more info.
 
 ## PWM Output
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/StellarH7V2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/StellarH7V2/README.md
@@ -59,13 +59,13 @@ The default RC input is configured on the UART4 RX4 input and can be used for al
 
 - PPM is not supported.
 - SBUS/DSM/SRXL connects to the RX4 pin.
-- FPort requires connection to TX4 and :ref:`SERIAL4_OPTIONS<SERIAL4_OPTIONS>` set to "7". See :ref:`common-FPort-receivers`.
+- FPort requires connection to TX4 and :ref:`SERIAL4_OPTIONS<SERIAL4_OPTIONS>` set to "7". See [FPort receivers](https://ardupilot.org/copter/docs/common-FPort-receivers.html).
 - CRSF also requires a TX4 connection, in addition to RX4, and automatically provides telemetry.
 - SRXL2 requires a connection to TX4 and automatically provides telemetry. Set :ref:`SERIAL4_OPTIONS<SERIAL4_OPTIONS>` to "4".
 
 ## OSD Support
 
-StellarH7V2 supports using its internal OSD using OSD_TYPE 1 (MAX7456 driver). Simultaneous DisplayPort OSD operation  is preconfigured on SERIAL 6 but requires OSD_TYPE2 = 5. See :ref:`common-msp-osd-overview-4.2` for more info.
+StellarH7V2 supports using its internal OSD using OSD_TYPE 1 (MAX7456 driver). Simultaneous DisplayPort OSD operation  is preconfigured on SERIAL 6 but requires OSD_TYPE2 = 5. See [MSP OSD](https://ardupilot.org/copter/docs/common-msp-osd-overview-4.2.html) for more info.
 
 ## PWM Output
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7_WING/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7_WING/README.md
@@ -126,8 +126,8 @@ GPIO 82 controls the camera output to the connectors marked "C1" and "C2". Setti
 
 ## Loading Firmware
 
-The TBS Lucid H7 Wing does not come with ArduPilot firmware pre-installed. Use the instructions here to load ArduPilot the first time :ref:`common-loading-firmware-onto-chibios-only-boards`.
-Firmware for the TBS Lucid H7 Wing can be found `here <https://firmware.ardupilot.org>`_ in sub-folders labeled “TBS_LUCID_H7_WING".
+The TBS Lucid H7 Wing does not come with ArduPilot firmware pre-installed. Use the instructions here to load ArduPilot the first time [loading firmware onto ChibiOS boards](https://ardupilot.org/copter/docs/common-loading-firmware-onto-chibios-only-boards.html).
+Firmware for the TBS Lucid H7 Wing can be found [here](https://firmware.ardupilot.org) in sub-folders labeled “TBS_LUCID_H7_WING".
 
 Initial firmware load can be done with DFU by plugging in USB with the
 bootloader button pressed. Then you should load the "with_bl.hex"

--- a/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7_WING_AIO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7_WING_AIO/README.md
@@ -126,8 +126,8 @@ GPIO 82 controls the camera output to the connectors marked "C1" and "C2". Setti
 
 ## Loading Firmware
 
-The TBS Lucid H7 Wing AIO does not come with ArduPilot firmware pre-installed. Use the instructions here to load ArduPilot the first time :ref:`common-loading-firmware-onto-chibios-only-boards`.
-Firmware for the TBS Lucid H7 Wing AIO can be found `here <https://firmware.ardupilot.org>`_ in sub-folders labeled “TBS_LUCID_H7_WING_AIO".
+The TBS Lucid H7 Wing AIO does not come with ArduPilot firmware pre-installed. Use the instructions here to load ArduPilot the first time [loading firmware onto ChibiOS boards](https://ardupilot.org/copter/docs/common-loading-firmware-onto-chibios-only-boards.html).
+Firmware for the TBS Lucid H7 Wing AIO can be found [here](https://firmware.ardupilot.org) in sub-folders labeled “TBS_LUCID_H7_WING_AIO".
 
 Initial firmware load can be done with DFU by plugging in USB with the
 bootloader button pressed. Then you should load the "with_bl.hex"

--- a/libraries/AP_HAL_ChibiOS/hwdef/ZeroOneX6/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ZeroOneX6/README.md
@@ -72,7 +72,7 @@ To allow CRSF and embedded telemetry available in Fport, CRSF, and SRXL2 receive
 - CRSF/ELRS would require :ref:`SERIAL6_OPTIONS<SERIAL6_OPTIONS>` be set to "0".
 - SRXL2 would require :ref:`SERIAL6_OPTIONS<SERIAL6_OPTIONS>` be set to "4" and connects only the TX pin.
 
-Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM. See :ref:`common-rc-systems` for details.
+Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM. See [RC systems](https://ardupilot.org/copter/docs/common-rc-systems.html) for details.
 
 ## PWM Output
 
@@ -151,7 +151,7 @@ The X6 flight controller supports switching between 5V and 3.3V PWM levels. Swit
 The board comes pre-installed with an ArduPilot compatible bootloader,
 allowing the loading of xxxxxx.apj firmware files with any ArduPilot
 compatible ground station.
-Firmware for these boards can be found `here <https://firmware.ardupilot.org>`_ in  sub-folders labeled "ZeroOneX6".
+Firmware for these boards can be found [here](https://firmware.ardupilot.org) in  sub-folders labeled "ZeroOneX6".
 
 ## Where to Buy
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ZeroOneX6_Air/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ZeroOneX6_Air/README.md
@@ -83,7 +83,7 @@ To allow CRSF and embedded telemetry available in Fport, CRSF, and SRXL2 receive
 - CRSF/ELRS would require :ref:`SERIAL6_OPTIONS<SERIAL6_OPTIONS>` be set to "0".
 - SRXL2 would require :ref:`SERIAL6_OPTIONS<SERIAL6_OPTIONS>` be set to "4" and connects only the TX pin.
 
-Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM. See :ref:`common-rc-systems` for details.
+Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM. See [RC systems](https://ardupilot.org/copter/docs/common-rc-systems.html) for details.
 
 ## PWM Output
 
@@ -163,7 +163,7 @@ The X6_Air flight controller has 2 analog inputs.
 The board comes pre-installed with an ArduPilot compatible bootloader,
 allowing the loading of xxxxxx.apj firmware files with any ArduPilot
 compatible ground station.
-Firmware for these boards can be found `here <https://firmware.ardupilot.org>`_ in  sub-folders labeled "ZeroOne_Air".
+Firmware for these boards can be found [here](https://firmware.ardupilot.org) in  sub-folders labeled "ZeroOne_Air".
 
 ## Where to Buy
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/sparknavi-blue/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/sparknavi-blue/README.md
@@ -75,7 +75,7 @@ For CRSF/ELRS, SRXL2, and bidirectional FPort with telemetry, a full UART such a
 - CRSF/ELRS would require :ref:`SERIAL2_OPTIONS<SERIAL2_OPTIONS>` be set to "0".
 - SRXL2 would require :ref:`SERIAL2_OPTIONS<SERIAL2_OPTIONS>` be set to "4" and connects only the TX pin.
 
-Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM. See :ref:`common-rc-systems` for details.
+Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM. See [RC systems](https://ardupilot.org/copter/docs/common-rc-systems.html) for details.
 
 ## PWM Outputs
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/speedybeef4v5/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/speedybeef4v5/README.md
@@ -44,7 +44,7 @@ FrSky Telemetry is supported using the Tx pin of any UART including SERIAL6/UART
 
 ## OSD Support
 
-The SpeedyBee F405 v5 supports OSD using :ref:`OSD_TYPE<OSD_TYPE>` = 1 (MAX7456 driver). Simultaneous DisplayPort OSD operation is also pre-configured via UART3. See :ref:`common-msp-osd-overview-4.2` for more info.
+The SpeedyBee F405 v5 supports OSD using :ref:`OSD_TYPE<OSD_TYPE>` = 1 (MAX7456 driver). Simultaneous DisplayPort OSD operation is also pre-configured via UART3. See [MSP OSD](https://ardupilot.org/copter/docs/common-msp-osd-overview-4.2.html) for more info.
 
 ## VTX Support
 
@@ -92,19 +92,19 @@ The SpeedyBee F405 v5 does not have a builtin compass, but you can attach an ext
 
 ## Camera Control
 
-The CC pin is a GPIO (pin 70) and is assigned by default to RELAY2 functionality. This pin can be controlled via GCS or by RC transmitter using the :ref:`Auxiliary Function<common-auxiliary-functions>` feature.
+The CC pin is a GPIO (pin 70) and is assigned by default to RELAY2 functionality. This pin can be controlled via GCS or by RC transmitter using the [Auxiliary Function](https://ardupilot.org/copter/docs/common-auxiliary-functions.html) feature.
 
 ## VTX power control
 
 GPIO 71 controls the VTX BEC output to pins marked "9V". Setting this GPIO high removes voltage supply to pins.
 
-By default RELAY3 is configured to control this pin and sets the GPIO low. This pin can be controlled via GCS or by RC transmitter using the :ref:`Auxiliary Function<common-auxiliary-functions>` feature.
+By default RELAY3 is configured to control this pin and sets the GPIO low. This pin can be controlled via GCS or by RC transmitter using the [Auxiliary Function](https://ardupilot.org/copter/docs/common-auxiliary-functions.html) feature.
 
 ## Programmable Power Switch
 
 GPIO 72 controls the programmable switch labeled “P+ / P−”, P- is connected to GND. P+ outputs 5V. Setting this GPIO low disables the voltage supply to the P+ pin.
 
-By default, RELAY4 is configured to control this GPIO and keeps it low.This pin can be controlled via GCS or by RC transmitter using the :ref:`Auxiliary Function<common-auxiliary-functions>` feature.
+By default, RELAY4 is configured to control this GPIO and keeps it low.This pin can be controlled via GCS or by RC transmitter using the [Auxiliary Function](https://ardupilot.org/copter/docs/common-auxiliary-functions.html) feature.
 
 ## Firmware
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/uav-dev-fc-um982/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/uav-dev-fc-um982/README.md
@@ -150,7 +150,7 @@ Via DroneCAN by UAV-DEV-POWERMODULE
 
 ## Compass
 
-The autopilot includes an internal compass as well as GNSS-based heading, but GNSS-based heading is the recommended heading source. Proper setup and placement of the dual antennas is required as well as setup of the moving baseline parameters, see :ref:`common-gps-for-yaw` for more details.
+The autopilot includes an internal compass as well as GNSS-based heading, but GNSS-based heading is the recommended heading source. Proper setup and placement of the dual antennas is required as well as setup of the moving baseline parameters, see [GPS for yaw](https://ardupilot.org/copter/docs/common-gps-for-yaw.html) for more details.
 
 ## Motor Output
 


### PR DESCRIPTION
### Summary

`:ref:` is a sphinxism - it doesn't belong in markdown.  Replace with markdown style links for non-parameter references.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

URLs have been tested and work.

### Description

Replace :ref: with markdown.  But not for `:ref:` for parameters - that's a future PR.

Also fixes a few broken URLs.
