### PR TITLE
Tools: CPUInfo: allow this to work under SITL

### DIFF
--- a/Tools/CPUInfo/CPUInfo.cpp
+++ b/Tools/CPUInfo/CPUInfo.cpp
@@ -20,7 +20,9 @@
 #endif
 #include <hrt.h>
 #include <ch.h>
-#endif // HAL_BOARD_CHIBIOS
+#elif CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#include <fenv.h>
+#endif  // HAL_BOARD_CHIBIOS
 
 void setup();
 void loop();
@@ -252,6 +254,10 @@ static void test_div1000(void)
 
 void loop()
 {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    // pretend we are embedded so that 1.0/0 "works"
+    fedisableexcept(FE_ALL_EXCEPT);
+#endif
     show_sizes();
     hal.console->printf("\n");
     show_timings();


### PR DESCRIPTION
### Summary

Allows CPUInfo to work under SITL (roughly speaking)

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Replicates bug found.  See https://github.com/ArduPilot/ardupilot/pull/33024

<img width="1597" height="2029" alt="image" src="https://github.com/user-attachments/assets/c12b7819-4a06-4dfa-8ee2-a2351c11d120" />

### Description

Allows Tool to be run in SITL.

Would be nice to run this in CI once the ftoa-engine is fixed.
