### PR TITLE
AP_DDS: added rangefinder topic

### DIFF
--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -40,6 +40,11 @@
 #if AP_DDS_RC_PUB_ENABLED
 #include "AP_RSSI/AP_RSSI.h"
 #endif // AP_DDS_RC_PUB_ENABLED
+#if AP_DDS_RANGEFINDER_PUB_ENABLED
+#include "sensor_msgs/msg/Range.h"
+#include <AP_RangeFinder/AP_RangeFinder.h>
+#include <AP_RangeFinder/AP_RangeFinder_Backend.h>
+#endif // AP_DDS_RANGEFINDER_PUB_ENABLED
 
 #if AP_EXTERNAL_CONTROL_ENABLED
 #include "AP_DDS_ExternalControl.h"
@@ -92,6 +97,9 @@ static constexpr uint16_t DELAY_PING_MS = 500;
 #if AP_DDS_STATUS_PUB_ENABLED
 static constexpr uint16_t DELAY_STATUS_TOPIC_MS = AP_DDS_DELAY_STATUS_TOPIC_MS;
 #endif // AP_DDS_STATUS_PUB_ENABLED
+#if AP_DDS_RANGEFINDER_PUB_ENABLED
+static constexpr uint16_t DELAY_RANGEFINDER_TOPIC_MS = AP_DDS_DELAY_RANGEFINDER_TOPIC_MS;
+#endif // AP_DDS_RANGEFINDER_PUB_ENABLED
 
 // Define the subscriber data members, which are static class scope.
 // If these are created on the stack in the subscriber,
@@ -773,6 +781,47 @@ bool AP_DDS_Client::update_topic(ardupilot_msgs_msg_Status& msg)
     }
 }
 #endif // AP_DDS_STATUS_PUB_ENABLED
+
+#if AP_DDS_RANGEFINDER_PUB_ENABLED
+bool AP_DDS_Client::update_topic(sensor_msgs_msg_Range& msg, const uint8_t instance)
+{
+    RangeFinder *rangefinder = RangeFinder::get_singleton();
+    if (rangefinder == nullptr) {
+        return false;
+    }
+
+    AP_RangeFinder_Backend *sensor = rangefinder->get_backend(instance);
+    if (sensor == nullptr) {
+        return false;
+    }
+
+    if (!sensor->has_data()) {
+        return false;
+    }
+
+    update_topic(msg.header.stamp);
+
+    hal.util->snprintf(msg.header.frame_id, ARRAY_SIZE(msg.header.frame_id),
+                       "rangefinder_%u", unsigned(instance));
+
+    // Sensor_msgs/msg/Range only has:  ULTRASOUND = 0 and INFRARED   = 1
+    // For a 1D LiDAR / ToF rangefinder, INFRARED is the closest standard value
+    // available in sensor_msgs/msg/Range.
+
+    msg.radiation_type = 1U;
+
+    msg.field_of_view = 0.0f;
+
+    // Assign the min and max range based on the sensor's specifications.
+    msg.min_range = sensor->min_distance();
+    msg.max_range = sensor->max_distance();
+    // Assign the current range reading from the sensor.
+    msg.range = sensor->distance();
+
+    return true;
+}
+#endif // AP_DDS_RANGEFINDER_PUB_ENABLED
+
 /*
   start the DDS thread
  */
@@ -1806,6 +1855,30 @@ void AP_DDS_Client::write_status_topic()
 }
 #endif // AP_DDS_STATUS_PUB_ENABLED
 
+
+#if AP_DDS_RANGEFINDER_PUB_ENABLED
+void AP_DDS_Client::write_rangefinder_topic()
+{
+    WITH_SEMAPHORE(csem);
+
+    if (connected) {
+        ucdrBuffer ub {};
+
+        const uint32_t topic_size = sensor_msgs_msg_Range_size_of_topic(&rangefinder_topic, 0);
+
+        uxr_prepare_output_stream(&session, reliable_out,
+                                  topics[to_underlying(TopicIndex::RANGEFINDER_PUB)].dw_id, &ub, topic_size);
+
+        const bool success = sensor_msgs_msg_Range_serialize_topic(&ub, &rangefinder_topic);
+
+        if (!success) {
+            // TODO sometimes serialization fails on bootup. Determine why.
+            // AP_HAL::panic("FATAL: DDS_Client failed to serialize");
+        }
+    }
+}
+#endif // AP_DDS_RANGEFINDER_PUB_ENABLED
+
 void AP_DDS_Client::update()
 {
     WITH_SEMAPHORE(csem);
@@ -1910,6 +1983,16 @@ void AP_DDS_Client::update()
         last_status_check_time_ms = cur_time_ms;
     }
 #endif // AP_DDS_STATUS_PUB_ENABLED
