### PR TITLE
autotest: check TerrainLoiterToCircle altitude in terrain frame, not home

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -3026,7 +3026,8 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.change_mode('LOITER')
         self.delay_sim_time(10)
         self.change_mode('CIRCLE')
-        self.wait_altitude(alt*0.9, alt*1.1, minimum_duration=10, relative=True)
+        self.wait_altitude(alt*0.9, alt*1.1, minimum_duration=10,
+                           altitude_source="TERRAIN_REPORT.current_height")
         self.fly_home_land_and_disarm()
 
     def fly_generic_mission(self, filename, mission_timeout=60.0, strict=True,


### PR DESCRIPTION

### Summary

 As far as I have understood this test, it's actually trying to maintain height above terrain, but the altitude check was using relative=True; i.e. height above home. This was causing one of my PRs (https://github.com/ArduPilot/ardupilot/pull/32022) to fail randomly because this test's passing was a matter of timing and not the accuracy of the height being read by the test.                                                                  
 
I have changed this test to read from terrain-relative height from TERRAIN_REPORT.current_height, which I also found some of the other similar tests doing.   

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

