### PR TITLE
GCS_MAVLink_Copter: implement yaw control in guided do_reposition

### DIFF
--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -3,6 +3,7 @@
 #include "GCS_MAVLink_Copter.h"
 #include <AP_RPM/AP_RPM_config.h>
 #include <AP_EFI/AP_EFI_config.h>
+#include <cmath>
 
 MAV_TYPE GCS_Copter::frame_type() const
 {
@@ -449,8 +450,12 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_int_do_reposition(const mavlink_co
         return MAV_RESULT_DENIED; // failed as the location is not valid
     }
 
+    const float yaw_rad = packet.param4;
+    const bool use_yaw = !isnan(yaw_rad);
+    const bool relative_yaw = ((int32_t)packet.param2 & MAV_DO_REPOSITION_FLAGS_RELATIVE_YAW) == MAV_DO_REPOSITION_FLAGS_RELATIVE_YAW;
+
     // we need to do this first, as we don't want to change the flight mode unless we can also set the target
-    if (!copter.mode_guided.set_destination(request_location, false, 0, false, 0)) {
+    if (!copter.mode_guided.set_destination(request_location, use_yaw, yaw_rad, false, 0, relative_yaw)) {
         return MAV_RESULT_FAILED;
     }
 
@@ -459,7 +464,7 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_int_do_reposition(const mavlink_co
             return MAV_RESULT_FAILED;
         }
         // the position won't have been loaded if we had to change the flight mode, so load it again
-        if (!copter.mode_guided.set_destination(request_location, false, 0, false, 0)) {
+        if (!copter.mode_guided.set_destination(request_location, use_yaw, yaw_rad, false, 0, relative_yaw)) {
             return MAV_RESULT_FAILED;
         }
     }


### PR DESCRIPTION
### Summary

handle_command_int_do_reposition now unpacks param4 to get target yaw from MAV_CMD_DO_REPOSITION packet. Also checks the MAV_DO_REPOSITION_FLAGS_RELATIVE_YAW bit in param2

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [x] Logs attached
- [x] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description
[logs.zip](https://github.com/user-attachments/files/26837930/logs.zip)

Attached are two logs for the same commands, pre.BIN and post.BIN, before and after the change respectively. The commands send the copter to one position with a yaw of 180º (pi in radians) with relative_yaw=0. The second command sends the copter to the same position at a lower altitude, with relative_yaw=1 and yaw of 45º (pi/4). Without the change, the copter does not follow the requested angles. With the change it does.

Before:
<img width="600" height="300" alt="pre_yaw" src="https://github.com/user-attachments/assets/974bdfb8-4453-4e19-a155-91bc768babd3" />

After:
<img width="600" height="300" alt="post_yaw" src="https://github.com/user-attachments/assets/09e44820-accf-4bf4-94f3-52af4dd04605" />



