### PR TITLE
Improve device driver discovery messaging

### DIFF
--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -1092,10 +1092,17 @@ float AP_Baro::thrust_pressure_correction(uint8_t instance)
 /* register a new sensor, claiming a sensor slot. If we are out of
    slots it will panic
 */
-uint8_t AP_Baro::register_sensor(void)
+uint8_t AP_Baro::register_sensor(int32_t dev_id, const char *name)
 {
     if (_num_sensors >= ARRAY_SIZE(sensors)) {
         AP_HAL::panic("Too many barometers");
+    }
+    if (name != nullptr) {
+        DISCOVERY_PRINTF("%s found on bus %u id %u address 0x%02x\n",
+                         name,
+                         AP_HAL::Device::devid_get_bus(dev_id),
+                         unsigned(dev_id),
+                         AP_HAL::Device::devid_get_address(dev_id));
     }
     return _num_sensors++;
 }

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -1092,10 +1092,17 @@ float AP_Baro::thrust_pressure_correction(uint8_t instance)
 /* register a new sensor, claiming a sensor slot. If we are out of
    slots it will panic
 */
-uint8_t AP_Baro::register_sensor(void)
+uint8_t AP_Baro::register_sensor(int32_t dev_id, const char *name)
 {
     if (_num_sensors >= ARRAY_SIZE(sensors)) {
         AP_HAL::panic("Too many barometers");
+    }
+    if (name != nullptr) {
+        printf("%s found on bus %u id %u address 0x%02x\n",
+               name,
+               AP_HAL::Device::devid_get_bus(dev_id),
+               unsigned(dev_id),
+               AP_HAL::Device::devid_get_address(dev_id));
     }
     return _num_sensors++;
 }

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -188,8 +188,10 @@ public:
     baro_type_t get_type(uint8_t instance) { return sensors[instance].type; };
 
     // register a new sensor, claiming a sensor slot. If we are out of
-    // slots it will panic
-    uint8_t register_sensor(void);
+    // slots it will panic. Prints a "<name> found on bus N id N
+    // address 0xN" discovery message; name must not be null in normal
+    // callers (a defensive null-check is retained inside).
+    uint8_t register_sensor(int32_t dev_id, const char *name);
 
     // return number of registered sensors
     uint8_t num_instances(void) const { return _num_sensors; }

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -188,8 +188,9 @@ public:
     baro_type_t get_type(uint8_t instance) { return sensors[instance].type; };
 
     // register a new sensor, claiming a sensor slot. If we are out of
-    // slots it will panic
-    uint8_t register_sensor(void);
+    // slots it will panic. If name is non-null, prints a
+    // "<name> found on bus N id N address 0xN" discovery message.
+    uint8_t register_sensor(int32_t dev_id = 0, const char *name = nullptr);
 
     // return number of registered sensors
     uint8_t num_instances(void) const { return _num_sensors; }

--- a/libraries/AP_Baro/AP_Baro_AUAV.cpp
+++ b/libraries/AP_Baro/AP_Baro_AUAV.cpp
@@ -59,7 +59,7 @@ bool AP_Baro_AUAV::init()
     }
 
     // Register sensor and set dev-id
-    instance = _frontend.register_sensor();
+    instance = _frontend.register_sensor(dev->get_bus_id(), "AUAV");
     dev->set_device_type(DEVTYPE_BARO_AUAV);
     set_bus_id(instance, dev->get_bus_id());
 

--- a/libraries/AP_Baro/AP_Baro_BMP085.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP085.cpp
@@ -134,7 +134,7 @@ bool AP_Baro_BMP085::_init()
 
     _state = 0;
 
-    _instance = _frontend.register_sensor();
+    _instance = _frontend.register_sensor(_dev->get_bus_id(), "BMP085");
 
     _dev->set_device_type(DEVTYPE_BARO_BMP085);
     set_bus_id(_instance, _dev->get_bus_id());

--- a/libraries/AP_Baro/AP_Baro_BMP280.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP280.cpp
@@ -110,7 +110,7 @@ bool AP_Baro_BMP280::_init()
 
     _dev->write_register((BMP280_REG_CONFIG & mask), BMP280_FILTER_COEFFICIENT << 2, true);
 
-    _instance = _frontend.register_sensor();
+    _instance = _frontend.register_sensor(_dev->get_bus_id(), "BMP280");
 
     _dev->set_device_type(DEVTYPE_BARO_BMP280);
     set_bus_id(_instance, _dev->get_bus_id());

--- a/libraries/AP_Baro/AP_Baro_BMP388.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP388.cpp
@@ -90,12 +90,15 @@ bool AP_Baro_BMP388::init()
         return false;
     }
 
+    const char *name;
     switch (whoami) {
     case BMP388_ID:
         dev->set_device_type(DEVTYPE_BARO_BMP388);
+        name = "BMP388";
         break;
     case BMP390_ID:
         dev->set_device_type(DEVTYPE_BARO_BMP390);
+        name = "BMP390";
         break;
     default:
         return false;
@@ -112,7 +115,7 @@ bool AP_Baro_BMP388::init()
     // normal mode, temp and pressure
     dev->write_register(BMP388_REG_PWR_CTRL, 0x33, true);
 
-    instance = _frontend.register_sensor();
+    instance = _frontend.register_sensor(dev->get_bus_id(), name);
 
     set_bus_id(instance, dev->get_bus_id());
 

--- a/libraries/AP_Baro/AP_Baro_BMP581.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP581.cpp
@@ -132,7 +132,7 @@ bool AP_Baro_BMP581::init()
     // ORD 50Hz | Normal Mode
     _dev->write_register(BMP581_REG_ODR_CONFIG, 0b0111101, true);
 
-    instance = _frontend.register_sensor();
+    instance = _frontend.register_sensor(_dev->get_bus_id(), "BMP581");
 
     set_bus_id(instance, _dev->get_bus_id());
 

--- a/libraries/AP_Baro/AP_Baro_DPS280.cpp
+++ b/libraries/AP_Baro/AP_Baro_DPS280.cpp
@@ -187,7 +187,8 @@ bool AP_Baro_DPS280::init()
 
     set_config_registers();
 
-    instance = _frontend.register_sensor();
+    instance = _frontend.register_sensor(dev->get_bus_id(),
+                                          device_type() == DEVTYPE_BARO_DPS310 ? "DPS310" : "DPS280");
 
     dev->set_device_type(device_type());
     set_bus_id(instance, dev->get_bus_id());

--- a/libraries/AP_Baro/AP_Baro_DroneCAN.cpp
+++ b/libraries/AP_Baro/AP_Baro_DroneCAN.cpp
@@ -51,7 +51,7 @@ AP_Baro_Backend* AP_Baro_DroneCAN::probe(AP_Baro &baro)
                 backend->_ap_dronecan = detected_module.ap_dronecan;
                 backend->_node_id = detected_module.node_id;
 
-                backend->_instance = backend->_frontend.register_sensor();
+                backend->_instance = backend->_frontend.register_sensor(0, "DroneCAN");
                 backend->set_bus_id(backend->_instance, AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_UAVCAN,
                                                                                     detected_module.ap_dronecan->get_driver_index(),
                                                                                     backend->_node_id, 0));

--- a/libraries/AP_Baro/AP_Baro_Dummy.cpp
+++ b/libraries/AP_Baro/AP_Baro_Dummy.cpp
@@ -5,7 +5,7 @@
 AP_Baro_Dummy::AP_Baro_Dummy(AP_Baro &baro) :
     AP_Baro_Backend(baro)
 {
-    _instance = _frontend.register_sensor();
+    _instance = _frontend.register_sensor(0, "Dummy");
 }
 
 // Read the sensor

--- a/libraries/AP_Baro/AP_Baro_ExternalAHRS.cpp
+++ b/libraries/AP_Baro/AP_Baro_ExternalAHRS.cpp
@@ -5,7 +5,7 @@
 AP_Baro_ExternalAHRS::AP_Baro_ExternalAHRS(AP_Baro &baro, uint8_t port) :
     AP_Baro_Backend(baro)
 {
-    instance = _frontend.register_sensor();
+    instance = _frontend.register_sensor(0, "ExternalAHRS");
     set_bus_id(instance, AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_SERIAL,port,0,0));
 }
 

