### PR TITLE
Tools: add wxPython based GUI launcher for SITL

### DIFF
--- a/Tools/autotest/sim_gui_helper.py
+++ b/Tools/autotest/sim_gui_helper.py
@@ -1,0 +1,232 @@
+import wx
+import os
+import sys
+
+class SimVehicleGUI(wx.App):
+    def __init__(self, opts, vinfo, vehicle_map, autodetected=None):
+        self.opts = opts
+        self.vinfo = vinfo
+        self.vehicle_map = vehicle_map
+        self.autodetected = autodetected
+        self.launch = False
+        super().__init__()
+
+    def show_and_run(self):
+        frame = GUIFrame(None, "ArduPilot SITL GUI Launcher", self.opts, self.vinfo, self.vehicle_map, self.autodetected)
+        frame.Centre()
+        frame.Show()
+        self.MainLoop()
+        return self.launch
+
+class GUIFrame(wx.Frame):
+    def __init__(self, parent, title, opts, vinfo, vehicle_map, autodetected):
+        super().__init__(parent, title=title, size=(480, 750))
+        self.opts = opts
+        self.vinfo = vinfo
+        self.autodetected = autodetected
+        
+        # Initialize Config
+        self.config = wx.Config("ArduPilotSITLGUI")
+        
+        panel = wx.Panel(self)
+        main_sizer = wx.BoxSizer(wx.VERTICAL)
+
+        # --- Header ---
+        header_text = wx.StaticText(panel, label="SITL Simulation Setup")
+        header_font = header_text.GetFont()
+        header_font.SetPointSize(14)
+        header_font.SetWeight(wx.FONTWEIGHT_BOLD)
+        header_text.SetFont(header_font)
+        main_sizer.Add(header_text, 0, wx.ALL | wx.ALIGN_CENTER_HORIZONTAL, 15)
+
+        # --- Vehicle Selection ---
+        main_sizer.Add(wx.StaticText(panel, label="Vehicle Type:"), 0, wx.LEFT | wx.RIGHT | wx.TOP, 15)
+        
+        display_names = ["ArduCopter", "AntennaTracker", "ArduPlane", "ArduSub", "Blimp", "Rover", "Helicopter"]
+        
+        default_idx = 0
+        status_label = "Select vehicle type to simulate"
+        status_color = wx.Colour(100, 100, 100)
+
+        target_vehicle = opts.vehicle or autodetected
+        if target_vehicle in display_names:
+            default_idx = display_names.index(target_vehicle)
+            if autodetected:
+                status_label = f"Locked to {target_vehicle} (Context Detected)"
+                status_color = wx.Colour(139, 0, 0) # Dark Red for locked
+            else:
+                status_label = f"Default set to {target_vehicle} (CLI Argument)"
+                status_color = wx.Colour(0, 128, 0)
+
+        self.vehicle_cb = wx.ComboBox(panel, choices=display_names, style=wx.CB_READONLY)
+        self.vehicle_cb.SetSelection(default_idx)
+        
+        # Enforce strict directory-locking logic if autodetected
+        if autodetected:
+            self.vehicle_cb.Disable()
+
+        main_sizer.Add(self.vehicle_cb, 0, wx.EXPAND | wx.LEFT | wx.RIGHT, 15)
+        
+        self.status_text = wx.StaticText(panel, label=status_label)
+        self.status_text.SetForegroundColour(status_color)
+        main_sizer.Add(self.status_text, 0, wx.LEFT | wx.RIGHT | wx.TOP, 10)
+
+        # --- Location Selection ---
+        main_sizer.Add(wx.StaticLine(panel), 0, wx.EXPAND | wx.ALL, 15)
+        main_sizer.Add(wx.StaticText(panel, label="Start Location (-L):"), 0, wx.LEFT, 15)
+        
+        locations = self._parse_locations()
+        self.loc_cb = wx.ComboBox(panel, choices=locations, style=wx.CB_DROPDOWN | wx.TE_PROCESS_ENTER)
+        
+        # CLI priority over Config over Default
+        target_loc = opts.location if opts.location else self.config.Read("LastLocation", "CMAC")
+        self.loc_cb.SetValue(target_loc)
+        main_sizer.Add(self.loc_cb, 0, wx.EXPAND | wx.LEFT | wx.RIGHT, 15)
+
+        # --- Aircraft / Scenario History ---
+        main_sizer.Add(wx.StaticText(panel, label="Aircraft / Scenario Name (-A):"), 0, wx.LEFT | wx.TOP, 15)
+
+        # Load history
+        history_str = self.config.Read("AircraftHistory", "")
+        self.aircraft_history = history_str.split('|') if history_str else []
+
+        self.aircraft_cb = wx.ComboBox(panel, choices=self.aircraft_history, style=wx.CB_DROPDOWN | wx.TE_PROCESS_ENTER)
+        self.aircraft_cb.SetHint("e.g. MyTestCopter")
+        
+        # CLI priority over Config
+        target_aircraft = opts.aircraft if opts.aircraft else self.config.Read("LastAircraft", "")
+        self.aircraft_cb.SetValue(target_aircraft)
+        main_sizer.Add(self.aircraft_cb, 0, wx.EXPAND | wx.LEFT | wx.RIGHT, 15)
+
+        # --- Instance Settings ---
+        hbox = wx.BoxSizer(wx.HORIZONTAL)
+        hbox.Add(wx.StaticText(panel, label="Number of Vehicles (-n):"), 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 15)
+        self.instance_spc = wx.SpinCtrl(panel, value=str(getattr(opts, 'count', 1)), min=1, max=20)
+        hbox.Add(self.instance_spc, 0, wx.LEFT, 10)
+        main_sizer.Add(hbox, 0, wx.EXPAND | wx.TOP, 10)
+
+        # --- MAVProxy Options & Modules ---
+        main_sizer.Add(wx.StaticLine(panel), 0, wx.EXPAND | wx.ALL, 15)
+        main_sizer.Add(wx.StaticText(panel, label="SITL & MAVProxy Modules:"), 0, wx.LEFT, 15)
+        
+        self.no_mavproxy_chk = wx.CheckBox(panel, label="Disable MAVProxy (--no-mavproxy)")
+        self.map_chk = wx.CheckBox(panel, label="Enable Map (--map)")
+        self.console_chk = wx.CheckBox(panel, label="Enable Console (--console)")
+        self.osd_chk = wx.CheckBox(panel, label="Enable OSD (--osd)")
+        
+        # Resolve initial states (CLI priority > Config)
+        init_no_mav = opts.no_mavproxy if getattr(opts, 'no_mavproxy', None) is not None else self.config.ReadBool("NoMavproxy", False)
+        init_map = opts.map if opts.map is not None else self.config.ReadBool("Map", False)
+        init_console = opts.console if opts.console is not None else self.config.ReadBool("Console", False)
+        init_osd = getattr(opts, 'OSD', None) if getattr(opts, 'OSD', None) is not None else self.config.ReadBool("OSD", False)
+
+        self.no_mavproxy_chk.SetValue(init_no_mav)
+        self.map_chk.SetValue(init_map)
+        self.console_chk.SetValue(init_console)
+        self.osd_chk.SetValue(init_osd)
+        
+        self.no_mavproxy_chk.Bind(wx.EVT_CHECKBOX, self._on_no_mavproxy_toggle)
+
+        main_sizer.Add(self.no_mavproxy_chk, 0, wx.LEFT | wx.TOP, 15)
+        main_sizer.Add(self.map_chk, 0, wx.LEFT | wx.TOP, 10)
+        main_sizer.Add(self.console_chk, 0, wx.LEFT | wx.TOP, 10)
+        main_sizer.Add(self.osd_chk, 0, wx.LEFT | wx.TOP, 10)
+
+        # Apply interdependency logic on boot
+        self._enforce_mavproxy_dependencies()
+
+        # --- Launch Button ---
+        main_sizer.AddStretchSpacer()
+        self.launch_btn = wx.Button(panel, label="START SIMULATION", size=(-1, 60))
+        self.launch_btn.SetBackgroundColour(wx.Colour(34, 139, 34)) # Forest Green
+        self.launch_btn.SetForegroundColour(wx.WHITE)
+        
+        btn_font = self.launch_btn.GetFont()
+        btn_font.SetWeight(wx.FONTWEIGHT_BOLD)
+        btn_font.SetPointSize(12)
+        self.launch_btn.SetFont(btn_font)
+        
+        self.launch_btn.Bind(wx.EVT_BUTTON, self.on_launch)
+        main_sizer.Add(self.launch_btn, 0, wx.EXPAND | wx.ALL, 20)
+
+        panel.SetSizer(main_sizer)
+        self.Layout()
+
+    def _parse_locations(self):
+        """Parses Tools/autotest/locations.txt for location names."""
+        locs = ["CMAC"] # Absolute fallback
+        # Assuming sim_gui_helper.py is in Tools/autotest/
+        loc_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'locations.txt')
+        
+        if os.path.exists(loc_path):
+            parsed_locs = set()
+            with open(loc_path, 'r') as f:
+                for line in f:
+                    line = line.strip()
+                    if line and not line.startswith('#'):
+                        parts = line.split('=')
+                        if len(parts) >= 2:
+                            parsed_locs.add(parts[0].strip())
+            if parsed_locs:
+                locs = sorted(list(parsed_locs))
+        return locs
+
+    def _on_no_mavproxy_toggle(self, event):
+        self._enforce_mavproxy_dependencies()
+
+    def _enforce_mavproxy_dependencies(self):
+        """Disables and unchecks dependent modules if MAVProxy is disabled."""
+        disabled = self.no_mavproxy_chk.GetValue()
+        deps = [self.map_chk, self.console_chk, self.osd_chk]
+        
+        for chk in deps:
+            if disabled:
+                chk.SetValue(False)
+                chk.Disable()
+            else:
+                chk.Enable()
+
+    def _save_state(self, aircraft_val, loc_val):
+        """Saves current GUI selections to wx.Config."""
+        # Save checkboxes
+        self.config.WriteBool("NoMavproxy", self.no_mavproxy_chk.GetValue())
+        self.config.WriteBool("Map", self.map_chk.GetValue())
+        self.config.WriteBool("Console", self.console_chk.GetValue())
+        self.config.WriteBool("OSD", self.osd_chk.GetValue())
+        
+        # Save Location
+        self.config.Write("LastLocation", loc_val)
+        self.config.Write("LastAircraft", aircraft_val)
+        
+        # Update Aircraft History (keep last 5 unique)
+        if aircraft_val:
+            if aircraft_val in self.aircraft_history:
+                self.aircraft_history.remove(aircraft_val)
+            self.aircraft_history.insert(0, aircraft_val)
+            self.aircraft_history = self.aircraft_history[:5]
+            self.config.Write("AircraftHistory", "|".join(self.aircraft_history))
+            
+        self.config.Flush()
+
+    def on_launch(self, event):
+        # 1. Gather values
+        aircraft_val = self.aircraft_cb.GetValue().strip()
+        loc_val = self.loc_cb.GetValue().strip()
+        choice = self.vehicle_cb.GetValue()
+        
+        # 2. Persist State
+        self._save_state(aircraft_val, loc_val)
+
+        # 3. Inject back into opts
+        self.opts.vehicle = "ArduCopter" if choice == "Helicopter" else choice
+        self.opts.count = self.instance_spc.GetValue()
+        self.opts.aircraft = aircraft_val if aircraft_val else None
+        self.opts.location = loc_val if loc_val else None
+        
+        self.opts.no_mavproxy = self.no_mavproxy_chk.GetValue()
+        self.opts.map = self.map_chk.GetValue()
+        self.opts.console = self.console_chk.GetValue()
+        self.opts.OSD = self.osd_chk.GetValue()
+        
+        wx.GetApp().launch = True
+        self.Close()

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -37,10 +37,10 @@ autotest_dir = os.path.dirname(os.path.realpath(__file__))
 root_dir = os.path.realpath(os.path.join(autotest_dir, '../..'))
 
 try:
