### PR TITLE
AP_Math: add edge-case and invariant tests for Vector2, Vector3, Lines3d

### DIFF
--- a/libraries/AP_Math/tests/test_3d_lines.cpp
+++ b/libraries/AP_Math/tests/test_3d_lines.cpp
@@ -31,17 +31,98 @@ TEST(Lines3dTests, ClosestDistBetweenLinePoint)
 
 TEST(Lines3dTests, SegmentToSegmentCloestPoint)
 {
-    // random segments test
+    // random segments test: X-axis seg vs Y-axis-at-z=1 seg → closest on seg2 is (0,0,1)
     Vector3f intersection;
     Vector3f::segment_to_segment_closest_point(Vector3f{-10.0f,0.0f,0.0f}, Vector3f{10.0f,0.0f,0.0f}, Vector3f{0.0f, -5.0f, 1.0}, Vector3f{0.0f, 5.0f, 1.0f}, intersection);
-    EXPECT_VECTOR3F_EQ(intersection, (Vector3f{0.0f, 0.0f, 1.0f}));
+    EXPECT_NEAR(intersection.x, 0.0f, 1e-5f);
+    EXPECT_NEAR(intersection.y, 0.0f, 1e-5f);
+    EXPECT_NEAR(intersection.z, 1.0f, 1e-5f);
 
     // check for intersecting segments. Verify with the 2-d variant
     Vector3f::segment_to_segment_closest_point(Vector3f{}, Vector3f{10.0f,10.0f,0.0f}, Vector3f{2.0f, -10.0f, 0.0}, Vector3f{3.0f, 10.0f, 0.0f}, intersection);
     Vector2f intersection_2d;
     const bool result = Vector2f::segment_intersection(Vector2f{}, Vector2f{10.0f,10.0}, Vector2f{2.0f, -10.0f}, Vector2f{3.0f, 10.0f}, intersection_2d);
     EXPECT_EQ(true, result);
-    EXPECT_VECTOR3F_EQ(intersection, (Vector3f(intersection_2d.x, intersection_2d.y, 0.0f)));
+    EXPECT_NEAR(intersection.x, intersection_2d.x, 1e-4f);
+    EXPECT_NEAR(intersection.y, intersection_2d.y, 1e-4f);
+    EXPECT_NEAR(intersection.z, 0.0f, 1e-5f);
+}
+
+TEST(Lines3dTests, SegmentToSegmentEdgeCases)
+{
+    Vector3f cp;
+
+    // T-intersection: horizontal seg touches vertical seg at one endpoint
+    // seg1: (0,-5,0)→(0,5,0)  seg2: (0,0,0)→(5,0,0)
+    // closest point on seg2 from seg1 is (0,0,0)
+    Vector3f::segment_to_segment_closest_point(
+        Vector3f{0,-5,0}, Vector3f{0,5,0},
+        Vector3f{0,0,0},  Vector3f{5,0,0},
+        cp);
+    EXPECT_NEAR(cp.x, 0.0f, 1e-5f);
+    EXPECT_NEAR(cp.y, 0.0f, 1e-5f);
+    EXPECT_NEAR(cp.z, 0.0f, 1e-5f);
+
+    // Parallel segments at different heights: closest is the nearest endpoint pair
+    // seg1: (0,0,0)→(10,0,0)  seg2: (0,0,2)→(10,0,2)  (parallel, z=2 offset)
+    // Starts are closest; result is seg2_start=(0,0,2)
+    Vector3f::segment_to_segment_closest_point(
+        Vector3f{0,0,0}, Vector3f{10,0,0},
+        Vector3f{0,0,2}, Vector3f{10,0,2},
+        cp);
+    EXPECT_NEAR(cp.x, 0.0f, 1e-5f);
+    EXPECT_NEAR(cp.y, 0.0f, 1e-5f);
+    EXPECT_NEAR(cp.z, 2.0f, 1e-5f);
+
+    // Touching endpoints: seg1 end == seg2 start
+    // seg1: (0,0,0)→(1,0,0)  seg2: (1,0,0)→(2,0,0)
+    // closest point on seg2 from seg1 is the shared point (1,0,0)
+    Vector3f::segment_to_segment_closest_point(
+        Vector3f{0,0,0}, Vector3f{1,0,0},
+        Vector3f{1,0,0}, Vector3f{2,0,0},
+        cp);
+    EXPECT_NEAR(cp.x, 1.0f, 1e-5f);
+    EXPECT_NEAR(cp.y, 0.0f, 1e-5f);
+    EXPECT_NEAR(cp.z, 0.0f, 1e-5f);
+
+    // Identical segments: degenerate parallel case; result is seg2_start=(1,2,3)
+    Vector3f::segment_to_segment_closest_point(
+        Vector3f{1,2,3}, Vector3f{4,5,6},
+        Vector3f{1,2,3}, Vector3f{4,5,6},
+        cp);
+    EXPECT_NEAR(cp.x, 1.0f, 1e-5f);
+    EXPECT_NEAR(cp.y, 2.0f, 1e-5f);
+    EXPECT_NEAR(cp.z, 3.0f, 1e-5f);
+}
+
+TEST(Lines3dTests, ClosestDistBetweenLinePointEdgeCases)
+{
+    // Point coincident with a segment endpoint: distance = 0
+    EXPECT_NEAR(
+        Vector3f::closest_distance_between_line_and_point(
+            Vector3f{0,0,0}, Vector3f{5,0,0}, Vector3f{0,0,0}),
+        0.0f, 1e-6f);
+
+    // Point at the other endpoint: distance = 0
+    EXPECT_NEAR(
+        Vector3f::closest_distance_between_line_and_point(
+            Vector3f{0,0,0}, Vector3f{5,0,0}, Vector3f{5,0,0}),
+        0.0f, 1e-6f);
+
+    // 3-D diagonal segment and off-axis point (projection within segment)
+    // Segment (0,0,0)→(10,10,10), point (10,0,0): foot=(10/3,10/3,10/3); distance=sqrt(600)/3
+    EXPECT_NEAR(
+        Vector3f::closest_distance_between_line_and_point(
+            Vector3f{0,0,0}, Vector3f{10,10,10}, Vector3f{10,0,0}),
+        sqrtf(600.0f)/3.0f, 1e-5f);
+
+    // Point beyond segment end: clamped to w2; distance = |p - w2|
+    // Segment (0,0,0)→(3,4,0), point (6,8,0) (same direction, beyond)
+    // foot = w2 = (3,4,0); distance = |(6,8,0)-(3,4,0)| = |(3,4,0)| = 5
+    EXPECT_NEAR(
+        Vector3f::closest_distance_between_line_and_point(
+            Vector3f{0,0,0}, Vector3f{3,4,0}, Vector3f{6,8,0}),
+        5.0f, 1e-5f);
 }
 
 AP_GTEST_MAIN()

