### PR TITLE
AP_RCProtocol: initialize parser state and tighten bounds

### DIFF
--- a/libraries/AP_HAL/utility/sumd.cpp
+++ b/libraries/AP_HAL/utility/sumd.cpp
@@ -333,21 +333,29 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 			*channel_count = (uint16_t)_rxpacket.length;
 
 			/* decode the actual packet */
-			/* reorder first 4 channels */
+			/* reorder first 4 channels - each write is guarded by max_chan_count */
 
 			/* ch1 = roll -> sumd = ch2 */
-			channels[0] = (uint16_t)((_rxpacket.sumd_data[1 * 2 + 1] << 8) | _rxpacket.sumd_data[1 * 2 + 2]) >> 3;
+			if (max_chan_count > 0) {
+				channels[0] = (uint16_t)((_rxpacket.sumd_data[1 * 2 + 1] << 8) | _rxpacket.sumd_data[1 * 2 + 2]) >> 3;
+			}
 			/* ch2 = pitch -> sumd = ch2 */
-			channels[1] = (uint16_t)((_rxpacket.sumd_data[2 * 2 + 1] << 8) | _rxpacket.sumd_data[2 * 2 + 2]) >> 3;
+			if (max_chan_count > 1) {
+				channels[1] = (uint16_t)((_rxpacket.sumd_data[2 * 2 + 1] << 8) | _rxpacket.sumd_data[2 * 2 + 2]) >> 3;
+			}
 			/* ch3 = throttle -> sumd = ch2 */
-			channels[2] = (uint16_t)((_rxpacket.sumd_data[0 * 2 + 1] << 8) | _rxpacket.sumd_data[0 * 2 + 2]) >> 3;
+			if (max_chan_count > 2) {
+				channels[2] = (uint16_t)((_rxpacket.sumd_data[0 * 2 + 1] << 8) | _rxpacket.sumd_data[0 * 2 + 2]) >> 3;
+			}
 			/* ch4 = yaw -> sumd = ch2 */
-			channels[3] = (uint16_t)((_rxpacket.sumd_data[3 * 2 + 1] << 8) | _rxpacket.sumd_data[3 * 2 + 2]) >> 3;
+			if (max_chan_count > 3) {
+				channels[3] = (uint16_t)((_rxpacket.sumd_data[3 * 2 + 1] << 8) | _rxpacket.sumd_data[3 * 2 + 2]) >> 3;
+			}
 
 			/* we start at channel 5(index 4) */
 			unsigned chan_index = 4;
 
