### PR TITLE
AP_GPS_NMEA: fix two bugs in _parse_decimal_100

### DIFF
--- a/libraries/AP_GPS/AP_GPS_NMEA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NMEA.cpp
@@ -144,7 +144,9 @@ int32_t AP_GPS_NMEA::_parse_decimal_100(const char *p)
 {
     char *endptr = nullptr;
     long ret = 100 * strtol(p, &endptr, 10);
-    int sign = ret < 0 ? -1 : 1;
+    // Use the input character to determine sign; strtol("-0") == 0, which
+    // is non-negative, so `ret < 0` would wrongly set sign = +1 for "-0.x".
+    int sign = (*p == '-') ? -1 : 1;
 
     if (ret >= (long)INT32_MAX) {
         return INT32_MAX;
@@ -164,6 +166,14 @@ int32_t AP_GPS_NMEA::_parse_decimal_100(const char *p)
                 ret += sign * (DIGIT_TO_VAL(endptr[3]) >= 5);
             }
         }
+    }
+    // Re-check after fractional addition: e.g. "21474836.9" passes the integer
+    // guard (2147483600 < INT32_MAX) but the +90 pushes it over the limit.
+    if (ret >= (long)INT32_MAX) {
+        return INT32_MAX;
+    }
+    if (ret <= (long)INT32_MIN) {
+        return INT32_MIN;
     }
     return ret;
 }

--- a/libraries/AP_GPS/tests/test_gps.cpp
+++ b/libraries/AP_GPS/tests/test_gps.cpp
@@ -60,6 +60,72 @@ TEST(AP_GPS_NMEA, parse_decimal_100)
     /* Integer numbers */
     ASSERT_EQ(100, test.parse_decimal_100("1"));
     ASSERT_EQ(-100, test.parse_decimal_100("-1"));
+
+    /* Zero */
+    ASSERT_EQ(0, test.parse_decimal_100("0"));
+    ASSERT_EQ(0, test.parse_decimal_100("0.0"));
+
+    /* Single fractional digit */
+    ASSERT_EQ(50, test.parse_decimal_100("0.5"));
+    /* sign is derived from the leading '-' character, not from strtol's
+     * return value, so "-0.x" inputs correctly negate the fractional part. */
+    ASSERT_EQ(-50,  test.parse_decimal_100("-0.5"));
+    ASSERT_EQ(-150, test.parse_decimal_100("-1.5"));
+
+    /* Two fractional digits */
+    ASSERT_EQ(55, test.parse_decimal_100("0.55"));
+    ASSERT_EQ(-55, test.parse_decimal_100("-0.55"));
+
+    /* Rounding of third digit: >= 5 rounds up, < 5 truncates */
+    ASSERT_EQ(56, test.parse_decimal_100("0.555"));
+    ASSERT_EQ(55, test.parse_decimal_100("0.554"));
+    ASSERT_EQ(56, test.parse_decimal_100("0.556"));
+    ASSERT_EQ(-56, test.parse_decimal_100("-0.555"));
+    ASSERT_EQ(-55, test.parse_decimal_100("-0.554"));
+
+    /* Leading decimal point (no integer part): ".5" treated as 0.5 */
+    ASSERT_EQ(50, test.parse_decimal_100(".5"));
+    ASSERT_EQ(150, test.parse_decimal_100("1.5"));
+
+    /* Large integers */
+    ASSERT_EQ(99900, test.parse_decimal_100("999"));
+    ASSERT_EQ(-99900, test.parse_decimal_100("-999"));
+
+    /* Extra digits beyond third decimal are ignored */
+    ASSERT_EQ(100, test.parse_decimal_100("1.00000"));
+
+    /* Rounding boundary: 1.004 → 100, 1.005 → 101 */
+    ASSERT_EQ(100, test.parse_decimal_100("1.004"));
+    ASSERT_EQ(101, test.parse_decimal_100("1.005"));
+    ASSERT_EQ(-101, test.parse_decimal_100("-1.005"));
+    ASSERT_EQ(-100, test.parse_decimal_100("-1.004"));
+}
+
+/* Verify parse_decimal_100 clamps overflowing inputs to INT32_MAX / INT32_MIN.
+ * INT32_MAX = 2147483647; strtol("21474837") * 100 = 2147483700 > INT32_MAX.
+ * The function must return INT32_MAX, not a wrapped/UB value. */
+TEST(AP_GPS_NMEA, parse_decimal_100_overflow)
+{
+    AP_GPS_NMEA_Test test;
+
+    /* Positive overflow: clamps to INT32_MAX */
+    EXPECT_EQ(INT32_MAX, test.parse_decimal_100("21474837"));
+
+    /* Negative overflow: clamps to INT32_MIN */
+    EXPECT_EQ(INT32_MIN, test.parse_decimal_100("-21474837"));
+
+    /* Just below overflow threshold: passes through unchanged */
+    /* strtol("21474836") * 100 = 2147483600, which fits in int32_t */
+    EXPECT_EQ(2147483600, test.parse_decimal_100("21474836"));
+
+    /* Fractional digits can push past INT32_MAX/MIN even when the integer
+     * part alone passes the guard: 21474836*100=2147483600 < INT32_MAX,
+     * but adding 0.9*100=90 gives 2147483690 > INT32_MAX. */
+    EXPECT_EQ(INT32_MAX, test.parse_decimal_100("21474836.9"));
+    EXPECT_EQ(INT32_MIN, test.parse_decimal_100("-21474836.9"));
+
+    /* Non-overflowing fractional: 21474836.4 → 2147483600 + 40 = 2147483640 */
+    EXPECT_EQ(2147483640, test.parse_decimal_100("21474836.4"));
 }
 
 AP_GTEST_MAIN()


### PR DESCRIPTION
## Summary

Two independent bugs in `AP_GPS_NMEA::_parse_decimal_100`, both found by writing unit tests against the function's boundary conditions.

### Bug 1 — wrong sign for negative values whose integer part is zero

`strtol("-0")` returns `0`, which is non-negative, so the original sign-detection:

```cpp
int sign = ret < 0 ? -1 : 1;
```

evaluated to `sign = +1` for any input of the form `"-0.x"` (e.g. `"-0.5"`, `"-0.55"`), silently returning a **positive** value.

**Fix:** read the sign from the first character of the input string, which is unambiguous:

```cpp
int sign = (*p == '-') ? -1 : 1;
```

Values like `"-1.5"` were already correct because `strtol` returns a negative integer for them.

### Bug 2 — integer overflow guard runs before fractional digits are added

The `INT32_MAX` / `INT32_MIN` clamp only covered the integer part `× 100`. For an input like `"21474836.9"`:

- integer part × 100 = `2147483600` < `INT32_MAX` → guard passes
- after adding the `9` fractional digit: `ret += 90` → `2147483690` > `INT32_MAX`
- `return ret` performs an implicit `long → int32_t` truncation, yielding **`-2147483606`** — wrong sign and magnitude

A second clamp after the fractional-digit loop fixes this.

## Test plan

New tests in `libraries/AP_GPS/tests/test_gps.cpp`:

- **Bug 1:** `"-0.5"` → `-50`, `"-0.55"` → `-55`, `"-0.554"` → `-55`, `"-0.555"` → `-56`, `"-1.5"` → `-150`
- **Bug 2 (fractional overflow):** `"21474836.9"` → `INT32_MAX`, `"-21474836.9"` → `INT32_MIN`
- **Bug 2 (safe fractional):** `"21474836.4"` → `2147483640` (no clamp needed)

All existing tests continue to pass.