### PR TITLE
AP_Logger: don't mark NVF message as streaming

### DIFF
--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -961,7 +961,7 @@ void AP_Logger::Write_Fence()
 
 void AP_Logger::Write_NamedValueFloat(const char *name, float value)
 {
-    WriteStreaming(
+    Write(
         "NVF",
         "TimeUS,Name,Value",
         "s#-",

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -340,7 +340,7 @@ void GCS::send_named_float(const char *name, float value) const
 // @Field: TimeUS: Time since system startup
 // @Field: Name: Name of float
 // @Field: Value: Value of float
-    AP::logger().WriteStreaming(
+    AP::logger().Write(
         "NVF",
         "TimeUS," "Name," "Value",
         "s"       "#"     "-",


### PR DESCRIPTION
### Summary

when LOG_FILE_RATEMAX is used we lose messages as the rate calculator for streaming messages doesn't account for changes to the NVF Name field

Also remove old function in AP_Logger

Tested in SITL with a lua script

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->
