### PR TITLE
AP_GSOF: add parser bounds guards

### DIFF
--- a/libraries/AP_GSOF/AP_GSOF.cpp
+++ b/libraries/AP_GSOF/AP_GSOF.cpp
@@ -99,7 +99,10 @@ AP_GSOF::process_message(MsgTypes& parsed_msgs)
             a++;
             const uint8_t output_length = msg.data[a];
             a++;
-            // TODO handle corruption on output_length causing buffer overrun?
+            // Validate that the record fits within the packet before parsing.
+            if (a + output_length > msg.length) {
+                return false;
+            }
 
             switch (output_type) {
             case POS_TIME:


### PR DESCRIPTION
This draft isolates the AP_GSOF parser bounds checks from the larger hardening branch.

Summary:
- add small defensive parsing guards in AP_GSOF

Why:
- this is a narrow parser-correctness change that is easier to review alone than inside the larger branch

Validation:
- branch was split cleanly from upstream/master
- not fully validated locally as a standalone branch beyond the split and commit flow
- draft only pending review
