### PR TITLE
Improve device driver console messaging

### DIFF
--- a/libraries/AP_Baro/AP_Baro_BMP085.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP085.cpp
@@ -105,6 +105,8 @@ bool AP_Baro_BMP085::_init()
         return false;
     }
 
+    DEV_PRINTF("BMP085 found on bus %u address 0x%02x\n", _dev->bus_num(), _dev->get_bus_address());
+
     ac1 = ((int16_t)bb.buff[0] << 8) | bb.buff[1];
     ac2 = ((int16_t)bb.buff[2] << 8) | bb.buff[3];
     ac3 = ((int16_t)bb.buff[4] << 8) | bb.buff[5];

--- a/libraries/AP_Baro/AP_Baro_BMP280.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP280.cpp
@@ -78,6 +78,10 @@ bool AP_Baro_BMP280::_init()
         return false;
     }
 
+    DEV_PRINTF("%s found on bus %u address 0x%02x\n",
+               (whoami == BME280_ID) ? "BME280" : "BMP280",
+               _dev->bus_num(), _dev->get_bus_address());
+
     // read the calibration data
     uint8_t buf[24];
     if (!_dev->read_registers(BMP280_REG_CALIB, buf, sizeof(buf))) {

--- a/libraries/AP_Baro/AP_Baro_BMP388.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP388.cpp
@@ -101,6 +101,10 @@ bool AP_Baro_BMP388::init()
         return false;
     }
 
+    DEV_PRINTF("%s found on bus %u address 0x%02x\n",
+               (whoami == BMP388_ID) ? "BMP388" : "BMP390",
+               dev->bus_num(), dev->get_bus_address());
+
     // read the calibration data
     read_registers(BMP388_REG_CAL_P, (uint8_t *)&calib_p, sizeof(calib_p));
     read_registers(BMP388_REG_CAL_T, (uint8_t *)&calib_t, sizeof(calib_t));

--- a/libraries/AP_Baro/AP_Baro_BMP581.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP581.cpp
@@ -103,6 +103,8 @@ bool AP_Baro_BMP581::init()
         return false;
     }
 
+    DEV_PRINTF("BMP581 found on bus %u address 0x%02x\n", _dev->bus_num(), _dev->get_bus_address());
+
     uint8_t status;
     if (!_dev->read_registers(BMP581_REG_STATUS, &status, 1)) {
         return false;

--- a/libraries/AP_Baro/AP_Baro_DPS280.cpp
+++ b/libraries/AP_Baro/AP_Baro_DPS280.cpp
@@ -183,6 +183,10 @@ bool AP_Baro_DPS280::init()
         return false;
     }
 
+    DEV_PRINTF("%s found on bus %u address 0x%02x\n",
+               (device_type() == DEVTYPE_BARO_DPS310) ? "DPS310" : "DPS280",
+               dev->bus_num(), dev->get_bus_address());
+
     dev->setup_checked_registers(4, 20);
 
     set_config_registers();

--- a/libraries/AP_Baro/AP_Baro_FBM320.cpp
+++ b/libraries/AP_Baro/AP_Baro_FBM320.cpp
@@ -111,7 +111,7 @@ bool AP_Baro_FBM320::init()
         dev->get_semaphore()->give();
         return false;
     }
-    printf("FBM320 ID 0x%x\n", whoami);
+    DEV_PRINTF("FBM320 ID 0x%x\n", whoami);
 
     if (!read_calibration()) {
         dev->get_semaphore()->give();

--- a/libraries/AP_Baro/AP_Baro_ICM20789.cpp
+++ b/libraries/AP_Baro/AP_Baro_ICM20789.cpp
@@ -198,6 +198,8 @@ bool AP_Baro_ICM20789::init()
         goto failed;
     }
 
+    DEV_PRINTF("ICM20789 found on bus %u address 0x%02x\n", dev->bus_num(), dev->get_bus_address());
+
     dev->set_retries(0);
 
     instance = _frontend.register_sensor();

--- a/libraries/AP_Baro/AP_Baro_ICP101XX.cpp
+++ b/libraries/AP_Baro/AP_Baro_ICP101XX.cpp
@@ -94,6 +94,8 @@ bool AP_Baro_ICP101XX::init()
         goto failed;
     }
 
+    DEV_PRINTF("ICP101XX found on bus %u address 0x%02x\n", dev->bus_num(), dev->get_bus_address());
+
     dev->set_retries(0);
 
     instance = _frontend.register_sensor();

--- a/libraries/AP_Baro/AP_Baro_ICP201XX.cpp
+++ b/libraries/AP_Baro/AP_Baro_ICP201XX.cpp
@@ -123,6 +123,8 @@ bool AP_Baro_ICP201XX::init()
         goto failed;
     }
 
