### PR TITLE
AP_NavEKF3: getLLH falls back to GPS only if pos source GPS

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -11623,6 +11623,53 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             raise NotAchievedException("Changed to ALT_HOLD with no altitude estimate")
         self.disarm_vehicle(force=True)
 
+    def EK3_NoGPSLeakWhenNotSource(self):
+        '''verify EKF does not leak GPS position when GPS is not the configured source'''
+        # With EKF configured to use optical flow (POSXY source is
+        # not GPS) and GPS simultaneously healthy, verify the
+        # reported vehicle position does not track a simulated GPS
+        # glitch.  On master, NavEKF3_core::getGPSLLH() returns the
+        # raw GPS fix irrespective of the configured POSXY source,
+        # so getLLH() fallbacks leak the glitched GPS lat/lon to
+        # callers (including GCS_MAVLINK::send_global_position_int
+        # which ignores the return value of ahrs.get_location()).
+        # This bypasses the EKF's source configuration and causes
+        # vehicle code to follow GPS glitches/spoofing that the EKF
+        # has correctly rejected.
+        self.set_parameters({
+            "EK3_SRC1_POSXY": 5,   # OPTFLOW (no optflow data provided)
+            "EK3_SRC1_VELXY": 5,   # OPTFLOW
+            "EK3_SRC1_POSZ": 1,    # BARO
+            "EK3_SRC1_VELZ": 0,    # None
+            "AHRS_EKF_TYPE": 3,
+        })
+        self.reboot_sitl()
+
+        # allow EKF to initialise: validOrigin set from GPS, filter
+        # reaches steady AID_NONE state
+        self.wait_statustext("EKF3 IMU0 initialised", timeout=30)
+
+        # capture baseline reported position
+        m = self.assert_receive_message('GLOBAL_POSITION_INT')
+        baseline_lat = m.lat
+        baseline_lon = m.lon
+        self.progress("Baseline: lat=%d lon=%d" % (baseline_lat, baseline_lon))
+
+        # glitch simulated GPS by ~0.005 deg latitude (~555 m north)
+        self.set_parameter("SIM_GPS1_GLTCH_X", 0.005)
+
+        m = self.assert_receive_message('GLOBAL_POSITION_INT')
+        lat_change_deg = abs(m.lat - baseline_lat) * 1e-7
+        self.progress("After GPS glitch: lat=%d lon=%d (baseline lat=%d, change=%.6f deg)" %
+                      (m.lat, m.lon, baseline_lat, lat_change_deg))
+
+        if lat_change_deg > 0.001:
+            raise NotAchievedException(
+                "GPS position leaked into reported location despite "
+                "EK3_SRC1_POSXY=OPTFLOW: baseline lat %d, after glitch %d "
+                "(delta %.6f deg)" %
+                (baseline_lat, m.lat, lat_change_deg))
+
     def EKFSource(self):
         '''Check EKF Source Prearms work'''
         self.wait_ready_to_arm()
@@ -16608,6 +16655,7 @@ return update, 1000
             self.CRSF,
             self.MotorTest,
             self.AltEstimation,
+            self.EK3_NoGPSLeakWhenNotSource,
             self.EKFSource,
             self.GSF,
             self.GSF_reset,

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -328,12 +328,13 @@ bool NavEKF3_core::getHAGL(float &HAGL) const
 }
 
 // Return the last calculated latitude, longitude and height in WGS-84