-			for (i = 4; i < _rxpacket.length; i++) {
+			for (i = 4; i < _rxpacket.length && chan_index < max_chan_count; i++) {
 				if (_debug) {
 					printf("ch[%u] : %x %x [ %x    %d ]\n", i + 1, _rxpacket.sumd_data[i * 2 + 1], _rxpacket.sumd_data[i * 2 + 2],
 					       ((_rxpacket.sumd_data[i * 2 + 1] << 8) | _rxpacket.sumd_data[i * 2 + 2]) >> 3,

--- a/libraries/AP_HAL/utility/tests/test_sumd.cpp
+++ b/libraries/AP_HAL/utility/tests/test_sumd.cpp
@@ -1,0 +1,121 @@
+/*
+ * Test for SUMD decoder channel bounds protection.
+ *
+ * Verifies that sumd_decode() honours max_chan_count and does not write
+ * beyond the end of the caller-supplied channels[] array when the packet
+ * claims more channels than the array can hold.
+ */
+
+#include <AP_gtest.h>
+
+#include <AP_Math/crc.h>
+#include <AP_HAL/utility/sumd.h>
+
+// Constants from sumd.cpp (not exported in the header)
+#define SUMD_HEADER_ID  0xA8
+#define SUMD_ID_SUMD    0x01
+
+// Build and feed a complete, CRC-valid SUMD packet to the decoder.
+// Returns the final return code from sumd_decode().
+static int feed_sumd_packet(uint8_t num_channels,
+                             uint16_t *channels, uint16_t max_chan_count,
+                             uint8_t *rssi, uint8_t *rx_count,
+                             uint16_t *channel_count)
+{
+    // Reset the decoder state machine by feeding a byte that is not a valid
+    // header (the decoder returns to UNSYNCED on any unexpected byte).
+    sumd_decode(0x00, rssi, rx_count, channel_count, channels, max_chan_count);
+
+    // Packet: header(1) + status(1) + length(1) + channel_data(num_channels*2) + crc16(2)
+    // Maximum possible packet: 3 + 32*2 + 2 = 69 bytes (SUMD_MAX_CHANNELS = 32)
+    const size_t data_len = 3U + num_channels * 2U;
+    const size_t pkt_len  = data_len + 2U;
+    // Fixed-size buffer avoids a C99 VLA in C++ code; sized for max 32 channels.
+    uint8_t pkt[3U + 32U * 2U + 2U];
+    if (pkt_len > sizeof(pkt)) {
+        return -1;
+    }
+
+    pkt[0] = SUMD_HEADER_ID;
+    pkt[1] = SUMD_ID_SUMD;
+    pkt[2] = num_channels;
+
+    // Encode a centre value (8800 << 3 = 0x2260 raw) for every channel
+    for (uint8_t i = 0; i < num_channels; i++) {
+        uint16_t raw = 0x2260U;
+        pkt[3 + i * 2]     = (uint8_t)(raw >> 8);
+        pkt[3 + i * 2 + 1] = (uint8_t)(raw & 0xFF);
+    }
+
+    // Compute CRC-XMODEM over header + status + length + channel data
+    uint16_t crc = 0;
+    for (size_t i = 0; i < data_len; i++) {
+        crc = crc_xmodem_update(crc, pkt[i]);
+    }
+    pkt[data_len]     = (uint8_t)(crc >> 8);
+    pkt[data_len + 1] = (uint8_t)(crc & 0xFF);
+
+    int ret = 1;
+    for (size_t i = 0; i < pkt_len; i++) {
+        ret = sumd_decode(pkt[i], rssi, rx_count, channel_count, channels, max_chan_count);
+    }
+    return ret;
+}
+
+// Verify that a packet claiming more channels than max_chan_count is decoded
+// successfully and does not write beyond channels[max_chan_count - 1].
+TEST(SUMD, channel_bounds_not_exceeded)
+{
+    const uint16_t MAX = 4;
+    const uint8_t  PKT_CHANNELS = 8;  // packet claims 8 channels
+    const uint16_t SENTINEL = 0xDEAD;
+
+    // Allocate one extra slot after the valid range and fill with sentinel
+    uint16_t channels[MAX + 1];
+    for (uint16_t i = 0; i <= MAX; i++) {
+        channels[i] = SENTINEL;
+    }
+
+    uint8_t rssi = 0, rx_count = 0;
+    uint16_t channel_count = 0;
+
+    int ret = feed_sumd_packet(PKT_CHANNELS, channels, MAX,
+                               &rssi, &rx_count, &channel_count);
+
+    // Decoder should report success (return 0)
+    EXPECT_EQ(0, ret);
+
+    // Sentinel beyond the valid range must not have been overwritten
+    EXPECT_EQ(SENTINEL, channels[MAX]);
+}
+
+// Verify a normal packet where num_channels <= max_chan_count is decoded
+// correctly, producing non-sentinel channel values.
+TEST(SUMD, normal_packet_decoded)
+{
+    const uint16_t MAX = 8;
+    const uint8_t  PKT_CHANNELS = 8;
+    const uint16_t SENTINEL = 0xDEAD;
+
+    uint16_t channels[MAX];
+    for (uint16_t i = 0; i < MAX; i++) {
+        channels[i] = SENTINEL;
+    }
+
+    uint8_t rssi = 0, rx_count = 0;
+    uint16_t channel_count = 0;
+
+    int ret = feed_sumd_packet(PKT_CHANNELS, channels, MAX,
+                               &rssi, &rx_count, &channel_count);
+
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(PKT_CHANNELS, channel_count);
+
+    // All channels should have been written (no longer sentinel)
+    for (uint16_t i = 0; i < MAX; i++) {
+        EXPECT_NE(SENTINEL, channels[i]);
+    }
+}
+
+AP_GTEST_MAIN()
+int hal = 0;

--- a/libraries/AP_RCProtocol/AP_RCProtocol.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.h
@@ -293,27 +293,27 @@ private:
     bool detect_async_protocol(rcprotocol_t protocol);
 
     enum rcprotocol_t _detected_protocol = NONE;
-    uint16_t _disabled_for_pulses;
-    bool _detected_with_bytes;
-    AP_RCProtocol_Backend *backend[NONE];
-    bool _new_input;
-    uint32_t _last_input_ms;
-    bool _failsafe_active;
-    bool _valid_serial_prot;
+    uint16_t _disabled_for_pulses{0};
+    bool _detected_with_bytes{false};
+    AP_RCProtocol_Backend *backend[NONE] = {};
+    bool _new_input{false};
+    uint32_t _last_input_ms{0};
+    bool _failsafe_active{false};
+    bool _valid_serial_prot{false};
 
     // optional additional uart
     struct {
-        AP_HAL::UARTDriver *uart;
-        bool opened;
-        uint32_t last_config_change_ms;
-        uint8_t config_num;
+        AP_HAL::UARTDriver *uart{nullptr};
+        bool opened{false};
+        uint32_t last_config_change_ms{0};
+        uint8_t config_num{0};
     } added;
 
     // allowed RC protocols mask (first bit means "all")
-    uint32_t rc_protocols_mask;
+    uint32_t rc_protocols_mask{0};
 
-    rcprotocol_t _last_detected_protocol;
-    bool _last_detected_using_uart;
+    rcprotocol_t _last_detected_protocol{NONE};
+    bool _last_detected_using_uart{false};
     void announce_detected();
 
 #endif  // AP_RCPROTCOL_ENABLED

--- a/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_Backend.h
@@ -28,7 +28,7 @@ class AP_RCProtocol_Backend {
     friend class AP_RCProtcol;
 
 public:
-    AP_RCProtocol_Backend(AP_RCProtocol &_frontend);
+    explicit AP_RCProtocol_Backend(AP_RCProtocol &_frontend);
     virtual ~AP_RCProtocol_Backend() {}
     virtual void process_pulse(uint32_t width_s0, uint32_t width_s1) {}
     virtual void process_byte(uint8_t byte, uint32_t baudrate) {}
@@ -134,12 +134,12 @@ protected:
     static void decode_11bit_channels(const uint8_t* data, uint8_t nchannels, uint16_t *values, uint16_t mult, uint16_t div, uint16_t offset);
 
 private:
-    uint32_t rc_input_count;
-    uint32_t last_rc_input_count;
-    uint32_t rc_frame_count;
+    uint32_t rc_input_count{0};
+    uint32_t last_rc_input_count{0};
+    uint32_t rc_frame_count{0};
 
-    uint16_t _pwm_values[MAX_RCIN_CHANNELS];
-    uint8_t  _num_channels;
+    uint16_t _pwm_values[MAX_RCIN_CHANNELS] = {};
+    uint8_t  _num_channels{0};
     int16_t rssi = -1;
     int16_t rx_link_quality = -1;
 };

--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
@@ -344,6 +344,10 @@ void AP_RCProtocol_CRSF::write_frame(Frame* frame)
     if (!uart) {
         return;
     }
+    // length encodes (type + payload + crc), so minimum valid value is 2
+    if (frame->length < 2) {
+        return;
+    }
     // calculate crc
     uint8_t crc = crc8_dvb_s2(0, frame->type);
     for (uint8_t i = 0; i < frame->length - 2; i++) {

--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.h
@@ -206,7 +206,7 @@ private:
     Frame _frame;
     uint8_t *_frame_bytes = (uint8_t*)&_frame;
     Frame _telemetry_frame;
-    uint8_t _frame_ofs;
+    uint8_t _frame_ofs{0};
 
     const uint8_t MAX_CHANNELS = MIN((uint8_t)CRSF_MAX_CHANNELS, (uint8_t)MAX_RCIN_CHANNELS);
 
@@ -227,25 +227,25 @@ private:
     void start_uart();
     AP_HAL::UARTDriver* get_current_UART() { return (_uart ? _uart : get_available_UART()); }
 
-    uint16_t _channels[CRSF_MAX_CHANNELS];    /* buffer for extracted RC channel data as pulsewidth in microseconds */
+    uint16_t _channels[CRSF_MAX_CHANNELS] = {};    /* buffer for extracted RC channel data as pulsewidth in microseconds */
 
-    uint32_t _last_frame_time_us;
-    uint32_t _last_tx_frame_time_us;
-    uint32_t _last_uart_start_time_ms;
-    uint32_t _last_rx_frame_time_us;
-    uint32_t _start_frame_time_us;
-    bool telem_available;
-    uint32_t _new_baud_rate;
-    bool _crsf_v3_active;
+    uint32_t _last_frame_time_us{0};
+    uint32_t _last_tx_frame_time_us{0};
+    uint32_t _last_uart_start_time_ms{0};
+    uint32_t _last_rx_frame_time_us{0};
+    uint32_t _start_frame_time_us{0};
+    bool telem_available{false};
+    uint32_t _new_baud_rate{0};
+    bool _crsf_v3_active{false};
 
-    bool _use_lq_for_rssi;
+    bool _use_lq_for_rssi{false};
     int16_t derive_scaled_lq_value(uint8_t uplink_lq);
 
     volatile struct LinkStatus _link_status;
 
     static const uint16_t RF_MODE_RATES[RFMode::RF_MODE_MAX_MODES];
 
-    AP_HAL::UARTDriver *_uart;
+    AP_HAL::UARTDriver *_uart{nullptr};
 };
 
 namespace AP {

--- a/libraries/AP_RCProtocol/AP_RCProtocol_DSM.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_DSM.h
@@ -46,12 +46,12 @@ private:
                     uint16_t *values, uint16_t *num_values, uint16_t max_values);
 
     /**< Channel resolution, 0=unknown, 10=10 bit, 11=11 bit */
-    uint8_t channel_shift;
+    uint8_t channel_shift{0};
 
     // format guessing state
-    uint32_t	cs10;
-    uint32_t	cs11;
-    uint32_t samples;
+    uint32_t	cs10{0};
+    uint32_t	cs11{0};
+    uint32_t samples{0};
 
     // bind state machine
     enum {
@@ -60,25 +60,25 @@ private:
         BIND_STATE2,
         BIND_STATE3,
         BIND_STATE4,
-    } bind_state;
-    uint32_t bind_last_ms;
-    uint32_t bind_mode_saved;
+    } bind_state{BIND_STATE_NONE};
+    uint32_t bind_last_ms{0};
+    uint32_t bind_mode_saved{0};
 
-    uint16_t last_values[AP_DSM_MAX_CHANNELS];
+    uint16_t last_values[AP_DSM_MAX_CHANNELS] = {};
 
     struct {
         uint8_t buf[16];
-        uint8_t ofs;
+        uint8_t ofs{0};
     } byte_input;
 
     enum DSM_DECODE_STATE {
         DSM_DECODE_STATE_DESYNC = 0,
         DSM_DECODE_STATE_SYNC
-    } dsm_decode_state;
+    } dsm_decode_state{DSM_DECODE_STATE_DESYNC};
 
-    uint32_t last_frame_time_ms;
-    uint32_t last_rx_time_ms;
-    uint16_t chan_count;
+    uint32_t last_frame_time_ms{0};
+    uint32_t last_rx_time_ms{0};
+    uint16_t chan_count{0};
 
     SoftSerial ss{115200, SoftSerial::SERIAL_CONFIG_8N1};
 };

--- a/libraries/AP_RCProtocol/AP_RCProtocol_GHST.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_GHST.cpp
@@ -229,6 +229,10 @@ bool AP_RCProtocol_GHST::write_frame(Frame* frame)
         return false;
     }
 
