### PR TITLE
GCS_MAVLink: compile support for MISSION_REQUEST out by default

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4718,11 +4718,19 @@ void GCS_MAVLINK::handle_common_mission_message(const mavlink_message_t &msg)
         handle_mission_request_int(msg);
         break;
 
-#if AP_MAVLINK_MSG_MISSION_REQUEST_ENABLED
     case MAVLINK_MSG_ID_MISSION_REQUEST:
+#if AP_MAVLINK_MSG_MISSION_REQUEST_ENABLED
         handle_mission_request(msg);
-        break;
+#else
+        // this is temporary code which is slated to be removed in
+        // ArduPilot-4.10:
+        static bool mission_request_warning_sent;
+        if (!mission_request_warning_sent) {
+            mission_request_warning_sent = true;
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "got MISSION_REQUEST; use MISSION_REQUEST_INT!");
+        }
 #endif
+        break;
 
 #if AP_MAVLINK_MISSION_SET_CURRENT_ENABLED
     case MAVLINK_MSG_ID_MISSION_SET_CURRENT:    // MAV ID: 41

--- a/libraries/GCS_MAVLink/GCS_config.h
+++ b/libraries/GCS_MAVLink/GCS_config.h
@@ -106,12 +106,12 @@
 // sending warnings to the GCS in Sep 2022 if MISSION_REQUEST was used.
 // Copter 4.4.0 sends this warning.
 // CODE_REMOVAL
-// ArduPilot 4.4 sends warnings if MISSION_ITEM used
-// ArduPilot 4.8 stops compiling in MISSION_ITEM but still sends warnings
-// ArduPilot 4.9 removes the code but sends message about MISSION_ITEM not supported
+// ArduPilot 4.4 sends warnings if MISSION_REQUEST used
+// ArduPilot 4.8 stops compiling in MISSION_REQUEST but still sends warnings
+// ArduPilot 4.9 removes the code but sends message about MISSION_REQUEST not supported
 // ArduPilot 4.10 stops sending the warning
 #ifndef AP_MAVLINK_MSG_MISSION_REQUEST_ENABLED
-#define AP_MAVLINK_MSG_MISSION_REQUEST_ENABLED AP_MISSION_ENABLED
+#define AP_MAVLINK_MSG_MISSION_REQUEST_ENABLED 0
 #endif
 
 // RANGEFINDER is a subset of the DISTANCE_SENSOR message which we


### PR DESCRIPTION
### Summary

Compiles support for handling of MISSION_REQUEST out by default

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

I tested sending this message in by hand and the new message does come out.

```
Board,plane
MatekF405-Wing,-336
```

### Description

Subset https://github.com/ArduPilot/ardupilot/pull/33091

also correct the message name in the deprecation instructions

had to add a little bit of code in there to maintain the instructions (which said we would warn)

This message has been deprecated since forever, `MISSION_REQUEST_INT` has been the way to do this since forever.

The message handling can be re-enabled in a custom build or via the custom build server - but it will still spit out a warning.
