### PR TITLE
AP_NavEKF3: gate stationary zero-velocity fusion on !inFlight

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -517,6 +517,18 @@ void NavEKF3_core::CalculateVelInnovationsAndVariances(const Vector3F &velocity,
     variances.z = P[6][6] + obs_data_chk;
 }
 
+// Combines onGroundNotMoving (movement check, only valid when onGround is true)
+// and takeoff_expected (covers the armed-on-ground period before liftoff). Gated
+// on !inFlight because Plane can briefly assert takeoff_expected mid-flight (high
+// throttle + transient !is_flying()), and injecting zero velocity into a vehicle
+// that is actually flying corrupts EKF velocity, the wind state and dead
+// reckoning. onGround would be too tight a gate — it goes false the moment motors
+// arm, which excludes the legitimate Copter pre-liftoff case.
+bool NavEKF3_core::onGroundNotFlying() const
+{
+    return !inFlight && (onGroundNotMoving || dal.get_takeoff_expected());
+}
+
 /********************************************************
 *                   FUSE MEASURED_DATA                  *
 ********************************************************/
@@ -700,11 +712,7 @@ void NavEKF3_core::SelectVelPosFusion()
             // to constrain gyro bias and Z-axis accel bias learning. XY accel biases
             // remain unobservable until the vehicle accelerates and are separately
             // inhibited by dvelBiasAxisInhibit in CovariancePrediction.
-            // Use onGroundNotMoving to avoid fusing zero velocity when the vehicle
-            // is being moved (e.g. on a boat or carried by hand).
-            // takeoff_expected covers the armed-on-ground case before liftoff.
-            const bool onGroundNotFlying = onGroundNotMoving || dal.get_takeoff_expected();
-            if (onGroundNotFlying && tiltAlignComplete) {
+            if (onGroundNotFlying() && tiltAlignComplete) {
                 fuseVelData = true;
                 fusingStationaryZeroVel = true;
                 velPosObs[0] = 0.0f;
@@ -725,13 +733,9 @@ void NavEKF3_core::SelectVelPosFusion()
     // PV_AidingMode is AID_RELATIVE but no velocity data is available when stationary
     // have no velocity observations at all, causing unchecked bias drift. The timeout
     // check on each velocity source ensures we only inject zero velocity when no real
-    // sensor data is being fused. Use onGroundNotMoving to avoid injecting zero velocity
-    // when the vehicle is being moved, and takeoff_expected for armed-on-ground.
-    // Gate behind fuseHgtData to limit fusion rate to baro rate (~10Hz) and avoid
-    // overconstraining the filter by fusing at IMU rate.
-    const bool onGroundNotFlying = onGroundNotMoving || dal.get_takeoff_expected();
-
-    if (fuseHgtData && PV_AidingMode != AID_NONE && onGroundNotFlying) {
+    // sensor data is being fused. Gate behind fuseHgtData to limit fusion rate to baro
+    // rate (~10Hz) and avoid overconstraining the filter by fusing at IMU rate.
+    if (fuseHgtData && PV_AidingMode != AID_NONE && onGroundNotFlying()) {
         // Check if we have recent velocity aiding from any source
         const uint32_t velAidTimeout_ms = 1000;
         const bool haveRecentGpsVel = (imuSampleTime_ms - lastVelPassTime_ms < velAidTimeout_ms);

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -832,6 +832,9 @@ private:
     // determine when to perform fusion of GPS position and  velocity measurements
     void SelectVelPosFusion();
 
+    // true when stationary on the ground and synthetic zero velocity should be fused
+    bool onGroundNotFlying() const;
+
 #if EK3_FEATURE_BEACON_FUSION
     // determine when to perform fusion of range measurements take relative to a beacon at a known NED position
     void SelectRngBcnFusion();


### PR DESCRIPTION
### Summary

Fixes #32980. PR #32396's stationary zero-velocity fusion was gated on `onGroundNotMoving || dal.get_takeoff_expected()`. The second half of that gate is unsafe for Plane: `Plane::set_takeoff_expected()` asserts the flag whenever `!is_flying() && armed && (throw_detected || throttle > throttle_cruise)`, and `Plane::is_flying()` is probabilistic — during aggressive maneuvers it can briefly drop below 0.1, producing a transient `takeoff_expected` pulse on a vehicle that is actually flying. With no GPS/flow/body-vel aiding (e.g. dead reckoning) the new fusion then injects `velPosObs=(0,0,0)` at 1 m/s noise, the EKF velocity state is pulled toward zero, FuseAirspeed produces a large innovation absorbed by the wind state, and DR position drifts at the corrupt wind.

Gate on `!inFlight` instead. That flag stays false through the armed-on-ground period (preserving the Copter pre-liftoff case the original fusion was designed for) and only goes true once `detectFlight()` has high certainty the vehicle is flying. `onGround` would have been too tight — it goes false the moment motors arm.

### Classification & Testing

- [x] Checked by a human programmer
- [x] Tested manually, description below (e.g. SITL)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)

`test.Plane.GuidedAttitudeNoGPS` reproduces the regression on master and recovers pre-PR-32396 behavior with this fix:

| Build | Wind VWN @ t=120s | Wind VWE @ t=120s | DR position PN @ t=125s |
|---|---|---|---|
| Pre-PR-32396 | 0.72 | -0.09 | -481.3 |
| Master (broken) | 20.08 | 12.47 | -589.7 |
| With this fix | 0.71 | -0.09 | -481.9 |

The four autotests added in PR #32396 still pass: `EK3_AccelBiasInhibitOnGroundMoving`, `EK3_AccelBiasZeroVelOptFlow`, `EK3_ZeroVelFusionNotUsedWithGPS`, `EK3AccelBias`.

### Description

Two-line behavior change in `SelectVelPosFusion()`: both `onGroundNotFlying` constructions now AND with `!inFlight`. Comments above each construction document why `!inFlight` rather than `onGround`. No other state, parameters, or fusion paths touched.