### PR TITLE
Tools: use a set to prevent duplicated heading

### DIFF
--- a/Tools/autotest/param_metadata/jsonemit.py
+++ b/Tools/autotest/param_metadata/jsonemit.py
@@ -32,7 +32,8 @@ class JSONEmit(Emit):
         # Copy content to avoid any modification
         g = copy.deepcopy(g)
 
-        self.content[g.name] = {}
+        if g.name not in self.content:
+            self.content[g.name] = {}
 
         # Check all params available
         for param in g.params:

--- a/Tools/autotest/param_metadata/rstemit.py
+++ b/Tools/autotest/param_metadata/rstemit.py
@@ -30,7 +30,7 @@ This list is automatically generated from the latest ardupilot source code, and 
         self.f = open(self.output_fname(), mode='w')
         self.spacer = re.compile("^", re.MULTILINE)
         self.rstescape = re.compile("([^a-zA-Z0-9\n 	])")
-        self.emitted_sitl_heading = False
+        self.emitted_headings = set()
         parameterlisttype = "Complete Parameter List"
         parameterlisttype += "\n" + "=" * len(parameterlisttype)
         self.preamble = """.. Dynamically generated list of documented parameters
@@ -194,17 +194,15 @@ This list is automatically generated from the latest ardupilot source code, and 
         return ''
 
     def emit(self, g):
-        # make only a single group for SIM_ parameters
-        do_emit_heading = True
         if g.reference.startswith("SIM_"):
-            if self.emitted_sitl_heading:
-                do_emit_heading = False
-            self.emitted_sitl_heading = True
             tag = "Simulation Parameters"
             reference = "parameters_sim"
         else:
             tag = '%s Parameters' % self.escape(g.reference)
             reference = "parameters_" + g.reference
+
+        do_emit_heading = reference not in self.emitted_headings
+        self.emitted_headings.add(reference)
 
         field_table_info = {
             "Values": {

--- a/Tools/autotest/param_metadata/xmlemit.py
+++ b/Tools/autotest/param_metadata/xmlemit.py
@@ -81,7 +81,11 @@ class XmlEmit(Emit):
         return sorted(keys, key=sort_key)
 
     def emit(self, g):
-        xml_parameters = etree.SubElement(self.current_element, 'parameters', name=g.reference)  # i.e. ArduPlane
+        existing = self.current_element.find("parameters[@name='%s']" % g.reference)
+        if existing is not None:
+            xml_parameters = existing
+        else:
+            xml_parameters = etree.SubElement(self.current_element, 'parameters', name=g.reference)  # i.e. ArduPlane
 
         for param in g.params:
             if not self.should_emit_param(param):


### PR DESCRIPTION
### Summary

Correct our parameter documentation emit to not generate duplicated header. This is triggering error on the wiki for example.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [x] Logs attached
- [x] Logs available on request


### Description

This fix rst, json and xml emiter to not create duplicated heading.
Finding comes from the rst emit that have a duplicated NET heading and trigger warning on wiki.

#### Claude review
`Tools/AP_Periph/networking.cpp` defines a `GOBJECT` with prefix `NET_` (in `Parameters.cpp`)
which itself contains an `AP_SUBGROUPINFO` with an empty prefix `""` pointing to
`AP_Networking.cpp`. The parser builds two `Library` objects with the same `reference`
value `"NET_"`, causing each emitter's `emit()` to be called twice for that group.
## Fixes applied

### `rstemit.py` — duplicate RST label (Sphinx error)

Replaced the single `emitted_sitl_heading` boolean (which only deduplicated `SIM_`)
with a generic `emitted_headings` set. Any section reference that has already been
emitted will not generate a second `.. _label:` anchor.

### `jsonemit.py` — data loss on duplicate group

`self.content[g.name] = {}` was called unconditionally, wiping parameters already
collected for that group. Fixed by only initialising the dict when the key is absent:

```python
if g.name not in self.content:
    self.content[g.name] = {}
```

### `xmlemit.py` — duplicate `<parameters>` elements

A second `etree.SubElement(…, 'parameters', name=…)` was created for the same
group, producing invalid/duplicate XML. Fixed by looking up an existing element first:

```python
existing = self.current_element.find("parameters[@name='%s']" % g.reference)
if existing is not None:
    xml_parameters = existing
else:
    xml_parameters = etree.SubElement(…)
```

### `htmlemit.py` / `mdemit.py` — cosmetic duplicates only

Both emitters produce duplicate section headings but no parser/consumer breaks.
`mdemit.py` already has its own deduplication logic for numeric groups (`RCn_`,
`SERVOn_`, etc.). No fix required.

### `rstlatexpdfemit.py`

Inherits from `RSTEmit` — covered by the `rstemit.py` fix.


### Testing done : 
Using : 
```
for v in Rover AntennaTracker ArduCopter ArduPlane ArduSub Blimp AP_Periph; do
            for t in json xml; do
                python3 Tools/autotest/param_metadata/param_parse.py --vehicle $v --format $t
                mv apm.pdef.$t ./params/apm.pdef_$v.$t
            done
            python3 Tools/autotest/param_metadata/param_parse.py --vehicle $v --format rst
            mv Parameters.rst ./params/Parameters_$v.rst

        done
```
I generate all the parameters then do a comparison between master and PR version.
`
╰─$ diff params_master params
diff --color params_master/apm.pdef_AP_Periph.json params/apm.pdef_AP_Periph.json
20067a20068,20103
>     "NET_PPP_BAUD": {
>       "Description": "PPP serial baudrate",
>       "DisplayName": "PPP serial baudrate",
>       "Range": {
>         "high": "20000000",
>         "low": "1"
>       },
>       "User": "Standard",
>       "Values": {
>         "1": "1200",
>         "111": "111100",
>         "115": "115200",
>         "12500000": "12.5MBaud",
>         "1500": "1.5MBaud",
>         "19": "19200",
>         "2": "2400",
>         "2000": "2MBaud",
>         "230": "230400",
>         "256": "256000",
>         "38": "38400",
>         "4": "4800",
>         "460": "460800",
>         "500": "500000",
>         "57": "57600",
>         "9": "9600",
>         "921": "921600"
>       }
>     },
>     "NET_PPP_PORT": {
>       "Description": "PPP serial port",
>       "DisplayName": "PPP serial port",
>       "Range": {
>         "high": "10",
>         "low": "-1"
>       }
>     },
diff --color params_master/apm.pdef_AP_Periph.xml params/apm.pdef_AP_Periph.xml
13206,13207d13205
<     </parameters>
<     <parameters name="NET_">
diff --color params_master/apm.pdef_ArduCopter.json params/apm.pdef_ArduCopter.json
1398a1399,1429
>     "FLTMODE_GCSBLOCK": {
>       "Bitmask": {
>         "0": "Stabilize",
>         "1": "Acro",
>         "10": "AutoTune",
>         "11": "PosHold",
>         "12": "Brake",
>         "13": "Throw",
>         "14": "Avoid_ADSB",
>         "15": "Guided_NoGPS",
>         "16": "Smart_RTL",
>         "17": "FlowHold",
>         "18": "Follow",
>         "19": "ZigZag",
>         "2": "AltHold",
>         "20": "SystemID",
>         "21": "Heli_Autorotate",
>         "22": "Auto RTL",
>         "23": "Turtle",
>         "3": "Auto",
>         "4": "Guided",
>         "5": "Loiter",
>         "6": "Circle",
>         "7": "Drift",
>         "8": "Sport",
>         "9": "Flip"
>       },
>       "Description": "Bitmask of flight modes to disable for GCS selection. Mode can still be accessed via RC or failsafe.",
>       "DisplayName": "Flight mode block from GCS",
>       "User": "Standard"
>     },
diff --color params_master/apm.pdef_ArduPlane.json params/apm.pdef_ArduPlane.json
1398a1399,1427
>     "FLTMODE_GCSBLOCK": {
>       "Bitmask": {
>         "0": "Manual",
>         "1": "Circle",
>         "10": "Loiter",
>         "11": "Takeoff",
>         "12": "AVOID_ADSB",
>         "13": "Guided",
>         "14": "THERMAL",
>         "15": "QSTABILIZE",
>         "16": "QHOVER",
>         "17": "QLOITER",
>         "18": "QACRO",
>         "19": "QAUTOTUNE",
>         "2": "Stabilize",
>         "20": "Loiter to QLand",
>         "21": "Autoland",
>         "3": "Training",
>         "4": "ACRO",
>         "5": "FBWA",
>         "6": "FBWB",
>         "7": "CRUISE",
>         "8": "AUTOTUNE",
>         "9": "Auto"
>       },
>       "Description": "Bitmask of flight modes to disable for GCS selection. Mode can still be accessed via RC or failsafe.",
>       "DisplayName": "Flight mode block from GCS",
>       "User": "Standard"
>     },
diff --color params_master/apm.pdef_Rover.json params/apm.pdef_Rover.json
1398a1399,1417
>     "FLTMODE_GCSBLOCK": {
>       "Bitmask": {
>         "0": "Manual",
>         "1": "Acro",
>         "10": "Guided",
>         "11": "Dock",
>         "2": "Steering",
>         "3": "Loiter",
>         "4": "Follow",
>         "5": "Simple",
>         "6": "Circle",
>         "7": "Auto",
>         "8": "RTL",
>         "9": "SmartRTL"
>       },
>       "Description": "Bitmask of flight modes to disable for GCS selection. Mode can still be accessed via RC or failsafe.",
>       "DisplayName": "Flight mode block from GCS",
>       "User": "Standard"
>     },
diff --color params_master/Parameters_AP_Periph.rst params/Parameters_AP_Periph.rst
39978,39983d39977
< .. _parameters_NET_:
< 
< NET\_ Parameters
< ----------------
< 
< 
`

And the changes are good. Duplicated NET_ section is remove and FLTMODE_GCSBLOCK that was missing is now there ! 