### PR TITLE
.pre-commit: Autofix ruff errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,6 +98,7 @@ repos:
     rev: v0.15.6
     hooks:
     -   id: ruff-check
+        args: [ --fix ]
 
 # # Use to sort python imports by name and put system import first.
 #   -   repo: https://github.com/pycqa/isort


### PR DESCRIPTION


### Summary

* Import errors aren't spelled out by ruff.
We can just fix them automatically, so just let ruff fix it at commit time if you have it enabled.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Autofix ruff errors that can be autofixed.

### Opinions

Pierre -
```
that make no send to auto fix some part and just be blocking for the other on CI ... But on python linting, we are nowadays stable and don't have major version incompatibilities so it should quite safe , double that by the package versionning that we didn't had before
For what it is worth is also support introducing linting/tools that makes development easier, specially for low value tasks such as whitespace and import ordering...
```

Thomas -
```
it's out of the question for anything to add its own commits in CI

i would definitely not want a tool to change my commit in between when i type "git commit" and when the commit gets recorded 
if it's something that i can run and it modifies my tree then fine

```

Ryan - 
We are already letting pre-commit autofix line endings. Black formats some of code already in the main AP repo, and we use similar tools in many other repos in the org. This is a next logical step.
I don't want to manually order my imports when they are wrong.
This doesn't add new commits, it modifies your working tree when you commit, if you have pre-commit enabled.
Like all pre-commit checks, you can ignore it with `--no-verify` if you want, or just uninstall pre-commit to not have it run locally.
Pre-commit modifies your staging tree, not your working tree. We should check if there is reflog support if pre-commit hoses your staging tree to assuage Thomas's concern.

