### PR TITLE
AP_Mount: clamp MAVLink gimbal attitude interval to half loop rate

### DIFF
--- a/libraries/AP_Mount/AP_Mount_MAVLink.cpp
+++ b/libraries/AP_Mount/AP_Mount_MAVLink.cpp
@@ -10,7 +10,7 @@
 extern const AP_HAL::HAL& hal;
 
 #define AP_MOUNT_MAVLINK_SEARCH_MS  60000    // search for gimbal for 1 minute after startup
-#define AP_MOUNT_MAVLINK_ATTITUDE_INTERVAL_US    20000  // send ATTITUDE and AUTOPILOT_STATE_FOR_GIMBAL_DEVICE at 50hz
+#define AP_MOUNT_MAVLINK_ATTITUDE_INTERVAL_MS    20  // send ATTITUDE and AUTOPILOT_STATE_FOR_GIMBAL_DEVICE at 50hz
 
 // update mount position
 void AP_Mount_MAVLink::update()
@@ -198,11 +198,12 @@ bool AP_Mount_MAVLink::start_sending_attitude_to_gimbal()
     if (_link == nullptr) {
         return false;
     }
-    // send AUTOPILOT_STATE_FOR_GIMBAL_DEVICE
-    const MAV_RESULT res = _link->set_message_interval(MAVLINK_MSG_ID_AUTOPILOT_STATE_FOR_GIMBAL_DEVICE, AP_MOUNT_MAVLINK_ATTITUDE_INTERVAL_US);
 
-    // return true on success
-    return (res == MAV_RESULT_ACCEPTED);
+    // request AUTOPILOT_STATE_FOR_GIMBAL_DEVICE be streamed to the gimbal.
+    // set_ap_message_interval() caps the rate to what SCHED_LOOP_RATE allows
+    // rather than refusing it, so vehicles with a low loop rate (e.g. Plane
+    // and Sub default to 50Hz) still get the message, just at a lower rate.
+    return _link->set_ap_message_interval(MSG_AUTOPILOT_STATE_FOR_GIMBAL_DEVICE, AP_MOUNT_MAVLINK_ATTITUDE_INTERVAL_MS);
 }
 
 // send GIMBAL_DEVICE_SET_ATTITUDE to gimbal to command gimbal to retract (aka relax)

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -503,6 +503,11 @@ public:
 
     MAV_RESULT set_message_interval(uint32_t msg_id, int32_t interval_us);
 
+    // set the interval at which an ap_message should be emitted (in ms).
+    // unlike set_message_interval() the requested rate is capped to what
+    // SCHED_LOOP_RATE allows rather than being refused.
+    bool set_ap_message_interval(enum ap_message id, uint16_t interval_ms);
+
 protected:
 
     bool mavlink_coordinate_frame_to_location_alt_frame(MAV_FRAME coordinate_frame,
@@ -939,8 +944,6 @@ private:
     // try_send_message, will cause a mavlink message with that id to
     // be emitted.  Returns MSG_LAST if no such mapping exists.
     ap_message mavlink_id_to_ap_message_id(const uint32_t mavlink_id) const;
-    // set the interval at which an ap_message should be emitted (in ms)
-    bool set_ap_message_interval(enum ap_message id, uint16_t interval_ms);
     // call set_ap_message_interval for each entry in a stream,
     // the interval being based on the stream's rate
     void initialise_message_intervals_for_stream(GCS_MAVLINK::streams id);


### PR DESCRIPTION
## Summary

Fixes #31101. The MAVLink mount backend asks for `AUTOPILOT_STATE_FOR_GIMBAL_DEVICE` to be streamed to the gimbal at 50Hz. It did this via `set_message_interval()`, which *refuses* any rate faster than `0.8 * SCHED_LOOP_RATE`. On vehicles with a low loop rate (Plane and Sub default to a 50Hz `SCHED_LOOP_RATE`) the 50Hz request gets rejected, so the gimbal never receives the message and the GCS is spammed with `Requested rate for message ID 286 too fast. Increase SCHED_LOOP_RATE`.

Instead of adding new clamping logic, this switches the request over to the existing `set_ap_message_interval()` helper, which already *caps* the requested rate to what the loop rate allows rather than refusing it. Low-loop-rate vehicles now still get the message (just at a lower rate), and Copter (400Hz loop) is unaffected — still 50Hz. The helper is made public so the mount backend can call it.

## Classification & Testing

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Built ArduCopter SITL — compiles clean and behaviour is unchanged at the default 400Hz loop. The change just reuses `set_ap_message_interval()`, which is already exercised throughout the codebase for stream-rate setup, so no new autotest is added.
