### PR TITLE
Add compilation gates for MAV_CMD_GET_HOME_POSITION

### DIFF
--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -450,6 +450,7 @@ BUILD_OPTIONS = [
     Feature('MAVLink', 'MAVLINK_MSG_FLIGHT_INFORMATION', 'AP_MAVLINK_MSG_FLIGHT_INFORMATION_ENABLED', 'Enable FLIGHT_INFORMATION MAVLink message', 0, None),  # noqa
     Feature('MAVLink', 'RANGEFINDER_SENDING', 'AP_MAVLINK_MSG_RANGEFINDER_SENDING_ENABLED', 'Enable sending of RANGEFINDER mavlink message', 0, "RANGEFINDER"),  # noqa
     Feature('MAVLink', 'MAVLINK_SIGNING', 'AP_MAVLINK_SIGNING_ENABLED', 'Enable MAVLink2 packet signing and validation', 0, "RANGEFINDER"),  # noqa
+    Feature('MAVLink', 'MAVLINK_GET_HOME_POSITION', 'AP_MAVLINK_MAV_CMD_GET_HOME_POSITION_ENABLED', 'Enable superseded MAV_CMD_GET_HOME_POSITION', 0, None),  # noqa
 
     Feature('Developer', 'KILL_IMU', 'AP_INERTIALSENSOR_KILL_IMU_ENABLED', 'Allow IMUs to be disabled at runtime', 0, None),
     Feature('Developer', 'CRASHCATCHER', 'AP_CRASHDUMP_ENABLED', 'Enable CrashCatcher', 0, None),

--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -260,6 +260,7 @@ class ExtractFeatures(BuildScriptBase):
             ('AP_MAVLINK_MSG_RC_CHANNELS_RAW_ENABLED', r'GCS_MAVLINK::send_rc_channels_raw\b'),
             ('AP_MAVLINK_FTP_ENABLED', 'GCS_FTP::init'),
             ('AP_MAVLINK_MAV_CMD_SET_HAGL_ENABLED', 'Plane::handle_external_hagl'),
+            ('AP_MAVLINK_MAV_CMD_GET_HOME_POSITION_ENABLED', 'GCS_MAVLINK::handle_command_get_home_position'),  # noqa
             ('AP_MAVLINK_MSG_VIDEO_STREAM_INFORMATION_ENABLED', 'AP_Camera::send_video_stream_information'),
             ('AP_MAVLINK_MSG_FLIGHT_INFORMATION_ENABLED', 'GCS_MAVLINK::send_flight_information'),
             ('AP_MAVLINK_MSG_RANGEFINDER_SENDING_ENABLED', r'GCS_MAVLINK::send_rangefinder'),

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -720,7 +720,9 @@ protected:
     MAV_RESULT handle_command_do_gripper(const mavlink_command_int_t &packet);
     MAV_RESULT handle_command_do_sprayer(const mavlink_command_int_t &packet);
     MAV_RESULT handle_command_do_set_mode(const mavlink_command_int_t &packet);
+#if AP_MAVLINK_MAV_CMD_GET_HOME_POSITION_ENABLED
     MAV_RESULT handle_command_get_home_position(const mavlink_command_int_t &packet);
+#endif  // AP_MAVLINK_MAV_CMD_GET_HOME_POSITION_ENABLED
     MAV_RESULT handle_command_do_fence_enable(const mavlink_command_int_t &packet);
     MAV_RESULT handle_command_debug_trap(const mavlink_command_int_t &packet);
     MAV_RESULT handle_command_set_ekf_source_set(const mavlink_command_int_t &packet);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -5105,7 +5105,7 @@ MAV_RESULT GCS_MAVLINK::handle_command_do_set_mode(const mavlink_command_int_t &
     return _set_mode_common(_base_mode, _custom_mode);
 }
 
-#if AP_AHRS_ENABLED
+#if AP_MAVLINK_MAV_CMD_GET_HOME_POSITION_ENABLED
 MAV_RESULT GCS_MAVLINK::handle_command_get_home_position(const mavlink_command_int_t &packet)
 {
     if (!AP::ahrs().home_is_set()) {
@@ -5122,7 +5122,7 @@ MAV_RESULT GCS_MAVLINK::handle_command_get_home_position(const mavlink_command_i
 
     return MAV_RESULT_ACCEPTED;
 }
-#endif  // AP_AHRS_ENABLED
+#endif  // AP_MAVLINK_MAV_CMD_GET_HOME_POSITION_ENABLED
 
 MAV_RESULT GCS_MAVLINK::handle_command_debug_trap(const mavlink_command_int_t &packet)
 {
@@ -5802,10 +5802,10 @@ MAV_RESULT GCS_MAVLINK::handle_command_int_packet(const mavlink_command_int_t &p
         return handle_command_flash_bootloader(packet);
 #endif
 
-#if AP_AHRS_ENABLED
+#if AP_MAVLINK_MAV_CMD_GET_HOME_POSITION_ENABLED
     case MAV_CMD_GET_HOME_POSITION:
         return handle_command_get_home_position(packet);
-#endif
+#endif  // AP_MAVLINK_MAV_CMD_GET_HOME_POSITION_ENABLED
 
     case MAV_CMD_PREFLIGHT_CALIBRATION:
         return handle_command_preflight_calibration(packet, msg);

--- a/libraries/GCS_MAVLink/GCS_config.h
+++ b/libraries/GCS_MAVLink/GCS_config.h
@@ -23,6 +23,15 @@
 #define HAL_HIGH_LATENCY2_ENABLED 1
 #endif
 
+// MAV_CMD_GET_HOME_POSITION is redundant with
+// MAV_CMD_REQUEST_MESSAGE, it is slated for removal:
+// ArduPilot 4.8 allows it to be compiled out
+// ArduPilot 4.9 stops compiling in by default
+// ArduPilot 4.10 removes the code entirely
+#ifndef AP_MAVLINK_MAV_CMD_GET_HOME_POSITION_ENABLED
+#define AP_MAVLINK_MAV_CMD_GET_HOME_POSITION_ENABLED AP_AHRS_ENABLED
+#endif
+
 // handling of MISSION_SET_CURRENT (the message) is slated to be
 // removed.  It has signficant deficiencies vs MAV_CMD_DO_SET_CURRENT.
 // The command was added to the spec in January 2019 and to MAVLink in


### PR DESCRIPTION
### Summary

Allows GET_HOME_POSITION to be compiled out and adds a schedule for it to be removed from the code

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

No compiler change:
```
Board                  AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
Durandal                          *               *      *           *       *                 *      *      *
Hitec-Airspeed         *                                 *                                                   
KakuteH7-bdshot                   *               *      *           *       *                 *      *      *
MatekF405                         *               *      *           *       *                 *      *      *
MatekH7A3                         *               *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                *               *                  *       *                 *      *      *
SITL_x86_64_linux_gnu             *               *                  *       *                 *      *      *
YJUAV_A6SE                        *               *      *           *       *                 *      *      *
f103-QiotekPeriph      *                                 *                                                   
f303-MatekGPS          *                                 *                                                   
f303-Universal         *                                 *                                                   
iomcu                                                                              *                         
mindpx-v2                         *               *      *           *       *                 *      *      *
revo-mini                         *               *      *           *       *                 *      *      *
skyviper-v2450                                                       *                                       
speedybeef4                       *               *      *           *       *                 *      *      *
```

Compiles when the option is disabled:
```
Board,plane
CubeOrangePlus,-80
```

### Description

This message has been superseded by using `MAV_CMD_REQUEST_MESSAGE`.  Doesn't save a lot of bytes, but codepaths can be cleaner on the GCS side.
