### PR TITLE
workflows: labels.yml: add automatic vehicle tagging

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -78,6 +78,23 @@ jobs:
               Submarine: 'Sub',
             };
 
+            const generic_suffix_labels = {
+              '.lua': 'Scripting',
+              '.py': 'Python',
+            };
+
+            const generic_prefix_labels = {
+              'libraries/AP_ExternalAHRS': 'ExternalAHRS',
+              'libraries/AP_Compass': 'Compass',
+              'libraries/AP_NavEKF': 'EKF',
+              'libraries/AP_HAL_Linux': 'Linux',
+              'libraries/GCS_MAVLink': 'MAVLink',
+              'libraries/SITL': 'SITL',
+              'Tools/AP_Periph': 'AP_Periph',
+              'Tools/autotest': 'CI',
+              '.github/workflows': 'github_actions',
+            };
+
             const specific_vehicle_checks = {
               'VTOL-Plane': ['ArduPlane/quadplane'],
               'TradHeli': [
@@ -92,8 +109,18 @@ jobs:
             const labels = new Set();
             for (const filename of filenames) {
               // Generic checks
-              if (filename.endsWith('.lua')) labels.add('Scripting');
-              else if (filename.endsWith('.py')) labels.add('Python');
+              for (const [suffix, label] of Object.entries(generic_suffix_labels)) {
+                if (filename.endsWith(suffix)) {
+                  labels.add(label);
+                  break;
+                }
+              }
+              for (const [prefix, label] of Object.entries(generic_prefix_labels)) {
+                if (filename.startsWith(prefix)) {
+                  labels.add(label);
+                  break;
+                }
+              }
 
               // Specific/niche vehicle checks
               var specific = false;  // There can only be one specific label per file.

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -59,10 +59,82 @@ jobs:
             })).map(file => file.filename);
             console.log(filenames);
 
+            const vehicle_labels = {
+              AntennaTracker: 'AntennaTracker',
+              ArduCopter: 'Copter',
+              ArduPlane: 'Plane',
+              ArduSub: 'Sub',
+              Blimp: 'Blimp',
+              Rover: 'Rover',
+            };
+
+            const vehicle_sim_labels = {
+              Helicopter: 'TradHeli',
+              QuadPlane: 'VTOL-Plane',
+              Sailboat: 'Sailboat',
+              Blimp: 'Blimp',
+              Plane: 'Plane',
+              Rover: 'Rover',
+              Submarine: 'Sub',
+            };
+
+            const specific_vehicle_checks = {
+              'VTOL-Plane': ['ArduPlane/quadplane'],
+              'TradHeli': [
+                'ArduCopter/heli.cpp',
+                'Tools/autotest/default_params/copter-heli',
+                'libraries/AP_Motors/AP_MotorsHeli',
+              ],
+              'Sailboat': ['Rover/sailboat'],
+              'Sub': ['libraries/AP_Motors/AP_Motors6DOF'],
+            };
+
             const labels = new Set();
             for (const filename of filenames) {
+              // Generic checks
               if (filename.endsWith('.lua')) labels.add('Scripting');
               else if (filename.endsWith('.py')) labels.add('Python');
+
+              // Specific/niche vehicle checks
+              var specific = false;  // There can only be one specific label per file.
+              for (const [vehicle, prefixes] of Object.entries(specific_vehicle_checks)) {
+                for (const prefix of prefixes) {
+                  if (filename.startsWith(prefix)) {
+                    labels.add(vehicle);
+                    specific = true;
+                    break;
+                  }
+                }
+                if (specific) break;
+              }
+
+              if (specific) continue;
+              
+              for (const [vehicle, label] of Object.entries(vehicle_sim_labels)) {
+                if (
+                  filename === `Tools/autotest/${vehicle.toLowerCase()}.py` ||
+                  filename.startsWith(`Tools/autotest/default_params/${vehicle.toLowerCase()}`) ||
+                  filename.startsWith(`libraries/SITL/SIM_${vehicle}`)
+                ) {
+                  labels.add(label);
+                  specific = true;
+                  break;
+                }
+              }
+
+              if (specific) continue;
+
+              // General vehicle checks
+              for (const [vehicle, label] of Object.entries(vehicle_labels)) {
+                if (
+                  filename.startsWith(vehicle) ||
+                  filename.startsWith(`Tools/autotest/${vehicle}_Test`) ||
+                  filename === `Tools/autotest/${vehicle.toLowerCase()}.py`
+                ) {
+                  labels.add(label);
+                  break;
+                }
+              }
             }
             console.log(labels);
 

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,4 +1,4 @@
-name: ci
+name: Apply PR Labels
 
 # workflow_run is used intentionally here: the elevated-permission step runs
 # in the base-repo context but never checks out PR code, so it is safe.


### PR DESCRIPTION
### Summary

Automatically adds vehicle tags when relevant files have been changed.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->
There are likely some files I've missed for the niche/specific checks, but this is at least a start to automatically applying relevant vehicle labels when a PR changes corresponding code files.

Checks for core vehicle code changes, as well as SITL and autotest changes.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
