### PR TITLE
AP_Notify: auto-activate lost-vehicle alarm on dual RC/GCS failsafe and crash

### DIFF
--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -93,6 +93,8 @@ void Copter::crash_check()
         gcs().send_text(MAV_SEVERITY_EMERGENCY,"Crash: Disarming: AngErr=%.0f>%.0f, Accel=%.1f<%.1f", angle_error, CRASH_CHECK_ANGLE_DEVIATION_DEG, filtered_acc, CRASH_CHECK_ACCEL_MAX);
         // disarm motors
         copter.arming.disarm(AP_Arming::Method::CRASH);
+        // activate lost-vehicle alarm to aid recovery of a downed vehicle
+        AP_Notify::flags.vehicle_lost = true;
     }
 }
 
@@ -344,7 +346,7 @@ void Copter::parachute_release()
 }
 
 // parachute_manual_release - trigger the release of the parachute, after performing some checks for pilot error
-//   checks if the vehicle is landed 
+//   checks if the vehicle is landed
 void Copter::parachute_manual_release()
 {
     // exit immediately if parachute is not enabled

--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -346,7 +346,7 @@ void Copter::parachute_release()
 }
 
 // parachute_manual_release - trigger the release of the parachute, after performing some checks for pilot error
-//   checks if the vehicle is landed
+//   checks if the vehicle is landed 
 void Copter::parachute_manual_release()
 {
     // exit immediately if parachute is not enabled

--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -434,7 +434,7 @@ void AP_Notify::update(void)
     // links are simultaneously absent; this covers the case where the
     // vehicle has flown out of range and the operator cannot trigger the
     // alarm manually via RC sticks
-    if (_lost_alarm_enable != 0 && flags.failsafe_radio && flags.failsafe_gcs) {
+    if (_lost_alarm_enable != 0 && !flags.armed && flags.failsafe_radio && flags.failsafe_gcs) {
         flags.vehicle_lost = true;
     }
 

--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -208,6 +208,13 @@ const AP_Param::GroupInfo AP_Notify::var_info[] = {
     // @RebootRequired: True
     AP_GROUPINFO("LED_LEN", 9, AP_Notify, _led_len, NOTIFY_LED_LEN_DEFAULT),
 
+    // @Param: LOST_ALARM
+    // @DisplayName: Lost Vehicle Alarm
+    // @Description: Activate the lost-vehicle alarm automatically when both the RC and GCS links are simultaneously lost. Useful for locating a downed vehicle when manual activation via RC sticks is not possible. This also activates when a crash is detected.
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Standard
+    AP_GROUPINFO("LOST_ALARM", 10, AP_Notify, _lost_alarm_enable, 1),
+
     AP_GROUPEND
 };
 
@@ -421,6 +428,14 @@ void AP_Notify::update(void)
         if (_devices[i] != nullptr) {
             _devices[i]->update();
         }
+    }
+
+    // automatically activate the lost-vehicle alarm when both RC and GCS
+    // links are simultaneously absent; this covers the case where the
+    // vehicle has flown out of range and the operator cannot trigger the
+    // alarm manually via RC sticks
+    if (_lost_alarm_enable != 0 && flags.failsafe_radio && flags.failsafe_gcs) {
+        flags.vehicle_lost = true;
     }
 
     //reset the events

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -214,7 +214,7 @@ public:
     void send_text(const char *str);
     const char* get_text() const { return _send_text; }
     uint32_t get_text_updated_millis() const {return _send_text_updated_millis; }
-
+ 
 #if AP_SCRIPTING_ENABLED
     // send text to the display using scripting
     void send_text_scripting(const char *str, uint8_t r);

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -214,7 +214,7 @@ public:
     void send_text(const char *str);
     const char* get_text() const { return _send_text; }
     uint32_t get_text_updated_millis() const {return _send_text_updated_millis; }
- 
+
 #if AP_SCRIPTING_ENABLED
     // send text to the display using scripting
     void send_text_scripting(const char *str, uint8_t r);
@@ -253,6 +253,7 @@ private:
     AP_Int8 _buzzer_level;
     AP_Int8 _buzzer_volume;
     AP_Int8 _led_len;
+    AP_Int8 _lost_alarm_enable;
 
     char _send_text[NOTIFY_TEXT_BUFFER_SIZE];
     uint32_t _send_text_updated_millis; // last time text changed

--- a/libraries/AP_Notify/RGBLed.cpp
+++ b/libraries/AP_Notify/RGBLed.cpp
@@ -105,6 +105,12 @@ uint32_t RGBLed::get_colour_sequence(void) const
         return sequence_initialising;
     }
 