-// If a calculated location isn't available, return a raw GPS measurement
+// If a calculated location isn't available and position source is GPS, return a raw GPS measurement
 // The status will return true if a calculation or raw measurement is available
 // The getFilterStatus() function provides a more detailed description of data health and must be checked if data is to be used for flight control
 bool NavEKF3_core::getLLH(Location &loc) const
 {
     Location origin;
+    const bool pos_from_GPS = (frontend->sources.getPosXYSource(core_index) == AP_NavEKF_Source::SourceXY::GPS);
     if (getOriginLLH(origin)) {
         postype_t posD;
         if (getPosD_local(posD) && PV_AidingMode != AID_NONE) {
@@ -348,7 +349,7 @@ bool NavEKF3_core::getLLH(Location &loc) const
                 return true;
             } else {
                 // We have been be doing inertial dead reckoning for too long so use raw GPS if available
-                if (getGPSLLH(loc)) {
+                if (pos_from_GPS && getGPSLLH(loc)) {
                     return true;
                 } else {
                     // Return the EKF estimate but mark it as invalid
@@ -361,7 +362,7 @@ bool NavEKF3_core::getLLH(Location &loc) const
             }
         } else {
             // Return a raw GPS reading if available and the last recorded positon if not
-            if (getGPSLLH(loc)) {
+            if (pos_from_GPS && getGPSLLH(loc)) {
                 return true;
             } else {
                 loc.lat = EKF_origin.lat;
@@ -374,7 +375,7 @@ bool NavEKF3_core::getLLH(Location &loc) const
         }
     } else {
         // The EKF is not navigating so use raw GPS if available
-        return getGPSLLH(loc);
+        return pos_from_GPS && getGPSLLH(loc);
     }
 }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -215,7 +215,7 @@ public:
     bool getMagOffsets(uint8_t mag_idx, Vector3f &magOffsets) const;
 
     // Return the last calculated latitude, longitude and height in WGS-84
-    // If a calculated location isn't available, return a raw GPS measurement
+    // If a calculated location isn't available and position source is GPS, return a raw GPS measurement
     // The status will return true if a calculation or raw measurement is available
     // The getFilterStatus() function provides a more detailed description of data health and must be checked if data is to be used for flight control
     bool getLLH(Location &loc) const;


### PR DESCRIPTION
### Summary

This is an alternative implementation of @andyp1per's PR https://github.com/ArduPilot/ardupilot/pull/32769

This modifies the EKF3 so that the getLLH method (called by AP_AHRS's get_location method) only falls back to the GPS position if the EKF source set is using the GPS (e.g. EK3_SRCx_POSXY = 3/GPS).  The practical impact of this is that the vehicle's position on the map remains at the last known position estimated by the EKF instead of jumping to wherever the GPS happens to be.

I suppose this is good for non-GPS navigation where the non-GPS method (e.g. optical flow, external nav) has temporarily failed and the attached GPS cannot be trusted.  In this situation the vehicle's position on the map would jump to the GPS's location but it might be more accurate to remain at the last-known-good EKF position until the non-GPS navigation method recovers.

This has been lightly tested in SITL by doing the following

- ./Tools/autotest/sim_vehicle.py --map --console
- param set RC6_OPTION 90 (EKF Pos Source)
- rc 6 1500 (to change to EK3_SRC2_xxx which **does not** use GPS)
- two vehicle will appear overlayed on the map (EKF estimate and GPS)
- arm the vehicle in stabilize and fly a short distance, note that only the GPS vehicle moves while the EKF vehicle stays at the home/origin
  - stabilize
  - arm throttle
  - rc 3 1600
  - rc 2 1200
  - rc 3 1400
  - disarm
- rc 6 1000 (to change to use GPS) and EKF vehicle jumps to GPS vehicle's location
<img width="876" height="1289" alt="testing-after" src="https://github.com/user-attachments/assets/a38bf8f1-a965-4ca9-bd25-955accc98b32" />

<img width="1212" height="1289" alt="testing-after" src="https://github.com/user-attachments/assets/837bfc4e-a9ce-43a8-810d-c7a95f6760d2" />

Repeat the above with master and note that the EKF vehicle always flies with the GPS vehicle.
<img width="876" height="1271" alt="testing-before" src="https://github.com/user-attachments/assets/79b36cdf-a1a0-4315-b4b2-86799a589499" />

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

