### PR TITLE
AP_NavEKF3: log baro offset

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
@@ -199,7 +199,7 @@ void NavEKF3_core::Log_Write_XKF5(uint64_t time_us) const
         FIY : (int16_t)(1000*flowInnov[1]),  // optical flow LOS rate vector innovations from the main nav filter
         AFI : (int16_t)(1000 * auxFlowObsInnov.length()),  // optical flow LOS rate innovation from terrain offset estimator
         HAGL : float_to_int16(100*(terrainState - stateStruct.position.z)),    // height above ground level
-        offset : (int16_t)(100*terrainState),           // filter ground offset state error
+        terrOffset : (int16_t)(100*terrainState),       // filter ground offset state error
         RI : (int16_t)(100*innovRng),                   // range finder innovations
         meaRng : (uint16_t)(100*rangeDataDelayed.rng),  // measured range
 #if EK3_FEATURE_OPTFLOW_FUSION
@@ -209,7 +209,8 @@ void NavEKF3_core::Log_Write_XKF5(uint64_t time_us) const
 #endif
         angErr : (float)outputTrackError.x,             // output predictor angle error
         velErr : (float)outputTrackError.y,             // output predictor velocity error
-        posErr : (float)outputTrackError.z              // output predictor position tracking error
+        posErr : (float)outputTrackError.z,             // output predictor position tracking error
+        baroOffset : (float)baroHgtOffset               // barometer height offset subtracted from raw baro measurement when fusing baro height
     };
     AP::logger().WriteBlock(&pkt5, sizeof(pkt5));
 }

--- a/libraries/AP_NavEKF3/LogStructure.h
+++ b/libraries/AP_NavEKF3/LogStructure.h
@@ -220,13 +220,14 @@ struct PACKED log_XKF4 {
 // @Field: FIY: Optical flow LOS rate vector innovations from the main nav filter (Y-axis)
 // @Field: AFI: Optical flow LOS rate innovation from terrain offset estimator
 // @Field: HAGL: Height above ground level
-// @Field: offset: Estimated vertical position of the terrain relative to the nav filter zero datum
+// @Field: TOfs: Estimated vertical position of the terrain relative to the nav filter zero datum
 // @Field: RI: Range finder innovations
 // @Field: rng: Measured range
 // @Field: Herr: Filter ground offset state error
 // @Field: eAng: Magnitude of angular error
 // @Field: eVel: Magnitude of velocity error
 // @Field: ePos: Magnitude of position error
+// @Field: BOf: Barometer offset subtracted from raw baro measurement when fusing baro height
 struct PACKED log_XKF5 {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -236,13 +237,14 @@ struct PACKED log_XKF5 {
     int16_t FIY;
     int16_t AFI;
     int16_t HAGL;
-    int16_t offset;
+    int16_t terrOffset;
     int16_t RI;
     uint16_t meaRng;
     uint16_t errHAGL;
     float angErr;
     float velErr;
     float posErr;
+    float baroOffset;
 };
 
 
@@ -441,7 +443,7 @@ struct PACKED log_XKV {
     { LOG_XKF4_MSG, sizeof(log_XKF4), \
       "XKF4","QBcccccfffHBIHb","TimeUS,C,SV,SP,SH,SM,SVT,errRP,OFN,OFE,FS,TS,SS,GPS,PI", "s#------mm-----", "F-------??-----" , true }, \
     { LOG_XKF5_MSG, sizeof(log_XKF5), \
-      "XKF5","QBBhhhcccCCfff","TimeUS,C,NI,FIX,FIY,AFI,HAGL,offset,RI,rng,Herr,eAng,eVel,ePos", "s#----m???mrnm", "F-----BBBBB000" , true }, \
+      "XKF5","QBBhhhcccCCffff","TimeUS,C,NI,FIX,FIY,AFI,HAGL,TOfs,RI,rng,Herr,eAng,eVel,ePos,BOf", "s#----m???mrnmm", "F-----BBBBB0000" , true }, \
     { LOG_XKFD_MSG, sizeof(log_XKFD), \
       "XKFD","QBffffff","TimeUS,C,IX,IY,IZ,IVX,IVY,IVZ", "s#------", "F-------" , true }, \
     { LOG_XKFM_MSG, sizeof(log_XKFM),   \


### PR DESCRIPTION
### Summary

This adds logging of the EKF's baroHgtOffset variable which essentially resolves issue https://github.com/ArduPilot/ardupilot/issues/32612 because the EKF is actually acting as it should, it is just difficult for users reviewing the log to understand why the EKF's altitude doesn't exactly match the barometer.

This variable is updated by [NavEKF3_core::calcFiltBaroOffset](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp#L806) whenever the barometer is **not** the active altitude source ([see code here](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp#L1379)).  This ensures that there is no jump when falling back to baro from another altitude source (e.g. rangefinder or GPS).  This fall back may occur if the user actively [changes the EKF source](https://ardupilot.org/copter/docs/common-ekf-sources.html) or if the other source becomes unavailable for some reason (e.g. GPS failure, rangefinder out-of-range).

The alternative behaviour would be for the EKF's altitude estimate to be reset to the barometer's altitude during fall back but I suspect this could cause the vehicle to dramatically climb or descend especially when falling back from GPS to baro during long distance flights.

For the moment I think simply logging the offset removes confusion.

Below is a screen shot from MP's log review tool showing Copter's CTUN's message's Alt (aka EKF altitude estimate), BAlt (barometer altitude) and the new XKF5.B message (barometer offset).

<img width="2053" height="795" alt="image" src="https://github.com/user-attachments/assets/9ac5fec9-eb97-4bc8-8e9e-232d8e8018f3" />

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request
