### PR TITLE
Rover: use "velocity" (not speed) when a negative value is sensible

### DIFF
--- a/Rover/AP_ExternalControl_Rover.cpp
+++ b/Rover/AP_ExternalControl_Rover.cpp
@@ -22,10 +22,9 @@ bool AP_ExternalControl_Rover::set_linear_velocity_and_yaw_rate(const Vector3f &
     auto &ahrs = AP::ahrs();
     Vector3f linear_velocity_body = ahrs.earth_to_body(linear_velocity_ned_ms);
 
-    const float target_speed = linear_velocity_body.x;
     const float turn_rate_cds = isnan(yaw_rate_rads)? 0: degrees(yaw_rate_rads)*100;
 
-    rover.mode_guided.set_desired_turn_rate_and_speed(turn_rate_cds, target_speed);
+    rover.mode_guided.set_desired_turn_rate_and_velocity(turn_rate_cds, linear_velocity_body.x);
     return true;
 }
 

--- a/Rover/GCS_MAVLink_Rover.cpp
+++ b/Rover/GCS_MAVLink_Rover.cpp
@@ -622,16 +622,16 @@ void GCS_MAVLINK_Rover::handle_set_attitude_target(const mavlink_message_t &msg)
 
     // convert thrust to ground speed
     packet.thrust = constrain_float(packet.thrust, -1.0f, 1.0f);
-    const float target_speed = rover.control_mode->get_speed_default() * packet.thrust;
+    const float target_velocity = rover.control_mode->get_speed_default() * packet.thrust;
 
     // if the body_yaw_rate field is ignored, convert quaternion to heading
     if ((packet.type_mask & MAVLINK_SET_ATT_TYPE_MASK_YAW_RATE_IGNORE) != 0) {
         // convert quaternion to heading
         float target_heading_cd = degrees(Quaternion(packet.q[0], packet.q[1], packet.q[2], packet.q[3]).get_euler_yaw()) * 100.0f;
-        rover.mode_guided.set_desired_heading_and_speed(target_heading_cd, target_speed);
+        rover.mode_guided.set_desired_heading_and_velocity(target_heading_cd, target_velocity);
     } else {
         // use body_yaw_rate field
-        rover.mode_guided.set_desired_turn_rate_and_speed((RAD_TO_DEG * packet.body_yaw_rate) * 100.0f, target_speed);
+        rover.mode_guided.set_desired_turn_rate_and_velocity((RAD_TO_DEG * packet.body_yaw_rate) * 100.0f, target_velocity);
     }
 }
 
