### PR TITLE
AP_Scripting: VTOL-quicktune restrict tuning to QSTABILIZE/QHOVER/QLOITER

### DIFF
--- a/libraries/AP_Scripting/applets/VTOL-quicktune.lua
+++ b/libraries/AP_Scripting/applets/VTOL-quicktune.lua
@@ -530,12 +530,28 @@ function update()
            return
        end
    end
+   -- For quadplanes, refuse to tune unless in QSTABILIZE/QHOVER/QLOITER.
+   -- In fixed-wing flight the VTOL rate controllers are not active, so the
+   -- slew-rate oscillation gate cannot detect runaway and gains would ramp
+   -- unbounded. Auto-descent VTOL modes (QLAND/QRTL) and QAUTOTUNE/QACRO
+   -- are also excluded -- tuning needs a stable pilot-controlled hover.
+   local in_tunable_mode = true
+   if is_quadplane then
+      local m = vehicle:get_mode()
+      -- QSTABILIZE=17, QHOVER=18, QLOITER=19
+      in_tunable_mode = (m == 17 or m == 18 or m == 19)
+   end
    if sw_pos == sw_pos_tune and (not arming:is_armed() or not vehicle:get_likely_flying()) and get_time() > last_warning + 5 then
       gcs:send_text(MAV_SEVERITY_EMERGENCY, string.format("Tuning: Must be flying to tune"))
       last_warning = get_time()
       return
    end
-   if sw_pos == 0 or not arming:is_armed() or not vehicle:get_likely_flying() then
+   if sw_pos == sw_pos_tune and not in_tunable_mode and get_time() > last_warning + 5 then
+      gcs:send_text(MAV_SEVERITY_EMERGENCY, string.format("Tuning: requires QSTABILIZE/QHOVER/QLOITER"))
+      last_warning = get_time()
+      return
+   end
+   if sw_pos == 0 or not arming:is_armed() or not vehicle:get_likely_flying() or not in_tunable_mode then
       -- abort, revert parameters
       if need_restore then
          need_restore = false

--- a/libraries/AP_Scripting/applets/VTOL-quicktune.md
+++ b/libraries/AP_Scripting/applets/VTOL-quicktune.md
@@ -4,9 +4,19 @@ This script implements a fast VTOL tuning system for multicopters and
 quadplanes. This script can be used to automate the process of
 producing a good "manual tune" for the VTOL rate control parameters.
 
+> **Note for Plane users:** native QuickTune was built into ArduPlane in
+> the 4.6 release cycle (first shipped in Plane 4.6.0, May 2025) as the
+> `AP_Quicktune` library, wired into QSTABILIZE/QHOVER/QLOITER. On
+> Plane 4.6+ you should use the built-in native version instead of this
+> Lua applet -- it does not require scripting, has a smaller flash
+> footprint, and enforces the mode gate in C++. This applet remains
+> available for Copter (where native QuickTune is not yet wired up) and
+> for users on older Plane firmware.
+
 The script is designed to be used in QLOITER mode for quadplanes or
 LOITER mode in multicopters, although it can also be used in other
-VTOL modes.
+VTOL modes (subject to the mode-gate restrictions enforced in the
+script).
 
 ## Parameters
 


### PR DESCRIPTION
### Summary

Refuse to tune in `VTOL-quicktune.lua` unless the quadplane is in QSTABILIZE / QHOVER / QLOITER, and add a note in the applet README pointing Plane users at the built-in `AP_Quicktune` library (shipping in Plane since 4.6.0).

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

SITL test plan run against this branch on `arduplane --model quadplane`, `--speedup 20`, scripting on, `RC7_OPTION=300`, `QUIK_RC_FUNC=300`, `QUIK_DOUBLE_TIME=5`. Test harness drives everything via pymavlink (mode set, force-arm, RC overrides, param polls).

