### PR TITLE
AP_NavEKF3: Optimize fault status assignment with switch statement

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -1242,34 +1242,50 @@ void NavEKF3_core::FuseVelPosNED()
                     ConstrainVariances();
 
                     // record good fusion status
-                    if (obsIndex == 0) {
+                    switch (obsIndex) {
+                    case 0:
                         faultStatus.bad_nvel = false;
-                    } else if (obsIndex == 1) {
+                        break;
+                    case 1:
                         faultStatus.bad_evel = false;
-                    } else if (obsIndex == 2) {
+                        break;
+                    case 2:
                         faultStatus.bad_dvel = false;
-                    } else if (obsIndex == 3) {
+                        break;
+                    case 3:
                         faultStatus.bad_npos = false;
-                    } else if (obsIndex == 4) {
+                        break;
+                    case 4:
                         faultStatus.bad_epos = false;
-                    } else if (obsIndex == 5) {
+                        break;
+                    case 5:
                         faultStatus.bad_dpos = false;
+                        break;
                     }
+
                 } else {
                     // record bad fusion status
-                    if (obsIndex == 0) {
+                    switch (obsIndex) {
+                    case 0:
                         faultStatus.bad_nvel = true;
-                    } else if (obsIndex == 1) {
+                        break;
+                    case 1:
                         faultStatus.bad_evel = true;
-                    } else if (obsIndex == 2) {
+                        break;
+                    case 2:
                         faultStatus.bad_dvel = true;
-                    } else if (obsIndex == 3) {
+                        break;
+                    case 3:
                         faultStatus.bad_npos = true;
-                    } else if (obsIndex == 4) {
+                        break;
+                    case 4:
                         faultStatus.bad_epos = true;
-                    } else if (obsIndex == 5) {
+                        break;
+                    case 5:
                         faultStatus.bad_dpos = true;
+                        break;
                     }
+
                 }
             }
         }
@@ -2105,12 +2121,18 @@ void NavEKF3_core::FuseBodyVel()
                 ConstrainVariances();
             } else {
                 // record bad axis
-                if (obsIndex == 0) {
+                switch (obsIndex) {
+                case 0:
                     faultStatus.bad_xvel = true;
-                } else if (obsIndex == 1) {
+                    break;
+                case 1:
                     faultStatus.bad_yvel = true;
-                } else if (obsIndex == 2) {
+                    break;
+                case 2:
                     faultStatus.bad_zvel = true;
+                    break;
+                default:
+                    break;
                 }
 
             }


### PR DESCRIPTION
### Summary

Refactor `AP_NavEKF3_PosVelFusion.cpp` to use `switch` statements instead of `if-else` chains for better readability.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

**Testing description:**
Compiled successfully and verified via SITL. The logic remains completely identical to the previous implementation.

### Description

This PR refactors the assignment of `faultStatus` and axis flags based on `obsIndex` in `libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp`.

**Changes:**
- Replaced the long `if-else if` chains with `switch` statements.
- Added a `default: break;` clause to ensure safety against any unexpected `obsIndex` values in the future.

**Reasoning:**
This change makes the intent of the code much clearer and improves readability. While changing the `faultStatus` struct itself to use arrays would also reduce lines of code, this `switch` statement approach was chosen to strictly limit the scope of the change to this file and avoid widespread ripple effects across the codebase. 
This is purely a non-functional refactoring.