### PR TITLE
Tools: add gdb_crash_report.py

### DIFF
--- a/Tools/debug/crash_dump_report.py
+++ b/Tools/debug/crash_dump_report.py
@@ -1,0 +1,989 @@
+#!/usr/bin/env python3
+
+"""
+Non-interactive crash dump analysis tool for ArduPilot.
+
+Reads a crash_dump.bin file using GDB and CrashDebug, emitting a
+human-readable report to stdout.
+
+Usage:
+    python3 crash_dump_report.py ELF_FILE CRASH_DUMP_FILE
+
+Requires:
+    - arm-none-eabi-gdb
+    - CrashDebug binary (from modules/CrashDebug/bins/)
+
+Copyright ArduPilot Project 2026
+Released under GNU GPL version 3 or later
+"""
+
+import argparse
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+
+# crash dump signature bytes
+CRASHDUMP_SIG = b'cC'
+
+# register names in dump order (version 3.0)
+INT_REG_NAMES = [
+    'R0', 'R1', 'R2', 'R3',
+    'R4', 'R5', 'R6', 'R7',
+    'R8', 'R9', 'R10', 'R11',
+    'R12', 'SP', 'LR', 'PC',
+    'xPSR', 'MSP', 'PSP', 'exceptionPSR',
+]
+
+FP_REG_NAMES = [f'S{i}' for i in range(32)] + ['FPSCR']
+
+# Cortex-M fault status register addresses
+FAULT_REGS = {
+    'CFSR':   0xE000ED28,  # Configurable Fault Status Register
+    'HFSR':   0xE000ED2C,  # HardFault Status Register
+    'DFSR':   0xE000ED30,  # Debug Fault Status Register
+    'MMFAR':  0xE000ED34,  # MemManage Fault Address Register
+    'BFAR':   0xE000ED38,  # BusFault Address Register
+    'AFSR':   0xE000ED3C,  # Auxiliary Fault Status Register
+    'ICSR':   0xE000ED04,  # Interrupt Control and State Register
+}
+
+# CFSR bit definitions
+CFSR_BITS = {
+    # MemManage (bits 0-7)
+    0:  'IACCVIOL  - Instruction access violation',
+    1:  'DACCVIOL  - Data access violation',
+    3:  'MUNSTKERR - MemManage fault on unstacking for return from exception',
+    4:  'MSTKERR   - MemManage fault on stacking for exception entry',
+    5:  'MLSPERR   - MemManage fault during FP lazy state preservation',
+    7:  'MMARVALID - MMFAR holds a valid address',
+    # BusFault (bits 8-15)
+    8:  'IBUSERR   - Instruction bus error',
+    9:  'PRECISERR - Precise data bus error',
+    10: 'IMPRECISERR - Imprecise data bus error',
+    11: 'UNSTKERR  - BusFault on unstacking for return from exception',
+    12: 'STKERR    - BusFault on stacking for exception entry',
+    13: 'LSPERR    - BusFault during FP lazy state preservation',
+    15: 'BFARVALID - BFAR holds a valid address',
+    # UsageFault (bits 16-31)
+    16: 'UNDEFINSTR - Undefined instruction',
+    17: 'INVSTATE  - Invalid state (e.g. executing ARM instruction in Thumb mode)',
+    18: 'INVPC     - Invalid PC load',
+    19: 'NOCP      - No coprocessor',
+    20: 'STKOF     - Stack overflow (ARMv8-M)',
+    24: 'UNALIGNED - Unaligned access',
+    25: 'DIVBYZERO - Divide by zero',
+}
+
+HFSR_BITS = {
+    1:  'VECTTBL - BusFault on vector table read',
+    30: 'FORCED  - Forced HardFault (escalated from configurable fault)',
+    31: 'DEBUGEVT - Debug event triggered HardFault',
+}
+
+# ChibiOS thread state names (tstate_t values from chschd.h)
+CHIBI_THREAD_STATES = {
+    0:  'READY',
+    1:  'CURRENT',
+    2:  'WTSTART',
+    3:  'SUSPENDED',
+    4:  'QUEUED',
+    5:  'WTSEM',
+    6:  'WTMTX',
+    7:  'WTCOND',
+    8:  'SLEEPING',
+    9:  'WTEXIT',
+    10: 'WTOREVT',
+    11: 'WTANDEVT',
+    12: 'SNDMSGQ',
+    13: 'SNDMSG',
+    14: 'WTMSG',
+    15: 'FINAL',
+}
+
+# Cortex-M EXC_RETURN patterns loaded into LR by hardware on exception entry
+EXC_RETURN_PATTERNS = {
+    0xFFFFFFF1: 'Return to Handler mode, MSP, no FPU',
+    0xFFFFFFF9: 'Return to Thread mode, MSP, no FPU',
+    0xFFFFFFFD: 'Return to Thread mode, PSP, no FPU',
+    0xFFFFFFE1: 'Return to Handler mode, MSP, FPU active',
+    0xFFFFFFE9: 'Return to Thread mode, MSP, FPU active',
+    0xFFFFFFED: 'Return to Thread mode, PSP, FPU active',
+}
+
+
+def resolve_addr2line(elf_file, addr):
+    """Resolve an address to (function_name, source_location) via addr2line.
+
+    Strips the Thumb mode bit (bit 0) before lookup.
+    Returns (None, None) on failure or unresolvable address.
+    """
+    addr_clean = addr & ~1
+    if addr_clean > 0xF0000000:
+        return None, None
+    try:
+        result = subprocess.run(
+            ['arm-none-eabi-addr2line', '-e', elf_file, '-f', '-C', '-s',
+             f'{addr_clean:#010x}'],
+            capture_output=True, text=True, timeout=10,
+        )
+        lines = result.stdout.strip().splitlines()
+        if len(lines) >= 2:
+            func = lines[0].strip()
+            loc = lines[1].strip()
+            if func and func not in ('??', '??()'):
+                resolved_loc = loc if loc and loc not in ('??:0', '??:?') else None
+                return func, resolved_loc
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return None, None
+
+
+def find_thread_working_areas(elf_file):
+    """Locate ChibiOS thread working-area symbols in the ELF.
+
+    Returns a dict mapping symbol_name -> start_address (int), sorted by
+    address.  Includes static _thread_wa symbols and the ChibiOS main thread
+    (ch0.mainthread), whose stack lives between __main_thread_stack_base__ and
+    __main_thread_stack_end__.
+    """
+    result = {}
+    nm_syms = {}
+    try:
+        out = subprocess.run(
+            ['arm-none-eabi-nm', '--defined-only', elf_file],
+            capture_output=True, text=True, timeout=15,
+        )
+        for line in out.stdout.splitlines():
+            parts = line.split()
+            if len(parts) >= 3:
+                try:
+                    nm_syms[parts[2]] = int(parts[0], 16)
+                except ValueError:
+                    pass
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+    for name, addr in nm_syms.items():
+        if '_thread_wa' in name:
+            result[name] = addr
+
+    # The ArduPilot/ChibiOS main thread is not a _thread_wa static array;
+    # its thread_t is embedded in ch0.mainthread and its stack occupies the
+    # __main_thread_stack_base__ region.  Use None as the wa_addr sentinel so
+    # the caller knows to use a GDB expression rather than a dump-region lookup.
+    if 'ch0' in nm_syms and '__main_thread_stack_base__' in nm_syms:
+        result['ch0.mainthread'] = nm_syms['__main_thread_stack_base__']
+
+    return dict(sorted(result.items(), key=lambda kv: kv[1]))
+
+
+def find_crashdebug():
+    """Locate the CrashDebug binary."""
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+    base = os.path.join(script_dir, '..', '..', 'modules', 'CrashDebug', 'bins')
+
+    if sys.platform.startswith('linux'):
+        path = os.path.join(base, 'lin64', 'CrashDebug')
+    elif sys.platform == 'darwin':
+        path = os.path.join(base, 'osx64', 'CrashDebug')
+    elif sys.platform == 'win32':
+        path = os.path.join(base, 'win32', 'CrashDebug.exe')
+    else:
+        return None
+
+    path = os.path.normpath(path)
+    if os.path.isfile(path):
+        return path
+    return None
+
+
+def validate_crashdump(path):
+    """Read and validate the crash dump header, return parsed info."""
+    with open(path, 'rb') as f:
+        data = f.read()
+
+    if len(data) < 4:
+        print(f"Error: crash dump too small ({len(data)} bytes)", file=sys.stderr)
+        sys.exit(1)
+
+    if data[0:2] != CRASHDUMP_SIG:
+        print(f"Error: invalid crash dump signature (got 0x{data[0]:02x} 0x{data[1]:02x}, "
+              f"expected 0x63 0x43)", file=sys.stderr)
+        sys.exit(1)
+
+    version_major = data[2]
+    version_minor = data[3]
+
+    if len(data) < 8:
+        print("Error: crash dump truncated", file=sys.stderr)
+        sys.exit(1)
+
+    flags = struct.unpack_from('<I', data, 4)[0]
+    has_fpu = bool(flags & 1)
+
+    # parse integer registers
+    int_reg_count = 20 if version_major >= 3 else 18
+    reg_offset = 8
+    needed = reg_offset + int_reg_count * 4
+    if len(data) < needed:
+        print(f"Error: crash dump truncated (need {needed} bytes for registers, "
+              f"have {len(data)})", file=sys.stderr)
+        sys.exit(1)
+
+    int_regs = {}
+    for i in range(int_reg_count):
+        val = struct.unpack_from('<I', data, reg_offset + i * 4)[0]
+        if i < len(INT_REG_NAMES):
+            int_regs[INT_REG_NAMES[i]] = val
+
+    offset = reg_offset + int_reg_count * 4
+
+    # parse FP registers if present
+    fp_regs = {}
+    if has_fpu:
+        fp_needed = offset + 33 * 4
+        if len(data) >= fp_needed:
+            for i in range(33):
+                val = struct.unpack_from('<I', data, offset + i * 4)[0]
+                fp_regs[FP_REG_NAMES[i]] = val
+            offset += 33 * 4
+
+    # parse memory regions
+    regions = []
+    while offset + 8 <= len(data):
+        start_addr = struct.unpack_from('<I', data, offset)[0]
+        end_addr = struct.unpack_from('<I', data, offset + 4)[0]
+        if start_addr == 0xFFFFFFFF:
+            break
+        if start_addr == 0xACCE55ED:
+            regions.append(('STACK_OVERFLOW_SENTINEL', 0, 0))
+            break
+        size = end_addr - start_addr
+        offset += 8
+        if offset + size > len(data):
+            regions.append((start_addr, end_addr, min(size, len(data) - offset)))
+            break
+        regions.append((start_addr, end_addr, size))
+        offset += size
+
+    return {
+        'version': (version_major, version_minor),
+        'flags': flags,
+        'has_fpu': has_fpu,
+        'int_regs': int_regs,
+        'fp_regs': fp_regs,
+        'regions': regions,
+        'size': len(data),
+    }
+
+
+def decode_fault_type(xpsr):
+    """Decode the exception number from xPSR."""
+    exception_num = xpsr & 0x1FF
+    fault_names = {
+        0: 'Thread mode (no exception)',
+        2: 'NMI',
+        3: 'HardFault',
+        4: 'MemManage',
+        5: 'BusFault',
+        6: 'UsageFault',
+        11: 'SVCall',
+        12: 'Debug Monitor',
+        14: 'PendSV',
+        15: 'SysTick',
+    }
+    if exception_num in fault_names:
+        return fault_names[exception_num]
+    if exception_num >= 16:
+        return f'IRQ{exception_num - 16} (External Interrupt)'
+    return f'Reserved (exception #{exception_num})'
+
+
+def build_gdb_script(int_regs):
+    """Build the GDB commands for extracting crash information."""
+    commands = []
+    commands.append('set pagination off')
+    commands.append('set print pretty on')
+    commands.append('set print array on')
+    commands.append('set print demangle on')
+    commands.append('set width 0')
+
+    # register dump
+    commands.append('echo ===GDB_REGISTERS_START===\\n')
+    commands.append('info registers')
+    commands.append('echo ===GDB_REGISTERS_END===\\n')
+
+    # resolve address-bearing registers to symbols
+    # use "info symbol" for symbol+offset and "info line" for source location
+    commands.append('echo ===GDB_SYMBOLS_START===\\n')
+    for reg_name in ['PC', 'LR', 'R0', 'R1', 'R2', 'R3', 'R4', 'R5',
+                     'R6', 'R7', 'R8', 'R9', 'R10', 'R11', 'R12']:
+        addr = int_regs.get(reg_name)
+        if addr is None:
+            continue
+        # EXC_RETURN values in LR are not code addresses; skip symbol lookup
+        if reg_name == 'LR' and addr in EXC_RETURN_PATTERNS:
+            continue
+        commands.append(f'echo {reg_name}_SYM=\\n')
+        commands.append(f'info symbol {addr:#010x}')
+        if reg_name in ('PC', 'LR'):
+            commands.append(f'echo {reg_name}_LINE=\\n')
+            commands.append(f'info line *{addr:#010x}')
+    commands.append('echo ===GDB_SYMBOLS_END===\\n')
+
+    # backtrace of current thread
+    commands.append('echo ===GDB_BACKTRACE_START===\\n')
+    commands.append('bt full')
+    commands.append('echo ===GDB_BACKTRACE_END===\\n')
+
+    # thread info
+    commands.append('echo ===GDB_THREADS_START===\\n')
+    commands.append('info threads')
+    commands.append('echo ===GDB_THREADS_END===\\n')
+
+    # backtrace of all threads
+    commands.append('echo ===GDB_THREAD_BACKTRACE_START===\\n')
+    commands.append('thread apply all bt full')
+    commands.append('echo ===GDB_THREAD_BACKTRACE_END===\\n')
+
+    # stack dump around SP
+    commands.append('echo ===GDB_STACK_START===\\n')
+    commands.append('x/32xw $sp')
+    commands.append('echo ===GDB_STACK_END===\\n')
+
+    # Fault status registers last: reading unmapped peripheral addresses can
+    # abort the GDB script, so all critical sections must run before this.
+    commands.append('echo ===GDB_FAULT_REGS_START===\\n')
+    for name, addr in FAULT_REGS.items():
+        commands.append(f'echo {name}=\\n')
+        commands.append(f'x/1xw {addr:#010x}')
+    commands.append('echo ===GDB_FAULT_REGS_END===\\n')
+
+    commands.append('quit')
+    return '\n'.join(commands)
+
+
+def _build_chibi_thread_gdb_script(thread_t_addr, sym_name):
+    """Build a minimal GDB script to get info and bt for one ChibiOS thread.
+
+    Each thread runs in its own GDB session so a GDB internal error on one
+    thread cannot prevent the others from being processed.
+
+    thread_t_addr may be an int (for static _thread_wa threads) or None, in
+    which case the GDB expression '&ch0.mainthread' is used.
+    """
+    if thread_t_addr is None:
+        tp_expr = '(thread_t *)(&ch0.mainthread)'
+    else:
+        tp_expr = f'(thread_t *){thread_t_addr:#010x}'
+    cmds = [
+        'set pagination off',
+        'set print frame-arguments none',
+        'set width 0',
+        'echo CHIBI_THREAD_START\\n',
+        f'set $tp = {tp_expr}',
+        'printf "CHIBI_THREAD_ADDR=0x%08x\\n", (unsigned int)$tp',
+        f'echo CHIBI_THREAD_WA={sym_name}\\n',
+        # Verify name pointer is in flash/RAM range to avoid dereferencing fill
+        'if ($tp->name >= 0x08000000 && $tp->name < 0x40000000)',
+        'printf "CHIBI_THREAD_NAME=%s\\n", $tp->name',
+        'else',
+        'echo CHIBI_THREAD_NAME=\\n',
+        'end',
+        'printf "CHIBI_THREAD_STATE=%d\\n", (int)$tp->state',
+        'printf "CHIBI_THREAD_PRIO=%d\\n", (int)$tp->hdr.pqueue.prio',
+        'printf "CHIBI_THREAD_WABASE=0x%08x\\n", (unsigned int)$tp->wabase',
+        'printf "CHIBI_THREAD_CTX_SP=0x%08x\\n", (unsigned int)$tp->ctx.sp',
+        'echo CHIBI_THREAD_BT_START\\n',
+        'if ((int)$tp->state != 1)',
+        # ctx.sp must point into RAM; fill pattern (0x55555555) or uninitialised
+        # values would cause GDB to abort on dereference.
+        'if ($tp->ctx.sp >= 0x20000000 && $tp->ctx.sp < 0x40000000)',
+        'set $ictx = $tp->ctx.sp',
+        'set $r4  = $ictx->r4',
+        'set $r5  = $ictx->r5',
+        'set $r6  = $ictx->r6',
+        'set $r7  = $ictx->r7',
+        'set $r8  = $ictx->r8',
+        'set $r9  = $ictx->r9',
+        'set $r10 = $ictx->r10',
+        'set $r11 = $ictx->r11',
+        'set $pc  = (unsigned int)$ictx->lr',
+        'set $sp  = (unsigned int)($ictx + 1)',
+        'bt',
+        'else',
+        'echo (ctx.sp not in valid RAM range - stack not captured)\\n',
+        'end',
+        'end',
+        'echo CHIBI_THREAD_BT_END\\n',
+        'echo CHIBI_THREAD_END\\n',
+        'quit',
+    ]
+    return '\n'.join(cmds)
+
+
+def run_gdb_chibi_threads(elf_file, dump_file, crashdebug_exe, thread_areas):
+    """Run a separate GDB session per ChibiOS thread and collect results.
+
+    Returns a concatenated string in the same format as the inline CHIBI
+    section so parse_chibi_threads() can consume it unchanged.
+    """
+    combined = '===GDB_CHIBI_THREADS_START===\n'
+
+    for sym_name, (wa_addr, thread_t_addr) in thread_areas.items():
+        script = _build_chibi_thread_gdb_script(thread_t_addr, sym_name)
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.gdb', delete=False) as f:
+            f.write(script)
+            script_path = f.name
+
+        try:
+            target_cmd = (f'target remote | {crashdebug_exe} '
+                          f'--elf {elf_file} --dump {dump_file}')
+            cmd = [
+                'arm-none-eabi-gdb', '-nx', '--batch', '--quiet', elf_file,
+                '-ex', 'set target-charset ASCII',
+                '-ex', target_cmd,
+                '-x', script_path,
+            ]
+            result = subprocess.run(
+                cmd, capture_output=True, text=True,
+                encoding='utf-8', errors='replace', timeout=30,
+            )
+            out = result.stdout
+            start = out.find('CHIBI_THREAD_START')
+            end = out.find('CHIBI_THREAD_END')
+            if start >= 0 and end >= 0:
+                combined += out[start:end + len('CHIBI_THREAD_END')] + '\n'
+            elif start >= 0:
+                # GDB crashed before CHIBI_THREAD_END - close it out
+                combined += out[start:] + '\nCHIBI_THREAD_END\n'
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            combined += f'CHIBI_THREAD_START\nCHIBI_THREAD_WA={sym_name}\n'
+            combined += 'CHIBI_THREAD_NAME=\nCHIBI_THREAD_STATE=-1\n'
+            combined += 'CHIBI_THREAD_BT_START\n(GDB timed out or not found)\n'
+            combined += 'CHIBI_THREAD_BT_END\nCHIBI_THREAD_END\n'
+        finally:
+            os.unlink(script_path)
+
+    combined += '===GDB_CHIBI_THREADS_END===\n'
+    return combined
+
+
+def run_gdb(elf_file, dump_file, crashdebug_exe, int_regs):
+    """Run GDB in batch mode and capture output."""
+    script = build_gdb_script(int_regs)
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.gdb', delete=False) as f:
+        f.write(script)
+        script_path = f.name
+
+    try:
+        target_cmd = (f'target remote | {crashdebug_exe} '
+                      f'--elf {elf_file} --dump {dump_file}')
+        cmd = [
+            'arm-none-eabi-gdb',
+            '-nx',
+            '--batch',
+            '--quiet',
+            elf_file,
+            '-ex', 'set target-charset ASCII',
+            '-ex', target_cmd,
+            '-x', script_path,
+        ]
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding='utf-8',
+            errors='replace',
+            timeout=120,
+        )
+        return result.stdout, result.stderr, result.returncode
+    except FileNotFoundError:
+        print("Error: arm-none-eabi-gdb not found. Is the ARM toolchain installed?",
+              file=sys.stderr)
+        sys.exit(1)
+    except subprocess.TimeoutExpired:
+        print("Error: GDB timed out after 120 seconds", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        os.unlink(script_path)
+
+
+def extract_section(output, start_marker, end_marker, allow_partial=False):
+    """Extract text between markers from GDB output.
+
+    If allow_partial is True and the end marker is absent (e.g. GDB crashed
+    before writing it), return whatever follows the start marker.
+    """
+    start = output.find(start_marker)
+    if start == -1:
+        return None
+    end = output.find(end_marker, start)
+    if end == -1:
+        if allow_partial:
+            return output[start + len(start_marker):].strip()
+        return None
+    return output[start + len(start_marker):end].strip()
+
+
+def parse_gdb_fault_regs(section):
+    """Parse fault register values from GDB output."""
+    if section is None:
+        return {}
+    regs = {}
+    current_name = None
+    for line in section.splitlines():
+        line = line.strip()
+        if line.endswith('='):
+            current_name = line[:-1]
+        elif current_name and ':' in line:
+            # line like "0xe000ed28:   0x00000000"
+            parts = line.split()
+            if len(parts) >= 2:
+                try:
+                    regs[current_name] = int(parts[1], 16)
+                except ValueError:
+                    pass
+            current_name = None
+    return regs
+
+
+def parse_gdb_symbols(section):
+    """Parse symbol resolution results from GDB output.
+
+    Returns a dict mapping register names to dicts with keys:
+        'symbol': e.g. "AP_InertialSensor::update() + 124"
+        'line':   e.g. "Line 456 of \"AP_InertialSensor.cpp\" ..."  (PC/LR only)
+    """
+    if section is None:
+        return {}
+    results = {}
+    current_key = None
+    current_field = None  # 'symbol' or 'line'
+    for line in section.splitlines():
+        line = line.strip()
+        if line.endswith('_SYM='):
+            reg_name = line[:-5]
+            current_key = reg_name
+            current_field = 'symbol'
+            results.setdefault(reg_name, {})
+        elif line.endswith('_LINE='):
+            reg_name = line[:-6]
+            current_key = reg_name
+            current_field = 'line'
+            results.setdefault(reg_name, {})
+        elif current_key and current_field:
+            # GDB outputs "No symbol matches ..." for unknown addresses
+            if 'No symbol' in line or 'No line' in line:
+                current_field = None
+                continue
+            results[current_key][current_field] = line
+            current_field = None
+    return results
+
+
+def parse_chibi_threads(section):
+    """Parse ChibiOS thread info from the GDB registry-walk output.
+
+    Returns a list of dicts, each with keys:
+        CHIBI_THREAD_ADDR, CHIBI_THREAD_NAME, CHIBI_THREAD_STATE,
+        CHIBI_THREAD_PRIO, CHIBI_THREAD_WABASE, CHIBI_THREAD_CTX_SP,
+        'bt' (list of backtrace lines)
+    """
+    if not section:
+        return []
+
+    threads = []
+    current = None
+    in_bt = False
+    bt_lines = []
+
+    for line in section.splitlines():
+        line = line.rstrip()
+        stripped = line.strip()
+        if stripped == 'CHIBI_THREAD_START':
+            current = {}
+            in_bt = False
+            bt_lines = []
+        elif stripped == 'CHIBI_THREAD_END':
+            if current is not None:
+                current['bt'] = bt_lines
+                threads.append(current)
+                current = None
+                bt_lines = []
+        elif stripped == 'CHIBI_THREAD_BT_START':
+            in_bt = True
+        elif stripped == 'CHIBI_THREAD_BT_END':
+            in_bt = False
+        elif in_bt:
+            # Collect backtrace; skip blank and GDB error lines
+            if stripped and not stripped.startswith('Cannot access') \
+                    and not stripped.startswith('warning:'):
+                bt_lines.append(stripped)
+        elif current is not None and '=' in stripped and not in_bt:
+            key, _, val = stripped.partition('=')
+            if key.startswith('CHIBI_THREAD_'):
+                current[key] = val
+    return threads
+
+
+def format_reg_with_symbol(name, value, symbols):
+    """Format a register value with its symbolic name if available."""
+    sym_info = symbols.get(name, {})
+    sym = sym_info.get('symbol', '')
+    line = sym_info.get('line', '')
+
+    result = f'{name:>3}: {value:#010x}'
+    if sym:
+        # "info symbol" output looks like:
+        #   "func_name + offset in section .text of /path/to/elf"
+        # trim the " in section .text of /path" part for readability
+        display = sym
+        in_section = display.find(' in section ')
+        if in_section != -1:
+            display = display[:in_section]
+        result += f'  <{display}>'
+    if line:
+        # "info line" output looks like:
+        #   "Line 123 of \"file.cpp\" starts at address 0x... and ends at 0x..."
+        # extract just the "Line N of "file.cpp"" part
+        ends_at = line.find(' starts at address')
+        if ends_at != -1:
+            display = line[:ends_at]
+        else:
+            display = line
+        # clean up escaped quotes from GDB
+        display = display.replace('\\"', '"')
+        result += f'\n{"":>18}{display}'
+    return result
+
+
+def decode_cfsr(val):
+    """Decode CFSR register bits."""
+    lines = []
+    for bit, desc in sorted(CFSR_BITS.items()):
+        if val & (1 << bit):
+            lines.append(f'    bit {bit:2d}: {desc}')
+    return lines
+
+
+def decode_hfsr(val):
+    """Decode HFSR register bits."""
+    lines = []
+    for bit, desc in sorted(HFSR_BITS.items()):
+        if val & (1 << bit):
+            lines.append(f'    bit {bit:2d}: {desc}')
+    return lines
+
+
+def print_report(dump_info, gdb_stdout, gdb_stderr, elf_file=None, chibi_stdout=None):
+    """Print the formatted crash dump report."""
+    print('=' * 72)
+    print('ArduPilot Crash Dump Report')
+    print('=' * 72)
+
+    # dump file info
+    ver = dump_info['version']
+    print(f'\nDump format version: {ver[0]}.{ver[1]}')
+    print(f'Dump size: {dump_info["size"]} bytes')
+    print(f'FPU state saved: {"yes" if dump_info["has_fpu"] else "no"}')
+
+    # fault type from xPSR
+    int_regs = dump_info['int_regs']
+    if 'exceptionPSR' in int_regs:
+        fault_type = decode_fault_type(int_regs['exceptionPSR'])
+        exc_num = int_regs['exceptionPSR'] & 0x1FF
+        print(f'Exception type: {fault_type} (exception #{exc_num})')
+    elif 'xPSR' in int_regs:
+        fault_type = decode_fault_type(int_regs['xPSR'])
+        exc_num = int_regs['xPSR'] & 0x1FF
+        print(f'Exception type: {fault_type} (exception #{exc_num})')
+
+    # check for stack overflow sentinel
+    for region in dump_info['regions']:
+        if region[0] == 'STACK_OVERFLOW_SENTINEL':
+            print('\n*** WARNING: CrashCatcher stack overflow detected! ***')
+            print('*** The crash dump itself may be corrupt. ***')
+
+    # resolve register addresses to symbols
+    sym_section = extract_section(
+        gdb_stdout, '===GDB_SYMBOLS_START===', '===GDB_SYMBOLS_END===')
+    symbols = parse_gdb_symbols(sym_section)
+
+    # registers from dump with symbolic names
+    print(f'\n{"Registers":=^72}')
+    print(f'  {format_reg_with_symbol("PC", int_regs.get("PC", 0), symbols)}')
+    print(f'  {format_reg_with_symbol("LR", int_regs.get("LR", 0), symbols)}')
+    lr_addr = int_regs.get('LR', 0)
+    lr_indent = ' ' * 20
+    if lr_addr in EXC_RETURN_PATTERNS:
+        print(f'{lr_indent}EXC_RETURN: {EXC_RETURN_PATTERNS[lr_addr]}')
+    elif not symbols.get('LR', {}).get('symbol') and elf_file:
+        func, loc = resolve_addr2line(elf_file, lr_addr)
+        if func:
+            loc_str = f' at {loc}' if loc else ''
+            print(f'{lr_indent}(in function: {func}{loc_str})')
+    print(f'  SP:  {int_regs.get("SP", 0):#010x}    '
+          f'MSP: {int_regs.get("MSP", 0):#010x}    '
+          f'PSP: {int_regs.get("PSP", 0):#010x}')
+    # print R0-R12: those with symbols get their own line,
+    # the rest are grouped compactly
+    printed = set()
+    for i in range(13):
+        name = f'R{i}'
+        if symbols.get(name, {}).get('symbol'):
+            print(f'  {format_reg_with_symbol(name, int_regs.get(name, 0), symbols)}')
+            printed.add(i)
+    # print remaining in groups of 4
+    non_sym = [i for i in range(13) if i not in printed]
+    for start in range(0, len(non_sym), 4):
+        group = non_sym[start:start + 4]
+        parts = [f'R{i:>2}: {int_regs.get(f"R{i}", 0):#010x}' for i in group]
+        print(f'  {"    ".join(parts)}')
+    print(f'  xPSR: {int_regs.get("xPSR", 0):#010x}    '
+          f'exceptionPSR: {int_regs.get("exceptionPSR", 0):#010x}')
+
+    # fault status registers (from GDB/memory)
+    fault_regs_section = extract_section(
+        gdb_stdout, '===GDB_FAULT_REGS_START===', '===GDB_FAULT_REGS_END===')
+    fault_regs = parse_gdb_fault_regs(fault_regs_section)
+
+    if fault_regs:
+        print(f'\n{"Fault Status Registers":=^72}')
+        for name in ['CFSR', 'HFSR', 'DFSR', 'MMFAR', 'BFAR', 'AFSR', 'ICSR']:
+            if name in fault_regs:
+                print(f'  {name:6s}: {fault_regs[name]:#010x}')
+                if name == 'CFSR' and fault_regs[name]:
+                    for line in decode_cfsr(fault_regs[name]):
+                        print(line)
+                elif name == 'HFSR' and fault_regs[name]:
+                    for line in decode_hfsr(fault_regs[name]):
+                        print(line)
+    else:
+        print(f'\n{"Fault Status Registers":=^72}')
+        print('  (not available in crash dump - SCB registers were not captured)')
+
+    # backtrace from GDB
+    bt_section = extract_section(
+        gdb_stdout, '===GDB_BACKTRACE_START===', '===GDB_BACKTRACE_END===')
+    print(f'\n{"Backtrace":=^72}')
+    if bt_section:
+        print(bt_section)
+    else:
+        print('  (GDB backtrace not available)')
+
+    # threads from GDB
+    threads_section = extract_section(
+        gdb_stdout, '===GDB_THREADS_START===', '===GDB_THREADS_END===')
+    if threads_section:
+        print(f'\n{"Threads":=^72}')
+        print(threads_section)
+
+    # backtrace of all threads
+    thread_bt_section = extract_section(
+        gdb_stdout, '===GDB_THREAD_BACKTRACE_START===', '===GDB_THREAD_BACKTRACE_END===')
+    if thread_bt_section:
+        print(f'\n{"Backtrace (all threads)":=^72}')
+        print(thread_bt_section)
+
+    # GDB register view (may contain symbolic names)
+    regs_section = extract_section(
+        gdb_stdout, '===GDB_REGISTERS_START===', '===GDB_REGISTERS_END===')
+    if regs_section:
+        print(f'\n{"Registers (GDB view)":=^72}')
+        print(regs_section)
+
+    # stack dump
+    stack_section = extract_section(
+        gdb_stdout, '===GDB_STACK_START===', '===GDB_STACK_END===')
+    if stack_section:
+        print(f'\n{"Stack Dump (32 words from SP)":=^72}')
+        print(stack_section)
+
+    # ChibiOS thread registry
+    # ChibiOS thread data comes from per-thread GDB sessions (chibi_stdout),
+    # not from the main GDB run.
+    chibi_section = extract_section(
+        chibi_stdout or '', '===GDB_CHIBI_THREADS_START===',
+        '===GDB_CHIBI_THREADS_END===', allow_partial=True)
+    chibi_threads = parse_chibi_threads(chibi_section)
+    if chibi_threads:
+        print(f'\n{"ChibiOS Threads":=^72}')
+        for t in chibi_threads:
+            addr = t.get('CHIBI_THREAD_ADDR', '?')
+            wa_sym = t.get('CHIBI_THREAD_WA', '')
+            raw_name = t.get('CHIBI_THREAD_NAME', '')
+            # Keep only ASCII printable chars (32-126); filters out both
+            # non-printable bytes and UTF-8 replacement chars (U+FFFD) that
+            # arise when the name pointer points to arbitrary memory.
+            name = ''.join(c for c in raw_name if 32 <= ord(c) <= 126)[:32]
+            try:
+                state_num = int(t.get('CHIBI_THREAD_STATE', '-1'))
+            except ValueError:
+                state_num = -1
+            state_str = CHIBI_THREAD_STATES.get(state_num, f'state {state_num}')
+            prio = t.get('CHIBI_THREAD_PRIO', '?')
+            wabase = t.get('CHIBI_THREAD_WABASE', '?')
+            ctx_sp = t.get('CHIBI_THREAD_CTX_SP', '?')
+
+            name_display = f'"{name}"' if name else '(unnamed)'
+            wa_display = f'  [{wa_sym}]' if wa_sym else ''
+            print(f'\n  Thread {addr}{wa_display}  {name_display}  prio={prio}  [{state_str}]')
+            print(f'    wabase={wabase}  ctx.sp={ctx_sp}', end='')
+
+            # detect stack overflow (ctx.sp < wabase)
+            try:
+                if int(ctx_sp, 16) < int(wabase, 16):
+                    print('  *** STACK OVERFLOW ***', end='')
+            except ValueError:
+                pass
+            print()
+
+            bt = t.get('bt', [])
+            if state_num == 1:  # CH_STATE_CURRENT
+                print('    (thread was active at crash; registers shown above)')
+            elif bt:
+                print('    Backtrace:')
+                for btline in bt:
+                    print(f'      {btline}')
+            else:
+                print('    (no backtrace available)')
+
+    # memory regions summary
+    print(f'\n{"Memory Regions in Dump":=^72}')
+    total_mem = 0
+    for region in dump_info['regions']:
+        if region[0] == 'STACK_OVERFLOW_SENTINEL':
+            print('  [STACK OVERFLOW SENTINEL]')
+            continue
+        start, end, size = region
+        total_mem += size
+        print(f'  {start:#010x} - {end:#010x}  ({size:>7d} bytes)')
+    print(f'  Total memory captured: {total_mem} bytes')
+
+    # FP registers if present
+    if dump_info['fp_regs']:
+        print(f'\n{"Floating Point Registers":=^72}')
+        fp = dump_info['fp_regs']
+        # detect ChibiOS stack fill pattern (lazy FPU stacking)
+        fill_pattern = 0x55555555
+        s_regs = [fp.get(f'S{i}', 0) for i in range(32)]
+        fill_count = sum(1 for v in s_regs if v == fill_pattern)
+        if fill_count > 24:
+            print('  FP registers contain ChibiOS stack fill pattern (0x55555555)')
+            print('  This indicates lazy FPU context save - the faulting code was')
+            print('  not using floating point, so the FP register slots on the')
+            print('  stack were never written by hardware.')
+            non_fill = {f'S{i}': v for i, v in enumerate(s_regs) if v != fill_pattern}
+            if non_fill:
+                print('  Non-fill registers:')
+                for name, raw in non_fill.items():
+                    fval = struct.unpack('<f', struct.pack('<I', raw))[0]
+                    print(f'    {name}: {raw:#010x} ({fval:.6g})')
+        else:
+            for i in range(0, 32, 4):
+                parts = []
+                for j in range(4):
+                    name = f'S{i+j}'
+                    if name in fp:
+                        raw = fp[name]
+                        fval = struct.unpack('<f', struct.pack('<I', raw))[0]
+                        parts.append(f'{name:>3}: {raw:#010x} ({fval:>12.6g})')
+                print(f'  {"  ".join(parts)}')
+        if 'FPSCR' in fp:
+            print(f'  FPSCR: {fp["FPSCR"]:#010x}')
+
+    # any GDB errors worth noting
+    if gdb_stderr:
+        # filter out common noise
+        errors = []
+        for line in gdb_stderr.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            # skip common harmless warnings
+            if 'warning: No executable has been specified' in line:
+                continue
+            if 'Try "help target"' in line:
+                continue
+            errors.append(line)
+        if errors:
+            print(f'\n{"GDB Warnings/Errors":=^72}')
+            for line in errors:
+                print(f'  {line}')
+
+    print(f'\n{"=" * 72}')
+    print('Note: crash dumps contain only a subset of RAM at the time of')
+    print('the fault. Some memory reads and backtraces may be incomplete.')
+    print(f'{"=" * 72}')
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Generate a non-interactive crash dump report for ArduPilot',
+    )
+    parser.add_argument('elf_file', help='ELF file matching the firmware that crashed')
+    parser.add_argument('dump_file', help='crash_dump.bin file')
+    parser.add_argument('--gdb', default='arm-none-eabi-gdb',
+                        help='path to arm-none-eabi-gdb (default: from PATH)')
+    parser.add_argument('--crashdebug', default=None,
+                        help='path to CrashDebug binary (default: auto-detect)')
+
+    args = parser.parse_args()
+
+    if not os.path.isfile(args.elf_file):
+        print(f"Error: ELF file not found: {args.elf_file}", file=sys.stderr)
+        sys.exit(1)
+
+    if not os.path.isfile(args.dump_file):
+        print(f"Error: crash dump file not found: {args.dump_file}", file=sys.stderr)
+        sys.exit(1)
+
+    crashdebug = args.crashdebug or find_crashdebug()
+    if crashdebug is None or not os.path.isfile(crashdebug):
+        print("Error: CrashDebug binary not found. Ensure modules/CrashDebug "
+              "is checked out.", file=sys.stderr)
+        sys.exit(1)
+
+    # validate and parse the dump file directly
+    dump_info = validate_crashdump(args.dump_file)
+
+    thread_was = find_thread_working_areas(args.elf_file)
+
+    # In ChibiOS, thread_t lives at the TOP (high address) of the working
+    # area, not at the base.  The dump captures the used stack as one region
+    # starting at wa_addr, with the thread_t struct immediately above it as a
+    # separate small region.  Identify thread_t_addr as the end address of the
+    # large stack region that begins at wa_addr.
+    region_end = {r[0]: r[1] for r in dump_info['regions'] if isinstance(r[0], int)}
+    thread_areas = {}
+    for sym, wa in thread_was.items():
+        if sym == 'ch0.mainthread':
+            # Main thread: thread_t is ch0.mainthread (embedded in ch_os_instance,
+            # not at the top of a _thread_wa array).  Use the sentinel None so
+            # run_gdb_chibi_threads uses a GDB expression instead of a number.
+            thread_areas[sym] = (wa, None)
+        else:
+            thread_areas[sym] = (wa, region_end.get(wa, wa))
+
+    # run GDB for symbolic information (main crash context)
+    gdb_stdout, gdb_stderr, gdb_rc = run_gdb(
+        args.elf_file, args.dump_file, crashdebug, dump_info['int_regs'])
+
+    # run per-thread GDB sessions for ChibiOS thread backtraces; each thread
+    # runs in its own session so a GDB internal error on one thread does not
+    # prevent the others from being processed.
+    chibi_stdout = run_gdb_chibi_threads(
+        args.elf_file, args.dump_file, crashdebug, thread_areas)
+
+    print_report(dump_info, gdb_stdout, gdb_stderr, elf_file=args.elf_file,
+                 chibi_stdout=chibi_stdout)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### Summary

