### PR TITLE
AP_AHRS: harden state access and SRV safety paths

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -636,7 +636,12 @@ public:
     int32_t pitch_sensor;
     int32_t yaw_sensor;
 
-    const Matrix3f &get_rotation_body_to_ned(void) const { return state.dcm_matrix; }
+    // Return a snapshot copy of dcm_matrix under _rsem to prevent
+    // torn 36-byte reads from concurrent updates.
+    const Matrix3f get_rotation_body_to_ned(void) const {
+        WITH_SEMAPHORE(_rsem);
+        return state.dcm_matrix;
+    }
 
     // return a Quaternion representing our current attitude in NED frame
     void get_quat_body_to_ned(Quaternion &quat) const;
@@ -754,7 +759,9 @@ private:
     VehicleClass _vehicle_class{VehicleClass::UNKNOWN};
 
     // multi-thread access support
-    HAL_Semaphore _rsem;
+    // mutable so const getter functions can hold the semaphore for
+    // a consistent pair/matrix snapshot (semaphores are recursive).
+    mutable HAL_Semaphore _rsem;
 
     /*
      * Parameters

--- a/libraries/AP_AHRS/AP_AHRS_Backend.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.cpp
@@ -119,7 +119,12 @@ void AP_AHRS::calc_trig(const Matrix3f &rot,
         cr = 1.0f;
     } else {
         cp = safe_sqrt(1 - cx2);
-        cr = rot.c.z / cp;
+        // Prevent division by zero - check cp before using it
+        if (is_zero(cp)) {
+            cr = 1.0f;
+        } else {
+            cr = rot.c.z / cp;
+        }
     }
     cp = constrain_float(cp, 0.0f, 1.0f);
     cr = constrain_float(cr, -1.0f, 1.0f); // this relies on constrain_float() of infinity doing the right thing
@@ -135,6 +140,13 @@ void AP_AHRS::calc_trig(const Matrix3f &rot,
         rot.to_euler(&r, &p, &y);
         cr = cosf(r);
         sr = sinf(r);
+        // Validate recalculated values - to_euler() can produce NaN/Inf for edge cases
+        if (isnan(cr) || isinf(cr)) {
+            cr = 1.0f;
+        }
+        if (isnan(sr) || isinf(sr)) {
+            sr = 0.0f;
+        }
     }
 }
 
@@ -238,6 +250,10 @@ void AP_AHRS::update_AOA_SSA(void)
 // rotate a 2D vector from earth frame to body frame
 Vector2f AP_AHRS::earth_to_body2D(const Vector2f &ef) const
 {
+    // Hold the AHRS semaphore to get a consistent (_cos_yaw, _sin_yaw)
+    // pair from the same attitude update cycle.  The semaphore is
+    // recursive so this is safe even if the caller already holds it.
+    WITH_SEMAPHORE(_rsem);
     return Vector2f(ef.x * _cos_yaw + ef.y * _sin_yaw,
                     -ef.x * _sin_yaw + ef.y * _cos_yaw);
 }
@@ -245,6 +261,7 @@ Vector2f AP_AHRS::earth_to_body2D(const Vector2f &ef) const
 // rotate a 2D vector from body frame to earth frame
 Vector2f AP_AHRS::body_to_earth2D(const Vector2f &bf) const
 {
+    WITH_SEMAPHORE(_rsem);
     return Vector2f(bf.x * _cos_yaw - bf.y * _sin_yaw,
                     bf.x * _sin_yaw + bf.y * _cos_yaw);
 }
@@ -252,6 +269,7 @@ Vector2f AP_AHRS::body_to_earth2D(const Vector2f &bf) const
 // rotate a 2D vector from body frame to earth frame
 Vector2p AP_AHRS::body_to_earth2D_p(const Vector2p &bf) const
 {
+    WITH_SEMAPHORE(_rsem);
     return Vector2p(bf.x * _cos_yaw - bf.y * _sin_yaw,
                     bf.x * _sin_yaw + bf.y * _cos_yaw);
 }

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -176,18 +176,18 @@ private:
 
     // euler angles - used for recovering if the DCM
     // matrix becomes ill-conditioned and watchdog storage
-    float roll;
-    float pitch;
-    float yaw;
+    float roll{0.0f};
+    float pitch{0.0f};
+    float yaw{0.0f};
 
     Vector3f _omega_P;                          // accel Omega proportional correction
     Vector3f _omega_yaw_P;                      // proportional yaw correction
     Vector3f _omega_I;                          // Omega Integrator correction
     Vector3f _omega_I_sum;
-    float _omega_I_sum_time;
+    float _omega_I_sum_time{0.0f};
     Vector3f _omega;                            // Corrected Gyro_Vector data
 
-    bool have_initial_yaw; // true if the yaw value has been initialised with a reference
+    bool have_initial_yaw{false}; // true if the yaw value has been initialised with a reference
 
     // variables to cope with delaying the GA sum to match GPS lag
     Vector3f ra_delayed(uint8_t instance, const Vector3f &ra);
@@ -207,60 +207,60 @@ private:
     bool should_correct_centrifugal() const;
 
     // state to support status reporting
-    float _renorm_val_sum;
-    uint16_t _renorm_val_count;
+    float _renorm_val_sum{0.0f};
+    uint16_t _renorm_val_count{0};
     float _error_rp{1.0f};
     float _error_yaw{1.0f};
 
     // time in microseconds of last compass update
-    uint32_t _compass_last_update;
+    uint32_t _compass_last_update{0};
 
     // time in millis when we last got a GPS heading
-    uint32_t _gps_last_update;
+    uint32_t _gps_last_update{0};
 
     // state of accel drift correction
     Vector3f _ra_sum[INS_MAX_INSTANCES];
     Vector3f _last_velocity;
-    float _ra_deltat;
-    uint32_t _ra_sum_start;
+    float _ra_deltat{0.0f};
+    uint32_t _ra_sum_start{0};
 
     // which accelerometer instance is active
-    uint8_t _active_accel_instance;
+    uint8_t _active_accel_instance{0};
 
     // the earths magnetic field
-    float _last_declination;
+    float _last_declination{0.0f};
     Vector2f _mag_earth{1, 0};
 
     // whether we have GPS lock
-    bool _have_gps_lock;
+    bool _have_gps_lock{false};
 
     // the lat/lng where we last had GPS lock
-    int32_t _last_lat;
-    int32_t _last_lng;
-    uint32_t _last_pos_ms;
+    int32_t _last_lat{0};
+    int32_t _last_lng{0};
+    uint32_t _last_pos_ms{0};
 
     // position offset from last GPS lock
-    float _position_offset_north;
-    float _position_offset_east;
+    float _position_offset_north{0.0f};
+    float _position_offset_east{0.0f};
 
     // whether we have a position estimate
-    bool _have_position;
+    bool _have_position{false};
 
     // support for wind estimation
     Vector3f _last_fuse;
     Vector3f _last_vel;
-    uint32_t _last_wind_time;
-    float _last_airspeed_TAS;
-    uint32_t _last_consistent_heading;
+    uint32_t _last_wind_time{0};
+    float _last_airspeed_TAS{0.0f};
+    uint32_t _last_consistent_heading{0};
 
     // estimated wind in m/s
     Vector3f _wind;
 
     // last time AHRS failed in milliseconds
-    uint32_t _last_failure_ms;
+    uint32_t _last_failure_ms{0};
 
     // time when DCM was last reset
-    uint32_t _last_startup_ms;
+    uint32_t _last_startup_ms{0};
 
     // last origin we returned, for DCM fallback from EKF
     Location last_origin;
@@ -272,10 +272,10 @@ private:
     Vector2f _lastGndVelADS; // previous HPF input
 
     // pre-calculated trig cache:
-    float _sin_yaw;
-    float _cos_yaw;
+    float _sin_yaw{0.0f};
+    float _cos_yaw{1.0f};
 
-    uint32_t last_log_ms;
+    uint32_t last_log_ms{0};
 };
 
 #endif  // AP_AHRS_DCM_ENABLED

--- a/libraries/AP_AHRS/AP_AHRS_SIM.h
+++ b/libraries/AP_AHRS/AP_AHRS_SIM.h
@@ -113,8 +113,8 @@ private:
     NavEKF3 &EKF3;
 #endif
 
-    class SITL::SIM *_sitl;
-    uint32_t _last_body_odm_update_ms;
+    class SITL::SIM *_sitl{nullptr};
+    uint32_t _last_body_odm_update_ms{0};
 };
 
 #endif  // AP_AHRS_SIM_ENABLED

--- a/libraries/SRV_Channel/SRV_Channel.cpp
+++ b/libraries/SRV_Channel/SRV_Channel.cpp
@@ -246,6 +246,11 @@ void SRV_Channel::calc_pwm(float output_scaled)
 
 void SRV_Channel::set_output_pwm(uint16_t pwm, bool force)
 {
+    // Even when force is true, never bypass an active emergency stop
+    // on channels that should be E-stopped.
+    if (SRV_Channel::should_e_stop(get_function()) && SRV_Channels::emergency_stop) {
+        return;
+    }
     if (!override_active || force) {
         output_pwm = pwm;
         have_pwm_mask |= (1U<<ch_num);


### PR DESCRIPTION
This draft isolates the AHRS and adjacent SRV safety-path changes from the larger hardening branch.

Summary:
- tighten AHRS state access / initialization handling in this slice
- include the adjacent SRV safety-path change carried by the same theme

Why:
- this keeps the review surface limited to attitude-state access and servo safety behavior
- it avoids mixing these changes with parser, tooling, and documentation work from the original branch

Validation:
- branch was split cleanly from upstream/master
- not fully validated locally as a standalone branch beyond the split and commit flow
- draft only: this slice changes sensitive flight/safety paths and should be reviewed conservatively
