### PR TITLE
AC_PID: re-order member declarations to avoid gcc-16 warning

### DIFF
--- a/libraries/AC_PID/AC_PID.h
+++ b/libraries/AC_PID/AC_PID.h
@@ -161,6 +161,19 @@ protected:
     // If `limit` is true, the integrator is only allowed to shrink to avoid wind-up.
     void update_i(float dt, bool limit, float i_scale = 1.0f);
 
+    // Declared before AP_Float members so they are initialized first; GCC analyses
+    // the AP_GROUPINFO_FLAGS_DEFAULT_POINTER offset and warns if these come later.
+    const float default_kp;
+    const float default_ki;
+    const float default_kd;
+    const float default_kff;
+    const float default_kdff;
+    const float default_kimax;
+    const float default_filt_T_hz;
+    const float default_filt_E_hz;
+    const float default_filt_D_hz;
+    const float default_slew_rate_max;
+
     // parameters
     AP_Float _kp;
     AP_Float _ki;
@@ -202,15 +215,4 @@ protected:
 #endif
 
     AP_PIDInfo _pid_info;
-
-    const float default_kp;
-    const float default_ki;
-    const float default_kd;
-    const float default_kff;
-    const float default_kdff;
-    const float default_kimax;
-    const float default_filt_T_hz;
-    const float default_filt_E_hz;
-    const float default_filt_D_hz;
-    const float default_slew_rate_max;
 };


### PR DESCRIPTION
### Summary

Fixes archlinux CI by getting rid of a (pssible false-positive) uninitalised value warning.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Not a no-compiler output change:
```
Board,heli
MatekF405-Wing,-32
```
<img width="3328" height="1592" alt="image" src="https://github.com/user-attachments/assets/f8bb893f-e132-4b81-84f9-cfa08aa96d30" />


### Description

```
  [  30/1360] Compiling libraries/AC_PID/AC_HELI_PID.cpp
  ../../libraries/AC_PID/AC_PID.cpp: In constructor ‘AC_PID::AC_PID(float, float, float, float, float, float, float, float, float, float, float)’:
  ../../libraries/AC_PID/AC_PID.cpp:114:40: error: ‘<unknown>’ may be used uninitialized [-Werror=maybe-uninitialized]
    114 |     default_slew_rate_max(initial_srmax)
        |                                        ^
  compilation terminated due to -Wfatal-errors.
  cc1plus: some warnings being treated as errors
```
