### PR TITLE
Plane: remove unused delay_arming member from quadplane

### DIFF
--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -634,10 +634,6 @@ private:
     uint32_t takeoff_last_run_ms;
     float takeoff_start_alt_m;
 
-    // oneshot with duration ARMING_DELAY_MS used by quadplane to delay spoolup after arming:
-    // ignored unless OPTION_DELAY_ARMING or OPTION_TILT_DISARMED is set
-    bool delay_arming;
-
     // should we force use of fixed wing controller for attitude upset recovery?
     bool force_fw_control_recovery;
 


### PR DESCRIPTION
### Summary

Removes dead member

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

this was moved to AP_Arming_Plane
