### PR TITLE
autotest: wait for home in Replay body-odom before takeoff

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -11929,6 +11929,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.change_mode("LOITER")
         self.wait_ready_to_arm(require_absolute=False)
+        # require_absolute=False does not wait for the EKF origin (and thus home)
+        # to be set. Block until home is set so the GUIDED takeoff's ABOVE_HOME
+        # alt frame conversion succeeds.
+        self.poll_home_position()
         self.arm_vehicle()
         self.takeoffAndMoveAway()
         self.do_RTL()


### PR DESCRIPTION
  The Replay body-odom test relies on a timing-sensitive race where wait_ready_to_arm(require_absolute=False) happens to return after the EKF origin (and home) in the current master, but with any speedup to prearm checks (https://github.com/ArduPilot/ardupilot/pull/32022), the vehicle arms before home is set, and the GUIDED takeoff  fails  takeoff above home command                     

I have added a small change to wait for the home to be set before arming                                                                                                                                                                                                        
                                                                                                      
### Summary

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
