### PR TITLE
AP_Logger: guarantee Replay block written out

### DIFF
--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -789,8 +789,9 @@ bool AP_Logger::WriteReplayBlock(uint8_t msg_id, const void *pBuffer, uint16_t s
                     ret = false;
                 }
                 GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Failed to log replay block");
-                // give time for the thread to run
-                hal.scheduler->delay_microseconds(1000);
+                // give time for the thread to run - i.e. delay
+                // wallclock but not simclock
+                usleep(10000);
             }
 #else  // this is not SITL:
             if (!backends[i]->WritePrioritisedBlock(buf, sizeof(buf), true)) {

--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -782,19 +782,23 @@ bool AP_Logger::WriteReplayBlock(uint8_t msg_id, const void *pBuffer, uint16_t s
         buf[2] = msg_id;
         memcpy(&buf[3], pBuffer, size);
         for (uint8_t i=0; i<_next_backend; i++) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+            while (!backends[i]->WritePrioritisedBlock(buf, sizeof(buf), true)) {
+                if (!log_while_disarmed()) {
+                    // we don't care
+                    ret = false;
+                }
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Failed to log replay block");
+                // give time for the thread to run
+                hal.scheduler->delay_microseconds(1000);
+            }
+#else  // this is not SITL:
             if (!backends[i]->WritePrioritisedBlock(buf, sizeof(buf), true)) {
                 ret = false;
             }
+#endif  // CONFIG_HAL_BOARD == HAL_BOARD_SITL
         }
     }
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    // things will almost certainly go sour.  However, if we are not
-    // logging while disarmed then the EKF can be started and trying
-    // to log things even 'though the backends might be saying "no".
-    if (!ret && log_while_disarmed()) {
-        AP_HAL::panic("Failed to log replay block");
-    }
-#endif
     return ret;
 }
 

--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -444,6 +444,12 @@ bool AP_Logger_File::_WritePrioritisedBlock(const void *pBuffer, uint16_t size, 
 {
     WITH_SEMAPHORE(semaphore);
 
+    static bool did_fail;
+    if (!did_fail && AP_HAL::millis() > 5000) {
+        did_fail = true;
+        return false;
+    }
+
 #if APM_BUILD_TYPE(APM_BUILD_Replay)
     if (AP::FS().write(_write_fd, pBuffer, size) != size) {
         AP_HAL::panic("Short write");


### PR DESCRIPTION
### Summary

Guarantee that if we're supposed to be logging a block that it does go out - instead of panicking.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

No compiler output change on non-SITL:
```
CubeOrangePlus,*
sitl,0
```

### Description

so instead of panicking randomly in CI we will just give the (real) thread a chance to run

I originally broke out a method for the body but decided no-compiler-output change for embedded was a good thing.
