### PR TITLE
Clarify SIM::Battery's maximum delta-time behavior

### DIFF
--- a/libraries/SITL/SIM_Battery.cpp
+++ b/libraries/SITL/SIM_Battery.cpp
@@ -69,6 +69,8 @@ static const struct {
     { 0.01,  0.01},
     { 0.001, 0.001 }};
 
+constexpr float maximum_permissible_dt = 0.1f; // seconds
+
 /*
   use table to get resting voltage from remaining capacity
  */
@@ -152,11 +154,10 @@ void Battery::consume_energy(float current_amp, uint64_t now_us)
 {
     constexpr float microsec_to_sec = 1.0e-6f;
     float dt = static_cast<float>(now_us - last_us) * microsec_to_sec;
-    if (dt > 0.1) {
-        // we stopped updating
-        dt = 0;
-    }
     last_us = now_us;
+    if (dt > maximum_permissible_dt) {
+        return;
+    }
     const float delta_Ah = current_amp * dt / 3600;
     remaining_Ah -= delta_Ah;
     remaining_Ah = MAX(0, remaining_Ah);

--- a/libraries/SITL/tests/test_battery.cpp
+++ b/libraries/SITL/tests/test_battery.cpp
@@ -184,6 +184,31 @@ TEST_F(BatteryTest, EnergyConsumption)
                     batteries_and_data[infinite].final_observed_voltage);
 }
 
+TEST_F(BatteryTest, MaximumDeltaTime)
+{
+    // For this test, value must be larger than SIM::Battery's maximum permissible dt.
+    constexpr float dt_sec = 0.11f;
+
+    constexpr float current_amp = 25.0f; // This value is arbitrary
+
+    for (auto& b_and_d : batteries_and_data) {
+        SITL::Battery& battery = std::ref(*b_and_d.batt);
+        const float initial_voltage = battery.get_voltage();
+        const float initial_temperature_degC = battery.get_temperature_degC();
+
+        for (float t = 0.0f; t <= dt_sec * 10; t+=dt_sec) {
+            const uint64_t now_us = initial_us + static_cast<uint64_t>(t * 1e6);
+
+            // Attempt to consume battery energy (but does not work because dt is too large)
+            battery.consume_energy(current_amp, now_us);
+
+            // Confirm no voltage or temperature change (because energy-consumption did not work)
+            EXPECT_FLOAT_EQ(battery.get_voltage(), initial_voltage);
+            EXPECT_FLOAT_EQ(battery.get_temperature_degC(), initial_temperature_degC);
+        }
+    }
+}
+
 namespace {
 void use_some_energy(SITL::Battery& battery) {
     constexpr float current_amp = 25.0f;
@@ -218,7 +243,7 @@ TEST_F(BatteryTest, Resetting)
 
         // Show that attempting a reset without changing any batt params is a no-op.
         use_some_energy(battery);
-        if (is_positive(battery.get_capacity())) {
+        if (!battery.capacity_is_unlimited()) {
             // Show that some voltage has been lost
             float observed = battery.get_voltage();
             EXPECT_LT(observed, max_voltage);


### PR DESCRIPTION
### Summary

This converts a buried "magic number" to a file-level constant + adds a unit test for the behavior.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Locally, I set the test's dt to 0.09 and observed the test fails, as expected.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
