### PR TITLE
Rover: fixed skid-steer motor boats spinning

### DIFF
--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -5298,6 +5298,69 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.zero_throttle()
         self.disarm_vehicle()
 
+    def MotorBoatSkidGuided(self):
+        '''ensure a skid-steering motorboat does not spin in GUIDED when retargeting directly behind'''
+        model = "motorboat-skid"
+        self.customise_SITL_commandline([],
+                                        model=model,
+                                        defaults_filepath=self.model_defaults_filepath(model))
+
+        self.change_mode('LOITER')
+        self.wait_ready_to_arm()
+
+        # capture initial heading so we can place the two waypoints
+        # along that axis - that way each trip is a true 180-deg turn
+        att = self.assert_receive_message('ATTITUDE')
+        initial_yaw_deg = math.degrees(att.yaw)
+        here = self.mav.location()
+        north = math.cos(math.radians(initial_yaw_deg))
+        east = math.sin(math.radians(initial_yaw_deg))
+        loc_a = self.offset_location_ne(here, 25*north, 25*east)
+        loc_b = self.offset_location_ne(here, -25*north, -25*east)
+
+        self.change_mode('GUIDED')
+        self.arm_vehicle()
+
+        # accumulate per-sample yaw deltas (wrapped to +/-180) to
+        # detect a spinning boat. With the SITL fix the skid-steer
+        # max yaw rate is bounded to 5*pi ~= 16 deg/s; without it,
+        # rates can exceed 300 deg/s when the bug fires.
+        state = {'last_yaw_deg': None, 'total_change': 0.0}
+
+        def yaw_hook(mav, m):
+            if m.get_type() != 'ATTITUDE':
+                return
+            yaw = math.degrees(m.yaw)
+            if state['last_yaw_deg'] is not None:
+                delta = mavextra.wrap_180(yaw - state['last_yaw_deg'])
+                state['total_change'] += abs(delta)
+            state['last_yaw_deg'] = yaw
+
+        self.install_message_hook_context(yaw_hook)
+
+        # drive between two waypoints 50m apart along the initial
+        # heading axis, pausing 10s at each. Each transition is a
+        # 180-deg target relative to the boat's current heading,
+        # which triggers the skid-steer spin bug in SITL when speed
+        # has drifted slightly off zero.
+        spin_limit_deg = 3 * 360
+        for trip in range(4):
+            target = loc_a if trip % 2 == 0 else loc_b
+            name = 'A' if trip % 2 == 0 else 'B'
+            self.progress("Trip %u: driving 50m to %s (180-deg turn)" % (trip, name))
+            self.send_do_reposition(int(target.lat * 1e7), int(target.lng * 1e7))
+            self.wait_location(target, accuracy=5, height_accuracy=None, timeout=60)
+            self.progress("Dwelling at %s for 10s" % name)
+            self.delay_sim_time(10)
+
+        total = state['total_change']
+        self.progress("Total yaw change %.0f deg over %u trips" % (total, trip + 1))
+        if total > spin_limit_deg:
+            raise NotAchievedException(
+                "Boat spun: total yaw change %.0f deg exceeds %u deg" % (total, spin_limit_deg))
+
+        self.disarm_vehicle(force=True)
+
     def SlewRate(self):
         """Test Motor Slew Rate feature."""
         self.context_push()
@@ -7181,6 +7244,7 @@ return update()
             self.DataFlashOverMAVLink,
             self.DataFlash,
             self.SkidSteer,
+            self.MotorBoatSkidGuided,
             self.PolyFence,
             self.SDPolyFence,
             self.PolyFenceAvoidance,

--- a/libraries/SITL/SIM_Sailboat.cpp
+++ b/libraries/SITL/SIM_Sailboat.cpp
@@ -100,19 +100,20 @@ float Sailboat::get_turn_circle(float steering) const
 // return yaw rate in deg/sec given a steering input (in the range -1 to +1) and speed in m/s
 float Sailboat::get_yaw_rate(float steering, float speed) const
 {
-    float rate = 0.0f;
-    if (is_zero(steering) || (!skid_steering && is_zero(speed))) {
-        return rate;
-    } 
-    
-    if (is_zero(speed) && skid_steering) {
-        rate = steering * M_PI * 5;
-    } else {
-        float d = get_turn_circle(steering);
-        float c = M_PI * d;
-        float t = c / speed;
-        rate = 360.0f / t;
+    if (skid_steering) {
+        return steering * M_PI * 5;
     }
+
+    float rate = 0.0f;
+    if (is_zero(steering) || is_zero(speed)) {
+        return rate;
+    }
+
+    float d = get_turn_circle(steering);
+    float c = M_PI * d;
+    float t = c / speed;
+    rate = 360.0f / t;
+
     return rate;
 }
 


### PR DESCRIPTION
### Summary

the motorboat-skid model would spin and fail to navigate in GUIDED when given a target position behind the boat

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

fix the skidsteer boat model to be much simpler, and added a test demonstrating the issue

The issue manifests either as failing to reach the destination, or in some cases spinning on the spot, like this:
<img width="1004" height="497" alt="image" src="https://github.com/user-attachments/assets/43d9547a-4cb7-46be-9f20-567d12785e44" />
log here: https://uav.tridgell.net/tmp/00000049.BIN



<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
