### PR TITLE
Add support for Shanghai Fudan Microelectronics (FMSH) FM25Q series NOR Flash

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_FlashMemory_LittleFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_FlashMemory_LittleFS.cpp
@@ -619,6 +619,9 @@ void AP_Filesystem_FlashMemory_LittleFS::mark_dead()
 #define JEDEC_ID_CYPRESS_S25FL128L     0x016018
 #define JEDEC_ID_GIGA_GD25Q16E         0xC84015
 #define JEDEC_ID_ZBIT_ZB25VQ128        0x5E4018 
+#define JEDEC_ID_FMSH_FM25Q64          0xA14017
+#define JEDEC_ID_FMSH_FM25Q128A        0xA14018
+#define JEDEC_ID_FMSH_FM25Q256         0xA14019
 
 /* Hardware-specific constants */
 
@@ -780,6 +783,7 @@ uint32_t AP_Filesystem_FlashMemory_LittleFS::find_block_size_and_count() {
 
     case JEDEC_ID_MICRON_N25Q064:
     case JEDEC_ID_WINBOND_W25Q64:
+    case JEDEC_ID_FMSH_FM25Q64:
     case JEDEC_ID_MACRONIX_MX25L6406E:
     case JEDEC_ID_CYPRESS_S25FL064L:
         block_count = 128;    /* 8MiB */
@@ -790,11 +794,13 @@ uint32_t AP_Filesystem_FlashMemory_LittleFS::find_block_size_and_count() {
     case JEDEC_ID_WINBOND_W25Q128_2:
     case JEDEC_ID_CYPRESS_S25FL128L:
     case JEDEC_ID_ZBIT_ZB25VQ128:   
+    case JEDEC_ID_FMSH_FM25Q128A:
         block_count = 256;    /* 16MiB */
         break;
 
     case JEDEC_ID_WINBOND_W25Q256:
     case JEDEC_ID_MACRONIX_MX25L25635E:
+    case JEDEC_ID_FMSH_FM25Q256:
         block_count = 512;    /* 32MiB */
         use_32bit_address = true;
         break;

--- a/libraries/AP_FlashIface/AP_FlashIface_JEDEC.cpp
+++ b/libraries/AP_FlashIface/AP_FlashIface_JEDEC.cpp
@@ -47,6 +47,7 @@ struct supported_device {
 static const struct supported_device supported_devices[] = {
     {"mt25q",       0x20, 0xBA, SupportedDeviceType::QuadSPI},  // https://www.mouser.in/datasheet/2/671/mict_s_a0003959700_1-2290909.pdf
     {"w25q",        0xEF, 0x40, SupportedDeviceType::QuadSPI},
+    {"fm25q",       0xA1, 0x40, SupportedDeviceType::QuadSPI}, //add by FMSH FAE ，NOR Flash  FM25Q64(0xA14017) / FM25Q128A(0xA14017)/FM25Q256 (0xA14017)
     {"w25q-dtr",    0xEF, 0x70, SupportedDeviceType::QuadSPI},
 };
 

--- a/libraries/AP_Logger/AP_Logger_Flash_JEDEC.cpp
+++ b/libraries/AP_Logger/AP_Logger_Flash_JEDEC.cpp
@@ -59,6 +59,9 @@ extern const AP_HAL::HAL& hal;
 #define JEDEC_ID_CYPRESS_S25FL128L     0x016018
 #define JEDEC_ID_GIGA_GD25Q16E         0xC84015
 #define JEDEC_ID_ZBIT_ZB25VQ128        0x5E4018
+#define JEDEC_ID_FMSH_FM25Q64          0xA14017
+#define JEDEC_ID_FMSH_FM25Q128A        0xA14018
+#define JEDEC_ID_FMSH_FM25Q256         0xA14019
 
 void AP_Logger_Flash_JEDEC::Init()
 {
@@ -138,6 +141,7 @@ bool AP_Logger_Flash_JEDEC::getSectorCount(void)
         break;
     case JEDEC_ID_MICRON_N25Q064:
     case JEDEC_ID_WINBOND_W25Q64:
+    case JEDEC_ID_FMSH_FM25Q64:
     case JEDEC_ID_MACRONIX_MX25L6406E:
     case JEDEC_ID_CYPRESS_S25FL064L:
         blocks = 128;
@@ -147,6 +151,7 @@ bool AP_Logger_Flash_JEDEC::getSectorCount(void)
     case JEDEC_ID_MICRON_N25Q128:
     case JEDEC_ID_WINBOND_W25Q128:
     case JEDEC_ID_WINBOND_W25Q128_2:
+    case JEDEC_ID_FMSH_FM25Q128A:
     case JEDEC_ID_CYPRESS_S25FL128L:
     case JEDEC_ID_ZBIT_ZB25VQ128:   
         blocks = 256;
@@ -154,6 +159,7 @@ bool AP_Logger_Flash_JEDEC::getSectorCount(void)
         df_PagePerSector = 16;
         break;
     case JEDEC_ID_WINBOND_W25Q256:
+    case JEDEC_ID_FMSH_FM25Q256:
     case JEDEC_ID_MACRONIX_MX25L25635E:
         blocks = 512;
         df_PagePerBlock = 256;


### PR DESCRIPTION
This PR adds support for Shanghai Fudan Microelectronics (FMSH) FM25Q series NOR Flash (64M/128M/256M).

Key changes:

AP_FlashIface: Added JEDEC manufacturer ID (0xA1) for hardware detection.

AP_Logger: Defined JEDEC IDs and added capacity configurations for FM25Q64/FM25Q128A/FM25Q256.

AP_Filesystem: Configured LittleFS block counts for the FMSH series.

The implementation is based on vendor specifications and follows the existing driver structure for SPI flash devices.