### PR TITLE
hwdef: ARKV6X: enable high-resolution IMU sampling

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/ARKV6X/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ARKV6X/hwdef.dat
@@ -319,6 +319,9 @@ IMU Invensensev3 SPI:iim42653_ext2 ROTATION_ROLL_180_YAW_270
 
 define HAL_DEFAULT_INS_FAST_SAMPLE 7
 
+# enable high-resolution FIFO sampling on all three IMUs
+define HAL_INS_HIGHRES_SAMPLE 7
+
 # enable RAMTRON parameter storage
 define HAL_STORAGE_SIZE 32768
 define HAL_WITH_RAMTRON 1


### PR DESCRIPTION
## Summary
Enable 19-bit high-resolution FIFO sampling on all three ARKV6X IMUs. I noticed this while working on bring-up for a new flight controller.

## Problem
The ARKV6X ships with three Invensensev3 IMUs (IIM-42652 + 2× ICM-42688, or 3× IIM-42653 on the Extended Range variant). All four part numbers support high-resolution FIFO mode per `libraries/AP_InertialSensor/AP_InertialSensor_Invensensev3.cpp:354-357`, but `HAL_INS_HIGHRES_SAMPLE` was left at its default of 0, so the driver falls back to 16-bit samples on every instance.

## Solution
Set `HAL_INS_HIGHRES_SAMPLE 7` (bits 0-2, one per IMU instance). Matches the configuration used by Pixhawk6X, Aeromind6X, ZeroOneX6, CUAV-V6X-v2, and other H7 boards with all-v3 IMU stacks.