### PR TITLE
Improve high_latency_tgt_dist()

### DIFF
--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -1301,12 +1301,11 @@ uint8_t GCS_MAVLINK_Copter::high_latency_tgt_heading() const
     return 0;     
 }
     
-uint16_t GCS_MAVLINK_Copter::high_latency_tgt_dist() const
+uint16_t GCS_MAVLINK_Copter::high_latency_tgt_dist_dam() const
 {
     if (copter.ap.initialised) {
-        // return units are dm
         const Mode *flightmode = copter.flightmode;
-        return MIN(flightmode->wp_distance_m(), UINT16_MAX) / 10;
+        return MIN(static_cast<uint16_t>(flightmode->wp_distance_m() * 0.1), UINT16_MAX);
     }
     return 0;
 }

--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -1296,12 +1296,11 @@ uint8_t GCS_MAVLINK_Copter::high_latency_tgt_heading() const
     return 0;     
 }
     
-uint16_t GCS_MAVLINK_Copter::high_latency_tgt_dist() const
+uint16_t GCS_MAVLINK_Copter::high_latency_tgt_dist_dam() const
 {
     if (copter.ap.initialised) {
-        // return units are dm
         const Mode *flightmode = copter.flightmode;
-        return MIN(flightmode->wp_distance_m(), UINT16_MAX) / 10;
+        return MIN(static_cast<uint16_t>(flightmode->wp_distance_m() * 0.1), UINT16_MAX);
     }
     return 0;
 }

--- a/ArduCopter/GCS_MAVLink_Copter.h
+++ b/ArduCopter/GCS_MAVLink_Copter.h
@@ -94,7 +94,7 @@ private:
 #if HAL_HIGH_LATENCY2_ENABLED
     int16_t high_latency_target_altitude() const override;
     uint8_t high_latency_tgt_heading() const override;
-    uint16_t high_latency_tgt_dist() const override;
+    uint16_t high_latency_tgt_dist_dam() const override;
     uint8_t high_latency_tgt_airspeed() const override;
     uint8_t high_latency_wind_speed() const override;
     uint8_t high_latency_wind_direction() const override;

--- a/ArduPlane/GCS_MAVLink_Plane.cpp
+++ b/ArduPlane/GCS_MAVLink_Plane.cpp
@@ -1211,18 +1211,17 @@ uint8_t GCS_MAVLINK_Plane::high_latency_tgt_heading() const
         return wrap_360_cd(nav_controller->target_bearing_cd() ) / 200;
 }
 
-// return units are dm
-uint16_t GCS_MAVLINK_Plane::high_latency_tgt_dist() const
+uint16_t GCS_MAVLINK_Plane::high_latency_tgt_dist_dam() const
 {
 #if HAL_QUADPLANE_ENABLED
     const QuadPlane &quadplane = plane.quadplane;
     if (quadplane.show_vtol_view()) {
         bool wp_nav_valid = quadplane.using_wp_nav();
-        return (wp_nav_valid ? MIN(quadplane.wp_nav->get_wp_distance_to_destination_cm(), UINT16_MAX) : 0) / 10;
+        return (wp_nav_valid ? MIN(static_cast<uint16_t>(quadplane.wp_nav->get_wp_distance_to_destination_cm() * 1e-3), UINT16_MAX) : 0);
     }
     #endif
 
-    return MIN(plane.auto_state.wp_distance, UINT16_MAX) / 10;
+    return MIN(static_cast<uint16_t>(plane.auto_state.wp_distance * 0.1), UINT16_MAX);
 }
 
 uint8_t GCS_MAVLINK_Plane::high_latency_tgt_airspeed() const

--- a/ArduPlane/GCS_MAVLink_Plane.cpp
+++ b/ArduPlane/GCS_MAVLink_Plane.cpp
@@ -1206,18 +1206,17 @@ uint8_t GCS_MAVLINK_Plane::high_latency_tgt_heading() const
         return wrap_360_cd(nav_controller->target_bearing_cd() ) / 200;
 }
 
-// return units are dm
-uint16_t GCS_MAVLINK_Plane::high_latency_tgt_dist() const
+uint16_t GCS_MAVLINK_Plane::high_latency_tgt_dist_dam() const
 {
 #if HAL_QUADPLANE_ENABLED
     const QuadPlane &quadplane = plane.quadplane;
     if (quadplane.show_vtol_view()) {
         bool wp_nav_valid = quadplane.using_wp_nav();
-        return (wp_nav_valid ? MIN(quadplane.wp_nav->get_wp_distance_to_destination_cm(), UINT16_MAX) : 0) / 10;
+        return (wp_nav_valid ? MIN(static_cast<uint16_t>(quadplane.wp_nav->get_wp_distance_to_destination_cm() * 1e-3), UINT16_MAX) : 0);
     }
     #endif
 
-    return MIN(plane.auto_state.wp_distance, UINT16_MAX) / 10;
+    return MIN(static_cast<uint16_t>(plane.auto_state.wp_distance * 0.1), UINT16_MAX);
 }
 
 uint8_t GCS_MAVLINK_Plane::high_latency_tgt_airspeed() const

