### PR TITLE
CPUInfo: enable operation on F4

### DIFF
--- a/Tools/CPUInfo/CPUInfo.cpp
+++ b/Tools/CPUInfo/CPUInfo.cpp
@@ -72,8 +72,10 @@ static void show_sizes(void)
     hal.console->printf("void*     : %lu\n", (unsigned long)sizeof(void *));
 
     hal.console->printf("printing NaN: %f\n", (double)sqrtf(-1.0f));
+#if !defined(STM32F4)   // divide by zero seems not to work on F4
     hal.console->printf("printing +Inf: %f\n", (double)(1.0f/0.0f));
     hal.console->printf("printing -Inf: %f\n", (double)(-1.0f/0.0f));
+#endif
 }
 
 #define TENTIMES(x) do { x; x; x; x; x; x; x; x; x; x; } while (0)


### PR DESCRIPTION
### Summary

CPUInfo does not work on F4 because divice-by-zero does not work

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Disable divide-by-zero operations on F4