### PR TITLE
AR_WPNav: Rename to set_destination_to_stopping_location

### DIFF
--- a/Rover/mode_smart_rtl.cpp
+++ b/Rover/mode_smart_rtl.cpp
@@ -23,8 +23,7 @@ bool ModeSmartRTL::_enter()
     // initialise waypoint navigation library
     g2.wp_nav.init(MAX(0, g2.rtl_speed));
 
-    // set desired location to reasonable stopping point
-    if (!g2.wp_nav.set_desired_location_to_stopping_location()) {
+    if (!g2.wp_nav.set_destination_to_stopping_location()) {
         return false;
     }
 

--- a/libraries/AR_WPNav/AR_WPNav.cpp
+++ b/libraries/AR_WPNav/AR_WPNav.cpp
@@ -301,8 +301,7 @@ bool AR_WPNav::set_desired_location(const Location& destination, Location next_d
     return true;
 }
 
-// set desired location to a reasonable stopping point, return true on success
-bool AR_WPNav::set_desired_location_to_stopping_location()
+bool AR_WPNav::set_destination_to_stopping_location()
 {
     Location stopping_loc;
     if (!get_stopping_location(stopping_loc)) {

--- a/libraries/AR_WPNav/AR_WPNav.h
+++ b/libraries/AR_WPNav/AR_WPNav.h
@@ -43,8 +43,8 @@ public:
     // next_destination should be provided if known to allow smooth cornering
     virtual bool set_desired_location(const Location &destination, Location next_destination = Location()) WARN_IF_UNUSED;
 
-    // set desired location to a reasonable stopping point, return true on success
-    bool set_desired_location_to_stopping_location()  WARN_IF_UNUSED;
+    // set destination to a reasonable stopping point, return true on success
+    bool set_destination_to_stopping_location()  WARN_IF_UNUSED;
 
     // set desired location as offset from the EKF origin, return true on success
     bool set_desired_location_NED(const Vector3f& destination) WARN_IF_UNUSED;


### PR DESCRIPTION
### Summary

Improves the naming & clarity of the function. (Similar PRs: #32883 #32884 #32886 )

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
./Tools/scripts/size_compare_branches.py --vehicle=rover --board=CubeOrange

Board,rover
CubeOrange,*
```

### Description

Regarding the redundant documenting comments in the cpp file and at the call-site, I prefer removing them.
In the past, some reviewers have required keeping all of them updated. If that's required, please make it clear via a request-changes.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
