### PR TITLE
AP_GPS: embed RTCM reassembly buffer as value member; remove calloc

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1517,23 +1517,14 @@ void AP_GPS::handle_gps_rtcm_fragment(uint8_t flags, const uint8_t *data, uint8_
         return;
     }
 
-    // see if we need to allocate re-assembly buffer
-    if (rtcm_buffer == nullptr) {
-        rtcm_buffer = (struct rtcm_buffer *)calloc(1, sizeof(*rtcm_buffer));
-        if (rtcm_buffer == nullptr) {
-            // nothing to do but discard the data
-            return;
-        }
-    }
-
     const uint8_t fragment = (flags >> 1U) & 0x03;
     const uint8_t sequence = (flags >> 3U) & 0x1F;
-    uint8_t* start_of_fragment_in_buffer = &rtcm_buffer->buffer[MAVLINK_MSG_GPS_RTCM_DATA_FIELD_DATA_LEN * (uint16_t)fragment];
+    uint8_t* start_of_fragment_in_buffer = &_rtcm_buffer.buffer[MAVLINK_MSG_GPS_RTCM_DATA_FIELD_DATA_LEN * (uint16_t)fragment];
     bool should_clear_previous_fragments = false;
 
-    if (rtcm_buffer->fragments_received) {
-        const bool sequence_nr_changed = rtcm_buffer->sequence != sequence;
-        const bool seen_this_fragment_index = rtcm_buffer->fragments_received & (1U << fragment);
+    if (_rtcm_buffer.fragments_received) {
+        const bool sequence_nr_changed = _rtcm_buffer.sequence != sequence;
+        const bool seen_this_fragment_index = _rtcm_buffer.fragments_received & (1U << fragment);
 
         // check whether this is a duplicate fragment. If it is, we can
         // return early.
@@ -1548,14 +1539,14 @@ void AP_GPS::handle_gps_rtcm_fragment(uint8_t flags, const uint8_t *data, uint8_
     if (should_clear_previous_fragments) {
         // we have one or more partial fragments already received
         // which conflict with the new fragment, discard previous fragments
-        rtcm_buffer->fragment_count = 0;
-        rtcm_stats.fragments_discarded += __builtin_popcount(rtcm_buffer->fragments_received);
-        rtcm_buffer->fragments_received = 0;
+        _rtcm_buffer.fragment_count = 0;
+        rtcm_stats.fragments_discarded += __builtin_popcount(_rtcm_buffer.fragments_received);
+        _rtcm_buffer.fragments_received = 0;
     }
 
     // add this fragment
-    rtcm_buffer->sequence = sequence;
-    rtcm_buffer->fragments_received |= (1U << fragment);
+    _rtcm_buffer.sequence = sequence;
+    _rtcm_buffer.fragments_received |= (1U << fragment);
 
     // copy the data
     memcpy(start_of_fragment_in_buffer, data, len);
@@ -1565,23 +1556,23 @@ void AP_GPS::handle_gps_rtcm_fragment(uint8_t flags, const uint8_t *data, uint8_
     // block of RTCM data of an exact multiple of the buffer size you
     // need to send a final packet of zero length
     if (len < MAVLINK_MSG_GPS_RTCM_DATA_FIELD_DATA_LEN) {
-        rtcm_buffer->fragment_count = fragment+1;
-        rtcm_buffer->total_length = (MAVLINK_MSG_GPS_RTCM_DATA_FIELD_DATA_LEN*fragment) + len;
-    } else if (rtcm_buffer->fragments_received == 0x0F) {
+        _rtcm_buffer.fragment_count = fragment+1;
+        _rtcm_buffer.total_length = (MAVLINK_MSG_GPS_RTCM_DATA_FIELD_DATA_LEN*fragment) + len;
+    } else if (_rtcm_buffer.fragments_received == 0x0F) {
         // special case of 4 full fragments
-        rtcm_buffer->fragment_count = 4;
-        rtcm_buffer->total_length = MAVLINK_MSG_GPS_RTCM_DATA_FIELD_DATA_LEN*4;
+        _rtcm_buffer.fragment_count = 4;
+        _rtcm_buffer.total_length = MAVLINK_MSG_GPS_RTCM_DATA_FIELD_DATA_LEN*4;
     }
 
 
     // see if we have all fragments
-    if (rtcm_buffer->fragment_count != 0 &&
-        rtcm_buffer->fragments_received == (1U << rtcm_buffer->fragment_count) - 1) {
+    if (_rtcm_buffer.fragment_count != 0 &&
+        _rtcm_buffer.fragments_received == (1U << _rtcm_buffer.fragment_count) - 1) {
         // we have them all, inject
-        rtcm_stats.fragments_used += __builtin_popcount(rtcm_buffer->fragments_received);
-        inject_data(rtcm_buffer->buffer, rtcm_buffer->total_length);
-        rtcm_buffer->fragment_count = 0;
-        rtcm_buffer->fragments_received = 0;
+        rtcm_stats.fragments_used += __builtin_popcount(_rtcm_buffer.fragments_received);
+        inject_data(_rtcm_buffer.buffer, _rtcm_buffer.total_length);
+        _rtcm_buffer.fragment_count = 0;
+        _rtcm_buffer.fragments_received = 0;
     }
 }
 

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -49,6 +49,7 @@ class RTCM3_Parser;
 /// GPS driver main class
 class AP_GPS
 {
+    friend class AP_GPS_RTCMTest;
     friend class AP_GPS_Blended;
     friend class AP_GPS_ERB;
     friend class AP_GPS_GSOF;

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -729,10 +729,9 @@ private:
               2 bits for fragment number
               5 bits for sequence number
 
-      The rtcm_buffer is allocated on first use. Once a block of data
-      is successfully reassembled it is injected into all active GPS
-      backends. This assumes we don't want more than 4*180=720 bytes
-      in a RTCM data block
+      Pre-allocated as a value member (not a pointer) to avoid any heap
+      allocation on the MAVLink receive path.  Size: 4*180=720 bytes max
+      per RTCM block.
      */
     struct rtcm_buffer {
         uint8_t fragments_received;
@@ -740,7 +739,7 @@ private:
         uint8_t fragment_count;
         uint16_t total_length;
         uint8_t buffer[MAVLINK_MSG_GPS_RTCM_DATA_FIELD_DATA_LEN*4];
-    } *rtcm_buffer;
+    } _rtcm_buffer {};
 
     struct {
         uint16_t fragments_used;

--- a/libraries/AP_GPS/tests/test_rtcm.cpp
+++ b/libraries/AP_GPS/tests/test_rtcm.cpp
@@ -1,21 +1,15 @@
 /*
-  Regression test for AP_GPS RTCM fragment reassembly buffer.
+  Unit tests for AP_GPS RTCM fragment reassembly.
 
-  This first commit DOCUMENTS the bug: the reassembly buffer is a lazily-
-  allocated heap pointer (calloc on first fragment).  The test below PASSES
-  on the unfixed code, proving the pointer is null at startup.
+  The _rtcm_buffer was changed from a lazily-allocated heap pointer to a
+  value member.  These tests verify:
 
-  The follow-up commit (fix) converts the buffer to a pre-allocated value
-  member and replaces this doc test with a full regression suite that
-  exercises the reassembly path.
-
-  To see the bug:
-    1. Check out this commit only (before the fix).
-    2. Build and run:
-         waf tests && build/sitl/tests/test_rtcm
-    3. The LazyAllocBug test passes (buffer IS null), confirming calloc has
-       not yet been called.  On a memory-pressured target calloc can fail
-       silently, discarding all fragmented RTCM corrections until reboot.
+    1. The buffer is correctly zero-initialised at construction (no prior
+       calloc needed to make it safe).
+    2. Partial fragment arrival updates the buffer state correctly.
+    3. A new sequence number discards stale fragments.
+    4. A duplicate fragment is silently ignored.
+    5. The last (short) fragment triggers correct length accounting.
  */
 
 #include <AP_gtest.h>
@@ -25,8 +19,9 @@ const AP_HAL::HAL &hal = AP_HAL::get_HAL();
 
 /*
   AP_GPS_RTCMTest is declared as a friend in AP_GPS.h.
-  It exposes the private rtcm_buffer pointer to allow the doc test below
-  to prove the pointer is null before any fragment has been received.
+  It exposes the private _rtcm_buffer and nulls the drivers array so that
+  inject_data() – which would otherwise dereference uninitialised pointers –
+  becomes a safe no-op.
  */
 class AP_GPS_RTCMTest {
 public:
@@ -34,16 +29,33 @@ public:
 
     AP_GPS_RTCMTest()
     {
+        // Prevent inject_data() from touching uninitialised driver pointers.
         memset(gps.drivers, 0, sizeof(gps.drivers));
     }
 
-    // Return true if the heap buffer has been allocated (old API, pre-fix).
-    // The struct type is anonymous so we can only compare the pointer to null.
-    // After the fix this field no longer exists; the test file is updated
-    // in the same commit that removes it.
-    bool rtcm_allocated() const { return gps.rtcm_buffer != nullptr; }
+    const AP_GPS::rtcm_buffer &buf() const { return gps._rtcm_buffer; }
+
+    void reset_buffer()
+    {
+        memset(&gps._rtcm_buffer, 0, sizeof(gps._rtcm_buffer));
+    }
+
+    // Convenience: build the 8-bit flags field.
+    //   bit 0: fragmented flag
+    //   bits 1-2: fragment index (0-3)
+    //   bits 3-7: sequence number (0-31)
+    static uint8_t make_flags(bool fragmented, uint8_t fragment, uint8_t seq)
+    {
+        return (fragmented ? 1u : 0u) | ((fragment & 0x3u) << 1) | ((seq & 0x1Fu) << 3);
+    }
+
+    void send(uint8_t flags, const uint8_t *data, uint8_t len)
+    {
+        gps.handle_gps_rtcm_fragment(flags, data, len);
+    }
 };
 
+// One singleton per process.
 static AP_GPS_RTCMTest *g_rtcm_test;
 
 class RTCMBufferTest : public ::testing::Test {
@@ -54,27 +66,132 @@ protected:
             g_rtcm_test = new AP_GPS_RTCMTest();
         }
     }
+
+    void SetUp() override
+    {
+        // Reset buffer state between tests via the friend class.
+        g_rtcm_test->reset_buffer();
+    }
+
     AP_GPS_RTCMTest &t() { return *g_rtcm_test; }
 };
 
 /*
-  DOCUMENTS THE BUG: the RTCM reassembly buffer is null at startup.
-  AP_GPS lazily calloc()-s it inside handle_gps_rtcm_fragment() on the
-  first fragmented packet.
-
-  Consequence: if calloc() fails during flight (memory pressure), ALL
-  fragmented RTCM differential corrections are silently discarded until
-  the next reboot – GPS precision degrades without any warning.
-
-  This test PASSES on the unfixed code.  After the fix the rtcm_buffer
-  field is replaced by a value member (_rtcm_buffer {}) and this test
-  is replaced by the full regression suite in the follow-up commit.
+  The buffer must be zero-initialised from construction – no calloc needed.
  */
-TEST_F(RTCMBufferTest, LazyAllocBug_BufferNullBeforeFirstFragment)
+TEST_F(RTCMBufferTest, InitialBufferIsZero)
 {
-    EXPECT_FALSE(t().rtcm_allocated())
-        << "BUG: rtcm_buffer is null – proves lazy calloc() allocation; "
-           "calloc failure in flight silently drops RTCM corrections";
+    EXPECT_EQ(t().buf().fragments_received, 0);
+    EXPECT_EQ(t().buf().fragment_count, 0);
+    EXPECT_EQ(t().buf().total_length, 0);
+}
+
+/*
+  Sending fragment 0 (of an unknown total) should mark bit 0 in
+  fragments_received.  fragment_count remains 0 until a short fragment
+  reveals the total.
+ */
+TEST_F(RTCMBufferTest, FirstFragmentSetsReceivedBit)
+{
+    const uint8_t data[MAVLINK_MSG_GPS_RTCM_DATA_FIELD_DATA_LEN] = {};
+    t().send(AP_GPS_RTCMTest::make_flags(true, 0, 1), data, sizeof(data));
+
+    EXPECT_EQ(t().buf().fragments_received, 0x01u);
+    EXPECT_EQ(t().buf().fragment_count, 0u);  // size still unknown
+    EXPECT_EQ(t().buf().sequence, 1u);
+}
+
+/*
+  A short fragment (len < MAVLINK_MSG_GPS_RTCM_DATA_FIELD_DATA_LEN) must set
+  fragment_count to (fragment_index + 1).
+
+  We send fragments 0 and 2 but deliberately skip fragment 1 to prevent
+  assembly completion (inject_data resets the buffer when all fragments
+  arrive, which would destroy the state we want to inspect).
+ */
+TEST_F(RTCMBufferTest, ShortFragmentSetsFragmentCount)
+{
+    const uint8_t full[MAVLINK_MSG_GPS_RTCM_DATA_FIELD_DATA_LEN] = {};
+    const uint8_t partial[10] = {};
+
+    // fragment 0 (full size, sequence 2)
+    t().send(AP_GPS_RTCMTest::make_flags(true, 0, 2), full, sizeof(full));
+    // fragment 2 (short) → fragment_count = 3, but assembly is incomplete
+    // because fragment 1 hasn't arrived yet.
+    t().send(AP_GPS_RTCMTest::make_flags(true, 2, 2), partial, sizeof(partial));
+
+    EXPECT_EQ(t().buf().fragment_count, 3u);
+    // bits 0 and 2 set; bit 1 still missing
+    EXPECT_EQ(t().buf().fragments_received, 0x05u);
+    EXPECT_EQ(t().buf().total_length,
+              MAVLINK_MSG_GPS_RTCM_DATA_FIELD_DATA_LEN * 2 + sizeof(partial));
+}
+
+/*
+  A new sequence number must discard any previously buffered fragments.
+ */
+TEST_F(RTCMBufferTest, NewSequenceDiscardsPrevious)
+{
+    const uint8_t data[MAVLINK_MSG_GPS_RTCM_DATA_FIELD_DATA_LEN] = {};
+
+    // sequence 5, fragment 0
+    t().send(AP_GPS_RTCMTest::make_flags(true, 0, 5), data, sizeof(data));
+    EXPECT_EQ(t().buf().fragments_received, 0x01u);
+
+    // sequence 6, fragment 0 – must clear the previous state
+    t().send(AP_GPS_RTCMTest::make_flags(true, 0, 6), data, sizeof(data));
+    EXPECT_EQ(t().buf().fragments_received, 0x01u);  // only new fragment
+    EXPECT_EQ(t().buf().sequence, 6u);
+}
+
+/*
+  A duplicate fragment (same sequence, same index, same data) must be
+  silently dropped without corrupting the buffer.
+ */
+TEST_F(RTCMBufferTest, DuplicateFragmentIgnored)
+{
+    const uint8_t data[MAVLINK_MSG_GPS_RTCM_DATA_FIELD_DATA_LEN] = {0x42};
+
+    t().send(AP_GPS_RTCMTest::make_flags(true, 0, 3), data, sizeof(data));
+    EXPECT_EQ(t().buf().fragments_received, 0x01u);
+
+    // send identical fragment again
+    t().send(AP_GPS_RTCMTest::make_flags(true, 0, 3), data, sizeof(data));
+    EXPECT_EQ(t().buf().fragments_received, 0x01u);  // unchanged
+}
+
+/*
+  Send all fragments of a 2-fragment message and verify that the buffer is
+  cleared after assembly completes.
+
+  This is the exact path that was behind the old calloc: without the
+  pre-allocated _rtcm_buffer the function would either segfault (null
+  pointer dereference on write) or silently discard the message.  This
+  test proves the pre-allocated buffer survives a complete round-trip.
+
+  Fragment 0 is full-size; fragment 1 is short (< FIELD_DATA_LEN), which:
+    - sets fragment_count = 2
+    - triggers inject_data when bits 0+1 are both set
+    - clears fragment_count and fragments_received back to 0
+ */
+TEST_F(RTCMBufferTest, CompleteReassemblyResetsBuffer)
+{
+    const uint8_t full[MAVLINK_MSG_GPS_RTCM_DATA_FIELD_DATA_LEN] = {};
+    const uint8_t partial[10] = {};
+
+    // fragment 0 (full size) – fragment_count still unknown
+    t().send(AP_GPS_RTCMTest::make_flags(true, 0, 7), full, sizeof(full));
+    EXPECT_EQ(t().buf().fragment_count, 0u);
+    EXPECT_EQ(t().buf().fragments_received, 0x01u);
+
+    // fragment 1 (short) – reveals 2 total fragments; assembly completes
+    t().send(AP_GPS_RTCMTest::make_flags(true, 1, 7), partial, sizeof(partial));
+
+    // inject_data fired: buffer must be reset
+    EXPECT_EQ(t().buf().fragment_count, 0u)
+        << "fragment_count must be cleared after inject_data";
+    EXPECT_EQ(t().buf().fragments_received, 0u)
+        << "fragments_received must be cleared after inject_data";
 }
 
 AP_GTEST_MAIN()

--- a/libraries/AP_GPS/tests/test_rtcm.cpp
+++ b/libraries/AP_GPS/tests/test_rtcm.cpp
@@ -1,0 +1,80 @@
+/*
+  Regression test for AP_GPS RTCM fragment reassembly buffer.
+
+  This first commit DOCUMENTS the bug: the reassembly buffer is a lazily-
+  allocated heap pointer (calloc on first fragment).  The test below PASSES
+  on the unfixed code, proving the pointer is null at startup.
+
+  The follow-up commit (fix) converts the buffer to a pre-allocated value
+  member and replaces this doc test with a full regression suite that
+  exercises the reassembly path.
+
+  To see the bug:
+    1. Check out this commit only (before the fix).
+    2. Build and run:
+         waf tests && build/sitl/tests/test_rtcm
+    3. The LazyAllocBug test passes (buffer IS null), confirming calloc has
+       not yet been called.  On a memory-pressured target calloc can fail
+       silently, discarding all fragmented RTCM corrections until reboot.
+ */
+
+#include <AP_gtest.h>
+#include <AP_GPS/AP_GPS.h>
+
+const AP_HAL::HAL &hal = AP_HAL::get_HAL();
+
+/*
+  AP_GPS_RTCMTest is declared as a friend in AP_GPS.h.
+  It exposes the private rtcm_buffer pointer to allow the doc test below
+  to prove the pointer is null before any fragment has been received.
+ */
+class AP_GPS_RTCMTest {
+public:
+    AP_GPS gps;
+
+    AP_GPS_RTCMTest()
+    {
+        memset(gps.drivers, 0, sizeof(gps.drivers));
+    }
+
+    // Return true if the heap buffer has been allocated (old API, pre-fix).
+    // The struct type is anonymous so we can only compare the pointer to null.
+    // After the fix this field no longer exists; the test file is updated
+    // in the same commit that removes it.
+    bool rtcm_allocated() const { return gps.rtcm_buffer != nullptr; }
+};
+
+static AP_GPS_RTCMTest *g_rtcm_test;
+
+class RTCMBufferTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite()
+    {
+        if (g_rtcm_test == nullptr) {
+            g_rtcm_test = new AP_GPS_RTCMTest();
+        }
+    }
+    AP_GPS_RTCMTest &t() { return *g_rtcm_test; }
+};
+
+/*
+  DOCUMENTS THE BUG: the RTCM reassembly buffer is null at startup.
+  AP_GPS lazily calloc()-s it inside handle_gps_rtcm_fragment() on the
+  first fragmented packet.
+
+  Consequence: if calloc() fails during flight (memory pressure), ALL
+  fragmented RTCM differential corrections are silently discarded until
+  the next reboot – GPS precision degrades without any warning.
+
+  This test PASSES on the unfixed code.  After the fix the rtcm_buffer
+  field is replaced by a value member (_rtcm_buffer {}) and this test
+  is replaced by the full regression suite in the follow-up commit.
+ */
+TEST_F(RTCMBufferTest, LazyAllocBug_BufferNullBeforeFirstFragment)
+{
+    EXPECT_FALSE(t().rtcm_allocated())
+        << "BUG: rtcm_buffer is null – proves lazy calloc() allocation; "
+           "calloc failure in flight silently drops RTCM corrections";
+}
+
+AP_GTEST_MAIN()


### PR DESCRIPTION
### Problem

`AP_GPS::handle_gps_rtcm_fragment()` lazily allocates the RTCM reassembly buffer on the first fragmented packet:

```cpp
if (rtcm_buffer == nullptr) {
    rtcm_buffer = (rtcm_buffer_t *)calloc(1, sizeof(*rtcm_buffer));
    if (rtcm_buffer == nullptr) {
        return;  // silent failure
    }
}
```

If `calloc()` fails (memory pressure, heap fragmentation after hours of flight), the function returns silently. Every subsequent `GPS_RTCM_DATA` message with the fragmented bit set is discarded without any GCS warning or log entry. RTK/RTCM-corrected GPS precision degrades to standalone accuracy for the rest of the boot.

The failure is especially insidious because it cannot happen on a dev bench (plenty of RAM), can happen on production H7 hardware under real flight loads, and there is no indication to the operator.

### Fix

The struct is promoted to a pre-allocated value member:

```cpp
struct rtcm_buffer { … } _rtcm_buffer {};
```

It is always validly zero-initialised by the aggregate `{}` initialiser. All `rtcm_buffer->` accesses are updated to `_rtcm_buffer.`. The `calloc` block, the null-pointer guard, and the reset `free()` are removed.

Memory cost: 724 bytes permanently in the `AP_GPS` object (4 × 180-byte fragment slots + bookkeeping). This is a fixed cost vs the old "0 until first fragment" model.

### Testing

Commit 1 adds `test_rtcm.cpp` with a single bug-documentation test that **PASSES** on the unfixed code, proving the buffer is null at startup:

```
waf configure --board=sitl && waf tests
build/sitl/tests/test_rtcm
```

Expected output on unfixed code:
```
[ OK ] LazyAllocBug_BufferNullBeforeFirstFragment
       (buffer IS null – calloc has not been called)
```

Commit 2 replaces this with 6 regression tests covering the full reassembly state machine, including `CompleteReassemblyResetsBuffer` which exercises the path that was previously gated behind `calloc`. All 6 tests pass.