### PR TITLE
AP_Motors: increase BAT_VOLT_MAX and MIN ranges for 14S batteries

### DIFF
--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -63,7 +63,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @Param: BAT_VOLT_MAX
     // @DisplayName: Battery voltage compensation maximum voltage
     // @Description: Battery voltage compensation maximum voltage (voltage above this will have no additional scaling effect on thrust).  Recommend 4.2 * cell count, 0 = Disabled
-    // @Range: 6 53
+    // @Range: 6 61
     // @Units: V
     // @Increment: 0.1
     // @User: Advanced
@@ -72,7 +72,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @Param: BAT_VOLT_MIN
     // @DisplayName: Battery voltage compensation minimum voltage
     // @Description: Battery voltage compensation minimum voltage (voltage below this will have no additional scaling effect on thrust).  Recommend 3.3 * cell count, 0 = Disabled
-    // @Range: 6 42
+    // @Range: 6 47
     // @Units: V
     // @Increment: 0.1
     // @User: Advanced


### PR DESCRIPTION
### Summary

Expand `@Range` metadata for `BAT_VOLT_MAX` and `BAT_VOLT_MIN` in `AP_MotorsMulticopter` to support 14S LiPo and LiHv batteries.

EX
https://www.grepow.com/blog/grepow-14s-lipo-battery-solutions.html

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

This is a parameter metadata update. It updates the generated parameter documentation for GCS use and does not change the compiled flight logic.

### Description

Currently, configuring a 14S battery on large agricultural or industrial frames triggers out-of-range warnings in Ground Control Stations (such as Mission Planner). This is because the upper limit for `BAT_VOLT_MAX` is set to 53, and `BAT_VOLT_MIN` is 42.

This PR updates the parameter metadata in `AP_MotorsMulticopter` to properly accommodate 14S batteries without GCS warnings:
- Increased the upper limit of `BAT_VOLT_MAX` to `61` to fully cover 14S LiHv batteries (fully charged at 4.35V * 14 = 60.9V).
- Increased the upper limit of `BAT_VOLT_MIN` to `47`.