### PR TITLE
AP_RCProtocol: guard CRSF against early startup

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol.cpp
@@ -494,10 +494,18 @@ bool AP_RCProtocol::new_input()
     // if we have an extra UART from a SERIALn_PROTOCOL then check it for data
     check_added_uart();
 
-    // run update function on backends
-    for (uint8_t i = 0; i < ARRAY_SIZE(backend); i++) {
-        if (backend[i] != nullptr) {
-            backend[i]->update();
+    const uint32_t now = AP_HAL::millis();
+    const bool searching = should_search(now);
+    const bool pulse_protocol_active =
+        (_detected_protocol != AP_RCProtocol::NONE) && !_detected_with_bytes && !searching;
+
+    if (!pulse_protocol_active) {
+// Once a pulse-based protocol is actively providing input there is no value in polling the other backends here
+// detect_async_protocol() will only consider alternates again after should_search() says input has gone idle.
+        for (uint8_t i = 0; i < ARRAY_SIZE(backend); i++) {
+            if (backend[i] != nullptr) {
+                backend[i]->update();
+            }
         }
     }
 

--- a/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp
@@ -332,7 +332,13 @@ void AP_RCProtocol_CRSF::update(void)
 
 #if AP_RC_CHANNEL_ENABLED
     //Check if LQ is to be reported in place of RSSI
-    _use_lq_for_rssi = rc().option_is_enabled(RC_Channels::Option::USE_CRSF_LQ_AS_RSSI);
+// RC protocol update can run before RC_Channels singleton is created on fast boot paths.
+// Guard the option access to avoid transient early-startup dereferences while RC_Channels and vehicle state are still coming up.
+    if (hal.scheduler != nullptr &&
+        hal.scheduler->is_system_initialized() &&
+        RC_Channels::get_singleton() != nullptr) {
+        _use_lq_for_rssi = rc().option_is_enabled(RC_Channels::Option::USE_CRSF_LQ_AS_RSSI);
+    }
 #endif
 }
 
@@ -726,6 +732,12 @@ void AP_RCProtocol_CRSF::start_bind(void)
 bool AP_RCProtocol_CRSF::bind_in_progress(void)
 {
 #if !APM_BUILD_TYPE(APM_BUILD_UNKNOWN) && !APM_BUILD_TYPE(APM_BUILD_Replay)
+// On fast bring-up paths the RCIN thread can start polling protocols before vehicle setup has finished.
+// Avoid constructing the CRSF telemetry singleton from that early thread context
+    if (hal.scheduler == nullptr || !hal.scheduler->is_system_initialized()) {
+        return false;
+    }
+
     AP_CRSF_Telem* telem = AP::crsf_telem();
     if (telem != nullptr) {
         return telem->bind_in_progress();


### PR DESCRIPTION
### Summary

Stop CRSF touching RC_Channels and the CRSF telemetry singleton before the vehicle has finished starting.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Tested on hardware

### Description

On a fast boot the RCIN thread can start polling protocols before vehicle setup has finished. CRSF reached `rc()` and `AP::crsf_telem()` while RC_Channels and the telemetry singleton were still being constructed. Both accesses now wait for `hal.scheduler->is_system_initialized()`, and `bind_in_progress()` returns false rather than constructing the telemetry singleton from that early thread context.

Found on the RP2350 port (#32995), where the boot is fast enough to hit this reliably, but nothing in it is RP2350-specific.

**The backend polling change has been dropped from this PR.** An earlier version also gated the `backend[i]->update()` loop in `AP_RCProtocol::new_input()` behind a `pulse_protocol_active` test built from `_detected_with_bytes`. That flag is false for async-detected protocols too, not only pulse ones, so the gate stopped the only thing pumping the IOMCU, UDP and FDM backends once a protocol was detected - RC input stopped after the first frame. Review of the RP2350 branch caught it there, and `AP_RCProtocol.cpp` is untouched here as a result.