Tool to generate an extensive crash report from a corefile and `-g`-enhanced binary

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

This adds a tool to try to dump as much information out of a "CrashDump" log as can be extracted.

It is *entirely* AI-generated.   I wouldn't look closely at the code if I were you.  I know I haven't.

```
  Crash context
  - Dump format version, size, FPU state
  - Exception type decoded from xPSR (HardFault, MemManage, BusFault, UsageFault, IRQ number, etc.)
  - All CPU registers (R0–R12, SP, LR, PC, xPSR, MSP, PSP) with symbolic names and source locations where GDB can resolve them
  - LR annotation: detects Cortex-M EXC_RETURN values (0xFFFFFFF9 etc.) and explains them, or falls back to addr2line if GDB's info symbol can't resolve it
  - Fault status registers (CFSR, HFSR, DFSR, MMFAR, BFAR, AFSR, ICSR) with bit-level decode of CFSR and HFSR, when captured
  - GDB backtrace of the faulting thread with local variables
  - Raw stack dump (32 words from SP)
  - Stack overflow sentinel warning if CrashCatcher detected one

  ChibiOS thread backtraces
  - Enumerates all static _thread_wa threads plus the ArduPilot main thread (ch0.mainthread) — typically 8 threads total
  - For each thread: address, working-area symbol, name, priority, state (SLEEPING/WTOREVT/CURRENT/etc.), wabase, ctx.sp, and a GDB backtrace reconstructed from the saved ChibiOS context
  switch frame
  - Flags stack overflow if ctx.sp < wabase
  - Each thread runs in its own GDB subprocess so a GDB internal error on one thread doesn't prevent the others

  FP registers
  - All 32 S-registers and FPSCR, with float values
  - Recognises the ChibiOS lazy-FPU fill pattern (0x55555555) and explains it rather than printing meaningless floats

  Memory regions summary
  - Lists every captured region with address range and size, plus total bytes captured
```

