### PR TITLE
AP_Periph: check return of canard_broadcast in send_moving_baseline_msg

### DIFF
--- a/Tools/AP_Periph/gps.cpp
+++ b/Tools/AP_Periph/gps.cpp
@@ -269,6 +269,7 @@ void AP_Periph_FW::send_moving_baseline_msg()
 #endif
 
     // get the data from the moving base and send as MovingBaselineData message
+    bool all_sent = true;
     while (len > 0) {
         ardupilot_gnss_MovingBaselineData mbldata {};
 
@@ -280,17 +281,22 @@ void AP_Periph_FW::send_moving_baseline_msg()
         uint8_t buffer[ARDUPILOT_GNSS_MOVINGBASELINEDATA_MAX_SIZE];
         const uint16_t total_size = ardupilot_gnss_MovingBaselineData_encode(&mbldata, buffer, !canfdout());
 
-        canard_broadcast(ARDUPILOT_GNSS_MOVINGBASELINEDATA_SIGNATURE,
-                         ARDUPILOT_GNSS_MOVINGBASELINEDATA_ID,
-                         CANARD_TRANSFER_PRIORITY_LOW,
-                         &buffer[0],
-                         total_size,
-                         iface_mask);
+        if (!canard_broadcast(ARDUPILOT_GNSS_MOVINGBASELINEDATA_SIGNATURE,
+                              ARDUPILOT_GNSS_MOVINGBASELINEDATA_ID,
+                              CANARD_TRANSFER_PRIORITY_LOW,
+                              &buffer[0],
+                              total_size,
+                              iface_mask)) {
+            all_sent = false;
+            break;
+        }
         len -= n;
         data += n;
     }
 
-    gps.clear_RTCMV3();
+    if (all_sent) {
+        gps.clear_RTCMV3();
+    }
 #endif // GPS_MOVING_BASELINE
 }
 


### PR DESCRIPTION
### Summary

Check the return value of `canard_broadcast` in `send_moving_baseline_msg` so that a pool-exhaustion failure on any RTCMv3 chunk does not silently drop the source packet.

### Classification & Testing

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Untested on hardware. The failure mode — libcanard tx-pool exhaustion mid-RTCMv3-packet — is intermittent and hard to reproduce deterministically. The change only affects behaviour on the failure path.

### Description

This bug was identified during an automated inspection of the AP_Periph RTCM / MovingBaselineData flow while investigating an unrelated customer GPS issue on a dual-F9P moving-baseline setup.

`send_moving_baseline_msg()` fragments each RTCMv3 packet from the moving base into one or more `MovingBaselineData` DroneCAN transfers. If any chunk fails to broadcast — e.g. libcanard's tx pool is momentarily exhausted, or the local node ID has not yet been assigned — the failure is silently swallowed and `gps.clear_RTCMV3()` discards the source buffer anyway. The rover assembles the partial stream and rejects it via the F9P's own CRC-24Q, with no diagnostic at either end.

This change bails out of the chunk loop on the first failed broadcast and only clears the RTCMv3 source buffer when every fragment has been sent. The pattern matches `0eded27a9` (`AP_Periph: check return of get_RelPosHeading`).

Not believed to be related to any actively reported field issue; filed as a latent robustness fix.

---
Posted by Claude (Opus 4.7) on behalf of @dakejahl.