### PR TITLE
Add DroneCAN CircuitStatus logging

### DIFF
--- a/Tools/autotest/test_build_options.py
+++ b/Tools/autotest/test_build_options.py
@@ -249,6 +249,7 @@ class TestBuildOptions(object):
             'AP_RANGEFINDER_ENABLED',  # only at vehicle level ATM
             'HAL_PERIPH_SUPPORT_LONG_CAN_PRINTF',  # no symbol
             'AP_DRONECAN_VOLZ_FEEDBACK_ENABLED',  # broken, no subscriber
+            'AP_DRONECAN_LOG_CIRCUIT_STATUS_ENABLED',  # no symbol
             # Baro drivers either come in because you have
             # external-probing enabled or you have them specified in
             # your hwdef.  If you're not probing and its not in your

--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -498,6 +498,7 @@ BUILD_OPTIONS = [
     Feature('Actuators', 'KDECAN', 'AP_KDECAN_ENABLED', 'KDE Direct KDECAN ESC', 0, None),
     Feature('Actuators', 'HimarkServo', 'AP_DRONECAN_HIMARK_SERVO_SUPPORT', 'Enable Himark DroneCAN servos', 0, "DroneCAN"),
     Feature('Actuators', 'HobbywingESC', 'AP_DRONECAN_HOBBYWING_ESC_SUPPORT', 'Enable Hobbywing DroneCAN ESCs', 0, "DroneCAN,ESC_TELEM"),  # noqa: E501
+    Feature('Actuators', 'LogCircuitStatus_DroneCAN', 'AP_DRONECAN_LOG_CIRCUIT_STATUS_ENABLED', 'Enable DroneCAN circuit status logging', 0, "DroneCAN,Logging"),  # noqa: E501
 
     Feature('Precision Landing', 'PrecLand', 'AC_PRECLAND_ENABLED', 'Enable Precision landing support', 0, None),
     Feature('Precision Landing', 'PrecLand - Companion', 'AC_PRECLAND_MAVLINK_ENABLED', 'Enable MAVLink precision landing support', 0, "PrecLand"),  # noqa

--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -348,6 +348,7 @@ class ExtractFeatures(BuildScriptBase):
             'HAL_PERIPH_SUPPORT_LONG_CAN_PRINTF',  # this define changes single method body, hard to detect?
             'AP_PLANE_BLACKBOX_LOGGING', # no visible signature
             'AC_POLYFENCE_CIRCLE_INT_SUPPORT_ENABLED',  # no visible signature
+            'AP_DRONECAN_LOG_CIRCUIT_STATUS_ENABLED',  # no visible signature
         ])
         for option in build_options.BUILD_OPTIONS:
             if option.define in whitelist:

--- a/libraries/AP_DroneCAN/AP_DroneCAN.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.cpp
@@ -1416,6 +1416,59 @@ void AP_DroneCAN::handle_actuator_status(const CanardRxTransfer& transfer, const
 
     servo_telem->update_telem_data(msg.actuator_id - 1, telem_data);
 }
+
+/*
+    handle circuit status message     
+*/
+void AP_DroneCAN::handle_circuit_status(const CanardRxTransfer& transfer, const uavcan_equipment_power_CircuitStatus& msg)
+{
+
+    if (msg.circuit_id >= DRONECAN_SRV_NUMBER) {
+        return;
+    }
+
+    AP_Servo_Telem *servo_telem = AP_Servo_Telem::get_singleton();
+
+    if (servo_telem == nullptr || !servo_telem->is_active(msg.circuit_id - 1)) {
+        return;
+    }
+
+    const AP_Servo_Telem::TelemetryData telem_data {
+        .voltage = msg.voltage,
+        .current = msg.current,
+        .status_flags = msg.error_flags,
+        .present_types = AP_Servo_Telem::TelemetryData::Types::VOLTAGE |
+                         AP_Servo_Telem::TelemetryData::Types::CURRENT |
+                         AP_Servo_Telem::TelemetryData::Types::STATUS
+    };
+
+    servo_telem->update_telem_data(msg.circuit_id - 1, telem_data);
+}
+
+/*
+    handle equipment temperature message
+*/
+void AP_DroneCAN::handle_device_temperature(const CanardRxTransfer& transfer, const uavcan_equipment_device_Temperature& msg)
+{
+    
+    if (msg.device_id >= DRONECAN_SRV_NUMBER) {
+        return;
+    }
+
+    AP_Servo_Telem *servo_telem = AP_Servo_Telem::get_singleton();
+
+    if (servo_telem == nullptr || !servo_telem->is_active(msg.device_id - 1)) {
+        return;
+    }
+    
+    const AP_Servo_Telem::TelemetryData telem_data {
+        .motor_temperature_cdeg = int16_t(msg.temperature * 100),
+        .present_types = AP_Servo_Telem::TelemetryData::Types::MOTOR_TEMP
+    };
+
+    servo_telem->update_telem_data(msg.device_id - 1, telem_data);
+}
+
 #endif
 
 #if AP_DRONECAN_HIMARK_SERVO_SUPPORT && AP_SERVO_TELEM_ENABLED

