### PR TITLE
More markdown cleanup - tree-wide spelling fixes and markup fixes

### DIFF
--- a/Tools/autotest/logger_metadata/README.md
+++ b/Tools/autotest/logger_metadata/README.md
@@ -22,7 +22,7 @@ For each vehicle type, the following files are generated:
 * **LogMessages.md** - Markdown format file (not used)
 * **LogMessages.rst** - reStructuredText format file - used for populating the Log Message
 
-pages of the Ardupilot website.
+pages of the ArduPilot website.
 
 * **LogMessages.xml** - XML file - used by tools such as MavExplorer to provide
 

--- a/Tools/scripts/check_branch_conventions.py
+++ b/Tools/scripts/check_branch_conventions.py
@@ -435,6 +435,7 @@ class CheckBranchConventions(build_script_base.BuildScriptBase):
             return True
 
         underline_re = re.compile(r'^([=\-~^#+*])\1{2,}$')
+        fence_re = re.compile(r'^(`{3,}|~{3,})')
         errors = []
         for path in changed_md.splitlines():
             path = path.strip()
@@ -442,9 +443,13 @@ class CheckBranchConventions(build_script_base.BuildScriptBase):
                 continue
             with open(path, encoding="utf-8", errors="replace") as fh:
                 prev_line = ""
+                in_fence = False
                 for lineno, raw in enumerate(fh, 1):
                     line = raw.rstrip("\n")
