### PR TITLE
SIM::Battery: Use physically reasonable thermal capacity

### DIFF
--- a/libraries/SITL/SIM_Battery.cpp
+++ b/libraries/SITL/SIM_Battery.cpp
@@ -184,12 +184,13 @@ void Battery::consume_energy(float current_amp, uint64_t now_us)
 
 void Battery::update_temperature(float current_amp, float dt)
 {
-    // thermal_capacity value chosen to match previous steady-state behavior at 28amps
+    // Reasonable thermal_capacity value for a commonly sized (500g) Li-ion battery
     // (reminder: thermal_capacity = mass * specific_heat)
-    constexpr float thermal_capacity = 2.8f;  // watt*seconds/degC
+    constexpr float thermal_capacity = 500.0f;  // J/degC
     constexpr float inverse_of_thermal_capacity = 1 / thermal_capacity;  // use inverse so we can multiply, not divide
     const float temp_increase = (current_amp * current_amp) * resistance_ohm * inverse_of_thermal_capacity * dt;
-    // decay temperature at some %second towards ambient
-    const float temp_decrease = (temperature_degC - ambient_temperature_degC) * 0.10 * dt;
+    // Account for ambient dissipation. Rate chosen to match previous (unjustified) steady-state behavior
+    constexpr float temperature_decay_coefficient = 5.6e-4f;
+    const float temp_decrease = (temperature_degC - ambient_temperature_degC) * temperature_decay_coefficient * dt;
     temperature_degC += (temp_increase - temp_decrease);
 }


### PR DESCRIPTION
### Summary

While no one really cares about the temperature model specifics, switch to use a realistic thermal capacity value.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

The prior thermal capacity value was chosen to match (arbitrary) prior performance. Now we change it to a realistic value.
The corresponding decay value was also arbitrary. It is correspondingly changed to preserve _steady state_ behavior.
Notice that this PR will change the *transient* behavior:
- Higher thermal capacity -> Slower temp climb
- Lower decay coefficient -> Slower temp decay

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
