### PR TITLE
AP_VideoTX: surface actual transmit power and bound Tramp retries

### DIFF
--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -2496,7 +2496,9 @@ void AP_OSD_Screen::draw_vtx_power(uint8_t x, uint8_t y)
     uint16_t powr = 0;
     // If currently in pit mode, just render 0mW to the screen
     if(!vtx->has_option(AP_VideoTX::VideoOptions::VTX_PITMODE)){
-        powr = vtx->get_power_mw();
+        // prefer VTX-reported actual; SmartAudio returns -1 here
+        const int32_t actual_mw = vtx->get_actual_power_mw();
+        powr = actual_mw >= 0 ? uint16_t(actual_mw) : vtx->get_power_mw();
     }
     backend->write(x, y, !vtx->is_configuration_finished(), "%4hu%c", powr, SYMBOL(SYM_MW));
 }

--- a/libraries/AP_VideoTX/AP_Tramp.cpp
+++ b/libraries/AP_VideoTX/AP_Tramp.cpp
@@ -128,6 +128,21 @@ char AP_Tramp::handle_response(void)
             }
 
             vtx.set_power_mw(power);
+            vtx.set_actual_power_mw(cur_act_power);
+
+            // VTX-reported rf_power_max is unreliable, so warn on the user cap instead
+            if (!_act_power_warned && cur_act_power != 0) {
+                const uint16_t user_cap = vtx.get_max_power_mw();
+                const bool over_cap = (user_cap != 0 && cur_act_power > user_cap);
+                const bool over_request = (power != 0 && cur_act_power > power + (power / 2));
+                if (over_cap || over_request) {
+                    GCS_SEND_TEXT(MAV_SEVERITY_WARNING,
+                                  "VTX: requested %umW, actual %umW, cap %umW",
+                                  unsigned(power), unsigned(cur_act_power), unsigned(user_cap));
+                    _act_power_warned = true;
+                }
+            }
+
             if (pit_mode) {
                 vtx.set_options(vtx.get_options() | uint8_t(AP_VideoTX::VideoOptions::VTX_PITMODE));
             } else {
@@ -140,8 +155,9 @@ char AP_Tramp::handle_response(void)
                 vtx.announce_vtx_settings();
             }
 
-            debug("device config: freq: %u, cfg pwr: %umw, act pwr: %umw, pitmode: %u",
-                unsigned(freq), unsigned(power), unsigned(cur_act_power), unsigned(pit_mode));
+            debug("device config: freq: %u, cfg pwr: %umw, act pwr: %umw, pitmode: %u, ctrl: 0x%02x",
+                unsigned(freq), unsigned(power), unsigned(cur_act_power),
+                unsigned(pit_mode), unsigned(cur_control_mode));
 
             // update the "_configuration_finished" flag, otherwise OSD item VTX_POWER blinks forever
             vtx.set_configuration_finished(!update_pending);
@@ -470,20 +486,38 @@ void AP_Tramp::update()
     AP_VideoTX& vtx = AP::vtx();
 
     if (vtx.have_params_changed() && retry_count == 0) {
-        // check changes in the order they will be processed
+        // check changes in the order they will be processed; re-arm retries
+        // only on real changes so a VTX rejecting a value can't loop forever
         if (vtx.update_frequency() || vtx.update_band() || vtx.update_channel()) {
             if (vtx.update_frequency()) {
                 vtx.update_configured_channel_and_band();
             } else {
                 vtx.update_configured_frequency();
             }
-            set_frequency(vtx.get_configured_frequency_mhz());
+            const uint16_t conf_freq = vtx.get_configured_frequency_mhz();
+            if (conf_freq != _last_conf_freq) {
+                _last_conf_freq = conf_freq;
+                set_frequency(conf_freq);
+            }
         }
         else if (vtx.update_power()) {
-            retry_count = VTX_TRAMP_MAX_RETRIES;
+            const uint16_t conf_power = vtx.get_configured_power_mw();
+            if (conf_power != _last_conf_power) {
+                _last_conf_power = conf_power;
+                retry_count = VTX_TRAMP_MAX_RETRIES;
+                _power_warn_pending = true;
+            } else if (_power_warn_pending) {
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING,
+                              "VTX: rejected power %umW", unsigned(conf_power));
+                _power_warn_pending = false;
+            }
         }
         else if (vtx.update_options()) {
-            retry_count = VTX_TRAMP_MAX_RETRIES;
+            const uint16_t conf_options = vtx.get_configured_options();
+            if (conf_options != _last_conf_options) {
+                _last_conf_options = conf_options;
+                retry_count = VTX_TRAMP_MAX_RETRIES;
+            }
         }
     }
 

--- a/libraries/AP_VideoTX/AP_Tramp.h
+++ b/libraries/AP_VideoTX/AP_Tramp.h
@@ -59,8 +59,9 @@ public:
     bool init(void);
     void update();
 
-    uint16_t get_current_actual_power();
-    uint16_t get_current_temp();
+    // actual transmitted power reported by the VTX in the 'v' response
+    uint16_t get_current_actual_power() const { return cur_act_power; }
+    int16_t get_current_temp() const { return cur_temp; }
 
 private:
     uint8_t checksum(uint8_t *buf);