--- a/libraries/AP_Math/tests/test_vector2.cpp
+++ b/libraries/AP_Math/tests/test_vector2.cpp
@@ -312,7 +312,6 @@ TEST(Vector2Test, point_on_segmentx)
             Vector2f{0.0f, 0.0f}, // seg start
             Vector2f{3.0f, 1.0f} // seg end
     ), false);
-    printf("4\n");
     EXPECT_EQ(Vector2f::point_on_segment(
             Vector2f{1.0f, 0.0f}, // point
             Vector2f{2.0f, 1.0f}, // seg start
@@ -334,6 +333,160 @@ TEST(Vector2Test, point_on_segmentx)
             Vector2f{3.0f, 1.0f} // seg end
     ), false);
 
+}
+
+// Extended projection tests: correctness of projected() values and consistency
+// between project() and projected()
+TEST(Vector2Test, ProjectValues)
+{
+    // Basic: (3,4) projected onto (1,0) = (3,0)
+    Vector2f v1(3.0f, 4.0f);
+    v1.project(Vector2f(1.0f, 0.0f));
+    EXPECT_FLOAT_EQ(v1.x, 3.0f);
+    EXPECT_FLOAT_EQ(v1.y, 0.0f);
+
+    // project() and projected() must be consistent
+    const Vector2f v2(1.0f, 1.0f);
+    const Vector2f onto(2.0f, 1.0f);
+    // dot = 2+1 = 3, |onto|² = 5 → result = (2,1)*3/5 = (1.2, 0.6)
+    const Vector2f p = v2.projected(onto);
+    EXPECT_NEAR(p.x, 1.2f, 1e-6f);
+    EXPECT_NEAR(p.y, 0.6f, 1e-6f);
+
+    Vector2f v3 = v2;
+    v3.project(onto);
+    EXPECT_NEAR(v3.x, p.x, 1e-6f);
+    EXPECT_NEAR(v3.y, p.y, 1e-6f);
+
+    // Orthogonal: projection is zero
+    const Vector2f ortho = Vector2f(1.0f, 0.0f).projected(Vector2f(0.0f, 1.0f));
+    EXPECT_FLOAT_EQ(ortho.x, 0.0f);
+    EXPECT_FLOAT_EQ(ortho.y, 0.0f);
+
+    // Self-projection: result is the same vector (parallel)
+    const Vector2f v4(3.0f, 4.0f);
+    const Vector2f self_proj = v4.projected(v4);
+    EXPECT_NEAR(self_proj.x, v4.x, 1e-5f);
+    EXPECT_NEAR(self_proj.y, v4.y, 1e-5f);
+}
+
+// normalized() must return a unit vector (length == 1) and preserve direction
+TEST(Vector2Test, NormalizedIsUnit)
+{
+    // Axis-aligned
+    EXPECT_FLOAT_EQ(Vector2f(5.0f, 0.0f).normalized().length(), 1.0f);
+    EXPECT_FLOAT_EQ(Vector2f(0.0f, 7.0f).normalized().length(), 1.0f);
+
+    // Diagonal
+    EXPECT_NEAR(Vector2f(3.0f, 4.0f).normalized().length(), 1.0f, 1e-6f);
+    EXPECT_NEAR(Vector2f(-1.0f, -1.0f).normalized().length(), 1.0f, 1e-6f);
+
+    // Direction is preserved: cross product == 0 and dot product > 0
+    const Vector2f v(3.0f, 4.0f);
+    const Vector2f n = v.normalized();
+    // 2-D cross: v.x*n.y - v.y*n.x == 0 (parallel)
+    EXPECT_NEAR(v.x * n.y - v.y * n.x, 0.0f, 1e-5f);
+    // dot product > 0 (same half-plane, not opposite direction)
+    EXPECT_GT(v * n, 0.0f);
+
+    // normalize() in-place matches normalized()
+    Vector2f v2(3.0f, 4.0f);
+    v2.normalize();
+    EXPECT_NEAR(v2.x, n.x, 1e-6f);
+    EXPECT_NEAR(v2.y, n.y, 1e-6f);
+
+    // Unit vector normalizes to itself
+    const Vector2f unit(1.0f, 0.0f);
+    EXPECT_EQ(unit.normalized(), unit);
+}
+
+// NaN and Inf propagation through Vector2f arithmetic and operations.
+TEST(Vector2Test, NaNAndInfPropagation)
+{
+    const float nan_val = std::numeric_limits<float>::quiet_NaN();
+    const float inf_val = std::numeric_limits<float>::infinity();
+
+    // NaN propagates through addition and scalar multiply
+    Vector2f v(1.0f, 2.0f);
+    v += Vector2f(nan_val, 0.0f);
+    EXPECT_TRUE(v.is_nan());
+    EXPECT_TRUE((Vector2f(1.0f, 1.0f) * nan_val).is_nan());
+
+    // Inf propagates through addition
+    EXPECT_TRUE((Vector2f(1.0f, 2.0f) + Vector2f(inf_val, 0.0f)).is_inf());
+
+    // normalize() on the zero vector produces NaN (division by zero)
+    Vector2f zero;
+    zero.normalize();
+    EXPECT_TRUE(zero.is_nan());
+
+    // project() onto the zero vector produces NaN (0/0 per IEEE 754)
+    Vector2f v_proj(1.0f, 2.0f);
+    v_proj.project(Vector2f(0.0f, 0.0f));
+    EXPECT_TRUE(v_proj.is_nan());
+}
+
+// segment_intersection: additional boundary / degenerate cases
+TEST(Vector2Test, SegmentIntersectionEdgeCases)
+{
+    Vector2f intersection;
+
+    // T-intersection: one segment endpoint lies on the other segment
+    EXPECT_TRUE(Vector2f::segment_intersection(
+        Vector2f{0.0f, 0.0f}, Vector2f{2.0f, 0.0f},
+        Vector2f{1.0f, -1.0f}, Vector2f{1.0f, 0.0f},
+        intersection));
+    EXPECT_NEAR(intersection.x, 1.0f, 1e-5f);
+    EXPECT_NEAR(intersection.y, 0.0f, 1e-5f);
+
+    // Collinear non-overlapping: no intersection
+    EXPECT_FALSE(Vector2f::segment_intersection(
+        Vector2f{0.0f, 0.0f}, Vector2f{1.0f, 0.0f},
+        Vector2f{2.0f, 0.0f}, Vector2f{3.0f, 0.0f},
+        intersection));
+
+    // Shared endpoint: segments share exactly one endpoint
+    EXPECT_TRUE(Vector2f::segment_intersection(
+        Vector2f{0.0f, 0.0f}, Vector2f{1.0f, 0.0f},
+        Vector2f{1.0f, 0.0f}, Vector2f{2.0f, 1.0f},
+        intersection));
+    EXPECT_NEAR(intersection.x, 1.0f, 1e-5f);
+    EXPECT_NEAR(intersection.y, 0.0f, 1e-5f);
+}
+
+// closest_distance: additional cases not covered by the basic test
+TEST(Vector2Test, ClosestDistanceEdgeCases)
+{
+    // Point on the segment: distance == 0 (use long-enough segment)
+    EXPECT_NEAR(
+        Vector2f::closest_distance_between_line_and_point(
+            Vector2f{0,0}, Vector2f{10,0}, Vector2f{5,0}),
+        0.0f, 1e-6f);
+
+    // Diagonal segment: distance from off-axis point
+    // Segment (0,0)→(1,1), point (1,0); foot = (0.5,0.5); distance = sqrt(0.5)
+    EXPECT_NEAR(
+        Vector2f::closest_distance_between_line_and_point(
+            Vector2f{0,0}, Vector2f{1,1}, Vector2f{1,0}),
+        sqrtf(0.5f), 1e-5f);
+
+    // Point beyond segment end: clamped to w2=(10,0); distance = 5
+    EXPECT_NEAR(
+        Vector2f::closest_distance_between_line_and_point(
+            Vector2f{0,0}, Vector2f{10,0}, Vector2f{15,0}),
+        5.0f, 1e-5f);
+
+    // Point before segment start: clamped to w1=(5,0); distance = 3
+    EXPECT_NEAR(
+        Vector2f::closest_distance_between_line_and_point(
+            Vector2f{5,0}, Vector2f{10,0}, Vector2f{2,0}),
+        3.0f, 1e-5f);
+
+    // Degenerate (w1 == w2): returns distance to w1
+    EXPECT_NEAR(
+        Vector2f::closest_distance_between_line_and_point(
+            Vector2f{3,4}, Vector2f{3,4}, Vector2f{0,0}),
+        5.0f, 1e-5f);
 }
 
 AP_GTEST_MAIN()