--- a/libraries/AP_Baro/AP_Baro_FBM320.cpp
+++ b/libraries/AP_Baro/AP_Baro_FBM320.cpp
@@ -111,7 +111,6 @@ bool AP_Baro_FBM320::init()
         dev->get_semaphore()->give();
         return false;
     }
-    printf("FBM320 ID 0x%x\n", whoami);
 
     if (!read_calibration()) {
         dev->get_semaphore()->give();
@@ -120,7 +119,7 @@ bool AP_Baro_FBM320::init()
 
     dev->write_register(FBM320_REG_CMD, FBM320_CMD_READ_T);
 
-    instance = _frontend.register_sensor();
+    instance = _frontend.register_sensor(dev->get_bus_id(), "FBM320");
 
     dev->set_device_type(DEVTYPE_BARO_FBM320);
     set_bus_id(instance, dev->get_bus_id());

--- a/libraries/AP_Baro/AP_Baro_ICM20789.cpp
+++ b/libraries/AP_Baro/AP_Baro_ICM20789.cpp
@@ -200,7 +200,7 @@ bool AP_Baro_ICM20789::init()
 
     dev->set_retries(0);
 
-    instance = _frontend.register_sensor();
+    instance = _frontend.register_sensor(dev->get_bus_id(), "ICM20789");
 
     dev->set_device_type(DEVTYPE_BARO_ICM20789);
     set_bus_id(instance, dev->get_bus_id());

--- a/libraries/AP_Baro/AP_Baro_ICP101XX.cpp
+++ b/libraries/AP_Baro/AP_Baro_ICP101XX.cpp
@@ -96,7 +96,7 @@ bool AP_Baro_ICP101XX::init()
 
     dev->set_retries(0);
 
-    instance = _frontend.register_sensor();
+    instance = _frontend.register_sensor(dev->get_bus_id(), "ICP101XX");
 
     dev->set_device_type(DEVTYPE_BARO_ICP101XX);
     set_bus_id(instance, dev->get_bus_id());

--- a/libraries/AP_Baro/AP_Baro_ICP201XX.cpp
+++ b/libraries/AP_Baro/AP_Baro_ICP201XX.cpp
@@ -127,7 +127,7 @@ bool AP_Baro_ICP201XX::init()
 
     dev->set_retries(0);
 
-    instance = _frontend.register_sensor();
+    instance = _frontend.register_sensor(dev->get_bus_id(), "ICP201XX");
 
     dev->set_device_type(DEVTYPE_BARO_ICP201XX);
     set_bus_id(instance, dev->get_bus_id());

--- a/libraries/AP_Baro/AP_Baro_KellerLD.cpp
+++ b/libraries/AP_Baro/AP_Baro_KellerLD.cpp
@@ -192,14 +192,12 @@ bool AP_Baro_KellerLD::_init()
         return false;
     }
 
-    printf("Keller LD found on bus %u address 0x%02x\n", _dev->bus_num(), _dev->get_bus_address());
-
     // Send a command to take a measurement
     _dev->transfer(&CMD_REQUEST_MEASUREMENT, 1, nullptr, 0);
 
     memset(&_accum, 0, sizeof(_accum));
 
-    _instance = _frontend.register_sensor();
+    _instance = _frontend.register_sensor(_dev->get_bus_id(), "KellerLD");
 
     _dev->set_device_type(DEVTYPE_BARO_KELLERLD);
     set_bus_id(_instance, _dev->get_bus_id());

--- a/libraries/AP_Baro/AP_Baro_LPS2XH.cpp
+++ b/libraries/AP_Baro/AP_Baro_LPS2XH.cpp
@@ -169,7 +169,7 @@ bool AP_Baro_LPS2XH::_init()
         CallTime = 1000000/75;
     }
 
-    _instance = _frontend.register_sensor();
+    _instance = _frontend.register_sensor(_dev->get_bus_id(), "LPS2XH");
 
     _dev->set_device_type(DEVTYPE_BARO_LPS2XH);
     set_bus_id(_instance, _dev->get_bus_id());

--- a/libraries/AP_Baro/AP_Baro_MS5611.cpp
+++ b/libraries/AP_Baro/AP_Baro_MS5611.cpp
@@ -149,8 +149,6 @@ bool AP_Baro_MS56XX::_init()
         return false;
     }
 
-    printf("%s found on bus %u address 0x%02x\n", name(), _dev->bus_num(), _dev->get_bus_address());
-
     // Save factory calibration coefficients
     _cal_reg.c1 = prom[1];
     _cal_reg.c2 = prom[2];
@@ -165,7 +163,7 @@ bool AP_Baro_MS56XX::_init()
 
     memset(&_accum, 0, sizeof(_accum));
 
-    _instance = _frontend.register_sensor();
+    _instance = _frontend.register_sensor(_dev->get_bus_id(), name());
 
     _dev->set_device_type(devtype());
     set_bus_id(_instance, _dev->get_bus_id());

--- a/libraries/AP_Baro/AP_Baro_MSP.cpp
+++ b/libraries/AP_Baro/AP_Baro_MSP.cpp
@@ -6,7 +6,7 @@ AP_Baro_MSP::AP_Baro_MSP(AP_Baro &baro, uint8_t _msp_instance) :
     AP_Baro_Backend(baro)
 {
     msp_instance = _msp_instance;
-    instance = _frontend.register_sensor();
+    instance = _frontend.register_sensor(0, "MSP");
     set_bus_id(instance, AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_MSP,0,msp_instance,0));
 }
 

--- a/libraries/AP_Baro/AP_Baro_SITL.cpp
+++ b/libraries/AP_Baro/AP_Baro_SITL.cpp
@@ -16,7 +16,7 @@ AP_Baro_SITL::AP_Baro_SITL(AP_Baro &baro) :
     _has_sample(false)
 {
     if (_sitl != nullptr) {
-        _instance = _frontend.register_sensor();
+        _instance = _frontend.register_sensor(0, "SITL");
 #if APM_BUILD_TYPE(APM_BUILD_ArduSub)
         _frontend.set_type(_instance, AP_Baro::BARO_TYPE_WATER);
 #endif

--- a/libraries/AP_Baro/AP_Baro_SPL06.cpp
+++ b/libraries/AP_Baro/AP_Baro_SPL06.cpp
@@ -233,7 +233,8 @@ bool AP_Baro_SPL06::_init()
     }
     _dev->write_register(SPL06_REG_INT_AND_FIFO_CFG, int_and_fifo_reg_value, true);
 
-    _instance = _frontend.register_sensor();
+    _instance = _frontend.register_sensor(_dev->get_bus_id(),
+                                           type == Type::SPA06 ? "SPA06" : "SPL06");
 
     if(type == Type::SPA06) {
 	    _dev->set_device_type(DEVTYPE_BARO_SPA06);

--- a/libraries/AP_BattMonitor/AP_BattMonitor_AD7091R5.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_AD7091R5.cpp
@@ -141,6 +141,7 @@ void AP_BattMonitor_AD7091R5::init()
             //Reset and config device
             if (_initialize()) {
                 _dev->set_retries(2); // drop to 2 retries for runtime
+                announce_discovery(_dev->get_bus_id(), "AD7091R5");
                 _dev->register_periodic_callback(AD7091R5_PERIOD_USEC, FUNCTOR_BIND_MEMBER(&AP_BattMonitor_AD7091R5::_read_adc, void));
             }
         }

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
@@ -59,6 +59,19 @@ AP_BattMonitor_Backend::AP_BattMonitor_Backend(AP_BattMonitor &mon, AP_BattMonit
 {
 }
 
+void AP_BattMonitor_Backend::announce_discovery(int32_t dev_id, const char *name)
+{
+    if (_discovery_announced || name == nullptr) {
+        return;
+    }
+    _discovery_announced = true;
+    DISCOVERY_PRINTF("%s found on bus %u id %u address 0x%02x\n",
+                     name,
+                     AP_HAL::Device::devid_get_bus(dev_id),
+                     unsigned(dev_id),
+                     AP_HAL::Device::devid_get_address(dev_id));
+}
+
 // capacity_remaining_pct - returns true if the battery % is available and writes to the percentage argument
 // return false if the battery is unhealthy, does not have current monitoring, or the pack_capacity is too small
 bool AP_BattMonitor_Backend::capacity_remaining_pct(uint8_t &percentage) const

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
@@ -117,6 +117,12 @@ protected:
     void check_failsafe_types(bool &low_voltage, bool &low_capacity, bool &critical_voltage, bool &critical_capacity) const;
     void update_consumed(AP_BattMonitor::BattMonitor_State &state, uint32_t dt_us);
 
+    // Announce successful device discovery via DISCOVERY_PRINTF (a no-op
+    // unless the board defines HAL_DISCOVERY_PRINTF_ENABLED). Subsequent
+    // calls on the same backend instance are ignored, so it is safe to
+    // call from probe paths that may run more than once.
+    void announce_discovery(int32_t dev_id, const char *name);
+
 private:
     // resistance estimate
     uint32_t    _resistance_timer_ms;    // system time of last resistance estimate update
@@ -125,6 +131,8 @@ private:
     float       _current_filt_amps;      // filtered current
     float       _resistance_voltage_ref; // voltage used for maximum resistance calculation
     float       _resistance_current_ref; // current used for maximum resistance calculation
+
+    bool        _discovery_announced{false}; // true once announce_discovery() has fired
 };
 
 #if AP_BATTERY_SCRIPTING_ENABLED

--- a/libraries/AP_BattMonitor/AP_BattMonitor_INA239.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_INA239.cpp
@@ -97,6 +97,7 @@ void AP_BattMonitor_INA239::configure(void)
     }
 
     configured = true;