- [x] **FBWA + tune-switch high**: blocked — `Tuning: requires QSTABILIZE/QHOVER/QLOITER` repeats, `Q_A_RAT_RLL_D` stays at baseline.
- [x] **QRTL + tune-switch high**: blocked — same gate message, gain unchanged. Script remains blocked even as the QRTL state machine progresses through `VTOL airbrake → position1 → position2 → Land descend`.
- [x] **QLOITER + tune-switch high (happy path)**: tune proceeds normally — full `RLL_D → RLL_P → PIT_D → PIT_P → YAW_D` ramp/done sequence. Behavior identical to unpatched script in the supported mode.
- [x] **Mid-tune mode change (QLOITER → FBWA)**: tune was in progress with gains elevated; switching to FBWA emitted `Tuning: reverted` and gains returned to baseline. Existing abort path fires correctly via the new `not in_tunable_mode` clause.
- [ ] Multicopter LOITER tuning unchanged (untested — patch path is `(not is_quadplane) → in_tunable_mode = true`, so behavior is byte-identical for Copter; would still be good to confirm.)

### Description

#### Bug

`VTOL-quicktune.lua` only gates on `arming:is_armed()` and `vehicle:get_likely_flying()`. Both are true during fixed-wing flight on a quadplane.

The "oscillation done" check uses `AC_AttitudeControl:get_rpy_srate()`. On a quadplane in fixed-wing flight, the VTOL attitude/rate controllers are not actively producing motor outputs, so the slew rate stays near zero. With `srate < QUIK_OSC_SMAX` always, the gain doubles every `QUIK_DOUBLE_TIME` seconds (default 10 s) without ever satisfying the "done" condition. `QUIK_ANGLE_MAX` (PR #28890) doesn't help either — same reason: the VTOL controller isn't running, so attitude error from its perspective stays at zero.

If the tune-position switch is bumped during a fixed-wing leg, `Q_A_RAT_*_D` ramps unbounded; on the transition back to VTOL the inflated gains drive the controller unstable.

#### Motivation

A pilot accidentally toggled the quicktune script during an RTL leg, which caused a progressive loss of control through the landing phase. The script ramped gains throughout the fixed-wing return; on the transition back to VTOL for landing, the inflated gains drove the aircraft unstable.

#### Fix (commit 1)

Restrict tuning to QSTABILIZE / QHOVER / QLOITER only — the pilot-controlled VTOL hover modes the applet's documentation was written for:

```lua
local in_tunable_mode = true
if is_quadplane then
   local m = vehicle:get_mode()
   in_tunable_mode = (m == 17 or m == 18 or m == 19)  -- QSTABILIZE/QHOVER/QLOITER
end
```

- **Quadplane:** refuse to tune outside QSTABILIZE/QHOVER/QLOITER. Excludes fixed-wing modes (the bug above), auto-descent VTOL modes (`QLAND`, `QRTL` — pilot can't intervene cleanly), `QAUTOTUNE` (conflicts), and `QACRO` (rate-control intent collides with tune-induced motion). If the pilot transitions out of a tunable mode mid-tune, gains revert via the existing abort path (same behavior as disarming or moving the switch low).
- **Multicopter:** unchanged. Rate controllers are always active in copter, so the existing slew-rate gate is sufficient and a mode restriction would be a regression.
- The three mode IDs in the new gate match exactly the three modes that override `Mode::supports_quicktune()` to `true` in [ArduPlane/mode.h](https://github.com/ArduPilot/ardupilot/blob/master/ArduPlane/mode.h) — QSTABILIZE, QHOVER, QLOITER. Convergent evidence that this gate set is the right one.

#### Doc note (commit 2)

Adds a note to `libraries/AP_Scripting/applets/VTOL-quicktune.md` pointing Plane users at the built-in `AP_Quicktune` library, which has shipped in ArduPlane since 4.6.0 (May 2025). The Lua applet remains the only quicktune option for Copter (native quicktune is enabled only with `HAL_QUADPLANE_ENABLED`) and for users on older Plane firmware.

#### Suggested follow-up (separate PR to ardupilot_wiki)

The Plane wiki page <https://ardupilot.org/plane/docs/quicktune.html> documents the built-in version (parameters `QWIK_*`, aux function `181`) but does not mention the Lua applet at all. A user with `VTOL-quicktune.lua` already on their SD card from a pre-4.6 setup has no easy way to tell that they're running a different code path (`QUIK_*` params, aux function `300`). A short note on that wiki page calling out the distinction would close the loop. Happy to open a PR against `ArduPilot/ardupilot_wiki` if that's useful.
