### PR TITLE
Move writing of compass log messages into compass library

### DIFF
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -1861,7 +1861,7 @@ Compass::read(void)
 #endif
 #if HAL_LOGGING_ENABLED
     if (any_healthy && _log_bit != (uint32_t)-1 && AP::logger().should_log(_log_bit)) {
-        AP::logger().Write_Compass();
+        Write_Compass();
     }
 #endif
 

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -195,6 +195,9 @@ public:
     // indicate which bit in LOG_BITMASK indicates we should log compass readings
     void set_log_bit(uint32_t log_bit) { _log_bit = log_bit; }
 
+    void Write_Compass(void);
+    void Write_Compass_instance(uint64_t time_us, uint8_t mag_instance);
+
     // check if the compasses are pointing in the same direction
     bool consistent() const;
 

--- a/libraries/AP_Compass/AP_Compass_Logging.cpp
+++ b/libraries/AP_Compass/AP_Compass_Logging.cpp
@@ -1,0 +1,43 @@
+#include <AP_Compass/AP_Compass_config.h>
+#include <AP_Logger/AP_Logger_config.h>
+
+#if AP_COMPASS_ENABLED && HAL_LOGGING_ENABLED
+
+#include "AP_Compass.h"
+
+#include <AP_Logger/AP_Logger.h>
+
+void Compass::Write_Compass_instance(const uint64_t time_us, const uint8_t mag_instance)
+{
+    const Vector3f &mag_field = get_field(mag_instance);
+    const Vector3f &mag_offsets = get_offsets(mag_instance);
+    const Vector3f &mag_motor_offsets = get_motor_offsets(mag_instance);
+    const struct log_MAG pkt{
+        LOG_PACKET_HEADER_INIT(LOG_MAG_MSG),
+        time_us         : time_us,
+        instance        : mag_instance,
+        mag_x           : (int16_t)mag_field.x,
+        mag_y           : (int16_t)mag_field.y,
+        mag_z           : (int16_t)mag_field.z,
+        offset_x        : (int16_t)mag_offsets.x,
+        offset_y        : (int16_t)mag_offsets.y,
+        offset_z        : (int16_t)mag_offsets.z,
+        motor_offset_x  : (int16_t)mag_motor_offsets.x,
+        motor_offset_y  : (int16_t)mag_motor_offsets.y,
+        motor_offset_z  : (int16_t)mag_motor_offsets.z,
+        health          : (uint8_t)healthy(mag_instance),
+        SUS             : last_update_usec(mag_instance)
+    };
+    AP::logger().WriteBlock(&pkt, sizeof(pkt));
+}
+
+// Write a Compass packet
+void Compass::Write_Compass()
+{
+    const uint64_t time_us = AP_HAL::micros64();
+    for (uint8_t i=0; i<get_count(); i++) {
+        Write_Compass_instance(time_us, i);
+    }
+}
+
+#endif  // AP_COMPASS_ENABLED && HAL_LOGGING_ENABLED

