### PR TITLE
AR_WPNav: Rename to set_wp_destination_NED_m

### DIFF
--- a/Rover/mode_smart_rtl.cpp
+++ b/Rover/mode_smart_rtl.cpp
@@ -69,7 +69,7 @@ void ModeSmartRTL::update()
                         }
                     } else {
                         // no next point so add only immediate point
-                        if (!g2.wp_nav.set_desired_location_NED(dest_NED.tofloat())) {
+                        if (!g2.wp_nav.set_wp_destination_NED_m(dest_NED.tofloat())) {
                             // this should never happen because the EKF origin should already be set
                             GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SmartRTL: failed to set destination");
                             smart_rtl_state = SmartRTLState::Failure;

--- a/libraries/AR_WPNav/AR_WPNav.cpp
+++ b/libraries/AR_WPNav/AR_WPNav.cpp
@@ -311,18 +311,17 @@ bool AR_WPNav::set_desired_location_to_stopping_location()
     return set_desired_location(stopping_loc);
 }
 
-// set desired location as offset from the EKF origin, return true on success
-bool AR_WPNav::set_desired_location_NED(const Vector3f& destination)
+bool AR_WPNav::set_wp_destination_NED_m(const Vector3f& offset_from_origin)
 {
     // initialise destination to ekf origin
-    Location destination_ned;
-    if (!AP::ahrs().get_origin(destination_ned)) {
+    Location destination;
+    if (!AP::ahrs().get_origin(destination)) {
         return false;
     }
 
     // apply offset
-    destination_ned.offset(destination.x, destination.y);
-    return set_desired_location(destination_ned);
+    destination.offset(offset_from_origin.x, offset_from_origin.y);
+    return set_desired_location(destination);
 }
 
 bool AR_WPNav::set_desired_location_NED(const Vector3f &destination, const Vector3f &next_destination)

--- a/libraries/AR_WPNav/AR_WPNav.h
+++ b/libraries/AR_WPNav/AR_WPNav.h
@@ -46,8 +46,9 @@ public:
     // set desired location to a reasonable stopping point, return true on success
     bool set_desired_location_to_stopping_location()  WARN_IF_UNUSED;
 
-    // set desired location as offset from the EKF origin, return true on success
-    bool set_desired_location_NED(const Vector3f& destination) WARN_IF_UNUSED;
+    // set destination as North, East offset from the EKF origin, return true on success
+    // (offset_D component is neglected, origin_D is used.)
+    bool set_wp_destination_NED_m(const Vector3f& offset_from_origin_NE) WARN_IF_UNUSED;
     bool set_desired_location_NED(const Vector3f &destination, const Vector3f &next_destination) WARN_IF_UNUSED;
 
     // set desired location but expect the destination to be updated again in the near future


### PR DESCRIPTION
### Summary

Improves the naming & clarity of the function by aligning with terms used in AC_WPNav. (Several similar PRs will be created.)

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
./Tools/scripts/size_compare_branches.py --vehicle=rover --board=CubeOrange

Board,rover
CubeOrange,*
```
### Description

The old name was not good for 2 reasons:
"Desired" is redundant with preferred term 'destination'.
"Location" is essentially wrong, since this is a NED-vector not a `Location` object.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
