### PR TITLE
Tools: add mintty terminal support for Cygwin SITL

### DIFF
--- a/Tools/autotest/run_in_terminal_window.sh
+++ b/Tools/autotest/run_in_terminal_window.sh
@@ -47,6 +47,9 @@ elif [ -n "$STY" ]; then
 elif [ -n "$ZELLIJ" ]; then
   # Create a new pane to run
   zellij run -n "$name" -- "$1" "${@:2}"
+elif [ -n "$(which mintty 2>/dev/null)" ]; then
+  # Cygwin native terminal - no X11 fonts required
+  mintty --hold always -T "$name" -e "$@" &
 else
   filename="/tmp/$name.log"
   echo "RiTW: Window access not found, logging to $filename"


### PR DESCRIPTION
## What does this PR do?

Adds mintty as a fallback terminal emulator in run_in_terminal_window.sh,
placed between zellij and the log-to-file fallback.

On Cygwin, the existing fallback order requires xterm, which in turn needs
an X11 server and bitmap fonts (xfonts-base) to be installed. mintty is
the native Cygwin terminal emulator and works without X11, making SITL
terminal windows work out-of-the-box on Cygwin/Windows.

## Testing

Tested on Windows 11 with Cygwin64, running ArduPlane SITL:
  ./Tools/autotest/sim_vehicle.py -v ArduPlane --map --console

The ArduPlane terminal window now opens in mintty without requiring
an X server.

## AI Assistance

This contribution was developed with AI assistance (GitHub Copilot).
The human author reviewed and tested all changes.
