### PR TITLE
AP_HAL_QURT: Add support for the ModalAI VOXL3 board

### DIFF
--- a/Tools/ardupilotwaf/qurt.py
+++ b/Tools/ardupilotwaf/qurt.py
@@ -66,6 +66,7 @@ def build(bld):
     STUB_SO = bld.bldnode.find_or_declare('slpi_link_stub.so')
     MAIN_CPP = bld.srcnode.make_node('libraries/AP_HAL_QURT/ap_host/src/main.cpp')
     IFADDR_CPP = bld.srcnode.make_node('libraries/AP_HAL_QURT/ap_host/src/getifaddrs.cpp')
+    UART_CPP = bld.srcnode.make_node('libraries/AP_HAL_QURT/ap_host/src/RemoteUARTDriver.cpp')
     AP_HOST = bld.bldnode.find_or_declare('ardupilot')
 
     bld(
@@ -78,9 +79,9 @@ def build(bld):
 
     bld(
         # build ap_host
-        source=[STUB_SO, MAIN_CPP],
-        rule="%s -I%s %s %s %s -lpthread -o %s" % (AARCH64_CXX, STUB_INC.abspath(),
-                                          MAIN_CPP.abspath(), IFADDR_CPP.abspath(), STUB_SO.abspath(), AP_HOST.abspath()),
+        source=[STUB_SO, MAIN_CPP, UART_CPP],
+        rule="%s -I%s %s %s %s %s -lpthread -o %s" % (AARCH64_CXX, STUB_INC.abspath(),
+                                          MAIN_CPP.abspath(), IFADDR_CPP.abspath(), UART_CPP.abspath(), STUB_SO.abspath(), AP_HOST.abspath()),
         target=[AP_HOST],
         group='dynamic_sources'
     )

--- a/libraries/AP_HAL/board/qurt.h
+++ b/libraries/AP_HAL/board/qurt.h
@@ -100,3 +100,11 @@
 #include <AP_HAL_QURT/replace.h>
 
 #define DEFAULT_SERIAL4_PROTOCOL 23 // RC input
+
+// enable SerialManager::register_port() so tunneled remote UARTs can
+// be assigned any protocol via SERIALn_PROTOCOL parameters
+#define AP_SERIALMANAGER_REGISTER_ENABLED 1
+
+// 10 serial slots: SERIAL0..SERIAL4 are MAVLink/GPS/RCIN, SERIAL5..SERIAL9
+// are the 5 tunneled remote serial ports registered with AP_SerialManager.
+#define HAL_UART_NUM_SERIAL_PORTS 10

--- a/libraries/AP_HAL_QURT/AP_HAL_QURT_Namespace.h
+++ b/libraries/AP_HAL_QURT/AP_HAL_QURT_Namespace.h
@@ -21,6 +21,7 @@ class UARTDriver;
 class UARTDriver_Console;
 class UARTDriver_MAVLinkUDP;
 class UARTDriver_Local;
+class UARTDriver_RemoteRegistered;
 class UDPDriver;
 class Util;
 class Scheduler;

--- a/libraries/AP_HAL_QURT/HAL_QURT_Class.cpp
+++ b/libraries/AP_HAL_QURT/HAL_QURT_Class.cpp
@@ -47,8 +47,62 @@ using namespace QURT;
 static UARTDriver_Console consoleDriver;
 static UARTDriver_MAVLinkUDP serial0Driver(0);
 static UARTDriver_MAVLinkUDP serial1Driver(1);
+
+/*
+  SERIAL3 defaults to the DSP-local GPS UART. Boards that run GPS through
+  a UART on the apps processor instead (e.g. ModalAI-VOXL3) define
+  HAL_NO_DSP_GPS_UART in hwdef and leave SERIAL3 unclaimed; the remote
+  GPS is reached via one of the registered tunneled serial ports.
+ */
+#ifndef HAL_NO_DSP_GPS_UART
 static UARTDriver_Local serial3Driver(QURT_UART_GPS);
+#endif
+
 static UARTDriver_Local serial4Driver(QURT_UART_RCIN);
+
+/*
+  Per-slot device IDs for the 5 tunneled remote serial ports. Each device id
+  maps to "/dev/ttyHS<device_id>" on the apps processor. Boards set these
+  explicitly in hwdef.dat; values here are only a fallback for boards that
+  leave them unset.
+ */
+#ifndef APPS_REMOTE_UART_0_DEVICE
+  #define APPS_REMOTE_UART_0_DEVICE 0
+#endif
+#ifndef APPS_REMOTE_UART_1_DEVICE
+  #define APPS_REMOTE_UART_1_DEVICE 1
+#endif
+#ifndef APPS_REMOTE_UART_2_DEVICE
+  #define APPS_REMOTE_UART_2_DEVICE 2
+#endif
+#ifndef APPS_REMOTE_UART_3_DEVICE
+  #define APPS_REMOTE_UART_3_DEVICE 3
+#endif
+#ifndef APPS_REMOTE_UART_4_DEVICE
+  #define APPS_REMOTE_UART_4_DEVICE 4
+#endif
+
+/*
+  SERIALn slot each remote port occupies. Chosen to avoid the fixed HAL slots
+  (SERIAL0..SERIAL4 carry MAVLink/GPS/RCIN on existing targets).
+ */
+static const uint8_t remote_uart_serial_idx[] = { 5, 6, 7, 8, 9 };
+
+static UARTDriver_RemoteRegistered remote_uart_ports[] = {
+    { 0, APPS_REMOTE_UART_0_DEVICE },
+    { 1, APPS_REMOTE_UART_1_DEVICE },
+    { 2, APPS_REMOTE_UART_2_DEVICE },
+    { 3, APPS_REMOTE_UART_3_DEVICE },
+    { 4, APPS_REMOTE_UART_4_DEVICE },
+};
+
+// Catch a future mismatch between the protocol cap and the per-board
+// configuration arrays at compile time rather than walking off the end
+// of them in the registration loop below.
+static_assert(ARRAY_SIZE(remote_uart_ports) == MAX_REMOTE_UART_INSTANCES,
+              "remote_uart_ports size must match MAX_REMOTE_UART_INSTANCES");
+static_assert(ARRAY_SIZE(remote_uart_serial_idx) == MAX_REMOTE_UART_INSTANCES,
+              "remote_uart_serial_idx size must match MAX_REMOTE_UART_INSTANCES");
 
 static SPIDeviceManager spiDeviceManager;
 static AnalogIn analogIn;
@@ -67,7 +121,11 @@ HAL_QURT::HAL_QURT() :
         &serial0Driver,
         &serial1Driver,
         nullptr,
+#ifndef HAL_NO_DSP_GPS_UART
         &serial3Driver,
+#else
+        nullptr,
+#endif
         &serial4Driver,
         nullptr,
         nullptr,
@@ -135,6 +193,13 @@ void HAL_QURT::run(int argc, char* const argv[], Callbacks* callbacks) const
      * up to the programmer to do this in the correct order.
      * Scheduler should likely come first. */
     scheduler->init();
+
+    // register tunneled remote serial ports before hal_initialized() so the
+    // uart thread will start ticking them as soon as it starts
+    for (uint8_t i = 0; i < MAX_REMOTE_UART_INSTANCES; i++) {
+        remote_uart_ports[i].init(remote_uart_serial_idx[i]);
+    }
+
     schedulerInstance.hal_initialized();
     serial0Driver.begin(115200);
 

--- a/libraries/AP_HAL_QURT/I2CDevice.cpp
+++ b/libraries/AP_HAL_QURT/I2CDevice.cpp
@@ -23,16 +23,13 @@
 using namespace QURT;
 
 /*
-  4 I2C buses
-
-  bus1: mag
-  bus2: power manager
-  bus5: barometer (internal)*
-  bus4: external spare bus (unused)
+  I2C bus map is defined per-board in hwdef.dat (see I2C_BUS directive).
+  HAL_QURT_I2C_BUS_IDS lists physical SLPI bus ids in logical order;
+  HAL_QURT_I2C_INTERNAL_MASK is a bitmask of logical indices flagged internal.
 */
-static uint8_t i2c_bus_ids[] = { 1, 2, 5 };
+static uint8_t i2c_bus_ids[] = HAL_QURT_I2C_BUS_IDS;
 
-static uint32_t i2c_internal_mask = (1U<<3);
+static uint32_t i2c_internal_mask = HAL_QURT_I2C_INTERNAL_MASK;
 
 I2CBus I2CDeviceManager::businfo[ARRAY_SIZE(i2c_bus_ids)];
 

--- a/libraries/AP_HAL_QURT/Scheduler.cpp
+++ b/libraries/AP_HAL_QURT/Scheduler.cpp
@@ -17,6 +17,7 @@
 #include "RCOutput.h"
 #include "RCInput.h"
 #include <AP_Scheduler/AP_Scheduler.h>
+#include <AP_SerialManager/AP_SerialManager.h>
 #include "Thread.h"
 
 using namespace QURT;
@@ -297,10 +298,21 @@ void *Scheduler::_uart_thread(void *arg)
     while (true) {
         sched->delay_microseconds(200);
 
-        // process any pending serial bytes
+        // process any pending serial bytes on fixed HAL serial slots
         for (uint8_t i = 0; i < hal.num_serial; i++) {
             auto *p = hal.serial(i);
             if (p != nullptr) {
+                p->_timer_tick();
+            }
+        }
+
+        // and on any ports registered with AP_SerialManager (tunneled
+        // remote serial ports on QURT, networking ports, etc.). Hold
+        // port_sem since register_port() can splice this list at runtime.
+        {
+            auto &sm = AP::serialmanager();
+            WITH_SEMAPHORE(sm.port_sem);
+            for (auto *p = sm.registered_ports; p != nullptr; p = p->next) {
                 p->_timer_tick();
             }
         }

--- a/libraries/AP_HAL_QURT/UARTDriver.cpp
+++ b/libraries/AP_HAL_QURT/UARTDriver.cpp
@@ -286,3 +286,218 @@ uint64_t UARTDriver_Local::receive_time_constraint_us(uint16_t nbytes)
     }
     return last_receive_us;
 }
