### PR TITLE
AP_Filesystem: add @MAV_LOG virtual path for FTP log download

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem.cpp
@@ -63,6 +63,11 @@ static AP_Filesystem_Sys fs_sys;
 static AP_Filesystem_Mission fs_mission;
 #endif
 
+#if AP_FILESYSTEM_MAV_LOG_ENABLED
+#include "AP_Filesystem_MAV_Log.h"
+static AP_Filesystem_MAV_Log fs_mav_log;
+#endif
+
 /*
   mapping from filesystem prefix to backend
  */
@@ -79,6 +84,9 @@ const AP_Filesystem::Backend AP_Filesystem::backends[] = {
 #endif
 #if AP_FILESYSTEM_MISSION_ENABLED
     { "@MISSION", fs_mission },
+#endif
+#if AP_FILESYSTEM_MAV_LOG_ENABLED
+    { "@MAV_LOG", fs_mav_log },
 #endif
 };
 
@@ -445,6 +453,11 @@ bool AP_Filesystem::stat(const char *pathname, stat_t &stbuf)
 AP_Filesystem *AP_Filesystem::get_singleton(void)
 {
     return &fs;
+}
+
+AP_Filesystem_Backend &AP_Filesystem::local_backend()
+{
+    return LOCAL_BACKEND.fs;
 }
 
 namespace AP

--- a/libraries/AP_Filesystem/AP_Filesystem.h
+++ b/libraries/AP_Filesystem/AP_Filesystem.h
@@ -151,6 +151,10 @@ public:
     // get_singleton for scripting
     static AP_Filesystem *get_singleton(void);
 