@@ -713,7 +713,7 @@ void GCS_MAVLINK_Rover::handle_set_position_target_local_ned(const mavlink_messa
     if (!vel_ignore) {
         const float speed_max = rover.control_mode->get_speed_default();
         // convert vector length into a speed
-        target_speed = constrain_float(safe_sqrt(sq(packet.vx) + sq(packet.vy)), -speed_max, speed_max);
+        target_speed = constrain_float(safe_sqrt(sq(packet.vx) + sq(packet.vy)), 0.0f, speed_max);
         // convert vector direction to target yaw
         target_yaw_cd = degrees(atan2f(packet.vy, packet.vx)) * 100.0f;
 
@@ -766,19 +766,19 @@ void GCS_MAVLINK_Rover::handle_set_position_target_local_ned(const mavlink_messa
 
     if (!vel_ignore && yaw_ignore && yaw_rate_ignore) {
         // consume velocity
-        rover.mode_guided.set_desired_heading_and_speed(target_yaw_cd, speed_dir * target_speed);
+        rover.mode_guided.set_desired_heading_and_velocity(target_yaw_cd, speed_dir * target_speed);
     } else if (!vel_ignore && yaw_ignore && !yaw_rate_ignore) {
         // consume velocity and turn rate
-        rover.mode_guided.set_desired_turn_rate_and_speed(target_turn_rate_cds, speed_dir * target_speed);
+        rover.mode_guided.set_desired_turn_rate_and_velocity(target_turn_rate_cds, speed_dir * target_speed);
     } else if (!vel_ignore && !yaw_ignore && yaw_rate_ignore) {
         // consume velocity and heading
-        rover.mode_guided.set_desired_heading_and_speed(target_yaw_cd, speed_dir * target_speed);
+        rover.mode_guided.set_desired_heading_and_velocity(target_yaw_cd, speed_dir * target_speed);
     } else if (vel_ignore && !yaw_ignore && yaw_rate_ignore) {
         // consume just target heading (probably only skid steering vehicles can do this)
-        rover.mode_guided.set_desired_heading_and_speed(target_yaw_cd, 0.0f);
+        rover.mode_guided.set_desired_heading_and_velocity(target_yaw_cd, 0.0f);
     } else if (vel_ignore && yaw_ignore && !yaw_rate_ignore) {
         // consume just turn rate (probably only skid steering vehicles can do this)
-        rover.mode_guided.set_desired_turn_rate_and_speed(target_turn_rate_cds, 0.0f);
+        rover.mode_guided.set_desired_turn_rate_and_velocity(target_turn_rate_cds, 0.0f);
     }
 }
 
@@ -876,19 +876,19 @@ void GCS_MAVLINK_Rover::handle_set_position_target_global_int(const mavlink_mess
 
     if (!vel_ignore && yaw_ignore && yaw_rate_ignore) {
         // consume velocity
-        rover.mode_guided.set_desired_heading_and_speed(target_yaw_cd, speed_dir * target_speed);
+        rover.mode_guided.set_desired_heading_and_velocity(target_yaw_cd, speed_dir * target_speed);
     } else if (!vel_ignore && yaw_ignore && !yaw_rate_ignore) {
         // consume velocity and turn rate
-        rover.mode_guided.set_desired_turn_rate_and_speed(target_turn_rate_cds, speed_dir * target_speed);
+        rover.mode_guided.set_desired_turn_rate_and_velocity(target_turn_rate_cds, speed_dir * target_speed);
     } else if (!vel_ignore && !yaw_ignore && yaw_rate_ignore) {
         // consume velocity
-        rover.mode_guided.set_desired_heading_and_speed(target_yaw_cd, speed_dir * target_speed);
+        rover.mode_guided.set_desired_heading_and_velocity(target_yaw_cd, speed_dir * target_speed);
     } else if (vel_ignore && !yaw_ignore && yaw_rate_ignore) {
         // consume just target heading (probably only skid steering vehicles can do this)
-        rover.mode_guided.set_desired_heading_and_speed(target_yaw_cd, 0.0f);
+        rover.mode_guided.set_desired_heading_and_velocity(target_yaw_cd, 0.0f);
     } else if (vel_ignore && yaw_ignore && !yaw_rate_ignore) {
         // consume just turn rate(probably only skid steering vehicles can do this)
-        rover.mode_guided.set_desired_turn_rate_and_speed(target_turn_rate_cds, 0.0f);
+        rover.mode_guided.set_desired_turn_rate_and_velocity(target_turn_rate_cds, 0.0f);
     }
 }
 

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -185,7 +185,7 @@ bool Rover::set_target_velocity_NED(const Vector3f& vel_ned_ms, bool align_yaw_t
     const float target_yaw_cd = degrees(atan2f(vel_ned_ms.y, vel_ned_ms.x)) * 100.0f;
 
     // send target heading and speed
-    mode_guided.set_desired_heading_and_speed(target_yaw_cd, target_speed_ms);
+    mode_guided.set_desired_heading_and_velocity(target_yaw_cd, target_speed_ms);
 
     return true;
 }
@@ -220,7 +220,7 @@ bool Rover::set_desired_turn_rate_and_speed(float turn_rate_degs, float speed_ms
     }
 
     // set turn rate and speed. Turn rate is expected in centidegrees/s and speed in meters/s
-    mode_guided.set_desired_turn_rate_and_speed(turn_rate_degs * 100.0f, speed_ms);
+    mode_guided.set_desired_turn_rate_and_velocity(turn_rate_degs * 100.0f, speed_ms);
     return true;
 }
 

--- a/Rover/mode.h
+++ b/Rover/mode.h
@@ -553,12 +553,9 @@ public:
     bool get_desired_location(Location& destination) const override WARN_IF_UNUSED;
     bool set_desired_location(const Location &destination, Location next_destination = Location()) override WARN_IF_UNUSED;
 
-    // set desired heading and speed
-    void set_desired_heading_and_speed(float yaw_angle_cd, float target_speed);
-
-    // set desired heading-delta, turn-rate and speed
-    void set_desired_heading_delta_and_speed(float yaw_delta_cd, float target_speed);
-    void set_desired_turn_rate_and_speed(float turn_rate_cds, float target_speed);
+    void set_desired_heading_and_velocity(float yaw_angle_cd, float target_velocity);
+    void set_desired_heading_delta_and_velocity(float yaw_delta_cd, float target_velocity);
+    void set_desired_turn_rate_and_velocity(float turn_rate_cds, float target_velocity);
 
     // set steering and throttle (-1 to +1).  Only called from scripts
     void set_steering_and_throttle(float steering, float throttle);
@@ -604,7 +601,7 @@ protected:
     uint32_t _des_att_time_ms;  // system time last call to set_desired_attitude was made (used for timeout)
     float _desired_yaw_rate_cds;// target turn rate centi-degrees per second
     bool send_notification;     // used to send one time notification to ground station
-    float _desired_speed;       // desired speed used only in HeadingAndSpeed submode
+    float _desired_velocity;
 
     // direct steering and throttle control
     bool _have_strthr;          // true if we have a valid direct steering and throttle inputs

--- a/Rover/mode.h
+++ b/Rover/mode.h
@@ -367,8 +367,7 @@ private:
     bool waiting_to_start;  // true if waiting for EKF origin before starting mission
     bool auto_triggered;        // true when auto has been triggered to start
 
-    // HeadingAndSpeed sub mode variables
-    float _desired_speed;   // desired speed in HeadingAndSpeed submode
+    float _desired_velocity;
     bool _reached_heading;  // true when vehicle has reached desired heading in TurnToHeading sub mode
 
     // Loiter control

--- a/Rover/mode_auto.cpp
+++ b/Rover/mode_auto.cpp
@@ -100,7 +100,7 @@ void ModeAuto::update()
             if (!_reached_heading) {
                 // run steering and throttle controllers
                 calc_steering_to_heading(_desired_yaw_cd);
-                calc_throttle(calc_speed_nudge(_desired_speed, is_negative(_desired_speed)), true);
+                calc_throttle(calc_speed_nudge(_desired_velocity, is_negative(_desired_velocity)), true);
                 // check if we have reached within 5 degrees of target
                 _reached_heading = (fabsf(_desired_yaw_cd - ahrs.yaw_sensor) < 500);
             } else {
@@ -356,7 +356,7 @@ bool ModeAuto::set_desired_speed(float speed_ms)
     case SubMode::Stop:
         return g2.wp_nav.set_speed_max(speed_ms);
     case SubMode::HeadingAndSpeed:
-        _desired_speed = speed_ms;
+        _desired_velocity = speed_ms;
         return true;
     case SubMode::RTL:
         return rover.mode_rtl.set_desired_speed(speed_ms);
@@ -812,7 +812,7 @@ void ModeAuto::do_nav_set_yaw_speed(const AP_Mission::Mission_Command& cmd)
 
     // set targets
     const float speed_max = g2.wp_nav.get_default_speed();
-    _desired_speed = constrain_float(cmd.content.set_yaw_speed.speed, -speed_max, speed_max);
+    _desired_velocity = constrain_float(cmd.content.set_yaw_speed.speed, -speed_max, speed_max);
     _desired_yaw_cd = desired_heading_cd;
     _reached_heading = false;
     _submode = SubMode::HeadingAndSpeed;

--- a/Rover/mode_guided.cpp
+++ b/Rover/mode_guided.cpp
@@ -59,7 +59,7 @@ void ModeGuided::update()
             if (have_attitude_target) {
                 // run steering and throttle controllers
                 calc_steering_to_heading(_desired_yaw_cd);
-                calc_throttle(calc_speed_nudge(_desired_speed, is_negative(_desired_speed)), true);
+                calc_throttle(calc_speed_nudge(_desired_velocity, is_negative(_desired_velocity)), true);
             } else {
                 // we have reached the destination so stay here
                 if (rover.is_boat()) {
@@ -87,7 +87,7 @@ void ModeGuided::update()
                                                                             g2.motors.limit.steer_right,
                                                                             rover.G_Dt);
                 set_steering(steering_out * 4500.0f);
-                calc_throttle(calc_speed_nudge(_desired_speed, is_negative(_desired_speed)), true);
+                calc_throttle(calc_speed_nudge(_desired_velocity, is_negative(_desired_velocity)), true);
             } else {
                 // we have reached the destination so stay here
                 if (rover.is_boat()) {
@@ -329,7 +329,7 @@ bool ModeGuided::set_desired_location(const Location &destination, Location next
 }
 
 // set desired attitude
-void ModeGuided::set_desired_heading_and_speed(float yaw_angle_cd, float target_speed)
+void ModeGuided::set_desired_heading_and_velocity(float yaw_angle_cd, float target_velocity)
 {
     // initialisation and logging
     _guided_mode = SubMode::HeadingAndSpeed;
@@ -337,27 +337,27 @@ void ModeGuided::set_desired_heading_and_speed(float yaw_angle_cd, float target_
 
     // record targets
     _desired_yaw_cd = yaw_angle_cd;
-    _desired_speed = target_speed;
+    _desired_velocity = target_velocity;
     have_attitude_target = true;
 
 #if HAL_LOGGING_ENABLED
     // log new target
-    rover.Log_Write_GuidedTarget((uint8_t)_guided_mode, Vector3f(_desired_yaw_cd, 0.0f, 0.0f), Vector3f(_desired_speed, 0.0f, 0.0f));
+    rover.Log_Write_GuidedTarget((uint8_t)_guided_mode, Vector3f(_desired_yaw_cd, 0.0f, 0.0f), Vector3f(_desired_velocity, 0.0f, 0.0f));
 #endif
 }
 
-void ModeGuided::set_desired_heading_delta_and_speed(float yaw_delta_cd, float target_speed)
+void ModeGuided::set_desired_heading_delta_and_velocity(float yaw_delta_cd, float target_velocity)
 {
     // handle initialisation
     if (_guided_mode != SubMode::HeadingAndSpeed) {
         _guided_mode = SubMode::HeadingAndSpeed;
         _desired_yaw_cd = ahrs.yaw_sensor;
     }
-    set_desired_heading_and_speed(wrap_180_cd(_desired_yaw_cd + yaw_delta_cd), target_speed);
+    set_desired_heading_and_velocity(wrap_180_cd(_desired_yaw_cd + yaw_delta_cd), target_velocity);
 }
 
-// set desired velocity
-void ModeGuided::set_desired_turn_rate_and_speed(float turn_rate_cds, float target_speed)
+// set desired velocity (angular & linear)
+void ModeGuided::set_desired_turn_rate_and_velocity(float turn_rate_cds, float target_velocity)
 {
     // handle initialisation
     _guided_mode = SubMode::TurnRateAndSpeed;
@@ -365,12 +365,12 @@ void ModeGuided::set_desired_turn_rate_and_speed(float turn_rate_cds, float targ
 
     // record targets
     _desired_yaw_rate_cds = turn_rate_cds;
-    _desired_speed = target_speed;
+    _desired_velocity = target_velocity;
     have_attitude_target = true;
 
 #if HAL_LOGGING_ENABLED
     // log new target
-    rover.Log_Write_GuidedTarget((uint8_t)_guided_mode, Vector3f(_desired_yaw_rate_cds, 0.0f, 0.0f), Vector3f(_desired_speed, 0.0f, 0.0f));
+    rover.Log_Write_GuidedTarget((uint8_t)_guided_mode, Vector3f(_desired_yaw_rate_cds, 0.0f, 0.0f), Vector3f(_desired_velocity, 0.0f, 0.0f));
 #endif
 }
 

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -986,26 +986,27 @@ void AR_AttitudeControl::get_srate(float &steering_srate, float &speed_srate)
     speed_srate = _throttle_speed_pid_info.slew_rate;
 }
 
-// get forward speed in m/s (earth-frame horizontal velocity but only along vehicle x-axis).  returns true on success
-bool AR_AttitudeControl::get_forward_speed(float &speed) const
+// get forward velocity in m/s (earth-frame horizontal velocity but only along vehicle x-axis).  returns true on success
+// FIXME: rename this as get_forward_velocity, since speed is always a positive quantity.
+bool AR_AttitudeControl::get_forward_speed(float &forward_velocity) const
 {
-    Vector3f velocity;
+    Vector3f velocity_NED;
     const AP_AHRS &_ahrs = AP::ahrs();
-    if (!_ahrs.get_velocity_NED(velocity)) {
+    if (!_ahrs.get_velocity_NED(velocity_NED)) {
         // use less accurate GPS, assuming entire length is along forward/back axis of vehicle
         if (AP::gps().status() >= AP_GPS_FixType::FIX_3D) {
             if (abs(wrap_180_cd(_ahrs.yaw_sensor - AP::gps().ground_course_cd())) <= 9000) {
-                speed = AP::gps().ground_speed();
+                forward_velocity = AP::gps().ground_speed();
             } else {
-                speed = -AP::gps().ground_speed();
+                forward_velocity = -AP::gps().ground_speed();
             }
             return true;
         } else {
             return false;
         }
     }
-    // calculate forward speed velocity into body frame
-    speed = velocity.x*_ahrs.cos_yaw() + velocity.y*_ahrs.sin_yaw();
+    // transform into body frame
+    forward_velocity = velocity_NED.x*_ahrs.cos_yaw() + velocity_NED.y*_ahrs.sin_yaw();
     return true;
 }
 

--- a/libraries/APM_Control/AR_AttitudeControl.h
+++ b/libraries/APM_Control/AR_AttitudeControl.h
@@ -106,8 +106,8 @@ public:
     // get the slew rate value for speed and steering for oscillation detection in lua scripts
     void get_srate(float &steering_srate, float &speed_srate);
 
-    // get forward speed in m/s (earth-frame horizontal velocity but only along vehicle x-axis).  returns true on success
-    bool get_forward_speed(float &speed) const;
+    // get forward velocity in m/s (earth-frame horizontal velocity but only along vehicle x-axis).  returns true on success
+    bool get_forward_speed(float &forward_velocity) const;
 
     // get throttle/speed controller maximum acceleration (also used for deceleration)
     float get_accel_max() const { return MAX(_throttle_accel_max, 0.0f); }


### PR DESCRIPTION
### Summary

Rename variables and functions to "velocity" when a negative value is reasonable/used.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

There are more modes to convert, but this is a start.

In case anyone is not familiar: Most (all?) references define speed as the magnitude of velocity. ([example](https://www.physicsclassroom.com/class/1dkin/lesson-1/speed-and-velocity)) In my experience, it is common to (mis)use the term "speed" when velocity, especially along-path or longitudinal velocity, is intended. I'm not proposing that we need to prioritize this issue, but it's worth fixing at an appropriate time.

In case it's helpful, I stumbled into this attempting to figure out "reverse" behavior. It will help clarify that code, because reverse can be tricky. (When in reverse, the 'forward' velocity is negative, but the along-path velocity is positive. That's atypical but easy to understand with a little clarity improvement.)

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
