### PR TITLE
AP_RangeFinder: TeraRangerI2C use non-blocking semaphore

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_TeraRangerI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_TeraRangerI2C.cpp
@@ -144,7 +144,11 @@ void AP_RangeFinder_TeraRangerI2C::timer(void)
 */
 void AP_RangeFinder_TeraRangerI2C::update(void)
 {
-    WITH_SEMAPHORE(_sem);
+    // Try to take the semaphore without blocking. 
+    // If we can't get it immediately, exit and try again next loop.
+    if (!_sem.take(0)) {
+        return;
+    }
 
     if (accum.count > 0) {
         state.distance_m = (accum.sum * 0.01f) / accum.count;
@@ -155,6 +159,9 @@ void AP_RangeFinder_TeraRangerI2C::update(void)
     } else if (AP_HAL::millis() - state.last_reading_ms > 200) {
         set_status(RangeFinder::Status::NoData);
     }
+
+    // We must manually release the semaphore when we are done
+    _sem.give();
 }
 
 #endif  // AP_RANGEFINDER_TRI2C_ENABLED


### PR DESCRIPTION
### Summary

Update AP_RangeFinder_TeraRangerI2C to use a non-blocking semaphore in the update() function to prevent thread lock-ups. 

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Verified in SITL. Confirmed the vehicle boots and flies correctly with the modified driver code.

### Description

This PR addresses a long-standing issue where the TeraRangerI2C driver used a blocking semaphore, which could cause the main loop to lock up if the sensor became unresponsive.

I have replaced the WITH_SEMAPHORE macro with a non-blocking .take(0) call. If the semaphore cannot be taken immediately, the update is skipped to ensure the main thread remains responsive. This fulfills the request in issue #8471.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