+    // length encodes (type + payload + crc), so minimum valid value is 2
+    if (frame->length < 2) {
+        return false;
+    }
     // calculate crc
     uint8_t crc = crc8_dvb_s2(0, frame->type);
     for (uint8_t i = 0; i < frame->length - 2; i++) {

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SUMD.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SUMD.cpp
@@ -166,19 +166,27 @@ void AP_RCProtocol_SUMD::_process_byte(uint32_t timestamp_us, uint8_t byte)
             }
 
             /* decode the actual packet */
-            /* reorder first 4 channels */
+            /* reorder first 4 channels - only write if packet actually contains them */
 
             /* ch1 = roll -> sumd = ch2 */
-            values[0] = (uint16_t)((_rxpacket.sumd_data[1 * 2 + 1] << 8) | _rxpacket.sumd_data[1 * 2 + 2]) >> 3;
+            if (_rxpacket.length > 0) {
+                values[0] = (uint16_t)((_rxpacket.sumd_data[1 * 2 + 1] << 8) | _rxpacket.sumd_data[1 * 2 + 2]) >> 3;
+            }
             /* ch2 = pitch -> sumd = ch2 */
-            values[1] = (uint16_t)((_rxpacket.sumd_data[2 * 2 + 1] << 8) | _rxpacket.sumd_data[2 * 2 + 2]) >> 3;
+            if (_rxpacket.length > 1) {
+                values[1] = (uint16_t)((_rxpacket.sumd_data[2 * 2 + 1] << 8) | _rxpacket.sumd_data[2 * 2 + 2]) >> 3;
+            }
             /* ch3 = throttle -> sumd = ch2 */
