### PR TITLE
autotest: add test for plane-wind-failsafe.lua

### DIFF
--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -3122,6 +3122,87 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.test_takeoff_check_mode("AUTO", force_disarm=True)
         self.context_pop()
 
+    def PlaneWindFailsafe(self):
+        '''test the plane-wind-failsafe.lua example script'''
+        self.install_example_script_context("plane-wind-failsafe.lua")
+        self.set_parameters({
+            "SCR_ENABLE": 1,
+            "SIM_WIND_DIR": 180,
+        })
+        self.reboot_sitl()
+
+        self.takeoff(30, 'QLOITER')
+        self.change_mode('LOITER')
+
+        self.context_push()
+        # EKF3 wind estimation is significantly less accurate than DCM
+        # across the full wind speed range; use DCM for reliable estimates
+        self.set_parameter('AHRS_EKF_TYPE', 1)
+
+        self.start_subtest("No warning when wind is below warn threshold")
+        self.context_push()
+        self.context_collect('STATUSTEXT')
+        self.set_parameter('SIM_WIND_SPD', 3)
+        # The script runs every 1 simulated second; wait 30s to give it
+        # enough iterations to detect any spurious warning
+        self.delay_sim_time(30)
+        if self.statustext_in_collections("Wind warning"):
+            raise NotAchievedException("Got unexpected wind warning with wind=3m/s")
+        if self.statustext_in_collections("Wind failsafe"):
+            raise NotAchievedException("Got unexpected wind failsafe with wind=3m/s")
+        self.context_pop()
+
+        # Allow the EKF to converge at warning-level wind before exercising the
+        # warning threshold; EKF wind estimation requires sustained fixed-wing flight
+        self.set_parameter('SIM_WIND_SPD', 13)
+        self.delay_sim_time(200)
+
+        self.start_subtest("Warning repeated approximately every 15 seconds, no failsafe")
+        self.context_push()
+        self.context_collect('STATUSTEXT')
+        t_last = None
+        for i in range(3):
+            self.wait_statustext("Wind warning at", timeout=30)
+            t_now = self.get_sim_time()
+            if t_last is not None:
+                interval = t_now - t_last
+                if interval < 10 or interval > 25:
+                    raise NotAchievedException(
+                        "Warning interval %.1fs, expected ~15s" % interval
+                    )
+            t_last = t_now
+        if self.statustext_in_collections("Wind failsafe"):
+            raise NotAchievedException("Got failsafe while wind in warning-only range")
+        self.context_pop()
+
+        self.start_subtest("Failsafe and RTL when wind exceeds failsafe_speed")
+        self.context_push()
+        self.context_collect('STATUSTEXT')
+        self.set_parameter('SIM_WIND_SPD', 25)
+        self.wait_statustext("Wind failsafe at", check_context=True, timeout=120)
+        self.wait_mode('RTL', timeout=10)
+        self.context_pop()
+        # switch to QRTL so the vehicle does a VTOL landing and disarms promptly
+        self.change_mode('QRTL')
+
+        self.start_subtest("Script is one-shot and stops after triggering failsafe")
+        self.context_push()
+        self.context_collect('STATUSTEXT')
+        # SIM_WIND_SPD is 14 (restored by failsafe context_pop), in warning range;
+        # wait more than one interval (15s) to confirm the script has stopped
+        self.delay_sim_time(35)
+        if self.statustext_in_collections("Wind warning"):
+            raise NotAchievedException("Wind warning received after script should have exited")
+        if self.statustext_in_collections("Wind failsafe"):
+            raise NotAchievedException("Wind failsafe received after script should have exited")
+        self.context_pop()
+
+        self.context_pop()
+
+        self.wait_altitude(-5, 1, relative=True, timeout=60)
+        self.wait_disarmed(timeout=60)
+        self.zero_throttle()
+
     def tests(self):
         '''return list of all tests'''
 
@@ -3200,5 +3281,6 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.FenceRelativeToAMSLCliff,
             self.FenceRelativeToTerrainMaxAlt,
             self.FenceRelativeToTerrainMinAlt,
+            self.PlaneWindFailsafe,
         ])
         return ret


### PR DESCRIPTION
### Summary

Adds an autotest which thoroughly tests the Plane wind failsafe example.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Exhautsively tests this script in preparation for expansion.
