### PR TITLE
Tradheli - reorganize to allow spool state update before rsc update

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -198,7 +198,8 @@ void AP_MotorsHeli::output_min()
     
     // _spool_state is enforced to SHUT_DOWN when _spool_desired is SHUT_DOWN.
     set_desired_spool_state(DesiredSpoolState::SHUT_DOWN);
-    _spool_state = update_motor_control(_spool_desired);
+    _spool_state = update_spool_state(_spool_desired);
+    update_motor_control(_spool_desired);
 
     output_to_motors();
 
@@ -225,6 +226,12 @@ void AP_MotorsHeli::output()
         output_disarmed();
     }
 
+    // helicopters always run stabilizing flight controls
+    move_actuators(_roll_in, _pitch_in, get_throttle(), _yaw_in);
+
+    // motor control must be updated after move_actuators because DDFP Tail Rotor output is based on move actuators()
+    update_motor_control(_spool_desired);
+
     update_turbine_start();
 
     output_to_motors();
@@ -240,8 +247,6 @@ void AP_MotorsHeli::output_armed_stabilizing()
     if (_servo_mode != SERVO_CONTROL_MODE_AUTOMATED) {
         reset_flight_controls();
     }
-
-    move_actuators(_roll_in, _pitch_in, get_throttle(), _yaw_in);
 }
 
 // output_disarmed - sends commands to the motors
@@ -310,9 +315,6 @@ void AP_MotorsHeli::output_disarmed()
 
     // continuously recalculate scalars to allow setup
     calculate_scalars();
-
-    // helicopters always run stabilizing flight controls
-    move_actuators(_roll_in, _pitch_in, get_throttle(), _yaw_in);
 }
 
 // set_desired_spool_state - set desired spool state with safety constraints
@@ -361,7 +363,7 @@ void AP_MotorsHeli::output_logic()
     // send desired spool state update to Heli RSC and update outputs
     // the Heli RSC will return the current spool state which is used to update _spool_state variable
     // _spool_state is enforced to SHUT_DOWN when _spool_desired is SHUT_DOWN.
-    _spool_state = update_motor_control(_spool_desired);
+    _spool_state = update_spool_state(_spool_desired);
 
     // Always reset the collective limit flags, they get set in move_actuators() if collective reaches a limit
     limit.set_throttle(false);

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -171,7 +171,10 @@ protected:
     AP_MotorsHeli_RSC   _main_rotor;            // main rotor
 
     // update_motor_controls - sends commands to motor controllers
-    virtual AP_Motors::SpoolState update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state) = 0;
+    virtual void update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state) = 0;
+
+    // update_spool_state - updates the spool state based on the desired state
+    virtual AP_Motors::SpoolState update_spool_state(AP_MotorsHeli_RSC::DesiredRSCSpoolState state) = 0;
 
     // run spool logic
     void                output_logic();

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -332,10 +332,10 @@ void AP_MotorsHeli_Dual::mix_intermeshing(float pitch_input, float roll_input, f
 }
 
 // update_motor_controls - sends commands to motor controllers
