### PR TITLE
Improve SIM::Battery temperature

### DIFF
--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -178,7 +178,7 @@ public:
     void set_dronecan_device(DroneCANDevice *_dronecan) { dronecan = _dronecan; }
 #endif
     float get_battery_voltage() const { return battery_voltage; }
-    float get_battery_temperature() const { return battery.get_temperature(); }
+    float get_battery_temperature_degC() const { return battery.get_temperature_degC(); }
 
     float ambient_outside_temperature_degC() const;
     float ambient_outside_pressure_Pascal() const;

--- a/libraries/SITL/SIM_Battery.cpp
+++ b/libraries/SITL/SIM_Battery.cpp
@@ -178,19 +178,17 @@ void Battery::consume_energy(float current_amp, uint64_t now_us)
 
     voltage_filter.apply(voltage, dt);
 
-    update_temperature(current_amp, now_us);
+    update_temperature(current_amp, dt);
 }
 
-void Battery::update_temperature(float current_amp, uint64_t now_us)
+void Battery::update_temperature(float current_amp, float dt)
 {
-    const uint64_t temperature_dt = now_us - temperature.last_update_us;
-    temperature.last_update_us = now_us;
     // thermal_capacity value chosen to match previous steady-state behavior at 28amps
     // (reminder: thermal_capacity = mass * specific_heat)
     constexpr float thermal_capacity = 2.8f;  // watt*seconds/degC
     constexpr float inverse_of_thermal_capacity = 1 / thermal_capacity;  // use inverse so we can multiply, not divide
-    const float temp_increase = (current_amp * current_amp) * resistance_ohm * inverse_of_thermal_capacity * (temperature_dt * 0.000001);
+    const float temp_increase = (current_amp * current_amp) * resistance_ohm * inverse_of_thermal_capacity * dt;
     // decay temperature at some %second towards ambient
-    const float temp_decrease = (temperature.kelvin - 273.15f) * 0.10 * temperature_dt * 0.000001;
+    const float temp_decrease = (temperature.kelvin - 273.15f) * 0.10 * dt;
     temperature.kelvin += (temp_increase - temp_decrease);
 }

--- a/libraries/SITL/SIM_Battery.cpp
+++ b/libraries/SITL/SIM_Battery.cpp
@@ -183,12 +183,15 @@ void Battery::consume_energy(float current_amp, uint64_t now_us)
 
 void Battery::update_temperature(float current_amp, float dt)
 {
+    // In the (near) future, this value will instead come from Aircraft::ambient_outside_temperature_degC()
+    constexpr float ambient_temperature_degC = 0.0f;
+
     // thermal_capacity value chosen to match previous steady-state behavior at 28amps
     // (reminder: thermal_capacity = mass * specific_heat)
     constexpr float thermal_capacity = 2.8f;  // watt*seconds/degC
     constexpr float inverse_of_thermal_capacity = 1 / thermal_capacity;  // use inverse so we can multiply, not divide
     const float temp_increase = (current_amp * current_amp) * resistance_ohm * inverse_of_thermal_capacity * dt;
     // decay temperature at some %second towards ambient
-    const float temp_decrease = (temperature.kelvin - 273.15f) * 0.10 * dt;
-    temperature.kelvin += (temp_increase - temp_decrease);
+    const float temp_decrease = (temperature_degC - ambient_temperature_degC) * 0.10 * dt;
+    temperature_degC += (temp_increase - temp_decrease);
 }

--- a/libraries/SITL/SIM_Battery.h
+++ b/libraries/SITL/SIM_Battery.h
@@ -51,9 +51,8 @@ private:
 
     struct {
         float kelvin = 273;
-        uint64_t last_update_us;
     } temperature;
-    void update_temperature(float current_amp, uint64_t now_us);
+    void update_temperature(float current_amp, float dt);
 
     // 10Hz filter for battery voltage
     LowPassFilterFloat voltage_filter{10};

--- a/libraries/SITL/SIM_Battery.h
+++ b/libraries/SITL/SIM_Battery.h
@@ -37,9 +37,7 @@ public:
 
     float get_voltage(void) const { return voltage_filter.get(); }
     float get_capacity(void) const { return capacity_Ah; }
-
-    // return battery temperature in Kelvin:
-    float get_temperature(void) const { return temperature.kelvin; }
+    float get_temperature_degC(void) const { return temperature_degC; }
 
 private:
     float capacity_Ah;
@@ -49,9 +47,7 @@ private:
     float remaining_Ah;
     uint64_t last_us;
 
-    struct {
-        float kelvin = 273;
-    } temperature;
+    float temperature_degC = 0.0f;
     void update_temperature(float current_amp, float dt);
 
     // 10Hz filter for battery voltage