Most notably walks the chibios thread structures so you can see what everyone was up to.  Means that for the bug fixed by  https://github.com/ArduPilot/ardupilot/pull/31955 you can see that the main thread was doing exactly as theorised (ordinarily gdb will just show that you're in the monitor thread, it triggering a hardfault after 1.9s or whatever)

Example output:
```
pbarker@crun:~/rc/ardupilot-claude(pr-claude/gdb-crash-dump-tool)$ Tools/debug/crash_dump_report.py ~/rc/ardupilot/build/Callisto-2.5/bin/arducopter /tmp/bob.bin 
========================================================================
ArduPilot Crash Dump Report
========================================================================

Dump format version: 3.0
Dump size: 43891 bytes
FPU state saved: yes
Exception type: MemManage (exception #4)

===============================Registers================================
   PC: 0xe000fffe
   LR: 0x0815fa3f  <ChibiOS::Scheduler::_monitor_thread(void*) + 319>
                  Line 475 of "../../libraries/AP_HAL_ChibiOS/Scheduler.cpp"
  SP:  0x3001c3c8    MSP: 0x30000600    PSP: 0x3001c360
   R0: 0x3002067c  <ch0 + 60>
   R1: 0x3000dbd0  <utilInstance>
   R5: 0x300168a8  <schedulerInstance>
   R7: 0x3000d9cc  <hal_chibios>
   R9: 0x0815ede9  <AP_HAL::GPIO::timer_tick() + 1>
  R10: 0x0815ef71  <ChibiOS::Scheduler::in_expected_delay() const + 1>
  R11: 0x3000c6ac  <AP_Logger::_singleton>
  R 2: 0x00000000    R 3: 0xe000ffff    R 4: 0x0000073b    R 6: 0x00000085
  R 8: 0x00000001    R12: 0x00000000
  xPSR: 0x21000000    exceptionPSR: 0x20000004

=========================Fault Status Registers=========================
  (not available in crash dump - SCB registers were not captured)

===============================Backtrace================================
#0  0xe000fffe in ?? ()
No symbol table info available.
#1  0x0815fa3e in ChibiOS::Scheduler::_monitor_thread (arg=0x300168a8 <schedulerInstance>) at ../../libraries/AP_HAL_ChibiOS/Scheduler.cpp:470
        ptr = 0xe000ffff
        gptr = 0xe000ffff
        now = <optimized out>
        loop_delay = 1851
        sched = 0x300168a8 <schedulerInstance>
        using_watchdog = true
        log_wd_counter = <optimized out>
#2  0x08020f1e in __port_thread_start ()
No symbol table info available.
Backtrace stopped: previous frame identical to this frame (corrupt stack?)

================================Threads=================================
Id   Target Id         Frame 
* 1    Thread <main>     0xe000fffe in ?? ()

========================Backtrace (all threads)=========================
Thread 1 (Thread <main>):
#0  0xe000fffe in ?? ()
No symbol table info available.
#1  0x0815fa3e in ChibiOS::Scheduler::_monitor_thread (arg=0x300168a8 <schedulerInstance>) at ../../libraries/AP_HAL_ChibiOS/Scheduler.cpp:470
        ptr = 0xe000ffff
        gptr = 0xe000ffff
        now = <optimized out>
        loop_delay = 1851
        sched = 0x300168a8 <schedulerInstance>
        using_watchdog = true
        log_wd_counter = <optimized out>
#2  0x08020f1e in __port_thread_start ()
No symbol table info available.
Backtrace stopped: previous frame identical to this frame (corrupt stack?)

==========================Registers (GDB view)==========================
r0             0x3002067c          805439100
r1             0x3000dbd0          805362640
r2             0x0                 0
r3             0xe000ffff          -536805377
r4             0x73b               1851
r5             0x300168a8          805398696
r6             0x85                133
r7             0x3000d9cc          805362124
r8             0x1                 1
r9             0x815ede9           135654889
r10            0x815ef71           135655281
r11            0x3000c6ac          805357228
r12            0x0                 0
sp             0x3001c3c8          0x3001c3c8 <_monitor_thread_wa+1360>
lr             0x815fa3f           135658047
pc             0xe000fffe          0xe000fffe
xpsr           0x21000000          553648128
fpscr          0x0                 0
msp            0x30000600          805307904
psp            0x3001c360          805421920

=====================Stack Dump (32 words from SP)======================
0x3001c3c8 <_monitor_thread_wa+1360>:	0x55555555	0x3000dbd0	0x755895a3	0x002176c2
0x3001c3d8 <_monitor_thread_wa+1376>:	0x3b000000	0x30000007	0x00008000	0x0000000d
0x3001c3e8 <_monitor_thread_wa+1392>:	0x00000000	0xaaf80000	0x0d210079	0x55550004
0x3001c3f8 <_monitor_thread_wa+1408>:	0x55555555	0x55555555	0x55555555	0x0815f901
0x3001c408 <_monitor_thread_wa+1424>:	0x300168a8	0x55555555	0x55555555	0x55555555
0x3001c418 <_monitor_thread_wa+1440>:	0x55555555	0x55555555	0x55555555	0x08020f1f
0x3001c428 <_monitor_thread_wa+1456>:	0x30020640	0x30020640	0x000000b7	0x3001c31c
0x3001c438 <_monitor_thread_wa+1472>:	0x3001dbf8	0x3003a8d0	0x30020640	0x081b9bd0

============================ChibiOS Threads=============================

  Thread 0x3002067c  [ch0.mainthread]  "%u bs2=%u"  prio=180  [SUSPENDED]
    wabase=0x30000600  ctx.sp=0x30001edc
    Backtrace:
      #0  chSchGoSleepTimeoutS (newstate=..., timeout=...) at ../../modules/ChibiOS/os/rt/src/chschd.c:377
      #1  0x0817520a in chThdSuspendTimeoutS (trp=..., timeout=...) at ../../modules/ChibiOS/os/rt/src/chthreads.c:782
      #2  0x081710ac in osalThreadSuspendS (trp=...) at ../../modules/ChibiOS/os/hal/osal/rt-nil/osal.h:801
      #3  sdc_lld_wait_transaction_end (sdcp=..., n=..., resp=...) at ../../modules/ChibiOS/os/hal/ports/STM32/LLD/SDMMCv2/hal_sdc_lld.c:267
      #4  0x08171534 in sdc_lld_read_aligned (sdcp=..., startblk=..., buf=..., blocks=...) at ../../modules/ChibiOS/os/hal/ports/STM32/LLD/SDMMCv2/hal_sdc_lld.c:758
      #5  0x081717f0 in sdc_lld_read (sdcp=..., startblk=..., buf=..., blocks=...) at ../../modules/ChibiOS/os/hal/ports/STM32/LLD/SDMMCv2/hal_sdc_lld.c:867
      #6  0x081736f0 in sdcRead (n=..., buf=..., startblk=..., sdcp=...) at ../../modules/ChibiOS/os/hal/src/hal_sdc.c:830
      #7  sdcRead (sdcp=..., startblk=..., buf=..., n=...) at ../../modules/ChibiOS/os/hal/src/hal_sdc.c:816
      #8  0x08175628 in disk_read (pdrv=..., buff=..., sector=..., count=...) at ../../modules/ChibiOS/os/various/fatfs_bindings/fatfs_diskio.c:108
      #9  0x0816c9ac in f_read (fp=..., buff=..., btr=..., br=...) at ../../modules/ChibiOS/ext/fatfs/source/ff.c:3924
      #10 0x080d184a in AP_Filesystem_FATFS::read (this=..., fd=..., buf=..., count=...) at ../../libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp:424
      #11 0x0809e704 in AP_Logger_File::get_log_data (this=..., list_entry=..., page=..., offset=..., len=..., data=...) at ../../libraries/AP_Logger/AP_Logger_File.cpp:676
      #12 0x0814d412 in AP_Logger::handle_log_send_data (this=...) at ../../libraries/AP_Logger/AP_Logger_MAVLinkLogTransfer.cpp:303
      #13 0x0814d536 in AP_Logger::handle_log_sending (this=...) at ../../libraries/AP_Logger/AP_Logger_MAVLinkLogTransfer.cpp:236
      #14 0x0814d58c in AP_Logger::handle_log_send (this=...) at ../../libraries/AP_Logger/AP_Logger_MAVLinkLogTransfer.cpp:205
      #15 0x080a93e0 in GCS_MAVLINK::update_send (this=...) at ../../libraries/GCS_MAVLink/GCS_Common.cpp:1445
      #16 0x080a9510 in GCS::update_send (this=...) at ../../libraries/GCS_MAVLink/GCS_Common.cpp:2477
      #17 0x08097b8c in Functor<void>::operator() (this=...) at ../../libraries/AP_HAL/utility/functor.h:52
      #18 AP_Scheduler::run (this=..., time_available=...) at ../../libraries/AP_Scheduler/AP_Scheduler.cpp:261
      #19 0x080981ea in AP_Scheduler::loop (this=...) at ../../libraries/AP_Scheduler/AP_Scheduler.cpp:389
      #20 0x0809a286 in AP_Vehicle::loop (this=...) at ../../libraries/AP_Vehicle/AP_Vehicle.cpp:457
      #21 0x08105014 in main_loop () at ../../libraries/AP_HAL_ChibiOS/HAL_ChibiOS_Class.cpp:297
      #22 HAL_ChibiOS::run (this=..., argc=..., argv=..., callbacks=...) at ../../libraries/AP_HAL_ChibiOS/HAL_ChibiOS_Class.cpp:350
      #23 0x080248a0 in main (argc=..., argv=...) at ../../ArduCopter/Copter.cpp:843

  Thread 0x3001be38  [_io_thread_wa]  "io"  prio=58  [SLEEPING]
    wabase=0x3001b488  ctx.sp=0x3001bd84
    Backtrace:
      #0  chSchGoSleepTimeoutS (newstate=..., timeout=...) at ../../modules/ChibiOS/os/rt/include/chvt.h:252
      #1  0x081751f0 in chThdSleepS (ticks=...) at ../../modules/ChibiOS/os/rt/include/chthreads.h:451
      #2  chThdSleep (time=...) at ../../modules/ChibiOS/os/rt/src/chthreads.c:660
      #3  0x0815f7f0 in ChibiOS::Scheduler::delay_microseconds (this=..., usec=...) at ../../libraries/AP_HAL_ChibiOS/Scheduler.cpp:165
      #4  ChibiOS::Scheduler::delay_microseconds (this=..., usec=...) at ../../libraries/AP_HAL_ChibiOS/Scheduler.cpp:153
      #5  ChibiOS::Scheduler::_io_thread (arg=...) at ../../libraries/AP_HAL_ChibiOS/Scheduler.cpp:558
      #6  0x08020f1e in __port_thread_start ()
      Backtrace stopped: previous frame identical to this frame (corrupt stack?)

  Thread 0x3001c428  [_monitor_thread_wa]  "5LLY5PANIC: scheduler::set_syste"  prio=183  [CURRENT]
    wabase=0x3001be78  ctx.sp=0x3001c31c
    (thread was active at crash; registers shown above)

  Thread 0x3001ca18  [_rcin_thread_wa]  (unnamed)  prio=177  [SLEEPING]
    wabase=0x3001c468  ctx.sp=0x3001c974
    Backtrace:
      #0  chSchGoSleepTimeoutS (newstate=..., timeout=...) at ../../modules/ChibiOS/os/rt/include/chvt.h:252
      #1  0x081751f0 in chThdSleepS (ticks=...) at ../../modules/ChibiOS/os/rt/include/chthreads.h:451
      #2  chThdSleep (time=...) at ../../modules/ChibiOS/os/rt/src/chthreads.c:660
      #3  0x0815f16e in ChibiOS::Scheduler::delay_microseconds (this=..., usec=...) at ../../libraries/AP_HAL_ChibiOS/Scheduler.cpp:165
      #4  ChibiOS::Scheduler::delay_microseconds (this=..., usec=...) at ../../libraries/AP_HAL_ChibiOS/Scheduler.cpp:153
      #5  ChibiOS::Scheduler::_rcin_thread (arg=...) at ../../libraries/AP_HAL_ChibiOS/Scheduler.cpp:518
      #6  0x08020f1e in __port_thread_start ()
      Backtrace stopped: previous frame identical to this frame (corrupt stack?)

  Thread 0x3001ce08  [_rcout_thread_wa]  (unnamed)  prio=181  [WTOREVT]
    wabase=0x3001ca58  ctx.sp=0x3001cd5c
    Backtrace:
      #0  chEvtWaitOne (events=...) at ../../modules/ChibiOS/os/rt/src/chevents.c:441
      #1  0x0815d42c in ChibiOS::RCOutput::rcout_thread (this=...) at ../../libraries/AP_HAL_ChibiOS/RCOutput.cpp:241
      #2  0x08020f1e in __port_thread_start ()
      Backtrace stopped: previous frame identical to this frame (corrupt stack?)

  Thread 0x3001d3f8  [_storage_thread_wa]  (unnamed)  prio=59  [SLEEPING]
    wabase=0x3001ce48  ctx.sp=0x3001d344
    Backtrace:
      #0  chSchGoSleepTimeoutS (newstate=..., timeout=...) at ../../modules/ChibiOS/os/rt/include/chvt.h:252
      #1  0x081751f0 in chThdSleepS (ticks=...) at ../../modules/ChibiOS/os/rt/include/chthreads.h:451
      #2  chThdSleep (time=...) at ../../modules/ChibiOS/os/rt/src/chthreads.c:660
      #3  0x0815f600 in ChibiOS::Scheduler::delay_microseconds (this=..., usec=...) at ../../libraries/AP_HAL_ChibiOS/Scheduler.cpp:165
      #4  ChibiOS::Scheduler::delay_microseconds (this=..., usec=...) at ../../libraries/AP_HAL_ChibiOS/Scheduler.cpp:153
      #5  ChibiOS::Scheduler::_storage_thread (arg=...) at ../../libraries/AP_HAL_ChibiOS/Scheduler.cpp:628
      #6  0x08020f1e in __port_thread_start ()
      Backtrace stopped: previous frame identical to this frame (corrupt stack?)

  Thread 0x3001dbe8  [_timer_thread_wa]  "0"  prio=181  [SLEEPING]
    wabase=0x3001d438  ctx.sp=0x3001db44
    Backtrace:
      #0  chSchGoSleepTimeoutS (newstate=..., timeout=...) at ../../modules/ChibiOS/os/rt/include/chvt.h:252
      #1  0x081751f0 in chThdSleepS (ticks=...) at ../../modules/ChibiOS/os/rt/include/chthreads.h:451
      #2  chThdSleep (time=...) at ../../modules/ChibiOS/os/rt/src/chthreads.c:660
      #3  0x0815f2c8 in ChibiOS::Scheduler::delay_microseconds (this=..., usec=...) at ../../libraries/AP_HAL_ChibiOS/Scheduler.cpp:165
      #4  ChibiOS::Scheduler::delay_microseconds (this=..., usec=...) at ../../libraries/AP_HAL_ChibiOS/Scheduler.cpp:153
      #5  ChibiOS::Scheduler::_timer_thread (arg=...) at ../../libraries/AP_HAL_ChibiOS/Scheduler.cpp:349
      #6  0x08020f1e in __port_thread_start ()
      Backtrace stopped: previous frame identical to this frame (corrupt stack?)

  Thread 0x300208b0  [ch_c0_idle_thread_wa]  "$"  prio=1  [READY]
    wabase=0x300206c0  ctx.sp=0x300207e4
    Backtrace:
      #0  0x08020f2a in __port_exit_from_isr ()
      #1  0x0815fa3e in ChibiOS::Scheduler::_monitor_thread (arg=...) at ../../libraries/AP_HAL_ChibiOS/Scheduler.cpp:470
      #2  0x3f800000 in ?? ()
      Backtrace stopped: previous frame identical to this frame (corrupt stack?)

=========================Memory Regions in Dump=========================
  0x3001beb4 - 0x3001dfc8  (   8468 bytes)
  0x300208f0 - 0x300208fc  (     12 bytes)
  0x3002067c - 0x300206b8  (     60 bytes)
  0x30000600 - 0x30002200  (   7168 bytes)
  0x300208b0 - 0x300208ec  (     60 bytes)
  0x300206c0 - 0x300208b0  (    496 bytes)
  0x3003b9c8 - 0x3003ba04  (     60 bytes)
  0x3003b518 - 0x3003b9c8  (   1200 bytes)
  0x3000dca4 - 0x3000dcb1  (     13 bytes)
  0x3003a8c0 - 0x3003a8fc  (     60 bytes)
  0x3003a5d0 - 0x3003a8c0  (    752 bytes)
  0x3001c428 - 0x3001c464  (     60 bytes)
  0x3001be78 - 0x3001c428  (   1456 bytes)
  0x3001dbe8 - 0x3001dc24  (     60 bytes)
  0x3001d438 - 0x3001dbe8  (   1968 bytes)
  0x3001ce08 - 0x3001ce44  (     60 bytes)
  0x3001ca58 - 0x3001ce08  (    944 bytes)
  0x3001ca18 - 0x3001ca54  (     60 bytes)
  0x3001c468 - 0x3001ca18  (   1456 bytes)
  0x3001be38 - 0x3001be74  (     60 bytes)
  0x3001b488 - 0x3001be38  (   2480 bytes)
  0x3001d3f8 - 0x3001d434  (     60 bytes)
  0x3001ce48 - 0x3001d3f8  (   1456 bytes)
  0x3000dddc - 0x3000dde9  (     13 bytes)
  0x300376f0 - 0x3003772c  (     60 bytes)
  0x30037400 - 0x300376f0  (    752 bytes)
  0x3000df14 - 0x3000df21  (     13 bytes)
  0x30038238 - 0x30038274  (     60 bytes)
  0x30037f48 - 0x30038238  (    752 bytes)
  0x3000e04c - 0x3000e059  (     13 bytes)
  0x300399e8 - 0x30039a24  (     60 bytes)
  0x300396f8 - 0x300399e8  (    752 bytes)
  0x3000e184 - 0x3000e191  (     13 bytes)
  0x3003a128 - 0x3003a164  (     60 bytes)
  0x30039e38 - 0x3003a128  (    752 bytes)
  0x3000e2bc - 0x3000e2c9  (     13 bytes)
  0x30035ec0 - 0x30035efc  (     60 bytes)
  0x30035bd0 - 0x30035ec0  (    752 bytes)
  0x3000e52c - 0x3000e539  (     13 bytes)
  0x30034f78 - 0x30034fb4  (     60 bytes)
  0x30034c88 - 0x30034f78  (    752 bytes)
  0x30016d7c - 0x30016d89  (     13 bytes)
  0x30034178 - 0x300341b4  (     60 bytes)
  0x30033e88 - 0x30034178  (    752 bytes)
  0x3002a058 - 0x3002a094  (     60 bytes)
  0x30029aa8 - 0x3002a058  (   1456 bytes)
  0x30027740 - 0x3002774d  (     13 bytes)
  0x30027d00 - 0x30027d3c  (     60 bytes)
  0x30027750 - 0x30027d00  (   1456 bytes)
  0x30029568 - 0x300295a4  (     60 bytes)
  0x30028d88 - 0x30029568  (   2016 bytes)
  0x30026410 - 0x3002644c  (     60 bytes)
  0x30026160 - 0x30026410  (    688 bytes)
  0x30026938 - 0x30026945  (     13 bytes)
  0x30026ef8 - 0x30026f34  (     60 bytes)
  0x30026948 - 0x30026ef8  (   1456 bytes)
  0x30026ff8 - 0x30027005  (     13 bytes)
  0x30031810 - 0x3003184c  (     60 bytes)
  0x30031260 - 0x30031810  (   1456 bytes)
  0xe000ed28 - 0xe000ed3c  (     20 bytes)
  Total memory captured: 43191 bytes

========================Floating Point Registers========================
  FP registers contain ChibiOS stack fill pattern (0x55555555)
  This indicates lazy FPU context save - the faulting code was
  not using floating point, so the FP register slots on the
  stack were never written by hardware.
  Non-fill registers:
    S9: 0x08178635 (4.55977e-34)
    S10: 0x00000000 (0)
  FPSCR: 0x00000000

==========================GDB Warnings/Errors===========================
  warning: Overlapping regions in memory map: ignoring
  /tmp/tmp3h3f8rq8.gdb:69: Error in sourced command file:
  Cannot access memory at address 0xe000ed3c

========================================================================
Note: crash dumps contain only a subset of RAM at the time of
the fault. Some memory reads and backtraces may be incomplete.
========================================================================
pbarker@crun:~/rc/ardupilot-claude(pr-claude/gdb-crash-dump-tool)$ 
```


This work partly sponsored by FreeSpace Operations - thanks!


