### PR TITLE
hwdef: ARKV6X: consolidate IOMCU configuration into one block

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/ARKV6X/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ARKV6X/hwdef.dat
@@ -26,11 +26,8 @@ env USE_ALT_RAM_MAP 1
 FLASH_SIZE_KB 2048
 
 
-# order of UARTs (and USB) no IO MCU
+# order of UARTs (and USB)
 SERIAL_ORDER OTG1 UART7 UART5 USART1 UART8 USART2 UART4 USART3 USART6 OTG2
-
-# order of UARTs (and USB) with IO MCU
-# SERIAL_ORDER OTG1 UART7 UART5 USART1 UART8 USART2 UART4 USART3 OTG2
 
 # debug console
 STDOUT_SERIAL SD3
@@ -87,8 +84,16 @@ PC6 USART6_TX USART6
 PC7 USART6_RX USART6
 define DEFAULT_SERIAL8_PROTOCOL SerialProtocol_RCIN
 
-# Uncomment this line for carriers boards with an IO MCU
+# USART6 is the PAB X1 IO MCU bus pin (per DS-010). The ARK FMU PAB
+# Carrier wires it directly to the RC input header, so this build
+# defaults to DEFAULT_SERIAL8_PROTOCOL = RCIN. To use this FMU on a
+# carrier that has an on-board IO MCU on USART6 (e.g. the Holybro
+# Pixhawk6X carrier), comment out the SERIAL_ORDER above and the three
+# USART6 / DEFAULT_SERIAL8_PROTOCOL lines just above this comment, then
+# uncomment the block below.
+# SERIAL_ORDER OTG1 UART7 UART5 USART1 UART8 USART2 UART4 USART3 OTG2
 # IOMCU_UART USART6
+# ROMFS io_firmware.bin Tools/IO_Firmware/iofirmware_lowpolh.bin
 
 # Ethernet
 PB11 ETH_RMII_TX_EN     ETH1
@@ -335,8 +340,6 @@ DMA_PRIORITY SDMMC* USART6* ADC* UART* USART* SPI* TIM*
 
 # enable FAT filesystem support (needs a microSD defined via SDMMC)
 define HAL_OS_FATFS_IO 1
-
-ROMFS io_firmware.bin Tools/IO_Firmware/iofirmware_lowpolh.bin
 
 # enable DFU reboot for installing bootloader
 # note that if firmware is build with --secure-bl then DFU is


### PR DESCRIPTION
## Summary
Group the V6X IOMCU-related lines and drop the unused `io_firmware` ROMFS from the default build.

## Problem
The IOMCU configuration is split across the file: an alternate `SERIAL_ORDER` is commented out near the top, `IOMCU_UART USART6` is commented out near the USART6 RC pins, and the `ROMFS io_firmware.bin` line is active at the bottom even though USART6 defaults to direct RC input (`SerialProtocol_RCIN`). The default build always carries the ~30 KB `iofirmware_lowpolh.bin` blob even when no IOMCU is wired, and someone enabling IOMCU has to find the toggles in three different places.

## Solution
Move all three lines into a single commented-out block adjacent to the USART6 RC pins, with a short comment telling the user which lines to flip to enable IOMCU. The ROMFS is now only included when the IOMCU block is enabled.