### PR TITLE
AP_HAL_QURT: Change scheduler DEV_PRINTF to HAP_PRINTF

### DIFF
--- a/libraries/AP_HAL_QURT/Scheduler.cpp
+++ b/libraries/AP_HAL_QURT/Scheduler.cpp
@@ -125,7 +125,7 @@ bool Scheduler::thread_create(AP_HAL::MemberProc proc, const char *name, uint32_
      */
     thread->set_auto_free(true);
 
-    DEV_PRINTF("Starting thread %s: Priority %u\n", name, thread_priority);
+    HAP_PRINTF("Starting thread %s: Priority %u\n", name, thread_priority);
 
     if (!thread->start(name, SCHED_FIFO, thread_priority)) {
         delete thread;


### PR DESCRIPTION

### Summary

The scheduler has a nice diagnostic print for each task it creates. But that is only needed on the DSP diagnostic display, not the console, so changing output to only DSP diagnostic display.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested on VOXL2