--- a/libraries/AP_DroneCAN/AP_DroneCAN.cpp
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.cpp
@@ -1407,6 +1407,61 @@ void AP_DroneCAN::handle_actuator_status(const CanardRxTransfer& transfer, const
 }
 #endif
 
+#if AP_SERVO_TELEM_ENABLED || AP_DRONECAN_LOG_CIRCUIT_STATUS_ENABLED
+/*
+    handle circuit status message
+*/
+void AP_DroneCAN::handle_circuit_status(const CanardRxTransfer& transfer, const uavcan_equipment_power_CircuitStatus& msg)
+{
+#if AP_SERVO_TELEM_ENABLED
+    if (msg.circuit_id >= 1 && msg.circuit_id <= DRONECAN_SRV_NUMBER &&
+        (_servo_bm & (1U << (msg.circuit_id - 1)))) {
+        // circuit_id maps to a channel we are driving as a DroneCAN servo,
+        // route into AP_Servo_Telem so it is logged alongside other servo telemetry
+        const uint8_t servo_index = msg.circuit_id - 1;
+
+        AP_Servo_Telem *servo_telem = AP_Servo_Telem::get_singleton();
+        if (servo_telem != nullptr && servo_telem->is_active(servo_index)) {
+            const AP_Servo_Telem::TelemetryData telem_data {
+                .voltage = msg.voltage,
+                .current = msg.current,
+                .status_flags = msg.error_flags,
+                .present_types = AP_Servo_Telem::TelemetryData::Types::VOLTAGE |
+                                 AP_Servo_Telem::TelemetryData::Types::CURRENT |
+                                 AP_Servo_Telem::TelemetryData::Types::STATUS
+            };
+            servo_telem->update_telem_data(servo_index, telem_data);
+        }
+        return;
+    }
+#endif  // AP_SERVO_TELEM_ENABLED
+
+#if AP_DRONECAN_LOG_CIRCUIT_STATUS_ENABLED && HAL_LOGGING_ENABLED
+    if (AP::logger().logging_enabled()) {
+// @LoggerMessage: CSCU
+// @Description: Generic DroneCAN circuit status
+// @Field: TimeUS: Time since system startup
+// @Field: I: driver index
+// @Field: Id: circuit id
+// @Field: V: Voltage
+// @Field: A: Current
+// @Field: Err: error flags
+        AP::logger().WriteStreaming("CSCU",
+                                    "TimeUS,I,Id,V,A,Err",
+                                    "s#-vA-",
+                                    "F-----",
+                                    "QBHffB",
+                                    AP_HAL::micros64(),
+                                    _driver_index,
+                                    msg.circuit_id,
+                                    msg.voltage,
+                                    msg.current,
+                                    msg.error_flags);
+    }
+#endif // AP_DRONECAN_LOG_CIRCUIT_STATUS_ENABLED && HAL_LOGGING_ENABLED
+}
+#endif // AP_SERVO_TELEM_ENABLED || AP_DRONECAN_LOG_CIRCUIT_STATUS_ENABLED
+
 #if AP_DRONECAN_HIMARK_SERVO_SUPPORT && AP_SERVO_TELEM_ENABLED
 /*
   handle himark ServoInfo message

--- a/libraries/AP_DroneCAN/AP_DroneCAN.h
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.h
@@ -337,6 +337,14 @@ private:
 #if AP_SERVO_TELEM_ENABLED
     Canard::ObjCallback<AP_DroneCAN, uavcan_equipment_actuator_Status> actuator_status_cb{this, &AP_DroneCAN::handle_actuator_status};
     Canard::Subscriber<uavcan_equipment_actuator_Status> actuator_status_listener{actuator_status_cb, _driver_index};
+
+    // add in circuit status listener
+    Canard::ObjCallback<AP_DroneCAN, uavcan_equipment_power_CircuitStatus> circuit_status_cb{this, &AP_DroneCAN::handle_circuit_status};
+    Canard::Subscriber<uavcan_equipment_power_CircuitStatus> circuit_status_listener{circuit_status_cb, _driver_index};
+
+    // add in device temperature 
+    Canard::ObjCallback<AP_DroneCAN, uavcan_equipment_device_Temperature> device_temp_cb{this, &AP_DroneCAN::handle_device_temperature};
+    Canard::Subscriber<uavcan_equipment_device_Temperature> device_temp_listener{device_temp_cb, _driver_index};    
 #endif
 
     Canard::ObjCallback<AP_DroneCAN, uavcan_equipment_esc_Status> esc_status_cb{this, &AP_DroneCAN::handle_ESC_status};
@@ -421,6 +429,8 @@ private:
     void handle_traffic_report(const CanardRxTransfer& transfer, const ardupilot_equipment_trafficmonitor_TrafficReport& msg);
 #if AP_SERVO_TELEM_ENABLED
     void handle_actuator_status(const CanardRxTransfer& transfer, const uavcan_equipment_actuator_Status& msg);
+    void handle_circuit_status(const CanardRxTransfer& transfer, const uavcan_equipment_power_CircuitStatus& msg);
+    void handle_device_temperature(const CanardRxTransfer& transfer, const uavcan_equipment_device_Temperature& msg);
 #endif
 #if AP_DRONECAN_VOLZ_FEEDBACK_ENABLED
     void handle_actuator_status_Volz(const CanardRxTransfer& transfer, const com_volz_servo_ActuatorStatus& msg);

--- a/libraries/AP_DroneCAN/AP_DroneCAN.h
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.h
@@ -70,6 +70,10 @@
 #define AP_DRONECAN_VOLZ_FEEDBACK_ENABLED 0
 #endif
 
+#ifndef AP_DRONECAN_LOG_CIRCUIT_STATUS_ENABLED
+#define AP_DRONECAN_LOG_CIRCUIT_STATUS_ENABLED 0
+#endif
+
 #if AP_DRONECAN_SERIAL_ENABLED
 #include "AP_DroneCAN_serial.h"
 #endif
@@ -339,6 +343,11 @@ private:
     Canard::Subscriber<uavcan_equipment_actuator_Status> actuator_status_listener{actuator_status_cb, _driver_index};
 #endif
 
+#if AP_SERVO_TELEM_ENABLED || AP_DRONECAN_LOG_CIRCUIT_STATUS_ENABLED
+    Canard::ObjCallback<AP_DroneCAN, uavcan_equipment_power_CircuitStatus> circuit_status_cb{this, &AP_DroneCAN::handle_circuit_status};
+    Canard::Subscriber<uavcan_equipment_power_CircuitStatus> circuit_status_listener{circuit_status_cb, _driver_index};
+#endif
+
     Canard::ObjCallback<AP_DroneCAN, uavcan_equipment_esc_Status> esc_status_cb{this, &AP_DroneCAN::handle_ESC_status};
     Canard::Subscriber<uavcan_equipment_esc_Status> esc_status_listener{esc_status_cb, _driver_index};
 
@@ -421,6 +430,9 @@ private:
     void handle_traffic_report(const CanardRxTransfer& transfer, const ardupilot_equipment_trafficmonitor_TrafficReport& msg);
 #if AP_SERVO_TELEM_ENABLED
     void handle_actuator_status(const CanardRxTransfer& transfer, const uavcan_equipment_actuator_Status& msg);
+#endif
+#if AP_SERVO_TELEM_ENABLED || AP_DRONECAN_LOG_CIRCUIT_STATUS_ENABLED
+    void handle_circuit_status(const CanardRxTransfer& transfer, const uavcan_equipment_power_CircuitStatus& msg);
 #endif
 #if AP_DRONECAN_VOLZ_FEEDBACK_ENABLED
     void handle_actuator_status_Volz(const CanardRxTransfer& transfer, const com_volz_servo_ActuatorStatus& msg);

--- a/libraries/AP_Servo_Telem/AP_Servo_Telem.cpp
+++ b/libraries/AP_Servo_Telem/AP_Servo_Telem.cpp
@@ -149,12 +149,17 @@ bool AP_Servo_Telem::get_telem(const uint8_t servo_index, TelemetryData& telem) 
     }
 
     // Check if data has ever been received for the servo index provided
-    if ((active_mask & (1U << servo_index)) == 0) {
+    if (!is_active(servo_index)) {
         return false;
     }
 
     telem = *const_cast<TelemetryData*>(&_telem_data[servo_index]);
     return true;
+}
+
+bool AP_Servo_Telem::is_active(const uint8_t servo_index) const volatile
+{
+    return (active_mask & (1U << servo_index)) != 0;
 }
 
 // Get the AP_Servo_Telem singleton

--- a/libraries/AP_Servo_Telem/AP_Servo_Telem.h
+++ b/libraries/AP_Servo_Telem/AP_Servo_Telem.h
@@ -76,6 +76,9 @@ public:
     // Fill in telem structure if telem is available, return false if not
     bool get_telem(const uint8_t servo_index, TelemetryData& telem) const volatile;
 
+    // return true if a servo with specific node id is currently sending servo telemetry data
+    bool is_active(const uint8_t servo_index) const volatile;
+
 private:
 
     // Log telem of each servo


### PR DESCRIPTION
### Summary

<!-- Put a one or two line summary of what your PR does here -->

This PR adds the CircuitStatus telemetry reported by droneCAN servos such as MKS servos into the existing CSRV log structure as well as handles logging for non-servo devices which also broadcast CircuitStatus messages. 

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [X] Tested on hardware
- [X] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

The MKS droneCAN servos broadcast CircuitStatus messages but currently the codebase only logs the Actuator Status message into the active servo's CSRV log field. To improve the usefulness for these servos, this PR intends to add the Circuit Status message into this same field.

Update on 22/7/26:

The CircuitStatus handling has been made more flexible by supporting non-servo droneCAN devices to log their CircuitStatus into a seperate CSCU field.

<!--
Don't overlook our commu
nity's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
