### PR TITLE
hwdef: skyviper-v2450 still requires MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/skyviper-v2450/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/skyviper-v2450/hwdef.dat
@@ -357,4 +357,7 @@ define AP_MISSION_NAV_PAYLOAD_PLACE_ENABLED 0
 # don't need so many servo outputs (~850 bytes!)
 define NUM_SERVO_CHANNELS 15
 
+# Sonix firmware requests capabilities using older message:
+define AP_MAVLINK_MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES_ENABLED 1
+
 AUTOBUILD_TARGETS Copter


### PR DESCRIPTION
### Summary

Re-instates support for this command just on skyviper.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

the problem is benign, but we should still consider what to do here.

This is a good example I think of the process working, and some of the problems as we try to remove support for some commands and messages from the code.