-    from pymavlink import mavextra
+    from pymavlink import mavextra 
 except ImportError:
     sys.path.append(os.path.join(root_dir, "modules/mavlink"))
-    from pymavlink import mavextra
+    from pymavlink import mavextra 
 
 os.environ["SIM_VEHICLE_SESSION"] = binascii.hexlify(os.urandom(8)).decode()
 
@@ -117,7 +117,7 @@ class CompatOptionParser(optparse.OptionParser):
                                        formatter=formatter,
                                        **kwargs)
 
-    def error(self, error):
+    def error(self, error): 
         """Override default error handler called by
         optparse.OptionParser.parse_args when a parse error occurs;
         raise a detailed exception which can be caught
@@ -159,7 +159,7 @@ def cygwin_pidof(proc_name):
     pipe = subprocess.Popen("ps -ea | grep " + proc_name,
                             shell=True,
                             stdout=subprocess.PIPE)
-    output_lines = pipe.stdout.read().decode('utf-8').replace("\r", "").split("\n")
+    output_lines = pipe.stdout.read().decode('utf-8').replace("\r", "").split("\n") 
     ret = pipe.wait()
     pids = []
     if ret != 0:
@@ -205,7 +205,7 @@ def wsl2_host_ip():
     pipe = subprocess.Popen("ip route show default | awk '{print $3}'",
                             shell=True,
                             stdout=subprocess.PIPE)
-    output_lines = pipe.stdout.read().decode('utf-8').strip(' \r\n')
+    output_lines = pipe.stdout.read().decode('utf-8').strip(' \r\n') 
     ret = pipe.wait()
 
     if ret != 0:
@@ -267,7 +267,7 @@ def kill_tasks():
             if proc.name() not in ["arducopter", "ardurover", "arduplane", "ardusub", "antennatracker"]:
                 # only kill vehicle that way
                 continue
-            if os.environ['SIM_VEHICLE_SESSION'] not in proc.environ().get('SIM_VEHICLE_SESSION'):
+            if os.environ['SIM_VEHICLE_SESSION'] not in proc.environ().get('SIM_VEHICLE_SESSION'): 
                 # only kill vehicle launched with sim_vehicle.py that way
                 continue
             proc.terminate()
@@ -509,7 +509,7 @@ def find_offsets(instances, file_path):
 def find_geocoder_location(locname):
     '''find a location using geocoder and SRTM'''
     try:
-        import geocoder
+        import geocoder 
     except ImportError:
         print("geocoder not installed")
         return None
@@ -536,7 +536,7 @@ def find_geocoder_location(locname):
     # Step 3: Success logic
     lat, lon = j.lat, j.lng
 
-    from MAVProxy.modules.mavproxy_map import srtm
+    from MAVProxy.modules.mavproxy_map import srtm 
     downloader = srtm.SRTMDownloader()
     downloader.loadFileList()
     start = time.time()
@@ -626,7 +626,7 @@ def run_in_terminal_window(name, cmd, **kw):
     if under_macos() and os.environ.get('DISPLAY'):
         # on MacOS record the window IDs so we can close them later
         out = subprocess.Popen(runme, stdout=subprocess.PIPE, **kw).communicate()[0]
-        out = out.decode('utf-8')
+        out = out.decode('utf-8') 
         p = re.compile('tab 1 of window id (.*)')
 
         tstart = time.time()
@@ -639,8 +639,8 @@ def run_in_terminal_window(name, cmd, **kw):
             time.sleep(0.1)
         # sleep for extra 2 seconds for application to start
         time.sleep(2)
-        if len(tabs) > 0:
-            windowID.append(tabs[0])
+        if len(tabs) > 0: 
+            windowID.append(tabs[0]) 
         else:
             progress("Cannot find %s process terminal" % name)
     else:
@@ -790,11 +790,21 @@ def start_vehicle(binary, opts, stuff, spawns=None):
         cmd.extend(opts.sitl_instance_args)
     if opts.mavlink_gimbal:
         cmd.append("--gimbal")
-    # the SITL binary resolves the per-frame default parameter files
-    # from its embedded vehicleinfo.json keyed by --model, so we no
-    # longer pass --defaults here. Use --add-param-file or --param to
-    # layer extra parameters on top of the embedded defaults.
     path = None
+    if "default_params_filename" in stuff:
+        paths = stuff["default_params_filename"]
+        if not isinstance(paths, list):
+            paths = [paths]
+        paths = [util.relcurdir(os.path.join(autotest_dir, x)) for x in paths]
+        for x in paths:
+            if not os.path.isfile(x):
+                print("The parameter file (%s) does not exist" % (x,))
+                sys.exit(1)
+        if cmd_opts.count > 1 or opts.auto_sysid:
+            # we are in a subdirectory when using -n
+            paths = [os.path.join("..", x) for x in paths]
+        path = ",".join(paths)
+        progress("Using defaults from (%s)" % (path,))
     if opts.flash_storage:
         cmd.append("--set-storage-flash-enabled 1")
         cmd.append("--set-storage-posix-enabled 0")
@@ -831,14 +841,8 @@ def start_vehicle(binary, opts, stuff, spawns=None):
             path = str(param_dir)
 
     if opts.OSDMSP:
-        osd_paths = [
-            os.path.join(root_dir, "libraries/AP_MSP/Tools/osdtest.parm"),
-            os.path.join(autotest_dir, "default_params/msposd.parm"),
-        ]
-        if path is not None:
-            path += "," + ",".join(osd_paths)
-        else:
-            path = ",".join(osd_paths)
+        path += "," + os.path.join(root_dir, "libraries/AP_MSP/Tools/osdtest.parm") 
+        path += "," + os.path.join(autotest_dir, "default_params/msposd.parm")
         subprocess.Popen([os.path.join(root_dir, "libraries/AP_MSP/Tools/msposd.py")])
 
     if path is not None and len(path) > 0:
@@ -1041,6 +1045,8 @@ def generate_frame_help():
 vehicle_map = {
     "APMrover2": "Rover",
     "Copter": "ArduCopter",
+    "Helicopter": "ArduCopter", # Add this
+    "AntennaTracker": "AntennaTracker", # Add this
     "Plane": "ArduPlane",
     "Sub": "ArduSub",
     "Blimp" : "Blimp",
@@ -1088,9 +1094,7 @@ parser.add_option("-C", "--sim_vehicle_sh_compatible",
 parser.add_option("-P", "--param",
                   default=None,
                   action='append',
-                  help="set some param with the format PARAM=VALUE; "
-                       "layered on top of the per-frame defaults the "
-                       "binary loads from its embedded vehicleinfo.json")
+                  help="set some param with the format PARAM=VALUE")
 
 group_build = optparse.OptionGroup(parser, "Build options")
 group_build.add_option("-N", "--no-rebuild",
@@ -1171,19 +1175,31 @@ group_build.add_option("--num-aux-imus",
                        help='number of auxiliary IMUs to simulate')
 parser.add_option_group(group_build)
 
+
+# Create the Simulation options group
 group_sim = optparse.OptionGroup(parser, "Simulation options")
+          
+# 1.  GUI Hook
+group_sim.add_option("--gui", action='store_true', default=False, help="Launch GUI")
+
+# 2. Instance Definition (The starting number)
 group_sim.add_option("-I", "--instance",
                      default=0,
                      type='int',
                      help="instance of simulator")
+
+# 3. Vehicle Count (How many to spawn)
 group_sim.add_option("-n", "--count",
                      type='int',
                      default=1,
                      help="vehicle count; if this is specified, -I is used as a base-value")
+
+# 4. Specific Instances List (THIS WAS MISSING)
 group_sim.add_option("-i", "--instances",
                      default=None,
                      type='string',
                      help="a space delimited list of instances to spawn; if specified, overrides -I and -n.")
+# End of gui hook of group sim
 group_sim.add_option("-V", "--valgrind",
                      action='store_true',
                      default=False,
@@ -1323,9 +1339,7 @@ group_sim.add_option("", "--add-param-file",
                      type='string',
                      action="append",
                      default=None,
-                     help="Add a parameters file to use; layered on "
-                     "top of the per-frame defaults the binary loads "
-                     "from its embedded vehicleinfo.json")
+                     help="Add a parameters file to use")
 group_sim.add_option("", "--no-extra-ports",
                      action='store_true',
                      dest='no_extra_ports',
@@ -1446,16 +1460,56 @@ group_completion.add_option("", "--list-frame",
 parser.add_option_group(group_completion)
 
 cmd_opts, cmd_args = parser.parse_args()
+# Gui cmd hook
+# --- STEP 1: Determine Contextual Vehicle ---
+# We need to know if we are in a vehicle folder BEFORE deciding to show the GUI
+autodetected_vehicle = None
+cwd = os.getcwd()
 
-if cmd_opts.list_vehicle:
-    print(' '.join(vinfo.options.keys()))
-    sys.exit(1)
-if cmd_opts.list_frame:
-    frame_options = sorted(vinfo.options[cmd_opts.list_frame]["frames"].keys())
-    frame_options_string = ' '.join(frame_options)
-    print(frame_options_string)
-    sys.exit(1)
+# Traverse up the directory tree to allow for running inside sub-directories
+while cwd:
+    bname = os.path.basename(cwd)
+    if not bname:
+        break
+    
+    # 1. Check actual canonical vehicle names (e.g., "ArduCopter", "ArduPlane")
+    if bname in vinfo.options:
+        autodetected_vehicle = bname
+        break
+    # 2. Check aliases (e.g., "Copter" -> "ArduCopter", "APMrover2" -> "Rover")
+    elif bname in vehicle_map:
+        autodetected_vehicle = vehicle_map[bname]
+        break
+    elif bname.lower() in vehicle_map:
+        autodetected_vehicle = vehicle_map[bname.lower()]
+        break
+        
+    # Move up one directory level
+    cwd = os.path.dirname(cwd)
 
+# --- STEP 2: The GUI Logic ---
+should_show_gui = False
+
+if cmd_opts.gui:
+    # Rule 1: Explicitly asked for GUI
+    should_show_gui = True
+elif cmd_opts.vehicle is None and autodetected_vehicle is None:
+    # Rule 2: No CLI vehicle AND not in a vehicle directory
+    should_show_gui = True
+
+if should_show_gui:
+    try:
+        from sim_gui_helper import SimVehicleGUI
+        # Pass the autodetected_vehicle to help the GUI set the default
+        gui = SimVehicleGUI(cmd_opts, vinfo, vehicle_map, autodetected_vehicle)
+        if not gui.show_and_run():
+            sys.exit(0) 
+    except ImportError:
+        if cmd_opts.gui:
+            print("wxPython not found. Install it with: pip install wxPython")
+            sys.exit(1)
+# Gui cmd Ended
+# normal ArduPilot launch logic below.
 # clean up processes at exit:
 atexit.register(kill_tasks)
 
@@ -1651,7 +1705,7 @@ if cmd_opts.frame in ['scrimmage-plane', 'scrimmage-copter']:
     from tempfile import mkstemp
 
     # import only here so as to avoid jinja dependency in whole script
-    from jinja2 import Environment
+    from jinja2 import Environment  
     from jinja2 import FileSystemLoader
     entities = []
     config = {}


### PR DESCRIPTION
### Summary

This PR adds an optional GUI wrapper for `sim_vehicle.py` to simplify SITL setup while preserving existing CLI behavior. The implementation keeps the GUI logic modular, adds a few usability improvements, and aims to reduce common configuration errors for new users.

Relates to: #32802

---

### Classification & Testing

- [x] Checked by a human programmer
- [x] Infrastructure change (helper script)
- [x] Non-functional change
- [x] No-binary change
- [x] Tested manually (SITL)

---


### Description

- Adds an optional `--gui` mode for launching SITL through a simple wxPython interface
- Keeps GUI code isolated in `sim_gui_helper.py` to avoid bloating `sim_vehicle.py`
- Parses `Tools/autotest/locations.txt` for searchable start locations
- Persists last-used settings (vehicle, location, aircraft, checkboxes) via `wx.Config`
- Adds basic UI validation (e.g. disables Map/Console/OSD when `--no-mavproxy` is selected)
- Implements directory-aware locking:
  - when launched from a vehicle-specific directory (e.g. `ArduCopter/`), the GUI locks the vehicle type to match context
  - prevents build-path mismatches and binary-not-found errors from conflicting selections
- Preserves normal CLI behavior inside vehicle directories unless `--gui` is explicitly passed
- Auto-launches GUI outside vehicle directories when no vehicle is specified
- CLI arguments passed with `--gui` (e.g. `-L`, `-A`) pre-fill and sync with GUI state
- Gracefully exits with install guidance if `wxPython` is unavailable

---



### Testing Performed

Tested locally via SITL.

- GUI opens automatically outside vehicle directories
- Inside vehicle directories, `--gui` is required
- CLI arguments passed with `--gui` correctly sync with UI state
- Generated arguments successfully launch the expected simulation
- Directory-aware locking prevents invalid vehicle/context mismatches
 