### PR TITLE
AP_NavEKF3: set origin from public origin on InitialiseFilterBootStrap 

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -2183,12 +2183,13 @@ const EKFGSF_yaw *NavEKF3::get_yawEstimator(void) const
 
 // Do a reset and bootstrap alignment of all EKF cores
 // return true if successful for all cores
-// The per-core InitialiseFilterBootstrap()
-// (Different to the core method where the return value is false when the IMU delay buffer is not yet full)
+// When on the ground and stationary, gyros are recalibrated first so
+// the filter bootstraps with clean offsets.  In flight the gyro
+// calibration is skipped and the filter resets with existing biases.
 bool NavEKF3::InitialiseFilterBootstrap()
 {
     // ignore any data if the EKF is not started
-    if (core == nullptr) {
+    if (!core) {
         return false;
     }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -681,20 +681,6 @@ bool NavEKF3_core::assume_zero_sideslip(void) const
     return dal.get_fly_forward() && dal.get_vehicle_class() != AP_DAL::VehicleClass::GROUND;
 }
 
-// sets the local NED origin using a LLH location (latitude, longitude, height)
-// returns false if the origin is already set
-bool NavEKF3_core::setOriginLLH(const Location &loc)
-{
-    // reject external origin setting until the filter has finished
-    // bootstrap initialisation.  InitialiseVariables() resets
-    // validOrigin, so an origin set before that point is lost.
-    // Callers (e.g. AHRS use_recorded_origin_maybe) will retry.
-    if (!statesInitialised) {
-        return false;
-    }
-    return setOrigin(loc);
-}
-
 // populates the Earth magnetic field table using the given location
 void NavEKF3_core::setEarthFieldFromLocation(const Location &loc)
 {
@@ -711,7 +697,7 @@ void NavEKF3_core::setEarthFieldFromLocation(const Location &loc)
 
 // sets the local NED origin using a LLH location (latitude, longitude, height)
 // returns false is the origin has already been set
-bool NavEKF3_core::setOrigin(const Location &loc)
+bool NavEKF3_core::setOriginLLH(const Location &loc)
 {
     // if the origin is valid reject setting a new origin
     if (validOrigin) {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -691,7 +691,7 @@ void NavEKF3_core::readGpsData()
             gpsloc_fieldelevation.alt += (int32_t)(100.0f * stateStruct.position.z);
         }
 
-        if (!setOrigin(gpsloc_fieldelevation)) {
+        if (!setOriginLLH(gpsloc_fieldelevation)) {
             // set an error as an attempt was made to set the origin more than once
             INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
             return;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -514,22 +514,8 @@ bool NavEKF3_core::InitialiseFilterBootstrap(void)
         return false;
     }
 
-    // preserve origin across re-initialisation so a bootstrap reset
-    // does not shift the local NED frame.  On first boot validOrigin
-    // is false and the restore below is a no-op.
-    const bool hadValidOrigin = validOrigin;
-    const Location savedEKFOrigin = EKF_origin;
-
     // set re-used variables to zero
     InitialiseVariables();
-
-    // restore origin so per-core EKF_origin stays consistent with the
-    // shared frontend public_origin
-    if (hadValidOrigin) {
-        EKF_origin = savedEKFOrigin;
-        ekfGpsRefHgt = (double)0.01 * (double)EKF_origin.alt;
-        validOrigin = true;
-    }
 
     // acceleration vector in XYZ body axes measured by the IMU (m/s^2)
     Vector3F initAccVec;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -590,6 +590,11 @@ bool NavEKF3_core::InitialiseFilterBootstrap(void)
         inactiveBias[i].accel_bias.zero();
     }
 
+    // restore the navigation origin from the public origin if possible:
+    if (public_origin.initialised()) {
+        setOriginLLH(public_origin);
+    }
+
     GCS_SEND_TEXT(MAV_SEVERITY_INFO, "EKF3 IMU%u initialised",(unsigned)imu_index);
 
     // we initially return false to wait for the IMU buffer to fill

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -960,11 +960,6 @@ private:
     // Control reset of yaw and magnetic field states
     void controlMagYawReset();
 
-    // set the latitude and longitude and height used to set the NED origin
-    // All NED positions calculated by the filter will be relative to this location
-    // returns false if the origin has already been set
-    bool setOrigin(const Location &loc);
-
     // Assess GPS data quality and set gpsGoodToAlign
     void calcGpsGoodToAlign(void);
 


### PR DESCRIPTION
### Summary

Copies any public origin which has been set into the EKF into the core origin when the filter is reset

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested with the autotest suite as part of wider changes to make CI more reliable.

### Description

if the origin is set in within the startup delay ms enforced by AP_AHRS then we simply lose the origin.

If the filter resets in-flight we wouldn't get the origin reset either.

@rmackay9 asked this be created after DevCall and post-DevCall discussions.  It mirrors what we're doing in AHRS - allowing home to be set even if it can't currently be used.