-AP_Motors::SpoolState AP_MotorsHeli_Dual::update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state)
+void AP_MotorsHeli_Dual::update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state)
 {
     // Send state update to motors
-    AP_MotorsHeli_RSC::RSCSpoolState main_rotor_state = _main_rotor.update(state);
+    _main_rotor.update(_dt_s);
 
     if (state == AP_MotorsHeli_RSC::DesiredRSCSpoolState::SHUT_DOWN) {
         // set engine run enable aux output to not run position to kill engine when disarmed
@@ -344,13 +344,24 @@ AP_Motors::SpoolState AP_MotorsHeli_Dual::update_motor_control(AP_MotorsHeli_RSC
         // else if armed, set engine run enable output to run position
         SRV_Channels::set_output_limit(SRV_Channel::k_engine_run_enable, SRV_Channel::Limit::MAX);
     }
+}
 
-    // Check if rotors are run-up
+// update_spool_state - updates the spool state based on the desired state
+AP_Motors::SpoolState AP_MotorsHeli_Dual::update_spool_state(AP_MotorsHeli_RSC::DesiredRSCSpoolState state)
+{
+
+    SpoolState main_rotor_state = _main_rotor.update_spool_state(_dt_s, state);
+
+        // Check if main rotor is run-up complete.  Tail rotor run-up is not included in check because currently
+    // the tail rotor in DDVP uses the same ramp and runup time as the main rotor.  This may need changed if 
+    // the RSC is used for DDFP tail rotors.
     set_rotor_runup_complete(main_rotor_state == AP_MotorsHeli_RSC::RSCSpoolState::THROTTLE_UNLIMITED);
 
     return main_rotor_state;
+
 }
 
+//
 //
 // move_actuators - moves swash plate to attitude of parameters passed in
 //                - expected ranges:

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -350,7 +350,7 @@ void AP_MotorsHeli_Dual::update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpool
 AP_Motors::SpoolState AP_MotorsHeli_Dual::update_spool_state(AP_MotorsHeli_RSC::DesiredRSCSpoolState state)
 {
 
-    SpoolState main_rotor_state = _main_rotor.update_spool_state(_dt_s, state);
+    SpoolState main_rotor_state = _main_rotor.update_spool_state(state, _dt_s);
 
     // Check if main rotor is run-up complete.  Tail rotor run-up is not included in check because currently
     // the tail rotor in DDVP uses the same ramp and runup time as the main rotor.  This may need changed if 

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -352,7 +352,7 @@ AP_Motors::SpoolState AP_MotorsHeli_Dual::update_spool_state(AP_MotorsHeli_RSC::
 
     SpoolState main_rotor_state = _main_rotor.update_spool_state(_dt_s, state);
 
-        // Check if main rotor is run-up complete.  Tail rotor run-up is not included in check because currently
+    // Check if main rotor is run-up complete.  Tail rotor run-up is not included in check because currently
     // the tail rotor in DDVP uses the same ramp and runup time as the main rotor.  This may need changed if 
     // the RSC is used for DDFP tail rotors.
     set_rotor_runup_complete(main_rotor_state == AP_MotorsHeli_RSC::RSCSpoolState::THROTTLE_UNLIMITED);
@@ -361,7 +361,6 @@ AP_Motors::SpoolState AP_MotorsHeli_Dual::update_spool_state(AP_MotorsHeli_RSC::
 
 }
 
-//
 //
 // move_actuators - moves swash plate to attitude of parameters passed in
 //                - expected ranges:

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.h
@@ -70,7 +70,10 @@ protected:
     void init_outputs () override;
 
     // update_motor_controls - sends commands to motor controllers
-    AP_Motors::SpoolState update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state) override;
+    void update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state) override;
+
+    // update_spool_state - updates the spool state based on the desired state
+    AP_Motors::SpoolState update_spool_state(AP_MotorsHeli_RSC::DesiredRSCSpoolState state) override;
 
     // get_swashplate - calculate movement of each swashplate based on configuration
     float get_swashplate(int8_t swash_num, int8_t swash_axis, float pitch_input, float roll_input, float yaw_input, float coll_input);

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -138,7 +138,7 @@ AP_Motors::SpoolState AP_MotorsHeli_Quad::update_spool_state(AP_MotorsHeli_RSC::
 
     SpoolState main_rotor_state = _main_rotor.update_spool_state(_dt_s, state);
 
-        // Check if main rotor is run-up complete.  Tail rotor run-up is not included in check because currently
+    // Check if main rotor is run-up complete.  Tail rotor run-up is not included in check because currently
     // the tail rotor in DDVP uses the same ramp and runup time as the main rotor.  This may need changed if 
     // the RSC is used for DDFP tail rotors.
     set_rotor_runup_complete(main_rotor_state == AP_MotorsHeli_RSC::RSCSpoolState::THROTTLE_UNLIMITED);

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -117,10 +117,10 @@ void AP_MotorsHeli_Quad::calculate_roll_pitch_collective_factors()
 }
 
 // update_motor_controls - sends commands to motor controllers
-AP_Motors::SpoolState  AP_MotorsHeli_Quad::update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state)
+void  AP_MotorsHeli_Quad::update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state)
 {
     // Send state update to motors
-    AP_MotorsHeli_RSC::RSCSpoolState main_rotor_state = _main_rotor.update(state);
+    _main_rotor.update(_dt_s);
 
     if (state == AP_MotorsHeli_RSC::DesiredRSCSpoolState::SHUT_DOWN) {
         // set engine run enable aux output to not run position to kill engine when disarmed
@@ -130,7 +130,17 @@ AP_Motors::SpoolState  AP_MotorsHeli_Quad::update_motor_control(AP_MotorsHeli_RS
         SRV_Channels::set_output_limit(SRV_Channel::k_engine_run_enable, SRV_Channel::Limit::MAX);
     }
 
-    // Check if rotors are run-up
+}
+
+// update_spool_state - updates the spool state based on the desired state
+AP_Motors::SpoolState AP_MotorsHeli_Quad::update_spool_state(AP_MotorsHeli_RSC::DesiredRSCSpoolState state)
+{
+
+    SpoolState main_rotor_state = _main_rotor.update_spool_state(_dt_s, state);
+
+        // Check if main rotor is run-up complete.  Tail rotor run-up is not included in check because currently
+    // the tail rotor in DDVP uses the same ramp and runup time as the main rotor.  This may need changed if 
+    // the RSC is used for DDFP tail rotors.
     set_rotor_runup_complete(main_rotor_state == AP_MotorsHeli_RSC::RSCSpoolState::THROTTLE_UNLIMITED);
 
     return main_rotor_state;

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.cpp
@@ -136,7 +136,7 @@ void  AP_MotorsHeli_Quad::update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoo
 AP_Motors::SpoolState AP_MotorsHeli_Quad::update_spool_state(AP_MotorsHeli_RSC::DesiredRSCSpoolState state)
 {
 
-    SpoolState main_rotor_state = _main_rotor.update_spool_state(_dt_s, state);
+    SpoolState main_rotor_state = _main_rotor.update_spool_state(state, _dt_s);
 
     // Check if main rotor is run-up complete.  Tail rotor run-up is not included in check because currently
     // the tail rotor in DDVP uses the same ramp and runup time as the main rotor.  This may need changed if 

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.h
@@ -51,7 +51,10 @@ protected:
     void init_outputs () override;
 
     // update_motor_controls - sends commands to motor controllers
-    AP_Motors::SpoolState update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state) override;
+    void update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state) override;
+
+    // update_spool_state - updates the spool state based on the desired state
+    AP_Motors::SpoolState update_spool_state(AP_MotorsHeli_RSC::DesiredRSCSpoolState state) override;
 
     // calculate_roll_pitch_collective_factors - setup rate factors
     void calculate_roll_pitch_collective_factors ();

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -316,19 +316,14 @@ void AP_MotorsHeli_RSC::set_throttle_curve()
 }
 
 // update - ran each loop to update the RSC