+
+/*
+  methods for UARTDriver_RemoteRegistered — a dynamic serial port that
+  tunnels to a UART on the apps processor. The port is registered with
+  AP_SerialManager at boot; the user selects a protocol for it via the
+  SERIALn_PROTOCOL parameter matching the registered state.idx.
+*/
+typedef void (*remote_uart_data_callback_t)(const struct qurt_rpc_msg *msg, void *p);
+extern void register_remote_uart_data_callback(uint8_t port_id,
+                                               remote_uart_data_callback_t func,
+                                               void *p);
+
+void UARTDriver_RemoteRegistered::init(uint8_t serial_idx)
+{
+    state.idx = serial_idx;
+    // this port's protocol and baud come from the matching SERIALn_*
+    // parameters via AP_SerialManager::state[serial_idx]; leave our own
+    // state.protocol at SerialProtocol_None so it is not matched in the
+    // registered_ports search path of find_protocol_instance()
+    state.protocol.set(AP_SerialManager::SerialProtocol_None);
+    // register once; data callbacks start flowing immediately
+    register_remote_uart_data_callback(port_id, uart_data_cb, (void *)this);
+    AP::serialmanager().register_port(this);
+}
+
+uint32_t UARTDriver_RemoteRegistered::get_baud_rate() const
+{
+    // once _begin() has been called, return the negotiated baud
+    if (baudrate != 0) {
+        return baudrate;
+    }
+    // before first _begin(), fall back to the SERIALn_BAUD configured
+    // for our slot. AP_GPS's auto-baud detection calls get_baud_rate()
+    // to seed its first probe; returning 0 here would wedge the probe
+    // in a begin(0) loop (_begin skips send_config when b==0).
+    const auto *st = AP::serialmanager().get_state_by_id(state.idx);
+    return st != nullptr ? st->baudrate() : 0;
+}
+
+bool UARTDriver_RemoteRegistered::tx_pending()
+{
+    WITH_SEMAPHORE(write_mutex);
+    return writebuffer != nullptr && writebuffer->available() > 0;
+}
+
+uint32_t UARTDriver_RemoteRegistered::txspace()
+{
+    WITH_SEMAPHORE(write_mutex);
+    return writebuffer != nullptr ? writebuffer->space() : 0;
+}
+
+bool UARTDriver_RemoteRegistered::send_config(uint32_t b)
+{
+    struct qurt_rpc_msg msg {};
+    msg.msg_id = QURT_MSG_ID_UART_CONFIG;
+    msg.inst = port_id;
+    msg.seq = 0;
+    struct qurt_uart_config cfg {};
+    cfg.baudrate = b;
+    cfg.device_id = device_id;
+    cfg.port_id = port_id;
+    msg.data_length = sizeof(cfg);
+    memcpy(msg.data, &cfg, sizeof(cfg));
+    if (!qurt_rpc_send(msg)) {
+        DEV_PRINTF("Remote UART %u: config send failed (baud=%lu device=%lu)",
+                   (unsigned)port_id,
+                   (unsigned long)b,
+                   (unsigned long)device_id);
+        return false;
+    }
+    return true;
+}
+
+void UARTDriver_RemoteRegistered::_begin(uint32_t b, uint16_t rxS, uint16_t txS)
+{
+    if (rxS < 4096) {
+        rxS = 4096;
+    }
+    if (txS < 4096) {
+        txS = 4096;
+    }
+
+    {
+        WITH_SEMAPHORE(read_mutex);
+        if (readbuffer == nullptr) {
+            readbuffer = NEW_NOTHROW ByteBuffer(rxS);
+        } else {
+            readbuffer->set_size_best(rxS);
+        }
+    }
+    {
+        WITH_SEMAPHORE(write_mutex);
+        if (writebuffer == nullptr) {
+            writebuffer = NEW_NOTHROW ByteBuffer(txS);
+        } else {
+            writebuffer->set_size_best(txS);
+        }
+    }
+
+    initialised = (readbuffer != nullptr) && (writebuffer != nullptr);
+
+    if (b != 0 && initialised && (!remote_configured || baudrate != b)) {
+        {
+            WITH_SEMAPHORE(read_mutex);
+            readbuffer->clear();
+        }
+        if (send_config(b)) {
+            baudrate = b;
+            remote_configured = true;
+        }
+    }
+}
+
+size_t UARTDriver_RemoteRegistered::_write(const uint8_t *buffer, size_t size)
+{
+    WITH_SEMAPHORE(write_mutex);
+    return writebuffer != nullptr ? writebuffer->write(buffer, size) : 0;
+}
+
+ssize_t UARTDriver_RemoteRegistered::_read(uint8_t *buffer, uint16_t count)
+{
+    WITH_SEMAPHORE(read_mutex);
+    return readbuffer != nullptr ? readbuffer->read(buffer, count) : -1;
+}
+
+uint32_t UARTDriver_RemoteRegistered::_available()
+{
+    WITH_SEMAPHORE(read_mutex);
+    return readbuffer != nullptr ? readbuffer->available() : 0;
+}
+
+bool UARTDriver_RemoteRegistered::_discard_input()
+{
+    WITH_SEMAPHORE(read_mutex);
+    if (readbuffer != nullptr) {
+        readbuffer->clear();
+    }
+    return true;
+}
+
+bool UARTDriver_RemoteRegistered::push_pending_bytes()
+{
+    if (!remote_configured) {
+        return false;
+    }
+
+    WITH_SEMAPHORE(write_mutex);
+
+    if (writebuffer == nullptr) {
+        return false;
+    }
+
+    uint32_t available;
+    const uint8_t *ptr = writebuffer->readptr(available);
+    if (ptr == nullptr || available == 0) {
+        return false;
+    }
+
+    struct qurt_rpc_msg msg {};
+    const uint16_t n = (uint16_t)(available < sizeof(msg.data) ? available : sizeof(msg.data));
+
+    msg.msg_id = QURT_MSG_ID_UART_DATA;
+    msg.inst = port_id;
+    msg.seq = tx_seq++;
+    msg.data_length = n;
+    memcpy(msg.data, ptr, n);
+
+    if (qurt_rpc_send(msg)) {
+        writebuffer->advance(n);
+        return true;
+    }
+    return false;
+}
+
+void UARTDriver_RemoteRegistered::_timer_tick(void)
+{
+    if (!initialised) {
+        return;
+    }
+    // cap chunks per tick so one port can't starve the others in the
+    // shared uart thread (each chunk is up to sizeof(qurt_rpc_msg::data))
+    constexpr uint8_t MAX_TX_BURST = 10;
+    for (uint8_t i = 0; i < MAX_TX_BURST; i++) {
+        if (!push_pending_bytes()) {
+            break;
+        }
+    }
+}
+
+void UARTDriver_RemoteRegistered::uart_data_cb(const struct qurt_rpc_msg *msg, void *p)
+{
+    auto *driver = (UARTDriver_RemoteRegistered *)p;
+    if (msg->seq != driver->rx_seq) {
+        DEV_PRINTF("Remote UART %u: RX seq mismatch expected=%lu got=%lu len=%u",
+                   (unsigned)driver->port_id,
+                   (unsigned long)driver->rx_seq,
+                   (unsigned long)msg->seq,
+                   msg->data_length);
+        driver->rx_seq = msg->seq;
+    }
+    WITH_SEMAPHORE(driver->read_mutex);
+    if (driver->readbuffer == nullptr) {
+        return;
+    }
+    const uint16_t written = driver->readbuffer->write(msg->data, msg->data_length);
+    if (written != msg->data_length) {
+        DEV_PRINTF("Remote UART %u: RX buffer dropped %u/%u bytes (space=%u)",
+                   (unsigned)driver->port_id,
+                   (unsigned)(msg->data_length - written),
+                   (unsigned)msg->data_length,
+                   (unsigned)driver->readbuffer->space());
+    }
+
+    driver->rx_seq++;
+}

