### PR TITLE
ArduCopter: fix data races in rate thread cross-thread state

### DIFF
--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -14,7 +14,7 @@ void Copter::run_rate_controller_main()
     pos_control->set_dt_s(last_loop_time_s);
     attitude_control->set_dt_s(last_loop_time_s);
 
-    if (!using_rate_thread) {
+    if (!rate_thread_active()) {
         motors->set_dt_s(last_loop_time_s);
         // only run the rate controller if we are not using the rate thread
         attitude_control->rate_controller_run();

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -638,13 +638,13 @@ void Copter::loop_rate_logging()
 {
    if (should_log(MASK_LOG_ATTITUDE_FAST) && !copter.flightmode->logs_attitude()) {
         Log_Write_Attitude();
-        if (!using_rate_thread) {
+        if (!rate_thread_active()) {
             Log_Write_Rate();
             Log_Write_PIDS(); // only logs if PIDS bitmask is set
         }
     }
 #if AP_INERTIALSENSOR_HARMONICNOTCH_ENABLED
-    if (should_log(MASK_LOG_FTN_FAST) && !using_rate_thread) {
+    if (should_log(MASK_LOG_FTN_FAST) && !rate_thread_active()) {
         AP::ins().write_notch_log_messages();
     }
 #endif
@@ -664,13 +664,13 @@ void Copter::ten_hz_logging_loop()
     // log attitude controller data if we're not already logging at the higher rate
     if (should_log(MASK_LOG_ATTITUDE_MED) && !should_log(MASK_LOG_ATTITUDE_FAST) && !copter.flightmode->logs_attitude()) {
         Log_Write_Attitude();
-        if (!using_rate_thread) {
+        if (!rate_thread_active()) {
             Log_Write_Rate();
         }
     }
     if (!should_log(MASK_LOG_ATTITUDE_FAST) && !copter.flightmode->logs_attitude()) {
     // log at 10Hz if PIDS bitmask is selected, even if no ATT bitmask is selected; logs at looprate if ATT_FAST and PIDS bitmask set
-        if (!using_rate_thread) {
+        if (!rate_thread_active()) {
             Log_Write_PIDS();
         }
     }
@@ -812,7 +812,7 @@ void Copter::one_hz_loop()
     AP_Notify::flags.flying = !ap.land_complete;
 
     // slowly update the PID notches with the average loop rate
-    if (!using_rate_thread) {
+    if (!rate_thread_active()) {
         attitude_control->set_notch_sample_rate(AP::scheduler().get_filtered_loop_rate_hz());
     }
     pos_control->D_get_accel_pid().set_notch_sample_rate(AP::scheduler().get_filtered_loop_rate_hz());

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -21,6 +21,7 @@
 // Header includes
 ////////////////////////////////////////////////////////////////////////////////
 
+#include <atomic>
 #include <cmath>
 #include <stdio.h>
 #include <stdarg.h>
@@ -1110,7 +1111,19 @@ private:
     void exit_mode(Mode *&old_flightmode, Mode *&new_flightmode);
 
     bool started_rate_thread;
-    bool using_rate_thread;
+
+    // using_rate_thread is written by the rate thread (enable/disable_fast_rate_loop)
+    // and read by multiple main-thread functions.  Must be atomic to prevent a data race.
+    // Writes use RELEASE (all setup/teardown visible to readers); main-thread reads use
+    // ACQUIRE (see enable_fast_rate_loop comment); the rate thread's own self-read uses RELAXED.
+    // Use rate_thread_active() for main-thread reads; access .load(relaxed) directly in the
+    // rate thread.
+    std::atomic<bool> using_rate_thread{false};
+
+    // Acquire-ordered read for all main-thread callers of using_rate_thread.
+    bool rate_thread_active() const {
+        return using_rate_thread.load(std::memory_order_acquire);
+    }
 
 public:
     void failsafe_check();      // failsafe.cpp

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -121,7 +121,7 @@ void Copter::motors_output(bool full_push)
 // motors_output from main thread at main loop rate
 void Copter::motors_output_main()
 {
-    if (!using_rate_thread) {
+    if (!rate_thread_active()) {
         motors_output();
     }
 }

--- a/ArduCopter/rate_thread.cpp
+++ b/ArduCopter/rate_thread.cpp
@@ -226,7 +226,8 @@ void Copter::rate_controller_thread()
         }
 
         // set up rate thread requirements
-        if (!using_rate_thread) {
+        // Relaxed: self-read — the rate thread sees its own RELEASE store in program order.
+        if (!using_rate_thread.load(std::memory_order_relaxed)) {
             enable_fast_rate_loop(rate_decimation, rates);
         }
         ins.set_rate_decimation(rate_decimation);
@@ -448,7 +449,9 @@ void Copter::enable_fast_rate_loop(uint8_t rate_decimation, RateControllerRates&
     ins.enable_fast_rate_buffer();
     rate_controller_set_rates(rate_decimation, rates, false);
     hal.rcout->force_trigger_groups(true);
-    using_rate_thread = true;
+    // RELEASE: all setup writes above are visible to any thread that subsequently
+    // acquires using_rate_thread == true (e.g. run_rate_controller_main).
+    using_rate_thread.store(true, std::memory_order_release);
 }
 
 // disable the fast rate thread and record the new output rates
@@ -464,7 +467,9 @@ void Copter::disable_fast_rate_loop(RateControllerRates& rates)
     rate_controller_set_rates(rate_decimation, rates, false);
     hal.rcout->force_trigger_groups(false);
     ins.disable_fast_rate_buffer();
-    using_rate_thread = false;
+    // RELEASE: all teardown writes above are now visible to any thread that
+    // subsequently acquires using_rate_thread == false (e.g. run_rate_controller_main).
+    using_rate_thread.store(false, std::memory_order_release);
 }
 
 /*
@@ -488,7 +493,7 @@ void Copter::rate_controller_log_update()
 // run notch update at either loop rate or 200Hz
 void Copter::update_dynamic_notch_at_specified_rate_main()
 {
-    if (using_rate_thread) {
+    if (rate_thread_active()) {
         return;
     }
 

--- a/ArduCopter/rate_thread.cpp
+++ b/ArduCopter/rate_thread.cpp
@@ -454,11 +454,17 @@ void Copter::enable_fast_rate_loop(uint8_t rate_decimation, RateControllerRates&
 // disable the fast rate thread and record the new output rates
 void Copter::disable_fast_rate_loop(RateControllerRates& rates)
 {
-    using_rate_thread = false;
+    // Perform all teardown BEFORE clearing using_rate_thread.
+    // The main thread checks using_rate_thread in motors_output_main() and
+    // run_rate_controller_main(); if we clear the flag first, the main thread
+    // resumes motor output while rcout is still at the fast DShot rate and
+    // the fast buffer is still active, producing incorrect motor output.
+    // Mirror enable_fast_rate_loop which correctly does setup-before-set.
     uint8_t rate_decimation = calc_gyro_decimation(1, AP::scheduler().get_filtered_loop_rate_hz());
     rate_controller_set_rates(rate_decimation, rates, false);
     hal.rcout->force_trigger_groups(false);
     ins.disable_fast_rate_buffer();
+    using_rate_thread = false;
 }
 
 /*

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -731,6 +731,18 @@ This option is only supported on macOS versions of clang.
     g.add_option('--ubsan-abort',
         action='store_true',
         help='''Build using the gcc undefined behaviour sanitizer and abort on error''')
+
+    g.add_option('--tsan',
+        action='store_true',
+        default=False,
+        help='''Build using ThreadSanitizer to detect data races.
+Requires GCC or Clang with TSan support (Linux/macOS).
+Use with SITL to find cross-thread races in the rate-loop code:
+  ./waf configure --board sitl --tsan
+  ./waf copter
+  TSAN_OPTIONS="halt_on_error=1 suppressions=Tools/scripts/tsan_suppressions.txt" \\
+      build/sitl/bin/arducopter -S --speedup 5
+''')
     
 def build(bld):
     bld.add_pre_fun(_process_build_command)

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -853,6 +853,14 @@ class SITLBoard(Board):
                 "-fno-sanitize-recover"
             ]
 
+        if cfg.options.tsan:
+            env.CXXFLAGS += [
+                '-fsanitize=thread',
+                '-fno-omit-frame-pointer',
+                '-DTSAN_ENABLED',
+            ]
+            env.LINKFLAGS += ['-fsanitize=thread']
+
         if not cfg.env.DEBUG:
             env.CXXFLAGS += [
                 '-O3',

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -7745,6 +7745,113 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 "Notch-per-motor peak was higher than single-notch peak %fdB > %fdB" %
                 (esc_peakdb2, esc_peakdb1))
 
+    def RateThreadFixedDivParamRefresh(self):
+        """FSTRATE_DIV changes must take effect in FAST_RATE_FIXED mode.
+
+        Regression guard: target_rate_decimation must be refreshed from the
+        parameter at 100 ms cadence regardless of the current FastRateType.
+        If the refresh is placed inside the FastRateType guard (which is always
+        false for FIXED mode when at target), runtime FSTRATE_DIV changes are
+        silently ignored.
+
+        Observable: changing FSTRATE_DIV while FSTRATE_ENABLE=3 must produce
+        a "Rate CPU … rate set to Nhz" GCS notification within ~200 ms.
+        """
+        self.progress("RateThread PR1: FSTRATE_DIV param refresh in FIXED mode")
+        self.context_push()
+        self.set_parameters({
+            "AHRS_EKF_TYPE": 10,
+            "FSTRATE_ENABLE": 3,    # FAST_RATE_FIXED: always honour FSTRATE_DIV
+            "FSTRATE_DIV": 1,
+        })
+        self.reboot_sitl()
+        self.takeoff(10, mode="ALT_HOLD")
+
+        try:
+            self.wait_statustext("Rate CPU", timeout=5)
+        except AutoTestTimeoutException:
+            self.progress("FSTRATE not supported in this build – skipping")
+            self.do_RTL()
+            self.context_pop()
+            self.reboot_sitl()
+            return
+
+        self.context_collect("STATUSTEXT")
+        self.set_parameter("FSTRATE_DIV", 2)
+
+        try:
+            self.wait_statustext("Rate CPU", timeout=2, check_context=True)
+        except AutoTestTimeoutException:
+            raise NotAchievedException(
+                "No rate-change GCS notification after FSTRATE_DIV change "
+                "(target_rate_decimation refresh may be inside FastRateType guard)"
+            )
+
+        self.do_RTL()
+        self.context_pop()
+        self.reboot_sitl()
+
+    def RateThreadEnableDisableCycle(self):
+        """Rate thread enable/disable cycle must not corrupt rcout state.
+
+        Regression guard: disable_fast_rate_loop() must complete all teardown
+        (rate_controller_set_rates, force_trigger_groups(false),
+        disable_fast_rate_buffer) before clearing using_rate_thread.  If
+        using_rate_thread is cleared first, the main thread resumes motor output
+        while rcout is still at the fast DShot rate.
+
+        Observable: performing an enable→disable→re-enable cycle while hovering
+        must not cause the vehicle to crash or lose significant altitude.
+        """
+        self.progress("RateThread PR1: enable/disable cycle ordering")
+        self.context_push()
+        self.set_parameters({
+            "AHRS_EKF_TYPE": 10,
+            "FSTRATE_ENABLE": 1,
+        })
+        self.reboot_sitl()
+        self.takeoff(10, mode="ALT_HOLD")
+
+        try:
+            self.wait_statustext("Rate CPU", timeout=5)
+        except AutoTestTimeoutException:
+            self.progress("FSTRATE not supported in this build – skipping")
+            self.do_RTL()
+            self.context_pop()
+            self.reboot_sitl()
+            return
+
+        # disable
+        self.set_parameter("FSTRATE_ENABLE", 0)
+        self.delay_sim_time(2)
+        m = self.mav.recv_match(type="GLOBAL_POSITION_INT", blocking=True, timeout=5)
+        if m is None:
+            raise NotAchievedException("Lost telemetry after rate thread disable")
+        if m.relative_alt / 1000.0 < 3.0:
+            raise NotAchievedException(
+                "Altitude dropped after rate thread disable: %.1f m" % (m.relative_alt / 1000.0)
+            )
+
+        # re-enable
+        self.set_parameter("FSTRATE_ENABLE", 1)
+        try:
+            self.wait_statustext("Rate CPU", timeout=5)
+        except AutoTestTimeoutException:
+            raise NotAchievedException("Rate thread did not restart after re-enable")
+
+        self.delay_sim_time(2)
+        m = self.mav.recv_match(type="GLOBAL_POSITION_INT", blocking=True, timeout=5)
+        if m is None:
+            raise NotAchievedException("Lost telemetry after rate thread re-enable")
+        if m.relative_alt / 1000.0 < 3.0:
+            raise NotAchievedException(
+                "Altitude dropped after rate thread re-enable: %.1f m" % (m.relative_alt / 1000.0)
+            )
+
+        self.do_RTL()
+        self.context_pop()
+        self.reboot_sitl()
+
     def DynamicRpmNotchesRateThread(self):
         """Use dynamic harmonic notch to control motor noise via ESC telemetry."""
         self.progress("Flying with ESC telemetry driven dynamic notches")
@@ -16524,6 +16631,8 @@ return update, 1000
             self.PositionWhenGPSIsZero,
             self.DynamicRpmNotches, # Do not add attempts to this - failure is sign of a bug
             self.DynamicRpmNotchesRateThread,
+            self.RateThreadFixedDivParamRefresh,
+            self.RateThreadEnableDisableCycle,
             self.PIDNotches,
             self.mission_NAV_LOITER_TURNS,
             self.mission_NAV_LOITER_TURNS_off_center,

--- a/Tools/scripts/rate_thread_tsan.sh
+++ b/Tools/scripts/rate_thread_tsan.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# rate_thread_tsan.sh — verify no data races in ArduCopter rate thread
+#
+# Builds ArduCopter SITL with ThreadSanitizer and runs a short flight with
+# FSTRATE_ENABLE=1 to exercise all cross-thread paths.  Any TSan report
+# written to stderr indicates a real data race that needs fixing.
+#
+# Usage:
+#   cd <ardupilot-root>
+#   Tools/scripts/rate_thread_tsan.sh [--no-build] [--speedup N]
+#
+# Options:
+#   --no-build   Skip the waf configure+build step (use existing binary)
+#   --speedup N  SITL speedup factor (default: 5)
+#
+# Expected output on a clean (fixed) tree:
+#   [TSan] No data races detected.  All clear.
+#
+# Expected output on the unpatched tree (plain bool / plain uint8_t):
+#   WARNING: ThreadSanitizer: data race ...
+#     Write of size 1 at ... by thread T1:
+#       #0 Copter::enable_fast_rate_loop ...
+#     Previous read of size 1 at ... by thread T2:
+#       #0 Copter::run_rate_controller_main ...
+#   ...
+#
+# Dependencies: gcc or clang with TSan, python3, mavproxy or pymavlink
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SITL_BIN="$ROOT/build/sitl/bin/arducopter"
+SPEEDUP=5
+BUILD=1
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --no-build)  BUILD=0; shift ;;
+        --speedup)   SPEEDUP="$2"; shift 2 ;;
+        *)           echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+# ── 1. Build ──────────────────────────────────────────────────────────────────
+if [[ $BUILD -eq 1 ]]; then
+    echo "=== Configuring SITL with ThreadSanitizer ==="
+    cd "$ROOT"
+    python3 waf configure --board sitl --tsan
+    echo "=== Building ArduCopter ==="
+    python3 waf copter
+fi
+
+if [[ ! -x "$SITL_BIN" ]]; then
+    echo "ERROR: $SITL_BIN not found.  Run without --no-build first."
+    exit 1
+fi
+
+# ── 2. Prepare TSAN environment ───────────────────────────────────────────────
+SUPP="$SCRIPT_DIR/tsan_suppressions.txt"
+TSAN_LOG="$ROOT/tsan_report.txt"
+
+export TSAN_OPTIONS="halt_on_error=0 \
+log_path=$TSAN_LOG \
+suppressions=$SUPP \
+second_deadlock_stack=1 \
+history_size=5"
+
+# ── 3. Create a minimal param file that enables the fast rate thread ──────────
+PARAM_FILE="$(mktemp /tmp/fstrate_XXXXXX.parm)"
+cat > "$PARAM_FILE" <<'PARAMS'
+FSTRATE_ENABLE 1
+AHRS_EKF_TYPE 10
+INS_GYRO_FILTER 300
+PARAMS
+trap 'rm -f "$PARAM_FILE"' EXIT
+
+# ── 4. Run SITL for 30 simulated seconds ─────────────────────────────────────
+echo "=== Running SITL with TSan (speedup=${SPEEDUP}x, 30 sim-seconds) ==="
+echo "    TSan log: ${TSAN_LOG}.* "
+echo "    Param file: $PARAM_FILE"
+echo ""
+
+# We use a Python helper to arm, hover, and disarm via MAVLink.
+# SITL exits when the helper script completes.
+HELPER="$(mktemp /tmp/tsan_flight_XXXXXX.py)"
+cat > "$HELPER" <<'PYEOF'
+#!/usr/bin/env python3
+"""Minimal MAVLink flight script for TSan validation.
+
+Arms the vehicle, takes off to 10 m, hovers for 10 s,
+then lands and disarms.  This exercises all rate-thread
+cross-thread paths under TSan observation.
+"""
+import time, sys
+try:
+    from pymavlink import mavutil
+except ImportError:
+    print("pymavlink not installed — install with: pip3 install pymavlink")
+    sys.exit(0)
+
+mav = mavutil.mavlink_connection('udp:127.0.0.1:14550')
+mav.wait_heartbeat(timeout=30)
+print("Connected to vehicle")
+
+# Switch to GUIDED mode
+mav.mav.command_long_send(
+    mav.target_system, mav.target_component,
+    mavutil.mavlink.MAV_CMD_DO_SET_MODE, 0,
+    1,  # base_mode (custom mode enabled)
+    4,  # GUIDED
+    0, 0, 0, 0, 0)
+time.sleep(1)
+
+# Arm
+mav.arducopter_arm()
+mav.motors_armed_wait()
+print("Armed")
+
+# Take off to 10 m
+mav.mav.command_long_send(
+    mav.target_system, mav.target_component,
+    mavutil.mavlink.MAV_CMD_NAV_TAKEOFF, 0,
+    0, 0, 0, 0, 0, 0, 10)
+print("Taking off ...")
+time.sleep(8)
+
+# Hover for 15 s (exercises the hot path + rate-check cadence)
+print("Hovering for 15 s ...")
+time.sleep(15)
+
+# Land
+mav.mav.command_long_send(
+    mav.target_system, mav.target_component,
+    mavutil.mavlink.MAV_CMD_NAV_LAND, 0,
+    0, 0, 0, 0, 0, 0, 0)
+print("Landing ...")
+time.sleep(8)
+
+mav.arducopter_disarm()
+print("Disarmed — test complete")
+PYEOF
+trap 'rm -f "$PARAM_FILE" "$HELPER"' EXIT
+
+# Start SITL in the background
+"$SITL_BIN" \
+    -S \
+    -I0 \
+    --home 51.8733,-1.1481,50,270 \
+    --speedup "$SPEEDUP" \
+    --defaults "$PARAM_FILE" \
+    &
+SITL_PID=$!
+
+# Give SITL time to start
+sleep 3
+
+# Run the flight helper
+python3 "$HELPER" || true
+
+# Give TSan a moment to flush its reports
+sleep 2
+kill "$SITL_PID" 2>/dev/null || true
+wait "$SITL_PID" 2>/dev/null || true
+
+# ── 5. Analyse TSan output ────────────────────────────────────────────────────
+echo ""
+echo "=== ThreadSanitizer report ==="
+
+RACE_FILES=( "${TSAN_LOG}"* )
+RACES_FOUND=0
+
+for f in "${RACE_FILES[@]}"; do
+    if [[ -f "$f" && -s "$f" ]]; then
+        grep -c "data race" "$f" >/dev/null 2>&1 && {
+            RACE_COUNT=$(grep -c "data race" "$f" || true)
+            echo "FAIL: $RACE_COUNT data race(s) detected in $f"
+            echo "---------- TSan report ----------"
+            cat "$f"
+            echo "---------------------------------"
+            RACES_FOUND=$((RACES_FOUND + RACE_COUNT))
+        }
+    fi
+done
+
+if [[ $RACES_FOUND -eq 0 ]]; then
+    echo "[TSan] No data races detected.  All clear."
+    exit 0
+else
+    echo ""
+    echo "FAIL: $RACES_FOUND data race(s) detected."
+    echo "Apply the PR2 atomic fixes and re-run."
+    exit 1
+fi

--- a/Tools/scripts/tsan_suppressions.txt
+++ b/Tools/scripts/tsan_suppressions.txt
@@ -1,0 +1,29 @@
+# ThreadSanitizer suppressions for ArduPilot SITL
+#
+# These suppress known-benign or third-party races so that TSan output
+# highlights only the application-level races we care about.
+#
+# Format: <type>:<symbol/file glob>
+#   race     — data race on a variable/function
+#   mutex    — lock-ordering problem
+#   thread   — thread leak
+
+# ── Known-benign SITL infrastructure ──────────────────────────────────────────
+
+# AP_HAL_SITL uses a global simulation clock that is updated from the main
+# thread and read from bus-emulation threads without synchronisation.
+# This is intentional SITL-only behaviour (no shared clock on real hardware).
+race:HALSITL::Scheduler::_run_timer_procs
+race:HALSITL::Scheduler::stop_clock
+
+# ── Third-party / system library races (not our code) ─────────────────────────
+race:libstdc++
+race:__cxa_guard_acquire
+race:pthread_create
+
+# ── Logging infrastructure ────────────────────────────────────────────────────
+# AP_Logger uses a ring-buffer with its own internal locking that TSan cannot
+# see through because the locks are in a different compilation unit.
+race:AP_Logger
+
+# ── End of suppressions ───────────────────────────────────────────────────────

--- a/libraries/AP_InertialSensor/FastRateBuffer.cpp
+++ b/libraries/AP_InertialSensor/FastRateBuffer.cpp
@@ -110,6 +110,9 @@ bool FastRateBuffer::get_next_gyro_sample(Vector3f& gyro)
         _notifier.wait_blocking();
     }
 
+    // _mutex is held only for the pop() — a single pointer/index update in ObjectBuffer.
+    // The competing thread (push_next_gyro_sample) holds it for an equally short push().
+    // Both critical sections are O(1), bounded, and allocation-free.
     WITH_SEMAPHORE(_mutex);
 
     return _rate_loop_gyro_window.pop(gyro);
@@ -118,10 +121,10 @@ bool FastRateBuffer::get_next_gyro_sample(Vector3f& gyro)
 void FastRateBuffer::reset()
 {
     _rate_loop_gyro_window.clear();
-    // Reset the push counter so the first sample after re-enable is not
-    // pushed at a stale offset within the decimation cycle.  Without this,
-    // a re-enable after disable_fast_rate_buffer() inherits a non-zero count
-    // and may push (or skip) the first sample at the wrong position.
+    // Reset the push counter so the first sample after re-enable is not pushed at an
+    // offset position within the decimation cycle.  Without this, a re-enable after
+    // disable_fast_rate_buffer() would inherit a stale count, producing a one-cycle
+    // phase error in the decimation pattern.
     rate_decimation_count = 0;
 }
 
@@ -131,7 +134,11 @@ bool AP_InertialSensor::push_next_gyro_sample(const Vector3f& gyro)
         return false;
     }
 
-    if (++fast_rate_buffer->rate_decimation_count < fast_rate_buffer->rate_decimation) {
+    // Read rate_decimation with ACQUIRE to pair with the rate thread's RELEASE store in
+    // set_rate_decimation().  Without this the backend thread may see a stale value and
+    // push at the wrong rate.
+    if (++fast_rate_buffer->rate_decimation_count <
+            fast_rate_buffer->rate_decimation.load(std::memory_order_acquire)) {
         return false;
     }
     /*

--- a/libraries/AP_InertialSensor/FastRateBuffer.cpp
+++ b/libraries/AP_InertialSensor/FastRateBuffer.cpp
@@ -118,6 +118,11 @@ bool FastRateBuffer::get_next_gyro_sample(Vector3f& gyro)
 void FastRateBuffer::reset()
 {
     _rate_loop_gyro_window.clear();
+    // Reset the push counter so the first sample after re-enable is not
+    // pushed at a stale offset within the decimation cycle.  Without this,
+    // a re-enable after disable_fast_rate_buffer() inherits a non-zero count
+    // and may push (or skip) the first sample at the wrong position.
+    rate_decimation_count = 0;
 }
 
 bool AP_InertialSensor::push_next_gyro_sample(const Vector3f& gyro)

--- a/libraries/AP_InertialSensor/FastRateBuffer.h
+++ b/libraries/AP_InertialSensor/FastRateBuffer.h
@@ -24,6 +24,7 @@
 #include <AP_HAL/utility/RingBuffer.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_HAL/Semaphores.h>
+#include <atomic>
 
 class FastRateBuffer
 {
@@ -31,9 +32,14 @@ class FastRateBuffer
 public:
     bool get_next_gyro_sample(Vector3f& gyro);
     uint32_t get_num_gyro_samples() { return _rate_loop_gyro_window.available(); }
-    void set_rate_decimation(uint8_t rdec) { rate_decimation = rdec; }
+    void set_rate_decimation(uint8_t rdec) {
+        // RELEASE so the backend thread sees the new value before the next push.
+        rate_decimation.store(rdec, std::memory_order_release);
+    }
     // whether or not to push the current gyro sample
-    bool use_rate_loop_gyro_samples() const { return rate_decimation > 0; }
+    bool use_rate_loop_gyro_samples() const {
+        return rate_decimation.load(std::memory_order_acquire) > 0;
+    }
     bool gyro_samples_available() { return  _rate_loop_gyro_window.available() > 0; }
     void reset();
 
@@ -43,8 +49,12 @@ private:
       we hav finished filtering the primary IMU
      */
     ObjectBuffer<Vector3f> _rate_loop_gyro_window{AP_INERTIAL_SENSOR_RATE_LOOP_BUFFER_SIZE};
-    uint8_t rate_decimation; // 0 means off
-    uint8_t rate_decimation_count;
+    // rate_decimation is written by the rate thread (set_rate_decimation) and read
+    // by the SPI/backend thread (push_next_gyro_sample / use_rate_loop_gyro_samples).
+    // Must be atomic to prevent a data race between these two threads.
+    // RELEASE on write, ACQUIRE on read — ensures the reader always sees a coherent value.
+    std::atomic<uint8_t> rate_decimation{0};
+    uint8_t rate_decimation_count{0}; // only touched by the backend/push thread; no atomic needed
     HAL_BinarySemaphore _notifier;
     HAL_Semaphore _mutex;
 };


### PR DESCRIPTION
## Summary

The fast rate thread shares several variables with the main thread and other
threads. These are accessed without synchronisation, producing data races under
the C++ memory model (undefined behaviour, possible torn reads, and incorrect
compiler optimisations such as caching in a register across iterations).

**`using_rate_thread` — plain `bool` with 8 unsynchronised cross-thread sites**

Read from the attitude loop, motors, and multiple Copter.cpp call sites while
written by `enable_fast_rate_loop` / `disable_fast_rate_loop` on the main
thread. A `volatile` annotation is insufficient: it prevents register-caching
but provides no ordering guarantees and is not a substitute for `std::atomic`.

Fix: `std::atomic<bool> using_rate_thread{false}` with:
- Writes at enable/disable: `store(true/false, memory_order_release)` — makes
  all preceding setup/teardown writes visible to any thread that observes the
  new flag value.
- Main-thread reads: `rate_thread_active()` accessor using `memory_order_acquire`
  — pairs with the release stores, ensuring the main thread sees a consistent
  post-setup or post-teardown state.
- Rate-thread self-read: `memory_order_relaxed` — the rate thread is the writer;
  it cannot observe its own stale value.

**`FastRateBuffer::rate_decimation` — plain `uint8_t` with cross-thread store**

Written by the main thread (`set_rate_decimation`) and read by the backend
thread (`push_next_gyro_sample`). A plain integer load/store is not atomic on
all architectures and provides no ordering guarantee.

Fix: `std::atomic<uint8_t> rate_decimation{0}` with RELEASE store in
`set_rate_decimation()` and ACQUIRE load in `push_next_gyro_sample()`.

**TSan build support**

Add `--tsan` waf option for SITL builds. When configured, compiles with
`-fsanitize=thread` and links the TSan runtime. A helper script
(`Tools/scripts/rate_thread_tsan.sh`) builds SITL with TSan, starts it, runs a
short pymavlink flight with rate thread enabled, and exits non-zero if any races
are reported.

A `tsan_suppressions.txt` file suppresses known-benign races in SITL
infrastructure (HAL scheduler, libstdc++, AP_Logger) that are not present in
real flight code.

## Why `volatile` is not sufficient

`volatile` in C++ prevents the compiler from caching a variable in a register
across reads, but it does not:
- Prevent the CPU from reordering loads/stores with adjacent memory accesses
- Prevent the compiler from reordering across `volatile` accesses when other
  non-volatile objects are involved
- Provide any inter-thread visibility guarantee under the C++ memory model

`std::atomic` with appropriate ordering tags provides all three.

## Test plan

- [ ] `./waf configure --board sitl --tsan && ./waf copter`
- [ ] `TSAN_OPTIONS="halt_on_error=1 suppressions=Tools/scripts/tsan_suppressions.txt" Tools/scripts/rate_thread_tsan.sh` — must exit 0
- [ ] SITL regression: all existing `DynamicRpmNotchesRateThread` tests pass

## Notes

Stacked on top of PR #32839 (logic bugs). Contains no functional changes beyond
correct memory ordering — the same operations happen in the same order; they are
now visible to all threads as intended.

This is PR 2/3 in a stacked series.