### PR TITLE
AP_NavEKF3: remove unnecessary zeroing from FuseSideslip

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_AirDataFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_AirDataFusion.cpp
@@ -324,9 +324,6 @@ void NavEKF3_core::FuseSideslip()
 
         if (!airDataFusionWindOnly) {
             kalman_mask = (1<<10)-1;
-        } else {
-            // zero indexes 0 to 9
-            zero_range(&Kfusion[0], 0, 9);
         }
 
         if (!inhibitDelAngBiasStates && !airDataFusionWindOnly) {


### PR DESCRIPTION
Missed as part of the kalman gain loop work in #32213 . No change in behavior as zeroing will be done in the gain calculation loop.

### Summary

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [X] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [X] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Validated `Tools/Replay/check_replay_branch.py` shows zero replay differences vs. master.

<!-- Put additional testing description for this PR's changes here -->

### Description

Saves a handful of bytes and removes questions.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
