### PR TITLE
Rover: increase proximity update rate to 200Hz

### DIFF
--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -84,7 +84,7 @@ const AP_Scheduler::Task Rover::scheduler_tasks[] = {
     SCHED_TASK_CLASS(AP_Beacon,           &rover.g2.beacon,        update,         50,  200,  24),
 #endif
 #if HAL_PROXIMITY_ENABLED
-    SCHED_TASK_CLASS(AP_Proximity,        &rover.g2.proximity,     update,         50,  200,  27),
+    SCHED_TASK_CLASS(AP_Proximity,        &rover.g2.proximity,     update,         200,  200,  27),
 #endif
     SCHED_TASK_CLASS(AP_WindVane,         &rover.g2.windvane,      update,         20,  100,  30),
     SCHED_TASK(update_wheel_encoder,   50,    200,  36),


### PR DESCRIPTION
### Summary

Increase Rover's AP_Proximity update rate from 50Hz to 200Hz.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

Tested on CubeOrangePlus with RPLIDAR A2 (SCHED_LOOP_RATE=400).
I checked the tasks.txt.
```AP_Proximity::update             MIN=   3 MAX= 112 AVG=  43 OVR=  0 SLP=  0, TOT= 3.6%```

### Description

The RPLidar wiki notes that on rovers it may be necessary to increase SCHED_LOOP_RATE to 400 in order to reliably consume all data from the sensor.
https://ardupilot.org/copter/docs/common-rplidar-a2.html

However, if the Rover AP_Proximity task remains scheduled at 50Hz, the proximity backend still only gets 50 update opportunities per second, so it cannot fully benefit from a faster main loop rate.