### PR TITLE
hwdef: regularise markdown headings

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/AEDROXH7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/AEDROXH7/README.md
@@ -44,7 +44,7 @@ Onboard OSD using OSD_TYPE 1 (MAX7456 driver) is supported by default. Simultane
 
 The SH1.0-6P connector supports a DJI Air Unit / HD VTX connection. Protocol defaults to DisplayPort. Pin 1 of the connector is 10v so be careful not to connect this to a peripheral requiring 5v. DisplayPort OSD is enabled by default on SERIAL8.
 
-## VTX power control
+## VTX Power Control
 
 GPIO 83 controls the VTX BEC output to pins marked "12V" and is included on the HD VTX connector. Setting this GPIO low removes voltage supply to this pin/pad. By default RELAY3 is configured to control this pin and sets the GPIO high.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ARK_FPV/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ARK_FPV/README.md
@@ -238,7 +238,7 @@ This autopilot has a built-in compass. The compass is the IIS2MDC
 
 This flight controller has an MSP-DisplayPort output on a 6-pin DJI-compatible JST SH.
 
-## Motor Output
+## PWM Output
 
 All outputs are capable of PWM and DShot. Motors 1-4 are capable of Bidirectional-DSHOT. All outputs in the motor groups below must be either PWM or DShot:
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ARK_PI6X/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ARK_PI6X/README.md
@@ -163,7 +163,7 @@ The default battery parameters are:
 
 This autopilot has a built-in compass. The compass is the IIS2MDC. Often this internal compass is disabled due to power interference and a remotely located compass is used.
 
