### PR TITLE
Simplify SIM::Battery resetting (remove unnecessary functions)

### DIFF
--- a/libraries/SITL/SIM_Battery.cpp
+++ b/libraries/SITL/SIM_Battery.cpp
@@ -142,20 +142,6 @@ void Battery::maybe_reset(float desired_voltage, float desired_capacity_Ah)
     set_initial_SoC(voltage_set);
 }
 
-void Battery::init_voltage(float voltage)
-{
-    voltage = MIN(voltage, max_voltage);
-    voltage_filter.reset(voltage);
-    voltage_set = voltage;
-    set_initial_SoC(voltage);
-}
-
-void Battery::init_capacity(float capacity)
-{
-    capacity_Ah = capacity;
-    set_initial_SoC(voltage_set);
-}
-
 void Battery::consume_energy(float current_amp, uint64_t now_us)
 {
     constexpr float microsec_to_sec = 1.0e-6f;

--- a/libraries/SITL/SIM_Battery.h
+++ b/libraries/SITL/SIM_Battery.h
@@ -29,9 +29,6 @@ public:
     // Resets the battery state if the configuration (e.g. from SIM_BATT_* parameters) has changed.
     void maybe_reset(float desired_voltage, float desired_capacity_Ah);
 
-    void init_voltage(float voltage);
-    void init_capacity(float capacity);
-
     // Call this periodically to "step" the battery forward in time
     void consume_energy(float current_amp, uint64_t now_us);
 

--- a/libraries/SITL/examples/EvaluateBatteryModel/EvaluateBatteryModel.cpp
+++ b/libraries/SITL/examples/EvaluateBatteryModel/EvaluateBatteryModel.cpp
@@ -63,7 +63,6 @@ void setup(void)
 
     // setup battery model
     battery.setup(amp_hour_capacity, resistance, max_voltage, ambient_temperature_degC);
-    battery.init_voltage(max_voltage);
 
     uint64_t time_us = 0;
     const double time_step_s = 0.05;

--- a/libraries/SITL/tests/test_battery.cpp
+++ b/libraries/SITL/tests/test_battery.cpp
@@ -28,23 +28,13 @@ class BatteryTest : public testing::Test {
 protected:
     BatteryTest() {
         small_battery.setup(small_capacity_Ah, low_resistance_ohm, max_voltage, ambient_temperature_degC);
-        small_battery.init_voltage(max_voltage);
-        small_battery.init_capacity(small_capacity_Ah);
         large_battery.setup(large_capacity_Ah, low_resistance_ohm, max_voltage, ambient_temperature_degC);
-        large_battery.init_voltage(max_voltage);
-        large_battery.init_capacity(large_capacity_Ah);
         // Recall that capacity==0 means unlimited.
         infinite_battery.setup(0.0f, low_resistance_ohm, max_voltage, ambient_temperature_degC);
-        infinite_battery.init_voltage(max_voltage);
-        infinite_battery.init_capacity(0.0f);
 
         small_high_resistance_battery.setup(small_capacity_Ah, high_resistance_ohm, max_voltage, ambient_temperature_degC);
-        small_high_resistance_battery.init_voltage(max_voltage);
-        small_high_resistance_battery.init_capacity(small_capacity_Ah);
         // Recall that capacity==0 means unlimited.
         infinite_high_resistance_battery.setup(0.0f, high_resistance_ohm, max_voltage, ambient_temperature_degC);
-        infinite_high_resistance_battery.init_voltage(max_voltage);
-        infinite_high_resistance_battery.init_capacity(0.0f);
     }
 
     struct BattAndObservations {
@@ -211,48 +201,45 @@ TEST_F(BatteryTest, Resetting)
     for (auto& b_and_d : batteries_and_data) {
         SITL::Battery& battery = std::ref(*b_and_d.batt);
 
-        const float initial_voltage = battery.get_voltage();
-
-        // Show that voltage-based reset works.
-        use_some_energy(battery);
-        if (is_positive(battery.get_capacity())) {
-            // Show that some voltage has been lost
-            EXPECT_LT(battery.get_voltage(), initial_voltage);
-            // Reset to initial value using voltage
-            battery.init_voltage(initial_voltage);
-            // Show it worked
-            EXPECT_FLOAT_EQ(battery.get_voltage(), initial_voltage);
-        }
-
-        // Show that capacity-based reset does not (instantly) impact voltage.
-        use_some_energy(battery);
-        if (is_positive(battery.get_capacity())) {
-            // Show that some voltage has been lost
-            const float observed_voltage = battery.get_voltage();
-            EXPECT_LT(observed_voltage, initial_voltage);
-            // Reset to initial capacity
-            battery.init_capacity(battery.get_capacity());
-            // Show voltage did not change
-            EXPECT_FLOAT_EQ(battery.get_voltage(), observed_voltage);
-        }
-
-        // Show that reset-to-partial-voltage works.
+        // Show that resetting to some new voltage works.
         const float partial_voltage = 0.8f * max_voltage;
-        battery.init_voltage(partial_voltage);
+        battery.maybe_reset(partial_voltage, battery.get_capacity());
         EXPECT_FLOAT_EQ(battery.get_voltage(), partial_voltage);
 
-        // Show that setting higher-than-max voltage has no effect
-        battery.init_voltage(higher_than_max_voltage);
-        EXPECT_LT(battery.get_voltage(), higher_than_max_voltage);
+        // Show that resetting to zero & negative voltages works.
+        for (auto& voltage : {0.0f, -0.5f}) {
+            battery.maybe_reset(voltage, battery.get_capacity());
+            EXPECT_FLOAT_EQ(battery.get_voltage(), voltage);
+        }
+
+        // Show that resetting to the initial voltage works.
+        battery.maybe_reset(max_voltage, battery.get_capacity());
         EXPECT_FLOAT_EQ(battery.get_voltage(), max_voltage);
+
+        // Show that attempting a reset without changing any batt params is a no-op.
+        use_some_energy(battery);
+        if (is_positive(battery.get_capacity())) {
+            // Show that some voltage has been lost
+            float observed = battery.get_voltage();
+            EXPECT_LT(observed, max_voltage);
+
+            battery.maybe_reset(max_voltage, battery.get_capacity());
+            // Show reset did nothing
+            EXPECT_FLOAT_EQ(battery.get_voltage(), observed);
+        }
+
+        // Show that resetting to higher-than-max voltage resets to max, but not higher
+        battery.maybe_reset(higher_than_max_voltage, battery.get_capacity());
+        EXPECT_FLOAT_EQ(battery.get_voltage(), max_voltage);
+        EXPECT_LT(battery.get_voltage(), higher_than_max_voltage);
 
         // Show that switching from limited to unlimited capacity (or vice versa) works
         if (is_zero(battery.get_capacity())) {
-            battery.init_capacity(small_capacity_Ah);
+            battery.maybe_reset(max_voltage, small_capacity_Ah);
             EXPECT_FLOAT_EQ(battery.get_voltage(), max_voltage);
             EXPECT_FLOAT_EQ(battery.get_capacity(), small_capacity_Ah);
         } else {
-            battery.init_capacity(0.0f);
+            battery.maybe_reset(max_voltage, 0.0f);
             EXPECT_FLOAT_EQ(battery.get_voltage(), max_voltage);
             EXPECT_FLOAT_EQ(battery.get_capacity(), 0.0f);
         }


### PR DESCRIPTION
### Summary

SIM::Battery does not need (now-unused) independent voltage/capacity resetting behaviors. This PR removes them.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
