### PR TITLE
Tools: Switch SITL callisto args from raw dict to NamedTuple

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -15,6 +15,8 @@ import shutil
 import tempfile
 import time
 
+from typing import NamedTuple
+
 import numpy
 
 from pymavlink import mavextra
@@ -106,13 +108,17 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
     def default_frame(self):
         return "+"
 
-    def callisto_sitl_kwargs(self):
+    class SITLVehicleConfig(NamedTuple):
+        defaults_filepath: str
+        model: str
+        wipe: bool = True
+
+    def callisto_sitl_config(self) -> SITLVehicleConfig:
         """Returns kwargs for a SITL commandline to fly the Callisto. Wipes params."""
-        return {
-            "defaults_filepath": self.model_defaults_filepath('Callisto'),
-            "model": "octa-quad:@ROMFS/models/Callisto.json",
-            "wipe": True
-        }
+        return self.SITLVehicleConfig(
+            defaults_filepath=self.model_defaults_filepath('Callisto'),
+            model="octa-quad:@ROMFS/models/Callisto.json",
+        )
 
     def apply_defaultfile_parameters(self):
         # Copter passes in a defaults_filepath in place of applying
@@ -9658,7 +9664,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         '''Test wind estimation and baro position error compensation'''
         self.customise_SITL_commandline(
             [],
-            **self.callisto_sitl_kwargs()
+            **self.callisto_sitl_config()._asdict()
         )
         wind_spd_truth = 8.0
         wind_dir_truth = 90.0
@@ -12144,7 +12150,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         '''Test Callisto'''
         self.customise_SITL_commandline(
             [],
-            **self.callisto_sitl_kwargs()
+            **self.callisto_sitl_config()._asdict()
         )
         self.takeoff(10)
         self.do_RTL()
@@ -16208,7 +16214,7 @@ RTL_ALT_M 111
             self.customise_SITL_commandline([
                 "--serial5=mcast:",
             ],
-                **self.callisto_sitl_kwargs()
+                **self.callisto_sitl_config()._asdict()
             )
 
             self.set_parameters({
@@ -16299,7 +16305,7 @@ RTL_ALT_M 111
         '''test the config_profiles.lua example script'''
         self.customise_SITL_commandline(
             [],
-            **self.callisto_sitl_kwargs()
+            **self.callisto_sitl_config()._asdict()
         )
         self.install_example_script_context("config_profiles.lua")
         self.set_parameters({


### PR DESCRIPTION
### Summary

Follow up to https://github.com/ArduPilot/ardupilot/pull/32828 to add stronger typing as requested by other devs.

`SITLVehicleConfig` is a class that can be used to create other models now.

We use [_asdict](https://docs.python.org/3/library/collections.html#collections.somenamedtuple._asdict) - not a private method, to convert the tuple to a dictionary. 

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
./Tools/autotest/autotest.py  test.CopterTests2b.PeriphMultiUARTTunnel test.CopterTests1c.BaroWindCorrection test.CopterTests2b.LUAConfigProfile test.CopterTests1c.BaroWindCorrection
```

### Description

Switch to using named tuple. It's recommended to use NamedTuple over named_tuple from collections.

https://stackoverflow.com/questions/50766461/namedtuple-vs-namedtuple-in-python



<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
