### PR TITLE
Remove handling of MISSION_ITEM

### DIFF
--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -443,6 +443,7 @@ BUILD_OPTIONS = [
     Feature('MAVLink', 'MAV_SERVO_RELAY', 'AP_MAVLINK_SERVO_RELAY_ENABLED', 'Enable ServoRelay MAVLink messages', 0, 'SERVORELAY_EVENTS'),  # noqa
     Feature('MAVLink', 'MAV_MSG_SERIAL_CONTROL', 'AP_MAVLINK_MSG_SERIAL_CONTROL_ENABLED', 'Enable Serial Control MAVLink messages', 0, None),  # noqa
     Feature('MAVLink', 'MAVLINK_MSG_MISSION_REQUEST', 'AP_MAVLINK_MSG_MISSION_REQUEST_ENABLED', 'Enable MISSION_REQUEST MAVLink messages', 0, None),  # noqa
+    Feature('MAVLink', 'MISSION_ITEM', 'AP_MISSION_ITEM_ENABLED', 'Enable MISSION_ITEM handling', 0, None),  # noqa: E501
     Feature('MAVLink', 'MAVLINK_MSG_RC_CHANNELS_RAW', 'AP_MAVLINK_MSG_RC_CHANNELS_RAW_ENABLED', 'Enable RC_CHANNELS_RAW MAVLink messages', 0, None),  # noqa
     Feature('MAVLink', 'AP_MAVLINK_FTP_ENABLED', 'AP_MAVLINK_FTP_ENABLED', 'Enable MAVLink FTP protocol', 0, None),  # noqa
     Feature('MAVLink', 'MAV_CMD_SET_HAGL', 'AP_MAVLINK_MAV_CMD_SET_HAGL_ENABLED', 'Enable MAVLink HAGL command', 0, None),  # noqa

--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -156,6 +156,7 @@ class ExtractFeatures(BuildScriptBase):
             ('AP_OAPATHPLANNER_ENABLED', 'AP_OAPathPlanner::AP_OAPathPlanner',),
             ('AC_PAYLOAD_PLACE_ENABLED', 'PayloadPlace::start_descent'),
             ('AP_MISSION_NAV_PAYLOAD_PLACE_ENABLED', ExtractFeatures.FindString('PayloadPlace')),
+            ('AP_MISSION_ITEM_ENABLED', 'AP_Mission::convert_MISSION_ITEM_to_MISSION_ITEM_INT'),
             ('AP_ICENGINE_ENABLED', 'AP_ICEngine::AP_ICEngine',),
             ('HAL_EFI_ENABLED', 'AP_RPM_EFI::AP_RPM_EFI',),
             ('AP_EFI_NWPWU_ENABLED', r'AP_EFI_NWPMU::update\b',),

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -1524,6 +1524,7 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
     return MAV_MISSION_ACCEPTED;
 }
 
