### PR TITLE
AP_CANManager: send log_text via GCS and AP_Logger 

### DIFF
--- a/libraries/AP_CANManager/AP_CANManager.cpp
+++ b/libraries/AP_CANManager/AP_CANManager.cpp
@@ -39,12 +39,10 @@
 #include <AP_HAL_ChibiOS/CANIface.h>
 #endif
 
-#include <AP_Common/ExpandingString.h>
 #include <AP_Common/sorting.h>
 #include <AP_Logger/AP_Logger.h>
 
 #define LOG_TAG "CANMGR"
-#define LOG_BUFFER_SIZE 1024
 
 extern const AP_HAL::HAL& hal;
 
@@ -128,11 +126,6 @@ void AP_CANManager::init()
         AP_HAL::panic("CANManager: SITL not initialised!");
     }
 #endif
-    // We only allocate log buffer only when under debug
-    if (_loglevel != AP_CANManager::LOG_NONE) {
-        _log_buf = NEW_NOTHROW char[LOG_BUFFER_SIZE];
-        _log_pos = 0;
-    }
 
 #if AP_CAN_SLCAN_ENABLED
     //Reset all SLCAN related params that needs resetting at boot
@@ -356,61 +349,38 @@ bool AP_CANManager::register_11bit_driver(AP_CAN::Protocol dtype, CANSensor *sen
 
 }
 
-// Method used by CAN related library methods to report status and debug info
-// The result of this method can be accessed via ftp get @SYS/can_log.txt
+// Method used by CAN related library methods to report status and debug info via GCS
 void AP_CANManager::log_text(AP_CANManager::LogLevel loglevel, const char *tag, const char *fmt, ...)
 {
-    if (_log_buf == nullptr) {
-        return;
-    }
     if (loglevel > _loglevel) {
         return;
     }
-    WITH_SEMAPHORE(_sem);
 
-    if ((LOG_BUFFER_SIZE - _log_pos) < (10 + strlen(tag) + strlen(fmt))) {
-        // reset log pos
-        _log_pos = 0;
-    }
-    //Tag Log Message
-    const char *log_level_tag = "";
+    MAV_SEVERITY severity = MAV_SEVERITY_INFO;
     switch (loglevel) {
-    case AP_CANManager::LOG_DEBUG :
-        log_level_tag = "DEBUG";
+    case AP_CANManager::LOG_ERROR:
+        severity = MAV_SEVERITY_ERROR;
         break;
-
-    case AP_CANManager::LOG_INFO :
-        log_level_tag = "INFO";
+    case AP_CANManager::LOG_WARNING:
+        severity = MAV_SEVERITY_WARNING;
         break;
-
-    case AP_CANManager::LOG_WARNING :
-        log_level_tag = "WARN";
+    case AP_CANManager::LOG_INFO:
+        severity = MAV_SEVERITY_INFO;
         break;
-
-    case AP_CANManager::LOG_ERROR :
-        log_level_tag = "ERROR";
+    case AP_CANManager::LOG_DEBUG:
+        severity = MAV_SEVERITY_DEBUG;
         break;
-
     case AP_CANManager::LOG_NONE:
         return;
     }
 
-    _log_pos += hal.util->snprintf(&_log_buf[_log_pos], LOG_BUFFER_SIZE - _log_pos, "\n%s %s :", log_level_tag, tag);
-
+    char msg[100];
     va_list arg_list;
     va_start(arg_list, fmt);
-    _log_pos += hal.util->vsnprintf(&_log_buf[_log_pos], LOG_BUFFER_SIZE - _log_pos, fmt, arg_list);
+    hal.util->vsnprintf(msg, sizeof(msg), fmt, arg_list);
     va_end(arg_list);
-}
 
-// log retrieve method used by file sys method to report can log
-void AP_CANManager::log_retrieve(ExpandingString &str) const
-{
-    if (_log_buf == nullptr) {
-        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Log buffer not available");
-        return;
-    }
-    str.append(_log_buf, _log_pos);
+    GCS_SEND_TEXT(severity, "%s: %s", tag, msg);
 }
 
 #if AP_CAN_LOGGING_ENABLED

--- a/libraries/AP_CANManager/AP_CANManager.h
+++ b/libraries/AP_CANManager/AP_CANManager.h
@@ -84,10 +84,8 @@ public:
         return LogLevel(_loglevel.get());
     }
     
-    // Method to log status and debug information for review while debugging
+    // Method to log status and debug information via GCS
     void log_text(AP_CANManager::LogLevel loglevel, const char *tag, const char *fmt, ...) FMT_PRINTF(4,5);
-
-    void log_retrieve(ExpandingString &str) const;
 
     // return driver type index i
     AP_CAN::Protocol get_driver_type(uint8_t i) const
@@ -165,9 +163,6 @@ private:
 #endif
 
     static AP_CANManager *_singleton;
-
-    char* _log_buf;
-    uint32_t _log_pos;
 
     HAL_Semaphore _sem;
 

--- a/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
@@ -40,9 +40,6 @@ static const SysFileList sysfs_file_list[] = {
     {"memory.txt"},
     {"uarts.txt"},
     {"timers.txt"},
-#if HAL_MAX_CAN_PROTOCOL_DRIVERS
-    {"can_log.txt"},
-#endif
 #if HAL_NUM_CAN_IFACES > 0
     {"can0_stats.txt"},
     {"can1_stats.txt"},
@@ -120,11 +117,6 @@ int AP_Filesystem_Sys::open(const char *fname, int flags, bool allow_absolute_pa
     if (strcmp(fname, "timers.txt") == 0) {
         hal.util->timer_info(*r.str);
     }
-#if HAL_CANMANAGER_ENABLED
-    if (strcmp(fname, "can_log.txt") == 0) {
-        AP::can().log_retrieve(*r.str);
-    }
-#endif
 #if HAL_NUM_CAN_IFACES > 0
     int8_t can_stats_num = -1;
     if (strcmp(fname, "can0_stats.txt") == 0) {


### PR DESCRIPTION
Replace the in-memory _log_buf with GCS_SEND_TEXT, mapping LogLevel to MAV_SEVERITY, and mirror each line to AP_Logger via Write_MessageF so messages emitted before a GCS connects are still captured. Drop log_retrieve() and the LOG_BUFFER_SIZE buffer that backed @SYS/can_log.txt.

This resolves another issue that can lead to a crash, following is what happens with existing method:
The comparision `(LOG_BUFFER_SIZE - _log_pos) < (10 + strlen(tag) + strlen(fmt)` clears even though it shouldn't as the string size with format filled will overflow. It goes to the next steps till snprintf and vsnprintf calls and it doesn't return what is written into the string, but what could have been (i.e. the full string length with values filled in). So we basically end up with _log_pos value greater than LOG_BUFFER_SIZE.

On next calls we simply keep writing to the memory as comparision `(LOG_BUFFER_SIZE - _log_pos) < (10 + strlen(tag) + strlen(fmt)` is going to be true `LOG_BUFFER_SIZE - _log_pos` is now a negative number, and we crash.
