### PR TITLE
AP_Motors6DOF: Clarify MOT_FV_CPLNG_K applicability

### DIFF
--- a/libraries/AP_Motors/AP_Motors6DOF.cpp
+++ b/libraries/AP_Motors/AP_Motors6DOF.cpp
@@ -84,7 +84,7 @@ const AP_Param::GroupInfo AP_Motors6DOF::var_info[] = {
 
     // @Param: FV_CPLNG_K
     // @DisplayName: Forward/vertical to pitch decoupling factor
-    // @Description: Used to decouple pitch from forward/vertical motion. 0 to disable, 1.2 normal
+    // @Description: (Vectored frame only) Used to decouple pitch from forward/vertical motion. 0 to disable, 1.2 normal
     // @Range: 0.0 1.5
     // @Increment: 0.1
     // @User: Standard


### PR DESCRIPTION
### Summary

Documents that the parameter only applies when the Vectored frame is selected.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

From [the implementation](https://github.com/ArduPilot/ardupilot/blob/fddfee0fe19cbc25e78becdf945ab8938a659594/libraries/AP_Motors/AP_Motors6DOF.cpp#L439-L443), the parameter value is only used when calculating stabilised outputs for the Vectored frame. Other frames use other methods.