### PR TITLE
Tools/autotest: Copter's flip mode testing includes abandoning the flip

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -3413,11 +3413,11 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_rc(flip_rc_aux_channel, aux_low)
         rc_option_flip_mode = 2 # (source: RC1_OPTION definition)
         self.set_parameter(f'RC{flip_rc_aux_channel}_OPTION', rc_option_flip_mode)
-        self.set_rc(flip_rc_aux_channel, aux_high)
-        # By the time self.set_rc() finishes, copter is mid-flip.
-        self.wait_attitude(despitch=0, desroll=150, tolerance=30)
-        self.wait_attitude(despitch=0, desroll=-130, tolerance=30)
-        self.wait_attitude(despitch=0, desroll=-45, tolerance=30)
+        self.set_rc(flip_rc_aux_channel, aux_high, timeout=None)
+        self.wait_attitude(despitch=0, desroll=120, tolerance=30)
+        self.wait_attitude(despitch=0, desroll=-120, tolerance=30)
+        self.wait_attitude(despitch=0, desroll=-30, tolerance=30)
+        self.wait_attitude(despitch=0, desroll=0, tolerance=30)
         self.progress("Waiting for level")
         self.wait_attitude(despitch=0, desroll=0, tolerance=5)
         self.wait_mode('ALT_HOLD')
@@ -3432,10 +3432,17 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         gentle_positive_stick = 1700
         self.set_rc(2, gentle_positive_stick)
         self.send_cmd_do_set_mode('FLIP') # don't wait for success
-        self.wait_attitude(despitch=45, desroll=0, tolerance=30)
-        # can't check roll here as it flips from 0 to -180..
-        self.wait_attitude(despitch=90, tolerance=30)
-        self.wait_attitude(despitch=-45, tolerance=30)
+        # Due to Euler-angle choices, a pitch-back flip progresses like:
+        #  Roll = 0, pitch 0 -> +90
+        #  (instantly with pitch = +90) Roll 0 -> 180
+        #  Roll = 180, pitch +90 -> 0 -> -90
+        #  (instantly with pitch = -90) Roll 180 -> 0
+        #  Roll = 0, pitch -90 -> 0
+        # (Note that Roll ~180 might be positive or negative, or even flip-flop)
+        self.wait_attitude(despitch=60, desroll=0, tolerance=30)
+        self.wait_attitude(despitch=60, tolerance=30) # desroll is +/-180
+        self.wait_attitude(despitch=-60, desroll=0, tolerance=30)
+        self.wait_attitude(despitch=0, desroll=0, tolerance=30)
         self.progress("Waiting for level")
         self.set_rc(2, neutral_stick)
         self.wait_attitude(despitch=0, desroll=0, tolerance=5)

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -3475,6 +3475,45 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.progress("Regaining altitude")
         self.wait_altitude(19, 60, relative=True)
 
+        class RollReachesMagnitude(vehicle_test_suite.TestSuite.MessageHook):
+            """Observes if roll angle ever exceeds specified magnitude."""
+            def __init__(self, suite: vehicle_test_suite.TestSuite, roll_magnitude_deg: float):
+                super(RollReachesMagnitude, self).__init__(suite)
+                self.roll_magnitude = math.radians(roll_magnitude_deg)
+                self.roll_exceeded_magnitude = False
+
+            def process(self, mav, m):
+                if self.roll_exceeded_magnitude:
+                    return
+                if m.get_type() == 'ATTITUDE' and abs(m.roll) > self.roll_magnitude:
+                    self.roll_exceeded_magnitude = True
+
+        # Test 3: abandon the flip
+        self.progress("Start then abandon a default flip (roll-right)")
+        higher_than_usual_roll_mag_deg = 20.0 # Seeing this indicates the copter started an unusual maneuver
+        flip_start_watcher = RollReachesMagnitude(self, higher_than_usual_roll_mag_deg)
+        # Bigger than the flip-mode abandon threshold (45 deg) plus a bit more for 'momentum during recovery'.
+        flip_happened_threshold_deg = 95.0
+        flip_abort_watcher = RollReachesMagnitude(self, flip_happened_threshold_deg)
+        self.install_message_hook(flip_mode_watcher)
+        self.install_message_hook(flip_start_watcher)
+        self.install_message_hook(flip_abort_watcher)
+        self.send_cmd_do_set_mode('FLIP')
+        # Enough delay that the flip physically initiates, but not enough that it passes the no-abandon point.
+        time.sleep(0.04) # (self.delay_sim_time is too slow for this use-case.)
+        self.send_cmd_do_set_mode('ALT_HOLD')
+        self.wait_attitude(despitch=0, desroll=0, tolerance=5)
+        self.wait_mode('ALT_HOLD')
+        if not flip_mode_watcher.mode_was_observed:
+            raise NotAchievedException("Flip mode did not occur as expected.")
+        if not flip_start_watcher.roll_exceeded_magnitude:
+            raise NotAchievedException("Flip mode abandoned too quickly.")
+        if flip_abort_watcher.roll_exceeded_magnitude:
+            raise NotAchievedException("Flip mode did not abandon, so the flip actually happened.")
+        self.remove_message_hook(flip_mode_watcher)
+        self.remove_message_hook(flip_start_watcher)
+        self.remove_message_hook(flip_abort_watcher)
+
         self.do_RTL()
 
     def configure_EKFs_to_use_optical_flow_instead_of_GPS(self):

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -3381,34 +3381,56 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
     def ModeFlip(self):
         '''Fly Flip Mode'''
