### PR TITLE
hwdef: canonicalise README heading names and levels

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/3DRControlZeroG/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/3DRControlZeroG/README.md
@@ -36,7 +36,7 @@ The Control Zero H7 OEM revision G is a flight controller produced by [3DR (mRo)
   - Buzzer
   - Safety Button
 
-### Uncased Weight and Dimensions
+### Physical
 
  Weight: 3.66g (13.oz)
  Width:  20mm (.79in)
@@ -124,6 +124,6 @@ This board has a built-in voltage and current sensors. The following settings ne
 
 The compiled binary will be located in `build/3DRControlZeroG/bin/arducopter.apj`.
 
-## Uploading Firmware
+## Loading Firmware
 
 Any Control Zero H7 OEM revision G has a preloaded Ardupilot bootloader, which allows the user to use a compatible Ground Station software to upload the `.apj` file.

--- a/libraries/AP_HAL_ChibiOS/hwdef/ACNS-CM4Pilot/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ACNS-CM4Pilot/README.md
@@ -91,7 +91,7 @@ firmware, using your favorite DFU loading tool.
 
 Subsequently, you can update the firmware with Mission Planner.
 
-## Pinout and Size
+## Pinout
 
 ![CM4Pilot Pinout](CM4Pilot_Pinout.jpg)
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/AET-H743-Basic/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/AET-H743-Basic/README.md
@@ -27,12 +27,12 @@ The AET-H743-Basic is a flight controller designed and produced by AeroEggTech
 
 ![AET-H743-Basic power board](AET-H743-Basic_power_board.png)
 
-## Mechanical
+## Physical
 
 - Dimensions: 36 x 47 x 17 mm
 - Weight: 45g
 
-## Power supply
+## Power Supply
 
 The AET-H743-Basic supports 2-6s Li battery input. It has 3 ways of BEC, which result in 6 ways of power supplys. Please see the table below.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ARK_FPV/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ARK_FPV/README.md
@@ -17,7 +17,7 @@
 - Bosch BMP390 Barometer
 - ST IIS2MDC Magnetometer
 
-### Power
+### Power Supplies
 
 - 5.5V - 54V (2S - 12S) input
 - 12V, 2A output
@@ -59,7 +59,7 @@
   - 3.3V Out, UART, SWD
   - JST-SH 6 Pin
 
-### Dimensions
+### Physical
 
 - Size: 3.6 x 3.6 x 0.8 cm
 - Weight: 7.5g with MicroSD card

--- a/libraries/AP_HAL_ChibiOS/hwdef/ARK_PI6X/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ARK_PI6X/README.md
@@ -20,7 +20,7 @@
 - INA226 Voltage/Current Monitor
 - Buzzer
 
-### Power
+### Power Supplies
 
 - 5.5V - 25.2V (2S - 6S) input
 - 5V, 2A output. 300ma for main system, 200ma for heater
@@ -47,7 +47,7 @@
   - 3.3V Out, USART3, SWD
   - JST-SH 6 Pin
 
-### Dimensions
+### Physical
 
 - Size: 91.5mm x 56mm
 - Weight: 41g

--- a/libraries/AP_HAL_ChibiOS/hwdef/ATOMRCF405NAVI-Deluxe/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ATOMRCF405NAVI-Deluxe/README.md
@@ -63,7 +63,7 @@ tbd
 
 Serial protocols shown are defaults, but can be adjusted to personal preferences.
 
-## Dshot capability
+## PWM Output
 
 All motor/servo outputs are Dshot and PWM capable. Outputs 1/2 and 6/7 are Bi-Directional DSHot capable.
 
@@ -98,7 +98,7 @@ Enable Battery monitor with `BATT_MONITOR=4`, then reboot, then set:
 - BATT_VOLT_MULT = 11
 - BATT_AMP_PERVLT = 30
 
-## Connecting a GPS/Compass module
+## Connecting a GPS/Compass Module
 
 This board does not include a GPS or compass. But a connector is provided to attach an external module.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/Aeromind6X/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Aeromind6X/README.md
@@ -38,7 +38,7 @@ Featuring **Triple Redundant IMUs** and **Integrated High-Speed Ethernet**, it o
 - Input Voltage: up to 6 V
 - USB Input: 4.75 V - 5.25 V
 
-### Mechanical
+### Physical
 
 - Weight: 150 g
 - Dimensions: 94 x 46 x 38 mm
@@ -108,7 +108,7 @@ Featuring **Triple Redundant IMUs** and **Integrated High-Speed Ethernet**, it o
 
 ---
 
-## RC Input Configuration
+## RC Input
 
 RC input supports SBUS, PPM, and DSM protocols with dedicated ports available for each. For bi-directional protocols, UART4 or other telemetry ports can be configured to handle the connection. For more details, refer to the [ArduPilot documentation](https://ardupilot.org/plane/docs/common-rc-systems.html)
 
@@ -136,7 +136,7 @@ An internal compass is provided by a RM3100  sensor. Often this compass is disab
 
 ---
 
-## Analog Ports
+## Analog Inputs
 
 Includes two native ADC inputs:
 
@@ -176,13 +176,9 @@ Below is the mapping of GPIO labels to their respective GPIO numbers:
 
 ---
 
-## Firmware
+## Loading Firmware
 
 Firmware is available via the [ArduPilot Firmware Server](https://firmware.ardupilot.org) under the `Aeromind6X` target.
-
----
-
-## Loading Firmware
 
 The board ships with an ArduPilot-compatible bootloader, allowing you to load `.apj` firmware files using any ArduPilot-compatible Ground Control Station (GCS) such as **Mission Planner** or **QGroundControl**.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/Airvolute-DCS2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Airvolute-DCS2/README.md
@@ -27,7 +27,7 @@ info@airvolute.com
 
 ![DC2 Pilot peripherals](https://github.com/vrsanskytom/ardupilot/blob/hwdef_for_airvolute_dcs2/libraries/AP_HAL_ChibiOS/hwdef/Airvolute-DCS2/DC2.Pilot%20peripherals.png)
 
-## DCS2.Pilot onboard FMU related connectors pinout
+## Pinout
 
 ### Top side
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BETAFPV-F405-I2C/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BETAFPV-F405-I2C/README.md
@@ -1,4 +1,4 @@
-# BETAFPV F405 AIO Flight Controller
+# BETAFPV F405 AIO Flight Controller (I2C)
 
 The BETAFPV F405 AIO is a flight controller produced by [BETAFPV](https://betafpv.com/collections/flight-controller-1/products/f4-2-3s-20a-aio-fc-v1).
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BOTWINGF405/Readme.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BOTWINGF405/Readme.md
@@ -24,7 +24,7 @@ The BOTWINGF405 is a compact, high-performance flight controller developed for f
 - DPS310 Barometer
 - Optional External Compass (AK8963 supported)
 
-### Power
+### Power Supplies
 
 - 2S-6S LiPo input with onboard voltage and current monitoring
 - BEC Outputs:

--- a/libraries/AP_HAL_ChibiOS/hwdef/BlitzH743Pro/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BlitzH743Pro/README.md
@@ -75,7 +75,7 @@ Channels within the same group need to use the same output rate. If
 any channel in a group uses DShot then all channels in the group need
 to use DShot.
 
-## Video Power Control
+## VTX Power Control
 
 The 12V video power can be turned off/on  using GPIO 81 which is already assigned by default to RELAY2.  This relay can be controlled either from the GCS or using a transmitter channel (See [auxiliary functions](https://ardupilot.org/copter/docs/common-auxiliary-functions.html))
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BlitzWingH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BlitzWingH743/README.md
@@ -69,7 +69,7 @@ Channels within the same group need to use the same output rate. If
 any channel in a group uses DShot then all channels in the group need
 to use DShot.
 
-## Video Power Control
+## VTX Power Control
 
 The 9V video power can be turned off/on  using GPIO 81 which is already assigned by default to RELAY2.  This relay can be controlled either from the GCS or using a transmitter channel (See [auxiliary functions](https://ardupilot.org/copter/docs/common-auxiliary-functions.html))
 
@@ -77,7 +77,7 @@ The 9V video power can be turned off/on  using GPIO 81 which is already assigned
 
 The camera output can be switched using GPIO 82 which is already assigned by default to RELAY3.  This relay can be controlled either from the GCS or using a transmitter channel (See [auxiliary functions](https://ardupilot.org/copter/docs/common-auxiliary-functions.html))
 
-## Analog Airspeed Input
+## Analog Airspeed
 
 The analog airspeed pin is "4"
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/BrahmaF4/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/BrahmaF4/README.md
@@ -16,7 +16,7 @@
 - 5V Power Out: 2.0A max
 - 9V Power Out: 2.0A max
 
-## Pinout for BRAHMA F405
+## Pinout
 
 ![BrahmaF405](BRAHMA_F405-diagram.jpg "DM_BrahmaF4")
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CBU-H7-LC-Stamp/readme.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CBU-H7-LC-Stamp/readme.md
@@ -84,7 +84,7 @@ USART 6 Tx is available for use with bi directional protocols.
 
 An optional IOMCU can be connected to this serial port, a compatible custom build of the firmware required.
 
-## CAN Ports
+## CAN
 
 2 CAN buses are available, each with a built in 120 ohm termination resistor.
 
@@ -140,7 +140,7 @@ USB Signals D+ & D- are available to route to a suitable connector for your proj
 
 Optional, if it is not fitted remove the check from arming mask. To activate short this pad to 3.3v with a momentary push button (Press & Hold)
 
-## Power
+## Power Supplies
 
 A regulated 3.3v output is available from the stamp for use with the safety button. WARNING! This is shared with the main IC - Do NOT use for accessories. Keep current draw under 0.1A!
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CBU-H7-Stamp/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CBU-H7-Stamp/README.md
@@ -50,7 +50,7 @@ The [CBUnmanned H743 Stamp](https://cbunmanned.com/store) is a flight controller
 
 ![H743 Stamp Pinout](H743Pinout.png "H743")
 
-### UART Mapping
+## UART Mapping
 
  Ardupilot -> STM32
 
@@ -68,7 +68,7 @@ Serial 2, 5 & 7 have RTS/CTS pins, the other UARTs do not have RTS/CTS.
 
 GPS 1 & 2 are on Serial 3 & 4 respectively.
 
-### RC Input
+## RC Input
 
 RC input is configured on the USART 6 Rx Pin. This pin allows all RC protocols compatible with direct connection to a H7 IC (SBus requires setting the bitmask for hardware inversion, CRSF etc), PPM is NOT supported.
 
@@ -76,11 +76,11 @@ USART 6 Tx is available for use with bi directional protocols.
 
 An optional IOMCU can be connected to this serial port, a compatible custom build of the firmware required.
 
-### CAN Ports
+## CAN
 
 2 CAN buses are available, each with a built in 120 ohm termination resistor.
 
-### I2C
+## I2C
 
 I2C 1 - Internal for BMM150 Compass.
 
@@ -90,11 +90,11 @@ I2C 3 - External With internal 2.2k Pull Up.
 
 I2C 4 - External With internal 2.2k Pull Up.
 
-### SPI
+## SPI
 
 SPI 4 is available for use with external sensors alongside a Chip Select and Data Ready pin, compatible custom build of the firmware required.
 
-### PWM Output
+## PWM Output
 
 The Stamp supports up to 10 PWM outputs with D-Shot.
 
@@ -110,27 +110,27 @@ BiDirectional DShot available on the first 8 outputs.
 
 A buzzer alarm signal is available on Timer 14.
 
-### Analog Inputs
+## Analog Inputs
 
 The board has two ADC input channels for Voltage (0-3.3v) and Current (0-3.3v) measurement. Settings are dependent on the external hardware used.
 
-### Ethernet
+## Ethernet
 
 Ethernet is available on 4 output pads and has internal magnetics supporting direct connection to external equipment, no need for a large RJ45 connector.
 
-### Compass
+## Compass
 
 The H743 Stamp has a built in compass, the BMM150. Due to potential interference the board is usually used with an external I2C or CAN compass as part of a GPS/Compass combination.
 
-### USB
+## USB
 
 USB Signals D+ & D- are available to route to a suitable connector for your project.
 
-### Safety Button
+## Safety Button
 
 Optional, if it is not fitted remove the check from arming mask. To activate short this pad to 3.3v with a momentary push button (Press & Hold).
 
-### Power
+## Power Supplies
 
 A regulated 3.3v output is available from the stamp for use with the safety button. WARNING! This is shared with the main IC - Do NOT use for accessories. Keep current draw under 0.1A!
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CORVON405V2_1/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CORVON405V2_1/README.md
@@ -76,7 +76,7 @@ The default battery parameters are:
 
 The CORVON405V2.1 does not have a built-in compass, but you can attach an external compass using I2C on the SDA and SCL connector.
 
-## Ports Connector
+## Pinout
 
 ![CORVON405V2.1 Ports Connection](CORVON405V2.1_PortsConnection.jpg)
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CORVON743V1/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CORVON743V1/README.md
@@ -80,13 +80,13 @@ The default battery parameters are:
 
 The CORVON743V1 has a built-in compass sensor (IST8310), and you can also attach an external compass using I2C on the SDA and SCL connector.
 
-## Mechanical
+## Physical
 
 - Mounting: 30.5 x 30.5mm, Φ4mm
 - Dimensions: 36 x 36 x 8 mm
 - Weight: 9g
 
-## Ports Connector
+## Pinout
 
 ![CORVON743V1 Ports Connection](CORVON743V1_PortsConnection.jpg)
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CUAVv5-bdshot/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CUAVv5-bdshot/README.md
@@ -1,4 +1,4 @@
-# CUAVv5 Flight Controller
+# CUAVv5 Flight Controller (bdshot)
 
 The CUAVv5 flight controller is sold by [CUAV](http://store.cuav.net/)
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrangePlus-ODID/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrangePlus-ODID/README.md
@@ -1,4 +1,4 @@
-# CubeOrangePlus Flight Controller
+# CubeOrangePlus Flight Controller (ODID)
 
 The CubePilot CubeOrangePlus flight controller is sold by a range of resellers
 listed on the

--- a/libraries/AP_HAL_ChibiOS/hwdef/F4BY_F427/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/F4BY_F427/README.md
@@ -4,7 +4,7 @@ The [F4BY flight controller shop](https://f4by.com/en/?order/our_product).
 
 The instructions are available here: [F4BY mcu upgrade instructions](https://f4by.com/en/?doc/fc_f4by_v2.1.5)
 
-## Howto
+## How to use
 
 for self upgrage old fc:
 replace old MCU STM32F407VGT (1MB Flash) with STM32F427VET rev3 or above (2MB Flash)

--- a/libraries/AP_HAL_ChibiOS/hwdef/F4BY_H743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/F4BY_H743/README.md
@@ -36,7 +36,7 @@ The instructions, schematic, 3D model  are available [here](https://f4by.com/en/
   - USB GHS type port for external connector.
   - DFU bootloader button
 
-## Analog sensors
+## Analog Inputs
 
 - Analog airspeed PC0 (0...+3.3v range) pin 10
 - Analog rssi PC1     (0...+3.3v range) pin 11
@@ -128,7 +128,7 @@ Group #4
 
 **Note:**  0 ... +3.3V range. This pins can be used for relay control, camera shutter, camera feedback e.t.c.
 
-## Dimensions
+## Physical
 
 - Size: 50 x 50 mm
 - Mounting holes: 45 x 45 mm (M3)

--- a/libraries/AP_HAL_ChibiOS/hwdef/FlysparkF4/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/FlysparkF4/README.md
@@ -22,13 +22,13 @@ The **FlySpark F4** flight controller is sold by [FlySpark](https://flyspark.in/
 - 3 S - 6 S LiPo input voltage range
 - 30.5 x 30.5 mm mounting pattern (⌀4 mm holes)
 
-## Mechanical
+## Physical
 
 - 41.6mm x 39.4mm x 7.8mm
 - 10.5g
 - Mounting: 30.5mmx30.5mm (4 mm holes)
 
-## Wiring / Pinout
+## Pinout
 
 ![FlySparkF4 Pinout1](flyspark_f4_connections.png "Pinout1")
 ![FlySparkF4 Pinout2](flyspark_f4_connections_1.png "Pinout2")

--- a/libraries/AP_HAL_ChibiOS/hwdef/GreenSightUltraBlue/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/GreenSightUltraBlue/README.md
@@ -30,7 +30,7 @@ The UltraBlue flight controller is sold by [GreenSight](https://greensightag.com
 - SERIAL7 -> UART7 (USER/[debug tx/rx], no DMA)
 - SERIAL8 -> USB2
 
-## Connectors
+## Pinout
 
 All connectors are JST GH type unless otherwise specified.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/HEEWING-F405/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/HEEWING-F405/README.md
@@ -14,7 +14,7 @@ The HEEWING F405 is a flight controller produced by [HEEWING](https://www.heewin
 - 4 UARTs
 - 9 PWM outputs
 
-### HEEWING F405 Pinout
+## Pinout
 
 ![HEEWING F405 Board](heewingf405.jpg "HEEWING F405")
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/HEEWING-F405v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/HEEWING-F405v2/README.md
@@ -1,4 +1,4 @@
-# HEEWING F405 Flight Controller
+# HEEWING F405 Flight Controller (v2)
 
 [HEEWING](https://www.heewing.com/pages/t1-ranger-vtol-pnp-manual)
 
@@ -14,7 +14,7 @@ The HEEWING F405 is a flight controller produced by [HEEWING](https://www.heewin
 - 4 UARTs
 - 9 PWM outputs
 
-### HEEWING F405 Pinout
+## Pinout
 
 ![HEEWING F405 Board](heewingf405.jpg "HEEWING F405")
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/HWH7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/HWH7/README.md
@@ -14,7 +14,7 @@ The **HWH7** is a flight controller designed and produced by HW.
 - Power (board hardware): 4S–8S LiPo input (12–35.6 V), on-board 5V/3A and 12V/3A BECs.
 - Other hardware (board option): 512Mb blackbox flash.
 
-## Pinout / Connectors
+## Pinout
 
 ![image](HWH7.png)
 
@@ -63,7 +63,7 @@ The HWH7 supports up to 12 PWM or DShot outputs. These outputs are organized int
 - **Bi-directional DShot:** Support is available for **PWM 1 through 8** (Groups 1 and 2).
 - **Timer Grouping Warning:** Be cautious when mixing different types of servos, ESCs, or other timer-based outputs. For example, if PWM 9 is used for a standard servo and PWM 10 is used for a NeoPixel LED, they will conflict because they share **Group 3 (TIM15)**. In typical setups, PE5 and PE6 are used together as servo outputs by default.
 
-## Battery Monitor (ADC)
+## Battery Monitoring
 
 The board has a built-in voltage sensor and external current sensor input.
 
@@ -73,7 +73,7 @@ The board has a built-in voltage sensor and external current sensor input.
 - **BATT_VOLT_MULT** = 11.0
 - **BATT_AMP_PERVLT** = 5.882 (or specify your sensor sensitivity like 170mV/A)
 
-## User GPIOs
+## GPIOs
 
 - GPIO 62 (PD10): Status LED.
 - GPIO 80 (PE2) controls the camera output to the connectors marked "CAM1" and "CAM2". Setting this GPIO high switches the video output from CAM1 to CAM2. By default, RELAY1 is configured to control this pin and sets the GPIO high (CAM1).

--- a/libraries/AP_HAL_ChibiOS/hwdef/Here4FC/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Here4FC/README.md
@@ -21,6 +21,6 @@ Here4 Module is sold as a GPS module, but it can be used as a flight controller.
 - For enabling future updates to FC firmware, use flash bootloader through mission planner, and then user should be able to update firmware through Serial port.
 - Please note that once the firmware is updated to FC, to rollback to GPS firmware user will need to update using APJ file available here [GNSSPeriph-release](https://github.com/CubePilot/GNSSPeriph-release/releases.)
 
-## Pinout and Connectors
+## Pinout
 
 [CubePilot documentation](https://docs.cubepilot.org/user-guides/here-4/here-4-manual#pinout)

--- a/libraries/AP_HAL_ChibiOS/hwdef/JPilot-C/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/JPilot-C/README.md
@@ -119,7 +119,7 @@ Port      UART      Protocol        TX DMA  RX DMA
 5         UART8     None            ✔       ✔
 6         UART4     None            ✔       ✔
 
-## CAN Ports
+## CAN
 
 There are 2 CAN buses available, each with a 120 Ohm termination resistor built-in.
 
@@ -156,7 +156,7 @@ The default battery parameters are:
 - BATT2_VOLT_MULT 11
 - BATT2_AMP_PERVLT 40
 
-## Analog pins
+## Analog Inputs
 
 These analog pins are used in addition to battery monitoring:
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteF4Mini/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteF4Mini/README.md
@@ -14,7 +14,7 @@ The KakuteF7 Mini is a flight controller produced by [Holybro](http://www.holybr
 - 5 UARTs
 - 7 PWM outputs (2 unallocated)
 
-### KakuteF4 Mini Pinout
+## Pinout
 
 ![KakuteF4 Mini Board](kakutef4mini.jpg "KakuteF4 Mini")
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/KakuteF7Mini/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/KakuteF7Mini/README.md
@@ -14,7 +14,7 @@ The KakuteF7 Mini is a flight controller produced by [Holybro](http://www.holybr
 - 6 UARTs
 - 6 PWM outputs
 
-### KakuteF7 Mini Pinout
+## Pinout
 
 ![KakuteF7 Mini Board](kakutef7mini.jpg "KakuteF7 Mini")
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MFT-SEMA100/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MFT-SEMA100/README.md
@@ -30,7 +30,7 @@ The MFT-SEMA100 is a flight controller designed and produced by MFT Savunma ve H
 - SERIAL5 -> UART7 (DMA-enabled)
 - SERIAL6 -> UART8 (RX only)
 
-## Connectors
+## Pinout
 
 All pins are 2.54 mm Pin Headers
 
@@ -98,7 +98,7 @@ The MFT-SEMA100 has a built-in compass sensor (LIB3MDL), and you can also attach
 
 The IMU heater in the MFT-SEMA100 can be controlled with the BRD_HEAT_TARG parameter, which is in degrees C.
 
-## Mechanical
+## Physical
 
 - Mounting: 55 x 56 mm, Φ4 mm
 - Dimensions: 64 x 65 x 10 mm

--- a/libraries/AP_HAL_ChibiOS/hwdef/MUPilot/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MUPilot/README.md
@@ -22,12 +22,12 @@ The MUPilot flight controller is sold by [MUGIN UAV](http://https://www.muginuav
 - voltage monitoring for servo rail and Vcc
 - two dedicated power input ports for external power bricks
 
-## Mechanical
+## Physical
 
 - 91mm x 46mm x 31mm
 - 106g
 
-## Connectors
+## Pinout
 
 ![MUPilot Pinout1](MUPilot-pinout1.png "Pinout1")
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MicoAir405Mini/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MicoAir405Mini/README.md
@@ -76,13 +76,13 @@ The default battery parameters are:
 
 The MicoAir405Mini does not have a built-in compass, but you can attach an external compass using I2C on the SDA and SCL connector.
 
-## Mechanical
+## Physical
 
 - Mounting: 20 x 20mm, Φ3.5mm
 - Dimensions: 30 x 30 x 8 mm
 - Weight: 6g
 
-## Ports Connector
+## Pinout
 
 ![MicoAir F405 Mini V2.1 Ports Connection](MicoAir405Mini_PortsConnection.jpg)
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MicoAir405v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MicoAir405v2/README.md
@@ -73,7 +73,7 @@ The default battery parameters are:
 
 The MicoAir405v2 does not have a built-in compass, but you can attach an external compass using I2C on the SDA and SCL connector.
 
-## Ports Connector
+## Pinout
 
 ![MicoAir F405 V2.1 Ports Connection](MicoAir405v2_PortsConnection.jpg)
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743-AIO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743-AIO/README.md
@@ -73,13 +73,13 @@ The default battery parameters are:
 
 The MicoAir743-AIO does not have a built-in compass, but you can attach an external compass using I2C on the SDA and SCL connector.
 
-## Mechanical
+## Physical
 
 - Mounting: 25.5 x 25.5mm, Φ3mm
 - Dimensions: 36 x 36 x 8 mm
 - Weight: 10g
 
-## Ports Connector
+## Pinout
 
 ![MicoAir H743 AIO Ports Connection](MicoAir743-AIO_Ports_Connection.jpg)
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743-Lite/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743-Lite/README.md
@@ -94,7 +94,7 @@ The MicoAir743-Lite doesn’t have a built-in compass sensor, but you can attach
 
 The MicoAir743-Lite has an on board Bluetooth module connected to UART8(SERIAL8). The Bluetooth id is MicoAir743-Lite-xxxxxx and you can connect to it without pairing id.
 
-## Mechanical
+## Physical
 
 - Mounting: 30.5 x 30.5mm, Φ4mm
 
@@ -102,7 +102,7 @@ The MicoAir743-Lite has an on board Bluetooth module connected to UART8(SERIAL8)
 
 - Weight: 10g
 
-## Ports Connector
+## Pinout
 
 ![MicoAir H743 Lite Ports Connection](MicoAir743-Lite_Ports_Connection.jpg)
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743/README.md
@@ -79,13 +79,13 @@ The default battery parameters are:
 
 The MicoAir743 has a built-in compass sensor (IST8310), and you can also attach an external compass using I2C on the SDA and SCL connector.
 
-## Mechanical
+## Physical
 
 - Mounting: 30.5 x 30.5mm, Φ4mm
 - Dimensions: 36 x 36 x 8 mm
 - Weight: 9g
 
-## Ports Connector
+## Pinout
 
 ![MicoAir H743 V1.3 Ports Connection](MicoAir743_PortsConnection.jpg)
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/MicoAir743v2/README.md
@@ -97,13 +97,13 @@ The MicoAir743v2 has a built-in compass sensor (QMC5883L), and you can also atta
 
 The MicoAir743v2 has an on board Bluetooth module connected to UART8(SERIAL8). The Bluetooth id is MicoAir743v2-xxxxxx and you can connect to it without pairing id.
 
-## Mechanical
+## Physical
 
 - Mounting: 30.5 x 30.5mm, Φ4mm
 - Dimensions: 36 x 36 x 8 mm
 - Weight: 10g
 
-## Ports Connector
+## Pinout
 
 ![MicoAir H743 v2.0 Ports Connection](MicoAir743v2_Ports_Connection.jpg)
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/Morakot/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Morakot/README.md
@@ -26,7 +26,7 @@ Engineered, tested, and manufactured in Taiwan, the Morakot Flight Controller me
 - [STM32H743VIT MCU](https://www.st.com/en/microcontrollers-microprocessors/stm32h743vi.html)
 - 480Mhz / 1MB RAM / 2MB Flash
 
-### Power
+### Power SUpplies
 
 - 3S-8S DC Input power
 - 5V 2A BEC peripherals power
@@ -43,7 +43,7 @@ Engineered, tested, and manufactured in Taiwan, the Morakot Flight Controller me
 - 1x CAN
 - 1x Ethernet
 
-### UART Mapping
+## UART Mapping
 
 UART Mapping
 The UARTs are marked Rn and Tn in the above pinouts. The Rn pin is the receive pin for UARTn. The Tn pin is the transmit pin for UARTn.

--- a/libraries/AP_HAL_ChibiOS/hwdef/NarinFC-H7/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/NarinFC-H7/README.md
@@ -1,6 +1,6 @@
 # [NarinFC-H7 VOLOLAND CO., LTD](https://vololand.com/pages/product/computer "NarinFC-H7")
 
-## Introduction
+## Overview
 
 The NarinFC-H7 is a flight controller produced by [VOLOLAND CO., LTD](https://vololand.com "VOLOLAND CO., LTD")
 
@@ -12,7 +12,7 @@ Compared with previous autopilots, it has better performance and higher reliabil
 
 ![NarinFC-H7](./images/NarinFC_Header.jpg "NarinFC")
 
-## Features/Specifications
+## Features
 
 - **Processor**
   - STM32H743
@@ -47,7 +47,7 @@ Compared with previous autopilots, it has better performance and higher reliabil
 
 [VOLOLAND CO., LTD](https://vololand.com "VOLOLAND CO., LTD")
 
-## Outline Dimensions
+## Physical
 
 ![Outline Dimensions](./images/2.Outline_Dimensions.png "Outline Dimensions")
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/NarinFC-X3/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/NarinFC-X3/README.md
@@ -1,6 +1,6 @@
 # [NarinFC-X3 VOLOLAND Inc.](https://vololand.com/pages/product/computer "NarinFC-X3")
 
-## Introduction
+## Overview
 
 The NarinFC-X3 is a flight controller produced by [VOLOLAND Inc.](https://vololand.com "VOLOLAND Inc.")
 
@@ -12,7 +12,7 @@ Compared with previous autopilots, it has better performance and higher reliabil
 
 ![NarinFC-X3](./images/NarinFC_X3_Introduction.png "NarinFC")
 
-## Features/Specifications
+## Features
 
 - **Processor**
   - STM32H743
@@ -45,7 +45,7 @@ Compared with previous autopilots, it has better performance and higher reliabil
 
 [VOLOLAND Inc.](https://vololand.com "VOLOLAND Inc.")
 
-## Outline Dimensions
+## Physical
 
 ![Outline Dimensions](./images/NarinFC_X3_Dimensions.png "Outline Dimensions")
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/NxtPX4v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/NxtPX4v2/README.md
@@ -79,7 +79,7 @@ The numbering of the GPIOs for PIN variables in ardupilot is:
 - Dimensions: 27 x 32 x 8 mm
 - Weight: 6.5g
 
-## Ports Connector
+## Pinout
 
 ![NxtPX4v2 Front View](NxtPX4v2_FrontView.jpg)
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ORBITH743/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ORBITH743/README.md
@@ -85,11 +85,11 @@ Analog inputs are supported.
 
 The ORBITH743 has an onboard OSD using a MAX7456 chip and is enabled by default. The CAM1/2 and VTX pins provide connections for using the internal OSD. Simultaneous DisplayPort OSD is possible and is configured by default.
 
-## DJI Video and OSD
+## OSD Support
 
 An **SH1.0 6P** connector supports a standard DJI HD VTX. `SERIAL3` is configured by default for DisplayPort. Pin 1 provides 10V which is controlled by GPIO81 -**do not** connect peripherals that require 5V to this pin.
 
-## DShot Capability
+## PWM Output
 
 All motor outputs (M1-M8) support:
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/OrqaF405Pro/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/OrqaF405Pro/README.md
@@ -67,7 +67,7 @@ The correct battery setting parameters are:
 - BATT_VOLT_MULT 8.3
 - BATT_AMP_PERVLT 92.6
 
-## VTX Control
+## VTX Power Control
 
 Switching between Camera1 and Camera2 can be achieved via GPIO pin 74 which is configured on RELAY2
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/OrqaH7QuadCore/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/OrqaH7QuadCore/README.md
@@ -72,7 +72,7 @@ The correct battery setting parameters are:
 - BATT_VOLT_MULT 8.3
 - BATT_AMP_PERVLT 92.6
 
-## VTX Control
+## Camera Control
 
 Switching between Camera1 and Camera2 can be achieved via GPIO pin 74 which is configured on RELAY2
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PilotGaeaSH7V1-bdshot/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PilotGaeaSH7V1-bdshot/README.md
@@ -19,18 +19,18 @@ The PilotGaeaSH7V1-bdshot is a flight controller designed and produced by PilotG
 - 5V/1.5A BEC for main power supply
 - 8V/1.5A BEC for powering Video Transmitter
 
-## Mechanical
+## Physical
 
 - Dimensions: 36 x 36 x 17 mm
 - Weight: 10.5g
 
-## Physical and pinout
+## Pinout
 
 ![PilotGaeaSH7V1-bdshot front view](./PilotGaea_front_view_Pin.jpg)
 
 ![PilotGaeaSH7V1-bdshot rear view](./PilotGaea_rear_view_Pin.jpg)
 
-## Power supply
+## Power Supply
 
 The PilotGaeaSH7V1-bdshot supports 3-8s Li battery input. It has 2 ways of BEC, which result in 3 ways of power supplies. Please see the table below.
 
@@ -71,7 +71,7 @@ RC input can be attached to any UART port. To reassign it:
 
 The PilotGaeaSH7V1-bdshot Supports onboard analog OSD using the AT7456 chip. The composited image is output via the VTX pin.  Simultaneous HD VTX DisplayPort is supported via SERIAL6.
 
-## PWM Output and DShot
+## PWM Output
 
 The PilotGaeaSH7V1-bdshot supports up to **11 physical PWM outputs**, organized into **6 independent timer groups**. All groups support DShot, but **Bi-directional DShot (BDShot)** is fully optimized for **Groups 1-4 (Outputs 1-8)**.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixFlamingo-F767/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixFlamingo-F767/README.md
@@ -25,7 +25,7 @@ Contact dheeranlabs@gmail.com for sales
   - Buzzer port
   - USB-C port
 
-## Connectors
+## Pinout
 
 ### POWER ADC
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-V6PRO/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PixPilot-V6PRO/README.md
@@ -38,7 +38,7 @@ The PixPilot-V6PRO flight controller is sold by a range of resellers listed at [
 - SERIAL4 -> UART8 (GPS2) (RX is DMA capable)
 - SERIAL5 -> UART7   (USER)
 
-## Connector pin assignments
+## Pinout
 
 ### POWER_CAN1 port, POWER_CAN2 ports
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/PrincipIoTH7Pi/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/PrincipIoTH7Pi/README.md
@@ -110,7 +110,7 @@ All outputs are directly wired to the H743 MCU. All 8 outputs support normal
 PWM output formats. All outputs support DShot, outputs 1-6 support
 Bi-Directional DShot.
 
-## Analog Video and OSD Support
+## OSD Support
 
 The Raspberry Pi Zero 2 support analog video output through a pad on its PCB.
 Installing the included POGO pin connects this pad to the H7 Pi and routes the

--- a/libraries/AP_HAL_ChibiOS/hwdef/QioTekAdeptF407/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/QioTekAdeptF407/README.md
@@ -178,7 +178,7 @@ The 12 PWM outputs are in 3 groups:
 
 Channels within the same group need to use the same output rate. If any channel in a group uses DShot or then all channels in the group need to use DShot.
 
-## CAN Port
+## CAN
 
 The CAN port is disabled by default. Enable the CAN port setting the parameters CAN_P1_Driver to 1 (DroneCAN protocol).
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/RadiolinkPIX6/Readme.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/RadiolinkPIX6/Readme.md
@@ -291,6 +291,6 @@ The RadiolinkPIX6 has 3 analog inputs, one 6V tolerant and two 3.3V tolerant
 - ADC Pin13 -> ADC IN2 3.3V Sense
 - Analog 3.3V RSSI input pin = 103
 
-## Connectors
+## Pinout
 
 Unless noted otherwise all connectors are JST GH

--- a/libraries/AP_HAL_ChibiOS/hwdef/SPRacingH7RF/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SPRacingH7RF/README.md
@@ -49,7 +49,7 @@ protocols. PPM is not supported. For protocols requiring half-duplex serial to t
 telemetry (such as FPort) you should setup SERIAL2 as an RC input serial port,
 with half-duplex, pin-swap and inversion enabled. For duplex protocols, like CRSF/ELRS, T2 must also be connected to the receiver.
 
-## Pixel OSD Support
+## OSD Support
 
 Ardupilot does not currently support the integrated OSD chip. UART3 is setup fir use with DisplayPort goggles with OSD.
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SkystarsF405v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SkystarsF405v2/README.md
@@ -82,7 +82,7 @@ The default battery parameters are:
 - BATT_VOLT_MULT = 11.0
 - BATT_AMP_PERVLT = 25.0
 
-## Analog RSSI input
+## Analog RSSI
 
 Analog RSSI uses [RSSI_ANA_PIN](https://ardupilot.org/copter/docs/parameters.html#rssi-ana-pin-receiver-rssi-sensing-pin) 12
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/SkystarsH7HD-bdshot/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SkystarsH7HD-bdshot/README.md
@@ -1,4 +1,4 @@
-# Skystars H7 Flight Controller
+# Skystars H7 Flight Controller (bdshot)
 
 The Skystars H7 is a flight controller produced by [Skystars](http://www.skystars-rc.com/).
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/X-MAV-AP-H743r1/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/X-MAV-AP-H743r1/README.md
@@ -111,11 +111,11 @@ The default battery parameters are:
 - BATT_VOLT_MULT 18.5
 - BATT_AMP_PERVLT 40
 
-## Pinouts
+## Pinout
 
 ![AP-H743-R1 pinouts](ap-h743r1-pinouts.png)
 
-## Mechanical
+## Physical
 
 ![AP-H743-R1](ap-h743r1-size.png)
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/X-MAV-AP-H743v2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/X-MAV-AP-H743v2/README.md
@@ -78,7 +78,7 @@ The default battery parameters are:
 
 The AP-H743v2 has a built-in compass sensor (IST8310), and you can also attach an external compass using I2C on the SDA and SCL connector.
 
-## Mechanical
+## Physical
 
 - Mounting: 30.5 x 30.5mm, Φ4mm
 - Dimensions: 36 x 36 x 8 mm

--- a/libraries/AP_HAL_ChibiOS/hwdef/YARIV6X/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/YARIV6X/README.md
@@ -1,6 +1,6 @@
 # YARI V6X
 
-## Introduction
+## Overview
 
 The YARI V6X autopilot is based on the [FMUV6X and Pixhawk Autopilot Bus open source specifications](https://github.com/pixhawk/Pixhawk-Standards). The Pixhawk Autopilot Bus (PAB) form factor enables the YARI V6X to be used on any PAB carrier board.
 
@@ -136,7 +136,7 @@ Additional GPIOs:
 - FMU_CAP1 58
 - NFC_GPIO 59
 
-## Analog Input
+## Analog Inputs
 
 The YARI V6X has 2 analog inputs, one 6V tolerant and one 3.3V tolerant
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/modalai_fc-v1/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/modalai_fc-v1/README.md
@@ -43,7 +43,7 @@ See Flight Core Datasheet [Here](https://docs.modalai.com/flight-core-datasheets
 
 For detailed pinout descriptions see [FlightCore Pinout](https://docs.modalai.com/flight-core-datasheets-connectors/)
 
-## Dimensions
+## Physical
 
 ![ModalAI-fc-dims](flight_core_v1_imu_locations.png "modal-fc-dims")
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/thepeach-k1/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/thepeach-k1/README.md
@@ -40,7 +40,7 @@ Contact the [manufacturer](https://thepeach.kr/) for hardware support or complia
   - Dimensions: 40.2 x 61.1 x 24.8 mm
   - Weight: 65g
 
-## Connectors
+## Pinout
 
 ![pinmap_top](./pinmap_top.png)
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/thepeach-r1/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/thepeach-r1/README.md
@@ -46,7 +46,7 @@ Contact the [manufacturer](https://thepeach.kr/) for hardware support or complia
   - Dimensions: 49.2 x 101 x 18.2mm
   - Weight: 100g
 
-## Connectors
+## Pinout
 
 ![pinmap_top](./pinmap.png)
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/uav-dev-fc-um982/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/uav-dev-fc-um982/README.md
@@ -18,12 +18,12 @@ The UAV-DEV-FC-UM92 Flight Controller is sold by [UAV-DEV GmbH Webshop](https://
 - Magnetometer Bosch BMM150
 - GNSS Unicore UM982 L1/L2/L5 RTK GNSS with GNSS Heading
 
-### Dimensions
+### Physical
 
 - Size: 50mm x 50mm (without SMA connector) x 15mm
 - Weight: 22g with microSD card
 
-### Power
+### Power Supplies
 
 - 5.2V input via JST-GH
 


### PR DESCRIPTION
### Summary

Replaces closed #33018; clean up markdown structures


### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description




Rename non-canonical H2 headings to their required forms:
- "Pinout and Size", "Pinout and Connectors", "Pinout / Connectors", "Wiring / Pinout", "Physical and pinout", "Pinout for BRAHMA F405", "DCS2.Pilot onboard FMU related connectors pinout", "Pinouts" → "Pinout"
- "Battery Monitor (ADC)" → "Battery Monitoring"
- "RC Input Configuration", "PWM Output and DShot" → canonical names
- "Features/Specifications" → "Features" (NarinFC-H7, NarinFC-X3)

Promote H3 headings that should be H2 required sections:
- "### HEEWING F405 Pinout" → "## Pinout" (HEEWING-F405, HEEWING-F405v2)
- "### KakuteF4 Mini Pinout" → "## Pinout" (KakuteF4Mini)
- "### KakuteF7 Mini Pinout" → "## Pinout" (KakuteF7Mini)
- "### UART Mapping", "### RC Input", "### PWM Output" → H2 (CBU-H7-Stamp)
- "### UART Mapping" → "## UART Mapping" (Morakot)

No content, ordering, or other structure changed.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

hwdef: further README heading canonicalisation

Rename non-standard H2 headings to their canonical forms:
- "Ports Connector" → "Pinout" (9 boards: CORVON*, MicoAir*, NxtPX4v2)
- "Connector pin assignments" → "Pinout" (PixPilot-V6PRO)
- "Dimensions" → "Physical" (F4BY_H743, modalai_fc-v1)
- "Outline Dimensions" → "Physical" (NarinFC-H7, NarinFC-X3)
- "Introduction" → "Overview" (NarinFC-H7, NarinFC-X3, YARIV6X)
- "Analog Input" / "Analog pins" / "Analog Ports" / "Analog sensors" → "Analog Inputs"
- "Dshot capability" → "DShot Capability" (ATOMRCF405NAVI-Deluxe)
- "Connecting a GPS/Compass module" → "Connecting a GPS/Compass Module"

No content, ordering, or heading levels changed.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

hwdef: fix minor heading capitalisation and synonyms

- "Power supply" → "Power Supply"
- "Uploading Firmware" → "Loading Firmware"
- "Analog Airspeed Input" → "Analog Airspeed"
- "Analog RSSI input" → "Analog RSSI"
- "Howto" → "How to use"

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

hwdef: rename "Uncased Weight and Dimensions" heading to "Physical"

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

hwdef: rename "Video Power Control" heading to "VTX Power Control"

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

hwdef: rename "Mechanical" heading to "Physical"

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

hwdef: disambiguate duplicate README H1 titles

Variant boards shared the same title as their base board. Add a parenthetical suffix to make each title unique:
- BETAFPV-F405-I2C → "... (I2C)"
- CUAVv5-bdshot → "... (bdshot)"
- CubeOrangePlus-ODID → "... (ODID)"
- HEEWING-F405v2 → "... (v2)"
- SkystarsH7HD-bdshot → "... (bdshot)"

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

hwdef: further canonicalise README heading names

- ## VTX Control → ## VTX Power Control
- ## User GPIOs → ## GPIOs
- ## Analog Video and OSD Support → ## OSD Support
- ## DJI Video and OSD → ## OSD Support
- ## Pixel OSD Support → ## OSD Support
- ## CAN Port / ## CAN Ports → ## CAN
- ### Mechanical → ### Physical
- ### Dimensions → ### Physical

hwdef: rename ## Connectors to ## Pinout

Skipped 18 files where ## Connectors and ## Pinout both exist and serve different purposes.

hwdef: tidy structure of CBU-H7-Stamp and Aeromind6X