--- a/ArduPlane/GCS_MAVLink_Plane.h
+++ b/ArduPlane/GCS_MAVLink_Plane.h
@@ -89,7 +89,7 @@ private:
 #if HAL_HIGH_LATENCY2_ENABLED
     int16_t high_latency_target_altitude() const override;
     uint8_t high_latency_tgt_heading() const override;
-    uint16_t high_latency_tgt_dist() const override;
+    uint16_t high_latency_tgt_dist_dam() const override;
     uint8_t high_latency_tgt_airspeed() const override;
     uint8_t high_latency_wind_speed() const override;
     uint8_t high_latency_wind_direction() const override;

--- a/ArduSub/GCS_MAVLink_Sub.cpp
+++ b/ArduSub/GCS_MAVLink_Sub.cpp
@@ -821,11 +821,10 @@ uint8_t GCS_MAVLINK_Sub::high_latency_tgt_heading() const
     return 0;      
 }
     
-uint16_t GCS_MAVLINK_Sub::high_latency_tgt_dist() const
+uint16_t GCS_MAVLINK_Sub::high_latency_tgt_dist_dam() const
 {
-    // return units are dm
     if (sub.control_mode == Mode::Number::AUTO || sub.control_mode == Mode::Number::GUIDED) {
-        return MIN(sub.wp_nav.get_wp_distance_to_destination_cm() * 0.001, UINT16_MAX);
+        return MIN(static_cast<uint16_t>(sub.wp_nav.get_wp_distance_to_destination_cm() * 1e-3), UINT16_MAX);
     }
     return 0;
 }

--- a/ArduSub/GCS_MAVLink_Sub.cpp
+++ b/ArduSub/GCS_MAVLink_Sub.cpp
@@ -818,11 +818,10 @@ uint8_t GCS_MAVLINK_Sub::high_latency_tgt_heading() const
     return 0;      
 }
     
-uint16_t GCS_MAVLINK_Sub::high_latency_tgt_dist() const
+uint16_t GCS_MAVLINK_Sub::high_latency_tgt_dist_dam() const
 {
-    // return units are dm
     if (sub.control_mode == Mode::Number::AUTO || sub.control_mode == Mode::Number::GUIDED) {
-        return MIN(sub.wp_nav.get_wp_distance_to_destination_cm() * 0.001, UINT16_MAX);
+        return MIN(static_cast<uint16_t>(sub.wp_nav.get_wp_distance_to_destination_cm() * 1e-3), UINT16_MAX);
     }
     return 0;
 }

--- a/ArduSub/GCS_MAVLink_Sub.h
+++ b/ArduSub/GCS_MAVLink_Sub.h
@@ -73,7 +73,7 @@ private:
 #if HAL_HIGH_LATENCY2_ENABLED
     int16_t high_latency_target_altitude() const override;
     uint8_t high_latency_tgt_heading() const override;
-    uint16_t high_latency_tgt_dist() const override;
+    uint16_t high_latency_tgt_dist_dam() const override;
     uint8_t high_latency_tgt_airspeed() const override;
 #endif // HAL_HIGH_LATENCY2_ENABLED
 };

--- a/Rover/GCS_MAVLink_Rover.cpp
+++ b/Rover/GCS_MAVLink_Rover.cpp
@@ -924,12 +924,11 @@ uint8_t GCS_MAVLINK_Rover::high_latency_tgt_heading() const
     return 0;
 }
     
-uint16_t GCS_MAVLINK_Rover::high_latency_tgt_dist() const
+uint16_t GCS_MAVLINK_Rover::high_latency_tgt_dist_dam() const
 {
     const Mode *control_mode = rover.control_mode;
     if (rover.control_mode->is_autopilot_mode()) {
-        // return units are dm
-        return MIN((control_mode->get_distance_to_destination()) / 10, UINT16_MAX);
+        return MIN(static_cast<uint16_t>(control_mode->get_distance_to_destination() * 0.1), UINT16_MAX);
     }
     return 0;
 }

--- a/Rover/GCS_MAVLink_Rover.cpp
+++ b/Rover/GCS_MAVLink_Rover.cpp
@@ -890,12 +890,11 @@ uint8_t GCS_MAVLINK_Rover::high_latency_tgt_heading() const
     return 0;
 }
     
