### PR TITLE
Rover: add has_ever_passed check to EKF failsafe

### DIFF
--- a/Rover/ekf_check.cpp
+++ b/Rover/ekf_check.cpp
@@ -19,6 +19,7 @@
 static struct {
     uint8_t fail_count;         // number of iterations ekf or dcm have been out of tolerances
     uint8_t bad_variance : 1;   // true if ekf should be considered untrusted (fail_count has exceeded EKF_CHECK_ITERATIONS_MAX)
+    bool has_ever_passed;       // true if the ekf checks have ever passed
     uint32_t last_warn_time;    // system time of last warning in milliseconds.  Used to throttle text warnings sent to GCS
 } ekf_check_state;
 
@@ -42,7 +43,17 @@ void Rover::ekf_check()
     }
 
     // compare compass and velocity variance vs threshold
-    if (ekf_over_threshold()) {
+    const bool over_threshold = ekf_over_threshold();
+    const bool position_ok = ekf_position_ok();
+    const bool checks_passed = !over_threshold && position_ok;
+
+    // return if ekf checks have never passed
+    ekf_check_state.has_ever_passed |= checks_passed;
+    if (!ekf_check_state.has_ever_passed) {
+        return;
+    }
+
+    if (over_threshold) {
         // if compass is not yet flagged as bad
         if (!ekf_check_state.bad_variance) {
             // increase counter


### PR DESCRIPTION
fixes premature EKF failsafe triggering in Manual mode before a valid position estimate is acquired.
Fixes #32977 