### PR TITLE
Copter, Plane, Sub, AP_Motors: spoolup reporting enhancements

### DIFF
--- a/ArduCopter/mode_throw.cpp
+++ b/ArduCopter/mode_throw.cpp
@@ -149,6 +149,8 @@ void ModeThrow::run()
 
         // set motors to full range
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
+        // ignore motor checks
+        motors->set_spoolup_block(false);
 
         break;
 

--- a/ArduCopter/takeoff_check.cpp
+++ b/ArduCopter/takeoff_check.cpp
@@ -35,8 +35,8 @@ void Copter::takeoff_check()
         return;
     }
 
-    // warn about CPU load every 5 seconds
-    if (now_ms - takeoff_check_warning_ms > 5000) {
+    // warn about CPU load every 2 seconds
+    if (now_ms - takeoff_check_warning_ms > 2000) {
         takeoff_check_warning_ms = now_ms;
         const char* prefix_str = "Takeoff blocked:";
         if (!load_adequate) {

--- a/ArduCopter/takeoff_check.cpp
+++ b/ArduCopter/takeoff_check.cpp
@@ -9,11 +9,19 @@ void Copter::takeoff_check()
 {
 #if HAL_WITH_ESC_TELEM && FRAME_CONFIG != HELI_FRAME
     // if motors have become unblocked return immediately
-    // this ensures the motors can only be blocked immediate after arming
+    // this ensures the motors can only be blocked immediately after arming
     uint32_t now_ms = AP_HAL::millis();
     if (!motors->get_spoolup_block()) {
         takeoff_check_warning_ms = now_ms;
         takeoff_check_state.warning_ms = now_ms;
+        return;
+    }
+
+    // Motors Library has enabled the spool up block.
+
+    // Immediately clear the spool up block if not landed
+    if (!ap.land_complete) {
+        motors->set_spoolup_block(false);
         return;
     }
 

--- a/ArduCopter/takeoff_check.cpp
+++ b/ArduCopter/takeoff_check.cpp
@@ -8,27 +8,17 @@
 void Copter::takeoff_check()
 {
 #if HAL_WITH_ESC_TELEM && FRAME_CONFIG != HELI_FRAME
-    // If takeoff check is disabled or vehicle is armed and flying then clear block and return
-    if ((g2.takeoff_rpm_min <= 0) || (motors->armed() && !ap.land_complete)) {
-        motors->set_spoolup_block(false);
+    // if motors have become unblocked return immediately
+    // this ensures the motors can only be blocked immediate after arming
+    uint32_t now_ms = AP_HAL::millis();
+    if (!motors->get_spoolup_block()) {
+        takeoff_check_warning_ms = now_ms;
+        takeoff_check_state.warning_ms = now_ms;
         return;
     }
 
     // Run the common motor checks (called early so it can clear its warning timer when disarmed)
     const bool motor_check_passed = motors_takeoff_check(g2.takeoff_rpm_min, g2.takeoff_rpm_max);
-
-    // block takeoff when disarmed but do not display warnings
-    if (!motors->armed()) {
-        motors->set_spoolup_block(true);
-        takeoff_check_warning_ms = 0;
-        return;
-    }
-
-    // if motors have become unblocked return immediately
-    // this ensures the motors can only be blocked immediate after arming
-    if (!motors->get_spoolup_block()) {
-        return;
-    }
 
     // Check system load
     float avg_load, peak_load;
@@ -46,10 +36,6 @@ void Copter::takeoff_check()
     }
 
     // warn about CPU load every 5 seconds
-    uint32_t now_ms = AP_HAL::millis();
-    if (takeoff_check_warning_ms == 0) {
-        takeoff_check_warning_ms = now_ms;
-    }
     if (now_ms - takeoff_check_warning_ms > 5000) {
         takeoff_check_warning_ms = now_ms;
         const char* prefix_str = "Takeoff blocked:";

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1963,6 +1963,12 @@ void QuadPlane::update_throttle_hover()
  */
 void QuadPlane::motors_output(bool run_rate_controller)
 {
+    // QuadPlane has no pre-takeoff RPM gate that asserts the spool-up block,
+    // so clear it every cycle before motors->output() runs output_logic().
+    // Without this the block set during ground-idle ramp would never clear
+    // and the spool would stay in GROUND_IDLE.
+    motors->set_spoolup_block(false);
+
     /* Delay for ARMING_DELAY_MS after arming before allowing props to spin:
        1) for safety (OPTION_DELAY_ARMING)
        2) to allow motors to return to vertical (OPTION_DISARMED_TILT)

--- a/ArduSub/motors.cpp
+++ b/ArduSub/motors.cpp
@@ -9,6 +9,12 @@ void Sub::enable_motor_output()
 // motors_output - send output to motors library which will adjust and send to ESCs and servos
 void Sub::motors_output()
 {
+    // Sub has no pre-takeoff RPM gate that asserts the spool-up block,
+    // so clear it every cycle before motors.output() runs output_logic().
+    // Without this the block set during ground-idle ramp would never clear
+    // and the spool would stay in GROUND_IDLE.
+    motors.set_spoolup_block(false);
+    
     // Motor detection mode controls the thrusters directly
     if (control_mode == Mode::Number::MOTOR_DETECT){
         return;

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1671,6 +1671,25 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
     # Tests the motor failsafe
     def TakeoffCheck(self):
         '''Test takeoff check'''
+
+        self.start_subtest("Test blocking doesn't occur with in-range RPM")
+        self.context_push()
+        self.context_collect('STATUSTEXT')
+        self.set_parameters({
+            "AHRS_EKF_TYPE": 10,
+            'SIM_ESC_TELEM': 1,
+            'SIM_ESC_ARM_RPM': 1000,
+            'TKOFF_RPM_MIN': 900,
+            'TKOFF_RPM_MAX': 1100,
+        })
+        self.takeoff(10, mode="LOITER")
+        self.land_and_disarm()
+        # ensure no spurious takeoff blocked warnings during spoolup
+        for m in self.context_collection('STATUSTEXT'):
+            if "Takeoff blocked" in m.text:
+                raise NotAchievedException("Spurious takeoff blocked message: %s" % m.text)
+        self.context_pop()
+
         self.set_parameters({
             "AHRS_EKF_TYPE": 10,
             'SIM_ESC_TELEM': 1,

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -3082,6 +3082,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
 
         self.start_subtest("Test blocking doesn't occur with in-range RPM")
         self.context_push()
+        self.context_collect('STATUSTEXT')
         self.set_parameters({
             'SIM_VIB_MOT_MAX': 150, # Hz, 9000 RPM, ensures the test fails if check occurs after takeoff starts
             'SIM_ESC_ARM_RPM': 1000,
@@ -3098,6 +3099,10 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.wait_current_waypoint(2)
         self.wait_disarmed()
         self.set_current_waypoint(0, check_afterwards=False)
+        # ensure no spurious takeoff blocked warnings during spoolup
+        for m in self.context_collection('STATUSTEXT'):
+            if "Takeoff blocked" in m.text:
+                raise NotAchievedException("Spurious takeoff blocked message: %s" % m.text)
         self.context_pop()
 
         self.start_subtest("Ensure blocked if motors don't spool up")

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -718,18 +718,25 @@ void AP_MotorsMulticopter::output_logic()
                 break;
             }
 
-            // constrain ramp value and update mode
+            // wait for spin up to complete
             if (_spin_up_ratio < 1.0f) {
-                set_spoolup_block(true);
+                _spin_up_complete = false;
             } else {
                 _spin_up_ratio = 1.0f;
-                if (!get_spoolup_block()) {
-                    // only advance from ground idle when pre-takeoff checks have cleared
-                    // get_spoolup_block() is true while takeoff_check() is blocking spool-up
-                    // (e.g. esc telemetry inactive, rpm not in range, cpu overload, or disarmed)
-                    // must be false to proceed
-                    _spool_state = SpoolState::SPOOLING_UP;
+                if (!_spin_up_complete) {
+                    // Spin up is complete.
+                    // Enable spoolup block to hold the aircraft in GROUND_IDLE.
+                    // Main code should start checks when the block is enabled and remove the lock when ready.
+                    _spin_up_complete = true;
+                    set_spoolup_block(true);
                 }
+            }
+            if (_spin_up_complete && !get_spoolup_block()) {
+                // only advance from ground idle when pre-takeoff checks have cleared
+                // get_spoolup_block() is true while takeoff_check() is blocking spool-up
+                // (e.g. esc telemetry inactive, rpm not in range, cpu overload, or disarmed)
+                // must be false to proceed
+                _spool_state = SpoolState::SPOOLING_UP;
             }
             break;
         }

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -719,7 +719,9 @@ void AP_MotorsMulticopter::output_logic()
             }
 
             // constrain ramp value and update mode
-            if (_spin_up_ratio >= 1.0f) {
+            if (_spin_up_ratio < 1.0f) {
+                set_spoolup_block(true);
+            } else {
                 _spin_up_ratio = 1.0f;
                 if (!get_spoolup_block()) {
                     // only advance from ground idle when pre-takeoff checks have cleared

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -209,6 +209,7 @@ protected:
     // spool variables
     float               _spin_up_ratio;         // normalized spin scalar [0..1] between 0 and spin_min (used for ground-idle ramp)
     float               _idle_time;             // idle delay elapsed time at/above ground-idle spin [s]
+    bool                _spin_up_complete;      // set to true when spin up is complete and spool up blocks have been enabled
 
     // battery voltage, current and air pressure compensation variables
     float               _throttle_limit;        // ratio of throttle limit between hover and maximum

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -1180,8 +1180,8 @@ bool AP_Vehicle::motors_takeoff_check(float rpm_min, float rpm_max)
         return true;
     }
 
-    // warn user telem inactive or rpm is inadequate every 5 seconds
-    if (now_ms - takeoff_check_state.warning_ms > 5000) {
+    // warn the user every 2 seconds that telemetry is inactive or rpm is inadequate
+    if (now_ms - takeoff_check_state.warning_ms > 2000) {
         takeoff_check_state.warning_ms = now_ms;
         const char* prefix_str = "Takeoff blocked:";
         if (!telem_active) {

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -1164,8 +1164,9 @@ bool AP_Vehicle::motors_takeoff_check(float rpm_min, float rpm_max)
     }
 
     // clear warning timer when disarmed
+    uint32_t now_ms = AP_HAL::millis();
     if (!motors->armed()) {
-        takeoff_check_state.warning_ms = 0;
+        takeoff_check_state.warning_ms = now_ms;
         return false;
     }
 
@@ -1180,10 +1181,6 @@ bool AP_Vehicle::motors_takeoff_check(float rpm_min, float rpm_max)
     }
 
     // warn user telem inactive or rpm is inadequate every 5 seconds
-    uint32_t now_ms = AP_HAL::millis();
-    if (takeoff_check_state.warning_ms == 0) {
-        takeoff_check_state.warning_ms = now_ms;
-    }
     if (now_ms - takeoff_check_state.warning_ms > 5000) {
         takeoff_check_state.warning_ms = now_ms;
         const char* prefix_str = "Takeoff blocked:";


### PR DESCRIPTION
Spurious "Takeoff blocked" warnings during normal spool-up, fixed by:

Checks only run when we are ready for them. Previously they started running when the aircraft was not necessarily expecting motors to be turning, so false positives could fire.
The block is asserted in the fast loop by the spool state machine, not at 50 Hz from takeoff_check. A 50 Hz writer cannot reliably gate a fast-loop state machine.
Also resets the warning timer eagerly so a stale timestamp from a prior arm cycle cannot fire a warning the instant the block re-asserts, and adds a per-cycle clear in QuadPlane::motors_output() since QuadPlane has no pre-takeoff RPM gate of its own.

Auto-tests supplied by @andyp1per 

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request