-uint16_t GCS_MAVLINK_Rover::high_latency_tgt_dist() const
+uint16_t GCS_MAVLINK_Rover::high_latency_tgt_dist_dam() const
 {
     const Mode *control_mode = rover.control_mode;
     if (rover.control_mode->is_autopilot_mode()) {
-        // return units are dm
-        return MIN((control_mode->get_distance_to_destination()) / 10, UINT16_MAX);
+        return MIN(static_cast<uint16_t>(control_mode->get_distance_to_destination() * 0.1), UINT16_MAX);
     }
     return 0;
 }

--- a/Rover/GCS_MAVLink_Rover.h
+++ b/Rover/GCS_MAVLink_Rover.h
@@ -74,7 +74,7 @@ private:
 
 #if HAL_HIGH_LATENCY2_ENABLED
     uint8_t high_latency_tgt_heading() const override;
-    uint16_t high_latency_tgt_dist() const override;
+    uint16_t high_latency_tgt_dist_dam() const override;
     uint8_t high_latency_tgt_airspeed() const override;
     uint8_t high_latency_wind_speed() const override;
     uint8_t high_latency_wind_direction() const override;

--- a/Rover/GCS_MAVLink_Rover.h
+++ b/Rover/GCS_MAVLink_Rover.h
@@ -68,7 +68,7 @@ private:
 
 #if HAL_HIGH_LATENCY2_ENABLED
     uint8_t high_latency_tgt_heading() const override;
-    uint16_t high_latency_tgt_dist() const override;
+    uint16_t high_latency_tgt_dist_dam() const override;
     uint8_t high_latency_tgt_airspeed() const override;
     uint8_t high_latency_wind_speed() const override;
     uint8_t high_latency_wind_direction() const override;

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -772,7 +772,7 @@ protected:
 #if HAL_HIGH_LATENCY2_ENABLED
     virtual int16_t high_latency_target_altitude() const { return 0; }
     virtual uint8_t high_latency_tgt_heading() const { return 0; }
-    virtual uint16_t high_latency_tgt_dist() const { return 0; }
+    virtual uint16_t high_latency_tgt_dist_dam() const { return 0; }
     virtual uint8_t high_latency_tgt_airspeed() const { return 0; }
     virtual uint8_t high_latency_wind_speed() const { return 0; }
     virtual uint8_t high_latency_wind_direction() const { return 0; }

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -771,7 +771,7 @@ protected:
 #if HAL_HIGH_LATENCY2_ENABLED
     virtual int16_t high_latency_target_altitude() const { return 0; }
     virtual uint8_t high_latency_tgt_heading() const { return 0; }
-    virtual uint16_t high_latency_tgt_dist() const { return 0; }
+    virtual uint16_t high_latency_tgt_dist_dam() const { return 0; }
     virtual uint8_t high_latency_tgt_airspeed() const { return 0; }
     virtual uint8_t high_latency_wind_speed() const { return 0; }
     virtual uint8_t high_latency_wind_direction() const { return 0; }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -7764,7 +7764,7 @@ void GCS_MAVLINK::send_high_latency2() const
         high_latency_target_altitude(), // [m] Altitude setpoint
         uint16_t(ahrs.get_yaw_deg()) / 2, // [deg/2] Heading
         high_latency_tgt_heading(), // [deg/2] Heading setpoint
-        high_latency_tgt_dist(), // [dam] Distance to target waypoint or position
+        high_latency_tgt_dist_dam(), // [dam] Distance to target waypoint or position
         abs(vfr_hud_throttle()), // [%] Throttle
         MIN(vfr_hud_airspeed() * 5, UINT8_MAX), // [m/s*5] Airspeed
         high_latency_tgt_airspeed(), // [m/s*5] Airspeed setpoint

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -7733,7 +7733,7 @@ void GCS_MAVLINK::send_high_latency2() const
         high_latency_target_altitude(), // [m] Altitude setpoint
         uint16_t(ahrs.get_yaw_deg()) / 2, // [deg/2] Heading
         high_latency_tgt_heading(), // [deg/2] Heading setpoint
-        high_latency_tgt_dist(), // [dam] Distance to target waypoint or position
+        high_latency_tgt_dist_dam(), // [dam] Distance to target waypoint or position
         abs(vfr_hud_throttle()), // [%] Throttle
         MIN(vfr_hud_airspeed() * 5, UINT8_MAX), // [m/s*5] Airspeed
         high_latency_tgt_airspeed(), // [m/s*5] Airspeed setpoint


### PR DESCRIPTION
### Summary

Some spots were incorrectly using decimeters (dm) rather than decameters (dam). Also improved some values and typecasting.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

This resolves #32838 .

- Some unit-scaling was done outside a MAX(..., uint16_max), which means the likely-intended max-value was not possible.
- Unit suffix is added to the function, per our preference for that in our dev wiki.
- Some divisions are converted to multiplications, per our preference for that in our dev wiki.
- Some implicit casts are made explicit.
- One change from `0.001` to `1e-3` was made, because I find that easier to read for exponents >= 3.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