--- a/libraries/AP_Compass/LogStructure.h
+++ b/libraries/AP_Compass/LogStructure.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <AP_Logger/LogStructure.h>
+
+#define LOG_IDS_FROM_COMPASS \
+    LOG_MAG_MSG
+
+// @LoggerMessage: MAG
+// @Description: Information received from compasses
+// @Field: TimeUS: Time since system startup
+// @Field: I: compass instance number
+// @Field: MagX: magnetic field strength in body frame
+// @Field: MagY: magnetic field strength in body frame
+// @Field: MagZ: magnetic field strength in body frame
+// @Field: OfsX: magnetic field offset in body frame
+// @Field: OfsY: magnetic field offset in body frame
+// @Field: OfsZ: magnetic field offset in body frame
+// @Field: MOX: motor interference magnetic field in body frame
+// @Field: MOY: motor interference magnetic field in body frame
+// @Field: MOZ: motor interference magnetic field in body frame
+// @Field: Health: true if compass is considered healthy
+// @Field: S: time when the compass sample was taken
+struct PACKED log_MAG {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t  instance;
+    int16_t  mag_x;
+    int16_t  mag_y;
+    int16_t  mag_z;
+    int16_t  offset_x;
+    int16_t  offset_y;
+    int16_t  offset_z;
+    int16_t  motor_offset_x;
+    int16_t  motor_offset_y;
+    int16_t  motor_offset_z;
+    uint8_t  health;
+    uint32_t SUS;
+};
+
+#define LOG_STRUCTURE_FROM_COMPASS \
+    { LOG_MAG_MSG, sizeof(log_MAG), \
+      "MAG", "QBhhhhhhhhhBI",    "TimeUS,I,MagX,MagY,MagZ,OfsX,OfsY,OfsZ,MOX,MOY,MOZ,Health,S", "s#GGGGGGGGG-s", "F-CCCCCCCCC-F", true },

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -274,7 +274,6 @@ public:
     void Write_MessageChunk(uint8_t id, const char *messagechunk, uint8_t chunk_seq);
 
     void Write_MessageF(const char *fmt, ...);
-    void Write_Compass();
     void Write_Mode(uint8_t mode, const ModeReason reason);
 
     void Write_EntireMission();
@@ -479,8 +478,6 @@ private:
     bool fill_logstructure(struct LogStructure &logstruct, const uint8_t msg_type) const;
 
     bool _armed;
-
-    void Write_Compass_instance(uint64_t time_us, uint8_t mag_instance);
 
     void backend_starting_new_log(const AP_Logger_Backend *backend);
 

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -5,7 +5,6 @@
 #include <stdlib.h>
 
 #include <AP_AHRS/AP_AHRS.h>
-#include <AP_Compass/AP_Compass.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
 #include <AP_Param/AP_Param.h>
@@ -430,42 +429,6 @@ void AP_Logger::Write_Radio(const mavlink_radio_t &packet)
         fixed        : packet.fixed
     };
     WriteBlock(&pkt, sizeof(pkt));
