### PR TITLE
AP_Logger: allow for much faster logging over MAVLink

### DIFF
--- a/ArduPlane/Plane.cpp
+++ b/ArduPlane/Plane.cpp
@@ -125,7 +125,7 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
 #endif // AP_TERRAIN_AVAILABLE
     SCHED_TASK(update_is_flying_5Hz,    5,    100, 135),
 #if HAL_LOGGING_ENABLED
-    SCHED_TASK_CLASS(AP_Logger,         &plane.logger, periodic_tasks, 50, 400, 138),
+    SCHED_TASK_CLASS(AP_Logger,         &plane.logger, periodic_tasks, 400, 300, 138),
 #endif
     SCHED_TASK_CLASS(AP_InertialSensor, &plane.ins,    periodic,       50,  50, 141),
 #if HAL_ADSB_ENABLED || AP_ADSB_AVOIDANCE_ENABLED


### PR DESCRIPTION
### Summary

This brings the period update of logging in plane up to match copter, which allows for a lot faster logging.
It also adds a new LOG_MAV_BLK_SEND parameter which allows for more blocks per loop

The combination allows log message loss (from DMS.Dp) of about 0.25% when flying a SITL quadplane with MAVProxy as the logger. Without these changes we get about 70% log message loss.

The remaining 0.25% loss is still a puzzle which we can look at separately

Tested in SITL only. I expect these changes will help with people using high bandwidth links (eg. LTE or starlink)

Should we also set LOG_MAV_RATEMAX default to 10? Unlimited really isn't practical

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->


UPDATE: as discussed on the dev call, changed to just update scheduler rate in plane
