### PR TITLE
  Rover: fix mode entry gate for safety switch engaged 

### DIFF
--- a/Rover/AP_Arming_Rover.cpp
+++ b/Rover/AP_Arming_Rover.cpp
@@ -126,8 +126,7 @@ bool AP_Arming_Rover::arm_checks(AP_Arming::Method method)
 
 void AP_Arming_Rover::update_soft_armed()
 {
-    hal.util->set_soft_armed(is_armed() &&
-                             hal.util->safety_switch_state() != AP_HAL::Util::SAFETY_DISARMED);
+    hal.util->set_soft_armed(is_armed());
 }
 
 /*

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -486,20 +486,20 @@ void Rover::one_second_loop(void)
     AP_Notify::flags.pre_arm_check = arming.pre_arm_checks(false);
     AP_Notify::flags.pre_arm_gps_check = true;
     AP_Notify::flags.armed = arming.is_armed();
-    AP_Notify::flags.flying = hal.util->get_soft_armed();
+    AP_Notify::flags.flying = arming.is_armed_and_safety_off();
 
 #if AP_ROVER_AUTO_ARM_ONCE_ENABLED
     handle_auto_arm_once();
 #endif  // AP_ROVER_AUTO_ARM_ONCE_ENABLED
 
     // attempt to update home position and baro calibration if not armed:
-    if (!hal.util->get_soft_armed()) {
+    if (!arming.is_armed_and_safety_off()) {
         update_home();
     }
 
     // need to set "likely flying" when armed to allow for compass
     // learning to run
-    set_likely_flying(hal.util->get_soft_armed());
+    set_likely_flying(arming.is_armed_and_safety_off());
 
     // send latest param values to wp_nav
     g2.wp_nav.set_turn_params(g2.turn_radius, g2.motors.have_skid_steering());

--- a/Rover/mode.cpp
+++ b/Rover/mode.cpp
@@ -21,7 +21,7 @@ void Mode::exit()
 
 bool Mode::enter()
 {
-    const bool ignore_checks = !rover.arming.is_armed_and_safety_off();   // allow switching to any mode if disarmed.  We rely on the arming check to perform
+    const bool ignore_checks = !rover.arming.is_armed();   // allow switching to any mode if disarmed.  We rely on the arming check to perform
     if (!ignore_checks) {
 
         // get EKF filter status

--- a/Rover/mode.cpp
+++ b/Rover/mode.cpp
@@ -21,7 +21,7 @@ void Mode::exit()
 
 bool Mode::enter()
 {
-    const bool ignore_checks = !hal.util->get_soft_armed();   // allow switching to any mode if disarmed.  We rely on the arming check to perform
+    const bool ignore_checks = !rover.arming.is_armed_and_safety_off();   // allow switching to any mode if disarmed.  We rely on the arming check to perform
     if (!ignore_checks) {
 
         // get EKF filter status

--- a/Rover/mode_auto.cpp
+++ b/Rover/mode_auto.cpp
@@ -47,7 +47,7 @@ void ModeAuto::update()
     // check if mission exists (due to being cleared while disarmed in AUTO,
     // if no mission, then stop...needs mode change out of AUTO, mission load,
     // and change back to AUTO to run a mission at this point
-    if (!hal.util->get_soft_armed() && !mission.present()) {
+    if (!rover.arming.is_armed_and_safety_off() && !mission.present()) {
         start_stop();
     }
     // start or update mission

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -7028,6 +7028,31 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.set_rc(3, 1500)
         self.disarm_vehicle()
 
+    def EnterModeOnSafetySwitch(self):
+        '''test mode enter behaviour when there's a safety switch involved'''
+        self.set_parameters({
+            "SIM_GPS1_ENABLE": 0,
+        })
+        self.reboot_sitl()
+        self.wait_mode('MANUAL')
+        self.wait_prearm_sys_status_healthy()
+        self.arm_vehicle()
+        self.run_cmd(
+            mavutil.mavlink.MAV_CMD_DO_SET_MODE,
+            p1=mavutil.mavlink.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,
+            p2=self.get_mode_from_mode_mapping('GUIDED'),
+            want_result=mavutil.mavlink.MAV_RESULT_FAILED,
+        )
+        self.set_safetyswitch_on()
+        self.run_cmd(
+            mavutil.mavlink.MAV_CMD_DO_SET_MODE,
+            p1=mavutil.mavlink.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,
+            p2=self.get_mode_from_mode_mapping('GUIDED'),
+            want_result=mavutil.mavlink.MAV_RESULT_FAILED,
+        )
+        self.set_safetyswitch_off()
+        self.disarm_vehicle()
+
     def GetMessageInterval(self):
         '''check that the two methods for requesting a MESSAGE_INTERVAL message are equivalent'''
         target_msg = mavutil.mavlink.MAVLINK_MSG_ID_HOME_POSITION
@@ -7364,6 +7389,7 @@ return update()
             self.REQUIRE_LOCATION_FOR_ARMING,
             self.GetMessageInterval,
             self.SafetySwitch,
+            self.EnterModeOnSafetySwitch,
             self.ThrottleFailsafe,
             self.DriveEachFrame,
             self.AP_ROVER_AUTO_ARM_ONCE_ENABLED,


### PR DESCRIPTION
### Summary

Stops modes being entered on Rover when they really shouldn't be

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested the original case in SITL.

### Description

Most of this change mirrors a change made in Plane in https://github.com/ArduPilot/ardupilot/pull/22899 (which probably also fixes the same bug in Rover, I haven't checked).

What this does fix (and the autotest fails before and passed afterwards) is that putting the safety switch into the "vehicle is safe" state allows you to bypass the entry checks for modes.  The sequence presented in the test leaves the vehicle armed in guided mode with no position.  It will probably failsafe, but... who knows?

Various libraries also change behaviour; I haven't done an audit.  But e.g. the DroneCAN "armed" status would toggle based on the safety switch for Rover but on other vehicle.  So long as we're consistent with the other vehicles there should be no issue.