-                    if (underline_re.match(line)
+                    if fence_re.match(line):
+                        in_fence = not in_fence
+                    if (not in_fence
+                            and underline_re.match(line)
                             and len(line.strip()) == len(prev_line.strip())):
                         errors.append((path, lineno, line.strip()))
                     prev_line = line

--- a/Tools/vagrant/README.md
+++ b/Tools/vagrant/README.md
@@ -1,5 +1,5 @@
 # Vagrant for SITL and ardupilot development
 
-We support a vagrant container for _easily_ running SITL (software in the loop simulator) and compling Ardupilot code.
+We support a vagrant container for _easily_ running SITL (software in the loop simulator) and compiling ArduPilot code.
 
 Instructions for how to install and run this vagrant container are provided on the ArduPilot dev wiki in: [Setting up SITL using Vagrant](https://ardupilot.org/dev/docs/setting-up-sitl-using-vagrant.html).

--- a/libraries/AP_DDS/README.md
+++ b/libraries/AP_DDS/README.md
@@ -2,7 +2,7 @@
 
 ## Architecture
 
-Ardupilot contains the DDS Client library, which can run as SITL. Then, the DDS application runs a ROS 2 node, an eProsima Integration Service, and the MicroXRCE Agent. The two systems communicate over serial or UDP.
+ArduPilot contains the DDS Client library, which can run as SITL. Then, the DDS application runs a ROS 2 node, an eProsima Integration Service, and the MicroXRCE Agent. The two systems communicate over serial or UDP.
 
 ```mermaid
 ---
@@ -12,7 +12,7 @@ graph LR
 
   subgraph Linux Computer
 
-    subgraph Ardupilot SITL
+    subgraph ArduPilot SITL
       veh[sim_vehicle.py] <--> xrceClient[EProsima Micro XRCE DDS Client]
       xrceClient <--> port1[udp:2019]
     end
@@ -35,7 +35,7 @@ graph LR
 
   subgraph Linux Computer
 
-    subgraph Ardupilot SITL
+    subgraph ArduPilot SITL
       veh[sim_vehicle.py] <--> xrceClient[EProsima Micro XRCE DDS Client]
       xrceClient <--> port1[devUSB1]
     end
@@ -52,7 +52,7 @@ graph LR
 
 ## Installation
 
-While DDS support in Ardupilot is mostly through git submodules,
+While DDS support in ArduPilot is mostly through git submodules,
 you must install Micro XRCE DDS Gen and create a workspace.
 
 Follow the wiki [here](https://ardupilot.org/dev/docs/ros2.html)
@@ -97,7 +97,7 @@ param set DDS_ENABLE 0
 REBOOT
 ```
 
-## Using the ROS 2 CLI to Read Ardupilot Data
+## Using the ROS 2 CLI to Read ArduPilot Data
 
 After your setup is complete, do the following:
 
@@ -146,7 +146,7 @@ Next, follow the associated section for your chosen transport, and finally you c
 - Run SITL (remember to kill any terminals running ardupilot SITL beforehand)
 
   ```console
-  # assuming we are using /dev/pts/1 for Ardupilot SITL
+  # assuming we are using /dev/pts/1 for ArduPilot SITL
   sim_vehicle.py -v ArduPlane -DG --console --enable-DDS -A "--serial1=uart:/dev/pts/1"
   ```
 
@@ -310,9 +310,9 @@ publishing #1: ardupilot_msgs.msg.GlobalPosition(header=std_msgs.msg.Header(stam
 
 ## Contributing to `AP_DDS` library
 
-### Adding DDS messages to Ardupilot
+### Adding DDS messages to ArduPilot
 
-Unlike the use of ROS 2 `.msg` files, since Ardupilot supports native DDS, the message files follow [OMG IDL DDS v4.2](https://www.omg.org/spec/IDL/4.2/PDF).
+Unlike the use of ROS 2 `.msg` files, since ArduPilot supports native DDS, the message files follow [OMG IDL DDS v4.2](https://www.omg.org/spec/IDL/4.2/PDF).
 This package is intended to work with any `.idl` file complying with those extensions.
 
 Over time, these restrictions will ideally go away.

--- a/libraries/AP_HAL_ChibiOS/hwdef/AcctonGodwit_GA1/readme.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/AcctonGodwit_GA1/readme.md
@@ -53,7 +53,7 @@ Visit [Accton-IoT Godwit](https://www.accton-iot.com/godwit/) for more informati
 ## Where to Buy
 
 - [Accton-IoT Godwit](https://www.accton-iot.com/godwit/)
-- [sales@accton-iot.com](sales@accton-iot.com)
+- [sales@accton-iot.com](mailto:sales@accton-iot.com)
 
 ## Pinout
 
@@ -156,5 +156,5 @@ To upgrade firmware use any ArduPilot GCS.  Firmware for the Godwit G-A1 is loca
 ## More Information and Support
 
 - [Accton-IoT Godwit](https://www.accton-iot.com/godwit/)
-- [sales@accton-iot.com](sales@accton-iot.com)
-- [support@accton-iot.com](support@accton-iot.com)
+- [sales@accton-iot.com](mailto:sales@accton-iot.com)
+- [support@accton-iot.com](mailto:support@accton-iot.com)

--- a/libraries/AP_HAL_ChibiOS/hwdef/CrazyF405/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CrazyF405/README.md
@@ -42,7 +42,7 @@ The CrazyF405HDAIO is optimized for Digital HD FPV and does not require the anal
 
 ## PWM Output
 
-The Carzyf405HD AIO has 4 PWM outputs internally connected to its 4-in-1 ESC. The pads for motor output are M1 to M4 on the board. All 4 outputs support DShot, as well as all PWM types. The default configuration is for DShot using the already installed BlueJay firmware.
+The CrazyF405HD AIO has 4 PWM outputs internally connected to its 4-in-1 ESC. The pads for motor output are M1 to M4 on the board. All 4 outputs support DShot, as well as all PWM types. The default configuration is for DShot using the already installed BlueJay firmware.
 
 ## Battery Monitoring
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/F4BY_H743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/F4BY_H743/README.md
@@ -74,7 +74,7 @@ The UARTs are marked Rn and Tn in the above pinouts. The Rn pin is the receive p
 - RCin  PB0
 Using the RCin pin will support all unidirectional RC protocols. (PPM, SBUS, iBus, PPM-Sum, DSM,DSM2,DSM-X,SRXL and SUM-D)
 
-- USART2 for Bi-directional protocols (CRSF/ELRS,SRXL2,IRC Ghost, and FPort) see `here <https://ardupilot.org/sub/docs/common-rc-systems.html#common-rc-systems>`
+- USART2 for Bi-directional protocols (CRSF/ELRS,SRXL2,IRC Ghost, and FPort) see [here](https://ardupilot.org/sub/docs/common-rc-systems.html#common-rc-systems)
 
 ## PWM Output
 
@@ -159,7 +159,7 @@ The F4BY_H743 has a built-in compass. Due to potential interference, the autopil
 
 ## Firmware
 
-for F4BY_H743 can be found `here <https://firmware.ardupilot.org>`  in sub-folders labeled “F4BY_H743”.
+for F4BY_H743 can be found [here](https://firmware.ardupilot.org) in sub-folders labeled “F4BY_H743”.
 
 ## Loading Firmware
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/JHEMCU-GSF405A-RX2/readme.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/JHEMCU-GSF405A-RX2/readme.md
@@ -63,7 +63,7 @@ The GSF405A supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Motor Output
 
-The built-in ESC is mapped to motor outputs 1-4. Bidirectional DShot is supported (requires flashing the ESC to a BLHeli_S version that supports bdshot, such as [Bluejay](esc-configurator.com)).
+The built-in ESC is mapped to motor outputs 1-4. Bidirectional DShot is supported (requires flashing the ESC to a BLHeli_S version that supports bdshot, such as [Bluejay](https://esc-configurator.com)).
 
 ## Battery Monitoring
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MFE_PDB_CAN/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MFE_PDB_CAN/README.md
@@ -59,4 +59,4 @@ BATT_AMP_PERVLT 22.0
 
 ## Where to Buy
 
-[www.makeflyeasy.com](www.makeflyeasy.com)
+[www.makeflyeasy.com](https://www.makeflyeasy.com)

--- a/libraries/AP_HAL_ChibiOS/hwdef/MFE_POS3_CAN/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MFE_POS3_CAN/README.md
@@ -27,4 +27,4 @@ The MFE_POS3_CAN is sold by a range of resellers listed at [MakeFlyEasy](http://
 
 ## Where to Buy
 
-`makeflyeasy <http://www.makeflyeasy.com>`
+[makeflyeasy](http://www.makeflyeasy.com)

--- a/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743-Lite/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743-Lite/README.md
@@ -6,7 +6,7 @@ The MicoAir743-Lite is a flight controller designed and produced by [MicoAir Tec
 
 - STM32H743 microcontroller
 - ICM45686 IMU
-- Integrated BlueTooth module for telemetry
+- Integrated Bluetooth module for telemetry
 - SPA06 barometer
 - 9V 2A BEC; 5V 2A BEC
 - MicroSD Card Slot
@@ -26,7 +26,7 @@ The MicoAir743-Lite is a flight controller designed and produced by [MicoAir Tec
 - SERIAL5 -> UART5 (User, DMA-enabled)
 - SERIAL6 -> UART6 (RCIN, DMA-enabled)
 - SERIAL7 -> UART7 (RX only, ESC Telemetry, DMA-enabled)
-- SERIAL8 -> UART8 (MAVLink2, connected to on board BlueTooth module)
+- SERIAL8 -> UART8 (MAVLink2, connected to on board Bluetooth module)
 
 ## RC Input
 
@@ -90,9 +90,9 @@ The default battery parameters are:
 
 The MicoAir743-Lite doesn’t have a built-in compass sensor, but you can attach an external compass using I2C on the SDA and SCL connector.
 
-## BlueTooth
+## Bluetooth
 
-The MicoAir743-Lite has an on board BlueTooth module connected to UART8(SERIAL8). The BlueTooth id is MicoAir743-Lite-xxxxxx and you can connect to it without pairing id.
+The MicoAir743-Lite has an on board Bluetooth module connected to UART8(SERIAL8). The Bluetooth id is MicoAir743-Lite-xxxxxx and you can connect to it without pairing id.
 
 ## Mechanical
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743v2/README.md
@@ -6,7 +6,7 @@ The MicoAir743v2 is a flight controller designed and produced by [MicoAir Tech](
 
 - STM32H743 microcontroller
 - BMI088/BMI270 dual IMUs
-- Integrated BlueTooth module for telemetry
+- Integrated Bluetooth module for telemetry
 - SPL06 barometer
 - QMC5883L magnetometer
 - AT7456E OSD
@@ -31,7 +31,7 @@ The MicoAir743v2 is a flight controller designed and produced by [MicoAir Tech](
 - SERIAL5 -> UART5 (User, DMA-enabled)
 - SERIAL6 -> UART6 (RCIN, DMA-enabled)
 - SERIAL7 -> UART7 (RX only, ESC Telemetry, DMA-enabled)
-- SERIAL8 -> UART8 (MAVLink2, connected to on board BlueTooth module)
+- SERIAL8 -> UART8 (MAVLink2, connected to on board Bluetooth module)
 
 ## RC Input
 
@@ -93,9 +93,9 @@ The default battery parameters are:
 
 The MicoAir743v2 has a built-in compass sensor (QMC5883L), and you can also attach an external compass using I2C on the SDA and SCL connector.
 
-## BlueTooth
+## Bluetooth
 
-The MicoAir743v2 has an on board BlueTooth module connected to UART8(SERIAL8). The BlueTooth id is MicoAir743v2-xxxxxx and you can connect to it without pairing id.
+The MicoAir743v2 has an on board Bluetooth module connected to UART8(SERIAL8). The Bluetooth id is MicoAir743v2-xxxxxx and you can connect to it without pairing id.
 
 ## Mechanical
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/QioTekAdeptF407/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/QioTekAdeptF407/README.md
@@ -27,7 +27,7 @@ It is an autopilot used CKS MCU.
 
 ## Pinout
 
-![QioTek AdpetF407 Board](../QioTekAdeptF407/adept_f407.jpg "QioTek AdpetF407")
+![QioTek AdeptF407 Board](../QioTekAdeptF407/adept_f407.jpg "QioTek AdeptF407")
 
 ## Connectors
 
@@ -164,11 +164,11 @@ RC input is configured on the RCIN pin by PA15 TIM2_CH1 TIM2 , at one end of the
 
 ## OSD Support
 
-QioTek AdpetF407 supports OSD using OSD_TYPE 1 (MAX7456 driver).
+QioTek AdeptF407 supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## PWM Output
 
-The QioTek AdpetF407 AIO supports up to 12 PWM outputs. All 14 PWM outputs have GND on the top row, 5V on the middle row and signal on the bottom row.
+The QioTek AdeptF407 AIO supports up to 12 PWM outputs. All 14 PWM outputs have GND on the top row, 5V on the middle row and signal on the bottom row.
 
 The 12 PWM outputs are in 3 groups:
 
@@ -206,7 +206,7 @@ The built-in BEC 5V output has a starting voltage of 2S, and 9V/12V has a starti
 
 ## Compass
 
-The QioTek AdpetF407 has a builtin QMC5883 compass. Due to potential interference the board is usually used with an external I2C compass as part of a GPS/Compass combination.
+The QioTek AdeptF407 has a builtin QMC5883 compass. Due to potential interference the board is usually used with an external I2C compass as part of a GPS/Compass combination.
 
 ## Loading Firmware
 

--- a/libraries/AP_HAL_ESP32/README.md
+++ b/libraries/AP_HAL_ESP32/README.md
@@ -141,7 +141,7 @@ see `build/<board>/esp-idf_build/flash_project_args` (after building) for hints 
 ---
 OLD
 
-Alternatively, the "./waf plane' build outputs a python command that y can cut-n-paste to flash... buzz found that but using that command with a slower baudrate of 921600 instead of its recommended 2000000 worked for him:
+Alternatively, the "./waf plane' build outputs a python command that you can cut-n-paste to flash... buzz found that but using that command with a slower baudrate of 921600 instead of its recommended 2000000 worked for him:
 cd ardupilot
 python ./modules/esp_idf/components/esptool_py/esptool/esptool.py --chip esp32 --port /dev/ttyUSB0 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size detect 0xf000 ./build/esp32buzz/idf-plane/ota_data_initial.bin 0x1000 ./build/esp32buzz/idf-plane/bootloader/bootloader.bin 0x20000 ./build/esp32buzz/idf-plane/arduplane.bin 0x8000 ./build/esp32buzz/idf-plane/partitions.bin
 

--- a/libraries/AP_Scripting/applets/Aerobatics/FixedWing/README.md
+++ b/libraries/AP_Scripting/applets/Aerobatics/FixedWing/README.md
@@ -8,7 +8,7 @@ manoeuvres either in AUTO mission or by triggering using pilot commands
 using RC switches.
 
 As always, but particularly with scripted aerobatics, test in SITL until
-you understand the function and behaviour of each manouver. You will need
+you understand the function and behaviour of each manoeuvre. You will need
 an appropriate aircraft, and be ready to take manual control if necessary!
 
 ## Available Manoeuvres
@@ -59,13 +59,13 @@ Length = 100, num points = 4, hold fraction = 0.5, pts to do = 2.
 
 Remember, the model is now exiting inverted so the next maneuver must be planned to start from this position.
 
-Note: In the script you will find other (specialised) manouvers which do not appear in the
+Note: In the script you will find other (specialised) manoeuvres which do not appear in the
 'command table'. These are not intended to be used for 'tricks on a switch'. These
-manouvers are used in some of the schedules defined below.
+manoeuvres are used in some of the schedules defined below.
 
 Some are explained in the README.md file for the Schedules examples.
 
-## Available Schedules (pre-defined sequences of manouvers)
+## Available Schedules (pre-defined sequences of manoeuvres)
 
 See the Schedules subdirectory for a wide variety of pre-defined
 full aerobatic schedules you can use and instructions for how to
@@ -190,8 +190,8 @@ tracking. Some of the key parameters are:
 - AEROM_KE_RUDD : This is the required rudder percentage in knifeedge flight to hold height at cruise speed.
 - AEROM_KE_RUDD_LK : This is the time ahead in seconds that the anticipated rudder required will be applied
 - AEROM_ENTRY_RATE : roll rate in degrees per second for entering and exiting a roll change
-- AEROM_THR_MIN : minumum throttle percentage for all aerobatic maneuvers
-- AEROM_THR_BOOST: minumum throttle percentage for maneuvers marked as throttle boost
+- AEROM_THR_MIN : minimum throttle percentage for all aerobatic maneuvers
+- AEROM_THR_BOOST: minimum throttle percentage for maneuvers marked as throttle boost
 - AEROM_YAW_ACCEL: maximum yaw acceleration in degrees per second per second. Lower to soften yaw control
 - AEROM_BOX_WIDTH: the length of the aerobatic box whose center is defined by the start of a schedule
 - AEROM_PATH_SCALE: scale factor for all maneuvers. A value above 1.0 will increase the size of the maneuvers. A value below 1.0 will decrease the size. A negative value will mirror the maneuvers, allowing a sequence designed for left-to-right to be flown right-to-left.

--- a/libraries/AP_Scripting/applets/Aerobatics/FixedWing/RateBased/README.md
+++ b/libraries/AP_Scripting/applets/Aerobatics/FixedWing/RateBased/README.md
@@ -6,7 +6,7 @@ manoeuvres either in AUTO mission or by triggering using pilot commands
 using RC switches.
 
 As always, but particularly with scripted aerobatics, test in SITL until
-you understand the function and behaviour of each manouver. You will need
+you understand the function and behaviour of each manoeuvre. You will need
 an appropriate aircraft, and be ready to take manual control if necessary!
 
 These tricks are rate-based vs the precision trajectory-based manouvers of the script in the TrajectoryBased directory above this one. However, many planes have difficulty completing those tricks unless they can sustain extended vertical climbs and knife-edges, especially in wind. These tricks do not try to maintain a geospatial track, but rather, just attitude rates. Even planes that cannot hold the 90 deg knife edge trick, will probably hold the 180 deg (inverted) one and do loops and rolls, and these tricks can be done in even strong wind, although will not be well shaped.

--- a/libraries/AP_Scripting/applets/RockBlock.md
+++ b/libraries/AP_Scripting/applets/RockBlock.md
@@ -1,6 +1,6 @@
 # RockBlock Lua Script
 
-Lua script to send a recieve very basic MAVLink telemetry over a
+Lua script to send and receive very basic MAVLink telemetry over a
 Rockblock SBD satellite modem
 Requires [rockblock2mav](https://github.com/stephendade/rockblock2mav) at the GCS end
 

--- a/libraries/AP_Scripting/applets/quadplane_terrain_avoid.md
+++ b/libraries/AP_Scripting/applets/quadplane_terrain_avoid.md
@@ -20,10 +20,10 @@ This code works best long range rangefinders such as the LightWare long range li
 The "Can't make that climb" (CMTC) feature will prevent ArduPlane from flying into terrain it does know about
 by calculating the required pitch to avoid terrain between the current location and the next waypoint including
 all points in between. If the pitch required is > PTCH_LIM_MAX_DEG / 2 then the code will perform a loiter to
-altitude, using fixed wing loiter, to acheive a safe altitude to avoid the terrain before continuing the mission.
+altitude, using fixed wing loiter, to achieve a safe altitude to avoid the terrain before continuing the mission.
 
-For CMTC remember to turn it on (defaults to off), also set TA_CMTC_HGT (height above terrain for CMTC to try to acheive) and TA_ALT_MAX (max altitude to fly).
-Aso set TA_CMTC_RAD to a smaller radius than WP_LOITER_RAD. Make sure that the plane can acheive TA_CMTC_RAD based on the ROLL_LIMIT_MAX.
+For CMTC remember to turn it on (defaults to off), also set TA_CMTC_HGT (height above terrain for CMTC to try to achieve) and TA_ALT_MAX (max altitude to fly).
+Also set TA_CMTC_RAD to a smaller radius than WP_LOITER_RAD. Make sure that the plane can achieve TA_CMTC_RAD based on the ROLL_LIMIT_MAX.
 
 Note:
 
@@ -79,7 +79,7 @@ angle. (the same one used by TA_PTCH_FWD_MIN)
 
 The maximum groundspeed to attempt to fly. For best results when doing
 magnetometry surveys ideally a steady groundspeed is required even
-in windy conditions. This attempts to acheive that.
+in windy conditions. This attempts to achieve that.
 
 ## TA_GSP_AIRBRAKE
 

--- a/libraries/AP_Scripting/applets/repl.md
+++ b/libraries/AP_Scripting/applets/repl.md
@@ -54,7 +54,7 @@ below.
 
 ## MAVLink Connection
 
-* Requires at least Ardupilot 4.6.
+* Requires at least ArduPilot 4.6.
 * Set the port in the script text to `nil` to enable.
 * In addition to `repl.lua`, copy the `mavport.lua` file and `MAVLink` directory
 

--- a/libraries/AP_Scripting/examples/trisonicia-mini.md
+++ b/libraries/AP_Scripting/examples/trisonicia-mini.md
@@ -27,7 +27,7 @@ Set the following parameters:
 
 ## Sensor configuration
 
-Use Trisonica's [CLI](logger:write) to configure the unit. On Linux, you can use `screen` to interract with the device:
+Use Trisonica's CLI to configure the unit. On Linux, you can use `screen` to interact with the device:
 
 ```bash
 screen /dev/ttyUSB0 230400

--- a/libraries/AP_WindVane/Tools/Bluetooth NMEA receiver/Bluetooth NMEA receiver.md
+++ b/libraries/AP_WindVane/Tools/Bluetooth NMEA receiver/Bluetooth NMEA receiver.md
@@ -12,7 +12,7 @@ Any Arduino compatible nRF52 Bluetooth board should work, this guide is written 
 
 Follow the instructions from the manufacturer to setup the Arduino envoroment for your board. Install the [Adafruit nRF52](https://github.com/adafruit/Adafruit_nRF52_Arduino/tree/master/libraries/Bluefruit52Lib) library as outlined here: https://github.com/adafruit/Adafruit_nRF52_Arduino#bsp-installation.
 
-Use a smartphone and blue tooth tool to find the adress of your windvane. On Android [BLE Scanner](https://play.google.com/store/apps/details?id=com.macdom.ble.blescanner&hl=en_GB&gl=US) can be used, although there are many equivalent apps.
+Use a smartphone and Bluetooth tool to find the address of your windvane. On Android [BLE Scanner](https://play.google.com/store/apps/details?id=com.macdom.ble.blescanner&hl=en_GB&gl=US) can be used, although there are many equivalent apps.
 
 Locate the wind-vane and note down its address, in this case `DD:B7:BE:B4:56:38`.
 

--- a/libraries/AP_WindVane/Tools/Bluetooth NMEA receiver/Bluetooth NMEA receiver.md
+++ b/libraries/AP_WindVane/Tools/Bluetooth NMEA receiver/Bluetooth NMEA receiver.md
@@ -10,7 +10,7 @@ Any Arduino compatible nRF52 Bluetooth board should work, this guide is written 
 
 ## Script setup
 
-Follow the instructions from the manufacturer to setup the Arduino envoroment for your board. Install the [Adafruit nRF52](https://github.com/adafruit/Adafruit_nRF52_Arduino/tree/master/libraries/Bluefruit52Lib) library as outlined here: https://github.com/adafruit/Adafruit_nRF52_Arduino#bsp-installation.
+Follow the instructions from the manufacturer to setup the Arduino envoroment for your board. Install the [Adafruit nRF52](https://github.com/adafruit/Adafruit_nRF52_Arduino/tree/master/libraries/Bluefruit52Lib) library as outlined here: <https://github.com/adafruit/Adafruit_nRF52_Arduino#bsp-installation>.
 
 Use a smartphone and Bluetooth tool to find the address of your windvane. On Android [BLE Scanner](https://play.google.com/store/apps/details?id=com.macdom.ble.blescanner&hl=en_GB&gl=US) can be used, although there are many equivalent apps.
 
@@ -19,7 +19,8 @@ Locate the wind-vane and note down its address, in this case `DD:B7:BE:B4:56:38`
 ![Wind-vane address](BLE_Scanner.jpg)
 
 Take your the address and replace the one at the top of the script, removing colons and pre-fixing `0x` to denote a hexadecimal value. For example:
-```
+
+```cpp
 #define WIND_VANE_ADDRESS 0xDDB7BEB45638
 ```
 
@@ -32,12 +33,15 @@ Note! The wind-vane can only accept one connection at a time, if you cann't conn
 The Arduino script is setup to output NMEA 0183 messages as they are already supported by ArduPilot.
 
 Enable NMEA wind-vane with:
-```
+
+```text
 WNDVN_TYPE 4
 WNDVN_SPEED_TYPE 4
 ```
+
 Setup the serial port you have connected the nRF52 to with:
-```
+
+```text
 SERIALx_PROTOCOL 21
 SERIALx_BAUD 57
 ```
@@ -49,9 +53,3 @@ After a re-boot you should see wind messages reported to the GCS. For example `M
 ## Future work
 
 The script does send back the battery level of the wind-vane formatted as a NMEA `XDR` message. Some ArduPilot changes are required to allow this value to be parsed and displayed.
-
-
-
-
-
-


### PR DESCRIPTION
### Summary

Correct spelling and some markup in markdown files

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Hopefully the last for a while tidying of markdown files.

A few bad links which crept through the filters as they're not *quite* enough like rst to get caught.

Apart from that some URL fixes and spelling issues.

Only problem known after this is that AdeptF407 has a broken image in it.
