### PR TITLE
SIM::Battery uses Aircraft's ambient temperature

### DIFF
--- a/libraries/SITL/SIM_Battery.cpp
+++ b/libraries/SITL/SIM_Battery.cpp
@@ -115,11 +115,12 @@ void Battery::set_initial_SoC(float voltage)
     remaining_Ah = 0;
 }
 
-void Battery::setup(float _capacity_Ah, float _resistance_ohm, float _max_voltage)
+void Battery::setup(float _capacity_Ah, float _resistance_ohm, float _max_voltage, float _ambient_temperature_degC)
 {
     capacity_Ah = _capacity_Ah;
     resistance_ohm = _resistance_ohm;
     max_voltage = _max_voltage;
+    ambient_temperature_degC = _ambient_temperature_degC;
 
     voltage_set = max_voltage;
     voltage_filter.reset(voltage_set);
@@ -183,9 +184,6 @@ void Battery::consume_energy(float current_amp, uint64_t now_us)
 
 void Battery::update_temperature(float current_amp, float dt)
 {
-    // In the (near) future, this value will instead come from Aircraft::ambient_outside_temperature_degC()
-    constexpr float ambient_temperature_degC = 0.0f;
-
     // thermal_capacity value chosen to match previous steady-state behavior at 28amps
     // (reminder: thermal_capacity = mass * specific_heat)
     constexpr float thermal_capacity = 2.8f;  // watt*seconds/degC

--- a/libraries/SITL/SIM_Battery.h
+++ b/libraries/SITL/SIM_Battery.h
@@ -24,7 +24,7 @@ namespace SITL {
 
 class Battery {
 public:
-    void setup(float _capacity_Ah, float _resistance_ohm, float _max_voltage);
+    void setup(float _capacity_Ah, float _resistance_ohm, float _max_voltage, float _ambient_temperature_degC);
 
     // Resets the battery state if the configuration (e.g. from SIM_BATT_* parameters) has changed.
     void maybe_reset(float desired_voltage, float desired_capacity_Ah);
@@ -43,6 +43,7 @@ private:
     float capacity_Ah;
     float resistance_ohm;
     float max_voltage;
+    float ambient_temperature_degC;
     float voltage_set;
     float remaining_Ah;
     uint64_t last_us;

--- a/libraries/SITL/SIM_Multicopter.cpp
+++ b/libraries/SITL/SIM_Multicopter.cpp
@@ -35,7 +35,8 @@ MultiCopter::MultiCopter(const char *frame_str) :
     frame->init(frame_str);
     battery.setup(frame->get_model_batt_capacity_ah(),
                   frame->get_model_batt_resistance_ohm(),
-                  frame->get_model_batt_max_voltage());
+                  frame->get_model_batt_max_voltage(),
+                  ambient_outside_temperature_degC());
 
     mass = frame->get_mass();
     frame_height = 0.1;

--- a/libraries/SITL/SIM_QuadPlane.cpp
+++ b/libraries/SITL/SIM_QuadPlane.cpp
@@ -104,7 +104,8 @@ QuadPlane::QuadPlane(const char *frame_str) :
     frame->init(frame_str);
     battery.setup(frame->get_model_batt_capacity_ah(),
                   frame->get_model_batt_resistance_ohm(),
-                  frame->get_model_batt_max_voltage());
+                  frame->get_model_batt_max_voltage(),
+                  ambient_outside_temperature_degC());
 
     // increase mass for plane components
     mass = frame->get_mass() * 1.5;

--- a/libraries/SITL/examples/EvaluateBatteryModel/EvaluateBatteryModel.cpp
+++ b/libraries/SITL/examples/EvaluateBatteryModel/EvaluateBatteryModel.cpp
@@ -56,12 +56,13 @@ void setup(void)
     const float resistance = frame.get_resistance();
     const float max_voltage = frame.get_max_volt();
     const float min_voltage = max_voltage * 0.7;
+    constexpr float ambient_temperature_degC = 0.0f;
 
     ::printf("Simulating %0.2fv, %0.2f ah battery with resistance of %f\n", max_voltage, amp_hour_capacity, resistance);
     ::printf("Voltage from %0.2f to %0.2f with constant current draw of %0.2f\n", max_voltage, min_voltage, current_amps);
 
     // setup battery model
-    battery.setup(amp_hour_capacity, resistance, max_voltage);
+    battery.setup(amp_hour_capacity, resistance, max_voltage, ambient_temperature_degC);
     battery.init_voltage(max_voltage);
 
     uint64_t time_us = 0;

--- a/libraries/SITL/tests/test_battery.cpp
+++ b/libraries/SITL/tests/test_battery.cpp
@@ -21,25 +21,28 @@ constexpr float high_resistance_ohm = 0.04f;
 // This can be any value, in operation it would come from AP_HAL::micros64().
 constexpr uint64_t initial_us = 0;
 
+// This is arbitrary
+constexpr float ambient_temperature_degC = 0.0f;
+
 class BatteryTest : public testing::Test {
 protected:
     BatteryTest() {
-        small_battery.setup(small_capacity_Ah, low_resistance_ohm, max_voltage);
+        small_battery.setup(small_capacity_Ah, low_resistance_ohm, max_voltage, ambient_temperature_degC);
         small_battery.init_voltage(max_voltage);
         small_battery.init_capacity(small_capacity_Ah);
-        large_battery.setup(large_capacity_Ah, low_resistance_ohm, max_voltage);
+        large_battery.setup(large_capacity_Ah, low_resistance_ohm, max_voltage, ambient_temperature_degC);
         large_battery.init_voltage(max_voltage);
         large_battery.init_capacity(large_capacity_Ah);
         // Recall that capacity==0 means unlimited.
-        infinite_battery.setup(0.0f, low_resistance_ohm, max_voltage);
+        infinite_battery.setup(0.0f, low_resistance_ohm, max_voltage, ambient_temperature_degC);
         infinite_battery.init_voltage(max_voltage);
         infinite_battery.init_capacity(0.0f);
 
-        small_high_resistance_battery.setup(small_capacity_Ah, high_resistance_ohm, max_voltage);
+        small_high_resistance_battery.setup(small_capacity_Ah, high_resistance_ohm, max_voltage, ambient_temperature_degC);
         small_high_resistance_battery.init_voltage(max_voltage);
         small_high_resistance_battery.init_capacity(small_capacity_Ah);
         // Recall that capacity==0 means unlimited.
-        infinite_high_resistance_battery.setup(0.0f, high_resistance_ohm, max_voltage);
+        infinite_high_resistance_battery.setup(0.0f, high_resistance_ohm, max_voltage, ambient_temperature_degC);
         infinite_high_resistance_battery.init_voltage(max_voltage);
         infinite_high_resistance_battery.init_capacity(0.0f);
     }


### PR DESCRIPTION
### Summary

Since SIM::Aircraft has an ambient_temperature_degC method, SIM::Battery now uses it.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] No change to autopilot functionality
- [x] No change to autopilot binary
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Currently, Aircraft::ambient_temperature_degC has a `FIXME` related to barometer temperature, but it seems fine to use it anyway. (We anticipate the SIM::Battery temperature is rarely used at present.)

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