--- a/libraries/SITL/SIM_Temperature_TSYS03.cpp
+++ b/libraries/SITL/SIM_Temperature_TSYS03.cpp
@@ -178,10 +178,10 @@ void SITL::TSYS03::update(const class Aircraft &aircraft)
         break;
     case State::CONVERTING:
         if (time_in_state_ms() > 5) {
-            const float temperature = get_sim_temperature(aircraft);
-            if (!is_equal(last_temperature, temperature)) {
-                last_temperature = temperature;
-                adc = calculate_adc(KELVIN_TO_C(temperature));
+            const float temperature_degC = get_sim_temperature_degC(aircraft);
+            if (!is_equal(last_temperature_degC, temperature_degC)) {
+                last_temperature_degC = temperature_degC;
+                adc = calculate_adc(temperature_degC);
             }
             set_state(State::CONVERTED);
         }
@@ -191,9 +191,9 @@ void SITL::TSYS03::update(const class Aircraft &aircraft)
     }
 }
 
-float SITL::TSYS03::get_sim_temperature(const Aircraft &aircraft) const
+float SITL::TSYS03::get_sim_temperature_degC(const Aircraft &aircraft) const
 {
-    return aircraft.get_battery_temperature();
+    return aircraft.get_battery_temperature_degC();
 }
 
 #endif  // AP_SIM_TSYS03_ENABLED

--- a/libraries/SITL/SIM_Temperature_TSYS03.h
+++ b/libraries/SITL/SIM_Temperature_TSYS03.h
@@ -39,7 +39,7 @@ private:
     int rdwr_handle_write(I2C::i2c_rdwr_ioctl_data *&data);
 
     // should be a call on aircraft:
-    float last_temperature = -1000.0f;
+    float last_temperature_degC = -1000.0f;
 
     enum class State {
         UNKNOWN = 22,
@@ -60,7 +60,7 @@ private:
         return AP_HAL::millis() - state_start_time_ms;
     }
 
-    float get_sim_temperature(const class Aircraft &aircraft) const;
+    float get_sim_temperature_degC(const class Aircraft &aircraft) const;
 
     float temperature_for_adc(uint16_t adc) const;
     uint16_t calculate_adc(float temperature) const;

--- a/libraries/SITL/tests/test_battery.cpp
+++ b/libraries/SITL/tests/test_battery.cpp
@@ -93,8 +93,8 @@ TEST_F(BatteryTest, EnergyConsumption)
 
         const float initial_voltage = battery.get_voltage();
         min_observed_voltage = initial_voltage;
-        const float initial_temperature = battery.get_temperature();
-        float prev_temperature = initial_temperature;
+        const float initial_temperature_degC = battery.get_temperature_degC();
+        float prev_temperature_degC = initial_temperature_degC;
 
         for (float t = 0.0f; t <= test_duration_sec; t+=dt_sec) {
             const uint64_t now_us = initial_us + static_cast<uint64_t>(t * 1e6);
@@ -108,12 +108,12 @@ TEST_F(BatteryTest, EnergyConsumption)
 
             // Confirm temperature rise
             if (is_zero(t)) {
-                EXPECT_FLOAT_EQ(battery.get_temperature(), initial_temperature);
+                EXPECT_FLOAT_EQ(battery.get_temperature_degC(), initial_temperature_degC);
             } else {
                 // Regardless of whether temp is rising (first half of test) or cooling (second half),
                 // it should be somewhat higher than the initial temp.
                 // (This test does not set an expectation on how much higher.)
-                EXPECT_GT(battery.get_temperature(), initial_temperature);
+                EXPECT_GT(battery.get_temperature_degC(), initial_temperature_degC);
             }
 
             // Confirm temperature-change direction
@@ -121,14 +121,14 @@ TEST_F(BatteryTest, EnergyConsumption)
                 if (t < first_half) {
                     // First half: consuming => temperature increasing
                     // (Note: the test parameters are tuned so that the consumption half ends before temp reaches steady-state.)
-                    EXPECT_GT(battery.get_temperature(), prev_temperature);
+                    EXPECT_GT(battery.get_temperature_degC(), prev_temperature_degC);
                 } else {
                     // Second half: resting => temperature decreasing
                     // (Note: the test parameters are tuned so that the test ends before temp returns to steady-state.)
-                    EXPECT_LT(battery.get_temperature(), prev_temperature);
+                    EXPECT_LT(battery.get_temperature_degC(), prev_temperature_degC);
                 }
             }
-            prev_temperature = battery.get_temperature();
+            prev_temperature_degC = battery.get_temperature_degC();
 
             // Confirm voltage drop
             if (is_zero(t) || is_zero(battery.get_capacity())) {


### PR DESCRIPTION
### Summary

Multiple improvements, they should be self-evident but also described below.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Does not change autopilot behavior. (Does switch some units inside SITL.)
- [x] Does not change autopilot binary. (Does change SITL binary.)
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

CI proves that this change works.

### Description

This makes several improvements:
- Replace unnecessary "temperature time" with main delta-time.
- Replace the now-unnecessary temperature (time, value) struct with a simple value.
- Switch to Celsius and add _degC suffix.
- Add _ohm suffix, and fix _amp suffix.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
