### PR TITLE
AR_WPNav: Rename to set_destination_expect_fast_update

### DIFF
--- a/Rover/mode_guided.cpp
+++ b/Rover/mode_guided.cpp
@@ -322,7 +322,7 @@ bool ModeGuided::set_desired_location(const Location &destination, Location next
     } else {
         // use position controller input shaping for navigation
         // this does not support object avoidance but does allow faster updates of the target
-        if (!g2.wp_nav.set_desired_location_expect_fast_update(destination)) {
+        if (!g2.wp_nav.set_destination_expect_fast_update(destination)) {
             return false;
         }
     }

--- a/libraries/AR_WPNav/AR_WPNav.cpp
+++ b/libraries/AR_WPNav/AR_WPNav.cpp
@@ -340,10 +340,7 @@ bool AR_WPNav::set_desired_location_NED(const Vector3f &destination, const Vecto
     return set_desired_location(dest_loc, next_dest_loc);
 }
 
-// set desired location but expect the destination to be updated again in the near future
-// position controller input shaping will be used for navigation instead of scurves
-// Note: object avoidance is not supported if this method is used
-bool AR_WPNav::set_desired_location_expect_fast_update(const Location &destination)
+bool AR_WPNav::set_destination_expect_fast_update(const Location &destination)
 {
     // initialise if not active
     if (!is_active() || (_nav_control_type != NavControllerType::NAV_PSC_INPUT_SHAPING)) {

--- a/libraries/AR_WPNav/AR_WPNav.h
+++ b/libraries/AR_WPNav/AR_WPNav.h
@@ -50,10 +50,10 @@ public:
     bool set_desired_location_NED(const Vector3f& destination) WARN_IF_UNUSED;
     bool set_desired_location_NED(const Vector3f &destination, const Vector3f &next_destination) WARN_IF_UNUSED;
 
-    // set desired location but expect the destination to be updated again in the near future
+    // set destination but expect it to be updated again in the near future
     // position controller input shaping will be used for navigation instead of scurves
     // Note: object avoidance is not supported if this method is used
-    bool set_desired_location_expect_fast_update(const Location &destination) WARN_IF_UNUSED;
+    bool set_destination_expect_fast_update(const Location &destination) WARN_IF_UNUSED;
 
     // true if vehicle has reached desired location. defaults to true because this is normally used by missions and we do not want the mission to become stuck
     virtual bool reached_destination() const { return _reached_destination; }

--- a/libraries/AR_WPNav/AR_WPNav_OA.cpp
+++ b/libraries/AR_WPNav/AR_WPNav_OA.cpp
@@ -115,7 +115,7 @@ void AR_WPNav_OA::update(float dt)
             case AP_OAPathPlanner::OAPathPlannerUsed::BendyRulerHorizontal: {
                 // BendyRuler.  Action is only needed if path planner has just became active or the target destination's lat or lon has changed
                 if (!_oa_active || !oa_destination_new.same_latlon_as(_oa_destination)) {
-                    if (AR_WPNav::set_desired_location_expect_fast_update(oa_destination_new)) {
+                    if (AR_WPNav::set_destination_expect_fast_update(oa_destination_new)) {
                         // if new target set successfully, update oa state and destination
                         _oa_active = true;
                         _oa_origin = oa_origin_new;


### PR DESCRIPTION
### Summary

Improves the naming & clarity of the function by aligning with terms used in AC_WPNav. (Similar PRs: #32883 #32884 )

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
./Tools/scripts/size_compare_branches.py --vehicle=rover --board=CubeOrange

Board,rover
CubeOrange,*
```

### Description

Regarding the redundant docstring in in the cpp file, I see 3 options:
1. Remove it
2. Replace it with "(See declaration for docstring)"
3. Update it identically to the one in the h file.

Clearly I prefer (1). If a reviewer forces (3), I'll comply. On a similar PR, I proposed (2) and had a reviewer request changing it to (1).

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
