### PR TITLE
AC_WPNav: Fix sign mistake in a sub-part of BendyRulerHorizontal

### DIFF
--- a/libraries/AC_WPNav/AC_WPNav_OA.cpp
+++ b/libraries/AC_WPNav/AC_WPNav_OA.cpp
@@ -242,7 +242,7 @@ bool AC_WPNav_OA::update_wpnav()
                     return false;
                 }
 
-                // Convert global destination to NEU vector and pass directly to position controller
+                // Convert global destination to NED vector and pass directly to position controller
                 Vector2f destination_ne_m;
                 if (!_oa_destination.get_vector_xy_from_origin_NE_m(destination_ne_m)) {
                     // this should never happen because we can only get here if we have an EKF origin
@@ -251,7 +251,7 @@ bool AC_WPNav_OA::update_wpnav()
                 }
                 float target_alt_loc_alt_m = 0;
                 UNUSED_RESULT(target_alt_loc.get_alt_m(target_alt_loc.get_alt_frame(), target_alt_loc_alt_m));
-                Vector3p destination_ned_m{destination_ne_m.x, destination_ne_m.y, target_alt_loc_alt_m};
+                Vector3p destination_ned_m{destination_ne_m.x, destination_ne_m.y, -target_alt_loc_alt_m};
 
                 // pass the desired position directly to the position controller
                 _pos_control.input_pos_NED_m(destination_ned_m, terrain_d_m, 10.0);


### PR DESCRIPTION
### Summary

One of the NED/NEU typos is a bug in the code. This PR fixes it. (Related to #32891 )

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

(I'm still determining how to test this... trying CI first.)

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
