### PR TITLE
Copter: AutoYaw: ensure weathervane exit code path is always hit

### DIFF
--- a/ArduCopter/autoyaw.cpp
+++ b/ArduCopter/autoyaw.cpp
@@ -375,12 +375,9 @@ AC_AttitudeControl::HeadingCommand Mode::AutoYaw::get_heading()
 #if WEATHERVANE_ENABLED
 void Mode::AutoYaw::update_weathervane(const float pilot_yaw_rads)
 {
-    if (!copter.flightmode->allows_weathervaning()) {
-        return;
-    }
-
     float yaw_rate_cds;
-    if (copter.g2.weathervane.get_yaw_out(yaw_rate_cds, rad_to_cd(pilot_yaw_rads), copter.flightmode->get_alt_above_ground_m(),
+    if (copter.flightmode->allows_weathervaning() &&
+        copter.g2.weathervane.get_yaw_out(yaw_rate_cds, rad_to_cd(pilot_yaw_rads), copter.flightmode->get_alt_above_ground_m(),
                                                                        copter.pos_control->get_roll_cd()-copter.attitude_control->get_roll_trim_cd(),
                                                                        copter.pos_control->get_pitch_cd(),
                                                                        copter.flightmode->is_taking_off(),
@@ -389,6 +386,8 @@ void Mode::AutoYaw::update_weathervane(const float pilot_yaw_rads)
         _yaw_rate_rads = cd_to_rad(yaw_rate_cds);
         return;
     }
+
+    // Weathervane not allowed in current mode, or weathervane thresholds not met
 
     // if the weathervane controller has previously been activated we need to ensure we return control back to what was previously set
     if (mode() == Mode::WEATHERVANE) {


### PR DESCRIPTION
### Summary

This ensures that the weathervane exit code path is still hit if the current mode either changes, or changes its weathervane enabled state.

https://github.com/ArduPilot/ardupilot/issues/33003

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

We have some special code to handle the exit from weathervane here:

https://github.com/ArduPilot/ardupilot/blob/faa316a07b38f863ca7d1b047860fa0c383df98d/ArduCopter/autoyaw.cpp#L393-L401

However, if the current flight mode does not allow weathervaning at all then that code path is skiped by the early return here:

https://github.com/ArduPilot/ardupilot/blob/faa316a07b38f863ca7d1b047860fa0c383df98d/ArduCopter/autoyaw.cpp#L378-L380

The fix is just to remove the early return, this ensures you can never be left in weathervane mode when weathervaning is not being updated.

The test is to have the copter weathervaning in guided with `GUID_OPTIONS` 7: Allow weathervaning. Then change the param to zero.

**Master**

Changing `GUID_OPTIONS` disables the weathervane update but leaves the yaw mode as weathervane, resulting in a constant rate demand.

<img width="1403" height="396" alt="image" src="https://github.com/user-attachments/assets/ad64c598-1355-4c5b-b901-033608a815d7" />

**PR**

Changing the option reverts yaw to the defualt mode which stops the yaw.

<img width="1393" height="407" alt="image" src="https://github.com/user-attachments/assets/3e32451d-df8d-4824-bd13-2b825d27424b" />
