### PR TITLE
Use python's keyword-only arguments to mandate call-site clarity

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -7816,7 +7816,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.context_pop()
         self.reboot_sitl()
 
-    def hover_and_check_matched_frequency(self, dblevel=-15, minhz=200, maxhz=300, fftLength=32, peakhz=None):
+    def hover_and_check_matched_frequency(self, *, dblevel=-15, minhz=200, maxhz=300, fftLength=32, peakhz=None):
         '''do a simple up-and-down test flight with current vehicle state.
         Check that the onboard filter comes up with the same peak-frequency that
         post-processing does.'''

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -8005,7 +8005,12 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         })
 
         self.reboot_sitl()
-        freq = self.hover_and_check_matched_frequency(-15, 100, 250, 64)
+        freq = self.hover_and_check_matched_frequency(
+            dblevel=-15,
+            minhz=100,
+            maxhz=250,
+            fftLength=64,
+        )
 
         # Step 2: add a second harmonic and check the first is still tracked
         self.start_subtest("Add a fixed frequency harmonic at twice the hover frequency "
@@ -8018,7 +8023,13 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         })
         self.reboot_sitl()
 
-        self.hover_and_check_matched_frequency(-15, 100, 250, 64, None)
+        self.hover_and_check_matched_frequency(
+            dblevel=-15,
+            minhz=100,
+            maxhz=250,
+            fftLength=64,
+            peakhz=None,
+        )
 
         # Step 3: switch harmonics mid flight and check for tracking
         self.start_subtest("Switch harmonics mid flight and check the right harmonic is found")
@@ -8131,7 +8142,13 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.reboot_sitl()
 
         # find a motor peak
-        self.hover_and_check_matched_frequency(-15, 100, 350, 128, 250)
+        self.hover_and_check_matched_frequency(
+            dblevel=-15,
+            minhz=100,
+            maxhz=350,
+            fftLength=128,
+            peakhz=250,
+        )
 
         # Step 1b: run the same test with an FFT length of 256 which is needed to flush out a
         # whole host of bugs related to uint8_t. This also tests very accurately the frequency resolution
@@ -8141,7 +8158,13 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.reboot_sitl()
 
         # find a motor peak
-        self.hover_and_check_matched_frequency(-15, 100, 350, 256, 250)
+        self.hover_and_check_matched_frequency(
+            dblevel=-15,
+            minhz=100,
+            maxhz=350,
+            fftLength=256,
+            peakhz=250,
+        )
         self.set_parameter("FFT_WINDOW_SIZE", 128)
 
         # Step 2: inject actual motor noise and use the standard length FFT to track it
@@ -8156,7 +8179,12 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         })
 
         self.reboot_sitl()
-        freq = self.hover_and_check_matched_frequency(-15, 100, 250, 32)
+        freq = self.hover_and_check_matched_frequency(
+            dblevel=-15,
+            minhz=100,
+            maxhz=250,
+            fftLength=32,
+        )
 
         self.set_parameter("SIM_VIB_MOT_MULT", 1.)
 


### PR DESCRIPTION
### Summary

This PR is intended as a discussion starter: "How could we use Python's keyword-only arguments to improve code clarity?"

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

(This is a change to autotests, so it is automatically verified by CI.)

### Motivation

Consider the following function call which exists in our autotest code:
```
self.hover_and_check_matched_frequency(-15, 250, 100, 64, None)
```
Do you understand what this does?
I'll bet a drink-of-choice that you don't recall which arguments each value belongs to!

<details>
  <summary>Did you win the bet? Click here...</summary>

  Then you must have noticed that I lied, and injected a mistake 😈. The actual line in our code is:
  ```
  self.hover_and_check_matched_frequency(-15, 100, 250, 64, None)
  ```
  (Fortunately in this specific case, the bug I created by swapping the arg-value order probably would be caught by other mechanisms.)
</details>

If you agree this could be improved, you've probably also already thought of several ways. The big-picture question at the heart of this PR is **Should we have forbidden this (probably unclear) function-call from being possible?**

### A Possible Solution

[Keyword-only arguments](https://peps.python.org/pep-3102/) are one Python feature which could be used in this way. The first commit in this PR (a 1-liner, adding the '*') successfully forbids the situation. The second commit in the PR updates all the existing calls so that they comply with the (new) mandate.

Of course every time we "force explicitness" onto developers, that's an opinion-based judgement call with pros and cons.

This PR was created at the request of @peterbarker , because using this feature in this way is not common in our Python, and code that folks don't understand is no better than hard-to-read code.

My own personal favorite stance aligns with common linter tooling like [Pylint's R0917](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/too-many-positional-arguments.html): A function may only have N positional arguments. (Personally, I like N=4.)

But IMO more importantly, especially for "flexible"/"modified-as-needed" code like our autotest suite, kw-only args are a great tool to have available for ensuring that args which are only occasionally used must be "explicitly named at the call site". So distinct from a controversial yes/no agreement on a rule like Pylint R0917, we **should** permit authors to propose making certain arguments kw-only, and resolve each specific situation via the PR review process.

Said differently: We **should not forbid** using keyword-only arguments to enforce clarity on ourselves and our fellow devs.

### Call to Action

Please Approve this PR in order to imply "Yes, I agree that kw-only args should not be forbidden in ArduPilot's python code."

Additionally, it will also indicate that in the specific case changed by this PR, you agree that using kw-only args is better than before.

Note that approving it does _not_ mean:
- A future PR author _must_ use kw-only args, despite personally not wanting to. (Every PR is a discussion of its specific case.)
- A PR-ed and approved usage of kw-only args cannot be "undone" in the future by another PR. (Yes, that's churn... but risk of churn is better than stagnation.)


Please Request-Changes to indicate "No, I don't think kw-only args should ever be used."

Please use Comment for all other ideas/feedback/suggestions/etc. They are all welcome!
Very likely, if this discussion gains momentum, it will come up in at least one DevCall in the future.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
