### PR TITLE
pre-commit: Lint C and C++ files with cpplint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
             )$
 
   - repo: https://github.com/cpplint/cpplint
-    rev: 2.0.2
+    rev: 1.5.5  # Corresponds to apt install cpplint on Ubuntu 22.04
     hooks:  # See CPPLINT.cfg for configuration
       - id: cpplint
         args: [--quiet]  # Do not print the path of every file checked

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,6 +51,12 @@ repos:
               Tools/ros2/.*\.py
             )$
 
+  - repo: https://github.com/cpplint/cpplint
+    rev: 2.0.2
+    hooks:  # See CPPLINT.cfg for configuration
+      - id: cpplint
+        args: [--quiet]  # Do not print the path of every file checked
+
   -   repo: https://github.com/pycqa/flake8
       rev: 7.3.0
       hooks:

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,40 @@
+# This is the root directory of this project so stop cpplint from looking
+# for settings in parent directories.
+set noparent
+
+# Use the C-standard allowlist to classify angle-bracket includes, giving
+# more accurate build/include_order diagnostics than the default heuristic.
+includeorder=standardcfirst
+
+# Filters are grouped by category. Permanently disabled filters reflect
+# deliberate ArduPilot code style decisions or embedded platform constraints.
+# Before enabling any filter below, discuss on Discord or the developer forum
+# and prepare a separate PR that fixes all existing violations.
+
+
+# Build -- Do NOT fix.
+filter=-build
+
+# Legal -- Do NOT fix.
+filter=-legal/copyright
+
+# Readability -- Do NOT fix except readability/alt_tokens.
+filter=-readability
+# FIXME: enable readability/alt_tokens - bans alternative tokens (and, or, etc.) in favour of &&, ||
+# filter=+readability/alt_tokens
+
+# Runtime
+filter=-runtime/arrays         # Do NOT fix.
+# FIXME: enable runtime/casting - flags unsafe casts; ~10 existing violations to fix first
+filter=-runtime/casting
+# FIXME: enable runtime/explicit - prevents implicit constructor conversions; check existing violations first
+filter=-runtime/explicit
+# FIXME: enable runtime/int - encourages fixed-width integer types, which is already an ArduPilot guideline
+filter=-runtime/int
+filter=-runtime/printf         # # Do NOT fix.
+filter=-runtime/threadsafe_fn  # # Do NOT fix.
+
+# Whitespace -- # Do NOT fix.
+# Whitespace-only changes will NOT be accepted: ArduPilot uses astyle for
+# formatting. See https://ardupilot.org/dev/docs/style-guide.html
+filter=-whitespace

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -24,15 +24,17 @@ filter=-readability
 # filter=+readability/alt_tokens
 
 # Runtime
-filter=-runtime/arrays         # Do NOT fix.
+filter=-runtime/arrays                 # Do NOT fix.
 # FIXME: enable runtime/casting - flags unsafe casts; ~10 existing violations to fix first
 filter=-runtime/casting
 # FIXME: enable runtime/explicit - prevents implicit constructor conversions; check existing violations first
 filter=-runtime/explicit
 # FIXME: enable runtime/int - encourages fixed-width integer types, which is already an ArduPilot guideline
 filter=-runtime/int
-filter=-runtime/printf         # # Do NOT fix.
-filter=-runtime/threadsafe_fn  # # Do NOT fix.
+filter=-runtime/indentation_namespace  # Do NOT fix. -- Failures on cpplint v1
+filter=-runtime/printf                 # Do NOT fix.
+filter=-runtime/references             # Do NOT fix. -- Failures on cpplint v1
+filter=-runtime/threadsafe_fn          # Do NOT fix.
 
 # Whitespace -- # Do NOT fix.
 # Whitespace-only changes will NOT be accepted: ArduPilot uses astyle for


### PR DESCRIPTION
### Summary

<!-- Put a one or two-line summary of what your PR does here -->

pre-commit: Lint C and C++ files with `cpplint`.
https://pypi.org/project/cpplint --> https://github.com/cpplint/cpplint

`CPPLINT.cfg:`
> linelength=6724
* #32848

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g., pre-commit)
- [x] Automated test(s) verify changes (e.g., pre-commit)
- [x] Tested manually, description below (e.g., pre-commit))
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### How was this tested?

% `uvx cpplint --quiet **/*.c `  # Repeat with `.cpp`, etc.
% `pipx run cpplint --quiet **/*.c `  # Repeat with `.cpp`, etc.
% `pre-commit run --all-files --verbose cpplint`
```
cpplint..................................................................Passed
- hook id: cpplint
- duration: 42.96s
```
Quite long when running with `--all-files` but quite workable on local `git diff`s.