-AP_MotorsHeli_RSC::RSCSpoolState AP_MotorsHeli_RSC::update(DesiredRSCSpoolState desired_spool_state)
+void AP_MotorsHeli_RSC::update(float dt)
 {
 
-    // if control mode is disabled, then we should always be in SHUT_DOWN spool state and ignore any other desired spool state inputs
+    // if control mode is disabled, then control output is forced to zero and no other updates are needed
     if (_rsc_control_mode == ROTOR_CONTROL_MODE_DISABLED) {
-        _desired_spool_state = DesiredRSCSpoolState::SHUT_DOWN;
-        update_spool_state();
         _control_output = 0.0f;
-        return _spool_state;
+        return;
     }
-
-    // set desired spool state
-    _desired_spool_state = desired_spool_state;
 
     // _rotor_RPM available to the RSC output
 #if AP_RPM_ENABLED
@@ -346,22 +341,10 @@ AP_MotorsHeli_RSC::RSCSpoolState AP_MotorsHeli_RSC::update(DesiredRSCSpoolState 
     _rotor_rpm = -1;
 #endif
 
-    float dt;
-    uint64_t now = AP_HAL::micros64();
     float last_control_output = _control_output;
-
-    if (_last_update_us == 0) {
-        _last_update_us = now;
-        dt = 0.001f;
-    } else {
-        dt = 1.0e-6f * (now - _last_update_us);
-        _last_update_us = now;
-    }
 
     switch (_desired_spool_state) {
         case DesiredRSCSpoolState::SHUT_DOWN:
-            // set rotor ramp to decrease speed to zero, this happens instantly inside update_rotor_ramp()
-            update_rotor_ramp(0.0f, dt);
 
             // control output forced to zero
             _control_output = 0.0f;
@@ -384,9 +367,6 @@ AP_MotorsHeli_RSC::RSCSpoolState AP_MotorsHeli_RSC::update(DesiredRSCSpoolState 
             break;
 
         case DesiredRSCSpoolState::GROUND_IDLE:
-            // set rotor ramp to decrease speed to zero
-            update_rotor_ramp(0.0f, dt);
-
             // set rotor control speed to engine idle and ensure governor is reset, if used
             governor_reset();
             _autothrottle = false;
@@ -426,9 +406,6 @@ AP_MotorsHeli_RSC::RSCSpoolState AP_MotorsHeli_RSC::update(DesiredRSCSpoolState 
             break;
 
         case DesiredRSCSpoolState::THROTTLE_UNLIMITED:
-            // set main rotor ramp to increase to full speed
-            update_rotor_ramp(1.0f, dt);
-
             // set fast idle timer so next time RSC goes to idle, the cooldown timer starts
             if (_cooldown_time.get() > 0) {
                 _fast_idle_timer = _cooldown_time.get();
@@ -454,29 +431,51 @@ AP_MotorsHeli_RSC::RSCSpoolState AP_MotorsHeli_RSC::update(DesiredRSCSpoolState 
             break;
     }
 
-    // update rotor speed run-up estimate
-    update_rotor_runup(dt);
-
-    update_spool_state();
-
     if (_power_slewrate > 0) {
         // implement slew rate for throttle
         float max_delta = dt * _power_slewrate * 0.01f;
         _control_output = constrain_float(_control_output, last_control_output-max_delta, last_control_output+max_delta);
     }
-    return _spool_state;
-
 }
 
 // update_spool_state - updates the spool state machine based on the desired spool state and current spool state
-void AP_MotorsHeli_RSC::update_spool_state()
+AP_MotorsHeli_RSC::RSCSpoolState AP_MotorsHeli_RSC::update_spool_state(float dt, AP_MotorsHeli_RSC::DesiredRSCSpoolState desired_spool_state)
 {
+
+    // if control mode is disabled, then we should always be in SHUT_DOWN spool state and ignore any other desired spool state inputs
+    if (_rsc_control_mode == ROTOR_CONTROL_MODE_DISABLED) {
+        desired_spool_state = DesiredRSCSpoolState::SHUT_DOWN;
+    }
+
+    // set desired spool state
+    _desired_spool_state = desired_spool_state;
 
     if (_desired_spool_state == DesiredRSCSpoolState::SHUT_DOWN) {
         // if we are shutting down, we want to immediately go to SHUT_DOWN state and not wait for spool down to complete
         _spool_state = RSCSpoolState::SHUT_DOWN;
-        return;
+        return _spool_state;
     }
+
+    switch (_desired_spool_state) {
+        case DesiredRSCSpoolState::SHUT_DOWN:
+            // set rotor ramp to decrease speed to zero, this happens instantly inside update_rotor_ramp()
+            update_rotor_ramp(0.0f, dt);
+            break;
+
+        case DesiredRSCSpoolState::GROUND_IDLE:
+            // set rotor ramp to decrease speed to zero
+            update_rotor_ramp(0.0f, dt);
+            break;
+
+        case DesiredRSCSpoolState::THROTTLE_UNLIMITED:
+            // set main rotor ramp to increase to full speed
+            update_rotor_ramp(1.0f, dt);
+            break;
+    }
+
+    // update rotor speed run-up estimate
+    update_rotor_runup(dt);
+
     switch (_spool_state) {
         case RSCSpoolState::SHUT_DOWN:
             // Motors should be stationary.
@@ -534,6 +533,7 @@ void AP_MotorsHeli_RSC::update_spool_state()
             }
             break;
     }
+    return _spool_state;
 }
 
 // update_rotor_ramp - slews rotor output scalar between 0 and 1, outputs float scalar to _rotor_ramp_output

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -450,14 +450,10 @@ AP_MotorsHeli_RSC::RSCSpoolState AP_MotorsHeli_RSC::update_spool_state(float dt,
     // set desired spool state
     _desired_spool_state = desired_spool_state;
 
-    if (_desired_spool_state == DesiredRSCSpoolState::SHUT_DOWN) {
-        // if we are shutting down, we want to immediately go to SHUT_DOWN state and not wait for spool down to complete
-        _spool_state = RSCSpoolState::SHUT_DOWN;
-        return _spool_state;
-    }
-
     switch (_desired_spool_state) {
         case DesiredRSCSpoolState::SHUT_DOWN:
+            // if we are shutting down, we want to immediately go to SHUT_DOWN state and not wait for spool down to complete
+            _spool_state = RSCSpoolState::SHUT_DOWN;
             // set rotor ramp to decrease speed to zero, this happens instantly inside update_rotor_ramp()
             update_rotor_ramp(0.0f, dt);
             break;

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -439,7 +439,7 @@ void AP_MotorsHeli_RSC::update(float dt)
 }
 
 // update_spool_state - updates the spool state machine based on the desired spool state and current spool state
-AP_MotorsHeli_RSC::RSCSpoolState AP_MotorsHeli_RSC::update_spool_state(float dt, AP_MotorsHeli_RSC::DesiredRSCSpoolState desired_spool_state)
+AP_MotorsHeli_RSC::RSCSpoolState AP_MotorsHeli_RSC::update_spool_state(AP_MotorsHeli_RSC::DesiredRSCSpoolState desired_spool_state, float dt)
 {
 
     // if control mode is disabled, then we should always be in SHUT_DOWN spool state and ignore any other desired spool state inputs

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -56,7 +56,7 @@ public:
     void        update(float dt);
 
     // update_spool_state - updates the spool state machine based on the desired spool state and current spool state
-    RSCSpoolState   update_spool_state(float dt, DesiredRSCSpoolState desired_spool_state);
+    RSCSpoolState   update_spool_state(DesiredRSCSpoolState desired_spool_state, float dt);
 
     // output_to_servo - outputs pwm onto output rsc channel.
     void        output_to_servo() { write_rsc(_control_output);}

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -53,7 +53,10 @@ public:
     void        configure_armed();
 
     // update - runs RSC logic and outputs to motors, returns current spool state for use in motor output logic
-    RSCSpoolState        update(DesiredRSCSpoolState desired_spool_state);
+    void        update(float dt);
+
+    // update_spool_state - updates the spool state machine based on the desired spool state and current spool state
+    RSCSpoolState   update_spool_state(float dt, DesiredRSCSpoolState desired_spool_state);
 
     // output_to_servo - outputs pwm onto output rsc channel.
     void        output_to_servo() { write_rsc(_control_output);}
@@ -98,9 +101,6 @@ public:
     AP_Int16        _idle_output;             // Rotor control output while at idle
 
 private:
-
-    // update_spool_state - updates the spool state machine based on the desired spool state and current spool state
-    void            update_spool_state();
 
     // set_rsc_control_mode - sets RSC control mode
     void            set_rsc_control_mode(RotorControlMode mode) { _rsc_control_mode = mode; }

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -265,11 +265,11 @@ uint32_t AP_MotorsHeli_Single::get_motor_mask()
 }
 
 // update_motor_controls - sends commands to motor controllers
-AP_Motors::SpoolState AP_MotorsHeli_Single::update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state)
+void AP_MotorsHeli_Single::update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state)
 {
     // Send state update to motors
-    _tail_rotor.update(state);
-    AP_MotorsHeli_RSC::RSCSpoolState main_rotor_state = _main_rotor.update(state);
+    _tail_rotor.update(_dt_s);
+    _main_rotor.update(_dt_s);
 
     if (state == AP_MotorsHeli_RSC::DesiredRSCSpoolState::SHUT_DOWN){
         // set engine run enable aux output to not run position to kill engine when disarmed
@@ -279,7 +279,16 @@ AP_Motors::SpoolState AP_MotorsHeli_Single::update_motor_control(AP_MotorsHeli_R
         SRV_Channels::set_output_limit(SRV_Channel::k_engine_run_enable, SRV_Channel::Limit::MAX);
     }
     
-    // Check if main rotor is run-up complete.  Tail rotor run-up is not included in check because currently
+}
+
+// update_spool_state - updates the spool state based on the desired state
+AP_Motors::SpoolState AP_MotorsHeli_Single::update_spool_state(AP_MotorsHeli_RSC::DesiredRSCSpoolState state)
+{
+
+    _tail_rotor.update_spool_state(_dt_s, state);
+    SpoolState main_rotor_state = _main_rotor.update_spool_state(_dt_s, state);
+
+        // Check if main rotor is run-up complete.  Tail rotor run-up is not included in check because currently
     // the tail rotor in DDVP uses the same ramp and runup time as the main rotor.  This may need changed if 
     // the RSC is used for DDFP tail rotors.
     set_rotor_runup_complete(main_rotor_state == AP_MotorsHeli_RSC::RSCSpoolState::THROTTLE_UNLIMITED);
@@ -287,7 +296,6 @@ AP_Motors::SpoolState AP_MotorsHeli_Single::update_motor_control(AP_MotorsHeli_R
     return main_rotor_state;
 
 }
-
 //
 // move_actuators - moves swash plate and tail rotor
 //                 - expected ranges:

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -285,8 +285,8 @@ void AP_MotorsHeli_Single::update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpo
 AP_Motors::SpoolState AP_MotorsHeli_Single::update_spool_state(AP_MotorsHeli_RSC::DesiredRSCSpoolState state)
 {
 
-    _tail_rotor.update_spool_state(_dt_s, state);
-    SpoolState main_rotor_state = _main_rotor.update_spool_state(_dt_s, state);
+    _tail_rotor.update_spool_state(state, _dt_s);
+    SpoolState main_rotor_state = _main_rotor.update_spool_state(state, _dt_s);
 
     // Check if main rotor is run-up complete.  Tail rotor run-up is not included in check because currently
     // the tail rotor in DDVP uses the same ramp and runup time as the main rotor.  This may need changed if 

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -288,7 +288,7 @@ AP_Motors::SpoolState AP_MotorsHeli_Single::update_spool_state(AP_MotorsHeli_RSC
     _tail_rotor.update_spool_state(_dt_s, state);
     SpoolState main_rotor_state = _main_rotor.update_spool_state(_dt_s, state);
 
-        // Check if main rotor is run-up complete.  Tail rotor run-up is not included in check because currently
+    // Check if main rotor is run-up complete.  Tail rotor run-up is not included in check because currently
     // the tail rotor in DDVP uses the same ramp and runup time as the main rotor.  This may need changed if 
     // the RSC is used for DDFP tail rotors.
     set_rotor_runup_complete(main_rotor_state == AP_MotorsHeli_RSC::RSCSpoolState::THROTTLE_UNLIMITED);
@@ -296,6 +296,7 @@ AP_Motors::SpoolState AP_MotorsHeli_Single::update_spool_state(AP_MotorsHeli_RSC
     return main_rotor_state;
 
 }
+
 //
 // move_actuators - moves swash plate and tail rotor
 //                 - expected ranges:

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.h
@@ -70,7 +70,10 @@ protected:
     void init_outputs() override;
 
     // update_motor_controls - sends commands to motor controllers
-    AP_Motors::SpoolState update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state) override;
+    void update_motor_control(AP_MotorsHeli_RSC::DesiredRSCSpoolState state) override;
+
+    // update_spool_state - updates the spool state based on the desired state
+    AP_Motors::SpoolState update_spool_state(AP_MotorsHeli_RSC::DesiredRSCSpoolState state) override;
 
     // heli_move_actuators - moves swash plate and tail rotor
     void move_actuators(float roll_out, float pitch_out, float coll_in, float yaw_out) override;


### PR DESCRIPTION
### Summary

This PR reorganizes the recent Rotor Speed Control rework.  With the rework, the update to spool state moved into the RSC and was combined with the RSC Update.  This moved the update earlier before the motors move_actuators method is called.  The RSC update is best to be called after move actuators especially since DDFP will be moved into the RSC and the control output depends on move_actuators.  

Thus the spool state update was separated from the RSC update method.  Within the spool state update, the update to rotor ramp and rotor runup was also included to ensure the rotor runup complete flags were set at the same time.  

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Tested manually, description below 
       All modes of RSC tested to ensure RSC behaved as expected



