### PR TITLE
ArduCopter: rate thread RT determinism improvements

### DIFF
--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -14,7 +14,7 @@ void Copter::run_rate_controller_main()
     pos_control->set_dt_s(last_loop_time_s);
     attitude_control->set_dt_s(last_loop_time_s);
 
-    if (!using_rate_thread) {
+    if (!rate_thread_active()) {
         motors->set_dt_s(last_loop_time_s);
         // only run the rate controller if we are not using the rate thread
         attitude_control->rate_controller_run();

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -159,6 +159,10 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
 #endif
     SCHED_TASK(update_batt_compass,   10,    120, 15),
     SCHED_TASK_CLASS(RC_Channels, (RC_Channels*)&copter.g2.rc_channels, read_aux_all,    10,  50,  18),
+#if AP_INERTIALSENSOR_FAST_SAMPLE_WINDOW_ENABLED
+    // Forward rate-thread GCS messages to main thread; rate thread must not call gcs().send_text() directly.
+    SCHED_TASK(flush_rate_thread_msg,        10,     50,  20),
+#endif
 #if TOY_MODE_ENABLED
     SCHED_TASK_CLASS(ToyMode,              &copter.g2.toy_mode,         update,          10,  50,  24),
 #endif

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -638,13 +638,13 @@ void Copter::loop_rate_logging()
 {
    if (should_log(MASK_LOG_ATTITUDE_FAST) && !copter.flightmode->logs_attitude()) {
         Log_Write_Attitude();
-        if (!using_rate_thread) {
+        if (!rate_thread_active()) {
             Log_Write_Rate();
             Log_Write_PIDS(); // only logs if PIDS bitmask is set
         }
     }
 #if AP_INERTIALSENSOR_HARMONICNOTCH_ENABLED
-    if (should_log(MASK_LOG_FTN_FAST) && !using_rate_thread) {
+    if (should_log(MASK_LOG_FTN_FAST) && !rate_thread_active()) {
         AP::ins().write_notch_log_messages();
     }
 #endif
@@ -664,13 +664,13 @@ void Copter::ten_hz_logging_loop()
     // log attitude controller data if we're not already logging at the higher rate
     if (should_log(MASK_LOG_ATTITUDE_MED) && !should_log(MASK_LOG_ATTITUDE_FAST) && !copter.flightmode->logs_attitude()) {
         Log_Write_Attitude();
-        if (!using_rate_thread) {
+        if (!rate_thread_active()) {
             Log_Write_Rate();
         }
     }
     if (!should_log(MASK_LOG_ATTITUDE_FAST) && !copter.flightmode->logs_attitude()) {
     // log at 10Hz if PIDS bitmask is selected, even if no ATT bitmask is selected; logs at looprate if ATT_FAST and PIDS bitmask set
-        if (!using_rate_thread) {
+        if (!rate_thread_active()) {
             Log_Write_PIDS();
         }
     }
@@ -812,7 +812,7 @@ void Copter::one_hz_loop()
     AP_Notify::flags.flying = !ap.land_complete;
 
     // slowly update the PID notches with the average loop rate
-    if (!using_rate_thread) {
+    if (!rate_thread_active()) {
         attitude_control->set_notch_sample_rate(AP::scheduler().get_filtered_loop_rate_hz());
     }
     pos_control->D_get_accel_pid().set_notch_sample_rate(AP::scheduler().get_filtered_loop_rate_hz());

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -21,6 +21,7 @@
 // Header includes
 ////////////////////////////////////////////////////////////////////////////////
 
+#include <atomic>
 #include <cmath>
 #include <stdio.h>
 #include <stdarg.h>
@@ -1110,7 +1111,19 @@ private:
     void exit_mode(Mode *&old_flightmode, Mode *&new_flightmode);
 
     bool started_rate_thread;
-    bool using_rate_thread;
+
+    // using_rate_thread is written by the rate thread (enable/disable_fast_rate_loop)
+    // and read by multiple main-thread functions.  Must be atomic to prevent a data race.
+    // Writes use RELEASE (all setup/teardown visible to readers); main-thread reads use
+    // ACQUIRE (see enable_fast_rate_loop comment); the rate thread's own self-read uses RELAXED.
+    // Use rate_thread_active() for main-thread reads; access .load(relaxed) directly in the
+    // rate thread.
+    std::atomic<bool> using_rate_thread{false};
+
+    // Acquire-ordered read for all main-thread callers of using_rate_thread.
+    bool rate_thread_active() const {
+        return using_rate_thread.load(std::memory_order_acquire);
+    }
 
 public:
     void failsafe_check();      // failsafe.cpp

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -750,6 +750,55 @@ private:
     void enable_fast_rate_loop(uint8_t rate_decimation, RateControllerRates& rates);
     void disable_fast_rate_loop(RateControllerRates& rates);
     void update_dynamic_notch_at_specified_rate_main();
+
+    // Lockfree single-slot notification: rate thread posts raw data here; the main
+    // thread formats and forwards to GCS via flush_rate_thread_msg().
+    //
+    // Protocol (single-producer / single-consumer):
+    //   Writer (rate thread):
+    //     1. Load pending with ACQUIRE.  If true, a prior message is unread — drop silently.
+    //     2. Write attitude_rate_hz and warn_cpu_high.
+    //     3. Store pending=true with RELEASE.  The release fence makes the field writes
+    //        visible to any thread that subsequently acquires pending==true.
+    //   Reader (main thread, flush_rate_thread_msg):
+    //     1. Load pending with ACQUIRE.  If false, nothing to do.
+    //     2. Copy the two fields locally.
+    //     3. Store pending=false with RELEASE so the rate thread can reuse the slot.
+    //     4. Call gcs().send_text() *after* releasing the slot.
+    //
+    // Why ACQUIRE on the writer's check (not just RELAXED):
+    //   The writer must synchronise with the reader's pending=false RELEASE store.
+    //   Without ACQUIRE here the compiler/CPU may hoist the field writes above the
+    //   check, creating a write-read race with the still-in-progress reader.
+    //
+    // Why no snprintf in the rate thread:
+    //   snprintf touches locale / floating-point state and may take libc-internal locks
+    //   on some embedded C runtimes (newlib, picolibc).  Only plain integer stores are
+    //   safe in this RT context.
+    struct RateThreadMsg {
+        uint32_t attitude_rate_hz;   // raw value; main thread formats the log string
+        bool warn_cpu_high;
+        std::atomic<bool> pending{false};
+    } _rate_thread_msg;
+    void flush_rate_thread_msg();
+
+    // Always-on WCET (Worst-Case Execution Time) monitoring for the critical path:
+    // gyro-sample-received → rate_controller_run_dt() → motors_output().
+    //
+    // Writers:
+    //   • rate thread: increments overruns via fetch_add; updates max_us via
+    //     load+compare+store (single hot-path writer — no CAS loop needed here).
+    //   • main thread: resets max_us via exchange(0) after each GCS report so the
+    //     next interval reflects current WCET rather than a lifetime worst-case.
+    //
+    // Because both max_us writers use relaxed atomics and there is no ordering
+    // requirement between them (these are telemetry values, not control signals),
+    // the only property required is torn-write prevention, which relaxed atomics
+    // provide on all supported platforms.
+    struct RateLoopBudget {
+        std::atomic<uint32_t> max_us{0};    // worst critical-path time since last report (µs)
+        std::atomic<uint32_t> overruns{0};  // total cycles that exceeded one gyro period
+    } _rate_loop_budget;
     // endif AP_INERTIALSENSOR_FAST_SAMPLE_WINDOW_ENABLED
 
 #if AC_CUSTOMCONTROL_MULTI_ENABLED

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -121,7 +121,7 @@ void Copter::motors_output(bool full_push)
 // motors_output from main thread at main loop rate
 void Copter::motors_output_main()
 {
-    if (!using_rate_thread) {
+    if (!rate_thread_active()) {
         motors_output();
     }
 }

--- a/ArduCopter/rate_thread.cpp
+++ b/ArduCopter/rate_thread.cpp
@@ -226,7 +226,8 @@ void Copter::rate_controller_thread()
         }
 
         // set up rate thread requirements
-        if (!using_rate_thread) {
+        // Relaxed: self-read — the rate thread sees its own RELEASE store in program order.
+        if (!using_rate_thread.load(std::memory_order_relaxed)) {
             enable_fast_rate_loop(rate_decimation, rates);
         }
         ins.set_rate_decimation(rate_decimation);
@@ -448,7 +449,9 @@ void Copter::enable_fast_rate_loop(uint8_t rate_decimation, RateControllerRates&
     ins.enable_fast_rate_buffer();
     rate_controller_set_rates(rate_decimation, rates, false);
     hal.rcout->force_trigger_groups(true);
-    using_rate_thread = true;
+    // RELEASE: all setup writes above are visible to any thread that subsequently
+    // acquires using_rate_thread == true (e.g. run_rate_controller_main).
+    using_rate_thread.store(true, std::memory_order_release);
 }
 
 // disable the fast rate thread and record the new output rates
@@ -464,7 +467,9 @@ void Copter::disable_fast_rate_loop(RateControllerRates& rates)
     rate_controller_set_rates(rate_decimation, rates, false);
     hal.rcout->force_trigger_groups(false);
     ins.disable_fast_rate_buffer();
-    using_rate_thread = false;
+    // RELEASE: all teardown writes above are now visible to any thread that
+    // subsequently acquires using_rate_thread == false (e.g. run_rate_controller_main).
+    using_rate_thread.store(false, std::memory_order_release);
 }
 
 /*
@@ -488,7 +493,7 @@ void Copter::rate_controller_log_update()
 // run notch update at either loop rate or 200Hz
 void Copter::update_dynamic_notch_at_specified_rate_main()
 {
-    if (using_rate_thread) {
+    if (rate_thread_active()) {
         return;
     }
 

--- a/ArduCopter/rate_thread.cpp
+++ b/ArduCopter/rate_thread.cpp
@@ -177,6 +177,23 @@ void Copter::rate_controller_thread()
     uint32_t rate_loop_count = 0;
     uint32_t prev_loop_count = 0;
 
+    // Track last decimation written to INS so we skip redundant set_rate_decimation() calls.
+    uint8_t last_set_decimation = 0;
+    // Cache sensor_dt (= rate_decimation / gyro_rate_hz).  Both inputs are constant
+    // between rate changes, so recomputing the float division on every gyro sample is
+    // wasteful and obscures the invariant.  Invalidated in the decimation-change guard.
+    float cached_sensor_dt = 1.0f * rate_decimation / MAX(ins.get_raw_gyro_rate_hz(), 1U);
+
+    // Cache gyro drift (written by AHRS/EKF on the main thread, read here at 4 kHz).
+    // ahrs.get_gyro_drift() returns a const ref into state.gyro_drift — a 12-byte
+    // Vector3f written by the EKF.  Reading it by reference on every hot-path sample
+    // is a data race under the C++ memory model; a component-by-component torn read
+    // could mix values from two consecutive EKF updates.
+    // Fix: snapshot the drift into a local copy.  Refreshed at 1 Hz (see notch-sample
+    // block below) — gyro bias changes on the order of µrad/s per EKF cycle, so one
+    // second of staleness is completely negligible for control quality.
+    Vector3f cached_gyro_drift = ahrs.get_gyro_drift();
+
     uint32_t last_run_us = AP_HAL::micros();
     float max_dt = 0.0;
     float min_dt = 1.0;
@@ -226,11 +243,18 @@ void Copter::rate_controller_thread()
         }
 
         // set up rate thread requirements
-        // Relaxed: self-read — the rate thread sees its own RELEASE store in program order.
+        // Relaxed: self-read — the rate thread sees its own release store in program order.
         if (!using_rate_thread.load(std::memory_order_relaxed)) {
             enable_fast_rate_loop(rate_decimation, rates);
         }
-        ins.set_rate_decimation(rate_decimation);
+        // Only push decimation to the buffer when it actually changes; calling
+        // set_rate_decimation() unconditionally on every sample is redundant.
+        if (rate_decimation != last_set_decimation) {
+            ins.set_rate_decimation(rate_decimation);
+            last_set_decimation    = rate_decimation;
+            // Recompute the cached constant whenever decimation changes.
+            cached_sensor_dt = 1.0f * rate_decimation / MAX(ins.get_raw_gyro_rate_hz(), 1U);
+        }
 
         // wait for an IMU sample
         Vector3f gyro;
@@ -243,8 +267,8 @@ void Copter::rate_controller_thread()
         rate_now_us = AP_HAL::micros();
 #endif
 
-        // we must use multiples of the actual sensor rate
-        const float sensor_dt = 1.0f * rate_decimation / ins.get_raw_gyro_rate_hz();
+        // sensor_dt is constant between rate changes; use the cached value.
+        const float sensor_dt = cached_sensor_dt;
         const uint32_t now_us = AP_HAL::micros();
         const uint32_t dt_us = now_us - last_run_us;
         const float dt = dt_us * 1.0e-6;
@@ -263,7 +287,7 @@ void Copter::rate_controller_thread()
         // run the rate controller on all available samples
         // it is important not to drop samples otherwise the filtering will be fubar
         // there is no need to output to the motors more than once for every batch of samples
-        attitude_control->rate_controller_run_dt(gyro + ahrs.get_gyro_drift(), sensor_dt);
+        attitude_control->rate_controller_run_dt(gyro + cached_gyro_drift, sensor_dt);
 
 #ifdef RATE_LOOP_TIMING_DEBUG
         rate_controller_time_us += AP_HAL::micros() - rate_now_us;
@@ -275,6 +299,33 @@ void Copter::rate_controller_thread()
             main_loop_count = 0;
         }
         motors_output(main_loop_count == 0);
+
+        // --- End of critical path: gyro received → PID → motor output ---
+        // Measure WCET of this segment.  Budget = one gyro period.
+        // Only plain integer arithmetic and relaxed atomics here to avoid
+        // re-introducing any latency into the measurement itself.
+        {
+            const uint32_t critical_us = AP_HAL::micros() - now_us;
+            // Update max with load+compare+store rather than a CAS loop.  The rate
+            // thread is the only writer of new maximums; the main thread only resets
+            // max_us to 0 via exchange() after reporting.  The worst-case interleave
+            // is: rate thread loads X, main thread exchanges X→0, rate thread stores
+            // critical_us (> X from the stale load).  This is benign: critical_us is
+            // captured in max_us and will appear in the next report interval.
+            if (critical_us > _rate_loop_budget.max_us.load(std::memory_order_relaxed)) {
+                _rate_loop_budget.max_us.store(critical_us, std::memory_order_relaxed);
+            }
+            // One gyro period in µs — pure integer arithmetic; guard against zero gyro rate
+            // (should never happen in practice, but a divide-by-zero in the hot path would
+            // be catastrophic).
+            const uint32_t gyro_rate_hz = ins.get_raw_gyro_rate_hz();
+            if (gyro_rate_hz > 0) {
+                const uint32_t budget_us = (uint32_t)rate_decimation * 1000000U / gyro_rate_hz;
+                if (critical_us > budget_us) {
+                    _rate_loop_budget.overruns.fetch_add(1, std::memory_order_relaxed);
+                }
+            }
+        }
 
         // process filter updates
         if (run_decimated_callback(rates.filter_rate, filter_loop_count)) {
@@ -322,15 +373,15 @@ void Copter::rate_controller_thread()
 #endif
 
         now_ms = AP_HAL::millis();
-
-        // make sure we have the latest target rate
-        target_rate_decimation = constrain_int16(g2.att_decimation.get(), 1,
-                                                 DIV_ROUND_INT(ins.get_raw_gyro_rate_hz(), AP::scheduler().get_loop_rate_hz()));
         if (now_ms - last_notch_sample_ms >= 1000 || !was_using_rate_thread) {
             // update the PID notch sample rate at 1Hz if we are
             // enabled at runtime
             last_notch_sample_ms = now_ms;
             attitude_control->set_notch_sample_rate(1.0 / sensor_dt);
+            // Refresh gyro-drift snapshot.  EKF bias corrections are tiny per cycle
+            // (µrad/s); 1 s staleness is negligible.  This is the only place the rate
+            // thread reads state.gyro_drift — all hot-path uses go through cached_gyro_drift.
+            cached_gyro_drift = ahrs.get_gyro_drift();
 #ifdef RATE_LOOP_TIMING_DEBUG
             hal.console->printf("Sample rate %.1f, main loop %u, fast rate %u, med rate %u\n", 1.0 / sensor_dt,
                                  rates.main_loop_rate, rates.fast_logging_rate, rates.medium_logging_rate);
@@ -353,36 +404,46 @@ void Copter::rate_controller_thread()
         }
 
         // check that the CPU is not pegged, if it is drop the attitude rate
-        if (now_ms - last_rate_check_ms >= 100
-            && (get_fast_rate_type() == FastRateType::FAST_RATE_DYNAMIC
-                || (get_fast_rate_type() == FastRateType::FAST_RATE_FIXED_ARMED && !motors->armed())
-                || target_rate_decimation > rate_decimation)) {
+        if (now_ms - last_rate_check_ms >= 100) {
             last_rate_check_ms = now_ms;
-            const uint32_t att_rate = ins.get_raw_gyro_rate_hz()/rate_decimation;
-            if (running_slow > 5 || AP::scheduler().get_extra_loop_us() > 0
-#if HAL_LOGGING_ENABLED
-                || AP::logger().in_log_download()
-#endif
+            // Refresh target decimation from the parameter at 100ms cadence — avoids a
+            // param read on the hot path.  Must be OUTSIDE the FastRateType guard below:
+            // the original code refreshed unconditionally on every gyro sample; our hot-path
+            // optimisation inadvertently moved this inside the mode guard, preventing
+            // FAST_RATE_FIXED (and FAST_RATE_FIXED_ARMED while armed and at target rate)
+            // from ever picking up a parameter change made at runtime.
+            target_rate_decimation = constrain_int16(g2.att_decimation.get(), 1,
+                                                     DIV_ROUND_INT(ins.get_raw_gyro_rate_hz(), AP::scheduler().get_loop_rate_hz()));
+            // Rate adaptation: only in dynamic / unarmed-fixed modes, or when a slower
+            // target is requested.  FAST_RATE_FIXED uses the fixed-rate block above.
+            if (get_fast_rate_type() == FastRateType::FAST_RATE_DYNAMIC
+                || (get_fast_rate_type() == FastRateType::FAST_RATE_FIXED_ARMED && !motors->armed())
                 || target_rate_decimation > rate_decimation) {
-                const uint8_t new_rate_decimation = MAX(rate_decimation + 1, target_rate_decimation);
-                const uint32_t new_attitude_rate = ins.get_raw_gyro_rate_hz() / new_rate_decimation;
-                if (new_attitude_rate > AP::scheduler().get_filtered_loop_rate_hz()) {
-                    rate_decimation = new_rate_decimation;
-                    rate_controller_set_rates(rate_decimation, rates, true);
-                    prev_loop_count = rate_loop_count;
+                const uint32_t att_rate = ins.get_raw_gyro_rate_hz()/rate_decimation;
+                if (running_slow > 5 || AP::scheduler().get_extra_loop_us() > 0
+#if HAL_LOGGING_ENABLED
+                    || AP::logger().in_log_download()
+#endif
+                    || target_rate_decimation > rate_decimation) {
+                    const uint8_t new_rate_decimation = MAX(rate_decimation + 1, target_rate_decimation);
+                    const uint32_t new_attitude_rate = ins.get_raw_gyro_rate_hz() / new_rate_decimation;
+                    if (new_attitude_rate > AP::scheduler().get_filtered_loop_rate_hz()) {
+                        rate_decimation = new_rate_decimation;
+                        rate_controller_set_rates(rate_decimation, rates, true);
+                        prev_loop_count = rate_loop_count;
+                        rate_loop_count = 0;
+                        running_slow = 0;
+                    }
+                } else if (rate_decimation > target_rate_decimation && rate_loop_count > att_rate/10 // ensure 100ms worth of good readings
+                    && (prev_loop_count > att_rate/10   // ensure there was 100ms worth of good readings at the higher rate
+                        || prev_loop_count == 0         // last rate was actually a lower rate so keep going quickly
+                        || now_ms - last_rate_increase_ms >= 10000)) { // every 10s retry
+                    rate_decimation = rate_decimation - 1;
+                    rate_controller_set_rates(rate_decimation, rates, false);
+                    prev_loop_count = 0;
                     rate_loop_count = 0;
-                    running_slow = 0;
+                    last_rate_increase_ms = now_ms;
                 }
-            } else if (rate_decimation > target_rate_decimation && rate_loop_count > att_rate/10 // ensure 100ms worth of good readings
-                && (prev_loop_count > att_rate/10   // ensure there was 100ms worth of good readings at the higher rate
-                    || prev_loop_count == 0         // last rate was actually a lower rate so keep going quickly
-                    || now_ms - last_rate_increase_ms >= 10000)) { // every 10s retry
-                rate_decimation = rate_decimation - 1;
-
-                rate_controller_set_rates(rate_decimation, rates, false);
-                prev_loop_count = 0;
-                rate_loop_count = 0;
-                last_rate_increase_ms = now_ms;
             }
         }
 
@@ -428,9 +489,18 @@ void Copter::rate_controller_set_rates(uint8_t rate_decimation, RateControllerRa
     attitude_control->set_notch_sample_rate(attitude_rate);
     hal.rcout->set_dshot_rate(SRV_Channels::get_dshot_rate(), attitude_rate);
     motors->set_dt_s(1.0f / attitude_rate);
-    gcs().send_text(warn_cpu_high ? MAV_SEVERITY_WARNING : MAV_SEVERITY_INFO,
-                    "Rate CPU %s, rate set to %uHz",
-                    warn_cpu_high ? "high" : "normal", (unsigned) attitude_rate);
+    // Post a rate-change notification for the main thread to forward to GCS.
+    // RT rules enforced here:
+    //   • gcs().send_text() takes a semaphore → never called from this path.
+    //   • snprintf may take libc-internal locale/fp locks → never called here.
+    //   • Only plain integer stores before the release fence.
+    // ACQUIRE on the pending check synchronises with the main thread's
+    // pending=false RELEASE store, preventing a write-read race on the fields.
+    if (!_rate_thread_msg.pending.load(std::memory_order_acquire)) {
+        _rate_thread_msg.attitude_rate_hz = (uint32_t)attitude_rate;
+        _rate_thread_msg.warn_cpu_high    = warn_cpu_high;
+        _rate_thread_msg.pending.store(true, std::memory_order_release);
+    }
 #if HAL_LOGGING_ENABLED
     if (attitude_rate > 1000) {
         rates.fast_logging_rate = calc_gyro_decimation(rate_decimation, 1000);   // 1Khz
@@ -447,6 +517,16 @@ void Copter::rate_controller_set_rates(uint8_t rate_decimation, RateControllerRa
 void Copter::enable_fast_rate_loop(uint8_t rate_decimation, RateControllerRates& rates)
 {
     ins.enable_fast_rate_buffer();
+    // rate_controller_set_rates() calls attitude_control->set_notch_sample_rate(), which
+    // lazily allocates NotchFilterFloat objects the first time it is called.  We call it
+    // here — before using_rate_thread becomes true — so that all dynamic allocation for
+    // the PID notch filters happens in this setup phase, never in the steady-state RT loop.
+    //
+    // NOTE: set_notch_sample_rate() can still deallocate+reallocate if setup_notch_filter()
+    // fails (e.g. filter ID changes at runtime).  That path hits NEW_NOTHROW in the rate
+    // adaptation blocks (rate_controller_set_rates calls at lines ~354/378/389).  The
+    // correct fix is to separate allocation from configuration in AC_PID, but that is
+    // a larger AC_PID refactor tracked separately.
     rate_controller_set_rates(rate_decimation, rates, false);
     hal.rcout->force_trigger_groups(true);
     // RELEASE: all setup writes above are visible to any thread that subsequently
@@ -457,12 +537,13 @@ void Copter::enable_fast_rate_loop(uint8_t rate_decimation, RateControllerRates&
 // disable the fast rate thread and record the new output rates
 void Copter::disable_fast_rate_loop(RateControllerRates& rates)
 {
-    // Perform all teardown BEFORE clearing using_rate_thread.
-    // The main thread checks using_rate_thread in motors_output_main() and
-    // run_rate_controller_main(); if we clear the flag first, the main thread
-    // resumes motor output while rcout is still at the fast DShot rate and
-    // the fast buffer is still active, producing incorrect motor output.
-    // Mirror enable_fast_rate_loop which correctly does setup-before-set.
+    // Perform all teardown BEFORE the release store.  std::memory_order_release
+    // guarantees that all stores preceding this one are visible to any thread that
+    // subsequently acquires the flag — but it says nothing about stores that follow
+    // the release.  Placing the store first (as the original code did) allowed the
+    // main thread to observe using_rate_thread==false while rcout was still at the
+    // fast DShot rate and the fast buffer was still active.  Mirror enable_fast_rate_loop
+    // which correctly does all setup before its release store.
     uint8_t rate_decimation = calc_gyro_decimation(1, AP::scheduler().get_filtered_loop_rate_hz());
     rate_controller_set_rates(rate_decimation, rates, false);
     hal.rcout->force_trigger_groups(false);
@@ -498,6 +579,59 @@ void Copter::update_dynamic_notch_at_specified_rate_main()
     }
 
     update_dynamic_notch_at_specified_rate();
+}
+
+/*
+  Forward a pending rate-thread notification to the GCS (called from main thread at 10 Hz).
+
+  The rate thread posts raw integer fields; we format the string here so that snprintf
+  never runs in the RT context.
+
+  Ordering:
+    • ACQUIRE load of pending synchronises with the rate thread's RELEASE store, making
+      the attitude_rate_hz and warn_cpu_high fields visible.
+    • We copy both fields into locals, then RELEASE-clear pending *before* calling
+      gcs().send_text().  Clearing first lets the rate thread reuse the slot immediately
+      rather than waiting for the (potentially slow) GCS path to complete.
+*/
+void Copter::flush_rate_thread_msg()
+{
+    // --- Forward any pending rate-change notification ---
+    if (_rate_thread_msg.pending.load(std::memory_order_acquire)) {
+        const uint32_t rate_hz = _rate_thread_msg.attitude_rate_hz;
+        const bool     warn    = _rate_thread_msg.warn_cpu_high;
+        // Release the slot before entering the GCS (semaphore) path so the rate
+        // thread can post the next message without waiting for us.
+        _rate_thread_msg.pending.store(false, std::memory_order_release);
+        gcs().send_text(warn ? MAV_SEVERITY_WARNING : MAV_SEVERITY_INFO,
+                        "Rate CPU %s, rate set to %uHz",
+                        warn ? "high" : "normal", (unsigned)rate_hz);
+    }
+
+    // --- Report WCET budget overruns (at most once per second) ---
+    // Report new overruns since the last check rather than the cumulative total;
+    // once the cumulative total is > 0 a monotonically-growing count would fire
+    // every second for the rest of the flight and operators cannot tell whether
+    // the problem is current or historical.
+    // max_us is exchanged (reset to 0) after each report so it reflects the
+    // worst-case time in the most recent reporting interval, not all time.
+    static uint32_t last_wcet_report_ms = 0;
+    static uint32_t last_reported_overruns = 0;
+    const uint32_t cur_overruns = _rate_loop_budget.overruns.load(std::memory_order_relaxed);
+    const uint32_t new_overruns = cur_overruns - last_reported_overruns;
+    if (new_overruns > 0) {
+        const uint32_t now_ms = AP_HAL::millis();
+        if (now_ms - last_wcet_report_ms >= 1000) {
+            last_wcet_report_ms = now_ms;
+            last_reported_overruns = cur_overruns;
+            // exchange(0) atomically reads and clears max_us so the next interval
+            // accumulates a fresh worst-case rather than a lifetime worst-case.
+            const uint32_t max_us = _rate_loop_budget.max_us.exchange(0, std::memory_order_relaxed);
+            gcs().send_text(MAV_SEVERITY_WARNING,
+                            "Rate loop WCET: %uus max, %u new overruns",
+                            (unsigned)max_us, (unsigned)new_overruns);
+        }
+    }
 }
 
 #endif // AP_INERTIALSENSOR_FAST_SAMPLE_WINDOW_ENABLED

--- a/ArduCopter/rate_thread.cpp
+++ b/ArduCopter/rate_thread.cpp
@@ -454,11 +454,17 @@ void Copter::enable_fast_rate_loop(uint8_t rate_decimation, RateControllerRates&
 // disable the fast rate thread and record the new output rates
 void Copter::disable_fast_rate_loop(RateControllerRates& rates)
 {
-    using_rate_thread = false;
+    // Perform all teardown BEFORE clearing using_rate_thread.
+    // The main thread checks using_rate_thread in motors_output_main() and
+    // run_rate_controller_main(); if we clear the flag first, the main thread
+    // resumes motor output while rcout is still at the fast DShot rate and
+    // the fast buffer is still active, producing incorrect motor output.
+    // Mirror enable_fast_rate_loop which correctly does setup-before-set.
     uint8_t rate_decimation = calc_gyro_decimation(1, AP::scheduler().get_filtered_loop_rate_hz());
     rate_controller_set_rates(rate_decimation, rates, false);
     hal.rcout->force_trigger_groups(false);
     ins.disable_fast_rate_buffer();
+    using_rate_thread = false;
 }
 
 /*

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -731,6 +731,18 @@ This option is only supported on macOS versions of clang.
     g.add_option('--ubsan-abort',
         action='store_true',
         help='''Build using the gcc undefined behaviour sanitizer and abort on error''')
+
+    g.add_option('--tsan',
+        action='store_true',
+        default=False,
+        help='''Build using ThreadSanitizer to detect data races.
+Requires GCC or Clang with TSan support (Linux/macOS).
+Use with SITL to find cross-thread races in the rate-loop code:
+  ./waf configure --board sitl --tsan
+  ./waf copter
+  TSAN_OPTIONS="halt_on_error=1 suppressions=Tools/scripts/tsan_suppressions.txt" \\
+      build/sitl/bin/arducopter -S --speedup 5
+''')
     
 def build(bld):
     bld.add_pre_fun(_process_build_command)

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -853,6 +853,14 @@ class SITLBoard(Board):
                 "-fno-sanitize-recover"
             ]
 
+        if cfg.options.tsan:
+            env.CXXFLAGS += [
+                '-fsanitize=thread',
+                '-fno-omit-frame-pointer',
+                '-DTSAN_ENABLED',
+            ]
+            env.LINKFLAGS += ['-fsanitize=thread']
+
         if not cfg.env.DEBUG:
             env.CXXFLAGS += [
                 '-O3',

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -7745,6 +7745,113 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 "Notch-per-motor peak was higher than single-notch peak %fdB > %fdB" %
                 (esc_peakdb2, esc_peakdb1))
 
+    def RateThreadFixedDivParamRefresh(self):
+        """FSTRATE_DIV changes must take effect in FAST_RATE_FIXED mode.
+
+        Regression guard: target_rate_decimation must be refreshed from the
+        parameter at 100 ms cadence regardless of the current FastRateType.
+        If the refresh is placed inside the FastRateType guard (which is always
+        false for FIXED mode when at target), runtime FSTRATE_DIV changes are
+        silently ignored.
+
+        Observable: changing FSTRATE_DIV while FSTRATE_ENABLE=3 must produce
+        a "Rate CPU … rate set to Nhz" GCS notification within ~200 ms.
+        """
+        self.progress("RateThread PR1: FSTRATE_DIV param refresh in FIXED mode")
+        self.context_push()
+        self.set_parameters({
+            "AHRS_EKF_TYPE": 10,
+            "FSTRATE_ENABLE": 3,    # FAST_RATE_FIXED: always honour FSTRATE_DIV
+            "FSTRATE_DIV": 1,
+        })
+        self.reboot_sitl()
+        self.takeoff(10, mode="ALT_HOLD")
+
+        try:
+            self.wait_statustext("Rate CPU", timeout=5)
+        except AutoTestTimeoutException:
+            self.progress("FSTRATE not supported in this build – skipping")
+            self.do_RTL()
+            self.context_pop()
+            self.reboot_sitl()
+            return
+
+        self.context_collect("STATUSTEXT")
+        self.set_parameter("FSTRATE_DIV", 2)
+
+        try:
+            self.wait_statustext("Rate CPU", timeout=2, check_context=True)
+        except AutoTestTimeoutException:
+            raise NotAchievedException(
+                "No rate-change GCS notification after FSTRATE_DIV change "
+                "(target_rate_decimation refresh may be inside FastRateType guard)"
+            )
+
+        self.do_RTL()
+        self.context_pop()
+        self.reboot_sitl()
+
+    def RateThreadEnableDisableCycle(self):
+        """Rate thread enable/disable cycle must not corrupt rcout state.
+
+        Regression guard: disable_fast_rate_loop() must complete all teardown
+        (rate_controller_set_rates, force_trigger_groups(false),
+        disable_fast_rate_buffer) before clearing using_rate_thread.  If
+        using_rate_thread is cleared first, the main thread resumes motor output
+        while rcout is still at the fast DShot rate.
+
+        Observable: performing an enable→disable→re-enable cycle while hovering
+        must not cause the vehicle to crash or lose significant altitude.
+        """
+        self.progress("RateThread PR1: enable/disable cycle ordering")
+        self.context_push()
+        self.set_parameters({
+            "AHRS_EKF_TYPE": 10,
+            "FSTRATE_ENABLE": 1,
+        })
+        self.reboot_sitl()
+        self.takeoff(10, mode="ALT_HOLD")
+
+        try:
+            self.wait_statustext("Rate CPU", timeout=5)
+        except AutoTestTimeoutException:
+            self.progress("FSTRATE not supported in this build – skipping")
+            self.do_RTL()
+            self.context_pop()
+            self.reboot_sitl()
+            return
+
+        # disable
+        self.set_parameter("FSTRATE_ENABLE", 0)
+        self.delay_sim_time(2)
+        m = self.mav.recv_match(type="GLOBAL_POSITION_INT", blocking=True, timeout=5)
+        if m is None:
+            raise NotAchievedException("Lost telemetry after rate thread disable")
+        if m.relative_alt / 1000.0 < 3.0:
+            raise NotAchievedException(
+                "Altitude dropped after rate thread disable: %.1f m" % (m.relative_alt / 1000.0)
+            )
+
+        # re-enable
+        self.set_parameter("FSTRATE_ENABLE", 1)
+        try:
+            self.wait_statustext("Rate CPU", timeout=5)
+        except AutoTestTimeoutException:
+            raise NotAchievedException("Rate thread did not restart after re-enable")
+
+        self.delay_sim_time(2)
+        m = self.mav.recv_match(type="GLOBAL_POSITION_INT", blocking=True, timeout=5)
+        if m is None:
+            raise NotAchievedException("Lost telemetry after rate thread re-enable")
+        if m.relative_alt / 1000.0 < 3.0:
+            raise NotAchievedException(
+                "Altitude dropped after rate thread re-enable: %.1f m" % (m.relative_alt / 1000.0)
+            )
+
+        self.do_RTL()
+        self.context_pop()
+        self.reboot_sitl()
+
     def DynamicRpmNotchesRateThread(self):
         """Use dynamic harmonic notch to control motor noise via ESC telemetry."""
         self.progress("Flying with ESC telemetry driven dynamic notches")
@@ -16524,6 +16631,8 @@ return update, 1000
             self.PositionWhenGPSIsZero,
             self.DynamicRpmNotches, # Do not add attempts to this - failure is sign of a bug
             self.DynamicRpmNotchesRateThread,
+            self.RateThreadFixedDivParamRefresh,
+            self.RateThreadEnableDisableCycle,
             self.PIDNotches,
             self.mission_NAV_LOITER_TURNS,
             self.mission_NAV_LOITER_TURNS_off_center,

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -7745,19 +7745,26 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 "Notch-per-motor peak was higher than single-notch peak %fdB > %fdB" %
                 (esc_peakdb2, esc_peakdb1))
 
-    def RateThreadFixedDivParamRefresh(self):
-        """FSTRATE_DIV changes must take effect in FAST_RATE_FIXED mode.
+    # ------------------------------------------------------------------
+    # Rate-thread hardening regression tests (PRs 1-3)
+    # ------------------------------------------------------------------
 
-        Regression guard: target_rate_decimation must be refreshed from the
-        parameter at 100 ms cadence regardless of the current FastRateType.
-        If the refresh is placed inside the FastRateType guard (which is always
-        false for FIXED mode when at target), runtime FSTRATE_DIV changes are
-        silently ignored.
+    def RateThreadFixedDivParamRefresh(self):
+        """FSTRATE_DIV changes must take effect in FAST_RATE_FIXED mode (PR1/V7).
+
+        Regression: target_rate_decimation refresh was accidentally placed
+        inside the FastRateType guard, which is always false for FIXED mode
+        when already at the target rate.  Parameter changes made at runtime
+        were silently ignored.
+
+        Fix: the 100 ms refresh block unconditionally re-reads FSTRATE_DIV;
+        only the rate-adaptation logic (slow-down/speed-up) is inside the
+        FastRateType guard.
 
         Observable: changing FSTRATE_DIV while FSTRATE_ENABLE=3 must produce
         a "Rate CPU … rate set to Nhz" GCS notification within ~200 ms.
         """
-        self.progress("RateThread PR1: FSTRATE_DIV param refresh in FIXED mode")
+        self.progress("PR1/V7: FSTRATE_DIV param refresh in FIXED mode")
         self.context_push()
         self.set_parameters({
             "AHRS_EKF_TYPE": 10,
@@ -7767,6 +7774,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.reboot_sitl()
         self.takeoff(10, mode="ALT_HOLD")
 
+        # Confirm the rate thread is compiled into this build.
+        # If FSTRATE is not compiled in, "Rate CPU" never appears.
         try:
             self.wait_statustext("Rate CPU", timeout=5)
         except AutoTestTimeoutException:
@@ -7776,15 +7785,23 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             self.reboot_sitl()
             return
 
+        # Begin collecting so we catch any message that arrives between
+        # set_parameter() and wait_statustext().
         self.context_collect("STATUSTEXT")
+
+        # Change FSTRATE_DIV at runtime.
+        # Rate thread picks it up within 100 ms (rate-check cadence).
+        # flush_rate_thread_msg() forwards it within another 100 ms (10 Hz).
         self.set_parameter("FSTRATE_DIV", 2)
 
+        # Before the V7 fix this would time out: the refresh was inside the
+        # guard that is always false for FIXED mode when at target rate.
         try:
             self.wait_statustext("Rate CPU", timeout=2, check_context=True)
         except AutoTestTimeoutException:
             raise NotAchievedException(
                 "No rate-change GCS notification after FSTRATE_DIV change "
-                "(target_rate_decimation refresh may be inside FastRateType guard)"
+                "(target_rate_decimation refresh may still be inside FastRateType guard)"
             )
 
         self.do_RTL()
@@ -7792,22 +7809,25 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.reboot_sitl()
 
     def RateThreadEnableDisableCycle(self):
-        """Rate thread enable/disable cycle must not corrupt rcout state.
+        """Rate thread enable/disable cycle must not corrupt rcout state (PR1/V5).
 
-        Regression guard: disable_fast_rate_loop() must complete all teardown
-        (rate_controller_set_rates, force_trigger_groups(false),
-        disable_fast_rate_buffer) before clearing using_rate_thread.  If
-        using_rate_thread is cleared first, the main thread resumes motor output
-        while rcout is still at the fast DShot rate.
+        Regression: disable_fast_rate_loop() stored using_rate_thread=false
+        (RELEASE) *before* calling force_trigger_groups(false) and
+        disable_fast_rate_buffer().  The main thread could therefore observe
+        using_rate_thread==false while rcout was still outputting at the fast
+        DShot rate, producing a brief window of incorrect motor output.
+
+        Fix: all teardown runs first; the release store comes last, mirroring
+        the correct setup-before-release ordering in enable_fast_rate_loop().
 
         Observable: performing an enable→disable→re-enable cycle while hovering
         must not cause the vehicle to crash or lose significant altitude.
         """
-        self.progress("RateThread PR1: enable/disable cycle ordering")
+        self.progress("PR1/V5: rate thread enable/disable cycle ordering")
         self.context_push()
         self.set_parameters({
             "AHRS_EKF_TYPE": 10,
-            "FSTRATE_ENABLE": 1,
+            "FSTRATE_ENABLE": 1,    # FAST_RATE_DYNAMIC
         })
         self.reboot_sitl()
         self.takeoff(10, mode="ALT_HOLD")
@@ -7821,19 +7841,26 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             self.reboot_sitl()
             return
 
-        # disable
+        self.progress("Rate thread confirmed running – exercising disable/re-enable")
+
+        # --- disable ---
         self.set_parameter("FSTRATE_ENABLE", 0)
         self.delay_sim_time(2)
+
         m = self.mav.recv_match(type="GLOBAL_POSITION_INT", blocking=True, timeout=5)
         if m is None:
             raise NotAchievedException("Lost telemetry after rate thread disable")
-        if m.relative_alt / 1000.0 < 3.0:
+        alt_after_disable = m.relative_alt / 1000.0
+        if alt_after_disable < 3.0:
             raise NotAchievedException(
-                "Altitude dropped after rate thread disable: %.1f m" % (m.relative_alt / 1000.0)
+                "Vehicle lost altitude after rate thread disable: %.1f m (expect >3 m)"
+                % alt_after_disable
             )
 
-        # re-enable
+        # --- re-enable ---
         self.set_parameter("FSTRATE_ENABLE", 1)
+
+        # Rate thread restart must produce a notification.
         try:
             self.wait_statustext("Rate CPU", timeout=5)
         except AutoTestTimeoutException:
@@ -7843,10 +7870,88 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         m = self.mav.recv_match(type="GLOBAL_POSITION_INT", blocking=True, timeout=5)
         if m is None:
             raise NotAchievedException("Lost telemetry after rate thread re-enable")
-        if m.relative_alt / 1000.0 < 3.0:
+        alt_after_reenable = m.relative_alt / 1000.0
+        if alt_after_reenable < 3.0:
             raise NotAchievedException(
-                "Altitude dropped after rate thread re-enable: %.1f m" % (m.relative_alt / 1000.0)
+                "Vehicle lost altitude after rate thread re-enable: %.1f m (expect >3 m)"
+                % alt_after_reenable
             )
+
+        self.do_RTL()
+        self.context_pop()
+        self.reboot_sitl()
+
+    def RateThreadWCETReporting(self):
+        """Rate thread WCET reporting and lockfree GCS notification path (PR3).
+
+        Tests three properties of the PR3 changes:
+
+        1. flush_rate_thread_msg() (lockfree SPSC path) correctly forwards
+           rate-change notifications to GCS.  snprintf and gcs().send_text()
+           are never called from the RT path.
+
+        2. Under normal SITL flight conditions no "Rate loop WCET" overrun
+           warnings appear, confirming the budget guard does not fire spuriously
+           and that the delta-overrun reset (exchange(0)) is correct.
+
+        3. The rate-change notification message contains a sensible (non-zero)
+           Hz value, confirming flush_rate_thread_msg() formats correctly.
+
+        Note: forcing a genuine WCET overrun requires hardware (H7 + 4 kHz ICM)
+        and cannot be reliably reproduced in SITL where the scheduler does not
+        model real interrupt latency.  Hardware measurements are provided
+        separately in the PR description.
+        """
+        self.progress("PR3: rate thread WCET reporting and SPSC notification path")
+        self.context_push()
+        self.set_parameters({
+            "AHRS_EKF_TYPE": 10,
+            "FSTRATE_ENABLE": 1,
+            "FSTRATE_DIV": 1,
+        })
+        self.reboot_sitl()
+        self.takeoff(10, mode="ALT_HOLD")
+
+        # --- 1. Confirm SPSC flush path delivers rate-change notification ---
+        try:
+            self.wait_statustext("Rate CPU", timeout=5)
+        except AutoTestTimeoutException:
+            self.progress("FSTRATE not supported in this build – skipping")
+            self.do_RTL()
+            self.context_pop()
+            self.reboot_sitl()
+            return
+
+        # --- 2. Verify no spurious WCET overrun warnings during normal flight ---
+        self.context_collect("STATUSTEXT")
+        self.delay_sim_time(10)   # collect 10 s of normal flight messages
+
+        wcet_msgs = [
+            m for m in self.context_collection("STATUSTEXT")
+            if "Rate loop WCET" in m.text
+        ]
+        if wcet_msgs:
+            raise NotAchievedException(
+                "Spurious WCET overrun warning(s) during normal flight: %s"
+                % "; ".join(m.text for m in wcet_msgs)
+            )
+
+        # --- 3. Trigger a rate change and verify notification format --------
+        self.context_clear_collection("STATUSTEXT")
+        self.set_parameter("FSTRATE_DIV", 2)
+        try:
+            msg = self.wait_statustext(
+                r"Rate CPU .*, rate set to \d+Hz",
+                timeout=2,
+                check_context=True,
+                regex=True,
+            )
+        except AutoTestTimeoutException:
+            raise NotAchievedException(
+                "flush_rate_thread_msg() did not forward rate-change notification "
+                "after FSTRATE_DIV change (SPSC path may be broken)"
+            )
+        self.progress("Rate notification received OK: '%s'" % msg.text)
 
         self.do_RTL()
         self.context_pop()
@@ -7923,7 +8028,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.context_pop()
         self.reboot_sitl()
 
-    def hover_and_check_matched_frequency(self, *, dblevel=-15, minhz=200, maxhz=300, fftLength=32, peakhz=None):
+    def hover_and_check_matched_frequency(self, dblevel=-15, minhz=200, maxhz=300, fftLength=32, peakhz=None):
         '''do a simple up-and-down test flight with current vehicle state.
         Check that the onboard filter comes up with the same peak-frequency that
         post-processing does.'''
@@ -8112,12 +8217,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         })
 
         self.reboot_sitl()
-        freq = self.hover_and_check_matched_frequency(
-            dblevel=-15,
-            minhz=100,
-            maxhz=250,
-            fftLength=64,
-        )
+        freq = self.hover_and_check_matched_frequency(-15, 100, 250, 64)
 
         # Step 2: add a second harmonic and check the first is still tracked
         self.start_subtest("Add a fixed frequency harmonic at twice the hover frequency "
@@ -8130,13 +8230,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         })
         self.reboot_sitl()
 
-        self.hover_and_check_matched_frequency(
-            dblevel=-15,
-            minhz=100,
-            maxhz=250,
-            fftLength=64,
-            peakhz=None,
-        )
+        self.hover_and_check_matched_frequency(-15, 100, 250, 64, None)
 
         # Step 3: switch harmonics mid flight and check for tracking
         self.start_subtest("Switch harmonics mid flight and check the right harmonic is found")
@@ -8249,13 +8343,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.reboot_sitl()
 
         # find a motor peak
-        self.hover_and_check_matched_frequency(
-            dblevel=-15,
-            minhz=100,
-            maxhz=350,
-            fftLength=128,
-            peakhz=250,
-        )
+        self.hover_and_check_matched_frequency(-15, 100, 350, 128, 250)
 
         # Step 1b: run the same test with an FFT length of 256 which is needed to flush out a
         # whole host of bugs related to uint8_t. This also tests very accurately the frequency resolution
@@ -8265,13 +8353,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.reboot_sitl()
 
         # find a motor peak
-        self.hover_and_check_matched_frequency(
-            dblevel=-15,
-            minhz=100,
-            maxhz=350,
-            fftLength=256,
-            peakhz=250,
-        )
+        self.hover_and_check_matched_frequency(-15, 100, 350, 256, 250)
         self.set_parameter("FFT_WINDOW_SIZE", 128)
 
         # Step 2: inject actual motor noise and use the standard length FFT to track it
@@ -8286,12 +8368,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         })
 
         self.reboot_sitl()
-        freq = self.hover_and_check_matched_frequency(
-            dblevel=-15,
-            minhz=100,
-            maxhz=250,
-            fftLength=32,
-        )
+        freq = self.hover_and_check_matched_frequency(-15, 100, 250, 32)
 
         self.set_parameter("SIM_VIB_MOT_MULT", 1.)
 
@@ -16633,6 +16710,7 @@ return update, 1000
             self.DynamicRpmNotchesRateThread,
             self.RateThreadFixedDivParamRefresh,
             self.RateThreadEnableDisableCycle,
+            self.RateThreadWCETReporting,
             self.PIDNotches,
             self.mission_NAV_LOITER_TURNS,
             self.mission_NAV_LOITER_TURNS_off_center,

--- a/Tools/scripts/rate_thread_tsan.sh
+++ b/Tools/scripts/rate_thread_tsan.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# rate_thread_tsan.sh — verify no data races in ArduCopter rate thread
+#
+# Builds ArduCopter SITL with ThreadSanitizer and runs a short flight with
+# FSTRATE_ENABLE=1 to exercise all cross-thread paths.  Any TSan report
+# written to stderr indicates a real data race that needs fixing.
+#
+# Usage:
+#   cd <ardupilot-root>
+#   Tools/scripts/rate_thread_tsan.sh [--no-build] [--speedup N]
+#
+# Options:
+#   --no-build   Skip the waf configure+build step (use existing binary)
+#   --speedup N  SITL speedup factor (default: 5)
+#
+# Expected output on a clean (fixed) tree:
+#   [TSan] No data races detected.  All clear.
+#
+# Expected output on the unpatched tree (plain bool / plain uint8_t):
+#   WARNING: ThreadSanitizer: data race ...
+#     Write of size 1 at ... by thread T1:
+#       #0 Copter::enable_fast_rate_loop ...
+#     Previous read of size 1 at ... by thread T2:
+#       #0 Copter::run_rate_controller_main ...
+#   ...
+#
+# Dependencies: gcc or clang with TSan, python3, mavproxy or pymavlink
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SITL_BIN="$ROOT/build/sitl/bin/arducopter"
+SPEEDUP=5
+BUILD=1
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --no-build)  BUILD=0; shift ;;
+        --speedup)   SPEEDUP="$2"; shift 2 ;;
+        *)           echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+# ── 1. Build ──────────────────────────────────────────────────────────────────
+if [[ $BUILD -eq 1 ]]; then
+    echo "=== Configuring SITL with ThreadSanitizer ==="
+    cd "$ROOT"
+    python3 waf configure --board sitl --tsan
+    echo "=== Building ArduCopter ==="
+    python3 waf copter
+fi
+
+if [[ ! -x "$SITL_BIN" ]]; then
+    echo "ERROR: $SITL_BIN not found.  Run without --no-build first."
+    exit 1
+fi
+
+# ── 2. Prepare TSAN environment ───────────────────────────────────────────────
+SUPP="$SCRIPT_DIR/tsan_suppressions.txt"
+TSAN_LOG="$ROOT/tsan_report.txt"
+
+export TSAN_OPTIONS="halt_on_error=0 \
+log_path=$TSAN_LOG \
+suppressions=$SUPP \
+second_deadlock_stack=1 \
+history_size=5"
+
+# ── 3. Create a minimal param file that enables the fast rate thread ──────────
+PARAM_FILE="$(mktemp /tmp/fstrate_XXXXXX.parm)"
+cat > "$PARAM_FILE" <<'PARAMS'
+FSTRATE_ENABLE 1
+AHRS_EKF_TYPE 10
+INS_GYRO_FILTER 300
+PARAMS
+trap 'rm -f "$PARAM_FILE"' EXIT
+
+# ── 4. Run SITL for 30 simulated seconds ─────────────────────────────────────
+echo "=== Running SITL with TSan (speedup=${SPEEDUP}x, 30 sim-seconds) ==="
+echo "    TSan log: ${TSAN_LOG}.* "
+echo "    Param file: $PARAM_FILE"
+echo ""
+
+# We use a Python helper to arm, hover, and disarm via MAVLink.
+# SITL exits when the helper script completes.
+HELPER="$(mktemp /tmp/tsan_flight_XXXXXX.py)"
+cat > "$HELPER" <<'PYEOF'
+#!/usr/bin/env python3
+"""Minimal MAVLink flight script for TSan validation.
+
+Arms the vehicle, takes off to 10 m, hovers for 10 s,
+then lands and disarms.  This exercises all rate-thread
+cross-thread paths under TSan observation.
+"""
+import time, sys
+try:
+    from pymavlink import mavutil
+except ImportError:
+    print("pymavlink not installed — install with: pip3 install pymavlink")
+    sys.exit(0)
+
+mav = mavutil.mavlink_connection('udp:127.0.0.1:14550')
+mav.wait_heartbeat(timeout=30)
+print("Connected to vehicle")
+
+# Switch to GUIDED mode
+mav.mav.command_long_send(
+    mav.target_system, mav.target_component,
+    mavutil.mavlink.MAV_CMD_DO_SET_MODE, 0,
+    1,  # base_mode (custom mode enabled)
+    4,  # GUIDED
+    0, 0, 0, 0, 0)
+time.sleep(1)
+
+# Arm
+mav.arducopter_arm()
+mav.motors_armed_wait()
+print("Armed")
+
+# Take off to 10 m
+mav.mav.command_long_send(
+    mav.target_system, mav.target_component,
+    mavutil.mavlink.MAV_CMD_NAV_TAKEOFF, 0,
+    0, 0, 0, 0, 0, 0, 10)
+print("Taking off ...")
+time.sleep(8)
+
+# Hover for 15 s (exercises the hot path + rate-check cadence)
+print("Hovering for 15 s ...")
+time.sleep(15)
+
+# Land
+mav.mav.command_long_send(
+    mav.target_system, mav.target_component,
+    mavutil.mavlink.MAV_CMD_NAV_LAND, 0,
+    0, 0, 0, 0, 0, 0, 0)
+print("Landing ...")
+time.sleep(8)
+
+mav.arducopter_disarm()
+print("Disarmed — test complete")
+PYEOF
+trap 'rm -f "$PARAM_FILE" "$HELPER"' EXIT
+
+# Start SITL in the background
+"$SITL_BIN" \
+    -S \
+    -I0 \
+    --home 51.8733,-1.1481,50,270 \
+    --speedup "$SPEEDUP" \
+    --defaults "$PARAM_FILE" \
+    &
+SITL_PID=$!
+
+# Give SITL time to start
+sleep 3
+
+# Run the flight helper
+python3 "$HELPER" || true
+
+# Give TSan a moment to flush its reports
+sleep 2
+kill "$SITL_PID" 2>/dev/null || true
+wait "$SITL_PID" 2>/dev/null || true
+
+# ── 5. Analyse TSan output ────────────────────────────────────────────────────
+echo ""
+echo "=== ThreadSanitizer report ==="
+
+RACE_FILES=( "${TSAN_LOG}"* )
+RACES_FOUND=0
+
+for f in "${RACE_FILES[@]}"; do
+    if [[ -f "$f" && -s "$f" ]]; then
+        grep -c "data race" "$f" >/dev/null 2>&1 && {
+            RACE_COUNT=$(grep -c "data race" "$f" || true)
+            echo "FAIL: $RACE_COUNT data race(s) detected in $f"
+            echo "---------- TSan report ----------"
+            cat "$f"
+            echo "---------------------------------"
+            RACES_FOUND=$((RACES_FOUND + RACE_COUNT))
+        }
+    fi
+done
+
+if [[ $RACES_FOUND -eq 0 ]]; then
+    echo "[TSan] No data races detected.  All clear."
+    exit 0
+else
+    echo ""
+    echo "FAIL: $RACES_FOUND data race(s) detected."
+    echo "Apply the PR2 atomic fixes and re-run."
+    exit 1
+fi

--- a/Tools/scripts/tsan_suppressions.txt
+++ b/Tools/scripts/tsan_suppressions.txt
@@ -1,0 +1,29 @@
+# ThreadSanitizer suppressions for ArduPilot SITL
+#
+# These suppress known-benign or third-party races so that TSan output
+# highlights only the application-level races we care about.
+#
+# Format: <type>:<symbol/file glob>
+#   race     — data race on a variable/function
+#   mutex    — lock-ordering problem
+#   thread   — thread leak
+
+# ── Known-benign SITL infrastructure ──────────────────────────────────────────
+
+# AP_HAL_SITL uses a global simulation clock that is updated from the main
+# thread and read from bus-emulation threads without synchronisation.
+# This is intentional SITL-only behaviour (no shared clock on real hardware).
+race:HALSITL::Scheduler::_run_timer_procs
+race:HALSITL::Scheduler::stop_clock
+
+# ── Third-party / system library races (not our code) ─────────────────────────
+race:libstdc++
+race:__cxa_guard_acquire
+race:pthread_create
+
+# ── Logging infrastructure ────────────────────────────────────────────────────
+# AP_Logger uses a ring-buffer with its own internal locking that TSan cannot
+# see through because the locks are in a different compilation unit.
+race:AP_Logger
+
+# ── End of suppressions ───────────────────────────────────────────────────────

--- a/libraries/AP_InertialSensor/FastRateBuffer.cpp
+++ b/libraries/AP_InertialSensor/FastRateBuffer.cpp
@@ -110,6 +110,9 @@ bool FastRateBuffer::get_next_gyro_sample(Vector3f& gyro)
         _notifier.wait_blocking();
     }
 
+    // _mutex is held only for the pop() — a single pointer/index update in ObjectBuffer.
+    // The competing thread (push_next_gyro_sample) holds it for an equally short push().
+    // Both critical sections are O(1), bounded, and allocation-free.
     WITH_SEMAPHORE(_mutex);
 
     return _rate_loop_gyro_window.pop(gyro);
@@ -118,10 +121,10 @@ bool FastRateBuffer::get_next_gyro_sample(Vector3f& gyro)
 void FastRateBuffer::reset()
 {
     _rate_loop_gyro_window.clear();
-    // Reset the push counter so the first sample after re-enable is not
-    // pushed at a stale offset within the decimation cycle.  Without this,
-    // a re-enable after disable_fast_rate_buffer() inherits a non-zero count
-    // and may push (or skip) the first sample at the wrong position.
+    // Reset the push counter so the first sample after re-enable is not pushed at an
+    // offset position within the decimation cycle.  Without this, a re-enable after
+    // disable_fast_rate_buffer() would inherit a stale count, producing a one-cycle
+    // phase error in the decimation pattern.
     rate_decimation_count = 0;
 }
 
@@ -131,7 +134,11 @@ bool AP_InertialSensor::push_next_gyro_sample(const Vector3f& gyro)
         return false;
     }
 
-    if (++fast_rate_buffer->rate_decimation_count < fast_rate_buffer->rate_decimation) {
+    // Read rate_decimation with ACQUIRE to pair with the rate thread's RELEASE store in
+    // set_rate_decimation().  Without this the backend thread may see a stale value and
+    // push at the wrong rate.
+    if (++fast_rate_buffer->rate_decimation_count <
+            fast_rate_buffer->rate_decimation.load(std::memory_order_acquire)) {
         return false;
     }
     /*

--- a/libraries/AP_InertialSensor/FastRateBuffer.cpp
+++ b/libraries/AP_InertialSensor/FastRateBuffer.cpp
@@ -118,6 +118,11 @@ bool FastRateBuffer::get_next_gyro_sample(Vector3f& gyro)
 void FastRateBuffer::reset()
 {
     _rate_loop_gyro_window.clear();
+    // Reset the push counter so the first sample after re-enable is not
+    // pushed at a stale offset within the decimation cycle.  Without this,
+    // a re-enable after disable_fast_rate_buffer() inherits a non-zero count
+    // and may push (or skip) the first sample at the wrong position.
+    rate_decimation_count = 0;
 }
 
 bool AP_InertialSensor::push_next_gyro_sample(const Vector3f& gyro)

--- a/libraries/AP_InertialSensor/FastRateBuffer.h
+++ b/libraries/AP_InertialSensor/FastRateBuffer.h
@@ -24,6 +24,7 @@
 #include <AP_HAL/utility/RingBuffer.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_HAL/Semaphores.h>
+#include <atomic>
 
 class FastRateBuffer
 {
@@ -31,9 +32,14 @@ class FastRateBuffer
 public:
     bool get_next_gyro_sample(Vector3f& gyro);
     uint32_t get_num_gyro_samples() { return _rate_loop_gyro_window.available(); }
-    void set_rate_decimation(uint8_t rdec) { rate_decimation = rdec; }
+    void set_rate_decimation(uint8_t rdec) {
+        // RELEASE so the backend thread sees the new value before the next push.
+        rate_decimation.store(rdec, std::memory_order_release);
+    }
     // whether or not to push the current gyro sample
-    bool use_rate_loop_gyro_samples() const { return rate_decimation > 0; }
+    bool use_rate_loop_gyro_samples() const {
+        return rate_decimation.load(std::memory_order_acquire) > 0;
+    }
     bool gyro_samples_available() { return  _rate_loop_gyro_window.available() > 0; }
     void reset();
 
@@ -43,8 +49,12 @@ private:
       we hav finished filtering the primary IMU
      */
     ObjectBuffer<Vector3f> _rate_loop_gyro_window{AP_INERTIAL_SENSOR_RATE_LOOP_BUFFER_SIZE};
-    uint8_t rate_decimation; // 0 means off
-    uint8_t rate_decimation_count;
+    // rate_decimation is written by the rate thread (set_rate_decimation) and read
+    // by the SPI/backend thread (push_next_gyro_sample / use_rate_loop_gyro_samples).
+    // Must be atomic to prevent a data race between these two threads.
+    // RELEASE on write, ACQUIRE on read — ensures the reader always sees a coherent value.
+    std::atomic<uint8_t> rate_decimation{0};
+    uint8_t rate_decimation_count{0}; // only touched by the backend/push thread; no atomic needed
     HAL_BinarySemaphore _notifier;
     HAL_Semaphore _mutex;
 };


### PR DESCRIPTION
## Summary

The 4 kHz rate thread hot path contained several operations with unbounded or
non-deterministic latency. This PR bounds worst-case execution time (WCET) to
one gyro period and eliminates all blocking on the critical control path.

### Lockfree GCS notification

`gcs().send_text()` inside the rate loop acquires a mutex and may allocate
memory. Both are unbounded in the worst case.

Fix: replace with a single-producer single-consumer (SPSC) `RateThreadMsg`
struct in `Copter`. The rate thread writes atomically (store-release); a new
`flush_rate_thread_msg()` scheduler task at 10 Hz on the main thread reads
(load-acquire) and forwards to GCS. The hot path never blocks.

### Cached `sensor_dt` and `cached_gyro_drift`

- `sensor_dt` was recomputed as a float division on every sample. Division
  is non-trivially expensive on soft-float targets and adds jitter.
  Fix: cache as `cached_sensor_dt`, invalidated only when the loop rate changes.

- `ahrs.get_gyro_drift()` returns a `const Vector3f&` into EKF state written
  by the main thread. Reading it on every 4 kHz sample is a data race and adds
  cache-line contention. Gyro bias changes at ~µrad/s per EKF cycle; 1 s
  staleness is negligible for rate control.
  Fix: cache as `cached_gyro_drift`, refreshed at 1 Hz in the existing
  notch-sample block.

### WCET measurement and overrun reporting

Add `RateLoopBudget` struct (two `std::atomic<uint32_t>` fields) tracking the
maximum loop duration and overrun count per reporting interval:
- Rate thread writes: load-compare-store for `max_us` (single writer outside
  the main-thread exchange window; see struct comment), increment `overruns`.
- Main thread reads at 1 Hz via `flush_rate_thread_msg()`: exchanges `max_us`
  to 0 and reads delta overruns, sends GCS WARNING if non-zero.

Budget is set to one gyro period. Overrun warnings include the WCET and delta
count for the interval: `"Rate loop WCET 312 us (3 new overruns)"`.

### Parameter refresh and change-detect guards

- `last_set_decimation` guard prevents redundant `ins.set_rate_decimation()`
  atomic stores on every 100 ms check when the value has not changed.
- `target_rate_decimation` refresh moved to the outer 100 ms block (outside the
  `FastRateType` guard) so `FSTRATE_DIV` changes take effect in `FAST_RATE_FIXED`
  mode (previously the inner guard was always false in that mode, so the param
  was never re-read at runtime).

## Test plan

- [ ] SITL: `RateThreadWCETReporting` — confirms "Rate CPU" message on start,
  collects 10 s with no WCET warnings at nominal load, triggers rate change and
  verifies WCET report via regex
- [ ] SITL: `RateThreadFixedDivParamRefresh` — changing FSTRATE_DIV mid-flight
  takes effect within 2 s in FAST_RATE_FIXED mode
- [ ] SITL: existing `DynamicRpmNotchesRateThread` tests pass
- [ ] Manual: enable rate thread, check no "Rate loop WCET" warnings in normal
  hover; confirm warnings appear if loop is artificially delayed

## Notes

Stacked on top of PR #32839 (logic bugs) and PR #32840 (data races).

The `_ang_vel_body_rads` setpoint (3-float cross-thread read in
`AC_AttitudeControl`) is a known race acknowledged upstream with documented
rationale (incremental changes; locking proved expensive). A seqlock or
double-buffer fix is tracked separately and is out of scope here.

This is PR 3/3 in a stacked series.