### PR TITLE
Copter: Permit abandoning flip via RC Aux change

### DIFF
--- a/ArduCopter/RC_Channel_Copter.cpp
+++ b/ArduCopter/RC_Channel_Copter.cpp
@@ -182,9 +182,12 @@ bool RC_Channel_Copter::do_aux_function(const AuxFuncTrigger &trigger)
 
     switch(ch_option) {
         case AUX_FUNC::FLIP:
-            // flip if switch is on, positive throttle and we're actually flying
             if (ch_flag == AuxSwitchPos::HIGH) {
                 copter.set_mode(Mode::Number::FLIP, ModeReason::AUX_FUNCTION);
+            } else {
+#if MODE_FLIP_ENABLED
+                copter.mode_flip.abandon_flip();
+#endif
             }
             break;
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -969,6 +969,8 @@ public:
     bool is_autopilot() const override { return false; }
     bool crash_check_enabled() const override { return false; }
 
+    void abandon_flip();
+
 protected:
 
     const char *name() const override { return "Flip"; }
@@ -987,6 +989,7 @@ private:
         Recover,
         Abandon
     };
+    bool abandon_requested;
     FlipState _state;                   // current state of flip
     Mode::Number  orig_control_mode;    // flight mode when flip was initiated
     uint32_t start_time_ms;             // time since flip began

--- a/ArduCopter/mode_flip.cpp
+++ b/ArduCopter/mode_flip.cpp
@@ -60,6 +60,7 @@ bool ModeFlip::init(bool ignore_checks)
 
     // initialise state
     _state = FlipState::Start;
+    abandon_requested = false;
     start_time_ms = millis();
 
     roll_dir = pitch_dir = 0;
@@ -92,8 +93,9 @@ bool ModeFlip::init(bool ignore_checks)
 void ModeFlip::run()
 {
     // if pilot inputs roll > 40deg or timeout occurs abandon flip
-    if (!motors->armed() || (abs(channel_roll->get_control_in()) >= 4000) || (abs(channel_pitch->get_control_in()) >= 4000) || ((millis() - start_time_ms) > FLIP_TIMEOUT_MS)) {
+    if (abandon_requested || !motors->armed() || (abs(channel_roll->get_control_in()) >= 4000) || (abs(channel_pitch->get_control_in()) >= 4000) || ((millis() - start_time_ms) > FLIP_TIMEOUT_MS)) {
         _state = FlipState::Abandon;
+        abandon_requested = false;
     }
 
     // get pilot's desired throttle
@@ -212,6 +214,11 @@ void ModeFlip::run()
 
     // output pilot's throttle without angle boost
     attitude_control->set_throttle_out(throttle_out, false, g.throttle_filt);
+}
+
+void ModeFlip::abandon_flip()
+{
+    abandon_requested = true;
 }
 
 #endif

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -3475,6 +3475,37 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.progress("Regaining altitude")
         self.wait_altitude(19, 60, relative=True)
 
+        self.start_subtest("Test 3: Enter & abandon the flip using RC Aux")
+
+        def df_log_shows_a_flip_was_abandoned() -> bool:
+            """Returns true if the dataflash log shows a flip mode was abandoned."""
+            dfreader = self.dfreader_for_current_onboard_log()
+            err_msg_found = dfreader.recv_match(type="ERR", condition="ERR.Subsys==13 and ERR.ECode==2")
+            return bool(err_msg_found)
+
+        self.set_rc(1, neutral_stick) # forces default flip behavior
+        self.set_rc(flip_rc_aux_channel, aux_low) # start low, so a switch-to-high is detected
+        # Precondition: Confirm there are no flip-error messages.
+        if df_log_shows_a_flip_was_abandoned():
+            raise NotAchievedException("The dataflash log already has a Flip Mode error, somehow.")
+        # Because the initiate-and-abandon must happen in a tight window of time, slow down sim
+        self.context_push()
+        self.set_parameter('SIM_SPEEDUP', 1.0)
+        # Pre-constrain tilt so that if we reach the desroll, that's definitely due to the flip
+        self.set_parameter("ATC_ANGLE_MAX", 10.0)
+        self.install_message_hook(flip_mode_watcher)
+        self.set_rc(flip_rc_aux_channel, aux_high, timeout=None)
+        self.wait_attitude(desroll=15, despitch=0, use_cached_simtime=True, timeout=30)
+        self.set_rc(flip_rc_aux_channel, aux_low, timeout=None)
+        self.wait_attitude(despitch=0, desroll=0, tolerance=5)
+        self.wait_mode('ALT_HOLD')
+        if not flip_mode_watcher.mode_was_observed:
+            raise NotAchievedException("Flip mode did not occur as expected.")
+        if not df_log_shows_a_flip_was_abandoned():
+            raise NotAchievedException("Flip was not aborted as expected.")
+        self.remove_message_hook(flip_mode_watcher)
+        self.context_pop()
+
         self.do_RTL()
 
     def configure_EKFs_to_use_optical_flow_instead_of_GPS(self):

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -5971,11 +5971,15 @@ class TestSuite(abc.ABC):
                           (delta, timeout))
             return
 
-    def wait_attitude(self, desroll=None, despitch=None, timeout=2, tolerance=10, message_type='ATTITUDE'):
+    def wait_attitude(self, desroll=None, despitch=None, timeout=2, tolerance=10,
+                      message_type='ATTITUDE', use_cached_simtime=False):
         '''wait for an attitude (degrees)'''
         if desroll is None and despitch is None:
             raise ValueError("despitch or desroll must be supplied")
-        tstart = self.get_sim_time()
+        if use_cached_simtime:
+            tstart = self.get_sim_time()
+        else:
+            tstart = self.get_sim_time_cached()
         while True:
             if self.get_sim_time_cached() - tstart > timeout:
                 raise AutoTestTimeoutException("Failed to achieve attitude")


### PR DESCRIPTION
### Summary

Flip can be aborted via the RC switch. This resolves #32491 .

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

This is tested via a new autotest which enters-then-quickly-exits flip mode via the RC Aux switch. The test confirms that:
1. FlipMode was entered and exited.
2. FlipMode wrote the expected ERR message to the log about the flip being abandoned.

```
./Tools/scripts/size_compare_branches.py --master-branch=upstream/master --vehicle=copter --board=CubeOrange,sitl
CubeOrange,32
sitl,80
```

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
