### PR TITLE
AP_Filesystem: memset d_name before strncpy to clear stale tail bytes

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
@@ -248,7 +248,8 @@ struct dirent *AP_Filesystem_Sys::readdir(void *dirp)
     dtracker->curr_file.d_type = DT_REG;
 #endif
     size_t max_length = ARRAY_SIZE(dtracker->curr_file.d_name);
-    strncpy_noterm(dtracker->curr_file.d_name, sysfs_file_list[dtracker->file_offset].name, max_length);
+    memset(dtracker->curr_file.d_name, 0, max_length);
+    strncpy_noterm(dtracker->curr_file.d_name, sysfs_file_list[dtracker->file_offset].name, max_length-1);
     dtracker->file_offset++;
     return &dtracker->curr_file;
 }


### PR DESCRIPTION
strncpy_noterm writes up to max_length-1 bytes but does not zero the remainder of d_name. If a previous directory entry had a longer name, tail bytes of d_name contain stale characters that can appear as garbage in directory listings.

Zero the full d_name buffer with memset before copying, and reduce the strncpy limit to max_length-1 (leaving the NUL terminator intact) to ensure listings are always cleanly terminated regardless of entry length.

### Classification & Testing (check all that apply and add your own)

- [ x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

null-terminated string corner case. 

discovered while working on the rp2350 port and was asked to make it a separate PR.

