### PR TITLE
Fix some SIM::Battery unit suffixes

### DIFF
--- a/libraries/SITL/SIM_Battery.cpp
+++ b/libraries/SITL/SIM_Battery.cpp
@@ -115,10 +115,10 @@ void Battery::set_initial_SoC(float voltage)
     remaining_Ah = 0;
 }
 
-void Battery::setup(float _capacity_Ah, float _resistance, float _max_voltage)
+void Battery::setup(float _capacity_Ah, float _resistance_ohm, float _max_voltage)
 {
     capacity_Ah = _capacity_Ah;
-    resistance = _resistance;
+    resistance_ohm = _resistance_ohm;
     max_voltage = _max_voltage;
 
     voltage_set = max_voltage;
@@ -168,7 +168,7 @@ void Battery::consume_energy(float current_amps, uint64_t now_us)
     remaining_Ah -= delta_Ah;
     remaining_Ah = MAX(0, remaining_Ah);
 
-    float voltage_delta = current_amps * resistance;
+    float voltage_delta = current_amps * resistance_ohm;
     float voltage;
     if (!is_positive(capacity_Ah)) {
         voltage = voltage_set;
@@ -189,7 +189,7 @@ void Battery::update_temperature(float current_amps, uint64_t now_us)
     // (reminder: thermal_capacity = mass * specific_heat)
     constexpr float thermal_capacity = 2.8f;  // watt*seconds/degC
     constexpr float inverse_of_thermal_capacity = 1 / thermal_capacity;  // use inverse so we can multiply, not divide
-    const float temp_increase = (current_amps * current_amps) * resistance * inverse_of_thermal_capacity * (temperature_dt * 0.000001);
+    const float temp_increase = (current_amps * current_amps) * resistance_ohm * inverse_of_thermal_capacity * (temperature_dt * 0.000001);
     // decay temperature at some %second towards ambient
     const float temp_decrease = (temperature.kelvin - 273.15f) * 0.10 * temperature_dt * 0.000001;
     temperature.kelvin += (temp_increase - temp_decrease);

--- a/libraries/SITL/SIM_Battery.cpp
+++ b/libraries/SITL/SIM_Battery.cpp
@@ -155,7 +155,7 @@ void Battery::init_capacity(float capacity)
     set_initial_SoC(voltage_set);
 }
 
-void Battery::consume_energy(float current_amps, uint64_t now_us)
+void Battery::consume_energy(float current_amp, uint64_t now_us)
 {
     constexpr float microsec_to_sec = 1.0e-6f;
     float dt = static_cast<float>(now_us - last_us) * microsec_to_sec;
@@ -164,11 +164,11 @@ void Battery::consume_energy(float current_amps, uint64_t now_us)
         dt = 0;
     }
     last_us = now_us;
-    float delta_Ah = current_amps * dt / 3600;
+    float delta_Ah = current_amp * dt / 3600;
     remaining_Ah -= delta_Ah;
     remaining_Ah = MAX(0, remaining_Ah);
 
-    float voltage_delta = current_amps * resistance_ohm;
+    float voltage_delta = current_amp * resistance_ohm;
     float voltage;
     if (!is_positive(capacity_Ah)) {
         voltage = voltage_set;
@@ -178,10 +178,10 @@ void Battery::consume_energy(float current_amps, uint64_t now_us)
 
     voltage_filter.apply(voltage, dt);
 
-    update_temperature(current_amps, now_us);
+    update_temperature(current_amp, now_us);
 }
 
-void Battery::update_temperature(float current_amps, uint64_t now_us)
+void Battery::update_temperature(float current_amp, uint64_t now_us)
 {
     const uint64_t temperature_dt = now_us - temperature.last_update_us;
     temperature.last_update_us = now_us;
@@ -189,7 +189,7 @@ void Battery::update_temperature(float current_amps, uint64_t now_us)
     // (reminder: thermal_capacity = mass * specific_heat)
     constexpr float thermal_capacity = 2.8f;  // watt*seconds/degC
     constexpr float inverse_of_thermal_capacity = 1 / thermal_capacity;  // use inverse so we can multiply, not divide
-    const float temp_increase = (current_amps * current_amps) * resistance_ohm * inverse_of_thermal_capacity * (temperature_dt * 0.000001);
+    const float temp_increase = (current_amp * current_amp) * resistance_ohm * inverse_of_thermal_capacity * (temperature_dt * 0.000001);
     // decay temperature at some %second towards ambient
     const float temp_decrease = (temperature.kelvin - 273.15f) * 0.10 * temperature_dt * 0.000001;
     temperature.kelvin += (temp_increase - temp_decrease);

--- a/libraries/SITL/SIM_Battery.h
+++ b/libraries/SITL/SIM_Battery.h
@@ -24,7 +24,7 @@ namespace SITL {
 
 class Battery {
 public:
-    void setup(float _capacity_Ah, float _resistance, float _max_voltage);
+    void setup(float _capacity_Ah, float _resistance_ohm, float _max_voltage);
 
     // Resets the battery state if the configuration (e.g. from SIM_BATT_* parameters) has changed.
     void maybe_reset(float desired_voltage, float desired_capacity_Ah);
@@ -43,7 +43,7 @@ public:
 
 private:
     float capacity_Ah;
-    float resistance;
+    float resistance_ohm;
     float max_voltage;
     float voltage_set;
     float remaining_Ah;

--- a/libraries/SITL/SIM_Battery.h
+++ b/libraries/SITL/SIM_Battery.h
@@ -33,7 +33,7 @@ public:
     void init_capacity(float capacity);
 
     // Call this periodically to "step" the battery forward in time
-    void consume_energy(float current_amps, uint64_t now_us);
+    void consume_energy(float current_amp, uint64_t now_us);
 
     float get_voltage(void) const { return voltage_filter.get(); }
     float get_capacity(void) const { return capacity_Ah; }
@@ -53,7 +53,7 @@ private:
         float kelvin = 273;
         uint64_t last_update_us;
     } temperature;
-    void update_temperature(float current_amps, uint64_t now_us);
+    void update_temperature(float current_amp, uint64_t now_us);
 
     // 10Hz filter for battery voltage
     LowPassFilterFloat voltage_filter{10};

--- a/libraries/SITL/tests/test_battery.cpp
+++ b/libraries/SITL/tests/test_battery.cpp
@@ -82,7 +82,7 @@ protected:
 
 TEST_F(BatteryTest, EnergyConsumption)
 {
-    constexpr float current_amps = 25.0f;
+    constexpr float current_amp = 25.0f;
     constexpr float test_duration_sec = 60.0f;
     constexpr float first_half = test_duration_sec / 2.0f;
     constexpr float dt_sec = 0.01f;
@@ -101,7 +101,7 @@ TEST_F(BatteryTest, EnergyConsumption)
 
             // Consume battery energy (or not)
             if (t > 0.0f && t < first_half) {
-                battery.consume_energy(current_amps, now_us);
+                battery.consume_energy(current_amp, now_us);
             } else {
                 battery.consume_energy(0.0f, now_us);
             }
@@ -193,12 +193,12 @@ TEST_F(BatteryTest, EnergyConsumption)
 
 namespace {
 void use_some_energy(SITL::Battery& battery) {
-    constexpr float current_amps = 25.0f;
+    constexpr float current_amp = 25.0f;
     constexpr float current_duration_sec = 60.0f;
     constexpr float dt_sec = 0.01f;
 
     for (float t = 0.0f; t <= current_duration_sec; t+=dt_sec) {
-        battery.consume_energy(current_amps, initial_us + static_cast<uint64_t>(t * 1e6));
+        battery.consume_energy(current_amp, initial_us + static_cast<uint64_t>(t * 1e6));
     }
 };
 } // namespace

--- a/libraries/SITL/tests/test_battery.cpp
+++ b/libraries/SITL/tests/test_battery.cpp
@@ -15,8 +15,8 @@ constexpr float small_capacity_Ah = 1.0f;
 constexpr float large_capacity_Ah = 8.0f;
 
 // These values are arbitrary, need only be 'low' and 'high' compared to each other.
-constexpr float low_resistance_Ohm = 0.005f;
-constexpr float high_resistance_Ohm = 0.04f;
+constexpr float low_resistance_ohm = 0.005f;
+constexpr float high_resistance_ohm = 0.04f;
 
 // This can be any value, in operation it would come from AP_HAL::micros64().
 constexpr uint64_t initial_us = 0;
@@ -24,22 +24,22 @@ constexpr uint64_t initial_us = 0;
 class BatteryTest : public testing::Test {
 protected:
     BatteryTest() {
-        small_battery.setup(small_capacity_Ah, low_resistance_Ohm, max_voltage);
+        small_battery.setup(small_capacity_Ah, low_resistance_ohm, max_voltage);
         small_battery.init_voltage(max_voltage);
         small_battery.init_capacity(small_capacity_Ah);
-        large_battery.setup(large_capacity_Ah, low_resistance_Ohm, max_voltage);
+        large_battery.setup(large_capacity_Ah, low_resistance_ohm, max_voltage);
         large_battery.init_voltage(max_voltage);
         large_battery.init_capacity(large_capacity_Ah);
         // Recall that capacity==0 means unlimited.
-        infinite_battery.setup(0.0f, low_resistance_Ohm, max_voltage);
+        infinite_battery.setup(0.0f, low_resistance_ohm, max_voltage);
         infinite_battery.init_voltage(max_voltage);
         infinite_battery.init_capacity(0.0f);
 
-        small_high_resistance_battery.setup(small_capacity_Ah, high_resistance_Ohm, max_voltage);
+        small_high_resistance_battery.setup(small_capacity_Ah, high_resistance_ohm, max_voltage);
         small_high_resistance_battery.init_voltage(max_voltage);
         small_high_resistance_battery.init_capacity(small_capacity_Ah);
         // Recall that capacity==0 means unlimited.
-        infinite_high_resistance_battery.setup(0.0f, high_resistance_Ohm, max_voltage);
+        infinite_high_resistance_battery.setup(0.0f, high_resistance_ohm, max_voltage);
         infinite_high_resistance_battery.init_voltage(max_voltage);
         infinite_high_resistance_battery.init_capacity(0.0f);
     }


### PR DESCRIPTION
### Summary

Adds `_ohm` to resistance and changes `_amps` to `_amp` for current. Broken out separately from #32855 per [request](https://github.com/ArduPilot/ardupilot/pull/32855#pullrequestreview-4159296306).

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Does not change behavior.
- [x] Does not change binary.
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

CI proves that this change works.

size_compare_branches result:
```
Board,copter
CubeOrange,*
sitl,*
```

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