--- a/libraries/AP_HAL_QURT/UARTDriver.h
+++ b/libraries/AP_HAL_QURT/UARTDriver.h
@@ -18,6 +18,7 @@
 #include "AP_HAL_QURT.h"
 #include "Semaphores.h"
 #include <AP_HAL/utility/RingBuffer.h>
+#include <AP_SerialManager/AP_SerialManager.h>
 #include "ap_host/src/protocol.h"
 
 class QURT::UARTDriver : public AP_HAL::UARTDriver
@@ -134,4 +135,60 @@ private:
     int fd = -1;
     uint32_t baudrate;
     uint64_t receive_timestamp_us;
+};
+
+/*
+  RegisteredPort subclass for tunneled UARTs on the apps processor.
+  Each instance owns a fixed port_id (embedded in the encapsulating
+  qurt_rpc_msg) and a hardcoded device_id (mapped to /dev/ttyHS<id>
+  on the apps processor). Multiple instances can be registered so
+  the user can assign any SERIALn_PROTOCOL to each.
+*/
+class QURT::UARTDriver_RemoteRegistered : public AP_SerialManager::RegisteredPort
+{
+public:
+    UARTDriver_RemoteRegistered(uint8_t _port_id, uint32_t _device_id)
+        : port_id(_port_id), device_id(_device_id) {}
+
+    // called once at boot to register with SerialManager
+    void init(uint8_t serial_idx);
+
+    // called from the HAL timer thread to drain the tx buffer
+    void _timer_tick(void) override;
+
+    // receive callback invoked when a UART_DATA packet for this port
+    // arrives from the apps processor
+    static void uart_data_cb(const struct qurt_rpc_msg *msg, void *p);
+
+    bool is_initialized() override { return initialised; }
+    bool tx_pending() override;
+    uint32_t txspace() override;
+    uint32_t get_baud_rate() const override;
+
+protected:
+    void     _begin(uint32_t b, uint16_t rxS, uint16_t txS) override;
+    size_t   _write(const uint8_t *buffer, size_t size) override;
+    ssize_t  _read(uint8_t *buffer, uint16_t count) override;
+    uint32_t _available() override;
+    void     _end() override {}
+    void     _flush() override {}
+    bool     _discard_input() override;
+
+private:
+    bool send_config(uint32_t b);
+    bool push_pending_bytes();
+
+    const uint8_t  port_id;
+    const uint32_t device_id;
+
+    ByteBuffer *readbuffer = nullptr;
+    ByteBuffer *writebuffer = nullptr;
+    QURT::Semaphore read_mutex;
+    QURT::Semaphore write_mutex;
+
+    uint32_t baudrate = 0;
+    uint32_t tx_seq = 0;
+    uint32_t rx_seq = 0;
+    bool remote_configured = false;
+    bool initialised = false;
 };

