### PR TITLE
AP_SerialManager: pre-arm check for too many MAVLink ports

### DIFF
--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -858,6 +858,40 @@ bool AP_SerialManager::pre_arm_checks(char *failure_msg, const uint8_t failure_m
             return false;
         }
     }
+
+#if HAL_GCS_ENABLED
+    // warn if the user has configured more MAVLink-protocol ports than this
+    // build can actually serve (each MAVLink port consumes one comm buffer).
+    uint8_t mavlink_count = 0;
+    for (uint8_t i=0; i<ARRAY_SIZE(state); i++) {
+        const auto p = state[i].protocol;
+        if (p == SerialProtocol_MAVLink ||
+            p == SerialProtocol_MAVLink2 ||
+            p == SerialProtocol_MAVLinkHL) {
+            mavlink_count++;
+        }
+    }
+#if AP_SERIALMANAGER_REGISTER_ENABLED
+    {
+        WITH_SEMAPHORE(port_sem);
+        for (auto *rp = registered_ports; rp != nullptr; rp = rp->next) {
+            const auto p = rp->state.protocol;
+            if (p == SerialProtocol_MAVLink ||
+                p == SerialProtocol_MAVLink2 ||
+                p == SerialProtocol_MAVLinkHL) {
+                mavlink_count++;
+            }
+        }
+    }
+#endif
+    if (mavlink_count > MAVLINK_COMM_NUM_BUFFERS) {
+        hal.util->snprintf(failure_msg, failure_msg_len,
+                           "%u MAVLink ports defined, only %u supported",
+                           unsigned(mavlink_count), unsigned(MAVLINK_COMM_NUM_BUFFERS));
+        return false;
+    }
+#endif  // HAL_GCS_ENABLED
+
     return true;
 }
 


### PR DESCRIPTION
## Summary

Fixes #30997. Each serial or network port configured with a MAVLink protocol (`MAVLink` / `MAVLink2` / `MAVLinkHL`) consumes one of the build's `MAVLINK_COMM_NUM_BUFFERS` comm buffers. When the user sets more `SERIALx_PROTOCOL = 2` and/or `NET_Px_PROTOCOL = 2` entries than the build can serve, the surplus ports silently miss out on a buffer and there is no signal to the user — it is, as @rmackay9 put it on the issue, "very hard to figure out otherwise".

Extended the existing `AP_SerialManager::pre_arm_checks()` to count MAVLink-protocol ports across both the `SERIALx` state array **and** any `AP_SERIALMANAGER_REGISTER_ENABLED` network/registered ports, and fail with a clear message when the count exceeds `MAVLINK_COMM_NUM_BUFFERS`:

```
N MAVLink ports defined, only M supported
```

The whole block is gated by `HAL_GCS_ENABLED` (no point checking on a build that has no GCS at all). The registered-ports walk takes `port_sem` for the duration of the iteration.

**Companion PR (alternative approach):** see #33095 for a `config_error`-based implementation per @peterbarker's suggestion, opened for side-by-side comparison.

## Classification & Testing

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below
- [ ] Tested on hardware

Built ArduCopter SITL on macOS (arm64) — change compiles cleanly. Did not exercise the failure path in a running SITL session because reproducing it requires forcing more MAVLink-protocol ports than the SITL build's `MAVLINK_COMM_NUM_BUFFERS` (5 on the smallest configurations, 16 on standard) and walking through arming. Happy to add an autotest if maintainers would prefer one.
