### PR TITLE
AP_InertialSensor: modify axis of ASM330LHH

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_ASM330.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_ASM330.cpp
@@ -364,7 +364,7 @@ void AP_InertialSensor_ASM330::poll_data()
  */
 void AP_InertialSensor_ASM330::update_transaction_g(struct sensor_raw_data raw_data)
 {
-    Vector3f gyro_data(raw_data.x, -raw_data.y, -raw_data.z);
+    Vector3f gyro_data(raw_data.x, raw_data.y, raw_data.z);
     gyro_data *= gyro_scale;
 
     _rotate_and_correct_gyro(gyro_instance, gyro_data);
@@ -373,7 +373,7 @@ void AP_InertialSensor_ASM330::update_transaction_g(struct sensor_raw_data raw_d
 
 void AP_InertialSensor_ASM330::update_transaction_x(struct sensor_raw_data raw_data)
 {
-    Vector3f accel_data(raw_data.x, -raw_data.y, -raw_data.z);
+    Vector3f accel_data(raw_data.x, raw_data.y, raw_data.z);
     accel_data *= accel_scale;
 
     _rotate_and_correct_accel(accel_instance, accel_data);


### PR DESCRIPTION
### Summary
Modified  the issue that the Y and Z axes of the ASM330LHH were reversed.

### Classification & Testing (check all that apply and add your own)
- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

### Description
We modified  the issue that the Y and Z axes of the ASM330LHH were reversed.
This PR of ASM330LHH sensor was recently by our. It is unlikely to affect anyone other than us.