### PR TITLE
AP_Scripting: never try and delay for more than 65535ms

### DIFF
--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -4998,6 +4998,16 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.context_pop()
         self.reboot_sitl()
 
+    def test_scripting_callback_time(self):
+        self.start_subtest("Scripting callback time")
+
+        self.context_collect('STATUSTEXT')
+        self.set_parameter("SCR_ENABLE", 1)
+        self.install_test_script_context("callback_time_test.lua")
+        self.reboot_sitl()
+
+        self.wait_statustext('Timing test passed', check_context=True, timeout=600)
+
     def Scripting(self):
         '''Scripting test'''
         self.test_scripting_set_home_to_vehicle_location()
@@ -5007,6 +5017,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.test_scripting_internal_test()
         self.test_scripting_auxfunc()
         self.test_scripting_serial_loopback()
+        self.test_scripting_callback_time()
 
     def test_mission_frame(self, frame, target_system=1, target_component=1):
         self.clear_mission(mavutil.mavlink.MAV_MISSION_TYPE_MISSION,

--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -577,9 +577,18 @@ int lua_scripts::run_engine(lua_State *L) {
 #endif // defined(AP_SCRIPTING_CHECKS) && AP_SCRIPTING_CHECKS >= 1
 
             // compute delay time
-            uint64_t now_ms = AP_HAL::millis64();
+            const uint64_t now_ms = AP_HAL::millis64();
             if (now_ms < scripts->next_run_ms) {
-                hal.scheduler->delay(scripts->next_run_ms - now_ms);
+                const uint32_t delay_ms = scripts->next_run_ms - now_ms;
+                if (delay_ms > UINT16_MAX) {
+                    // The delay method takes a uint16, so any longer delays must be done in sections (>65.535s)
+                    hal.scheduler->delay(UINT16_MAX);
+
+                    // Restart loop, this means delay is re-calculated to make up for any drift
+                    // This also means `should_run` is re-checked allowing a possible stop or restart
+                    continue;
+                }
+                hal.scheduler->delay(delay_ms);
             }
 
             if (option_is_set(AP_Scripting::DebugOption::RUNTIME_MSG)) {

--- a/libraries/AP_Scripting/tests/callback_time_test.lua
+++ b/libraries/AP_Scripting/tests/callback_time_test.lua
@@ -1,0 +1,37 @@
+-- Test call back times from 2^0 to 2^18 (0.001 to 262.144 seconds)
+local power = 0
+local end_power = 18
+
+-- The error must be less than the larger of the two thresholds
+-- This can be (alot) smaller if speedup is not used
+local absTheshold = 250
+local pctThreshold = 1
+
+local last_run_us
+
+local function update()
+  local now_us = micros()
+
+  local expectedDelay = (2^power) / 1000
+  local measuredDelay = (now_us - last_run_us):tofloat() / 1000000
+  local error_ms = (expectedDelay - measuredDelay) * 1000
+
+  print(string.format("Timing test want: %0.3f s, got: %0.3f s, error: %0.3f ms", expectedDelay, measuredDelay, error_ms))
+
+  local threshold = math.max(absTheshold, expectedDelay * 10 * pctThreshold)
+  if math.abs(error_ms) > threshold then
+    error(string.format("Large timeing error! (>%0.3fms)", threshold))
+  end
+
+  power = power + 1
+  if power > end_power then
+    print("Timing test passed")
+    return
+  end
+
+  last_run_us = micros()
+  return update, 2^power
+end
+
+last_run_us = micros()
+return update, 2^power


### PR DESCRIPTION
### Summary

The `hal.scheduler->delay` function takes a `uint16_t`. Scripting might want to delay for longer than that, the values is from the users `return x, y` call. The value will just wrap down, so trying to delay for 5 mins for example you will currently actually get a delay of 37 seconds.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->

I have added a test lua script and a auto test to run the script and check there is no error. Upsettingly the timing thresholds have to be quite relaxed to pass when SITL is run with speedup. The thesholds still easily catch this bug.