+    announce_discovery(dev->get_bus_id(), "INA239");
 }
 
 /// read the battery_voltage and current, should be called at 10hz

--- a/libraries/AP_BattMonitor/AP_BattMonitor_INA2xx.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_INA2xx.cpp
@@ -375,6 +375,26 @@ void AP_BattMonitor_INA2XX::timer(void)
 
         // Reset failed reads after successful detection
         failed_reads = 0;
+
+        const char *dev_name = "INA2xx";
+        switch (dev_type) {
+        case DevType::INA226: dev_name = "INA226"; break;
+        case DevType::INA228: dev_name = "INA228"; break;
+        case DevType::INA231: dev_name = "INA231"; break;
+        case DevType::INA238: dev_name = "INA238"; break;
+        case DevType::INA260: dev_name = "INA260"; break;
+        case DevType::UNKNOWN: break;
+        }
+        // detect_device() may have probed by cycling dev->set_address(),
+        // which updates the runtime address but leaves the cached bus_id
+        // with the construction-time address (0 when I2C_ADDR is unset).
+        // Rebuild the bus_id with the actual address that responded.
+        const uint8_t probed_addr = (i2c_address.get() != 0)
+            ? uint8_t(i2c_address.get())
+            : i2c_probe_addresses[(i2c_probe_next + sizeof(i2c_probe_addresses) - 1) % sizeof(i2c_probe_addresses)];
+        const int32_t announced_id = AP_HAL::Device::make_bus_id(
+            AP_HAL::Device::BUS_TYPE_I2C, i2c_bus.get(), probed_addr, 0);
+        announce_discovery(announced_id, dev_name);
     }
 
     float voltage = 0, current = 0;

--- a/libraries/AP_BattMonitor/AP_BattMonitor_INA3221.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_INA3221.cpp
@@ -251,6 +251,7 @@ void AP_BattMonitor_INA3221::init()
     d->statelist = address_driver_state;
 
     debug("Found INA3221 ch%d@0x%02x on bus %u", dev_channel, dev_address, dev_bus);
+    announce_discovery(d->dev->get_bus_id(), "INA3221");
 
     address_driver_count++;
 

--- a/libraries/AP_BattMonitor/AP_BattMonitor_LTC2946.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_LTC2946.cpp
@@ -48,6 +48,7 @@ void AP_BattMonitor_LTC2946::init(void)
     current_LSB = (0.1024/0.0005) / 4095.0;
 
     GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "LTC2946: found monitor on bus %u", HAL_BATTMON_LTC2946_BUS);
