### PR TITLE
Set wp yaw behavior

### DIFF
--- a/ArduCopter/RC_Channel_Copter.cpp
+++ b/ArduCopter/RC_Channel_Copter.cpp
@@ -142,6 +142,7 @@ void RC_Channel_Copter::init_aux_function(const AUX_FUNC ch_option, const AuxSwi
     case AUX_FUNC::FORCEFLYING:
     case AUX_FUNC::CUSTOM_CONTROLLER:
     case AUX_FUNC::WEATHER_VANE_ENABLE:
+    case AUX_FUNC::WP_YAW_BEHAVIOR_0_2:
 #if AP_RC_TRANSMITTER_TUNING_ENABLED
     case AUX_FUNC::TRANSMITTER_TUNING:
     case AUX_FUNC::TRANSMITTER_TUNING2:
@@ -583,6 +584,20 @@ bool RC_Channel_Copter::do_aux_function(const AuxFuncTrigger &trigger)
             }
             break;
 #endif
+
+        case AUX_FUNC::WP_YAW_BEHAVIOR_0_2:
+            switch (ch_flag) {
+            case AuxSwitchPos::LOW:
+                copter.g.wp_yaw_behavior.set(Copter::WPYawBehavior::NONE);
+                break;
+            case AuxSwitchPos::MIDDLE:
+                // no change
+                break;
+            case AuxSwitchPos::HIGH:
+                copter.g.wp_yaw_behavior.set(Copter::WPYawBehavior::LOOK_AT_NEXT_WP_EXCEPT_RTL);
+                break;
+            }
+            break;
 
         case AUX_FUNC::FLIGHTMODE_PAUSE:
             switch (ch_flag) {

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -252,6 +252,7 @@ const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Values{Plane}: 184: System ID Chirp
     // @Values{Copter, Rover, Plane, Blimp, Sub}:  185:Mount Roll/Pitch Lock
     // @Values{Copter, Rover, Plane, Blimp, Sub}:  186:Mount POI Lock
+    // @Values{Copter}: 187:WP Yaw Behavior 0/2
     // @Values{Rover}: 201:Roll
     // @Values{Rover}: 202:Pitch
     // @Values{Rover}: 207:MainSail

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -372,6 +372,7 @@ public:
 #if AP_MOUNT_POI_LOCK_ENABLED
         MOUNT_POI_LOCK =     186,  // Lock mount target to current ROI seen and switch mount to GPS Targeting mode
 #endif  // AP_MOUNT_POI_LOCK_ENABLED
+        WP_YAW_BEHAVIOR_0_2 = 187, // switch Copter WP_YAW_BEHAVIOR between 0 and 2
         // inputs from 200 will eventually used to replace RCMAP
         ROLL =               201, // roll input
         PITCH =              202, // pitch input


### PR DESCRIPTION
### Summary

<!-- Put a one or two line summary of what your PR does here -->
Adds a new RC aux switch option to allow switching WP_YAW_BEHAVIOR between modes 0 and 2 during flight.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

<!-- Put additional testing description for this PR's changes here -->
#### on SITL
assign RC channel 7 to the new aux option
```
param set RC7_OPTION 187
param show WP_YAW_BEHAVIOR
```

toggle between High, Mid, Low values of RC channel 7. In the middle display the parameter WP_YAW_BEHAVIOR.
One thing I noticed is when manually testing, is parameter change of WP_YAW_BEHAVIOR does not get updated in mavproxy side. I had to do `param fetch WP_YAW_BEHAVIOR`.

```
rc 7 1000
param fetch WP_YAW_BEHAVIOR
param show WP_YAW_BEHAVIOR # (if needed)
```
same for 
```
rc 7 1500
rc 7 2000
```

### Description

<!-- Describe the PR's content here -->
This PR adds a new RC aux switch option (value 187) to allow pilots to change the WP_YAW_BEHAVIOR parameter in-flight.

The switch behavior is:

- LOW : sets WP_YAW_BEHAVIOR to 0 (NONE)
- HIGH: sets WP_YAW_BEHAVIOR to 2 (LOOK_AT_NEXT_WP_EXCEPT_RTL)
- MID : no change


Happy to adjust behavior based on feedback.
<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->


fixes #2471