### PR TITLE
Copter: Abandon flip if RC aux set non-HIGH

### DIFF
--- a/ArduCopter/RC_Channel_Copter.cpp
+++ b/ArduCopter/RC_Channel_Copter.cpp
@@ -182,9 +182,10 @@ bool RC_Channel_Copter::do_aux_function(const AuxFuncTrigger &trigger)
 
     switch(ch_option) {
         case AUX_FUNC::FLIP:
-            // flip if switch is on, positive throttle and we're actually flying
             if (ch_flag == AuxSwitchPos::HIGH) {
                 copter.set_mode(Mode::Number::FLIP, ModeReason::AUX_FUNCTION);
+            } else {
+                copter.mode_flip.abandon_flip();
             }
             break;
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -970,6 +970,8 @@ public:
     bool is_autopilot() const override { return false; }
     bool crash_check_enabled() const override { return false; }
 
+    void abandon_flip();
+
 protected:
 
     const char *name() const override { return "Flip"; }
@@ -985,8 +987,7 @@ private:
         Roll,
         Pitch_A,
         Pitch_B,
-        Recover,
-        Abandon
+        Recover
     };
     FlipState _state;                   // current state of flip
     Mode::Number  orig_control_mode;    // flight mode when flip was initiated

--- a/ArduCopter/mode_flip.cpp
+++ b/ArduCopter/mode_flip.cpp
@@ -93,7 +93,7 @@ void ModeFlip::run()
 {
     // if pilot inputs roll > 40deg or timeout occurs abandon flip
     if (!motors->armed() || (abs(channel_roll->get_control_in()) >= 4000) || (abs(channel_pitch->get_control_in()) >= 4000) || ((millis() - start_time_ms) > FLIP_TIMEOUT_MS)) {
-        _state = FlipState::Abandon;
+        abandon_flip();
     }
 
     // get pilot's desired throttle
@@ -199,19 +199,23 @@ void ModeFlip::run()
         break;
 
     }
-    case FlipState::Abandon:
-        // restore original flight mode
-        if (!copter.set_mode(orig_control_mode, ModeReason::FLIP_COMPLETE)) {
-            // this should never happen but just in case
-            copter.set_mode(Mode::Number::STABILIZE, ModeReason::UNKNOWN);
-        }
-        // log abandoning flip
-        LOGGER_WRITE_ERROR(LogErrorSubsystem::FLIP, LogErrorCode::FLIP_ABANDONED);
-        break;
     }
 
     // output pilot's throttle without angle boost
     attitude_control->set_throttle_out(throttle_out, false, g.throttle_filt);
+}
+
+void ModeFlip::abandon_flip()
+{
+    // this defends against attempts to abandon when not actually flipping
+    if (copter.get_mode() == static_cast<uint8_t>(Mode::Number::FLIP)) {
+        return;
+    }
+    if (!copter.set_mode(orig_control_mode, ModeReason::FLIP_COMPLETE)) {
+        // this should never happen but just in case
+        copter.set_mode(Mode::Number::STABILIZE, ModeReason::UNKNOWN);
+    }
+    LOGGER_WRITE_ERROR(LogErrorSubsystem::FLIP, LogErrorCode::FLIP_ABANDONED);
 }
 
 #endif


### PR DESCRIPTION
### Summary

**NOTE**: This is a DRAFT, meaning NOT READY for review, while I determine appropriate testing.

Flip can be aborted via the RC switch. This resolves #32491 .

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

**TODO:** Describe the testing (which I am currently authoring).

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
