### PR TITLE
board_types.txt: reserve IDs for ZeroOneX9 and ZeroOneA6i

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -522,10 +522,10 @@ AP_HW_MATEKH743SE                    5501
 
 #IDs 5600-5699 reserved for ZeroOne
 AP_HW_ZeroOne_X6                     5600
-AP_HW_ZeroOne_PMU                    5601
-AP_HW_ZeroOne_GNSS                   5602
+AP_HW_ZeroOne_X9                     5601
 AP_HW_ZeroOne_M9                     5610
 AP_HW_ZeroOne_A3                     5620
+AP_HW_ZeroOne_A6i                    5621
 
 #IDs 5700-5710 reserved for DroneBuild
 AP_HW_DroneBuild_G1                  5700


### PR DESCRIPTION
Reserve IDs for the new X9 and A6i flight controllers, new boards designed by ZeroOne.
Removed AP_HW_ZeroOne_PMU and AP_HW_ZeroOne_GNSS that were not in use before.
