### PR TITLE
Autotest: Create structured object for rc values

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -32,6 +32,7 @@ from vehicle_test_suite import MAV_POS_TARGET_TYPE_MASK
 from vehicle_test_suite import AutoTestTimeoutException
 from vehicle_test_suite import NotAchievedException
 from vehicle_test_suite import PreconditionFailedException
+from vehicle_test_suite import RcValues
 from vehicle_test_suite import Test
 from vehicle_test_suite import WaitAndMaintainArmed
 from vehicle_test_suite import WaitAndMaintainAttitude
@@ -204,12 +205,12 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
     # Takeoff, climb to given altitude, and fly east for 10 seconds
     def takeoffAndMoveAway(self, dAlt=50, dDist=50):
         self.progress("Centering sticks")
-        self.set_rc_from_map({
+        self.set_rc_from_map(RcValues({
             1: 1500,
             2: 1500,
             3: 1000,
             4: 1500,
-        })
+        }))
         self.takeoff(alt_min=dAlt, mode='GUIDED')
         self.hover()
         self.change_mode("ALT_HOLD")
@@ -281,15 +282,15 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.watch_altitude_maintained(altitude_min=9, altitude_max=11)
         # feed in full elevator and aileron input and make sure we
         # retain altitude:
-        self.set_rc_from_map({
+        self.set_rc_from_map(RcValues({
             1: 1000,
             2: 1000,
-        })
+        }))
         self.watch_altitude_maintained(altitude_min=9, altitude_max=11)
-        self.set_rc_from_map({
+        self.set_rc_from_map(RcValues({
             1: 1500,
             2: 1500,
-        })
+        }))
         self.do_RTL()
 
     def fly_to_origin(self, final_alt=10):
@@ -324,12 +325,12 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         tstart = self.get_sim_time()
 
         # ensure all sticks in the middle
-        self.set_rc_from_map({
+        self.set_rc_from_map(RcValues({
             1: 1500,
             2: 1500,
             3: 1500,
             4: 1500,
-        })
+        }))
 
         # switch to loiter mode temporarily to stop us from rising
         self.change_mode('LOITER')
@@ -1167,10 +1168,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.install_message_hook_context(ensure_SERVO_values_never_input)
         self.progress("Forcing receiver into failsafe")
-        self.set_rc_from_map({
+        self.set_rc_from_map(RcValues({
             3: 800,
             channel: 1300,
-        })
+        }))
         self.wait_servo_channel_value(channel, trim_value)
         self.delay_sim_time(10)
 
@@ -2292,10 +2293,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.wait_distance(20)
 
         self.progress("flying up")
-        self.set_rc_from_map({
+        self.set_rc_from_map(RcValues({
             2: 1500,
             3: 1800,
-        })
+        }))
 
         # wait for fence to trigger
         self.wait_mode('RTL', timeout=120)
@@ -2415,10 +2416,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.wait_distance(20)
 
         # stop flying forward and start flying down:
-        self.set_rc_from_map({
+        self.set_rc_from_map(RcValues({
             2: 1500,
             3: 1200,
-        })
+        }))
 
         # wait for fence to trigger
         self.wait_mode('RTL', timeout=120)
@@ -6685,11 +6686,11 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             })
             self.progress("Testing RC angular control")
             # default RC min=1100 max=1900
-            self.set_rc_from_map({
+            self.set_rc_from_map(RcValues({
                 11: 1500,
                 12: 1500,
                 13: 1500,
-            })
+            }))
             self.test_mount_pitch(0, 1, mavutil.mavlink.MAV_MOUNT_MODE_RC_TARGETING)
             self.progress("Testing RC input down 1/4 of its range in the output, should be down 1/4 range in output")
             rc12_in = 1400
@@ -6705,11 +6706,11 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             self.test_mount_pitch(-11.25, 0.1, mavutil.mavlink.MAV_MOUNT_MODE_RC_TARGETING)
             self.set_rc(12, 1800)
             self.test_mount_pitch(33.75, 0.1, mavutil.mavlink.MAV_MOUNT_MODE_RC_TARGETING)
