### PR TITLE
AP_Bootloader: Reassign ID from X-MAV-AP-F405Mini to X-MAV-AP-H743Lite

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -306,7 +306,7 @@ AP_HW_FlywooH743Pro                  1181
 AP_HW_CBU_StampH743_LC               1182
 AP_HW_NarinH7                        1183
 AP_HW_BrahmaF4                       1184
-AP_HW_X-MAV-AP-F405Mini              1185
+AP_HW_X-MAV-AP-H743Lite              1185
 AP_HW_3DRControlN1                   1186
 AP_HW_CORVON405V2_1                  1187
 AP_HW_NarinH5                        1188


### PR DESCRIPTION
The X-MAV-AP-F405Mini board was never completed in design and is now being discontinued; its reserved ID is reassigned to the new X-MAV-AP-H743Lite board.