### PR TITLE
AR_WPNav: Rename to set_wp_destination_and_next_destination_NED_m

### DIFF
--- a/Rover/mode_smart_rtl.cpp
+++ b/Rover/mode_smart_rtl.cpp
@@ -61,7 +61,7 @@ void ModeSmartRTL::update()
                     // peek at the next point.  this can fail if the IO task currently has the path semaphore
                     Vector3p next_dest_NED;
                     if (g2.smart_rtl.peek_point(next_dest_NED)) {
-                        if (!g2.wp_nav.set_desired_location_NED(dest_NED.tofloat(), next_dest_NED.tofloat())) {
+                        if (!g2.wp_nav.set_wp_destination_and_next_destination_NED_m(dest_NED.tofloat(), next_dest_NED.tofloat())) {
                             // this should never happen because the EKF origin should already be set
                             GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SmartRTL: failed to set destination");
                             smart_rtl_state = SmartRTLState::Failure;

--- a/libraries/AR_WPNav/AR_WPNav.cpp
+++ b/libraries/AR_WPNav/AR_WPNav.cpp
@@ -325,19 +325,20 @@ bool AR_WPNav::set_desired_location_NED(const Vector3f& destination)
     return set_desired_location(destination_ned);
 }
 
-bool AR_WPNav::set_desired_location_NED(const Vector3f &destination, const Vector3f &next_destination)
+bool AR_WPNav::set_wp_destination_and_next_destination_NED_m(const Vector3f &offset_of_dest_from_origin,
+                                                             const Vector3f &offset_of_next_from_origin)
 {
     // initialise destination to ekf origin
-    Location dest_loc, next_dest_loc;
-    if (!AP::ahrs().get_origin(dest_loc)) {
+    Location destination, next_destination;
+    if (!AP::ahrs().get_origin(destination)) {
         return false;
     }
-    next_dest_loc = dest_loc;
+    next_destination = destination;
 
     // apply offsets
-    dest_loc.offset(destination.x, destination.y);
-    next_dest_loc.offset(next_destination.x, next_destination.y);
-    return set_desired_location(dest_loc, next_dest_loc);
+    destination.offset(offset_of_dest_from_origin.x, offset_of_dest_from_origin.y);
+    next_destination.offset(offset_of_next_from_origin.x, offset_of_next_from_origin.y);
+    return set_desired_location(destination, next_destination);
 }
 
 // set desired location but expect the destination to be updated again in the near future

--- a/libraries/AR_WPNav/AR_WPNav.h
+++ b/libraries/AR_WPNav/AR_WPNav.h
@@ -48,7 +48,8 @@ public:
 
     // set desired location as offset from the EKF origin, return true on success
     bool set_desired_location_NED(const Vector3f& destination) WARN_IF_UNUSED;
-    bool set_desired_location_NED(const Vector3f &destination, const Vector3f &next_destination) WARN_IF_UNUSED;
+    bool set_wp_destination_and_next_destination_NED_m(const Vector3f &offset_of_dest_from_origin,
+                                                       const Vector3f &offset_of_next_from_origin) WARN_IF_UNUSED;
 
     // set desired location but expect the destination to be updated again in the near future
     // position controller input shaping will be used for navigation instead of scurves


### PR DESCRIPTION
### Summary

Improves the naming & clarity of the function by aligning with terms used in AC_WPNav. (Several similar PRs will be created, such as #32883 .)

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
./Tools/scripts/size_compare_branches.py --vehicle=rover --board=CubeOrange

Board,rover
CubeOrange,*
```
### Description

The old name was not good because "desired" is redundant with preferred term 'destination'.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
