### PR TITLE
AP_L1_Control: limit loiter PD when inside radius

### DIFF
--- a/libraries/AP_L1_Control/AP_L1_Control.cpp
+++ b/libraries/AP_L1_Control/AP_L1_Control.cpp
@@ -431,13 +431,18 @@ void AP_L1_Control::update_loiter(const Location &center_WP, float radius, int8_
     // Calculate tangential velocity
     float velTangent = xtrackVelCap * float(loiter_direction);
 
-    // Prevent PD demand from turning the wrong way by limiting the command when flying the wrong way
-    if (ltrackVelCap < 0.0f && velTangent < 0.0f) {
-        latAccDemCircPD =  MAX(latAccDemCircPD, 0.0f);
-    }
-
     // Calculate centripetal acceleration demand
     float latAccDemCircCtr = velTangent * velTangent / MAX((0.5f * radius), (radius + xtrackErrCirc));
+
+    // Prevent PD demand from turning the wrong way by limiting it when flying
+    // the wrong way, or while flying out from inside the loiter radius
+    if (ltrackVelCap < 0.0f) {
+        if (velTangent < 0.0f) {
+            latAccDemCircPD = MAX(latAccDemCircPD, 0.0f);
+        } else if (xtrackErrCirc < 0.0f) {
+            latAccDemCircPD = MAX(latAccDemCircPD, -latAccDemCircCtr);
+        }
+    }
 
     // Sum PD control and centripetal acceleration to calculate lateral manoeuvre demand
     float latAccDemCirc = loiter_direction * (latAccDemCircPD + latAccDemCircCtr);


### PR DESCRIPTION
### Summary

Fixes #33083.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [X] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [X] Logs attached
- [ ] Logs available on request

Tested using the autotest @IamPete1 made for this issue @ #33082.

### Description

When loiter is entered from inside a large radius, the aircraft starts by flying out from near the loiter center before a usable tangential direction is established. In that case the existing wrong-way PD limit did not trigger, because it only caught negative tangential velocity.

This extends the existing PD limiting to also cover the inside-radius case.

### Logs

[inside-radius-roll-steps-bug-iampete-autotests.zip](https://github.com/user-attachments/files/27956752/inside-radius-roll-steps-bug-iampete-autotests.zip)

#### Without fix

<img width="1503" height="325" alt="imagen" src="https://github.com/user-attachments/assets/19d66596-4371-4efc-8ae5-34daf279d9a0" />

#### With this fix

<img width="1535" height="325" alt="imagen" src="https://github.com/user-attachments/assets/3f39ab79-78b1-4b85-982b-f57011f6ced6" />