+    // return the on-disk backend, so virtual backends can delegate to
+    // the underlying storage without going back through the dispatcher
+    AP_Filesystem_Backend &local_backend();
+
 private:
     struct Backend {
         const char *prefix;

--- a/libraries/AP_Filesystem/AP_Filesystem_MAV_Log.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_MAV_Log.cpp
@@ -1,0 +1,111 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "AP_Filesystem.h"
+#include "AP_Filesystem_MAV_Log.h"
+
+#if AP_FILESYSTEM_MAV_LOG_ENABLED
+
+#include <AP_HAL/AP_HAL.h>
+#include <errno.h>
+#include <stdio.h>
+
+extern const AP_HAL::HAL& hal;
+
+// return the active log directory, honouring a custom override
+static const char *log_directory()
+{
+    const char *custom = hal.util->get_custom_log_directory();
+    if (custom != nullptr) {
+        return custom;
+    }
+    return HAL_BOARD_LOG_DIRECTORY;
+}
+
+// rewrite "foo/bar" to "<log_dir>/foo/bar" in the caller-supplied buffer.
+// An empty fname resolves to the log directory itself.
+// Returns false if the rewrite doesn't fit.
+static bool rewrite_path(const char *fname, char *buf, size_t buflen)
+{
+    const char *dir = log_directory();
+    int n;
+    if (fname[0] == '\0') {
+        n = snprintf(buf, buflen, "%s", dir);
+    } else {
+        n = snprintf(buf, buflen, "%s/%s", dir, fname);
+    }
+    if (n < 0 || size_t(n) >= buflen) {
+        errno = ENAMETOOLONG;
+        return false;
+    }
+    return true;
+}
+
+int AP_Filesystem_MAV_Log::open(const char *fname, int flags, bool allow_absolute_paths)
+{
+    if ((flags & O_ACCMODE) != O_RDONLY) {
+        errno = EROFS;
+        return -1;
+    }
+    char path[128];
+    if (!rewrite_path(fname, path, sizeof(path))) {
+        return -1;
+    }
+    return AP::FS().local_backend().open(path, flags, true);
+}
+
+int AP_Filesystem_MAV_Log::close(int fd)
+{
+    return AP::FS().local_backend().close(fd);
+}
+
+int32_t AP_Filesystem_MAV_Log::read(int fd, void *buf, uint32_t count)
+{
+    return AP::FS().local_backend().read(fd, buf, count);
+}
+
+int32_t AP_Filesystem_MAV_Log::lseek(int fd, int32_t offset, int whence)
+{
+    return AP::FS().local_backend().lseek(fd, offset, whence);
+}
+
+int AP_Filesystem_MAV_Log::stat(const char *pathname, struct stat *stbuf)
+{
+    char path[128];
+    if (!rewrite_path(pathname, path, sizeof(path))) {
+        return -1;
+    }
+    return AP::FS().local_backend().stat(path, stbuf);
+}
+
+void *AP_Filesystem_MAV_Log::opendir(const char *pathname)
+{
+    char path[128];
+    if (!rewrite_path(pathname, path, sizeof(path))) {
+        return nullptr;
+    }
+    return AP::FS().local_backend().opendir(path);
+}
+
+struct dirent *AP_Filesystem_MAV_Log::readdir(void *dirp)
+{
+    return AP::FS().local_backend().readdir(dirp);
+}
+
+int AP_Filesystem_MAV_Log::closedir(void *dirp)
+{
+    return AP::FS().local_backend().closedir(dirp);
+}
+
+#endif  // AP_FILESYSTEM_MAV_LOG_ENABLED

--- a/libraries/AP_Filesystem/AP_Filesystem_MAV_Log.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_MAV_Log.h
@@ -1,0 +1,43 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "AP_Filesystem_backend.h"
+
+#include "AP_Filesystem_config.h"
+
+#if AP_FILESYSTEM_MAV_LOG_ENABLED
+
+/*
+  Virtual path "@MAV_LOG" that points at the active log directory.
+  All operations are delegated to the local filesystem backend after
+  rewriting the path. The view is read-only so GCS tools can download
+  logs over MAVLink FTP without needing to know the board-specific
+  log directory path.
+ */
+class AP_Filesystem_MAV_Log : public AP_Filesystem_Backend
+{
+public:
+    int open(const char *fname, int flags, bool allow_absolute_paths = false) override;
+    int close(int fd) override;
+    int32_t read(int fd, void *buf, uint32_t count) override;
+    int32_t lseek(int fd, int32_t offset, int whence) override;
+    int stat(const char *pathname, struct stat *stbuf) override;
+    void *opendir(const char *pathname) override;
+    struct dirent *readdir(void *dirp) override;
+    int closedir(void *dirp) override;
+};
+
+#endif  // AP_FILESYSTEM_MAV_LOG_ENABLED

--- a/libraries/AP_Filesystem/AP_Filesystem_config.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_config.h
@@ -74,6 +74,13 @@
 #define AP_FILESYSTEM_MISSION_ENABLED AP_MISSION_ENABLED
 #endif
 
+// @MAV_LOG exposes the on-disk log directory as a virtual path so
+// GCS tools don't need to know the board-specific path. Only useful
+// when the local filesystem is writable (i.e. logs live there).
+#ifndef AP_FILESYSTEM_MAV_LOG_ENABLED
+#define AP_FILESYSTEM_MAV_LOG_ENABLED AP_FILESYSTEM_FILE_WRITING_ENABLED
+#endif
+
 #ifndef AP_FATFS_MAX_IO_SIZE
 #define AP_FATFS_MAX_IO_SIZE 4096
 #endif


### PR DESCRIPTION
### Summary

Exposes the log directory as @MAV_LOG as specified in: github.com/mavlink/mavlink-devguide/pull/668.

Implemented by Claude Code, tested manually by hand against https://github.com/mavlink/qgroundcontrol/pull/14290.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

This adds a virtual drive mapping from `@MAV_LOG` to `/APM/LOGS`.

FYI @peterbarker and @hamishwillee: one important caveat:

When using [FTP](https://mavlink.io/en/services/ftp.html) instead of the [LOG_*](https://mavlink.io/en/messages/common.html#LOG_REQUEST_LIST) messages. We don't have functionality to transmit the file date/time (yet) using MAVLink FTP, so the logs are shown without date when listed via FTP. One way is to encode the date/time as part of the filename (which is what PX4 does). Alternatively, we could potentially extend MAVLink FTP to support list directory with date/time though. The latter solution would be the nicer, and specced way of doing things.