### PR TITLE
AP_Scripting: follow-target-send: guard poscontrol nil on non-Copter/Heli

### DIFF
--- a/libraries/AP_Scripting/applets/follow-target-send.lua
+++ b/libraries/AP_Scripting/applets/follow-target-send.lua
@@ -54,7 +54,7 @@ local function send_follow_target_msg()
     local capabilities = FOLLOW_TARGET_CAPABILITIES.POS
 
     -- get vehicle target velocity in m/s in NED frame
-    local vel_target_NED = poscontrol:get_vel_target()
+    local vel_target_NED = poscontrol and poscontrol:get_vel_target()
     if vel_target_NED ~= nil then
         capabilities = capabilities + FOLLOW_TARGET_CAPABILITIES.VEL
     else
@@ -62,7 +62,7 @@ local function send_follow_target_msg()
     end
 
     -- get vehicle target acceleration in m/s/s in NED frame
-    local accel_target_NED = poscontrol:get_accel_target()
+    local accel_target_NED = poscontrol and poscontrol:get_accel_target()
     if accel_target_NED ~= nil then
         capabilities = capabilities + FOLLOW_TARGET_CAPABILITIES.ACCEL
     else


### PR DESCRIPTION
### Summary

<!-- Put a one or two line summary of what your PR does here -->
fix follow-target-send.lua error raised on none Copter/Heli target

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->
fix error raised on none Copter/Heli target https://github.com/ArduPilot/ardupilot/blob/a2fa7a3a12e41200aae94259c84e7cf1560622b9/libraries/AP_Scripting/generator/description/bindings.desc#L842
```AP: Lua: ./scripts/follow-target-send.lua:57: attempt to index a nil value (global 'poscontrol')```
<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