+#if AP_MISSION_ITEM_ENABLED
 MAV_MISSION_RESULT AP_Mission::convert_MISSION_ITEM_to_MISSION_ITEM_INT(const mavlink_mission_item_t &packet,
         mavlink_mission_item_int_t &mav_cmd)
 {
@@ -1606,6 +1607,7 @@ MAV_MISSION_RESULT AP_Mission::convert_MISSION_ITEM_INT_to_MISSION_ITEM(const ma
 
     return MAV_MISSION_ACCEPTED;
 }
+#endif  // AP_MISSION_ITEM_ENABLED
 
 // mission_cmd_to_mavlink_int - converts an AP_Mission::Mission_Command object to a mavlink message which can be sent to the GCS
 //  return true on success, false on failure

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -650,10 +650,12 @@ public:
     ///     home is taken directly from ahrs
     void write_home_to_storage();
 
+#if AP_MISSION_ITEM_ENABLED
     static MAV_MISSION_RESULT convert_MISSION_ITEM_to_MISSION_ITEM_INT(const mavlink_mission_item_t &mission_item,
             mavlink_mission_item_int_t &mission_item_int) WARN_IF_UNUSED;
     static MAV_MISSION_RESULT convert_MISSION_ITEM_INT_to_MISSION_ITEM(const mavlink_mission_item_int_t &mission_item_int,
             mavlink_mission_item_t &mission_item) WARN_IF_UNUSED;
+#endif  // AP_MISSION_ITEM_ENABLED
 
     // mavlink_int_to_mission_cmd - converts mavlink message to an AP_Mission::Mission_Command object which can be stored to eeprom
     //  return MAV_MISSION_ACCEPTED on success, MAV_MISSION_RESULT error on failure

--- a/libraries/AP_Mission/AP_Mission_config.h
+++ b/libraries/AP_Mission/AP_Mission_config.h
@@ -7,3 +7,18 @@
 #ifndef AP_MISSION_NAV_PAYLOAD_PLACE_ENABLED
 #define AP_MISSION_NAV_PAYLOAD_PLACE_ENABLED 1
 #endif
+
+// No handling of MISSION_ITEM is present in the AP_Mission library -
+// everything is MISSION_ITEM_INT.  However, there is a pair of static
+// methods which allows conversion from a mavlink MISSION_ITEM message
+// to a MISSION_ITEM_INT method and vice-versa, and they are gated on
+// this define.  Additionally, the GCS library uses this define to
+// gate acceptance of various mavlink messages (the GCS library also
+// being the user of the static methods)
+// CODE_REMOVAL
+// ArduPilot 4.4 sends a warning if MISSION_ITEM is handled
+// ArduPilot 4.8 compiles the code out by default
+// ArduPilot 4.9 removes the code entirely
+#ifndef AP_MISSION_ITEM_ENABLED
+#define AP_MISSION_ITEM_ENABLED (CONFIG_HAL_BOARD == HAL_BOARD_SITL)
+#endif  // AP_MISSION_ITEM_ENABLED

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4718,11 +4718,19 @@ void GCS_MAVLINK::handle_common_mission_message(const mavlink_message_t &msg)
         handle_mission_request_int(msg);
         break;
 
-#if AP_MAVLINK_MSG_MISSION_REQUEST_ENABLED
     case MAVLINK_MSG_ID_MISSION_REQUEST:
+#if AP_MAVLINK_MSG_MISSION_REQUEST_ENABLED
         handle_mission_request(msg);
-        break;
+#else
+        // this is temporary code which is slated to be removed in
+        // ArduPilot-4.10:
+        static bool mission_request_warning_sent;
+        if (!mission_request_warning_sent) {
+            mission_request_warning_sent = true;
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "got MISSION_REQUEST; use MISSION_REQUEST_INT!");
+        }
 #endif