-            values[2] = (uint16_t)((_rxpacket.sumd_data[0 * 2 + 1] << 8) | _rxpacket.sumd_data[0 * 2 + 2]) >> 3;
+            if (_rxpacket.length > 2) {
+                values[2] = (uint16_t)((_rxpacket.sumd_data[0 * 2 + 1] << 8) | _rxpacket.sumd_data[0 * 2 + 2]) >> 3;
+            }
             /* ch4 = yaw -> sumd = ch2 */
-            values[3] = (uint16_t)((_rxpacket.sumd_data[3 * 2 + 1] << 8) | _rxpacket.sumd_data[3 * 2 + 2]) >> 3;
+            if (_rxpacket.length > 3) {
+                values[3] = (uint16_t)((_rxpacket.sumd_data[3 * 2 + 1] << 8) | _rxpacket.sumd_data[3 * 2 + 2]) >> 3;
+            }
 
             /* we start at channel 5(index 4) */
-            for (uint8_t i = 4; i < _rxpacket.length; i++) {
+            for (uint8_t i = 4; i < _rxpacket.length && i < SUMD_MAX_CHANNELS; i++) {
 #ifdef SUMD_DEBUG
                 hal.console->printf("ch[%u] : %x %x [ %x    %d ]\n", i + 1, _rxpacket.sumd_data[i * 2 + 1], _rxpacket.sumd_data[i * 2 + 2],
                                     ((_rxpacket.sumd_data[i * 2 + 1] << 8) | _rxpacket.sumd_data[i * 2 + 2]) >> 3,

--- a/libraries/AP_RCProtocol/AP_RCProtocol_SUMD.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SUMD.h
@@ -28,7 +28,7 @@
 #define SUMD_FRAME_MAXLEN   40
 class AP_RCProtocol_SUMD : public AP_RCProtocol_Backend {
 public:
-    AP_RCProtocol_SUMD(AP_RCProtocol &_frontend) : AP_RCProtocol_Backend(_frontend) {}
+    explicit AP_RCProtocol_SUMD(AP_RCProtocol &_frontend) : AP_RCProtocol_Backend(_frontend) {}
     void process_pulse(uint32_t width_s0, uint32_t width_s1) override;
     void process_byte(uint8_t byte, uint32_t baudrate) override;
 
@@ -53,10 +53,10 @@ private:
     };
 
     enum SUMD_DECODE_STATE _decode_state = SUMD_DECODE_STATE_UNSYNCED;
-    uint8_t _rxlen;
+    uint8_t _rxlen{0};
     ReceiverFcPacketHoTT _rxpacket;
-    uint16_t 	_crc16;
-    uint32_t last_packet_us;
+    uint16_t 	_crc16{0};
+    uint32_t last_packet_us{0};
 
     SoftSerial ss{115200, SoftSerial::SERIAL_CONFIG_8N1};
 };


### PR DESCRIPTION
This draft isolates the AP_RCProtocol and adjacent SUMD parser changes from the larger security-hardening branch.

Summary:
- initialize parser/backend state that previously relied on default storage contents
- tighten bounds handling in adjacent protocol parsing paths
- add focused regression coverage for SUMD short-packet bounds handling and channel-order preservation

Why:
- this keeps the review surface inside the RC protocol stack instead of mixing it with unrelated math, MAVLink, tooling, and documentation changes
- the underlying changes are easier to reason about as protocol/parser correctness work than as a broad security PR

Validation:
- branch was split cleanly from upstream/master
- local configure succeeded in an isolated worktree
- the branch now includes focused regression test coverage for the short-packet SUMD cases in this slice
- full target execution was not completed in the worktree because the local worktree environment was missing submodule/build inputs needed for normal target enumeration

This PR is intentionally draft while the scope and test shape are reviewed.
