### PR TITLE
AP_Periph: filter MovingBaselineData by source node id

### DIFF
--- a/Tools/AP_Periph/gps.cpp
+++ b/Tools/AP_Periph/gps.cpp
@@ -35,6 +35,18 @@ void AP_Periph_FW::handle_RTCMStream(CanardInstance* canard_instance, CanardRxTr
 #if GPS_MOVING_BASELINE
 void AP_Periph_FW::handle_MovingBaselineData(CanardInstance* canard_instance, CanardRxTransfer* transfer)
 {
+    // latch the first base we hear from; reject any other source so a
+    // misconfigured second base on the same bus cannot interleave its
+    // RTCMv3 stream into our rover.
+    static uint8_t mbl_source_node_id;
+    if (mbl_source_node_id == 0) {
+        mbl_source_node_id = transfer->source_node_id;
+    } else if (transfer->source_node_id != mbl_source_node_id) {
+        Debug("MovingBaselineData: ignoring node %u (bound to %u)\n",
+              transfer->source_node_id, mbl_source_node_id);
+        return;
+    }
+
     ardupilot_gnss_MovingBaselineData msg;
     if (ardupilot_gnss_MovingBaselineData_decode(transfer, &msg)) {
         return;


### PR DESCRIPTION
### Summary

Filter incoming `MovingBaselineData` messages in AP_Periph by source node id so only one base's RTCMv3 stream is injected into the local rover.

### Classification & Testing

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Untested on hardware. The scenario (two bases broadcasting `MovingBaselineData` on the same CAN bus) is not a normal setup; this is defensive hardening.

### Description

This was identified during an automated inspection of the AP_Periph RTCM / MovingBaselineData flow while investigating an unrelated customer GPS issue on a dual-F9P moving-baseline setup.

`handle_MovingBaselineData()` currently injects the payload from any `MovingBaselineData` transfer into `gps.inject_MBL_data()` without filtering by `transfer->source_node_id`. If a second base (misconfigured or accidental) broadcasts on the same CAN bus, its RTCMv3 bytes will be interleaved into the rover's F9P, and all packets will be rejected by the F9P's CRC-24Q.

The FC-side receive path in `AP_GPS_DroneCAN` already filters by source node id via its per-backend trampoline (`handle_moving_baseline_msg_trampoline`). This change applies the same discipline in AP_Periph by latching the first observed source node id and ignoring subsequent messages from a different source.

Open to alternative approaches — e.g. an explicit `GPS_MB_BASE_NODE` parameter — if explicit configuration is preferred over first-observed latching. Happy to iterate.

Not believed to be related to any actively reported field issue; filed as a latent robustness fix.

---
Posted by Claude (Opus 4.7) on behalf of @dakejahl.