--- a/libraries/AP_HAL_QURT/ap_host/src/RemoteUARTDriver.cpp
+++ b/libraries/AP_HAL_QURT/ap_host/src/RemoteUARTDriver.cpp
@@ -1,0 +1,216 @@
+/*
+  Generic UART relay driver for the ap_host process.
+  Handles serial port open/configure/read/write and the receive thread.
+  Uses termios2/ioctl for arbitrary baud rate support.
+*/
+
+#include "RemoteUARTDriver.h"
+#include "protocol.h"
+#include "slpi_link.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <asm/ioctls.h>
+#include <asm/termbits.h>
+
+// Note: <termios.h> is intentionally NOT included here as it
+// conflicts with <asm/termbits.h>. We use ioctl(TCGETS2/TCSETS2)
+// with struct termios2 instead, which supports arbitrary baud rates.
+
+RemoteUARTDriver::~RemoteUARTDriver()
+{
+    _close();
+    if (_thread_running) {
+        pthread_join(_recv_thread_id, nullptr);
+        _thread_running = false;
+    }
+}
+
+bool RemoteUARTDriver::_open()
+{
+    if (_fd != -1) {
+        return true;
+    }
+
+    _fd = ::open(_device_path, O_RDWR | O_NOCTTY);
+    if (_fd < 0) {
+        _fd = -1;
+        fprintf(stderr, "Remote UART: failed to open %s: %s\n",
+                _device_path, strerror(errno));
+        return false;
+    }
+
+    struct termios2 t {};
+    if (ioctl(_fd, TCGETS2, &t) != 0) {
+        fprintf(stderr, "Remote UART: TCGETS2 failed for %s: %s\n",
+                _device_path, strerror(errno));
+        _close();
+        return false;
+    }
+
+    // raw mode (equivalent to cfmakeraw)
+    t.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP |
+                    INLCR | IGNCR | ICRNL | IXON | IXOFF);
+    t.c_oflag &= ~OPOST;
+    t.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
+
+    // 8N1, no flow control
+    t.c_cflag &= ~(CSIZE | PARENB | CSTOPB | CRTSCTS);
+    t.c_cflag |= CS8 | CLOCAL | CREAD;
+
+    // non-blocking reads with small timeout
+    t.c_cc[VMIN] = 0;
+    t.c_cc[VTIME] = 1;
+
+    if (ioctl(_fd, TCSETS2, &t) != 0) {
+        fprintf(stderr, "Remote UART: TCSETS2 failed for %s: %s\n",
+                _device_path, strerror(errno));
+        _close();
+        return false;
+    }
+
+    // flush any stale data
+    ioctl(_fd, TCFLSH, TCIOFLUSH);
+
+    return true;
+}
+
+void RemoteUARTDriver::_close()
+{
+    if (_fd != -1) {
+        ::close(_fd);
+        _fd = -1;
+    }
+}
+
+bool RemoteUARTDriver::_set_speed(uint32_t baudrate)
+{
+    struct termios2 t {};
+    if (ioctl(_fd, TCGETS2, &t) != 0) {
+        fprintf(stderr, "Remote UART: TCGETS2 failed for %s: %s\n",
+                _device_path, strerror(errno));
+        return false;
+    }
+
+    t.c_cflag &= ~CBAUD;
+#if defined(BOTHER)
+    t.c_cflag |= BOTHER;
+#endif
+    t.c_ispeed = baudrate;
+    t.c_ospeed = baudrate;
+
+    if (ioctl(_fd, TCSETS2, &t) != 0) {
+        fprintf(stderr, "Remote UART: set_speed(%u) failed for %s: %s\n",
+                baudrate, _device_path, strerror(errno));
+        return false;
+    }
+
+    // flush after speed change
+    ioctl(_fd, TCFLSH, TCIFLUSH);
+
+    return true;
+}
+
+bool RemoteUARTDriver::configure(uint32_t baudrate, uint32_t device_id)
+{
+    if (is_open()) {
+        if (device_id != _device_id) {
+            fprintf(stderr, "Remote UART: device id change not supported "
+                    "(current=%u, requested=%u)\n", _device_id, device_id);
+            return false;
+        }
+        if (!_set_speed(baudrate)) {
+            return false;
+        }
+        // printf("Remote UART: reconfigured baud=%u\n", baudrate);
+        return true;
+    }
+
+    snprintf(_device_path, sizeof(_device_path), "/dev/ttyHS%u", device_id);
+    _device_id = device_id;
+
+    if (!_open()) {
+        return false;
+    }
+    if (!_set_speed(baudrate)) {
+        _close();
+        return false;
+    }
+
+    printf("Remote UART: opened %s at baud=%u\n", _device_path, baudrate);
+    _start_recv_thread();
+    return true;
+}
+
+void RemoteUARTDriver::_start_recv_thread()
+{
+    if (_thread_running) {
+        return;
+    }
+    pthread_create(&_recv_thread_id, nullptr, _recv_thread_fn, this);
+    _thread_running = true;
+}
+
+void *RemoteUARTDriver::_recv_thread_fn(void *arg)
+{
+    static_cast<RemoteUARTDriver *>(arg)->_recv_loop();
+    return nullptr;
+}
+
+void RemoteUARTDriver::_recv_loop()
+{
+    // printf("Remote UART: read thread started\n");
+
+    while (is_open()) {
+        struct qurt_rpc_msg msg {};
+        ssize_t nread = ::read(_fd, msg.data, sizeof(msg.data));
+        if (nread <= 0) {
+            if (nread < 0 && errno != EINTR) {
+                fprintf(stderr, "Remote UART: read failed: %s\n", strerror(errno));
+            }
+            continue;
+        }
+
+        msg.msg_id = QURT_MSG_ID_UART_DATA;
+        msg.inst = _port_id;
+        msg.data_length = nread;
+        msg.seq = _rx_seq++;
+        if (slpi_link_send((const uint8_t *)&msg, nread + QURT_RPC_MSG_HEADER_LEN)) {
+            fprintf(stderr, "Remote UART: slpi_link_send failed\n");
+        }
+    }
+
+    // printf("Remote UART: read thread exiting\n");
+}
+
+bool RemoteUARTDriver::write(const uint8_t *buf, uint16_t len)
+{
+    if (!is_open() || len == 0) {
+        return false;
+    }
+
+    // All remote UART writes share the slpi_link callback thread,
+    // so we cannot block here - a clogged device would stall every
+    // other tunneled port and all other DSP to apps proc messaging.
+    // Issue a single non-blocking write and drop any bytes that weren't written.
+    // TODO: Look at other options like doing the writes in per port
+    // threads that can do retries.
+    const ssize_t written = ::write(_fd, buf, len);
+    if (written == (ssize_t)len) {
+        return true;
+    }
+    if (written < 0) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            fprintf(stderr, "Remote UART: dropped %u bytes (buffer full)\n", len);
+        } else {
+            fprintf(stderr, "Remote UART: write failed: %s\n", strerror(errno));
+        }
+    } else {
+        fprintf(stderr, "Remote UART: short write, dropped %u/%u bytes\n",
+                len - (uint16_t)written, len);
+    }
+    return false;
+}