+    DEV_PRINTF("ICP201XX found on bus %u address 0x%02x\n", dev->bus_num(), dev->get_bus_address());
+
     wait_read();
 
     dev->set_retries(0);

--- a/libraries/AP_Baro/AP_Baro_KellerLD.cpp
+++ b/libraries/AP_Baro/AP_Baro_KellerLD.cpp
@@ -192,7 +192,7 @@ bool AP_Baro_KellerLD::_init()
         return false;
     }
 
-    printf("Keller LD found on bus %u address 0x%02x\n", _dev->bus_num(), _dev->get_bus_address());
+    DEV_PRINTF("Keller LD found on bus %u address 0x%02x\n", _dev->bus_num(), _dev->get_bus_address());
 
     // Send a command to take a measurement
     _dev->transfer(&CMD_REQUEST_MEASUREMENT, 1, nullptr, 0);

--- a/libraries/AP_Baro/AP_Baro_LPS2XH.cpp
+++ b/libraries/AP_Baro/AP_Baro_LPS2XH.cpp
@@ -169,6 +169,10 @@ bool AP_Baro_LPS2XH::_init()
         CallTime = 1000000/75;
     }
 
+    DEV_PRINTF("%s found on bus %u address 0x%02x\n",
+               (_lps2xh_type == BARO_LPS22H) ? "LPS22H" : "LPS25H",
+               _dev->bus_num(), _dev->get_bus_address());
+
     _instance = _frontend.register_sensor();
 
     _dev->set_device_type(DEVTYPE_BARO_LPS2XH);

--- a/libraries/AP_Baro/AP_Baro_MS5611.cpp
+++ b/libraries/AP_Baro/AP_Baro_MS5611.cpp
@@ -149,7 +149,7 @@ bool AP_Baro_MS56XX::_init()
         return false;
     }
 
-    printf("%s found on bus %u address 0x%02x\n", name(), _dev->bus_num(), _dev->get_bus_address());
+    DEV_PRINTF("%s found on bus %u address 0x%02x\n", name(), _dev->bus_num(), _dev->get_bus_address());
 
     // Save factory calibration coefficients
     _cal_reg.c1 = prom[1];

--- a/libraries/AP_Baro/AP_Baro_SPL06.cpp
+++ b/libraries/AP_Baro/AP_Baro_SPL06.cpp
@@ -138,6 +138,10 @@ bool AP_Baro_SPL06::_init()
         return false;
     }
 
+    DEV_PRINTF("%s found on bus %u address 0x%02x\n",
+               (type == Type::SPA06) ? "SPA06" : "SPL06",
+               _dev->bus_num(), _dev->get_bus_address());
+
     // read the calibration data
     uint8_t SPL06_CALIB_COEFFS_LEN = 18;
 	switch(type) {

--- a/libraries/AP_Compass/AP_Compass_IST8308.cpp
+++ b/libraries/AP_Compass/AP_Compass_IST8308.cpp
@@ -139,7 +139,7 @@ bool AP_Compass_IST8308::init()
     }
 
     if (reset_count == 5) {
-        printf("IST8308: failed to reset device\n");
+        DEV_PRINTF("IST8308: failed to reset device\n");
         goto fail;
     }
 
@@ -151,7 +151,7 @@ bool AP_Compass_IST8308::init()
         !_dev->write_register(CNTL4_REG, CNTL4_VAL_DYNAMIC_RANGE_500) ||
         !_dev->write_register(OSRCNTL_REG, OSRCNTL_VAL_Y_16 | OSRCNTL_VAL_XZ_16) ||
         !_dev->write_register(CNTL2_REG, CNTL2_VAL_CONT_ODR100_MODE)) {
-        printf("IST8308: found device but could not set it up\n");
+        DEV_PRINTF("IST8308: found device but could not set it up\n");
         goto fail;
     }
 
@@ -166,7 +166,7 @@ bool AP_Compass_IST8308::init()
         return false;
     }
 
