### PR TITLE
waf: run waf-light script directly instead of using subprocess

### DIFF
--- a/waf
+++ b/waf
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os.path as p
+import runpy
 import subprocess
 import sys
 
@@ -19,24 +20,30 @@ if sys.version_info[:3] < MIN_VER:
           min_txt, "but you have", current_txt, file=sys.stderr)
     sys.exit(1)
 
-d = p.dirname(p.realpath(__file__))
-waf_light = p.join(d, 'modules', 'waf', 'waf-light')
 
-python = sys.executable
+def main():
+    d = p.dirname(p.realpath(__file__))
+    waf_light = p.join(d, 'modules', 'waf', 'waf-light')
 
-try:
-    subprocess.check_call([python, waf_light] + sys.argv[1:])
-except subprocess.CalledProcessError as e:
-    if e.returncode != 2 or p.isfile(waf_light):
-        sys.exit(1)
+    if not p.isfile(waf_light): # file does not exist?
+        print('Missing waf submodule. Trying to get it')
 
-    print('Missing waf submodule. Trying to get it')
+        try:
+            subprocess.check_call(['git', 'submodule', 'update', '--init',
+                                   'modules/waf'])
+        except subprocess.CalledProcessError:
+            print('Could not update submodule', file=sys.stderr)
+            return 1
 
-    try:
-        subprocess.check_call(['git', 'submodule', 'update', '--init',
-                               'modules/waf'])
-    except subprocess.CalledProcessError:
-        print('Could not update submodule', file=sys.stderr)
-        sys.exit(1)
+        print('Submodules OK, try running again')
 
-    print('Submodules OK, try running again')
+        return 0 # ensure user sees what happened
+
+    # run as if python3 "$waf_light"
+    runpy.run_path(waf_light, {}, "__main__")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Summary

Makes debugging easier, avoids a weird extra traceback on a Ctrl-C, and makes startup infinitesimally faster.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [X] Non-functional change
- [ ] No-binary change
- [X] Infrastructure change (e.g. unit tests, helper scripts)
- [X] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

I have played a bit manually and found no problems.

### Description
As above.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