--- a/libraries/AP_HAL_QURT/ap_host/src/RemoteUARTDriver.h
+++ b/libraries/AP_HAL_QURT/ap_host/src/RemoteUARTDriver.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <stdint.h>
+#include <unistd.h>
+#include <pthread.h>
+
+/*
+  Generic UART relay driver for the ap_host process.
+  The DSP sends a config message containing a baudrate and a device id;
+  the device id maps directly to the Linux path "/dev/ttyHS<device_id>".
+  The port_id is echoed back in the encapsulating RPC packet so the DSP
+  can demultiplex data across multiple tunneled ports.
+*/
+class RemoteUARTDriver {
+public:
+    explicit RemoteUARTDriver(uint8_t port_id) : _port_id(port_id) {}
+    ~RemoteUARTDriver();
+
+    bool configure(uint32_t baudrate, uint32_t device_id);
+    bool write(const uint8_t *buf, uint16_t len);
+    bool is_open() const { return _fd != -1; }
+
+private:
+    bool _open();
+    void _close();
+    bool _set_speed(uint32_t baudrate);
+    void _start_recv_thread();
+    void _recv_loop();
+    static void *_recv_thread_fn(void *arg);
+
+    const uint8_t _port_id;
+    char _device_path[32] {};
+    uint32_t _device_id = 0;
+    int _fd = -1;
+
+    // recv thread
+    pthread_t _recv_thread_id {};
+    bool _thread_running = false;
+    uint32_t _rx_seq = 0;
+};

--- a/libraries/AP_HAL_QURT/ap_host/src/main.cpp
+++ b/libraries/AP_HAL_QURT/ap_host/src/main.cpp
@@ -19,6 +19,8 @@
 #include "protocol.h"
 #include "getifaddrs.h"
 