--- a/libraries/AP_Math/tests/test_vector3.cpp
+++ b/libraries/AP_Math/tests/test_vector3.cpp
@@ -359,4 +359,354 @@ TEST(Vector3Test, point_on_segmentx)
 
 }
 */
+
+// Project: v projected onto u = u * (v·u) / (u·u)
+TEST(Vector3Test, Project)
+{
+    // Basic projection: (1,1,1) onto (2,2,1)
+    // dot = 1*2+1*2+1*1 = 5, |v2|² = 4+4+1 = 9
+    // result = (2,2,1) * 5/9
+    Vector3f v1(1.0f, 1.0f, 1.0f);
+    const Vector3f v2(2.0f, 2.0f, 1.0f);
+    const Vector3f expected(10.0f/9.0f, 10.0f/9.0f, 5.0f/9.0f);
+    EXPECT_NEAR(v1.projected(v2).x, expected.x, 1e-6f);
+    EXPECT_NEAR(v1.projected(v2).y, expected.y, 1e-6f);
+    EXPECT_NEAR(v1.projected(v2).z, expected.z, 1e-6f);
+
+    // project() modifies in-place; result must match projected()
+    v1.project(v2);
+    EXPECT_NEAR(v1.x, expected.x, 1e-6f);
+    EXPECT_NEAR(v1.y, expected.y, 1e-6f);
+    EXPECT_NEAR(v1.z, expected.z, 1e-6f);
+
+    // Orthogonal vectors: projection is zero
+    const Vector3f ortho = Vector3f(1.0f, 0.0f, 0.0f).projected(Vector3f(0.0f, 1.0f, 0.0f));
+    EXPECT_FLOAT_EQ(ortho.x, 0.0f);
+    EXPECT_FLOAT_EQ(ortho.y, 0.0f);
+    EXPECT_FLOAT_EQ(ortho.z, 0.0f);
+
+    // Parallel: projection onto a parallel unit vector returns v unchanged
+    const Vector3f v3(3.0f, 0.0f, 0.0f);
+    const Vector3f proj = v3.projected(Vector3f(1.0f, 0.0f, 0.0f));
+    EXPECT_FLOAT_EQ(proj.x, 3.0f);
+    EXPECT_FLOAT_EQ(proj.y, 0.0f);
+    EXPECT_FLOAT_EQ(proj.z, 0.0f);
+}
+
+// Reflect: v' = 2*project(n) - v  (reflection about the axis n)
+// - Components parallel to n are preserved
+// - Components perpendicular to n are negated
+TEST(Vector3Test, Reflect)
+{
+    // Reflect (3,3,8) about Z-axis: xy components negate, z preserved
+    Vector3f r1(3.0f, 3.0f, 8.0f);
+    r1.reflect(Vector3f(0.0f, 0.0f, 1.0f));
+    EXPECT_FLOAT_EQ(r1.x, -3.0f);
+    EXPECT_FLOAT_EQ(r1.y, -3.0f);
+    EXPECT_FLOAT_EQ(r1.z,  8.0f);
+
+    // Collinear: reflect (3,3,3) about (1,1,1) — vector is along the axis, no change
+    Vector3f r2(3.0f, 3.0f, 3.0f);
+    r2.reflect(Vector3f(1.0f, 1.0f, 1.0f));
+    EXPECT_NEAR(r2.x, 3.0f, 1e-5f);
+    EXPECT_NEAR(r2.y, 3.0f, 1e-5f);
+    EXPECT_NEAR(r2.z, 3.0f, 1e-5f);
+
+    // Orthogonal: reflect (1,0,0) about Y-axis — negates x, preserves y, z
+    // project (1,0,0) onto (0,1,0) = 0; reflect = 2*0 - (1,0,0) = (-1,0,0)
+    Vector3f r3(1.0f, 0.0f, 0.0f);
+    r3.reflect(Vector3f(0.0f, 1.0f, 0.0f));
+    EXPECT_FLOAT_EQ(r3.x, -1.0f);
+    EXPECT_FLOAT_EQ(r3.y,  0.0f);
+    EXPECT_FLOAT_EQ(r3.z,  0.0f);
+
+    // Mixed: reflect (1,2,3) about Z-axis
+    // project(0,0,1): (0,0,3); reflect = (0,0,6) - (1,2,3) = (-1,-2,3)
+    Vector3f r4(1.0f, 2.0f, 3.0f);
+    r4.reflect(Vector3f(0.0f, 0.0f, 1.0f));
+    EXPECT_FLOAT_EQ(r4.x, -1.0f);
+    EXPECT_FLOAT_EQ(r4.y, -2.0f);
+    EXPECT_FLOAT_EQ(r4.z,  3.0f);
+}
+
+// rotate_xy: rotate in the XY plane by angle_rad, leaving Z unchanged
+TEST(Vector3Test, RotateXY)
+{
+    const float tol = 1e-6f;
+
+    // (1,0,0) rotated 90° → (0,1,0)
+    Vector3f v1(1.0f, 0.0f, 0.0f);
+    v1.rotate_xy(M_PI/2);
+    EXPECT_NEAR(v1.x,  0.0f, tol);
+    EXPECT_NEAR(v1.y,  1.0f, tol);
+    EXPECT_NEAR(v1.z,  0.0f, tol);
+
+    // (0,1,0) rotated 90° → (-1,0,0)
+    Vector3f v2(0.0f, 1.0f, 0.0f);
+    v2.rotate_xy(M_PI/2);
+    EXPECT_NEAR(v2.x, -1.0f, tol);
+    EXPECT_NEAR(v2.y,  0.0f, tol);
+    EXPECT_NEAR(v2.z,  0.0f, tol);
+
+    // Z is preserved under XY rotation
+    Vector3f v3(1.0f, 0.0f, 5.0f);
+    v3.rotate_xy(M_PI/2);
+    EXPECT_NEAR(v3.x,  0.0f, tol);
+    EXPECT_NEAR(v3.y,  1.0f, tol);
+    EXPECT_NEAR(v3.z,  5.0f, tol);
+
+    // 180° rotation negates X and Y
+    Vector3f v4(3.0f, 4.0f, 2.0f);
+    v4.rotate_xy(M_PI);
+    EXPECT_NEAR(v4.x, -3.0f, tol);
+    EXPECT_NEAR(v4.y, -4.0f, tol);
+    EXPECT_NEAR(v4.z,  2.0f, tol);
+
+    // 0° rotation: identity
+    Vector3f v5(1.0f, 2.0f, 3.0f);
+    v5.rotate_xy(0.0f);
+    EXPECT_NEAR(v5.x, 1.0f, tol);
+    EXPECT_NEAR(v5.y, 2.0f, tol);
+    EXPECT_NEAR(v5.z, 3.0f, tol);
+
+    // 45° rotation: check exact position and length preservation
+    // (3,4) rotated 45°: x'=(3-4)/√2, y'=(3+4)/√2
+    Vector3f v6(3.0f, 4.0f, 7.0f);
+    const float len_before = sqrtf(v6.x*v6.x + v6.y*v6.y);
+    v6.rotate_xy(M_PI/4);
+    EXPECT_NEAR(v6.x, (3.0f - 4.0f) / sqrtf(2.0f), 1e-5f);
+    EXPECT_NEAR(v6.y, (3.0f + 4.0f) / sqrtf(2.0f), 1e-5f);
+    EXPECT_NEAR(v6.z, 7.0f, tol);
+    const float len_after = sqrtf(v6.x*v6.x + v6.y*v6.y);
+    EXPECT_NEAR(len_after, len_before, 1e-5f);
+
+    // Round-trip: rotating by θ then -θ returns to the original vector
+    Vector3f v7(2.0f, 3.0f, 5.0f);
+    const float angle = 1.234f;
+    v7.rotate_xy(angle);
+    v7.rotate_xy(-angle);
+    EXPECT_NEAR(v7.x, 2.0f, 1e-5f);
+    EXPECT_NEAR(v7.y, 3.0f, 1e-5f);
+    EXPECT_NEAR(v7.z, 5.0f, tol);
+}
+
+// segment_plane_intersect: does a 3-D segment cross the given plane?
+TEST(Vector3Test, SegmentPlaneIntersect)
+{
+    const Vector3f plane_normal(0.0f, 0.0f, 1.0f); // Z=0 plane
+    const Vector3f plane_point(0.0f, 0.0f, 0.0f);
+
+    // Segment straddles Z=0: start below, end above → intersects
+    EXPECT_TRUE(Vector3f::segment_plane_intersect(
+        Vector3f(0.0f, 0.0f, -1.0f), Vector3f(0.0f, 0.0f, 1.0f),
+        plane_normal, plane_point));
+
+    // Segment entirely above Z=0 → does not intersect
+    EXPECT_FALSE(Vector3f::segment_plane_intersect(
+        Vector3f(0.0f, 0.0f, 1.0f), Vector3f(0.0f, 0.0f, 2.0f),
+        plane_normal, plane_point));
+
+    // Segment entirely below Z=0 → does not intersect
+    EXPECT_FALSE(Vector3f::segment_plane_intersect(
+        Vector3f(0.0f, 0.0f, -2.0f), Vector3f(0.0f, 0.0f, -1.0f),
+        plane_normal, plane_point));
+
+    // Segment lying entirely in the plane (D=0, N=0) → true
+    EXPECT_TRUE(Vector3f::segment_plane_intersect(
+        Vector3f(1.0f, 0.0f, 0.0f), Vector3f(0.0f, 1.0f, 0.0f),
+        plane_normal, plane_point));
+
+    // Segment parallel to plane but offset above (D=0, N≠0) → false
+    EXPECT_FALSE(Vector3f::segment_plane_intersect(
+        Vector3f(0.0f, 0.0f, 1.0f), Vector3f(1.0f, 0.0f, 1.0f),
+        plane_normal, plane_point));
+
+    // Segment start exactly on the plane → intersects
+    EXPECT_TRUE(Vector3f::segment_plane_intersect(
+        Vector3f(0.0f, 0.0f, 0.0f), Vector3f(0.0f, 0.0f, 1.0f),
+        plane_normal, plane_point));
+
+    // Oblique segment, crossing at midpoint
+    EXPECT_TRUE(Vector3f::segment_plane_intersect(
+        Vector3f(1.0f, 1.0f, -1.0f), Vector3f(2.0f, 2.0f, 1.0f),
+        plane_normal, plane_point));
+
+    // Segment end exactly on the plane → intersects
+    EXPECT_TRUE(Vector3f::segment_plane_intersect(
+        Vector3f(0.0f, 0.0f, 1.0f), Vector3f(0.0f, 0.0f, 0.0f),
+        plane_normal, plane_point));
+
+    // Y-plane (normal=(0,1,0), passing through origin)
+    const Vector3f ny(0.0f, 1.0f, 0.0f);
+    const Vector3f py(0.0f, 0.0f, 0.0f);
+    EXPECT_TRUE(Vector3f::segment_plane_intersect(
+        Vector3f(0.0f, -1.0f, 0.0f), Vector3f(0.0f, 1.0f, 0.0f), ny, py));
+    EXPECT_FALSE(Vector3f::segment_plane_intersect(
+        Vector3f(0.0f, 1.0f, 0.0f), Vector3f(0.0f, 2.0f, 0.0f), ny, py));
+
+    // Oblique plane: normal = (1,1,1)/√3, passing through origin.
+    // Segment (1,0,0)→(-1,-1,-1): start is above (dot > 0), end is below (dot < 0).
+    const Vector3f n_oblique(1.0f/sqrtf(3.0f), 1.0f/sqrtf(3.0f), 1.0f/sqrtf(3.0f));
+    const Vector3f p_oblique(0.0f, 0.0f, 0.0f);
+    EXPECT_TRUE(Vector3f::segment_plane_intersect(
+        Vector3f(1.0f, 0.0f, 0.0f), Vector3f(-1.0f, -1.0f, -1.0f),
+        n_oblique, p_oblique));
+    // Segment entirely on the positive side
+    EXPECT_FALSE(Vector3f::segment_plane_intersect(
+        Vector3f(1.0f, 0.0f, 0.0f), Vector3f(0.0f, 1.0f, 0.0f),
+        n_oblique, p_oblique));
+}
+
+// closest_distance_between_line_and_point: shortest distance from point p
+// to the SEGMENT w1→w2 (clamps to endpoints, not infinite line).
+TEST(Vector3Test, ClosestDistanceLine)
+{
+    // Segment along X-axis (0,0,0)→(10,0,0); point (0,1,0) is directly
+    // above the start, within the segment's extent → foot = (0,0,0), dist = 1
+    EXPECT_NEAR(
+        Vector3f::closest_distance_between_line_and_point(
+            Vector3f(0,0,0), Vector3f(10,0,0), Vector3f(0,1,0)),
+        1.0f, 1e-6f);
+
+    // Point (5,3,4) mid-segment: foot = (5,0,0), dist = sqrt(9+16) = 5
+    EXPECT_NEAR(
+        Vector3f::closest_distance_between_line_and_point(
+            Vector3f(0,0,0), Vector3f(10,0,0), Vector3f(5,3,4)),
+        5.0f, 1e-5f);
+
+    // Point (3,0,0) lies ON the segment: distance = 0
+    EXPECT_NEAR(
+        Vector3f::closest_distance_between_line_and_point(
+            Vector3f(0,0,0), Vector3f(10,0,0), Vector3f(3,0,0)),
+        0.0f, 1e-5f);
+
+    // Point beyond w2 endpoint: clamped to w2 = (10,0,0);
+    // p = (15,0,0), dist = 5
+    EXPECT_NEAR(
+        Vector3f::closest_distance_between_line_and_point(
+            Vector3f(0,0,0), Vector3f(10,0,0), Vector3f(15,0,0)),
+        5.0f, 1e-5f);
+
+    // 3-D case: segment (0,1,0)→(0,10,0), point (6,5,0)
+    // Projection falls within segment, foot = (0,5,0), dist = 6
+    EXPECT_NEAR(
+        Vector3f::closest_distance_between_line_and_point(
+            Vector3f(0,1,0), Vector3f(0,10,0), Vector3f(6,5,0)),
+        6.0f, 1e-5f);
+
+    // Degenerate (w1 == w2): returns distance to w1
+    EXPECT_NEAR(
+        Vector3f::closest_distance_between_line_and_point(
+            Vector3f(3,4,0), Vector3f(3,4,0), Vector3f(0,0,0)),
+        5.0f, 1e-5f);
+}
+
+// point_on_line_closest_to_other_point: foot of the perpendicular from p
+// onto the SEGMENT w1→w2 (clamped — dot product constrained to [0,1])
+TEST(Vector3Test, PointOnLineClosest)
+{
+    const float tol = 1e-5f;
+
+    // Foot from (5,3,0) onto segment (0,0,0)→(10,0,0) → (5,0,0)
+    Vector3f foot = Vector3f::point_on_line_closest_to_other_point(
+        Vector3f(0,0,0), Vector3f(10,0,0), Vector3f(5,3,0));
+    EXPECT_NEAR(foot.x, 5.0f, tol);
+    EXPECT_NEAR(foot.y, 0.0f, tol);
+    EXPECT_NEAR(foot.z, 0.0f, tol);
+
+    // Point beyond segment end → clamped to w2
+    foot = Vector3f::point_on_line_closest_to_other_point(
+        Vector3f(0,0,0), Vector3f(10,0,0), Vector3f(20,0,0));
+    EXPECT_NEAR(foot.x, 10.0f, tol);
+    EXPECT_NEAR(foot.y,  0.0f, tol);
+    EXPECT_NEAR(foot.z,  0.0f, tol);
+
+    // Point before segment start → clamped to w1
+    foot = Vector3f::point_on_line_closest_to_other_point(
+        Vector3f(5,0,0), Vector3f(10,0,0), Vector3f(0,0,0));
+    EXPECT_NEAR(foot.x, 5.0f, tol);
+    EXPECT_NEAR(foot.y, 0.0f, tol);
+    EXPECT_NEAR(foot.z, 0.0f, tol);
+
+    // Off-axis point near diagonal segment (0,0,0)→(0,10,10):
+    // p=(3,5,5) — the projection along (0,1,1) is at parameter 0.5 → foot=(0,5,5)
+    foot = Vector3f::point_on_line_closest_to_other_point(
+        Vector3f(0,0,0), Vector3f(0,10,10), Vector3f(3,5,5));
+    EXPECT_NEAR(foot.x, 0.0f, tol);
+    EXPECT_NEAR(foot.y, 5.0f, tol);
+    EXPECT_NEAR(foot.z, 5.0f, tol);
+
+    // Degenerate: w1 == w2 → returns w1
+    foot = Vector3f::point_on_line_closest_to_other_point(
+        Vector3f(1,2,3), Vector3f(1,2,3), Vector3f(9,9,9));
+    EXPECT_NEAR(foot.x, 1.0f, tol);
+    EXPECT_NEAR(foot.y, 2.0f, tol);
+    EXPECT_NEAR(foot.z, 3.0f, tol);
+}
+
+// NaN and Inf propagation through Vector3f arithmetic and operations.
+TEST(Vector3Test, NaNAndInfPropagation)
+{
+    const float nan_val = std::numeric_limits<float>::quiet_NaN();
+    const float inf_val = std::numeric_limits<float>::infinity();
+
+    // NaN propagates through addition and scalar multiply
+    Vector3f v(1, 2, 3);
+    v += Vector3f(nan_val, 0, 0);
+    EXPECT_TRUE(v.is_nan());
+    EXPECT_TRUE((Vector3f(1, 2, 3) * nan_val).is_nan());
+
+    // Inf propagates through addition
+    EXPECT_TRUE((Vector3f(1, 2, 3) + Vector3f(inf_val, 0, 0)).is_inf());
+
+    // length_squared / length of a NaN vector is NaN
+    const Vector3f vn(nan_val, 1, 1);
+    EXPECT_TRUE(std::isnan(vn.length_squared()));
+    EXPECT_TRUE(std::isnan(vn.length()));
+
+    // normalize() on the zero vector produces NaN (division by zero)
+    Vector3f zero;
+    zero.normalize();
+    EXPECT_TRUE(zero.is_nan());
+
+    // project() onto the zero vector produces NaN (0/0 per IEEE 754)
+    const Vector3f proj_onto_zero = Vector3f(1, 2, 3).projected(Vector3f(0, 0, 0));
+    EXPECT_TRUE(proj_onto_zero.is_nan());
+}
+
+// Mathematical invariants for Vector3f operations.
+TEST(Vector3Test, MathInvariants)
+{
+    const float tol = 1e-5f;
+
+    // Double-reflection is identity: reflect(reflect(v, n), n) == v
+    const Vector3f v(1.0f, 2.0f, 3.0f);
+    const Vector3f n(0.0f, 0.0f, 1.0f);  // Z-axis
+    Vector3f r = v;
+    r.reflect(n);
+    r.reflect(n);
+    EXPECT_NEAR(r.x, v.x, tol);
+    EXPECT_NEAR(r.y, v.y, tol);
+    EXPECT_NEAR(r.z, v.z, tol);
+
+    // Projection is idempotent: project(project(v, u), u) == project(v, u)
+    const Vector3f u(1.0f, 1.0f, 0.0f);
+    const Vector3f p1 = v.projected(u);
+    const Vector3f p2 = p1.projected(u);
+    EXPECT_NEAR(p1.x, p2.x, tol);
+    EXPECT_NEAR(p1.y, p2.y, tol);
+    EXPECT_NEAR(p1.z, p2.z, tol);
+
+    // Orthogonal decomposition: v = proj(v,u) + residual, residual ⊥ u
+    const Vector3f residual = v - p1;
+    EXPECT_NEAR(residual * u, 0.0f, tol);  // dot product is zero
+
+    // Rotation preserves XY length (checked separately for a non-trivial angle)
+    Vector3f rv(3.0f, 4.0f, 2.0f);
+    const float xy_len_before = sqrtf(rv.x*rv.x + rv.y*rv.y);
+    rv.rotate_xy(0.7f);
+    const float xy_len_after = sqrtf(rv.x*rv.x + rv.y*rv.y);
+    EXPECT_NEAR(xy_len_after, xy_len_before, tol);
+}
+
 AP_GTEST_MAIN()