-}
-
-void AP_Logger::Write_Compass_instance(const uint64_t time_us, const uint8_t mag_instance)
-{
-    const Compass &compass = AP::compass();
-
-    const Vector3f &mag_field = compass.get_field(mag_instance);
-    const Vector3f &mag_offsets = compass.get_offsets(mag_instance);
-    const Vector3f &mag_motor_offsets = compass.get_motor_offsets(mag_instance);
-    const struct log_MAG pkt{
-        LOG_PACKET_HEADER_INIT(LOG_MAG_MSG),
-        time_us         : time_us,
-        instance        : mag_instance,
-        mag_x           : (int16_t)mag_field.x,
-        mag_y           : (int16_t)mag_field.y,
-        mag_z           : (int16_t)mag_field.z,
-        offset_x        : (int16_t)mag_offsets.x,
-        offset_y        : (int16_t)mag_offsets.y,
-        offset_z        : (int16_t)mag_offsets.z,
-        motor_offset_x  : (int16_t)mag_motor_offsets.x,
-        motor_offset_y  : (int16_t)mag_motor_offsets.y,
-        motor_offset_z  : (int16_t)mag_motor_offsets.z,
-        health          : (uint8_t)compass.healthy(mag_instance),
-        SUS             : compass.last_update_usec(mag_instance)
-    };
-    WriteBlock(&pkt, sizeof(pkt));
-}
-
-// Write a Compass packet
-void AP_Logger::Write_Compass()
-{
-    const uint64_t time_us = AP_HAL::micros64();
-    const Compass &compass = AP::compass();
-    for (uint8_t i=0; i<compass.get_count(); i++) {
-        Write_Compass_instance(time_us, i);
-    }
 }
 
 // Write a mode packet.

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -137,6 +137,7 @@ const struct MultiplierStructure log_Multipliers[] = {
 #include <AP_Camera/LogStructure.h>
 #include <AP_Mount/LogStructure.h>
 #include <AP_Baro/LogStructure.h>
+#include <AP_Compass/LogStructure.h>
 #include <AP_CANManager/LogStructure.h>
 #include <AP_VisualOdom/LogStructure.h>
 #include <AC_PrecLand/LogStructure.h>
@@ -429,23 +430,6 @@ struct PACKED log_ADSB {
     uint16_t hor_velocity;
     int16_t ver_velocity;
     uint16_t squawk;
-};
-
-struct PACKED log_MAG {
-    LOG_PACKET_HEADER;
-    uint64_t time_us;
-    uint8_t  instance;
-    int16_t  mag_x;
-    int16_t  mag_y;
-    int16_t  mag_z;
-    int16_t  offset_x;
-    int16_t  offset_y;
-    int16_t  offset_z;
-    int16_t  motor_offset_x;
-    int16_t  motor_offset_y;
-    int16_t  motor_offset_z;
-    uint8_t  health;
-    uint32_t SUS;
 };
 
 struct PACKED log_Mode {
@@ -1224,8 +1208,7 @@ LOG_STRUCTURE_FROM_CAMERA \
 LOG_STRUCTURE_FROM_MOUNT \
     { LOG_ARSP_MSG, sizeof(log_ARSP), "ARSP",  "QBffcffBBffB", "TimeUS,I,Airspeed,DiffPress,Temp,RawPress,Offset,U,H,Hp,TR,Pri", "s#nPOPP-----", "F-00B00-----", true }, \
     LOG_STRUCTURE_FROM_BATTMONITOR \
-    { LOG_MAG_MSG, sizeof(log_MAG), \
-      "MAG", "QBhhhhhhhhhBI",    "TimeUS,I,MagX,MagY,MagZ,OfsX,OfsY,OfsZ,MOX,MOY,MOZ,Health,S", "s#GGGGGGGGG-s", "F-CCCCCCCCC-F", true }, \
+    LOG_STRUCTURE_FROM_COMPASS \
     { LOG_MODE_MSG, sizeof(log_Mode), \
       "MODE", "QMBB",         "TimeUS,Mode,ModeNum,Rsn", "s---", "F---" }, \
 LOG_RTC_MESSAGE \
@@ -1350,7 +1333,7 @@ enum LogMessages : uint8_t {
     LOG_PIDE_MSG,
     LOG_PIDW_MSG,
     LOG_IDS_FROM_LANDING,
-    LOG_MAG_MSG,
+    LOG_IDS_FROM_COMPASS,
     LOG_ARSP_MSG,
     LOG_IDS_FROM_RPM,
     LOG_RFND_MSG,


### PR DESCRIPTION
### Summary

Mirror structure used by baro already for logging

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request


Still get log messages in SITL:
```
1970-01-01 10:00:09.03: MAG {TimeUS : 9039716, I : 0, MagX : 224, MagY : 80, MagZ : -528, OfsX : 5, OfsY : 13, OfsZ : -18, MOX : 0, MOY : 0, MOZ : 0, Health : 1, S : 9039716}
1970-01-01 10:00:09.03: MAG {TimeUS : 9039716, I : 1, MagX : 224, MagY : 80, MagZ : -528, OfsX : 5, OfsY : 13, OfsZ : -18, MOX : 0, MOY : 0, MOZ : 0, Health : 1, S : 9039716}
1970-01-01 10:00:09.03: MAG {TimeUS : 9039716, I : 2, MagX : 224, MagY : 80, MagZ : -528, OfsX : 5, OfsY : 13, OfsZ : -18, MOX : 0, MOY : 0, MOZ : 0, Health : 1, S : 9039716}
```

```
Board,plane
MatekF405,-16
```

### Description

Moves the implementation from A to B - same pattern we use for the baro library.

Doing this to simplify a PR moving logging around.
