### PR TITLE
AP_InertialSensor_BMI270: Fix for PWR_CONF register configuration

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_BMI270.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_BMI270.cpp
@@ -542,8 +542,9 @@ bool AP_InertialSensor_BMI270::hardware_init()
         // successfully identified the chip, proceed with initialisation
         read_chip_id = true;
 
-        // disable power save
-        write_register(BMI270_REG_PWR_CONF, 0x00);
+        // disable power save - use _dev->write_register directly to avoid
+        // readback retry loop which interferes with the init sequence
+        _dev->write_register(BMI270_REG_PWR_CONF, 0x00);
         hal.scheduler->delay(1); // needs to be at least 450us
 
         // upload config


### PR DESCRIPTION
### Summary

According to the Bosch BMI270 data sheet there should be a minimum of a 450us pause after writing the PWR_CONF register. The code is currently calling write_register which will write the register and then immediately try to confirm the write with a read back. Testing on my VOXL3 board with BMI270 shows this causes the init sequence to fail. So, I changed it to write the register and then skip the read back, wait for it to take effect, then move on and now it works fine. 

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Test on VOXL3

