### PR TITLE
AP_RCProtocol: bump min SUMD channels to 4 to avoid corruption

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol_SUMD.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_SUMD.cpp
@@ -104,7 +104,7 @@ void AP_RCProtocol_SUMD::_process_byte(uint32_t timestamp_us, uint8_t byte)
         break;
 
     case SUMD_DECODE_STATE_GOT_STATE:
-        if (byte >= 2 && byte <= SUMD_MAX_CHANNELS) {
+        if (byte >= 4 && byte <= SUMD_MAX_CHANNELS) { // need at least 4 for reordering
             _rxpacket.length = byte;
             _crc16 = crc_xmodem_update(_crc16, byte);
             _rxlen++;


### PR DESCRIPTION
### Summary

Fix unlikely case which may result in SUMD receivers feeding garbage RC values.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [X] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

If the receiver sends less than four channels, the reordering step will use unspecified data from the input buffer as valid RC input values. The official minimum channel count from the protocol documentation is two.

There is no risk of a buffer overread or overwrite, it is hard to believe a user would set up this configuration, and there is a relatively strong checksum which protects the channel count too. Therefore, an actual problem is unlikely.

Fix by rejecting packets claiming to have less than four channels. This fix is zero-cost and removes any risk of garbage from such packets.

Disclaimer: this problem was stumbled upon by an AI spammer, but that fix was incorrect

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