-    printf("%s found on bus %u id %u address 0x%02x\n", name,
+    DEV_PRINTF("%s found on bus %u id %u address 0x%02x\n", name,
            _dev->bus_num(), unsigned(_dev->get_bus_id()), _dev->get_bus_address());
 
     set_rotation(_rotation);

--- a/libraries/AP_Compass/AP_Compass_IST8310.cpp
+++ b/libraries/AP_Compass/AP_Compass_IST8310.cpp
@@ -152,13 +152,13 @@ bool AP_Compass_IST8310::init()
     }
 
     if (reset_count == 5) {
-        printf("IST8310: failed to reset device\n");
+        DEV_PRINTF("IST8310: failed to reset device\n");
         goto fail;
     }
 
     if (!_dev->write_register(AVGCNTL_REG, AVGCNTL_VAL_Y_16 | AVGCNTL_VAL_XZ_16) ||
         !_dev->write_register(PDCNTL_REG, PDCNTL_VAL_PULSE_DURATION_NORMAL)) {
-        printf("IST8310: found device but could not set it up\n");
+        DEV_PRINTF("IST8310: found device but could not set it up\n");
         goto fail;
     }
 
@@ -176,7 +176,7 @@ bool AP_Compass_IST8310::init()
         return false;
     }
 
-    printf("%s found on bus %u id %u address 0x%02x\n", name,
+    DEV_PRINTF("%s found on bus %u id %u address 0x%02x\n", name,
            _dev->bus_num(), unsigned(_dev->get_bus_id()), _dev->get_bus_address());
 
     set_rotation(_rotation);

--- a/libraries/AP_Compass/AP_Compass_LIS2MDL.cpp
+++ b/libraries/AP_Compass/AP_Compass_LIS2MDL.cpp
@@ -26,6 +26,8 @@
 #include <AP_Math/AP_Math.h>
 #include <stdio.h>
 
+extern const AP_HAL::HAL &hal;
+
 // Register addresses
 #define ADDR_WHO_AM_I       0x4F
 #define ADDR_CFG_REG_A      0x60
@@ -102,7 +104,7 @@ bool AP_Compass_LIS2MDL::init()
         return false;
     }
 
-    printf("Found a LIS2MDL on 0x%x as compass %u\n", unsigned(dev->get_bus_id()), instance);
+    DEV_PRINTF("Found a LIS2MDL on 0x%x as compass %u\n", unsigned(dev->get_bus_id()), instance);
 
     set_rotation(rotation);
 

--- a/libraries/AP_Compass/AP_Compass_LIS3MDL.cpp
+++ b/libraries/AP_Compass/AP_Compass_LIS3MDL.cpp
@@ -26,6 +26,8 @@
 #include <AP_Math/AP_Math.h>
 #include <stdio.h>
 
+extern const AP_HAL::HAL &hal;
+
 #define ADDR_CTRL_REG1      0x20
 #define ADDR_CTRL_REG2      0x21
 #define ADDR_CTRL_REG3      0x22
@@ -110,7 +112,7 @@ bool AP_Compass_LIS3MDL::init()
         return false;
     }
 
-    printf("Found a LIS3MDL on 0x%x as compass %u\n", unsigned(dev->get_bus_id()), instance);
+    DEV_PRINTF("Found a LIS3MDL on 0x%x as compass %u\n", unsigned(dev->get_bus_id()), instance);
 
     set_rotation(rotation);
 

--- a/libraries/AP_Compass/AP_Compass_MAG3110.cpp
+++ b/libraries/AP_Compass/AP_Compass_MAG3110.cpp
@@ -162,7 +162,7 @@ bool AP_Compass_MAG3110::_hardware_init()
 
     _dev->set_retries(3);
     
-    printf("MAG3110 found on bus 0x%x\n", (uint16_t)_dev->get_bus_id());
+    DEV_PRINTF("MAG3110 found on bus 0x%x\n", (uint16_t)_dev->get_bus_id());
 
 exit:
     _dev->set_speed(AP_HAL::Device::SPEED_HIGH);

--- a/libraries/AP_Compass/AP_Compass_MMC3416.cpp
+++ b/libraries/AP_Compass/AP_Compass_MMC3416.cpp
@@ -101,7 +101,7 @@ bool AP_Compass_MMC3416::init()
         return false;
     }
 
-    printf("Found a MMC3416 on 0x%x as compass %u\n", unsigned(dev->get_bus_id()), instance);
+    DEV_PRINTF("Found a MMC3416 on 0x%x as compass %u\n", unsigned(dev->get_bus_id()), instance);
 
     set_rotation(rotation);
 

--- a/libraries/AP_Compass/AP_Compass_MMC5xx3.cpp
+++ b/libraries/AP_Compass/AP_Compass_MMC5xx3.cpp
@@ -113,7 +113,7 @@ bool AP_Compass_MMC5XX3::init()
         return false;
     }
 
-    printf("Found a MMC5983 on 0x%x as compass %u\n", unsigned(dev->get_bus_id()), instance);
+    DEV_PRINTF("Found a MMC5983 on 0x%x as compass %u\n", unsigned(dev->get_bus_id()), instance);
 
     set_rotation(rotation);
 
