### PR TITLE
AP_NavEKF3: resetHeightDatum stricter early return

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -366,8 +366,8 @@ void NavEKF3_core::ResetHeight(void)
 // Return true if the height datum reset has been performed
 bool NavEKF3_core::resetHeightDatum(void)
 {
-    if (activeHgtSource == AP_NavEKF_Source::SourceZ::RANGEFINDER || !onGround) {
-        // only allow resets when on the ground.
+    if (activeHgtSource == AP_NavEKF_Source::SourceZ::RANGEFINDER || !onGround || inFlight) {
+        // only allow resets when on the ground and not flying.
         // If using using rangefinder for height then never perform a
         // reset of the height datum
         return false;


### PR DESCRIPTION
### Summary

Attempts to fix issue #32720 with altitude spikes on termination (or disarm). AP_NavEKF3 lib treats all disarmed states as definetly on-ground. During flight termination, the vehicle can be airborne while disarmed which can trigger a height origin reset, causing an altitude spike.

### Classification & Testing (check all that apply and add your own)

- [ x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ x] Logs available on request

### Description

`NavEKF3_core::detectFlight()` marks `NavEKF3_core::onGround` as true, this allows `NavEKF3_core::resetHeightDatum()` to run which may update `NavEKF3_core::ekfGpsRefHgt` which in turn may update the vehicle's `local_origin` in `NavEKF3_core::getPosD()` causing discontinuity in vertical position.

Function `resetHeightDatum()` returns false immediately if `onGround` is false. During the untermination test, `onGround` is true when the vehicle terminates (even tho we are still airborne), which aligns with the spike from the original issue.

This pr prevents `NavEKF3_core::resetHeightDatum` from executing if vehicle is disarmed while airborne.
Untermination test running on this patch: 
<img width="1200" height="600" alt="solution" src="https://github.com/user-attachments/assets/af2b4f21-c764-4ed8-88c1-a5487c8ca590" />


-----

Some logs that explain the original issue:
```
AT-0001.8: AP: Throttle disarmed
arduplane: posD=-52.596778, onGround=0, inFlight=1, highAirSpd=1, highGndSpd=1, largeHgtChange=1, motorsArmed=1
arduplane: posD=-52.755922, onGround=1, inFlight=0, highAirSpd=1, highGndSpd=1, largeHgtChange=1, motorsArmed=0
...
AT-0001.8: Waiting for disarm (0.00s so far of allowed 30.00)
...
AT-0001.8: DISARMED after 0.00 seconds (allowed=30.00)
AT-0001.8: Waiting for text : terminating due to gcs request
AT-0001.8:   statustext got=(Terminating due to GCS request) want=(Terminating due to GCS request)
AT-0001.8: Found expected text in collection: terminating due to gcs request
...
AT-0001.8: Sending COMMAND_INT to (1,1) (MAV_CMD_DO_FLIGHTTERMINATION=185) (p1=0.000000 p2=0.000000 p3=0.000000 p4=0.000000 p5=0 p6=0  p7=0.000000 f=5)
...
AT-0001.8: ACK received: COMMAND_ACK {command : 185, result : 0, progress : 0, result_param2 : 0, target_system : 250, target_component : 250} (0.000000s)
AT-0001.8: Waiting for DISARM
AT-0001.8: AP: Aborting termination due to GCS request
...
AT-0001.8: Waiting for disarm (0.00s so far of allowed 30.00)
arduplane: posD=-56.713185, onGround=1, inFlight=0, highAirSpd=1, highGndSpd=1, largeHgtChange=1, motorsArmed=0
...
arduplane: posD=-56.213194, onGround=1, inFlight=0, highAirSpd=1, highGndSpd=1, largeHgtChange=1, motorsArmed=0
arduplane: posD=-112.811547, onGround=1, inFlight=0, highAirSpd=1, highGndSpd=1, largeHgtChange=1, motorsArmed=0
arduplane: posD=-108.178366, onGround=1, inFlight=0, highAirSpd=1, highGndSpd=1, largeHgtChange=1, motorsArmed=0
...
```