-            self.set_rc_from_map({
+            self.set_rc_from_map(RcValues({
                 11: 1500,
                 12: 1500,
                 13: 1500,
-            })
+            }))
 
             try:
                 self.context_push()
@@ -10022,9 +10023,9 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "LOG_DISARMED": 1
         })
 
-        self.set_rc_from_map({
+        self.set_rc_from_map(RcValues({
             gen_ctrl_ch: 1000,   # remember this is a switch position - stop
-        })
+        }))
 
         self.customise_SITL_commandline(["--serial5=sim:loweheiser"])
 
@@ -10323,11 +10324,11 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "RC%u_OPTION" % loweheiser_man_start_ch: 111, # loweheiser starter channel
         })
 
-        self.set_rc_from_map({
+        self.set_rc_from_map(RcValues({
             gen_ctrl_ch: 1000,   # remember this is a switch position - stop
             loweheiser_man_throt_ch: 1000,  # zero throttle
             loweheiser_man_start_ch: 1000,  # the starter is off
-        })
+        }))
 
         self.customise_SITL_commandline(["--serial5=sim:loweheiser"])
 
@@ -15943,10 +15944,10 @@ RTL_ALT_M 111
                     pitch_input += delta
                 elif lpn.vy < 0:
                     pitch_input -= delta
-                self.set_rc_from_map({
+                self.set_rc_from_map(RcValues({
                     1: roll_input,
                     2: pitch_input,
-                }, quiet=True)
+                }), quiet=True)
 
                 # check parameters once/second:
                 if now - param_last_check_time > 1:

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -24,6 +24,7 @@ from vehicle_test_suite import AutoTestTimeoutException
 from vehicle_test_suite import NotAchievedException
 from vehicle_test_suite import OldpymavlinkException
 from vehicle_test_suite import PreconditionFailedException
+from vehicle_test_suite import RcValues
 from vehicle_test_suite import Test
 from vehicle_test_suite import WaitModeTimeout
 
@@ -138,17 +139,17 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.wait_groundspeed(6, 100)
 
         # a bit faster again, straighten rudder
-        self.set_rc_from_map({
+        self.set_rc_from_map(RcValues({
             3: 1600,
             4: 1500,
-        })
+        }))
         self.wait_groundspeed(12, 100)
 
         # hit the gas harder now, and give it some more elevator
-        self.set_rc_from_map({
+        self.set_rc_from_map(RcValues({
             2: 1100,
             3: 2000,
-        })
+        }))
 
         # gain a bit of altitude
         self.wait_altitude(alt, alt_max, timeout=timeout, relative=relative)
@@ -1322,10 +1323,10 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         self.set_parameter("RC7_OPTION", 11) # AC_Fence uses Aux switch functionality
         self.set_parameter("FENCE_ACTION", 4) # Fence action Brake
-        self.set_rc_from_map({
+        self.set_rc_from_map(RcValues({
             3: 1000,
             7: 2000,
-        }) # Turn fence on with aux function
+        })) # Turn fence on with aux function
 
         m = self.assert_receive_message('FENCE_STATUS', timeout=2, verbose=True)
 
@@ -2564,9 +2565,9 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         if rc_chan == 0:
             raise NotAchievedException("Did not find soaring enable channel option.")
 
