### PR TITLE
Filter: pre-allocate HarmonicNotchFilter bank at startup; fix log_notch_centers

### DIFF
--- a/libraries/Filter/HarmonicNotchFilter.cpp
+++ b/libraries/Filter/HarmonicNotchFilter.cpp
@@ -205,53 +205,48 @@ void HarmonicNotchFilter<T>::init(float sample_freq_hz, HarmonicNotchFilterParam
 }
 
 /*
-  allocate a collection of, at most HAL_HNF_MAX_FILTERS, notch filters to be managed by this harmonic notch filter
+  allocate a collection of notch filters to be managed by this harmonic notch filter.
+  Always allocates HAL_HNF_MAX_FILTERS upfront to avoid any runtime reallocation on the
+  hot filter-update path.
  */
 template <class T>
 void HarmonicNotchFilter<T>::allocate_filters(uint8_t num_notches, uint32_t harmonics, uint8_t composite_notches)
 {
     _composite_notches = MIN(composite_notches, 3);
     _num_harmonics = __builtin_popcount(harmonics);
-    _num_filters = MIN(_num_harmonics * num_notches * _composite_notches, HAL_HNF_MAX_FILTERS);
     _harmonics = harmonics;
 
-    if (_num_filters > 0) {
-        _filters = NEW_NOTHROW NotchFilter<T>[_num_filters];
-        if (_filters == nullptr) {
-            GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Failed to allocate %u bytes for notch filter", (unsigned int)(_num_filters * sizeof(NotchFilter<T>)));
-            _num_filters = 0;
-        }
+    // Always allocate the maximum possible count so expand_filter_count() never
+    // needs to heap-allocate on the real-time update path.
+    // Skip allocation entirely when no harmonics are enabled (harmonics=0)
+    // to preserve the old behaviour of zero allocation for disabled notches.
+    if (_num_harmonics == 0) {
+        _num_filters = 0;
+        return;
+    }
+    _num_filters = HAL_HNF_MAX_FILTERS;
+    _filters = NEW_NOTHROW NotchFilter<T>[HAL_HNF_MAX_FILTERS];
+    if (_filters == nullptr) {
+        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Failed to allocate %u bytes for notch filter", (unsigned int)(HAL_HNF_MAX_FILTERS * sizeof(NotchFilter<T>)));
+        _num_filters = 0;
     }
 }
 
 /*
-  expand the number of filters at runtime, allowing for RPM sources such as lua scripts
+  expand the in-use filter count up to total_notches.
+  Because allocate_filters() pre-allocates HAL_HNF_MAX_FILTERS, this never
+  needs to allocate memory – it only updates the bookkeeping counter.
  */
 template <class T>
 void HarmonicNotchFilter<T>::expand_filter_count(uint16_t total_notches)
 {
     if (total_notches <= _num_filters) {
-        // enough already
+        // already have enough capacity
         return;
     }
-    if (_alloc_has_failed) {
-        // we've failed to allocate before, don't try again
-        return;
-    }
-    /*
-      note that we rely on the semaphore in
-      AP_InertialSensor_Backend.cpp to make this thread safe
-     */
-    auto filters = NEW_NOTHROW NotchFilter<T>[total_notches];
-    if (filters == nullptr) {
-        _alloc_has_failed = true;
-        return;
-    }
-    memcpy(filters, _filters, sizeof(filters[0])*_num_filters);
-    auto _old_filters = _filters;
-    _filters = filters;
-    _num_filters = total_notches;
-    delete[] _old_filters;
+    // Should never be reached: total_notches is always capped at HAL_HNF_MAX_FILTERS
+    // (see update()) and _num_filters == HAL_HNF_MAX_FILTERS after allocate_filters().
+    _alloc_has_failed = true;
 }
 
 /*
@@ -487,7 +482,11 @@ void HarmonicNotchFilter<T>::log_notch_centers(uint8_t instance, uint64_t now_us
     if (_num_filters == 0 || filters_per_source == 0) {
         return;
     }
-    const uint8_t num_sources = MIN(6, _num_filters / filters_per_source);
+    // Use _num_enabled_filters (updated each update() call) not _num_filters
+    // (which is now permanently HAL_HNF_MAX_FILTERS after our pre-alloc change).
+    // Using _num_filters would cause the logger to access uninitialized filter
+    // slots and record garbage center frequencies.
+    const uint8_t num_sources = MIN(6, _num_enabled_filters / filters_per_source);
     float centers[6] {};
     float first_harmonic[6] {};
 

--- a/libraries/Filter/HarmonicNotchFilter.h
+++ b/libraries/Filter/HarmonicNotchFilter.h
@@ -34,7 +34,10 @@ public:
     ~HarmonicNotchFilter();
     // allocate a bank of notch filters for this harmonic notch filter
     void allocate_filters(uint8_t num_notches, uint32_t harmonics, uint8_t composite_notches);
-    // expand filter bank with new filters
+    // assert that the pre-allocated capacity is sufficient for total_notches.
+    // Since allocate_filters() always reserves HAL_HNF_MAX_FILTERS, this is
+    // a no-op for all valid inputs; it sets _alloc_has_failed if called with
+    // an out-of-range value (which should never happen).
     void expand_filter_count(uint16_t total_notches);
     // initialize the underlying filters using the provided filter parameters
     void init(float sample_freq_hz, HarmonicNotchFilterParams &params);

--- a/libraries/Filter/HarmonicNotchFilter.h
+++ b/libraries/Filter/HarmonicNotchFilter.h
@@ -29,6 +29,7 @@ class HarmonicNotchFilterParams;
  */
 template <class T>
 class HarmonicNotchFilter {
+    friend class HarmonicNotchFilterTest;
 public:
     ~HarmonicNotchFilter();
     // allocate a bank of notch filters for this harmonic notch filter

--- a/libraries/Filter/tests/test_notchfilter.cpp
+++ b/libraries/Filter/tests/test_notchfilter.cpp
@@ -363,4 +363,157 @@ TEST(NotchFilterTest, HarmonicNotchTest5)
     fclose(f);
 }
 
+// ---------------------------------------------------------------------------
+// RT-safety regression tests for HarmonicNotchFilter pre-allocation.
+//
+// These tests describe the EXPECTED post-fix behaviour.  On the unfixed
+// code they will FAIL, proving the bugs are real:
+//
+//   PreAllocMaxCapacity       – fails: _num_filters == 1 not HAL_HNF_MAX_FILTERS
+//   ExpandFilterCountIsNoop   – fails: expand_filter_count heap-allocates
+//   EnabledFiltersAfterUpdate – fails: update() triggers heap realloc via
+//                                      expand_filter_count when num_centers > 1
+//   ExpandFilterCountOverflow – passes on old code (realloc succeeds on a
+//                                      dev machine) but exposes the RT alloc path
+//
+// Run "waf tests && build/sitl/tests/test_notchfilter --gtest_filter=*PreAlloc*"
+// on an unpatched tree to observe the failures.
+// ---------------------------------------------------------------------------
+
+/*
+  Accessor for private HarmonicNotchFilter members used by the tests below.
+  The class is declared as a friend in HarmonicNotchFilter.h.
+ */
+class HarmonicNotchFilterTest {
+public:
+    template <class T>
+    static uint16_t num_filters(const HarmonicNotchFilter<T> &f) { return f._num_filters; }
+    template <class T>
+    static uint16_t num_enabled_filters(const HarmonicNotchFilter<T> &f) { return f._num_enabled_filters; }
+    template <class T>
+    static bool alloc_failed(const HarmonicNotchFilter<T> &f) { return f._alloc_has_failed; }
+};
+
+/*
+  allocate_filters() must reserve HAL_HNF_MAX_FILTERS up front so that
+  expand_filter_count() never needs to heap-allocate on the real-time
+  filter-update path.
+
+  WITHOUT THE FIX: allocate_filters(1,1,1) sets _num_filters = 1*1*1 = 1,
+  not HAL_HNF_MAX_FILTERS.  This test fails with:
+      Expected: num_filters == HAL_HNF_MAX_FILTERS (24 or 54)
+      Actual:   num_filters == 1
+ */
+TEST(NotchFilterTest, PreAllocMaxCapacity)
+{
+    // normal case: at least one harmonic enabled
+    {
+        HarmonicNotchFilter<float> f {};
+        f.allocate_filters(1, 1, 1);
+        EXPECT_EQ(HarmonicNotchFilterTest::num_filters(f), HAL_HNF_MAX_FILTERS)
+            << "allocate_filters must reserve HAL_HNF_MAX_FILTERS when harmonics != 0";
+        EXPECT_FALSE(HarmonicNotchFilterTest::alloc_failed(f));
+    }
+    // harmonics=0 (filter disabled): must NOT allocate
+    {
+        HarmonicNotchFilter<float> f {};
+        f.allocate_filters(1, 0, 1);
+        EXPECT_EQ(HarmonicNotchFilterTest::num_filters(f), 0u)
+            << "allocate_filters must not allocate when harmonics == 0";
+        EXPECT_FALSE(HarmonicNotchFilterTest::alloc_failed(f));
+    }
+}
+
+/*
+  expand_filter_count() with a count <= _num_filters must be a pure no-op:
+  no allocation, no flag set.
+
+  WITHOUT THE FIX: expand_filter_count(HAL_HNF_MAX_FILTERS) finds
+  total_notches > _num_filters (1) and calls NEW_NOTHROW to grow the
+  bank — heap allocation on the RT path.
+ */
+TEST(NotchFilterTest, ExpandFilterCountIsNoop)
+{
+    HarmonicNotchFilter<float> f {};
+    f.allocate_filters(1, 1, 1);
+
+    f.expand_filter_count(HAL_HNF_MAX_FILTERS);
+    EXPECT_FALSE(HarmonicNotchFilterTest::alloc_failed(f))
+        << "expand_filter_count must not fail when capacity is sufficient";
+    EXPECT_EQ(HarmonicNotchFilterTest::num_filters(f), HAL_HNF_MAX_FILTERS);
+}
+
+/*
+  Calling expand_filter_count() with a value beyond HAL_HNF_MAX_FILTERS
+  must set _alloc_has_failed (the only safe fallback: cap at max capacity).
+ */
+TEST(NotchFilterTest, ExpandFilterCountOverflowSetsAllocFailed)
+{
+    HarmonicNotchFilter<float> f {};
+    f.allocate_filters(1, 1, 1);
+    ASSERT_FALSE(HarmonicNotchFilterTest::alloc_failed(f));
+
+    f.expand_filter_count(HAL_HNF_MAX_FILTERS + 1);
+    EXPECT_TRUE(HarmonicNotchFilterTest::alloc_failed(f))
+        << "expand_filter_count beyond capacity must set _alloc_has_failed";
+}
+
+/*
+  After update() with N centers, _num_enabled_filters must equal
+  N × num_harmonics × composite_notches.
+
+  This is the field log_notch_centers() must read to know how many
+  active sources to log.  Using _num_filters (= HAL_HNF_MAX_FILTERS
+  after the pre-alloc fix) would cause it to log garbage for uninitialized
+  filter slots.
+
+  WITHOUT THE FIX: update(4, centers) triggers expand_filter_count(4)
+  which heap-allocates a new bank — RT allocation on the hot path.
+ */
+TEST(NotchFilterTest, EnabledFiltersAfterUpdate)
+{
+    HarmonicNotchFilter<float> f {};
+    HarmonicNotchFilterParams params {};
+    params.set_center_freq_hz(50);
+    params.set_bandwidth_hz(20);
+    params.set_attenuation(40);
+    params.set_freq_min_ratio(1.0);
+
+    f.allocate_filters(4, 1, 1);
+    f.init(2000.0f, params);
+
+    const float centers[4] = { 50.0f, 60.0f, 70.0f, 80.0f };
+    f.update(4, centers);
+
+    EXPECT_EQ(HarmonicNotchFilterTest::num_enabled_filters(f), 4u)
+        << "4 centers × 1 harmonic × 1 composite = 4 enabled filters";
+    // capacity must still be the full pre-allocated max
+    EXPECT_EQ(HarmonicNotchFilterTest::num_filters(f), HAL_HNF_MAX_FILTERS);
+}
+
+/*
+  update() with more centers than the initial allocation must not crash
+  and must not heap-allocate (expand_filter_count must be a true no-op).
+ */
+TEST(NotchFilterTest, UpdateWithManyCentersNoAlloc)
+{
+    const uint8_t num_centers = 4;
+    float centers[num_centers] { 50, 60, 70, 80 };
+
+    HarmonicNotchFilter<float> f {};
+    HarmonicNotchFilterParams params {};
+    params.set_center_freq_hz(50);
+    params.set_bandwidth_hz(10);
+    params.set_attenuation(40);
+    params.set_freq_min_ratio(1.0);
+
+    f.allocate_filters(1, 1, params.num_composite_notches());
+    f.init(2000, params);
+    f.update(num_centers, centers);
+
+    EXPECT_FALSE(HarmonicNotchFilterTest::alloc_failed(f));
+    const float out = f.apply(1.0f);
+    EXPECT_TRUE(std::isfinite(out));
+}
+
 AP_GTEST_MAIN()


### PR DESCRIPTION
### Problem

`HarmonicNotchFilter::allocate_filters()` allocated only the minimum number of filter slots needed at construction time:

```cpp
_num_filters = num_notches * num_harmonics * composite_notches;
```

In dynamic-harmonic mode (ESC telemetry, FFT, RPM) the number of active frequency sources can grow at runtime as motors are detected. Each time `update()` was called with more sources than originally allocated, `expand_filter_count()` fired and called:

```cpp
NEW_NOTHROW NotchFilter<T>[total_notches]
memcpy(...)
delete[] old_filters
```

on the gyro-sample hot path — every IMU update. On a memory-pressured target (H7 with logging active, DroneCAN, etc.) the allocation can fail silently, leaving `_alloc_has_failed` set and the filter running with fewer notches than configured.

A second bug: `log_notch_centers()` used `_num_filters / filters_per_source` to count how many frequency sources to log. After this fix `_num_filters` is permanently `HAL_HNF_MAX_FILTERS`, so that expression would produce up to 54 "sources" and log garbage center frequencies for all uninitialized filter slots.

### Fix

`allocate_filters()` now always reserves `HAL_HNF_MAX_FILTERS` (24 on F4, 54 on H7) upfront, regardless of the initial source count. This is the maximum `update()` will ever use (it already clamps to `HAL_HNF_MAX_FILTERS` internally). `expand_filter_count()` becomes a true no-op for all valid inputs.

`log_notch_centers()` is fixed to use `_num_enabled_filters` (updated each `update()` call) instead of `_num_filters`.

Memory cost: one allocation of `HAL_HNF_MAX_FILTERS * sizeof(NotchFilter<T>)` per instance at startup. With up to 9 instances on H7 the total overhead is ~35 KB which is within normal H7 SRAM budgets.

### Testing

Commit 1 adds regression tests to `test_notchfilter.cpp`. They **FAIL** on the unfixed code, proving the bugs:

```
waf configure --board=sitl && waf tests
build/sitl/tests/test_notchfilter \
    --gtest_filter="*PreAlloc*:*EnabledFilters*:*Overflow*"
```

Expected output before fix:
```
FAILED: PreAllocMaxCapacity        (_num_filters == 1, not 54)
FAILED: EnabledFiltersAfterUpdate  (_num_filters == 4, not 54)
FAILED: ExpandFilterCountOverflow  (_alloc_has_failed stays false)
```

All 5 new tests pass after commit 2.