### PR TITLE
SITL: Move SIM::Battery's one-liner voltage-getter into header

### DIFF
--- a/libraries/SITL/SIM_Battery.cpp
+++ b/libraries/SITL/SIM_Battery.cpp
@@ -194,8 +194,3 @@ void Battery::update_temperature(float current_amps, uint64_t now_us)
     const float temp_decrease = (temperature.kelvin - 273.15f) * 0.10 * temperature_dt * 0.000001;
     temperature.kelvin += (temp_increase - temp_decrease);
 }
-
-float Battery::get_voltage(void) const
-{
-    return voltage_filter.get();
-}

--- a/libraries/SITL/SIM_Battery.h
+++ b/libraries/SITL/SIM_Battery.h
@@ -35,7 +35,7 @@ public:
     // Call this periodically to "step" the battery forward in time
     void consume_energy(float current_amps, uint64_t now_us);
 
-    float get_voltage(void) const;
+    float get_voltage(void) const { return voltage_filter.get(); }
     float get_capacity(void) const { return capacity_Ah; }
 
     // return battery temperature in Kelvin:


### PR DESCRIPTION
### Summary

(Does what title says.)

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

CI is sufficient to prove this works.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
