### PR TITLE
GCS_MAVLink: remove code for sending HWSTATUS message

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -754,9 +754,6 @@ protected:
 
     // message sending functions:
     bool try_send_mission_message(enum ap_message id);
-#if AP_MAVLINK_MSG_HWSTATUS_ENABLED
-    void send_hwstatus();
-#endif  // AP_MAVLINK_MSG_HWSTATUS_ENABLED
     void handle_data_packet(const mavlink_message_t &msg);
 
     // these two methods are called after current_loc is updated:

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1100,9 +1100,6 @@ ap_message GCS_MAVLINK::mavlink_id_to_ap_message_id(const uint32_t mavlink_id) c
 #endif  // AP_AHRS_ENABLED
         { MAVLINK_MSG_ID_VFR_HUD,               MSG_VFR_HUD},
 #endif
-#if AP_MAVLINK_MSG_HWSTATUS_ENABLED
-        { MAVLINK_MSG_ID_HWSTATUS,              MSG_HWSTATUS},
-#endif  // AP_MAVLINK_MSG_HWSTATUS_ENABLED
 #if AP_MAVLINK_MSG_WIND_ENABLED
         { MAVLINK_MSG_ID_WIND,                  MSG_WIND},
 #endif  // AP_MAVLINK_MSG_WIND_ENABLED
@@ -5968,16 +5965,6 @@ bool GCS_MAVLINK::try_send_mission_message(const enum ap_message id)
     return true;
 }
 
-#if AP_MAVLINK_MSG_HWSTATUS_ENABLED
-void GCS_MAVLINK::send_hwstatus()
-{
-    mavlink_msg_hwstatus_send(
-        chan,
-        hal.analogin->board_voltage()*1000,
-        0);
-}
-#endif  // AP_MAVLINK_MSG_HWSTATUS_ENABLED
-
 #if AP_RPM_ENABLED
 void GCS_MAVLINK::send_rpm() const
 {
@@ -6628,13 +6615,6 @@ bool GCS_MAVLINK::try_send_message(const enum ap_message id)
         last_heartbeat_time = AP_HAL::millis();
         send_heartbeat();
         break;
-
-#if AP_MAVLINK_MSG_HWSTATUS_ENABLED
-    case MSG_HWSTATUS:
-        CHECK_PAYLOAD_SIZE(HWSTATUS);
-        send_hwstatus();
-        break;
-#endif  // AP_MAVLINK_MSG_HWSTATUS_ENABLED
 
 #if AP_AHRS_ENABLED
     case MSG_LOCATION:

--- a/libraries/GCS_MAVLink/GCS_config.h
+++ b/libraries/GCS_MAVLink/GCS_config.h
@@ -135,13 +135,6 @@
 #define AP_MAVLINK_MSG_HIGHRES_IMU_ENABLED (HAL_PROGRAM_SIZE_LIMIT_KB > 1024) && AP_INERTIALSENSOR_ENABLED
 #endif
 
-// ArduPilot 4.4 stopped sending this message by default
-// ArduPilot 4.7 stops compiling support into the firmware
-// ArduPilot 4.8 removes the code
-#ifndef AP_MAVLINK_MSG_HWSTATUS_ENABLED
-#define AP_MAVLINK_MSG_HWSTATUS_ENABLED 0
-#endif
-
 #ifndef AP_MAVLINK_MAV_CMD_SET_HAGL_ENABLED
 #define AP_MAVLINK_MAV_CMD_SET_HAGL_ENABLED (HAL_PROGRAM_SIZE_LIMIT_KB > 1024)
 #endif

--- a/libraries/GCS_MAVLink/ap_message.h
+++ b/libraries/GCS_MAVLink/ap_message.h
@@ -49,9 +49,7 @@ enum ap_message : uint8_t {
     MSG_FENCE_STATUS                   =  32,
     MSG_SIMSTATE                       =  33,
     MSG_SIM_STATE                      =  34,
-#if AP_MAVLINK_MSG_HWSTATUS_ENABLED
-    MSG_HWSTATUS                       =  35,
-#endif  // AP_MAVLINK_MSG_HWSTATUS_ENABLED
+    // MSG_HWSTATUS                       =  35,
     MSG_WIND                           =  36,
 #if AP_MAVLINK_MSG_RANGEFINDER_SENDING_ENABLED
     MSG_RANGEFINDER                    =  37,


### PR DESCRIPTION
### Summary

Removes code that allowed for sending HWSTATUS message

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board,plane
MatekF405-Wing,*
```

### Description

Removes code which can send this message - hasn't been send for years.