+#if AP_DDS_RANGEFINDER_PUB_ENABLED
+    for (uint8_t rangefinder_instance = 0; rangefinder_instance < RANGEFINDER_MAX_INSTANCES; rangefinder_instance++) {
+        if (cur_time_ms - last_rangefinder_time_ms[rangefinder_instance] > DELAY_RANGEFINDER_TOPIC_MS) {
+            if (update_topic(rangefinder_topic, rangefinder_instance)) {
+                write_rangefinder_topic();
+            }
+            last_rangefinder_time_ms[rangefinder_instance] = cur_time_ms;
+        }
+    }
+#endif // AP_DDS_RANGEFINDER_PUB_ENABLED
 
     status_ok = uxr_run_session_time(&session, 1);
 }

--- a/libraries/AP_DDS/AP_DDS_Client.h
+++ b/libraries/AP_DDS/AP_DDS_Client.h
@@ -53,6 +53,10 @@
 #if AP_DDS_CLOCK_PUB_ENABLED
 #include "rosgraph_msgs/msg/Clock.h"
 #endif // AP_DDS_CLOCK_PUB_ENABLED
+#if AP_DDS_RANGEFINDER_PUB_ENABLED
+#include "sensor_msgs/msg/Range.h"
+#include <AP_RangeFinder/AP_RangeFinder.h>
+#endif // AP_DDS_RANGEFINDER_PUB_ENABLED
 #if AP_DDS_PARAMETER_SERVER_ENABLED
 #include "rcl_interfaces/srv/SetParameters.h"
 #include "rcl_interfaces/msg/Parameter.h"
@@ -220,6 +224,16 @@ private:
     //! @brief Serialize the current status and publish to the IO stream(s)
     void write_status_topic();
 #endif // AP_DDS_STATUS_PUB_ENABLED
+
+#if AP_DDS_RANGEFINDER_PUB_ENABLED
+    sensor_msgs_msg_Range rangefinder_topic;
+    // The last ms timestamp AP_DDS attempted to publish each rangefinder instance
+    uint64_t last_rangefinder_time_ms[RANGEFINDER_MAX_INSTANCES];
+    //! @brief Serialize the current rangefinder data and publish to the IO stream(s)
+    void write_rangefinder_topic();
+    //! @brief Update a ROS 2 Range message from an ArduPilot rangefinder instance
+    static bool update_topic(sensor_msgs_msg_Range& msg, const uint8_t instance) WARN_IF_UNUSED;
+#endif // AP_DDS_RANGEFINDER_PUB_ENABLED
 
 #if AP_DDS_STATIC_TF_PUB_ENABLED
     // outgoing transforms

--- a/libraries/AP_DDS/AP_DDS_Topic_Table.h
+++ b/libraries/AP_DDS/AP_DDS_Topic_Table.h
@@ -9,6 +9,9 @@
 #if AP_DDS_IMU_PUB_ENABLED
 #include "sensor_msgs/msg/Imu.h"
 #endif //AP_DDS_IMU_PUB_ENABLED
+#if AP_DDS_RANGEFINDER_PUB_ENABLED
+#include "sensor_msgs/msg/Range.h"
+#endif // AP_DDS_RANGEFINDER_PUB_ENABLED
 
 #include "uxr/client/client.h"
 
@@ -59,6 +62,9 @@ enum class TopicIndex: uint8_t {
 #if AP_DDS_STATUS_PUB_ENABLED
     STATUS_PUB,
 #endif // AP_DDS_STATUS_PUB_ENABLED
+#if AP_DDS_RANGEFINDER_PUB_ENABLED
+    RANGEFINDER_PUB,
+#endif // AP_DDS_RANGEFINDER_PUB_ENABLED
 #if AP_DDS_JOY_SUB_ENABLED
     JOY_SUB,
 #endif // AP_DDS_JOY_SUB_ENABLED
@@ -333,6 +339,24 @@ constexpr struct AP_DDS_Client::Topic_table AP_DDS_Client::topics[] = {
         },
     },
 #endif // AP_DDS_STATUS_PUB_ENABLED
