### PR TITLE
Have all AHRS backends return quaternion rotated into vehicle body frame

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -1193,16 +1193,15 @@ bool AP_AHRS::_get_quaternion(Quaternion &quat) const
 // return the quaternion defining the rotation from NED to XYZ (body) axes
 bool AP_AHRS::_get_quaternion_for_ekf_type(Quaternion &quat, EKFType type) const
 {
-    // backends always return in autopilot XYZ frame; rotate result
-    // according to trim
+    // backends must always return the result in the vehicle body
+    // frame.  A backend using the autopilot sensors will need to
+    // rotate according to the TRIM parameters.  An ExternalAHRS
+    // won't!
     switch (type) {
 #if AP_AHRS_DCM_ENABLED
     case EKFType::DCM:
-        if (!dcm_estimates.attitude_valid) {
-            return false;
-        }
         quat = dcm_estimates.quaternion;
-        break;
+        return dcm_estimates.attitude_valid;
 #endif
 #if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
@@ -1216,26 +1215,17 @@ bool AP_AHRS::_get_quaternion_for_ekf_type(Quaternion &quat, EKFType type) const
 #endif
 #if AP_AHRS_SIM_ENABLED
     case EKFType::SIM:
-        if (!sim_estimates.attitude_valid) {
-            return false;
-        }
         quat = sim_estimates.quaternion;
-        break;
+        return sim_estimates.attitude_valid;
 #endif
 #if AP_AHRS_EXTERNAL_ENABLED
     case EKFType::EXTERNAL:
-        // we assume the external AHRS isn't trimmed with the autopilot!
-        if (!external_estimates.attitude_valid) {
-            return false;
-        }
         quat = external_estimates.quaternion;
-        return true;
+        return external_estimates.attitude_valid;
 #endif
     }
 
-    quat.rotate(-_trim.get());
-
-    return true;
+    return false;
 }
 
 // return secondary attitude solution if available, as eulers in radians

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -151,6 +151,7 @@ void AP_AHRS_DCM::get_results(AP_AHRS_Backend::Estimates &results)
 
     // quaternion is derived from transformation matrix:
     results.quaternion.from_rotation_matrix(_dcm_matrix);
+    results.quaternion.rotate(-AP::ahrs().get_trim());
 
     results.attitude_valid = true;
 

--- a/libraries/AP_AHRS/AP_AHRS_SIM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_SIM.cpp
@@ -205,12 +205,13 @@ void AP_AHRS_SIM::get_results(AP_AHRS_Backend::Estimates &results)
 
     results.attitude_valid = true;
 
-    // note that this result is rotated by AP_AHRS::get_quaternion
     results.quaternion = fdm.quaternion;
 
     fdm.quaternion.rotation_matrix(results.dcm_matrix);
     results.dcm_matrix = results.dcm_matrix * AP::ahrs().get_rotation_vehicle_body_to_autopilot_body();
     results.dcm_matrix.to_euler(&results.roll_rad, &results.pitch_rad, &results.yaw_rad);
+
+    results.quaternion.rotate(-AP::ahrs().get_trim());
 
     results.gyro_estimate = _ins.get_gyro();
     results.gyro_drift.zero();

--- a/libraries/AP_AHRS/AP_AHRS_SIM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_SIM.cpp
@@ -205,13 +205,13 @@ void AP_AHRS_SIM::get_results(AP_AHRS_Backend::Estimates &results)
 
     results.attitude_valid = true;
 
+    // populate vehicle body attitude:
     results.quaternion = fdm.quaternion;
-
-    fdm.quaternion.rotation_matrix(results.dcm_matrix);
-    results.dcm_matrix = results.dcm_matrix * AP::ahrs().get_rotation_vehicle_body_to_autopilot_body();
-    results.dcm_matrix.to_euler(&results.roll_rad, &results.pitch_rad, &results.yaw_rad);
-
     results.quaternion.rotate(-AP::ahrs().get_trim());
+
+    // update derived attitude values:
+    results.quaternion.rotation_matrix(results.dcm_matrix);
+    results.quaternion.to_euler(results.roll_rad, results.pitch_rad, results.yaw_rad);
 
     results.gyro_estimate = _ins.get_gyro();
     results.gyro_drift.zero();


### PR DESCRIPTION
### Summary

Adjusts the DCM and SIM backends to rotate their results into the vehicle body frame, rather than have AP_AHRS_Backend do it.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

I have tested the DCM change by omitting the rotation in the DCM backend and having test.Plane.AHRSTrim fail.

We don't test SIM in the AHRSTrim test as it's... kind of stuffed.  I have a branch trying to fix that, but I'm relying on autotest to ensure SITL remains good.

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *                                                   
Durandal                            0               0      *           0       0                 0      0      0
Hitec-Airspeed           *                                 *                                                   
KakuteH7-bdshot                     0               0      *           0       0                 0      0      0
MatekF405                           0               0      *           0       0                 0      0      0
MatekH7A3                           0               0      *           0       0                 0      0      0
Pixhawk1-1M-bdshot                  0               0                  0       0                 0      0      0
SITL_x86_64_linux_gnu               0               0                  0       0                 0      0      0
YJUAV_A6SE                          0               0      *           0       -16               0      -16    -16
f103-QiotekPeriph        *                                 *                                                   
f303-MatekGPS            *                                 *                                                   
f303-Universal           *                                 *                                                   
iomcu                                                                                *                         
mindpx-v2                           0               0      *           0       0                 0      0      0
revo-mini                           0               0      *           0       0                 0      0      0
skyviper-v2450                                                         0                                       
speedybeef4                         0               0      *           0       0                 0      0      0
```

### Description

Adjusts the DCM and SIM backends to rotate their results into the vehicle body frame, rather than have AP_AHRS_Backend do it.

Makes the backend structure entirely regular (this provides for future cleanups where we don't need to switch on the active EKF type to get the correct result!

Also adjusts the SIM backend to first rotate the quaternion and then derive the matrix and eulers from that rotated matrix, rather than deriving the matrix, rotating it and then deriving the eulers from the rotated matrix and then rotating the quaternion!

(future work will stop the backends supply eulers at all, hopefully!  And perhaps canonicalising on "backend only supplies a quaternion" with DCM calculating the quaternion and AP_AHRS_Backend creating the matrix from that quat)