+#include "RemoteUARTDriver.h"
+
 volatile bool _running = false;
 static bool enable_debug = false;
 static bool enable_remote_debug = false;
@@ -43,7 +45,6 @@ static struct sockaddr_in obd_addr;
 // Ports for external GCS stream
 #define MAVLINK_GCS_UDP_PORT_LOCAL 14558
 #define MAVLINK_GCS_UDP_PORT_REMOTE 14559
-
 
 // directory for logs, parameters, terrain etc
 #define DATA_DIRECTORY "/data/APM"
@@ -74,6 +75,15 @@ static void slpi_init(void);
 
 static uint32_t num_params = 0;
 static uint32_t expected_seq[MAX_MAVLINK_INSTANCES] = {0, 0};
+static RemoteUARTDriver remote_uarts[] = {
+    RemoteUARTDriver(0),
+    RemoteUARTDriver(1),
+    RemoteUARTDriver(2),
+    RemoteUARTDriver(3),
+    RemoteUARTDriver(4),
+};
+static_assert(sizeof(remote_uarts) / sizeof(remote_uarts[0]) == MAX_REMOTE_UART_INSTANCES,
+              "remote_uarts size must match MAX_REMOTE_UART_INSTANCES");
 
 static void receive_callback(const uint8_t *data, uint32_t length_in_bytes)
 {
@@ -121,6 +131,27 @@ static void receive_callback(const uint8_t *data, uint32_t length_in_bytes)
     case QURT_MSG_ID_REBOOT: {
         printf("Rebooting\n");
         exit(0);
+        break;
+    }
+    case QURT_MSG_ID_UART_CONFIG: {
+        if (msg->data_length != sizeof(struct qurt_uart_config)) {
+            fprintf(stderr, "Remote UART: invalid config message length %u\n", msg->data_length);
+            break;
+        }
+        const auto *cfg = (const struct qurt_uart_config *)msg->data;
+        if (cfg->port_id >= MAX_REMOTE_UART_INSTANCES) {
+            fprintf(stderr, "Remote UART: invalid config port_id %u\n", cfg->port_id);
+            break;
+        }
+        remote_uarts[cfg->port_id].configure(cfg->baudrate, cfg->device_id);
+        break;
+    }
+    case QURT_MSG_ID_UART_DATA: {
+        if (msg->inst >= MAX_REMOTE_UART_INSTANCES) {
+            fprintf(stderr, "Remote UART: invalid data port_id %u\n", msg->inst);
+            break;
+        }
+        remote_uarts[msg->inst].write(msg->data, msg->data_length);
         break;
     }
     default:

--- a/libraries/AP_HAL_QURT/ap_host/src/protocol.h
+++ b/libraries/AP_HAL_QURT/ap_host/src/protocol.h
@@ -6,8 +6,15 @@
 #define QURT_MSG_ID_MAVLINK_MSG 1
 #define QURT_MSG_ID_REBOOT 2
 #define QURT_MSG_ID_PRINTF 3
+#define QURT_MSG_ID_UART_CONFIG 4
+#define QURT_MSG_ID_UART_DATA 5
 
 #define MAX_MAVLINK_INSTANCES 2
+
+// Number of tunneled remote UART ports. Each port has a fixed mapping
+// to an apps-processor Linux serial device; the encapsulating packet
+// carries a port_id so multiple ports can be multiplexed over the RPC.
+#define MAX_REMOTE_UART_INSTANCES 5
 
 struct __attribute__((__packed__)) qurt_rpc_msg {
     uint8_t msg_id;
@@ -19,3 +26,13 @@ struct __attribute__((__packed__)) qurt_rpc_msg {
 
 #define QURT_RPC_MSG_HEADER_LEN 8
 
+// Payload for QURT_MSG_ID_UART_CONFIG. device_id maps directly to the
+// Linux device path on the apps processor as "/dev/ttyHS<device_id>".
+// port_id is the tunneled-port index (0..MAX_REMOTE_UART_INSTANCES-1)
+// used to demultiplex data between multiple remote UARTs.
+struct __attribute__((__packed__)) qurt_uart_config {
+    uint32_t baudrate;
+    uint32_t device_id;
+    uint8_t  port_id;
+    uint8_t  _reserved[3];
+};

--- a/libraries/AP_HAL_QURT/hwdef/ModalAI-VOXL2/README.md
+++ b/libraries/AP_HAL_QURT/hwdef/ModalAI-VOXL2/README.md
@@ -1,3 +1,9 @@
-# ModalAI-VOXL2 Flight Controller
+# ModalAI VOXL2 Flight Controllers
 
-The [ModalAI-VOXL2 flight controller](https://www.modalai.com/products/voxl-2?variant=39914779836467) is produced by [ModalAI](https://www.modalai.com).
+## VOXL2
+
+The [VOXL2 flight controller](https://www.modalai.com/products/voxl-2?variant=39914779836467) is produced by [ModalAI](https://www.modalai.com).
+
+## VOXL2 Mini
+
+The [VOXL2 mini flight controller](https://www.modalai.com/products/voxl-2-mini?variant=44246380577072) is produced by [ModalAI](https://www.modalai.com).

--- a/libraries/AP_HAL_QURT/hwdef/ModalAI-VOXL2/hwdef.dat
+++ b/libraries/AP_HAL_QURT/hwdef/ModalAI-VOXL2/hwdef.dat
@@ -1,9 +1,15 @@
-# SPI devices
+# SPI buses
 #           NAME
 QURT_SPIDEV "INV3"
 
+# I2C buses
+#       LogicalIdx  PhysicalId  Internal
+I2C_BUS 0           1           false    # mag
+I2C_BUS 1           2           false    # power manager
+I2C_BUS 2           5           true     # barometer (internal)
+
 #  compass list
-#       Driver   BusAndAddr External Rotation
+#       Driver   Bus+Addr   External Rotation
 COMPASS QMC5883L I2C:0:0x0d true     ROTATION_NONE
 
 #  barometer list
@@ -11,5 +17,5 @@ COMPASS QMC5883L I2C:0:0x0d true     ROTATION_NONE
 BARO ICP101XX I2C:2:0x63
 
 #  IMU list
-    driver       Bus+Addr   Rotation
+#   Driver       Bus+Addr   Rotation
 IMU Invensensev3 SPI:INV3   ROTATION_NONE

--- a/libraries/AP_HAL_QURT/hwdef/ModalAI-VOXL3/README.md
+++ b/libraries/AP_HAL_QURT/hwdef/ModalAI-VOXL3/README.md
@@ -1,0 +1,3 @@
+# VOXL3 Flight Controller
+
+Documentation and specs TBD

--- a/libraries/AP_HAL_QURT/hwdef/ModalAI-VOXL3/hwdef.dat
+++ b/libraries/AP_HAL_QURT/hwdef/ModalAI-VOXL3/hwdef.dat
@@ -1,0 +1,40 @@
+# SPI buses
+#           NAME
+QURT_SPIDEV "INV3"
+
+# I2C buses
+# VOXL3 has a single external I2C bus shared by compass and baro.
+#       LogicalIdx  PhysicalId  Internal
+I2C_BUS 0           1           false
+I2C_BUS 1           5           true     # barometer (internal)
+
+#  compass list
+#       Driver   BusAndAddr External Rotation
+COMPASS QMC5883L I2C:0:0x0d true     ROTATION_NONE
+
+#  barometer list
+#    Driver I2C Bus+Addr
+BARO DPS310 I2C:1:0x77
+
+#  IMU list
+#   Driver Bus+Addr   Rotation
+IMU BMI270 SPI:INV3   ROTATION_NONE
+
+# VOXL3 has no DSP-local GPS UART; GPS is wired to a UART on the apps
+# processor. Skipping the SERIAL3 DSP driver leaves SERIAL3 unclaimed,
+# and the remote GPS is reached via tunneled remote port 0. SERIAL3's
+# default protocol must also be overridden from GPS to None, otherwise
+# AP_SerialManager's default state[3].protocol=GPS would be matched by
+# find_serial(GPS, 0) before state[5] and point at the dead slot.
+define HAL_NO_DSP_GPS_UART 1
+define DEFAULT_SERIAL3_PROTOCOL -1
+
+# Apps-processor UART device ids for the tunneled remote serial ports.
+# Each maps to /dev/ttyHS<id> on the apps processor. Ports are exposed
+# as SERIAL5..SERIAL9; the user assigns a protocol via SERIALn_PROTOCOL.
+define APPS_REMOTE_UART_0_DEVICE 7
+
+# Default SERIAL5 (remote port 0) to GPS @ 9600. The M10 UBX receiver
+# powers up at 9600; AP_GPS sends its configuration blob at that baud.
+define DEFAULT_SERIAL5_PROTOCOL 5
+define DEFAULT_SERIAL5_BAUD 9

--- a/libraries/AP_HAL_QURT/hwdef/scripts/qurt_hwdef.py
+++ b/libraries/AP_HAL_QURT/hwdef/scripts/qurt_hwdef.py
@@ -22,12 +22,21 @@ class QURTSPIDev():
     name : str
 
 
+@dataclass
+class QURTI2CBus():
+    logical_idx : int
+    physical_id : int
+    internal : bool
+
+
 class QURTHWDef(hwdef.HWDef):
 
     def __init__(self, **kwargs):
         super(QURTHWDef, self).__init__(**kwargs)
         # a list of QURT_SPIDEV devices
         self.qurt_spidev = []
+        # a list of QURTI2CBus entries, ordered by logical index
+        self.qurt_i2c_buses = []
 
     def write_hwdef_header_content(self, f):
         for d in self.alllines:
@@ -35,6 +44,7 @@ class QURTHWDef(hwdef.HWDef):
                 f.write('#define %s\n' % d[7:])
 
         self.write_SPI_config(f)
+        self.write_I2C_config(f)
         self.write_IMU_config(f)
         self.write_MAG_config(f)
         self.write_BARO_config(f)
@@ -48,6 +58,8 @@ class QURTHWDef(hwdef.HWDef):
         a = shlex.split(line, posix=False)
         if a[0] == 'QURT_SPIDEV':
             self.process_line_qurt_spidev(line, depth, a)
+        elif a[0] == 'I2C_BUS':
+            self.process_line_i2c_bus(line, depth, a)
 
         super(QURTHWDef, self).process_line(line, depth)
 
@@ -62,6 +74,14 @@ class QURTHWDef(hwdef.HWDef):
     def process_line_qurt_spidev(self, line, depth, a):
         (cmd, devname) = a
         self.qurt_spidev.append(QURTSPIDev(devname))
+
+    def process_line_i2c_bus(self, line, depth, a):
+        if len(a) != 4:
+            self.error("I2C_BUS expects: I2C_BUS <logical_idx> <physical_id> <true|false>")
+        logical_idx = int(a[1], 0)
+        physical_id = int(a[2], 0)
+        internal = a[3].lower() in ('true', '1', 'internal')
+        self.qurt_i2c_buses.append(QURTI2CBus(logical_idx, physical_id, internal))
 
     def write_SPI_device_table(self, f):
         '''write SPI device table'''
@@ -79,6 +99,27 @@ class QURTHWDef(hwdef.HWDef):
         '''write SPI config defines'''
 
         self.write_SPI_device_table(f)
+
+    def write_I2C_config(self, f):
+        '''write I2C bus table and internal-bus mask'''
+        buses = sorted(self.qurt_i2c_buses, key=lambda b: b.logical_idx)
+        for i, b in enumerate(buses):
+            if b.logical_idx != i:
+                self.error(f"I2C_BUS logical indices must be contiguous starting at 0 (got {b.logical_idx} at position {i})")
+
+        f.write('\n// I2C buses\n')
+        if len(buses) == 0:
+            f.write('#define HAL_QURT_I2C_BUS_IDS { }\n')
+            f.write('#define HAL_QURT_I2C_INTERNAL_MASK 0\n')
+            return
+
+        ids = ', '.join(str(b.physical_id) for b in buses)
+        mask = 0
+        for b in buses:
+            if b.internal:
+                mask |= (1 << b.logical_idx)
+        f.write(f'#define HAL_QURT_I2C_BUS_IDS {{ {ids} }}\n')
+        f.write(f'#define HAL_QURT_I2C_INTERNAL_MASK 0x{mask:x}\n')
 
 
 if __name__ == '__main__':

--- a/libraries/AP_HAL_QURT/install.sh
+++ b/libraries/AP_HAL_QURT/install.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
-# script to install ArduPilot on a voxl2 board
+# script to install ArduPilot on a VOXL board
 # this assumes you have already installed the voxl-ardupilot.service file
 # and /usr/bin/voxl-ardupilot script
 
 USE_ADB=false
+
+usage() {
+    echo "Usage: install.sh -a BOARD"
+    echo "       install.sh BOARD IPADDRESS"
+    echo ""
+    echo "  BOARD      Board name (ModalAI-VOXL2 or ModalAI-VOXL3)"
+    echo "  IPADDRESS  IP address of target (required when using rsync)"
+    echo "  -a         Use adb push instead of rsync"
+    exit 1
+}
 
 while getopts "a" opt; do
     case $opt in
@@ -11,29 +21,44 @@ while getopts "a" opt; do
             USE_ADB=true
             ;;
         *)
-            echo "Usage: install.sh [-a] [IPADDRESS]"
-            echo "  -a  Use adb push instead of rsync"
-            exit 1
+            usage
             ;;
     esac
 done
 shift $((OPTIND - 1))
 
+# Board is the first positional argument (required)
+[ $# -ge 1 ] || usage
+BOARD="$1"
+shift
+
+if [ "$BOARD" != "ModalAI-VOXL2" ] && [ "$BOARD" != "ModalAI-VOXL3" ]; then
+    echo "Error: BOARD must be ModalAI-VOXL2 or ModalAI-VOXL3"
+    exit 1
+fi
+
+BUILDDIR="build/${BOARD}"
+
+if [ ! -d "$BUILDDIR" ]; then
+    echo "Error: Build directory $BUILDDIR not found"
+    exit 1
+fi
+
 set -e
 
 if $USE_ADB; then
-    echo "Installing ArduPilot via adb"
-    adb push build/QURT/bin/arducopter /usr/lib/rfsa/adsp/ArduPilot.so
-    adb push build/QURT/ardupilot /usr/bin/
+    echo "Installing ArduPilot via adb from $BUILDDIR"
+    adb push ${BUILDDIR}/bin/arducopter /usr/lib/rfsa/adsp/ArduPilot.so
+    adb push ${BUILDDIR}/ardupilot /usr/bin/
 else
     [ $# -eq 1 ] || {
-        echo "Usage: install.sh [-a] IPADDRESS"
-        exit 1
+        echo "Error: IPADDRESS is required when using rsync"
+        usage
     }
     DEST="$1"
-    echo "Installing ArduPilot on $DEST"
-    rsync -a build/QURT/bin/arducopter $DEST:/usr/lib/rfsa/adsp/ArduPilot.so
-    rsync -a build/QURT/ardupilot $DEST:/usr/bin/
+    echo "Installing ArduPilot on $DEST from $BUILDDIR"
+    rsync -a ${BUILDDIR}/bin/arducopter $DEST:/usr/lib/rfsa/adsp/ArduPilot.so
+    rsync -a ${BUILDDIR}/ardupilot $DEST:/usr/bin/
     echo "Restarting ArduPilot"
     ssh $DEST systemctl restart voxl-ardupilot
 fi

--- a/libraries/AP_HAL_QURT/replace.cpp
+++ b/libraries/AP_HAL_QURT/replace.cpp
@@ -138,6 +138,23 @@ extern "C" {
 
 extern "C" int qurt_ardupilot_main(int argc, char* const argv[]);
 
+typedef void (*remote_uart_data_callback_t)(const struct qurt_rpc_msg *msg, void* p);
+
+static remote_uart_data_callback_t remote_uart_cb[MAX_REMOTE_UART_INSTANCES];
+static void *remote_uart_cb_ptr[MAX_REMOTE_UART_INSTANCES];
+
+void register_remote_uart_data_callback(uint8_t port_id,
+                                        remote_uart_data_callback_t func,
+                                        void *p)
+{
+    if (port_id >= MAX_REMOTE_UART_INSTANCES) {
+        HAP_PRINTF("Error: Invalid remote uart port_id %u", port_id);
+        return;
+    }
+    remote_uart_cb[port_id] = func;
+    remote_uart_cb_ptr[port_id] = p;
+}
+
 int slpi_link_client_init(void)
 {
     HAP_PRINTF("About to call qurt_ardupilot_main %p", &qurt_ardupilot_main);
@@ -179,6 +196,14 @@ int slpi_link_client_receive(const uint8_t *data, int data_len_in_bytes)
         }
         break;
     }
+    case QURT_MSG_ID_UART_DATA: {
+        // msg->inst carries the tunneled port_id
+        if (msg->inst < MAX_REMOTE_UART_INSTANCES && remote_uart_cb[msg->inst]) {
+            remote_uart_cb[msg->inst](msg, remote_uart_cb_ptr[msg->inst]);
+        }
+        break;
+    }
+
     default:
         HAP_PRINTF("Got unknown message id %d", msg->msg_id);
         break;


### PR DESCRIPTION
### Summary

Add support for the new ModalAI VOXL3 board.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested changes on both VOXL2 and VOXL3 hardware

### Description

Adding support for VOXL3 included a new hwdef.dat file, support for specifying i2c buses in the hwdef.dat file, and adding remote UART support (on apps processor side) for GPS. The remote UART mechanism was built upon SerialManager so that up to 5 external serial ports can be configured.
