### PR TITLE
GCS_MAVLink: config_error when MAVLink backend creation fails

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -1338,7 +1338,7 @@ private:
 
     static GCS *_singleton;
 
-    void create_gcs_mavlink_backend(AP_HAL::UARTDriver &uart);
+    bool create_gcs_mavlink_backend(AP_HAL::UARTDriver &uart) WARN_IF_UNUSED;
 
     char statustext_printf_buffer[256+1];
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2818,18 +2818,20 @@ void GCS::setup_console()
     if (ARRAY_SIZE(_chan_var_info) == 0) {
         return;
     }
-    create_gcs_mavlink_backend(*uart);
+    if (!create_gcs_mavlink_backend(*uart)) {
+        AP_BoardConfig::config_error("Failed to create MAVLink console backend");
+    }
 }
 
 
-void GCS::create_gcs_mavlink_backend(AP_HAL::UARTDriver &uart)
+bool GCS::create_gcs_mavlink_backend(AP_HAL::UARTDriver &uart)
 {
     if (_num_gcs >= ARRAY_SIZE(_chan_var_info)) {
-        return;
+        return false;
     }
     _chan[_num_gcs] = new_gcs_mavlink_backend(uart);
     if (_chan[_num_gcs] == nullptr) {
-        return;
+        return false;
     }
 
     // prepare parameters:
@@ -2839,23 +2841,15 @@ void GCS::create_gcs_mavlink_backend(AP_HAL::UARTDriver &uart)
     if (!_chan[_num_gcs]->init(_num_gcs)) {
         delete _chan[_num_gcs];
         _chan[_num_gcs] = nullptr;
-        return;
+        return false;
     }
 
     _num_gcs++;
+    return true;
 }
 
 void GCS::setup_uarts()
 {
-    for (uint8_t i = 1; i < MAVLINK_COMM_NUM_BUFFERS; i++) {
-        AP_HAL::UARTDriver *uart = AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_MAVLink, i);
-        if (uart == nullptr) {
-            // no more mavlink uarts
-            break;
-        }
-        create_gcs_mavlink_backend(*uart);
-    }
-
 #if AP_FRSKY_TELEM_ENABLED
     if (frsky == nullptr) {
         frsky = NEW_NOTHROW AP_Frsky_Telem();
@@ -2873,6 +2867,20 @@ void GCS::setup_uarts()
 #if AP_DEVO_TELEM_ENABLED
     devo_telemetry.init();
 #endif
+
+    for (uint8_t i = 1; i < UINT8_MAX; i++) {  // we really can't have this many serial connections, right?!
+        AP_HAL::UARTDriver *uart = AP::serialmanager().find_serial(AP_SerialManager::SerialProtocol_MAVLink, i);
+        if (uart == nullptr) {
+            // no more mavlink uarts
+            return;
+        }
+        if (!create_gcs_mavlink_backend(*uart)) {
+            AP_BoardConfig::config_error("Failed to create MAVLink backend %u", unsigned(i));
+        }
+    }
+
+    // no way we allocated UINT8_MAX backends, something has gone wrong
+    INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
 }
 
 /*


### PR DESCRIPTION
## Summary

Companion to #33085 — alternative implementation of the same fix per @peterbarker's suggestion ([comment](https://github.com/ArduPilot/ardupilot/pull/33085#issuecomment-4469648353)), opened so the two approaches can be evaluated side-by-side.

Fixes #30997. Each MAVLink-protocol serial/network port consumes one of the build's `MAVLINK_COMM_NUM_BUFFERS` comm buffers. Previously, if backend allocation failed (or the user configured more MAVLink ports than the loop bound), the surplus ports silently missed out on a buffer with no signal to the user — as @rmackay9 put it on the issue, "very hard to figure out otherwise".

This PR takes the `config_error` route inside `GCS_MAVLink` rather than a pre-arm check in `AP_SerialManager`:

- `GCS::create_gcs_mavlink_backend()` now returns `bool` (marked `WARN_IF_UNUSED`) so allocation/init failures are visible to callers.
- `GCS::setup_console()` raises `AP_BoardConfig::config_error()` if the console backend fails to create.
- `GCS::setup_uarts()` walks ports up to `UINT8_MAX` and raises `config_error()` if any backend creation fails — this catches both alloc/init failures and over-allocation past `MAVLINK_COMM_NUM_BUFFERS` in a single place. A trailing `INTERNAL_ERROR(flow_of_control)` guards what should now be unreachable.

### Trade-off vs #33085

| | #33085 (pre-arm) | this PR (config_error) |
|---|---|---|
| Where it fires | At arming | At boot |
| Field recoverable | Yes — connect GCS, fix params, retry | Yes — GCS can still connect to a board in `config_error_loop`, fix params, reboot |
| Coverage of alloc/init failures | No | Yes |
| Coverage of over-allocation past loop bound | Yes | Yes |
| Touched subsystem | `AP_SerialManager` only | `GCS_MAVLink` |

## Classification & Testing

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change
- [ ] Automated test(s) verify changes
- [x] Tested manually, description below
- [ ] Tested on hardware

Built ArduCopter SITL on macOS (arm64) — change compiles cleanly. Failure path requires forcing more MAVLink-protocol ports than the build's `MAVLINK_COMM_NUM_BUFFERS` and walking through boot; happy to add an autotest if maintainers would prefer one.