### PR TITLE
AP_HAL_QURT: Made __wrap_printf equivalent to hal console printf

### DIFF
--- a/libraries/AP_HAL_QURT/UARTDriver.cpp
+++ b/libraries/AP_HAL_QURT/UARTDriver.cpp
@@ -136,19 +136,7 @@ void UARTDriver_Console::printf(const char *fmt, ...)
     vsnprintf(buf, sizeof(buf), fmt, ap);
     va_end(ap);
     HAP_PRINTF(buf);
-
-    // send to apps side for printing
-    struct qurt_rpc_msg msg;
-    const auto len = strnlen(buf, sizeof(buf));
-    if (len > sizeof(msg.data)) {
-        return;
-    }
-    msg.msg_id = QURT_MSG_ID_PRINTF;
-    msg.inst = 0;
-    msg.seq = 0;
-    msg.data_length = len;
-    memcpy(msg.data, buf, len);
-    qurt_rpc_send(msg);
+    qurt_printf_to_host(buf);
 }
 
 

--- a/libraries/AP_HAL_QURT/replace.cpp
+++ b/libraries/AP_HAL_QURT/replace.cpp
@@ -187,6 +187,24 @@ int slpi_link_client_receive(const uint8_t *data, int data_len_in_bytes)
     return 0;
 }
 
+/*
+  forward a pre-formatted string to the apps proc console over RPC
+ */
+void qurt_printf_to_host(const char *buf)
+{
+    struct qurt_rpc_msg msg;
+    const auto len = strnlen(buf, sizeof(msg.data));
+    if (len > sizeof(msg.data)) {
+        return;
+    }
+    msg.msg_id = QURT_MSG_ID_PRINTF;
+    msg.inst = 0;
+    msg.seq = 0;
+    msg.data_length = len;
+    memcpy(msg.data, buf, len);
+    qurt_rpc_send(msg);
+}
+
 int __wrap_printf(const char *fmt, ...)
 {
     va_list ap;
@@ -196,6 +214,7 @@ int __wrap_printf(const char *fmt, ...)
     vsnprintf(buf, sizeof(buf), fmt, ap);
     va_end(ap);
     HAP_PRINTF(buf);
+    qurt_printf_to_host(buf);
 
     return 0;
 }

--- a/libraries/AP_HAL_QURT/replace.h
+++ b/libraries/AP_HAL_QURT/replace.h
@@ -52,5 +52,8 @@ extern volatile uint32_t _last_counter;
 #ifdef __cplusplus
 // send a message to the host
 bool qurt_rpc_send(struct qurt_rpc_msg &msg);
+
+// forward a pre-formatted console string to the apps proc
+void qurt_printf_to_host(const char *buf);
 #endif
 


### PR DESCRIPTION
### Summary

Very simple update to QURT HAL to make __wrap_printf equivalent to DEV_PRINTF so that messages
can also be seen on the applications processor console output.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested on VOXL3

