### PR TITLE
Copter: Refactor Flip Mode code for clarity (no behavior change)

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -978,7 +978,6 @@ protected:
 
 private:
 
-    // Flip
     Vector3f orig_attitude_euler_rad;   // original vehicle attitude before flip
 
     enum class FlipState : uint8_t {
@@ -992,9 +991,11 @@ private:
     bool abandon_requested;
     FlipState _state;                   // current state of flip
     Mode::Number  orig_control_mode;    // flight mode when flip was initiated
-    uint32_t start_time_ms;             // time since flip began
+    uint32_t start_time_ms;
     int8_t roll_dir;                    // roll direction (-1 = roll left, 1 = roll right)
     int8_t pitch_dir;                   // pitch direction (-1 = pitch forward, 1 = pitch back)
+
+    bool input_is_high_magnitude(RC_Channel &input) const;
 };
 
 

--- a/ArduCopter/mode_flip.cpp
+++ b/ArduCopter/mode_flip.cpp
@@ -45,8 +45,7 @@ bool ModeFlip::init(bool ignore_checks)
         return false;
     }
 
-    // ensure roll input is less than 40deg
-    if (abs(channel_roll->get_control_in()) >= 4000) {
+    if (input_is_high_magnitude(*channel_roll)) {
         return false;
     }
 
@@ -92,8 +91,7 @@ bool ModeFlip::init(bool ignore_checks)
 // should be called at 100hz or more
 void ModeFlip::run()
 {
-    // if pilot inputs roll > 40deg or timeout occurs abandon flip
-    if (abandon_requested || !motors->armed() || (abs(channel_roll->get_control_in()) >= 4000) || (abs(channel_pitch->get_control_in()) >= 4000) || ((millis() - start_time_ms) > FLIP_TIMEOUT_MS)) {
+    if (abandon_requested || !motors->armed() || input_is_high_magnitude(*channel_roll) || input_is_high_magnitude(*channel_pitch) || ((millis() - start_time_ms) > FLIP_TIMEOUT_MS)) {
         _state = FlipState::Abandon;
         abandon_requested = false;
     }
@@ -118,13 +116,13 @@ void ModeFlip::run()
     switch (_state) {
 
     case FlipState::Start:
-        // under 45 degrees request 400deg/sec roll or pitch
+        // request FLIP_ROTATION_RATE_RADS in the nonzero dir
         attitude_control->input_rate_bf_roll_pitch_yaw_rads(FLIP_ROTATION_RATE_RADS * roll_dir, FLIP_ROTATION_RATE_RADS * pitch_dir, 0.0);
 
         // increase throttle
         throttle_out += FLIP_THR_INC;
 
-        // beyond 45deg lean angle move to next stage
+        // beyond specified lean angle: move to next stage
         if (flip_angle_rad >= radians(45.0)) {
             if (roll_dir != 0) {
                 // we are rolling
@@ -132,24 +130,24 @@ void ModeFlip::run()
             } else {
                 // we are pitching
                 _state = FlipState::Pitch_A;
-        }
+            }
         }
         break;
 
     case FlipState::Roll:
-        // between 45deg ~ -90deg request 400deg/sec roll
+        // request FLIP_ROTATION_RATE_RADS roll
         attitude_control->input_rate_bf_roll_pitch_yaw_rads(FLIP_ROTATION_RATE_RADS * roll_dir, 0.0, 0.0);
         // decrease throttle
         throttle_out = MAX(throttle_out - FLIP_THR_DEC, 0.0f);
 
-        // beyond -90deg move on to recovery
+        // if state transition conditions are met: move on to recovery
         if ((flip_angle_rad < radians(45.0)) && (flip_angle_rad > -radians(90.0))) {
             _state = FlipState::Recover;
         }
         break;
 
     case FlipState::Pitch_A:
-        // between 45deg ~ -90deg request 400deg/sec pitch
+        // request FLIP_ROTATION_RATE_RADS pitch
         attitude_control->input_rate_bf_roll_pitch_yaw_rads(0.0f, FLIP_ROTATION_RATE_RADS * pitch_dir, 0.0);
         // decrease throttle
         throttle_out = MAX(throttle_out - FLIP_THR_DEC, 0.0f);
@@ -161,7 +159,7 @@ void ModeFlip::run()
         break;
 
     case FlipState::Pitch_B:
-        // between 45deg ~ -90deg request 400deg/sec pitch
+        // request FLIP_ROTATION_RATE_RADS pitch
         attitude_control->input_rate_bf_roll_pitch_yaw_rads(0.0, FLIP_ROTATION_RATE_RADS * pitch_dir, 0.0);
         // decrease throttle
         throttle_out = MAX(throttle_out - FLIP_THR_DEC, 0.0f);
@@ -219,6 +217,11 @@ void ModeFlip::run()
 void ModeFlip::abandon_flip()
 {
     abandon_requested = true;
+}
+
+bool ModeFlip::input_is_high_magnitude(RC_Channel &input) const
+{
+    return abs(input.get_control_in()) >= 4000;
 }
 
 #endif


### PR DESCRIPTION
### Summary

This fixes/removes comments, creates subfunctions, and similar clarity improvements for Flip Mode. **No changes to autopilot behavior.**

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

1. Make explicit that flip mode does not "allow_flip()". (The english is odd, but this is the correct behavior. It is also the default behavior inherited from the parent, but due to the oddness, I think it's worth being explicit.)
2. Several spots check for "high RC stick input" from the pilot. Create a subfunction to make the value defining "high magnitude" (control >= 4000) DRY and reuse that subfunction at all call-spots.
3. Several comments are outdated, non-DRY, or self-evident. They are removed because the code is clear as-is.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
