### PR TITLE
Refactor SIM::Battery voltage-getting and capacity-checking

### DIFF
--- a/libraries/SITL/SIM_Battery.cpp
+++ b/libraries/SITL/SIM_Battery.cpp
@@ -72,22 +72,27 @@ static const struct {
 /*
   use table to get resting voltage from remaining capacity
  */
-float Battery::get_resting_voltage(float charge_pct) const
+float Battery::get_resting_voltage(void) const
 {
+    if (capacity_is_unlimited()) {
+        return voltage_set;
+    }
+    const float charge_pct = 100 * remaining_Ah / capacity_Ah;
     const float max_cell_voltage = soc_table[0].volt_per_cell;
+    const float min_cell_voltage = soc_table[ARRAY_SIZE(soc_table) - 1].volt_per_cell;
     for (uint8_t i=1; i<ARRAY_SIZE(soc_table); i++) {
         if (charge_pct >= soc_table[i].soc_pct) {
             // linear interpolation between table rows
-            float dv1 = charge_pct - soc_table[i].soc_pct;
-            float dv2 = soc_table[i-1].soc_pct - soc_table[i].soc_pct;
-            float vpc1 = soc_table[i].volt_per_cell;
-            float vpc2 = soc_table[i-1].volt_per_cell;
-            float cell_volt = vpc1 + (dv1 / dv2) * (vpc2 - vpc1);
+            const float dv1 = charge_pct - soc_table[i].soc_pct;
+            const float dv2 = soc_table[i-1].soc_pct - soc_table[i].soc_pct;
+            const float vpc1 = soc_table[i].volt_per_cell;
+            const float vpc2 = soc_table[i-1].volt_per_cell;
+            const float cell_volt = vpc1 + (dv1 / dv2) * (vpc2 - vpc1);
             return (cell_volt / max_cell_voltage) * max_voltage;
         }
     }
-    // off the bottom of the table, return a small non-zero to prevent math errors
-    return 0.001;
+    // off the bottom of the table
+    return min_cell_voltage;
 }
 
 /*
@@ -96,16 +101,16 @@ float Battery::get_resting_voltage(float charge_pct) const
 void Battery::set_initial_SoC(float voltage)
 {
     const float max_cell_voltage = soc_table[0].volt_per_cell;
-    float cell_volt = (voltage / max_voltage) * max_cell_voltage;
+    const float cell_volt = (voltage / max_voltage) * max_cell_voltage;
 
     for (uint8_t i=1; i<ARRAY_SIZE(soc_table); i++) {
         if (cell_volt >= soc_table[i].volt_per_cell) {
             // linear interpolation between table rows
-            float dv1 = cell_volt - soc_table[i].volt_per_cell;
-            float dv2 = soc_table[i-1].volt_per_cell - soc_table[i].volt_per_cell;
-            float soc1 = soc_table[i].soc_pct;
-            float soc2 = soc_table[i-1].soc_pct;
-            float soc = soc1 + (dv1 / dv2) * (soc2 - soc1);
+            const float dv1 = cell_volt - soc_table[i].volt_per_cell;
+            const float dv2 = soc_table[i-1].volt_per_cell - soc_table[i].volt_per_cell;
+            const float soc1 = soc_table[i].soc_pct;
+            const float soc2 = soc_table[i-1].soc_pct;
+            const float soc = soc1 + (dv1 / dv2) * (soc2 - soc1);
             remaining_Ah = capacity_Ah * soc * 0.01;
             return;
         }
@@ -115,6 +120,7 @@ void Battery::set_initial_SoC(float voltage)
     remaining_Ah = 0;
 }
 
+// Reminder: capacity <= 0 means **unlimited**
 void Battery::setup(float _capacity_Ah, float _resistance_ohm, float _max_voltage, float _ambient_temperature_degC)
 {
     capacity_Ah = _capacity_Ah;
@@ -151,16 +157,16 @@ void Battery::consume_energy(float current_amp, uint64_t now_us)
         dt = 0;
     }
     last_us = now_us;
-    float delta_Ah = current_amp * dt / 3600;
+    const float delta_Ah = current_amp * dt / 3600;
     remaining_Ah -= delta_Ah;
     remaining_Ah = MAX(0, remaining_Ah);
 
-    float voltage_delta = current_amp * resistance_ohm;
+    const float voltage_delta = current_amp * resistance_ohm;
     float voltage;
     if (!is_positive(capacity_Ah)) {
         voltage = voltage_set;
     } else {
-        voltage = get_resting_voltage(100 * remaining_Ah / capacity_Ah) - voltage_delta;
+        voltage = get_resting_voltage() - voltage_delta;
     }
 
     voltage_filter.apply(voltage, dt);
@@ -168,6 +174,7 @@ void Battery::consume_energy(float current_amp, uint64_t now_us)
     update_temperature(current_amp, dt);
 }
 
+// A first-order temperature growth & decay model
 void Battery::update_temperature(float current_amp, float dt)
 {
     // Reasonable thermal_capacity value for a commonly sized (500g) Li-ion battery

--- a/libraries/SITL/SIM_Battery.h
+++ b/libraries/SITL/SIM_Battery.h
@@ -24,6 +24,7 @@ namespace SITL {
 
 class Battery {
 public:
+    // Note: capacity<=0 means **unlimited** capacity.
     void setup(float _capacity_Ah, float _resistance_ohm, float _max_voltage, float _ambient_temperature_degC);
 
     // Resets the battery state if the configuration (e.g. from SIM_BATT_* parameters) has changed.
@@ -35,9 +36,10 @@ public:
     float get_voltage(void) const { return voltage_filter.get(); }
     float get_capacity(void) const { return capacity_Ah; }
     float get_temperature_degC(void) const { return temperature_degC; }
+    bool capacity_is_unlimited(void) const { return !(is_positive(capacity_Ah)); } // for readability
 
 private:
-    float capacity_Ah;
+    float capacity_Ah; // set <= 0 for unlmited capacity
     float resistance_ohm;
     float max_voltage;
     float ambient_temperature_degC;
@@ -51,7 +53,7 @@ private:
     // 10Hz filter for battery voltage
     LowPassFilterFloat voltage_filter{10};
 
-    float get_resting_voltage(float charge_pct) const;
+    float get_resting_voltage(void) const;
     void set_initial_SoC(float voltage);
 };
 }

--- a/libraries/SITL/tests/test_battery.cpp
+++ b/libraries/SITL/tests/test_battery.cpp
@@ -124,7 +124,7 @@ TEST_F(BatteryTest, EnergyConsumption)
             prev_temperature_degC = battery.get_temperature_degC();
 
             // Confirm voltage drop
-            if (is_zero(t) || is_zero(battery.get_capacity())) {
+            if (is_zero(t) || battery.capacity_is_unlimited()) {
                 EXPECT_FLOAT_EQ(battery.get_voltage(), initial_voltage);
             } else {
                 // During consumption, both voltage sag and capacity-loss contribute to voltage < initial.
@@ -134,7 +134,7 @@ TEST_F(BatteryTest, EnergyConsumption)
 
             // Confirm voltage drop works as expected.
             const float observed_voltage = battery.get_voltage();
-            if (is_zero(t) || is_zero(battery.get_capacity())) {
+            if (is_zero(t) || battery.capacity_is_unlimited()) {
                 EXPECT_FLOAT_EQ(observed_voltage, initial_voltage);
                 EXPECT_FLOAT_EQ(observed_voltage, min_observed_voltage);
             }
@@ -234,7 +234,7 @@ TEST_F(BatteryTest, Resetting)
         EXPECT_LT(battery.get_voltage(), higher_than_max_voltage);
 
         // Show that switching from limited to unlimited capacity (or vice versa) works
-        if (is_zero(battery.get_capacity())) {
+        if (battery.capacity_is_unlimited()) {
             battery.maybe_reset(max_voltage, small_capacity_Ah);
             EXPECT_FLOAT_EQ(battery.get_voltage(), max_voltage);
             EXPECT_FLOAT_EQ(battery.get_capacity(), small_capacity_Ah);
@@ -245,7 +245,7 @@ TEST_F(BatteryTest, Resetting)
         }
         use_some_energy(battery);
         // Show that now-unlimited batteries do not lose voltage, and now-limited ones do.
-        if (is_zero(battery.get_capacity())) {
+        if (battery.capacity_is_unlimited()) {
             EXPECT_FLOAT_EQ(battery.get_voltage(), max_voltage);
         } else {
             EXPECT_LT(battery.get_voltage(), max_voltage);


### PR DESCRIPTION
### Summary

Small internal improvements to how SIM::Battery works:
- resting voltage getter computes its own state-of-charge.
- checking if capacity is unlimited via a helper function.
- return a non-arbitrary small voltage for nearly depleted battery.
- improve const-correctness for intermediate variables (per reviewer request).

(This is one of the many PRs related to issue #10050 .)

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
