### PR TITLE
AP_NavEKF3: zero full rows/cols when treating wind states as truth

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -1099,7 +1099,8 @@ void NavEKF3_core::CovariancePrediction(Vector3F *rotVarVecPtr)
         const bool newTreatWindStatesAsTruth = isDragFusionDeadReckoning || !windStateIsObservable;
         if (newTreatWindStatesAsTruth) {
             treatWindStatesAsTruth = true;
-            P[23][23] = P[22][22] = 0.0f;
+            zeroRows(P,22,23);
+            zeroCols(P,22,23);
         } else {
             if (treatWindStatesAsTruth) {
                 treatWindStatesAsTruth = false;
@@ -1993,7 +1994,8 @@ void NavEKF3_core::ConstrainVariances()
 
     if (!inhibitWindStates) {
         if (treatWindStatesAsTruth) {
-            P[23][23] = P[22][22] = 0.0f;
+            zeroRows(P,22,23);
+            zeroCols(P,22,23);
         } else {
             for (uint8_t i=22; i<=23; i++) P[i][i] = constrain_ftype(P[i][i],0.0f,WIND_VEL_VARIANCE_MAX);
         }


### PR DESCRIPTION
## Summary

When `treatWindStatesAsTruth` is set (GPS lost, wind unobservable), the previous code zeroed only the diagonal:

```cpp
P[23][23] = P[22][22] = 0.0f;
```

This leaves off-diagonal cross-terms nonzero, making P non-positive-definite. The non-PD covariance causes the innovation variance in `FuseAirspeed`/`FuseSideslip` to drop below the observation noise floor, triggering the badly-conditioned branch on every cycle.

Uses `zeroRows`/`zeroCols` to clear full rows and columns for wind states 22-23, consistent with how other inhibited states are handled (e.g. mag states at lines 1070-1081).

Both sites fixed: `CovariancePrediction` (called each prediction step) and `ConstrainVariances` (called after prediction to enforce bounds).

## Observed on hardware

ArduPlane V4.6.3 on MatekH743. After ~1000s of GPS-denied cruise flight, `airspeed_variance` starts oscillating (0.03-7.86), followed by lane switches, DCM fallbacks, and roll snaps (-200 deg/s).

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