@@ -121,6 +122,7 @@ private:
     uint16_t cur_act_power; // Actual power
     int16_t cur_temp;
     uint8_t cur_control_mode;
+    bool _act_power_warned;
 
     // statistics
     uint16_t _packets_sent;
@@ -135,6 +137,12 @@ private:
 
     // Retry count
     uint8_t retry_count = VTX_TRAMP_MAX_RETRIES;
+
+    // retry counter only re-arms when one of these changes
+    uint16_t _last_conf_freq;
+    uint16_t _last_conf_power;
+    uint16_t _last_conf_options;
+    bool _power_warn_pending;
 
     // Receive state machine
     enum class ReceiveState {

--- a/libraries/AP_VideoTX/AP_VideoTX.cpp
+++ b/libraries/AP_VideoTX/AP_VideoTX.cpp
@@ -276,9 +276,22 @@ void AP_VideoTX::set_power_mw(uint16_t power)
     for (uint8_t i = 0; i < VTX_MAX_POWER_LEVELS; i++) {
         if (power == _power_levels[i].mw) {
             _current_power = i;
-            break;
+            return;
         }
     }
+    // power 0 (pit mode) should always match the built-in 0mW entry; bail
+    // here so it can never reach log10f below
+    if (power == 0) {
+        return;
+    }
+    // non-standard value (e.g. Tramp 2500mW): stash it in the custom slot
+    PowerLevel &slot = _power_levels[VTX_MAX_POWER_LEVELS - 1];
+    slot.mw = power;
+    slot.dbm = uint8_t(roundf(10.0f * log10f(float(power))));
+    slot.level = 255;
+    slot.dac = 255;
+    slot.active = PowerActive::Active;
+    _current_power = VTX_MAX_POWER_LEVELS - 1;
 }
 
 // set the power "level"
@@ -401,6 +414,10 @@ bool AP_VideoTX::update_power() const {
             && _power_levels[i].active != PowerActive::Inactive) {
             return true;
         }
+    }
+    // Tramp accepts arbitrary mW; the table check above is SmartAudio-only
+    if (_power_mw > 0 && is_provider_enabled(VTXType::Tramp)) {
+        return true;
     }
     // asked for something unsupported - only SA2.1 allows this and will have already provided a list
     return false;

--- a/libraries/AP_VideoTX/AP_VideoTX.h
+++ b/libraries/AP_VideoTX/AP_VideoTX.h
@@ -114,6 +114,10 @@ public:
     void set_configured_power_mw(uint16_t power);
     uint16_t get_configured_power_mw() const { return _power_mw; }
     uint16_t get_power_mw() const { return _power_levels[_current_power].mw; }
+    // VTX-reported actual power; -1 if the provider doesn't report it, 0 is pit mode
+    void set_actual_power_mw(uint16_t power) { _actual_power_mw = int32_t(power); }
+    int32_t get_actual_power_mw() const { return _actual_power_mw; }
+    uint16_t get_max_power_mw() const { return _max_power_mw; }
 
     // get the power in dbm, rounding appropriately
     uint8_t get_configured_power_dbm() const {
@@ -187,6 +191,7 @@ private:
     // power output in mw
     AP_Int16 _power_mw;
     uint16_t _current_power;
+    int32_t _actual_power_mw {-1};
     AP_Int16 _max_power_mw;
 
     // frequency band


### PR DESCRIPTION
### Summary

Three independent issues affecting Tramp VTX users, found while debugging a 2500mW analog setup:

1. The OSD power panel always showed the configured request, never the power the VTX reports it is actually transmitting. Tramp's 'v' reply carries both, but only the configured value was plumbed through AP_VideoTX.
2. update_power() rejected any mW not in the SmartAudio-derived power table. Tramp carries arbitrary 16-bit mW values, so common settings like 2500mW were silently dropped, with no protocol traffic and no GCS feedback.
3. A VTX that silently refuses a value drove an unbounded retry loop, because AP_Tramp::update() re-armed retry_count on every parameter mismatch.

### Classification & Testing

- [x] Checked by a human programmer
- [x] Tested manually
- [x] Tested on hardware

MicoAir 743 v2 with a 2500mW analog Tramp VTX:

- VTX_POWER 2500 was previously silent (update_power() returned false, AP_Tramp sent nothing). Now the 'P' 2500 command goes out and the VTX echoes 2500 back.
- VTX_POWER 400 (advertised as max but rejected by this VTX): retries stop after 20, one "VTX: rejected power 400mW" warning is sent, then quiet until the value changes.
- The OSD VTX_PWR panel now shows the VTX's self-reported actual power.
- SmartAudio is unchanged: the table check is retained for non-Tramp providers.

### Description

AP_VideoTX gains set/get_actual_power_mw() (-1 = provider doesn't report, 0 is valid for pit mode). AP_Tramp writes both the configured power (drives the state machine) and the actual power (display only); the OSD reads actual when available and falls back to configured.

update_power() accepts off-table mW when a Tramp provider is active, and set_power_mw() populates the custom power slot for those values so the equality short-circuit works on later calls.

update() re-arms retry_count only when the configured value changed since the last attempt, matching Betaflight's vtxTrampSetPowerByIndex(). rf_power_max from the Tramp 'r' reply is deliberately not used to gate requests: Betaflight tried that in 6560f80da and reverted it because the value is unreliable across firmware variants.