+        class WatchForMode(vehicle_test_suite.TestSuite.MessageHook):
+            """Records whether specified mode was ever entered."""
+            def __init__(self, suite: vehicle_test_suite.TestSuite, mode: str):
+                super(WatchForMode, self).__init__(suite)
+                self.desired_mode = suite.get_mode_from_mode_mapping(mode)
+                self.mode_was_observed = False
+
+            def process(self, mav, m):
+                if self.mode_was_observed:
+                    return
+                if m.get_type() == 'HEARTBEAT' and m.custom_mode == self.desired_mode:
+                    self.mode_was_observed = True
+
         self.context_set_message_rate_hz(mavutil.mavlink.MAVLINK_MSG_ID_ATTITUDE, 100)
 
         self.takeoff(20)
 
+        # Specify this starting mode in order to confirm it is reselected after FLIP mode.
         self.change_mode('ALT_HOLD')
 
-        self.progress("Flipping in roll")
-        self.set_rc(1, 1700)
+        # Test 1: default flip initialized by mode-change to FLIP.
+        self.progress("Flipping in roll (default = roll-right)")
+        flip_mode_watcher = WatchForMode(self, 'FLIP')
+        self.install_message_hook(flip_mode_watcher)
+        neutral_stick = 1500
+        self.set_rc(1, neutral_stick) # forces default flip behavior
         self.send_cmd_do_set_mode('FLIP') # don't wait for success
         self.wait_attitude(despitch=0, desroll=45, tolerance=30)
         self.wait_attitude(despitch=0, desroll=90, tolerance=30)
         self.wait_attitude(despitch=0, desroll=-45, tolerance=30)
         self.progress("Waiting for level")
-        self.set_rc(1, 1500) # can't change quickly enough!
         self.wait_attitude(despitch=0, desroll=0, tolerance=5)
         self.wait_mode('ALT_HOLD')
+        if not flip_mode_watcher.mode_was_observed:
+            raise NotAchievedException("Flip mode did not occur as expected.")
+        self.remove_message_hook(flip_mode_watcher)
         self.progress("Regaining altitude")
         self.wait_altitude(19, 60, relative=True)
 
-        self.progress("Flipping in pitch")
-        self.set_rc(2, 1700)
+        # Test 2: flip in a pilot-directed direction initialized by mode-change to FLIP.
+        self.progress("Flipping in pitch-back")
+        gentle_positive_stick = 1700
+        self.set_rc(2, gentle_positive_stick)
         self.send_cmd_do_set_mode('FLIP') # don't wait for success
         self.wait_attitude(despitch=45, desroll=0, tolerance=30)
         # can't check roll here as it flips from 0 to -180..
         self.wait_attitude(despitch=90, tolerance=30)
         self.wait_attitude(despitch=-45, tolerance=30)
         self.progress("Waiting for level")
-        self.set_rc(2, 1500) # can't change quickly enough!
+        self.set_rc(2, neutral_stick)
         self.wait_attitude(despitch=0, desroll=0, tolerance=5)
         self.wait_mode('ALT_HOLD')
         self.progress("Regaining altitude")

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -3401,15 +3401,22 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # Specify this starting mode in order to confirm it is reselected after FLIP mode.
         self.change_mode('ALT_HOLD')
 
