### PR TITLE
Allow autotest to measure Lua script coverage after testing it

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -794,6 +794,7 @@ class SITLBoard(Board):
             CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_NONE',
             AP_SCRIPTING_CHECKS = 1, # SITL should always do runtime scripting checks
             AP_BARO_PROBE_EXTERNAL_I2C_BUSES = 1,
+            AP_LUA_COVERAGE_ENABLED = 1,
         )
 
         env.BOARD_CLASS = "SITL"

--- a/Tools/autotest/lua/luacov.lua
+++ b/Tools/autotest/lua/luacov.lua
@@ -1,0 +1,46 @@
+-- Line coverage tracker for ArduPilot SITL Lua scripts.
+-- Requires AP_LUA_COVERAGE_ENABLED build flag (enables the debug library and
+-- the C-level line hook dispatch in lua_scripts.cpp).
+-- Stats are saved to luacov.stats.out periodically by luacov_start.lua.
+
+if not debug then
+    return {}
+end
+
+local M = {}
+local stats = {}  -- stats[source] = {[line] = hit_count}
+
+local function line_hook(_, line)
+    local info = debug.getinfo(2, "S")
+    if not info then return end
+    local src = info.source
+    local s = stats[src]
+    if not s then
+        s = {}
+        stats[src] = s
+    end
+    s[line] = (s[line] or 0) + 1
+end
+
+function M.save_stats()
+    local f = io.open("luacov.stats.out", "w")
+    if not f then return end
+    for src, lines in pairs(stats) do
+        local max_line = 0
+        for ln in pairs(lines) do
+            if ln > max_line then max_line = ln end
+        end
+        f:write("# " .. src .. "\n")
+        f:write(max_line .. "\n")
+        for i = 1, max_line do
+            f:write((lines[i] or 0) .. "\n")
+        end
+    end
+    f:close()
+end
+
+-- Register the hook in the Lua registry so lua_scripts.cpp can call it for
+-- every line event without being overwritten by reset_loop_overtime().
+debug.getregistry()["AP_LUA_LINE_HOOK"] = line_hook
+
+return M

--- a/Tools/autotest/lua/luacov_start.lua
+++ b/Tools/autotest/lua/luacov_start.lua
@@ -1,0 +1,16 @@
+-- Load the coverage tracker and schedule periodic stats saves.
+local cov = require('luacov')
+
+local SAVE_INTERVAL_MS = uint32_t(5000)
+local last_save_ms = millis()
+
+function update()
+    local now = millis()
+    if now - last_save_ms > SAVE_INTERVAL_MS then
+        cov.save_stats()
+        last_save_ms = now
+    end
+    return update, 1000
+end
+
+return update, 1000

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -3122,6 +3122,87 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.test_takeoff_check_mode("AUTO", force_disarm=True)
         self.context_pop()
 
