### PR TITLE
Remove redundant static methods on RC_Channels

### DIFF
--- a/AntennaTracker/RC_Channel_Tracker.h
+++ b/AntennaTracker/RC_Channel_Tracker.h
@@ -19,7 +19,13 @@ public:
 
     RC_Channel_Tracker obj_channels[NUM_RC_CHANNELS];
     RC_Channel_Tracker *channel(const uint8_t chan) override {
-        if (chan >= NUM_RC_CHANNELS) {
+        if (chan >= ARRAY_SIZE(obj_channels)) {
+            return nullptr;
+        }
+        return &obj_channels[chan];
+    }
+    const RC_Channel_Tracker *channel(const uint8_t chan) const override {
+        if (chan >= ARRAY_SIZE(obj_channels)) {
             return nullptr;
         }
         return &obj_channels[chan];

--- a/AntennaTracker/mode_manual.cpp
+++ b/AntennaTracker/mode_manual.cpp
@@ -11,9 +11,9 @@
 void ModeManual::update()
 {
     // copy yaw and pitch input to output
-    SRV_Channels::set_output_pwm(SRV_Channel::k_tracker_yaw, RC_Channels::rc_channel(CH_YAW)->get_radio_in());
+    SRV_Channels::set_output_pwm(SRV_Channel::k_tracker_yaw, rc().channel(CH_YAW)->get_radio_in());
     SRV_Channels::constrain_pwm(SRV_Channel::k_tracker_yaw);
 
-    SRV_Channels::set_output_pwm(SRV_Channel::k_tracker_pitch, RC_Channels::rc_channel(CH_PITCH)->get_radio_in());
+    SRV_Channels::set_output_pwm(SRV_Channel::k_tracker_pitch, rc().channel(CH_PITCH)->get_radio_in());
     SRV_Channels::constrain_pwm(SRV_Channel::k_tracker_pitch);
 }

--- a/ArduCopter/RC_Channel_Copter.h
+++ b/ArduCopter/RC_Channel_Copter.h
@@ -37,7 +37,13 @@ public:
 
     RC_Channel_Copter obj_channels[NUM_RC_CHANNELS];
     RC_Channel_Copter *channel(const uint8_t chan) override {
-        if (chan >= NUM_RC_CHANNELS) {
+        if (chan >= ARRAY_SIZE(obj_channels)) {
+            return nullptr;
+        }
+        return &obj_channels[chan];
+    }
+    const RC_Channel_Copter *channel(const uint8_t chan) const override {
+        if (chan >= ARRAY_SIZE(obj_channels)) {
             return nullptr;
         }
         return &obj_channels[chan];

--- a/ArduCopter/toy_mode.cpp
+++ b/ArduCopter/toy_mode.cpp
@@ -226,9 +226,21 @@ void ToyMode::update()
     bool power_button = false;
     bool left_change = false;
     
-    uint16_t ch5_in = RC_Channels::get_radio_in(CH_5);
-    uint16_t ch6_in = RC_Channels::get_radio_in(CH_6);
-    uint16_t ch7_in = RC_Channels::get_radio_in(CH_7);
+    uint16_t ch5_in = 0;
+    const auto *ch5 = rc().channel(CH_5);
+    if (ch5 != nullptr) {
+        ch5_in = ch5->get_radio_in();
+    }
+    uint16_t ch6_in = 0;
+    const auto *ch6 = rc().channel(CH_6);
+    if (ch6 != nullptr) {
+        ch6_in = ch6->get_radio_in();
+    }
+    uint16_t ch7_in = 0;
+    const auto *ch7 = rc().channel(CH_7);
+    if (ch7 != nullptr) {
+        ch7_in = ch7->get_radio_in();
+    }
 
     if (!rc().has_valid_input() || ch5_in < 900) {
         // failsafe handling is outside the scope of toy mode, it does
@@ -758,7 +770,7 @@ void ToyMode::trim_update(void)
     
     uint8_t need_trim = 0;
     for (uint8_t i=0; i<4; i++) {
-        RC_Channel *c = RC_Channels::rc_channel(i);
+        RC_Channel *c = rc().channel(i);
         if (c && abs(chan[i] - c->get_radio_trim()) > noise_limit) {
             need_trim |= 1U<<i;
         }
@@ -768,7 +780,7 @@ void ToyMode::trim_update(void)
     }
     for (uint8_t i=0; i<4; i++) {
         if (need_trim & (1U<<i)) {
-            RC_Channel *c = RC_Channels::rc_channel(i);
+            RC_Channel *c = rc().channel(i);
             c->set_and_save_radio_trim(chan[i]);
         }
     }

--- a/ArduPlane/RC_Channel_Plane.h
+++ b/ArduPlane/RC_Channel_Plane.h
@@ -38,7 +38,13 @@ public:
 
     RC_Channel_Plane obj_channels[NUM_RC_CHANNELS];
     RC_Channel_Plane *channel(const uint8_t chan) override {
-        if (chan >= NUM_RC_CHANNELS) {
+        if (chan >= ARRAY_SIZE(obj_channels)) {
+            return nullptr;
+        }
+        return &obj_channels[chan];
+    }
+    const RC_Channel_Plane *channel(const uint8_t chan) const override{
+        if (chan >= ARRAY_SIZE(obj_channels)) {
             return nullptr;
         }
         return &obj_channels[chan];

--- a/ArduSub/RC_Channel_Sub.h
+++ b/ArduSub/RC_Channel_Sub.h
@@ -28,7 +28,13 @@ public:
     bool arming_check_throttle() const override;
     RC_Channel_Sub obj_channels[NUM_RC_CHANNELS];
     RC_Channel_Sub *channel(const uint8_t chan) override {
-        if (chan >= NUM_RC_CHANNELS) {
+        if (chan >= ARRAY_SIZE(obj_channels)) {
+            return nullptr;
+        }
+        return &obj_channels[chan];
+    }
+    const RC_Channel_Sub *channel(const uint8_t chan) const override {
+        if (chan >= ARRAY_SIZE(obj_channels)) {
             return nullptr;
         }
         return &obj_channels[chan];
@@ -60,7 +66,13 @@ public:
 
     RC_Channel_Sub obj_channels[NUM_RC_CHANNELS];
     RC_Channel_Sub *channel(const uint8_t chan) override {
-        if (chan >= NUM_RC_CHANNELS) {
+        if (chan >= ARRAY_SIZE(obj_channels)) {
+            return nullptr;
+        }
+        return &obj_channels[chan];
+    }
+    const RC_Channel_Sub *channel(const uint8_t chan) const override {
+        if (chan >= ARRAY_SIZE(obj_channels)) {
             return nullptr;
         }
         return &obj_channels[chan];

--- a/Blimp/RC_Channel_Blimp.h
+++ b/Blimp/RC_Channel_Blimp.h
@@ -37,7 +37,13 @@ public:
     RC_Channel_Blimp obj_channels[NUM_RC_CHANNELS];
     RC_Channel_Blimp *channel(const uint8_t chan) override
     {
-        if (chan >= NUM_RC_CHANNELS) {
+        if (chan >= ARRAY_SIZE(obj_channels)) {
+            return nullptr;
+        }
+        return &obj_channels[chan];
+    }
+    const RC_Channel_Blimp *channel(const uint8_t chan) const override {
+        if (chan >= ARRAY_SIZE(obj_channels)) {
             return nullptr;
         }
         return &obj_channels[chan];

--- a/Rover/RC_Channel_Rover.h
+++ b/Rover/RC_Channel_Rover.h
@@ -40,7 +40,13 @@ public:
     RC_Channel_Rover obj_channels[NUM_RC_CHANNELS];
 
     RC_Channel_Rover *channel(const uint8_t chan) override {
-        if (chan >= NUM_RC_CHANNELS) {
+        if (chan >= ARRAY_SIZE(obj_channels)) {
+            return nullptr;
+        }
+        return &obj_channels[chan];
+    }
+    const RC_Channel_Rover *channel(const uint8_t chan) const override {
+        if (chan >= ARRAY_SIZE(obj_channels)) {
             return nullptr;
         }
         return &obj_channels[chan];

--- a/libraries/AC_PID/examples/AC_PID_test/AC_PID_test.cpp
+++ b/libraries/AC_PID/examples/AC_PID_test/AC_PID_test.cpp
@@ -27,6 +27,9 @@ class RC_Channel_PIDTest : public RC_Channel
 class RC_Channels_PIDTest : public RC_Channels
 {
 public:
+    const RC_Channel *channel(uint8_t chan) const override {
+        return &obj_channels[chan];
+    }
     RC_Channel *channel(uint8_t chan) override {
         return &obj_channels[chan];
     }

--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -563,8 +563,8 @@ bool AP_DDS_Client::update_topic(ardupilot_msgs_msg_Rc& msg)
     msg.active_overrides_size = msg.channels_size;
     if (msg.channels_size) {
         for (uint8_t i = 0; i < static_cast<uint8_t>(msg.channels_size); i++) {
-            msg.channels[i] = rc->rc_channel(i)->get_radio_in();
-            msg.active_overrides[i] = rc->rc_channel(i)->has_override();
+            msg.channels[i] = rc->channel(i)->get_radio_in();
+            msg.active_overrides[i] = rc->channel(i)->has_override();
         }
     } else {
         // If no channels are available, the RC is disconnected.

--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -546,7 +546,7 @@ void AP_OSD::update_current_screen()
     }
 
 #if AP_RC_CHANNEL_ENABLED
-    RC_Channel *channel = RC_Channels::rc_channel(rc_channel-1);
+    RC_Channel *channel = rc().channel(rc_channel-1);
     if (channel == nullptr) {
         return;
     }

--- a/libraries/AP_RCProtocol/examples/RCProtocolDecoder/RCProtocolDecoder.cpp
+++ b/libraries/AP_RCProtocol/examples/RCProtocolDecoder/RCProtocolDecoder.cpp
@@ -58,6 +58,9 @@ class RC_Channel_RC : public RC_Channel
 class RC_Channels_RC : public RC_Channels
 {
 public:
+    const RC_Channel *channel(uint8_t chan) const override {
+        return &obj_channels[chan];
+    }
     RC_Channel *channel(uint8_t chan) override {
         return &obj_channels[chan];
     }

--- a/libraries/AP_RCProtocol/examples/RCProtocolTest/RCProtocolTest.cpp
+++ b/libraries/AP_RCProtocol/examples/RCProtocolTest/RCProtocolTest.cpp
@@ -40,6 +40,12 @@ class RC_Channels_Example : public RC_Channels
 public:
     RC_Channel_Example obj_channels[NUM_RC_CHANNELS];
 
+    const RC_Channel_Example *channel(const uint8_t chan) const override {
+        if (chan >= NUM_RC_CHANNELS) {
+            return nullptr;
+        }
+        return &obj_channels[chan];
+    }
     RC_Channel_Example *channel(const uint8_t chan) override {
         if (chan >= NUM_RC_CHANNELS) {
             return nullptr;

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -604,6 +604,7 @@ public:
     // this function is implemented in the child class in the vehicle
     // code
     virtual RC_Channel *channel(uint8_t chan) = 0;
+    virtual const RC_Channel *channel(uint8_t chan) const = 0;
     // helper used by scripting to convert the above function from 0 to 1 indexeing
     // range is checked correctly by the underlying channel function
     RC_Channel *lua_rc_channel(const uint8_t chan) {
@@ -740,12 +741,19 @@ public:
     uint32_t get_fs_timeout_ms() const { return MAX(_fs_timeout * 1000, 100); }
 
     // methods which return RC input channels used for various axes.
-    RC_Channel &get_roll_channel() const;
-    RC_Channel &get_pitch_channel() const;
-    RC_Channel &get_yaw_channel() const;
-    RC_Channel &get_throttle_channel() const;
-    RC_Channel &get_forward_channel() const;
-    RC_Channel &get_lateral_channel() const;
+    const RC_Channel &get_roll_channel() const;
+    const RC_Channel &get_pitch_channel() const;
+    const RC_Channel &get_yaw_channel() const;
+    const RC_Channel &get_throttle_channel() const;
+    const RC_Channel &get_forward_channel() const;
+    const RC_Channel &get_lateral_channel() const;
+
+    RC_Channel &get_roll_channel();
+    RC_Channel &get_pitch_channel();
+    RC_Channel &get_yaw_channel();
+    RC_Channel &get_throttle_channel();
+    RC_Channel &get_forward_channel();
+    RC_Channel &get_lateral_channel();
 
     bool seen_neutral_rudder() const { return have_seen_neutral_rudder; }
 
@@ -774,7 +782,8 @@ private:
     // set to true if we see overrides or other RC input
     bool _has_ever_seen_rc_input;
 
-    RC_Channel *flight_mode_channel() const;
+    RC_Channel *flight_mode_channel();
+    const RC_Channel *flight_mode_channel() const;
 
     // Allow override by default at start
     bool _gcs_overrides_enabled = true;
@@ -791,7 +800,8 @@ private:
     void set_aux_cached(RC_Channel::AUX_FUNC aux_fn, RC_Channel::AuxSwitchPos pos);
 #endif
 
-    RC_Channel &get_rcmap_channel_nonnull(uint8_t rcmap_number) const;
+    const RC_Channel &get_rcmap_channel_nonnull(uint8_t rcmap_number) const;
+    RC_Channel &get_rcmap_channel_nonnull(uint8_t rcmap_number);
 
     // time that rudder arming has been running
     uint32_t rudder_arm_timer;

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -601,19 +601,6 @@ public:
 
     static const struct AP_Param::GroupInfo var_info[];
 
-    // compatability functions for Plane:
-    static uint16_t get_radio_in(const uint8_t chan) {
-        RC_Channel *c = _singleton->channel(chan);
-        if (c == nullptr) {
-            return 0;
-        }
-        return c->get_radio_in();
-    }
-    static RC_Channel *rc_channel(const uint8_t chan) {
-        return _singleton->channel(chan);
-    }
-    //end compatability functions for Plane
-
     // this function is implemented in the child class in the vehicle
     // code
     virtual RC_Channel *channel(uint8_t chan) = 0;
@@ -724,7 +711,7 @@ public:
     // method for other parts of the system (e.g. Button and mavlink)
     // to trigger auxiliary functions
     bool run_aux_function(RC_Channel::AUX_FUNC ch_option, RC_Channel::AuxSwitchPos pos, RC_Channel::AuxFuncTrigger::Source source, uint16_t source_index) {
-        return rc_channel(0)->run_aux_function(ch_option, pos, source, source_index);
+        return channel(0)->run_aux_function(ch_option, pos, source, source_index);
     }
 
     // check if flight mode channel is assigned RC option

--- a/libraries/RC_Channel/RC_Channels.cpp
+++ b/libraries/RC_Channel/RC_Channels.cpp
@@ -208,7 +208,7 @@ void RC_Channels::init_aux_all()
 //
 // Support for mode switches
 //
-RC_Channel *RC_Channels::flight_mode_channel() const
+RC_Channel *RC_Channels::flight_mode_channel()
 {
     const int8_t num = flight_mode_channel_number();
     if (num <= 0) {
@@ -217,7 +217,16 @@ RC_Channel *RC_Channels::flight_mode_channel() const
     if (num >= NUM_RC_CHANNELS) {
         return nullptr;
     }
-    return rc_channel(num-1);
+    return channel(num-1);
+}
+const RC_Channel *RC_Channels::flight_mode_channel() const
+{
+    const int8_t num = flight_mode_channel_number();
+    if (num <= 0) {
+        // avoid integer underflow on e.g. -1
+        return nullptr;
+    }
+    return channel(num-1);
 }
 
 void RC_Channels::reset_mode_switch()
@@ -246,7 +255,7 @@ void RC_Channels::read_mode_switch()
 // return true if assigned
 bool RC_Channels::flight_mode_channel_conflicts_with_rc_option() const
 {
-    RC_Channel *chan = flight_mode_channel();
+    const RC_Channel *chan = flight_mode_channel();
     if (chan == nullptr) {
         return false;
     }
@@ -260,7 +269,7 @@ bool RC_Channels::flight_mode_channel_conflicts_with_rc_option() const
 */
 bool RC_Channels::get_pwm(uint8_t c, uint16_t &pwm) const
 {
-    RC_Channel *chan = rc_channel(c-1);
+    const RC_Channel *chan = channel(c-1);
     if (chan == nullptr) {
         return false;
     }
@@ -328,35 +337,67 @@ void RC_Channels::set_aux_cached(RC_Channel::AUX_FUNC aux_fn, RC_Channel::AuxSwi
 // invalid option has been chosen somehow then the returned channel
 // will be a dummy channel.
 static RC_Channel dummy_rcchannel;
-RC_Channel &RC_Channels::get_rcmap_channel_nonnull(uint8_t rcmap_number) const
+const RC_Channel &RC_Channels::get_rcmap_channel_nonnull(uint8_t rcmap_number) const
 {
-    RC_Channel *ret = RC_Channels::rc_channel(rcmap_number-1);
+    const RC_Channel *ret = channel(rcmap_number-1);
     if (ret != nullptr) {
         return *ret;
     }
     return dummy_rcchannel;
 }
-RC_Channel &RC_Channels::get_roll_channel() const
+RC_Channel &RC_Channels::get_rcmap_channel_nonnull(uint8_t rcmap_number)
+{
+    RC_Channel *ret = channel(rcmap_number-1);
+    if (ret != nullptr) {
+        return *ret;
+    }
+    return dummy_rcchannel;
+}
+const RC_Channel &RC_Channels::get_roll_channel() const
 {
     return get_rcmap_channel_nonnull(AP::rcmap()->roll());
 };
-RC_Channel &RC_Channels::get_pitch_channel() const
+RC_Channel &RC_Channels::get_roll_channel()
+{
+    return get_rcmap_channel_nonnull(AP::rcmap()->roll());
+};
+const RC_Channel &RC_Channels::get_pitch_channel() const
 {
     return get_rcmap_channel_nonnull(AP::rcmap()->pitch());
 };
-RC_Channel &RC_Channels::get_throttle_channel() const
+RC_Channel &RC_Channels::get_pitch_channel()
+{
+    return get_rcmap_channel_nonnull(AP::rcmap()->pitch());
+};
+const RC_Channel &RC_Channels::get_throttle_channel() const
 {
     return get_rcmap_channel_nonnull(AP::rcmap()->throttle());
 };
-RC_Channel &RC_Channels::get_yaw_channel() const
+RC_Channel &RC_Channels::get_throttle_channel()
+{
+    return get_rcmap_channel_nonnull(AP::rcmap()->throttle());
+};
+const RC_Channel &RC_Channels::get_yaw_channel() const
 {
     return get_rcmap_channel_nonnull(AP::rcmap()->yaw());
 };
-RC_Channel &RC_Channels::get_forward_channel() const
+RC_Channel &RC_Channels::get_yaw_channel()
+{
+    return get_rcmap_channel_nonnull(AP::rcmap()->yaw());
+};
+const RC_Channel &RC_Channels::get_forward_channel() const
 {
     return get_rcmap_channel_nonnull(AP::rcmap()->forward());
 };
-RC_Channel &RC_Channels::get_lateral_channel() const
+RC_Channel &RC_Channels::get_forward_channel()
+{
+    return get_rcmap_channel_nonnull(AP::rcmap()->forward());
+};
+const RC_Channel &RC_Channels::get_lateral_channel() const
+{
+    return get_rcmap_channel_nonnull(AP::rcmap()->lateral());
+};
+RC_Channel &RC_Channels::get_lateral_channel()
 {
     return get_rcmap_channel_nonnull(AP::rcmap()->lateral());
 };

--- a/libraries/RC_Channel/examples/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/examples/RC_Channel/RC_Channel.cpp
@@ -28,6 +28,12 @@ public:
 
     RC_Channel_Example obj_channels[NUM_RC_CHANNELS];
 
+    const RC_Channel_Example *channel(const uint8_t chan) const override {
+        if (chan >= NUM_RC_CHANNELS) {
+            return nullptr;
+        }
+        return &obj_channels[chan];
+    }
     RC_Channel_Example *channel(const uint8_t chan) override {
         if (chan >= NUM_RC_CHANNELS) {
             return nullptr;


### PR DESCRIPTION
### Summary

Remove static RC channels methods which duplicate non-static methods

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  -24                               *                                                   
Durandal                            48              40     *           40      40                40     40     40
Hitec-Airspeed           *                                 *                                                   
KakuteH7-bdshot                     56              40     *           40      40                40     40     40
MatekF405                           48              40     *           40      40                40     40     40
MatekH7A3                           48              40     *           40      40                40     40     40
Pixhawk1-1M-bdshot                  48              40                 40      40                40     40     40
SITL_x86_64_linux_gnu               56              4152               56      56                48     56     48
YJUAV_A6SE                          56              40     *           40      40                40     40     40
f103-QiotekPeriph        *                                 *                                                   
f303-MatekGPS            *                                 *                                                   
f303-Universal           *                                 *                                                   
iomcu                                                                                *                         
mindpx-v2                           48              40     *           40      40                40     40     40
revo-mini                           48              40     *           40      40                40     40     40
skyviper-v2450                                                         56                                      
speedybeef4                         48              40     *           40      40                40     40     40
```

I've flashed this onto an mRoPixracerPro running Plane and RC continues to function.

### Description

We kept these methods around for Plane to use many years back.  Various other places sneakily still used them too, creeping in after they were supposed to not be used any more!

Had to make a whole bunch of non-const methods because the static methods lost the const-correctness being relied on in a few places.
