### PR TITLE
Remove -Wno-digraphs from clang

### DIFF
--- a/Blimp/AP_Arming_Blimp.cpp
+++ b/Blimp/AP_Arming_Blimp.cpp
@@ -35,7 +35,9 @@ bool AP_Arming_Blimp::run_pre_arm_checks(bool display_failure)
     }
 
 #pragma clang diagnostic push
+#if defined(__clang_major__) && __clang_major__ >= 14
 #pragma clang diagnostic ignored "-Wbitwise-instead-of-logical"
+#endif
     return parameter_checks(display_failure)
 #if AP_FENCE_ENABLED
            & fence_checks(display_failure)

--- a/Rover/AP_Arming_Rover.cpp
+++ b/Rover/AP_Arming_Rover.cpp
@@ -94,7 +94,9 @@ bool AP_Arming_Rover::pre_arm_checks(bool report)
     }
 
 #pragma clang diagnostic push
+#if defined(__clang_major__) && __clang_major__ >= 14
 #pragma clang diagnostic ignored "-Wbitwise-instead-of-logical"
+#endif
     return (AP_Arming::pre_arm_checks(report)
             & motor_checks(report)
 #if AP_OAPATHPLANNER_ENABLED

--- a/Tools/CPUInfo/CPUInfo.cpp
+++ b/Tools/CPUInfo/CPUInfo.cpp
@@ -105,7 +105,12 @@ volatile uint8_t mbuf1[128], mbuf2[128];
 volatile uint64_t v_64 = 1;
 volatile uint64_t v_out_64 = 1;
 
+//Main loop where the action takes place
+#if defined(__clang_major__)
+// clang doesn't understand -Wframe-larger-than=
+#else
 #pragma GCC diagnostic error "-Wframe-larger-than=2000"
+#endif
 static void show_timings(void)
 {
 

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -433,6 +433,7 @@ class Board:
 
                 '-Werror=address-of-packed-member',
 
+                '-Werror=unknown-warning-option',
                 '-Werror=inconsistent-missing-override',
                 '-Werror=overloaded-virtual',
 

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -286,7 +286,6 @@ class Board:
             '-Wno-unused-parameter',
             '-Wno-redundant-decls',
             '-Wno-unknown-pragmas',
-            '-Wno-digraphs',
             '-Wno-trigraphs',
             '-Werror=shadow',
             '-Werror=return-type',
@@ -336,6 +335,7 @@ class Board:
             ]
         else:
             env.CFLAGS += [
+                '-Wno-digraphs',
                 '-Wno-format-contains-nul',
                 '-fsingle-precision-constant', # force const vals to be float , not double. so 100.0 means 100.0f
             ]
@@ -418,7 +418,6 @@ class Board:
             '-Werror=unused-variable',
             '-Werror=delete-non-virtual-dtor',
             '-Wfatal-errors',
-            '-Wno-digraphs',
             '-Wno-trigraphs',
             '-Werror=parentheses',
             '-DARDUPILOT_BUILD',
@@ -467,6 +466,7 @@ class Board:
                 '-Werror=unused-but-set-variable',
                 '-fsingle-precision-constant',
                 '-Wno-psabi',
+                '-Wno-digraphs',
             ]
             if self.cc_version_gte(cfg, 5, 2):
                 env.CXXFLAGS += [

--- a/libraries/AP_HAL/tests/test_vsnprintf.cpp
+++ b/libraries/AP_HAL/tests/test_vsnprintf.cpp
@@ -35,14 +35,19 @@ TEST(vsnprintf_Test, Basic)
         EXPECT_EQ(bytes_required, 8);
     }
     { // ensure rest of buffer survives
-        memset(output, 'A', 10);
+//Main loop where the action takes place
 #pragma GCC diagnostic push
+#if defined(__clang_major__)
+// clang doesn't understand -Wformat-truncation
+#else
 #pragma GCC diagnostic ignored "-Wformat-truncation"
+        memset(output, 'A', 10);
         const int bytes_required = snprintf(output, 5, "012345678");
-#pragma GCC diagnostic pop
         EXPECT_TRUE(streq(output, "0123"));
         EXPECT_EQ(bytes_required, 9);
         EXPECT_EQ(output[6], 'A');
+#endif
+#pragma GCC diagnostic pop
     }
     { // simple float
         const int bytes_required = hal.util->snprintf(output, ARRAY_SIZE(output), "%f", 1/3.0);

--- a/libraries/AP_RCProtocol/examples/RCProtocolTest/RCProtocolTest.cpp
+++ b/libraries/AP_RCProtocol/examples/RCProtocolTest/RCProtocolTest.cpp
@@ -321,7 +321,11 @@ static void test_random(void)
 }
 
 //Main loop where the action takes place
+#if defined(__clang_major__)
+// clang doesn't understand -Wframe-larger-than=
+#else
 #pragma GCC diagnostic error "-Wframe-larger-than=2000"
+#endif
 void loop()
 {
     const uint8_t srxl_bytes[] = { 0xa5, 0x03, 0x0c, 0x04, 0x2f, 0x6c, 0x10, 0xb4, 0x26,

--- a/libraries/AP_SmartRTL/examples/SmartRTL_test/SmartRTL_test.cpp
+++ b/libraries/AP_SmartRTL/examples/SmartRTL_test/SmartRTL_test.cpp
@@ -130,6 +130,10 @@ void check_path(const std::vector<Vector3p>& correct_path, const char* test_name
 }
 
 // gcc9 produces a large frame
+#if defined(__clang_major__)
+// clang doesn't understand -Wframe-larger-than=
+#else
 #pragma GCC diagnostic ignored "-Wframe-larger-than="
+#endif
 
 AP_HAL_MAIN();


### PR DESCRIPTION
### Summary

Removes this compiler option as clang doesn't know about it.  Also make unknown compiler options fatal as they may actually be important...

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *
Durandal                            *               *      *           *       *                 *      *      *
Hitec-Airspeed           *                                 *
KakuteH7-bdshot                     *               *      *           *       *                 *      *      *
MatekF405                           *               *      *           *       *                 *      *      *
MatekH7A3                           *               *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *               *                  *       *                 *      *      *
SITL_x86_64_linux_gnu               *               *                  *       *                 *      *      *
YJUAV_A6SE                          *               *      *           *       *                 *      *      *
f103-QiotekPeriph        *                                 *
f303-MatekGPS            *                                 *
f303-Universal           *                                 *
iomcu                                                                                *
mindpx-v2                           *               *      *           *       *                 *      *      *
revo-mini                           *               *      *           *       *                 *      *      *
skyviper-v2450                                                         *
speedybeef4                         *               *      *           *       *                 *      *      *
```

... no vast amounts of warnings now for clang

### Description

This warning was coming out a lot on clang.  Compiles but warns.

Make the warning non-clang only and make future "don't know about this warning" fatal on clang.
