### PR TITLE
autotest: Add self.dive(...) for Sub, similar to self.takeoff(...)

### DIFF
--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -158,24 +158,23 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
                     "Altitude not maintained: want %.2f (+/- %.2f) got=%.2f" %
                     (previous_altitude, delta, m.alt))
 
+    def dive(self, alt, mode='MANUAL', timeout=120):
+        """Dive to a target altitude."""
+        self.progress("DIVE")
+        self.change_mode(mode)
+        if not self.armed():
+            self.wait_ready_to_arm()
+            self.arm_vehicle()
+        pwm = 1300 if self.get_altitude(relative=True) > alt else 1700
+        self.set_rc(Joystick.Throttle, pwm)
+        self.wait_altitude(altitude_min=alt - 1, altitude_max=alt, relative=False, timeout=timeout)
+        self.set_rc(Joystick.Throttle, 1500)
+        self.delay_sim_time(1)
+        self.progress("DIVE COMPLETE")
+
     def AltitudeHold(self):
         """Test ALT_HOLD mode"""
-        self.wait_ready_to_arm()
-        self.arm_vehicle()
-        self.change_mode('ALT_HOLD')
-
-        msg = self.assert_receive_message('GLOBAL_POSITION_INT', timeout=5)
-        pwm = 1300
-        if msg.relative_alt/1000.0 < -6.0:
-            # need to go up, not down!
-            pwm = 1700
-        self.set_rc(Joystick.Throttle, pwm)
-        self.wait_altitude(altitude_min=-6, altitude_max=-5)
-        self.set_rc(Joystick.Throttle, 1500)
-
-        # let the vehicle settle (momentum / stopping point shenanigans....)
-        self.delay_sim_time(1)
-
+        self.dive(-5, mode='ALT_HOLD')
         self.watch_altitude_maintained()
 
         self.set_rc(Joystick.Throttle, 1000)
@@ -312,16 +311,8 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.context_push()
         self.set_parameter("SIM_BARO_RND", 0.01)
 
-        self.wait_ready_to_arm()
-        self.arm_vehicle()
-        self.change_mode('MANUAL')
-
         # Dive to -5m, outside of rangefinder range, will act like ALT_HOLD
-        pwm = 1300 if self.get_altitude(relative=True) > -6 else 1700
-        self.set_rc(Joystick.Throttle, pwm)
-        self.wait_altitude(altitude_min=-6, altitude_max=-5, relative=False, timeout=60)
-        self.set_rc(Joystick.Throttle, 1500)
-        self.delay_sim_time(1)
+        self.dive(-5, timeout=60)
         self.context_collect('STATUSTEXT')
         self.change_mode(21)
         self.wait_statustext('waiting for a rangefinder reading', check_context=True)
@@ -430,15 +421,9 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
 
         self.context_push()
         self.prepare_synthetic_seafloor_test(sea_floor_depth, match_distance)
-        self.change_mode('MANUAL')
-        self.arm_vehicle()
 
         # Dive to match_distance off the bottom in preparation for the mission
-        pwm = 1300 if self.get_altitude(relative=True) > start_altitude else 1700
-        self.set_rc(Joystick.Throttle, pwm)
-        self.wait_altitude(altitude_min=start_altitude-1, altitude_max=start_altitude, relative=False, timeout=120)
-        self.set_rc(Joystick.Throttle, 1500)
-        self.delay_sim_time(1)
+        self.dive(start_altitude)
 
         # Turn on surftrak and move around
         self.change_mode(21)
@@ -489,16 +474,8 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         filename = "terrain_mission.txt"
         self.load_mission(filename)
 
-        self.change_mode('MANUAL')
-        self.arm_vehicle()
-
         # Dive to match_distance off the bottom in preparation for the mission
-        pwm = 1300 if self.get_altitude(relative=True) > start_altitude else 1700
-        self.set_rc(Joystick.Throttle, pwm)
-        self.wait_altitude(altitude_min=start_altitude-1, altitude_max=start_altitude, relative=False, timeout=120)
-        self.set_rc(Joystick.Throttle, 1500)
-        self.delay_sim_time(1)
-
+        self.dive(start_altitude)
         self.change_mode('AUTO')
         self.watch_true_distance_maintained(match_distance, delta=validation_delta, timeout=500.0, final_waypoint=4)
 
@@ -886,15 +863,9 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
 
     def MAV_CMD_DO_REPOSITION(self):
         """Move vehicle using MAV_CMD_DO_REPOSITION"""
-        self.wait_ready_to_arm()
-        self.arm_vehicle()
-
         # Dive so that rangefinder is in range, required for MAV_FRAME_GLOBAL_TERRAIN_ALT
         start_altitude = -25
-        pwm = 1300 if self.get_altitude(relative=True) > start_altitude else 1700
-        self.set_rc(Joystick.Throttle, pwm)
-        self.wait_altitude(altitude_min=start_altitude-1, altitude_max=start_altitude, relative=False, timeout=120)
-        self.set_rc(Joystick.Throttle, 1500)
+        self.dive(start_altitude)
         self.change_mode('GUIDED')
 
         loc = self.mav.location()


### PR DESCRIPTION
### Summary

Add a self.dive(...) method for Sub, similar to self.takeoff(...) for Plane and Copter.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

This is a simple "start a dive" method that encapsulates some of the startup logic used by a number of Sub tests. There should be no behavior change.

Suggested by @peterbarker in https://github.com/ArduPilot/ardupilot/pull/27767