+    // vehicle lost: override all other patterns with fast bright-white flash
+    // to aid visual recovery regardless of armed/failsafe state
+    if (AP_Notify::flags.vehicle_lost) {
+        return sequence_vehicle_lost;
+    }
+
     // save trim or any calibration pattern
     if (AP_Notify::flags.save_trim ||
         AP_Notify::flags.esc_calibration ||

--- a/libraries/AP_Notify/RGBLed.cpp
+++ b/libraries/AP_Notify/RGBLed.cpp
@@ -190,6 +190,10 @@ uint32_t RGBLed::get_colour_sequence_traffic_light(void) const
         return DEFINE_COLOUR_SEQUENCE(RED,GREEN,BLUE,RED,GREEN,BLUE,RED,GREEN,BLUE,BLACK);
     }
 
+    if (AP_Notify::flags.vehicle_lost) {
+        return sequence_vehicle_lost;
+    }
+
     if (AP_Notify::flags.armed) {
         return DEFINE_COLOUR_SEQUENCE_SLOW(RED);
     }

--- a/libraries/AP_Notify/RGBLed.h
+++ b/libraries/AP_Notify/RGBLed.h
@@ -1,5 +1,5 @@
 /*
- *  AP_Notify Library.
+ *  AP_Notify Library. 
  * based upon a prototype library by David "Buzz" Bussenschutt.
  */
 
@@ -49,7 +49,7 @@ protected:
     virtual void _set_rgb(uint8_t red, uint8_t green, uint8_t blue);
 
     void update_override();
-
+    
     // meta-data common to all hw devices
     uint8_t _red_curr, _green_curr, _blue_curr;  // current colours displayed by the led
     uint8_t _led_off;
@@ -62,7 +62,7 @@ protected:
         uint8_t rate_hz;
         uint32_t start_ms;
     } _led_override;
-
+    
 private:
     void update_colours();
     uint32_t get_colour_sequence() const;

--- a/libraries/AP_Notify/RGBLed.h
+++ b/libraries/AP_Notify/RGBLed.h
@@ -1,5 +1,5 @@
 /*
- *  AP_Notify Library. 
+ *  AP_Notify Library.
  * based upon a prototype library by David "Buzz" Bussenschutt.
  */
 
@@ -49,7 +49,7 @@ protected:
     virtual void _set_rgb(uint8_t red, uint8_t green, uint8_t blue);
 
     void update_override();
-    
+
     // meta-data common to all hw devices
     uint8_t _red_curr, _green_curr, _blue_curr;  // current colours displayed by the led
     uint8_t _led_off;
@@ -62,7 +62,7 @@ protected:
         uint8_t rate_hz;
         uint32_t start_ms;
     } _led_override;
-    
+
 private:
     void update_colours();
     uint32_t get_colour_sequence() const;
@@ -103,6 +103,7 @@ private:
     const uint32_t sequence_disarmed_good_dgps_and_location = DEFINE_COLOUR_SEQUENCE_ALTERNATE(GREEN,BLACK);
     const uint32_t sequence_disarmed_good_gps_and_location = DEFINE_COLOUR_SEQUENCE_SLOW(GREEN);
     const uint32_t sequence_disarmed_bad_gps_or_no_location = DEFINE_COLOUR_SEQUENCE_SLOW(BLUE);
+    const uint32_t sequence_vehicle_lost = DEFINE_COLOUR_SEQUENCE_ALTERNATE(WHITE, BLACK);
 
     uint8_t last_step;
     enum class Source {


### PR DESCRIPTION
### Summary

Adds NTF_LOST_ALARM parameter that automatically triggers the lost-vehicle alarm when both RC and GCS links are simultaneously absent, and on crash detection in Copter.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Closes #13194

The lost-vehicle alarm currently requires a manual RC stick gesture or AUX switch. If the RC link is gone the operator has no way to activate it.

Three small changes:

- AP_Notify::update(): if NTF_LOST_ALARM is non-zero (default 1) and both failsafe_radio and failsafe_gcs are set simultaneously, flags.vehicle_lost is forced true each 50 Hz cycle. Clears when either link recovers or via the existing stick combo.
- RGBLed::get_colour_sequence(): returns a fast white/black alternating flash when vehicle_lost is set, overriding other patterns so the vehicle acts as a visual beacon regardless of state.
- ArduCopter/crash_check.cpp: sets vehicle_lost after crash-induced disarm so the alarm fires without needing an active RC link.

NTF_LOST_ALARM defaults to 1; set to 0 to restore manual-only behaviour.