-## Motor Output
+## PWM Output
 
 All outputs are capable of PWM and DShot. Motors 1-4 are configured as Bidirectional-DSHOT by default. All outputs in the motor groups below must be either PWM or DShot:
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ATOMRCF405NAVI-Deluxe/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ATOMRCF405NAVI-Deluxe/README.md
@@ -51,7 +51,7 @@ the above image and some content courtesy of [ATOMRC](http://atomrc.com/)
 
 tbd
 
-## Default UART order
+## UART Mapping
 
 - SERIAL0 = console = USB
 - SERIAL1 = RF Module = USART1(MAVLink2), not usable by AP GCS
@@ -87,7 +87,7 @@ The SBUS pin, is passed by an inverter to RX2 (UART2 RX). UART2 is defaulted to 
 
 > **Note:** the 5v pin above the SBUS pin is powered when USB is connected. All other 5V pins are only powered when battery is present.
 
-## Battery Monitor Configuration
+## Battery Monitoring
 
 These settings are set as defaults when the firmware is loaded (except `BATT_AMP_PERVLT` which needs to be changed from the default value). However, if they are ever lost, you can manually set the parameters:
 
@@ -102,7 +102,7 @@ Enable Battery monitor with `BATT_MONITOR=4`, then reboot, then set:
 
 This board does not include a GPS or compass. But a connector is provided to attach an external module.
 
-## OSD
+## OSD Support
 
 The internal analog OSD is enabled by default. Simultaneous use of HD VTX with OSD (DisplayPort) is also enabled by default via the 6 pin connector labeled "DJI". Either 9V (default) or 12V VTX power can be selected by solder jumper.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/Aeromind6X/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Aeromind6X/README.md
@@ -118,7 +118,7 @@ RC input supports SBUS, PPM, and DSM protocols with dedicated ports available fo
 
 ---
 
-## PWM Outputs
+## PWM Output
 
 Supports up to **16 PWM outputs**:
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/Airvolute-DCS2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Airvolute-DCS2/README.md
@@ -5,7 +5,7 @@ This system usually uses a "CUBE" autopilot as its primary FMU, but can use an o
 For more information on DCS2.Pilot board see:
 [Airvolute documentation](https://docs.airvolute.com/dronecore-autopilot/dcs2)
 
-## Where To Buy
+## Where to Buy
 
 info@airvolute.com
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/AnyleafH7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/AnyleafH7/README.md
@@ -65,7 +65,7 @@ SBUS on the DJI connector may be used if SERIAL5_PROTOCOL is changed to 0 and SE
 
 This flight controller has an MSP-DisplayPort output on a 6-pin DJI-compatible JST SH port re-configured.
 
-## Motor Output
+## PWM Output
 
 Motor 1-8 is capable of bidirectional DSHOT and PWM.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BOTWINGF405/Readme.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BOTWINGF405/Readme.md
@@ -89,7 +89,7 @@ Any UART can be used for RC system connections in ArduPilot also, and is compati
 
 The BOTWINGF405 includes an internal AT7456E OSD enabled for analog video. Simultaneous DisplayPort operation is enabled by default on UART3
 
-## PWM Outputs
+## PWM Output
 
 All motor/servo outputs are Dshot and PWM capable. M1-4 are also BDshot capable. However, mixing Dshot, serial LED, and normal PWM operation for outputs is restricted into groups, ie. enabling Dshot for an output in a group requires that ALL outputs in that group be configured and used as Dshot, rather than PWM outputs.
 
@@ -117,7 +117,7 @@ There is no onboard compass. External compass modules can be connected via I2C (
 
 GPIO81 controls 9V video BEC output. Set GPIO high to enable 9V for connected devices. RELAY1 is configured by default to control this GPIO.
 
-## GPIO
+## GPIOs
 
 The PIO pad is setup as a user GPIO (GPIO82) by default, controlled by RELAY2.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BROTHERHOBBYH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BROTHERHOBBYH743/README.md
@@ -89,12 +89,12 @@ The default battery parameters are:
 
 The BROTHERHOBBYH743 does not have a built-in compass, but you can attach an external compass using I2C on the SDA and SCL connector.
 
-## VTX power control
+## VTX Power Control
 
 GPIO 81 controls the VTX BEC output to pins marked "10V". Setting this GPIO low removes voltage supply to pins.
 By default RELAY2 is configured to control this pin and sets the GPIO high.
 
-## Camera control
+## Camera Control
 
 GPIO 82 controls the camera output to the connectors marked "CAM1" and "CAM2". Setting this GPIO high switches the video output from CAM1 to CAM2. By default RELAY3 is configured to control this pin and sets the GPIO low.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BrahmaF4/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BrahmaF4/README.md
@@ -47,7 +47,7 @@ The UARTs are marked Rx and Tx in the above pinouts.
 
 Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM. See Radio Control Systems for details.
 
-## OSD
+## OSD Support
 
 - ANALOG OSD (MAX7456) (SPI1) (Preconfigured)
 - DIGITAL OSD (MSP)    (UART4 can be used for MSP Displayport by changing [SERIAL4_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial4-protocol-serial4-protocol-selection) to "42")

--- a/libraries/AP_HAL_ChibiOS/hwdef/CSKY405/Readme.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CSKY405/Readme.md
@@ -84,7 +84,7 @@ The correct battery setting parameters are set by default and are:
 
 The CSKY405 does not have a built-in compass, but you can attach an external compass using I2C on the SDA and SCL pads.
 
-## VTX power control
+## VTX Power Control
 
 GPIO 84 controls the VTX BEC output to pins marked "12V". Setting this GPIO high removes voltage supply to pins.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CUAV-7-Nano/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CUAV-7-Nano/README.md
@@ -62,7 +62,7 @@ The board has a dedicated power monitor ports on 6 pin connectors(POWER A). The 
 
 The CUAV-7-Nano has an IST8310 builtin compass, but due to interference the board is usually used with an external I2C compass as part of a GPS/Compass combination.
 
-## Analog inputs
+## Analog Inputs
 
 The CUAV-7-Nano has 6 analog inputs.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CUAV-V6X-v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CUAV-V6X-v2/README.md
@@ -111,7 +111,7 @@ The numbering of the GPIOs for PIN variables in ArduPilot is:
 - MAIN(7) 107
 - MAIN(8) 108
 
-## Analog inputs
+## Analog Inputs
 
 The CUAV-V6X-v2 has 3 analog inputs
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CUAV-X25-EVO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CUAV-X25-EVO/README.md
@@ -82,7 +82,7 @@ The CUAV-X25-EVO has an RM3100 builtin compass. If interference is experienced f
 
 The CUAV-X25-EVO has 3 IMUs. one IIM42652 with an external crystal oscillator and two IIM42653. All these IMUs have heater.
 
-## Analog inputs
+## Analog Inputs
 
 The CUAV-X25-EVO has 3 analog inputs.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CUAVv5-bdshot/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CUAVv5-bdshot/README.md
@@ -103,7 +103,7 @@ The numbering of the GPIOs for PIN variables in ArduPilot is:
 - AUX5 54
 - AUX6 55
 
-## Analog inputs
+## Analog Inputs
 
 The CUAVv5 has 7 analog inputs
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CUAVv5/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CUAVv5/README.md
@@ -103,7 +103,7 @@ The numbering of the GPIOs for PIN variables in ArduPilot is:
 - AUX5 54
 - AUX6 55
 
-## Analog inputs
+## Analog Inputs
 
 The CUAVv5 has 7 analog inputs
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack/README.md
@@ -267,7 +267,7 @@ The numbering of the GPIOs for PIN variables in ArduPilot is:
 - PWM5 54
 - PWM6 55
 
-## Analog inputs
+## Analog Inputs
 
 The CubeBlack has 7 analog inputs
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/README.md
@@ -271,7 +271,7 @@ The numbering of the GPIOs for PIN variables in ArduPilot is:
 - EXTERN_GPIO1 1 (requires custom carrier board, and alternate pin configuration 2)
 - EXTERN_GPIO2 2 (requires custom carrier board, and alternate pin configuration 2)
 
-## Analog inputs
+## Analog Inputs
 
 The CubeOrange has 7 analog inputs
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrangePlus-ODID/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrangePlus-ODID/README.md
@@ -271,7 +271,7 @@ The numbering of the GPIOs for PIN variables in ArduPilot is:
 - EXTERN_GPIO1 1 (requires custom carrier board, and alternate pin configuration 2)
 - EXTERN_GPIO2 2 (requires custom carrier board, and alternate pin configuration 2)
 
-## Analog inputs
+## Analog Inputs
 
 The CubeOrangePlus has 7 analog inputs
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrangePlus/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrangePlus/README.md
@@ -269,7 +269,7 @@ The numbering of the GPIOs for PIN variables in ArduPilot is:
 - EXTERN_GPIO1 1 (requires custom carrier board, and alternate pin configuration 2)
 - EXTERN_GPIO2 2 (requires custom carrier board, and alternate pin configuration 2)
 
-## Analog inputs
+## Analog Inputs
 
 The CubeOrangePlus has 7 analog inputs
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVF405/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVF405/README.md
@@ -93,12 +93,12 @@ The correct battery setting parameters are:
 
 The DAKEFPV F405 does not have a builtin compass, but you can attach an external compass using I2C on the SDA and SCL pads.
 
-## VTX power control
+## VTX Power Control
 
 GPIO 81 controls the VTX BEC output to pins marked "12V". Setting this GPIO low removes voltage supply to pins.
 By default RELAY2 is configured to control this pin and sets the GPIO high on boot.
 
-## Camera control
+## Camera Control
 
 GPIO 82 controls the camera output to the connectors marked "CAM1" and "CAM2". Setting this GPIO low switches the video output from CAM1 to CAM2. By default RELAY3 is configured to control this pin and sets the GPIO high on boot.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743/README.md
@@ -103,7 +103,7 @@ The correct battery setting parameters are:
 
 The DAKEFPV H743 does not have a builtin compass, but you can attach an external compass using I2C on the SDA and SCL pads.
 
-## Camera control
+## Camera Control
 
 GPIO 81 controls the camera output to the connectors marked "CAM1" and "CAM2". Setting this GPIO low switches the video output from CAM1 to CAM2. By default RELAY1 is configured to control this pin and sets the GPIO high.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743Pro/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743Pro/README.md
@@ -112,7 +112,7 @@ The correct battery setting parameters are:
 
 The DAKEFPV H743 Pro does not have a builtin compass, but you can attach an external compass using I2C on the SDA and SCL pads.
 
-## Camera control
+## Camera Control
 
 GPIO 81 controls the camera output to the connectors marked "CAM1" and "CAM2". Setting this GPIO low switches the video output from CAM1 to CAM2. By default RELAY1 is configured to control this pin and sets the GPIO high.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743_SLIM/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743_SLIM/README.md
@@ -102,7 +102,7 @@ The correct battery setting parameters are:
 
 The DAKEFPV H743 SLIM does not have a builtin compass, but you can attach an external compass using I2C on the SDA and SCL pads.
 
-## Camera control
+## Camera Control
 
 GPIO 81 controls the camera output to the connectors marked "CAM1" and "CAM2". Setting this GPIO low switches the video output from CAM1 to CAM2. By default RELAY1 is configured to control this pin and sets the GPIO high.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/Durandal/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Durandal/README.md
@@ -239,7 +239,7 @@ The numbering of the GPIOs for PIN variables in ArduPilot is:
 - PWM7 56
 - PWM8 57
 
-## Analog inputs
+## Analog Inputs
 
 The Durandal has 7 analog inputs
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/F4BY_H743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/F4BY_H743/README.md
@@ -141,7 +141,7 @@ Group #4
 RCIN solder pad location for board version 3.0.3
 ![RCIN solder pad location](rcin_303.jpg "RCIN solder pad location ")
 
-## Battery Monitor
+## Battery Monitoring
 
 The board has a external current and voltage sensor input. The sensors range from 0v to +6.6V.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/FlysparkF4/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/FlysparkF4/README.md
@@ -115,13 +115,13 @@ ArduPilot automatically probes for **external I2C compasses** on I2C1.
 
 ---
 
-## Camera Control (CC) Output
+## Camera Control
 
 The **CC pin** is controlled as a standard GPIO via **RELAY2**.
 
 ---
 
-## OSD
+## OSD Support
 
 Analog OSD is supported via the internal **AT7456** chip.
 
@@ -129,7 +129,7 @@ Simultaneously, **DisplayPort HD OSD** is available by default via **UART1**,
 
 ---
 
-## RSSI Input
+## RSSI
 
 Analog RSSI input is supported through **RSSI_ANA_PIN = 15**.
 Connect your receiver’s analog RSSI output to this pad to enable RSSI display in OSD and telemetry.

--- a/libraries/AP_HAL_ChibiOS/hwdef/FlywooF405HD-AIOv2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/FlywooF405HD-AIOv2/README.md
@@ -102,7 +102,7 @@ The board includes a NeoPixel LED pad.
 
 9V/VTX state can be controlled using ArduPilot Relay, GPIO pin 81.
 
-## Loading Firmware (you will need to compile your own firmware)
+## Loading Firmware
 
 Initial firmware load can be done with DFU by plugging in USB with the
 bootloader button pressed. Then you should load the "with_bl.hex"

--- a/libraries/AP_HAL_ChibiOS/hwdef/FlywooF405Pro/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/FlywooF405Pro/README.md
@@ -85,7 +85,7 @@ The GOKU F405 Pro does not have a builtin compass but it does have an external I
 
 The board includes a NeoPixel LED pad.
 
-## Loading Firmware (you will need to compile your own firmware)
+## Loading Firmware
 
 Initial firmware load can be done with DFU by plugging in USB with the
 bootloader button pressed. Then you should load the "with_bl.hex"

--- a/libraries/AP_HAL_ChibiOS/hwdef/FlywooF405S-AIO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/FlywooF405S-AIO/README.md
@@ -92,7 +92,7 @@ The GOKU F405 AIO does not have a builtin compass but it does have an external I
 
 The board includes a NeoPixel LED pad.
 
-## Loading Firmware (you will need to compile your own firmware)
+## Loading Firmware
 
 Initial firmware load can be done with DFU by plugging in USB with the
 bootloader button pressed. Then you should load the "with_bl.hex"

--- a/libraries/AP_HAL_ChibiOS/hwdef/FlywooH743Pro/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/FlywooH743Pro/README.md
@@ -92,12 +92,12 @@ The correct battery setting parameters are:
 
 The Flywoo H743 Pro does not have a builtin compass, but you can attach an external compass using I2C on the SDA and SCL pads.
 
-## VTX power control
+## VTX Power Control
 
 GPIO 81 controls the VTX BEC output to pins marked "10V". Setting this GPIO low removes voltage supply to pins.
 By default RELAY2 is configured to control this pin and sets the GPIO high.
 
-## Camera control
+## Camera Control
 
 GPIO 82 controls the camera output to the connectors marked "CAM1" and "CAM2". Setting this GPIO low switches the video output from CAM1 to CAM2. By default RELAY3 is configured to control this pin and sets the GPIO high.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/HWH7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/HWH7/README.md
@@ -18,7 +18,7 @@ The **HWH7** is a flight controller designed and produced by HW.
 
 ![image](HWH7.png)
 
-## Serial Ports (UARTs)
+## UART Mapping
 
 Serial ordering (ArduPilot): `SERIAL0..SERIAL8` = `OTG1, USART1, USART2, USART3, UART4, UART5, USART6, UART7, UART8`
 
@@ -34,7 +34,7 @@ Serial ordering (ArduPilot): `SERIAL0..SERIAL8` = `OTG1, USART1, USART2, USART3,
 | UART7 | SERIAL7 | UART7 | PE8 | PE7 | User |
 | UART8 | SERIAL8 | UART8 | PE1 | PE0 | ESC Telemetry |
 
-## PWM Outputs
+## PWM Output
 
 The HWH7 supports up to 12 PWM or DShot outputs. These outputs are organized into 5 groups based on the MCU timers:
 
@@ -98,7 +98,7 @@ Because both signals share the same UART port on different pins, **simultaneous 
 - **To use telemetry from ESC 1:** Set `SERIAL8_OPTIONS` to `0` (default).
 - **To use telemetry from ESC 2:** Set `SERIAL8_OPTIONS` to `8` (SwapTXRX), which allows the flight controller to listen for telemetry on the TX8 pin.
 
-## OSD
+## OSD Support
 
 The HWH7 includes an integrated AT7456E analog OSD chip, accessible via the CAM1/2 and VTX pins. MSP DisplayPort OSD is also supported and enabled by default for use with digital video systems.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/IFLIGHT_2RAW_H7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/IFLIGHT_2RAW_H7/README.md
@@ -84,7 +84,7 @@ The correct battery setting parameters are:
 
 The iFlight 2RAW H743 does not have a builtin compass, but you can attach an external compass using I2C on the SDA and SCL pads.
 
-## VTX power control
+## VTX Power Control
 
 GPIO 81 controls the VTX BEC output to pins marked "10V". Setting this GPIO low removes voltage supply to pins.
 By default RELAY2 is configured to control this pin and sets the GPIO high.

--- a/libraries/AP_HAL_ChibiOS/hwdef/JFB100/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/JFB100/README.md
@@ -85,7 +85,7 @@ The numbering of the GPIOs for PIN variables in ArduPilot is:
 - AUX5 54
 - AUX6 55
 
-## Analog inputs
+## Analog Inputs
 
 The JFB-100 has 7 analog inputs
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/JFB110/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/JFB110/README.md
@@ -103,7 +103,7 @@ The numbering of the GPIOs for PIN variables in ArduPilot is:
 - FMU_CAP1 66
 - FMU_CAP2 67
 
-## Analog inputs
+## Analog Inputs
 
 The JFB-110 has 9 analog inputs
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/JHEMCU-GSF405A-RX2/readme.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/JHEMCU-GSF405A-RX2/readme.md
@@ -61,7 +61,7 @@ RC input is configured on SERIAL2 (USART2), which is available on the RX2, TX2, 
 
 The GSF405A supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
-## Motor Output
+## PWM Output
 
 The built-in ESC is mapped to motor outputs 1-4. Bidirectional DShot is supported (requires flashing the ESC to a BLHeli_S version that supports bdshot, such as [Bluejay](https://esc-configurator.com)).
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/JHEMCU-GSF405A/readme.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/JHEMCU-GSF405A/readme.md
@@ -61,7 +61,7 @@ RC input is configured on SERIAL1 (USART1) connected to the ELRS receiver, confi
 
 The GSF405A supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
-## Motor Output
+## PWM Output
 
 The built-in ESC is mapped to motor outputs 1-4. Bidirectional DShot is supported (requires flashing the ESC to a BLHeli_S version that supports bdshot, such as Bluejay [esc-configurator.com]).
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/JHEMCUF405WING/Readme.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/JHEMCUF405WING/Readme.md
@@ -111,7 +111,7 @@ The correct battery setting parameters are set by default and are:
 
 The JHEMCUF405Wing does not have a built-in compass, but you can attach an external compass using I2C on the SDA and SCL pads.
 
-## VTX power control
+## VTX Power Control
 
 GPIO 81 controls the VTX BEC output to pins marked "9V". Setting this GPIO high removes voltage supply to pins. `Relay2` controls this GPIO by default.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/JPilot-C/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/JPilot-C/README.md
@@ -141,7 +141,7 @@ Channels within the same group need to use the same output rate. If any channel 
 
 Any of the serial ports can be used for a bidirectional RC connection. Change its `SERIALx_PROTOCOL` to "23" and follow the instructions in [RC systems](https://ardupilot.org/copter/docs/common-rc-systems.html) to other setup info for the RC system being used.
 
-## Battery Monitor
+## Battery Monitoring
 
 The board has internal voltage sensors and connection for external current sensors, able to monitor two batteries.
 The default battery parameters are:

--- a/libraries/AP_HAL_ChibiOS/hwdef/KT-FMU-F1/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KT-FMU-F1/README.md
@@ -19,7 +19,7 @@ The KT-FMU-F1 is a flight controller manufactured by [Coolfly](https://www.cecoo
   - 1x CAN
   - 1x USB
 
-## UART Mapping and Default Protocols
+## UART Mapping
 
 | Serial | Port  | Protocol    | Notes       |
 | ------ | ----- | ----------- | ----------- |

--- a/libraries/AP_HAL_ChibiOS/hwdef/LongBowF405WING/Readme.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/LongBowF405WING/Readme.md
@@ -94,7 +94,7 @@ The correct battery setting parameters are set by default and are:
 
 The LongBowF405WING does not have a built-in compass, but you can attach an external compass using I2C on the SDA and SCL pads.
 
-## VTX power control
+## VTX Power Control
 
 GPIO 81 controls the VTX BEC output to pins marked "9V" and "Vs1". Setting a RELAY function to this pin and turning it "ON" will remove the supply from these pins.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/LumenierLUXF765-NDAA/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/LumenierLUXF765-NDAA/README.md
@@ -157,14 +157,14 @@ The AT7456E communicates with the flight controller on SPI3.
 
 The LUX F765 - NDAA has a camera control output on PE10, which corresponds to GPIO 82. Additionally, RELAY3 is pre-configured to control GPIO 82.
 
-## Analog inputs
+## Analog Inputs
 
 The LUX F765 NDAA has 2 analog inputs:
 
 - PC2 -> Battery Current
 - PC3 -> Battery Voltage
 
-## Battery Monitor
+## Battery Monitoring
 
 The LUX F765 - NDAA has an internal voltage sensor and connections on the ESC connector
 for an external current sensor input. The voltage sensor can handle up to an 8S battery.

--- a/libraries/AP_HAL_ChibiOS/hwdef/MUPilot/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MUPilot/README.md
@@ -270,7 +270,7 @@ The numbering of the GPIOs for PIN variables in ArduPilot is:
 - AUX5 54
 - AUX6 55
 
-## Analog inputs
+## Analog Inputs
 
 The MUPilot has 7 analog inputs
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekH7A3-Wing/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekH7A3-Wing/README.md
@@ -99,7 +99,7 @@ The correct battery setting parameters are set by default and are:
 
 H7A3-SLIM does not have a built-in compass, but you can attach an external compass using I2C on the SDA and SCL pads.
 
-## VTX power control
+## VTX Power Control
 
 GPIO 81 controls the 9V BEC output to pins marked "9V". Setting this GPIO high removes voltage supply to pins. Default GPIO 81 is low(9V output enable)
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekH7A3/Readme.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekH7A3/Readme.md
@@ -100,7 +100,7 @@ The correct battery setting parameters are set by default and are:
 
 H7A3-SLIM does not have a built-in compass, but you can attach an external compass using I2C on the SDA and SCL pads.
 
-## VTX power control
+## VTX Power Control
 
 GPIO 81 controls the 9V BEC output to pins marked "9V". Setting this GPIO high removes voltage supply to pins. Default GPIO 81 is low(9V output enable)
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/Morakot/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Morakot/README.md
@@ -189,7 +189,7 @@ RC input is via SERIAL7(UART8) on the RC connector. Unidirectional protocols can
 
 In order to use the SBUS pin on the HD VTX connector, you must change SERIAL7_PROTOCOL to something other than "23" and set [SERIAL3_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial3-protocol-serial-3-gps-protocol-selection) to "23".
 
-## PWM Outputs
+## PWM Output
 
 The Morakot supports up to 9 PWM outputs. All are DSHot and Bi-Directional DShot capable
 
@@ -205,7 +205,7 @@ The PWM is in 3 groups:
 
 The Morakot has a built-in compass. Due to potential interference, the autopilot is usually used with an external I2C compass as part of a GPS/Compass combination and the internal compass disabled.
 
-## OSD
+## OSD Support
 
 DisplayPort OSD is enabled by default on the HD VTX connector. Simultaneous DisplayPort operation on HD VTX connector is enabled by default also.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/NarinFC-H7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/NarinFC-H7/README.md
@@ -55,7 +55,7 @@ Compared with previous autopilots, it has better performance and higher reliabil
 
 ![Wire Diagram](./images/3.Wire_Diagram.png "Wire Diagram")
 
-## UART Mapping (Port Diagram & Pin outs)
+## UART Mapping
 
  UART corresponding to each SERIAL port, and its default protocol, are shown below:
 
@@ -196,7 +196,7 @@ The numbering of the GPIOs for use in the PIN parameters in ArduPilot is:
 - PWM13(M13) 62
 - PWM14(M14) 63
 
-## Analog inputs
+## Analog Inputs
 
 The NarinFC-H7 has 2 analog inputs, one 6V tolerant and one 3.3V tolerant
 
@@ -210,7 +210,7 @@ The NarinFC-H7 has 2 analog inputs, one 6V tolerant and one 3.3V tolerant
 - ADC Pin8  -> VDD_5V_SENS
 - ADC Pin11 -> SCALED_V3V3
 
-## Battery Monitor
+## Battery Monitoring
 
 The board has two dedicated power monitor ports on 6 pin connectors. The correct battery setting parameters are dependent on the type of power brick which is connected. By default, use of a CAN battery monitor is enabled.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/NarinFC-X3/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/NarinFC-X3/README.md
@@ -49,7 +49,7 @@ Compared with previous autopilots, it has better performance and higher reliabil
 
 ![Outline Dimensions](./images/NarinFC_X3_Dimensions.png "Outline Dimensions")
 
-## UART Mapping (Port Diagram & Pin outs)
+## UART Mapping
 
  UART corresponding to each SERIAL port, and its default protocol, are shown below:
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ORBITH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ORBITH743/README.md
@@ -46,7 +46,7 @@ The above image and some content courtesy of [orbitteknoloji.com.tr](https://orb
 
 - 30.5 mm x 30.5 mm
 
-## Default UART Order
+## UART Mapping
 
 - `SERIAL0` = USB (MAVLink2)  
 - `SERIAL1` = UART1 (ESC Telemetry)  
@@ -139,7 +139,7 @@ Example (using Channel 10 to toggle VTX BEC using Relay 2, as an example):
 
 > ⚠️ **Warning:** GPIO81 controls the 10V DC-DC converter (HIGH = on, LOW = off). Default: ON. Always install an antenna on the VTX when battery-powered.
 
-## Camera Switch Control
+## Camera Switch
 
 GPIO 82 controls camera switching via PINIO2. Set high or low to toggle between cameras (e.g., front/rear).
 
@@ -159,7 +159,7 @@ This board does **not** include GPS or compass modules. An [external GPS/compass
 <!-- -->
 > **Tip:** The 4V5 pin can power both RC and GPS for bench setup (without battery), as long as the total current does not exceed USB limits (typically 1A).
 
-## Battery Monitor Settings
+## Battery Monitoring
 
 These are set by default. If reset:
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PH4-mini/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PH4-mini/README.md
@@ -108,7 +108,7 @@ following GPIO numbers:
 - CAP3 60
 - CAP4 61
 
-## Analog inputs
+## Analog Inputs
 
 The Pixhawk4-Mini has 4 analog inputs
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixFlamingo-F767/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixFlamingo-F767/README.md
@@ -147,7 +147,7 @@ The pin numbers for these PWM channels in ArduPilot are shown below:
 | PWM6         | 55   |              |      |
 | PWM7         | 56   |              |      |
 
-## Analog inputs
+## Analog Inputs
 
 The PixFlamingo-F767 flight controller has 4 analog inputs
 
@@ -156,7 +156,7 @@ The PixFlamingo-F767 flight controller has 4 analog inputs
 - ADC Pin14   -> ADC 3V3 Sense
 - ADC Pin15 -> ADC 6V6 Sense
 
-## Battery Monitor Configuration
+## Battery Monitoring
 
 The board has voltage and current sensor inputs on the POWER_ADC connector.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-C3/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-C3/README.md
@@ -142,7 +142,7 @@ Channels within the same group need to use the same output rate. If
 any channel in a group uses DShot then all channels in the group need
 to use DShot.
 
-## Battery Monitor Settings
+## Battery Monitoring
 
 These should already be set by default. However, if lost or changed:
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-V3/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-V3/README.md
@@ -140,7 +140,7 @@ Channels within the same group need to use the same output rate. If
 any channel in a group uses DShot then all channels in the group need
 to use DShot.
 
-## Battery Monitor Settings
+## Battery Monitoring
 
 These should already be set by default. However, if lost or changed:
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-V6/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-V6/README.md
@@ -113,7 +113,7 @@ The PixPilot-V6 flight controller is sold by a range of resellers listed at [Mak
 
 All compatible RC protocols can be decoded by attaching the Receiver's output to the SBUS input pin next to the Servo/Output VCC input connector. Note that some protocols such as CRSF or FPort including telemetry, require connection to, and setup of, one of the UARTs instead of this pin.
 
-## Battery Monitor Settings
+## Battery Monitoring
 
 These should already be set by default. However, if lost or changed:
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-V6PRO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-V6PRO/README.md
@@ -129,7 +129,7 @@ The PixPilot-V6PRO flight controller is sold by a range of resellers listed at [
 
 All compatible RC protocols can be decoded by attaching the Receiver's output to the SBUS input pin next to the Servo/Output VCC input connector. Note that some protocols such as CRSF or FPort including telemetry, require connection to, and setup of, one of the UARTs instead of this pin.
 
-## Battery Monitor Settings
+## Battery Monitoring
 
 These should already be set by default. However, if lost or changed:
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixSurveyA1-IND/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixSurveyA1-IND/README.md
@@ -153,7 +153,7 @@ Channels within the same group need to use the same output rate. If
 any channel in a group uses DShot then all channels in the group need
 to use DShot.
 
-## Battery Monitor Settings
+## Battery Monitoring
 
 These should already be set by default. However, if lost or changed:
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixSurveyA2-IND/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixSurveyA2-IND/README.md
@@ -130,7 +130,7 @@ To allow CRSF and embedded telemetry available in Fport, CRSF, and SRXL2 receive
 - CRSF/ELRS would require [SERIAL2_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial2-options-telem2-options) be set to "0".
 - SRXL2 would require [SERIAL2_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial2-options-telem2-options) be set to "4" and connects only the TX pin.
 
-## PWM Outputs
+## PWM Output
 
 The autopilot supports up to 14 PWM outputs. All 14 outputs
 support all normal PWM output formats. All outputs also support DShot. Outputs 9-14 support Bi-Directional DShot. Outputs within the same timer group need to use the same output rate. If any output in a group uses DShot then all channels in the group need to use DShot,etc..
@@ -169,7 +169,7 @@ All PWM outputs can be used as GPIOs (relays, camera, RPM etc). To use them you 
 | 108 | Out8 |  |
 |  |  |  |
 
-## Battery Monitor Settings
+## Battery Monitoring
 
 These should already be set by default. However, if lost or changed:
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk1/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk1/README.md
@@ -209,7 +209,7 @@ The numbering of the GPIOs for PIN variables in ArduPilot is:
 - AUX5 54
 - AUX6 55
 
-## Analog inputs
+## Analog Inputs
 
 The Pixhawk1 has 6 analog inputs on the FMU, plus servo rail voltage
 and RSSI monitoring on the IO controller.

--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk4/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk4/README.md
@@ -125,7 +125,7 @@ The numbering of the GPIOs for PIN variables in ArduPilot is:
 - AUX5 54
 - AUX6 55
 
-## Analog inputs
+## Analog Inputs
 
 The Pixhawk4 has 7 analog inputs
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixracer/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixracer/README.md
@@ -200,7 +200,7 @@ The numbering of the GPIOs for PIN variables in ArduPilot is:
 - PWM5 54
 - PWM6 55
 
-## Analog inputs
+## Analog Inputs
 
 The Pixracer has 4 analog inputs
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PrincipIoTH7Pi/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PrincipIoTH7Pi/README.md
@@ -76,7 +76,7 @@ USART3 is wired to the UART on the 40 pin Raspberry Pi header and the external
 UART connector.
 UART7 is receive only.
 
-## RC input
+## RC Input
 
 The PrincipIoT H7 Pi defaults SERIAL 6 as RC input. It can be used with any
 ArduPilot compatible serial protocol. It does not support PPM protocols.
@@ -92,7 +92,7 @@ SBUS/DSM would connect to UART8 RX input.
 Any other UART can be used for RC system connections in ArduPilot also, see
 [RC systems](https://ardupilot.org/copter/docs/common-rc-systems.html) for details.
 
-## PWM Outputs
+## PWM Output
 
 The PrincipIoT H7 Pi controller supports up to 8 PWM outputs.
 
@@ -121,7 +121,7 @@ The SH1.0-5P connector supports a connection to a VTX. Protocol defaults to
 DisplayPort. Pin 1 of the connector is +10V so be careful not to connect this
 to a peripheral requiring 5v. DisplayPort OSD is enabled by default on SERIAL5.
 
-## VTX power control
+## VTX Power Control
 
 GPIO 81 controls the VTX BEC output to pins marked "10V" and is included on
 the HD VTX connector. Setting this GPIO high turns off the voltage regulator.
@@ -159,7 +159,7 @@ model or desolder the onboard one.
 |LED0          | 90         |Blue LED        |
 |LED1          | 91         |Green LED       |
 
-## Battery Monitor
+## Battery Monitoring
 
 The board has a internal voltage sensor and connections on the ESC connector
 for an external current sensor input.

--- a/libraries/AP_HAL_ChibiOS/hwdef/RADIX2HD/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/RADIX2HD/README.md
@@ -66,7 +66,7 @@ all channels in the same group need to use the same configuration / rate.
 - PWM 7-8 Group 4
 - PWM 9-10 Group 5 (These are on the TX6 and RX6 pads that can also be used for SERIAL6)
 
-## Analog inputs
+## Analog Inputs
 
 The RADIX 2 HD has 3 analog inputs:
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/RadiolinkPIX6/Readme.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/RadiolinkPIX6/Readme.md
@@ -282,7 +282,7 @@ The parameters should be set.:
 
 The RadiolinkPIX6 has a built-in compass. Due to potential interference, the autopilot is usually used with an external I2C compass as part of a GPS/Compass combination.
 
-## Analog inputs
+## Analog Inputs
 
 The RadiolinkPIX6 has 3 analog inputs, one 6V tolerant and two 3.3V tolerant
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ResoluteH7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ResoluteH7/README.md
@@ -78,7 +78,7 @@ The correct battery setting parameters are:
 
 The Resolute H7 does not have a builtin compass, but you can attach an external compass using I2C on the SDA and SCL pads.
 
-## Camera control
+## Camera Control
 
 GPIO 82 controls the camera output to the connectors marked "CAM1" and "CAM2". Setting this GPIO low switches the video output from CAM1 to CAM2. By default RELAY3 is configured to control this pin.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SIYI_N7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SIYI_N7/README.md
@@ -171,7 +171,7 @@ The numbering of the GPIOs for PIN variables in ArduPilot is:
 - PWM4 53
 - PWM5 54
 
-## Analog inputs
+## Analog Inputs
 
 The SIYI N7 has 7 analog inputs
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SPEDIXF405/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SPEDIXF405/README.md
@@ -80,7 +80,7 @@ The correct battery setting parameters are:
 
 The board has no onboard compass. External compass modules can be connected via the I2C bus (SDA/SCL).
 
-## Camera control
+## Camera Control
 
 GPIO 82 controls the camera output to the connectors marked "CAM1" and "CAM2". Setting this GPIO low switches the video output from CAM1 to CAM2. By default RELAY3 is configured to control this pin and sets the GPIO high.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SPEDIXH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SPEDIXH743/README.md
@@ -79,11 +79,11 @@ The correct battery setting parameters are:
 
 No onboard compass. Use external I2C compass via SDA/SCL pads.
 
-## VTX power control
+## VTX Power Control
 
 GPIO 82 controls the VTX BEC output to pins marked "12V" and is included on the HD VTX connector. Setting this GPIO low removes voltage supply to this pin/pad. By default RELAY3 is configured to control this pin and sets the GPIO high.
 
-## Camera control
+## Camera Control
 
 GPIO 83 controls the camera output to the connectors marked "CAM1" and "CAM2". Setting this GPIO low switches the video output from CAM1 to CAM2. By default RELAY4 is configured to control this pin and sets the GPIO high.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SULILGH7-P1-P2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SULILGH7-P1-P2/README.md
@@ -83,7 +83,7 @@ The 8 FMU PWM outputs are in 4 groups:
 
 Channels within the same group need to use the same output rate. If any channel in a group uses DShot then all channels in the group need to use DShot.
 
-## GPIO
+## GPIOs
 
 All PWM outputs can be used as GPIOs (relays, camera, RPM etc). To use them you need to set the output’s SERVOx_FUNCTION to -1. The numbering of the GPIOs for PIN variables in ArduPilot is:
 
@@ -120,7 +120,7 @@ These are set by default in the firmware and shouldn't need to be adjusted.
 
 The P1/P2 flight controllers have an integrated IST8310 high-precision magnetometer.
 
-## Analog inputs
+## Analog Inputs
 
 The P1/P2 flight controller has 2 analog inputs.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SVehicle-E2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SVehicle-E2/README.md
@@ -124,7 +124,7 @@ The board has connectors for 3 power monitors. The board is configure by default
 
 The E2-Plus has an RM3100 builtin compass, but due to interference the board is usually used with an external I2C or CAN compass as part of a GPS/Compass combination.
 
-## Analog inputs
+## Analog Inputs
 
 The E2-Plus has 6 analog inputs.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SequreH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SequreH743/README.md
@@ -53,7 +53,7 @@ The SequreH743 supports OSD using OSD_TYPE 1 (MAX7456 driver)
 The SH1.0-6P connector supports a DJI Air Unit / HD VTX connection. Protocol defaults to DisplayPort. Pin 1 of the connector is 9v so
 be careful not to connect this to a peripheral that can not tolerate this voltage.
 
-## Camera control
+## Camera Control
 
 GPIO 81 is a pin for PWM camera control which is not supported by ArduPilot. It can be used as a general GPIO pin. By default RELAY2 is configured to control this pin and sets the GPIO high.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SkystarsF405v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SkystarsF405v2/README.md
@@ -90,7 +90,7 @@ Analog RSSI uses [RSSI_ANA_PIN](https://ardupilot.org/copter/docs/parameters.htm
 
 The SkystarsF405v2 does not have a builtin compass, but you can attach an external compass using I2C on the SDA and SCL pads.
 
-## Camera control
+## Camera Control
 
 GPIO 81 controls the camera output to the connectors marked "CAM1" and "CAM2". Setting this GPIO low switches the video output
 from CAM1 to CAM2. By default RELAY2 is configured to control this pin and sets the GPIO high.

--- a/libraries/AP_HAL_ChibiOS/hwdef/SkystarsH7HDv2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SkystarsH7HDv2/README.md
@@ -78,13 +78,13 @@ The correct battery setting parameters are:
 
 The Skystars H7HDv2 does not have a builtin compass, but you can attach an external compass using I2C on the SDA and SCL pads.
 
-## VTX power control
+## VTX Power Control
 
 If the JP jumper is bridged to PIT then GPIO 81 controls the VTX BEC output to pins marked "10V" and is included on the HD VTX connector. Setting this GPIO low removes voltage supply to this pin/pad. RELAY2 is configured by default to control this GPIO and is high by default.
 
 GPIO 82 controls the analogue camera outputs. Setting this GPIO high selects Camera 1, low selects Camera 2. RELAY3 is configured by default to control this GPIO and is high by default.
 
-## Camera control
+## Camera Control
 
 GPIO 83 is marked as "OSD". It can be used as a general GPIO pin. By default RELAY4 is configured to control this pin and sets the GPIO high.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SpeedyBeeF405AIO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SpeedyBeeF405AIO/README.md
@@ -106,7 +106,7 @@ The board includes a NeoPixel LED pad.
 
 Firmware for this board can be found: [here](https://firmware.ardupilot.org) in sub-folders labeled “SpeedyBeeF405AIO”.
 
-## Loading Firmware (you will need to compile your own firmware)
+## Loading Firmware
 
 Initial firmware load can be done with DFU by plugging in USB with the
 bootloader button pressed. Then you should load the "with_bl.hex"

--- a/libraries/AP_HAL_ChibiOS/hwdef/SpeedyBeeF405WING/Readme.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SpeedyBeeF405WING/Readme.md
@@ -89,7 +89,7 @@ The correct battery setting parameters are set by default and are:
 
 The SpeedyBeeF405Wing does not have a built-in compass, but you can attach an external compass using I2C on the SDA and SCL pads.
 
-## VTX power control
+## VTX Power Control
 
 GPIO 81 controls the VTX BEC output to pins marked "9V". Setting this GPIO high removes voltage supply to pins.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7/README.md
@@ -110,7 +110,7 @@ Analog Airspeed sensor would use ARSPD_PIN 4
 
 The TBS LUCID H7 does not have a builtin compass, but you can attach an external compass using I2C on the SDA and SCL pads.
 
-## VTX power control
+## VTX Power Control
 
 GPIO 81 controls the VSW pins which can be set to output either VBAT or 5V via a board jumper. Setting this GPIO low removes voltage supply to pins. RELAY2 is configured by default to control this GPIO and is low by default.
 
@@ -118,7 +118,7 @@ GPIO 83 controls the VTX BEC output to pins marked "9V" and is included on the H
 
 By default RELAY4 is configured to control this pin and sets the GPIO high.
 
-## Camera control
+## Camera Control
 
 GPIO 82 controls the camera output to the connectors marked "CAM1" and "CAM2". Setting this GPIO low switches the video output from CAM1 to CAM2. By default RELAY3 is configured to control this pin and sets the GPIO high.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7_WING/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7_WING/README.md
@@ -113,14 +113,14 @@ Analog Airspeed sensor would use ARSPD_PIN 4
 
 The TBS Lucid H7 Wing does not have a builtin compass, but you can attach an external compass using I2C on the SDA and SCL pads.
 
-## VTX power control
+## VTX Power Control
 
 GPIO 81 controls the Vsw pins which can be set to output either VFC (9/12V) or 5V via a board jumper. Setting this GPIO high removes voltage supply to pins. RELAY2 is configured by default to control this GPIO and is low by default.
 
 GPIO 83 controls the VTX BEC output to pins marked "9V/12V"  included on the HD VTX connector and VFC pads and is included on the HD VTX connector. Setting this GPIO low removes voltage supply to this pin/pad.
 By default RELAY4 is configured to control this pin and sets the GPIO high.
 
-## Camera control
+## Camera Control
 
 GPIO 82 controls the camera output to the connectors marked "C1" and "C2". Setting this GPIO low switches the video input from C1 to C2. By default RELAY3 is configured to control this pin.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7_WING_AIO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7_WING_AIO/README.md
@@ -113,14 +113,14 @@ Analog Airspeed sensor would use ARSPD_PIN 4
 
 The TBS Lucid H7 Wing AIO does not have a builtin compass, but you can attach an external compass using I2C on the SDA and SCL pads.
 
-## VTX power control
+## VTX Power Control
 
 GPIO 81 controls the Vsw pins which can be set to output either VFC (9/12V) or 5V via a board jumper. Setting this GPIO high removes voltage supply to pins. RELAY2 is configured by default to control this GPIO and is low by default.
 
 GPIO 83 controls the VTX BEC output to pins marked "9V/12V"  included on the HD VTX connector and VFC pads and is included on the HD VTX connector. Setting this GPIO low removes voltage supply to this pin/pad.
 By default RELAY4 is configured to control this pin and sets the GPIO high.
 
-## Camera control
+## Camera Control
 
 GPIO 82 controls the camera output to the connectors marked "C1" and "C2". Setting this GPIO low switches the video input from C1 to C2. By default RELAY3 is configured to control this pin.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/VUAV-TinyV7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/VUAV-TinyV7/README.md
@@ -171,7 +171,7 @@ The pin numbers for these PWM channels in ArduPilot are shown below:
 |     PWM5     |  54  |    PWM11     |  60  |
 |     PWM6     |  55  |    PWM12     |  61  |
 
-## Analog inputs
+## Analog Inputs
 
 The VUAV-V7Tiny  flight controller has 6 Analog inputs
 
@@ -182,7 +182,7 @@ The VUAV-V7Tiny  flight controller has 6 Analog inputs
 - ADC Pin10  -> Battery Voltage input on ESC connector
 - ADC Pin8  -> Servo Voltage
 
-## Battery Monitor Configuration
+## Battery Monitoring
 
 The board has voltage and current inputs sensor on the POWER and ESC connector.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/VUAV-V7pro/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/VUAV-V7pro/README.md
@@ -199,7 +199,7 @@ The pin numbers for these PWM channels in ArduPilot are shown below:
 | PWM6 | 55 | PWM13 | 62 |
 | PWM7 | 56 | PWM14 | 63 |
 
-## Analog inputs
+## Analog Inputs
 
 The VUAV-V7pro flight controller has 5 Analog inputs
 
@@ -209,7 +209,7 @@ The VUAV-V7pro flight controller has 5 Analog inputs
 - ADC Pin3 -> ADC 6V6 Sense
 - ADC Pin9 -> RSSI voltage monitoring
 
-## Battery Monitor Configuration
+## Battery Monitoring
 
 The board has voltage and current inputs sensor on the POWER1 ADC and POWER2 CAN connector.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/YARIV6X/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/YARIV6X/README.md
@@ -102,7 +102,7 @@ To allow CRSF and embedded telemetry available in Fport, CRSF, and SRXL2 receive
 
 Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM. See [Radio Control Systems](https://ardupilot.org/copter/docs/common-rc-systems.html#common-rc-systems) for details.
 
-## Battery Monitor
+## Battery Monitoring
 
 The default battery parameters for use with a digital power module (with INA2xx) connected to Power1 port:
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/YJUAV_A6/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/YJUAV_A6/README.md
@@ -218,7 +218,7 @@ The pin numbers for these PWM channels in ArduPilot are shown below:
 | PWM6         | 55   | PWM13        | 62   |
 | PWM7         | 56   | PWM14        | 63   |
 
-## Analog inputs
+## Analog Inputs
 
 The A6 flight controller has 5 analog inputs
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/YJUAV_A6SE/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/YJUAV_A6SE/README.md
@@ -189,7 +189,7 @@ The pin numbers for these PWM channels in ArduPilot are shown below:
 | PWM6         | 55   |              |      |
 | PWM7         | 56   |              |      |
 
-## Analog inputs
+## Analog Inputs
 
 The A6SE flight controller has 5 analog inputs
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/YJUAV_A6SE_H743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/YJUAV_A6SE_H743/README.md
@@ -223,7 +223,7 @@ The pin numbers for these PWM channels in ArduPilot are shown below:
 | PWM6         | 55   |              |      |
 | PWM7         | 56   |              |      |
 
-## Analog inputs
+## Analog Inputs
 
 The A6SE_H743 flight controller has 5 analog inputs
 
@@ -233,7 +233,7 @@ The A6SE_H743 flight controller has 5 analog inputs
 - ADC Pin10 -> ADC 6V6 Sense
 - ADC Pin11 -> RSSI voltage monitoring
 
-## Battery Monitor Configuration
+## Battery Monitoring
 
 The board has voltage and current sensor inputs on the POWER_ADC connector.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/YJUAV_A6Ultra/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/YJUAV_A6Ultra/README.md
@@ -235,7 +235,7 @@ The pin numbers for these PWM channels in ArduPilot are shown below:
 | PWM6         | 55   | PWM13        | 62   |
 | PWM7         | 56   |              |      |
 
-## Analog inputs
+## Analog Inputs
 
 The A6Ultra flight controller has 7 Analog inputs
 
@@ -247,7 +247,7 @@ The A6Ultra flight controller has 7 Analog inputs
 - ADC Pin10 -> ADC 6V6 Sense
 - ADC Pin11 -> RSSI voltage monitoring
 
-## Battery Monitor Configuration
+## Battery Monitoring
 
 The board has voltage and current sensor inputs on the POWER1_ADC and POWER2_ADC connector.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ZeroOneX6/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ZeroOneX6/README.md
@@ -95,7 +95,7 @@ The 8 FMU PWM outputs are in 4 groups:
 
 Channels within the same group need to use the same output rate. If any channel in a group uses DShot then all channels in the group need to use DShot.
 
-## GPIO
+## GPIOs
 
 All PWM outputs can be used as GPIOs (relays, camera, RPM etc). To use them you need to set the output’s SERVOx_FUNCTION to -1. The numbering of the GPIOs for PIN variables in ArduPilot is:
 
@@ -134,7 +134,7 @@ These are set by default in the firmware and shouldn't need to be adjusted.
 
 The X6 flight controller built-in industrial-grade electronic compass chip RM3100.
 
-## Analog inputs
+## Analog Inputs
 
 The X6 flight controller has 2 analog inputs.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ZeroOneX6_Air/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ZeroOneX6_Air/README.md
@@ -106,7 +106,7 @@ The A9-15 outputs are in 4 groups:
 
 Channels within the same group need to use the same output rate. If any channel in a group uses DShot then all channels in the group need to use DShot.
 
-## GPIO
+## GPIOs
 
 All PWM outputs can be used as GPIOs (relays, camera, RPM etc). To use them you need to set the output’s SERVOx_FUNCTION to -1. The numbering of the GPIOs for PIN variables in ArduPilot is:
 
@@ -151,7 +151,7 @@ The X6_Air flight controller built-in industrial-grade electronic compass chip I
 interference, the autopilot is usually used with an external I2C compass as
 part of a GPS/Compass combination.
 
-## Analog inputs
+## Analog Inputs
 
 The X6_Air flight controller has 2 analog inputs.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/modalai_fc-v1/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/modalai_fc-v1/README.md
@@ -89,7 +89,7 @@ Channels within the same group need to use the same output rate. If
 any channel in a group uses DShot then all channels in the group need
 to use DShot.
 
-## Power Monitoring
+## Battery Monitoring
 
 In addition to the normal range of ArduPilot power monitoring options,
 the modalAI build supports two I2C power monitors, the INA231 and the

--- a/libraries/AP_HAL_ChibiOS/hwdef/sparknavi-blue/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/sparknavi-blue/README.md
@@ -64,7 +64,7 @@ The SparkNavi Blue autopilot is manufactured by [SparkNavi](https://www.sparknav
 
 USART2 (TELEM1) and USART3 (TELEM2) have CTS/RTS flow control pins.
 
-## RC input
+## RC Input
 
 RC input is configured on the RC IN/SBUS IN pin on the MAIN OUT connector. This pin supports all unidirectional RC protocols (PPM, SBUS, iBus, DSM, DSM2, DSM-X, SRXL, and SUMD). In addition, there is a dedicated Spektrum satellite port (SPKT) which supports software power control, allowing for binding of Spektrum satellite receivers.
 
@@ -77,7 +77,7 @@ For CRSF/ELRS, SRXL2, and bidirectional FPort with telemetry, a full UART such a
 
 Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM. See [RC systems](https://ardupilot.org/copter/docs/common-rc-systems.html) for details.
 
-## PWM Outputs
+## PWM Output
 
 The SparkNavi Blue supports up to 14 PWM outputs.
 
@@ -133,7 +133,7 @@ If the ARSPD pin is used for analog airspeed  input. Set [ARSPD_PIN](https://ard
 | MAIN(7)        | 107         |
 | MAIN(8)        | 108         |
 
-## Battery Monitor
+## Battery Monitoring
 
 The board has dual internal voltage and current sensors connected to the POWER1 and POWER2 connectors. Maximum power input voltage: 6V.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/speedybeef4v5/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/speedybeef4v5/README.md
@@ -94,7 +94,7 @@ The SpeedyBee F405 v5 does not have a builtin compass, but you can attach an ext
 
 The CC pin is a GPIO (pin 70) and is assigned by default to RELAY2 functionality. This pin can be controlled via GCS or by RC transmitter using the [Auxiliary Function](https://ardupilot.org/copter/docs/common-auxiliary-functions.html) feature.
 
-## VTX power control
+## VTX Power Control
 
 GPIO 71 controls the VTX BEC output to pins marked "9V". Setting this GPIO high removes voltage supply to pins.
 
@@ -110,7 +110,7 @@ By default, RELAY4 is configured to control this GPIO and keeps it low.This pin 
 
 Firmware for this board can be found: [here](https://firmware.ardupilot.org) in sub-folders labeled “speedybeef4v5”.
 
-## Loading Firmware (you will need to compile your own firmware)
+## Loading Firmware
 
 Initial firmware load can be done with DFU by plugging in USB with the
 bootloader button pressed. Then you should load the "with_bl.hex"

--- a/libraries/AP_HAL_ChibiOS/hwdef/thepeach-k1/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/thepeach-k1/README.md
@@ -46,7 +46,7 @@ Contact the [manufacturer](https://thepeach.kr/) for hardware support or complia
 
 ![pinmap_bottom](./pinmap_bottom.png)
 
-## Serial Port Mapping
+## UART Mapping
 
 | UART | Device | Port
 --- | --- | ---
@@ -82,6 +82,6 @@ Under these conditions, all power sources cause permanent damage to the flight c
 1. POWER input (5.5V Over)
 2. USB input (5.5V Over)
 
-## Where to buy
+## Where to Buy
 
 Order from [ThePeach](http://thepeach.shop/)

--- a/libraries/AP_HAL_ChibiOS/hwdef/thepeach-r1/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/thepeach-r1/README.md
@@ -50,7 +50,7 @@ Contact the [manufacturer](https://thepeach.kr/) for hardware support or complia
 
 ![pinmap_top](./pinmap.png)
 
-## Serial Port Mapping
+## UART Mapping
 
 | UART   | Device     | Port                       |
 | ------ | ---------- | -------------------------- |
@@ -86,6 +86,6 @@ Under these conditions, all power sources cause permanent damage to the flight c
 
 2. USB input (5.5V Over)
 
-## Where to buy
+## Where to Buy
 
 Order from [ThePeach](http://thepeach.shop/)

--- a/libraries/AP_HAL_ChibiOS/hwdef/uav-dev-fc-um982/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/uav-dev-fc-um982/README.md
@@ -152,7 +152,7 @@ Via DroneCAN by UAV-DEV-POWERMODULE
 
 The autopilot includes an internal compass as well as GNSS-based heading, but GNSS-based heading is the recommended heading source. Proper setup and placement of the dual antennas is required as well as setup of the moving baseline parameters, see [GPS for yaw](https://ardupilot.org/copter/docs/common-gps-for-yaw.html) for more details.
 
-## Motor Output
+## PWM Output
 
 All outputs are capable of PWM and DShot. Motors 1 through 4 are capable of Bidirectional-DShot. All outputs in the motor groups below must be either PWM or DShot:
 


### PR DESCRIPTION
### Summary

Adjusts headings in markdown files to conform to a smaller set of possible headings

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

consistent headings across markdown files will allow us to make wide-spread mechanical changes to these as desired.  As well as looking nicer.

I'm wondering about the truthidity of the phrase, "you must build your own firmware" in some of these files!