+        break;
 
 #if AP_MAVLINK_MISSION_SET_CURRENT_ENABLED
     case MAVLINK_MSG_ID_MISSION_SET_CURRENT:    // MAV ID: 41

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -957,7 +957,7 @@ void GCS_MAVLINK::handle_mission_item(const mavlink_message_t &msg)
     if (msg.msgid == MAVLINK_MSG_ID_MISSION_ITEM) {
         mavlink_mission_item_t mission_item;
         mavlink_msg_mission_item_decode(&msg, &mission_item);
-#if AP_MISSION_ENABLED
+#if AP_MISSION_ITEM_ENABLED
         MAV_MISSION_RESULT ret = AP_Mission::convert_MISSION_ITEM_to_MISSION_ITEM_INT(mission_item, mission_item_int);
         if (ret != MAV_MISSION_ACCEPTED) {
             const MAV_MISSION_TYPE type = (MAV_MISSION_TYPE)mission_item_int.mission_type;
@@ -965,14 +965,12 @@ void GCS_MAVLINK::handle_mission_item(const mavlink_message_t &msg)
             return;
         }
 #else
-        // No mission library, so we can't convert from MISSION_ITEM
-        // to MISSION_ITEM_INT.  Since we shouldn't be receiving fence
-        // or rally items via MISSION_ITEM, we don't need to work hard
-        // here, just fail:
+        // No MISSION_ITEM support, so we can't convert from MISSION_ITEM
+        // to MISSION_ITEM_INT.
         const MAV_MISSION_TYPE type = (MAV_MISSION_TYPE)mission_item.mission_type;
         send_mission_ack(msg, type, MAV_MISSION_UNSUPPORTED);
         return;
-#endif
+#endif  // AP_MISSION_ITEM_ENABLED
         send_mission_item_warning = true;
     } else {
         mavlink_msg_mission_item_int_decode(&msg, &mission_item_int);

--- a/libraries/GCS_MAVLink/GCS_config.h
+++ b/libraries/GCS_MAVLink/GCS_config.h
@@ -106,12 +106,12 @@
 // sending warnings to the GCS in Sep 2022 if MISSION_REQUEST was used.
 // Copter 4.4.0 sends this warning.
 // CODE_REMOVAL
-// ArduPilot 4.4 sends warnings if MISSION_ITEM used
-// ArduPilot 4.8 stops compiling in MISSION_ITEM but still sends warnings
-// ArduPilot 4.9 removes the code but sends message about MISSION_ITEM not supported
+// ArduPilot 4.4 sends warnings if MISSION_REQUEST used
+// ArduPilot 4.8 stops compiling in MISSION_REQUEST but still sends warnings
+// ArduPilot 4.9 removes the code but sends message about MISSION_REQUEST not supported
 // ArduPilot 4.10 stops sending the warning
 #ifndef AP_MAVLINK_MSG_MISSION_REQUEST_ENABLED
-#define AP_MAVLINK_MSG_MISSION_REQUEST_ENABLED AP_MISSION_ENABLED
+#define AP_MAVLINK_MSG_MISSION_REQUEST_ENABLED 0
 #endif
 
 // RANGEFINDER is a subset of the DISTANCE_SENSOR message which we

--- a/libraries/GCS_MAVLink/GCS_config.h
+++ b/libraries/GCS_MAVLink/GCS_config.h
@@ -111,7 +111,7 @@
 // ArduPilot 4.9 removes the code but sends message about MISSION_REQUEST not supported
 // ArduPilot 4.10 stops sending the warning
 #ifndef AP_MAVLINK_MSG_MISSION_REQUEST_ENABLED
-#define AP_MAVLINK_MSG_MISSION_REQUEST_ENABLED 0
+#define AP_MAVLINK_MSG_MISSION_REQUEST_ENABLED AP_MISSION_ITEM_ENABLED
 #endif
 
 // RANGEFINDER is a subset of the DISTANCE_SENSOR message which we


### PR DESCRIPTION
### Summary

Removes handling of both `MISSION_ITEM` and `MISSION_REQUEST` - both of these have sent warnings for about 4 years when used.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Requires https://github.com/ArduPilot/MissionPlanner/pull/3724 first or MP users will just always get the warning!

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  72                                *
Durandal                            -688            -688   *           -640    -640              -640   -640   -640
Hitec-Airspeed           *                                 *
KakuteH7-bdshot                     -688            -688   *           -640    -640              -640   -640   -640
MatekF405                           -696            -696   *           -688    -696              -688   -688   -688
MatekH7A3                           -696            -688   *           -640    -640              -640   -640   -640
Pixhawk1-1M-bdshot                  -688            -696               -696    -696              -696   -688   -688
SITL_x86_64_linux_gnu               *               *                  *       *                 *      *      *
YJUAV_A6SE                          -688            -696   *           -640    -640              -640   -640   -640
f103-QiotekPeriph        *                                 *
f303-MatekGPS            *                                 *
f303-Universal           *                                 *
iomcu                                                                                *
mindpx-v2                           -696            -696   *           -640    -640              -640   -640   -640
revo-mini                           -688            -688   *           -688    -688              -688   -696   -688
skyviper-v2450                                                         -696
speedybeef4                         -688            -688   *           -696    -696              -688   -696   -696
```
