### PR TITLE
.github: avoid use of pull_request_target

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,7 +1,7 @@
 name: ci
 
 on:
-  pull_request_target:  # pull_request_target, NOT pull_request
+  pull_request:
     types: [opened, synchronize, reopened]
 
 jobs:


### PR DESCRIPTION
### Summary

Stop using pull_request_target in our github workflows.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

this is starting to get a very bad name in terms of security vulnerability.

It is not clear why this required pull_request_target