+#if AP_DDS_RANGEFINDER_PUB_ENABLED
+    {
+        .topic_id = to_underlying(TopicIndex::RANGEFINDER_PUB),
+        .pub_id = to_underlying(TopicIndex::RANGEFINDER_PUB),
+        .sub_id = to_underlying(TopicIndex::RANGEFINDER_PUB),
+        .dw_id = uxrObjectId{.id=to_underlying(TopicIndex::RANGEFINDER_PUB), .type=UXR_DATAWRITER_ID},
+        .dr_id = uxrObjectId{.id=to_underlying(TopicIndex::RANGEFINDER_PUB), .type=UXR_DATAREADER_ID},
+        .topic_rw = Topic_rw::DataWriter,
+        .topic_name = "experimental/rangefinder",
+        .type_name = "sensor_msgs::msg::dds_::Range_",
+        .qos = {
+            .durability = UXR_DURABILITY_VOLATILE,
+            .reliability = UXR_RELIABILITY_BEST_EFFORT,
+            .history = UXR_HISTORY_KEEP_LAST,
+            .depth = 5,
+        },
+    },
+#endif // AP_DDS_RANGEFINDER_PUB_ENABLED
 #if AP_DDS_JOY_SUB_ENABLED
     {
         .topic_id = to_underlying(TopicIndex::JOY_SUB),

--- a/libraries/AP_DDS/AP_DDS_config.h
+++ b/libraries/AP_DDS/AP_DDS_config.h
@@ -3,6 +3,7 @@
 #include <AP_GPS/AP_GPS_config.h>
 #include <AP_HAL/AP_HAL_Boards.h>
 #include <AP_Networking/AP_Networking_Config.h>
+#include <AP_RangeFinder/AP_RangeFinder_config.h>
 #include <AP_VisualOdom/AP_VisualOdom_config.h>
 #include <RC_Channel/RC_Channel_config.h>
 #include <AP_RSSI/AP_RSSI_config.h>
@@ -127,6 +128,14 @@
 #endif
 #ifndef AP_DDS_STATUS_PUB_ENABLED
 #define AP_DDS_STATUS_PUB_ENABLED 1
+#endif
+
+#ifndef AP_DDS_RANGEFINDER_PUB_ENABLED
+#define AP_DDS_RANGEFINDER_PUB_ENABLED AP_RANGEFINDER_ENABLED
+#endif
+
+#ifndef AP_DDS_DELAY_RANGEFINDER_TOPIC_MS
+#define AP_DDS_DELAY_RANGEFINDER_TOPIC_MS 10
 #endif
 
 #ifndef AP_DDS_JOY_SUB_ENABLED

--- a/libraries/AP_DDS/Idl/sensor_msgs/msg/Range.idl
+++ b/libraries/AP_DDS/Idl/sensor_msgs/msg/Range.idl
@@ -1,0 +1,70 @@
+// generated from rosidl_adapter/resource/msg.idl.em
+// with input from sensor_msgs/msg/Range.msg
+// generated code does not contain a copyright notice
+
+#include "std_msgs/msg/Header.idl"
+
+module sensor_msgs {
+  module msg {
+    module Range_Constants {
+      @verbatim (language="comment", text=
+        "Radiation type enums" "\n"        "If you want a value added to this list, send an email to the ros-users list")
+      const uint8 ULTRASOUND = 0;
+      const uint8 INFRARED = 1;
+    };
+    @verbatim (language="comment", text=
+      "Single range reading from an active ranger that emits energy and reports" "\n"
+      "one range reading that is valid along an arc at the distance measured." "\n"
+      "This message is  not appropriate for laser scanners. See the LaserScan" "\n"
+      "message if you are working with a laser scanner." "\n"
+      "" "\n"
+      "This message also can represent a fixed-distance (binary) ranger.  This" "\n"
+      "sensor will have min_range===max_range===distance of detection." "\n"
+      "These sensors follow REP 117 and will output -Inf if the object is detected" "\n"
+      "and +Inf if the object is outside of the detection range.")
+    struct Range {
+      @verbatim (language="comment", text=
+        "timestamp in the header is the time the ranger" "\n"
+        "returned the distance reading")
+      std_msgs::msg::Header header;
+
+      @verbatim (language="comment", text=
+        "the type of radiation used by the sensor" "\n"
+        "(sound, IR, etc)")
+      @unit (value="enum")
+      uint8 radiation_type;
+
+      @verbatim (language="comment", text=
+        "the size of the arc that the distance reading is" "\n"
+        "valid for" "\n"
+        "the object causing the range reading may have" "\n"
+        "been anywhere within -field_of_view/2 and" "\n"
+        "field_of_view/2 at the measured range." "\n"
+        "0 angle corresponds to the x-axis of the sensor.")
+      @unit (value="rad")
+      float field_of_view;
+
+      @verbatim (language="comment", text=
+        "minimum range value")
+      @unit (value="m")
+      float min_range;
+
+      @verbatim (language="comment", text=
+        "maximum range value" "\n"
+        "Fixed distance rangers require min_range==max_range")
+      @unit (value="m")
+      float max_range;
+
+      @verbatim (language="comment", text=
+        "range data" "\n"
+        "(Note: values < range_min or > range_max should be discarded)" "\n"
+        "Fixed distance rangers only output -Inf or +Inf." "\n"
+        "-Inf represents a detection within fixed distance." "\n"
+        "(Detection too close to the sensor to quantify)" "\n"
+        "+Inf represents no detection within the fixed distance." "\n"
+        "(Object out of range)")
+      @unit (value="m")
+      float range;
+    };
+  };
+};


### PR DESCRIPTION
### Summary

This adds range finder target topic, `/ap/experimental/rangefinder`.

This enables ArduPilot to publish rangefinder distance data over ROS 2, for sensors such as 1D LiDARs or optical-flow sensors with integrated rangefinders. The implementation follows the same logic used for publishing distance data via MAVLink.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->
Tested with SITL and ROS 2. The /ap/experimental/rangefinder topic appears in ros2 topic list. I was unable to test ros2 topic echo for this topic because I could not find a SITL setup that simulates rangefinder data.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
