### PR TITLE
Rover: remove support for from-GCS MAV_CMD_NAV_SET_YAW_SPEED_ENABLED

### DIFF
--- a/Rover/GCS_MAVLink_Rover.cpp
+++ b/Rover/GCS_MAVLink_Rover.cpp
@@ -501,40 +501,10 @@ MAV_RESULT GCS_MAVLINK_Rover::handle_command_int_packet(const mavlink_command_in
         }
         return MAV_RESULT_FAILED;
 
-#if AP_MAVLINK_MAV_CMD_NAV_SET_YAW_SPEED_ENABLED
-    case MAV_CMD_NAV_SET_YAW_SPEED:
-        send_received_message_deprecation_warning("MAV_CMD_NAV_SET_YAW_SPEED");
-        return handle_command_nav_set_yaw_speed(packet, msg);
-#endif
-
     default:
         return GCS_MAVLINK::handle_command_int_packet(packet, msg);
     }
 }
-
-#if AP_MAVLINK_MAV_CMD_NAV_SET_YAW_SPEED_ENABLED
-MAV_RESULT GCS_MAVLINK_Rover::handle_command_nav_set_yaw_speed(const mavlink_command_int_t &packet, const mavlink_message_t &msg)
-{
-        // param1 : yaw angle (may be absolute or relative)
-        // param2 : Speed - in metres/second
-        // param3 : 0 = param1 is absolute, 1 = param1 is relative
-
-        // exit if vehicle is not in Guided mode
-        if (!rover.control_mode->in_guided_mode()) {
-            return MAV_RESULT_FAILED;
-        }
-
-        // get final angle, 1 = Relative, 0 = Absolute
-        if (packet.param3 > 0) {
-            // relative angle
-            rover.mode_guided.set_desired_heading_delta_and_speed(packet.param1 * 100.0f, packet.param2);
-        } else {
-            // absolute angle
-            rover.mode_guided.set_desired_heading_and_speed(packet.param1 * 100.0f, packet.param2);
-        }
-        return MAV_RESULT_ACCEPTED;
-}
-#endif
 
 MAV_RESULT GCS_MAVLINK_Rover::handle_command_int_do_reposition(const mavlink_command_int_t &packet)
 {

--- a/Rover/GCS_MAVLink_Rover.h
+++ b/Rover/GCS_MAVLink_Rover.h
@@ -2,11 +2,6 @@
 
 #include <GCS_MAVLink/GCS.h>
 
-  // set 0 in 4.6, remove feature in 4.7:
-#ifndef AP_MAVLINK_MAV_CMD_NAV_SET_YAW_SPEED_ENABLED
-#define AP_MAVLINK_MAV_CMD_NAV_SET_YAW_SPEED_ENABLED 0
-#endif
-
 #include "defines.h"
 
 class GCS_MAVLINK_Rover : public GCS_MAVLINK
@@ -20,7 +15,6 @@ protected:
     MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_int_t &packet, const mavlink_message_t &msg) override;
     MAV_RESULT handle_command_int_packet(const mavlink_command_int_t &packet, const mavlink_message_t &msg) override;
     MAV_RESULT handle_command_int_do_reposition(const mavlink_command_int_t &packet);
-    MAV_RESULT handle_command_nav_set_yaw_speed(const mavlink_command_int_t &packet, const mavlink_message_t &msg);
 
     bool get_target_location(Location &loc) const override;
 

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6283,65 +6283,6 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             self.wait_groundspeed(3, 100)
         self.disarm_vehicle()
 
-    def MAV_CMD_NAV_SET_YAW_SPEED(self):
-        '''tests for MAV_CMD_NAV_SET_YAW_SPEED guided-mode command'''
-        self.change_mode('GUIDED')
-        self.wait_ready_to_arm()
-        self.arm_vehicle()
-
-        for method in self.run_cmd, self.run_cmd_int:
-            self.change_mode('MANUAL')
-            self.wait_groundspeed(0, 1)
-            self.change_mode('GUIDED')
-            self.start_subtest("Absolute angles")
-            for (heading, speed) in (10, 5), (190, 10), (0, 2), (135, 6):
-                def cf(*args, **kwargs):
-                    method(
-                        mavutil.mavlink.MAV_CMD_NAV_SET_YAW_SPEED,
-                        p1=heading,
-                        p2=speed,
-                        p3=0,  # zero is absolute-angles
-                    )
-                self.wait_groundspeed(speed-0.5, speed+0.5, called_function=cf, minimum_duration=2)
-                self.wait_heading(heading-0.5, heading+0.5, called_function=cf, minimum_duration=2)
-
-            self.start_subtest("relative angles")
-            original_angle = 90
-            method(
-                mavutil.mavlink.MAV_CMD_NAV_SET_YAW_SPEED,
-                p1=original_angle,
-                p2=5,
-                p3=0,  # zero is absolute-angles
-            )
-            self.wait_groundspeed(4, 6)
-            self.wait_heading(original_angle-0.5, original_angle+0.5)
-
-            expected_angle = original_angle
-            for (angle_delta, speed) in (5, 6), (-30, 2), (180, 7):
-                method(
-                    mavutil.mavlink.MAV_CMD_NAV_SET_YAW_SPEED,
-                    p1=angle_delta,
-                    p2=speed,
-                    p3=1,  # one is relative-angles
-                )
-
-                def cf(*args, **kwargs):
-                    method(
-                        mavutil.mavlink.MAV_CMD_NAV_SET_YAW_SPEED,
-                        p1=0,
-                        p2=speed,
-                        p3=1,  # one is absolute-angles
-                    )
-                expected_angle += angle_delta
-                if expected_angle < 0:
-                    expected_angle += 360
-                if expected_angle > 360:
-                    expected_angle -= 360
-                self.wait_groundspeed(speed-0.5, speed+0.5, called_function=cf, minimum_duration=2)
-                self.wait_heading(expected_angle, called_function=cf, minimum_duration=2)
-        self.do_RTL()
-        self.disarm_vehicle()
-
     def _MAV_CMD_GET_HOME_POSITION(self, run_cmd):
         '''test handling of mavlink command MAV_CMD_GET_HOME_POSITION'''
         self.context_collect('HOME_POSITION')
@@ -7228,7 +7169,6 @@ return update()
             self.MAV_CMD_DO_SET_MISSION_CURRENT_looped_mission,
             self.MAV_CMD_DO_CHANGE_SPEED,
             self.MAV_CMD_MISSION_START,
-            self.MAV_CMD_NAV_SET_YAW_SPEED,
             self.Button,
             self.Rally,
             self.Offboard,
@@ -7313,7 +7253,6 @@ return update()
     def disabled_tests(self):
         return {
             "SlewRate": "got timing report failure on CI",
-            "MAV_CMD_NAV_SET_YAW_SPEED": "compiled out of code by default",
             "PolyFenceObjectAvoidanceBendyRuler": "unreliable",
         }
 


### PR DESCRIPTION
### Summary

Removes code for handling GCS MAV_CMD_NAV_SET_YAW_SPEED_ENABLED.  It was not compiled in by default.  Wasn't available on the custom build server.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board,rover
CubeOrangePlus,*
```


### Description

remove this per schedule. (ish)

Rover now supports better ways for a GCS to command the vehicle