-        # Test 1: default flip initialized by mode-change to FLIP.
+        # Test 1: default flip initialized by RC Aux.
         self.progress("Flipping in roll (default = roll-right)")
         flip_mode_watcher = WatchForMode(self, 'FLIP')
         self.install_message_hook(flip_mode_watcher)
         neutral_stick = 1500
         self.set_rc(1, neutral_stick) # forces default flip behavior
-        self.send_cmd_do_set_mode('FLIP') # don't wait for success
-        self.wait_attitude(despitch=0, desroll=45, tolerance=30)
-        self.wait_attitude(despitch=0, desroll=90, tolerance=30)
+        flip_rc_aux_channel = 9
+        aux_low = 1000
+        aux_high = 2000
+        self.set_rc(flip_rc_aux_channel, aux_low)
+        rc_option_flip_mode = 2 # (source: RC1_OPTION definition)
+        self.set_parameter(f'RC{flip_rc_aux_channel}_OPTION', rc_option_flip_mode)
+        self.set_rc(flip_rc_aux_channel, aux_high)
+        # By the time self.set_rc() finishes, copter is mid-flip.
+        self.wait_attitude(despitch=0, desroll=150, tolerance=30)
+        self.wait_attitude(despitch=0, desroll=-130, tolerance=30)
         self.wait_attitude(despitch=0, desroll=-45, tolerance=30)
         self.progress("Waiting for level")
         self.wait_attitude(despitch=0, desroll=0, tolerance=5)

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -3402,6 +3402,18 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.change_mode('ALT_HOLD')
 
         # Test 1: default flip initialized by RC Aux.
+        def wait_for_roll_right_flip():
+            """These checkpoints and thresholds need hand-tuning to avoid flakes.
+
+            In the future, they may be replaced by a lower-overhead solution,
+            such as a MessageHook + logic to analyze the observed values to find
+            if the flip happened or not.
+            """
+            self.wait_attitude(despitch=0, desroll=120, tolerance=30)
+            self.wait_attitude(despitch=0, desroll=-120, tolerance=30)
+            self.wait_attitude(despitch=0, desroll=-30, tolerance=30)
+            self.wait_attitude(despitch=0, desroll=0, tolerance=30)
+
         self.progress("Flipping in roll (default = roll-right)")
         flip_mode_watcher = WatchForMode(self, 'FLIP')
         self.install_message_hook(flip_mode_watcher)
@@ -3414,10 +3426,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         rc_option_flip_mode = 2 # (source: RC1_OPTION definition)
         self.set_parameter(f'RC{flip_rc_aux_channel}_OPTION', rc_option_flip_mode)
         self.set_rc(flip_rc_aux_channel, aux_high, timeout=None)
-        self.wait_attitude(despitch=0, desroll=120, tolerance=30)
-        self.wait_attitude(despitch=0, desroll=-120, tolerance=30)
-        self.wait_attitude(despitch=0, desroll=-30, tolerance=30)
-        self.wait_attitude(despitch=0, desroll=0, tolerance=30)
+        try:
+            wait_for_roll_right_flip()
+        except AutoTestTimeoutException:
+            raise NotAchievedException("Flip not confirmed. (If the flip did happen, our detection needs tuning.)")
         self.progress("Waiting for level")
         self.wait_attitude(despitch=0, desroll=0, tolerance=5)
         self.wait_mode('ALT_HOLD')
@@ -3428,21 +3440,34 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.wait_altitude(19, 60, relative=True)
 
         # Test 2: flip in a pilot-directed direction initialized by mode-change to FLIP.
+        def wait_for_pitch_back_flip():
+            """These checkpoints and thresholds need hand-tuning to avoid flakes.
+
+            Due to Euler-angle choices, a pitch-back flip progresses like:
+              Roll = 0, pitch 0 -> +90
+              (instantly with pitch = +90) Roll 0 -> 180
+              Roll = 180, pitch +90 -> 0 -> -90
+              (instantly with pitch = -90) Roll 180 -> 0
+              Roll = 0, pitch -90 -> 0
+              (Note that Roll ~180 might be positive or negative, or even flip-flop)
+
+            In the future, the detection logic may be replaced by a lower-overhead solution,
+            such as a MessageHook + logic to analyze the observed values to find
+            if the flip happened or not.
+            """
+            self.wait_attitude(despitch=60, desroll=0, tolerance=30)
+            self.wait_attitude(despitch=60, tolerance=30) # desroll is +/-180
+            self.wait_attitude(despitch=-60, desroll=0, tolerance=30)
+            self.wait_attitude(despitch=0, desroll=0, tolerance=30)
+
         self.progress("Flipping in pitch-back")
         gentle_positive_stick = 1700
         self.set_rc(2, gentle_positive_stick)
         self.send_cmd_do_set_mode('FLIP') # don't wait for success