-        self.set_rc_from_map({
+        self.set_rc_from_map(RcValues({
             rc_chan: 1900,
-        })
+        }))
 
         self.set_parameters({
             "SOAR_VSPEED": 0.55,
@@ -4090,10 +4091,10 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         self.load_fence("CMAC-fence.txt")
 
-        self.set_rc_from_map({
+        self.set_rc_from_map(RcValues({
             3: 1500,
             7: 2000,
-        }) # Turn fence on with aux function
+        })) # Turn fence on with aux function
 
         m = self.assert_receive_message('FENCE_STATUS', timeout=2, verbose=True)
 
@@ -4118,9 +4119,9 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         # check we are in breach
         self.assert_fence_enabled()
 
-        self.set_rc_from_map({
+        self.set_rc_from_map(RcValues({
             7: 1000,
-        }) # Turn fence off with aux function
+        })) # Turn fence off with aux function
 
         # wait to no longer be in breach
         self.delay_sim_time(5)

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -8,6 +8,7 @@ AP_FLAKE8_CLEAN
 from __future__ import annotations
 
 import abc
+import collections
 import copy
 import enum
 import errno
@@ -200,6 +201,49 @@ class ArmedAtEndOfTestException(ErrorException):
 
 
 NUM_RC_CHANNELS: Final[int] = 16
+
+
+class RcValues(collections.UserDict):
+    """A dict for {channel: pwm_value} restricted to valid values.
+
+    Channels range from 1 to NUM_RC_CHANNELS.
+
+    RC Pulse Width Modulated (PWM) values typically range from 1000-2000 (microsec) with 1500
+    representing 'midpoint' but values outside this range are fine too.
+    """
+    def __init__(self, *args, **kwargs) -> None:
+        """Prevent creation of an invalid RcValues dict.
+
+        Note: This is not foolproof.
+        But it helps, and it strongly establishes expectations.
+        """
+        super().__init__(*args, **kwargs)
+
+        if not all(self._channel_is_valid(key) for key in self.keys()):
+            possible_channels = set(range(1, NUM_RC_CHANNELS+1))
+            invalid_channels = set(self.keys()) - possible_channels
+            # Users violating the typehints might be surprised here, but that's an ok risk.
+            raise ValueError(f"Invalid RC channels: {invalid_channels} ({NUM_RC_CHANNELS=}).")
+        if not all(self._value_is_valid(val) for val in self.values()):
+            invalid = {ch: val for ch, val in self.items() if not self._value_is_valid(val)}
+            # Users violating the typehints might be surprised here, but that's an ok risk.
+            raise ValueError(f"These RC (channel, value) pairs are invalid values: {invalid}.")
+
+    def __setitem__(self, channel: int, pwm_value: int) -> None:
+        if not self._channel_is_valid(channel):
+            raise ValueError(f"Invalid RC channel: {channel} ({NUM_RC_CHANNELS=}).")
+        if not self._value_is_valid(pwm_value):
+            raise ValueError(f"Invalid RC pwm value: {pwm_value}.")
+        super().__setitem__(channel, pwm_value)
+
+    @staticmethod
+    def _channel_is_valid(channel: int) -> bool:
+        return isinstance(channel, int) and (1 <= channel <= NUM_RC_CHANNELS)
+
+    @staticmethod
+    def _value_is_valid(value: int) -> bool:
+        """While typical PWM values are ~1000-2000, the 'possibly valid' range is larger."""
+        return isinstance(value, int) and (0 <= value <= 20_000)
 
 
 class Context(object):
@@ -2028,7 +2072,7 @@ class TestSuite(abc.ABC):
 
         self.rc_thread: threading.Thread | None = None
         self.rc_thread_should_quit: bool = False
-        self.rc_queue: queue.Queue[dict[int, int]] = queue.Queue()
+        self.rc_queue: queue.Queue[RcValues] = queue.Queue()
 
         self.expect_list = []
 
@@ -5584,11 +5628,8 @@ class TestSuite(abc.ABC):
     def rc_defaults(self):
         return {channel: 1500 for channel in range(1, NUM_RC_CHANNELS+1)}
 
-    def set_rc_from_map(self, map: dict[int, int], timeout=20, quiet=False):
+    def set_rc_from_map(self, map: RcValues, timeout=20, quiet=False):
         rc_values = map.copy()
-        for v in rc_values.values():
-            if not isinstance(v, int):
-                raise NotAchievedException("RC values must be integers")
         self.rc_queue.put(rc_values)
 
         if self.rc_thread is None:
@@ -5627,10 +5668,9 @@ class TestSuite(abc.ABC):
         rc_values = [1000] * NUM_RC_CHANNELS  # (Don't forget this is persistent.)
         while not self.rc_thread_should_quit:
             try:
-                updates = self.rc_queue.get(timeout=max_wait_before_sending_values)
+                updates: RcValues = self.rc_queue.get(timeout=max_wait_before_sending_values)
                 for chan, val in updates.items():
-                    if isinstance(chan, int) and 1 <= chan <= NUM_RC_CHANNELS:
-                        rc_values[chan-1] = val
+                    rc_values[chan-1] = val
             except queue.Empty:
                 pass
             sitl_output.write(struct.pack(format_str, *rc_values))
@@ -5638,7 +5678,7 @@ class TestSuite(abc.ABC):
     def set_rc_default(self):
         """Set all channels of simulated RC control to the default value (typically 1500)."""
         _defaults = self.rc_defaults()
-        self.set_rc_from_map(_defaults)
+        self.set_rc_from_map(RcValues(_defaults))
 
     def check_rc_defaults(self):
         """Ensure all rc outputs are at defaults"""
@@ -5651,11 +5691,11 @@ class TestSuite(abc.ABC):
                 self.progress("chan=%u needs resetting is=%u want=%u" %
                               (chan, current_value, default_value))
                 need_set[chan] = default_value
-        self.set_rc_from_map(need_set)
+        self.set_rc_from_map(RcValues(need_set))
 
     def set_rc(self, chan: int, pwm: int, timeout=20):
         """Setup a simulated RC control to a PWM value"""
-        self.set_rc_from_map({chan: pwm}, timeout=timeout)
+        self.set_rc_from_map(RcValues({chan: pwm}), timeout=timeout)
 
     def set_servo(self, chan, pwm):
         """Replicate the functionality of MAVProxy: servo set <ch> <pwm>"""
@@ -6032,10 +6072,10 @@ class TestSuite(abc.ABC):
         # Different scaling for RC input and servo output means the
         # servo output value isn't the rc input value:
         self.progress("Setting RC to 1200")
-        self.rc_queue.put({2: 1200})
+        self.rc_queue.put(RcValues({2: 1200}))
         self.progress("Waiting for servo of 1260")
         self.cpufailsafe_wait_servo_channel_value(2, 1260)
-        self.rc_queue.put({2: 1700})
+        self.rc_queue.put(RcValues({2: 1700}))
         self.cpufailsafe_wait_servo_channel_value(2, 1660)
         self.reset_SITL_commandline()
 

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -19,6 +19,7 @@ import math
 import operator
 import os
 import pathlib
+import queue
 import random
 import re
 import shutil
@@ -61,11 +62,6 @@ from pymavlink.rotmat import Vector3
 
 from pysim import util
 from pysim import vehicleinfo
-
-try:
-    import queue as Queue
-except ImportError:
-    import Queue
 
 
 # Enumeration convenience class for mavlink POSITION_TARGET_TYPEMASK
@@ -2032,7 +2028,7 @@ class TestSuite(abc.ABC):
 
         self.rc_thread: threading.Thread | None = None
         self.rc_thread_should_quit: bool = False
-        self.rc_queue = Queue.Queue()
+        self.rc_queue = queue.Queue()
 
         self.expect_list = []
 
@@ -5652,7 +5648,7 @@ class TestSuite(abc.ABC):
                 for chan, val in rc_value_updates.items():
                     if isinstance(chan, int) and 1 <= chan <= NUM_RC_CHANNELS:
                         rc_values[chan-1] = val
-            except Queue.Empty:
+            except queue.Empty:
                 pass
             sitl_output.write(struct.pack(format_str, *rc_values))
 

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -2028,7 +2028,7 @@ class TestSuite(abc.ABC):
 
         self.rc_thread: threading.Thread | None = None
         self.rc_thread_should_quit: bool = False
-        self.rc_queue = queue.Queue()
+        self.rc_queue: queue.Queue[dict[int, int]] = queue.Queue()
 
         self.expect_list = []
 
@@ -5601,12 +5601,12 @@ class TestSuite(abc.ABC):
             16: 1500,
         }
 
-    def set_rc_from_map(self, _map, timeout=20, quiet=False):
-        map_copy = _map.copy()
-        for v in map_copy.values():
+    def set_rc_from_map(self, map: dict[int, int], timeout=20, quiet=False):
+        rc_values = map.copy()
+        for v in rc_values.values():
             if not isinstance(v, int):
                 raise NotAchievedException("RC values must be integers")
-        self.rc_queue.put(map_copy)
+        self.rc_queue.put(rc_values)
 
         if self.rc_thread is None:
             self.rc_thread = threading.Thread(target=self.rc_thread_main, name='RC')
@@ -5622,10 +5622,10 @@ class TestSuite(abc.ABC):
             if m is None:
                 continue
             bad_channels = ""
-            for chan in map_copy:
+            for chan in rc_values:
                 chan_pwm = getattr(m, "chan" + str(chan) + "_raw")
-                if chan_pwm != map_copy[chan]:
-                    bad_channels += " (ch=%u want=%u got=%u)" % (chan, map_copy[chan], chan_pwm)
+                if chan_pwm != rc_values[chan]:
+                    bad_channels += " (ch=%u want=%u got=%u)" % (chan, rc_values[chan], chan_pwm)
                     break
             if len(bad_channels) == 0:
                 if not quiet:
@@ -5644,8 +5644,8 @@ class TestSuite(abc.ABC):
         rc_values = [1000] * NUM_RC_CHANNELS  # (Don't forget this is persistent.)
         while not self.rc_thread_should_quit:
             try:
-                rc_value_updates = self.rc_queue.get(timeout=max_wait_before_sending_values)
-                for chan, val in rc_value_updates.items():
+                updates = self.rc_queue.get(timeout=max_wait_before_sending_values)
+                for chan, val in updates.items():
                     if isinstance(chan, int) and 1 <= chan <= NUM_RC_CHANNELS:
                         rc_values[chan-1] = val
             except queue.Empty:
@@ -5672,7 +5672,7 @@ class TestSuite(abc.ABC):
                 need_set[chan] = default_value
         self.set_rc_from_map(need_set)
 
-    def set_rc(self, chan, pwm, timeout=20):
+    def set_rc(self, chan: int, pwm: int, timeout=20):
         """Setup a simulated RC control to a PWM value"""
         self.set_rc_from_map({chan: pwm}, timeout=timeout)
 

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -36,6 +36,7 @@ from inspect import currentframe
 from inspect import getframeinfo
 from pathlib import Path
 from typing import Dict
+from typing import Final
 from typing import List
 from typing import Tuple
 
@@ -200,6 +201,9 @@ class PreconditionFailedException(ErrorException):
 class ArmedAtEndOfTestException(ErrorException):
     """Created when test left vehicle armed"""
     pass
+
+
+NUM_RC_CHANNELS: Final[int] = 16
 
 
 class Context(object):
@@ -1977,9 +1981,7 @@ class TestSuite(abc.ABC):
         self.gdbserver = gdbserver
         self.breakpoints = breakpoints
         self.disable_breakpoints = disable_breakpoints
-        self.speedup = speedup
-        if self.speedup is None:
-            self.speedup = self.default_speedup()
+        self.speedup: Final = speedup or self.default_speedup()
         self.sup_binaries = sup_binaries
         self.reset_after_every_test = reset_after_every_test
         self.force_32bit = force_32bit
@@ -2028,8 +2030,8 @@ class TestSuite(abc.ABC):
         self.tlog = None
         self.enable_fgview = enable_fgview
 
-        self.rc_thread = None
-        self.rc_thread_should_quit = False
+        self.rc_thread: threading.Thread | None = None
+        self.rc_thread_should_quit: bool = False
         self.rc_queue = Queue.Queue()
 
         self.expect_list = []
@@ -5639,40 +5641,20 @@ class TestSuite(abc.ABC):
                 raise ValueError("RC thread is dead")  # FIXME: type
 
     def rc_thread_main(self):
-        chan16 = [1000] * 16
-
+        """When this function completes, the thread terminates."""
         sitl_output = mavutil.mavudp("127.0.0.1:%u" % self.sitl_rcin_port(), input=False)
-        buf = None
-
-        while True:
-            if self.rc_thread_should_quit:
-                break
-
-            # the 0.05 here means we're updating the RC values into
-            # the autopilot at 20Hz - that's our 50Hz wallclock, , not
-            # the autopilot's simulated 20Hz, so if speedup is 10 the
-            # autopilot will see ~2Hz.
-            timeout = 0.02
-            # ... and 2Hz is too slow when we now run at 100x speedup:
-            timeout /= (self.speedup / 10.0)
-
+        max_wait_before_sending_values: Final = 0.2 / self.speedup
+        format_str: Final = "<" + "H" * NUM_RC_CHANNELS
+        rc_values = [1000] * NUM_RC_CHANNELS  # (Don't forget this is persistent.)
+        while not self.rc_thread_should_quit:
             try:
-                map_copy = self.rc_queue.get(timeout=timeout)
-
-                # 16 packed entries:
-                for i in range(1, 17):
-                    if i in map_copy:
-                        chan16[i-1] = map_copy[i]
-
+                rc_value_updates = self.rc_queue.get(timeout=max_wait_before_sending_values)
+                for chan, val in rc_value_updates.items():
+                    if isinstance(chan, int) and 1 <= chan <= NUM_RC_CHANNELS:
+                        rc_values[chan-1] = val
             except Queue.Empty:
                 pass
-
-            buf = struct.pack('<HHHHHHHHHHHHHHHH', *chan16)
-
-            if buf is None:
-                continue
-
-            sitl_output.write(buf)
+            sitl_output.write(struct.pack(format_str, *rc_values))
 
     def set_rc_default(self):
         """Setup all simulated RC control to 1500."""

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -5582,24 +5582,7 @@ class TestSuite(abc.ABC):
         return path
 
     def rc_defaults(self):
-        return {
-            1: 1500,
-            2: 1500,
-            3: 1500,
-            4: 1500,
-            5: 1500,
-            6: 1500,
-            7: 1500,
-            8: 1500,
-            9: 1500,
-            10: 1500,
-            11: 1500,
-            12: 1500,
-            13: 1500,
-            14: 1500,
-            15: 1500,
-            16: 1500,
-        }
+        return {channel: 1500 for channel in range(1, NUM_RC_CHANNELS+1)}
 
     def set_rc_from_map(self, map: dict[int, int], timeout=20, quiet=False):
         rc_values = map.copy()
@@ -5653,18 +5636,16 @@ class TestSuite(abc.ABC):
             sitl_output.write(struct.pack(format_str, *rc_values))
 
     def set_rc_default(self):
-        """Setup all simulated RC control to 1500."""
+        """Set all channels of simulated RC control to the default value (typically 1500)."""
         _defaults = self.rc_defaults()
         self.set_rc_from_map(_defaults)
 
     def check_rc_defaults(self):
         """Ensure all rc outputs are at defaults"""
         self.do_timesync_roundtrip()
-        _defaults = self.rc_defaults()
         m = self.assert_receive_message('RC_CHANNELS', timeout=5)
         need_set = {}
-        for chan in _defaults:
-            default_value = _defaults[chan]
+        for chan, default_value in self.rc_defaults().items():
             current_value = getattr(m, "chan" + str(chan) + "_raw")
             if default_value != current_value:
                 self.progress("chan=%u needs resetting is=%u want=%u" %


### PR DESCRIPTION
### Summary

The new `RcValues` object provides validity-checking, which promotes code clarity. (Clarity is extra important for testing infra since it is 'trusted' and not itself tested.)

This PR was 'spun out of' #33061 for future consideration. It is DRAFT because it is much lower priority than that one. It is also 'chained behind' that one, meaning it has copies of that PR's commits until that one lands and they can be rebased away.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Because this adds some validity-checking to our autotest infrastructure, I locally injected some invalid values (channel > MAX, negative PWM, etc) to confirm the infra rejects them as expected.

### Description

As a general rule, when data structure is known, structured objects are superior to general ones. Specifically in this case we get:
- Explicit clarity about what "RC values" means, for anyone unfamiliar with the details.
- Validity checking on the values (defends against mistakes).
- The future possibility of refactoring the underlying data to a more efficient form. (A fixed-length array is superior to a dict.)

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
