### PR TITLE
Start to understand multiple camera IDs for mavlink and mission commands

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -7374,6 +7374,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             trigger_counts[m.cam_idx] += 1
 
         self.install_message_hook_context(trig_counter)
+        self.delay_sim_time(12, "wait for MAVLink camera backends to initialise")
         self.progress("Test triggering of the two cameras")
         self.run_cmd_int(
             mavutil.mavlink.MAV_CMD_DO_SET_CAM_TRIGG_DIST,

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -7353,8 +7353,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_parameters({
             "MNT1_TYPE": 6,         # MAVLink
             "MNT2_TYPE": 6,         # MAVLink
-            "CAM1_TYPE": 4,         # Mount
-            "CAM2_TYPE": 4,         # Mount
+            "CAM1_TYPE": 6,         # MAVLink
+            "CAM2_TYPE": 6,         # MAVLink
             "SERIAL5_PROTOCOL": 2,  # MAVLink2
             "SERIAL6_PROTOCOL": 2,  # MAVLink2
         })

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -7363,6 +7363,46 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "--serial6=sim:avt_cm62_gimbal:",
         ])
 
+        # note that CAMERA_FEEDBACK uses instance numbers starting from 0
+        trigger_counts = {}
+
+        def trig_counter(mav, m):
+            if m.get_type() != 'CAMERA_FEEDBACK':
+                return
+            if m.cam_idx not in trigger_counts:
+                trigger_counts[m.cam_idx] = 0
+            trigger_counts[m.cam_idx] += 1
+
+        self.install_message_hook_context(trig_counter)
+        self.progress("Test triggering of the two cameras")
+        self.run_cmd_int(
+            mavutil.mavlink.MAV_CMD_DO_SET_CAM_TRIGG_DIST,
+            p1=10,  # trigger distance
+            p3=1,   # trigger instantly
+            p4=0,   # 0 means trigger for all cameras
+        )
+        self.delay_sim_time(2, "allow CAMERA_FEEDBACK to come through")
+        for cam in 0, 1:
+            if cam not in trigger_counts:
+                raise NotAchievedException(f"Did not see trigger for cam{cam}")
+            if trigger_counts[cam] != 1:
+                raise NotAchievedException(f"Incorrect trigger count for cam{cam}")
+
+        for cam in 0, 1:
+            self.progress(f"Test triggering of the just cam{cam}")
+            trigger_counts = {}
+            self.run_cmd_int(
+                mavutil.mavlink.MAV_CMD_DO_SET_CAM_TRIGG_DIST,
+                p1=10,  # trigger distance
+                p3=1,   # trigger instantly
+                p4=cam+1,
+            )
+            self.delay_sim_time(2, "allow CAMERA_FEEDBACK to come through")
+            if cam not in trigger_counts:
+                raise NotAchievedException(f"Did not see trigger for cam{cam}")
+            if trigger_counts[cam] != 1:
+                raise NotAchievedException(f"Incorrect trigger count for cam{cam}")
+
     def assert_mount_rpy(self, r, p, y, tolerance=1):
         '''assert mount atttiude in degrees'''
         got_r, got_p, got_y, yaw_is_absolute = self.get_mount_roll_pitch_yaw_deg()

--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -70,17 +70,6 @@ AP_Camera::AP_Camera(uint32_t _log_camera_bit) :
     _singleton = this;
 }
 
-// set camera trigger distance in a mission
-void AP_Camera::set_trigger_distance(float distance_m)
-{
-    WITH_SEMAPHORE(_rsem);
-
-    if (primary == nullptr) {
-        return;
-    }
-    primary->set_trigger_distance(distance_m);
-}
-
 // momentary switch to change camera between picture and video modes
 void AP_Camera::cam_mode_toggle()
 {
@@ -308,6 +297,62 @@ void AP_Camera::handle_message(mavlink_channel_t chan, const mavlink_message_t &
     }
 }
 
