### PR TITLE
AP_DDS: add shared constant for frame conversion

### DIFF
--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -459,8 +459,7 @@ void AP_DDS_Client::update_topic(geometry_msgs_msg_PoseStamped& msg)
     Quaternion orientation;
     if (ahrs.get_quaternion(orientation)) {
         Quaternion aux(orientation[0], orientation[2], orientation[1], -orientation[3]); //NED to ENU transformation
-        Quaternion transformation (sqrtF(2) * 0.5,0,0,sqrtF(2) * 0.5); // Z axis 90 degree rotation
-        orientation = aux * transformation;
+        orientation = aux * FRAME_Z_ROTATION_90;
         msg.pose.orientation.w = orientation[0];
         msg.pose.orientation.x = orientation[1];
         msg.pose.orientation.y = orientation[2];
@@ -605,8 +604,7 @@ void AP_DDS_Client::update_topic(geographic_msgs_msg_GeoPoseStamped& msg)
     Quaternion orientation;
     if (ahrs.get_quaternion(orientation)) {
         Quaternion aux(orientation[0], orientation[2], orientation[1], -orientation[3]); //NED to ENU transformation
-        Quaternion transformation(sqrtF(2) * 0.5, 0, 0, sqrtF(2) * 0.5); // Z axis 90 degree rotation
-        orientation = aux * transformation;
+        orientation = aux * FRAME_Z_ROTATION_90;
         msg.pose.orientation.w = orientation[0];
         msg.pose.orientation.x = orientation[1];
         msg.pose.orientation.y = orientation[2];

--- a/libraries/AP_DDS/AP_DDS_Frames.h
+++ b/libraries/AP_DDS/AP_DDS_Frames.h
@@ -1,8 +1,14 @@
 #pragma once
 
+#include <AP_Math/rotations.h>
+#include <AP_Math/quaternion.h>
+
 static constexpr char WGS_84_FRAME_ID[] = "WGS-84";
 // https://www.ros.org/reps/rep-0105.html#base-link
 static constexpr char BASE_LINK_FRAME_ID[] = "base_link";
 static constexpr char BASE_LINK_NED_FRAME_ID[] = "base_link_ned";
 // https://www.ros.org/reps/rep-0105.html#map
 static constexpr char MAP_FRAME[] = "map";
+
+// Z-axis 90° rotation: (w=√2/2, x=0, y=0, z=√2/2), ROS REP-103 NED→ENU
+static const Quaternion FRAME_Z_ROTATION_90 {HALF_SQRT_2, 0.0f, 0.0f, HALF_SQRT_2};


### PR DESCRIPTION
### Summary

This PR adds a shared quaternion constant for a +90 degree rotation about the Z axis. The constant is used in AP_DDS frame conversions between ArduPilot and ROS 2, improving code reuse and consistency.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description
It introduces a `static const Quaternion FRAME_Z_ROTATION_90 {HALF_SQRT_2, 0.0f, 0.0f, HALF_SQRT_2};` in `AP_DDS_Frames.h`. 

This replaces the duplicated local quaternion definition in `AP_DDS_Client.cpp` and can also be reused by upcoming conversion logic in `AP_DDS_ExternalControl.cpp`.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
