### PR TITLE
AP_SurfaceDistance: Handle bugs in abrupt reading changes

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -255,8 +255,8 @@ private:
     RC_Channel *rc_tuning2;
 #endif  // AP_RC_TRANSMITTER_TUNING_ENABLED
 
-    AP_SurfaceDistance rangefinder_state {ROTATION_PITCH_270, 0U};
-    AP_SurfaceDistance rangefinder_up_state {ROTATION_PITCH_90, 1U};
+    AP_SurfaceDistance rangefinder_state {ROTATION_PITCH_270, 0U, &g2.surf_dist_parameters};
+    AP_SurfaceDistance rangefinder_up_state {ROTATION_PITCH_90, 1U, &g2.surf_dist_parameters};
 
     // helper function to get inertially interpolated rangefinder height.
     bool get_rangefinder_height_interpolated_m(float& ret) const;

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1169,6 +1169,25 @@ const AP_Param::GroupInfo ParametersG2::var_info2[] = {
     // @Increment: 0.1
     AP_GROUPINFO("PILOT_TKO_ALT_M", 20, ParametersG2, pilot_takeoff_alt_m, PILOT_TKO_ALT_M_DEFAULT),
 
+#if AP_RANGEFINDER_ENABLED
+    // @Param: SURFTRAK_GLDST
+    // @DisplayName: Surface Tracking Glitch threshold
+    // @Description: When a rangefinder reading differs from the previous by more than this, it will be considered a glitch and will not be used. A value of zero disables this check.
+    // @Units: m
+    // @Range: 0 100
+    // @User: Advanced
+    // @RebootRequired: True
+    AP_GROUPINFO("SURFTRAK_GLDST", 21, ParametersG2, surf_dist_parameters.glitch_alt, AP_SURFACEDISTANCE_GLITCH_ALT_M_DEFAULT),
+
+    // @Param: SURFTRAK_GLSAM
+    // @DisplayName: Surface Tracking glitched sample count
+    // @Description: When this many consecutive samples are considered a glitch, we give up and accept the new reading. A value of zero disables this behaviour and glitched values are never accepted.
+    // @Range: 0 10
+    // @User: Advanced
+    // @RebootRequired: True
+    AP_GROUPINFO("SURFTRAK_GLSAM", 22, ParametersG2, surf_dist_parameters.glitch_num_samples, AP_SURFACEDISTANCE_GLITCH_NUM_SAMPLES_DEFAULT),
+#endif
+
     // ID 62 is reserved for the AP_SUBGROUPEXTENSION
 
     AP_GROUPEND

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -5,6 +5,7 @@
 #include <AP_Common/AP_Common.h>
 #include "RC_Channel_Copter.h"
 #include <AP_Proximity/AP_Proximity.h>
+#include <AP_SurfaceDistance/AP_SurfaceDistance.h>
 
 class ModeRTL;
 
@@ -695,6 +696,7 @@ public:
     AP_Int8                 failsafe_dr_enable;
     AP_Int16                failsafe_dr_timeout;
     AP_Float                surftrak_tc;
+    AP_SurfaceDistance::SurfDistParameters surf_dist_parameters;
 
     // ramp time of throttle during take-off
     AP_Float takeoff_throttle_slew_time;

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -74,6 +74,14 @@
  # define RANGEFINDER_FILT_DEFAULT 0.5f     // filter for rangefinder distance
 #endif
 
+#ifndef AP_SURFACEDISTANCE_GLITCH_NUM_SAMPLES_DEFAULT
+ # define AP_SURFACEDISTANCE_GLITCH_NUM_SAMPLES_DEFAULT  3 // number of rangefinder glitches in a row to take new reading
+#endif
+
+#ifndef AP_SURFACEDISTANCE_GLITCH_ALT_M_DEFAULT
+ # define AP_SURFACEDISTANCE_GLITCH_ALT_M_DEFAULT 2.00     // amount of rangefinder change to be considered a glitch
+#endif
+
 #ifndef SURFACE_TRACKING_TIMEOUT_MS
  # define SURFACE_TRACKING_TIMEOUT_MS  1000 // surface tracking target alt will reset to current rangefinder alt after this many milliseconds without a good rangefinder alt
 #endif

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -5288,6 +5288,56 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         if ex is not None:
             raise ex
 
+    def SurfaceTrackingCornerCases(self):
+        """test the AP_SurfaceDistance library behaviour under real-life corner-cases"""
+
+        def restore_offset(steps):
+            """Gradually restore SIM_SONAR_OFFSET back to 0."""
+            initial_value = self.get_parameter("SIM_SONAR_OFFSET")
+            for i in range(steps):
+                self.set_parameter("SIM_SONAR_OFFSET", initial_value*(steps-1-i)/steps)
+
+        self.context_push()
+        self.set_analog_rangefinder_parameters()
+        self.reboot_sitl()
+
+        self.change_mode("LOITER")
+        self.wait_ready_to_arm()
+        self.takeoff(15, takeoff_throttle=1700, mode="LOITER")
+        alt_initial = self.get_altitude()
+        glitch_offset = 1
+        # Test cases of real-life.
+        self.progress("*** Fly over building and come back.")
+        # Assumption: The building is higher than the glitch distance threshold.
+        threshold = 2  # This is the hard-coded threshold.
+        # Fly over the building, clipping the side-wall abruptly, the rangefinder reading reduces.
+        self.set_parameter("SIM_SONAR_OFFSET", -(threshold+glitch_offset))
+        self.delay_sim_time(5) # Wait for the vehicle altitude to stabilize.
+        # This should result in increase of altitude.
+        self.assert_altitude(alt_initial + (threshold + glitch_offset), accuracy=0.5)
+        # Fly off the building. The vertical wall is scanned by the beam, resulting in gradual reading increase.
+        restore_offset(10)
+        self.delay_sim_time(5) # Wait for the vehicle altitude to stabilize.
+        # We should be once again at the original altitude.
+        self.assert_altitude(alt_initial, accuracy=0.5)
+
+        self.progress("*** Fly with interference from an underslung tether.")
+        threshold = self.get_parameter("SURFDSTD_GLDST")
+        # The tether moves in the FOV of the sensor.
+        self.set_parameter("SIM_SONAR_OFFSET", -(threshold+glitch_offset))
+        self.delay_sim_time(5) # Wait for the vehicle altitude to stabilize.
+        # The vehicle should reject the reading and keep still.
+        self.assert_altitude(alt_initial, accuracy=0.5)
+        # The tether moves out of the FOV of the sensor.
+        self.set_parameter("SIM_SONAR_OFFSET", 0)
+        self.delay_sim_time(5) # Wait for the vehicle altitude to stabilize.
+        # We should still be at the same altitude.
+        self.assert_altitude(alt_initial, accuracy=0.5)
+
+        self.do_RTL()
+        self.reboot_sitl()
+        self.context_pop()
+
     def test_rangefinder_switchover(self):
         """test that the EKF correctly handles the switchover between baro and rangefinder"""
         self.set_analog_rangefinder_parameters()
@@ -13616,6 +13666,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.RangeFinder,
              self.BaroDrivers,
              self.SurfaceTracking,
+             self.SurfaceTrackingCornerCases,
              self.Parachute,
              self.ParameterChecks,
              self.ManualThrottleModeChange,

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -5288,6 +5288,79 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         if ex is not None:
             raise ex
 
+    def SurfaceTracking2(self):
+        """test the AP_SurfaceDistance library parameters"""
+
+        def restore_offset(steps):
+            """Gradually restore SIM_SONAR_OFFSET back to 0."""
+            initial_value = self.get_parameter("SIM_SONAR_OFFSET")
+            for i in range(steps):
+                self.set_parameter("SIM_SONAR_OFFSET", initial_value*(steps-1-i)/steps)
+
+        self.set_analog_rangefinder_parameters()
+        self.reboot_sitl()
+
+        self.change_mode("LOITER")
+        self.wait_ready_to_arm()
+        self.takeoff(15, takeoff_throttle=1700, mode="LOITER")
+        alt_initial = self.get_altitude()
+        glitch_offset = 1
+
+        self.start_subtest("Testing normal glitch procedure.")
+        threshold = self.get_parameter("SURFTRAK_GLDST")
+        # Glitch it below the threshold, observe that the reading is not rejected and there is no reset.
+        self.set_parameter("SIM_SONAR_OFFSET", -(threshold-glitch_offset))
+        self.delay_sim_time(5) # Wait for the vehicle altitude to stabilize.
+        self.assert_altitude(alt_initial + (threshold - glitch_offset), accuracy=0.5)
+        restore_offset(10)
+        self.delay_sim_time(5) # Wait for the vehicle altitude to stabilize.
+        self.assert_altitude(alt_initial, accuracy=0.5)
+
+        # Glitch it over the threshold, observe there is reset.
+        self.set_parameter("SIM_SONAR_OFFSET", -(threshold+glitch_offset))
+        self.delay_sim_time(5) # Wait for the vehicle altitude to stabilize.
+        # Vehicle doesn't change altitude, because the rangefinder offset has been reset.
+        self.assert_altitude(alt_initial, accuracy=0.5)
+        restore_offset(10)
+        self.delay_sim_time(5) # Wait for the vehicle altitude to stabilize.
+        self.assert_altitude(alt_initial - (threshold + glitch_offset), accuracy=0.5)
+
+        self.start_subtest("Testing that the glitch threshold can be extended.")
+        alt_initial = self.get_altitude()
+        # Increase the threshold.
+        # The threshold is extended by glitch_offset+1, which means that if the parameter doesn't work,
+        # both cases below would trigger a reset.
+        self.set_parameter("SURFTRAK_GLDST", threshold+glitch_offset+1)
+        threshold = self.get_parameter("SURFTRAK_GLDST")
+        # Glitch it below the threshold, observe that the reading is not rejected and there is no reset.
+        self.set_parameter("SIM_SONAR_OFFSET", -(threshold-glitch_offset))
+        self.delay_sim_time(5) # Wait for the vehicle altitude to stabilize.
+        self.assert_altitude(alt_initial + (threshold - glitch_offset), accuracy=0.5)
+        restore_offset(10)
+        self.delay_sim_time(5) # Wait for the vehicle to stabilize again.
+        self.assert_altitude(alt_initial, accuracy=0.5)
+
+        # Glitch it over the threshold, observe there is reset.
+        self.set_parameter("SIM_SONAR_OFFSET", -(threshold+glitch_offset))
+        self.delay_sim_time(5) # Wait for the vehicle altitude to stabilize.
+        self.assert_altitude(alt_initial, accuracy=0.5)
+        restore_offset(10)
+        self.delay_sim_time(5) # Wait for the vehicle to stabilize again.
+        self.assert_altitude(alt_initial - (threshold + glitch_offset), accuracy=0.5)
+
+        self.start_subtest("Testing that the glitch reset can be disabled.")
+        alt_initial = self.get_altitude()
+        self.set_parameter("SURFTRAK_GLSAM", 0)  # Disable resetting.
+        # Glitch it above the threshold, observe that the reading is rejected and there is no reset.
+        self.set_parameter("SIM_SONAR_OFFSET", -(threshold+glitch_offset))
+        self.delay_sim_time(5) # Wait for the vehicle altitude to stabilize.
+        self.assert_altitude(alt_initial, accuracy=0.5)  # The aircraft should reject the measurements and not climb.
+        restore_offset(10)
+        self.delay_sim_time(5) # Wait for the vehicle to stabilize again.
+        self.assert_altitude(alt_initial, accuracy=0.5)  # The aircraft should have maintained the same altitude reference.
+
+        self.do_RTL()
+
     def SurfaceTrackingCornerCases(self):
         """test the AP_SurfaceDistance library behaviour under real-life corner-cases"""
 
@@ -5297,7 +5370,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             for i in range(steps):
                 self.set_parameter("SIM_SONAR_OFFSET", initial_value*(steps-1-i)/steps)
 
-        self.context_push()
         self.set_analog_rangefinder_parameters()
         self.reboot_sitl()
 
@@ -5307,36 +5379,34 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         alt_initial = self.get_altitude()
         glitch_offset = 1
         # Test cases of real-life.
-        self.progress("*** Fly over building and come back.")
-        # Assumption: The building is higher than the glitch distance threshold.
-        threshold = 2  # This is the hard-coded threshold.
+        self.start_subtest("Fly over building and come back.")
+        # This is the same as the first test, but made explicit for the real-life use-case.
+        # Assumption: The building is lower than the glitch distance threshold.
+        threshold = self.get_parameter("SURFTRAK_GLDST")
         # Fly over the building, clipping the side-wall abruptly, the rangefinder reading reduces.
-        self.set_parameter("SIM_SONAR_OFFSET", -(threshold+glitch_offset))
-        self.delay_sim_time(5) # Wait for the vehicle altitude to stabilize.
+        self.set_parameter("SIM_SONAR_OFFSET", -(threshold-glitch_offset))
         # This should result in increase of altitude.
-        self.assert_altitude(alt_initial + (threshold + glitch_offset), accuracy=0.5)
+        target = alt_initial + (threshold - glitch_offset)
+        self.wait_altitude(target-0.5, target+0.5, minimum_duration=5, timeout=20)
         # Fly off the building. The vertical wall is scanned by the beam, resulting in gradual reading increase.
         restore_offset(10)
-        self.delay_sim_time(5) # Wait for the vehicle altitude to stabilize.
         # We should be once again at the original altitude.
-        self.assert_altitude(alt_initial, accuracy=0.5)
+        self.wait_altitude(alt_initial-0.5, alt_initial+0.5, minimum_duration=5, timeout=20)
 
-        self.progress("*** Fly with interference from an underslung tether.")
-        threshold = self.get_parameter("SURFDSTD_GLDST")
+        self.start_subtest("Fly with interference from an underslung tether.")
+        threshold = self.get_parameter("SURFTRAK_GLDST")
+        # Disable reference resets, we expect a lot of false glitches, due to cable interference.
+        self.set_parameter("SURFTRAK_GLSAM", 0)
         # The tether moves in the FOV of the sensor.
         self.set_parameter("SIM_SONAR_OFFSET", -(threshold+glitch_offset))
-        self.delay_sim_time(5) # Wait for the vehicle altitude to stabilize.
         # The vehicle should reject the reading and keep still.
-        self.assert_altitude(alt_initial, accuracy=0.5)
+        self.wait_altitude(alt_initial-0.5, alt_initial+0.5, minimum_duration=5, timeout=20)
         # The tether moves out of the FOV of the sensor.
         self.set_parameter("SIM_SONAR_OFFSET", 0)
-        self.delay_sim_time(5) # Wait for the vehicle altitude to stabilize.
         # We should still be at the same altitude.
-        self.assert_altitude(alt_initial, accuracy=0.5)
+        self.wait_altitude(alt_initial-0.5, alt_initial+0.5, minimum_duration=5, timeout=20)
 
         self.do_RTL()
-        self.reboot_sitl()
-        self.context_pop()
 
     def test_rangefinder_switchover(self):
         """test that the EKF correctly handles the switchover between baro and rangefinder"""
@@ -13666,6 +13736,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.RangeFinder,
              self.BaroDrivers,
              self.SurfaceTracking,
+             self.SurfaceTracking2,
              self.SurfaceTrackingCornerCases,
              self.Parachute,
              self.ParameterChecks,

--- a/libraries/AP_SurfaceDistance/AP_SurfaceDistance.cpp
+++ b/libraries/AP_SurfaceDistance/AP_SurfaceDistance.cpp
@@ -15,17 +15,10 @@
  # define RANGEFINDER_TILT_CORRECTION 1
 #endif
 
-#ifndef RANGEFINDER_GLITCH_NUM_SAMPLES
- # define RANGEFINDER_GLITCH_NUM_SAMPLES  3 // number of rangefinder glitches in a row to take new reading
-#endif
-
-#ifndef RANGEFINDER_GLITCH_ALT_CM
- # define RANGEFINDER_GLITCH_ALT_M 2.00     // amount of rangefinder change to be considered a glitch
-#endif
-
 #ifndef RANGEFINDER_HEALTH_MIN
  # define RANGEFINDER_HEALTH_MIN 3          // number of good reads that indicates a healthy rangefinder
 #endif
+
 
 void AP_SurfaceDistance::update()
 {
@@ -71,23 +64,23 @@ void AP_SurfaceDistance::update()
     // tilt corrected but unfiltered, not glitch protected alt
     alt_m = tilt_correction * rangefinder->distance_orient(rotation);
 
-    // Glitch Handling. Rangefinder readings more than RANGEFINDER_GLITCH_ALT_M from the last good reading
+    // Glitch Handling. Rangefinder readings more than glitch_alt_m from the last good reading
     // are considered a glitch and glitch_count becomes non-zero
     // glitches clear after RANGEFINDER_GLITCH_NUM_SAMPLES samples in a row.
     // glitch_cleared_ms is set so surface tracking (or other consumers) can trigger a target reset
     const float glitch_m = alt_m - alt_glitch_protected_m;
     bool reset_terrain = false;
-    if (glitch_m >= RANGEFINDER_GLITCH_ALT_M) {
+    if ((glitch_m >= parameters->glitch_alt) && (parameters->glitch_alt > 0)) {
         glitch_count = MAX(glitch_count+1, 1);
         status |= (uint8_t)Surface_Distance_Status::Glitch_Detected;
-    } else if (glitch_m <= -RANGEFINDER_GLITCH_ALT_M) {
+    } else if ((glitch_m <= -parameters->glitch_alt) && (parameters->glitch_alt > 0)) {
         glitch_count = MIN(glitch_count-1, -1);
         status |= (uint8_t)Surface_Distance_Status::Glitch_Detected;
     } else {
         glitch_count = 0;
         alt_glitch_protected_m = alt_m;
     }
-    if (abs(glitch_count) >= RANGEFINDER_GLITCH_NUM_SAMPLES) {
+    if ((abs(glitch_count) >= parameters->glitch_num_samples) && (parameters->glitch_num_samples > 0)) {
         // clear glitch and record time so consumers (i.e. surface tracking) can reset their target altitudes
         glitch_count = 0;
         alt_glitch_protected_m = alt_m;

--- a/libraries/AP_SurfaceDistance/AP_SurfaceDistance.h
+++ b/libraries/AP_SurfaceDistance/AP_SurfaceDistance.h
@@ -4,11 +4,20 @@
 #include <Filter/LowPassFilter.h>
 #include <AP_HAL/Semaphores.h>
 
+
 class AP_SurfaceDistance {
+private:
 public:
-    AP_SurfaceDistance(Rotation rot, uint8_t i) :
-        instance(i),
-        rotation(rot)
+    struct SurfDistParameters {
+        AP_Float                glitch_alt; // Glitch detection threshold, in meters.
+        AP_Int8                 glitch_num_samples; // Number of consecutive glitches before the value is deemed correct.
+    };
+    SurfDistParameters *parameters;
+
+    AP_SurfaceDistance(Rotation rot, uint8_t i, SurfDistParameters *surf_dist_params) :
+            parameters(surf_dist_params),
+            rotation(rot),
+            instance(i)
     {};
 
     void update();
@@ -32,6 +41,9 @@ public:
     uint32_t glitch_cleared_ms;             // system time glitch cleared
     float terrain_u_m;                      // filtered terrain offset (e.g. terrain's height above EKF origin)
 
+    // accessor functions for the params
+    static const struct AP_Param::GroupInfo var_info[];
+
 private:
 #if HAL_LOGGING_ENABLED
     void Log_Write(void) const;
@@ -40,9 +52,8 @@ private:
     // multi-thread access support
     HAL_Semaphore sem;
 
+    const Rotation rotation;
     const uint8_t instance;
     uint8_t status;
     uint32_t last_healthy_ms;
-
-    const Rotation rotation;
 };

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -586,6 +586,8 @@ float Aircraft::rangefinder_range() const
         altitude -= relPosSensorEF.z;
     }
 
+    altitude += sitl->sonar_offset;
+
     const auto orientation = (Rotation)sitl->sonar_rot.get();
 #if SITL_RANGEFINDER_AS_OBJECT_SENSOR
 

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -111,10 +111,7 @@ const AP_Param::GroupInfo SIM::var_info[] = {
     // @Path: ./ServoModel.cpp
     AP_SUBGROUPINFO(servo, "SERVO_", 16, SIM, ServoParams),
 
-    // @Param: SONAR_ROT
-    // @DisplayName: Sonar rotation
-    // @Description: Sonar rotation from rotations enumeration
-    AP_GROUPINFO("SONAR_ROT",     17, SIM,  sonar_rot, Rotation::ROTATION_PITCH_270),
+    AP_SUBGROUPEXTENSION("",      17, SIM,  var_sonar),
     // @Param: BATT_VOLTAGE
     // @DisplayName: Simulated battery resting voltage
     // @Description: Simulated battery resting voltage (no load sag). Defaults to and clipped to the battery model's maximum voltage. Changes re-initialize the state of charge, and values below the maximum indicate a partially-charged battery. For batteries with unlimited capacity, see `SIM_BATT_CAP_AH`. Value ignored when receiving battery state updates from an external source.
@@ -127,17 +124,8 @@ const AP_Param::GroupInfo SIM::var_info[] = {
     // @Units: Ah
     // @User: Advanced
     AP_GROUPINFO("BATT_CAP_AH",   20, SIM,  batt_capacity_ah,  0),
-    // @Param: SONAR_GLITCH
-    // @DisplayName: Sonar glitch probablility
-    // @Description: Probablility a sonar glitch would happen
-    // @Range: 0 1
-    // @User: Advanced
-    AP_GROUPINFO("SONAR_GLITCH",  23, SIM,  sonar_glitch, 0),
-    // @Param: SONAR_RND
-    // @DisplayName: Sonar noise factor
-    // @Description: Scaling factor for simulated sonar noise
-    // @User: Advanced
-    AP_GROUPINFO("SONAR_RND",     24, SIM,  sonar_noise, 0),
+    // 23 was SONAR_GLITCH
+    // 24 was SONAR_RND
     // @Param: RC_FAIL
     // @DisplayName: Simulated RC signal failure
     // @Description: Allows you to emulate rc failures in sim
@@ -175,11 +163,7 @@ const AP_Param::GroupInfo SIM::var_info[] = {
     AP_GROUPINFO("CAN_TYPE2", 31, SIM,  can_transport[1], uint8_t(CANTransport::MulticastUDP)),
 #endif
 
-    // @Param: SONAR_SCALE
-    // @DisplayName: Sonar conversion scale
-    // @Description: Sonar conversion scale from distance to voltage
-    // @Units: m/V
-    AP_GROUPINFO("SONAR_SCALE",   32, SIM,  sonar_scale, 12.1212f),
+    // 32 was SONAR_SCALE
     // @Param: FLOW_ENABLE
     // @DisplayName: Opflow Enable
     // @Description: Enable simulated Optical Flow sensor
@@ -236,12 +220,7 @@ const AP_Param::GroupInfo SIM::var_info[] = {
     // @Vector3Parameter: 1
     AP_GROUPINFO("IMU_POS",       53, SIM,  imu_pos_offset, 0),
     AP_SUBGROUPEXTENSION("",      54, SIM,  var_ins),
-    // @Param: SONAR_POS
-    // @DisplayName: Sonar Offsets
-    // @Description: XYZ position of the sonar relative to the body frame origin
-    // @Units: m
-    // @Vector3Parameter: 1
-    AP_GROUPINFO("SONAR_POS",     55, SIM,  rngfnd_pos_offset, 0),
+    // 55 was SONAR_POS
     // @Param: FLOW_POS
     // @DisplayName: Opflow Pos
     // @Description: XYZ position of the optical flow sensor focal point relative to the body frame origin
@@ -658,6 +637,8 @@ const AP_Param::GroupInfo SIM::var_info3[] = {
 #ifdef SFML_JOYSTICK
     AP_SUBGROUPEXTENSION("",      63, SIM,  var_sfml_joystick),
 #endif // SFML_JOYSTICK
+    //
+    // 57 was SONAR_OFFSET
 
     AP_GROUPEND
 };
@@ -1515,6 +1496,41 @@ const AP_Param::GroupInfo SIM::var_ins[] = {
     AP_SUBGROUPINFO(imu_tcal[4], "IMUT5_", 59, SIM, AP_InertialSensor_TCal),
 #endif
 #endif  // HAL_INS_TEMPERATURE_CAL_ENABLE
+    AP_GROUPEND
+};
+
+const AP_Param::GroupInfo SIM::var_sonar[] = {
+    // @Param: SONAR_ROT
+    // @DisplayName: Sonar rotation
+    // @Description: Sonar rotation from rotations enumeration
+    AP_GROUPINFO("SONAR_ROT",     17, SIM,  sonar_rot, Rotation::ROTATION_PITCH_270),
+    // @Param: SONAR_GLITCH
+    // @DisplayName: Sonar glitch probablility
+    // @Description: Probablility a sonar glitch would happen
+    // @Range: 0 1
+    // @User: Advanced
+    AP_GROUPINFO("SONAR_GLITCH",  23, SIM,  sonar_glitch, 0),
+    // @Param: SONAR_RND
+    // @DisplayName: Sonar noise factor
+    // @Description: Scaling factor for simulated sonar noise
+    // @User: Advanced
+    AP_GROUPINFO("SONAR_RND",     24, SIM,  sonar_noise, 0),
+    // @Param: SONAR_SCALE
+    // @DisplayName: Sonar conversion scale
+    // @Description: Sonar conversion scale from distance to voltage
+    // @Units: m/V
+    AP_GROUPINFO("SONAR_SCALE",   32, SIM,  sonar_scale, 12.1212f),
+    // @Param: SONAR_POS
+    // @DisplayName: Sonar Offsets
+    // @Description: XYZ position of the sonar relative to the body frame origin
+    // @Units: m
+    // @Vector3Parameter: 1
+    AP_GROUPINFO("SONAR_POS",     55, SIM,  rngfnd_pos_offset, 0),
+    // @Param: SONAR_OFFSET
+    // @DisplayName: Sonar measurement offset.
+    // @Description: Sonar measurement offset, in meters. Can be used for error injection.
+    // @User: Advanced
+    AP_GROUPINFO("SONAR_OFFSET",     57, SIM,  sonar_offset, 0),
     AP_GROUPEND
 };
 

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -140,6 +140,7 @@ public:
 #endif
         AP_Param::setup_object_defaults(this, var_mag);
         AP_Param::setup_object_defaults(this, var_ins);
+        AP_Param::setup_object_defaults(this, var_sonar);
 #ifdef SFML_JOYSTICK
         AP_Param::setup_object_defaults(this, var_sfml_joystick);
 #endif // SFML_JOYSTICK
@@ -188,6 +189,7 @@ public:
 #endif
     static const struct AP_Param::GroupInfo var_mag[];
     static const struct AP_Param::GroupInfo var_ins[];
+    static const struct AP_Param::GroupInfo var_sonar[];
 #ifdef SFML_JOYSTICK
     static const struct AP_Param::GroupInfo var_sfml_joystick[];
 #endif //SFML_JOYSTICK
@@ -209,6 +211,7 @@ public:
     AP_Float sonar_noise; // in metres
     AP_Float sonar_scale; // meters per volt
     AP_Int8 sonar_rot;  // from rotations enumeration
+    AP_Float sonar_offset; // offset measurement, in meters. Can be used for error injection.
 
     AP_Float drift_speed; // degrees/second/minute
     AP_Float drift_time;  // period in minutes


### PR DESCRIPTION
### Summary

This PR fixes the buggy behaviour of AP_SurfaceDistance (Surface Tracking) when flying with tethers and over vertical walls.
It introduces `SURFDSTD/U_` parameters to do so.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [X] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [X] Logs available on request

There are new autotests available. You can run them to observe the behaviour change before/after the fix.

### Description

#### Problem description

The surface tracking behaviour would be buggy in the following corner cases:

1. You fly over a building that is >2m high. The rangefinder readings usually do a step-change that is detected as a glitch. As a result the surface offset is reset and the vehicle does not climb to match the height of the building.
You then fly off the building, the rangefinder beam scanning its vertical wall. There is no step change and no glitch is detected. as a result, the vehicle descends even more and it's not in the initial altitude anymore.

Note: the 2m threshold is currently hardcoded. The glitch will cause a reset after 3 consecutive samples that exceed the threshold.

2. You fly with a tethered vehicle. Depending on how the tether flops around, abruptly getting into the FOV of the rangefinder and causing step changes in the measurements, it might:
- Cause the vehicle to temporarily ascend or descend, if the step change is below the 2m step threshold.
- Cause the vehicle to permanently ascend or descend, if the step change is above the 2m step threshold, through the same mechanism explained above.

I have had personal reports of both of these incidents from clients and partners.

You can see how these bugs play out in the 2nd commit, where autotests have been introduced.

#### Fix

The proposed solution is to add a glitch threshold parameter `GLDST` and a number of samples to trigger a reset parameter `GLSAM`. Setting either to 0 disables the respective feature.
Each is hosted in duplicate in the groups `SURFDSTU_` and `SURFDSTD_` groups, for the up-facing and down-facing rangefinder.

To address the building use-case, you increase `GLDST` to be higher than the highest building you plan to fly over, so that the step change will not be considered a glitch.

To address the tether use-case, you disable the `GLSAM` parameter, so that it never allows the reference altitude reset. It will ignore measurement step changes, but will not reset altitude because of them.

#### Testing

I have created an initial autotest that highlights the problem and intentionally fails. Then it is amended with the new parameters and passes.

#### Unknowns

I notice that not just `SURF[0].D` freezes and not updates when glitching, but also `RFND.Dist` (Arrow 2). I wasn't expecting that and I don't know why this happens.

Also, `XKF5.HAGL` seems to temporarily go bad and then recover (example in arrow 1). I don't know if this is expected or not, nor if this has other bad consequences.

<img width="689" height="305" alt="image" src="https://github.com/user-attachments/assets/6413e1f0-c2bc-49c6-a733-275f607706ff" />

---

I wanted to have shared parameters for both the up and down rangefinder, but I couldn't figure out how to do it without assigning them on top-level Copter and then passing their reference inside the `AP_SurfaceDistance` library, which seems wasteful.
