### PR TITLE
AP_Common: add SITL check for matching alt frame in linearly_interpolate_alt

### DIFF
--- a/libraries/AP_Common/Location.cpp
+++ b/libraries/AP_Common/Location.cpp
@@ -681,6 +681,13 @@ int32_t Location::limit_lattitude(int32_t lat)
 // this alt-frame will be updated to match the destination alt frame
 void Location::linearly_interpolate_alt(const Location &point1, const Location &point2)
 {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    // alt frames must match; mixing frames produces meaningless interpolated altitudes
+    if (point1.get_alt_frame() != point2.get_alt_frame()) {
+        AP_HAL::panic("linearly_interpolate_alt: alt frames differ (point1=%u point2=%u)",
+                      (unsigned)point1.get_alt_frame(), (unsigned)point2.get_alt_frame());
+    }
+#endif
     // new target's distance along the original track and then linear interpolate between the original origin and destination altitudes
     set_alt_cm(point1.alt + (point2.alt - point1.alt) * constrain_float(line_path_proportion(point1, point2), 0.0f, 1.0f), point2.get_alt_frame());
 }


### PR DESCRIPTION
## Summary

Fixes #32926. `update_wpnav()` calls `linearly_interpolate_alt()` against `origin_loc` and `destination_loc` for both the BendyRulerHorizontal and Dijkstras path-handling branches. That helper's contract is that its two endpoint Locations share an alt frame; mixing frames produces meaningless interpolated altitudes.

Today the two locations are always constructed from the same `_is_terrain_alt_oabak` conditional so the invariant holds, but there's no runtime check to catch a future change that breaks it. Added a SITL-only `INTERNAL_ERROR` right after the Locations are constructed.

## Classification & Testing

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below
- [ ] Tested on hardware

Built ArduCopter SITL on macOS (arm64). With the current code path the alt frames match by construction, so the new check does not fire (no behavior change). The check is guarded by `#if CONFIG_HAL_BOARD == HAL_BOARD_SITL` so production builds are unaffected.