### PR TITLE
AP_Logger: remove unused should_log_rcin2

### DIFF
--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -483,9 +483,6 @@ private:
 
     bool _armed;
 
-    // state to help us not log unnecessary RCIN values:
-    bool should_log_rcin2;
-
     void Write_Compass_instance(uint64_t time_us, uint8_t mag_instance);
 
     void backend_starting_new_log(const AP_Logger_Backend *backend);


### PR DESCRIPTION
### Summary

Removes an unused member

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

moved to needing this for RCI2 override mask and flags