### PR TITLE
Remove incorrect ExternalAHRS eulers/rotmat rotation

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -13151,22 +13151,9 @@ switch value'''
                            relative=True,
                            timeout=timeout)
 
-    def ahrstrim_attitude_correctness_test_attitude(self, ahrs_type: int, divergence_r, divergence_p):
+    def ahrstrim_attitude_correctness_test_attitude(self, ahrs_type: int):
         self.context_set_message_rate_hz(mavutil.mavlink.MAVLINK_MSG_ID_SIM_STATE, 10)
-        ATTITUDE_euler_desroll = 0
-        ATTITUDE_euler_despitch = 0
-        if ahrs_type == 11:
-            # this is very nasty compatibility
-            # code for the fact our rotations are
-            # incorrect for ExternalAHRS eulers
-            # and rotation matrix!  It is here to
-            # ensure behaviour is preserved until
-            # we can fix the bug!  Search for
-            # "note that this is suspect" to find
-            # the problem code.
-            ATTITUDE_euler_desroll = -divergence_r
-            ATTITUDE_euler_despitch = -divergence_p
-        self.wait_attitude(desroll=ATTITUDE_euler_desroll, despitch=ATTITUDE_euler_despitch, timeout=120, tolerance=1.5)
+        self.wait_attitude(desroll=0, despitch=0, timeout=120, tolerance=1.5)
         if ahrs_type != 0:
             self.wait_attitude(desroll=0, despitch=0, message_type='AHRS2', tolerance=1, timeout=120)
         self.wait_attitude_quaternion(desroll=0, despitch=0, tolerance=1, timeout=120)
@@ -13240,7 +13227,7 @@ switch value'''
                         "SIM_ACC_TRIM_Y": math.radians(p),
                     })
                     self.reboot_sitl()
-                    self.ahrstrim_attitude_correctness_test_attitude(11, r, p)
+                    self.ahrstrim_attitude_correctness_test_attitude(11)
                 self.context_pop()
                 self.reboot_sitl()
 
@@ -13260,7 +13247,7 @@ switch value'''
                         "SIM_ACC_TRIM_Y": math.radians(p),
                     })
                     self.reboot_sitl()
-                    self.ahrstrim_attitude_correctness_test_attitude(ahrs_type, r, p)
+                    self.ahrstrim_attitude_correctness_test_attitude(ahrs_type)
 
                 self.context_pop()
 

--- a/libraries/AP_AHRS/AP_AHRS_External.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_External.cpp
@@ -30,9 +30,6 @@ void AP_AHRS_External::get_results(AP_AHRS_Backend::Estimates &results)
     }
     results.attitude_valid = true;
     results.quaternion.rotation_matrix(results.dcm_matrix);
-    // note that this is suspect; we are rotating the matrix and
-    // eulers away from alignment with the quaternion:
-    results.dcm_matrix = results.dcm_matrix * AP::ahrs().get_rotation_vehicle_body_to_autopilot_body();
     results.dcm_matrix.to_euler(&results.roll_rad, &results.pitch_rad, &results.yaw_rad);
 
     results.gyro_drift.zero();


### PR DESCRIPTION
### Summary

Moves ExternalAHRS and eulers to be in same frame as its quaternion result.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

The AHRS ExternalAHRS backend was rotating the rotation matrix and euler values into the autopilot body frame, where each backend should be returning the attitude in vehicle body frame (i.e. the ExternalAHRS must trim itself into the vehicle body frame as it may be mounted at some weird angle).  It was not rotating the quaternion, leaving that in the correct frame.

This is not a small change - once applied if any trim was used for an ExternalAHRS unit they will need to be adjusted.

We agreed at DevCallEU we can get away with release notes for this.