+    def PlaneWindFailsafe(self):
+        '''test the plane-wind-failsafe.lua example script'''
+        self.install_example_script_context("plane-wind-failsafe.lua")
+        self.set_parameters({
+            "SCR_ENABLE": 1,
+            "SIM_WIND_DIR": 180,
+        })
+        self.reboot_sitl()
+
+        self.takeoff(30, 'QLOITER')
+        self.change_mode('LOITER')
+
+        self.context_push()
+        # EKF3 wind estimation is significantly less accurate than DCM
+        # across the full wind speed range; use DCM for reliable estimates
+        self.set_parameter('AHRS_EKF_TYPE', 1)
+
+        self.start_subtest("No warning when wind is below warn threshold")
+        self.context_push()
+        self.context_collect('STATUSTEXT')
+        self.set_parameter('SIM_WIND_SPD', 3)
+        # The script runs every 1 simulated second; wait 30s to give it
+        # enough iterations to detect any spurious warning
+        self.delay_sim_time(30)
+        if self.statustext_in_collections("Wind warning"):
+            raise NotAchievedException("Got unexpected wind warning with wind=3m/s")
+        if self.statustext_in_collections("Wind failsafe"):
+            raise NotAchievedException("Got unexpected wind failsafe with wind=3m/s")
+        self.context_pop()
+
+        # Allow the EKF to converge at warning-level wind before exercising the
+        # warning threshold; EKF wind estimation requires sustained fixed-wing flight
+        self.set_parameter('SIM_WIND_SPD', 13)
+        self.delay_sim_time(200)
+
+        self.start_subtest("Warning repeated approximately every 15 seconds, no failsafe")
+        self.context_push()
+        self.context_collect('STATUSTEXT')
+        t_last = None
+        for i in range(3):
+            self.wait_statustext("Wind warning at", timeout=30)
+            t_now = self.get_sim_time()
+            if t_last is not None:
+                interval = t_now - t_last
+                if interval < 10 or interval > 25:
+                    raise NotAchievedException(
+                        "Warning interval %.1fs, expected ~15s" % interval
+                    )
+            t_last = t_now
+        if self.statustext_in_collections("Wind failsafe"):
+            raise NotAchievedException("Got failsafe while wind in warning-only range")
+        self.context_pop()
+
+        self.start_subtest("Failsafe and RTL when wind exceeds failsafe_speed")
+        self.context_push()
+        self.context_collect('STATUSTEXT')
+        self.set_parameter('SIM_WIND_SPD', 25)
+        self.wait_statustext("Wind failsafe at", check_context=True, timeout=120)
+        self.wait_mode('RTL', timeout=10)
+        self.context_pop()
+        # switch to QRTL so the vehicle does a VTOL landing and disarms promptly
+        self.change_mode('QRTL')
+
+        self.start_subtest("Script is one-shot and stops after triggering failsafe")
+        self.context_push()
+        self.context_collect('STATUSTEXT')
+        # SIM_WIND_SPD is 14 (restored by failsafe context_pop), in warning range;
+        # wait more than one interval (15s) to confirm the script has stopped
+        self.delay_sim_time(35)
+        if self.statustext_in_collections("Wind warning"):
+            raise NotAchievedException("Wind warning received after script should have exited")
+        if self.statustext_in_collections("Wind failsafe"):
+            raise NotAchievedException("Wind failsafe received after script should have exited")
+        self.context_pop()
+
+        self.context_pop()
+
+        self.wait_altitude(-5, 1, relative=True, timeout=60)
+        self.wait_disarmed(timeout=60)
+        self.zero_throttle()
+
     def tests(self):
         '''return list of all tests'''
 
@@ -3200,5 +3281,6 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.FenceRelativeToAMSLCliff,
             self.FenceRelativeToTerrainMaxAlt,
             self.FenceRelativeToTerrainMinAlt,
+            self.PlaneWindFailsafe,
         ])
         return ret

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -3122,8 +3122,17 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.test_takeoff_check_mode("AUTO", force_disarm=True)
         self.context_pop()
 
+    def check_plane_wind_failsafe_coverage(self):
+        '''verify 100% of executable lines in plane-wind-failsafe.lua were hit'''
+        script_path = self.script_example_source_path("plane-wind-failsafe.lua")
+        coverage = self.lua_coverage_stats()
+        html_out = self.buildlogs_path("plane-wind-failsafe-coverage.html")
+        self.generate_lua_coverage_html(coverage, script_path, html_out)
+        self.check_lua_coverage(coverage, script_path)
+
     def PlaneWindFailsafe(self):
         '''test the plane-wind-failsafe.lua example script'''