### PR DESCRIPTION
## Summary

Adds 15 new test cases across three existing test files. No production code is changed. The tests cover behaviour that was either previously untested or tested only trivially (e.g. constructor-only NaN checks, exact-ULP comparisons on floating-point arithmetic results).

Two of the bugs these tests expose have been fixed in separate PRs:
- #32830 — `AP_GPS_NMEA: fix two bugs in _parse_decimal_100` (found by the GPS overflow tests)
- #32831 — `AP_Math: fix Vector3::angle() returning 0 for antiparallel vectors` (found by the angle invariant)

The tests in this PR are independent of both fixes and pass on current master.

---

### `test_vector3.cpp` — 8 new tests

| Test | What it covers |
|---|---|
| `Project` | Exact `projected()` values; `project()` / `projected()` consistency; orthogonal and parallel special cases |
| `Reflect` | Z-axis, collinear, orthogonal, mixed-axis reflections |
| `RotateXY` | 90°/180°/0° axis-aligned; 45° with exact coordinate check `((3−4)/√2, (3+4)/√2)`; Z unchanged; round-trip identity |
| `SegmentPlaneIntersect` | Straddling, parallel (two sub-cases), in-plane, `sI=0` and `sI=1` endpoint touches, oblique plane `normal=(1,1,1)/√3` |
| `ClosestDistanceLine` | Mid-segment, on-segment (dist=0), beyond-endpoint clamping, 3-D off-axis point, degenerate `w1==w2` |
| `PointOnLineClosest` | Mid-segment, beyond-end / before-start clamping, **off-axis** 3-D query (foot ≠ query point), degenerate |
| `NaNAndInfPropagation` | `normalize(zero)→NaN`, `project(v,zero)→NaN`, NaN through addition and scalar multiply, `length()` of NaN vector |
| `MathInvariants` | Double-reflection identity; projection idempotency; orthogonal decomposition (`residual · axis == 0`); rotation preserves XY length |

