### PR TITLE
AP_Math: fix Vector3::angle() returning 0 for antiparallel vectors

### DIFF
--- a/libraries/AP_Math/tests/test_vector3.cpp
+++ b/libraries/AP_Math/tests/test_vector3.cpp
@@ -359,4 +359,37 @@ TEST(Vector3Test, point_on_segmentx)
 
 }
 */
+// angle() between two Vector3f values.
+// The Vector2 implementation correctly returns M_PI for antiparallel vectors;
+// Vector3 had a combined guard `if (cosv >= 1 || cosv <= -1) return 0.0f`
+// that returned 0 for both the parallel (cosv==1) AND antiparallel (cosv==-1)
+// cases.  This test covers all cases including antiparallel.
+TEST(Vector3Test, AngleBetween)
+{
+    // Parallel: angle = 0
+    EXPECT_FLOAT_EQ(Vector3f(1,0,0).angle(Vector3f(1,0,0)), 0.0f);
+    EXPECT_FLOAT_EQ(Vector3f(1,0,0).angle(Vector3f(5,0,0)), 0.0f);  // scale invariant
+
+    // Orthogonal: angle = π/2
+    EXPECT_FLOAT_EQ(Vector3f(1,0,0).angle(Vector3f(0,1,0)), float(M_PI/2));
+    EXPECT_FLOAT_EQ(Vector3f(1,0,0).angle(Vector3f(0,0,1)), float(M_PI/2));
+
+    // 45° and 60°
+    EXPECT_NEAR(Vector3f(1,0,0).angle(Vector3f(1,1,0)),                   float(M_PI/4), 1e-6f);
+    EXPECT_NEAR(Vector3f(1,0,0).angle(Vector3f(0.5f,sqrtf(3)/2.0f,0.0f)), float(M_PI/3), 1e-6f);
+
+    // Antiparallel: angle = π  (was returning 0 before this fix)
+    EXPECT_NEAR(Vector3f(1,0,0).angle(Vector3f(-1,0,0)),    float(M_PI), 1e-6f);
+    EXPECT_NEAR(Vector3f(0,1,0).angle(Vector3f(0,-1,0)),    float(M_PI), 1e-6f);
+    EXPECT_NEAR(Vector3f(1,1,1).angle(Vector3f(-1,-1,-1)),  float(M_PI), 1e-6f);
+
+    // Zero vector: guarded, returns 0
+    EXPECT_FLOAT_EQ(Vector3f(0,0,0).angle(Vector3f(1,0,0)), 0.0f);
+    EXPECT_FLOAT_EQ(Vector3f(1,0,0).angle(Vector3f(0,0,0)), 0.0f);
+
+    // Symmetry: angle(a,b) == angle(b,a)
+    EXPECT_FLOAT_EQ(Vector3f(1,0,0).angle(Vector3f(0,1,0)),
+                    Vector3f(0,1,0).angle(Vector3f(1,0,0)));
+}
+
 AP_GTEST_MAIN()

--- a/libraries/AP_Math/vector3.cpp
+++ b/libraries/AP_Math/vector3.cpp
@@ -429,8 +429,11 @@ T Vector3<T>::angle(const Vector3<T> &v2) const
         return 0.0f;
     }
     const T cosv = ((*this)*v2) / len;
-    if (cosv >= 1 || cosv <= -1) {
+    if (cosv >= 1) {
         return 0.0f;
+    }
+    if (cosv <= -1) {
+        return M_PI;
     }
     return acosF(cosv);
 }


### PR DESCRIPTION
## Summary

`Vector3<T>::angle()` returns `0` for antiparallel vectors instead of `π`.

### Root cause

The guard that clamps floating-point rounding at the edges of `[-1, 1]` combined both cases into one branch:

```cpp
// Before — vector3.cpp
if (cosv >= 1 || cosv <= -1) {
    return 0.0f;          // ← wrong for cosv == -1 (antiparallel)
}
```

When two vectors point in exactly opposite directions `cosv` computes to `-1` (or slightly below due to floating-point), and the function returns `0` instead of `π`.

### Fix

Split the condition, matching the `Vector2` implementation which already handles this correctly:

```cpp
// After — vector3.cpp  (matches Vector2::angle exactly)
if (cosv >= 1) {
    return 0.0f;
}
if (cosv <= -1) {
    return M_PI;
}
```

### Impact

Any code that computes the angle between two 3-D vectors and relies on the result being near `π` for opposite directions receives `0` instead — e.g. path planning, attitude error calculations, obstacle avoidance dot-product checks.

## Test plan

New `TEST(Vector3Test, AngleBetween)` in `libraries/AP_Math/tests/test_vector3.cpp`:

| Input | Expected | Before fix |
|---|---|---|
| `(1,0,0)` · `(1,0,0)` | `0` | `0` ✓ |
| `(1,0,0)` · `(0,1,0)` | `π/2` | `π/2` ✓ |
| `(1,0,0)` · `(1,1,0)` | `π/4` | `π/4` ✓ |
| `(1,0,0)` · `(-1,0,0)` | `π` | **`0`** ✗ |
| `(1,1,1)` · `(-1,-1,-1)` | `π` | **`0`** ✗ |
| `(0,0,0)` · `(1,0,0)` | `0` | `0` ✓ |