+#if HAL_MAVLINK_BINDINGS_ENABLED
+// a method which handles mavlink-style semantics for instance_id; if
+// instance_id is zero or matches backend instance ID code is run
+MAV_RESULT AP_Camera::handle_mav_DO_SET_CAM_TRIGG_DISTANCE(uint8_t instance_id, bool trigger, float dist_m)
+{
+    for (uint8_t i=0; i<AP_CAMERA_MAX_INSTANCES; i++) {
+        if (_backends[i] == nullptr) {
+            continue;
+        }
+        // honour packet instance number:
+        if (instance_id != 0 && i+1 != instance_id) {
+            continue;
+        }
+        _backends[i]->set_trigger_distance(dist_m);
+        if (trigger) {
+            _backends[i]->take_picture();
+        }
+    }
+
+    return MAV_RESULT_ACCEPTED;
+}
+
+MAV_RESULT AP_Camera::handle_mav_SET_CAMERA_ZOOM(uint8_t instance_id, CAMERA_ZOOM_TYPE mav_zoom_type, float zoom_value)
+{
+    ZoomType zoom_type;
+    switch (mav_zoom_type) {
+    case ZOOM_TYPE_CONTINUOUS:
+        zoom_type = ZoomType::RATE;
+        break;
+    case ZOOM_TYPE_RANGE:
+        zoom_type = ZoomType::PCT;
+        break;
+    default:
+        // invalid param1
+        return MAV_RESULT_DENIED;
+    }
+
+    MAV_RESULT result = MAV_RESULT_ACCEPTED;
+    for (uint8_t i=0; i<AP_CAMERA_MAX_INSTANCES; i++) {
+        if (_backends[i] == nullptr) {
+            continue;
+        }
+        // honour packet instance number:
+        if (instance_id != 0 && i+1 != instance_id) {
+            continue;
+        }
+        // all backends must succeed:
+        if (!_backends[i]->set_zoom(zoom_type, zoom_value)) {
+            result = MAV_RESULT_FAILED;
+        }
+    }
+
+    return result;
+}
+#endif  // HAL_MAVLINK_BINDINGS_ENABLED
+
 // handle command_long mavlink messages
 MAV_RESULT AP_Camera::handle_command(const mavlink_command_int_t &packet)
 {
@@ -319,21 +364,17 @@ MAV_RESULT AP_Camera::handle_command(const mavlink_command_int_t &packet)
         control(packet.param1, packet.param2, packet.param3, packet.param4, packet.x, packet.y);
         return MAV_RESULT_ACCEPTED;
     case MAV_CMD_DO_SET_CAM_TRIGG_DIST:
-        set_trigger_distance(packet.param1);
-        if (is_equal(packet.param3, 1.0f)) {
-            take_picture();
-        }
-        return MAV_RESULT_ACCEPTED;
+        return handle_mav_DO_SET_CAM_TRIGG_DISTANCE(
+            packet.param4,                  // instance
+            is_equal(packet.param3, 1.0f),  // trigger
+            packet.param1                   // distance
+        );
     case MAV_CMD_SET_CAMERA_ZOOM:
-        if (is_equal(packet.param1, (float)ZOOM_TYPE_CONTINUOUS) &&
-            set_zoom(ZoomType::RATE, packet.param2)) {
-            return MAV_RESULT_ACCEPTED;
-        }
-        if (is_equal(packet.param1, (float)ZOOM_TYPE_RANGE) &&
-            set_zoom(ZoomType::PCT, packet.param2)) {
-            return MAV_RESULT_ACCEPTED;
-        }
-        return MAV_RESULT_UNSUPPORTED;
+        return handle_mav_SET_CAMERA_ZOOM(
+            packet.param3,                   // instance
+            CAMERA_ZOOM_TYPE(packet.param1), // zoom type
+            packet.param2                    // zoom level
+        );
     case MAV_CMD_SET_CAMERA_FOCUS:
         // accept any of the auto focus types
         switch ((SET_FOCUS_TYPE)packet.param1) {

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -86,6 +86,7 @@ public:
     // update - to be called periodically at 50Hz
     void update();
 
+#if HAL_GCS_ENABLED
     // handle MAVLink messages from the camera
     void handle_message(mavlink_channel_t chan, const mavlink_message_t &msg);
 
@@ -98,6 +99,13 @@ public:
 
     // send camera information for a specific instance (0-based) to GCS
     void send_camera_information(uint8_t instance, mavlink_channel_t chan);
+#endif  // HAL_GCS_ENABLED
+
+#if HAL_MAVLINK_BINDINGS_ENABLED
+    // methods to handle mavlink-style instance-id (0 meaning all cameras)
+    MAV_RESULT handle_mav_DO_SET_CAM_TRIGG_DISTANCE(uint8_t instance_id, bool trigger, float dist_m);
+    MAV_RESULT handle_mav_SET_CAMERA_ZOOM(uint8_t instance_id, CAMERA_ZOOM_TYPE mav_zoom_type, float zoom_value);
+#endif  // HAL_MAVLINK_BINDINGS_ENABLED
 
     // select which instance to send on the next deferred MSG_CAMERA_INFORMATION send
     void set_camera_information_send_instance(int16_t instance) { _camera_information_send_instance = instance; }
@@ -111,7 +119,6 @@ public:
     void control(uint8_t instance, float session, float zoom_pos, float zoom_step, float focus_lock, int32_t shooting_cmd, int32_t cmd_id);
 
     // set camera trigger distance in a mission
-    void set_trigger_distance(float distance_m);
     void set_trigger_distance(uint8_t instance, float distance_m);
 
     // momentary switch to change camera between picture and video modes

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -1301,6 +1301,7 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
     case MAV_CMD_DO_SET_CAM_TRIGG_DIST:                 // MAV ID: 206
         cmd.content.cam_trigg_dist.meters = packet.param1;  // distance between camera shots in meters
         cmd.content.cam_trigg_dist.trigger = packet.param3; // when enabled, camera triggers once immediately
+        cmd.content.cam_trigg_dist.camera_id = packet.param4; // which camera to trigger
         break;
 
     case MAV_CMD_DO_FENCE_ENABLE:                       // MAV ID: 207
@@ -1446,6 +1447,7 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
     case MAV_CMD_SET_CAMERA_ZOOM:
         cmd.content.set_camera_zoom.zoom_type = packet.param1;
         cmd.content.set_camera_zoom.zoom_value = packet.param2;
+        cmd.content.set_camera_zoom.camera_id = packet.param3;
         break;
 
     case MAV_CMD_SET_CAMERA_FOCUS:
@@ -1821,6 +1823,7 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
     case MAV_CMD_DO_SET_CAM_TRIGG_DIST:                 // MAV ID: 206
         packet.param1 = cmd.content.cam_trigg_dist.meters;  // distance between camera shots in meters
         packet.param3 = cmd.content.cam_trigg_dist.trigger; // when enabled, camera triggers once immediately
+        packet.param4 = cmd.content.cam_trigg_dist.camera_id; // which camera to trigger
         break;
 
     case MAV_CMD_DO_FENCE_ENABLE:                       // MAV ID: 207
@@ -1968,6 +1971,7 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
     case MAV_CMD_SET_CAMERA_ZOOM:
         packet.param1 = cmd.content.set_camera_zoom.zoom_type;
         packet.param2 = cmd.content.set_camera_zoom.zoom_value;
+        packet.param3 = cmd.content.set_camera_zoom.camera_id;
         break;
 
     case MAV_CMD_SET_CAMERA_FOCUS:

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -153,6 +153,7 @@ public:
     struct PACKED Cam_Trigg_Distance {
         float meters;           // distance
         uint8_t trigger;        // triggers one image capture immediately
+        uint8_t camera_id;      // which camera to trigger
     };
 
     // gripper command structure
@@ -277,6 +278,7 @@ public:
     struct PACKED set_camera_zoom_Command {
         uint8_t zoom_type;
         float zoom_value;
+        uint8_t camera_id;
     };
 
     // MAV_CMD_SET_CAMERA_FOCUS support

--- a/libraries/AP_Mission/AP_Mission_Commands.cpp
+++ b/libraries/AP_Mission/AP_Mission_Commands.cpp
@@ -6,6 +6,7 @@
 
 #include <GCS_MAVLink/GCS.h>
 #include <AP_Camera/AP_Camera.h>
+#include <AP_Camera/AP_Camera_Backend.h>
 #include <AP_Gripper/AP_Gripper.h>
 #include <AP_Parachute/AP_Parachute.h>
 #include <AP_ServoRelayEvents/AP_ServoRelayEvents.h>
@@ -134,21 +135,18 @@ bool AP_Mission::start_command_camera(const AP_Mission::Mission_Command& cmd)
         return true;
 
     case MAV_CMD_DO_SET_CAM_TRIGG_DIST:
-        camera->set_trigger_distance(cmd.content.cam_trigg_dist.meters);
-        if (cmd.content.cam_trigg_dist.trigger == 1) {
-            camera->take_picture();
-        }
-        return true;
+        return camera->handle_mav_DO_SET_CAM_TRIGG_DISTANCE(
+            cmd.content.cam_trigg_dist.camera_id,
+            cmd.content.cam_trigg_dist.trigger,
+            cmd.content.cam_trigg_dist.meters
+        ) == MAV_RESULT_ACCEPTED;
 
     case MAV_CMD_SET_CAMERA_ZOOM:
-        if (cmd.content.set_camera_zoom.zoom_type == ZOOM_TYPE_CONTINUOUS) {
-            return camera->set_zoom(ZoomType::RATE, cmd.content.set_camera_zoom.zoom_value);
-        }
-        if (cmd.content.set_camera_zoom.zoom_type == ZOOM_TYPE_RANGE) {
-            return camera->set_zoom(ZoomType::PCT, cmd.content.set_camera_zoom.zoom_value);
-        }
-        return false;
-
+        return camera->handle_mav_SET_CAMERA_ZOOM(
+            cmd.content.set_camera_zoom.camera_id,
+            (CAMERA_ZOOM_TYPE)cmd.content.set_camera_zoom.zoom_type,
+            cmd.content.set_camera_zoom.zoom_value
+        ) == MAV_RESULT_ACCEPTED;
     case MAV_CMD_SET_CAMERA_FOCUS:
         // accept any of the auto focus types
         if ((cmd.content.set_camera_focus.focus_type == FOCUS_TYPE_AUTO) ||

--- a/libraries/SITL/SIM_AVT_CM62.h
+++ b/libraries/SITL/SIM_AVT_CM62.h
@@ -9,11 +9,29 @@
 #if AP_SIM_AVT_CM62_ENABLED
 
 #include "SIM_MAVLinkGimbalv2.h"
+#include "SIM_MAVLinkCamV2.h"
 #include <AP_Math/AP_Math.h>
 
 namespace SITL {
 
-class AVT_CM62 : public MAVLinkGimbalv2 {
+class AVT_CM62 : public MAVLinkGimbalv2, public MAVLinkCamV2 {
+public:
+    void set_instance(uint8_t instance) override {
+        MAVLinkGimbalv2::set_instance(instance);
+        set_camera_instance(instance);
+    }
+
+    void handle_message(const mavlink_message_t &msg) override {
+        MAVLinkGimbalv2::handle_message(msg);
+        MAVLinkCamV2::handle_message(msg);
+    }
+
+    void update(const class Aircraft &aircraft) override {
+        MAVLinkGimbalv2::update(aircraft);
+        MAVLinkCamV2::update(aircraft);
+    }
+
+private:
     const char *get_vendor_name()      const override { return "AVTA"; }
     const char *get_model_name()       const override { return "SIM_AVTA"; }
     // firmware_version encoding: major=1 | (minor=2)<<8 | (patch=3)<<16
@@ -26,6 +44,17 @@ class AVT_CM62 : public MAVLinkGimbalv2 {
     float get_pitch_max_rad() const override { return radians( 45.0f); }
     float get_yaw_min_rad()   const override { return radians(-180.0f); }
     float get_yaw_max_rad()   const override { return radians( 180.0f); }
+
+    const char *get_camera_vendor_name()      const override { return "AVTA"; }
+    const char *get_camera_model_name()       const override { return "SIM_AVTA_CAM"; }
+    uint32_t    get_camera_firmware_version() const override { return (3U << 16) | (2U << 8) | 1U; }
+    uint32_t    get_camera_cap_flags()        const override { return CAMERA_CAP_FLAGS_CAPTURE_IMAGE; }
+
+    void camera_send_mavlink_message(const mavlink_message_t &msg) override {
+        send_mavlink_message(msg);
+    }
+    uint8_t camera_vehicle_sysid() const override { return vehicle_sysid(); }
+    mavlink_status_t &camera_mav_status() override { return gimbal_mav_status(); }
 };
 
 }  // namespace SITL

--- a/libraries/SITL/SIM_Camera.h
+++ b/libraries/SITL/SIM_Camera.h
@@ -1,0 +1,27 @@
+/*
+   Camera state class for SITL combined gimbal+camera simulations.
+   Analogous to SIM_Gimbal.h but for camera state; no physics simulation.
+*/
+
+#pragma once
+
+#include "SIM_config.h"
+
+#if AP_SIM_MAVLINKCAMV2_ENABLED
+
+#include <stdint.h>
+
+namespace SITL {
+
+class Camera {
+public:
+    void     trigger_shutter() { _shot_count++; }
+    uint16_t shot_count() const { return _shot_count; }
+
+private:
+    uint16_t _shot_count {};
+};
+
+}  // namespace SITL
+
+#endif  // AP_SIM_MAVLINKCAMV2_ENABLED

--- a/libraries/SITL/SIM_MAVLinkCamV2.cpp
+++ b/libraries/SITL/SIM_MAVLinkCamV2.cpp
@@ -1,0 +1,116 @@
+/*
+   Simulator mixin for MAVLink Camera Protocol v2 peripherals.
+*/
+
+#include "SIM_config.h"
+
+#if AP_SIM_MAVLINKCAMV2_ENABLED
+
+#include "SIM_MAVLinkCamV2.h"
+#include <AP_HAL/AP_HAL.h>
+#include <stdio.h>
+
+namespace SITL {
+
+void MAVLinkCamV2::set_camera_instance(uint8_t instance)
+{
+    _camera_compid = MIN(MAV_COMP_ID_CAMERA + instance, (uint8_t)MAV_COMP_ID_CAMERA6);
+}
+
+void MAVLinkCamV2::update(const class Aircraft &aircraft)
+{
+    if (camera_vehicle_sysid() == 0) {
+        return;
+    }
+    const uint32_t now_ms = AP_HAL::millis();
+    if (now_ms - _last_camera_heartbeat_ms >= 1000) {
+        _last_camera_heartbeat_ms = now_ms;
+        send_camera_heartbeat();
+    }
+}
+
+void MAVLinkCamV2::handle_message(const mavlink_message_t &msg)
+{
+    if (msg.msgid != MAVLINK_MSG_ID_COMMAND_LONG) {
+        return;
+    }
+    mavlink_command_long_t cmd;
+    mavlink_msg_command_long_decode(&msg, &cmd);
+    if (cmd.target_system    != camera_vehicle_sysid() ||
+        cmd.target_component != _camera_compid) {
+        return;
+    }
+    switch ((MAV_CMD)cmd.command) {
+    case MAV_CMD_REQUEST_MESSAGE:
+        if ((uint32_t)cmd.param1 == MAVLINK_MSG_ID_CAMERA_INFORMATION) {
+            send_camera_information(msg.sysid, msg.compid);
+            send_camera_command_ack(msg.sysid, msg.compid,
+                                    MAV_CMD_REQUEST_MESSAGE, MAV_RESULT_ACCEPTED);
+        }
+        break;
+    case MAV_CMD_IMAGE_START_CAPTURE:
+        _camera.trigger_shutter();
+        ::printf("MAVLinkCamV2[compid=%u]: image captured (shot %u)\n",
+                 (unsigned)_camera_compid, (unsigned)_camera.shot_count());
+        send_camera_command_ack(msg.sysid, msg.compid,
+                                MAV_CMD_IMAGE_START_CAPTURE, MAV_RESULT_ACCEPTED);
+        break;
+    default:
+        break;
+    }
+}
+
+void MAVLinkCamV2::send_camera_heartbeat()
+{
+    mavlink_heartbeat_t hb {};
+    hb.type            = MAV_TYPE_CAMERA;
+    hb.autopilot       = MAV_AUTOPILOT_INVALID;
+    hb.system_status   = MAV_STATE_ACTIVE;
+    hb.mavlink_version = 3;
+
+    mavlink_message_t msg;
+    mavlink_msg_heartbeat_encode_status(
+        camera_vehicle_sysid(), _camera_compid,
+        &camera_mav_status(), &msg, &hb);
+    camera_send_mavlink_message(msg);
+}
+
+void MAVLinkCamV2::send_camera_information(uint8_t target_sysid, uint8_t target_compid)
+{
+    mavlink_camera_information_t info {};
+    info.time_boot_ms     = AP_HAL::millis();
+    info.firmware_version = get_camera_firmware_version();
+    info.focal_length     = NAN;
+    info.sensor_size_h    = NAN;
+    info.sensor_size_v    = NAN;
+    info.flags            = get_camera_cap_flags();
+    strncpy_noterm((char *)info.vendor_name, get_camera_vendor_name(), sizeof(info.vendor_name));
+    strncpy_noterm((char *)info.model_name,  get_camera_model_name(),  sizeof(info.model_name));
+
+    mavlink_message_t msg;
+    mavlink_msg_camera_information_encode_status(
+        camera_vehicle_sysid(), _camera_compid,
+        &camera_mav_status(), &msg, &info);
+    camera_send_mavlink_message(msg);
+}
+
+void MAVLinkCamV2::send_camera_command_ack(uint8_t target_sysid, uint8_t target_compid,
+                                            MAV_CMD cmd, MAV_RESULT result)
+{
+    mavlink_command_ack_t ack {};
+    ack.command          = (uint16_t)cmd;
+    ack.result           = (uint8_t)result;
+    ack.progress         = 255;
+    ack.target_system    = target_sysid;
+    ack.target_component = target_compid;
+
+    mavlink_message_t msg;
+    mavlink_msg_command_ack_encode_status(
+        camera_vehicle_sysid(), _camera_compid,
+        &camera_mav_status(), &msg, &ack);
+    camera_send_mavlink_message(msg);
+}
+
+}  // namespace SITL
+
+#endif  // AP_SIM_MAVLINKCAMV2_ENABLED

--- a/libraries/SITL/SIM_MAVLinkCamV2.h
+++ b/libraries/SITL/SIM_MAVLinkCamV2.h
@@ -1,0 +1,56 @@
+/*
+   Simulator mixin for MAVLink Camera Protocol v2 peripherals.
+
+   Mix this into a combined device class (e.g. AVT_CM62) alongside a
+   MAVLinkGimbalv2 subclass.  The combined class wires the transport
+   pure-virtuals to the gimbal's serial link and supplies device-specific
+   identity via the identity pure-virtuals.
+
+   Protocol reference: AP_Camera/AP_Camera_MAVLinkCamV2.cpp
+*/
+
+#pragma once
+
+#include "SIM_config.h"
+
+#if AP_SIM_MAVLINKCAMV2_ENABLED
+
+#include "SIM_Camera.h"
+#include <GCS_MAVLink/GCS_MAVLink.h>
+#include <AP_Math/AP_Math.h>
+
+namespace SITL {
+
+class MAVLinkCamV2 {
+public:
+    void handle_message(const mavlink_message_t &msg);
+    void update(const class Aircraft &aircraft);
+    void set_camera_instance(uint8_t instance);
+
+protected:
+    Camera _camera;
+
+    // identity — every combined device class must implement all of these
+    virtual const char *get_camera_vendor_name()      const = 0;
+    virtual const char *get_camera_model_name()       const = 0;
+    virtual uint32_t    get_camera_firmware_version() const = 0;
+    virtual uint32_t    get_camera_cap_flags()        const = 0;
+
+    // transport — combined device class wires these to the shared serial link
+    virtual void camera_send_mavlink_message(const mavlink_message_t &msg) = 0;
+    virtual uint8_t camera_vehicle_sysid() const = 0;
+    virtual mavlink_status_t &camera_mav_status() = 0;
+
+private:
+    void send_camera_heartbeat();
+    void send_camera_information(uint8_t target_sysid, uint8_t target_compid);
+    void send_camera_command_ack(uint8_t target_sysid, uint8_t target_compid,
+                                  MAV_CMD cmd, MAV_RESULT result);
+
+    uint8_t  _camera_compid {MAV_COMP_ID_CAMERA};
+    uint32_t _last_camera_heartbeat_ms {};
+};
+
+}  // namespace SITL
+
+#endif  // AP_SIM_MAVLINKCAMV2_ENABLED

--- a/libraries/SITL/SIM_MAVLinkGimbalv2.h
+++ b/libraries/SITL/SIM_MAVLinkGimbalv2.h
@@ -48,21 +48,28 @@ protected:
     virtual float get_yaw_min_rad()   const = 0;
     virtual float get_yaw_max_rad()   const = 0;
 
-protected:
     // physics model shared by all MAVLink gimbal simulators
     Gimbal _gimbal;
+
+    // available to combined classes (e.g. gimbal+camera) for sending messages
+    // and accessing transport state
+    void send_mavlink_message(const mavlink_message_t &msg);
+    uint8_t vehicle_sysid()  const { return _vehicle_system_id; }
+    uint8_t vehicle_compid() const { return _vehicle_component_id; }
+    mavlink_status_t &gimbal_mav_status() { return mav.status; }
+
+    // override in a combined class to handle non-gimbal commands on the same link
+    virtual void handle_message(const mavlink_message_t &msg);
 
 private:
     void update_input();
     void update_gimbal(const class Aircraft &aircraft);
-    void handle_message(const mavlink_message_t &msg);
 
     void send_heartbeat();
     void send_gimbal_device_information();
     void send_attitude_status();
     void send_command_ack(uint8_t target_sysid, uint8_t target_compid,
                           MAV_CMD command, MAV_RESULT result);
-    void send_mavlink_message(const mavlink_message_t &msg);
 
     uint8_t _compid {MAV_COMP_ID_GIMBAL};
 

--- a/libraries/SITL/SIM_config.h
+++ b/libraries/SITL/SIM_config.h
@@ -221,6 +221,11 @@
 #define AP_SIM_MAVLINKGIMBALV2_ENABLED AP_SIM_AVT_CM62_ENABLED
 #endif
 
+// MAVLink Camera Protocol v2 simulation (mixed into combined gimbal+camera devices):
+#ifndef AP_SIM_MAVLINKCAMV2_ENABLED
+#define AP_SIM_MAVLINKCAMV2_ENABLED AP_SIM_AVT_CM62_ENABLED
+#endif
+
 // base class for all simulated gimbal backends:
 #ifndef AP_SIM_MOUNT_ENABLED
 #define AP_SIM_MOUNT_ENABLED (AP_SIM_SIYI_ENABLED || AP_SIM_TOPOTEK_ENABLED || AP_SIM_VIEWPRO_ENABLED || AP_SIM_MAVLINKGIMBALV2_ENABLED)


### PR DESCRIPTION
### Summary

Understand various command parameters and field values which specify which camera to trigger / zoom.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest) (partial)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Starts to add support for being able to command more than one camera.  We currently ignore the parameters meaning we'd trigger the primary meaning we're just not spec-compliant.  The spec change broke us.

This takes the approach of passing a lambda function into a function on AP_Camera which understands the mavlink ID semantics.

We don't use lambda functions in the code much, but this definitely reduces the number of places that we'd need to have the logic.  There are roughly 17 commands that should use the logic.

```
    // call lambda for each backend indicated by camera_id.  The
    // mavlink semantics are that if camera_id is zero then the
    // operation is to be performed on all backends.  If the value is
    // between 1 and 6 (inclusive) then the camera is assumed to be
    // local.  If it is greater than 6 then the value is assumed to be
    // a mavlink component ID.
```

If this is acceptable it will also be used in mount
