### PR TITLE
Rover: Use name 'destination' (not desired location)

### DIFF
--- a/Rover/GCS_MAVLink_Rover.cpp
+++ b/Rover/GCS_MAVLink_Rover.cpp
@@ -74,7 +74,7 @@ MAV_STATE GCS_MAVLINK_Rover::vehicle_system_status() const
 
 bool GCS_MAVLINK_Rover::get_target_location(Location &target) const
 {
-    return rover.control_mode->get_desired_location(target);
+    return rover.control_mode->get_destination(target);
 }
 
 void GCS_MAVLINK_Rover::send_nav_controller_output() const
@@ -416,7 +416,7 @@ bool GCS_MAVLINK_Rover::handle_guided_request(AP_Mission::Mission_Command &cmd)
     }
 
     // make any new wp uploaded instant (in case we are already in Guided mode)
-    return rover.mode_guided.set_desired_location(cmd.content.location);
+    return rover.mode_guided.set_destination(cmd.content.location);
 }
 
 MAV_RESULT GCS_MAVLINK_Rover::_handle_command_preflight_calibration(const mavlink_command_int_t &packet, const mavlink_message_t &msg)
@@ -534,8 +534,7 @@ MAV_RESULT GCS_MAVLINK_Rover::handle_command_int_do_reposition(const mavlink_com
         }
     }
 
