### PR TITLE
AP_HAL_ESP32: Use latest i2c api for esp32

### DIFF
--- a/libraries/AP_HAL_ESP32/I2CDevice.cpp
+++ b/libraries/AP_HAL_ESP32/I2CDevice.cpp
@@ -39,21 +39,15 @@ I2CDeviceManager::I2CDeviceManager(void)
             businfo[i].soft = true;
             i2c_init(&(businfo[i].sw_handle));
         } else {
-            i2c_config_t i2c_bus_config;
-            i2c_bus_config.mode = I2C_MODE_MASTER;
-            i2c_bus_config.sda_io_num = i2c_bus_desc[i].sda;
-            i2c_bus_config.scl_io_num = i2c_bus_desc[i].scl;
-            i2c_bus_config.sda_pullup_en = GPIO_PULLUP_ENABLE;
-            i2c_bus_config.scl_pullup_en = GPIO_PULLUP_ENABLE;
-            i2c_bus_config.master.clk_speed = i2c_bus_desc[i].speed;
-            i2c_bus_config.clk_flags = 0;
-            i2c_port_t p = i2c_bus_desc[i].port;
-            businfo[i].port = p;
-            businfo[i].bus_clock = i2c_bus_desc[i].speed;
-            businfo[i].soft = false;
-            i2c_param_config(p, &i2c_bus_config);
-            i2c_driver_install(p, I2C_MODE_MASTER, 0, 0, ESP_INTR_FLAG_IRAM);
-            i2c_filter_enable(p, 7);
+            i2c_master_bus_config_t bus_cfg = {
+                .i2c_port = i2c_bus_desc[i].port,
+                .sda_io_num = (gpio_num_t)i2c_bus_desc[i].sda,
+                .scl_io_num = (gpio_num_t)i2c_bus_desc[i].scl,
+                .clk_source = I2C_CLK_SRC_DEFAULT,
+                .glitch_ignore_cnt = 7,
+                .flags = { .enable_internal_pullup = true }
+            };
+            ESP_ERROR_CHECK(i2c_new_master_bus(&bus_cfg, &businfo[i].bus_handle));
         }
     }
 }
@@ -66,12 +60,26 @@ I2CDevice::I2CDevice(uint8_t busnum, uint8_t address, uint32_t bus_clock, bool u
 {
     set_device_bus(busnum);
     set_device_address(address);
+    if (!bus.soft) {
+        i2c_device_config_t dev_cfg = {
+            .dev_addr_length = I2C_ADDR_BIT_LEN_7,
+            .device_address = address,
+            .scl_speed_hz = bus_clock,
+        };
+        esp_err_t err = i2c_master_bus_add_device(bus.bus_handle, &dev_cfg, &_dev_handle);
+        if (err != ESP_OK) {
+            _dev_handle = nullptr;
+        }
+    }
     asprintf(&pname, "I2C:%u:%02x",
              (unsigned)busnum, (unsigned)address);
 }
 
 I2CDevice::~I2CDevice()
 {
+    if (_dev_handle != nullptr) {
+        i2c_master_bus_rm_device(_dev_handle);
+    }
     free(pname);
 }
 
@@ -103,35 +111,16 @@ bool I2CDevice::transfer(const uint8_t *send, uint32_t send_len,
         }
         result = true; //TODO check all
     } else {
-        i2c_cmd_handle_t cmd = i2c_cmd_link_create();
-        if (send_len != 0 && send != nullptr) {
-            //tx with optional rx (after tx)
-            i2c_master_start(cmd);
-            i2c_master_write_byte(cmd, (_address << 1) | I2C_MASTER_WRITE, true);
-            i2c_master_write(cmd, (uint8_t*)send, send_len, true);
+        esp_err_t err;
+        if (send_len > 0 && recv_len > 0) {
+            err = i2c_master_transmit_receive(_dev_handle, send, send_len, recv, recv_len, pdMS_TO_TICKS(_timeout_ms));
+        } else if (send_len > 0) {
+            err = i2c_master_transmit(_dev_handle, send, send_len, pdMS_TO_TICKS(_timeout_ms));
+        } else {
+            err = i2c_master_receive(_dev_handle, recv, recv_len, pdMS_TO_TICKS(_timeout_ms));
         }
-        if (recv_len != 0 && recv != nullptr) {
-            //rx only or rx after tx
-            //rx separated from tx by (re)start
-            i2c_master_start(cmd);
-            i2c_master_write_byte(cmd, (_address << 1) | I2C_MASTER_READ, true);
-            i2c_master_read(cmd, (uint8_t *)recv, recv_len, I2C_MASTER_LAST_NACK);
-        }
-        i2c_master_stop(cmd);
-
-        uint32_t timeout_ms = 1 + 16L * (send_len + recv_len) * 1000 / bus.bus_clock;
-        timeout_ms = MAX(timeout_ms, _timeout_ms);
-        for (int i = 0; !result && i < _retries; i++) {
-            result = (i2c_master_cmd_begin(bus.port, cmd, pdMS_TO_TICKS(timeout_ms)) == ESP_OK);
-            if (!result) {
-                i2c_reset_tx_fifo(bus.port);
-                i2c_reset_rx_fifo(bus.port);
-            }
-        }
-
-        i2c_cmd_link_delete(cmd);
+        return (err == ESP_OK);
     }
-
     return result;
 }
 

--- a/libraries/AP_HAL_ESP32/I2CDevice.h
+++ b/libraries/AP_HAL_ESP32/I2CDevice.h
@@ -23,7 +23,7 @@
 #include "Scheduler.h"
 #include "DeviceBus.h"
 
-#include "driver/i2c.h"
+#include "driver/i2c_master.h"
 #include "i2c_sw.h"
 
 namespace ESP32
@@ -42,6 +42,7 @@ class I2CBus : public  DeviceBus
 {
 public:
     I2CBus():DeviceBus(Scheduler::I2C_PRIORITY) {};
+    i2c_master_bus_handle_t bus_handle;
     i2c_port_t port;
     uint32_t bus_clock;
     _i2c_bus_t sw_handle;
@@ -102,6 +103,7 @@ public:
 
 protected:
     I2CBus &bus;
+    i2c_master_dev_handle_t _dev_handle;
     uint8_t _retries;
     uint8_t _address;
     char *pname;


### PR DESCRIPTION

### Summary
`i2c.h` is phased out in ESP-IDF > v5.3. Rewrote the I2C HAL functions based on the latest recommended driver (I2C Master) from SDK v5.5. This eliminates I2C warning messages on boot.

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [x] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description
Modified the I2CDevice.cpp and I2CDevice.h to use the i2c_master.h api.

log before fix:
```log
I (631) spi_flash: flash io: qio
W (635) rmt(legacy): legacy driver is deprecated...
⚠️ W (645) i2c: This driver is an old driver, please migrate your application code to adapt `driver/i2c_master.h`**
I (667) main_task: Started on CPU0
```
log after fix:
```log
I (602) spi_flash: flash io: qio
W (605) rmt(legacy): legacy driver is deprecated, please migrate to `driver/rmt_tx.h` and/or `driver/rmt_rx.h`
I (626) main_task: Started on CPU0
```
<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