-        # Due to Euler-angle choices, a pitch-back flip progresses like:
-        #  Roll = 0, pitch 0 -> +90
-        #  (instantly with pitch = +90) Roll 0 -> 180
-        #  Roll = 180, pitch +90 -> 0 -> -90
-        #  (instantly with pitch = -90) Roll 180 -> 0
-        #  Roll = 0, pitch -90 -> 0
-        # (Note that Roll ~180 might be positive or negative, or even flip-flop)
-        self.wait_attitude(despitch=60, desroll=0, tolerance=30)
-        self.wait_attitude(despitch=60, tolerance=30) # desroll is +/-180
-        self.wait_attitude(despitch=-60, desroll=0, tolerance=30)
-        self.wait_attitude(despitch=0, desroll=0, tolerance=30)
+        try:
+            wait_for_pitch_back_flip()
+        except AutoTestTimeoutException:
+            raise NotAchievedException("Flip not confirmed. (If the flip did happen, our detection needs tuning.)")
         self.progress("Waiting for level")
         self.set_rc(2, neutral_stick)
         self.wait_attitude(despitch=0, desroll=0, tolerance=5)

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -5603,7 +5603,7 @@ class TestSuite(abc.ABC):
             16: 1500,
         }
 
-    def set_rc_from_map(self, _map, timeout=20, quiet=False):
+    def set_rc_from_map(self, _map, *, timeout=20, quiet=False):
         map_copy = _map.copy()
         for v in map_copy.values():
             if not isinstance(v, int):
@@ -5694,7 +5694,7 @@ class TestSuite(abc.ABC):
                 need_set[chan] = default_value
         self.set_rc_from_map(need_set)
 
-    def set_rc(self, chan, pwm, timeout=20):
+    def set_rc(self, chan, pwm, *, timeout=20):
         """Setup a simulated RC control to a PWM value"""
         self.set_rc_from_map({chan: pwm}, timeout=timeout)
 

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -5603,7 +5603,11 @@ class TestSuite(abc.ABC):
             16: 1500,
         }
 
-    def set_rc_from_map(self, _map, *, timeout=20, quiet=False):
+    def set_rc_from_map(self, _map, *, timeout: float | int | None = 20.0, quiet=False):
+        """Sets provided RC channel/value pairs.
+
+        Passing the special value 'None' for timeout means 'do not wait for confirmation'.
+        """
         map_copy = _map.copy()
         for v in map_copy.values():
             if not isinstance(v, int):
@@ -5615,6 +5619,9 @@ class TestSuite(abc.ABC):
             if self.rc_thread is None:
                 raise NotAchievedException("Could not create thread")
             self.rc_thread.start()
+
+        if timeout is None:
+            return
 
         tstart = self.get_sim_time()
         while True:
@@ -5694,8 +5701,11 @@ class TestSuite(abc.ABC):
                 need_set[chan] = default_value
         self.set_rc_from_map(need_set)
 
-    def set_rc(self, chan, pwm, *, timeout=20):
-        """Setup a simulated RC control to a PWM value"""
+    def set_rc(self, chan, pwm, *, timeout: float | int | None = 20.0):
+        """Setup a simulated RC control to a PWM value.
+
+        Passing the special value 'None' for timeout means 'do not wait for confirmation'.
+        """
         self.set_rc_from_map({chan: pwm}, timeout=timeout)
 
     def set_servo(self, chan, pwm):


### PR DESCRIPTION
### Summary

This adds an autotest for abandoning Copter's flip mode.

It is chained behind #33012 , so view only the last commit to isolate the changes unique to this PR.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

When a pilot mode-switches to Flip, but then quickly away, the flip abandons if it has not progressed too far already. This autotest confirms that behavior by doing such a mode-switch and observing that:
- Flip mode is in fact entered.
- The copter meaningfully starts to physically flip.
- The copter does not actually do a full flip.

Note to self: `0.08` sec delay passed locally but failed in CI.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