@@ -251,7 +251,7 @@ void AP_Compass_MMC5XX3::timer()
         accumulate_sample(field);
 
         if (!dev->write_register(REG_CONTROL0, REG_CONTROL0_TMM)) {
-            printf("failed to initiate measurement\n");
+            DEV_PRINTF("MMC5983: failed to initiate measurement\n");
             state = MMCState::STATE_SET;
         } else {
             state = MMCState::STATE_MEASURE;
@@ -276,7 +276,7 @@ void AP_Compass_MMC5XX3::timer()
 
         uint8_t data1[6];
         if (!dev->read_registers(REG_XOUT_L, (uint8_t *)&data1[0], 6)) {
-            printf("cant read data\n");
+            DEV_PRINTF("MMC5983: cant read data\n");
             state = MMCState::STATE_SET;
             break;
         }

--- a/libraries/AP_Compass/AP_Compass_QMC5883L.cpp
+++ b/libraries/AP_Compass/AP_Compass_QMC5883L.cpp
@@ -28,6 +28,8 @@
 #include <AP_HAL/utility/sparse-endian.h>
 #include <AP_Math/AP_Math.h>
 
+extern const AP_HAL::HAL &hal;
+
 #define QMC5883L_REG_CONF1 0x09
 #define QMC5883L_REG_CONF2 0x0A
 
@@ -119,7 +121,7 @@ bool AP_Compass_QMC5883L::init()
         return false;
     }
 
-    printf("%s found on bus %u id %u address 0x%02x\n", name,
+    DEV_PRINTF("%s found on bus %u id %u address 0x%02x\n", name,
            _dev->bus_num(), unsigned(_dev->get_bus_id()), _dev->get_bus_address());
 
     set_rotation(_rotation);

--- a/libraries/AP_Compass/AP_Compass_QMC5883P.cpp
+++ b/libraries/AP_Compass/AP_Compass_QMC5883P.cpp
@@ -23,6 +23,8 @@
 
 #if AP_COMPASS_QMC5883P_ENABLED
 
+extern const AP_HAL::HAL &hal;
+
 //Register Address
 #define QMC5883P_REG_ID                 0x00
 #define QMC5883P_REG_DATA_OUTPUT_X      0x01
@@ -130,7 +132,7 @@ bool AP_Compass_QMC5883P::init()
         return false;
     }
 
-    printf("%s found on bus %u id %u address 0x%02x\n", name,
+    DEV_PRINTF("%s found on bus %u id %u address 0x%02x\n", name,
            _dev->bus_num(), unsigned(_dev->get_bus_id()), _dev->get_bus_address());
 
     set_rotation(_rotation);

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -921,6 +921,7 @@ void AP_GPS::update_instance(uint8_t instance)
         if (!state[instance].announced_detection) {
             state[instance].announced_detection = true;
             GCS_SEND_TEXT(MAV_SEVERITY_INFO, "GPS %d: detected %s", instance + 1, drivers[instance]->name());
+            DEV_PRINTF("GPS %d: detected %s\n", instance + 1, drivers[instance]->name());
         }
 
         // delta will only be correct after parsing two messages

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -1434,6 +1434,11 @@ AP_GPS_UBLOX::_parse_gps(void)
                                              state.instance + 1,
                                              _version.hwVersion,
                                              _version.swVersion);
+            DEV_PRINTF("u-blox %s%s%d HW: %s SW: %s\n",
+                       _module, mod != nullptr ? " " : "",
+                       state.instance + 1,
+                       _version.hwVersion,
+                       _version.swVersion);
             // check for F9 and M9. The F9 does not respond to SVINFO,
             // so we need to use MON_VER for hardware generation
             if (strncmp(_version.hwVersion, "00190000", 8) == 0) {


### PR DESCRIPTION
### Summary

It's very nice to see which devices have been discovered on initialization. This PR cleans up that device discovery messaging for compass, barometer, and GPS.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested on my VOXL3. For example, this is the output I see on the console on startup:

```
Waiting for GCS receive
Waiting for OBD receive
Connnected to GCS at 127.0.0.1


Init ArduCopter V4.8.0-dev (691f05dd)

Free RAM: 2906301
AP_Logger_File: buffer size=204800
DPS310 found on bus 2 address 0x77
QMC5883L found on bus 0 id 855297 address 0x0d
BMI270 initialized after 1 retries
Init Gyro***
Remote UART: opened /dev/ttyHS7 at baud=9600
Connnected to OBD addr 127.0.0.1
GPS 1: detected u-blox
u-blox MAX-M10S 1 HW: 000A0000 SW: ROM SPG 5.10 (7b202e)
```

