### PR TITLE
GCS_MAVLink: remove AUTOPILOT_VERSION_REQUEST/MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES

### DIFF
--- a/libraries/GCS_MAVLink/GCS_config.h
+++ b/libraries/GCS_MAVLink/GCS_config.h
@@ -34,8 +34,11 @@
 // AUTOPILOT_VERSION_REQUEST is slated to be removed; an instance of
 // AUTOPILOT_VERSION can be requested with MAV_CMD_REQUEST_MESSAGE,
 // which gets you an ACK/NACK
+// ArduPilot 4.5 allows to be compiled out
+// ArduPilot 4.8 stops compiling in by default
+// ArduPilot 4.9 removes the code entirely
 #ifndef AP_MAVLINK_AUTOPILOT_VERSION_REQUEST_ENABLED
-#define AP_MAVLINK_AUTOPILOT_VERSION_REQUEST_ENABLED 1
+#define AP_MAVLINK_AUTOPILOT_VERSION_REQUEST_ENABLED (CONFIG_HAL_BOARD == HAL_BOARD_SITL)
 #endif
 
 #ifndef AP_MAVLINK_MSG_RC_CHANNELS_RAW_ENABLED
@@ -44,8 +47,11 @@
 
 // handling of MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES is slated to be
 // removed; the message can be requested with MAV_CMD_REQUEST_MESSAGE
+// ArduPilot 4.5 allows to be compiled out
+// ArduPilot 4.8 stops compiling in by default
+// ArduPilot 4.9 removes the code entirely
 #ifndef AP_MAVLINK_MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES_ENABLED
-#define AP_MAVLINK_MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES_ENABLED 1
+#define AP_MAVLINK_MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES_ENABLED (CONFIG_HAL_BOARD == HAL_BOARD_SITL)
 #endif
 
 #ifndef HAL_MAVLINK_INTERVALS_FROM_FILES_ENABLED


### PR DESCRIPTION
### Summary

Stops compiling support for these two messages in by default, with an eye to removing them in 4.9

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Fired up MissionPlanner against this and there weren't any issues.

Likewise QGC

### Description

MissionPlanner currently sends in both; if we add a warning then many users will start to get messages.
