### PR TITLE
Rover: GUIDED mode with heading command only

### DIFF
--- a/Rover/GCS_MAVLink_Rover.cpp
+++ b/Rover/GCS_MAVLink_Rover.cpp
@@ -576,6 +576,9 @@ void GCS_MAVLINK_Rover::handle_manual_control_axes(const mavlink_manual_control_
 
 void GCS_MAVLINK_Rover::handle_set_attitude_target(const mavlink_message_t &msg)
 {
+
+    bool doThrottleAndHeading = false;
+
     // decode packet
     mavlink_set_attitude_target_t packet;
     mavlink_msg_set_attitude_target_decode(&msg, &packet);
@@ -587,7 +590,12 @@ void GCS_MAVLINK_Rover::handle_set_attitude_target(const mavlink_message_t &msg)
 
     // ensure type_mask specifies to use thrust
     if ((packet.type_mask & MAVLINK_SET_ATT_TYPE_MASK_THROTTLE_IGNORE) != 0) {
-        return;
+
+        if(rover.mode_guided.closed_loop_heading_only()){
+            doThrottleAndHeading = true;
+        }else{
+            return;
+        }
     }
 
     // convert thrust to ground speed
@@ -598,7 +606,12 @@ void GCS_MAVLINK_Rover::handle_set_attitude_target(const mavlink_message_t &msg)
     if ((packet.type_mask & MAVLINK_SET_ATT_TYPE_MASK_YAW_RATE_IGNORE) != 0) {
         // convert quaternion to heading
         float target_heading_cd = degrees(Quaternion(packet.q[0], packet.q[1], packet.q[2], packet.q[3]).get_euler_yaw()) * 100.0f;
-        rover.mode_guided.set_desired_heading_and_speed(target_heading_cd, target_speed);
+
+        if (doThrottleAndHeading) {//send heading only (throttle is from RC)
+            rover.mode_guided.set_desired_heading(target_heading_cd);
+        }else{//nominal case set speed and heading
+            rover.mode_guided.set_desired_heading_and_speed(target_heading_cd, target_speed);
+        }
     } else {
         // use body_yaw_rate field
         rover.mode_guided.set_desired_turn_rate_and_speed((RAD_TO_DEG * packet.body_yaw_rate) * 100.0f, target_speed);

--- a/Rover/mode.h
+++ b/Rover/mode.h
@@ -564,6 +564,8 @@ public:
     // set steering and throttle (-1 to +1).  Only called from scripts
     void set_steering_and_throttle(float steering, float throttle);
 
+    void set_desired_heading(float yaw_angle_cd);
+
     // vehicle start loiter
     bool start_loiter();
 
@@ -576,6 +578,8 @@ public:
     void limit_init_time_and_location();
     bool limit_breached() const;
 
+    bool closed_loop_heading_only() const;
+
 protected:
 
     enum class SubMode: uint8_t {
@@ -584,12 +588,14 @@ protected:
         TurnRateAndSpeed,
         Loiter,
         SteeringAndThrottle,
-        Stop
+        Stop,
+        HeadingAndThrottle
     };
 
     // enum for GUID_OPTIONS parameter
     enum class Options : int32_t {
-        SCurvesUsedForNavigation = (1U << 6)
+        SCurvesUsedForNavigation = (1U << 6),
+        ClosedLoopHeadingOnly    = (1U << 7)
     };
 
     bool _enter() override;

--- a/Rover/mode_guided.cpp
+++ b/Rover/mode_guided.cpp
@@ -48,7 +48,32 @@ void ModeGuided::update()
             }
             break;
         }
+        case SubMode::HeadingAndThrottle:
+        {
+            // stop vehicle if target not updated within 3 seconds
+            if (have_attitude_target && (millis() - _des_att_time_ms) > 3000) {
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "heading not received last 3 secs, stopping");
+                have_attitude_target = false;
+            }
+            if (have_attitude_target) {
+                // steering from yaw cmd
+                calc_steering_to_heading(_desired_yaw_cd);
 
+                //throttle from pilot
+                float dummy, desired_throttle;
+                get_pilot_desired_steering_and_throttle(dummy, desired_throttle);
+                g2.motors.set_throttle(desired_throttle);
+            } else {
+                if (rover.is_boat()) {
+                    if (!start_loiter()) {
+                        stop_vehicle();
+                    }
+                } else {
+                    stop_vehicle();
+                }
+            }
+            break;
+        }
         case SubMode::HeadingAndSpeed:
         {
             // stop vehicle if target not updated within 3 seconds
@@ -149,6 +174,7 @@ float ModeGuided::wp_bearing() const
         return g2.wp_nav.wp_bearing_cd() * 0.01f;
     case SubMode::HeadingAndSpeed:
     case SubMode::TurnRateAndSpeed:
+    case SubMode::HeadingAndThrottle:
         return 0.0f;
     case SubMode::Loiter:
         return rover.mode_loiter.wp_bearing();
@@ -168,6 +194,7 @@ float ModeGuided::nav_bearing() const
         return g2.wp_nav.nav_bearing_cd() * 0.01f;
     case SubMode::HeadingAndSpeed:
     case SubMode::TurnRateAndSpeed:
+    case SubMode::HeadingAndThrottle:
         return 0.0f;
     case SubMode::Loiter:
         return rover.mode_loiter.nav_bearing();
@@ -187,6 +214,7 @@ float ModeGuided::crosstrack_error_m() const
         return g2.wp_nav.crosstrack_error_m();
     case SubMode::HeadingAndSpeed:
     case SubMode::TurnRateAndSpeed:
+    case SubMode::HeadingAndThrottle:
         return 0.0f;
     case SubMode::Loiter:
         return rover.mode_loiter.crosstrack_error_m();
@@ -206,6 +234,7 @@ float ModeGuided::get_desired_lat_accel() const
         return g2.wp_nav.get_lat_accel();
     case SubMode::HeadingAndSpeed:
     case SubMode::TurnRateAndSpeed:
+    case SubMode::HeadingAndThrottle:
         return 0.0f;
     case SubMode::Loiter:
         return rover.mode_loiter.get_desired_lat_accel();
@@ -226,6 +255,7 @@ float ModeGuided::get_distance_to_destination() const
         return _distance_to_destination;
     case SubMode::HeadingAndSpeed:
     case SubMode::TurnRateAndSpeed:
+    case SubMode::HeadingAndThrottle:
         return 0.0f;
     case SubMode::Loiter:
         return rover.mode_loiter.get_distance_to_destination();
@@ -246,6 +276,7 @@ bool ModeGuided::reached_destination() const
         return g2.wp_nav.reached_destination();
     case SubMode::HeadingAndSpeed:
     case SubMode::TurnRateAndSpeed:
+    case SubMode::HeadingAndThrottle:
     case SubMode::Loiter:
     case SubMode::SteeringAndThrottle:
     case SubMode::Stop:
@@ -269,6 +300,7 @@ bool ModeGuided::set_desired_speed(float speed_ms)
     case SubMode::Loiter:
         return rover.mode_loiter.set_desired_speed(speed_ms);
     case SubMode::SteeringAndThrottle:
+    case SubMode::HeadingAndThrottle:
     case SubMode::Stop:
         // no speed control
         return false;
@@ -288,6 +320,7 @@ bool ModeGuided::get_desired_location(Location& destination) const
         return false;
     case SubMode::HeadingAndSpeed:
     case SubMode::TurnRateAndSpeed:
+    case SubMode::HeadingAndThrottle:
         // not supported in these submodes
         return false;
     case SubMode::Loiter:
@@ -384,6 +417,16 @@ void ModeGuided::set_steering_and_throttle(float steering, float throttle)
     _have_strthr = true;
 }
 
+
+void ModeGuided::set_desired_heading(float yaw_angle_cd){
+
+    _guided_mode = SubMode::HeadingAndThrottle;
+    _des_att_time_ms = AP_HAL::millis();
+
+    _desired_yaw_cd = yaw_angle_cd;
+    have_attitude_target = true;
+}
+
 bool ModeGuided::start_loiter()
 {
     if (rover.mode_loiter.enter()) {
@@ -444,4 +487,9 @@ bool ModeGuided::limit_breached() const
 bool ModeGuided::use_scurves_for_navigation() const
 {
     return ((g2.guided_options.get() & uint32_t(Options::SCurvesUsedForNavigation)) != 0);
+}
+
+bool ModeGuided::closed_loop_heading_only() const
+{
+    return ((g2.guided_options.get() & uint32_t(Options::ClosedLoopHeadingOnly)) != 0);
 }


### PR DESCRIPTION

### Summary

I am working on a special case in Rover where heading command comes from mavlink SET_ATTITUDE_TARGET,
but the throttle is still using RC. Tested in SITL using Gazebo.  


### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