-    // set the destination
-    if (!rover.mode_guided.set_desired_location(requested_location)) {
+    if (!rover.mode_guided.set_destination(requested_location)) {
         return MAV_RESULT_FAILED;
     }
 
@@ -720,12 +719,12 @@ void GCS_MAVLINK_Rover::handle_set_position_target_local_ned(const mavlink_messa
         return;
     }
 
-    // set guided mode targets
+    // set guided mode target
     if (!pos_ignore) {
         // consume position target
-        if (!rover.mode_guided.set_desired_location(target_loc)) {
-            // GCS will need to monitor desired location to
-            // see if they are having an effect.
+        if (!rover.mode_guided.set_destination(target_loc)) {
+            // GCS will need to monitor destination to
+            // see if it is having an effect.
         }
         return;
     }
@@ -833,9 +832,9 @@ void GCS_MAVLINK_Rover::handle_set_position_target_global_int(const mavlink_mess
     // set guided mode targets
     if (!pos_ignore) {
         // consume position target
-        if (!rover.mode_guided.set_desired_location(target_loc)) {
-            // GCS will just need to look at desired location
-            // outputs to see if it having an effect.
+        if (!rover.mode_guided.set_destination(target_loc)) {
+            // GCS will need to monitor destination to
+            // see if it is having an effect.
         }
         return;
     }

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -165,7 +165,7 @@ bool Rover::set_target_location(const Location& target_loc)
         return false;
     }
 
-    return mode_guided.set_desired_location(target_loc);
+    return mode_guided.set_destination(target_loc);
 }
 #endif //AP_SCRIPTING_ENABLED || AP_EXTERNAL_CONTROL_ENABLED
 

--- a/Rover/mode.cpp
+++ b/Rover/mode.cpp
@@ -245,8 +245,7 @@ float Mode::get_desired_lat_accel() const
     return g2.wp_nav.get_lat_accel();
 }
 
-// set desired location
-bool Mode::set_desired_location(const Location &destination, Location next_destination )
+bool Mode::set_destination(const Location &destination, Location next_destination )
 {
     if (!g2.wp_nav.set_desired_location(destination, next_destination)) {
         return false;

--- a/Rover/mode.h
+++ b/Rover/mode.h
@@ -110,15 +110,13 @@ public:
     // return straight-line distance (in meters) to destination
     virtual float get_distance_to_destination() const { return 0.0f; }
 
-    // return desired location (used in Guided, Auto, RTL, etc)
     // return true on success, false if there is no valid destination
-    virtual bool get_desired_location(Location& destination) const WARN_IF_UNUSED { return false; }
+    virtual bool get_destination(Location& destination) const WARN_IF_UNUSED { return false; }
 
-    // set desired location (used in Guided, Auto)
-    // set next_destination (if known).  If not provided vehicle stops at destination
-    virtual bool set_desired_location(const Location &destination, Location next_destination = Location()) WARN_IF_UNUSED;
+    // set destination (if next_destination is not provided, vehicle stops at destination)
+    virtual bool set_destination(const Location &destination, Location next_destination = Location()) WARN_IF_UNUSED;
 
-    // true if vehicle has reached desired location. defaults to true because this is normally used by missions and we do not want the mission to become stuck
+    // true if vehicle has reached destination. defaults to true because this is normally used by missions and we do not want the mission to become stuck
     virtual bool reached_destination() const { return true; }
 
     // get default speed for this mode (held in CRUISE_SPEED, WP_SPEED or RTL_SPEED)
@@ -274,9 +272,9 @@ public:
     // return straight-line distance (in meters) to destination
     float get_distance_to_destination() const override;
 
-    // get or set desired location
-    bool get_desired_location(Location& destination) const override WARN_IF_UNUSED;
-    bool set_desired_location(const Location &destination, Location next_destination = Location()) override WARN_IF_UNUSED;
+    // get or set destination
+    bool get_destination(Location& destination) const override WARN_IF_UNUSED;
+    bool set_destination(const Location &destination, Location next_destination = Location()) override WARN_IF_UNUSED;
     bool reached_destination() const override;
 
     // set desired speed in m/s
@@ -452,8 +450,7 @@ public:
     // return straight-line distance (in meters) to destination
     float get_distance_to_destination() const override { return _distance_to_destination; }
 
-    // get or set desired location
-    bool get_desired_location(Location& destination) const override WARN_IF_UNUSED;
+    bool get_destination(Location& destination) const override WARN_IF_UNUSED;
 
     // return total angle in radians that vehicle has circled
     // fabsf is used so that full rotations in either direction are counted
@@ -550,9 +547,8 @@ public:
     // set desired speed in m/s
     bool set_desired_speed(float speed_ms) override;
 
-    // get or set desired location
-    bool get_desired_location(Location& destination) const override WARN_IF_UNUSED;
-    bool set_desired_location(const Location &destination, Location next_destination = Location()) override WARN_IF_UNUSED;
+    bool get_destination(Location& destination) const override WARN_IF_UNUSED;
+    bool set_destination(const Location &destination, Location next_destination = Location()) override WARN_IF_UNUSED;
 
     // set desired heading and speed
     void set_desired_heading_and_speed(float yaw_angle_cd, float target_speed);
@@ -661,8 +657,8 @@ public:
     float nav_bearing() const override { return _desired_yaw_cd * 0.01f; }
     float crosstrack_error_m() const override { return 0.0f; }
 
-    // return desired location
-    bool get_desired_location(Location& destination) const override WARN_IF_UNUSED;
+    // return destination
+    bool get_destination(Location& destination) const override WARN_IF_UNUSED;
 
     // return straight-line distance (in meters) to destination
     float get_distance_to_destination() const override { return _distance_to_destination; }
@@ -717,8 +713,7 @@ public:
     // do not allow arming from this mode
     bool allows_arming() const override { return false; }
 
-    // return desired location
-    bool get_desired_location(Location& destination) const override WARN_IF_UNUSED;
+    bool get_destination(Location& destination) const override WARN_IF_UNUSED;
 
     // return straight-line distance (in meters) to destination
     float get_distance_to_destination() const override { return _distance_to_destination; }
@@ -756,8 +751,7 @@ public:
     // do not allow arming from this mode
     bool allows_arming() const override { return false; }
 
-    // return desired location
-    bool get_desired_location(Location& destination) const override WARN_IF_UNUSED;
+    bool get_destination(Location& destination) const override WARN_IF_UNUSED;
 
     // return straight-line distance (in meters) to destination
     float get_distance_to_destination() const override { return _distance_to_destination; }
@@ -859,8 +853,7 @@ public:
     float nav_bearing() const override { return wp_bearing(); }
     float crosstrack_error_m() const override { return 0.0f; }
 
-    // return desired location
-    bool get_desired_location(Location& destination) const override WARN_IF_UNUSED { return false; }
+    bool get_destination(Location& destination) const override WARN_IF_UNUSED { return false; }
 
     // return straight-line distance (in meters) to destination
     float get_distance_to_destination() const override;

--- a/Rover/mode_auto.cpp
+++ b/Rover/mode_auto.cpp
@@ -277,8 +277,7 @@ float ModeAuto::get_distance_to_destination() const
     return 0.0f;
 }
 
-// get desired location
-bool ModeAuto::get_desired_location(Location& destination) const
+bool ModeAuto::get_destination(Location& destination) const
 {
     switch (_submode) {
     case SubMode::WP:
@@ -289,28 +288,28 @@ bool ModeAuto::get_desired_location(Location& destination) const
         return false;
     case SubMode::HeadingAndSpeed:
     case SubMode::Stop:
-        // no desired location for this submode
+        // no destination for this submode
         return false;
     case SubMode::RTL:
-        return rover.mode_rtl.get_desired_location(destination);
+        return rover.mode_rtl.get_destination(destination);
     case SubMode::Loiter:
-        return rover.mode_loiter.get_desired_location(destination);
+        return rover.mode_loiter.get_destination(destination);
     case SubMode::Guided:
     case SubMode::NavScriptTime:
-        return rover.mode_guided.get_desired_location(destination);
+        return rover.mode_guided.get_destination(destination);
     case SubMode::Circle:
-        return g2.mode_circle.get_desired_location(destination);
+        return g2.mode_circle.get_destination(destination);
     }
 
     // we should never reach here but just in case
     return false;
 }
 
-// set desired location to drive to
-bool ModeAuto::set_desired_location(const Location &destination, Location next_destination)
+// set destination to drive to
+bool ModeAuto::set_destination(const Location &destination, Location next_destination)
 {
     // call parent
-    if (!Mode::set_desired_location(destination, next_destination)) {
+    if (!Mode::set_destination(destination, next_destination)) {
         return false;
     }
 
@@ -742,14 +741,14 @@ bool ModeAuto::do_nav_wp(const AP_Mission::Mission_Command& cmd, bool always_sto
     AP_Mission::Mission_Command next_cmd;
     if (always_stop_at_destination || !mission.get_next_nav_cmd(cmd.index+1, next_cmd)) {
         // single destination
-        if (!set_desired_location(cmdloc)) {
+        if (!set_destination(cmdloc)) {
             return false;
         }
     } else {
         // retrieve and sanitize next destination location
         Location next_cmdloc = next_cmd.content.location;
         next_cmdloc.sanitize(cmdloc);
-        if (!set_desired_location(cmdloc, next_cmdloc)) {
+        if (!set_destination(cmdloc, next_cmdloc)) {
             return false;
         }
     }

--- a/Rover/mode_circle.cpp
+++ b/Rover/mode_circle.cpp
@@ -287,8 +287,7 @@ bool ModeCircle::set_desired_speed(float speed_ms)
     return false;
 }
 
-// return desired location
-bool ModeCircle::get_desired_location(Location& destination) const
+bool ModeCircle::get_destination(Location& destination) const
 {
     destination = config.center_loc;
     destination.offset_bearing(degrees(target.yaw_rad), config.radius);

--- a/Rover/mode_guided.cpp
+++ b/Rover/mode_guided.cpp
@@ -276,8 +276,7 @@ bool ModeGuided::set_desired_speed(float speed_ms)
     return false;
 }
 
-// get desired location
-bool ModeGuided::get_desired_location(Location& destination) const
+bool ModeGuided::get_destination(Location& destination) const
 {
     switch (_guided_mode) {
     case SubMode::WP:
@@ -292,10 +291,10 @@ bool ModeGuided::get_desired_location(Location& destination) const
         return false;
     case SubMode::Loiter:
         // get destination from loiter
-        return rover.mode_loiter.get_desired_location(destination);
+        return rover.mode_loiter.get_destination(destination);
     case SubMode::SteeringAndThrottle:
     case SubMode::Stop:
-        // no desired location in this submode
+        // no destination in this submode
         break;
     }
 
@@ -303,8 +302,7 @@ bool ModeGuided::get_desired_location(Location& destination) const
     return false;
 }
 
-// set desired location
-bool ModeGuided::set_desired_location(const Location &destination, Location next_destination)
+bool ModeGuided::set_destination(const Location &destination, Location next_destination)
 {
 #if AP_FENCE_ENABLED
     // reject destination outside the fence

--- a/Rover/mode_loiter.cpp
+++ b/Rover/mode_loiter.cpp
@@ -72,8 +72,7 @@ void ModeLoiter::update()
     calc_throttle(_desired_speed, true);
 }
 
-// get desired location
-bool ModeLoiter::get_desired_location(Location& destination) const
+bool ModeLoiter::get_destination(Location& destination) const
 {
     destination = _destination;
     return true;

--- a/Rover/mode_rtl.cpp
+++ b/Rover/mode_rtl.cpp
@@ -62,8 +62,7 @@ void ModeRTL::update()
     }
 }
 
-// get desired location
-bool ModeRTL::get_desired_location(Location& destination) const
+bool ModeRTL::get_destination(Location& destination) const
 {
     if (g2.wp_nav.is_destination_valid()) {
         destination = g2.wp_nav.get_oa_destination();

--- a/Rover/mode_smart_rtl.cpp
+++ b/Rover/mode_smart_rtl.cpp
@@ -110,8 +110,7 @@ void ModeSmartRTL::update()
     }
 }
 
-// get desired location
-bool ModeSmartRTL::get_desired_location(Location& destination) const
+bool ModeSmartRTL::get_destination(Location& destination) const
 {
     switch (smart_rtl_state) {
     case SmartRTLState::WaitForPathCleanup:


### PR DESCRIPTION
### Summary

Improve code clarity by aligning Rover on term 'destination' (not "desired location"). This corresponds to PR-set #32883 #32884 #32886 #32887 #32888 which do the same in `AR_WPNav`.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
./Tools/scripts/size_compare_branches.py --vehicle=rover --board=CubeOrange

Board,rover
CubeOrange,*
```

I am trusting that Rover's autotests cover all modes, although I have not verified that myself. The fact that it compiles already demonstrates the rename was successful (at least for all compiled-in code paths).

### Description

Fixes a few comments which contribute non-obvious information. Removes self-evident ones. 

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