+    announce_discovery(dev->get_bus_id(), "LTC2946");
 
     if (dev) {
         dev->register_periodic_callback(25000, FUNCTOR_BIND_MEMBER(&AP_BattMonitor_LTC2946::timer, void));

--- a/libraries/AP_BattMonitor/AP_BattMonitor_TIBQ76952.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_TIBQ76952.cpp
@@ -699,6 +699,7 @@ bool AP_BattMonitor_TIBQ76952::configure()
     // mark configuration as complete to prevent repeated attempts
     configured = true;
     Debug("BQ76952: Configuration complete");
+    announce_discovery(dev->get_bus_id(), "BQ76952");
 
     // report success
     return true;

--- a/libraries/AP_Compass/AP_Compass_AK09916.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK09916.cpp
@@ -252,7 +252,7 @@ bool AP_Compass_AK09916::init()
 
     /* register the compass instance in the frontend */
     _bus->set_device_type(_devtype);
-    if (!register_compass(_bus->get_bus_id())) {
+    if (!register_compass(_bus->get_bus_id(), name)) {
         goto fail;
     }
 

--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -162,7 +162,7 @@ bool AP_Compass_AK8963::init()
 
     /* register the compass instance in the frontend */
     _bus->set_device_type(DEVTYPE_AK8963);
-    if (!register_compass(_bus->get_bus_id())) {
+    if (!register_compass(_bus->get_bus_id(), name)) {
         goto fail;
     }
 

--- a/libraries/AP_Compass/AP_Compass_BMM150.cpp
+++ b/libraries/AP_Compass/AP_Compass_BMM150.cpp
@@ -214,7 +214,7 @@ bool AP_Compass_BMM150::init()
 
     /* register the compass instance in the frontend */
     _dev->set_device_type(DEVTYPE_BMM150);
-    if (!register_compass(_dev->get_bus_id())) {
+    if (!register_compass(_dev->get_bus_id(), name)) {
         return false;
     }
 

--- a/libraries/AP_Compass/AP_Compass_BMM350.cpp
+++ b/libraries/AP_Compass/AP_Compass_BMM350.cpp
@@ -406,11 +406,9 @@ bool AP_Compass_BMM350::init()
 
     /* Register the compass instance in the frontend */
     _dev->set_device_type(DEVTYPE_BMM350);
-    if (!register_compass(_dev->get_bus_id())) {
+    if (!register_compass(_dev->get_bus_id(), name)) {
         return false;
     }
-
-    // printf("BMM350: Found at address 0x%x as compass %u\n", _dev->get_bus_address(), _compass_instance);
 
     set_rotation(_rotation);
 

--- a/libraries/AP_Compass/AP_Compass_Backend.cpp
+++ b/libraries/AP_Compass/AP_Compass_Backend.cpp
@@ -205,12 +205,19 @@ void AP_Compass_Backend::set_last_update_usec(uint32_t last_update)
   register a new backend with frontend, returning instance which
   should be used in publish_field()
  */
-bool AP_Compass_Backend::register_compass(int32_t dev_id)
+bool AP_Compass_Backend::register_compass(int32_t dev_id, const char *name)
 {
     if (!_compass.register_compass(dev_id, instance)) {
         return false;
     }
     set_dev_id(dev_id);
+    if (name != nullptr) {
+        DISCOVERY_PRINTF("%s found on bus %u id %u address 0x%02x\n",
+                         name,
+                         AP_HAL::Device::devid_get_bus(dev_id),
+                         unsigned(dev_id),
+                         AP_HAL::Device::devid_get_address(dev_id));
+    }
     return true;
 }
 

--- a/libraries/AP_Compass/AP_Compass_Backend.cpp
+++ b/libraries/AP_Compass/AP_Compass_Backend.cpp
@@ -11,6 +11,8 @@
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
 
+#include <stdio.h>
+
 AP_Compass_Backend::AP_Compass_Backend()
     : _compass(AP::compass())
 {
@@ -205,12 +207,19 @@ void AP_Compass_Backend::set_last_update_usec(uint32_t last_update)
   register a new backend with frontend, returning instance which
   should be used in publish_field()
  */
-bool AP_Compass_Backend::register_compass(int32_t dev_id)
+bool AP_Compass_Backend::register_compass(int32_t dev_id, const char *name)
 {
     if (!_compass.register_compass(dev_id, instance)) {
         return false;
     }
     set_dev_id(dev_id);
+    if (name != nullptr) {
+        printf("%s found on bus %u id %u address 0x%02x\n",
+               name,
+               AP_HAL::Device::devid_get_bus(dev_id),
+               unsigned(dev_id),
+               AP_HAL::Device::devid_get_address(dev_id));
+    }
     return true;
 }
 

--- a/libraries/AP_Compass/AP_Compass_Backend.h
+++ b/libraries/AP_Compass/AP_Compass_Backend.h
@@ -117,8 +117,11 @@ protected:
                            uint32_t max_samples = 10);
     void drain_accumulated_samples(const Vector3f *scale = NULL);
 
-    // register compass instance with the frontend
-    bool register_compass(int32_t dev_id) WARN_IF_UNUSED;
+    // register compass instance with the frontend. Prints a
+    // "<name> found on bus N id N address 0xN" discovery message on
+    // success; name must not be null in normal callers (a defensive
+    // null-check is retained inside register_compass).
+    bool register_compass(int32_t dev_id, const char *name) WARN_IF_UNUSED;
 
     // set dev_id for an instance
     void set_dev_id(uint32_t dev_id);

--- a/libraries/AP_Compass/AP_Compass_Backend.h
+++ b/libraries/AP_Compass/AP_Compass_Backend.h
@@ -117,8 +117,10 @@ protected:
                            uint32_t max_samples = 10);
     void drain_accumulated_samples(const Vector3f *scale = NULL);
 
-    // register compass instance with the frontend
-    bool register_compass(int32_t dev_id) WARN_IF_UNUSED;
+    // register compass instance with the frontend. If name is non-null,
+    // prints a "<name> found on bus N id N address 0xN" discovery message
+    // on success.
+    bool register_compass(int32_t dev_id, const char *name = nullptr) WARN_IF_UNUSED;
 
     // set dev_id for an instance
     void set_dev_id(uint32_t dev_id);

--- a/libraries/AP_Compass/AP_Compass_DroneCAN.cpp
+++ b/libraries/AP_Compass/AP_Compass_DroneCAN.cpp
@@ -91,7 +91,7 @@ AP_Compass_Backend* AP_Compass_DroneCAN::probe(uint8_t index)
 bool AP_Compass_DroneCAN::init()
 {
     // Adding 1 is necessary to allow backward compatibility, where this field was set as 1 by default
-    if (!register_compass(_devid)) {
+    if (!register_compass(_devid, "DroneCAN")) {
         return false;
     }
     set_external(true);

--- a/libraries/AP_Compass/AP_Compass_ExternalAHRS.cpp
+++ b/libraries/AP_Compass/AP_Compass_ExternalAHRS.cpp
@@ -25,7 +25,7 @@ AP_Compass_Backend *AP_Compass_ExternalAHRS::probe(uint8_t port)
     if (ret == nullptr) {
         return nullptr;
     }
-    if (!ret->register_compass(devid)) {
+    if (!ret->register_compass(devid, "ExternalAHRS")) {
         delete ret;
         return nullptr;
     }

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -196,7 +196,7 @@ bool AP_Compass_HMC5843::init()
 
     //register compass instance
     _bus->set_device_type(DEVTYPE_HMC5883);
-    if (!register_compass(_bus->get_bus_id())) {
+    if (!register_compass(_bus->get_bus_id(), name)) {
         return false;
     }
 
@@ -210,8 +210,6 @@ bool AP_Compass_HMC5843::init()
     _bus->register_periodic_callback(13333,
                                      FUNCTOR_BIND_MEMBER(&AP_Compass_HMC5843::_timer, void));
 
-    DEV_PRINTF("HMC5843 found on bus 0x%x\n", (unsigned)_bus->get_bus_id());
-    
     return true;
 
 errout:

--- a/libraries/AP_Compass/AP_Compass_IIS2MDC.cpp
+++ b/libraries/AP_Compass/AP_Compass_IIS2MDC.cpp
@@ -98,7 +98,7 @@ bool AP_Compass_IIS2MDC::init()
     // register compass instance
     _dev->set_device_type(DEVTYPE_IIS2MDC);
 
-    if (!register_compass(_dev->get_bus_id())) {
+    if (!register_compass(_dev->get_bus_id(), name)) {
         return false;
     }
 

--- a/libraries/AP_Compass/AP_Compass_IST8308.cpp
+++ b/libraries/AP_Compass/AP_Compass_IST8308.cpp
@@ -162,12 +162,9 @@ bool AP_Compass_IST8308::init()
 
     //register compass instance
     _dev->set_device_type(DEVTYPE_IST8308);
-    if (!register_compass(_dev->get_bus_id())) {
+    if (!register_compass(_dev->get_bus_id(), name)) {
         return false;
     }
-
-    printf("%s found on bus %u id %u address 0x%02x\n", name,
-           _dev->bus_num(), unsigned(_dev->get_bus_id()), _dev->get_bus_address());
 
     set_rotation(_rotation);
 

--- a/libraries/AP_Compass/AP_Compass_IST8310.cpp
+++ b/libraries/AP_Compass/AP_Compass_IST8310.cpp
@@ -172,12 +172,9 @@ bool AP_Compass_IST8310::init()
 
     // register compass instance
     _dev->set_device_type(DEVTYPE_IST8310);
-    if (!register_compass(_dev->get_bus_id())) {
+    if (!register_compass(_dev->get_bus_id(), name)) {
         return false;
     }
-
-    printf("%s found on bus %u id %u address 0x%02x\n", name,
-           _dev->bus_num(), unsigned(_dev->get_bus_id()), _dev->get_bus_address());
 
     set_rotation(_rotation);
 

--- a/libraries/AP_Compass/AP_Compass_LIS2MDL.cpp
+++ b/libraries/AP_Compass/AP_Compass_LIS2MDL.cpp
@@ -98,11 +98,9 @@ bool AP_Compass_LIS2MDL::init()
 
     /* register the compass instance in the frontend */
     dev->set_device_type(DEVTYPE_LIS2MDL);
-    if (!register_compass(dev->get_bus_id())) {
+    if (!register_compass(dev->get_bus_id(), name)) {
         return false;
     }
-
-    printf("Found a LIS2MDL on 0x%x as compass %u\n", unsigned(dev->get_bus_id()), instance);
 
     set_rotation(rotation);
 

--- a/libraries/AP_Compass/AP_Compass_LIS3MDL.cpp
+++ b/libraries/AP_Compass/AP_Compass_LIS3MDL.cpp
@@ -106,11 +106,9 @@ bool AP_Compass_LIS3MDL::init()
 
     /* register the compass instance in the frontend */
     dev->set_device_type(DEVTYPE_LIS3MDL);
-    if (!register_compass(dev->get_bus_id())) {
+    if (!register_compass(dev->get_bus_id(), name)) {
         return false;
     }
-
-    printf("Found a LIS3MDL on 0x%x as compass %u\n", unsigned(dev->get_bus_id()), instance);
 
     set_rotation(rotation);
 

--- a/libraries/AP_Compass/AP_Compass_LSM303D.cpp
+++ b/libraries/AP_Compass/AP_Compass_LSM303D.cpp
@@ -270,7 +270,7 @@ bool AP_Compass_LSM303D::init(enum Rotation rotation)
 
     /* register the compass instance in the frontend */
     _dev->set_device_type(DEVTYPE_LSM303D);
-    if (!register_compass(_dev->get_bus_id())) {
+    if (!register_compass(_dev->get_bus_id(), name)) {
         return false;
     }
 

--- a/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp
+++ b/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp
@@ -98,7 +98,7 @@ bool AP_Compass_LSM9DS1::init()
 
     //register compass instance
     _dev->set_device_type(DEVTYPE_LSM9DS1);
-    if (!register_compass(_dev->get_bus_id())) {
+    if (!register_compass(_dev->get_bus_id(), name)) {
         goto errout;
     }
 

--- a/libraries/AP_Compass/AP_Compass_MAG3110.cpp
+++ b/libraries/AP_Compass/AP_Compass_MAG3110.cpp
@@ -119,7 +119,7 @@ bool AP_Compass_MAG3110::init(enum Rotation rotation)
     
     /* register the compass instance in the frontend */
     _dev->set_device_type(DEVTYPE_MAG3110);
-    if (!register_compass(_dev->get_bus_id())) {
+    if (!register_compass(_dev->get_bus_id(), name)) {
         return false;
     }
 
@@ -161,8 +161,6 @@ bool AP_Compass_MAG3110::_hardware_init()
     ret = true;
 
     _dev->set_retries(3);
-    
-    printf("MAG3110 found on bus 0x%x\n", (uint16_t)_dev->get_bus_id());
 
 exit:
     _dev->set_speed(AP_HAL::Device::SPEED_HIGH);

--- a/libraries/AP_Compass/AP_Compass_MMC3416.cpp
+++ b/libraries/AP_Compass/AP_Compass_MMC3416.cpp
@@ -97,11 +97,9 @@ bool AP_Compass_MMC3416::init()
 
     /* register the compass instance in the frontend */
     dev->set_device_type(DEVTYPE_MMC3416);
-    if (!register_compass(dev->get_bus_id())) {
+    if (!register_compass(dev->get_bus_id(), name)) {
         return false;
     }
-
-    printf("Found a MMC3416 on 0x%x as compass %u\n", unsigned(dev->get_bus_id()), instance);
 
     set_rotation(rotation);
 

--- a/libraries/AP_Compass/AP_Compass_MMC5xx3.cpp
+++ b/libraries/AP_Compass/AP_Compass_MMC5xx3.cpp
@@ -109,11 +109,9 @@ bool AP_Compass_MMC5XX3::init()
 
     /* register the compass instance in the frontend */
     dev->set_device_type(DEVTYPE_MMC5983);
-    if (!register_compass(dev->get_bus_id())) {
+    if (!register_compass(dev->get_bus_id(), name)) {
         return false;
     }
-
-    printf("Found a MMC5983 on 0x%x as compass %u\n", unsigned(dev->get_bus_id()), instance);
 
     set_rotation(rotation);
 

--- a/libraries/AP_Compass/AP_Compass_MSP.cpp
+++ b/libraries/AP_Compass/AP_Compass_MSP.cpp
@@ -35,7 +35,7 @@ AP_Compass_Backend *AP_Compass_MSP::probe(uint8_t _msp_instance)
 bool AP_Compass_MSP::init()
 {
     auto devid = AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_MSP, 0, msp_instance, 0);
-    if (!register_compass(devid)) {
+    if (!register_compass(devid, "MSP")) {
         return false;
     }
 

--- a/libraries/AP_Compass/AP_Compass_QMC5883L.cpp
+++ b/libraries/AP_Compass/AP_Compass_QMC5883L.cpp
@@ -115,12 +115,9 @@ bool AP_Compass_QMC5883L::init()
 
     //register compass instance
     _dev->set_device_type(DEVTYPE_QMC5883L);
-    if (!register_compass(_dev->get_bus_id())) {
+    if (!register_compass(_dev->get_bus_id(), name)) {
         return false;
     }
-
-    printf("%s found on bus %u id %u address 0x%02x\n", name,
-           _dev->bus_num(), unsigned(_dev->get_bus_id()), _dev->get_bus_address());
 
     set_rotation(_rotation);
 

--- a/libraries/AP_Compass/AP_Compass_QMC5883P.cpp
+++ b/libraries/AP_Compass/AP_Compass_QMC5883P.cpp
@@ -126,12 +126,9 @@ bool AP_Compass_QMC5883P::init()
 
     //register compass instance
     _dev->set_device_type(DEVTYPE_QMC5883P);
-    if (!register_compass(_dev->get_bus_id())) {
+    if (!register_compass(_dev->get_bus_id(), name)) {
         return false;
     }
-
-    printf("%s found on bus %u id %u address 0x%02x\n", name,
-           _dev->bus_num(), unsigned(_dev->get_bus_id()), _dev->get_bus_address());
 
     set_rotation(_rotation);
 

--- a/libraries/AP_Compass/AP_Compass_RM3100.cpp
+++ b/libraries/AP_Compass/AP_Compass_RM3100.cpp
@@ -145,11 +145,9 @@ bool AP_Compass_RM3100::init()
 
     /* register the compass instance in the frontend */
     dev->set_device_type(DEVTYPE_RM3100);
-    if (!register_compass(dev->get_bus_id())) {
+    if (!register_compass(dev->get_bus_id(), name)) {
         return false;
     }
-
-    DEV_PRINTF("RM3100: Found at address 0x%x as compass %u\n", dev->get_bus_address(), instance);
 
     set_rotation(rotation);
 

--- a/libraries/AP_Compass/AP_Compass_SITL.cpp
+++ b/libraries/AP_Compass/AP_Compass_SITL.cpp
@@ -18,7 +18,7 @@ AP_Compass_SITL::AP_Compass_SITL(uint8_t _sitl_instance) :
             if (dev_id == 0) {
                 return;
             }
-            if (!register_compass(dev_id)) {
+            if (!register_compass(dev_id, "SITL")) {
                 return;
             }
                 if (_sitl->mag_save_ids) {

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -921,6 +921,7 @@ void AP_GPS::update_instance(uint8_t instance)
         if (!state[instance].announced_detection) {
             state[instance].announced_detection = true;
             GCS_SEND_TEXT(MAV_SEVERITY_INFO, "GPS %d: detected %s", instance + 1, drivers[instance]->name());
+            DISCOVERY_PRINTF("GPS %d: detected %s\n", instance + 1, drivers[instance]->name());
         }
 
         // delta will only be correct after parsing two messages

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -16,6 +16,8 @@
 
 #if AP_GPS_ENABLED
 
+#include <stdio.h>
+
 #include "AP_GPS.h"
 
 #include <AP_Common/AP_Common.h>
@@ -921,6 +923,7 @@ void AP_GPS::update_instance(uint8_t instance)
         if (!state[instance].announced_detection) {
             state[instance].announced_detection = true;
             GCS_SEND_TEXT(MAV_SEVERITY_INFO, "GPS %d: detected %s", instance + 1, drivers[instance]->name());
+            printf("GPS %d: detected %s\n", instance + 1, drivers[instance]->name());
         }
 
         // delta will only be correct after parsing two messages

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -1434,6 +1434,11 @@ AP_GPS_UBLOX::_parse_gps(void)
                                              state.instance + 1,
                                              _version.hwVersion,
                                              _version.swVersion);
+            DISCOVERY_PRINTF("u-blox %s%s%d HW: %s SW: %s\n",
+                             _module, mod != nullptr ? " " : "",
+                             state.instance + 1,
+                             _version.hwVersion,
+                             _version.swVersion);
             // check for F9 and M9. The F9 does not respond to SVINFO,
             // so we need to use MON_VER for hardware generation
             if (strncmp(_version.hwVersion, "00190000", 8) == 0) {

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -1434,6 +1434,11 @@ AP_GPS_UBLOX::_parse_gps(void)
                                              state.instance + 1,
                                              _version.hwVersion,
                                              _version.swVersion);
+            printf("u-blox %s%s%d HW: %s SW: %s\n",
+                   _module, mod != nullptr ? " " : "",
+                   state.instance + 1,
+                   _version.hwVersion,
+                   _version.swVersion);
             // check for F9 and M9. The F9 does not respond to SVINFO,
             // so we need to use MON_VER for hardware generation
             if (strncmp(_version.hwVersion, "00190000", 8) == 0) {

--- a/libraries/AP_HAL/HAL.h
+++ b/libraries/AP_HAL/HAL.h
@@ -4,6 +4,10 @@ class AP_Param;
 
 #include "AP_HAL_Namespace.h"
 
+#if defined(HAL_DISCOVERY_PRINTF_ENABLED) && HAL_DISCOVERY_PRINTF_ENABLED
+#include <stdio.h>
+#endif
+
 #include "AnalogIn.h"
 #include "GPIO.h"
 #include "RCInput.h"
@@ -158,6 +162,17 @@ public:
 # define DEV_PRINTF(fmt, args ...)  do { hal.console->printf(fmt, ## args); } while(0)
 #else
 # define DEV_PRINTF(fmt, args ...)
+#endif
+
+// DISCOVERY_PRINTF is used by sensor backends to announce successful
+// device discovery during boot. Sending these to stdout is not a good
+// idea on STM32, so by default it is a no-op; discovery is still
+// reported to the GCS via GCS_SEND_TEXT. A board can opt in by
+// defining HAL_DISCOVERY_PRINTF_ENABLED in its board header (or hwdef).
+#if defined(HAL_DISCOVERY_PRINTF_ENABLED) && HAL_DISCOVERY_PRINTF_ENABLED
+# define DISCOVERY_PRINTF(fmt, args ...)  do { ::printf(fmt, ## args); } while(0)
+#else
+# define DISCOVERY_PRINTF(fmt, args ...)  do { } while(0)
 #endif
 
 };

--- a/libraries/AP_HAL/board/qurt.h
+++ b/libraries/AP_HAL/board/qurt.h
@@ -54,6 +54,9 @@
 
 #define HAL_LOGGING_FILESYSTEM_ENABLED 1
 
+// print sensor device discovery messages to stdout during boot
+#define HAL_DISCOVERY_PRINTF_ENABLED 1
+
 #define AP_FILESYSTEM_POSIX_HAVE_UTIME 0
 #define AP_FILESYSTEM_POSIX_HAVE_FSYNC 0
 #define AP_FILESYSTEM_POSIX_HAVE_STATFS 0

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -813,7 +813,7 @@ bool AP_InertialSensor::get_gyro_instance(uint8_t &instance) const
 /*
   register a new accel instance
  */
-bool AP_InertialSensor::register_accel(uint8_t &instance, uint16_t raw_sample_rate_hz, uint32_t id)
+bool AP_InertialSensor::register_accel(uint8_t &instance, uint16_t raw_sample_rate_hz, uint32_t id, const char *name)
 {
     if (_accel_count == INS_MAX_INSTANCES) {
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Failed to register accel id %u", unsigned(id));
@@ -854,6 +854,15 @@ bool AP_InertialSensor::register_accel(uint8_t &instance, uint16_t raw_sample_ra
 #endif
 
     instance = _accel_count++;
+
+    if (name != nullptr) {
+        DISCOVERY_PRINTF("%s found on bus %u id %u address 0x%02x\n",
+                         name,
+                         AP_HAL::Device::devid_get_bus(id),
+                         unsigned(id),
+                         AP_HAL::Device::devid_get_address(id));
+    }
+
     return true;
 }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <stdio.h>
 
 #include "AP_InertialSensor.h"
 
@@ -812,7 +813,7 @@ bool AP_InertialSensor::get_gyro_instance(uint8_t &instance) const
 /*
   register a new accel instance
  */
-bool AP_InertialSensor::register_accel(uint8_t &instance, uint16_t raw_sample_rate_hz, uint32_t id)
+bool AP_InertialSensor::register_accel(uint8_t &instance, uint16_t raw_sample_rate_hz, uint32_t id, const char *name)
 {
     if (_accel_count == INS_MAX_INSTANCES) {
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Failed to register accel id %u", unsigned(id));
@@ -853,6 +854,15 @@ bool AP_InertialSensor::register_accel(uint8_t &instance, uint16_t raw_sample_ra
 #endif
 
     instance = _accel_count++;
+
+    if (name != nullptr) {
+        printf("%s found on bus %u id %u address 0x%02x\n",
+               name,
+               AP_HAL::Device::devid_get_bus(id),
+               unsigned(id),
+               AP_HAL::Device::devid_get_address(id));
+    }
+
     return true;
 }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -80,9 +80,11 @@ public:
     bool get_gyro_instance(uint8_t &instance) const;
 
     /// Register a new gyro/accel driver, allocating an instance
-    /// number
+    /// number. register_accel prints a "<name> found on bus N id N
+    /// address 0xN" discovery message; name must not be null in
+    /// normal callers (a defensive null-check is retained inside).
     bool register_gyro(uint8_t &instance, uint16_t raw_sample_rate_hz, uint32_t id);
-    bool register_accel(uint8_t &instance, uint16_t raw_sample_rate_hz, uint32_t id);
+    bool register_accel(uint8_t &instance, uint16_t raw_sample_rate_hz, uint32_t id, const char *name);
 
     // a function called by the main thread at the main loop rate:
     void periodic();

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -80,9 +80,10 @@ public:
     bool get_gyro_instance(uint8_t &instance) const;
 
     /// Register a new gyro/accel driver, allocating an instance
-    /// number
+    /// number. If name is non-null, register_accel prints a
+    /// "<name> found on bus N id N address 0xN" discovery message.
     bool register_gyro(uint8_t &instance, uint16_t raw_sample_rate_hz, uint32_t id);
-    bool register_accel(uint8_t &instance, uint16_t raw_sample_rate_hz, uint32_t id);
+    bool register_accel(uint8_t &instance, uint16_t raw_sample_rate_hz, uint32_t id, const char *name = nullptr);
 
     // a function called by the main thread at the main loop rate:
     void periodic();

--- a/libraries/AP_InertialSensor/AP_InertialSensor_ADIS1647x.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_ADIS1647x.cpp
@@ -105,7 +105,7 @@ AP_InertialSensor_ADIS1647x::probe(AP_InertialSensor &imu,
 
 void AP_InertialSensor_ADIS1647x::start()
 {
-    if (!_imu.register_accel(accel_instance, expected_sample_rate_hz, dev->get_bus_id_devtype(DEVTYPE_INS_ADIS1647X)) ||
+    if (!_imu.register_accel(accel_instance, expected_sample_rate_hz, dev->get_bus_id_devtype(DEVTYPE_INS_ADIS1647X), "ADIS1647x") ||
         !_imu.register_gyro(gyro_instance, expected_sample_rate_hz,   dev->get_bus_id_devtype(DEVTYPE_INS_ADIS1647X))) {
         return;
     }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_ADIS16607.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_ADIS16607.cpp
@@ -107,7 +107,7 @@ AP_InertialSensor_ADIS16607::probe(AP_InertialSensor &imu,
 
 void AP_InertialSensor_ADIS16607::start()
 {
-    if (!_imu.register_accel(accel_instance, expected_sample_rate_hz, dev->get_bus_id_devtype(DEVTYPE_INS_ADIS16607)) ||
+    if (!_imu.register_accel(accel_instance, expected_sample_rate_hz, dev->get_bus_id_devtype(DEVTYPE_INS_ADIS16607), "ADIS16607") ||
         !_imu.register_gyro(gyro_instance, expected_sample_rate_hz, dev->get_bus_id_devtype(DEVTYPE_INS_ADIS16607))) {
         return;
     }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_ASM330.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_ASM330.cpp
@@ -126,7 +126,7 @@ bool AP_InertialSensor_ASM330::hardware_init()
 void AP_InertialSensor_ASM330::start(void)
 {
     if (!_imu.register_gyro(gyro_instance, GYRO_SAMPLE_RATE, dev->get_bus_id_devtype(DEVTYPE_INS_ASM330)) ||
-        !_imu.register_accel(accel_instance, ACCEL_SAMPLE_RATE, dev->get_bus_id_devtype(DEVTYPE_INS_ASM330))) {
+        !_imu.register_accel(accel_instance, ACCEL_SAMPLE_RATE, dev->get_bus_id_devtype(DEVTYPE_INS_ASM330), "ASM330")) {
         return;
     }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_BMI055.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_BMI055.cpp
@@ -101,7 +101,7 @@ AP_InertialSensor_BMI055::probe(AP_InertialSensor &imu,
 
 void AP_InertialSensor_BMI055::start()
 {
-    if (!_imu.register_accel(accel_instance, ACCEL_BACKEND_SAMPLE_RATE, dev_accel->get_bus_id_devtype(DEVTYPE_INS_BMI055)) ||
+    if (!_imu.register_accel(accel_instance, ACCEL_BACKEND_SAMPLE_RATE, dev_accel->get_bus_id_devtype(DEVTYPE_INS_BMI055), "BMI055") ||
         !_imu.register_gyro(gyro_instance, GYRO_BACKEND_SAMPLE_RATE,   dev_gyro->get_bus_id_devtype(DEVTYPE_INS_BMI055))) {
         return;
     }
@@ -161,8 +161,6 @@ bool AP_InertialSensor_BMI055::accel_init()
         goto failed;
     }
 
-    DEV_PRINTF("BMI055: found accel\n");
-
     dev_accel->get_semaphore()->give();
     return true;
     
@@ -214,8 +212,6 @@ bool AP_InertialSensor_BMI055::gyro_init()
     if (!dev_gyro->write_register(REGG_FIFO_CONFIG_1, 0x80, true)) {
         goto failed;
     }
-
-    DEV_PRINTF("BMI055: found gyro\n");    
 
     dev_gyro->get_semaphore()->give();
     return true;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_BMI088.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_BMI088.cpp
@@ -100,7 +100,8 @@ AP_InertialSensor_BMI088::probe(AP_InertialSensor &imu,
 
 void AP_InertialSensor_BMI088::start()
 {
-    if (!_imu.register_accel(accel_instance, ACCEL_BACKEND_SAMPLE_RATE, dev_accel->get_bus_id_devtype(_accel_devtype)) ||
+    if (!_imu.register_accel(accel_instance, ACCEL_BACKEND_SAMPLE_RATE, dev_accel->get_bus_id_devtype(_accel_devtype),
+                             _accel_devtype == DEVTYPE_INS_BMI085 ? "BMI085" : "BMI088") ||
         !_imu.register_gyro(gyro_instance, GYRO_BACKEND_SAMPLE_RATE,   dev_gyro->get_bus_id_devtype(DEVTYPE_INS_BMI088))) {
         return;
     }
@@ -212,12 +213,10 @@ bool AP_InertialSensor_BMI088::accel_init()
         case 0x1E:
             _accel_devtype = DEVTYPE_INS_BMI088;
             accel_range = 24.0;
-            hal.console->printf("BMI088: Found device\n");
             break;
         case 0x1F:
             _accel_devtype = DEVTYPE_INS_BMI085;
             accel_range = 16.0;
-            hal.console->printf("BMI085: Found device\n");
             break;
         default:
             return false;
@@ -226,8 +225,6 @@ bool AP_InertialSensor_BMI088::accel_init()
     if (!setup_accel_config()) {
         DEV_PRINTF("BMI08x: delaying accel config\n");
     }
-
-    DEV_PRINTF("BMI08x: found accel\n");
 
     return true;
 }
@@ -278,7 +275,6 @@ bool AP_InertialSensor_BMI088::gyro_init()
         return false;
     }
 
-    DEV_PRINTF("BMI088: found gyro\n");    
 
     return true;
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_BMI160.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_BMI160.cpp
@@ -206,7 +206,7 @@ void AP_InertialSensor_BMI160::start()
 
     _dev->get_semaphore()->give();
 
-    if (!_imu.register_accel(accel_instance, BMI160_ODR_TO_HZ(BMI160_ODR), _dev->get_bus_id_devtype(DEVTYPE_BMI160)) ||
+    if (!_imu.register_accel(accel_instance, BMI160_ODR_TO_HZ(BMI160_ODR), _dev->get_bus_id_devtype(DEVTYPE_BMI160), "BMI160") ||
         !_imu.register_gyro(gyro_instance, BMI160_ODR_TO_HZ(BMI160_ODR),   _dev->get_bus_id_devtype(DEVTYPE_BMI160))) {
         return;
     }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_BMI270.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_BMI270.cpp
@@ -212,7 +212,7 @@ void AP_InertialSensor_BMI270::start()
 
     _dev->get_semaphore()->give();
 
-    if (!_imu.register_accel(accel_instance, BMI270_BACKEND_SAMPLE_RATE, _dev->get_bus_id_devtype(DEVTYPE_BMI270)) ||
+    if (!_imu.register_accel(accel_instance, BMI270_BACKEND_SAMPLE_RATE, _dev->get_bus_id_devtype(DEVTYPE_BMI270), "BMI270") ||
         !_imu.register_gyro(gyro_instance, BMI270_BACKEND_SAMPLE_RATE, _dev->get_bus_id_devtype(DEVTYPE_BMI270))) {
         return;
     }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_ExternalAHRS.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_ExternalAHRS.cpp
@@ -46,7 +46,8 @@ void AP_InertialSensor_ExternalAHRS::start()
     if (_imu.register_gyro(gyro_instance, rate,
                            AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_SERIAL, serial_port, 1, DEVTYPE_SERIAL)) &&
         _imu.register_accel(accel_instance, rate,
-                            AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_SERIAL, serial_port, 2, DEVTYPE_SERIAL))) {
+                            AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_SERIAL, serial_port, 2, DEVTYPE_SERIAL),
+                            "ExternalAHRS")) {
         started = true;
     }
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.cpp
@@ -238,15 +238,18 @@ void AP_InertialSensor_Invensense::start()
 
     // grab the used instances
     enum DevTypes gdev, adev;
+    const char *name;
     switch (_mpu_type) {
     case Invensense_MPU9250:
         gdev = DEVTYPE_GYR_MPU9250;
         adev = DEVTYPE_ACC_MPU9250;
+        name = "MPU9250";
         _enable_offset_checking = true;
         break;
     case Invensense_ICM20602:
         gdev = DEVTYPE_INS_ICM20602;
         adev = DEVTYPE_INS_ICM20602;
+        name = "ICM20602";
         // ICM20602 has a bug where sometimes the data gets a huge offset
         // this seems to be fixed by doing a quick FIFO reset via USR_CTRL
         // reg
@@ -256,6 +259,7 @@ void AP_InertialSensor_Invensense::start()
     case Invensense_ICM20601:
         gdev = DEVTYPE_INS_ICM20601;
         adev = DEVTYPE_INS_ICM20601;
+        name = "ICM20601";
         _enable_offset_checking = true;
         break;
     case Invensense_ICM20608:
@@ -263,16 +267,19 @@ void AP_InertialSensor_Invensense::start()
         // can't change this without breaking existing calibrations
         gdev = DEVTYPE_GYR_MPU6000;
         adev = DEVTYPE_ACC_MPU6000;
+        name = "ICM20608";
         _enable_offset_checking = true;
         break;
     case Invensense_ICM20789:
         gdev = DEVTYPE_INS_ICM20789;
         adev = DEVTYPE_INS_ICM20789;
+        name = "ICM20789";
         _enable_offset_checking = true;
         break;
     case Invensense_ICM20689:
         gdev = DEVTYPE_INS_ICM20689;
         adev = DEVTYPE_INS_ICM20689;
+        name = "ICM20689";
         _enable_offset_checking = true;
         break;
     case Invensense_MPU6000:
@@ -280,6 +287,7 @@ void AP_InertialSensor_Invensense::start()
     default:
         gdev = DEVTYPE_GYR_MPU6000;
         adev = DEVTYPE_ACC_MPU6000;
+        name = _mpu_type == Invensense_MPU6500 ? "MPU6500" : "MPU6000";
         break;
     }
 
@@ -317,7 +325,7 @@ void AP_InertialSensor_Invensense::start()
     }
 
     if (!_imu.register_gyro(gyro_instance, 1000, _dev->get_bus_id_devtype(gdev)) ||
-        !_imu.register_accel(accel_instance, 1000, _dev->get_bus_id_devtype(adev))) {
+        !_imu.register_accel(accel_instance, 1000, _dev->get_bus_id_devtype(adev), name)) {
         return;
     }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev2.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev2.cpp
@@ -185,10 +185,12 @@ void AP_InertialSensor_Invensensev2::start()
 
     // grab the used instances
     enum DevTypes gdev, adev;
+    const char *name;
     switch (_inv2_type) {
     case Invensensev2_ICM20648:
         gdev = DEVTYPE_INS_ICM20648;
         adev = DEVTYPE_INS_ICM20648;
+        name = "ICM20648";
         // using 16g full range, 2048 LSB/g
         _accel_scale = (GRAVITY_MSS / 2048);
         break;
@@ -196,19 +198,21 @@ void AP_InertialSensor_Invensensev2::start()
         // 20649 is setup for 30g full scale, 1024 LSB/g
         gdev = DEVTYPE_INS_ICM20649;
         adev = DEVTYPE_INS_ICM20649;
+        name = "ICM20649";
         _accel_scale = (GRAVITY_MSS / 1024);
         break;
     case Invensensev2_ICM20948:
     default:
         gdev = DEVTYPE_INS_ICM20948;
         adev = DEVTYPE_INS_ICM20948;
+        name = "ICM20948";
         // using 16g full range, 2048 LSB/g
         _accel_scale = (GRAVITY_MSS / 2048);
         break;
     }
 
     if (!_imu.register_gyro(gyro_instance, 1125, _dev->get_bus_id_devtype(gdev)) ||
-        !_imu.register_accel(accel_instance, 1125, _dev->get_bus_id_devtype(adev))) {
+        !_imu.register_accel(accel_instance, 1125, _dev->get_bus_id_devtype(adev), name)) {
         return;
     }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp
@@ -268,44 +268,53 @@ void AP_InertialSensor_Invensensev3::start()
     dev->set_speed(AP_HAL::Device::SPEED_LOW);
 
     enum DevTypes devtype = DEVTYPE_INS_ICM42688;
+    const char *name = "ICM42688";
     fifo_config1 = 0x07;
 
     switch (inv3_type) {
     case Invensensev3_Type::IIM42652:
         devtype = DEVTYPE_INS_IIM42652;
+        name = "IIM42652";
         temp_sensitivity = 1.0 / 2.07;
         break;
     case Invensensev3_Type::IIM42653:
         devtype = DEVTYPE_INS_IIM42653;
+        name = "IIM42653";
         temp_sensitivity = 1.0 / 2.07;
         gyro_scale = GYRO_SCALE_4000DPS;
         accel_scale = ACCEL_SCALE_32G;
         break;
     case Invensensev3_Type::ICM42688:
         devtype = DEVTYPE_INS_ICM42688;
+        name = "ICM42688";
         temp_sensitivity = 1.0 / 2.07;
         break;
     case Invensensev3_Type::ICM42605:
         devtype = DEVTYPE_INS_ICM42605;
+        name = "ICM42605";
         temp_sensitivity = 1.0 / 2.07;
         break;
     case Invensensev3_Type::ICM40605:
         devtype = DEVTYPE_INS_ICM40605;
+        name = "ICM40605";
         fifo_config1 = 0x0F;
         temp_sensitivity = 1.0 * 128 / 115.49;
         break;
     case Invensensev3_Type::ICM42670:
         devtype = DEVTYPE_INS_ICM42670;
+        name = "ICM42670";
         temp_sensitivity = 1.0 / 2.0;
         break;
     case Invensensev3_Type::ICM45686:
         devtype = DEVTYPE_INS_ICM45686;
+        name = "ICM45686";
         temp_sensitivity = 1.0 / 2.0;
         gyro_scale = GYRO_SCALE_4000DPS;
         accel_scale = ACCEL_SCALE_32G;
         break;
     case Invensensev3_Type::ICM40609:
         devtype = DEVTYPE_INS_ICM40609;
+        name = "ICM40609";
         temp_sensitivity = 1.0 / 2.07;
         accel_scale = ACCEL_SCALE_32G;
         break;
@@ -364,7 +373,7 @@ void AP_InertialSensor_Invensensev3::start()
     backend_period_us = 1000000UL / backend_rate_hz;
 
     if (!_imu.register_gyro(gyro_instance, sampling_rate_hz, dev->get_bus_id_devtype(devtype)) ||
-        !_imu.register_accel(accel_instance, sampling_rate_hz, dev->get_bus_id_devtype(devtype))) {
+        !_imu.register_accel(accel_instance, sampling_rate_hz, dev->get_bus_id_devtype(devtype), name)) {
         return;
     }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.cpp
@@ -251,7 +251,7 @@ bool AP_InertialSensor_L3G4200D::_init_sensor(void)
 void AP_InertialSensor_L3G4200D::start(void)
 {
     if (!_imu.register_gyro(gyro_instance, 800, _dev_gyro->get_bus_id_devtype(DEVTYPE_L3G4200D)) ||
-        !_imu.register_accel(accel_instance, 800, _dev_accel->get_bus_id_devtype(DEVTYPE_L3G4200D))) {
+        !_imu.register_accel(accel_instance, 800, _dev_accel->get_bus_id_devtype(DEVTYPE_L3G4200D), "L3G4200D")) {
         return;
     }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM6DSV.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM6DSV.cpp
@@ -240,7 +240,7 @@ void AP_InertialSensor_LSM6DSV::start()
     }
     _backend_period_us = 1000000UL / _backend_rate_hz;
 
-    if (!_imu.register_accel(accel_instance, _backend_rate_hz, _dev->get_bus_id_devtype(DEVTYPE_INS_LSM6DSV)) ||
+    if (!_imu.register_accel(accel_instance, _backend_rate_hz, _dev->get_bus_id_devtype(DEVTYPE_INS_LSM6DSV), "LSM6DSV") ||
         !_imu.register_gyro(gyro_instance, _backend_rate_hz, _dev->get_bus_id_devtype(DEVTYPE_INS_LSM6DSV))) {
         return;
     }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
@@ -513,7 +513,7 @@ fail_whoami:
 void AP_InertialSensor_LSM9DS0::start(void)
 {
     if (!_imu.register_gyro(gyro_instance, 760, _dev_gyro->get_bus_id_devtype(DEVTYPE_GYR_L3GD20)) ||
-        !_imu.register_accel(accel_instance, 1000, _dev_accel->get_bus_id_devtype(DEVTYPE_ACC_LSM303D))) {
+        !_imu.register_accel(accel_instance, 1000, _dev_accel->get_bus_id_devtype(DEVTYPE_ACC_LSM303D), "LSM9DS0")) {
         return;
     }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS1.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS1.cpp
@@ -331,7 +331,7 @@ void AP_InertialSensor_LSM9DS1::_fifo_reset()
 void AP_InertialSensor_LSM9DS1::start(void)
 {
     if (!_imu.register_gyro(gyro_instance, 952, _dev->get_bus_id_devtype(DEVTYPE_GYR_LSM9DS1)) ||
-        !_imu.register_accel(accel_instance, 952, _dev->get_bus_id_devtype(DEVTYPE_ACC_LSM9DS1))) {
+        !_imu.register_accel(accel_instance, 952, _dev->get_bus_id_devtype(DEVTYPE_ACC_LSM9DS1), "LSM9DS1")) {
         return;
     }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_NONE.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_NONE.cpp
@@ -309,7 +309,8 @@ void AP_InertialSensor_NONE::start()
     if (!_imu.register_gyro(gyro_instance, gyro_sample_hz,
                             AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_SITL, bus_id, 1, DEVTYPE_SITL)) ||
         !_imu.register_accel(accel_instance, accel_sample_hz,
-                             AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_SITL, bus_id, 2, DEVTYPE_SITL))) {
+                             AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_SITL, bus_id, 2, DEVTYPE_SITL),
+                             "NONE")) {
         return;
     }
     bus_id++;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SCHA63T.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SCHA63T.cpp
@@ -83,7 +83,7 @@ AP_InertialSensor_Backend* AP_InertialSensor_SCHA63T::probe(AP_InertialSensor &i
 
 void AP_InertialSensor_SCHA63T::start()
 {
-    if (!_imu.register_accel(accel_instance, BACKEND_SAMPLE_RATE, dev_uno->get_bus_id_devtype(DEVTYPE_INS_SCHA63T)) ||
+    if (!_imu.register_accel(accel_instance, BACKEND_SAMPLE_RATE, dev_uno->get_bus_id_devtype(DEVTYPE_INS_SCHA63T), "SCHA63T") ||
         !_imu.register_gyro(gyro_instance, BACKEND_SAMPLE_RATE, dev_due->get_bus_id_devtype(DEVTYPE_INS_SCHA63T))) {
         return;
     }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
@@ -416,7 +416,8 @@ void AP_InertialSensor_SITL::start()
     if (!_imu.register_gyro(gyro_instance, gyro_sample_hz,
                             AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_SITL, bus_id, 1, DEVTYPE_SITL)) ||
         !_imu.register_accel(accel_instance, accel_sample_hz,
-                             AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_SITL, bus_id, 2, DEVTYPE_SITL))) {
+                             AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_SITL, bus_id, 2, DEVTYPE_SITL),
+                             "SITL")) {
         return;
     }
     bus_id++;


### PR DESCRIPTION
### Summary

Currently compass, baro, magnetometers, and GPS have a mish-mash of reporting device discovery. Some drivers do not report it, some report it with printf, some with hal.console->printf, and some with DEV_PRINTF. And the actual text varies as to what is reported. This PR attempts to standardize the reporting using printf with support in the underlying base class.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested on VOXL3 with qmc5883l mag, dps310 barometer, bmi270 IMU, and ublox M10S GPS.

