### PR TITLE
Update FS_OPTIONS description for clarity

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -784,7 +784,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
 
     // @Param: FS_OPTIONS
     // @DisplayName: Failsafe options bitmask
-    // @Description: Bitmask of additional options for battery, radio, & GCS failsafes. 0 (default) disables all options.
+    // @Description: Bitmask of additional options for battery, radio, & GCS failsafes. 0 disables all options.
     // @Bitmask: 0:Continue if in Auto on RC failsafe, 1:Continue if in Auto on GCS failsafe, 2:Continue if in Guided on RC failsafe, 3:Continue if landing on any failsafe, 4:Continue if in pilot controlled modes on GCS failsafe, 5:Release Gripper
     // @User: Advanced
     AP_GROUPINFO("FS_OPTIONS", 36, ParametersG2, fs_options, (float)Copter::FailsafeOption::GCS_CONTINUE_IF_PILOT_CONTROL),


### PR DESCRIPTION
### Summary

Fix the outdated FS_OPTIONS default description to match the current code.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

The FS_OPTIONS default is currently set to bit 4 (16) in code, but the inline parameter comment still says `0 (default) disables all options`, which is also reflected in the generated parameter list.