### PR TITLE
Fix hwdef README.md files to have specific sections headings at start

### DIFF
--- a/Tools/scripts/build_script_base.py
+++ b/Tools/scripts/build_script_base.py
@@ -232,6 +232,46 @@ class BuildScriptBase:
 
         return sorted(modified_board_names, key=lambda x: x.lower())
 
+    def find_boards_with_modified_readmes(self, branch, master_branch, use_merge_base=True):
+        '''find board objects whose README.md files have been modified between
+        branch and master. Returns a list of (path, board_obj) pairs, one per
+        changed README.md that belongs to a known board directory.'''
+        if use_merge_base:
+            base_commit = self.find_git_branch_merge_base(branch, master_branch)
+        else:
+            base_commit = master_branch
+
+        delta_files = self.run_git([
+            'diff',
+            '--name-only',
+            '--diff-filter=AM',
+            base_commit,
+            branch,
+        ], show_output=False)
+
+        readme_paths = [
+            f.strip() for f in delta_files.splitlines()
+            if f.strip().endswith('README.md')
+        ]
+        if not readme_paths:
+            return []
+
+        bl = board_list.BoardList()
+        board_by_name = {b.name: b for b in bl.boards}
+        hwdef_dirs_real = {os.path.realpath(d) for d in bl.hwdef_dir}
+
+        result = []
+        for path in readme_paths:
+            board_name = os.path.basename(os.path.dirname(path))
+            if board_name not in board_by_name:
+                continue
+            board_dir_real = os.path.realpath(os.path.dirname(path))
+            if os.path.dirname(board_dir_real) not in hwdef_dirs_real:
+                continue
+            result.append((path, board_by_name[board_name]))
+
+        return result
+
     def progress(self, string):
         '''pretty-print progress'''
         print(f"{self.progress_prefix()}: {string}", file=sys.stderr)

--- a/Tools/scripts/check_branch_conventions.py
+++ b/Tools/scripts/check_branch_conventions.py
@@ -9,6 +9,7 @@ Validates:
   - commit messages have a well-formed subsystem prefix before ':'
   - commit subject lines are <= 160 characters
   - changed markdown files pass markdownlint-cli2
+  - non-AP_Periph README.md files have required headings in the correct order
 
 AP_FLAKE8_CLEAN
 '''
@@ -28,6 +29,25 @@ import build_script_base
 
 DOCS_URL = "https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html"
 MAX_SUBJECT_LEN = 160
+
+# Required heading sequence for hardware README.md files (non-AP_Periph).
+# Each entry is (heading_pattern, todo_pattern, display_label).
+# todo_pattern matches the placeholder comment added when content is absent.
+
+
+def _todo(label):
+    return re.compile(r'^<!-- TODO: add ' + re.escape(label) + r' content -->')
+
+
+REQUIRED_README_HEADINGS = [
+    (re.compile(r'^# .+'),              None,                   '# <title>'),
+    (re.compile(r'^## Features$'),      _todo('Features'),      '## Features'),
+    (re.compile(r'^## Pinout$'),        _todo('Pinout'),        '## Pinout'),
+    (re.compile(r'^## UART Mapping$'),  _todo('UART Mapping'),  '## UART Mapping'),
+    (re.compile(r'^## RC Input$'),      _todo('RC Input'),      '## RC Input'),
+    (re.compile(r'^## PWM Output$'),    _todo('PWM Output'),    '## PWM Output'),
+    (re.compile(r'^## Battery Monitoring$'), _todo('Battery Monitoring'), '## Battery Monitoring'),
+]
 BLACKLISTED_PREFIXES = {
     "DEBUG",
     "DRAFT",
@@ -486,6 +506,78 @@ class CheckBranchConventions(build_script_base.BuildScriptBase):
         print(f"{PASS} Markdown files pass linting.")
         return True
 
+    def check_markdown_readme_heading_order(self) -> bool:
+        '''check non-AP_Periph README.md files have required headings in the correct order
+        with no other headings interspersed between them'''
+        boards_with_readmes = self.find_boards_with_modified_readmes(
+            branch='HEAD',
+            master_branch=self.base_branch,
+            use_merge_base=False,
+        )
+
+        readme_files = [
+            path for path, board_obj in boards_with_readmes
+            if not board_obj.is_ap_periph
+        ]
+
+        if not readme_files:
+            print(f"{PASS} No non-AP_Periph README.md files changed (heading order check).")
+            return True
+
+        heading_re = re.compile(r'^#{1,6} ')
+        fence_re = re.compile(r'^(`{3,}|~{3,})')
+
+        ok = True
+        for path in readme_files:
+            if not os.path.exists(path):
+                continue
+
+            # Collect heading lines and TODO placeholder comments as tokens.
+            tokens = []
+            in_fence = False
+            todo_re = re.compile(r'^<!-- TODO: add .+ content -->')
+            with open(path, encoding="utf-8", errors="replace") as fh:
+                for lineno, raw in enumerate(fh, 1):
+                    line = raw.rstrip("\n")
+                    if fence_re.match(line):
+                        in_fence = not in_fence
+                    if not in_fence and (heading_re.match(line) or todo_re.match(line)):
+                        tokens.append((lineno, line.strip()))
+
+            errors = []
+            req_idx = 0
+            in_sequence = False
+
+            for lineno, token in tokens:
+                if req_idx < len(REQUIRED_README_HEADINGS):
+                    h_pat, t_pat, _ = REQUIRED_README_HEADINGS[req_idx]
+                    if h_pat.match(token) or (t_pat and t_pat.match(token)):
+                        in_sequence = True
+                        req_idx += 1
+                        continue
+                if in_sequence and req_idx < len(REQUIRED_README_HEADINGS):
+                    _, _, next_label = REQUIRED_README_HEADINGS[req_idx]
+                    errors.append(
+                        f"         {path}:{lineno}: unexpected heading '{token}'"
+                        f" (expected '{next_label}')"
+                    )
+
+            if req_idx < len(REQUIRED_README_HEADINGS):
+                missing = [label for _, _, label in REQUIRED_README_HEADINGS[req_idx:]]
+                errors.append(
+                    f"         {path}: missing required headings: {', '.join(missing)}"
+                )
+
+            if errors:
+                print(f"{FAIL} README.md heading order check failed for {path}:")
+                for e in errors:
+                    print(e)
+                ok = False
+            else:
+                print(f"{PASS} {path}: required headings present in correct order.")
+
+        return ok
+
     def run(self) -> None:
         if self.base_branch is None:
             current = self.find_current_git_branch_or_sha1()
@@ -511,6 +603,7 @@ class CheckBranchConventions(build_script_base.BuildScriptBase):
             self.check_markdown(),
             self.check_markdown_rst_hyperlinks(),
             self.check_markdown_rst_underlines(),
+            self.check_markdown_readme_heading_order(),
         ]
 
         failures = results.count(False)

--- a/libraries/AP_HAL_ChibiOS/hwdef/3DRControlZeroG/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/3DRControlZeroG/README.md
@@ -44,11 +44,6 @@ The Control Zero H7 OEM revision G is a flight controller produced by [3DR (mRo)
 
  *Note:* Case sold separately.
 
-## Changelog
-
-- M10059C - Initial Release
-- M10059G adds external power supply and TCXO.
-
 ## Pinout
 
 ![Control Zero H7 OEM revision G pinout](https://vddwxegfxugwzpfnrrlp.supabase.co/storage/v1/object/public/Website-CDN/pinouts/czoem_pinout_revG_topview.png)
@@ -79,15 +74,6 @@ Spektrum DSM / DSM2 / DSM-X® Satellite compatible input and binding.
 Futaba S.BUS® & S.BUS2® compatible input.
 Graupner SUMD. Yuneec ST24.
 
-## Analog Inputs
-
-The Control Zero H7 OEM revision G has 4 ADC inputs:
-
-- ADC1 Pin11 -> RSSI IN
-- ADC1 Pin14 -> Battery Voltage
-- ADC1 Pin15 -> Battery Current
-- ADC1 Pin18 -> 5V Sensor
-
 ## PWM Output
 
 The Control Zero H7 OEM revision G supports up to 8 PWM outputs. All DShot and BiDirDShot capable.
@@ -100,10 +86,6 @@ The PWM outputs are distributed in 3 groups:
 
 Channels within the same group must use only one output rate. If any channel is using DShot or BiDirDShot the rest of the group will use the said output type.
 
-## Power Supply
-
-This board requires a 5V, 1 Amps power supply.
-
 ## Battery Monitoring
 
 This board has a built-in voltage and current sensors. The following settings need to be present already on the board to work with a Power Zero Module (M10077):
@@ -115,6 +97,24 @@ This board has a built-in voltage and current sensors. The following settings ne
 - BATT_AMP_PERVLT 50.0
 
 *Note:* Other Power Module needs to be adjusted accordingly.
+
+## Changelog
+
+- M10059C - Initial Release
+- M10059G adds external power supply and TCXO.
+
+## Analog Inputs
+
+The Control Zero H7 OEM revision G has 4 ADC inputs:
+
+- ADC1 Pin11 -> RSSI IN
+- ADC1 Pin14 -> Battery Voltage
+- ADC1 Pin15 -> Battery Current
+- ADC1 Pin18 -> 5V Sensor
+
+## Power Supply
+
+This board requires a 5V, 1 Amps power supply.
 
 ## Build
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ACNS-CM4Pilot/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ACNS-CM4Pilot/README.md
@@ -29,6 +29,10 @@ The CM4PILOT is a low-cost and compact flight controller which integrated a Rasp
 - RBG LED on board
 - 128M flash on board for logging
 
+
+
+<!-- TODO: add Pinout content -->
+
 ## UART Mapping
 
 - SERIAL0 -> USB(OTG1)
@@ -52,6 +56,16 @@ The PWM is in 4 groups:
 - PWM 7,8 in group3
 - Buzzer on board in group4
 
+## Battery Monitoring
+
+The correct battery setting parameters are set by default and are:
+
+- BATT_MONITOR 4
+- BATT_VOLT_PIN 11
+- BATT_CURR_PIN 12
+- BATT_VOLT_SCALE 10.1
+- BATT_AMP_PERVLT 17.0
+
 ## GPIOs
 
 All 8 PWM channels can be used for GPIO functions.
@@ -66,16 +80,6 @@ The pin numbers for these PWM channels in ArduPilot are shown below:
 | PWM5         | 54   |
 | PWM6         | 55   |
 | PWM7         | 56   |
-
-## Battery Monitoring
-
-The correct battery setting parameters are set by default and are:
-
-- BATT_MONITOR 4
-- BATT_VOLT_PIN 11
-- BATT_CURR_PIN 12
-- BATT_VOLT_SCALE 10.1
-- BATT_AMP_PERVLT 17.0
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ACNS-F405AIO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ACNS-F405AIO/README.md
@@ -19,6 +19,12 @@ The ACNS-F405AIO is a low-cost compact flight controller for multi-rotor UAVs wh
 - 4 BLheli_s ESCs, 3-4s, 30A, The motor order matches the Arducotper X frame type config
 - Small footprint and lightweight, 39mm X 39mm X 10mm, 9g(without shell)
 
+## Pinout
+
+![F405AIO Top](F405AIO_top.jpg)
+
+![F405AIO Bottom](F405AIO_bottom.jpg)
+
 ## UART Mapping
 
 - SERIAL0 -> USB (OTG1)
@@ -41,6 +47,16 @@ The PWM is in 3 groups:
 - PWM 5,6 in group2 (External PWM)
 - PWM 7,8 in group3 (External PWM)
 
+## Battery Monitoring
+
+The correct battery setting parameters are set by default and are:
+
+- BATT_MONITOR 4
+- BATT_VOLT_PIN 11
+- BATT_CURR_PIN 12
+- BATT_VOLT_SCALE 9.2
+- BATT_AMP_PERVLT 50.0
+
 ## GPIOs
 
 4 External PWM channels can be used for GPIO functions.
@@ -52,16 +68,6 @@ The pin numbers for these PWM channels in ArduPilot are shown below:
 | PWM6         | 55   |
 | PWM7         | 56   |
 | PWM8         | 57   |
-
-## Battery Monitoring
-
-The correct battery setting parameters are set by default and are:
-
-- BATT_MONITOR 4
-- BATT_VOLT_PIN 11
-- BATT_CURR_PIN 12
-- BATT_VOLT_SCALE 9.2
-- BATT_AMP_PERVLT 50.0
 
 ## Compass
 
@@ -76,9 +82,3 @@ boot button pressed. Then you should load the "xxx_bl.hex"
 firmware, using your favorite DFU loading tool.
 
 Subsequently, you can update the firmware with Mission Planner.
-
-## Pinout
-
-![F405AIO Top](F405AIO_top.jpg)
-
-![F405AIO Bottom](F405AIO_bottom.jpg)

--- a/libraries/AP_HAL_ChibiOS/hwdef/AEDROXH7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/AEDROXH7/README.md
@@ -36,18 +36,6 @@ The default RC input is configured on the UART3 (RX3/SBUS). Non SBUS,  single wi
 - FPort requires connection to TX3. Set [SERIAL3_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial3-options-serial3-options) = 7
 - CRSF/ELRS also requires both TX3 and RX3 connections and provides telemetry automatically.
 
-## OSD Support
-
-Onboard OSD using OSD_TYPE 1 (MAX7456 driver) is supported by default. Simultaneously, DisplayPort OSD is available on the HD VTX connector.
-
-## VTX Support
-
-The SH1.0-6P connector supports a DJI Air Unit / HD VTX connection. Protocol defaults to DisplayPort. Pin 1 of the connector is 10v so be careful not to connect this to a peripheral requiring 5v. DisplayPort OSD is enabled by default on SERIAL8.
-
-## VTX Power Control
-
-GPIO 83 controls the VTX BEC output to pins marked "12V" and is included on the HD VTX connector. Setting this GPIO low removes voltage supply to this pin/pad. By default RELAY3 is configured to control this pin and sets the GPIO high.
-
 ## PWM Output
 
 The SPEDIX F405 supports up to 9 PWM (8 + LED) outputs. The pads for motor output
@@ -76,6 +64,18 @@ The default battery parameters are:
 - [BATT_CURR_PIN](https://ardupilot.org/copter/docs/parameters.html#batt-curr-pin-ap-battmonitor-analog-battery-current-sensing-pin) = 11 (CURR pin)
 - [BATT_VOLT_MULT](https://ardupilot.org/copter/docs/parameters.html#batt-volt-mult-ap-battmonitor-analog-voltage-multiplier) = 11.0
 - [BATT_AMP_PERVLT](https://ardupilot.org/copter/docs/parameters.html#batt-amp-pervlt-ap-battmonitor-analog-amps-per-volt) = 40
+
+## OSD Support
+
+Onboard OSD using OSD_TYPE 1 (MAX7456 driver) is supported by default. Simultaneously, DisplayPort OSD is available on the HD VTX connector.
+
+## VTX Support
+
+The SH1.0-6P connector supports a DJI Air Unit / HD VTX connection. Protocol defaults to DisplayPort. Pin 1 of the connector is 10v so be careful not to connect this to a peripheral requiring 5v. DisplayPort OSD is enabled by default on SERIAL8.
+
+## VTX Power Control
+
+GPIO 83 controls the VTX BEC output to pins marked "12V" and is included on the HD VTX connector. Setting this GPIO low removes voltage supply to this pin/pad. By default RELAY3 is configured to control this pin and sets the GPIO high.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/AET-H743-Basic/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/AET-H743-Basic/README.md
@@ -19,37 +19,9 @@ The AET-H743-Basic is a flight controller designed and produced by AeroEggTech
 - AT7456E OSD
 - 2 I2Cs
 
-## Physical
 
-![AET-H743-Basic overview](AET-H743-Basic_overview.jpg)
 
-![AET-H743-Basic core board](AET-H743-Basic_core_board.png)
-
-![AET-H743-Basic power board](AET-H743-Basic_power_board.png)
-
-## Mechanical
-
-- Dimensions: 36 x 47 x 17 mm
-- Weight: 45g
-
-## Power supply
-
-The AET-H743-Basic supports 2-6s Li battery input. It has 3 ways of BEC, which result in 6 ways of power supplys. Please see the table below.
-
-| Power symbol | Power source | Max power (current) |
-|--------------|--------------|---------------------|
-| 5V | from 5V BEC | 20W (4A) |
-| 9V | from 9V BEC | 18W (2A) |
-| 9Vsw | from 9V BEC, controlled by MCU with an NPN MOS | 10W (1A) |
-| 4V5 | from USB or 5V BEC, with a diode | 5W (1A) |
-| VX | from Servo rail VX BEC, default 5V, can be changed to 6V or 7V | 50W (10A) |
-| BAT | directly from battery | (5A) |
-
-## Loading Firmware
-
-Initial firmware load can be done with DFU by plugging in USB with the bootloader button pressed. Then you should load the "with_bl.hex" firmware, using your favorite DFU loading tool, such as Mission Planner.
-
-Once the initial firmware is loaded you can update the firmware using any ArduPilot ground station software. Updates should be done with the "\*.apj" firmware files.
+<!-- TODO: add Pinout content -->
 
 ## UART Mapping
 
@@ -68,10 +40,6 @@ All UARTs are DMA capable.
 ## RC Input
 
 The default RC input is configured on the UART6 and supports all RC protocols except PPM. The SBUS pin is inverted and connected to RX6. RC can be attached to any UART port as long as the serial port protocol is set to `SERIALn_PROTOCOL=23` and SERIAL6_Protocol is changed to something other than '23'.
-
-## OSD Support
-
-The AET-H743-Basic supports onboard analog SD OSD using a AT7456 chip. The analog VTX should connect to the VTX pin.
 
 ## PWM Output
 
@@ -109,6 +77,42 @@ The first voltage/current sensor is enabled by default and the pin inputs for th
 - BATT2_VOLT_PIN 18
 - BATT2_CURR_PIN 7
 - BATT2_VOLT_MULT 11
+
+## Physical
+
+![AET-H743-Basic overview](AET-H743-Basic_overview.jpg)
+
+![AET-H743-Basic core board](AET-H743-Basic_core_board.png)
+
+![AET-H743-Basic power board](AET-H743-Basic_power_board.png)
+
+## Mechanical
+
+- Dimensions: 36 x 47 x 17 mm
+- Weight: 45g
+
+## Power supply
+
+The AET-H743-Basic supports 2-6s Li battery input. It has 3 ways of BEC, which result in 6 ways of power supplys. Please see the table below.
+
+| Power symbol | Power source | Max power (current) |
+|--------------|--------------|---------------------|
+| 5V | from 5V BEC | 20W (4A) |
+| 9V | from 9V BEC | 18W (2A) |
+| 9Vsw | from 9V BEC, controlled by MCU with an NPN MOS | 10W (1A) |
+| 4V5 | from USB or 5V BEC, with a diode | 5W (1A) |
+| VX | from Servo rail VX BEC, default 5V, can be changed to 6V or 7V | 50W (10A) |
+| BAT | directly from battery | (5A) |
+
+## Loading Firmware
+
+Initial firmware load can be done with DFU by plugging in USB with the bootloader button pressed. Then you should load the "with_bl.hex" firmware, using your favorite DFU loading tool, such as Mission Planner.
+
+Once the initial firmware is loaded you can update the firmware using any ArduPilot ground station software. Updates should be done with the "\*.apj" firmware files.
+
+## OSD Support
+
+The AET-H743-Basic supports onboard analog SD OSD using a AT7456 chip. The analog VTX should connect to the VTX pin.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ARK_FPV/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ARK_FPV/README.md
@@ -218,6 +218,14 @@ RC input is configured on the RX6 (UART6_RX) pin. It supports all RC protocols e
 - CRSF also requires a TX6 connection, in addition to RX6, and automatically provides telemetry. Set [SERIAL6_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial6-options-serial6-options)
 - SRXL2 requires a connection to TX6 and automatically provides telemetry. Set [SERIAL6_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial6-options-serial6-options) to “4”. =3.
 
+## PWM Output
+
+All outputs are capable of PWM and DShot. Motors 1-4 are capable of Bidirectional-DSHOT. All outputs in the motor groups below must be either PWM or DShot:
+
+- Motors 1-4  Group1 (TIM5)
+- Motors 5-8  Group2 (TIM8)
+- Motor 9     Group3 (TIM4)
+
 ## Battery Monitoring
 
 The board has a internal voltage sensor and connections on the ESC connector for an external current sensor input. The board supports up to 12S LiPo batteries.
@@ -237,14 +245,6 @@ This autopilot has a built-in compass. The compass is the IIS2MDC
 ## OSD Support
 
 This flight controller has an MSP-DisplayPort output on a 6-pin DJI-compatible JST SH.
-
-## PWM Output
-
-All outputs are capable of PWM and DShot. Motors 1-4 are capable of Bidirectional-DSHOT. All outputs in the motor groups below must be either PWM or DShot:
-
-- Motors 1-4  Group1 (TIM5)
-- Motors 5-8  Group2 (TIM8)
-- Motor 9     Group3 (TIM4)
 
 ## Loading Firmware
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ARK_PI6X/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ARK_PI6X/README.md
@@ -151,6 +151,14 @@ RC input is configured on the RX6 (UART6_RX) pin. It supports all RC protocols e
 - CRSF also requires a TX6 connection, in addition to RX6, and automatically provides telemetry.
 - SRXL2 requires a connection to TX6 and automatically provides telemetry. Set [SERIAL6_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial6-options-serial6-options) to “4”.
 
+## PWM Output
+
+All outputs are capable of PWM and DShot. Motors 1-4 are configured as Bidirectional-DSHOT by default. All outputs in the motor groups below must be either PWM or DShot:
+
+- Motors 1-4  Group1 (TIM5)
+- Motors 5-6  Group2 (TIM4)
+- Motors 7-8  Group3 (TIM12)
+
 ## Battery Monitoring
 
 The board has an integrated INA226 digital power monitor. The board supports up to 6S LiPo batteries.
@@ -162,14 +170,6 @@ The default battery parameters are:
 ## Compass
 
 This autopilot has a built-in compass. The compass is the IIS2MDC. Often this internal compass is disabled due to power interference and a remotely located compass is used.
-
-## PWM Output
-
-All outputs are capable of PWM and DShot. Motors 1-4 are configured as Bidirectional-DSHOT by default. All outputs in the motor groups below must be either PWM or DShot:
-
-- Motors 1-4  Group1 (TIM5)
-- Motors 5-6  Group2 (TIM4)
-- Motors 7-8  Group3 (TIM12)
 
 ## Loading Firmware
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ATOMRCF405NAVI-Deluxe/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ATOMRCF405NAVI-Deluxe/README.md
@@ -6,6 +6,57 @@ the above image and some content courtesy of [ATOMRC](http://atomrc.com/)
 
 > **Note:** Due to flash memory limitations, this board does not include all ArduPilot features. See [Firmware Limitations](https://ardupilot.org/copter/docs/common-limited-firmware.html) for details.
 
+
+
+<!-- TODO: add Features content -->
+
+## Pinout
+
+tbd
+
+## UART Mapping
+
+- SERIAL0 = console = USB
+- SERIAL1 = RF Module = USART1(MAVLink2), not usable by AP GCS
+- SERIAL2 = RCinput, DMA capable = USART2 (RX2 connected to SBUS pins via inverter for SBUS receivers)
+- SERIAL3 = USER = USART3
+- SERIAL4 = GPS2 = UART4
+- SERIAL5 = DisplayPort = UART5
+- SERIAL6 = USER = USART6 (DMA capable)
+
+Serial protocols shown are defaults, but can be adjusted to personal preferences.
+
+## RC Input
+
+The SBUS pin, is passed by an inverter to RX2 (UART2 RX). UART2 is defaulted to RCIN protocol and can be used for all ArduPilot supported receiver protocols, except CRSF/ELRS and SRXL2 which require a true UART connection.
+
+- PPM is not supported.
+
+- DSM/SRXL connects to the RX2  pin, but SBUS would still be connected to SBUS.
+
+- FPort requires connection to TX2 and RX2 via a bi-directional inverter. See [FPort receivers](https://ardupilot.org/copter/docs/common-FPort-receivers.html).
+
+- CRSF/ELRS also requires a TX2 connection, in addition to RX2, and automatically provides telemetry.
+
+- SRXL2 requires a connection to TX2 and automatically provides telemetry.  Set [SERIAL6_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial6-options-serial6-options) to "4".
+
+> **Note:** the 5v pin above the SBUS pin is powered when USB is connected. All other 5V pins are only powered when battery is present.
+
+
+
+<!-- TODO: add PWM Output content -->
+
+## Battery Monitoring
+
+These settings are set as defaults when the firmware is loaded (except `BATT_AMP_PERVLT` which needs to be changed from the default value). However, if they are ever lost, you can manually set the parameters:
+
+Enable Battery monitor with `BATT_MONITOR=4`, then reboot, then set:
+
+- BATT_VOLT_PIN = 10
+- BATT_CURR_PIN = 11
+- BATT_VOLT_MULT = 11
+- BATT_AMP_PERVLT = 30
+
 ## Specifications
 
 - **Processor**
@@ -47,22 +98,6 @@ the above image and some content courtesy of [ATOMRC](http://atomrc.com/)
 
 [ATOMRC](https://atomrc.com)
 
-## Pinout
-
-tbd
-
-## UART Mapping
-
-- SERIAL0 = console = USB
-- SERIAL1 = RF Module = USART1(MAVLink2), not usable by AP GCS
-- SERIAL2 = RCinput, DMA capable = USART2 (RX2 connected to SBUS pins via inverter for SBUS receivers)
-- SERIAL3 = USER = USART3
-- SERIAL4 = GPS2 = UART4
-- SERIAL5 = DisplayPort = UART5
-- SERIAL6 = USER = USART6 (DMA capable)
-
-Serial protocols shown are defaults, but can be adjusted to personal preferences.
-
 ## Dshot capability
 
 All motor/servo outputs are Dshot and PWM capable. Outputs 1/2 and 6/7 are Bi-Directional DSHot capable.
@@ -70,33 +105,6 @@ All motor/servo outputs are Dshot and PWM capable. Outputs 1/2 and 6/7 are Bi-Di
 Mixing Dshot and normal PWM operation for outputs is restricted into groups, ie. enabling Dshot for an output in a group requires that ALL outputs in that group be configured and used as Dshot, rather than PWM outputs. The output groups that must be the same (PWM rate or Dshot, when configured as a normal servo/motor output) are: 1/2, 3/4, 5/6/7, 8/9/10, and 11/12(LED).
 
 > **Note:** PWM12 is marked as "LED" and defaulted to serial led protocol, so output 11 must also be used for serial LED unless output 12 function is changed.
-
-## RC Input
-
-The SBUS pin, is passed by an inverter to RX2 (UART2 RX). UART2 is defaulted to RCIN protocol and can be used for all ArduPilot supported receiver protocols, except CRSF/ELRS and SRXL2 which require a true UART connection.
-
-- PPM is not supported.
-
-- DSM/SRXL connects to the RX2  pin, but SBUS would still be connected to SBUS.
-
-- FPort requires connection to TX2 and RX2 via a bi-directional inverter. See [FPort receivers](https://ardupilot.org/copter/docs/common-FPort-receivers.html).
-
-- CRSF/ELRS also requires a TX2 connection, in addition to RX2, and automatically provides telemetry.
-
-- SRXL2 requires a connection to TX2 and automatically provides telemetry.  Set [SERIAL6_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial6-options-serial6-options) to "4".
-
-> **Note:** the 5v pin above the SBUS pin is powered when USB is connected. All other 5V pins are only powered when battery is present.
-
-## Battery Monitoring
-
-These settings are set as defaults when the firmware is loaded (except `BATT_AMP_PERVLT` which needs to be changed from the default value). However, if they are ever lost, you can manually set the parameters:
-
-Enable Battery monitor with `BATT_MONITOR=4`, then reboot, then set:
-
-- BATT_VOLT_PIN = 10
-- BATT_CURR_PIN = 11
-- BATT_VOLT_MULT = 11
-- BATT_AMP_PERVLT = 30
 
 ## Connecting a GPS/Compass module
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/AeroCogito-H7Digital/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/AeroCogito-H7Digital/README.md
@@ -13,17 +13,6 @@ The AeroCogito H7-Digital is a **NDAA-compliant**, high-performance flight contr
 - 10 PWM outputs
 - Software-controlled 10V VTX power
 
-## Specifications
-
-- **MCU**: STM32H743 @ 480MHz
-- **Memory**: 1MB RAM, 2MB Flash
-- **IMU**: ICM-42688-P 6-axis, with isolated power rail and additional filtering
-- **Baro**: DPS368
-- **Size**: 41mm x 41mm (30.5mm mounting)
-- **Input**: 3S-6S (11.1V - 25.2V)
-- **5V BEC**: 2.5A peak, 2A continuous
-- **10V BEC**: 2.5A peak, 2A continuous
-
 ## Pinout
 
 ![AeroCogito H7-Digital Pinout - Front and back views with labeled pins](H7-Digital_pinout.jpg)
@@ -43,6 +32,66 @@ The UARTs are marked Rn and Tn in the above pinouts. The Rn pin is the receive p
 | SERIAL6     | UART7    | NONE          | RX only on R7 for DJI, DMA-enabled      |
 
 Note: in order to use SERIAL6 for SBUS input on HD VTX connector, SERIAL 4 must not be used for RC, its protocol changed from "23", and SERIAL6_PROTOCOL changed to "23".
+
+## RC Input
+
+RC input is configured by default on UART4 (SERIAL4). It supports all standard protocols (SBUS, CRSF/ELRS, DSM, PPM).
+
+## PWM Output
+
+The H7-Digital supports up to 10 PWM outputs. All motor outputs support DShot (150/300/600) as well as PWM/OneShot.
+
+Bidirectional DShot supported on motors 1-8.
+
+**Note**: All outputs in the same group must use the same protocol:
+
+- Group 1 (M1-M4): Must all be the same (e.g., all DShot300)
+- Group 2 (M5-M8): Must all be the same
+- Group 3 (S1-S2): Must all be the same
+
+### Motor Outputs (Outputs 1-8)
+
+| Output | Pin  | Group |
+|--------|------|-------|
+| M1     | PE9  | 1     |
+| M2     | PE11 | 1     |
+| M3     | PE13 | 1     |
+| M4     | PE14 | 1     |
+| M5     | PD12 | 2     |
+| M6     | PD13 | 2     |
+| M7     | PD14 | 2     |
+| M8     | PD15 | 2     |
+
+### Servo Outputs (Outputs 9-10)
+
+| Output | Pin | Group |
+|--------|-----|-------|
+| S1     | PC6 | 3     |
+| S2     | PC7 | 3     |
+
+## Battery Monitoring
+
+The board has built-in voltage and current monitoring:
+
+- **Voltage Sensing**: default scale - 11.0
+- **Current Sensing**: default scale - 18.0
+
+Default battery monitoring parameters:
+
+- `BATT_MONITOR = 4` (Voltage and Current)
+- `BATT_VOLT_PIN = 16`
+- `BATT_CURR_PIN = 17`
+
+## Specifications
+
+- **MCU**: STM32H743 @ 480MHz
+- **Memory**: 1MB RAM, 2MB Flash
+- **IMU**: ICM-42688-P 6-axis, with isolated power rail and additional filtering
+- **Baro**: DPS368
+- **Size**: 41mm x 41mm (30.5mm mounting)
+- **Input**: 3S-6S (11.1V - 25.2V)
+- **5V BEC**: 2.5A peak, 2A continuous
+- **10V BEC**: 2.5A peak, 2A continuous
 
 ## Connectors
 
@@ -148,10 +197,6 @@ Connect your companion computer (e.g. Raspberry Pi, Nvidia Jetson) to the Compan
 - For high-bandwidth applications, consider `SERIAL1_BAUD = 921` (921600 baud)
 - Note: Higher baud rates require short, shielded cables and good electrical design.
 
-## RC Input
-
-RC input is configured by default on UART4 (SERIAL4). It supports all standard protocols (SBUS, CRSF/ELRS, DSM, PPM).
-
 ## OSD Support
 
 The H7-Digital supports **digital HD VTX only** via MSP DisplayPort on UART2 (SERIAL2). There is no analog OSD chip on this board.
@@ -167,51 +212,6 @@ Defaults set to:
 
 - `OSD_TYPE = 5` (MSP DisplayPort)
 - `SERIAL2_PROTOCOL = 42` (DisplayPort)
-
-## PWM Output
-
-The H7-Digital supports up to 10 PWM outputs. All motor outputs support DShot (150/300/600) as well as PWM/OneShot.
-
-Bidirectional DShot supported on motors 1-8.
-
-**Note**: All outputs in the same group must use the same protocol:
-
-- Group 1 (M1-M4): Must all be the same (e.g., all DShot300)
-- Group 2 (M5-M8): Must all be the same
-- Group 3 (S1-S2): Must all be the same
-
-### Motor Outputs (Outputs 1-8)
-
-| Output | Pin  | Group |
-|--------|------|-------|
-| M1     | PE9  | 1     |
-| M2     | PE11 | 1     |
-| M3     | PE13 | 1     |
-| M4     | PE14 | 1     |
-| M5     | PD12 | 2     |
-| M6     | PD13 | 2     |
-| M7     | PD14 | 2     |
-| M8     | PD15 | 2     |
-
-### Servo Outputs (Outputs 9-10)
-
-| Output | Pin | Group |
-|--------|-----|-------|
-| S1     | PC6 | 3     |
-| S2     | PC7 | 3     |
-
-## Battery Monitoring
-
-The board has built-in voltage and current monitoring:
-
-- **Voltage Sensing**: default scale - 11.0
-- **Current Sensing**: default scale - 18.0
-
-Default battery monitoring parameters:
-
-- `BATT_MONITOR = 4` (Voltage and Current)
-- `BATT_VOLT_PIN = 16`
-- `BATT_CURR_PIN = 17`
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/Aeromind6X/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Aeromind6X/README.md
@@ -7,6 +7,52 @@ Featuring **Triple Redundant IMUs** and **Integrated High-Speed Ethernet**, it o
 
 ---
 
+
+
+<!-- TODO: add Features content -->
+
+## Pinout
+
+![Pinout Diagram](Pinout.png)
+
+---
+
+## UART Mapping
+
+| SERIAL Port | UART Interface | Label / Function     | Flow Control |
+|-------------|----------------|----------------------|---------------|
+| SERIAL1     | UART7          | TELEM1/MAVLink2| Yes           |
+| SERIAL2     | UART5          | TELEM2/MAVLink2| Yes           |
+| SERIAL3     | UART1          | GPS1                 | No            |
+| SERIAL4     | UART8          | GPS2                 | No            |
+| SERIAL5     | USART2         | TELEM3/MAVLink2| Yes           |
+| SERIAL6     | UART4          | UART4 (General Use)  | No            |
+| SERIAL7     | USART3         | FMU_DEBUG            | No            |
+
+> **Note**: All UARTS are DMA capable. UART7, USART2, and UART5 support hardware flow control.
+
+---
+
+
+
+<!-- TODO: add RC Input content -->
+
+## PWM Output
+
+Supports up to **16 PWM outputs**:
+
+- **Main Outputs (M1-M8)**: via STM32F103 IO Processor
+- **Auxiliary Outputs (A1-A8)**: via STM32H753 FMU
+
+> **Note:** All outputs support both PWM and DShot protocols, except for outputs **A7** and **A8**, which are PWM-only. Outputs **M1-M8** are bi-directional DShot capable.
+---
+
+## Battery Monitoring
+
+Includes **two I2C power monitor ports** using 6-pin connectors. Configuration is defaulted for the first monitor to be INA2XX I2C type power monitor.
+
+---
+
 ## Specifications
 
 ### Main Processors
@@ -86,47 +132,9 @@ Featuring **Triple Redundant IMUs** and **Integrated High-Speed Ethernet**, it o
 
 ---
 
-## Pinout
-
-![Pinout Diagram](Pinout.png)
-
----
-
-## UART Mapping
-
-| SERIAL Port | UART Interface | Label / Function     | Flow Control |
-|-------------|----------------|----------------------|---------------|
-| SERIAL1     | UART7          | TELEM1/MAVLink2| Yes           |
-| SERIAL2     | UART5          | TELEM2/MAVLink2| Yes           |
-| SERIAL3     | UART1          | GPS1                 | No            |
-| SERIAL4     | UART8          | GPS2                 | No            |
-| SERIAL5     | USART2         | TELEM3/MAVLink2| Yes           |
-| SERIAL6     | UART4          | UART4 (General Use)  | No            |
-| SERIAL7     | USART3         | FMU_DEBUG            | No            |
-
-> **Note**: All UARTS are DMA capable. UART7, USART2, and UART5 support hardware flow control.
-
----
-
 ## RC Input Configuration
 
 RC input supports SBUS, PPM, and DSM protocols with dedicated ports available for each. For bi-directional protocols, UART4 or other telemetry ports can be configured to handle the connection. For more details, refer to the [ArduPilot documentation](https://ardupilot.org/plane/docs/common-rc-systems.html)
-
----
-
-## PWM Output
-
-Supports up to **16 PWM outputs**:
-
-- **Main Outputs (M1-M8)**: via STM32F103 IO Processor
-- **Auxiliary Outputs (A1-A8)**: via STM32H753 FMU
-
-> **Note:** All outputs support both PWM and DShot protocols, except for outputs **A7** and **A8**, which are PWM-only. Outputs **M1-M8** are bi-directional DShot capable.
----
-
-## Battery Monitoring
-
-Includes **two I2C power monitor ports** using 6-pin connectors. Configuration is defaulted for the first monitor to be INA2XX I2C type power monitor.
 
 ---
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/Airvolute-DCS2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Airvolute-DCS2/README.md
@@ -5,10 +5,6 @@ This system usually uses a "CUBE" autopilot as its primary FMU, but can use an o
 For more information on DCS2.Pilot board see:
 [Airvolute documentation](https://docs.airvolute.com/dronecore-autopilot/dcs2)
 
-## Where to Buy
-
-info@airvolute.com
-
 ## Features
 
 - MCU: STM32H743
@@ -22,6 +18,31 @@ info@airvolute.com
 - SD card connector
 - USB connection onboard with Jetson Host
 - Ethernet
+
+
+
+<!-- TODO: add Pinout content -->
+
+## UART Mapping
+
+- SERIAL0 -> USB (Default baud: 115200)
+- SERIAL1 -> UART1 (FMU SEC) (Default baud: 57600, Default protocol: Mavlink2 (2))
+- SERIAL2 -> UART2 (FMU SEC) (Default baud: 57600, Default protocol: Mavlink2 (2))
+- SERIAL3 -> UART3 (RX pin only labeled as PPM on PPM connector) (Since this is a secondary FMU, default protocol is set to NONE instead of RCIN (23))
+
+UARTs do not have RTS/CTS. UARTs 1 and 2 are routed to FMU_SEC. connector.
+
+
+
+
+
+<!-- TODO: add RC Input content -->
+<!-- TODO: add PWM Output content -->
+<!-- TODO: add Battery Monitoring content -->
+
+## Where to Buy
+
+info@airvolute.com
 
 ## DCS2.Pilot peripherals diagram
 
@@ -139,15 +160,6 @@ Matching connector JST GHR-04V-S.
 | 2 | CAN_H |
 | 3 | CAN_L |
 | 4 | GND |
-
-## UART Mapping
-
-- SERIAL0 -> USB (Default baud: 115200)
-- SERIAL1 -> UART1 (FMU SEC) (Default baud: 57600, Default protocol: Mavlink2 (2))
-- SERIAL2 -> UART2 (FMU SEC) (Default baud: 57600, Default protocol: Mavlink2 (2))
-- SERIAL3 -> UART3 (RX pin only labeled as PPM on PPM connector) (Since this is a secondary FMU, default protocol is set to NONE instead of RCIN (23))
-
-UARTs do not have RTS/CTS. UARTs 1 and 2 are routed to FMU_SEC. connector.
 
 ## Loading Firmware
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/AnyleafH7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/AnyleafH7/README.md
@@ -50,20 +50,11 @@ Pins and connector values are labeled on the flight controller PCB, with the fol
 - SERIAL5 -> UART7 (Onboard ELRS receiver only, RCIN protocol)
 - SERIAL6 -> UART8 (USER, External pads)
 
-## Can FD port
-
-This flight controller includes a 4-pin DroneCAN standard CAN port. It's capable of 64-byte frames,
-and up to 5Mbps data rates. It's useful for connecting GPS devices, compasses, power monitoring, sensors, motors, servos, and other CAN peripherals.
-
 ## RC Input
 
 This flight controller includes a 2.4Ghz ExpressLRS transceiver, capable of receiving control input, and transmitting or receiving MavLink telemetry. To enable all ELRS features, either RC5 channel should be setup as an ARM switch (there are several RC5_OPTIONS that can do this) or by mapping the transmitter's Channel 5 to reflect ARM status from telemetry. See: [this video](https://youtu.be/YO2yA1fmZBs) for an example.
 
 SBUS on the DJI connector may be used if SERIAL5_PROTOCOL is changed to 0 and SERIAL1_PROTOCOL is changed to 23 for RC input.
-
-## OSD Support
-
-This flight controller has an MSP-DisplayPort output on a 6-pin DJI-compatible JST SH port re-configured.
 
 ## PWM Output
 
@@ -73,6 +64,19 @@ All outputs in the motor groups below must be either PWM or DShot:
 Motors 1-4  Group1
 Motors 5-6  Group2
 Motors 7-8  Group3
+
+
+
+<!-- TODO: add Battery Monitoring content -->
+
+## Can FD port
+
+This flight controller includes a 4-pin DroneCAN standard CAN port. It's capable of 64-byte frames,
+and up to 5Mbps data rates. It's useful for connecting GPS devices, compasses, power monitoring, sensors, motors, servos, and other CAN peripherals.
+
+## OSD Support
+
+This flight controller has an MSP-DisplayPort output on a 6-pin DJI-compatible JST SH port re-configured.
 
 ## Magnetometer
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/Aocoda-RC-H743Dual/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Aocoda-RC-H743Dual/README.md
@@ -49,10 +49,6 @@ With recommended option:
 - Set SERIAL1_PROTOCOL<SERIAL1_PROTOCOL must be set to "23"
 - Set SERIAL1_OPTIONS<SERIAL1_OPTIONS to "0".
 
-## OSD Support
-
-The Aocoda-RC-H743Dual supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The Aocoda-RC-H743Dual supports up to 12 PWM outputs.
@@ -71,12 +67,6 @@ The PWM is in 6 groups:
 - PWM 11, 12 in group6
 
 Channels within the same group need to use the same output rate. If any channel in a group uses DShot then all channels in the group need to use DShot.
-
-## Pin IO
-
-- PINIO1: 9V DCDC control (HIGH:on; LOW:off)
-
-*Note: DCDC default is enabled.*
 
 ## Battery Monitoring
 
@@ -98,6 +88,16 @@ Please calibrate before use amp parameters.
 - BATT2_AMP_PERVLT 17.0
 
 *Note:* Please check carefully before use BATT_AMP_PERVLT/BATT2_AMP_PERVLT, as voltage divider circuit for data collection is at ESC/BEC side.
+
+## OSD Support
+
+The Aocoda-RC-H743Dual supports OSD using OSD_TYPE 1 (MAX7456 driver).
+
+## Pin IO
+
+- PINIO1: 9V DCDC control (HIGH:on; LOW:off)
+
+*Note: DCDC default is enabled.*
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/Atlas-Control/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Atlas-Control/README.md
@@ -55,6 +55,37 @@ The Atlas Control flight controller
 
 > **Note:** SERIAL 1 and 2 have RTS/CTS flow control capability.
 
+## RC Input
+
+RC input is configured on the RCIN pin, at one end of the servo rail,
+marked RCIN in the above diagram. All ArduPilot supported unidirectional
+RC protocols can be input here including PPM. For bi-directional or half-duplex
+protocols, such as CRSF/ELRS a full UART will have to be used.
+See [ArduPilot RC documentation](https://ardupilot.org/plane/docs/common-rc-systems.html)
+
+## PWM Output
+
+The 14 PWM outputs are in 4 groups: Each group must be the same protocol (ie PWM or DShot or Serial LED, etc.):
+
+- Outputs 1, 2, 3 and 4 in group1 (supports Bi-directional DShot)
+- Outputs 5, 6, 7 and 8 in group2 (supports Bi-directional DShot)
+- Outputs 9, 10, 11 and 12 in group3 (supports DShot)
+- Outputs 13 and 14 in group4 (PWM only, no DMA)
+
+## Battery Monitoring
+
+The board has two dedicated power monitor ports on 6 pin connectors.
+
+The board is supplied with an analog power module. Analog monitoring is set as the default configuration.
+The module is rated for up to 60V (14S) and 60A continuous current.
+
+- **BATT_MONITOR**: 4 (Analog Voltage and Current)
+- **BATT_VOLT_PIN**: 16
+- **BATT_CURR_PIN**: 17
+- **BATT_VOLT_MULT**: 18.000
+- **BATT_AMP_PERVLT**: 24.000
+- **BATT_VLT_OFFSET**: -0.1
+
 ## Connectors
 
 Unless noted otherwise all connectors are JST GH 1.25mm pitch
@@ -135,37 +166,6 @@ the servo rail.
 | 4 (blk) | GND | GND |
 | 5 (blk) | BUZZER | battery voltage |
 | 6 (blk) | Boot/Error LED |  |
-
-## RC Input
-
-RC input is configured on the RCIN pin, at one end of the servo rail,
-marked RCIN in the above diagram. All ArduPilot supported unidirectional
-RC protocols can be input here including PPM. For bi-directional or half-duplex
-protocols, such as CRSF/ELRS a full UART will have to be used.
-See [ArduPilot RC documentation](https://ardupilot.org/plane/docs/common-rc-systems.html)
-
-## PWM Output
-
-The 14 PWM outputs are in 4 groups: Each group must be the same protocol (ie PWM or DShot or Serial LED, etc.):
-
-- Outputs 1, 2, 3 and 4 in group1 (supports Bi-directional DShot)
-- Outputs 5, 6, 7 and 8 in group2 (supports Bi-directional DShot)
-- Outputs 9, 10, 11 and 12 in group3 (supports DShot)
-- Outputs 13 and 14 in group4 (PWM only, no DMA)
-
-## Battery Monitoring
-
-The board has two dedicated power monitor ports on 6 pin connectors.
-
-The board is supplied with an analog power module. Analog monitoring is set as the default configuration.
-The module is rated for up to 60V (14S) and 60A continuous current.
-
-- **BATT_MONITOR**: 4 (Analog Voltage and Current)
-- **BATT_VOLT_PIN**: 16
-- **BATT_CURR_PIN**: 17
-- **BATT_VOLT_MULT**: 18.000
-- **BATT_AMP_PERVLT**: 24.000
-- **BATT_VLT_OFFSET**: -0.1
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BETAFPV-F405-I2C/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BETAFPV-F405-I2C/README.md
@@ -36,10 +36,6 @@ receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
 
 RC input is configured on the on-board ELRS on UART3 or through (UART6_RX/UART6_TX) pins. It supports all serial RC protocols.
 
-## OSD Support
-
-The BETAFPV F405 AIO supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The BETAFPV F405 AIO has 4 PWM outputs internally connected to its 4-in-1 ESC. The pads for motor output are M1 to M4 on the board. All 4 outputs support bi-directional DShot and DShot, as well as all PWM types. The default configuration is for bi-directional DShot using the already installed BlueJay firmware.
@@ -68,6 +64,10 @@ The correct battery setting parameters are:
 - BATT_CURR_MULT 50
 
 These are set by default in the firmware and shouldn't need to be adjusted
+
+## OSD Support
+
+The BETAFPV F405 AIO supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BETAFPV-F405/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BETAFPV-F405/README.md
@@ -55,10 +55,6 @@ receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
 
 RC input is configured on the on-board ELRS on UART3 or through (UART6_RX/UART6_TX) pins. It supports all serial RC protocols.
 
-## OSD Support
-
-The BETAFPV F405 AIO supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The BETAFPV F405 AIO has 4 PWM outputs internally connected to its 4-in-1 ESC. The pads for motor output are M1 to M4 on the board. All 4 outputs support bi-directional DShot and DShot, as well as all PWM types. The default configuration is for bi-directional DShot using the already installed BlueJay firmware.
@@ -87,6 +83,10 @@ The correct battery setting parameters are:
 - BATT_CURR_MULT 50
 
 These are set by default in the firmware and shouldn't need to be adjusted
+
+## OSD Support
+
+The BETAFPV F405 AIO supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BROTHERHOBBYF405v3/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BROTHERHOBBYF405v3/README.md
@@ -39,22 +39,6 @@ The default RC input is configured on UART2, all ArduPilot compatible protocols,
 - DSM/SRXL connects to the RX2 pin, but SBUS would still be connected to SBUS.
 - SRXL2 requires a connection to TX2 and automatically provides telemetry. Set [SERIAL2_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial2-options-telem2-options) to "4".
 
-## FrSky Telemetry
-
-FrSky Telemetry can be supported using a spare UART transmit pin. You need to set the following parameters to enable support for FrSky S.PORT on SERIAL4
-
-- [SERIAL4_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial4-protocol-serial4-protocol-selection) 10
-- [SERIAL4_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial4-options-serial4-options) 7
-
-## OSD Support
-
-The BROTHERHOBBYF405v3 supports OSD using OSD_TYPE 1 (MAX7456 driver). Simultaneously, DisplayPort HD VTX connections can be made to UART3 (included on the HD VTX connector) by setting OSD_TYPE2 = 5.
-
-## VTX Support
-
-The SH1.0-6P connector supports a standard DJI HD VTX connection. Pin 1 of the connector is 10v so be careful not to connect
-anything that could be damaged by this voltage.
-
 ## PWM Output
 
 The BROTHERHOBBYF405v3 supports up to 9 PWM outputs. Outputs 1-4 are on the ESC connector, while the others are available via solder pads.
@@ -82,6 +66,22 @@ The default battery parameters are:
 - [BATT_CURR_PIN](https://ardupilot.org/copter/docs/parameters.html#batt-curr-pin-ap-battmonitor-analog-battery-current-sensing-pin) = 11
 - [BATT_VOLT_MULT](https://ardupilot.org/copter/docs/parameters.html#batt-volt-mult-ap-battmonitor-analog-voltage-multiplier) = 11
 - [BATT_AMP_PERVLT](https://ardupilot.org/copter/docs/parameters.html#batt-amp-pervlt-ap-battmonitor-analog-amps-per-volt) = 25.9 (will need to be adjusted for whichever current sensor is attached)
+
+## FrSky Telemetry
+
+FrSky Telemetry can be supported using a spare UART transmit pin. You need to set the following parameters to enable support for FrSky S.PORT on SERIAL4
+
+- [SERIAL4_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial4-protocol-serial4-protocol-selection) 10
+- [SERIAL4_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial4-options-serial4-options) 7
+
+## OSD Support
+
+The BROTHERHOBBYF405v3 supports OSD using OSD_TYPE 1 (MAX7456 driver). Simultaneously, DisplayPort HD VTX connections can be made to UART3 (included on the HD VTX connector) by setting OSD_TYPE2 = 5.
+
+## VTX Support
+
+The SH1.0-6P connector supports a standard DJI HD VTX connection. Pin 1 of the connector is 10v so be careful not to connect
+anything that could be damaged by this voltage.
 
 ## RSSI
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BROTHERHOBBYH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BROTHERHOBBYH743/README.md
@@ -37,21 +37,6 @@ The default RC input is configured on the UART2_RX inverted from the SBUS pin.  
 - CRSF/ELRS also requires a TX2 connection, in addition to RX2, and automatically provides telemetry.
 - SRXL2 requires a connection to TX2 and automatically provides telemetry. Set [SERIAL2_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial2-options-telem2-options) to "4".
 
-## FrSky Telemetry
-
-FrSky Telemetry can be supported using the T1 pin (UART1 transmit). You need to set the following parameters to enable support for FrSky S.PORT
-
-- SERIAL1_PROTOCOL 10
-- SERIAL1_OPTIONS 7
-
-## OSD Support
-
-The BROTHERHOBBYH743 supports using its internal OSD (MAX7456 driver). Simultaneous DisplayPort OSD operation  is also pre-configured on SERIAL 6. See [MSP OSD](https://ardupilot.org/copter/docs/common-msp-osd-overview-4.2.html) for more info.
-
-## VTX Support
-
-The SH1.0-6P connector supports a standard DJI HD VTX connection. Pin 1 of the connector is 12v so be careful not to connect incorrectly.
-
 ## PWM Output
 
 The BROTHERHOBBYH743 supports up to 13 PWM outputs.
@@ -80,6 +65,21 @@ The default battery parameters are:
 - [BATT_CURR_PIN](https://ardupilot.org/copter/docs/parameters.html#batt-curr-pin-ap-battmonitor-analog-battery-current-sensing-pin) = 11
 - [BATT_VOLT_MULT](https://ardupilot.org/copter/docs/parameters.html#batt-volt-mult-ap-battmonitor-analog-voltage-multiplier) = 11
 - [BATT_AMP_PERVLT](https://ardupilot.org/copter/docs/parameters.html#batt-amp-pervlt-ap-battmonitor-analog-amps-per-volt) = 40.2
+
+## FrSky Telemetry
+
+FrSky Telemetry can be supported using the T1 pin (UART1 transmit). You need to set the following parameters to enable support for FrSky S.PORT
+
+- SERIAL1_PROTOCOL 10
+- SERIAL1_OPTIONS 7
+
+## OSD Support
+
+The BROTHERHOBBYH743 supports using its internal OSD (MAX7456 driver). Simultaneous DisplayPort OSD operation  is also pre-configured on SERIAL 6. See [MSP OSD](https://ardupilot.org/copter/docs/common-msp-osd-overview-4.2.html) for more info.
+
+## VTX Support
+
+The SH1.0-6P connector supports a standard DJI HD VTX connection. Pin 1 of the connector is 12v so be careful not to connect incorrectly.
 
 ## RSSI
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BeastF7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BeastF7/README.md
@@ -39,10 +39,6 @@ UART1 supports RX and TX DMA. UART2, UART3 and UART4 support RX DMA. UART7 suppo
 RC input is configured on the (UART3_RX) pin which forms part of the DJI connector. It supports all RC protocols.
 For RC input/output use UART1 with SERIAL1_PROTOCOL as 23 and set SERIAL3_PROTOCOL set to -1
 
-## OSD Support
-
-The Beast F7 AIO supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The Beast F7 AIO supports up to 4 PWM outputs. The pads for motor output ESC1 to ESC4 on the above diagram are for the 4 outputs. All 4 outputs support DShot as well as all PWM types.
@@ -67,6 +63,10 @@ The correct battery setting parameters are:
 - BATT_CURR_MULT around 28.5
 
 These are set by default in the firmware and shouldn't need to be adjusted
+
+## OSD Support
+
+The Beast F7 AIO supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BeastF7v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BeastF7v2/README.md
@@ -38,10 +38,6 @@ UART1 supports RX and TX DMA. UART2, UART3 and UART4 support RX DMA. UART7 suppo
 RC input is configured on the (UART3_RX) pin which forms part of the DJI connector. It supports all RC protocols.
 For RC input/output use UART1 with SERIAL1_PROTOCOL as 23 and set SERIAL3_PROTOCOL set to -1
 
-## OSD Support
-
-The Beast F7 AIO supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The Beast F7 AIO supports up to 4 PWM outputs. The pads for motor output ESC1 to ESC4 on the above diagram are for the 4 outputs. All 4 outputs support DShot as well as all PWM types.
@@ -66,6 +62,10 @@ The correct battery setting parameters are:
 - BATT_CURR_MULT around 28.5
 
 These are set by default in the firmware and shouldn't need to be adjusted
+
+## OSD Support
+
+The Beast F7 AIO supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BeastH7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BeastH7/README.md
@@ -39,10 +39,6 @@ All UARTS support DMA.
 RC input is configured on the (UART3_RX) pin which forms part of the DJI connector. It supports all RC protocols.
 For RC input/output use UART1 with SERIAL1_PROTOCOL as 23 and set SERIAL3_PROTOCOL set to -1
 
-## OSD Support
-
-The Beast H7 AIO supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The Beast H7 AIO supports up to 4 PWM outputs. The pads for motor output ESC1 to ESC4 on the above diagram are for the 4 outputs. All 4 outputs support DShot as well as all PWM types.
@@ -67,6 +63,10 @@ The correct battery setting parameters are:
 - BATT_CURR_MULT around 28.5
 
 These are set by default in the firmware and shouldn't need to be adjusted
+
+## OSD Support
+
+The Beast H7 AIO supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BeastH7v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BeastH7v2/README.md
@@ -39,10 +39,6 @@ All UARTS support DMA.
 
 RC input is configured on the (UART2_RX/UART2_TX) pins which forms part of the DJI connector. It supports all RC protocols.
 
-## OSD Support
-
-The Beast H7 v2 AIO supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The Beast H7 AIO supports up to 4 PWM outputs. The pads for motor output ESC1 to ESC4 on the above diagram are for the 4 outputs. All 4 outputs support DShot as well as all PWM types.
@@ -67,6 +63,10 @@ The correct battery setting parameters are:
 - BATT_CURR_MULT around 28.5
 
 These are set by default in the firmware and shouldn't need to be adjusted
+
+## OSD Support
+
+The Beast H7 v2 AIO supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BlitzF745/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BlitzF745/README.md
@@ -40,10 +40,6 @@ Note:UART3 is used for GPS not UART4 as shown in typical wiring diagram
 
 RC input is configured on the (UART2_RX/UART2_TX). It supports all serial RC protocols.
 
-## OSD Support
-
-The BLITZ F745 supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The BLITZ F745 has 9 PWM outputs. The pads for motor output are M1 to M8 on the board and M1-M4 are also in the ESC connector housing. All 9 outputs support DShot and the first four outputs support bi-directional DShot as well as all PWM types. Output 9 is the "LED" pin and is configured for serial LED by default.
@@ -72,6 +68,10 @@ The correct battery setting parameters are:
 - BATT_CURR_MULT 50
 
 These are set by default in the firmware and shouldn't need to be adjusted
+
+## OSD Support
+
+The BLITZ F745 supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BlitzF745AIO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BlitzF745AIO/README.md
@@ -38,10 +38,6 @@ receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
 
 RC input is configured on the (UART2_RX/UART2_TX) pins which forms part of the DJI connector. It supports all RC protocols.
 
-## OSD Support
-
-The BLITZ Whoop F7 AIO supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The BLITZ Whoop F7 AIO has 4 PWM outputs internally connected to its 4-in-1 ESC. The pads for motor output are M1 to M4 on the board. All 4 outputs support bi-directional DShot and DShot, as well as all PWM types. The default configuration is for bi-directional DShot using the already installed BlueJay firmware.
@@ -69,6 +65,10 @@ The correct battery setting parameters are:
 - BATT_CURR_MULT 50
 
 These are set by default in the firmware and shouldn't need to be adjusted
+
+## OSD Support
+
+The BLITZ Whoop F7 AIO supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BlitzH743Pro/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BlitzH743Pro/README.md
@@ -50,10 +50,6 @@ receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
 
 RC input is configured on the (UART2_RX/UART2_TX) pins which forms part of the DJI connector. It supports all serial RC protocols.
 
-## OSD Support
-
-The BLITZ H7 Pro supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The BLITZ H7 Pro has 13 PWM outputs. The pads for motor output M1-M4 are in one ESC connector and M5-M8 in the second ESC connector. The remaining outputs are on the pads on the daughterboard. The first 8 outputs support bi-directional DShot and DShot, as well as all PWM types. Outputs 9-10 support DShot, as well as all PWM types and outputs 11-12 only support PWM.
@@ -75,18 +71,6 @@ Channels within the same group need to use the same output rate. If
 any channel in a group uses DShot then all channels in the group need
 to use DShot.
 
-## Video Power Control
-
-The 12V video power can be turned off/on  using GPIO 81 which is already assigned by default to RELAY2.  This relay can be controlled either from the GCS or using a transmitter channel (See [auxiliary functions](https://ardupilot.org/copter/docs/common-auxiliary-functions.html))
-
-## Camera Switch
-
-The camera output can be switched using GPIO 82 which is already assigned by default to RELAY3.  This relay can be controlled either from the GCS or using a transmitter channel (See [auxiliary functions](https://ardupilot.org/copter/docs/common-auxiliary-functions.html))
-
-## RSSI
-
-Analog RSSI pin is "4"
-
 ## Battery Monitoring
 
 The board has a builtin voltage sensor and a current sensor input tied to its 4 in 1 ESC current sensor. The voltage sensor can handle up to 6S
@@ -101,6 +85,22 @@ The correct battery setting parameters are:
 - BATT_CURR_MULT 50
 
 These are set by default in the firmware and shouldn't need to be adjusted
+
+## OSD Support
+
+The BLITZ H7 Pro supports OSD using OSD_TYPE 1 (MAX7456 driver).
+
+## Video Power Control
+
+The 12V video power can be turned off/on  using GPIO 81 which is already assigned by default to RELAY2.  This relay can be controlled either from the GCS or using a transmitter channel (See [auxiliary functions](https://ardupilot.org/copter/docs/common-auxiliary-functions.html))
+
+## Camera Switch
+
+The camera output can be switched using GPIO 82 which is already assigned by default to RELAY3.  This relay can be controlled either from the GCS or using a transmitter channel (See [auxiliary functions](https://ardupilot.org/copter/docs/common-auxiliary-functions.html))
+
+## RSSI
+
+Analog RSSI pin is "4"
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BlitzMiniF745/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BlitzMiniF745/README.md
@@ -38,10 +38,6 @@ receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
 
 RC input is configured on the (UART2_RX/UART2_TX). It supports all serial RC protocols.
 
-## OSD Support
-
-The BLITZ Mini F745 supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The BLITZ Mini F745 has 5 PWM outputs. The motor outputs M1-M4 are in the ESC connector housing. All 5 outputs support DShot and the first four outputs support bi-directional DShot as well as all PWM types. Output 5 is the "LED" pin and is configured for serial LED by default.
@@ -69,6 +65,10 @@ The correct battery setting parameters are:
 - BATT_CURR_MULT 50
 
 These are set by default in the firmware and shouldn't need to be adjusted
+
+## OSD Support
+
+The BLITZ Mini F745 supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BlitzWingH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BlitzWingH743/README.md
@@ -18,12 +18,6 @@ The BLITZ Wing H743 is a flight controller produced by [iFlight](https://shop.if
 - 2x I2C for external compass, airspeed, etc.
 - CAN port
 
-## Physical
-
-- Mount pattern: 30.5*30.5mm/?4
-- Dimensions: 36.9*52mm
-- Weight: 35g
-
 ## Pinout
 
 ![BLITZ Wing H743 Board](blitz_h7_wing_top.PNG "BLITZ Wing H743 Top")
@@ -49,10 +43,6 @@ receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
 
 RC input is configured on the (UART2_RX/UART2_TX) pins which forms part of the DJI connector. It supports all serial RC protocols.
 
-## OSD Support
-
-The BLITZ Wing H743 supports OSD using OSD_TYPE 1 (MAX7456 driver). Simultaneously, DisplayPort HD OSD is enabled by default and available on the HD VTX connector.
-
 ## PWM Output
 
 The BLITZ Wing H743 has 13 PWM outputs. The first 8 outputs support bi-directional DShot and DShot, as well as all PWM types. Outputs 9-10 support DShot, as well as all PWM types and outputs 11-12 only support PWM.
@@ -69,18 +59,6 @@ Channels within the same group need to use the same output rate. If
 any channel in a group uses DShot then all channels in the group need
 to use DShot.
 
-## Video Power Control
-
-The 9V video power can be turned off/on  using GPIO 81 which is already assigned by default to RELAY2.  This relay can be controlled either from the GCS or using a transmitter channel (See [auxiliary functions](https://ardupilot.org/copter/docs/common-auxiliary-functions.html))
-
-## Camera Switch
-
-The camera output can be switched using GPIO 82 which is already assigned by default to RELAY3.  This relay can be controlled either from the GCS or using a transmitter channel (See [auxiliary functions](https://ardupilot.org/copter/docs/common-auxiliary-functions.html))
-
-## Analog Airspeed Input
-
-The analog airspeed pin is "4"
-
 ## Battery Monitoring
 
 The board has a built-in voltage sensor and  current sensor. The voltage sensor can handle up to 8S
@@ -95,6 +73,28 @@ The correct battery setting parameters are:
 - BATT_CURR_MULT 50
 
 These are set by default in the firmware and shouldn't need to be adjusted
+
+## Physical
+
+- Mount pattern: 30.5*30.5mm/?4
+- Dimensions: 36.9*52mm
+- Weight: 35g
+
+## OSD Support
+
+The BLITZ Wing H743 supports OSD using OSD_TYPE 1 (MAX7456 driver). Simultaneously, DisplayPort HD OSD is enabled by default and available on the HD VTX connector.
+
+## Video Power Control
+
+The 9V video power can be turned off/on  using GPIO 81 which is already assigned by default to RELAY2.  This relay can be controlled either from the GCS or using a transmitter channel (See [auxiliary functions](https://ardupilot.org/copter/docs/common-auxiliary-functions.html))
+
+## Camera Switch
+
+The camera output can be switched using GPIO 82 which is already assigned by default to RELAY3.  This relay can be controlled either from the GCS or using a transmitter channel (See [auxiliary functions](https://ardupilot.org/copter/docs/common-auxiliary-functions.html))
+
+## Analog Airspeed Input
+
+The analog airspeed pin is "4"
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BrahmaF4/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BrahmaF4/README.md
@@ -16,9 +16,9 @@
 - 5V Power Out: 2.0A max
 - 9V Power Out: 2.0A max
 
-## Pinout for BRAHMA F405
 
-![BrahmaF405](BRAHMA_F405-diagram.jpg "DM_BrahmaF4")
+
+<!-- TODO: add Pinout content -->
 
 ## UART Mapping
 
@@ -46,11 +46,6 @@ The UARTs are marked Rx and Tx in the above pinouts.
 - SRXL2 requires a connection to T1 and automatically provides telemetry. Set [SERIAL1_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial1-options-telem1-options) to "4".
 
 Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM. See Radio Control Systems for details.
-
-## OSD Support
-
-- ANALOG OSD (MAX7456) (SPI1) (Preconfigured)
-- DIGITAL OSD (MSP)    (UART4 can be used for MSP Displayport by changing [SERIAL4_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial4-protocol-serial4-protocol-selection) to "42")
 
 ## PWM Output
 
@@ -81,6 +76,15 @@ The default battery configuration is:
 - BATT_VOLT_MULT 11
 - BATT_CURR_PIN 13
 - BATT_CURR_MULT 37
+
+## Pinout for BRAHMA F405
+
+![BrahmaF405](BRAHMA_F405-diagram.jpg "DM_BrahmaF4")
+
+## OSD Support
+
+- ANALOG OSD (MAX7456) (SPI1) (Preconfigured)
+- DIGITAL OSD (MSP)    (UART4 can be used for MSP Displayport by changing [SERIAL4_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial4-protocol-serial4-protocol-selection) to "42")
 
 ## Compass & Baro
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CBU-H7-Stamp/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CBU-H7-Stamp/README.md
@@ -15,37 +15,6 @@ The [CBUnmanned H743 Stamp](https://cbunmanned.com/store) is a flight controller
 - All complicated/supporting circuitry is on-board, just power with 5v.
 - Just 22mm x 24.25mm & 3g.
 
-## Specifications
-
-- Processor
-- STM32H743IIK6 microcontroller
-- 480MHz
-- 2Mb Flash
-- 1Mb RAM
-
-- Sensors
-- x2 Ivensense ICM-42688 IMU
-- x1 Ivensense ICM-42670 IMU
-- x1 BMP280 Barometer
-- x1 Bosch BMM150 Magnetometer
-
-- Power
-- 5v Main Power in
-- x6 Independent Power Regulators
-- x2 ADC Inputs for Voltage and Current Sense
-
-- Interfaces
-- x1 MicroSD card slot
-- x8 UARTs inc RC, x3 with flow control
-- x10 PWM outputs
-- x2 I2C
-- x2 CAN
-- x1 External SPI
-- x1 Ethernet
-- External Buzzer
-- External Safety Switch
-- External USB connectors
-
 ## Pinout
 
 ![H743 Stamp Pinout](H743Pinout.png "H743")
@@ -135,6 +104,47 @@ Optional, if it is not fitted remove the check from arming mask. To activate sho
 A regulated 3.3v output is available from the stamp for use with the safety button. WARNING! This is shared with the main IC - Do NOT use for accessories. Keep current draw under 0.1A!
 
 The Stamp requires a stable 5v supply input of at least 1.5A. This directly powers the 5v components and supplies the 3.3v LDOs with power. Typical idle usage is 0.35A @ 5v.
+
+
+
+
+
+
+<!-- TODO: add UART Mapping content -->
+<!-- TODO: add RC Input content -->
+<!-- TODO: add PWM Output content -->
+<!-- TODO: add Battery Monitoring content -->
+
+## Specifications
+
+- Processor
+- STM32H743IIK6 microcontroller
+- 480MHz
+- 2Mb Flash
+- 1Mb RAM
+
+- Sensors
+- x2 Ivensense ICM-42688 IMU
+- x1 Ivensense ICM-42670 IMU
+- x1 BMP280 Barometer
+- x1 Bosch BMM150 Magnetometer
+
+- Power
+- 5v Main Power in
+- x6 Independent Power Regulators
+- x2 ADC Inputs for Voltage and Current Sense
+
+- Interfaces
+- x1 MicroSD card slot
+- x8 UARTs inc RC, x3 with flow control
+- x10 PWM outputs
+- x2 I2C
+- x2 CAN
+- x1 External SPI
+- x1 Ethernet
+- External Buzzer
+- External Safety Switch
+- External USB connectors
 
 ## Loading Firmware
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CORVON405V2_1/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CORVON405V2_1/README.md
@@ -14,11 +14,9 @@ The CORVON405V2.1 is a flight controller produced by CORVON.
 - 10 PWM outputs
 - 1 SWD
 
-## Physical
 
-![CORVON F405 V2.1 Front View](CORVON405V2.1_FrontView.jpg)
 
-![CORVON F405 V2.1 Back View](CORVON405V2.1_BackView.jpg)
+<!-- TODO: add Pinout content -->
 
 ## UART Mapping
 
@@ -37,14 +35,6 @@ The default RC input is configured on the UART6_RX input which is inverted from 
 - CRSF/ELRS also requires a TX1 connection, in addition to RX1, and automatically provides telemetry.
 - FPort requires connection to TX1 and [SERIAL1_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial1-options-telem1-options) set to "7". See [FPort receivers](https://ardupilot.org/copter/docs/common-FPort-receivers.html)
 - SRXL2 requires a connection to TX2 and automatically provides telemetry. Set [SERIAL1_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial1-options-telem1-options) to "4".
-
-## OSD Support
-
-The CORVON405V2.1 supports  internal analog OSD MAX7456. Simultaneous external HD OSD support is preconfigured on SERIAL6. See [MSP OSD](https://ardupilot.org/copter/docs/common-msp-osd-overview-4.2.html) for more info.
-
-## VTX Support
-
-Both Analog and HD VTX connectors are provided. Pin 1 of the connector is 9v so be careful not to connect this to a peripheral requiring 5v.
 
 ## PWM Output
 
@@ -71,6 +61,20 @@ The default battery parameters are:
 - BATT_CURR_PIN =1 1
 - BATT_VOLT_MULT = 21.2
 - BATT_AMP_PERVLT = 40.2
+
+## Physical
+
+![CORVON F405 V2.1 Front View](CORVON405V2.1_FrontView.jpg)
+
+![CORVON F405 V2.1 Back View](CORVON405V2.1_BackView.jpg)
+
+## OSD Support
+
+The CORVON405V2.1 supports  internal analog OSD MAX7456. Simultaneous external HD OSD support is preconfigured on SERIAL6. See [MSP OSD](https://ardupilot.org/copter/docs/common-msp-osd-overview-4.2.html) for more info.
+
+## VTX Support
+
+Both Analog and HD VTX connectors are provided. Pin 1 of the connector is 9v so be careful not to connect this to a peripheral requiring 5v.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CORVON743V1/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CORVON743V1/README.md
@@ -17,11 +17,9 @@ The CORVON743V1 is a flight controller designed and produced by [CORVON]
 - 1 I2C
 - 1 SWD
 
-## Physical
 
-![CORVON743V1 Front View](CORVON743V1_FrontView.jpg)
 
-![CORVON743V1 Back View](CORVON743V1_BackView.jpg)
+<!-- TODO: add Pinout content -->
 
 ## UART Mapping
 
@@ -42,14 +40,6 @@ The default RC input is configured on the UART6. The SBUS pin is inverted and co
 - FPort would require [SERIAL5_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial5-options-serial5-options) be set to "15".
 - CRSF would require [SERIAL5_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial5-options-serial5-options) be set to "0".
 - SRXL2 would require [SERIAL5_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial5-options-serial5-options) be set to "4" and connects only the TX pin.
-
-## OSD Support
-
-The CORVON743V1 supports onboard OSD using OSD_TYPE 1 (MAX7456 driver). Simultaneously, DisplayPort OSD is available on the HD VTX connector, See below.
-
-## VTX Support
-
-The SH1.0-6P connector supports a DJI Air Unit / HD VTX connection. Protocol defaults to DisplayPort. Pin 1 of the connector is 9v so be careful not to connect this to a peripheral that can not tolerate this voltage.
 
 ## PWM Output
 
@@ -75,6 +65,20 @@ The default battery parameters are:
 - [BATT_CURR_PIN](https://ardupilot.org/copter/docs/parameters.html#batt-curr-pin-ap-battmonitor-analog-battery-current-sensing-pin) = 11 (CURR pin)
 - [BATT_VOLT_MULT](https://ardupilot.org/copter/docs/parameters.html#batt-volt-mult-ap-battmonitor-analog-voltage-multiplier) = 21.12
 - [BATT_AMP_PERVLT](https://ardupilot.org/copter/docs/parameters.html#batt-amp-pervlt-ap-battmonitor-analog-amps-per-volt) = 40.2
+
+## Physical
+
+![CORVON743V1 Front View](CORVON743V1_FrontView.jpg)
+
+![CORVON743V1 Back View](CORVON743V1_BackView.jpg)
+
+## OSD Support
+
+The CORVON743V1 supports onboard OSD using OSD_TYPE 1 (MAX7456 driver). Simultaneously, DisplayPort OSD is available on the HD VTX connector, See below.
+
+## VTX Support
+
+The SH1.0-6P connector supports a DJI Air Unit / HD VTX connection. Protocol defaults to DisplayPort. Pin 1 of the connector is 9v so be careful not to connect this to a peripheral that can not tolerate this voltage.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CUAV-V6X-v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CUAV-V6X-v2/README.md
@@ -12,10 +12,6 @@ The CUAV-V6X-v2 is an upgraded version of CUAV-V6X flight controller. It has the
 - Replace one of the ICP20100 barometer with BMP581.
 - Replace ICM42688P with IIM42652 and ICM20649 with ICM45686.
 
-## Pinout
-
-![CUAV-V6X-v2-pinout.png](CUAV-V6X-v2-pinout.png)
-
 ## Features
 
 - STM32H753 microcontroller
@@ -31,6 +27,10 @@ The CUAV-V6X-v2 is an upgraded version of CUAV-V6X flight controller. It has the
 - 2 CAN ports (two independent CAN buses)
 - Analog RSSI input
 - 3.3V/5V configurable PWM output voltage
+
+## Pinout
+
+![CUAV-V6X-v2-pinout.png](CUAV-V6X-v2-pinout.png)
 
 ## UART Mapping
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CrazyF405/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CrazyF405/README.md
@@ -36,10 +36,6 @@ To disable the onboard ELRS module and use an external RC on TX2/RX2, desolder t
 
 ![CrazyF405HD ELRS Pinout](CrazyF405_external_elrs.jpg)
 
-## OSD Support
-
-The CrazyF405HDAIO is optimized for Digital HD FPV and does not require the analog OSD chip (MAX7456); OSD data is transmitted via MSP to the digital VTX.
-
 ## PWM Output
 
 The CrazyF405HD AIO has 4 PWM outputs internally connected to its 4-in-1 ESC. The pads for motor output are M1 to M4 on the board. All 4 outputs support DShot, as well as all PWM types. The default configuration is for DShot using the already installed BlueJay firmware.
@@ -58,6 +54,10 @@ The correct battery setting parameters are:
 - BATT_CURR_MULT 50
 
 These are set by default in the firmware and shouldn't need to be adjusted
+
+## OSD Support
+
+The CrazyF405HDAIO is optimized for Digital HD FPV and does not require the analog OSD chip (MAX7456); OSD data is transmitted via MSP to the digital VTX.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack/README.md
@@ -45,6 +45,48 @@ have RTS/CTS.
 The CONS port was originally used as a debug console, but is now a
 general purpose UART (debug output is now on USB).
 
+## RC Input
+
+RC input is configured on the RCIN pin, at one end of the servo rail,
+marked RCIN in the above diagram. This pin supports all RC
+protocols. In addition there is a dedicated Spektrum satellite port
+which supports software power control, allowing for binding of
+Spektrum satellite receivers.
+
+## PWM Output
+
+The CubeBlack supports up to 14 PWM outputs. First first 8 outputs (labelled
+"MAIN") are controlled by a dedicated STM32F100 IO controller. These 8
+outputs support all PWM output formats, but not DShot.
+
+The remaining 6 outputs (labelled AUX1 to AUX6) are the "auxiliary"
+outputs. These are directly attached to the STM32F427 and support all
+PWM protocols as well as DShot.
+
+All 14 PWM outputs have GND on the top row, 5V on the middle row and
+signal on the bottom row.
+
+The 8 main PWM outputs are in 3 groups:
+
+- PWM 1 and 2 in group1
+- PWM 3 and 4 in group2
+- PWM 5, 6, 7 and 8 in group3
+
+The 6 auxiliary PWM outputs are in 2 groups:
+
+- PWM 1, 2, 3 and 4 in group1
+- PWM 5 and 6 in group2
+
+Channels within the same group need to use the same output rate. If
+any channel in a group uses DShot then all channels in the group need
+to use DShot.
+
+## Battery Monitoring
+
+The board has two dedicated power monitor ports on 6 pin
+connectors. The correct battery setting parameters are dependent on
+the type of power brick which is connected.
+
 ## Connectors
 
 Unless noted otherwise all connectors are JST GH
@@ -200,48 +242,6 @@ the servo rail.
 | 4 (blk) | GND | GND |
 | 5 (blk) | BUZZER | battery voltage |
 | 6 (blk) | Boot/Error LED |  |
-
-## RC Input
-
-RC input is configured on the RCIN pin, at one end of the servo rail,
-marked RCIN in the above diagram. This pin supports all RC
-protocols. In addition there is a dedicated Spektrum satellite port
-which supports software power control, allowing for binding of
-Spektrum satellite receivers.
-
-## PWM Output
-
-The CubeBlack supports up to 14 PWM outputs. First first 8 outputs (labelled
-"MAIN") are controlled by a dedicated STM32F100 IO controller. These 8
-outputs support all PWM output formats, but not DShot.
-
-The remaining 6 outputs (labelled AUX1 to AUX6) are the "auxiliary"
-outputs. These are directly attached to the STM32F427 and support all
-PWM protocols as well as DShot.
-
-All 14 PWM outputs have GND on the top row, 5V on the middle row and
-signal on the bottom row.
-
-The 8 main PWM outputs are in 3 groups:
-
-- PWM 1 and 2 in group1
-- PWM 3 and 4 in group2
-- PWM 5, 6, 7 and 8 in group3
-
-The 6 auxiliary PWM outputs are in 2 groups:
-
-- PWM 1, 2, 3 and 4 in group1
-- PWM 5 and 6 in group2
-
-Channels within the same group need to use the same output rate. If
-any channel in a group uses DShot then all channels in the group need
-to use DShot.
-
-## Battery Monitoring
-
-The board has two dedicated power monitor ports on 6 pin
-connectors. The correct battery setting parameters are dependent on
-the type of power brick which is connected.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeGreen-solo/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeGreen-solo/README.md
@@ -6,6 +6,20 @@ The `CubeGreen-solo` build is identical to the CubeBlack build, but includes a l
 - For data on the Hex CubeBlack flight controller, see the [Hex CubeBlack hwdef readme](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/CubeBlack/README.md)
 - For the parameter list used by this build, see [Tools/Fram_params/Solo_Copter-3.7_GreenCube.param](https://github.com/ArduPilot/ardupilot/blob/master/Tools/Frame_params/Solo_Copter-3.7_GreenkCube.param)
 
+
+
+
+
+
+
+
+<!-- TODO: add Features content -->
+<!-- TODO: add Pinout content -->
+<!-- TODO: add UART Mapping content -->
+<!-- TODO: add RC Input content -->
+<!-- TODO: add PWM Output content -->
+<!-- TODO: add Battery Monitoring content -->
+
 ## Using this build in waf
 
 - `./waf configure --board CubeGreen-solo`

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/README.md
@@ -49,6 +49,48 @@ have RTS/CTS.
 The CONS port was originally used as a debug console, but is now a
 general purpose UART (debug output is now on USB).
 
+## RC Input
+
+RC input is configured on the RCIN pin, at one end of the servo rail,
+marked RCIN in the above diagram. This pin supports all RC
+protocols. In addition there is a dedicated Spektrum satellite port
+which supports software power control, allowing for binding of
+Spektrum satellite receivers.
+
+## PWM Output
+
+The CubeOrange supports up to 14 PWM outputs. First first 8 outputs (labelled
+"MAIN") are controlled by a dedicated STM32F100 IO controller. These 8
+outputs support all PWM output formats, but not DShot.
+
+The remaining 6 outputs (labelled AUX1 to AUX6) are the "auxiliary"
+outputs. These are directly attached to the STM32H743 and support all
+PWM protocols as well as DShot.
+
+All 14 PWM outputs have GND on the top row, 5V on the middle row and
+signal on the bottom row.
+
+The 8 main PWM outputs are in 3 groups:
+
+- PWM 1 and 2 in group1
+- PWM 3 and 4 in group2
+- PWM 5, 6, 7 and 8 in group3
+
+The 6 auxiliary PWM outputs are in 2 groups:
+
+- PWM 1, 2, 3 and 4 in group1
+- PWM 5 and 6 in group2
+
+Channels within the same group need to use the same output rate. If
+any channel in a group uses DShot then all channels in the group need
+to use DShot.
+
+## Battery Monitoring
+
+The board has two dedicated power monitor ports on 6 pin
+connectors. The correct battery setting parameters are dependent on
+the type of power brick which is connected.
+
 ## Connectors
 
 Unless noted otherwise all connectors are JST GH 1.25mm pitch
@@ -204,48 +246,6 @@ the servo rail.
 | 4 (blk) | GND | GND |
 | 5 (blk) | BUZZER | battery voltage |
 | 6 (blk) | Boot/Error LED |  |
-
-## RC Input
-
-RC input is configured on the RCIN pin, at one end of the servo rail,
-marked RCIN in the above diagram. This pin supports all RC
-protocols. In addition there is a dedicated Spektrum satellite port
-which supports software power control, allowing for binding of
-Spektrum satellite receivers.
-
-## PWM Output
-
-The CubeOrange supports up to 14 PWM outputs. First first 8 outputs (labelled
-"MAIN") are controlled by a dedicated STM32F100 IO controller. These 8
-outputs support all PWM output formats, but not DShot.
-
-The remaining 6 outputs (labelled AUX1 to AUX6) are the "auxiliary"
-outputs. These are directly attached to the STM32H743 and support all
-PWM protocols as well as DShot.
-
-All 14 PWM outputs have GND on the top row, 5V on the middle row and
-signal on the bottom row.
-
-The 8 main PWM outputs are in 3 groups:
-
-- PWM 1 and 2 in group1
-- PWM 3 and 4 in group2
-- PWM 5, 6, 7 and 8 in group3
-
-The 6 auxiliary PWM outputs are in 2 groups:
-
-- PWM 1, 2, 3 and 4 in group1
-- PWM 5 and 6 in group2
-
-Channels within the same group need to use the same output rate. If
-any channel in a group uses DShot then all channels in the group need
-to use DShot.
-
-## Battery Monitoring
-
-The board has two dedicated power monitor ports on 6 pin
-connectors. The correct battery setting parameters are dependent on
-the type of power brick which is connected.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrangePlus-ODID/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrangePlus-ODID/README.md
@@ -49,6 +49,48 @@ have RTS/CTS.
 The CONS port was originally used as a debug console, but is now a
 general purpose UART (debug output is now on USB).
 
+## RC Input
+
+RC input is configured on the RCIN pin, at one end of the servo rail,
+marked RCIN in the above diagram. This pin supports all RC
+protocols. In addition there is a dedicated Spektrum satellite port
+which supports software power control, allowing for binding of
+Spektrum satellite receivers.
+
+## PWM Output
+
+The CubeOrangePlus supports up to 14 PWM outputs. First first 8 outputs (labelled
+"MAIN") are controlled by a dedicated STM32F100 IO controller. These 8
+outputs support all PWM output formats, but not DShot.
+
+The remaining 6 outputs (labelled AUX1 to AUX6) are the "auxiliary"
+outputs. These are directly attached to the STM32H743 and support all
+PWM protocols as well as DShot.
+
+All 14 PWM outputs have GND on the top row, 5V on the middle row and
+signal on the bottom row.
+
+The 8 main PWM outputs are in 3 groups:
+
+- PWM 1 and 2 in group1
+- PWM 3 and 4 in group2
+- PWM 5, 6, 7 and 8 in group3
+
+The 6 auxiliary PWM outputs are in 2 groups:
+
+- PWM 1, 2, 3 and 4 in group1
+- PWM 5 and 6 in group2
+
+Channels within the same group need to use the same output rate. If
+any channel in a group uses DShot then all channels in the group need
+to use DShot.
+
+## Battery Monitoring
+
+The board has two dedicated power monitor ports on 6 pin
+connectors. The correct battery setting parameters are dependent on
+the type of power brick which is connected.
+
 ## Connectors
 
 Unless noted otherwise all connectors are JST GH 1.25mm pitch
@@ -204,48 +246,6 @@ the servo rail.
 | 4 (blk) | GND | GND |
 | 5 (blk) | BUZZER | battery voltage |
 | 6 (blk) | Boot/Error LED |  |
-
-## RC Input
-
-RC input is configured on the RCIN pin, at one end of the servo rail,
-marked RCIN in the above diagram. This pin supports all RC
-protocols. In addition there is a dedicated Spektrum satellite port
-which supports software power control, allowing for binding of
-Spektrum satellite receivers.
-
-## PWM Output
-
-The CubeOrangePlus supports up to 14 PWM outputs. First first 8 outputs (labelled
-"MAIN") are controlled by a dedicated STM32F100 IO controller. These 8
-outputs support all PWM output formats, but not DShot.
-
-The remaining 6 outputs (labelled AUX1 to AUX6) are the "auxiliary"
-outputs. These are directly attached to the STM32H743 and support all
-PWM protocols as well as DShot.
-
-All 14 PWM outputs have GND on the top row, 5V on the middle row and
-signal on the bottom row.
-
-The 8 main PWM outputs are in 3 groups:
-
-- PWM 1 and 2 in group1
-- PWM 3 and 4 in group2
-- PWM 5, 6, 7 and 8 in group3
-
-The 6 auxiliary PWM outputs are in 2 groups:
-
-- PWM 1, 2, 3 and 4 in group1
-- PWM 5 and 6 in group2
-
-Channels within the same group need to use the same output rate. If
-any channel in a group uses DShot then all channels in the group need
-to use DShot.
-
-## Battery Monitoring
-
-The board has two dedicated power monitor ports on 6 pin
-connectors. The correct battery setting parameters are dependent on
-the type of power brick which is connected.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrangePlus/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrangePlus/README.md
@@ -49,6 +49,46 @@ have RTS/CTS.
 The CONS port was originally used as a debug console, but is now a
 general purpose UART (debug output is now on USB).
 
+## RC Input
+
+RC input is configured on the RCIN pin, at one end of the servo rail,
+marked RCIN in the above diagram. This pin supports all RC
+protocols. In addition there is a dedicated Spektrum satellite port
+which supports software power control, allowing for binding of
+Spektrum satellite receivers.
+
+## PWM Output
+
+The CubeOrangePlus supports up to 14 PWM outputs, with the first 8 ("MAIN") managed by an STM32F100 IO controller. These support all PWM formats, and DShot can be enabled by setting BRD_IO_DSHOT to 1, which loads the DShot firmware on the IO co-processor.
+
+The remaining 6 outputs (labelled AUX1 to AUX6) are the "auxiliary"
+outputs. These are directly attached to the STM32H743 and support all
+PWM protocols as well as DShot.
+
+All 14 PWM outputs have GND on the top row, 5V on the middle row and
+signal on the bottom row.
+
+The 8 main PWM outputs are in 3 groups:
+
+- PWM 1 and 2 in group1
+- PWM 3 and 4 in group2
+- PWM 5, 6, 7 and 8 in group3
+
+The 6 auxiliary PWM outputs are in 2 groups:
+
+- PWM 1, 2, 3 and 4 in group1
+- PWM 5 and 6 in group2
+
+Channels within the same group need to use the same output rate. If
+any channel in a group uses DShot then all channels in the group need
+to use DShot.
+
+## Battery Monitoring
+
+The board has two dedicated power monitor ports on 6 pin
+connectors. The correct battery setting parameters are dependent on
+the type of power brick which is connected.
+
 ## Connectors
 
 Unless noted otherwise all connectors are JST GH 1.25mm pitch
@@ -204,46 +244,6 @@ the servo rail.
 | 4 (blk) | GND | GND |
 | 5 (blk) | BUZZER | battery voltage |
 | 6 (blk) | Boot/Error LED |  |
-
-## RC Input
-
-RC input is configured on the RCIN pin, at one end of the servo rail,
-marked RCIN in the above diagram. This pin supports all RC
-protocols. In addition there is a dedicated Spektrum satellite port
-which supports software power control, allowing for binding of
-Spektrum satellite receivers.
-
-## PWM Output
-
-The CubeOrangePlus supports up to 14 PWM outputs, with the first 8 ("MAIN") managed by an STM32F100 IO controller. These support all PWM formats, and DShot can be enabled by setting BRD_IO_DSHOT to 1, which loads the DShot firmware on the IO co-processor.
-
-The remaining 6 outputs (labelled AUX1 to AUX6) are the "auxiliary"
-outputs. These are directly attached to the STM32H743 and support all
-PWM protocols as well as DShot.
-
-All 14 PWM outputs have GND on the top row, 5V on the middle row and
-signal on the bottom row.
-
-The 8 main PWM outputs are in 3 groups:
-
-- PWM 1 and 2 in group1
-- PWM 3 and 4 in group2
-- PWM 5, 6, 7 and 8 in group3
-
-The 6 auxiliary PWM outputs are in 2 groups:
-
-- PWM 1, 2, 3 and 4 in group1
-- PWM 5 and 6 in group2
-
-Channels within the same group need to use the same output rate. If
-any channel in a group uses DShot then all channels in the group need
-to use DShot.
-
-## Battery Monitoring
-
-The board has two dedicated power monitor ports on 6 pin
-connectors. The correct battery setting parameters are dependent on
-the type of power brick which is connected.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeSolo/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeSolo/README.md
@@ -4,6 +4,20 @@ The `CubeSolo` build is based on FMUv3, but includes a large set of default para
 
 For the parameter list used by this build, see [Tools/Fram_params/Solo_Copter-3.7_BlackCube.param](https://github.com/ArduPilot/ardupilot/blob/master/Tools/Frame_params/Solo_Copter-3.7_BlackCube.param)
 
+
+
+
+
+
+
+
+<!-- TODO: add Features content -->
+<!-- TODO: add Pinout content -->
+<!-- TODO: add UART Mapping content -->
+<!-- TODO: add RC Input content -->
+<!-- TODO: add PWM Output content -->
+<!-- TODO: add Battery Monitoring content -->
+
 ## Using this build in waf
 
 - `./waf configure --board CubeSolo`

--- a/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVF405/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVF405/README.md
@@ -22,11 +22,6 @@ The DAKEFPV F405 is a flight controller produced by [DAKEFPV](https://www.dakefp
 ![DAKEFPV F405 Board Top](Top.png "DAKEFPV F405 Top")
 ![DAKEFPV F405 Board Bottom](Bottom.png "DAKEFPV F405 Bottom")
 
-## DAKEFPV F405 Wiring Diagram
-
-![DAKEFPV F405 Wiring Diagram Top]( WiringDiagramTop.png "DAKEFPV F405 Wiring Diagram Top")
-![DAKEFPV F405 Wiring Diagram Bottom](WiringDiagramBottom.png "DAKEFPV F405 Wiring Diagram Bottom")
-
 ## UART Mapping
 
 The UARTs are marked Rn and Tn in the above pinouts. The Rn pin is the
@@ -47,14 +42,6 @@ RC input is configured by default via the USART2 RX input. It supports all unidi
 - FPort requires an external bi-directional inverter attached to T2 and [SERIAL1_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial1-options-telem1-options) set to 4 (half-duplex).  See [FPort receivers](https://ardupilot.org/copter/docs/common-FPort-receivers.html).
 - CRSF/ELRS uses RX2/TX2.
 - SRXL2 requires a connection to T2 and automatically provides telemetry.  Set [SERIAL1_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial1-options-telem1-options) to "4".
-
-## FrSky Telemetry
-
-FrSky Telemetry is supported using an unused UART, such as the TX5 pin (UART5 transmit).
-You need to set the following parameters to enable support for FrSky S.PORT:
-
-- [SERIAL5_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial5-protocol-serial5-protocol-selection) 10
-- [SERIAL5_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial5-options-serial5-options) 7
 
 ## PWM Output
 
@@ -84,6 +71,19 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN = 10
 - BATT_VOLT_MULT = 11.0
 - BATT_AMP_PERVLT = 83.3
+
+## DAKEFPV F405 Wiring Diagram
+
+![DAKEFPV F405 Wiring Diagram Top]( WiringDiagramTop.png "DAKEFPV F405 Wiring Diagram Top")
+![DAKEFPV F405 Wiring Diagram Bottom](WiringDiagramBottom.png "DAKEFPV F405 Wiring Diagram Bottom")
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using an unused UART, such as the TX5 pin (UART5 transmit).
+You need to set the following parameters to enable support for FrSky S.PORT:
+
+- [SERIAL5_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial5-protocol-serial5-protocol-selection) 10
+- [SERIAL5_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial5-options-serial5-options) 7
 
 ## RSSI
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743/README.md
@@ -22,16 +22,6 @@ The DAKEFPV H743 is a flight controller produced by [DAKEFPV](https://www.dakefp
 ![DAKEFPV H743 Board Top](DAKEFPVH743_Top.jpg "DAKEFPV H743 Top")
 ![DAKEFPV H743 Board Bottom](DAKEFPVH743_Bottom.jpg "DAKEFPV H743 Bottom")
 
-## DAKEFPV H743 Wiring Diagram
-
-### DAKEFPV H743 Pro Wiring Diagram Top
-
-![DAKEFPV H743 Wiring Diagram Top](DAKEFPVH743_WiringDiagramTop.jpg "DAKEFPV H743 Wiring Diagram Top")
-
-### DAKEFPV H743 Pro Wiring Diagram Bottom
-
-![DAKEFPV H743 Wiring Diagram Bottom](DAKEFPVH743_WiringDiagramBottom.jpg "DAKEFPV H743 Wiring Diagram Bottom")
-
 ## UART Mapping
 
 The UARTs are marked Rn and Tn in the above pinouts. The Rn pin is the
@@ -54,14 +44,6 @@ RC input is configured by default via the USART5 RX input. It supports all unidi
 - FPort requires an external bi-directional inverter attached to T5 and [SERIAL5_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial5-options-serial5-options) set to 4 (half-duplex).  See [FPort receivers](https://ardupilot.org/copter/docs/common-FPort-receivers.html).
 - CRSF/ELRS uses RX5/TX5.
 - SRXL2 requires a connection to T5 and automatically provides telemetry.  Set [SERIAL5_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial5-options-serial5-options) to "4".
-
-## FrSky Telemetry
-
-FrSky Telemetry is supported using an unused UART, such as the TX2 pin (UART2 transmit).
-You need to set the following parameters to enable support for FrSky S.PORT:
-
-- [SERIAL2_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial2-protocol-telemetry-2-protocol-selection) 10
-- [SERIAL2_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial2-options-telem2-options) 7
 
 ## PWM Output
 
@@ -94,6 +76,24 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN =1 0
 - BATT_VOLT_MULT = 16.0
 - BATT_AMP_PERVLT = 83.3
+
+## DAKEFPV H743 Wiring Diagram
+
+### DAKEFPV H743 Pro Wiring Diagram Top
+
+![DAKEFPV H743 Wiring Diagram Top](DAKEFPVH743_WiringDiagramTop.jpg "DAKEFPV H743 Wiring Diagram Top")
+
+### DAKEFPV H743 Pro Wiring Diagram Bottom
+
+![DAKEFPV H743 Wiring Diagram Bottom](DAKEFPVH743_WiringDiagramBottom.jpg "DAKEFPV H743 Wiring Diagram Bottom")
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using an unused UART, such as the TX2 pin (UART2 transmit).
+You need to set the following parameters to enable support for FrSky S.PORT:
+
+- [SERIAL2_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial2-protocol-telemetry-2-protocol-selection) 10
+- [SERIAL2_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial2-options-telem2-options) 7
 
 ## RSSI
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743Pro/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743Pro/README.md
@@ -23,16 +23,6 @@ The DAKEFPV H743 Pro is a flight controller produced by [DAKEFPV](https://www.da
 ![DAKEFPV H743 Pro Board Top](DAKEFPVH743Pro_Top.png "DAKEFPV H743 Pro Top")
 ![DAKEFPV H743 Pro Board Bottom](DAKEFPVH743Pro_Bottom.png "DAKEFPV H743 Pro Bottom")
 
-## DAKEFPV H743 Pro Wiring Diagram
-
-### DAKEFPV H743 Pro Wiring Diagram Top
-
-![DAKEFPV H743 Pro Wiring Diagram Top](DAKEFPVH743Pro_WiringDiagramTop.png "DAKEFPV H743 Pro Wiring Diagram Top")
-
-### DAKEFPV H743 Pro Wiring Diagram Bottom
-
-![DAKEFPV H743 Pro Wiring Diagram Bottom](DAKEFPVH743Pro_WiringDiagramBottom.png "DAKEFPV H743 Pro Wiring Diagram Bottom")
-
 ## UART Mapping
 
 The UARTs are marked Rn and Tn in the above pinouts. The Rn pin is the
@@ -55,14 +45,6 @@ RC input is configured by default via the USART5 RX input. It supports all unidi
 - FPort requires an external bi-directional inverter attached to T5 and [SERIAL5_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial5-options-serial5-options) set to 4 (half-duplex).  See [FPort receivers](https://ardupilot.org/copter/docs/common-FPort-receivers.html).
 - CRSF/ELRS uses RX5/TX5.
 - SRXL2 requires a connection to T5 and automatically provides telemetry.  Set [SERIAL5_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial5-options-serial5-options) to "4".
-
-## FrSky Telemetry
-
-FrSky Telemetry is supported using an unused UART, such as the TX2 pin (UART2 transmit).
-You need to set the following parameters to enable support for FrSky S.PORT:
-
-- [SERIAL2_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial2-protocol-telemetry-2-protocol-selection) 10
-- [SERIAL2_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial2-options-telem2-options) 7
 
 ## PWM Output
 
@@ -103,6 +85,24 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN = 10
 - BATT_VOLT_MULT = 16.0
 - BATT_AMP_PERVLT = 83.3
+
+## DAKEFPV H743 Pro Wiring Diagram
+
+### DAKEFPV H743 Pro Wiring Diagram Top
+
+![DAKEFPV H743 Pro Wiring Diagram Top](DAKEFPVH743Pro_WiringDiagramTop.png "DAKEFPV H743 Pro Wiring Diagram Top")
+
+### DAKEFPV H743 Pro Wiring Diagram Bottom
+
+![DAKEFPV H743 Pro Wiring Diagram Bottom](DAKEFPVH743Pro_WiringDiagramBottom.png "DAKEFPV H743 Pro Wiring Diagram Bottom")
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using an unused UART, such as the TX2 pin (UART2 transmit).
+You need to set the following parameters to enable support for FrSky S.PORT:
+
+- [SERIAL2_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial2-protocol-telemetry-2-protocol-selection) 10
+- [SERIAL2_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial2-options-telem2-options) 7
 
 ## RSSI
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743_SLIM/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/DAKEFPVH743_SLIM/README.md
@@ -21,17 +21,6 @@ The DAKEFPV H743 SLIM is a flight controller produced by [DAKEFPV](https://www.d
 ![DAKEFPV H743 SLIM Board Top](DAKEFPVH743_SLIM_Top.jpg "DAKEFPV H743 SLIM Top")
 ![DAKEFPV H743 SLIM Board Bottom](DAKEFPVH743_SLIM_Bottom.jpg "DAKEFPV H743 SLIM Bottom")
 
-## DAKEFPV H743 SLIM Wiring Diagram
-
-### DAKEFPV H743 SLIM Wiring Diagram Top
-
-![DAKEFPV H743 SLIM Wiring Diagram Top](DAKEFPVH743_SLIM_WiringDiagramTop.png "DAKEFPV H743 SLIM Wiring Diagram Top")
-![DAKEFPV H743 SLIM Wiring Diagram Top](DAKEFPVH743_SLIM_WiringDiagramTop2.png "DAKEFPV H743 SLIM Wiring Diagram Top1")
-
-### DAKEFPV H743 SLIM Wiring Diagram Bottom
-
-![DAKEFPV H743 SLIM Wiring Diagram Bottom](DAKEFPVH743_SLIM_WiringDiagramBottom.png "DAKEFPV H743 SLIM Wiring Diagram Bottom")
-
 ## UART Mapping
 
 The UARTs are marked Rxn and Txn in the above pinouts. The Rxn pin is the
@@ -56,14 +45,6 @@ RC input is configured by default via the USART5 RX input. It supports all seria
 - SRXL2 requires a connection to T5 and automatically provides telemetry.  Set [SERIAL5_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial5-options-serial5-options) to "4".
 
 If the user wishes to use the SBUS from a DJI air unit for RC control, it is suggested that the RX8 pad be used as shown in the wiring diagram and [SERIAL8_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial8-protocol-serial8-protocol-selection) be set to "23" and [SERIAL5_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial5-protocol-serial5-protocol-selection) be changed from "23" to something else.
-
-## FrSky Telemetry
-
-FrSky Telemetry is supported using an unused UART, such as the TX2 pin (UART2 transmit).
-You need to set the following parameters to enable support for FrSky S.PORT:
-
-- [SERIAL2_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial2-protocol-telemetry-2-protocol-selection) 10
-- [SERIAL2_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial2-options-telem2-options) 7
 
 ## PWM Output
 
@@ -93,6 +74,25 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN = 10
 - BATT_VOLT_MULT = 16.0
 - BATT_AMP_PERVLT = 83.3
+
+## DAKEFPV H743 SLIM Wiring Diagram
+
+### DAKEFPV H743 SLIM Wiring Diagram Top
+
+![DAKEFPV H743 SLIM Wiring Diagram Top](DAKEFPVH743_SLIM_WiringDiagramTop.png "DAKEFPV H743 SLIM Wiring Diagram Top")
+![DAKEFPV H743 SLIM Wiring Diagram Top](DAKEFPVH743_SLIM_WiringDiagramTop2.png "DAKEFPV H743 SLIM Wiring Diagram Top1")
+
+### DAKEFPV H743 SLIM Wiring Diagram Bottom
+
+![DAKEFPV H743 SLIM Wiring Diagram Bottom](DAKEFPVH743_SLIM_WiringDiagramBottom.png "DAKEFPV H743 SLIM Wiring Diagram Bottom")
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using an unused UART, such as the TX2 pin (UART2 transmit).
+You need to set the following parameters to enable support for FrSky S.PORT:
+
+- [SERIAL2_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial2-protocol-telemetry-2-protocol-selection) 10
+- [SERIAL2_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial2-options-telem2-options) 7
 
 ## RSSI
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/DroneerF405/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/DroneerF405/README.md
@@ -44,20 +44,6 @@ RC input is configured on the R2 (UART2_RX) pin for most RC unidirectional proto
 For Fport, a bi-directional inverter will be required. See the [ArduPilot FPort documentation](https://ardupilot.org/plane/docs/common-connecting-sport-fport.html)
 For CRSF/ELRS/SRXL2 connection of the receiver to T2 will also be required.
 
-## FrSky Telemetry
-
-FrSky Telemetry is supported using the Tx pin of any UART including SERIAL2/UART2. You need to set the following parameters to enable support for FrSky S.PORT (example shows SERIAL3).
-
-- SERIAL3_PROTOCOL 10
-- SERIAL3_OPTIONS 7
-
-## OSD Support
-
-The Droneer F405 supports analog OSD using OSD_TYPE 1 (MAX7456 driver). Simultaneous HD TVX OSD operation can also be obtained using an available UART whose protocol is set to "DisplayPort (42)" and OSD_TYPE2 set to "5".
-
-The JST-GH-4P connector supports a standard DJI HD VTX connection. Pin 1 of the connector is 9v so be careful not to connect
-this to a peripheral requiring 5v.
-
 ## PWM Output
 
 The Droneer F405 supports up to 9 PWM outputs. The pads for motor output
@@ -87,6 +73,20 @@ The default battery parameters are:
 - BATT_CURR_PIN 11
 - BATT_VOLT_MULT 11
 - BATT_AMP_PERVLT 30.2 (will need to be adjusted for whichever current sensor is attached)
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using the Tx pin of any UART including SERIAL2/UART2. You need to set the following parameters to enable support for FrSky S.PORT (example shows SERIAL3).
+
+- SERIAL3_PROTOCOL 10
+- SERIAL3_OPTIONS 7
+
+## OSD Support
+
+The Droneer F405 supports analog OSD using OSD_TYPE 1 (MAX7456 driver). Simultaneous HD TVX OSD operation can also be obtained using an available UART whose protocol is set to "DisplayPort (42)" and OSD_TYPE2 set to "5".
+
+The JST-GH-4P connector supports a standard DJI HD VTX connection. Pin 1 of the connector is 9v so be careful not to connect
+this to a peripheral requiring 5v.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/Durandal/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Durandal/README.md
@@ -45,6 +45,49 @@ The [full schematics](https://github.com/ArduPilot/Schematics/tree/master/Holybr
 The Telem1, Telem2 and Telem3 ports have RTS/CTS pins, the other UARTs do not
 have RTS/CTS.
 
+## RC Input
+
+RC input is configured on the RCIN pin, at one end of the servo rail,
+marked RCIN in the above diagram. This pin supports all RC
+protocols. In addition there is a dedicated Spektrum satellite port
+which supports software power control, allowing for binding of
+Spektrum satellite receivers.
+
+## PWM Output
+
+The Durandal supports up to 16 PWM outputs. First first 8 outputs (labelled
+"MAIN") are controlled by a dedicated STM32F100 IO controller. These 8
+outputs support all PWM output formats, but not DShot.
+
+The remaining 6 outputs (labelled AUX1 to AUX6) are the "auxiliary"
+outputs. These are directly attached to the STM32F427 and support all
+PWM protocols as well as DShot.
+
+All 14 PWM outputs have GND on the top row, 5V on the middle row and
+signal on the bottom row.
+
+The 8 main PWM outputs are in 3 groups:
+
+- PWM 1 and 2 in group1
+- PWM 3 and 4 in group2
+- PWM 5, 6, 7 and 8 in group3
+
+The 8 auxiliary PWM outputs are in 2 groups:
+
+- PWM 1, 2, 3 and 4 in group4
+- PWM 5 and 6 in group5
+- PWM 7 and 8 in group6 (no DMA, no DShot)
+
+Channels within the same group need to use the same output rate. If
+any channel in a group uses DShot then all channels in the group need
+to use DShot.
+
+## Battery Monitoring
+
+The board has two dedicated power monitor ports on 6 pin
+connectors. The correct battery setting parameters are dependent on
+the type of power brick which is connected.
+
 ## Connectors
 
 Unless noted otherwise all connectors are JST GH
@@ -172,49 +215,6 @@ satellite receivers.
 | 2 (blk) | D_minus | +3.3V |
 | 3 (blk) | D_plus | +3.3V |
 | 4 (blk) | GND | GND |
-
-## RC Input
-
-RC input is configured on the RCIN pin, at one end of the servo rail,
-marked RCIN in the above diagram. This pin supports all RC
-protocols. In addition there is a dedicated Spektrum satellite port
-which supports software power control, allowing for binding of
-Spektrum satellite receivers.
-
-## PWM Output
-
-The Durandal supports up to 16 PWM outputs. First first 8 outputs (labelled
-"MAIN") are controlled by a dedicated STM32F100 IO controller. These 8
-outputs support all PWM output formats, but not DShot.
-
-The remaining 6 outputs (labelled AUX1 to AUX6) are the "auxiliary"
-outputs. These are directly attached to the STM32F427 and support all
-PWM protocols as well as DShot.
-
-All 14 PWM outputs have GND on the top row, 5V on the middle row and
-signal on the bottom row.
-
-The 8 main PWM outputs are in 3 groups:
-
-- PWM 1 and 2 in group1
-- PWM 3 and 4 in group2
-- PWM 5, 6, 7 and 8 in group3
-
-The 8 auxiliary PWM outputs are in 2 groups:
-
-- PWM 1, 2, 3 and 4 in group4
-- PWM 5 and 6 in group5
-- PWM 7 and 8 in group6 (no DMA, no DShot)
-
-Channels within the same group need to use the same output rate. If
-any channel in a group uses DShot then all channels in the group need
-to use DShot.
-
-## Battery Monitoring
-
-The board has two dedicated power monitor ports on 6 pin
-connectors. The correct battery setting parameters are dependent on
-the type of power brick which is connected.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/F4BY_F427/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/F4BY_F427/README.md
@@ -4,14 +4,26 @@ The [F4BY flight controller shop](https://f4by.com/en/?order/our_product).
 
 The instructions are available here: [F4BY mcu upgrade instructions](https://f4by.com/en/?doc/fc_f4by_v2.1.5)
 
+## Features
+
+- Full Ardupilot features support (exclude LUA Script)
+
+
+
+
+
+
+
+<!-- TODO: add Pinout content -->
+<!-- TODO: add UART Mapping content -->
+<!-- TODO: add RC Input content -->
+<!-- TODO: add PWM Output content -->
+<!-- TODO: add Battery Monitoring content -->
+
 ## Howto
 
 for self upgrage old fc:
 replace old MCU STM32F407VGT (1MB Flash) with STM32F427VET rev3 or above (2MB Flash)
-
-## Features
-
-- Full Ardupilot features support (exclude LUA Script)
 
 ## Loading Firmware
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/F4BY_H743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/F4BY_H743/README.md
@@ -4,57 +4,16 @@ The F4BY_H743 autopilot is manufactured by [F4BY Team](https://f4by.com)
 
 ![F4BY_H743](F4BY_H743_board_image.jpg)
 
-## Where to Buy
 
-Shop [here](https://f4by.com/en/?order/our_product)
-The instructions, schematic, 3D model  are available [here](https://f4by.com/en/?doc/fc_f4by_v3.0.1_h743)
 
-## Specifications
+<!-- TODO: add Features content -->
 
-- Processor
-  - STM32H743 32-bit processor, 480Mhz
-  - 2MB Flash
-  - 1MB RAM
-- Sensors
-  - ICM-42688-P IMU (F4BY_H743 v3.0.3)
-  - IIM-42652   IMU (F4BY_H743 v3.0.2)
-  - MPU6000     IMU (F4BY_H743 v3.0.1)
-  - MS5611 Barometer
-  - QMC5883P Compass
-- Power
-  - Power from external power module (range +5.0 ... +6.0V)
-  - Anslog current and voltage analog inputs (range 0 ... +6,6V)
-- Interfaces
-  - 16x PWM outputs DShot capable (include 4x BDShot)
-  - 1x RC input
-  - 5x UARTs/serial for GPS, bi-directional RC and other peripherals)
-  - 1x I2C port for external compass, airspeed, etc.
-  - 1x CAN bus
-  - Buzzer output
-  - micro SD Card for logging, Lua scripts etc.
-  - USB type-C port
-  - USB GHS type port for external connector.
-  - DFU bootloader button
+## Pinout
 
-## Analog sensors
+![F4BY_H743 V3.0.3 Board](f4BY_H743_v303_diagramm.jpg "F4BY_H743 V3.0.3")
 
-- Analog airspeed PC0 (0...+3.3v range) pin 10
-- Analog rssi PC1     (0...+3.3v range) pin 11
-- Voltage sensing PC3 (0...+6.6v range) pin 13
-- Current sensing PC2 (0...+6.6v range) pin 12
-- Board power sensing PC4 (0...+6.6v range)
-- Servo power sensing PC5 (0...+9.9v range)
-
-## Analog Airspeed
-
-If the ARSPD pin is used for analog airspeed  input.
-Set [ARSPD_PIN](https://ardupilot.org/copter/docs/parameters.html#arspd-pin-airspeed-pin) to 10.
-Set [ARSPD_TYPE](https://ardupilot.org/copter/docs/parameters.html#arspd-type-airspeed-type) to "1".
-
-## Analog RSSI
-
-If the RSSI pin is used for analog RSSI input. Set [RSSI_ANA_PIN](https://ardupilot.org/copter/docs/parameters.html#rssi-ana-pin-receiver-rssi-sensing-pin) to 11.
-Set [RSSI_TYPE](https://ardupilot.org/copter/docs/parameters.html#rssi-type-rssi-type) to "1" .
+RCIN solder pad location for board version 3.0.3
+![RCIN solder pad location](rcin_303.jpg "RCIN solder pad location ")
 
 ## UART Mapping
 
@@ -118,6 +77,70 @@ Group #4
 
 **Note:** All outputs of a group must be of the same type (PWM or DSHOT).
 
+## Battery Monitoring
+
+The board has a external current and voltage sensor input. The sensors range from 0v to +6.6V.
+
+The default battery parameters are:
+
+- BATT_MONITOR = 4
+- BATT_VOLT_PIN = 13
+- BATT_CURR_PIN = 12
+- BATT_VOLT_MULT = 16.04981
+- BATT_AMP_PERVLT = 100
+
+## Where to Buy
+
+Shop [here](https://f4by.com/en/?order/our_product)
+The instructions, schematic, 3D model  are available [here](https://f4by.com/en/?doc/fc_f4by_v3.0.1_h743)
+
+## Specifications
+
+- Processor
+  - STM32H743 32-bit processor, 480Mhz
+  - 2MB Flash
+  - 1MB RAM
+- Sensors
+  - ICM-42688-P IMU (F4BY_H743 v3.0.3)
+  - IIM-42652   IMU (F4BY_H743 v3.0.2)
+  - MPU6000     IMU (F4BY_H743 v3.0.1)
+  - MS5611 Barometer
+  - QMC5883P Compass
+- Power
+  - Power from external power module (range +5.0 ... +6.0V)
+  - Anslog current and voltage analog inputs (range 0 ... +6,6V)
+- Interfaces
+  - 16x PWM outputs DShot capable (include 4x BDShot)
+  - 1x RC input
+  - 5x UARTs/serial for GPS, bi-directional RC and other peripherals)
+  - 1x I2C port for external compass, airspeed, etc.
+  - 1x CAN bus
+  - Buzzer output
+  - micro SD Card for logging, Lua scripts etc.
+  - USB type-C port
+  - USB GHS type port for external connector.
+  - DFU bootloader button
+
+## Analog sensors
+
+- Analog airspeed PC0 (0...+3.3v range) pin 10
+- Analog rssi PC1     (0...+3.3v range) pin 11
+- Voltage sensing PC3 (0...+6.6v range) pin 13
+- Current sensing PC2 (0...+6.6v range) pin 12
+- Board power sensing PC4 (0...+6.6v range)
+- Servo power sensing PC5 (0...+9.9v range)
+
+## Analog Airspeed
+
+If the ARSPD pin is used for analog airspeed  input.
+Set [ARSPD_PIN](https://ardupilot.org/copter/docs/parameters.html#arspd-pin-airspeed-pin) to 10.
+Set [ARSPD_TYPE](https://ardupilot.org/copter/docs/parameters.html#arspd-type-airspeed-type) to "1".
+
+## Analog RSSI
+
+If the RSSI pin is used for analog RSSI input. Set [RSSI_ANA_PIN](https://ardupilot.org/copter/docs/parameters.html#rssi-ana-pin-receiver-rssi-sensing-pin) to 11.
+Set [RSSI_TYPE](https://ardupilot.org/copter/docs/parameters.html#rssi-type-rssi-type) to "1" .
+
 ## GPIOs
 
 -D1 pin 1
@@ -133,25 +156,6 @@ Group #4
 - Size: 50 x 50 mm
 - Mounting holes: 45 x 45 mm (M3)
 - Weight: 15.5 g
-
-## Pinout
-
-![F4BY_H743 V3.0.3 Board](f4BY_H743_v303_diagramm.jpg "F4BY_H743 V3.0.3")
-
-RCIN solder pad location for board version 3.0.3
-![RCIN solder pad location](rcin_303.jpg "RCIN solder pad location ")
-
-## Battery Monitoring
-
-The board has a external current and voltage sensor input. The sensors range from 0v to +6.6V.
-
-The default battery parameters are:
-
-- BATT_MONITOR = 4
-- BATT_VOLT_PIN = 13
-- BATT_CURR_PIN = 12
-- BATT_VOLT_MULT = 16.04981
-- BATT_AMP_PERVLT = 100
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/FlysparkF4/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/FlysparkF4/README.md
@@ -22,36 +22,9 @@ The **FlySpark F4** flight controller is sold by [FlySpark](https://flyspark.in/
 - 3 S - 6 S LiPo input voltage range
 - 30.5 x 30.5 mm mounting pattern (⌀4 mm holes)
 
-## Mechanical
 
-- 41.6mm x 39.4mm x 7.8mm
-- 10.5g
-- Mounting: 30.5mmx30.5mm (4 mm holes)
 
-## Wiring / Pinout
-
-![FlySparkF4 Pinout1](flyspark_f4_connections.png "Pinout1")
-![FlySparkF4 Pinout2](flyspark_f4_connections_1.png "Pinout2")
-
-| Function | MCU / Pin | Notes |
-|---|---|---|
-| ESC / motor outputs | M1-M8 | M1-M4 bottom, M5-M8 front side |
-| UART1 | TX1 / RX1 | DisplayPort |
-| UART2 | TX2 / RX2 | For RC. SBUS pins are inverted and connected directly to to RX2. |
-| UART3 | TX3 / RX3 | Spare |
-| UART4 | TX4 / RX4 | Bluetooth, NOT supported by ArduPilot |
-| UART5 | TX5 / RX5 | ESC telemetry |
-| UART6 | TX6 / RX6 | GPS |
-| I2C | SDA / SCL pads | Magnetometer, Rangefinder, etc. |
-| SPI | SPI pins | IMU |
-| ADC / analog | Current sensor input |
-| Buzzer | BZ+ / BZ− | 5 V buzzer support |
-| RSSI | RS pad | RSSI voltage input |
-| Boot button | BOOT | Forces DFU mode |
-| SD  | SD card slot | |
-| OSD | Via VTX,CAM,CC pins | |
-
----
+<!-- TODO: add Pinout content -->
 
 ## UART Mapping
 
@@ -105,6 +78,37 @@ Default configuration:
 - BATT_AMP_PERVLT = 25.0
 
 Supports direct 3 S-6 S LiPo voltage measurement.
+
+---
+
+## Mechanical
+
+- 41.6mm x 39.4mm x 7.8mm
+- 10.5g
+- Mounting: 30.5mmx30.5mm (4 mm holes)
+
+## Wiring / Pinout
+
+![FlySparkF4 Pinout1](flyspark_f4_connections.png "Pinout1")
+![FlySparkF4 Pinout2](flyspark_f4_connections_1.png "Pinout2")
+
+| Function | MCU / Pin | Notes |
+|---|---|---|
+| ESC / motor outputs | M1-M8 | M1-M4 bottom, M5-M8 front side |
+| UART1 | TX1 / RX1 | DisplayPort |
+| UART2 | TX2 / RX2 | For RC. SBUS pins are inverted and connected directly to to RX2. |
+| UART3 | TX3 / RX3 | Spare |
+| UART4 | TX4 / RX4 | Bluetooth, NOT supported by ArduPilot |
+| UART5 | TX5 / RX5 | ESC telemetry |
+| UART6 | TX6 / RX6 | GPS |
+| I2C | SDA / SCL pads | Magnetometer, Rangefinder, etc. |
+| SPI | SPI pins | IMU |
+| ADC / analog | Current sensor input |
+| Buzzer | BZ+ / BZ− | 5 V buzzer support |
+| RSSI | RS pad | RSSI voltage input |
+| Boot button | BOOT | Forces DFU mode |
+| SD  | SD card slot | |
+| OSD | Via VTX,CAM,CC pins | |
 
 ---
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/FlywooF405HD-AIOv2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/FlywooF405HD-AIOv2/README.md
@@ -52,10 +52,6 @@ USART1 and USART3 supports RX and TX DMA. UART4 supports TX DMA. USART2 supports
 
 RC input is configured  as ELRS by default using UART1. Alternatively, UART3 could be used for RC inputs other than ELRS but its protocol would need to be changed to 23 and UART1 disabled by setting its protocol as -1. This board does not support PPM.
 
-## OSD Support
-
-The GOKU F405 HD AIO v2 supports OSD using OSD_TYPE 5 (MSP DisplayPort).
-
 ## PWM Output
 
 The GOKU F405 AIO supports up to 5 PWM outputs. The pads for motor output ESC1 to ESC4 on the above diagram are the first 4 outputs. All 5 outputs support DShot.
@@ -89,6 +85,10 @@ The correct battery setting parameters are:
 - BATT_AMP_PERVLT around 60.2
 
 These are set by default in the firmware and shouldn't need to be adjusted
+
+## OSD Support
+
+The GOKU F405 HD AIO v2 supports OSD using OSD_TYPE 5 (MSP DisplayPort).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/FlywooF405Pro/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/FlywooF405Pro/README.md
@@ -42,10 +42,6 @@ USART3 and USART6 supports RX and TX DMA. UART4 supports TX DMA. UART1, UART2 an
 
 RC input is configured on UART3, UART4 or UART6 which support serial RC protocols. SBUS *must* be used on UART4 which has hardware inversion, UART5 also has hardware inversion but no DMA so use for SBUS is not recommended.
 
-## OSD Support
-
-The GOKU F405 Pro supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The GOKU F405 Pro supports up to 9 PWM outputs. The pads for motor output ESC1 to ESC4 on the above diagram are the first 4 outputs.All 9 outputs support DShot.
@@ -76,6 +72,10 @@ The correct battery setting parameters are:
 - BATT_CURR_MULT around 59
 
 These are set by default in the firmware and shouldn't need to be adjusted
+
+## OSD Support
+
+The GOKU F405 Pro supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/FlywooF405S-AIO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/FlywooF405S-AIO/README.md
@@ -51,10 +51,6 @@ USART1 and USART3 supports RX and TX DMA. UART4 supports TX DMA. USART2 supports
 
 RC input is configured on UART1 or UART3, which supports serial RC protocols. This board does not support PPM.
 
-## OSD Support
-
-The GOKU F405 AIO supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The GOKU F405 AIO supports up to 5 PWM outputs. The pads for motor output ESC1 to ESC4 on the above diagram are the first 4 outputs.All 5 outputs support DShot.
@@ -83,6 +79,10 @@ The correct battery setting parameters are:
 - BATT_CURR_MULT around 60.2
 
 These are set by default in the firmware and shouldn't need to be adjusted
+
+## OSD Support
+
+The GOKU F405 AIO supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/FlywooF745/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/FlywooF745/README.md
@@ -66,10 +66,6 @@ UART3 supports RX and TX DMA. UART1, UART2, UART4, and UART6 supports TX DMA. UA
 In versions 1.0 and 1.2, RC input is usually configured on the UART3, which supports serial RC protocols. This board does not support PPM.
 In version 3, the connector intended for RC input is on the UART2, so the default protocol will need to be changed for SERIAL 2 to "23" and SERIAL 33 protocol changed to something else.
 
-## OSD Support
-
-The GOKU GN 745 AIO supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The GOKU GN 745 AIO supports up to 8 PWM outputs. The pads for motor output ESC1 to ESC4 on the above diagram are the first 4 outputs, there are four additional pads for PWM 5-8. All 8 outputs support DShot as well as all PWM types.
@@ -114,6 +110,10 @@ for version 3.0:
 
 - BATT_AMP_PERVLT around 14.0
 - BATT_AMP_OFFSET around 0.0055
+
+## OSD Support
+
+The GOKU GN 745 AIO supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Sensor Orientation
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/FlywooH743Pro/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/FlywooH743Pro/README.md
@@ -44,18 +44,6 @@ Note: If the receiver is FPort the receiver must be tied to the USART2 TX pin , 
 and SERIAL2_OPTIONS must be set to 7 (invert TX/RX, half duplex). For full duplex like CRSF/ELRS use both
 RX1 and TX1 and set RSSI_TYPE also to 3.
 
-## FrSky Telemetry
-
-FrSky Telemetry is supported using an unused UART, such as the T3 pin (UART3 transmit).
-You need to set the following parameters to enable support for FrSky S.PORT:
-
-- SERIAL3_PROTOCOL 10
-- SERIAL3_OPTIONS 7
-
-## OSD Support
-
-The Flywoo H743 Pro supports OSD using OSD_TYPE 1 (MAX7456 driver) and simultaneously DisplayPort using TX8/RX8 on the HD VTX connector.
-
 ## PWM Output
 
 The Flywoo H743 Pro supports up to 13 PWM or DShot outputs. The pads for motor output
@@ -87,6 +75,18 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN 13
 - BATT_VOLT_MULT 11.1
 - BATT_AMP_PERVLT 40
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using an unused UART, such as the T3 pin (UART3 transmit).
+You need to set the following parameters to enable support for FrSky S.PORT:
+
+- SERIAL3_PROTOCOL 10
+- SERIAL3_OPTIONS 7
+
+## OSD Support
+
+The Flywoo H743 Pro supports OSD using OSD_TYPE 1 (MAX7456 driver) and simultaneously DisplayPort using TX8/RX8 on the HD VTX connector.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/FoxeerF405v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/FoxeerF405v2/README.md
@@ -40,10 +40,6 @@ protocols. Half-duplex serial protocols should be configured on T2 (UART2_TX). R
 supported on UART6_RX within the DJI connector, although because it is not inverted it cannot be
 used for SBUS.
 
-## OSD Support
-
-The FoxeerF405v2 supports OSD using OSD_TYPE 1 (MAX7456 driver) or OSD_TYPE 3 if using DJI OSD
-
 ## PWM Output
 
 The FoxeerF405v2 supports up to 9 PWM outputs. The pads for motor output
@@ -76,6 +72,10 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN 11
 - BATT_VOLT_MULT 11
 - BATT_AMP_PERVLT 142.9
+
+## OSD Support
+
+The FoxeerF405v2 supports OSD using OSD_TYPE 1 (MAX7456 driver) or OSD_TYPE 3 if using DJI OSD
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/FoxeerH743v1/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/FoxeerH743v1/README.md
@@ -42,17 +42,6 @@ protocols. For protocols requiring separate half-duplex serial to transmit
 telemetry (such as FPort) you should setup SERIAL1 as an RC input serial port,
 with half-duplex, pin-swap and inversion enabled. You can also use the soldered pads on UART1 by setting SERIAL4_PROTOCOL to -1 and SERIAL1_PROTOCOL to 23. For PPM support on UART1_RX set BRD_ALT_CONFIG to 1.
 
-## FrSky Telemetry
-
-FrSky Telemetry can be supported using the T1 pin (UART1 transmit). You need to set the following parameters to enable support for FrSky S.PORT
-
-- SERIAL1_PROTOCOL 10
-- SERIAL1_OPTIONS 7
-
-## OSD Support
-
-The FoxeerH743 supports OSD using OSD_TYPE 1 (MAX7456 driver) or OSD_TYPE 3 if using DJI OSD
-
 ## PWM Output
 
 The FoxeerH743 supports up to 9 PWM outputs. The pads for motor output
@@ -83,6 +72,17 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN 12
 - BATT_VOLT_MULT 11
 - BATT_AMP_PERVLT 35.4
+
+## FrSky Telemetry
+
+FrSky Telemetry can be supported using the T1 pin (UART1 transmit). You need to set the following parameters to enable support for FrSky S.PORT
+
+- SERIAL1_PROTOCOL 10
+- SERIAL1_OPTIONS 7
+
+## OSD Support
+
+The FoxeerH743 supports OSD using OSD_TYPE 1 (MAX7456 driver) or OSD_TYPE 3 if using DJI OSD
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/GEPRCF745BTHD/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/GEPRCF745BTHD/README.md
@@ -38,21 +38,6 @@ RC input is configured by default via the USAR2 RX input. It supports all unidir
 Note:
 If the receiver is FPort or a full duplex protocol, then the receiver must be tied to the USART2 TX pin and [SERIAL2_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial2-options) = 7 (invert TX/RX, half duplex), and [RSSI_TYPE](https://ardupilot.org/copter/docs/parameters.html#rssi-type) =3.
 
-## FrSky Telemetry
-
-FrSky Telemetry is supported using the Tx pin of any UART including SERIAL2/UART2. You need to set the following parameters to enable support for FrSky S.PORT (example shows SERIAL3).
-
-- SERIAL3_PROTOCOL 10
-- SERIAL3_OPTIONS 7
-
-## OSD Support
-
-The TAKER F745 BT supports analog OSD using its internal OSD chip and simultaneously HD goggle DisplayPort OSDs via the HD VTX connector.
-
-## VTX Support
-
-The SH1.0-6P connector supports a standard DJI HD VTX connection. Pin 1 of the connector is 12v (or VBAT by solder pad selection) so be careful not to connect to devices expecting 5v.
-
 ## PWM Output
 
 The TAKER F745 BT supports up to 9 PWM outputs. The pads for motor output
@@ -82,6 +67,21 @@ The default battery parameters are:
 - BATT_VOLT_SCALE 11.0
 - BATT_CURR_PIN 12
 - BATT_AMP_PERVLT 28.5
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using the Tx pin of any UART including SERIAL2/UART2. You need to set the following parameters to enable support for FrSky S.PORT (example shows SERIAL3).
+
+- SERIAL3_PROTOCOL 10
+- SERIAL3_OPTIONS 7
+
+## OSD Support
+
+The TAKER F745 BT supports analog OSD using its internal OSD chip and simultaneously HD goggle DisplayPort OSDs via the HD VTX connector.
+
+## VTX Support
+
+The SH1.0-6P connector supports a standard DJI HD VTX connection. Pin 1 of the connector is 12v (or VBAT by solder pad selection) so be careful not to connect to devices expecting 5v.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/GEPRC_TAKER_H743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/GEPRC_TAKER_H743/README.md
@@ -38,21 +38,6 @@ RC input is configured by default via the USAR2 RX input. It supports all unidir
 Note:
 If the receiver is FPort or a full duplex protocol, then the receiver must be tied to the USART2 TX pin and [SERIAL2_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial2-options) = 7 (invert TX/RX, half duplex), and [RSSI_TYPE](https://ardupilot.org/copter/docs/parameters.html#rssi-type) =3.
 
-## FrSky Telemetry
-
-FrSky Telemetry is supported using the Tx pin of any UART excluding SERIAL3UART3. To enable support for FrSky S.PORT (the example shows SERIAL6), you need to set the following parameters.
-
-- SERIAL6_PROTOCOL 10
-- SERIAL6_OPTIONS 7
-
-## OSD Support
-
-The TAKER H743 BT supports analog OSD using its internal OSD chip and simultaneously HD goggle DisplayPort OSDs via the HD VTX connector.
-
-## VTX Support
-
-The SH1.0-6P connector supports a standard DJI HD VTX connection. Pin 1 of the connector is 12v (or VBAT by solder pad selection) so be careful not to connect to devices expecting 5v.
-
 ## PWM Output
 
 The TAKER H743 BT supports up to 9 PWM/DShot outputs. The pads for motor output
@@ -82,6 +67,21 @@ The default battery parameters are:
 - BATT_VOLT_SCALE 11.1
 - BATT_CURR_PIN 12
 - BATT_AMP_PERVLT 28.5
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using the Tx pin of any UART excluding SERIAL3UART3. To enable support for FrSky S.PORT (the example shows SERIAL6), you need to set the following parameters.
+
+- SERIAL6_PROTOCOL 10
+- SERIAL6_OPTIONS 7
+
+## OSD Support
+
+The TAKER H743 BT supports analog OSD using its internal OSD chip and simultaneously HD goggle DisplayPort OSDs via the HD VTX connector.
+
+## VTX Support
+
+The SH1.0-6P connector supports a standard DJI HD VTX connection. Pin 1 of the connector is 12v (or VBAT by solder pad selection) so be careful not to connect to devices expecting 5v.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/GreenSightUltraBlue/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/GreenSightUltraBlue/README.md
@@ -12,11 +12,9 @@ The UltraBlue flight controller is sold by [GreenSight](https://greensightag.com
 - microSD card slot
 - DF9-41S-1V(32) Hirose Mezzanine Connector
 
-## Connector Overview
 
-![UltraBlue Board Connector Overview - Top View](UltraBlue_connector_overview_top.png)
 
-![UltraBlue Board Connector Overview - Bottom View](UltraBlue_connector_overview_bottom.png)
+<!-- TODO: add Pinout content -->
 
 ## UART Mapping
 
@@ -29,6 +27,47 @@ The UltraBlue flight controller is sold by [GreenSight](https://greensightag.com
 - SERIAL6 -> USART3 (ESC telemetry)
 - SERIAL7 -> UART7 (USER/[debug tx/rx], no DMA)
 - SERIAL8 -> USB2
+
+## RC Input
+
+The RCIN pin, which is physically mapped to UART8 and configured by default as SERIAL5, can be used for most ArduPilot supported unidirectional receiver protocols. For this reason SERIAL5_PROTOCOL defaults to “23” (RCIN).
+
+- PPM: Connect to the JP1 connector. PPM input is only supported on JP1 as it requires a special interrupt.
+- SBUS: Connect to the JP1 connector.
+- Spektrum/DSM radios: Connect to the JP4 connector.
+
+Bi-directional protocols such as CRSF/ELRS and SRXL2 require a full UART connection. FPort, when connected to RCIN, will only provide RC without telemetry.
+
+To allow CRSF and embedded telemetry available in Fport, CRSF, and SRXL2 receivers, a full UART, such as SERIAL2 (telem2) or SERIAL4 (GPS2) would need to be used for receiver connections. Below are setups using Serial2.
+
+- SERIAL2_PROTOCOL should be set to "23".
+- FPort would require SERIAL2_OPTIONS be set to "15"
+- CRSF would require SERIAL2_OPTIONS be set to "0"
+- SRXL2 would require SERIAL2_OPTIONS be set to "4" and connects only the TX pin.
+
+## PWM Output
+
+The UltraBlue flight controller supports up to 16 PWM outputs.
+
+The 16 PWM outputs are in 5 groups:
+
+- PWM 1 - 4 are in group1 (TIM5)
+- PWM 5 - 8 are in group2 (TIM4)
+- PWM 9 - 12 are in group3 (TIM1)
+- PWM 13 and 14 are in group4 (TIM12) (no DMA, no DShot)
+- PWM 15 and 16 are in group5 (TIM8)
+
+Channels within the same group need to use the same output rate and protocol. Outputs 1 - 8 support bi-directional DShot.
+
+## Battery Monitoring
+
+The J1 - Mezzanine Connector has inputs for battery voltage and current. It also has an I2C bus connection, Bus 1 (I2C3), intended for use with SMBus batteries and BMSs. The BATT_I2C_BUS parameter should be set to 1.
+
+## Connector Overview
+
+![UltraBlue Board Connector Overview - Top View](UltraBlue_connector_overview_top.png)
+
+![UltraBlue Board Connector Overview - Bottom View](UltraBlue_connector_overview_bottom.png)
 
 ## Connectors
 
@@ -279,37 +318,6 @@ External Pin Information:
 | 38 | Serial LED Controller Output, AP FMU CAP1 Port (3.3v) |
 | 40 | One Wire Bus to Jetson (3.3v PU) |
 
-## RC Input
-
-The RCIN pin, which is physically mapped to UART8 and configured by default as SERIAL5, can be used for most ArduPilot supported unidirectional receiver protocols. For this reason SERIAL5_PROTOCOL defaults to “23” (RCIN).
-
-- PPM: Connect to the JP1 connector. PPM input is only supported on JP1 as it requires a special interrupt.
-- SBUS: Connect to the JP1 connector.
-- Spektrum/DSM radios: Connect to the JP4 connector.
-
-Bi-directional protocols such as CRSF/ELRS and SRXL2 require a full UART connection. FPort, when connected to RCIN, will only provide RC without telemetry.
-
-To allow CRSF and embedded telemetry available in Fport, CRSF, and SRXL2 receivers, a full UART, such as SERIAL2 (telem2) or SERIAL4 (GPS2) would need to be used for receiver connections. Below are setups using Serial2.
-
-- SERIAL2_PROTOCOL should be set to "23".
-- FPort would require SERIAL2_OPTIONS be set to "15"
-- CRSF would require SERIAL2_OPTIONS be set to "0"
-- SRXL2 would require SERIAL2_OPTIONS be set to "4" and connects only the TX pin.
-
-## PWM Output
-
-The UltraBlue flight controller supports up to 16 PWM outputs.
-
-The 16 PWM outputs are in 5 groups:
-
-- PWM 1 - 4 are in group1 (TIM5)
-- PWM 5 - 8 are in group2 (TIM4)
-- PWM 9 - 12 are in group3 (TIM1)
-- PWM 13 and 14 are in group4 (TIM12) (no DMA, no DShot)
-- PWM 15 and 16 are in group5 (TIM8)
-
-Channels within the same group need to use the same output rate and protocol. Outputs 1 - 8 support bi-directional DShot.
-
 ## GPIOs
 
 All PWM outputs can be used as GPIO (relays, buttons, RPM, etc.). To use them you need to set the output's SERVOx_FUNCTION to -1. See GPIOs page for more information.
@@ -334,10 +342,6 @@ The numbering of the GPIOs for PIN parameters in ArduPilot is:
 ## Firmware
 
 The board comes pre-installed with an ArduPilot compatible bootloader, allowing the loading of *.apj firmware files with any ArduPilot compatible ground station.
-
-## Battery Monitoring
-
-The J1 - Mezzanine Connector has inputs for battery voltage and current. It also has an I2C bus connection, Bus 1 (I2C3), intended for use with SMBus batteries and BMSs. The BATT_I2C_BUS parameter should be set to 1.
 
 ## Camera Control
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/HEEWING-F405/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/HEEWING-F405/README.md
@@ -18,6 +18,10 @@ The HEEWING F405 is a flight controller produced by [HEEWING](https://www.heewin
 
 ![HEEWING F405 Board](heewingf405.jpg "HEEWING F405")
 
+
+
+<!-- TODO: add Pinout content -->
+
 ## UART Mapping
 
 The UARTs are marked Rn and Tn in the above pinouts. The Rn pin is the
@@ -33,14 +37,6 @@ receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
 ## RC Input
 
 RC input is configured on the RCIN connector (UART2_RX) pin. It supports all serial RC protocols. It can be configured for two-way protocols (e.g. CRSF) by setting BRD_ALT_CONFIG=1
-
-## FrSky Telemetry
-
-FrSky Telemetry can be supported using the transmit pin on a spare serial ports SERIAL1 and SERIAL2.
-
-## OSD Support
-
-The HEEWING F405 supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## PWM Output
 
@@ -70,6 +66,14 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN 11
 - BATT_VOLT_MULT 7.71
 - BATT_AMP_PERVLT 26.67
+
+## FrSky Telemetry
+
+FrSky Telemetry can be supported using the transmit pin on a spare serial ports SERIAL1 and SERIAL2.
+
+## OSD Support
+
+The HEEWING F405 supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/HEEWING-F405v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/HEEWING-F405v2/README.md
@@ -18,6 +18,10 @@ The HEEWING F405 is a flight controller produced by [HEEWING](https://www.heewin
 
 ![HEEWING F405 Board](heewingf405.jpg "HEEWING F405")
 
+
+
+<!-- TODO: add Pinout content -->
+
 ## UART Mapping
 
 The UARTs are marked Rn and Tn in the above pinouts. The Rn pin is the
@@ -32,14 +36,6 @@ receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
 ## RC Input
 
 RC input is configured on the RCIN connector (UART2_RX) pin. It supports all serial RC protocols. It can be configured for two-way protocols (e.g. CRSF) by setting BRD_ALT_CONFIG=1
-
-## FrSky Telemetry
-
-FrSky Telemetry can be supported using the transmit pin on a spare serial ports SERIAL1 and SERIAL2.
-
-## OSD Support
-
-The HEEWING F405 supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## PWM Output
 
@@ -69,6 +65,14 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN 11
 - BATT_VOLT_MULT 7.71
 - BATT_AMP_PERVLT 26.67
+
+## FrSky Telemetry
+
+FrSky Telemetry can be supported using the transmit pin on a spare serial ports SERIAL1 and SERIAL2.
+
+## OSD Support
+
+The HEEWING F405 supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/HWH7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/HWH7/README.md
@@ -14,9 +14,9 @@ The **HWH7** is a flight controller designed and produced by HW.
 - Power (board hardware): 4S–8S LiPo input (12–35.6 V), on-board 5V/3A and 12V/3A BECs.
 - Other hardware (board option): 512Mb blackbox flash.
 
-## Pinout / Connectors
 
-![image](HWH7.png)
+
+<!-- TODO: add Pinout content -->
 
 ## UART Mapping
 
@@ -33,6 +33,10 @@ Serial ordering (ArduPilot): `SERIAL0..SERIAL8` = `OTG1, USART1, USART2, USART3,
 | UART6 | SERIAL6 | USART6 | PC6 | PC7 | User |
 | UART7 | SERIAL7 | UART7 | PE8 | PE7 | User |
 | UART8 | SERIAL8 | UART8 | PE1 | PE0 | ESC Telemetry |
+
+
+
+<!-- TODO: add RC Input content -->
 
 ## PWM Output
 
@@ -62,6 +66,14 @@ The HWH7 supports up to 12 PWM or DShot outputs. These outputs are organized int
 - **Rate and Protocol Consistency:** All channels within the same group **must** use the same output rate and protocol. If any channel in a group is configured for DShot, all other channels in that group must also be configured for DShot.
 - **Bi-directional DShot:** Support is available for **PWM 1 through 8** (Groups 1 and 2).
 - **Timer Grouping Warning:** Be cautious when mixing different types of servos, ESCs, or other timer-based outputs. For example, if PWM 9 is used for a standard servo and PWM 10 is used for a NeoPixel LED, they will conflict because they share **Group 3 (TIM15)**. In typical setups, PE5 and PE6 are used together as servo outputs by default.
+
+
+
+<!-- TODO: add Battery Monitoring content -->
+
+## Pinout / Connectors
+
+![image](HWH7.png)
 
 ## Battery Monitor (ADC)
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/Here4FC/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Here4FC/README.md
@@ -14,6 +14,18 @@ Here4 Module is sold as a GPS module, but it can be used as a flight controller.
 - 1x RCIN
 - 1x UBLOX NEO-F9P L1L5 GNSS
 
+
+
+
+
+
+
+<!-- TODO: add Pinout content -->
+<!-- TODO: add UART Mapping content -->
+<!-- TODO: add RC Input content -->
+<!-- TODO: add PWM Output content -->
+<!-- TODO: add Battery Monitoring content -->
+
 ## How to use
 
 - To load the FC firmware on production Here4. User needs to first update Here4 through DroneCAN tool or Mission Planners DroneCAN config using FC firmware, which is .bin format.

--- a/libraries/AP_HAL_ChibiOS/hwdef/IFLIGHT_2RAW_H7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/IFLIGHT_2RAW_H7/README.md
@@ -38,17 +38,6 @@ protocols. For protocols requiring half-duplex serial to transmit
 telemetry (such as FPort) you should setup SERIAL3 as an RC input serial port,
 with half-duplex, pin-swap and inversion enabled.
 
-## FrSky Telemetry
-
-FrSky Telemetry is supported using the T3 pin (UART3 transmit). You need to set the following parameters to enable support for FrSky S.PORT
-
-- SERIAL3_PROTOCOL 10
-- SERIAL3_OPTIONS 7
-
-## OSD Support
-
-The iFlight 2RAW H743 supports MSP DisplayPort OSD using OSD_TYPE 5
-
 ## PWM Output
 
 The iFlight 2RAW H743 supports up to 9 PWM outputs. The pads for motor output
@@ -79,6 +68,17 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN 13
 - BATT_VOLT_MULT 11.1
 - BATT_AMP_PERVLT 64
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using the T3 pin (UART3 transmit). You need to set the following parameters to enable support for FrSky S.PORT
+
+- SERIAL3_PROTOCOL 10
+- SERIAL3_OPTIONS 7
+
+## OSD Support
+
+The iFlight 2RAW H743 supports MSP DisplayPort OSD using OSD_TYPE 5
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/JFB100/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/JFB100/README.md
@@ -17,6 +17,10 @@ The JFB-100 flight controller is sold by [JAE](https://www.jae.com/files/user/mo
 - voltage monitoring for servo rail and Vcc
 - two dedicated power input ports for external power bricks
 
+
+
+<!-- TODO: add Pinout content -->
+
 ## UART Mapping
 
 - SERIAL0 -> USB

--- a/libraries/AP_HAL_ChibiOS/hwdef/JFB110/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/JFB110/README.md
@@ -17,6 +17,10 @@ The JFB-110 flight controller is sold by [JAE](https://www.jae.com/Motion_Sensor
 - voltage monitoring for servo rail and Vcc
 - two dedicated power input ports for external power bricks
 
+
+
+<!-- TODO: add Pinout content -->
+
 ## UART Mapping
 
 - SERIAL0 -> USB

--- a/libraries/AP_HAL_ChibiOS/hwdef/JHEMCU-H743HD/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/JHEMCU-H743HD/README.md
@@ -40,10 +40,6 @@ In addition to pinouts, the board also has SH6P 1mm connector for DJI FPV and SH
 
 RC input is configured on the RX2/TX2 (USART2_RX/USART2_TX) pins. It supports ELRS(CSRF), TBS(CSRF), SBUS, IBUS, DSM2, and DSMX.
 
-## OSD Support
-
-JHEMCU H743 supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 JHEMCU H743 supports up to 9 PWM outputs. 8 motors and 1 LED strip or another PWM output.
@@ -62,6 +58,10 @@ Channels within the same group need to use the same output rate. If any channel 
 The board has a built-in voltage and current sensor. The current
 sensor's max Amps is not specified. The voltage sensor can handle up to 6S
 LiPo batteries.
+
+## OSD Support
+
+JHEMCU H743 supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/JHEMCUF405PRO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/JHEMCUF405PRO/README.md
@@ -53,13 +53,6 @@ RC input is best configured on the RX1/TX1 (USART1_RX/USART1_TX) pins due to hav
 
 Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM. See [Radio Control Systems](https://ardupilot.org/copter/docs/common-rc-systems.html) for details.
 
-## OSD Support
-
-JHEMCUF405PRO supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
-- Use of internal MAX7456 for analog OSD/VTX is enabled by default.
-- Simultaneous HD VTX OSD support is pre-configured on UART6
-
 ## PWM Output
 
 JHEMCUF405PRO supports up to 5 motor/servo outputs. 4 motors and 1 LED strip or another PWM output. Outputs are grouped and each group must use the same protocol. All outputs support PWM and DShot.
@@ -77,6 +70,13 @@ The default battery configuration is:
 - BATT_CURR_PIN = 12
 - BATT_VOLT_MULT = 11
 - BATT_AMP_PERVLT = 95.84
+
+## OSD Support
+
+JHEMCUF405PRO supports OSD using OSD_TYPE 1 (MAX7456 driver).
+
+- Use of internal MAX7456 for analog OSD/VTX is enabled by default.
+- Simultaneous HD VTX OSD support is pre-configured on UART6
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/JPilot-C/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/JPilot-C/README.md
@@ -119,9 +119,9 @@ Port      UART      Protocol        TX DMA  RX DMA
 5         UART8     None            ✔       ✔
 6         UART4     None            ✔       ✔
 
-## CAN Ports
+## RC Input
 
-There are 2 CAN buses available, each with a 120 Ohm termination resistor built-in.
+Any of the serial ports can be used for a bidirectional RC connection. Change its `SERIALx_PROTOCOL` to "23" and follow the instructions in [RC systems](https://ardupilot.org/copter/docs/common-rc-systems.html) to other setup info for the RC system being used.
 
 ## PWM Output
 
@@ -137,10 +137,6 @@ The PWM outputs are in 5 groups:
 
 Channels within the same group need to use the same output rate. If any channel in a group uses D-Shot then all channels in the group need to use D-Shot.
 
-## RC Input
-
-Any of the serial ports can be used for a bidirectional RC connection. Change its `SERIALx_PROTOCOL` to "23" and follow the instructions in [RC systems](https://ardupilot.org/copter/docs/common-rc-systems.html) to other setup info for the RC system being used.
-
 ## Battery Monitoring
 
 The board has internal voltage sensors and connection for external current sensors, able to monitor two batteries.
@@ -155,6 +151,10 @@ The default battery parameters are:
 - BATT2_CURR_PIN 7
 - BATT2_VOLT_MULT 11
 - BATT2_AMP_PERVLT 40
+
+## CAN Ports
+
+There are 2 CAN buses available, each with a 120 Ohm termination resistor built-in.
 
 ## Analog pins
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/KT-FMU-F1/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KT-FMU-F1/README.md
@@ -19,19 +19,6 @@ The KT-FMU-F1 is a flight controller manufactured by [Coolfly](https://www.cecoo
   - 1x CAN
   - 1x USB
 
-## UART Mapping
-
-| Serial | Port  | Protocol    | Notes       |
-| ------ | ----- | ----------- | ----------- |
-| 0      | USB   | MAVLink2    |             |
-| 1      | UART1 | MAVLink2    | DMA-enabled |
-| 2      | UART2 | DisplayPort | DMA-enabled |
-| 3      | UART3 | GPS         | DMA-enabled |
-| 4      | UART4 | MAVLink2    | DMA-enabled |
-| 6      | UART6 | RCIN        | DMA-enabled |
-| 7      | UART7 | ESC Telem   | RX only     |
-| 8      | UART8 | None        |             |
-
 ## Pinout
 
 There are a lot of interfaces on the board:
@@ -180,16 +167,18 @@ Pin definition:
 | 9          | Buzzer        |
 | 10         | GND           |
 
-## PWM Output
+## UART Mapping
 
-KT-FMU-F1 supports up to 10 PWM outputs.
-The PWM channels are divided into 3 groups:
-
-| PWM Channel | Group |
-| ----------- | ----- |
-| 1 - 4       | TIM1  |
-| 5 - 6       | TIM3  |
-| 7 - 10      | TIM4  |
+| Serial | Port  | Protocol    | Notes       |
+| ------ | ----- | ----------- | ----------- |
+| 0      | USB   | MAVLink2    |             |
+| 1      | UART1 | MAVLink2    | DMA-enabled |
+| 2      | UART2 | DisplayPort | DMA-enabled |
+| 3      | UART3 | GPS         | DMA-enabled |
+| 4      | UART4 | MAVLink2    | DMA-enabled |
+| 6      | UART6 | RCIN        | DMA-enabled |
+| 7      | UART7 | ESC Telem   | RX only     |
+| 8      | UART8 | None        |             |
 
 ## RC Input
 
@@ -200,14 +189,16 @@ telemetry (such as FPort) you should set SERIAL6_OPTIONS to 4 (HalfDuplex).
 Additionally, there's also a connector `RCOUT` outputing the RC signal from `RCIN`,
 allowing another module to receive it.
 
-## OSD Support
+## PWM Output
 
-Onboard OSD (using MAX7456 driver) is supported by default.
-DisplayPort OSD is also simultaneously available on any of the UART connectors (default is UART2).
+KT-FMU-F1 supports up to 10 PWM outputs.
+The PWM channels are divided into 3 groups:
 
-## Compass
-
-The KT-FMU-F1 has a built-in compass on the IMU submodule. Due to potential interference,  this compass is disabled, and the autopilot is usually used with an external I2C compass as part of a GPS/Compass combination.  
+| PWM Channel | Group |
+| ----------- | ----- |
+| 1 - 4       | TIM1  |
+| 5 - 6       | TIM3  |
+| 7 - 10      | TIM4  |
 
 ## Battery Monitoring
 
@@ -222,6 +213,15 @@ The default battery parameters are:
 - BATT_CURR_PIN 11
 - BATT_VOLT_MULT 21
 - BATT_AMP_PERVLT 40.2
+
+## OSD Support
+
+Onboard OSD (using MAX7456 driver) is supported by default.
+DisplayPort OSD is also simultaneously available on any of the UART connectors (default is UART2).
+
+## Compass
+
+The KT-FMU-F1 has a built-in compass on the IMU submodule. Due to potential interference,  this compass is disabled, and the autopilot is usually used with an external I2C compass as part of a GPS/Compass combination.  
 
 ## Loading Firmware
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteF4-Wing/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteF4-Wing/README.md
@@ -45,10 +45,6 @@ receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
 RC input is configured on the R3 (UART3_RX) pin. It supports all serial RC
 protocols.
 
-## OSD Support
-
-The KakuteF4-Wing supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The KakuteF4 supports up to 7 PWM outputs. All outputs support DShot. Outputs 1-4 support BiDirDshot.
@@ -77,6 +73,10 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN 11
 - BATT_VOLT_MULT 11
 - BATT_AMP_PERVLT 40
+
+## OSD Support
+
+The KakuteF4-Wing supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteF4/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteF4/README.md
@@ -34,20 +34,6 @@ ESC telemetry input.
 
 RC input is configured on the R6 (UART3_RX) pin. It supports all RC protocols.
 
-## FrSky Telemetry
-
-FrSky Telemetry is supported using the SmartPort pad (UART1). You need
-to set the following parameters to enable support for FrSky S.PORT. It
-has builtin inverters and a diode to allow for operation from a single
-pin with no special adapters.
-
-- SERIAL2_PROTOCOL 10
-- SERIAL2_OPTIONS 0
-
-## OSD Support
-
-The KakuteF4 supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The KakuteF4 supports up to 4 PWM outputs. The pads for motor output
@@ -76,6 +62,20 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN 12
 - BATT_VOLT_MULT 10.1
 - BATT_AMP_PERVLT 17.0
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using the SmartPort pad (UART1). You need
+to set the following parameters to enable support for FrSky S.PORT. It
+has builtin inverters and a diode to allow for operation from a single
+pin with no special adapters.
+
+- SERIAL2_PROTOCOL 10
+- SERIAL2_OPTIONS 0
+
+## OSD Support
+
+The KakuteF4 supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteF4Mini/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteF4Mini/README.md
@@ -18,6 +18,10 @@ The KakuteF7 Mini is a flight controller produced by [Holybro](http://www.holybr
 
 ![KakuteF4 Mini Board](kakutef4mini.jpg "KakuteF4 Mini")
 
+
+
+<!-- TODO: add Pinout content -->
+
 ## UART Mapping
 
 The UARTs are marked Rn and Tn in the above pinouts. The Rn pin is the
@@ -30,22 +34,9 @@ receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
 - SERIAL5 -> UART5 (Receive only, ESC Telemetry)
 - SERIAL6 -> UART6 (GPS2/Telem2)
 
-## ESC Telemetry
-
-The SERIAL5 port (UART5) is for ESC telemetry. It is connected through the
-motor connector and works out of the box with the [Tekko32 F3 Mini](https://shop.holybro.com/tekko32-f3-4in1-45a-mini-esc_p1132.html) which is commonly paired with this flight controller
-
 ## RC Input
 
 RC input is configured on the R3 (UART3_RX) pin. It supports all serial RC protocols.
-
-## FrSky Telemetry
-
-FrSky Telemetry is supported using the T1 pin (UART1 transmit). You need to set the following parameters to enable support for FrSky S.PORT
-
-## OSD Support
-
-The KakuteF7 Mini supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## PWM Output
 
@@ -74,6 +65,19 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN 12
 - BATT_VOLT_MULT 10.9
 - BATT_AMP_PERVLT 28.5
+
+## ESC Telemetry
+
+The SERIAL5 port (UART5) is for ESC telemetry. It is connected through the
+motor connector and works out of the box with the [Tekko32 F3 Mini](https://shop.holybro.com/tekko32-f3-4in1-45a-mini-esc_p1132.html) which is commonly paired with this flight controller
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using the T1 pin (UART1 transmit). You need to set the following parameters to enable support for FrSky S.PORT
+
+## OSD Support
+
+The KakuteF7 Mini supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteF7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteF7/README.md
@@ -47,17 +47,6 @@ each of the four corners of the KakuteF7 AIO board.
 
 RC input is configured on the R6 (UART6_RX) pin. It supports all RC protocols.
 
-## FrSky Telemetry
-
-FrSky Telemetry is supported using the T6 pin (UART6 transmit). You need to set the following parameters to enable support for FrSky S.PORT
-
-- SERIAL6_PROTOCOL 10
-- SERIAL6_OPTIONS 7
-
-## OSD Support
-
-The KakuteF7 AIO supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The KakuteF7 supports up to 6 PWM outputs. The pads for motor output M1 to M6 on the above diagram are for the 6 outputs. All 6 outputs support DShot as well as all PWM types.
@@ -85,6 +74,17 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN 12
 - BATT_VOLT_MULT 10.1
 - BATT_AMP_PERVLT 17.0
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using the T6 pin (UART6 transmit). You need to set the following parameters to enable support for FrSky S.PORT
+
+- SERIAL6_PROTOCOL 10
+- SERIAL6_OPTIONS 7
+
+## OSD Support
+
+The KakuteF7 AIO supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteF7Mini/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteF7Mini/README.md
@@ -18,6 +18,10 @@ The KakuteF7 Mini is a flight controller produced by [Holybro](http://www.holybr
 
 ![KakuteF7 Mini Board](kakutef7mini.jpg "KakuteF7 Mini")
 
+
+
+<!-- TODO: add Pinout content -->
+
 ## UART Mapping
 
 The UARTs are marked Rn and Tn in the above pinouts. The Rn pin is the
@@ -31,25 +35,9 @@ receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
 - SERIAL6 -> UART6 (Transmit only, FrSky)
 - SERIAL7 -> UART7 (Receive only, ESC Telemetry)
 
-## ESC Telemetry
-
-The SERIAL7 port (UART7) is for ESC telemetry. It is connected through the
-motor connector and works out of the box with the [Tekko32 F3 Mini](https://shop.holybro.com/tekko32-f3-4in1-45a-mini-esc_p1132.html) which is commonly paired with this flight controller
-
 ## RC Input
 
 RC input is configured on the R6 (UART6_RX) pin. It supports all RC protocols.
-
-## FrSky Telemetry
-
-FrSky Telemetry is supported using the T6 pin (UART6 transmit). You need to set the following parameters to enable support for FrSky S.PORT
-
-- SERIAL6_PROTOCOL 10
-- SERIAL6_OPTIONS 7
-
-## OSD Support
-
-The KakuteF7 Mini supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## PWM Output
 
@@ -78,6 +66,22 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN 12
 - BATT_VOLT_MULT 10.9
 - BATT_AMP_PERVLT 28.5
+
+## ESC Telemetry
+
+The SERIAL7 port (UART7) is for ESC telemetry. It is connected through the
+motor connector and works out of the box with the [Tekko32 F3 Mini](https://shop.holybro.com/tekko32-f3-4in1-45a-mini-esc_p1132.html) which is commonly paired with this flight controller
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using the T6 pin (UART6 transmit). You need to set the following parameters to enable support for FrSky S.PORT
+
+- SERIAL6_PROTOCOL 10
+- SERIAL6_OPTIONS 7
+
+## OSD Support
+
+The KakuteF7 Mini supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteH7-Wing/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteH7-Wing/README.md
@@ -52,10 +52,6 @@ telemetry (such as FPort) you should set BRD_ALT_CONFIG=1 and setup
 SERIAL6 as an RC input serial port, with half-duplex, pin-swap
 and inversion enabled.
 
-## OSD Support
-
-The KakuteH7 supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The KakuteH7 supports up to 14 PWM outputs. Outputs 1-10 support DShot. Outputs 5-8 support BiDirDshot.
@@ -86,6 +82,10 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN 4
 - BATT_VOLT_MULT 18.18
 - BATT_AMP_PERVLT 36.6
+
+## OSD Support
+
+The KakuteH7 supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Switchable Vidoe Supply and Camera Inputs
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteH7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteH7/README.md
@@ -40,17 +40,6 @@ telemetry (such as FPort) you should set BRD_ALT_CONFIG=1 and setup
 SERIAL6 as an RC input serial port, with half-duplex, pin-swap
 and inversion enabled.
 
-## FrSky Telemetry
-
-FrSky Telemetry is supported using the Tx pin of any UART including SERIAL6/UART6 . You need to set the following parameters to enable support for FrSky S.PORT (example shows SERIAL6). Note this assumes the RC input is using default (ALT_BRD_CONFIG =0). Obviously, if using ALT_BRD_CONFIG = 1 for full duplex RC prtocols, you must a different UART for FrSky Telemetry.
-
-- SERIAL6_PROTOCOL 10
-- SERIAL6_OPTIONS 7
-
-## OSD Support
-
-The KakuteH7 supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The KakuteH7 supports up to 9 PWM outputs. The pads for motor output
@@ -82,6 +71,17 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN 11
 - BATT_VOLT_MULT 10.1
 - BATT_AMP_PERVLT 17.0
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using the Tx pin of any UART including SERIAL6/UART6 . You need to set the following parameters to enable support for FrSky S.PORT (example shows SERIAL6). Note this assumes the RC input is using default (ALT_BRD_CONFIG =0). Obviously, if using ALT_BRD_CONFIG = 1 for full duplex RC prtocols, you must a different UART for FrSky Telemetry.
+
+- SERIAL6_PROTOCOL 10
+- SERIAL6_OPTIONS 7
+
+## OSD Support
+
+The KakuteH7 supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteH7Mini-Nand/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteH7Mini-Nand/README.md
@@ -39,17 +39,6 @@ protocols except PPM. For protocols requiring half-duplex serial to transmit
 telemetry (such as FPort) you should setup SERIAL6 with half-duplex, pin-swap
 and inversion enabled.
 
-## FrSky Telemetry
-
-FrSky Telemetry is supported using the T6 pin (UART6 transmit). You need to set the following parameters to enable support for FrSky S.PORT
-
-- SERIAL6_PROTOCOL 10
-- SERIAL6_OPTIONS 7
-
-## OSD Support
-
-The KakuteH7Mini-Nand supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The KakuteH7Mini-Nand supports up to 9 PWM outputs. The pads for motor output
@@ -81,6 +70,17 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN 11
 - BATT_VOLT_MULT 11.1
 - BATT_AMP_PERVLT 59.5
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using the T6 pin (UART6 transmit). You need to set the following parameters to enable support for FrSky S.PORT
+
+- SERIAL6_PROTOCOL 10
+- SERIAL6_OPTIONS 7
+
+## OSD Support
+
+The KakuteH7Mini-Nand supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteH7Mini/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteH7Mini/README.md
@@ -39,17 +39,6 @@ protocols. For protocols requiring half-duplex serial to transmit
 telemetry (such as FPort) you should setup SERIAL6 as an RC input serial port,
 with half-duplex, pin-swap and inversion enabled.
 
-## FrSky Telemetry
-
-FrSky Telemetry is supported using the T6 pin (UART6 transmit). You need to set the following parameters to enable support for FrSky S.PORT
-
-- SERIAL6_PROTOCOL 10
-- SERIAL6_OPTIONS 7
-
-## OSD Support
-
-The KakuteH7Mini supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The KakuteH7Mini supports up to 9 PWM outputs. The pads for motor output
@@ -81,6 +70,17 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN 11
 - BATT_VOLT_MULT 11.1
 - BATT_AMP_PERVLT 59.5
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using the T6 pin (UART6 transmit). You need to set the following parameters to enable support for FrSky S.PORT
+
+- SERIAL6_PROTOCOL 10
+- SERIAL6_OPTIONS 7
+
+## OSD Support
+
+The KakuteH7Mini supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteH7v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteH7v2/README.md
@@ -38,22 +38,6 @@ protocols except PPM. For protocols requiring half-duplex serial to transmit
 telemetry (such as FPort) you should configure SERIAL6 with half-duplex, pin-swap
 and inversion enabled.
 
-## FrSky Telemetry
-
-FrSky Telemetry is supported using the Tx pin of any UART including SERIAL6/UART6 . You need to set the following parameters to enable support for FrSky S.PORT (example shows SERIAL6).
-
-- SERIAL6_PROTOCOL 10
-- SERIAL6_OPTIONS 7
-
-## OSD Support
-
-The KakuteH7 v2 supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
-## VTX Support
-
-The JST-GH-6P connector supports a standard DJI HD VTX connection. Pin 1 of the connector is 9v so be careful not to connect
-this to a peripheral requiring 5v. The 9v supply is controlled by RELAY2_PIN and is on by default. It can be configured to be operated by an RC switch by selecting the function RELAY2.
-
 ## PWM Output
 
 The KakuteH7 supports up to 9 PWM outputs. The pads for motor output
@@ -85,6 +69,22 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN 11
 - BATT_VOLT_MULT 10.1
 - BATT_AMP_PERVLT 17.0
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using the Tx pin of any UART including SERIAL6/UART6 . You need to set the following parameters to enable support for FrSky S.PORT (example shows SERIAL6).
+
+- SERIAL6_PROTOCOL 10
+- SERIAL6_OPTIONS 7
+
+## OSD Support
+
+The KakuteH7 v2 supports OSD using OSD_TYPE 1 (MAX7456 driver).
+
+## VTX Support
+
+The JST-GH-6P connector supports a standard DJI HD VTX connection. Pin 1 of the connector is 9v so be careful not to connect
+this to a peripheral requiring 5v. The 9v supply is controlled by RELAY2_PIN and is on by default. It can be configured to be operated by an RC switch by selecting the function RELAY2.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/LumenierLUXF765-NDAA/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/LumenierLUXF765-NDAA/README.md
@@ -46,6 +46,42 @@ The Lumenier LUX F765 NDAA flight controller is sold by
 - SERIAL7 -> UART7  (RCinput, DMA enabled)
 - SERIAL8 -> USART6 (Spare)
 
+## RC Input
+
+Bi-directional RC inputs like CRSF/ELRS are supported on UART7 (Serial7).
+UART7 (Serial7) will also support all unidirectional RC protocols.
+
+## PWM Output
+
+The Lumenier LUX F765 NDAA supports 12 PWM outputs and a serial LED PWM output.
+All outputs are DShot capable. Outputs 1-4 are bi-directional DShot capable.
+The 8 main PWM outputs are labeled M1 through M8.
+The 4 auxiliary outputs are labeled S1 through S4.
+
+The 8 main PWM outputs are in 2 groups:
+
+- PWM 1 through 4 (M1 - M4) are in TIM2
+- PWM 5 through 8 (M5 - M8) are in TIM4
+
+The auxiliary PWM outputs are grouped as follows:
+
+- PWM 9/10 (S1/S2) are in a group
+- PWM 11/12 (S3/S4) are in a group
+- PWM 13 (LED) is in a group
+
+## Battery Monitoring
+
+The LUX F765 - NDAA has an internal voltage sensor and connections on the ESC connector
+for an external current sensor input. The voltage sensor can handle up to an 8S battery.
+
+The default parameters are as follows:
+
+- BATT_MONITOR = 4
+- BATT_VOLT_PIN = 12
+- BATT_CURR_PIN = 13
+- BATT_VOLT_MULT = 10.1
+- BATT_AMP_PERVLT = 17.0
+
 ## SPI Mapping
 
    | SPI | Device |
@@ -125,29 +161,6 @@ All connectors are JST SH 1.0mm pitch EXCEPT for the CANbus port, which is JST G
 | 3 | CAN_H | +5V |
 | 4 | CAN_L | +5V |
 
-## PWM Output
-
-The Lumenier LUX F765 NDAA supports 12 PWM outputs and a serial LED PWM output.
-All outputs are DShot capable. Outputs 1-4 are bi-directional DShot capable.
-The 8 main PWM outputs are labeled M1 through M8.
-The 4 auxiliary outputs are labeled S1 through S4.
-
-The 8 main PWM outputs are in 2 groups:
-
-- PWM 1 through 4 (M1 - M4) are in TIM2
-- PWM 5 through 8 (M5 - M8) are in TIM4
-
-The auxiliary PWM outputs are grouped as follows:
-
-- PWM 9/10 (S1/S2) are in a group
-- PWM 11/12 (S3/S4) are in a group
-- PWM 13 (LED) is in a group
-
-## RC Input
-
-Bi-directional RC inputs like CRSF/ELRS are supported on UART7 (Serial7).
-UART7 (Serial7) will also support all unidirectional RC protocols.
-
 ## OSD Support
 
 The LUX F765 - NDAA is equipped with an onboard AT7456E OSD.
@@ -163,19 +176,6 @@ The LUX F765 NDAA has 2 analog inputs:
 
 - PC2 -> Battery Current
 - PC3 -> Battery Voltage
-
-## Battery Monitoring
-
-The LUX F765 - NDAA has an internal voltage sensor and connections on the ESC connector
-for an external current sensor input. The voltage sensor can handle up to an 8S battery.
-
-The default parameters are as follows:
-
-- BATT_MONITOR = 4
-- BATT_VOLT_PIN = 12
-- BATT_CURR_PIN = 13
-- BATT_VOLT_MULT = 10.1
-- BATT_AMP_PERVLT = 17.0
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MFT-SEMA100/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MFT-SEMA100/README.md
@@ -14,11 +14,9 @@ The MFT-SEMA100 is a flight controller designed and produced by MFT Savunma ve H
 - 2 CANs
 - 2 I2Cs
 
-## Physical
 
-![MFT-SEMA100_Top_View](MFT-SEMA100_TopView.jpeg)
 
-![MFT-SEMA100_Bottom_View](MFT-SEMA100_BottomView.jpeg)
+<!-- TODO: add Pinout content -->
 
 ## UART Mapping
 
@@ -29,14 +27,6 @@ The MFT-SEMA100 is a flight controller designed and produced by MFT Savunma ve H
 - SERIAL4 -> UART5 (GPS2, DMA-enabled)
 - SERIAL5 -> UART7 (DMA-enabled)
 - SERIAL6 -> UART8 (RX only)
-
-## Connectors
-
-All pins are 2.54 mm Pin Headers
-
-## Power Connector
-
-XT30-PW 5V Input for powering the board
 
 ## RC Input
 
@@ -60,6 +50,33 @@ PWM outputs are grouped and every group must use the same output protocol:
 
 Channels within the same group need to use the same output rate.
 
+## Battery Monitoring
+
+The board has a internal voltage sensor and connections on the ESC connector for an external current sensor input.
+The voltage sensor can handle up to 6S LiPo batteries.
+
+The default battery parameters are:
+
+- BATT_MONITOR 4
+- BATT_VOLT_PIN 19
+- BATT_CURR_PIN 8
+- BATT_VOLT_MULT 10
+- BATT_AMP_PERVLT 10
+
+## Physical
+
+![MFT-SEMA100_Top_View](MFT-SEMA100_TopView.jpeg)
+
+![MFT-SEMA100_Bottom_View](MFT-SEMA100_BottomView.jpeg)
+
+## Connectors
+
+All pins are 2.54 mm Pin Headers
+
+## Power Connector
+
+XT30-PW 5V Input for powering the board
+
 ## GPIOs
 
 The numbering of the GPIOs for PIN variables in ArduPilot is:
@@ -76,19 +93,6 @@ The numbering of the GPIOs for PIN variables in ArduPilot is:
 - PWM10 59
 - PWM11 60
 - PWM12 61
-
-## Battery Monitoring
-
-The board has a internal voltage sensor and connections on the ESC connector for an external current sensor input.
-The voltage sensor can handle up to 6S LiPo batteries.
-
-The default battery parameters are:
-
-- BATT_MONITOR 4
-- BATT_VOLT_PIN 19
-- BATT_CURR_PIN 8
-- BATT_VOLT_MULT 10
-- BATT_AMP_PERVLT 10
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MUPilot/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MUPilot/README.md
@@ -22,6 +22,77 @@ The MUPilot flight controller is sold by [MUGIN UAV](http://https://www.muginuav
 - voltage monitoring for servo rail and Vcc
 - two dedicated power input ports for external power bricks
 
+
+
+<!-- TODO: add Pinout content -->
+
+## UART Mapping
+
+- SERIAL0 -> USB
+- SERIAL1 -> UART2 (Telem1)
+- SERIAL2 -> UART3 (Telem2)
+- SERIAL3 -> UART1 (GPS)
+- SERIAL4 -> UART4 (GPS2)
+- SERIAL5 -> UART6 (spare)
+- SERIAL6 -> UART7 (spare, debug)
+- SERIAL7 -> USB2  (SLCAN)
+
+The Telem1 and Telem2 ports have RTS/CTS pins, the other UARTs do not
+have RTS/CTS.
+
+The UART7 connector is labelled debug, but is available as a general
+purpose UART with ArduPilot.
+
+## RC Input
+
+RC input is configured on the PPM pin, at one end of the servo rail,
+marked RC in the above diagram. This pin supports all unidirectional RC protocols including PPM.  The DSM/SBUS pin is also tied to the PPM pin.For CRSF/ELRS/etc. protocols
+a full UART will need to be used with its SERIALx_PROTOCOL set to "23".
+
+## PWM Output
+
+The MUPilot supports up to 14 PWM outputs. First first 8 outputs (labelled
+"M1 to M8") are controlled by a dedicated STM32F103 IO controller. These 8
+outputs support all PWM output formats, but not DShot.
+
+The remaining 6 outputs (labelled A1 to A6) are the "auxiliary"
+outputs. These are directly attached to the STM32F765 and support all
+PWM protocols as well as DShot.
+
+All 14 PWM outputs have GND on the top row, 5V on the middle row and
+signal on the bottom row.
+
+The 8 main PWM outputs are in 3 groups:
+
+- PWM 1 and 2 in group1
+- PWM 3 and 4 in group2
+- PWM 5, 6, 7 and 8 in group3
+
+The 6 auxiliary PWM outputs are in 2 groups:
+
+- PWM 1, 2, 3 and 4 in group1
+- PWM 5 and 6 in group2
+
+Channels within the same group need to use the same output rate. If
+any channel in a group uses DShot then all channels in the group need
+to use DShot.
+
+The output levels of the auxiliary outputs can be selected by switch to be either 3.3V or 5V. The output level is 3.3V for the main outputs.
+
+## Battery Monitoring
+
+The board has two dedicated power monitor ports on 6 pin
+connectors. The correct battery setting parameters are dependent on
+the type of power brick which is connected. The first is analog only, the second may be either analog or I2C, depending on baseboard jumpers.
+In order to enable monitoring, the BATT_MONITOR or BATT2_MONITOR parameter must be set. By default BATT_MONITOR is set to "4" for the included power module.
+
+Default params for the first monitor are set and are:
+
+- BATT_VOLT_PIN = 2
+- BATT_CURR_PIN = 1
+- BATT_VOLT_MULT = 18.0
+- BATT_AMP_PERVLT = 24.0
+
 ## Mechanical
 
 - 91mm x 46mm x 31mm
@@ -174,73 +245,6 @@ The MUPilot flight controller is sold by [MUGIN UAV](http://https://www.muginuav
 |  3   |   RSSI      | +3.3V |
 |  4   |   3V3_OUT   | +3.3V |
 |  5   |   GND       |  GND  |
-
-## UART Mapping
-
-- SERIAL0 -> USB
-- SERIAL1 -> UART2 (Telem1)
-- SERIAL2 -> UART3 (Telem2)
-- SERIAL3 -> UART1 (GPS)
-- SERIAL4 -> UART4 (GPS2)
-- SERIAL5 -> UART6 (spare)
-- SERIAL6 -> UART7 (spare, debug)
-- SERIAL7 -> USB2  (SLCAN)
-
-The Telem1 and Telem2 ports have RTS/CTS pins, the other UARTs do not
-have RTS/CTS.
-
-The UART7 connector is labelled debug, but is available as a general
-purpose UART with ArduPilot.
-
-## RC Input
-
-RC input is configured on the PPM pin, at one end of the servo rail,
-marked RC in the above diagram. This pin supports all unidirectional RC protocols including PPM.  The DSM/SBUS pin is also tied to the PPM pin.For CRSF/ELRS/etc. protocols
-a full UART will need to be used with its SERIALx_PROTOCOL set to "23".
-
-## PWM Output
-
-The MUPilot supports up to 14 PWM outputs. First first 8 outputs (labelled
-"M1 to M8") are controlled by a dedicated STM32F103 IO controller. These 8
-outputs support all PWM output formats, but not DShot.
-
-The remaining 6 outputs (labelled A1 to A6) are the "auxiliary"
-outputs. These are directly attached to the STM32F765 and support all
-PWM protocols as well as DShot.
-
-All 14 PWM outputs have GND on the top row, 5V on the middle row and
-signal on the bottom row.
-
-The 8 main PWM outputs are in 3 groups:
-
-- PWM 1 and 2 in group1
-- PWM 3 and 4 in group2
-- PWM 5, 6, 7 and 8 in group3
-
-The 6 auxiliary PWM outputs are in 2 groups:
-
-- PWM 1, 2, 3 and 4 in group1
-- PWM 5 and 6 in group2
-
-Channels within the same group need to use the same output rate. If
-any channel in a group uses DShot then all channels in the group need
-to use DShot.
-
-The output levels of the auxiliary outputs can be selected by switch to be either 3.3V or 5V. The output level is 3.3V for the main outputs.
-
-## Battery Monitoring
-
-The board has two dedicated power monitor ports on 6 pin
-connectors. The correct battery setting parameters are dependent on
-the type of power brick which is connected. The first is analog only, the second may be either analog or I2C, depending on baseboard jumpers.
-In order to enable monitoring, the BATT_MONITOR or BATT2_MONITOR parameter must be set. By default BATT_MONITOR is set to "4" for the included power module.
-
-Default params for the first monitor are set and are:
-
-- BATT_VOLT_PIN = 2
-- BATT_CURR_PIN = 1
-- BATT_VOLT_MULT = 18.0
-- BATT_AMP_PERVLT = 24.0
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MambaF405-2022/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MambaF405-2022/README.md
@@ -31,10 +31,6 @@ receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
 
 RC input is configured on the PPM (UART1_RX) pin. It supports all RC protocols.
 
-## OSD Support
-
-The Mamba F405 MK4 supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The Mamba F405 MK4 supports up to 7 PWM outputs. The pads for motor output ESC1 to ESC4 on the above diagram are for the 4 outputs. All outputs support DShot as well as all PWM types. Motors 1-4 support bi-directional DShot.
@@ -62,6 +58,10 @@ The correct battery setting parameters are:
 - BATT_VOLT_MULT around 11.0
 - BATT_CURR_PIN 13
 - BATT_CURR_MULT around 28 with the 20x20 40A ESC (calculated, needs to be verified)
+
+## OSD Support
+
+The Mamba F405 MK4 supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MambaF405US-I2C/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MambaF405US-I2C/README.md
@@ -35,10 +35,6 @@ receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
 
 RC input is configured on the PPM (UART1_RX) pin. It supports all RC protocols.
 
-## OSD Support
-
-The Mamba F405 MK2 supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The Mamba F405 MK2 supports up to 4 PWM outputs. The pads for motor output ESC1 to ESC4 on the above diagram are for the 4 outputs. All 4 outputs support DShot as well as all PWM types.
@@ -61,6 +57,10 @@ The correct battery setting parameters are:
 - BATT_VOLT_MULT around 11.0
 - BATT_CURR_PIN 13
 - BATT_CURR_MULT around 28 with the 20x20 40A ESC (calculated, needs to be verified)
+
+## OSD Support
+
+The Mamba F405 MK2 supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MambaF405v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MambaF405v2/README.md
@@ -32,10 +32,6 @@ receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
 RC input is configured on the PPM (UART1_RX) pin. It supports all RC protocols.
 The S.BUS pad provides an inverted input for S.BUS receivers.
 
-## OSD Support
-
-The Mamba F405 MK2 supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The Mamba F405 MK2 supports up to 4 PWM outputs. The pads for motor output ESC1 to ESC4 on the above diagram are for the 4 outputs. All 4 outputs support DShot as well as all PWM types.
@@ -58,6 +54,10 @@ The correct battery setting parameters are:
 - BATT_VOLT_MULT around 12.0
 - BATT_CURR_PIN 13
 - BATT_CURR_MULT around 39 with the included 40A ESC
+
+## OSD Support
+
+The Mamba F405 MK2 supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MambaH743v4/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MambaH743v4/README.md
@@ -42,17 +42,6 @@ protocols. For protocols requiring half-duplex serial to transmit
 telemetry (such as FPort) you should setup SERIAL6 as an RC input serial port,
 with half-duplex, pin-swap and inversion enabled.
 
-## FrSky Telemetry
-
-FrSky Telemetry is supported using the T5 pin (UART5 transmit). You need to set the following parameters to enable support for FrSky S.PORT
-
-- SERIAL5_PROTOCOL 10
-- SERIAL5_OPTIONS 7
-
-## OSD Support
-
-The MambaH743v4 supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The MambaH743v4 supports up to 9 PWM outputs. The pads for motor output
@@ -83,6 +72,17 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN 13
 - BATT_VOLT_MULT 11.1
 - BATT_AMP_PERVLT 64
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using the T5 pin (UART5 transmit). You need to set the following parameters to enable support for FrSky S.PORT
+
+- SERIAL5_PROTOCOL 10
+- SERIAL5_OPTIONS 7
+
+## OSD Support
+
+The MambaH743v4 supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MatekH7A3-Wing/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MatekH7A3-Wing/README.md
@@ -28,11 +28,9 @@
 - Size
   - 36 x 36mm PCB with 30.5mm M3 mounting
 
-## Overview
 
-![MATEKH7A3-SLIM](H7A3-WING.jpg)
 
-## Wiring Diagram
+<!-- TODO: add Pinout content -->
 
 ## UART Mapping
 
@@ -47,11 +45,6 @@ receive pin for UARTx. The Tx pin is the transmit pin for UARTx.
 - SERIAL5 -> UART5  (User) (NO DMA)
 - SERIAL6 -> USART6 (User) (NO DMA)
 
-## CAN and I2C
-
-H7A3-SLIM supports 1x CAN bus and 1x I2C bus
-multiple CAN peripherals can be connected to one CAN bus in parallel. similarly for I2C bus.
-
 ## RC Input
 
 RC input is configured on the USART2(SERIAL2). It supports all serial RC protocols. SERIAL2_PROTOCOL=23 by default.
@@ -61,10 +54,6 @@ RC input is configured on the USART2(SERIAL2). It supports all serial RC protoco
 - SBUS/DSM/SRXL connects to the Rx2 pin, but SBUS requires that the SERIAL2_OPTIONS be set to “3”.
 - FPort requires connection to Tx2, and set SERIAL2_OPTIONS to “7”.
 - SRXL2 requires a connection to Tx2, and automatically provides telemetry. Set SERIAL2_OPTIONS to “4”.
-
-## OSD Support
-
-H7A3-SLIM supports using its internal OSD using OSD_TYPE 1 (MAX7456 driver). External OSD support such as DJI or DisplayPort is supported using any spare UART. See [MSP OSD](https://ardupilot.org/copter/docs/common-msp-osd-overview-4.2.html) for more info.
 
 ## PWM Output
 
@@ -94,6 +83,21 @@ The correct battery setting parameters are set by default and are:
 - BATT2_CURR_PIN 8
 - BATT2_VOLT_MULT 21.0  ("VB2" pad support Max.69V voltage sense)
 - BATT_AMP_PERVLT X ("CU2" pad, set it according to external current sensor spec)
+
+## Overview
+
+![MATEKH7A3-SLIM](H7A3-WING.jpg)
+
+## Wiring Diagram
+
+## CAN and I2C
+
+H7A3-SLIM supports 1x CAN bus and 1x I2C bus
+multiple CAN peripherals can be connected to one CAN bus in parallel. similarly for I2C bus.
+
+## OSD Support
+
+H7A3-SLIM supports using its internal OSD using OSD_TYPE 1 (MAX7456 driver). External OSD support such as DJI or DisplayPort is supported using any spare UART. See [MSP OSD](https://ardupilot.org/copter/docs/common-msp-osd-overview-4.2.html) for more info.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MazzyStarDrone/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MazzyStarDrone/README.md
@@ -3,3 +3,14 @@
 [Vimdrones](https://www.vimdrones.com)
 
 The Mazzy Star Drone is a ready to fly drone for making drone light show produced by [Vimdrones](https://www.vimdrones.com)
+
+
+
+
+
+<!-- TODO: add Features content -->
+<!-- TODO: add Pinout content -->
+<!-- TODO: add UART Mapping content -->
+<!-- TODO: add RC Input content -->
+<!-- TODO: add PWM Output content -->
+<!-- TODO: add Battery Monitoring content -->

--- a/libraries/AP_HAL_ChibiOS/hwdef/MicoAir405Mini/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MicoAir405Mini/README.md
@@ -13,11 +13,9 @@ The MicoAir405Mini is a flight controller designed and produced by [MicoAir Tech
 - 6 UARTs
 - 9 PWM outputs
 
-## Physical
 
-![MicoAir F405 Mini V2.1 Front View](MicoAir405Mini_FrontView.jpg)
 
-![MicoAir F405 Mini V2.1 Back View](MicoAir405Mini_BackView.jpg)
+<!-- TODO: add Pinout content -->
 
 ## UART Mapping
 
@@ -32,14 +30,6 @@ The MicoAir405Mini is a flight controller designed and produced by [MicoAir Tech
 ## RC Input
 
 The default RC input is configured as SBUS via the SBUS pin. Other RC  protocols  should be applied at a UART port such as UART1 or UART4, and set the protocol to receive RC data: `SERIALn_PROTOCOL=23` and change SERIAL6 _Protocol to something other than '23'
-
-## OSD Support
-
-The MicoAir405Mini supports onboard OSD using OSD_TYPE 1 (MAX7456 driver).
-
-## VTX Support
-
-The SH1.0-6P connector supports a DJI O3 Air Unit connection. Pin 1 of the connector is 9v so be careful not to connect this to a peripheral requiring 5v.
 
 ## PWM Output
 
@@ -71,6 +61,20 @@ The default battery parameters are:
 - BATT_CURR_PIN 11
 - BATT_VOLT_MULT 21.2
 - BATT_AMP_PERVLT 40.2
+
+## Physical
+
+![MicoAir F405 Mini V2.1 Front View](MicoAir405Mini_FrontView.jpg)
+
+![MicoAir F405 Mini V2.1 Back View](MicoAir405Mini_BackView.jpg)
+
+## OSD Support
+
+The MicoAir405Mini supports onboard OSD using OSD_TYPE 1 (MAX7456 driver).
+
+## VTX Support
+
+The SH1.0-6P connector supports a DJI O3 Air Unit connection. Pin 1 of the connector is 9v so be careful not to connect this to a peripheral requiring 5v.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MicoAir405v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MicoAir405v2/README.md
@@ -14,11 +14,9 @@ The MicoAir405v2 is a flight controller produced by [MicoAir](http://micoair.com
 - 10 PWM outputs
 - 1 SWD
 
-## Physical
 
-![MicoAir F405 V2.1 Front View](MicoAir405v2_FrontView.jpg)
 
-![MicoAir F405 V2.1 Back View](MicoAir405v2_BackView.jpg)
+<!-- TODO: add Pinout content -->
 
 ## UART Mapping
 
@@ -33,15 +31,6 @@ The MicoAir405v2 is a flight controller produced by [MicoAir](http://micoair.com
 ## RC Input
 
 The default RC input is configured on the UART6_RX inverted from the SBUS pin. Other RC  protocols  should be applied at other UART port such as UART1 or UART4, and set the protocol to receive RC data: `SERIALn_PROTOCOL=23` and change SERIAL6 _Protocol to something other than '23'
-
-## OSD Support
-
-The MicoAir405v2 supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
-## VTX Support
-
-The SH1.0-6P connector supports a standard DJI HD VTX connection. Pin 1 of the connector is 9v so be careful not to connect
-this to a peripheral requiring 5v.
 
 ## PWM Output
 
@@ -68,6 +57,21 @@ The default battery parameters are:
 - BATT_CURR_PIN 11
 - BATT_VOLT_MULT 21.2
 - BATT_AMP_PERVLT 40.2
+
+## Physical
+
+![MicoAir F405 V2.1 Front View](MicoAir405v2_FrontView.jpg)
+
+![MicoAir F405 V2.1 Back View](MicoAir405v2_BackView.jpg)
+
+## OSD Support
+
+The MicoAir405v2 supports OSD using OSD_TYPE 1 (MAX7456 driver).
+
+## VTX Support
+
+The SH1.0-6P connector supports a standard DJI HD VTX connection. Pin 1 of the connector is 9v so be careful not to connect
+this to a peripheral requiring 5v.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743-AIO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743-AIO/README.md
@@ -15,9 +15,9 @@ The MicoAir743-AIO is a flight controller designed and produced by [MicoAir Tech
 - 1 I2C
 - 1 SWD
 
-## Physical
 
-![MicoAir H743 AIO Physical Size](MicoAir743-AIO_Physical_Size.jpg)
+
+<!-- TODO: add Pinout content -->
 
 ## UART Mapping
 
@@ -33,10 +33,6 @@ The MicoAir743-AIO is a flight controller designed and produced by [MicoAir Tech
 ## RC Input
 
 The default RC input is configured on the UART6. The SBus input on the HD VTX connector is tied to RX6.
-
-## VTX Support
-
-The SH1.0-6P connector supports a DJI Air Unit / HD VTX connection. Protocol defaults to DisplayPort. Pin 1 of the connector is 12v so be careful not to connect this to a peripheral requiring 5v.
 
 ## PWM Output
 
@@ -68,6 +64,14 @@ The default battery parameters are:
 - BATT_CURR_PIN 11
 - BATT_VOLT_MULT 21.2
 - BATT_AMP_PERVLT 14.14
+
+## Physical
+
+![MicoAir H743 AIO Physical Size](MicoAir743-AIO_Physical_Size.jpg)
+
+## VTX Support
+
+The SH1.0-6P connector supports a DJI Air Unit / HD VTX connection. Protocol defaults to DisplayPort. Pin 1 of the connector is 12v so be careful not to connect this to a peripheral requiring 5v.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743-Lite/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743-Lite/README.md
@@ -16,6 +16,10 @@ The MicoAir743-Lite is a flight controller designed and produced by [MicoAir Tec
 - 1 I2C
 - 1 SWD
 
+
+
+<!-- TODO: add Pinout content -->
+
 ## UART Mapping
 
 - SERIAL0 -> USB
@@ -43,14 +47,6 @@ The UART6  is compatible with all ArduPilot supported receiver protocols,
 - SRXL2 requires a connection to TX6 and automatically provides telemetry. Set SERIAL6_OPTIONS to "4".
 
 Any UART can also be used for RC system connections in ArduPilot and is compatible with all protocols except PPM. See Radio Control Systems for details.
-
-## OSD Support
-
-The MicoAir743-Lite doesn’t have an onboard OSD chip, but DisplayPort OSD is available on the HD VTX connector, See below.
-
-## VTX Support
-
-The SH1.0-6P connector supports a DJI Air Unit / HD VTX connection. Protocol defaults to DisplayPort. Pin 1 of the connector is 9v so be careful not to connect this to a peripheral requiring 5v.
 
 ## PWM Output
 
@@ -85,6 +81,14 @@ The default battery parameters are:
 - BATT_CURR_PIN 11
 - BATT_VOLT_MULT 21.12
 - BATT_AMP_PERVLT 40.2 (may need adjustment according to ESC used)
+
+## OSD Support
+
+The MicoAir743-Lite doesn’t have an onboard OSD chip, but DisplayPort OSD is available on the HD VTX connector, See below.
+
+## VTX Support
+
+The SH1.0-6P connector supports a DJI Air Unit / HD VTX connection. Protocol defaults to DisplayPort. Pin 1 of the connector is 9v so be careful not to connect this to a peripheral requiring 5v.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743/README.md
@@ -17,11 +17,9 @@ The MicoAir743 is a flight controller designed and produced by [MicoAir Tech.](h
 - 1 I2C
 - 1 SWD
 
-## Physical
 
-![MicoAir H743 V1.3 Front View](MicoAir743_FrontView.jpg)
 
-![MicoAir H743 V1.3 Back View](MicoAir743_BackView.jpg)
+<!-- TODO: add Pinout content -->
 
 ## UART Mapping
 
@@ -37,14 +35,6 @@ The MicoAir743 is a flight controller designed and produced by [MicoAir Tech.](h
 ## RC Input
 
 The default RC input is configured on the UART6. The SBUS pin is inverted and connected to RX6. Non SBUS, single wire serial inputs can be directly tied to RX6 if SBUS pin is left unconnected. RC could  be applied instead at a different UART port such as UART1, UART4 or UART8, and set the protocol to receive RC data: `SERIALn_PROTOCOL=23` and change SERIAL5 _Protocol to something other than '23'.
-
-## OSD Support
-
-The MicoAir743 supports onboard OSD using OSD_TYPE 1 (MAX7456 driver). Simultaneously, DisplayPort OSD is available on the HD VTX connector, See below.
-
-## VTX Support
-
-The SH1.0-6P connector supports a DJI Air Unit / HD VTX connection. Protocol defaults to DisplayPort. Pin 1 of the connector is 9v so be careful not to connect this to a peripheral requiring 5v.
 
 ## PWM Output
 
@@ -74,6 +64,20 @@ The default battery parameters are:
 - BATT_CURR_PIN 11
 - BATT_VOLT_MULT 21.2
 - BATT_AMP_PERVLT 40.2
+
+## Physical
+
+![MicoAir H743 V1.3 Front View](MicoAir743_FrontView.jpg)
+
+![MicoAir H743 V1.3 Back View](MicoAir743_BackView.jpg)
+
+## OSD Support
+
+The MicoAir743 supports onboard OSD using OSD_TYPE 1 (MAX7456 driver). Simultaneously, DisplayPort OSD is available on the HD VTX connector, See below.
+
+## VTX Support
+
+The SH1.0-6P connector supports a DJI Air Unit / HD VTX connection. Protocol defaults to DisplayPort. Pin 1 of the connector is 9v so be careful not to connect this to a peripheral requiring 5v.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743v2/README.md
@@ -17,9 +17,9 @@ The MicoAir743v2 is a flight controller designed and produced by [MicoAir Tech](
 - 1 I2C
 - 1 SWD
 
-## Physical
 
-![MicoAir H743 v2.0 Physical Size](MicoAir743v2_Physical_Size.jpg)
+
+<!-- TODO: add Pinout content -->
 
 ## UART Mapping
 
@@ -48,14 +48,6 @@ The UART6  is compatible with all ArduPilot supported receiver protocols,
 - SRXL2 requires a connection to TX6 and automatically provides telemetry. Set SERIAL6_OPTIONS to "4".
 
 Any UART can also be used for RC system connections in ArduPilot and is compatible with all protocols except PPM. See Radio Control Systems for details.
-
-## OSD Support
-
-The MicoAir743v2 supports onboard OSD using OSD_TYPE 1 (MAX7456 driver). Simultaneously, DisplayPort OSD is available on the HD VTX connector, set OSD_TYPE2 = "5".
-
-## VTX Support
-
-The SH1.0-6P connector supports a DJI Air Unit / HD VTX connection. Protocol defaults to DisplayPort. Pin 1 of the connector is 9v so be careful not to connect this to a peripheral requiring 5v.
 
 ## PWM Output
 
@@ -88,6 +80,18 @@ The default battery parameters are:
 - BATT_CURR_PIN 11
 - BATT_VOLT_MULT 21.12
 - BATT_AMP_PERVLT 40.2
+
+## Physical
+
+![MicoAir H743 v2.0 Physical Size](MicoAir743v2_Physical_Size.jpg)
+
+## OSD Support
+
+The MicoAir743v2 supports onboard OSD using OSD_TYPE 1 (MAX7456 driver). Simultaneously, DisplayPort OSD is available on the HD VTX connector, set OSD_TYPE2 = "5".
+
+## VTX Support
+
+The SH1.0-6P connector supports a DJI Air Unit / HD VTX connection. Protocol defaults to DisplayPort. Pin 1 of the connector is 9v so be careful not to connect this to a peripheral requiring 5v.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/Morakot/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Morakot/README.md
@@ -1,4 +1,4 @@
-﻿# Morakot Flight Controller Overview
+# Morakot Flight Controller Overview
 
 The Morakot is a flight controller designed and produced by [Taiphoon](https://taiphoon.com.tw/)
 
@@ -7,11 +7,6 @@ The Morakot is a flight controller designed and produced by [Taiphoon](https://t
 
 Morakot Flight Controller - **NDAA-Compliant. Made in Taiwan.** Built for Performance.
 Engineered, tested, and manufactured in Taiwan, the Morakot Flight Controller meets full NDAA compliance, ensuring trusted quality and security for professional applications. With an integrated Ethernet interface, it delivers high-speed, reliable connectivity for next-generation FPV and unmanned aerial systems.
-
-## Pinout
-
-![top_wired](Morakot_top_Wired.jpg)
-![bottom_wired](Morakot_bottom_Wired.jpg)
 
 ## Features
 
@@ -64,6 +59,42 @@ RTS/CTS flow control is available on UART7.
 ### VTX Support
 
 The JST-GH 7p connector supports a DJI Air Unit / HD VTX connection. Protocol defaults to DisplayPort. Pin 1 of the connector is 12v so be careful not to connect this to a peripheral that can not tolerate this voltage.
+
+## Pinout
+
+![top_wired](Morakot_top_Wired.jpg)
+![bottom_wired](Morakot_bottom_Wired.jpg)
+
+
+
+<!-- TODO: add UART Mapping content -->
+
+## RC Input
+
+RC input is via SERIAL7(UART8) on the RC connector. Unidirectional protocols can be connected to R8. Bi-Directional Protocols will use the T8 pin also.
+
+- PPM is not supported.
+- SBUS/DSM/SRXL connects to the RX8 pin.
+- FPort requires connection to TX8. Set [SERIAL7_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial7-options-serial7-options) = 7
+- CRSF/ELRS also requires both TX8 and RX8 connections and provides telemetry automatically.
+
+In order to use the SBUS pin on the HD VTX connector, you must change SERIAL7_PROTOCOL to something other than "23" and set [SERIAL3_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial3-protocol-serial-3-gps-protocol-selection) to "23".
+
+## PWM Output
+
+The Morakot supports up to 9 PWM outputs. All are DSHot and Bi-Directional DShot capable
+
+The PWM is in 3 groups:
+
+- PWM 1-4  in group1
+- PWM 4-8  in group2
+- PWM 9  in group3
+
+ Channels within the same group need to use the same output rate. If any channel in a group uses DShot then all channels in that group need to use DShot.
+
+
+
+<!-- TODO: add Battery Monitoring content -->
 
 ## Additional Information
 
@@ -177,29 +208,6 @@ Note: connector pinout not in same order as standard HD VTX cabling
 | 2   | RXP                 | 3.3V    |
 | 3   | TXN                 | 3.3V    |
 | 4   | TXP                 | 3.3V    |
-
-## RC Input
-
-RC input is via SERIAL7(UART8) on the RC connector. Unidirectional protocols can be connected to R8. Bi-Directional Protocols will use the T8 pin also.
-
-- PPM is not supported.
-- SBUS/DSM/SRXL connects to the RX8 pin.
-- FPort requires connection to TX8. Set [SERIAL7_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial7-options-serial7-options) = 7
-- CRSF/ELRS also requires both TX8 and RX8 connections and provides telemetry automatically.
-
-In order to use the SBUS pin on the HD VTX connector, you must change SERIAL7_PROTOCOL to something other than "23" and set [SERIAL3_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial3-protocol-serial-3-gps-protocol-selection) to "23".
-
-## PWM Output
-
-The Morakot supports up to 9 PWM outputs. All are DSHot and Bi-Directional DShot capable
-
-The PWM is in 3 groups:
-
-- PWM 1-4  in group1
-- PWM 4-8  in group2
-- PWM 9  in group3
-
- Channels within the same group need to use the same output rate. If any channel in a group uses DShot then all channels in that group need to use DShot.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/NarinFC-H5/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/NarinFC-H5/README.md
@@ -7,3 +7,14 @@ The NarinFC-H5 is the same autopilot as the NarinFC-H7 but uses different IMUs:
   - Accelerometer/Gyroscope: BMI088
   - Magnetometer: RM3100
   - Barometer: MS5611*2
+
+
+
+
+
+<!-- TODO: add Features content -->
+<!-- TODO: add Pinout content -->
+<!-- TODO: add UART Mapping content -->
+<!-- TODO: add RC Input content -->
+<!-- TODO: add PWM Output content -->
+<!-- TODO: add Battery Monitoring content -->

--- a/libraries/AP_HAL_ChibiOS/hwdef/NarinFC-H7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/NarinFC-H7/README.md
@@ -1,74 +1,8 @@
 # [NarinFC-H7 VOLOLAND CO., LTD](https://vololand.com/pages/product/computer "NarinFC-H7")
 
-## Introduction
 
-The NarinFC-H7 is a flight controller produced by [VOLOLAND CO., LTD](https://vololand.com "VOLOLAND CO., LTD")
 
-NarinFC-H7 is an advanced autopilot family designed in-house by VOLOLAND CO., LTD.
-
-It uses a higher-performance STM32H7 processor and integrates industrial-grade sensors.
-
-Compared with previous autopilots, it has better performance and higher reliability.
-
-![NarinFC-H7](./images/NarinFC_Header.jpg "NarinFC")
-
-## Features/Specifications
-
-- **Processor**
-  - STM32H743
-
-- **Sensors**
-  - Accelerometer/Gyroscope: ADIS16470
-  - Accelerometer/Gyroscope: ICM-20649
-  - Accelerometer/Gyroscope: BMI088
-  - Magnetometer: RM3100
-  - Barometer: MS5611*2
-
-- **Interfaces**
-  - 14 PWM servo outputs
-  - Support multiple RC inputs (SBus / CPPM / DSM)
-  - Analog/PWM RSSI input
-  - 2 GPS ports (GPS and UART4 ports)
-  - 4 ⅹ I2C buses
-  - 2 ⅹ CAN bus ports
-  - 2 ⅹ Power ports
-  - 2 ⅹ ADC ports
-  - 1 ⅹ USB port
-
-- **Power**
-  - Power 4.3V ~ 5.4V
-  - USB Input 4.75V ~ 5.25V
-
-- **Size and Dimensions**
-  - 93.4mm x 46.4mm x 34.1mm
-  - 106g
-
-## Where to Buy
-
-[VOLOLAND CO., LTD](https://vololand.com "VOLOLAND CO., LTD")
-
-## Outline Dimensions
-
-![Outline Dimensions](./images/2.Outline_Dimensions.png "Outline Dimensions")
-
-## Wiring Diagram
-
-![Wire Diagram](./images/3.Wire_Diagram.png "Wire Diagram")
-
-## UART Mapping
-
- UART corresponding to each SERIAL port, and its default protocol, are shown below:
-
-- SERIAL0 = USB (MAVLink2 default)
-- SERIAL1 = USART2,Telemetry1 (MAVlink2 default,DMA-enabled)
-- SERIAL2 = USART6,Telemetry2 (MAVlink2 default,DMA-enabled)
-- SERIAL3 = USART1,GPS1 (GPS default, DMA-enabled)
-- SERIAL4 = UART4,GPS2 (GPS2 default)
-- SERIAL5 = UART8 (not available except on custom carrier boards)(USER default,DMA-enabled)
-- SERIAL6 = UART7,DEBUG (USER)
-- SERIAL7 = USB2 (MAVLink2 default)
-
-  Serial protocols can be adjusted to personal preferences.
+<!-- TODO: add Features content -->
 
 ## Pinout
 
@@ -162,6 +96,35 @@ UART7(SERIAL6) is labeled DEBUG RX/TX below
 
 - SD CARD
 
+## UART Mapping
+
+ UART corresponding to each SERIAL port, and its default protocol, are shown below:
+
+- SERIAL0 = USB (MAVLink2 default)
+- SERIAL1 = USART2,Telemetry1 (MAVlink2 default,DMA-enabled)
+- SERIAL2 = USART6,Telemetry2 (MAVlink2 default,DMA-enabled)
+- SERIAL3 = USART1,GPS1 (GPS default, DMA-enabled)
+- SERIAL4 = UART4,GPS2 (GPS2 default)
+- SERIAL5 = UART8 (not available except on custom carrier boards)(USER default,DMA-enabled)
+- SERIAL6 = UART7,DEBUG (USER)
+- SERIAL7 = USB2 (MAVLink2 default)
+
+  Serial protocols can be adjusted to personal preferences.
+
+## RC Input
+
+The RCIN pin, which by default is mapped to a timer input, can be used for all ArduPilot supported unidirectional receiver protocols. Bi-directional protocols such as CRSF/ELRS and SRXL2 require a full UART connection. FPort, when connected to RCIN, will only provide RC without telemetry.
+
+To allow CRSF and embedded telemetry available in Fport, CRSF, and SRXL2 receivers, a full UART, such as SERIAL6 (UART7) would need to be used for receiver connections. Below are setups using Serial6.
+
+- [SERIAL6_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial6-protocol-serial6-protocol-selection) should be set to "23".
+- FPort would require [SERIAL6_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial6-options-serial6-options) be set to "15".
+- CRSF would require [SERIAL6_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial6-options-serial6-options) be set to "0".
+- SRXL2 would require [SERIAL6_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial6-options-serial6-options) be set to "4" and connects only the TX pin.
+
+Any UART can also be used for RC system connections in ArduPilot, and is compatible with all protocols except PPM. See [RC systems](https://ardupilot.org/copter/docs/common-rc-systems.html) for details.
+The power rail associated with this connector position is powered via USB or PMU.
+
 ## PWM Output
 
 The NarinFC-H7 supports up to 14 PWM outputs. All outputs except M13 and M14 support DShot. Outputs 1-8 support Bi-Directional DShot.
@@ -174,6 +137,65 @@ The 14 PWM outputs are in 4 groups:
 - Outputs 13 and 14 in group4
 
 ALL outputs within the same group need to use the same output rate and protocol.
+
+## Battery Monitoring
+
+The board has two dedicated power monitor ports on 6 pin connectors. The correct battery setting parameters are dependent on the type of power brick which is connected. By default, use of a CAN battery monitor is enabled.
+
+## Introduction
+
+The NarinFC-H7 is a flight controller produced by [VOLOLAND CO., LTD](https://vololand.com "VOLOLAND CO., LTD")
+
+NarinFC-H7 is an advanced autopilot family designed in-house by VOLOLAND CO., LTD.
+
+It uses a higher-performance STM32H7 processor and integrates industrial-grade sensors.
+
+Compared with previous autopilots, it has better performance and higher reliability.
+
+![NarinFC-H7](./images/NarinFC_Header.jpg "NarinFC")
+
+## Features/Specifications
+
+- **Processor**
+  - STM32H743
+
+- **Sensors**
+  - Accelerometer/Gyroscope: ADIS16470
+  - Accelerometer/Gyroscope: ICM-20649
+  - Accelerometer/Gyroscope: BMI088
+  - Magnetometer: RM3100
+  - Barometer: MS5611*2
+
+- **Interfaces**
+  - 14 PWM servo outputs
+  - Support multiple RC inputs (SBus / CPPM / DSM)
+  - Analog/PWM RSSI input
+  - 2 GPS ports (GPS and UART4 ports)
+  - 4 ⅹ I2C buses
+  - 2 ⅹ CAN bus ports
+  - 2 ⅹ Power ports
+  - 2 ⅹ ADC ports
+  - 1 ⅹ USB port
+
+- **Power**
+  - Power 4.3V ~ 5.4V
+  - USB Input 4.75V ~ 5.25V
+
+- **Size and Dimensions**
+  - 93.4mm x 46.4mm x 34.1mm
+  - 106g
+
+## Where to Buy
+
+[VOLOLAND CO., LTD](https://vololand.com "VOLOLAND CO., LTD")
+
+## Outline Dimensions
+
+![Outline Dimensions](./images/2.Outline_Dimensions.png "Outline Dimensions")
+
+## Wiring Diagram
+
+![Wire Diagram](./images/3.Wire_Diagram.png "Wire Diagram")
 
 ## GPIOs
 
@@ -209,24 +231,6 @@ The NarinFC-H7 has 2 analog inputs, one 6V tolerant and one 3.3V tolerant
 - ADC Pin6  -> RSSI_IN_ADC1(3.3V)
 - ADC Pin8  -> VDD_5V_SENS
 - ADC Pin11 -> SCALED_V3V3
-
-## Battery Monitoring
-
-The board has two dedicated power monitor ports on 6 pin connectors. The correct battery setting parameters are dependent on the type of power brick which is connected. By default, use of a CAN battery monitor is enabled.
-
-## RC Input
-
-The RCIN pin, which by default is mapped to a timer input, can be used for all ArduPilot supported unidirectional receiver protocols. Bi-directional protocols such as CRSF/ELRS and SRXL2 require a full UART connection. FPort, when connected to RCIN, will only provide RC without telemetry.
-
-To allow CRSF and embedded telemetry available in Fport, CRSF, and SRXL2 receivers, a full UART, such as SERIAL6 (UART7) would need to be used for receiver connections. Below are setups using Serial6.
-
-- [SERIAL6_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial6-protocol-serial6-protocol-selection) should be set to "23".
-- FPort would require [SERIAL6_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial6-options-serial6-options) be set to "15".
-- CRSF would require [SERIAL6_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial6-options-serial6-options) be set to "0".
-- SRXL2 would require [SERIAL6_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial6-options-serial6-options) be set to "4" and connects only the TX pin.
-
-Any UART can also be used for RC system connections in ArduPilot, and is compatible with all protocols except PPM. See [RC systems](https://ardupilot.org/copter/docs/common-rc-systems.html) for details.
-The power rail associated with this connector position is powered via USB or PMU.
 
 ## Loading Firmware
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/NarinFC-X3/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/NarinFC-X3/README.md
@@ -1,68 +1,8 @@
 # [NarinFC-X3 VOLOLAND Inc.](https://vololand.com/pages/product/computer "NarinFC-X3")
 
-## Introduction
 
-The NarinFC-X3 is a flight controller produced by [VOLOLAND Inc.](https://vololand.com "VOLOLAND Inc.")
 
-NarinFC-X3 is an advanced autopilot family designed in-house by VOLOLAND Inc.
-
-It uses a higher-performance STM32H7 processor and integrates industrial-grade sensors.
-
-Compared with previous autopilots, it has better performance and higher reliability.
-
-![NarinFC-X3](./images/NarinFC_X3_Introduction.png "NarinFC")
-
-## Features/Specifications
-
-- **Processor**
-  - STM32H743
-
-- **Sensors**
-  - Accelerometer/Gyroscope: ICM-42688-P X 2
-  - Barometer: DPS368XTSA1
-
-- **Interfaces**
-  - 12 x PWM servo outputs
-  - 1 ⅹ I2C buses
-  - 1 ⅹ CAN bus ports
-  - 5 ⅹ UART
-  - 1 ⅹ USB Type-C
-  - 1 ⅹ MicroSD card
-  - JST Connector (SH1.0)
-
-- **Power**
-  - Input Power 6VDC ~ 36VDC (2S ~ 8S)
-  - Output Power
-    - 3.3VDC 0.5A
-    - 5VDC 2.5A
-    - 9VDC 2.5A
-
-- **Size and Dimensions**
-  - 38mm x 38mm (mount hole 30.5mm x 30.5mm)
-  - 8g
-
-## Where to Buy
-
-[VOLOLAND Inc.](https://vololand.com "VOLOLAND Inc.")
-
-## Outline Dimensions
-
-![Outline Dimensions](./images/NarinFC_X3_Dimensions.png "Outline Dimensions")
-
-## UART Mapping
-
- UART corresponding to each SERIAL port, and its default protocol, are shown below:
-
-- SERIAL0 -> USB (MAVLink2)
-- SERIAL1 -> UART1 (RX1 is SBUS in HD VTX connector)
-- SERIAL2 -> UART2 (GPS, DMA-enabled)
-- SERIAL3 -> UART3 (DisplayPort, DMA-enabled)
-- SERIAL4 -> UART4 (MAVLink2, Telem1)
-- SERIAL6 -> UART6 (RC Input, DMA-enabled)
-- SERIAL7 -> UART7 (MAVLink2, Telem2, DMA and flow-control enabled)
-- SERIAL8 -> UART8 (ESC Telemetry, RX8 on ESC connector for telem)
-
-  Serial protocols can be adjusted to personal preferences.
+<!-- TODO: add Features content -->
 
 ## Pinout
 
@@ -138,22 +78,26 @@ UART7(SERIAL6) is labeled DEBUG RX/TX below
 - JST GH 6P connector
 - DEBUG NODMA
 
+## UART Mapping
+
+ UART corresponding to each SERIAL port, and its default protocol, are shown below:
+
+- SERIAL0 -> USB (MAVLink2)
+- SERIAL1 -> UART1 (RX1 is SBUS in HD VTX connector)
+- SERIAL2 -> UART2 (GPS, DMA-enabled)
+- SERIAL3 -> UART3 (DisplayPort, DMA-enabled)
+- SERIAL4 -> UART4 (MAVLink2, Telem1)
+- SERIAL6 -> UART6 (RC Input, DMA-enabled)
+- SERIAL7 -> UART7 (MAVLink2, Telem2, DMA and flow-control enabled)
+- SERIAL8 -> UART8 (ESC Telemetry, RX8 on ESC connector for telem)
+
+  Serial protocols can be adjusted to personal preferences.
+
 ## RC Input
 
 RC input is configured by default via the USART6 RX input. It supports all serial RC protocols except PPM.
 Note: If the receiver is FPort the receiver must be tied to the USART6 TX pin , RSSI_TYPE set to 3, and SERIAL6_OPTIONS must be set to 7 (invert TX/RX, half duplex). For full duplex like CRSF/ELRS use both RX6 and TX6 and set RSSI_TYPE also to 3.
 If SBUS is used on HD VTX connector (DJI TX), then SERIAL1_PROTOCOl should be set to “23” and SERIAL6_PROTOCOL changed to something else.
-
-## FrSky Telemetry
-
-FrSky Telemetry is supported using an unused UART, such as the T1 pin (UART1 transmit). You need to set the following parameters to enable support for FrSky S.PORT:
-
-- SERIAL1_PROTOCOL = 10
-- SERIAL1_OPTIONS = 7
-
-## OSD Support
-
-The NarinFC-X3 supports OSD using OSD_TYPE 1 (MAX7456 driver) and simultaneously DisplayPort using TX3/RX3 on the HD VTX connector.
 
 ## PWM Output
 
@@ -190,6 +134,66 @@ Pads for a second analog battery monitor are provided. To use:
 - BATT2_CURR_PIN = 7
 - BATT2_VOLT_MULT = 11.0
 - BATT2_AMP_PERVLT as required
+
+## Introduction
+
+The NarinFC-X3 is a flight controller produced by [VOLOLAND Inc.](https://vololand.com "VOLOLAND Inc.")
+
+NarinFC-X3 is an advanced autopilot family designed in-house by VOLOLAND Inc.
+
+It uses a higher-performance STM32H7 processor and integrates industrial-grade sensors.
+
+Compared with previous autopilots, it has better performance and higher reliability.
+
+![NarinFC-X3](./images/NarinFC_X3_Introduction.png "NarinFC")
+
+## Features/Specifications
+
+- **Processor**
+  - STM32H743
+
+- **Sensors**
+  - Accelerometer/Gyroscope: ICM-42688-P X 2
+  - Barometer: DPS368XTSA1
+
+- **Interfaces**
+  - 12 x PWM servo outputs
+  - 1 ⅹ I2C buses
+  - 1 ⅹ CAN bus ports
+  - 5 ⅹ UART
+  - 1 ⅹ USB Type-C
+  - 1 ⅹ MicroSD card
+  - JST Connector (SH1.0)
+
+- **Power**
+  - Input Power 6VDC ~ 36VDC (2S ~ 8S)
+  - Output Power
+    - 3.3VDC 0.5A
+    - 5VDC 2.5A
+    - 9VDC 2.5A
+
+- **Size and Dimensions**
+  - 38mm x 38mm (mount hole 30.5mm x 30.5mm)
+  - 8g
+
+## Where to Buy
+
+[VOLOLAND Inc.](https://vololand.com "VOLOLAND Inc.")
+
+## Outline Dimensions
+
+![Outline Dimensions](./images/NarinFC_X3_Dimensions.png "Outline Dimensions")
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using an unused UART, such as the T1 pin (UART1 transmit). You need to set the following parameters to enable support for FrSky S.PORT:
+
+- SERIAL1_PROTOCOL = 10
+- SERIAL1_OPTIONS = 7
+
+## OSD Support
+
+The NarinFC-X3 supports OSD using OSD_TYPE 1 (MAX7456 driver) and simultaneously DisplayPort using TX3/RX3 on the HD VTX connector.
 
 ## Analog RSSI and AIRSPEED inputs
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/NxtPX4v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/NxtPX4v2/README.md
@@ -15,6 +15,10 @@ The NxtPX4v2 is an open-source hardware designed and maintened by [HKUST UAV-Gro
 - 1x SPI
 - 1x SWD
 
+
+
+<!-- TODO: add Pinout content -->
+
 ## UART Mapping
 
 - SERIAL0 -> USB
@@ -29,10 +33,6 @@ The NxtPX4v2 is an open-source hardware designed and maintened by [HKUST UAV-Gro
 ## RC Input
 
 The default RC input is configured on the UART5. The SBUS pin is inverted and connected to RX5. Non SBUS,  single wire serial inputs can be directly tied to RX5 if SBUS pin is left unconnected. RC could  be applied instead at a different UART port such as UART2, UART4 or UART8, and set the protocol to receive RC data: `SERIALn_PROTOCOL=23` and change SERIAL6 _Protocol to something other than '23'
-
-## VTX Support
-
-The SH1.0-6P connector supports a DJI Air Unit / HD VTX connection. Protocol defaults to DisplayPort. Pin 1 of the connector is 12v so be careful not to connect this to a peripheral requiring 5v.
 
 ## PWM Output
 
@@ -58,6 +58,10 @@ The default battery parameters are:
 - BATT_CURR_PIN 8
 - BATT_VOLT_MULT 10.2
 - BATT_AMP_PERVLT 20.4
+
+## VTX Support
+
+The SH1.0-6P connector supports a DJI Air Unit / HD VTX connection. Protocol defaults to DisplayPort. Pin 1 of the connector is 12v so be careful not to connect this to a peripheral requiring 5v.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ORBITH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ORBITH743/README.md
@@ -5,6 +5,63 @@
 
 The above image and some content courtesy of [orbitteknoloji.com.tr](https://orbitteknoloji.com.tr/)
 
+
+
+
+<!-- TODO: add Features content -->
+<!-- TODO: add Pinout content -->
+
+## UART Mapping
+
+- `SERIAL0` = USB (MAVLink2)  
+- `SERIAL1` = UART1 (ESC Telemetry)  
+- `SERIAL2` = UART2 (USER)  
+- `SERIAL3` = UART3 (DJI HD Air Unit)  
+- `SERIAL4` = UART4 (VTX)  
+- `SERIAL5` = UART5 (RC Input)  
+- `SERIAL6` = UART6 (GPS)  
+- `SERIAL7` = UART7 (USER)  
+- `SERIAL8` = UART8 (USER)  
+
+All UARTs, except UART1, are DMA capable.
+
+> **Note:** Serial port protocols (Telem, GPS, etc.) can be adjusted based on personal preferences.
+
+## RC Input
+
+RC input is configured by default on `SERIAL5` (UART5). The 4V5 pin is powered by both USB and the onboard 5V BEC from the battery.
+
+- PPM is supported.  
+- SBUS/DSM/SRXL connects to the RX5 pin.  
+- FPort requires connection to TX5. Set [SERIAL5_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial5-options-serial5-options) = 7  
+- CRSF also requires both TX5 and RX5 connections and provides telemetry automatically.
+
+Any UART can be used for RC system connections in ArduPilot. See the [common RC systems](https://ardupilot.org) documentation for details.
+
+
+
+<!-- TODO: add PWM Output content -->
+
+## Battery Monitoring
+
+These are set by default. If reset:
+
+Enable battery monitor with `BATT_MONITOR=4`, then reboot, then set:
+
+**First battery monitor is enabled by default:**
+
+- BATT_VOLT_PIN = 10
+- BATT_CURR_PIN = 11
+- BATT_VOLT_MULT = 10.1
+- BATT_AMP_PERVLT = 80.0
+
+**The second battery monitor is not enabled by default, but its parameter defaults have been set:**
+
+- BATT2_VOLT_PIN = 4
+- BATT2_CURR_PIN = 18
+- BATT2_VOLT_MULT = 10.1
+- BATT2_AMP_PERVLT = 80.0
+
 ## Specifications
 
 ### **Processor**
@@ -45,33 +102,6 @@ The above image and some content courtesy of [orbitteknoloji.com.tr](https://orb
 ### **Mounting Hole**
 
 - 30.5 mm x 30.5 mm
-
-## UART Mapping
-
-- `SERIAL0` = USB (MAVLink2)  
-- `SERIAL1` = UART1 (ESC Telemetry)  
-- `SERIAL2` = UART2 (USER)  
-- `SERIAL3` = UART3 (DJI HD Air Unit)  
-- `SERIAL4` = UART4 (VTX)  
-- `SERIAL5` = UART5 (RC Input)  
-- `SERIAL6` = UART6 (GPS)  
-- `SERIAL7` = UART7 (USER)  
-- `SERIAL8` = UART8 (USER)  
-
-All UARTs, except UART1, are DMA capable.
-
-> **Note:** Serial port protocols (Telem, GPS, etc.) can be adjusted based on personal preferences.
-
-## RC Input
-
-RC input is configured by default on `SERIAL5` (UART5). The 4V5 pin is powered by both USB and the onboard 5V BEC from the battery.
-
-- PPM is supported.  
-- SBUS/DSM/SRXL connects to the RX5 pin.  
-- FPort requires connection to TX5. Set [SERIAL5_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial5-options-serial5-options) = 7  
-- CRSF also requires both TX5 and RX5 connections and provides telemetry automatically.
-
-Any UART can be used for RC system connections in ArduPilot. See the [common RC systems](https://ardupilot.org) documentation for details.
 
 ## RSSI
 
@@ -158,26 +188,6 @@ This board does **not** include GPS or compass modules. An [external GPS/compass
 > **Note:** If GPS is powered via 5V , a battery is required for power.
 <!-- -->
 > **Tip:** The 4V5 pin can power both RC and GPS for bench setup (without battery), as long as the total current does not exceed USB limits (typically 1A).
-
-## Battery Monitoring
-
-These are set by default. If reset:
-
-Enable battery monitor with `BATT_MONITOR=4`, then reboot, then set:
-
-**First battery monitor is enabled by default:**
-
-- BATT_VOLT_PIN = 10
-- BATT_CURR_PIN = 11
-- BATT_VOLT_MULT = 10.1
-- BATT_AMP_PERVLT = 80.0
-
-**The second battery monitor is not enabled by default, but its parameter defaults have been set:**
-
-- BATT2_VOLT_PIN = 4
-- BATT2_CURR_PIN = 18
-- BATT2_VOLT_MULT = 10.1
-- BATT2_AMP_PERVLT = 80.0
 
 ## Where to Buy
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/OrqaF405Pro/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/OrqaF405Pro/README.md
@@ -34,9 +34,6 @@ receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
 
 RC input is configured for GHST by default on the T1 (UART1_TX) pin using half-duplex. To support other RC protocols set SERIAL1_OPTIONS to 0. This will support all serial RC protocols except SBUS. For PPM and SBUS support on UART1_RX set BRD_ALT_CONFIG to 1.
   
-## OSD Support
-
-The Orqa FC 3030 F405 supports OSD using OSD_TYPE 1 (MAX7456 driver) or OSD_TYPE 3 if using DJI OSD
 
 ## PWM Output
 
@@ -66,6 +63,10 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN 12
 - BATT_VOLT_MULT 8.3
 - BATT_AMP_PERVLT 92.6
+
+## OSD Support
+
+The Orqa FC 3030 F405 supports OSD using OSD_TYPE 1 (MAX7456 driver) or OSD_TYPE 3 if using DJI OSD
 
 ## VTX Control
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/OrqaH7QuadCore/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/OrqaH7QuadCore/README.md
@@ -37,9 +37,6 @@ receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
 
 RC input is configured for half duplex protocls (GHST/SRXL2) by default on the T3 (UART3_TX) pin using half-duplex. To support other RC protocols set SERIAL1_OPTIONS to 0 and connect to R3/T3 as required (see [ArduPilot RC documentation](https://ardupilot.org/plane/docs/common-rc-systems.html)). This will support all serial RC protocols but not PPM.
   
-## OSD Support
-
-The Orqa FC 3030 H7 QuadCore supports OSD using OSD_TYPE 1 (MAX7456 driver). HD OSD and other ODSDs can be supported using a UART (see [ArduPilot Plane documentation](https://ardupilot.org/plane/docs/common-osd-boards-on-screen-display.html))
 
 ## PWM Output
 
@@ -71,6 +68,10 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN 12
 - BATT_VOLT_MULT 8.3
 - BATT_AMP_PERVLT 92.6
+
+## OSD Support
+
+The Orqa FC 3030 H7 QuadCore supports OSD using OSD_TYPE 1 (MAX7456 driver). HD OSD and other ODSDs can be supported using a UART (see [ArduPilot Plane documentation](https://ardupilot.org/plane/docs/common-osd-boards-on-screen-display.html))
 
 ## VTX Control
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PilotGaeaSH7V1-bdshot/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PilotGaeaSH7V1-bdshot/README.md
@@ -19,27 +19,9 @@ The PilotGaeaSH7V1-bdshot is a flight controller designed and produced by PilotG
 - 5V/1.5A BEC for main power supply
 - 8V/1.5A BEC for powering Video Transmitter
 
-## Mechanical
 
-- Dimensions: 36 x 36 x 17 mm
-- Weight: 10.5g
 
-## Physical and pinout
-
-![PilotGaeaSH7V1-bdshot front view](./PilotGaea_front_view_Pin.jpg)
-
-![PilotGaeaSH7V1-bdshot rear view](./PilotGaea_rear_view_Pin.jpg)
-
-## Power supply
-
-The PilotGaeaSH7V1-bdshot supports 3-8s Li battery input. It has 2 ways of BEC, which result in 3 ways of power supplies. Please see the table below.
-
-| Power symbol | Power source | Max power (current) |
-| :--- | :--- | :--- |
-| BAT | directly from battery | |
-| 5V | from 5V BEC | 7.5W (1.5A) |
-| 8V | from 8V BEC, controlled by MCU | 12W (1.5A) |
-| 4V5 | from USB or 5V BEC, diodes isolate the two powers | 4.7W (1A) |
+<!-- TODO: add Pinout content -->
 
 ## UART Mapping
 
@@ -66,6 +48,54 @@ RC input can be attached to any UART port. To reassign it:
 
 1. Set the target port protocol to RC input (e.g., `SERIALn_PROTOCOL` = 23).
 2. Change `SERIAL6_PROTOCOL` to a different protocol (e.g., -1 or 2) to avoid resource conflicts.
+
+
+
+<!-- TODO: add PWM Output content -->
+
+## Battery Monitoring
+
+The PilotGaeaSH7V1-bdshot features high-voltage monitoring capabilities, supporting up to 8S LiPo on both sensors. Notably, **BATT2** is optimized with a higher divider ratio for enhanced voltage range support.
+
+### Primary Battery (BATT)
+
+- `BATT_MONITOR`: **4** (Analog Voltage and Current)
+- `BATT_VOLT_PIN`: **10**
+- `BATT_CURR_PIN`: **11**
+- `BATT_VOLT_MULT`: **11.0**
+- `BATT_AMP_PERVLT`: **40.0**
+
+### Secondary Battery (BATT2)
+
+To enable the second monitor, set the parameters below and **reboot** the flight controller:
+
+- `BATT2_MONITOR`: **4**
+- `BATT2_VOLT_PIN`: **18**
+- `BATT2_CURR_PIN`: **7**
+- `BATT2_VOLT_MULT`: **21.0**
+- `BATT2_AMP_PERVLT`: **40.0**
+
+## Mechanical
+
+- Dimensions: 36 x 36 x 17 mm
+- Weight: 10.5g
+
+## Physical and pinout
+
+![PilotGaeaSH7V1-bdshot front view](./PilotGaea_front_view_Pin.jpg)
+
+![PilotGaeaSH7V1-bdshot rear view](./PilotGaea_rear_view_Pin.jpg)
+
+## Power supply
+
+The PilotGaeaSH7V1-bdshot supports 3-8s Li battery input. It has 2 ways of BEC, which result in 3 ways of power supplies. Please see the table below.
+
+| Power symbol | Power source | Max power (current) |
+| :--- | :--- | :--- |
+| BAT | directly from battery | |
+| 5V | from 5V BEC | 7.5W (1.5A) |
+| 8V | from 8V BEC, controlled by MCU | 12W (1.5A) |
+| 4V5 | from USB or 5V BEC, diodes isolate the two powers | 4.7W (1A) |
 
 ## OSD Support
 
@@ -99,28 +129,6 @@ To use BDShot for RPM filtering, you must flash the `PilotGaeaSH7V1-bdshot` firm
 > **Note:** **PWM 13 (Group 5)** supports DMA, but is pre-configured for Serial LED ( `NTF_LED_TYPES` = **455** ) in default parameters to support onboard status lighting.
 >
 > **Important:** Every output within a timer group must use the same protocol (e.g., Output 3 & 4 must both be DShot or PWM).
-
-## Battery Monitoring
-
-The PilotGaeaSH7V1-bdshot features high-voltage monitoring capabilities, supporting up to 8S LiPo on both sensors. Notably, **BATT2** is optimized with a higher divider ratio for enhanced voltage range support.
-
-### Primary Battery (BATT)
-
-- `BATT_MONITOR`: **4** (Analog Voltage and Current)
-- `BATT_VOLT_PIN`: **10**
-- `BATT_CURR_PIN`: **11**
-- `BATT_VOLT_MULT`: **11.0**
-- `BATT_AMP_PERVLT`: **40.0**
-
-### Secondary Battery (BATT2)
-
-To enable the second monitor, set the parameters below and **reboot** the flight controller:
-
-- `BATT2_MONITOR`: **4**
-- `BATT2_VOLT_PIN`: **18**
-- `BATT2_CURR_PIN`: **7**
-- `BATT2_VOLT_MULT`: **21.0**
-- `BATT2_AMP_PERVLT`: **40.0**
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixFlamingo-F767/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixFlamingo-F767/README.md
@@ -25,6 +25,60 @@ Contact dheeranlabs@gmail.com for sales
   - Buzzer port
   - USB-C port
 
+
+
+<!-- TODO: add Pinout content -->
+
+## UART Mapping
+
+The UARTs are marked Rn and Tn in the above pinouts. The Rn pin is the
+receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
+
+- SERIAL0 -> USB (OTG1)
+- SERIAL1 -> UART3 (TELEM1) with CTS/RTS DMA Enabled
+- SERIAL2 -> UART6 (TELEM2) with DMA Enabled
+- SERIAL3 -> UART1 (GPS1) Tx(NODMA), Rx(DMA Enabled)
+- SERIAL4 -> EMPTY
+- SERIAL5 -> UART7 (User) NODMA
+- SERIAL6 -> USART2 (User) NODMA
+
+## RC Input
+
+Supports I-Bus/S-bus
+
+Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM. See Radio Control Systems for details.
+
+## PWM Output
+
+The PixFlaminog-F767 supports up to 10 PWM outputs.
+
+The PWM is in 5 groups:
+
+- PWM 1-4 in group1
+- PWM 5-8 in group2
+- PWM 9 in group3
+- PWM 10 in group4
+
+## Battery Monitoring
+
+The board has voltage and current sensor inputs on the POWER_ADC connector.
+
+The correct battery setting parameters are:
+
+Enable Battery monitor.
+
+BATT_MONITOR =4
+
+Then reboot.
+
+BATT_VOLT_PIN 11
+
+BATT_CURR_PIN 10
+
+BATT_VOLT_MULT 10.1 (may need adjustment if supplied monitor is not used)
+
+BATT_AMP_PERVLT 17.0 (may need adjustment if supplied monitor is not used)
+
 ## Connectors
 
 ### POWER ADC
@@ -101,36 +155,6 @@ Contact dheeranlabs@gmail.com for sales
 |  4   |      BUZZER+     | +3.3V |
 |  5   |      BUZZER-     | GND   |
 
-## UART Mapping
-
-The UARTs are marked Rn and Tn in the above pinouts. The Rn pin is the
-receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
-
-- SERIAL0 -> USB (OTG1)
-- SERIAL1 -> UART3 (TELEM1) with CTS/RTS DMA Enabled
-- SERIAL2 -> UART6 (TELEM2) with DMA Enabled
-- SERIAL3 -> UART1 (GPS1) Tx(NODMA), Rx(DMA Enabled)
-- SERIAL4 -> EMPTY
-- SERIAL5 -> UART7 (User) NODMA
-- SERIAL6 -> USART2 (User) NODMA
-
-## RC Input
-
-Supports I-Bus/S-bus
-
-Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM. See Radio Control Systems for details.
-
-## PWM Output
-
-The PixFlaminog-F767 supports up to 10 PWM outputs.
-
-The PWM is in 5 groups:
-
-- PWM 1-4 in group1
-- PWM 5-8 in group2
-- PWM 9 in group3
-- PWM 10 in group4
-
 ## GPIOs
 
 All 10 PWM channels can be used for GPIO functions (relays, buttons, RPM etc).
@@ -155,26 +179,6 @@ The PixFlamingo-F767 flight controller has 4 analog inputs
 - ADC Pin11   -> Battery Voltage
 - ADC Pin14   -> ADC 3V3 Sense
 - ADC Pin15 -> ADC 6V6 Sense
-
-## Battery Monitoring
-
-The board has voltage and current sensor inputs on the POWER_ADC connector.
-
-The correct battery setting parameters are:
-
-Enable Battery monitor.
-
-BATT_MONITOR =4
-
-Then reboot.
-
-BATT_VOLT_PIN 11
-
-BATT_CURR_PIN 10
-
-BATT_VOLT_MULT 10.1 (may need adjustment if supplied monitor is not used)
-
-BATT_AMP_PERVLT 17.0 (may need adjustment if supplied monitor is not used)
 
 ## Build the FC
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-C3/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-C3/README.md
@@ -35,6 +35,52 @@ The PixPilot-C3 flight controller is sold by a range of resellers listed at [Mak
 - SERIAL4 -> UART8   (GPS2, DMA-enabled)
 - SERIAL5 -> UART7   (USER)
 
+## RC Input
+
+All compatible RC protocols can be decoded by attaching the Receiver's output to the SBUS input pin next to the Servo/Output VCC input connector. Note that some protocols such as CRSF or FPort including telemetry, require connection to, and setup of, one of the UARTs instead of this pin.
+
+## PWM Output
+
+The PixPilot-V3 supports up to 14 PWM outputs. First first 8 outputs (labelled S1 to S8) are controlled by a dedicated STM32F103 IO controller. These 8
+outputs support all PWM output formats, but not DShot.
+
+The remaining 6 outputs (labelled AUX1 to AUX6) are the "auxiliary"
+outputs. These are directly attached to the STM32F427 and support all
+PWM protocols as well as DShot.
+
+All 14 PWM outputs have GND on the top row, 5V on the middle row and
+signal on the bottom row.
+
+The 8 main PWM outputs are in 3 groups:
+
+- PWM 1 and 2 in group1
+- PWM 3 and 4 in group2
+- PWM 5, 6, 7 and 8 in group3
+
+The 6 auxiliary PWM outputs are in 2 groups:
+
+- PWM 1, 2, 3 and 4 in group1
+- PWM 5 and 6 in group2
+
+Channels within the same group need to use the same output rate. If
+any channel in a group uses DShot then all channels in the group need
+to use DShot.
+
+## Battery Monitoring
+
+These should already be set by default. However, if lost or changed:
+
+Enable Battery monitor with `BATT_MONITOR=4`, then reboot, then set:
+
+- BATT_VOLT_PIN = 2
+- BATT_CURR_PIN = 3
+- BATT_VOLT_MULT = 18.0
+- BATT_AMP_PERVLT = 24.0
+- BATT2_VOLT_PIN = 14
+- BATT2_CURR_PIN = 13
+- BATT2_VOLT_MULT = 18.0
+- BATT2_AMP_PERVLT = 24.0
+
 ## Connector pin assignments
 
 ### TELEM1, TELEM2 ports
@@ -110,52 +156,6 @@ The PixPilot-C3 flight controller is sold by a range of resellers listed at [Mak
 | 1 | VCC | +3.3V |
 | 2 | RX | +3.3V |
 | 3 | GND | GND |
-
-## RC Input
-
-All compatible RC protocols can be decoded by attaching the Receiver's output to the SBUS input pin next to the Servo/Output VCC input connector. Note that some protocols such as CRSF or FPort including telemetry, require connection to, and setup of, one of the UARTs instead of this pin.
-
-## PWM Output
-
-The PixPilot-V3 supports up to 14 PWM outputs. First first 8 outputs (labelled S1 to S8) are controlled by a dedicated STM32F103 IO controller. These 8
-outputs support all PWM output formats, but not DShot.
-
-The remaining 6 outputs (labelled AUX1 to AUX6) are the "auxiliary"
-outputs. These are directly attached to the STM32F427 and support all
-PWM protocols as well as DShot.
-
-All 14 PWM outputs have GND on the top row, 5V on the middle row and
-signal on the bottom row.
-
-The 8 main PWM outputs are in 3 groups:
-
-- PWM 1 and 2 in group1
-- PWM 3 and 4 in group2
-- PWM 5, 6, 7 and 8 in group3
-
-The 6 auxiliary PWM outputs are in 2 groups:
-
-- PWM 1, 2, 3 and 4 in group1
-- PWM 5 and 6 in group2
-
-Channels within the same group need to use the same output rate. If
-any channel in a group uses DShot then all channels in the group need
-to use DShot.
-
-## Battery Monitoring
-
-These should already be set by default. However, if lost or changed:
-
-Enable Battery monitor with `BATT_MONITOR=4`, then reboot, then set:
-
-- BATT_VOLT_PIN = 2
-- BATT_CURR_PIN = 3
-- BATT_VOLT_MULT = 18.0
-- BATT_AMP_PERVLT = 24.0
-- BATT2_VOLT_PIN = 14
-- BATT2_CURR_PIN = 13
-- BATT2_VOLT_MULT = 18.0
-- BATT2_AMP_PERVLT = 24.0
 
 ## DroneCAN capability
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-V3/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-V3/README.md
@@ -38,6 +38,52 @@ The PixPilot-V3 flight controller is sold by a range of resellers listed at [Mak
 - SERIAL4 -> UART8   (GPS2, DMA-enabled)
 - SERIAL5 -> UART7   (USER)
 
+## RC Input
+
+All compatible RC protocols can be decoded by attaching the Receiver's output to the SBUS input pin next to the Servo/Output VCC input connector. Note that some protocols such as CRSF or FPort including telemetry, require connection to, and setup of, one of the UARTs instead of this pin.
+
+## PWM Output
+
+The PixPilot-V3 supports up to 14 PWM outputs. First first 8 outputs (labelled S1 to S8) are controlled by a dedicated STM32F103 IO controller. These 8
+outputs support all PWM output formats, but not DShot.
+
+The remaining 6 outputs (labelled AUX1 to AUX6) are the "auxiliary"
+outputs. These are directly attached to the STM32F427 and support all
+PWM protocols as well as DShot.
+
+All 14 PWM outputs have GND on the top row, 5V on the middle row and
+signal on the bottom row.
+
+The 8 main PWM outputs are in 3 groups:
+
+- PWM 1 and 2 in group1
+- PWM 3 and 4 in group2
+- PWM 5, 6, 7 and 8 in group3
+
+The 6 auxiliary PWM outputs are in 2 groups:
+
+- PWM 1, 2, 3 and 4 in group1
+- PWM 5 and 6 in group2
+
+Channels within the same group need to use the same output rate. If
+any channel in a group uses DShot then all channels in the group need
+to use DShot.
+
+## Battery Monitoring
+
+These should already be set by default. However, if lost or changed:
+
+Enable Battery monitor with `BATT_MONITOR=4`, then reboot, then set:
+
+- BATT_VOLT_PIN = 2
+- BATT_CURR_PIN = 3
+- BATT_VOLT_MULT = 18.0
+- BATT_AMP_PERVLT = 24.0
+- BATT2_VOLT_PIN = 14
+- BATT2_CURR_PIN = 13
+- BATT2_VOLT_MULT = 18.0
+- BATT2_AMP_PERVLT = 24.0
+
 ## Connector pin assignments
 
 ### TELEM1, TELEM2 ports
@@ -108,52 +154,6 @@ The PixPilot-V3 flight controller is sold by a range of resellers listed at [Mak
 | 4 | VOLTAGE | +3.3V |
 | 5 | GND | GND |
 | 6 | GND | GND |
-
-## RC Input
-
-All compatible RC protocols can be decoded by attaching the Receiver's output to the SBUS input pin next to the Servo/Output VCC input connector. Note that some protocols such as CRSF or FPort including telemetry, require connection to, and setup of, one of the UARTs instead of this pin.
-
-## PWM Output
-
-The PixPilot-V3 supports up to 14 PWM outputs. First first 8 outputs (labelled S1 to S8) are controlled by a dedicated STM32F103 IO controller. These 8
-outputs support all PWM output formats, but not DShot.
-
-The remaining 6 outputs (labelled AUX1 to AUX6) are the "auxiliary"
-outputs. These are directly attached to the STM32F427 and support all
-PWM protocols as well as DShot.
-
-All 14 PWM outputs have GND on the top row, 5V on the middle row and
-signal on the bottom row.
-
-The 8 main PWM outputs are in 3 groups:
-
-- PWM 1 and 2 in group1
-- PWM 3 and 4 in group2
-- PWM 5, 6, 7 and 8 in group3
-
-The 6 auxiliary PWM outputs are in 2 groups:
-
-- PWM 1, 2, 3 and 4 in group1
-- PWM 5 and 6 in group2
-
-Channels within the same group need to use the same output rate. If
-any channel in a group uses DShot then all channels in the group need
-to use DShot.
-
-## Battery Monitoring
-
-These should already be set by default. However, if lost or changed:
-
-Enable Battery monitor with `BATT_MONITOR=4`, then reboot, then set:
-
-- BATT_VOLT_PIN = 2
-- BATT_CURR_PIN = 3
-- BATT_VOLT_MULT = 18.0
-- BATT_AMP_PERVLT = 24.0
-- BATT2_VOLT_PIN = 14
-- BATT2_CURR_PIN = 13
-- BATT2_VOLT_MULT = 18.0
-- BATT2_AMP_PERVLT = 24.0
 
 ## DroneCAN capability
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-V6/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-V6/README.md
@@ -38,6 +38,29 @@ The PixPilot-V6 flight controller is sold by a range of resellers listed at [Mak
 - SERIAL4 -> UART8   (GPS2)
 - SERIAL5 -> UART7   (USER)
 
+## RC Input
+
+All compatible RC protocols can be decoded by attaching the Receiver's output to the SBUS input pin next to the Servo/Output VCC input connector. Note that some protocols such as CRSF or FPort including telemetry, require connection to, and setup of, one of the UARTs instead of this pin.
+
+
+
+<!-- TODO: add PWM Output content -->
+
+## Battery Monitoring
+
+These should already be set by default. However, if lost or changed:
+
+Enable Battery monitor with `BATT_MONITOR=4`, then reboot, then set:
+
+- BATT_VOLT_PIN = 14
+- BATT_CURR_PIN = 15
+- BATT_VOLT_MULT = 18.0
+- BATT_AMP_PERVLT = 24.0
+- BATT2_VOLT_PIN = 13
+- BATT2_CURR_PIN = 4
+- BATT2_VOLT_MULT = 18.0
+- BATT2_AMP_PERVLT = 24.0
+
 ## Connector pin assignments
 
 ### TELEM1, TELEM2 ports
@@ -108,25 +131,6 @@ The PixPilot-V6 flight controller is sold by a range of resellers listed at [Mak
 | 4 | VOLTAGE | +3.3V |
 | 5 | GND | GND |
 | 6 | GND | GND |
-
-## RC Input
-
-All compatible RC protocols can be decoded by attaching the Receiver's output to the SBUS input pin next to the Servo/Output VCC input connector. Note that some protocols such as CRSF or FPort including telemetry, require connection to, and setup of, one of the UARTs instead of this pin.
-
-## Battery Monitoring
-
-These should already be set by default. However, if lost or changed:
-
-Enable Battery monitor with `BATT_MONITOR=4`, then reboot, then set:
-
-- BATT_VOLT_PIN = 14
-- BATT_CURR_PIN = 15
-- BATT_VOLT_MULT = 18.0
-- BATT_AMP_PERVLT = 24.0
-- BATT2_VOLT_PIN = 13
-- BATT2_CURR_PIN = 4
-- BATT2_VOLT_MULT = 18.0
-- BATT2_AMP_PERVLT = 24.0
 
 ## DroneCAN capability
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-V6PRO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-V6PRO/README.md
@@ -24,10 +24,9 @@ The PixPilot-V6PRO flight controller is sold by a range of resellers listed at [
 - servo rail BEC independent power input for servos
 - external safety Switch
 
-## Picture
 
-![PixPilot-V6PRO](PixPilot-V6Pro-1.png "PixPilot-V6Pro-1")
-![PixPilot-V6PRO](PixPilot-V6Pro-2.png "PixPilot-V6Pro-2")
+
+<!-- TODO: add Pinout content -->
 
 ## UART Mapping
 
@@ -37,6 +36,34 @@ The PixPilot-V6PRO flight controller is sold by a range of resellers listed at [
 - SERIAL3 -> UART4 (GPS1) (TX is DMA capable)
 - SERIAL4 -> UART8 (GPS2) (RX is DMA capable)
 - SERIAL5 -> UART7   (USER)
+
+## RC Input
+
+All compatible RC protocols can be decoded by attaching the Receiver's output to the SBUS input pin next to the Servo/Output VCC input connector. Note that some protocols such as CRSF or FPort including telemetry, require connection to, and setup of, one of the UARTs instead of this pin.
+
+
+
+<!-- TODO: add PWM Output content -->
+
+## Battery Monitoring
+
+These should already be set by default. However, if lost or changed:
+
+Enable Battery monitor with `BATT_MONITOR=4`, then reboot, then set:
+
+- BATT_VOLT_PIN = 14
+- BATT_CURR_PIN = 15
+- BATT_VOLT_MULT = 18.0
+- BATT_AMP_PERVLT = 24.0
+- BATT2_VOLT_PIN = 13
+- BATT2_CURR_PIN = 4
+- BATT2_VOLT_MULT = 18.0
+- BATT2_AMP_PERVLT = 24.0
+
+## Picture
+
+![PixPilot-V6PRO](PixPilot-V6Pro-1.png "PixPilot-V6Pro-1")
+![PixPilot-V6PRO](PixPilot-V6Pro-2.png "PixPilot-V6Pro-2")
 
 ## Connector pin assignments
 
@@ -124,25 +151,6 @@ The PixPilot-V6PRO flight controller is sold by a range of resellers listed at [
 | 4 | VOLTAGE | +3.3V |
 | 5 | GND | GND |
 | 6 | GND | GND |
-
-## RC Input
-
-All compatible RC protocols can be decoded by attaching the Receiver's output to the SBUS input pin next to the Servo/Output VCC input connector. Note that some protocols such as CRSF or FPort including telemetry, require connection to, and setup of, one of the UARTs instead of this pin.
-
-## Battery Monitoring
-
-These should already be set by default. However, if lost or changed:
-
-Enable Battery monitor with `BATT_MONITOR=4`, then reboot, then set:
-
-- BATT_VOLT_PIN = 14
-- BATT_CURR_PIN = 15
-- BATT_VOLT_MULT = 18.0
-- BATT_AMP_PERVLT = 24.0
-- BATT2_VOLT_PIN = 13
-- BATT2_CURR_PIN = 4
-- BATT2_VOLT_MULT = 18.0
-- BATT2_AMP_PERVLT = 24.0
 
 ## DroneCAN capability
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixSurveyA1-IND/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixSurveyA1-IND/README.md
@@ -37,6 +37,49 @@ The PixSurveyA1-IND flight controller is an upgrade to PixSurveyA1, with better 
 - SERIAL4 -> UART8   (GPS2, DMA-enabled)
 - SERIAL5 -> UART7   (USER)
 
+## RC Input
+
+All compatible RC protocols can be decoded by attaching the Receiver's output to the SBUS input pin next to the Servo/Output VCC input connector. Note that some protocols such as CRSF or FPort including telemetry, require connection to, and setup of, one of the UARTs instead of this pin.
+
+## PWM Output
+
+The PixSurveyA1-IND supports up to 14 PWM outputs. First first 8 outputs (labelled 1 to 8) are controlled by a dedicated STM32F103 IO controller. These 8
+outputs support all PWM output formats, but not DShot.
+
+The remaining 6 outputs (labelled 9 to 14) are the "auxiliary"
+outputs. These are directly attached to the STM32F427 and support all
+PWM protocols as well as DShot.
+
+The 8 main PWM outputs are in 3 groups:
+
+- PWM 1 and 2 in group1
+- PWM 3 and 4 in group2
+- PWM 5, 6, 7 and 8 in group3
+
+The 6 auxiliary PWM outputs are in 2 groups:
+
+- PWM 1, 2, 3 and 4 in group1
+- PWM 5 and 6 in group2
+
+Channels within the same group need to use the same output rate. If
+any channel in a group uses DShot then all channels in the group need
+to use DShot.
+
+## Battery Monitoring
+
+These should already be set by default. However, if lost or changed:
+
+Enable Battery monitor with `BATT_MONITOR=4`, then reboot, then set:
+
+- BATT_VOLT_PIN = 2
+- BATT_CURR_PIN = 3
+- BATT_VOLT_MULT = 18.0
+- BATT_AMP_PERVLT = 24.0
+- BATT2_VOLT_PIN = 14
+- BATT2_CURR_PIN = 13
+- BATT2_VOLT_MULT = 18.0
+- BATT2_AMP_PERVLT = 24.0
+
 ## Connector pin assignments
 
 ### TELEM1, TELEM2 ports
@@ -121,52 +164,9 @@ The PixSurveyA1-IND flight controller is an upgrade to PixSurveyA1, with better 
 | 2 | NC | NC |
 | 3 | GND | GND |
 
-## RC Input
-
-All compatible RC protocols can be decoded by attaching the Receiver's output to the SBUS input pin next to the Servo/Output VCC input connector. Note that some protocols such as CRSF or FPort including telemetry, require connection to, and setup of, one of the UARTs instead of this pin.
-
 ## Compass
 
 The PixSurveyA1-IND has a built-in compass. Due to potential interference, the autopilot is usually used with an external I2C compass as part of a GPS/Compass combination.
-
-## PWM Output
-
-The PixSurveyA1-IND supports up to 14 PWM outputs. First first 8 outputs (labelled 1 to 8) are controlled by a dedicated STM32F103 IO controller. These 8
-outputs support all PWM output formats, but not DShot.
-
-The remaining 6 outputs (labelled 9 to 14) are the "auxiliary"
-outputs. These are directly attached to the STM32F427 and support all
-PWM protocols as well as DShot.
-
-The 8 main PWM outputs are in 3 groups:
-
-- PWM 1 and 2 in group1
-- PWM 3 and 4 in group2
-- PWM 5, 6, 7 and 8 in group3
-
-The 6 auxiliary PWM outputs are in 2 groups:
-
-- PWM 1, 2, 3 and 4 in group1
-- PWM 5 and 6 in group2
-
-Channels within the same group need to use the same output rate. If
-any channel in a group uses DShot then all channels in the group need
-to use DShot.
-
-## Battery Monitoring
-
-These should already be set by default. However, if lost or changed:
-
-Enable Battery monitor with `BATT_MONITOR=4`, then reboot, then set:
-
-- BATT_VOLT_PIN = 2
-- BATT_CURR_PIN = 3
-- BATT_VOLT_MULT = 18.0
-- BATT_AMP_PERVLT = 24.0
-- BATT2_VOLT_PIN = 14
-- BATT2_CURR_PIN = 13
-- BATT2_VOLT_MULT = 18.0
-- BATT2_AMP_PERVLT = 24.0
 
 ## DroneCAN capability
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixSurveyA1/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixSurveyA1/README.md
@@ -21,3 +21,12 @@ The flight controller is based on FMUv3, with added MPU9250 or ICM20948 internal
 - two voltage & current monitoring and servo rail voltage monitoring
 - servo rail BEC independent power input for servos
 - external safety Switch
+
+
+
+
+<!-- TODO: add Pinout content -->
+<!-- TODO: add UART Mapping content -->
+<!-- TODO: add RC Input content -->
+<!-- TODO: add PWM Output content -->
+<!-- TODO: add Battery Monitoring content -->

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixSurveyA2-IND/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixSurveyA2-IND/README.md
@@ -23,10 +23,6 @@ The PixSurveyA2-IND flight controller is sold by a range of resellers listed at 
 - Independent power input for servo rail BEC
 - External safety Switch
 
-## Where to Buy
-
-[makeflyeasy](http://www.makeflyeasy.com)
-
 ## Pinout
 
 ![PixSurveyA2-IND](PixSurveyA2-IND-1.png "PixSurveyA2-IND-1")
@@ -39,6 +35,50 @@ The PixSurveyA2-IND flight controller is sold by a range of resellers listed at 
 - SERIAL3 -> UART4 (GPS1) (TX is DMA capable)
 - SERIAL4 -> UART8 (GPS2) (RX is DMA capable)
 - SERIAL5 -> UART7 (USER)
+
+## RC Input
+
+All compatible unidirectional RC protocols can be decoded by attaching the Receiver's output to the SBUS input pin next to the Servo/Output VCC input connector.
+
+To allow CRSF and embedded telemetry available in Fport, CRSF, and SRXL2 receivers, a full UART with DMA, such as SERIAL2 would need to be used for receiver connections. Below are setups using Serial6.
+
+- [SERIAL2_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial2-protocol-telemetry-2-protocol-selection) should be set to "23".
+- FPort would require [SERIAL2_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial2-options-telem2-options) be set to "15".
+- CRSF/ELRS would require [SERIAL2_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial2-options-telem2-options) be set to "0".
+- SRXL2 would require [SERIAL2_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial2-options-telem2-options) be set to "4" and connects only the TX pin.
+
+## PWM Output
+
+The autopilot supports up to 14 PWM outputs. All 14 outputs
+support all normal PWM output formats. All outputs also support DShot. Outputs 9-14 support Bi-Directional DShot. Outputs within the same timer group need to use the same output rate. If any output in a group uses DShot then all channels in the group need to use DShot,etc..
+
+- Outputs 1 and 2 in group1
+- Outputs 3 and 4 in group2
+- Outputs 5, 6, 7 and 8 in group3
+- Outputs 9-12 in group4
+- Outputs 13 and 14 in group5
+
+## Battery Monitoring
+
+These should already be set by default. However, if lost or changed:
+
+Enable Battery monitor with these parameter settings :
+
+- [BATT_MONITOR](https://ardupilot.org/copter/docs/parameters.html#batt-monitor-battery-monitoring) 8
+- [BATT2_MONITOR](https://ardupilot.org/copter/docs/parameters.html#batt2-monitor-battery-monitoring) 4
+
+Then reboot.
+
+- [BATT2_VOLT_PIN](https://ardupilot.org/copter/docs/parameters.html#batt2-volt-pin-ap-battmonitor-analog-battery-voltage-sensing-pin) 13
+- [BATT2_CURR_PIN](https://ardupilot.org/copter/docs/parameters.html#batt2-curr-pin-ap-battmonitor-analog-battery-current-sensing-pin) 4
+- [BATT2_VOLT_MULT](https://ardupilot.org/copter/docs/parameters.html#batt2-volt-mult-ap-battmonitor-analog-voltage-multiplier) 18.0
+- [BATT2_AMP_PERVLT](https://ardupilot.org/copter/docs/parameters.html#batt2-amp-pervlt-ap-battmonitor-analog-amps-per-volt) 24.0
+
+> **Note:** OSDs will by default display the first battery monitor unless the second battery monitor panel is setup in OSD parameters.
+
+## Where to Buy
+
+[makeflyeasy](http://www.makeflyeasy.com)
 
 ## Connectors
 
@@ -119,28 +159,6 @@ The PixSurveyA2-IND flight controller is sold by a range of resellers listed at 
 | 5 | GND | GND |
 | 6 | GND | GND |
 
-## RC Input
-
-All compatible unidirectional RC protocols can be decoded by attaching the Receiver's output to the SBUS input pin next to the Servo/Output VCC input connector.
-
-To allow CRSF and embedded telemetry available in Fport, CRSF, and SRXL2 receivers, a full UART with DMA, such as SERIAL2 would need to be used for receiver connections. Below are setups using Serial6.
-
-- [SERIAL2_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial2-protocol-telemetry-2-protocol-selection) should be set to "23".
-- FPort would require [SERIAL2_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial2-options-telem2-options) be set to "15".
-- CRSF/ELRS would require [SERIAL2_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial2-options-telem2-options) be set to "0".
-- SRXL2 would require [SERIAL2_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial2-options-telem2-options) be set to "4" and connects only the TX pin.
-
-## PWM Output
-
-The autopilot supports up to 14 PWM outputs. All 14 outputs
-support all normal PWM output formats. All outputs also support DShot. Outputs 9-14 support Bi-Directional DShot. Outputs within the same timer group need to use the same output rate. If any output in a group uses DShot then all channels in the group need to use DShot,etc..
-
-- Outputs 1 and 2 in group1
-- Outputs 3 and 4 in group2
-- Outputs 5, 6, 7 and 8 in group3
-- Outputs 9-12 in group4
-- Outputs 13 and 14 in group5
-
 ## GPIOs
 
 All PWM outputs can be used as GPIOs (relays, camera, RPM etc). To use them you need to set the output’s `SERVOx_FUNCTION` to -1. The numbering of the GPIOs for PIN variables in ArduPilot is:
@@ -168,24 +186,6 @@ All PWM outputs can be used as GPIOs (relays, camera, RPM etc). To use them you 
 |  |  | M8 |
 | 108 | Out8 |  |
 |  |  |  |
-
-## Battery Monitoring
-
-These should already be set by default. However, if lost or changed:
-
-Enable Battery monitor with these parameter settings :
-
-- [BATT_MONITOR](https://ardupilot.org/copter/docs/parameters.html#batt-monitor-battery-monitoring) 8
-- [BATT2_MONITOR](https://ardupilot.org/copter/docs/parameters.html#batt2-monitor-battery-monitoring) 4
-
-Then reboot.
-
-- [BATT2_VOLT_PIN](https://ardupilot.org/copter/docs/parameters.html#batt2-volt-pin-ap-battmonitor-analog-battery-voltage-sensing-pin) 13
-- [BATT2_CURR_PIN](https://ardupilot.org/copter/docs/parameters.html#batt2-curr-pin-ap-battmonitor-analog-battery-current-sensing-pin) 4
-- [BATT2_VOLT_MULT](https://ardupilot.org/copter/docs/parameters.html#batt2-volt-mult-ap-battmonitor-analog-voltage-multiplier) 18.0
-- [BATT2_AMP_PERVLT](https://ardupilot.org/copter/docs/parameters.html#batt2-amp-pervlt-ap-battmonitor-analog-amps-per-volt) 24.0
-
-> **Note:** OSDs will by default display the first battery monitor unless the second battery monitor panel is setup in OSD parameters.
 
 ## DroneCAN capability
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk1/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk1/README.md
@@ -43,6 +43,45 @@ The GPS2/spare port (labelled serial5) has two UARTs on one 6 pin
 connector. The spare port was originally used as a debug console, but
 debug is now on USB, so this port is free for any UART protocol.
 
+## RC Input
+
+RC input is configured on the RCIN pin, at one end of the servo rail,
+marked PPM in the above diagram. This pin supports all RC
+protocols. In addition there is a dedicated Spektrum satellite port
+which supports software power control, allowing for binding of
+Spektrum satellite receivers.
+
+## PWM Output
+
+The Pixhawk1 supports up to 14 PWM outputs. First first 8 outputs (labelled
+"MAIN") are controlled by a dedicated STM32F100 IO controller. These 8
+outputs support all PWM output formats, but not DShot.
+
+The remaining 6 outputs (labelled AUX1 to AUX6) are the "auxiliary"
+outputs. These are directly attached to the STM32F427 and support all
+PWM protocols as well as DShot.
+
+The 8 main PWM outputs are in 3 groups:
+
+- PWM 1 and 2 in group1
+- PWM 3 and 4 in group2
+- PWM 5, 6, 7 and 8 in group3
+
+The 6 auxiliary PWM outputs are in 2 groups:
+
+- PWM 1, 2, 3 and 4 in group1
+- PWM 5 and 6 in group2
+
+Channels within the same group need to use the same output rate. If
+any channel in a group uses DShot then all channels in the group need
+to use DShot.
+
+## Battery Monitoring
+
+The board has a dedicated power monitor port on a 6 pin DF13
+connector. The correct battery setting parameters are dependent on the
+type of power brick which is connected.
+
 ## Connectors
 
 The original Pixhawk1 uses DF13 connectors, and has 14 ports
@@ -146,45 +185,6 @@ The original Pixhawk1 uses DF13 connectors, and has 14 ports
 | 1 (red) | VCC | +3.3V |
 | 2 (blk) | !IO_LED_SAFETY | GND |
 | 3 (blk) | SAFETY | GND |
-
-## RC Input
-
-RC input is configured on the RCIN pin, at one end of the servo rail,
-marked PPM in the above diagram. This pin supports all RC
-protocols. In addition there is a dedicated Spektrum satellite port
-which supports software power control, allowing for binding of
-Spektrum satellite receivers.
-
-## PWM Output
-
-The Pixhawk1 supports up to 14 PWM outputs. First first 8 outputs (labelled
-"MAIN") are controlled by a dedicated STM32F100 IO controller. These 8
-outputs support all PWM output formats, but not DShot.
-
-The remaining 6 outputs (labelled AUX1 to AUX6) are the "auxiliary"
-outputs. These are directly attached to the STM32F427 and support all
-PWM protocols as well as DShot.
-
-The 8 main PWM outputs are in 3 groups:
-
-- PWM 1 and 2 in group1
-- PWM 3 and 4 in group2
-- PWM 5, 6, 7 and 8 in group3
-
-The 6 auxiliary PWM outputs are in 2 groups:
-
-- PWM 1, 2, 3 and 4 in group1
-- PWM 5 and 6 in group2
-
-Channels within the same group need to use the same output rate. If
-any channel in a group uses DShot then all channels in the group need
-to use DShot.
-
-## Battery Monitoring
-
-The board has a dedicated power monitor port on a 6 pin DF13
-connector. The correct battery setting parameters are dependent on the
-type of power brick which is connected.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixracer/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixracer/README.md
@@ -40,6 +40,38 @@ The [full schematics](https://github.com/ArduPilot/Schematics/tree/master/mRobot
 The Telem1 and Telem2 ports have RTS/CTS pins, the other UARTs do not
 have RTS/CTS.
 
+## RC Input
+
+RC input is via a RC input cable. That cable comes in two forms, one
+for Spektrum satellite receivers and another for all other receiver
+types.
+
+Both cables support all protocols with ArduPilot, but you need to use
+the Spektrum cable if you want to be able to bind the receiver using
+the ArduPilot binding support as only the Spektrum cable gives
+ArduPilot the ability to control the power on the Spektrum satellite
+receiver.
+
+## PWM Output
+
+The Pixracer supports up to 6 PWM outputs. All 6 outputs can support
+DShot as well as all PWM protocols.
+
+The 6 PWM outputs are in 2 groups:
+
+- PWM 1, 2, 3 and 4 in group1
+- PWM 5 and 6 in group2
+
+Channels within the same group need to use the same output rate. If
+any channel in a group uses DShot then all channels in the group need
+to use DShot.
+
+## Battery Monitoring
+
+The board has a dedicated power monitor port on a 6 pin connector. The
+correct battery setting parameters are dependent on the type of power
+brick which is connected.
+
 ## Connectors
 
 Unless noted otherwise all connectors are JST GH
@@ -133,18 +165,6 @@ purpose UART.
 | 5 (blk) | SWCLK | +3.3V |
 | 6 (blk) | GND | GND |
 
-## RC Input
-
-RC input is via a RC input cable. That cable comes in two forms, one
-for Spektrum satellite receivers and another for all other receiver
-types.
-
-Both cables support all protocols with ArduPilot, but you need to use
-the Spektrum cable if you want to be able to bind the receiver using
-the ArduPilot binding support as only the Spektrum cable gives
-ArduPilot the ability to control the power on the Spektrum satellite
-receiver.
-
 ## FrSky Telemetry
 
 FrSky Telemetry is supported using SERIAL4, on the port marked as
@@ -155,26 +175,6 @@ port to the FrSky S.Port pin on your receiver.
 
 - SERIAL4_PROTOCOL 10
 - SERIAL4_OPTIONS 0
-
-## PWM Output
-
-The Pixracer supports up to 6 PWM outputs. All 6 outputs can support
-DShot as well as all PWM protocols.
-
-The 6 PWM outputs are in 2 groups:
-
-- PWM 1, 2, 3 and 4 in group1
-- PWM 5 and 6 in group2
-
-Channels within the same group need to use the same output rate. If
-any channel in a group uses DShot then all channels in the group need
-to use DShot.
-
-## Battery Monitoring
-
-The board has a dedicated power monitor port on a 6 pin connector. The
-correct battery setting parameters are dependent on the type of power
-brick which is connected.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PrincipIoTH7Pi/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PrincipIoTH7Pi/README.md
@@ -6,49 +6,9 @@ Raspberry Pi Zero 2 for low cost onboard computing applications.
 
 ![PrincipIoT H7 Pi](H7-Pi-board-image.jpg)
 
-## Where to Buy
 
-[PrincipIoT Website](https://principiot.com>)
 
-## Specifications
-
-- Processor
-
-  - STM32H743 32-bit processor, 480Mhz
-  - 2MB Flash
-  - 1MB RAM
-
-- Sensors
-
-  - Invensense ICM-42688P
-  - Invensense IIM-42653
-  - Infineon DPS368 Barometer
-  - ST IIS2MDC Magnetometer
-
-- Interfaces
-
-  - Micro SD card
-  - USB-C
-  - 9 PWM (6 motors, 2 servos, and LED strip)
-  - 6 UARTS, one shared with the Raspberry Pi
-  - CAN
-  - ESC Connector with current sense and telemetry inputs
-  - VTX Connector with UART and analog video from the Raspberry Pi
-  - Debug port
-
-- Power
-
-  - Integrated voltage/current power monitor 11V - 30V (3S - 6S) input
-  - 10V GPIO controlled Video power BEC, 2A output
-  - 5V, 2A output for board, Raspberry Pi, and peripherals
-
-- Dimensions
-
-  - Size: 65 x 30 x 9 mm (20mm high with Raspberry Pi installed)
-  - Weight: 11.3g with MicroSD card
-
-For more information, see the
-[PrincipIoT Wiki](https://principiot.gitbook.io/principiot-docs/h7-pi/).
+<!-- TODO: add Features content -->
 
 ## Pinout
 
@@ -110,6 +70,64 @@ All outputs are directly wired to the H743 MCU. All 8 outputs support normal
 PWM output formats. All outputs support DShot, outputs 1-6 support
 Bi-Directional DShot.
 
+## Battery Monitoring
+
+The board has a internal voltage sensor and connections on the ESC connector
+for an external current sensor input.
+The voltage sensor can handle up to 6S LiPo batteries.
+
+The default battery parameters are:
+
+- [BATT_MONITOR](https://ardupilot.org/copter/docs/parameters.html#batt-monitor-battery-monitoring) = 4
+- [BATT_VOLT_PIN](https://ardupilot.org/copter/docs/parameters.html#batt-volt-pin-ap-battmonitor-analog-battery-voltage-sensing-pin) = 10
+- [BATT_CURR_PIN](https://ardupilot.org/copter/docs/parameters.html#batt-curr-pin-ap-battmonitor-analog-battery-current-sensing-pin) = 11 (CURR pin)
+- [BATT_VOLT_MULT](https://ardupilot.org/copter/docs/parameters.html#batt-volt-mult-ap-battmonitor-analog-voltage-multiplier) = 11.0
+- [BATT_AMP_PERVLT](https://ardupilot.org/copter/docs/parameters.html#batt-amp-pervlt-ap-battmonitor-analog-amps-per-volt) = 40
+
+## Where to Buy
+
+[PrincipIoT Website](https://principiot.com>)
+
+## Specifications
+
+- Processor
+
+  - STM32H743 32-bit processor, 480Mhz
+  - 2MB Flash
+  - 1MB RAM
+
+- Sensors
+
+  - Invensense ICM-42688P
+  - Invensense IIM-42653
+  - Infineon DPS368 Barometer
+  - ST IIS2MDC Magnetometer
+
+- Interfaces
+
+  - Micro SD card
+  - USB-C
+  - 9 PWM (6 motors, 2 servos, and LED strip)
+  - 6 UARTS, one shared with the Raspberry Pi
+  - CAN
+  - ESC Connector with current sense and telemetry inputs
+  - VTX Connector with UART and analog video from the Raspberry Pi
+  - Debug port
+
+- Power
+
+  - Integrated voltage/current power monitor 11V - 30V (3S - 6S) input
+  - 10V GPIO controlled Video power BEC, 2A output
+  - 5V, 2A output for board, Raspberry Pi, and peripherals
+
+- Dimensions
+
+  - Size: 65 x 30 x 9 mm (20mm high with Raspberry Pi installed)
+  - Weight: 11.3g with MicroSD card
+
+For more information, see the
+[PrincipIoT Wiki](https://principiot.gitbook.io/principiot-docs/h7-pi/).
+
 ## Analog Video and OSD Support
 
 The Raspberry Pi Zero 2 support analog video output through a pad on its PCB.
@@ -158,20 +176,6 @@ model or desolder the onboard one.
 |USER SW       | 82         |GPIO Switch     |
 |LED0          | 90         |Blue LED        |
 |LED1          | 91         |Green LED       |
-
-## Battery Monitoring
-
-The board has a internal voltage sensor and connections on the ESC connector
-for an external current sensor input.
-The voltage sensor can handle up to 6S LiPo batteries.
-
-The default battery parameters are:
-
-- [BATT_MONITOR](https://ardupilot.org/copter/docs/parameters.html#batt-monitor-battery-monitoring) = 4
-- [BATT_VOLT_PIN](https://ardupilot.org/copter/docs/parameters.html#batt-volt-pin-ap-battmonitor-analog-battery-voltage-sensing-pin) = 10
-- [BATT_CURR_PIN](https://ardupilot.org/copter/docs/parameters.html#batt-curr-pin-ap-battmonitor-analog-battery-current-sensing-pin) = 11 (CURR pin)
-- [BATT_VOLT_MULT](https://ardupilot.org/copter/docs/parameters.html#batt-volt-mult-ap-battmonitor-analog-voltage-multiplier) = 11.0
-- [BATT_AMP_PERVLT](https://ardupilot.org/copter/docs/parameters.html#batt-amp-pervlt-ap-battmonitor-analog-amps-per-volt) = 40
 
 ## Firmware
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/QioTekAdeptF407/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/QioTekAdeptF407/README.md
@@ -29,6 +29,57 @@ It is an autopilot used CKS MCU.
 
 ![QioTek AdeptF407 Board](../QioTekAdeptF407/adept_f407.jpg "QioTek AdeptF407")
 
+## UART Mapping
+
+The UARTs are marked Rn and Tn in the above pinouts. The Rn pin is the
+receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
+|Name|Pin|Function|
+|:-|:-|:-|
+|SERIAL0|OTG1|USB|
+|SERIAL1|TX6/RX6|UART1 (Telem1)|
+|SERIAL2|TX3/RX3|UART2 (Telem2 buadrate 921600)|
+|SERIAL3|TX1/RX1|UART3 (GNSS)|
+|SERIAL4|TX4/RX4|UART4 (Reserve for GNSS2)|
+|SERIAL5|TX2/RX2|UART5 (Debug)|
+
+## RC Input
+
+RC input is configured on the RCIN pin by PA15 TIM2_CH1 TIM2 , at one end of the servo rail, marked RC in the above diagram. This pin supports PPM and S.Bus. protocols.
+
+## PWM Output
+
+The QioTek AdeptF407 AIO supports up to 12 PWM outputs. All 14 PWM outputs have GND on the top row, 5V on the middle row and signal on the bottom row.
+
+The 12 PWM outputs are in 3 groups:
+
+- PWM 1 and 4 in group1
+- PWM 4 and 8 in group2
+- PWM 9 and 12 in group3
+
+Channels within the same group need to use the same output rate. If any channel in a group uses DShot or then all channels in the group need to use DShot.
+
+## Battery Monitoring
+
+The board has two dedicated power monitor ports on 6 pin connectors. The correct battery setting parameters are dependent on the type of power brick which is connected.
+
+The correct battery setting parameters are:
+
+- BATT_VOLT_PIN 2
+- BATT_CURR_PIN 3
+- BATT_VOLT_MULT 20.000
+- BATT_AMP_PERVLT 60.000
+- BATT2_VOLT_PIN 14
+- BATT2_CURR_PIN 15
+- BATT2_VOLT_MULT 20.000
+- BATT2_AMP_PERVLT 60.000
+
+In addition, the builtin voltage divider circuit can be used by Solder pad to switching to share the battery voltage monitoring by power2 support to 6S.
+
+If you want to use the built-in voltage monitor on power 1, you can manually invert the `BATT_VOLT_PIN` to 14, `BATT_CURR_PIN` to 15, `BATT2_VOLT_PIN` to 2, `BATT2_CURR_PIN` to 3.
+
+**Built-in BEC**
+The built-in BEC 5V output has a starting voltage of 2S, and 9V/12V has a starting voltage of 3S/4S respectively.
+
 ## Connectors
 
 ### External USB
@@ -145,64 +196,13 @@ It is an autopilot used CKS MCU.
 |  1   |  Battery_VCC    | MAX 30V |
 |  2   |  Battery_GND    |   GND   |
 
-## UART Mapping
-
-The UARTs are marked Rn and Tn in the above pinouts. The Rn pin is the
-receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
-|Name|Pin|Function|
-|:-|:-|:-|
-|SERIAL0|OTG1|USB|
-|SERIAL1|TX6/RX6|UART1 (Telem1)|
-|SERIAL2|TX3/RX3|UART2 (Telem2 buadrate 921600)|
-|SERIAL3|TX1/RX1|UART3 (GNSS)|
-|SERIAL4|TX4/RX4|UART4 (Reserve for GNSS2)|
-|SERIAL5|TX2/RX2|UART5 (Debug)|
-
-## RC Input
-
-RC input is configured on the RCIN pin by PA15 TIM2_CH1 TIM2 , at one end of the servo rail, marked RC in the above diagram. This pin supports PPM and S.Bus. protocols.
-
 ## OSD Support
 
 QioTek AdeptF407 supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
-## PWM Output
-
-The QioTek AdeptF407 AIO supports up to 12 PWM outputs. All 14 PWM outputs have GND on the top row, 5V on the middle row and signal on the bottom row.
-
-The 12 PWM outputs are in 3 groups:
-
-- PWM 1 and 4 in group1
-- PWM 4 and 8 in group2
-- PWM 9 and 12 in group3
-
-Channels within the same group need to use the same output rate. If any channel in a group uses DShot or then all channels in the group need to use DShot.
-
 ## CAN Port
 
 The CAN port is disabled by default. Enable the CAN port setting the parameters CAN_P1_Driver to 1 (DroneCAN protocol).
-
-## Battery Monitoring
-
-The board has two dedicated power monitor ports on 6 pin connectors. The correct battery setting parameters are dependent on the type of power brick which is connected.
-
-The correct battery setting parameters are:
-
-- BATT_VOLT_PIN 2
-- BATT_CURR_PIN 3
-- BATT_VOLT_MULT 20.000
-- BATT_AMP_PERVLT 60.000
-- BATT2_VOLT_PIN 14
-- BATT2_CURR_PIN 15
-- BATT2_VOLT_MULT 20.000
-- BATT2_AMP_PERVLT 60.000
-
-In addition, the builtin voltage divider circuit can be used by Solder pad to switching to share the battery voltage monitoring by power2 support to 6S.
-
-If you want to use the built-in voltage monitor on power 1, you can manually invert the `BATT_VOLT_PIN` to 14, `BATT_CURR_PIN` to 15, `BATT2_VOLT_PIN` to 2, `BATT2_CURR_PIN` to 3.
-
-**Built-in BEC**
-The built-in BEC 5V output has a starting voltage of 2S, and 9V/12V has a starting voltage of 3S/4S respectively.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/QioTekZealotF427/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/QioTekZealotF427/README.md
@@ -27,3 +27,12 @@ The QioTek Zealot F427 flight controller is sold by a range of resellers listed 
 - builtin BEC (6S 1.5A) power input (share power2 module voltage monitoring)
 - external safety Switch
 - external USB connectors (Type-C USB and JST GH1.25)
+
+
+
+
+<!-- TODO: add Pinout content -->
+<!-- TODO: add UART Mapping content -->
+<!-- TODO: add RC Input content -->
+<!-- TODO: add PWM Output content -->
+<!-- TODO: add Battery Monitoring content -->

--- a/libraries/AP_HAL_ChibiOS/hwdef/QioTekZealotH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/QioTekZealotH743/README.md
@@ -27,3 +27,12 @@ The QioTek Zealot H743 flight controller is sold by a range of resellers listed 
 - builtin BEC (6S 1.5A) power input (share power2 module voltage monitoring)
 - external safety Switch
 - external USB connectors (Type-C USB and JST GH1.25)
+
+
+
+
+<!-- TODO: add Pinout content -->
+<!-- TODO: add UART Mapping content -->
+<!-- TODO: add RC Input content -->
+<!-- TODO: add PWM Output content -->
+<!-- TODO: add Battery Monitoring content -->

--- a/libraries/AP_HAL_ChibiOS/hwdef/RADIX2HD/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/RADIX2HD/README.md
@@ -66,14 +66,6 @@ all channels in the same group need to use the same configuration / rate.
 - PWM 7-8 Group 4
 - PWM 9-10 Group 5 (These are on the TX6 and RX6 pads that can also be used for SERIAL6)
 
-## Analog Inputs
-
-The RADIX 2 HD has 3 analog inputs:
-
-- ADC Pin 10 -> Battery Voltage (VBAT pin, builtin 1:17.6 voltage divider)
-- ADC Pin 3  -> Battery Current Sensor (CUR pin)
-- ADC Pin 11 -> RSSI voltage monitoring (RSSI pad)
-
 ## Battery Monitoring
 
 The RADIX 2 HD can monitor battery voltages up to 12S using a built-in voltage divider.
@@ -84,6 +76,14 @@ WARNING Powering the board with more than 8S (35 V) with the "PWR:VBAT" jumper s
 will damage it. Refer to the official documentation for more details.
 
 In addition to voltage sensing, the board also has an input for an external current sensor.
+
+## Analog Inputs
+
+The RADIX 2 HD has 3 analog inputs:
+
+- ADC Pin 10 -> Battery Voltage (VBAT pin, builtin 1:17.6 voltage divider)
+- ADC Pin 3  -> Battery Current Sensor (CUR pin)
+- ADC Pin 11 -> RSSI voltage monitoring (RSSI pad)
 
 ## Loading Firmware
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/RadiolinkF405/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/RadiolinkF405/README.md
@@ -34,15 +34,6 @@ receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
 RC input is configured on the R2 (UART2_RX) pin for most RC unidirectional protocols except SBUS which should be applied at the SBUS pin. PPM is not supported.
 For CRSF/ELRS/SRXL2 connection of the receiver to T2 will also be required. See [RC systems](https://ardupilot.org/copter/docs/common-rc-systems.html) for more info
 
-## OSD Support
-
-The RadiolinkF405 supports analog OSD using its internal MAX7456. Simultaneous HD OSD operation is enabled by defaullt also.
-
-## VTX Support
-
-The JST-GH-6P connector supports a standard DJI HD VTX connection. Pin 1 of the connector is 9v so be careful not to connect
-this to a peripheral requiring 5v.
-
 ## PWM Output
 
 The RadiolinkF405 supports up to 7 PWM outputs. The pads for motor output
@@ -58,11 +49,6 @@ Channels within the same group need to use the same output rate. If
 any channel in a group uses DShot then all channels in the group need
 to use DShot. Channels 1-4 support bi-directional DShot.
 
-## Pin IO
-
-- GPIO81 is 9V VTX power control (HIGH:on; LOW:off)
-- RELAY2 is assigned to control this GPIO by default.
-
 ## Battery Monitoring
 
 The board has a internal voltage sensor and connections on the ESC connector for an external current sensor input.
@@ -75,6 +61,20 @@ The default battery parameters are:
 - BATT_CURR_PIN = 11
 - BATT_VOLT_MULT = 11.0
 - BATT_AMP_PERVLT = 25
+
+## OSD Support
+
+The RadiolinkF405 supports analog OSD using its internal MAX7456. Simultaneous HD OSD operation is enabled by defaullt also.
+
+## VTX Support
+
+The JST-GH-6P connector supports a standard DJI HD VTX connection. Pin 1 of the connector is 9v so be careful not to connect
+this to a peripheral requiring 5v.
+
+## Pin IO
+
+- GPIO81 is 9V VTX power control (HIGH:on; LOW:off)
+- RELAY2 is assigned to control this GPIO by default.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ReaperF745/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ReaperF745/README.md
@@ -35,10 +35,6 @@ RC input is configured on the R2 (UART2_RX) pin by default. It supports all seri
 protocols. For FPort you should setup the TX PIN as an RC input serial port,
 with half-duplex and inversion enabled.
 
-## OSD Support
-
-The ReaperF745v2 supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The ReaperF745v2 supports up to 5 PWM outputs. There are no pads for motor output
@@ -67,6 +63,10 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN 12
 - BATT_VOLT_MULT 10.9
 - BATT_AMP_PERVLT 100
+
+## OSD Support
+
+The ReaperF745v2 supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SDMODELH7V1/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SDMODELH7V1/README.md
@@ -6,30 +6,9 @@
 
 above image and some content courtesy of SDMODEL
 
-## Specifications
 
-- Processor
-  - STM32H743 32-bit processor
-  - AT7456E OSD
-  - 128 MByte flash for logging
 
-- Sensors
-  - BMI270 IMU (accel and gyro only, no compass)
-  - BMP280 barometer
-
-- Power
-  - 2S - 8S Lipo input voltage with voltage monitoring
-  - 9V, 1.5A BEC for powering Video Transmitter
-
-- Interfaces
-  - 9x PWM outputs (9th pwm output is for NeoPixel LED string via the LED pad)
-  - 1x RC input
-  - 6x UARTs/serial for GPS and other peripherals
-  - 1x I2C port for external compass
-  - USB-C port
-  - Switchable VTX power
-  - All UARTS support hardware inversion. SBUS, SmartPort, and other inverted protocols work on any UART without "uninvert hack"
-  - External current monitor input
+<!-- TODO: add Features content -->
 
 ## Pinout
 
@@ -108,10 +87,6 @@ The SERIAL7 port (UART7) is normally for ESC telemetry, and has an R7 pin on bot
 
 Any UART may be re-tasked by changing its protocol parameter.
 
-## Copter Default Frame Type
-
-For Copter firmware the FRAME_TYPE is already defaulted to type "12" (BetaFlight X) allowing existing BetaFlight configurations with ESCs attached to have the correct motor ordering without changes to the FRAME_TYPE and FRAME_CLASS parameters or ESC wiring.
-
 ## RC Input
 
 RC input is configured on the R6 (UART6_RX) pin. It supports all RC protocols except PPM. See Radio Control Systems for details for a specific RC system. SERIAL6_PROTOCOL is set to "23", by default, to enable this.
@@ -122,17 +97,6 @@ RC input is configured on the R6 (UART6_RX) pin. It supports all RC protocols ex
 - SRXL2 requires a connection to T6 and automatically provides telemetry. Set SERIAL6_OPTIONS to "4".
 
 Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM. See Radio Control Systems for details.
-
-## FrSky Telemetry
-
-FrSky Telemetry is supported using the Tx pin of any UART. You need to set the following parameters to enable support for FrSky S.PORT (example shows SERIAL2).
-
-- SERIAL2_PROTOCOL 10
-- SERIAL2_OPTIONS 7
-
-## OSD Support
-
-The SDH7V1 supports OSD using OSD_TYPE 1 (MAX7456 driver). The defaults are also setup to allow DJI Goggle OSD support on UART1.
 
 ## PWM Output
 
@@ -148,10 +112,6 @@ The PWM is in 3 groups:
 
 Channels within the same group need to use the same output rate, whether PWM or Dshot. If any channel in a group uses DShot then all channels in the group need to use DShot.
 
-## LED Output
-
-The LED output is configured by default to support NeoPixel LED strings.
-
 ## Battery Monitoring
 
 The board has a built-in voltage sensor via the B+ pin, but no internal current sensor. An external current sensor can be connected to the CUR pin.
@@ -163,6 +123,50 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN 11
 - BATT_VOLT_MULT 10.1
 - BATT_AMP_PERVLT varies depending on external current sensor
+
+## Specifications
+
+- Processor
+  - STM32H743 32-bit processor
+  - AT7456E OSD
+  - 128 MByte flash for logging
+
+- Sensors
+  - BMI270 IMU (accel and gyro only, no compass)
+  - BMP280 barometer
+
+- Power
+  - 2S - 8S Lipo input voltage with voltage monitoring
+  - 9V, 1.5A BEC for powering Video Transmitter
+
+- Interfaces
+  - 9x PWM outputs (9th pwm output is for NeoPixel LED string via the LED pad)
+  - 1x RC input
+  - 6x UARTs/serial for GPS and other peripherals
+  - 1x I2C port for external compass
+  - USB-C port
+  - Switchable VTX power
+  - All UARTS support hardware inversion. SBUS, SmartPort, and other inverted protocols work on any UART without "uninvert hack"
+  - External current monitor input
+
+## Copter Default Frame Type
+
+For Copter firmware the FRAME_TYPE is already defaulted to type "12" (BetaFlight X) allowing existing BetaFlight configurations with ESCs attached to have the correct motor ordering without changes to the FRAME_TYPE and FRAME_CLASS parameters or ESC wiring.
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using the Tx pin of any UART. You need to set the following parameters to enable support for FrSky S.PORT (example shows SERIAL2).
+
+- SERIAL2_PROTOCOL 10
+- SERIAL2_OPTIONS 7
+
+## OSD Support
+
+The SDH7V1 supports OSD using OSD_TYPE 1 (MAX7456 driver). The defaults are also setup to allow DJI Goggle OSD support on UART1.
+
+## LED Output
+
+The LED output is configured by default to support NeoPixel LED strings.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SDMODELH7V2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SDMODELH7V2/README.md
@@ -38,26 +38,6 @@ protocols. For protocols requiring half-duplex  or full duplex serial for operat
 select another UART with DMA and set its protocol to "23". To use this UART for other uses, set
 [BRD_ALT_CONFIG](https://ardupilot.org/copter/docs/parameters.html#brd-alt-config-alternative-hw-config) to "1"
 
-## FrSky Telemetry
-
-FrSky Telemetry is supported using the Tx pin of any UART including SERIAL6/UART6 . You need to set the following parameters to enable support for FrSky S.PORT (example shows SERIAL6). Note this assumes the RC input is using default (ALT_BRD_CONFIG =0). Obviously, if using ALT_BRD_CONFIG = 1 for full duplex RC prtocols, you must a different UART for FrSky Telemetry.
-
-- SERIAL6_PROTOCOL 10
-- SERIAL6_OPTIONS 7
-
-## OSD Support
-
-The SDMODEL SDH7 V2 supports OSD using OSD_TYPE 1 (MAX7456 driver).The defaults are also setup to allow DJI Goggle OSD support on UART1. Both OSDs can operate simultaneously.
-
-## VTX Support
-
-The JST-GH-6P connector supports a standard DJI HD VTX connection. Pin 1 of the connector is 9v so be careful not to connect
-this to a peripheral requiring 5v. The 9v supply is controlled by RELAY2_PIN set to GPIO 81 and is on by default. It can be configured to be operated by an RC switch by selecting the function RELAY2.
-
-## Camera Control
-
-The Cam pin is GPIO82 and is set to be controlled by RELAY4 by default. Relay pins can be controlled either by an RC switch or GCS command. See [relay documentation](https://ardupilot.org/copter/docs/common-relay.html) for more information.
-
 ## PWM Output
 
 The SDMODEL SDH7 V2 supports up to 9 PWM or DShot outputs.  Outputs 1-4 support BDShot. The pads for motor output
@@ -94,6 +74,26 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN 11
 - BATT_VOLT_MULT 11
 - BATT_AMP_PERVLT 59.5
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using the Tx pin of any UART including SERIAL6/UART6 . You need to set the following parameters to enable support for FrSky S.PORT (example shows SERIAL6). Note this assumes the RC input is using default (ALT_BRD_CONFIG =0). Obviously, if using ALT_BRD_CONFIG = 1 for full duplex RC prtocols, you must a different UART for FrSky Telemetry.
+
+- SERIAL6_PROTOCOL 10
+- SERIAL6_OPTIONS 7
+
+## OSD Support
+
+The SDMODEL SDH7 V2 supports OSD using OSD_TYPE 1 (MAX7456 driver).The defaults are also setup to allow DJI Goggle OSD support on UART1. Both OSDs can operate simultaneously.
+
+## VTX Support
+
+The JST-GH-6P connector supports a standard DJI HD VTX connection. Pin 1 of the connector is 9v so be careful not to connect
+this to a peripheral requiring 5v. The 9v supply is controlled by RELAY2_PIN set to GPIO 81 and is on by default. It can be configured to be operated by an RC switch by selecting the function RELAY2.
+
+## Camera Control
+
+The Cam pin is GPIO82 and is set to be controlled by RELAY4 by default. Relay pins can be controlled either by an RC switch or GCS command. See [relay documentation](https://ardupilot.org/copter/docs/common-relay.html) for more information.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SIYI_N7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SIYI_N7/README.md
@@ -35,6 +35,47 @@ resellers, linked from [SIYI](https://siyi.biz)
 
 The Telem1 port has RTS/CTS pins, the other UARTs do not have RTS/CTS.
 
+## RC Input
+
+RC input is configured on the RCIN pin, at one end of the servo rail,
+marked RCIN in the above diagram. This pin supports all RC
+protocols.
+
+## PWM Output
+
+The SIYI N7 supports up to 13 PWM outputs. First first 8 outputs
+(labelled "MAIN") are controlled by a dedicated STM32F103 IO
+controller. These 8 outputs support all PWM output formats, but not
+DShot.
+
+The remaining 5 outputs (labelled AUX1 to AUX5) are the "auxiliary"
+outputs. These are directly attached to the STM32H743 and support all
+PWM protocols as well as DShot.
+
+All 13 PWM outputs have GND on the top row, 5V on the middle row and
+signal on the bottom row.
+
+The 8 main PWM outputs are in 3 groups:
+
+- PWM 1 and 2 in group1
+- PWM 3 and 4 in group2
+- PWM 5, 6, 7 and 8 in group3
+
+The 4 auxiliary PWM outputs are in 2 groups:
+
+- PWM 1, 2, 3 and 4 in group4
+- PWM 5 in group5
+
+Channels within the same group need to use the same output rate. If
+any channel in a group uses DShot then all channels in the group need
+to use DShot.
+
+## Battery Monitoring
+
+The board has a dedicated power monitor ports on a 6 pin
+connector. The correct battery setting parameters are dependent on
+the type of power brick which is connected.
+
 ## Connectors
 
 Unless noted otherwise all connectors are JST GH
@@ -113,47 +154,6 @@ Unless noted otherwise all connectors are JST GH
 | 2 (blk) | D_minus | +3.3V |
 | 3 (blk) | D_plus | +3.3V |
 | 4 (blk) | GND | GND |
-
-## RC Input
-
-RC input is configured on the RCIN pin, at one end of the servo rail,
-marked RCIN in the above diagram. This pin supports all RC
-protocols.
-
-## PWM Output
-
-The SIYI N7 supports up to 13 PWM outputs. First first 8 outputs
-(labelled "MAIN") are controlled by a dedicated STM32F103 IO
-controller. These 8 outputs support all PWM output formats, but not
-DShot.
-
-The remaining 5 outputs (labelled AUX1 to AUX5) are the "auxiliary"
-outputs. These are directly attached to the STM32H743 and support all
-PWM protocols as well as DShot.
-
-All 13 PWM outputs have GND on the top row, 5V on the middle row and
-signal on the bottom row.
-
-The 8 main PWM outputs are in 3 groups:
-
-- PWM 1 and 2 in group1
-- PWM 3 and 4 in group2
-- PWM 5, 6, 7 and 8 in group3
-
-The 4 auxiliary PWM outputs are in 2 groups:
-
-- PWM 1, 2, 3 and 4 in group4
-- PWM 5 in group5
-
-Channels within the same group need to use the same output rate. If
-any channel in a group uses DShot then all channels in the group need
-to use DShot.
-
-## Battery Monitoring
-
-The board has a dedicated power monitor ports on a 6 pin
-connector. The correct battery setting parameters are dependent on
-the type of power brick which is connected.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SPEDIXF405/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SPEDIXF405/README.md
@@ -42,10 +42,6 @@ RX3 and TX3 and set RSSI_TYPE also to 3.
 The SBUS pad comprises a hardware inverter connected to USART2_RX. If you wish to use SBUS then set SERIAL3_PROTOCOL to something
 other than RCIN and set SERIAL2_PROTOCL to RCIN.
 
-## OSD Support
-
-Onboard OSD using OSD_TYPE 1 (MAX7456 driver) is supported by default. Simultaneously, DisplayPort OSD is available on the HD VTX connector.
-
 ## PWM Output
 
 The SPEDIX F405 supports up to 9 PWM outputs. The pads for motor output
@@ -75,6 +71,10 @@ The correct battery setting parameters are:
 - [BATT_CURR_PIN](https://ardupilot.org/copter/docs/parameters.html#batt-curr-pin-ap-battmonitor-analog-battery-current-sensing-pin) = 11 (CURR pin)
 - [BATT_VOLT_MULT](https://ardupilot.org/copter/docs/parameters.html#batt-volt-mult-ap-battmonitor-analog-voltage-multiplier) = 11.0
 - [BATT_AMP_PERVLT](https://ardupilot.org/copter/docs/parameters.html#batt-amp-pervlt-ap-battmonitor-analog-amps-per-volt) = 50
+
+## OSD Support
+
+Onboard OSD using OSD_TYPE 1 (MAX7456 driver) is supported by default. Simultaneously, DisplayPort OSD is available on the HD VTX connector.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SPEDIXH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SPEDIXH743/README.md
@@ -41,10 +41,6 @@ Note: If the receiver is FPort the receiver must be tied to the USART2 TX pin , 
 and SERIAL2_OPTIONS must be set to 7 (invert TX/RX, half duplex). For full duplex like CRSF/ELRS use both
 RX2 and TX2 and set RSSI_TYPE also to 3.
 
-## OSD Support
-
-Onboard OSD using OSD_TYPE 1 (MAX7456 driver) is supported by default. Simultaneously, DisplayPort OSD is available on the HD VTX connector.
-
 ## PWM Output
 
 The SPEDIX F405 supports up to 9 PWM outputs. The pads for motor output
@@ -74,6 +70,10 @@ The correct battery setting parameters are:
 - [BATT_CURR_PIN](https://ardupilot.org/copter/docs/parameters.html#batt-curr-pin-ap-battmonitor-analog-battery-current-sensing-pin) = 11 (CURR pin)
 - [BATT_VOLT_MULT](https://ardupilot.org/copter/docs/parameters.html#batt-volt-mult-ap-battmonitor-analog-voltage-multiplier) = 11.0
 - [BATT_AMP_PERVLT](https://ardupilot.org/copter/docs/parameters.html#batt-amp-pervlt-ap-battmonitor-analog-amps-per-volt) = 25
+
+## OSD Support
+
+Onboard OSD using OSD_TYPE 1 (MAX7456 driver) is supported by default. Simultaneously, DisplayPort OSD is available on the HD VTX connector.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SPRacingH7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SPRacingH7/README.md
@@ -40,17 +40,6 @@ protocols. For protocols requiring half-duplex serial to transmit
 telemetry (such as FPort) you should setup SERIAL1
 with half-duplex, pin-swap and inversion enabled.
 
-## FrSky Telemetry
-
-FrSky Telemetry is supported using the T2 pin (UART2 transmit). You need to set the following parameters to enable support for FrSky S.PORT
-
-- SERIAL2_PROTOCOL 10
-- SERIAL2_OPTIONS 15
-
-## OSD Support
-
-The SPRacingH7 supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The SPRacingH7 supports up to 11 PWM outputs. The pads for motor output
@@ -82,6 +71,17 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN 11
 - BATT_VOLT_MULT 10.9
 - BATT_AMP_PERVLT 28.5
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using the T2 pin (UART2 transmit). You need to set the following parameters to enable support for FrSky S.PORT
+
+- SERIAL2_PROTOCOL 10
+- SERIAL2_OPTIONS 15
+
+## OSD Support
+
+The SPRacingH7 supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SPRacingH7RF/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SPRacingH7RF/README.md
@@ -49,10 +49,6 @@ protocols. PPM is not supported. For protocols requiring half-duplex serial to t
 telemetry (such as FPort) you should setup SERIAL2 as an RC input serial port,
 with half-duplex, pin-swap and inversion enabled. For duplex protocols, like CRSF/ELRS, T2 must also be connected to the receiver.
 
-## Pixel OSD Support
-
-Ardupilot does not currently support the integrated OSD chip. UART3 is setup fir use with DisplayPort goggles with OSD.
-
 ## PWM Output
 
 The SPRacingH7 RF supports up to 9 PWM outputs. PWM 1-8 support DShot and Bi-Directional DShot. The pads for motor output
@@ -81,6 +77,10 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN 11
 - BATT_VOLT_MULT 10.9
 - BATT_AMP_PERVLT 28.5 (will need adjustment for the current sensor range of the ESC)
+
+## Pixel OSD Support
+
+Ardupilot does not currently support the integrated OSD chip. UART3 is setup fir use with DisplayPort goggles with OSD.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SULILGH7-P1-P2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SULILGH7-P1-P2/README.md
@@ -1,11 +1,5 @@
 # SULILGH7P1/P2 Flight Controller
 
-## This firmware is compatible with SULILGH7-P1 and SULILGH7-P2
-
-This is the open-source hardware I have released, and you can find more details at the following link: [OSHW Hub](https://oshwhub.com/shuyedeye/p1-flight-control.)
-
-![SULILGH7-P1](P1.jpg)
-
 ## Features
 
 - Separate flight control core design.
@@ -33,6 +27,10 @@ This is the open-source hardware I have released, and you can find more details 
 
    Two barometers:Baro1-BMP581 , Baro2-ICP20100
   Magnetometer:   Builtin IST8310 magnetometer
+
+
+
+<!-- TODO: add Pinout content -->
 
 ## UART Mapping
 
@@ -83,6 +81,17 @@ The 8 FMU PWM outputs are in 4 groups:
 
 Channels within the same group need to use the same output rate. If any channel in a group uses DShot then all channels in the group need to use DShot.
 
+## Battery Monitoring
+
+Two DroneCAN power monitor interfaces have been configured
+These are set by default in the firmware and shouldn't need to be adjusted.
+
+## This firmware is compatible with SULILGH7-P1 and SULILGH7-P2
+
+This is the open-source hardware I have released, and you can find more details at the following link: [OSHW Hub](https://oshwhub.com/shuyedeye/p1-flight-control.)
+
+![SULILGH7-P1](P1.jpg)
+
 ## GPIOs
 
 All PWM outputs can be used as GPIOs (relays, camera, RPM etc). To use them you need to set the output’s SERVOx_FUNCTION to -1. The numbering of the GPIOs for PIN variables in ArduPilot is:
@@ -110,11 +119,6 @@ All PWM outputs can be used as GPIOs (relays, camera, RPM etc). To use them you 
 | 56 |  | M8 |
 | 108 | MainOut8 |  |
 | M16 | 57 |  |
-
-## Battery Monitoring
-
-Two DroneCAN power monitor interfaces have been configured
-These are set by default in the firmware and shouldn't need to be adjusted.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SVehicle-E2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SVehicle-E2/README.md
@@ -23,10 +23,6 @@ The S-Vehicle E2-Plus Flight Controller produced by [S-Vehicle](http://svehicle.
 - 100Mbps Ethernet port
 - 3 power monitor inputs
 
-## IOMCU
-
-This board has an IOMCU implemented on a STM32F103 microcontroller which, manages
-
 ## Pinout
 
 ![E2plus-Top.png](E2plus-Top.png)
@@ -76,6 +72,14 @@ A5, A6 are in a 2nd group.
 
 Channels within the same group need to use the same output rate. If any channel in a group uses DShot then all channels in the group need to use DShot.
 
+## Battery Monitoring
+
+The board has connectors for 3 power monitors. The board is configure by default for a DroneCAN power monitor, and also has analog power monitor defaults configured which is enabled. The default PDB included with the E2+ is DroneCAN and must be connected to Power 2. If using a analog power monitor, battery voltage is on pin 6 and current on pin 9 and this should be connected to Power 1.
+
+## IOMCU
+
+This board has an IOMCU implemented on a STM32F103 microcontroller which, manages
+
 ## GPIOs
 
 Two of the PWM ports on the FMU labeled A5 and A6, can be used as GPIOs (relays, buttons, RPM etc). To use them you need to limit the number of these pins that are used for PWM by setting the BRD_PWM_COUNT to a number less than 6. For example if you set BRD_PWM_COUNT to 4 then PWM A5 and PWM A6 will be available for use as GPIOs.
@@ -115,10 +119,6 @@ The complete list of GPIOS is:
 | MAIN(6) | 106 |
 | MAIN(7) | 107 |
 | MAIN(8) | 108 |
-
-## Battery Monitoring
-
-The board has connectors for 3 power monitors. The board is configure by default for a DroneCAN power monitor, and also has analog power monitor defaults configured which is enabled. The default PDB included with the E2+ is DroneCAN and must be connected to Power 2. If using a analog power monitor, battery voltage is on pin 6 and current on pin 9 and this should be connected to Power 1.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SequreH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SequreH743/README.md
@@ -43,20 +43,6 @@ to something other than '23'. For rc protocols other than unidirectional, the US
 - SRXL2 would require [SERIAL1_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial1-options-telem1-options) be set to "4" and connects only the TX pin.
 - PPM is not supported
 
-## OSD Support
-
-The SequreH743 supports OSD using OSD_TYPE 1 (MAX7456 driver)
- and simultaneously DisplayPort using UART7 on the HD VTX connector.
-
-## VTX Support
-
-The SH1.0-6P connector supports a DJI Air Unit / HD VTX connection. Protocol defaults to DisplayPort. Pin 1 of the connector is 9v so
-be careful not to connect this to a peripheral that can not tolerate this voltage.
-
-## Camera Control
-
-GPIO 81 is a pin for PWM camera control which is not supported by ArduPilot. It can be used as a general GPIO pin. By default RELAY2 is configured to control this pin and sets the GPIO high.
-
 ## PWM Output
 
 The SequreH743 supports up to 9 PWM or DShot outputs. The pads for motor output
@@ -86,6 +72,20 @@ The default battery parameters are:
 - [BATT_CURR_PIN](https://ardupilot.org/copter/docs/parameters.html#batt-curr-pin-ap-battmonitor-analog-battery-current-sensing-pin) = 12 (CURR pin)
 - [BATT_VOLT_MULT](https://ardupilot.org/copter/docs/parameters.html#batt-volt-mult-ap-battmonitor-analog-voltage-multiplier) = 11.0
 - [BATT_AMP_PERVLT](https://ardupilot.org/copter/docs/parameters.html#batt-amp-pervlt-ap-battmonitor-analog-amps-per-volt) = 17.2
+
+## OSD Support
+
+The SequreH743 supports OSD using OSD_TYPE 1 (MAX7456 driver)
+ and simultaneously DisplayPort using UART7 on the HD VTX connector.
+
+## VTX Support
+
+The SH1.0-6P connector supports a DJI Air Unit / HD VTX connection. Protocol defaults to DisplayPort. Pin 1 of the connector is 9v so
+be careful not to connect this to a peripheral that can not tolerate this voltage.
+
+## Camera Control
+
+GPIO 81 is a pin for PWM camera control which is not supported by ArduPilot. It can be used as a general GPIO pin. By default RELAY2 is configured to control this pin and sets the GPIO high.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SkyRukh_Surge_H7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SkyRukh_Surge_H7/README.md
@@ -46,9 +46,6 @@ The SERIAL1 and SERIAL2 ports have RTS/CTS pins, the other UARTs do not have RTS
 
 RC input is provided through the SBUS connector and supports all unidirectional RC protocols. For bi-directional protocols, such as CRSF/ELRS/SRXL2, a UART with DMA will be need to be used, See [ArduPilot RC documentation](https://ardupilot.org/plane/docs/common-rc-systems.html) for more information.
   
-## OSD Support
-
-The SkyRukh Surge H7 supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## PWM Output
 
@@ -76,6 +73,10 @@ The default battery parameters are:
 - BATT_CUR_PIN = 17 (C pin on ESC connector)
 - BATT_VOLT_MULT = 7.39
 - BATT_AMP_PERVLT = 40 (should be set according to ESC block used)
+
+## OSD Support
+
+The SkyRukh Surge H7 supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SkySakuraH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SkySakuraH743/README.md
@@ -38,24 +38,9 @@ receive pin for UARTn. The Tn pin is the transmit pin for UARTn.
 |SERIAL7|TX8/RX8|UART8 (ESC-Telemetry, RX8 on ESC connectors, TX8 can be used if protocol is change from ESC telem)|
 |SERIAL8|COMPUTER|USB|
 
-## Safety Button
-
-SkySakura H743 supports safety button, with connection to sh1.0 6 pin connector, with buzzer and safety led on the same connector.
-Safety button is defaulted to be disabled but can be enabled by setting the following parameter:
-
-- BRD_SAFETY_DEFLT 1
-
 ## RC Input
 
 RC input is configured on UART4 with an sh1.0 connector. It supports all RC protocols except PPM. The SBUS pin on the HD VTX connector is tied directly the UART4 RX. If ELRS is used on UART4, then the SBUS lead from a DJI VTX must not be connected to the SBUS to prevent ELRS lock up on boot.
-
-## OSD Support
-
-SkySakura H743  supports HD OSD through UART6 by default.
-
-## VTX Power Control
-
-The 12VSW output voltage on the HD VTX connector is controlled by GPIO 85, via RELAY1 by default. Low activates the voltage.
 
 ## PWM Output
 
@@ -90,6 +75,21 @@ The default battery setting parameters are:
 - BATT2_CURR_PIN 13
 - BATT2_VOLT_MULT 10
 - set BATT2_AMP_PERVLT to appropriate value for second current sensor
+
+## Safety Button
+
+SkySakura H743 supports safety button, with connection to sh1.0 6 pin connector, with buzzer and safety led on the same connector.
+Safety button is defaulted to be disabled but can be enabled by setting the following parameter:
+
+- BRD_SAFETY_DEFLT 1
+
+## OSD Support
+
+SkySakura H743  supports HD OSD through UART6 by default.
+
+## VTX Power Control
+
+The 12VSW output voltage on the HD VTX connector is controlled by GPIO 85, via RELAY1 by default. Low activates the voltage.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SkystarsF405v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SkystarsF405v2/README.md
@@ -42,16 +42,6 @@ to something other than '23'. For rc protocols other than unidirectional, the US
 
 SBUS is supported via hardware inversion connected to USART_RX2 and is available on both a solder pad and in the DJI HD connector.
 
-## OSD Support
-
-The SkystarsF405v2 supports OSD using OSD_TYPE 1 (MAX7456 driver)
- and simultaneously DisplayPort using USART6 on the HD VTX connector.
-
-## VTX Support
-
-The SH1.0-6P connector supports a DJI Air Unit / HD VTX connection. Protocol defaults to DisplayPort. Pin 1 of the connector is 10v so
-be careful not to connect this to a peripheral that can not tolerate this voltage.
-
 ## PWM Output
 
 The SkystarsF405v2 supports up to 7 PWM or DShot outputs. The pads for motor output
@@ -81,6 +71,16 @@ The default battery parameters are:
 - BATT_CURR_PIN = 11
 - BATT_VOLT_MULT = 11.0
 - BATT_AMP_PERVLT = 25.0
+
+## OSD Support
+
+The SkystarsF405v2 supports OSD using OSD_TYPE 1 (MAX7456 driver)
+ and simultaneously DisplayPort using USART6 on the HD VTX connector.
+
+## VTX Support
+
+The SH1.0-6P connector supports a DJI Air Unit / HD VTX connection. Protocol defaults to DisplayPort. Pin 1 of the connector is 10v so
+be careful not to connect this to a peripheral that can not tolerate this voltage.
 
 ## Analog RSSI input
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SkystarsH7HD-bdshot/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SkystarsH7HD-bdshot/README.md
@@ -37,10 +37,6 @@ It supports all serial RC protocols. For protocols requiring half-duplex serial 
 telemetry (such as FPort) you should setup SERIAL1 with half-duplex and connect to T1 or use
 R1 with pin-swap. You also need to set inversion enabled if using FPort.
 
-## OSD Support
-
-The Skystars H7 supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The Skystars H7 supports up to 9 PWM outputs. The pads for motor output
@@ -71,6 +67,10 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN 11
 - BATT_VOLT_MULT 10.1
 - BATT_AMP_PERVLT 17.0
+
+## OSD Support
+
+The Skystars H7 supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SkystarsH7HD/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SkystarsH7HD/README.md
@@ -37,10 +37,6 @@ telemetry (such as FPort) you should set BRD_ALT_CONFIG=1 and setup
 SERIAL6 as an RC input serial port, with half-duplex, pin-swap
 and inversion enabled.
 
-## OSD Support
-
-The Skystars H7 supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The Skystars H7 supports up to 9 PWM outputs. The pads for motor output
@@ -72,6 +68,10 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN 11
 - BATT_VOLT_MULT 10.1
 - BATT_AMP_PERVLT 17.0
+
+## OSD Support
+
+The Skystars H7 supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SkystarsH7HDv2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SkystarsH7HDv2/README.md
@@ -38,11 +38,6 @@ It supports all serial RC protocols. For protocols requiring half-duplex serial 
 telemetry (such as FPort) you should setup SERIAL1 with half-duplex and connect to T1 or use
 R1 with pin-swap.
 
-## OSD Support
-
-The Skystars H7HDv2 supports OSD using OSD_TYPE 1 (MAX7456 driver) and simultaneously DisplayPort
-using UART6 on the HD VTX connector.
-
 ## PWM Output
 
 The Skystars H7HDv2 supports up to 9 PWM outputs. The pads for motor output
@@ -73,6 +68,11 @@ The correct battery setting parameters are:
 - [BATT_CURR_PIN](https://ardupilot.org/copter/docs/parameters.html#batt-curr-pin-ap-battmonitor-analog-battery-current-sensing-pin) = 11 (CURR pin)
 - [BATT_VOLT_MULT](https://ardupilot.org/copter/docs/parameters.html#batt-volt-mult-ap-battmonitor-analog-voltage-multiplier) = 10.1
 - [BATT_AMP_PERVLT](https://ardupilot.org/copter/docs/parameters.html#batt-amp-pervlt-ap-battmonitor-analog-amps-per-volt) = 17.0
+
+## OSD Support
+
+The Skystars H7HDv2 supports OSD using OSD_TYPE 1 (MAX7456 driver) and simultaneously DisplayPort
+using UART6 on the HD VTX connector.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SpeedyBeeF405AIO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SpeedyBeeF405AIO/README.md
@@ -57,10 +57,6 @@ RC input is configured on UART6. It supports all RC protocols except PPM, FPort,
 
 Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM. See [Radio Control Systems](https://ardupilot.org/plane/docs/common-rc-systems.html#common-rc-systems) for details.
 
-## OSD Support
-
-The SpeedyBee F405 AIO supports OSD using [OSD_TYPE](https://ardupilot.org/copter/docs/parameters.html#osd-type-osd-type) =  1 (MAX7456 driver). The defaults are also setup to allow DJI Goggle OSD support on UART3. Both the internal analog OSD and the DisplayPort OSD can be used simultaneously by setting [OSD_TYPE2](https://ardupilot.org/copter/docs/parameters.html#osd-type2-osd-type-2)= 5
-
 ## PWM Output
 
 The SpeedyBee F405 AIO supports up to 5 PWM outputs. The pads for motor output ESC1 to ESC4 on the above diagram are the first 4 outputs.All 5 outputs support DShot.
@@ -89,6 +85,10 @@ The correct battery setting parameters are:
 - BATT_AMP_PERVLT 39.4
 
 These are set by default in the firmware and shouldn't need to be adjusted
+
+## OSD Support
+
+The SpeedyBee F405 AIO supports OSD using [OSD_TYPE](https://ardupilot.org/copter/docs/parameters.html#osd-type-osd-type) =  1 (MAX7456 driver). The defaults are also setup to allow DJI Goggle OSD support on UART3. Both the internal analog OSD and the DisplayPort OSD can be used simultaneously by setting [OSD_TYPE2](https://ardupilot.org/copter/docs/parameters.html#osd-type2-osd-type-2)= 5
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SpeedyBeeF405Mini/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SpeedyBeeF405Mini/README.md
@@ -35,22 +35,6 @@ RC input is configured on the R2 (UART2_RX) pin for most RC unidirectional proto
 For Fport, a bi-directional inverter will be required. See [ArduPilot FPort documentation](https://ardupilot.org/plane/docs/common-connecting-sport-fport.html)
 For CRSF/ELRS/SRXL2 connection of the receiver to T2 will also be required.
 
-## FrSky Telemetry
-
-FrSky Telemetry is supported using the Tx pin of any UART including SERIAL2/UART2. You need to set the following parameters to enable support for FrSky S.PORT (example shows SERIAL3).
-
-- SERIAL3_PROTOCOL 10
-- SERIAL3_OPTIONS 7
-
-## OSD Support
-
-The SpeedyBee F405 Mini supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
-## VTX Support
-
-The JST-GH-6P connector supports a standard DJI HD VTX connection. Pin 1 of the connector is 9v so be careful not to connect
-this to a peripheral requiring 5v.
-
 ## PWM Output
 
 The SpeedyBee F405 Mini supports up to 5 PWM outputs. The pads for motor output
@@ -80,6 +64,22 @@ The default battery parameters are:
 - BATT_CURR_PIN 11
 - BATT_VOLT_MULT 11.2
 - BATT_AMP_PERVLT 40 (will need to be adjusted for whichever current sensor is attached)
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using the Tx pin of any UART including SERIAL2/UART2. You need to set the following parameters to enable support for FrSky S.PORT (example shows SERIAL3).
+
+- SERIAL3_PROTOCOL 10
+- SERIAL3_OPTIONS 7
+
+## OSD Support
+
+The SpeedyBee F405 Mini supports OSD using OSD_TYPE 1 (MAX7456 driver).
+
+## VTX Support
+
+The JST-GH-6P connector supports a standard DJI HD VTX connection. Pin 1 of the connector is 9v so be careful not to connect
+this to a peripheral requiring 5v.
 
 ## RSSI
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/StellarF4/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/StellarF4/README.md
@@ -28,13 +28,9 @@
 - Size
   - 41 x 41mm PCB with 30.5mm M3 mounting
 
-## Overview
 
-![StellarF4](StellarF4-top.png)
 
-![StellarF4](StellarF4-bot.png)
-
-## Wiring Diagram
+<!-- TODO: add Pinout content -->
 
 ## UART Mapping
 
@@ -49,11 +45,6 @@ receive pin for UARTx. The Tx pin is the transmit pin for UARTx. The UARTs 1,2,6
 - SERIAL5 -> UART5  (ESC Telemetry) (NO DMA)
 - SERIAL6 -> USART6 (GPS) (NO DMA)
 
-## CAN and I2C
-
-StellarF4 supports I2C bus
-multiple I2C peripherals can be connected to one I2C bus in parallel.
-
 ## RC Input
 
 The default RC input is configured on the UART2 RX2 input and can be used for all ArduPilot supported unidirectional receiver protocols.
@@ -61,10 +52,6 @@ The default RC input is configured on the UART2 RX2 input and can be used for al
 - SBUS/DSM/SRXL connects to the PPM pad or RX2 pin on the HD VTX connector. PPM pin connected to RX2 via inverter.
 - CRSF also requires a TX2 connection, in addition to RX2, and automatically provides telemetry.
 - FPort requires connection to TX2 and [SERIAL2_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial2-options-telem2-options) set to "7". See [FPort receivers](https://ardupilot.org/copter/docs/common-FPort-receivers.html).
-
-## OSD Support
-
-StellarF4 supports using its internal OSD, and/or DisplayPort on Serial1, by default. See [MSP OSD](https://ardupilot.org/copter/docs/common-msp-osd-overview-4.2.html) for more info.
 
 ## PWM Output
 
@@ -87,6 +74,23 @@ The default battery parameters are:
 - BATT_CURR_PIN = 11
 - BATT_VOLT_MULT = 11.2
 - BATT_AMP_PERVLT = 52.7
+
+## Overview
+
+![StellarF4](StellarF4-top.png)
+
+![StellarF4](StellarF4-bot.png)
+
+## Wiring Diagram
+
+## CAN and I2C
+
+StellarF4 supports I2C bus
+multiple I2C peripherals can be connected to one I2C bus in parallel.
+
+## OSD Support
+
+StellarF4 supports using its internal OSD, and/or DisplayPort on Serial1, by default. See [MSP OSD](https://ardupilot.org/copter/docs/common-msp-osd-overview-4.2.html) for more info.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/StellarF4V2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/StellarF4V2/README.md
@@ -28,11 +28,9 @@
 - Size
   - 41 x 41mm PCB with 30.5mm M3 mounting
 
-## Overview
 
-![StellarF4 V2](StellarF4V2-top.png)
 
-![StellarF4 V2](StellarF4V2-bot.png)
+<!-- TODO: add Pinout content -->
 
 ## UART Mapping
 
@@ -45,11 +43,6 @@ receive pin for UARTx. The Tx pin is the transmit pin for UARTx.
 - SERIAL3 -> UART4 (DisplayPort) (NO DMA)
 - SERIAL4 -> UART5 (ESC Telemetry) (NO DMA)
 
-## CAN and I2C
-
-StellarF4V2 supports 1x I2C bus
-multiple I2C peripherals can be connected to one I2C bus in parallel.
-
 ## RC Input
 
 The default RC input is configured on the UART2(SERIAL1) RX2 input and can be used for all ArduPilot supported unidirectional receiver protocols.
@@ -58,11 +51,6 @@ The default RC input is configured on the UART2(SERIAL1) RX2 input and can be us
 - CRSF also requires a TX2 connection, in addition to RX2, and automatically provides telemetry.
 - FPort requires connection to TX2 and [SERIAL1_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial1-options-telem1-options) set to "7". See [FPort receivers](https://ardupilot.org/copter/docs/common-FPort-receivers.html).
 - SRXL2 requires a connection to TX2 and automatically provides telemetry. Set [SERIAL1_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial1-options-telem1-options) to "4".
-
-## OSD Support
-
-StellarF4V2 supports using its internal OSD using OSD_TYPE 1 (MAX7456 driver).
-External OSD support such as DJI or DisplayPort is preconfigured on SERIAL3 but supported on any spare UART. See [MSP OSD](https://ardupilot.org/copter/docs/common-msp-osd-overview-4.2.html) for more info.
 
 ## PWM Output
 
@@ -86,6 +74,22 @@ The default battery parameters are:
 - BATT_CURR_PIN = 11
 - BATT_VOLT_MULT = 11
 - BATT_AMP_PERVLT = 10
+
+## Overview
+
+![StellarF4 V2](StellarF4V2-top.png)
+
+![StellarF4 V2](StellarF4V2-bot.png)
+
+## CAN and I2C
+
+StellarF4V2 supports 1x I2C bus
+multiple I2C peripherals can be connected to one I2C bus in parallel.
+
+## OSD Support
+
+StellarF4V2 supports using its internal OSD using OSD_TYPE 1 (MAX7456 driver).
+External OSD support such as DJI or DisplayPort is preconfigured on SERIAL3 but supported on any spare UART. See [MSP OSD](https://ardupilot.org/copter/docs/common-msp-osd-overview-4.2.html) for more info.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/StellarH7V2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/StellarH7V2/README.md
@@ -29,11 +29,9 @@
 - Size
   - 41 x 41mm PCB with 30.5mm M3 mounting
 
-## Overview
 
-![StellarH7V2](StellarH7V2-top.png)
 
-![StellarH7V2](StellarH7V2-bot.png)
+<!-- TODO: add Pinout content -->
 
 ## UART Mapping
 
@@ -49,10 +47,6 @@ receive pin for UARTx. The Tx pin is the transmit pin for UARTx. All UARTS excep
 - SERIAL6 -> UART7 (DisplayPort)
 - SERIAL7 -> UART8 (ESC Telemetry, RX8 pin only)
 
-## CAN and I2C
-
-StellarH7V2 supports 1x CAN bus and 1x I2C bus
-
 ## RC Input
 
 The default RC input is configured on the UART4 RX4 input and can be used for all ArduPilot supported unidirectional receiver protocols.
@@ -62,10 +56,6 @@ The default RC input is configured on the UART4 RX4 input and can be used for al
 - FPort requires connection to TX4 and [SERIAL4_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial4-options-serial4-options) set to "7". See [FPort receivers](https://ardupilot.org/copter/docs/common-FPort-receivers.html).
 - CRSF also requires a TX4 connection, in addition to RX4, and automatically provides telemetry.
 - SRXL2 requires a connection to TX4 and automatically provides telemetry. Set [SERIAL4_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial4-options-serial4-options) to "4".
-
-## OSD Support
-
-StellarH7V2 supports using its internal OSD using OSD_TYPE 1 (MAX7456 driver). Simultaneous DisplayPort OSD operation  is preconfigured on SERIAL 6 but requires OSD_TYPE2 = 5. See [MSP OSD](https://ardupilot.org/copter/docs/common-msp-osd-overview-4.2.html) for more info.
 
 ## PWM Output
 
@@ -95,6 +85,20 @@ Pads for a second analog - BATTery monitor are provided (Voltage only). To use:
 - BATT2_MONITOR = 4
 - BATT2_VOLT_PIN = 18
 - BATT2_VOLT_MULT = 21.0
+
+## Overview
+
+![StellarH7V2](StellarH7V2-top.png)
+
+![StellarH7V2](StellarH7V2-bot.png)
+
+## CAN and I2C
+
+StellarH7V2 supports 1x CAN bus and 1x I2C bus
+
+## OSD Support
+
+StellarH7V2 supports using its internal OSD using OSD_TYPE 1 (MAX7456 driver). Simultaneous DisplayPort OSD operation  is preconfigured on SERIAL 6 but requires OSD_TYPE2 = 5. See [MSP OSD](https://ardupilot.org/copter/docs/common-msp-osd-overview-4.2.html) for more info.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7/README.md
@@ -48,18 +48,6 @@ RX6 and TX6 and set RSSI_TYPE also to 3.
 
 If SBUS is used on HD VTX connector (DJI TX), then SERIAL1_PROTOCOl should be set to "23" and SERIAL6_PROTOCOL changed to something else.
 
-## FrSky Telemetry
-
-FrSky Telemetry is supported using an unused UART, such as the T1 pin (UART1 transmit).
-You need to set the following parameters to enable support for FrSky S.PORT:
-
-- SERIAL1_PROTOCOL 10
-- SERIAL1_OPTIONS 7
-
-## OSD Support
-
-The TBS LUCID H7 supports OSD using OSD_TYPE 1 (MAX7456 driver) and simultaneously DisplayPort using TX3/RX3 on the HD VTX connector.
-
 ## PWM Output
 
 The TBS LUCID H7 supports up to 13 PWM or DShot outputs. The pads for motor output
@@ -100,6 +88,18 @@ Pads for a second analog battery monitor are provided. To use:
 - BATT2_CURR_PIN 7
 - BATT2_VOLT_MULT 11.0
 - BATT2_AMP_PERVLT as required
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using an unused UART, such as the T1 pin (UART1 transmit).
+You need to set the following parameters to enable support for FrSky S.PORT:
+
+- SERIAL1_PROTOCOL 10
+- SERIAL1_OPTIONS 7
+
+## OSD Support
+
+The TBS LUCID H7 supports OSD using OSD_TYPE 1 (MAX7456 driver) and simultaneously DisplayPort using TX3/RX3 on the HD VTX connector.
 
 ## Analog RSSI and AIRSPEED inputs
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7_WING/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7_WING/README.md
@@ -51,18 +51,6 @@ RC input is configured by default via the USART6 RX input. It supports all seria
 
 If SBUS is used on HD VTX connector (DJI TX), then [SERIAL1_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial1-protocol-telem1-protocol-selection) should be set to "23" and [SERIAL6_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial6-protocol-serial6-protocol-selection) changed to something else. If UART1 is used for something else, be sure the RX2 pin on the HD VTX connector is left open.
 
-## FrSky Telemetry
-
-FrSky Telemetry is supported using an unused UART, such as the T1 pin (UART1 transmit).
-You need to set the following parameters to enable support for FrSky S.PORT:
-
-- [SERIAL1_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial1-protocol-telem1-protocol-selection) 10
-- [SERIAL1_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial1-options-telem1-options) 7
-
-## OSD Support
-
-The TBS Lucid H7 Wing supports analog OSD using its onboard MAX7456 and simultaneously DisplayPort using TX3/RX3 on the HD VTX connector.
-
 ## PWM Output
 
 The TBS Lucid H7 Wing supports up to 13 PWM or DShot outputs. The pads for motor output
@@ -103,6 +91,18 @@ Pads for a second analog battery monitor are provided. To use:
 - [BATT2_CURR_PIN](https://ardupilot.org/copter/docs/parameters.html#batt2-curr-pin-ap-battmonitor-analog-battery-current-sensing-pin) 7
 - [BATT2_VOLT_MULT](https://ardupilot.org/copter/docs/parameters.html#batt2-volt-mult-ap-battmonitor-analog-voltage-multiplier) 11.0
 - [BATT2_AMP_PERVLT](https://ardupilot.org/copter/docs/parameters.html#batt2-amp-pervlt-ap-battmonitor-analog-amps-per-volt) as required
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using an unused UART, such as the T1 pin (UART1 transmit).
+You need to set the following parameters to enable support for FrSky S.PORT:
+
+- [SERIAL1_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial1-protocol-telem1-protocol-selection) 10
+- [SERIAL1_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial1-options-telem1-options) 7
+
+## OSD Support
+
+The TBS Lucid H7 Wing supports analog OSD using its onboard MAX7456 and simultaneously DisplayPort using TX3/RX3 on the HD VTX connector.
 
 ## Analog RSSI and AIRSPEED inputs
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7_WING_AIO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_H7_WING_AIO/README.md
@@ -53,18 +53,6 @@ RC input is configured by default via the USART4 RX input. It supports all seria
 
 If SBUS is used on HD VTX connector (DJI TX), then [SERIAL1_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial1-protocol-telem1-protocol-selection) should be set to "23" and [SERIAL4_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial4-protocol-serial4-protocol-selection) changed to something else. If UART1 is used for something else, be sure the RX2 pin on the HD VTX connector is left open.
 
-## FrSky Telemetry
-
-FrSky Telemetry is supported using an unused UART, such as the T2 pin (UART2 transmit).
-Using UART2 you would need to set the following parameters to enable support for FrSky S.PORT:
-
-- [SERIAL2_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial2-protocol-telemetry-2-protocol-selection) 10
-- [SERIAL2_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial2-options-telem2-options) 7
-
-## OSD Support
-
-The TBS Lucid H7 Wing AIO supports analog OSD using its onboard MAX7456 and simultaneously DisplayPort using TX3/RX3 on the HD VTX connector.
-
 ## PWM Output
 
 The TBS Lucid H7 Wing AIO supports up to 8 PWM or DShot outputs. Motor outputs
@@ -103,6 +91,18 @@ Pads for a second analog - BATTery monitor are provided. To use:
 - BATT2_CURR_PIN = 7
 - BATT2_VOLT_MULT = 11.0
 - BATT2_AMP_PERVLT = as required
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using an unused UART, such as the T2 pin (UART2 transmit).
+Using UART2 you would need to set the following parameters to enable support for FrSky S.PORT:
+
+- [SERIAL2_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial2-protocol-telemetry-2-protocol-selection) 10
+- [SERIAL2_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial2-options-telem2-options) 7
+
+## OSD Support
+
+The TBS Lucid H7 Wing AIO supports analog OSD using its onboard MAX7456 and simultaneously DisplayPort using TX3/RX3 on the HD VTX connector.
 
 ## Analog RSSI and AIRSPEED inputs
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_PRO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/TBS_LUCID_PRO/README.md
@@ -42,18 +42,6 @@ Note: If the receiver is FPort the receiver must be tied to the SERIAL1 TX pin ,
 and SERIAL1_OPTIONS must be set to 7 (invert TX/RX, half duplex). For full duplex like CRSF/ELRS use both
 RX1 and TX1 and set RSSI_TYPE also to 3.
 
-## FrSky Telemetry
-
-FrSky Telemetry is supported using an unused UART, such as the T4 pin (UART4 transmit).
-You need to set the following parameters to enable support for FrSky S.PORT:
-
-- SERIAL4_PROTOCOL 10
-- SERIAL4_OPTIONS 7
-
-## OSD Support
-
-The TBS LUCID PRO supports OSD using OSD_TYPE 1 (MAX7456 driver) and simultaneously DisplayPort using TX3/RX3 on the HD VTX connector.
-
 ## PWM Output
 
 The TBS LUCID PRO supports up to 6 PWM or DShot outputs. The pads for motor output
@@ -83,6 +71,18 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN 11
 - BATT_VOLT_MULT 20
 - BATT_AMP_PERVLT 40
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using an unused UART, such as the T4 pin (UART4 transmit).
+You need to set the following parameters to enable support for FrSky S.PORT:
+
+- SERIAL4_PROTOCOL 10
+- SERIAL4_OPTIONS 7
+
+## OSD Support
+
+The TBS LUCID PRO supports OSD using OSD_TYPE 1 (MAX7456 driver) and simultaneously DisplayPort using TX3/RX3 on the HD VTX connector.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/TMotorH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/TMotorH743/README.md
@@ -37,10 +37,6 @@ RC input is configured on the R6/TX6 (UART6_RX/UART6_TX) pins. It supports all s
 protocols. For protocols requiring half-duplex serial to transmit
 telemetry (such as FPort) you should setup SERIAL6 with half-duplex, pin-swap and inversion enabled.
 
-## OSD Support
-
-The T-Motor H7 Mini supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
 ## PWM Output
 
 The T-Motor H7 Mini supports up to 5 PWM outputs. The pads for motor output
@@ -69,6 +65,10 @@ The correct battery setting parameters are:
 - BATT_CURR_PIN 13
 - BATT_VOLT_MULT 11.0
 - BATT_AMP_PERVLT 50.0
+
+## OSD Support
+
+The T-Motor H7 Mini supports OSD using OSD_TYPE 1 (MAX7456 driver).
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/VUAV-TinyV7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/VUAV-TinyV7/README.md
@@ -36,6 +36,43 @@ The VUAV-V7Tiny  flight controller is manufactured and sold by [V-UAV](http://ww
 
 The Telem1 port has RTS/CTS pins, the other UARTs do not have RTS/CTS.
 
+## RC Input
+
+The RC input is configured on the RCIN pin at one end of the servo rail. This pin supports all unidirectional RC protocols. For bidirectional protocols, such as CRSF/ELRS, any SERIAL port can be set to protocol "23" and the receiver can be connected to its RX and TX pins as described in [RC control systems](https://ardupilot.org/rover/docs/common-rc-systems.html).
+
+## PWM Output
+
+The VUAV-V7Tiny supports up to 12 PWM outputs and all PWM protocols. Outputs 1-8 support bidirectional Dshot protocol. All 8 PWM outputs use a three-row design: the top row is GND, the middle rows are connected together, and the bottom row is the signal line. Outputs 9-12 do not support Dshot and are located at the ESC interface.
+
+The 12 PWM outputs are in 4 groups:
+
+- PWM 1, 2, 3 and 4 in group1
+- PWM 5, 6, 7 and 8 in group2
+- PWM 9, 10 in group3
+- PWM 11, 12 in group4
+
+Channels within the same group need to use the same output rate. If any channel in a group uses DShot, then all channels in that group need to use DShot.
+
+## Battery Monitoring
+
+The board has voltage and current inputs sensor on the POWER and ESC connector.
+
+The correct battery setting parameters are:
+
+Enable POWER monitor:
+
+- BATT_MONITOR 4
+- BATT_VOLT_PIN 4
+- BATT_CUR_PIN 8
+- BATT_VOLT_MULT 20
+- BATT_AMP_PERVLT 24
+
+Enable ESC battery monitor (if used) :
+
+- BATT2_MONITOR 3
+- BATT2_VOLT_PIN 10
+- BATT2_VOLT_MULT 10.09
+
 ## Connectors
 
 ### TELEM1 port
@@ -139,23 +176,6 @@ NOTE: RX7 is pinned out here and on the ESC connector
 |  7   |   PWM12    |    +3.3V    |
 |  8   |    GND     |     GND     |
 
-## RC Input
-
-The RC input is configured on the RCIN pin at one end of the servo rail. This pin supports all unidirectional RC protocols. For bidirectional protocols, such as CRSF/ELRS, any SERIAL port can be set to protocol "23" and the receiver can be connected to its RX and TX pins as described in [RC control systems](https://ardupilot.org/rover/docs/common-rc-systems.html).
-
-## PWM Output
-
-The VUAV-V7Tiny supports up to 12 PWM outputs and all PWM protocols. Outputs 1-8 support bidirectional Dshot protocol. All 8 PWM outputs use a three-row design: the top row is GND, the middle rows are connected together, and the bottom row is the signal line. Outputs 9-12 do not support Dshot and are located at the ESC interface.
-
-The 12 PWM outputs are in 4 groups:
-
-- PWM 1, 2, 3 and 4 in group1
-- PWM 5, 6, 7 and 8 in group2
-- PWM 9, 10 in group3
-- PWM 11, 12 in group4
-
-Channels within the same group need to use the same output rate. If any channel in a group uses DShot, then all channels in that group need to use DShot.
-
 ## GPIOs
 
 All 12 PWM channels can be used for GPIO functions (relays, buttons, RPM etc).
@@ -181,26 +201,6 @@ The VUAV-V7Tiny  flight controller has 6 Analog inputs
 - ADC Pin5 -> ADC 6V6 Sense
 - ADC Pin10  -> Battery Voltage input on ESC connector
 - ADC Pin8  -> Servo Voltage
-
-## Battery Monitoring
-
-The board has voltage and current inputs sensor on the POWER and ESC connector.
-
-The correct battery setting parameters are:
-
-Enable POWER monitor:
-
-- BATT_MONITOR 4
-- BATT_VOLT_PIN 4
-- BATT_CUR_PIN 8
-- BATT_VOLT_MULT 20
-- BATT_AMP_PERVLT 24
-
-Enable ESC battery monitor (if used) :
-
-- BATT2_MONITOR 3
-- BATT2_VOLT_PIN 10
-- BATT2_VOLT_MULT 10.09
 
 ## Loading Firmware
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/VUAV-V7pro/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/VUAV-V7pro/README.md
@@ -41,6 +41,41 @@ The VUAV-V7pro  flight controller is manufactured and sold by [V-UAV](http://www
 
 The Telem1,Telem2 port has RTS/CTS pins, the other UARTs do not have RTS/CTS.
 
+## RC Input
+
+RC input is configured on the RCIN pin, at one end of the servo rail. This pin supports all unidirectional RC protocols. For bi-directional protocols, such as CRSF/ELRS, UART8 can be set to protocol "23" and the receiver tied to RCIN (shared with UART8 RX) and UART8 TX. In this case, the RC_PROTOCOLS parameter should be set to the expected protocol type to avoid accidental erroneous detection by the RCIN path.
+
+## PWM Output
+
+The VUAV-V7pro supports up to 14 PWM outputs,support all PWM protocols. Outputs 1-12 support  DShot. Outputs 1-8 support bi-directional Dshot. All 14 PWM outputs have GND on the top row, 5V on the middle row and signal on the bottom row.
+
+The 14 PWM outputs are in 4 groups:
+
+- PWM 1, 2, 3 and 4 in group1
+- PWM 5, 6, 7 and 8 in group2
+- PWM 9, 10, 11 and 12 in group3
+- PWM 13, 14 in group4
+
+Channels within the same group need to use the same output rate. If any channel in a group uses DShot, then all channels in that group need to use DShot.
+
+## Battery Monitoring
+
+The board has voltage and current inputs sensor on the POWER1 ADC and POWER2 CAN connector.
+
+The correct battery setting parameters are:
+
+Enable Battery1 monitor:
+
+- BATT_MONITOR   4
+- BATT_VOLT_PIN 16
+- BATT_CUR_PIN 2
+- BATT_VOLT_MULT 15.7 (may need adjustment if supplied monitor is not used)
+- BATT_AMP_PERVLT 60.61 (may need adjustment if supplied monitor is not used)
+
+Enable Battery2 monitor (if used):
+
+- BATT2_MONITOR  8
+
 ## Connectors
 
 ### TELEM1 ,TELEM2 port
@@ -167,23 +202,6 @@ The Telem1,Telem2 port has RTS/CTS pins, the other UARTs do not have RTS/CTS.
 | 5 | GND | GND |
 | 6 | GND | GND |
 
-## RC Input
-
-RC input is configured on the RCIN pin, at one end of the servo rail. This pin supports all unidirectional RC protocols. For bi-directional protocols, such as CRSF/ELRS, UART8 can be set to protocol "23" and the receiver tied to RCIN (shared with UART8 RX) and UART8 TX. In this case, the RC_PROTOCOLS parameter should be set to the expected protocol type to avoid accidental erroneous detection by the RCIN path.
-
-## PWM Output
-
-The VUAV-V7pro supports up to 14 PWM outputs,support all PWM protocols. Outputs 1-12 support  DShot. Outputs 1-8 support bi-directional Dshot. All 14 PWM outputs have GND on the top row, 5V on the middle row and signal on the bottom row.
-
-The 14 PWM outputs are in 4 groups:
-
-- PWM 1, 2, 3 and 4 in group1
-- PWM 5, 6, 7 and 8 in group2
-- PWM 9, 10, 11 and 12 in group3
-- PWM 13, 14 in group4
-
-Channels within the same group need to use the same output rate. If any channel in a group uses DShot, then all channels in that group need to use DShot.
-
 ## GPIOs
 
 All 14 PWM channels can be used for GPIO functions (relays, buttons, RPM etc).
@@ -208,24 +226,6 @@ The VUAV-V7pro flight controller has 5 Analog inputs
 - ADC Pin19 -> ADC 3V3 Sense
 - ADC Pin3 -> ADC 6V6 Sense
 - ADC Pin9 -> RSSI voltage monitoring
-
-## Battery Monitoring
-
-The board has voltage and current inputs sensor on the POWER1 ADC and POWER2 CAN connector.
-
-The correct battery setting parameters are:
-
-Enable Battery1 monitor:
-
-- BATT_MONITOR   4
-- BATT_VOLT_PIN 16
-- BATT_CUR_PIN 2
-- BATT_VOLT_MULT 15.7 (may need adjustment if supplied monitor is not used)
-- BATT_AMP_PERVLT 60.61 (may need adjustment if supplied monitor is not used)
-
-Enable Battery2 monitor (if used):
-
-- BATT2_MONITOR  8
 
 ## Loading Firmware
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/X-MAV-AP-H743r1/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/X-MAV-AP-H743r1/README.md
@@ -7,43 +7,11 @@ It brings you ultimate performance, stability, and reliability in every aspect.
 
 ![AP-H743-R1](ap-h743r1-main.png)
 
-## Processors & Sensors
 
-- FMU Processor: STM32H743VIT6
-- 32 Bit Arm® Cortex®-M7, 480MHz, 2MB flash memory, 1MB RAM
-- IO Processor: STM32F103
-- 32 Bit Arm® Cortex®-M3, 72MHz, 20KB SRAM
-- On-board sensors
-- Accel/Gyro: ICM-42688-P\*2(Version1), BMI270\*2(Version2)
-- Mag: QMC5883P
-- Barometer: SPL06
 
-## Interfaces
 
-- 15x PWM Servo Outputs
-- 1x Dedicated S.Bus Input
-- 6x UARTs
-- 1x USB Port (TYPE-C)
-- 3x I2C Bus Ports
-- 2x CAN Ports
-- microSD card slot
-- 2x Dedicated Debug Port
-- FMU Debug
-- IO Debug
-
-## Purchase Channels
-
-Order from [X-MAV](https://www.x-mav.cn/).
-
-## Radio Control
-
-The SBUS-in pin supports all unidirectional RC protocols. For bi-directional RC systems (CRSF/ELRS,etc.) you will need to use a UART/SERIAL port such as SERIAL4:
-
-- Set SERIAL4_PROTOCOL to "23"
-- PPM is not supported.
-- FPort requires connection to TX4 and RX4 via a bi-directional inverter. See [FPort receivers](https://ardupilot.org/copter/docs/common-FPort-receivers.html)
-- CRSF/ELRS also requires a TX4 connection, in addition to RX4, and automatically provides telemetry.
-- SRXL2 requires a connection to TX4 and automatically provides telemetry. Set SERIAL4_OPTIONS to "4".
+<!-- TODO: add Features content -->
+<!-- TODO: add Pinout content -->
 
 ## UART Mapping
 
@@ -56,6 +24,10 @@ all UARTs have DMA
 - SERIAL4 -> UART4 (MAVLink2)
 - SERIAL5 -> UART7 (User)
 - SERIAL6 -> UART8 (User)
+
+
+
+<!-- TODO: add RC Input content -->
 
 ## PWM Output
 
@@ -110,6 +82,44 @@ The default battery parameters are:
 - BATT_CURR_PIN 8
 - BATT_VOLT_MULT 18.5
 - BATT_AMP_PERVLT 40
+
+## Processors & Sensors
+
+- FMU Processor: STM32H743VIT6
+- 32 Bit Arm® Cortex®-M7, 480MHz, 2MB flash memory, 1MB RAM
+- IO Processor: STM32F103
+- 32 Bit Arm® Cortex®-M3, 72MHz, 20KB SRAM
+- On-board sensors
+- Accel/Gyro: ICM-42688-P\*2(Version1), BMI270\*2(Version2)
+- Mag: QMC5883P
+- Barometer: SPL06
+
+## Interfaces
+
+- 15x PWM Servo Outputs
+- 1x Dedicated S.Bus Input
+- 6x UARTs
+- 1x USB Port (TYPE-C)
+- 3x I2C Bus Ports
+- 2x CAN Ports
+- microSD card slot
+- 2x Dedicated Debug Port
+- FMU Debug
+- IO Debug
+
+## Purchase Channels
+
+Order from [X-MAV](https://www.x-mav.cn/).
+
+## Radio Control
+
+The SBUS-in pin supports all unidirectional RC protocols. For bi-directional RC systems (CRSF/ELRS,etc.) you will need to use a UART/SERIAL port such as SERIAL4:
+
+- Set SERIAL4_PROTOCOL to "23"
+- PPM is not supported.
+- FPort requires connection to TX4 and RX4 via a bi-directional inverter. See [FPort receivers](https://ardupilot.org/copter/docs/common-FPort-receivers.html)
+- CRSF/ELRS also requires a TX4 connection, in addition to RX4, and automatically provides telemetry.
+- SRXL2 requires a connection to TX4 and automatically provides telemetry. Set SERIAL4_OPTIONS to "4".
 
 ## Pinouts
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/X-MAV-AP-H743v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/X-MAV-AP-H743v2/README.md
@@ -17,11 +17,9 @@ The AP-H743v2 is a flight controller designed and produced by X-MAV
 - 1 I2C
 - 1 SWD
 
-## Physical
 
-![X-MAV AP-H743v2 Front View](AP-H743v2_TopPort.png)
 
-![X-MAV AP-H743v2  Back View](AP-H743v2_BottomPort.png)
+<!-- TODO: add Pinout content -->
 
 ## UART Mapping
 
@@ -38,14 +36,6 @@ The AP-H743v2 is a flight controller designed and produced by X-MAV
 ## RC Input
 
 The default RC input is configured on the UART5 and supports all RC protocols except PPM. The SBUS pin is inverted and connected to RX5. When using RX5 or SBUS, the other input should be unconnected. RC can be attached to any UART port as long as the serial port protocol is set to `SERIALn_PROTOCOL=23` and SERIAL7_Protocol  is changed to something other than '23'.
-
-## OSD Support
-
-The AP-H743v2 supports onboard analog SD OSD using a MAX7456 chip. Simultaneously, DisplayPort HD OSD is available on the DJI connector for HD VTX. Both on board OSD and DisplayPort OSD can be operated simultaneously.
-
-## VTX Support
-
-The SH1.0-6P connector supports a DJI Air Unit / HD VTX connection. Protocol defaults to DisplayPort. Pin 1 of the connector is 9v so be careful not to connect this to a peripheral requiring 5v.
 
 ## PWM Output
 
@@ -73,6 +63,20 @@ The default battery parameters are:
 - BATT_CURR_PIN 8
 - BATT_VOLT_MULT 10.2
 - BATT_AMP_PERVLT 20.4
+
+## Physical
+
+![X-MAV AP-H743v2 Front View](AP-H743v2_TopPort.png)
+
+![X-MAV AP-H743v2  Back View](AP-H743v2_BottomPort.png)
+
+## OSD Support
+
+The AP-H743v2 supports onboard analog SD OSD using a MAX7456 chip. Simultaneously, DisplayPort HD OSD is available on the DJI connector for HD VTX. Both on board OSD and DisplayPort OSD can be operated simultaneously.
+
+## VTX Support
+
+The SH1.0-6P connector supports a DJI Air Unit / HD VTX connection. Protocol defaults to DisplayPort. Pin 1 of the connector is 9v so be careful not to connect this to a peripheral requiring 5v.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/YARIV6X/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/YARIV6X/README.md
@@ -1,15 +1,5 @@
 # YARI V6X
 
-## Introduction
-
-The YARI V6X autopilot is based on the [FMUV6X and Pixhawk Autopilot Bus open source specifications](https://github.com/pixhawk/Pixhawk-Standards). The Pixhawk Autopilot Bus (PAB) form factor enables the YARI V6X to be used on any PAB carrier board.
-
-![YARI V6X Product](yariv6x-product.jpg)
-
-## Where to Buy
-
-YARI V6X autopilots are produced and sold by [YARI Robotics](https://yarirobotics.com).
-
 ## Features
 
 - Modular architecture: Discrete IMU, FMU, and base boards linked by the Pixhawk Autopilot Bus (PAB) for clean routing, serviceability, and future upgrades.
@@ -19,6 +9,71 @@ YARI V6X autopilots are produced and sold by [YARI Robotics](https://yarirobotic
 - Thermally stabilized IMUs: Actively temperature controlled IMU board maintains the IMU sensors at their optimal operating temperature for consistent accuracy.
 - Vibration isolation: Durable custom formulated foam material to offer optimal vibration damping characteristics for better IMU stability and accuracy.
 - Rugged enclosure: Precision CNC-machined aluminum housing for durability, thermal performance, and EMI shielding.
+
+## Pinout
+
+![YARI V6X Pinout](yariv6x-pinout.jpg)
+
+## UART Mapping
+
+| Serial# | Port            | UART              |
+|---------|-----------------|-------------------|
+| SERIAL0 | OTG1            | USB               |
+| SERIAL1 | Telem1          | UART7 (RTC/CTS)   |
+| SERIAL2 | Telem2          | UART5 (RTS/CTS)   |
+| SERIAL3 | GPS1            | USART1            |
+| SERIAL4 | GPS2            | UART8             |
+| SERIAL5 | Telem3          | USART2 (RTS/CTS)  |
+| SERIAL6 | UART4, I2C      | UART4             |
+| SERIAL7 | Debug Console   | USART3            |
+| SERIAL8 | IO/RC           | USART6            |
+
+All UARTs have DMA capability
+
+## RC Input
+
+The PPM pin, which by default is mapped to a timer input, can be used for all ArduPilot supported unidirectional receiver protocols,. Half-Duplex and bi-directional protocols, such as CRSF/ELRS, Fport, and SRXL2) require a true UART connection (see below). FPort when connected to PPM will only provide RC without telemetry.
+
+To allow CRSF and embedded telemetry available in Fport, CRSF, and SRXL2 receivers, a full UART, such as SERIAL6 (UART4) would need to be used for receiver connections. Below are setups using SERIAL6.
+
+- [SERIAL6_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial6-protocol-serial6-protocol-selection) should be set to “23”.
+- FPort would require [SERIAL6_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial6-options-serial6-options) be set to “15”.
+- CRSF/ELRS would require [SERIAL6_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial6-options-serial6-options) be set to “0”.
+- SRXL2 would require [SERIAL6_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial6-options-serial6-options) be set to “4” and connects only the TX pin.
+
+Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM. See [Radio Control Systems](https://ardupilot.org/copter/docs/common-rc-systems.html#common-rc-systems) for details.
+
+## PWM Output
+
+The YARI V6X supports up to 16 PWM outputs (M1-8 and A1-8). All 16 outputs support all normal PWM output formats. All outputs support DShot and BiDir DShot, except A7 and A8 which only support PWM.
+
+The 8 FMU PWM outputs (A1-8) are in 4 groups:
+
+- Outputs 1, 2, 3 and 4 in group1
+- Outputs 5 and 6 in group2
+- Outputs 7 and 8 in group3
+
+FMU outputs within the same group need to use the same output rate and protocol. If any output in a group uses DShot then all channels in that group need to use DShot.
+
+## Battery Monitoring
+
+The default battery parameters for use with a digital power module (with INA2xx) connected to Power1 port:
+
+BATT_I2C_BUS=1
+BATT_I2C_ADDR=0
+BATT_MONITOR=21
+
+For use with Power2 port update BATT_I2C_BUS = 2
+
+## Introduction
+
+The YARI V6X autopilot is based on the [FMUV6X and Pixhawk Autopilot Bus open source specifications](https://github.com/pixhawk/Pixhawk-Standards). The Pixhawk Autopilot Bus (PAB) form factor enables the YARI V6X to be used on any PAB carrier board.
+
+![YARI V6X Product](yariv6x-product.jpg)
+
+## Where to Buy
+
+YARI V6X autopilots are produced and sold by [YARI Robotics](https://yarirobotics.com).
 
 ## Specifications
 
@@ -56,61 +111,6 @@ Carrier Board
 - LED Indicators
 
 ![YARI V6X Dimensions](yariv6x-dimensions.jpg)
-
-## Pinout
-
-![YARI V6X Pinout](yariv6x-pinout.jpg)
-
-## UART Mapping
-
-| Serial# | Port            | UART              |
-|---------|-----------------|-------------------|
-| SERIAL0 | OTG1            | USB               |
-| SERIAL1 | Telem1          | UART7 (RTC/CTS)   |
-| SERIAL2 | Telem2          | UART5 (RTS/CTS)   |
-| SERIAL3 | GPS1            | USART1            |
-| SERIAL4 | GPS2            | UART8             |
-| SERIAL5 | Telem3          | USART2 (RTS/CTS)  |
-| SERIAL6 | UART4, I2C      | UART4             |
-| SERIAL7 | Debug Console   | USART3            |
-| SERIAL8 | IO/RC           | USART6            |
-
-All UARTs have DMA capability
-
-## PWM Output
-
-The YARI V6X supports up to 16 PWM outputs (M1-8 and A1-8). All 16 outputs support all normal PWM output formats. All outputs support DShot and BiDir DShot, except A7 and A8 which only support PWM.
-
-The 8 FMU PWM outputs (A1-8) are in 4 groups:
-
-- Outputs 1, 2, 3 and 4 in group1
-- Outputs 5 and 6 in group2
-- Outputs 7 and 8 in group3
-
-FMU outputs within the same group need to use the same output rate and protocol. If any output in a group uses DShot then all channels in that group need to use DShot.
-
-## RC Input
-
-The PPM pin, which by default is mapped to a timer input, can be used for all ArduPilot supported unidirectional receiver protocols,. Half-Duplex and bi-directional protocols, such as CRSF/ELRS, Fport, and SRXL2) require a true UART connection (see below). FPort when connected to PPM will only provide RC without telemetry.
-
-To allow CRSF and embedded telemetry available in Fport, CRSF, and SRXL2 receivers, a full UART, such as SERIAL6 (UART4) would need to be used for receiver connections. Below are setups using SERIAL6.
-
-- [SERIAL6_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial6-protocol-serial6-protocol-selection) should be set to “23”.
-- FPort would require [SERIAL6_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial6-options-serial6-options) be set to “15”.
-- CRSF/ELRS would require [SERIAL6_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial6-options-serial6-options) be set to “0”.
-- SRXL2 would require [SERIAL6_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial6-options-serial6-options) be set to “4” and connects only the TX pin.
-
-Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM. See [Radio Control Systems](https://ardupilot.org/copter/docs/common-rc-systems.html#common-rc-systems) for details.
-
-## Battery Monitoring
-
-The default battery parameters for use with a digital power module (with INA2xx) connected to Power1 port:
-
-BATT_I2C_BUS=1
-BATT_I2C_ADDR=0
-BATT_MONITOR=21
-
-For use with Power2 port update BATT_I2C_BUS = 2
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/YJUAV_A6/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/YJUAV_A6/README.md
@@ -26,6 +26,41 @@ The [full schematics](https://github.com/yunjiuav/Hardware/tree/main/A6) of the 
 
 ![YJUAV_A6 Board](YJUAV_A6-pinout.jpg "YJUAV_A6")
 
+## UART Mapping
+
+- SERIAL0 -> USB(OTG1)
+- SERIAL1 -> USART1(Telem1)
+- SERIAL2 -> USART2 (Telem2)
+- SERIAL3 -> USART3 (GPS1), NODMA
+- SERIAL4 -> UART5 (GPS2), NODMA
+- SERIAL5 -> UART6 (SBUS)
+- SERIAL6 -> UART7 (Debug), NODMA
+- SERIAL7 -> USB2(OTG2)
+
+## RC Input
+
+The remote control signal should be connected to the “RC IN” pin, at one side of the servo channels.
+
+This signal pin supports two types of remote control signal inputs, SBUS and PPM signals.
+
+## PWM Output
+
+The A6 supports up to 14 PWM outputs,support all PWM protocols as well as DShot. All 14 PWM outputs have GND on the bottom row, 5V on the middle row and signal on the top row.
+
+The 14 PWM outputs are in 4 groups:
+
+- PWM 1, 2, 3 and 4 in group1
+- PWM 5, 6, 7 and 8 in group2
+- PWM 9, 10, 11 and 12 in group3
+- PWM 13 and 14 group4
+
+Channels 1-8 support bi-directional Dshot, channels 9-12 support Dshot, channels 13-14 support regular PWM.
+Channels within the same group need to use the same output rate. If any channel in a group uses DShot, then all channels in that group need to use DShot.
+
+## Battery Monitoring
+
+The A6 flight controller has two six-pin power connectors, supporting CAN interface power supply and analog interface power supply.
+
 ## Connectors
 
 ### ADC
@@ -162,41 +197,6 @@ The [full schematics](https://github.com/yunjiuav/Hardware/tree/main/A6) of the 
 |  4   | CAN_N  | +3.3V |
 |  5   |  GND   |  GND  |
 |  6   |  GND   |  GND  |
-
-## UART Mapping
-
-- SERIAL0 -> USB(OTG1)
-- SERIAL1 -> USART1(Telem1)
-- SERIAL2 -> USART2 (Telem2)
-- SERIAL3 -> USART3 (GPS1), NODMA
-- SERIAL4 -> UART5 (GPS2), NODMA
-- SERIAL5 -> UART6 (SBUS)
-- SERIAL6 -> UART7 (Debug), NODMA
-- SERIAL7 -> USB2(OTG2)
-
-## RC Input
-
-The remote control signal should be connected to the “RC IN” pin, at one side of the servo channels.
-
-This signal pin supports two types of remote control signal inputs, SBUS and PPM signals.
-
-## PWM Output
-
-The A6 supports up to 14 PWM outputs,support all PWM protocols as well as DShot. All 14 PWM outputs have GND on the bottom row, 5V on the middle row and signal on the top row.
-
-The 14 PWM outputs are in 4 groups:
-
-- PWM 1, 2, 3 and 4 in group1
-- PWM 5, 6, 7 and 8 in group2
-- PWM 9, 10, 11 and 12 in group3
-- PWM 13 and 14 group4
-
-Channels 1-8 support bi-directional Dshot, channels 9-12 support Dshot, channels 13-14 support regular PWM.
-Channels within the same group need to use the same output rate. If any channel in a group uses DShot, then all channels in that group need to use DShot.
-
-## Battery Monitoring
-
-The A6 flight controller has two six-pin power connectors, supporting CAN interface power supply and analog interface power supply.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/YJUAV_A6SE/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/YJUAV_A6SE/README.md
@@ -24,6 +24,40 @@ The A6SE flight controller is manufactured and sold by [YJUAV](http://www.yjuav.
 
 ![YJUAV_A6SE Board](YJUAV_A6SE-pinout.jpg "YJUAV_A6SE")
 
+## UART Mapping
+
+- SERIAL0 -> USB (OTG1)
+- SERIAL1 -> USART1 (Telem1)
+- SERIAL2 -> USART6 (Telem2)
+- SERIAL3 -> USART3 (GPS1), NODMA
+- SERIAL4 -> USART2 (GPS2), NODMA
+- SERIAL5 -> UART8 (SBUS)
+- SERIAL6 -> UART7 (Debug), NODMA
+- SERIAL7 -> USB2 (OTG2)
+
+## RC Input
+
+The remote control signal should be connected to the “RC IN” pin, at one side of the servo channels.
+
+This signal pin supports two types of remote control signal inputs, SBUS and PPM signals.
+
+## PWM Output
+
+The A6SE supports up to 11 PWM outputs,support all PWM protocols as well as DShot. All 11 PWM outputs have GND on the bottom row, 5V on the middle row and signal on the top row.
+
+The 11 PWM outputs are in 4 groups:
+
+- PWM 1, 2, 3 and 4 in group1
+- PWM 5, 6, 7 and 8 in group2
+- PWM 9, 10, 11 in group3
+
+Channels 1-8 support bi-directional Dshot.
+Channels within the same group need to use the same output rate. If any channel in a group uses DShot, then all channels in that group need to use DShot.
+
+
+
+<!-- TODO: add Battery Monitoring content -->
+
 ## Connectors
 
 ### POWER ADC
@@ -142,36 +176,6 @@ The A6SE flight controller is manufactured and sold by [YJUAV](http://www.yjuav.
 |  2   |   DM   | +3.3V |
 |  3   |   DP   | +3.3V |
 |  4   |  GND   |  GND  |
-
-## UART Mapping
-
-- SERIAL0 -> USB (OTG1)
-- SERIAL1 -> USART1 (Telem1)
-- SERIAL2 -> USART6 (Telem2)
-- SERIAL3 -> USART3 (GPS1), NODMA
-- SERIAL4 -> USART2 (GPS2), NODMA
-- SERIAL5 -> UART8 (SBUS)
-- SERIAL6 -> UART7 (Debug), NODMA
-- SERIAL7 -> USB2 (OTG2)
-
-## RC Input
-
-The remote control signal should be connected to the “RC IN” pin, at one side of the servo channels.
-
-This signal pin supports two types of remote control signal inputs, SBUS and PPM signals.
-
-## PWM Output
-
-The A6SE supports up to 11 PWM outputs,support all PWM protocols as well as DShot. All 11 PWM outputs have GND on the bottom row, 5V on the middle row and signal on the top row.
-
-The 11 PWM outputs are in 4 groups:
-
-- PWM 1, 2, 3 and 4 in group1
-- PWM 5, 6, 7 and 8 in group2
-- PWM 9, 10, 11 in group3
-
-Channels 1-8 support bi-directional Dshot.
-Channels within the same group need to use the same output rate. If any channel in a group uses DShot, then all channels in that group need to use DShot.
 
 ## GPIOs
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/YJUAV_A6SE_H743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/YJUAV_A6SE_H743/README.md
@@ -24,6 +24,70 @@ The A6SE_H743 flight controller is manufactured and sold by [YJUAV](http://www.y
 
 ![YJUAV_A6SE_H743 Board](YJUAV_A6SE_H743-pinout.jpg "YJUAV_A6SE_H743")
 
+## UART Mapping
+
+- SERIAL0 -> USB (OTG1)
+- SERIAL1 -> USART2 (Telem1)
+- SERIAL2 -> USART6 (Telem2)
+- SERIAL3 -> USART3 (GPS1), NODMA
+- SERIAL4 -> USART1 (GPS2), NODMA
+- SERIAL5 -> UART8 (USER) TX only, normally used for SBUS_OUT with protocol change
+- SERIAL6 -> UART7 (USER/Debug), NODMA
+- SERIAL7 -> USB2 (OTG2)
+
+## RC Input
+
+The RCIN pin is mapped to a timer input instead of the UART, and can be used for all ArduPilot supported receiver protocols, except CRSF/ELRS and SRXL2 which require a true UART connection. However, FPort, when connected in this manner, can provide RC without telemetry.
+
+To allow CRSF and embedded telemetry available in Fport, CRSF, and SRXL2 receivers, a full UART must be used. For example, UART1 can have its protocol changed from the default GPS protocol for GPS2 to RX input protocol:
+
+With this option, SERIAL4_PROTOCOL must be set to “23”, and:
+
+PPM is not supported.
+
+SBUS/DSM/SRXL connects to the RX1 pin.
+
+FPort requires connection to TX1 and RX1. See FPort Receivers.
+
+CRSF also requires a TX1 connection, in addition to RX1, and automatically provides telemetry.
+
+SRXL2 requires a connection to TX1 and automatically provides telemetry. Set SERIAL4_OPTIONS to “4”.
+
+Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM. See Radio Control Systems for details.
+
+## PWM Output
+
+The A6SE_H743 supports up to 11 PWM outputs,support all PWM protocols as well as DShot. All 11 PWM outputs have GND on the bottom row, 5V on the middle row and signal on the top row.
+
+The 11 PWM outputs are in 3 groups:
+
+- PWM 1, 2, 3 and 4 in group1
+- PWM 5, 6, 7 and 8 in group2
+- PWM 9, 10, 11 in group3
+
+Channels 1-8 support bi-directional Dshot.
+Channels within the same group need to use the same output rate. If any channel in a group uses DShot, then all channels in that group need to use DShot.
+
+## Battery Monitoring
+
+The board has voltage and current sensor inputs on the POWER_ADC connector.
+
+The correct battery setting parameters are:
+
+Enable Battery monitor.
+
+BATT_MONITOR =4
+
+Then reboot.
+
+BATT_VOLT_PIN 2
+
+BATT_CURR_PIN 4
+
+BATT_VOLT_MULT 21.0 (may need adjustment if supplied monitor is not used)
+
+BATT_AMP_PERVLT 34.0 (may need adjustment if supplied monitor is not used)
+
 ## Connectors
 
 ### POWER ADC
@@ -163,50 +227,6 @@ The A6SE_H743 flight controller is manufactured and sold by [YJUAV](http://www.y
 |  3   |   DP   | +3.3V |
 |  4   |  GND   |  GND  |
 
-## UART Mapping
-
-- SERIAL0 -> USB (OTG1)
-- SERIAL1 -> USART2 (Telem1)
-- SERIAL2 -> USART6 (Telem2)
-- SERIAL3 -> USART3 (GPS1), NODMA
-- SERIAL4 -> USART1 (GPS2), NODMA
-- SERIAL5 -> UART8 (USER) TX only, normally used for SBUS_OUT with protocol change
-- SERIAL6 -> UART7 (USER/Debug), NODMA
-- SERIAL7 -> USB2 (OTG2)
-
-## RC Input
-
-The RCIN pin is mapped to a timer input instead of the UART, and can be used for all ArduPilot supported receiver protocols, except CRSF/ELRS and SRXL2 which require a true UART connection. However, FPort, when connected in this manner, can provide RC without telemetry.
-
-To allow CRSF and embedded telemetry available in Fport, CRSF, and SRXL2 receivers, a full UART must be used. For example, UART1 can have its protocol changed from the default GPS protocol for GPS2 to RX input protocol:
-
-With this option, SERIAL4_PROTOCOL must be set to “23”, and:
-
-PPM is not supported.
-
-SBUS/DSM/SRXL connects to the RX1 pin.
-
-FPort requires connection to TX1 and RX1. See FPort Receivers.
-
-CRSF also requires a TX1 connection, in addition to RX1, and automatically provides telemetry.
-
-SRXL2 requires a connection to TX1 and automatically provides telemetry. Set SERIAL4_OPTIONS to “4”.
-
-Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM. See Radio Control Systems for details.
-
-## PWM Output
-
-The A6SE_H743 supports up to 11 PWM outputs,support all PWM protocols as well as DShot. All 11 PWM outputs have GND on the bottom row, 5V on the middle row and signal on the top row.
-
-The 11 PWM outputs are in 3 groups:
-
-- PWM 1, 2, 3 and 4 in group1
-- PWM 5, 6, 7 and 8 in group2
-- PWM 9, 10, 11 in group3
-
-Channels 1-8 support bi-directional Dshot.
-Channels within the same group need to use the same output rate. If any channel in a group uses DShot, then all channels in that group need to use DShot.
-
 ## GPIOs
 
 All 11 PWM channels can be used for GPIO functions (relays, buttons, RPM etc).
@@ -232,26 +252,6 @@ The A6SE_H743 flight controller has 5 analog inputs
 - ADC Pin8   -> ADC 3V3 Sense
 - ADC Pin10 -> ADC 6V6 Sense
 - ADC Pin11 -> RSSI voltage monitoring
-
-## Battery Monitoring
-
-The board has voltage and current sensor inputs on the POWER_ADC connector.
-
-The correct battery setting parameters are:
-
-Enable Battery monitor.
-
-BATT_MONITOR =4
-
-Then reboot.
-
-BATT_VOLT_PIN 2
-
-BATT_CURR_PIN 4
-
-BATT_VOLT_MULT 21.0 (may need adjustment if supplied monitor is not used)
-
-BATT_AMP_PERVLT 34.0 (may need adjustment if supplied monitor is not used)
 
 ## Build the FC
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/YJUAV_A6Ultra/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/YJUAV_A6Ultra/README.md
@@ -24,6 +24,80 @@ The A6Ultra flight controller is manufactured and sold by [YJUAV](http://www.yju
 
 ![YJUAV_A6Ultra Board](YJUAV_A6Ultra-pinout.jpg "YJUAV_A6Ultra")
 
+## UART Mapping
+
+- SERIAL0 -> USB (OTG1)
+- SERIAL1 -> USART2 (Telem1)
+- SERIAL2 -> USART6 (Telem2)
+- SERIAL3 -> USART3 (GPS1)
+- SERIAL4 -> USART1 (GPS2)
+- SERIAL5 -> UART8 (USER) TX only, normally used for SBUS_OUT with protocol change
+- SERIAL6 -> UART7 (USER/Debug), NODMA
+- SERIAL7 -> USB2 (OTG2)
+
+## RC Input
+
+The RCIN pin is mapped to a timer input instead of the UART, and can be used for all ArduPilot supported receiver protocols, except CRSF/ELRS and SRXL2 which require a true UART connection. However, FPort, when connected in this manner, can provide RC without telemetry.
+
+To allow CRSF and embedded telemetry available in Fport, CRSF, and SRXL2 receivers, a full UART must be used. For example, UART1 can have its protocol changed from the default GPS protocol for GPS2 to RX input protocol:
+
+With this option, SERIAL4_PROTOCOL must be set to “23”, and:
+
+PPM is not supported.
+
+SBUS/DSM/SRXL connects to the RX1 pin.
+
+FPort requires connection to TX1 and RX1. See FPort Receivers.
+
+CRSF also requires a TX1 connection, in addition to RX1, and automatically provides telemetry.
+
+SRXL2 requires a connection to TX1 and automatically provides telemetry. Set SERIAL4_OPTIONS to “4”.
+
+Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM. See Radio Control Systems for details.
+
+## PWM Output
+
+The A6Ultra supports up to 13 PWM outputs,support all PWM protocols as well as DShot. All 13 PWM outputs have GND on the bottom row, 5V on the middle row and Signal on the top row.
+
+The 13 PWM outputs are in 4 groups:
+
+- PWM 1, 2, 3 and 4 in group1
+- PWM 5, 6, 7 and 8 in group2
+- PWM 9, 10, 11 in group3
+- PWM 12, 13 in group4
+
+Channels 1-8 support bi-directional Dshot.
+Channels within the same group need to use the same output rate. If any channel in a group uses DShot, then all channels in that group need to use DShot.
+
+## Battery Monitoring
+
+The board has voltage and current sensor inputs on the POWER1_ADC and POWER2_ADC connector.
+
+The correct battery setting parameters are:
+
+Enable Battery1 monitor:
+
+BATT_MONITOR    4
+
+BATT_VOLT_PIN   2
+
+BATT_CURR_PIN   4
+
+BATT_VOLT_MULT 21.0 (may need adjustment if supplied monitor is not used)
+
+BATT_AMP_PERVLT 34.6 (may need adjustment if supplied monitor is not used)
+
+Enable Battery2 monitor:
+BATT2_MONITOR   4
+
+BATT2_VOLT_PIN  12
+
+BATT2_CURR_PIN  16
+
+BATT2_VOLT_MULT 21.0 (may need adjustment if supplied monitor is not used)
+
+BATT2_AMP_PERVLT 34.6 (may need adjustment if supplied monitor is not used)
+
 ## Connectors
 
 ### POWER1 ADC
@@ -174,51 +248,6 @@ The A6Ultra flight controller is manufactured and sold by [YJUAV](http://www.yju
 |  3   |   DP   | +3.3V |
 |  4   |  GND   |  GND  |
 
-## UART Mapping
-
-- SERIAL0 -> USB (OTG1)
-- SERIAL1 -> USART2 (Telem1)
-- SERIAL2 -> USART6 (Telem2)
-- SERIAL3 -> USART3 (GPS1)
-- SERIAL4 -> USART1 (GPS2)
-- SERIAL5 -> UART8 (USER) TX only, normally used for SBUS_OUT with protocol change
-- SERIAL6 -> UART7 (USER/Debug), NODMA
-- SERIAL7 -> USB2 (OTG2)
-
-## RC Input
-
-The RCIN pin is mapped to a timer input instead of the UART, and can be used for all ArduPilot supported receiver protocols, except CRSF/ELRS and SRXL2 which require a true UART connection. However, FPort, when connected in this manner, can provide RC without telemetry.
-
-To allow CRSF and embedded telemetry available in Fport, CRSF, and SRXL2 receivers, a full UART must be used. For example, UART1 can have its protocol changed from the default GPS protocol for GPS2 to RX input protocol:
-
-With this option, SERIAL4_PROTOCOL must be set to “23”, and:
-
-PPM is not supported.
-
-SBUS/DSM/SRXL connects to the RX1 pin.
-
-FPort requires connection to TX1 and RX1. See FPort Receivers.
-
-CRSF also requires a TX1 connection, in addition to RX1, and automatically provides telemetry.
-
-SRXL2 requires a connection to TX1 and automatically provides telemetry. Set SERIAL4_OPTIONS to “4”.
-
-Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM. See Radio Control Systems for details.
-
-## PWM Output
-
-The A6Ultra supports up to 13 PWM outputs,support all PWM protocols as well as DShot. All 13 PWM outputs have GND on the bottom row, 5V on the middle row and Signal on the top row.
-
-The 13 PWM outputs are in 4 groups:
-
-- PWM 1, 2, 3 and 4 in group1
-- PWM 5, 6, 7 and 8 in group2
-- PWM 9, 10, 11 in group3
-- PWM 12, 13 in group4
-
-Channels 1-8 support bi-directional Dshot.
-Channels within the same group need to use the same output rate. If any channel in a group uses DShot, then all channels in that group need to use DShot.
-
 ## GPIOs
 
 All 13 PWM channels can be used for GPIO functions (relays, buttons, RPM etc).
@@ -246,35 +275,6 @@ The A6Ultra flight controller has 7 Analog inputs
 - ADC Pin8   -> ADC 3V3 Sense
 - ADC Pin10 -> ADC 6V6 Sense
 - ADC Pin11 -> RSSI voltage monitoring
-
-## Battery Monitoring
-
-The board has voltage and current sensor inputs on the POWER1_ADC and POWER2_ADC connector.
-
-The correct battery setting parameters are:
-
-Enable Battery1 monitor:
-
-BATT_MONITOR    4
-
-BATT_VOLT_PIN   2
-
-BATT_CURR_PIN   4
-
-BATT_VOLT_MULT 21.0 (may need adjustment if supplied monitor is not used)
-
-BATT_AMP_PERVLT 34.6 (may need adjustment if supplied monitor is not used)
-
-Enable Battery2 monitor:
-BATT2_MONITOR   4
-
-BATT2_VOLT_PIN  12
-
-BATT2_CURR_PIN  16
-
-BATT2_VOLT_MULT 21.0 (may need adjustment if supplied monitor is not used)
-
-BATT2_AMP_PERVLT 34.6 (may need adjustment if supplied monitor is not used)
 
 ## Build the FC
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ZeroOneX6/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ZeroOneX6/README.md
@@ -95,6 +95,11 @@ The 8 FMU PWM outputs are in 4 groups:
 
 Channels within the same group need to use the same output rate. If any channel in a group uses DShot then all channels in the group need to use DShot.
 
+## Battery Monitoring
+
+The X6 flight controller has two six-pin power connectors, supporting CAN interface power supply.
+These are set by default in the firmware and shouldn't need to be adjusted.
+
 ## GPIOs
 
 All PWM outputs can be used as GPIOs (relays, camera, RPM etc). To use them you need to set the output’s SERVOx_FUNCTION to -1. The numbering of the GPIOs for PIN variables in ArduPilot is:
@@ -124,11 +129,6 @@ All PWM outputs can be used as GPIOs (relays, camera, RPM etc). To use them you 
 | M16 | 57 | BB Blue GPIo pin 3 |
 |  |  |  |
 |  | FCU CAP | 58 |
-
-## Battery Monitoring
-
-The X6 flight controller has two six-pin power connectors, supporting CAN interface power supply.
-These are set by default in the firmware and shouldn't need to be adjusted.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ZeroOneX6_Air/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ZeroOneX6_Air/README.md
@@ -106,6 +106,17 @@ The A9-15 outputs are in 4 groups:
 
 Channels within the same group need to use the same output rate. If any channel in a group uses DShot then all channels in the group need to use DShot.
 
+## Battery Monitoring
+
+The X6_Air flight controller has one six-pin power connectors, supporting CAN interface power supply.
+The autopilot defaults are setup for CAN Power Module use (normally supplied with autopilot):
+
+- BATT_MONITOR = 8
+- CAN_P1_DRIVER = 1
+- CAN_P2_DRIVER = 1
+- CAN_D1_PROTOCOL = 1
+- CAN_D2_PROTOCOL = 1
+
 ## GPIOs
 
 All PWM outputs can be used as GPIOs (relays, camera, RPM etc). To use them you need to set the output’s SERVOx_FUNCTION to -1. The numbering of the GPIOs for PIN variables in ArduPilot is:
@@ -133,17 +144,6 @@ All PWM outputs can be used as GPIOs (relays, camera, RPM etc). To use them you 
 | 56 |  | M8 |
 | 108 | MainOut8 |  |
 |  |  |  |
-
-## Battery Monitoring
-
-The X6_Air flight controller has one six-pin power connectors, supporting CAN interface power supply.
-The autopilot defaults are setup for CAN Power Module use (normally supplied with autopilot):
-
-- BATT_MONITOR = 8
-- CAN_P1_DRIVER = 1
-- CAN_P2_DRIVER = 1
-- CAN_D1_PROTOCOL = 1
-- CAN_D2_PROTOCOL = 1
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/modalai_fc-v1/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/modalai_fc-v1/README.md
@@ -43,16 +43,6 @@ See Flight Core Datasheet [Here](https://docs.modalai.com/flight-core-datasheets
 
 For detailed pinout descriptions see [FlightCore Pinout](https://docs.modalai.com/flight-core-datasheets-connectors/)
 
-## Dimensions
-
-![ModalAI-fc-dims](flight_core_v1_imu_locations.png "modal-fc-dims")
-
-![ModalAI_fc-dims2](flight-core-dims.png "modal-fc-dims2")
-
-## Block Diagram
-
-![ModalAI_FC](fc-dk-preliminary-datasheet.png "modal-fc-block")
-
 ## UART Mapping
 
 The UARTs are marked Rn and Tn in the above pinouts. The Rn pin is the
@@ -96,6 +86,16 @@ the modalAI build supports two I2C power monitors, the INA231 and the
 LTC2946. The FlightCore board comes with the INA231 and you should set
 BATTERY_MONITOR to 21. For the LTC2946 based power brick you should
 set BATTERY_MONITOR to 22.
+
+## Dimensions
+
+![ModalAI-fc-dims](flight_core_v1_imu_locations.png "modal-fc-dims")
+
+![ModalAI_fc-dims2](flight-core-dims.png "modal-fc-dims2")
+
+## Block Diagram
+
+![ModalAI_FC](fc-dk-preliminary-datasheet.png "modal-fc-block")
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/sparknavi-blue/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/sparknavi-blue/README.md
@@ -4,47 +4,9 @@ The SparkNavi Blue autopilot is manufactured by [SparkNavi](https://www.sparknav
 
 ![SparkNavi Blue](sparknavi-blue.png)
 
-## Where to Buy
 
-[SparkNavi Official](https://www.sparknavi.com)
 
-## Specifications
-
-- Processor
-
-  - STM32H743 32-bit processor, 480MHz
-  - STM32F103 IOMCU
-  - 2MB Flash
-  - 1MB RAM
-
-- Sensors
-
-  - InvenSense ICM42688 / ICM42652 IMU
-  - Bosch BMP280 Barometer
-  - Honeywell HMC5883L Magnetometer
-
-- Interfaces
-
-  - Micro SD card
-  - USB-C
-  - 14 PWM outputs (8 Main + 6 AUX)
-  - 5 UARTs, two with flow control
-  - Dual CAN
-  - I2C expansion port
-  - SPI expansion port
-  - ADC expansion port (6.6V input range)
-  - FRAM for parameter storage
-  - Safety switch input (on GPS1 connector)
-
-- Power
-
-  - Dual power input connectors (POWER1, POWER2) with independent voltage and current monitoring
-  - Maximum power input voltage: 6V
-
-- Dimensions
-
-  - Size: 7.4 × 4.8 × 1.7 cm
-  - Weight: 70g with MicroSD card
+<!-- TODO: add Features content -->
 
 ## Pinout
 
@@ -99,6 +61,70 @@ The 6 AUX OUT outputs are in 3 groups:
 
 Channels within the same group need to use the same output rate. If any channel in a group uses DShot then all channels in the group need to use DShot.
 
+## Battery Monitoring
+
+The board has dual internal voltage and current sensors connected to the POWER1 and POWER2 connectors. Maximum power input voltage: 6V.
+
+The default battery parameters are:
+
+- BATT_MONITOR = 4
+- BATT_VOLT_PIN = 16
+- BATT_CURR_PIN = 17
+- BATT_VOLT_MULT = 16.76
+- BATT_AMP_PERVLT = 100
+
+A second battery monitor is also enabled by default:
+
+- BATT2_MONITOR = 4
+- BATT2_VOLT_PIN = 14
+- BATT2_CURR_PIN = 15
+- BATT2_VOLT_MULT = 16.76
+- BATT2_AMP_PERVLT = 100
+
+These scale values are calibrated for the SparkNavi Blue power module and may need adjustment for other power modules.
+
+## Where to Buy
+
+[SparkNavi Official](https://www.sparknavi.com)
+
+## Specifications
+
+- Processor
+
+  - STM32H743 32-bit processor, 480MHz
+  - STM32F103 IOMCU
+  - 2MB Flash
+  - 1MB RAM
+
+- Sensors
+
+  - InvenSense ICM42688 / ICM42652 IMU
+  - Bosch BMP280 Barometer
+  - Honeywell HMC5883L Magnetometer
+
+- Interfaces
+
+  - Micro SD card
+  - USB-C
+  - 14 PWM outputs (8 Main + 6 AUX)
+  - 5 UARTs, two with flow control
+  - Dual CAN
+  - I2C expansion port
+  - SPI expansion port
+  - ADC expansion port (6.6V input range)
+  - FRAM for parameter storage
+  - Safety switch input (on GPS1 connector)
+
+- Power
+
+  - Dual power input connectors (POWER1, POWER2) with independent voltage and current monitoring
+  - Maximum power input voltage: 6V
+
+- Dimensions
+
+  - Size: 7.4 × 4.8 × 1.7 cm
+  - Weight: 70g with MicroSD card
+
 ## Compass
 
 An on-board HMC5883L compass is provided. However, users often will disable this compass and use an external one remotely located to avoid power circuitry interference using the SDA and SCL I2C lines provided.
@@ -132,28 +158,6 @@ If the ARSPD pin is used for analog airspeed  input. Set [ARSPD_PIN](https://ard
 | MAIN(6)        | 106         |
 | MAIN(7)        | 107         |
 | MAIN(8)        | 108         |
-
-## Battery Monitoring
-
-The board has dual internal voltage and current sensors connected to the POWER1 and POWER2 connectors. Maximum power input voltage: 6V.
-
-The default battery parameters are:
-
-- BATT_MONITOR = 4
-- BATT_VOLT_PIN = 16
-- BATT_CURR_PIN = 17
-- BATT_VOLT_MULT = 16.76
-- BATT_AMP_PERVLT = 100
-
-A second battery monitor is also enabled by default:
-
-- BATT2_MONITOR = 4
-- BATT2_VOLT_PIN = 14
-- BATT2_CURR_PIN = 15
-- BATT2_VOLT_MULT = 16.76
-- BATT2_AMP_PERVLT = 100
-
-These scale values are calibrated for the SparkNavi Blue power module and may need adjustment for other power modules.
 
 ## Firmware
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/speedybeef4v3/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/speedybeef4v3/README.md
@@ -36,22 +36,6 @@ RC input is configured on the R2 (UART2_RX) pin for most RC unidirectional proto
 For Fport, a bi-directional inverter will be required. See [ArduPilot FPort documentation](https://ardupilot.org/plane/docs/common-connecting-sport-fport.html)
 For CRSF/ELRS/SRXL2 connection of the receiver to T2 will also be required.
 
-## FrSky Telemetry
-
-FrSky Telemetry is supported using the Tx pin of any UART including SERIAL2/UART2. You need to set the following parameters to enable support for FrSky S.PORT (example shows SERIAL3).
-
-- SERIAL3_PROTOCOL 10
-- SERIAL3_OPTIONS 7
-
-## OSD Support
-
-The SpeedyBee F405 v3 supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
-## VTX Support
-
-The JST-GH-6P connector supports a standard DJI HD VTX connection. Pin 1 of the connector is 9v so be careful not to connect
-this to a peripheral requiring 5v.
-
 ## PWM Output
 
 The SpeedyBee F405 v3 supports up to 9 PWM outputs. The pads for motor output
@@ -81,6 +65,22 @@ The default battery parameters are:
 - BATT_CURR_PIN 11
 - BATT_VOLT_MULT 11.2
 - BATT_AMP_PERVLT 52.7 (will need to be adjusted for whichever current sensor is attached)
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using the Tx pin of any UART including SERIAL2/UART2. You need to set the following parameters to enable support for FrSky S.PORT (example shows SERIAL3).
+
+- SERIAL3_PROTOCOL 10
+- SERIAL3_OPTIONS 7
+
+## OSD Support
+
+The SpeedyBee F405 v3 supports OSD using OSD_TYPE 1 (MAX7456 driver).
+
+## VTX Support
+
+The JST-GH-6P connector supports a standard DJI HD VTX connection. Pin 1 of the connector is 9v so be careful not to connect
+this to a peripheral requiring 5v.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/speedybeef4v4/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/speedybeef4v4/README.md
@@ -36,22 +36,6 @@ RC input is configured on the R2 (UART2_RX) pin for most RC unidirectional proto
 For Fport, a bi-directional inverter will be required. See [ArduPilot FPort documentation](https://ardupilot.org/plane/docs/common-connecting-sport-fport.html)
 For CRSF/ELRS/SRXL2 connection of the receiver to T2 will also be required.
 
-## FrSky Telemetry
-
-FrSky Telemetry is supported using the Tx pin of any UART including SERIAL2/UART2. You need to set the following parameters to enable support for FrSky S.PORT (example shows SERIAL3).
-
-- SERIAL3_PROTOCOL 10
-- SERIAL3_OPTIONS 7
-
-## OSD Support
-
-The SpeedyBee F405 v4 supports OSD using OSD_TYPE 1 (MAX7456 driver).
-
-## VTX Support
-
-The JST-GH-6P connector supports a standard DJI HD VTX connection. Pin 1 of the connector is 9v so be careful not to connect
-this to a peripheral requiring 5v.
-
 ## PWM Output
 
 The SpeedyBee F405 v4 supports up to 9 PWM outputs. The pads for motor output
@@ -83,6 +67,22 @@ The default battery parameters are:
 - BATT_CURR_PIN 11
 - BATT_VOLT_MULT 11.2
 - BATT_AMP_PERVLT 52.7 (will need to be adjusted for whichever current sensor is attached)
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using the Tx pin of any UART including SERIAL2/UART2. You need to set the following parameters to enable support for FrSky S.PORT (example shows SERIAL3).
+
+- SERIAL3_PROTOCOL 10
+- SERIAL3_OPTIONS 7
+
+## OSD Support
+
+The SpeedyBee F405 v4 supports OSD using OSD_TYPE 1 (MAX7456 driver).
+
+## VTX Support
+
+The JST-GH-6P connector supports a standard DJI HD VTX connection. Pin 1 of the connector is 9v so be careful not to connect
+this to a peripheral requiring 5v.
 
 ## Compass
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/speedybeef4v5/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/speedybeef4v5/README.md
@@ -35,22 +35,6 @@ For Fport, a bi-directional inverter will be required. See [ArduPilot FPort docu
 
 SBUS is supported. When using an SBUS receiver, the SBUS jumper pad on the flight controller must be soldered. The signal uses hardware inversion and is connected to USART6_RX. SBUS is available on both a dedicated solder pad and the DJI HD connector.
 
-## FrSky Telemetry
-
-FrSky Telemetry is supported using the Tx pin of any UART including SERIAL6/UART6. You need to set the following parameters to enable support for FrSky S.PORT (example shows SERIAL3).
-
-- SERIAL3_PROTOCOL 10
-- SERIAL3_OPTIONS 7
-
-## OSD Support
-
-The SpeedyBee F405 v5 supports OSD using [OSD_TYPE](https://ardupilot.org/copter/docs/parameters.html#osd-type-osd-type) = 1 (MAX7456 driver). Simultaneous DisplayPort OSD operation is also pre-configured via UART3. See [MSP OSD](https://ardupilot.org/copter/docs/common-msp-osd-overview-4.2.html) for more info.
-
-## VTX Support
-
-The JST-GH-6P connector supports a standard DJI HD VTX connection. Pin 1 of the connector is 9v so be careful not to connect
-this to a peripheral requiring 5v.
-
 ## PWM Output
 
 The SpeedyBee F405 v5 supports up to 7 PWM outputs. The pads for motor output
@@ -81,6 +65,22 @@ The default battery parameters are:
 - BATT_CURR_PIN = 15
 - BATT_VOLT_MULT = 11.2
 - BATT_AMP_PERVLT = 1
+
+## FrSky Telemetry
+
+FrSky Telemetry is supported using the Tx pin of any UART including SERIAL6/UART6. You need to set the following parameters to enable support for FrSky S.PORT (example shows SERIAL3).
+
+- SERIAL3_PROTOCOL 10
+- SERIAL3_OPTIONS 7
+
+## OSD Support
+
+The SpeedyBee F405 v5 supports OSD using [OSD_TYPE](https://ardupilot.org/copter/docs/parameters.html#osd-type-osd-type) = 1 (MAX7456 driver). Simultaneous DisplayPort OSD operation is also pre-configured via UART3. See [MSP OSD](https://ardupilot.org/copter/docs/common-msp-osd-overview-4.2.html) for more info.
+
+## VTX Support
+
+The JST-GH-6P connector supports a standard DJI HD VTX connection. Pin 1 of the connector is 9v so be careful not to connect
+this to a peripheral requiring 5v.
 
 ## RSSI
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/thepeach-k1/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/thepeach-k1/README.md
@@ -9,6 +9,32 @@ Contact the [manufacturer](https://thepeach.kr/) for hardware support or complia
 
 ![ThePeach FCC-K1](./main.png)
 
+
+
+
+<!-- TODO: add Features content -->
+<!-- TODO: add Pinout content -->
+
+## UART Mapping
+
+| UART | Device | Port
+--- | --- | ---
+USART1 | /dev/ttyS0 | IO Processor Debug
+USART2 | /dev/ttyS1 | TELEM1 (flow control)
+USART3 | /dev/ttyS2 | TELEM2 (flow control)
+UART4  | /dev/ttyS3 | GPS1
+USART6 | /dev/ttyS4 | PX4IO
+UART7  | /dev/ttyS5 | Debug Console
+UART8  | /dev/ttyS6 | TELEM4
+
+
+
+
+
+<!-- TODO: add RC Input content -->
+<!-- TODO: add PWM Output content -->
+<!-- TODO: add Battery Monitoring content -->
+
 ## Specifications
 
 - Main Processor: STM32F427VIT6
@@ -45,18 +71,6 @@ Contact the [manufacturer](https://thepeach.kr/) for hardware support or complia
 ![pinmap_top](./pinmap_top.png)
 
 ![pinmap_bottom](./pinmap_bottom.png)
-
-## UART Mapping
-
-| UART | Device | Port
---- | --- | ---
-USART1 | /dev/ttyS0 | IO Processor Debug
-USART2 | /dev/ttyS1 | TELEM1 (flow control)
-USART3 | /dev/ttyS2 | TELEM2 (flow control)
-UART4  | /dev/ttyS3 | GPS1
-USART6 | /dev/ttyS4 | PX4IO
-UART7  | /dev/ttyS5 | Debug Console
-UART8  | /dev/ttyS6 | TELEM4
 
 ## Voltage Ratings
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/thepeach-r1/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/thepeach-r1/README.md
@@ -9,6 +9,32 @@ Contact the [manufacturer](https://thepeach.kr/) for hardware support or complia
 
 ![ThePeach_R1](./main.png)
 
+
+
+
+<!-- TODO: add Features content -->
+<!-- TODO: add Pinout content -->
+
+## UART Mapping
+
+| UART   | Device     | Port                       |
+| ------ | ---------- | -------------------------- |
+| USART1 | /dev/ttyS0 | IO Processor Debug         |
+| USART2 | /dev/ttyS1 | TELEM1 (flow control)      |
+| USART3 | /dev/ttyS2 | TELEM2 (Raspberry pi cm3+) |
+| UART4  | /dev/ttyS3 | GPS1                       |
+| USART6 | /dev/ttyS4 | PX4IO                      |
+| UART7  | /dev/ttys5 | Debug console              |
+| UART8  | /dev/ttyS6 | TELEM4                     |
+
+
+
+
+
+<!-- TODO: add RC Input content -->
+<!-- TODO: add PWM Output content -->
+<!-- TODO: add Battery Monitoring content -->
+
 ## Specifications
 
 - Main Processor: STM32F427VIT6
@@ -49,18 +75,6 @@ Contact the [manufacturer](https://thepeach.kr/) for hardware support or complia
 ## Connectors
 
 ![pinmap_top](./pinmap.png)
-
-## UART Mapping
-
-| UART   | Device     | Port                       |
-| ------ | ---------- | -------------------------- |
-| USART1 | /dev/ttyS0 | IO Processor Debug         |
-| USART2 | /dev/ttyS1 | TELEM1 (flow control)      |
-| USART3 | /dev/ttyS2 | TELEM2 (Raspberry pi cm3+) |
-| UART4  | /dev/ttyS3 | GPS1                       |
-| USART6 | /dev/ttyS4 | PX4IO                      |
-| UART7  | /dev/ttys5 | Debug console              |
-| UART8  | /dev/ttyS6 | TELEM4                     |
 
 ## Voltage Ratings
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/uav-dev-fc-um982/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/uav-dev-fc-um982/README.md
@@ -144,6 +144,13 @@ RC input is configured on connector S1 / SERIAL4 / UART6. It supports all RC pro
 - CRSF would require [SERIAL4_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial4-options-serial4-options) set to "0".
 - SRXL2 would require [SERIAL4_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial4-options-serial4-options) set to "4". And only connect the TX pin.
 
+## PWM Output
+
+All outputs are capable of PWM and DShot. Motors 1 through 4 are capable of Bidirectional-DShot. All outputs in the motor groups below must be either PWM or DShot:
+
+- Motors 1-4  Group1 (TIM4)
+- Motors 5-6  Group2 (TIM3)
+
 ## Battery Monitoring
 
 Via DroneCAN by UAV-DEV-POWERMODULE
@@ -151,13 +158,6 @@ Via DroneCAN by UAV-DEV-POWERMODULE
 ## Compass
 
 The autopilot includes an internal compass as well as GNSS-based heading, but GNSS-based heading is the recommended heading source. Proper setup and placement of the dual antennas is required as well as setup of the moving baseline parameters, see [GPS for yaw](https://ardupilot.org/copter/docs/common-gps-for-yaw.html) for more details.
-
-## PWM Output
-
-All outputs are capable of PWM and DShot. Motors 1 through 4 are capable of Bidirectional-DShot. All outputs in the motor groups below must be either PWM or DShot:
-
-- Motors 1-4  Group1 (TIM4)
-- Motors 5-6  Group2 (TIM3)
 
 ## Firmware
 

--- a/libraries/AP_HAL_QURT/hwdef/ModalAI-VOXL2/README.md
+++ b/libraries/AP_HAL_QURT/hwdef/ModalAI-VOXL2/README.md
@@ -1,3 +1,14 @@
 # ModalAI-VOXL2 Flight Controller
 
 The [ModalAI-VOXL2 flight controller](https://www.modalai.com/products/voxl-2?variant=39914779836467) is produced by [ModalAI](https://www.modalai.com).
+
+
+
+
+
+<!-- TODO: add Features content -->
+<!-- TODO: add Pinout content -->
+<!-- TODO: add UART Mapping content -->
+<!-- TODO: add RC Input content -->
+<!-- TODO: add PWM Output content -->
+<!-- TODO: add Battery Monitoring content -->

--- a/libraries/AP_HAL_SITL/hwdef/SITL_arm_linux_gnueabihf/README.md
+++ b/libraries/AP_HAL_SITL/hwdef/SITL_arm_linux_gnueabihf/README.md
@@ -3,3 +3,14 @@
 Software-In-The_Loop target to run on ARM Linux, e.g. Raspberry Pi
 
 Critically the output binaries are statically linked so are more-easily moved to machines of a different configuration to that which they are compiled on.
+
+
+
+
+
+<!-- TODO: add Features content -->
+<!-- TODO: add Pinout content -->
+<!-- TODO: add UART Mapping content -->
+<!-- TODO: add RC Input content -->
+<!-- TODO: add PWM Output content -->
+<!-- TODO: add Battery Monitoring content -->

--- a/libraries/AP_HAL_SITL/hwdef/SITL_x86_64_linux_gnu/README.md
+++ b/libraries/AP_HAL_SITL/hwdef/SITL_x86_64_linux_gnu/README.md
@@ -3,3 +3,14 @@
 Software-In-The_Loop target to run on x86-64 Linux - i.e. most desktop computers
 
 Critically the output binaries are statically linked so are more-easily moved to machines of a different configuration to that which they are compiled on.
+
+
+
+
+
+<!-- TODO: add Features content -->
+<!-- TODO: add Pinout content -->
+<!-- TODO: add UART Mapping content -->
+<!-- TODO: add RC Input content -->
+<!-- TODO: add PWM Output content -->
+<!-- TODO: add Battery Monitoring content -->

--- a/libraries/AP_HAL_SITL/hwdef/sitl/README.md
+++ b/libraries/AP_HAL_SITL/hwdef/sitl/README.md
@@ -3,3 +3,14 @@
 This is the base hwdef.dat for ArduPilot simulations.
 
 You can create new boards based off this which only include features that you want in there.
+
+
+
+
+
+<!-- TODO: add Features content -->
+<!-- TODO: add Pinout content -->
+<!-- TODO: add UART Mapping content -->
+<!-- TODO: add RC Input content -->
+<!-- TODO: add PWM Output content -->
+<!-- TODO: add Battery Monitoring content -->


### PR DESCRIPTION
### Summary

Adds a CI test so new boards must have a specific order for their headings.  Old boards are brought into line - but with only comments where content is just missing from the file.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Boards must have the following headings and nothing in between them.

```
# BoardName goes here

## Features

## Pinout

## UART Mapping

## RC Input

## PWM Output

## Battery Monitor
```

For existing boards which don't have the correct structure:
```
pbarker@crun:~/rc/ardupilot-claude(pr-claude/fixing-hwdef-README.md-files-basic-ordering)$ git diff master | grep TODO | sort | uniq -c
     21 +<!-- TODO: add Battery Monitoring content -->
     20 +<!-- TODO: add Features content -->
     50 +<!-- TODO: add Pinout content -->
     22 +<!-- TODO: add PWM Output content -->
     20 +<!-- TODO: add RC Input content -->
     15 +<!-- TODO: add UART Mapping content -->
pbarker@crun:~/rc/ardupilot-claude(pr-claude/fixing-hwdef-README.md-files-basic-ordering)$ 
```

We'll come back and do more analysis and cleanup once we have this basic structure in place.  We may be able to auto-generate the Battery Monitoring content from the hwdef files.