+        self.install_lua_coverage_context()
         self.install_example_script_context("plane-wind-failsafe.lua")
         self.set_parameters({
             "SCR_ENABLE": 1,
@@ -3202,6 +3211,10 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.wait_altitude(-5, 1, relative=True, timeout=60)
         self.wait_disarmed(timeout=60)
         self.zero_throttle()
+
+        # Reboot to close the Lua VM; __gc on the luacov sentinel flushes stats.
+        self.reboot_sitl()
+        self.check_plane_wind_failsafe_coverage()
 
     def tests(self):
         '''return list of all tests'''

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -8963,11 +8963,230 @@ Also, ignores heartbeats not from our target system'''
     def remove_installed_modules(self, modulename):
         dest = os.path.join("scripts", "modules", modulename)
         try:
-            shutil.rmtree(dest)
-        except IOError:
+            if os.path.isdir(dest):
+                shutil.rmtree(dest)
+            else:
+                os.unlink(dest)
+        except (IOError, OSError):
             pass
+
+    def install_lua_coverage_context(self):
+        """Install the luacov coverage tracker for the current context.
+
+        The tracker hooks all Lua line events and saves stats to
+        luacov.stats.out when the VM closes (triggered by reboot_sitl()).
+        Call reboot_sitl() after the test to flush the stats, then call
+        lua_coverage_stats() to read them.
+        """
+        try:
+            os.unlink("luacov.stats.out")
         except OSError:
             pass
+        autotest_lua = os.path.join(self.rootdir(), "Tools", "autotest", "lua")
+        self.install_script_module(
+            os.path.join(autotest_lua, "luacov.lua"), "luacov.lua"
+        )
+        self.install_script(
+            os.path.join(autotest_lua, "luacov_start.lua"), "luacov_start.lua"
+        )
+        self.context_get().installed_scripts.append("luacov_start.lua")
+        self.context_get().installed_modules.append("luacov.lua")
+
+    def lua_coverage_stats(self, stats_path="luacov.stats.out"):
+        """Parse luacov.stats.out; return dict mapping source name to list of hit counts.
+
+        The list is 1-indexed (index 0 is unused); list[n] is the hit count
+        for line n of that source file.
+        """
+        if not os.path.exists(stats_path):
+            raise NotAchievedException(
+                "%s not found - was reboot_sitl() called to flush stats?" % stats_path
+            )
+        result = {}
+        with open(stats_path) as f:
+            src = None
+            max_line = 0
+            line_idx = 0
+            for raw in f:
+                raw = raw.rstrip('\n')
+                if raw.startswith('# '):
+                    src = raw[2:]
+                    max_line = 0
+                    line_idx = 0
+                elif src is not None and max_line == 0:
+                    max_line = int(raw)
+                    result[src] = [0] * (max_line + 1)
+                elif src is not None:
+                    line_idx += 1
+                    if line_idx <= max_line:
+                        result[src][line_idx] = int(raw)
+        return result
+
+    def generate_lua_coverage_html(self, coverage, source_path, output_path):
+        """Write an HTML coverage report for a Lua script.
+
+        coverage  - dict from lua_coverage_stats() (key = Lua source name)
+        source_path - path to the .lua source file on disk
+        output_path - where to write the HTML file
+        """
+        with open(source_path) as f:
+            lines = f.readlines()
+
+        # find the matching coverage entry
+        hits = None
+        for src, counts in coverage.items():
+            if os.path.basename(source_path) in src:
+                hits = counts
+                break
+
+        script_name = os.path.basename(source_path)
+
+        hit_lines = 0
+        miss_lines = 0
+
+        def is_executable(line_text):
+            s = line_text.strip()
+            if not s:
+                return False
+            if s.startswith('--'):
+                return False
+            # bare 'end', 'else', 'until' are not instrumented by Lua
+            if s in ('end', 'else', 'until', 'end,', 'end;'):
+                return False
+            return True
+
+        rows = []
+        for i, text in enumerate(lines, start=1):
+            count = hits[i] if (hits and i < len(hits)) else 0
+            exe = is_executable(text)
+            if exe:
+                if count > 0:
+                    hit_lines += 1
+                    row_class = 'hit'
+                    count_class = 'count-hit'
+                    count_str = str(count)
+                else:
+                    miss_lines += 1
+                    row_class = 'miss'
+                    count_class = 'count-miss'
+                    count_str = '0'
+            else:
+                row_class = 'neutral'
+                count_class = 'count-neutral'
+                count_str = ''
+
+            import html as html_mod
+            rows.append(
+                '<tr class="%s">'
+                '<td class="lineno">%d</td>'
+                '<td class="%s">%s</td>'
+                '<td class="src">%s</td>'
+                '</tr>' % (
+                    row_class,
+                    i,
+                    count_class,
+                    count_str,
+                    html_mod.escape(text.rstrip('\n')),
+                )
+            )
+
+        total = hit_lines + miss_lines
+        pct = (100 * hit_lines // total) if total else 0
+
+        html_content = """<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Lua Coverage: {script_name}</title>
+<style>
+  body {{ font-family: monospace; background: #1e1e1e; color: #d4d4d4; margin: 20px; }}
+  h1 {{ color: #569cd6; margin-bottom: 4px; }}
+  p  {{ margin-top: 4px; color: #9cdcfe; }}
+  table {{ border-collapse: collapse; width: 100%; }}
+  td {{ padding: 1px 8px; white-space: pre; }}
+  .lineno      {{ color: #858585; text-align: right; width: 3em; border-right: 1px solid #333; }}
+  .count-hit   {{ color: #4ec94e; text-align: right; width: 5em; border-right: 1px solid #333; }}
+  .count-miss  {{ color: #f44747; text-align: right; width: 5em; border-right: 1px solid #333; }}
+  .count-neutral {{ color: #555; text-align: right; width: 5em; border-right: 1px solid #333; }}
+  .src {{ padding-left: 12px; }}
+  .hit     {{ background: #1a2e1a; }}
+  .miss    {{ background: #2e1a1a; }}
+  .neutral {{ background: #1e1e1e; }}
+</style>
+</head>
+<body>
+<h1>Coverage: {script_name}</h1>
+<p>{hit_lines} / {total} executable lines hit ({pct}%)</p>
+<table>
+{rows}
+</table>
+</body>
+</html>
+""".format(
+            script_name=script_name,
+            hit_lines=hit_lines,
+            total=total,
+            pct=pct,
+            rows='\n'.join(rows),
+        )
+
+        with open(output_path, 'w') as f:
+            f.write(html_content)
+        self.progress("Coverage report written to %s (%d/%d lines, %d%%)" % (
+            output_path, hit_lines, total, pct))
+
+    def check_lua_coverage(self, coverage, source_path, min_pct=100):
+        """Assert that at least min_pct% of executable lines in source_path were hit.
+
+        Uses the same is_executable heuristic as generate_lua_coverage_html.
+        Raises NotAchievedException listing any missed lines.
+        """
+        with open(source_path) as f:
+            lines = f.readlines()
+
+        hits = None
+        for src, counts in coverage.items():
+            if os.path.basename(source_path) in src:
+                hits = counts
+                break
+
+        script_name = os.path.basename(source_path)
+
+        if hits is None:
+            raise NotAchievedException("No coverage data found for %s" % script_name)
+
+        def is_executable(line_text):
+            s = line_text.strip()
+            if not s:
+                return False
+            if s.startswith('--'):
+                return False
+            if s in ('end', 'else', 'until', 'end,', 'end;'):
+                return False
+            return True
+
+        missed = []
+        hit_count = 0
+        total = 0
+        for i, text in enumerate(lines, start=1):
+            if not is_executable(text):
+                continue
+            total += 1
+            count = hits[i] if i < len(hits) else 0
+            if count > 0:
+                hit_count += 1
+            else:
+                missed.append(i)
+
+        pct = (100 * hit_count // total) if total else 0
+        self.progress("%s coverage: %d/%d executable lines hit (%d%%)" % (
+            script_name, hit_count, total, pct))
+
+        if pct < min_pct:
+            raise NotAchievedException(
+                "%s coverage %d%% < required %d%%; missed lines: %s" % (
+                    script_name, pct, min_pct, missed)
+            )
 
     def get_mavlink_connection_going(self):
         # get a mavlink connection going

--- a/libraries/AP_Scripting/lua/src/linit.c
+++ b/libraries/AP_Scripting/lua/src/linit.c
@@ -51,7 +51,9 @@ static const luaL_Reg loadedlibs[] = {
 #if !defined(ARDUPILOT_BUILD)
   {LUA_UTF8LIBNAME, luaopen_utf8},
 #endif
-//  {LUA_DBLIBNAME, luaopen_debug},
+#if defined(AP_LUA_COVERAGE_ENABLED)
+  {LUA_DBLIBNAME, luaopen_debug},
+#endif
 #if defined(LUA_COMPAT_BITLIB)
   {LUA_BITLIBNAME, luaopen_bit32},
 #endif

--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -27,7 +27,11 @@
 #define DISABLE_INTERRUPTS_FOR_SCRIPT_RUN 0
 
 extern const AP_HAL::HAL& hal;
+#ifdef AP_LUA_COVERAGE_ENABLED
+#define ENABLE_DEBUG_MODULE 1
+#else
 #define ENABLE_DEBUG_MODULE 0
+#endif
 
 bool lua_scripts::overtime;
 char *lua_scripts::error_msg_buf;
@@ -61,13 +65,29 @@ lua_scripts::~lua_scripts() {
 }
 
 void lua_scripts::hook(lua_State *L, lua_Debug *ar) {
-    lua_scripts::overtime = true;
+    if (ar->event == LUA_HOOKCOUNT) {
+        lua_scripts::overtime = true;
 
-    // we need to aggressively bail out as we are over time
-    // so we will aggressively trap errors until we clear out
-    lua_sethook(L, hook, LUA_MASKCOUNT, 1);
+        // we need to aggressively bail out as we are over time
+        // so we will aggressively trap errors until we clear out
+        lua_sethook(L, hook, LUA_MASKCOUNT, 1);
 
-    luaL_error(L, "Exceeded CPU time");
+        luaL_error(L, "Exceeded CPU time");
+    }
+#if defined(AP_LUA_COVERAGE_ENABLED)
+    else if (ar->event == LUA_HOOKLINE) {
+        // call the Lua line-hook stored in the registry by luacov.lua
+        int saved_top = lua_gettop(L);
+        lua_pushliteral(L, "AP_LUA_LINE_HOOK");
+        lua_rawget(L, LUA_REGISTRYINDEX);
+        if (lua_isfunction(L, -1)) {
+            lua_pushstring(L, "line");
+            lua_pushinteger(L, ar->currentline);
+            lua_pcall(L, 2, 0, 0);  // errors are suppressed; stack restored below
+        }
+        lua_settop(L, saved_top);
+    }
+#endif
 }
 
 void lua_scripts::print_error(MAV_SEVERITY severity) {
@@ -317,7 +337,11 @@ void lua_scripts::reset_loop_overtime(lua_State *L) {
     overtime = false;
     // reset the hook to clear the counter
     const int32_t vm_steps = MAX(_vm_steps, 1000);
+#if defined(AP_LUA_COVERAGE_ENABLED)
+    lua_sethook(L, hook, LUA_MASKCOUNT | LUA_MASKLINE, vm_steps);
+#else
     lua_sethook(L, hook, LUA_MASKCOUNT, vm_steps);
+#endif
 }
 
 void lua_scripts::run_next_script(lua_State *L) {


### PR DESCRIPTION
### Summary

I thought it would be nice to see how much of a Lua script has been automatically tested.

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
❯ Please add a clause into the lua script we are testing which will not be      
  covered - then re-run the test.  The coverage html file should show me that   
  the lines are not covered (preferably highlighted nicely)                     
﻿
● I'll add an "extreme wind" branch to the script that the test never triggers:
﻿
  Read 1 file (ctrl+o to expand)    
                                                            
● Update(libraries/AP_Scripting/examples/plane-wind-failsafe.lua)
  ⎿  Added 3 lines                                               
      22              vehicle:set_mode(11) -- FIXME: should be an enum.         
          11 is RTL.                                                            
      23              return                                                    
      24          end                                                           
      25 +        if speed > 50 then                                            
      26 +            gcs:send_text(0, "Extreme wind speed - seek shelter       
         +!")                                                                   
      27 +        end                                                           
      28          if speed > warn_speed then                                    
      29              if millis() - warning_last_sent_ms > warning_interv       
          al_ms then                                                            
      30                      gcs:send_text(4, "Wind warning at " .. spee       
          d .. " metres/second")                                                
```

<img width="2138" height="1091" alt="image" src="https://github.com/user-attachments/assets/6e461e67-ffcb-411a-aac3-d65421e6ff15" />


### Description

Very rough coverage implementation based on [another PR](https://github.com/ArduPilot/ardupilot/pull/32807) adding an autotest for a Lua script.

The Python implementation can certainly be tidied up a bit.

The Lua... looks OK at first glance, but I haven't played in there.  I don't think we really want to run SITL with such a different setup vs the real board.  Perhaps we can not set the new define by default.  If you want to do coverage you'd have to compile especially for that circumstance.

Written with Claude.  A lot.
