### PR TITLE
AC_Fence: Reduce code duplication in PolyFence loader

### DIFF
--- a/libraries/AC_Fence/AC_PolyFence_loader.cpp
+++ b/libraries/AC_Fence/AC_PolyFence_loader.cpp
@@ -809,16 +809,13 @@ bool AC_PolyFence_loader::load_from_storage()
 #endif  // AC_POLYFENCE_CIRCLE_INT_SUPPORT_ENABLED
         case AC_PolyFenceType::CIRCLE_EXCLUSION: {
             ExclusionCircle &circle = _loaded_circle_exclusion_boundary[_num_loaded_circle_exclusion_boundaries];
-            if (!read_latlon_from_storage(storage_offset, circle.point)) {
+            if (!read_latlon_from_storage(storage_offset, circle.point) || 
+                !scale_latlon_from_origin(loaded_origin, circle.point, circle.pos_cm)) {
                 GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "AC_Fence: latlon read failed");
                 storage_valid = false;
                 break;
             }
-            if (!scale_latlon_from_origin(loaded_origin, circle.point, circle.pos_cm)) {
-                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "AC_Fence: latlon read failed");
-                storage_valid = false;
-                break;
-            }
+
             // now read the radius
 #if AC_POLYFENCE_CIRCLE_INT_SUPPORT_ENABLED
             if (index.type == AC_PolyFenceType::CIRCLE_EXCLUSION_INT) {
@@ -841,16 +838,13 @@ bool AC_PolyFence_loader::load_from_storage()
 #endif  // AC_POLYFENCE_CIRCLE_INT_SUPPORT_ENABLED
         case AC_PolyFenceType::CIRCLE_INCLUSION: {
             InclusionCircle &circle = _loaded_circle_inclusion_boundary[_num_loaded_circle_inclusion_boundaries];
-            if (!read_latlon_from_storage(storage_offset, circle.point)) {
+            if (!read_latlon_from_storage(storage_offset, circle.point) || 
+                !scale_latlon_from_origin(loaded_origin, circle.point, circle.pos_cm)) {
                 GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "AC_Fence: latlon read failed");
                 storage_valid = false;
                 break;
             }
-            if (!scale_latlon_from_origin(loaded_origin, circle.point, circle.pos_cm)){
-                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "AC_Fence: latlon read failed");
-                storage_valid = false;
-                break;
-            }
+
             // now read the radius
 #if AC_POLYFENCE_CIRCLE_INT_SUPPORT_ENABLED
             if (index.type == AC_PolyFenceType::CIRCLE_INCLUSION_INT) {
@@ -869,17 +863,14 @@ bool AC_PolyFence_loader::load_from_storage()
             break;
         }
         case AC_PolyFenceType::RETURN_POINT:
-            if (_loaded_return_point != nullptr) {
+            if (_loaded_return_point != nullptr ||
+                _loaded_return_point_lla != nullptr) {
                 GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "PolyFence: Multiple return points found");
                 storage_valid = false;
                 break;
             }
             _loaded_return_point = next_storage_point;
-            if (_loaded_return_point_lla != nullptr) {
-                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "PolyFence: Multiple return points found");
-                storage_valid = false;
-                break;
-            }
+
             _loaded_return_point_lla = next_storage_point_lla;
             // Read the point from storage
             if (!read_latlon_from_storage(storage_offset, *next_storage_point_lla)) {


### PR DESCRIPTION
### Summary

This PR simplifies the error handling logic in `AC_PolyFence_loader.cpp` by consolidating multiple `if` statements into single conditions using short-circuit evaluation.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Compiled successfully. Since this relies entirely on standard C++ short-circuit evaluation, the execution flow remains strictly identical to the original code.

### Description

In `AC_PolyFence_loader.cpp`, the error handling for `read_latlon_from_storage` and `scale_latlon_from_origin` inside both the `CIRCLE_INCLUSION` and `CIRCLE_EXCLUSION` cases duplicated the exact same failure logic (sending a GCS warning, setting `storage_valid = false`, and breaking).

This PR refactors these sections to use the logical OR operator (`||`). Due to short-circuit evaluation, if the first read fails, the scale function is safely skipped, perfectly mirroring the original behavior while reducing code duplication and improving readability.

A similar consolidation was also applied to the multiple return point checks (`_loaded_return_point != nullptr` and `_loaded_return_point_lla != nullptr`) in the `RETURN_POINT` case.