### PR TITLE
SITL: In SIM::Battery, add "_amps" suffix on current variable names

### DIFF
--- a/libraries/SITL/SIM_Battery.cpp
+++ b/libraries/SITL/SIM_Battery.cpp
@@ -155,7 +155,7 @@ void Battery::init_capacity(float capacity)
     set_initial_SoC(voltage_set);
 }
 
-void Battery::set_current(float current, uint64_t now_us)
+void Battery::set_current(float current_amps, uint64_t now_us)
 {
     constexpr float microsec_to_sec = 1.0e-6f;
     float dt = static_cast<float>(now_us - last_us) * microsec_to_sec;
@@ -164,11 +164,11 @@ void Battery::set_current(float current, uint64_t now_us)
         dt = 0;
     }
     last_us = now_us;
-    float delta_Ah = current * dt / 3600;
+    float delta_Ah = current_amps * dt / 3600;
     remaining_Ah -= delta_Ah;
     remaining_Ah = MAX(0, remaining_Ah);
 
-    float voltage_delta = current * resistance;
+    float voltage_delta = current_amps * resistance;
     float voltage;
     if (!is_positive(capacity_Ah)) {
         voltage = voltage_set;
@@ -178,10 +178,10 @@ void Battery::set_current(float current, uint64_t now_us)
 
     voltage_filter.apply(voltage, dt);
 
-    update_temperature(current, now_us);
+    update_temperature(current_amps, now_us);
 }
 
-void Battery::update_temperature(float current, uint64_t now_us)
+void Battery::update_temperature(float current_amps, uint64_t now_us)
 {
     const uint64_t temperature_dt = now_us - temperature.last_update_us;
     temperature.last_update_us = now_us;
@@ -189,7 +189,7 @@ void Battery::update_temperature(float current, uint64_t now_us)
     // (reminder: thermal_capacity = mass * specific_heat)
     constexpr float thermal_capacity = 2.8f;  // watt*seconds/degC
     constexpr float inverse_of_thermal_capacity = 1 / thermal_capacity;  // use inverse so we can multiply, not divide
-    const float temp_increase = (current * current) * resistance * inverse_of_thermal_capacity * (temperature_dt * 0.000001);
+    const float temp_increase = (current_amps * current_amps) * resistance * inverse_of_thermal_capacity * (temperature_dt * 0.000001);
     // decay temperature at some %second towards ambient
     const float temp_decrease = (temperature.kelvin - 273.15f) * 0.10 * temperature_dt * 0.000001;
     temperature.kelvin += (temp_increase - temp_decrease);

--- a/libraries/SITL/SIM_Battery.h
+++ b/libraries/SITL/SIM_Battery.h
@@ -53,7 +53,7 @@ private:
         float kelvin = 273;
         uint64_t last_update_us;
     } temperature;
-    void update_temperature(float current, uint64_t now_us);
+    void update_temperature(float current_amps, uint64_t now_us);
 
     // 10Hz filter for battery voltage
     LowPassFilterFloat voltage_filter{10};

--- a/libraries/SITL/examples/EvaluateBatteryModel/EvaluateBatteryModel.cpp
+++ b/libraries/SITL/examples/EvaluateBatteryModel/EvaluateBatteryModel.cpp
@@ -50,7 +50,7 @@ void setup(void)
     frame.public_load_frame_params(argv[1]);
 
     // parse current draw
-    const float current = strtof(argv[2], NULL);
+    const float current_amps = strtof(argv[2], NULL);
 
     const float amp_hour_capacity = frame.get_capacity();
     const float resistance = frame.get_resistance();
@@ -58,7 +58,7 @@ void setup(void)
     const float min_voltage = max_voltage * 0.7;
 
     ::printf("Simulating %0.2fv, %0.2f ah battery with resistance of %f\n", max_voltage, amp_hour_capacity, resistance);
-    ::printf("Voltage from %0.2f to %0.2f with constant current draw of %0.2f\n", max_voltage, min_voltage, current);
+    ::printf("Voltage from %0.2f to %0.2f with constant current draw of %0.2f\n", max_voltage, min_voltage, current_amps);
 
     // setup battery model
     battery.setup(amp_hour_capacity, resistance, max_voltage);
@@ -71,7 +71,7 @@ void setup(void)
 
     ::printf("time, voltage\n");
     while (battery.get_voltage() >= min_voltage) {
-        battery.set_current(current, time_us);
+        battery.set_current(current_amps, time_us);
 
         ::printf("%0.2f, %0.2f\n", time_us * us_to_seconds, battery.get_voltage());
 


### PR DESCRIPTION
### Summary

Simply rename battery current variables `current` to `current_amps`.
It is trivially "PR-chained" behind #32808 . (I will rebase for clarity when that one lands.)

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

This is confirmed correct by successfully compiling and also SIM::Battery's unit tests.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
