### PR TITLE
ArduSub: allow mode change to altitude-hold modes when EKF altitude is valid

### DIFF
--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -513,6 +513,7 @@ private:
     bool position_ok();
     bool ekf_position_ok();
     bool optflow_position_ok();
+    bool ekf_alt_ok();
     bool should_log(uint32_t mask);
     bool start_command(const AP_Mission::Mission_Command& cmd);
     bool verify_command(const AP_Mission::Mission_Command& cmd);

--- a/ArduSub/mode.cpp
+++ b/ArduSub/mode.cpp
@@ -93,10 +93,13 @@ bool Sub::set_mode(Mode::Number mode, ModeReason reason)
     }
 
     // check for valid altitude if old mode did not require it but new one does
-    // we only want to stop changing modes if it could make things worse
+    // we only want to stop changing modes if it could make things worse.
+    // accept the mode change if either the EKF has a valid altitude estimate
+    // (e.g. from GPS or ExternalNav) or the depth sensor is healthy.
     if (!flightmode->requires_altitude() &&
         new_flightmode->requires_altitude() &&
-        !sub.control_check_barometer()) { // maybe use ekf_alt_ok() instead?
+        !sub.ekf_alt_ok() &&
+        !sub.control_check_barometer()) {
         gcs().send_text(MAV_SEVERITY_WARNING, "Mode change failed: %s need alt estimate", new_flightmode->name());
         LOGGER_WRITE_ERROR(LogErrorSubsystem::FLIGHT_MODE, LogErrorCode(mode));
         return false;

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -267,6 +267,26 @@ bool Sub::optflow_position_ok()
     return ahrs.has_status(AP_AHRS::Status::HORIZ_POS_REL);
 }
 
+// ekf_alt_ok - returns true if the ekf has a good altitude estimate
+// (e.g. from GPS or ExternalNav), allowing modes which require altitude
+// hold to be entered without a healthy depth sensor.
+bool Sub::ekf_alt_ok()
+{
+    if (!ahrs.have_inertial_nav()) {
+        // do not allow alt control with only dcm
+        return false;
+    }
+
+    // require both vertical position and velocity estimates
+    if (!ahrs.has_status(AP_AHRS::Status::VERT_POS)) {
+        return false;
+    }
+    if (!ahrs.has_status(AP_AHRS::Status::VERT_VEL)) {
+        return false;
+    }
+    return true;
+}
+
 #if HAL_LOGGING_ENABLED
 /*
   should we log a message type now?


### PR DESCRIPTION
## Summary

Fixes #32276. The flight-mode entry check in `Sub::set_mode` rejected switching to a mode requiring altitude (e.g. `ALT_HOLD`) whenever the depth sensor was unhealthy or absent, even when the EKF had a valid altitude estimate from an external source (GPS or ExternalNav).

Added `Sub::ekf_alt_ok()` mirroring [`Copter::ekf_alt_ok()`](https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/system.cpp#L299) (checks `ahrs.have_inertial_nav()` and the `VERT_POS` / `VERT_VEL` AHRS status flags). The mode-entry check now accepts the change if **either** the EKF altitude estimate is valid **or** the depth sensor passes its existing health check.

The new helper is evaluated first so that `control_check_barometer()` (which emits a GCS warning on failure) is skipped when the EKF altitude is already valid.

## Classification & Testing

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Built ArduSub SITL on macOS (arm64, `./waf configure --board sitl` + `./waf sub`) and verified the default-config mode switch from `MANUAL` (19) → `ALT_HOLD` (2) still works — no regression on the existing happy path.

The new code path (depth sensor unhealthy + EKF altitude valid) was not exercised in SITL because flipping `ap.depth_sensor_present` at runtime requires a custom sim setup. Code review of that path is welcome, and I am happy to follow up with an autotest if maintainers would like one.