### PR TITLE
autotest: add tests for copter circle mode speeds

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -769,6 +769,72 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.wait_disarmed(timeout=600)
         self.context_pop()
 
+    # test circle speed - should be constant degrees/second:
+    def CircleSpeed(self):
+        '''test the consistent-ground-speed-circling works'''
+        self.takeoff(10, mode='LOITER')
+        self.hover()  # circle mode uses throttle input
+        self.change_mode('CIRCLE')
+        tests = [
+            (10, 20),
+            (20, 10),
+        ]
+        for (radius_m, rate_degs) in tests:
+            self.set_parameters({
+                "CIRCLE_RADIUS_M": radius_m,
+                "CIRCLE_RATE": rate_degs,
+            })
+            self.change_mode('LOITER')
+            self.change_mode('CIRCLE')
+            expected_groundspeed = math.pi * 2 * radius_m * (rate_degs/360)
+            self.wait_groundspeed(
+                expected_groundspeed-0.1,
+                expected_groundspeed+0.1,
+                minimum_duration=10,
+            )
+        self.do_RTL()
+
+    # test copter-circle-speed lua script:
+    def LuaCopterCircleSpeed(self):
+        '''test the consistent-ground-speed-circling works'''
+        self.install_example_script_context('copter-circle-speed.lua')
+        self.set_parameters({
+            "SCR_ENABLE": 1,
+            "WP_ACC": 5,
+        })
+        self.reboot_sitl()
+
+        expected_groundspeed = 3
+        self.set_parameter("CSPD_SPEED", expected_groundspeed)
+        radius_m = self.get_parameter('CIRCLE_RADIUS_M')
+        circle_point = self.offset_location_heading_distance(
+            self.mav.location(),
+            270,  # see SITL_START_LOCATION, FIXME!
+            radius_m
+        )
+
+        self.change_mode('LOITER')
+        self.wait_ready_to_arm()
+
+        self.takeoff(10, mode='LOITER')
+        self.hover()  # circle mode uses throttle input
+        self.change_mode('CIRCLE')
+
+        self.wait_groundspeed(
+            expected_groundspeed-0.2,
+            expected_groundspeed+0.2,
+            minimum_duration=10,
+        )
+        self.set_rc(2, 1550)  # pilot increases radius
+        self.wait_distance_to_location(circle_point, radius_m*2-1, radius_m*2+1)
+        self.set_rc(2, 1500)
+        self.wait_groundspeed(
+            expected_groundspeed-0.2,
+            expected_groundspeed+0.2,
+            minimum_duration=10,
+        )
+        self.do_RTL()
+
     # enter RTL mode and wait for the vehicle to disarm
     def do_RTL(self, distance_min=None, check_alt=True, distance_max=10, timeout=250, quiet=False):
         """Enter RTL mode and wait for the vehicle to disarm at Home."""
@@ -16568,6 +16634,8 @@ return update, 1000
             self.ScriptCopterPosOffsets,
             self.MountSolo,
             self.MountSiyiZT30,
+            self.CircleSpeed,
+            self.LuaCopterCircleSpeed,
             self.MountTopotek,
             self.MountViewPro,
             self.MountAVTCM62,

--- a/libraries/AP_Scripting/examples/copter-circle-speed.lua
+++ b/libraries/AP_Scripting/examples/copter-circle-speed.lua
@@ -4,7 +4,12 @@
 -- this script waits for the vehicle to be armed and in circle mode and then
 -- updates the target rate around the circle (in degrees / sec) to maintain the desired ground speed
 
-local circle_ground_speed = 6 -- the ground speed in circle mode (m/s)
+-- create and initialise parameters
+local PARAM_TABLE_KEY = 95
+assert(param:add_table(PARAM_TABLE_KEY, "CSPD_", 1), 'could not add param table')
+assert(param:add_param(PARAM_TABLE_KEY, 1, 'SPEED', 6), 'could not add CSPD_SPEED param') -- ground speed in circle mode (m/s)
+
+local circle_ground_speed = Parameter("CSPD_SPEED")
 
 function update() -- this is the loop which periodically runs
 
@@ -21,7 +26,7 @@ function update() -- this is the loop which periodically runs
   end
 
   -- set the rate to give the desired ground speed at the current radius
-  local new_rate = 360 * (circle_ground_speed / (radius*math.pi*2))
+  local new_rate = 360 * (circle_ground_speed:get() / (radius*math.pi*2))
   new_rate = math.max(new_rate, -90)
   new_rate = math.min(new_rate, 90)
   if not vehicle:set_circle_rate(new_rate) then


### PR DESCRIPTION
### Summary

Adds two tests for Copter Circle mode.  One just making sure the changing the radius changes the angular speed,  the other that a script can make the Copter keep a constant groundspeed regardless of radius.  The latter is currently broken - either as a test or in the code, I'm not sure!

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

See issue for details; basically the non-Lua test passes, the Lua-test fails as the ground speed is not appropiately constrained by the Lua script by adjuting the angular  speed.

The failing test is in the failing list; once someone fixes the issue it can be removed from the failing list.

Issue is here: https://github.com/ArduPilot/ardupilot/issues/32799
