### PR TITLE
ArduCopter: fix rate thread logic bugs

### DIFF
--- a/ArduCopter/rate_thread.cpp
+++ b/ArduCopter/rate_thread.cpp
@@ -454,11 +454,17 @@ void Copter::enable_fast_rate_loop(uint8_t rate_decimation, RateControllerRates&
 // disable the fast rate thread and record the new output rates
 void Copter::disable_fast_rate_loop(RateControllerRates& rates)
 {
-    using_rate_thread = false;
+    // Perform all teardown BEFORE clearing using_rate_thread.
+    // The main thread checks using_rate_thread in motors_output_main() and
+    // run_rate_controller_main(); if we clear the flag first, the main thread
+    // resumes motor output while rcout is still at the fast DShot rate and
+    // the fast buffer is still active, producing incorrect motor output.
+    // Mirror enable_fast_rate_loop which correctly does setup-before-set.
     uint8_t rate_decimation = calc_gyro_decimation(1, AP::scheduler().get_filtered_loop_rate_hz());
     rate_controller_set_rates(rate_decimation, rates, false);
     hal.rcout->force_trigger_groups(false);
     ins.disable_fast_rate_buffer();
+    using_rate_thread = false;
 }
 
 /*

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -7745,6 +7745,113 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 "Notch-per-motor peak was higher than single-notch peak %fdB > %fdB" %
                 (esc_peakdb2, esc_peakdb1))
 
+    def RateThreadFixedDivParamRefresh(self):
+        """FSTRATE_DIV changes must take effect in FAST_RATE_FIXED mode.
+
+        Regression guard: target_rate_decimation must be refreshed from the
+        parameter at 100 ms cadence regardless of the current FastRateType.
+        If the refresh is placed inside the FastRateType guard (which is always
+        false for FIXED mode when at target), runtime FSTRATE_DIV changes are
+        silently ignored.
+
+        Observable: changing FSTRATE_DIV while FSTRATE_ENABLE=3 must produce
+        a "Rate CPU … rate set to Nhz" GCS notification within ~200 ms.
+        """
+        self.progress("RateThread PR1: FSTRATE_DIV param refresh in FIXED mode")
+        self.context_push()
+        self.set_parameters({
+            "AHRS_EKF_TYPE": 10,
+            "FSTRATE_ENABLE": 3,    # FAST_RATE_FIXED: always honour FSTRATE_DIV
+            "FSTRATE_DIV": 1,
+        })
+        self.reboot_sitl()
+        self.takeoff(10, mode="ALT_HOLD")
+
+        try:
+            self.wait_statustext("Rate CPU", timeout=5)
+        except AutoTestTimeoutException:
+            self.progress("FSTRATE not supported in this build – skipping")
+            self.do_RTL()
+            self.context_pop()
+            self.reboot_sitl()
+            return
+
+        self.context_collect("STATUSTEXT")
+        self.set_parameter("FSTRATE_DIV", 2)
+
+        try:
+            self.wait_statustext("Rate CPU", timeout=2, check_context=True)
+        except AutoTestTimeoutException:
+            raise NotAchievedException(
+                "No rate-change GCS notification after FSTRATE_DIV change "
+                "(target_rate_decimation refresh may be inside FastRateType guard)"
+            )
+
+        self.do_RTL()
+        self.context_pop()
+        self.reboot_sitl()
+
+    def RateThreadEnableDisableCycle(self):
+        """Rate thread enable/disable cycle must not corrupt rcout state.
+
+        Regression guard: disable_fast_rate_loop() must complete all teardown
+        (rate_controller_set_rates, force_trigger_groups(false),
+        disable_fast_rate_buffer) before clearing using_rate_thread.  If
+        using_rate_thread is cleared first, the main thread resumes motor output
+        while rcout is still at the fast DShot rate.
+
+        Observable: performing an enable→disable→re-enable cycle while hovering
+        must not cause the vehicle to crash or lose significant altitude.
+        """
+        self.progress("RateThread PR1: enable/disable cycle ordering")
+        self.context_push()
+        self.set_parameters({
+            "AHRS_EKF_TYPE": 10,
+            "FSTRATE_ENABLE": 1,
+        })
+        self.reboot_sitl()
+        self.takeoff(10, mode="ALT_HOLD")
+
+        try:
+            self.wait_statustext("Rate CPU", timeout=5)
+        except AutoTestTimeoutException:
+            self.progress("FSTRATE not supported in this build – skipping")
+            self.do_RTL()
+            self.context_pop()
+            self.reboot_sitl()
+            return
+
+        # disable
+        self.set_parameter("FSTRATE_ENABLE", 0)
+        self.delay_sim_time(2)
+        m = self.mav.recv_match(type="GLOBAL_POSITION_INT", blocking=True, timeout=5)
+        if m is None:
+            raise NotAchievedException("Lost telemetry after rate thread disable")
+        if m.relative_alt / 1000.0 < 3.0:
+            raise NotAchievedException(
+                "Altitude dropped after rate thread disable: %.1f m" % (m.relative_alt / 1000.0)
+            )
+
+        # re-enable
+        self.set_parameter("FSTRATE_ENABLE", 1)
+        try:
+            self.wait_statustext("Rate CPU", timeout=5)
+        except AutoTestTimeoutException:
+            raise NotAchievedException("Rate thread did not restart after re-enable")
+
+        self.delay_sim_time(2)
+        m = self.mav.recv_match(type="GLOBAL_POSITION_INT", blocking=True, timeout=5)
+        if m is None:
+            raise NotAchievedException("Lost telemetry after rate thread re-enable")
+        if m.relative_alt / 1000.0 < 3.0:
+            raise NotAchievedException(
+                "Altitude dropped after rate thread re-enable: %.1f m" % (m.relative_alt / 1000.0)
+            )
+
+        self.do_RTL()
+        self.context_pop()
+        self.reboot_sitl()
+
     def DynamicRpmNotchesRateThread(self):
         """Use dynamic harmonic notch to control motor noise via ESC telemetry."""
         self.progress("Flying with ESC telemetry driven dynamic notches")
@@ -16524,6 +16631,8 @@ return update, 1000
             self.PositionWhenGPSIsZero,
             self.DynamicRpmNotches, # Do not add attempts to this - failure is sign of a bug
             self.DynamicRpmNotchesRateThread,
+            self.RateThreadFixedDivParamRefresh,
+            self.RateThreadEnableDisableCycle,
             self.PIDNotches,
             self.mission_NAV_LOITER_TURNS,
             self.mission_NAV_LOITER_TURNS_off_center,

--- a/libraries/AP_InertialSensor/FastRateBuffer.cpp
+++ b/libraries/AP_InertialSensor/FastRateBuffer.cpp
@@ -118,6 +118,11 @@ bool FastRateBuffer::get_next_gyro_sample(Vector3f& gyro)
 void FastRateBuffer::reset()
 {
     _rate_loop_gyro_window.clear();
+    // Reset the push counter so the first sample after re-enable is not
+    // pushed at a stale offset within the decimation cycle.  Without this,
+    // a re-enable after disable_fast_rate_buffer() inherits a non-zero count
+    // and may push (or skip) the first sample at the wrong position.
+    rate_decimation_count = 0;
 }
 
 bool AP_InertialSensor::push_next_gyro_sample(const Vector3f& gyro)


### PR DESCRIPTION
## Summary

Two logic bugs in the ArduCopter fast rate thread that cause incorrect behaviour
even without concurrency:

**1. `FastRateBuffer::reset()` — stale decimation phase after re-enable**

`disable_fast_rate_buffer()` called `reset()` but `reset()` did not zero
`rate_decimation_count`. When the rate thread was re-enabled, the push counter
picked up mid-cycle, producing a one-cycle phase offset in the decimation
pattern. Gyro samples were dropped or duplicated on the first decimation window
after every enable/disable cycle.

Fix: zero `rate_decimation_count` in `reset()`.

**2. `disable_fast_rate_loop()` — flag cleared before teardown**

`using_rate_thread = false` was set *before* `disable_fast_rate_buffer()` and
`force_trigger_groups(false)`. Any code on the main thread that checked
`using_rate_thread` could observe `false` while rcout was still running at the
fast DShot rate and the fast buffer was still active.

Fix: move `using_rate_thread = false` to the last line of
`disable_fast_rate_loop()`, after all teardown is complete. This mirrors the
correct ordering in `enable_fast_rate_loop()` where setup precedes the flag set.

## Test plan

- [ ] SITL: `RateThreadEnableDisableCycle` — enables rate thread, takes off,
  disables (FSTRATE_ENABLE=0), checks altitude held >3 m, re-enables, verifies
  no rcout glitch
- [ ] SITL: `RateThreadFixedDivParamRefresh` — sets FSTRATE_ENABLE=3 / FSTRATE_DIV=1,
  confirms rate thread active, changes FSTRATE_DIV=2, expects "Rate CPU" status
  text within 2 s confirming the new decimation is applied

## Notes

This is PR 1/3 in a stacked series:
- **PR 1 (this)**: logic bugs — no concurrency changes
- PR 2: data races — `std::atomic` for cross-thread state
- PR 3: RT determinism — lockfree GCS path, WCET measurement