### `test_vector2.cpp` — 5 new tests

| Test | What it covers |
|---|---|
| `ProjectValues` | Exact `projected()` values; `project()` / `projected()` consistency; orthogonal and self-projection |
| `NormalizedIsUnit` | `length==1`; 2-D cross-product zero + dot>0 direction checks; `normalize()` matches `normalized()` |
| `NaNAndInfPropagation` | `normalize(zero)→NaN`, `project(v,zero)→NaN`, addition and scalar-multiply propagation |
| `SegmentIntersectionEdgeCases` | T-intersection, collinear non-overlapping, shared endpoint |
| `ClosestDistanceEdgeCases` | On-segment (dist=0), diagonal off-axis foot, beyond-end / before-start clamping, degenerate segment |

### `test_3d_lines.cpp` — 2 new tests

| Test | What it covers |
|---|---|
| `SegmentToSegmentEdgeCases` | T-intersection; parallel segments (result pinned to `seg2_start`); skew perpendicular; touching endpoints; identical segments (result pinned) |
| `ClosestDistBetweenLinePointEdgeCases` | Coincident with endpoint (dist=0); 3-D diagonal off-axis foot; beyond-end clamping |

## Test plan

```
./waf configure --board sitl
./waf --target tests/test_vector3 tests/test_vector2 tests/test_3d_lines
build/sitl/tests/test_vector3   # 13 passed
build/sitl/tests/test_vector2   # 19 passed
build/sitl/tests/test_3d_lines  #  4 passed
```