### PR TITLE
AR_WPNav: Rename to set_destination

### DIFF
--- a/Rover/mode.cpp
+++ b/Rover/mode.cpp
@@ -248,7 +248,7 @@ float Mode::get_desired_lat_accel() const
 // set desired location
 bool Mode::set_desired_location(const Location &destination, Location next_destination )
 {
-    if (!g2.wp_nav.set_desired_location(destination, next_destination)) {
+    if (!g2.wp_nav.set_destination(destination, next_destination)) {
         return false;
     }
 

--- a/Rover/mode_guided.cpp
+++ b/Rover/mode_guided.cpp
@@ -316,7 +316,7 @@ bool ModeGuided::set_desired_location(const Location &destination, Location next
 
     if (use_scurves_for_navigation()) {
         // use scurves for navigation
-        if (!g2.wp_nav.set_desired_location(destination, next_destination)) {
+        if (!g2.wp_nav.set_destination(destination, next_destination)) {
             return false;
         }
     } else {

--- a/Rover/mode_rtl.cpp
+++ b/Rover/mode_rtl.cpp
@@ -12,12 +12,11 @@ bool ModeRTL::_enter()
 
     // set target to the closest rally point or home
 #if HAL_RALLY_ENABLED
-    if (!g2.wp_nav.set_desired_location(g2.rally.calc_best_rally_or_home_location(rover.current_loc, ahrs.get_home().alt))) {
+    if (!g2.wp_nav.set_destination(g2.rally.calc_best_rally_or_home_location(rover.current_loc, ahrs.get_home().alt))) {
         return false;
     }
 #else
-    // set destination
-    if (!g2.wp_nav.set_desired_location(ahrs.get_home())) {
+    if (!g2.wp_nav.set_destination(ahrs.get_home())) {
         return false;
     }
 #endif

--- a/libraries/AR_WPNav/AR_WPNav.cpp
+++ b/libraries/AR_WPNav/AR_WPNav.cpp
@@ -198,9 +198,7 @@ void AR_WPNav::set_nudge_speed_max(float nudge_speed_max)
     _nudge_speed_max = nudge_speed_max;
 }
 
-// set desired location and (optionally) next_destination
-// next_destination should be provided if known to allow smooth cornering
-bool AR_WPNav::set_desired_location(const Location& destination, Location next_destination)
+bool AR_WPNav::set_destination(const Location& destination, Location next_destination)
 {
     // re-initialise if inactive, previous destination has been interrupted or different controller was used
     if (!is_active() || !_reached_destination || (_nav_control_type != NavControllerType::NAV_SCURVE)) {
@@ -308,7 +306,7 @@ bool AR_WPNav::set_desired_location_to_stopping_location()
     if (!get_stopping_location(stopping_loc)) {
         return false;
     }
-    return set_desired_location(stopping_loc);
+    return set_destination(stopping_loc);
 }
 
 // set desired location as offset from the EKF origin, return true on success
@@ -322,7 +320,7 @@ bool AR_WPNav::set_desired_location_NED(const Vector3f& destination)
 
     // apply offset
     destination_ned.offset(destination.x, destination.y);
-    return set_desired_location(destination_ned);
+    return set_destination(destination_ned);
 }
 
 bool AR_WPNav::set_desired_location_NED(const Vector3f &destination, const Vector3f &next_destination)
@@ -337,7 +335,7 @@ bool AR_WPNav::set_desired_location_NED(const Vector3f &destination, const Vecto
     // apply offsets
     dest_loc.offset(destination.x, destination.y);
     next_dest_loc.offset(next_destination.x, next_destination.y);
-    return set_desired_location(dest_loc, next_dest_loc);
+    return set_destination(dest_loc, next_dest_loc);
 }
 
 // set desired location but expect the destination to be updated again in the near future

--- a/libraries/AR_WPNav/AR_WPNav.h
+++ b/libraries/AR_WPNav/AR_WPNav.h
@@ -39,9 +39,9 @@ public:
     // get desired lateral acceleration (for reporting purposes only because will be zero during pivot turns)
     float get_lat_accel() const { return _desired_lat_accel; }
 
-    // set desired location and (optionally) next_destination
+    // set destination and (optionally) next_destination
     // next_destination should be provided if known to allow smooth cornering
-    virtual bool set_desired_location(const Location &destination, Location next_destination = Location()) WARN_IF_UNUSED;
+    virtual bool set_destination(const Location &destination, Location next_destination = Location()) WARN_IF_UNUSED;
 
     // set desired location to a reasonable stopping point, return true on success
     bool set_desired_location_to_stopping_location()  WARN_IF_UNUSED;
@@ -55,7 +55,7 @@ public:
     // Note: object avoidance is not supported if this method is used
     bool set_desired_location_expect_fast_update(const Location &destination) WARN_IF_UNUSED;
 
-    // true if vehicle has reached desired location. defaults to true because this is normally used by missions and we do not want the mission to become stuck
+    // true if vehicle has reached destination. defaults to true because this is normally used by missions and we do not want the mission to become stuck
     virtual bool reached_destination() const { return _reached_destination; }
 
     // return straight-line distance (in meters) to destination
@@ -100,7 +100,7 @@ public:
     // returns true on success, false on failure
     bool get_stopping_location(Location& stopping_loc) WARN_IF_UNUSED;
 
-    // is_fast_waypoint returns true if vehicle will not stop at destination (e.g. set_desired_location provided a next_destination)
+    // is_fast_waypoint returns true if vehicle will not stop at destination (e.g. a next_destination has been provided)
     bool is_fast_waypoint() const { return _fast_waypoint; }
 
     // parameter var table

--- a/libraries/AR_WPNav/AR_WPNav_OA.cpp
+++ b/libraries/AR_WPNav/AR_WPNav_OA.cpp
@@ -67,7 +67,7 @@ void AR_WPNav_OA::update(float dt)
         case AP_OAPathPlanner::OA_NOT_REQUIRED:
             if (_oa_active) {
                 // object avoidance has become inactive so reset target to original destination
-                if (!AR_WPNav::set_desired_location(_destination_oabak)) {
+                if (!AR_WPNav::set_destination(_destination_oabak)) {
                     // this should never happen because we should have an EKF origin and the destination must be valid
                     INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
                     stop_vehicle = true;
@@ -99,7 +99,7 @@ void AR_WPNav_OA::update(float dt)
             case AP_OAPathPlanner::OAPathPlannerUsed::Dijkstras:
                 // Dijkstra's.  Action is only needed if path planner has just became active or the target destination's lat or lon has changed
                 if (!_oa_active || !oa_destination_new.same_latlon_as(_oa_destination)) {
-                    if (AR_WPNav::set_desired_location(oa_destination_new)) {
+                    if (AR_WPNav::set_destination(oa_destination_new)) {
                         // if new target set successfully, update oa state and destination
                         _oa_active = true;
                         _oa_origin = oa_origin_new;
@@ -149,11 +149,9 @@ void AR_WPNav_OA::update(float dt)
     AR_WPNav::update(dt);
 }
 
-// set desired location and (optionally) next_destination
-// next_destination should be provided if known to allow smooth cornering
-bool AR_WPNav_OA::set_desired_location(const Location& destination, Location next_destination)
+bool AR_WPNav_OA::set_destination(const Location& destination, Location next_destination)
 {
-    const bool ret = AR_WPNav::set_desired_location(destination, next_destination);
+    const bool ret = AR_WPNav::set_destination(destination, next_destination);
 
     if (ret) {
         // disable object avoidance, it will be re-enabled (if necessary) on next update
@@ -163,7 +161,6 @@ bool AR_WPNav_OA::set_desired_location(const Location& destination, Location nex
     return ret;
 }
 
-// true if vehicle has reached desired location. defaults to true because this is normally used by missions and we do not want the mission to become stuck
 bool AR_WPNav_OA::reached_destination() const
 {
     // object avoidance should always be deactivated before reaching final destination

--- a/libraries/AR_WPNav/AR_WPNav_OA.h
+++ b/libraries/AR_WPNav/AR_WPNav_OA.h
@@ -11,11 +11,11 @@ public:
     // update navigation
     void update(float dt) override;
 
-    // set desired location and (optionally) next_destination
+    // set destination and (optionally) next_destination
     // next_destination should be provided if known to allow smooth cornering
-    bool set_desired_location(const Location &destination, Location next_destination = Location()) override WARN_IF_UNUSED;
+    bool set_destination(const Location &destination, Location next_destination = Location()) override WARN_IF_UNUSED;
 
-    // true if vehicle has reached desired location. defaults to true because this is normally used by missions and we do not want the mission to become stuck
+    // true if vehicle has reached destination. defaults to true because this is normally used by missions and we do not want the mission to become stuck
     bool reached_destination() const override;
 
     // get object avoidance adjusted origin. Note: this is not guaranteed to be valid (i.e. _orig_and_dest_valid is not checked)


### PR DESCRIPTION
### Summary

Improves the naming & clarity of the function. (Similar PRs: #32883 #32884 #32886 #32887 )

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
./Tools/scripts/size_compare_branches.py --vehicle=rover --board=CubeOrange

Board,rover
CubeOrange,*
```

### Description

This PR may conflict with one of the prior ones. If so, it's easy to rebase once it merges.

Regarding the redundant documentation in the cpp file, I prefer removing them.
In the past, some reviewers have required keeping all of them updated. If that's required, please make it clear via a request-changes.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
