### PR TITLE
Copter: set AP_Proximity scheduler expected time to 200us

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -170,7 +170,7 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
     SCHED_TASK(read_rangefinder,      20,    100,  33),
 #endif
 #if HAL_PROXIMITY_ENABLED
-    SCHED_TASK_CLASS(AP_Proximity,         &copter.g2.proximity,        update,         200,  50,  36),
+    SCHED_TASK_CLASS(AP_Proximity,         &copter.g2.proximity,        update,         200, 200,  36),
 #endif
 #if AP_BEACON_ENABLED
     SCHED_TASK_CLASS(AP_Beacon,            &copter.g2.beacon,           update,         400,  50,  39),


### PR DESCRIPTION
### Summary

Increase Copter AP_Proximity scheduler expected time from 50us to 200us.
The current 50us expected time is too small for real hardware measurements.

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

Tested current master on CubeOrangePlus with a RPLIDAR A2:

[Before]
```AP_Proximity::update             MIN=  17 MAX= 132 AVG=  47 OVR=411 SLP=  0, TOT= 3.5%```

[After - This PR]
```AP_Proximity::update             MIN=  25 MAX= 144 AVG=  50 OVR=  0 SLP=  0, TOT= 3.7%```

Rover had a similar scheduler expected-time cleanup in 2018 here. #8063
This makes the Copter AP_Proximity scheduler entry use the same 200Hz, 200us setting as Rover.
https://github.com/ArduPilot/ardupilot/blob/master/Rover/Rover.cpp#L87

